### PR TITLE
Add config line allow_authentication_failure

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -254,6 +254,7 @@ func (s *Server) isClientAuthorized(c *client) bool {
 	s.optsMu.RLock()
 	customClientAuthentication := s.opts.CustomClientAuthentication
 	authorization := s.opts.Authorization
+	allowAuthFailure := s.opts.AllowAuthFailure
 	username := s.opts.Username
 	password := s.opts.Password
 	tlsMap := s.opts.TLSMap
@@ -281,6 +282,12 @@ func (s *Server) isClientAuthorized(c *client) bool {
 	if !authRequired {
 		// TODO(dlc) - If they send us credentials should we fail?
 		s.mu.Unlock()
+		return true
+	}
+
+	// Check if allowFailure is defined. If so, WARN in the logs but allow the user to continue.
+	if allowAuthFailure {
+		s.Warnf("Allowed host %v because allow_authentication_failure was set", c.host)
 		return true
 	}
 

--- a/server/configs/test.conf
+++ b/server/configs/test.conf
@@ -10,6 +10,8 @@ authorization {
   timeout:  1
 }
 
+allow_authentication_failure: false
+
 # logging options
 debug:   false
 trace:   true

--- a/server/opts.go
+++ b/server/opts.go
@@ -155,6 +155,7 @@ type Options struct {
 	Accounts         []*Account    `json:"-"`
 	SystemAccount    string        `json:"-"`
 	AllowNewAccounts bool          `json:"-"`
+	AllowAuthFailure bool          `json:"-"`
 	Username         string        `json:"-"`
 	Password         string        `json:"-"`
 	Authorization    string        `json:"-"`
@@ -507,6 +508,8 @@ func (o *Options) ProcessConfigFile(configFile string) error {
 			}
 		case "logfile", "log_file":
 			o.LogFile = v.(string)
+		case "allow_authentication_failure":
+			o.AllowAuthFailure = v.(bool)
 		case "syslog":
 			o.Syslog = v.(bool)
 			trackExplicitVal(o, &o.inConfig, "Syslog", o.Syslog)


### PR DESCRIPTION
 - [ ] Documentation added (if applicable)
 - [x] Tests added
 - [x] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)
### Changes proposed in this pull request:

 - Add config line allow_authentication_failure
   - This is useful in deploying NATS 2.0 and slowly rolling out JWT authentication across all clients

/cc @nats-io/core
