### PR TITLE
[Adding] ability to reference $SYS in leaf node config

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -422,6 +422,9 @@ func NewServer(opts *Options) (*Server, error) {
 				return nil
 			}
 			if _, ok := s.accounts.Load(accName); !ok {
+				if accName == DEFAULT_SYSTEM_ACCOUNT && opts.SystemAccount == _EMPTY_ && !opts.NoSystemAccount {
+					return nil
+				}
 				return fmt.Errorf("cannot find account %q specified in leafnode authorization", accName)
 			}
 			return nil
@@ -442,6 +445,9 @@ func NewServer(opts *Options) (*Server, error) {
 				continue
 			}
 			if _, ok := s.accounts.Load(r.LocalAccount); !ok {
+				if r.LocalAccount == DEFAULT_SYSTEM_ACCOUNT && opts.SystemAccount == _EMPTY_ && !opts.NoSystemAccount {
+					continue
+				}
 				return nil, fmt.Errorf("no local account %q for remote leafnode", r.LocalAccount)
 			}
 		}


### PR DESCRIPTION
only do so if $SYS is the system account

Signed-off-by: Matthias Hanel <mh@synadia.com>

shortcut if all I want is forward it. Avoid unnecessary configuration.