### PR TITLE
[ADDED] base path for monitoring endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,9 +43,9 @@ Logging Options:
     -r, --remote_syslog <addr>       Syslog server addr (udp://localhost:514)
     -D, --debug                      Enable debugging output
     -V, --trace                      Trace the raw protocol
-    -VV                              Verbose trace (traces system account as well) 
+    -VV                              Verbose trace (traces system account as well)
     -DV                              Debug and trace
-    -DVV                             Debug and verbose trace (traces system account as well) 
+    -DVV                             Debug and verbose trace (traces system account as well)
 
 Authorization Options:
         --user <user>                User required for connections

--- a/server/configs/test.conf
+++ b/server/configs/test.conf
@@ -6,6 +6,8 @@ listen: 127.0.0.1:4242
 
 http: 8222
 
+http_base_path: /nats
+
 authorization {
   user:     derek
   password: porkchop

--- a/server/const.go
+++ b/server/const.go
@@ -97,6 +97,9 @@ const (
 	// DEFAULT_HTTP_PORT is the default monitoring port.
 	DEFAULT_HTTP_PORT = 8222
 
+	// DEFAULT_HTTP_BASE_PATH is the default base path for monitoring.
+	DEFAULT_HTTP_BASE_PATH = "/"
+
 	// ACCEPT_MIN_SLEEP is the minimum acceptable sleep times on temporary errors.
 	ACCEPT_MIN_SLEEP = 10 * time.Millisecond
 

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -975,6 +975,7 @@ type Varz struct {
 	MaxPingsOut       int               `json:"ping_max"`
 	HTTPHost          string            `json:"http_host"`
 	HTTPPort          int               `json:"http_port"`
+	HTTPBasePath      string            `json:"http_base_path"`
 	HTTPSPort         int               `json:"https_port"`
 	AuthTimeout       float64           `json:"auth_timeout"`
 	MaxControlLine    int32             `json:"max_control_line"`
@@ -1081,7 +1082,7 @@ func myUptime(d time.Duration) string {
 // HandleRoot will show basic info and links to others handlers.
 func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 	// This feels dumb to me, but is required: https://code.google.com/p/go/issues/detail?id=4799
-	if r.URL.Path != "/" {
+	if r.URL.Path != s.httpBasePath {
 		http.NotFound(w, r)
 		return
 	}
@@ -1099,16 +1100,23 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
   <body>
     <img src="http://nats.io/img/logo.png" alt="NATS">
     <br/>
-	<a href=/varz>varz</a><br/>
-	<a href=/connz>connz</a><br/>
-	<a href=/routez>routez</a><br/>
-	<a href=/gatewayz>gatewayz</a><br/>
-	<a href=/leafz>leafz</a><br/>
-	<a href=/subsz>subsz</a><br/>
+	<a href=%s>varz</a><br/>
+	<a href=%s>connz</a><br/>
+	<a href=%s>routez</a><br/>
+	<a href=%s>gatewayz</a><br/>
+	<a href=%s>leafz</a><br/>
+	<a href=%s>subsz</a><br/>
     <br/>
     <a href=https://docs.nats.io/nats-server/configuration/monitoring.html>help</a>
   </body>
-</html>`)
+</html>`,
+		s.basePath(VarzPath),
+		s.basePath(ConnzPath),
+		s.basePath(RoutezPath),
+		s.basePath(GatewayzPath),
+		s.basePath(LeafzPath),
+		s.basePath(SubszPath),
+	)
 }
 
 // Varz returns a Varz struct containing the server information.
@@ -1138,18 +1146,19 @@ func (s *Server) createVarz(pcpu float64, rss int64) *Varz {
 	gw := &opts.Gateway
 	ln := &opts.LeafNode
 	varz := &Varz{
-		ID:        info.ID,
-		Version:   info.Version,
-		Proto:     info.Proto,
-		GitCommit: info.GitCommit,
-		GoVersion: info.GoVersion,
-		Name:      info.Name,
-		Host:      info.Host,
-		Port:      info.Port,
-		IP:        info.IP,
-		HTTPHost:  opts.HTTPHost,
-		HTTPPort:  opts.HTTPPort,
-		HTTPSPort: opts.HTTPSPort,
+		ID:           info.ID,
+		Version:      info.Version,
+		Proto:        info.Proto,
+		GitCommit:    info.GitCommit,
+		GoVersion:    info.GoVersion,
+		Name:         info.Name,
+		Host:         info.Host,
+		Port:         info.Port,
+		IP:           info.IP,
+		HTTPHost:     opts.HTTPHost,
+		HTTPPort:     opts.HTTPPort,
+		HTTPBasePath: opts.HTTPBasePath,
+		HTTPSPort:    opts.HTTPSPort,
 		Cluster: ClusterOptsVarz{
 			Host:        c.Host,
 			Port:        c.Port,

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -43,13 +43,14 @@ const CLUSTER_PORT = -1
 
 func DefaultMonitorOptions() *Options {
 	return &Options{
-		Host:       "127.0.0.1",
-		Port:       CLIENT_PORT,
-		HTTPHost:   "127.0.0.1",
-		HTTPPort:   MONITOR_PORT,
-		ServerName: "monitor_server",
-		NoLog:      true,
-		NoSigs:     true,
+		Host:         "127.0.0.1",
+		Port:         CLIENT_PORT,
+		HTTPHost:     "127.0.0.1",
+		HTTPPort:     MONITOR_PORT,
+		HTTPBasePath: "/",
+		ServerName:   "monitor_server",
+		NoLog:        true,
+		NoSigs:       true,
 	}
 }
 
@@ -136,6 +137,7 @@ var (
 	appJSONContent = "application/json"
 	appJSContent   = "application/javascript"
 	textPlain      = "text/plain; charset=utf-8"
+	textHTML       = "text/html; charset=utf-8"
 )
 
 func readBodyEx(t *testing.T, url string, status int, content string) []byte {
@@ -156,6 +158,18 @@ func readBodyEx(t *testing.T, url string, status int, content string) []byte {
 		stackFatalf(t, "Got an error reading the body: %v\n", err)
 	}
 	return body
+}
+
+func TestHTTPBasePath(t *testing.T) {
+	resetPreviousHTTPConnections()
+	opts := DefaultMonitorOptions()
+	opts.HTTPBasePath = "/nats"
+
+	s := RunServer(opts)
+	defer s.Shutdown()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/nats", s.MonitorAddr().Port)
+	readBodyEx(t, url, http.StatusOK, textHTML)
 }
 
 func readBody(t *testing.T, url string) []byte {

--- a/server/opts.go
+++ b/server/opts.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -173,6 +174,7 @@ type Options struct {
 	MaxPingsOut           int           `json:"ping_max"`
 	HTTPHost              string        `json:"http_host"`
 	HTTPPort              int           `json:"http_port"`
+	HTTPBasePath          string        `json:"http_base_path"`
 	HTTPSPort             int           `json:"https_port"`
 	AuthTimeout           float64       `json:"auth_timeout"`
 	MaxControlLine        int32         `json:"max_control_line"`
@@ -593,6 +595,8 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 		o.HTTPPort = int(v.(int64))
 	case "https_port":
 		o.HTTPSPort = int(v.(int64))
+	case "http_base_path":
+		o.HTTPBasePath = v.(string)
 	case "cluster":
 		err := parseCluster(tk, o, errors, warnings)
 		if err != nil {
@@ -2814,6 +2818,9 @@ func MergeOptions(fileOpts, flagOpts *Options) *Options {
 	if flagOpts.HTTPPort != 0 {
 		opts.HTTPPort = flagOpts.HTTPPort
 	}
+	if flagOpts.HTTPBasePath != "" {
+		opts.HTTPBasePath = flagOpts.HTTPBasePath
+	}
 	if flagOpts.Debug {
 		opts.Debug = true
 	}
@@ -3316,6 +3323,17 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	}
 
 	return opts, nil
+}
+
+func normalizeBasePath(p string) string {
+	if len(p) == 0 {
+		return "/"
+	}
+	// add leading slash
+	if p[0] != '/' {
+		p = "/" + p
+	}
+	return path.Clean(p)
 }
 
 // overrideTLS is called when at least "-tls=true" has been set.

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -96,6 +96,7 @@ func TestConfigFile(t *testing.T) {
 		Trace:                 true,
 		Logtime:               false,
 		HTTPPort:              8222,
+		HTTPBasePath:          "/nats",
 		PidFile:               "/tmp/nats-server.pid",
 		ProfPort:              6543,
 		Syslog:                true,
@@ -252,6 +253,7 @@ func TestMergeOverrides(t *testing.T) {
 		Trace:          true,
 		Logtime:        false,
 		HTTPPort:       DEFAULT_HTTP_PORT,
+		HTTPBasePath:   DEFAULT_HTTP_BASE_PATH,
 		PidFile:        "/tmp/nats-server.pid",
 		ProfPort:       6789,
 		Syslog:         true,
@@ -279,11 +281,12 @@ func TestMergeOverrides(t *testing.T) {
 
 	// Overrides via flags
 	opts := &Options{
-		Port:     2222,
-		Password: "porkchop",
-		Debug:    true,
-		HTTPPort: DEFAULT_HTTP_PORT,
-		ProfPort: 6789,
+		Port:         2222,
+		Password:     "porkchop",
+		Debug:        true,
+		HTTPPort:     DEFAULT_HTTP_PORT,
+		HTTPBasePath: DEFAULT_HTTP_BASE_PATH,
+		ProfPort:     6789,
 		Cluster: ClusterOpts{
 			NoAdvertise:    true,
 			ConnectRetries: 2,
@@ -1110,6 +1113,7 @@ func TestOptionsClone(t *testing.T) {
 		Trace:          true,
 		Logtime:        false,
 		HTTPPort:       DEFAULT_HTTP_PORT,
+		HTTPBasePath:   DEFAULT_HTTP_BASE_PATH,
 		PidFile:        "/tmp/nats-server.pid",
 		ProfPort:       6789,
 		Syslog:         true,


### PR DESCRIPTION
 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #

### Changes proposed in this pull request:

 - Add flag `http_base_path` to be able to access nats monitoring endpoint behind a proxy (e.g. nginx) 

/cc @nats-io/core
