### PR TITLE
Add build instructions & version constraint notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,30 @@ pid_file: "/tmp/gnatsd.pid"
 ```
 
 
+## Building
+
+This code currently requires at _least_ version 1.1 of Go, but we encourage
+the use of the latest stable release.  Go is still young and improving
+rapidly, new releases provide performance improvements and fixes.  Information
+on installation, including pre-built binaries, is available at
+<http://golang.org/doc/install>.  Stable branches of operating system
+packagers provided by your OS vendor may not be sufficient.
+
+Run `go version` to see the version of Go which you have installed.
+
+Run `go build` inside the directory to build.
+
+Run `go test ./...` to run the unit regression tests.
+
+A successful build run produces no messages and creates an executable called
+`gnatsd` in this directory.  You can invoke that binary, with no options and
+no configuration file, to start a server with acceptable standalone defaults
+(no authentication, no clustering).
+
+Run `go help` for more guidance, and visit <http://golang.org/> for tutorials,
+presentations, references and more.
+
+
 ## Nats client libraries
 
 There are several client language bindings.


### PR DESCRIPTION
We take too much Go-specific knowledge for granted; provide hints and
guidance in the `README.md` to better guide those new to Go.

@krobertson @derekcollison 
