### PR TITLE
Fix for reloadAuthorization bugs

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3097,3 +3097,8 @@ func (c *client) Tracef(format string, v ...interface{}) {
 	format = fmt.Sprintf("%s - %s", c, format)
 	c.srv.Tracef(format, v...)
 }
+
+func (c *client) Warnf(format string, v ...interface{}) {
+	format = fmt.Sprintf("%s - %s", c, format)
+	c.srv.Warnf(format, v...)
+}

--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.0.0-RC14"
+	VERSION = "2.0.0-RC15"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/reload.go
+++ b/server/reload.go
@@ -730,8 +730,9 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 			diffOpts = append(diffOpts, &accountsOption{})
 		case "accountresolver":
 			// We can't move from no resolver to one. So check for that.
-			if oldValue == nil && newValue != nil {
-				return nil, fmt.Errorf("config reload does not support adding a new account resolver")
+			if (oldValue == nil && newValue != nil) ||
+				(oldValue != nil && newValue == nil) {
+				return nil, fmt.Errorf("config reload does not support moving to or from an account resolver")
 			}
 			diffOpts = append(diffOpts, &accountsOption{})
 		case "gateway":

--- a/server/reload.go
+++ b/server/reload.go
@@ -249,14 +249,6 @@ func (u *nkeysOption) Apply(server *Server) {
 	server.Noticef("Reloaded: authorization nkey users")
 }
 
-type trustKeysOption struct {
-	noopOption
-}
-
-func (u *trustKeysOption) Apply(server *Server) {
-	server.Noticef("Reloaded: trusted keys")
-}
-
 // clusterOption implements the option interface for the `cluster` setting.
 type clusterOption struct {
 	authOption
@@ -540,6 +532,7 @@ func (s *Server) Reload() error {
 		s.mu.Unlock()
 		return errors.New("can only reload config when a file is provided using -c or --config")
 	}
+
 	newOpts, err := ProcessConfigFile(s.configFile)
 	if err != nil {
 		s.mu.Unlock()
@@ -735,8 +728,12 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 			diffOpts = append(diffOpts, &clientAdvertiseOption{newValue: cliAdv})
 		case "accounts":
 			diffOpts = append(diffOpts, &accountsOption{})
-		case "trustedkeys":
-			diffOpts = append(diffOpts, &trustKeysOption{})
+		case "accountresolver":
+			// We can't move from no resolver to one. So check for that.
+			if oldValue == nil && newValue != nil {
+				return nil, fmt.Errorf("config reload does not support adding a new account resolver")
+			}
+			diffOpts = append(diffOpts, &accountsOption{})
 		case "gateway":
 			// Not supported for now, but report warning if configuration of gateway
 			// is actually changed so that user knows that it won't take effect.
@@ -780,6 +777,7 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 				continue
 			}
 			fallthrough
+
 		default:
 			// TODO(ik): Implement String() on those options to have a nice print.
 			// %v is difficult to figure what's what, %+v print private fields and
@@ -831,53 +829,86 @@ func (s *Server) applyOptions(ctx *reloadContext, opts []option) {
 // disconnects any clients who are no longer authorized, and removes any
 // unauthorized subscriptions.
 func (s *Server) reloadAuthorization() {
-	s.mu.Lock()
-
-	// We need to drain the old accounts here since we have something
-	// new configured. We do not want s.accounts to change since that would
-	// mean adding a lock to lookupAccount which is what we are trying to
-	// optimize for with the change from a map to a sync.Map.
-	oldAccounts := make(map[string]*Account)
-	s.accounts.Range(func(k, v interface{}) bool {
-		acc := v.(*Account)
-		acc.mu.RLock()
-		oldAccounts[acc.Name] = acc
-		acc.mu.RUnlock()
-		s.accounts.Delete(k)
-		return true
-	})
-	s.gacc = nil
-	s.configureAccounts()
-
-	s.configureAuthorization()
-
 	// This map will contain the names of accounts that have their streams
 	// import configuration changed.
 	awcsti := make(map[string]struct{})
 
-	s.accounts.Range(func(k, v interface{}) bool {
-		newAcc := v.(*Account)
-		if acc, ok := oldAccounts[newAcc.Name]; ok {
-			// If account exist in latest config, "transfer" the account's
-			// sublist and client map to the new account.
+	s.mu.Lock()
+
+	// This can not be changed for now so ok to check server's trustedKeys
+	if s.trustedKeys == nil {
+		// We need to drain the old accounts here since we have something
+		// new configured. We do not want s.accounts to change since that would
+		// mean adding a lock to lookupAccount which is what we are trying to
+		// optimize for with the change from a map to a sync.Map.
+		oldAccounts := make(map[string]*Account)
+		s.accounts.Range(func(k, v interface{}) bool {
+			acc := v.(*Account)
 			acc.mu.RLock()
-			if len(acc.clients) > 0 {
-				newAcc.clients = make(map[*client]*client, len(acc.clients))
-				for _, c := range acc.clients {
-					newAcc.clients[c] = c
+			oldAccounts[acc.Name] = acc
+			acc.mu.RUnlock()
+			s.accounts.Delete(k)
+			return true
+		})
+		s.gacc = nil
+		s.configureAccounts()
+		s.configureAuthorization()
+
+		s.accounts.Range(func(k, v interface{}) bool {
+			newAcc := v.(*Account)
+			if acc, ok := oldAccounts[newAcc.Name]; ok {
+				// If account exist in latest config, "transfer" the account's
+				// sublist and client map to the new account.
+				acc.mu.RLock()
+				if len(acc.clients) > 0 {
+					newAcc.clients = make(map[*client]*client, len(acc.clients))
+					for _, c := range acc.clients {
+						newAcc.clients[c] = c
+					}
+				}
+				newAcc.sl = acc.sl
+				newAcc.rm = acc.rm
+				acc.mu.RUnlock()
+
+				// Check if current and new config of this account are same
+				// in term of stream imports.
+				if !acc.checkStreamImportsEqual(newAcc) {
+					awcsti[newAcc.Name] = struct{}{}
 				}
 			}
-			newAcc.sl = acc.sl
-			acc.mu.RUnlock()
+			return true
+		})
+	} else if s.opts.AccountResolver != nil {
+		s.configureResolver()
+		if _, ok := s.accResolver.(*MemAccResolver); ok {
+			// With a memory resolver we want to do something similar to configured accounts.
+			// We will walk the accounts and delete them if they are no longer present via fetch.
+			// If they are present we will force a claim update to process changes.
+			s.accounts.Range(func(k, v interface{}) bool {
+				acc := v.(*Account)
+				// Skip global account.
+				if acc == s.gacc {
+					return true
+				}
+				acc.mu.RLock()
+				accName := acc.Name
+				acc.mu.RUnlock()
+				accClaims, claimJWT, _ := s.fetchAccountClaims(accName)
+				if accClaims != nil {
+					err := s.updateAccountWithClaimJWT(acc, claimJWT)
+					if err != nil && err != ErrAccountResolverSameClaims {
+						s.Noticef("Reloaded: deleting account [bad claims]: %q", accName)
+						s.accounts.Delete(k)
+					}
+				} else {
+					s.Noticef("Reloaded: deleting account [removed]: %q", accName)
+					s.accounts.Delete(k)
+				}
+				return true
+			})
 
-			// Check if current and new config of this account are same
-			// in term of stream imports.
-			if !acc.checkStreamImportsEqual(newAcc) {
-				awcsti[newAcc.Name] = struct{}{}
-			}
 		}
-		return true
-	})
+	}
 
 	// Gather clients that changed accounts. We will close them and they
 	// will reconnect, doing the right thing.
@@ -918,7 +949,7 @@ func (s *Server) reloadAuthorization() {
 
 	for _, route := range routes {
 		// Disconnect any unauthorized routes.
-		// Do this only for route that were accepted, not initiated
+		// Do this only for routes that were accepted, not initiated
 		// because in the later case, we don't have the user name/password
 		// of the remote server.
 		if !route.isSolicitedRoute() && !s.isRouterAuthorized(route) {

--- a/server/route.go
+++ b/server/route.go
@@ -919,7 +919,12 @@ func (s *Server) sendSubsToRoute(route *client) {
 			a.mu.RLock()
 			c := a.randomClient()
 			if c == nil {
+				nsubs := len(a.rm)
+				accName := a.Name
 				a.mu.RUnlock()
+				if nsubs > 0 {
+					route.Warnf("Ignoring account %q with %d subs, no clients", accName, nsubs)
+				}
 				continue
 			}
 			for key, n := range a.rm {
@@ -936,7 +941,6 @@ func (s *Server) sendSubsToRoute(route *client) {
 				// efficient with these tmp subs.
 				sub := &subscription{client: c, subject: subj, queue: qn, qw: n}
 				subs = append(subs, sub)
-
 			}
 			a.mu.RUnlock()
 

--- a/test/configs/new_cluster.conf
+++ b/test/configs/new_cluster.conf
@@ -3,7 +3,6 @@
 listen: 127.0.0.1:5343
 
 cluster {
-  #nkey: CBSMNSOLVGFSP62Q2VD24KQIQXIVG2XVKSHE4DL7KKNN55MUYQKMDCHZ
   listen: 127.0.0.1:5344
 
   # Routes are actively solicited and connected to from this server.

--- a/test/operator_test.go
+++ b/test/operator_test.go
@@ -14,8 +14,13 @@
 package test
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/nats-io/jwt"
 	"github.com/nats-io/nats-server/server"
@@ -270,5 +275,216 @@ func TestOperatorConfigReloadDoesntKillNonce(t *testing.T) {
 
 	if !s.NonceRequired() {
 		t.Fatalf("Error nonce should still be required after reload")
+	}
+}
+
+func createAccountForConfig(t *testing.T) (string, nkeys.KeyPair) {
+	t.Helper()
+	okp, _ := nkeys.FromSeed(oSeed)
+	akp, _ := nkeys.CreateAccount()
+	pub, _ := akp.PublicKey()
+	nac := jwt.NewAccountClaims(pub)
+	jwt, _ := nac.Encode(okp)
+	return jwt, akp
+}
+
+func TestReloadDoesNotWipeAccountsWithOperatorMode(t *testing.T) {
+	// We will run an operator mode server that forms a cluster. We will
+	// make sure that a reload does not wipe account information.
+	// We will force reload of auth by changing cluster auth timeout.
+
+	// Create two accounts, system and normal account.
+	sysJWT, sysKP := createAccountForConfig(t)
+	sysPub, _ := sysKP.PublicKey()
+
+	accJWT, accKP := createAccountForConfig(t)
+	accPub, _ := accKP.PublicKey()
+
+	cf := `
+	listen: 127.0.0.1:-1
+	cluster {
+		listen: 127.0.0.1:-1
+		authorization {
+			timeout: 2.2
+		} %s
+	}
+
+	operator = "./configs/nkeys/op.jwt"
+	system_account = "%s"
+
+	resolver = MEMORY
+	resolver_preload = {
+		%s : "%s"
+		%s : "%s"
+	}
+	`
+	contents := strings.Replace(fmt.Sprintf(cf, "", sysPub, sysPub, sysJWT, accPub, accJWT), "\n\t", "\n", -1)
+	conf := createConfFile(t, []byte(contents))
+	defer os.Remove(conf)
+
+	s, opts := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	// Create a new server and route to main one.
+	routeStr := fmt.Sprintf("\n\t\troutes = [nats-route://%s:%d]", opts.Cluster.Host, opts.Cluster.Port)
+	contents2 := strings.Replace(fmt.Sprintf(cf, routeStr, sysPub, sysPub, sysJWT, accPub, accJWT), "\n\t", "\n", -1)
+
+	conf2 := createConfFile(t, []byte(contents2))
+	defer os.Remove(conf2)
+
+	s2, opts2 := RunServerWithConfig(conf2)
+	defer s2.Shutdown()
+
+	checkClusterFormed(t, s, s2)
+
+	// Create a client on the first server and subscribe.
+	url := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
+	nc, err := nats.Connect(url, createUserCreds(t, s, accKP))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc.Close()
+
+	ch := make(chan bool)
+	nc.Subscribe("foo", func(m *nats.Msg) { ch <- true })
+	nc.Flush()
+
+	// Use this to check for message.
+	checkForMsg := func() {
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Timeout waiting for message across route")
+		}
+	}
+
+	// Create second client and send message from this one. Interest should be here.
+	url2 := fmt.Sprintf("nats://%s:%d/", opts2.Host, opts2.Port)
+	nc2, err := nats.Connect(url2, createUserCreds(t, s2, accKP))
+	if err != nil {
+		t.Fatalf("Error creating client: %v\n", err)
+	}
+	defer nc2.Close()
+
+	// Check that we can send messages.
+	nc2.Publish("foo", nil)
+	checkForMsg()
+
+	// Now shutdown nc2 and srvA.
+	nc2.Close()
+	s2.Shutdown()
+
+	// Now change config and do reload which will do an auth change.
+	b, err := ioutil.ReadFile(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newConf := bytes.Replace(b, []byte("2.2"), []byte("3.3"), 1)
+	err = ioutil.WriteFile(conf, newConf, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This will cause reloadAuthorization to kick in and reprocess accounts.
+	s.Reload()
+
+	s2, opts2 = RunServerWithConfig(conf2)
+	defer s2.Shutdown()
+
+	checkClusterFormed(t, s, s2)
+
+	// Reconnect and make sure this works. If accounts blown away this will fail.
+	url2 = fmt.Sprintf("nats://%s:%d/", opts2.Host, opts2.Port)
+	nc2, err = nats.Connect(url2, createUserCreds(t, s2, accKP))
+	if err != nil {
+		t.Fatalf("Error creating client: %v\n", err)
+	}
+	defer nc2.Close()
+
+	// Check that we can send messages.
+	nc2.Publish("foo", nil)
+	checkForMsg()
+}
+
+func TestReloadDoesUpdatesAccountsWithMemoryResolver(t *testing.T) {
+	// We will run an operator mode server with a memory resolver.
+	// Reloading should behave similar to configured accounts.
+
+	// Create two accounts, system and normal account.
+	sysJWT, sysKP := createAccountForConfig(t)
+	sysPub, _ := sysKP.PublicKey()
+
+	accJWT, accKP := createAccountForConfig(t)
+	accPub, _ := accKP.PublicKey()
+
+	cf := `
+	listen: 127.0.0.1:-1
+	cluster {
+		listen: 127.0.0.1:-1
+		authorization {
+			timeout: 2.2
+		} %s
+	}
+
+	operator = "./configs/nkeys/op.jwt"
+	system_account = "%s"
+
+	resolver = MEMORY
+	resolver_preload = {
+		%s : "%s"
+		%s : "%s"
+	}
+	`
+	contents := strings.Replace(fmt.Sprintf(cf, "", sysPub, sysPub, sysJWT, accPub, accJWT), "\n\t", "\n", -1)
+	conf := createConfFile(t, []byte(contents))
+	defer os.Remove(conf)
+
+	s, opts := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	// Create a client on the first server and subscribe.
+	url := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
+	nc, err := nats.Connect(url, createUserCreds(t, s, accKP))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	asyncErr := make(chan error, 1)
+	nc.SetErrorHandler(func(nc *nats.Conn, sub *nats.Subscription, err error) {
+		asyncErr <- err
+	})
+	defer nc.Close()
+
+	nc.Subscribe("foo", func(m *nats.Msg) {})
+	nc.Flush()
+
+	// Now update and remove normal account and make sure we get disconnected.
+	accJWT2, accKP2 := createAccountForConfig(t)
+	accPub2, _ := accKP2.PublicKey()
+	contents = strings.Replace(fmt.Sprintf(cf, "", sysPub, sysPub, sysJWT, accPub2, accJWT2), "\n\t", "\n", -1)
+	err = ioutil.WriteFile(conf, []byte(contents), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This will cause reloadAuthorization to kick in and reprocess accounts.
+	s.Reload()
+
+	select {
+	case err := <-asyncErr:
+		if err != nats.ErrAuthorization {
+			t.Fatalf("Expected ErrAuthorization, got %v", err)
+		}
+	case <-time.After(time.Second):
+		// Give it up to 1 sec.
+		t.Fatal("Expected connection to be disconnected")
+	}
+
+	// Make sure we can lool up new account and not old one.
+	if _, err := s.LookupAccount(accPub2); err != nil {
+		t.Fatalf("Error looking up account: %v", err)
+	}
+
+	if _, err := s.LookupAccount(accPub); err == nil {
+		t.Fatalf("Expected error looking up old account")
 	}
 }


### PR DESCRIPTION
When tls is on routes it can cause reloadAuthorization to be called.
We were assuming configured accounts, but did not copy the remote map.
This copies the remote map when transferring for configured accounts
and also handles operator mode. In operator mode we leave the accounts
in place, and if we have a memory resolver we will remove accounts that
are not longer defined or have bad claims.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
