### PR TITLE
First pass at headers awareness for server

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -2856,36 +2856,6 @@ func isReservedReply(reply []byte) bool {
 	return false
 }
 
-// Header constants for new msg header support.
-const (
-	hdrMarker    = "⚡NATS⚡"
-	hdrMagic     = "⚡NATS⚡/0.1\r\n"
-	hdrTerm      = "\r\n\r\n"
-	hdrMarkerLen = len(hdrMarker)
-	hdrMagicLen  = len(hdrMagic)
-	minHdrLen    = len(hdrMagic) + len(hdrTerm)
-)
-
-func (c *client) checkForHeader(msg []byte) error {
-	ml := len(msg)
-	// I think these are ok, possible collision for header but no big deal IMO.
-	if ml <= hdrMarkerLen {
-		return nil
-	}
-	if ml < hdrMagicLen || !bytes.Equal(msg[:hdrMagicLen], []byte(hdrMagic)) {
-		return ErrBadMsgHeader
-	}
-	if !c.headers {
-		return ErrMsgHeadersNotSupported
-	}
-	hendi := bytes.Index(msg[hdrMagicLen:], []byte(hdrTerm))
-	if hendi < 0 {
-		return ErrBadMsgHeader
-	}
-	c.pa.hdr = hendi + hdrMagicLen + len(hdrTerm)
-	return nil
-}
-
 // This will decide to call the client code or router code.
 func (c *client) processInboundMsg(msg []byte) {
 	switch c.kind {

--- a/server/client.go
+++ b/server/client.go
@@ -221,7 +221,7 @@ type client struct {
 	msgb    [msgScratchSize]byte
 	last    time.Time
 	parseState
-	hdrsOk bool
+	headers bool
 
 	rtt      time.Duration
 	rttStart time.Time
@@ -1739,7 +1739,6 @@ func (c *client) generateClientInfoJSON(info Info) []byte {
 	info.CID = c.cid
 	info.ClientIP = c.host
 	info.MaxPayload = c.mpay
-	c.hdrsOk = info.Headers
 	// Generate the info json
 	b, _ := json.Marshal(info)
 	pcs := [][]byte{[]byte("INFO"), b, []byte(CR_LF)}
@@ -2815,7 +2814,7 @@ func (c *client) checkForHeader(msg []byte) error {
 	if ml < hdrMagicLen || !bytes.Equal(msg[:hdrMagicLen], []byte(hdrMagic)) {
 		return ErrBadMsgHeader
 	}
-	if !c.hdrsOk {
+	if !c.headers {
 		return ErrMsgHeadersNotSupported
 	}
 	hendi := bytes.Index(msg[hdrMagicLen:], []byte(hdrTerm))

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -195,7 +195,8 @@ func TestServerHeaderSupport(t *testing.T) {
 	opts := defaultServerOptions
 	opts.Port = -1
 	s := New(&opts)
-	_, _, l := newClientForServer(s)
+	c, _, l := newClientForServer(s)
+	defer c.close()
 
 	if !strings.HasPrefix(l, "INFO ") {
 		t.Fatalf("INFO response incorrect: %s\n", l)
@@ -211,7 +212,9 @@ func TestServerHeaderSupport(t *testing.T) {
 	opts.NoHeaderSupport = true
 	opts.Port = -1
 	s = New(&opts)
-	_, _, l = newClientForServer(s)
+	c, _, l = newClientForServer(s)
+	defer c.close()
+
 	if err := json.Unmarshal([]byte(l[5:]), &info); err != nil {
 		t.Fatalf("Could not parse INFO json: %v\n", err)
 	}

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -205,7 +205,7 @@ func TestServerHeaderSupport(t *testing.T) {
 		t.Fatalf("Could not parse INFO json: %v\n", err)
 	}
 	if !info.Headers {
-		t.Fatalf("Expected by default for headers support to be enabled")
+		t.Fatalf("Expected by default for header support to be enabled")
 	}
 
 	opts.NoHeaderSupport = true
@@ -216,81 +216,7 @@ func TestServerHeaderSupport(t *testing.T) {
 		t.Fatalf("Could not parse INFO json: %v\n", err)
 	}
 	if info.Headers {
-		t.Fatalf("Expected headers support to be disabled")
-	}
-}
-
-// This will test the parser identifying headers.
-func TestParseMsgHeader(t *testing.T) {
-	_, c, r := setupClient()
-	defer c.close()
-
-	// And emoty hdr, first \r\n terminate marker line (like HTTP)
-	// The end of a valid header is 2 CR_LF back to back.
-	ehdr := []byte("⚡NATS⚡/0.1\r\n\r\n\r\nHELLO HEADERS")
-	publ := []byte(fmt.Sprintf("PUB foo %d\r\n", len(ehdr)))
-	msg := append(publ, ehdr...)
-	msg = append(msg, []byte(CR_LF)...)
-	err := c.parse(msg)
-	if err != nil {
-		t.Fatalf("Received error: %v\n", err)
-	}
-	if c.pa.hdr == 0 {
-		t.Fatalf("Expected to detect a header")
-	}
-	// Make sure our indexing works.
-	if !bytes.Equal(ehdr[c.pa.hdr:], []byte("HELLO HEADERS")) {
-		t.Fatalf("Expected just the msg body, but got %q for hdr index of %d", ehdr[c.pa.hdr:], c.pa.hdr)
-	}
-
-	// Now lets directly test some failure scenarios.
-	expectError := func(msgh []byte) {
-		t.Helper()
-		if err := c.checkForHeader(msgh); err != ErrBadMsgHeader {
-			t.Fatalf("Expected an error, got %v", err)
-		}
-	}
-	expectError([]byte("⚡NATS⚡/0.1\r\n\r\n\r"))
-	expectError([]byte("⚡NATS⚡ 0.1\r\n\r\n\r"))
-	expectError([]byte("⚡NATS⚡ "))
-	expectError([]byte("⚡NATS⚡ \r\n\r\n\r\n"))
-	expectError([]byte("⚡NOTS⚡/0.1"))
-
-	expectNoError := func(msgh []byte) {
-		t.Helper()
-		if err := c.checkForHeader(msgh); err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-	}
-	expectNoError([]byte("⚡NATS"))
-	expectNoError([]byte("⚡NOTS⚡"))
-	expectNoError([]byte("⚡NATS⚡/0.1\r\nWE DO NOT CARE WHAT IS IN BETWEEN\r\n\r\n"))
-
-	// Make sure we get chopped off on error.
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	// The client here is using a pipe, we need to be dequeuing
-	// data otherwise the server would be blocked trying to send
-	// the error back to it.
-	go func() {
-		defer wg.Done()
-		for {
-			if _, _, err := r.ReadLine(); err != nil {
-				return
-			}
-		}
-	}()
-
-	ehdr = []byte("⚡NATS⚡/0.1\r\nK:V\r\nHELLO HEADERS")
-	publ = []byte(fmt.Sprintf("PUB foo %d\r\n", len(ehdr)))
-	msg = append(publ, ehdr...)
-	msg = append(msg, []byte(CR_LF)...)
-
-	if err = c.parse(msg); err != ErrBadMsgHeader {
-		t.Fatalf("Expected to receive an error")
-	}
-	if !c.isClosed() {
-		t.Fatalf("Expected to have been closed")
+		t.Fatalf("Expected header support to be disabled")
 	}
 }
 

--- a/server/const.go
+++ b/server/const.go
@@ -127,6 +127,9 @@ const (
 	// MAX_PUB_ARGS Maximum possible number of arguments from PUB proto.
 	MAX_PUB_ARGS = 3
 
+	// MAX_HPUB_ARGS Maximum possible number of arguments from HPUB proto.
+	MAX_HPUB_ARGS = 4
+
 	// DEFAULT_MAX_CLOSED_CLIENTS is the maximum number of closed connections we hold onto.
 	DEFAULT_MAX_CLOSED_CLIENTS = 10000
 

--- a/server/errors.go
+++ b/server/errors.go
@@ -135,8 +135,15 @@ var (
 	// ErrRevocation is returned when a credential has been revoked.
 	ErrRevocation = errors.New("credentials have been revoked")
 
-	// Used to signal an error that a server is not running.
+	// ErrServerNotRunning is used to signal an error that a server is not running.
 	ErrServerNotRunning = errors.New("server is not running")
+
+	// ErrBadMsgHeader signals the parser detected a bad message header
+	ErrBadMsgHeader = errors.New("bad message header detected")
+
+	// ErrMsgHeadersNotSupported signals the parser detected a message header
+	// but they are not supported on this server.
+	ErrMsgHeadersNotSupported = errors.New("message headers not supported")
 )
 
 // configErr is a configuration error.

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1849,6 +1849,8 @@ func (reason ClosedState) String() string {
 		return "Credentials Revoked"
 	case InternalClient:
 		return "Internal Client"
+	case MsgHeaderViolation:
+		return "Message Header Violation"
 	}
 	return "Unknown State"
 }

--- a/server/opts.go
+++ b/server/opts.go
@@ -157,6 +157,7 @@ type Options struct {
 	NoLog                 bool          `json:"-"`
 	NoSigs                bool          `json:"-"`
 	NoSublistCache        bool          `json:"-"`
+	NoHeaderSupport       bool          `json:"-"`
 	DisableShortFirstPing bool          `json:"-"`
 	Logtime               bool          `json:"-"`
 	MaxConn               int           `json:"max_connections"`

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -235,70 +235,38 @@ func TestParsePubArg(t *testing.T) {
 		size    int
 		szb     string
 	}{
-		{arg: "a 2",
-			subject: "a", reply: "", size: 2, szb: "2"},
-		{arg: "a 222",
-			subject: "a", reply: "", size: 222, szb: "222"},
-		{arg: "foo 22",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: " foo 22",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "foo 22 ",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "foo   22",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: " foo 22 ",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: " foo   22 ",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "foo bar 22",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: " foo bar 22",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "foo bar 22 ",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "foo  bar  22",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: " foo bar 22 ",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "  foo   bar  22  ",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "  foo   bar  2222  ",
-			subject: "foo", reply: "bar", size: 2222, szb: "2222"},
-		{arg: "  foo     2222  ",
-			subject: "foo", reply: "", size: 2222, szb: "2222"},
-		{arg: "a\t2",
-			subject: "a", reply: "", size: 2, szb: "2"},
-		{arg: "a\t222",
-			subject: "a", reply: "", size: 222, szb: "222"},
-		{arg: "foo\t22",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "\tfoo\t22",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "foo\t22\t",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "foo\t\t\t22",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "\tfoo\t22\t",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "\tfoo\t\t\t22\t",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "foo\tbar\t22",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "\tfoo\tbar\t22",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "foo\tbar\t22\t",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "foo\t\tbar\t\t22",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "\tfoo\tbar\t22\t",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "\t \tfoo\t \t \tbar\t \t22\t \t",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "\t\tfoo\t\t\tbar\t\t2222\t\t",
-			subject: "foo", reply: "bar", size: 2222, szb: "2222"},
-		{arg: "\t \tfoo\t \t \t\t\t2222\t \t",
-			subject: "foo", reply: "", size: 2222, szb: "2222"},
+		{arg: "a 2", subject: "a", reply: "", size: 2, szb: "2"},
+		{arg: "a 222", subject: "a", reply: "", size: 222, szb: "222"},
+		{arg: "foo 22", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: " foo 22", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "foo 22 ", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "foo   22", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: " foo 22 ", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: " foo   22 ", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "foo bar 22", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: " foo bar 22", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "foo bar 22 ", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "foo  bar  22", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: " foo bar 22 ", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "  foo   bar  22  ", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "  foo   bar  2222  ", subject: "foo", reply: "bar", size: 2222, szb: "2222"},
+		{arg: "  foo     2222  ", subject: "foo", reply: "", size: 2222, szb: "2222"},
+		{arg: "a\t2", subject: "a", reply: "", size: 2, szb: "2"},
+		{arg: "a\t222", subject: "a", reply: "", size: 222, szb: "222"},
+		{arg: "foo\t22", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "\tfoo\t22", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "foo\t22\t", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "foo\t\t\t22", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "\tfoo\t22\t", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "\tfoo\t\t\t22\t", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "foo\tbar\t22", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "\tfoo\tbar\t22", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "foo\tbar\t22\t", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "foo\t\tbar\t\t22", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "\tfoo\tbar\t22\t", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "\t \tfoo\t \t \tbar\t \t22\t \t", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "\t\tfoo\t\t\tbar\t\t2222\t\t", subject: "foo", reply: "bar", size: 2222, szb: "2222"},
+		{arg: "\t \tfoo\t \t \t\t\t2222\t \t", subject: "foo", reply: "", size: 2222, szb: "2222"},
 	} {
 		t.Run(test.arg, func(t *testing.T) {
 			if err := c.processPub([]byte(test.arg)); err != nil {
@@ -326,6 +294,134 @@ func TestParsePubBadSize(t *testing.T) {
 	c.mpay = 32768
 	if err := c.processPub([]byte("foo 2222222222222222")); err == nil {
 		t.Fatalf("Expected parse error for size too large")
+	}
+}
+
+func TestParseHeaderPub(t *testing.T) {
+	c := dummyClient()
+
+	hpub := []byte("HPUB foo 12 17\r\nname:derek\r\nHELLO\r")
+	if err := c.parse(hpub); err != nil || c.state != MSG_END_N {
+		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
+	}
+	if !bytes.Equal(c.pa.subject, []byte("foo")) {
+		t.Fatalf("Did not parse subject correctly: 'foo' vs '%s'\n", c.pa.subject)
+	}
+	if c.pa.reply != nil {
+		t.Fatalf("Did not parse reply correctly: 'nil' vs '%s'\n", c.pa.reply)
+	}
+	if c.pa.hdr != 12 {
+		t.Fatalf("Did not parse msg header size correctly: 12 vs %d\n", c.pa.hdr)
+	}
+	if c.pa.size != 17 {
+		t.Fatalf("Did not parse msg size correctly: 17 vs %d\n", c.pa.size)
+	}
+
+	// Clear snapshots
+	c.argBuf, c.msgBuf, c.state = nil, nil, OP_START
+
+	hpub = []byte("HPUB foo INBOX.22 12 17\r\nname:derek\r\nHELLO\r")
+	if err := c.parse(hpub); err != nil || c.state != MSG_END_N {
+		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
+	}
+	if !bytes.Equal(c.pa.subject, []byte("foo")) {
+		t.Fatalf("Did not parse subject correctly: 'foo' vs '%s'\n", c.pa.subject)
+	}
+	if !bytes.Equal(c.pa.reply, []byte("INBOX.22")) {
+		t.Fatalf("Did not parse reply correctly: 'INBOX.22' vs '%s'\n", c.pa.reply)
+	}
+	if c.pa.hdr != 12 {
+		t.Fatalf("Did not parse msg header size correctly: 12 vs %d\n", c.pa.hdr)
+	}
+	if c.pa.size != 17 {
+		t.Fatalf("Did not parse msg size correctly: 17 vs %d\n", c.pa.size)
+	}
+
+	// Clear snapshots
+	c.argBuf, c.msgBuf, c.state = nil, nil, OP_START
+
+	hpub = []byte("HPUB foo INBOX.22 0 5\r\nHELLO\r")
+	if err := c.parse(hpub); err != nil || c.state != MSG_END_N {
+		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
+	}
+	if !bytes.Equal(c.pa.subject, []byte("foo")) {
+		t.Fatalf("Did not parse subject correctly: 'foo' vs '%s'\n", c.pa.subject)
+	}
+	if !bytes.Equal(c.pa.reply, []byte("INBOX.22")) {
+		t.Fatalf("Did not parse reply correctly: 'INBOX.22' vs '%s'\n", c.pa.reply)
+	}
+	if c.pa.hdr != 0 {
+		t.Fatalf("Did not parse msg header size correctly: 0 vs %d\n", c.pa.hdr)
+	}
+	if c.pa.size != 5 {
+		t.Fatalf("Did not parse msg size correctly: 5 vs %d\n", c.pa.size)
+	}
+}
+
+func TestParseHeaderPubArg(t *testing.T) {
+	c := dummyClient()
+
+	for _, test := range []struct {
+		arg     string
+		subject string
+		reply   string
+		hdr     int
+		size    int
+		szb     string
+	}{
+		{arg: "a 2 4", subject: "a", reply: "", hdr: 2, size: 4, szb: "4"},
+		{arg: "a 22 222", subject: "a", reply: "", hdr: 22, size: 222, szb: "222"},
+		{arg: "foo 3 22", subject: "foo", reply: "", hdr: 3, size: 22, szb: "22"},
+		{arg: " foo   1 22", subject: "foo", reply: "", hdr: 1, size: 22, szb: "22"},
+		{arg: "foo 0   22 ", subject: "foo", reply: "", hdr: 0, size: 22, szb: "22"},
+		{arg: "foo  0     22", subject: "foo", reply: "", hdr: 0, size: 22, szb: "22"},
+		{arg: " foo 1 22 ", subject: "foo", reply: "", hdr: 1, size: 22, szb: "22"},
+		{arg: " foo   3 22 ", subject: "foo", reply: "", hdr: 3, size: 22, szb: "22"},
+		{arg: "foo bar 1 22", subject: "foo", reply: "bar", hdr: 1, size: 22, szb: "22"},
+		{arg: " foo bar 11 22", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "foo bar 11 22 ", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "foo  bar  11  22", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: " foo bar  11 22 ", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "  foo   bar  11   22  ", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "  foo   bar  22   2222  ", subject: "foo", reply: "bar", hdr: 22, size: 2222, szb: "2222"},
+		{arg: "  foo 1    2222  ", subject: "foo", reply: "", hdr: 1, size: 2222, szb: "2222"},
+		{arg: "a\t2\t22", subject: "a", reply: "", hdr: 2, size: 22, szb: "22"},
+		{arg: "a\t2\t\t222", subject: "a", reply: "", hdr: 2, size: 222, szb: "222"},
+		{arg: "foo\t2 22", subject: "foo", reply: "", hdr: 2, size: 22, szb: "22"},
+		{arg: "\tfoo\t11\t  22", subject: "foo", reply: "", hdr: 11, size: 22, szb: "22"},
+		{arg: "foo\t11\t22\t", subject: "foo", reply: "", hdr: 11, size: 22, szb: "22"},
+		{arg: "foo\t\t\t11 22", subject: "foo", reply: "", hdr: 11, size: 22, szb: "22"},
+		{arg: "\tfoo\t11\t \t 22\t", subject: "foo", reply: "", hdr: 11, size: 22, szb: "22"},
+		{arg: "\tfoo\t\t\t11 22\t", subject: "foo", reply: "", hdr: 11, size: 22, szb: "22"},
+		{arg: "foo\tbar\t2 22", subject: "foo", reply: "bar", hdr: 2, size: 22, szb: "22"},
+		{arg: "\tfoo\tbar\t11\t22", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "foo\tbar\t11\t\t22\t ", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "foo\t\tbar\t\t11\t\t\t22", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "\tfoo\tbar\t11\t22\t", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "\t \tfoo\t \t \tbar\t \t11\t 22\t \t", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "\t\tfoo\t\t\tbar\t\t22\t\t\t2222\t\t", subject: "foo", reply: "bar", hdr: 22, size: 2222, szb: "2222"},
+		{arg: "\t \tfoo\t \t \t\t\t11\t\t 2222\t \t", subject: "foo", reply: "", hdr: 11, size: 2222, szb: "2222"},
+	} {
+		t.Run(test.arg, func(t *testing.T) {
+			if err := c.processHeaderPub([]byte(test.arg)); err != nil {
+				t.Fatalf("Unexpected parse error: %v\n", err)
+			}
+			if !bytes.Equal(c.pa.subject, []byte(test.subject)) {
+				t.Fatalf("Mismatched subject: '%s'\n", c.pa.subject)
+			}
+			if !bytes.Equal(c.pa.reply, []byte(test.reply)) {
+				t.Fatalf("Mismatched reply subject: '%s'\n", c.pa.reply)
+			}
+			if !bytes.Equal(c.pa.szb, []byte(test.szb)) {
+				t.Fatalf("Bad size buf: '%s'\n", c.pa.szb)
+			}
+			if c.pa.hdr != test.hdr {
+				t.Fatalf("Bad header size: %d\n", c.pa.hdr)
+			}
+			if c.pa.size != test.size {
+				t.Fatalf("Bad size: %d\n", c.pa.size)
+			}
+		})
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -1822,6 +1822,7 @@ func (s *Server) createClient(conn net.Conn) *client {
 	s.mu.Lock()
 	info := s.copyInfo()
 	c.nonce = []byte(info.Nonce)
+	c.headers = info.Headers
 	s.totalClients++
 	s.mu.Unlock()
 

--- a/server/server.go
+++ b/server/server.go
@@ -68,6 +68,7 @@ type Info struct {
 	GoVersion         string   `json:"go"`
 	Host              string   `json:"host"`
 	Port              int      `json:"port"`
+	Headers           bool     `json:"headers"`
 	AuthRequired      bool     `json:"auth_required,omitempty"`
 	TLSRequired       bool     `json:"tls_required,omitempty"`
 	TLSVerify         bool     `json:"tls_verify,omitempty"`
@@ -269,6 +270,7 @@ func NewServer(opts *Options) (*Server, error) {
 		TLSVerify:    verify,
 		MaxPayload:   opts.MaxPayload,
 		JetStream:    opts.JetStream,
+		Headers:      !opts.NoHeaderSupport,
 	}
 
 	now := time.Now()


### PR DESCRIPTION
Before we get too far along I wanted to present this to this group for review.

What I am trying to get to is a few things. One that a server can communicate that it supports options to a client. We can suppress this but will default to enabled.

The big one is how we detect etc. I want the server to identify messages that have what it believes to be headers and during the parse stage can store the index for fast stripping off to older clients or servers.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
