### PR TITLE
Fix message expiration

### DIFF
--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -144,14 +145,16 @@ func TestMemStoreAgeLimit(t *testing.T) {
 		t.Fatalf("Expected %d msgs, got %d", toStore, stats.Msgs)
 	}
 	// Let them expire
-	time.Sleep(maxAge * 10)
-	stats = ms.Stats()
-	if stats.Msgs != 0 {
-		t.Fatalf("Expected no msgs, got %d", stats.Msgs)
-	}
-	if stats.Bytes != 0 {
-		t.Fatalf("Expected no bytes, got %d", stats.Bytes)
-	}
+	checkFor(t, time.Second, maxAge, func() error {
+		stats = ms.Stats()
+		if stats.Msgs != 0 {
+			return fmt.Errorf("Expected no msgs, got %d", stats.Msgs)
+		}
+		if stats.Bytes != 0 {
+			return fmt.Errorf("Expected no bytes, got %d", stats.Bytes)
+		}
+		return nil
+	})
 }
 
 func TestMemStoreTimeStamps(t *testing.T) {

--- a/server/sysmem/mem_windows.go
+++ b/server/sysmem/mem_windows.go
@@ -13,6 +13,8 @@
 
 // +build windows
 
+package sysmem
+
 import (
 	"syscall"
 	"unsafe"


### PR DESCRIPTION
- If all messages are expired, stop/set timer to nil so new messages can be expired
- If not all messages are expired, reset timer to fire soon.

Also add missing `package` for sysmem/windows

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
