### PR TITLE
Fix sysSubscribe races

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -154,6 +154,12 @@ var (
 
 	// ErrClusterNameRemoteConflict signals that a remote server has a different cluster name.
 	ErrClusterNameRemoteConflict = errors.New("cluster name from remote server conflicts")
+
+	// ErrMalformedSubject is returned when a subscription is made with a subject that does not conform to subject rules.
+	ErrMalformedSubject = errors.New("malformed subject")
+
+	// ErrSubscribePermissionViolation is returned when processing of a subscription fails due to permissions.
+	ErrSubscribePermissionViolation = errors.New("subscribe permission viloation")
 )
 
 // configErr is a configuration error.

--- a/server/events.go
+++ b/server/events.go
@@ -1227,20 +1227,12 @@ func (s *Server) systemSubscribe(subject string, internalOnly bool, cb msgHandle
 	sid := strconv.Itoa(s.sys.sid)
 	s.mu.Unlock()
 
-	arg := []byte(subject + " " + sid)
 	if trace {
-		c.traceInOp("SUB", arg)
+		c.traceInOp("SUB", []byte(subject+" "+sid))
 	}
 
 	// Now create the subscription
-	sub, err := c.processSub(arg, internalOnly)
-	if err != nil {
-		return nil, err
-	}
-	c.mu.Lock()
-	sub.icb = cb
-	c.mu.Unlock()
-	return sub, nil
+	return c.processSub([]byte(subject), nil, []byte(sid), cb, internalOnly)
 }
 
 func (s *Server) sysUnsubscribe(sub *subscription) {

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1056,14 +1056,10 @@ func (t *StreamTemplate) createTemplateSubscriptions() error {
 	sid := 1
 	for _, subject := range t.Config.Subjects {
 		// Now create the subscription
-		sub, err := c.processSub([]byte(subject+" "+strconv.Itoa(sid)), false)
-		if err != nil {
+		if _, err := c.processSub([]byte(subject), nil, []byte(strconv.Itoa(sid)), t.processInboundTemplateMsg, false); err != nil {
 			c.acc.DeleteStreamTemplate(t.Name)
 			return err
 		}
-		c.mu.Lock()
-		sub.icb = t.processInboundTemplateMsg
-		c.mu.Unlock()
 		sid++
 	}
 	return nil

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -910,3 +910,11 @@ func TestNoRaceLeafNodeClusterNameConflictDeadlock(t *testing.T) {
 	checkLeafNodeConnected(t, s3)
 	checkClusterFormed(t, s1, s2, s3)
 }
+
+// This test is same than TestAccountAddServiceImportRace but running
+// without the -race flag, it would capture more easily the possible
+// duplicate sid, resulting in less than expected number of subscriptions
+// in the account's internal subscriptions map.
+func TestNoRaceAccountAddServiceImportRace(t *testing.T) {
+	TestAccountAddServiceImportRace(t)
+}

--- a/server/parser.go
+++ b/server/parser.go
@@ -580,7 +580,7 @@ func (c *client) parse(buf []byte) error {
 					if trace {
 						c.traceInOp("SUB", arg)
 					}
-					_, err = c.processSub(arg, false)
+					err = c.parseSub(arg, false)
 				case ROUTER:
 					switch c.op {
 					case 'R', 'r':

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -3845,7 +3845,7 @@ func TestConfigReloadLeafNodeWithRemotesNoChanges(t *testing.T) {
 	s1, o1 := RunServerWithConfig(conf1)
 	defer s1.Shutdown()
 
-	u, err := url.Parse(fmt.Sprintf("nats://localhost:%d", o1.LeafNode.Port))
+	u, err := url.Parse(fmt.Sprintf("nats://127.0.0.1:%d", o1.LeafNode.Port))
 	if err != nil {
 		t.Fatalf("Error creating url: %v", err)
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -576,16 +576,7 @@ func (mset *Stream) subscribeInternal(subject string, cb msgHandler) (*subscript
 	mset.sid++
 
 	// Now create the subscription
-	sub, err := c.processSub([]byte(subject+" "+strconv.Itoa(mset.sid)), false)
-	if err != nil {
-		return nil, err
-	} else if sub == nil {
-		return nil, fmt.Errorf("malformed subject")
-	}
-	c.mu.Lock()
-	sub.icb = cb
-	c.mu.Unlock()
-	return sub, nil
+	return c.processSub([]byte(subject), nil, []byte(strconv.Itoa(mset.sid)), cb, false)
 }
 
 // Helper for unlocked stream.

--- a/test/jetstream_test.go
+++ b/test/jetstream_test.go
@@ -688,7 +688,7 @@ func TestJetStreamAddStreamBadSubjects(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		e := scResp.Error
-		if e == nil || e.Code != 500 || e.Description != "malformed subject" {
+		if e == nil || e.Code != 500 || e.Description != server.ErrMalformedSubject.Error() {
 			t.Fatalf("Did not get proper error response: %+v", e)
 		}
 	}

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -3558,6 +3558,8 @@ func TestServiceExportWithMultipleAccounts(t *testing.T) {
 	})
 	nc2.Flush()
 
+	checkSubInterest(t, srvB, "INTERNAL", "foo", time.Second)
+
 	nc, err := nats.Connect(fmt.Sprintf("nats://good:pwd@%s:%d", optsB.Host, optsB.Port))
 	if err != nil {
 		t.Fatalf("Error on connect: %v", err)


### PR DESCRIPTION
Made changes to processSub() to accept a subscription which allows
the icb callback to be set prior to add the subscription to the
account's sublist, which prevent races.
Fixed some other racy conditions, notably in addServiceImportSub()

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
