### PR TITLE
fixed bad issuer check performed against account issuer instead account subject (Name)

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2692,7 +2692,7 @@ func (a *Account) hasIssuer(issuer string) bool {
 
 // hasIssuerNoLock is the unlocked version of hasIssuer
 func (a *Account) hasIssuerNoLock(issuer string) bool {
-	// same issuer
+	// same issuer -- keep this for safety on the calling code
 	if a.Name == issuer {
 		return true
 	}

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2693,7 +2693,7 @@ func (a *Account) hasIssuer(issuer string) bool {
 // hasIssuerNoLock is the unlocked version of hasIssuer
 func (a *Account) hasIssuerNoLock(issuer string) bool {
 	// same issuer
-	if a.Issuer == issuer {
+	if a.Name == issuer {
 		return true
 	}
 	for i := 0; i < len(a.signingKeys); i++ {

--- a/server/auth.go
+++ b/server/auth.go
@@ -525,6 +525,7 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			c.Debugf("Account JWT not signed by trusted operator")
 			return false
 		}
+		// this only executes IF there's an issuer on the Juc - otherwise the account is already
 		if juc.IssuerAccount != "" && !acc.hasIssuer(juc.Issuer) {
 			c.Debugf("User JWT issuer is not known")
 			return false

--- a/server/auth.go
+++ b/server/auth.go
@@ -525,7 +525,7 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			c.Debugf("Account JWT not signed by trusted operator")
 			return false
 		}
-		// this only executes IF there's an issuer on the Juc - otherwise the account is already
+		// this only executes IF there's an issuer on the Juc - otherwise the account is already vetted
 		if juc.IssuerAccount != "" && !acc.hasIssuer(juc.Issuer) {
 			c.Debugf("User JWT issuer is not known")
 			return false


### PR DESCRIPTION
fixed check of user issuer against the account id (Name) - was set to Issuer instead (issuer is always an operator)
added tests

FIX #1740

/cc @nats-io/core
