### PR TITLE
Servicecyclewithmapping

### DIFF
--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -1363,6 +1363,26 @@ func TestServiceCycle(t *testing.T) {
 	}
 }
 
+func TestServiceCycleWithMapping(t *testing.T) {
+	t.Skip("will fail without an error otherwise")
+	conf := createConfFile(t, []byte(`
+		accounts {
+		  A {
+		    exports [ { service: a } ]
+			imports [ { service { subject: b, account: B }, to: a } ]
+		  }
+		  B {
+		    exports [ { service: b } ]
+			imports [ { service { subject: a, account: A }, to: b } ]
+		  }
+		}
+	`))
+	defer os.Remove(conf)
+	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), server.ErrServiceImportFormsCycle.Error()) {
+		t.Fatalf("Expected an error on cycle service import, got none")
+	}
+}
+
 // Check we get the proper detailed information for the requestor when allowed.
 func TestServiceLatencyRequestorSharesDetailedInfo(t *testing.T) {
 	sc := createSuperCluster(t, 3, 3)

--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -1363,6 +1363,26 @@ func TestServiceCycle(t *testing.T) {
 	}
 }
 
+func TestStreamCycleWithMapping(t *testing.T) {
+	t.Skip("will fail without an error otherwise")
+	conf := createConfFile(t, []byte(`
+		accounts {
+		  A {
+		    exports [ { stream: strm } ]
+			imports [ { stream { subject: strm, account: B } } ]
+		  }
+		  B {
+		    exports [ { stream: strm } ]
+			imports [ { stream { subject: strm, account: A } } ]
+		  }
+		}
+	`))
+	defer os.Remove(conf)
+	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), server.ErrServiceImportFormsCycle.Error()) {
+		t.Fatalf("Expected an error on cycle service import, got none")
+	}
+}
+
 func TestServiceCycleWithMapping(t *testing.T) {
 	t.Skip("will fail without an error otherwise")
 	conf := createConfFile(t, []byte(`


### PR DESCRIPTION
as pointed out int the review to https://github.com/nats-io/nats-server/pull/1731 importFormsCycle does not work and:
cycles are found where there are none
the 3 account test in TestServiceCycle does not fail because a cycle between A - B - C is detected. 
rewriting the imported subject is not taken into account
If we do not allow cycles for services, we shouldn't allow cycles for streams either.

Frankly we shouldn't look at subjects or import types, we should require that no information flow in a cyclic way, thereby requiring accounts to be hierarchical.  
I would certainly consider this a best practice practice as it avoids common errors (see lock hierarchies).
Anything tightly coupled should end up in the same account.

This should be detected as cycle. 
```
accounts {
A {
exports [ { stream: strm } ]
imports [ { service { subject: srv, account: B } } ]
}
B {
exports [ { service: srv } ]
imports [ { stream { subject: strm, account: A } } ]
}
}
```
Having the assertion that there are no reference cycles between accounts is a handy property to have and would simplify other tasks like account cleanup as well.

Taking subjects and types into account or not, cycle detection can't be done by just looking at two nodes in a graph.

Here is a rough draft:
A list of nodes to visit (to implement depth or breadth first search) is needed as well as a map[*Account]strict{} (to mark visited Accounts).
As an import is added to account X, put the imported account into the to visit queue and the visited map
begin:
Take a node from the to visit list
for each import in the account, 
     if the imported account is X, then we have a loop, return
     if the imported account is not in the visited map (this also takes care of imports from the same account)
          add the imported account to the visited map
          add the imported account to the to visit list
goto begin 

This should be fine as, the checks are not expensive (especially when subjects are not looked at) and I would not expect many accounts to be involved in this process. Also, imports are not added all too often.