### PR TITLE
Adding option to enable tracing the system account. (default: false)

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ Logging Options:
     -D, --debug                      Enable debugging output
     -V, --trace                      Trace the raw protocol
     -DV                              Debug and trace
+    --sys_trace                      Trace the system account (default: false)
 
 Authorization Options:
         --user <user>                User required for connections

--- a/main.go
+++ b/main.go
@@ -43,9 +43,9 @@ Logging Options:
     -r, --remote_syslog <addr>       Syslog server addr (udp://localhost:514)
     -D, --debug                      Enable debugging output
     -V, --trace                      Trace the raw protocol
-    -VV                              Verbose trace (traces system account) 
+    -VV                              Verbose trace (traces system account as well) 
     -DV                              Debug and trace
-    -DVV                             Debug and verbose trace (traces system account) 
+    -DVV                             Debug and verbose trace (traces system account as well) 
 
 Authorization Options:
         --user <user>                User required for connections

--- a/main.go
+++ b/main.go
@@ -43,8 +43,9 @@ Logging Options:
     -r, --remote_syslog <addr>       Syslog server addr (udp://localhost:514)
     -D, --debug                      Enable debugging output
     -V, --trace                      Trace the raw protocol
+    -VV                              Verbose trace (traces system account) 
     -DV                              Debug and trace
-    --sys_trace                      Trace the system account (default: false)
+    -DVV                             Debug and verbose trace (traces system account) 
 
 Authorization Options:
         --user <user>                User required for connections

--- a/server/client.go
+++ b/server/client.go
@@ -451,11 +451,10 @@ func (c *client) initClient() {
 	c.echo = true
 
 	c.debug = (atomic.LoadInt32(&c.srv.logging.debug) != 0)
+	c.trace = (atomic.LoadInt32(&c.srv.logging.trace) != 0)
 
-	if c.kind == SYSTEM {
-		c.trace = c.srv.logging.traceSystemAcc
-	} else {
-		c.trace = (atomic.LoadInt32(&c.srv.logging.trace) != 0)
+	if c.kind == SYSTEM && !c.srv.logging.traceSysAcc {
+		c.trace = false
 	}
 
 	// This is a scratch buffer used for processMsg()

--- a/server/client.go
+++ b/server/client.go
@@ -453,6 +453,10 @@ func (c *client) initClient() {
 	c.debug = (atomic.LoadInt32(&c.srv.logging.debug) != 0)
 	c.trace = (atomic.LoadInt32(&c.srv.logging.trace) != 0)
 
+	if c.kind == SYSTEM && !c.srv.logging.traceSystemAcc {
+		c.trace = false
+	}
+
 	// This is a scratch buffer used for processMsg()
 	// The msg header starts with "RMSG ", which can be used
 	// for both local and routes.

--- a/server/client.go
+++ b/server/client.go
@@ -451,10 +451,11 @@ func (c *client) initClient() {
 	c.echo = true
 
 	c.debug = (atomic.LoadInt32(&c.srv.logging.debug) != 0)
-	c.trace = (atomic.LoadInt32(&c.srv.logging.trace) != 0)
 
-	if c.kind == SYSTEM && !c.srv.logging.traceSystemAcc {
-		c.trace = false
+	if c.kind == SYSTEM {
+		c.trace = c.srv.logging.traceSystemAcc
+	} else {
+		c.trace = (atomic.LoadInt32(&c.srv.logging.trace) != 0)
 	}
 
 	// This is a scratch buffer used for processMsg()

--- a/server/events.go
+++ b/server/events.go
@@ -267,6 +267,11 @@ func (s *Server) internalSendLoop(wg *sync.WaitGroup) {
 			c.pa.reply = []byte(pm.rply)
 			c.mu.Unlock()
 
+			if c.trace {
+				c.traceInOp(fmt.Sprintf(
+					"PUB %s %s %d", c.pa.subject, c.pa.reply, c.pa.size), nil)
+			}
+
 			// Add in NL
 			b = append(b, _CRLF_...)
 			c.processInboundClientMsg(b)

--- a/server/log.go
+++ b/server/log.go
@@ -87,7 +87,7 @@ func (s *Server) ConfigureLogger() {
 
 	s.SetLogger(log, opts.Debug, opts.Trace)
 
-	s.logging.traceSystemAcc = opts.SysTrace
+	s.logging.traceSystemAcc = opts.TraceVerbose
 }
 
 // SetLogger sets the logger of the server

--- a/server/log.go
+++ b/server/log.go
@@ -87,7 +87,7 @@ func (s *Server) ConfigureLogger() {
 
 	s.SetLogger(log, opts.Debug, opts.Trace)
 
-	s.logging.traceSystemAcc = opts.TraceVerbose
+	s.logging.traceSysAcc = opts.TraceVerbose
 }
 
 // SetLogger sets the logger of the server

--- a/server/log.go
+++ b/server/log.go
@@ -86,6 +86,8 @@ func (s *Server) ConfigureLogger() {
 	}
 
 	s.SetLogger(log, opts.Debug, opts.Trace)
+
+	s.logging.traceSystemAcc = opts.SysTrace
 }
 
 // SetLogger sets the logger of the server

--- a/server/opts.go
+++ b/server/opts.go
@@ -149,6 +149,7 @@ type Options struct {
 	ClientAdvertise       string        `json:"-"`
 	Trace                 bool          `json:"-"`
 	Debug                 bool          `json:"-"`
+	SysTrace              bool          `json:"-"`
 	NoLog                 bool          `json:"-"`
 	NoSigs                bool          `json:"-"`
 	NoSublistCache        bool          `json:"-"`
@@ -513,6 +514,9 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 	case "trace":
 		o.Trace = v.(bool)
 		trackExplicitVal(o, &o.inConfig, "Trace", o.Trace)
+	case "sys_trace":
+		o.SysTrace = v.(bool)
+		trackExplicitVal(o, &o.inConfig, "SysTrace", o.SysTrace)
 	case "logtime":
 		o.Logtime = v.(bool)
 		trackExplicitVal(o, &o.inConfig, "Logtime", o.Logtime)
@@ -3042,6 +3046,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.BoolVar(&opts.Trace, "V", false, "Enable Trace logging.")
 	fs.BoolVar(&opts.Trace, "trace", false, "Enable Trace logging.")
 	fs.BoolVar(&dbgAndTrace, "DV", false, "Enable Debug and Trace logging.")
+	fs.BoolVar(&opts.SysTrace, "sys_trace", false, "Trace the system account.")
 	fs.BoolVar(&opts.Logtime, "T", true, "Timestamp log entries.")
 	fs.BoolVar(&opts.Logtime, "logtime", true, "Timestamp log entries.")
 	fs.StringVar(&opts.Username, "user", "", "Username required for connection.")
@@ -3142,6 +3147,8 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "Trace", FlagSnapshot.Trace)
 		case "T":
 			fallthrough
+		case "sys_trace":
+			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "SysTrace", FlagSnapshot.SysTrace)
 		case "logtime":
 			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "Logtime", FlagSnapshot.Logtime)
 		case "s":

--- a/server/opts.go
+++ b/server/opts.go
@@ -3026,15 +3026,15 @@ func setBaselineOptions(opts *Options) {
 func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, printTLSHelp func()) (*Options, error) {
 	opts := &Options{}
 	var (
-		showVersion       bool
-		showHelp          bool
-		showTLSHelp       bool
-		signal            string
-		configFile        string
-		dbgAndTrace       bool
-		traceAndSys       bool
-		dbgAndTraceAndSys bool
-		err               error
+		showVersion            bool
+		showHelp               bool
+		showTLSHelp            bool
+		signal                 string
+		configFile             string
+		dbgAndTrace            bool
+		trcAndVerboseTrc       bool
+		dbgAndTrcAndVerboseTrc bool
+		err                    error
 	)
 
 	fs.BoolVar(&showHelp, "h", false, "Show this message.")
@@ -3048,10 +3048,10 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.BoolVar(&opts.Debug, "D", false, "Enable Debug logging.")
 	fs.BoolVar(&opts.Debug, "debug", false, "Enable Debug logging.")
 	fs.BoolVar(&opts.Trace, "V", false, "Enable Trace logging.")
-	fs.BoolVar(&traceAndSys, "VV", false, "Enable Trace and system account logging.")
+	fs.BoolVar(&trcAndVerboseTrc, "VV", false, "Enable Verbose Trace logging. (Traces system account as well)")
 	fs.BoolVar(&opts.Trace, "trace", false, "Enable Trace logging.")
 	fs.BoolVar(&dbgAndTrace, "DV", false, "Enable Debug and Trace logging.")
-	fs.BoolVar(&dbgAndTraceAndSys, "DVV", false, "Enable Debug, Trace and system account logging.")
+	fs.BoolVar(&dbgAndTrcAndVerboseTrc, "DVV", false, "Enable Debug and Verbose Trace logging. (Traces system account as well)")
 	fs.BoolVar(&opts.Logtime, "T", true, "Timestamp log entries.")
 	fs.BoolVar(&opts.Logtime, "logtime", true, "Timestamp log entries.")
 	fs.StringVar(&opts.Username, "user", "", "Username required for connection.")
@@ -3140,9 +3140,9 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.Visit(func(f *flag.Flag) {
 		switch f.Name {
 		case "DVV":
-			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "Debug", dbgAndTraceAndSys)
-			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "Trace", dbgAndTraceAndSys)
-			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "Syslog", dbgAndTraceAndSys)
+			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "Debug", dbgAndTrcAndVerboseTrc)
+			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "Trace", dbgAndTrcAndVerboseTrc)
+			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "TraceVerbose", dbgAndTrcAndVerboseTrc)
 		case "DV":
 			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "Debug", dbgAndTrace)
 			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "Trace", dbgAndTrace)
@@ -3151,8 +3151,8 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 		case "debug":
 			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "Debug", FlagSnapshot.Debug)
 		case "VV":
