### PR TITLE
[CHANGED] Include port in "Connected leafnode" log statement

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -285,7 +285,7 @@ func (s *Server) connectToRemoteLeafNode(remote *leafNodeCfg, firstConnect bool)
 		// We will put this in the normal log if first connect, does not force -DV mode to know
 		// that the connect worked.
 		if firstConnect {
-			s.Noticef("Connected leafnode to %q", rURL.Hostname())
+			s.Noticef("Connected leafnode to %q", rURL.Host)
 		}
 		return
 	}


### PR DESCRIPTION
Sample output
[62401] 2020/03/06 15:15:55.433837 [INF] Starting nats-server version 2.1.4
[62401] 2020/03/06 15:15:55.434100 [INF] Git commit [not set]
[62401] 2020/03/06 15:15:55.434932 [INF] Listening for client connections on 127.0.0.1:5222
[62401] 2020/03/06 15:15:55.435001 [INF] Server id is ND7OUS...HSLES
[62401] 2020/03/06 15:15:55.435024 [INF] Server is ready
[62401] 2020/03/06 15:15:55.435320 [ERR] Error trying to connect as leafnode to remote server "127.0.0.1:6223" (attempt 1): dial tcp 127.0.0.1:6223: connect: connection refused
[62401] 2020/03/06 15:15:55.436832 [INF] Connected leafnode to "127.0.0.1:4223"
[62401] 2020/03/06 15:15:59.449039 [INF] Connected leafnode to "127.0.0.1:6223"

Signed-off-by: Matthias Hanel <mh@synadia.com>
