### PR TITLE
parse ping_interval as duration, else assume seconds and warn

### DIFF
--- a/server/configs/test.conf
+++ b/server/configs/test.conf
@@ -41,7 +41,7 @@ max_control_line: 2048
 max_payload: 65536
 
 # ping interval and no pong threshold
-ping_interval: 60
+ping_interval: "60s"
 ping_max: 3
 
 # how long server can block on a socket write to a client

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -1155,6 +1155,36 @@ func TestPanic(t *testing.T) {
 	}
 }
 
+func TestPingIntervalOld(t *testing.T) {
+	conf := createConfFile(t, []byte(`ping_interval: 5`))
+	defer os.Remove(conf)
+	opts := &Options{}
+	err := opts.ProcessConfigFile(conf)
+	if err == nil {
+		t.Fatalf("expected an error")
+	} else if err, ok := err.(*processConfigErr); !ok {
+		t.Fatalf("expected an error of type processConfigErr")
+	} else if len(err.warnings) != 1 {
+		t.Fatalf("expected processConfigErr to have one warning")
+	} else if len(err.errors) != 0 {
+		t.Fatalf("expected processConfigErr to have no error")
+	} else if opts.PingInterval != 5*time.Second {
+		t.Fatalf("expected ping interval to be 5 seconds")
+	}
+}
+
+func TestPingIntervalNew(t *testing.T) {
+	conf := createConfFile(t, []byte(`ping_interval: "5m"`))
+	defer os.Remove(conf)
+	opts := &Options{}
+	err := opts.ProcessConfigFile(conf)
+	if err != nil {
+		t.Fatalf("expected no error")
+	} else if opts.PingInterval != 5*time.Minute {
+		t.Fatalf("expected ping interval to be 5 minutes")
+	}
+}
+
 func TestOptionsProcessConfigFile(t *testing.T) {
 	// Create options with default values of Debug and Trace
 	// that are the opposite of what is in the config file.

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -1163,11 +1163,14 @@ func TestPingIntervalOld(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected an error")
 	}
-	if err, ok := err.(*processConfigErr); !ok {
+	errTyped, ok := err.(*processConfigErr)
+	if !ok {
 		t.Fatalf("expected an error of type processConfigErr")
-	} else if len(err.warnings) != 1 {
+	}
+	if len(errTyped.warnings) != 1 {
 		t.Fatalf("expected processConfigErr to have one warning")
-	} else if len(err.errors) != 0 {
+	}
+	if len(errTyped.errors) != 0 {
 		t.Fatalf("expected processConfigErr to have no error")
 	}
 	if opts.PingInterval != 5*time.Second {
@@ -1179,8 +1182,7 @@ func TestPingIntervalNew(t *testing.T) {
 	conf := createConfFile(t, []byte(`ping_interval: "5m"`))
 	defer os.Remove(conf)
 	opts := &Options{}
-	err := opts.ProcessConfigFile(conf)
-	if err != nil {
+	if err := opts.ProcessConfigFile(conf); err != nil {
 		t.Fatalf("expected no error")
 	}
 	if opts.PingInterval != 5*time.Minute {

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -1162,13 +1162,15 @@ func TestPingIntervalOld(t *testing.T) {
 	err := opts.ProcessConfigFile(conf)
 	if err == nil {
 		t.Fatalf("expected an error")
-	} else if err, ok := err.(*processConfigErr); !ok {
+	}
+	if err, ok := err.(*processConfigErr); !ok {
 		t.Fatalf("expected an error of type processConfigErr")
 	} else if len(err.warnings) != 1 {
 		t.Fatalf("expected processConfigErr to have one warning")
 	} else if len(err.errors) != 0 {
 		t.Fatalf("expected processConfigErr to have no error")
-	} else if opts.PingInterval != 5*time.Second {
+	}
+	if opts.PingInterval != 5*time.Second {
 		t.Fatalf("expected ping interval to be 5 seconds")
 	}
 }
@@ -1180,7 +1182,8 @@ func TestPingIntervalNew(t *testing.T) {
 	err := opts.ProcessConfigFile(conf)
 	if err != nil {
 		t.Fatalf("expected no error")
-	} else if opts.PingInterval != 5*time.Minute {
+	}
+	if opts.PingInterval != 5*time.Minute {
 		t.Fatalf("expected ping interval to be 5 minutes")
 	}
 }

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -1571,6 +1571,9 @@ func TestConfigReloadClusterRemoveSolicitedRoutes(t *testing.T) {
 	if err := srvaConn.Flush(); err != nil {
 		t.Fatalf("Error flushing: %v", err)
 	}
+	if err := srvaConn.Flush(); err != nil {
+		t.Fatalf("Error flushing: %v", err)
+	}
 
 	srvbAddr := fmt.Sprintf("nats://%s:%d", srvbOpts.Host, srvbOpts.Port)
 	srvbConn, err := nats.Connect(srvbAddr)

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -1571,9 +1571,7 @@ func TestConfigReloadClusterRemoveSolicitedRoutes(t *testing.T) {
 	if err := srvaConn.Flush(); err != nil {
 		t.Fatalf("Error flushing: %v", err)
 	}
-	if err := srvaConn.Flush(); err != nil {
-		t.Fatalf("Error flushing: %v", err)
-	}
+	checkExpectedSubs(t, 1, srvb)
 
 	srvbAddr := fmt.Sprintf("nats://%s:%d", srvbOpts.Host, srvbOpts.Port)
 	srvbConn, err := nats.Connect(srvbAddr)


### PR DESCRIPTION
took code of write_deadline and moved it into separate function.
added tests. 
changed tests.conf to not produce the warning as to not throw off other tests.

Signed-off-by: Matthias Hanel <mh@synadia.com>
