### PR TITLE
Fix flappers

### DIFF
--- a/server/events_test.go
+++ b/server/events_test.go
@@ -497,9 +497,9 @@ func TestSystemAccountConnectionUpdatesStopAfterNoLocal(t *testing.T) {
 		nc.Close()
 	}
 
-	// Wait for all 4 notifications.
+	// Wait for the 4 new notifications, 8 total (4 for connect, 4 for disconnect)
 	checkFor(t, time.Second, 50*time.Millisecond, func() error {
-		if len(received) == 4 {
+		if len(received) == 8 {
 			return nil
 		}
 		return fmt.Errorf("Not enough messages, %d vs 4", len(received))

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -39,6 +39,9 @@ func init() {
 // Wait for the expected number of outbound gateways, or fails.
 func waitForOutboundGateways(t *testing.T, s *Server, expected int, timeout time.Duration) {
 	t.Helper()
+	if timeout < 2*time.Second {
+		timeout = 2 * time.Second
+	}
 	checkFor(t, timeout, 15*time.Millisecond, func() error {
 		if n := s.numOutboundGateways(); n != expected {
 			return fmt.Errorf("Expected %v outbound gateway(s), got %v", expected, n)
@@ -50,6 +53,9 @@ func waitForOutboundGateways(t *testing.T, s *Server, expected int, timeout time
 // Wait for the expected number of inbound gateways, or fails.
 func waitForInboundGateways(t *testing.T, s *Server, expected int, timeout time.Duration) {
 	t.Helper()
+	if timeout < 2*time.Second {
+		timeout = 2 * time.Second
+	}
 	checkFor(t, timeout, 15*time.Millisecond, func() error {
 		if n := s.numInboundGateways(); n != expected {
 			return fmt.Errorf("Expected %v inbound gateway(s), got %v", expected, n)
@@ -2123,6 +2129,7 @@ func TestGatewaySendRemoteQSubs(t *testing.T) {
 	ob2 := testDefaultOptionsForGateway("B")
 	ob2.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", ob1.Cluster.Host, ob1.Cluster.Port))
 	sb2 := runGatewayServer(ob2)
+	defer sb2.Shutdown()
 
 	checkClusterFormed(t, sb1, sb2)
 
@@ -3128,7 +3135,7 @@ func TestGatewaySendAllSubsBadProtocol(t *testing.T) {
 	checkFor(t, 3*time.Second, 15*time.Millisecond, func() error {
 		c = getInboundGatewayConnection(sa, "A")
 		if c == nil {
-			t.Fatalf("Did not reconnect")
+			return fmt.Errorf("Did not reconnect")
 		}
 		return nil
 	})

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -2427,6 +2427,7 @@ func TestMonitorGatewayURLsUpdated(t *testing.T) {
 	ob2 := testDefaultOptionsForGateway("B")
 	ob2.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", sb1.ClusterAddr().Port))
 	sb2 := runGatewayServer(ob2)
+	defer sb2.Shutdown()
 
 	// Wait for sb1 and sb2 to connect
 	checkClusterFormed(t, sb1, sb2)

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -539,6 +539,9 @@ func shutdownCluster(c *cluster) {
 // Wait for the expected number of outbound gateways, or fails.
 func waitForOutboundGateways(t *testing.T, s *server.Server, expected int, timeout time.Duration) {
 	t.Helper()
+	if timeout < 2*time.Second {
+		timeout = 2 * time.Second
+	}
 	checkFor(t, timeout, 15*time.Millisecond, func() error {
 		if n := s.NumOutboundGateways(); n != expected {
 			return fmt.Errorf("Expected %v outbound gateway(s), got %v", expected, n)
@@ -1902,6 +1905,10 @@ func TestLeafNodeResetsMSGProto(t *testing.T) {
 	defer lc.Close()
 
 	leafSend, leafExpect := setupConn(t, lc)
+
+	// To avoid possible INFO when switching to interest mode only,
+	// delay start of gateway.
+	time.Sleep(500 * time.Millisecond)
 
 	gw := createGatewayConn(t, opts.Gateway.Host, opts.Gateway.Port)
 	defer gw.Close()


### PR DESCRIPTION
- TestSystemAccountConnectionUpdatesStopAfterNoLocal: I believe that
  the check on number of notifications was wrong. Since we did not
  consume the ones for the connect, the expected count after the
  disconnect is 8 instead of 4.

- Possible fix GW tests complaining about number of outbound/inbound
  I think that it may be possible that connection does not succeed
  right away (remote to fully started, etc) and due to dial timeout
  and reconnect attempt delay, I suspect that when given a max time
  of 1sec to complete, it may not be enough.
  Quick change for now is to override to 2secs for now in the
  wait helpers. If that proves conclusive, we could remove the
  timeout given to these helpers.

- TestGatewaySendAllSubsBadProtocol: used a t.Fatalf() in checkFor
  instead of return fmt.Errorf().

- TestLeafNodeResetsMSGProto: this test is not about change to
  interest mode only, so to avoid possible mix of protos, delay
  a bit creation of gateway after creation of leaf node.

- Some defer s.Shutdown() were missing

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
