### PR TITLE
Added -cluster_name command line option

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ TLS Options:
 Cluster Options:
         --routes <rurl-1, rurl-2>    Routes to solicit and connect
         --cluster <cluster-url>      Cluster URL for solicited routes
+        --cluster_name <string>      Cluster Name, if not set one will be dynamically generated
         --no_advertise <bool>        Advertise known cluster IPs to clients
         --cluster_advertise <string> Cluster URL to advertise to other servers
         --connect_retries <number>   For implicit routes, number of connect retries

--- a/server/opts.go
+++ b/server/opts.go
@@ -3595,6 +3595,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.StringVar(&opts.Cluster.Advertise, "cluster_advertise", "", "Cluster URL to advertise to other servers.")
 	fs.BoolVar(&opts.Cluster.NoAdvertise, "no_advertise", false, "Advertise known cluster IPs to clients.")
 	fs.IntVar(&opts.Cluster.ConnectRetries, "connect_retries", 0, "For implicit routes, number of connect retries.")
+	fs.StringVar(&opts.Cluster.Name, "cluster_name", "", "Cluster Name, if not set one will be dynamically generated.")
 	fs.BoolVar(&showTLSHelp, "help_tls", false, "TLS help.")
 	fs.BoolVar(&opts.TLS, "tls", false, "Enable TLS.")
 	fs.BoolVar(&opts.TLSVerify, "tlsverify", false, "Enable TLS with client verification.")


### PR DESCRIPTION
This is handy for client libraries that start the server as
external executable and pass command line arguments. Without
specifying the cluster name, routes can take time to establish
and cause some tests to fail.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
