### PR TITLE
create advisories for stream and consumer add/delete/modify

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -88,14 +88,6 @@ type ServerStatsMsg struct {
 	Stats  ServerStats `json:"statsz"`
 }
 
-// TypedEvent is a event or advisory sent by the server that has nats type hints
-// typically used for events that might be consumed by 3rd party event systems
-type TypedEvent struct {
-	Type string    `json:"type"`
-	ID   string    `json:"id"`
-	Time time.Time `json:"timestamp"`
-}
-
 // ConnectEventMsg is sent when a new connection is made that is part of an account.
 type ConnectEventMsg struct {
 	TypedEvent
@@ -220,6 +212,14 @@ type pubMsg struct {
 type serverUpdate struct {
 	seq   uint64
 	ltime time.Time
+}
+
+// TypedEvent is a event or advisory sent by the server that has nats type hints
+// typically used for events that might be consumed by 3rd party event systems
+type TypedEvent struct {
+	Type string    `json:"type"`
+	ID   string    `json:"id"`
+	Time time.Time `json:"timestamp"`
 }
 
 // internalSendLoop will be responsible for serializing all messages that

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -146,6 +146,21 @@ const (
 	// JetStreamAdvisoryConsumerMaxDeliveryExceedPre is a notification published when a message exceeds its delivery threshold.
 	JSAdvisoryConsumerMaxDeliveryExceedPre = "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES"
 
+	// JSAdvisoryStreamCreatedPre notification that a stream was created
+	JSAdvisoryStreamCreatedPre = "$JS.EVENT.ADVISORY.STREAM.CREATED"
+
+	// JSAdvisoryStreamDeletedPre notification that a stream was deleted
+	JSAdvisoryStreamDeletedPre = "$JS.EVENT.ADVISORY.STREAM.DELETED"
+
+	// JSAdvisoryStreamUpdatedPre notification that a stream was updated
+	JSAdvisoryStreamUpdatedPre = "$JS.EVENT.ADVISORY.STREAM.UPDATED"
+
+	// JSAdvisoryConsumerCreatedPre notification that a template created
+	JSAdvisoryConsumerCreatedPre = "$JS.EVENT.ADVISORY.CONSUMER.CREATED"
+
+	// JSAdvisoryConsumerDeletedPre notification that a template deleted
+	JSAdvisoryConsumerDeletedPre = "$JS.EVENT.ADVISORY.CONSUMER.DELETED"
+
 	// JetStreamAPIAuditAdvisory is a notification about JetStream API access.
 	// FIXME - Add in details about who..
 	JSAuditAdvisory = "$JS.EVENT.ADVISORY.API"
@@ -1284,32 +1299,6 @@ func (s *Server) jsConsumerDeleteRequest(sub *subscription, c *client, subject, 
 	s.sendAPIResponse(c, subject, reply, string(msg), s.jsonResponse(resp))
 }
 
-// For delivering advisories for API calls.
-
-// ClientAPIAudit is for identifying a client who initiated an API call to the system.
-type ClientAPIAudit struct {
-	Host     string `json:"host"`
-	Port     int    `json:"port"`
-	CID      uint64 `json:"cid"`
-	Account  string `json:"account"`
-	User     string `json:"user,omitempty"`
-	Name     string `json:"name,omitempty"`
-	Language string `json:"lang,omitempty"`
-	Version  string `json:"version,omitempty"`
-}
-
-// JetStreamAPIAudit is an advisory about administrative actions taken on JetStream
-type JetStreamAPIAudit struct {
-	TypedEvent
-	Server   string         `json:"server"`
-	Client   ClientAPIAudit `json:"client"`
-	Subject  string         `json:"subject"`
-	Request  string         `json:"request,omitempty"`
-	Response string         `json:"response"`
-}
-
-const auditType = "io.nats.jetstream.advisory.v1.api_audit"
-
 // sendJetStreamAPIAuditAdvisor will send the audit event for a given event.
 func (s *Server) sendJetStreamAPIAuditAdvisory(c *client, subject, request, response string) {
 	c.mu.Lock()
@@ -1321,9 +1310,9 @@ func (s *Server) sendJetStreamAPIAuditAdvisory(c *client, subject, request, resp
 	cid := c.cid
 	c.mu.Unlock()
 
-	e := &JetStreamAPIAudit{
+	e := JSAPIAudit{
 		TypedEvent: TypedEvent{
-			Type: auditType,
+			Type: JSAPIAuditType,
 			ID:   nuid.Next(),
 			Time: time.Now().UTC(),
 		},

--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -1,0 +1,84 @@
+package server
+
+// ClientAPIAudit is for identifying a client who initiated an API call to the system.
+type ClientAPIAudit struct {
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+	CID      uint64 `json:"cid"`
+	Account  string `json:"account"`
+	User     string `json:"user,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Language string `json:"lang,omitempty"`
+	Version  string `json:"version,omitempty"`
+}
+
+// JSAPIAudit is an advisory about administrative actions taken on JetStream
+type JSAPIAudit struct {
+	TypedEvent
+	Server   string         `json:"server"`
+	Client   ClientAPIAudit `json:"client"`
+	Subject  string         `json:"subject"`
+	Request  string         `json:"request,omitempty"`
+	Response string         `json:"response"`
+}
+
+const JSAPIAuditType = "io.nats.jetstream.advisory.v1.api_audit"
+
+// ActionAdvisoryType indicates which action against a stream, consumer or template triggered an advisory
+type ActionAdvisoryType string
+
+const (
+	CreateEvent ActionAdvisoryType = "create"
+	DeleteEvent ActionAdvisoryType = "delete"
+	ModifyEvent ActionAdvisoryType = "modify"
+)
+
+// JSStreamActionAdvisory indicates that a stream was created, edited or deleted
+type JSStreamActionAdvisory struct {
+	TypedEvent
+	Stream                string             `json:"stream"`
+	Action                ActionAdvisoryType `json:"action"`
+	Template              string             `json:"template,omitempty"`
+	OriginalConfiguration *StreamConfig      `json:"original,omitempty"`
+	NewConfiguration      *StreamConfig      `json:"new,omitempty"`
+}
+
+const JSStreamActionAdvisoryType = "io.nats.jetstream.advisory.v1.stream_action"
+
+// JSConsumerActionAdvisory indicates that a consumer was created or deleted
+type JSConsumerActionAdvisory struct {
+	TypedEvent
+	Stream   string             `json:"stream"`
+	Consumer string             `json:"consumer"`
+	Action   ActionAdvisoryType `json:"action"`
+}
+
+const JSConsumerActionAdvisoryType = "io.nats.jetstream.advisory.v1.consumer_action"
+
+// JSConsumerAckMetric is a metric published when a user acknowledges a message, the
+// number of these that will be published is dependent on SampleFrequency
+type JSConsumerAckMetric struct {
+	TypedEvent
+	Stream      string `json:"stream"`
+	Consumer    string `json:"consumer"`
+	ConsumerSeq uint64 `json:"consumer_seq"`
+	StreamSeq   uint64 `json:"stream_seq"`
+	Delay       int64  `json:"ack_time"`
+	Deliveries  uint64 `json:"deliveries"`
+}
+
+// JSConsumerAckMetricType is the schema type for JSConsumerAckMetricType
+const JSConsumerAckMetricType = "io.nats.jetstream.metric.v1.consumer_ack"
+
+// JSConsumerDeliveryExceededAdvisory is an advisory informing that a message hit
+// its MaxDeliver threshold and so might be a candidate for DLQ handling
+type JSConsumerDeliveryExceededAdvisory struct {
+	TypedEvent
+	Stream     string `json:"stream"`
+	Consumer   string `json:"consumer"`
+	StreamSeq  uint64 `json:"stream_seq"`
+	Deliveries uint64 `json:"deliveries"`
+}
+
+// JSConsumerDeliveryExceededAdvisoryType is the schema type for JSConsumerDeliveryExceededAdvisory
+const JSConsumerDeliveryExceededAdvisoryType = "io.nats.jetstream.advisory.v1.max_deliver"


### PR DESCRIPTION
We now publish advisories when streams and consumers are added,
deleted and modified

Also rework how TypedEvents are created to be easier to use

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
