### PR TITLE
Allow stream lookup by subject.

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -169,6 +169,15 @@ var (
 
 	// ErrNoTransforms signals no subject transforms are available to map this subject.
 	ErrNoTransforms = errors.New("no matching transforms available")
+
+	// ErrJetStreamNotEnabled is returned when JetStream is not enabled.
+	ErrJetStreamNotEnabled = errors.New("jetstream not enabled")
+
+	// ErrJetStreamStreamNotFound is returned when a stream can not be found.
+	ErrJetStreamStreamNotFound = errors.New("stream not found")
+
+	// ErrJetStreamNotEnabledForAccount is returned JetStream is not enabled for this account.
+	ErrJetStreamNotEnabledForAccount = errors.New("jetstream not enabled for account")
 )
 
 // configErr is a configuration error.

--- a/server/stream.go
+++ b/server/stream.go
@@ -491,7 +491,7 @@ func (mset *Stream) Delete() error {
 	jsa := mset.jsa
 	mset.mu.Unlock()
 	if jsa == nil {
-		return fmt.Errorf("jetstream not enabled for account")
+		return ErrJetStreamNotEnabledForAccount
 	}
 	jsa.mu.Lock()
 	delete(jsa.streams, mset.config.Name)


### PR DESCRIPTION
Allow an API endpoint and public API to lookup a stream by subject. The subject needs to be an exact match or a subset. If the subject is considered a filtered subject for the stream that will also be returned.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
