### PR TITLE
add nightly docker build workflows

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,36 @@
+name: NATS Server Nightly
+on:
+  schedule:
+    - cron: "0 40 * * *"
+
+jobs:
+  nightly_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+
+      - name: goreleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --snapshot --config .goreleaser-nightly.yml
+
+      - name: images
+        run: |
+          docker images
+
+      - name: docker_login
+        run: |
+          docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"
+
+      - name: docker_push
+        run: |
+          NDATE=$(date +%Y%m%d)
+          docker push synadia/nats-server:nightly-${NDATE}
+          docker push synadia/nats-server:nightly

--- a/.goreleaser-night.yml
+++ b/.goreleaser-night.yml
@@ -1,0 +1,33 @@
+project_name: nats-server
+
+builds:
+  - main: ./main.go
+    id: nats-server
+    binary: nats-server
+    ldflags:
+      - -s -w -X github.com/nats-io/nats-server/server.gitCommit={{.ShortCommit}}
+    env:
+      - GO111MODULE=off
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+
+dockers:
+  - goos: linux
+    goarch: amd64
+    skip_push: true
+    dockerfile: docker/Dockerfile.nightly
+    image_templates:
+      - synadia/nats-server:{{.Version}}
+      - synadia/nats-server:nightly
+    extra_files:
+      - docker/nats-server.conf
+
+checksum:
+  name_template: 'SHA256SUMS'
+  algorithm: sha256
+
+snapshot:
+  name_template: 'nightly-{{ time "20060102" }}'

--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -1,0 +1,17 @@
+FROM golang:1.14-alpine AS builder
+
+RUN apk add --update git
+RUN go get github.com/nats-io/jetstream/nats
+
+FROM alpine:latest
+
+RUN apk add --update ca-certificates && mkdir -p /nats/bin && mkdir /nats/conf
+
+COPY docker/nats-server.conf /nats/conf/nats-server.conf
+COPY nats-server /bin/nats-server
+COPY --from=builder /go/bin/nats /bin/nats
+
+EXPOSE 4222 8222 6222 5222
+
+ENTRYPOINT ["/bin/nats-server"]
+CMD ["-c", "/nats/conf/nats-server.conf"]


### PR DESCRIPTION
Adds a nightly build as `synadia/nats-server:nightly` and `synadia/nats-server:nightly-yyyymmdd`

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
