### PR TITLE
Place server's version of client IP in INFO

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1694,6 +1694,7 @@ func (c *client) sendPing() {
 // Assume lock is held.
 func (c *client) generateClientInfoJSON(info Info) []byte {
 	info.CID = c.cid
+	info.ClientHost = c.host
 	info.MaxPayload = c.mpay
 	// Generate the info json
 	b, _ := json.Marshal(info)

--- a/server/client.go
+++ b/server/client.go
@@ -1694,7 +1694,7 @@ func (c *client) sendPing() {
 // Assume lock is held.
 func (c *client) generateClientInfoJSON(info Info) []byte {
 	info.CID = c.cid
-	info.ClientHost = c.host
+	info.ClientIP = c.host
 	info.MaxPayload = c.mpay
 	// Generate the info json
 	b, _ := json.Marshal(info)

--- a/server/server.go
+++ b/server/server.go
@@ -72,6 +72,7 @@ type Info struct {
 	MaxPayload        int32    `json:"max_payload"`
 	IP                string   `json:"ip,omitempty"`
 	CID               uint64   `json:"client_id,omitempty"`
+	ClientHost        string   `json:"client_ip,omitempty"`
 	Nonce             string   `json:"nonce,omitempty"`
 	Cluster           string   `json:"cluster,omitempty"`
 	ClientConnectURLs []string `json:"connect_urls,omitempty"` // Contains URLs a client can connect to.

--- a/server/server.go
+++ b/server/server.go
@@ -72,7 +72,7 @@ type Info struct {
 	MaxPayload        int32    `json:"max_payload"`
 	IP                string   `json:"ip,omitempty"`
 	CID               uint64   `json:"client_id,omitempty"`
-	ClientHost        string   `json:"client_ip,omitempty"`
+	ClientIP          string   `json:"client_ip,omitempty"`
 	Nonce             string   `json:"nonce,omitempty"`
 	Cluster           string   `json:"cluster,omitempty"`
 	ClientConnectURLs []string `json:"connect_urls,omitempty"` // Contains URLs a client can connect to.


### PR DESCRIPTION
This can be used when a NATS client application wants to know its public IP, or at least the server's version of the client IP.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
