### PR TITLE
Leafnode updates

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -143,6 +143,9 @@ const (
 	// DEFAULT_LEAFNODE_INFO_WAIT Route dial timeout.
 	DEFAULT_LEAFNODE_INFO_WAIT = 1 * time.Second
 
+	// DEFAULT_LEAFNODE_PORT is the default port for remote leafnode connections.
+	DEFAULT_LEAFNODE_PORT = 7422
+
 	// DEFAULT_CONNECT_ERROR_REPORTS is the number of attempts at which a
 	// repeated failed route, gateway or leaf node connection is reported.
 	// This is used for initial connection, that is, when the server has

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -166,7 +166,7 @@ func (s *Server) connectToRemoteLeafNode(remote *leafNodeCfg, firstConnect bool)
 
 	var conn net.Conn
 
-	const connErrFmt = "Error trying to connect as leafnode to remote server (attempt %v): %v"
+	const connErrFmt = "Error trying to connect as leafnode to remote server %q (attempt %v): %v"
 
 	attempts := 0
 	for s.isRunning() && s.remoteLeafNodeStillValid(remote) {
@@ -177,15 +177,15 @@ func (s *Server) connectToRemoteLeafNode(remote *leafNodeCfg, firstConnect bool)
 			if url != rURL.Host {
 				ipStr = fmt.Sprintf(" (%s)", url)
 			}
-			s.Debugf("Trying to connect as leafnode to remote server on %s%s", rURL.Host, ipStr)
+			s.Debugf("Trying to connect as leafnode to remote server on %q%s", rURL.Host, ipStr)
 			conn, err = net.DialTimeout("tcp", url, dialTimeout)
 		}
 		if err != nil {
 			attempts++
 			if s.shouldReportConnectErr(firstConnect, attempts) {
-				s.Errorf(connErrFmt, attempts, err)
+				s.Errorf(connErrFmt, rURL.Host, attempts, err)
 			} else {
-				s.Debugf(connErrFmt, attempts, err)
+				s.Debugf(connErrFmt, rURL.Host, attempts, err)
 			}
 			select {
 			case <-s.quitCh:
@@ -202,6 +202,12 @@ func (s *Server) connectToRemoteLeafNode(remote *leafNodeCfg, firstConnect bool)
 		// We have a connection here to a remote server.
 		// Go ahead and create our leaf node and return.
 		s.createLeafNode(conn, remote)
+
+		// We will put this in the normal log if first connect, does not force -DV mode to know
+		// that the connect worked.
+		if firstConnect {
+			s.Noticef("Connected leafnode to %q", remote.RemoteLeafOpts.URL.Hostname())
+		}
 		return
 	}
 }
@@ -611,6 +617,8 @@ func (s *Server) createLeafNode(conn net.Conn, remote *leafNodeCfg) *client {
 
 	c.mu.Unlock()
 
+	c.Debugf("Leafnode connection created")
+
 	// Update server's accounting here if we solicited.
 	// Also send our local subs.
 	if solicited {
@@ -620,8 +628,6 @@ func (s *Server) createLeafNode(conn net.Conn, remote *leafNodeCfg) *client {
 		s.initLeafNodeSmap(c)
 		c.sendAllAccountSubs()
 	}
-
-	c.Noticef("Leafnode connection created")
 
 	return c
 }

--- a/server/opts.go
+++ b/server/opts.go
@@ -2435,7 +2435,7 @@ func setBaselineOptions(opts *Options) {
 	// Set baseline connect port for remotes.
 	for _, r := range opts.LeafNode.Remotes {
 		if r != nil && r.URL.Port() == "" {
-			r.URL.Host = fmt.Sprintf("%s:%d", r.URL.Host, DEFAULT_LEAFNODE_PORT)
+			r.URL.Host = net.JoinHostPort(r.URL.Host, strconv.Itoa(DEFAULT_LEAFNODE_PORT))
 		}
 	}
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -2432,10 +2432,18 @@ func setBaselineOptions(opts *Options) {
 			opts.LeafNode.AuthTimeout = float64(AUTH_TIMEOUT) / float64(time.Second)
 		}
 	}
+	// Set baseline connect port for remotes.
+	for _, r := range opts.LeafNode.Remotes {
+		if r != nil && r.URL.Port() == "" {
+			r.URL.Host = fmt.Sprintf("%s:%d", r.URL.Host, DEFAULT_LEAFNODE_PORT)
+		}
+	}
+
 	// Set this regardless of opts.LeafNode.Port
 	if opts.LeafNode.ReconnectInterval == 0 {
 		opts.LeafNode.ReconnectInterval = DEFAULT_LEAF_NODE_RECONNECT
 	}
+
 	if opts.MaxControlLine == 0 {
 		opts.MaxControlLine = MAX_CONTROL_LINE_SIZE
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1231,6 +1231,16 @@ func TestConnectErrorReports(t *testing.T) {
 		t.Fatalf("Error reading log file: %v", err)
 	}
 
+	checkLeafContent := func(t *testing.T, txt, host string, attempt int, shouldBeThere bool) {
+		t.Helper()
+		present := bytes.Contains(content, []byte(fmt.Sprintf("%s %q (attempt %d)", txt, host, attempt)))
+		if shouldBeThere && !present {
+			t.Fatalf("Did not find expected log statement (%s %q) for attempt %d: %s", txt, host, attempt, content)
+		} else if !shouldBeThere && present {
+			t.Fatalf("Log statement (%s %q) for attempt %d should not be present: %s", txt, host, attempt, content)
+		}
+	}
+
 	for _, test := range []testConnect{
 		{"leafnode_attempt_1", 1, true},
 		{"leafnode_attempt_2", 2, false},
@@ -1241,8 +1251,8 @@ func TestConnectErrorReports(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			debugExpected := !test.errExpected
-			checkContent(t, "[DBG] Error trying to connect as leafnode to remote server", test.attempt, debugExpected)
-			checkContent(t, "[ERR] Error trying to connect as leafnode to remote server", test.attempt, test.errExpected)
+			checkLeafContent(t, "[DBG] Error trying to connect as leafnode to remote server", remoteURLs[0].Host, test.attempt, debugExpected)
+			checkLeafContent(t, "[ERR] Error trying to connect as leafnode to remote server", remoteURLs[0].Host, test.attempt, test.errExpected)
 		})
 	}
 
@@ -1374,7 +1384,9 @@ func TestReconnectErrorReports(t *testing.T) {
 
 	// Now try with leaf nodes
 	csOpts.Cluster.Port = 0
+	csOpts.LeafNode.Host = "127.0.0.1"
 	csOpts.LeafNode.Port = -1
+
 	cs = RunServer(csOpts)
 	defer cs.Shutdown()
 
@@ -1405,6 +1417,16 @@ func TestReconnectErrorReports(t *testing.T) {
 		t.Fatalf("Error reading log file: %v", err)
 	}
 
+	checkLeafContent := func(t *testing.T, txt, host string, attempt int, shouldBeThere bool) {
+		t.Helper()
+		present := bytes.Contains(content, []byte(fmt.Sprintf("%s %q (attempt %d)", txt, host, attempt)))
+		if shouldBeThere && !present {
+			t.Fatalf("Did not find expected log statement (%s %q) for attempt %d: %s", txt, host, attempt, content)
+		} else if !shouldBeThere && present {
+			t.Fatalf("Log statement (%s %q) for attempt %d should not be present: %s", txt, host, attempt, content)
+		}
+	}
+
 	for _, test := range []testConnect{
 		{"leafnode_attempt_1", 1, true},
 		{"leafnode_attempt_2", 2, false},
@@ -1415,8 +1437,8 @@ func TestReconnectErrorReports(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			debugExpected := !test.errExpected
-			checkContent(t, "[DBG] Error trying to connect as leafnode to remote server", test.attempt, debugExpected)
-			checkContent(t, "[ERR] Error trying to connect as leafnode to remote server", test.attempt, test.errExpected)
+			checkLeafContent(t, "[DBG] Error trying to connect as leafnode to remote server", u.Host, test.attempt, debugExpected)
+			checkLeafContent(t, "[ERR] Error trying to connect as leafnode to remote server", u.Host, test.attempt, test.errExpected)
 		})
 	}
 

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -2330,3 +2330,27 @@ func TestLeafNodeDistributedQueueEvenly(t *testing.T) {
 		}
 	}
 }
+
+func TestLeafNodeDefaultPort(t *testing.T) {
+	o := testDefaultOptionsForLeafNodes()
+	o.LeafNode.Port = server.DEFAULT_LEAFNODE_PORT
+	s := RunServer(o)
+	defer s.Shutdown()
+
+	conf := createConfFile(t, []byte(`
+		port: -1
+		leaf {
+			remotes = [
+				{
+					url: "leafnode://127.0.0.1"
+				}
+			]
+		}
+	`))
+	defer os.Remove(conf)
+
+	sl, _ := RunServerWithConfig(conf)
+	defer sl.Shutdown()
+
+	checkLeafNodeConnected(t, s)
+}


### PR DESCRIPTION
Added a default port so you can make simpler configs to connect to remote clusters like NGS.
Connect was incorrectly a Noticef, where all other connection types this is a Debugf, fixed. 
Did add a Noticef on first connect though to avoid need for -DV to know connection worked.

/cc @nats-io/core
