### PR TITLE
Add check to prevent leafnode connecting to client port

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1264,7 +1264,7 @@ func (c *client) processInfo(arg []byte) error {
 	case GATEWAY:
 		c.processGatewayInfo(&info)
 	case LEAF:
-		c.processLeafnodeInfo(&info)
+		return c.processLeafnodeInfo(&info)
 	}
 	return nil
 }

--- a/server/client.go
+++ b/server/client.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/server/errors.go
+++ b/server/errors.go
@@ -66,6 +66,10 @@ var (
 	// attempted to connect to the leaf node listen port.
 	ErrClientConnectedToLeafNodePort = errors.New("attempted to connect to leaf node port")
 
+	// ErrLeafConnectedToClientPort represents an error condition when a client
+	// attempted to connect to the leaf node listen port.
+	ErrLeafConnectedToClientPort = errors.New("attempted to connect to client port")
+
 	// ErrAccountExists is returned when an account is attempted to be registered
 	// but already exists.
 	ErrAccountExists = errors.New("account exists")

--- a/server/errors.go
+++ b/server/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -66,9 +66,9 @@ var (
 	// attempted to connect to the leaf node listen port.
 	ErrClientConnectedToLeafNodePort = errors.New("attempted to connect to leaf node port")
 
-	// ErrLeafConnectedToClientPort represents an error condition when a client
-	// attempted to connect to the leaf node listen port.
-	ErrLeafConnectedToClientPort = errors.New("attempted to connect to client port")
+	// ErrConnectedToWrongPort represents an error condition when a connection is attempted
+	// to the wrong listen port (for instance a LeafNode to a client port, etc...)
+	ErrConnectedToWrongPort = errors.New("attempted to connect to wrong port")
 
 	// ErrAccountExists is returned when an account is attempted to be registered
 	// but already exists.

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The NATS Authors
+// Copyright 2019-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -870,65 +870,82 @@ func TestLeafCloseTLSConnection(t *testing.T) {
 	ch <- true
 }
 
-type captureDebugErrorLogger struct {
-	DummyLogger
-	errCh chan string
-}
-
-func (l *captureDebugErrorLogger) Debugf(format string, v ...interface{}) {
-	select {
-	case l.errCh <- fmt.Sprintf(format, v...):
-	default:
-	}
-}
-
 func TestLeafNodeRemoteWrongPort(t *testing.T) {
-	port := 8786
+	for _, test1 := range []struct {
+		name              string
+		clusterAdvertise  bool
+		leafnodeAdvertise bool
+	}{
+		{"advertise_on", false, false},
+		{"cluster_no_advertise", true, false},
+		{"leafnode_no_advertise", false, true},
+	} {
+		t.Run(test1.name, func(t *testing.T) {
+			oa := DefaultOptions()
+			// Make sure we have all ports (client, route, gateway) and we will try
+			// to create a leafnode to connection to each and make sure we get the error.
+			oa.Cluster.NoAdvertise = test1.clusterAdvertise
+			oa.Cluster.Host = "127.0.0.1"
+			oa.Cluster.Port = -1
+			oa.Gateway.Host = "127.0.0.1"
+			oa.Gateway.Port = -1
+			oa.Gateway.Name = "A"
+			oa.LeafNode.Host = "127.0.0.1"
+			oa.LeafNode.Port = -1
+			oa.LeafNode.NoAdvertise = test1.leafnodeAdvertise
+			oa.Accounts = []*Account{NewAccount("sys")}
+			oa.SystemAccount = "sys"
+			sa := RunServer(oa)
+			defer sa.Shutdown()
 
-	// Server with the wrong config against other server client's port.
-	leafURL, _ := url.Parse(fmt.Sprintf("nats://127.0.0.1:%d", port))
-	oa := DefaultOptions()
-	oa.Port = -1
-	oa.PingInterval = 15 * time.Millisecond
-	oa.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{leafURL}}}
-	sa := RunServer(oa)
-	defer sa.Shutdown()
-	l := &captureDebugErrorLogger{errCh: make(chan string, 10)}
-	sa.SetLogger(l, true, true)
+			ob := DefaultOptions()
+			ob.Cluster.NoAdvertise = test1.clusterAdvertise
+			ob.Cluster.Host = "127.0.0.1"
+			ob.Cluster.Port = -1
+			ob.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", oa.Cluster.Host, oa.Cluster.Port))
+			ob.Gateway.Host = "127.0.0.1"
+			ob.Gateway.Port = -1
+			ob.Gateway.Name = "A"
+			ob.LeafNode.Host = "127.0.0.1"
+			ob.LeafNode.Port = -1
+			ob.LeafNode.NoAdvertise = test1.leafnodeAdvertise
+			ob.Accounts = []*Account{NewAccount("sys")}
+			ob.SystemAccount = "sys"
+			sb := RunServer(ob)
+			defer sb.Shutdown()
 
-	// Make a cluster so that connect_urls is gossiped to clients.
-	ob := DefaultOptions()
-	ob.PingInterval = 15 * time.Millisecond
-	ob.Host = "127.0.0.1"
-	ob.Port = -1
-	ob.Cluster = ClusterOpts{
-		Host: "127.0.0.1",
-		Port: -1,
-	}
-	sb := RunServer(ob)
-	defer sb.Shutdown()
+			checkClusterFormed(t, sa, sb)
 
-	oc := DefaultOptions()
-	oc.PingInterval = 15 * time.Millisecond
-	oc.Host = "127.0.0.1"
-	oc.Port = port
-	oc.Cluster = ClusterOpts{
-		Host: "127.0.0.1",
-		Port: -1,
-	}
-	routeURL, _ := url.Parse(fmt.Sprintf("nats://127.0.0.1:%d", ob.Cluster.Port))
-	oc.Routes = []*url.URL{routeURL}
-	sc := RunServer(oc)
-	defer sc.Shutdown()
+			for _, test := range []struct {
+				name string
+				port int
+			}{
+				{"client", oa.Port},
+				{"cluster", oa.Cluster.Port},
+				{"gateway", oa.Gateway.Port},
+			} {
+				t.Run(test.name, func(t *testing.T) {
+					oc := DefaultOptions()
+					// Server with the wrong config against non leafnode port.
+					leafURL, _ := url.Parse(fmt.Sprintf("nats://127.0.0.1:%d", test.port))
+					oc.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{leafURL}}}
+					oc.LeafNode.ReconnectInterval = 5 * time.Millisecond
+					sc := RunServer(oc)
+					defer sc.Shutdown()
+					l := &captureErrorLogger{errCh: make(chan string, 10)}
+					sc.SetLogger(l, true, true)
 
-	for {
-		select {
-		case e := <-l.errCh:
-			if strings.Contains(e, `attempted to connect to client port`) {
-				return
+					select {
+					case e := <-l.errCh:
+						if strings.Contains(e, ErrConnectedToWrongPort.Error()) {
+							return
+						}
+					case <-time.After(2 * time.Second):
+						t.Fatalf("Did not get any error about connecting to wrong port for %q - %q",
+							test1.name, test.name)
+					}
+				})
 			}
-		case <-time.After(2 * time.Second):
-			t.Fatalf("Did not get any error about connecting to client port")
-		}
+		})
 	}
 }


