### PR TITLE
add long version to toggle on jetstream

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -2963,6 +2963,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.StringVar(&opts.TLSCaCert, "tlscacert", "", "Client certificate CA for verification.")
 	fs.IntVar(&opts.MaxTracedMsgLen, "max_traced_msg_len", 0, "Maximum printable length for traced messages. 0 for unlimited.")
 	fs.BoolVar(&opts.JetStream, "js", false, "Enable JetStream.")
+	fs.BoolVar(&opts.JetStream, "jetstream", false, "Enable JetStream.")
 
 	// The flags definition above set "default" values to some of the options.
 	// Calling Parse() here will override the default options with any value


### PR DESCRIPTION
According to the help it should be possible to use --jetstream command line option.

/cc @nats-io/core
