### PR TITLE
adds API type hints to responses

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -163,71 +163,101 @@ type ApiError struct {
 	Description string `json:"description,omitempty"`
 }
 
+// ApiResponse is a standard response from the JetStream JSON API
+type ApiResponse struct {
+	Type  string    `json:"type"`
+	Error *ApiError `json:"error,omitempty"`
+}
+
+// ApiPagedResponse includes variables used to create paged responses from the JSON API
+type ApiPagedResponse struct {
+	Total  int `json:"total"`
+	Offset int `json:"offset"`
+	Limit  int `json:"limit"`
+}
+
+// ApiPagedRequest includes parameters allowing specific pages to be requests from APIs responding with ApiPagedResponse
+type ApiPagedRequest struct {
+	Offset int `json:"offset"`
+}
+
 // JSApiAccountInfoResponse reports back information on jetstream for this account.
 type JSApiAccountInfoResponse struct {
-	Error *ApiError `json:"error,omitempty"`
+	ApiResponse
 	*JetStreamAccountStats
 }
 
+const JSApiAccountInfoResponseType = "io.nats.jetstream.api.v1.account_info_response"
+
 // JSApiStreamCreateResponse stream creation.
 type JSApiStreamCreateResponse struct {
-	Error *ApiError `json:"error,omitempty"`
+	ApiResponse
 	*StreamInfo
 }
+
+const JSApiStreamCreateResponseType = "io.nats.jetstream.api.v1.stream_create_response"
 
 // JSApiStreamDeleteResponse stream removal.
 type JSApiStreamDeleteResponse struct {
-	Error   *ApiError `json:"error,omitempty"`
-	Success bool      `json:"success,omitempty"`
+	ApiResponse
+	Success bool `json:"success,omitempty"`
 }
+
+const JSApiStreamDeleteResponseType = "io.nats.jetstream.api.v1.stream_delete_response"
 
 // JSApiStreamInfoResponse.
 type JSApiStreamInfoResponse struct {
-	Error *ApiError `json:"error,omitempty"`
+	ApiResponse
 	*StreamInfo
 }
+
+const JSApiStreamInfoResponseType = "io.nats.jetstream.api.v1.stream_info_response"
 
 // Maximum entries we will return for streams or consumers lists.
 // TODO(dlc) - with header or request support could request chunked response.
 const JSApiNamesLimit = 1024
 const JSApiListLimit = 256
 
