### PR TITLE
Fix event ordering issue caused by re-locking

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -1185,7 +1185,14 @@ func (s *Server) sendAccConnsUpdate(a *Account, subj ...string) {
 		}
 	}
 	for _, sub := range subj {
-		sendQ <- &pubMsg{nil, sub, _EMPTY_, &m.Server, &m, false}
+		msg := &pubMsg{nil, sub, _EMPTY_, &m.Server, &m, false}
+		select {
+		case sendQ <- msg:
+		default:
+			a.mu.Unlock()
+			sendQ <- msg
+			a.mu.Lock()
+		}
 	}
 	a.mu.Unlock()
 	s.mu.Lock()


### PR DESCRIPTION
Noticed TestSystemAccountConnectionUpdatesStopAfterNoLocal failing du to the timer still being around.

I moved clearing of the timer, but still got failures where the last message does not contain conn count 0.
This hinted at one event from one client interfering with an event from another.

To avoid this holding the account lock during send seems the most appropriate solution.
sendInternalMsg essentially records the send queue and unlocks the server. 
This change just merges that with the code in sendAccConnsUpdate.
