### PR TITLE
Update to connect/reconnect error reports logic

### DIFF
--- a/server/configs/test.conf
+++ b/server/configs/test.conf
@@ -49,4 +49,7 @@ lame_duck_duration: "4m"
 
 # report repeated failed route/gateway/leafNode connection
 # every 24hour (24*60*60)
-connection_error_report_attempts: 86400
+connect_error_reports: 86400
+
+# report failed reconnect events every 5 attempts
+reconnect_error_reports: 5

--- a/server/const.go
+++ b/server/const.go
@@ -140,8 +140,17 @@ const (
 	// DEFAULT_LEAFNODE_INFO_WAIT Route dial timeout.
 	DEFAULT_LEAFNODE_INFO_WAIT = 1 * time.Second
 
-	// DEFAULT_CONNECTION_ERROR_REPORT_ATTEMPTS is the number of attempts at which a
-	// repeated failed route, gateway or leaf node connection is reported. The default
-	// corresponds to a report every hour.
-	DEFAULT_CONNECTION_ERROR_REPORT_ATTEMPTS = 3600
+	// DEFAULT_CONNECT_ERROR_REPORTS is the number of attempts at which a
+	// repeated failed route, gateway or leaf node connection is reported.
+	// This is used for initial connection, that is, when the server has
+	// never had a connection to the given endpoint. Once connected, and
+	// if a disconnect occurs, DEFAULT_RECONNECT_ERROR_REPORTS is used
+	// instead.
+	// The default is to report every 3600 attempts (roughly every hour).
+	DEFAULT_CONNECT_ERROR_REPORTS = 3600
+
+	// DEFAULT_RECONNECT_ERROR_REPORTS is the default number of failed
+	// attempt to reconnect a route, gateway or leaf node connection.
+	// The default is to report every attempt.
+	DEFAULT_RECONNECT_ERROR_REPORTS = 1
 )

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -521,7 +521,7 @@ func (s *Server) solicitGateways() {
 		if !cfg.isImplicit() {
 			cfg := cfg // Create new instance for the goroutine.
 			s.startGoRoutine(func() {
-				s.solicitGateway(cfg)
+				s.solicitGateway(cfg, true)
 				s.grWG.Done()
 			})
 		}
@@ -542,12 +542,12 @@ func (s *Server) reconnectGateway(cfg *gatewayCfg) {
 	case <-s.quitCh:
 		return
 	}
-	s.solicitGateway(cfg)
+	s.solicitGateway(cfg, false)
 }
 
 // This function will loop trying to connect to any URL attached
 // to the given Gateway. It will return once a connection has been created.
