### PR TITLE
Release 2.1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
 - set -e
 - go test -i ./...
 - go test -v -run=TestNoRace --failfast -p=1 ./...
-- if [[ "$TRAVIS_GO_VERSION" =~ 1.13 ]]; then ./scripts/cov.sh TRAVIS; else go test -v -race -p=1 --failfast ./...; fi
+- if [[ "$TRAVIS_GO_VERSION" =~ 1.14 ]]; then ./scripts/cov.sh TRAVIS; else go test -v -race -p=1 --failfast ./...; fi
 - set +e
 
 deploy:
@@ -35,4 +35,4 @@ deploy:
   script: curl -sL http://git.io/goreleaser | bash
   on:
     tags: true
-    condition: $TRAVIS_GO_VERSION =~ 1.13
+    condition: $TRAVIS_GO_VERSION =~ 1.14

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ If you are interested in contributing to NATS, read about our...
 [Fossa-Image]: https://app.fossa.io/api/projects/git%2Bgithub.com%2Fnats-io%2Fgnatsd.svg?type=shield
 [Build-Status-Url]: https://travis-ci.org/nats-io/nats-server
 [Build-Status-Image]: https://travis-ci.org/nats-io/nats-server.svg?branch=master
-[Release-Url]: https://github.com/nats-io/nats-server/releases/tag/v2.1.7
-[Release-image]: https://img.shields.io/badge/release-v2.1.7-1eb0fc.svg
+[Release-Url]: https://github.com/nats-io/nats-server/releases/tag/v2.1.8
+[Release-image]: https://img.shields.io/badge/release-v2.1.8-1eb0fc.svg
 [Coverage-Url]: https://coveralls.io/r/nats-io/nats-server?branch=master
 [Coverage-image]: https://coveralls.io/repos/github/nats-io/nats-server/badge.svg?branch=master
 [ReportCard-Url]: https://goreportcard.com/report/nats-io/nats-server

--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.1.7"
+	VERSION = "2.1.8"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original


### PR DESCRIPTION
This is based on branch_2_1_x and includes the following fixes:

- Allow response permissions to work across accounts (#1487)
- Race condition during implicit Gateway reconnection (#1412)
- Possible stall on shutdown with leafnode setup (#1414)
- Possible removal of interest on queue subs with leaf nodes (#1424)
- Unsubscribe may not be propagated through a leaf node (#1455)
- LeafNode solicit failure race could leave conn registered (#1475)
- Handling or real duplicate subscription (#1507)
- Log file size limit not honored after re-open signal (#1438)
- Connection name in log statement for some IPv6 addresses (#1506)
- Better support for distinguishedNameMatch in TLS Auth (#1577)
- Error when importing an account results in an error (#1578)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>