### PR TITLE
[FIXED] Closing of Gateway or Route TLS connection may hang

### DIFF
--- a/server/client_test.go
+++ b/server/client_test.go
@@ -998,7 +998,7 @@ func TestUnsubRace(t *testing.T) {
 	wg.Wait()
 }
 
-func TestTLSCloseClientConnection(t *testing.T) {
+func TestClientCloseTLSConnection(t *testing.T) {
 	opts, err := ProcessConfigFile("./configs/tls.conf")
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -1065,12 +1065,13 @@ func TestTLSCloseClientConnection(t *testing.T) {
 		t.Error("RemoteAddress() returned incorrect ip " + addr.String())
 	}
 
-	// Fill the buffer. Need to send 1 byte at a time so that we timeout here
-	// the nc.Close() would block due to a write that can not complete.
+	// Fill the buffer. We want to timeout on write so that nc.Close()
+	// would block due to a write that cannot complete.
+	buf := make([]byte, 64*1024)
 	done := false
 	for !done {
 		cli.nc.SetWriteDeadline(time.Now().Add(time.Second))
-		if _, err := cli.nc.Write([]byte("a")); err != nil {
+		if _, err := cli.nc.Write(buf); err != nil {
 			done = true
 		}
 		cli.nc.SetWriteDeadline(time.Time{})

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -789,6 +789,9 @@ func (s *Server) createGateway(cfg *gatewayCfg, url *url.URL, conn net.Conn) {
 		// Re-Grab lock
 		c.mu.Lock()
 
+		// To be consistent with client, set this flag to indicate that handshake is done
+		c.flags.set(handshakeComplete)
+
 		// Verify that the connection did not go away while we released the lock.
 		if c.nc == nil {
 			c.mu.Unlock()

--- a/server/route.go
+++ b/server/route.go
@@ -1113,6 +1113,9 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 		// Re-Grab lock
 		c.mu.Lock()
 
+		// To be consistent with client, set this flag to indicate that handshake is done
+		c.flags.set(handshakeComplete)
+
 		// Verify that the connection did not go away while we released the lock.
 		if c.nc == nil {
 			c.mu.Unlock()


### PR DESCRIPTION
This could happen if the remote server is running but not dequeueing
from the socket. TLS connection Close() may send/read and so we
need to protect with a deadline.

For non client/leaf connection, do not call flushOutbound().
Set the write deadline regardless of handshakeComplete flag, and
set it to a low value.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
