### PR TITLE
Skip revocation check if the client has no jwt and is therefore internal

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2654,7 +2654,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 		theJWT := c.opts.JWT
 		c.mu.Unlock()
 		// Check for being revoked here. We use ac one to avoid the account lock.
-		if ac.Revocations != nil {
+		if ac.Revocations != nil && theJWT != "" {
 			if juc, err := jwt.DecodeUserClaims(theJWT); err != nil {
 				c.Debugf("User JWT not valid: %v", err)
 				c.authViolation()


### PR DESCRIPTION
Related to #1632

Signed-off-by: Matthias Hanel <mh@synadia.com>
