### PR TITLE
Fix for bug when requestor and leafnode on same server.

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1045,6 +1045,8 @@ func (a *Account) createRespWildcard() []byte {
 			a.siReplyClient = c
 			a.mu.Unlock()
 		}
+		// Now check on leafnode updates.
+		s.updateLeafNodes(a, sub, 1)
 	}
 
 	return pre

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1468,8 +1468,8 @@ func (c *client) processLeafMsgArgs(arg []byte) error {
 // processInboundLeafMsg is called to process an inbound msg from a leaf node.
 func (c *client) processInboundLeafMsg(msg []byte) {
 	// Update statistics
-	c.in.msgs++
 	// The msg includes the CR_LF, so pull back out for accounting.
+	c.in.msgs++
 	c.in.bytes += int32(len(msg) - LEN_CR_LF)
 
 	// Check pub permissions


### PR DESCRIPTION
When a responder was on a leaf node and the requestor was connected to the same server as the leafnode we did not propagate the service reply wildcard properly. This fixes that.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
