### PR TITLE
Avoid deadlock by releasing consumer lock.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,9 @@
 module github.com/nats-io/nats-server/v2
 
-go 1.14
-
 require (
+	github.com/minio/highwayhash v1.0.0
 	github.com/nats-io/jwt v0.3.3-0.20200519195258-f2bf5ce574c7
 	github.com/nats-io/nats.go v1.10.0
-	github.com/minio/highwayhash v1.0.0
 	github.com/nats-io/nkeys v0.1.4
 	github.com/nats-io/nuid v1.0.1
 	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59


### PR DESCRIPTION
Since consumers use the stream's internal sendq and that can fill up we need to make sure we do not hold the consumer lock across a send. We avoided this for normal message sends, this adds advisories.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
