### PR TITLE
[ADDED] verify_cert_and_check_known_urls to tie subject alt name to url in cfg

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -808,12 +808,12 @@ func (s *Server) isRouterAuthorized(c *client) bool {
 		return s.opts.CustomRouterAuthentication.Check(c)
 	}
 
-	if opts.Cluster.TLSMap || opts.Cluster.TLSAcceptKnownUrls {
+	if opts.Cluster.TLSMap || opts.Cluster.TLSCheckKnwonURLs {
 		return checkClientTLSCertSubject(c, func(user string, _ *ldap.DN, isDNSAltName bool) (string, bool) {
 			if user == "" {
 				return "", false
 			}
-			if opts.Cluster.TLSAcceptKnownUrls && isDNSAltName {
+			if opts.Cluster.TLSCheckKnwonURLs && isDNSAltName {
 				if dnsAltNameMatches(dnsAltNameLabels(user), opts.Routes) {
 					return "", true
 				}
@@ -844,12 +844,12 @@ func (s *Server) isGatewayAuthorized(c *client) bool {
 	opts := s.getOpts()
 
 	// Check whether TLS map is enabled, otherwise use single user/pass.
-	if opts.Gateway.TLSMap || opts.Gateway.TLSAcceptKnownUrls {
+	if opts.Gateway.TLSMap || opts.Gateway.TLSCheckKnownURLs {
 		return checkClientTLSCertSubject(c, func(user string, _ *ldap.DN, isDNSAltName bool) (string, bool) {
 			if user == "" {
 				return "", false
 			}
-			if opts.Gateway.TLSAcceptKnownUrls && isDNSAltName {
+			if opts.Gateway.TLSCheckKnownURLs && isDNSAltName {
 				labels := dnsAltNameLabels(user)
 				for _, gw := range opts.Gateway.Gateways {
 					if gw != nil && dnsAltNameMatches(labels, gw.URLs) {

--- a/server/auth.go
+++ b/server/auth.go
@@ -808,12 +808,11 @@ func (s *Server) isRouterAuthorized(c *client) bool {
 		return s.opts.CustomRouterAuthentication.Check(c)
 	}
 
-	if opts.Cluster.Username == "" {
-		return true
-	}
-
 	if opts.Cluster.TLSMap || opts.Cluster.TLSImplicitAllow {
 		return checkClientTLSCertSubject(c, func(user string, _ *ldap.DN, isDNSAltName bool) (string, bool) {
+			if user == "" {
+				return "", false
+			}
 			if opts.Cluster.TLSImplicitAllow && isDNSAltName {
 				if dnsAltNameMatches(dnsAltNameLabels(user), opts.Routes) {
 					return "", true
@@ -824,6 +823,10 @@ func (s *Server) isRouterAuthorized(c *client) bool {
 			}
 			return "", false
 		})
+	}
+
+	if opts.Cluster.Username == "" {
+		return true
 	}
 
 	if opts.Cluster.Username != c.opts.Username {
@@ -839,9 +842,6 @@ func (s *Server) isRouterAuthorized(c *client) bool {
 func (s *Server) isGatewayAuthorized(c *client) bool {
 	// Snapshot server options.
 	opts := s.getOpts()
-	if opts.Gateway.Username == "" {
-		return true
-	}
 
 	// Check whether TLS map is enabled, otherwise use single user/pass.
 	if opts.Gateway.TLSMap || opts.Gateway.TLSImplicitAllow {
@@ -862,6 +862,10 @@ func (s *Server) isGatewayAuthorized(c *client) bool {
 			}
 			return "", false
 		})
+	}
+
+	if opts.Gateway.Username == "" {
+		return true
 	}
 
 	if opts.Gateway.Username != c.opts.Username {

--- a/server/auth.go
+++ b/server/auth.go
@@ -777,8 +777,8 @@ URLS:
 			continue URLS
 		}
 		hostLabels := strings.Split(strings.ToLower(url.Hostname()), ".")
-		// following https://tools.ietf.org/html/rfc6125#section-6.4.3, should not => will not, may => will not
-		// wilcard does not match multiple labels
+		// Following https://tools.ietf.org/html/rfc6125#section-6.4.3, should not => will not, may => will not
+		// The wilcard * never matches multiple label and only matches the left most label.
 		if len(hostLabels) != len(dnsAltNameLabels) {
 			continue URLS
 		}
@@ -808,12 +808,12 @@ func (s *Server) isRouterAuthorized(c *client) bool {
 		return s.opts.CustomRouterAuthentication.Check(c)
 	}
 
-	if opts.Cluster.TLSMap || opts.Cluster.TLSImplicitAllow {
+	if opts.Cluster.TLSMap || opts.Cluster.TLSAcceptKnownUrls {
 		return checkClientTLSCertSubject(c, func(user string, _ *ldap.DN, isDNSAltName bool) (string, bool) {
 			if user == "" {
 				return "", false
 			}
-			if opts.Cluster.TLSImplicitAllow && isDNSAltName {
+			if opts.Cluster.TLSAcceptKnownUrls && isDNSAltName {
 				if dnsAltNameMatches(dnsAltNameLabels(user), opts.Routes) {
 					return "", true
 				}
@@ -844,12 +844,12 @@ func (s *Server) isGatewayAuthorized(c *client) bool {
 	opts := s.getOpts()
 
 	// Check whether TLS map is enabled, otherwise use single user/pass.
-	if opts.Gateway.TLSMap || opts.Gateway.TLSImplicitAllow {
+	if opts.Gateway.TLSMap || opts.Gateway.TLSAcceptKnownUrls {
 		return checkClientTLSCertSubject(c, func(user string, _ *ldap.DN, isDNSAltName bool) (string, bool) {
 			if user == "" {
 				return "", false
 			}
-			if opts.Gateway.TLSImplicitAllow && isDNSAltName {
+			if opts.Gateway.TLSAcceptKnownUrls && isDNSAltName {
 				labels := dnsAltNameLabels(user)
 				for _, gw := range opts.Gateway.Gateways {
 					if gw != nil && dnsAltNameMatches(labels, gw.URLs) {

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -14,6 +14,7 @@
 package server
 
 import (
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -151,6 +152,63 @@ func TestUserUnknownAllowedConnectionType(t *testing.T) {
 	for act := range nkey.AllowedConnectionTypes {
 		if act != jwt.ConnectionTypeWebsocket {
 			t.Fatalf("Expected map to have been updated with proper case, got %v", act)
+		}
+	}
+}
+
+func TestDNSAltNameMatching(t *testing.T) {
+	for idx, test := range []struct {
+		altName string
+		urls    []string
+		match   bool
+	}{
+		{"foo", []string{"FOO"}, true},
+		{"foo", []string{".."}, false},
+		{"foo", []string{"."}, false},
+		{"Foo", []string{"foO"}, true},
+		{"FOO", []string{"foo"}, true},
+		{"foo1", []string{"bar"}, false},
+		{"multi", []string{"m", "mu", "mul", "multi"}, true},
+		{"multi", []string{"multi", "m", "mu", "mul"}, true},
+		{"foo.bar", []string{"foo", "foo.bar.bar", "foo.baz"}, false},
+		{"foo.Bar", []string{"foo", "bar.foo", "Foo.Bar"}, true},
+		{"foo.*", []string{"foo", "bar.foo", "Foo.Bar"}, false}, // only match left most
+		{"f*.bar", []string{"foo", "bar.foo", "Foo.Bar"}, false},
+		{"*.bar", []string{"foo.bar"}, true},
+		{"*", []string{"baz.bar", "bar", "z.y"}, true},
+		{"*", []string{"bar"}, true},
+		{"*", []string{"."}, false},
+		{"*", []string{""}, true},
+		{"*", []string{"*"}, true},
+		{"bar.*", []string{"bar.*"}, true},
+		{"*.Y-X-red-mgmt.default.svc", []string{"A.Y-X-red-mgmt.default.svc"}, true},
+		{"*.Y-X-green-mgmt.default.svc", []string{"A.Y-X-green-mgmt.default.svc"}, true},
+		{"*.Y-X-blue-mgmt.default.svc", []string{"A.Y-X-blue-mgmt.default.svc"}, true},
+		{"Y-X-red-mgmt", []string{"Y-X-red-mgmt"}, true},
+		{"Y-X-red-mgmt", []string{"X-X-red-mgmt"}, false},
+		{"Y-X-red-mgmt", []string{"Y-X-green-mgmt"}, false},
+		{"Y-X-red-mgmt", []string{"Y"}, false},
+		{"Y-X-red-mgmt", []string{"Y-X"}, false},
+		{"Y-X-red-mgmt", []string{"Y-X-red"}, false},
+		{"Y-X-red-mgmt", []string{"X-red-mgmt"}, false},
+		{"Y-X-green-mgmt", []string{"Y-X-green-mgmt"}, true},
+		{"Y-X-blue-mgmt", []string{"Y-X-blue-mgmt"}, true},
+		{"connect.Y.local", []string{"connect.Y.local"}, true},
+		{"connect.Y.local", []string{".Y.local"}, false},
+		{"connect.Y.local", []string{"..local"}, false},
+		{"gcp.Y.local", []string{"gcp.Y.local"}, true},
+		{"uswest1.gcp.Y.local", []string{"uswest1.gcp.Y.local"}, true},
+	} {
+		urlSet := make([]*url.URL, len(test.urls))
+		for i, u := range test.urls {
+			var err error
+			urlSet[i], err = url.Parse("nats://" + u)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if dnsAltNameMatches(dnsAltNameLabels(test.altName), urlSet) != test.match {
+			t.Fatal("Test", idx, "Match miss match, expected:", test.match)
 		}
 	}
 }

--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -361,15 +361,15 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  5,
 		},
 		{
-			name: "verify_and_implicit_allow not support for clients",
+			name: "verify_and_accept_known_urls not support for clients",
 			config: `
 		tls = {
 						cert_file: "configs/certs/server.pem"
 						key_file: "configs/certs/key.pem"
-					    verify_and_implicit_allow: true
+					    verify_and_accept_known_urls: true
 		}
 		`,
-			err:       errors.New("verify_and_implicit_allow not supported in this context"),
+			err:       errors.New("verify_and_accept_known_urls not supported in this context"),
 			errorLine: 5,
 			errorPos:  10,
 		},
@@ -1154,7 +1154,7 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  0,
 		},
 		{
-			name: "verify_and_implicit_allow do not work for leaf nodes",
+			name: "verify_and_accept_known_urls do not work for leaf nodes",
 			config: `
 		leafnodes {
 		  remotes = [
@@ -1162,13 +1162,13 @@ func TestConfigCheck(t *testing.T) {
 		      url: "tls://nats:7422"
 		      tls {
 		        timeout: 0.01
-				verify_and_implicit_allow: true
+				verify_and_accept_known_urls: true
 		      }
 		    }
 		  ]
 		}`,
 			//Unexpected error after processing config: /var/folders/9h/6g_c9l6n6bb8gp331d_9y0_w0000gn/T/057996446:8:5:
-			err:       errors.New("verify_and_implicit_allow not supported in this context"),
+			err:       errors.New("verify_and_accept_known_urls not supported in this context"),
 			errorLine: 8,
 			errorPos:  5,
 		},
@@ -1393,17 +1393,17 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  21,
 		},
 		{
-			name: "verify_and_implicit_allow not support for websockets",
+			name: "verify_and_accept_known_urls not support for websockets",
 			config: `
 				websocket {
                     tls {
 						cert_file: "configs/certs/server.pem"
 						key_file: "configs/certs/key.pem"
-					    verify_and_implicit_allow: true
+					    verify_and_accept_known_urls: true
 					}
 				}
 			`,
-			err:       fmt.Errorf("verify_and_implicit_allow not supported in this context"),
+			err:       fmt.Errorf("verify_and_accept_known_urls not supported in this context"),
 			errorLine: 6,
 			errorPos:  10,
 		},

--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -361,15 +361,15 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  5,
 		},
 		{
-			name: "verify_and_accept_known_urls not support for clients",
+			name: "verify_cert_and_check_known_urls not support for clients",
 			config: `
 		tls = {
 						cert_file: "configs/certs/server.pem"
 						key_file: "configs/certs/key.pem"
-					    verify_and_accept_known_urls: true
+					    verify_cert_and_check_known_urls: true
 		}
 		`,
-			err:       errors.New("verify_and_accept_known_urls not supported in this context"),
+			err:       errors.New("verify_cert_and_check_known_urls not supported in this context"),
 			errorLine: 5,
 			errorPos:  10,
 		},
@@ -1154,7 +1154,7 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  0,
 		},
 		{
-			name: "verify_and_accept_known_urls do not work for leaf nodes",
+			name: "verify_cert_and_check_known_urls do not work for leaf nodes",
 			config: `
 		leafnodes {
 		  remotes = [
@@ -1162,13 +1162,13 @@ func TestConfigCheck(t *testing.T) {
 		      url: "tls://nats:7422"
 		      tls {
 		        timeout: 0.01
-				verify_and_accept_known_urls: true
+				verify_cert_and_check_known_urls: true
 		      }
 		    }
 		  ]
 		}`,
 			//Unexpected error after processing config: /var/folders/9h/6g_c9l6n6bb8gp331d_9y0_w0000gn/T/057996446:8:5:
-			err:       errors.New("verify_and_accept_known_urls not supported in this context"),
+			err:       errors.New("verify_cert_and_check_known_urls not supported in this context"),
 			errorLine: 8,
 			errorPos:  5,
 		},
@@ -1393,17 +1393,17 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  21,
 		},
 		{
-			name: "verify_and_accept_known_urls not support for websockets",
+			name: "verify_cert_and_check_known_urls not support for websockets",
 			config: `
 				websocket {
                     tls {
 						cert_file: "configs/certs/server.pem"
 						key_file: "configs/certs/key.pem"
-					    verify_and_accept_known_urls: true
+					    verify_cert_and_check_known_urls: true
 					}
 				}
 			`,
-			err:       fmt.Errorf("verify_and_accept_known_urls not supported in this context"),
+			err:       fmt.Errorf("verify_cert_and_check_known_urls not supported in this context"),
 			errorLine: 6,
 			errorPos:  10,
 		},

--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -361,6 +361,19 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  5,
 		},
 		{
+			name: "verify_and_implicit_allow not support for clients",
+			config: `
+		tls = {
+						cert_file: "configs/certs/server.pem"
+						key_file: "configs/certs/key.pem"
+					    verify_and_implicit_allow: true
+		}
+		`,
+			err:       errors.New("verify_and_implicit_allow not supported in this context"),
+			errorLine: 5,
+			errorPos:  10,
+		},
+		{
 			name: "when unknown option is in cluster config with defined routes",
 			config: `
 		cluster {
@@ -1141,6 +1154,25 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  0,
 		},
 		{
+			name: "verify_and_implicit_allow do not work for leaf nodes",
+			config: `
+		leafnodes {
+		  remotes = [
+		    {
+		      url: "tls://nats:7422"
+		      tls {
+		        timeout: 0.01
+				verify_and_implicit_allow: true
+		      }
+		    }
+		  ]
+		}`,
+			//Unexpected error after processing config: /var/folders/9h/6g_c9l6n6bb8gp331d_9y0_w0000gn/T/057996446:8:5:
+			err:       errors.New("verify_and_implicit_allow not supported in this context"),
+			errorLine: 8,
+			errorPos:  5,
+		},
+		{
 			name: "when leafnode remotes use wrong type",
 			config: `
 		leafnodes {
@@ -1359,6 +1391,21 @@ func TestConfigCheck(t *testing.T) {
 			err:       fmt.Errorf("missing 'key_file' in TLS configuration"),
 			errorLine: 3,
 			errorPos:  21,
+		},
+		{
+			name: "verify_and_implicit_allow not support for websockets",
+			config: `
+				websocket {
+                    tls {
+						cert_file: "configs/certs/server.pem"
+						key_file: "configs/certs/key.pem"
+					    verify_and_implicit_allow: true
+					}
+				}
+			`,
+			err:       fmt.Errorf("verify_and_implicit_allow not supported in this context"),
+			errorLine: 6,
+			errorPos:  10,
 		},
 	}
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -57,21 +57,21 @@ func NoErrOnUnknownFields(noError bool) {
 // NOTE: This structure is no longer used for monitoring endpoints
 // and json tags are deprecated and may be removed in the future.
 type ClusterOpts struct {
-	Name             string            `json:"-"`
-	Host             string            `json:"addr,omitempty"`
-	Port             int               `json:"cluster_port,omitempty"`
-	Username         string            `json:"-"`
-	Password         string            `json:"-"`
-	AuthTimeout      float64           `json:"auth_timeout,omitempty"`
-	Permissions      *RoutePermissions `json:"-"`
-	TLSTimeout       float64           `json:"-"`
-	TLSConfig        *tls.Config       `json:"-"`
-	TLSMap           bool              `json:"-"`
-	TLSImplicitAllow bool              `json:"-"`
-	ListenStr        string            `json:"-"`
-	Advertise        string            `json:"-"`
-	NoAdvertise      bool              `json:"-"`
-	ConnectRetries   int               `json:"-"`
+	Name               string            `json:"-"`
+	Host               string            `json:"addr,omitempty"`
+	Port               int               `json:"cluster_port,omitempty"`
+	Username           string            `json:"-"`
+	Password           string            `json:"-"`
+	AuthTimeout        float64           `json:"auth_timeout,omitempty"`
+	Permissions        *RoutePermissions `json:"-"`
+	TLSTimeout         float64           `json:"-"`
+	TLSConfig          *tls.Config       `json:"-"`
+	TLSMap             bool              `json:"-"`
+	TLSAcceptKnownUrls bool              `json:"-"`
+	ListenStr          string            `json:"-"`
+	Advertise          string            `json:"-"`
+	NoAdvertise        bool              `json:"-"`
+	ConnectRetries     int               `json:"-"`
 
 	// Not exported (used in tests)
 	resolver netResolver
@@ -81,20 +81,20 @@ type ClusterOpts struct {
 // NOTE: This structure is no longer used for monitoring endpoints
 // and json tags are deprecated and may be removed in the future.
 type GatewayOpts struct {
-	Name             string               `json:"name"`
-	Host             string               `json:"addr,omitempty"`
-	Port             int                  `json:"port,omitempty"`
-	Username         string               `json:"-"`
-	Password         string               `json:"-"`
-	AuthTimeout      float64              `json:"auth_timeout,omitempty"`
-	TLSConfig        *tls.Config          `json:"-"`
-	TLSTimeout       float64              `json:"tls_timeout,omitempty"`
-	TLSMap           bool                 `json:"-"`
-	TLSImplicitAllow bool                 `json:"-"`
-	Advertise        string               `json:"advertise,omitempty"`
-	ConnectRetries   int                  `json:"connect_retries,omitempty"`
-	Gateways         []*RemoteGatewayOpts `json:"gateways,omitempty"`
-	RejectUnknown    bool                 `json:"reject_unknown,omitempty"` // config got renamed to reject_unknown_cluster
+	Name               string               `json:"name"`
+	Host               string               `json:"addr,omitempty"`
+	Port               int                  `json:"port,omitempty"`
+	Username           string               `json:"-"`
+	Password           string               `json:"-"`
+	AuthTimeout        float64              `json:"auth_timeout,omitempty"`
+	TLSConfig          *tls.Config          `json:"-"`
+	TLSTimeout         float64              `json:"tls_timeout,omitempty"`
+	TLSMap             bool                 `json:"-"`
+	TLSAcceptKnownUrls bool                 `json:"-"`
+	Advertise          string               `json:"advertise,omitempty"`
+	ConnectRetries     int                  `json:"connect_retries,omitempty"`
+	Gateways           []*RemoteGatewayOpts `json:"gateways,omitempty"`
+	RejectUnknown      bool                 `json:"reject_unknown,omitempty"` // config got renamed to reject_unknown_cluster
 
 	// Not exported, for tests.
 	resolver         netResolver
@@ -399,7 +399,7 @@ type TLSConfigOpts struct {
 	Verify           bool
 	Insecure         bool
 	Map              bool
-	ImplicitAllow    bool
+	AcceptKnownUrls  bool
 	Timeout          float64
 	Ciphers          []uint16
 	CurvePreferences []tls.CurveID
@@ -1163,7 +1163,7 @@ func parseCluster(v interface{}, opts *Options, errors *[]error, warnings *[]err
 			opts.Cluster.TLSConfig = config
 			opts.Cluster.TLSTimeout = tlsopts.Timeout
 			opts.Cluster.TLSMap = tlsopts.Map
-			opts.Cluster.TLSImplicitAllow = tlsopts.ImplicitAllow
+			opts.Cluster.TLSAcceptKnownUrls = tlsopts.AcceptKnownUrls
 		case "cluster_advertise", "advertise":
 			opts.Cluster.Advertise = mv.(string)
 		case "no_advertise":
@@ -1279,7 +1279,7 @@ func parseGateway(v interface{}, o *Options, errors *[]error, warnings *[]error)
 			o.Gateway.TLSConfig = config
 			o.Gateway.TLSTimeout = tlsopts.Timeout
 			o.Gateway.TLSMap = tlsopts.Map
-			o.Gateway.TLSImplicitAllow = tlsopts.ImplicitAllow
+			o.Gateway.TLSAcceptKnownUrls = tlsopts.AcceptKnownUrls
 		case "advertise":
 			o.Gateway.Advertise = mv.(string)
 		case "connect_retries":
@@ -3256,18 +3256,22 @@ func parseTLS(v interface{}, isClientCtx bool) (t *TLSConfigOpts, retErr error) 
 			if !ok {
 				return nil, &configErr{tk, "error parsing tls config, expected 'verify_and_map' to be a boolean"}
 			}
-			tc.Verify = verify
+			if verify {
+				tc.Verify = verify
+			}
 			tc.Map = verify
-		case "verify_and_implicit_allow":
+		case "verify_and_accept_known_urls":
 			verify, ok := mv.(bool)
 			if !ok {
-				return nil, &configErr{tk, "error parsing tls config, expected 'verify_and_implicit_allow' to be a boolean"}
+				return nil, &configErr{tk, "error parsing tls config, expected 'verify_and_accept_known_urls' to be a boolean"}
 			}
 			if verify && isClientCtx {
-				return nil, &configErr{tk, "verify_and_implicit_allow not supported in this context"}
+				return nil, &configErr{tk, "verify_and_accept_known_urls not supported in this context"}
 			}
-			tc.Verify = verify
-			tc.ImplicitAllow = verify
+			if verify {
+				tc.Verify = verify
+			}
+			tc.AcceptKnownUrls = verify
 		case "cipher_suites":
 			ra := mv.([]interface{})
 			if len(ra) == 0 {

--- a/server/opts.go
+++ b/server/opts.go
@@ -57,20 +57,21 @@ func NoErrOnUnknownFields(noError bool) {
 // NOTE: This structure is no longer used for monitoring endpoints
 // and json tags are deprecated and may be removed in the future.
 type ClusterOpts struct {
-	Name           string            `json:"-"`
-	Host           string            `json:"addr,omitempty"`
-	Port           int               `json:"cluster_port,omitempty"`
-	Username       string            `json:"-"`
-	Password       string            `json:"-"`
-	AuthTimeout    float64           `json:"auth_timeout,omitempty"`
-	Permissions    *RoutePermissions `json:"-"`
-	TLSTimeout     float64           `json:"-"`
-	TLSConfig      *tls.Config       `json:"-"`
-	TLSMap         bool              `json:"-"`
-	ListenStr      string            `json:"-"`
-	Advertise      string            `json:"-"`
-	NoAdvertise    bool              `json:"-"`
-	ConnectRetries int               `json:"-"`
+	Name             string            `json:"-"`
+	Host             string            `json:"addr,omitempty"`
+	Port             int               `json:"cluster_port,omitempty"`
+	Username         string            `json:"-"`
+	Password         string            `json:"-"`
+	AuthTimeout      float64           `json:"auth_timeout,omitempty"`
+	Permissions      *RoutePermissions `json:"-"`
+	TLSTimeout       float64           `json:"-"`
+	TLSConfig        *tls.Config       `json:"-"`
+	TLSMap           bool              `json:"-"`
+	TLSImplicitAllow bool              `json:"-"`
+	ListenStr        string            `json:"-"`
+	Advertise        string            `json:"-"`
+	NoAdvertise      bool              `json:"-"`
+	ConnectRetries   int               `json:"-"`
 
 	// Not exported (used in tests)
 	resolver netResolver
@@ -80,19 +81,20 @@ type ClusterOpts struct {
 // NOTE: This structure is no longer used for monitoring endpoints
 // and json tags are deprecated and may be removed in the future.
 type GatewayOpts struct {
-	Name           string               `json:"name"`
-	Host           string               `json:"addr,omitempty"`
-	Port           int                  `json:"port,omitempty"`
-	Username       string               `json:"-"`
-	Password       string               `json:"-"`
-	AuthTimeout    float64              `json:"auth_timeout,omitempty"`
-	TLSConfig      *tls.Config          `json:"-"`
-	TLSTimeout     float64              `json:"tls_timeout,omitempty"`
-	TLSMap         bool                 `json:"-"`
-	Advertise      string               `json:"advertise,omitempty"`
-	ConnectRetries int                  `json:"connect_retries,omitempty"`
-	Gateways       []*RemoteGatewayOpts `json:"gateways,omitempty"`
-	RejectUnknown  bool                 `json:"reject_unknown,omitempty"` // config got renamed to reject_unknown_cluster
+	Name             string               `json:"name"`
+	Host             string               `json:"addr,omitempty"`
+	Port             int                  `json:"port,omitempty"`
+	Username         string               `json:"-"`
+	Password         string               `json:"-"`
+	AuthTimeout      float64              `json:"auth_timeout,omitempty"`
+	TLSConfig        *tls.Config          `json:"-"`
+	TLSTimeout       float64              `json:"tls_timeout,omitempty"`
+	TLSMap           bool                 `json:"-"`
+	TLSImplicitAllow bool                 `json:"-"`
+	Advertise        string               `json:"advertise,omitempty"`
+	ConnectRetries   int                  `json:"connect_retries,omitempty"`
+	Gateways         []*RemoteGatewayOpts `json:"gateways,omitempty"`
+	RejectUnknown    bool                 `json:"reject_unknown,omitempty"` // config got renamed to reject_unknown_cluster
 
 	// Not exported, for tests.
 	resolver         netResolver
@@ -397,6 +399,7 @@ type TLSConfigOpts struct {
 	Verify           bool
 	Insecure         bool
 	Map              bool
+	ImplicitAllow    bool
 	Timeout          float64
 	Ciphers          []uint16
 	CurvePreferences []tls.CurveID
@@ -745,7 +748,7 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 	case "ping_max":
 		o.MaxPingsOut = int(v.(int64))
 	case "tls":
-		tc, err := parseTLS(tk)
+		tc, err := parseTLS(tk, true)
 		if err != nil {
 			*errors = append(*errors, err)
 			return
@@ -924,7 +927,7 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 			*errors = append(*errors, err)
 		}
 	case "resolver_tls":
-		tc, err := parseTLS(tk)
+		tc, err := parseTLS(tk, true)
 		if err != nil {
 			*errors = append(*errors, err)
 			return
@@ -1160,6 +1163,7 @@ func parseCluster(v interface{}, opts *Options, errors *[]error, warnings *[]err
 			opts.Cluster.TLSConfig = config
 			opts.Cluster.TLSTimeout = tlsopts.Timeout
 			opts.Cluster.TLSMap = tlsopts.Map
+			opts.Cluster.TLSImplicitAllow = tlsopts.ImplicitAllow
 		case "cluster_advertise", "advertise":
 			opts.Cluster.Advertise = mv.(string)
 		case "no_advertise":
@@ -1275,6 +1279,7 @@ func parseGateway(v interface{}, o *Options, errors *[]error, warnings *[]error)
 			o.Gateway.TLSConfig = config
 			o.Gateway.TLSTimeout = tlsopts.Timeout
 			o.Gateway.TLSMap = tlsopts.Map
+			o.Gateway.TLSImplicitAllow = tlsopts.ImplicitAllow
 		case "advertise":
 			o.Gateway.Advertise = mv.(string)
 		case "connect_retries":
@@ -1481,7 +1486,7 @@ func parseLeafNodes(v interface{}, opts *Options, errors *[]error, warnings *[]e
 		case "reconnect", "reconnect_delay", "reconnect_interval":
 			opts.LeafNode.ReconnectInterval = time.Duration(int(mv.(int64))) * time.Second
 		case "tls":
-			tc, err := parseTLS(tk)
+			tc, err := parseTLS(tk, true)
 			if err != nil {
 				*errors = append(*errors, err)
 				continue
@@ -1678,7 +1683,7 @@ func parseRemoteLeafNodes(v interface{}, errors *[]error, warnings *[]error) ([]
 				}
 				remote.Credentials = p
 			case "tls":
-				tc, err := parseTLS(tk)
+				tc, err := parseTLS(tk, true)
 				if err != nil {
 					*errors = append(*errors, err)
 					continue
@@ -1733,7 +1738,7 @@ func parseRemoteLeafNodes(v interface{}, errors *[]error, warnings *[]error) ([]
 // Parse TLS and returns a TLSConfig and TLSTimeout.
 // Used by cluster and gateway parsing.
 func getTLSConfig(tk token) (*tls.Config, *TLSConfigOpts, error) {
-	tc, err := parseTLS(tk)
+	tc, err := parseTLS(tk, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -3203,7 +3208,7 @@ func parseCurvePreferences(curveName string) (tls.CurveID, error) {
 }
 
 // Helper function to parse TLS configs.
-func parseTLS(v interface{}) (t *TLSConfigOpts, retErr error) {
+func parseTLS(v interface{}, isClientCtx bool) (t *TLSConfigOpts, retErr error) {
 	var (
 		tlsm map[string]interface{}
 		tc   = TLSConfigOpts{}
@@ -3253,6 +3258,16 @@ func parseTLS(v interface{}) (t *TLSConfigOpts, retErr error) {
 			}
 			tc.Verify = verify
 			tc.Map = verify
+		case "verify_and_implicit_allow":
+			verify, ok := mv.(bool)
+			if !ok {
+				return nil, &configErr{tk, "error parsing tls config, expected 'verify_and_map' to be a boolean"}
+			}
+			if verify && isClientCtx {
+				return nil, &configErr{tk, "verify_and_implicit_allow not supported in this context"}
+			}
+			tc.Verify = verify
+			tc.ImplicitAllow = verify
 		case "cipher_suites":
 			ra := mv.([]interface{})
 			if len(ra) == 0 {
@@ -3408,7 +3423,7 @@ func parseWebsocket(v interface{}, o *Options, errors *[]error, warnings *[]erro
 		case "no_tls":
 			o.Websocket.NoTLS = mv.(bool)
 		case "tls":
-			tc, err := parseTLS(tk)
+			tc, err := parseTLS(tk, true)
 			if err != nil {
 				*errors = append(*errors, err)
 				continue

--- a/server/opts.go
+++ b/server/opts.go
@@ -3261,7 +3261,7 @@ func parseTLS(v interface{}, isClientCtx bool) (t *TLSConfigOpts, retErr error) 
 		case "verify_and_implicit_allow":
 			verify, ok := mv.(bool)
 			if !ok {
-				return nil, &configErr{tk, "error parsing tls config, expected 'verify_and_map' to be a boolean"}
+				return nil, &configErr{tk, "error parsing tls config, expected 'verify_and_implicit_allow' to be a boolean"}
 			}
 			if verify && isClientCtx {
 				return nil, &configErr{tk, "verify_and_implicit_allow not supported in this context"}

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -795,25 +795,28 @@ func TestTLSRoutesCertificateImplicitAllowFail(t *testing.T) {
 }
 
 func testTLSRoutesCertificateImplicitAllow(t *testing.T, pass bool) {
+	t.Helper()
 	// Base config for the servers
 	cfg, err := ioutil.TempFile("", "cfg")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = cfg.Sync(); err != nil {
-		t.Fatal(err)
-	}
-	cfg.WriteString(`
+	defer os.Remove(cfg.Name())
+	cfg.WriteString(fmt.Sprintf(`
 		cluster {
 		  tls {
 			cert_file = "./configs/certs/tlsauth/server.pem"
 			key_file = "./configs/certs/tlsauth/server-key.pem"
 			ca_file = "./configs/certs/tlsauth/ca.pem"
 			verify_and_implicit_allow = true
+			insecure = %t
 			timeout = 1
 		  }
 		}
-	`)
+	`, !pass)) // set insecure to skip verification on the outgoing end
+	if err = cfg.Sync(); err != nil {
+		t.Fatal(err)
+	}
 
 	optsA := LoadConfig(cfg.Name())
 	optsB := LoadConfig(cfg.Name())
@@ -847,7 +850,7 @@ func testTLSRoutesCertificateImplicitAllow(t *testing.T, pass bool) {
 		checkNumRoutes(t, srvA, 1)
 		checkNumRoutes(t, srvB, 1)
 	} else {
-		time.Sleep(1 * time.Second)
+		time.Sleep(5 * time.Second)
 		checkNumRoutes(t, srvA, 0)
 		checkNumRoutes(t, srvB, 0)
 	}
@@ -862,25 +865,28 @@ func TestTLSGatewaysCertificateImplicitAllowFail(t *testing.T) {
 }
 
 func testTLSGatewaysCertificateImplicitAllow(t *testing.T, pass bool) {
+	t.Helper()
 	// Base config for the servers
 	cfg, err := ioutil.TempFile("", "cfg")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = cfg.Sync(); err != nil {
-		t.Fatal(err)
-	}
-	cfg.WriteString(`
+	defer os.Remove(cfg.Name())
+	cfg.WriteString(fmt.Sprintf(`
 		gateway {
 		  tls {
 			cert_file = "./configs/certs/tlsauth/server.pem"
 			key_file = "./configs/certs/tlsauth/server-key.pem"
 			ca_file = "./configs/certs/tlsauth/ca.pem"
 			verify_and_implicit_allow = true
+			insecure = %t
 			timeout = 1
 		  }
 		}
-	`)
+	`, !pass)) // set insecure to skip verification on the outgoing end
+	if err = cfg.Sync(); err != nil {
+		t.Fatal(err)
+	}
 
 	optsA := LoadConfig(cfg.Name())
 	optsB := LoadConfig(cfg.Name())
@@ -941,9 +947,9 @@ func testTLSGatewaysCertificateImplicitAllow(t *testing.T, pass bool) {
 		waitForOutboundGateways(t, srvA, 1, 5*time.Second)
 		waitForOutboundGateways(t, srvB, 1, 5*time.Second)
 	} else {
-		time.Sleep(1 * time.Second)
-		waitForOutboundGateways(t, srvA, 0, 5*time.Second)
-		waitForOutboundGateways(t, srvB, 0, 5*time.Second)
+		time.Sleep(5 * time.Second)
+		waitForOutboundGateways(t, srvA, 0, 1*time.Second)
+		waitForOutboundGateways(t, srvB, 0, 1*time.Second)
 	}
 }
 

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -808,7 +808,7 @@ func testTLSRoutesCertificateImplicitAllow(t *testing.T, pass bool) {
 			cert_file = "./configs/certs/tlsauth/server.pem"
 			key_file = "./configs/certs/tlsauth/server-key.pem"
 			ca_file = "./configs/certs/tlsauth/ca.pem"
-			verify_and_implicit_allow = true
+			verify_and_accept_known_urls = true
 			insecure = %t
 			timeout = 1
 		  }
@@ -879,7 +879,7 @@ func testTLSGatewaysCertificateImplicitAllow(t *testing.T, pass bool) {
 			cert_file = "./configs/certs/tlsauth/server.pem"
 			key_file = "./configs/certs/tlsauth/server-key.pem"
 			ca_file = "./configs/certs/tlsauth/ca.pem"
-			verify_and_implicit_allow = true
+			verify_and_accept_known_urls = true
 			insecure = %t
 			timeout = 1
 		  }

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -808,7 +808,7 @@ func testTLSRoutesCertificateImplicitAllow(t *testing.T, pass bool) {
 			cert_file = "./configs/certs/tlsauth/server.pem"
 			key_file = "./configs/certs/tlsauth/server-key.pem"
 			ca_file = "./configs/certs/tlsauth/ca.pem"
-			verify_and_accept_known_urls = true
+			verify_cert_and_check_known_urls = true
 			insecure = %t
 			timeout = 1
 		  }
@@ -879,7 +879,7 @@ func testTLSGatewaysCertificateImplicitAllow(t *testing.T, pass bool) {
 			cert_file = "./configs/certs/tlsauth/server.pem"
 			key_file = "./configs/certs/tlsauth/server-key.pem"
 			ca_file = "./configs/certs/tlsauth/ca.pem"
-			verify_and_accept_known_urls = true
+			verify_cert_and_check_known_urls = true
 			insecure = %t
 			timeout = 1
 		  }

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -850,9 +850,10 @@ func testTLSRoutesCertificateImplicitAllow(t *testing.T, pass bool) {
 		checkNumRoutes(t, srvA, 1)
 		checkNumRoutes(t, srvB, 1)
 	} else {
-		time.Sleep(5 * time.Second)
-		checkNumRoutes(t, srvA, 0)
-		checkNumRoutes(t, srvB, 0)
+		time.Sleep(1 * time.Second) // the fail case uses the IP, so a short wait is sufficient
+		if srvA.NumRoutes() != 0 || srvB.NumRoutes() != 0 {
+			t.Fatal("No route connection expected")
+		}
 	}
 }
 
@@ -947,9 +948,10 @@ func testTLSGatewaysCertificateImplicitAllow(t *testing.T, pass bool) {
 		waitForOutboundGateways(t, srvA, 1, 5*time.Second)
 		waitForOutboundGateways(t, srvB, 1, 5*time.Second)
 	} else {
-		time.Sleep(5 * time.Second)
-		waitForOutboundGateways(t, srvA, 0, 1*time.Second)
-		waitForOutboundGateways(t, srvB, 0, 1*time.Second)
+		time.Sleep(1 * time.Second) // the fail case uses the IP, so a short wait is sufficient
+		if srvA.NumOutboundGateways() != 0 || srvB.NumOutboundGateways() != 0 {
+			t.Fatal("No outbound gateway connection expected")
+		}
 	}
 }
 


### PR DESCRIPTION
Only works for gateways and routes. When true the subject alt DNS name
must match one url in the corresponding configuration

As discussed. At the very least have a look at the unit test cases in TestDNSAltNameMatching. Looking at certs to write my other tests I started to wonder if we should extend this to IPs too?

```
        X509v3 extensions:
            X509v3 Subject Alternative Name:
                DNS:localhost, IP Address:127.0.0.1
```

Also look for 127.0.0.1 and it's IPv6 variant. Opinions?

If yes, I'd be open to suggestions on which urls to provide in test/tls_test.go line 823, 891, 892

What I intend to include in the doc
verify_and_implicit_allow| Only settable in a non client context where verify=true is the default (gateways/cluster). The incoming connections certificate's `X509v3 Subject Alternative Name` DNS entries will be matched against all urls in the configuration context that contains this tls map. If a match is found the connection is accepted, otherwise rejected. Meaning for gateways we will match all DNS entries in the certificate against all gateway urls. For cluster we will match against all route urls. As a consequence of this, dynamic cluster growth may require config changes in other cluster where this flag is true. DNS name checking is performed according to https://tools.ietf.org/html/rfc6125#section-6.4.1 Only the full wildcard `*` is supported for the left most label.  This would be a way to keep cluster growth flexible.


Signed-off-by: Matthias Hanel <mh@synadia.com>