### PR TITLE
Deliver to all non remote queue subscriber instead of kind == CLIENT

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3611,7 +3611,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 			ql := _ql[:0]
 			for i := 0; i < len(qsubs); i++ {
 				sub = qsubs[i]
-				if sub.client.kind == LEAF || sub.client.kind == ROUTER || sub.client.kind == GATEWAY {
+				if sub.client.kind == LEAF || sub.client.kind == ROUTER {
 					if rsub == nil {
 						rsub = sub
 					}

--- a/server/client.go
+++ b/server/client.go
@@ -3611,10 +3611,12 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 			ql := _ql[:0]
 			for i := 0; i < len(qsubs); i++ {
 				sub = qsubs[i]
-				if sub.client.kind == CLIENT {
+				if sub.client.kind == LEAF || sub.client.kind == ROUTER || sub.client.kind == GATEWAY {
+					if rsub == nil {
+						rsub = sub
+					}
+				} else {
 					ql = append(ql, sub)
-				} else if rsub == nil {
-					rsub = sub
 				}
 			}
 			qsubs = ql


### PR DESCRIPTION
When using a queue subscription with an internal client, this caused messages to be sent back.
Going with a check for remote sub seems to match the comment best.

Signed-off-by: Matthias Hanel <mh@synadia.com>

