### PR TITLE
[FIXED] Possible removal of interest on queue subs with leaf nodes

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3975,6 +3975,7 @@ func (c *client) teardownConn() {
 				// Update route as normal for a normal subscriber.
 				if sub.queue == nil {
 					srv.updateRouteSubscriptionMap(acc, sub, -1)
+					srv.updateLeafNodes(acc, sub, -1)
 				} else {
 					// We handle queue subscribers special in case we
 					// have a bunch we can just send one update to the
@@ -3989,8 +3990,6 @@ func (c *client) teardownConn() {
 				if srv.gateway.enabled {
 					srv.gatewayUpdateSubInterest(acc.Name, sub, -1)
 				}
-				// Now check on leafnode updates.
-				srv.updateLeafNodes(acc, sub, -1)
 			}
 			// Process any qsubs here.
 			for _, esub := range qsubs {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1395,7 +1395,7 @@ func TestConnectErrorReports(t *testing.T) {
 	defer s.Shutdown()
 
 	// Wait long enough for the number of recurring attempts to happen
-	time.Sleep(10 * routeConnectDelay)
+	time.Sleep(50 * routeConnectDelay)
 	s.Shutdown()
 
 	content, err := ioutil.ReadFile(log)
@@ -1444,7 +1444,7 @@ func TestConnectErrorReports(t *testing.T) {
 	defer s.Shutdown()
 
 	// Wait long enough for the number of recurring attempts to happen
-	time.Sleep(10 * opts.LeafNode.ReconnectInterval)
+	time.Sleep(50 * opts.LeafNode.ReconnectInterval)
 	s.Shutdown()
 
 	content, err = ioutil.ReadFile(log)
@@ -1494,7 +1494,7 @@ func TestConnectErrorReports(t *testing.T) {
 	defer s.Shutdown()
 
 	// Wait long enough for the number of recurring attempts to happen
-	time.Sleep(10 * gatewayConnectDelay)
+	time.Sleep(50 * gatewayConnectDelay)
 	s.Shutdown()
 
 	content, err = ioutil.ReadFile(log)
@@ -1569,7 +1569,7 @@ func TestReconnectErrorReports(t *testing.T) {
 	cs.Shutdown()
 
 	// Wait long enough for the number of recurring attempts to happen
-	time.Sleep(DEFAULT_ROUTE_RECONNECT + 15*routeConnectDelay)
+	time.Sleep(DEFAULT_ROUTE_RECONNECT + 50*routeConnectDelay)
 	s.Shutdown()
 
 	content, err := ioutil.ReadFile(log)
@@ -1636,7 +1636,7 @@ func TestReconnectErrorReports(t *testing.T) {
 	cs.Shutdown()
 
 	// Wait long enough for the number of recurring attempts to happen
-	time.Sleep(opts.LeafNode.ReconnectInterval + 15*opts.LeafNode.ReconnectInterval)
+	time.Sleep(50 * opts.LeafNode.ReconnectInterval)
 	s.Shutdown()
 
 	content, err = ioutil.ReadFile(log)
@@ -1699,7 +1699,7 @@ func TestReconnectErrorReports(t *testing.T) {
 	cs.Shutdown()
 
 	// Wait long enough for the number of recurring attempts to happen
-	time.Sleep(2*gatewayReconnectDelay + 15*gatewayConnectDelay)
+	time.Sleep(50 * gatewayConnectDelay)
 	s.Shutdown()
 
 	content, err = ioutil.ReadFile(log)


### PR DESCRIPTION
Server was incorrectly processing a queue subscription removal
as both a plain sub and queue sub, which may have resulted in
drop of interest even when some queue subs remained.

Resolves #1421

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
