### PR TITLE
Replace sync.Cond with go channel for writeLoop notification

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -761,8 +761,8 @@ func (c *client) writeLoop() {
 	waitOk := true
 
 	// Used to limit the wait for a signal
-	t := time.NewTimer(time.Second)
-	var lastReport time.Time
+	const maxWait = 3 * time.Second
+	t := time.NewTimer(maxWait)
 
 	var close bool
 
@@ -777,8 +777,8 @@ func (c *client) writeLoop() {
 				c.mu.Unlock()
 
 				var timeout bool
-				// Set our maximum wait to 3secs.
-				t.Reset(3 * time.Second)
+				// Reset our timer
+				t.Reset(maxWait)
 
 				// Wait on pending data.
 				select {
@@ -789,9 +789,8 @@ func (c *client) writeLoop() {
 
 				c.mu.Lock()
 				close = c.flags.isSet(closeConnection)
-				if !close && timeout && fspBeforeWait > 0 && time.Since(lastReport) > 10*time.Minute {
+				if !close && timeout && fspBeforeWait > 0 {
 					c.Warnf("Entered wait with fsp=%v and was not signaled within timeout", fspBeforeWait)
-					lastReport = time.Now()
 				}
 			}
 		}

--- a/server/client.go
+++ b/server/client.go
@@ -250,13 +250,12 @@ type outbound struct {
 	pb  int64         // Total pending/queued bytes.
 	pm  int32         // Total pending/queued messages.
 	fsp int32         // Flush signals that are pending per producer from readLoop's pcd.
-	sg  *sync.Cond    // Flusher conditional for signaling to writeLoop.
+	sch chan struct{} // To signal writeLoop that there is data to flush.
 	wdl time.Duration // Snapshot of write deadline.
 	mp  int64         // Snapshot of max pending for client.
 	lft time.Duration // Last flush time for Write.
 	stc chan struct{} // Stall chan we create to slow down producers on overrun, e.g. fan-in.
 	lwb int32         // Last byte size of Write.
-	sgw bool          // Indicate flusher is waiting on condition wait.
 }
 
 type perm struct {
@@ -441,7 +440,7 @@ func (c *client) initClient() {
 
 	// Outbound data structure setup
 	c.out.sz = startBufSize
-	c.out.sg = sync.NewCond(&c.mu)
+	c.out.sch = make(chan struct{}, 1)
 	opts := s.getOpts()
 	// Snapshots to avoid mutex access in fast paths.
 	c.out.wdl = opts.WriteDeadline
@@ -752,6 +751,7 @@ func (c *client) writeLoop() {
 		return
 	}
 	c.flags.set(writeLoopStarted)
+	ch := c.out.sch
 	c.mu.Unlock()
 
 	// This will clear connection state and remove it from the server.
@@ -759,6 +759,10 @@ func (c *client) writeLoop() {
 
 	// Used to check that we did flush from last wake up.
 	waitOk := true
+
+	// Used to limit the wait for a signal
+	t := time.NewTimer(time.Second)
+	var lastReport time.Time
 
 	var close bool
 
@@ -769,11 +773,26 @@ func (c *client) writeLoop() {
 		if close = c.flags.isSet(closeConnection); !close {
 			owtf := c.out.fsp > 0 && c.out.pb < maxBufSize && c.out.fsp < maxFlushPending
 			if waitOk && (c.out.pb == 0 || owtf) {
+				fspBeforeWait := c.out.fsp
+				c.mu.Unlock()
+
+				var timeout bool
+				// Set our maximum wait to 3secs.
+				t.Reset(3 * time.Second)
+
 				// Wait on pending data.
-				c.out.sgw = true
-				c.out.sg.Wait()
-				c.out.sgw = false
+				select {
+				case <-ch:
+				case <-t.C:
+					timeout = true
+				}
+
+				c.mu.Lock()
 				close = c.flags.isSet(closeConnection)
+				if !close && timeout && fspBeforeWait > 0 && time.Since(lastReport) > 10*time.Minute {
+					c.Warnf("Entered wait with fsp=%v and was not signaled within timeout", fspBeforeWait)
+					lastReport = time.Now()
+				}
 			}
 		}
 		if close {
@@ -1183,7 +1202,7 @@ func (c *client) markConnAsClosed(reason ClosedState, skipFlush bool) bool {
 	}
 	// If writeLoop exists, let it do the final flush, close and teardown.
 	if c.flags.isSet(writeLoopStarted) {
-		c.out.sg.Broadcast()
+		c.flushSignal()
 		return false
 	}
 	// Flush (if skipFlushOnClose is not set) and close in place. If flushing,
@@ -1195,9 +1214,10 @@ func (c *client) markConnAsClosed(reason ClosedState, skipFlush bool) bool {
 // flushSignal will use server to queue the flush IO operation to a pool of flushers.
 // Lock must be held.
 func (c *client) flushSignal() bool {
-	if c.out.sgw {
-		c.out.sg.Signal()
+	select {
+	case c.out.sch <- struct{}{}:
 		return true
+	default:
 	}
 	return false
 }


### PR DESCRIPTION
Also make the wait bound to 3secs after which writeLoop will attempt
to flush. Will log if it timed out on the wait and entering with
fsp > 0. Limit the report to once every 10 minutes

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
