### PR TITLE
Fixed no_responders use of sendProtoNow()

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1208,8 +1208,7 @@ func (s *Server) sendSubsToGateway(c *client, accountName []byte) {
 	}
 	// Send
 	c.mu.Lock()
-	c.queueOutbound(buf)
-	c.flushSignal()
+	c.enqueueProto(buf)
 	c.Debugf("Sent queue subscriptions to gateway")
 	c.mu.Unlock()
 }

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1210,8 +1210,7 @@ func (s *Server) initLeafNodeSmapAndSendSubs(c *client) {
 		c.writeLeafSub(&b, key, n)
 	}
 	if b.Len() > 0 {
-		c.queueOutbound(b.Bytes())
-		c.flushSignal()
+		c.enqueueProto(b.Bytes())
 	}
 	if c.leaf.tsub != nil {
 		// Clear the tsub map after 5 seconds.

--- a/server/route.go
+++ b/server/route.go
@@ -1233,8 +1233,7 @@ func (c *client) sendRouteSubOrUnSubProtos(subs []*subscription, isSubProto, tra
 		buf = append(buf, CR_LF...)
 	}
 
-	c.queueOutbound(buf)
-	c.flushSignal()
+	c.enqueueProto(buf)
 }
 
 func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {


### PR DESCRIPTION
The call sendProtoNow() should not normally be used (only when
setting up a connection when the writeloop is not yet started and
server needs to send something before being able to start the
writeLoop.

Instead, code should use enqueueProto(). For this particular
case though, use queueOutbound() directly and add to the
producer's pcd map.

Also fixed other places where we were using queueOutbound() +
flushSignal() which is what enqueueProto is doing.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>