### PR TITLE
[added] enforcement and usage of scoped signing keys

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2857,14 +2857,13 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 	}
 	if len(a.signingKeys) != len(old.signingKeys) {
 		signersChanged = true
-	} else {
-		for k, scope := range a.signingKeys {
-			if oldScope, ok := old.signingKeys[k]; !ok {
-				signersChanged = true
-			} else if !reflect.DeepEqual(scope, oldScope) {
-				signersChanged = true
-				alteredScope[k] = struct{}{}
-			}
+	}
+	for k, scope := range a.signingKeys {
+		if oldScope, ok := old.signingKeys[k]; !ok {
+			signersChanged = true
+		} else if !reflect.DeepEqual(scope, oldScope) {
+			signersChanged = true
+			alteredScope[k] = struct{}{}
 		}
 	}
 	a.mu.Unlock()

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2849,7 +2849,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 	// update account signing keys
 	a.signingKeys = nil
 	if len(ac.SigningKeys) > 0 {
-		a.signingKeys = map[string]jwt.Scope{}
+		a.signingKeys = make(map[string]jwt.Scope, len(ac.SigningKeys))
 	}
 	signersChanged := false
 	for k, scope := range ac.SigningKeys {
@@ -3157,7 +3157,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 			c.mu.Lock()
 			sk := c.user.SigningKey
 			c.mu.Unlock()
-			if sk == "" {
+			if sk == _EMPTY_ {
 				continue
 			}
 			if _, ok := alteredScope[sk]; ok {

--- a/server/auth.go
+++ b/server/auth.go
@@ -567,7 +567,7 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 				return false
 			} else if scope != nil {
 				if err := scope.ValidateScopedSigner(juc); err != nil {
-					c.Debugf("User JWT is not valid")
+					c.Debugf("User JWT is not valid: %v", err)
 					return false
 				} else if uSc, ok := scope.(*jwt.UserScope); !ok {
 					c.Debugf("User JWT is not valid")

--- a/server/auth.go
+++ b/server/auth.go
@@ -561,9 +561,21 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			return false
 		}
 		// this only executes IF there's an issuer on the Juc - otherwise the account is already vetted
-		if juc.IssuerAccount != "" && !acc.hasIssuer(juc.Issuer) {
-			c.Debugf("User JWT issuer is not known")
-			return false
+		if juc.IssuerAccount != "" {
+			if scope, ok := acc.hasIssuer(juc.Issuer); !ok {
+				c.Debugf("User JWT issuer is not known")
+				return false
+			} else if scope != nil {
+				if err := scope.ValidateScopedSigner(juc); err != nil {
+					c.Debugf("User JWT is not valid")
+					return false
+				} else if uSc, ok := scope.(*jwt.UserScope); !ok {
+					c.Debugf("User JWT is not valid")
+					return false
+				} else {
+					juc.UserPermissionLimits = uSc.Template
+				}
+			}
 		}
 		if acc.IsExpired() {
 			c.Debugf("Account JWT has expired")

--- a/server/auth.go
+++ b/server/auth.go
@@ -561,7 +561,7 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			return false
 		}
 		// this only executes IF there's an issuer on the Juc - otherwise the account is already vetted
-		if juc.IssuerAccount != "" {
+		if juc.IssuerAccount != _EMPTY_ {
 			if scope, ok := acc.hasIssuer(juc.Issuer); !ok {
 				c.Debugf("User JWT issuer is not known")
 				return false

--- a/server/client.go
+++ b/server/client.go
@@ -688,7 +688,7 @@ func (c *client) applyAccountLimits() {
 		if uc, _ := jwt.DecodeUserClaims(c.opts.JWT); uc != nil {
 			c.mpay = int32(uc.Limits.Payload)
 			c.msubs = int32(uc.Limits.Subs)
-			if uc.IssuerAccount != "" && uc.IssuerAccount != uc.Issuer {
+			if uc.IssuerAccount != _EMPTY_ && uc.IssuerAccount != uc.Issuer {
 				if scope, ok := c.acc.signingKeys[uc.Issuer]; ok {
 					if userScope, ok := scope.(*jwt.UserScope); ok {
 						// if signing key disappeared or changed and we don't get here, the client will be disconnected

--- a/server/client.go
+++ b/server/client.go
@@ -688,6 +688,15 @@ func (c *client) applyAccountLimits() {
 		if uc, _ := jwt.DecodeUserClaims(c.opts.JWT); uc != nil {
 			c.mpay = int32(uc.Limits.Payload)
 			c.msubs = int32(uc.Limits.Subs)
+			if uc.IssuerAccount != "" && uc.IssuerAccount != uc.Issuer {
+				if scope, ok := c.acc.signingKeys[uc.Issuer]; ok {
+					if userScope, ok := scope.(*jwt.UserScope); ok {
+						// if signing key disappeared or changed and we don't get here, the client will be disconnected
+						c.mpay = int32(userScope.Template.Limits.Payload)
+						c.msubs = int32(userScope.Template.Limits.Subs)
+					}
+				}
+			}
 		}
 	}
 	minLimit(&c.mpay, c.acc.mpay)

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -4571,7 +4571,7 @@ func newUserEx(t *testing.T, accKp nkeys.KeyPair, scoped bool, issuerAccount str
 	uclaim := newJWTTestUserClaims()
 	uclaim.Subject = upub
 	uclaim.SetScoped(scoped)
-	if issuerAccount != "" {
+	if issuerAccount != _EMPTY_ {
 		uclaim.IssuerAccount = issuerAccount
 	}
 	ujwt, err := uclaim.Encode(accKp)

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -4497,9 +4497,9 @@ func TestJWTAccountOps(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			var syspub, sysjwt, sysCreds string
 			createAccountAndUser(&syspub, &sysjwt, &sysCreds)
+			defer os.Remove(sysCreds)
 			var apub, ajwt1, aCreds1 string
 			createAccountAndUser(&apub, &ajwt1, &aCreds1)
-			defer os.Remove(sysCreds)
 			defer os.Remove(aCreds1)
 			dirSrv := createDir(t, "srv")
 			defer os.RemoveAll(dirSrv)
@@ -4563,15 +4563,25 @@ func encodeClaim(t *testing.T, claim *jwt.AccountClaims, pub string) string {
 	return theJWT
 }
 
-func newUser(t *testing.T, accKp nkeys.KeyPair) string {
+// returns user creds
+func newUserEx(t *testing.T, accKp nkeys.KeyPair, scoped bool, issuerAccount string) string {
 	ukp, _ := nkeys.CreateUser()
 	seed, _ := ukp.Seed()
 	upub, _ := ukp.PublicKey()
 	uclaim := newJWTTestUserClaims()
 	uclaim.Subject = upub
+	uclaim.SetScoped(scoped)
+	if issuerAccount != "" {
+		uclaim.IssuerAccount = issuerAccount
+	}
 	ujwt, err := uclaim.Encode(accKp)
 	require_NoError(t, err)
 	return genCredsFile(t, ujwt, seed)
+}
+
+// returns user creds
+func newUser(t *testing.T, accKp nkeys.KeyPair) string {
+	return newUserEx(t, accKp, false, "")
 }
 
 func TestJWTHeader(t *testing.T) {
@@ -4978,4 +4988,133 @@ func TestJWTQueuePermissions(t *testing.T) {
 		})
 
 	}
+}
+
+func TestJWScopedSigningKeys(t *testing.T) {
+	sysKp, syspub := createKey(t)
+	sysJwt := encodeClaim(t, jwt.NewAccountClaims(syspub), syspub)
+	sysCreds := newUser(t, sysKp)
+	defer os.Remove(sysCreds)
+
+	_, aExpPub := createKey(t)
+	accClaim := jwt.NewAccountClaims(aExpPub)
+	accClaim.Name = "acc"
+
+	aSignNonScopedKp, aSignNonScopedPub := createKey(t)
+	accClaim.SigningKeys.Add(aSignNonScopedPub)
+
+	aSignScopedKp, aSignScopedPub := createKey(t)
+	signer := jwt.NewUserScope()
+	signer.Key = aSignScopedPub
+	signer.Template.Pub.Deny.Add("denied")
+	signer.Template.Payload = 5
+	accClaim.SigningKeys.AddScopedSigner(signer)
+	accJwt := encodeClaim(t, accClaim, aExpPub)
+
+	aNonScopedCreds := newUserEx(t, aSignNonScopedKp, false, aExpPub)
+	defer os.Remove(aNonScopedCreds)
+	aBadScopedCreds := newUserEx(t, aSignScopedKp, false, aExpPub)
+	defer os.Remove(aBadScopedCreds)
+	aScopedCreds := newUserEx(t, aSignScopedKp, true, aExpPub)
+	defer os.Remove(aScopedCreds)
+
+	dirSrv := createDir(t, "srv")
+	defer os.RemoveAll(dirSrv)
+	cf := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: -1
+		operator: %s
+		system_account: %s
+		resolver: {
+			type: full
+			dir: %s
+		}
+    `, ojwt, syspub, dirSrv)))
+	defer os.Remove(cf)
+	s, opts := RunServerWithConfig(cf)
+	defer s.Shutdown()
+
+	url := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
+	errChan := make(chan error, 1)
+	awaitError := func(expected bool) {
+		t.Helper()
+		select {
+		case err := <-errChan:
+			if !expected {
+				t.Fatalf("Expected no error, got %v", err)
+			}
+		case <-time.After(150 * time.Millisecond):
+			if expected {
+				t.Fatal("Expected an error")
+			}
+		}
+	}
+	errHdlr := nats.DisconnectErrHandler(func(conn *nats.Conn, err error) {
+		errChan <- err
+	})
+	if updateJwt(t, url, sysCreds, sysJwt, 1) != 1 {
+		t.Error("Expected update to pass")
+	} else if updateJwt(t, url, sysCreds, accJwt, 1) != 1 {
+		t.Error("Expected update to pass")
+	}
+	t.Run("bad-scoped-signing-key", func(t *testing.T) {
+		_, err := nats.Connect(url, nats.UserCredentials(aBadScopedCreds))
+		require_Error(t, err)
+	})
+	t.Run("regular-signing-key", func(t *testing.T) {
+		nc := natsConnect(t, url, nats.UserCredentials(aNonScopedCreds), errHdlr)
+		defer nc.Close()
+		err := nc.Publish("denied", nil)
+		require_NoError(t, err)
+		awaitError(false)
+	})
+	t.Run("scoped-signing-key-1", func(t *testing.T) {
+		nc := natsConnect(t, url, nats.UserCredentials(aScopedCreds), errHdlr)
+		defer nc.Close()
+		err := nc.Publish("too-long", []byte("way.too.long.for.payload.limit"))
+		require_NoError(t, err)
+		awaitError(true)
+	})
+	t.Run("scoped-signing-key-2", func(t *testing.T) {
+		nc := natsConnect(t, url, nats.UserCredentials(aScopedCreds), errHdlr)
+		defer nc.Close()
+		err := nc.Publish("denied", nil)
+		require_NoError(t, err)
+		awaitError(true)
+	})
+	t.Run("scoped-signing-key-reload", func(t *testing.T) {
+		reconChan := make(chan struct{}, 1)
+		defer close(reconChan)
+		msgChan := make(chan *nats.Msg, 2)
+		defer close(msgChan)
+		nc := natsConnect(t, url, nats.UserCredentials(aScopedCreds), errHdlr,
+			nats.ReconnectHandler(func(conn *nats.Conn) {
+				reconChan <- struct{}{}
+			}),
+		)
+		defer nc.Close()
+		_, err := nc.ChanSubscribe("denied", msgChan)
+		require_NoError(t, err)
+		err = nc.Publish("denied", nil)
+		require_NoError(t, err)
+		awaitError(true)
+		require_Len(t, len(msgChan), 0)
+		// Alter scoped permissions and update
+		signer.Template.Payload = -1
+		signer.Template.Pub.Deny.Remove("denied")
+		accClaim.SigningKeys.AddScopedSigner(signer)
+		accUpdatedJwt := encodeClaim(t, accClaim, aExpPub)
+		if updateJwt(t, url, sysCreds, accUpdatedJwt, 1) != 1 {
+			t.Error("Expected update to pass")
+		}
+		// disconnect triggered by update
+		awaitError(true)
+		<-reconChan
+		if err := nc.Publish("denied", []byte("way.too.long.for.old.payload.limit")); err != nil {
+			t.Fatalf("Expected no error %v", err)
+		}
+		awaitError(false)
+		msg := <-msgChan
+		require_Equal(t, string(msg.Data), "way.too.long.for.old.payload.limit")
+		require_Len(t, len(msgChan), 0)
+	})
 }


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

I added a lookup of the scoped signing key to applyAccountLimits. 
passing in the values into the function would have made the change a lot bigger.

Currently the update strategy of scoped keys is to disconnect the clients