### PR TITLE
Offer .tar.gz releases additionally

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,6 +52,13 @@ archives:
     files:
       - README.md
       - LICENSE
+  - name_template: '{{.ProjectName}}-{{.Tag}}-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}'
+    id: targz-archives
+    wrap_in_directory: true
+    format: tar.gz
+    files:
+      - README.md
+      - LICENSE
 
 checksum:
   name_template: 'SHA256SUMS'


### PR DESCRIPTION
 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [x] Tests added
 - [x] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request:

The zip/unzip commands aren't installed by default on most Linux
distros. However, tar is almost always installed. Additionally, users
may get confused when they try to uncompress an archive with
gzip/gunzip, only for it to fail because gunzip is for .gz files, not
.zip.

This change makes it a little easier to grab a copy of a nats-server
release binary.

I tested the change in a junk repo on my account:
https://github.com/variadico/tmp/blob/master/.goreleaser.yml#L37

The existing zip archives are preserved, this just adds .tar.gz, like so: 
https://github.com/variadico/tmp/releases/tag/0.1.0

The archive structure remains the same.

```
$ tree .
.
├── tar
│   ├── tmp-0.1.0-linux-amd64
│   │   ├── LICENSE
│   │   ├── README.md
│   │   └── tmp
│   └── tmp-0.1.0-linux-amd64.tar.gz
└── zip
    ├── tmp-0.1.0-linux-amd64
    │   ├── LICENSE
    │   ├── README.md
    │   └── tmp
    └── tmp-0.1.0-linux-amd64.zip

4 directories, 8 files
```

/cc @nats-io/core