### PR TITLE
Check inbound GW connection connected state in parser

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.0.0-RC12"
+	VERSION = "2.0.0-RC14"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/parser.go
+++ b/server/parser.go
@@ -127,8 +127,17 @@ func (c *client) parse(buf []byte) error {
 
 		switch c.state {
 		case OP_START:
-			if b != 'C' && b != 'c' && authSet {
-				goto authErr
+			if b != 'C' && b != 'c' {
+				if authSet {
+					goto authErr
+				}
+				// If the connection is a gateway connection, make sure that
+				// if this is an inbound, it starts with a CONNECT.
+				if c.kind == GATEWAY && !c.gw.outbound && !c.gw.connected {
+					// Use auth violation since no CONNECT was sent.
+					// It could be a parseErr too.
+					goto authErr
+				}
 			}
 			switch b {
 			case 'P', 'p':


### PR DESCRIPTION
If the first protocol for an inbound gateway connection is not
CONNECT, reject with auth violation.

Fixes #1006

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
