### PR TITLE
Fixed some tests

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -800,6 +800,7 @@ func TestFileStoreMeta(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+	defer fs.Stop()
 
 	metafile := path.Join(storeDir, JetStreamMetaFile)
 	metasum := path.Join(storeDir, JetStreamMetaFileSum)
@@ -896,6 +897,7 @@ func TestFileStoreWriteAndReadSameBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+	defer fs.Stop()
 
 	subj, msg := "foo", []byte("Hello World!")
 
@@ -939,6 +941,7 @@ func TestFileStoreAndRetrieveMultiBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+	defer fs.Stop()
 
 	for i := uint64(1); i <= 20; i++ {
 		if _, _, _, err := fs.LoadMsg(i); err != nil {
@@ -962,6 +965,7 @@ func TestFileStoreCollapseDmap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+	defer fs.Stop()
 
 	for i := 0; i < 10; i++ {
 		fs.StoreMsg(subj, msg)
@@ -1169,6 +1173,7 @@ func TestFileStoreSnapshot(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error restoring from snapshot: %v", err)
 		}
+		defer fsr.Stop()
 		state := fs.State()
 		rstate := fsr.State()
 

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1491,7 +1491,7 @@ func TestLeafNodeTmpClients(t *testing.T) {
 	}
 	bo.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{u}}}
 	b := RunServer(bo)
-	defer a.Shutdown()
+	defer b.Shutdown()
 
 	checkLeafNodeConnected(t, b)
 	checkTmp(0)

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1979,7 +1979,6 @@ func TestMonitorRoutezRace(t *testing.T) {
 	srvBOpts := nextServerOpts(srvAOpts)
 	srvBOpts.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", srvA.ClusterAddr().Port))
 
-	url := fmt.Sprintf("http://127.0.0.1:%d/", srvA.MonitorAddr().Port)
 	doneCh := make(chan struct{})
 	go func() {
 		defer func() {
@@ -1997,10 +1996,8 @@ func TestMonitorRoutezRace(t *testing.T) {
 	}()
 	done := false
 	for !done {
-		if resp, err := http.Get(url + "routez"); err != nil {
+		if _, err := srvA.Routez(nil); err != nil {
 			time.Sleep(10 * time.Millisecond)
-		} else {
-			resp.Body.Close()
 		}
 		select {
 		case <-doneCh:


### PR DESCRIPTION
- A race test may have consumed a lot of fds going in TIME_WAIT
that could cause some issues for other tests
- Missing defer filestore.Stop() that would leave flushLoop()
routines
- A defer for the from server in a LeafNode test
- Rework [Re]ConnectErrorReports that was failing often for me
locally (probably due to exhaustion of fds - too many TIME_WAIT).

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
