### PR TITLE
[FIXED] on reload, check error conditions checked in validateOptions

### DIFF
--- a/server/reload.go
+++ b/server/reload.go
@@ -672,6 +672,13 @@ func (s *Server) reloadOptions(curOpts, newOpts *Options) error {
 	if err != nil {
 		return err
 	}
+
+	if len(changed) != 0 {
+		if err := validateOptions(newOpts); err != nil {
+			return err
+		}
+	}
+
 	// Create a context that is used to pass special info that we may need
 	// while applying the new options.
 	ctx := reloadContext{oldClusterPerms: curOpts.Cluster.Permissions}

--- a/server/server.go
+++ b/server/server.go
@@ -414,6 +414,8 @@ func validateOptions(o *Options) error {
 	if err := validateAuth(o); err != nil {
 		return err
 	}
+	// Check that gateway is properly configured. Returns no error
+	// if there is no gateway defined.
 	return validateGatewayOptions(o)
 }
 


### PR DESCRIPTION
Fixes #1378 by calling validateOptions on reload
Add missing comment to validateOptions

Signed-off-by: Matthias Hanel <mh@synadia.com>
