### PR TITLE
Removing skipping email notification [ci skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,3 @@ deploy:
     tags: true
     condition: $TRAVIS_GO_VERSION =~ 1.12
 
-notifications:
-  email: false


### PR DESCRIPTION
I had put that in place when testing the release process.
Removing now.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
