### PR TITLE
Track destination leafnode status

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3526,7 +3526,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 			// Leaf node delivery audience is different however.
 			// Also leaf nodes are always no echo, so we make sure we are not
 			// going to send back to ourselves here.
-			if c != sub.client && (c.kind != ROUTER || !c.isSpokeLeafNode()) {
+			if c != sub.client && (c.kind != ROUTER || sub.client.isHubLeafNode()) {
 				c.addSubToRouteTargets(sub)
 			}
 			continue


### PR DESCRIPTION
Fix for duplicate delivery into a hub, was checking wrong client for hub status.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
