### PR TITLE
Check port when removing self referenced routes

### DIFF
--- a/gnatsd.go
+++ b/gnatsd.go
@@ -83,7 +83,11 @@ func main() {
 	}
 
 	// Remove any host/ip that points to itself in Route
-	opts.Routes = server.RemoveSelfReference(opts.Routes)
+	newroutes, err := server.RemoveSelfReference(opts.ClusterPort, opts.Routes)
+	if err != nil {
+		server.PrintAndDie(err.Error())
+	}
+	opts.Routes = newroutes
 
 	// Create the server with appropriate options.
 	s := server.New(&opts)

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -110,17 +110,32 @@ func TestRemoveSelfReference(t *testing.T) {
 	url2, _ := url.Parse("nats-route://user:password@localhost:4223")
 	url3, _ := url.Parse("nats-route://user:password@127.0.0.1:4223")
 
-	opts := &Options{
-		Routes: []*url.URL{url1, url2, url3},
+	routes := []*url.URL{url1, url2, url3}
+
+	newroutes, err := RemoveSelfReference(4223, routes)
+	if err != nil {
+		t.Fatalf("Error during RemoveSelfReference: %v", err)
 	}
 
-	opts.Routes = RemoveSelfReference(opts.Routes)
-
-	if len(opts.Routes) != 1 {
-		t.Fatalf("Self reference IP address exists in Routes ")
+	if len(newroutes) != 1 {
+		t.Fatalf("Wrong number of routes: %d", len(newroutes))
 	}
 
-	if opts.Routes[0].String() != "nats-route://user:password@10.4.5.6:4223" {
-		t.Fatalf("Self reference IP address %s in Routes", opts.Routes[0])
+	if newroutes[0] != routes[0] {
+		t.Fatalf("Self reference IP address %s in Routes", routes[0])
+	}
+}
+
+func TestAllowRouteWithDifferentPort(t *testing.T) {
+	url1, _ := url.Parse("nats-route://user:password@127.0.0.1:4224")
+	routes := []*url.URL{url1}
+
+	newroutes, err := RemoveSelfReference(4223, routes)
+	if err != nil {
+		t.Fatalf("Error during RemoveSelfReference: %v", err)
+	}
+
+	if len(newroutes) != 1 {
+		t.Fatalf("Wrong number of routes: %d", len(newroutes))
 	}
 }


### PR DESCRIPTION
- Cleanup how self referenced routes were determined
- If the ports are different, don't bother checking the host