### PR DESCRIPTION
Currently when a NATS Server connects to a leafnode to the client port, the connection is established successfully and remains connected until the first message is sent.

For example given this config:

```hcl
leafnodes {
  remotes = [
    {
      url = "nats://connect.ngs.global:4222"
      credentials = "~/.nkeys/creds/synadia/NGS/NGS.creds"
    }
  ]
}
```

The server will remain connected, with ping/pong working ok:

```
2020/01/28 12:52:16.468011 [INF] Starting nats-server version 2.1.3-RC05
2020/01/28 12:52:16.468129 [DBG] Go build version go1.13.3
2020/01/28 12:52:16.468134 [INF] Git commit [not set]
2020/01/28 12:52:16.468479 [INF] Listening for client connections on 0.0.0.0:4222
2020/01/28 12:52:16.468496 [INF] Server id is NC2IUWWQCR7OYW6ONQAFQINLKCDWJ6BXGAL52L5JLDZHWJGVIMFXMA72
2020/01/28 12:52:16.468503 [INF] Server is ready
2020/01/28 12:52:16.468517 [DBG] Get non local IPs for "0.0.0.0"
2020/01/28 12:52:16.468840 [DBG]  ip=192.168.1.7
2020/01/28 12:52:16.470977 [DBG] Trying to connect as leafnode to remote server on "connect.ngs.global:4222" (35.166.100.73:4222)
2020/01/28 12:52:16.546743 [DBG] 35.166.100.73:4222 - lid:1 - Starting TLS leafnode client handshake
2020/01/28 12:52:16.791221 [DBG] 35.166.100.73:4222 - lid:1 - Authenticating with credentials file "/Users/wallyqs/.nkeys/creds/synadia/NGS/NGS.creds"
2020/01/28 12:52:16.792689 [DBG] 35.166.100.73:4222 - lid:1 - Remote leafnode connect msg sent
2020/01/28 12:52:16.792746 [DBG] 35.166.100.73:4222 - lid:1 - Leafnode connection created
2020/01/28 12:52:16.792860 [INF] Connected leafnode to "connect.ngs.global"
2020/01/28 12:52:17.847924 [DBG] 35.166.100.73:4222 - lid:1 - LeafNode Ping Timer
2020/01/28 12:52:17.849605 [TRC] 35.166.100.73:4222 - lid:1 - ->> [PING]
2020/01/28 12:52:17.909107 [TRC] 35.166.100.73:4222 - lid:1 - <<- [PONG]
2020/01/28 12:52:18.950025 [TRC] 35.166.100.73:4222 - lid:1 - <<- [PING]
2020/01/28 12:52:18.950061 [TRC] 35.166.100.73:4222 - lid:1 - ->> [PONG]
```

