### PR TITLE
Travis file was making the coveralls report think everything was master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: go
 go:
 - 1.3
-branches:
-  only:
-  - master
 install:
 - DST=~/gopath/src/github.com/apcera
 - mkdir -p "$DST"


### PR DESCRIPTION
I found that this was in here for gnatsd, but not nats. It allows for the branch bucket in coveralls to be utilized when sorting. With that added block in the config it grouped every build as a master one, vs the branch that was tested.
