### PR TITLE
Properly handle leafnode spoke permissions.

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -808,7 +808,7 @@ func (s *Server) isLeafNodeAuthorized(c *client) bool {
 		return false
 	}
 
-	// We are here if we accept leafnode connections without any credential.
+	// We are here if we accept leafnode connections without any credentials.
 
 	// Still, if the CONNECT has some user info, we will bind to the
 	// user's account or to the specified default account (if provided)

--- a/server/client.go
+++ b/server/client.go
@@ -2707,8 +2707,8 @@ func (c *client) deliverMsg(sub *subscription, subject, mh, msg []byte, gwrply b
 		return false
 	}
 
-	// Check if we are a spoke leafnode and have perms to check.
-	if client.isSpokeLeafNode() && client.perms != nil {
+	// Check if we are a leafnode and have perms to check.
+	if client.kind == LEAF && client.perms != nil {
 		if !client.pubAllowed(string(subject)) {
 			client.mu.Unlock()
 			return false

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -909,10 +909,20 @@ func (c *client) processLeafnodeInfo(info *Info) error {
 
 	// Check to see if we have permissions updates here.
 	if info.Import != nil || info.Export != nil {
-		c.setPermissions(&Permissions{
+		perms := &Permissions{
 			Publish:   info.Export,
 			Subscribe: info.Import,
-		})
+		}
+		// Check if we have local deny clauses that we need to merge.
+		if remote := c.leaf.remote; remote != nil {
+			if len(remote.DenyExports) > 0 {
+				perms.Publish.Deny = append(perms.Publish.Deny, remote.DenyExports...)
+			}
+			if len(remote.DenyImports) > 0 {
+				perms.Subscribe.Deny = append(perms.Subscribe.Deny, remote.DenyImports...)
+			}
+		}
+		c.setPermissions(perms)
 	}
 
 	return nil

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -177,10 +177,10 @@ func newLeafNodeCfg(remote *RemoteLeafOpts) *leafNodeCfg {
 	if len(remote.DenyExports) > 0 || len(remote.DenyImports) > 0 {
 		perms := &Permissions{}
 		if len(remote.DenyExports) > 0 {
-			perms.Subscribe = &SubjectPermission{Deny: remote.DenyExports}
+			perms.Publish = &SubjectPermission{Deny: remote.DenyExports}
 		}
 		if len(remote.DenyImports) > 0 {
-			perms.Publish = &SubjectPermission{Deny: remote.DenyImports}
+			perms.Subscribe = &SubjectPermission{Deny: remote.DenyImports}
 		}
 		cfg.perms = perms
 	}
@@ -1310,7 +1310,7 @@ func (c *client) sendLeafNodeSubUpdate(key string, n int32) {
 	// If we are a spoke, we need to check if we are allowed to send this subscription over to the hub.
 	if c.isSpokeLeafNode() {
 		checkPerms := true
-		if len(key) > 0 && key[0] == '$' || key[0] == '_' {
+		if len(key) > 0 && (key[0] == '$' || key[0] == '_') {
 			if strings.HasPrefix(key, leafNodeLoopDetectionSubjectPrefix) ||
 				strings.HasPrefix(key, oldGWReplyPrefix) ||
 				strings.HasPrefix(key, gwReplyPrefix) {

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -89,6 +89,22 @@ func checkSubInterest(t *testing.T, s *server.Server, accName, subject string, t
 	})
 }
 
+func checkNoSubInterest(t *testing.T, s *server.Server, accName, subject string, timeout time.Duration) {
+	t.Helper()
+	acc, err := s.LookupAccount(accName)
+	if err != nil {
+		t.Fatalf("error looking up account %q: %v", accName, err)
+	}
+
+	start := time.Now()
+	for time.Now().Before(start.Add(timeout)) {
+		if acc.SubscriptionInterest(subject) {
+			t.Fatalf("Did not expect interest for %q", subject)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 func runThreeServers(t *testing.T) (srvA, srvB, srvC *server.Server, optsA, optsB, optsC *server.Options) {
 	srvA, optsA = RunServerWithConfig("./configs/srv_a.conf")
 	srvB, optsB = RunServerWithConfig("./configs/srv_b.conf")


### PR DESCRIPTION
When a leafnode would connect with credentials that had permissions the spoke did not have a way of knowing what those were. This could lead to being disconnected when sending subscriptions or messages to the hub which were not allowed.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
