### PR TITLE
LameDuckMode takes into account websocket accept loop

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -836,6 +836,13 @@ func (s *Server) startWebsocketServer() {
 		if err := hs.Serve(hl); err != http.ErrServerClosed {
 			s.Fatalf("websocket listener error: %v", err)
 		}
+		if s.isLameDuckMode() {
+			// Signal that we are not accepting new clients
+			s.ldmCh <- true
+			// Now wait for the Shutdown...
+			<-s.quitCh
+			return
+		}
 		s.done <- true
 	})
 }


### PR DESCRIPTION
This is related to #1408.
Make sure that we close the websocket "accept loop" if configured
before proceeding with the lame duck mode.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
