### PR TITLE
Fix for leafnode messages and DQ selection over GWs

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -644,6 +644,9 @@ func (s *Server) isLeafNodeAuthorized(c *client) bool {
 		return true
 	}
 
+	// FIXME(dlc) - Add ability to support remote account bindings via
+	// other auth like user or nkey and tlsMapping.
+
 	// For now this means we are binding the leafnode to the global account.
 	c.registerWithAccount(s.globalAccount())
 

--- a/server/client.go
+++ b/server/client.go
@@ -2355,9 +2355,9 @@ func (c *client) checkForImportServices(acc *Account, msg []byte) {
 		// FIXME(dlc) - Do L1 cache trick from above.
 		rr := rm.acc.sl.Match(rm.to)
 
-		// If we are a route or gateway and this message is flipped to a queue subscriber we
+		// If we are a route or gateway or leafnode and this message is flipped to a queue subscriber we
 		// need to handle that since the processMsgResults will want a queue filter.
-		if (c.kind == ROUTER || c.kind == GATEWAY) && c.pa.queues == nil && len(rr.qsubs) > 0 {
+		if (c.kind == ROUTER || c.kind == GATEWAY || c.kind == LEAF) && c.pa.queues == nil && len(rr.qsubs) > 0 {
 			c.makeQFilter(rr.qsubs)
 		}
 

--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.0.0-RC17"
+	VERSION = "2.0.0-RC18"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original


### PR DESCRIPTION
Leafnodes should behave like direct connected clients and prefer local cluster distributed queue subscribers before crossing a gateway. 

/cc @nats-io/core
