### PR TITLE
[fixed] timeout in configuration lexer found by oss-fuzz

### DIFF
--- a/conf/lex.go
+++ b/conf/lex.go
@@ -666,8 +666,9 @@ func lexMapKeyStart(lx *lexer) stateFn {
 
 // lexMapQuotedKey consumes the text of a key between quotes.
 func lexMapQuotedKey(lx *lexer) stateFn {
-	r := lx.peek()
-	if r == sqStringEnd {
+	if r := lx.peek(); r == eof {
+		return lx.errorf("Unexpected EOF processing quoted map key.")
+	} else if r == sqStringEnd {
 		lx.emit(itemKey)
 		lx.next()
 		return lexSkip(lx, lexMapKeyEnd)
@@ -678,8 +679,9 @@ func lexMapQuotedKey(lx *lexer) stateFn {
 
 // lexMapQuotedKey consumes the text of a key between quotes.
 func lexMapDubQuotedKey(lx *lexer) stateFn {
-	r := lx.peek()
-	if r == dqStringEnd {
+	if r := lx.peek(); r == eof {
+		return lx.errorf("Unexpected EOF processing double quoted map key.")
+	} else if r == dqStringEnd {
 		lx.emit(itemKey)
 		lx.next()
 		return lexSkip(lx, lexMapKeyEnd)
@@ -691,8 +693,9 @@ func lexMapDubQuotedKey(lx *lexer) stateFn {
 // lexMapKey consumes the text of a key. Assumes that the first character (which
 // is not whitespace) has already been consumed.
 func lexMapKey(lx *lexer) stateFn {
-	r := lx.peek()
-	if unicode.IsSpace(r) {
+	if r := lx.peek(); r == eof {
+		return lx.errorf("Unexpected EOF processing map key.")
+	} else if unicode.IsSpace(r) {
 		// Spaces signal we could be looking at a keyword, e.g. include.
 		// Keywords will eat the keyword and set the appropriate return stateFn.
 		return lx.keyCheckKeyword(lexMapKeyEnd, lexMapValueEnd)

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -384,6 +384,10 @@ func TestIncludeVariablesWithChecks(t *testing.T) {
 	expectKeyVal(t, m, "CAROL_PASS", "foo", 6, 3)
 }
 
-func TestParser(t *testing.T) {
-	Parse(`A@@Føøøø?˛ø:{øøøø˙˙`)
+func TestParserNoInfiniteLoop(t *testing.T) {
+	if _, err := Parse(`A@@Føøøø?˛ø:{øøøø˙˙`); err == nil {
+		t.Fatal("expected an error")
+	} else if !strings.Contains(err.Error(), "Unexpected EOF") {
+		t.Fatal("expected unexpected eof error")
+	}
 }

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -383,3 +383,7 @@ func TestIncludeVariablesWithChecks(t *testing.T) {
 	expectKeyVal(t, m, "BOB_PASS", "$2a$11$dZM98SpGeI7dCFFGSpt.JObQcix8YHml4TBUZoge9R1uxnMIln5ly", 3, 1)
 	expectKeyVal(t, m, "CAROL_PASS", "foo", 6, 3)
 }
+
+func TestParser(t *testing.T) {
+	Parse(`A@@Føøøø?˛ø:{øøøø˙˙`)
+}


### PR DESCRIPTION
Peek followed by next resulted in an infinite loop when eof was not
checked.
I looked for all instances of this pattern and return an error when eof is not already checked or skip was used.

Signed-off-by: Matthias Hanel <mh@synadia.com>

