### PR TITLE
[ADDED] Ability to specify TLS configuration for account resolver

### DIFF
--- a/server/reload.go
+++ b/server/reload.go
@@ -749,6 +749,8 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 				return nil, fmt.Errorf("config reload does not support moving to or from an account resolver")
 			}
 			diffOpts = append(diffOpts, &accountsOption{})
+		case "accountresolvertlsconfig":
+			diffOpts = append(diffOpts, &accountsOption{})
 		case "gateway":
 			// Not supported for now, but report warning if configuration of gateway
 			// is actually changed so that user knows that it won't take effect.


### PR DESCRIPTION
A new config section allows to specify specific TLS parameters for
the account resolver:
```
resolver_tls {
  cert_file: ...
  key_file: ...
  ca_file: ...
}
```

Resolves #1271

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
