### PR TITLE
Added support for service response types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/nats-io/nats-server/v2
 
 require (
-	github.com/nats-io/jwt v0.2.13-0.20190726194050-829b612a49c3
+	github.com/nats-io/jwt v0.2.13-0.20190807221443-88776a07123f
 	github.com/nats-io/nats.go v1.8.1
 	github.com/nats-io/nkeys v0.1.0
 	github.com/nats-io/nuid v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/nats-io/jwt v0.2.13-0.20190726194050-829b612a49c3 h1:5vVSRJhjWOTv/TeJX1NUGuDYbZkfcWTu/97AHlsC02o=
 github.com/nats-io/jwt v0.2.13-0.20190726194050-829b612a49c3/go.mod h1:mQxQ0uHQ9FhEVPIcTSKwx2lqZEpXWWcCgA7R6NrWvvY=
+github.com/nats-io/jwt v0.2.13-0.20190807221443-88776a07123f h1:HXbsDIrce5ay5anz4HAI57VYDcGznOYs0hCj2QZXBzI=
+github.com/nats-io/jwt v0.2.13-0.20190807221443-88776a07123f/go.mod h1:mQxQ0uHQ9FhEVPIcTSKwx2lqZEpXWWcCgA7R6NrWvvY=
 github.com/nats-io/nats.go v1.8.1 h1:6lF/f1/NN6kzUDBz6pyvQDEXO39jqXcWRLu/tKjtOUQ=
 github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=
 github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7TDb/4=
@@ -14,5 +16,6 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1200,7 +1200,14 @@ func (s *Server) updateAccountClaims(a *Account, ac *jwt.AccountClaims) {
 			}
 		case jwt.Service:
 			s.Debugf("Adding service export %q for %s", e.Subject, a.Name)
-			if err := a.AddServiceExport(string(e.Subject), authAccounts(e.TokenReq)); err != nil {
+			rt := Singelton
+			switch e.ResponseType {
+			case jwt.ResponseTypeStream:
+				rt = Stream
+			case jwt.ResponseTypeChunked:
+				rt = Chunked
+			}
+			if err := a.AddServiceExportWithResponse(string(e.Subject), rt, authAccounts(e.TokenReq)); err != nil {
 				s.Debugf("Error adding service export to account [%s]: %v", a.Name, err.Error())
 			}
 		}

--- a/vendor/github.com/nats-io/jwt/creds_utils.go
+++ b/vendor/github.com/nats-io/jwt/creds_utils.go
@@ -33,6 +33,15 @@ func formatJwt(kind string, jwtString string) ([]byte, error) {
 	return w.Bytes(), nil
 }
 
+// DecorateSeed takes a seed and returns a string that wraps
+// the seed in the form:
+//  ************************* IMPORTANT *************************
+//  NKEY Seed printed below can be used sign and prove identity.
+//  NKEYs are sensitive and should be treated as secrets.
+//
+//  -----BEGIN USER NKEY SEED-----
+//  SUAIO3FHUX5PNV2LQIIP7TZ3N4L7TX3W53MQGEIVYFIGA635OZCKEYHFLM
+//  ------END USER NKEY SEED------
 func DecorateSeed(seed []byte) ([]byte, error) {
 	w := bytes.NewBuffer(nil)
 	ts := bytes.TrimSpace(seed)
@@ -121,6 +130,7 @@ func FormatUserConfig(jwtString string, seed []byte) ([]byte, error) {
 	return w.Bytes(), nil
 }
 
+// ParseDecoratedJWT takes a creds file and returns the JWT portion.
 func ParseDecoratedJWT(contents []byte) (string, error) {
 	defer wipeSlice(contents)
 
@@ -136,6 +146,8 @@ func ParseDecoratedJWT(contents []byte) (string, error) {
 	return string(tmp), nil
 }
 
+// ParseDecoratedNKey takes a creds file, finds the NKey portion and creates a
+// key pair from it.
 func ParseDecoratedNKey(contents []byte) (nkeys.KeyPair, error) {
 	var seed []byte
 	defer wipeSlice(contents)
@@ -169,6 +181,8 @@ func ParseDecoratedNKey(contents []byte) (nkeys.KeyPair, error) {
 	return kp, nil
 }
 
+// ParseDecoratedUserNKey takes a creds file, finds the NKey portion and creates a
+// key pair from it. Similar to ParseDecoratedNKey but fails for non-user keys.
 func ParseDecoratedUserNKey(contents []byte) (nkeys.KeyPair, error) {
 	nk, err := ParseDecoratedNKey(contents)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/nats-io/jwt v0.2.13-0.20190726194050-829b612a49c3
+# github.com/nats-io/jwt v0.2.13-0.20190807221443-88776a07123f
 github.com/nats-io/jwt
 # github.com/nats-io/nats.go v1.8.1
 github.com/nats-io/nats.go


### PR DESCRIPTION
Test checks that response types are initialized
Updated to latest JWT library with response types

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [X] Tests added
 - [X ] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X ] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #

### Changes proposed in this pull request:

 - Add support for response types in services, based on latest JWT library
 - Updated to latest JWT library
 - Updated vendor

/cc @nats-io/core
