### PR TITLE
Rework closeConnection()

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -264,7 +264,7 @@ func (a *Account) nextEventID() string {
 
 // Called to track a remote server and connections and leafnodes it
 // has for this account.
-func (a *Account) updateRemoteServer(m *AccountNumConns) {
+func (a *Account) updateRemoteServer(m *AccountNumConns) []*client {
 	a.mu.Lock()
 	if a.strack == nil {
 		a.strack = make(map[string]sconns)
@@ -308,9 +308,7 @@ func (a *Account) updateRemoteServer(m *AccountNumConns) {
 	a.mu.Unlock()
 
 	// If we have exceeded our max clients this will be populated.
-	for _, c := range clients {
-		c.maxAccountConnExceeded()
-	}
+	return clients
 }
 
 // Removes tracking for a remote server that has shutdown.

--- a/server/server.go
+++ b/server/server.go
@@ -2129,13 +2129,13 @@ func (s *Server) createClient(conn net.Conn, ws *websocket) *client {
 	// The connection may have been closed
 	if c.isClosed() {
 		c.mu.Unlock()
-		// If it was due to TLS timeout, teardownConn() has already been called.
+		// If it was due to TLS timeout, closeConnection() has already been called.
 		// Otherwise, if connection was marked as closed while sending the INFO,
-		// we need to call teardownConn() directly here.
+		// we need to call closeConnection() directly here.
 		if !info.TLSRequired {
-			c.teardownConn()
+			c.closeConnection(WriteError)
 		}
-		return c
+		return nil
 	}
 
 	// Check for Auth. We schedule this timer after the TLS handshake to avoid


### PR DESCRIPTION
This change allows the removal of the connection and update of
the server state to be done "in place" but still delay the flushing
of and close of tcp connection to the writeLoop. With ref counting
we ensure that the reconnect happens after the flushing but not
before the state has been updated.

Had to fix some places where we may have called closeConnection()
from under the server lock since it now would deadlock for sure.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
