### PR TITLE
Fix for #1065 (leaked subscribers from dq subs across routes)

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -50,6 +50,7 @@ type Account struct {
 	nrleafs    int32
 	clients    map[*client]*client
 	rm         map[string]int32
+	lqws       map[string]int32
 	lleafs     []*client
 	imports    importMap
 	exports    exportMap

--- a/server/client.go
+++ b/server/client.go
@@ -954,13 +954,13 @@ func (c *client) flushOutbound() bool {
 			}
 			if sce {
 				atomic.AddInt64(&srv.slowConsumers, 1)
-				c.clearConnection(SlowConsumerWriteDeadline)
 				c.Noticef("Slow Consumer Detected: WriteDeadline of %v exceeded with %d chunks of %d total bytes.",
 					c.out.wdl, len(cnb), attempted)
+				c.clearConnection(SlowConsumerWriteDeadline)
 			}
 		} else {
-			c.clearConnection(WriteError)
 			c.Debugf("Error flushing: %v", err)
+			c.clearConnection(WriteError)
 		}
 		return true
 	}
@@ -1343,9 +1343,9 @@ func (c *client) queueOutbound(data []byte) bool {
 	// Check for slow consumer via pending bytes limit.
 	// ok to return here, client is going away.
 	if c.out.pb > c.out.mp {
-		c.clearConnection(SlowConsumerPendingBytes)
 		atomic.AddInt64(&c.srv.slowConsumers, 1)
 		c.Noticef("Slow Consumer Detected: MaxPending of %d Exceeded", c.out.mp)
+		c.clearConnection(SlowConsumerPendingBytes)
 		return referenced
 	}
 
@@ -2913,7 +2913,8 @@ func (c *client) closeConnection(reason ClosedState) {
 	// and reference existing one.
 	var subs []*subscription
 	if kind == CLIENT || kind == LEAF {
-		subs = make([]*subscription, 0, len(c.subs))
+		var _subs [32]*subscription
+		subs = _subs[:0]
 		for _, sub := range c.subs {
 			// Auto-unsubscribe subscriptions must be unsubscribed forcibly.
 			sub.max = 0

--- a/server/route.go
+++ b/server/route.go
@@ -1318,13 +1318,6 @@ func (s *Server) updateRouteSubscriptionMap(acc *Account, sub *subscription, del
 	var n int32
 	var ok bool
 
-	// Create the fast key which will use the subject or 'subject<spc>queue' for queue subscribers.
-	key := keyFromSub(sub)
-	isq := len(sub.queue) > 0
-
-	// Decide whether we need to send an update out to all the routes.
-	update := isq
-
 	acc.mu.Lock()
 
 	// This is non-nil when we know we are in cluster mode.
@@ -1333,6 +1326,13 @@ func (s *Server) updateRouteSubscriptionMap(acc *Account, sub *subscription, del
 		acc.mu.Unlock()
 		return
 	}
+
+	// Create the fast key which will use the subject or 'subject<spc>queue' for queue subscribers.
+	key := keyFromSub(sub)
+	isq := len(sub.queue) > 0
+
+	// Decide whether we need to send an update out to all the routes.
+	update := isq
 
 	// This is where we do update to account. For queues we need to take
 	// special care that this order of updates is same as what is sent out
@@ -1382,7 +1382,7 @@ func (s *Server) updateRouteSubscriptionMap(acc *Account, sub *subscription, del
 	s.mu.Unlock()
 
 	// If we are a queue subscriber we need to make sure our updates are serialized from
-	// poyential multiple connections. We want to make sure that the order above is preserved
+	// potential multiple connections. We want to make sure that the order above is preserved
 	// here but not necessarily all updates need to be sent. We need to block and recheck the
 	// n count with the lock held through sending here. We will suppress duplicate sends of same qw.
 	if isq {

--- a/server/server.go
+++ b/server/server.go
@@ -785,6 +785,7 @@ func (s *Server) registerAccount(acc *Account) {
 	// TODO(dlc)- Double check that we need this for GWs.
 	if acc.rm == nil && s.opts != nil && s.shouldTrackSubscriptions() {
 		acc.rm = make(map[string]int32)
+		acc.lqws = make(map[string]int32)
 	}
 	acc.srv = s
 	acc.mu.Unlock()


### PR DESCRIPTION
Fix for #1065 

When the same dq subscriber was represented across multiple client connections the state of updates to the queue weight could have been delivered out of order to a route server, resulting in orphaned subscriptions. This fix deals with contention and will only send the latest update such that it can avoid sending needless updates and will not send a previous update to a remote route.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
