### PR TITLE
[UPDATED] Reduce report of failed connection attempts

### DIFF
--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -27,6 +27,10 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
+func init() {
+	routeConnectDelay = 15 * time.Millisecond
+}
+
 func checkNumRoutes(t *testing.T, s *Server, expected int) {
 	t.Helper()
 	checkFor(t, 5*time.Second, 15*time.Millisecond, func() error {

--- a/server/util.go
+++ b/server/util.go
@@ -110,3 +110,12 @@ func parseHostPort(hostPort string, defaultPort int) (host string, port int, err
 func urlsAreEqual(u1, u2 *url.URL) bool {
 	return reflect.DeepEqual(u1, u2)
 }
+
+// Returns true for the first attempt, after a minute and then an hour.
+// It is assumed that each failed attempt is done every second.
+func shouldReportConnectErr(attempts int) bool {
+	if attempts == 1 || attempts == 60 || attempts%3600 == 0 {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
This applies to routes, gateways and leaf node connections.
The failed attempts will be printed at the first, after the first
minute and then every hour.
The connect/error statements now include the attempt number.

Note that in debug mode, all attempts are traced, so you may get
double trace (one for debug, one for info/error).

Resolves #969

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
