### PR TITLE
[FIXED] Handling or real duplicate subscription

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -2165,7 +2165,8 @@ func (c *client) processSub(argo []byte, noForward bool) (*subscription, error) 
 	var err error
 
 	// Subscribe here.
-	if c.subs[sid] == nil {
+	es := c.subs[sid]
+	if es == nil {
 		c.subs[sid] = sub
 		if acc != nil && acc.sl != nil {
 			err = acc.sl.Insert(sub)
@@ -2184,6 +2185,11 @@ func (c *client) processSub(argo []byte, noForward bool) (*subscription, error) 
 		return nil, nil
 	} else if c.opts.Verbose && kind != SYSTEM {
 		c.sendOK()
+	}
+
+	// If it was already registered, return it.
+	if es != nil {
+		return es, nil
 	}
 
 	// No account just return.


### PR DESCRIPTION
That is, if the server receives "SUB foo 1" more than once from
the same client, we would register in the client map this subscription
only once, and add to the account's sublist only once, however we
would have updated shadow subscriptions and route/gateway maps for
each SUB protocol, which would result in inability to send unsubscribe
to routes when the client goes away or unsubscribes.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
