### PR TITLE
Fixed service import cycle detection that broke with JS clustering

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3632,6 +3632,8 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 	// Copy our pubArg and account
 	pacopy := c.pa
 	oacc := c.acc
+	// Change this so that we detect recursion
+	c.pa.psi = si
 
 	// Place our client info for the request in the message.
 	// This will survive going across routes, etc.

--- a/test/accounts_cycles_test.go
+++ b/test/accounts_cycles_test.go
@@ -217,9 +217,6 @@ func TestAccountCycleServiceNonCycleChain(t *testing.T) {
 
 // bug: https://github.com/nats-io/nats-server/issues/1769
 func TestServiceImportReplyMatchCycle(t *testing.T) {
-	// FIXME(dlc) - failing
-	t.SkipNow()
-
 	conf := createConfFile(t, []byte(`
 		port: -1
 		accounts {
@@ -260,9 +257,6 @@ func TestServiceImportReplyMatchCycle(t *testing.T) {
 }
 
 func TestServiceImportReplyMatchCycleMultiHops(t *testing.T) {
-	// FIXME(dlc) - Fix!
-	t.SkipNow()
-
 	conf := createConfFile(t, []byte(`
 		port: -1
 		accounts {

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
+var noOpErrHandler = func(_ *nats.Conn, _ *nats.Subscription, _ error) {}
+
 func TestTLSConnection(t *testing.T) {
 	srv, opts := RunServerWithConfig("./configs/tls.conf")
 	defer srv.Shutdown()
@@ -1497,7 +1499,7 @@ func TestTLSClientAuthWithRDNSequence(t *testing.T) {
 			`
 				port: -1
 				%s
-		
+
 				authorization {
 				  users = [
 				    { user = "DC=com, DC=example, CN=*.example.com, O=NATS, OU=NATS, L=Los Angeles, ST=CA, C=US" }
@@ -1516,7 +1518,7 @@ func TestTLSClientAuthWithRDNSequence(t *testing.T) {
 			`
 				port: -1
 				%s
-		
+
 				authorization {
 				  users = [
 				    { user = "CN=*.example.com,OU=NATS,O=NATS,L=Los Angeles,ST=CA,C=US,DC=example,DC=com" }
@@ -1659,6 +1661,7 @@ func TestTLSClientAuthWithRDNSequence(t *testing.T) {
 			nc, err := nats.Connect(fmt.Sprintf("tls://localhost:%d", opts.Port),
 				test.certs,
 				nats.RootCAs("./configs/certs/rdns/ca.pem"),
+				nats.ErrorHandler(noOpErrHandler),
 			)
 			if test.err == nil && err != nil {
 				t.Errorf("Expected to connect, got %v", err)
@@ -1911,6 +1914,7 @@ func TestTLSClientSVIDAuth(t *testing.T) {
 			nc, err := nats.Connect(fmt.Sprintf("tls://localhost:%d", opts.Port),
 				test.certs,
 				nats.RootCAs("./configs/certs/svid/ca.pem"),
+				nats.ErrorHandler(noOpErrHandler),
 			)
 			if test.err == nil && err != nil {
 				t.Errorf("Expected to connect, got %v", err)


### PR DESCRIPTION
Also added some no-op error handler for some tests to silence the
error report in the log.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
