### PR TITLE
[FIXED] Early closed connection may linger in the server

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1793,6 +1793,12 @@ func (s *Server) createClient(conn net.Conn) *client {
 	// The connection may have been closed
 	if c.isClosed() {
 		c.mu.Unlock()
+		// If it was due to TLS timeout, teardownConn() has already been called.
+		// Otherwise, if connection was marked as closed while sending the INFO,
+		// we need to call teardownConn() directly here.
+		if !info.TLSRequired {
+			c.teardownConn()
+		}
 		return c
 	}
 


### PR DESCRIPTION
If the connection is marked as closed while sending the INFO, the
connection would not be removed from the internal map, which would
cause it to be shown in the monitoring list of opened connections.

Resolves #1384

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
