### PR TITLE
[FIXED] Display of connections address when using IPv6

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -465,10 +466,10 @@ func (c *client) initClient() {
 	// snapshot the string version of the connection
 	var conn string
 	if ip, ok := c.nc.(*net.TCPConn); ok {
-		addr := ip.RemoteAddr().(*net.TCPAddr)
-		c.host = addr.IP.String()
-		c.port = uint16(addr.Port)
-		conn = fmt.Sprintf("%s:%d", addr.IP, addr.Port)
+		conn = ip.RemoteAddr().String()
+		host, port, _ := net.SplitHostPort(conn)
+		iPort, _ := strconv.Atoi(port)
+		c.host, c.port = host, uint16(iPort)
 	}
 
 	switch c.kind {

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -1893,3 +1893,25 @@ func TestClientStalledDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestClientIPv6Address(t *testing.T) {
+	opts := DefaultOptions()
+	opts.Host = "0.0.0.0"
+	s := RunServer(opts)
+	defer s.Shutdown()
+
+	nc, err := nats.Connect(fmt.Sprintf("nats://[::1]:%v", opts.Port))
+	// Travis may not accept IPv6, in that case, skip the test.
+	if err != nil {
+		t.Skipf("Skipping test because could not connect: %v", err)
+	}
+	defer nc.Close()
+
+	c := s.GetClient(1)
+	c.mu.Lock()
+	ncs := c.ncs
+	c.mu.Unlock()
+	if !strings.HasPrefix(ncs, "[::1]") {
+		t.Fatalf("Wrong string representation of an IPv6 address: %q", ncs)
+	}
+}


### PR DESCRIPTION
When the server logs information related to a connection, it uses
the connection IP and remote port as a prefix. When it was an IPv6
address, the square brackets would be missing.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
