### PR TITLE
Limit search depth for account cycles for imports

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -128,6 +128,9 @@ var (
 	// ErrImportFormsCycle is returned when an import would form a cycle.
 	ErrImportFormsCycle = errors.New("import forms a cycle")
 
+	// ErrCycleSearchDepth is returned when we have exceeded our maximum search depth..
+	ErrCycleSearchDepth = errors.New("search cycle depth exhausted")
+
 	// ErrClientOrRouteConnectedToGatewayPort represents an error condition when
 	// a client or route attempted to connect to the Gateway port.
 	ErrClientOrRouteConnectedToGatewayPort = errors.New("attempted to connect to gateway port")

--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -122,7 +122,7 @@ func (sc *supercluster) setupLatencyTracking(t *testing.T, p int) {
 				t.Fatalf("Error adding latency tracking to 'FOO': %v", err)
 			}
 			if err := bar.AddServiceImport(foo, "ngs.usage", "ngs.usage.bar"); err != nil {
-				t.Fatalf("Error adding latency tracking to 'FOO': %v", err)
+				t.Fatalf("Error adding service import to 'ngs.usage': %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
Although Go stacks are not limited per se (just by memory), we wanted to put a limit to the depth to check. I chose 1024, which in my opinion if we hit this from a chaining perspective something is probably wrong.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
