### PR TITLE
[ADDED] Cookie JWT auth for WebSocket

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1497,7 +1497,13 @@ func (c *client) processConnect(arg []byte) error {
 	lang := c.opts.Lang
 	account := c.opts.Account
 	accountNew := c.opts.AccountNew
+
+	// If websocket client and JWT not in the CONNECT, use the cookie JWT (possibly empty).
+	if ws := c.ws; ws != nil && c.opts.JWT == "" {
+		c.opts.JWT = ws.cookieJwt
+	}
 	ujwt := c.opts.JWT
+
 	// For headers both client and server need to support.
 	c.headers = supportsHeaders && c.opts.Headers
 	c.mu.Unlock()

--- a/server/opts.go
+++ b/server/opts.go
@@ -265,6 +265,11 @@ type WebsocketOpts struct {
 	// Users defined here or in the global options.
 	NoAuthUser string
 
+	// Name of the cookie, which if present in WebSocket upgrade headers,
+	// will be treated as JWT during CONNECT phase as long as
+	// "jwt" specified in the CONNECT options is missing or empty.
+	JWTCookie string
+
 	// Authentication section. If anything is configured in this section,
 	// it will override the authorization configuration for regular clients.
 	Username string
@@ -3152,6 +3157,8 @@ func parseWebsocket(v interface{}, o *Options, errors *[]error, warnings *[]erro
 			if auth.nkeys != nil {
 				o.Websocket.Nkeys = append(o.Websocket.Nkeys, auth.nkeys...)
 			}
+		case "jwt_cookie":
+			o.Websocket.JWTCookie = mv.(string)
 		case "no_auth_user":
 			o.Websocket.NoAuthUser = mv.(string)
 		default:


### PR DESCRIPTION
When authenticating via browser, the best security practice is to use HttpOnly cookies, to avoid scripts stealing client identity via XSS.

HttpOnly cookies can't be accessed by JavaScript, making those perfect for server-certified authentication.

PR implements optional JWT auth using cookies by specifying this option in a config file:
`ws: { jwt_cookie: "cookie_name" }`

This will make NATS treat a cookie named "cookie_name" as JWT for authentication. If this cookie exists in the HTTP request and is valid, the server will act as if authentication is not required. If this token is missing or invalid, it's possible to authenticate using other configured methods.

Notice that since signing is not possible when authorizing this way, BearerToken should be set in the JWT (e.g. User should be created with `nsc add user --bearer`).

Tests for regular JWT auth and cookie auth are included.

/cc @nats-io/core