The connection will be in the established state until the first message is sent on the leafnode connection, after which the server will fail to parse it with an `Unknown Protocol Error`.

```
2020/01/28 12:54:43.292346 [DBG] Trying to connect as leafnode to remote server on "connect.ngs.global:4222" (35.166.100.73:4222)
2020/01/28 12:54:43.368876 [DBG] 35.166.100.73:4222 - lid:4 - Starting TLS leafnode client handshake
2020/01/28 12:54:43.464516 [DBG] 35.166.100.73:4222 - lid:4 - Authenticating with credentials file "/Users/wallyqs/.nkeys/creds/synadia/NGS/NGS.creds"
2020/01/28 12:54:43.466691 [DBG] 35.166.100.73:4222 - lid:4 - Remote leafnode connect msg sent
2020/01/28 12:54:43.466830 [DBG] 35.166.100.73:4222 - lid:4 - Leafnode connection created
2020/01/28 12:54:43.466920 [TRC] 35.166.100.73:4222 - lid:4 - ->> [LS+ _INBOX.Nn5na6z6dFjbXIbwiLmQQm.*]
2020/01/28 12:54:43.502832 [ERR] 35.166.100.73:4222 - lid:4 - Leafnode Error 'Unknown Protocol Operation'
2020/01/28 12:54:43.503007 [DBG] 35.166.100.73:4222 - lid:4 - LeafNode connection closed
```

The INFO protocol from both client and leafnode port is the same other, with the only difference so far being that the client port uses `connect_urls` for gossiping whereas the leafnode port uses
`leafnode_urls`.  In this commit we use that as the check to prevent leafnode connections using the wrong port and report with debug level any errors while connecting:

```sh
2020/01/28 12:51:48.104976 [INF] Starting nats-server version 2.1.3-RC05
2020/01/28 12:51:48.105102 [DBG] Go build version go1.13.3
2020/01/28 12:51:48.105107 [INF] Git commit [not set]
2020/01/28 12:51:48.105465 [INF] Listening for client connections on 0.0.0.0:4222
2020/01/28 12:51:48.105477 [INF] Server id is NAQ7IMSSPVYMBY5GJTE3PWVDL3ODSAC6WJ6BUM4G5VB3T4ILEU4S7BOT
2020/01/28 12:51:48.105482 [INF] Server is ready
2020/01/28 12:51:48.105493 [DBG] Get non local IPs for "0.0.0.0"
2020/01/28 12:51:48.105786 [DBG]  ip=192.168.1.7
2020/01/28 12:51:48.127007 [DBG] Trying to connect as leafnode to remote server on "connect.ngs.global:4222" (35.166.100.73:4222)
2020/01/28 12:51:48.199762 [DBG] 35.166.100.73:4222 - lid:1 - Error reading remote leafnode's INFO: attempted to connect to client port
2020/01/28 12:51:48.200044 [DBG] 35.166.100.73:4222 - lid:1 - LeafNode connection closed
2020/01/28 12:51:48.200283 [INF] Connected leafnode to "connect.ngs.global"
```

 - [X] Link to issue, e.g. `Resolves #NNN`
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

/cc @nats-io/core

Signed-off-by: Waldemar Quevedo <wally@synadia.com>