### PR TITLE
Work on Gateways reply mapping

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -814,9 +814,6 @@ func (a *Account) removeServiceImport(subject string) {
 	}
 	delete(a.imports.services, subject)
 	a.mu.Unlock()
-	if a.srv != nil && a.srv.gateway.enabled {
-		a.srv.gatewayHandleServiceImport(a, []byte(subject), nil, -1)
-	}
 }
 
 // This tracks responses to service requests mappings. This is used for cleanup.

--- a/server/client.go
+++ b/server/client.go
@@ -212,19 +212,13 @@ type client struct {
 	leaf  *leaf
 
 	// To keep track of gateway replies mapping
-	gwrt *gwReplyTracking
+	gwrm map[string]*gwReplyMap
 
 	debug bool
 	trace bool
 	echo  bool
 
 	flags clientFlag // Compact booleans into a single field. Size will be increased when needed.
-}
-
-// This is to track gateway reply subjects
-type gwReplyTracking struct {
-	m   map[string]*gwReplyMap
-	tmr *time.Timer
 }
 
 // Struct for PING initiation from the server.
@@ -2781,7 +2775,7 @@ func (c *client) processInboundClientMsg(msg []byte) {
 // If there is no mapping for the subject, false is returned.
 func (c *client) handleGWReplyMap(msg []byte) bool {
 	c.mu.Lock()
-	rm, ok := c.gwrt.m[string(c.pa.subject)]
+	rm, ok := c.gwrm[string(c.pa.subject)]
 	if !ok {
 		c.mu.Unlock()
 		return false

--- a/server/events.go
+++ b/server/events.go
@@ -1047,8 +1047,8 @@ func (s *Server) remoteLatencyUpdate(sub *subscription, _ *client, subject, _ st
 	}
 	// Now get the request id / reply. We need to see if we have a GW prefix and if so strip that off.
 	reply := rl.ReqId
-	if isGWRoutedReply([]byte(reply)) {
-		reply = string(getSubjectFromGWRoutedReply([]byte(reply)))
+	if gwPrefix, old := isGWRoutedSubjectAndIsOldPrefix([]byte(reply)); gwPrefix {
+		reply = string(getSubjectFromGWRoutedReply([]byte(reply), old))
 	}
 	acc.mu.RLock()
 	si := acc.imports.services[reply]

--- a/server/events.go
+++ b/server/events.go
@@ -233,7 +233,7 @@ func (s *Server) internalSendLoop(wg *sync.WaitGroup) {
 	for s.eventsRunning() {
 		// Setup information for next message
 		if len(sendq) > warnThresh && time.Since(last) >= warnFreq {
-			s.Warnf("Internal system send queue > 75%")
+			s.Warnf("Internal system send queue > 75%%")
 			last = time.Now()
 		}
 
@@ -1047,8 +1047,8 @@ func (s *Server) remoteLatencyUpdate(sub *subscription, _ *client, subject, _ st
 	}
 	// Now get the request id / reply. We need to see if we have a GW prefix and if so strip that off.
 	reply := rl.ReqId
-	if subjectStartsWithGatewayReplyPrefix([]byte(reply)) {
-		reply = reply[gwReplyStart:]
+	if isGWRoutedSubject([]byte(reply)) {
+		reply = string(getSubjectFromGWRoutedReply([]byte(reply)))
 	}
 	acc.mu.RLock()
 	si := acc.imports.services[reply]

--- a/server/events.go
+++ b/server/events.go
@@ -1047,7 +1047,7 @@ func (s *Server) remoteLatencyUpdate(sub *subscription, _ *client, subject, _ st
 	}
 	// Now get the request id / reply. We need to see if we have a GW prefix and if so strip that off.
 	reply := rl.ReqId
-	if isGWRoutedSubject([]byte(reply)) {
+	if isGWRoutedReply([]byte(reply)) {
 		reply = string(getSubjectFromGWRoutedReply([]byte(reply)))
 	}
 	acc.mu.RLock()

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -33,10 +33,21 @@ const (
 	defaultSolicitGatewaysDelay         = time.Second
 	defaultGatewayConnectDelay          = time.Second
 	defaultGatewayReconnectDelay        = time.Second
-	defaultGatewayRecentSubExpiration   = 5 * time.Second
+	defaultGatewayRecentSubExpiration   = 250 * time.Millisecond
 	defaultGatewayMaxRUnsubBeforeSwitch = 1000
-	gwReplyPrefix                       = "$GR."
-	gwReplyStart                        = len(gwReplyPrefix) + 5 // len of prefix above + len of hash (4) + "."
+
+	oldGWReplyPrefix = "$GR."
+	oldGWReplyStart  = len(oldGWReplyPrefix) + 5 // len of prefix above + len of hash (4) + "."
+
+	// The new prefix is "$GNR.<x>.<cluster>.<server>." where <x> is 1 character
+	// reserved for service imports, <cluster> is 8 characters hash of origin
+	// cluster name and <server> is 8 characters hash of origin server pub key.
+	gwReplyPrefix    = "$GNR."
+	gwReplyPrefixLen = len(gwReplyPrefix)
+	gwHashLen        = 8
+	gwClusterOffset  = gwReplyPrefixLen + 2
+	gwServerOffset   = gwClusterOffset + gwHashLen + 1
+	gwSubjectOffset  = gwServerOffset + gwHashLen + 1
 )
 
 var (
@@ -116,7 +127,7 @@ type srvGateway struct {
 	info     *Info                  // Gateway Info protocol
 	infoJSON []byte                 // Marshal'ed Info protocol
 	runknown bool                   // Rejects unknown (not configured) gateway connections
-	replyPfx []byte                 // Will be "$GR.<this cluster name hash>."
+	replyPfx []byte                 // Will be "$GNR.<1:reserved>.<8:cluster hash>.<8:server hash>."
 
 	// We maintain the interest of subjects and queues per account.
 	// For a given account, entries in the map could be something like this:
@@ -152,7 +163,7 @@ type sitally struct {
 type gatewayCfg struct {
 	sync.RWMutex
 	*RemoteGatewayOpts
-	replyPfx       []byte
+	hash           []byte
 	urls           map[string]*url.URL
 	connAttempts   int
 	tlsName        string
@@ -245,24 +256,23 @@ func validateGatewayOptions(o *Options) error {
 	return nil
 }
 
-// Computes a hash of 4 characters for the given gateway name.
+// Computes a hash of 8 characters for the name.
 // This will be used for routing of replies.
-func getReplyPrefixForGateway(name string) []byte {
+func getHash(name string) []byte {
 	sha := sha256.New()
 	sha.Write([]byte(name))
-	fullHash := []byte(fmt.Sprintf("%x", sha.Sum(nil)))
-	prefix := make([]byte, 0, len(gwReplyPrefix)+5)
-	prefix = append(prefix, gwReplyPrefix...)
-	prefix = append(prefix, fullHash[:4]...)
-	prefix = append(prefix, '.')
-	return prefix
+	b := sha.Sum(nil)
+	for i := 0; i < gwHashLen; i++ {
+		b[i] = digits[int(b[i]%base)]
+	}
+	return b[:gwHashLen]
 }
 
 // Initialize the s.gateway structure. We do this even if the server
 // does not have a gateway configured. In some part of the code, the
 // server will check the number of outbound gateways, etc.. and so
 // we don't have to check if s.gateway is nil or not.
-func newGateway(opts *Options) (*srvGateway, error) {
+func (s *Server) newGateway(opts *Options) error {
 	gateway := &srvGateway{
 		name:     opts.Gateway.Name,
 		out:      make(map[string]*client),
@@ -272,10 +282,20 @@ func newGateway(opts *Options) (*srvGateway, error) {
 		URLs:     make(map[string]struct{}),
 		resolver: opts.Gateway.resolver,
 		runknown: opts.Gateway.RejectUnknown,
-		replyPfx: getReplyPrefixForGateway(opts.Gateway.Name),
 	}
 	gateway.Lock()
 	defer gateway.Unlock()
+
+	s.hash = getHash(s.info.ID)
+	clusterHash := getHash(opts.Gateway.Name)
+	prefix := make([]byte, 0, gwSubjectOffset)
+	prefix = append(prefix, gwReplyPrefix...)
+	prefix = append(prefix, '_', '.')
+	prefix = append(prefix, clusterHash...)
+	prefix = append(prefix, '.')
+	prefix = append(prefix, s.hash...)
+	prefix = append(prefix, '.')
+	gateway.replyPfx = prefix
 
 	gateway.pasi.m = make(map[string]map[string]*sitally)
 
@@ -291,7 +311,7 @@ func newGateway(opts *Options) (*srvGateway, error) {
 		}
 		cfg := &gatewayCfg{
 			RemoteGatewayOpts: rgo.clone(),
-			replyPfx:          getReplyPrefixForGateway(rgo.Name),
+			hash:              getHash(rgo.Name),
 			urls:              make(map[string]*url.URL, len(rgo.URLs)),
 		}
 		if opts.Gateway.TLSConfig != nil && cfg.TLSConfig == nil {
@@ -315,7 +335,8 @@ func newGateway(opts *Options) (*srvGateway, error) {
 	gateway.recSubExp = defaultGatewayRecentSubExpiration
 
 	gateway.enabled = opts.Gateway.Name != "" && opts.Gateway.Port != 0
-	return gateway, nil
+	s.gateway = gateway
+	return nil
 }
 
 // Returns the Gateway's name of this server.
@@ -1273,7 +1294,7 @@ func (s *Server) processImplicitGateway(info *Info) {
 	opts := s.getOpts()
 	cfg = &gatewayCfg{
 		RemoteGatewayOpts: &RemoteGatewayOpts{Name: gwName},
-		replyPfx:          getReplyPrefixForGateway(gwName),
+		hash:              getHash(gwName),
 		urls:              make(map[string]*url.URL, len(info.GatewayURLs)),
 		implicit:          true,
 	}
@@ -1713,6 +1734,12 @@ func (c *client) processGatewayRUnsub(arg []byte) error {
 	}()
 
 	c.mu.Lock()
+	if c.gw.outsim == nil {
+		c.Errorf("Received RS- from gateway on inbound connection")
+		c.mu.Unlock()
+		c.closeConnection(ProtocolViolation)
+		return nil
+	}
 	defer c.mu.Unlock()
 
 	ei, _ := c.gw.outsim.Load(accName)
@@ -1815,6 +1842,12 @@ func (c *client) processGatewayRSub(arg []byte) error {
 	}()
 
 	c.mu.Lock()
+	if c.gw.outsim == nil {
+		c.Errorf("Received RS+ from gateway on inbound connection")
+		c.mu.Unlock()
+		c.closeConnection(ProtocolViolation)
+		return nil
+	}
 	defer c.mu.Unlock()
 
 	ei, _ := c.gw.outsim.Load(string(accName))
@@ -2173,31 +2206,31 @@ func (s *Server) gatewayUpdateSubInterest(accName string, sub *subscription, cha
 			}
 		}
 	}
-	if first || last {
-		if sub.client != nil {
-			rsubs := &s.gateway.rsubs
-			c := sub.client
-			sli, _ := rsubs.Load(c)
-			if first {
-				var sl *Sublist
-				if sli == nil {
-					sl = NewSublistNoCache()
-					rsubs.Store(c, sl)
-				} else {
-					sl = sli.(*Sublist)
-				}
-				sl.Insert(sub)
-				time.AfterFunc(s.gateway.recSubExp, func() {
-					sl.Remove(sub)
-				})
-			} else if sli != nil {
-				sl := sli.(*Sublist)
+	if sub.client != nil {
+		rsubs := &s.gateway.rsubs
+		c := sub.client
+		sli, _ := rsubs.Load(c)
+		if change > 0 {
+			var sl *Sublist
+			if sli == nil {
+				sl = NewSublistNoCache()
+				rsubs.Store(c, sl)
+			} else {
+				sl = sli.(*Sublist)
+			}
+			sl.Insert(sub)
+			time.AfterFunc(s.gateway.recSubExp, func() {
 				sl.Remove(sub)
-				if sl.Count() == 0 {
-					rsubs.Delete(c)
-				}
+			})
+		} else if sli != nil {
+			sl := sli.(*Sublist)
+			sl.Remove(sub)
+			if sl.Count() == 0 {
+				rsubs.Delete(c)
 			}
 		}
+	}
+	if first || last {
 		if entry.q {
 			s.sendQueueSubOrUnsubToGateways(accName, sub, first)
 		} else {
@@ -2206,27 +2239,42 @@ func (s *Server) gatewayUpdateSubInterest(accName string, sub *subscription, cha
 	}
 }
 
-// Returns true if the given subject starts with `$GR.`
-func subjectStartsWithGatewayReplyPrefix(subj []byte) bool {
-	return len(subj) > gwReplyStart && string(subj[:len(gwReplyPrefix)]) == gwReplyPrefix
+// Returns true if the given subject is a GW routed subject,
+// that is, starts with $GNR and is long enough to contain
+// cluster/server hash and subject.
+func isGWRoutedSubject(subj []byte) bool {
+	return len(subj) > gwSubjectOffset && subj[0] == '$' && subj[1] == 'G' &&
+		subj[2] == 'N' && subj[3] == 'R' && subj[4] == '.'
 }
 
-// Evaluates if the given reply should be mapped (adding the origin cluster
-// hash as a prefix) or not.
-func (g *srvGateway) shouldMapReplyForGatewaySend(c *client, reply []byte) bool {
+// Returns true if subject starts with "$GNR.". This is to check that
+// clients can't publish on this subject.
+func hasGWRoutedPrefix(subj []byte) bool {
+	return len(subj) > gwReplyPrefixLen && subj[0] == '$' && subj[1] == 'G' &&
+		subj[2] == 'N' && subj[3] == 'R' && subj[4] == '.'
+}
+
+// Evaluates if the given reply should be mapped or not.
+func (g *srvGateway) shouldMapReplyForGatewaySend(c *client, acc *Account, reply []byte) bool {
+	// If the reply is a service reply (_R_), we must map to make sure that
+	// it comes back to this server since the mapping back to the real reply
+	// can only be made here.
+	if isServiceReply(reply) {
+		return true
+	}
+	// If for this client there is a recent matching subscription interest
+	// then we will map.
 	sli, _ := g.rsubs.Load(c)
 	if sli == nil {
 		return false
 	}
 	sl := sli.(*Sublist)
-	if sl.Count() == 0 {
-		return false
+	if sl.Count() > 0 {
+		if r := sl.Match(string(reply)); len(r.psubs)+len(r.qsubs) > 0 {
+			return true
+		}
 	}
-	if subjectStartsWithGatewayReplyPrefix(reply) {
-		return false
-	}
-	r := sl.Match(string(reply))
-	return len(r.psubs)+len(r.qsubs) > 0
+	return false
 }
 
 var subPool = &sync.Pool{
@@ -2263,7 +2311,7 @@ func (c *client) sendMsgToGateways(acc *Account, msg, subject, reply []byte, qgr
 		accName    = acc.Name
 		mreplya    [256]byte
 		mreply     []byte
-		dstPfx     []byte
+		dstHash    []byte
 		checkReply = len(reply) > 0
 	)
 
@@ -2273,18 +2321,16 @@ func (c *client) sendMsgToGateways(acc *Account, msg, subject, reply []byte, qgr
 	// Make sure we are an 'R' proto
 	c.msgb[0] = 'R'
 
-	// Check if the subject is on "$GR.<cluster hash>.",
-	// and if so, send to that GW regardless of its
-	// interest on the real subject (that is, skip the
-	// check of subject interest).
-	if subjectStartsWithGatewayReplyPrefix(subject) {
-		dstPfx = subject[:gwReplyStart]
+	// Check if the subject is on the reply prefix, if so, we
+	// need to send that message directly to the origin cluster.
+	if isGWRoutedSubject(subject) {
+		dstHash = subject[gwClusterOffset : gwClusterOffset+gwHashLen]
 	}
 	for i := 0; i < len(gws); i++ {
 		gwc := gws[i]
-		if dstPfx != nil {
+		if dstHash != nil {
 			gwc.mu.Lock()
-			ok := gwc.gw.cfg != nil && bytes.Equal(dstPfx, gwc.gw.cfg.replyPfx)
+			ok := gwc.gw.cfg != nil && bytes.Equal(dstHash, gwc.gw.cfg.hash)
 			gwc.mu.Unlock()
 			if !ok {
 				continue
@@ -2325,9 +2371,8 @@ func (c *client) sendMsgToGateways(acc *Account, msg, subject, reply []byte, qgr
 			checkReply = false
 			// Assume we will use original
 			mreply = reply
-			// If there was a recent matching subscription on that connection
-			// and the reply is not already mapped, then map (add prefix).
-			if gw.shouldMapReplyForGatewaySend(c, reply) {
+			// Decide if we should map.
+			if gw.shouldMapReplyForGatewaySend(c, acc, reply) {
 				mreply = mreplya[:0]
 				mreply = append(mreply, thisClusterReplyPrefix...)
 				mreply = append(mreply, reply...)
@@ -2358,44 +2403,12 @@ func (c *client) sendMsgToGateways(acc *Account, msg, subject, reply []byte, qgr
 		// So set/reset important fields.
 		sub.nm, sub.max = 0, 0
 		sub.client = gwc
-		sub.subject = c.pa.subject
-		c.deliverMsg(sub, c.pa.subject, mh, msg)
+		sub.subject = subject
+		c.deliverMsg(sub, subject, mh, msg)
 	}
 	// Done with subscription, put back to pool. We don't need
 	// to reset content since we explicitly set when using it.
 	subPool.Put(sub)
-}
-
-func (s *Server) gatewayHandleServiceImport(acc *Account, subject []byte, c *client, change int32) {
-	sid := make([]byte, 0, len(acc.Name)+len(subject)+1)
-	sid = append(sid, acc.Name...)
-	sid = append(sid, ' ')
-	sid = append(sid, subject...)
-	sub := &subscription{client: c, subject: subject, sid: sid}
-
-	var rspa [1024]byte
-	rsproto := rspa[:0]
-	if change > 0 {
-		rsproto = append(rsproto, rSubBytes...)
-	} else {
-		rsproto = append(rsproto, rUnsubBytes...)
-	}
-	rsproto = append(rsproto, ' ')
-	rsproto = append(rsproto, sid...)
-	rsproto = append(rsproto, CR_LF...)
-
-	s.mu.Lock()
-	for _, r := range s.routes {
-		r.mu.Lock()
-		r.sendProto(rsproto, false)
-		if r.trace {
-			r.traceOutOp("", rsproto[:len(rsproto)-LEN_CR_LF])
-		}
-		r.mu.Unlock()
-	}
-	s.mu.Unlock()
-	// Possibly send RS+ to gateways too.
-	s.gatewayUpdateSubInterest(acc.Name, sub, change)
 }
 
 // Possibly sends an A- to the remote gateway `c`.
@@ -2501,15 +2514,125 @@ func (s *Server) gatewayHandleSubjectNoInterest(c *client, acc *Account, accName
 	}
 }
 
-func (g *srvGateway) getReplyPrefix() []byte {
+// Returns the cluster hash from the gateway reply prefix
+func (g *srvGateway) getClusterHash() []byte {
 	g.RLock()
-	replyPfx := g.replyPfx
+	clusterHash := g.replyPfx[gwClusterOffset : gwClusterOffset+gwHashLen]
 	g.RUnlock()
-	return replyPfx
+	return clusterHash
 }
 
-func (s *Server) isGatewayReplyForThisCluster(subj []byte) bool {
-	return string(s.gateway.getReplyPrefix()) == string(subj[:gwReplyStart])
+// Returns the route with given hash or nil if not found.
+func (s *Server) getRouteByHash(srvHash []byte) *client {
+	var route *client
+	if v, ok := s.routesByHash.Load(string(srvHash)); ok {
+		route = v.(*client)
+	}
+	return route
+}
+
+// Returns the subject from the routed reply
+func getSubjectFromGWRoutedReply(reply []byte) []byte {
+	return reply[gwSubjectOffset:]
+}
+
+// This should be invoked only from processInboundGatewayMsg() or
+// processInboundRoutedMsg() and is checking if the subject
+// (c.pa.subject) has the $GNR prefix. If so, this is processed
+// as a GW reply and `true` is returned to indicate to the caller
+// that it should stop processing.
+// If gateway is not enabled on this server or if the subject
+// does not start with $GR, `false` is returned and caller should
+// process message as usual.
+func (c *client) handleGatewayReply(msg []byte) (processed bool) {
+	// Do not handle GW prefixed messages if this server does not have
+	// gateway enabled or if the subject does not start with the previx.
+	if !c.srv.gateway.enabled || !isGWRoutedSubject(c.pa.subject) {
+		return false
+	}
+	// Save original subject (in case we have to forward)
+	orgSubject := c.pa.subject
+
+	clusterPrefix := c.pa.subject[gwClusterOffset : gwClusterOffset+gwHashLen]
+	srvHash := c.pa.subject[gwServerOffset : gwServerOffset+gwHashLen]
+	subject := c.pa.subject[gwSubjectOffset:]
+
+	// Check if this reply is intended for our cluster.
+	if !bytes.Equal(clusterPrefix, c.srv.gateway.getClusterHash()) {
+		// We could report, for now, just drop.
+		return true
+	}
+
+	var route *client
+
+	// If the origin is not this server, get the route this should be sent to.
+	if c.kind == GATEWAY && !bytes.Equal(srvHash, c.srv.hash) {
+		route = c.srv.getRouteByHash(srvHash)
+		// This will be possibly nil, and in this case we will try to process
+		// the interest from this server.
+	}
+
+	// Adjust the subject
+	c.pa.subject = subject
+
+	// Use a stack buffer to rewrite c.pa.cache since we only need it for
+	// getAccAndResultFromCache()
+	var _pacache [256]byte
+	pacache := _pacache[:0]
+	pacache = append(pacache, c.pa.account...)
+	pacache = append(pacache, ' ')
+	pacache = append(pacache, c.pa.subject...)
+	c.pa.pacache = pacache
+
+	acc, r := c.getAccAndResultFromCache()
+	if acc == nil {
+		typeConn := "routed"
+		if c.kind == GATEWAY {
+			typeConn = "gateway"
+		}
+		c.Debugf("Unknown account %q for %s message on subject: %q", c.pa.account, typeConn, c.pa.subject)
+		if c.kind == GATEWAY {
+			c.srv.gatewayHandleAccountNoInterest(c, c.pa.account)
+		}
+		return true
+	}
+	// If route is nil, we will process the incoming message locally.
+	if route == nil {
+		// Check if this is a service reply subject (_R_)
+		if acc.imports.services != nil && isServiceReply(c.pa.subject) {
+			// This will map the _R_ back to a real subject and get
+			// the interest for that subject and process the message.
+			c.checkForImportServices(acc, msg)
+			return true
+		}
+		var queues [][]byte
+		if len(r.psubs)+len(r.qsubs) > 0 {
+			flags := pmrCollectQueueNames | pmrIgnoreEmptyQueueFilter
+			// If this message came from a ROUTE, allow to pick queue subs
+			// only if the message was directly sent by the "gateway" server
+			// in our cluster that received it.
+			if c.kind == ROUTER {
+				flags |= pmrAllowSendFromRouteToRoute
+			}
+			queues = c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply, flags)
+		}
+		// Since this was a reply that made it to the origin cluster,
+		// we now need to send the message with the real subject to
+		// gateways in case they have interest on that reply subject.
+		c.sendMsgToGateways(acc, msg, c.pa.subject, c.pa.reply, queues)
+	} else if c.kind == GATEWAY {
+		// Only if we are a gateway connection should we try to route
+		// to the server where the request originated.
+		header := []byte(fmt.Sprintf("RMSG %s %s %s %v", acc.Name, orgSubject, c.pa.reply, len(msg)-LEN_CR_LF))
+		proto := []byte(fmt.Sprintf("%s\r\n%s", header, msg))
+		route.mu.Lock()
+		route.sendProto(proto, true)
+		if route.trace {
+			route.traceOutOp("", header)
+		}
+		route.mu.Unlock()
+	}
+	return true
 }
 
 // Process a message coming from a remote gateway. Send to any sub/qsub
@@ -2536,32 +2659,11 @@ func (c *client) processInboundGatewayMsg(msg []byte) {
 		return
 	}
 
-	// If we receive a message on $GR.<cluster>.<subj>
-	// we will drop the prefix before processing interest
-	// in this cluster, but we also need to resend to
-	// other gateways.
-	sendBackToGateways := false
-
-	// First thing to do is to check if the subject starts
-	// with "$GR.<hash>.".
-	if subjectStartsWithGatewayReplyPrefix(c.pa.subject) {
-		// If it does, then is this server/cluster the actual
-		// destination for this message?
-		if !c.srv.isGatewayReplyForThisCluster(c.pa.subject) {
-			// We could report, for now, just drop.
-			return
-		}
-		// Adjust the subject to past the prefix
-		c.pa.subject = c.pa.subject[gwReplyStart:]
-		// Use a stack buffer to rewrite c.pa.cache since we
-		// only need it for getAccAndResultFromCache()
-		var _pacache [256]byte
-		pacache := _pacache[:0]
-		pacache = append(pacache, c.pa.account...)
-		pacache = append(pacache, ' ')
-		pacache = append(pacache, c.pa.subject...)
-		c.pa.pacache = pacache
-		sendBackToGateways = true
+	// If the subject (c.pa.subject) has the gateway prefix, this function will
+	// handle it.
+	if c.handleGatewayReply(msg) {
+		// We are done here.
+		return
 	}
 
 	acc, r := c.getAccAndResultFromCache()
@@ -2571,36 +2673,18 @@ func (c *client) processInboundGatewayMsg(msg []byte) {
 		return
 	}
 
-	// Check to see if we need to map/route to another account.
-	if acc.imports.services != nil && isServiceReply(c.pa.subject) {
-		// We are handling a response to a request that we mapped
-		// via service imports, so if we are here we are the
-		// origin server
-		c.checkForImportServices(acc, msg)
-	}
+	// If there is no interest on plain subs, possibly send an RS-,
+	// even if there is qsubs interest.
+	if len(r.psubs) == 0 {
+		c.srv.gatewayHandleSubjectNoInterest(c, acc, c.pa.account, c.pa.subject)
 
-	if !sendBackToGateways {
-		// If there is no interest on plain subs, possibly send an RS-,
-		// even if there is qsubs interest.
-		if len(r.psubs) == 0 {
-			c.srv.gatewayHandleSubjectNoInterest(c, acc, c.pa.account, c.pa.subject)
-
-			// If there is also no queue filter, then no point in continuing
-			// (even if r.qsubs i > 0).
-			if len(c.pa.queues) == 0 {
-				return
-			}
+		// If there is also no queue filter, then no point in continuing
+		// (even if r.qsubs i > 0).
+		if len(c.pa.queues) == 0 {
+			return
 		}
-		c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply, pmrNoFlag)
-	} else {
-		// We normally would not allow sending to a queue unless the
-		// RMSG contains the queue groups, however, if the incoming
-		// message was a "$GR." then we need to act as if this was
-		// a CLIENT connection..
-		qnames := c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply,
-			pmrCollectQueueNames|pmrTreatGatewayAsClient)
-		c.sendMsgToGateways(c.acc, msg, c.pa.subject, c.pa.reply, qnames)
 	}
+	c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply, pmrNoFlag)
 }
 
 // Indicates that the remote which we are sending messages to
@@ -2735,5 +2819,72 @@ func (c *client) gatewaySwitchAccountToSendAllSubs(e *insie, accName string) {
 
 		c.Noticef("Gateway %q: switching account %q to %s mode complete",
 			remoteGWName, accName, InterestOnly)
+	})
+}
+
+type gwReplyMap struct {
+	c   *client
+	rs  string
+	ms  string
+	exp int64
+}
+
+func (s *Server) trackGWReply(c *client, rs, ms string) {
+	s.gwrmMu.Lock()
+	c.mu.Lock()
+	if c.gwrm == nil {
+		c.gwrm = make(map[string]*gwReplyMap)
+	}
+	now := time.Now()
+	grm := &gwReplyMap{c, rs, ms, now.Add(s.gateway.recSubExp).UnixNano()}
+	s.gwrm = append(s.gwrm, grm)
+	if len(s.gwrm) == 1 {
+		select {
+		case s.gwrmCh <- struct{}{}:
+		default:
+		}
+	}
+	c.gwrm[rs] = grm
+	c.mu.Unlock()
+	s.gwrmMu.Unlock()
+}
+
+func (s *Server) startGWReplyMappingExpiration() {
+	s.gwrmMu.Lock()
+	s.gwrmCh = make(chan struct{}, 1)
+	s.gwrmMu.Unlock()
+	s.startGoRoutine(func() {
+		defer s.grWG.Done()
+		t := time.NewTimer(time.Hour)
+		for {
+			select {
+			case <-s.gwrmCh:
+			case <-t.C:
+			case <-s.quitCh:
+				return
+			}
+			now := time.Now().UnixNano()
+			s.gwrmMu.Lock()
+			var i int
+			for i = 0; i < len(s.gwrm); i++ {
+				grm := s.gwrm[i]
+				if grm.exp < now {
+					c := grm.c
+					c.mu.Lock()
+					delete(c.gwrm, grm.rs)
+					c.mu.Unlock()
+				} else {
+					t.Reset(time.Duration(grm.exp - now))
+					break
+				}
+			}
+			if i == len(s.gwrm) {
+				s.gwrm = nil
+				t.Reset(time.Hour)
+			} else {
+				s.gwrm = s.gwrm[i:]
+			}
+			s.gwrmMu.Unlock()
+		}
 	})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -193,6 +193,13 @@ type Server struct {
 	// for the $GNR.*.*.*.> subject so that a server can send back a mapped
 	// gateway reply.
 	gwLeafSubs *Sublist
+
+	// Used for expiration of mapped GW replies
+	gwrm struct {
+		w  int32
+		ch chan time.Duration
+		m  sync.Map
+	}
 }
 
 // Make sure all are 64bits for atomic use
@@ -1095,6 +1102,10 @@ func (s *Server) Start() {
 			return
 		}
 	}
+
+	// Start expiration of mapped GW replies, regardless if
+	// this server is configured with gateway or not.
+	s.startGWReplyMapExpiration()
 
 	// Start up gateway if needed. Do this before starting the routes, because
 	// we want to resolve the gateway host:port so that this information can

--- a/server/server.go
+++ b/server/server.go
@@ -188,11 +188,6 @@ type Server struct {
 	// to know if it should update the cluster's URLs array.
 	varzUpdateRouteURLs bool
 
-	// Use for gateways reply mapping expiration
-	gwrmMu sync.Mutex
-	gwrmCh chan struct{}
-	gwrm   []*gwReplyMap
-
 	// Keeps a sublist of of subscriptions attached to leafnode connections
 	// for the $GNR.*.*.*.> subject so that a server can send back a mapped
 	// gateway reply.
@@ -1099,13 +1094,6 @@ func (s *Server) Start() {
 			return
 		}
 	}
-
-	// Start this even if this server has no gateway enabled in
-	// case it is part of a cluster and receives a message with
-	// mapped reply - note that this would still be considered
-	// misconfiguration since this server would not have any
-	// gateway connection...
-	s.startGWReplyMappingExpiration()
 
 	// Start up gateway if needed. Do this before starting the routes, because
 	// we want to resolve the gateway host:port so that this information can

--- a/server/server.go
+++ b/server/server.go
@@ -86,6 +86,7 @@ type Info struct {
 	GatewayURL        string   `json:"gateway_url,omitempty"`         // Gateway URL on that server (sent by route's INFO)
 	GatewayCmd        byte     `json:"gateway_cmd,omitempty"`         // Command code for the receiving server to know what to do
 	GatewayCmdPayload []byte   `json:"gateway_cmd_payload,omitempty"` // Command payload when needed
+	GatewayNRP        bool     `json:"gateway_nrp,omitempty"`         // Uses new $GNR. prefix for mapped replies
 
 	// LeafNode Specific
 	LeafNodeURLs []string `json:"leafnode_urls,omitempty"` // LeafNode URLs that the server can reconnect to.

--- a/server/split_test.go
+++ b/server/split_test.go
@@ -24,11 +24,10 @@ func TestSplitBufferSubOp(t *testing.T) {
 	defer cli.Close()
 	defer trash.Close()
 
-	gws, err := newGateway(DefaultOptions())
-	if err != nil {
+	s := &Server{gacc: NewAccount(globalAccountName)}
+	if err := s.newGateway(DefaultOptions()); err != nil {
 		t.Fatalf("Error creating gateways: %v", err)
 	}
-	s := &Server{gacc: NewAccount(globalAccountName), gateway: gws}
 	s.registerAccount(s.gacc)
 	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription), nc: cli}
 

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -1252,9 +1252,6 @@ func gatewaySendRequestsBench(b *testing.B, singleReplySub bool) {
 
 	lenMsg := len("MSG foo reply.xxxxxxxxxx 1 2\r\nok\r\n")
 	expected := b.N * lenMsg
-	if !singleReplySub {
-		expected += b.N * len("$GR.1234.")
-	}
 	ch := make(chan bool, 1)
 	go drainConnection(b, sub, ch, expected)
 
@@ -1275,9 +1272,9 @@ func gatewaySendRequestsBench(b *testing.B, singleReplySub bool) {
 	numBytes += len("RMSG $G foo reply.0123456789 2\r\nok\r\n")
 	// If mapping of reply...
 	if !singleReplySub {
-		// the mapping uses about 10 more bytes. So add them
-		// for RMSG from server to server, and MSG to sub.
-		numBytes += 20
+		// the mapping uses about 24 more bytes. So add them
+		// for RMSG from server to server.
+		numBytes += 24
 	}
 	// From server in cluster B to sub
 	numBytes += lenMsg

--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -451,6 +451,7 @@ func TestServiceLatencyWithNameMultiServer(t *testing.T) {
 
 	// Listen for metrics
 	rsub, _ := nc.SubscribeSync("results")
+	nc.Flush()
 
 	nc2 := clientConnect(t, sc.clusters[1].opts[1], "bar")
 	defer nc2.Close()


### PR DESCRIPTION
- New prefix that includes origin server for the request
- Mapping done if request is service import or requestor has
  recent subscription
- Subscription considered recent if less than 250ms
- Destination server strip GW prefix before giving to client
  and restore when getting a reply on that subject
- Mapping removed aftert 250ms
- Server rejects client publish on "$GNR." (the new prefix)
- Cluster and server hash are now 8 chars long and from base 62
  alphabets
- Mapped replies need to be sent to leafnode servers due to race
  (cluster B sends RS+ on GW inbound then RMSG on outbound, the
  RS+ may be processed later and cluster A may have given message
  to LN before RS+ on reply subject. So LN needs to accept the
  mapped reply but will strip to give to client and reassemble
  before sending it back)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>