### PR TITLE
Add in leafnode bound account events for accounting

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -636,6 +636,9 @@ func (s *Server) isLeafNodeAuthorized(c *client) bool {
 			return false
 		}
 
+		// Generate an event if we have a system account.
+		s.accountConnectEvent(c)
+
 		// Check if we need to set an auth timer if the user jwt expires.
 		c.checkExpiration(juc.Claims())
 		return true

--- a/server/client.go
+++ b/server/client.go
@@ -2739,8 +2739,8 @@ func (c *client) clearConnection(reason ClosedState) {
 	// Do this always to also kick out any IO writes.
 	nc.SetWriteDeadline(time.Time{})
 
-	// Save off the connection if its a client.
-	if c.kind == CLIENT {
+	// Save off the connection if its a client or leafnode.
+	if c.kind == CLIENT || c.kind == LEAF {
 		go srv.saveClosedClient(c, nc, reason)
 	}
 }

--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.0.0-RC16"
+	VERSION = "2.0.0-RC17"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original


### PR DESCRIPTION
This allows account connect and disconnect events for leafnodes. Still need accounting for long standing connections, but this brings leafnodes up to clients for the moment.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
