### PR TITLE
Do not send ping to presumed telnet clients until they connected/send ping

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1353,6 +1353,11 @@ func (c *client) processConnect(arg []byte) error {
 	// Estimate RTT to start.
 	if c.kind == CLIENT {
 		c.rtt = computeRTT(c.start)
+
+		if c.srv != nil {
+			c.clearPingTimer()
+			c.srv.setFirstPingTimer(c)
+		}
 	}
 	kind := c.kind
 	srv := c.srv

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -117,11 +117,12 @@ func genAsyncParser(c *client) (func(string), chan bool) {
 }
 
 var defaultServerOptions = Options{
-	Host:   "127.0.0.1",
-	Trace:  false,
-	Debug:  false,
-	NoLog:  true,
-	NoSigs: true,
+	Host:                  "127.0.0.1",
+	Trace:                 true,
+	Debug:                 true,
+	DisableShortFirstPing: true,
+	NoLog:                 true,
+	NoSigs:                true,
 }
 
 func rawSetup(serverOptions Options) (*Server, *testAsyncClient, *bufio.Reader, string) {

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/nats-io/nats-server/v2/logger"
 )
@@ -189,7 +190,7 @@ func TestNoPasswordsFromConnectTrace(t *testing.T) {
 	opts.Trace = true
 	opts.Username = "derek"
 	opts.Password = "s3cr3t"
-
+	opts.PingInterval = 2 * time.Minute
 	s := &Server{opts: opts}
 	dl := &DummyLogger{}
 	s.SetLogger(dl, false, true)

--- a/server/server.go
+++ b/server/server.go
@@ -1792,8 +1792,8 @@ func (s *Server) createClient(conn net.Conn) *client {
 
 	// Do final client initialization
 
-	// Set the First Ping timer.
-	s.setFirstPingTimer(c)
+	// Set the Ping timer. Will be reset once connect was received.
+	c.setPingTimer()
 
 	// Spin up the read loop.
 	s.startGoRoutine(func() { c.readLoop() })

--- a/test/test.go
+++ b/test/test.go
@@ -37,11 +37,12 @@ type tLogger interface {
 
 // DefaultTestOptions are default options for the unit tests.
 var DefaultTestOptions = server.Options{
-	Host:           "127.0.0.1",
-	Port:           4222,
-	NoLog:          true,
-	NoSigs:         true,
-	MaxControlLine: 2048,
+	Host:                  "127.0.0.1",
+	Port:                  4222,
+	NoLog:                 true,
+	NoSigs:                true,
+	MaxControlLine:        2048,
+	DisableShortFirstPing: true,
 }
 
 // RunDefaultServer starts a new Go routine based server using the default options


### PR DESCRIPTION
Increment the ping counter so they remain subject to the overall timeout.

This does not affect pings sent to directly obtain RTT.
These seem to be generally called when the connect message has been received already.
To keep this change small I refrained from altering that logic.

server
[49483] 2020/02/27 14:05:10.184185 [DBG] 127.0.0.1:50612 - cid:1 - Client connection created
[49483] 2020/02/27 14:05:12.496584 [DBG] 127.0.0.1:50612 - cid:1 - Client Ping Timer
[49483] 2020/02/27 14:05:12.496654 [DBG] 127.0.0.1:50612 - cid:1 - Faking PING until connect message, timeout in 2 intervals false
[49483] 2020/02/27 14:07:12.498158 [DBG] 127.0.0.1:50612 - cid:1 - Client Ping Timer
[49483] 2020/02/27 14:07:12.498200 [DBG] 127.0.0.1:50612 - cid:1 - Faking PING until connect message, timeout in 1 intervals false
[49483] 2020/02/27 14:09:12.500238 [DBG] 127.0.0.1:50612 - cid:1 - Client Ping Timer
[49483] 2020/02/27 14:09:12.500280 [DBG] 127.0.0.1:50612 - cid:1 - Stale Client Connection - Closing
[49483] 2020/02/27 14:09:12.500548 [DBG] 127.0.0.1:50612 - cid:1 - Client connection closed

telnet client:
14:05:10 > telnet 0.0.0.0 4222
Trying 0.0.0.0...
Connected to 0.0.0.0.
Escape character is '^]'.
INFO {"server_id":"NBHHDJY63BQDEWDQL6Z6YEJDVFLJ4H5BZHHG6EK45C23R37HAZ3G4LFO","server_name":"NBHHDJY63BQDEWDQL6Z6YEJDVFLJ4H5BZHHG6EK45C23R37HAZ3G4LFO","version":"2.1.4","proto":1,"go":"go1.13.6","host":"0.0.0.0","port":4222,"max_payload":1048576,"client_id":1}
-ERR 'Stale Connection'
Connection closed by foreign host.
 14:09:13 >

Signed-off-by: Matthias Hanel <mh@synadia.com>
