### PR TITLE
[ADDED] URLs to cluster{} in /varz and update of gateway ones

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -133,11 +133,12 @@ type sitally struct {
 type gatewayCfg struct {
 	sync.RWMutex
 	*RemoteGatewayOpts
-	replyPfx     []byte
-	urls         map[string]*url.URL
-	connAttempts int
-	implicit     bool
-	tlsName      string
+	replyPfx       []byte
+	urls           map[string]*url.URL
+	connAttempts   int
+	tlsName        string
+	implicit       bool
+	varzUpdateURLs bool // Tells monitoring code to update URLs when varz is inspected.
 }
 
 // Struct for client's gateway related fields
@@ -1379,6 +1380,8 @@ func (g *gatewayCfg) addURLs(infoURLs []string) {
 				g.saveTLSHostname(u)
 				// Use u.Host for the key.
 				g.urls[u.Host] = u
+				// Signal that we have updated the list. Used by monitoring code.
+				g.varzUpdateURLs = true
 			}
 		}
 	}

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1050,7 +1050,7 @@ func (s *Server) createVarz(pcpu float64, rss int64) *Varz {
 		MaxSubs: opts.MaxSubs,
 	}
 	if len(opts.Routes) > 0 {
-		varz.Cluster.URLs = convertArrayOfURLsToArrayOfStrings(opts.Routes)
+		varz.Cluster.URLs = urlsToStrings(opts.Routes)
 	}
 	if l := len(gw.Gateways); l > 0 {
 		rgwa := make([]RemoteGatewayOptsVarz, l)
@@ -1080,7 +1080,7 @@ func (s *Server) createVarz(pcpu float64, rss int64) *Varz {
 	return varz
 }
 
-func convertArrayOfURLsToArrayOfStrings(urls []*url.URL) []string {
+func urlsToStrings(urls []*url.URL) []string {
 	sURLs := make([]string, len(urls))
 	for i, u := range urls {
 		sURLs[i] = u.Host
@@ -1113,7 +1113,7 @@ func (s *Server) updateVarzConfigReloadableFields(v *Varz) {
 	v.ConfigLoadTime = s.configTime
 	// Update route URLs if applicable
 	if s.varzUpdateRouteURLs {
-		v.Cluster.URLs = convertArrayOfURLsToArrayOfStrings(opts.Routes)
+		v.Cluster.URLs = urlsToStrings(opts.Routes)
 		s.varzUpdateRouteURLs = false
 	}
 }

--- a/server/reload.go
+++ b/server/reload.go
@@ -306,6 +306,11 @@ func (r *routesOption) Apply(server *Server) {
 		routes[i] = client
 		i++
 	}
+	// If there was a change, notify monitoring code that it should
+	// update the route URLs if /varz endpoint is inspected.
+	if len(r.add)+len(r.remove) > 0 {
+		server.varzUpdateRouteURLs = true
+	}
 	server.mu.Unlock()
 
 	// Remove routes.

--- a/server/server.go
+++ b/server/server.go
@@ -171,6 +171,10 @@ type Server struct {
 	// endpoint /varz (when it comes from http).
 	varzMu sync.Mutex
 	varz   *Varz
+	// This is set during a config reload if we detect that we have
+	// added/removed routes. The monitoring code then check that
+	// to know if it should update the cluster's URLs array.
+	varzUpdateRouteURLs bool
 }
 
 // Make sure all are 64bits for atomic use


### PR DESCRIPTION
In varz's cluster{} section, there was no URLs field. This PR adds
it and displays the routes defined in the cluster{} config section.
The value gets updated should there be a config reload following
addition/removal of an url from "routes".

If config had 1 route to "nats://127.0.0.1:1234", here is what
it would look like now:
```
"cluster": {
    "addr": "0.0.0.0",
    "cluster_port": 6222,
    "auth_timeout": 1,
    "urls": [
      "127.0.0.1:1234"
    ]
  },
```
Adding route to "127.0.0.1:4567" and doing config reload:
```
"cluster": {
    "addr": "0.0.0.0",
    "cluster_port": 6222,
    "auth_timeout": 1,
    "urls": [
      "127.0.0.1:1234",
      "127.0.0.1:4567"
    ]
  },
```
Note that due to how we handle discovered servers in the cluster,
new urls dynamically discovered will not show in above output.
This could be done, but would need some changes in how we store
things (actually in this case, new urls are not stored, just
attempted to be connected. Once they connect, they would be visible
in /routez).

For gateways, however, this PR displays the combination of the
URLs defined in config and the ones that are discovered after
a connection is made to a give cluster. So say cluster A has a single
url to one server in cluster B, when connecting to that server,
the server on A will get the list of the gateway URLs that one
can connect to, and these will be reflected in /varz. So this is
a different behavior that for routes. As explained above, we could
harmonize the behavior in a future PR.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
