### PR TITLE
AckExplicit removes message for "offline" durable

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -664,7 +664,7 @@ func (o *Consumer) updateDeliverSubject(newDeliver string) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	if o.mset == nil || o.isPullMode() {
+	if o.closed || o.isPullMode() {
 		return
 	}
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -1120,14 +1120,12 @@ func (mset *Stream) partitionUnique(partition string) bool {
 
 // Lock should be held.
 func (mset *Stream) checkInterest(seq uint64, obs *Consumer) bool {
-	var needAck bool
 	for _, o := range mset.consumers {
 		if o != obs && o.needAck(seq) {
-			needAck = true
-			break
+			return true
 		}
 	}
-	return needAck
+	return false
 }
 
 // ackMsg is called into from an observable when we have a WorkQueue or Interest retention policy.

--- a/test/jetstream_test.go
+++ b/test/jetstream_test.go
@@ -8005,14 +8005,11 @@ func TestJetStreamAckExplicitMsgRemoval(t *testing.T) {
 				}
 				m.Respond(nil)
 
-				sseq, _, dc, _ := o2.ReplyInfo(m.Reply)
+				sseq := o2.StreamSeqFromReply(m.Reply)
 				// Depending on timing from above we could receive stream sequences out of order but
 				// we know we want 3 & 4.
 				if sseq != 3 && sseq != 4 {
 					t.Fatalf("Expected stream sequence of 3 or 4 but got %d", sseq)
-				}
-				if sseq == 3 && dc == 1 {
-					t.Fatalf("Expected a redelivery count greater then 1 for sseq 3, got %d", dc)
 				}
 			}
 		})

--- a/test/jetstream_test.go
+++ b/test/jetstream_test.go
@@ -8005,10 +8005,7 @@ func TestJetStreamAckExplicitMsgRemoval(t *testing.T) {
 				}
 				m.Respond(nil)
 
-				sseq, dseq, dc, _ := o2.ReplyInfo(m.Reply)
-				if dseq != uint64(i+3) {
-					t.Fatalf("Expected consumer sequence of %d got %d", i+3, dseq)
-				}
+				sseq, _, dc, _ := o2.ReplyInfo(m.Reply)
 				// Depending on timing from above we could receive stream sequences out of order but
 				// we know we want 3 & 4.
 				if sseq != 3 && sseq != 4 {


### PR DESCRIPTION
As of now, this PR has only a new test that shows the issue.

It seems that Consumer.needAck() for AckExplicit should consider
that an Ack is needed if sseq > o.asflr and there is no pending
ack at all. However making this change would break the test
TestJetStreamInterestRetentionStream.

Also, running the new test with `-count 100` and by adding an
artificial delay in stream.ackMsg() (just before calling
mset.store.RemoveMsg(seq)) causes sometimes delete requests
for the same sequence to be processed twice, which causes
the new test to fail (even with an attempted fix as discussed
above). I think that the attempt to remove the same sequence twice
is messing up the state.

Resolves to #1627 

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
