### PR TITLE
[FIXED] Do not check URL account resolver reachability on reload

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2094,10 +2094,6 @@ func NewURLAccResolver(url string) (*URLAccResolver, error) {
 		url: url,
 		c:   &http.Client{Timeout: 2 * time.Second, Transport: tr},
 	}
-	// Do basic test to see if anyone is home.
-	if _, err := ur.Fetch(""); err != nil {
-		return nil, err
-	}
 	return ur, nil
 }
 

--- a/server/reload.go
+++ b/server/reload.go
@@ -742,7 +742,7 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 			diffOpts = append(diffOpts, &clientAdvertiseOption{newValue: cliAdv})
 		case "accounts":
 			diffOpts = append(diffOpts, &accountsOption{})
-		case "accountresolver":
+		case "resolver", "accountresolver", "accountsresolver":
 			// We can't move from no resolver to one. So check for that.
 			if (oldValue == nil && newValue != nil) ||
 				(oldValue != nil && newValue == nil) {

--- a/server/server.go
+++ b/server/server.go
@@ -244,6 +244,15 @@ func NewServer(opts *Options) (*Server, error) {
 		return nil, err
 	}
 
+	// If there is an URL account resolver, do basic test to see if anyone is home
+	if ar := opts.AccountResolver; ar != nil {
+		if ur, ok := ar.(*URLAccResolver); ok {
+			if _, err := ur.Fetch(""); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	info := Info{
 		ID:           pub,
 		Version:      VERSION,


### PR DESCRIPTION
On config reload, the URL account resolver was recreated and a
Fetch() with empty account was done. Move the empty fetch test
in NewServer() instead.
Added a test that shows that fetch is no longer invoked on reload
but server reports failure on startup.

Resolves #1229

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
