### PR TITLE
[ADDED] LeafNode permissions

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -113,6 +113,9 @@ type RoutePermissions struct {
 	Export *SubjectPermission `json:"export"`
 }
 
+// LeafNodePermissions has import/export permissions
+type LeafNodePermissions = RoutePermissions
+
 // clone will clone an individual subject permission.
 func (p *SubjectPermission) clone() *SubjectPermission {
 	if p == nil {

--- a/server/client.go
+++ b/server/client.go
@@ -1278,6 +1278,7 @@ func (c *client) processInfo(arg []byte) error {
 }
 
 func (c *client) processErr(errStr string) {
+	close := true
 	switch c.kind {
 	case CLIENT:
 		c.Errorf("Client Error %s", errStr)
@@ -1287,8 +1288,11 @@ func (c *client) processErr(errStr string) {
 		c.Errorf("Gateway Error %s", errStr)
 	case LEAF:
 		c.Errorf("Leafnode Error %s", errStr)
+		close = false
 	}
-	c.closeConnection(ParseError)
+	if close {
+		c.closeConnection(ParseError)
+	}
 }
 
 // Password pattern matcher.


### PR DESCRIPTION
This allows filtering of interest in LeafNodes. The permissions
can be specified in the top level leafnodes{} section (for leafnodes
connections that are accepted) or in the remotes[] to be applied
to those remote connections.

For instance:
```
leafnodes {
  remotes: [
    {
      url: "nats://localhost:6222"
      permissions: {
        import: {
          deny: ["foo", "bar"]
        }
        export: {
          deny: "baz"
        }
      }
    }
  ]
}
```
Or:
```
leafnodes {
  port: 6222
  permissions: {
    export: {
      deny: ["bar", "baz"]
    }
  }
}
```

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
