### PR TITLE
[ADDED] Server name in the RouteStat for statsz

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -165,6 +165,7 @@ type ServerStats struct {
 // RouteStat holds route statistics.
 type RouteStat struct {
 	ID       uint64    `json:"rid"`
+	Name     string    `json:"name,omitempty"`
 	Sent     DataStats `json:"sent"`
 	Received DataStats `json:"received"`
 	Pending  int       `json:"pending"`
@@ -412,6 +413,9 @@ func routeStat(r *client) *RouteStat {
 			Bytes: atomic.LoadInt64(&r.inBytes),
 		},
 		Pending: int(r.out.pb),
+	}
+	if r.route != nil {
+		rs.Name = r.route.remoteName
 	}
 	r.mu.Unlock()
 	return rs

--- a/server/route.go
+++ b/server/route.go
@@ -63,6 +63,7 @@ var testRouteProto = RouteProtoV2
 
 type route struct {
 	remoteID     string
+	remoteName   string
 	didSolicit   bool
 	retry        bool
 	routeType    RouteType
@@ -411,6 +412,7 @@ func (c *client) processRouteInfo(info *Info) {
 	c.route.authRequired = info.AuthRequired
 	c.route.tlsRequired = info.TLSRequired
 	c.route.gatewayURL = info.GatewayURL
+	c.route.remoteName = info.Name
 	// When sent through route INFO, if the field is set, it should be of size 1.
 	if len(info.LeafNodeURLs) == 1 {
 		c.route.leafnodeURL = info.LeafNodeURLs[0]
@@ -1472,6 +1474,7 @@ func (s *Server) routeAcceptLoop(ch chan struct{}) {
 	tlsReq := opts.Cluster.TLSConfig != nil
 	info := Info{
 		ID:           s.info.ID,
+		Name:         s.info.Name,
 		Version:      s.info.Version,
 		GoVersion:    runtime.Version(),
 		AuthRequired: false,


### PR DESCRIPTION
Add the remote server name for a route in the statsz event

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

