### PR TITLE
Move reset of internal client to after the account sublist was moved.

### DIFF
--- a/server/reload.go
+++ b/server/reload.go
@@ -1106,7 +1106,16 @@ func (s *Server) reloadAuthorization() {
 	for _, route := range s.routes {
 		routes = append(routes, route)
 	}
+	var resetCh chan struct{}
+	if s.sys != nil {
+		// can't hold the lock as go routine reading it may be waiting for lock as well
+		resetCh = s.sys.resetCh
+	}
 	s.mu.Unlock()
+
+	if resetCh != nil {
+		resetCh <- struct{}{}
+	}
 
 	// Close clients that have moved accounts
 	for _, client := range cclients {

--- a/server/server.go
+++ b/server/server.go
@@ -515,8 +515,6 @@ func (s *Server) configureAccounts() error {
 			s.mu.Unlock()
 			// acquires server lock separately
 			s.addSystemAccountExports(acc)
-			// can't hold the lock as go routine reading it may be waiting for lock as well
-			s.sys.resetCh <- struct{}{}
 			s.mu.Lock()
 		}
 		if err != nil {


### PR DESCRIPTION
This does not avoid the race condition, but makes it less likely to trigger in unit tests.

Signed-off-by: Matthias Hanel <mh@synadia.com>
