### PR TITLE
[FIXES] https://github.com/nats-io/jetstream/issues/396

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2265,13 +2265,9 @@ func (o *Consumer) incStreamPending(sseq uint64, subj string) {
 
 func (o *Consumer) decStreamPending(sseq uint64, subj string) {
 	o.mu.Lock()
-	defer o.mu.Unlock()
-
 	// Ignore if we have already seen this one.
-	if sseq < o.sseq || o.sgap == 0 {
-		return
-	}
-	if o.isFilteredMatch(subj) {
+	if sseq >= o.sseq && o.sgap > 0 && o.isFilteredMatch(subj) {
 		o.sgap--
 	}
+	o.mu.Unlock()
 }


### PR DESCRIPTION
Had a deadlock with new preconditions. We need to hold lock across Store() call but that call could call into storeUpdate() such that we may need to acquire the lock. We can enter this callback from the storage layer itself and the lock would not be held so added an atomic.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves https://github.com/nats-io/jetstream/issues/396

/cc @nats-io/core
