### PR TITLE
Changes on how tests can override route protocol

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -225,6 +225,7 @@ type Options struct {
 
 	// private fields, used for testing
 	gatewaysSolicitDelay time.Duration
+	routeProto           int
 }
 
 type netResolver interface {

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -2459,11 +2459,9 @@ func TestConfigReloadClusterPermsOldServer(t *testing.T) {
 	optsB := DefaultOptions()
 	optsB.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", srva.ClusterAddr().Port))
 	// Make server B behave like an old server
-	testRouteProto = RouteProtoZero
-	defer func() { testRouteProto = RouteProtoInfo }()
+	optsB.routeProto = setRouteProtoForTest(RouteProtoZero)
 	srvb := RunServer(optsB)
 	defer srvb.Shutdown()
-	testRouteProto = RouteProtoInfo
 
 	checkClusterFormed(t, srva, srvb)
 


### PR DESCRIPTION
I may need to introduce a new route protocol version for an upcoming
PR and realized that this needed some cleaning.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
