### PR TITLE
Allow support for no responders nil response message.

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -144,6 +144,10 @@ var (
 	// ErrMsgHeadersNotSupported signals the parser detected a message header
 	// but they are not supported on this server.
 	ErrMsgHeadersNotSupported = errors.New("message headers not supported")
+
+	// ErrNoRespondersRequiresHeaders signals that a client needs to have headers
+	// on if they want no responders behavior.
+	ErrNoRespondersRequiresHeaders = errors.New("no responders requires headers support")
 )
 
 // configErr is a configuration error.


### PR DESCRIPTION
Allow support for a empty response message when no responders are present.
This will also set a response status of 503 with the new header support.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
