### PR TITLE
Fixed gateway reply mapping following changes in JetStream clustering

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -562,6 +562,11 @@ func (s *Server) startRemoteServerSweepTimer() {
 // Length of our system hash used for server targeted messages.
 const sysHashLen = 8
 
+// Computes a hash of 8 characters for the name.
+func getHash(name string) []byte {
+	return getHashSize(name, sysHashLen)
+}
+
 // This will setup our system wide tracking subs.
 // For now we will setup one wildcard subscription to
 // monitor all accounts for changes in number of connections.

--- a/server/server.go
+++ b/server/server.go
@@ -124,7 +124,6 @@ type Server struct {
 	clients          map[uint64]*client
 	routes           map[uint64]*client
 	routesByHash     sync.Map
-	hash             []byte
 	remotes          map[string]*client
 	leafs            map[uint64]*client
 	users            map[string]*User


### PR DESCRIPTION
Those changes are required to maintain backward compatibility.
Since the replies are "_G_.<gateway name hash>.<server ID hash>"
and the hash were 6 characters long, changing to 8 the hash function
would break things.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
