### PR TITLE
Track number of stream pending for each consumer.

### DIFF
--- a/server/store.go
+++ b/server/store.go
@@ -61,7 +61,7 @@ type StreamStore interface {
 	Purge() uint64
 	GetSeqFromTime(t time.Time) uint64
 	State() StreamState
-	StorageBytesUpdate(func(int64))
+	RegisterStorageUpdates(func(int64, int64, uint64))
 	UpdateConfig(cfg *StreamConfig) error
 	Delete() error
 	Stop() error


### PR DESCRIPTION
This will track the stream pending state for each consumer.
This code does account for filtered consumers.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
