### PR TITLE
[FIXED] Allow TLS InsecureSkipVerify again

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -47,7 +47,7 @@ var (
 )
 
 // Warning when user configures gateway TLS insecure
-const gatewayTLSInsecureWarning = "TLS certificate chain and hostname of solicited gateways will not be verified, do not use in production!"
+const gatewayTLSInsecureWarning = "TLS certificate chain and hostname of solicited gateways will not be verified. DO NOT USE IN PRODUCTION!"
 
 // SetGatewaysSolicitDelay sets the initial delay before gateways
 // connections are initiated.

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -46,6 +46,9 @@ var (
 	gatewaySolicitDelay          = int64(defaultSolicitGatewaysDelay)
 )
 
+// Warning when user configures gateway TLS insecure
+const gatewayTLSInsecureWarning = "TLS certificate chain and hostname of solicited gateways will not be verified, do not use in production!"
+
 // SetGatewaysSolicitDelay sets the initial delay before gateways
 // connections are initiated.
 // Used by tests.
@@ -231,18 +234,12 @@ func validateGatewayOptions(o *Options) error {
 	if o.Gateway.Port == 0 {
 		return fmt.Errorf("gateway %q has no port specified (select -1 for random port)", o.Gateway.Name)
 	}
-	if o.Gateway.TLSConfig != nil && o.Gateway.TLSConfig.InsecureSkipVerify {
-		return fmt.Errorf("tls InsecureSkipVerify not supported for gateway")
-	}
 	for i, g := range o.Gateway.Gateways {
 		if g.Name == "" {
 			return fmt.Errorf("gateway in the list %d has no name", i)
 		}
 		if len(g.URLs) == 0 {
 			return fmt.Errorf("gateway %q has no URL", g.Name)
-		}
-		if g.TLSConfig != nil && g.TLSConfig.InsecureSkipVerify {
-			return fmt.Errorf("tls InsecureSkipVerify not supported for remote gateway %q", g.Name)
 		}
 	}
 	return nil
@@ -434,6 +431,21 @@ func (s *Server) gatewayAcceptLoop(ch chan struct{}) {
 	}
 	// Setup state that can enable shutdown
 	s.gatewayListener = l
+	// Warn if insecure is configured in gateway{} or any remoteGateway{}
+	if tlsReq {
+		warn := opts.Gateway.TLSConfig.InsecureSkipVerify
+		if !warn {
+			for _, g := range opts.Gateway.Gateways {
+				if g.TLSConfig != nil && g.TLSConfig.InsecureSkipVerify {
+					warn = true
+					break
+				}
+			}
+		}
+		if warn {
+			s.Warnf(gatewayTLSInsecureWarning)
+		}
+	}
 	s.mu.Unlock()
 
 	// Let them know we are up

--- a/server/route.go
+++ b/server/route.go
@@ -97,7 +97,7 @@ const (
 const sendRouteSubsInGoRoutineThreshold = 1024 * 1024 // 1MB
 
 // Warning when user configures cluster TLS insecure
-const clusterTLSInsecureWarning = "TLS certificate chain and hostname of solicited routes will not be verified, do not use in production!"
+const clusterTLSInsecureWarning = "TLS certificate chain and hostname of solicited routes will not be verified. DO NOT USE IN PRODUCTION!"
 
 // Can be changed for tests
 var routeConnectDelay = DEFAULT_ROUTE_CONNECT

--- a/server/route.go
+++ b/server/route.go
@@ -97,7 +97,7 @@ const (
 const sendRouteSubsInGoRoutineThreshold = 1024 * 1024 // 1MB
 
 // Warning when user configures cluster TLS insecure
-const clusterTLSInsecureWarning = "TLS Hostname verification disabled, system will not verify identity of the solicited route"
+const clusterTLSInsecureWarning = "TLS certificate chain and hostname of solicited routes will not be verified, do not use in production!"
 
 // Can be changed for tests
 var routeConnectDelay = DEFAULT_ROUTE_CONNECT

--- a/server/server.go
+++ b/server/server.go
@@ -309,11 +309,6 @@ func NewServer(opts *Options) (*Server, error) {
 }
 
 func validateOptions(o *Options) error {
-	// For now, InsecureSkipVerify is supported only for Cluster.
-	// So fail if it was set to client and or gateways.
-	if o.TLSConfig != nil && o.TLSConfig.InsecureSkipVerify {
-		return fmt.Errorf("tls InsecureSkipVerify not supported for client connections")
-	}
 	// Check that the trust configuration is correct.
 	if err := validateTrustedOperators(o); err != nil {
 		return err

--- a/test/cluster_tls_test.go
+++ b/test/cluster_tls_test.go
@@ -89,7 +89,7 @@ type captureClusterTLSInsecureLogger struct {
 
 func (c *captureClusterTLSInsecureLogger) Warnf(format string, v ...interface{}) {
 	msg := fmt.Sprintf(format, v...)
-	if strings.Contains(msg, "verification disabled") {
+	if strings.Contains(msg, "solicited routes will not be verified") {
 		select {
 		case c.ch <- struct{}{}:
 		default:


### PR DESCRIPTION
This has an effect only on connections created by the server,
so routes and gateways (explicit and implicit).
Make sure that an explicit warning is printed if the insecure
property is set, but otherwise allow it.

Resolves #1062

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
