### PR TITLE
Add store.SkipMsg() and update no interest retention streams

### DIFF
--- a/server/store.go
+++ b/server/store.go
@@ -54,6 +54,7 @@ var (
 
 type StreamStore interface {
 	StoreMsg(subj string, hdr, msg []byte) (uint64, int64, error)
+	SkipMsg() uint64
 	LoadMsg(seq uint64) (subj string, hdr, msg []byte, ts int64, err error)
 	RemoveMsg(seq uint64) (bool, error)
 	EraseMsg(seq uint64) (bool, error)


### PR DESCRIPTION
Previously interest based retention streams would save and the delete a message from the store if there were no consumers interested. This could lead to issues with messages showing up in the stream when none should be there.

This could also be the effect seen here: https://github.com/nats-io/jetstream/issues/314

We introduce SkipMsg() for the store interface to allow bumping the sequence number but never saving a message, which will guarantee there can never be a state observation of non-zero.

During this investigation I also realized that the filestore did not properly select a new starting sequence upon removal if the removal's block and the true next first sequence were not in the same message block, so fixed that too.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
