### PR TITLE
[ADDED] Websocket for Leaf Node connections

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -675,7 +675,7 @@ func (s *Server) createLeafNode(conn net.Conn, rURL *url.URL, remote *leafNodeCf
 	// a remote Leaf Node connection as a websocket connection.
 	if remote != nil && rURL != nil && isWSURL(rURL) {
 		remote.RLock()
-		c.ws = &websocket{compress: remote.Compress, maskwrite: remote.WSMasking}
+		c.ws = &websocket{compress: remote.Websocket.Compression, maskwrite: !remote.Websocket.NoMasking}
 		remote.RUnlock()
 	}
 
@@ -1987,9 +1987,9 @@ func (c *client) leafNodeGetTLSConfigForSolicit(remote *leafNodeCfg, needsLock b
 // Lock held on entry.
 func (c *client) leafNodeSolicitWSConnection(opts *Options, rURL *url.URL, remote *leafNodeCfg) ([]byte, ClosedState, error) {
 	remote.RLock()
-	compress := remote.Compress
-	// WSMasking will be true if the server should mask its writes and behave like a websocket client.
-	noMasking := !remote.WSMasking
+	compress := remote.Websocket.Compression
+	// By default the server will mask outbound frames, but it can be disabled with this option.
+	noMasking := remote.Websocket.NoMasking
 	tlsRequired, tlsConfig, tlsName, tlsTimeout := c.leafNodeGetTLSConfigForSolicit(remote, false)
 	remote.RUnlock()
 	// Do TLS here as needed.

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -953,7 +953,7 @@ func TestLeafCloseTLSConnection(t *testing.T) {
 	ch <- true
 }
 
-func TestLeafCloseTLSSaveName(t *testing.T) {
+func TestLeafNodeTLSSaveName(t *testing.T) {
 	opts := DefaultOptions()
 	opts.LeafNode.Host = "127.0.0.1"
 	opts.LeafNode.Port = -1

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -2496,8 +2496,8 @@ func TestLeafNodeWSBasic(t *testing.T) {
 			defer s.Shutdown()
 
 			lo := testDefaultRemoteLeafNodeWSOptions(t, o, test.tls)
-			lo.LeafNode.Remotes[0].Compress = test.remoteCompression
-			lo.LeafNode.Remotes[0].WSMasking = test.masking
+			lo.LeafNode.Remotes[0].Websocket.Compression = test.remoteCompression
+			lo.LeafNode.Remotes[0].Websocket.NoMasking = !test.masking
 			ln := RunServer(lo)
 			defer ln.Shutdown()
 
@@ -2573,26 +2573,26 @@ func TestLeafNodeWSBasic(t *testing.T) {
 
 func TestLeafNodeWSRemoteCompressAndMaskingOptions(t *testing.T) {
 	for _, test := range []struct {
-		name     string
-		compress bool
-		compStr  string
-		masking  bool
-		maskStr  string
+		name      string
+		compress  bool
+		compStr   string
+		noMasking bool
+		noMaskStr string
 	}{
-		{"compression no masking", true, "true", false, "false"},
-		{"compression masking", true, "true", true, "true"},
-		{"no compression no masking", false, "false", false, "false"},
-		{"no compression masking", false, "false", true, "true"},
+		{"compression masking", true, "true", false, "false"},
+		{"compression no masking", true, "true", true, "true"},
+		{"no compression masking", false, "false", false, "false"},
+		{"no compression no masking", false, "false", true, "true"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			conf := createConfFile(t, []byte(fmt.Sprintf(`
 				port: -1
 				leafnodes {
 					remotes [
-						{url: "ws://127.0.0.1:1234", compress: %s, ws_masking: %s}
+						{url: "ws://127.0.0.1:1234", ws_compression: %s, ws_no_masking: %s}
 					]
 				}
-			`, test.compStr, test.maskStr)))
+			`, test.compStr, test.noMaskStr)))
 			defer os.Remove(conf)
 			o, err := ProcessConfigFile(conf)
 			if err != nil {
@@ -2602,11 +2602,11 @@ func TestLeafNodeWSRemoteCompressAndMaskingOptions(t *testing.T) {
 				t.Fatalf("Expected 1 remote, got %v", nr)
 			}
 			r := o.LeafNode.Remotes[0]
-			if cur := r.Compress; cur != test.compress {
+			if cur := r.Websocket.Compression; cur != test.compress {
 				t.Fatalf("Expected compress to be %v, got %v", test.compress, cur)
 			}
-			if cur := r.WSMasking; cur != test.masking {
-				t.Fatalf("Expected ws_masking to be %v, got %v", test.compress, cur)
+			if cur := r.Websocket.NoMasking; cur != test.noMasking {
+				t.Fatalf("Expected ws_masking to be %v, got %v", test.noMasking, cur)
 			}
 		})
 	}

--- a/server/opts.go
+++ b/server/opts.go
@@ -145,6 +145,8 @@ type RemoteLeafOpts struct {
 	TLSConfig    *tls.Config `json:"-"`
 	TLSTimeout   float64     `json:"tls_timeout,omitempty"`
 	Hub          bool        `json:"hub,omitempty"`
+	Compress     bool        `json:"-"`
+	WSMasking    bool        `json:"-"`
 	DenyImports  []string    `json:"-"`
 	DenyExports  []string    `json:"-"`
 }
@@ -1798,6 +1800,10 @@ func parseRemoteLeafNodes(v interface{}, errors *[]error, warnings *[]error) ([]
 					continue
 				}
 				remote.DenyExports = subjects
+			case "compress", "compression":
+				remote.Compress = v.(bool)
+			case "ws_masking", "websocket_masking":
+				remote.WSMasking = v.(bool)
 			default:
 				if !tk.IsUsedVariable() {
 					err := &unknownConfigFieldErr{
@@ -3541,7 +3547,7 @@ func parseWebsocket(v interface{}, o *Options, errors *[]error, warnings *[]erro
 				*errors = append(*errors, err)
 			}
 			o.Websocket.HandshakeTimeout = ht
-		case "compression":
+		case "compress", "compression":
 			o.Websocket.Compression = mv.(bool)
 		case "authorization", "authentication":
 			auth := parseSimpleAuth(tk, errors, warnings)

--- a/server/opts.go
+++ b/server/opts.go
@@ -145,10 +145,17 @@ type RemoteLeafOpts struct {
 	TLSConfig    *tls.Config `json:"-"`
 	TLSTimeout   float64     `json:"tls_timeout,omitempty"`
 	Hub          bool        `json:"hub,omitempty"`
-	Compress     bool        `json:"-"`
-	WSMasking    bool        `json:"-"`
 	DenyImports  []string    `json:"-"`
 	DenyExports  []string    `json:"-"`
+
+	// When an URL has the "ws" (or "wss") scheme, then the server will initiate the
+	// connection as a websocket connection. By default, the websocket frames will be
+	// masked (as if this server was a websocket client to the remote server). The
+	// NoMasking option will change this behavior and will send umasked frames.
+	Websocket struct {
+		Compression bool `json:"-"`
+		NoMasking   bool `json:"-"`
+	}
 }
 
 // Options block for nats-server.
@@ -1800,10 +1807,10 @@ func parseRemoteLeafNodes(v interface{}, errors *[]error, warnings *[]error) ([]
 					continue
 				}
 				remote.DenyExports = subjects
-			case "compress", "compression":
-				remote.Compress = v.(bool)
-			case "ws_masking", "websocket_masking":
-				remote.WSMasking = v.(bool)
+			case "ws_compress", "ws_compression", "websocket_compress", "websocket_compression":
+				remote.Websocket.Compression = v.(bool)
+			case "ws_no_masking", "websocket_no_masking":
+				remote.Websocket.NoMasking = v.(bool)
 			default:
 				if !tk.IsUsedVariable() {
 					err := &unknownConfigFieldErr{


### PR DESCRIPTION
Users will now be able to create a Leafnode connection to the websocket
port of the remote server.

The URL in the remote configuration has to start with "ws" (or "wss").

By default, since this is communication between two servers, the websocket
frames will not be masked. However, there is an option to force the masking.

Here is what a remote leafnode configuration would look like:
```
leaf {
  remotes [
     # Ask for compression (the websocket{} block in the remote server has
     # to have compression enabled for them to negotiate), and ask for
     # the server to not mask outbound websocket frames.
     {url: "ws://host1:6222", ws_compression: true, ws_no_masking: true}

     # Same than above but with masking of websocket frames (the default)
     {url: "ws://host2:6222", ws_compression: true}

     # Without specific options, this will mask frames and not ask for compression.
     {url: "ws://host3:6222"}
  ]
}
```

/cc @nats-io/core
