### PR TITLE
Adding new subscription for account conns

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -571,11 +571,16 @@ func (s *Server) initEventTracking() {
 	s.sys.inboxPre = subject
 	// This is for remote updates for connection accounting.
 
-	for _, subj := range []string{accConnsEventSubjOld, accConnsEventSubjNew, connsRespSubj} {
+	for _, subj := range []string{accConnsEventSubjOld, accConnsEventSubjNew} {
 		subject = fmt.Sprintf(subj, "*")
 		if _, err := s.sysSubscribe(subject, s.remoteConnsUpdate); err != nil {
 			s.Errorf("Error setting up internal tracking for %s: %v", subject, err)
 		}
+	}
+	// This will be for responses for account info that we send out.
+	subject = fmt.Sprintf(connsRespSubj, s.info.ID)
+	if _, err := s.sysSubscribe(subject, s.remoteConnsUpdate); err != nil {
+		s.Errorf("Error setting up internal tracking: %v", err)
 	}
 	// Listen for broad requests to respond with account info.
 	subject = fmt.Sprintf(accConnsReqSubj, "*")


### PR DESCRIPTION
This fits better with similar events
New subject is $SYS.ACCOUNT.%s.SERVER.CONNS
Old subject remains for backwards compatibility

Signed-off-by: Matthias Hanel <mh@synadia.com>

For backwards compatibility 2 subjects are used.
The utility to check if interest exists comes in handy here.

Going forward I'd add those to other system events as well, just thought this is a good first show case.