### PR TITLE
show basic jetstream info in varz and server info

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -122,13 +122,14 @@ type accNumConnsReq struct {
 
 // ServerInfo identifies remote servers.
 type ServerInfo struct {
-	Name    string    `json:"name"`
-	Host    string    `json:"host"`
-	ID      string    `json:"id"`
-	Cluster string    `json:"cluster,omitempty"`
-	Version string    `json:"ver"`
-	Seq     uint64    `json:"seq"`
-	Time    time.Time `json:"time"`
+	Name      string    `json:"name"`
+	Host      string    `json:"host"`
+	ID        string    `json:"id"`
+	Cluster   string    `json:"cluster,omitempty"`
+	Version   string    `json:"ver"`
+	Seq       uint64    `json:"seq"`
+	JetStream bool      `json:"jetstream"`
+	Time      time.Time `json:"time"`
 }
 
 // ClientInfo is detailed information about the client forming a connection.
@@ -219,6 +220,7 @@ func (s *Server) internalSendLoop(wg *sync.WaitGroup) {
 	host := s.info.Host
 	servername := s.info.Name
 	seqp := &s.sys.seq
+	js := s.js != nil
 	var cluster string
 	if s.gateway.enabled {
 		cluster = s.getGatewayName()
@@ -247,6 +249,7 @@ func (s *Server) internalSendLoop(wg *sync.WaitGroup) {
 				pm.si.Seq = atomic.AddUint64(seqp, 1)
 				pm.si.Version = VERSION
 				pm.si.Time = time.Now()
+				pm.si.JetStream = js
 			}
 			var b []byte
 			if pm.msg != nil {

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -919,6 +919,7 @@ type Varz struct {
 	Cluster           ClusterOptsVarz   `json:"cluster,omitempty"`
 	Gateway           GatewayOptsVarz   `json:"gateway,omitempty"`
 	LeafNode          LeafNodeOptsVarz  `json:"leaf,omitempty"`
+	JetStream         JetStreamVarz     `json:"jetstream,omitempty"`
 	TLSTimeout        float64           `json:"tls_timeout"`
 	WriteDeadline     time.Duration     `json:"write_deadline"`
 	Start             time.Time         `json:"start"`
@@ -940,6 +941,14 @@ type Varz struct {
 	Subscriptions     uint32            `json:"subscriptions"`
 	HTTPReqStats      map[string]uint64 `json:"http_req_stats"`
 	ConfigLoadTime    time.Time         `json:"config_load_time"`
+}
+
+// JetStreamVarz contains basic runtime information about jetstream
+type JetStreamVarz struct {
+	MaxMemory int64  `json:"max_memory,omitempty"`
+	MaxStore  int64  `json:"max_store,omitempty"`
+	StoreDir  string `json:"store_dir,omitempty"`
+	Accounts  int    `json:"accounts,omitempty"`
 }
 
 // ClusterOptsVarz contains monitoring cluster information
@@ -1135,6 +1144,17 @@ func (s *Server) createVarz(pcpu float64, rss int64) *Varz {
 		}
 		varz.LeafNode.Remotes = rlna
 	}
+
+	if s.js != nil {
+		s.js.mu.RLock()
+		varz.JetStream = JetStreamVarz{
+			MaxMemory: s.js.config.MaxMemory,
+			MaxStore:  s.js.config.MaxStore,
+			StoreDir:  s.js.config.StoreDir,
+		}
+		s.js.mu.RUnlock()
+	}
+
 	// Finish setting it up with fields that can be updated during
 	// configuration reload and runtime.
 	s.updateVarzConfigReloadableFields(varz)
@@ -1240,6 +1260,12 @@ func (s *Server) updateVarzRuntimeFields(v *Varz, forceUpdate bool, pcpu float64
 		}
 	}
 	gw.RUnlock()
+
+	if s.js != nil {
+		s.js.mu.RLock()
+		v.JetStream.Accounts = len(s.js.accounts)
+		s.js.mu.RUnlock()
+	}
 }
 
 // HandleVarz will process HTTP requests for server information.

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+
 	// Allow dynamic profiling.
 	_ "net/http/pprof"
 	"os"


### PR DESCRIPTION
I know we're not really sure how to show all the per account stuff, but I figured some basic varz/event info would be helpful