### PR TITLE
[FIXED] Config reload for gateways/leaf remote TLS configurations

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -151,6 +151,7 @@ type Server struct {
 		resolver    netResolver
 		dialTimeout time.Duration
 	}
+	leafRemoteCfgs []*leafNodeCfg
 
 	quitCh           chan struct{}
 	shutdownComplete chan struct{}

--- a/test/gateway_test.go
+++ b/test/gateway_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -596,6 +597,7 @@ func TestGatewayTLSMixedIPAndDNS(t *testing.T) {
 			listen: "127.0.0.1:-1"
 		}
 	`))
+	defer os.Remove(confA1)
 	srvA1, optsA1 := RunServerWithConfig(confA1)
 	defer srvA1.Shutdown()
 
@@ -620,6 +622,7 @@ func TestGatewayTLSMixedIPAndDNS(t *testing.T) {
 	`
 	confA2 := createConfFile(t, []byte(fmt.Sprintf(confA2Template,
 		optsA1.Cluster.Host, optsA1.Cluster.Port)))
+	defer os.Remove(confA2)
 	srvA2, optsA2 := RunServerWithConfig(confA2)
 	defer srvA2.Shutdown()
 


### PR DESCRIPTION
Presence of TLS config in any remote gateway or leafnode would
cause the config reload to fail (because TLS config internal
content may change which fails the DeepEqual check).

This PR excludes the TLS configs in such case to check for
changes in gateways and leafnodes.

Although GW and LN config reload is technically supported, this
PR updates the internal remotes' TLS configuration so that
changes/updates to TLS certificates would take effect after
a configuration reload.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
