### PR TITLE
[FIXED] More than expected switch to Interest-Only mode for account

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1013,6 +1013,8 @@ func (c *client) flushOutbound() bool {
 	attempted := c.out.pb
 	apm := c.out.pm
 
+	// Capture this (we change the value in some tests)
+	wdl := c.out.wdl
 	// Do NOT hold lock during actual IO.
 	c.mu.Unlock()
 
@@ -1020,7 +1022,7 @@ func (c *client) flushOutbound() bool {
 	now := time.Now()
 	// FIXME(dlc) - writev will do multiple IOs past 1024 on
 	// most platforms, need to account for that with deadline?
-	nc.SetWriteDeadline(now.Add(c.out.wdl))
+	nc.SetWriteDeadline(now.Add(wdl))
 
 	// Actual write to the socket.
 	n, err := nb.WriteTo(nc)

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -2847,9 +2847,11 @@ func getAccountFromGatewayCommand(c *client, info *Info, cmd string) string {
 // The client's lock is held on entry.
 // <Invoked from inbound connection's readLoop>
 func (c *client) gatewaySwitchAccountToSendAllSubs(e *insie, accName string) {
-	// Set this map to nil so that the no-interest is
-	// no longer checked.
+	// Set this map to nil so that the no-interest is no longer checked.
 	e.ni = nil
+	// Switch mode to transitioning to prevent switchAccountToInterestMode
+	// to possibly call this function multiple times.
+	e.mode = Transitioning
 	s := c.srv
 
 	remoteGWName := c.gw.name

--- a/test/client_cluster_test.go
+++ b/test/client_cluster_test.go
@@ -438,7 +438,7 @@ func TestQueueDistributionAcrossRoutes(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	send := 600
+	send := 10000
 	for i := 0; i < send; i++ {
 		nc2.Publish("foo", nil)
 	}
@@ -470,7 +470,7 @@ func TestQueueDistributionAcrossRoutes(t *testing.T) {
 		total, _, _ := qsubs[i].Pending()
 		if total > avg+(avg*3/10) {
 			if i == 8 {
-				t.Fatalf("Qsub in 8th position gets majority of the messages  (prior 6 spots) in this test")
+				t.Fatalf("Qsub in 8th position gets majority of the messages (prior 6 spots) in this test")
 			}
 			t.Fatalf("Received too high, %d vs %d", total, avg)
 		}


### PR DESCRIPTION
When an account is switched to interest-only mode due to no interest,
it was not possible to switch that account more than once. But the
function switchAccountToInterestMode() that triggers a switch could
possibly doing it more than once. This should not cause problems
but increased the number of traces in a big super cluster.

Also fixed some flappers and a data race.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
