### PR TITLE
Websocket: add option to disable TLS

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -281,6 +281,15 @@ type WebsocketOpts struct {
 	// Timeout for the authentication process.
 	AuthTimeout float64
 
+	// By default the server will enforce the use of TLS. If no TLS configuration
+	// is provided, you need to explicitly set NoTLS to true to allow the server
+	// to start without TLS configuration. Note that if a TLS configuration is
+	// present, this boolean is ignored and the server will run the Websocket
+	// server with that TLS configuration.
+	// Running without TLS is less secure since Websocket clients that use bearer
+	// tokens will send them in clear. So this should not be used in production.
+	NoTLS bool
+
 	// TLS configuration is required.
 	TLSConfig *tls.Config
 	// If true, map certificate values for authentication purposes.
@@ -3070,6 +3079,8 @@ func parseWebsocket(v interface{}, o *Options, errors *[]error, warnings *[]erro
 			o.Websocket.Host = mv.(string)
 		case "advertise":
 			o.Websocket.Advertise = mv.(string)
+		case "no_tls":
+			o.Websocket.NoTLS = mv.(bool)
 		case "tls":
 			tc, err := parseTLS(tk)
 			if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1229,9 +1229,6 @@ func TestAcceptError(t *testing.T) {
 }
 
 func TestAcceptLoopsDoNotLeaveOpenedConn(t *testing.T) {
-	testWebsocketAllowNonTLS = true
-	defer func() { testWebsocketAllowNonTLS = false }()
-
 	for _, test := range []struct {
 		name string
 		url  func(o *Options) (string, int)
@@ -1258,6 +1255,7 @@ func TestAcceptLoopsDoNotLeaveOpenedConn(t *testing.T) {
 			o.Websocket.Host = "127.0.0.1"
 			o.Websocket.Port = -1
 			o.Websocket.HandshakeTimeout = 1
+			o.Websocket.NoTLS = true
 			s := RunServer(o)
 			defer s.Shutdown()
 
@@ -1321,9 +1319,6 @@ func TestAcceptLoopsDoNotLeaveOpenedConn(t *testing.T) {
 }
 
 func TestServerShutdownDuringStart(t *testing.T) {
-	testWebsocketAllowNonTLS = true
-	defer func() { testWebsocketAllowNonTLS = false }()
-
 	o := DefaultOptions()
 	o.DisableShortFirstPing = true
 	o.Accounts = []*Account{NewAccount("$SYS")}
@@ -1339,6 +1334,7 @@ func TestServerShutdownDuringStart(t *testing.T) {
 	o.Websocket.Host = "127.0.0.1"
 	o.Websocket.Port = -1
 	o.Websocket.HandshakeTimeout = 1
+	o.Websocket.NoTLS = true
 
 	// We are going to test that if the server is shutdown
 	// while Start() runs (in this case, before), we don't


### PR DESCRIPTION
The new option Websocket.NoTLS would have to be set to true
to disable the server check that enforces TLS configuration.

Resolves #1529

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
