### PR TITLE
Add ability for cross account import services to return streams

### DIFF
--- a/server/client_test.go
+++ b/server/client_test.go
@@ -66,6 +66,7 @@ func newClientForServer(s *Server) (*client, *bufio.Reader, string) {
 }
 
 var defaultServerOptions = Options{
+	Host:   "127.0.0.1",
 	Trace:  false,
 	Debug:  false,
 	NoLog:  true,
@@ -295,7 +296,7 @@ func TestClientPing(t *testing.T) {
 	}
 }
 
-var msgPat = regexp.MustCompile(`\AMSG\s+([^\s]+)\s+([^\s]+)\s+(([^\s]+)[^\S\r\n]+)?(\d+)\r\n`)
+var msgPat = regexp.MustCompile(`MSG\s+([^\s]+)\s+([^\s]+)\s+(([^\s]+)[^\S\r\n]+)?(\d+)\r\n`)
 
 const (
 	SUB_INDEX   = 1

--- a/server/configs/accounts.conf
+++ b/server/configs/accounts.conf
@@ -39,7 +39,10 @@ accounts: {
     ]
 
     exports = [
-      {service: "nats.time"}
+      {service: "nats.time", response: stream}
+      {service: "nats.photo", response: chunked}
+      {service: "nats.add", response: singelton, accounts: [cncf]}
+      {service: "nats.sub"}
     ]
   }
 

