### PR TITLE
WIP: Add websocket browser_redirect_url config option

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -263,6 +263,12 @@ type WebsocketOpts struct {
 	// The host:port to advertise to websocket clients in the cluster.
 	Advertise string
 
+	// If someone visits the NATS server with a browser, they will send a GET
+	// without the Upgrade header.
+	// For convenience, you can supply a URL to be used as an HTTP redirect,
+	// instead of erroring out.
+	BrowserRedirectURL string
+
 	// If no user name is provided when a client connects, will default to the
 	// matching user from the global list of users in `Options.Users`.
 	NoAuthUser string
@@ -3453,6 +3459,8 @@ func parseWebsocket(v interface{}, o *Options, errors *[]error, warnings *[]erro
 			o.Websocket.JWTCookie = mv.(string)
 		case "no_auth_user":
 			o.Websocket.NoAuthUser = mv.(string)
+		case "browser_redirect_url":
+			o.Websocket.BrowserRedirectURL = mv.(string)
 		default:
 			if !tk.IsUsedVariable() {
 				err := &unknownConfigFieldErr{


### PR DESCRIPTION
If an HTTP(S) request is received without the Upgrade: header, then if this new
option is set then we'll assume it's a browser and issue a redirect.

There's no flexibility based upon the passed in URL; this should help with
redirecting people to dashboards or other tooling.

There's no documentation and no tests, this should not be merged as-is, the PR
exists for people to discuss, or replace with something better.

/cc @nats-io/core