### PR TITLE
Do not ack to AckNxt

### DIFF
--- a/test/jetstream_test.go
+++ b/test/jetstream_test.go
@@ -1665,6 +1665,11 @@ func TestJetStreamWorkQueueAckAndNext(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Unexpected error waiting for messages: %v", err)
 				}
+
+				if !bytes.Equal(m.Data, []byte("Hello World!")) {
+					t.Fatalf("Got an invalid message from the stream: %q", m.Data)
+				}
+
 				nc.PublishRequest(m.Reply, sub.Subject, server.AckNext)
 			}
 		})


### PR DESCRIPTION
This causes nil messages mid content stream and is confusing,
the test for this is amended to test the content received for
validity - where previously the test assumed any content is
good content but in fact it only received half the content.

Removing this behaviour until we can design this properly

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
