### PR TITLE
[ADDED] Value of GOMAXPROCS in /varz monitoring output

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1111,8 +1111,10 @@ func (s *Server) createVarz(pcpu float64, rss int64) *Varz {
 			TLSTimeout:  ln.TLSTimeout,
 			Remotes:     []RemoteLeafOptsVarz{},
 		},
-		Start:   s.start,
-		MaxSubs: opts.MaxSubs,
+		Start:    s.start,
+		MaxSubs:  opts.MaxSubs,
+		Cores:    numCores,
+		MaxProcs: maxProcs,
 	}
 	if len(opts.Routes) > 0 {
 		varz.Cluster.URLs = urlsToStrings(opts.Routes)
@@ -1192,8 +1194,6 @@ func (s *Server) updateVarzRuntimeFields(v *Varz, forceUpdate bool, pcpu float64
 	v.Uptime = myUptime(time.Since(s.start))
 	v.Mem = rss
 	v.CPU = pcpu
-	v.Cores = numCores
-	v.MaxProcs = maxProcs
 	if l := len(s.info.ClientConnectURLs); l > 0 {
 		v.ClientConnectURLs = make([]string, l)
 		copy(v.ClientConnectURLs, s.info.ClientConnectURLs)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -32,9 +32,11 @@ import (
 
 // Snapshot this
 var numCores int
+var maxProcs int
 
 func init() {
 	numCores = runtime.NumCPU()
+	maxProcs = runtime.GOMAXPROCS(0)
 }
 
 // Connz represents detailed information on current client connections.
@@ -926,6 +928,7 @@ type Varz struct {
 	Uptime            string            `json:"uptime"`
 	Mem               int64             `json:"mem"`
 	Cores             int               `json:"cores"`
+	MaxProcs          int               `json:"gomaxprocs"`
 	CPU               float64           `json:"cpu"`
 	Connections       int               `json:"connections"`
 	TotalConnections  uint64            `json:"total_connections"`
@@ -1190,6 +1193,7 @@ func (s *Server) updateVarzRuntimeFields(v *Varz, forceUpdate bool, pcpu float64
 	v.Mem = rss
 	v.CPU = pcpu
 	v.Cores = numCores
+	v.MaxProcs = maxProcs
 	if l := len(s.info.ClientConnectURLs); l > 0 {
 		v.ClientConnectURLs = make([]string, l)
 		copy(v.ClientConnectURLs, s.info.ClientConnectURLs)


### PR DESCRIPTION
Sample output of  /varz
{
...
  "cores": 16,
  "gomaxprocs": 16,
  ...
  },
  "config_load_time": "2020-03-06T13:55:53.816454-05:00"
}

Signed-off-by: Matthias Hanel <mh@synadia.com>
