### PR TITLE
Propose going back to condition variable to notify writeLoop

### DIFF
--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -938,9 +938,10 @@ func doFanIn(b *testing.B, numServers, numPublishers, numSubscribers int, subjec
 	if b.N < numPublishers {
 		return
 	}
-	if numSubscribers > numPublishers {
-		b.Fatalf("Fan in tests should have numPublishers (%d) > numSubscribers (%d)", numPublishers, numSubscribers)
-	}
+	// Don't check for number of subscribers being lower than the number of publishers.
+	// We also use this bench to show the performance impact of increased number of publishers,
+	// and for those tests, the number of publishers will start at 1 and increase to 10,
+	// while the number of subscribers will always be 3.
 	if numSubscribers > 10 {
 		b.Fatalf("numSubscribers should be <= 10")
 	}
@@ -1057,6 +1058,22 @@ func Benchmark____FanIn_64kx100x1(b *testing.B) {
 
 func Benchmark___FanIn_128kx100x1(b *testing.B) {
 	doFanIn(b, 1, 100, 1, sub, sizedString(65536*2))
+}
+
+func Benchmark___BumpPubCount_1x3(b *testing.B) {
+	doFanIn(b, 1, 1, 3, sub, sizedString(128))
+}
+
+func Benchmark___BumpPubCount_2x3(b *testing.B) {
+	doFanIn(b, 1, 2, 3, sub, sizedString(128))
+}
+
+func Benchmark___BumpPubCount_5x3(b *testing.B) {
+	doFanIn(b, 1, 5, 3, sub, sizedString(128))
+}
+
+func Benchmark__BumpPubCount_10x3(b *testing.B) {
+	doFanIn(b, 1, 10, 3, sub, sizedString(128))
 }
 
 func testDefaultBenchOptionsForGateway(name string) *server.Options {


### PR DESCRIPTION
This is how it was up to v2.1.2 included (changed in v2.1.4 onward).
I added a benchmark that has 3 subscribers running and increase
the number of publishers: 1, 2, 5 and 10. This is the comparison
between the pre-PR and post-PR:

```
benchcmp old.txt new.txt
benchmark                           old ns/op     new ns/op     delta
Benchmark___BumpPubCount_1x3-16     396           385           -2.78%
Benchmark___BumpPubCount_2x3-16     495           406           -17.98%
Benchmark___BumpPubCount_5x3-16     542           395           -27.12%
Benchmark__BumpPubCount_10x3-16     549           515           -6.19%

benchmark                           old MB/s     new MB/s     speedup
Benchmark___BumpPubCount_1x3-16     717.27       737.54       1.03x
Benchmark___BumpPubCount_2x3-16     574.31       699.02       1.22x
Benchmark___BumpPubCount_5x3-16     524.35       718.80       1.37x
Benchmark__BumpPubCount_10x3-16     517.26       551.53       1.07x
```

It is inline with what the user reported, seeing a 20% drop in performance
when going from 1 publisher to 2. But, as we can see, the difference
between go channel and cond variable reduces with the increased number
of publishers after a certain number.

I am not sure of the performance impact on other situations, so this
PR is more of a proposal than a fix.

Resolves #1786

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
