### PR TITLE
[FIXED] trace/debug/sys_log reload will affect existing clients

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -2562,7 +2562,7 @@ func (c *client) deliverMsg(sub *subscription, subject, mh, msg []byte, gwrply b
 		c.pcd[client] = needFlush
 	}
 
-	if c.trace {
+	if client.trace {
 		client.traceOutOp(string(mh[:len(mh)-LEN_CR_LF]), nil)
 	}
 

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1723,7 +1723,7 @@ func (c *client) processGatewayAccountSub(accName string) error {
 // the sublist if present.
 // <Invoked from outbound connection's readLoop>
 func (c *client) processGatewayRUnsub(arg []byte, trace bool) error {
-	accName, subject, queue, err := c.parseUnsubProto(trace, arg)
+	accName, subject, queue, err := c.parseUnsubProto(arg, trace)
 	if err != nil {
 		return fmt.Errorf("processGatewaySubjectUnsub %s", err.Error())
 	}

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1722,8 +1722,8 @@ func (c *client) processGatewayAccountSub(accName string) error {
 // If in modeInterestOnly or for a queue sub, remove from
 // the sublist if present.
 // <Invoked from outbound connection's readLoop>
-func (c *client) processGatewayRUnsub(arg []byte, trace bool) error {
-	accName, subject, queue, err := c.parseUnsubProto(arg, trace)
+func (c *client) processGatewayRUnsub(arg []byte) error {
+	accName, subject, queue, err := c.parseUnsubProto(arg)
 	if err != nil {
 		return fmt.Errorf("processGatewaySubjectUnsub %s", err.Error())
 	}
@@ -1813,11 +1813,7 @@ func (c *client) processGatewayRUnsub(arg []byte, trace bool) error {
 // For queue subs, or if in modeInterestOnly, register interest
 // from remote gateway.
 // <Invoked from outbound connection's readLoop>
-func (c *client) processGatewayRSub(arg []byte, trace bool) error {
-	if trace {
-		c.traceInOp("RS+", arg)
-	}
-
+func (c *client) processGatewayRSub(arg []byte) error {
 	// Indicate activity.
 	c.in.subs++
 
@@ -2727,15 +2723,11 @@ func (c *client) handleGatewayReply(msg []byte) (processed bool) {
 // account or subject for which there is no interest in this cluster
 // an A-/RS- protocol may be send back.
 // <Invoked from inbound connection's readLoop>
-func (c *client) processInboundGatewayMsg(msg []byte, trace bool) {
+func (c *client) processInboundGatewayMsg(msg []byte) {
 	// Update statistics
 	c.in.msgs++
 	// The msg includes the CR_LF, so pull back out for accounting.
 	c.in.bytes += int32(len(msg) - LEN_CR_LF)
-
-	if trace {
-		c.traceMsg(msg)
-	}
 
 	if c.opts.Verbose {
 		c.sendOK()

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1722,8 +1722,8 @@ func (c *client) processGatewayAccountSub(accName string) error {
 // If in modeInterestOnly or for a queue sub, remove from
 // the sublist if present.
 // <Invoked from outbound connection's readLoop>
-func (c *client) processGatewayRUnsub(arg []byte) error {
-	accName, subject, queue, err := c.parseUnsubProto(arg)
+func (c *client) processGatewayRUnsub(arg []byte, trace bool) error {
+	accName, subject, queue, err := c.parseUnsubProto(trace, arg)
 	if err != nil {
 		return fmt.Errorf("processGatewaySubjectUnsub %s", err.Error())
 	}
@@ -1813,8 +1813,10 @@ func (c *client) processGatewayRUnsub(arg []byte) error {
 // For queue subs, or if in modeInterestOnly, register interest
 // from remote gateway.
 // <Invoked from outbound connection's readLoop>
-func (c *client) processGatewayRSub(arg []byte) error {
-	c.traceInOp("RS+", arg)
+func (c *client) processGatewayRSub(arg []byte, trace bool) error {
+	if trace {
+		c.traceInOp("RS+", arg)
+	}
 
 	// Indicate activity.
 	c.in.subs++
@@ -2725,13 +2727,13 @@ func (c *client) handleGatewayReply(msg []byte) (processed bool) {
 // account or subject for which there is no interest in this cluster
 // an A-/RS- protocol may be send back.
 // <Invoked from inbound connection's readLoop>
-func (c *client) processInboundGatewayMsg(msg []byte) {
+func (c *client) processInboundGatewayMsg(msg []byte, trace bool) {
 	// Update statistics
 	c.in.msgs++
 	// The msg includes the CR_LF, so pull back out for accounting.
 	c.in.bytes += int32(len(msg) - LEN_CR_LF)
 
-	if c.trace {
+	if trace {
 		c.traceMsg(msg)
 	}
 

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1193,6 +1193,7 @@ func (c *client) sendAllLeafSubs() {
 	c.mu.Unlock()
 }
 
+// Lock should be held.
 func (c *client) writeLeafSub(w *bytes.Buffer, key string, n int32) {
 	if key == "" {
 		return
@@ -1226,8 +1227,10 @@ func (c *client) writeLeafSub(w *bytes.Buffer, key string, n int32) {
 }
 
 // processLeafSub will process an inbound sub request for the remote leaf node.
-func (c *client) processLeafSub(argo []byte) (err error) {
-	c.traceInOp("LS+", argo)
+func (c *client) processLeafSub(argo []byte, trace bool) (err error) {
+	if trace {
+		c.traceInOp("LS+", argo)
+	}
 
 	// Indicate activity.
 	c.in.subs++
@@ -1352,8 +1355,10 @@ func (s *Server) reportLeafNodeLoop(c *client) {
 }
 
 // processLeafUnsub will process an inbound unsub request for the remote leaf node.
-func (c *client) processLeafUnsub(arg []byte) error {
-	c.traceInOp("LS-", arg)
+func (c *client) processLeafUnsub(arg []byte, trace bool) error {
+	if trace {
+		c.traceInOp("LS-", arg)
+	}
 
 	// Indicate any activity, so pub and sub or unsubs.
 	c.in.subs++
@@ -1389,7 +1394,7 @@ func (c *client) processLeafUnsub(arg []byte) error {
 	return nil
 }
 
-func (c *client) processLeafMsgArgs(trace bool, arg []byte) error {
+func (c *client) processLeafMsgArgs(arg []byte, trace bool) error {
 	if trace {
 		c.traceInOp("LMSG", arg)
 	}
@@ -1464,13 +1469,13 @@ func (c *client) processLeafMsgArgs(trace bool, arg []byte) error {
 }
 
 // processInboundLeafMsg is called to process an inbound msg from a leaf node.
-func (c *client) processInboundLeafMsg(msg []byte) {
+func (c *client) processInboundLeafMsg(msg []byte, trace bool) {
 	// Update statistics
 	c.in.msgs++
 	// The msg includes the CR_LF, so pull back out for accounting.
 	c.in.bytes += int32(len(msg) - LEN_CR_LF)
 
-	if c.trace {
+	if trace {
 		c.traceMsg(msg)
 	}
 

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1227,11 +1227,7 @@ func (c *client) writeLeafSub(w *bytes.Buffer, key string, n int32) {
 }
 
 // processLeafSub will process an inbound sub request for the remote leaf node.
-func (c *client) processLeafSub(argo []byte, trace bool) (err error) {
-	if trace {
-		c.traceInOp("LS+", argo)
-	}
-
+func (c *client) processLeafSub(argo []byte) (err error) {
 	// Indicate activity.
 	c.in.subs++
 
@@ -1355,11 +1351,7 @@ func (s *Server) reportLeafNodeLoop(c *client) {
 }
 
 // processLeafUnsub will process an inbound unsub request for the remote leaf node.
-func (c *client) processLeafUnsub(arg []byte, trace bool) error {
-	if trace {
-		c.traceInOp("LS-", arg)
-	}
-
+func (c *client) processLeafUnsub(arg []byte) error {
 	// Indicate any activity, so pub and sub or unsubs.
 	c.in.subs++
 
@@ -1394,11 +1386,7 @@ func (c *client) processLeafUnsub(arg []byte, trace bool) error {
 	return nil
 }
 
-func (c *client) processLeafMsgArgs(arg []byte, trace bool) error {
-	if trace {
-		c.traceInOp("LMSG", arg)
-	}
-
+func (c *client) processLeafMsgArgs(arg []byte) error {
 	// Unroll splitArgs to avoid runtime/heap issues
 	a := [MAX_MSG_ARGS][]byte{}
 	args := a[:0]
@@ -1469,15 +1457,11 @@ func (c *client) processLeafMsgArgs(arg []byte, trace bool) error {
 }
 
 // processInboundLeafMsg is called to process an inbound msg from a leaf node.
-func (c *client) processInboundLeafMsg(msg []byte, trace bool) {
+func (c *client) processInboundLeafMsg(msg []byte) {
 	// Update statistics
 	c.in.msgs++
 	// The msg includes the CR_LF, so pull back out for accounting.
 	c.in.bytes += int32(len(msg) - LEN_CR_LF)
-
-	if trace {
-		c.traceMsg(msg)
-	}
 
 	// Check pub permissions
 	if c.perms != nil && (c.perms.pub.allow != nil || c.perms.pub.deny != nil) && !c.pubAllowed(string(c.pa.subject)) {

--- a/server/log.go
+++ b/server/log.go
@@ -85,13 +85,16 @@ func (s *Server) ConfigureLogger() {
 		log = srvlog.NewStdLogger(opts.Logtime, opts.Debug, opts.Trace, colors, true)
 	}
 
-	s.SetLogger(log, opts.Debug, opts.Trace)
-
-	s.logging.traceSysAcc = opts.TraceVerbose
+	s.SetLoggerV2(log, opts.Debug, opts.Trace, opts.TraceVerbose)
 }
 
 // SetLogger sets the logger of the server
 func (s *Server) SetLogger(logger Logger, debugFlag, traceFlag bool) {
+	s.SetLoggerV2(logger, debugFlag, traceFlag, false)
+}
+
+// SetLogger sets the logger of the server
+func (s *Server) SetLoggerV2(logger Logger, debugFlag, traceFlag, sysTrace bool) {
 	if debugFlag {
 		atomic.StoreInt32(&s.logging.debug, 1)
 	} else {
@@ -101,6 +104,11 @@ func (s *Server) SetLogger(logger Logger, debugFlag, traceFlag bool) {
 		atomic.StoreInt32(&s.logging.trace, 1)
 	} else {
 		atomic.StoreInt32(&s.logging.trace, 0)
+	}
+	if sysTrace {
+		atomic.StoreInt32(&s.logging.traceSysAcc, 1)
+	} else {
+		atomic.StoreInt32(&s.logging.traceSysAcc, 0)
 	}
 	s.logging.Lock()
 	if s.logging.logger != nil {

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -301,7 +301,7 @@ func TestParsePubArg(t *testing.T) {
 			subject: "foo", reply: "", size: 2222, szb: "2222"},
 	} {
 		t.Run(test.arg, func(t *testing.T) {
-			if err := c.processPub([]byte(test.arg), false); err != nil {
+			if err := c.processPub([]byte(test.arg)); err != nil {
 				t.Fatalf("Unexpected parse error: %v\n", err)
 			}
 			if !bytes.Equal(c.pa.subject, []byte(test.subject)) {
@@ -324,7 +324,7 @@ func TestParsePubBadSize(t *testing.T) {
 	c := dummyClient()
 	// Setup localized max payload
 	c.mpay = 32768
-	if err := c.processPub([]byte("foo 2222222222222222"), false); err == nil {
+	if err := c.processPub([]byte("foo 2222222222222222")); err == nil {
 		t.Fatalf("Expected parse error for size too large")
 	}
 }

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -301,7 +301,7 @@ func TestParsePubArg(t *testing.T) {
 			subject: "foo", reply: "", size: 2222, szb: "2222"},
 	} {
 		t.Run(test.arg, func(t *testing.T) {
-			if err := c.processPub(false, []byte(test.arg)); err != nil {
+			if err := c.processPub([]byte(test.arg), false); err != nil {
 				t.Fatalf("Unexpected parse error: %v\n", err)
 			}
 			if !bytes.Equal(c.pa.subject, []byte(test.subject)) {
@@ -324,7 +324,7 @@ func TestParsePubBadSize(t *testing.T) {
 	c := dummyClient()
 	// Setup localized max payload
 	c.mpay = 32768
-	if err := c.processPub(false, []byte("foo 2222222222222222")); err == nil {
+	if err := c.processPub([]byte("foo 2222222222222222"), false); err == nil {
 		t.Fatalf("Expected parse error for size too large")
 	}
 }

--- a/server/reload.go
+++ b/server/reload.go
@@ -901,7 +901,7 @@ func (s *Server) reloadClientTraceLevel() {
 
 	s.gateway.RLock()
 	clientCnt += len(s.gateway.in) + len(s.gateway.outo)
-	s.gateway.Unlock()
+	s.gateway.RUnlock()
 
 	clients := make([]*client, 0, clientCnt)
 

--- a/server/reload.go
+++ b/server/reload.go
@@ -895,8 +895,8 @@ func (s *Server) reloadClientTraceLevel() {
 	update := func(c *client) {
 		// client.trace is commonly read while holding the lock
 		c.mu.Lock()
-		defer c.mu.Unlock()
 		c.setTraceLevel()
+		c.mu.Unlock()
 	}
 
 	// Iterate over every client and update

--- a/server/route.go
+++ b/server/route.go
@@ -139,8 +139,10 @@ func (c *client) removeReplySubTimeout(sub *subscription) {
 	}
 }
 
-func (c *client) processAccountSub(arg []byte) error {
-	c.traceInOp("A+", arg)
+func (c *client) processAccountSub(arg []byte, trace bool) error {
+	if trace {
+		c.traceInOp("A+", arg)
+	}
 	accName := string(arg)
 	if c.kind == GATEWAY {
 		return c.processGatewayAccountSub(accName)
@@ -157,7 +159,7 @@ func (c *client) processAccountUnsub(arg []byte) {
 }
 
 // Process an inbound RMSG specification from the remote route.
-func (c *client) processRoutedMsgArgs(trace bool, arg []byte) error {
+func (c *client) processRoutedMsgArgs(arg []byte, trace bool) error {
 	if trace {
 		c.traceInOp("RMSG", arg)
 	}
@@ -232,13 +234,13 @@ func (c *client) processRoutedMsgArgs(trace bool, arg []byte) error {
 }
 
 // processInboundRouteMsg is called to process an inbound msg from a route.
-func (c *client) processInboundRoutedMsg(msg []byte) {
+func (c *client) processInboundRoutedMsg(msg []byte, trace bool) {
 	// Update statistics
 	c.in.msgs++
 	// The msg includes the CR_LF, so pull back out for accounting.
 	c.in.bytes += int32(len(msg) - LEN_CR_LF)
 
-	if c.trace {
+	if trace {
 		c.traceMsg(msg)
 	}
 
@@ -666,8 +668,10 @@ func (c *client) removeRemoteSubs() {
 	}
 }
 
-func (c *client) parseUnsubProto(arg []byte) (string, []byte, []byte, error) {
-	c.traceInOp("RS-", arg)
+func (c *client) parseUnsubProto(trace bool, arg []byte) (string, []byte, []byte, error) {
+	if trace {
+		c.traceInOp("RS-", arg)
+	}
 
 	// Indicate any activity, so pub and sub or unsubs.
 	c.in.subs++
@@ -686,12 +690,12 @@ func (c *client) parseUnsubProto(arg []byte) (string, []byte, []byte, error) {
 }
 
 // Indicates no more interest in the given account/subject for the remote side.
-func (c *client) processRemoteUnsub(arg []byte) (err error) {
+func (c *client) processRemoteUnsub(arg []byte, trace bool) (err error) {
 	srv := c.srv
 	if srv == nil {
 		return nil
 	}
-	accountName, subject, _, err := c.parseUnsubProto(arg)
+	accountName, subject, _, err := c.parseUnsubProto(trace, arg)
 	if err != nil {
 		return fmt.Errorf("processRemoteUnsub %s", err.Error())
 	}
@@ -736,8 +740,10 @@ func (c *client) processRemoteUnsub(arg []byte) (err error) {
 	return nil
 }
 
-func (c *client) processRemoteSub(argo []byte) (err error) {
-	c.traceInOp("RS+", argo)
+func (c *client) processRemoteSub(argo []byte, trace bool) (err error) {
+	if trace {
+		c.traceInOp("RS+", argo)
+	}
 
 	// Indicate activity.
 	c.in.subs++

--- a/server/route.go
+++ b/server/route.go
@@ -668,7 +668,7 @@ func (c *client) removeRemoteSubs() {
 	}
 }
 
-func (c *client) parseUnsubProto(trace bool, arg []byte) (string, []byte, []byte, error) {
+func (c *client) parseUnsubProto(arg []byte, trace bool) (string, []byte, []byte, error) {
 	if trace {
 		c.traceInOp("RS-", arg)
 	}
@@ -695,7 +695,7 @@ func (c *client) processRemoteUnsub(arg []byte, trace bool) (err error) {
 	if srv == nil {
 		return nil
 	}
-	accountName, subject, _, err := c.parseUnsubProto(trace, arg)
+	accountName, subject, _, err := c.parseUnsubProto(arg, trace)
 	if err != nil {
 		return fmt.Errorf("processRemoteUnsub %s", err.Error())
 	}

--- a/server/route.go
+++ b/server/route.go
@@ -139,10 +139,7 @@ func (c *client) removeReplySubTimeout(sub *subscription) {
 	}
 }
 
-func (c *client) processAccountSub(arg []byte, trace bool) error {
-	if trace {
-		c.traceInOp("A+", arg)
-	}
+func (c *client) processAccountSub(arg []byte) error {
 	accName := string(arg)
 	if c.kind == GATEWAY {
 		return c.processGatewayAccountSub(accName)
@@ -151,7 +148,6 @@ func (c *client) processAccountSub(arg []byte, trace bool) error {
 }
 
 func (c *client) processAccountUnsub(arg []byte) {
-	c.traceInOp("A-", arg)
 	accName := string(arg)
 	if c.kind == GATEWAY {
 		c.processGatewayAccountUnsub(accName)
@@ -159,10 +155,7 @@ func (c *client) processAccountUnsub(arg []byte) {
 }
 
 // Process an inbound RMSG specification from the remote route.
-func (c *client) processRoutedMsgArgs(arg []byte, trace bool) error {
-	if trace {
-		c.traceInOp("RMSG", arg)
-	}
+func (c *client) processRoutedMsgArgs(arg []byte) error {
 	// Unroll splitArgs to avoid runtime/heap issues
 	a := [MAX_MSG_ARGS][]byte{}
 	args := a[:0]
@@ -234,15 +227,11 @@ func (c *client) processRoutedMsgArgs(arg []byte, trace bool) error {
 }
 
 // processInboundRouteMsg is called to process an inbound msg from a route.
-func (c *client) processInboundRoutedMsg(msg []byte, trace bool) {
+func (c *client) processInboundRoutedMsg(msg []byte) {
 	// Update statistics
 	c.in.msgs++
 	// The msg includes the CR_LF, so pull back out for accounting.
 	c.in.bytes += int32(len(msg) - LEN_CR_LF)
-
-	if trace {
-		c.traceMsg(msg)
-	}
 
 	if c.opts.Verbose {
 		c.sendOK()
@@ -668,11 +657,7 @@ func (c *client) removeRemoteSubs() {
 	}
 }
 
-func (c *client) parseUnsubProto(arg []byte, trace bool) (string, []byte, []byte, error) {
-	if trace {
-		c.traceInOp("RS-", arg)
-	}
-
+func (c *client) parseUnsubProto(arg []byte) (string, []byte, []byte, error) {
 	// Indicate any activity, so pub and sub or unsubs.
 	c.in.subs++
 
@@ -690,12 +675,12 @@ func (c *client) parseUnsubProto(arg []byte, trace bool) (string, []byte, []byte
 }
 
 // Indicates no more interest in the given account/subject for the remote side.
-func (c *client) processRemoteUnsub(arg []byte, trace bool) (err error) {
+func (c *client) processRemoteUnsub(arg []byte) (err error) {
 	srv := c.srv
 	if srv == nil {
 		return nil
 	}
-	accountName, subject, _, err := c.parseUnsubProto(arg, trace)
+	accountName, subject, _, err := c.parseUnsubProto(arg)
 	if err != nil {
 		return fmt.Errorf("processRemoteUnsub %s", err.Error())
 	}
@@ -740,11 +725,7 @@ func (c *client) processRemoteUnsub(arg []byte, trace bool) (err error) {
 	return nil
 }
 
-func (c *client) processRemoteSub(argo []byte, trace bool) (err error) {
-	if trace {
-		c.traceInOp("RS+", argo)
-	}
-
+func (c *client) processRemoteSub(argo []byte) (err error) {
 	// Indicate activity.
 	c.in.subs++
 

--- a/server/server.go
+++ b/server/server.go
@@ -157,7 +157,7 @@ type Server struct {
 		logger      Logger
 		trace       int32
 		debug       int32
-		traceSysAcc bool
+		traceSysAcc int32
 	}
 
 	clientConnectURLs []string


### PR DESCRIPTION
Fixed #1296, by altering client state on reload

Detect a trace level change on reload and update all clients.
To avoid data races, read client.trace while holding the lock,
pass the value into functions that trace while not holding the lock.
Delete unused client.debug.

Taking to @kozlovic, we had no strong opinions for/against holding the server lock while updating clients.

Signed-off-by: Matthias Hanel <mh@synadia.com>