### PR TITLE
[FIXED] Connection name in log statement for some IPv6 addresses

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -492,6 +492,9 @@ func (c *client) initClient() {
 				host, port, _ := net.SplitHostPort(conn)
 				iPort, _ := strconv.Atoi(port)
 				c.host, c.port = host, uint16(iPort)
+				// Now that we have extracted host and port, escape
+				// the string because it is going to be used in Sprintf
+				conn = strings.ReplaceAll(conn, "%", "%%")
 			}
 		}
 	}


### PR DESCRIPTION
If an IPv6 address contains some "%" characters, this was causing
the connection name in log statement to mess up the Sprintf formatting.
The solution is to escape those "%" characters.

Resolves #1505

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
