### PR TITLE
ensure unlimited account limits are calculated correctly

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -773,11 +773,11 @@ func (jsa *jsAccount) limitsExceeded(storeType StorageType) bool {
 	var exceeded bool
 	jsa.mu.Lock()
 	if storeType == MemoryStorage {
-		if jsa.memUsed > jsa.limits.MaxMemory {
+		if jsa.limits.MaxMemory > 0 && jsa.memUsed > jsa.limits.MaxMemory {
 			exceeded = true
 		}
 	} else {
-		if jsa.storeUsed > jsa.limits.MaxStore {
+		if jsa.limits.MaxStore > 0 && jsa.storeUsed > jsa.limits.MaxStore {
 			exceeded = true
 		}
 	}

--- a/test/jetstream_test.go
+++ b/test/jetstream_test.go
@@ -5223,6 +5223,17 @@ func TestJetStreamStreamStorageTrackingAndLimits(t *testing.T) {
 	if usage.Memory > uint64(al.MaxMemory) {
 		t.Fatalf("Expected memory to not exceed limit of %d, got %d", al.MaxMemory, usage.Memory)
 	}
+
+	// make sure that unlimited accounts work
+	al.MaxMemory = -1
+
+	if err := gacc.UpdateJetStreamLimits(al); err != nil {
+		t.Fatalf("Unexpected error updating jetstream account limits: %v", err)
+	}
+
+	for i := 0; i < toSend; i++ {
+		sendStreamMsg(t, nc, "LIMITS", "Hello World!")
+	}
 }
 
 func TestJetStreamStreamFileStorageTrackingAndLimits(t *testing.T) {


### PR DESCRIPTION
Previously unlimited accounts - ones who inherit server values - would
be unable to publish any messags at all

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
