### PR TITLE
[FIXED] Idx bug

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -171,14 +171,14 @@ type Consumer struct {
 	dseq              uint64
 	adflr             uint64
 	asflr             uint64
-	spending          uint64
+	sgap              uint64
 	dsubj             string
 	rlimit            *rate.Limiter
 	reqSub            *subscription
 	ackSub            *subscription
 	ackReplyT         string
 	nextMsgSubj       string
-	pending           map[uint64]int64
+	pending           map[uint64]*Pending
 	ptmr              *time.Timer
 	rdq               []uint64
 	rdc               map[uint64]uint64
@@ -191,7 +191,6 @@ type Consumer struct {
 	filterWC          bool
 	dtmr              *time.Timer
 	dthresh           time.Duration
-	fch               chan struct{}
 	qch               chan struct{}
 	inch              chan bool
 	sfreq             int32
@@ -385,7 +384,6 @@ func (mset *Stream) AddConsumer(config *ConsumerConfig) (*Consumer, error) {
 		dsubj:   config.DeliverSubject,
 		active:  true,
 		qch:     make(chan struct{}),
-		fch:     make(chan struct{}, 1),
 		sfreq:   int32(sampleFreq),
 		maxdc:   uint64(config.MaxDeliver),
 		created: time.Now().UTC(),
@@ -529,8 +527,9 @@ func (mset *Stream) AddConsumer(config *ConsumerConfig) (*Consumer, error) {
 
 	// Now start up Go routine to deliver msgs.
 	go o.loopAndDeliverMsgs(s, a)
-	// Startup our state update loop.
-	go o.updateStateLoop()
+	// Startup our interest update loop.
+	// FIXME(dlc) - combine with above once conditional signaling removed.
+	go o.updateInterestLoop()
 
 	o.sendCreateAdvisory()
 
@@ -740,8 +739,10 @@ func (o *Consumer) processAck(_ *subscription, _ *client, subject, reply string,
 func (o *Consumer) progressUpdate(seq uint64) {
 	o.mu.Lock()
 	if len(o.pending) > 0 {
-		if _, ok := o.pending[seq]; ok {
-			o.pending[seq] = time.Now().UnixNano()
+		if p, ok := o.pending[seq]; ok {
+			p.Timestamp = time.Now().UnixNano()
+			// Update store system.
+			o.store.UpdateDelivered(p.Sequence, seq, 1, p.Timestamp)
 		}
 	}
 	o.mu.Unlock()
@@ -756,7 +757,7 @@ func (o *Consumer) processNak(sseq, dseq uint64) {
 		o.mu.Unlock()
 		return
 	}
-	// If we are explicit ack make sure this is still on pending list.
+	// If we are explicit ack make sure this is still on our pending list.
 	if len(o.pending) > 0 {
 		if _, ok := o.pending[sseq]; !ok {
 			o.mu.Unlock()
@@ -825,10 +826,10 @@ func (o *Consumer) readStoredState() error {
 	state, err := o.store.State()
 	if err == nil && state != nil {
 		// FIXME(dlc) - re-apply state.
-		o.dseq = state.Delivered.ConsumerSeq
-		o.sseq = state.Delivered.StreamSeq
-		o.adflr = state.AckFloor.ConsumerSeq
-		o.asflr = state.AckFloor.StreamSeq
+		o.dseq = state.Delivered.Consumer + 1
+		o.sseq = state.Delivered.Stream + 1
+		o.adflr = state.AckFloor.Consumer
+		o.asflr = state.AckFloor.Stream
 		o.pending = state.Pending
 		o.rdc = state.Redelivered
 	}
@@ -848,12 +849,12 @@ func (o *Consumer) writeState() {
 	if o.store != nil {
 		state := ConsumerState{
 			Delivered: SequencePair{
-				ConsumerSeq: o.dseq,
-				StreamSeq:   o.sseq,
+				Consumer: o.dseq - 1,
+				Stream:   o.sseq - 1,
 			},
 			AckFloor: SequencePair{
-				ConsumerSeq: o.adflr,
-				StreamSeq:   o.asflr,
+				Consumer: o.adflr,
+				Stream:   o.asflr,
 			},
 			Pending:     o.pending,
 			Redelivered: o.rdc,
@@ -864,9 +865,8 @@ func (o *Consumer) writeState() {
 	o.mu.Unlock()
 }
 
-func (o *Consumer) updateStateLoop() {
+func (o *Consumer) updateInterestLoop() {
 	o.mu.Lock()
-	fch := o.fch
 	qch := o.qch
 	inch := o.inch
 	o.mu.Unlock()
@@ -879,10 +879,6 @@ func (o *Consumer) updateStateLoop() {
 			// inch can be nil on pull-based, but then this will
 			// just block and not fire.
 			o.updateDeliveryInterest(interest)
-		case <-fch:
-			// FIXME(dlc) - Do better, check for fast changes at quick intervals.
-			time.Sleep(10 * time.Millisecond)
-			o.writeState()
 		}
 	}
 }
@@ -896,16 +892,16 @@ func (o *Consumer) Info() *ConsumerInfo {
 		Created: o.created,
 		Config:  o.config,
 		Delivered: SequencePair{
-			ConsumerSeq: o.dseq - 1,
-			StreamSeq:   o.sseq - 1,
+			Consumer: o.dseq - 1,
+			Stream:   o.sseq - 1,
 		},
 		AckFloor: SequencePair{
-			ConsumerSeq: o.adflr,
-			StreamSeq:   o.asflr,
+			Consumer: o.adflr,
+			Stream:   o.asflr,
 		},
 		NumAckPending:  len(o.pending),
 		NumRedelivered: len(o.rdc),
-		NumPending:     o.spending,
+		NumPending:     o.sgap,
 	}
 	// If we are a pull mode consumer, report on number of waiting requests.
 	if o.isPullMode() {
@@ -913,19 +909,6 @@ func (o *Consumer) Info() *ConsumerInfo {
 	}
 	o.mu.Unlock()
 	return info
-}
-
-// Will update the underlying store.
-// Lock should be held.
-func (o *Consumer) updateStore() {
-	if o.store == nil {
-		return
-	}
-	// Kick our flusher
-	select {
-	case o.fch <- struct{}{}:
-	default:
-	}
 }
 
 // shouldSample lets us know if we are sampling metrics on acks.
@@ -960,7 +943,7 @@ func (o *Consumer) sampleAck(sseq, dseq, dcount uint64) {
 		Consumer:    o.name,
 		ConsumerSeq: dseq,
 		StreamSeq:   sseq,
-		Delay:       unow - o.pending[sseq],
+		Delay:       unow - o.pending[sseq].Timestamp,
 		Deliveries:  dcount,
 	}
 
@@ -978,23 +961,36 @@ func (o *Consumer) ackMsg(sseq, dseq, dcount uint64) {
 }
 
 func (o *Consumer) processAckMsg(sseq, dseq, dcount uint64, doSample bool) {
+	o.mu.Lock()
 	var sagap uint64
 
-	o.mu.Lock()
 	switch o.config.AckPolicy {
 	case AckExplicit:
-		if _, ok := o.pending[sseq]; ok {
+		if p, ok := o.pending[sseq]; ok {
 			if doSample {
 				o.sampleAck(sseq, dseq, dcount)
 			}
 			delete(o.pending, sseq)
-			// Consumers sequence numbers can skip during redlivery since
+
+			// Use the original deliver sequence from our pending record.
+			dseq = p.Sequence
+
+			// Consumers sequence numbers can skip during re-delivery since
 			// they always increment. So if we do not have any pending treat
 			// as all scenario below. Otherwise check that we filled in a gap.
 			if len(o.pending) == 0 {
 				o.adflr, o.asflr = o.dseq-1, o.sseq-1
+				o.pending = nil
 			} else if dseq == o.adflr+1 {
 				o.adflr, o.asflr = dseq, sseq
+				for ss := sseq + 1; ss < o.sseq; ss++ {
+					if p, ok := o.pending[ss]; ok {
+						if p.Sequence > 0 {
+							o.adflr, o.asflr = p.Sequence-1, ss-1
+						}
+						break
+					}
+				}
 			}
 		}
 		// We do these regardless.
@@ -1018,7 +1014,9 @@ func (o *Consumer) processAckMsg(sseq, dseq, dcount uint64, doSample bool) {
 		o.mu.Unlock()
 		return
 	}
-	o.updateStore()
+
+	// Update underlying store.
+	o.store.UpdateAcks(dseq, sseq)
 
 	mset := o.mset
 	o.mu.Unlock()
@@ -1547,11 +1545,12 @@ func (o *Consumer) deliverMsg(dsubj, subj string, hdr, msg []byte, seq, dcount u
 		return
 	}
 	// Update pending on first attempt
-	if dcount == 1 && o.spending > 0 {
-		o.spending--
+	if dcount == 1 && o.sgap > 0 {
+		o.sgap--
 	}
 
-	pmsg := &jsPubMsg{dsubj, subj, o.ackReply(seq, o.dseq, dcount, ts, o.spending), hdr, msg, o, seq}
+	dseq := o.dseq
+	pmsg := &jsPubMsg{dsubj, subj, o.ackReply(seq, dseq, dcount, ts, o.sgap), hdr, msg, o, seq}
 	mset := o.mset
 	sendq := mset.sendq
 	ap := o.config.AckPolicy
@@ -1568,7 +1567,7 @@ func (o *Consumer) deliverMsg(dsubj, subj string, hdr, msg []byte, seq, dcount u
 	o.mu.Lock()
 
 	if ap == AckExplicit || ap == AckAll {
-		o.trackPending(seq)
+		o.trackPending(seq, dseq)
 	} else if ap == AckNone {
 		o.adflr = o.dseq
 		o.asflr = seq
@@ -1576,19 +1575,24 @@ func (o *Consumer) deliverMsg(dsubj, subj string, hdr, msg []byte, seq, dcount u
 
 	o.dseq++
 
-	o.updateStore()
+	// FIXME(dlc) - Capture errors?
+	o.store.UpdateDelivered(dseq, seq, dcount, ts)
 }
 
 // Tracks our outstanding pending acks. Only applicable to AckExplicit mode.
 // Lock should be held.
-func (o *Consumer) trackPending(seq uint64) {
+func (o *Consumer) trackPending(sseq, dseq uint64) {
 	if o.pending == nil {
-		o.pending = make(map[uint64]int64)
+		o.pending = make(map[uint64]*Pending)
 	}
 	if o.ptmr == nil {
 		o.ptmr = time.AfterFunc(o.ackWait(0), o.checkPending)
 	}
-	o.pending[seq] = time.Now().UnixNano()
+	if p, ok := o.pending[sseq]; ok {
+		p.Timestamp = time.Now().UnixNano()
+	} else {
+		o.pending[sseq] = &Pending{dseq, time.Now().UnixNano()}
+	}
 }
 
 // didNotDeliver is called when a delivery for a consumer message failed.
@@ -1661,10 +1665,9 @@ func (o *Consumer) checkPending() {
 
 	// Since we can update timestamps, we have to review all pending.
 	// We may want to unlock here or warn if list is big.
-	// We also need to sort after.
 	var expired []uint64
-	for seq, ts := range o.pending {
-		elapsed := now - ts
+	for seq, p := range o.pending {
+		elapsed := now - p.Timestamp
 		if elapsed >= ttl {
 			if !o.onRedeliverQueue(seq) {
 				expired = append(expired, seq)
@@ -1677,13 +1680,16 @@ func (o *Consumer) checkPending() {
 	}
 
 	if len(expired) > 0 {
+		// We need to sort.
 		sort.Slice(expired, func(i, j int) bool { return expired[i] < expired[j] })
 		o.rdq = append(o.rdq, expired...)
 		// Now we should update the timestamp here since we are redelivering.
 		// We will use an incrementing time to preserve order for any other redelivery.
-		off := now - o.pending[expired[0]]
+		off := now - o.pending[expired[0]].Timestamp
 		for _, seq := range expired {
-			o.pending[seq] += off
+			if p, ok := o.pending[seq]; ok {
+				p.Timestamp += off
+			}
 		}
 	}
 
@@ -1853,7 +1859,7 @@ func (o *Consumer) purge(sseq uint64) {
 	o.sseq = sseq
 	o.asflr = sseq - 1
 	o.adflr = o.dseq - 1
-	o.spending = 0
+	o.sgap = 0
 	if len(o.pending) > 0 {
 		o.pending = nil
 		if o.ptmr != nil {
@@ -1874,6 +1880,8 @@ func (o *Consumer) purge(sseq uint64) {
 		o.rdq = newRDQ
 	}
 	o.mu.Unlock()
+
+	o.writeState()
 }
 
 func stopAndClearTimer(tp **time.Timer) {
@@ -1967,11 +1975,6 @@ func (o *Consumer) stop(dflag, doSignal, advisory bool) error {
 		}
 	}
 
-	// Make sure we stamp our update state
-	if !dflag {
-		o.writeState()
-	}
-
 	var err error
 	if store != nil {
 		if dflag {
@@ -2056,7 +2059,7 @@ func (o *Consumer) setInitialPending() {
 	if o.config.FilterSubject == _EMPTY_ {
 		state := mset.store.State()
 		if state.Msgs > 0 {
-			o.spending = state.Msgs - (o.sseq - state.FirstSeq)
+			o.sgap = state.Msgs - (o.sseq - state.FirstSeq)
 		}
 	} else {
 		// Here we are filtered.
@@ -2068,7 +2071,7 @@ func (o *Consumer) setInitialPending() {
 			} else if err == ErrStoreEOF {
 				break
 			} else if err == nil && o.isFilteredMatch(subj) {
-				o.spending++
+				o.sgap++
 			}
 		}
 	}
@@ -2078,7 +2081,7 @@ func (o *Consumer) setInitialPending() {
 func (o *Consumer) incStreamPending(sseq uint64, subj string) {
 	o.mu.Lock()
 	if o.isFilteredMatch(subj) {
-		o.spending++
+		o.sgap++
 	}
 	o.mu.Unlock()
 }
@@ -2086,15 +2089,15 @@ func (o *Consumer) incStreamPending(sseq uint64, subj string) {
 func (o *Consumer) decStreamPending(sseq uint64) {
 	o.mu.Lock()
 	// Ignore if we have already sent this one.
-	if sseq < o.sseq || o.spending == 0 {
+	if sseq < o.sseq || o.sgap == 0 {
 		o.mu.Unlock()
 		return
 	}
 	if o.config.FilterSubject == _EMPTY_ {
-		o.spending--
+		o.sgap--
 	} else if o.mset != nil {
 		if subj, _, _, _, _ := o.mset.store.LoadMsg(sseq); o.isFilteredMatch(subj) {
-			o.spending--
+			o.sgap--
 		}
 	}
 	o.mu.Unlock()

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -981,9 +981,7 @@ func (mb *msgBlock) spinUpFlushLoop() {
 	fch, qch := mb.fch, mb.qch
 	mb.mu.Unlock()
 
-	sch := make(chan struct{})
-	go mb.flushLoop(fch, qch, sch)
-	<-sch // Will be closed when flush loop starts.
+	go mb.flushLoop(fch, qch)
 }
 
 // Raw low level kicker for flush loops.
@@ -1016,14 +1014,9 @@ func (mb *msgBlock) clearInFlusher() {
 }
 
 // flushLoop watches for messages, index info, or recently closed msg block updates.
-func (mb *msgBlock) flushLoop(fch, qch, sch chan struct{}) {
+func (mb *msgBlock) flushLoop(fch, qch chan struct{}) {
 	mb.setInFlusher()
 	defer mb.clearInFlusher()
-
-	// Signal back that we are runnng.
-	if sch != nil {
-		close(sch)
-	}
 
 	// Will use to test if we have meta data updates.
 	var firstSeq, lastSeq uint64
@@ -1934,6 +1927,7 @@ var (
 	errNoPending    = errors.New("message block does not have pending data")
 	errNotReadable  = errors.New("storage directory not readable")
 	errFlushRunning = errors.New("flush is already running")
+	errCorruptState = errors.New("corrupt state file")
 )
 
 // Used for marking messages that have had their checksums checked.
@@ -2636,7 +2630,6 @@ func (fs *fileStore) streamSnapshot(w io.WriteCloser, blks []*msgBlock, includeC
 	fs.mu.Unlock()
 
 	for _, o := range cfs {
-		o.syncStateFile()
 		o.mu.Lock()
 		meta, err := ioutil.ReadFile(path.Join(o.odir, JetStreamMetaFile))
 		if err != nil {
@@ -2650,10 +2643,12 @@ func (fs *fileStore) streamSnapshot(w io.WriteCloser, blks []*msgBlock, includeC
 			writeErr(fmt.Sprintf("Could not read consumer checksum file for %q: %v", o.name, err))
 			return
 		}
-		state, err := ioutil.ReadFile(path.Join(o.odir, consumerState))
+
+		// We can have the running state directly encoded now.
+		state, err := o.encodeState()
 		if err != nil {
 			o.mu.Unlock()
-			writeErr(fmt.Sprintf("Could not read consumer state for %q: %v", o.name, err))
+			writeErr(fmt.Sprintf("Could not encode consumer state for %q: %v", o.name, err))
 			return
 		}
 		odirPre := consumerDir + "/" + o.name
@@ -2719,16 +2714,21 @@ func (fs *fileStore) fileStoreConfig() FileStoreConfig {
 ////////////////////////////////////////////////////////////////////////////////
 
 type consumerFileStore struct {
-	mu     sync.Mutex
-	fs     *fileStore
-	cfg    *FileConsumerInfo
-	name   string
-	odir   string
-	ifn    string
-	ifd    *os.File
-	lwsz   int64
-	hh     hash.Hash64
-	closed bool
+	mu      sync.Mutex
+	fs      *fileStore
+	cfg     *FileConsumerInfo
+	name    string
+	odir    string
+	ifn     string
+	ifd     *os.File
+	lwsz    int64
+	hh      hash.Hash64
+	state   ConsumerState
+	fch     chan struct{}
+	qch     chan struct{}
+	flusher bool
+	writing bool
+	closed  bool
 }
 
 func (fs *fileStore) ConsumerStore(name string, cfg *ConsumerConfig) (ConsumerStore, error) {
@@ -2769,6 +2769,11 @@ func (fs *fileStore) ConsumerStore(name string, cfg *ConsumerConfig) (ConsumerSt
 		}
 	}
 
+	// Create channels to control our flush go routine.
+	o.fch = make(chan struct{}, 1)
+	o.qch = make(chan struct{})
+	go o.flushLoop()
+
 	fs.mu.Lock()
 	fs.cfs = append(fs.cfs, o)
 	fs.mu.Unlock()
@@ -2776,91 +2781,302 @@ func (fs *fileStore) ConsumerStore(name string, cfg *ConsumerConfig) (ConsumerSt
 	return o, nil
 }
 
+// Kick flusher for this consumer.
+// Lock should be held.
+func (o *consumerFileStore) kickFlusher() {
+	if o.fch != nil {
+		select {
+		case o.fch <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// Set in flusher status
+func (o *consumerFileStore) setInFlusher() {
+	o.mu.Lock()
+	o.flusher = true
+	o.mu.Unlock()
+}
+
+// Clear in flusher status
+func (o *consumerFileStore) clearInFlusher() {
+	o.mu.Lock()
+	o.flusher = false
+	o.mu.Unlock()
+}
+
+// Report in flusher status
+func (o *consumerFileStore) inFlusher() bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.flusher
+}
+
+// flushLoop watches for consumer updates and the quit channel.
+func (o *consumerFileStore) flushLoop() {
+	o.mu.Lock()
+	fch, qch := o.fch, o.qch
+	o.mu.Unlock()
+
+	o.setInFlusher()
+	defer o.clearInFlusher()
+
+	for {
+		select {
+		case <-fch:
+			time.Sleep(5 * time.Millisecond)
+			select {
+			case <-qch:
+				return
+			default:
+			}
+			o.mu.Lock()
+			if o.closed {
+				o.mu.Unlock()
+				return
+			}
+			buf, err := o.encodeState()
+			o.mu.Unlock()
+			if err != nil {
+				return
+			}
+			// TODO(dlc) - if we error should start failing upwards.
+			o.writeState(buf)
+		case <-qch:
+			return
+		}
+	}
+}
+
+// UpdateDelivered is called whenever a new message has been delivered.
+func (o *consumerFileStore) UpdateDelivered(dseq, sseq, dc uint64, ts int64) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if dc != 1 && o.cfg.AckPolicy == AckNone {
+		return ErrNoAckPolicy
+	}
+
+	// See if we expect an ack for this.
+	if o.cfg.AckPolicy != AckNone {
+		// Need to create pending records here.
+		if o.state.Pending == nil {
+			o.state.Pending = make(map[uint64]*Pending)
+		}
+		var p *Pending
+		// Check for an update to a message already delivered.
+		if sseq <= o.state.Delivered.Stream {
+			if p = o.state.Pending[sseq]; p != nil {
+				p.Timestamp = ts
+			}
+		}
+		if p == nil {
+			// Move delivered if this is new.
+			o.state.Delivered.Consumer = dseq
+			o.state.Delivered.Stream = sseq
+			p = &Pending{dseq, ts}
+		} else if dc > 1 {
+			if o.state.Redelivered == nil {
+				o.state.Redelivered = make(map[uint64]uint64)
+			}
+			o.state.Redelivered[sseq] = dc
+		}
+		o.state.Pending[sseq] = &Pending{dseq, ts}
+	} else {
+		// For AckNone just update delivered and ackfloor at the same time.
+		o.state.Delivered.Consumer = dseq
+		o.state.Delivered.Stream = sseq
+		o.state.AckFloor.Consumer = dseq
+		o.state.AckFloor.Stream = sseq
+	}
+	// Make sure we flush to disk.
+	o.kickFlusher()
+
+	return nil
+}
+
+// UpdateAcks is called whenever a consumer with explicit ack or ack all acks a message.
+func (o *consumerFileStore) UpdateAcks(dseq, sseq uint64) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.cfg.AckPolicy == AckNone {
+		return ErrNoAckPolicy
+	}
+	if len(o.state.Pending) == 0 {
+		return ErrStoreMsgNotFound
+	}
+	p := o.state.Pending[sseq]
+	if p == nil {
+		return ErrStoreMsgNotFound
+	}
+	delete(o.state.Pending, sseq)
+
+	// TODO(dlc) - Check to see if we move ack floor.
+	if len(o.state.Pending) == 0 {
+		o.state.Pending = nil
+		o.state.AckFloor.Consumer = o.state.Delivered.Consumer
+		o.state.AckFloor.Stream = o.state.Delivered.Stream
+	} else if o.state.AckFloor.Consumer == 0 {
+		o.state.AckFloor.Consumer = dseq
+		o.state.AckFloor.Stream = sseq
+	} else if o.state.AckFloor.Consumer == dseq-1 {
+		o.state.AckFloor.Consumer = dseq
+		o.state.AckFloor.Stream = sseq
+		// Close gap if needed.
+		for ss := sseq + 1; ss < o.state.Delivered.Stream; ss++ {
+			if p, ok := o.state.Pending[ss]; ok {
+				if p.Sequence > 0 {
+					o.state.AckFloor.Consumer = p.Sequence - 1
+					o.state.AckFloor.Stream = ss - 1
+				}
+				break
+			}
+		}
+	}
+	o.kickFlusher()
+	return nil
+}
+
 const seqsHdrSize = 6*binary.MaxVarintLen64 + hdrLen
 
-func (o *consumerFileStore) Update(state *ConsumerState) error {
-	// Sanity checks.
-	if state.Delivered.ConsumerSeq < 1 || state.Delivered.StreamSeq < 1 {
-		return fmt.Errorf("bad delivered sequences")
-	}
-	if state.AckFloor.ConsumerSeq > state.Delivered.ConsumerSeq {
-		return fmt.Errorf("bad ack floor for consumer")
-	}
-	if state.AckFloor.StreamSeq > state.Delivered.StreamSeq {
-		return fmt.Errorf("bad ack floor for stream")
+// Encode our consumer state, version 2.
+// Lock should be held.
+func (o *consumerFileStore) encodeState() ([]byte, error) {
+	if o.closed {
+		return nil, ErrStoreClosed
 	}
 
 	var hdr [seqsHdrSize]byte
+	var buf []byte
+
+	maxSize := seqsHdrSize
+	if lp := len(o.state.Pending); lp > 0 {
+		maxSize += lp*(3*binary.MaxVarintLen64) + binary.MaxVarintLen64
+	}
+	if lr := len(o.state.Redelivered); lr > 0 {
+		maxSize += lr*(2*binary.MaxVarintLen64) + binary.MaxVarintLen64
+	}
+	if maxSize == seqsHdrSize {
+		buf = hdr[:seqsHdrSize]
+	} else {
+		buf = make([]byte, maxSize)
+	}
+
+	now := time.Now()
 
 	// Write header
-	hdr[0] = magic
-	hdr[1] = version
+	buf[0] = magic
+	buf[1] = 2
 
 	n := hdrLen
-	n += binary.PutUvarint(hdr[n:], state.AckFloor.ConsumerSeq)
-	n += binary.PutUvarint(hdr[n:], state.AckFloor.StreamSeq)
-	n += binary.PutUvarint(hdr[n:], state.Delivered.ConsumerSeq-state.AckFloor.ConsumerSeq)
-	n += binary.PutUvarint(hdr[n:], state.Delivered.StreamSeq-state.AckFloor.StreamSeq)
-	n += binary.PutUvarint(hdr[n:], uint64(len(state.Pending)))
-	buf := hdr[:n]
+	n += binary.PutUvarint(buf[n:], o.state.AckFloor.Consumer)
+	n += binary.PutUvarint(buf[n:], o.state.AckFloor.Stream)
+	n += binary.PutUvarint(buf[n:], o.state.Delivered.Consumer)
+	n += binary.PutUvarint(buf[n:], o.state.Delivered.Stream)
+	n += binary.PutUvarint(buf[n:], uint64(len(o.state.Pending)))
+
+	asflr := o.state.AckFloor.Stream
+	adflr := o.state.AckFloor.Consumer
 
 	// These are optional, but always write len. This is to avoid a truncate inline.
-	// If these get big might make more sense to do writes directly to the file.
-	if len(state.Pending) > 0 {
-		mbuf := make([]byte, len(state.Pending)*(2*binary.MaxVarintLen64)+binary.MaxVarintLen64)
-		aflr := state.AckFloor.StreamSeq
-		maxd := state.Delivered.StreamSeq
-
-		// To save space we select the smallest timestamp.
-		var mints int64
-		for k, v := range state.Pending {
-			if mints == 0 || v < mints {
-				mints = v
-			}
-			if k <= aflr || k > maxd {
-				return fmt.Errorf("bad pending entry, sequence [%d] out of range", k)
-			}
-		}
-
-		// Downsample the minimum timestamp.
-		mints /= int64(time.Second)
-		var n int
+	if len(o.state.Pending) > 0 {
+		// To save space we will use now rounded to seconds to be base timestamp.
+		mints := now.Round(time.Second).Unix()
 		// Write minimum timestamp we found from above.
-		n += binary.PutVarint(mbuf[n:], mints)
+		n += binary.PutVarint(buf[n:], mints)
 
-		for k, v := range state.Pending {
-			n += binary.PutUvarint(mbuf[n:], k-aflr)
-			// Downsample to seconds to save on space. Subsecond resolution not
-			// needed for recovery etc.
-			n += binary.PutVarint(mbuf[n:], (v/int64(time.Second))-mints)
+		for k, v := range o.state.Pending {
+			n += binary.PutUvarint(buf[n:], k-asflr)
+			n += binary.PutUvarint(buf[n:], v.Sequence-adflr)
+			// Downsample to seconds to save on space.
+			// Subsecond resolution not needed for recovery etc.
+			ts := v.Timestamp / 1_000_000_000
+			n += binary.PutVarint(buf[n:], mints-ts)
 		}
-		buf = append(buf, mbuf[:n]...)
 	}
 
-	var lenbuf [binary.MaxVarintLen64]byte
-	n = binary.PutUvarint(lenbuf[0:], uint64(len(state.Redelivered)))
-	buf = append(buf, lenbuf[:n]...)
+	// We always write the redelivered len.
+	n += binary.PutUvarint(buf[n:], uint64(len(o.state.Redelivered)))
 
-	// We expect these to be small so will not do anything too crazy here to
-	// keep the size small. Trick could be to offset sequence like above, but
-	// we would need to know low sequence number for redelivery, can't depend on ackfloor etc.
+	// We expect these to be small.
+	if len(o.state.Redelivered) > 0 {
+		for k, v := range o.state.Redelivered {
+			n += binary.PutUvarint(buf[n:], k-asflr)
+			n += binary.PutUvarint(buf[n:], v)
+		}
+	}
+	return buf[:n], nil
+}
+
+func (o *consumerFileStore) Update(state *ConsumerState) error {
+	// Sanity checks.
+	if state.Delivered.Consumer < 1 || state.Delivered.Stream < 1 {
+		return fmt.Errorf("bad delivered sequences")
+	}
+	if state.AckFloor.Consumer > state.Delivered.Consumer {
+		return fmt.Errorf("bad ack floor for consumer")
+	}
+	if state.AckFloor.Stream > state.Delivered.Stream {
+		return fmt.Errorf("bad ack floor for stream")
+	}
+
+	// Copy to our state.
+	var pending map[uint64]*Pending
+	var redelivered map[uint64]uint64
+	if len(state.Pending) > 0 {
+		pending = make(map[uint64]*Pending, len(state.Pending))
+		for seq, p := range state.Pending {
+			pending[seq] = &Pending{p.Sequence, p.Timestamp}
+		}
+		for seq := range pending {
+			if seq <= state.AckFloor.Stream || seq > state.Delivered.Stream {
+				return fmt.Errorf("bad pending entry, sequence [%d] out of range", seq)
+			}
+		}
+	}
 	if len(state.Redelivered) > 0 {
-		mbuf := make([]byte, len(state.Redelivered)*(2*binary.MaxVarintLen64))
-		var n int
-		for k, v := range state.Redelivered {
-			n += binary.PutUvarint(mbuf[n:], k)
-			n += binary.PutUvarint(mbuf[n:], v)
+		redelivered = make(map[uint64]uint64, len(state.Redelivered))
+		for seq, dc := range state.Redelivered {
+			redelivered[seq] = dc
 		}
-		buf = append(buf, mbuf[:n]...)
 	}
 
+	// Replace our state.
+	o.mu.Lock()
+	o.state.Delivered = state.Delivered
+	o.state.AckFloor = state.AckFloor
+	o.state.Pending = pending
+	o.state.Redelivered = redelivered
+	o.mu.Unlock()
+
+	o.kickFlusher()
+	return nil
+}
+
+func (o *consumerFileStore) writeState(buf []byte) error {
 	// Check if we have the index file open.
 	o.mu.Lock()
-	err := o.ensureStateFileOpen()
+	if o.writing || len(buf) == 0 {
+		o.mu.Unlock()
+		return nil
+	}
+	if err := o.ensureStateFileOpen(); err != nil {
+		o.mu.Unlock()
+		return err
+	}
+	o.writing = true
+	ifd := o.ifd
+	o.mu.Unlock()
+
+	n, err := ifd.WriteAt(buf, 0)
+
+	o.mu.Lock()
 	if err == nil {
-		n, err = o.ifd.WriteAt(buf, 0)
 		o.lwsz = int64(n)
 	}
+	o.writing = false
 	o.mu.Unlock()
 
 	return err
@@ -2922,9 +3138,37 @@ func (o *consumerFileStore) ensureStateFileOpen() error {
 
 func checkHeader(hdr []byte) error {
 	if hdr == nil || len(hdr) < 2 || hdr[0] != magic || hdr[1] != version {
-		return fmt.Errorf("corrupt state file")
+		return errCorruptState
 	}
 	return nil
+}
+
+func checkConsumerHeader(hdr []byte) (uint8, error) {
+	if hdr == nil || len(hdr) < 2 || hdr[0] != magic {
+		return 0, errCorruptState
+	}
+	version := hdr[1]
+	switch version {
+	case 1, 2:
+		return version, nil
+	}
+	return 0, fmt.Errorf("unsupported version: %d", version)
+}
+
+func (o *consumerFileStore) copyPending() map[uint64]*Pending {
+	pending := make(map[uint64]*Pending, len(o.state.Pending))
+	for seq, p := range o.state.Pending {
+		pending[seq] = &Pending{p.Sequence, p.Timestamp}
+	}
+	return pending
+}
+
+func (o *consumerFileStore) copyRedelivered() map[uint64]uint64 {
+	redelivered := make(map[uint64]uint64, len(o.state.Redelivered))
+	for seq, dc := range o.state.Redelivered {
+		redelivered[seq] = dc
+	}
+	return redelivered
 }
 
 // State retrieves the state from the state file.
@@ -2933,18 +3177,34 @@ func (o *consumerFileStore) State() (*ConsumerState, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
+	var state *ConsumerState
+
+	// See if we have a running state or if we need to read in from disk.
+	if o.state.Delivered.Consumer != 0 {
+		state = &ConsumerState{}
+		state.Delivered = o.state.Delivered
+		state.AckFloor = o.state.AckFloor
+		if len(o.state.Pending) > 0 {
+			state.Pending = o.copyPending()
+		}
+		if len(o.state.Redelivered) > 0 {
+			state.Redelivered = o.copyRedelivered()
+		}
+		return state, nil
+	}
+
+	// Read the state in here from disk..
 	buf, err := ioutil.ReadFile(o.ifn)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 
-	var state *ConsumerState
-
 	if len(buf) == 0 {
 		return state, nil
 	}
 
-	if err := checkHeader(buf); err != nil {
+	version, err := checkConsumerHeader(buf)
+	if err != nil {
 		return nil, err
 	}
 
@@ -2980,36 +3240,50 @@ func (o *consumerFileStore) State() (*ConsumerState, error) {
 	readCount := readSeq
 
 	state = &ConsumerState{}
-	state.AckFloor.ConsumerSeq = readSeq()
-	state.AckFloor.StreamSeq = readSeq()
-	state.Delivered.ConsumerSeq = readSeq()
-	state.Delivered.StreamSeq = readSeq()
+	state.AckFloor.Consumer = readSeq()
+	state.AckFloor.Stream = readSeq()
+	state.Delivered.Consumer = readSeq()
+	state.Delivered.Stream = readSeq()
 
 	if bi == -1 {
-		return nil, fmt.Errorf("corrupt state file")
+		return nil, errCorruptState
 	}
-	// Adjust back.
-	state.Delivered.ConsumerSeq += state.AckFloor.ConsumerSeq
-	state.Delivered.StreamSeq += state.AckFloor.StreamSeq
+	if version == 1 {
+		// Adjust back. Version 1 also stored delivered as next to be delivered,
+		// so adjust that back down here.
+		state.Delivered.Consumer += state.AckFloor.Consumer - 1
+		state.Delivered.Stream += state.AckFloor.Stream - 1
+	}
 
 	numPending := readLen()
 
 	// We have additional stuff.
 	if numPending > 0 {
 		mints := readTimeStamp()
-		state.Pending = make(map[uint64]int64, numPending)
+		state.Pending = make(map[uint64]*Pending, numPending)
 		for i := 0; i < int(numPending); i++ {
-			seq := readSeq()
+			sseq := readSeq()
+			var dseq uint64
+			if version == 2 {
+				dseq = readSeq()
+			}
 			ts := readTimeStamp()
-			if seq == 0 || ts == -1 {
-				return nil, fmt.Errorf("corrupt state file")
+			if sseq == 0 || ts == -1 {
+				return nil, errCorruptState
 			}
 			// Adjust seq back.
-			seq += state.AckFloor.StreamSeq
+			sseq += state.AckFloor.Stream
+			if version == 2 {
+				dseq += state.AckFloor.Consumer
+			}
 			// Adjust the timestamp back.
-			ts = (ts + mints) * int64(time.Second)
+			if version == 1 {
+				ts = (ts + mints) * int64(time.Second)
+			} else {
+				ts = (mints - ts) * int64(time.Second)
+			}
 			// Store in pending.
-			state.Pending[seq] = ts
+			state.Pending[sseq] = &Pending{dseq, ts}
 		}
 	}
 
@@ -3022,7 +3296,7 @@ func (o *consumerFileStore) State() (*ConsumerState, error) {
 			seq := readSeq()
 			n := readCount()
 			if seq == 0 || n == 0 {
-				return nil, fmt.Errorf("corrupt state file")
+				return nil, errCorruptState
 			}
 			state.Redelivered[seq] = n
 		}
@@ -3037,43 +3311,82 @@ func (o *consumerFileStore) Stop() error {
 		o.mu.Unlock()
 		return nil
 	}
-	o.closed = true
-	if o.ifd != nil {
-		o.ifd.Sync()
-		o.ifd.Close()
-		o.ifd = nil
+	if o.qch != nil {
+		close(o.qch)
+		o.qch = nil
 	}
+
+	err := o.ensureStateFileOpen()
+	ifd := o.ifd
+
+	if err == nil {
+		var buf []byte
+		// Make sure to write this out..
+		if buf, err = o.encodeState(); err == nil {
+			_, err = ifd.WriteAt(buf, 0)
+		}
+	}
+
+	o.ifd, o.odir = nil, _EMPTY_
 	fs := o.fs
+	o.closed = true
+	o.kickFlusher()
 	o.mu.Unlock()
+
+	if ifd != nil {
+		ifd.Sync()
+		ifd.Close()
+	}
+
 	fs.removeConsumer(o)
-	return nil
+	return err
 }
 
 // Delete the consumer.
 func (o *consumerFileStore) Delete() error {
-	// Call stop first. OK if already stopped.
-	o.Stop()
 	o.mu.Lock()
+
+	if o.closed {
+		o.mu.Unlock()
+		return nil
+	}
+	if o.qch != nil {
+		close(o.qch)
+		o.qch = nil
+	}
+
+	if o.ifd != nil {
+		o.ifd.Close()
+		o.ifd = nil
+	}
 	var err error
-	if o.odir != "" {
+	if o.odir != _EMPTY_ {
 		err = os.RemoveAll(o.odir)
 	}
+	o.ifd, o.odir = nil, _EMPTY_
+	o.closed = true
+	fs := o.fs
 	o.mu.Unlock()
+
+	fs.removeConsumer(o)
 	return err
 }
 
 func (fs *fileStore) removeConsumer(cfs *consumerFileStore) {
 	fs.mu.Lock()
+	defer fs.mu.Unlock()
 	for i, o := range fs.cfs {
 		if o == cfs {
 			fs.cfs = append(fs.cfs[:i], fs.cfs[i+1:]...)
 			break
 		}
 	}
-	fs.mu.Unlock()
 }
 
+////////////////////////////////////////////////////////////////////////////////
 // Templates
+////////////////////////////////////////////////////////////////////////////////
+
 type templateFileStore struct {
 	dir string
 	hh  hash.Hash64

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -348,7 +348,6 @@ func TestFileStoreSkipMsg(t *testing.T) {
 
 	subj, _, msg, _, err = fs.LoadMsg(nseq)
 	if err != nil {
-		fmt.Printf("fs is %+v\n", fs)
 		t.Fatalf("Unexpected error looking up seq %d: %v", nseq, err)
 	}
 	if subj != "AAA" || string(msg) != "Skip?" {
@@ -1389,16 +1388,16 @@ func TestFileStoreSnapshot(t *testing.T) {
 		t.Fatalf("Unexepected error: %v", err)
 	}
 	state := &ConsumerState{}
-	state.Delivered.ConsumerSeq = 100
-	state.Delivered.StreamSeq = 100
-	state.AckFloor.ConsumerSeq = 22
-	state.AckFloor.StreamSeq = 22
+	state.Delivered.Consumer = 100
+	state.Delivered.Stream = 100
+	state.AckFloor.Consumer = 22
+	state.AckFloor.Stream = 22
 
 	if err := o1.Update(state); err != nil {
 		t.Fatalf("Unexepected error updating state: %v", err)
 	}
-	state.AckFloor.ConsumerSeq = 33
-	state.AckFloor.StreamSeq = 33
+	state.AckFloor.Consumer = 33
+	state.AckFloor.Stream = 33
 
 	if err := o2.Update(state); err != nil {
 		t.Fatalf("Unexepected error updating state: %v", err)
@@ -1581,47 +1580,47 @@ func TestFileStoreConsumer(t *testing.T) {
 		}
 	}
 
-	state.Delivered.ConsumerSeq = 1
-	state.Delivered.StreamSeq = 22
+	state.Delivered.Consumer = 1
+	state.Delivered.Stream = 22
 	updateAndCheck()
 
-	state.Delivered.ConsumerSeq = 100
-	state.Delivered.StreamSeq = 122
-	state.AckFloor.ConsumerSeq = 50
-	state.AckFloor.StreamSeq = 123
+	state.Delivered.Consumer = 100
+	state.Delivered.Stream = 122
+	state.AckFloor.Consumer = 50
+	state.AckFloor.Stream = 123
 	// This should fail, bad state.
 	shouldFail()
 	// So should this.
-	state.AckFloor.ConsumerSeq = 200
-	state.AckFloor.StreamSeq = 100
+	state.AckFloor.Consumer = 200
+	state.AckFloor.Stream = 100
 	shouldFail()
 
 	// Should succeed
-	state.AckFloor.ConsumerSeq = 50
-	state.AckFloor.StreamSeq = 72
+	state.AckFloor.Consumer = 50
+	state.AckFloor.Stream = 72
 	updateAndCheck()
 
 	tn := time.Now().UnixNano()
 
 	// We should sanity check pending here as well, so will check if a pending value is below
 	// ack floor or above delivered.
-	state.Pending = map[uint64]int64{70: tn}
+	state.Pending = map[uint64]*Pending{70: &Pending{70, tn}}
 	shouldFail()
-	state.Pending = map[uint64]int64{140: tn}
+	state.Pending = map[uint64]*Pending{140: &Pending{140, tn}}
 	shouldFail()
-	state.Pending = map[uint64]int64{72: tn} // exact on floor should fail
+	state.Pending = map[uint64]*Pending{72: &Pending{72, tn}} // exact on floor should fail
 	shouldFail()
 
 	// Put timestamps a second apart.
 	// We will downsample to second resolution to save space. So setup our times
 	// to reflect that.
 	ago := time.Now().Add(-30 * time.Second).Truncate(time.Second)
-	nt := func() int64 {
+	nt := func() *Pending {
 		ago = ago.Add(time.Second)
-		return ago.UnixNano()
+		return &Pending{0, ago.UnixNano()}
 	}
 	// Should succeed.
-	state.Pending = map[uint64]int64{75: nt(), 80: nt(), 83: nt(), 90: nt(), 111: nt()}
+	state.Pending = map[uint64]*Pending{75: nt(), 80: nt(), 83: nt(), 90: nt(), 111: nt()}
 	updateAndCheck()
 
 	// Now do redlivery, but first with no pending.
@@ -1630,16 +1629,16 @@ func TestFileStoreConsumer(t *testing.T) {
 	updateAndCheck()
 
 	// All together.
-	state.Pending = map[uint64]int64{75: nt(), 80: nt(), 83: nt(), 90: nt(), 111: nt()}
+	state.Pending = map[uint64]*Pending{75: nt(), 80: nt(), 83: nt(), 90: nt(), 111: nt()}
 	updateAndCheck()
 
 	// Large one
-	state.Delivered.ConsumerSeq = 10000
-	state.Delivered.StreamSeq = 10000
-	state.AckFloor.ConsumerSeq = 100
-	state.AckFloor.StreamSeq = 100
+	state.Delivered.Consumer = 10000
+	state.Delivered.Stream = 10000
+	state.AckFloor.Consumer = 100
+	state.AckFloor.Stream = 100
 	// Generate 8k pending.
-	state.Pending = make(map[uint64]int64)
+	state.Pending = make(map[uint64]*Pending)
 	for len(state.Pending) < 8192 {
 		seq := uint64(rand.Intn(9890) + 101)
 		if _, ok := state.Pending[seq]; !ok {
@@ -1649,8 +1648,8 @@ func TestFileStoreConsumer(t *testing.T) {
 	updateAndCheck()
 
 	state.Pending = nil
-	state.AckFloor.ConsumerSeq = 10000
-	state.AckFloor.StreamSeq = 10000
+	state.AckFloor.Consumer = 10000
+	state.AckFloor.Stream = 10000
 	updateAndCheck()
 }
 
@@ -1942,14 +1941,10 @@ func TestFileStorePubPerfWithSmallBlkSize(t *testing.T) {
 	fmt.Printf("%s per sec\n", FriendlyBytes(int64(float64(toStore*storedMsgSize)/tt.Seconds())))
 }
 
-func TestFileStoreConsumerPerf(t *testing.T) {
-	// Comment out to run, holding place for now.
-	t.SkipNow()
-
+func TestFileStoreConsumerFlusher(t *testing.T) {
 	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
-	fmt.Printf("StoreDir is %q\n", storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -1957,53 +1952,274 @@ func TestFileStoreConsumerPerf(t *testing.T) {
 	}
 	defer fs.Stop()
 
-	// Test Consumers.
-	o, err := fs.ConsumerStore("obs22", &ConsumerConfig{})
+	o, err := fs.ConsumerStore("o22", &ConsumerConfig{})
 	if err != nil {
 		t.Fatalf("Unexepected error: %v", err)
 	}
-	state := &ConsumerState{}
-	toStore := uint64(1000000)
-	fmt.Printf("consumer of %d msgs for ACK NONE\n", toStore)
+	// Get the underlying impl.
+	oc := o.(*consumerFileStore)
+	// Wait for flusher to be running.
+	checkFor(t, time.Second, 20*time.Millisecond, func() error {
+		if !oc.inFlusher() {
+			return fmt.Errorf("Flusher not running")
+		}
+		return nil
+	})
+	// Stop and make sure the flusher goes away
+	o.Stop()
+	// Wait for flusher to stop.
+	checkFor(t, time.Second, 20*time.Millisecond, func() error {
+		if oc.inFlusher() {
+			return fmt.Errorf("Flusher still running")
+		}
+		return nil
+	})
+}
+
+func TestFileStoreConsumerDeliveredUpdates(t *testing.T) {
+	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	os.MkdirAll(storeDir, 0755)
+	defer os.RemoveAll(storeDir)
+
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer fs.Stop()
+
+	// Simple consumer, no ack policy configured.
+	o, err := fs.ConsumerStore("o22", &ConsumerConfig{})
+	if err != nil {
+		t.Fatalf("Unexepected error: %v", err)
+	}
+	defer o.Stop()
+
+	testDelivered := func(dseq, sseq uint64) {
+		t.Helper()
+		ts := time.Now().UnixNano()
+		if err := o.UpdateDelivered(dseq, sseq, 1, ts); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		state, err := o.State()
+		if err != nil {
+			t.Fatalf("Error getting state: %v", err)
+		}
+		if state == nil {
+			t.Fatalf("No state available")
+		}
+		expected := SequencePair{dseq, sseq}
+		if state.Delivered != expected {
+			t.Fatalf("Unexpected state, wanted %+v, got %+v", expected, state.Delivered)
+		}
+		if state.AckFloor != expected {
+			t.Fatalf("Unexpected ack floor state, wanted %+v, got %+v", expected, state.AckFloor)
+		}
+		if len(state.Pending) != 0 {
+			t.Fatalf("Did not expect any pending, got %d pending", len(state.Pending))
+		}
+	}
+
+	testDelivered(1, 100)
+	testDelivered(2, 110)
+	testDelivered(5, 130)
+
+	// If we try to do an ack this should err since we are not configured with ack policy.
+	if err := o.UpdateAcks(1, 100); err != ErrNoAckPolicy {
+		t.Fatalf("Expected a no ack policy error on update acks, got %v", err)
+	}
+	// Also if we do an update with a delivery count of anything but 1 here should also give same error.
+	ts := time.Now().UnixNano()
+	if err := o.UpdateDelivered(5, 130, 2, ts); err != ErrNoAckPolicy {
+		t.Fatalf("Expected a no ack policy error on update delivered with dc > 1, got %v", err)
+	}
+}
+
+func TestFileStoreConsumerDeliveredAndAckUpdates(t *testing.T) {
+	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	os.MkdirAll(storeDir, 0755)
+	defer os.RemoveAll(storeDir)
+
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer fs.Stop()
+
+	// Simple consumer, no ack policy configured.
+	o, err := fs.ConsumerStore("o22", &ConsumerConfig{AckPolicy: AckExplicit})
+	if err != nil {
+		t.Fatalf("Unexepected error: %v", err)
+	}
+	defer o.Stop()
+
+	// Track pending.
+	var pending int
+
+	testDelivered := func(dseq, sseq uint64) {
+		t.Helper()
+		ts := time.Now().Round(time.Second).UnixNano()
+		if err := o.UpdateDelivered(dseq, sseq, 1, ts); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		pending++
+		state, err := o.State()
+		if err != nil {
+			t.Fatalf("Error getting state: %v", err)
+		}
+		if state == nil {
+			t.Fatalf("No state available")
+		}
+		expected := SequencePair{dseq, sseq}
+		if state.Delivered != expected {
+			t.Fatalf("Unexpected delivered state, wanted %+v, got %+v", expected, state.Delivered)
+		}
+		if len(state.Pending) != pending {
+			t.Fatalf("Expected %d pending, got %d pending", pending, len(state.Pending))
+		}
+	}
+
+	testDelivered(1, 100)
+	testDelivered(2, 110)
+	testDelivered(3, 130)
+	testDelivered(4, 150)
+	testDelivered(5, 165)
+
+	testBadAck := func(dseq, sseq uint64) {
+		t.Helper()
+		if err := o.UpdateAcks(dseq, sseq); err == nil {
+			t.Fatalf("Expected error but got none")
+		}
+	}
+	testBadAck(3, 101)
+	testBadAck(1, 1)
+
+	testAck := func(dseq, sseq, dflr, sflr uint64) {
+		t.Helper()
+		if err := o.UpdateAcks(dseq, sseq); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		pending--
+		state, err := o.State()
+		if err != nil {
+			t.Fatalf("Error getting state: %v", err)
+		}
+		if state == nil {
+			t.Fatalf("No state available")
+		}
+		if len(state.Pending) != pending {
+			t.Fatalf("Expected %d pending, got %d pending", pending, len(state.Pending))
+		}
+		eflr := SequencePair{dflr, sflr}
+		if state.AckFloor != eflr {
+			t.Fatalf("Unexpected ack floor state, wanted %+v, got %+v", eflr, state.AckFloor)
+		}
+	}
+
+	testAck(1, 100, 1, 100)
+	testAck(3, 130, 1, 100)
+	testAck(2, 110, 3, 149) // We do not track explicit state on previous stream floors, so we take last known -1
+	testAck(5, 165, 3, 149)
+	testAck(4, 150, 5, 165)
+
+	testDelivered(6, 170)
+	testDelivered(7, 171)
+	testDelivered(8, 172)
+	testDelivered(9, 173)
+	testDelivered(10, 200)
+
+	testAck(7, 171, 5, 165)
+	testAck(8, 172, 5, 165)
+
+	state, err := o.State()
+	if err != nil {
+		t.Fatalf("Unexpected error getting state: %v", err)
+	}
+	o.Stop()
+
+	o, err = fs.ConsumerStore("o22", &ConsumerConfig{AckPolicy: AckExplicit})
+	if err != nil {
+		t.Fatalf("Unexepected error: %v", err)
+	}
+	defer o.Stop()
+
+	nstate, err := o.State()
+	if err != nil {
+		t.Fatalf("Unexpected error getting state: %v", err)
+	}
+	if !reflect.DeepEqual(nstate, state) {
+		t.Fatalf("States don't match!")
+	}
+}
+
+func TestFileStoreConsumerPerf(t *testing.T) {
+	// Comment out to run, holding place for now.
+	t.SkipNow()
+
+	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	os.MkdirAll(storeDir, 0755)
+	defer os.RemoveAll(storeDir)
+
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer fs.Stop()
+
+	o, err := fs.ConsumerStore("o22", &ConsumerConfig{AckPolicy: AckExplicit})
+	if err != nil {
+		t.Fatalf("Unexepected error: %v", err)
+	}
+	// Get the underlying impl.
+	oc := o.(*consumerFileStore)
+	// Wait for flusher to br running
+	checkFor(t, time.Second, 20*time.Millisecond, func() error {
+		if !oc.inFlusher() {
+			return fmt.Errorf("not in flusher")
+		}
+		return nil
+	})
+
+	// Stop flusher for this benchmark since we will invoke directly.
+	oc.mu.Lock()
+	qch := oc.qch
+	oc.qch = nil
+	oc.mu.Unlock()
+	close(qch)
+
+	checkFor(t, time.Second, 20*time.Millisecond, func() error {
+		if oc.inFlusher() {
+			return fmt.Errorf("still in flusher")
+		}
+		return nil
+	})
+
+	toStore := uint64(1_000_000)
 
 	start := time.Now()
+
+	ts := start.UnixNano()
+
 	for i := uint64(1); i <= toStore; i++ {
-		state.Delivered.ConsumerSeq = i
-		state.Delivered.StreamSeq = i
-		state.AckFloor.ConsumerSeq = i
-		state.AckFloor.StreamSeq = i
-		if err := o.Update(state); err != nil {
-			t.Fatalf("Unexepected error updating state: %v", err)
+		if err := o.UpdateDelivered(i, i, 1, ts); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
 		}
 	}
 	tt := time.Since(start)
-	fmt.Printf("time is %v\n", tt)
+	fmt.Printf("time to update %d is %v\n", toStore, tt)
 	fmt.Printf("%.0f updates/sec\n", float64(toStore)/tt.Seconds())
-
-	// We will lag behind with pending.
-	state.Pending = make(map[uint64]int64)
-	lag := uint64(100)
-	state.AckFloor.ConsumerSeq = 0
-	state.AckFloor.StreamSeq = 0
-
-	fmt.Printf("\nconsumer of %d msgs for ACK EXPLICIT with pending lag of %d\n", toStore, lag)
 
 	start = time.Now()
-	for i := uint64(1); i <= toStore; i++ {
-		state.Delivered.ConsumerSeq = i
-		state.Delivered.StreamSeq = i
-		state.Pending[i] = time.Now().UnixNano()
-		if i > lag {
-			ackseq := i - lag
-			state.AckFloor.ConsumerSeq = ackseq
-			state.AckFloor.StreamSeq = ackseq
-			delete(state.Pending, ackseq)
-		}
-		if err := o.Update(state); err != nil {
-			t.Fatalf("Unexepected error updating state: %v", err)
-		}
+	oc.mu.Lock()
+	buf, err := oc.encodeState()
+	oc.mu.Unlock()
+	if err != nil {
+		t.Fatalf("Error encoding state: %v", err)
 	}
-	tt = time.Since(start)
-	fmt.Printf("time is %v\n", tt)
-	fmt.Printf("%.0f updates/sec\n", float64(toStore)/tt.Seconds())
+	fmt.Printf("time to encode %d bytes is %v\n", len(buf), time.Since(start))
+	start = time.Now()
+	oc.writeState(buf)
+	fmt.Printf("time to write is %v\n", time.Since(start))
+	start = time.Now()
+	oc.syncStateFile()
+	fmt.Printf("time to sync is %v\n", time.Since(start))
 }

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -533,7 +533,7 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 		stats := mset.State()
 		s.Noticef("  Restored %s messages for Stream %q", comma(int64(stats.Msgs)), fi.Name())
 
-		// Now do Consumers.
+		// Now do the consumers.
 		odir := path.Join(sdir, fi.Name(), consumerDir)
 		ofis, _ := ioutil.ReadDir(odir)
 		if len(ofis) > 0 {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -435,9 +435,12 @@ func (ms *memStore) Snapshot(_ time.Duration, _, _ bool) (*SnapshotResult, error
 }
 
 // No-ops.
-func (os *consumerMemStore) Update(_ *ConsumerState) error {
-	return nil
-}
+func (os *consumerMemStore) Update(_ *ConsumerState) error { return nil }
+
+func (os *consumerMemStore) UpdateDelivered(_, _, _ uint64, _ int64) error { return nil }
+
+func (os *consumerMemStore) UpdateAcks(_, _ uint64) error { return nil }
+
 func (os *consumerMemStore) Stop() error {
 	os.ms.decConsumers()
 	return nil

--- a/server/stream.go
+++ b/server/stream.go
@@ -1335,16 +1335,7 @@ func (mset *Stream) Snapshot(deadline time.Duration, checkMsgs, includeConsumers
 		return nil, fmt.Errorf("invalid stream")
 	}
 	store := mset.store
-	var obs []*Consumer
-	for _, o := range mset.consumers {
-		obs = append(obs, o)
-	}
 	mset.mu.Unlock()
-
-	// Make sure to sync their state.
-	for _, o := range obs {
-		o.writeState()
-	}
 
 	return store.Snapshot(deadline, checkMsgs, includeConsumers)
 }


### PR DESCRIPTION
Updates to index cache handling for message blocks.
    
We can have partial caches and we can also remove the idx cache. This was causing a bug where we would get the wrong slotInfo from the cache.idx. This code fixes the bug and detects idx partials.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
