### PR TITLE
Add --server_name flag to set server name

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -4036,6 +4036,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.IntVar(&opts.Port, "p", 0, "Port to listen on.")
 	fs.StringVar(&opts.ServerName, "n", "", "Server name.")
 	fs.StringVar(&opts.ServerName, "name", "", "Server name.")
+	fs.StringVar(&opts.ServerName, "server_name", "", "Server name.")
 	fs.StringVar(&opts.Host, "addr", "", "Network host to listen on.")
 	fs.StringVar(&opts.Host, "a", "", "Network host to listen on.")
 	fs.StringVar(&opts.Host, "net", "", "Network host to listen on.")


### PR DESCRIPTION
When JS with clustering is enabled, a `server_name` is required error is reported (since that is the name of the config option), though there is no `server_name` flag since to set the name in the command line either `-n` or `--name` have to be used instead. Have ran into this a few times so thought might be good to add an option when creating a cluster via the CLI.

```sh
nats-server -js -p 4222 --cluster nats://127.0.0.1:6222 --cluster_name ABC --routes nats://127.0.0.1:6222,nats://127.0.0.1:6223,nats://127.0.0.1:6224 -D
nats-server: jetstream cluster requires `server_name` to be set
```

With the new flag:

```sh
nats-server -js -p 4222 --server_name=A --cluster nats://127.0.0.1:6222 --cluster_name ABC --routes nats://127.0.0.1:6222,nats://127.0.0.1:6223,nats://127.0.0.1:6224 -D
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

/cc @nats-io/core
