### PR TITLE
proposed schemas for events

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -139,8 +139,17 @@ const (
 	// JetStreamMsgBySeqPre is the prefix for direct requests for a message by its stream sequence number.
 	JetStreamMsgBySeqPre = "$JS.BYSEQ"
 
-	// JetStreamConsumerAckSamplePre is the prefix for sampling metric messages for consumers.
-	JetStreamConsumerAckSamplePre = "$JS.CONSUMER.ACKSAMPLE"
+	// JetStreamNotificationPrefix is a prefix for all JetStream notification
+	JetStreamNotificationPrefix = "$JS.EVENT.NOTIFICATION"
+
+	// JetStreamMetricPrefix is a prefix for all JetStream metrics
+	JetStreamMetricPrefix = "$JS.EVENT.METRIC"
+
+	// JetStreamMetricConsumerAckPre is a metric containing ack latency
+	JetStreamMetricConsumerAckPre = JetStreamMetricPrefix + ".CONSUMER_ACK"
+
+	// JetStreamEventConsumerMaxDeliveryExceedPre is a notification published when a message exceeds its delivery threshold
+	JetStreamEventConsumerMaxDeliveryExceedPre = JetStreamNotificationPrefix + ".MAX_DELIVERIES"
 )
 
 // This is for internal accounting for JetStream for this server.

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -139,8 +139,8 @@ const (
 	// JetStreamMsgBySeqPre is the prefix for direct requests for a message by its stream sequence number.
 	JetStreamMsgBySeqPre = "$JS.BYSEQ"
 
-	// JetStreamNotificationPrefix is a prefix for all JetStream notification
-	JetStreamNotificationPrefix = "$JS.EVENT.NOTIFICATION"
+	// JetStreamAdvisoryPrefix is a prefix for all JetStream advisories
+	JetStreamAdvisoryPrefix = "$JS.EVENT.ADVISORY"
 
 	// JetStreamMetricPrefix is a prefix for all JetStream metrics
 	JetStreamMetricPrefix = "$JS.EVENT.METRIC"
@@ -148,8 +148,8 @@ const (
 	// JetStreamMetricConsumerAckPre is a metric containing ack latency
 	JetStreamMetricConsumerAckPre = JetStreamMetricPrefix + ".CONSUMER_ACK"
 
-	// JetStreamEventConsumerMaxDeliveryExceedPre is a notification published when a message exceeds its delivery threshold
-	JetStreamEventConsumerMaxDeliveryExceedPre = JetStreamNotificationPrefix + ".MAX_DELIVERIES"
+	// JetStreamAdvisoryConsumerMaxDeliveryExceedPre is a notification published when a message exceeds its delivery threshold
+	JetStreamAdvisoryConsumerMaxDeliveryExceedPre = JetStreamAdvisoryPrefix + ".MAX_DELIVERIES"
 )
 
 // This is for internal accounting for JetStream for this server.


### PR DESCRIPTION
This is a proposal to add schema, timestamps and unique ids to
events.  For now just JS ones but I propose to do these for all
events the server sends that might be end user consumed.

These exist to help the user identify a message even if it was
sent to a 3rd party system, the schema will be translatable to
a well known url like https://nats.io/schames/jetstream/event/v1/obs_ack.json
or to another wll known identifier like a NATS subject name

We'd publish JSON schema documents at these well known locations
describing each key and so forth
