### PR TITLE
Added a function to allow ignoring top-level unknown config option

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -37,12 +37,13 @@ import (
 
 var allowUnknownTopLevelField = int32(0)
 
-// AllowUnknownTopLevelConfigurationField sets if the processing of a
-// configuration file returns an error if it finds an unknown top-level
-// configuration option.
-func AllowUnknownTopLevelConfigurationField(allow bool) {
+// NoErrOnUnknownFields can be used to change the behavior the processing
+// of a configuration file. By default, an error is reported if unknown
+// fields are found. If `noError` is set to true, no error will be reported
+// if top-level unknown fields are found.
+func NoErrOnUnknownFields(noError bool) {
 	var val int32
-	if allow {
+	if noError {
 		val = int32(1)
 	}
 	atomic.StoreInt32(&allowUnknownTopLevelField, val)

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -1836,8 +1836,8 @@ func TestHandleUnknownTopLevelConfigurationField(t *testing.T) {
 	}
 
 	// Verify that if that is set, we get no error
-	AllowUnknownTopLevelConfigurationField(true)
-	defer AllowUnknownTopLevelConfigurationField(false)
+	NoErrOnUnknownFields(true)
+	defer NoErrOnUnknownFields(false)
 
 	if err := opts.ProcessConfigFile(conf); err != nil {
 		t.Fatalf("Unexpected error: %v", err)

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -1819,3 +1819,44 @@ func TestLargeMaxPayload(t *testing.T) {
 		t.Fatalf("Expected an error from too large of a max_payload entry")
 	}
 }
+
+func TestHandleUnknownTopLevelConfigurationField(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		port: 1234
+		streaming {
+			id: "me"
+		}
+	`))
+	defer os.Remove(conf)
+
+	// Verify that we get an error because of unknown "streaming" field.
+	opts := &Options{}
+	if err := opts.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), "streaming") {
+		t.Fatal("Expected error, got none")
+	}
+
+	// Verify that if that is set, we get no error
+	AllowUnknownTopLevelConfigurationField(true)
+	defer AllowUnknownTopLevelConfigurationField(false)
+
+	if err := opts.ProcessConfigFile(conf); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if opts.Port != 1234 {
+		t.Fatalf("Port was not parsed correctly: %v", opts.Port)
+	}
+
+	// Verify that ignore works only on top level fields.
+	changeCurrentConfigContentWithNewContent(t, conf, []byte(`
+		port: 1234
+		cluster {
+			non_top_level_unknown_field: 123
+		}
+		streaming {
+			id: "me"
+		}
+	`))
+	if err := opts.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), "non_top_level") {
+		t.Fatal("Expected error, got none")
+	}
+}


### PR DESCRIPTION
This will be required for NATS Streaming server since streaming
allows user to have NATS and Streaming specific options in same
file.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
