### PR TITLE
[ADDED] Checks for CIDR blocks and connect time ranges specified in jwt

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -767,16 +767,23 @@ func (c *client) setPermissions(perms *Permissions) {
 
 // Check to see if we have an expiration for the user JWT via base claims.
 // FIXME(dlc) - Clear on connect with new JWT.
-func (c *client) checkExpiration(claims *jwt.ClaimsData) {
-	if claims.Expires == 0 {
-		return
-	}
+func (c *client) setExpiration(claims *jwt.ClaimsData, validFor time.Duration) {
 	tn := time.Now().Unix()
-	if claims.Expires < tn {
+	expiresAt := time.Duration(0)
+	if claims.Expires > tn {
+		expiresAt = time.Duration(claims.Expires - tn)
+	}
+	if claims.Expires == 0 {
+		if validFor != 0 {
+			c.setExpirationTimer(validFor)
+		}
 		return
 	}
-	expiresAt := time.Duration(claims.Expires - tn)
-	c.setExpirationTimer(expiresAt * time.Second)
+	if validFor != 0 && validFor < expiresAt {
+		c.setExpirationTimer(validFor)
+	} else if claims.Expires != 0 {
+		c.setExpirationTimer(expiresAt * time.Second)
+	}
 }
 
 // This will load up the deny structure used for filtering delivered

--- a/server/client.go
+++ b/server/client.go
@@ -771,7 +771,7 @@ func (c *client) setExpiration(claims *jwt.ClaimsData, validFor time.Duration) {
 	tn := time.Now().Unix()
 	expiresAt := time.Duration(0)
 	if claims.Expires > tn {
-		expiresAt = time.Duration(claims.Expires - tn)
+		expiresAt = time.Duration(claims.Expires-tn) * time.Second
 	}
 	if claims.Expires == 0 {
 		if validFor != 0 {
@@ -781,8 +781,8 @@ func (c *client) setExpiration(claims *jwt.ClaimsData, validFor time.Duration) {
 	}
 	if validFor != 0 && validFor < expiresAt {
 		c.setExpirationTimer(validFor)
-	} else if claims.Expires != 0 {
-		c.setExpirationTimer(expiresAt * time.Second)
+	} else {
+		c.setExpirationTimer(expiresAt)
 	}
 }
 

--- a/server/client.go
+++ b/server/client.go
@@ -769,15 +769,15 @@ func (c *client) setPermissions(perms *Permissions) {
 // FIXME(dlc) - Clear on connect with new JWT.
 func (c *client) setExpiration(claims *jwt.ClaimsData, validFor time.Duration) {
 	tn := time.Now().Unix()
-	expiresAt := time.Duration(0)
-	if claims.Expires > tn {
-		expiresAt = time.Duration(claims.Expires-tn) * time.Second
-	}
 	if claims.Expires == 0 {
 		if validFor != 0 {
 			c.setExpirationTimer(validFor)
 		}
 		return
+	}
+	expiresAt := time.Duration(0)
+	if claims.Expires > tn {
+		expiresAt = time.Duration(claims.Expires-tn) * time.Second
 	}
 	if validFor != 0 && validFor < expiresAt {
 		c.setExpirationTimer(validFor)

--- a/server/client.go
+++ b/server/client.go
@@ -768,7 +768,6 @@ func (c *client) setPermissions(perms *Permissions) {
 // Check to see if we have an expiration for the user JWT via base claims.
 // FIXME(dlc) - Clear on connect with new JWT.
 func (c *client) setExpiration(claims *jwt.ClaimsData, validFor time.Duration) {
-	tn := time.Now().Unix()
 	if claims.Expires == 0 {
 		if validFor != 0 {
 			c.setExpirationTimer(validFor)
@@ -776,6 +775,7 @@ func (c *client) setExpiration(claims *jwt.ClaimsData, validFor time.Duration) {
 		return
 	}
 	expiresAt := time.Duration(0)
+	tn := time.Now().Unix()
 	if claims.Expires > tn {
 		expiresAt = time.Duration(claims.Expires-tn) * time.Second
 	}

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -16,8 +16,10 @@ package server
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
@@ -139,4 +141,61 @@ func validateTrustedOperators(o *Options) error {
 		}
 	}
 	return nil
+}
+
+func validateSrc(claims *jwt.UserClaims, host string) bool {
+	if claims == nil {
+		return false
+	} else if claims.Src == "" {
+		return true
+	} else if host == "" {
+		return false
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	for _, cidr := range strings.Split(claims.Src, ",") {
+		if _, net, err := net.ParseCIDR(cidr); err != nil {
+			return false // should not happen as this jwt is invalid
+		} else if net.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateTimes(claims *jwt.UserClaims) (bool, time.Duration) {
+	if claims == nil {
+		return false, time.Duration(0)
+	} else if len(claims.Times) == 0 {
+		return true, time.Duration(0)
+	}
+	now := time.Now()
+	for _, timeRange := range claims.Times {
+		y, m, d := now.Date()
+		m = m - 1
+		d = d - 1
+		start, err := time.ParseInLocation("15:04:05", timeRange.Start, now.Location())
+		if err != nil {
+			return false, time.Duration(0) // parsing not expected to fail at this point
+		}
+		end, err := time.ParseInLocation("15:04:05", timeRange.End, now.Location())
+		if err != nil {
+			return false, time.Duration(0) // parsing not expected to fail at this point
+		}
+		if start.After(end) {
+			start = start.AddDate(y, int(m), d)
+			d++ // the intent is to be the next day
+		} else {
+			start = start.AddDate(y, int(m), d)
+		}
+		if start.Before(now) {
+			end = end.AddDate(y, int(m), d)
+			if end.After(now) {
+				return true, end.Sub(now)
+			}
+		}
+	}
+	return false, time.Duration(0)
 }

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -3286,7 +3286,8 @@ func TestJWTUserLimits(t *testing.T) {
 }
 
 func TestJWTTimeExpiration(t *testing.T) {
-	validFor := 4 * time.Second
+	validFor := 1500 * time.Millisecond
+	validRange := 500 * time.Millisecond
 	doNotExpire := time.Now().AddDate(1, 0, 0)
 	// create account
 	kp, _ := nkeys.CreateAccount()
@@ -3328,7 +3329,7 @@ func TestJWTTimeExpiration(t *testing.T) {
 				now := time.Now()
 				stop := start.Add(validFor)
 				// assure event happens within a second of stop
-				if stop.Add(-time.Second).Before(stop) && now.Before(stop.Add(time.Second)) {
+				if stop.Add(-validRange).Before(stop) && now.Before(stop.Add(validRange)) {
 					errChan <- struct{}{}
 				}
 			}))
@@ -3361,13 +3362,13 @@ func TestJWTTimeExpiration(t *testing.T) {
 				now := time.Now()
 				stop := start1.Add(validFor)
 				// assure event happens within a second of stop
-				if stop.Add(-time.Second).Before(stop) && now.Before(stop.Add(time.Second)) {
+				if stop.Add(-validRange).Before(stop) && now.Before(stop.Add(validRange)) {
 					errChan <- struct{}{}
 					return
 				}
 				stop = start2.Add(validFor)
 				// assure event happens within a second of stop
-				if stop.Add(-time.Second).Before(stop) && now.Before(stop.Add(time.Second)) {
+				if stop.Add(-validRange).Before(stop) && now.Before(stop.Add(validRange)) {
 					errChan <- struct{}{}
 				}
 			}))
@@ -3401,7 +3402,7 @@ func TestJWTTimeExpiration(t *testing.T) {
 				now := time.Now()
 				stop := start.Add(validFor)
 				// assure event happens within a second of stop
-				if stop.Add(-time.Second).Before(stop) && now.Before(stop.Add(time.Second)) {
+				if stop.Add(-validRange).Before(stop) && now.Before(stop.Add(validRange)) {
 					errChan <- struct{}{}
 				}
 			}))

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -3367,7 +3367,6 @@ func TestJWTTimeExpiration(t *testing.T) {
 				}
 			}))
 		<-errChan
-		require_False(t, c.IsConnected())
 		<-reConnectChan
 		require_False(t, c.IsReconnecting())
 		require_True(t, c.IsConnected())


### PR DESCRIPTION
because times stored are hh:mm:ss it is possible to end up with start > end where end is actually the next day.
jwt.go line 189

Also, ranges are based on the servers location, not the clients.