### PR TITLE
Adding fetch on missing jwt of full nats based resolver

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3053,9 +3053,8 @@ func (dr *DirAccResolver) Fetch(name string) (string, error) {
 		dr.Unlock()
 		if srv == nil {
 			return "", err
-		} else {
-			return srv.fetch(dr, name) // lookup from other server
 		}
+		return srv.fetch(dr, name) // lookup from other server
 	}
 }
 

--- a/server/dirstore.go
+++ b/server/dirstore.go
@@ -261,11 +261,11 @@ func (store *DirJWTStore) PackWalk(maxJWTs int, cb func(partialPackMsg string)) 
 	exp := store.expiration
 	store.Unlock()
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if !info.IsDir() && strings.HasSuffix(path, fileExtension) { // this is a JWT
+		if info != nil && !info.IsDir() && strings.HasSuffix(path, fileExtension) { // this is a JWT
 			pubKey := strings.TrimSuffix(filepath.Base(path), fileExtension)
 			store.Lock()
 			if exp != nil {
-				if _, ok := store.expiration.idx[pubKey]; !ok {
+				if _, ok := exp.idx[pubKey]; !ok {
 					store.Unlock()
 					return nil // only include indexed files
 				}

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -3531,6 +3531,19 @@ func TestAccountNATSResolverFetch(t *testing.T) {
 	// It is not expected to be hit. When hit the administrator is supposed to take action.
 	passCnt = updateJwt(t, sA.ClientURL(), sysCreds, dpub, djwt1, 3)
 	require_True(t, passCnt == 1) // Only Server C updated
+	for _, srv := range []*Server{sA, sB, sC} {
+		if a, ok := srv.accounts.Load(syspub); ok {
+			acc := a.(*Account)
+			checkFor(t, time.Second, 20*time.Millisecond, func() error {
+				acc.mu.Lock()
+				defer acc.mu.Unlock()
+				if acc.ctmr != nil {
+					return fmt.Errorf("Timer still exists")
+				}
+				return nil
+			})
+		}
+	}
 }
 
 func TestAccountNATSResolverCrossClusterFetch(t *testing.T) {


### PR DESCRIPTION
Full nats based resolver sync within a cluster.
This functionality addresses syncing between cluster.

Fixing deadlock when more than one server responds to lookup.
Fixing 2 crashes when shutdown and pack happen at the same time.

As a side effect of also doing fetch in the full account resolver, functionality was moved from the caching account resolver.