### PR TITLE
Removed double connection close trace

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1283,7 +1283,7 @@ func (c *client) markConnAsClosed(reason ClosedState) bool {
 	if c.srv != nil {
 		if c.kind == ROUTER || c.kind == GATEWAY {
 			c.Noticef("%s connection closed: %s", c.typeString(), reason)
-		} else { // Client and Leaf Node connections.
+		} else { // Client, System, Jetstream, Account and Leafnode connections.
 			c.Debugf("%s connection closed: %s", c.typeString(), reason)
 		}
 	}
@@ -3879,16 +3879,6 @@ func (c *client) closeConnection(reason ClosedState) {
 // been started.
 func (c *client) teardownConn() {
 	c.mu.Lock()
-
-	// Be consistent with the creation: for routes and gateways,
-	// we use Noticef on create, so use that too for delete.
-	if c.srv != nil {
-		if c.kind == ROUTER || c.kind == GATEWAY {
-			c.Noticef("%s connection closed", c.typeString())
-		} else { // Client, System, Jetstream, Account and Leafnode connections.
-			c.Debugf("%s connection closed", c.typeString())
-		}
-	}
 
 	c.clearAuthTimer()
 	c.clearPingTimer()


### PR DESCRIPTION
In master, this this what happens when a connection is closed
and server runs with `-D`
```
[95023] 2020/06/03 14:55:28.395532 [DBG] 127.0.0.1:54077 - cid:2 - Client connection created
[95023] 2020/06/03 14:55:29.164118 [DBG] 127.0.0.1:54077 - cid:2 - Client connection closed: Client Closed
[95023] 2020/06/03 14:55:29.164191 [DBG] 127.0.0.1:54077 - cid:2 - Client connection closed
```
Notice the trace of connection closed with the reason, and then
the bare connection closed statement.

This double trace was introduced by mistake during the JS branch
work (https://github.com/nats-io/nats-server/commit/dd116fcfd4ecada200bd4dc8c7b72d213d549ece#diff-853eb184ac73cf9597d7833f6b89e9c9R3547)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
