### PR TITLE
Cross-compile for FreeBSD/amd64 without cgo

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,7 @@ builds:
   - darwin
   - linux
   - windows
+  - freebsd
   goarch:
   - amd64
   - arm
@@ -32,6 +33,12 @@ builds:
   - 7
   ignore:
     - goos: darwin
+      goarch: 386
+    - goos: freebsd
+      goarch: arm
+    - goos: freebsd
+      goarch: arm64
+    - goos: freebsd
       goarch: 386
 
 nfpms:

--- a/server/pse/freebsd.txt
+++ b/server/pse/freebsd.txt
@@ -1,0 +1,30 @@
+/*
+ * Compile and run this as a C program to get the kinfo_proc offsets
+ * for your architecture.
+ * While FreeBSD works hard at binary-compatibility within an ABI, various
+ * we can't say for sure that these are right for _all_ use on a hardware
+ * platform.  The LP64 ifdef affects the offsets considerably.
+ *
+ * We use these offsets in hardware-specific files for FreeBSD, to avoid a cgo
+ * compilation-time dependency, allowing us to cross-compile for FreeBSD from
+ * other hardware platforms, letting us distribute binaries for FreeBSD.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/user.h>
+
+#define SHOW_OFFSET(FIELD) printf(" KIP_OFF_%s = %zu\n", #FIELD, offsetof(struct kinfo_proc, ki_ ## FIELD))
+
+int main(int argc, char *argv[]) {
+	/* Uncomment these if you want some extra debugging aids:
+	SHOW_OFFSET(pid);
+	SHOW_OFFSET(ppid);
+	SHOW_OFFSET(uid);
+	*/
+	SHOW_OFFSET(size);
+	SHOW_OFFSET(rssize);
+	SHOW_OFFSET(pctcpu);
+}

--- a/server/pse/pse_freebsd.go
+++ b/server/pse/pse_freebsd.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !amd64
+
 package pse
 
 /*
@@ -54,7 +56,7 @@ int getusage(double *pcpu, unsigned int *rss, unsigned int *vss)
 
     *rss = pagetok(kp.ki_rssize);
     *vss = kp.ki_size;
-    *pcpu = kp.ki_pctcpu;
+    *pcpu = (double)kp.ki_pctcpu / FSCALE;
 
     return 0;
 }

--- a/server/pse/pse_freebsd_amd64.go
+++ b/server/pse/pse_freebsd_amd64.go
@@ -1,0 +1,91 @@
+// Copyright 2015-2020 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is the amd64-specific FreeBSD implementation, with hard-coded offset
+// constants derived by running freebsd.txt; having this implementation allows
+// us to compile without CGO, which lets us cross-compile for FreeBSD from our
+// CI system and so supply binaries for FreeBSD amd64.
+//
+// To generate for other architectures:
+//   1. Update pse_freebsd.go, change the build exclusion to exclude your arch
+//   2. Copy this file to be built for your arch
+//   3. Update `nativeEndian` below
+//   4. Link `freebsd.txt` to have a .c filename and compile and run, then
+//      paste the outputs into the const section below.
+
+package pse
+
+import (
+	"encoding/binary"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// On FreeBSD, to get proc information we read it out of the kernel using a
+// binary sysctl.  The endianness of integers is thus explicitly "host", rather
+// than little or big endian.
+var nativeEndian = binary.LittleEndian
+
+const (
+	KIP_OFF_size   = 256
+	KIP_OFF_rssize = 264
+	KIP_OFF_pctcpu = 308
+)
+
+var pageshift int
+
+func init() {
+	// To get the physical page size, the C library checks two places:
+	//   process ELF auxiliary info, AT_PAGESZ
+	//   as a fallback, the hw.pagesize sysctl
+	// In looking closely, I found that the Go runtime support is handling
+	// this for us, and exposing that as syscall.Getpagesize, having checked
+	// both in the same ways, at process start, so a call to that should return
+	// a memory value without even a syscall bounce.
+	pagesize := syscall.Getpagesize()
+	pageshift = 0
+	for pagesize > 1 {
+		pageshift += 1
+		pagesize >>= 1
+	}
+}
+
+func ProcUsage(pcpu *float64, rss, vss *int64) error {
+	rawdata, err := unix.SysctlRaw("kern.proc.pid", unix.Getpid())
+	if err != nil {
+		return err
+	}
+
+	r_vss_bytes := nativeEndian.Uint32(rawdata[KIP_OFF_size:])
+	r_rss_pages := nativeEndian.Uint32(rawdata[KIP_OFF_rssize:])
+	rss_bytes := r_rss_pages << pageshift
+
+	// In C: fixpt_t ki_pctcpu
+	// Doc: %cpu for process during ki_swtime
+	// fixpt_t is __uint32_t
+	// usr.bin/top uses pctdouble to convert to a double (float64)
+	// define pctdouble(p) ((double)(p) / FIXED_PCTCPU)
+	// FIXED_PCTCPU is _usually_ FSCALE (some architectures are special)
+	// <sys/param.h> has:
+	//   #define FSHIFT  11              /* bits to right of fixed binary point */
+	//   #define FSCALE  (1<<FSHIFT)
+	r_pcpu := nativeEndian.Uint32(rawdata[KIP_OFF_pctcpu:])
+	f_pcpu := float64(r_pcpu) / float64(2048)
+
+	*rss = int64(rss_bytes)
+	*vss = int64(r_vss_bytes)
+	*pcpu = f_pcpu
+
+	return nil
+}


### PR DESCRIPTION
(These commits should be preserved in merge, not squashed.)

The first commit fixes FreeBSD %cpu calculation, which was wrong by a factor of
2048, and provides an alternative implementation on amd64 which avoids the need
for cgo.  The framework setup is extensible to other architectures.

The second commit adds goreleaser targeting FreeBSD/amd64 as part of our usual
release artifact generation.

f088660d
   goreleaser target freebsd/amd64

80d11fa1
   FreeBSD fixes: %cpu scale; no-cgo for amd64

   It would be convenient if we did not need to use cgo to compile for FreeBSD
   for common architectures, allowing builds to be generated in Linux CI
   flows.

   The sysctl interface uses offsets which can vary by build architecture, so
   doing this in the general case without cgo is not realistic.  But we can
   front-load the C work to get the offsets for a given architecture, then use
   encoding/binary at run-time.

   While doing this, I saw that the existing FreeBSD code was mis-calculating
   `%cpu` by converting the `fixpt_t` scaled int straight to a double without
   dividing by the scaling factor, so we also fix for all other architectures
   by introducing a division by `FSCALE`.

   The offsets-emitting code is in `freebsd.txt`, with the filename chosen to
   keep the Go toolchain from picking it up and trying to compile.

   The result is unsafe-free cgo-free builds for FreeBSD/amd64.

/cc @nats-io/core