### PR TITLE
Unbreak FreeBSD compilation (syscall.Statfs_t)

### DIFF
--- a/server/disk_avail.go
+++ b/server/disk_avail.go
@@ -28,7 +28,7 @@ func diskAvailable(storeDir string) int64 {
 	var fs syscall.Statfs_t
 	if err := syscall.Statfs(storeDir, &fs); err == nil {
 		// Estimate 75% of available storage.
-		ba = int64(fs.Bavail * uint64(fs.Bsize) / 4 * 3)
+		ba = int64(uint64(fs.Bavail) * uint64(fs.Bsize) / 4 * 3)
 	} else {
 		// Used 1TB default as a guess if all else fails.
 		ba = JetStreamMaxStoreDefault


### PR DESCRIPTION
The types of fields in syscall.Statfs_t varies between platforms.
fs.Bavail is uint64 on Linux and int64 on FreeBSD.  This is the opposite way
around to fs.Bsize.

For now, just coerce the Bavail to be uint64.

If the VFS layer might return -1 for one or the other of these then these casts
will be problematic and we'll need more safeguards.

/cc @nats-io/core