### PR TITLE
Inhibit Go's default TCP keepalive settings for NATS

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -425,7 +425,7 @@ func (s *Server) startGatewayAcceptLoop() {
 		return
 	}
 	hp := net.JoinHostPort(opts.Gateway.Host, strconv.Itoa(port))
-	l, e := net.Listen("tcp", hp)
+	l, e := natsListen("tcp", hp)
 	if e != nil {
 		s.mu.Unlock()
 		s.Fatalf("Error listening on gateway port: %d - %v", opts.Gateway.Port, e)

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -630,7 +630,7 @@ func (s *Server) solicitGateway(cfg *gatewayCfg, firstConnect bool) {
 			} else {
 				s.Debugf(connFmt, typeStr, cfg.Name, u.Host, address, attempts)
 			}
-			conn, err := net.DialTimeout("tcp", address, DEFAULT_ROUTE_DIAL)
+			conn, err := natsDialTimeout("tcp", address, DEFAULT_ROUTE_DIAL)
 			if err == nil {
 				// We could connect, create the gateway connection and return.
 				s.createGateway(cfg, u, conn)

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -5790,7 +5790,7 @@ func TestGatewayAccountInterestModeSwitchOnlyOncePerAccount(t *testing.T) {
 }
 
 func TestGatewaySingleOutbound(t *testing.T) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	l, err := natsListen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Error on listen: %v", err)
 	}

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -290,7 +290,7 @@ func (s *Server) connectToRemoteLeafNode(remote *leafNodeCfg, firstConnect bool)
 				ipStr = fmt.Sprintf(" (%s)", url)
 			}
 			s.Debugf("Trying to connect as leafnode to remote server on %q%s", rURL.Host, ipStr)
-			conn, err = net.DialTimeout("tcp", url, dialTimeout)
+			conn, err = natsDialTimeout("tcp", url, dialTimeout)
 		}
 		if err != nil {
 			attempts++

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -359,7 +359,7 @@ func (s *Server) startLeafNodeAcceptLoop() {
 		return
 	}
 	hp := net.JoinHostPort(opts.LeafNode.Host, strconv.Itoa(port))
-	l, e := net.Listen("tcp", hp)
+	l, e := natsListen("tcp", hp)
 	if e != nil {
 		s.mu.Unlock()
 		s.Fatalf("Error listening on leafnode port: %d - %v", opts.LeafNode.Port, e)

--- a/server/route.go
+++ b/server/route.go
@@ -1675,7 +1675,7 @@ func (s *Server) startRouteAcceptLoop() {
 	}
 
 	hp := net.JoinHostPort(opts.Cluster.Host, strconv.Itoa(port))
-	l, e := net.Listen("tcp", hp)
+	l, e := natsListen("tcp", hp)
 	if e != nil {
 		s.mu.Unlock()
 		s.Fatalf("Error listening on router port: %d - %v", opts.Cluster.Port, e)

--- a/server/route.go
+++ b/server/route.go
@@ -1842,7 +1842,7 @@ func (s *Server) connectToRoute(rURL *url.URL, tryForEver, firstConnect bool) {
 			return
 		}
 		s.Debugf("Trying to connect to route on %s", rURL.Host)
-		conn, err := net.DialTimeout("tcp", rURL.Host, DEFAULT_ROUTE_DIAL)
+		conn, err := natsDialTimeout("tcp", rURL.Host, DEFAULT_ROUTE_DIAL)
 		if err != nil {
 			attempts++
 			if s.shouldReportConnectErr(firstConnect, attempts) {

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -92,7 +92,7 @@ func TestRouteConfig(t *testing.T) {
 }
 
 func TestClusterAdvertise(t *testing.T) {
-	lst, err := net.Listen("tcp", "127.0.0.1:0")
+	lst, err := natsListen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Error starting listener: %v", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1754,7 +1754,7 @@ func (s *Server) StartProfiler() {
 	}
 	hp := net.JoinHostPort(opts.Host, strconv.Itoa(port))
 
-	l, err := natsListen("tcp", hp)
+	l, err := net.Listen("tcp", hp)
 	s.Noticef("profiling port: %d", l.Addr().(*net.TCPAddr).Port)
 
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -1632,7 +1632,7 @@ func (s *Server) AcceptLoop(clr chan struct{}) {
 		return
 	}
 	hp := net.JoinHostPort(opts.Host, strconv.Itoa(opts.Port))
-	l, e := net.Listen("tcp", hp)
+	l, e := natsListen("tcp", hp)
 	if e != nil {
 		s.mu.Unlock()
 		s.Fatalf("Error listening on port: %s, %q", hp, e)
@@ -1754,7 +1754,7 @@ func (s *Server) StartProfiler() {
 	}
 	hp := net.JoinHostPort(opts.Host, strconv.Itoa(port))
 
-	l, err := net.Listen("tcp", hp)
+	l, err := natsListen("tcp", hp)
 	s.Noticef("profiling port: %d", l.Addr().(*net.TCPAddr).Port)
 
 	if err != nil {

--- a/server/util.go
+++ b/server/util.go
@@ -211,3 +211,13 @@ var natsListenConfig = &net.ListenConfig{
 func natsListen(network, address string) (net.Listener, error) {
 	return natsListenConfig.Listen(context.Background(), network, address)
 }
+
+// natsDialTimeout is the same as net.DialTimeout() except the TCP keepalives
+// are disabled (to match Go's behavior before Go 1.13).
+func natsDialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
+	d := net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: -1,
+	}
+	return d.Dial(network, address)
+}


### PR DESCRIPTION
Go 1.13 changed the semantics of the tuning parameters for TCP keepalives, including the default value.  This affects all TCP listeners.  The NATS protocol has its own L7 keepalive system (PING/PONG) and the Go defaults are not a good fit for some valid deployment scenarios, while Go doesn't directly expose a working API for tuning these.

Rather than add a configuration knob and pull in another dependency (with portability issues) just disable TCP keepalives for all listeners used for speaking the NATS protocol.

Change the tests so we test the same logic.  Do not change HTTP monitoring or the websocket API.

This addresses the same problem as Issue #1561 but does not resolve all of it, as we're not making this configurable.

/cc @nats-io/core