### PR TITLE
[FIXED]: syslog Warnf call Notice() instead of Warning()

### DIFF
--- a/logger/syslog.go
+++ b/logger/syslog.go
@@ -102,9 +102,9 @@ func (l *SysLogger) Noticef(format string, v ...interface{}) {
 	l.writer.Notice(fmt.Sprintf(format, v...))
 }
 
-// Warnf logs a notice statement
+// Warnf logs a warning statement
 func (l *SysLogger) Warnf(format string, v ...interface{}) {
-	l.writer.Notice(fmt.Sprintf(format, v...))
+	l.writer.Warning(fmt.Sprintf(format, v...))
 }
 
 // Fatalf logs a fatal error

--- a/logger/syslog_windows.go
+++ b/logger/syslog_windows.go
@@ -80,7 +80,7 @@ func (l *SysLogger) Noticef(format string, v ...interface{}) {
 	l.writer.Info(1, formatMsg("NOTICE", format, v...))
 }
 
-// Noticef logs a notice statement
+// Warnf logs a warning statement
 func (l *SysLogger) Warnf(format string, v ...interface{}) {
 	l.writer.Info(1, formatMsg("WARN", format, v...))
 }


### PR DESCRIPTION
Use `Warning()` instead of `Notice()` and fix documentation for both syslog and Windows event log.

Signed-off-by: Paolo Teti <paolo.teti@gmail.com>

/cc @nats-io/core
