### PR TITLE
Better randomize solicited Gateway URLs

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1304,6 +1304,10 @@ func (g *gatewayCfg) getURLs() []*url.URL {
 		a = append(a, u)
 	}
 	g.RUnlock()
+	// Map iteration is random, but not that good with small maps.
+	rand.Shuffle(len(a), func(i, j int) {
+		a[i], a[j] = a[j], a[i]
+	})
 	return a
 }
 


### PR DESCRIPTION
Shuffle the array created when iterating through the gateways URLs
map since map iteration may not be well randomized with small maps.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
