### PR TITLE
Fixed TestVersionMatchesTag test

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -104,7 +104,8 @@ func RunServerWithConfig(configFile string) (srv *Server, opts *Options) {
 
 func TestVersionMatchesTag(t *testing.T) {
 	tag := os.Getenv("TRAVIS_TAG")
-	if tag == "" {
+	// Travis started to return '' when no tag is set. Support both now.
+	if tag == "" || tag == "''" {
 		t.SkipNow()
 	}
 	// We expect a tag of the form vX.Y.Z. If that's not the case,


### PR DESCRIPTION
When no tag was set, os.Getenv("TRAVIS_TAG") would return empty string.
Travis now set TRAVIS_TAG to `''`. So check for both.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
