### PR TITLE
Fixed compression http header request/response

### DIFF
--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -2621,6 +2621,7 @@ func TestLeafNodeWSNoMaskingRejected(t *testing.T) {
 	defer s.Shutdown()
 
 	lo := testDefaultRemoteLeafNodeWSOptions(t, o, false)
+	lo.LeafNode.Remotes[0].Websocket.NoMasking = true
 	ln := RunServer(lo)
 	defer ln.Shutdown()
 


### PR DESCRIPTION
The issue was introduced by PR #1858.

Key points:

- Sec-WebSocket-Extensions must contain approved headers, so moving
the "no-masking" private extension to its own header "Nats-No-Masking".

- The format of the permessage-deflate negotiation response became
invalid, I have fixed that.

- For leaf nodes, if `permessage-deflate` extension is not at all
present in the response, then simply disable compression, however
if it is present but there is no server/client no context take over,
then we have to fail the connection.

- A leafnode test was not setting the "NoMasking" option so the
test TestLeafNodeWSNoMaskingRejected was not capturing possible
error if negotiation failed.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
