### PR TITLE
[FIXED] Prevent LeafNode loop detection on early reconnect

### DIFF
--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -1722,7 +1722,7 @@ func TestLeafNodeExportsImports(t *testing.T) {
 	}
 }
 
-func TestLeadNodeExportImportComplexSetup(t *testing.T) {
+func TestLeafNodeExportImportComplexSetup(t *testing.T) {
 	content := `
 	port: -1
 	operator = "./configs/nkeys/op.jwt"


### PR DESCRIPTION
If the soliciting side detects the disconnect and attempts to
reconnect but the accepting side did not yet close the connection,
a "loop detected" error would be reported and the soliciting server
would not try to reconnect for 30 seconds.

Made a change so that the accepting server checks for existing
leafnode connection for the same server and same account, and if
it is found, close the "old" connection so it is replaced by
the "new" one.

Resolves #1606

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
