### PR TITLE
Support all bcrypt versions

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
 	"time"
 
@@ -728,11 +729,11 @@ func (s *Server) isLeafNodeAuthorized(c *client) bool {
 }
 
 // Support for bcrypt stored passwords and tokens.
-const bcryptPrefix = "$2a$"
+var validBcryptPrefix = regexp.MustCompile(`^\$2[a,b,x,y]{1}\$\d{2}\$.*`)
 
 // isBcrypt checks whether the given password or token is bcrypted.
 func isBcrypt(password string) bool {
-	return strings.HasPrefix(password, bcryptPrefix)
+	return validBcryptPrefix.MatchString(password)
 }
 
 func comparePasswords(serverPassword, clientPassword string) bool {


### PR DESCRIPTION
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request:

 - Support all bcrypt versions, see https://en.wikipedia.org/wiki/Bcrypt#Versioning_history

/cc @nats-io/core
