### PR TITLE
Update to 3.10 and go 1.12

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine3.8 AS builder
+FROM golang:1.12-alpine3.10 AS builder
 
 WORKDIR $GOPATH/src/github.com/nats-io/nats-server
 
@@ -10,7 +10,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GO111MODULE=off go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/nats-server/server.gitCommit=`git rev-parse --short HEAD`" -o /nats-server
 
-FROM alpine:3.8
+FROM alpine:3.10
 
 RUN apk add --update ca-certificates && mkdir -p /nats/bin && mkdir /nats/conf
 


### PR DESCRIPTION
Wondering if we should move to root as well to work better with some of the new tools?

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