-type JSApiStreamsRequest struct {
-	Offset int `json:"offset"`
+type JSApiStreamNamesRequest struct {
+	ApiPagedRequest
 }
 
-// JSApiStreamsResponse list of streams.
+// JSApiStreamNamesResponse list of streams.
 // A nil request is valid and means all streams.
-type JSApiStreamsResponse struct {
-	Error   *ApiError `json:"error,omitempty"`
-	Total   int       `json:"total"`
-	Offset  int       `json:"offset"`
-	Limit   int       `json:"limit"`
-	Streams []string  `json:"streams"`
+type JSApiStreamNamesResponse struct {
+	ApiResponse
+	ApiPagedResponse
+	Streams []string `json:"streams"`
 }
+
+const JSApiStreamNamesResponseType = "io.nats.jetstream.api.v1.stream_names_response"
 
 // JSApiStreamListResponse list of detailed stream information.
 // A nil request is valid and means all streams.
 type JSApiStreamListResponse struct {
-	Error   *ApiError     `json:"error,omitempty"`
-	Total   int           `json:"total"`
-	Offset  int           `json:"offset"`
-	Limit   int           `json:"limit"`
+	ApiResponse
+	ApiPagedResponse
 	Streams []*StreamInfo `json:"streams"`
 }
 
+const JSApiStreamListResponseType = "io.nats.jetstream.api.v1.stream_list_response"
+
 // JSApiStreamPurgeResponse.
 type JSApiStreamPurgeResponse struct {
-	Error   *ApiError `json:"error,omitempty"`
-	Success bool      `json:"success,omitempty"`
-	Purged  uint64    `json:"purged,omitempty"`
+	ApiResponse
+	Success bool   `json:"success,omitempty"`
+	Purged  uint64 `json:"purged,omitempty"`
 }
+
+const JSApiStreamPurgeResponseType = "io.nats.jetstream.api.v1.stream_purge_response"
 
 // JSApiStreamUpdateResponse for updating a stream.
 type JSApiStreamUpdateResponse struct {
-	Error *ApiError `json:"error,omitempty"`
+	ApiResponse
 	*StreamInfo
 }
+
+const JSApiStreamUpdateResponseType = "io.nats.jetstream.api.v1.stream_update_response"
 
 // JSApiMsgDeleteRequest delete message request.
 type JSApiMsgDeleteRequest struct {
@@ -236,9 +266,11 @@ type JSApiMsgDeleteRequest struct {
 
 // JSApiMsgDeleteResponse.
 type JSApiMsgDeleteResponse struct {
-	Error   *ApiError `json:"error,omitempty"`
-	Success bool      `json:"success,omitempty"`
+	ApiResponse
+	Success bool `json:"success,omitempty"`
 }
+
+const JSApiMsgDeleteResponseType = "io.nats.jetstream.api.v1.stream_delete_response"
 
 // JSApiMsgGetRequest get a message request.
 type JSApiMsgGetRequest struct {
@@ -247,82 +279,96 @@ type JSApiMsgGetRequest struct {
 
 // JSApiMsgGetResponse.
 type JSApiMsgGetResponse struct {
-	Error   *ApiError  `json:"error,omitempty"`
+	ApiResponse
 	Message *StoredMsg `json:"message,omitempty"`
 }
 
+const JSApiMsgGetResponseType = "io.nats.jetstream.api.v1.stream_msg_get_request"
+
 // JSApiConsumerCreateResponse.
 type JSApiConsumerCreateResponse struct {
-	Error *ApiError `json:"error,omitempty"`
+	ApiResponse
 	*ConsumerInfo
 }
+
+const JSApiConsumerCreateResponseType = "io.nats.jetstream.api.v1.consumer_create_response"
 
 // JSApiConsumerDeleteResponse.
 type JSApiConsumerDeleteResponse struct {
-	Error   *ApiError `json:"error,omitempty"`
-	Success bool      `json:"success,omitempty"`
+	ApiResponse
+	Success bool `json:"success,omitempty"`
 }
+
+const JSApiConsumerDeleteResponseType = "io.nats.jetstream.api.v1.consumer_delete_response"
 
 // JSApiConsumerInfoResponse.
 type JSApiConsumerInfoResponse struct {
-	Error *ApiError `json:"error,omitempty"`
+	ApiResponse
 	*ConsumerInfo
 }
 
+const JSApiConsumerInfoResponseType = "io.nats.jetstream.api.v1.consumer_info_response"
+
 // JSApiConsumersRequest
 type JSApiConsumersRequest struct {
-	Offset int `json:"offset"`
+	ApiPagedRequest
 }
 
-// JSApiConsumersResponse.
-type JSApiConsumersResponse struct {
-	Error     *ApiError `json:"error,omitempty"`
-	Total     int       `json:"total"`
-	Offset    int       `json:"offset"`
-	Limit     int       `json:"limit"`
-	Consumers []string  `json:"consumers"`
+// JSApiConsumerNamesResponse.
+type JSApiConsumerNamesResponse struct {
+	ApiResponse
+	ApiPagedResponse
+	Consumers []string `json:"consumers"`
 }
+
+const JSApiConsumerNamesResponseType = "io.nats.jetstream.api.v1.consumer_names_response"
 
 // JSApiConsumerListResponse.
 type JSApiConsumerListResponse struct {
-	Error     *ApiError       `json:"error,omitempty"`
-	Total     int             `json:"total"`
-	Offset    int             `json:"offset"`
-	Limit     int             `json:"limit"`
+	ApiResponse
+	ApiPagedResponse
 	Consumers []*ConsumerInfo `json:"consumers"`
 }
 
+const JSApiConsumerListResponseType = "io.nats.jetstream.api.v1.consumer_list_response"
+
 // JSApiStreamTemplateCreateResponse for creating templates.
 type JSApiStreamTemplateCreateResponse struct {
-	Error *ApiError `json:"error,omitempty"`
+	ApiResponse
 	*StreamTemplateInfo
 }
+
+const JSApiStreamTemplateCreateResponseType = "io.nats.jetstream.api.v1.stream_template_create_response"
 
 // JSApiStreamTemplateDeleteResponse
 type JSApiStreamTemplateDeleteResponse struct {
-	Error   *ApiError `json:"error,omitempty"`
-	Success bool      `json:"success,omitempty"`
+	ApiResponse
+	Success bool `json:"success,omitempty"`
 }
+
+const JSApiStreamTemplateDeleteResponseType = "io.nats.jetstream.api.v1.stream_template_delete_response"
 
 // JSApiStreamTemplateInfoResponse for information about stream templates.
 type JSApiStreamTemplateInfoResponse struct {
-	Error *ApiError `json:"error,omitempty"`
+	ApiResponse
 	*StreamTemplateInfo
 }
 
-// JSApiTemplatessRequest
-type JSApiTemplatessRequest struct {
-	Offset int `json:"offset"`
+const JSApiStreamTemplateInfoResponseType = "io.nats.jetstream.api.v1.stream_template_info_response"
+
+// JSApiStreamTemplatesRequest
+type JSApiStreamTemplatesRequest struct {
+	ApiPagedRequest
 }
 
-// JSApiStreamTemplateListResponse list of templates.
-type JSApiStreamTemplatesResponse struct {
-	Error     *ApiError `json:"error,omitempty"`
-	Total     int       `json:"total"`
-	Offset    int       `json:"offset"`
-	Limit     int       `json:"limit"`
-	Templates []string  `json:"streams,omitempty"`
+// JSApiStreamTemplateNamesResponse list of templates
+type JSApiStreamTemplateNamesResponse struct {
+	ApiResponse
+	ApiPagedResponse
+	Templates []string `json:"streams,omitempty"`
 }
+
+const JSApiStreamTemplateNamesResponseType = "io.nats.jetstream.api.v1.stream_template_names_response"
 
 var (
 	jsNotEnabledErr = &ApiError{Code: 503, Description: "jetstream not enabled for account"}
@@ -398,7 +444,8 @@ func (s *Server) jsAccountInfoRequest(sub *subscription, c *client, subject, rep
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiAccountInfoResponse
+
+	var resp = JSApiAccountInfoResponse{ApiResponse: ApiResponse{Type: JSApiAccountInfoResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 	} else {
@@ -430,7 +477,8 @@ func (s *Server) jsTemplateCreateRequest(sub *subscription, c *client, subject, 
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiStreamTemplateCreateResponse
+
+	var resp = JSApiStreamTemplateCreateResponse{ApiResponse: ApiResponse{Type: JSApiStreamTemplateCreateResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -467,7 +515,8 @@ func (s *Server) jsTemplateNamesRequest(sub *subscription, c *client, subject, r
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiStreamTemplatesResponse
+
+	var resp = JSApiStreamTemplateNamesResponse{ApiResponse: ApiResponse{Type: JSApiStreamTemplateNamesResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -475,7 +524,7 @@ func (s *Server) jsTemplateNamesRequest(sub *subscription, c *client, subject, r
 	}
 	var offset int
 	if !isEmptyRequest(msg) {
-		var req JSApiTemplatessRequest
+		var req JSApiStreamTemplatesRequest
 		if err := json.Unmarshal(msg, &req); err != nil {
 			resp.Error = jsBadRequestErr
 			s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -509,7 +558,8 @@ func (s *Server) jsTemplateInfoRequest(sub *subscription, c *client, subject, re
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiStreamTemplateInfoResponse
+
+	var resp = JSApiStreamTemplateInfoResponse{ApiResponse: ApiResponse{Type: JSApiStreamTemplateInfoResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -541,7 +591,8 @@ func (s *Server) jsTemplateDeleteRequest(sub *subscription, c *client, subject, 
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiStreamTemplateDeleteResponse
+
+	var resp = JSApiStreamTemplateDeleteResponse{ApiResponse: ApiResponse{Type: JSApiStreamTemplateDeleteResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -592,7 +643,7 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, subject, re
 		return
 	}
 
-	var resp JSApiStreamCreateResponse
+	var resp = JSApiStreamCreateResponse{ApiResponse: ApiResponse{Type: JSApiStreamCreateResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -626,7 +677,8 @@ func (s *Server) jsStreamUpdateRequest(sub *subscription, c *client, subject, re
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiStreamUpdateResponse
+
+	var resp = JSApiStreamUpdateResponse{ApiResponse: ApiResponse{Type: JSApiStreamUpdateResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -665,7 +717,8 @@ func (s *Server) jsStreamNamesRequest(sub *subscription, c *client, subject, rep
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiStreamsResponse
+
+	var resp = JSApiStreamNamesResponse{ApiResponse: ApiResponse{Type: JSApiStreamNamesResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -674,7 +727,7 @@ func (s *Server) jsStreamNamesRequest(sub *subscription, c *client, subject, rep
 
 	var offset int
 	if !isEmptyRequest(msg) {
-		var req JSApiStreamsRequest
+		var req JSApiStreamNamesRequest
 		if err := json.Unmarshal(msg, &req); err != nil {
 			resp.Error = jsBadRequestErr
 			s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -708,7 +761,8 @@ func (s *Server) jsStreamListRequest(sub *subscription, c *client, subject, repl
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiStreamListResponse
+
+	var resp = JSApiStreamListResponse{ApiResponse: ApiResponse{Type: JSApiStreamListResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -717,7 +771,7 @@ func (s *Server) jsStreamListRequest(sub *subscription, c *client, subject, repl
 
 	var offset int
 	if !isEmptyRequest(msg) {
-		var req JSApiStreamsRequest
+		var req JSApiStreamNamesRequest
 		if err := json.Unmarshal(msg, &req); err != nil {
 			resp.Error = jsBadRequestErr
 			s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -750,7 +804,8 @@ func (s *Server) jsStreamInfoRequest(sub *subscription, c *client, subject, repl
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiStreamInfoResponse
+
+	var resp = JSApiStreamInfoResponse{ApiResponse: ApiResponse{Type: JSApiStreamInfoResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -796,7 +851,8 @@ func (s *Server) jsStreamDeleteRequest(sub *subscription, c *client, subject, re
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiStreamDeleteResponse
+
+	var resp = JSApiStreamDeleteResponse{ApiResponse: ApiResponse{Type: JSApiStreamDeleteResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -829,7 +885,8 @@ func (s *Server) jsMsgDeleteRequest(sub *subscription, c *client, subject, reply
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiMsgDeleteResponse
+
+	var resp = JSApiMsgDeleteResponse{ApiResponse: ApiResponse{Type: JSApiMsgDeleteResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -874,7 +931,8 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, subject, reply st
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiMsgGetResponse
+
+	var resp = JSApiMsgGetResponse{ApiResponse: ApiResponse{Type: JSApiMsgGetResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -920,7 +978,8 @@ func (s *Server) jsStreamPurgeRequest(sub *subscription, c *client, subject, rep
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiStreamPurgeResponse
+
+	var resp = JSApiStreamPurgeResponse{ApiResponse: ApiResponse{Type: JSApiStreamPurgeResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -958,7 +1017,7 @@ func (s *Server) jsConsumerCreate(sub *subscription, c *client, subject, reply s
 		return
 	}
 
-	var resp JSApiConsumerCreateResponse
+	var resp = JSApiConsumerCreateResponse{ApiResponse: ApiResponse{Type: JSApiConsumerCreateResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -1034,7 +1093,8 @@ func (s *Server) jsConsumerNamesRequest(sub *subscription, c *client, subject, r
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiConsumersResponse
+
+	var resp = JSApiConsumerNamesResponse{ApiResponse: ApiResponse{Type: JSApiConsumerNamesResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -1081,7 +1141,8 @@ func (s *Server) jsConsumerListRequest(sub *subscription, c *client, subject, re
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiConsumerListResponse
+
+	var resp = JSApiConsumerListResponse{ApiResponse: ApiResponse{Type: JSApiConsumerListResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -1128,7 +1189,8 @@ func (s *Server) jsConsumerInfoRequest(sub *subscription, c *client, subject, re
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiConsumerInfoResponse
+
+	var resp = JSApiConsumerInfoResponse{ApiResponse: ApiResponse{Type: JSApiConsumerInfoResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -1163,7 +1225,8 @@ func (s *Server) jsConsumerDeleteRequest(sub *subscription, c *client, subject, 
 	if c == nil || c.acc == nil {
 		return
 	}
-	var resp JSApiConsumerDeleteResponse
+
+	var resp = JSApiConsumerDeleteResponse{ApiResponse: ApiResponse{Type: JSApiConsumerDeleteResponseType}}
 	if !c.acc.JetStreamEnabled() {
 		resp.Error = jsNotEnabledErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -371,8 +371,10 @@ type JSApiStreamTemplateNamesResponse struct {
 const JSApiStreamTemplateNamesResponseType = "io.nats.jetstream.api.v1.stream_template_names_response"
 
 var (
-	jsNotEnabledErr = &ApiError{Code: 503, Description: "jetstream not enabled for account"}
-	jsBadRequestErr = &ApiError{Code: 400, Description: "bad request"}
+	jsNotEnabledErr      = &ApiError{Code: 503, Description: "jetstream not enabled for account"}
+	jsBadRequestErr      = &ApiError{Code: 400, Description: "bad request"}
+	jsNotEmptyRequestErr = &ApiError{Code: 400, Description: "expected an empty request payload"}
+	jsInvalidJSONErr     = &ApiError{Code: 400, Description: "invalid JSON received in request"}
 )
 
 // For easier handling of exports and imports.
@@ -486,7 +488,7 @@ func (s *Server) jsTemplateCreateRequest(sub *subscription, c *client, subject, 
 	}
 	var cfg StreamTemplateConfig
 	if err := json.Unmarshal(msg, &cfg); err != nil {
-		resp.Error = jsBadRequestErr
+		resp.Error = jsInvalidJSONErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
@@ -526,7 +528,7 @@ func (s *Server) jsTemplateNamesRequest(sub *subscription, c *client, subject, r
 	if !isEmptyRequest(msg) {
 		var req JSApiStreamTemplatesRequest
 		if err := json.Unmarshal(msg, &req); err != nil {
-			resp.Error = jsBadRequestErr
+			resp.Error = jsInvalidJSONErr
 			s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
@@ -566,7 +568,7 @@ func (s *Server) jsTemplateInfoRequest(sub *subscription, c *client, subject, re
 		return
 	}
 	if !isEmptyRequest(msg) {
-		resp.Error = jsBadRequestErr
+		resp.Error = jsNotEmptyRequestErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
@@ -599,7 +601,7 @@ func (s *Server) jsTemplateDeleteRequest(sub *subscription, c *client, subject, 
 		return
 	}
 	if !isEmptyRequest(msg) {
-		resp.Error = jsBadRequestErr
+		resp.Error = jsNotEmptyRequestErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
@@ -651,7 +653,7 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, subject, re
 	}
 	var cfg StreamConfig
 	if err := json.Unmarshal(msg, &cfg); err != nil {
-		resp.Error = jsBadRequestErr
+		resp.Error = jsInvalidJSONErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
@@ -686,7 +688,7 @@ func (s *Server) jsStreamUpdateRequest(sub *subscription, c *client, subject, re
 	}
 	var cfg StreamConfig
 	if err := json.Unmarshal(msg, &cfg); err != nil {
-		resp.Error = jsBadRequestErr
+		resp.Error = jsInvalidJSONErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
@@ -729,7 +731,7 @@ func (s *Server) jsStreamNamesRequest(sub *subscription, c *client, subject, rep
 	if !isEmptyRequest(msg) {
 		var req JSApiStreamNamesRequest
 		if err := json.Unmarshal(msg, &req); err != nil {
-			resp.Error = jsBadRequestErr
+			resp.Error = jsInvalidJSONErr
 			s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
@@ -773,7 +775,7 @@ func (s *Server) jsStreamListRequest(sub *subscription, c *client, subject, repl
 	if !isEmptyRequest(msg) {
 		var req JSApiStreamNamesRequest
 		if err := json.Unmarshal(msg, &req); err != nil {
-			resp.Error = jsBadRequestErr
+			resp.Error = jsInvalidJSONErr
 			s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
@@ -812,7 +814,7 @@ func (s *Server) jsStreamInfoRequest(sub *subscription, c *client, subject, repl
 		return
 	}
 	if !isEmptyRequest(msg) {
-		resp.Error = jsBadRequestErr
+		resp.Error = jsNotEmptyRequestErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
@@ -859,7 +861,7 @@ func (s *Server) jsStreamDeleteRequest(sub *subscription, c *client, subject, re
 		return
 	}
 	if !isEmptyRequest(msg) {
-		resp.Error = jsBadRequestErr
+		resp.Error = jsNotEmptyRequestErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
@@ -892,14 +894,14 @@ func (s *Server) jsMsgDeleteRequest(sub *subscription, c *client, subject, reply
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
-	if len(msg) == 0 {
+	if isEmptyRequest(msg) {
 		resp.Error = jsBadRequestErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
 	var req JSApiMsgDeleteRequest
 	if err := json.Unmarshal(msg, &req); err != nil {
-		resp.Error = jsBadRequestErr
+		resp.Error = jsInvalidJSONErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
@@ -938,14 +940,14 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, subject, reply st
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
-	if len(msg) == 0 {
+	if isEmptyRequest(msg) {
 		resp.Error = jsBadRequestErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
 	var req JSApiMsgGetRequest
 	if err := json.Unmarshal(msg, &req); err != nil {
-		resp.Error = jsBadRequestErr
+		resp.Error = jsInvalidJSONErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
@@ -986,7 +988,7 @@ func (s *Server) jsStreamPurgeRequest(sub *subscription, c *client, subject, rep
 		return
 	}
 	if !isEmptyRequest(msg) {
-		resp.Error = jsBadRequestErr
+		resp.Error = jsNotEmptyRequestErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
@@ -1025,7 +1027,7 @@ func (s *Server) jsConsumerCreate(sub *subscription, c *client, subject, reply s
 	}
 	var req CreateConsumerRequest
 	if err := json.Unmarshal(msg, &req); err != nil {
-		resp.Error = jsBadRequestErr
+		resp.Error = jsInvalidJSONErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
@@ -1105,7 +1107,7 @@ func (s *Server) jsConsumerNamesRequest(sub *subscription, c *client, subject, r
 	if !isEmptyRequest(msg) {
 		var req JSApiConsumersRequest
 		if err := json.Unmarshal(msg, &req); err != nil {
-			resp.Error = jsBadRequestErr
+			resp.Error = jsInvalidJSONErr
 			s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
@@ -1153,7 +1155,7 @@ func (s *Server) jsConsumerListRequest(sub *subscription, c *client, subject, re
 	if !isEmptyRequest(msg) {
 		var req JSApiConsumersRequest
 		if err := json.Unmarshal(msg, &req); err != nil {
-			resp.Error = jsBadRequestErr
+			resp.Error = jsInvalidJSONErr
 			s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
@@ -1197,7 +1199,7 @@ func (s *Server) jsConsumerInfoRequest(sub *subscription, c *client, subject, re
 		return
 	}
 	if !isEmptyRequest(msg) {
-		resp.Error = jsBadRequestErr
+		resp.Error = jsNotEmptyRequestErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
@@ -1233,7 +1235,7 @@ func (s *Server) jsConsumerDeleteRequest(sub *subscription, c *client, subject, 
 		return
 	}
 	if !isEmptyRequest(msg) {
-		resp.Error = jsBadRequestErr
+		resp.Error = jsNotEmptyRequestErr
 		s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -365,7 +365,7 @@ type JSApiStreamTemplatesRequest struct {
 type JSApiStreamTemplateNamesResponse struct {
 	ApiResponse
 	ApiPagedResponse
-	Templates []string `json:"streams,omitempty"`
+	Templates []string `json:"streams"`
 }
 
 const JSApiStreamTemplateNamesResponseType = "io.nats.jetstream.api.v1.stream_template_names_response"

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -169,14 +169,14 @@ type ApiResponse struct {
 	Error *ApiError `json:"error,omitempty"`
 }
 
-// ApiPagedResponse includes variables used to create paged responses from the JSON API
-type ApiPagedResponse struct {
+// ApiPaged includes variables used to create paged responses from the JSON API
+type ApiPaged struct {
 	Total  int `json:"total"`
 	Offset int `json:"offset"`
 	Limit  int `json:"limit"`
 }
 
-// ApiPagedRequest includes parameters allowing specific pages to be requests from APIs responding with ApiPagedResponse
+// ApiPagedRequest includes parameters allowing specific pages to be requests from APIs responding with ApiPaged
 type ApiPagedRequest struct {
 	Offset int `json:"offset"`
 }
@@ -226,7 +226,7 @@ type JSApiStreamNamesRequest struct {
 // A nil request is valid and means all streams.
 type JSApiStreamNamesResponse struct {
 	ApiResponse
-	ApiPagedResponse
+	ApiPaged
 	Streams []string `json:"streams"`
 }
 
@@ -236,7 +236,7 @@ const JSApiStreamNamesResponseType = "io.nats.jetstream.api.v1.stream_names_resp
 // A nil request is valid and means all streams.
 type JSApiStreamListResponse struct {
 	ApiResponse
-	ApiPagedResponse
+	ApiPaged
 	Streams []*StreamInfo `json:"streams"`
 }
 
@@ -317,7 +317,7 @@ type JSApiConsumersRequest struct {
 // JSApiConsumerNamesResponse.
 type JSApiConsumerNamesResponse struct {
 	ApiResponse
-	ApiPagedResponse
+	ApiPaged
 	Consumers []string `json:"consumers"`
 }
 
@@ -326,7 +326,7 @@ const JSApiConsumerNamesResponseType = "io.nats.jetstream.api.v1.consumer_names_
 // JSApiConsumerListResponse.
 type JSApiConsumerListResponse struct {
 	ApiResponse
-	ApiPagedResponse
+	ApiPaged
 	Consumers []*ConsumerInfo `json:"consumers"`
 }
 
@@ -364,7 +364,7 @@ type JSApiStreamTemplatesRequest struct {
 // JSApiStreamTemplateNamesResponse list of templates
 type JSApiStreamTemplateNamesResponse struct {
 	ApiResponse
-	ApiPagedResponse
+	ApiPaged
 	Templates []string `json:"streams"`
 }
 

--- a/test/jetstream_test.go
+++ b/test/jetstream_test.go
@@ -4432,7 +4432,7 @@ func TestJetStreamRequestAPI(t *testing.T) {
 
 	// Make sure list names works.
 	resp, err = nc.Request(server.JSApiStreams, nil, time.Second)
-	var namesResponse server.JSApiStreamsResponse
+	var namesResponse server.JSApiStreamNamesResponse
 	if err = json.Unmarshal(resp.Data, &namesResponse); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -4570,7 +4570,7 @@ func TestJetStreamRequestAPI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	var clResponse server.JSApiConsumersResponse
+	var clResponse server.JSApiConsumerNamesResponse
 	if err = json.Unmarshal(resp.Data, &clResponse); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -4771,7 +4771,7 @@ func TestJetStreamRequestAPI(t *testing.T) {
 	}
 
 	// Now grab the list of templates
-	var tListResp server.JSApiStreamTemplatesResponse
+	var tListResp server.JSApiStreamTemplateNamesResponse
 	resp, err = nc.Request(server.JSApiTemplates, nil, time.Second)
 	if err = json.Unmarshal(resp.Data, &tListResp); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -4887,7 +4887,7 @@ func TestJetStreamAPIStreamListPaging(t *testing.T) {
 		t.Helper()
 		var req []byte
 		if offset > 0 {
-			req, _ = json.Marshal(&server.JSApiStreamsRequest{Offset: offset})
+			req, _ = json.Marshal(&server.JSApiStreamNamesRequest{ApiPagedRequest: server.ApiPagedRequest{Offset: offset}})
 		}
 		resp, err := nc.Request(server.JSApiStreams, req, time.Second)
 		if err != nil {
@@ -4898,7 +4898,7 @@ func TestJetStreamAPIStreamListPaging(t *testing.T) {
 
 	checkResp := func(resp []byte, expectedLen, expectedOffset int) {
 		t.Helper()
-		var listResponse server.JSApiStreamsResponse
+		var listResponse server.JSApiStreamNamesResponse
 		if err := json.Unmarshal(resp, &listResponse); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -4964,7 +4964,7 @@ func TestJetStreamAPIConsumerListPaging(t *testing.T) {
 		t.Helper()
 		var req []byte
 		if offset > 0 {
-			req, _ = json.Marshal(&server.JSApiConsumersRequest{Offset: offset})
+			req, _ = json.Marshal(&server.JSApiConsumersRequest{ApiPagedRequest: server.ApiPagedRequest{Offset: offset}})
 		}
 		resp, err := nc.Request(reqListSubject, req, time.Second)
 		if err != nil {
@@ -4975,7 +4975,7 @@ func TestJetStreamAPIConsumerListPaging(t *testing.T) {
 
 	checkResp := func(resp []byte, expectedLen, expectedOffset int) {
 		t.Helper()
-		var listResponse server.JSApiConsumersResponse
+		var listResponse server.JSApiConsumerNamesResponse
 		if err := json.Unmarshal(resp, &listResponse); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}


### PR DESCRIPTION
Also standardise some names of response structures and create
reusable types that can be included into others to construct
our standard API requests and responses.

Fixes some json tags.

Updates the design document of the JSON responses to reflect
the implementation that was done

Signed-off-by: R.I.Pienaar <rip@devco.net>