### PR TITLE
Expose service latency info in config file

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -487,7 +487,7 @@ func (a *Account) AddServiceExportWithResponse(subject string, respType ServiceR
 // TrackServiceExport will enable latency tracking of the named service.
 // Results will be published in this account to the given results subject.
 func (a *Account) TrackServiceExport(service, results string) error {
-	return a.TrackServiceExportWithSampling(service, results, 100)
+	return a.TrackServiceExportWithSampling(service, results, DEFAULT_SERVICE_LATENCY_SAMPLING)
 }
 
 // TrackServiceExportWithSampling will enable latency tracking of the named service for the given

--- a/server/client.go
+++ b/server/client.go
@@ -2228,7 +2228,7 @@ func (c *client) deliverMsg(sub *subscription, subject, mh, msg []byte) bool {
 	}
 
 	// Do a fast check here to see if we should be tracking this from a latency
-	// persepective. This will be for a request being received for an exported service.
+	// perspective. This will be for a request being received for an exported service.
 	// This needs to be from a non-client (otherwise tracking happens at requestor).
 	if client.kind == CLIENT && len(c.pa.reply) > minReplyLen {
 		// If we do not have a registered RTT queue that up now.

--- a/server/const.go
+++ b/server/const.go
@@ -175,4 +175,8 @@ const (
 	// DEFAULT_ALLOW_RESPONSE_EXPIRATION is the default time allowed for a given
 	// dynamic response permission.
 	DEFAULT_ALLOW_RESPONSE_EXPIRATION = 2 * time.Minute
+
+	// DEFAULT_SERVICE_LATENCY_SAMPLING is the default sampling rate for service
+	// latency metrics
+	DEFAULT_SERVICE_LATENCY_SAMPLING = 100
 )


### PR DESCRIPTION
Currently, the config file doesn't recognize the `latency` config block in account exports. This change exposes those settings in the config file.

TODO:
- [x] return a `*serviceLatency`
- [x] rename `export.latency` to `export.lat`
- [x] delete `AddServiceExportWithResponseAndLatency`
- [x] fix lints
- [x] make sampling default `100`
- [x] allow `latency` to be string
- [x] accept both `int(100)` and `string(100%)`
- [x] test for explicitly setting sampling and letting the default fall through
- [x] use `TrackServiceExportWithSampling` to add latency to `exportAuth`

/cc @nats-io/core
