### PR TITLE
LeafNode: delay connect even when loop detected by accepting side

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1288,6 +1288,7 @@ func (c *client) processErr(errStr string) {
 		c.Errorf("Gateway Error %s", errStr)
 	case LEAF:
 		c.Errorf("Leafnode Error %s", errStr)
+		c.leafProcessErr(errStr)
 		close = false
 	}
 	if close {


### PR DESCRIPTION
If the loop is detected by a server accepting the leafnode connection,
an error is sent back and connection is closed.
This change ensures that the server checks an -ERR for "Loop detected"
and then set the connect delay, so that it does not try to reconnect
right away.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
