### PR TITLE
Fixed subscription close

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,11 @@ before_script:
 - misspell -error -locale US $EXCLUDE_VENDOR
 - staticcheck $EXCLUDE_VENDOR
 script:
+- set -e
 - go test -i $EXCLUDE_VENDOR
-- go test -run=TestNoRace $EXCLUDE_VENDOR
+- go test -run=TestNoRace --failfast -p=1 $EXCLUDE_VENDOR
 - if [[ "$TRAVIS_GO_VERSION" =~ 1.12 ]]; then ./scripts/cov.sh TRAVIS; else go test -v -race -p=1 --failfast $EXCLUDE_VENDOR; fi
+- set +e
 
 deploy:
   provider: script

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -1496,20 +1496,30 @@ func TestCrossAccountServiceResponseLeaks(t *testing.T) {
 
 	// Now send some requests..We will not respond.
 	var sb strings.Builder
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 50; i++ {
 		sb.WriteString(fmt.Sprintf("PUB foo REPLY.%d 4\r\nhelp\r\n", i))
 	}
 	go cbar.parseAndFlush([]byte(sb.String()))
 
 	// Make sure requests are processed.
-	_, err := crFoo.ReadString('\n')
-	if err != nil {
+	if _, err := crFoo.ReadString('\n'); err != nil {
 		t.Fatalf("Error reading from client 'bar': %v", err)
 	}
 
 	// We should have leaked response maps.
-	if nr := fooAcc.numServiceRoutes(); nr != 100 {
+	if nr := fooAcc.numServiceRoutes(); nr != 50 {
 		t.Fatalf("Expected response maps to be present, got %d", nr)
+	}
+
+	sb.Reset()
+	for i := 50; i < 100; i++ {
+		sb.WriteString(fmt.Sprintf("PUB foo REPLY.%d 4\r\nhelp\r\n", i))
+	}
+	go cbar.parseAndFlush([]byte(sb.String()))
+
+	// Make sure requests are processed.
+	if _, err := crFoo.ReadString('\n'); err != nil {
+		t.Fatalf("Error reading from client 'bar': %v", err)
 	}
 
 	// They should be gone here eventually.

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -612,12 +612,12 @@ func TestNoRaceRouteMemUsage(t *testing.T) {
 func TestNoRaceRouteCache(t *testing.T) {
 	maxPerAccountCacheSize = 20
 	prunePerAccountCacheSize = 5
-	orphanSubsCheckInterval = 1
+	closedSubsCheckInterval = 250 * time.Millisecond
 
 	defer func() {
 		maxPerAccountCacheSize = defaultMaxPerAccountCacheSize
 		prunePerAccountCacheSize = defaultPrunePerAccountCacheSize
-		orphanSubsCheckInterval = defaultOrphanSubsCheckInterval
+		closedSubsCheckInterval = defaultClosedSubsCheckInterval
 	}()
 
 	for _, test := range []struct {
@@ -705,7 +705,7 @@ func TestNoRaceRouteCache(t *testing.T) {
 			checkExpected(t, (maxPerAccountCacheSize+1)-(prunePerAccountCacheSize+1))
 
 			// Wait for more than the orphan check
-			time.Sleep(1500 * time.Millisecond)
+			time.Sleep(2 * closedSubsCheckInterval)
 
 			// Add a new subs up to point where new prune would occur
 			sendReqs(t, requestor, prunePerAccountCacheSize+1, false)
@@ -721,7 +721,7 @@ func TestNoRaceRouteCache(t *testing.T) {
 			checkExpected(t, maxPerAccountCacheSize-prunePerAccountCacheSize)
 
 			// Wait for more than the orphan check
-			time.Sleep(1500 * time.Millisecond)
+			time.Sleep(2 * closedSubsCheckInterval)
 
 			// Now create new connection and send prunePerAccountCacheSize+1
 			// and that should cause all subs from previous connection to be


### PR DESCRIPTION
I noticed that TestNoRaceRoutedQueueAutoUnsubscribe started to
fail a lot on Travis. Running locally I could see a 45 to 50%
failures. After investigation I realized that the issue was that
we have wrongly re-used `subscription.nm` and set to -1 on unsubscribe
however, I believe that it was possible that when subscription was
closed, the server may have already picked that consumer for a delivery
which then causes nm==-1 to be bumped to 0, which was wrong.
Commenting out the subscription.close() that sets nm to -1, I could
not get the test to fail on macOS but would still get 7% failure on
Linux VM. Adding the check to see if sub is closed in deliverMsg()
completely erase the failures, even on Linux VM.

We could still use `nm` set to -1 but check on deliverMsg(), the
same way I use the closed int32 now.

Fixed some flappers.
Updated .travis.yml to failfast if one of the command in the
`script` fails. User `set -e` and `set +e` as recommended in
https://github.com/travis-ci/travis-ci/issues/1066

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
