### PR TITLE
Add in a terminate delivery

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -161,8 +161,11 @@ const (
 	// JSMetricConsumerAckPre is a metric containing ack latency.
 	JSMetricConsumerAckPre = "$JS.EVENT.METRIC.CONSUMER.ACK"
 
-	// JetStreamAdvisoryConsumerMaxDeliveryExceedPre is a notification published when a message exceeds its delivery threshold.
+	// JSAdvisoryConsumerMaxDeliveryExceedPre is a notification published when a message exceeds its delivery threshold.
 	JSAdvisoryConsumerMaxDeliveryExceedPre = "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES"
+
+	// JSAdvisoryConsumerMsgTerminatedPre is a notification published when a message has been terminated.
+	JSAdvisoryConsumerMsgTerminatedPre = "$JS.EVENT.ADVISORY.CONSUMER.MSG_TERMINATED"
 
 	// JSAdvisoryStreamCreatedPre notification that a stream was created
 	JSAdvisoryStreamCreatedPre = "$JS.EVENT.ADVISORY.STREAM.CREATED"
@@ -179,7 +182,7 @@ const (
 	// JSAdvisoryConsumerDeletedPre notification that a template deleted
 	JSAdvisoryConsumerDeletedPre = "$JS.EVENT.ADVISORY.CONSUMER.DELETED"
 
-	// JetStreamAPIAuditAdvisory is a notification about JetStream API access.
+	// JSAuditAdvisory is a notification about JetStream API access.
 	// FIXME - Add in details about who..
 	JSAuditAdvisory = "$JS.EVENT.ADVISORY.API"
 )

--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -80,3 +80,17 @@ type JSConsumerDeliveryExceededAdvisory struct {
 
 // JSConsumerDeliveryExceededAdvisoryType is the schema type for JSConsumerDeliveryExceededAdvisory
 const JSConsumerDeliveryExceededAdvisoryType = "io.nats.jetstream.advisory.v1.max_deliver"
+
+// JSConsumerDeliveryTerminatedAdvisory is an advisory informing that a message was
+// terminated by the consumer, so might be a candidate for DLQ handling
+type JSConsumerDeliveryTerminatedAdvisory struct {
+	TypedEvent
+	Stream      string `json:"stream"`
+	Consumer    string `json:"consumer"`
+	ConsumerSeq uint64 `json:"consumer_seq"`
+	StreamSeq   uint64 `json:"stream_seq"`
+	Deliveries  uint64 `json:"deliveries"`
+}
+
+// JSConsumerDeliveryTerminatedAdvisoryType is the schema type for JSConsumerDeliveryTerminatedAdvisory
+const JSConsumerDeliveryTerminatedAdvisoryType = "io.nats.jetstream.advisory.v1.terminated"


### PR DESCRIPTION
Allow a message to be terminated for delivery. Will send advisory.

https://github.com/nats-io/jetstream/issues/189

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
