### PR TITLE
Updating jetstream account settings from jwt

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -721,6 +721,10 @@ func (s *Server) generateRouteInfoJSON() {
 func (s *Server) globalAccountOnly() bool {
 	var hasOthers bool
 
+	if len(s.trustedKeys) > 0 {
+		return false
+	}
+
 	s.mu.Lock()
 	s.accounts.Range(func(k, v interface{}) bool {
 		acc := v.(*Account)


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

I'm setting the account to incomplete so it is set for when we start to report things like that.
Have to set srv in update as on connect update is called before register. JS depends on that pointer existing.