### PR TITLE
Updates for new logging to appease govet

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -43,7 +43,7 @@ func NewFileLogger(filename string, time, debug, trace bool) *Logger {
 	fileflags := os.O_WRONLY | os.O_APPEND | os.O_CREATE
 	f, err := os.OpenFile(filename, fileflags, 0660)
 	if err != nil {
-		log.Fatal("error opening file: %v", err)
+		log.Fatalf("error opening file: %v", err)
 	}
 
 	flags := 0
@@ -78,25 +78,25 @@ func setColoredLabelFormats(l *Logger) {
 	l.traceLabel = fmt.Sprintf(colorFormat, 33, "TRACE")
 }
 
-func (l *Logger) Notice(format string, v ...interface{}) {
+func (l *Logger) Noticef(format string, v ...interface{}) {
 	l.logger.Printf(l.infoLabel+format, v...)
 }
 
-func (l *Logger) Error(format string, v ...interface{}) {
+func (l *Logger) Errorf(format string, v ...interface{}) {
 	l.logger.Printf(l.errorLabel+format, v...)
 }
 
-func (l *Logger) Fatal(format string, v ...interface{}) {
+func (l *Logger) Fatalf(format string, v ...interface{}) {
 	l.logger.Fatalf(l.fatalLabel+format, v)
 }
 
-func (l *Logger) Debug(format string, v ...interface{}) {
+func (l *Logger) Debugf(format string, v ...interface{}) {
 	if l.debug == true {
 		l.logger.Printf(l.debugLabel+format, v...)
 	}
 }
 
-func (l *Logger) Trace(format string, v ...interface{}) {
+func (l *Logger) Tracef(format string, v ...interface{}) {
 	if l.trace == true {
 		l.logger.Printf(l.traceLabel+format, v...)
 	}

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -46,42 +46,42 @@ func TestStdLoggerWithDebugTraceAndTime(t *testing.T) {
 func TestStdLoggerNotice(t *testing.T) {
 	expectOutput(t, func() {
 		logger := NewStdLogger(false, false, false, false)
-		logger.Notice("foo")
+		logger.Noticef("foo")
 	}, "[INFO] foo\n")
 }
 
 func TestStdLoggerNoticeWithColor(t *testing.T) {
 	expectOutput(t, func() {
 		logger := NewStdLogger(false, false, false, true)
-		logger.Notice("foo")
+		logger.Noticef("foo")
 	}, "[\x1b[32mINFO\x1b[0m] foo\n")
 }
 
 func TestStdLoggerDebug(t *testing.T) {
 	expectOutput(t, func() {
 		logger := NewStdLogger(false, true, false, false)
-		logger.Debug("foo %s", "bar")
+		logger.Debugf("foo %s", "bar")
 	}, "[DEBUG] foo bar\n")
 }
 
 func TestStdLoggerDebugWithOutDebug(t *testing.T) {
 	expectOutput(t, func() {
 		logger := NewStdLogger(false, false, false, false)
-		logger.Debug("foo")
+		logger.Debugf("foo")
 	}, "")
 }
 
 func TestStdLoggerTrace(t *testing.T) {
 	expectOutput(t, func() {
 		logger := NewStdLogger(false, false, true, false)
-		logger.Trace("foo")
+		logger.Tracef("foo")
 	}, "[TRACE] foo\n")
 }
 
 func TestStdLoggerTraceWithOutDebug(t *testing.T) {
 	expectOutput(t, func() {
 		logger := NewStdLogger(false, false, false, false)
-		logger.Trace("foo")
+		logger.Tracef("foo")
 	}, "")
 }
 
@@ -96,7 +96,7 @@ func TestFileLogger(t *testing.T) {
 	file.Close()
 
 	logger := NewFileLogger(file.Name(), false, false, false)
-	logger.Notice("foo")
+	logger.Noticef("foo")
 
 	buf, err := ioutil.ReadFile(file.Name())
 	if err != nil {

--- a/logger/syslog.go
+++ b/logger/syslog.go
@@ -59,25 +59,25 @@ func getNetworkAndAddr(fqn string) (network, addr string) {
 	return
 }
 
-func (l *SysLogger) Notice(format string, v ...interface{}) {
+func (l *SysLogger) Noticef(format string, v ...interface{}) {
 	l.writer.Notice(fmt.Sprintf(format, v...))
 }
 
-func (l *SysLogger) Fatal(format string, v ...interface{}) {
+func (l *SysLogger) Fatalf(format string, v ...interface{}) {
 	l.writer.Crit(fmt.Sprintf(format, v...))
 }
 
-func (l *SysLogger) Error(format string, v ...interface{}) {
+func (l *SysLogger) Errorf(format string, v ...interface{}) {
 	l.writer.Err(fmt.Sprintf(format, v...))
 }
 
-func (l *SysLogger) Debug(format string, v ...interface{}) {
+func (l *SysLogger) Debugf(format string, v ...interface{}) {
 	if l.debug {
 		l.writer.Debug(fmt.Sprintf(format, v...))
 	}
 }
 
-func (l *SysLogger) Trace(format string, v ...interface{}) {
+func (l *SysLogger) Tracef(format string, v ...interface{}) {
 	if l.trace {
 		l.writer.Notice(fmt.Sprintf(format, v...))
 	}

--- a/logger/syslog_test.go
+++ b/logger/syslog_test.go
@@ -54,7 +54,7 @@ func TestRemoteSysLoggerNotice(t *testing.T) {
 	startServer(done)
 	logger := NewRemoteSysLogger(serverFQN, true, true)
 
-	logger.Notice("foo %s", "bar")
+	logger.Noticef("foo %s", "bar")
 	expectSyslogOutput(t, <-done, "foo bar\n")
 }
 
@@ -63,7 +63,7 @@ func TestRemoteSysLoggerDebug(t *testing.T) {
 	startServer(done)
 	logger := NewRemoteSysLogger(serverFQN, true, true)
 
-	logger.Debug("foo %s", "qux")
+	logger.Debugf("foo %s", "qux")
 	expectSyslogOutput(t, <-done, "foo qux\n")
 }
 
@@ -72,7 +72,7 @@ func TestRemoteSysLoggerDebugDisabled(t *testing.T) {
 	startServer(done)
 	logger := NewRemoteSysLogger(serverFQN, false, false)
 
-	logger.Debug("foo %s", "qux")
+	logger.Debugf("foo %s", "qux")
 	rcvd := <-done
 	if rcvd != "" {
 		t.Fatalf("Unexpected syslog response %s\n", rcvd)
@@ -84,7 +84,7 @@ func TestRemoteSysLoggerTrace(t *testing.T) {
 	startServer(done)
 	logger := NewRemoteSysLogger(serverFQN, true, true)
 
-	logger.Trace("foo %s", "qux")
+	logger.Tracef("foo %s", "qux")
 	expectSyslogOutput(t, <-done, "foo qux\n")
 }
 
@@ -93,7 +93,7 @@ func TestRemoteSysLoggerTraceDisabled(t *testing.T) {
 	startServer(done)
 	logger := NewRemoteSysLogger(serverFQN, true, false)
 
-	logger.Trace("foo %s", "qux")
+	logger.Tracef("foo %s", "qux")
 	rcvd := <-done
 	if rcvd != "" {
 		t.Fatalf("Unexpected syslog response %s\n", rcvd)

--- a/server/log.go
+++ b/server/log.go
@@ -3,7 +3,6 @@
 package server
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 )
@@ -16,11 +15,11 @@ var log = struct {
 }{}
 
 type Logger interface {
-	Notice(format string, v ...interface{})
-	Fatal(format string, v ...interface{})
-	Error(format string, v ...interface{})
-	Debug(format string, v ...interface{})
-	Trace(format string, v ...interface{})
+	Noticef(format string, v ...interface{})
+	Fatalf(format string, v ...interface{})
+	Errorf(format string, v ...interface{})
+	Debugf(format string, v ...interface{})
+	Tracef(format string, v ...interface{})
 }
 
 func (s *Server) SetLogger(logger Logger, d, t bool) {
@@ -37,41 +36,41 @@ func (s *Server) SetLogger(logger Logger, d, t bool) {
 	log.logger = logger
 }
 
-func Notice(format string, v ...interface{}) {
+func Noticef(format string, v ...interface{}) {
 	executeLogCall(func(logger Logger, format string, v ...interface{}) {
-		logger.Notice(format, v...)
+		logger.Noticef(format, v...)
 	}, format, v...)
 }
 
-func Error(format string, v ...interface{}) {
+func Errorf(format string, v ...interface{}) {
 	executeLogCall(func(logger Logger, format string, v ...interface{}) {
-		logger.Error(format, v...)
+		logger.Errorf(format, v...)
 	}, format, v...)
 }
 
-func Fatal(format string, v ...interface{}) {
+func Fatalf(format string, v ...interface{}) {
 	executeLogCall(func(logger Logger, format string, v ...interface{}) {
-		logger.Fatal(format, v...)
+		logger.Fatalf(format, v...)
 	}, format, v...)
 }
 
-func Debug(format string, v ...interface{}) {
+func Debugf(format string, v ...interface{}) {
 	if debug == 0 {
 		return
 	}
 
 	executeLogCall(func(logger Logger, format string, v ...interface{}) {
-		logger.Debug(format, v...)
+		logger.Debugf(format, v...)
 	}, format, v...)
 }
 
-func Trace(format string, v ...interface{}) {
+func Tracef(format string, v ...interface{}) {
 	if trace == 0 {
 		return
 	}
 
 	executeLogCall(func(logger Logger, format string, v ...interface{}) {
-		logger.Trace(format, v...)
+		logger.Tracef(format, v...)
 	}, format, v...)
 }
 
@@ -81,14 +80,5 @@ func executeLogCall(f func(logger Logger, format string, v ...interface{}), form
 	if log.logger == nil {
 		return
 	}
-
-	argc := len(args)
-	if argc != 0 {
-		if client, ok := args[argc-1].(*client); ok {
-			args = args[:argc-1]
-			format = fmt.Sprintf("%s - %s", client, format)
-		}
-	}
-
 	f(log.logger, format, args...)
 }

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -24,8 +24,8 @@ func TestSetLogger(t *testing.T) {
 
 type DummyLogger struct{}
 
-func (l *DummyLogger) Notice(format string, v ...interface{}) {}
-func (l *DummyLogger) Error(format string, v ...interface{})  {}
-func (l *DummyLogger) Fatal(format string, v ...interface{})  {}
-func (l *DummyLogger) Debug(format string, v ...interface{})  {}
-func (l *DummyLogger) Trace(format string, v ...interface{})  {}
+func (l *DummyLogger) Noticef(format string, v ...interface{}) {}
+func (l *DummyLogger) Errorf(format string, v ...interface{})  {}
+func (l *DummyLogger) Fatalf(format string, v ...interface{})  {}
+func (l *DummyLogger) Debugf(format string, v ...interface{})  {}
+func (l *DummyLogger) Tracef(format string, v ...interface{})  {}

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -88,7 +88,7 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 
 	b, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
-		Error("Error marshalling response to /connz request: %v", err)
+		Errorf("Error marshalling response to /connz request: %v", err)
 	}
 	w.Write(b)
 }
@@ -114,7 +114,7 @@ func (s *Server) HandleSubsz(w http.ResponseWriter, r *http.Request) {
 
 	b, err := json.MarshalIndent(st, "", "  ")
 	if err != nil {
-		Error("Error marshalling response to /subscriptionsz request: %v", err)
+		Errorf("Error marshalling response to /subscriptionsz request: %v", err)
 	}
 	w.Write(b)
 }
@@ -161,7 +161,7 @@ func (s *Server) HandleVarz(w http.ResponseWriter, r *http.Request) {
 
 	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
-		Error("Error marshalling response to /varz request: %v", err)
+		Errorf("Error marshalling response to /varz request: %v", err)
 	}
 	w.Write(b)
 }

--- a/server/opts.go
+++ b/server/opts.go
@@ -225,7 +225,7 @@ func RemoveSelfReference(clusterPort int, routes []*url.URL) ([]*url.URL, error)
 		}
 
 		if cport == port && isIpInList(selfIPs, getUrlIp(host)) {
-			Notice("Self referencing IP found: ", r)
+			Noticef("Self referencing IP found: ", r)
 			continue
 		}
 		cleanRoutes = append(cleanRoutes, r)
@@ -256,7 +256,7 @@ func getUrlIp(ipStr string) []net.IP {
 
 	hostAddr, err := net.LookupHost(ipStr)
 	if err != nil {
-		Error("Error looking up host with route hostname: ", err)
+		Errorf("Error looking up host with route hostname: %v", err)
 		return ipList
 	}
 	for _, addr := range hostAddr {
@@ -273,7 +273,7 @@ func getInterfaceIPs() []net.IP {
 
 	interfaceAddr, err := net.InterfaceAddrs()
 	if err != nil {
-		Error("Error getting self referencing address: ", err)
+		Errorf("Error getting self referencing address: %v", err)
 		return localIPs
 	}
 
@@ -282,7 +282,7 @@ func getInterfaceIPs() []net.IP {
 		if net.ParseIP(interfaceIP.String()) != nil {
 			localIPs = append(localIPs, interfaceIP)
 		} else {
-			Error("Error parsing self referencing address: ", err)
+			Errorf("Error parsing self referencing address: %v", err)
 		}
 	}
 	return localIPs


### PR DESCRIPTION
Govet doesn't like functions that look like format handlers not ending in `f`,
such as Debug() vs Debugf(). This is changing some of the new log handling to
use 'f' function names to appease govet.

Updated the implicit handling of including the client as an arg without being
used in a format string. Now the client object simply has a Errorf function
for logging errors and it adds itself onto the format string.

FYI PR @derekcollison 
