### PR TITLE
[Fixed] Operator signed by own signing key would render accounts invalid

### DIFF
--- a/server/jwt.go
+++ b/server/jwt.go
@@ -132,7 +132,7 @@ func validateTrustedOperators(o *Options) error {
 		if o.TrustedKeys == nil {
 			o.TrustedKeys = make([]string, 0, 4)
 		}
-		o.TrustedKeys = append(o.TrustedKeys, opc.Issuer)
+		o.TrustedKeys = append(o.TrustedKeys, opc.Subject)
 		o.TrustedKeys = append(o.TrustedKeys, opc.SigningKeys...)
 	}
 	for _, key := range o.TrustedKeys {


### PR DESCRIPTION
The situation applied to accounts that where signed by the identity nkey
We picked up the wrong key and ended up comparing against the signing key twice.

Signed-off-by: Matthias Hanel <mh@synadia.com>

It's either this or nsc should choke.

```
> nsc list keys --all
╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                               Keys                                               │
├────────────────┬──────────────────────────────────────────────────────────┬─────────────┬────────┤
│ Entity         │ Key                                                      │ Signing Key │ Stored │
├────────────────┼──────────────────────────────────────────────────────────┼─────────────┼────────┤
│ OP             │ ODMFND7EIJ2MBHNPO2JHCKOZIAY6NAK7OT4V2ZT2C5O6LEB3DPKYV3QL │             │        │ <--- removed the identity nkey
│ OP             │ OC37ZW6IO3UNBIBVOQUHORPR6FHHBFIYY3A32EEE6ITANCKHNI35NFZH │ *           │ *      │
│ OP             │ OABLHBXSSPHXYTM7JD7EO76NUK6W5YHK7VLFKYYCJDAB34EGSSTB6IW6 │ *           │ *      │
│  ACC           │ ADVUO5GHMFTSEPCJNZ2WGDHP4IXJI7WBMP6Q7K6SNBVOGHYZY5ZXBDR7 │             │ *      │
│  ACC           │ AB4WDG3ZH4CCRIIVWNTKJPQMFZGUCQ23YS6US2V5MMX2DOB3RF3D5MQQ │ *           │ *      │
│   USER         │ UCCQC35ZZIYB5MIG7LIMC576SMMDOJQTA3GGTPYOMWF7H4DNNFHFVSVX │             │ *      │
│  ACC-SIGNINKEY │ ABRY6AME6JJEYMIDKIUCXTGNH22CDLEIFEJMGY55QWYQTHFPZP5HWVJH │             │ *      │
│  SYS           │ ABLXXSWDPAMZV3ND4CJN5Y6FCMFE3OMQHX5OWQOEZL65QACJDP4K2FFE │             │ *      │
│   sys          │ UAJXMGLXOXG4GEPEVJXAZPAAEJL4MR24HFI2MUOHUE4SGBROD5B2YPAI │             │ *      │
╰────────────────┴──────────────────────────────────────────────────────────┴─────────────┴────────╯
> nsc generate nkey -o --store
OABLHBXSSPHXYTM7JD7EO76NUK6W5YHK7VLFKYYCJDAB34EGSSTB6IW6
operator key stored /Users/matthiashanel/.nkeys/keys/O/AB/OABLHBXSSPHXYTM7JD7EO76NUK6W5YHK7VLFKYYCJDAB34EGSSTB6IW6.nk

>nsc edit operator --sk OABLHBXSSPHXYTM7JD7EO76NUK6W5YHK7VLFKYYCJDAB34EGSSTB6IW6
[ OK ] added signing key "OABLHBXSSPHXYTM7JD7EO76NUK6W5YHK7VLFKYYCJDAB34EGSSTB6IW6"
[ OK ] edited operator "OP"

> nsc describe operator
╭──────────────────────────────────────────────────────────────────────────────────╮
│                                 Operator Details                                 │
├───────────────────────┬──────────────────────────────────────────────────────────┤
│ Name                  │ OP                                                       │
│ Operator ID           │ ODMFND7EIJ2MBHNPO2JHCKOZIAY6NAK7OT4V2ZT2C5O6LEB3DPKYV3QL │ <--- differs from issuer
│ Issuer ID             │ OC37ZW6IO3UNBIBVOQUHORPR6FHHBFIYY3A32EEE6ITANCKHNI35NFZH │ <--- modified the operator to add yet another signing key
│ Issued                │ 2020-10-14 17:17:11 UTC                                  │
│ Expires               │                                                          │
│ Operator Service URLs │ nats://localhost:4222                                    │
│ System Account        │ ABLXXSWDPAMZV3ND4CJN5Y6FCMFE3OMQHX5OWQOEZL65QACJDP4K2FFE │
├───────────────────────┼──────────────────────────────────────────────────────────┤
│ Signing Keys          │ OC37ZW6IO3UNBIBVOQUHORPR6FHHBFIYY3A32EEE6ITANCKHNI35NFZH │ <--- issued by self still
│                       │ OABLHBXSSPHXYTM7JD7EO76NUK6W5YHK7VLFKYYCJDAB34EGSSTB6IW6 │
╰───────────────────────┴──────────────────────────────────────────────────────────╯

All accounts created with the original identity nkey, would fail. (system account for once)
Here with added tracing when checking against trusted keys.

[94683] 2020/10/14 13:26:28.970752 [DBG] Account [ABLXXSWDPAMZV3ND4CJN5Y6FCMFE3OMQHX5OWQOEZL65QACJDP4K2FFE] fetch took 77.819µs
[94683] 2020/10/14 13:26:28.974018 [WRN] pre check
[94683] 2020/10/14 13:26:28.974051 [WRN] check key cnt 3 OC37ZW6IO3UNBIBVOQUHORPR6FHHBFIYY3A32EEE6ITANCKHNI35NFZH == ODMFND7EIJ2MBHNPO2JHCKOZIAY6NAK7OT4V2ZT2C5O6LEB3DPKYV3QL
[94683] 2020/10/14 13:26:28.974082 [WRN] check key cnt 3 OC37ZW6IO3UNBIBVOQUHORPR6FHHBFIYY3A32EEE6ITANCKHNI35NFZH == ODMFND7EIJ2MBHNPO2JHCKOZIAY6NAK7OT4V2ZT2C5O6LEB3DPKYV3QL
[94683] 2020/10/14 13:26:28.974099 [WRN] check key cnt 3 OABLHBXSSPHXYTM7JD7EO76NUK6W5YHK7VLFKYYCJDAB34EGSSTB6IW6 == ODMFND7EIJ2MBHNPO2JHCKOZIAY6NAK7OT4V2ZT2C5O6LEB3DPKYV3QL
[94683] 2020/10/14 13:26:28.974115 [WRN] fail check
```