### PR TITLE
Add support for base2 units in NATS config

### DIFF
--- a/conf/lex.go
+++ b/conf/lex.go
@@ -995,7 +995,7 @@ func lexNumberOrDateOrStringOrIP(lx *lexer) stateFn {
 func lexConvenientNumber(lx *lexer) stateFn {
 	r := lx.next()
 	switch {
-	case r == 'b' || r == 'B':
+	case r == 'b' || r == 'B' || r == 'i' || r == 'I':
 		return lexConvenientNumber
 	}
 	lx.backup()

--- a/conf/parse.go
+++ b/conf/parse.go
@@ -253,27 +253,27 @@ func (p *parser) processItem(it item, fp string) error {
 			setValue(it, num)
 		case "k":
 			setValue(it, num*1000)
-		case "kb":
+		case "kb", "ki", "kib":
 			setValue(it, num*1024)
 		case "m":
 			setValue(it, num*1000*1000)
-		case "mb":
+		case "mb", "mi", "mib":
 			setValue(it, num*1024*1024)
 		case "g":
 			setValue(it, num*1000*1000*1000)
-		case "gb":
+		case "gb", "gi", "gib":
 			setValue(it, num*1024*1024*1024)
 		case "t":
 			setValue(it, num*1000*1000*1000*1000)
-		case "tb":
+		case "tb", "ti", "tib":
 			setValue(it, num*1024*1024*1024*1024)
 		case "p":
 			setValue(it, num*1000*1000*1000*1000*1000)
-		case "pb":
+		case "pb", "pi", "pib":
 			setValue(it, num*1024*1024*1024*1024*1024)
 		case "e":
 			setValue(it, num*1000*1000*1000*1000*1000*1000)
-		case "eb":
+		case "eb", "ei", "eib":
 			setValue(it, num*1024*1024*1024*1024*1024*1024)
 		}
 	case itemFloat:

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -142,20 +142,44 @@ func TestBcryptVariable(t *testing.T) {
 var easynum = `
 k = 8k
 kb = 4kb
+ki = 3ki
+kib = 4ki
 m = 1m
 mb = 2MB
+mi = 2Mi
+mib = 64MiB
 g = 2g
 gb = 22GB
+gi = 22Gi
+gib = 22GiB
+tb = 22TB
+ti = 22Ti
+tib = 22TiB
+pb = 22PB
+pi = 22Pi
+pib = 22PiB
 `
 
 func TestConvenientNumbers(t *testing.T) {
 	ex := map[string]interface{}{
 		"k":  int64(8 * 1000),
 		"kb": int64(4 * 1024),
+		"ki": int64(3 * 1024),
+		"kib": int64(4 * 1024),
 		"m":  int64(1000 * 1000),
 		"mb": int64(2 * 1024 * 1024),
+		"mi": int64(2 * 1024 * 1024),
+		"mib": int64(64 * 1024 * 1024),
 		"g":  int64(2 * 1000 * 1000 * 1000),
 		"gb": int64(22 * 1024 * 1024 * 1024),
+		"gi": int64(22 * 1024 * 1024 * 1024),
+		"gib": int64(22 * 1024 * 1024 * 1024),
+		"tb": int64(22 * 1024 * 1024 * 1024 * 1024),
+		"ti": int64(22 * 1024 * 1024 * 1024 * 1024),
+		"tib": int64(22 * 1024 * 1024 * 1024 * 1024),
+		"pb": int64(22 * 1024 * 1024 * 1024 * 1024 * 1024),
+		"pi": int64(22 * 1024 * 1024 * 1024 * 1024 * 1024),
+		"pib": int64(22 * 1024 * 1024 * 1024 * 1024 * 1024),
 	}
 	test(t, easynum, ex)
 }


### PR DESCRIPTION
This adds an alias to the NATS config to be able to use base2 units like `Gi`, `Mi`.  This will help it make it easier to declare when allocating volumes in Kubernetes which uses the units in this format as well, otherwise will have to use total bytes:

```yaml
nats:
  image: synadia/nats-server:nightly

  jetstream:
    enabled: true

    memStorage:
      enabled: true
      size: 1 Gi

    fileStorage:
      enabled: true
      storageDirectory: /data/
      # size: 1073741824 # 1 Gi
      size: 1 Gi
      storageClassName: default
```

 - [X] Link to issue, e.g. `Resolves #NNN`
 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request:

 - Add alias of base 2 units to SI units

/cc @nats-io/core

Signed-off-by: Waldemar Quevedo <wally@synadia.com>
