### PR TITLE
[ADDED] Option to include subscription details in monitoring responses

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -62,6 +62,9 @@ type ConnzOptions struct {
 	// Subscriptions indicates if subscriptions should be included in the results.
 	Subscriptions bool `json:"subscriptions"`
 
+	// SubscriptionsDetail indicates if subscription details should be included in the results
+	SubscriptionsDetail bool `json:"subscriptions_detail"`
+
 	// Offset is used for pagination. Connz() only returns connections starting at this
 	// offset from the global results.
 	Offset int `json:"offset"`
@@ -98,30 +101,31 @@ const (
 
 // ConnInfo has detailed information on a per connection basis.
 type ConnInfo struct {
-	Cid            uint64     `json:"cid"`
-	IP             string     `json:"ip"`
-	Port           int        `json:"port"`
-	Start          time.Time  `json:"start"`
-	LastActivity   time.Time  `json:"last_activity"`
-	Stop           *time.Time `json:"stop,omitempty"`
-	Reason         string     `json:"reason,omitempty"`
-	RTT            string     `json:"rtt,omitempty"`
-	Uptime         string     `json:"uptime"`
-	Idle           string     `json:"idle"`
-	Pending        int        `json:"pending_bytes"`
-	InMsgs         int64      `json:"in_msgs"`
-	OutMsgs        int64      `json:"out_msgs"`
-	InBytes        int64      `json:"in_bytes"`
-	OutBytes       int64      `json:"out_bytes"`
-	NumSubs        uint32     `json:"subscriptions"`
-	Name           string     `json:"name,omitempty"`
-	Lang           string     `json:"lang,omitempty"`
-	Version        string     `json:"version,omitempty"`
-	TLSVersion     string     `json:"tls_version,omitempty"`
-	TLSCipher      string     `json:"tls_cipher_suite,omitempty"`
-	AuthorizedUser string     `json:"authorized_user,omitempty"`
-	Account        string     `json:"account,omitempty"`
-	Subs           []string   `json:"subscriptions_list,omitempty"`
+	Cid            uint64      `json:"cid"`
+	IP             string      `json:"ip"`
+	Port           int         `json:"port"`
+	Start          time.Time   `json:"start"`
+	LastActivity   time.Time   `json:"last_activity"`
+	Stop           *time.Time  `json:"stop,omitempty"`
+	Reason         string      `json:"reason,omitempty"`
+	RTT            string      `json:"rtt,omitempty"`
+	Uptime         string      `json:"uptime"`
+	Idle           string      `json:"idle"`
+	Pending        int         `json:"pending_bytes"`
+	InMsgs         int64       `json:"in_msgs"`
+	OutMsgs        int64       `json:"out_msgs"`
+	InBytes        int64       `json:"in_bytes"`
+	OutBytes       int64       `json:"out_bytes"`
+	NumSubs        uint32      `json:"subscriptions"`
+	Name           string      `json:"name,omitempty"`
+	Lang           string      `json:"lang,omitempty"`
+	Version        string      `json:"version,omitempty"`
+	TLSVersion     string      `json:"tls_version,omitempty"`
+	TLSCipher      string      `json:"tls_cipher_suite,omitempty"`
+	AuthorizedUser string      `json:"authorized_user,omitempty"`
+	Account        string      `json:"account,omitempty"`
+	Subs           []string    `json:"subscriptions_list,omitempty"`
+	SubsDetail     []SubDetail `json:"subscriptions_list_detail,omitempty"`
 }
 
 // DefaultConnListSize is the default size of the connection list.
@@ -132,12 +136,29 @@ const DefaultSubListSize = 1024
 
 const defaultStackBufSize = 10000
 
+func newSubsDetailList(client *client) []SubDetail {
+	subsDetail := make([]SubDetail, 0, len(client.subs))
+	for _, sub := range client.subs {
+		subsDetail = append(subsDetail, newSubDetail(sub))
+	}
+	return subsDetail
+}
+
+func newSubsList(client *client) []string {
+	subs := make([]string, 0, len(client.subs))
+	for _, sub := range client.subs {
+		subs = append(subs, string(sub.subject))
+	}
+	return subs
+}
+
 // Connz returns a Connz struct containing information about connections.
 func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 	var (
 		sortOpt = ByCid
 		auth    bool
 		subs    bool
+		subsDet bool
 		offset  int
 		limit   = DefaultConnListSize
 		cid     = uint64(0)
@@ -166,6 +187,7 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 		acc = opts.Account
 
 		subs = opts.Subscriptions
+		subsDet = opts.SubscriptionsDetail
 		offset = opts.Offset
 		if offset < 0 {
 			offset = 0
@@ -297,10 +319,11 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 		ci := &conns[i]
 		ci.fill(client, client.nc, c.Now)
 		// Fill in subscription data if requested.
-		if subs && len(client.subs) > 0 {
-			ci.Subs = make([]string, 0, len(client.subs))
-			for _, sub := range client.subs {
-				ci.Subs = append(ci.Subs, string(sub.subject))
+		if len(client.subs) > 0 {
+			if subsDet {
+				ci.SubsDetail = newSubsDetailList(client)
+			} else if subs {
+				ci.Subs = newSubsList(client)
 			}
 		}
 		// Fill in user if auth requested.
@@ -336,8 +359,15 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 			cc = &cx
 		}
 		// Fill in subscription data if requested.
-		if subs && len(cc.subs) > 0 {
-			cc.Subs = cc.subs
+		if len(cc.subs) > 0 {
+			if subsDet {
+				cc.SubsDetail = cc.subs
+			} else if subs {
+				cc.Subs = make([]string, 0, len(cc.subs))
+				for _, sub := range cc.subs {
+					cc.Subs = append(cc.Subs, sub.Subject)
+				}
+			}
 		}
 		// Fill in user if auth requested.
 		if auth {
@@ -526,6 +556,14 @@ func decodeState(w http.ResponseWriter, r *http.Request) (ConnState, error) {
 	return 0, err
 }
 
+func decodeSubs(w http.ResponseWriter, r *http.Request) (subs bool, subsDet bool, err error) {
+	subsDet = strings.ToLower(r.URL.Query().Get("subs")) == "detail"
+	if !subsDet {
+		subs, err = decodeBool(w, r, "subs")
+	}
+	return
+}
+
 // HandleConnz process HTTP requests for connection information.
 func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 	sortOpt := SortOpt(r.URL.Query().Get("sort"))
@@ -533,7 +571,7 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	subs, err := decodeBool(w, r, "subs")
+	subs, subsDet, err := decodeSubs(w, r)
 	if err != nil {
 		return
 	}
@@ -558,15 +596,16 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 	acc := r.URL.Query().Get("acc")
 
 	connzOpts := &ConnzOptions{
-		Sort:          sortOpt,
-		Username:      auth,
-		Subscriptions: subs,
-		Offset:        offset,
-		Limit:         limit,
-		CID:           cid,
-		State:         state,
-		User:          user,
-		Account:       acc,
+		Sort:                sortOpt,
+		Username:            auth,
+		Subscriptions:       subs,
+		SubscriptionsDetail: subsDet,
+		Offset:              offset,
+		Limit:               limit,
+		CID:                 cid,
+		State:               state,
+		User:                user,
+		Account:             acc,
 	}
 
 	s.mu.Lock()
@@ -602,6 +641,8 @@ type Routez struct {
 type RoutezOptions struct {
 	// Subscriptions indicates that Routez will return a route's subscriptions
 	Subscriptions bool `json:"subscriptions"`
+	// SubscriptionsDetail indicates if subscription details should be included in the results
+	SubscriptionsDetail bool `json:"subscriptions_detail"`
 }
 
 // RouteInfo has detailed information on a per connection basis.
@@ -622,6 +663,7 @@ type RouteInfo struct {
 	OutBytes     int64              `json:"out_bytes"`
 	NumSubs      uint32             `json:"subscriptions"`
 	Subs         []string           `json:"subscriptions_list,omitempty"`
+	SubsDetail   []SubDetail        `json:"subscriptions_list_detail,omitempty"`
 }
 
 // Routez returns a Routez struct containing information about routes.
@@ -629,7 +671,9 @@ func (s *Server) Routez(routezOpts *RoutezOptions) (*Routez, error) {
 	rs := &Routez{Routes: []*RouteInfo{}}
 	rs.Now = time.Now()
 
-	subs := routezOpts != nil && routezOpts.Subscriptions
+	if routezOpts == nil {
+		routezOpts = &RoutezOptions{}
+	}
 
 	s.mu.Lock()
 	rs.NumRoutes = len(s.routes)
@@ -661,12 +705,14 @@ func (s *Server) Routez(routezOpts *RoutezOptions) (*Routez, error) {
 			RTT:          r.getRTT(),
 		}
 
-		if subs && len(r.subs) > 0 {
-			ri.Subs = make([]string, 0, len(r.subs))
-			for _, sub := range r.subs {
-				ri.Subs = append(ri.Subs, string(sub.subject))
+		if len(r.subs) > 0 {
+			if routezOpts.SubscriptionsDetail {
+				ri.SubsDetail = newSubsDetailList(r)
+			} else if routezOpts.Subscriptions {
+				ri.Subs = newSubsList(r)
 			}
 		}
+
 		switch conn := r.nc.(type) {
 		case *net.TCPConn, *tls.Conn:
 			addr := conn.RemoteAddr().(*net.TCPAddr)
@@ -682,21 +728,19 @@ func (s *Server) Routez(routezOpts *RoutezOptions) (*Routez, error) {
 
 // HandleRoutez process HTTP requests for route information.
 func (s *Server) HandleRoutez(w http.ResponseWriter, r *http.Request) {
-	subs, err := decodeBool(w, r, "subs")
+	subs, subsDetail, err := decodeSubs(w, r)
 	if err != nil {
 		return
 	}
-	var opts *RoutezOptions
-	if subs {
-		opts = &RoutezOptions{Subscriptions: true}
-	}
+
+	opts := RoutezOptions{Subscriptions: subs, SubscriptionsDetail: subsDetail}
 
 	s.mu.Lock()
 	s.httpReqStats[RoutezPath]++
 	s.mu.Unlock()
 
 	// As of now, no error is ever returned.
-	rs, _ := s.Routez(opts)
+	rs, _ := s.Routez(&opts)
 	b, err := json.MarshalIndent(rs, "", "  ")
 	if err != nil {
 		s.Errorf("Error marshaling response to /routez request: %v", err)
@@ -741,6 +785,17 @@ type SubDetail struct {
 	Msgs    int64  `json:"msgs"`
 	Max     int64  `json:"max,omitempty"`
 	Cid     uint64 `json:"cid"`
+}
+
+func newSubDetail(sub *subscription) SubDetail {
+	return SubDetail{
+		Subject: string(sub.subject),
+		Queue:   string(sub.queue),
+		Sid:     string(sub.sid),
+		Msgs:    sub.nm,
+		Max:     sub.max,
+		Cid:     sub.client.cid,
+	}
 }
 
 // Subsz returns a Subsz struct containing subjects statistics
@@ -793,14 +848,7 @@ func (s *Server) Subsz(opts *SubszOptions) (*Subsz, error) {
 				continue
 			}
 			sub.client.mu.Lock()
-			details[i] = SubDetail{
-				Subject: string(sub.subject),
-				Queue:   string(sub.queue),
-				Sid:     string(sub.sid),
-				Msgs:    sub.nm,
-				Max:     sub.max,
-				Cid:     sub.client.cid,
-			}
+			details[i] = newSubDetail(sub)
 			sub.client.mu.Unlock()
 			i++
 		}

--- a/server/ring.go
+++ b/server/ring.go
@@ -16,7 +16,7 @@ package server
 // We wrap to hold onto optional items for /connz.
 type closedClient struct {
 	ConnInfo
-	subs []string
+	subs []SubDetail
 	user string
 	acc  string
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1828,9 +1828,9 @@ func (s *Server) saveClosedClient(c *client, nc net.Conn, reason ClosedState) {
 
 	// Do subs, do not place by default in main ConnInfo
 	if len(c.subs) > 0 {
-		cc.subs = make([]string, 0, len(c.subs))
+		cc.subs = make([]SubDetail, 0, len(c.subs))
 		for _, sub := range c.subs {
-			cc.subs = append(cc.subs, string(sub.subject))
+			cc.subs = append(cc.subs, newSubDetail(sub))
 		}
 	}
 	// Hold user as well.


### PR DESCRIPTION
added sub=detail option to routez/connz. 
When specified will include subscriptions_list_detail instead.
I would have liked to change the type of subscriptions_list from []string to []interface{} and not have subscriptions_list_detail, but that is part of the interface used by embedded server.

Applies to routez and connz and closed connections.
with detail                 
```                                                                                                                                                                                                                                                                                         >curl "http://localhost:8080/connz?subs=detail"
{
  "server_id": "NDVNBYWHR7OZFDDVLNAHFK5PLRTBLENHSNMRV5WBSFAF6W3E67PCLC6A",
  "now": "2020-03-20T17:00:12.399586-04:00",
  "num_connections": 1,
  "total": 1,
  "offset": 0,
  "limit": 1024,
  "connections": [
    {
      "cid": 2,
      "ip": "127.0.0.1",
      "port": 49722,
      "start": "2020-03-20T16:59:57.558987-04:00",
      "last_activity": "2020-03-20T17:00:05.690868-04:00",
      "uptime": "14s",
      "idle": "6s",
      "pending_bytes": 0,
      "in_msgs": 0,
      "out_msgs": 0,
      "in_bytes": 0,
      "out_bytes": 0,
      "subscriptions": 1,
      "subscriptions_list_detail": [
        {
          "subject": "foo",
          "qgroup": "queue",
          "sid": "5",
          "msgs": 0,
          "cid": 2
        }
      ]
    }
  ]
}%
```
without
```
curl "http://localhost:8080/connz?subs=1"
{
  "server_id": "NDVNBYWHR7OZFDDVLNAHFK5PLRTBLENHSNMRV5WBSFAF6W3E67PCLC6A",
  "now": "2020-03-20T17:00:08.310969-04:00",
  "num_connections": 1,
  "total": 1,
  "offset": 0,
  "limit": 1024,
  "connections": [
    {
      "cid": 2,
      "ip": "127.0.0.1",
      "port": 49722,
      "start": "2020-03-20T16:59:57.558987-04:00",
      "last_activity": "2020-03-20T17:00:05.690868-04:00",
      "uptime": "10s",
      "idle": "2s",
      "pending_bytes": 0,
      "in_msgs": 0,
      "out_msgs": 0,
      "in_bytes": 0,
      "out_bytes": 0,
      "subscriptions": 1,
      "subscriptions_list": [
        "foo"
      ]
    }
  ]
}%  
```