### PR TITLE
Rename reject_unknown to reject_unknown_cluster

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1065,7 +1065,7 @@ type GatewayOptsVarz struct {
 	Advertise      string                  `json:"advertise,omitempty"`
 	ConnectRetries int                     `json:"connect_retries,omitempty"`
 	Gateways       []RemoteGatewayOptsVarz `json:"gateways,omitempty"`
-	RejectUnknown  bool                    `json:"reject_unknown,omitempty"`
+	RejectUnknown  bool                    `json:"reject_unknown,omitempty"` // config got renamed to reject_unknown_cluster
 }
 
 // RemoteGatewayOptsVarz contains monitoring remote gateway information

--- a/server/opts.go
+++ b/server/opts.go
@@ -92,7 +92,7 @@ type GatewayOpts struct {
 	Advertise      string               `json:"advertise,omitempty"`
 	ConnectRetries int                  `json:"connect_retries,omitempty"`
 	Gateways       []*RemoteGatewayOpts `json:"gateways,omitempty"`
-	RejectUnknown  bool                 `json:"reject_unknown,omitempty"`
+	RejectUnknown  bool                 `json:"reject_unknown,omitempty"` // config got renamed to reject_unknown_cluster
 
 	// Not exported, for tests.
 	resolver         netResolver
@@ -1285,7 +1285,7 @@ func parseGateway(v interface{}, o *Options, errors *[]error, warnings *[]error)
 				return err
 			}
 			o.Gateway.Gateways = gateways
-		case "reject_unknown":
+		case "reject_unknown", "reject_unknown_cluster":
 			o.Gateway.RejectUnknown = mv.(bool)
 		default:
 			if !tk.IsUsedVariable() {

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -1859,6 +1859,7 @@ func TestParsingGateways(t *testing.T) {
 		listen: "127.0.0.1:4444"
 		host: "127.0.0.1"
 		port: 4444
+		reject_unknown_cluster: true
 		authorization {
 			user: "ivan"
 			password: "pwd"
@@ -1903,6 +1904,7 @@ func TestParsingGateways(t *testing.T) {
 		Advertise:      "me:1",
 		ConnectRetries: 10,
 		TLSTimeout:     3.0,
+		RejectUnknown:  true,
 	}
 	u1, _ := url.Parse("nats://user1:pwd1@host2:5222")
 	u2, _ := url.Parse("nats://user1:pwd1@host3:6222")
@@ -1969,7 +1971,7 @@ func TestParsingGatewaysErrors(t *testing.T) {
 			`gateway {
 				name: "A"
 				port: -1
-				reject_unknown: true
+				reject_unknown_cluster: true
 				unknown_field: 1
 			}`,
 			"unknown field",


### PR DESCRIPTION
this is supposed to make it clearer what is being rejected

Signed-off-by: Matthias Hanel <mh@synadia.com>
