### PR TITLE
[FIXED] Error when importing an account results in an error, retry later

### DIFF
--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -1719,6 +1719,198 @@ func TestAccountURLResolverNoFetchOnReload(t *testing.T) {
 	}
 }
 
+func TestAccountURLResolverFetchFailureInServer1(t *testing.T) {
+	const subj = "test"
+	const crossAccSubj = "test"
+	// Create Exporting Account
+	expkp, _ := nkeys.CreateAccount()
+	exppub, _ := expkp.PublicKey()
+	expac := jwt.NewAccountClaims(exppub)
+	expac.Exports.Add(&jwt.Export{
+		Subject: crossAccSubj,
+		Type:    jwt.Stream,
+	})
+	expjwt, err := expac.Encode(oKp)
+	if err != nil {
+		t.Fatalf("Error generating account JWT: %v", err)
+	}
+	// Create importing Account
+	impkp, _ := nkeys.CreateAccount()
+	imppub, _ := impkp.PublicKey()
+	impac := jwt.NewAccountClaims(imppub)
+	impac.Imports.Add(&jwt.Import{
+		Account: exppub,
+		Subject: crossAccSubj,
+		Type:    jwt.Stream,
+	})
+	impjwt, err := impac.Encode(oKp)
+	if err != nil {
+		t.Fatalf("Error generating account JWT: %v", err)
+	}
+	// Simulate an account server that drops the first request to exppub
+	chanImpA := make(chan struct{}, 10)
+	defer close(chanImpA)
+	chanExpS := make(chan struct{}, 10)
+	defer close(chanExpS)
+	chanExpF := make(chan struct{}, 1)
+	defer close(chanExpF)
+	failureCnt := int32(0)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/A/" {
+			// Server startup
+			w.Write(nil)
+			chanImpA <- struct{}{}
+		} else if r.URL.Path == "/A/"+imppub {
+			w.Write([]byte(impjwt))
+			chanImpA <- struct{}{}
+		} else if r.URL.Path == "/A/"+exppub {
+			if atomic.AddInt32(&failureCnt, 1) <= 1 {
+				// skip the write to simulate the failure
+				chanExpF <- struct{}{}
+			} else {
+				w.Write([]byte(expjwt))
+				chanExpS <- struct{}{}
+			}
+		} else {
+			t.Fatal("not expected")
+		}
+	}))
+	defer ts.Close()
+	// Create server
+	confA := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: -1
+		operator: %s
+		resolver: URL("%s/A/")
+    `, ojwt, ts.URL)))
+	defer os.Remove(confA)
+	sA := RunServer(LoadConfig(confA))
+	defer sA.Shutdown()
+	// server observed one fetch on startup
+	chanRecv(t, chanImpA, 10*time.Second)
+	// Create first client
+	ncA := natsConnect(t, sA.ClientURL(), createUserCreds(t, nil, impkp))
+	defer ncA.Close()
+	// create a test subscription
+	subA, err := ncA.SubscribeSync(subj)
+	if err != nil {
+		t.Fatalf("Expected no error during subscribe: %v", err)
+	}
+	defer subA.Unsubscribe()
+	// Connect of client triggered a fetch of both accounts
+	// the fetch for the imported account will fail
+	chanRecv(t, chanImpA, 10*time.Second)
+	chanRecv(t, chanExpF, 10*time.Second)
+	// create second client for user exporting
+	ncB := natsConnect(t, sA.ClientURL(), createUserCreds(t, nil, expkp))
+	defer ncB.Close()
+	chanRecv(t, chanExpS, 10*time.Second)
+	// Connect of client triggered another fetch, this time passing
+	checkSubInterest(t, sA, imppub, subj, 10*time.Second)
+	checkSubInterest(t, sA, exppub, crossAccSubj, 10*time.Second) // Will fail as a result of this issue
+}
+
+func TestAccountURLResolverFetchFailurePushReorder(t *testing.T) {
+	const subj = "test"
+	const crossAccSubj = "test"
+	// Create System Account
+	syskp, _ := nkeys.CreateAccount()
+	syspub, _ := syskp.PublicKey()
+	sysAc := jwt.NewAccountClaims(syspub)
+	sysjwt, err := sysAc.Encode(oKp)
+	if err != nil {
+		t.Fatalf("Error generating account JWT: %v", err)
+	}
+	// Create Exporting Account
+	expkp, _ := nkeys.CreateAccount()
+	exppub, _ := expkp.PublicKey()
+	expac := jwt.NewAccountClaims(exppub)
+	expjwt1, err := expac.Encode(oKp)
+	if err != nil {
+		t.Fatalf("Error generating account JWT: %v", err)
+	}
+	expac.Exports.Add(&jwt.Export{
+		Subject: crossAccSubj,
+		Type:    jwt.Stream,
+	})
+	expjwt2, err := expac.Encode(oKp)
+	if err != nil {
+		t.Fatalf("Error generating account JWT: %v", err)
+	}
+	// Create importing Account
+	impkp, _ := nkeys.CreateAccount()
+	imppub, _ := impkp.PublicKey()
+	impac := jwt.NewAccountClaims(imppub)
+	impac.Imports.Add(&jwt.Import{
+		Account: exppub,
+		Subject: crossAccSubj,
+		Type:    jwt.Stream,
+	})
+	impjwt, err := impac.Encode(oKp)
+	if err != nil {
+		t.Fatalf("Error generating account JWT: %v", err)
+	}
+	// Simulate an account server that does not serve the updated jwt for exppub
+	chanImpA := make(chan struct{}, 10)
+	defer close(chanImpA)
+	chanExpS := make(chan struct{}, 10)
+	defer close(chanExpS)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/A/" {
+			// Server startup
+			w.Write(nil)
+			chanImpA <- struct{}{}
+		} else if r.URL.Path == "/A/"+imppub {
+			w.Write([]byte(impjwt))
+			chanImpA <- struct{}{}
+		} else if r.URL.Path == "/A/"+exppub {
+			// respond with jwt that does not have the export
+			// this simulates an ordering issue
+			w.Write([]byte(expjwt1))
+			chanExpS <- struct{}{}
+		} else if r.URL.Path == "/A/"+syspub {
+			w.Write([]byte(sysjwt))
+		} else {
+			t.Fatal("not expected")
+		}
+	}))
+	defer ts.Close()
+	confA := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: -1
+		operator: %s
+		resolver: URL("%s/A/")
+		system_account: %s
+    `, ojwt, ts.URL, syspub)))
+	defer os.Remove(confA)
+	sA := RunServer(LoadConfig(confA))
+	defer sA.Shutdown()
+	// server observed one fetch on startup
+	chanRecv(t, chanImpA, 10*time.Second)
+	// Create first client
+	ncA := natsConnect(t, sA.ClientURL(), createUserCreds(t, nil, impkp))
+	defer ncA.Close()
+	// create a test subscription
+	subA, err := ncA.SubscribeSync(subj)
+	if err != nil {
+		t.Fatalf("Expected no error during subscribe: %v", err)
+	}
+	defer subA.Unsubscribe()
+	// Connect of client triggered a fetch of both accounts
+	// the fetch for the imported account will fail
+	chanRecv(t, chanImpA, 10*time.Second)
+	chanRecv(t, chanExpS, 10*time.Second)
+	// create second client for user exporting
+	ncB := natsConnect(t, sA.ClientURL(), createUserCreds(t, nil, expkp))
+	defer ncB.Close()
+	// update expjwt2, this will correct the import issue
+	sysc := natsConnect(t, sA.ClientURL(), createUserCreds(t, nil, syskp))
+	defer sysc.Close()
+	natsPub(t, sysc, fmt.Sprintf(accUpdateEventSubj, exppub), []byte(expjwt2))
+	sysc.Flush()
+	// updating expjwt should cause this to pass
+	checkSubInterest(t, sA, imppub, subj, 10*time.Second)
+	checkSubInterest(t, sA, exppub, crossAccSubj, 10*time.Second) // Will fail as a result of this issue
+}
+
 func TestAccountURLResolverFetchFailureInCluster(t *testing.T) {
 	assertChanLen := func(x int, chans ...chan struct{}) {
 		t.Helper()
@@ -1730,15 +1922,6 @@ func TestAccountURLResolverFetchFailureInCluster(t *testing.T) {
 	}
 	const subj = ">"
 	const crossAccSubj = "test"
-	// Create Operator
-	op, _ := nkeys.CreateOperator()
-	opub, _ := op.PublicKey()
-	oc := jwt.NewOperatorClaims(opub)
-	oc.Subject = opub
-	ojwt, err := oc.Encode(op)
-	if err != nil {
-		t.Fatalf("Error generating operator JWT: %v", err)
-	}
 	// Create Exporting Account
 	expkp, _ := nkeys.CreateAccount()
 	exppub, _ := expkp.PublicKey()
@@ -1747,7 +1930,7 @@ func TestAccountURLResolverFetchFailureInCluster(t *testing.T) {
 		Subject: crossAccSubj,
 		Type:    jwt.Stream,
 	})
-	expjwt, err := expac.Encode(op)
+	expjwt, err := expac.Encode(oKp)
 	if err != nil {
 		t.Fatalf("Error generating account JWT: %v", err)
 	}
@@ -1764,7 +1947,7 @@ func TestAccountURLResolverFetchFailureInCluster(t *testing.T) {
 		Subject: "srvc",
 		Type:    jwt.Service,
 	})
