### PR TITLE
Close connections when a remote update exceeds maximum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,9 @@
 module github.com/nats-io/nats-server/v2
 
-go 1.14
-
 require (
+	github.com/minio/highwayhash v1.0.0
 	github.com/nats-io/jwt v0.3.3-0.20200519195258-f2bf5ce574c7
 	github.com/nats-io/nats.go v1.10.0
-	github.com/minio/highwayhash v1.0.0
 	github.com/nats-io/nkeys v0.1.4
 	github.com/nats-io/nuid v1.0.1
 	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -780,7 +780,7 @@ func TestSystemAccountConnectionLimits(t *testing.T) {
 		defer ncb1.Close()
 	}
 
-	checkFor(t, 1*time.Second, 50*time.Millisecond, func() error {
+	checkFor(t, 5*time.Second, 50*time.Millisecond, func() error {
 		total := sa.NumClients() + sb.NumClients()
 		if total > int(nac.Limits.Conn) {
 			return fmt.Errorf("Expected only %d connections, was allowed to connect %d", nac.Limits.Conn, total)


### PR DESCRIPTION
When a remote update is delayed and local connections are being made we could discover we have exceeded our maximum after the fact. Close new connections here if an update from a remote server shows we are over.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
