### PR TITLE
Make profiling port configurable via file

### DIFF
--- a/server/configs/test.conf
+++ b/server/configs/test.conf
@@ -21,4 +21,5 @@ log_file: "/tmp/gnatsd.log"
 #pid file
 pid_file: "/tmp/gnatsd.pid"
 
+prof_port: 6543
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -98,6 +98,8 @@ func ProcessConfigFile(configFile string) (*Options, error) {
 			opts.LogFile = v.(string)
 		case "pidfile", "pid_file":
 			opts.PidFile = v.(string)
+		case "prof_port":
+			opts.ProfPort = int(v.(int64))
 		}
 	}
 	return opts, nil
@@ -197,6 +199,9 @@ func MergeOptions(fileOpts, flagOpts *Options) *Options {
 	}
 	if flagOpts.PidFile != "" {
 		opts.PidFile = flagOpts.PidFile
+	}
+	if flagOpts.ProfPort != 0 {
+		opts.ProfPort = flagOpts.ProfPort
 	}
 	return &opts
 }

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -44,6 +44,7 @@ func TestConfigFile(t *testing.T) {
 		HTTPPort:    8222,
 		LogFile:     "/tmp/gnatsd.log",
 		PidFile:     "/tmp/gnatsd.pid",
+		ProfPort:    6543,
 	}
 
 	opts, err := ProcessConfigFile("./configs/test.conf")
@@ -70,6 +71,7 @@ func TestMergeOverrides(t *testing.T) {
 		HTTPPort:    DEFAULT_HTTP_PORT,
 		LogFile:     "/tmp/gnatsd.log",
 		PidFile:     "/tmp/gnatsd.pid",
+		ProfPort:    6789,
 	}
 	fopts, err := ProcessConfigFile("./configs/test.conf")
 	if err != nil {
@@ -82,6 +84,7 @@ func TestMergeOverrides(t *testing.T) {
 		Password: "spooky",
 		Debug:    true,
 		HTTPPort: DEFAULT_HTTP_PORT,
+		ProfPort: 6789,
 	}
 	merged := MergeOptions(fopts, opts)
 


### PR DESCRIPTION
- Port can be specified with 'prof_port' value in file
- CLI flag overrides config file setting
