### PR TITLE
Adding list/delete/update operations for jwt stored by nats-resolver

### DIFF
--- a/server/dirstore.go
+++ b/server/dirstore.go
@@ -420,6 +420,24 @@ func (store *DirJWTStore) write(path string, publicKey string, theJWT string) (b
 	return true, nil
 }
 
+func (store *DirJWTStore) delete(publicKey string) error {
+	if store.readonly {
+		return fmt.Errorf("store is read-only")
+	}
+	store.Lock()
+	defer store.Unlock()
+	if err := os.Remove(store.pathForKey(publicKey)); err != nil {
+		if _, ok := err.(*os.PathError); ok || err == os.ErrNotExist {
+			return nil
+		}
+		return err
+	} else {
+		store.expiration.unTrack(publicKey)
+	}
+	// TODO do cb
+	return nil
+}
+
 // Save puts the JWT in a map by public key and performs update callbacks
 // Assumes lock is NOT held
 func (store *DirJWTStore) save(publicKey string, theJWT string) error {

--- a/server/dirstore.go
+++ b/server/dirstore.go
@@ -431,9 +431,8 @@ func (store *DirJWTStore) delete(publicKey string) error {
 			return nil
 		}
 		return err
-	} else {
-		store.expiration.unTrack(publicKey)
 	}
+	store.expiration.unTrack(publicKey)
 	// TODO do cb
 	return nil
 }

--- a/server/dirstore_test.go
+++ b/server/dirstore_test.go
@@ -793,6 +793,31 @@ func TestTTL(t *testing.T) {
 	require_Len(t, len(f), 0)
 }
 
+func TestRemove(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
+	require_NoError(t, err)
+	require_OneJWT := func() {
+		t.Helper()
+		f, err := ioutil.ReadDir(dir)
+		require_NoError(t, err)
+		require_Len(t, len(f), 1)
+	}
+	dirStore, err := NewExpiringDirJWTStore(dir, false, false, 0, 10, true, 0, nil)
+	require_NoError(t, err)
+	defer dirStore.Close()
+
+	accountKey, err := nkeys.CreateAccount()
+	require_NoError(t, err)
+	pubKey, err := accountKey.PublicKey()
+	require_NoError(t, err)
+	createTestAccount(t, dirStore, 0, accountKey)
+	require_OneJWT()
+	dirStore.delete(pubKey)
+	f, err := ioutil.ReadDir(dir)
+	require_NoError(t, err)
+	require_Len(t, len(f), 0)
+}
+
 const infDur = time.Duration(math.MaxInt64)
 
 func TestNotificationOnPack(t *testing.T) {

--- a/server/events.go
+++ b/server/events.go
@@ -36,6 +36,9 @@ const (
 	accLookupReqTokens = 6
 	accLookupReqSubj   = "$SYS.REQ.ACCOUNT.%s.CLAIMS.LOOKUP"
 	accPackReqSubj     = "$SYS.REQ.CLAIMS.PACK"
+	accListReqSubj     = "$SYS.REQ.CLAIMS.LIST"
+	accClaimsReqSubj   = "$SYS.REQ.CLAIMS.UPDATE"
+	accDeleteReqSubj   = "$SYS.REQ.CLAIMS.DELETE"
 
 	connectEventSubj    = "$SYS.ACCOUNT.%s.CONNECT"
 	disconnectEventSubj = "$SYS.ACCOUNT.%s.DISCONNECT"

--- a/server/opts.go
+++ b/server/opts.go
@@ -872,11 +872,14 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 				return
 			}
 			if dir == "" {
-				*errors = append(*errors, &configErr{tk, "dir needs to point to a directory"})
+				*errors = append(*errors, &configErr{tk, "dir has no value and needs to point to a directory"})
 				return
 			}
-			if info, err := os.Stat(dir); err != nil || !info.IsDir() || info.Mode().Perm()&(1<<(uint(7))) == 0 {
-				info.IsDir()
+			if info, err := os.Stat(dir); err != nil {
+
+			} else if !info.IsDir() || info.Mode().Perm()&(1<<(uint(7))) == 0 {
+				*errors = append(*errors, &configErr{tk, "dir needs to point to an accessible directory"})
+				return
 			}
 			var res AccountResolver
 			switch strings.ToUpper(dirType) {

--- a/server/opts.go
+++ b/server/opts.go
@@ -875,9 +875,7 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 				*errors = append(*errors, &configErr{tk, "dir has no value and needs to point to a directory"})
 				return
 			}
-			if info, err := os.Stat(dir); err != nil {
-
-			} else if !info.IsDir() || info.Mode().Perm()&(1<<(uint(7))) == 0 {
+			if info, err := os.Stat(dir); err != nil && (!info.IsDir() || info.Mode().Perm()&(1<<(uint(7))) == 0) {
 				*errors = append(*errors, &configErr{tk, "dir needs to point to an accessible directory"})
 				return
 			}


### PR DESCRIPTION
Update already existed scoped by account, this exposes update without account.
List returns a list of all stored accounts.
Delete deletes accounts.
Fix a crash on startup with non existing directory.

Signed-off-by: Matthias Hanel <mh@synadia.com>

This does NOT cause existing accounts to be evicted from memory and will be added in a separate PR.