### PR TITLE
Stability and performance updates for filestore.

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -337,6 +337,14 @@ func (a *Account) removeRemoteServer(sid string) {
 	a.mu.Unlock()
 }
 
+// Return our server.
+func (a *Account) server() *Server {
+	a.mu.RLock()
+	s := a.srv
+	a.mu.RUnlock()
+	return s
+}
+
 // When querying for subject interest this is the number of
 // expected responses. We need to actually check that the entry
 // has active connections.

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -337,14 +337,6 @@ func (a *Account) removeRemoteServer(sid string) {
 	a.mu.Unlock()
 }
 
-// Return our server.
-func (a *Account) server() *Server {
-	a.mu.RLock()
-	s := a.srv
-	a.mu.RUnlock()
-	return s
-}
-
 // When querying for subject interest this is the number of
 // expected responses. We need to actually check that the entry
 // has active connections.

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -229,7 +229,7 @@ func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created tim
 	fs := &fileStore{
 		fcfg: fcfg,
 		cfg:  FileStreamInfo{Created: created, StreamConfig: cfg},
-		fch:  make(chan struct{}),
+		fch:  make(chan struct{}, 1), // Make buffered on purpose.
 		qch:  make(chan struct{}),
 	}
 

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -376,7 +376,7 @@ func TestFileStoreWriteExpireWrite(t *testing.T) {
 	}
 
 	// Wait for write cache portion to go to zero.
