### PR TITLE
[FIXED] System account was not properly tracking GW routed replies

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -2951,6 +2951,13 @@ func (c *client) deliverMsg(sub *subscription, subject, reply, mh, msg []byte, g
 
 	// Check for internal subscriptions.
 	if sub.icb != nil {
+		if gwrply {
+			// Note that we keep track of the GW routed reply in the destination
+			// connection (`client`). The routed reply subject is in `c.pa.reply`,
+			// should that change, we would have to pass the GW routed reply as
+			// a parameter of deliverMsg().
+			srv.trackGWReply(client, c.pa.reply)
+		}
 		client.mu.Unlock()
 		// Internal account clients are for service imports and need the '\r\n'.
 		if client.kind == ACCOUNT {
@@ -2988,9 +2995,10 @@ func (c *client) deliverMsg(sub *subscription, subject, reply, mh, msg []byte, g
 	// header (which is c.pa.reply without the GNR routing prefix).
 	if client.kind == CLIENT && len(c.pa.reply) > minReplyLen {
 		if gwrply {
-			// Note we keep track "in" the destination client (`client`) but the
-			// routed reply subject is in `c.pa.reply`. Should that change, we
-			// would have to pass the "reply" in deliverMsg().
+			// Note that we keep track of the GW routed reply in the destination
+			// connection (`client`). The routed reply subject is in `c.pa.reply`,
+			// should that change, we would have to pass the GW routed reply as
+			// a parameter of deliverMsg().
 			srv.trackGWReply(client, c.pa.reply)
 		}
 

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -155,7 +155,9 @@ func runTrustedGateways(t *testing.T) (*Server, *Options, *Server, *Options, nke
 
 	sb := RunServer(optsB)
 
+	waitForInboundGateways(t, sa, 1, time.Second)
 	waitForOutboundGateways(t, sa, 1, time.Second)
+	waitForInboundGateways(t, sb, 1, time.Second)
 	waitForOutboundGateways(t, sb, 1, time.Second)
 
 	return sa, optsA, sb, optsB, akp


### PR DESCRIPTION
In some cases, the reply of a request message is prefixed when
going over a gateway so that if it comes back to a different
server than when the request originates, it can be routed back.

For system accounts, this routed reply subject was not tracked
so the server would reply to the inbox and may reach a server
that had not yet processed (through the route) the interest
on that inbox. If the reply came with the GW routed info, that
server would know to route it to the original server.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
