### PR TITLE
removes the configuration from advisories

### DIFF
--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -36,11 +36,9 @@ const (
 // JSStreamActionAdvisory indicates that a stream was created, edited or deleted
 type JSStreamActionAdvisory struct {
 	TypedEvent
-	Stream                string             `json:"stream"`
-	Action                ActionAdvisoryType `json:"action"`
-	Template              string             `json:"template,omitempty"`
-	OriginalConfiguration *StreamConfig      `json:"original,omitempty"`
-	NewConfiguration      *StreamConfig      `json:"new,omitempty"`
+	Stream   string             `json:"stream"`
+	Action   ActionAdvisoryType `json:"action"`
+	Template string             `json:"template,omitempty"`
 }
 
 const JSStreamActionAdvisoryType = "io.nats.jetstream.advisory.v1.stream_action"

--- a/server/stream.go
+++ b/server/stream.go
@@ -225,7 +225,7 @@ func (mset *Stream) sendDeleteAdvisoryLocked() {
 	}
 }
 
-func (mset *Stream) sendUpdateAdvisoryLocked(old, new StreamConfig) {
+func (mset *Stream) sendUpdateAdvisoryLocked() {
 	if mset.sendq == nil {
 		return
 	}
@@ -236,10 +236,8 @@ func (mset *Stream) sendUpdateAdvisoryLocked(old, new StreamConfig) {
 			ID:   nuid.Next(),
 			Time: time.Now().UTC(),
 		},
-		Stream:                mset.config.Name,
-		Action:                ModifyEvent,
-		OriginalConfiguration: &old,
-		NewConfiguration:      &new,
+		Stream: mset.config.Name,
+		Action: ModifyEvent,
 	}
 
 	j, err := json.MarshalIndent(m, "", "  ")
@@ -436,7 +434,7 @@ func (mset *Stream) Update(config *StreamConfig) error {
 	mset.config = cfg
 	mset.store.UpdateConfig(&cfg)
 
-	mset.sendUpdateAdvisoryLocked(o_cfg, cfg)
+	mset.sendUpdateAdvisoryLocked()
 
 	return nil
 }


### PR DESCRIPTION
On reflection I think this is a bad idea,
it's enough to know there was a change we
do not need to expose this to potential 3rd
parties

Also since advisories are versioned but
configuration is not, this is awkward.

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
