### PR TITLE
use go 1.15 for nightly builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -18,6 +18,11 @@ jobs:
         with:
           path: src/github.com/nats-io/nats-server
 
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine AS builder
+FROM golang:1.15-alpine AS builder
 
 RUN apk add --update git
 RUN mkdir -p src/github.com/nats-io && \


### PR DESCRIPTION
2.2 will be built with 1.15 so preparing nightlies to match

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
