### PR TITLE
Fixed accept loops that could leave connections opened

### DIFF
--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -147,29 +147,7 @@ func TestClusterAdvertiseErrorOnStartup(t *testing.T) {
 	opts := DefaultOptions()
 	// Set invalid address
 	opts.Cluster.Advertise = "addr:::123"
-	s := New(opts)
-	defer s.Shutdown()
-	dl := &DummyLogger{}
-	s.SetLogger(dl, false, false)
-
-	// Start will keep running, so start in a go-routine.
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		s.Start()
-		wg.Done()
-	}()
-	checkFor(t, 2*time.Second, 15*time.Millisecond, func() error {
-		dl.Lock()
-		msg := dl.msg
-		dl.Unlock()
-		if strings.Contains(msg, "Cluster.Advertise") {
-			return nil
-		}
-		return fmt.Errorf("Did not get expected error, got %v", msg)
-	})
-	s.Shutdown()
-	wg.Wait()
+	testFatalErrorOnStart(t, opts, "Cluster.Advertise")
 }
 
 func TestClientAdvertise(t *testing.T) {


### PR DESCRIPTION
This was discovered with the test TestLeafNodeWithGatewaysServerRestart
that was sometimes failing. Investigation showed that when cluster B
was shutdown, one of the server on A that had a connection from B
that just broke tried to reconnect (as part of reconnect retries of
implicit gateways) to a server in B that was in the process of shuting down.
The connection had been accepted but createGateway not called because
the server's running boolean had been set to false as part of the shutdown.
However, the connection was not closed so the server on A had a valid
connection to a dead server from cluster B. When the B cluster (now single
server) was restarted and a LeafNode connection connected to it, then
the gateway from B to A was created, that server on A did not create outbound
connection to that B server because it already had one (the zombie one).

So this PR strengthens the starting of accept loops and also make sure
that if a connection (all type of connections) is not accepted because
the server is shuting down, that connection is properly closed.

Since all accept loops had almost same code, made a generic function
that accept functions to call specific create connection functions.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
