### PR TITLE
Allow updating TLS timeout for leafnode remotes

### DIFF
--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -1083,9 +1083,9 @@ func TestConfigCheck(t *testing.T) {
 		  }
 		}
 		`,
-			err:       errors.New(`error parsing X509 certificate/key pair: open : no such file or directory`),
-			errorLine: 3,
-			errorPos:  5,
+			err:       nil,
+			errorLine: 0,
+			errorPos:  0,
 		},
 		{
 			name: "invalid lame_duck_duration type",
@@ -1095,6 +1095,23 @@ func TestConfigCheck(t *testing.T) {
 			err:       errors.New(`error parsing lame_duck_duration: time: invalid duration abc`),
 			errorLine: 2,
 			errorPos:  3,
+		},
+		{
+			name: "when only setting TLS timeout for a leafnode remote",
+			config: `
+		leafnodes {
+		  remotes = [
+		    {
+		      url: "tls://connect.ngs.global:7422"
+		      tls {
+		        timeout: 0.01
+		      }
+		    }
+		  ]
+		}`,
+			err:       nil,
+			errorLine: 0,
+			errorPos:  0,
 		},
 	}
 

--- a/server/const.go
+++ b/server/const.go
@@ -115,6 +115,9 @@ const (
 	// DEFAULT_LEAF_NODE_RECONNECT LeafNode reconnect interval.
 	DEFAULT_LEAF_NODE_RECONNECT = time.Second
 
+	// DEFAULT_LEAF_TLS_TIMEOUT TLS timeout for LeafNodes
+	DEFAULT_LEAF_TLS_TIMEOUT = 2 * time.Second
+
 	// PROTO_SNIPPET_SIZE is the default size of proto to print on parse errors.
 	PROTO_SNIPPET_SIZE = 32
 

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -1614,12 +1614,59 @@ func TestParsingGatewaysErrors(t *testing.T) {
 			"to be filename",
 		},
 		{
-			"tls_gen_error",
+			"tls_gen_error_cert_file_not_found",
+			`gateway {
+				name: "A"
+				port: -1
+				tls {
+					cert_file: "./configs/certs/missing.pem"
+					key_file: "./configs/certs/server-key.pem"
+				}
+			}`,
+			"certificate/key pair",
+		},
+		{
+			"tls_gen_error_key_file_not_found",
 			`gateway {
 				name: "A"
 				port: -1
 				tls {
 					cert_file: "./configs/certs/server.pem"
+					key_file: "./configs/certs/missing.pem"
+				}
+			}`,
+			"certificate/key pair",
+		},
+		{
+			"tls_gen_error_key_file_missing",
+			`gateway {
+				name: "A"
+				port: -1
+				tls {
+					cert_file: "./configs/certs/server.pem"
+				}
+			}`,
+			`missing 'key_file' in TLS configuration`,
+		},
+		{
+			"tls_gen_error_cert_file_missing",
+			`gateway {
+				name: "A"
+				port: -1
+				tls {
+					key_file: "./configs/certs/server-key.pem"
+				}
+			}`,
+			`missing 'cert_file' in TLS configuration`,
+		},
+		{
+			"tls_gen_error_key_file_not_found",
+			`gateway {
+				name: "A"
+				port: -1
+				tls {
+					cert_file: "./configs/certs/server.pem"
+					key_file: "./configs/certs/missing.pem"
 				}
 			}`,
 			"certificate/key pair",
@@ -1687,7 +1734,7 @@ func TestParsingGatewaysErrors(t *testing.T) {
 			"to be filename",
 		},
 		{
-			"gateway_unknon_field",
+			"gateway_unknown_field",
 			`gateway {
 				name: "A"
 				port: -1


### PR DESCRIPTION
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #1039

### Changes proposed in this pull request:

 - Allows overriding the TLS timeout for leaf remotes when no using certs (otherwise fail with file not found error)
 - Bumps the default timeout for leafnode remotes to 2s

/cc @nats-io/core
