### PR TITLE
Latency tracking updates.

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -510,7 +510,7 @@ func (a *Account) IsExportServiceTracking(service string) bool {
 
 // NATSLatency represents the internal NATS latencies, including RTTs to clients.
 type NATSLatency struct {
-	Requestor time.Duration `json:"request_rtt"`
+	Requestor time.Duration `json:"requestor_rtt"`
 	Responder time.Duration `json:"responder_rtt"`
 	System    time.Duration `json:"system_latency"`
 }

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -486,12 +486,13 @@ func (a *Account) IsExportService(service string) bool {
 // IsExportServiceTracking will indicate if given publish subject is an export service with tracking enabled.
 func (a *Account) IsExportServiceTracking(service string) bool {
 	a.mu.RLock()
-	defer a.mu.RUnlock()
 	ea, ok := a.exports.services[service]
 	if ok && ea == nil {
+		a.mu.RUnlock()
 		return false
 	}
 	if ok && ea != nil && ea.latency != nil {
+		a.mu.RUnlock()
 		return true
 	}
 	// FIXME(dlc) - Might want to cache this is in the hot path checking for
@@ -499,10 +500,24 @@ func (a *Account) IsExportServiceTracking(service string) bool {
 	tokens := strings.Split(service, tsep)
 	for subj, ea := range a.exports.services {
 		if isSubsetMatch(tokens, subj) && ea != nil && ea.latency != nil {
+			a.mu.RUnlock()
 			return true
 		}
 	}
+	a.mu.RUnlock()
 	return false
+}
+
+// NATSLatency represents the internal NATS latencies, including RTTs to clients.
+type NATSLatency struct {
+	Requestor time.Duration `json:"request_rtt"`
+	Responder time.Duration `json:"responder_rtt"`
+	System    time.Duration `json:"system_latency"`
+}
+
+// TotalTime is a helper function that totals the NATS latencies.
+func (nl *NATSLatency) TotalTime() time.Duration {
+	return nl.Requestor + nl.Responder + nl.System
 }
 
 // ServiceLatency is the JSON message sent out in response to latency tracking for
@@ -511,11 +526,25 @@ type ServiceLatency struct {
 	AppName        string        `json:"app_name,omitempty"`
 	RequestStart   time.Time     `json:"request_start"`
 	ServiceLatency time.Duration `json:"service_latency"`
-	NATSLatency    time.Duration `json:"nats_latency"`
+	NATSLatency    NATSLatency   `json:"nats_latency"`
 	TotalLatency   time.Duration `json:"total_latency"`
 }
 
-// Used for transporting remote laytency measurements.
+// Merge function to merge m1 and m2 (requestor and responder) measurements
+// when there are two samples. This happens when the requestor and responder
+// are on different servers.
+//
+// m2 ServiceLatency is correct, so use that.
+// m1 TotalLatency is correct, so use that.
+// Will use those to back into NATS latency.
+func (m1 *ServiceLatency) merge(m2 *ServiceLatency) {
+	m1.AppName = m2.AppName
+	m1.NATSLatency.System = m1.ServiceLatency - (m2.ServiceLatency + m2.NATSLatency.Responder)
+	m1.ServiceLatency = m2.ServiceLatency
+	m1.NATSLatency.Responder = m2.NATSLatency.Responder
+}
+
+// Used for transporting remote latency measurements.
 type remoteLatency struct {
 	Account string         `json:"account"`
 	ReqId   string         `json:"req_id"`
@@ -532,7 +561,6 @@ func (a *Account) sendTrackingLatency(si *serviceImport, requestor, responder *c
 
 	var (
 		reqClientRTT  = requestor.getRTTValue()
-		natsRTT       = reqClientRTT
 		respClientRTT time.Duration
 		appName       string
 	)
@@ -541,7 +569,6 @@ func (a *Account) sendTrackingLatency(si *serviceImport, requestor, responder *c
 
 	if responder != nil && responder.kind == CLIENT {
 		respClientRTT = responder.getRTTValue()
-		natsRTT += respClientRTT
 		appName = responder.GetName()
 	}
 
@@ -552,8 +579,12 @@ func (a *Account) sendTrackingLatency(si *serviceImport, requestor, responder *c
 		AppName:        appName,
 		RequestStart:   reqStart,
 		ServiceLatency: serviceRTT - respClientRTT,
-		NATSLatency:    natsRTT,
-		TotalLatency:   reqClientRTT + serviceRTT,
+		NATSLatency: NATSLatency{
+			Requestor: reqClientRTT,
+			Responder: respClientRTT,
+			System:    0,
+		},
+		TotalLatency: reqClientRTT + serviceRTT,
 	}
 
 	// If we are expecting a remote measurement, store our sl here.
@@ -564,11 +595,8 @@ func (a *Account) sendTrackingLatency(si *serviceImport, requestor, responder *c
 	if expectRemoteM2 {
 		si.acc.mu.Lock()
 		if si.m1 != nil {
-			m2 := si.m1
-			m1 := &sl
-			m1.AppName = m2.AppName
-			m1.ServiceLatency = m2.ServiceLatency
-			m1.NATSLatency = m1.TotalLatency - m1.ServiceLatency
+			m1, m2 := &sl, si.m1
+			m1.merge(m2)
 			si.acc.mu.Unlock()
 			a.srv.sendInternalAccountMsg(a, si.latency.subject, m1)
 			return true

--- a/server/events.go
+++ b/server/events.go
@@ -1033,7 +1033,7 @@ func (s *Server) remoteLatencyUpdate(sub *subscription, subject, _ string, msg [
 	lsub := si.latency.subject
 	acc.mu.RUnlock()
 
-	// So we have no processed the response tracking measurement yet.
+	// So we have not processed the response tracking measurement yet.
 	if m1 == nil {
 		acc.mu.Lock()
 		// Double check since could have slipped in.
@@ -1052,9 +1052,7 @@ func (s *Server) remoteLatencyUpdate(sub *subscription, subject, _ string, msg [
 	// M2 ServiceLatency is correct, so use that.
 	// M1 TotalLatency is correct, so use that.
 	// Will use those to back into NATS latency.
-	m1.AppName = m2.AppName
-	m1.ServiceLatency = m2.ServiceLatency
-	m1.NATSLatency = m1.TotalLatency - m1.ServiceLatency
+	m1.merge(&m2)
 
 	// Make sure we remove the entry here.
 	si.acc.removeServiceImport(si.from)

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -2356,7 +2356,7 @@ func (c *client) sendMsgToGateways(acc *Account, msg, subject, reply []byte, qgr
 		sub.nm, sub.max = 0, 0
 		sub.client = gwc
 		sub.subject = c.pa.subject
-		c.deliverMsg(sub, mh, msg)
+		c.deliverMsg(sub, c.pa.subject, mh, msg)
 	}
 	// Done with subscription, put back to pool. We don't need
 	// to reset content since we explicitly set when using it.

--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -115,15 +115,18 @@ func checkServiceLatency(t *testing.T, sl server.ServiceLatency, start time.Time
 	if sl.TotalLatency < sl.ServiceLatency {
 		t.Fatalf("Bad total latency: %v", sl.ServiceLatency)
 	}
+
 	// We should have NATS latency here that is non-zero with real clients.
-	if sl.NATSLatency == 0 {
-		t.Fatalf("Expected non-zero NATS latency")
+	if sl.NATSLatency.Requestor == 0 {
+		t.Fatalf("Expected non-zero NATS Requestor latency")
+	}
+	if sl.NATSLatency.Responder == 0 {
+		t.Fatalf("Expected non-zero NATS Requestor latency")
 	}
 	// Make sure they add up
-	if sl.TotalLatency != sl.ServiceLatency+sl.NATSLatency {
+	if sl.TotalLatency != sl.ServiceLatency+sl.NATSLatency.TotalTime() {
 		t.Fatalf("Numbers do not add up: %+v", sl)
 	}
-
 }
 
 func TestServiceLatencySingleServerConnect(t *testing.T) {
@@ -220,8 +223,8 @@ func TestServiceLatencyRemoteConnect(t *testing.T) {
 
 	// Lastly here, we need to make sure we are properly tracking the extra hops.
 	// We will make sure that NATS latency is close to what we see from the outside in terms of RTT.
-	if crtt := connRTT(nc) + connRTT(nc2); sl.NATSLatency < crtt {
-		t.Fatalf("Not tracking second measurement for NATS latency across servers: %v vs %v", sl.NATSLatency, crtt)
+	if crtt := connRTT(nc) + connRTT(nc2); sl.NATSLatency.TotalTime() < crtt {
+		t.Fatalf("Not tracking second measurement for NATS latency across servers: %v vs %v", sl.NATSLatency.TotalTime(), crtt)
 	}
 
 	// Gateway Requestor
@@ -244,8 +247,8 @@ func TestServiceLatencyRemoteConnect(t *testing.T) {
 
 	// Lastly here, we need to make sure we are properly tracking the extra hops.
 	// We will make sure that NATS latency is close to what we see from the outside in terms of RTT.
-	if crtt := connRTT(nc) + connRTT(nc2); sl.NATSLatency < crtt {
-		t.Fatalf("Not tracking second measurement for NATS latency across servers: %v vs %v", sl.NATSLatency, crtt)
+	if crtt := connRTT(nc) + connRTT(nc2); sl.NATSLatency.TotalTime() < crtt {
+		t.Fatalf("Not tracking second measurement for NATS latency across servers: %v vs %v", sl.NATSLatency.TotalTime(), crtt)
 	}
 }
 


### PR DESCRIPTION
Will now breakout the internal NATS latency to show requestor client RTT, responder client RTT and any internal latency caused by hopping between servers, etc.

Signed-off-by: Derek Collison <derek@nats.io>

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [ ] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [ ] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #

### Changes proposed in this pull request:

 -
 -
 -

/cc @nats-io/core
