### PR TITLE
First pass at supercluster enablement.

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4662,9 +4662,12 @@ func (c *client) getClientInfo(detailed bool) *ClientInfo {
 		return nil
 	}
 	// Server name. Defaults to server ID if not set explicitly.
-	var sn string
-	if detailed && c.kind != LEAF {
-		sn = c.srv.Name()
+	var cn, sn string
+	if detailed {
+		if c.kind != LEAF {
+			sn = c.srv.Name()
+		}
+		cn = c.srv.cachedClusterName()
 	}
 
 	c.mu.Lock()
@@ -4685,6 +4688,7 @@ func (c *client) getClientInfo(detailed bool) *ClientInfo {
 		ci.Lang = c.opts.Lang
 		ci.Version = c.opts.Version
 		ci.Server = sn
+		ci.Cluster = cn
 		ci.Jwt = c.opts.JWT
 		ci.IssuerKey = issuerForClient(c)
 		ci.NameTag = c.nameTag

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -46,6 +46,12 @@ type jetStreamCluster struct {
 	consumerResults *subscription
 }
 
+// Used to guide placement of streams in clustered JetStream.
+type Placement struct {
+	Cluster string   `json:"cluster"`
+	Tags    []string `json:"tags,omitempty"`
+}
+
 // Define types of the entry.
 type entryOp uint8
 
@@ -2582,22 +2588,32 @@ func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, removePe
 
 // selectPeerGroup will select a group of peers to start a raft group.
 // TODO(dlc) - For now randomly select. Can be way smarter.
-func (cc *jetStreamCluster) selectPeerGroup(r int) []string {
+func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string) []string {
 	var nodes []string
 	peers := cc.meta.Peers()
-	// Make sure they are active
-	s := cc.s
-	ourID := cc.meta.ID()
+	s, ourID := cc.s, cc.meta.ID()
+
+	now := time.Now()
 	for _, p := range peers {
-		// FIXME(dlc) - cluster scoped.
-		if p.ID == ourID || s.getRouteByHash([]byte(p.ID)) != nil {
-			nodes = append(nodes, p.ID)
+		// Make sure they are active and current.
+		current, lastSeen := p.Current, now.Sub(p.Last)
+		if current && lastSeen > lostQuorumInterval {
+			current = false
+		}
+		if p.ID == ourID || current {
+			if cluster != _EMPTY_ {
+				if s.clusterNameForNode(p.ID) == cluster {
+					nodes = append(nodes, p.ID)
+				}
+			} else {
+				nodes = append(nodes, p.ID)
+			}
 		}
 	}
 	if len(nodes) < r {
 		return nil
 	}
-	// Don't depend on range.
+	// Don't depend on range to randomize.
 	rand.Shuffle(len(nodes), func(i, j int) { nodes[i], nodes[j] = nodes[j], nodes[i] })
 	return nodes[:r]
 }
@@ -2622,15 +2638,18 @@ func groupName(prefix string, peers []string, storage StorageType) string {
 
 // createGroupForStream will create a group for assignment for the stream.
 // Lock should be held.
-func (cc *jetStreamCluster) createGroupForStream(cfg *StreamConfig) *raftGroup {
+func (cc *jetStreamCluster) createGroupForStream(ci *ClientInfo, cfg *StreamConfig) *raftGroup {
 	replicas := cfg.Replicas
 	if replicas == 0 {
 		replicas = 1
 	}
-
+	cluster := ci.Cluster
+	if cfg.Placement != nil && cfg.Placement.Cluster != _EMPTY_ {
+		cluster = cfg.Placement.Cluster
+	}
 	// Need to create a group here.
 	// TODO(dlc) - Can be way smarter here.
-	peers := cc.selectPeerGroup(replicas)
+	peers := cc.selectPeerGroup(replicas, cluster)
 	if len(peers) == 0 {
 		return nil
 	}
@@ -2682,7 +2701,7 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, subject, reply string,
 	}
 
 	// Raft group selection and placement.
-	rg := cc.createGroupForStream(cfg)
+	rg := cc.createGroupForStream(ci, cfg)
 	if rg == nil {
 		resp.Error = jsInsufficientErr
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
@@ -2770,7 +2789,7 @@ func (s *Server) jsClusteredStreamRestoreRequest(ci *ClientInfo, acc *Account, r
 	}
 
 	// Raft group selection and placement.
-	rg := cc.createGroupForStream(cfg)
+	rg := cc.createGroupForStream(ci, cfg)
 	if rg == nil {
 		resp.Error = jsInsufficientErr
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))

--- a/server/route.go
+++ b/server/route.go
@@ -1416,7 +1416,8 @@ func (s *Server) addRoute(c *client, info *Info) (bool, bool) {
 	if !exists {
 		s.routes[c.cid] = c
 		s.remotes[id] = c
-		s.nodeToName[c.route.hash] = c.route.remoteName
+		s.nodeToName.Store(c.route.hash, c.route.remoteName)
+		s.nodeToCluster.Store(c.route.hash, s.info.Cluster)
 		c.mu.Lock()
 		c.route.connectURLs = info.ClientConnectURLs
 		c.route.wsConnURLs = info.WSConnectURLs

--- a/server/stream.go
+++ b/server/stream.go
@@ -51,6 +51,7 @@ type StreamConfig struct {
 	NoAck        bool            `json:"no_ack,omitempty"`
 	Template     string          `json:"template_owner,omitempty"`
 	Duplicates   time.Duration   `json:"duplicate_window,omitempty"`
+	Placement    *Placement      `json:"placement,omitempty"`
 
 	// These are non public configuration options.
 	// If you add new options, check fileStreamInfoJSON in order for them to

--- a/test/jetstream_cluster_test.go
+++ b/test/jetstream_cluster_test.go
@@ -322,7 +322,6 @@ func TestJetStreamClusterCompaction(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 	}
-	nc.Flush()
 
 	if _, err := js.StreamInfo("TEST"); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -3097,6 +3096,84 @@ func TestJetStreamClusterRemoveServer(t *testing.T) {
 	})
 }
 
+func TestJetStreamClusterSuperClusterBasics(t *testing.T) {
+	sc := createJetStreamSuperCluster(t, 3, 3)
+	defer sc.shutdown()
+
+	// Client based API
+	s := sc.randomCluster().randomServer()
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Replicas: 3})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Send in 10 messages.
+	msg, toSend := []byte("Hello JS Clustering"), 10
+	for i := 0; i < toSend; i++ {
+		if _, err = js.Publish("TEST", msg); err != nil {
+			t.Fatalf("Unexpected publish error: %v", err)
+		}
+	}
+	// Now grab info for this stream.
+	si, err := js.StreamInfo("TEST")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if si == nil || si.Config.Name != "TEST" {
+		t.Fatalf("StreamInfo is not correct %+v", si)
+	}
+	// Check active state as well, shows that the owner answered.
+	if si.State.Msgs != uint64(toSend) {
+		t.Fatalf("Expected %d msgs, got bad state: %+v", toSend, si.State)
+	}
+	// Check request origin placement.
+	if si.Cluster.Name != s.ClusterName() {
+		t.Fatalf("Expected stream to be placed in %q, but got %q", s.ClusterName(), si.Cluster.Name)
+	}
+
+	// Check consumers.
+	sub, err := js.SubscribeSync("TEST")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	checkSubsPending(t, sub, toSend)
+	ci, err := sub.ConsumerInfo()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if ci.Delivered.Consumer != uint64(toSend) || ci.NumAckPending != toSend {
+		t.Fatalf("ConsumerInfo is not correct: %+v", ci)
+	}
+
+	// Now check we can place a stream.
+	// Need to do this by hand for now until Go client catches up.
+	pcn := "C3"
+	cfg := server.StreamConfig{
+		Name:      "TEST2",
+		Storage:   server.FileStorage,
+		Placement: &server.Placement{Cluster: pcn},
+	}
+	req, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	resp, _ := nc.Request(fmt.Sprintf(server.JSApiStreamCreateT, cfg.Name), req, time.Second)
+	var scResp server.JSApiStreamCreateResponse
+	if err := json.Unmarshal(resp.Data, &scResp); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if scResp.StreamInfo == nil || scResp.Error != nil {
+		t.Fatalf("Did not receive correct response: %+v", scResp.Error)
+	}
+
+	if scResp.StreamInfo.Cluster.Name != pcn {
+		t.Fatalf("Expected the stream to be placed in %q, got %q", pcn, scResp.StreamInfo.Cluster.Name)
+	}
+}
+
 func TestJetStreamClusterStreamPerf(t *testing.T) {
 	// Comment out to run, holding place for now.
 	skip(t)
@@ -3166,12 +3243,121 @@ var jsClusterTempl = `
 	listen: 127.0.0.1:-1
 	server_name: %s
 	jetstream: {max_mem_store: 256MB, max_file_store: 2GB, store_dir: "%s"}
+
 	cluster {
 		name: %s
 		listen: 127.0.0.1:%d
 		routes = [%s]
 	}
 `
+
+var jsSuperClusterTempl = `
+	%s
+	gateway {
+		name: %s
+		listen: 127.0.0.1:%d
+		gateways = [%s
+		]
+	}
+`
+
+var jsGWTempl = `%s{name: %s, urls: [%s]}`
+
+func createJetStreamSuperCluster(t *testing.T, numServersPer, numClusters int) *supercluster {
+	t.Helper()
+	if numServersPer < 1 {
+		t.Fatalf("Number of servers must be >= 1")
+	}
+	if numClusters <= 1 {
+		t.Fatalf("Number of clusters must be > 1")
+	}
+
+	const (
+		startClusterPort = 33222
+		startGWPort      = 11222
+	)
+
+	// Make the GWs form faster for the tests.
+	server.SetGatewaysSolicitDelay(10 * time.Millisecond)
+	defer server.ResetGatewaysSolicitDelay()
+
+	cp, gp := startClusterPort, startGWPort
+	var clusters []*cluster
+
+	var gws []string
+	// Build GWs first, will be same for all servers.
+	for i, port := 1, gp; i <= numClusters; i++ {
+		cn := fmt.Sprintf("C%d", i)
+		var urls []string
+		for n := 0; n < numServersPer; n++ {
+			urls = append(urls, fmt.Sprintf("nats-route://127.0.0.1:%d", port))
+			port++
+		}
+		gws = append(gws, fmt.Sprintf(jsGWTempl, "\n\t\t\t", cn, strings.Join(urls, ",")))
+	}
+	gwconf := strings.Join(gws, "")
+
+	for i := 1; i <= numClusters; i++ {
+		cn := fmt.Sprintf("C%d", i)
+		// Go ahead and build configurations.
+		c := &cluster{servers: make([]*server.Server, 0, numServersPer), opts: make([]*server.Options, 0, numServersPer), name: cn}
+
+		// Build out the routes that will be shared with all configs.
+		var routes []string
+		for port := cp; port < cp+numServersPer; port++ {
+			routes = append(routes, fmt.Sprintf("nats-route://127.0.0.1:%d", port))
+		}
+		routeConfig := strings.Join(routes, ",")
+
+		for i := 0; i < numServersPer; i++ {
+			storeDir, _ := ioutil.TempDir("", server.JetStreamStoreDir)
+			sn := fmt.Sprintf("%s-S%d", cn, i+1)
+			bconf := fmt.Sprintf(jsClusterTempl, sn, storeDir, cn, cp+i, routeConfig)
+			conf := fmt.Sprintf(jsSuperClusterTempl, bconf, cn, gp, gwconf)
+			gp++
+			s, o := RunServerWithConfig(createConfFile(t, []byte(conf)))
+			c.servers = append(c.servers, s)
+			c.opts = append(c.opts, o)
+		}
+		checkClusterFormed(t, c.servers...)
+		clusters = append(clusters, c)
+		cp += numServersPer
+		c.t = t
+	}
+
+	// Wait for the supercluster to be formed.
+	egws := numClusters - 1
+	for _, c := range clusters {
+		for _, s := range c.servers {
+			waitForOutboundGateways(t, s, egws, 2*time.Second)
+		}
+	}
+
+	sc := &supercluster{t, clusters}
+	sc.waitOnLeader()
+	return sc
+}
+
+func (sc *supercluster) waitOnLeader() {
+	expires := time.Now().Add(5 * time.Second)
+	for time.Now().Before(expires) {
+		for _, c := range sc.clusters {
+			if leader := c.leader(); leader != nil {
+				time.Sleep(200 * time.Millisecond)
+				return
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	sc.t.Fatalf("Expected a cluster leader, got none")
+}
+
+func (sc *supercluster) randomCluster() *cluster {
+	clusters := append(sc.clusters[:0:0], sc.clusters...)
+	rand.Shuffle(len(clusters), func(i, j int) { clusters[i], clusters[j] = clusters[j], clusters[i] })
+	return clusters[0]
+}
 
 // This will create a cluster that is explicitly configured for the routes, etc.
 // and also has a defined clustername. All configs for routes and cluster name will be the same.

--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -35,10 +35,14 @@ import (
 
 // Used to setup superclusters for tests.
 type supercluster struct {
+	t        *testing.T
 	clusters []*cluster
 }
 
 func (sc *supercluster) shutdown() {
+	if sc == nil {
+		return
+	}
 	for _, c := range sc.clusters {
 		shutdownCluster(c)
 	}
@@ -66,7 +70,7 @@ func createSuperCluster(t *testing.T, numServersPer, numClusters int) *superclus
 		c := createClusterEx(t, true, 5*time.Millisecond, true, randClusterName(), numServersPer, clusters...)
 		clusters = append(clusters, c)
 	}
-	return &supercluster{clusters}
+	return &supercluster{t, clusters}
 }
 
 func (sc *supercluster) setResponseThreshold(t *testing.T, maxTime time.Duration) {


### PR DESCRIPTION
This allows metacontrollers to span superclusters. Also includes placement directives for streams. By default they select the request origin cluster.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
