### PR TITLE
add the nats utility into the server container

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,3 +1,4 @@
+FROM synadia/jsm:latest AS jsm
 FROM golang:1.13.7-alpine3.11 AS builder
 
 WORKDIR $GOPATH/src/github.com/nats-io/nats-server
@@ -16,6 +17,7 @@ RUN apk add --update ca-certificates && mkdir -p /nats/bin && mkdir /nats/conf
 
 COPY docker/nats-server.conf /nats/conf/nats-server.conf
 COPY --from=builder /nats-server /nats/bin/nats-server
+COPY --from=jsm /usr/local/bin/nats /usr/local/bin/
 
 # NOTE: For backwards compatibility, we add a symlink to /gnatsd which is
 # where the binary from the scratch container image used to be located.


### PR DESCRIPTION
 - [x] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request:

@ColinSullivan1 suggested we might add the `nats` binary to the server container, so here it is.
Happy to defer till later

/cc @nats-io/core
