### PR TITLE
[Adding] Accountz monitoring endpoint and INFO monitoring req subject

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2618,6 +2618,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 			a.jsLimits = nil
 		}
 	}
+	a.updated = time.Now()
 	a.mu.Unlock()
 
 	clients := gatherClients()

--- a/server/events.go
+++ b/server/events.go
@@ -639,6 +639,10 @@ func (s *Server) initEventTracking() {
 			optz := &LeafzEventOptions{}
 			s.zReq(reply, msg, &optz.EventFilterOptions, optz, func() (interface{}, error) { return s.Leafz(&optz.LeafzOptions) })
 		},
+		"ACCOUNTZ": func(sub *subscription, _ *client, subject, reply string, msg []byte) {
+			optz := &AccountzEventOptions{}
+			s.zReq(reply, msg, &optz.EventFilterOptions, optz, func() (interface{}, error) { return s.Accountz(&optz.AccountzOptions) })
+		},
 	}
 	for name, req := range monSrvc {
 		subject = fmt.Sprintf(serverDirectReqSubj, s.info.ID, name)
@@ -678,6 +682,16 @@ func (s *Server) initEventTracking() {
 				} else {
 					optz.ConnzOptions.Account = acc
 					return s.Connz(&optz.ConnzOptions)
+				}
+			})
+		},
+		"INFO": func(sub *subscription, _ *client, subject, reply string, msg []byte) {
+			optz := &AccInfoEventOptions{}
+			s.zReq(reply, msg, &optz.EventFilterOptions, optz, func() (interface{}, error) {
+				if acc, err := extractAccount(subject); err != nil {
+					return nil, err
+				} else {
+					return s.accountInfo(acc)
 				}
 			})
 		},
