### PR TITLE
[ADDED] Gatewayz endpoint

### DIFF
--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -3031,7 +3031,7 @@ func TestGatewaySendAllSubs(t *testing.T) {
 		var switchedMode bool
 		e := c.gw.insim[globalAccountName]
 		if e != nil {
-			switchedMode = e.ni == nil && e.mode == modeInterestOnly
+			switchedMode = e.ni == nil && e.mode == InterestOnly
 		}
 		c.mu.Unlock()
 		if !switchedMode {
@@ -3044,7 +3044,7 @@ func TestGatewaySendAllSubs(t *testing.T) {
 		if ei != nil {
 			e := ei.(*outsie)
 			e.RLock()
-			switchedMode = e.ni == nil && e.mode == modeInterestOnly
+			switchedMode = e.ni == nil && e.mode == InterestOnly
 			e.RUnlock()
 		}
 		if !switchedMode {
@@ -3457,7 +3457,7 @@ func TestGatewayServiceImport(t *testing.T) {
 		outsie.RLock()
 		mode := outsie.mode
 		outsie.RUnlock()
-		if mode != modeInterestOnly {
+		if mode != InterestOnly {
 			return fmt.Errorf("Should have switched to interest only mode")
 		}
 		return nil
@@ -3764,7 +3764,7 @@ func TestGatewayServiceImportWithQueue(t *testing.T) {
 		outsie.RLock()
 		mode := outsie.mode
 		outsie.RUnlock()
-		if mode != modeInterestOnly {
+		if mode != InterestOnly {
 			return fmt.Errorf("Should have switched to interest only mode")
 		}
 		return nil
@@ -4105,7 +4105,7 @@ func TestGatewayServiceImportComplexSetup(t *testing.T) {
 		outsie.RLock()
 		mode := outsie.mode
 		outsie.RUnlock()
-		if mode != modeInterestOnly {
+		if mode != InterestOnly {
 			return fmt.Errorf("Not in interest-only mode yet")
 		}
 		return nil
@@ -4454,7 +4454,7 @@ func TestGatewayServiceExportWithWildcards(t *testing.T) {
 				outsie.RLock()
 				mode := outsie.mode
 				outsie.RUnlock()
-				if mode != modeInterestOnly {
+				if mode != InterestOnly {
 					return fmt.Errorf("Not in interest-only mode yet")
 				}
 				return nil

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -472,7 +472,7 @@ func TestNoRaceGatewayNoMissingReplies(t *testing.T) {
 			if ei != nil {
 				e := ei.(*outsie)
 				e.RLock()
-				switchedMode = e.ni == nil && e.mode == modeInterestOnly
+				switchedMode = e.ni == nil && e.mode == InterestOnly
 				e.RUnlock()
 			}
 			if !switchedMode {

--- a/server/server.go
+++ b/server/server.go
@@ -1332,12 +1332,13 @@ func (s *Server) StartMonitoring() error {
 
 // HTTP endpoints
 const (
-	RootPath    = "/"
-	VarzPath    = "/varz"
-	ConnzPath   = "/connz"
-	RoutezPath  = "/routez"
-	SubszPath   = "/subsz"
-	StackszPath = "/stacksz"
+	RootPath     = "/"
+	VarzPath     = "/varz"
+	ConnzPath    = "/connz"
+	RoutezPath   = "/routez"
+	GatewayzPath = "/gatewayz"
+	SubszPath    = "/subsz"
+	StackszPath  = "/stacksz"
 )
 
 // Start the monitoring server
@@ -1347,11 +1348,12 @@ func (s *Server) startMonitoring(secure bool) error {
 
 	// Used to track HTTP requests
 	s.httpReqStats = map[string]uint64{
-		RootPath:   0,
-		VarzPath:   0,
-		ConnzPath:  0,
-		RoutezPath: 0,
-		SubszPath:  0,
+		RootPath:     0,
+		VarzPath:     0,
+		ConnzPath:    0,
+		RoutezPath:   0,
+		GatewayzPath: 0,
+		SubszPath:    0,
 	}
 
 	var (
@@ -1400,6 +1402,8 @@ func (s *Server) startMonitoring(secure bool) error {
 	mux.HandleFunc(ConnzPath, s.HandleConnz)
 	// Routez
 	mux.HandleFunc(RoutezPath, s.HandleRoutez)
+	// Gatewayz
+	mux.HandleFunc(GatewayzPath, s.HandleGatewayz)
 	// Subz
 	mux.HandleFunc(SubszPath, s.HandleSubsz)
 	// Subz alias for backwards compatibility


### PR DESCRIPTION
Such endpoint will list the gateway/cluster name, address and port
then list of outbound/inbound connections.
For each remote gateway there will be at most one outbound connection.
There can be 0 or more inbound connections for the same remote
gateway.

For each of these outbound/inbound connection, the connection info
similar to Connz is reported. Optionally, one can include the
interest mode/stats for each account.

Here are possible options:

* No specific options

http://host:port/gatewayz

* Limit to specific remote gateway, say name "B":

http://host:port/gatewayz/gw_name=B

* Include accounts

http://host:port/gatewayz/accs=1

* Specific account, say "acc_1". Note that accs=1 is not required then

http://host:port/gatewayz/acc_name=acc_1

* Above options can be mixed: specific remote gateway (B) and accounts
  reported

http://host:port/gatewayz/gw_name=B&accs=1

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>