### PR TITLE
[ADDED] Allow bearer token as mqtt authentication method

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -1436,6 +1436,7 @@ func (c *client) mqttParseConnect(r *mqttReader, pl int) (byte, *mqttConnectProt
 			return 0, nil, err
 		}
 		c.opts.Token = c.opts.Password
+		c.opts.JWT = c.opts.Password
 	}
 	return 0, cp, nil
 }


### PR DESCRIPTION
### Changes proposed in this pull request:

 - Allow parsing password field on MQTT Connect request as a JWT to use bearer token client authentication/authorization

### Tests added

 - Test MQTT authentication with tokens with different "allowed connection types" to ensure correct user authorization

/cc @nats-io/core
