### PR TITLE
Allows a descriptive server_name to be set

### DIFF
--- a/server/configs/test.conf
+++ b/server/configs/test.conf
@@ -1,5 +1,7 @@
 # Simple config file
 
+server_name: testing_server
+
 listen: 127.0.0.1:4242
 
 http: 8222

--- a/server/events.go
+++ b/server/events.go
@@ -122,6 +122,7 @@ type accNumConnsReq struct {
 
 // ServerInfo identifies remote servers.
 type ServerInfo struct {
+	Name    string    `json:"name"`
 	Host    string    `json:"host"`
 	ID      string    `json:"id"`
 	Cluster string    `json:"cluster,omitempty"`
@@ -215,6 +216,7 @@ func (s *Server) internalSendLoop(wg *sync.WaitGroup) {
 	sendq := s.sys.sendq
 	id := s.info.ID
 	host := s.info.Host
+	servername := s.info.Name
 	seqp := &s.sys.seq
 	var cluster string
 	if s.gateway.enabled {
@@ -237,6 +239,7 @@ func (s *Server) internalSendLoop(wg *sync.WaitGroup) {
 		select {
 		case pm := <-sendq:
 			if pm.si != nil {
+				pm.si.Name = servername
 				pm.si.Host = host
 				pm.si.Cluster = cluster
 				pm.si.ID = id

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -893,6 +893,7 @@ func (s *Server) HandleStacksz(w http.ResponseWriter, r *http.Request) {
 // Varz will output server information on the monitoring port at /varz.
 type Varz struct {
 	ID                string            `json:"server_id"`
+	Name              string            `json:"server_name"`
 	Version           string            `json:"version"`
 	Proto             int               `json:"proto"`
 	GitCommit         string            `json:"git_commit,omitempty"`
@@ -1077,6 +1078,7 @@ func (s *Server) createVarz(pcpu float64, rss int64) *Varz {
 		Proto:     info.Proto,
 		GitCommit: info.GitCommit,
 		GoVersion: info.GoVersion,
+		Name:      info.Name,
 		Host:      info.Host,
 		Port:      info.Port,
 		IP:        info.IP,

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -43,12 +43,13 @@ const CLUSTER_PORT = -1
 
 func DefaultMonitorOptions() *Options {
 	return &Options{
-		Host:     "127.0.0.1",
-		Port:     CLIENT_PORT,
-		HTTPHost: "127.0.0.1",
-		HTTPPort: MONITOR_PORT,
-		NoLog:    true,
-		NoSigs:   true,
+		Host:       "127.0.0.1",
+		Port:       CLIENT_PORT,
+		HTTPHost:   "127.0.0.1",
+		HTTPPort:   MONITOR_PORT,
+		ServerName: "monitor_server",
+		NoLog:      true,
+		NoSigs:     true,
 	}
 }
 
@@ -209,6 +210,9 @@ func TestHandleVarz(t *testing.T) {
 		}
 		if v.Subscriptions != 0 {
 			t.Fatalf("Expected Subscriptions of 0, got %v\n", v.Subscriptions)
+		}
+		if v.Name != "monitor_server" {
+			t.Fatal("Expected ServerName to be 'monitor_server'")
 		}
 	}
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -142,6 +142,7 @@ type RemoteLeafOpts struct {
 // and json tags are deprecated and may be removed in the future.
 type Options struct {
 	ConfigFile       string        `json:"-"`
+	ServerName       string        `json:"server_name"`
 	Host             string        `json:"addr"`
 	Port             int           `json:"port"`
 	ClientAdvertise  string        `json:"-"`
@@ -446,6 +447,8 @@ func (o *Options) ProcessConfigFile(configFile string) error {
 			o.ClientAdvertise = v.(string)
 		case "port":
 			o.Port = int(v.(int64))
+		case "server_name":
+			o.ServerName = v.(string)
 		case "host", "net":
 			o.Host = v.(string)
 		case "debug":

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -84,6 +84,7 @@ func TestOptions_RandomPort(t *testing.T) {
 func TestConfigFile(t *testing.T) {
 	golden := &Options{
 		ConfigFile:            "./configs/test.conf",
+		ServerName:            "testing_server",
 		Host:                  "127.0.0.1",
 		Port:                  4242,
 		Username:              "derek",
@@ -239,6 +240,7 @@ func TestTLSConfigFile(t *testing.T) {
 func TestMergeOverrides(t *testing.T) {
 	golden := &Options{
 		ConfigFile:     "./configs/test.conf",
+		ServerName:     "testing_server",
 		Host:           "127.0.0.1",
 		Port:           2222,
 		Username:       "derek",

--- a/server/server.go
+++ b/server/server.go
@@ -56,6 +56,7 @@ var lameDuckModeInitialDelay = int64(lameDuckModeDefaultInitialDelay)
 // to help them understand information about this server.
 type Info struct {
 	ID                string   `json:"server_id"`
+	Name              string   `json:"server_name"`
 	Version           string   `json:"version"`
 	Proto             int      `json:"proto"`
 	GitCommit         string   `json:"git_commit,omitempty"`
@@ -212,6 +213,11 @@ func NewServer(opts *Options) (*Server, error) {
 	kp, _ := nkeys.CreateServer()
 	pub, _ := kp.PublicKey()
 
+	serverName := pub
+	if opts.ServerName != "" {
+		serverName = opts.ServerName
+	}
+
 	// Validate some options. This is here because we cannot assume that
 	// server will always be started with configuration parsing (that could
 	// report issues). Its options can be (incorrectly) set by hand when
@@ -226,6 +232,7 @@ func NewServer(opts *Options) (*Server, error) {
 		Proto:        PROTO,
 		GitCommit:    gitCommit,
 		GoVersion:    runtime.Version(),
+		Name:         serverName,
 		Host:         opts.Host,
 		Port:         opts.Port,
 		AuthRequired: false,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -284,6 +284,31 @@ func TestGetConnectURLs(t *testing.T) {
 	}
 }
 
+func TestInfoServerNameDefaultsToPK(t *testing.T) {
+	opts := DefaultOptions()
+	opts.Port = 4222
+	opts.ClientAdvertise = "nats.example.com"
+	s := New(opts)
+	defer s.Shutdown()
+
+	if s.info.Name != s.info.ID {
+		t.Fatalf("server info hostname is incorrect, got: '%v' expected: '%v'", s.info.Name, s.info.ID)
+	}
+}
+
+func TestInfoServerNameIsSettable(t *testing.T) {
+	opts := DefaultOptions()
+	opts.Port = 4222
+	opts.ClientAdvertise = "nats.example.com"
+	opts.ServerName = "test_server_name"
+	s := New(opts)
+	defer s.Shutdown()
+
+	if s.info.Name != "test_server_name" {
+		t.Fatalf("server info hostname is incorrect, got: '%v' expected: 'test_server_name'", s.info.Name)
+	}
+}
+
 func TestClientAdvertiseConnectURL(t *testing.T) {
 	opts := DefaultOptions()
 	opts.Port = 4222

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -17,6 +17,7 @@ import (
 	"flag"
 	"fmt"
 	"math/rand"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -1047,9 +1048,14 @@ func TestSublistAll(t *testing.T) {
 var benchSublistSubs []*subscription
 var benchSublistSl = NewSublistWithCache()
 
+// https://github.com/golang/go/issues/31859
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
+}
+
 func init() {
 	initSublist := false
-	flag.Parse()
 	flag.Visit(func(f *flag.Flag) {
 		if f.Name == "test.bench" {
 			initSublist = true


### PR DESCRIPTION
This adds a new config option server_name that
when set will be exposed in varz, events and more
as a descriptive name for the server.

If unset though the server_name will default to the pk

Signed-off-by: R.I.Pienaar <rip@devco.net>