### PR TITLE
[ADDED] Deny import/export options for LeafNode remote configuration

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1278,6 +1278,7 @@ func (c *client) processInfo(arg []byte) error {
 }
 
 func (c *client) processErr(errStr string) {
+	close := true
 	switch c.kind {
 	case CLIENT:
 		c.Errorf("Client Error %s", errStr)
@@ -1287,8 +1288,11 @@ func (c *client) processErr(errStr string) {
 		c.Errorf("Gateway Error %s", errStr)
 	case LEAF:
 		c.Errorf("Leafnode Error %s", errStr)
+		close = false
 	}
-	c.closeConnection(ParseError)
+	if close {
+		c.closeConnection(ParseError)
+	}
 }
 
 // Password pattern matcher.

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -366,7 +366,7 @@ func checkLeafNodeConnected(t *testing.T, s *Server) {
 // Helper function to check that a leaf node has connected to n server.
 func checkLeafNodeConnectedCount(t *testing.T, s *Server, lnCons int) {
 	t.Helper()
-	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+	checkFor(t, 5*time.Second, 15*time.Millisecond, func() error {
 		if nln := s.NumLeafNodes(); nln != lnCons {
 			return fmt.Errorf("Expected %d connected leafnode(s) for server %q, got %d",
 				lnCons, s.ID(), nln)

--- a/server/opts.go
+++ b/server/opts.go
@@ -125,7 +125,7 @@ type LeafNodeOpts struct {
 	// Not exported, for tests.
 	resolver    netResolver
 	dialTimeout time.Duration
-	loopDelay   time.Duration
+	connDelay   time.Duration
 }
 
 // RemoteLeafOpts are options for connecting to a remote server as a leaf node.
@@ -137,6 +137,8 @@ type RemoteLeafOpts struct {
 	TLSConfig    *tls.Config `json:"-"`
 	TLSTimeout   float64     `json:"tls_timeout,omitempty"`
 	Hub          bool        `json:"hub,omitempty"`
+	DenyImports  []string    `json:"-"`
+	DenyExports  []string    `json:"-"`
 }
 
 // Options block for nats-server.
@@ -1379,6 +1381,20 @@ func parseRemoteLeafNodes(v interface{}, errors *[]error, warnings *[]error) ([]
 				}
 			case "hub":
 				remote.Hub = v.(bool)
+			case "deny_imports", "deny_import":
+				subjects, err := parseSubjects(tk, errors, warnings)
+				if err != nil {
+					*errors = append(*errors, err)
+					continue
+				}
+				remote.DenyImports = subjects
+			case "deny_exports", "deny_export":
+				subjects, err := parseSubjects(tk, errors, warnings)
+				if err != nil {
+					*errors = append(*errors, err)
+					continue
+				}
+				remote.DenyExports = subjects
 			default:
 				if !tk.IsUsedVariable() {
 					err := &unknownConfigFieldErr{


### PR DESCRIPTION
This will allow a leafnode remote connection to prevent unwanted
messages to be received, or prevent local messages to be sent
to the remote server.

Configuration will be something like:
```
leafnodes {
  remotes: [
    {
      url: "nats://localhost:6222"
      deny_imports: ["foo.*", "bar"]
      deny_exports: ["baz.*", "bat"]
    }
  ]
}
```

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
