### PR TITLE
Enable JetStream streams and consumer access to be exported

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1631,6 +1631,7 @@ func (a *Account) addServiceImport(dest *Account, from, to string, claim *jwt.Im
 		if to == from {
 			usePub = true
 		} else {
+			from, _ = transformUntokenize(from)
 			// Create a transform
 			if tr, err = newTransform(from, transformTokenize(to)); err != nil {
 				a.mu.Unlock()

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -661,7 +661,7 @@ func TestSimpleMapping(t *testing.T) {
 		}
 		matches := mraw[0]
 		if matches[SUB_INDEX] != "import.foo" {
-			t.Fatalf("Did not get correct subject: '%s'", matches[SUB_INDEX])
+			t.Fatalf("Did not get correct subject: wanted %q, got %q", "import.foo", matches[SUB_INDEX])
 		}
 		if matches[SID_INDEX] != sid {
 			t.Fatalf("Did not get correct sid: '%s'", matches[SID_INDEX])

--- a/server/events.go
+++ b/server/events.go
@@ -305,12 +305,14 @@ RESET:
 				}
 			}
 			c.mu.Lock()
+
 			// We can have an override for account here.
 			if pm.acc != nil {
 				c.acc = pm.acc
 			} else {
 				c.acc = sysacc
 			}
+
 			// Prep internal structures needed to send message.
 			c.pa.subject = []byte(pm.sub)
 			c.pa.size = len(b)
@@ -1618,7 +1620,7 @@ func (s *Server) debugSubscribers(sub *subscription, c *client, subject, reply s
 
 	// If we are only local, go ahead and return.
 	if expected == 0 {
-		s.sendInternalAccountMsg(c.acc, reply, nsubs)
+		s.sendInternalAccountMsg(nil, reply, nsubs)
 		return
 	}
 
@@ -1662,7 +1664,7 @@ func (s *Server) debugSubscribers(sub *subscription, c *client, subject, reply s
 		delete(s.sys.replies, replySubj)
 		s.mu.Unlock()
 		// Send the response.
-		s.sendInternalAccountMsg(c.acc, reply, atomic.LoadInt32(&nsubs))
+		s.sendInternalAccountMsg(nil, reply, atomic.LoadInt32(&nsubs))
 	}()
 }
 

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -552,7 +552,7 @@ func (s *Server) setJetStreamExportSubs() error {
 }
 
 func (s *Server) sendAPIResponse(c *client, subject, reply, request, response string) {
-	s.sendInternalAccountMsg(c.acc, reply, response)
+	s.sendInternalAccountMsg(nil, reply, response)
 	s.sendJetStreamAPIAuditAdvisory(c, subject, request, response)
 }
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -873,6 +873,7 @@ func (mset *Stream) processInboundJetStreamMsg(_ *subscription, pc *client, subj
 	if c != nil && c.acc != nil {
 		accName = c.acc.Name
 	}
+
 	doAck := !mset.config.NoAck
 	pubAck := mset.pubAck
 	jsa := mset.jsa
@@ -1099,6 +1100,7 @@ func (mset *Stream) internalSendLoop() {
 			didDeliver := c.processInboundClientMsg(msg)
 			c.pa.szb = nil
 			c.flushClients(0)
+
 			// Check to see if this is a delivery for an observable and
 			// we failed to deliver the message. If so alert the observable.
 			if pm.o != nil && pm.seq > 0 && !didDeliver {


### PR DESCRIPTION
This allows basic access to publish into a stream and receive the pub ack across accounts, as well as pull and push based receipt of consumer messages and the ability to ack those messages.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
