### PR TITLE
[FIXED] Locking issue around account lookup/updates

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -291,17 +291,13 @@ func (a *Account) numLocalLeafNodes() int {
 
 // MaxTotalConnectionsReached returns if we have reached our limit for number of connections.
 func (a *Account) MaxTotalConnectionsReached() bool {
+	var mtc bool
 	a.mu.RLock()
-	mtc := a.maxTotalConnectionsReached()
+	if a.mconns != jwt.NoLimit {
+		mtc = len(a.clients)-int(a.sysclients)+int(a.nrclients) >= int(a.mconns)
+	}
 	a.mu.RUnlock()
 	return mtc
-}
-
-func (a *Account) maxTotalConnectionsReached() bool {
-	if a.mconns != jwt.NoLimit {
-		return len(a.clients)-int(a.sysclients)+int(a.nrclients) >= int(a.mconns)
-	}
-	return false
 }
 
 // MaxActiveConnections return the set limit for the account system
@@ -1456,8 +1452,9 @@ func (s *Server) SetAccountResolver(ar AccountResolver) {
 // AccountResolver returns the registered account resolver.
 func (s *Server) AccountResolver() AccountResolver {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.accResolver
+	ar := s.accResolver
+	s.mu.Unlock()
+	return ar
 }
 
 // UpdateAccountClaims will call updateAccountClaims.
@@ -1467,6 +1464,7 @@ func (s *Server) UpdateAccountClaims(a *Account, ac *jwt.AccountClaims) {
 
 // updateAccountClaims will update an existing account with new claims.
 // This will replace any exports or imports previously defined.
+// Lock MUST NOT be held upon entry.
 func (s *Server) updateAccountClaims(a *Account, ac *jwt.AccountClaims) {
 	if a == nil {
 		return
@@ -1547,22 +1545,10 @@ func (s *Server) updateAccountClaims(a *Account, ac *jwt.AccountClaims) {
 		}
 	}
 	for _, i := range ac.Imports {
-		var acc *Account
-		if v, ok := s.accounts.Load(i.Account); ok {
-			acc = v.(*Account)
-		}
-		if acc == nil {
-			// Check to see if the account referenced is not one that
-			// we are currently building (but not yet fully registered).
-			if v, ok := s.tmpAccounts.Load(i.Account); ok {
-				acc = v.(*Account)
-			}
-		}
-		if acc == nil {
-			if acc, _ = s.fetchAccount(i.Account); acc == nil {
-				s.Debugf("Can't locate account [%s] for import of [%v] %s", i.Account, i.Subject, i.Type)
-				continue
-			}
+		acc, err := s.lookupAccount(i.Account)
+		if acc == nil || err != nil {
+			s.Errorf("Can't locate account [%s] for import of [%v] %s (err=%v)", i.Account, i.Subject, i.Type, err)
+			continue
 		}
 		switch i.Type {
 		case jwt.Stream:
@@ -1645,14 +1631,17 @@ func (s *Server) updateAccountClaims(a *Account, ac *jwt.AccountClaims) {
 
 	clients := gatherClients()
 	// Sort if we are over the limit.
-	if a.maxTotalConnectionsReached() {
+	if a.MaxTotalConnectionsReached() {
 		sort.Slice(clients, func(i, j int) bool {
 			return clients[i].start.After(clients[j].start)
 		})
 	}
 	now := time.Now().Unix()
 	for i, c := range clients {
-		if a.mconns != jwt.NoLimit && i >= int(a.mconns) {
+		a.mu.RLock()
+		exceeded := a.mconns != jwt.NoLimit && i >= int(a.mconns)
+		a.mu.RUnlock()
+		if exceeded {
 			c.maxAccountConnExceeded()
 			continue
 		}
@@ -1690,6 +1679,7 @@ func (s *Server) updateAccountClaims(a *Account, ac *jwt.AccountClaims) {
 }
 
 // Helper to build an internal account structure from a jwt.AccountClaims.
+// Lock MUST NOT be held upon entry.
 func (s *Server) buildInternalAccount(ac *jwt.AccountClaims) *Account {
 	acc := NewAccount(ac.Subject)
 	acc.Issuer = ac.Issuer

--- a/server/events.go
+++ b/server/events.go
@@ -572,9 +572,7 @@ func (s *Server) initEventTracking() {
 
 // accountClaimUpdate will receive claim updates for accounts.
 func (s *Server) accountClaimUpdate(sub *subscription, _ *client, subject, reply string, msg []byte) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if !s.eventsEnabled() {
+	if !s.EventsEnabled() {
 		return
 	}
 	toks := strings.Split(subject, tsep)
@@ -903,8 +901,8 @@ func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string)
 			RTT:     c.getRTT(),
 		},
 		Sent: DataStats{
-			Msgs:  c.inMsgs,
-			Bytes: c.inBytes,
+			Msgs:  atomic.LoadInt64(&c.inMsgs),
+			Bytes: atomic.LoadInt64(&c.inBytes),
 		},
 		Received: DataStats{
 			Msgs:  c.outMsgs,

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -828,7 +828,7 @@ func TestSystemAccountConnectionLimitsServersStaggered(t *testing.T) {
 	}
 
 	// Restart server B.
-	optsB.AccountResolver = sa.accResolver
+	optsB.AccountResolver = sa.AccountResolver()
 	optsB.SystemAccount = sa.systemAccount().Name
 	sb = RunServer(optsB)
 	defer sb.Shutdown()
@@ -1409,10 +1409,8 @@ func TestFetchAccountRace(t *testing.T) {
 
 	// Replace B's account resolver with one that introduces
 	// delay during the Fetch()
-	sb.mu.Lock()
-	sac := &slowAccResolver{AccountResolver: sb.accResolver}
-	sb.accResolver = sac
-	sb.mu.Unlock()
+	sac := &slowAccResolver{AccountResolver: sb.AccountResolver()}
+	sb.SetAccountResolver(sac)
 
 	// Add the account in sa and sb
 	addAccountToMemResolver(sa, userAcc, jwt)

--- a/server/reload.go
+++ b/server/reload.go
@@ -912,6 +912,8 @@ func (s *Server) reloadAuthorization() {
 				acc.mu.RLock()
 				accName := acc.Name
 				acc.mu.RUnlock()
+				// Release server lock for following actions
+				s.mu.Unlock()
 				accClaims, claimJWT, _ := s.fetchAccountClaims(accName)
 				if accClaims != nil {
 					err := s.updateAccountWithClaimJWT(acc, claimJWT)
@@ -923,9 +925,10 @@ func (s *Server) reloadAuthorization() {
 					s.Noticef("Reloaded: deleting account [removed]: %q", accName)
 					s.accounts.Delete(k)
 				}
+				// Regrab server lock.
+				s.mu.Lock()
 				return true
 			})
-
 		}
 	}
 

--- a/server/split_test.go
+++ b/server/split_test.go
@@ -29,7 +29,9 @@ func TestSplitBufferSubOp(t *testing.T) {
 		t.Fatalf("Error creating gateways: %v", err)
 	}
 	s := &Server{gacc: NewAccount(globalAccountName), gateway: gws}
+	s.mu.Lock()
 	s.registerAccount(s.gacc)
+	s.mu.Unlock()
 	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription), nc: cli}
 
 	subop := []byte("SUB foo 1\r\n")
@@ -66,7 +68,9 @@ func TestSplitBufferSubOp(t *testing.T) {
 
 func TestSplitBufferUnsubOp(t *testing.T) {
 	s := &Server{gacc: NewAccount(globalAccountName), gateway: &srvGateway{}}
+	s.mu.Lock()
 	s.registerAccount(s.gacc)
+	s.mu.Unlock()
 	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
 
 	subop := []byte("SUB foo 1024\r\n")

--- a/server/split_test.go
+++ b/server/split_test.go
@@ -29,9 +29,7 @@ func TestSplitBufferSubOp(t *testing.T) {
 		t.Fatalf("Error creating gateways: %v", err)
 	}
 	s := &Server{gacc: NewAccount(globalAccountName), gateway: gws}
-	s.mu.Lock()
 	s.registerAccount(s.gacc)
-	s.mu.Unlock()
 	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription), nc: cli}
 
 	subop := []byte("SUB foo 1\r\n")
@@ -68,9 +66,7 @@ func TestSplitBufferSubOp(t *testing.T) {
 
 func TestSplitBufferUnsubOp(t *testing.T) {
 	s := &Server{gacc: NewAccount(globalAccountName), gateway: &srvGateway{}}
-	s.mu.Lock()
 	s.registerAccount(s.gacc)
-	s.mu.Unlock()
 	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
 
 	subop := []byte("SUB foo 1024\r\n")


### PR DESCRIPTION
Ensure that lookupAccount does not hold server lock during
updateAccount and fetchAccount.
Updating the account cannot have the server lock because it is
possible that during updateAccountClaims(), clients are being
removed, which would try to get the server lock (deep down in
closeConnection/s.removeClient).
Added a test that would have show the deadlock prior to changes
in this PR.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