@@ -918,7 +932,12 @@ type EventFilterOptions struct {
 // StatszEventOptions are options passed to Statsz
 type StatszEventOptions struct {
 	// No actual options yet
+	EventFilterOptions
+}
 
+// Options for account Info
+type AccInfoEventOptions struct {
+	// No actual options yet
 	EventFilterOptions
 }
 
@@ -955,6 +974,12 @@ type GatewayzEventOptions struct {
 // In the context of system events, LeafzEventOptions are options passed to Leafz
 type LeafzEventOptions struct {
 	LeafzOptions
+	EventFilterOptions
+}
+
+// In the context of system events, AccountzEventOptions are options passed to Accountz
+type AccountzEventOptions struct {
+	AccountzOptions
 	EventFilterOptions
 }
 

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1258,6 +1258,112 @@ func TestAccountReqMonitoring(t *testing.T) {
 	}
 }
 
+func TestAccountReqInfo(t *testing.T) {
+	s, opts := runTrustedServer(t)
+	defer s.Shutdown()
+	sacc, sakp := createAccount(s)
+	s.setSystemAccount(sacc)
+	// Let's create an account with service export.
+	akp, _ := nkeys.CreateAccount()
+	pub1, _ := akp.PublicKey()
+	nac1 := jwt.NewAccountClaims(pub1)
+	nac1.Exports.Add(&jwt.Export{Subject: "req.*", Type: jwt.Service})
+	ajwt1, _ := nac1.Encode(oKp)
+	addAccountToMemResolver(s, pub1, ajwt1)
+	s.LookupAccount(pub1)
+	info1 := fmt.Sprintf(accReqSubj, pub1, "INFO")
+	// Now add an account with service imports.
+	akp2, _ := nkeys.CreateAccount()
+	pub2, _ := akp2.PublicKey()
+	nac2 := jwt.NewAccountClaims(pub2)
+	nac2.Imports.Add(&jwt.Import{Account: pub1, Subject: "req.1", Type: jwt.Service})
+	ajwt2, _ := nac2.Encode(oKp)
+	addAccountToMemResolver(s, pub2, ajwt2)
+	s.LookupAccount(pub2)
+	info2 := fmt.Sprintf(accReqSubj, pub2, "INFO")
+	// Create system account connection to query
+	url := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
+	ncSys, err := nats.Connect(url, createUserCreds(t, s, sakp))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer ncSys.Close()
+	checkCommon := func(info *AccountInfo, srv *ServerInfo, pub, jwt string) {
+		if info.Complete != true {
+			t.Fatalf("Unexpected value: %v", info.Complete)
+		} else if info.Expired != false {
+			t.Fatalf("Unexpected value: %v", info.Expired)
+		} else if info.JetStream != false {
+			t.Fatalf("Unexpected value: %v", info.JetStream)
+		} else if info.ClientCnt != 0 {
+			t.Fatalf("Unexpected value: %v", info.ClientCnt)
+		} else if info.AccountName != pub {
+			t.Fatalf("Unexpected value: %v", info.AccountName)
+		} else if info.LeafCnt != 0 {
+			t.Fatalf("Unexpected value: %v", info.LeafCnt)
+		} else if info.Jwt != jwt {
+			t.Fatalf("Unexpected value: %v", info.Jwt)
+		} else if srv.Cluster != "abc" {
+			t.Fatalf("Unexpected value: %v", srv.Cluster)
+		} else if srv.Name != s.Name() {
+			t.Fatalf("Unexpected value: %v", srv.Name)
+		} else if srv.Host != opts.Host {
+			t.Fatalf("Unexpected value: %v", srv.Host)
+		} else if srv.Seq < 1 {
+			t.Fatalf("Unexpected value: %v", srv.Seq)
+		}
+	}
+	info := AccountInfo{}
+	srv := ServerInfo{}
+	msg := struct {
+		Data *AccountInfo `json:"data"`
+		Srv  *ServerInfo  `json:"server"`
+	}{
+		&info,
+		&srv,
+	}
+	if resp, err := ncSys.Request(info1, nil, time.Second); err != nil {
+		t.Fatalf("Error on request: %v", err)
+	} else if err := json.Unmarshal(resp.Data, &msg); err != nil {
+		t.Fatalf("Unmarshalling failed: %v", err)
+	} else if len(info.Exps) != 1 {
+		t.Fatalf("Unexpected value: %v", info.Exps)
+	} else if len(info.Imps) != 0 {
+		t.Fatalf("Unexpected value: %v", info.Imps)
+	} else if info.Exps[0].Subject != "req.*" {
+		t.Fatalf("Unexpected value: %v", info.Exps)
+	} else if info.Exps[0].Type != jwt.Service {
+		t.Fatalf("Unexpected value: %v", info.Exps)
+	} else if info.Exps[0].ResponseType != jwt.ResponseTypeSingleton {
+		t.Fatalf("Unexpected value: %v", info.Exps)
+	} else if info.SubCnt != 0 {
+		t.Fatalf("Unexpected value: %v", info.SubCnt)
+	} else {
+		checkCommon(&info, &srv, pub1, ajwt1)
+	}
+	info = AccountInfo{}
+	srv = ServerInfo{}
+	if resp, err := ncSys.Request(info2, nil, time.Second); err != nil {
+		t.Fatalf("Error on request: %v", err)
+	} else if err := json.Unmarshal(resp.Data, &msg); err != nil {
+		t.Fatalf("Unmarshalling failed: %v", err)
+	} else if len(info.Exps) != 0 {
+		t.Fatalf("Unexpected value: %v", info.Exps)
+	} else if len(info.Imps) != 1 {
+		t.Fatalf("Unexpected value: %v", info.Imps)
+	} else if info.Imps[0].Subject != "req.1" {
+		t.Fatalf("Unexpected value: %v", info.Exps)
+	} else if info.Imps[0].Type != jwt.Service {
+		t.Fatalf("Unexpected value: %v", info.Exps)
+	} else if info.Imps[0].Account != pub1 {
+		t.Fatalf("Unexpected value: %v", info.Exps)
+	} else if info.SubCnt != 1 {
+		t.Fatalf("Unexpected value: %v", info.SubCnt)
+	} else {
+		checkCommon(&info, &srv, pub2, ajwt2)
+	}
+}
+
 func TestAccountClaimsUpdatesWithServiceImports(t *testing.T) {
 	s, opts := runTrustedServer(t)
 	defer s.Shutdown()
@@ -1453,7 +1559,7 @@ func TestSystemAccountWithGateways(t *testing.T) {
 
 	// If this tests fails with wrong number after 10 seconds we may have
 	// added a new inititial subscription for the eventing system.
-	checkExpectedSubs(t, 30, sa)
+	checkExpectedSubs(t, 33, sa)
 
 	// Create a client on B and see if we receive the event
 	urlb := fmt.Sprintf("nats://%s:%d", ob.Host, ob.Port)
@@ -1775,7 +1881,7 @@ func TestServerEventsPingMonitorz(t *testing.T) {
 	sa, _, sb, optsB, akp := runTrustedCluster(t)
 	defer sa.Shutdown()
 	defer sb.Shutdown()
-
+	sysAcc, _ := akp.PublicKey()
 	url := fmt.Sprintf("nats://%s:%d", optsB.Host, optsB.Port)
 	nc, err := nats.Connect(url, createUserCreds(t, sb, akp))
 	if err != nil {
@@ -1814,6 +1920,8 @@ func TestServerEventsPingMonitorz(t *testing.T) {
 			[]string{"now", "outbound_gateways", "inbound_gateways"}},
 		{"LEAFZ", &LeafzOptions{}, &Leafz{},
 			[]string{"now", "leafs"}},
+		{"ACCOUNTZ", &AccountzOptions{}, &Accountz{},
+			[]string{"now", "accounts"}},
 
 		{"SUBSZ", &SubszOptions{Limit: 5}, &Subsz{},
 			[]string{"num_subscriptions", "num_cache"}},
@@ -1825,6 +1933,8 @@ func TestServerEventsPingMonitorz(t *testing.T) {
 			[]string{"now", "outbound_gateways", "inbound_gateways"}},
 		{"LEAFZ", &LeafzOptions{Subscriptions: true}, &Leafz{},
 			[]string{"now", "leafs"}},
+		{"ACCOUNTZ", &AccountzOptions{Account: sysAcc}, &Accountz{},
+			[]string{"now", "account_detail"}},
 
 		{"ROUTEZ", json.RawMessage(`{"cluster":""}`), &Routez{},
 			[]string{"now", "routes"}},

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1326,16 +1326,16 @@ func TestAccountReqInfo(t *testing.T) {
 		t.Fatalf("Error on request: %v", err)
 	} else if err := json.Unmarshal(resp.Data, &msg); err != nil {
 		t.Fatalf("Unmarshalling failed: %v", err)
-	} else if len(info.Exps) != 1 {
-		t.Fatalf("Unexpected value: %v", info.Exps)
-	} else if len(info.Imps) != 0 {
-		t.Fatalf("Unexpected value: %v", info.Imps)
-	} else if info.Exps[0].Subject != "req.*" {
-		t.Fatalf("Unexpected value: %v", info.Exps)
-	} else if info.Exps[0].Type != jwt.Service {
-		t.Fatalf("Unexpected value: %v", info.Exps)
-	} else if info.Exps[0].ResponseType != jwt.ResponseTypeSingleton {
-		t.Fatalf("Unexpected value: %v", info.Exps)
+	} else if len(info.Exports) != 1 {
+		t.Fatalf("Unexpected value: %v", info.Exports)
+	} else if len(info.Imports) != 0 {
+		t.Fatalf("Unexpected value: %v", info.Imports)
+	} else if info.Exports[0].Subject != "req.*" {
+		t.Fatalf("Unexpected value: %v", info.Exports)
+	} else if info.Exports[0].Type != jwt.Service {
+		t.Fatalf("Unexpected value: %v", info.Exports)
+	} else if info.Exports[0].ResponseType != jwt.ResponseTypeSingleton {
+		t.Fatalf("Unexpected value: %v", info.Exports)
 	} else if info.SubCnt != 0 {
 		t.Fatalf("Unexpected value: %v", info.SubCnt)
 	} else {
@@ -1347,16 +1347,16 @@ func TestAccountReqInfo(t *testing.T) {
 		t.Fatalf("Error on request: %v", err)
 	} else if err := json.Unmarshal(resp.Data, &msg); err != nil {
 		t.Fatalf("Unmarshalling failed: %v", err)
-	} else if len(info.Exps) != 0 {
-		t.Fatalf("Unexpected value: %v", info.Exps)
-	} else if len(info.Imps) != 1 {
-		t.Fatalf("Unexpected value: %v", info.Imps)
-	} else if info.Imps[0].Subject != "req.1" {
-		t.Fatalf("Unexpected value: %v", info.Exps)
-	} else if info.Imps[0].Type != jwt.Service {
-		t.Fatalf("Unexpected value: %v", info.Exps)
-	} else if info.Imps[0].Account != pub1 {
-		t.Fatalf("Unexpected value: %v", info.Exps)
+	} else if len(info.Exports) != 0 {
+		t.Fatalf("Unexpected value: %v", info.Exports)
+	} else if len(info.Imports) != 1 {
+		t.Fatalf("Unexpected value: %v", info.Imports)
+	} else if info.Imports[0].Subject != "req.1" {
+		t.Fatalf("Unexpected value: %v", info.Exports)
+	} else if info.Imports[0].Type != jwt.Service {
+		t.Fatalf("Unexpected value: %v", info.Exports)
+	} else if info.Imports[0].Account != pub1 {
+		t.Fatalf("Unexpected value: %v", info.Exports)
 	} else if info.SubCnt != 1 {
 		t.Fatalf("Unexpected value: %v", info.SubCnt)
 	} else {

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -2994,6 +2994,7 @@ func TestJWTAccountLimitsMaxConnsAfterExpired(t *testing.T) {
 	acc, _ := s.LookupAccount(fooPub)
 	acc.mu.Lock()
 	acc.expired = true
+	acc.updated = time.Now().Add(-2 * time.Second) // work around updating to quickly
 	acc.mu.Unlock()
 
 	// Now update with new expiration and max connections lowered to 2

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1922,12 +1922,12 @@ type AccountzOptions struct {
 
 type ExtImport struct {
 	jwt.Import
-	Invalid bool
+	Invalid bool `json:"invalid"`
 }
 
 type ExtExport struct {
 	jwt.Export
-	ApprovedAccounts []string `json:"approved_accounts"`
+	ApprovedAccounts []string `json:"approved_accounts,omitempty"`
 }
 
 type AccountInfo struct {
@@ -1939,8 +1939,8 @@ type AccountInfo struct {
 	LeafCnt     int                `json:"leafnode_connections"`
 	ClientCnt   int                `json:"client_connections"`
 	SubCnt      uint32             `json:"subscriptions"`
-	Exps        []ExtExport        `json:"exports"`
-	Imps        []ExtImport        `json:"imports"`
+	Exports     []ExtExport        `json:"exports"`
+	Imports     []ExtImport        `json:"imports"`
 	Jwt         string             `json:"jwt,omitempty"`
 	Claim       *jwt.AccountClaims `json:"decoded_jwt,omitempty"`
 }

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -3646,3 +3646,24 @@ func TestMonitorLeafz(t *testing.T) {
 		}
 	}
 }
+
+func TestMonitorAccountz(t *testing.T) {
+	s := RunServer(DefaultMonitorOptions())
+	defer s.Shutdown()
+	body := string(readBody(t, fmt.Sprintf("http://127.0.0.1:%d/accountz", s.MonitorAddr().Port)))
+	if !strings.Contains(body, `$G`) {
+		t.Fatalf("Body missing value. Contains: %s", body)
+	} else if !strings.Contains(body, `$SYS`) {
+		t.Fatalf("Body missing value. Contains: %s", body)
+	} else if !strings.Contains(body, `"accounts": [`) {
+		t.Fatalf("Body missing value. Contains: %s", body)
+	}
+	body = string(readBody(t, fmt.Sprintf("http://127.0.0.1:%d/accountz?acc=$SYS", s.MonitorAddr().Port)))
+	if !strings.Contains(body, `"account_detail": {`) {
+		t.Fatalf("Body missing value. Contains: %s", body)
+	} else if !strings.Contains(body, `"account_name": "$SYS",`) {
+		t.Fatalf("Body missing value. Contains: %s", body)
+	} else if !strings.Contains(body, `"subscriptions": 32,`) {
+		t.Fatalf("Body missing value. Contains: %s", body)
+	}
+}

--- a/server/route.go
+++ b/server/route.go
@@ -1028,6 +1028,7 @@ func (c *client) processRemoteSub(argo []byte, hasOrigin bool) (err error) {
 		if acc, isNew = srv.LookupOrRegisterAccount(accountName); isNew && expire {
 			acc.mu.Lock()
 			acc.expired = true
+			acc.incomplete = true
 			acc.mu.Unlock()
 		}
 	}


### PR DESCRIPTION
Returned imports/exports are formatted like jwt exports imports, even if they originating account is from config.
Fixes #1604

Signed-off-by: Matthias Hanel <mh@synadia.com>

I named the account specific subject INFO as it makes more sense than ACCOUNTZ.
ForCONNZ/SUBSZ we remain to have the plural even when scoped to the account, not so much for account itself.

Also setting update time on every update and account creation. (avoids empty values)
For consistency, setting incomplete when expired (dummy) account is created.
This is primarily to make the returned json make sense and look somewhat similar no matter the origin (jwt/cfg)


```
http://localhost:7222/accountz

{
  "server_id": "NDSVJWYHPIXEYV3PS66X4V2PUWWYVQVPQUJ35FZJRI5PN6QMWBHJ2MZH",
  "now": "2020-09-23T16:18:53.199956-04:00",
  "accounts": [
    "SYS",
    "$G",
    "USERS"
  ]
}
```


```
http://localhost:7222/accountz?acc=SYS

{
  "server_id": "NDSVJWYHPIXEYV3PS66X4V2PUWWYVQVPQUJ35FZJRI5PN6QMWBHJ2MZH",
  "now": "2020-09-23T16:19:56.311826-04:00",
  "account_detail": {
    "account_name": "SYS",
    "update_time": "2020-09-23T16:18:44.089969-04:00",
    "expired": false,
    "complete": true,
    "jetstream_enabled": false,
    "leafnode_connections": 0,
    "client_connections": 0,
    "subscriptions": 32,
    "exports": [
      {
        "subject": "$SYS.DEBUG.SUBSCRIBERS",
        "type": "service",
        "response_type": "Singleton",
        "approved_accounts": []
      }
    ],
    "imports": []
  }
}
```