### PR TITLE
[UPDATED] TCP Write and SlowConsumer handling

### DIFF
--- a/logger/syslog_test.go
+++ b/logger/syslog_test.go
@@ -111,6 +111,8 @@ func TestRemoteSysLogger(t *testing.T) {
 	if !logger.trace {
 		t.Fatalf("Expected %t, received %t\n", true, logger.trace)
 	}
+	logger.Noticef("foo")
+	<-done
 }
 
 func TestRemoteSysLoggerNotice(t *testing.T) {

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -229,24 +229,18 @@ func TestActiveAccounts(t *testing.T) {
 	cb1.closeConnection(ClientClosed)
 	waitTilActiveCount(1)
 
-	if nc := bar.NumConnections(); nc != 0 {
-		t.Fatalf("Expected account bar to have 0 clients, got %d", nc)
-	}
+	checkAccClientsCount(t, bar, 0)
 
 	// This should not change the count.
 	cf1.closeConnection(ClientClosed)
 	waitTilActiveCount(1)
 
-	if nc := foo.NumConnections(); nc != 1 {
-		t.Fatalf("Expected account foo to have 1 client, got %d", nc)
-	}
+	checkAccClientsCount(t, foo, 1)
 
 	cf2.closeConnection(ClientClosed)
 	waitTilActiveCount(0)
 
-	if nc := foo.NumConnections(); nc != 0 {
-		t.Fatalf("Expected account bar to have 0 clients, got %d", nc)
-	}
+	checkAccClientsCount(t, foo, 0)
 }
 
 // Clients can ask that the account be forced to be new. If it exists this is an error.

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -150,6 +150,17 @@ func checkClientsCount(t *testing.T, s *Server, expected int) {
 	})
 }
 
