### PR TITLE
add schema, id and time to client connect events

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -58,7 +58,7 @@ type CreateConsumerRequest struct {
 // ConsumerAckMetric is a metric published when a user acknowledges a message, the
 // number of these that will be published is dependant on SampleFrequency
 type ConsumerAckMetric struct {
-	Schema      string `json:"schema"`
+	Type        string `json:"type"`
 	ID          string `json:"id"`
 	Time        string `json:"timestamp"`
 	Stream      string `json:"stream"`
@@ -69,10 +69,13 @@ type ConsumerAckMetric struct {
 	Deliveries  uint64 `json:"deliveries"`
 }
 
+// ConsumerAckMetricType is the schema type for ConsumerAckMetricType
+const ConsumerAckMetricType = "io.nats.jetstream.metric.v1.consumer_ack"
+
 // ConsumerDeliveryExceededAdvisory is an advisory informing that a message hit
 // its MaxDeliver threshold and so might be a candidate for DLQ handling
 type ConsumerDeliveryExceededAdvisory struct {
-	Schema     string `json:"schema"`
+	Type       string `json:"type"`
 	ID         string `json:"id"`
 	Time       string `json:"timestamp"`
 	Stream     string `json:"stream"`
@@ -80,6 +83,9 @@ type ConsumerDeliveryExceededAdvisory struct {
 	StreamSeq  uint64 `json:"stream_seq"`
 	Deliveries uint64 `json:"deliveries"`
 }
+
+// ConsumerDeliveryExceededAdvisoryType is the schema type for ConsumerDeliveryExceededAdvisory
+const ConsumerDeliveryExceededAdvisoryType = "io.nats.jetstream.advisory.v1.max_deliver"
 
 // DeliverPolicy determines how the consumer should select the first message to deliver.
 type DeliverPolicy int
@@ -755,7 +761,7 @@ func (o *Consumer) sampleAck(sseq, dseq, dcount uint64) {
 	now := time.Now().UTC()
 	unow := now.UnixNano()
 	e := &ConsumerAckMetric{
-		Schema:      "io.nats.jetstream.metric.v1.consumer_ack",
+		Type:        ConsumerAckMetricType,
 		ID:          nuid.Next(),
 		Time:        now.Format(time.RFC3339Nano),
 		Stream:      o.stream,
@@ -897,7 +903,7 @@ func (o *Consumer) incDeliveryCount(sseq uint64) uint64 {
 
 func (o *Consumer) notifyDeliveryExceeded(sseq, dcount uint64) {
 	e := &ConsumerDeliveryExceededAdvisory{
-		Schema:     "io.nats.jetstream.advisory.v1.max_deliver",
+		Type:       ConsumerDeliveryExceededAdvisoryType,
 		ID:         nuid.Next(),
 		Time:       time.Now().UTC().Format(time.RFC3339Nano),
 		Stream:     o.stream,

--- a/server/events.go
+++ b/server/events.go
@@ -97,6 +97,9 @@ type ConnectEventMsg struct {
 	Client ClientInfo `json:"client"`
 }
 
+// ConnectEventMsgSchema is the schema ID for ConnectEventMsg
+const ConnectEventMsgSchema = "io.nats.server.advisory.v1.client_connect"
+
 // DisconnectEventMsg is sent when a new connection previously defined from a
 // ConnectEventMsg is closed.
 type DisconnectEventMsg struct {
@@ -109,6 +112,9 @@ type DisconnectEventMsg struct {
 	Received DataStats  `json:"received"`
 	Reason   string     `json:"reason"`
 }
+
+// DisconnectEventMsgSchema is the schema ID for DisconnectEventMsg
+const DisconnectEventMsgSchema = "io.nats.server.advisory.v1.client_disconnect"
 
 // AccountNumConns is an event that will be sent from a server that is tracking
 // a given account when the number of connections changes. It will also HB
@@ -928,7 +934,7 @@ func (s *Server) accountConnectEvent(c *client) {
 	}
 
 	m := ConnectEventMsg{
-		Schema: "io.nats.server.advisory.v1.client_connect",
+		Schema: ConnectEventMsgSchema,
 		ID:     nuid.Next(),
 		Time:   time.Now().UTC().Format(time.RFC3339Nano),
 		Client: ClientInfo{
@@ -968,7 +974,7 @@ func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string)
 	}
 
 	m := DisconnectEventMsg{
-		Schema: "io.nats.server.advisory.v1.client_disconnect",
+		Schema: DisconnectEventMsgSchema,
 		ID:     nuid.Next(),
 		Time:   time.Now().UTC().Format(time.RFC3339Nano),
 		Client: ClientInfo{
@@ -1009,7 +1015,7 @@ func (s *Server) sendAuthErrorEvent(c *client) {
 	now := time.Now()
 	c.mu.Lock()
 	m := DisconnectEventMsg{
-		Schema: "io.nats.server.advisory.v1.client_disconnect",
+		Schema: DisconnectEventMsgSchema,
 		ID:     nuid.Next(),
 		Time:   time.Now().UTC().Format(time.RFC3339Nano),
 		Client: ClientInfo{

--- a/server/events.go
+++ b/server/events.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/nats-io/nats-server/v2/server/pse"
-	"github.com/nats-io/nuid"
 )
 
 const (
@@ -79,7 +78,6 @@ type internal struct {
 	statsz   time.Duration
 	shash    string
 	inboxPre string
-	eventids *nuid.NUID
 }
 
 // ServerStatsMsg is sent periodically with stats updates.
@@ -915,19 +913,21 @@ func (s *Server) accConnsUpdate(a *Account) {
 	s.sendAccConnsUpdate(a, subj)
 }
 
+// server lock should be held
 func (s *Server) nextEventID() string {
-	return s.sys.eventids.Next()
+	return s.eventids.Next()
 }
 
 // accountConnectEvent will send an account client connect event if there is interest.
 // This is a billing event.
 func (s *Server) accountConnectEvent(c *client) {
 	s.mu.Lock()
-	gacc := s.gacc
 	if !s.eventsEnabled() {
 		s.mu.Unlock()
 		return
 	}
+	gacc := s.gacc
+	eid := s.nextEventID()
 	s.mu.Unlock()
 
 	c.mu.Lock()
@@ -939,7 +939,7 @@ func (s *Server) accountConnectEvent(c *client) {
 
 	m := ConnectEventMsg{
 		Type: ConnectEventMsgType,
-		ID:   s.nextEventID(),
+		ID:   eid,
 		Time: time.Now().UTC().Format(time.RFC3339Nano),
 		Client: ClientInfo{
 			Start:   c.start,
@@ -962,11 +962,12 @@ func (s *Server) accountConnectEvent(c *client) {
 // This is a billing event.
 func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string) {
 	s.mu.Lock()
-	gacc := s.gacc
 	if !s.eventsEnabled() {
 		s.mu.Unlock()
 		return
 	}
+	gacc := s.gacc
+	eid := s.nextEventID()
 	s.mu.Unlock()
 
 	c.mu.Lock()
@@ -979,8 +980,8 @@ func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string)
 
 	m := DisconnectEventMsg{
 		Type: DisconnectEventMsgType,
-		ID:   s.nextEventID(),
-		Time: time.Now().UTC().Format(time.RFC3339Nano),
+		ID:   eid,
+		Time: now.UTC().Format(time.RFC3339Nano),
 		Client: ClientInfo{
 			Start:   c.start,
 			Stop:    &now,
@@ -1015,13 +1016,14 @@ func (s *Server) sendAuthErrorEvent(c *client) {
 		s.mu.Unlock()
 		return
 	}
+	eid := s.nextEventID()
 	s.mu.Unlock()
 	now := time.Now()
 	c.mu.Lock()
 	m := DisconnectEventMsg{
 		Type: DisconnectEventMsgType,
-		ID:   s.nextEventID(),
-		Time: time.Now().UTC().Format(time.RFC3339Nano),
+		ID:   eid,
+		Time: now.UTC().Format(time.RFC3339Nano),
 		Client: ClientInfo{
 			Start:   c.start,
 			Stop:    &now,

--- a/server/events.go
+++ b/server/events.go
@@ -26,6 +26,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/nats-io/nuid"
+
 	"github.com/nats-io/nats-server/v2/server/pse"
 )
 
@@ -88,6 +90,9 @@ type ServerStatsMsg struct {
 
 // ConnectEventMsg is sent when a new connection is made that is part of an account.
 type ConnectEventMsg struct {
+	Schema string     `json:"schema"`
+	ID     string     `json:"id"`
+	Time   string     `json:"timestamp"`
 	Server ServerInfo `json:"server"`
 	Client ClientInfo `json:"client"`
 }
@@ -95,6 +100,9 @@ type ConnectEventMsg struct {
 // DisconnectEventMsg is sent when a new connection previously defined from a
 // ConnectEventMsg is closed.
 type DisconnectEventMsg struct {
+	Schema   string     `json:"schema"`
+	ID       string     `json:"id"`
+	Time     string     `json:"timestamp"`
 	Server   ServerInfo `json:"server"`
 	Client   ClientInfo `json:"client"`
 	Sent     DataStats  `json:"sent"`
@@ -920,6 +928,9 @@ func (s *Server) accountConnectEvent(c *client) {
 	}
 
 	m := ConnectEventMsg{
+		Schema: "io.nats.server.advisory.v1.client_connect",
+		ID:     nuid.Next(),
+		Time:   time.Now().UTC().Format(time.RFC3339Nano),
 		Client: ClientInfo{
 			Start:   c.start,
 			Host:    c.host,
@@ -957,6 +968,9 @@ func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string)
 	}
 
 	m := DisconnectEventMsg{
+		Schema: "io.nats.server.advisory.v1.client_disconnect",
+		ID:     nuid.Next(),
+		Time:   time.Now().UTC().Format(time.RFC3339Nano),
 		Client: ClientInfo{
 			Start:   c.start,
 			Stop:    &now,
@@ -995,6 +1009,9 @@ func (s *Server) sendAuthErrorEvent(c *client) {
 	now := time.Now()
 	c.mu.Lock()
 	m := DisconnectEventMsg{
+		Schema: "io.nats.server.advisory.v1.client_disconnect",
+		ID:     nuid.Next(),
+		Time:   time.Now().UTC().Format(time.RFC3339Nano),
 		Client: ClientInfo{
 			Start:   c.start,
 			Stop:    &now,

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -230,7 +230,7 @@ func TestSystemAccountNewConnection(t *testing.T) {
 	if err := json.Unmarshal(msg.Data, &cem); err != nil {
 		t.Fatalf("Error unmarshalling connect event message: %v", err)
 	}
-	if cem.Schema != "io.nats.server.advisory.v1.client_connect" {
+	if cem.Schema != ConnectEventMsgSchema {
 		t.Fatalf("Incorrect schema in connect event: %s", cem.Schema)
 	}
 	if cem.Time == "" {
@@ -286,7 +286,7 @@ func TestSystemAccountNewConnection(t *testing.T) {
 	if err := json.Unmarshal(msg.Data, &dem); err != nil {
 		t.Fatalf("Error unmarshalling disconnect event message: %v", err)
 	}
-	if dem.Schema != "io.nats.server.advisory.v1.client_disconnect" {
+	if dem.Schema != DisconnectEventMsgSchema {
 		t.Fatalf("Incorrect schema in connect event: %s", cem.Schema)
 	}
 	if dem.Time == "" {

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -230,6 +230,15 @@ func TestSystemAccountNewConnection(t *testing.T) {
 	if err := json.Unmarshal(msg.Data, &cem); err != nil {
 		t.Fatalf("Error unmarshalling connect event message: %v", err)
 	}
+	if cem.Schema != "io.nats.server.advisory.v1.client_connect" {
+		t.Fatalf("Incorrect schema in connect event: %s", cem.Schema)
+	}
+	if cem.Time == "" {
+		t.Fatalf("Event time is not set")
+	}
+	if len(cem.ID) != 22 {
+		t.Fatalf("Event ID is incorrectly set to len %d", len(cem.ID))
+	}
 	if cem.Server.ID != s.ID() {
 		t.Fatalf("Expected server to be %q, got %q", s.ID(), cem.Server.ID)
 	}
@@ -277,7 +286,15 @@ func TestSystemAccountNewConnection(t *testing.T) {
 	if err := json.Unmarshal(msg.Data, &dem); err != nil {
 		t.Fatalf("Error unmarshalling disconnect event message: %v", err)
 	}
-
+	if dem.Schema != "io.nats.server.advisory.v1.client_disconnect" {
+		t.Fatalf("Incorrect schema in connect event: %s", cem.Schema)
+	}
+	if dem.Time == "" {
+		t.Fatalf("Event time is not set")
+	}
+	if len(dem.ID) != 22 {
+		t.Fatalf("Event ID is incorrectly set to len %d", len(cem.ID))
+	}
 	if dem.Server.ID != s.ID() {
 		t.Fatalf("Expected server to be %q, got %q", s.ID(), dem.Server.ID)
 	}

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -230,8 +230,8 @@ func TestSystemAccountNewConnection(t *testing.T) {
 	if err := json.Unmarshal(msg.Data, &cem); err != nil {
 		t.Fatalf("Error unmarshalling connect event message: %v", err)
 	}
-	if cem.Schema != ConnectEventMsgSchema {
-		t.Fatalf("Incorrect schema in connect event: %s", cem.Schema)
+	if cem.Type != ConnectEventMsgType {
+		t.Fatalf("Incorrect schema in connect event: %s", cem.Type)
 	}
 	if cem.Time == "" {
 		t.Fatalf("Event time is not set")
@@ -286,8 +286,8 @@ func TestSystemAccountNewConnection(t *testing.T) {
 	if err := json.Unmarshal(msg.Data, &dem); err != nil {
 		t.Fatalf("Error unmarshalling disconnect event message: %v", err)
 	}
-	if dem.Schema != DisconnectEventMsgSchema {
-		t.Fatalf("Incorrect schema in connect event: %s", cem.Schema)
+	if dem.Type != DisconnectEventMsgType {
+		t.Fatalf("Incorrect schema in connect event: %s", cem.Type)
 	}
 	if dem.Time == "" {
 		t.Fatalf("Event time is not set")

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -734,7 +734,7 @@ type ClientAPIAudit struct {
 
 // JetStreamAPIAudit is an advisory about administrative actions taken on JetStream
 type JetStreamAPIAudit struct {
-	Schema   string         `json:"schema"`
+	Type     string         `json:"type"`
 	ID       string         `json:"id"`
 	Time     string         `json:"timestamp"`
 	Server   string         `json:"server"`
@@ -744,7 +744,7 @@ type JetStreamAPIAudit struct {
 	Response string         `json:"response"`
 }
 
-const auditSchema = "io.nats.jetstream.advisory.v1.api_audit"
+const auditType = "io.nats.jetstream.advisory.v1.api_audit"
 
 // sendJetStreamAPIAuditAdvisor will send the audit event for a given event.
 func (s *Server) sendJetStreamAPIAuditAdvisory(c *client, subject, request, response string) {
@@ -758,7 +758,7 @@ func (s *Server) sendJetStreamAPIAuditAdvisory(c *client, subject, request, resp
 	c.mu.Unlock()
 
 	e := &JetStreamAPIAudit{
-		Schema: auditSchema,
+		Type:   auditType,
 		ID:     nuid.Next(),
 		Time:   time.Now().UTC().Format(time.RFC3339Nano),
 		Server: s.Name(),

--- a/server/server.go
+++ b/server/server.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/nats-io/jwt"
 	"github.com/nats-io/nkeys"
+	"github.com/nats-io/nuid"
 
 	"github.com/nats-io/nats-server/v2/logger"
 )
@@ -873,16 +874,17 @@ func (s *Server) setSystemAccount(acc *Account) error {
 	acc.mu.Unlock()
 
 	s.sys = &internal{
-		account: acc,
-		client:  s.createInternalSystemClient(),
-		seq:     1,
-		sid:     1,
-		servers: make(map[string]*serverUpdate),
-		replies: make(map[string]msgHandler),
-		sendq:   make(chan *pubMsg, internalSendQLen),
-		statsz:  eventsHBInterval,
-		orphMax: 5 * eventsHBInterval,
-		chkOrph: 3 * eventsHBInterval,
+		account:  acc,
+		client:   s.createInternalSystemClient(),
+		seq:      1,
+		sid:      1,
+		servers:  make(map[string]*serverUpdate),
+		replies:  make(map[string]msgHandler),
+		sendq:    make(chan *pubMsg, internalSendQLen),
+		statsz:   eventsHBInterval,
+		orphMax:  5 * eventsHBInterval,
+		chkOrph:  3 * eventsHBInterval,
+		eventids: nuid.New(),
 	}
 	s.sys.wg.Add(1)
 	s.mu.Unlock()

--- a/server/server.go
+++ b/server/server.go
@@ -207,6 +207,8 @@ type Server struct {
 		ch chan time.Duration
 		m  sync.Map
 	}
+
+	eventids *nuid.NUID
 }
 
 // Make sure all are 64bits for atomic use
@@ -279,6 +281,7 @@ func NewServer(opts *Options) (*Server, error) {
 		start:      now,
 		configTime: now,
 		gwLeafSubs: NewSublistWithCache(),
+		eventids:   nuid.New(),
 	}
 
 	// Trusted root operator keys.
@@ -874,17 +877,16 @@ func (s *Server) setSystemAccount(acc *Account) error {
 	acc.mu.Unlock()
 
 	s.sys = &internal{
-		account:  acc,
-		client:   s.createInternalSystemClient(),
-		seq:      1,
-		sid:      1,
-		servers:  make(map[string]*serverUpdate),
-		replies:  make(map[string]msgHandler),
-		sendq:    make(chan *pubMsg, internalSendQLen),
-		statsz:   eventsHBInterval,
-		orphMax:  5 * eventsHBInterval,
-		chkOrph:  3 * eventsHBInterval,
-		eventids: nuid.New(),
+		account: acc,
+		client:  s.createInternalSystemClient(),
+		seq:     1,
+		sid:     1,
+		servers: make(map[string]*serverUpdate),
+		replies: make(map[string]msgHandler),
+		sendq:   make(chan *pubMsg, internalSendQLen),
+		statsz:  eventsHBInterval,
+		orphMax: 5 * eventsHBInterval,
+		chkOrph: 3 * eventsHBInterval,
 	}
 	s.sys.wg.Add(1)
 	s.mu.Unlock()


### PR DESCRIPTION
This bring these to same level as the JS events, these are the ones
I care for right now but will do this to the rest here in time as well
and document them in JSON schema

Signed-off-by: R.I.Pienaar <rip@devco.net>
