### PR TITLE
Fixed account update issue where signing key (and thus issuer) changes

### DIFF
--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -2640,8 +2640,6 @@ func TestAccountRouteMappingsConfiguration(t *testing.T) {
 	if len(az.Account.Mappings) != 3 {
 		t.Fatalf("Expected %d mappings, saw %d", 3, len(az.Account.Mappings))
 	}
-	b, _ := json.MarshalIndent(az, "", "  ")
-	fmt.Printf("%s", b)
 }
 
 func TestAccountRouteMappingsWithLossInjection(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -1221,7 +1221,7 @@ func (s *Server) lookupAccount(name string) (*Account, error) {
 	}
 	// If we have a resolver see if it can fetch the account.
 	if s.AccountResolver() == nil {
-		return nil, ErrMissingAccount
+		return nil, ErrNoAccountResolver
 	}
 	return s.fetchAccount(name)
 }
@@ -1262,7 +1262,8 @@ func (s *Server) updateAccountWithClaimJWT(acc *Account, claimJWT string) error 
 		acc.mu.Lock()
 		if acc.Issuer == "" {
 			acc.Issuer = accClaims.Issuer
-		} else if acc.Issuer != accClaims.Issuer {
+		}
+		if acc.Name != accClaims.Subject {
 			acc.mu.Unlock()
 			return ErrAccountValidation
 		}


### PR DESCRIPTION
Fix error and remove print from test.

Signed-off-by: Matthias Hanel <mh@synadia.com>

Signed-off-by: Matthias Hanel <mh@synadia.com>

My new found jwt knowledge made me realize that the issuer could change.
What needs to remain constant is the subject.
At the time of test we know we trust the jwt.

Internally acc.Name is set from accClaims.Subject 
The condition is to prevent one valid jwt becoming another by modifying the subject.

