### PR TITLE
Avoid unnecessary CONNS subscription

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -575,12 +575,9 @@ func (s *Server) initEventTracking() {
 	}
 	s.sys.inboxPre = subject
 	// This is for remote updates for connection accounting.
-
-	for _, subj := range []string{accConnsEventSubjOld, accConnsEventSubjNew} {
-		subject = fmt.Sprintf(subj, "*")
-		if _, err := s.sysSubscribe(subject, s.remoteConnsUpdate); err != nil {
-			s.Errorf("Error setting up internal tracking for %s: %v", subject, err)
-		}
+	subject = fmt.Sprintf(accConnsEventSubjOld, "*")
+	if _, err := s.sysSubscribe(subject, s.remoteConnsUpdate); err != nil {
+		s.Errorf("Error setting up internal tracking for %s: %v", subject, err)
 	}
 	// This will be for responses for account info that we send out.
 	subject = fmt.Sprintf(connsRespSubj, s.info.ID)

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1559,7 +1559,7 @@ func TestSystemAccountWithGateways(t *testing.T) {
 
 	// If this tests fails with wrong number after 10 seconds we may have
 	// added a new inititial subscription for the eventing system.
-	checkExpectedSubs(t, 34, sa)
+	checkExpectedSubs(t, 33, sa)
 
 	// Create a client on B and see if we receive the event
 	urlb := fmt.Sprintf("nats://%s:%d", ob.Host, ob.Port)

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -3683,7 +3683,7 @@ func TestMonitorAccountz(t *testing.T) {
 		t.Fatalf("Body missing value. Contains: %s", body)
 	} else if !strings.Contains(body, `"account_name": "$SYS",`) {
 		t.Fatalf("Body missing value. Contains: %s", body)
-	} else if !strings.Contains(body, `"subscriptions": 33,`) {
+	} else if !strings.Contains(body, `"subscriptions": 32,`) {
 		t.Fatalf("Body missing value. Contains: %s", body)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

Only one subscription is necessary. What is important for the user is that we publish on both, not that we also subscribe on both.