### PR TITLE
[FIXED] LameDuckMode sends INFO to clients

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3961,13 +3961,11 @@ func (c *client) teardownConn() {
 	}
 
 	if srv != nil {
-		// This is a route that disconnected, but we are not in lame duck mode...
-		if (len(connectURLs) > 0 || len(wsConnectURLs) > 0) && !srv.isLameDuckMode() {
-			// Unless disabled, possibly update the server's INFO protocol
-			// and send to clients that know how to handle async INFOs.
-			if !srv.getOpts().Cluster.NoAdvertise {
-				srv.removeConnectURLsAndSendINFOToClients(connectURLs, wsConnectURLs)
-			}
+		// If this is a route that disconnected, possibly send an INFO with
+		// the updated list of connect URLs to clients that know how to
+		// handle async INFOs.
+		if (len(connectURLs) > 0 || len(wsConnectURLs) > 0) && !srv.getOpts().Cluster.NoAdvertise {
+			srv.removeConnectURLsAndSendINFOToClients(connectURLs, wsConnectURLs)
 		}
 
 		// Unregister

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -36,14 +36,16 @@ import (
 )
 
 type serverInfo struct {
-	ID           string `json:"server_id"`
-	Host         string `json:"host"`
-	Port         uint   `json:"port"`
-	Version      string `json:"version"`
-	AuthRequired bool   `json:"auth_required"`
-	TLSRequired  bool   `json:"tls_required"`
-	MaxPayload   int64  `json:"max_payload"`
-	Headers      bool   `json:"headers"`
+	ID           string   `json:"server_id"`
+	Host         string   `json:"host"`
+	Port         uint     `json:"port"`
+	Version      string   `json:"version"`
+	AuthRequired bool     `json:"auth_required"`
+	TLSRequired  bool     `json:"tls_required"`
+	MaxPayload   int64    `json:"max_payload"`
+	Headers      bool     `json:"headers"`
+	ConnectURLs  []string `json:"connect_urls,omitempty"`
+	LameDuckMode bool     `json:"ldm,omitempty"`
 }
 
 type testAsyncClient struct {

--- a/server/server.go
+++ b/server/server.go
@@ -82,6 +82,7 @@ type Info struct {
 	Cluster           string   `json:"cluster,omitempty"`
 	ClientConnectURLs []string `json:"connect_urls,omitempty"`    // Contains URLs a client can connect to.
 	WSConnectURLs     []string `json:"ws_connect_urls,omitempty"` // Contains URLs a ws client can connect to.
+	LameDuckMode      bool     `json:"ldm,omitempty"`
 
 	// Route Specific
 	Import *SubjectPermission `json:"import,omitempty"`
@@ -620,11 +621,6 @@ func (s *Server) checkResolvePreloads() {
 }
 
 func (s *Server) generateRouteInfoJSON() {
-	// New proto wants a nonce.
-	var raw [nonceLen]byte
-	nonce := raw[:]
-	s.generateNonce(nonce)
-	s.routeInfo.Nonce = string(nonce)
 	b, _ := json.Marshal(s.routeInfo)
 	pcs := [][]byte{[]byte("INFO"), b, []byte(CR_LF)}
 	s.routeInfoJSON = bytes.Join(pcs, []byte(" "))
@@ -1835,13 +1831,6 @@ func (s *Server) copyInfo() Info {
 	if len(info.WSConnectURLs) > 0 {
 		info.WSConnectURLs = append([]string(nil), s.info.WSConnectURLs...)
 	}
-	if s.nonceRequired() {
-		// Nonce handling
-		var raw [nonceLen]byte
-		nonce := raw[:]
-		s.generateNonce(nonce)
-		info.Nonce = string(nonce)
-	}
 	return info
 }
 
@@ -1864,6 +1853,13 @@ func (s *Server) createClient(conn net.Conn, ws *websocket) *client {
 	// Grab JSON info string
 	s.mu.Lock()
 	info := s.copyInfo()
+	if s.nonceRequired() {
+		// Nonce handling
+		var raw [nonceLen]byte
+		nonce := raw[:]
+		s.generateNonce(nonce)
+		info.Nonce = string(nonce)
+	}
 	c.nonce = []byte(info.Nonce)
 	s.totalClients++
 	s.mu.Unlock()
@@ -2691,6 +2687,8 @@ func (s *Server) lameDuckMode() {
 	s.ldmCh = make(chan bool, 1)
 	s.listener.Close()
 	s.listener = nil
+	s.sendLDMToRoutes()
+	s.sendLDMToClients()
 	s.mu.Unlock()
 
 	// Wait for accept loop to be done to make sure that no new
@@ -2768,6 +2766,50 @@ func (s *Server) lameDuckMode() {
 		}
 	}
 	s.Shutdown()
+}
+
+// Send an INFO update to routes with the indication that this server is in LDM mode.
+// Server lock is held on entry.
+func (s *Server) sendLDMToRoutes() {
+	s.routeInfo.LameDuckMode = true
+	s.generateRouteInfoJSON()
+	for _, r := range s.routes {
+		r.mu.Lock()
+		r.enqueueProto(s.routeInfoJSON)
+		r.mu.Unlock()
+	}
+	// Clear now so that we notify only once, should we have to send other INFOs.
+	s.routeInfo.LameDuckMode = false
+}
+
+// Send an INFO update to clients with the indication that this server is in
+// LDM mode and with only URLs of other nodes.
+// Server lock is held on entry.
+func (s *Server) sendLDMToClients() {
+	s.info.LameDuckMode = true
+	// Clear this so that if there are further updates, we don't send our URLs.
+	s.clientConnectURLs = s.clientConnectURLs[:0]
+	if s.websocket.connectURLs != nil {
+		s.websocket.connectURLs = s.websocket.connectURLs[:0]
+	}
+	// Reset content first.
+	s.info.ClientConnectURLs = s.info.ClientConnectURLs[:0]
+	s.info.WSConnectURLs = s.info.WSConnectURLs[:0]
+	// Only add the other nodes if we are allowed to.
+	if !s.getOpts().Cluster.NoAdvertise {
+		for url := range s.clientConnectURLsMap {
+			s.info.ClientConnectURLs = append(s.info.ClientConnectURLs, url)
+		}
+		for url := range s.websocket.connectURLsMap {
+			s.info.WSConnectURLs = append(s.info.WSConnectURLs, url)
+		}
+	}
+	// Send to all registered clients that support async INFO protocols.
+	s.sendAsyncInfoToClients(true, true)
+	// We now clear the info.LameDuckMode flag so that if there are
+	// cluster updates and we send the INFO, we don't have the boolean
+	// set which would cause multiple LDM notifications to clients.
+	s.info.LameDuckMode = false
 }
 
 // If given error is a net.Error and is temporary, sleeps for the given


### PR DESCRIPTION
Also send an INFO to routes so that the remotes can remove the
LDM's server client URLs and notify their own clients of this
change.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