-func (s *Server) solicitGateway(cfg *gatewayCfg) {
+func (s *Server) solicitGateway(cfg *gatewayCfg, firstConnect bool) {
 	var (
 		opts       = s.getOpts()
 		isImplicit = cfg.isImplicit()
@@ -566,7 +566,7 @@ func (s *Server) solicitGateway(cfg *gatewayCfg) {
 
 	for s.isRunning() && len(urls) > 0 {
 		attempts++
-		report := shouldReportConnectErr(opts.ConnectionErrorReportAttempts, attempts)
+		report := s.shouldReportConnectErr(firstConnect, attempts)
 		// Iteration is random
 		for _, u := range urls {
 			address, err := s.getRandomIP(s.gateway.resolver, u.Host)
@@ -574,9 +574,10 @@ func (s *Server) solicitGateway(cfg *gatewayCfg) {
 				s.Errorf("Error getting IP for %s gateway %q (%s): %v", typeStr, cfg.Name, u.Host, err)
 				continue
 			}
-			s.Debugf(connFmt, typeStr, cfg.Name, u.Host, address, attempts)
 			if report {
 				s.Noticef(connFmt, typeStr, cfg.Name, u.Host, address, attempts)
+			} else {
+				s.Debugf(connFmt, typeStr, cfg.Name, u.Host, address, attempts)
 			}
 			conn, err := net.DialTimeout("tcp", address, DEFAULT_ROUTE_DIAL)
 			if err == nil {
@@ -584,9 +585,10 @@ func (s *Server) solicitGateway(cfg *gatewayCfg) {
 				s.createGateway(cfg, u, conn)
 				return
 			}
-			s.Debugf(connErrFmt, typeStr, cfg.Name, u.Host, address, attempts, err)
 			if report {
 				s.Errorf(connErrFmt, typeStr, cfg.Name, u.Host, address, attempts, err)
+			} else {
+				s.Debugf(connErrFmt, typeStr, cfg.Name, u.Host, address, attempts, err)
 			}
 			// Break this loop if server is being shutdown...
 			if !s.isRunning() {
@@ -1244,7 +1246,7 @@ func (s *Server) processImplicitGateway(info *Info) {
 	}
 	s.gateway.remotes[gwName] = cfg
 	s.startGoRoutine(func() {
-		s.solicitGateway(cfg)
+		s.solicitGateway(cfg, true)
 		s.grWG.Done()
 	})
 }

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -2123,6 +2123,7 @@ func TestGatewaySendRemoteQSubs(t *testing.T) {
 	ob2 := testDefaultOptionsForGateway("B")
 	ob2.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", ob1.Cluster.Host, ob1.Cluster.Port))
 	sb2 := runGatewayServer(ob2)
+	defer sb2.Shutdown()
 
 	checkClusterFormed(t, sb1, sb2)
 

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -2427,6 +2427,7 @@ func TestMonitorGatewayURLsUpdated(t *testing.T) {
 	ob2 := testDefaultOptionsForGateway("B")
 	ob2.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", sb1.ClusterAddr().Port))
 	sb2 := runGatewayServer(ob2)
+	defer sb2.Shutdown()
 
 	// Wait for sb1 and sb2 to connect
 	checkClusterFormed(t, sb1, sb2)

--- a/server/opts.go
+++ b/server/opts.go
@@ -187,14 +187,15 @@ type Options struct {
 	// CheckConfig configuration file syntax test was successful and exit.
 	CheckConfig bool `json:"-"`
 
-	// ConnectionErrorReportAttempts is the number of consecutive failed
-	// attempts to connect a route, gateway or leaf node at which point
-	// the server report the failure in the log. This is to prevent
-	// lots of errors when a configured endpoint is offline for a longer
-	// period of time.
-	// Default is DEFAULT_CONNECTION_ERROR_REPORT_ATTEMPTS (3600) which
-	// means that the server will report the error every hour.
-	ConnectionErrorReportAttempts int
+	// ConnectErrorReports specifies the number of failed attempts
+	// at which point server should report the failure of an initial
+	// connection to a route, gateway or leaf node.
+	// See DEFAULT_CONNECT_ERROR_REPORTS for default value.
+	ConnectErrorReports int
+
+	// ReconnectErrorReports is similar to ConnectErrorReports except
+	// that this applies to reconnect events.
+	ReconnectErrorReports int
 
 	// private fields, used to know if bool options are explicitly
 	// defined in config and/or command line params.
@@ -687,8 +688,10 @@ func (o *Options) ProcessConfigFile(configFile string) error {
 					errors = append(errors, err)
 				}
 			}
-		case "connection_error_report_attempts":
-			o.ConnectionErrorReportAttempts = int(v.(int64))
+		case "connect_error_reports":
+			o.ConnectErrorReports = int(v.(int64))
+		case "reconnect_error_reports":
+			o.ReconnectErrorReports = int(v.(int64))
 		default:
 			if !tk.IsUsedVariable() {
 				err := &unknownConfigFieldErr{
@@ -2432,8 +2435,11 @@ func setBaselineOptions(opts *Options) {
 			opts.Gateway.AuthTimeout = float64(AUTH_TIMEOUT) / float64(time.Second)
 		}
 	}
-	if opts.ConnectionErrorReportAttempts == 0 {
-		opts.ConnectionErrorReportAttempts = DEFAULT_CONNECTION_ERROR_REPORT_ATTEMPTS
+	if opts.ConnectErrorReports == 0 {
+		opts.ConnectErrorReports = DEFAULT_CONNECT_ERROR_REPORTS
+	}
+	if opts.ReconnectErrorReports == 0 {
+		opts.ReconnectErrorReports = DEFAULT_RECONNECT_ERROR_REPORTS
 	}
 }
 

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -59,7 +59,8 @@ func TestDefaultOptions(t *testing.T) {
 		LeafNode: LeafNodeOpts{
 			ReconnectInterval: DEFAULT_LEAF_NODE_RECONNECT,
 		},
-		ConnectionErrorReportAttempts: DEFAULT_CONNECTION_ERROR_REPORT_ATTEMPTS,
+		ConnectErrorReports:   DEFAULT_CONNECT_ERROR_REPORTS,
+		ReconnectErrorReports: DEFAULT_RECONNECT_ERROR_REPORTS,
 	}
 
 	opts := &Options{}
@@ -80,30 +81,31 @@ func TestOptions_RandomPort(t *testing.T) {
 
 func TestConfigFile(t *testing.T) {
 	golden := &Options{
-		ConfigFile:                    "./configs/test.conf",
-		Host:                          "127.0.0.1",
-		Port:                          4242,
-		Username:                      "derek",
-		Password:                      "porkchop",
-		AuthTimeout:                   1.0,
-		Debug:                         false,
-		Trace:                         true,
-		Logtime:                       false,
-		HTTPPort:                      8222,
-		PidFile:                       "/tmp/nats-server.pid",
-		ProfPort:                      6543,
-		Syslog:                        true,
-		RemoteSyslog:                  "udp://foo.com:33",
-		MaxControlLine:                2048,
-		MaxPayload:                    65536,
-		MaxConn:                       100,
-		MaxSubs:                       1000,
-		MaxPending:                    10000000,
-		PingInterval:                  60 * time.Second,
-		MaxPingsOut:                   3,
-		WriteDeadline:                 3 * time.Second,
-		LameDuckDuration:              4 * time.Minute,
-		ConnectionErrorReportAttempts: 86400,
+		ConfigFile:            "./configs/test.conf",
+		Host:                  "127.0.0.1",
+		Port:                  4242,
+		Username:              "derek",
+		Password:              "porkchop",
+		AuthTimeout:           1.0,
+		Debug:                 false,
+		Trace:                 true,
+		Logtime:               false,
+		HTTPPort:              8222,
+		PidFile:               "/tmp/nats-server.pid",
+		ProfPort:              6543,
+		Syslog:                true,
+		RemoteSyslog:          "udp://foo.com:33",
+		MaxControlLine:        2048,
+		MaxPayload:            65536,
+		MaxConn:               100,
+		MaxSubs:               1000,
+		MaxPending:            10000000,
+		PingInterval:          60 * time.Second,
+		MaxPingsOut:           3,
+		WriteDeadline:         3 * time.Second,
+		LameDuckDuration:      4 * time.Minute,
+		ConnectErrorReports:   86400,
+		ReconnectErrorReports: 5,
 	}
 
 	opts, err := ProcessConfigFile("./configs/test.conf")
@@ -259,9 +261,10 @@ func TestMergeOverrides(t *testing.T) {
 			NoAdvertise:    true,
 			ConnectRetries: 2,
 		},
-		WriteDeadline:                 3 * time.Second,
-		LameDuckDuration:              4 * time.Minute,
-		ConnectionErrorReportAttempts: 86400,
+		WriteDeadline:         3 * time.Second,
+		LameDuckDuration:      4 * time.Minute,
+		ConnectErrorReports:   86400,
+		ReconnectErrorReports: 5,
 	}
 	fopts, err := ProcessConfigFile("./configs/test.conf")
 	if err != nil {

--- a/server/reload.go
+++ b/server/reload.go
@@ -507,6 +507,30 @@ func (a *accountsOption) Apply(s *Server) {
 	s.Noticef("Reloaded: accounts")
 }
 
+// connectErrorReports implements the option interface for the `connect_error_reports`
+// setting.
+type connectErrorReports struct {
+	noopOption
+	newValue int
+}
+
+// Apply is a no-op because the value will be reloaded after options are applied.
+func (c *connectErrorReports) Apply(s *Server) {
+	s.Noticef("Reloaded: connect_error_reports = %v", c.newValue)
+}
+
+// connectErrorReports implements the option interface for the `connect_error_reports`
+// setting.
+type reconnectErrorReports struct {
+	noopOption
+	newValue int
+}
+
+// Apply is a no-op because the value will be reloaded after options are applied.
+func (r *reconnectErrorReports) Apply(s *Server) {
+	s.Noticef("Reloaded: reconnect_error_reports = %v", r.newValue)
+}
+
 // Reload reads the current configuration file and applies any supported
 // changes. This returns an error if the server was not started with a config
 // file or an option which doesn't support hot-swapping was changed.
@@ -741,6 +765,10 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 				return nil, fmt.Errorf("config reload not supported for %s: old=%v, new=%v",
 					field.Name, oldValue, newValue)
 			}
+		case "connecterrorreports":
+			diffOpts = append(diffOpts, &connectErrorReports{newValue: newValue.(int)})
+		case "reconnecterrorreports":
+			diffOpts = append(diffOpts, &reconnectErrorReports{newValue: newValue.(int)})
 		case "nolog", "nosigs":
 			// Ignore NoLog and NoSigs options since they are not parsed and only used in
 			// testing.

--- a/server/server.go
+++ b/server/server.go
@@ -2366,3 +2366,20 @@ func (s *Server) getRandomIP(resolver netResolver, url string) (string, error) {
 	}
 	return address, nil
 }
+
+// Returns true for the first attempt and depending on the nature
+// of the attempt (first connect or a reconnect), when the number
+// of attempts is equal to the configured report attempts.
+func (s *Server) shouldReportConnectErr(firstConnect bool, attempts int) bool {
+	opts := s.getOpts()
+	if firstConnect {
+		if attempts == 1 || attempts%opts.ConnectErrorReports == 0 {
+			return true
+		}
+		return false
+	}
+	if attempts == 1 || attempts%opts.ReconnectErrorReports == 0 {
+		return true
+	}
+	return false
+}

--- a/server/util.go
+++ b/server/util.go
@@ -110,11 +110,3 @@ func parseHostPort(hostPort string, defaultPort int) (host string, port int, err
 func urlsAreEqual(u1, u2 *url.URL) bool {
 	return reflect.DeepEqual(u1, u2)
 }
-
-// Returns true for the first attempt and every `reportAttempts`.
-func shouldReportConnectErr(reportAttempts int, attempts int) bool {
-	if attempts == 1 || attempts%reportAttempts == 0 {
-		return true
-	}
-	return false
-}


### PR DESCRIPTION
Changed the introduced new option and added a new one. The idea
is to be able to differentiate between never connected and reconnected
event. The never connected situation will be logged at first attempt
and every hour (by default, configurable).
However, once connected and if trying to reconnect, will report every
attempts by default, but this is configurable too.

These two options are supported for config reload.

Related to #1000
Related to #1001
Resolves #969

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
