### PR TITLE
Fix for #1736

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.2.0-beta.33"
+	VERSION = "2.2.0-beta.34"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -143,7 +143,7 @@ const (
 	jsSnapshotAckT    = "$JS.SNAPSHOT.ACK.%s.%s"
 	jsRestoreDeliverT = "$JS.SNAPSHOT.RESTORE.%s.%s"
 
-	// JetStreamAckT is the template for the ack message stream coming back from a consumer
+	// jsAckT is the template for the ack message stream coming back from a consumer
 	// when they ACK/NAK, etc a message.
 	jsAckT   = "$JS.ACK.%s.%s"
 	jsAckPre = "$JS.ACK."

--- a/server/reload.go
+++ b/server/reload.go
@@ -1269,11 +1269,15 @@ func (s *Server) reloadAuthorization() {
 
 	// We will double check all JetStream configs on a reload.
 	if checkJetStream {
+		var err error
 		s.getJetStream().clearResources()
 		if s.globalAccountOnly() {
-			s.GlobalAccount().EnableJetStream(nil)
+			err = s.GlobalAccount().EnableJetStream(nil)
 		} else {
-			s.configAllJetStreamAccounts()
+			err = s.configAllJetStreamAccounts()
+		}
+		if err != nil {
+			s.Errorf(err.Error())
 		}
 	}
 

--- a/server/reload.go
+++ b/server/reload.go
@@ -1269,7 +1269,11 @@ func (s *Server) reloadAuthorization() {
 
 	// We will double check all JetStream configs on a reload.
 	if checkJetStream {
-		s.configAllJetStreamAccounts()
+		if s.globalAccountOnly() {
+			s.GlobalAccount().EnableJetStream(nil)
+		} else {
+			s.configAllJetStreamAccounts()
+		}
 	}
 
 	if res := s.AccountResolver(); res != nil {

--- a/server/reload.go
+++ b/server/reload.go
@@ -1269,6 +1269,7 @@ func (s *Server) reloadAuthorization() {
 
 	// We will double check all JetStream configs on a reload.
 	if checkJetStream {
+		s.getJetStream().clearResources()
 		if s.globalAccountOnly() {
 			s.GlobalAccount().EnableJetStream(nil)
 		} else {


### PR DESCRIPTION
When a system account was configured and not the default when we did a reload we would lose the JetStream service exports.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #1736 

/cc @nats-io/core