-	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+	checkFor(t, time.Second, 20*time.Millisecond, func() error {
 		if csz := fs.cacheSize(); csz != 0 {
 			return fmt.Errorf("cache size not 0, got %s", FriendlyBytes(int64(csz)))
 		}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -60,6 +60,7 @@ func TestFileStoreBasics(t *testing.T) {
 	if state.Bytes != expectedSize {
 		t.Fatalf("Expected %d bytes, got %d", expectedSize, state.Bytes)
 	}
+
 	nsubj, _, nmsg, _, err := fs.LoadMsg(2)
 	if err != nil {
 		t.Fatalf("Unexpected error looking up msg: %v", err)
@@ -74,6 +75,27 @@ func TestFileStoreBasics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error looking up msg: %v", err)
 	}
+
+	remove := func(seq, expectedMsgs uint64) {
+		t.Helper()
+		removed, err := fs.RemoveMsg(seq)
+		if err != nil {
+			t.Fatalf("Got an error on remove of %d: %v", seq, err)
+		}
+		if !removed {
+			t.Fatalf("Expected remove to return true for %d", seq)
+		}
+		if state := fs.State(); state.Msgs != expectedMsgs {
+			t.Fatalf("Expected %d msgs, got %d", expectedMsgs, state.Msgs)
+		}
+	}
+
+	// Remove first
+	remove(1, 4)
+	// Remove last
+	remove(5, 3)
+	// Remove a middle
+	remove(3, 2)
 }
 
 func TestFileStoreMsgHeaders(t *testing.T) {
@@ -279,6 +301,123 @@ func TestFileStoreSkipMsg(t *testing.T) {
 	if state.FirstSeq != uint64(numSkips+1) || state.LastSeq != uint64(numSkips+4) {
 		t.Fatalf("Expected first to be %d and last to be %d. got first %d and last %d", numSkips+1, numSkips+4, state.FirstSeq, state.LastSeq)
 	}
+
+	// Make sure we recover same state.
+	fs.Stop()
+
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer fs.Stop()
+
+	state = fs.State()
+	if state.Msgs != 2 {
+		t.Fatalf("Expected %d msgs, got %d", 2, state.Msgs)
+	}
+	if state.FirstSeq != uint64(numSkips+1) || state.LastSeq != uint64(numSkips+4) {
+		t.Fatalf("Expected first to be %d and last to be %d. got first %d and last %d", numSkips+1, numSkips+4, state.FirstSeq, state.LastSeq)
+	}
+
+	subj, _, msg, _, err := fs.LoadMsg(11)
+	if err != nil {
+		t.Fatalf("Unexpected error looking up seq 11: %v", err)
+	}
+	if subj != "zzz" || string(msg) != "Hello World!" {
+		t.Fatalf("Message did not match")
+	}
+
+	fs.SkipMsg()
+	nseq, _, err := fs.StoreMsg("AAA", nil, []byte("Skip?"))
+	if err != nil {
+		t.Fatalf("Unexpected error looking up seq 11: %v", err)
+	}
+	if nseq != 16 {
+		t.Fatalf("Expected seq of %d but got %d", 16, nseq)
+	}
+
+	// Make sure we recover same state.
+	fs.Stop()
+
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer fs.Stop()
+
+	subj, _, msg, _, err = fs.LoadMsg(nseq)
+	if err != nil {
+		fmt.Printf("fs is %+v\n", fs)
+		t.Fatalf("Unexpected error looking up seq %d: %v", nseq, err)
+	}
+	if subj != "AAA" || string(msg) != "Skip?" {
+		t.Fatalf("Message did not match")
+	}
+}
+
+func TestFileStoreWriteExpireWrite(t *testing.T) {
+	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	os.MkdirAll(storeDir, 0755)
+	defer os.RemoveAll(storeDir)
+
+	cexp := 10 * time.Millisecond
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: storeDir, BlockSize: 256, CacheExpire: cexp},
+		StreamConfig{Name: "zzz", Storage: FileStorage},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer fs.Stop()
+
+	toSend := 10
+	for i := 0; i < toSend; i++ {
+		fs.StoreMsg("zzz", nil, []byte("Hello World!"))
+	}
+
+	// Wait for write cache portion to go to zero.
+	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+		if csz := fs.cacheSize(); csz != 0 {
+			return fmt.Errorf("cache size not 0, got %s", FriendlyBytes(int64(csz)))
+		}
+		return nil
+	})
+
+	for i := 0; i < toSend; i++ {
+		fs.StoreMsg("zzz", nil, []byte("Hello World! - 22"))
+	}
+
+	if state := fs.State(); state.Msgs != uint64(toSend*2) {
+		t.Fatalf("Expected %d msgs, got %d", toSend*2, state.Msgs)
+	}
+
+	// Make sure we recover same state.
+	fs.Stop()
+
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer fs.Stop()
+
+	if state := fs.State(); state.Msgs != uint64(toSend*2) {
+		t.Fatalf("Expected %d msgs, got %d", toSend*2, state.Msgs)
+	}
+
+	// Now load them in and check.
+	for i := 1; i <= toSend*2; i++ {
+		subj, _, msg, _, err := fs.LoadMsg(uint64(i))
+		if err != nil {
+			t.Fatalf("Unexpected error looking up seq 11: %v", err)
+		}
+		str := "Hello World!"
+		if i > toSend {
+			str = "Hello World! - 22"
+		}
+		if subj != "zzz" || string(msg) != str {
+			t.Fatalf("Message did not match")
+		}
+	}
 }
 
 func TestFileStoreMsgLimit(t *testing.T) {
@@ -437,7 +576,7 @@ func TestFileStoreTimeStamps(t *testing.T) {
 	for seq := uint64(1); seq <= 10; seq++ {
 		_, _, _, ts, err := fs.LoadMsg(seq)
 		if err != nil {
-			t.Fatalf("Unexpected error looking up msg: %v", err)
+			t.Fatalf("Unexpected error looking up msg [%d]: %v", seq, err)
 		}
 		// These should be different
 		if ts <= last {
@@ -685,7 +824,7 @@ func TestFileStoreAgeLimitRecovery(t *testing.T) {
 	defer os.RemoveAll(storeDir)
 
 	fs, err := newFileStore(
-		FileStoreConfig{StoreDir: storeDir, ReadCacheExpire: 1 * time.Millisecond},
+		FileStoreConfig{StoreDir: storeDir, CacheExpire: 1 * time.Millisecond},
 		StreamConfig{Name: "zzz", Storage: FileStorage, MaxAge: maxAge},
 	)
 	if err != nil {
@@ -799,6 +938,7 @@ func TestFileStoreEraseMsg(t *testing.T) {
 
 	subj, msg := "foo", []byte("Hello World")
 	fs.StoreMsg(subj, nil, msg)
+	fs.StoreMsg(subj, nil, msg) // To keep block from being deleted.
 	_, _, smsg, _, err := fs.LoadMsg(1)
 	if err != nil {
 		t.Fatalf("Unexpected error looking up msg: %v", err)
@@ -808,12 +948,14 @@ func TestFileStoreEraseMsg(t *testing.T) {
 	}
 	// Hold for offset check later.
 	sm, _ := fs.msgForSeq(1)
-
 	if removed, _ := fs.EraseMsg(1); !removed {
 		t.Fatalf("Expected erase msg to return success")
 	}
 	if sm2, _ := fs.msgForSeq(1); sm2 != nil {
 		t.Fatalf("Expected msg to be erased")
+	}
+	if err := fs.flushPendingWritesUnlocked(); err != nil {
+		t.Fatalf("Unexpected error flushing: %v", err)
 	}
 
 	// Now look on disk as well.
@@ -821,9 +963,10 @@ func TestFileStoreEraseMsg(t *testing.T) {
 	buf := make([]byte, rl)
 	fp, err := os.Open(path.Join(storeDir, msgDir, fmt.Sprintf(blkScan, 1)))
 	if err != nil {
-		t.Fatalf("Error opening msgs file: %v", err)
+		t.Fatalf("Error opening msg block file: %v", err)
 	}
 	defer fp.Close()
+
 	fp.ReadAt(buf, sm.off)
 	nsubj, _, nmsg, seq, ts, err := msgFromBuf(buf, nil)
 	if err != nil {
@@ -832,7 +975,7 @@ func TestFileStoreEraseMsg(t *testing.T) {
 	if nsubj == subj {
 		t.Fatalf("Expected the subjects to be different")
 	}
-	if seq != 0 {
+	if seq != 0 && seq&ebit == 0 {
 		t.Fatalf("Expected seq to be 0, marking as deleted, got %d", seq)
 	}
 	if ts != 0 {
@@ -1142,7 +1285,7 @@ func TestFileStoreReadCache(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, ReadCacheExpire: 50 * time.Millisecond}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, CacheExpire: 100 * time.Millisecond}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1154,6 +1297,14 @@ func TestFileStoreReadCache(t *testing.T) {
 	for i := 0; i < toStore; i++ {
 		fs.StoreMsg(subj, nil, msg)
 	}
+
+	// Wait for write cache portion to go to zero.
+	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+		if csz := fs.cacheSize(); csz != 0 {
+			return fmt.Errorf("cache size not 0, got %s", FriendlyBytes(int64(csz)))
+		}
+		return nil
+	})
 
 	fs.LoadMsg(1)
 	if csz := fs.cacheSize(); csz != totalBytes {
@@ -1668,6 +1819,58 @@ func TestFileStoreReadBackMsgPerf(t *testing.T) {
 	start = time.Now()
 	fs.LoadMsg(index + 2)
 	fmt.Printf("Time to load second msg [%d] = %v\n", index+2, time.Since(start))
+}
+
+// This test is testing an upper level stream with a message or byte limit.
+// Even though this is 1, any limit would trigger same behavior once the limit was reached
+// and we were adding and removing.
+func TestFileStoreStoreLimitRemovePerf(t *testing.T) {
+	// Comment out to run, holding place for now.
+	t.SkipNow()
+
+	subj, msg := "foo", make([]byte, 1024-33)
+	for i := 0; i < len(msg); i++ {
+		msg[i] = 'D'
+	}
+	storedMsgSize := fileStoreMsgSize(subj, nil, msg)
+
+	// 1GB
+	toStore := 1 * 1024 * 1024 * 1024 / storedMsgSize
+
+	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	os.MkdirAll(storeDir, 0755)
+	defer os.RemoveAll(storeDir)
+
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: storeDir},
+		StreamConfig{Name: "zzz", Storage: FileStorage},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	fmt.Printf("storing and removing (limit 1) %d msgs of %s each, totalling %s\n",
+		toStore,
+		FriendlyBytes(int64(storedMsgSize)),
+		FriendlyBytes(int64(toStore*storedMsgSize)),
+	)
+
+	start := time.Now()
+	for i := 0; i < int(toStore); i++ {
+		seq, _, err := fs.StoreMsg(subj, nil, msg)
+		if err != nil {
+			t.Fatalf("Unexpected error storing message: %v", err)
+		}
+		if i > 0 {
+			fs.RemoveMsg(seq - 1)
+		}
+	}
+	fs.Stop()
+
+	tt := time.Since(start)
+	fmt.Printf("time to store and remove all messages is %v\n", tt)
+	fmt.Printf("%.0f msgs/sec\n", float64(toStore)/tt.Seconds())
+	fmt.Printf("%s per sec\n", FriendlyBytes(int64(float64(toStore*storedMsgSize)/tt.Seconds())))
 }
 
 func TestFileStoreConsumerPerf(t *testing.T) {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -317,7 +317,7 @@ func (ms *memStore) EraseMsg(seq uint64) (bool, error) {
 	return removed, nil
 }
 
-// Performs logic tp update first sequence number.
+// Performs logic to update first sequence number.
 // Lock should be held.
 func (ms *memStore) updateFirstSeq(seq uint64) {
 	if seq != ms.state.FirstSeq {

--- a/server/store.go
+++ b/server/store.go
@@ -50,6 +50,8 @@ var (
 	ErrStoreSnapshotInProgress = errors.New("snapshot in progress")
 	// ErrMsgTooBig is returned when a message is considered too large.
 	ErrMsgTooLarge = errors.New("message to large")
+	// ErrStoreWrongType is for when you access the wrong storage type.
+	ErrStoreWrongType = errors.New("wrong storage type")
 )
 
 type StreamStore interface {

--- a/server/stream.go
+++ b/server/stream.go
@@ -210,13 +210,12 @@ func (a *Account) AddStreamWithStore(config *StreamConfig, fsConfig *FileStoreCo
 func (mset *Stream) maxMsgSize() uint64 {
 	maxMsgSize := mset.config.MaxMsgSize
 	if maxMsgSize <= 0 {
-		// Pull from server.
+		// Pull from the account.
 		if mset.jsa != nil {
 			if acc := mset.jsa.acc(); acc != nil {
-				if s := acc.server(); s != nil {
-					opts := s.getOpts()
-					maxMsgSize = opts.MaxPayload
-				}
+				acc.mu.RLock()
+				maxMsgSize = acc.mpay
+				acc.mu.RUnlock()
 			}
 		}
 		// If all else fails use default.

--- a/server/stream.go
+++ b/server/stream.go
@@ -169,6 +169,11 @@ func (a *Account) AddStreamWithStore(config *StreamConfig, fsConfig *FileStoreCo
 	fsCfg := fsConfig
 	if fsCfg == nil {
 		fsCfg = &FileStoreConfig{}
+		// If we are file based and not explicitly configured
+		// we may be able to auto-tune based on max msgs or bytes.
+		if cfg.Storage == FileStorage {
+			mset.autoTuneFileStorageBlockSize(fsCfg)
+		}
 	}
 	fsCfg.StoreDir = storeDir
 	if err := mset.setupStore(fsCfg); err != nil {
@@ -199,6 +204,68 @@ func (a *Account) AddStreamWithStore(config *StreamConfig, fsConfig *FileStoreCo
 	mset.sendCreateAdvisory()
 
 	return mset, nil
+}
+
+// Helper to determine the max msg size for this stream if file based.
+func (mset *Stream) maxMsgSize() uint64 {
+	maxMsgSize := mset.config.MaxMsgSize
+	if maxMsgSize <= 0 {
+		// Pull from server.
+		if mset.jsa != nil {
+			if acc := mset.jsa.acc(); acc != nil {
+				if s := acc.server(); s != nil {
+					opts := s.getOpts()
+					maxMsgSize = opts.MaxPayload
+				}
+			}
+		}
+		// If all else fails use default.
+		if maxMsgSize <= 0 {
+			maxMsgSize = MAX_PAYLOAD_SIZE
+		}
+	}
+	// Now determine an estimation for the subjects etc.
+	maxSubject := -1
+	for _, subj := range mset.config.Subjects {
+		if subjectIsLiteral(subj) {
+			if len(subj) > maxSubject {
+				maxSubject = len(subj)
+			}
+		}
+	}
+	if maxSubject < 0 {
+		const defaultMaxSubject = 256
+		maxSubject = defaultMaxSubject
+	}
+	// filestore will add in estimates for record headers, etc.
+	return fileStoreMsgSizeEstimate(maxSubject, int(maxMsgSize))
+}
+
+// If we are file based and the file storage config was not explicitly set
+// we can autotune block sizes to better match. Our target will be to store 125%
+// of the theoretical limit. We will round up to nearest 100 bytes as well.
+func (mset *Stream) autoTuneFileStorageBlockSize(fsCfg *FileStoreConfig) {
+	var totalEstSize uint64
+
+	// MaxBytes will take precedence for now.
+	if mset.config.MaxBytes > 0 {
+		totalEstSize = uint64(mset.config.MaxBytes)
+	} else if mset.config.MaxMsgs > 0 {
+		// Determine max message size to estimate.
+		totalEstSize = mset.maxMsgSize() * uint64(mset.config.MaxMsgs)
+	}
+	blkSize := (totalEstSize / 4) + 1 // (25% overhead)
+	// Round up to nearest 100
+	if m := blkSize % 100; m != 0 {
+		blkSize += 100 - m
+	}
+	if blkSize < FileStoreMinBlkSize {
+		blkSize = FileStoreMinBlkSize
+	}
+	if blkSize > FileStoreMaxBlkSize {
+		blkSize = FileStoreMaxBlkSize
+	}
+	fsCfg.BlockSize = uint64(blkSize)
 }
 
 // rebuildDedupe will rebuild any dedupe structures needed after recovery of a stream.
@@ -405,6 +472,16 @@ func (mset *Stream) Config() StreamConfig {
 	mset.mu.Lock()
 	defer mset.mu.Unlock()
 	return mset.config
+}
+
+func (mset *Stream) FileStoreConfig() (FileStoreConfig, error) {
+	mset.mu.Lock()
+	defer mset.mu.Unlock()
+	fs, ok := mset.store.(*fileStore)
+	if !ok {
+		return FileStoreConfig{}, ErrStoreWrongType
+	}
+	return fs.fileStoreConfig(), nil
 }
 
 // Delete deletes a stream from the owning account.

--- a/server/stream.go
+++ b/server/stream.go
@@ -252,7 +252,11 @@ func (mset *Stream) autoTuneFileStorageBlockSize(fsCfg *FileStoreConfig) {
 	} else if mset.config.MaxMsgs > 0 {
 		// Determine max message size to estimate.
 		totalEstSize = mset.maxMsgSize() * uint64(mset.config.MaxMsgs)
+	} else {
+		// If nothing set will let underlying filestore determine blkSize.
+		return
 	}
+
 	blkSize := (totalEstSize / 4) + 1 // (25% overhead)
 	// Round up to nearest 100
 	if m := blkSize % 100; m != 0 {


### PR DESCRIPTION
The original design had a shared filestore write buffer and individual message blocks had a read cache.
This presented some performance and stability issues when lots of reads and deletes were happening to a
message block that was also being written to actively.

This change eliminates the shared write buffer and uses the message block's cache as a write through as
well as read cache and handles partials correctly.

This PR also introduces a dynamic autotuned block size for file based streams aiming at 25% overhead in most cases.
We also now dynamically discover the available disk space by storage directory.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
