### PR TITLE
Fixed sublist notification

### DIFF
--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -1152,6 +1152,35 @@ func TestSublistRegisterInterestNotification(t *testing.T) {
 	s.Remove(sub3)
 	expectFalse()
 
+	if err := s.RegisterNotification("test.node", ch); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expectOne()
+	expectFalse()
+
+	tnSub1 := newSub("test.node.already.exist")
+	s.Insert(tnSub1)
+	expectNone()
+
+	tnSub2 := newSub("test.node")
+	s.Insert(tnSub2)
+	expectTrue()
+
+	tnSub3 := newSub("test.node")
+	s.Insert(tnSub3)
+	expectNone()
+
+	s.Remove(tnSub1)
+	expectNone()
+	s.Remove(tnSub2)
+	expectNone()
+	s.Remove(tnSub3)
+	expectFalse()
+
+	if !s.ClearNotification("test.node", ch) {
+		t.Fatalf("Expected to return true")
+	}
+
 	sub4 := newSub("bar")
 	s.Insert(sub4)
 	expectTrue()
@@ -1241,6 +1270,47 @@ func TestSublistRegisterInterestNotification(t *testing.T) {
 
 	s.Insert(wcqsub)
 	expectNone()
+
+	if err := s.RegisterNotification("queue.test.node", ch); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expectOne()
+	expectFalse()
+
+	qsub1 := newQSub("queue.test.node.already.exist", "queue")
+	s.Insert(qsub1)
+	expectNone()
+
+	qsub2 := newQSub("queue.test.node", "queue")
+	s.Insert(qsub2)
+	expectTrue()
+
+	qsub3 := newQSub("queue.test.node", "otherqueue")
+	s.Insert(qsub3)
+	expectNone()
+
+	qsub4 := newQSub("queue.different.node", "queue")
+	s.Insert(qsub4)
+	expectNone()
+
+	qsub5 := newQSub("queue.test.node", "queue")
+	s.Insert(qsub5)
+	expectNone()
+
+	s.Remove(qsub3)
+	expectNone()
+	s.Remove(qsub1)
+	expectNone()
+	s.Remove(qsub2)
+	expectNone()
+	s.Remove(qsub4)
+	expectNone()
+	s.Remove(qsub5)
+	expectFalse()
+
+	if !s.ClearNotification("queue.test.node", ch) {
+		t.Fatalf("Expected to return true")
+	}
 
 	// Test non-blocking notifications.
 	if err := s.RegisterNotification("bar", ch); err != nil {


### PR DESCRIPTION
The insert notification was done based on the creation of a node
during an insert, which was wrong since the node may have already
existed and still the subscription could be all new. For instance,
suppose that there is a subscription on "foo.bar".
We register an notification interest for "foo", which does not
notify, which is normal. Then we create a subscription on "foo".
During the insert, "foo" node already exists so notification would
not be sent, but it should.
Fixed also removed by having removeFromNode() returning a boolean
to indicate if the subscription was the last in that node.
However, it seems that we again check for interest in
chkForRemoveNotification(), so not sure if that is required.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
