### PR TITLE
[CHANGED] add client provided info into server side client logs when available

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1512,20 +1512,22 @@ func (c *client) processConnect(arg []byte) error {
 			ncs = fmt.Sprintf("v%s", c.opts.Version)
 		}
 		if c.opts.Lang != "" {
-			if c.opts.Version == _EMPTY_ && c.opts.Name == _EMPTY_ {
+			if c.opts.Version == _EMPTY_ {
 				ncs = c.opts.Lang
 			} else {
 				ncs = fmt.Sprintf("%s:%s", ncs, c.opts.Lang)
 			}
 		}
 		if c.opts.Name != "" {
-			if c.opts.Version == _EMPTY_ {
+			if c.opts.Version == _EMPTY_ && c.opts.Lang == _EMPTY_ {
 				ncs = c.opts.Name
 			} else {
 				ncs = fmt.Sprintf("%s:%s", ncs, c.opts.Name)
 			}
 		}
-		c.ncs.Store(fmt.Sprintf("%s - %q", c.String(), ncs))
+		if ncs != _EMPTY_ {
+			c.ncs.Store(fmt.Sprintf("%s - %q", c.String(), ncs))
+		}
 	}
 
 	// If websocket client and JWT not in the CONNECT, use the cookie JWT (possibly empty).

--- a/server/client.go
+++ b/server/client.go
@@ -3588,7 +3588,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 	// leaf nodes or routes even if there are no queue filters since we collect
 	// them above and do not process inline like normal clients.
 	// However, do select queue subs if asked to ignore empty queue filter.
-	if (c.kind != CLIENT && c.kind != JETSTREAM && c.kind != ACCOUNT) && qf == nil && flags&pmrIgnoreEmptyQueueFilter == 0 {
+	if (c.kind == LEAF || c.kind == ROUTER || c.kind == GATEWAY) && qf == nil && flags&pmrIgnoreEmptyQueueFilter == 0 {
 		goto sendToRoutesOrLeafs
 	}
 

--- a/server/client.go
+++ b/server/client.go
@@ -3584,7 +3584,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 	// Declared here because of goto.
 	var queues [][]byte
 
-	// For all non-client connections, we may still want to send messages to
+	// For all routes/leaf/gateway connections, we may still want to send messages to
 	// leaf nodes or routes even if there are no queue filters since we collect
 	// them above and do not process inline like normal clients.
 	// However, do select queue subs if asked to ignore empty queue filter.

--- a/server/client.go
+++ b/server/client.go
@@ -1506,17 +1506,27 @@ func (c *client) processConnect(arg []byte) error {
 	account := c.opts.Account
 	accountNew := c.opts.AccountNew
 
-	ncs := c.String()
-	if c.opts.Name != "" {
-		ncs = fmt.Sprintf("%s - name: %s", ncs, c.opts.Name)
+	if c.kind == CLIENT {
+		var ncs string
+		if c.opts.Version != "" {
+			ncs = fmt.Sprintf("v%s", c.opts.Version)
+		}
+		if c.opts.Lang != "" {
+			if c.opts.Version == _EMPTY_ && c.opts.Name == _EMPTY_ {
+				ncs = c.opts.Lang
+			} else {
+				ncs = fmt.Sprintf("%s:%s", ncs, c.opts.Lang)
+			}
+		}
+		if c.opts.Name != "" {
+			if c.opts.Version == _EMPTY_ {
+				ncs = c.opts.Name
+			} else {
+				ncs = fmt.Sprintf("%s:%s", ncs, c.opts.Name)
+			}
+		}
+		c.ncs.Store(fmt.Sprintf("%s - %q", c.String(), ncs))
 	}
-	if c.opts.Lang != "" {
-		ncs = fmt.Sprintf("%s - lang: %s", ncs, c.opts.Lang)
-	}
-	if c.opts.Version != "" {
-		ncs = fmt.Sprintf("%s - version: %s", ncs, c.opts.Version)
-	}
-	c.ncs.Store(ncs)
 
 	// If websocket client and JWT not in the CONNECT, use the cookie JWT (possibly empty).
 	if ws := c.ws; ws != nil && c.opts.JWT == "" {

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -2197,7 +2197,7 @@ func TestClientIPv6Address(t *testing.T) {
 	cid, _ := nc.GetClientID()
 	c := s.GetClient(cid)
 	c.mu.Lock()
-	ncs := c.ncs
+	ncs := c.String()
 	c.mu.Unlock()
 	if !strings.HasPrefix(ncs, "[::1]") {
 		t.Fatalf("Wrong string representation of an IPv6 address: %q", ncs)

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1734,7 +1734,7 @@ func (c *client) auditUser() string {
 
 // Returns the audit client name, which will just be IP:Port
 func (c *client) auditClient() (string, int) {
-	parts := strings.Split(c.ncs, " ")
+	parts := strings.Split(c.String(), " ")
 	h, p, _ := net.SplitHostPort(parts[0])
 	port, _ := strconv.Atoi(p)
 	return h, port


### PR DESCRIPTION
 - [x] Tests updated
 - [x] Changes squashed to a single commit
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request:

 - Server-side logs include the host IP and port that clients connected on as well as the client id created by the server but clients can specify additional info that would be useful for identifying them and this adds that info to the logs (when it is available)

/cc @nats-io/core
