### PR TITLE
Fixed client stalled duration computation and added back Gosched()

### DIFF
--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -492,6 +492,9 @@ func TestRouteResendsLocalSubsOnReconnect(t *testing.T) {
 	// Close and then re-open
 	route.Close()
 
+	// Give some time for the route close to be processed before trying to recreate.
+	checkNumRoutes(t, s, 0)
+
 	route = createRouteConn(t, opts.Cluster.Host, opts.Cluster.Port)
 	defer route.Close()
 


### PR DESCRIPTION
This related to PR #1233.

The computation of the time to stall a fast producer was bogus. Fixed
that and added a unit test for the function computing this stalled
duration.

Also, in PR #1233, I had removed Gosched() when a call to flushOutbound()
realizes that the flag is already set. It was forgetting that readLoop
in some cases will call flushOutbound() in place. So there is still
value in unlock/gosched/lock again in that function.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
