### PR TITLE
Provide exactly once semantics

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -49,7 +49,7 @@ type StreamConfig struct {
 	Replicas     int             `json:"num_replicas"`
 	NoAck        bool            `json:"no_ack,omitempty"`
 	Template     string          `json:"template_owner,omitempty"`
-	Duplicates   time.Duration   `json:"duplicates,omitempty"`
+	Duplicates   time.Duration   `json:"duplicate_window,omitempty"`
 }
 
 // PubAck is the detail you get back from a publish to a stream that was successful.

--- a/server/stream.go
+++ b/server/stream.go
@@ -693,8 +693,12 @@ func (mset *Stream) storeMsgId(dde *ddentry) {
 // Will return the value for the header denoted by key or nil if it does not exists.
 // This function ignores errors and tries to achieve speed and no additional allocations.
 func getHdrVal(key string, hdr []byte) []byte {
+	index := bytes.Index(hdr, []byte(key))
+	if index < 0 {
+		return nil
+	}
 	var value []byte
-	for i := bytes.Index(hdr, []byte(key)) + len(key) + 2; i > 0 && i < len(hdr); i++ {
+	for i := index + len(key) + 2; i > 0 && i < len(hdr); i++ {
 		if hdr[i] == '\r' && i < len(hdr)-1 && hdr[i+1] == '\n' {
 			break
 		}


### PR DESCRIPTION
This provides two mechanisms for exactly once.

1. Deduplication for messages that are published multiple times. We use headers to denote a Msg-Id per message. These are kept for a certain window of time.
2. When you ack a message that has been consumed you can receive an ack to your ack. If that ack is received you will not receive the message again.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
