### PR TITLE
Added split test buffer that shows the subject overwritte

### DIFF
--- a/server/parser.go
+++ b/server/parser.go
@@ -282,7 +282,7 @@ func (c *client) parse(buf []byte) error {
 			c.drop, c.as, c.state = 0, i+1, OP_START
 			// Drop all pub args
 			c.pa.arg, c.pa.pacache, c.pa.account, c.pa.subject = nil, nil, nil, nil
-			c.pa.reply, c.pa.szb, c.pa.queues = nil, nil, nil
+			c.pa.reply, c.pa.size, c.pa.szb, c.pa.queues = nil, 0, nil, nil
 		case OP_A:
 			switch b {
 			case '+':


### PR DESCRIPTION
With this test, and with previous cloneArg() code, the parsing
will cause subject to become "fff" because c.pa.subject points
to somewhere in the underlying buffer that is now overwritten
with the body payload. With proper cloneArg(), the c.pa.subject
(and other) point to the copy of argBuf.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
