### PR TITLE
Prevent panic when accepting TLS leafnode connections

### DIFF
--- a/server/client_test.go
+++ b/server/client_test.go
@@ -2306,7 +2306,6 @@ func TestCloseConnectionVeryEarly(t *testing.T) {
 			// Get a normal TCP connection to the server.
 			c, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", o.Port))
 			if err != nil {
-				s.mu.Unlock()
 				t.Fatalf("Unable to create tcp connection")
 			}
 			// Now close it.


### PR DESCRIPTION
This is an addition to PR #1652. I have simply added a check but
at this point in time there is no risk that connection is closed
this early.
I also renamed the small helper function and fixed a test that
had an improper `s.mu.Unlock()` in an error condition.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
