### PR TITLE
[ADDED] RTT in routez's route info

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -558,6 +558,7 @@ type RouteInfo struct {
 	Import       *SubjectPermission `json:"import,omitempty"`
 	Export       *SubjectPermission `json:"export,omitempty"`
 	Pending      int                `json:"pending_size"`
+	RTT          string             `json:"rtt,omitempty"`
 	InMsgs       int64              `json:"in_msgs"`
 	OutMsgs      int64              `json:"out_msgs"`
 	InBytes      int64              `json:"in_bytes"`
@@ -600,6 +601,7 @@ func (s *Server) Routez(routezOpts *RoutezOptions) (*Routez, error) {
 			NumSubs:      uint32(len(r.subs)),
 			Import:       r.opts.Import,
 			Export:       r.opts.Export,
+			RTT:          r.getRTT(),
 		}
 
 		if subs && len(r.subs) > 0 {

--- a/server/route.go
+++ b/server/route.go
@@ -485,6 +485,12 @@ func (c *client) processRouteInfo(info *Info) {
 		if !s.getOpts().Cluster.NoAdvertise {
 			s.addClientConnectURLsAndSendINFOToClients(info.ClientConnectURLs)
 		}
+
+		// This will allow us to determine the initial RTT without having to
+		// wait for first timer based PING.
+		c.mu.Lock()
+		c.sendPing()
+		c.mu.Unlock()
 	} else {
 		c.Debugf("Detected duplicate remote route %q", info.ID)
 		c.closeConnection(DuplicateRoute)

--- a/test/norace_test.go
+++ b/test/norace_test.go
@@ -359,7 +359,7 @@ func TestQueueSubWeightOrderMultipleConnections(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not marshal test route info: %v", err)
 	}
-	routeSend(fmt.Sprintf("INFO %s\r\n", b))
+	routeSendInfo(b, routeSend, routeExpect)
 
 	start := make(chan bool)
 	for _, nc := range clients {

--- a/test/route_discovery_test.go
+++ b/test/route_discovery_test.go
@@ -74,8 +74,7 @@ func TestSeedMultipleRouteInfo(t *testing.T) {
 	// register ourselves via INFO
 	r1Info := server.Info{ID: rc1ID, Host: rc1Host, Port: rc1Port}
 	b, _ := json.Marshal(r1Info)
-	infoJSON := fmt.Sprintf(server.InfoProto, b)
-	routeSend1(infoJSON)
+	routeSendInfo(b, routeSend1, route1Expect)
 	routeSend1("PING\r\n")
 	route1Expect(pongRe)
 
@@ -93,7 +92,7 @@ func TestSeedMultipleRouteInfo(t *testing.T) {
 	// register ourselves via INFO
 	r2Info := server.Info{ID: rc2ID, Host: rc2Host, Port: rc2Port}
 	b, _ = json.Marshal(r2Info)
-	infoJSON = fmt.Sprintf(server.InfoProto, b)
+	infoJSON := fmt.Sprintf(server.InfoProto, b)
 	routeSend2(infoJSON)
 
 	// Now read back the second INFO route1 should receive letting
@@ -556,8 +555,7 @@ func TestSeedReturnIPInInfo(t *testing.T) {
 	// register ourselves via INFO
 	r1Info := server.Info{ID: rc1ID, Host: rc1Host, Port: rc1Port}
 	b, _ := json.Marshal(r1Info)
-	infoJSON := fmt.Sprintf(server.InfoProto, b)
-	routeSend1(infoJSON)
+	routeSendInfo(b, routeSend1, route1Expect)
 	routeSend1("PING\r\n")
 	route1Expect(pongRe)
 
@@ -573,7 +571,7 @@ func TestSeedReturnIPInInfo(t *testing.T) {
 	// register ourselves via INFO
 	r2Info := server.Info{ID: rc2ID, Host: rc2Host, Port: rc2Port}
 	b, _ = json.Marshal(r2Info)
-	infoJSON = fmt.Sprintf(server.InfoProto, b)
+	infoJSON := fmt.Sprintf(server.InfoProto, b)
 	routeSend2(infoJSON)
 
 	// Now read info that route1 should have received from the seed
@@ -621,8 +619,7 @@ func TestImplicitRouteRetry(t *testing.T) {
 	// register ourselves via INFO
 	rbInfo := server.Info{ID: rcbID, Host: optsB.Cluster.Host, Port: optsB.Cluster.Port}
 	b, _ := json.Marshal(rbInfo)
-	infoJSON := fmt.Sprintf(server.InfoProto, b)
-	routeBSend(infoJSON)
+	routeSendInfo(b, routeBSend, routeBExpect)
 	routeBSend("PING\r\n")
 	routeBExpect(pongRe)
 
@@ -634,6 +631,7 @@ func TestImplicitRouteRetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error during listen: %v", err)
 	}
+	defer rbListen.Close()
 	c, err := rbListen.Accept()
 	if err != nil {
 		t.Fatalf("Error during accept: %v", err)


### PR DESCRIPTION
Added the RTT field to each route reported in routez.
Ensure that when a route is accepted, we send a PING to compute
the first RTT and don't have to wait for the ping timer to fire.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
