### PR TITLE
[FIXED] Log file size limit not honored after re-open signal

### DIFF
--- a/server/log.go
+++ b/server/log.go
@@ -148,6 +148,9 @@ func (s *Server) ReOpenLogFile() {
 		fileLog := srvlog.NewFileLogger(opts.LogFile,
 			opts.Logtime, opts.Debug, opts.Trace, true)
 		s.SetLogger(fileLog, opts.Debug, opts.Trace)
+		if opts.LogSizeLimit > 0 {
+			fileLog.SetSizeLimit(opts.LogSizeLimit)
+		}
 		s.Noticef("File log re-opened")
 	}
 }


### PR DESCRIPTION
When the logfile_size_limit option is specified, the logfile will
be automatically rotated. However, if user still sends the re-open
signal (SIGUSR1), the log file will then no longer apply the
size limit.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
