### PR TITLE
Properly support leadnode clusters.

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -500,6 +500,18 @@ func (a *Account) SubscriptionInterest(subject string) bool {
 	return interest
 }
 
+// Interest returns the number of subscriptions for a given subject that match.
+func (a *Account) Interest(subject string) int {
+	var nms int
+	a.mu.RLock()
+	if a.sl != nil {
+		res := a.sl.Match(subject)
+		nms = len(res.psubs) + len(res.qsubs)
+	}
+	a.mu.RUnlock()
+	return nms
+}
+
 // addClient keeps our accounting of local active clients or leafnodes updated.
 // Returns previous total.
 func (a *Account) addClient(c *client) int {

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -489,15 +489,7 @@ func (a *Account) TotalSubs() int {
 // for the given `subject`. Works only for literal subjects.
 // TODO: Add support for wildcards
 func (a *Account) SubscriptionInterest(subject string) bool {
-	var interest bool
-	a.mu.RLock()
-	if a.sl != nil {
-		if res := a.sl.Match(subject); len(res.psubs)+len(res.qsubs) > 0 {
-			interest = true
-		}
-	}
-	a.mu.RUnlock()
-	return interest
+	return a.Interest(subject) > 0
 }
 
 // Interest returns the number of subscriptions for a given subject that match.

--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.2.0-beta.17"
+	VERSION = "2.2.0-beta.18"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1639,6 +1639,7 @@ func TestLeafNodeOriginClusterInfo(t *testing.T) {
 	// Make sure we disconnect and reconnect.
 	checkLeafNodeConnectedCount(t, s, 0)
 	checkLeafNodeConnected(t, s)
+	checkLeafNodeConnected(t, hub)
 
 	l = grabLeaf()
 	if rc := l.remoteCluster(); rc != "xyz" {

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -787,10 +787,12 @@ func TestLeafNodeLoop(t *testing.T) {
 
 func TestLeafNodeLoopFromDAG(t *testing.T) {
 	// We want B & C to point to A, A itself does not point to any other server.
+	// We need to cancel clustering since now this will suppress on its own.
 	oa := DefaultOptions()
 	oa.ServerName = "A"
 	oa.LeafNode.ReconnectInterval = 10 * time.Millisecond
 	oa.LeafNode.Port = -1
+	oa.Cluster = ClusterOpts{}
 	sa := RunServer(oa)
 	defer sa.Shutdown()
 
@@ -802,6 +804,7 @@ func TestLeafNodeLoopFromDAG(t *testing.T) {
 	ob.LeafNode.ReconnectInterval = 10 * time.Millisecond
 	ob.LeafNode.Port = -1
 	ob.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{ua}}}
+	ob.Cluster = ClusterOpts{}
 	sb := RunServer(ob)
 	defer sb.Shutdown()
 
@@ -816,6 +819,7 @@ func TestLeafNodeLoopFromDAG(t *testing.T) {
 	oc.LeafNode.ReconnectInterval = 10 * time.Millisecond
 	oc.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{ua}}, {URLs: []*url.URL{ub}}}
 	oc.LeafNode.connDelay = 100 * time.Millisecond // Allow logger to be attached before connecting.
+	oc.Cluster = ClusterOpts{}
 	sc := RunServer(oc)
 
 	lc := &captureErrorLogger{errCh: make(chan string, 10)}
@@ -1460,7 +1464,6 @@ func TestLeafNodeTmpClients(t *testing.T) {
 }
 
 func TestLeafNodeTLSVerifyAndMap(t *testing.T) {
-
 	accName := "MyAccount"
 	acc := NewAccount(accName)
 	certUserName := "CN=example.com,OU=NATS.io"
@@ -1552,5 +1555,97 @@ func TestLeafNodeTLSVerifyAndMap(t *testing.T) {
 				t.Fatalf("Expected account %q, got %v", accName, accname)
 			}
 		})
+	}
+}
+
+func TestLeafNodeOriginClusterInfo(t *testing.T) {
+	hopts := DefaultOptions()
+	hopts.ServerName = "hub"
+	hopts.LeafNode.Port = -1
+
+	hub := RunServer(hopts)
+	defer hub.Shutdown()
+
+	conf := createConfFile(t, []byte(fmt.Sprintf(`
+		port: -1
+		leaf {
+			remotes [ { url: "nats://127.0.0.1:%d" } ]
+		}
+	`, hopts.LeafNode.Port)))
+
+	defer os.Remove(conf)
+	opts, err := ProcessConfigFile(conf)
+	if err != nil {
+		t.Fatalf("Error processing config file: %v", err)
+	}
+	opts.NoLog, opts.NoSigs = true, true
+
+	s := RunServer(opts)
+	defer s.Shutdown()
+
+	checkLeafNodeConnected(t, s)
+
+	// Check the info on the leadnode client in the hub.
+	grabLeaf := func() *client {
+		var l *client
+		hub.mu.Lock()
+		for _, l = range hub.leafs {
+			break
+		}
+		hub.mu.Unlock()
+		return l
+	}
+
+	l := grabLeaf()
+	if rc := l.remoteCluster(); rc != "" {
+		t.Fatalf("Expected an empty remote cluster, got %q", rc)
+	}
+
+	s.Shutdown()
+
+	// Now make our leafnode part of a cluster.
+	conf = createConfFile(t, []byte(fmt.Sprintf(`
+		port: -1
+		leaf {
+			remotes [ { url: "nats://127.0.0.1:%d" } ]
+		}
+		cluster {
+			name: "abc"
+			listen: "127.0.0.1:-1"
+		}
+	`, hopts.LeafNode.Port)))
+
+	defer os.Remove(conf)
+	opts, err = ProcessConfigFile(conf)
+	if err != nil {
+		t.Fatalf("Error processing config file: %v", err)
+	}
+	opts.NoLog, opts.NoSigs = true, true
+
+	s = RunServer(opts)
+	defer s.Shutdown()
+
+	checkLeafNodeConnected(t, s)
+
+	l = grabLeaf()
+	if rc := l.remoteCluster(); rc != "abc" {
+		t.Fatalf("Expected a remote cluster name of \"abc\", got %q", rc)
+	}
+	pcid := l.cid
+
+	// Now make sure that if we update our cluster name, simulating the settling
+	// of dynamic cluster names between competing servers.
+	s.setClusterName("xyz")
+	// Make sure we disconnect and reconnect.
+	checkLeafNodeConnectedCount(t, s, 0)
+	checkLeafNodeConnected(t, s)
+
+	l = grabLeaf()
+	if rc := l.remoteCluster(); rc != "xyz" {
+		t.Fatalf("Expected a remote cluster name of \"xyz\", got %q", rc)
+	}
+	// Make sure we reconnected and have a new CID.
+	if l.cid == pcid {
+		t.Fatalf("Expected a different id, got the same")
 	}
 }

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1902,6 +1902,11 @@ func (reason ClosedState) String() string {
 		return "Internal Client"
 	case MsgHeaderViolation:
 		return "Message Header Violation"
+	case NoRespondersRequiresHeaders:
+		return "No Responders Requires Headers"
+	case ClusterNameConflict:
+		return "Cluster Name Conflict"
 	}
+
 	return "Unknown State"
 }

