### PR TITLE
Bump version to 2.2.0-beta.27

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.2.0-beta.26"
+	VERSION = "2.2.0-beta.27"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original


### PR DESCRIPTION
(no code changes beyond server const)

/cc @nats-io/core