### PR TITLE
consistent timestamps in events

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -693,7 +693,7 @@ type ClientAPIAudit struct {
 type JetStreamAPIAudit struct {
 	Schema   string         `json:"schema"`
 	ID       string         `json:"id"`
-	Time     time.Time      `json:"time"`
+	Time     string         `json:"timestamp"`
 	Server   string         `json:"server"`
 	Client   ClientAPIAudit `json:"client"`
 	Subject  string         `json:"subject"`
@@ -717,7 +717,7 @@ func (s *Server) sendJetStreamAPIAuditAdvisory(c *client, subject, request, resp
 	e := &JetStreamAPIAudit{
 		Schema: auditSchema,
 		ID:     nuid.Next(),
-		Time:   time.Now(),
+		Time:   time.Now().UTC().Format(time.RFC3339Nano),
 		Server: s.Name(),
 		Client: ClientAPIAudit{
 			Host:     h,


### PR DESCRIPTION
Use the same key name for time in all events
Use the same format in all events

RFC3339 is the standard for this stuff and
for sure it should all be in UTC rather than
local time