### PR TITLE
[IMPROVED] Added close reason in the connection close log statement

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1199,9 +1199,9 @@ func (c *client) markConnAsClosed(reason ClosedState, skipFlush bool) bool {
 	// Be consistent with the creation: for routes and gateways,
 	// we use Noticef on create, so use that too for delete.
 	if c.kind == ROUTER || c.kind == GATEWAY {
-		c.Noticef("%s connection closed: %v", c.typeString(), reason.String())
+		c.Noticef("%s connection closed: %s", c.typeString(), reason)
 	} else { // Client and Leaf Node connections.
-		c.Debugf("%s connection closed: %v", c.typeString(), reason.String())
+		c.Debugf("%s connection closed: %s", c.typeString(), reason)
 	}
 
 	// Save off the connection if its a client or leafnode.

--- a/server/client.go
+++ b/server/client.go
@@ -1196,6 +1196,14 @@ func (c *client) markConnAsClosed(reason ClosedState, skipFlush bool) bool {
 	if skipFlush {
 		c.flags.set(skipFlushOnClose)
 	}
+	// Be consistent with the creation: for routes and gateways,
+	// we use Noticef on create, so use that too for delete.
+	if c.kind == ROUTER || c.kind == GATEWAY {
+		c.Noticef("%s connection closed: %v", c.typeString(), reason.String())
+	} else { // Client and Leaf Node connections.
+		c.Debugf("%s connection closed: %v", c.typeString(), reason.String())
+	}
+
 	// Save off the connection if its a client or leafnode.
 	if c.kind == CLIENT || c.kind == LEAF {
 		if nc := c.nc; nc != nil && c.srv != nil {
@@ -3517,13 +3525,6 @@ func (c *client) closeConnection(reason ClosedState) {
 // been started.
 func (c *client) teardownConn() {
 	c.mu.Lock()
-	// Be consistent with the creation: for routes and gateways,
-	// we use Noticef on create, so use that too for delete.
-	if c.kind == ROUTER || c.kind == GATEWAY {
-		c.Noticef("%s connection closed", c.typeString())
-	} else { // Client and Leaf Node connections.
-		c.Debugf("%s connection closed", c.typeString())
-	}
 
 	c.clearAuthTimer()
 	c.clearPingTimer()


### PR DESCRIPTION
This gives the close reason directly in the log without having to
get that information from the monitoring endpoint. Here is an
example of a route closed due to the remote side not replying to
PINGs:

```
[INF] 127.0.0.1:53839 - rid:2 - Router connection closed: Stale Connection
```

Without this change, the log statement would have been:
```
[INF] 127.0.0.1:53839 - rid:2 - Router connection closed
```

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
