### PR TITLE
Discard client provided jwt when not in operator mode

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1541,6 +1541,10 @@ func (c *client) processConnect(arg []byte) error {
 	if ws := c.ws; ws != nil && c.opts.JWT == "" {
 		c.opts.JWT = ws.cookieJwt
 	}
+	// when not in operator mode, discard the jwt
+	if srv != nil && srv.trustedKeys == nil {
+		c.opts.JWT = ""
+	}
 	ujwt := c.opts.JWT
 
 	// For headers both client and server need to support.


### PR DESCRIPTION
RI ran into an issue where he submitted a user jwt even though the server was not set up in operator mode.
Subsequently values from the jwt got used.

Signed-off-by: Matthias Hanel <mh@synadia.com>

