### PR TITLE
Add support for custom dialers and listeners

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -31,6 +31,12 @@ import (
 	"github.com/nats-io/gnatsd/util"
 )
 
+// CustomDialer can be used to specify any dialer, not necessarily
+// a *net.Dialer.
+type CustomDialer interface {
+	Dial(network, address string) (net.Conn, error)
+}
+
 // ClusterOpts are options for clusters.
 type ClusterOpts struct {
 	Host           string      `json:"addr"`
@@ -86,6 +92,9 @@ type Options struct {
 	TLSCaCert       string        `json:"-"`
 	TLSConfig       *tls.Config   `json:"-"`
 	WriteDeadline   time.Duration `json:"-"`
+	ClientListener  net.Listener  `json:"-"`
+	RouteListener   net.Listener  `json:"-"`
+	RouteDialer     CustomDialer  `json:"-"`
 
 	CustomClientAuthentication Authentication `json:"-"`
 	CustomRouterAuthentication Authentication `json:"-"`

--- a/server/server.go
+++ b/server/server.go
@@ -415,11 +415,18 @@ func (s *Server) AcceptLoop(clr chan struct{}) {
 	opts := s.getOpts()
 
 	hp := net.JoinHostPort(opts.Host, strconv.Itoa(opts.Port))
-	l, e := net.Listen("tcp", hp)
-	if e != nil {
-		s.Fatalf("Error listening on port: %s, %q", hp, e)
-		return
+	var l net.Listener
+	var e error
+	if opts.ClientListener == nil {
+		l, e = net.Listen("tcp", hp)
+		if e != nil {
+			s.Fatalf("Error listening on port: %s, %q", hp, e)
+			return
+		}
+	} else {
+		l = opts.ClientListener
 	}
+
 	s.Noticef("Listening for client connections on %s",
 		net.JoinHostPort(opts.Host, strconv.Itoa(l.Addr().(*net.TCPAddr).Port)))
 


### PR DESCRIPTION
 - [x] Resolves #668 
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [x] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #668

### Changes proposed in this pull request:

 - Add `ClientListener` `RouteListener` and `RouteDialer` to Server Options

This has allowed me to implement multiplexing multiple servers off of one socket. This can also let you implement a websocket server embedded directly in the same process the nats server (Because gnatsd will accept arbitrary `net.Conn`).

Overall this gives much more flexibility in managing sockets and connections with very little restructuring of the server.

/cc @nats-io/core