### PR TITLE
Make the error report attempts configurable

### DIFF
--- a/server/configs/test.conf
+++ b/server/configs/test.conf
@@ -46,3 +46,7 @@ ping_max: 3
 write_deadline: "3s"
 
 lame_duck_duration: "4m"
+
+# report repeated failed route/gateway/leafNode connection
+# every 24hour (24*60*60)
+connection_error_report_attempts: 86400

--- a/server/const.go
+++ b/server/const.go
@@ -139,4 +139,9 @@ const (
 
 	// DEFAULT_LEAFNODE_INFO_WAIT Route dial timeout.
 	DEFAULT_LEAFNODE_INFO_WAIT = 1 * time.Second
+
+	// DEFAULT_CONNECTION_ERROR_REPORT_ATTEMPTS is the number of attempts at which a
+	// repeated failed route, gateway or leaf node connection is reported. The default
+	// corresponds to a report every hour.
+	DEFAULT_CONNECTION_ERROR_REPORT_ATTEMPTS = 3600
 )

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -562,7 +562,7 @@ func (s *Server) solicitGateway(cfg *gatewayCfg) {
 
 	for s.isRunning() && len(urls) > 0 {
 		attempts++
-		report := shouldReportConnectErr(attempts)
+		report := shouldReportConnectErr(opts.ConnectionErrorReportAttempts, attempts)
 		// Iteration is random
 		for _, u := range urls {
 			address, err := s.getRandomIP(s.gateway.resolver, u.Host)

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -157,7 +157,8 @@ func (s *Server) connectToRemoteLeafNode(remote *leafNodeCfg) {
 		return
 	}
 
-	reconnectDelay := s.getOpts().LeafNode.ReconnectInterval
+	opts := s.getOpts()
+	reconnectDelay := opts.LeafNode.ReconnectInterval
 	s.mu.Lock()
 	dialTimeout := s.leafNodeOpts.dialTimeout
 	resolver := s.leafNodeOpts.resolver
@@ -182,7 +183,7 @@ func (s *Server) connectToRemoteLeafNode(remote *leafNodeCfg) {
 		if err != nil {
 			attempts++
 			s.Debugf(connErrFmt, attempts, err)
-			if shouldReportConnectErr(attempts) {
+			if shouldReportConnectErr(opts.ConnectionErrorReportAttempts, attempts) {
 				s.Errorf(connErrFmt, attempts, err)
 			}
 			select {

--- a/server/opts.go
+++ b/server/opts.go
@@ -187,6 +187,15 @@ type Options struct {
 	// CheckConfig configuration file syntax test was successful and exit.
 	CheckConfig bool `json:"-"`
 
+	// ConnectionErrorReportAttempts is the number of consecutive failed
+	// attempts to connect a route, gateway or leaf node at which point
+	// the server report the failure in the log. This is to prevent
+	// lots of errors when a configured endpoint is offline for a longer
+	// period of time.
+	// Default is DEFAULT_CONNECTION_ERROR_REPORT_ATTEMPTS (3600) which
+	// means that the server will report the error every hour.
+	ConnectionErrorReportAttempts int
+
 	// private fields, used to know if bool options are explicitly
 	// defined in config and/or command line params.
 	inConfig  map[string]bool
@@ -678,6 +687,8 @@ func (o *Options) ProcessConfigFile(configFile string) error {
 					errors = append(errors, err)
 				}
 			}
+		case "connection_error_report_attempts":
+			o.ConnectionErrorReportAttempts = int(v.(int64))
 		default:
 			if !tk.IsUsedVariable() {
 				err := &unknownConfigFieldErr{
@@ -2420,6 +2431,9 @@ func setBaselineOptions(opts *Options) {
 		if opts.Gateway.AuthTimeout == 0 {
 			opts.Gateway.AuthTimeout = float64(AUTH_TIMEOUT) / float64(time.Second)
 		}
+	}
+	if opts.ConnectionErrorReportAttempts == 0 {
+		opts.ConnectionErrorReportAttempts = DEFAULT_CONNECTION_ERROR_REPORT_ATTEMPTS
 	}
 }
 

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -59,6 +59,7 @@ func TestDefaultOptions(t *testing.T) {
 		LeafNode: LeafNodeOpts{
 			ReconnectInterval: DEFAULT_LEAF_NODE_RECONNECT,
 		},
+		ConnectionErrorReportAttempts: DEFAULT_CONNECTION_ERROR_REPORT_ATTEMPTS,
 	}
 
 	opts := &Options{}
@@ -79,29 +80,30 @@ func TestOptions_RandomPort(t *testing.T) {
 
 func TestConfigFile(t *testing.T) {
 	golden := &Options{
-		ConfigFile:       "./configs/test.conf",
-		Host:             "127.0.0.1",
-		Port:             4242,
-		Username:         "derek",
-		Password:         "porkchop",
-		AuthTimeout:      1.0,
-		Debug:            false,
-		Trace:            true,
-		Logtime:          false,
-		HTTPPort:         8222,
-		PidFile:          "/tmp/nats-server.pid",
-		ProfPort:         6543,
-		Syslog:           true,
-		RemoteSyslog:     "udp://foo.com:33",
-		MaxControlLine:   2048,
-		MaxPayload:       65536,
-		MaxConn:          100,
-		MaxSubs:          1000,
-		MaxPending:       10000000,
-		PingInterval:     60 * time.Second,
-		MaxPingsOut:      3,
-		WriteDeadline:    3 * time.Second,
-		LameDuckDuration: 4 * time.Minute,
+		ConfigFile:                    "./configs/test.conf",
+		Host:                          "127.0.0.1",
+		Port:                          4242,
+		Username:                      "derek",
+		Password:                      "porkchop",
+		AuthTimeout:                   1.0,
+		Debug:                         false,
+		Trace:                         true,
+		Logtime:                       false,
+		HTTPPort:                      8222,
+		PidFile:                       "/tmp/nats-server.pid",
+		ProfPort:                      6543,
+		Syslog:                        true,
+		RemoteSyslog:                  "udp://foo.com:33",
+		MaxControlLine:                2048,
+		MaxPayload:                    65536,
+		MaxConn:                       100,
+		MaxSubs:                       1000,
+		MaxPending:                    10000000,
+		PingInterval:                  60 * time.Second,
+		MaxPingsOut:                   3,
+		WriteDeadline:                 3 * time.Second,
+		LameDuckDuration:              4 * time.Minute,
+		ConnectionErrorReportAttempts: 86400,
 	}
 
 	opts, err := ProcessConfigFile("./configs/test.conf")
@@ -257,8 +259,9 @@ func TestMergeOverrides(t *testing.T) {
 			NoAdvertise:    true,
 			ConnectRetries: 2,
 		},
-		WriteDeadline:    3 * time.Second,
-		LameDuckDuration: 4 * time.Minute,
+		WriteDeadline:                 3 * time.Second,
+		LameDuckDuration:              4 * time.Minute,
+		ConnectionErrorReportAttempts: 86400,
 	}
 	fopts, err := ProcessConfigFile("./configs/test.conf")
 	if err != nil {

--- a/server/route.go
+++ b/server/route.go
@@ -1602,7 +1602,7 @@ func (s *Server) connectToRoute(rURL *url.URL, tryForEver bool) {
 		if err != nil {
 			attempts++
 			s.Debugf(connErrFmt, attempts, err)
-			if shouldReportConnectErr(attempts) {
+			if shouldReportConnectErr(opts.ConnectionErrorReportAttempts, attempts) {
 				s.Errorf(connErrFmt, attempts, err)
 			}
 			if !tryForEver {

--- a/server/util.go
+++ b/server/util.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2018 The NATS Authors
+// Copyright 2012-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -111,10 +111,9 @@ func urlsAreEqual(u1, u2 *url.URL) bool {
 	return reflect.DeepEqual(u1, u2)
 }
 
-// Returns true for the first attempt, after a minute and then an hour.
-// It is assumed that each failed attempt is done every second.
-func shouldReportConnectErr(attempts int) bool {
-	if attempts == 1 || attempts == 60 || attempts%3600 == 0 {
+// Returns true for the first attempt and every `reportAttempts`.
+func shouldReportConnectErr(reportAttempts int, attempts int) bool {
+	if attempts == 1 || attempts%reportAttempts == 0 {
 		return true
 	}
 	return false


### PR DESCRIPTION
This is a continuation of #1000. Added a configuration to specify
the number of attempts at which the repeated error is reported.
The algo is now to print only the 1st attempt and when current
attempt % <this config param> == 0.

Resolves #969

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
