### PR TITLE
[FIXED] Detect loop between LeafNode servers

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -66,6 +66,7 @@ type Account struct {
 	expired     bool
 	signingKeys []string
 	srv         *Server // server this account is registered with (possibly nil)
+	lds         string  // loop detection subject for leaf nodes
 }
 
 // Account based limits.

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -3329,14 +3329,26 @@ func TestMonitorLeafz(t *testing.T) {
 			if ln.RTT == "" {
 				t.Fatalf("RTT not tracked?")
 			}
-			if ln.NumSubs != 2 {
-				t.Fatalf("Expected 2 subs, got %v", ln.NumSubs)
+			if ln.NumSubs != 3 {
+				t.Fatalf("Expected 3 subs, got %v", ln.NumSubs)
 			}
-			if len(ln.Subs) != 2 {
+			if len(ln.Subs) != 3 {
 				t.Fatalf("Expected subs to be returned, got %v", len(ln.Subs))
 			}
-			if (ln.Subs[0] != "foo" || ln.Subs[1] != "bar") && (ln.Subs[0] != "bar" || ln.Subs[1] != "foo") {
-				t.Fatalf("Unexpected subjects: %v", ln.Subs)
+			var foundFoo bool
+			var foundBar bool
+			for _, sub := range ln.Subs {
+				if sub == "foo" {
+					foundFoo = true
+				} else if sub == "bar" {
+					foundBar = true
+				}
+			}
+			if !foundFoo {
+				t.Fatal("Did not find subject foo")
+			}
+			if !foundBar {
+				t.Fatal("Did not find subject bar")
 			}
 		}
 	}
@@ -3345,8 +3357,8 @@ func TestMonitorLeafz(t *testing.T) {
 	for pollMode := 1; pollMode < 2; pollMode++ {
 		l := pollLeafz(t, sa, pollMode, pollURL, nil)
 		for _, ln := range l.Leafs {
-			if ln.NumSubs != 2 {
-				t.Fatalf("Number of subs should be 2, got %v", ln.NumSubs)
+			if ln.NumSubs != 3 {
+				t.Fatalf("Number of subs should be 3, got %v", ln.NumSubs)
 			}
 			if len(ln.Subs) != 0 {
 				t.Fatalf("Subs should not have been returned, got %v", ln.Subs)

--- a/server/opts.go
+++ b/server/opts.go
@@ -125,6 +125,7 @@ type LeafNodeOpts struct {
 	// Not exported, for tests.
 	resolver    netResolver
 	dialTimeout time.Duration
+	loopDelay   time.Duration
 }
 
 // RemoteLeafOpts are options for connecting to a remote server as a leaf node.


### PR DESCRIPTION
This is achieved by subscribing to a unique subject. If the LS+
protocol is coming back for the same subject on the same account,
then this indicates a loop.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
