### PR TITLE
Add $SYS.REQ.ACCOUNT.%s.CLAIMS.UPDATE

### DIFF
--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -1904,7 +1904,7 @@ func TestAccountURLResolverFetchFailurePushReorder(t *testing.T) {
 	// update expjwt2, this will correct the import issue
 	sysc := natsConnect(t, sA.ClientURL(), createUserCreds(t, nil, syskp))
 	defer sysc.Close()
-	natsPub(t, sysc, fmt.Sprintf(accUpdateEventSubj, exppub), []byte(expjwt2))
+	natsPub(t, sysc, fmt.Sprintf(accUpdateEventSubjNew, exppub), []byte(expjwt2))
 	sysc.Flush()
 	// updating expjwt should cause this to pass
 	checkSubInterest(t, sA, imppub, subj, 10*time.Second)
@@ -1995,8 +1995,8 @@ func TestAccountURLResolverPermanentFetchFailure(t *testing.T) {
 	sysc := natsConnect(t, sA.ClientURL(), createUserCreds(t, nil, syskp))
 	defer sysc.Close()
 	// push accounts
-	natsPub(t, sysc, fmt.Sprintf(accUpdateEventSubj, imppub), []byte(impjwt))
-	natsPub(t, sysc, fmt.Sprintf(accUpdateEventSubj, exppub), []byte(expjwt))
+	natsPub(t, sysc, fmt.Sprintf(accUpdateEventSubjNew, imppub), []byte(impjwt))
+	natsPub(t, sysc, fmt.Sprintf(accUpdateEventSubjNew, exppub), []byte(expjwt))
 	sysc.Flush()
 	importErrCnt := 0
 	tmr := time.NewTimer(500 * time.Millisecond)
@@ -3293,7 +3293,7 @@ func TestAccountNATSResolverFetch(t *testing.T) {
 		sub := natsSubSync(t, c, resp)
 		err := sub.AutoUnsubscribe(3)
 		require_NoError(t, err)
-		require_NoError(t, c.PublishRequest(fmt.Sprintf(accUpdateEventSubj, pubKey), resp, []byte(jwt)))
+		require_NoError(t, c.PublishRequest(fmt.Sprintf(accUpdateEventSubjNew, pubKey), resp, []byte(jwt)))
 		passCnt := 0
 		if require_NextMsg(sub) {
 			passCnt++
@@ -3842,7 +3842,7 @@ func TestJWTJetStreamLimits(t *testing.T) {
 		t.Helper()
 		c := natsConnect(t, url, nats.UserCredentials(creds))
 		defer c.Close()
-		if msg, err := c.Request(fmt.Sprintf(accUpdateEventSubj, pubKey), []byte(jwt), time.Second); err != nil {
+		if msg, err := c.Request(fmt.Sprintf(accUpdateEventSubjNew, pubKey), []byte(jwt), time.Second); err != nil {
 			t.Fatal("error not expected in this test", err)
 		} else {
 			content := make(map[string]interface{})


### PR DESCRIPTION
Old $SYS.ACCOUNT.%s.CLAIMS.UPDATE is kept for backwards compatibility.
The old name is in the same name space as events.
To be able to abuse this, an attacker needs to be in possession of the operator key as well.

Signed-off-by: Matthias Hanel <mh@synadia.com>

In order to not introduce more version dependencies I decided to support old and new name for nats based account resolver as well.