### PR TITLE
[Fixed] race condition where account conns timer was disabled too soon

### DIFF
--- a/server/client_test.go
+++ b/server/client_test.go
@@ -169,7 +169,7 @@ func checkClientsCount(t *testing.T, s *Server, expected int) {
 
 func checkAccClientsCount(t *testing.T, acc *Account, expected int) {
 	t.Helper()
-	checkFor(t, 2*time.Second, 10*time.Millisecond, func() error {
+	checkFor(t, 4*time.Second, 10*time.Millisecond, func() error {
 		if nc := acc.NumConnections(); nc != expected {
 			return fmt.Errorf("Expected account %q to have %v clients, got %v",
 				acc.Name, expected, nc)

--- a/server/events.go
+++ b/server/events.go
@@ -1150,11 +1150,12 @@ func (s *Server) sendAccConnsUpdate(a *Account, subj ...string) {
 	}
 	// Build event with account name and number of local clients and leafnodes.
 	a.mu.RLock()
+	localConns := a.numLocalConnections()
 	m := &AccountNumConns{
 		Account:    a.Name,
-		Conns:      a.numLocalConnections(),
+		Conns:      localConns,
 		LeafNodes:  a.numLocalLeafNodes(),
-		TotalConns: a.numLocalConnections() + a.numLocalLeafNodes(),
+		TotalConns: localConns + a.numLocalLeafNodes(),
 	}
 	a.mu.RUnlock()
 	for _, sub := range subj {
@@ -1162,7 +1163,7 @@ func (s *Server) sendAccConnsUpdate(a *Account, subj ...string) {
 	}
 	// Set timer to fire again unless we are at zero.
 	a.mu.Lock()
-	if a.numLocalConnections() == 0 {
+	if localConns == 0 {
 		clearTimer(&a.ctmr)
 	} else {
 		// Check to see if we have an HB running and update.


### PR DESCRIPTION
The connection count sent and the connection count used to determine if
the timer should be disabled could differ.

Also fixed issues in unit test triggering this behavior.
It did not check if remote connections where set to 0 prior to doing
more tests.

Fixes #1613 

Signed-off-by: Matthias Hanel <mh@synadia.com>

When running with -race, tests kept failing until I increased the check time to 4 seconds.