### PR TITLE
AddConsumer causes redelivery of first message

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -675,6 +675,14 @@ func (o *Consumer) updateDeliverSubject(newDeliver string) {
 	o.dseq = o.adflr
 	o.sseq = o.asflr
 
+	// If we never received an ack, set to 1.
+	if o.dseq == 0 {
+		o.dseq = 1
+	}
+	if o.sseq == 0 {
+		o.sseq = 1
+	}
+
 	// When we register new one it will deliver to update state loop.
 	o.acc.sl.ClearNotification(oldDeliver, o.inch)
 	o.acc.sl.RegisterNotification(newDeliver, o.inch)


### PR DESCRIPTION
It seems that when updating the delivery subject, we use as the
first sequence the ack floor, but if no message was ever ack'ed
then it causes the first message to be redelivered twice.

Resolves #1619

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
