### PR TITLE
added 'no_header_support' config option mapping to NoHeaderSupport

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -886,6 +886,8 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 		return
 	case "no_system_account", "no_system", "no_sys_acc":
 		o.NoSystemAccount = v.(bool)
+	case "no_header_support":
+		o.NoHeaderSupport = v.(bool)
 	case "trusted", "trusted_keys":
 		switch v := v.(type) {
 		case string:


### PR DESCRIPTION
Internally option for NoHeaderSupport was available, but no way to set it.
