### PR TITLE
Added Server.Addr() helper to allow querying of the server's bound address

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -480,3 +480,13 @@ func (s *Server) NumSubscriptions() uint32 {
 	stats := s.sl.Stats()
 	return stats.NumSubs
 }
+
+// Addr will return the net.Addr object for the current listener.
+func (s *Server) Addr() net.Addr {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.listener == nil {
+		return nil
+	}
+	return s.listener.Addr()
+}


### PR DESCRIPTION
This can be useful in testing scenarios by allowing you to have the system pick
a random port by passing 0 on options.Port, but also give the user a way to
query the server for what port it actually bound to.

This change can also be useful because the behavior on some systems is that the OS will reuse a random port if it is unbound. For instance, create a listener on port 0, close the socket, give that port to gnatsd, and something else gets that port in the short time in between.