--- a/server/const.go
+++ b/server/const.go
@@ -133,6 +133,10 @@ const (
 	// DEFAULT_MAX_ACCOUNT_AE_RESPONSE_MAPS is for auto-expire response maps for imports.
 	DEFAULT_MAX_ACCOUNT_AE_RESPONSE_MAPS = 100000
 
+	// DEFAULT_MAX_ACCOUNT_INTERNAL_RESPONSE_MAPS is for non auto-expire response maps for imports.
+	// These are present for non-singelton response types.
+	DEFAULT_MAX_ACCOUNT_INTERNAL_RESPONSE_MAPS = 100000
+
 	// DEFAULT_TTL_AE_RESPONSE_MAP is the default time to expire auto-response map entries.
 	DEFAULT_TTL_AE_RESPONSE_MAP = 10 * time.Minute
 

--- a/server/events.go
+++ b/server/events.go
@@ -934,7 +934,7 @@ func (s *Server) sysUnsubscribe(sub *subscription) {
 	c := s.sys.client
 	delete(s.sys.subs, string(sub.sid))
 	s.mu.Unlock()
-	c.unsubscribe(acc, sub, true)
+	c.unsubscribe(acc, sub, true, true)
 }
 
 // Helper to grab name for a client.

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1189,7 +1189,7 @@ func (c *client) processLeafUnsub(arg []byte) error {
 	c.mu.Unlock()
 
 	if ok {
-		c.unsubscribe(acc, sub, true)
+		c.unsubscribe(acc, sub, true, true)
 		updateGWs = srv.gateway.enabled
 	}
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -103,18 +103,21 @@ type RemoteGatewayOpts struct {
 
 // LeafNodeOpts are options for a given server to accept leaf node connections and/or connect to a remote cluster.
 type LeafNodeOpts struct {
-	Host              string            `json:"addr,omitempty"`
-	Port              int               `json:"port,omitempty"`
-	Username          string            `json:"-"`
-	Password          string            `json:"-"`
-	AuthTimeout       float64           `json:"auth_timeout,omitempty"`
-	TLSConfig         *tls.Config       `json:"-"`
-	TLSTimeout        float64           `json:"tls_timeout,omitempty"`
-	TLSMap            bool              `json:"-"`
-	Remotes           []*RemoteLeafOpts `json:"remotes,omitempty"`
-	Advertise         string            `json:"-"`
-	NoAdvertise       bool              `json:"-"`
-	ReconnectInterval time.Duration     `json:"-"`
+	Host              string        `json:"addr,omitempty"`
+	Port              int           `json:"port,omitempty"`
+	Username          string        `json:"-"`
+	Password          string        `json:"-"`
+	AuthTimeout       float64       `json:"auth_timeout,omitempty"`
+	TLSConfig         *tls.Config   `json:"-"`
+	TLSTimeout        float64       `json:"tls_timeout,omitempty"`
+	TLSMap            bool          `json:"-"`
+	Advertise         string        `json:"-"`
+	NoAdvertise       bool          `json:"-"`
+	ReconnectInterval time.Duration `json:"-"`
+	MaxConn           int           `json:"max_connections"`
+
+	// For solicited connections to other clusters/superclusters.
+	Remotes []*RemoteLeafOpts `json:"remotes,omitempty"`
 
 	// Not exported, for tests.
 	resolver    netResolver
@@ -1247,6 +1250,7 @@ type export struct {
 	acc  *Account
 	sub  string
 	accs []string
+	rt   ServiceRespType
 }
 
 type importStream struct {
@@ -1439,7 +1443,7 @@ func parseAccounts(v interface{}, opts *Options, errors *[]error, warnings *[]er
 			}
 			accounts = append(accounts, ta)
 		}
-		if err := service.acc.AddServiceExport(service.sub, accounts); err != nil {
+		if err := service.acc.AddServiceExportWithResponse(service.sub, service.rt, accounts); err != nil {
 			msg := fmt.Sprintf("Error adding service export %q: %v", service.sub, err)
 			*errors = append(*errors, &configErr{tk, msg})
 			continue
@@ -1576,6 +1580,8 @@ func parseExportStreamOrService(v interface{}, errors, warnings *[]error) (*expo
 		curStream  *export
 		curService *export
 		accounts   []string
+		rt         ServiceRespType
+		rtSeen     bool
 	)
 	tk, v := unwrapValue(v)
 	vv, ok := v.(map[string]interface{})
@@ -1591,7 +1597,11 @@ func parseExportStreamOrService(v interface{}, errors, warnings *[]error) (*expo
 				*errors = append(*errors, err)
 				continue
 			}
-
+			if rtSeen {
+				err := &configErr{tk, "Detected response directive on non-service"}
+				*errors = append(*errors, err)
+				continue
+			}
 			mvs, ok := mv.(string)
 			if !ok {
 				err := &configErr{tk, fmt.Sprintf("Expected stream name to be string, got %T", mv)}
@@ -1601,6 +1611,33 @@ func parseExportStreamOrService(v interface{}, errors, warnings *[]error) (*expo
 			curStream = &export{sub: mvs}
 			if accounts != nil {
 				curStream.accs = accounts
+			}
+		case "response", "response_type":
+			rtSeen = true
+			mvs, ok := mv.(string)
+			if !ok {
+				err := &configErr{tk, fmt.Sprintf("Expected response type to be string, got %T", mv)}
+				*errors = append(*errors, err)
+				continue
+			}
+			switch strings.ToLower(mvs) {
+			case "single", "singelton":
+				rt = Singelton
+			case "stream":
+				rt = Stream
+			case "chunk", "chunked":
+				rt = Chunked
+			default:
+				err := &configErr{tk, fmt.Sprintf("Unknown response type: %q", mvs)}
+				*errors = append(*errors, err)
+				continue
+			}
+			if curService != nil {
+				curService.rt = rt
+			}
+			if curStream != nil {
+				err := &configErr{tk, "Detected response directive on non-service"}
+				*errors = append(*errors, err)
 			}
 		case "service":
 			if curStream != nil {
@@ -1617,6 +1654,9 @@ func parseExportStreamOrService(v interface{}, errors, warnings *[]error) (*expo
 			curService = &export{sub: mvs}
 			if accounts != nil {
 				curService.accs = accounts
+			}
+			if rtSeen {
+				curService.rt = rt
 			}
 		case "accounts":
 			for _, iv := range mv.([]interface{}) {

--- a/server/opts.go
+++ b/server/opts.go
@@ -114,7 +114,6 @@ type LeafNodeOpts struct {
 	Advertise         string        `json:"-"`
 	NoAdvertise       bool          `json:"-"`
 	ReconnectInterval time.Duration `json:"-"`
-	MaxConn           int           `json:"max_connections"`
 
 	// For solicited connections to other clusters/superclusters.
 	Remotes []*RemoteLeafOpts `json:"remotes,omitempty"`

--- a/server/reload.go
+++ b/server/reload.go
@@ -884,6 +884,7 @@ func (s *Server) reloadAuthorization() {
 				}
 				newAcc.sl = acc.sl
 				newAcc.rm = acc.rm
+				newAcc.respMap = acc.respMap
 				acc.mu.RUnlock()
 
 				// Check if current and new config of this account are same

--- a/server/route.go
+++ b/server/route.go
@@ -116,7 +116,7 @@ func (c *client) addReplySubTimeout(acc *Account, sub *subscription, d time.Dura
 		delete(rs, sub)
 		sub.max = 0
 		c.mu.Unlock()
-		c.unsubscribe(acc, sub, true)
+		c.unsubscribe(acc, sub, true, true)
 	})
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -773,6 +773,9 @@ func (s *Server) registerAccount(acc *Account) {
 	if acc.maxaettl == 0 {
 		acc.maxaettl = DEFAULT_TTL_AE_RESPONSE_MAP
 	}
+	if acc.maxnrm == 0 {
+		acc.maxnrm = DEFAULT_MAX_ACCOUNT_INTERNAL_RESPONSE_MAPS
+	}
 	if acc.clients == nil {
 		acc.clients = make(map[*client]*client)
 	}


### PR DESCRIPTION

Enable stream responses. Take into account tracking of response maps that are created and do proper cleanup.

Also fixes #1089 which was discovered while working on this.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
