### PR TITLE
always include purged number

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -295,7 +295,7 @@ const JSApiStreamListResponseType = "io.nats.jetstream.api.v1.stream_list_respon
 type JSApiStreamPurgeResponse struct {
 	ApiResponse
 	Success bool   `json:"success,omitempty"`
-	Purged  uint64 `json:"purged,omitempty"`
+	Purged  uint64 `json:"purged"`
 }
 
 const JSApiStreamPurgeResponseType = "io.nats.jetstream.api.v1.stream_purge_response"


### PR DESCRIPTION
When purging an empty stream success is true but the
purged is then omitted since its, correctly, 0. It's
better to include it even when zero so it's not weirdly
inconsistent between succesful purges.

Also helps with validation of payloads

Signed-off-by: R.I.Pienaar <rip@devco.net>


/cc @nats-io/core
