### PR TITLE
initial gh actions

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -1,0 +1,53 @@
+name: NATS Server Testing
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go: [1.13, 1.14]
+
+    env:
+      GOPATH: /home/runner/work/nats-server
+      GO111MODULE: "off"
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+        with:
+          path: src/github.com/nats-io/nats-server
+
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{matrix.go}}
+
+      - name: Install deps
+        shell: bash --noprofile --norc -x -eo pipefail {0}
+        run: |
+          go get github.com/nats-io/nats.go/
+          go get github.com/nats-io/nkeys
+          go get github.com/nats-io/jwt
+          go get -u honnef.co/go/tools/cmd/staticcheck
+          go get -u github.com/client9/misspell/cmd/misspell
+
+      - name: Lint
+        shell: bash --noprofile --norc -x -eo pipefail {0}
+        run: |
+          GO_LIST=$(go list ./...)
+          go build
+          $(exit $(go fmt $GO_LIST | wc -l))
+          go vet $GO_LIST
+          find . -type f -name "*.go" | grep -v "/vendor/" | xargs $GOPATH/bin/misspell -error -locale US
+          $GOPATH/bin/staticcheck $GO_LIST
+
+      - name: Run tests
+        shell: bash --noprofile --norc -x -eo pipefail {0}
+        run: |
+          set -e
+          go test -i ./...
+          go test -v -run=TestNoRace --failfast -p=1 ./...
+          # coverage via cov.sh disabled while just testing the waters
+          go test -v -race -p=1 --failfast ./...
+          set +e

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [NATS](https://nats.io) is a simple, secure and performant communications system for digital systems, services and devices. NATS is part of the Cloud Native Computing Foundation ([CNCF](https://cncf.io)). NATS has over [30 client language implementations](https://nats.io/download/), and its server can run on-premise, in the cloud, at the edge, and even on a Raspberry Pi. NATS can secure and simplify design and operation of modern distributed systems.
 
-[![License][License-Image]][License-Url] [![FOSSA Status][Fossa-Image]][Fossa-Url] [![ReportCard][ReportCard-Image]][ReportCard-Url] [![Build][Build-Status-Image]][Build-Status-Url] [![Release][Release-Image]][Release-Url] [![Coverage][Coverage-Image]][Coverage-Url] [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1895/badge)](https://bestpractices.coreinfrastructure.org/projects/1895)
+[![License][License-Image]][License-Url] [![FOSSA Status][Fossa-Image]][Fossa-Url] [![ReportCard][ReportCard-Image]][ReportCard-Url] [![Build][Build-Status-Image]][Build-Status-Url] [![Release][Release-Image]][Release-Url] [![Coverage][Coverage-Image]][Coverage-Url] [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1895/badge)](https://bestpractices.coreinfrastructure.org/projects/1895) [![NATS Server Testing](https://github.com/nats-io/nats-server/workflows/NATS%20Server%20Testing/badge.svg)]
 
 ## Documentation
 


### PR DESCRIPTION
Adds basic GH Workflow that runs tests on push and pr, coverage
is disabled.

The intention is to soft switch to GH Actions by just letting them
run next to travs for a while to get a feel for things

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
