### PR TITLE
fix absolute url in monitoring menu

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1138,12 +1138,12 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
   <body>
     <img src="http://nats.io/img/logo.png" alt="NATS">
     <br/>
-	<a href=%s>varz</a><br/>
-	<a href=%s>connz</a><br/>
-	<a href=%s>routez</a><br/>
-	<a href=%s>gatewayz</a><br/>
-	<a href=%s>leafz</a><br/>
-	<a href=%s>subsz</a><br/>
+	<a href=.%s>varz</a><br/>
+	<a href=.%s>connz</a><br/>
+	<a href=.%s>routez</a><br/>
+	<a href=.%s>gatewayz</a><br/>
+	<a href=.%s>leafz</a><br/>
+	<a href=.%s>subsz</a><br/>
     <br/>
     <a href=https://docs.nats.io/nats-server/configuration/monitoring.html>help</a>
   </body>


### PR DESCRIPTION
Minor fix for monitoring menu.
If we use nginx proxy for 8222 monitoring hosts. http://host:81/nats/node1/ urls in menu http://host:81/ like http://host:81/varz not http://host:81/nats/node1/varz