### PR TITLE
Use constant for error

### DIFF
--- a/server/parser.go
+++ b/server/parser.go
@@ -855,7 +855,7 @@ func (c *client) parse(buf []byte) error {
 		// exact at all but the performance hit is too great to be precise, and
 		// catching here should prevent memory exhaustion attacks.
 		if len(c.argBuf) > int(mcl) {
-			c.sendErr("Maximum Control Line Exceeded")
+			c.sendErr(ErrMaxControlLine.Error())
 			c.closeConnection(MaxControlLineExceeded)
 			return ErrMaxControlLine
 		}


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>
