### PR TITLE
Add a no_auth_user

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -163,6 +163,7 @@ type Options struct {
 	Nkeys                 []*NkeyUser   `json:"-"`
 	Users                 []*User       `json:"-"`
 	Accounts              []*Account    `json:"-"`
+	NoAuthUser            string        `json:"-"`
 	SystemAccount         string        `json:"-"`
 	AllowNewAccounts      bool          `json:"-"`
 	Username              string        `json:"-"`
@@ -783,6 +784,8 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 				o.resolverPreloads[key] = jwtstr
 			}
 		}
+	case "no_auth_user":
+		o.NoAuthUser = v.(string)
 	case "system_account", "system":
 		// Already processed at the beginning so we just skip them
 		// to not treat them as unknown values.

--- a/server/server.go
+++ b/server/server.go
@@ -410,8 +410,10 @@ func validateOptions(o *Options) error {
 	if err := validateLeafNode(o); err != nil {
 		return err
 	}
-	// Check that gateway is properly configured. Returns no error
-	// if there is no gateway defined.
+	// Check that authentication is properly configured.
+	if err := validateAuth(o); err != nil {
+		return err
+	}
 	return validateGatewayOptions(o)
 }
 


### PR DESCRIPTION
Added a no_auth_user as discussed.
To simplify error checking, I decided to do a post parsing error pass.
Reason being, we have multiple sections where users can be configured (multiple accounts as well authorization block). 

Signed-off-by: Matthias Hanel <mh@synadia.com>

