### PR TITLE
Remove limitation on AckAll for consumers with filtered subjects.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -277,9 +277,6 @@ func (mset *Stream) AddConsumer(config *ConsumerConfig) (*Consumer, error) {
 			if !mset.validSubject(config.FilterSubject) {
 				return nil, fmt.Errorf("consumer filter subject is not a valid subset of the interest subjects")
 			}
-			if config.AckPolicy == AckAll {
-				return nil, fmt.Errorf("consumer with filter subject can not have an ack policy of ack all")
-			}
 		}
 	}
 

--- a/test/jetstream_test.go
+++ b/test/jetstream_test.go
@@ -1210,16 +1210,6 @@ func TestJetStreamCreateConsumer(t *testing.T) {
 			defer sub.Unsubscribe()
 			nc.Flush()
 
-			// Filtered subjects can not be AckAll.
-			if _, err := mset.AddConsumer(&server.ConsumerConfig{
-				DeliverSubject: delivery,
-				FilterSubject:  "foo",
-				AckPolicy:      server.AckAll,
-			}); err == nil {
-				t.Fatalf("Expected an error on partitioned consumer with ack policy of all")
-			}
-
-			// This should work..
 			o, err := mset.AddConsumer(&server.ConsumerConfig{DeliverSubject: delivery})
 			if err != nil {
 				t.Fatalf("Expected no error with registered interest, got %v", err)


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
