### PR TITLE
Cluster nkeys tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
 install:
 - go get github.com/nats-io/go-nats
 - go get github.com/nats-io/nkeys
+- go get github.com/nats-io/jwt
 - go get github.com/mattn/goveralls
 - go get github.com/wadey/gocovmerge
 - go get -u honnef.co/go/tools/cmd/megacheck

--- a/util/nrc/nrc.go
+++ b/util/nrc/nrc.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 The NATS Authors
+// Copyright 2018 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -63,7 +63,7 @@ func NewNcrCmd() (*ncrCmd, error) {
 	var err error
 
 	var cmd = ncrCmd{}
-	flag.BoolVar(&cmd.create, "g", false, "processArgs cluster and/or server keys")
+	flag.BoolVar(&cmd.create, "g", false, "generate cluster and/or server keys")
 	flag.StringVar(&cmd.cluster.path, "c", "", "cluster key path")
 	flag.StringVar(&cmd.server.path, "s", "", "server key or path")
 	flag.StringVar(&cmd.outFile, "o", "--", "output file (defaults to stdout)")
@@ -364,7 +364,7 @@ func loadFromPath(s string) (string, error) {
 }
 
 func parseNKey(s string) (nkeys.KeyPair, error) {
-	if s[0:1] == "S" {
+	if s[0] == 'S' {
 		return nkeys.FromSeed(s)
 	} else {
 		return nkeys.FromPublicKey(s)

--- a/util/nrc/nrc.go
+++ b/util/nrc/nrc.go
@@ -1,0 +1,331 @@
+// Copyright 2015-2018 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nats-io/jwt"
+	"github.com/nats-io/nkeys"
+)
+
+func usage() {
+	printUsage()
+	os.Exit(1)
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, "Usage: nrc [-h] [-g] -c <cluster key path> -s <server key/path> [-o <output>]\n")
+	flag.PrintDefaults()
+}
+
+type ncrCmd struct {
+	makeNKeys *bool
+	outFile   *string
+	cluster   keyInfo
+	server    keyInfo
+	token     string
+}
+
+type keyInfo struct {
+	path *string
+	pair nkeys.KeyPair
+	pub  string
+	seed string
+}
+
+func NewNcrCmd() *ncrCmd {
+	var args = ncrCmd{}
+
+	args.makeNKeys = flag.Bool("g", false, "generate cluster and/or server keys")
+	args.cluster.path = flag.String("c", "", "cluster key path")
+	args.server.path = flag.String("s", "", "server key or path")
+	args.outFile = flag.String("o", "--", "output file (defaults to stdout)")
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	return &args
+}
+
+func main() {
+	cmd := NewNcrCmd()
+	if err := cmd.run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (n *ncrCmd) run() error {
+	if err := n.generate(); err != nil {
+		return err
+	}
+
+	if err, usageErr := n.loadClusterKey(); err != nil {
+		if usageErr {
+			printUsage()
+		}
+		return err
+	}
+
+	if err, usageErr := n.loadServerKey(); err != nil {
+		if usageErr {
+			printUsage()
+		}
+		return err
+	}
+
+	if err := n.generateToken(); err != nil {
+		return err
+	}
+
+	return n.doOutput()
+}
+
+func (n *ncrCmd) generate() error {
+	var err error
+	if *n.cluster.path == "" {
+		n.cluster.pair, err = nkeys.CreateCluster()
+		if err != nil {
+			return fmt.Errorf("error creating cluster keypair: %v", err)
+		}
+	}
+	if *n.server.path == "" {
+		n.server.pair, err = nkeys.CreateServer()
+		if err != nil {
+			return fmt.Errorf("error creating server keypair: %v", err)
+		}
+	}
+	return nil
+}
+
+func (n *ncrCmd) loadClusterKey() (error, bool) {
+	var err error
+	// cluster is read from a file
+
+	if n.cluster.pair == nil {
+		d, err := maybeParsePath(*n.cluster.path)
+		if err != nil {
+			return fmt.Errorf("unable to read cluster key: %v", err), false
+		}
+
+		n.cluster.pair, err = parseNKey(string(d), 'C')
+		if err != nil {
+			return fmt.Errorf("unable to parse cluster key: %v", err), false
+		}
+	}
+
+	if n.cluster.pair == nil {
+		return errors.New("cluster key was not provided"), true
+	}
+
+	n.cluster.pub, err = n.cluster.pair.PublicKey()
+	if err != nil {
+		return fmt.Errorf("error reading cluster public key: %v", err), false
+	}
+
+	if !nkeys.IsValidPublicClusterKey(n.cluster.pub) {
+		return fmt.Errorf("cluster key is not a valid key"), false
+	}
+	return nil, false
+}
+
+func (n *ncrCmd) loadServerKey() (error, bool) {
+	var err error
+	// server can be read from file or as an argument
+
+	if n.server.pair == nil {
+		n.server.pair, err = maybeParseNKey(*n.server.path, 'N')
+		if err != nil {
+			return fmt.Errorf("unable to parse server key: %v\n", err), false
+		}
+	}
+
+	if n.server.pair == nil {
+		return errors.New("server key was not provided"), true
+	}
+
+	n.server.pub, err = n.server.pair.PublicKey()
+	if err != nil {
+		return fmt.Errorf("error reading server public key: %v\n", err), false
+	}
+
+	if !nkeys.IsValidPublicServerKey(n.server.pub) {
+		return fmt.Errorf("server key is not a valid key"), false
+	}
+
+	return nil, false
+}
+
+func (n *ncrCmd) generateToken() error {
+	var err error
+	// generate the JWT
+	sc := jwt.NewServerClaims(n.server.pub)
+	n.token, err = sc.Encode(n.cluster.pair)
+	if err != nil {
+		return fmt.Errorf("error encoding server token: %v", err)
+	}
+
+	// if we generated the cluster - show them a public key
+	if *n.cluster.path == "" {
+		n.cluster.seed, err = n.cluster.pair.Seed()
+		if err != nil {
+			return fmt.Errorf("unable to generate cluster seed: %v", err)
+		}
+	}
+
+	// if we generated a server - show them a public key
+	if *n.server.path == "" {
+		n.server.seed, err = n.server.pair.Seed()
+		if err != nil {
+			return fmt.Errorf("unable to generate server seed: %v", err)
+		}
+	}
+	return nil
+}
+
+func (ki *keyInfo) printSeed(f *os.File) {
+	fmt.Fprintln(f, "-----BEGIN CLUSTER NKEY-----")
+	fmt.Fprintln(f, ki.seed)
+	fmt.Fprintln(f, "------END CLUSTER NKEY------")
+	fmt.Fprintln(f)
+
+	fmt.Fprintln(f, "-----BEGIN CLUSTER PUB KEY-----")
+	fmt.Fprintln(f, ki.pub)
+	fmt.Fprintln(f, "------END CLUSTER PUB KEY------")
+	fmt.Fprintln(f)
+}
+
+func (ki *keyInfo) isGenerated() bool {
+	return ki.seed != ""
+}
+
+func (n *ncrCmd) printToken(f *os.File) {
+	fmt.Fprintln(f, "-----BEGIN SERVER JWT-----")
+	fmt.Fprintln(f, n.token)
+	fmt.Fprintln(f, "------END SERVER JWT------")
+	fmt.Fprintln(f)
+}
+
+func (n *ncrCmd) doOutput() error {
+	var err error
+	var f *os.File
+
+	if *n.outFile == "--" {
+		f = os.Stdout
+	} else {
+		f, err = os.Create(*n.outFile)
+		if err != nil {
+			return fmt.Errorf("error creating output file %q: %v", *n.outFile, err)
+		}
+		defer f.Close()
+	}
+
+	if n.server.isGenerated() || n.cluster.isGenerated() {
+		fmt.Fprintln(f, "************************* IMPORTANT *************************")
+		fmt.Fprintln(f, "Your options generated cluster and/or server NKEYs which can")
+		fmt.Fprintln(f, "be used to create access tokens or prove identity.")
+		fmt.Fprintln(f, "Generated NKEYs printed below are sensitive and should be")
+		fmt.Fprintln(f, "treated as secrets to prevent unauthorized access to your")
+		fmt.Fprintln(f, "cluster.")
+		fmt.Fprintln(f)
+		fmt.Fprintln(f)
+		if n.cluster.isGenerated() {
+			n.cluster.printSeed(f)
+		}
+		if n.server.isGenerated() {
+			n.server.printSeed(f)
+		}
+		fmt.Fprintln(f, "*************************************************************")
+	}
+	n.printToken(f)
+	f.Sync()
+
+	if *n.outFile != "--" {
+		fmt.Printf("Success! - wrote server JWT to %q\n", *n.outFile)
+	}
+
+	return nil
+}
+
+func looksLikeNKey(s string, prefix byte) bool {
+	pre := string(prefix)
+	if len(s) == 58 {
+		pre = "S" + string(prefix)
+		return strings.HasPrefix(s, pre) && !strings.Contains(s, string(filepath.Separator))
+	}
+	if len(s) == 56 {
+		return strings.HasPrefix(s, pre) && !strings.Contains(s, string(filepath.Separator))
+	}
+	return false
+}
+
+func maybeParsePath(s string) (string, error) {
+	// otherwise see if they gave us a file
+	fi, err := os.Stat(s)
+	if err != nil && os.IsNotExist(err) {
+		return "", fmt.Errorf("file %q was not found", s)
+	}
+	if fi.IsDir() {
+		return "", fmt.Errorf("file %q is a directory", s)
+	}
+	// return the contents
+	d, err := ioutil.ReadFile(s)
+	if err != nil {
+		return "", fmt.Errorf("error reading %q: %v", s, err)
+	}
+	return string(d), nil
+}
+
+func maybeParseNKey(s string, prefix byte) (nkeys.KeyPair, error) {
+	var err error
+	var v string
+	if s == "" {
+		return nil, nil
+	}
+
+	if !looksLikeNKey(s, prefix) {
+		v, err = maybeParsePath(s)
+		if err != nil {
+			return nil, err
+		}
+		v = strings.TrimSpace(v)
+	} else {
+		v = s
+	}
+
+	if v[0:1] == "S" {
+		return nkeys.FromSeed(v)
+	} else {
+		return nkeys.FromPublicKey(v)
+	}
+}
+
+func parseNKey(s string, prefix byte) (nkeys.KeyPair, error) {
+	if !looksLikeNKey(s, prefix) {
+		if s[0:1] == "S" {
+			return nkeys.FromSeed(s)
+		} else {
+			return nkeys.FromPublicKey(s)
+		}
+	}
+	return nil, fmt.Errorf("%q is not an nkey", s)
+}

--- a/util/nrc/nrc.go
+++ b/util/nrc/nrc.go
@@ -14,7 +14,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -40,44 +39,49 @@ func printUsage() {
 	flag.PrintDefaults()
 }
 
-type ncrCmd struct {
-	makeNKeys *bool
-	outFile   *string
-	expiry    int64
-	cluster   keyInfo
-	server    keyInfo
-	token     string
+func main() {
+	cmd, err := NewNcrCmd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := cmd.run(); err != nil {
+		log.Fatal(err)
+	}
 }
 
-type keyInfo struct {
-	path *string
-	pair nkeys.KeyPair
-	pub  string
-	seed string
+type ncrCmd struct {
+	create  bool
+	outFile string
+	expiry  int64
+	cluster clusterKey
+	server  serverKey
+	token   string
 }
 
 func NewNcrCmd() (*ncrCmd, error) {
-	var args = ncrCmd{}
+	var err error
 
-	args.makeNKeys = flag.Bool("g", false, "generate cluster and/or server keys")
-	args.cluster.path = flag.String("c", "", "cluster key path")
-	args.server.path = flag.String("s", "", "server key or path")
-	args.outFile = flag.String("o", "--", "output file (defaults to stdout)")
+	var cmd = ncrCmd{}
+	flag.BoolVar(&cmd.create, "g", false, "processArgs cluster and/or server keys")
+	flag.StringVar(&cmd.cluster.path, "c", "", "cluster key path")
+	flag.StringVar(&cmd.server.path, "s", "", "server key or path")
+	flag.StringVar(&cmd.outFile, "o", "--", "output file (defaults to stdout)")
 	expiry := flag.String("e", "", "token expiry (YYYY-MM-DD, 1m, 1h, 1d, 1M, 1y, 1w)")
 
 	log.SetFlags(0)
 	flag.Usage = usage
 	flag.Parse()
 
-	var err error
-	args.expiry, err = parseExpiry(*expiry)
+	cmd.expiry, err = parseExpiry(*expiry)
 	if err != nil {
 		return nil, err
 	}
 
-	return &args, nil
+	return &cmd, nil
 }
 
+// parse expiration argument - supported are YYYY-MM-DD for absolute, and relative
+// (m)inute, (h)our, (d)ay, (w)week, (M)onth, (y)ear expressions
 func parseExpiry(s string) (int64, error) {
 	if s == "" {
 		return 0, nil
@@ -92,11 +96,12 @@ func parseExpiry(s string) (int64, error) {
 	}
 	re = regexp.MustCompile(`(?P<count>\d+)(?P<qualifier>[mhdMyw])`)
 	m := re.FindStringSubmatch(s)
-	if len(m) > 0 {
-		count, err := strconv.ParseInt(m[1], 10, 64)
+	if m != nil {
+		v, err := strconv.ParseInt(m[1], 10, 64)
 		if err != nil {
 			return 0, err
 		}
+		count := int(v)
 		if count == 0 {
 			return 0, nil
 		}
@@ -108,132 +113,145 @@ func parseExpiry(s string) (int64, error) {
 		case "h":
 			return now.Add(dur * time.Hour).Unix(), nil
 		case "d":
-			return now.Add(dur * time.Hour * 24).Unix(), nil
+			return now.AddDate(0, 0, count).Unix(), nil
 		case "w":
-			return now.Add(dur * time.Hour * 24 * 7).Unix(), nil
+			return now.AddDate(0, 0, 7*count).Unix(), nil
 		case "M":
-			return now.AddDate(0, 1, 0).Unix(), nil
+			return now.AddDate(0, count, 0).Unix(), nil
 		case "y":
-			return now.AddDate(1, 0, 0).Unix(), nil
+			return now.AddDate(count, 0, 0).Unix(), nil
 		}
 	}
-	return 0, fmt.Errorf("couldn't parse: %v", s)
+	return 0, fmt.Errorf("couldn't parse expiry: %v", s)
 }
 
-func main() {
-	cmd, err := NewNcrCmd()
-	if err != nil {
-		log.Fatal(err)
+// process arguments the cluster and server keys as per arguments
+func (n *ncrCmd) processArgs() error {
+	if err := n.cluster.init(n.create); err != nil {
+		return fmt.Errorf("error processing cluster keypair: %v", err)
 	}
-	if err := cmd.run(); err != nil {
-		log.Fatal(err)
+	if n.cluster.pair == nil {
+		return fmt.Errorf("mssing cluster key")
 	}
-}
-
-func (n *ncrCmd) run() error {
-	if err := n.generate(); err != nil {
-		return err
+	if err := n.server.init(n.create); err != nil {
+		return fmt.Errorf("error processing cluster keypair: %v", err)
 	}
-
-	if err, usageErr := n.loadClusterKey(); err != nil {
-		if usageErr {
-			printUsage()
-		}
-		return err
-	}
-
-	if err, usageErr := n.loadServerKey(); err != nil {
-		if usageErr {
-			printUsage()
-		}
-		return err
-	}
-
-	if err := n.generateToken(); err != nil {
-		return err
-	}
-
-	return n.doOutput()
-}
-
-func (n *ncrCmd) generate() error {
-	var err error
-	if *n.cluster.path == "" {
-		n.cluster.pair, err = nkeys.CreateCluster()
-		if err != nil {
-			return fmt.Errorf("error creating cluster keypair: %v", err)
-		}
-	}
-	if *n.server.path == "" {
-		n.server.pair, err = nkeys.CreateServer()
-		if err != nil {
-			return fmt.Errorf("error creating server keypair: %v", err)
-		}
+	if n.server.pair == nil {
+		return fmt.Errorf("mssing server key")
 	}
 	return nil
 }
 
-func (n *ncrCmd) loadClusterKey() (error, bool) {
-	var err error
-	// cluster is read from a file
-
-	if n.cluster.pair == nil {
-		d, err := maybeParsePath(*n.cluster.path)
-		if err != nil {
-			return fmt.Errorf("unable to read cluster key: %v", err), false
+// runs the command
+func (n *ncrCmd) run() error {
+	if err := n.processArgs(); err != nil {
+		if strings.HasPrefix(err.Error(), "missing") {
+			printUsage()
 		}
-
-		n.cluster.pair, err = parseNKey(string(d), 'C')
-		if err != nil {
-			return fmt.Errorf("unable to parse cluster key: %v", err), false
-		}
+		return err
 	}
-
-	if n.cluster.pair == nil {
-		return errors.New("cluster key was not provided"), true
+	if err := n.createToken(); err != nil {
+		return err
 	}
-
-	n.cluster.pub, err = n.cluster.pair.PublicKey()
-	if err != nil {
-		return fmt.Errorf("error reading cluster public key: %v", err), false
-	}
-
-	if !nkeys.IsValidPublicClusterKey(n.cluster.pub) {
-		return fmt.Errorf("cluster key is not a valid key"), false
-	}
-	return nil, false
+	return n.doOutput()
 }
 
-func (n *ncrCmd) loadServerKey() (error, bool) {
-	var err error
-	// server can be read from file or as an argument
+type serverKey struct {
+	prefix byte
+	path   string
+	pair   nkeys.KeyPair
+	pub    string
+	seed   string
+}
 
-	if n.server.pair == nil {
-		n.server.pair, err = maybeParseNKey(*n.server.path, 'N')
+type clusterKey struct {
+	serverKey
+}
+
+// server keys can be created/loaded/read from files or arguments
+func (sk *serverKey) init(create bool) error {
+	var err error
+	if create && sk.path == "" {
+		sk.pair, err = nkeys.CreateServer()
 		if err != nil {
-			return fmt.Errorf("unable to parse server key: %v\n", err), false
+			return err
+		}
+		sk.seed, err = sk.pair.Seed()
+		if err != nil {
+			return err
+		}
+	} else {
+		if looksLikeNKey(sk.path, sk.prefix) {
+			sk.pair, err = parseNKey(sk.path)
+			if err != nil {
+				return err
+			}
+		} else {
+			v, err := loadFromPath(sk.path)
+			if err != nil {
+				return err
+			}
+			sk.pair, err = parseNKey(v)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if sk.pair != nil {
+		sk.pub, err = sk.pair.PublicKey()
+		if err != nil {
+			return err
+		}
+		if !nkeys.IsValidPublicServerKey(sk.pub) {
+			return fmt.Errorf("invalid server public key: %q", sk.pub)
 		}
 	}
 
-	if n.server.pair == nil {
-		return errors.New("server key was not provided"), true
+	return nil
+}
+// cluster keys can only be created or loaded from files
+func (ck *clusterKey) init(create bool) error {
+	var err error
+	if create && ck.path == "" {
+		ck.pair, err = nkeys.CreateCluster()
+		if err != nil {
+			return err
+		}
+		ck.seed, err = ck.pair.Seed()
+		if err != nil {
+			return err
+		}
+		ck.pub, err = ck.pair.PublicKey()
+		if err != nil {
+			return err
+		}
+	} else {
+		v, err := loadFromPath(ck.path)
+		if err != nil {
+			return err
+		}
+		ck.pair, err = parseNKey(v)
+		if err != nil {
+			return err
+		}
+	}
+	if ck.pair != nil {
+		ck.pub, err = ck.pair.PublicKey()
+		if err != nil {
+			return err
+		}
+		if !nkeys.IsValidPublicClusterKey(ck.pub) {
+			return fmt.Errorf("invalid cluster public key: %q", ck.pub)
+		}
 	}
 
-	n.server.pub, err = n.server.pair.PublicKey()
-	if err != nil {
-		return fmt.Errorf("error reading server public key: %v\n", err), false
-	}
-
-	if !nkeys.IsValidPublicServerKey(n.server.pub) {
-		return fmt.Errorf("server key is not a valid key"), false
-	}
-
-	return nil, false
+	return nil
 }
 
-func (n *ncrCmd) generateToken() error {
+// generates the JWT token
+func (n *ncrCmd) createToken() error {
 	var err error
-	// generate the JWT
+	// processArgs the JWT
 	sc := jwt.NewServerClaims(n.server.pub)
 	if n.expiry > 0 {
 		sc.Expires = n.expiry
@@ -242,39 +260,27 @@ func (n *ncrCmd) generateToken() error {
 	if err != nil {
 		return fmt.Errorf("error encoding server token: %v", err)
 	}
-
-	// if we generated the cluster - show them a public key
-	if *n.cluster.path == "" {
-		n.cluster.seed, err = n.cluster.pair.Seed()
-		if err != nil {
-			return fmt.Errorf("unable to generate cluster seed: %v", err)
-		}
-	}
-
-	// if we generated a server - show them a public key
-	if *n.server.path == "" {
-		n.server.seed, err = n.server.pair.Seed()
-		if err != nil {
-			return fmt.Errorf("unable to generate server seed: %v", err)
-		}
-	}
 	return nil
 }
 
-func (ki *keyInfo) printSeed(f *os.File) {
-	fmt.Fprintln(f, "-----BEGIN CLUSTER NKEY-----")
-	fmt.Fprintln(f, ki.seed)
-	fmt.Fprintln(f, "------END CLUSTER NKEY------")
-	fmt.Fprintln(f)
+// template for a generated key
+func (sk *serverKey) printGeneratedKeys(f *os.File, label string) {
+	if sk.isGenerated() {
+		label = strings.ToUpper(label)
+		fmt.Fprintf(f, "-----BEGIN %s NKEY-----\n", label)
+		fmt.Fprintln(f, sk.seed)
+		fmt.Fprintf(f, "------END %s NKEY------\n", label)
+		fmt.Fprintln(f)
 
-	fmt.Fprintln(f, "-----BEGIN CLUSTER PUB KEY-----")
-	fmt.Fprintln(f, ki.pub)
-	fmt.Fprintln(f, "------END CLUSTER PUB KEY------")
-	fmt.Fprintln(f)
+		fmt.Fprintf(f, "-----BEGIN %s PUB KEY-----\n", label)
+		fmt.Fprintln(f, sk.pub)
+		fmt.Fprintf(f, "------END %s PUB KEY------\n", label)
+		fmt.Fprintln(f)
+	}
 }
 
-func (ki *keyInfo) isGenerated() bool {
-	return ki.seed != ""
+func (sk *serverKey) isGenerated() bool {
+	return sk.seed != ""
 }
 
 func (n *ncrCmd) printToken(f *os.File) {
@@ -288,12 +294,12 @@ func (n *ncrCmd) doOutput() error {
 	var err error
 	var f *os.File
 
-	if *n.outFile == "--" {
+	if n.outFile == "--" {
 		f = os.Stdout
 	} else {
-		f, err = os.Create(*n.outFile)
+		f, err = os.Create(n.outFile)
 		if err != nil {
-			return fmt.Errorf("error creating output file %q: %v", *n.outFile, err)
+			return fmt.Errorf("error creating output file %q: %v", n.outFile, err)
 		}
 		defer f.Close()
 	}
@@ -307,20 +313,18 @@ func (n *ncrCmd) doOutput() error {
 		fmt.Fprintln(f, "cluster.")
 		fmt.Fprintln(f)
 		fmt.Fprintln(f)
-		if n.cluster.isGenerated() {
-			n.cluster.printSeed(f)
-		}
-		if n.server.isGenerated() {
-			n.server.printSeed(f)
-		}
+
+		n.cluster.printGeneratedKeys(f, "cluster")
+		n.server.printGeneratedKeys(f, "server")
+
 		fmt.Fprintln(f, "*************************************************************")
 		fmt.Fprintln(f)
 	}
 	n.printToken(f)
 	f.Sync()
 
-	if *n.outFile != "--" {
-		fmt.Printf("Success! - wrote server JWT to %q\n", *n.outFile)
+	if n.outFile != "--" {
+		fmt.Printf("Success! - wrote server JWT to %q\n", n.outFile)
 	}
 
 	return nil
@@ -338,7 +342,7 @@ func looksLikeNKey(s string, prefix byte) bool {
 	return false
 }
 
-func maybeParsePath(s string) (string, error) {
+func loadFromPath(s string) (string, error) {
 	// otherwise see if they gave us a file
 	fi, err := os.Stat(s)
 	if err != nil && os.IsNotExist(err) {
@@ -355,37 +359,10 @@ func maybeParsePath(s string) (string, error) {
 	return string(d), nil
 }
 
-func maybeParseNKey(s string, prefix byte) (nkeys.KeyPair, error) {
-	var err error
-	var v string
-	if s == "" {
-		return nil, nil
-	}
-
-	if !looksLikeNKey(s, prefix) {
-		v, err = maybeParsePath(s)
-		if err != nil {
-			return nil, err
-		}
-		v = strings.TrimSpace(v)
+func parseNKey(s string) (nkeys.KeyPair, error) {
+	if s[0:1] == "S" {
+		return nkeys.FromSeed(s)
 	} else {
-		v = s
+		return nkeys.FromPublicKey(s)
 	}
-
-	if v[0:1] == "S" {
-		return nkeys.FromSeed(v)
-	} else {
-		return nkeys.FromPublicKey(v)
-	}
-}
-
-func parseNKey(s string, prefix byte) (nkeys.KeyPair, error) {
-	if !looksLikeNKey(s, prefix) {
-		if s[0:1] == "S" {
-			return nkeys.FromSeed(s)
-		} else {
-			return nkeys.FromPublicKey(s)
-		}
-	}
-	return nil, fmt.Errorf("%q is not an nkey", s)
 }

--- a/util/nrc/nrc_test.go
+++ b/util/nrc/nrc_test.go
@@ -1,0 +1,352 @@
+package main
+
+import (
+	"fmt"
+	"github.com/nats-io/jwt"
+	"github.com/nats-io/nkeys"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+
+func TestParseDate(t *testing.T) {
+	type testd struct {
+		input string
+		output int64
+		isError bool
+	}
+	tests := []testd{
+		{"", 0, false},
+		{"19-1-6", 0, true},
+		{"2019-1-6", 0, true},
+		{"2019-01-6", 0, true},
+		{"2019-01-06", time.Date(2019, 1, 6, 0, 0, 0, 0, time.UTC).Unix(), false},
+		{"1m", time.Now().Unix() + 60, false},
+		{"32m", time.Now().Unix() + 60*32, false},
+		{"1h", time.Now().Unix() + 60*60, false},
+		{"3h", time.Now().Unix() + 60*60*3, false},
+		{"1d", time.Now().Unix() + 60*60*24, false},
+		{"3d", time.Now().Unix() + 60*60*24*3, false},
+		{"1w", time.Now().Unix() + 60*60*24*7, false},
+		{"3w", time.Now().AddDate(0, 0, 7*3).Unix(), false},
+		{"2M", time.Now().AddDate(0, 2, 0).Unix(), false},
+		{"2y", time.Now().AddDate(2, 0, 0).Unix(), false},
+	}
+	for _, d := range tests {
+		v, err := parseExpiry(d.input)
+		if err != nil && !d.isError {
+			t.Errorf("%s didn't expect error: %v", d.input, err)
+			continue
+		}
+		if v != d.output {
+			t.Errorf("%s expected %d but got %d", d.input, d.output, v)
+		}
+	}
+}
+
+func TestGenerateAll(t *testing.T) {
+	p, err := ioutil.TempDir("", "ncr_tests")
+	if err != nil {
+		t.Fatal("error creating test dir", err)
+	}
+
+	cmd := ncrCmd{}
+	cmd.create = true
+	cmd.outFile = filepath.Join(p, "test_generate.jwt")
+
+	if err := cmd.run(); err != nil {
+		t.Fatal(err)
+	}
+
+	if cmd.token == "" {
+		t.Fatal("failed to generate token")
+	}
+
+	if cmd.server.seed == "" {
+		t.Fatal("failed to generate seed")
+	}
+
+	if cmd.cluster.seed == "" {
+		t.Fatal("failed to generate seed")
+	}
+
+	c, err := jwt.DecodeServerClaims(cmd.token)
+	if err != nil {
+		t.Fatal("failed to decode claim", err)
+	}
+
+	if c.Subject != cmd.server.pub {
+		t.Fatalf("subjects didn't match expected %q got %q", cmd.server.pub, c.Subject)
+	}
+
+	data, err := ioutil.ReadFile(cmd.outFile)
+	s := string(data)
+
+	if !strings.Contains(s, cmd.token) {
+		t.Fatal("token was not found")
+	}
+
+	if !strings.Contains(s, cmd.cluster.seed) {
+		t.Fatal("cluster seed was not found")
+	}
+
+	if !strings.Contains(s, cmd.cluster.pub) {
+		t.Fatal("cluster pub was not found")
+	}
+
+	if !strings.Contains(s, cmd.server.seed) {
+		t.Fatal("server seed was not found")
+	}
+
+	if !strings.Contains(s, cmd.server.pub) {
+		t.Fatal("server pub was not found")
+	}
+}
+
+func TestGenerateServer(t *testing.T) {
+	p, err := ioutil.TempDir("", "ncr_tests")
+	if err != nil {
+		t.Fatal("error creating test dir", err)
+	}
+
+	keys := generateKeys(nkeys.CreateCluster, t)
+	kfile := store(keys.seed, t)
+
+	cmd := ncrCmd{}
+	cmd.create = true
+	cmd.cluster.path = kfile
+	cmd.outFile = filepath.Join(p, "test_generate.jwt")
+
+	if err := cmd.run(); err != nil {
+		t.Fatal(err)
+	}
+
+	if cmd.token == "" {
+		t.Fatal("failed to generate token")
+	}
+
+	if cmd.server.seed == "" {
+		t.Fatal("failed to generate seed")
+	}
+
+	if cmd.cluster.seed != "" {
+		t.Fatal("generate seed - shouldn't have")
+	}
+
+	c, err := jwt.DecodeServerClaims(cmd.token)
+	if err != nil {
+		t.Fatal("failed to decode claim", err)
+	}
+
+	if c.Subject != cmd.server.pub {
+		t.Fatalf("subjects didn't match expected %q got %q", cmd.server.pub, c.Subject)
+	}
+
+	data, err := ioutil.ReadFile(cmd.outFile)
+	s := string(data)
+
+	if !strings.Contains(s, cmd.token) {
+		t.Fatal("token was not found")
+	}
+
+	if cmd.cluster.seed != "" && strings.Contains(s, cmd.cluster.seed) {
+		t.Fatal("cluster seed shouldn't be in the output", s)
+	}
+
+	if cmd.cluster.pub != "" && strings.Contains(s, cmd.cluster.pub) {
+		t.Fatal("cluster pub shoudn't be in the output")
+	}
+
+	if !strings.Contains(s, cmd.server.seed) {
+		t.Fatal("server seed was not found")
+	}
+
+	if !strings.Contains(s, cmd.server.pub) {
+		t.Fatal("server pub was not found")
+	}
+}
+
+func TestGenerateNone(t *testing.T) {
+	p, err := ioutil.TempDir("", "ncr_tests")
+	if err != nil {
+		t.Fatal("error creating test dir", err)
+	}
+
+	ck := generateKeys(nkeys.CreateCluster, t)
+	ckf := store(ck.seed, t)
+
+	sk := generateKeys(nkeys.CreateServer, t)
+	skf := store(sk.pub, t)
+
+	cmd := ncrCmd{}
+	cmd.create = true
+	cmd.cluster.path = ckf
+	cmd.server.path = skf
+	cmd.outFile = filepath.Join(p, "test_generate.jwt")
+	cmd.expiry, err = parseExpiry("1d")
+	if err != nil {
+		t.Fatal("failed to parse expiry")
+	}
+
+	if err := cmd.run(); err != nil {
+		t.Fatal(err)
+	}
+
+	if cmd.token == "" {
+		t.Fatal("failed to generate token")
+	}
+
+	if cmd.server.seed != "" {
+		t.Fatal("generated server seed - shouldn't have")
+	}
+
+	if cmd.cluster.seed != "" {
+		t.Fatal("generate seed - shouldn't have")
+	}
+
+	data, err := ioutil.ReadFile(cmd.outFile)
+	s := string(data)
+
+	if !strings.Contains(s, cmd.token) {
+		t.Fatal("token was not found")
+	}
+
+	if cmd.cluster.seed != "" && strings.Contains(s, cmd.cluster.seed) {
+		t.Fatal("cluster seed shouldn't be in the output", s)
+	}
+
+	if cmd.cluster.pub != "" && strings.Contains(s, cmd.cluster.pub) {
+		t.Fatal("cluster pub shoudn't be in the output")
+	}
+
+	if cmd.server.seed != "" && strings.Contains(s, cmd.server.seed) {
+		t.Fatal("server seed shouldn't be in the output")
+	}
+
+	if cmd.server.pub != "" && strings.Contains(s, cmd.server.pub) {
+		t.Fatal("server pub shouldn't be in the output")
+	}
+
+	c, err := jwt.DecodeServerClaims(cmd.token)
+	if err != nil {
+		t.Fatal("failed to decode claim", err)
+	}
+
+	if c.Subject != cmd.server.pub {
+		t.Fatalf("subjects didn't match expected %q got %q", cmd.server.pub, c.Subject)
+	}
+
+	if c.Expires == 0 {
+		t.Fatal("expiration was not set and should be")
+	}
+}
+
+func TestInvalidClusterKey(t *testing.T) {
+	p, err := ioutil.TempDir("", "ncr_tests")
+	if err != nil {
+		t.Fatal("error creating test dir", err)
+	}
+
+	keys := generateKeys(nkeys.CreateServer, t)
+	kfile := store(keys.seed, t)
+
+	cmd := ncrCmd{}
+	cmd.create = true
+	cmd.cluster.path = kfile
+	cmd.outFile = filepath.Join(p, "test_generate.jwt")
+
+	if err := cmd.run(); err != nil {
+		if !strings.Contains(err.Error(), "invalid cluster public key") {
+			t.Fatal("unexpected error", err)
+		}
+		return
+	}
+	t.Fatal("should have failed - with bad cluster key")
+}
+
+func TestInvalidClusterNKey(t *testing.T) {
+	p, err := ioutil.TempDir("", "ncr_tests")
+	if err != nil {
+		t.Fatal("error creating test dir", err)
+	}
+
+	keys := generateKeys(nkeys.CreateCluster, t)
+	kfile := store(keys.pub, t)
+
+	cmd := ncrCmd{}
+	cmd.create = true
+	cmd.cluster.path = kfile
+	cmd.outFile = filepath.Join(p, "test_generate.jwt")
+
+	if err := cmd.run(); err != nil {
+		if !strings.Contains(err.Error(), "no private key available") {
+			t.Fatal("unexpected error", err)
+		}
+		return
+	}
+	t.Fatal("should have failed - with bad cluster key")
+}
+
+func TestInvalidServerKey(t *testing.T) {
+	p, err := ioutil.TempDir("", "ncr_tests")
+	if err != nil {
+		t.Fatal("error creating test dir", err)
+	}
+
+	keys := generateKeys(nkeys.CreateCluster, t)
+	kfile := store(keys.seed, t)
+
+	cmd := ncrCmd{}
+	cmd.create = true
+	cmd.cluster.path = kfile
+	cmd.server.path = kfile
+	cmd.outFile = filepath.Join(p, "test_generate.jwt")
+
+	if err := cmd.run(); err != nil {
+		if !strings.Contains(err.Error(), "invalid server public key") {
+			t.Fatal("unexpected error", err)
+		}
+		return
+	}
+	t.Fatal("should have failed - with bad server key")
+}
+
+
+type kpfun func()(nkeys.KeyPair, error)
+
+func generateKeys(f kpfun, t *testing.T) (*serverKey) {
+	var err error
+	sk := serverKey{}
+	sk.pair, err = f()
+	if err != nil {
+		t.Fatal("error generating key", err)
+	}
+	sk.seed, err = sk.pair.Seed()
+	if err != nil {
+		t.Fatal("error reading seed", err)
+	}
+	sk.pub, err = sk.pair.PublicKey()
+	if err != nil {
+		t.Fatal("error reading seed", err)
+	}
+
+	return &sk
+}
+
+func store(s string, t *testing.T)(string) {
+	f, err := ioutil.TempFile("", "nkey")
+	if err != nil {
+		t.Fatal("error creating temp file", err)
+	}
+	defer f.Close()
+
+	_, err = fmt.Fprintln(f, s)
+	if err != nil {
+		t.Fatal("error writing temp file", err)
+	}
+	f.Sync()
+	return f.Name()
+}

--- a/util/nrc/nrc_test.go
+++ b/util/nrc/nrc_test.go
@@ -1,14 +1,28 @@
+// Copyright 2018 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
 	"fmt"
-	"github.com/nats-io/jwt"
-	"github.com/nats-io/nkeys"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/nats-io/jwt"
+	"github.com/nats-io/nkeys"
 )
 
 func TestParseDate(t *testing.T) {
@@ -38,6 +52,10 @@ func TestParseDate(t *testing.T) {
 		v, err := parseExpiry(d.input)
 		if err != nil && !d.isError {
 			t.Errorf("%s didn't expect error: %v", d.input, err)
+			continue
+		}
+		if err == nil && d.isError {
+			t.Errorf("expected error from %s", d.input)
 			continue
 		}
 		if v != d.output {
@@ -82,6 +100,9 @@ func TestGenerateAll(t *testing.T) {
 	}
 
 	data, err := ioutil.ReadFile(cmd.outFile)
+	if err != nil {
+		t.Fatal("error reading file", err)
+	}
 	s := string(data)
 
 	if !strings.Contains(s, cmd.token) {
@@ -145,6 +166,9 @@ func TestGenerateServer(t *testing.T) {
 	}
 
 	data, err := ioutil.ReadFile(cmd.outFile)
+	if err != nil {
+		t.Fatal("error reading file", err)
+	}
 	s := string(data)
 
 	if !strings.Contains(s, cmd.token) {
@@ -207,6 +231,9 @@ func TestGenerateNone(t *testing.T) {
 	}
 
 	data, err := ioutil.ReadFile(cmd.outFile)
+	if err != nil {
+		t.Fatal("error reading file", err)
+	}
 	s := string(data)
 
 	if !strings.Contains(s, cmd.token) {

--- a/util/nrc/nrc_test.go
+++ b/util/nrc/nrc_test.go
@@ -11,11 +11,10 @@ import (
 	"time"
 )
 
-
 func TestParseDate(t *testing.T) {
 	type testd struct {
-		input string
-		output int64
+		input   string
+		output  int64
 		isError bool
 	}
 	tests := []testd{
@@ -314,10 +313,9 @@ func TestInvalidServerKey(t *testing.T) {
 	t.Fatal("should have failed - with bad server key")
 }
 
+type kpfun func() (nkeys.KeyPair, error)
 
-type kpfun func()(nkeys.KeyPair, error)
-
-func generateKeys(f kpfun, t *testing.T) (*serverKey) {
+func generateKeys(f kpfun, t *testing.T) *serverKey {
 	var err error
 	sk := serverKey{}
 	sk.pair, err = f()
@@ -336,7 +334,7 @@ func generateKeys(f kpfun, t *testing.T) (*serverKey) {
 	return &sk
 }
 
-func store(s string, t *testing.T)(string) {
+func store(s string, t *testing.T) string {
 	f, err := ioutil.TempFile("", "nkey")
 	if err != nil {
 		t.Fatal("error creating temp file", err)


### PR DESCRIPTION
cluster jwt generation tool

```
Usage: nrc [-h] [-g] -c <cluster key path> -s <server key/path> [-o <output>]
  -c string
        cluster key path
  -e string
        token expiry (YYYY-MM-DD, 1m, 1h, 1d, 1M, 1y, 1w)
  -g    processArgs cluster and/or server keys
  -o string
        output file (defaults to stdout) (default "--")
  -s string
        server key or path
```