+func checkAccClientsCount(t *testing.T, acc *Account, expected int) {
+	t.Helper()
+	checkFor(t, 2*time.Second, 10*time.Millisecond, func() error {
+		if nc := acc.NumConnections(); nc != expected {
+			return fmt.Errorf("Expected account %q to have %v clients, got %v",
+				acc.Name, expected, nc)
+		}
+		return nil
+	})
+}
+
 func TestClientCreateAndInfo(t *testing.T) {
 	c, l := setUpClientWithResponse()
 	defer c.close()
@@ -562,9 +573,6 @@ func TestSplitSubjectQueue(t *testing.T) {
 }
 
 func TestQueueSubscribePermissions(t *testing.T) {
-	// TODO: (ik) skip for now until code is changed to do proper
-	// flush on connection close.
-	t.Skip("needs code to be fixed, skip for now...")
 	cases := []struct {
 		name    string
 		perms   *SubjectPermission
@@ -903,9 +911,7 @@ func TestClientRemoveSubsOnDisconnect(t *testing.T) {
 		t.Fatalf("Should have 2 subscriptions, got %d\n", s.NumSubscriptions())
 	}
 	c.closeConnection(ClientClosed)
-	if s.NumSubscriptions() != 0 {
-		t.Fatalf("Should have no subscriptions after close, got %d\n", s.NumSubscriptions())
-	}
+	checkExpectedSubs(t, 0, s)
 }
 
 func TestClientDoesNotAddSubscriptionsWhenConnectionClosed(t *testing.T) {
@@ -1479,6 +1485,7 @@ func TestReadloopWarning(t *testing.T) {
 	nc := natsConnect(t, url)
 	defer nc.Close()
 	natsSubSync(t, nc, "foo")
+	natsFlush(t, nc)
 	cid, _ := nc.GetClientID()
 
 	sender := natsConnect(t, url)
@@ -1489,8 +1496,8 @@ func TestReadloopWarning(t *testing.T) {
 	c.nc = &pauseWriteConn{Conn: c.nc}
 	c.mu.Unlock()
 
-	natsPub(t, nc, "foo", make([]byte, 100))
-	natsFlush(t, nc)
+	natsPub(t, sender, "foo", make([]byte, 100))
+	natsFlush(t, sender)
 
 	select {
 	case warn := <-l.warn:
@@ -1758,4 +1765,51 @@ func TestClientCheckUseOfGWReplyPrefix(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatalf("Did not receive permissions violation error")
 	}
+}
+
+func TestNoClientLeakOnSlowConsumer(t *testing.T) {
+	opts := DefaultOptions()
+	s := RunServer(opts)
+	defer s.Shutdown()
+
+	c, err := net.Dial("tcp", fmt.Sprintf("%s:%d", opts.Host, opts.Port))
+	if err != nil {
+		t.Fatalf("Error connecting: %v", err)
+	}
+	defer c.Close()
+
+	var buf [1024]byte
+	// Wait for INFO...
+	c.Read(buf[:])
+
+	// Send our connect
+	if _, err := c.Write([]byte("CONNECT {}\r\nSUB foo 1\r\nPING\r\n")); err != nil {
+		t.Fatalf("Error sending CONNECT and SUB: %v", err)
+	}
+	// Wait for PONG
+	c.Read(buf[:])
+
+	// Get the client from server map
+	cli := s.GetClient(1)
+	if cli == nil {
+		t.Fatalf("No client registered")
+	}
+	// Change the write deadline to very low value
+	cli.mu.Lock()
+	cli.out.wdl = time.Nanosecond
+	cli.mu.Unlock()
+
+	nc := natsConnect(t, s.ClientURL())
+	defer nc.Close()
+
+	// Send some messages to cause write deadline error on "cli"
+	payload := make([]byte, 1000)
+	for i := 0; i < 100; i++ {
+		natsPub(t, nc, "foo", payload)
+	}
+	natsFlush(t, nc)
+	nc.Close()
+
+	// Now make sure that the number of clients goes to 0.
+	checkClientsCount(t, s, 0)
 }

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1120,9 +1120,7 @@ func TestAccountConnsLimitExceededAfterUpdate(t *testing.T) {
 		t.Fatalf("Expected max connections to be set to 2, got %d", acc.MaxActiveConnections())
 	}
 	// We should have closed the excess connections.
-	if total := s.NumClients(); total != acc.MaxActiveConnections() {
-		t.Fatalf("Expected %d connections, got %d", acc.MaxActiveConnections(), total)
-	}
+	checkClientsCount(t, s, acc.MaxActiveConnections())
 }
 
 func TestAccountConnsLimitExceededAfterUpdateDisconnectNewOnly(t *testing.T) {
@@ -1158,9 +1156,7 @@ func TestAccountConnsLimitExceededAfterUpdateDisconnectNewOnly(t *testing.T) {
 	}
 
 	// We should have max here.
-	if total := s.NumClients(); total != acc.MaxActiveConnections() {
-		t.Fatalf("Expected %d connections, got %d", acc.MaxActiveConnections(), total)
-	}
+	checkClientsCount(t, s, acc.MaxActiveConnections())
 
 	// Now change limits to make current connections over the limit.
 	nac = jwt.NewAccountClaims(pub)
@@ -1172,9 +1168,7 @@ func TestAccountConnsLimitExceededAfterUpdateDisconnectNewOnly(t *testing.T) {
 		t.Fatalf("Expected max connections to be set to 2, got %d", acc.MaxActiveConnections())
 	}
 	// We should have closed the excess connections.
-	if total := s.NumClients(); total != acc.MaxActiveConnections() {
-		t.Fatalf("Expected %d connections, got %d", acc.MaxActiveConnections(), total)
-	}
+	checkClientsCount(t, s, acc.MaxActiveConnections())
 
 	// Now make sure that only the new ones were closed.
 	var closed int

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -737,6 +737,7 @@ func (s *Server) createGateway(cfg *gatewayCfg, url *url.URL, conn net.Conn) {
 
 		c.Noticef("Creating outbound gateway connection to %q", cfg.Name)
 	} else {
+		c.flags.set(expectConnect)
 		// Inbound gateway connection
 		c.Noticef("Processing inbound gateway connection")
 	}

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -2774,7 +2774,7 @@ func TestGatewayUnknownGatewayCommand(t *testing.T) {
 		GatewayCmd: 255,
 	}
 	b, _ := json.Marshal(info)
-	route.sendProto([]byte(fmt.Sprintf(InfoProto, b)), true)
+	route.enqueueProto([]byte(fmt.Sprintf(InfoProto, b)))
 	route.mu.Unlock()
 
 	checkFor(t, time.Second, 15*time.Millisecond, func() error {
@@ -3172,7 +3172,7 @@ func TestGatewaySendAllSubsBadProtocol(t *testing.T) {
 	}
 	b, _ := json.Marshal(info)
 	c.mu.Lock()
-	c.sendProto([]byte(fmt.Sprintf("INFO %s\r\n", b)), true)
+	c.enqueueProto([]byte(fmt.Sprintf("INFO %s\r\n", b)))
 	c.mu.Unlock()
 
 	orgConn := c
@@ -3200,14 +3200,14 @@ func TestGatewaySendAllSubsBadProtocol(t *testing.T) {
 	info.GatewayCmdPayload = []byte(globalAccountName)
 	b, _ = json.Marshal(info)
 	c.mu.Lock()
-	c.sendProto([]byte(fmt.Sprintf("INFO %s\r\n", b)), true)
+	c.enqueueProto([]byte(fmt.Sprintf("INFO %s\r\n", b)))
 	c.mu.Unlock()
 	// But incorrect end.
 	info.GatewayCmd = gatewayCmdAllSubsComplete
 	info.GatewayCmdPayload = nil
 	b, _ = json.Marshal(info)
 	c.mu.Lock()
-	c.sendProto([]byte(fmt.Sprintf("INFO %s\r\n", b)), true)
+	c.enqueueProto([]byte(fmt.Sprintf("INFO %s\r\n", b)))
 	c.mu.Unlock()
 
 	orgConn = c
@@ -5295,7 +5295,7 @@ func TestGatewayHandleUnexpectedASubUnsub(t *testing.T) {
 	// and reproduce old, wrong, behavior that would have resulted in sending an A-
 	gwA := getInboundGatewayConnection(sb, "A")
 	gwA.mu.Lock()
-	gwA.sendProto([]byte("A- $G\r\n"), true)
+	gwA.enqueueProto([]byte("A- $G\r\n"))
 	gwA.mu.Unlock()
 
 	// From A now, produce a message on each subject and
@@ -5331,7 +5331,7 @@ func TestGatewayHandleUnexpectedASubUnsub(t *testing.T) {
 
 	// Simulate B sending another A-, on A account no interest should remain same.
 	gwA.mu.Lock()
-	gwA.sendProto([]byte("A- $G\r\n"), true)
+	gwA.enqueueProto([]byte("A- $G\r\n"))
 	gwA.mu.Unlock()
 
 	checkForAccountNoInterest(t, gwb, globalAccountName, true, time.Second)
@@ -5344,7 +5344,7 @@ func TestGatewayHandleUnexpectedASubUnsub(t *testing.T) {
 
 	// Make B send an A+ and verify that we sitll have the registered qsub interest
 	gwA.mu.Lock()
-	gwA.sendProto([]byte("A+ $G\r\n"), true)
+	gwA.enqueueProto([]byte("A+ $G\r\n"))
 	gwA.mu.Unlock()
 
 	// Give a chance to A to possibly misbehave when receiving this proto
@@ -5358,20 +5358,20 @@ func TestGatewayHandleUnexpectedASubUnsub(t *testing.T) {
 
 	// Send A-, server A should set entry to nil
 	gwA.mu.Lock()
-	gwA.sendProto([]byte("A- $G\r\n"), true)
+	gwA.enqueueProto([]byte("A- $G\r\n"))
 	gwA.mu.Unlock()
 	checkForAccountNoInterest(t, gwb, globalAccountName, true, time.Second)
 
 	// Send A+ and entry should be removed since there is no longer reason to
 	// keep the entry.
 	gwA.mu.Lock()
-	gwA.sendProto([]byte("A+ $G\r\n"), true)
+	gwA.enqueueProto([]byte("A+ $G\r\n"))
 	gwA.mu.Unlock()
 	checkForAccountNoInterest(t, gwb, globalAccountName, false, time.Second)
 
 	// Last A+ should not change because account already removed from map.
 	gwA.mu.Lock()
-	gwA.sendProto([]byte("A+ $G\r\n"), true)
+	gwA.enqueueProto([]byte("A+ $G\r\n"))
 	gwA.mu.Unlock()
 	checkForAccountNoInterest(t, gwb, globalAccountName, false, time.Second)
 }

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -1679,7 +1679,13 @@ func TestJWTUserSigningKey(t *testing.T) {
 		t.Fatalf("Expected a PONG, got %q", l)
 	}
 
-	if c.nc == nil {
+	isClosed := func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return c.isClosed()
+	}
+
+	if isClosed() {
 		t.Fatal("expected client to be alive")
 	}
 	// remove the signing key should bounce client
@@ -1687,7 +1693,7 @@ func TestJWTUserSigningKey(t *testing.T) {
 	acc, _ = s.LookupAccount(apub)
 	s.updateAccountClaims(acc, nac)
 
-	if c.nc != nil {
+	if !isClosed() {
 		t.Fatal("expected client to be gone")
 	}
 }

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -591,6 +591,8 @@ func (s *Server) createLeafNode(conn net.Conn, remote *leafNodeCfg) *client {
 		}
 		c.mu.Lock()
 		c.acc = acc
+	} else {
+		c.flags.set(expectConnect)
 	}
 	c.mu.Unlock()
 

--- a/server/reload.go
+++ b/server/reload.go
@@ -1125,12 +1125,10 @@ func (s *Server) reloadClusterPermissions(oldPerms *RoutePermissions) {
 		// Send an update INFO, which will allow remote server to show
 		// our current route config in monitoring and resend subscriptions
 		// that we now possibly allow with a change of Export permissions.
-		route.sendInfo(infoJSON)
+		route.enqueueProto(infoJSON)
 		// Now send SUB and UNSUB protocols as needed.
-		closed := route.sendRouteSubProtos(subsNeedSUB, false, nil)
-		if !closed {
-			route.sendRouteUnSubProtos(subsNeedUNSUB, false, nil)
-		}
+		route.sendRouteSubProtos(subsNeedSUB, false, nil)
+		route.sendRouteUnSubProtos(subsNeedUNSUB, false, nil)
 		route.mu.Unlock()
 	}
 	// Remove as a batch all the subs that we have removed from each route.

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -1318,9 +1318,7 @@ func TestConfigReloadEnableClusterAuthorization(t *testing.T) {
 		t.Fatalf("Error reloading config: %v", err)
 	}
 
-	if numRoutes := srvb.NumRoutes(); numRoutes != 0 {
-		t.Fatalf("Expected 0 routes, got %d", numRoutes)
-	}
+	checkNumRoutes(t, srvb, 0)
 
 	// Ensure messages no longer flow through the cluster.
 	for i := 0; i < 5; i++ {
@@ -1854,9 +1852,7 @@ func TestConfigReloadMaxConnections(t *testing.T) {
 		t.Fatal("Expected to be disconnected")
 	}
 
-	if numClients := server.NumClients(); numClients != 1 {
-		t.Fatalf("Expected 1 client, got %d", numClients)
-	}
+	checkClientsCount(t, server, 1)
 
 	// Ensure new connections fail.
 	_, err = nats.Connect(addr)

--- a/server/route.go
+++ b/server/route.go
@@ -1029,6 +1029,8 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 		// Do this before the TLS code, otherwise, in case of failure
 		// and if route is explicit, it would try to reconnect to 'nil'...
 		r.url = rURL
+	} else {
+		c.flags.set(expectConnect)
 	}
 
 	// Check for TLS

--- a/server/server.go
+++ b/server/server.go
@@ -1673,6 +1673,9 @@ func (s *Server) createClient(conn net.Conn) *client {
 
 	// Grab lock
 	c.mu.Lock()
+	if info.AuthRequired || info.TLSRequired {
+		c.flags.set(expectConnect)
+	}
 
 	// Initialize
 	c.initClient()

--- a/server/server.go
+++ b/server/server.go
@@ -1673,7 +1673,7 @@ func (s *Server) createClient(conn net.Conn) *client {
 
 	// Grab lock
 	c.mu.Lock()
-	if info.AuthRequired || info.TLSRequired {
+	if info.AuthRequired {
 		c.flags.set(expectConnect)
 	}
 

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -2653,6 +2653,11 @@ func TestLeafNodeAndGatewayGlobalRouting(t *testing.T) {
 	})
 	ncl.Flush()
 
+	// Since for leafnodes the account becomes interest-only mode,
+	// let's make sure that the interest on "foo" has time to propagate
+	// to cluster B.
+	time.Sleep(250 * time.Millisecond)
+
 	// Create a direct connect requestor. Try with all possible
 	// servers in cluster B to make sure that we also receive the
 	// reply when the accepting leafnode server does not have
@@ -2676,10 +2681,10 @@ func TestLeafNodeAndGatewayGlobalRouting(t *testing.T) {
 			t.Fatalf("Error on subscribe: %v", err)
 		}
 		if err := nc.PublishRequest("foo", reply, []byte("Hello")); err != nil {
-			t.Fatalf("Failed to get response: %v", err)
+			t.Fatalf("Failed to send request: %v", err)
 		}
 		if _, err := sub.NextMsg(250 * time.Millisecond); err != nil {
-			t.Fatalf("Did not get reply: %v", err)
+			t.Fatalf("Did not get reply from server %d: %v", i, err)
 		}
 		nc.Close()
 	}

--- a/test/new_routes_test.go
+++ b/test/new_routes_test.go
@@ -1060,6 +1060,11 @@ func TestNewRouteStreamImport(t *testing.T) {
 	sendB("SUB foo 1\r\nPING\r\n")
 	expectB(pongRe)
 
+	// The subscription on "foo" for account $bar will also become
+	// a subscription on "foo" for account $foo due to import.
+	// So total of 2 subs.
+	checkExpectedSubs(2, srvA)
+
 	// Send on clientA
 	sendA("PING\r\n")
 	expectA(pongRe)
@@ -1080,6 +1085,8 @@ func TestNewRouteStreamImport(t *testing.T) {
 
 	sendB("UNSUB 1\r\nPING\r\n")
 	expectB(pongRe)
+
+	checkExpectedSubs(0, srvA)
 
 	sendA("PUB foo 2\r\nok\r\nPING\r\n")
 	expectA(pongRe)

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -1047,7 +1047,7 @@ func TestTLSTimeoutNotReportSlowConsumer(t *testing.T) {
 }
 
 func TestNotReportSlowConsumerUnlessConnected(t *testing.T) {
-	oa, err := server.ProcessConfigFile("./configs/srv_a_tls.conf")
+	oa, err := server.ProcessConfigFile("./configs/tls.conf")
 	if err != nil {
 		t.Fatalf("Unable to load config file: %v", err)
 	}

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -1046,34 +1046,6 @@ func TestTLSTimeoutNotReportSlowConsumer(t *testing.T) {
 	}
 }
 
-func TestNotReportSlowConsumerUnlessConnected(t *testing.T) {
-	oa, err := server.ProcessConfigFile("./configs/tls.conf")
-	if err != nil {
-		t.Fatalf("Unable to load config file: %v", err)
-	}
-
-	// Override WriteDeadline to very small value so that handshake
-	// fails with a slow consumer error.
-	oa.WriteDeadline = 1 * time.Nanosecond
-	sa := RunServer(oa)
-	defer sa.Shutdown()
-
-	ch := make(chan string, 1)
-	cscl := &captureSlowConsumerLogger{ch: ch}
-	sa.SetLogger(cscl, false, false)
-
-	nc := createClientConn(t, oa.Host, oa.Port)
-	defer nc.Close()
-
-	// Make sure we don't get any Slow Consumer error.
-	select {
-	case e := <-ch:
-		t.Fatalf("Unexpected slow consumer error: %s", e)
-	case <-time.After(500 * time.Millisecond):
-		// ok
-	}
-}
-
 func TestTLSHandshakeFailureMemUsage(t *testing.T) {
 	for i, test := range []struct {
 		name   string


### PR DESCRIPTION
- All writes will now be done by the writeLoop, unless when the
  writeLoop has not been started yet (likely in connection init).
- Slow consumers for non CLIENT connections will be reported but
  not failed. The idea is that routes, gateway, etc.. connections
  should stay connected as much as possible. However if a flush
  operation times out and no data at all has been written, the
  connection will be closed (regardless of type).
- Slow consumers due to max pending is only for CLIENT connections.
  This allows sending of SUBs through routes, etc.. to not have
  to be chunked.
- The backpressure to CLIENT connections is increased (up to 1sec)
  based on the sub's connection pending bytes level.
- Connection is flushed on close from the writeLoop as to not block
  the "fast path".

Some tests have been fixed and adapted since now closeConnection()
is not flushing/closing/removing connection in place.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
