### PR TITLE
Fix bug when removing the same message from a stream.

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1922,6 +1922,8 @@ func TestFileStoreStoreLimitRemovePerf(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
+	fs.RegisterStorageUpdates(func(md, bd int64, seq uint64, subj string) {})
+
 	fmt.Printf("storing and removing (limit 1) %d msgs of %s each, totalling %s\n",
 		toStore,
 		FriendlyBytes(int64(storedMsgSize)),

--- a/server/store.go
+++ b/server/store.go
@@ -56,6 +56,10 @@ var (
 	ErrNoAckPolicy = errors.New("ack policy is none")
 )
 
+// Used to call back into the upper layers to report on changes in storage resources.
+// For the cases where its a single message we will also supply sequence number and subject.
+type StorageUpdateHandler func(msgs, bytes int64, seq uint64, subj string)
+
 type StreamStore interface {
 	StoreMsg(subj string, hdr, msg []byte) (uint64, int64, error)
 	SkipMsg() uint64
@@ -65,7 +69,7 @@ type StreamStore interface {
 	Purge() uint64
 	GetSeqFromTime(t time.Time) uint64
 	State() StreamState
-	RegisterStorageUpdates(func(int64, int64, uint64))
+	RegisterStorageUpdates(StorageUpdateHandler)
 	UpdateConfig(cfg *StreamConfig) error
 	Delete() error
 	Stop() error

--- a/test/jetstream_test.go
+++ b/test/jetstream_test.go
@@ -8942,8 +8942,12 @@ func TestJetStreamAckExplicitMsgRemoval(t *testing.T) {
 				}
 			}
 			// To make sure acks are processed for checking state after sending new ones.
-			nc1.Flush()
-			nc2.Flush()
+			checkFor(t, time.Second, 25*time.Millisecond, func() error {
+				if state = mset.State(); state.Msgs != 0 {
+					return fmt.Errorf("Stream still has messages")
+				}
+				return nil
+			})
 
 			// Now close the 2nd subscription...
 			sub2.Unsubscribe()


### PR DESCRIPTION
We would release locks and call into upper layers when removing a message.
The upper layers may call back into the lower layers to get more information, such as the subject.
This fix has the storage updates optionally supply the subject for filtered consumers and fixes the bug of double deletes.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
