### PR TITLE
Don't allow JetStream on system account. 

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -176,7 +176,7 @@ func (s *Server) checkAuthforWarnings() {
 	}
 	if warn {
 		// Warning about using plaintext passwords.
-		s.Warnf("Plaintext passwords detected, use nkeys or bcrypt.")
+		s.Warnf("Plaintext passwords detected, use nkeys or bcrypt")
 	}
 }
 

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -366,6 +366,9 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 	if js == nil {
 		return fmt.Errorf("jetstream not enabled")
 	}
+	if s.SystemAccount() == a {
+		return fmt.Errorf("jetstream can not be enabled on the system account")
+	}
 
 	// No limits means we dynamically set up limits.
 	if limits == nil {

--- a/server/opts.go
+++ b/server/opts.go
@@ -1243,7 +1243,6 @@ func parseJetStreamForAccount(v interface{}, acc *Account, errors *[]error, warn
 	default:
 		return &configErr{tk, fmt.Sprintf("Expected map, bool or string to define JetStream, got %T", v)}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Also warn when accounts configured but JetStream is not enabled.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
