### PR TITLE
[FIXED] Do not report bad latency results on auto-unsubscribe triggers

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3516,6 +3516,8 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 	// This is always a response.
 	var didSendTL bool
 	if si.tracking {
+		// Stamp that we attempted delivery.
+		si.didDeliver = true
 		didSendTL = acc.sendTrackingLatency(si, c)
 	}
 

--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -1165,32 +1165,6 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  18,
 		},
 		{
-			name: "when setting latency tracking without a system account",
-			config: `
-                accounts {
-                  sys { users = [ {user: sys, pass: "" } ] }
-
-                  nats.io: {
-                    users = [ { user : bar, pass: "" } ]
-
-                    exports = [
-                      { service: "nats.add"
-                        response: singleton
-                        latency: {
-                          sampling: 100%
-                          subject: "latency.tracking.add"
-                        }
-                      }
-
-                    ]
-                  }
-                }
-                `,
-			err:       errors.New(`Error adding service latency sampling for "nats.add": system account not setup`),
-			errorLine: 2,
-			errorPos:  17,
-		},
-		{
 			name: "when setting latency tracking with a system account",
 			config: `
                 system_account: sys

--- a/server/opts.go
+++ b/server/opts.go
@@ -2209,7 +2209,8 @@ func parseAccounts(v interface{}, opts *Options, errors *[]error, warnings *[]er
 		}
 
 		if service.lat != nil {
-			if opts.SystemAccount == "" {
+			// System accounts are on be default so just make sure we have not opted out..
+			if opts.NoSystemAccount {
 				msg := fmt.Sprintf("Error adding service latency sampling for %q: %v", service.sub, ErrNoSysAccount.Error())
 				*errors = append(*errors, &configErr{tk, msg})
 				continue


### PR DESCRIPTION
When old requests were utilized and the requestor was on a different server then the responder, the auto-unsubscribe log on the requestors server when the reply was delivered would trigger a behavior that would report bad latency results since we did not have our second measurement m2 from the remote server yet.

This fixes that by tracking if we have delivered a response to the request, and if so will wait for the m2 measurement to arrive and not report bad results immediately.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
