### PR TITLE
Only fetch account jwt if the name is a proper public account key

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3125,7 +3125,7 @@ func buildInternalNkeyUser(uc *jwt.UserClaims, acts map[string]struct{}, acc *Ac
 
 const fetchTimeout = 2 * time.Second
 
-func FetchAccount(res AccountResolver, name string) (string, error) {
+func fetchAccount(res AccountResolver, name string) (string, error) {
 	if !nkeys.IsValidPublicAccountKey(name) {
 		return "", fmt.Errorf("will only fetch valid account keys")
 	}

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3125,6 +3125,13 @@ func buildInternalNkeyUser(uc *jwt.UserClaims, acts map[string]struct{}, acc *Ac
 
 const fetchTimeout = 2 * time.Second
 
+func FetchAccount(res AccountResolver, name string) (string, error) {
+	if !nkeys.IsValidPublicAccountKey(name) {
+		return "", fmt.Errorf("will only fetch valid account keys")
+	}
+	return res.Fetch(name)
+}
+
 // AccountResolver interface. This is to fetch Account JWTs by public nkeys
 type AccountResolver interface {
 	Fetch(name string) (string, error)

--- a/server/server.go
+++ b/server/server.go
@@ -397,7 +397,7 @@ func NewServer(opts *Options) (*Server, error) {
 			s.mu.Unlock()
 			var a *Account
 			// perform direct lookup to avoid warning trace
-			if _, err := FetchAccount(ar, s.opts.SystemAccount); err == nil {
+			if _, err := fetchAccount(ar, s.opts.SystemAccount); err == nil {
 				a, _ = s.fetchAccount(s.opts.SystemAccount)
 			}
 			s.mu.Lock()
@@ -1284,7 +1284,7 @@ func (s *Server) fetchRawAccountClaims(name string) (string, error) {
 	}
 	// Need to do actual Fetch
 	start := time.Now()
-	claimJWT, err := FetchAccount(accResolver, name)
+	claimJWT, err := fetchAccount(accResolver, name)
 	fetchTime := time.Since(start)
 	if fetchTime > time.Second {
 		s.Warnf("Account [%s] fetch took %v", name, fetchTime)
@@ -1452,7 +1452,7 @@ func (s *Server) Start() {
 						case <-s.quitCh:
 							return
 						case <-t.C:
-							if _, err := FetchAccount(ar, s.opts.SystemAccount); err != nil {
+							if _, err := fetchAccount(ar, s.opts.SystemAccount); err != nil {
 								continue
 							}
 							if _, err := s.fetchAccount(s.opts.SystemAccount); err != nil {


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

This only cuts down on obviously bad requests that would have otherwise resulted in failures/timeouts on the receiving end

