### PR TITLE
Do not fetch accounts on system events.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -699,6 +699,11 @@ func (s *Server) numAccounts() int {
 	return count
 }
 
+// NumLoadedAccounts returns the number of loaded accounts.
+func (s *Server) NumLoadedAccounts() int {
+	return s.numAccounts()
+}
+
 // LookupOrRegisterAccount will return the given account if known or create a new entry.
 func (s *Server) LookupOrRegisterAccount(name string) (account *Account, isNew bool) {
 	if v, ok := s.accounts.Load(name); ok {


### PR DESCRIPTION
Noticed we would lookup accounts, but would also fetch them when tracking remote connections, etc.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