--- a/server/server.go
+++ b/server/server.go
@@ -83,6 +83,7 @@ type Info struct {
 	// Route Specific
 	Import *SubjectPermission `json:"import,omitempty"`
 	Export *SubjectPermission `json:"export,omitempty"`
+	LNOC   bool               `json:"lnoc,omitempty"`
 
 	// Gateways Specific
 	Gateway           string   `json:"gateway,omitempty"`             // Name of the origin Gateway (sent by gateway's INFO)
@@ -434,11 +435,13 @@ func (s *Server) setClusterName(name string) {
 	}
 	s.info.Cluster = name
 	s.routeInfo.Cluster = name
+	s.updatedSolicitedLeafnodes()
 	s.mu.Unlock()
 	if resetCh != nil {
 		resetCh <- struct{}{}
 	}
 	s.Noticef("Cluster name updated to %s", name)
+
 }
 
 // Return whether the cluster name is dynamic.

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -3145,7 +3145,6 @@ func TestLeafNodeCycleWithSolicited(t *testing.T) {
 		atomic.AddInt32(&requestsReceived, 1)
 		m.Respond([]byte("22"))
 	})
-	nc.Flush()
 
 	nc = clientForCluster(t, cb)
 	defer nc.Close()
@@ -3153,11 +3152,34 @@ func TestLeafNodeCycleWithSolicited(t *testing.T) {
 		atomic.AddInt32(&requestsReceived, 1)
 		m.Respond([]byte("33"))
 	})
