### PR TITLE
Avoid parsing large sizes for messages

### DIFF
--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -225,6 +225,16 @@ func TestParsePub(t *testing.T) {
 	}
 }
 
+// https://www.twistlock.com/labs-blog/finding-dos-vulnerability-nats-go-fuzz-cve-2019-13126/
+func TestParsePubSizeOverflow(t *testing.T) {
+	c := dummyClient()
+
+	pub := []byte("PUB foo 3333333333333333333333333333333333333333333333333333333333333333\r\n")
+	if err := c.parse(pub); err == nil {
+		t.Fatalf("Expected an error")
+	}
+}
+
 func TestParsePubArg(t *testing.T) {
 	c := dummyClient()
 

--- a/server/util.go
+++ b/server/util.go
@@ -34,8 +34,10 @@ const (
 // parseSize expects decimal positive numbers. We
 // return -1 to signal error.
 func parseSize(d []byte) (n int) {
+	const maxParseSizeLen = 9 //999M
+
 	l := len(d)
-	if l == 0 {
+	if l == 0 || l > maxParseSizeLen {
 		return -1
 	}
 	var (

--- a/test/maxpayload_test.go
+++ b/test/maxpayload_test.go
@@ -112,7 +112,7 @@ func TestMaxPayloadOverrun(t *testing.T) {
 	defer c.Close()
 
 	send, expect := setupConn(t, c)
-	send("PUB foo 380571791000988\r\n")
+	send("PUB foo 199380988\r\n")
 	expect(errRe)
 
 	// Now overrun an int64, parseSize will have returned -1,


### PR DESCRIPTION
Fixes https://www.twistlock.com/labs-blog/finding-dos-vulnerability-nats-go-fuzz-cve-2019-13126/

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
