### PR TITLE
Fixed flushOutbound

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -1041,15 +1041,7 @@ func (c *client) sendRouteSubOrUnSubProtos(subs []*subscription, isSubProto, tra
 			// the lock, which could cause pingTimer to think that this
 			// connection is stale otherwise.
 			c.last = time.Now()
-			if !c.flushOutbound() {
-				// Another go-routine has set this and is either
-				// doing the write or waiting to re-acquire the
-				// lock post write. Release lock to give it a
-				// chance to complete.
-				c.mu.Unlock()
-				runtime.Gosched()
-				c.mu.Lock()
-			}
+			c.flushOutbound()
 			if closed = c.flags.isSet(clearConnection); closed {
 				break
 			}

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -1382,6 +1382,14 @@ func Benchmark___________RoutedInterestGraph(b *testing.B) {
 		bw := bufio.NewWriterSize(route.r, defaultSendBufSize)
 		account := fmt.Sprintf("$foo.account.%d", index)
 
+		// Wait for seed server's first PING so that it does
+		// not interfere with the expected PONG after sending
+		// all RS- and last PING.
+		// The wait here does not affect perf measurements
+		// since we do so *before* we signal that we are ready.
+		route.expect(pingRe)
+		route.send("PONG\r\n")
+
 		// Signal we are ready
 		close(ch)
 


### PR DESCRIPTION
With Go 1.12 (strangely was not able to reproduce with Go 1.11)
the test TestRouteNoCrashOnAddingSubToRoute() would frequently
locks up and consume all avail CPUs on the machine. Running
this test with GOMAXPROCS=2 you would see server.test CPU usage
pegged at 200% (assuming you have at least 2 CPUs).
The reason was that the writeLoop was spinning because another
routine was already in flushOutbound() and stack trace would
show that it was stuck in system calls. It seems that even though
the writeLoop does release the lock but grab it right away was
not allowing the syscall to complete.

So decided to put back the unlock/gosched/lock back in flushOutbound()
when flag is already set, but then protect the closeConnection()
with its own flag (similar to clearConnection) to not re-introduce
issue fixed in #1092.

Had to fix the benchmark test RoutedInterestGraph because after a
route is accepted, the initial PING will be sent after 1sec which
was breaking this test.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
