### PR TITLE
Refactor async client tests

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3440,7 +3440,7 @@ func (c *client) closeConnection(reason ClosedState) {
 	c.mu.Unlock()
 
 	// Remove client's or leaf node subscriptions.
-	if kind == CLIENT || kind == LEAF && acc != nil {
+	if (kind == CLIENT || kind == LEAF) && acc != nil {
 		acc.sl.RemoveBatch(subs)
 	} else if kind == ROUTER {
 		go c.removeRemoteSubs()

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1436,7 +1436,8 @@ func TestGatewayNameClientInfo(t *testing.T) {
 	defer sa.Shutdown()
 	defer sb.Shutdown()
 
-	_, _, l := newClientForServer(sa)
+	c, _, l := newClientForServer(sa)
+	defer c.close()
 
 	var info Info
 	err := json.Unmarshal([]byte(l[5:]), &info)

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -201,6 +201,7 @@ func TestNoPasswordsFromConnectTrace(t *testing.T) {
 	defer s.SetLogger(nil, false, false)
 
 	c, _, _ := newClientForServer(s)
+	defer c.close()
 
 	connectOp := []byte("CONNECT {\"user\":\"derek\",\"pass\":\"s3cr3t\"}\r\n")
 	err := c.parse(connectOp)

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1425,6 +1425,7 @@ func TestHandleRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("Expected a %d response, got %d\n", http.StatusOK, resp.StatusCode)
 	}
@@ -1443,7 +1444,6 @@ func TestHandleRoot(t *testing.T) {
 	if !strings.Contains(ct, "text/html") {
 		t.Fatalf("Expected text/html response, got %s\n", ct)
 	}
-	defer resp.Body.Close()
 }
 
 func TestConnzWithNamedClient(t *testing.T) {
@@ -1748,6 +1748,7 @@ func TestConcurrentMonitoring(t *testing.T) {
 					ech <- fmt.Sprintf("Expected no error: Got %v\n", err)
 					return
 				}
+				defer resp.Body.Close()
 				if resp.StatusCode != http.StatusOK {
 					ech <- fmt.Sprintf("Expected a %v response, got %d\n", http.StatusOK, resp.StatusCode)
 					return
@@ -1757,7 +1758,6 @@ func TestConcurrentMonitoring(t *testing.T) {
 					ech <- fmt.Sprintf("Expected application/json content-type, got %s\n", ct)
 					return
 				}
-				defer resp.Body.Close()
 				if _, err := ioutil.ReadAll(resp.Body); err != nil {
 					ech <- fmt.Sprintf("Got an error reading the body: %v\n", err)
 					return
@@ -2091,6 +2091,7 @@ func Benchmark_VarzHttp(b *testing.B) {
 		if err != nil {
 			b.Fatalf("Expected no error: Got %v\n", err)
 		}
+		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			b.Fatalf("Got an error reading the body: %v\n", err)
@@ -2665,6 +2666,7 @@ func TestMonitorGatewayz(t *testing.T) {
 	ob2 := testDefaultOptionsForGateway("B")
 	ob2.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", sb1.ClusterAddr().Port))
 	sb2 := runGatewayServer(ob2)
+	defer sb2.Shutdown()
 
 	// Wait for sb1 and sb2 to connect
 	checkClusterFormed(t, sb1, sb2)

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -2737,6 +2737,7 @@ func TestConfigReloadAccountNKeyUsers(t *testing.T) {
 	pubKey, _ := kp.PublicKey()
 
 	c, cr, l := newClientForServer(s)
+	defer c.close()
 	// Check for Nonce
 	var info nonceInfo
 	if err := json.Unmarshal([]byte(l[5:]), &info); err != nil {
@@ -2753,7 +2754,7 @@ func TestConfigReloadAccountNKeyUsers(t *testing.T) {
 
 	// PING needed to flush the +OK to us.
 	cs := fmt.Sprintf("CONNECT {\"nkey\":%q,\"sig\":\"%s\",\"verbose\":true,\"pedantic\":true}\r\nPING\r\n", pubKey, sig)
-	go c.parse([]byte(cs))
+	c.parseAsync(cs)
 	l, _ = cr.ReadString('\n')
 	if !strings.HasPrefix(l, "+OK") {
 		t.Fatalf("Expected an OK, got: %v", l)
@@ -2767,6 +2768,7 @@ func TestConfigReloadAccountNKeyUsers(t *testing.T) {
 	pubKey, _ = kp.PublicKey()
 
 	c, cr, l = newClientForServer(s)
+	defer c.close()
 	// Check for Nonce
 	err = json.Unmarshal([]byte(l[5:]), &info)
 	if err != nil {
@@ -2783,7 +2785,7 @@ func TestConfigReloadAccountNKeyUsers(t *testing.T) {
 
 	// PING needed to flush the +OK to us.
 	cs = fmt.Sprintf("CONNECT {\"nkey\":%q,\"sig\":\"%s\",\"verbose\":true,\"pedantic\":true}\r\nPING\r\n", pubKey, sig)
-	go c.parse([]byte(cs))
+	c.parseAsync(cs)
 	l, _ = cr.ReadString('\n')
 	if !strings.HasPrefix(l, "+OK") {
 		t.Fatalf("Expected an OK, got: %v", l)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -491,55 +491,6 @@ func TestProcessCommandLineArgs(t *testing.T) {
 	}
 }
 
-func TestWriteDeadline(t *testing.T) {
-	opts := DefaultOptions()
-	opts.WriteDeadline = 30 * time.Millisecond
-	s := RunServer(opts)
-	defer s.Shutdown()
-
-	c, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", opts.Host, opts.Port), 3*time.Second)
-	if err != nil {
-		t.Fatalf("Error on connect: %v", err)
-	}
-	defer c.Close()
-	if _, err := c.Write([]byte("CONNECT {}\r\nPING\r\nSUB foo 1\r\n")); err != nil {
-		t.Fatalf("Error sending protocols to server: %v", err)
-	}
-	// Reduce socket buffer to increase reliability of getting
-	// write deadline errors.
-	c.(*net.TCPConn).SetReadBuffer(4)
-
-	url := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
-	sender, err := nats.Connect(url)
-	if err != nil {
-		t.Fatalf("Error on connect: %v", err)
-	}
-	defer sender.Close()
-
-	payload := make([]byte, 1000000)
-	for i := 0; i < 10; i++ {
-		if err := sender.Publish("foo", payload); err != nil {
-			t.Fatalf("Error on publish: %v", err)
-		}
-	}
-	// Flush sender connection to ensure that all data has been sent.
-	if err := sender.Flush(); err != nil {
-		t.Fatalf("Error on flush: %v", err)
-	}
-
-	// At this point server should have closed connection c.
-
-	// On certain platforms, it may take more than one call before
-	// getting the error.
-	for i := 0; i < 100; i++ {
-		if _, err := c.Write([]byte("PUB bar 5\r\nhello\r\n")); err != nil {
-			// ok
-			return
-		}
-	}
-	t.Fatal("Connection should have been closed")
-}
-
 func TestRandomPorts(t *testing.T) {
 	opts := DefaultOptions()
 	opts.HTTPPort = -1

--- a/server/split_test.go
+++ b/server/split_test.go
@@ -417,6 +417,7 @@ func TestSplitDanglingArgBuf(t *testing.T) {
 
 func TestSplitRoutedMsgArg(t *testing.T) {
 	_, c, _ := setupClient()
+	defer c.close()
 	// Allow parser to process RMSG
 	c.kind = ROUTER
 

--- a/test/gosrv_test.go
+++ b/test/gosrv_test.go
@@ -14,6 +14,7 @@
 package test
 
 import (
+	"fmt"
 	"net"
 	"runtime"
 	"testing"
@@ -26,11 +27,13 @@ func TestSimpleGoServerShutdown(t *testing.T) {
 	opts.Port = -1
 	s := RunServer(&opts)
 	s.Shutdown()
-	time.Sleep(100 * time.Millisecond)
-	delta := (runtime.NumGoroutine() - base)
-	if delta > 1 {
-		t.Fatalf("%d Go routines still exist post Shutdown()", delta)
-	}
+	checkFor(t, time.Second, 100*time.Millisecond, func() error {
+		delta := (runtime.NumGoroutine() - base)
+		if delta > 1 {
+			return fmt.Errorf("%d go routines still exist post Shutdown()", delta)
+		}
+		return nil
+	})
 }
 
 func TestGoServerShutdownWithClients(t *testing.T) {

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -524,6 +524,7 @@ func TestLeafNodeSolicit(t *testing.T) {
 	s.Shutdown()
 	// Need to restart it on the same port.
 	s, _ = runLeafServerOnPort(opts.LeafNode.Port)
+	defer s.Shutdown()
 	checkLeafNodeConnected(t, s)
 }
 
@@ -1096,7 +1097,7 @@ func TestLeafNodeTLSMixIP(t *testing.T) {
 	// This will fail but we want to make sure in the correct way, not with
 	// TLS issue because we used an IP for serverName.
 	sl, _ := RunServerWithConfig(slconf)
-	defer s.Shutdown()
+	defer sl.Shutdown()
 
 	ll := &captureLeafNodeErrLogger{ch: make(chan string, 2)}
 	sl.SetLogger(ll, false, false)
@@ -2291,6 +2292,7 @@ func TestLeafNodeSendsRemoteSubsOnConnect(t *testing.T) {
 
 	// Need to restart it on the same port.
 	s, _ = runLeafServerOnPort(opts.LeafNode.Port)
+	defer s.Shutdown()
 	checkLeafNodeConnected(t, s)
 
 	lc := createLeafConn(t, opts.LeafNode.Host, opts.LeafNode.Port)

--- a/test/new_routes_test.go
+++ b/test/new_routes_test.go
@@ -14,18 +14,15 @@
 package test
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/nats-io/nats-server/v2/logger"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
-	"github.com/nats-io/nuid"
 )
 
 func runNewRouteServer(t *testing.T) (*server.Server, *server.Options) {
@@ -1599,127 +1596,6 @@ func TestNewRouteLargeDistinctQueueSubscribers(t *testing.T) {
 			if n, _, _ := qsubs[i].Pending(); n != 10 {
 				return fmt.Errorf("Number of messages is %d", n)
 			}
-		}
-		return nil
-	})
-}
-
-func TestClusterLeaksSubscriptions(t *testing.T) {
-	srvA, srvB, optsA, optsB := runServers(t)
-	defer srvA.Shutdown()
-	defer srvB.Shutdown()
-
-	checkClusterFormed(t, srvA, srvB)
-
-	urlA := fmt.Sprintf("nats://%s:%d/", optsA.Host, optsA.Port)
-	urlB := fmt.Sprintf("nats://%s:%d/", optsB.Host, optsB.Port)
-
-	numResponses := 100
-	repliers := make([]*nats.Conn, 0, numResponses)
-
-	// Create 100 repliers
-	for i := 0; i < 50; i++ {
-		nc1, _ := nats.Connect(urlA)
-		nc2, _ := nats.Connect(urlB)
-		repliers = append(repliers, nc1, nc2)
-		nc1.Subscribe("test.reply", func(m *nats.Msg) {
-			m.Respond([]byte("{\"sender\": 22 }"))
-		})
-		nc2.Subscribe("test.reply", func(m *nats.Msg) {
-			m.Respond([]byte("{\"sender\": 33 }"))
-		})
-		nc1.Flush()
-		nc2.Flush()
-	}
-
-	servers := fmt.Sprintf("%s, %s", urlA, urlB)
-	req := sizedBytes(8 * 1024)
-
-	// Now run a requestor in a loop, creating and tearing down each time to
-	// simulate running a modified nats-req.
-	doReq := func() {
-		msgs := make(chan *nats.Msg, 1)
-		inbox := nats.NewInbox()
-		grp := nuid.Next()
-		// Create 8 queue Subscribers for responses.
-		for i := 0; i < 8; i++ {
-			nc, _ := nats.Connect(servers)
-			nc.ChanQueueSubscribe(inbox, grp, msgs)
-			nc.Flush()
-			defer nc.Close()
-		}
-		nc, _ := nats.Connect(servers)
-		nc.PublishRequest("test.reply", inbox, req)
-		defer nc.Close()
-
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-		defer cancel()
-
-		var received int
-		for {
-			select {
-			case <-msgs:
-				received++
-				if received >= numResponses {
-					return
-				}
-			case <-ctx.Done():
-				return
-			}
-		}
-	}
-
-	var wg sync.WaitGroup
-
-	doRequests := func(n int) {
-		for i := 0; i < n; i++ {
-			doReq()
-		}
-		wg.Done()
-	}
-
-	concurrent := 10
-	wg.Add(concurrent)
-	for i := 0; i < concurrent; i++ {
-		go doRequests(10)
-	}
-	wg.Wait()
-
-	// Close responders too, should have zero(0) subs attached to routes.
-	for _, nc := range repliers {
-		nc.Close()
-	}
-
-	// Make sure no clients remain. This is to make sure the test is correct and that
-	// we have closed all the client connections.
-	checkFor(t, time.Second, 10*time.Millisecond, func() error {
-		v1, _ := srvA.Varz(nil)
-		v2, _ := srvB.Varz(nil)
-		if v1.Connections != 0 || v2.Connections != 0 {
-			return fmt.Errorf("We have lingering client connections %d:%d", v1.Connections, v2.Connections)
-		}
-		return nil
-	})
-
-	loadRoutez := func() (*server.Routez, *server.Routez) {
-		v1, err := srvA.Routez(&server.RoutezOptions{Subscriptions: true})
-		if err != nil {
-			t.Fatalf("Error getting Routez: %v", err)
-		}
-		v2, err := srvB.Routez(&server.RoutezOptions{Subscriptions: true})
-		if err != nil {
-			t.Fatalf("Error getting Routez: %v", err)
-		}
-		return v1, v2
-	}
-
-	checkFor(t, time.Second, 10*time.Millisecond, func() error {
-		r1, r2 := loadRoutez()
-		if r1.Routes[0].NumSubs != 0 {
-			return fmt.Errorf("Leaked %d subs: %+v", r1.Routes[0].NumSubs, r1.Routes[0].Subs)
-		}
-		if r2.Routes[0].NumSubs != 0 {
-			return fmt.Errorf("Leaked %d subs: %+v", r2.Routes[0].NumSubs, r2.Routes[0].Subs)
 		}
 		return nil
 	})

--- a/test/norace_test.go
+++ b/test/norace_test.go
@@ -16,6 +16,7 @@
 package test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -31,6 +32,7 @@ import (
 
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nuid"
 )
 
 // IMPORTANT: Tests in this file are not executed when running with the -race flag.
@@ -410,4 +412,125 @@ func TestQueueSubWeightOrderMultipleConnections(t *testing.T) {
 	if updates >= maxExpected {
 		t.Fatalf("Was not expecting all %v updates to be received", maxExpected)
 	}
+}
+
+func TestNoRaceClusterLeaksSubscriptions(t *testing.T) {
+	srvA, srvB, optsA, optsB := runServers(t)
+	defer srvA.Shutdown()
+	defer srvB.Shutdown()
+
+	checkClusterFormed(t, srvA, srvB)
+
+	urlA := fmt.Sprintf("nats://%s:%d/", optsA.Host, optsA.Port)
+	urlB := fmt.Sprintf("nats://%s:%d/", optsB.Host, optsB.Port)
+
+	numResponses := 100
+	repliers := make([]*nats.Conn, 0, numResponses)
+
+	// Create 100 repliers
+	for i := 0; i < 50; i++ {
+		nc1, _ := nats.Connect(urlA)
+		nc2, _ := nats.Connect(urlB)
+		repliers = append(repliers, nc1, nc2)
+		nc1.Subscribe("test.reply", func(m *nats.Msg) {
+			m.Respond([]byte("{\"sender\": 22 }"))
+		})
+		nc2.Subscribe("test.reply", func(m *nats.Msg) {
+			m.Respond([]byte("{\"sender\": 33 }"))
+		})
+		nc1.Flush()
+		nc2.Flush()
+	}
+
+	servers := fmt.Sprintf("%s, %s", urlA, urlB)
+	req := sizedBytes(8 * 1024)
+
+	// Now run a requestor in a loop, creating and tearing down each time to
+	// simulate running a modified nats-req.
+	doReq := func() {
+		msgs := make(chan *nats.Msg, 1)
+		inbox := nats.NewInbox()
+		grp := nuid.Next()
+		// Create 8 queue Subscribers for responses.
+		for i := 0; i < 8; i++ {
+			nc, _ := nats.Connect(servers)
+			nc.ChanQueueSubscribe(inbox, grp, msgs)
+			nc.Flush()
+			defer nc.Close()
+		}
+		nc, _ := nats.Connect(servers)
+		nc.PublishRequest("test.reply", inbox, req)
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+
+		var received int
+		for {
+			select {
+			case <-msgs:
+				received++
+				if received >= numResponses {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+
+	var wg sync.WaitGroup
+
+	doRequests := func(n int) {
+		for i := 0; i < n; i++ {
+			doReq()
+		}
+		wg.Done()
+	}
+
+	concurrent := 10
+	wg.Add(concurrent)
+	for i := 0; i < concurrent; i++ {
+		go doRequests(10)
+	}
+	wg.Wait()
+
+	// Close responders too, should have zero(0) subs attached to routes.
+	for _, nc := range repliers {
+		nc.Close()
+	}
+
+	// Make sure no clients remain. This is to make sure the test is correct and that
+	// we have closed all the client connections.
+	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+		v1, _ := srvA.Varz(nil)
+		v2, _ := srvB.Varz(nil)
+		if v1.Connections != 0 || v2.Connections != 0 {
+			return fmt.Errorf("We have lingering client connections %d:%d", v1.Connections, v2.Connections)
+		}
+		return nil
+	})
+
+	loadRoutez := func() (*server.Routez, *server.Routez) {
+		v1, err := srvA.Routez(&server.RoutezOptions{Subscriptions: true})
+		if err != nil {
+			t.Fatalf("Error getting Routez: %v", err)
+		}
+		v2, err := srvB.Routez(&server.RoutezOptions{Subscriptions: true})
+		if err != nil {
+			t.Fatalf("Error getting Routez: %v", err)
+		}
+		return v1, v2
+	}
+
+	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+		r1, r2 := loadRoutez()
+		if r1.Routes[0].NumSubs != 0 {
+			return fmt.Errorf("Leaked %d subs: %+v", r1.Routes[0].NumSubs, r1.Routes[0].Subs)
+		}
+		if r2.Routes[0].NumSubs != 0 {
+			return fmt.Errorf("Leaked %d subs: %+v", r2.Routes[0].NumSubs, r2.Routes[0].Subs)
+		}
+		return nil
+	})
 }

--- a/test/operator_test.go
+++ b/test/operator_test.go
@@ -67,6 +67,7 @@ func TestOperatorRestrictions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
 	}
+	opts.NoSigs = true
 	if _, err := server.NewServer(opts); err != nil {
 		t.Fatalf("Expected to create a server successfully")
 	}
@@ -117,6 +118,7 @@ func TestOperatorConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
 	}
+	opts.NoSigs = true
 	// Check we have the TrustedOperators
 	if len(opts.TrustedOperators) != 1 {
 		t.Fatalf("Expected to load the operator")
@@ -135,6 +137,7 @@ func TestOperatorConfigInline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
 	}
+	opts.NoSigs = true
 	// Check we have the TrustedOperators
 	if len(opts.TrustedOperators) != 1 {
 		t.Fatalf("Expected to load the operator")

--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -549,6 +549,7 @@ func TestServiceLatencyWithQueueSubscribersAndNames(t *testing.T) {
 	// Create 10 queue subscribers for the service. Randomly select the server.
 	for i := 0; i < numResponders; i++ {
 		nc := clientConnectWithName(t, selectServer(), "foo", sname(i))
+		defer nc.Close()
 		nc.QueueSubscribe("ngs.usage.*", "SERVICE", func(msg *nats.Msg) {
 			time.Sleep(time.Duration(rand.Int63n(10)) * time.Millisecond)
 			msg.Respond([]byte("22 msgs"))
@@ -558,6 +559,7 @@ func TestServiceLatencyWithQueueSubscribersAndNames(t *testing.T) {
 
 	doRequest := func() {
 		nc := clientConnect(t, selectServer(), "bar")
+		defer nc.Close()
 		if _, err := nc.Request("ngs.usage", []byte("1h"), time.Second); err != nil {
 			t.Fatalf("Failed to get request response: %v", err)
 		}

--- a/test/system_services_test.go
+++ b/test/system_services_test.go
@@ -221,6 +221,7 @@ func TestSystemServiceSubscribersLeafNodesWithoutSystem(t *testing.T) {
 	// This is so we can test when the subs on a leafnode are flushed to the connected supercluster.
 	fsubj := "__leaf.flush__"
 	fc := clientConnect(t, opts, "foo")
+	defer fc.Close()
 	fc.Subscribe(fsubj, func(m *nats.Msg) {
 		m.Respond(nil)
 	})
@@ -324,6 +325,7 @@ func TestSystemServiceSubscribersLeafNodesWithSystem(t *testing.T) {
 	// This is so we can test when the subs on a leafnode are flushed to the connected supercluster.
 	fsubj := "__leaf.flush__"
 	fc := clientConnect(t, opts, "foo")
+	defer fc.Close()
 	fc.Subscribe(fsubj, func(m *nats.Msg) {
 		m.Respond(nil)
 	})

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -743,7 +743,10 @@ func TestTLSGatewaysCertificateCNBasedAuth(t *testing.T) {
 
 	received := make(chan *nats.Msg)
 	_, err = nc1.Subscribe("foo", func(msg *nats.Msg) {
-		received <- msg
+		select {
+		case received <- msg:
+		default:
+		}
 	})
 	if err != nil {
 		t.Error(err)
@@ -1137,6 +1140,7 @@ func TestTLSHandshakeFailureMemUsage(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Error on dial: %v", err)
 				}
+				conn.SetWriteDeadline(time.Now().Add(10 * time.Millisecond))
 				conn.Write(buf)
 				conn.Close()
 			}


### PR DESCRIPTION
Updated all tests that use "async" clients.
- start the writeLoop (this is in preparation for changes in the
  server that will not do send-in-place for some protocols, such
  as PING, etc..)
- Added missing defers in several tests
- fixed an issue in client.go where test was wrong possibly causing
  a panic.
- Had to skip a test for now since it would fail without server code
  change.

The next step will be ensure that all protocols are sent through
the writeLoop and that the data is properly flushed on close (important
for -ERR for instance).

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
