### PR TITLE
Report leafnode reconnections with info level

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -248,7 +248,9 @@ func (s *Server) connectToRemoteLeafNode(remote *leafNodeCfg, firstConnect bool)
 
 	attempts := 0
 	for s.isRunning() && s.remoteLeafNodeStillValid(remote) {
+		cURL := remote.getCurrentURL()
 		rURL := remote.pickNextURL()
+		leafURLChanged := cURL != rURL
 		url, err := s.getRandomIP(resolver, rURL.Host)
 		if err == nil {
 			var ipStr string
@@ -281,10 +283,12 @@ func (s *Server) connectToRemoteLeafNode(remote *leafNodeCfg, firstConnect bool)
 		// Go ahead and create our leaf node and return.
 		s.createLeafNode(conn, remote)
 
-		// We will put this in the normal log if first connect, does not force -DV mode to know
-		// that the connect worked.
+		// We will put this in the normal log if first connect or when leafnode changed,
+		// does not force -DV mode to know that the connect/reconnect worked.
 		if firstConnect {
 			s.Noticef("Connected leafnode to %q", rURL.Hostname())
+		} else if leafURLChanged {
+			s.Noticef("Reconnected leafnode to %q", rURL.Hostname())
 		}
 		return
 	}


### PR DESCRIPTION
Currently when using leafnode remote connections, the server only reports the first successful attempt one with INF level, which can be confusing in case there is a reconnect to another node as it may look like the server is still connected.  With this change, now we report whenever the leafnode endpoint changes in case there are multiple URLs:

```hcl
listen: "0.0.0.0:4222"
http:   "0.0.0.0:8222"

leafnodes {
  remotes = [
    {
	urls: ["nats://3.17.184.16:7422", "nats://3.15.38.138:7422"]
        credentials: "/tmp/stan.creds"
    }
  ]
}
```

```
[2105] 2019/12/18 15:00:27.260975 [INF] Starting nats-server version 2.1.3-RC02
[2105] 2019/12/18 15:00:27.261080 [INF] Git commit [not set]
[2105] 2019/12/18 15:00:27.261371 [INF] Starting http monitor on 0.0.0.0:8222
[2105] 2019/12/18 15:00:27.261543 [INF] Listening for client connections on 0.0.0.0:4222
[2105] 2019/12/18 15:00:27.261552 [INF] Server id is NBPDYXCODBGJIE2FHT32PO7DGDO4DSJTQW3V23Q7ZDE7K6IPBBSQKRD2
[2105] 2019/12/18 15:00:27.261557 [INF] Server is ready
[2105] 2019/12/18 15:00:27.528443 [INF] Connected leafnode to "3.15.38.138"
[2105] 2019/12/18 15:00:35.208473 [INF] Reconnected leafnode to "3.17.184.16"
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

 - [X] Documentation added (if applicable)
 - [-] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [-] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [-] Build is green in Travis CI
 - [-] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request:

- Add message for when remote leafnode connection successfully reconnects

/cc @nats-io/core
