### PR TITLE
Traffic shaping and full wildcard support for streams and services exports/imports

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -709,7 +709,7 @@ func (a *Account) selectMappedSubject(dest string) (string, bool) {
 	} else {
 		w := uint8(a.prand.Int31n(100))
 		for _, rm := range m.dests {
-			if w <= rm.weight {
+			if w < rm.weight {
 				d = rm
 				break
 			}

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -260,6 +260,7 @@ func (a *Account) shallowCopy() *Account {
 			}
 		}
 	}
+	// JetStream
 	na.jsLimits = a.jsLimits
 
 	return na
@@ -496,8 +497,8 @@ func (a *Account) TotalSubs() int {
 
 // MapDest is for mapping published subjects for clients.
 type MapDest struct {
-	Subject string
-	Weight  uint8
+	Subject string `json:"subject"`
+	Weight  uint8  `json:"weight"`
 }
 
 // destination is for internal representation for a weighted mapped destination.

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -745,7 +745,7 @@ func (a *Account) selectMappedSubject(dest string) (string, bool) {
 
 	dests := m.dests
 	if len(m.cdests) > 0 {
-		cn := a.srv.ClusterName()
+		cn := a.srv.cachedClusterName()
 		dests = m.cdests[cn]
 		if dests == nil {
 			// Fallback to main if we do not match the cluster.

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -2629,6 +2629,17 @@ func TestAccountRouteMappingsConfiguration(t *testing.T) {
 	if !acc.hasMappings() {
 		t.Fatalf("Account %q does not have mappings", "synadia")
 	}
+
+	az, err := s.Accountz(&AccountzOptions{"synadia"})
+	if err != nil {
+		t.Fatalf("Error getting Accountz: %v", err)
+	}
+	if az.Account == nil {
+		t.Fatalf("Expected an Account")
+	}
+	if len(az.Account.Mappings) != 3 {
+		t.Fatalf("Expected %d mappings, saw %d", 3, len(az.Account.Mappings))
+	}
 }
 
 func TestAccountServiceImportWithRouteMappings(t *testing.T) {

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -2647,8 +2647,8 @@ func TestAccountRouteMappingsConfiguration(t *testing.T) {
 func TestAccountRouteMappingsWithLossInjection(t *testing.T) {
 	cf := createConfFile(t, []byte(`
 	mappings = {
-		foo: [ { dest: foo, weight: 80% } ]
-		bar: [ { dest: bar, weight: 0% } ]
+		foo: { dest: foo, weight: 80% }
+		bar: { dest: bar, weight: 0% }
     }
     `))
 	defer os.Remove(cf)
@@ -2685,7 +2685,7 @@ func TestAccountRouteMappingsWithLossInjection(t *testing.T) {
 func TestAccountRouteMappingsWithOriginClusterFilter(t *testing.T) {
 	cf := createConfFile(t, []byte(`
 	mappings = {
-		foo: [ { dest: bar, cluster: SYN, weight: 100% } ]
+		foo: { dest: bar, cluster: SYN, weight: 100% }
     }
     `))
 	defer os.Remove(cf)

--- a/server/client.go
+++ b/server/client.go
@@ -2405,9 +2405,10 @@ func (c *client) addShadowSubscriptions(acc *Account, sub *subscription) error {
 	}
 
 	// Now walk through collected stream imports that matched.
-	for _, ime := range ims {
+	for i := 0; i < len(ims); i++ {
+		ime := &ims[i]
 		// We will create a shadow subscription.
-		nsub, err := c.addShadowSub(sub, &ime)
+		nsub, err := c.addShadowSub(sub, ime)
 		if err != nil {
 			return err
 		}

--- a/server/client.go
+++ b/server/client.go
@@ -1031,7 +1031,7 @@ func (c *client) readLoop(pre []byte) {
 		// Check if the account has mappings and if so set the local readcache flag.
 		// We check here to make sure any changes such as config reload are reflected here.
 		if c.kind == CLIENT {
-			if c.acc.hasMappings() {
+			if c.Account().hasMappings() {
 				c.in.flags.set(hasMappings)
 			} else {
 				c.in.flags.clear(hasMappings)
@@ -4409,8 +4409,9 @@ func (c *client) Account() *Account {
 		return nil
 	}
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.acc
+	acc := c.acc
+	c.mu.Unlock()
+	return acc
 }
 
 // prunePerAccountCache will prune off a random number of cache entries.

--- a/server/errors.go
+++ b/server/errors.go
@@ -43,6 +43,12 @@ var (
 	// ErrBadPublishSubject represents an error condition for an invalid publish subject.
 	ErrBadPublishSubject = errors.New("invalid publish subject")
 
+	// ErrBadSubject represents an error condition for an invalid subject.
+	ErrBadSubject = errors.New("invalid subject")
+
+	// ErrBadQualifier is used to error on a bad qualifier for a transform.
+	ErrBadQualifier = errors.New("bad qualifier")
+
 	// ErrBadClientProtocol signals a client requested an invalid client protocol.
 	ErrBadClientProtocol = errors.New("invalid client protocol")
 
@@ -160,6 +166,9 @@ var (
 
 	// ErrSubscribePermissionViolation is returned when processing of a subscription fails due to permissions.
 	ErrSubscribePermissionViolation = errors.New("subscribe permission viloation")
+
+	// ErrNoTransforms signals no subject transforms are available to map this subject.
+	ErrNoTransforms = errors.New("no matching transforms available")
 )
 
 // configErr is a configuration error.

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2035,16 +2035,12 @@ func (s *Server) accountInfo(accName string) (*AccountInfo, error) {
 	}
 	imports := []ExtImport{}
 	for _, v := range a.imports.streams {
-		to := ""
-		if v.prefix != "" {
-			to = v.prefix + "." + v.from
-		}
 		imports = append(imports, ExtImport{
 			Import: jwt.Import{
 				Subject: jwt.Subject(v.from),
 				Account: v.acc.Name,
 				Type:    jwt.Stream,
-				To:      jwt.Subject(to),
+				To:      jwt.Subject(v.to),
 			},
 			Invalid: v.invalid,
 		})

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1934,10 +1934,7 @@ type ExtExport struct {
 	ApprovedAccounts []string `json:"approved_accounts,omitempty"`
 }
 
-type ExtMap struct {
-	Source      string     `json:"src"`
-	Destination []*MapDest `json:"dest"`
-}
+type ExtMap map[string][]*MapDest
 
 type AccountInfo struct {
 	AccountName string             `json:"account_name"`
@@ -1948,7 +1945,7 @@ type AccountInfo struct {
 	LeafCnt     int                `json:"leafnode_connections"`
 	ClientCnt   int                `json:"client_connections"`
 	SubCnt      uint32             `json:"subscriptions"`
-	Mappings    []*ExtMap          `json:"mappings,omitempty"`
+	Mappings    ExtMap             `json:"mappings,omitempty"`
 	Exports     []ExtExport        `json:"exports,omitempty"`
 	Imports     []ExtImport        `json:"imports,omitempty"`
 	Jwt         string             `json:"jwt,omitempty"`
@@ -2063,13 +2060,13 @@ func (s *Server) accountInfo(accName string) (*AccountInfo, error) {
 		})
 	}
 
-	var mappings []*ExtMap
+	mappings := ExtMap{}
 	for _, m := range a.mappings {
-		e := &ExtMap{m.src, nil}
+		var dests []*MapDest
 		for _, d := range m.dests {
-			e.Destination = append(e.Destination, &MapDest{d.tr.dest, d.weight})
+			dests = append(dests, &MapDest{d.tr.dest, d.weight, ""})
 		}
-		mappings = append(mappings, e)
+		mappings[m.src] = dests
 	}
 
 	return &AccountInfo{

--- a/server/opts.go
+++ b/server/opts.go
@@ -603,6 +603,14 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 	case "logtime":
 		o.Logtime = v.(bool)
 		trackExplicitVal(o, &o.inConfig, "Logtime", o.Logtime)
+	case "mappings", "maps":
+		gacc := NewAccount(globalAccountName)
+		o.Accounts = append(o.Accounts, gacc)
+		err := parseAccountMappings(tk, gacc, errors, warnings)
+		if err != nil {
+			*errors = append(*errors, err)
+			return
+		}
 	case "disable_sublist_cache", "no_sublist_cache":
 		o.NoSublistCache = v.(bool)
 	case "accounts":
@@ -1828,6 +1836,7 @@ type importStream struct {
 	acc *Account
 	an  string
 	sub string
+	to  string
 	pre string
 }
 
@@ -1842,6 +1851,99 @@ type importService struct {
 // Checks if an account name is reserved.
 func isReservedAccount(name string) bool {
 	return name == globalAccountName
+}
+
+// parseAccountMappings is called to parse account mappings.
+func parseAccountMappings(v interface{}, acc *Account, errors *[]error, warnings *[]error) error {
+	var lt token
+	defer convertPanicToErrorList(&lt, errors)
+
+	tk, v := unwrapValue(v, &lt)
+	am := v.(map[string]interface{})
+	for subj, mv := range am {
+		if !IsValidSubject(subj) {
+			err := &configErr{tk, fmt.Sprintf("Subject %q is not a valid subject", subj)}
+			*errors = append(*errors, err)
+			continue
+		}
+		tk, v := unwrapValue(mv, &lt)
+
+		switch vv := v.(type) {
+		case string:
+			if err := acc.AddMapping(subj, v.(string)); err != nil {
+				err := &configErr{tk, fmt.Sprintf("Error adding mapping for %q: %v", subj, err)}
+				*errors = append(*errors, err)
+				continue
+			}
+		case []interface{}:
+			var mappings []*MapDest
+			for _, mv := range v.([]interface{}) {
+				tk, amv := unwrapValue(mv, &lt)
+				// These should be maps.
+				mv, ok := amv.(map[string]interface{})
+				if !ok {
+					err := &configErr{tk, "Expected an entry for the mapping destination"}
+					*errors = append(*errors, err)
+					continue
+				}
+				mdest := &MapDest{}
+				for k, v := range mv {
+					tk, dmv := unwrapValue(v, &lt)
+					switch strings.ToLower(k) {
+					case "dest", "destination":
+						mdest.Subject = dmv.(string)
+					case "weight":
+						switch vv := dmv.(type) {
+						case string:
+							ws := vv
+							if strings.HasSuffix(ws, "%") {
+								ws = ws[:len(ws)-1]
+							}
+							weight, err := strconv.Atoi(ws)
+							if err != nil {
+								err := &configErr{tk, fmt.Sprintf("Invalid weight %q for mapping destination", ws)}
+								*errors = append(*errors, err)
+								continue
+							}
+							if weight > 100 || weight < 0 {
+								err := &configErr{tk, fmt.Sprintf("Invalid weight %d for mapping destination", weight)}
+								*errors = append(*errors, err)
+								continue
+							}
+							mdest.Weight = uint8(weight)
+						case int64:
+							weight := vv
+							if weight > 100 || weight < 0 {
+								err := &configErr{tk, fmt.Sprintf("Invalid weight %d for mapping destination", weight)}
+								*errors = append(*errors, err)
+								continue
+							}
+							mdest.Weight = uint8(weight)
+						}
+					default:
+						err := &configErr{tk, fmt.Sprintf("Unknown field %q for mapping destination", k)}
+						*errors = append(*errors, err)
+						continue
+					}
+				}
+				mappings = append(mappings, mdest)
+			}
+
+			// Now add them in..
+			if err := acc.AddWeightedMappings(subj, mappings...); err != nil {
+				err := &configErr{tk, fmt.Sprintf("Error adding mapping for %q: %v", subj, err)}
+				*errors = append(*errors, err)
+				continue
+			}
+
+		default:
+			err := &configErr{tk, fmt.Sprintf("Unknown type %T for mapping destination", vv)}
+			*errors = append(*errors, err)
+			continue
+		}
+	}
+
+	return nil
 }
 
 // parseAccounts will parse the different accounts syntax.
@@ -1958,6 +2060,12 @@ func parseAccounts(v interface{}, opts *Options, errors *[]error, warnings *[]er
 						continue
 					}
 					acc.defaultPerms = permissions
+				case "mappings", "maps":
+					err := parseAccountMappings(tk, acc, errors, warnings)
+					if err != nil {
+						*errors = append(*errors, err)
+						continue
+					}
 				default:
 					if !tk.IsUsedVariable() {
 						err := &unknownConfigFieldErr{
@@ -2075,10 +2183,18 @@ func parseAccounts(v interface{}, opts *Options, errors *[]error, warnings *[]er
 			*errors = append(*errors, &configErr{tk, msg})
 			continue
 		}
-		if err := stream.acc.AddStreamImport(ta, stream.sub, stream.pre); err != nil {
-			msg := fmt.Sprintf("Error adding stream import %q: %v", stream.sub, err)
-			*errors = append(*errors, &configErr{tk, msg})
-			continue
+		if stream.pre != "" {
+			if err := stream.acc.AddStreamImport(ta, stream.sub, stream.pre); err != nil {
+				msg := fmt.Sprintf("Error adding stream import %q: %v", stream.sub, err)
+				*errors = append(*errors, &configErr{tk, msg})
+				continue
+			}
+		} else {
+			if err := stream.acc.AddMappedStreamImport(ta, stream.sub, stream.to); err != nil {
+				msg := fmt.Sprintf("Error adding stream import %q: %v", stream.sub, err)
+				*errors = append(*errors, &configErr{tk, msg})
+				continue
+			}
 		}
 	}
 	for _, service := range importServices {
@@ -2518,6 +2634,9 @@ func parseImportStreamOrService(v interface{}, errors, warnings *[]error) (*impo
 				continue
 			}
 			curStream = &importStream{an: accountName, sub: subject}
+			if to != "" {
+				curStream.to = to
+			}
 			if pre != "" {
 				curStream.pre = pre
 			}
@@ -2560,6 +2679,14 @@ func parseImportStreamOrService(v interface{}, errors, warnings *[]error) (*impo
 			to = mv.(string)
 			if curService != nil {
 				curService.to = to
+			}
+			if curStream != nil {
+				curStream.to = to
+				if curStream.pre != "" {
+					err := &configErr{tk, "Stream import can not have a 'prefix' and a 'to' property"}
+					*errors = append(*errors, err)
+					continue
+				}
 			}
 		case "share":
 			share = mv.(bool)

--- a/server/parser.go
+++ b/server/parser.go
@@ -389,6 +389,17 @@ func (c *client) parse(buf []byte) error {
 				if err := c.processPub(arg); err != nil {
 					return err
 				}
+				// Check if we have and account mappings or tees or filters.
+				// FIXME(dlc) - Probably better way to do this.
+				// Could add in cache but will be tricky since results based on pub subject are dynamic
+				// due to wildcard matching and weight sets.
+				if c.kind == CLIENT && c.in.flags.isSet(hasMappings) {
+					old := c.pa.subject
+					changed := c.selectMappedSubject()
+					if trace && changed {
+						c.traceInOp("MAPPING", []byte(fmt.Sprintf("%s -> %s", old, c.pa.subject)))
+					}
+				}
 				c.drop, c.as, c.state = 0, i+1, MSG_PAYLOAD
 				// If we don't have a saved buffer then jump ahead with
 				// the index. If this overruns what is left we fall out

--- a/server/server.go
+++ b/server/server.go
@@ -596,6 +596,8 @@ func (s *Server) configureAccounts() error {
 			// For now just move and wipe from opts.Accounts version.
 			a.mappings = acc.mappings
 			acc.mappings = nil
+			// We use this for selecting between multiple weighted destinations.
+			a.prand = rand.New(rand.NewSource(time.Now().UnixNano()))
 		}
 		acc.sl = nil
 		acc.clients = nil

--- a/server/server.go
+++ b/server/server.go
@@ -586,7 +586,17 @@ func (s *Server) configureAccounts() error {
 	// Check opts and walk through them. We need to copy them here
 	// so that we do not keep a real one sitting in the options.
 	for _, acc := range s.opts.Accounts {
-		a := acc.shallowCopy()
+		var a *Account
+		if acc.Name == globalAccountName {
+			a = s.gacc
+		} else {
+			a = acc.shallowCopy()
+		}
+		if acc.hasMappings() {
+			// For now just move and wipe from opts.Accounts version.
+			a.mappings = acc.mappings
+			acc.mappings = nil
+		}
 		acc.sl = nil
 		acc.clients = nil
 		s.registerAccountNoLock(a)

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -1010,6 +1010,32 @@ func IsValidSubject(subject string) bool {
 	return true
 }
 
+// Will share relevant info regarding the subject.
+// Returns valid, tokens, num pwcs, has fwc.
+func subjectInfo(subject string) (bool, []string, int, bool) {
+	if subject == "" {
+		return false, nil, 0, false
+	}
+	npwcs := 0
+	sfwc := false
+	tokens := strings.Split(subject, tsep)
+	for _, t := range tokens {
+		if len(t) == 0 || sfwc {
+			return false, nil, 0, false
+		}
+		if len(t) > 1 {
+			continue
+		}
+		switch t[0] {
+		case fwc:
+			sfwc = true
+		case pwc:
+			npwcs++
+		}
+	}
+	return true, tokens, npwcs, sfwc
+}
+
 // IsValidLiteralSubject returns true if a subject is valid and literal (no wildcards), false otherwise
 func IsValidLiteralSubject(subject string) bool {
 	return isValidLiteralSubject(strings.Split(subject, tsep))


### PR DESCRIPTION
This PR contains code to allow accounts to form subject mappings from one subject to another for both client inbound and service import invocations. This also allows weighted sets for the destinations.

```go
mappings = {
	foo: bar
	foo.*: [ { dest: bar.v1.$1, weight: 40% }, { destination: baz.v2.$1, weight: 20 } ]
	bar.*.*: RAB.$2.$1
}
```

Full wildcard transformations are possible, such that a user has full control over how subjects are matched and transformed.

This transform code was also utilized to enable full wildcard support for service and stream exports/imports.
For instance this is now possible.

```go
imports = [
	{ service: {account: "foo", subject:"request.*"}, to:"my.request.*"}
	{ stream:  {account: "foo", subject:"events.>"}, to:"foo.events.>"}
	{ stream:  {account: "foo", subject:"info.*.*.>"}, to:"foo.info.$2.$1.>"}
]
```

/cc @nats-io/core
