### PR TITLE
Emit latency traces when sampling is set to headers

### DIFF
--- a/doc/adr/0003-distributed-tracing.md
+++ b/doc/adr/0003-distributed-tracing.md
@@ -5,7 +5,7 @@ Author: @ripienaar
 
 ## Status
 
-Proposed
+Approved
 
 ## Context
 
@@ -52,15 +52,14 @@ exports: [
 
 This enables sampling based `50%` of the service requests on this service.
 
-I propose we support additional sampling values `zipkin`, `jaeger`, `trace_context` which will configure the server to
+I propose we support the additional sampling value `headers` which will configure the server to
 interpret the headers as below to determine if a request should be sampled.
 
 ## Propagating headers
 
-The `io.nats.server.metric.v1.service_latency` advisory gets updated with additional `trace_format` and `headers` fields.
+The `io.nats.server.metric.v1.service_latency` advisory gets updated with an additional `headers` field.
 
-`headers` would just propagate all the headers unmodified. We might later add support for a whitelist here to avoid
-leaking sensitive information.
+`headers` contains only the headers used for the sampling decision.
 
 ```json
 {
@@ -68,9 +67,8 @@ leaking sensitive information.
   "id": "YBxAhpUFfs1rPGo323WcmQ",
   "timestamp": "2020-05-21T08:06:29.4981587Z",
   "status": 200,
-  "trace_format": "jaeger",
   "headers": {
-    "Uber-Trace-Id": "09931e3444de7c99:50ed16db42b98999:0:1"
+    "Uber-Trace-Id": ["09931e3444de7c99:50ed16db42b98999:0:1"]
   },
   "requestor": {
     "acc": "WEB",

--- a/server/client.go
+++ b/server/client.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/rand"
 	"net"
+	"net/http"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -3346,8 +3347,8 @@ func (c *client) handleGWReplyMap(msg []byte) bool {
 }
 
 // Used to setup the response map for a service import request that has a reply subject.
-func (c *client) setupResponseServiceImport(acc *Account, si *serviceImport) *serviceImport {
-	rsi := si.acc.addRespServiceImport(acc, string(c.pa.reply), si)
+func (c *client) setupResponseServiceImport(acc *Account, si *serviceImport, tracking bool, header http.Header) *serviceImport {
+	rsi := si.acc.addRespServiceImport(acc, string(c.pa.reply), si, tracking, header)
 	if si.latency != nil {
 		if c.rtt == 0 {
 			// We have a service import that we are tracking but have not established RTT.
@@ -3380,22 +3381,17 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 
 	// Check if there is a reply present and set up a response.
 	// TODO(dlc) - restrict to configured service imports and not responses?
+	tracking, headers := shouldSample(si.latency, c)
 	if len(c.pa.reply) > 0 {
-		rsi = c.setupResponseServiceImport(acc, si)
+		rsi = c.setupResponseServiceImport(acc, si, tracking, headers)
 		if rsi != nil {
 			nrr = []byte(rsi.from)
 		}
-	}
-
-	// Pick correct to subject. If we matched on a wildcard use the literal publish subject.
-	to := si.to
-	if si.hasWC {
-		to = string(c.pa.subject)
-	}
-
-	// Check to see if this was a bad request with no reply and we were supposed to be tracking.
-	if !si.response && si.latency != nil && len(c.pa.reply) == 0 && shouldSample(si.latency) {
-		si.acc.sendBadRequestTrackingLatency(si, c)
+	} else {
+		// Check to see if this was a bad request with no reply and we were supposed to be tracking.
+		if !si.response && si.latency != nil && tracking {
+			si.acc.sendBadRequestTrackingLatency(si, c, headers)
+		}
 	}
 
 	// Send tracking info here if we are tracking this response.
@@ -3403,6 +3399,12 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 	var didSendTL bool
 	if si.tracking {
 		didSendTL = acc.sendTrackingLatency(si, c)
+	}
+
+	// Pick correct to subject. If we matched on a wildcard use the literal publish subject.
+	to := si.to
+	if si.hasWC {
+		to = string(c.pa.subject)
 	}
 
 	// FIXME(dlc) - Do L1 cache trick like normal client?

--- a/server/opts.go
+++ b/server/opts.go
@@ -2415,7 +2415,7 @@ func parseServiceLatency(root token, v interface{}) (l *serviceLatency, retErr e
 	// Read sampling value.
 	if v, ok := latency["sampling"]; ok {
 		tk, v := unwrapValue(v, &lt)
-
+		header := false
 		var sample int64
 		switch vv := v.(type) {
 		case int64:
@@ -2423,6 +2423,11 @@ func parseServiceLatency(root token, v interface{}) (l *serviceLatency, retErr e
 			sample = vv
 		case string:
 			// Sample is a string, like "50%".
+			if strings.ToLower(strings.TrimSpace(vv)) == "headers" {
+				header = true
+				sample = 0
+				break
+			}
 			s := strings.TrimSuffix(vv, "%")
 			n, err := strconv.Atoi(s)
 			if err != nil {
@@ -2434,9 +2439,11 @@ func parseServiceLatency(root token, v interface{}) (l *serviceLatency, retErr e
 			return nil, &configErr{token: tk,
 				reason: fmt.Sprintf("Expected latency sample to be a string or map/struct, got %T", v)}
 		}
-		if sample < 1 || sample > 100 {
-			return nil, &configErr{token: tk,
-				reason: ErrBadSampling.Error()}
+		if !header {
+			if sample < 1 || sample > 100 {
+				return nil, &configErr{token: tk,
+					reason: ErrBadSampling.Error()}
+			}
 		}
 
 		sl.sampling = int8(sample)

--- a/server/parser.go
+++ b/server/parser.go
@@ -14,7 +14,11 @@
 package server
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
+	"net/http"
+	"net/textproto"
 )
 
 type parserState int
@@ -26,6 +30,7 @@ type parseState struct {
 	pa      pubArg
 	argBuf  []byte
 	msgBuf  []byte
+	header  http.Header // access via getHeader
 	scratch [MAX_CONTROL_LINE_SIZE]byte
 }
 
@@ -442,7 +447,7 @@ func (c *client) parse(buf []byte) error {
 				c.traceMsg(c.msgBuf)
 			}
 			c.processInboundMsg(c.msgBuf)
-			c.argBuf, c.msgBuf = nil, nil
+			c.argBuf, c.msgBuf, c.header = nil, nil, nil
 			c.drop, c.as, c.state = 0, i+1, OP_START
 			// Drop all pub args
 			c.pa.arg, c.pa.pacache, c.pa.origin, c.pa.account, c.pa.subject = nil, nil, nil, nil, nil
@@ -1174,4 +1179,18 @@ func (c *client) clonePubArg() error {
 			return c.processHeaderPub(c.argBuf)
 		}
 	}
+}
+
+func (ps *parseState) getHeader() http.Header {
+	if ps.header == nil {
+		if hdr := ps.pa.hdr; hdr > 0 {
+			reader := bufio.NewReader(bytes.NewReader(ps.msgBuf[0:hdr]))
+			tp := textproto.NewReader(reader)
+			tp.ReadLine() // skip over first line, contains version
+			if mimeHeader, err := tp.ReadMIMEHeader(); err == nil {
+				ps.header = http.Header(mimeHeader)
+			}
+		}
+	}
+	return ps.header
 }


### PR DESCRIPTION
When latency is set to a percentage, headers are included as well.
Header sharing can be turned off by setting (import) sharing to false.

Signed-off-by: Matthias Hanel <mh@synadia.com>

As of now config only has one new value, "headers" (see changes in test/service_latency_test.go)
Since some of the tracing systems make use of multiple header anyway I figured I inspect them all, instead of configuring a particular one. 
As a result I did not include the name of the tracing system (yet?).

Another difference is how headers are included. (array of values)
I also include them every time, even when sampling is set to 100%. (can change)

output sample:
```
{
    "type": "io.nats.server.metric.v1.service_latency",
    "id": "LnDl4oXc5MjOQsRSIO6GXc",
    "timestamp": "2020-08-11T18:38:47.853862Z",
    "status": 200,
    "requestor": {
    "acc": "CLIENT",
    "rtt": 264924,
    "start": "2020-08-11T18:38:47.823336Z",
    "user": "client",
    "lang": "go",
    "ver": "1.11.0",
    "ip": "127.0.0.1",
    "cid": 4,
    "server": "ND6S3NY5BQIJFIORFYHHJAGJOMHIZJU5IH6ZO5MRFBFHLAUU4CWZHKDV"
    },
    "responder": {
    "acc": "SVC",
    "rtt": 990893,
    "start": "2020-08-11T18:38:47.821541Z",
    "user": "svc",
    "lang": "go",
    "ver": "1.11.0",
    "ip": "127.0.0.1",
    "cid": 3,
    "server": "ND6S3NY5BQIJFIORFYHHJAGJOMHIZJU5IH6ZO5MRFBFHLAUU4CWZHKDV"
    },
    "header": {
    "Some-Other": [
        "header"
    ],
    "Uber-Trace-Id": [
        "479fefe9525eddb:479fefe9525eddb:0:1"
    ]
    },
    "start": "2020-08-11T18:38:47.823729076Z",
    "service": 28869107,
    "system": 7171,
    "total": 30132095
}
```