### PR TITLE
[FIXED] Explicit gateway not using discovered URLs

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -580,7 +580,6 @@ func (s *Server) solicitGateway(cfg *gatewayCfg, firstConnect bool) {
 	var (
 		opts       = s.getOpts()
 		isImplicit = cfg.isImplicit()
-		urls       = cfg.getURLs()
 		attempts   int
 		typeStr    string
 	)
@@ -593,7 +592,11 @@ func (s *Server) solicitGateway(cfg *gatewayCfg, firstConnect bool) {
 	const connFmt = "Connecting to %s gateway %q (%s) at %s (attempt %v)"
 	const connErrFmt = "Error connecting to %s gateway %q (%s) at %s (attempt %v): %v"
 
-	for s.isRunning() && len(urls) > 0 {
+	for s.isRunning() {
+		urls := cfg.getURLs()
+		if len(urls) == 0 {
+			break
+		}
 		attempts++
 		report := s.shouldReportConnectErr(firstConnect, attempts)
 		// Iteration is random


### PR DESCRIPTION
If cluster A configures a gateway to cluster B, the server on A
tries to connect to any configured URL. If there is no server on B
at any of the configured addresses, but a server on B with a 
different address connects to server on cluster A, that server
should be able to create its outbound connection in response.
That was not the case because the configured URLs were snapshot
before the loop of trying to connect. When accepting an inbound
connection and updating the array, this new URL was not being used.

The issue is only if the server on A had no outbound connection
at that time.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
