### PR TITLE
Let readLoop do the closeConnection magic on any error

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -831,7 +831,6 @@ func (c *client) clearConnection() {
 	}
 	c.bw.Flush()
 	c.nc.Close()
-	c.nc = nil
 }
 
 func (c *client) typeString() string {
@@ -858,6 +857,7 @@ func (c *client) closeConnection() {
 	c.clearAuthTimer()
 	c.clearPingTimer()
 	c.clearConnection()
+	c.nc = nil
 
 	// Snapshot for use.
 	subs := c.subs.All()


### PR DESCRIPTION
clearConnection will close the socket, but defer to readLoop to clean
up the client's connection
