### PR TITLE
Add filtering by name and cluster to PING events

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -834,8 +834,9 @@ func (s *Server) leafNodeConnected(sub *subscription, _ *client, subject, reply 
 
 // Common filter options for system requests STATSZ VARZ SUBSZ CONNZ ROUTEZ GATEWAYZ LEAFZ
 type ZFilterOptions struct {
-	Name    string `json:"server"`
+	Name    string `json:"name"`
 	Cluster string `json:"cluster"`
+	Host    string `json:"host"`
 }
 
 // returns true if the request does NOT apply to this server and can be ignored.
@@ -850,6 +851,9 @@ func (s *Server) filterRequest(msg []byte) (bool, error) {
 		return false, err
 	}
 	if fOpts.Name != "" && !strings.Contains(s.info.Name, fOpts.Name) {
+		return true, nil
+	}
+	if fOpts.Host != "" && !strings.Contains(s.info.Host, fOpts.Host) {
 		return true, nil
 	}
 	if fOpts.Cluster != "" {

--- a/server/events.go
+++ b/server/events.go
@@ -242,7 +242,7 @@ RESET:
 	servername := s.info.Name
 	seqp := &s.sys.seq
 	js := s.js != nil
-	var cluster string
+	cluster := s.info.Cluster
 	if s.gateway.enabled {
 		cluster = s.getGatewayName()
 	}
@@ -832,14 +832,57 @@ func (s *Server) leafNodeConnected(sub *subscription, _ *client, subject, reply 
 	}
 }
 
+// Common filter options for system requests STATSZ VARZ SUBSZ CONNZ ROUTEZ GATEWAYZ LEAFZ
+type ZFilterOptions struct {
+	Name    string `json:"server"`
+	Cluster string `json:"cluster"`
+}
+
+// returns true if the request does NOT apply to this server and can be ignored.
+// DO NOT hold the server lock when
+func (s *Server) filterRequest(msg []byte) (bool, error) {
+	if len(msg) == 0 {
+		return false, nil
+	}
+	var fOpts ZFilterOptions
+	err := json.Unmarshal(msg, &fOpts)
+	if err != nil {
+		return false, err
+	}
+	if fOpts.Name != "" && !strings.Contains(s.info.Name, fOpts.Name) {
+		return true, nil
+	}
+	if fOpts.Cluster != "" {
+		s.mu.Lock()
+		cluster := s.info.Cluster
+		s.mu.Unlock()
+		if !strings.Contains(cluster, fOpts.Cluster) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // statszReq is a request for us to respond with current statz.
 func (s *Server) statszReq(sub *subscription, _ *client, subject, reply string, msg []byte) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if !s.eventsEnabled() || reply == _EMPTY_ {
+	if !s.EventsEnabled() || reply == _EMPTY_ {
 		return
 	}
+	if ignore, err := s.filterRequest(msg); err != nil {
+		server := &ServerInfo{}
+		response := map[string]interface{}{"server": server}
+		response["error"] = map[string]interface{}{
+			"code":        http.StatusBadRequest,
+			"description": err.Error(),
+		}
+		s.sendInternalMsgLocked(reply, _EMPTY_, server, response)
+		return
+	} else if ignore {
+		return
+	}
+	s.mu.Lock()
 	s.sendStatsz(reply)
+	s.mu.Unlock()
 }
 
 func (s *Server) zReq(reply string, msg []byte, optz interface{}, respf func() (interface{}, error)) {
@@ -851,7 +894,12 @@ func (s *Server) zReq(reply string, msg []byte, optz interface{}, respf func() (
 	var err error
 	status := 0
 	if len(msg) != 0 {
-		err = json.Unmarshal(msg, optz)
+		filter := false
+		if filter, err = s.filterRequest(msg); filter {
+			return
+		} else if err == nil {
+			err = json.Unmarshal(msg, optz)
+		}
 		status = http.StatusBadRequest // status is only included on error, so record how far execution got
 	}
 	if err == nil {

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -100,7 +100,7 @@ func runTrustedCluster(t *testing.T) (*Server, *Options, *Server, *Options, nkey
 	optsA.TrustedKeys = []string{pub}
 	optsA.AccountResolver = mr
 	optsA.SystemAccount = apub
-	optsA.ServerName = "A"
+	optsA.ServerName = "A_SRV"
 	// Add in dummy gateway
 	optsA.Gateway.Name = "TEST CLUSTER 22"
 	optsA.Gateway.Host = "127.0.0.1"
@@ -110,7 +110,7 @@ func runTrustedCluster(t *testing.T) (*Server, *Options, *Server, *Options, nkey
 	sa := RunServer(optsA)
 
 	optsB := nextServerOpts(optsA)
-	optsB.ServerName = "B"
+	optsB.ServerName = "B_SRV"
 	optsB.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", optsA.Cluster.Host, optsA.Cluster.Port))
 	sb := RunServer(optsB)
 
@@ -1452,7 +1452,7 @@ func TestServerEventsStatsZ(t *testing.T) {
 	if lr := len(m3.Stats.Routes); lr != 1 {
 		t.Fatalf("Expected a route, but got %d", lr)
 	}
-	if sr := m3.Stats.Routes[0]; sr.Name != "B" {
+	if sr := m3.Stats.Routes[0]; sr.Name != "B_SRV" {
 		t.Fatalf("Expected server A's route to B to have Name set to %q, got %q", "B", sr.Name)
 	}
 
@@ -1470,8 +1470,8 @@ func TestServerEventsStatsZ(t *testing.T) {
 	if lr := len(m.Stats.Routes); lr != 1 {
 		t.Fatalf("Expected a route, but got %d", lr)
 	}
-	if sr := m.Stats.Routes[0]; sr.Name != "A" {
-		t.Fatalf("Expected server B's route to A to have Name set to %q, got %q", "A", sr.Name)
+	if sr := m.Stats.Routes[0]; sr.Name != "A_SRV" {
+		t.Fatalf("Expected server B's route to A to have Name set to %q, got %q", "A_SRV", sr.Name)
 	}
 }
 
@@ -1487,28 +1487,41 @@ func TestServerEventsPingStatsZ(t *testing.T) {
 	}
 	defer nc.Close()
 
-	reply := nc.NewRespInbox()
-	sub, _ := nc.SubscribeSync(reply)
-
-	nc.PublishRequest(serverStatsPingReqSubj, reply, nil)
-
-	// Make sure its a statsz
-	m := ServerStatsMsg{}
-
-	// Receive both manually.
-	msg, err := sub.NextMsg(time.Second)
-	if err != nil {
-		t.Fatalf("Error receiving msg: %v", err)
+	requestTbl := []string{
+		`{"cluster":"TEST"}`,
+		`{"cluster":"CLUSTER"}`,
+		`{"name":"SRV"}`,
+		`{"name":"_"}`,
+		fmt.Sprintf(`{"host":"%s"}`, optsB.Host),
+		fmt.Sprintf(`{"host":"%s", "cluster":"CLUSTER", "name":"SRV"}`, optsB.Host),
 	}
-	if err := json.Unmarshal(msg.Data, &m); err != nil {
-		t.Fatalf("Error unmarshalling the statz json: %v", err)
-	}
-	msg, err = sub.NextMsg(time.Second)
-	if err != nil {
-		t.Fatalf("Error receiving msg: %v", err)
-	}
-	if err := json.Unmarshal(msg.Data, &m); err != nil {
-		t.Fatalf("Error unmarshalling the statz json: %v", err)
+
+	for _, msg := range requestTbl {
+		t.Run(msg, func(t *testing.T) {
+			reply := nc.NewRespInbox()
+			sub, _ := nc.SubscribeSync(reply)
+
+			nc.PublishRequest(serverStatsPingReqSubj, reply, []byte(msg))
+
+			// Make sure its a statsz
+			m := ServerStatsMsg{}
+
+			// Receive both manually.
+			msg, err := sub.NextMsg(time.Second)
+			if err != nil {
+				t.Fatalf("Error receiving msg: %v", err)
+			}
+			if err := json.Unmarshal(msg.Data, &m); err != nil {
+				t.Fatalf("Error unmarshalling the statz json: %v", err)
+			}
+			msg, err = sub.NextMsg(time.Second)
+			if err != nil {
+				t.Fatalf("Error receiving msg: %v", err)
+			}
+			if err := json.Unmarshal(msg.Data, &m); err != nil {
+				t.Fatalf("Error unmarshalling the statz json: %v", err)
+			}
+		})
 	}
 }
 
@@ -1524,9 +1537,18 @@ func TestServerEventsPingStatsZFilter(t *testing.T) {
 	}
 	defer nc.Close()
 
-	// Receive both manually.
-	if _, err := nc.Request(serverStatsPingReqSubj, []byte(`{"cluster":"DOESNOTEXIST"}`), time.Second/4); err != nats.ErrTimeout {
-		t.Fatalf("Error, expected timeout: %v", err)
+	requestTbl := []string{
+		`{"cluster":"DOESNOTEXIST"}`,
+		`{"host":"DOESNOTEXIST"}`,
+		`{"name":"DOESNOTEXIST"}`,
+	}
+	for _, msg := range requestTbl {
+		t.Run(msg, func(t *testing.T) {
+			// Receive both manually.
+			if _, err := nc.Request(serverStatsPingReqSubj, []byte(msg), time.Second/4); err != nats.ErrTimeout {
+				t.Fatalf("Error, expected timeout: %v", err)
+			}
+		})
 	}
 }
 
@@ -1650,10 +1672,10 @@ func TestServerEventsPingMonitorz(t *testing.T) {
 			}
 
 			serverName := ""
-			if response1["server"]["name"] == "A" {
-				serverName = "B"
-			} else if response1["server"]["name"] == "B" {
-				serverName = "A"
+			if response1["server"]["name"] == "A_SRV" {
+				serverName = "B_SRV"
+			} else if response1["server"]["name"] == "B_SRV" {
+				serverName = "A_SRV"
 			} else {
 				t.Fatalf("Error finding server in %s", string(msg.Data))
 			}

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1047,6 +1047,7 @@ type JetStreamVarz struct {
 
 // ClusterOptsVarz contains monitoring cluster information
 type ClusterOptsVarz struct {
+	Name        string   `json:"name,omitempty"`
 	Host        string   `json:"addr,omitempty"`
 	Port        int      `json:"cluster_port,omitempty"`
 	AuthTimeout float64  `json:"auth_timeout,omitempty"`
@@ -1197,6 +1198,7 @@ func (s *Server) createVarz(pcpu float64, rss int64) *Varz {
 		HTTPBasePath: opts.HTTPBasePath,
 		HTTPSPort:    opts.HTTPSPort,
 		Cluster: ClusterOptsVarz{
+			Name:        info.Cluster,
 			Host:        c.Host,
 			Port:        c.Port,
 			AuthTimeout: c.AuthTimeout,

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -2415,6 +2415,7 @@ func TestMonitorCluster(t *testing.T) {
 	defer s.Shutdown()
 
 	expected := ClusterOptsVarz{
+		"A",
 		opts.Cluster.Host,
 		opts.Cluster.Port,
 		opts.Cluster.AuthTimeout,
@@ -2434,11 +2435,12 @@ func TestMonitorCluster(t *testing.T) {
 
 		// Having this here to make sure that if fields are added in ClusterOptsVarz,
 		// we make sure to update this test (compiler will report an error if we don't)
-		_ = ClusterOptsVarz{"", 0, 0, nil}
+		_ = ClusterOptsVarz{"", "", 0, 0, nil}
 
 		// Alter the fields to make sure that we have a proper deep copy
 		// of what may be stored in the server. Anything we change here
 		// should not affect the next returned value.
+		v.Cluster.Name = "wrong"
 		v.Cluster.Host = "wrong"
 		v.Cluster.Port = 0
 		v.Cluster.AuthTimeout = 0


### PR DESCRIPTION
Issue reset after cluster name changed. 
Add filtering by name and cluster to system events.

empty cluster name
```
 nats -s localhost:4141 --creds=$NATS_ADMIN_CREDS  req "\$SYS.REQ.SERVER.PING.VARZ" "{\"cluster\":\"\",\"subscriptions\":true}"
15:30:43 Sending request on [$SYS.REQ.SERVER.PING.VARZ]
15:30:43 Received on [_INBOX.SMi3XB4JfXyrhLMLK60lt2]: '{
  "data": {
    "server_id": "NBZEZ5V6J7N6MXVZPH7VOHFGW46NUMSJYXEDKZSBA5Y3USF4Z5J7SX74",
    "server_name": "NBZEZ5V6J7N6MXVZPH7VOHFGW46NUMSJYXEDKZSBA5Y3USF4Z5J7SX74",
    "version": "2.2.0-beta.15",
    "proto": 1,
    "go": "go1.14.1",
    "host": "localhost",
    "port": 4141,
    "auth_required": true,
    "max_connections": 65536,
    "ping_interval": 120000000000,
    "ping_max": 2,
    "http_host": "localhost",
    "http_port": 0,
    "http_base_path": "",
    "https_port": 0,
    "auth_timeout": 1,
    "max_control_line": 4096,
    "max_payload": 1048576,
    "max_pending": 67108864,
    "cluster": {
      "name": "testcluster"
    },
    "gateway": {},
    "leaf": {},
    "jetstream": {},
    "tls_timeout": 0.5,
    "write_deadline": 2000000000,
    "start": "2020-06-16T15:30:41.518627-04:00",
    "now": "2020-06-16T15:30:43.46485-04:00",
    "uptime": "1s",
    "mem": 8835072,
    "cores": 16,
    "gomaxprocs": 16,
    "cpu": 0,
    "connections": 1,
    "total_connections": 1,
    "routes": 0,
    "remotes": 0,
    "leafnodes": 0,
    "in_msgs": 0,
    "out_msgs": 0,
    "in_bytes": 0,
    "out_bytes": 0,
    "slow_consumers": 0,
    "subscriptions": 0,
    "http_req_stats": {},
    "config_load_time": "2020-06-16T15:30:41.518627-04:00"
  },
  "server": {
    "name": "NBZEZ5V6J7N6MXVZPH7VOHFGW46NUMSJYXEDKZSBA5Y3USF4Z5J7SX74",
    "host": "localhost",
    "id": "NBZEZ5V6J7N6MXVZPH7VOHFGW46NUMSJYXEDKZSBA5Y3USF4Z5J7SX74",
    "cluster": "testcluster",
    "ver": "2.2.0-beta.15",
    "seq": 8,
    "jetstream": false,
    "time": "2020-06-16T15:30:43.464889-04:00"
  }
}'
```
matching cluster name
```
nats -s localhost:4141 --creds=$NATS_ADMIN_CREDS  req "\$SYS.REQ.SERVER.PING.VARZ" "{\"cluster\":\"test\",\"subscriptions\":true}"
15:34:39 Sending request on [$SYS.REQ.SERVER.PING.VARZ]
15:34:39 Received on [_INBOX.iTNqmEGarJYdshuXRGIgwQ]: '{
  "data": {
    "server_id": "NDAWGFQUNDC3AB5RANCCNL5NK6SPHUDANUQAQLIPMGLDDEJJOQI7R7WR",
    "server_name": "NDAWGFQUNDC3AB5RANCCNL5NK6SPHUDANUQAQLIPMGLDDEJJOQI7R7WR",
    "version": "2.2.0-beta.15",
    "proto": 1,
    "go": "go1.14.1",
    "host": "localhost",
    "port": 4141,
    "auth_required": true,
    "max_connections": 65536,
    "ping_interval": 120000000000,
    "ping_max": 2,
    "http_host": "localhost",
    "http_port": 0,
    "http_base_path": "",
    "https_port": 0,
    "auth_timeout": 1,
    "max_control_line": 4096,
    "max_payload": 1048576,
    "max_pending": 67108864,
    "cluster": {
      "name": "testcluster"
    },
    "gateway": {},
    "leaf": {},
    "jetstream": {},
    "tls_timeout": 0.5,
    "write_deadline": 2000000000,
    "start": "2020-06-16T15:34:37.454438-04:00",
    "now": "2020-06-16T15:34:39.372401-04:00",
    "uptime": "1s",
    "mem": 9154560,
    "cores": 16,
    "gomaxprocs": 16,
    "cpu": 0,
    "connections": 1,
    "total_connections": 1,
    "routes": 0,
    "remotes": 0,
    "leafnodes": 0,
    "in_msgs": 0,
    "out_msgs": 0,
    "in_bytes": 0,
    "out_bytes": 0,
    "slow_consumers": 0,
    "subscriptions": 0,
    "http_req_stats": {},
    "config_load_time": "2020-06-16T15:34:37.454438-04:00"
  },
  "server": {
    "name": "NDAWGFQUNDC3AB5RANCCNL5NK6SPHUDANUQAQLIPMGLDDEJJOQI7R7WR",
    "host": "localhost",
    "id": "NDAWGFQUNDC3AB5RANCCNL5NK6SPHUDANUQAQLIPMGLDDEJJOQI7R7WR",
    "cluster": "testcluster",
    "ver": "2.2.0-beta.15",
    "seq": 8,
    "jetstream": false,
    "time": "2020-06-16T15:34:39.372457-04:00"
  }
}'
```

unused cluster name
```
 nats -s localhost:4141 --creds=$NATS_ADMIN_CREDS  req "\$SYS.REQ.SERVER.PING.VARZ" "{\"cluster\":\"sdf\",\"subscriptions\":true}"
15:30:48 Sending request on [$SYS.REQ.SERVER.PING.VARZ]
nats: error: nats: timeout, try --help
```
Signed-off-by: Matthias Hanel <mh@synadia.com>

