### PR TITLE
Fix possible panic on nil sublist.

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1857,6 +1857,10 @@ func (s *Server) updateAccountClaims(a *Account, ac *jwt.AccountClaims) {
 func (s *Server) buildInternalAccount(ac *jwt.AccountClaims) *Account {
 	acc := NewAccount(ac.Subject)
 	acc.Issuer = ac.Issuer
+	// Set this here since we are placing in s.tmpAccounts below and may be
+	// referenced by an route RS+, etc.
+	s.setAccountSublist(acc)
+
 	// We don't want to register an account that is in the process of
 	// being built, however, to solve circular import dependencies, we
 	// need to store it here.

--- a/server/server.go
+++ b/server/server.go
@@ -847,10 +847,9 @@ func (s *Server) registerAccount(acc *Account) {
 	s.mu.Unlock()
 }
 
-// Place common account setup here.
-// Lock should be held on entry.
-func (s *Server) registerAccountNoLock(acc *Account) {
-	if acc.sl == nil {
+// Helper to set the sublist based on preferences.
+func (s *Server) setAccountSublist(acc *Account) {
+	if acc != nil && acc.sl == nil {
 		opts := s.getOpts()
 		if opts != nil && opts.NoSublistCache {
 			acc.sl = NewSublistNoCache()
@@ -858,6 +857,12 @@ func (s *Server) registerAccountNoLock(acc *Account) {
 			acc.sl = NewSublistWithCache()
 		}
 	}
+}
+
+// Place common account setup here.
+// Lock should be held on entry.
+func (s *Server) registerAccountNoLock(acc *Account) {
+	s.setAccountSublist(acc)
 	if acc.maxnae == 0 {
 		acc.maxnae = DEFAULT_MAX_ACCOUNT_AE_RESPONSE_MAPS
 	}


### PR DESCRIPTION
We may have the case that the account is held in tmpAccounts but does not have a sublist. When this happens if we process as RS+ and do LookupAccount and get it from the tmpAccount and before it was registered the route code could try to do an insert on the sublist.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
