### PR TITLE
Add more config checks for leafnode remotes

### DIFF
--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -1129,7 +1129,7 @@ func TestConfigCheck(t *testing.T) {
 		leafnodes {
 		  remotes = [
 		    {
-		      url: "tls://connect.ngs.global:7422"
+		      url: "tls://nats:7422"
 		      tls {
 		        timeout: 0.01
 		      }
@@ -1139,6 +1139,30 @@ func TestConfigCheck(t *testing.T) {
 			err:       nil,
 			errorLine: 0,
 			errorPos:  0,
+		},
+		{
+			name: "when leafnode remotes use wrong type",
+			config: `
+		leafnodes {
+		  remotes: {
+  	            url: "tls://nats:7422"
+		  }
+		}`,
+			err:       errors.New(`Expected remotes field to be an array, got map[string]interface {}`),
+			errorLine: 3,
+			errorPos:  5,
+		},
+		{
+			name: "when leafnode remotes url uses wrong type",
+			config: `
+		leafnodes {
+		  remotes: [
+  	            { urls: 1234 }
+		  ]
+		}`,
+			err:       errors.New(`Expected remote leafnode url to be an array or string, got 1234`),
+			errorLine: 4,
+			errorPos:  18,
 		},
 		{
 			name: "when setting latency tracking without a system account",

--- a/server/opts.go
+++ b/server/opts.go
@@ -1455,8 +1455,9 @@ func parseLeafNodes(v interface{}, opts *Options, errors *[]error, warnings *[]e
 			}
 		case "remotes":
 			// Parse the remote options here.
-			remotes, err := parseRemoteLeafNodes(mv, errors, warnings)
+			remotes, err := parseRemoteLeafNodes(tk, errors, warnings)
 			if err != nil {
+				*errors = append(*errors, err)
 				continue
 			}
 			opts.LeafNode.Remotes = remotes
@@ -1612,7 +1613,6 @@ func parseLeafUsers(mv interface{}, errors *[]error, warnings *[]error) ([]*User
 func parseRemoteLeafNodes(v interface{}, errors *[]error, warnings *[]error) ([]*RemoteLeafOpts, error) {
 	var lt token
 	defer convertPanicToErrorList(&lt, errors)
-
 	tk, v := unwrapValue(v, &lt)
 	ra, ok := v.([]interface{})
 	if !ok {
@@ -1647,6 +1647,9 @@ func parseRemoteLeafNodes(v interface{}, errors *[]error, warnings *[]error) ([]
 						continue
 					}
 					remote.URLs = append(remote.URLs, url)
+				default:
+					*errors = append(*errors, &configErr{tk, fmt.Sprintf("Expected remote leafnode url to be an array or string, got %v", v)})
+					continue
 				}
 			case "account", "local":
 				remote.LocalAccount = v.(string)


### PR DESCRIPTION
Adding tests for a couple of conditions where the leafnode remotes config would fail silently.

 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

/cc @nats-io/core

Signed-off-by: Waldemar Quevedo <wally@synadia.com>