### PR TITLE
[FIXED] loop detection by checking for duplicate lds subscriptions

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1704,14 +1704,6 @@ func (a *Account) hasIssuerNoLock(issuer string) bool {
 	return false
 }
 
-// Returns the loop detection subject used for leafnodes
-func (a *Account) getLds() string {
-	a.mu.RLock()
-	lds := a.lds
-	a.mu.RUnlock()
-	return lds
-}
-
 // Placeholder for signaling token auth required.
 var tokenAuthReq = []*Account{}
 

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -360,10 +360,16 @@ func runSolicitWithCredentials(t *testing.T, opts *Options, creds string) (*Serv
 
 // Helper function to check that a leaf node has connected to our server.
 func checkLeafNodeConnected(t *testing.T, s *Server) {
+	checkLeafNodeConnectedCnt(t, s, 1)
+}
+
+// Helper function to check that a leaf node has connected to n server.
+func checkLeafNodeConnectedCnt(t *testing.T, s *Server, lnCons int) {
 	t.Helper()
 	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
-		if nln := s.NumLeafNodes(); nln != 1 {
-			return fmt.Errorf("Expected a connected leafnode for server %q, got none", s.ID())
+		if nln := s.NumLeafNodes(); nln != lnCons {
+			return fmt.Errorf("Expected %d connected leafnode(s) for server %q, got %d",
+				lnCons, s.ID(), nln)
 		}
 		return nil
 	})


### PR DESCRIPTION
This is in addition to checking if the own subscription comes back.
The duplicated lds subscription must come from a different client.
Added unit tests. 
Fixes #1305

Test output in a test where I configued a loop as follows:
A
B->A
C->B
D->C <--- this remote is wrong.
D->A <--- OR this remote is wrong

Server D will detect the error.
This holds true even if it is not the server closing the loop. 
If all server but Server B are running, starting server B will result in Server D detecting the loop and  close one of its connections. Which connection C/A is closed depends on timing, which one of the two connections is last to send the loop detection subscription for A to D.

nats-server -c cfg/daisyC.cfg
[11014] 2020/03/09 15:23:57.998901 [INF] Starting nats-server version 2.1.4
[11014] 2020/03/09 15:23:57.999114 [INF] Git commit [not set]
[11014] 2020/03/09 15:23:57.999560 [INF] Listening for leafnode connections on 0.0.0.0:6223
[11014] 2020/03/09 15:23:58.000821 [INF] Listening for client connections on 127.0.0.1:6222
[11014] 2020/03/09 15:23:58.000838 [INF] Server id is NAIFYASP6QZTGIX56R443LYIAFW3OHOXJA5FVDJ75DBPUMFKNKGBQKAX
[11014] 2020/03/09 15:23:58.000847 [INF] Server is ready
[11014] 2020/03/09 15:23:58.002067 [INF] Connected leafnode to "127.0.0.1"
[11014] 2020/03/09 15:23:59.152147 [ERR] 127.0.0.1:60585 - lid:2 - Leafnode Error 'Loop detected for leafnode account="$G". Delaying attempt to reconnect for 30s'

nats-server -c cfg/daisyD.cfg
[11015] 2020/03/09 15:23:59.148083 [INF] Starting nats-server version 2.1.4
[11015] 2020/03/09 15:23:59.148309 [INF] Git commit [not set]
[11015] 2020/03/09 15:23:59.148752 [INF] Listening for leafnode connections on 0.0.0.0:7223
[11015] 2020/03/09 15:23:59.150107 [INF] Listening for client connections on 127.0.0.1:7222
[11015] 2020/03/09 15:23:59.150126 [INF] Server id is NAYWWTCLBPOW7HBKXFF4TEGPXB6N7RMU3AJX4KTB5I64IGGVSLILXPAK
[11015] 2020/03/09 15:23:59.150136 [INF] Server is ready
[11015] 2020/03/09 15:23:59.151522 [INF] Connected leafnode to "127.0.0.1"
[11015] 2020/03/09 15:23:59.151528 [INF] Connected leafnode to "127.0.0.1"
[11015] 2020/03/09 15:23:59.152028 [ERR] 127.0.0.1:6223 - lid:2 - Loop detected for leafnode account="$G". Delaying attempt to reconnect for 30s

Signed-off-by: Matthias Hanel <mh@synadia.com>
