### PR TITLE
Fix tests for Go 1.15

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [1.13, 1.14]
+        go: [1.14, 1.15]
 
     env:
       GOPATH: /home/runner/work/nats-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
+- 1.15.x
 - 1.14.x
-- 1.13.x
 addons:
   apt:
     packages:

--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -1092,7 +1092,7 @@ func TestConfigCheck(t *testing.T) {
 			config: `
 				lame_duck_duration: abc
 			`,
-			err:       errors.New(`error parsing lame_duck_duration: time: invalid duration abc`),
+			err:       errors.New(`error parsing lame_duck_duration: time: invalid duration`),
 			errorLine: 2,
 			errorPos:  5,
 		},
@@ -1110,7 +1110,7 @@ func TestConfigCheck(t *testing.T) {
 			config: `
 				lame_duck_grace_period: abc
 			`,
-			err:       errors.New(`error parsing lame_duck_grace_period: time: invalid duration abc`),
+			err:       errors.New(`error parsing lame_duck_grace_period: time: invalid duration`),
 			errorLine: 2,
 			errorPos:  5,
 		},
@@ -1357,8 +1357,7 @@ func TestConfigCheck(t *testing.T) {
 				if test.reason != "" {
 					msg += ": " + test.reason
 				}
-				msg += "\n"
-				if err.Error() != msg {
+				if !strings.Contains(err.Error(), msg) {
 					t.Errorf("Expected:\n%q\ngot:\n%q", msg, err.Error())
 				}
 			}


### PR DESCRIPTION
Starting at Go 1.15 now the TLS connections from Go clients will fail with an error such as:

```
x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
```

when the certificates use the Common Name field.  As a workaround to enable running tests with Go 1.15 (and also to demonstrate the workaround for possibly impacted nats.go users in a commit), we disable the client verification for the TLS map permissions.

More info on this at: https://github.com/golang/go/issues/39568

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

 - [ ] Build is green in Travis CI
 - [ ] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

/cc @nats-io/core
