### PR TITLE
[FIXED] Reset of tlsName only for x509.HostnameError

### DIFF
--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -3082,8 +3082,6 @@ func TestClusterTLSMixedIPAndDNS(t *testing.T) {
 		t.Fatalf("Failed to parse root certificate from %q", "./configs/certs/ca.pem")
 	}
 	remote.TLSConfig.RootCAs = pool
-	host, _, _ := net.SplitHostPort(optsB.LeafNode.Host)
-	remote.TLSConfig.ServerName = host
 	o.LeafNode.Remotes = []*server.RemoteLeafOpts{remote}
 	sl, _ := RunServer(&o), &o
 	defer sl.Shutdown()


### PR DESCRIPTION
For issue #1256, we cleared the possibly saved tlsName on Hanshake failure.
However, this meant that for normal use cases, if a reconnect failed for
any reason we would not be able to reconnect if it is an IP until we get
back to the URL that contained the hostname.

We now clear only if the handshake error is of x509.HostnameError type,
which include errors such as:
```
"x509: Common Name is not a valid hostname: <x>"
"x509: cannot validate certificate for <x> because it doesn't contain any IP SANs"
"x509: certificate is not valid for any names, but wanted to match <x>"
"x509: certificate is valid for <x>, not <y>"
```

Applied the same logic to solicited gateway connections, and fixed the fact
that the tlsConfig should be cloned (since we set the ServerName).

I have also made a change for leafnode connections similar to what we are
doing for gateway connections, which is to use the saved tlsName only if
tlsConfig.ServerName is empty, which may not be the case for users that
embed NATS Server and pass directly tls configuration. In other words,
if the option TLSConfig.ServerName is not empty, always use this value.

Relates to #1256
