### PR TITLE
Fix dirstore code and speed up some tests

### DIFF
--- a/server/dirstore.go
+++ b/server/dirstore.go
@@ -566,7 +566,7 @@ func (pq *expirationTracker) updateTrack(publicKey string) {
 		i := e.Value.(*jwtItem)
 		if pq.ttl != 0 {
 			// only update expiration when set
-			i.expiration = time.Now().Add(pq.ttl).Unix()
+			i.expiration = time.Now().Round(time.Second).Add(pq.ttl).Unix()
 			heap.Fix(pq, i.index)
 		}
 		if pq.evictOnLimit {
@@ -590,7 +590,7 @@ func (pq *expirationTracker) track(publicKey string, hash *[sha256.Size]byte, th
 		if pq.ttl == time.Duration(math.MaxInt64) {
 			exp = math.MaxInt64
 		} else {
-			exp = time.Now().Add(pq.ttl).Unix()
+			exp = time.Now().Round(time.Second).Add(pq.ttl).Unix()
 		}
 	} else {
 		if g, err := jwt.DecodeGeneric(theJWT); err == nil {


### PR DESCRIPTION
When using Unix() time, since it is number of seconds, it is better
to round up the time before adding a ttl. Trying to shorten some
of the tests showed that in some cases a file was removed too early.
This was because the computed expiration with ttl fell in the same
second, so the file was removed prematurely.

So anywhere where we used to do: time.Now().Addd(ttl).Unix(), I
changed to time.Now().Round(time.Second).Add(ttl).Unix().

I was able to reduce the time of TestTTL from 21 seconds down to
less than 5. TestExpiration was also shorten.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
