### PR TITLE
Revert "Update nightly image server binary path"

### DIFF
--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -8,8 +8,7 @@ FROM alpine:latest
 RUN apk add --update ca-certificates && mkdir -p /nats/bin && mkdir /nats/conf
 
 COPY docker/nats-server.conf /nats/conf/nats-server.conf
-COPY nats-server /nats/bin/nats-server
-RUN ln -ns /nats/bin/nats-server /bin/nats-server && ln -ns /nats/bin/nats-server /nats-server && ln -ns /nats/bin/nats-server /gnatsd
+COPY nats-server /bin/nats-server
 COPY --from=builder /go/bin/nats /bin/nats
 
 EXPOSE 4222 8222 6222 5222


### PR DESCRIPTION
Approach we'll take instead is to change to use for the path in the container to be `/bin/nats-server`

Reverts nats-io/nats-server#1637