### PR TITLE
[FIXED] Incorrect buffer reuse in case of partial connection write

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1035,6 +1035,10 @@ func (c *client) flushOutbound() bool {
 
 	// For selecting primary replacement.
 	cnb := nb
+	var lfs int
+	if len(cnb) > 0 {
+		lfs = len(cnb[0])
+	}
 
 	// In case it goes away after releasing the lock.
 	nc := c.nc
@@ -1112,7 +1116,7 @@ func (c *client) flushOutbound() bool {
 	}
 
 	// Check to see if we can reuse buffers.
-	if len(cnb) > 0 && n >= int64(len(cnb[0])) {
+	if lfs != 0 && n >= int64(lfs) {
 		oldp := cnb[0][:0]
 		if cap(oldp) >= int(c.out.sz) {
 			// Replace primary or secondary if they are nil, reusing same buffer.

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -1916,3 +1916,82 @@ func TestClientIPv6Address(t *testing.T) {
 		t.Fatalf("Wrong string representation of an IPv6 address: %q", ncs)
 	}
 }
+
+func TestPBNotIncreasedOnMaxPending(t *testing.T) {
+	opts := DefaultOptions()
+	opts.MaxPending = 100
+	s := &Server{opts: opts}
+	c := &client{srv: s}
+	c.initClient()
+
+	c.mu.Lock()
+	c.queueOutbound(make([]byte, 200))
+	pb := c.out.pb
+	c.mu.Unlock()
+
+	if pb != 0 {
+		t.Fatalf("c.out.pb should be 0, got %v", pb)
+	}
+}
+
+type testConnWritePartial struct {
+	net.Conn
+	partial bool
+	buf     bytes.Buffer
+}
+
+func (c *testConnWritePartial) Write(p []byte) (int, error) {
+	n := len(p)
+	if c.partial {
+		n = 5
+	}
+	return c.buf.Write(p[:n])
+}
+
+func (c *testConnWritePartial) SetWriteDeadline(_ time.Time) error {
+	return nil
+}
+
+func TestFlushOutboundNoSliceReuseIfPartial(t *testing.T) {
+	opts := DefaultOptions()
+	opts.MaxPending = 1024
+	s := &Server{opts: opts}
+
+	fakeConn := &testConnWritePartial{}
+	c := &client{srv: s, nc: fakeConn}
+	c.initClient()
+
+	bufs := [][]byte{
+		[]byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+		[]byte("------"),
+		[]byte("0123456789"),
+	}
+	expected := bytes.Buffer{}
+	for i, buf := range bufs {
+		expected.Write(buf)
+		c.mu.Lock()
+		if i == 0 {
+			fakeConn.partial = true
+			c.out.sz = 10
+		} else {
+			fakeConn.partial = false
+			c.out.sz = 5
+		}
+		c.queueOutbound(buf)
+		c.flushOutbound()
+		c.mu.Unlock()
+	}
+	// Ensure everything is flushed.
+	for done := false; !done; {
+		c.mu.Lock()
+		if c.out.pb > 0 {
+			c.flushOutbound()
+		} else {
+			done = true
+		}
+		c.mu.Unlock()
+	}
+	if !bytes.Equal(expected.Bytes(), fakeConn.buf.Bytes()) {
+		t.Fatalf("Expected\n%q\ngot\n%q", expected.String(), fakeConn.buf.String())
+	}
+}


### PR DESCRIPTION
Added a test that demonstrates the issue and a proposed fix.

Also fixed the incorrect increment of c.out.pb when going over
MaxPending.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
