### PR TITLE
[FIXED] Possible deadlock with solicited leafnodes when cluster conflict

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1834,16 +1834,3 @@ func (c *client) setLeafConnectDelayIfSoliciting(delay time.Duration) (string, t
 	c.mu.Unlock()
 	return accName, delay
 }
-
-// updatedSolicitedLeafnodes will disconnect any solicited leafnodes such
-// that the reconnect will establish the proper origin cluster for the hub.
-func (s *Server) updatedSolicitedLeafnodes() {
-	for _, c := range s.leafs {
-		c.mu.Lock()
-		shouldClose := c.leaf != nil && c.leaf.remote != nil
-		c.mu.Unlock()
-		if shouldClose {
-			c.closeConnection(ClusterNameConflict)
-		}
-	}
-}

--- a/server/route.go
+++ b/server/route.go
@@ -515,7 +515,8 @@ func (c *client) processRouteInfo(info *Info) {
 	if info.Cluster != "" && info.Cluster != clusterName {
 		c.mu.Unlock()
 		// If we are dynamic we may update our cluster name.
-		if s.isClusterNameDynamic() && strings.Compare(clusterName, info.Cluster) < 0 {
+		// Use other if remote is non dynamic or their name is "bigger"
+		if s.isClusterNameDynamic() && (!info.Dynamic || (strings.Compare(clusterName, info.Cluster) < 0)) {
 			s.setClusterName(info.Cluster)
 			s.removeAllRoutesExcept(c)
 			c.mu.Lock()
@@ -1705,6 +1706,7 @@ func (s *Server) startRouteAcceptLoop() {
 		GatewayURL:   s.getGatewayURL(),
 		Headers:      s.supportsHeaders(),
 		Cluster:      s.info.Cluster,
+		Dynamic:      s.isClusterNameDynamic(),
 		LNOC:         true,
 	}
 	// Set this if only if advertise is not disabled

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1266,3 +1266,18 @@ func TestRouteCloseTLSConnection(t *testing.T) {
 	route.closeConnection(SlowConsumerWriteDeadline)
 	ch <- true
 }
+
+func TestRouteClusterNameConflictBetweenStaticAndDynamic(t *testing.T) {
+	o1 := DefaultOptions()
+	o1.Cluster.Name = "AAAAAAAAAAAAAAAAAAAA" // make it alphabetically the "smallest"
+	s1 := RunServer(o1)
+	defer s1.Shutdown()
+
+	o2 := DefaultOptions()
+	o2.Cluster.Name = "" // intentional, let it be assigned dynamically
+	o2.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", o1.Cluster.Port))
+	s2 := RunServer(o2)
+	defer s2.Shutdown()
+
+	checkClusterFormed(t, s1, s2)
+}


### PR DESCRIPTION
We cannot call c.closeConnection() under the server lock because
closeConnection() can invoke server lock in some cases.

Created a test that should run without `-race` to reproduce the deadlock
(which it does) but sometimes would fail because cluster would not be
formed. This unconvered an issue with conflict resolution which
test TestRouteClusterNameConflictBetweenStaticAndDynamic() can reproduce
easily. The issue was that we were not updating a dynamic name with
the remote if the remote was non dynamic.

Resolves #1543

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
