### PR TITLE
Snapshot performance tweaks

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1948,7 +1948,10 @@ const errFile = "errors.txt"
 func (fs *fileStore) streamSnapshot(w io.WriteCloser, blks []*msgBlock, includeConsumers bool) {
 	defer w.Close()
 
-	gzw := gzip.NewWriter(w)
+	bw := bufio.NewWriter(w)
+	defer bw.Flush()
+
+	gzw, _ := gzip.NewWriterLevel(bw, gzip.BestSpeed)
 	defer gzw.Close()
 
 	tw := tar.NewWriter(gzw)
@@ -2117,6 +2120,7 @@ func (fs *fileStore) Snapshot(deadline time.Duration, includeConsumers bool) (*S
 	fs.mu.Unlock()
 
 	pr, pw := net.Pipe()
+
 	// Set a write deadline here to protect ourselves.
 	if deadline > 0 {
 		pw.SetWriteDeadline(time.Now().Add(deadline))

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1233,18 +1233,15 @@ func TestFileStoreSnapshot(t *testing.T) {
 	})
 
 	// Make sure if we do not read properly then it will close the writer and report an error.
-	sr, err = fs.Snapshot(10*time.Millisecond, false)
+	sr, err = fs.Snapshot(25*time.Millisecond, false)
 	if err != nil {
 		t.Fatalf("Error creating snapshot")
 	}
-	var buf [32]byte
 
-	if n, err := sr.Reader.Read(buf[:]); err != nil || n == 0 {
-		t.Fatalf("Expected to read beginning, got %v and %d", err, n)
-	}
 	// Cause snapshot to timeout.
-	time.Sleep(20 * time.Millisecond)
-	// Read again should fail
+	time.Sleep(30 * time.Millisecond)
+	// Read should fail
+	var buf [32]byte
 	if _, err := sr.Reader.Read(buf[:]); err != io.EOF {
 		t.Fatalf("Expected read to produce an error, got none")
 	}


### PR DESCRIPTION
First design was very conservative. This one increase performance for API based snapshots by > 10x. We use a fixed window that is below all spike buffers in nats-servers. We track outstanding bytes and do accounting via the ack reply subject.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
