### PR TITLE
add stream name to create subject

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -976,6 +976,12 @@ func (s *Server) jsCreateStreamRequest(sub *subscription, c *client, subject, re
 		s.sendInternalAccountMsg(c.acc, reply, JetStreamBadRequest)
 		return
 	}
+	streamName := subjectToken(subject, 2)
+	if streamName != cfg.Name {
+		s.sendInternalAccountMsg(c.acc, reply, fmt.Sprintf("%s 'stream name in subject does not match request'", ErrPrefix))
+		return
+	}
+
 	var response = OK
 	if _, err := c.acc.AddStream(&cfg); err != nil {
 		response = fmt.Sprintf("%s %v", ErrPrefix, err)
@@ -1134,13 +1140,13 @@ func (s *Server) jsCreateConsumerRequest(sub *subscription, c *client, subject, 
 		s.sendInternalAccountMsg(c.acc, reply, fmt.Sprintf("%s 'stream name in subject does not match request'", ErrPrefix))
 		return
 	}
-	mset, err := c.acc.LookupStream(req.Stream)
+	stream, err := c.acc.LookupStream(req.Stream)
 	if err != nil {
 		s.sendInternalAccountMsg(c.acc, reply, fmt.Sprintf("%s %v", ErrPrefix, err))
 		return
 	}
 	var response = OK
-	if o, err := mset.AddConsumer(&req.Config); err != nil {
+	if o, err := stream.AddConsumer(&req.Config); err != nil {
 		response = fmt.Sprintf("%s '%v'", ErrPrefix, err)
 	} else if !o.isDurable() {
 		// If the consumer is ephemeral add in the name

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -80,7 +80,8 @@ const (
 
 	// JetStreamCreateStream is the endpoint to create new streams.
 	// Will return +OK on success and -ERR on failure.
-	JetStreamCreateStream = "$JS.STREAM.CREATE"
+	JetStreamCreateStream  = "$JS.STREAM.*.CREATE"
+	JetStreamCreateStreamT = "$JS.STREAM.%s.CREATE"
 
 	// JetStreamListStreams is the endpoint to list all streams for this account.
 	// Will return json list of string on success and -ERR on failure.
@@ -549,7 +550,7 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 		}
 
 		stats := mset.State()
-		s.Noticef("  Restored %d messages for Stream %q", comma(int64(stats.Msgs)), fi.Name())
+		s.Noticef("  Restored %s messages for Stream %q", comma(int64(stats.Msgs)), fi.Name())
 
 		// Now do Consumers.
 		odir := path.Join(sdir, fi.Name(), consumerDir)

--- a/test/jetstream_test.go
+++ b/test/jetstream_test.go
@@ -3436,7 +3436,7 @@ func TestJetStreamRequestAPI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	resp, _ = nc.Request(server.JetStreamCreateStream, req, time.Second)
+	resp, _ = nc.Request(fmt.Sprintf(server.JetStreamCreateStreamT, msetCfg.Name), req, time.Second)
 	expectOKResponse(t, resp)
 
 	// Now lookup info again and see that we can see the new stream.

--- a/test/jetstream_test.go
+++ b/test/jetstream_test.go
@@ -3439,6 +3439,12 @@ func TestJetStreamRequestAPI(t *testing.T) {
 	resp, _ = nc.Request(fmt.Sprintf(server.JetStreamCreateStreamT, msetCfg.Name), req, time.Second)
 	expectOKResponse(t, resp)
 
+	// Check that the name in config has to match the name in the subject
+	resp, _ = nc.Request(fmt.Sprintf(server.JetStreamCreateStreamT, "BOB"), req, time.Second)
+	if !strings.HasPrefix(string(resp.Data), "-ERR 'stream name in subject does not match request'") {
+		t.Fatalf("Got wrong error response: %q", resp.Data)
+	}
+
 	// Now lookup info again and see that we can see the new stream.
 	resp, err = nc.Request(server.JetStreamInfo, nil, time.Second)
 	if err != nil {


### PR DESCRIPTION
I anticipate it would be desirable to allow a microservice running
in an account to create only the stream it needs when it starts up
if there is no stream but no others, so a ACL would be written to
allow that.

Thus adding the T pattern to stream create too.
