### PR TITLE
Services rewrite #2

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -58,34 +58,26 @@ type Account struct {
 	lqws         map[string]int32
 	usersRevoked map[string]int64
 	actsRevoked  map[string]int64
-	respMap      map[string][]*serviceRespEntry
 	lleafs       []*client
 	imports      importMap
 	exports      exportMap
 	js           *jsAccount
 	jsLimits     *JetStreamAccountLimits
 	limits
-	nae           int32
-	pruning       bool
-	rmPruning     bool
-	expired       bool
-	signingKeys   []string
-	srv           *Server // server this account is registered with (possibly nil)
-	lds           string  // loop detection subject for leaf nodes
-	siReply       []byte  // service reply prefix, will form wildcard subscription.
-	siReplyClient *client
-	prand         *rand.Rand
+	expired     bool
+	signingKeys []string
+	srv         *Server // server this account is registered with (possibly nil)
+	lds         string  // loop detection subject for leaf nodes
+	siReply     []byte  // service reply prefix, will form wildcard subscription.
+	prand       *rand.Rand
 }
 
 // Account based limits.
 type limits struct {
-	mpay     int32
-	msubs    int32
-	mconns   int32
-	mleafs   int32
-	maxnae   int32
-	maxnrm   int32
-	maxaettl time.Duration
+	mpay   int32
+	msubs  int32
+	mconns int32
+	mleafs int32
 }
 
 // Used to track remote clients and leafnodes per remote server.
