### PR TITLE
Switch gateway to InterestMode only once

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1920,7 +1920,10 @@ func (s *Server) switchAccountToInterestMode(accName string) {
 			e = &insie{}
 			gin.gw.insim[accName] = e
 		}
-		gin.gatewaySwitchAccountToSendAllSubs(e, []byte(accName))
+		// Do it only if we are in Optimistic mode
+		if e.mode == Optimistic {
+			gin.gatewaySwitchAccountToSendAllSubs(e, []byte(accName))
+		}
 		gin.mu.Unlock()
 	}
 }

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -4892,4 +4892,20 @@ func TestGatewayLogAccountInterestModeSwitch(t *testing.T) {
 	}
 	checkLog(t, logB)
 	checkLog(t, logA)
+
+	// Clear log of server B
+	logB.Lock()
+	logB.imss = nil
+	logB.Unlock()
+
+	// Force a switch on B to inbound gateway from A and make sure that it is
+	// a no-op since this gateway connection has already been switched.
+	sb.switchAccountToInterestMode(globalAccountName)
+
+	logB.Lock()
+	didSwitch := len(logB.imss) > 0
+	logB.Unlock()
+	if didSwitch {
+		t.Fatalf("Attempted to switch while it was already in interest mode only")
+	}
 }


### PR DESCRIPTION
When a leafnode connection is created, the server forces all
gateway inbound connections to switch to InterestMode. Do this only
once, regardless of how many times the LN (re)connects.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
