### PR TITLE
Added 2 fuzzers

### DIFF
--- a/conf/fuzz.go
+++ b/conf/fuzz.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2020 The NATS Authors
+// Copyright 2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/conf/fuzz.go
+++ b/conf/fuzz.go
@@ -1,0 +1,24 @@
+// Copyright 2012-2020 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build gofuzz
+
+package conf
+
+func Fuzz(data []byte) int {
+	_, err := Parse(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/server/fuzz.go
+++ b/server/fuzz.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2020 The NATS Authors
+// Copyright 2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/server/fuzz.go
+++ b/server/fuzz.go
@@ -1,0 +1,34 @@
+// Copyright 2012-2020 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build gofuzz
+
+package server
+
+func Fuzz(data []byte) int {
+	if len(data) < 100 {
+		return -1
+	}
+	c := dummyClient()
+
+	err := c.parse(data[:50])
+	if err != nil {
+		return 0
+	}
+
+	err = c.parse(data[50:])
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR addresses https://github.com/nats-io/nats-server/issues/1442 by adding two fuzzers.

The parser in `/server` has been fuzzed before and as a result of this, bugs and vulnerabilities have been found. 

With this PR I suggest running these fuzzers continuously by way of oss-fuzz. This will allow Google to run the fuzzers and notify maintainers in case any bugs or vulnerabilities are found. The service is offered free of charge with an implied expectation that bugs are fixed, so that the resources spent on fuzzing NATS are put to good use. I have previously reported bugs in NATS and they were fixed incredibly fast, so I presume this is not a problem.

I can confirm that these fuzzers work on oss-fuzz's infrastructure, and I have the setup ready to integrate NATS into oss-fuzz. All I need to proceed are the email addresses of the maintainers that are to receive potential bug reports. These will be added to a public list and can be changed at any time.

Furthermore, I will be happy to write a fuzzer for the NATS client as well and include that in the integration for continuous fuzzing.