@@ -107,16 +99,18 @@ type streamImport struct {
 type serviceImport struct {
 	acc      *Account
 	claim    *jwt.Import
+	se       *serviceExport
 	sub      *subscription
 	from     string
 	to       string
+	exsub    string
 	ts       int64
 	rt       ServiceRespType
 	latency  *serviceLatency
 	m1       *ServiceLatency
-	ae       bool
+	rc       *client
 	hasWC    bool
-	internal bool
+	response bool
 	invalid  bool
 	tracking bool
 }
@@ -124,7 +118,7 @@ type serviceImport struct {
 // This is used to record when we create a mapping for implicit service
 // imports. We use this to clean up entries that are not singletons when
 // we detect that interest is no longer present. The key to the map will
-// be the actual interest. We record the mapped subject and the serviceImport
+// be the actual interest. We record the mapped subject and the account.
 type serviceRespEntry struct {
 	acc  *Account
 	msub string
@@ -168,8 +162,11 @@ type streamExport struct {
 // serviceExport holds additional information for exported services.
 type serviceExport struct {
 	exportAuth
-	respType ServiceRespType
-	latency  *serviceLatency
+	acc        *Account
+	respType   ServiceRespType
+	latency    *serviceLatency
+	rtmr       *time.Timer
+	respThresh time.Duration
 }
 
 // Used to track service latency.
@@ -180,21 +177,24 @@ type serviceLatency struct {
 
 // exportMap tracks the exported streams and services.
 type exportMap struct {
-	streams  map[string]*streamExport
-	services map[string]*serviceExport
+	streams   map[string]*streamExport
+	services  map[string]*serviceExport
+	responses map[string]*serviceImport
 }
 
 // importMap tracks the imported streams and services.
+// For services we will also track the response mappings as well.
 type importMap struct {
 	streams  []*streamImport
-	services map[string]*serviceImport // TODO(dlc) sync.Map may be better.
+	services map[string]*serviceImport
+	rrMap    map[string][]*serviceRespEntry
 }
 
 // NewAccount creates a new unlimited account with the given name.
 func NewAccount(name string) *Account {
 	a := &Account{
 		Name:   name,
-		limits: limits{-1, -1, -1, -1, 0, 0, 0},
+		limits: limits{-1, -1, -1, -1},
 	}
 
 	return a
@@ -264,6 +264,17 @@ func (a *Account) clearEventing() {
 	a.clients = nil
 	a.strack = nil
 	a.mu.Unlock()
+}
+
+// GetName will return the accounts name.
+func (a *Account) GetName() string {
+	if a == nil {
+		return "n/a"
+	}
+	a.mu.RLock()
+	name := a.Name
+	a.mu.RUnlock()
+	return name
 }
 
 // NumConnections returns active number of clients for this account for
@@ -477,7 +488,7 @@ func (a *Account) AddServiceExport(subject string, accounts []*Account) error {
 	return a.AddServiceExportWithResponse(subject, Singleton, accounts)
 }
 
-// AddServiceExportWithresponse will configure the account with the defined export and response type.
+// AddServiceExportWithResponse will configure the account with the defined export and response type.
 func (a *Account) AddServiceExportWithResponse(subject string, respType ServiceRespType, accounts []*Account) error {
 	if a == nil {
 		return ErrMissingAccount
@@ -489,32 +500,36 @@ func (a *Account) AddServiceExportWithResponse(subject string, respType ServiceR
 		a.exports.services = make(map[string]*serviceExport)
 	}
 
-	ea := a.exports.services[subject]
+	se := a.exports.services[subject]
+	// Always  create a service export
+	if se == nil {
+		se = &serviceExport{}
+	}
 
 	if respType != Singleton {
-		if ea == nil {
-			ea = &serviceExport{}
-		}
-		ea.respType = respType
+		se.respType = respType
 	}
 
 	if accounts != nil {
-		if ea == nil {
-			ea = &serviceExport{}
-		}
 		// empty means auth required but will be import token.
 		if len(accounts) == 0 {
-			ea.tokenReq = true
+			se.tokenReq = true
 		} else {
-			if ea.approved == nil {
-				ea.approved = make(map[string]*Account, len(accounts))
+			if se.approved == nil {
+				se.approved = make(map[string]*Account, len(accounts))
 			}
 			for _, acc := range accounts {
-				ea.approved[acc.Name] = acc
+				se.approved[acc.Name] = acc
 			}
 		}
 	}
-	a.exports.services[subject] = ea
+	lrt := a.lowestServiceExportResponseTime()
+	se.acc = a
+	se.respThresh = DEFAULT_SERVICE_EXPORT_RESPONSE_THRESHOLD
+	a.exports.services[subject] = se
+	if nlrt := a.lowestServiceExportResponseTime(); nlrt != lrt {
+		a.updateAllClientsServiceExportResponseTime(nlrt)
+	}
 	return nil
 }
 
@@ -687,6 +702,8 @@ func (nl *NATSLatency) TotalTime() time.Duration {
 // ServiceLatency is the JSON message sent out in response to latency tracking for
 // exported services.
 type ServiceLatency struct {
+	Status         int           `json:"status"`
+	Error          string        `json:"description,omitempty"`
 	AppName        string        `json:"app,omitempty"`
 	RequestStart   time.Time     `json:"start"`
 	ServiceLatency time.Duration `json:"svc"`
@@ -725,19 +742,84 @@ func sanitizeLatencyMetric(sl *ServiceLatency) {
 
 // Used for transporting remote latency measurements.
 type remoteLatency struct {
-	Account string         `json:"account"`
-	ReqId   string         `json:"req_id"`
-	M2      ServiceLatency `json:"m2"`
+	Account    string         `json:"account"`
+	ReqId      string         `json:"req_id"`
+	M2         ServiceLatency `json:"m2"`
+	respThresh time.Duration
+}
+
+// sendLatencyResult will send a latency result and clear the si of the requestor(rc).
+func (a *Account) sendLatencyResult(si *serviceImport, sl *ServiceLatency) {
+	si.acc.mu.Lock()
+	a.srv.sendInternalAccountMsg(a, si.latency.subject, sl)
+	si.rc = nil
+	si.acc.mu.Unlock()
+}
+
+// Used to send a bad request metric when we do not have a reply subject
+func (a *Account) sendBadRequestTrackingLatency(si *serviceImport, requestor *client) {
+	sl := &ServiceLatency{
+		Status:       400,
+		Error:        "Bad Request",
+		RequestStart: time.Now().Add(-requestor.getRTTValue()),
+	}
+	a.sendLatencyResult(si, sl)
+}
+
+// Used to send a latency result when the requestor interest was lost before the
+// response could be delivered.
+func (a *Account) sendReplyInterestLostTrackLatency(si *serviceImport) {
+	var reqClientRTT time.Duration
+	if si.rc != nil {
+		reqClientRTT = si.rc.getRTTValue()
+	}
+	reqStart := time.Unix(0, si.ts-int64(reqClientRTT))
+	sl := &ServiceLatency{
+		Status:       408,
+		Error:        "Request Timeout",
+		RequestStart: reqStart,
+		NATSLatency: NATSLatency{
+			Requestor: reqClientRTT,
+		},
+	}
+	a.sendLatencyResult(si, sl)
+}
+
+func (a *Account) sendBackendErrorTrackingLatency(si *serviceImport, reason rsiReason) {
+	var reqClientRTT time.Duration
+	if si.rc != nil {
+		reqClientRTT = si.rc.getRTTValue()
+	}
+	reqStart := time.Unix(0, si.ts-int64(reqClientRTT))
+	sl := &ServiceLatency{
+		RequestStart: reqStart,
+		NATSLatency: NATSLatency{
+			Requestor: reqClientRTT,
+		},
+	}
+	if reason == rsiNoDelivery {
+		sl.Status = 503
+		sl.Error = "Service Unavailable"
+	} else if reason == rsiTimeout {
+		sl.Status = 504
+		sl.Error = "Service Timeout"
+	}
+	a.sendLatencyResult(si, sl)
 }
 
 // sendTrackingMessage will send out the appropriate tracking information for the
 // service request/response latency. This is called when the requestor's server has
 // received the response.
 // TODO(dlc) - holding locks for RTTs may be too much long term. Should revisit.
-func (a *Account) sendTrackingLatency(si *serviceImport, requestor, responder *client) bool {
+func (a *Account) sendTrackingLatency(si *serviceImport, responder *client) bool {
+	if si.rc == nil {
+		return true
+	}
+
 	ts := time.Now()
 	serviceRTT := time.Duration(ts.UnixNano() - si.ts)
 
+	var requestor = si.rc
 	var reqClientRTT = requestor.getRTTValue()
 	var respClientRTT time.Duration
 	var appName string
@@ -751,6 +833,7 @@ func (a *Account) sendTrackingLatency(si *serviceImport, requestor, responder *c
 	// and the client RTT for the requestor.
 	reqStart := time.Unix(0, si.ts-int64(reqClientRTT))
 	sl := &ServiceLatency{
+		Status:         200,
 		AppName:        appName,
 		RequestStart:   reqStart,
 		ServiceLatency: serviceRTT - respClientRTT,
@@ -780,6 +863,7 @@ func (a *Account) sendTrackingLatency(si *serviceImport, requestor, responder *c
 			m1.merge(m2)
 			si.acc.mu.Unlock()
 			a.srv.sendInternalAccountMsg(a, si.latency.subject, m1)
+			si.rc = nil
 			return true
 		}
 		si.m1 = sl
@@ -787,16 +871,38 @@ func (a *Account) sendTrackingLatency(si *serviceImport, requestor, responder *c
 		return false
 	} else {
 		a.srv.sendInternalAccountMsg(a, si.latency.subject, sl)
+		si.rc = nil
 	}
 	return true
 }
 
-// numServiceRoutes returns the number of service routes on this account.
-func (a *Account) numServiceRoutes() int {
-	a.mu.RLock()
-	num := len(a.imports.services)
-	a.mu.RUnlock()
-	return num
+// This will check to make sure our response lower threshold is set
+// properly in any clients doing rrTracking.
+// Lock should be held.
+func (a *Account) updateAllClientsServiceExportResponseTime(lrt time.Duration) {
+	for _, c := range a.clients {
+		c.mu.Lock()
+		if c.rrTracking != nil && lrt != c.rrTracking.lrt {
+			c.rrTracking.lrt = lrt
+			if c.rrTracking.ptmr.Stop() {
+				c.rrTracking.ptmr.Reset(lrt)
+			}
+		}
+		c.mu.Unlock()
+	}
+}
+
+// Will select the lowest respThresh from all service exports.
+// Read lock should be held.
+func (a *Account) lowestServiceExportResponseTime() time.Duration {
+	// Lowest we will allow is 5 minutes. Its an upper bound for this function.
+	lrt := time.Duration(5 * time.Minute)
+	for _, se := range a.exports.services {
+		if se.respThresh < lrt {
+			lrt = se.respThresh
+		}
+	}
+	return lrt
 }
 
 // AddServiceImportWithClaim will add in the service import via the jwt claim.
@@ -830,17 +936,77 @@ func (a *Account) AddServiceImport(destination *Account, from, to string) error 
 	return a.AddServiceImportWithClaim(destination, from, to, nil)
 }
 
-// NumServiceImports return number of service imports we have.
+// NumPendingReverseResponses returns the number of response mappings we have for all outstanding
+// requests for service imports.
+func (a *Account) NumPendingReverseResponses() int {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return len(a.imports.rrMap)
+}
+
+// NumPendingAllResponses return the number of all responses outstanding for service exports.
+func (a *Account) NumPendingAllResponses() int {
+	return a.NumPendingResponses("")
+}
+
+// NumResponsesPending returns the number of responses outstanding for service exports
+// on this account. An empty filter string returns all responses regardless of which export.
+// If you specify the filter we will only return ones that are for that export.
+// NOTE this is only for what this server is tracking.
+func (a *Account) NumPendingResponses(filter string) int {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if filter == "" {
+		return len(a.exports.responses)
+	}
+	se := a.getServiceExport(filter)
+	if se == nil {
+		return 0
+	}
+	var nre int
+	for _, si := range a.exports.responses {
+		if si.se == se {
+			nre++
+		}
+	}
+	return nre
+}
+
+// NumServiceImports returns the number of service imports we have configured.
 func (a *Account) NumServiceImports() int {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return len(a.imports.services)
 }
 
+// Reason why we are removing this response serviceImport.
+type rsiReason int
+
+const (
+	rsiOk = rsiReason(iota)
+	rsiNoDelivery
+	rsiTimeout
+)
+
+// removeRespServiceImport removes a response si mapping and the reverse entries for interest detection.
+func (a *Account) removeRespServiceImport(si *serviceImport, reason rsiReason) {
+	if si == nil {
+		return
+	}
+	a.mu.Lock()
+	delete(a.exports.responses, si.from)
+	dest := si.acc
+	to := si.to
+	if si.tracking && si.rc != nil {
+		a.sendBackendErrorTrackingLatency(si, reason)
+	}
+	a.mu.Unlock()
+	dest.checkForReverseEntry(to, si, false)
+}
+
 // removeServiceImport will remove the route by subject.
 func (a *Account) removeServiceImport(subject string) {
 	a.mu.Lock()
-
 	si, ok := a.imports.services[subject]
 	delete(a.imports.services, subject)
 
@@ -848,9 +1014,6 @@ func (a *Account) removeServiceImport(subject string) {
 	c := a.ic
 
 	if ok && si != nil {
-		if si.ae {
-			a.nae--
-		}
 		if a.ic != nil && si.sub != nil && si.sub.sid != nil {
 			sid = si.sub.sid
 		}
@@ -863,140 +1026,137 @@ func (a *Account) removeServiceImport(subject string) {
 }
 
 // This tracks responses to service requests mappings. This is used for cleanup.
-func (a *Account) addRespMapEntry(acc *Account, reply, from string) {
+func (a *Account) addReverseRespMapEntry(acc *Account, reply, from string) {
 	a.mu.Lock()
-	if a.respMap == nil {
-		a.respMap = make(map[string][]*serviceRespEntry)
+	if a.imports.rrMap == nil {
+		a.imports.rrMap = make(map[string][]*serviceRespEntry)
 	}
 	sre := &serviceRespEntry{acc, from}
-	sra := a.respMap[reply]
-	a.respMap[reply] = append(sra, sre)
-	if len(a.respMap) > int(a.maxnrm) && !a.rmPruning {
-		a.rmPruning = true
-		go a.pruneNonAutoExpireResponseMaps()
-	}
+	sra := a.imports.rrMap[reply]
+	a.imports.rrMap[reply] = append(sra, sre)
 	a.mu.Unlock()
 }
 
-// This checks for any response map entries.
-func (a *Account) checkForRespEntry(reply string) {
+// checkForReverseEntries is for when we are trying to match reverse entries to a wildcard.
+// This will be called from checkForReverseEntry when the reply arg is a wildcard subject.
+// This will usually be called in a go routine since we need to walk all the entries.
+func (a *Account) checkForReverseEntries(reply string, checkInterest bool) {
 	a.mu.RLock()
-	if len(a.imports.services) == 0 || len(a.respMap) == 0 {
+	if len(a.imports.rrMap) == 0 {
 		a.mu.RUnlock()
 		return
 	}
-	sra := a.respMap[reply]
-	if sra == nil {
-		a.mu.RUnlock()
-		return
-	}
-	// If we are here we have an entry we should check. We will first check
-	// if there is any interest for this subject for the entire account. If
-	// there is we can not delete any entries yet.
-	rr := a.sl.Match(reply)
-	a.mu.RUnlock()
 
-	// No interest.
-	if len(rr.psubs)+len(rr.qsubs) > 0 {
+	if subjectIsLiteral(reply) {
+		a.mu.RUnlock()
+		a.checkForReverseEntry(reply, nil, checkInterest)
 		return
 	}
 
-	// Delete all the entries here.
-	a.mu.Lock()
-	delete(a.respMap, reply)
-	a.mu.Unlock()
+	var _rs [32]string
+	rs := _rs[:0]
 
-	// If we are here we no longer have interest and we have a respMap entry
-	// that we should clean up.
-	for _, sre := range sra {
-		sre.acc.removeServiceImport(sre.msub)
-	}
-}
-
-// Return the number of AutoExpireResponseMaps for request/reply. These are mapped to the account that
-// has the service import.
-func (a *Account) numAutoExpireResponseMaps() int {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	return int(a.nae)
-}
-
-// MaxAutoExpireResponseMaps return the maximum number of
-// auto expire response maps we will allow.
-func (a *Account) MaxAutoExpireResponseMaps() int {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	return int(a.maxnae)
-}
-
-// SetMaxAutoExpireResponseMaps sets the max outstanding auto expire response maps.
-func (a *Account) SetMaxAutoExpireResponseMaps(max int) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.maxnae = int32(max)
-}
-
-// AutoExpireTTL returns the ttl for response maps.
-func (a *Account) AutoExpireTTL() time.Duration {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	return a.maxaettl
-}
-
-// SetAutoExpireTTL sets the ttl for response maps.
-func (a *Account) SetAutoExpireTTL(ttl time.Duration) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.maxaettl = ttl
-}
-
-// Return a list of the current autoExpireResponseMaps.
-func (a *Account) autoExpireResponseMaps() []*serviceImport {
-	a.mu.RLock()
-	if len(a.imports.services) == 0 {
-		a.mu.RUnlock()
-		return nil
-	}
-	aesis := make([]*serviceImport, 0, len(a.imports.services))
-	for _, si := range a.imports.services {
-		if si.ae {
-			aesis = append(aesis, si)
+	for k := range a.imports.rrMap {
+		if subjectIsSubsetMatch(k, reply) {
+			rs = append(rs, k)
 		}
 	}
-	sort.Slice(aesis, func(i, j int) bool {
-		return aesis[i].ts < aesis[j].ts
-	})
-
 	a.mu.RUnlock()
-	return aesis
+
+	for _, reply := range rs {
+		a.checkForReverseEntry(reply, nil, checkInterest)
+	}
 }
 
-// MaxResponseMaps return the maximum number of
-// non auto-expire response maps we will allow.
-func (a *Account) MaxResponseMaps() int {
+// This checks for any response map entries. If you specify an si we will only match and
+// clean up for that one, otherwise we remove them all.
+func (a *Account) checkForReverseEntry(reply string, si *serviceImport, checkInterest bool) {
 	a.mu.RLock()
-	defer a.mu.RUnlock()
-	return int(a.maxnrm)
-}
+	if len(a.imports.rrMap) == 0 {
+		a.mu.RUnlock()
+		return
+	}
 
-// SetMaxResponseMaps sets the max outstanding non auto-expire response maps.
-func (a *Account) SetMaxResponseMaps(max int) {
+	if subjectHasWildcard(reply) {
+		a.mu.RUnlock()
+		go a.checkForReverseEntries(reply, checkInterest)
+		return
+	}
+
+	sres := a.imports.rrMap[reply]
+	if sres == nil {
+		a.mu.RUnlock()
+		return
+	}
+
+	// If we are here we have an entry we should check.
+	// If requested we will first check if there is any
+	// interest for this subject for the entire account.
+	// If there is we can not delete any entries yet.
+	// Note that if we are here reply has to be a literal subject.
+	if checkInterest {
+		rr := a.sl.Match(reply)
+		// If interest still exists we can not clean these up yet.
+		if len(rr.psubs)+len(rr.qsubs) > 0 {
+			a.mu.RUnlock()
+			return
+		}
+	}
+	a.mu.RUnlock()
+
+	// Delete the appropriate entries here based on optional si.
 	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.maxnrm = int32(max)
+	if si == nil {
+		delete(a.imports.rrMap, reply)
+	} else {
+		// Find the one we are looking for..
+		for i, sre := range sres {
+			if sre.msub == si.from {
+				sres = append(sres[:i], sres[i+1:]...)
+				break
+			}
+		}
+		if len(sres) > 0 {
+			a.imports.rrMap[si.to] = sres
+		} else {
+			delete(a.imports.rrMap, si.to)
+		}
+	}
+	a.mu.Unlock()
+
+	// If we are here we no longer have interest and we have
+	// response entries that we should clean up.
+	if si == nil {
+		for _, sre := range sres {
+			acc := sre.acc
+			var trackingCleanup bool
+			var rsi *serviceImport
+			acc.mu.Lock()
+			if rsi = acc.exports.responses[sre.msub]; rsi != nil {
+				delete(acc.exports.responses, rsi.from)
+				trackingCleanup = rsi.tracking && rsi.rc != nil
+			}
+			acc.mu.Unlock()
+
+			if trackingCleanup {
+				acc.sendReplyInterestLostTrackLatency(rsi)
+			}
+		}
+	}
 }
 
-// Add a service import to connect from an implicit import created for a response to a request.
-// This does no checks and should be only called by the msg processing code. Use
+// Add a service import.
+// This does no checks and should only be called by the msg processing code. Use
 // AddServiceImport from above if responding to user input or config changes, etc.
 func (a *Account) addServiceImport(dest *Account, from, to string, claim *jwt.Import) (*serviceImport, error) {
 	rt := Singleton
 	var lat *serviceLatency
 
 	dest.mu.Lock()
-	if ea := dest.getServiceExport(to); ea != nil {
-		rt = ea.respType
-		lat = ea.latency
+	se := dest.getServiceExport(to)
+	if se != nil {
+		rt = se.respType
+		lat = se.latency
 	}
 	dest.mu.Unlock()
 
@@ -1014,7 +1174,7 @@ func (a *Account) addServiceImport(dest *Account, from, to string, claim *jwt.Im
 	}
 	hasWC := subjectHasWildcard(from)
 
-	si := &serviceImport{dest, claim, nil, from, to, 0, rt, lat, nil, false, hasWC, false, false, false}
+	si := &serviceImport{dest, claim, se, nil, from, to, "", 0, rt, lat, nil, nil, hasWC, false, false, false}
 	a.imports.services[from] = si
 	a.mu.Unlock()
 
@@ -1025,21 +1185,30 @@ func (a *Account) addServiceImport(dest *Account, from, to string, claim *jwt.Im
 	return si, nil
 }
 
-// This will add an account subscription that matches the "from" from a service import entry.
-func (a *Account) addServiceImportSub(si *serviceImport) error {
-	a.mu.RLock()
-	// Create an internal client if we don't have on yet.
+// Returns the internal client, will create one if not present.
+// Lock should be held.
+func (a *Account) internalClient() *client {
 	if a.ic == nil && a.srv != nil {
 		a.ic = a.srv.createInternalAccountClient()
 		a.ic.acc = a
 	}
-	c := a.ic
+	return a.ic
+}
+
+// This will add an account subscription that matches the "from" from a service import entry.
+func (a *Account) addServiceImportSub(si *serviceImport) error {
+	a.mu.Lock()
+	c := a.internalClient()
 	sid := strconv.FormatUint(a.isid+1, 10)
-	a.mu.RUnlock()
+	a.mu.Unlock()
 
 	// This will happen in parsing when the account has not been properly setup.
 	if c == nil {
 		return nil
+	}
+
+	if si.sub != nil {
+		return fmt.Errorf("duplicate call to create subscription for service import")
 	}
 
 	sub, err := c.processSub([]byte(si.from+" "+sid), true)
@@ -1066,9 +1235,11 @@ func (a *Account) removeAllServiceImportSubs() {
 	for _, si := range a.imports.services {
 		if si.sub != nil && si.sub.sid != nil {
 			sids = append(sids, si.sub.sid)
+			si.sub = nil
 		}
 	}
 	c := a.ic
+	a.ic = nil
 	a.mu.RUnlock()
 
 	if c == nil {
@@ -1077,6 +1248,7 @@ func (a *Account) removeAllServiceImportSubs() {
 	for _, sid := range sids {
 		c.processUnsub(sid)
 	}
+	c.closeConnection(InternalClient)
 }
 
 // Add in subscriptions for all registered service imports.
@@ -1109,6 +1281,24 @@ const (
 	base           = 62
 )
 
+// This is where all service export responses are handled.
+func (a *Account) processServiceImportResponse(sub *subscription, c *client, subject, reply string, msg []byte) {
+	a.mu.RLock()
+	if a.expired || len(a.exports.responses) == 0 {
+		a.mu.RUnlock()
+		return
+	}
+	si := a.exports.responses[subject]
+	if si == nil || si.invalid {
+		a.mu.RUnlock()
+		return
+	}
+	a.mu.RUnlock()
+
+	// Send for normal processing.
+	c.processServiceImport(si, a, msg)
+}
+
 // Will create a wildcard subscription to handle interest graph propagation for all
 // service replies.
 // Lock should not be held.
@@ -1124,36 +1314,19 @@ func (a *Account) createRespWildcard() []byte {
 		l /= base
 	}
 	a.siReply = append(b[:], '.')
-	s := a.srv
-	aName := a.Name
 	pre := a.siReply
 	wcsub := append(a.siReply, '>')
+	c := a.internalClient()
+	a.isid += 1
+	sid := strconv.FormatUint(a.isid, 10)
 	a.mu.Unlock()
 
-	// Check to see if we need to propagate interest.
-	if s != nil {
-		now := time.Now()
-		c := &client{srv: a.srv, acc: a, kind: SYSTEM, opts: internalOpts, msubs: -1, mpay: -1, start: now, last: now}
-		sub := &subscription{client: c, subject: wcsub}
-		s.updateRouteSubscriptionMap(a, sub, 1)
-		if s.gateway.enabled {
-			s.gatewayUpdateSubInterest(aName, sub, 1)
-			a.mu.Lock()
-			a.siReplyClient = c
-			a.mu.Unlock()
-		}
-		// Now check on leafnode updates.
-		s.updateLeafNodes(a, sub, 1)
+	// Create subscription and internal callback for all the wildcard response subjects.
+	if sub, _ := c.processSub([]byte(string(wcsub)+" "+sid), false); sub != nil {
+		sub.icb = a.processServiceImportResponse
 	}
 
 	return pre
-}
-
-func (a *Account) replyClient() *client {
-	a.mu.RLock()
-	c := a.siReplyClient
-	a.mu.RUnlock()
-	return c
 }
 
 // Test whether this is a tracked reply.
@@ -1195,96 +1368,143 @@ func (a *Account) newServiceReply(tracking bool) []byte {
 	return reply
 }
 
-// This is for internal responses.
-func (a *Account) addRespServiceImport(dest *Account, from, to string, rt ServiceRespType, lat *serviceLatency) *serviceImport {
-	a.mu.Lock()
-	if a.imports.services == nil {
-		a.imports.services = make(map[string]*serviceImport)
-	}
-	// dest is the requestor's account. a is the service responder with the export.
-	ae := rt == Singleton
-	si := &serviceImport{dest, nil, nil, from, to, 0, rt, nil, nil, ae, false, true, false, false}
-	a.imports.services[from] = si
-	if ae {
-		a.nae++
-		si.ts = time.Now().UnixNano()
-		if lat != nil {
-			si.latency = lat
-			si.tracking = true
-		}
-		if a.nae > a.maxnae && !a.pruning {
-			a.pruning = true
-			go a.pruneAutoExpireResponseMaps()
-		}
-	}
-	a.mu.Unlock()
-
-	if err := a.addServiceImportSub(si); err != nil {
-		a.removeServiceImport(si.from)
-		return nil
-	}
-	return si
+// Checks if a serviceImport was created to map responses.
+func (si *serviceImport) isRespServiceImport() bool {
+	return si != nil && si.response
 }
 
-// This will prune off the non auto-expire (non singleton) response maps.
-func (a *Account) pruneNonAutoExpireResponseMaps() {
-	var sres []*serviceRespEntry
-	a.mu.Lock()
-	for subj, sra := range a.respMap {
-		rr := a.sl.Match(subj)
-		if len(rr.psubs)+len(rr.qsubs) == 0 {
-			delete(a.respMap, subj)
-			sres = append(sres, sra...)
-		}
+// Sets the response theshold timer for a service export.
+// Account lock should be held
+func (se *serviceExport) setResponseThresholdTimer() {
+	if se.rtmr != nil {
+		return // Already set
 	}
-	a.rmPruning = false
-	a.mu.Unlock()
-
-	for _, sre := range sres {
-		sre.acc.removeServiceImport(sre.msub)
-	}
+	se.rtmr = time.AfterFunc(se.respThresh, se.checkExpiredResponses)
 }
 
-// This will prune the list to below the threshold and remove all ttl'd maps.
-func (a *Account) pruneAutoExpireResponseMaps() {
-	defer func() {
-		a.mu.Lock()
-		a.pruning = false
-		a.mu.Unlock()
-	}()
+// Account lock should be held
+func (se *serviceExport) clearResponseThresholdTimer() bool {
+	if se.rtmr == nil {
+		return true
+	}
+	stopped := se.rtmr.Stop()
+	se.rtmr = nil
+	return stopped
+}
 
-	a.mu.RLock()
-	ttl := int64(a.maxaettl)
-	a.mu.RUnlock()
+// checkExpiredResponses will check for any pending responses that need to
+// be cleaned up.
+func (se *serviceExport) checkExpiredResponses() {
+	acc := se.acc
+	if acc == nil {
+		acc.mu.Lock()
+		se.clearResponseThresholdTimer()
+		acc.mu.Unlock()
+		return
+	}
 
-	for {
-		sis := a.autoExpireResponseMaps()
+	var expired []*serviceImport
+	mints := time.Now().UnixNano() - int64(se.respThresh)
 
-		// Check ttl items.
-		now := time.Now().UnixNano()
-		for i, si := range sis {
-			if now-si.ts >= ttl {
-				a.removeServiceImport(si.from)
-			} else {
-				sis = sis[i:]
-				break
+	// TODO(dlc) - Should we release lock while doing this? Or only do these in batches?
+	// Should we break this up for responses only from this service export?
+	// Responses live on acc directly for fast inbound processsing for the _R_ wildcard.
+	// We could do another indirection at this level but just to get to the service export?
+	var totalResponses int
+	acc.mu.RLock()
+	for _, si := range acc.exports.responses {
+		if si.se == se {
+			totalResponses++
+			if si.ts <= mints {
+				expired = append(expired, si)
 			}
 		}
-
-		a.mu.RLock()
-		numOver := int(a.nae - a.maxnae)
-		a.mu.RUnlock()
-
-		if numOver <= 0 {
-			return
-		} else if numOver >= len(sis) {
-			numOver = len(sis) - 1
-		}
-		// These are in sorted order, remove at least numOver
-		for _, si := range sis[:numOver] {
-			a.removeServiceImport(si.from)
-		}
 	}
+	acc.mu.RUnlock()
+
+	for _, si := range expired {
+		acc.removeRespServiceImport(si, rsiTimeout)
+	}
+
+	// Pull out expired to determine if we have any left for timer.
+	totalResponses -= len(expired)
+
+	// Redo timer as needed.
+	acc.mu.Lock()
+	if totalResponses > 0 && se.rtmr != nil {
+		se.rtmr.Stop()
+		se.rtmr.Reset(se.respThresh)
+	} else {
+		se.clearResponseThresholdTimer()
+	}
+	acc.mu.Unlock()
+}
+
+// ServiceExportResponseThreshold returns the current threshold.
+func (a *Account) ServiceExportResponseThreshold(export string) (time.Duration, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	se := a.getServiceExport(export)
+	if se == nil {
+		return 0, fmt.Errorf("no export defined for %q", export)
+	}
+	return se.respThresh, nil
+}
+
+// SetServiceExportResponseThreshold sets the maximum time the system will a response to be delivered
+// from a service export responder.
+func (a *Account) SetServiceExportResponseThreshold(export string, maxTime time.Duration) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	lrt := a.lowestServiceExportResponseTime()
+	se := a.getServiceExport(export)
+	if se == nil {
+		return fmt.Errorf("no export defined for %q", export)
+	}
+	se.respThresh = maxTime
+	if nlrt := a.lowestServiceExportResponseTime(); nlrt != lrt {
+		a.updateAllClientsServiceExportResponseTime(nlrt)
+	}
+	return nil
+}
+
+// This is for internal service import responses.
+func (a *Account) addRespServiceImport(dest *Account, to string, osi *serviceImport) *serviceImport {
+	tracking := shouldSample(osi.latency)
+	nrr := string(osi.acc.newServiceReply(tracking))
+
+	a.mu.Lock()
+	rt := osi.rt
+
+	// dest is the requestor's account. a is the service responder with the export.
+	se := osi.se
+	// Marked as internal here, that is how we distinguish.
+	si := &serviceImport{dest, nil, se, nil, nrr, to, osi.to, 0, rt, nil, nil, nil, false, true, false, false}
+
+	if a.exports.responses == nil {
+		a.exports.responses = make(map[string]*serviceImport)
+	}
+	a.exports.responses[nrr] = si
+
+	// Always grab time and make sure response threshold timer is running.
+	si.ts = time.Now().UnixNano()
+	se.setResponseThresholdTimer()
+
+	if rt == Singleton && tracking {
+		si.latency = osi.latency
+		si.tracking = true
+	}
+	a.mu.Unlock()
+
+	// We do not do individual subscriptions here like we do on configured imports.
+	// We have an internal callback for all responses inbound to this account and
+	// will process appropriately there. This does not pollute the sublist and the caches.
+
+	// We do add in the reverse map such that we can detect loss of interest and do proper
+	// cleanup of this si as interest goes away.
+	dest.addReverseRespMapEntry(a, to, nrr)
+
+	return si
 }
 
 // AddStreamImportWithClaim will add in the stream import from a specific account with optional token.
@@ -1430,18 +1650,18 @@ func (a *Account) checkStreamExportApproved(account *Account, subject string, im
 
 func (a *Account) checkServiceExportApproved(account *Account, subject string, imClaim *jwt.Import) bool {
 	// Check direct match of subject first
-	ea, ok := a.exports.services[subject]
+	se, ok := a.exports.services[subject]
 	if ok {
-		// if ea is nil or eq.approved is nil, that denotes a public export
-		if ea == nil || (ea.approved == nil && !ea.tokenReq) {
+		// if se is nil or eq.approved is nil, that denotes a public export
+		if se == nil || (se.approved == nil && !se.tokenReq) {
 			return true
 		}
 		// Check if token required
-		if ea.tokenReq {
+		if se.tokenReq {
 			return a.checkActivation(account, imClaim, true)
 		}
 		// If we have a matching account we are authorized
-		_, ok := ea.approved[account.Name]
+		_, ok := se.approved[account.Name]
 		return ok
 	}
 	// ok if we are here we did not match directly so we need to test each one.
@@ -1449,16 +1669,16 @@ func (a *Account) checkServiceExportApproved(account *Account, subject string, i
 	// has to be a true subset of the import claim. We already checked for
 	// exact matches above.
 	tokens := strings.Split(subject, tsep)
-	for subj, ea := range a.exports.services {
+	for subj, se := range a.exports.services {
 		if isSubsetMatch(tokens, subj) {
-			if ea == nil || ea.approved == nil && !ea.tokenReq {
+			if se == nil || (se.approved == nil && !se.tokenReq) {
 				return true
 			}
 			// Check if token required
-			if ea.tokenReq {
+			if se.tokenReq {
 				return a.checkActivation(account, imClaim, true)
 			}
-			_, ok := ea.approved[account.Name]
+			_, ok := se.approved[account.Name]
 			return ok
 		}
 	}
@@ -1468,12 +1688,12 @@ func (a *Account) checkServiceExportApproved(account *Account, subject string, i
 // Helper function to get a serviceExport.
 // Lock should be held on entry.
 func (a *Account) getServiceExport(subj string) *serviceExport {
-	ea, ok := a.exports.services[subj]
+	se, ok := a.exports.services[subj]
 	// The export probably has a wildcard, so lookup that up.
 	if !ok {
-		ea = a.getWildcardServiceExport(subj)
+		se = a.getWildcardServiceExport(subj)
 	}
-	return ea
+	return se
 }
 
 // This helper is used when trying to match a serviceExport record that is
@@ -1481,9 +1701,9 @@ func (a *Account) getServiceExport(subj string) *serviceExport {
 // Lock should be held on entry.
 func (a *Account) getWildcardServiceExport(from string) *serviceExport {
 	tokens := strings.Split(from, tsep)
-	for subj, ea := range a.exports.services {
+	for subj, se := range a.exports.services {
 		if isSubsetMatch(tokens, subj) {
-			return ea
+			return se
 		}
 	}
 	return nil
@@ -1851,15 +2071,10 @@ func (s *Server) AccountResolver() AccountResolver {
 	return ar
 }
 
-// UpdateAccountClaims will call updateAccountClaims.
-func (s *Server) UpdateAccountClaims(a *Account, ac *jwt.AccountClaims) {
-	s.updateAccountClaims(a, ac)
-}
-
 // updateAccountClaims will update an existing account with new claims.
 // This will replace any exports or imports previously defined.
 // Lock MUST NOT be held upon entry.
-func (s *Server) updateAccountClaims(a *Account, ac *jwt.AccountClaims) {
+func (s *Server) UpdateAccountClaims(a *Account, ac *jwt.AccountClaims) {
 	if a == nil {
 		return
 	}
@@ -1871,6 +2086,8 @@ func (s *Server) updateAccountClaims(a *Account, ac *jwt.AccountClaims) {
 	old := &Account{Name: a.Name, exports: a.exports, limits: a.limits, signingKeys: a.signingKeys}
 
 	// Reset exports and imports here.
+
+	// Exports is creating a whole new map.
 	a.exports = exportMap{}
 
 	// Imports are checked unlocked in processInbound, so we can't change out the struct here. Need to process inline.
@@ -1885,6 +2102,7 @@ func (s *Server) updateAccountClaims(a *Account, ac *jwt.AccountClaims) {
 		old.imports.services[k] = v
 		delete(a.imports.services, k)
 	}
+
 	// Reset any notion of export revocations.
 	a.actsRevoked = nil
 
@@ -1968,6 +2186,7 @@ func (s *Server) updateAccountClaims(a *Account, ac *jwt.AccountClaims) {
 				s.Debugf("Error adding stream import to account [%s]: %v", a.Name, err.Error())
 			}
 		case jwt.Service:
+			// FIXME(dlc) - need to add in respThresh here eventually.
 			s.Debugf("Adding service import %s:%q for %s:%q", acc.Name, i.Subject, a.Name, i.To)
 			if err := a.AddServiceImportWithClaim(acc, string(i.Subject), string(i.To), i); err != nil {
 				s.Debugf("Error adding service import to account [%s]: %v", a.Name, err.Error())
@@ -2030,6 +2249,12 @@ func (s *Server) updateAccountClaims(a *Account, ac *jwt.AccountClaims) {
 				if si != nil && si.acc.Name == a.Name {
 					// Check for if we are still authorized for an import.
 					si.invalid = !a.checkServiceImportAuthorized(acc, si.to, si.claim)
+					if si.latency != nil && !si.response {
+						// Make sure we should still be tracking latency.
+						if se := a.getServiceExport(si.to); se != nil {
+							si.latency = se.latency
+						}
+					}
 				}
 			}
 			acc.mu.Unlock()
@@ -2116,7 +2341,7 @@ func (s *Server) buildInternalAccount(ac *jwt.AccountClaims) *Account {
 	// being built, however, to solve circular import dependencies, we
 	// need to store it here.
 	s.tmpAccounts.Store(ac.Subject, acc)
-	s.updateAccountClaims(acc, ac)
+	s.UpdateAccountClaims(acc, ac)
 	return acc
 }
 
@@ -2197,7 +2422,6 @@ func NewURLAccResolver(url string) (*URLAccResolver, error) {
 	if !strings.HasSuffix(url, "/") {
 		url += "/"
 	}
-
 	// FIXME(dlc) - Make timeout and others configurable.
 	// We create our own transport to amortize TLS.
 	tr := &http.Transport{

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -761,7 +761,7 @@ func (a *Account) sendBadRequestTrackingLatency(si *serviceImport, requestor *cl
 	sl := &ServiceLatency{
 		Status:       400,
 		Error:        "Bad Request",
-		RequestStart: time.Now().Add(-requestor.getRTTValue()),
+		RequestStart: time.Now().Add(-requestor.getRTTValue()).UTC(),
 	}
 	a.sendLatencyResult(si, sl)
 }
@@ -777,7 +777,7 @@ func (a *Account) sendReplyInterestLostTrackLatency(si *serviceImport) {
 	sl := &ServiceLatency{
 		Status:       408,
 		Error:        "Request Timeout",
-		RequestStart: reqStart,
+		RequestStart: reqStart.UTC(),
 		NATSLatency: NATSLatency{
 			Requestor: reqClientRTT,
 		},
@@ -792,7 +792,7 @@ func (a *Account) sendBackendErrorTrackingLatency(si *serviceImport, reason rsiR
 	}
 	reqStart := time.Unix(0, si.ts-int64(reqClientRTT))
 	sl := &ServiceLatency{
-		RequestStart: reqStart,
+		RequestStart: reqStart.UTC(),
 		NATSLatency: NATSLatency{
 			Requestor: reqClientRTT,
 		},
@@ -835,7 +835,7 @@ func (a *Account) sendTrackingLatency(si *serviceImport, responder *client) bool
 	sl := &ServiceLatency{
 		Status:         200,
 		AppName:        appName,
-		RequestStart:   reqStart,
+		RequestStart:   reqStart.UTC(),
 		ServiceLatency: serviceRTT - respClientRTT,
 		NATSLatency: NATSLatency{
 			Requestor: reqClientRTT,

--- a/server/client.go
+++ b/server/client.go
@@ -171,6 +171,7 @@ const (
 	WrongGateway
 	MissingAccount
 	Revocation
+	InternalClient
 )
 
 // Some flags passed to processMsgResultsEx
@@ -219,10 +220,10 @@ type client struct {
 	last    time.Time
 	parseState
 
-	rtt        time.Duration
-	rttStart   time.Time
-	rrTracking map[string]*remoteLatency
-	rrMax      int
+	rtt      time.Duration
+	rttStart time.Time
+
+	rrTracking *rrTracking
 
 	route *route
 	gw    *gateway
@@ -235,6 +236,12 @@ type client struct {
 
 	trace bool
 	echo  bool
+}
+
+type rrTracking struct {
+	rmap map[string]*remoteLatency
+	ptmr *time.Timer
+	lrt  time.Duration
 }
 
 // Struct for PING initiation from the server.
@@ -496,6 +503,8 @@ func (c *client) initClient() {
 		c.ncs = "SYSTEM"
 	case JETSTREAM:
 		c.ncs = "JETSTREAM"
+	case ACCOUNT:
+		c.ncs = "ACCOUNT"
 	}
 }
 
@@ -1964,6 +1973,7 @@ func (c *client) processSub(argo []byte, noForward bool) (*subscription, error) 
 			return nil, nil
 		}
 	}
+
 	// Check if we have a maximum on the number of subscriptions.
 	if c.subsAtLimit() {
 		c.mu.Unlock()
@@ -2010,7 +2020,7 @@ func (c *client) processSub(argo []byte, noForward bool) (*subscription, error) 
 	}
 
 	// If we are routing and this is a local sub, add to the route map for the associated account.
-	if kind == CLIENT || kind == SYSTEM || kind == JETSTREAM {
+	if kind == CLIENT || kind == SYSTEM || kind == JETSTREAM || kind == ACCOUNT {
 		srv.updateRouteSubscriptionMap(acc, sub, 1)
 		if updateGWs {
 			srv.gatewayUpdateSubInterest(acc.Name, sub, 1)
@@ -2285,7 +2295,7 @@ func (c *client) unsubscribe(acc *Account, sub *subscription, force, remove bool
 
 	// Now check to see if this was part of a respMap entry for service imports.
 	if acc != nil {
-		acc.checkForRespEntry(string(sub.subject))
+		acc.checkForReverseEntry(string(sub.subject), nil, true)
 	}
 }
 
@@ -2550,8 +2560,8 @@ func (c *client) deliverMsg(sub *subscription, subject, mh, msg []byte, gwrply b
 		// FIXME(dlc) - We may need to optimize this.
 		// We will have tagged this with a suffix ('.T') if we are tracking. This is
 		// needed from sampling. Not all will be tracked.
-		if c.kind != CLIENT && client.acc.IsExportServiceTracking(string(subject)) && isTrackedReply(c.pa.reply) {
-			client.trackRemoteReply(string(c.pa.reply))
+		if c.kind != CLIENT && isTrackedReply(c.pa.reply) {
+			client.trackRemoteReply(string(subject), string(c.pa.reply))
 		}
 	}
 
@@ -2598,20 +2608,68 @@ func (c *client) deliverMsg(sub *subscription, subject, mh, msg []byte, gwrply b
 // This will track a remote reply for an exported service that has requested
 // latency tracking.
 // Lock assumed to be held.
-func (c *client) trackRemoteReply(reply string) {
+func (c *client) trackRemoteReply(subject, reply string) {
+	a := c.acc
+	if a == nil {
+		return
+	}
+
+	var lrt time.Duration
+	var respThresh time.Duration
+
+	a.mu.RLock()
+	se := a.getServiceExport(subject)
+	if se != nil {
+		lrt = a.lowestServiceExportResponseTime()
+		respThresh = se.respThresh
+	}
+	a.mu.RUnlock()
+
+	if se == nil {
+		return
+	}
+
 	if c.rrTracking == nil {
-		c.rrTracking = make(map[string]*remoteLatency)
-		c.rrMax = c.acc.MaxAutoExpireResponseMaps()
+		c.rrTracking = &rrTracking{
+			rmap: make(map[string]*remoteLatency),
+			ptmr: time.AfterFunc(lrt, c.pruneRemoteTracking),
+			lrt:  lrt,
+		}
 	}
 	rl := remoteLatency{
-		Account: c.acc.Name,
-		ReqId:   reply,
+		Account:    a.Name,
+		ReqId:      reply,
+		respThresh: respThresh,
 	}
 	rl.M2.RequestStart = time.Now()
-	c.rrTracking[reply] = &rl
-	if len(c.rrTracking) >= c.rrMax {
-		c.pruneRemoteTracking()
+	c.rrTracking.rmap[reply] = &rl
+}
+
+// pruneRemoteTracking will prune any remote tracking objects
+// that are too old. These are orphaned when a service is not
+// sending reponses etc.
+// Lock should be held upon entry.
+func (c *client) pruneRemoteTracking() {
+	c.mu.Lock()
+	if c.rrTracking == nil {
+		c.mu.Unlock()
+		return
 	}
+	now := time.Now()
+	for subject, rl := range c.rrTracking.rmap {
+		if now.After(rl.M2.RequestStart.Add(rl.respThresh)) {
+			delete(c.rrTracking.rmap, subject)
+		}
+	}
+	if len(c.rrTracking.rmap) > 0 {
+		t := c.rrTracking.ptmr
+		t.Stop()
+		t.Reset(c.rrTracking.lrt)
+	} else {
+		c.rrTracking.ptmr.Stop()
+		c.rrTracking = nil
+	}
+	c.mu.Unlock()
 }
 
 // pruneReplyPerms will remove any stale or expired entries
@@ -2657,20 +2715,6 @@ func (c *client) prunePubPermsCache() {
 		delete(c.perms.pcache, subject)
 		if r++; r > pruneSize {
 			break
-		}
-	}
-}
-
-// pruneRemoteTracking will prune any remote tracking objects
-// that are too old. These are orphaned when a service is not
-// sending reponses etc.
-// Lock should be held upon entry.
-func (c *client) pruneRemoteTracking() {
-	ttl := c.acc.AutoExpireTTL()
-	now := time.Now()
-	for reply, rl := range c.rrTracking {
-		if now.Sub(rl.M2.RequestStart) > ttl {
-			delete(c.rrTracking, reply)
 		}
 	}
 }
@@ -2810,9 +2854,9 @@ func (c *client) processInboundClientMsg(msg []byte) bool {
 	// to see if we need to report the latency.
 	if c.rrTracking != nil {
 		c.mu.Lock()
-		rl := c.rrTracking[string(c.pa.subject)]
+		rl := c.rrTracking.rmap[string(c.pa.subject)]
 		if rl != nil {
-			delete(c.rrTracking, string(c.pa.subject))
+			delete(c.rrTracking.rmap, string(c.pa.subject))
 		}
 		rtt := c.rtt
 		c.mu.Unlock()
@@ -2824,7 +2868,6 @@ func (c *client) processInboundClientMsg(msg []byte) bool {
 			sl.NATSLatency.Responder = rtt
 			sl.TotalLatency = sl.ServiceLatency + rtt
 			sanitizeLatencyMetric(sl)
-
 			lsub := remoteLatencySubjectForResponse(c.pa.subject)
 			c.srv.sendInternalAccountMsg(nil, lsub, &rl) // Send to SYS account
 		}
@@ -2867,7 +2910,6 @@ func (c *client) processInboundClientMsg(msg []byte) bool {
 	// Check for no interest, short circuit if so.
 	// This is the fanout scale.
 	if len(r.psubs)+len(r.qsubs) > 0 {
-		didDeliver = true
 		flag := pmrNoFlag
 		// If there are matching queue subs and we are in gateway mode,
 		// we need to keep track of the queue names the messages are
@@ -2878,7 +2920,7 @@ func (c *client) processInboundClientMsg(msg []byte) bool {
 			atomic.LoadInt64(&c.srv.gateway.totalQSubs) > 0 {
 			flag |= pmrCollectQueueNames
 		}
-		qnames = c.processMsgResults(c.acc, r, msg, c.pa.deliver, c.pa.subject, c.pa.reply, flag)
+		didDeliver, qnames = c.processMsgResults(c.acc, r, msg, c.pa.deliver, c.pa.subject, c.pa.reply, flag)
 	}
 
 	// Now deal with gateways
@@ -2908,9 +2950,9 @@ func (c *client) handleGWReplyMap(msg []byte) bool {
 	var rtt time.Duration
 
 	if c.rrTracking != nil {
-		rl = c.rrTracking[string(c.pa.subject)]
+		rl = c.rrTracking.rmap[string(c.pa.subject)]
 		if rl != nil {
-			delete(c.rrTracking, string(c.pa.subject))
+			delete(c.rrTracking.rmap, string(c.pa.subject))
 		}
 		rtt = c.rtt
 	}
@@ -2942,15 +2984,30 @@ func (c *client) handleGWReplyMap(msg []byte) bool {
 	return true
 }
 
+// Used to setup the response map for a service import request that has a reply subject.
+func (c *client) setupResponseServiceImport(acc *Account, si *serviceImport) *serviceImport {
+	rsi := si.acc.addRespServiceImport(acc, string(c.pa.reply), si)
+	if si.latency != nil {
+		if c.rtt == 0 {
+			// We have a service import that we are tracking but have not established RTT.
+			c.sendRTTPing()
+		}
+		si.acc.mu.Lock()
+		rsi.rc = c
+		si.acc.mu.Unlock()
+	}
+	return rsi
+}
+
 // processServiceImport is an internal callback when a subscription matches an imported service
-// from another account.
+// from another account. This includes response mappings as well.
 func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byte) {
-	if c.kind == GATEWAY && !isServiceReply(c.pa.subject) {
+	if c.kind == GATEWAY && !si.isRespServiceImport() {
 		return
 	}
 
 	acc.mu.RLock()
-	shouldReturn := si.invalid || acc.sl == nil || acc.imports.services == nil
+	shouldReturn := si.invalid || acc.sl == nil
 	acc.mu.RUnlock()
 
 	if shouldReturn {
@@ -2958,22 +3015,14 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 	}
 
 	var nrr []byte
-	if c.pa.reply != nil {
-		var latency *serviceLatency
-		var tracking bool
-		if tracking = shouldSample(si.latency); tracking {
-			latency = si.latency
-		}
-		// We want to remap this to provide anonymity.
-		nrr = si.acc.newServiceReply(tracking)
-		si.acc.addRespServiceImport(acc, string(nrr), string(c.pa.reply), si.rt, latency)
+	var rsi *serviceImport
 
-		// Track our responses for cleanup if not auto-expire.
-		if si.rt != Singleton {
-			acc.addRespMapEntry(si.acc, string(c.pa.reply), string(nrr))
-		} else if si.latency != nil && c.rtt == 0 {
-			// We have a service import that we are tracking but have not established RTT.
-			c.sendRTTPing()
+	// Check if there is a reply present and set up a response.
+	// TODO(dlc) - restrict to configured service imports and not responses?
+	if len(c.pa.reply) > 0 {
+		rsi = c.setupResponseServiceImport(acc, si)
+		if rsi != nil {
+			nrr = []byte(rsi.from)
 		}
 	}
 
@@ -2985,15 +3034,6 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 
 	// FIXME(dlc) - Do L1 cache trick like normal client?
 	rr := si.acc.sl.Match(to)
-
-	// This gives us a notion that we have interest in this message.
-	didDeliver := len(rr.psubs)+len(rr.qsubs) > 0
-	// Check to see if we have no results and this is an internal serviceImport.
-	// If so we need to clean that up.
-	if !didDeliver && si.internal {
-		// We may also have a response entry, so go through that way.
-		si.acc.checkForRespEntry(to)
-	}
 
 	// If we are a route or gateway or leafnode and this message is flipped to a queue subscriber we
 	// need to handle that since the processMsgResults will want a queue filter.
@@ -3011,30 +3051,57 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 	var lrts [routeTargetInit]routeTarget
 	c.in.rts = lrts[:0]
 
+	var didDeliver bool
+
 	// If this is not a gateway connection but gateway is enabled,
 	// try to send this converted message to all gateways.
 	if c.srv.gateway.enabled {
 		flags |= pmrCollectQueueNames
-		queues := c.processMsgResults(si.acc, rr, msg, nil, []byte(to), nrr, flags)
-		c.sendMsgToGateways(si.acc, msg, []byte(to), nrr, queues)
+		var queues [][]byte
+		didDeliver, queues = c.processMsgResults(si.acc, rr, msg, nil, []byte(to), nrr, flags)
+		didDeliver = c.sendMsgToGateways(si.acc, msg, []byte(to), nrr, queues) || didDeliver
 	} else {
-		c.processMsgResults(si.acc, rr, msg, nil, []byte(to), nrr, flags)
+		didDeliver, _ = c.processMsgResults(si.acc, rr, msg, nil, []byte(to), nrr, flags)
 	}
 
 	// Put what was there back now.
 	c.in.rts = orts
 
-	shouldRemove := si.ae
+	// Determine if we should remove this service import. This is for response service imports.
+	// We will remove if we did not deliver, or if we are a response service import and we are
+	// a singleton, or we have an EOF message.
+	shouldRemove := !didDeliver || (si.response && (si.rt == Singleton || len(msg) == LEN_CR_LF))
 
 	// Calculate tracking info here if we are tracking this request/response.
 	if si.tracking {
-		if requesting := firstSubFromResult(rr); requesting != nil {
-			shouldRemove = acc.sendTrackingLatency(si, requesting.client, c)
-		}
+		shouldRemove = acc.sendTrackingLatency(si, c)
 	}
 
+	// Check to see if this was a bad request with no reply and we were supposed to be tracking.
+	if !si.response && si.latency != nil && len(c.pa.reply) == 0 && shouldSample(si.latency) {
+		si.acc.sendBadRequestTrackingLatency(si, c)
+	}
+
+	// If we are streamed or chunked we need to update our timestamp to avoid cleanup.
+	if si.rt != Singleton && didDeliver {
+		acc.mu.Lock()
+		si.ts = time.Now().UnixNano()
+		acc.mu.Unlock()
+	}
+
+	// Cleanup of a response service import
 	if shouldRemove {
-		acc.removeServiceImport(si.from)
+		reason := rsiOk
+		if !didDeliver {
+			reason = rsiNoDelivery
+		}
+		if si.isRespServiceImport() {
+			acc.removeRespServiceImport(si, reason)
+		} else {
+			// This is a main import and since we could not even deliver to the exporting account
+			// go ahead and remove the respServiceImport we created above.
+			si.acc.removeRespServiceImport(rsi, reason)
+		}
 	}
 }
 
@@ -3074,7 +3141,8 @@ func (c *client) addSubToRouteTargets(sub *subscription) {
 }
 
 // This processes the sublist results for a given message.
-func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver, subject, reply []byte, flags int) [][]byte {
+// Returns if the message was delivered to at least target and queue filters.
+func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver, subject, reply []byte, flags int) (bool, [][]byte) {
 	// For sending messages across routes and leafnodes.
 	// Reset if we have one since we reuse this data structure.
 	if c.in.rts != nil {
@@ -3111,6 +3179,8 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 			subj, creply = creply[li+1:], creply[:li]
 		}
 	}
+
+	var didDeliver bool
 
 	// msg header for clients.
 	msgh := c.msgb[1:msgHeadProtoLen]
@@ -3152,7 +3222,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 		}
 		// Normal delivery
 		mh := c.msgHeader(msgh[:si], sub, creply)
-		c.deliverMsg(sub, subj, mh, msg, rplyHasGWPrefix)
+		didDeliver = c.deliverMsg(sub, subj, mh, msg, rplyHasGWPrefix) || didDeliver
 	}
 
 	// Set these up to optionally filter based on the queue lists.
@@ -3268,6 +3338,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 			// for client connections only.
 			mh := c.msgHeader(msgh[:si], sub, rreply)
 			if c.deliverMsg(sub, subject, mh, msg, rplyHasGWPrefix) {
+				didDeliver = true
 				// Clear rsub
 				rsub = nil
 				if flags&pmrCollectQueueNames != 0 {
@@ -3291,7 +3362,7 @@ sendToRoutesOrLeafs:
 
 	// If no messages for routes or leafnodes return here.
 	if len(c.in.rts) == 0 {
-		return queues
+		return didDeliver, queues
 	}
 
 	// If we do have a deliver subject we need to do something with it.
@@ -3340,9 +3411,9 @@ sendToRoutesOrLeafs:
 		}
 		mh = append(mh, c.pa.szb...)
 		mh = append(mh, _CRLF_...)
-		c.deliverMsg(rt.sub, subject, mh, msg, false)
+		didDeliver = c.deliverMsg(rt.sub, subject, mh, msg, false) || didDeliver
 	}
-	return queues
+	return didDeliver, queues
 }
 
 func (c *client) pubPermissionViolation(subject []byte) {
@@ -3496,12 +3567,27 @@ func (c *client) typeString() string {
 		return "LeafNode"
 	case JETSTREAM:
 		return "JetStream"
+	case ACCOUNT:
+		return "Account"
 	}
 	return "Unknown Type"
 }
 
+// swapAccountAfterReload will check to make sure the bound account for this client
+// is current. Under certain circumstances after a reload we could be pointing to
+// an older one.
+func (c *client) swapAccountAfterReload() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.srv == nil {
+		return
+	}
+	acc, _ := c.srv.LookupAccount(c.acc.Name)
+	c.acc = acc
+}
+
 // processSubsOnConfigReload removes any subscriptions the client has that are no
-// longer authorized, and check for imports (accounts) due to a config reload.
+// longer authorized, and checks for imports (accounts) due to a config reload.
 func (c *client) processSubsOnConfigReload(awcsti map[string]struct{}) {
 	c.mu.Lock()
 	var (
@@ -3652,6 +3738,12 @@ func (c *client) teardownConn() {
 		gwName = c.gw.name
 		gwIsOutbound = c.gw.outbound
 		gwCfg = c.gw.cfg
+	}
+
+	// If we have remote latency tracking running shut that down.
+	if c.rrTracking != nil {
+		c.rrTracking.ptmr.Stop()
+		c.rrTracking = nil
 	}
 
 	c.mu.Unlock()

--- a/server/client.go
+++ b/server/client.go
@@ -2641,7 +2641,7 @@ func (c *client) trackRemoteReply(subject, reply string) {
 		ReqId:      reply,
 		respThresh: respThresh,
 	}
-	rl.M2.RequestStart = time.Now()
+	rl.M2.RequestStart = time.Now().UTC()
 	c.rrTracking.rmap[reply] = &rl
 }
 

--- a/server/const.go
+++ b/server/const.go
@@ -130,16 +130,6 @@ const (
 	// DEFAULT_MAX_CLOSED_CLIENTS is the maximum number of closed connections we hold onto.
 	DEFAULT_MAX_CLOSED_CLIENTS = 10000
 
-	// DEFAULT_MAX_ACCOUNT_AE_RESPONSE_MAPS is for auto-expire response maps for imports.
-	DEFAULT_MAX_ACCOUNT_AE_RESPONSE_MAPS = 100000
-
-	// DEFAULT_MAX_ACCOUNT_INTERNAL_RESPONSE_MAPS is for non auto-expire response maps for imports.
-	// These are present for non-singleton response types.
-	DEFAULT_MAX_ACCOUNT_INTERNAL_RESPONSE_MAPS = 100000
-
-	// DEFAULT_TTL_AE_RESPONSE_MAP is the default time to expire auto-response map entries.
-	DEFAULT_TTL_AE_RESPONSE_MAP = 10 * time.Minute
-
 	// DEFAULT_LAME_DUCK_DURATION is the time in which the server spreads
 	// the closing of clients when signaled to go in lame duck mode.
 	DEFAULT_LAME_DUCK_DURATION = 2 * time.Minute
@@ -175,6 +165,11 @@ const (
 	// DEFAULT_ALLOW_RESPONSE_EXPIRATION is the default time allowed for a given
 	// dynamic response permission.
 	DEFAULT_ALLOW_RESPONSE_EXPIRATION = 2 * time.Minute
+
+	// DEFAULT_SERVICE_EXPORT_RESPONSE_THRESHOLD is the default time that the system will
+	// expect a service export response to be delivered. This is used in corner cases for
+	// time based cleanup of reverse mapping structures.
+	DEFAULT_SERVICE_EXPORT_RESPONSE_THRESHOLD = 2 * time.Minute
 
 	// DEFAULT_SERVICE_LATENCY_SAMPLING is the default sampling rate for service
 	// latency metrics

--- a/server/events.go
+++ b/server/events.go
@@ -1126,7 +1126,7 @@ func (s *Server) remoteLatencyUpdate(sub *subscription, _ *client, subject, _ st
 	}
 	rl := remoteLatency{}
 	if err := json.Unmarshal(msg, &rl); err != nil {
-		s.Errorf("Error unmarshalling remot elatency measurement: %v", err)
+		s.Errorf("Error unmarshalling remote latency measurement: %v", err)
 		return
 	}
 	// Now we need to look up the responseServiceImport associated with this measurement.
@@ -1141,7 +1141,7 @@ func (s *Server) remoteLatencyUpdate(sub *subscription, _ *client, subject, _ st
 		reply = string(getSubjectFromGWRoutedReply([]byte(reply), old))
 	}
 	acc.mu.RLock()
-	si := acc.imports.services[reply]
+	si := acc.exports.responses[reply]
 	if si == nil {
 		acc.mu.RUnlock()
 		return
@@ -1171,6 +1171,11 @@ func (s *Server) remoteLatencyUpdate(sub *subscription, _ *client, subject, _ st
 	// M1 TotalLatency is correct, so use that.
 	// Will use those to back into NATS latency.
 	m1.merge(&m2)
+
+	// Clear the requesting client since we send the result here.
+	si.acc.mu.Lock()
+	si.rc = nil
+	si.acc.mu.Unlock()
 
 	// Make sure we remove the entry here.
 	acc.removeServiceImport(si.from)

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -2282,11 +2282,11 @@ func hasGWRoutedReplyPrefix(subj []byte) bool {
 
 // Evaluates if the given reply should be mapped or not.
 func (g *srvGateway) shouldMapReplyForGatewaySend(c *client, acc *Account, reply []byte) bool {
-	// If the reply is a service reply (_R_), we will use the replyClient
-	// instead of the client handed to us. This client holds the wildcard
+	// If the reply is a service reply (_R_), we will use the account's internal
+	// clientinstead of the client handed to us. This client holds the wildcard
 	// for all service replies.
 	if isServiceReply(reply) {
-		c = acc.replyClient()
+		c = acc.internalClient()
 	}
 	// If for this client there is a recent matching subscription interest
 	// then we will map.
@@ -2300,6 +2300,7 @@ func (g *srvGateway) shouldMapReplyForGatewaySend(c *client, acc *Account, reply
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -2451,8 +2452,7 @@ func (c *client) sendMsgToGateways(acc *Account, msg, subject, reply []byte, qgr
 		sub.nm, sub.max = 0, 0
 		sub.client = gwc
 		sub.subject = subject
-		c.deliverMsg(sub, subject, mh, msg, false)
-		didDeliver = true
+		didDeliver = c.deliverMsg(sub, subject, mh, msg, false) || didDeliver
 	}
 	// Done with subscription, put back to pool. We don't need
 	// to reset content since we explicitly set when using it.
@@ -2674,6 +2674,7 @@ func (c *client) handleGatewayReply(msg []byte) (processed bool) {
 		}
 		return true
 	}
+
 	// If route is nil, we will process the incoming message locally.
 	if route == nil {
 		// Check if this is a service reply subject (_R_)
@@ -2688,7 +2689,7 @@ func (c *client) handleGatewayReply(msg []byte) (processed bool) {
 			if c.kind == ROUTER {
 				flags |= pmrAllowSendFromRouteToRoute
 			}
-			queues = c.processMsgResults(acc, r, msg, nil, c.pa.subject, c.pa.reply, flags)
+			_, queues = c.processMsgResults(acc, r, msg, nil, c.pa.subject, c.pa.reply, flags)
 		}
 		// Since this was a reply that made it to the origin cluster,
 		// we now need to send the message with the real subject to

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -236,6 +236,7 @@ func natsUnsub(t *testing.T, sub *nats.Subscription) {
 
 func testDefaultOptionsForGateway(name string) *Options {
 	o := DefaultOptions()
+	o.ServerName = name
 	o.Gateway.Name = name
 	o.Gateway.Host = "127.0.0.1"
 	o.Gateway.Port = -1
@@ -3338,7 +3339,7 @@ func TestGatewayServiceImport(t *testing.T) {
 		}
 
 		// Check for duplicate message
-		if msg, err := subB.NextMsg(100 * time.Millisecond); err != nats.ErrTimeout {
+		if msg, err := subB.NextMsg(250 * time.Millisecond); err != nats.ErrTimeout {
 			t.Fatalf("Unexpected msg: %v", msg)
 		}
 
@@ -3349,14 +3350,14 @@ func TestGatewayServiceImport(t *testing.T) {
 		}
 
 		// For B, we expect it to send to gateway on the two subjects: test.request
-		// and foo.request then send the reply to the client. We also send the reply
-		// optimistically to the other side.
+		// and foo.request then send the reply to the client and optimistically
+		// to the other gateway. Also send on _R_
 		if i == 0 {
-			expected = 4
+			expected = 5
 		} else {
 			// The second time, one of the accounts will be suppressed and the reply going
-			// back so we will get only 2 more messages.
-			expected = 6
+			// back so we should get only 2 more messages.
+			expected = 7
 		}
 		vz, _ = sb.Varz(nil)
 		if vz.OutMsgs != expected {
@@ -3372,7 +3373,10 @@ func TestGatewayServiceImport(t *testing.T) {
 	})
 
 	// Speed up exiration
-	fooA.SetAutoExpireTTL(10 * time.Millisecond)
+	err := fooA.SetServiceExportResponseThreshold("test.request", 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Error setting response threshold: %v", err)
+	}
 
 	// Send 100 requests from clientB on foo.request,
 	for i := 0; i < 100; i++ {
@@ -3402,7 +3406,10 @@ func TestGatewayServiceImport(t *testing.T) {
 	// Repeat similar test but without the small TTL and verify
 	// that if B is shutdown, the dangling subs for replies are
 	// cleared from the account sublist.
-	fooA.SetAutoExpireTTL(10 * time.Second)
+	err = fooA.SetServiceExportResponseThreshold("test.request", 10*time.Second)
+	if err != nil {
+		t.Fatalf("Error setting response threshold: %v", err)
+	}
 
 	subA = natsSubSync(t, clientA, "test.request")
 	natsFlush(t, clientA)
@@ -3645,7 +3652,7 @@ func TestGatewayServiceImportWithQueue(t *testing.T) {
 			t.Fatalf("Unexpected message: %v", msg)
 		}
 		// Check for duplicate message
-		if msg, err := subB.NextMsg(100 * time.Millisecond); err != nats.ErrTimeout {
+		if msg, err := subB.NextMsg(250 * time.Millisecond); err != nats.ErrTimeout {
 			t.Fatalf("Unexpected msg: %v", msg)
 		}
 
@@ -3656,14 +3663,14 @@ func TestGatewayServiceImportWithQueue(t *testing.T) {
 		}
 
 		// For B, we expect it to send to gateway on the two subjects: test.request
-		// and foo.request then send the reply to the client. We also send the reply
-		// optimistically to the other side.
+		// and foo.request then send the reply to the client and optimistically
+		// to the other gateway. Also send on _R_.
 		if i == 0 {
-			expected = 4
+			expected = 5
 		} else {
 			// The second time, one of the accounts will be suppressed and the reply going
-			// back so we will get only 2 more messages.
-			expected = 6
+			// back so we should get only 2 more messages.
+			expected = 7
 		}
 		vz, _ = sb.Varz(nil)
 		if vz.OutMsgs != expected {
@@ -3679,7 +3686,10 @@ func TestGatewayServiceImportWithQueue(t *testing.T) {
 	})
 
 	// Speed up exiration
-	fooA.SetAutoExpireTTL(10 * time.Millisecond)
+	err := fooA.SetServiceExportResponseThreshold("test.request", 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Error setting response threshold: %v", err)
+	}
 
 	// Send 100 requests from clientB on foo.request,
 	for i := 0; i < 100; i++ {
@@ -3710,7 +3720,10 @@ func TestGatewayServiceImportWithQueue(t *testing.T) {
 	// Repeat similar test but without the small TTL and verify
 	// that if B is shutdown, the dangling subs for replies are
 	// cleared from the account sublist.
-	fooA.SetAutoExpireTTL(10 * time.Second)
+	err = fooA.SetServiceExportResponseThreshold("test.request", 10*time.Second)
+	if err != nil {
+		t.Fatalf("Error setting response threshold: %v", err)
+	}
 
 	subA = natsQueueSubSync(t, clientA, "test.request", "queue")
 	natsFlush(t, clientA)
@@ -4109,8 +4122,14 @@ func TestGatewayServiceImportComplexSetup(t *testing.T) {
 	checkSubs(t, barB2, "B2", 2)
 
 	// Speed up exiration
-	fooA2.SetAutoExpireTTL(10 * time.Millisecond)
-	fooB1.SetAutoExpireTTL(10 * time.Millisecond)
+	err = fooA2.SetServiceExportResponseThreshold("test.request", 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Error setting response threshold: %v", err)
+	}
+	err = fooB1.SetServiceExportResponseThreshold("test.request", 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Error setting response threshold: %v", err)
+	}
 
 	// Send 100 requests from clientB on foo.request,
 	for i := 0; i < 100; i++ {
@@ -4133,17 +4152,15 @@ func TestGatewayServiceImportComplexSetup(t *testing.T) {
 
 	// We should expire because ttl.
 	checkFor(t, 2*time.Second, 10*time.Millisecond, func() error {
-		// Now run prune and make sure we collect the timed-out ones.
-		fooB1.pruneAutoExpireResponseMaps()
-		if nae := fooB1.numAutoExpireResponseMaps(); nae != 0 {
-			return fmt.Errorf("Number of responsemaps is %d", nae)
+		if nr := len(fooA1.exports.responses); nr != 0 {
+			return fmt.Errorf("Number of responses is %d", nr)
 		}
 		return nil
 	})
 
 	checkSubs(t, fooA1, "A1", 0)
 	checkSubs(t, fooA2, "A2", 0)
-	checkSubs(t, fooB1, "B1", 0)
+	checkSubs(t, fooB1, "B1", 1)
 	checkSubs(t, fooB2, "B2", 1)
 
 	checkSubs(t, barA1, "A1", 1)
@@ -4477,8 +4494,14 @@ func TestGatewayServiceExportWithWildcards(t *testing.T) {
 			checkSubs(t, barB2, "B2", 2)
 
 			// Speed up exiration
-			fooA2.SetAutoExpireTTL(10 * time.Millisecond)
-			fooB1.SetAutoExpireTTL(10 * time.Millisecond)
+			err = fooA1.SetServiceExportResponseThreshold("ngs.update.*", 10*time.Millisecond)
+			if err != nil {
+				t.Fatalf("Error setting response threshold: %v", err)
+			}
+			err = fooB1.SetServiceExportResponseThreshold("ngs.update.*", 10*time.Millisecond)
+			if err != nil {
+				t.Fatalf("Error setting response threshold: %v", err)
+			}
 
 			// Send 100 requests from clientB on foo.request,
 			for i := 0; i < 100; i++ {
@@ -4501,17 +4524,15 @@ func TestGatewayServiceExportWithWildcards(t *testing.T) {
 
 			// We should expire because ttl.
 			checkFor(t, 2*time.Second, 10*time.Millisecond, func() error {
-				// Now run prune and make sure we collect the timed-out ones.
-				fooB1.pruneAutoExpireResponseMaps()
-				if nae := fooB1.numAutoExpireResponseMaps(); nae != 0 {
-					return fmt.Errorf("Number of responsemaps is %d", nae)
+				if nr := len(fooA1.exports.responses); nr != 0 {
+					return fmt.Errorf("Number of responses is %d", nr)
 				}
 				return nil
 			})
 
 			checkSubs(t, fooA1, "A1", 0)
 			checkSubs(t, fooA2, "A2", 0)
-			checkSubs(t, fooB1, "B1", 0)
+			checkSubs(t, fooB1, "B1", 1)
 			checkSubs(t, fooB2, "B2", 1)
 
 			checkSubs(t, barA1, "A1", 1)

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -522,7 +522,7 @@ func TestJWTAccountRenew(t *testing.T) {
 	if acc == nil {
 		t.Fatalf("Expected to retrieve the account")
 	}
-	s.updateAccountClaims(acc, nac)
+	s.UpdateAccountClaims(acc, nac)
 
 	// Now make sure we can connect.
 	c, cr, cs := createClient(t, s, akp)
@@ -682,7 +682,7 @@ func TestJWTAccountBasicImportExport(t *testing.T) {
 	}
 	addAccountToMemResolver(s, barPub, barJWT)
 
-	s.updateAccountClaims(acc, barAC)
+	s.UpdateAccountClaims(acc, barAC)
 
 	// Our service import should have failed with a bad token.
 	if les := len(acc.imports.services); les != 0 {
@@ -707,7 +707,7 @@ func TestJWTAccountBasicImportExport(t *testing.T) {
 		t.Fatalf("Error generating account JWT: %v", err)
 	}
 	addAccountToMemResolver(s, barPub, barJWT)
-	s.updateAccountClaims(acc, barAC)
+	s.UpdateAccountClaims(acc, barAC)
 	// Our service import should have succeeded.
 	if les := len(acc.imports.services); les != 1 {
 		t.Fatalf("Expected imports services len of 1, got %d", les)
@@ -737,7 +737,7 @@ func TestJWTAccountBasicImportExport(t *testing.T) {
 		t.Fatalf("Error generating account JWT: %v", err)
 	}
 	addAccountToMemResolver(s, barPub, barJWT)
-	s.updateAccountClaims(acc, barAC)
+	s.UpdateAccountClaims(acc, barAC)
 	// Our service import should have succeeded. Should be the only one since we reset.
 	if les := len(acc.imports.services); les != 1 {
 		t.Fatalf("Expected imports services len of 1, got %d", les)
@@ -753,7 +753,7 @@ func TestJWTAccountBasicImportExport(t *testing.T) {
 		t.Fatalf("Error generating account JWT: %v", err)
 	}
 	addAccountToMemResolver(s, barPub, barJWT)
-	s.updateAccountClaims(acc, barAC)
+	s.UpdateAccountClaims(acc, barAC)
 	// Our stream import should have not succeeded.
 	if les := len(acc.imports.streams); les != 0 {
 		t.Fatalf("Expected imports services len of 0, got %d", les)
@@ -777,7 +777,7 @@ func TestJWTAccountBasicImportExport(t *testing.T) {
 		t.Fatalf("Error generating account JWT: %v", err)
 	}
 	addAccountToMemResolver(s, barPub, barJWT)
-	s.updateAccountClaims(acc, barAC)
+	s.UpdateAccountClaims(acc, barAC)
 	// Our stream import should have not succeeded.
 	if les := len(acc.imports.streams); les != 1 {
 		t.Fatalf("Expected imports services len of 1, got %d", les)
@@ -867,8 +867,8 @@ func TestJWTAccountExportWithResponseType(t *testing.T) {
 	}
 
 	se, ok = services["test.old"]
-	if !ok || se != nil {
-		t.Fatalf("Service with a singleton response and no tokens should be nil in the map")
+	if !ok || se == nil || len(se.approved) > 0 {
+		t.Fatalf("Service with a singleton response and no tokens should not be nil and have no approvals")
 	}
 }
 
@@ -954,7 +954,7 @@ func TestJWTAccountImportExportUpdates(t *testing.T) {
 	barJWT, _ = barAC.Encode(okp)
 	addAccountToMemResolver(s, barPub, barJWT)
 	acc, _ := s.LookupAccount(barPub)
-	s.updateAccountClaims(acc, barAC)
+	s.UpdateAccountClaims(acc, barAC)
 
 	checkShadow(0)
 
@@ -963,7 +963,7 @@ func TestJWTAccountImportExportUpdates(t *testing.T) {
 	barAC.Imports.Add(streamImport)
 	barJWT, _ = barAC.Encode(okp)
 	addAccountToMemResolver(s, barPub, barJWT)
-	s.updateAccountClaims(acc, barAC)
+	s.UpdateAccountClaims(acc, barAC)
 
 	checkShadow(1)
 
@@ -972,7 +972,7 @@ func TestJWTAccountImportExportUpdates(t *testing.T) {
 	fooJWT, _ = fooAC.Encode(okp)
 	addAccountToMemResolver(s, fooPub, fooJWT)
 	acc, _ = s.LookupAccount(fooPub)
-	s.updateAccountClaims(acc, fooAC)
+	s.UpdateAccountClaims(acc, fooAC)
 	checkShadow(0)
 
 	// Now add it in but with permission required.
@@ -980,7 +980,7 @@ func TestJWTAccountImportExportUpdates(t *testing.T) {
 	fooAC.Exports.Add(streamExport)
 	fooJWT, _ = fooAC.Encode(okp)
 	addAccountToMemResolver(s, fooPub, fooJWT)
-	s.updateAccountClaims(acc, fooAC)
+	s.UpdateAccountClaims(acc, fooAC)
 
 	checkShadow(0)
 
@@ -990,7 +990,7 @@ func TestJWTAccountImportExportUpdates(t *testing.T) {
 	fooAC.Exports.Add(streamExport)
 	fooJWT, _ = fooAC.Encode(okp)
 	addAccountToMemResolver(s, fooPub, fooJWT)
-	s.updateAccountClaims(acc, fooAC)
+	s.UpdateAccountClaims(acc, fooAC)
 
 	checkShadow(1)
 }
@@ -1137,7 +1137,7 @@ func TestJWTAccountLimitsSubs(t *testing.T) {
 		t.Fatalf("Error generating account JWT: %v", err)
 	}
 	addAccountToMemResolver(s, fooPub, fooJWT)
-	s.updateAccountClaims(fooAcc, fooAC)
+	s.UpdateAccountClaims(fooAcc, fooAC)
 	l, _ = cr.ReadString('\n')
 	if !strings.HasPrefix(l, "-ERR") {
 		t.Fatalf("Expected an ERR, got: %v", l)
@@ -1378,7 +1378,7 @@ func TestJWTAccountServiceImportAuthSwitch(t *testing.T) {
 	}
 	addAccountToMemResolver(s, fooPub, fooJWTPrivate)
 	acc, _ := s.LookupAccount(fooPub)
-	s.updateAccountClaims(acc, fooACPrivate)
+	s.UpdateAccountClaims(acc, fooACPrivate)
 
 	// Send Another Request
 	ca.parseAsync("PUB ngs.usage 2\r\nhi\r\nPING\r\n")
@@ -1390,7 +1390,7 @@ func TestJWTAccountServiceImportAuthSwitch(t *testing.T) {
 
 	// Now put it back again to public and make sure it works again.
 	addAccountToMemResolver(s, fooPub, fooJWT)
-	s.updateAccountClaims(acc, fooAC)
+	s.UpdateAccountClaims(acc, fooAC)
 
 	// Send Request
 	ca.parseAsync("PUB ngs.usage 2\r\nhi\r\nPING\r\n")
@@ -1468,7 +1468,7 @@ func TestJWTAccountServiceImportExpires(t *testing.T) {
 	}
 	addAccountToMemResolver(s, fooPub, fooJWT)
 	acc, _ := s.LookupAccount(fooPub)
-	s.updateAccountClaims(acc, fooAC)
+	s.UpdateAccountClaims(acc, fooAC)
 
 	// Send Another Request
 	ca.parseAsync("PUB foo 2\r\nhi\r\nPING\r\n")
@@ -1501,7 +1501,7 @@ func TestJWTAccountServiceImportExpires(t *testing.T) {
 	}
 	addAccountToMemResolver(s, barPub, barJWT)
 	acc, _ = s.LookupAccount(barPub)
-	s.updateAccountClaims(acc, barAC)
+	s.UpdateAccountClaims(acc, barAC)
 
 	// Now it should work again.
 	// Send Another Request
@@ -1753,7 +1753,7 @@ func TestJWTUserSigningKey(t *testing.T) {
 	nac.SigningKeys.Add(aspub)
 	// update the memory resolver
 	acc, _ := s.LookupAccount(apub)
-	s.updateAccountClaims(acc, nac)
+	s.UpdateAccountClaims(acc, nac)
 
 	// Create a client with a signing key
 	c, cr, cs = createClientWithIssuer(t, s, askp, apub)
@@ -1778,7 +1778,7 @@ func TestJWTUserSigningKey(t *testing.T) {
 	// remove the signing key should bounce client
 	nac.SigningKeys = nil
 	acc, _ = s.LookupAccount(apub)
-	s.updateAccountClaims(acc, nac)
+	s.UpdateAccountClaims(acc, nac)
 
 	if !isClosed() {
 		t.Fatal("expected client to be gone")
@@ -1897,7 +1897,7 @@ func TestJWTAccountImportSignerRemoved(t *testing.T) {
 	srvJWT, srvAC := createSrvJwt()
 	addAccountToMemResolver(s, srvPK, srvJWT)
 	acc, _ := s.LookupAccount(srvPK)
-	s.updateAccountClaims(acc, srvAC)
+	s.UpdateAccountClaims(acc, srvAC)
 
 	// Send Another Request
 	client.parseAsync("PUB foo 2\r\nhi\r\nPING\r\n")

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1176,8 +1176,8 @@ func (c *client) updateSmap(sub *subscription, delta int32) {
 
 	// If we are solicited make sure this is a local client or a non-solicited leaf node
 	skind := sub.client.kind
-
-	if c.isSpokeLeafNode() && !(skind == CLIENT || skind == SYSTEM || skind == JETSTREAM || (skind == LEAF && !sub.client.isSpokeLeafNode())) {
+	updateClient := skind == CLIENT || skind == SYSTEM || skind == JETSTREAM || skind == ACCOUNT
+	if c.isSpokeLeafNode() && !(updateClient || (skind == LEAF && !sub.client.isSpokeLeafNode())) {
 		c.mu.Unlock()
 		return
 	}
@@ -1578,7 +1578,7 @@ func (c *client) processInboundLeafMsg(msg []byte) {
 			atomic.LoadInt64(&c.srv.gateway.totalQSubs) > 0 {
 			flag |= pmrCollectQueueNames
 		}
-		qnames = c.processMsgResults(acc, r, msg, nil, c.pa.subject, c.pa.reply, flag)
+		_, qnames = c.processMsgResults(acc, r, msg, nil, c.pa.subject, c.pa.reply, flag)
 	}
 
 	// Now deal with gateways

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1847,6 +1847,8 @@ func (reason ClosedState) String() string {
 		return "Missing Account"
 	case Revocation:
 		return "Credentials Revoked"
+	case InternalClient:
+		return "Internal Client"
 	}
 	return "Unknown State"
 }

--- a/server/route.go
+++ b/server/route.go
@@ -1219,7 +1219,7 @@ func (s *Server) updateRouteSubscriptionMap(acc *Account, sub *subscription, del
 	}
 
 	// We only store state on local subs for transmission across all other routes.
-	if sub.client == nil || (sub.client.kind != CLIENT && sub.client.kind != SYSTEM && sub.client.kind != LEAF) {
+	if sub.client == nil || sub.client.kind == ROUTER || sub.client.kind == GATEWAY {
 		return
 	}
 

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -1261,7 +1261,8 @@ func matchLiteral(literal, subject string) bool {
 }
 
 func addLocalSub(sub *subscription, subs *[]*subscription) {
-	if sub != nil && sub.client != nil && (sub.client.kind == CLIENT || sub.client.kind == SYSTEM || sub.client.kind == JETSTREAM) && sub.im == nil {
+	if sub != nil && sub.client != nil &&
+		(sub.client.kind == CLIENT || sub.client.kind == SYSTEM || sub.client.kind == JETSTREAM || sub.client.kind == ACCOUNT) && sub.im == nil {
 		*subs = append(*subs, sub)
 	}
 }
@@ -1344,18 +1345,4 @@ func (s *Sublist) collectAllSubs(l *level, subs *[]*subscription) {
 		s.addAllNodeToSubs(l.fwc, subs)
 		s.collectAllSubs(l.fwc.next, subs)
 	}
-}
-
-// Helper to get the first result sub.
-func firstSubFromResult(rr *SublistResult) *subscription {
-	if rr == nil {
-		return nil
-	}
-	if len(rr.psubs) > 0 {
-		return rr.psubs[0]
-	}
-	if len(rr.qsubs) > 0 {
-		return rr.qsubs[0][0]
-	}
-	return nil
 }

--- a/test/new_routes_test.go
+++ b/test/new_routes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 The NATS Authors
+// Copyright 2018-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -1447,8 +1447,6 @@ func TestNewRouteServiceImportDanglingRemoteSubs(t *testing.T) {
 	// Do Accounts for the servers.
 	fooA, _ := registerAccounts(t, srvA)
 	fooB, barB := registerAccounts(t, srvB)
-
-	fooA.SetAutoExpireTTL(10 * time.Millisecond)
 
 	// Add in the service export for the requests. Make it public.
 	if err := fooA.AddServiceExport("test.request", nil); err != nil {

--- a/test/services_test.go
+++ b/test/services_test.go
@@ -1,0 +1,571 @@
+// Copyright 2020 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+)
+
+var basicMASetupContents = []byte(`
+	server_name: A
+	listen: 127.0.0.1:-1
+
+	accounts: {
+	    A: {
+	        users: [ {user: a, password: pwd} ]
+	        exports: [{service: "foo", response: stream}]
+	    },
+	    B: {
+	        users: [{user: b, password: pwd} ]
+		    imports: [{ service: { account: A, subject: "foo"}, to: "foo_request" }]
+	    }
+	}
+`)
+
+func TestServiceImportWithStreamed(t *testing.T) {
+	conf := createConfFile(t, basicMASetupContents)
+	defer os.Remove(conf)
+
+	srv, opts := RunServerWithConfig(conf)
+	defer srv.Shutdown()
+
+	// Limit max response maps here for the test.
+	accB, err := srv.LookupAccount("B")
+	if err != nil {
+		t.Fatalf("Error looking up account: %v", err)
+	}
+
+	// connect and offer a service
+	nc, err := nats.Connect(fmt.Sprintf("nats://a:pwd@%s:%d", opts.Host, opts.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc.Close()
+
+	nc.Subscribe("foo", func(msg *nats.Msg) {
+		if err := msg.Respond([]byte("world")); err != nil {
+			t.Fatalf("Error on respond: %v", err)
+		}
+	})
+	nc.Flush()
+
+	nc2, err := nats.Connect(fmt.Sprintf("nats://b:pwd@%s:%d", opts.Host, opts.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc2.Close()
+
+	numRequests := 10
+	for i := 0; i < numRequests; i++ {
+		resp, err := nc2.Request("foo_request", []byte("hello"), 2*time.Second)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if resp == nil || strings.Compare("world", string(resp.Data)) != 0 {
+			t.Fatal("Did not receive the correct message")
+		}
+	}
+
+	// Since we are using a new client that multiplexes, until the client itself goes away
+	// we will have the full number of entries, even with the tighter ResponseEntriesPruneThreshold.
+	accA, err := srv.LookupAccount("A")
+	if err != nil {
+		t.Fatalf("Error looking up account: %v", err)
+	}
+
+	// These should always be the same now.
+	if nre := accB.NumPendingReverseResponses(); nre != numRequests {
+		t.Fatalf("Expected %d entries, got %d", numRequests, nre)
+	}
+	if nre := accA.NumPendingAllResponses(); nre != numRequests {
+		t.Fatalf("Expected %d entries, got %d", numRequests, nre)
+	}
+
+	// Now kill of the client that was doing the requests.
+	nc2.Close()
+
+	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+		aNrssi := accA.NumPendingAllResponses()
+		bNre := accB.NumPendingReverseResponses()
+		if aNrssi != 0 || bNre != 0 {
+			return fmt.Errorf("Response imports and response entries should all be 0, got %d %d", aNrssi, bNre)
+		}
+		return nil
+	})
+
+	// Now let's test old style request and reply that uses a new inbox each time. This should work ok..
+	nc2, err = nats.Connect(fmt.Sprintf("nats://b:pwd@%s:%d", opts.Host, opts.Port), nats.UseOldRequestStyle())
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc2.Close()
+
+	for i := 0; i < numRequests; i++ {
+		resp, err := nc2.Request("foo_request", []byte("hello"), 2*time.Second)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if resp == nil || strings.Compare("world", string(resp.Data)) != 0 {
+			t.Fatal("Did not receive the correct message")
+		}
+	}
+
+	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+		aNrssi := accA.NumPendingAllResponses()
+		bNre := accB.NumPendingReverseResponses()
+		if aNrssi != 0 || bNre != 0 {
+			return fmt.Errorf("Response imports and response entries should all be 0, got %d %d", aNrssi, bNre)
+		}
+		return nil
+	})
+}
+
+func TestServiceImportWithStreamedResponseAndEOF(t *testing.T) {
+	conf := createConfFile(t, basicMASetupContents)
+	defer os.Remove(conf)
+
+	srv, opts := RunServerWithConfig(conf)
+	defer srv.Shutdown()
+
+	accA, err := srv.LookupAccount("A")
+	if err != nil {
+		t.Fatalf("Error looking up account: %v", err)
+	}
+	accB, err := srv.LookupAccount("B")
+	if err != nil {
+		t.Fatalf("Error looking up account: %v", err)
+	}
+
+	nc, err := nats.Connect(fmt.Sprintf("nats://a:pwd@%s:%d", opts.Host, opts.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc.Close()
+
+	// We will send four responses and then and nil message signaling EOF
+	nc.Subscribe("foo", func(msg *nats.Msg) {
+		// Streamed response.
+		msg.Respond([]byte("world-1"))
+		msg.Respond([]byte("world-2"))
+		msg.Respond([]byte("world-3"))
+		msg.Respond([]byte("world-4"))
+		msg.Respond(nil)
+	})
+	nc.Flush()
+
+	// Now setup requester.
+	nc2, err := nats.Connect(fmt.Sprintf("nats://b:pwd@%s:%d", opts.Host, opts.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc2.Close()
+
+	numRequests := 10
+	expectedResponses := 5
+
+	for i := 0; i < numRequests; i++ {
+		// Create an inbox
+		reply := nats.NewInbox()
+		sub, _ := nc2.SubscribeSync(reply)
+		defer sub.Unsubscribe()
+
+		if err := nc2.PublishRequest("foo_request", reply, []byte("XOXO")); err != nil {
+			t.Fatalf("Error sending request: %v", err)
+		}
+
+		// Wait and make sure we get all the responses. Should be five.
+		checkFor(t, 250*time.Millisecond, 10*time.Millisecond, func() error {
+			if nmsgs, _, _ := sub.Pending(); err != nil || nmsgs != expectedResponses {
+				return fmt.Errorf("Did not receive correct number of messages: %d vs %d", nmsgs, expectedResponses)
+			}
+			return nil
+		})
+	}
+
+	if nre := accA.NumPendingAllResponses(); nre != 0 {
+		t.Fatalf("Expected no entries, got %d", nre)
+	}
+	if nre := accB.NumPendingReverseResponses(); nre != 0 {
+		t.Fatalf("Expected no entries, got %d", nre)
+	}
+}
+
+func TestServiceExportsResponseFiltering(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		server_name: A
+		listen: 127.0.0.1:-1
+
+		accounts: {
+		    A: {
+		        users: [ {user: a, password: pwd} ]
+		        exports: [ {service: "foo"}, {service: "bar"} ]
+		    },
+		    B: {
+		        users: [{user: b, password: pwd} ]
+			    imports: [ {service: { account: A, subject: "foo"}}, {service: { account: A, subject: "bar"}, to: "baz"} ]
+		    }
+		}
+	`))
+	defer os.Remove(conf)
+
+	srv, opts := RunServerWithConfig(conf)
+	defer srv.Shutdown()
+
+	nc, err := nats.Connect(fmt.Sprintf("nats://a:pwd@%s:%d", opts.Host, opts.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc.Close()
+
+	// If we do not subscribe the system is now smart enough to not setup the response service imports.
+	nc.SubscribeSync("foo")
+	nc.SubscribeSync("bar")
+	nc.Flush()
+
+	nc2, err := nats.Connect(fmt.Sprintf("nats://b:pwd@%s:%d", opts.Host, opts.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc2.Close()
+
+	// We don't expect responses, so just do publishes.
+	// 5 for foo
+	sendFoo := 5
+	for i := 0; i < sendFoo; i++ {
+		nc2.PublishRequest("foo", "reply", nil)
+	}
+	// 17 for bar
+	sendBar := 17
+	for i := 0; i < sendBar; i++ {
+		nc2.PublishRequest("baz", "reply", nil)
+	}
+	nc2.Flush()
+
+	accA, err := srv.LookupAccount("A")
+	if err != nil {
+		t.Fatalf("Error looking up account: %v", err)
+	}
+
+	sendTotal := sendFoo + sendBar
+	if nre := accA.NumPendingAllResponses(); nre != sendTotal {
+		t.Fatalf("Expected %d entries, got %d", sendTotal, nre)
+	}
+
+	if nre := accA.NumPendingResponses("foo"); nre != sendFoo {
+		t.Fatalf("Expected %d entries, got %d", sendFoo, nre)
+	}
+
+	if nre := accA.NumPendingResponses("bar"); nre != sendBar {
+		t.Fatalf("Expected %d entries, got %d", sendBar, nre)
+	}
+}
+
+func TestServiceExportsAutoDirectCleanup(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		accounts: {
+		    A: {
+		        users: [ {user: a, password: pwd} ]
+		        exports: [ {service: "foo"} ]
+		    },
+		    B: {
+		        users: [{user: b, password: pwd} ]
+			    imports: [ {service: { account: A, subject: "foo"}} ]
+		    }
+		}
+	`))
+	defer os.Remove(conf)
+
+	srv, opts := RunServerWithConfig(conf)
+	defer srv.Shutdown()
+
+	acc, err := srv.LookupAccount("A")
+	if err != nil {
+		t.Fatalf("Error looking up account: %v", err)
+	}
+
+	// Potential resonder.
+	nc, err := nats.Connect(fmt.Sprintf("nats://a:pwd@%s:%d", opts.Host, opts.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc.Close()
+
+	// Requestor
+	nc2, err := nats.Connect(fmt.Sprintf("nats://b:pwd@%s:%d", opts.Host, opts.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc2.Close()
+
+	expectNone := func() {
+		t.Helper()
+		if nre := acc.NumPendingAllResponses(); nre != 0 {
+			t.Fatalf("Expected no entries, got %d", nre)
+		}
+	}
+
+	toSend := 10
+
+	// With no responders we should never register service import responses etc.
+	for i := 0; i < toSend; i++ {
+		nc2.PublishRequest("foo", "reply", nil)
+	}
+	nc2.Flush()
+	expectNone()
+
+	// Now register a responder.
+	sub, _ := nc.Subscribe("foo", func(msg *nats.Msg) {
+		msg.Respond([]byte("world"))
+	})
+	nc.Flush()
+	defer sub.Unsubscribe()
+
+	// With no reply subject on a request we should never register service import responses etc.
+	for i := 0; i < toSend; i++ {
+		nc2.Publish("foo", nil)
+	}
+	nc2.Flush()
+	expectNone()
+
+	// Create an old request style client.
+	nc3, err := nats.Connect(fmt.Sprintf("nats://b:pwd@%s:%d", opts.Host, opts.Port), nats.UseOldRequestStyle())
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc3.Close()
+
+	// If the request loses interest before the response we should not queue up service import responses either.
+	// This only works for old style requests at the moment where we can detect interest going away.
+	delay := 25 * time.Millisecond
+	sub.Unsubscribe()
+	sub, _ = nc.Subscribe("foo", func(msg *nats.Msg) {
+		time.Sleep(delay)
+		msg.Respond([]byte("world"))
+	})
+	nc.Flush()
+	defer sub.Unsubscribe()
+
+	for i := 0; i < toSend; i++ {
+		nc3.Request("foo", nil, time.Millisecond)
+	}
+	nc3.Flush()
+	time.Sleep(time.Duration(toSend) * delay * 2)
+	expectNone()
+}
+
+// In some instances we do not have a forceful trigger that signals us to clean up.
+// Like a stream that does not send EOF or a responder who receives requests but does
+// not answer. For these we will have an expectation of a response threshold which
+// tells the system we should have seen a response by T, say 2 minutes, 30 seconds etc.
+func TestServiceExportsPruningCleanup(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		accounts: {
+		    A: {
+		        users: [ {user: a, password: pwd} ]
+		        exports: [ {service: "foo", response: stream} ]
+		    },
+		    B: {
+		        users: [{user: b, password: pwd} ]
+			    imports: [ {service: { account: A, subject: "foo"}} ]
+		    }
+		}
+	`))
+	defer os.Remove(conf)
+
+	srv, opts := RunServerWithConfig(conf)
+	defer srv.Shutdown()
+
+	// Potential resonder.
+	nc, err := nats.Connect(fmt.Sprintf("nats://a:pwd@%s:%d", opts.Host, opts.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc.Close()
+
+	// We will subscribe but not answer.
+	sub, _ := nc.Subscribe("foo", func(msg *nats.Msg) {})
+	nc.Flush()
+	defer sub.Unsubscribe()
+
+	acc, err := srv.LookupAccount("A")
+	if err != nil {
+		t.Fatalf("Error looking up account: %v", err)
+	}
+
+	// Check on response thresholds.
+	rt, err := acc.ServiceExportResponseThreshold("foo")
+	if err != nil {
+		t.Fatalf("Error retrieving response threshold, %v", err)
+	}
+
+	if rt != server.DEFAULT_SERVICE_EXPORT_RESPONSE_THRESHOLD {
+		t.Fatalf("Expected the response threshold to be %v, got %v",
+			server.DEFAULT_SERVICE_EXPORT_RESPONSE_THRESHOLD, rt)
+	}
+	// now set it
+	newRt := 10 * time.Millisecond
+	if err := acc.SetServiceExportResponseThreshold("foo", newRt); err != nil {
+		t.Fatalf("Expected no error setting response threshold, got %v", err)
+	}
+
+	expectedPending := func(expected int) {
+		t.Helper()
+		if nre := acc.NumPendingResponses("foo"); nre != expected {
+			t.Fatalf("Expected %d entries, got %d", expected, nre)
+		}
+	}
+
+	// Requestor
+	nc2, err := nats.Connect(fmt.Sprintf("nats://b:pwd@%s:%d", opts.Host, opts.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc2.Close()
+
+	toSend := 10
+
+	// This should register and they will dangle. Make sure we clean them up.
+	for i := 0; i < toSend; i++ {
+		nc2.PublishRequest("foo", "reply", nil)
+	}
+	nc2.Flush()
+
+	expectedPending(10)
+	time.Sleep(4 * newRt)
+	expectedPending(0)
+
+	// Do it again.
+	for i := 0; i < toSend; i++ {
+		nc2.PublishRequest("foo", "reply", nil)
+	}
+	nc2.Flush()
+
+	expectedPending(10)
+	time.Sleep(2 * newRt)
+	expectedPending(0)
+}
+
+func TestServiceExportsResponseThreshold(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		accounts: {
+		    A: {
+		        users: [ {user: a, password: pwd} ]
+		        exports: [ {service: "foo", response: stream, threshold: "1s"} ]
+		    },
+		}
+	`))
+	defer os.Remove(conf)
+
+	srv, opts := RunServerWithConfig(conf)
+	defer srv.Shutdown()
+
+	// Potential responder.
+	nc, err := nats.Connect(fmt.Sprintf("nats://a:pwd@%s:%d", opts.Host, opts.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc.Close()
+
+	// We will subscribe but not answer.
+	sub, _ := nc.Subscribe("foo", func(msg *nats.Msg) {})
+	nc.Flush()
+	defer sub.Unsubscribe()
+
+	acc, err := srv.LookupAccount("A")
+	if err != nil {
+		t.Fatalf("Error looking up account: %v", err)
+	}
+
+	// Check on response thresholds.
+	rt, err := acc.ServiceExportResponseThreshold("foo")
+	if err != nil {
+		t.Fatalf("Error retrieving response threshold, %v", err)
+	}
+	if rt != 1*time.Second {
+		t.Fatalf("Expected response threshold to be %v, got %v", 1*time.Second, rt)
+	}
+}
+
+func TestServiceExportsResponseThresholdChunked(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		accounts: {
+		    A: {
+		        users: [ {user: a, password: pwd} ]
+		        exports: [ {service: "foo", response: chunked, threshold: "10ms"} ]
+		    },
+		    B: {
+		        users: [{user: b, password: pwd} ]
+			    imports: [ {service: { account: A, subject: "foo"}} ]
+		    }
+		}
+	`))
+	defer os.Remove(conf)
+
+	srv, opts := RunServerWithConfig(conf)
+	defer srv.Shutdown()
+
+	// Responder.
+	nc, err := nats.Connect(fmt.Sprintf("nats://a:pwd@%s:%d", opts.Host, opts.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc.Close()
+
+	numChunks := 10
+
+	// Respond with 5ms gaps for total response time for all chunks and EOF > 50ms.
+	nc.Subscribe("foo", func(msg *nats.Msg) {
+		// Streamed response.
+		for i := 1; i <= numChunks; i++ {
+			time.Sleep(5 * time.Millisecond)
+			msg.Respond([]byte(fmt.Sprintf("chunk-%d", i)))
+		}
+		msg.Respond(nil)
+	})
+	nc.Flush()
+
+	// Now setup requester.
+	nc2, err := nats.Connect(fmt.Sprintf("nats://b:pwd@%s:%d", opts.Host, opts.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc2.Close()
+
+	// Create an inbox
+	reply := nats.NewInbox()
+	sub, _ := nc2.SubscribeSync(reply)
+	defer sub.Unsubscribe()
+
+	if err := nc2.PublishRequest("foo", reply, nil); err != nil {
+		t.Fatalf("Error sending request: %v", err)
+	}
+
+	checkFor(t, 250*time.Millisecond, 10*time.Millisecond, func() error {
+		if nmsgs, _, _ := sub.Pending(); err != nil || nmsgs != numChunks+1 {
+			return fmt.Errorf("Did not receive correct number of chunks: %d vs %d", nmsgs, numChunks+1)
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
This contains a rewrite to the services layer for exporting and importing. The code this merges to already had a first significant rewrite that moved from special interest processing to plain subscriptions.

This code changes the prior version's dealing with reverse mapping which was based mostly on thresholds and manual pruning, with some sporadic timer usage. This version uses the jetstream branch's code that understands interest and failed deliveries. So this code is much more tuned to reacting to interest changes. It also removes thresholds and goes only by interest changes or expirations based around a new service export property, response thresholds. This allows a service provider to provide semantics on how long a response should take at a maximum.

This commit also introduces formal support for service export streamed and chunked response types send an empty message to signify EOF.

This commit also includes additions to the service latency tracking such that errors are now sent, not only successful interactions. We have added a Status field and an optional Error fields to ServiceLatency.

We support the following Status codes, these are directly from HTTP.

400 Bad Request (request did not have a reply subject)
408 Request Timeout (when system detects request interest went away, old request style to make dependable)..
503 Service Unavailable (no service responders running)
504 Service Timeout (The new response threshold expired)

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
