### PR TITLE
[FIXED] Fix for #1864

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1796,6 +1796,7 @@ func (a *Account) addServiceImportSub(si *serviceImport) error {
 		c.processServiceImport(si, a, msg)
 	}
 	_, err := c.processSub([]byte(subject), nil, []byte(sid), cb, true)
+
 	return err
 }
 
@@ -3085,6 +3086,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 	if a.srv == nil {
 		a.srv = s
 	}
+
 	if jsEnabled {
 		if ac.Limits.JetStreamLimits.DiskStorage != 0 || ac.Limits.JetStreamLimits.MemoryStorage != 0 {
 			// JetStreamAccountLimits and jwt.JetStreamLimits use same value for unlimited
@@ -3110,6 +3112,8 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 		})
 	}
 
+	// If JetStream is enabled for this server we will call into configJetStream for the account
+	// regardless of enabled or disabled. It handles both cases.
 	if jsEnabled {
 		if err := s.configJetStream(a); err != nil {
 			s.Errorf("Error configuring jetstream for account [%s]: %v", a.Name, err.Error())

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -157,7 +157,7 @@ func (s *Server) EnableJetStream(config *JetStreamConfig) error {
 
 	// JetStream is an internal service so we need to make sure we have a system account.
 	// This system account will export the JetStream service endpoints.
-	if sacc := s.SystemAccount(); sacc == nil {
+	if s.SystemAccount() == nil {
 		s.SetDefaultSystemAccount()
 	}
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -986,8 +986,10 @@ func (js *jetStream) monitorStream(mset *Stream, sa *streamAssignment) {
 	t := time.NewTicker(compactInterval)
 	defer t.Stop()
 
+	js.mu.RLock()
 	isLeader := cc.isStreamLeader(sa.Client.Account, sa.Config.Name)
 	isRestore := sa.Restore != nil
+	js.mu.RUnlock()
 
 	acc, err := s.LookupAccount(sa.Client.Account)
 	if err != nil {

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -4707,10 +4707,13 @@ func TestJWTHeader(t *testing.T) {
 
 func TestJWTAccountImportsWithWildcardSupport(t *testing.T) {
 	test := func(aExpPub, aExpJwt, aExpCreds, aImpPub, aImpJwt, aImpCreds string, jsEnabled bool, exSubExpect, exPub, imReq, imSubExpect string) {
-		jsSetting := ""
+		t.Helper()
+
+		var jsSetting string
 		if jsEnabled {
 			jsSetting = "jetstream: {max_mem_store: 10Mb, max_file_store: 10Mb}"
 		}
+
 		_, aSysPub := createKey(t)
 		aSysClaim := jwt.NewAccountClaims(aSysPub)
 		aSysJwt := encodeClaim(t, aSysClaim, aSysPub)

--- a/server/server.go
+++ b/server/server.go
@@ -1380,9 +1380,11 @@ func (s *Server) fetchAccount(name string) (*Account, error) {
 	}
 	// The sub imports may have been setup but will not have had their
 	// subscriptions properly setup. Do that here.
-	if len(acc.imports.services) > 0 && acc.ic == nil {
-		acc.ic = s.createInternalAccountClient()
-		acc.ic.acc = acc
+	if len(acc.imports.services) > 0 {
+		if acc.ic == nil {
+			acc.ic = s.createInternalAccountClient()
+			acc.ic.acc = acc
+		}
 		acc.addAllServiceImportSubs()
 	}
 	return acc, nil


### PR DESCRIPTION
When trying to make sure we properly created all subs for service imports we would check the internal client to see if we should process. With JS enabled on the server we would place system imports that would break that check and orphan other service imports.

Resolves #1864 

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
