### PR TITLE
Simplify sendSubsToRoute()

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -876,19 +876,6 @@ func (a *Account) removeClient(c *client) int {
 	return n
 }
 
-func (a *Account) randomClient() *client {
-	if a.ic != nil {
-		return a.ic
-	}
-	var c *client
-	for c = range a.clients {
-		if c.acc == a {
-			break
-		}
-	}
-	return c
-}
-
 // AddServiceExport will configure the account with the defined export.
 func (a *Account) AddServiceExport(subject string, accounts []*Account) error {
 	return a.AddServiceExportWithResponse(subject, Singleton, accounts)

--- a/server/server.go
+++ b/server/server.go
@@ -1048,14 +1048,6 @@ func (s *Server) setSystemAccount(acc *Account) error {
 	if acc.imports.services == nil {
 		acc.imports.services = make(map[string]*serviceImport)
 	}
-
-	// Create a dummy internal client for fast lookup for
-	// randomClient used in route xfer of subs. Also will
-	// be stable with account.
-	if acc.ic == nil {
-		acc.ic = s.createInternalAccountClient()
-		acc.ic.acc = acc
-	}
 	acc.mu.Unlock()
 
 	s.sys = &internal{

--- a/test/norace_test.go
+++ b/test/norace_test.go
@@ -82,8 +82,11 @@ func TestNoRaceRouteSendSubs(t *testing.T) {
 
 	// total number of subscriptions per server
 	totalPerServer := 100000
-	for i := 0; i < totalPerServer; i++ {
-		proto := fmt.Sprintf("SUB foo.%d %d\r\n", i, i*2)
+	for i := 0; i < totalPerServer/2; i++ {
+		proto := fmt.Sprintf("SUB foo.%d %d\r\n", i, i*2+1)
+		clientASend(proto)
+		clientBSend(proto)
+		proto = fmt.Sprintf("SUB bar.%d queue.%d %d\r\n", i, i, i*2+2)
 		clientASend(proto)
 		clientBSend(proto)
 	}


### PR DESCRIPTION
Since we were creating subs on the fly, sub.im would always be nil.
We were passing a client because it was needed in sendRouteSubOrUnSubProtos().

This PR simply fills the buffer with each account's subscriptions.
There is also no need to have subs sent from different go routine
based on some threshold. Routes are no longer subject to max pending.

Some code has been made into a function so that they can be shared
by sendSubsToRoute() and sendRouteSubOrUnSubProtos(). The function
is simply adding to given buffer the RS+/- protocol.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
