### PR TITLE
Add symlink to gnatsd on alpine image

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -17,7 +17,9 @@ RUN apk add --update ca-certificates && mkdir -p /nats/bin && mkdir /nats/conf
 COPY docker/nats-server.conf /nats/conf/nats-server.conf
 COPY --from=builder /nats-server /nats/bin/nats-server
 
-RUN ln -ns /nats/bin/nats-server /bin/nats-server && ln -ns /nats/bin/nats-server /nats-server
+# NOTE: For backwards compatibility, we add a symlink to /gnatsd which is
+# where the binary from the scratch container image used to be located.
+RUN ln -ns /nats/bin/nats-server /bin/nats-server && ln -ns /nats/bin/nats-server /nats-server && ln -ns /nats/bin/nats-server /gnatsd
 
 # Expose client, management, cluster and gateway ports
 EXPOSE 4222 8222 6222 5222


### PR DESCRIPTION
This adds a symlink of the `nats-server` binary to `/gnatsd`  in order to mimic how the `FROM scratch` image works.

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

/cc @nats-io/core
