### PR TITLE
JetStream Snapshots

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1289,6 +1289,27 @@ func (a *Account) internalClient() *client {
 	return a.ic
 }
 
+// Internal account scoped subscriptions.
+func (a *Account) subscribeInternal(c *client, subject string, cb msgHandler) (*subscription, error) {
+	a.mu.Lock()
+	sid := strconv.FormatUint(a.isid+1, 10)
+	a.isid++
+	a.mu.Unlock()
+
+	// This will happen in parsing when the account has not been properly setup.
+	if c == nil {
+		return nil, fmt.Errorf("no internal account client")
+	}
+
+	sub, err := c.processSub([]byte(subject+" "+sid), true)
+	if err != nil {
+		return nil, err
+	}
+
+	sub.icb = cb
+	return sub, nil
+}
+
 // This will add an account subscription that matches the "from" from a service import entry.
 func (a *Account) addServiceImportSub(si *serviceImport) error {
 	a.mu.Lock()

--- a/server/client.go
+++ b/server/client.go
@@ -2740,13 +2740,8 @@ func (c *client) deliverMsg(sub *subscription, subject, mh, msg []byte, gwrply b
 	client.outBytes += msgSize
 
 	// Check for internal subscriptions.
-	if client.kind == SYSTEM || client.kind == JETSTREAM || client.kind == ACCOUNT {
-		s := client.srv
+	if sub.icb != nil || client.kind == SYSTEM || client.kind == JETSTREAM || client.kind == ACCOUNT {
 		client.mu.Unlock()
-		if sub.icb == nil {
-			s.Debugf("Received internal callback with no registered handler")
-			return false
-		}
 		// Internal account clients are for service imports and need the
 		// complete raw msg with '\r\n'.
 		if client.kind == ACCOUNT {

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1086,18 +1086,18 @@ func (fs *fileStore) writeMsgRecord(seq uint64, subj string, msg []byte) (uint64
 	fs.wmb.Write(msg)
 
 	// Calculate hash.
-	hh := fs.lmb.hh
-	hh.Reset()
-	hh.Write(hdr[4:20])
-	hh.Write([]byte(subj))
-	hh.Write(msg)
-	checksum := hh.Sum(nil)
-	// Write to msg record.
-	fs.wmb.Write(checksum)
-	// Grab last checksum
 	mb.mu.Lock()
+	mb.hh.Reset()
+	mb.hh.Write(hdr[4:20])
+	mb.hh.Write([]byte(subj))
+	mb.hh.Write(msg)
+	checksum := mb.hh.Sum(nil)
+	// Grab last checksum
 	copy(mb.lchk[0:], checksum)
 	mb.mu.Unlock()
+
+	// Write to msg record.
+	fs.wmb.Write(checksum)
 
 	return rl, ts, nil
 }

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -14,9 +14,10 @@
 package server
 
 import (
-	"archive/zip"
+	"archive/tar"
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -27,6 +28,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
+	"net"
 	"os"
 	"path"
 	"sort"
@@ -226,7 +228,7 @@ func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created tim
 	}
 
 	// Create highway hash for message blocks. Use sha256 of directory as key.
-	key := sha256.Sum256([]byte(mdir))
+	key := sha256.Sum256([]byte(cfg.Name))
 	fs.hh, err = highwayhash.New64(key[:])
 	if err != nil {
 		return nil, fmt.Errorf("could not create hash: %v", err)
@@ -342,7 +344,7 @@ func (fs *fileStore) recoverMsgBlock(fi os.FileInfo, index uint64) *msgBlock {
 	mb.ifn = path.Join(mdir, fmt.Sprintf(indexScan, index))
 
 	if mb.hh == nil {
-		key := sha256.Sum256([]byte(mdir))
+		key := sha256.Sum256(fs.hashKeyForBlock(index))
 		mb.hh, _ = highwayhash.New64(key[:])
 	}
 
@@ -364,7 +366,6 @@ func (fs *fileStore) recoverMsgBlock(fi os.FileInfo, index uint64) *msgBlock {
 			fs.blks = append(fs.blks, mb)
 			return mb
 		}
-
 		// Fall back on the data file itself. We will keep the delete map if present.
 		mb.msgs = 0
 		mb.bytes = 0
@@ -421,6 +422,7 @@ func (fs *fileStore) recoverMsgs() error {
 	if err != nil {
 		return fmt.Errorf("storage directory not readable")
 	}
+
 	// Recover all of the msg blocks.
 	// These can come in a random order, so account for that.
 	for _, fi := range fis {
@@ -511,6 +513,12 @@ func (fs *fileStore) StorageBytesUpdate(cb func(int64)) {
 	}
 }
 
+// Helper to get hash key for specific message block.
+// Lock should be held
+func (fs *fileStore) hashKeyForBlock(index uint64) []byte {
+	return []byte(fmt.Sprintf("%s-%d", fs.cfg.Name, index))
+}
+
 // This rolls to a new append msg block.
 // Lock should be held.
 func (fs *fileStore) newMsgBlockForWrite() (*msgBlock, error) {
@@ -542,8 +550,7 @@ func (fs *fileStore) newMsgBlockForWrite() (*msgBlock, error) {
 	mb.ifd = ifd
 
 	// Now do local hash.
-	// TODO(dlc) - make specific to the file vs msgDir?
-	key := sha256.Sum256([]byte(mdir))
+	key := sha256.Sum256(fs.hashKeyForBlock(index))
 	mb.hh, err = highwayhash.New64(key[:])
 	if err != nil {
 		return nil, fmt.Errorf("could not create hash: %v", err)
@@ -955,9 +962,6 @@ func (fs *fileStore) checkMsgs() []uint64 {
 		return nil
 	}
 
-	key := sha256.Sum256([]byte(mdir))
-	hh, _ := highwayhash.New64(key[:])
-
 	var bad []uint64
 
 	// Check all of the msg blocks.
@@ -967,6 +971,8 @@ func (fs *fileStore) checkMsgs() []uint64 {
 			if fp, err := os.Open(path.Join(mdir, fi.Name())); err != nil {
 				continue
 			} else {
+				key := sha256.Sum256(fs.hashKeyForBlock(index))
+				hh, _ := highwayhash.New64(key[:])
 				bad = append(bad, checkMsgBlockFile(fp, hh)...)
 				fp.Close()
 			}
@@ -1080,11 +1086,12 @@ func (fs *fileStore) writeMsgRecord(seq uint64, subj string, msg []byte) (uint64
 	fs.wmb.Write(msg)
 
 	// Calculate hash.
-	fs.hh.Reset()
-	fs.hh.Write(hdr[4:20])
-	fs.hh.Write([]byte(subj))
-	fs.hh.Write(msg)
-	checksum := fs.hh.Sum(nil)
+	hh := fs.lmb.hh
+	hh.Reset()
+	hh.Write(hdr[4:20])
+	hh.Write([]byte(subj))
+	hh.Write(msg)
+	checksum := hh.Sum(nil)
 	// Write to msg record.
 	fs.wmb.Write(checksum)
 	// Grab last checksum
@@ -1129,11 +1136,11 @@ func (fs *fileStore) eraseMsg(mb *msgBlock, sm *fileStoredMsg) error {
 	wmb.Write(sm.msg)
 
 	// Calculate hash.
-	fs.hh.Reset()
-	fs.hh.Write(hdr[4:20])
-	fs.hh.Write([]byte(sm.subj))
-	fs.hh.Write(sm.msg)
-	checksum := fs.hh.Sum(nil)
+	mb.hh.Reset()
+	mb.hh.Write(hdr[4:20])
+	mb.hh.Write([]byte(sm.subj))
+	mb.hh.Write(sm.msg)
+	checksum := mb.hh.Sum(nil)
 	// Write to msg record.
 	wmb.Write(checksum)
 
@@ -1644,6 +1651,7 @@ func (mb *msgBlock) readIndexInfo() error {
 	mb.last.seq = readSeq()
 	mb.last.ts = readTimeStamp()
 	dmapLen := readCount()
+
 	// Checksum
 	copy(mb.lchk[0:], buf[bi:bi+checksumSize])
 	bi += checksumSize
@@ -1936,22 +1944,39 @@ func (fs *fileStore) Stop() error {
 
 const errFile = "errors.txt"
 
-// Stream our snapshot through zip.
-func (fs *fileStore) streamSnapshot(w io.Closer, zw *zip.Writer) {
+// Stream our snapshot through gzip and tar.
+func (fs *fileStore) streamSnapshot(w io.WriteCloser, includeConsumers bool) {
 	defer w.Close()
-	defer zw.Close()
+
+	gzw := gzip.NewWriter(w)
+	defer gzw.Close()
+
+	tw := tar.NewWriter(gzw)
+	defer tw.Close()
+
 	defer func() {
 		fs.mu.Lock()
 		fs.sips--
 		fs.mu.Unlock()
 	}()
 
-	// We want to grab the stream and consumers to snapshot their state.
-	// We will grab the messages after that.
+	writeFile := func(name string, buf []byte) error {
+		hdr := &tar.Header{
+			Name: name,
+			Mode: 0600,
+			Size: int64(len(buf)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if _, err := tw.Write(buf); err != nil {
+			return err
+		}
+		return nil
+	}
 
 	writeErr := func(err string) {
-		f, _ := zw.Create(errFile)
-		f.Write([]byte(err))
+		writeFile(errFile, []byte(err))
 	}
 
 	fs.mu.Lock()
@@ -1975,18 +2000,6 @@ func (fs *fileStore) streamSnapshot(w io.Closer, zw *zip.Writer) {
 	}
 	fs.mu.Unlock()
 
-	writeFile := func(name string, buf []byte) error {
-		f, err := zw.Create(name)
-		if err != nil {
-			return err
-		}
-		_, err = f.Write(meta)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
 	// Meta first.
 	if writeFile(JetStreamMetaFile, meta) != nil {
 		return
@@ -1994,8 +2007,6 @@ func (fs *fileStore) streamSnapshot(w io.Closer, zw *zip.Writer) {
 	if writeFile(JetStreamMetaFileSum, sum) != nil {
 		return
 	}
-
-	// FIXME(dlc) - Do templates
 
 	// Now do messages themselves.
 	fs.mu.Lock()
@@ -2036,6 +2047,12 @@ func (fs *fileStore) streamSnapshot(w io.Closer, zw *zip.Writer) {
 			return
 		}
 	}
+
+	// Bail if no consumers requested.
+	if !includeConsumers {
+		return
+	}
+
 	// Do consumers' state last.
 	fs.mu.Lock()
 	cfs := fs.cfs
@@ -2066,29 +2083,37 @@ func (fs *fileStore) streamSnapshot(w io.Closer, zw *zip.Writer) {
 		o.mu.Unlock()
 
 		// Write all the consumer files.
-		if writeFile(odirPre+"/"+JetStreamMetaFile, meta) != nil {
+		if writeFile(path.Join(odirPre, JetStreamMetaFile), meta) != nil {
 			return
 		}
-		if writeFile(odirPre+"/"+JetStreamMetaFileSum, sum) != nil {
+		if writeFile(path.Join(odirPre, JetStreamMetaFileSum), sum) != nil {
 			return
 		}
-		writeFile(odirPre+"/"+consumerState, state)
+		writeFile(path.Join(odirPre, consumerState), state)
 	}
 }
 
 // Create a snapshot of this stream and its consumer's state along with messages.
-func (fs *fileStore) Snapshot() (io.ReadCloser, error) {
+func (fs *fileStore) Snapshot(deadline time.Duration, includeConsumers bool) (io.ReadCloser, error) {
 	fs.mu.Lock()
 	if fs.closed {
 		fs.mu.Unlock()
 		return nil, ErrStoreClosed
 	}
+	// Only allow one at a time.
+	if fs.sips > 0 {
+		fs.mu.Unlock()
+		return nil, ErrStoreSnapshotInProgress
+	}
 	// Mark us as snapshotting
 	fs.sips += 1
 	fs.mu.Unlock()
 
-	pr, pw := io.Pipe()
-	go fs.streamSnapshot(pw, zip.NewWriter(pw))
+	pr, pw := net.Pipe()
+	// Set a write deadline here to protect ourselves.
+	pw.SetWriteDeadline(time.Now().Add(deadline))
+	// Stream in separate Go routine.
+	go fs.streamSnapshot(pw, includeConsumers)
 
 	return pr, nil
 }
@@ -2136,7 +2161,7 @@ func (fs *fileStore) ConsumerStore(name string, cfg *ConsumerConfig) (ConsumerSt
 		fch:  make(chan struct{}),
 		qch:  make(chan struct{}),
 	}
-	key := sha256.Sum256([]byte(odir))
+	key := sha256.Sum256([]byte(fs.cfg.Name + "/" + name))
 	hh, err := highwayhash.New64(key[:])
 	if err != nil {
 		return nil, fmt.Errorf("could not create hash: %v", err)
@@ -2466,7 +2491,7 @@ type templateFileStore struct {
 
 func newTemplateFileStore(storeDir string) *templateFileStore {
 	tdir := path.Join(storeDir, tmplsDir)
-	key := sha256.Sum256([]byte(tdir))
+	key := sha256.Sum256([]byte("templates"))
 	hh, err := highwayhash.New64(key[:])
 	if err != nil {
 		return nil

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -14,8 +14,9 @@
 package server
 
 import (
-	"archive/zip"
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -1075,7 +1076,7 @@ func TestFileStoreSnapshot(t *testing.T) {
 	subj, msg := "foo", []byte("Hello Snappy!")
 
 	fs, err := newFileStore(
-		FileStoreConfig{StoreDir: storeDir, BlockSize: 1024},
+		FileStoreConfig{StoreDir: storeDir},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
 	if err != nil {
@@ -1115,7 +1116,7 @@ func TestFileStoreSnapshot(t *testing.T) {
 
 	snapshot := func() []byte {
 		t.Helper()
-		r, err := fs.Snapshot()
+		r, err := fs.Snapshot(5*time.Second, true)
 		if err != nil {
 			t.Fatalf("Error creating snapshot")
 		}
@@ -1130,32 +1131,39 @@ func TestFileStoreSnapshot(t *testing.T) {
 	// We will compare the states for this vs the original one.
 	verifySnapshot := func(snap []byte) {
 		r := bytes.NewReader(snap)
-		zr, _ := zip.NewReader(r, int64(len(snap)))
+		gzr, err := gzip.NewReader(r)
+		if err != nil {
+			t.Fatalf("Error creating gzip reader: %v", err)
+		}
+		defer gzr.Close()
+		tr := tar.NewReader(gzr)
 
 		rstoreDir, _ := ioutil.TempDir("", JetStreamStoreDir)
-		sdir := path.Join(rstoreDir, "$G", "streams")
-		os.MkdirAll(sdir, 0755)
 		defer os.RemoveAll(rstoreDir)
 
-		for _, f := range zr.File {
-			rc, err := f.Open()
-			if err != nil {
-				t.Fatalf("Error opening file in zip file: %v", err)
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break // End of archive
 			}
-			fpath := path.Join(sdir, filepath.Clean(f.Name))
+			if err != nil {
+				t.Fatalf("Error getting next entry from snapshot: %v", err)
+			}
+			fpath := path.Join(rstoreDir, filepath.Clean(hdr.Name))
 			pdir := filepath.Dir(fpath)
 			os.MkdirAll(pdir, 0755)
-			fd, err := os.OpenFile(fpath, os.O_CREATE|os.O_RDWR, f.Mode())
+			fd, err := os.OpenFile(fpath, os.O_CREATE|os.O_RDWR, 0600)
 			if err != nil {
 				t.Fatalf("Error opening file[%s]: %v", fpath, err)
 			}
-			if _, err := io.Copy(fd, rc); err != nil {
+			if _, err := io.Copy(fd, tr); err != nil {
 				t.Fatalf("Error writing file[%s]: %v", fpath, err)
 			}
-			rc.Close()
+			fd.Close()
 		}
+
 		fsr, err := newFileStore(
-			FileStoreConfig{StoreDir: storeDir},
+			FileStoreConfig{StoreDir: rstoreDir},
 			StreamConfig{Name: "zzz", Storage: FileStorage},
 		)
 		if err != nil {
@@ -1167,6 +1175,7 @@ func TestFileStoreSnapshot(t *testing.T) {
 		// FIXME(dlc)
 		// Right now the upper layers in JetStream recover the consumers and do not expect
 		// the lower layers to do that. So for now blank that out of our original state.
+		// Will have more exhaustive tests in jetstream_test.go.
 		state.Consumers = 0
 
 		// FIXME(dlc) - Also the hashes will not match if directory is not the same, so need to
@@ -1203,7 +1212,7 @@ func TestFileStoreSnapshot(t *testing.T) {
 	// Now check to make sure that we get the correct error when trying to delete or erase
 	// a message when a snapshot is in progress and that closing the reader releases that condition.
 
-	r, err := fs.Snapshot()
+	r, err := fs.Snapshot(5*time.Second, true)
 	if err != nil {
 		t.Fatalf("Error creating snapshot")
 	}
@@ -1222,6 +1231,23 @@ func TestFileStoreSnapshot(t *testing.T) {
 		}
 		return nil
 	})
+
+	// Make sure if we do not read properly then it will close the writer and report an error.
+	r, err = fs.Snapshot(10*time.Millisecond, false)
+	if err != nil {
+		t.Fatalf("Error creating snapshot")
+	}
+	var buf [32]byte
+
+	if n, err := r.Read(buf[:]); err != nil || n == 0 {
+		t.Fatalf("Expected to read beginning, got %v and %d", err, n)
+	}
+	// Cause snapshot to timeout.
+	time.Sleep(20 * time.Millisecond)
+	// Read again should fail
+	if _, err := r.Read(buf[:]); err != io.EOF {
+		t.Fatalf("Expected read to produce an error, got none")
+	}
 }
 
 func TestFileStoreConsumer(t *testing.T) {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -15,7 +15,6 @@ package server
 
 import (
 	"fmt"
-	"io"
 	"math/rand"
 	"sort"
 	"sync"
@@ -382,7 +381,7 @@ func (ms *memStore) ConsumerStore(_ string, _ *ConsumerConfig) (ConsumerStore, e
 	return &consumerMemStore{ms}, nil
 }
 
-func (ms *memStore) Snapshot(_ time.Duration, _ bool) (io.ReadCloser, error) {
+func (ms *memStore) Snapshot(_ time.Duration, _ bool) (*SnapshotResult, error) {
 	return nil, fmt.Errorf("no impl")
 }
 

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -382,7 +382,7 @@ func (ms *memStore) ConsumerStore(_ string, _ *ConsumerConfig) (ConsumerStore, e
 	return &consumerMemStore{ms}, nil
 }
 
-func (ms *memStore) Snapshot() (io.ReadCloser, error) {
+func (ms *memStore) Snapshot(_ time.Duration, _ bool) (io.ReadCloser, error) {
 	return nil, fmt.Errorf("no impl")
 }
 

--- a/server/store.go
+++ b/server/store.go
@@ -63,7 +63,7 @@ type StreamStore interface {
 	Delete() error
 	Stop() error
 	ConsumerStore(name string, cfg *ConsumerConfig) (ConsumerStore, error)
-	Snapshot(deadline time.Duration, includeConsumers bool) (io.ReadCloser, error)
+	Snapshot(deadline time.Duration, includeConsumers bool) (*SnapshotResult, error)
 }
 
 // RetentionPolicy determines how messages in a set are retained.
@@ -99,6 +99,13 @@ type StreamState struct {
 	LastSeq   uint64    `json:"last_seq"`
 	LastTime  time.Time `json:"last_ts"`
 	Consumers int       `json:"consumer_count"`
+}
+
+// SnapshotResult contains information about the snapshot.
+type SnapshotResult struct {
+	Reader  io.ReadCloser
+	BlkSize int
+	NumBlks int
 }
 
 // ConsumerStore stores state on consumers for streams.

--- a/server/store.go
+++ b/server/store.go
@@ -63,7 +63,7 @@ type StreamStore interface {
 	Delete() error
 	Stop() error
 	ConsumerStore(name string, cfg *ConsumerConfig) (ConsumerStore, error)
-	Snapshot() (io.ReadCloser, error)
+	Snapshot(deadline time.Duration, includeConsumers bool) (io.ReadCloser, error)
 }
 
 // RetentionPolicy determines how messages in a set are retained.

--- a/server/stream.go
+++ b/server/stream.go
@@ -1001,7 +1001,7 @@ func (a *Account) RestoreStream(stream string, r io.Reader) (*Stream, error) {
 		}
 		fpath := path.Join(sdir, filepath.Clean(hdr.Name))
 		pdir := filepath.Dir(fpath)
-		os.MkdirAll(pdir, 0755)
+		os.MkdirAll(pdir, 0750)
 		fd, err := os.OpenFile(fpath, os.O_CREATE|os.O_RDWR, 0600)
 		if err != nil {
 			return nil, err

--- a/test/jetstream_test.go
+++ b/test/jetstream_test.go
@@ -2788,7 +2788,7 @@ func TestJetStreamSnapshotsAPI(t *testing.T) {
 		t.Fatalf("Unexpected error on snapshot request: %v", err)
 	}
 	json.Unmarshal(rmsg.Data, &resp)
-	if resp.Error == nil || resp.Error.Code != 400 || resp.Error.Description != "bad request" {
+	if resp.Error == nil || resp.Error.Code != 400 || resp.Error.Description != "deliver subject not valid" {
 		t.Fatalf("Did not get correct error response: %+v", resp.Error)
 	}
 
@@ -2801,8 +2801,9 @@ func TestJetStreamSnapshotsAPI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error on snapshot request: %v", err)
 	}
+	resp.Error = nil
 	json.Unmarshal(rmsg.Data, &resp)
-	if resp.Error == nil || resp.Error.Code != 400 || resp.Error.Description != "bad request" {
+	if resp.Error != nil {
 		t.Fatalf("Did not get correct error response: %+v", resp.Error)
 	}
 
@@ -2827,7 +2828,7 @@ func TestJetStreamSnapshotsAPI(t *testing.T) {
 	// Wait to receive the snapshot.
 	select {
 	case <-done:
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatalf("Did not receive our snapshot in time")
 	}
 

--- a/test/jetstream_test.go
+++ b/test/jetstream_test.go
@@ -68,11 +68,6 @@ func TestJetStreamBasicNilConfig(t *testing.T) {
 			t.Fatalf("Expected memory to be 80 percent of system memory, got %v vs %v", config.MaxMemory, est)
 		}
 	}
-	// Check store path, should be tmpdir.
-	expectedDir := filepath.Join(os.TempDir(), server.JetStreamStoreDir)
-	if config.StoreDir != expectedDir {
-		t.Fatalf("Expected storage directory of %q, but got %q", expectedDir, config.StoreDir)
-	}
 	// Make sure it was created.
 	stat, err := os.Stat(config.StoreDir)
 	if err != nil {
@@ -90,10 +85,11 @@ func RunBasicJetStreamServer() *server.Server {
 	return RunServer(&opts)
 }
 
-func RunJetStreamServerOnPort(port int) *server.Server {
+func RunJetStreamServerOnPort(port int, sd string) *server.Server {
 	opts := DefaultTestOptions
 	opts.Port = port
 	opts.JetStream = true
+	opts.StoreDir = filepath.Dir(sd)
 	return RunServer(&opts)
 }
 
@@ -2265,9 +2261,10 @@ func TestJetStreamEphemeralConsumerRecoveryAfterServerRestart(t *testing.T) {
 	restartServer := func() {
 		t.Helper()
 		// Stop current server.
+		sd := s.JetStreamConfig().StoreDir
 		s.Shutdown()
 		// Restart.
-		s = RunJetStreamServerOnPort(port)
+		s = RunJetStreamServerOnPort(port, sd)
 	}
 
 	// Do twice
@@ -2390,10 +2387,11 @@ func TestJetStreamConsumerMaxDeliveryAndServerRestart(t *testing.T) {
 
 	restartServer := func() {
 		t.Helper()
+		sd := s.JetStreamConfig().StoreDir
 		// Stop current server.
 		s.Shutdown()
 		// Restart.
-		s = RunJetStreamServerOnPort(port)
+		s = RunJetStreamServerOnPort(port, sd)
 	}
 
 	// Restart.
@@ -2473,11 +2471,16 @@ func TestJetStreamDeleteConsumerAndServerRestart(t *testing.T) {
 		t.Fatalf("Expected to have zero consumers, got %d", numo)
 	}
 
+	// Capture port since it was dynamic.
+	u, _ := url.Parse(s.ClientURL())
+	port, _ := strconv.Atoi(u.Port())
+	sd := s.JetStreamConfig().StoreDir
+
 	// Stop current server.
 	s.Shutdown()
 
 	// Restart.
-	s = RunBasicJetStreamServer()
+	s = RunJetStreamServerOnPort(port, sd)
 	defer s.Shutdown()
 
 	mset, err = s.GlobalAccount().LookupStream(sendSubj)
@@ -2540,11 +2543,16 @@ func TestJetStreamRedeliveryAfterServerRestart(t *testing.T) {
 		return nil
 	})
 
+	// Capture port since it was dynamic.
+	u, _ := url.Parse(s.ClientURL())
+	port, _ := strconv.Atoi(u.Port())
+	sd := s.JetStreamConfig().StoreDir
+
 	// Stop current server.
 	s.Shutdown()
 
 	// Restart.
-	s = RunBasicJetStreamServer()
+	s = RunJetStreamServerOnPort(port, sd)
 	defer s.Shutdown()
 
 	// Don't wait for reconnect from old client.
@@ -2560,6 +2568,140 @@ func TestJetStreamRedeliveryAfterServerRestart(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+func TestJetStreamSnapshots(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer s.Shutdown()
+
+	if config := s.JetStreamConfig(); config != nil {
+		defer os.RemoveAll(config.StoreDir)
+	}
+
+	mname := "MY-STREAM"
+	subjects := []string{"foo", "bar", "baz"}
+	cfg := server.StreamConfig{
+		Name:     mname,
+		Storage:  server.FileStorage,
+		Subjects: subjects,
+		MaxMsgs:  1000,
+	}
+
+	acc := s.GlobalAccount()
+	mset, err := acc.AddStream(&cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error adding stream: %v", err)
+	}
+
+	nc := clientConnectToServer(t, s)
+	defer nc.Close()
+
+	toSend := rand.Intn(100) + 1
+	for i := 1; i <= toSend; i++ {
+		msg := fmt.Sprintf("Hello World %d", i)
+		subj := subjects[rand.Intn(len(subjects))]
+		sendStreamMsg(t, nc, subj, msg)
+	}
+
+	// Create up to 10 consumers.
+	numConsumers := rand.Intn(10) + 1
+	var obs []obsi
+	for i := 1; i <= numConsumers; i++ {
+		cname := fmt.Sprintf("WQ-%d", i)
+		o, err := mset.AddConsumer(workerModeConfig(cname))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		// Now grab some messages.
+		toReceive := rand.Intn(toSend) + 1
+		for r := 0; r < toReceive; r++ {
+			resp, err := nc.Request(o.RequestNextMsgSubject(), nil, time.Second)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if resp != nil {
+				resp.Respond(nil)
+			}
+		}
+		obs = append(obs, obsi{o.Config(), toReceive})
+	}
+	// Snapshot state of the stream and consumers.
+	info := info{mset.Config(), mset.State(), obs}
+
+	zr, err := mset.Snapshot(5*time.Second, true)
+	if err != nil {
+		t.Fatalf("Error getting snapshot: %v", err)
+	}
+	snapshot, err := ioutil.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("Error reading snapshot")
+	}
+	// Try to restore from snapshot with current stream present, should error.
+	r := bytes.NewReader(snapshot)
+	if _, err := acc.RestoreStream(r); err == nil {
+		t.Fatalf("Expected an error trying to restore existing stream")
+	} else if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("Incorrect error received: %v", err)
+	}
+	// Now delete so we can restore.
+	pusage := acc.JetStreamUsage()
+	mset.Delete()
+	r.Reset(snapshot)
+
+	mset, err = acc.RestoreStream(r)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	// Now compare to make sure they are equal.
+	if nusage := acc.JetStreamUsage(); nusage != pusage {
+		t.Fatalf("Usage does not match after restore: %+v vs %+v", nusage, pusage)
+	}
+	if state := mset.State(); state != info.state {
+		t.Fatalf("State does not match: %+v vs %+v", state, info.state)
+	}
+	if cfg := mset.Config(); !reflect.DeepEqual(cfg, info.cfg) {
+		t.Fatalf("Configs do not match: %+v vs %+v", cfg, info.cfg)
+	}
+	// Consumers.
+	if mset.NumConsumers() != len(info.obs) {
+		t.Fatalf("Number of consumers do not match: %d vs %d", mset.NumConsumers(), len(info.obs))
+	}
+	for _, oi := range info.obs {
+		if o := mset.LookupConsumer(oi.cfg.Durable); o != nil {
+			if uint64(oi.ack+1) != o.NextSeq() {
+				t.Fatalf("Consumer next seq is not correct: %d vs %d", oi.ack+1, o.NextSeq())
+			}
+		} else {
+			t.Fatalf("Expected to get an consumer")
+		}
+	}
+
+	// Now try restoring to a different server.
+	s2 := RunBasicJetStreamServer()
+	defer s2.Shutdown()
+
+	if config := s2.JetStreamConfig(); config != nil && config.StoreDir != "" {
+		defer os.RemoveAll(config.StoreDir)
+	}
+	acc = s2.GlobalAccount()
+	r.Reset(snapshot)
+	mset, err = acc.RestoreStream(r)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	o := mset.LookupConsumer("WQ-1")
+	if o == nil {
+		t.Fatalf("Could not lookup consumer")
+	}
+
+	nc2 := clientConnectToServer(t, s2)
+	defer nc2.Close()
+
+	// Make sure we can read messages.
+	if _, err := nc2.Request(o.RequestNextMsgSubject(), nil, time.Second); err != nil {
+		t.Fatalf("Unexpected error getting next message: %v", err)
+	}
 }
 
 func TestJetStreamActiveDelivery(t *testing.T) {
@@ -4386,6 +4528,16 @@ func TestJetStreamStreamFileStorageTrackingAndLimits(t *testing.T) {
 	}
 }
 
+type obsi struct {
+	cfg server.ConsumerConfig
+	ack int
+}
+type info struct {
+	cfg   server.StreamConfig
+	state server.StreamState
+	obs   []obsi
+}
+
 func TestJetStreamSimpleFileStorageRecovery(t *testing.T) {
 	base := runtime.NumGoroutine()
 
@@ -4398,15 +4550,6 @@ func TestJetStreamSimpleFileStorageRecovery(t *testing.T) {
 
 	acc := s.GlobalAccount()
 
-	type obsi struct {
-		cfg server.ConsumerConfig
-		ack int
-	}
-	type info struct {
-		cfg   server.StreamConfig
-		state server.StreamState
-		obs   []obsi
-	}
 	ostate := make(map[string]info)
 
 	nid := nuid.New()
@@ -4464,6 +4607,11 @@ func TestJetStreamSimpleFileStorageRecovery(t *testing.T) {
 	pusage := acc.JetStreamUsage()
 
 	// Shutdown the server. Restart and make sure things come back.
+	// Capture port since it was dynamic.
+	u, _ := url.Parse(s.ClientURL())
+	port, _ := strconv.Atoi(u.Port())
+	sd := s.JetStreamConfig().StoreDir
+
 	s.Shutdown()
 
 	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
@@ -4474,7 +4622,7 @@ func TestJetStreamSimpleFileStorageRecovery(t *testing.T) {
 		return nil
 	})
 
-	s = RunBasicJetStreamServer()
+	s = RunJetStreamServerOnPort(port, sd)
 	defer s.Shutdown()
 
 	acc = s.GlobalAccount()
@@ -4490,7 +4638,7 @@ func TestJetStreamSimpleFileStorageRecovery(t *testing.T) {
 			t.Fatalf("Expected to find a stream for %q", mname)
 		}
 		if state := mset.State(); state != info.state {
-			t.Fatalf("Stats do not match: %+v vs %+v", state, info.state)
+			t.Fatalf("State does not match: %+v vs %+v", state, info.state)
 		}
 		if cfg := mset.Config(); !reflect.DeepEqual(cfg, info.cfg) {
 			t.Fatalf("Configs do not match: %+v vs %+v", cfg, info.cfg)
@@ -5382,9 +5530,10 @@ func TestJetStreamUpdateStream(t *testing.T) {
 				port, _ := strconv.Atoi(u.Port())
 
 				// Stop current server.
+				sd := s.JetStreamConfig().StoreDir
 				s.Shutdown()
 				// Restart.
-				s = RunJetStreamServerOnPort(port)
+				s = RunJetStreamServerOnPort(port, sd)
 				defer s.Shutdown()
 
 				mset, err = s.GlobalAccount().LookupStream(cfg.Name)
@@ -5508,10 +5657,15 @@ func TestJetStreamDeleteMsg(t *testing.T) {
 				return
 			}
 
+			// Capture port since it was dynamic.
+			u, _ := url.Parse(s.ClientURL())
+			port, _ := strconv.Atoi(u.Port())
+			sd := s.JetStreamConfig().StoreDir
+
 			// Shutdown the server.
 			s.Shutdown()
 
-			s = RunBasicJetStreamServer()
+			s = RunJetStreamServerOnPort(port, sd)
 			defer s.Shutdown()
 
 			mset, err = s.GlobalAccount().LookupStream("foo")
@@ -5773,10 +5927,11 @@ func TestJetStreamTemplateFileStoreRecovery(t *testing.T) {
 
 	restartServer := func() {
 		t.Helper()
+		sd := s.JetStreamConfig().StoreDir
 		// Stop current server.
 		s.Shutdown()
 		// Restart.
-		s = RunJetStreamServerOnPort(port)
+		s = RunJetStreamServerOnPort(port, sd)
 	}
 
 	// Restart.
@@ -6134,7 +6289,7 @@ func TestJetStreamServerResourcesConfig(t *testing.T) {
 ////////////////////////////////////////
 
 func TestJetStreamPubPerf(t *testing.T) {
-	// Uncomment to run, holding place for now.
+	// Comment out to run, holding place for now.
 	t.SkipNow()
 
 	s := RunBasicJetStreamServer()
@@ -6159,7 +6314,7 @@ func TestJetStreamPubPerf(t *testing.T) {
 	nc := clientConnectToServer(t, s)
 	defer nc.Close()
 
-	toSend := 2000000
+	toSend := 5000000
 	numProducers := 1
 
 	payload := []byte("Hello World")
@@ -6193,7 +6348,7 @@ func TestJetStreamPubPerf(t *testing.T) {
 }
 
 func TestJetStreamPubSubPerf(t *testing.T) {
-	// Uncomment to run, holding place for now.
+	// Comment out to run, holding place for now.
 	t.SkipNow()
 
 	s := RunBasicJetStreamServer()


### PR DESCRIPTION
We now support snapshots and restores for JetStream streams.
Snapshots are gzipped tar files of the file store directory for a stream.
This tries to protect the server and stream data and not bloat the server.

/cc @nats-io/core
