### PR TITLE
First check bcrypt '$' prefix before performing rexeg on password

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -733,7 +733,11 @@ var validBcryptPrefix = regexp.MustCompile(`^\$2[a,b,x,y]{1}\$\d{2}\$.*`)
 
 // isBcrypt checks whether the given password or token is bcrypted.
 func isBcrypt(password string) bool {
-	return validBcryptPrefix.MatchString(password)
+	if strings.HasPrefix(password, "$") {
+		return validBcryptPrefix.MatchString(password)
+	}
+
+	return false
 }
 
 func comparePasswords(serverPassword, clientPassword string) bool {


### PR DESCRIPTION
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request:

 - Check bcrypt '$' prefix before performing regex on password


/cc @nats-io/core
