### PR TITLE
Fix logging public nkey on auth violation

### DIFF
--- a/server/client_test.go
+++ b/server/client_test.go
@@ -1192,3 +1192,40 @@ func TestClientTraceRace(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestClientUserInfo(t *testing.T) {
+	pnkey := "UD6AYQSOIN2IN5OGC6VQZCR4H3UFMIOXSW6NNS6N53CLJA4PB56CEJJI"
+	c := &client{
+		cid: 1024,
+		opts: clientOpts{
+			Nkey: pnkey,
+		},
+	}
+	got := c.getAuthUser()
+	expected := `Nkey "UD6AYQSOIN2IN5OGC6VQZCR4H3UFMIOXSW6NNS6N53CLJA4PB56CEJJI"`
+	if got != expected {
+		t.Errorf("Expected %q, got %q", expected, got)
+	}
+
+	c = &client{
+		cid: 1024,
+		opts: clientOpts{
+			Username: "foo",
+		},
+	}
+	got = c.getAuthUser()
+	expected = `User "foo"`
+	if got != expected {
+		t.Errorf("Expected %q, got %q", expected, got)
+	}
+
+	c = &client{
+		cid:  1024,
+		opts: clientOpts{},
+	}
+	got = c.getAuthUser()
+	expected = `User "N/A"`
+	if got != expected {
+		t.Errorf("Expected %q, got %q", expected, got)
+	}
+}


### PR DESCRIPTION
Fixes a few logging entries where the public nkey would be missing in the log:

```
[92146] 2019/02/01 14:03:34.151755 [ERR] 127.0.0.1:60653 - cid:2 - Subscription Violation - Nkey "UD6AYQSOIN2IN5OGC6VQZCR4H3UFMIOXSW6NNS6N53CLJA4PB56CEJJI", Subject "foo.bar", SID 1
[92146] 2019/02/01 14:03:34.151882 [ERR] 127.0.0.1:60653 - cid:2 - Publish Violation - Nkey "UD6AYQSOIN2IN5OGC6VQZCR4H3UFMIOXSW6NNS6N53CLJA4PB56CEJJI", Subject "foo.bar"
[92146] 2019/02/01 14:13:57.147115 [INF] Removed sub "foo" (sid "1") for Nkey "UD6AYQSOIN2IN5OGC6VQZCR4H3UFMIOXSW6NNS6N53CLJA4PB56CEJJI" - not authorized
```

 - [X] Documentation added (if applicable)
 - [x] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Fixes #862 

/cc @nats-io/core

Signed-off-by: Waldemar Quevedo <wally@synadia.com>