### PR TITLE
Cluster names are now required.

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -173,6 +173,7 @@ const (
 	Revocation
 	InternalClient
 	MsgHeaderViolation
+	ClusterNameConflict
 )
 
 // Some flags passed to processMsgResultsEx

--- a/server/configs/cluster.conf
+++ b/server/configs/cluster.conf
@@ -14,6 +14,7 @@ pid_file: '/tmp/nats_cluster_test.pid'
 cluster {
   host: 127.0.0.1
   port: 4244
+  name: "abc"
 
   authorization {
     user: route_user

--- a/server/configs/listen.conf
+++ b/server/configs/listen.conf
@@ -7,4 +7,5 @@ https: 127.0.0.1:9443
 
 cluster {
   listen: 127.0.0.1:4244
+  name: "abc"
 }

--- a/server/configs/reload/reload.conf
+++ b/server/configs/reload/reload.conf
@@ -32,5 +32,6 @@ authorization {
 
 cluster {
     listen:       127.0.0.1:-1
+    name: "abc"
     no_advertise: true # enable on reload
 }

--- a/server/configs/reload/srv_a_1.conf
+++ b/server/configs/reload/srv_a_1.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:-1
 
 cluster {
   listen: 127.0.0.1:7244
+  name: "abc"
 
   routes = [
     nats-route://127.0.0.1:7246

--- a/server/configs/reload/srv_a_2.conf
+++ b/server/configs/reload/srv_a_2.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:-1
 
 cluster {
   listen: 127.0.0.1:7244
+  name: "abc"
 
   routes = [
     nats-route://tyler:foo@127.0.0.1:7246 # Use route credentials

--- a/server/configs/reload/srv_a_3.conf
+++ b/server/configs/reload/srv_a_3.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:-1
 
 cluster {
   listen: 127.0.0.1:7244
+  name: "abc"
 
   routes = [
     nats-route://127.0.0.1:7247 # Remove srv b route and add srv c

--- a/server/configs/reload/srv_a_4.conf
+++ b/server/configs/reload/srv_a_4.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:-1
 
 cluster {
   listen: 127.0.0.1:7244
+  name: "abc"
 }
 
 no_sys_acc: true

--- a/server/configs/reload/srv_b_1.conf
+++ b/server/configs/reload/srv_b_1.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:-1
 
 cluster {
   listen: 127.0.0.1:7246
+  name: "abc"
 }
 
 no_sys_acc: true

--- a/server/configs/reload/srv_b_2.conf
+++ b/server/configs/reload/srv_b_2.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:-1
 
 cluster {
   listen: 127.0.0.1:7246
+  name: "abc"
 
   # Enable route authorization.
   authorization {

--- a/server/configs/reload/srv_c_1.conf
+++ b/server/configs/reload/srv_c_1.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:-1
 
 cluster {
   listen: 127.0.0.1:7247
+  name: "abc"
 }
 
 no_sys_acc: true

--- a/server/configs/reload/test.conf
+++ b/server/configs/reload/test.conf
@@ -7,5 +7,6 @@ logtime: false
 
 cluster {
     listen:       127.0.0.1:-1
+    name:         "abc"
     no_advertise: false
 }

--- a/server/configs/seed.conf
+++ b/server/configs/seed.conf
@@ -6,4 +6,5 @@ http: 127.0.0.1:9222
 
 cluster {
   listen: 127.0.0.1:7248
+  name: "abc"
 }

--- a/server/configs/seed_tls.conf
+++ b/server/configs/seed_tls.conf
@@ -6,6 +6,7 @@ http: 127.0.0.1:9222
 
 cluster {
   listen: 127.0.0.1:7248
+  name: "abc"
 
   tls {
     # Route cert

--- a/server/configs/srv_a.conf
+++ b/server/configs/srv_a.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:7222
 
 cluster {
   listen: 127.0.0.1:7244
+  name: "abc"
 
   authorization {
     user: ruser

--- a/server/configs/srv_a_bcrypt.conf
+++ b/server/configs/srv_a_bcrypt.conf
@@ -10,6 +10,7 @@ authorization {
 
 cluster {
   listen: 127.0.0.1:7244
+  name: "abc"
 
   authorization {
     user: ruser

--- a/server/configs/srv_b.conf
+++ b/server/configs/srv_b.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:7224
 
 cluster {
   listen: 127.0.0.1:7246
+  name: "abc"
 
   authorization {
     user: ruser

--- a/server/configs/srv_b_bcrypt.conf
+++ b/server/configs/srv_b_bcrypt.conf
@@ -10,6 +10,7 @@ authorization {
 
 cluster {
   listen: 127.0.0.1:7246
+  name: "abc"
 
   authorization {
     user: ruser

--- a/server/errors.go
+++ b/server/errors.go
@@ -144,6 +144,12 @@ var (
 	// ErrMsgHeadersNotSupported signals the parser detected a message header
 	// but they are not supported on this server.
 	ErrMsgHeadersNotSupported = errors.New("message headers not supported")
+
+	// ErrClusterNameConfigConflict signals that the options for cluster name in cluster and gateway are in conflict.
+	ErrClusterNameConfigConflict = errors.New("cluster name conflicts between cluster and gateway definitions")
+
+	// ErrClusterNameRemoteConflict signals that a remote server has a different cluster name.
+	ErrClusterNameRemoteConflict = errors.New("cluster name from remote server conflicts")
 )
 
 // configErr is a configuration error.

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -95,6 +95,7 @@ func runTrustedCluster(t *testing.T) (*Server, *Options, *Server, *Options, nkey
 	mr.Store(apub, jwt)
 
 	optsA := DefaultOptions()
+	optsA.Cluster.Name = "TEST CLUSTER 22"
 	optsA.Cluster.Host = "127.0.0.1"
 	optsA.TrustedKeys = []string{pub}
 	optsA.AccountResolver = mr
@@ -138,6 +139,7 @@ func runTrustedGateways(t *testing.T) (*Server, *Options, *Server, *Options, nke
 	mr.Store(apub, jwt)
 
 	optsA := testDefaultOptionsForGateway("A")
+	optsA.Cluster.Name = "A"
 	optsA.Cluster.Host = "127.0.0.1"
 	optsA.TrustedKeys = []string{pub}
 	optsA.AccountResolver = mr
@@ -146,6 +148,7 @@ func runTrustedGateways(t *testing.T) (*Server, *Options, *Server, *Options, nke
 	sa := RunServer(optsA)
 
 	optsB := testGatewayOptionsFromToWithServers(t, "B", "A", sa)
+	optsB.Cluster.Name = "B"
 	optsB.TrustedKeys = []string{pub}
 	optsB.AccountResolver = mr
 	optsB.SystemAccount = apub

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1568,11 +1568,12 @@ func (fs *fileStore) LoadMsg(seq uint64) (string, []byte, []byte, int64, error) 
 	return "", nil, nil, 0, err
 }
 
+// State returns the current state of the stream.
 func (fs *fileStore) State() StreamState {
 	fs.mu.RLock()
-	defer fs.mu.RUnlock()
 	state := fs.state
 	state.Consumers = len(fs.cfs)
+	fs.mu.RUnlock()
 	return state
 }
 

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -1100,6 +1100,7 @@ func TestGatewayWrongDestination(t *testing.T) {
 	cfg.resetConnAttempts()
 
 	o2.Gateway.Name = "B"
+	o2.Cluster.Name = "B"
 	s2 = runGatewayServer(o2)
 	defer s2.Shutdown()
 
@@ -2883,6 +2884,7 @@ func TestGatewayRoutedServerWithoutGatewayConfigured(t *testing.T) {
 	waitForOutboundGateways(t, s2, 1, time.Second)
 
 	o3 := DefaultOptions()
+	o3.Cluster.Name = "B"
 	o3.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", s2.ClusterAddr().Port))
 	s3 := New(o3)
 	defer s3.Shutdown()

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -240,6 +240,7 @@ func testDefaultOptionsForGateway(name string) *Options {
 	o := DefaultOptions()
 	o.NoSystemAccount = true
 	o.ServerName = name
+	o.Cluster.Name = name
 	o.Gateway.Name = name
 	o.Gateway.Host = "127.0.0.1"
 	o.Gateway.Port = -1

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -346,6 +346,7 @@ func TestLeafNodeBasicAuthFailover(t *testing.T) {
 	content := `
 	listen: "127.0.0.1:-1"
 	cluster {
+		name: "abc"
 		listen: "127.0.0.1:-1"
 		%s
 	}
@@ -948,6 +949,7 @@ func TestLeafNodeRemoteWrongPort(t *testing.T) {
 			// Make sure we have all ports (client, route, gateway) and we will try
 			// to create a leafnode to connection to each and make sure we get the error.
 			oa.Cluster.NoAdvertise = test1.clusterAdvertise
+			oa.Cluster.Name = "A"
 			oa.Cluster.Host = "127.0.0.1"
 			oa.Cluster.Port = -1
 			oa.Gateway.Host = "127.0.0.1"
@@ -963,6 +965,7 @@ func TestLeafNodeRemoteWrongPort(t *testing.T) {
 
 			ob := DefaultOptions()
 			ob.Cluster.NoAdvertise = test1.clusterAdvertise
+			ob.Cluster.Name = "A"
 			ob.Cluster.Host = "127.0.0.1"
 			ob.Cluster.Port = -1
 			ob.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", oa.Cluster.Host, oa.Cluster.Port))
@@ -1271,6 +1274,7 @@ func TestLeafNodeExportPermissionsNotForSpecialSubs(t *testing.T) {
 	lo1 := DefaultOptions()
 	lo1.Accounts = []*Account{NewAccount("SYS")}
 	lo1.SystemAccount = "SYS"
+	lo1.Cluster.Name = "A"
 	lo1.Gateway.Name = "A"
 	lo1.Gateway.Port = -1
 	lo1.LeafNode.Host = "127.0.0.1"

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1267,6 +1267,7 @@ func TestConnzWithRoutes(t *testing.T) {
 	resetPreviousHTTPConnections()
 	opts := DefaultMonitorOptions()
 	opts.NoSystemAccount = true
+	opts.Cluster.Name = "A"
 	opts.Cluster.Host = "127.0.0.1"
 	opts.Cluster.Port = CLUSTER_PORT
 
@@ -1277,6 +1278,7 @@ func TestConnzWithRoutes(t *testing.T) {
 		Host: "127.0.0.1",
 		Port: -1,
 		Cluster: ClusterOpts{
+			Name: "A",
 			Host: "127.0.0.1",
 			Port: -1,
 		},
@@ -2003,6 +2005,7 @@ func TestMonitorRoutezRace(t *testing.T) {
 	resetPreviousHTTPConnections()
 	srvAOpts := DefaultMonitorOptions()
 	srvAOpts.NoSystemAccount = true
+	srvAOpts.Cluster.Name = "B"
 	srvAOpts.Cluster.Port = -1
 	srvA := RunServer(srvAOpts)
 	defer srvA.Shutdown()
@@ -2155,6 +2158,7 @@ func TestRoutezPermissions(t *testing.T) {
 	resetPreviousHTTPConnections()
 	opts := DefaultMonitorOptions()
 	opts.NoSystemAccount = true
+	opts.Cluster.Name = "A"
 	opts.Cluster.Host = "127.0.0.1"
 	opts.Cluster.Port = -1
 	opts.Cluster.Permissions = &RoutePermissions{
@@ -2172,6 +2176,7 @@ func TestRoutezPermissions(t *testing.T) {
 
 	opts = DefaultMonitorOptions()
 	opts.Cluster.Host = "127.0.0.1"
+	opts.Cluster.Name = "A"
 	opts.Cluster.Port = -1
 	routeURL, _ := url.Parse(fmt.Sprintf("nats-route://127.0.0.1:%d", s1.ClusterAddr().Port))
 	opts.Routes = []*url.URL{routeURL}
@@ -2402,6 +2407,7 @@ func TestMonitorCluster(t *testing.T) {
 	resetPreviousHTTPConnections()
 	opts := DefaultMonitorOptions()
 	opts.NoSystemAccount = true
+	opts.Cluster.Name = "A"
 	opts.Cluster.Port = -1
 	opts.Cluster.AuthTimeout = 1
 	opts.Routes = RoutesFromStr("nats://127.0.0.1:1234")
@@ -2447,6 +2453,8 @@ func TestMonitorClusterURLs(t *testing.T) {
 
 	o2 := DefaultOptions()
 	o2.Cluster.Host = "127.0.0.1"
+	o2.Cluster.Name = "A"
+
 	s2 := RunServer(o2)
 	defer s2.Shutdown()
 
@@ -2456,6 +2464,7 @@ func TestMonitorClusterURLs(t *testing.T) {
 		port: -1
 		http: -1
 		cluster: {
+			name: "A"
 			port: -1
 			routes [
 				%s

--- a/server/opts.go
+++ b/server/opts.go
@@ -57,6 +57,7 @@ func NoErrOnUnknownFields(noError bool) {
 // NOTE: This structure is no longer used for monitoring endpoints
 // and json tags are deprecated and may be removed in the future.
 type ClusterOpts struct {
+	Name           string            `json:"-"`
 	Host           string            `json:"addr,omitempty"`
 	Port           int               `json:"cluster_port,omitempty"`
 	Username       string            `json:"-"`
@@ -1009,6 +1010,13 @@ func parseCluster(v interface{}, opts *Options, errors *[]error, warnings *[]err
 		// Again, unwrap token value if line check is required.
 		tk, mv = unwrapValue(mv, &lt)
 		switch strings.ToLower(mk) {
+		case "name":
+			opts.Cluster.Name = mv.(string)
+			// Check to see if a cluster name has been defined in gateway section and if so and they do not match err.
+			if opts.Gateway.Name != "" && opts.Cluster.Name != opts.Gateway.Name {
+				*errors = append(*errors, ErrClusterNameConfigConflict)
+				continue
+			}
 		case "listen":
 			hp, err := parseListen(mv)
 			if err != nil {
@@ -1149,6 +1157,11 @@ func parseGateway(v interface{}, o *Options, errors *[]error, warnings *[]error)
 		switch strings.ToLower(mk) {
 		case "name":
 			o.Gateway.Name = mv.(string)
+			// Check to see if a cluster name has been defined. And if so and they do not match err.
+			if o.Cluster.Name != "" && o.Cluster.Name != o.Gateway.Name {
+				*errors = append(*errors, ErrClusterNameConfigConflict)
+				continue
+			}
 		case "listen":
 			hp, err := parseListen(mv)
 			if err != nil {
@@ -3519,7 +3532,7 @@ func setBaselineOptions(opts *Options) {
 	}
 }
 
-// ConfigureOptions accepts a flag set and augment it with NATS Server
+// ConfigureOptions accepts a flag set and augments it with NATS Server
 // specific flags. On success, an options structure is returned configured
 // based on the selected flags and/or configuration file.
 // The command line options take precedence to the ones in the configuration file.

--- a/server/opts.go
+++ b/server/opts.go
@@ -1012,11 +1012,6 @@ func parseCluster(v interface{}, opts *Options, errors *[]error, warnings *[]err
 		switch strings.ToLower(mk) {
 		case "name":
 			opts.Cluster.Name = mv.(string)
-			// Check to see if a cluster name has been defined in gateway section and if so and they do not match err.
-			if opts.Gateway.Name != "" && opts.Cluster.Name != opts.Gateway.Name {
-				*errors = append(*errors, ErrClusterNameConfigConflict)
-				continue
-			}
 		case "listen":
 			hp, err := parseListen(mv)
 			if err != nil {
@@ -1157,11 +1152,6 @@ func parseGateway(v interface{}, o *Options, errors *[]error, warnings *[]error)
 		switch strings.ToLower(mk) {
 		case "name":
 			o.Gateway.Name = mv.(string)
-			// Check to see if a cluster name has been defined. And if so and they do not match err.
-			if o.Cluster.Name != "" && o.Cluster.Name != o.Gateway.Name {
-				*errors = append(*errors, ErrClusterNameConfigConflict)
-				continue
-			}
 		case "listen":
 			hp, err := parseListen(mv)
 			if err != nil {

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -2760,3 +2760,27 @@ func TestReadOperatorAssertVersionFail(t *testing.T) {
 		t.Fatal("expected different error got: ", err)
 	}
 }
+
+func TestClusterNameAndGatewayNameConflict(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		cluster {
+			name: A
+			listen: 127.0.0.1:-1
+		}
+		gateway {
+			name: B
+			listen: 127.0.0.1:-1
+		}
+	`))
+	defer os.Remove(conf)
+
+	opts, err := ProcessConfigFile(conf)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if err := validateOptions(opts); err != ErrClusterNameConfigConflict {
+		t.Fatalf("Expected ErrClusterNameConfigConflict got %v", err)
+	}
+}

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -344,6 +344,7 @@ func TestRouteFlagOverride(t *testing.T) {
 		Host:       "127.0.0.1",
 		Port:       7222,
 		Cluster: ClusterOpts{
+			Name:        "abc",
 			Host:        "127.0.0.1",
 			Port:        7244,
 			Username:    "ruser",
@@ -383,6 +384,7 @@ func TestClusterFlagsOverride(t *testing.T) {
 		Host:       "127.0.0.1",
 		Port:       7222,
 		Cluster: ClusterOpts{
+			Name:        "abc",
 			Host:        "127.0.0.1",
 			Port:        7244,
 			ListenStr:   "nats://127.0.0.1:8224",
@@ -419,6 +421,7 @@ func TestRouteFlagOverrideWithMultiple(t *testing.T) {
 		Port:       7222,
 		Cluster: ClusterOpts{
 			Host:        "127.0.0.1",
+			Name:        "abc",
 			Port:        7244,
 			Username:    "ruser",
 			Password:    "top_secret",
@@ -922,7 +925,7 @@ func TestNkeyUsersDefaultPermissionsConfig(t *testing.T) {
 					}
 				}
 			]
-		}	
+		}
 	}
 	`))
 	checkPerms := func(permsDef *Permissions, permsNonDef *Permissions) {

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -151,6 +151,7 @@ func TestConfigReloadUnsupported(t *testing.T) {
 		MaxPingsOut:    2,
 		WriteDeadline:  2 * time.Second,
 		Cluster: ClusterOpts{
+			Name: "abc",
 			Host: "127.0.0.1",
 			Port: -1,
 		},
@@ -224,6 +225,7 @@ func TestConfigReloadInvalidConfig(t *testing.T) {
 		MaxPingsOut:    2,
 		WriteDeadline:  2 * time.Second,
 		Cluster: ClusterOpts{
+			Name: "abc",
 			Host: "127.0.0.1",
 			Port: -1,
 		},
@@ -289,6 +291,7 @@ func TestConfigReload(t *testing.T) {
 		MaxPingsOut:    2,
 		WriteDeadline:  2 * time.Second,
 		Cluster: ClusterOpts{
+			Name: "abc",
 			Host: "127.0.0.1",
 			Port: server.ClusterAddr().Port,
 		},

--- a/server/route.go
+++ b/server/route.go
@@ -359,6 +359,7 @@ func (c *client) sendRouteConnect(tlsRequired bool) {
 		user = userInfo.Username()
 		pass, _ = userInfo.Password()
 	}
+	s := c.srv
 	cinfo := connectInfo{
 		Echo:     true,
 		Verbose:  false,
@@ -366,10 +367,10 @@ func (c *client) sendRouteConnect(tlsRequired bool) {
 		User:     user,
 		Pass:     pass,
 		TLS:      tlsRequired,
-		Name:     c.srv.info.ID,
-		Headers:  c.srv.supportsHeaders(),
-		Cluster:  c.srv.ClusterName(),
-		Dynamic:  c.srv.getOpts().Cluster.Name == "",
+		Name:     s.info.ID,
+		Headers:  s.supportsHeaders(),
+		Cluster:  s.info.Cluster,
+		Dynamic:  s.getOpts().Cluster.Name == "",
 	}
 
 	b, err := json.Marshal(cinfo)
@@ -1784,6 +1785,9 @@ func (c *client) processRouteConnect(srv *Server, arg []byte, lang string) error
 			if !proto.Dynamic || strings.Compare(clusterName, proto.Cluster) < 0 {
 				// We will take on their name since theirs is configured or higher then ours.
 				srv.setClusterName(proto.Cluster)
+				if !proto.Dynamic {
+					srv.getOpts().Cluster.Name = proto.Cluster
+				}
 				srv.removeAllRoutesExcept(c)
 				shouldReject = false
 			}

--- a/server/route.go
+++ b/server/route.go
@@ -370,7 +370,7 @@ func (c *client) sendRouteConnect(tlsRequired bool) {
 		Name:     s.info.ID,
 		Headers:  s.supportsHeaders(),
 		Cluster:  s.info.Cluster,
-		Dynamic:  s.getOpts().Cluster.Name == "",
+		Dynamic:  s.isClusterNameDynamic(),
 	}
 
 	b, err := json.Marshal(cinfo)
@@ -420,7 +420,7 @@ func (c *client) processRouteInfo(info *Info) {
 	if info.Cluster != "" && info.Cluster != clusterName {
 		c.mu.Unlock()
 		// If we are dynamic we may update our cluster name.
-		if c.srv.getOpts().Cluster.Name == "" && strings.Compare(clusterName, info.Cluster) < 0 {
+		if s.isClusterNameDynamic() && strings.Compare(clusterName, info.Cluster) < 0 {
 			s.setClusterName(info.Cluster)
 			s.removeAllRoutesExcept(c)
 			c.mu.Lock()
@@ -1510,7 +1510,7 @@ func (s *Server) routeAcceptLoop(ch chan struct{}) {
 	}
 
 	s.Noticef("Cluster name is %s", s.ClusterName())
-	if opts.Cluster.Name == "" {
+	if s.isClusterNameDynamic() {
 		s.Warnf("Cluster name was dynamically generated, consider setting one")
 	}
 
@@ -1781,7 +1781,7 @@ func (c *client) processRouteConnect(srv *Server, arg []byte, lang string) error
 	if proto.Cluster != clusterName {
 		shouldReject := true
 		// If we have a dynamic name we will do additional checks.
-		if srv.getOpts().Cluster.Name == "" {
+		if srv.isClusterNameDynamic() {
 			if !proto.Dynamic || strings.Compare(clusterName, proto.Cluster) < 0 {
 				// We will take on their name since theirs is configured or higher then ours.
 				srv.setClusterName(proto.Cluster)

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -70,6 +70,7 @@ func TestRouteConfig(t *testing.T) {
 		Password:    "porkchop",
 		AuthTimeout: 1.0,
 		Cluster: ClusterOpts{
+			Name:           "abc",
 			Host:           "127.0.0.1",
 			Port:           4244,
 			Username:       "route_user",

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1205,6 +1205,7 @@ func TestRouteRTT(t *testing.T) {
 func TestRouteCloseTLSConnection(t *testing.T) {
 	opts := DefaultOptions()
 	opts.DisableShortFirstPing = true
+	opts.Cluster.Name = "A"
 	opts.Cluster.Host = "127.0.0.1"
 	opts.Cluster.Port = -1
 	opts.Cluster.TLSTimeout = 100
@@ -1235,7 +1236,7 @@ func TestRouteCloseTLSConnection(t *testing.T) {
 	if err := tlsConn.Handshake(); err != nil {
 		t.Fatalf("Unexpected error during handshake: %v", err)
 	}
-	connectOp := []byte("CONNECT {\"name\":\"route\",\"verbose\":false,\"pedantic\":false,\"tls_required\":true}\r\n")
+	connectOp := []byte("CONNECT {\"name\":\"route\",\"verbose\":false,\"pedantic\":false,\"tls_required\":true,\"cluster\":\"A\"}\r\n")
 	if _, err := tlsConn.Write(connectOp); err != nil {
 		t.Fatalf("Unexpected error writing CONNECT: %v", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -480,6 +480,13 @@ func validateOptions(o *Options) error {
 	if err := validateGatewayOptions(o); err != nil {
 		return err
 	}
+	// Check that cluster name if defined matches any gateway name.
+	if o.Gateway.Name != "" && o.Gateway.Name != o.Cluster.Name {
+		if o.Cluster.Name != "" {
+			return ErrClusterNameConfigConflict
+		}
+		o.Cluster.Name = o.Gateway.Name
+	}
 	return validateWebsocketOptions(o)
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -900,6 +900,7 @@ func TestLameDuckMode(t *testing.T) {
 
 func TestLameDuckModeInfo(t *testing.T) {
 	optsA := testWSOptions()
+	optsA.Cluster.Name = "abc"
 	optsA.Cluster.Host = "127.0.0.1"
 	optsA.Cluster.Port = -1
 	// Ensure that initial delay is set very high so that we can
@@ -947,6 +948,7 @@ func TestLameDuckModeInfo(t *testing.T) {
 	client.ReadString('\n')
 
 	optsB := testWSOptions()
+	optsB.Cluster.Name = "abc"
 	optsB.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", srvA.ClusterAddr().Port))
 	srvB := RunServer(optsB)
 	defer srvB.Shutdown()
@@ -974,6 +976,7 @@ func TestLameDuckModeInfo(t *testing.T) {
 
 	optsC := testWSOptions()
 	testSetLDMGracePeriod(optsA, 5*time.Second)
+	optsC.Cluster.Name = "abc"
 	optsC.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", srvA.ClusterAddr().Port))
 	srvC := RunServer(optsC)
 	defer srvC.Shutdown()
@@ -986,6 +989,7 @@ func TestLameDuckModeInfo(t *testing.T) {
 	checkConnectURLs(expected)
 
 	optsD := testWSOptions()
+	optsD.Cluster.Name = "abc"
 	optsD.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", srvA.ClusterAddr().Port))
 	srvD := RunServer(optsD)
 	defer srvD.Shutdown()
@@ -1341,6 +1345,7 @@ func TestInsecureSkipVerifyWarning(t *testing.T) {
 	}
 
 	o := DefaultOptions()
+	o.Cluster.Name = "A"
 	o.Cluster.Port = -1
 	o.Cluster.TLSConfig = config.Clone()
 	checkWarnReported(t, o, clusterTLSInsecureWarning)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -58,7 +58,7 @@ func DefaultOptions() *Options {
 		Host:     "127.0.0.1",
 		Port:     -1,
 		HTTPPort: -1,
-		Cluster:  ClusterOpts{Port: -1},
+		Cluster:  ClusterOpts{Port: -1, Name: "abc"},
 		NoLog:    true,
 		NoSigs:   true,
 		Debug:    true,
@@ -1521,6 +1521,7 @@ func TestConnectErrorReports(t *testing.T) {
 
 	// Now try with gateways
 	opts.LeafNode.Remotes = nil
+	opts.Cluster.Name = "A"
 	opts.Gateway.Name = "A"
 	opts.Gateway.Port = -1
 	opts.Gateway.Gateways = []*RemoteGatewayOpts{
@@ -1700,11 +1701,13 @@ func TestReconnectErrorReports(t *testing.T) {
 
 	// Now try with gateways
 	csOpts.LeafNode.Port = 0
+	csOpts.Cluster.Name = "B"
 	csOpts.Gateway.Name = "B"
 	csOpts.Gateway.Port = -1
 	cs = RunServer(csOpts)
 
 	opts.LeafNode.Remotes = nil
+	opts.Cluster.Name = "A"
 	opts.Gateway.Name = "A"
 	opts.Gateway.Port = -1
 	remoteGWPort := cs.GatewayAddr().Port

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -541,25 +541,6 @@ func TestClusterNameOption(t *testing.T) {
 	}
 }
 
-func TestClusterNameAndGatewayName(t *testing.T) {
-	conf := createConfFile(t, []byte(`
-		listen: 127.0.0.1:-1
-		cluster {
-			name: A
-			listen: 127.0.0.1:-1
-		}
-		gateway {
-			name: B
-			listen: 127.0.0.1:-1
-		}
-	`))
-	defer os.Remove(conf)
-
-	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), "cluster name conflicts") {
-		t.Fatalf("Expected an error with conflicting cluster names")
-	}
-}
-
 func TestEphemeralClusterName(t *testing.T) {
 	conf := createConfFile(t, []byte(`
 		listen: 127.0.0.1:-1

--- a/test/cluster_tls_test.go
+++ b/test/cluster_tls_test.go
@@ -101,6 +101,7 @@ func TestClusterTLSInsecure(t *testing.T) {
 	confA := createConfFile(t, []byte(`
 		port: -1
 		cluster {
+			name: "xyz"
 			listen: "127.0.0.1:-1"
 			tls {
 			    cert_file: "./configs/certs/server-noip.pem"
@@ -119,6 +120,7 @@ func TestClusterTLSInsecure(t *testing.T) {
 	bConfigTemplate := `
 		port: -1
 		cluster {
+			name: "xyz"
 			listen: "127.0.0.1:-1"
 			tls {
 			    cert_file: "./configs/certs/server-noip.pem"

--- a/test/configs/auth_seed.conf
+++ b/test/configs/auth_seed.conf
@@ -6,6 +6,7 @@ http: 8222
 
 cluster {
   listen: 127.0.0.1:4248
+  name: xyz
 
   authorization {
     user: ruser

--- a/test/configs/cluster.conf
+++ b/test/configs/cluster.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:5242
 
 cluster {
   listen: 127.0.0.1:5244
+  name: xyz
 
   authorization {
     user: route_user

--- a/test/configs/new_cluster.conf
+++ b/test/configs/new_cluster.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:5343
 
 cluster {
   listen: 127.0.0.1:5344
+  name: xyz
 
   # Routes are actively solicited and connected to from this server.
   # Other servers can connect to us if they supply the correct credentials

--- a/test/configs/seed.conf
+++ b/test/configs/seed.conf
@@ -6,6 +6,7 @@ http: 8222
 
 cluster {
   listen: 127.0.0.1:4248
+  name: xyz
 }
 
 no_sys_acc: true

--- a/test/configs/srv_a.conf
+++ b/test/configs/srv_a.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:5222
 
 cluster {
   listen: 127.0.0.1:5244
+  name: xyz
 
   authorization {
     user: ruser

--- a/test/configs/srv_a_leaf.conf
+++ b/test/configs/srv_a_leaf.conf
@@ -8,6 +8,7 @@ leafnodes {
 
 cluster {
   listen: 127.0.0.1:5244
+  name: xyz
 
   authorization {
     user: ruser

--- a/test/configs/srv_a_perms.conf
+++ b/test/configs/srv_a_perms.conf
@@ -5,6 +5,7 @@ http: 127.0.0.1:5223
 
 cluster {
   listen: 127.0.0.1:5244
+  name: xyz
 
   authorization {
     user: ruser

--- a/test/configs/srv_a_tls.conf
+++ b/test/configs/srv_a_tls.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:5222
 
 cluster {
   listen: 127.0.0.1:5244
+  name: xyz
 
   tls {
     # Route cert

--- a/test/configs/srv_b.conf
+++ b/test/configs/srv_b.conf
@@ -5,6 +5,7 @@ http: 127.0.0.1:5225
 
 cluster {
   listen: 127.0.0.1:5246
+  name: xyz
 
   authorization {
     user: ruser

--- a/test/configs/srv_b_tls.conf
+++ b/test/configs/srv_b_tls.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:5224
 
 cluster {
   listen: 127.0.0.1:5246
+  name: xyz
 
   tls {
     # Route cert

--- a/test/configs/srv_c.conf
+++ b/test/configs/srv_c.conf
@@ -4,6 +4,7 @@ listen: 127.0.0.1:5226
 
 cluster {
   listen: 127.0.0.1:5248
+  name: xyz
 
   authorization {
     user: ruser

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -1813,6 +1813,7 @@ func TestLeafNodeInfoURLs(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			opts := testDefaultOptionsForLeafNodes()
+			opts.Cluster.Name = "A"
 			opts.Cluster.Port = -1
 			opts.LeafNode.Host = "127.0.0.1"
 			if test.useAdvertise {
@@ -1839,6 +1840,7 @@ func TestLeafNodeInfoURLs(t *testing.T) {
 			lc.Close()
 
 			opts2 := testDefaultOptionsForLeafNodes()
+			opts2.Cluster.Name = "A"
 			opts2.Cluster.Port = -1
 			opts2.Routes = server.RoutesFromStr(fmt.Sprintf("nats://%s:%d", opts.Cluster.Host, opts.Cluster.Port))
 			opts2.LeafNode.Host = "127.0.0.1"
@@ -2024,11 +2026,13 @@ func TestLeafNodeAdvertise(t *testing.T) {
 
 	o2 := testDefaultOptionsForLeafNodes()
 	o2.LeafNode.Advertise = fmt.Sprintf("127.0.0.1:%d", port)
+	o2.Cluster.Name = "A"
 	o2.Cluster.Port = -1
 	s2 := RunServer(o2)
 	defer s2.Shutdown()
 
 	o1 := testDefaultOptionsForLeafNodes()
+	o1.Cluster.Name = "A"
 	o1.Cluster.Port = -1
 	o1.Routes = server.RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", o2.Cluster.Port))
 	s1 := RunServer(o1)
@@ -2964,6 +2968,7 @@ func runSolicitLeafCluster(t *testing.T, clusterName string, d1, d2 *cluster) *c
 	rurl, _ := url.Parse(surl)
 	o.LeafNode.Remotes = []*server.RemoteLeafOpts{{URLs: []*url.URL{rurl}}}
 	o.LeafNode.ReconnectInterval = 100 * time.Millisecond
+	o.Cluster.Name = clusterName
 	o.Cluster.Host = o.Host
 	o.Cluster.Port = -1
 	s := RunServer(&o)
@@ -2989,6 +2994,7 @@ func runSolicitLeafCluster(t *testing.T, clusterName string, d1, d2 *cluster) *c
 	rurl, _ = url.Parse(surl)
 	o2.LeafNode.Remotes = []*server.RemoteLeafOpts{{URLs: []*url.URL{rurl}}}
 	o2.LeafNode.ReconnectInterval = 100 * time.Millisecond
+	o2.Cluster.Name = clusterName
 	o2.Cluster.Host = o.Host
 	o2.Cluster.Port = -1
 	o2.Routes = []*url.URL{curl}
@@ -3107,6 +3113,7 @@ func TestLeafNodeCycleWithSolicited(t *testing.T) {
 func TestLeafNodeNoRaceGeneratingNonce(t *testing.T) {
 	opts := testDefaultOptionsForLeafNodes()
 	opts.Cluster.Port = -1
+	opts.Cluster.Name = "xyz"
 	s := RunServer(opts)
 	defer s.Shutdown()
 

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -1633,6 +1633,7 @@ func TestLeadNodeExportImportComplexSetup(t *testing.T) {
 	resolver = MEMORY
 	cluster {
 		port: -1
+		name: xyz
 	}
 	leafnodes {
 		listen: "127.0.0.1:-1"
@@ -1649,6 +1650,7 @@ func TestLeadNodeExportImportComplexSetup(t *testing.T) {
 	resolver = MEMORY
 	cluster {
 		port: -1
+		name: xyz
 		routes: ["nats://%s:%d"]
 	}
 	leafnodes {
@@ -2175,6 +2177,7 @@ func TestLeafNodeConnectionLimitsCluster(t *testing.T) {
 	resolver = MEMORY
 	cluster {
 		port: -1
+		name: xyz
 	}
 	leafnodes {
 		listen: "127.0.0.1:-1"
@@ -2195,6 +2198,7 @@ func TestLeafNodeConnectionLimitsCluster(t *testing.T) {
 	resolver = MEMORY
 	cluster {
 		port: -1
+		name: xyz
 		routes: ["nats://%s:%d"]
 	}
 	leafnodes {
@@ -2353,9 +2357,10 @@ func TestLeafNodeSwitchGatewayToInterestModeOnly(t *testing.T) {
 // route connections to simulate.
 func TestLeafNodeResetsMSGProto(t *testing.T) {
 	opts := testDefaultOptionsForLeafNodes()
+	opts.Cluster.Name = "xyz"
 	opts.Cluster.Host = opts.Host
 	opts.Cluster.Port = -1
-	opts.Gateway.Name = "lproto"
+	opts.Gateway.Name = "xyz"
 	opts.Gateway.Host = opts.Host
 	opts.Gateway.Port = -1
 	opts.Accounts = []*server.Account{server.NewAccount("$SYS")}
@@ -2376,7 +2381,7 @@ func TestLeafNodeResetsMSGProto(t *testing.T) {
 	gw := createGatewayConn(t, opts.Gateway.Host, opts.Gateway.Port)
 	defer gw.Close()
 
-	gwSend, gwExpect := setupGatewayConn(t, gw, "A", "lproto")
+	gwSend, gwExpect := setupGatewayConn(t, gw, "A", "xyz")
 	gwSend("PING\r\n")
 	gwExpect(pongRe)
 
@@ -3212,6 +3217,7 @@ func TestClusterTLSMixedIPAndDNS(t *testing.T) {
 		}
 		cluster {
 			listen: "127.0.0.1:-1"
+			name: xyz
 		}
 	`))
 	srvA, optsA := RunServerWithConfig(confA)
@@ -3230,6 +3236,7 @@ func TestClusterTLSMixedIPAndDNS(t *testing.T) {
 		}
 		cluster {
 			listen: "127.0.0.1:-1"
+			name: xyz
 			routes [
 				"nats://%s:%d"
 			]

--- a/test/monitor_test.go
+++ b/test/monitor_test.go
@@ -51,7 +51,7 @@ func runMonitorServerClusteredPair(t *testing.T) (*server.Server, *server.Server
 	opts.Port = CLIENT_PORT
 	opts.HTTPPort = MONITOR_PORT
 	opts.HTTPHost = "127.0.0.1"
-	opts.Cluster = server.ClusterOpts{Host: "127.0.0.1", Port: 10223}
+	opts.Cluster = server.ClusterOpts{Name: "M", Host: "127.0.0.1", Port: 10223}
 	opts.Routes = server.RoutesFromStr("nats-route://127.0.0.1:10222")
 	opts.NoSystemAccount = true
 
@@ -61,7 +61,7 @@ func runMonitorServerClusteredPair(t *testing.T) (*server.Server, *server.Server
 	opts2.Port = CLIENT_PORT + 1
 	opts2.HTTPPort = MONITOR_PORT + 1
 	opts2.HTTPHost = "127.0.0.1"
-	opts2.Cluster = server.ClusterOpts{Host: "127.0.0.1", Port: 10222}
+	opts2.Cluster = server.ClusterOpts{Name: "M", Host: "127.0.0.1", Port: 10222}
 	opts2.Routes = server.RoutesFromStr("nats-route://127.0.0.1:10223")
 	opts2.NoSystemAccount = true
 

--- a/test/operator_test.go
+++ b/test/operator_test.go
@@ -333,6 +333,7 @@ func TestReloadDoesNotWipeAccountsWithOperatorMode(t *testing.T) {
 	cf := `
 	listen: 127.0.0.1:-1
 	cluster {
+		name: "A"
 		listen: 127.0.0.1:-1
 		authorization {
 			timeout: 2.2
@@ -456,6 +457,7 @@ func TestReloadDoesUpdateAccountsWithMemoryResolver(t *testing.T) {
 	cf := `
 	listen: 127.0.0.1:-1
 	cluster {
+		name: "A"
 		listen: 127.0.0.1:-1
 		authorization {
 			timeout: 2.2
@@ -547,6 +549,7 @@ func TestReloadFailsWithBadAccountsWithMemoryResolver(t *testing.T) {
 	cf := `
 	listen: 127.0.0.1:-1
 	cluster {
+		name: "A"
 		listen: 127.0.0.1:-1
 		authorization {
 			timeout: 2.2
@@ -610,6 +613,7 @@ func TestConnsRequestDoesNotLoadAccountCheckingConnLimits(t *testing.T) {
 	cf := `
 	listen: 127.0.0.1:-1
 	cluster {
+		name: "A"
 		listen: 127.0.0.1:-1
 		authorization {
 			timeout: 2.2

--- a/test/opts_test.go
+++ b/test/opts_test.go
@@ -13,7 +13,9 @@
 
 package test
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestServerConfig(t *testing.T) {
 	srv, opts := RunServerWithConfig("./configs/override.conf")

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -603,6 +603,7 @@ func TestRouteSendAsyncINFOToClients(t *testing.T) {
 		sendRouteINFO := func(routeSend sendFun, routeExpect expectFun, urls []string) {
 			routeInfo := server.Info{}
 			routeInfo.ID = routeID
+			routeInfo.Cluster = "xyz"
 			routeInfo.Host = "127.0.0.1"
 			routeInfo.Port = 5222
 			routeInfo.ClientConnectURLs = urls

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -1123,6 +1123,7 @@ func TestRoutesOnlyImportOrExport(t *testing.T) {
 		cf := createConfFile(t, []byte(fmt.Sprintf(`
 			port: -1
 			cluster {
+				name: "Z"
 				port: -1
 				authorization {
 					user: ivan

--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -719,6 +719,7 @@ func TestServiceLatencyWithJWT(t *testing.T) {
 	cf := `
 	listen: 127.0.0.1:-1
 	cluster {
+		name: "A"
 		listen: 127.0.0.1:-1
 		authorization {
 			timeout: 2.2

--- a/test/test.go
+++ b/test/test.go
@@ -216,10 +216,10 @@ func doDefaultConnect(t tLogger, c net.Conn) {
 	doConnect(t, c, false, false, false)
 }
 
-const connectProto = "CONNECT {\"verbose\":false,\"user\":\"%s\",\"pass\":\"%s\",\"name\":\"%s\"}\r\n"
+const routeConnectProto = "CONNECT {\"verbose\":false,\"user\":\"%s\",\"pass\":\"%s\",\"name\":\"%s\",\"cluster\":\"xyz\"}\r\n"
 
 func doRouteAuthConnect(t tLogger, c net.Conn, user, pass, id string) {
-	cs := fmt.Sprintf(connectProto, user, pass, id)
+	cs := fmt.Sprintf(routeConnectProto, user, pass, id)
 	sendProto(t, c, cs)
 }
 

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -553,6 +553,7 @@ func TestTLSRoutesCertificateCNBasedAuth(t *testing.T) {
 
 	optsA.Host = "127.0.0.1"
 	optsA.Port = 9335
+	optsA.Cluster.Name = "xyz"
 	optsA.Cluster.Host = optsA.Host
 	optsA.Cluster.Port = 9935
 	optsA.Routes = server.RoutesFromStr(routeURLs)
@@ -562,6 +563,7 @@ func TestTLSRoutesCertificateCNBasedAuth(t *testing.T) {
 
 	optsB.Host = "127.0.0.1"
 	optsB.Port = 9336
+	optsB.Cluster.Name = "xyz"
 	optsB.Cluster.Host = optsB.Host
 	optsB.Cluster.Port = 9936
 	optsB.Routes = server.RoutesFromStr(routeURLs)
@@ -571,6 +573,7 @@ func TestTLSRoutesCertificateCNBasedAuth(t *testing.T) {
 
 	optsC.Host = "127.0.0.1"
 	optsC.Port = 9337
+	optsC.Cluster.Name = "xyz"
 	optsC.Cluster.Host = optsC.Host
 	optsC.Cluster.Port = 9937
 	optsC.Routes = server.RoutesFromStr(routeURLs)


### PR DESCRIPTION
Added cluster names as required for prep work for clustered JetStream. System can dynamically pick a cluster name and settle on one even in large clusters.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
