### PR TITLE
Fixes for system events

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3244,8 +3244,8 @@ func (c *client) clearConnection(reason ClosedState) {
 		c.out.stc = nil
 	}
 
-	// Flush any pending (do this for clients and leaf only)
-	if c.kind == CLIENT || c.kind == LEAF {
+	// Flush any pending (do this for clients, leaf and system only)
+	if c.kind == CLIENT || c.kind == LEAF || c.kind == SYSTEM {
 		c.flushOutbound()
 	}
 

--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.1.3-RC01"
+	VERSION = "2.1.3-RC02"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original


### PR DESCRIPTION
- Call flushOutbound() for SYSTEM connections
- Flush in place in internalSendLoop when sending the shutdown event
- Fix some tests:
  - missing defer client connection Close()
  - ensure subs are registered and messages received before shutdown
    of leafnode server to check disconnected event's stats.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
