### PR TITLE
Update error message with correct config value

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -131,7 +131,7 @@ func validateJetStreamOptions(o *Options) error {
 		return fmt.Errorf("jetstream cluster requires `server_name` to be set")
 	}
 	if o.Cluster.Name == _EMPTY_ {
-		return fmt.Errorf("jetstream cluster requires `cluster_name` to be set")
+		return fmt.Errorf("jetstream cluster requires `cluster.name` to be set")
 	}
 	return nil
 }

--- a/test/jetstream_cluster_test.go
+++ b/test/jetstream_cluster_test.go
@@ -58,7 +58,7 @@ func TestJetStreamClusterConfig(t *testing.T) {
 	`))
 	defer os.Remove(conf)
 
-	check("requires `cluster_name`")
+	check("requires `cluster.name`")
 }
 
 func TestJetStreamClusterLeader(t *testing.T) {


### PR DESCRIPTION
 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [x] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #

### Changes proposed in this pull request:

 - Update error message to indicate where the cluster name is set to. The current server startup error was misleading (it was probably copied from the `server_name`)

/cc @nats-io/core
