### PR TITLE
Fixed possible panic on consumer.Delete() during server Shutdown()

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -193,6 +193,7 @@ type Consumer struct {
 	ackEventT         string
 	deliveryExcEventT string
 	created           time.Time
+	closed            bool
 }
 
 const (
@@ -1707,11 +1708,11 @@ func (o *Consumer) Delete() error {
 
 func (o *Consumer) stop(dflag, doSignal, advisory bool) error {
 	o.mu.Lock()
-	mset := o.mset
-	if mset == nil {
+	if o.closed {
 		o.mu.Unlock()
 		return nil
 	}
+	o.closed = true
 
 	if dflag && advisory {
 		o.sendDeleteAdvisoryLocked()
@@ -1721,6 +1722,7 @@ func (o *Consumer) stop(dflag, doSignal, advisory bool) error {
 	close(o.qch)
 
 	store := o.store
+	mset := o.mset
 	o.mset = nil
 	o.active = false
 	ackSub := o.ackSub


### PR DESCRIPTION
The panic was caused by the closing of an already closed Go channel.
The Delete() relied on the consumer's mset being nil to consider
the consumer already closed. However, the consumer's mset is set
to nil after invoking sendDeleteAdvisoryLocked() which internally
invokes sendAdvisory() which releases/reacquires the consumer lock.
This left an open door for a race to occur and Delete() to be
invoked twice on the same consumer.

Moving setting the consumer's mset to nil too early would prevent
the sendAdvisory() to actually do its job. We could pass the mset
to sendAvisory(), but a simpler approach is to simply use a "closed"
boolean on the Consumer object that is set to true at the beginning
of the Delete() function.

Resolves #1621

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
