### PR TITLE
fix string trim func usage in pse

### DIFF
--- a/server/pse/pse_windows.go
+++ b/server/pse/pse_windows.go
@@ -160,7 +160,7 @@ func getCounterArrayData(counter PDH_HCOUNTER) ([]float64, error) {
 // the performance counter API.
 func getProcessImageName() (name string) {
 	name = filepath.Base(os.Args[0])
-	name = strings.TrimRight(name, ".exe")
+	name = strings.TrimSuffix(name, ".exe")
 	return
 }
 


### PR DESCRIPTION

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [ ] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #

### Changes proposed in this pull request:

TrimRight is char based, and TrimSuffix is word based, that's what we want here,
please see diffs here: https://play.golang.org/p/HwWzZ86WbqS

/cc @nats-io/core
