### PR TITLE
Introduced wildcard handling of _R_ mapped replies. 

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -60,13 +60,16 @@ type Account struct {
 	imports      importMap
 	exports      exportMap
 	limits
-	nae         int32
-	pruning     bool
-	rmPruning   bool
-	expired     bool
-	signingKeys []string
-	srv         *Server // server this account is registered with (possibly nil)
-	lds         string  // loop detection subject for leaf nodes
+	nae           int32
+	pruning       bool
+	rmPruning     bool
+	expired       bool
+	signingKeys   []string
+	srv           *Server // server this account is registered with (possibly nil)
+	lds           string  // loop detection subject for leaf nodes
+	siReply       []byte  // service reply prefix, will form wildcard subscription.
+	siReplyClient *client
+	prand         *rand.Rand
 }
 
 // Account based limits.
@@ -987,12 +990,105 @@ func shouldSample(l *serviceLatency) bool {
 	return rand.Int31n(100) <= int32(l.sampling)
 }
 
+// Used to mimic client like replies.
+const (
+	replyPrefix    = "_R_."
+	trackSuffix    = ".T"
+	replyPrefixLen = len(replyPrefix)
+	baseServerLen  = 10
+	replyLen       = 6
+	minReplyLen    = 15
+	digits         = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	base           = 62
+)
+
+// Will create a wildcard subscription to handle interest graph propagation for all
+// service replies.
+// Lock should not be held.
+func (a *Account) createRespWildcard() []byte {
+	a.mu.Lock()
+	if a.prand == nil {
+		a.prand = rand.New(rand.NewSource(time.Now().UnixNano()))
+	}
+	var b = [baseServerLen]byte{'_', 'R', '_', '.'}
+	rn := a.prand.Int63()
+	for i, l := replyPrefixLen, rn; i < len(b); i++ {
+		b[i] = digits[l%base]
+		l /= base
+	}
+	a.siReply = append(b[:], '.')
+	s := a.srv
+	aName := a.Name
+	pre := a.siReply
+	wcsub := append(a.siReply, '>')
+	a.mu.Unlock()
+
+	// Check to see if we need to propagate interest.
+	if s != nil {
+		now := time.Now()
+		c := &client{srv: a.srv, acc: a, kind: SYSTEM, opts: internalOpts, msubs: -1, mpay: -1, start: now, last: now}
+		sub := &subscription{client: c, subject: wcsub}
+		s.updateRouteSubscriptionMap(a, sub, 1)
+		if s.gateway.enabled {
+			s.gatewayUpdateSubInterest(aName, sub, 1)
+			a.mu.Lock()
+			a.siReplyClient = c
+			a.mu.Unlock()
+		}
+	}
+
+	return pre
+}
+
+func (a *Account) replyClient() *client {
+	a.mu.RLock()
+	c := a.siReplyClient
+	a.mu.RUnlock()
+	return c
+}
+
+// Test whether this is a tracked reply.
+func isTrackedReply(reply []byte) bool {
+	lreply := len(reply) - 1
+	return lreply > 3 && reply[lreply-1] == '.' && reply[lreply] == 'T'
+}
+
+// Generate a new service reply from the wildcard prefix.
+// FIXME(dlc) - probably do not have to use rand here. about 25ns per.
+func (a *Account) newServiceReply(tracking bool) []byte {
+	a.mu.RLock()
+	replyPre := a.siReply
+	s := a.srv
+	a.mu.RUnlock()
+
+	if replyPre == nil {
+		replyPre = a.createRespWildcard()
+	}
+
+	var b [replyLen]byte
+	rn := a.prand.Int63()
+	for i, l := 0, rn; i < len(b); i++ {
+		b[i] = digits[l%base]
+		l /= base
+	}
+	reply := append(replyPre, b[:]...)
+	if tracking && s.sys != nil {
+		// Add in our tracking identifier. This allows the metrics to get back to only
+		// this server without needless SUBS/UNSUBS.
+		reply = append(reply, '.')
+		reply = append(reply, s.sys.shash...)
+		reply = append(reply, '.', 'T')
+	}
+	return reply
+}
+
 // This is for internal responses.
 func (a *Account) addRespServiceImport(dest *Account, from, to string, rt ServiceRespType, lat *serviceLatency) *serviceImport {
 	a.mu.Lock()
 	if a.imports.services == nil {
 		a.imports.services = make(map[string]*serviceImport)
 	}
+	// dest is the requestor's account. a is the service responder with the export.
 	ae := rt == Singleton
 	si := &serviceImport{dest, nil, from, to, 0, rt, nil, nil, ae, true, false, false}
 	a.imports.services[from] = si

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -446,6 +446,9 @@ func (a *Account) removeClient(c *client) int {
 
 func (a *Account) randomClient() *client {
 	var c *client
+	if a.siReplyClient != nil {
+		return a.siReplyClient
+	}
 	for _, c = range a.clients {
 		break
 	}

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1071,7 +1071,11 @@ func (a *Account) newServiceReply(tracking bool) []byte {
 		b[i] = digits[l%base]
 		l /= base
 	}
-	reply := append(replyPre, b[:]...)
+	// Make sure to copy.
+	reply := make([]byte, 0, len(replyPre)+len(b))
+	reply = append(reply, replyPre...)
+	reply = append(reply, b[:]...)
+
 	if tracking && s.sys != nil {
 		// Add in our tracking identifier. This allows the metrics to get back to only
 		// this server without needless SUBS/UNSUBS.

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -2169,9 +2169,9 @@ func TestAccountDuplicateServiceImportSubject(t *testing.T) {
 func BenchmarkNewRouteReply(b *testing.B) {
 	opts := defaultServerOptions
 	s := New(&opts)
-	c, _, _ := newClientForServer(s)
+	g := s.globalAccount()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.newServiceReply(false)
+		g.newServiceReply(false)
 	}
 }

--- a/server/events.go
+++ b/server/events.go
@@ -16,6 +16,7 @@ package server
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -491,7 +492,7 @@ func (s *Server) startRemoteServerSweepTimer() {
 }
 
 // Length of our system hash used for server targeted messages.
-const sysHashLen = 4
+const sysHashLen = 6
 
 // This will setup our system wide tracking subs.
 // For now we will setup one wildcard subscription to
@@ -503,11 +504,10 @@ func (s *Server) initEventTracking() {
 	if !s.eventsEnabled() {
 		return
 	}
-	// Create a system hash which we use for other servers to target us
-	// specifically.
+	// Create a system hash which we use for other servers to target us specifically.
 	sha := sha256.New()
 	sha.Write([]byte(s.info.ID))
-	s.sys.shash = fmt.Sprintf("%x", sha.Sum(nil))[:sysHashLen]
+	s.sys.shash = base64.RawURLEncoding.EncodeToString(sha.Sum(nil))[:sysHashLen]
 
 	// This will be for all inbox responses.
 	subject := fmt.Sprintf(inboxRespSubj, s.sys.shash, "*")

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -33,7 +33,7 @@ const (
 	defaultSolicitGatewaysDelay         = time.Second
 	defaultGatewayConnectDelay          = time.Second
 	defaultGatewayReconnectDelay        = time.Second
-	defaultGatewayRecentSubExpiration   = 5 * time.Second
+	defaultGatewayRecentSubExpiration   = 250 * time.Millisecond
 	defaultGatewayMaxRUnsubBeforeSwitch = 1000
 
 	oldGWReplyPrefix    = "$GR."
@@ -2297,11 +2297,11 @@ func hasGWRoutedReplyPrefix(subj []byte) bool {
 
 // Evaluates if the given reply should be mapped or not.
 func (g *srvGateway) shouldMapReplyForGatewaySend(c *client, acc *Account, reply []byte) bool {
-	// If the reply is a service reply (_R_), we must map to make sure that
-	// it comes back to this server since the mapping back to the real reply
-	// can only be made here.
+	// If the reply is a service reply (_R_), we will use the replyClient
+	// instead of the client handed to us. This client holds the wildcard
+	// for all service replies.
 	if isServiceReply(reply) {
-		return true
+		c = acc.replyClient()
 	}
 	// If for this client there is a recent matching subscription interest
 	// then we will map.

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -40,13 +40,12 @@ const (
 	oldGWReplyPrefixLen = len(oldGWReplyPrefix)
 	oldGWReplyStart     = oldGWReplyPrefixLen + 5 // len of prefix above + len of hash (4) + "."
 
-	// The new prefix is "$GNR.<x>.<cluster>.<server>." where <x> is 1 character
-	// reserved for service imports, <cluster> is 8 characters hash of origin
-	// cluster name and <server> is 8 characters hash of origin server pub key.
-	gwReplyPrefix    = "$GNR."
+	// The new prefix is "_GR_.<cluster>.<server>." where <cluster> is 8 characters
+	// hash of origin cluster name and <server> is 8 characters hash of origin server pub key.
+	gwReplyPrefix    = "_GR_."
 	gwReplyPrefixLen = len(gwReplyPrefix)
-	gwHashLen        = 8
-	gwClusterOffset  = gwReplyPrefixLen + 2
+	gwHashLen        = 6
+	gwClusterOffset  = gwReplyPrefixLen
 	gwServerOffset   = gwClusterOffset + gwHashLen + 1
 	gwSubjectOffset  = gwServerOffset + gwHashLen + 1
 )
@@ -311,7 +310,6 @@ func (s *Server) newGateway(opts *Options) error {
 	clusterHash := getHash(opts.Gateway.Name)
 	prefix := make([]byte, 0, gwSubjectOffset)
 	prefix = append(prefix, gwReplyPrefix...)
-	prefix = append(prefix, '_', '.')
 	prefix = append(prefix, clusterHash...)
 	prefix = append(prefix, '.')
 	prefix = append(prefix, s.hash...)

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -2766,9 +2766,15 @@ func (c *client) processInboundGatewayMsg(msg []byte) {
 		return
 	}
 
-	// If there is no interest on plain subs, possibly send an RS-,
-	// even if there is qsubs interest.
-	if len(r.psubs) == 0 {
+	// Check if this is a service reply subject (_R_)
+	checkNoInterest := true
+	if acc.imports.services != nil && isServiceReply(c.pa.subject) {
+		c.checkForImportServices(acc, msg)
+		checkNoInterest = false
+	}
+	if checkNoInterest && len(r.psubs) == 0 {
+		// If there is no interest on plain subs, possibly send an RS-,
+		// even if there is qsubs interest.
 		c.srv.gatewayHandleSubjectNoInterest(c, acc, c.pa.account, c.pa.subject)
 
 		// If there is also no queue filter, then no point in continuing

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -40,8 +40,8 @@ const (
 	oldGWReplyPrefixLen = len(oldGWReplyPrefix)
 	oldGWReplyStart     = oldGWReplyPrefixLen + 5 // len of prefix above + len of hash (4) + "."
 
-	// The new prefix is "_GR_.<cluster>.<server>." where <cluster> is 8 characters
-	// hash of origin cluster name and <server> is 8 characters hash of origin server pub key.
+	// The new prefix is "_GR_.<cluster>.<server>." where <cluster> is 6 characters
+	// hash of origin cluster name and <server> is 6 characters hash of origin server pub key.
 	gwReplyPrefix    = "_GR_."
 	gwReplyPrefixLen = len(gwReplyPrefix)
 	gwHashLen        = 6

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -4077,7 +4077,7 @@ func TestGatewayServiceImportComplexSetup(t *testing.T) {
 	checkSubs(t, barA2, "A2", 0)
 	checkSubs(t, fooB1, "B1", 0)
 	checkSubs(t, barB1, "B1", 1)
-	checkSubs(t, fooB2, "B2", 0)
+	checkSubs(t, fooB2, "B2", 1)
 	checkSubs(t, barB2, "B2", 1)
 
 	// Speed up exiration
@@ -4116,7 +4116,7 @@ func TestGatewayServiceImportComplexSetup(t *testing.T) {
 	checkSubs(t, fooA1, "A1", 0)
 	checkSubs(t, fooA2, "A2", 0)
 	checkSubs(t, fooB1, "B1", 0)
-	checkSubs(t, fooB2, "B2", 0)
+	checkSubs(t, fooB2, "B2", 1)
 
 	checkSubs(t, barA1, "A1", 0)
 	checkSubs(t, barA2, "A2", 0)
@@ -4457,7 +4457,7 @@ func TestGatewayServiceExportWithWildcards(t *testing.T) {
 			checkSubs(t, barA2, "A2", 0)
 			checkSubs(t, fooB1, "B1", 0)
 			checkSubs(t, barB1, "B1", 1)
-			checkSubs(t, fooB2, "B2", 0)
+			checkSubs(t, fooB2, "B2", 1)
 			checkSubs(t, barB2, "B2", 1)
 
 			// Speed up exiration
@@ -4496,7 +4496,7 @@ func TestGatewayServiceExportWithWildcards(t *testing.T) {
 			checkSubs(t, fooA1, "A1", 0)
 			checkSubs(t, fooA2, "A2", 0)
 			checkSubs(t, fooB1, "B1", 0)
-			checkSubs(t, fooB2, "B2", 0)
+			checkSubs(t, fooB2, "B2", 1)
 
 			checkSubs(t, barA1, "A1", 0)
 			checkSubs(t, barA2, "A2", 0)

--- a/server/server.go
+++ b/server/server.go
@@ -785,9 +785,10 @@ func (s *Server) setSystemAccount(acc *Account) error {
 	}
 	acc.mu.Unlock()
 
+	now := time.Now()
 	s.sys = &internal{
 		account: acc,
-		client:  &client{srv: s, kind: SYSTEM, opts: internalOpts, msubs: -1, mpay: -1, start: time.Now(), last: time.Now()},
+		client:  &client{srv: s, kind: SYSTEM, opts: internalOpts, msubs: -1, mpay: -1, start: now, last: now},
 		seq:     1,
 		sid:     1,
 		servers: make(map[string]*serverUpdate),

--- a/test/new_routes_test.go
+++ b/test/new_routes_test.go
@@ -1170,7 +1170,7 @@ func TestNewRouteReservedReply(t *testing.T) {
 
 func TestNewRouteServiceImport(t *testing.T) {
 	// To quickly enable trace and debug logging
-	// doLog, doTrace, doDebug = true, true, true
+	//doLog, doTrace, doDebug = true, true, true
 	srvA, srvB, optsA, optsB := runServers(t)
 	defer srvA.Shutdown()
 	defer srvB.Shutdown()
@@ -1237,8 +1237,9 @@ func TestNewRouteServiceImport(t *testing.T) {
 	matches = expectMsgsB(1)
 	checkMsg(t, matches[0], "reply", "1", "", "2", "ok")
 
-	if ts := fooA.TotalSubs(); ts != 1 {
-		t.Fatalf("Expected one sub to be left on fooA, but got %d", ts)
+	// This will be the responder and the wildcard for all service replies.
+	if ts := fooA.TotalSubs(); ts != 2 {
+		t.Fatalf("Expected two subs to be left on fooA, but got %d", ts)
 	}
 
 	routez, _ := srvA.Routez(&server.RoutezOptions{Subscriptions: true})
@@ -1246,8 +1247,8 @@ func TestNewRouteServiceImport(t *testing.T) {
 	if r == nil {
 		t.Fatalf("Expected 1 route, got none")
 	}
-	if r.NumSubs != 1 {
-		t.Fatalf("Expected 1 sub in the route connection, got %v", r.NumSubs)
+	if r.NumSubs != 2 {
+		t.Fatalf("Expected 2 subs in the route connection, got %v", r.NumSubs)
 	}
 }
 
@@ -1332,8 +1333,8 @@ func TestNewRouteServiceExportWithWildcards(t *testing.T) {
 			matches = expectMsgsB(1)
 			checkMsg(t, matches[0], "reply", "1", "", "2", "ok")
 
-			if ts := fooA.TotalSubs(); ts != 1 {
-				t.Fatalf("Expected one sub to be left on fooA, but got %d", ts)
+			if ts := fooA.TotalSubs(); ts != 2 {
+				t.Fatalf("Expected two subs to be left on fooA, but got %d", ts)
 			}
 
 			routez, _ := srvA.Routez(&server.RoutezOptions{Subscriptions: true})
@@ -1341,8 +1342,8 @@ func TestNewRouteServiceExportWithWildcards(t *testing.T) {
 			if r == nil {
 				t.Fatalf("Expected 1 route, got none")
 			}
-			if r.NumSubs != 1 {
-				t.Fatalf("Expected 1 sub in the route connection, got %v", r.NumSubs)
+			if r.NumSubs != 2 {
+				t.Fatalf("Expected 2 subs in the route connection, got %v", r.NumSubs)
 			}
 		})
 	}
@@ -1407,8 +1408,8 @@ func TestNewRouteServiceImportQueueGroups(t *testing.T) {
 	matches = expectMsgsB(1)
 	checkMsg(t, matches[0], "reply", "1", "", "2", "ok")
 
-	if ts := fooA.TotalSubs(); ts != 1 {
-		t.Fatalf("Expected one sub to be left on fooA, but got %d", ts)
+	if ts := fooA.TotalSubs(); ts != 2 {
+		t.Fatalf("Expected two subs to be left on fooA, but got %d", ts)
 	}
 
 	routez, _ := srvA.Routez(&server.RoutezOptions{Subscriptions: true})
@@ -1416,8 +1417,8 @@ func TestNewRouteServiceImportQueueGroups(t *testing.T) {
 	if r == nil {
 		t.Fatalf("Expected 1 route, got none")
 	}
-	if r.NumSubs != 1 {
-		t.Fatalf("Expected 1 sub in the route connection, got %v", r.NumSubs)
+	if r.NumSubs != 2 {
+		t.Fatalf("Expected 2 subs in the route connection, got %v", r.NumSubs)
 	}
 }
 
@@ -1490,8 +1491,8 @@ func TestNewRouteServiceImportDanglingRemoteSubs(t *testing.T) {
 	expectA(pongRe)
 
 	checkFor(t, time.Second, 10*time.Millisecond, func() error {
-		if ts := fooA.TotalSubs(); ts != 0 {
-			return fmt.Errorf("Number of subs is %d, should be zero", ts)
+		if ts := fooA.TotalSubs(); ts != 1 {
+			return fmt.Errorf("Number of subs is %d, should be only 1", ts)
 		}
 		return nil
 	})

--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -439,6 +439,10 @@ func TestServiceLatencyNoSubsLeak(t *testing.T) {
 		nc.Close()
 	}
 
+	// We are adding 2 here for the wildcard response subject for service replies.
+	// we only have one but it will show in two places.
+	startSubs += 2
+
 	checkFor(t, time.Second, 50*time.Millisecond, func() error {
 		if numSubs := sc.totalSubs(); numSubs != startSubs {
 			return fmt.Errorf("Leaked %d subs", numSubs-startSubs)


### PR DESCRIPTION
We had too much special processing, so reduced to a single wildcard which will propagate across routes and gateways and is consistent with gateway handling of globally routed subjects and timeouts.

Signed-off-by: Derek Collison derek@nats.io

/cc @nats-io/core
