### PR TITLE
add the stream name in consumer info

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -30,6 +30,7 @@ import (
 )
 
 type ConsumerInfo struct {
+	Stream string         `json:"stream_name"`
 	Name   string         `json:"name"`
 	Config ConsumerConfig `json:"config"`
 	State  ConsumerState  `json:"state"`
@@ -633,6 +634,7 @@ func (o *Consumer) Info() *ConsumerInfo {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	info := &ConsumerInfo{
+		Stream: o.streamName,
 		Name:   o.name,
 		Config: o.config,
 		State: ConsumerState{


### PR DESCRIPTION
Handy to be able to look at the JSON out of context from where it was created and know what stream it relates to.

Not urgent at all.