### PR TITLE
Header support

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -172,6 +172,7 @@ const (
 	MissingAccount
 	Revocation
 	InternalClient
+	MsgHeaderViolation
 )
 
 // Some flags passed to processMsgResultsEx
@@ -220,6 +221,7 @@ type client struct {
 	msgb    [msgScratchSize]byte
 	last    time.Time
 	parseState
+	headers bool
 
 	rtt      time.Duration
 	rttStart time.Time
@@ -1833,6 +1835,68 @@ func (c *client) processPong() {
 	}
 }
 
+// Header pubs take form HPUB <subject> [reply] <hdr_len> <total_len>\r\n
+func (c *client) processHeaderPub(arg []byte) error {
+	// Unroll splitArgs to avoid runtime/heap issues
+	a := [MAX_HPUB_ARGS][]byte{}
+	args := a[:0]
+	start := -1
+	for i, b := range arg {
+		switch b {
+		case ' ', '\t':
+			if start >= 0 {
+				args = append(args, arg[start:i])
+				start = -1
+			}
+		default:
+			if start < 0 {
+				start = i
+			}
+		}
+	}
+	if start >= 0 {
+		args = append(args, arg[start:])
+	}
+
+	c.pa.arg = arg
+	switch len(args) {
+	case 3:
+		c.pa.subject = args[0]
+		c.pa.reply = nil
+		c.pa.hdr = parseSize(args[1])
+		c.pa.size = parseSize(args[2])
+		c.pa.szb = args[2]
+	case 4:
+		c.pa.subject = args[0]
+		c.pa.reply = args[1]
+		c.pa.hdr = parseSize(args[2])
+		c.pa.size = parseSize(args[3])
+		c.pa.szb = args[3]
+	default:
+		return fmt.Errorf("processHeaderPub Parse Error: '%s'", arg)
+	}
+	if c.pa.hdr < 0 {
+		return fmt.Errorf("processHeaderPub Bad or Missing Header Size: '%s'", arg)
+	}
+	// If number overruns an int64, parseSize() will have returned a negative value
+	if c.pa.size < 0 {
+		return fmt.Errorf("processHeaderPub Bad or Missing Total Size: '%s'", arg)
+	}
+	if c.pa.hdr > c.pa.size {
+		return fmt.Errorf("processHeaderPub Header Size larger then TotalSize: '%s'", arg)
+	}
+	maxPayload := atomic.LoadInt32(&c.mpay)
+	// Use int64() to avoid int32 overrun...
+	if maxPayload != jwt.NoLimit && int64(c.pa.size) > int64(maxPayload) {
+		c.maxPayloadViolation(c.pa.size, maxPayload)
+		return ErrMaxPayload
+	}
+	if c.opts.Pedantic && !IsValidLiteralSubject(string(c.pa.subject)) {
+		c.sendErr("Invalid Publish Subject")
+	}
+	return nil
+}
+
 func (c *client) processPub(arg []byte) error {
 	// Unroll splitArgs to avoid runtime/heap issues
 	a := [MAX_PUB_ARGS][]byte{}
@@ -1880,7 +1944,6 @@ func (c *client) processPub(arg []byte) error {
 		c.maxPayloadViolation(c.pa.size, maxPayload)
 		return ErrMaxPayload
 	}
-
 	if c.opts.Pedantic && !IsValidLiteralSubject(string(c.pa.subject)) {
 		c.sendErr("Invalid Publish Subject")
 	}

--- a/server/client.go
+++ b/server/client.go
@@ -1361,7 +1361,9 @@ func computeRTT(start time.Time) time.Duration {
 	return rtt
 }
 
+// processConnect will process a client connect op.
 func (c *client) processConnect(arg []byte) error {
+	supportsHeaders := c.srv.supportsHeaders()
 	c.mu.Lock()
 	// If we can't stop the timer because the callback is in progress...
 	if !c.clearAuthTimer() {
@@ -1407,9 +1409,8 @@ func (c *client) processConnect(arg []byte) error {
 	account := c.opts.Account
 	accountNew := c.opts.AccountNew
 	ujwt := c.opts.JWT
-	// For headers both need to support. If the server supports headers
-	/// it will have been set to true before this is called.
-	c.headers = c.headers && c.opts.Headers
+	// For headers both client and server need to support.
+	c.headers = supportsHeaders && c.opts.Headers
 	c.mu.Unlock()
 
 	if srv != nil {
@@ -1873,12 +1874,14 @@ func (c *client) processHeaderPub(arg []byte) error {
 		c.pa.reply = nil
 		c.pa.hdr = parseSize(args[1])
 		c.pa.size = parseSize(args[2])
+		c.pa.hdb = args[1]
 		c.pa.szb = args[2]
 	case 4:
 		c.pa.subject = args[0]
 		c.pa.reply = args[1]
 		c.pa.hdr = parseSize(args[2])
 		c.pa.size = parseSize(args[3])
+		c.pa.hdb = args[2]
 		c.pa.szb = args[3]
 	default:
 		return fmt.Errorf("processHeaderPub Parse Error: '%s'", arg)
@@ -2446,13 +2449,33 @@ func (c *client) checkDenySub(subject string) bool {
 	return false
 }
 
-func (c *client) msgHeader(mh []byte, sub *subscription, reply []byte) []byte {
+func (c *client) msgHeader(subj []byte, sub *subscription, reply []byte) []byte {
+	// See if we should do headers. We have to have a headers msg and
+	// the client we are going to deliver to needs to support headers as well.
+	// TODO(dlc) - This should only be for client connections, but should we check?
+	doHeaders := c.pa.hdr > 0 && sub.client != nil && sub.client.headers
+
+	var mh []byte
+	if doHeaders {
+		mh = c.msgb[:msgHeadProtoLen]
+		mh[0] = 'H'
+	} else {
+		mh = c.msgb[1:msgHeadProtoLen]
+	}
+	mh = append(mh, subj...)
+	mh = append(mh, ' ')
+
 	if len(sub.sid) > 0 {
 		mh = append(mh, sub.sid...)
 		mh = append(mh, ' ')
 	}
 	if reply != nil {
 		mh = append(mh, reply...)
+		mh = append(mh, ' ')
+	}
+
+	if doHeaders {
+		mh = append(mh, c.pa.hdb...)
 		mh = append(mh, ' ')
 	}
 	mh = append(mh, c.pa.szb...)
@@ -2557,6 +2580,12 @@ func (c *client) deliverMsg(sub *subscription, subject, mh, msg []byte, gwrply b
 				return false
 			}
 		}
+	}
+
+	// Check here if we have a header with our message. If this client can not
+	// support we need to strip the headers from the payload.
+	if c.pa.hdr > 0 && !sub.client.headers {
+		msg = msg[c.pa.hdr:]
 	}
 
 	// Update statistics
@@ -3251,11 +3280,10 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 
 	var didDeliver bool
 
-	// msg header for clients.
-	msgh := c.msgb[1:msgHeadProtoLen]
-	msgh = append(msgh, subj...)
-	msgh = append(msgh, ' ')
-	si := len(msgh)
+	// delivery subject for clients
+	var dsubj []byte
+	// Used as scratch if mapping
+	var _dsubj [64]byte
 
 	// Loop over all normal subscriptions that match.
 	for _, sub := range r.psubs {
@@ -3280,17 +3308,15 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 			}
 			continue
 		}
+		// Assume delivery subject is normal subject to this point.
+		dsubj = subj
 		// Check for stream import mapped subs. These apply to local subs only.
 		if sub.im != nil && sub.im.prefix != "" {
-			// Redo the subject here on the fly.
-			msgh = c.msgb[1:msgHeadProtoLen]
-			msgh = append(msgh, sub.im.prefix...)
-			msgh = append(msgh, subj...)
-			msgh = append(msgh, ' ')
-			si = len(msgh)
+			dsubj = append(_dsubj[:0], sub.im.prefix...)
+			dsubj = append(dsubj, subj...)
 		}
 		// Normal delivery
-		mh := c.msgHeader(msgh[:si], sub, creply)
+		mh := c.msgHeader(dsubj, sub, creply)
 		didDeliver = c.deliverMsg(sub, subj, mh, msg, rplyHasGWPrefix) || didDeliver
 	}
 
@@ -3389,14 +3415,12 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 				break
 			}
 
-			// Check for mapped subs
+			// Assume delivery subject is normal subject to this point.
+			dsubj = subj
+			// Check for stream import mapped subs. These apply to local subs only.
 			if sub.im != nil && sub.im.prefix != "" {
-				// Redo the subject here on the fly.
-				msgh = c.msgb[1:msgHeadProtoLen]
-				msgh = append(msgh, sub.im.prefix...)
-				msgh = append(msgh, subject...)
-				msgh = append(msgh, ' ')
-				si = len(msgh)
+				dsubj = append(_dsubj[:0], sub.im.prefix...)
+				dsubj = append(dsubj, subj...)
 			}
 
 			var rreply = reply
@@ -3405,7 +3429,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 			}
 			// "rreply" will be stripped of the $GNR prefix (if present)
 			// for client connections only.
-			mh := c.msgHeader(msgh[:si], sub, rreply)
+			mh := c.msgHeader(dsubj, sub, rreply)
 			if c.deliverMsg(sub, subject, mh, msg, rplyHasGWPrefix) {
 				didDeliver = true
 				// Clear rsub

--- a/server/client.go
+++ b/server/client.go
@@ -435,6 +435,7 @@ type clientOpts struct {
 	Protocol    int    `json:"protocol"`
 	Account     string `json:"account,omitempty"`
 	AccountNew  bool   `json:"new_account,omitempty"`
+	Headers     bool   `json:"headers,omitempty"`
 
 	// Routes only
 	Import *SubjectPermission `json:"import,omitempty"`
@@ -1406,6 +1407,9 @@ func (c *client) processConnect(arg []byte) error {
 	account := c.opts.Account
 	accountNew := c.opts.AccountNew
 	ujwt := c.opts.JWT
+	// For headers both need to support. If the server supports headers
+	/// it will have been set to true before this is called.
+	c.headers = c.headers && c.opts.Headers
 	c.mu.Unlock()
 
 	if srv != nil {
@@ -1837,6 +1841,10 @@ func (c *client) processPong() {
 
 // Header pubs take form HPUB <subject> [reply] <hdr_len> <total_len>\r\n
 func (c *client) processHeaderPub(arg []byte) error {
+	if !c.headers {
+		return ErrMsgHeadersNotSupported
+	}
+
 	// Unroll splitArgs to avoid runtime/heap issues
 	a := [MAX_HPUB_ARGS][]byte{}
 	args := a[:0]

--- a/server/const.go
+++ b/server/const.go
@@ -127,6 +127,9 @@ const (
 	// MAX_PUB_ARGS Maximum possible number of arguments from PUB proto.
 	MAX_PUB_ARGS = 3
 
+	// MAX_HPUB_ARGS Maximum possible number of arguments from HPUB proto.
+	MAX_HPUB_ARGS = 4
+
 	// DEFAULT_MAX_CLOSED_CLIENTS is the maximum number of closed connections we hold onto.
 	DEFAULT_MAX_CLOSED_CLIENTS = 10000
 

--- a/server/errors.go
+++ b/server/errors.go
@@ -135,8 +135,15 @@ var (
 	// ErrRevocation is returned when a credential has been revoked.
 	ErrRevocation = errors.New("credentials have been revoked")
 
-	// Used to signal an error that a server is not running.
+	// ErrServerNotRunning is used to signal an error that a server is not running.
 	ErrServerNotRunning = errors.New("server is not running")
+
+	// ErrBadMsgHeader signals the parser detected a bad message header
+	ErrBadMsgHeader = errors.New("bad message header detected")
+
+	// ErrMsgHeadersNotSupported signals the parser detected a message header
+	// but they are not supported on this server.
+	ErrMsgHeadersNotSupported = errors.New("message headers not supported")
 )
 
 // configErr is a configuration error.

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1849,6 +1849,8 @@ func (reason ClosedState) String() string {
 		return "Credentials Revoked"
 	case InternalClient:
 		return "Internal Client"
+	case MsgHeaderViolation:
+		return "Message Header Violation"
 	}
 	return "Unknown State"
 }

--- a/server/opts.go
+++ b/server/opts.go
@@ -157,6 +157,7 @@ type Options struct {
 	NoLog                 bool          `json:"-"`
 	NoSigs                bool          `json:"-"`
 	NoSublistCache        bool          `json:"-"`
+	NoHeaderSupport       bool          `json:"-"`
 	DisableShortFirstPing bool          `json:"-"`
 	Logtime               bool          `json:"-"`
 	MaxConn               int           `json:"max_connections"`

--- a/server/parser.go
+++ b/server/parser.go
@@ -36,6 +36,7 @@ type pubArg struct {
 	deliver []byte
 	reply   []byte
 	szb     []byte
+	hdb     []byte
 	queues  [][]byte
 	size    int
 	hdr     int
@@ -367,7 +368,7 @@ func (c *client) parse(buf []byte) error {
 			c.drop, c.as, c.state = 0, i+1, OP_START
 			// Drop all pub args
 			c.pa.arg, c.pa.pacache, c.pa.account, c.pa.subject = nil, nil, nil, nil
-			c.pa.reply, c.pa.hdr, c.pa.size, c.pa.szb, c.pa.queues = nil, -1, 0, nil, nil
+			c.pa.reply, c.pa.hdr, c.pa.size, c.pa.szb, c.pa.hdb, c.pa.queues = nil, -1, 0, nil, nil, nil
 		case OP_A:
 			switch b {
 			case '+':

--- a/server/parser.go
+++ b/server/parser.go
@@ -17,6 +17,17 @@ import (
 	"fmt"
 )
 
+type parserState int
+type parseState struct {
+	state   parserState
+	as      int
+	drop    int
+	pa      pubArg
+	argBuf  []byte
+	msgBuf  []byte
+	scratch [MAX_CONTROL_LINE_SIZE]byte
+}
+
 type pubArg struct {
 	arg     []byte
 	pacache []byte
@@ -27,17 +38,7 @@ type pubArg struct {
 	szb     []byte
 	queues  [][]byte
 	size    int
-}
-
-type parserState int
-type parseState struct {
-	state   parserState
-	as      int
-	drop    int
-	pa      pubArg
-	argBuf  []byte
-	msgBuf  []byte
-	scratch [MAX_CONTROL_LINE_SIZE]byte
+	hdr     int
 }
 
 // Parser constants
@@ -60,6 +61,12 @@ const (
 	OP_CONNEC
 	OP_CONNECT
 	CONNECT_ARG
+	OP_H
+	OP_HP
+	OP_HPU
+	OP_HPUB
+	OP_HPUB_SPC
+	HPUB_ARG
 	OP_P
 	OP_PU
 	OP_PUB
@@ -144,6 +151,8 @@ func (c *client) parse(buf []byte) error {
 			switch b {
 			case 'P', 'p':
 				c.state = OP_P
+			case 'H', 'h':
+				c.state = OP_H
 			case 'S', 's':
 				c.state = OP_S
 			case 'U', 'u':
@@ -177,6 +186,73 @@ func (c *client) parse(buf []byte) error {
 			default:
 				goto parseErr
 			}
+		case OP_H:
+			switch b {
+			case 'P', 'p':
+				c.state = OP_HP
+			default:
+				goto parseErr
+			}
+		case OP_HP:
+			switch b {
+			case 'U', 'u':
+				c.state = OP_HPU
+			default:
+				goto parseErr
+			}
+		case OP_HPU:
+			switch b {
+			case 'B', 'b':
+				c.state = OP_HPUB
+			default:
+				goto parseErr
+			}
+		case OP_HPUB:
+			switch b {
+			case ' ', '\t':
+				c.state = OP_HPUB_SPC
+			default:
+				goto parseErr
+			}
+		case OP_HPUB_SPC:
+			switch b {
+			case ' ', '\t':
+				continue
+			default:
+				c.pa.hdr = 0
+				c.state = HPUB_ARG
+				c.as = i
+			}
+		case HPUB_ARG:
+			switch b {
+			case '\r':
+				c.drop = 1
+			case '\n':
+				var arg []byte
+				if c.argBuf != nil {
+					arg = c.argBuf
+					c.argBuf = nil
+				} else {
+					arg = buf[c.as : i-c.drop]
+				}
+				if trace {
+					c.traceInOp("HPUB", arg)
+				}
+				if err := c.processHeaderPub(arg); err != nil {
+					return err
+				}
+				c.drop, c.as, c.state = 0, i+1, MSG_PAYLOAD
+				// If we don't have a saved buffer then jump ahead with
+				// the index. If this overruns what is left we fall out
+				// and process split buffer.
+				if c.msgBuf == nil {
+					i = c.as + c.pa.size - LEN_CR_LF
+				}
+			default:
+				if c.argBuf != nil {
+					c.argBuf = append(c.argBuf, b)
+				}
+			}
 		case OP_P:
 			switch b {
 			case 'U', 'u':
@@ -207,6 +283,7 @@ func (c *client) parse(buf []byte) error {
 			case ' ', '\t':
 				continue
 			default:
+				c.pa.hdr = -1
 				c.state = PUB_ARG
 				c.as = i
 			}
@@ -290,7 +367,7 @@ func (c *client) parse(buf []byte) error {
 			c.drop, c.as, c.state = 0, i+1, OP_START
 			// Drop all pub args
 			c.pa.arg, c.pa.pacache, c.pa.account, c.pa.subject = nil, nil, nil, nil
-			c.pa.reply, c.pa.size, c.pa.szb, c.pa.queues = nil, 0, nil, nil
+			c.pa.reply, c.pa.hdr, c.pa.size, c.pa.szb, c.pa.queues = nil, -1, 0, nil, nil
 		case OP_A:
 			switch b {
 			case '+':
@@ -895,7 +972,8 @@ func (c *client) parse(buf []byte) error {
 	}
 
 	// Check for split buffer scenarios for any ARG state.
-	if c.state == SUB_ARG || c.state == UNSUB_ARG || c.state == PUB_ARG ||
+	if c.state == SUB_ARG || c.state == UNSUB_ARG ||
+		c.state == PUB_ARG || c.state == HPUB_ARG ||
 		c.state == ASUB_ARG || c.state == AUSUB_ARG ||
 		c.state == MSG_ARG || c.state == MINUS_ERR_ARG ||
 		c.state == CONNECT_ARG || c.state == INFO_ARG {
@@ -985,6 +1063,10 @@ func (c *client) clonePubArg() error {
 	case LEAF:
 		return c.processLeafMsgArgs(c.argBuf)
 	default:
-		return c.processPub(c.argBuf)
+		if c.pa.hdr < 0 {
+			return c.processPub(c.argBuf)
+		} else {
+			return c.processHeaderPub(c.argBuf)
+		}
 	}
 }

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -235,70 +235,38 @@ func TestParsePubArg(t *testing.T) {
 		size    int
 		szb     string
 	}{
-		{arg: "a 2",
-			subject: "a", reply: "", size: 2, szb: "2"},
-		{arg: "a 222",
-			subject: "a", reply: "", size: 222, szb: "222"},
-		{arg: "foo 22",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: " foo 22",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "foo 22 ",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "foo   22",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: " foo 22 ",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: " foo   22 ",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "foo bar 22",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: " foo bar 22",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "foo bar 22 ",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "foo  bar  22",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: " foo bar 22 ",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "  foo   bar  22  ",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "  foo   bar  2222  ",
-			subject: "foo", reply: "bar", size: 2222, szb: "2222"},
-		{arg: "  foo     2222  ",
-			subject: "foo", reply: "", size: 2222, szb: "2222"},
-		{arg: "a\t2",
-			subject: "a", reply: "", size: 2, szb: "2"},
-		{arg: "a\t222",
-			subject: "a", reply: "", size: 222, szb: "222"},
-		{arg: "foo\t22",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "\tfoo\t22",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "foo\t22\t",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "foo\t\t\t22",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "\tfoo\t22\t",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "\tfoo\t\t\t22\t",
-			subject: "foo", reply: "", size: 22, szb: "22"},
-		{arg: "foo\tbar\t22",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "\tfoo\tbar\t22",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "foo\tbar\t22\t",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "foo\t\tbar\t\t22",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "\tfoo\tbar\t22\t",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "\t \tfoo\t \t \tbar\t \t22\t \t",
-			subject: "foo", reply: "bar", size: 22, szb: "22"},
-		{arg: "\t\tfoo\t\t\tbar\t\t2222\t\t",
-			subject: "foo", reply: "bar", size: 2222, szb: "2222"},
-		{arg: "\t \tfoo\t \t \t\t\t2222\t \t",
-			subject: "foo", reply: "", size: 2222, szb: "2222"},
+		{arg: "a 2", subject: "a", reply: "", size: 2, szb: "2"},
+		{arg: "a 222", subject: "a", reply: "", size: 222, szb: "222"},
+		{arg: "foo 22", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: " foo 22", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "foo 22 ", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "foo   22", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: " foo 22 ", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: " foo   22 ", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "foo bar 22", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: " foo bar 22", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "foo bar 22 ", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "foo  bar  22", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: " foo bar 22 ", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "  foo   bar  22  ", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "  foo   bar  2222  ", subject: "foo", reply: "bar", size: 2222, szb: "2222"},
+		{arg: "  foo     2222  ", subject: "foo", reply: "", size: 2222, szb: "2222"},
+		{arg: "a\t2", subject: "a", reply: "", size: 2, szb: "2"},
+		{arg: "a\t222", subject: "a", reply: "", size: 222, szb: "222"},
+		{arg: "foo\t22", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "\tfoo\t22", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "foo\t22\t", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "foo\t\t\t22", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "\tfoo\t22\t", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "\tfoo\t\t\t22\t", subject: "foo", reply: "", size: 22, szb: "22"},
+		{arg: "foo\tbar\t22", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "\tfoo\tbar\t22", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "foo\tbar\t22\t", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "foo\t\tbar\t\t22", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "\tfoo\tbar\t22\t", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "\t \tfoo\t \t \tbar\t \t22\t \t", subject: "foo", reply: "bar", size: 22, szb: "22"},
+		{arg: "\t\tfoo\t\t\tbar\t\t2222\t\t", subject: "foo", reply: "bar", size: 2222, szb: "2222"},
+		{arg: "\t \tfoo\t \t \t\t\t2222\t \t", subject: "foo", reply: "", size: 2222, szb: "2222"},
 	} {
 		t.Run(test.arg, func(t *testing.T) {
 			if err := c.processPub([]byte(test.arg)); err != nil {
@@ -326,6 +294,134 @@ func TestParsePubBadSize(t *testing.T) {
 	c.mpay = 32768
 	if err := c.processPub([]byte("foo 2222222222222222")); err == nil {
 		t.Fatalf("Expected parse error for size too large")
+	}
+}
+
+func TestParseHeaderPub(t *testing.T) {
+	c := dummyClient()
+
+	hpub := []byte("HPUB foo 12 17\r\nname:derek\r\nHELLO\r")
+	if err := c.parse(hpub); err != nil || c.state != MSG_END_N {
+		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
+	}
+	if !bytes.Equal(c.pa.subject, []byte("foo")) {
+		t.Fatalf("Did not parse subject correctly: 'foo' vs '%s'\n", c.pa.subject)
+	}
+	if c.pa.reply != nil {
+		t.Fatalf("Did not parse reply correctly: 'nil' vs '%s'\n", c.pa.reply)
+	}
+	if c.pa.hdr != 12 {
+		t.Fatalf("Did not parse msg header size correctly: 12 vs %d\n", c.pa.hdr)
+	}
+	if c.pa.size != 17 {
+		t.Fatalf("Did not parse msg size correctly: 17 vs %d\n", c.pa.size)
+	}
+
+	// Clear snapshots
+	c.argBuf, c.msgBuf, c.state = nil, nil, OP_START
+
+	hpub = []byte("HPUB foo INBOX.22 12 17\r\nname:derek\r\nHELLO\r")
+	if err := c.parse(hpub); err != nil || c.state != MSG_END_N {
+		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
+	}
+	if !bytes.Equal(c.pa.subject, []byte("foo")) {
+		t.Fatalf("Did not parse subject correctly: 'foo' vs '%s'\n", c.pa.subject)
+	}
+	if !bytes.Equal(c.pa.reply, []byte("INBOX.22")) {
+		t.Fatalf("Did not parse reply correctly: 'INBOX.22' vs '%s'\n", c.pa.reply)
+	}
+	if c.pa.hdr != 12 {
+		t.Fatalf("Did not parse msg header size correctly: 12 vs %d\n", c.pa.hdr)
+	}
+	if c.pa.size != 17 {
+		t.Fatalf("Did not parse msg size correctly: 17 vs %d\n", c.pa.size)
+	}
+
+	// Clear snapshots
+	c.argBuf, c.msgBuf, c.state = nil, nil, OP_START
+
+	hpub = []byte("HPUB foo INBOX.22 0 5\r\nHELLO\r")
+	if err := c.parse(hpub); err != nil || c.state != MSG_END_N {
+		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
+	}
+	if !bytes.Equal(c.pa.subject, []byte("foo")) {
+		t.Fatalf("Did not parse subject correctly: 'foo' vs '%s'\n", c.pa.subject)
+	}
+	if !bytes.Equal(c.pa.reply, []byte("INBOX.22")) {
+		t.Fatalf("Did not parse reply correctly: 'INBOX.22' vs '%s'\n", c.pa.reply)
+	}
+	if c.pa.hdr != 0 {
+		t.Fatalf("Did not parse msg header size correctly: 0 vs %d\n", c.pa.hdr)
+	}
+	if c.pa.size != 5 {
+		t.Fatalf("Did not parse msg size correctly: 5 vs %d\n", c.pa.size)
+	}
+}
+
+func TestParseHeaderPubArg(t *testing.T) {
+	c := dummyClient()
+
+	for _, test := range []struct {
+		arg     string
+		subject string
+		reply   string
+		hdr     int
+		size    int
+		szb     string
+	}{
+		{arg: "a 2 4", subject: "a", reply: "", hdr: 2, size: 4, szb: "4"},
+		{arg: "a 22 222", subject: "a", reply: "", hdr: 22, size: 222, szb: "222"},
+		{arg: "foo 3 22", subject: "foo", reply: "", hdr: 3, size: 22, szb: "22"},
+		{arg: " foo   1 22", subject: "foo", reply: "", hdr: 1, size: 22, szb: "22"},
+		{arg: "foo 0   22 ", subject: "foo", reply: "", hdr: 0, size: 22, szb: "22"},
+		{arg: "foo  0     22", subject: "foo", reply: "", hdr: 0, size: 22, szb: "22"},
+		{arg: " foo 1 22 ", subject: "foo", reply: "", hdr: 1, size: 22, szb: "22"},
+		{arg: " foo   3 22 ", subject: "foo", reply: "", hdr: 3, size: 22, szb: "22"},
+		{arg: "foo bar 1 22", subject: "foo", reply: "bar", hdr: 1, size: 22, szb: "22"},
+		{arg: " foo bar 11 22", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "foo bar 11 22 ", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "foo  bar  11  22", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: " foo bar  11 22 ", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "  foo   bar  11   22  ", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "  foo   bar  22   2222  ", subject: "foo", reply: "bar", hdr: 22, size: 2222, szb: "2222"},
+		{arg: "  foo 1    2222  ", subject: "foo", reply: "", hdr: 1, size: 2222, szb: "2222"},
+		{arg: "a\t2\t22", subject: "a", reply: "", hdr: 2, size: 22, szb: "22"},
+		{arg: "a\t2\t\t222", subject: "a", reply: "", hdr: 2, size: 222, szb: "222"},
+		{arg: "foo\t2 22", subject: "foo", reply: "", hdr: 2, size: 22, szb: "22"},
+		{arg: "\tfoo\t11\t  22", subject: "foo", reply: "", hdr: 11, size: 22, szb: "22"},
+		{arg: "foo\t11\t22\t", subject: "foo", reply: "", hdr: 11, size: 22, szb: "22"},
+		{arg: "foo\t\t\t11 22", subject: "foo", reply: "", hdr: 11, size: 22, szb: "22"},
+		{arg: "\tfoo\t11\t \t 22\t", subject: "foo", reply: "", hdr: 11, size: 22, szb: "22"},
+		{arg: "\tfoo\t\t\t11 22\t", subject: "foo", reply: "", hdr: 11, size: 22, szb: "22"},
+		{arg: "foo\tbar\t2 22", subject: "foo", reply: "bar", hdr: 2, size: 22, szb: "22"},
+		{arg: "\tfoo\tbar\t11\t22", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "foo\tbar\t11\t\t22\t ", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "foo\t\tbar\t\t11\t\t\t22", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "\tfoo\tbar\t11\t22\t", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "\t \tfoo\t \t \tbar\t \t11\t 22\t \t", subject: "foo", reply: "bar", hdr: 11, size: 22, szb: "22"},
+		{arg: "\t\tfoo\t\t\tbar\t\t22\t\t\t2222\t\t", subject: "foo", reply: "bar", hdr: 22, size: 2222, szb: "2222"},
+		{arg: "\t \tfoo\t \t \t\t\t11\t\t 2222\t \t", subject: "foo", reply: "", hdr: 11, size: 2222, szb: "2222"},
+	} {
+		t.Run(test.arg, func(t *testing.T) {
+			if err := c.processHeaderPub([]byte(test.arg)); err != nil {
+				t.Fatalf("Unexpected parse error: %v\n", err)
+			}
+			if !bytes.Equal(c.pa.subject, []byte(test.subject)) {
+				t.Fatalf("Mismatched subject: '%s'\n", c.pa.subject)
+			}
+			if !bytes.Equal(c.pa.reply, []byte(test.reply)) {
+				t.Fatalf("Mismatched reply subject: '%s'\n", c.pa.reply)
+			}
+			if !bytes.Equal(c.pa.szb, []byte(test.szb)) {
+				t.Fatalf("Bad size buf: '%s'\n", c.pa.szb)
+			}
+			if c.pa.hdr != test.hdr {
+				t.Fatalf("Bad header size: %d\n", c.pa.hdr)
+			}
+			if c.pa.size != test.size {
+				t.Fatalf("Bad size: %d\n", c.pa.size)
+			}
+		})
 	}
 }
 

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -299,6 +299,7 @@ func TestParsePubBadSize(t *testing.T) {
 
 func TestParseHeaderPub(t *testing.T) {
 	c := dummyClient()
+	c.headers = true
 
 	hpub := []byte("HPUB foo 12 17\r\nname:derek\r\nHELLO\r")
 	if err := c.parse(hpub); err != nil || c.state != MSG_END_N {
@@ -360,6 +361,7 @@ func TestParseHeaderPub(t *testing.T) {
 
 func TestParseHeaderPubArg(t *testing.T) {
 	c := dummyClient()
+	c.headers = true
 
 	for _, test := range []struct {
 		arg     string

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -306,16 +306,19 @@ func TestParseHeaderPub(t *testing.T) {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
 	if !bytes.Equal(c.pa.subject, []byte("foo")) {
-		t.Fatalf("Did not parse subject correctly: 'foo' vs '%s'\n", c.pa.subject)
+		t.Fatalf("Did not parse subject correctly: 'foo' vs '%s'", c.pa.subject)
 	}
 	if c.pa.reply != nil {
-		t.Fatalf("Did not parse reply correctly: 'nil' vs '%s'\n", c.pa.reply)
+		t.Fatalf("Did not parse reply correctly: 'nil' vs '%s'", c.pa.reply)
 	}
 	if c.pa.hdr != 12 {
-		t.Fatalf("Did not parse msg header size correctly: 12 vs %d\n", c.pa.hdr)
+		t.Fatalf("Did not parse msg header size correctly: 12 vs %d", c.pa.hdr)
+	}
+	if !bytes.Equal(c.pa.hdb, []byte("12")) {
+		t.Fatalf("Did not parse or capture the header size as bytes correctly: %q", c.pa.hdb)
 	}
 	if c.pa.size != 17 {
-		t.Fatalf("Did not parse msg size correctly: 17 vs %d\n", c.pa.size)
+		t.Fatalf("Did not parse msg size correctly: 17 vs %d", c.pa.size)
 	}
 
 	// Clear snapshots
@@ -326,16 +329,19 @@ func TestParseHeaderPub(t *testing.T) {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
 	if !bytes.Equal(c.pa.subject, []byte("foo")) {
-		t.Fatalf("Did not parse subject correctly: 'foo' vs '%s'\n", c.pa.subject)
+		t.Fatalf("Did not parse subject correctly: 'foo' vs '%s'", c.pa.subject)
 	}
 	if !bytes.Equal(c.pa.reply, []byte("INBOX.22")) {
-		t.Fatalf("Did not parse reply correctly: 'INBOX.22' vs '%s'\n", c.pa.reply)
+		t.Fatalf("Did not parse reply correctly: 'INBOX.22' vs '%s'", c.pa.reply)
 	}
 	if c.pa.hdr != 12 {
-		t.Fatalf("Did not parse msg header size correctly: 12 vs %d\n", c.pa.hdr)
+		t.Fatalf("Did not parse msg header size correctly: 12 vs %d", c.pa.hdr)
+	}
+	if !bytes.Equal(c.pa.hdb, []byte("12")) {
+		t.Fatalf("Did not parse or capture the header size as bytes correctly: %q", c.pa.hdb)
 	}
 	if c.pa.size != 17 {
-		t.Fatalf("Did not parse msg size correctly: 17 vs %d\n", c.pa.size)
+		t.Fatalf("Did not parse msg size correctly: 17 vs %d", c.pa.size)
 	}
 
 	// Clear snapshots
@@ -353,6 +359,9 @@ func TestParseHeaderPub(t *testing.T) {
 	}
 	if c.pa.hdr != 0 {
 		t.Fatalf("Did not parse msg header size correctly: 0 vs %d\n", c.pa.hdr)
+	}
+	if !bytes.Equal(c.pa.hdb, []byte("0")) {
+		t.Fatalf("Did not parse or capture the header size as bytes correctly: %q", c.pa.hdb)
 	}
 	if c.pa.size != 5 {
 		t.Fatalf("Did not parse msg size correctly: 5 vs %d\n", c.pa.size)

--- a/server/server.go
+++ b/server/server.go
@@ -68,6 +68,7 @@ type Info struct {
 	GoVersion         string   `json:"go"`
 	Host              string   `json:"host"`
 	Port              int      `json:"port"`
+	Headers           bool     `json:"headers"`
 	AuthRequired      bool     `json:"auth_required,omitempty"`
 	TLSRequired       bool     `json:"tls_required,omitempty"`
 	TLSVerify         bool     `json:"tls_verify,omitempty"`
@@ -269,6 +270,7 @@ func NewServer(opts *Options) (*Server, error) {
 		TLSVerify:    verify,
 		MaxPayload:   opts.MaxPayload,
 		JetStream:    opts.JetStream,
+		Headers:      !opts.NoHeaderSupport,
 	}
 
 	now := time.Now()
@@ -1820,6 +1822,7 @@ func (s *Server) createClient(conn net.Conn) *client {
 	s.mu.Lock()
 	info := s.copyInfo()
 	c.nonce = []byte(info.Nonce)
+	c.headers = info.Headers
 	s.totalClients++
 	s.mu.Unlock()
 

--- a/server/server.go
+++ b/server/server.go
@@ -1822,7 +1822,6 @@ func (s *Server) createClient(conn net.Conn) *client {
 	s.mu.Lock()
 	info := s.copyInfo()
 	c.nonce = []byte(info.Nonce)
-	c.headers = info.Headers
 	s.totalClients++
 	s.mu.Unlock()
 
@@ -2252,6 +2251,17 @@ func (s *Server) ReadyForConnections(dur time.Duration) bool {
 		time.Sleep(25 * time.Millisecond)
 	}
 	return false
+}
+
+// Quick utility to function to tell if the server supports headers.
+func (s *Server) supportsHeaders() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	ans := s.info.Headers
+	s.mu.Unlock()
+	return ans
 }
 
 // ID returns the server's ID

--- a/server/server.go
+++ b/server/server.go
@@ -2258,10 +2258,7 @@ func (s *Server) supportsHeaders() bool {
 	if s == nil {
 		return false
 	}
-	s.mu.Lock()
-	ans := s.info.Headers
-	s.mu.Unlock()
-	return ans
+	return !(s.getOpts().NoHeaderSupport)
 }
 
 // ID returns the server's ID


### PR DESCRIPTION
This is first pass header support in the server. This introduces a new client protocol HPUB and bidirectional agreement between server and client on abilities using the header feature flag both in INFO and CONNECT.

Next pass will add in HMSG and complete propagation through the server with ability to strip headers for older clients.

/cc @nats-io/core
