### PR TITLE
Header ADR clarifications

### DIFF
--- a/doc/adr/0004-nats-headers.md
+++ b/doc/adr/0004-nats-headers.md
@@ -18,7 +18,16 @@ The salient points of the HTTP header specification are:
 - The specification may allow any number of strange things like comments/tokens etc.
 - The keys can repeat.
 
-The reference NATS Go client uses the `http.Header` infrastructure for serializing NATS headers. Other language clients may not be able to reuse header serialization infrastructure outside of the context of an HTTP request. Furthermore, the implementation of the native header library may diverge from the Go `http.Header` while still being standard. 
+More specifically from [rfc822](https://www.ietf.org/rfc/rfc822.txt) Section 3.1.2:
+> Once a field has been unfolded, it may be viewed as being composed of a field-name followed by a colon (":"), followed by a field-body, and  terminated  by  a  carriage-return/line-feed.
+> The  field-name must be composed of printable ASCII characters (i.e., characters that  have  values  between  33.  and  126., decimal, except colon).  The field-body may be composed of any ASCII characters, except CR or LF.  (While CR and/or LF may be present  in the actual text, they are removed by the action of unfolding the field.)
+
+The reference NATS Go client uses the `http.Header` infrastructure for serializing NATS headers. Other language clients may not be able to reuse header serialization infrastructure outside of the context of an HTTP request. Furthermore, the implementation of the native header library may diverge from the Go `http.Header` while still being standard.
+
+For example, the Go `http.Header` library, performs the following formatting which the while not part of the spec, as header field names are case insensitive, are a requirement in NATS header fields:
+- First character in a header field is capitalized if in the range of [a-z]
+- First characters following a dash (`-`) are capitalized if in the range of [a-z]
+_If a client doesn't serialize field names as above, it is possible that the server may ignore them._
 
 NATS Headers:
 

--- a/doc/adr/0004-nats-headers.md
+++ b/doc/adr/0004-nats-headers.md
@@ -24,9 +24,10 @@ More specifically from [rfc822](https://www.ietf.org/rfc/rfc822.txt) Section 3.1
 
 The reference NATS Go client uses the `http.Header` infrastructure for serializing NATS headers. Other language clients may not be able to reuse header serialization infrastructure outside of the context of an HTTP request. Furthermore, the implementation of the native header library may diverge from the Go `http.Header` while still being standard.
 
-For example, the Go `http.Header` library, performs the following formatting which the while not part of the spec, as header field names are case insensitive, are a requirement in NATS header fields:
+For example, the Go `http.Header` library, performs the following formatting which while not part of the spec, as header field names are case-insensitive, become a requirement in NATS header fields:
 - First character in a header field is capitalized if in the range of [a-z]
 - First characters following a dash (`-`) are capitalized if in the range of [a-z]
+
 _If a client doesn't serialize field names as above, it is possible that the server may ignore them._
 
 NATS Headers:

--- a/doc/adr/0004-nats-headers.md
+++ b/doc/adr/0004-nats-headers.md
@@ -22,7 +22,7 @@ More specifically from [rfc822](https://www.ietf.org/rfc/rfc822.txt) Section 3.1
 > Once a field has been unfolded, it may be viewed as being composed of a field-name followed by a colon (":"), followed by a field-body, and  terminated  by  a  carriage-return/line-feed.
 > The  field-name must be composed of printable ASCII characters (i.e., characters that  have  values  between  33.  and  126., decimal, except colon).  The field-body may be composed of any ASCII characters, except CR or LF.  (While CR and/or LF may be present  in the actual text, they are removed by the action of unfolding the field.)
 
-The reference NATS Go client uses the `http.Header` infrastructure for serializing NATS headers. Other language clients may not be able to reuse header serialization infrastructure outside of the context of an HTTP request. Furthermore, the implementation of the native header library may diverge from the Go `http.Header` while still being standard.
+The reference NATS Go client uses the `http.Header` which internally uses `textproto.MIMEHeader` infrastructure for serializing NATS headers. Other language clients may not be able to reuse header serialization infrastructure outside of the context of an HTTP request. Furthermore, the implementation of the native header library may diverge from the Go `http.Header` while still being standard.
 
 For example, the Go `http.Header` library, performs the following formatting which while not part of the spec, as header field names are case-insensitive, become a requirement in NATS header fields:
 - First character in a header field is capitalized if in the range of [a-z]


### PR DESCRIPTION
clarifications on the ADR. Go is non-standard, and it's formatting
rules, create formatting dependencies that are not part of the spec.
Also added simplified guidance of allowed characters to help those
having to implement it.

[ci skip]

