### PR TITLE
remove self referencing ip/host

### DIFF
--- a/gnatsd.go
+++ b/gnatsd.go
@@ -82,6 +82,9 @@ func main() {
 		opts = *server.MergeOptions(fileOpts, &opts)
 	}
 
+	// Remove any host/ip that points to itself in Route
+	opts.Routes = server.RemoveSelfReference(opts.Routes)
+
 	// Create the server with appropriate options.
 	s := server.New(&opts)
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -4,8 +4,8 @@ package server
 
 import (
 	"fmt"
-
 	"io/ioutil"
+	"net"
 	"net/url"
 	"strings"
 	"time"
@@ -204,6 +204,79 @@ func MergeOptions(fileOpts, flagOpts *Options) *Options {
 		opts.ProfPort = flagOpts.ProfPort
 	}
 	return &opts
+}
+
+func RemoveSelfReference(routes []*url.URL) []*url.URL {
+	var cleanRoutes []*url.URL
+
+	selfIPs := getInterfaceIPs()
+	for i := 0; i < len(routes); i++ {
+		for _, routeIP := range getUrlIp(routes[i]) {
+			if !isIpInList(selfIPs, routeIP) {
+				cleanRoutes = append(cleanRoutes, routes[i])
+			} else {
+				Log("Self referencing IP found: ", routes[i])
+			}
+		}
+	}
+
+	return cleanRoutes
+}
+
+func isIpInList(list []net.IP, ip net.IP) bool {
+	for _, selfIP := range list {
+		if selfIP.Equal(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func getUrlIp(u *url.URL) []net.IP {
+	var ipList []net.IP
+	ipStr, _, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		Log("Error splitting host/port in route address: ", err)
+		return ipList
+	}
+
+	ip := net.ParseIP(ipStr)
+	if ip != nil {
+		ipList = append(ipList, ip)
+	} else {
+		hostAddr, err := net.LookupHost(ipStr)
+		if err != nil {
+			Log("Error looking up host with route hostname: ", err)
+			return ipList
+		}
+		for _, addr := range hostAddr {
+			ip = net.ParseIP(addr)
+			if ip != nil {
+				ipList = append(ipList, ip)
+			}
+		}
+	}
+	return ipList
+}
+
+func getInterfaceIPs() []net.IP {
+	var localIPs []net.IP
+
+	interfaceAddr, err := net.InterfaceAddrs()
+	if err != nil {
+		Log("Error getting self referencing address: ", err)
+		return localIPs
+	}
+
+	for i := 0; i < len(interfaceAddr); i++ {
+		interfaceIP, _, _ := net.ParseCIDR(interfaceAddr[i].String())
+		if net.ParseIP(interfaceIP.String()) != nil {
+			localIPs = append(localIPs, interfaceIP)
+		} else {
+			Log("Error parsing self referencing address: ", err)
+		}
+	}
+	return localIPs
 }
 
 func processOptions(opts *Options) {

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -3,6 +3,7 @@
 package server
 
 import (
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -101,5 +102,25 @@ func TestMergeOverrides(t *testing.T) {
 	if !reflect.DeepEqual(golden, merged) {
 		t.Fatalf("Options are incorrect.\nexpected: %+v\ngot: %+v",
 			golden, merged)
+	}
+}
+
+func TestRemoveSelfReference(t *testing.T) {
+	url1, _ := url.Parse("nats-route://user:password@10.4.5.6:4223")
+	url2, _ := url.Parse("nats-route://user:password@localhost:4223")
+	url3, _ := url.Parse("nats-route://user:password@127.0.0.1:4223")
+
+	opts := &Options{
+		Routes: []*url.URL{url1, url2, url3},
+	}
+
+	opts.Routes = RemoveSelfReference(opts.Routes)
+
+	if len(opts.Routes) != 1 {
+		t.Fatalf("Self reference IP address exists in Routes ")
+	}
+
+	if opts.Routes[0].String() != "nats-route://user:password@10.4.5.6:4223" {
+		t.Fatalf("Self reference IP address %s in Routes", opts.Routes[0])
 	}
 }


### PR DESCRIPTION
gnatsd should not be connecting and talking to itself.

This change make sure no entry in the routes is referencing to the server itself.