-	impjwt, err := impac.Encode(op)
+	impjwt, err := impac.Encode(oKp)
 	if err != nil {
 		t.Fatalf("Error generating account JWT: %v", err)
 	}

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -1999,13 +1999,15 @@ func TestAccountURLResolverPermanentFetchFailure(t *testing.T) {
 	natsPub(t, sysc, fmt.Sprintf(accUpdateEventSubj, exppub), []byte(expjwt))
 	sysc.Flush()
 	importErrCnt := 0
+	tmr := time.NewTimer(500 * time.Millisecond)
+	defer tmr.Stop()
 	for {
 		select {
 		case line := <-l.dbgCh:
 			if strings.HasPrefix(line, "Error adding stream import to account") {
 				importErrCnt++
 			}
-		case <-time.After(time.Second * 2):
+		case <-tmr.C:
 			// connecting and updating, each cause 3 traces (2 + 1 on iteration)
 			if importErrCnt != 6 {
 				t.Fatalf("Expected 6 debug traces, got %d", importErrCnt)


### PR DESCRIPTION
This failure can be caused if the imported account can't be fetched or
is not up to date yet.

Signed-off-by: Matthias Hanel <mh@synadia.com>

This change introduces a new account flag.
If this flag is set, perform the update and do NOT return ErrAccountResolverSameClaims.
Added two unit tests for both situations.
Shorten one unit test that was able to use the default operator.

