### PR TITLE
[FIXED] Detect service import cycles.

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1343,8 +1343,24 @@ func (a *Account) AddServiceImportWithClaim(destination *Account, from, to strin
 		return ErrServiceImportAuthorization
 	}
 
+	if a.importFormsCycle(destination, from, to) {
+		return ErrServiceImportFormsCycle
+	}
+
 	_, err := a.addServiceImport(destination, from, to, imClaim)
 	return err
+}
+
+// Detects if we have a cycle.
+func (a *Account) importFormsCycle(destination *Account, from, to string) bool {
+	// Check that what we are importing is not something we also export.
+	if a.serviceExportOverlaps(to) {
+		// So at this point if destination account is also importing from us, that forms a cycle.
+		if destination.serviceImportOverlaps(from) {
+			return true
+		}
+	}
+	return false
 }
 
 // SetServiceImportSharing will allow sharing of information about requests with the export account.
@@ -1583,6 +1599,30 @@ func (a *Account) checkForReverseEntry(reply string, si *serviceImport, checkInt
 			}
 		}
 	}
+}
+
+// Internal check to see if the to subject overlaps with another export.
+func (a *Account) serviceExportOverlaps(to string) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for subj := range a.exports.services {
+		if to == subj || SubjectsCollide(to, subj) {
+			return true
+		}
+	}
+	return false
+}
+
+// Internal check to see if the from subject overlaps with another import.
+func (a *Account) serviceImportOverlaps(from string) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for subj := range a.imports.services {
+		if from == subj || SubjectsCollide(from, subj) {
+			return true
+		}
+	}
+	return false
 }
 
 // Internal check to see if a service import exists.

--- a/server/client.go
+++ b/server/client.go
@@ -3705,6 +3705,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 			}
 			continue
 		}
+
 		// Assume delivery subject is the normal subject to this point.
 		dsubj = subj
 

--- a/server/errors.go
+++ b/server/errors.go
@@ -125,6 +125,9 @@ var (
 	// ErrServiceImportAuthorization is returned when a service import is not authorized.
 	ErrServiceImportAuthorization = errors.New("service import not authorized")
 
+	// ErrServiceImportFormsCycle is returned when a service import forms a cycle.
+	ErrServiceImportFormsCycle = errors.New("service import forms cycle")
+
 	// ErrClientOrRouteConnectedToGatewayPort represents an error condition when
 	// a client or route attempted to connect to the Gateway port.
 	ErrClientOrRouteConnectedToGatewayPort = errors.New("attempted to connect to gateway port")


### PR DESCRIPTION
Simple configs that represent a service export/import cycle between accounts could crash the server.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
