### PR TITLE
Make sure server lock is held while accessing server.gacc

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -438,8 +438,17 @@ func (a *Account) removeClient(c *client) int {
 		}
 	}
 	a.mu.Unlock()
-	if c != nil && c.srv != nil && a != c.srv.gacc && removed {
-		c.srv.accConnsUpdate(a)
+
+	if c != nil && c.srv != nil && removed {
+		doRemove := false
+		c.srv.mu.Lock()
+		if a != c.srv.gacc {
+			doRemove = true
+		}
+		c.srv.mu.Unlock()
+		if doRemove {
+			c.srv.accConnsUpdate(a)
+		}
 	}
 	return n
 }

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -440,11 +440,8 @@ func (a *Account) removeClient(c *client) int {
 	a.mu.Unlock()
 
 	if c != nil && c.srv != nil && removed {
-		doRemove := false
 		c.srv.mu.Lock()
-		if a != c.srv.gacc {
-			doRemove = true
-		}
+		doRemove := a != c.srv.gacc
 		c.srv.mu.Unlock()
 		if doRemove {
 			c.srv.accConnsUpdate(a)

--- a/server/client.go
+++ b/server/client.go
@@ -1403,9 +1403,12 @@ func (c *client) processConnect(arg []byte) error {
 				c.mu.Lock()
 				acc := c.acc
 				c.mu.Unlock()
+				srv.mu.Lock()
 				if acc != nil && acc != srv.gacc {
+					srv.mu.Unlock()
 					return ErrTooManyAccountConnections
 				}
+				srv.mu.Unlock()
 			}
 			c.authViolation()
 			return ErrAuthentication

--- a/server/client.go
+++ b/server/client.go
@@ -1404,11 +1404,11 @@ func (c *client) processConnect(arg []byte) error {
 				acc := c.acc
 				c.mu.Unlock()
 				srv.mu.Lock()
-				if acc != nil && acc != srv.gacc {
-					srv.mu.Unlock()
+				tooManyAccCons := acc != nil && acc != srv.gacc
+				srv.mu.Unlock()
+				if tooManyAccCons {
 					return ErrTooManyAccountConnections
 				}
-				srv.mu.Unlock()
 			}
 			c.authViolation()
 			return ErrAuthentication

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -772,15 +772,19 @@ func (s *Server) Subsz(opts *SubszOptions) (*Subsz, error) {
 		}
 	}
 
+	s.mu.Lock()
+	gaccSl := s.gacc.sl
+	s.mu.Unlock()
+
 	// FIXME(dlc) - Make account aware.
-	sz := &Subsz{s.gacc.sl.Stats(), 0, offset, limit, nil}
+	sz := &Subsz{gaccSl.Stats(), 0, offset, limit, nil}
 
 	if subdetail {
 		// Now add in subscription's details
 		var raw [4096]*subscription
 		subs := raw[:0]
 
-		s.gacc.sl.localSubs(&subs)
+		gaccSl.localSubs(&subs)
 		details := make([]SubDetail, len(subs))
 		i := 0
 		// TODO(dlc) - may be inefficient and could just do normal match when total subs is large and filtering.

--- a/server/reload.go
+++ b/server/reload.go
@@ -1143,27 +1143,22 @@ func (s *Server) reloadClusterPermissions(oldPerms *RoutePermissions) {
 	// Regenerate route INFO
 	s.generateRouteInfoJSON()
 	infoJSON = s.routeInfoJSON
-	s.mu.Unlock()
 
 	// If there were no route, we are done
 	if len(routes) == 0 {
+		s.mu.Unlock()
 		return
 	}
 
 	// If only older servers, simply close all routes and they will do the right
 	// thing on reconnect.
 	if withNewProto == 0 {
+		s.mu.Unlock()
 		for _, route := range routes {
 			route.closeConnection(RouteRemoved)
 		}
 		return
 	}
-
-	// Fake clients to test cluster permissions
-	oldPermsTester := &client{}
-	oldPermsTester.setRoutePermissions(oldPerms)
-	newPermsTester := &client{}
-	newPermsTester.setRoutePermissions(newPerms)
 
 	var (
 		_localSubs       [4096]*subscription
@@ -1174,6 +1169,13 @@ func (s *Server) reloadClusterPermissions(oldPerms *RoutePermissions) {
 	)
 	// FIXME(dlc) - Change for accounts.
 	s.gacc.sl.localSubs(&localSubs)
+	s.mu.Unlock()
+
+	// Fake clients to test cluster permissions
+	oldPermsTester := &client{}
+	oldPermsTester.setRoutePermissions(oldPerms)
+	newPermsTester := &client{}
+	newPermsTester.setRoutePermissions(newPerms)
 
 	// Go through all local subscriptions
 	for _, sub := range localSubs {
@@ -1220,9 +1222,14 @@ func (s *Server) reloadClusterPermissions(oldPerms *RoutePermissions) {
 		route.sendRouteUnSubProtos(subsNeedUNSUB, false, nil)
 		route.mu.Unlock()
 	}
-	// Remove as a batch all the subs that we have removed from each route.
-	// FIXME(dlc) - Change for accounts.
-	s.gacc.sl.RemoveBatch(deleteRoutedSubs)
+
+	if len(deleteRoutedSubs) > 0 {
+		s.mu.Lock()
+		// Remove as a batch all the subs that we have removed from each route.
+		// FIXME(dlc) - Change for accounts.
+		s.gacc.sl.RemoveBatch(deleteRoutedSubs)
+		s.mu.Unlock()
+	}
 }
 
 // validateClusterOpts ensures the new ClusterOpts does not change host or


### PR DESCRIPTION
Fixes #1314 by:
There was a data race with a write during reloadAuthorization.
Locking was added to all places where it was missing.
In situations were it appeared feasible, access was moved into existing
lock/unlock.
Where it was added, the lock order was already established.


Signed-off-by: Matthias Hanel <mh@synadia.com>

