### PR TITLE
Add support for cluster name changes from static to dynamic

### DIFF
--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1635,7 +1635,8 @@ func TestLeafNodeOriginClusterInfo(t *testing.T) {
 
 	// Now make sure that if we update our cluster name, simulating the settling
 	// of dynamic cluster names between competing servers.
-	s.setClusterName("xyz")
+	s.setClusterName("xyz", false)
+
 	// Make sure we disconnect and reconnect.
 	checkLeafNodeConnectedCount(t, s, 0)
 	checkLeafNodeConnected(t, s)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1337,6 +1337,7 @@ func (s *Server) updateVarzRuntimeFields(v *Varz, forceUpdate bool, pcpu float64
 	for key, val := range s.httpReqStats {
 		v.HTTPReqStats[key] = val
 	}
+	v.Cluster.Name = s.info.Cluster
 
 	// Update Gateway remote urls if applicable
 	gw := s.gateway


### PR DESCRIPTION
This adds support for servers using explicit names to be able to go back to dynamic mode. In order to do this, the servers need to remember some state about the solicited routes (their cluster name and whether in dynamic cluster mode), as well as whether the node has learned an explicit cluster name already if being in dynamic mode.  The NATS Servers also have a default cluster name generated on boot so that whenever there is a renegotiation of what ought to be the dynamic cluster name no new names are introduced.

 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request:

- Add support for changing cluster name modes from static to dynamic when using config reload

/cc @nats-io/core

Signed-off-by: Waldemar Quevedo <wally@synadia.com>
