### PR TITLE
stream handle headers with no space after colon

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -878,12 +878,19 @@ func getHdrVal(key string, hdr []byte) []byte {
 	if index < 0 {
 		return nil
 	}
+
 	var value []byte
-	for i := index + len(key) + 2; i > 0 && i < len(hdr); i++ {
-		if hdr[i] == '\r' && i < len(hdr)-1 && hdr[i+1] == '\n' {
+	hdrLen := len(hdr)
+	index += len(key) + 1
+	for hdr[index] == ' ' && index < hdrLen {
+		index++
+	}
+	for index < hdrLen {
+		if hdr[index] == '\r' && index < hdrLen-1 && hdr[index+1] == '\n' {
 			break
 		}
-		value = append(value, hdr[i])
+		value = append(value, hdr[index])
+		index++
 	}
 	return value
 }
@@ -948,6 +955,7 @@ func (mset *Stream) processInboundJetStreamMsg(_ *subscription, pc *client, subj
 			}
 			return
 		}
+
 		// Expected stream.
 		if sname := getExpectedStream(hdr); sname != _EMPTY_ && sname != name {
 			mset.mu.Unlock()


### PR DESCRIPTION
Resolves https://github.com/nats-io/nats.java/issues/384

So a header can be serialized `<key><colon><value>`  or `<key><colon><space><value>` 

When I wrote nats-java headers, I did not use the extra space b/c why send an extra byte. The go client uses a space.

https://tools.ietf.org/html/rfc2616#section-4.2 Leading Whitespace (LWS) is optional

```
message-header = field-name ":" [ field-value ]
       field-name     = token
       field-value    = *( field-content | LWS )
       field-content  = <the OCTETs making up the field-value
                        and consisting of either *TEXT or combinations
                        of token, separators, and quoted-string>
```

For example: 
If you send with a space `Nats-Expected-Stream: stream-name` the server compares the actual stream name to `stream-name`

If you send without a space, i.e `Nats-Expected-Stream:stream-name` it fails, the server compares the actual stream name to `tream-name` which fails

- No Tests added
- Built against master pulled today.
- 1 commit
- ? Build is green in Travis CI
- Commit is verified and original.

/cc @nats-io/core
