### PR TITLE
[FIXED] Stream's subscription propagation issue with gateways

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.2.0-beta.24"
+	VERSION = "2.2.0-beta.25"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original


### PR DESCRIPTION
When creating shadow subscriptions for import streams, we were
not invoking code for gateway subscription accounting, which means
that when the account (for leafnodes) was switched to interest
only, those shadow subscriptions were not sent.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
