### PR TITLE
[CHANGED] Enforce max_control_line for client connections only

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -124,8 +124,8 @@ const (
 	// PROTO_SNIPPET_SIZE is the default size of proto to print on parse errors.
 	PROTO_SNIPPET_SIZE = 32
 
-	// MAX_CONTOL_LINE_SNIPPET_SIZE is the default size of proto to print on max control line errors.
-	MAX_CONTOL_LINE_SNIPPET_SIZE = 128
+	// MAX_CONTROL_LINE_SNIPPET_SIZE is the default size of proto to print on max control line errors.
+	MAX_CONTROL_LINE_SNIPPET_SIZE = 128
 
 	// MAX_MSG_ARGS Maximum possible number of arguments from MSG proto.
 	MAX_MSG_ARGS = 4

--- a/server/const.go
+++ b/server/const.go
@@ -124,6 +124,9 @@ const (
 	// PROTO_SNIPPET_SIZE is the default size of proto to print on parse errors.
 	PROTO_SNIPPET_SIZE = 32
 
+	// MAX_CONTOL_LINE_SNIPPET_SIZE is the default size of proto to print on max control line errors.
+	MAX_CONTOL_LINE_SNIPPET_SIZE = 128
+
 	// MAX_MSG_ARGS Maximum possible number of arguments from MSG proto.
 	MAX_MSG_ARGS = 4
 

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -251,6 +251,7 @@ func TestNoPasswordsFromConnectTrace(t *testing.T) {
 	opts.Username = "derek"
 	opts.Password = "s3cr3t"
 	opts.PingInterval = 2 * time.Minute
+	setBaselineOptions(opts)
 	s := &Server{opts: opts}
 	dl := &DummyLogger{}
 	s.SetLogger(dl, false, true)

--- a/server/parser.go
+++ b/server/parser.go
@@ -259,6 +259,9 @@ func (c *client) parse(buf []byte) error {
 				} else {
 					arg = buf[c.as : i-c.drop]
 				}
+				if err := c.overMaxControlLineLimit(arg, mcl); err != nil {
+					return err
+				}
 				if trace {
 					c.traceInOp("HPUB", arg)
 				}
@@ -318,6 +321,9 @@ func (c *client) parse(buf []byte) error {
 					c.argBuf = nil
 				} else {
 					arg = buf[c.as : i-c.drop]
+				}
+				if err := c.overMaxControlLineLimit(arg, mcl); err != nil {
+					return err
 				}
 				var err error
 				if c.kind == ROUTER || c.kind == GATEWAY {
@@ -390,6 +396,9 @@ func (c *client) parse(buf []byte) error {
 					c.argBuf = nil
 				} else {
 					arg = buf[c.as : i-c.drop]
+				}
+				if err := c.overMaxControlLineLimit(arg, mcl); err != nil {
+					return err
 				}
 				if trace {
 					c.traceInOp("PUB", arg)
@@ -508,6 +517,9 @@ func (c *client) parse(buf []byte) error {
 				} else {
 					arg = buf[c.as : i-c.drop]
 				}
+				if err := c.overMaxControlLineLimit(arg, mcl); err != nil {
+					return err
+				}
 				if trace {
 					c.traceInOp("A+", arg)
 				}
@@ -546,6 +558,9 @@ func (c *client) parse(buf []byte) error {
 					c.argBuf = nil
 				} else {
 					arg = buf[c.as : i-c.drop]
+				}
+				if err := c.overMaxControlLineLimit(arg, mcl); err != nil {
+					return err
 				}
 				if trace {
 					c.traceInOp("A-", arg)
@@ -597,6 +612,9 @@ func (c *client) parse(buf []byte) error {
 					c.argBuf = nil
 				} else {
 					arg = buf[c.as : i-c.drop]
+				}
+				if err := c.overMaxControlLineLimit(arg, mcl); err != nil {
+					return err
 				}
 				var err error
 
@@ -729,6 +747,9 @@ func (c *client) parse(buf []byte) error {
 					c.argBuf = nil
 				} else {
 					arg = buf[c.as : i-c.drop]
+				}
+				if err := c.overMaxControlLineLimit(arg, mcl); err != nil {
+					return err
 				}
 				var err error
 
@@ -876,6 +897,9 @@ func (c *client) parse(buf []byte) error {
 				} else {
 					arg = buf[c.as : i-c.drop]
 				}
+				if err := c.overMaxControlLineLimit(arg, mcl); err != nil {
+					return err
+				}
 				if trace {
 					c.traceInOp("CONNECT", removePassFromTrace(arg))
 				}
@@ -933,6 +957,9 @@ func (c *client) parse(buf []byte) error {
 					c.argBuf = nil
 				} else {
 					arg = buf[c.as : i-c.drop]
+				}
+				if err := c.overMaxControlLineLimit(arg, mcl); err != nil {
+					return err
 				}
 				var err error
 				if c.kind == ROUTER || c.kind == GATEWAY {
@@ -1010,6 +1037,9 @@ func (c *client) parse(buf []byte) error {
 				} else {
 					arg = buf[c.as : i-c.drop]
 				}
+				if err := c.overMaxControlLineLimit(arg, mcl); err != nil {
+					return err
+				}
 				if err := c.processInfo(arg); err != nil {
 					return err
 				}
@@ -1086,6 +1116,9 @@ func (c *client) parse(buf []byte) error {
 				} else {
 					arg = buf[c.as : i-c.drop]
 				}
+				if err := c.overMaxControlLineLimit(arg, mcl); err != nil {
+					return err
+				}
 				c.processErr(string(arg))
 				c.drop, c.as, c.state = 0, i+1, OP_START
 			default:
@@ -1113,11 +1146,7 @@ func (c *client) parse(buf []byte) error {
 		// Check for violations of control line length here. Note that this is not
 		// exact at all but the performance hit is too great to be precise, and
 		// catching here should prevent memory exhaustion attacks.
-		if len(c.argBuf) > int(mcl) {
-			err := NewErrorCtx(ErrMaxControlLine, "State %d, max_control_line %d, Buffer len %d",
-				c.state, int(mcl), len(c.argBuf))
-			c.sendErr(err.Error())
-			c.closeConnection(MaxControlLineExceeded)
+		if err := c.overMaxControlLineLimit(c.argBuf, mcl); err != nil {
 			return err
 		}
 	}
@@ -1160,13 +1189,13 @@ authErr:
 
 parseErr:
 	c.sendErr("Unknown Protocol Operation")
-	snip := protoSnippet(i, buf)
+	snip := protoSnippet(i, PROTO_SNIPPET_SIZE, buf)
 	err := fmt.Errorf("%s parser ERROR, state=%d, i=%d: proto='%s...'", c.typeString(), c.state, i, snip)
 	return err
 }
 
-func protoSnippet(start int, buf []byte) string {
-	stop := start + PROTO_SNIPPET_SIZE
+func protoSnippet(start, max int, buf []byte) string {
+	stop := start + max
 	bufSize := len(buf)
 	if start >= bufSize {
 		return `""`
@@ -1175,6 +1204,23 @@ func protoSnippet(start int, buf []byte) string {
 		stop = bufSize - 1
 	}
 	return fmt.Sprintf("%q", buf[start:stop])
+}
+
+// Check if the length of buffer `arg` is over the max control line limit `mcl`.
+// If so, an error is sent to the client and the connection is closed.
+// The error ErrMaxControlLine is returned.
+func (c *client) overMaxControlLineLimit(arg []byte, mcl int32) error {
+	if c.kind != CLIENT {
+		return nil
+	}
+	if len(arg) > int(mcl) {
+		err := NewErrorCtx(ErrMaxControlLine, "State %d, max_control_line %d, Buffer len %d (snip: %s...)",
+			c.state, int(mcl), len(c.argBuf), protoSnippet(0, MAX_CONTOL_LINE_SNIPPET_SIZE, arg))
+		c.sendErr(err.Error())
+		c.closeConnection(MaxControlLineExceeded)
+		return err
+	}
+	return nil
 }
 
 // clonePubArg is used when the split buffer scenario has the pubArg in the existing read buffer, but

--- a/server/parser.go
+++ b/server/parser.go
@@ -1215,7 +1215,7 @@ func (c *client) overMaxControlLineLimit(arg []byte, mcl int32) error {
 	}
 	if len(arg) > int(mcl) {
 		err := NewErrorCtx(ErrMaxControlLine, "State %d, max_control_line %d, Buffer len %d (snip: %s...)",
-			c.state, int(mcl), len(c.argBuf), protoSnippet(0, MAX_CONTOL_LINE_SNIPPET_SIZE, arg))
+			c.state, int(mcl), len(c.argBuf), protoSnippet(0, MAX_CONTROL_LINE_SNIPPET_SIZE, arg))
 		c.sendErr(err.Error())
 		c.closeConnection(MaxControlLineExceeded)
 		return err


### PR DESCRIPTION
Only check limit for CLIENT connection types, however, the check
is done for CLIENT in all conditions, not only in the case of a
split buffer as it was the case so far.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
