### PR TITLE
update to go 1.12 and latest alpine

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine3.8 AS builder
+FROM golang:1.12-alpine3.11 AS builder
 
 WORKDIR $GOPATH/src/github.com/nats-io/nats-server
 
@@ -10,7 +10,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GO111MODULE=off go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/nats-server/server.gitCommit=`git rev-parse --short HEAD`" -o /nats-server
 
-FROM alpine:3.8
+FROM alpine:3.11
 
 RUN apk add --update ca-certificates && mkdir -p /nats/bin && mkdir /nats/conf
 


### PR DESCRIPTION
We require go 1.12 now at least, so this just bumps things up a bit.