-	nc.Flush()
 
 	// Soliciting cluster, both solicited connected to the "A" cluster
 	sc := runSolicitLeafCluster(t, "SC", ca, ca)
 	defer shutdownCluster(sc)
+
+	checkInterest := func(s *server.Server, subject string) bool {
+		t.Helper()
+		acc, _ := s.LookupAccount("$G")
+		return acc.SubscriptionInterest(subject)
+	}
+
+	waitForInterest := func(subject string, servers ...*server.Server) {
+		t.Helper()
+		checkFor(t, time.Second, 10*time.Millisecond, func() error {
+			for _, s := range servers {
+				if !checkInterest(s, subject) {
+					return fmt.Errorf("No interest")
+				}
+			}
+			return nil
+		})
+	}
+
+	waitForInterest("request",
+		sc.servers[0], sc.servers[1],
+		ca.servers[0], ca.servers[1], ca.servers[2],
+		cb.servers[0], cb.servers[1], cb.servers[2],
+	)
 
 	// Connect a client to a random server in sc
 	createClientAndRequest := func(c *cluster) (*nats.Conn, *nats.Subscription) {
@@ -3761,4 +3783,238 @@ func TestLeafNodeQueueSubscriberUnsubscribe(t *testing.T) {
 	}
 	// Make sure we receive nothing...
 	expectNothing(t, lc)
+}
+
+func TestLeafNodeOriginClusterSingleHub(t *testing.T) {
+	s, opts := runLeafServer()
+	defer s.Shutdown()
+
+	c1 := `
+	listen: 127.0.0.1:-1
+	cluster { name: ln22, listen: 127.0.0.1:-1 }
+	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
+	`
+	lconf1 := createConfFile(t, []byte(fmt.Sprintf(c1, opts.LeafNode.Port)))
+	defer os.Remove(lconf1)
+
+	ln1, lopts1 := RunServerWithConfig(lconf1)
+	defer ln1.Shutdown()
+
+	c2 := `
+	listen: 127.0.0.1:-1
+	cluster { name: ln22, listen: 127.0.0.1:-1, routes = [ nats-route://127.0.0.1:%d] }
+	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
+	`
+	lconf2 := createConfFile(t, []byte(fmt.Sprintf(c2, lopts1.Cluster.Port, opts.LeafNode.Port)))
+	defer os.Remove(lconf2)
+
+	ln2, _ := RunServerWithConfig(lconf2)
+	defer ln2.Shutdown()
+
+	ln3, _ := RunServerWithConfig(lconf2)
+	defer ln3.Shutdown()
+
+	checkClusterFormed(t, ln1, ln2, ln3)
+	checkLeafNodeConnections(t, s, 3)
+
+	// So now we are setup with 3 solicited leafnodes all connected to a hub.
+	// We will create two clients, one on each leafnode server.
+	nc1, err := nats.Connect(ln1.ClientURL())
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc1.Close()
+
+	nc2, err := nats.Connect(ln2.ClientURL())
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc2.Close()
+
+	checkInterest := func(s *server.Server, subject string) bool {
+		t.Helper()
+		acc, _ := s.LookupAccount("$G")
+		return acc.SubscriptionInterest(subject)
+	}
+
+	waitForInterest := func(subject string, servers ...*server.Server) {
+		t.Helper()
+		checkFor(t, time.Second, 10*time.Millisecond, func() error {
+			for _, s := range servers {
+				if !checkInterest(s, subject) {
+					return fmt.Errorf("No interest")
+				}
+			}
+			return nil
+		})
+	}
+
+	subj := "foo.bar"
+
+	sub, _ := nc2.SubscribeSync(subj)
+	waitForInterest(subj, ln1, ln2, ln3, s)
+
+	// Make sure we truncated the subscription bouncing through the hub and back to other leafnodes.
+	for _, s := range []*server.Server{ln1, ln3} {
+		acc, _ := s.LookupAccount("$G")
+		if nms := acc.Interest(subj); nms != 1 {
+			t.Fatalf("Expected only one active subscription, got %d", nms)
+		}
+	}
+
+	// Send a message.
+	nc1.Publish(subj, nil)
+	nc1.Flush()
+	// Wait to propagate
+	time.Sleep(25 * time.Millisecond)
+
+	// Make sure we only get it once.
+	if n, _, _ := sub.Pending(); n != 1 {
+		t.Fatalf("Expected only one message, got %d", n)
+	}
+}
+
+func TestLeafNodeOriginCluster(t *testing.T) {
+	ca := createClusterWithName(t, "A", 3)
+	defer shutdownCluster(ca)
+
+	c1 := `
+	server_name: L1
+	listen: 127.0.0.1:-1
+	cluster { name: ln22, listen: 127.0.0.1:-1 }
+	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
+	`
+	lconf1 := createConfFile(t, []byte(fmt.Sprintf(c1, ca.opts[0].LeafNode.Port)))
+	defer os.Remove(lconf1)
+
+	ln1, lopts1 := RunServerWithConfig(lconf1)
+	defer ln1.Shutdown()
+
+	c2 := `
+	server_name: L2
+	listen: 127.0.0.1:-1
+	cluster { name: ln22, listen: 127.0.0.1:-1, routes = [ nats-route://127.0.0.1:%d] }
+	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
+	`
+	lconf2 := createConfFile(t, []byte(fmt.Sprintf(c2, lopts1.Cluster.Port, ca.opts[1].LeafNode.Port)))
+	defer os.Remove(lconf2)
+
+	ln2, _ := RunServerWithConfig(lconf2)
+	defer ln2.Shutdown()
+
+	c3 := `
+	server_name: L3
+	listen: 127.0.0.1:-1
+	cluster { name: ln22, listen: 127.0.0.1:-1, routes = [ nats-route://127.0.0.1:%d] }
+	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
+	`
+	lconf3 := createConfFile(t, []byte(fmt.Sprintf(c3, lopts1.Cluster.Port, ca.opts[2].LeafNode.Port)))
+	defer os.Remove(lconf3)
+
+	ln3, _ := RunServerWithConfig(lconf3)
+	defer ln3.Shutdown()
+
+	checkClusterFormed(t, ln1, ln2, ln3)
+	checkLeafNodeConnections(t, ca.servers[0], 1)
+	checkLeafNodeConnections(t, ca.servers[1], 1)
+	checkLeafNodeConnections(t, ca.servers[2], 1)
+
+	// So now we are setup with 3 solicited leafnodes connected to different servers in the hub cluster.
+	// We will create two clients, one on each leafnode server.
+	nc1, err := nats.Connect(ln1.ClientURL())
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc1.Close()
+
+	nc2, err := nats.Connect(ln2.ClientURL())
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc2.Close()
+
+	checkInterest := func(s *server.Server, subject string) bool {
+		t.Helper()
+		acc, _ := s.LookupAccount("$G")
+		return acc.SubscriptionInterest(subject)
+	}
+
+	waitForInterest := func(subject string, servers ...*server.Server) {
+		t.Helper()
+		checkFor(t, time.Second, 10*time.Millisecond, func() error {
+			for _, s := range servers {
+				if !checkInterest(s, subject) {
+					return fmt.Errorf("No interest")
+				}
+			}
+			return nil
+		})
+	}
+
+	subj := "foo.bar"
+
+	sub, _ := nc2.SubscribeSync(subj)
+	waitForInterest(subj, ln1, ln2, ln3, ca.servers[0], ca.servers[1], ca.servers[2])
+
+	// Make sure we truncated the subscription bouncing through the hub and back to other leafnodes.
+	for _, s := range []*server.Server{ln1, ln3} {
+		acc, _ := s.LookupAccount("$G")
+		if nms := acc.Interest(subj); nms != 1 {
+			t.Fatalf("Expected only one active subscription, got %d", nms)
+		}
+	}
+
+	// Send a message.
+	nc1.Publish(subj, nil)
+	nc1.Flush()
+	// Wait to propagate
+	time.Sleep(25 * time.Millisecond)
+
+	// Make sure we only get it once.
+	if n, _, _ := sub.Pending(); n != 1 {
+		t.Fatalf("Expected only one message, got %d", n)
+	}
+	// eat the msg
+	sub.NextMsg(time.Second)
+
+	// Now create interest on the hub side. This will draw the message from a leafnode
+	// to the hub. We want to make sure that message does not bounce back to other leafnodes.
+	nc3, err := nats.Connect(ca.servers[0].ClientURL())
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc3.Close()
+
+	wcSubj := "foo.*"
+	nc3.SubscribeSync(wcSubj)
+	// This is a placeholder that we can use to check all interest has propagated.
+	nc3.SubscribeSync("bar")
+	waitForInterest("bar", ln1, ln2, ln3, ca.servers[0], ca.servers[1], ca.servers[2])
+
+	// Send another message.
+	m := nats.NewMsg(subj)
+	m.Header.Add("Accept-Encoding", "json")
+	m.Header.Add("Authorization", "s3cr3t")
+	m.Data = []byte("Hello Headers!")
+
+	nc1.PublishMsg(m)
+	nc1.Flush()
+	// Wait to propagate
+	time.Sleep(25 * time.Millisecond)
+
+	// Make sure we only get it once.
+	if n, _, _ := sub.Pending(); n != 1 {
+		t.Fatalf("Expected only one message, got %d", n)
+	}
+	// grab the msg
+	msg, _ := sub.NextMsg(time.Second)
+	if !bytes.Equal(m.Data, msg.Data) {
+		t.Fatalf("Expected the payloads to match, wanted %q, got %q", m.Data, msg.Data)
+	}
+	if len(msg.Header) != 2 {
+		t.Fatalf("Expected 2 header entries, got %d", len(msg.Header))
+	}
+	if msg.Header.Get("Authorization") != "s3cr3t" {
+		t.Fatalf("Expected auth header to match, wanted %q, got %q", "s3cr3t", msg.Header.Get("Authorization"))
+	}
 }

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -3986,7 +3986,7 @@ func TestLeafNodeOriginCluster(t *testing.T) {
 	defer nc3.Close()
 
 	wcSubj := "foo.*"
-	nc3.SubscribeSync(wcSubj)
+	wcsub, _ := nc3.SubscribeSync(wcSubj)
 	// This is a placeholder that we can use to check all interest has propagated.
 	nc3.SubscribeSync("bar")
 	waitForInterest("bar", ln1, ln2, ln3, ca.servers[0], ca.servers[1], ca.servers[2])
@@ -4006,6 +4006,11 @@ func TestLeafNodeOriginCluster(t *testing.T) {
 	if n, _, _ := sub.Pending(); n != 1 {
 		t.Fatalf("Expected only one message, got %d", n)
 	}
+	// Also for wc
+	if n, _, _ := wcsub.Pending(); n != 1 {
+		t.Fatalf("Expected only one message, got %d", n)
+	}
+
 	// grab the msg
 	msg, _ := sub.NextMsg(time.Second)
 	if !bytes.Equal(m.Data, msg.Data) {

--- a/test/test.go
+++ b/test/test.go
@@ -315,6 +315,7 @@ var (
 	lsubRe    = regexp.MustCompile(`LS\+\s+([^\s]+)\s*([^\s]+)?\s*(\d+)?\r\n`)
 	lunsubRe  = regexp.MustCompile(`LS\-\s+([^\s]+)\s*([^\s]+)?\r\n`)
 	lmsgRe    = regexp.MustCompile(`(?:(?:LMSG\s+([^\s]+)\s+(?:([|+]\s+([\w\s]+)|[^\s]+)[^\S\r\n]+)?(\d+)\s*\r\n([^\\r\\n]*?)\r\n)+?)`)
+	rlsubRe   = regexp.MustCompile(`LS\+\s+([^\s]+)\s+([^\s]+)\s+([^\s]+)\s*([^\s]+)?\s*(\d+)?\r\n`)
 )
 
 const (


### PR DESCRIPTION
Leafnodes that formed clusters were partially supported. This adds proper support for origin cluster, subscription suppression and data message no echo for the origin cluster.

Meaning we can now have a leafnode cluster that can transparently send through a hub (i.e. NGS) and to each other.

Signed-off-by: Derek Collison <derek@nats.io>

 
/cc @nats-io/core