-			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "Trace", traceAndSys)
-			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "Syslog", traceAndSys)
+			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "Trace", trcAndVerboseTrc)
+			trackExplicitVal(FlagSnapshot, &FlagSnapshot.inCmdLine, "TraceVerbose", trcAndVerboseTrc)
 		case "V":
 			fallthrough
 		case "trace":
@@ -3234,9 +3234,9 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 		} else {
 			switch f.Name {
 			case "VV":
-				opts.Trace, opts.TraceVerbose = traceAndSys, traceAndSys
+				opts.Trace, opts.TraceVerbose = trcAndVerboseTrc, trcAndVerboseTrc
 			case "DVV":
-				opts.Trace, opts.Debug, opts.TraceVerbose = dbgAndTraceAndSys, dbgAndTraceAndSys, dbgAndTraceAndSys
+				opts.Trace, opts.Debug, opts.TraceVerbose = dbgAndTrcAndVerboseTrc, dbgAndTrcAndVerboseTrc, dbgAndTrcAndVerboseTrc
 			case "DV":
 				// Check value to support -DV=false
 				opts.Trace, opts.Debug = dbgAndTrace, dbgAndTrace

--- a/server/server.go
+++ b/server/server.go
@@ -153,10 +153,10 @@ type Server struct {
 
 	logging struct {
 		sync.RWMutex
-		logger         Logger
-		trace          int32
-		debug          int32
-		traceSystemAcc bool
+		logger      Logger
+		trace       int32
+		debug       int32
+		traceSysAcc bool
 	}
 
 	clientConnectURLs []string

--- a/server/server.go
+++ b/server/server.go
@@ -153,9 +153,10 @@ type Server struct {
 
 	logging struct {
 		sync.RWMutex
-		logger Logger
-		trace  int32
-		debug  int32
+		logger         Logger
+		trace          int32
+		debug          int32
+		traceSystemAcc bool
 	}
 
 	clientConnectURLs []string


### PR DESCRIPTION
Use sys_trace option in config file or --sys_trace on the command line

I made this non reloadable as this affects clients and reload does not alter existing clients.
(Will address this in a separate PR)