### PR TITLE
Wait on requestor RTT when tracking latency.

### DIFF
--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -1396,7 +1396,7 @@ func TestAccountRequestReplyTrackLatency(t *testing.T) {
 		t.Fatalf("Error adding account service import to client bar: %v", err)
 	}
 
-	// Now setup the resonder under cfoo and the listener for the results
+	// Now setup the responder under cfoo and the listener for the results
 	cfoo.parse([]byte("SUB track.service 1\r\nSUB results 2\r\n"))
 
 	readFooMsg := func() ([]byte, string) {

--- a/server/events.go
+++ b/server/events.go
@@ -252,8 +252,8 @@ func (s *Server) internalSendLoop(wg *sync.WaitGroup) {
 			if pm.msg != nil {
 				b, _ = json.MarshalIndent(pm.msg, _EMPTY_, "  ")
 			}
-			// We can have an override for account here.
 			c.mu.Lock()
+			// We can have an override for account here.
 			if pm.acc != nil {
 				c.acc = pm.acc
 			} else {
@@ -1063,14 +1063,14 @@ func (s *Server) remoteLatencyUpdate(sub *subscription, _ *client, subject, _ st
 
 	// So we have not processed the response tracking measurement yet.
 	if m1 == nil {
-		acc.mu.Lock()
+		si.acc.mu.Lock()
 		// Double check since could have slipped in.
 		m1 = si.m1
 		if m1 == nil {
 			// Store our value there for them to pick up.
 			si.m1 = &m2
 		}
-		acc.mu.Unlock()
+		si.acc.mu.Unlock()
 		if m1 == nil {
 			return
 		}

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -328,8 +328,10 @@ func TestConnz(t *testing.T) {
 		if ci.Idle == "" {
 			t.Fatal("Expected Idle to be valid\n")
 		}
-		if ci.RTT != "" {
-			t.Fatal("Expected RTT to NOT be set for new connection\n")
+		// This is a change, we now expect them to be set for connections when the
+		// client sends a connect.
+		if ci.RTT == "" {
+			t.Fatal("Expected RTT to be set for new connection\n")
 		}
 	}
 

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -2382,10 +2382,8 @@ func TestExpandPath(t *testing.T) {
 	defer os.Setenv("HOME", origHome)
 
 	cases := []struct {
-		path    string
-		home    string
-		testEnv string
-
+		path     string
+		home     string
 		wantPath string
 		wantErr  bool
 	}{

--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -191,6 +191,73 @@ func TestServiceLatencySingleServerConnect(t *testing.T) {
 	checkServiceLatency(t, sl, start, serviceTime)
 }
 
+// If a client has a longer RTT that the effective RTT for NATS + responder
+// the requestor RTT will be marked as 0. This can happen quite often with
+// utility programs that are far away from a cluster like NGS but the service
+// response time has a shorter RTT.
+func TestServiceLatencyClientRTTSlowerThanServiceRTT(t *testing.T) {
+	sc := createSuperCluster(t, 2, 2)
+	defer sc.shutdown()
+
+	// Now add in new service export to FOO and have bar import that with tracking enabled.
+	sc.setupLatencyTracking(t, 100)
+
+	nc := clientConnect(t, sc.clusters[0].opts[0], "foo")
+	defer nc.Close()
+
+	// The service listener. Instant response.
+	nc.Subscribe("ngs.usage.*", func(msg *nats.Msg) {
+		msg.Respond([]byte("22 msgs"))
+	})
+
+	// Listen for metrics
+	rsub, _ := nc.SubscribeSync("results")
+
+	// Requestor and processing
+	requestAndCheck := func(sopts *server.Options) {
+		rtt := 10 * time.Millisecond
+		sp, opts := newSlowProxy(rtt, sopts)
+		defer sp.Stop()
+
+		nc2 := clientConnect(t, opts, "bar")
+		defer nc2.Close()
+
+		start := time.Now()
+		nc2.Flush()
+		if d := time.Since(start); d < rtt {
+			t.Fatalf("Expected an rtt of at least %v, got %v", rtt, d)
+		}
+
+		// Send the request.
+		start = time.Now()
+		_, err := nc2.Request("ngs.usage", []byte("1h"), time.Second)
+		if err != nil {
+			t.Fatalf("Expected a response")
+		}
+
+		var sl server.ServiceLatency
+		rmsg, _ := rsub.NextMsg(time.Second)
+		json.Unmarshal(rmsg.Data, &sl)
+
+		// We want to test here that when the client requestor RTT is larger then the response time
+		// we still deliver a requestor value > 0.
+		// Now check that it is close to rtt.
+		if sl.NATSLatency.Requestor < rtt {
+			t.Fatalf("Expected requestor latency to be > %v, got %v", rtt, sl.NATSLatency.Requestor)
+		}
+		if sl.TotalLatency < rtt {
+			t.Fatalf("Expected total latency to be > %v, got %v", rtt, sl.TotalLatency)
+		}
+	}
+
+	// Check same server.
+	requestAndCheck(sc.clusters[0].opts[0])
+	// Check from remote server across GW.
+	requestAndCheck(sc.clusters[1].opts[1])
+	// Same cluster but different server
+	requestAndCheck(sc.clusters[0].opts[1])
+}
+
 func connRTT(nc *nats.Conn) time.Duration {
 	// Do 5x to flatten
 	total := time.Duration(0)

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -76,7 +76,7 @@ func newSlowProxy(latency time.Duration, opts *server.Options) (*slowProxy, *ser
 func (sp *slowProxy) loop(latency time.Duration, r, w net.Conn) {
 	delay := latency / 2
 	for {
-		var buf [64]byte
+		var buf [1024]byte
 		n, err := r.Read(buf[:])
 		if err != nil {
 			return

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -15,10 +15,14 @@ package test
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
 )
 
 func checkFor(t *testing.T, totalWait, sleepDur time.Duration, f func() error) {
@@ -37,6 +41,64 @@ func checkFor(t *testing.T, totalWait, sleepDur time.Duration, f func() error) {
 	}
 }
 
+// Slow Proxy - really crude but works for introducing simple RTT delays.
+type slowProxy struct {
+	listener net.Listener
+	conns    []net.Conn
+}
+
+func newSlowProxy(latency time.Duration, opts *server.Options) (*slowProxy, *server.Options) {
+	saddr := net.JoinHostPort(opts.Host, strconv.Itoa(opts.Port))
+	hp := net.JoinHostPort("127.0.0.1", "0")
+	l, e := net.Listen("tcp", hp)
+	if e != nil {
+		panic(fmt.Sprintf("Error listening on port: %s, %q", hp, e))
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	sp := &slowProxy{listener: l}
+	go func() {
+		client, err := l.Accept()
+		if err != nil {
+			return
+		}
+		server, err := net.DialTimeout("tcp", saddr, time.Second)
+		if err != nil {
+			panic("Can't connect to server")
+		}
+		sp.conns = append(sp.conns, client, server)
+		go sp.loop(latency, client, server)
+		go sp.loop(latency, server, client)
+	}()
+	sopts := &server.Options{Host: "127.0.0.1", Port: port}
+	return sp, sopts
+}
+
+func (sp *slowProxy) loop(latency time.Duration, r, w net.Conn) {
+	delay := latency / 2
+	for {
+		var buf [64]byte
+		n, err := r.Read(buf[:])
+		if err != nil {
+			return
+		}
+		time.Sleep(delay)
+		if _, err = w.Write(buf[:n]); err != nil {
+			return
+		}
+	}
+}
+
+func (sp *slowProxy) Stop() {
+	if sp.listener != nil {
+		sp.listener.Close()
+		sp.listener = nil
+		for _, c := range sp.conns {
+			c.Close()
+		}
+	}
+}
+
+// Dummy Logger
 type dummyLogger struct {
 	sync.Mutex
 	msg string


### PR DESCRIPTION
If a client RTT for a requestor is longer than a service RTT, the requestor latency was often zero.
We now wait for the RTT (if zero) before sending out the metric.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
