### PR TITLE
[FIXED] Changes to Varz content and fixed race conditions

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -35,6 +35,8 @@ import (
 )
 
 // ClusterOpts are options for clusters.
+// NOTE: This structure is no longer used for monitoring endpoints
+// and json tags are deprecated and may be removed in the future.
 type ClusterOpts struct {
 	Host           string            `json:"addr,omitempty"`
 	Port           int               `json:"cluster_port,omitempty"`
@@ -52,6 +54,8 @@ type ClusterOpts struct {
 }
 
 // GatewayOpts are options for gateways.
+// NOTE: This structure is no longer used for monitoring endpoints
+// and json tags are deprecated and may be removed in the future.
 type GatewayOpts struct {
 	Name           string               `json:"name"`
 	Host           string               `json:"addr,omitempty"`
@@ -73,6 +77,8 @@ type GatewayOpts struct {
 }
 
 // RemoteGatewayOpts are options for connecting to a remote gateway
+// NOTE: This structure is no longer used for monitoring endpoints
+// and json tags are deprecated and may be removed in the future.
 type RemoteGatewayOpts struct {
 	Name       string      `json:"name"`
 	TLSConfig  *tls.Config `json:"-"`
@@ -81,6 +87,8 @@ type RemoteGatewayOpts struct {
 }
 
 // LeafNodeOpts are options for a given server to accept leaf node connections and/or connect to a remote cluster.
+// NOTE: This structure is no longer used for monitoring endpoints
+// and json tags are deprecated and may be removed in the future.
 type LeafNodeOpts struct {
 	Host              string            `json:"addr,omitempty"`
 	Port              int               `json:"port,omitempty"`
@@ -101,6 +109,8 @@ type LeafNodeOpts struct {
 }
 
 // RemoteLeafOpts are options for connecting to a remote server as a leaf node.
+// NOTE: This structure is no longer used for monitoring endpoints
+// and json tags are deprecated and may be removed in the future.
 type RemoteLeafOpts struct {
 	LocalAccount string      `json:"local_account,omitempty"`
 	URL          *url.URL    `json:"url,omitempty"`
@@ -111,6 +121,8 @@ type RemoteLeafOpts struct {
 }
 
 // Options block for nats-server.
+// NOTE: This structure is no longer used for monitoring endpoints
+// and json tags are deprecated and may be removed in the future.
 type Options struct {
 	ConfigFile       string        `json:"-"`
 	Host             string        `json:"addr"`

--- a/server/reload.go
+++ b/server/reload.go
@@ -564,6 +564,7 @@ func (s *Server) Reload() error {
 	}
 	s.mu.Lock()
 	s.configTime = time.Now()
+	s.updateVarzConfigReloadableFields(s.varz)
 	s.mu.Unlock()
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -166,6 +166,11 @@ type Server struct {
 
 	// Trusted public operator keys.
 	trustedKeys []string
+
+	// We use this to minimize mem copies for request to monitoring
+	// endpoint /varz (when it comes from http).
+	varzMu sync.Mutex
+	varz   *Varz
 }
 
 // Make sure all are 64bits for atomic use


### PR DESCRIPTION
----------------------------------------------------------------

Backward-incompatibility note:

Varz used to embed *Info and *Options which are other server objects.
However, Info is a struct that servers used to send protocols to other
servers or clients and its content must contain json tags since we
need to marshal those to be sent over. The problem is that it made
those fields now accessible to users calling Varz() and also visible
to the http /varz output. Some fields in Info were introduced in the
2.0 branch that clashed with json tag in Options, which made cluster{}
for instance disappear in the /varz output - because a Cluster string
in Info has the same json tag, and Cluster in Info is empty in some
cases.
For users that embed NATS and were using Server.Varz() directly,
without the use of the monitoring endpoint, they were then given
access (which was not the intent) to server internals (Info and Options).
Fields that were in Info or Options or directly in Varz that did not
clash with each other could be referenced directly, for instace, this
is you could access the server ID:

v, _ := s.Varz(nil)
fmt.Println(v.ID)

Another way would be:

fmt.Println(v.Info.ID)

Same goes for fields that were brought from embedding the Options:

fmt.Println(v.MaxConn)

or

fmt.Println(v.Options.MaxConn)

We have decided to explicitly define fields in Varz, which means
that if you previously accessed fields through v.Info or v.Options,
you will have to update your code to use the corresponding field
directly: v.ID or v.MaxConn for instance.

So fields were also duplicated between Info/Options and Varz itself
so depending on which one your application was accessing, you may
have to update your code.

---------------------------------------------------------------

Other issues that have been fixed is races that were introduced
by the fact that the creation of a Varz object (pointing to
some server data) was done under server lock, but marshaling not
being done under that lock caused races.

The fact that object returned to user through Server.Varz() also
had references to server internal objects had to be fixed by
returning deep copy of those internal objects.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
