### PR TITLE
Purge operation replay on restart

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -119,6 +119,7 @@ type consumerAssignment struct {
 type streamPurge struct {
 	Client  *ClientInfo `json:"client,omitempty"`
 	Stream  string      `json:"stream"`
+	LastSeq uint64      `json:"last_seq"`
 	Subject string      `json:"subject"`
 	Reply   string      `json:"reply"`
 }
@@ -1342,7 +1343,9 @@ func (js *jetStream) applyStreamEntries(mset *Stream, ce *CommittedEntry, isReco
 					continue
 				}
 				if err := mset.processJetStreamMsg(subject, reply, hdr, msg, lseq, ts); err != nil {
-					js.srv.Debugf("Got error processing JetStream msg: %v", err)
+					if err != errLastSeqMismatch || !isRecovering {
+						js.srv.Debugf("Got error processing JetStream msg: %v", err)
+					}
 				}
 			case deleteMsgOp:
 				md, err := decodeMsgDelete(buf[1:])
@@ -1357,8 +1360,8 @@ func (js *jetStream) applyStreamEntries(mset *Stream, ce *CommittedEntry, isReco
 				} else {
 					removed, err = mset.EraseMsg(md.Seq)
 				}
-				if err != nil {
-					s.Warnf("JetStream cluster failed to delete msg %d from stream %q for account %q: %v", md.Seq, md.Stream, md.Client.Account, err)
+				if err != nil && !isRecovering {
+					s.Debugf("JetStream cluster failed to delete msg %d from stream %q for account %q: %v", md.Seq, md.Stream, md.Client.Account, err)
 				}
 
 				js.mu.RLock()
@@ -1383,6 +1386,11 @@ func (js *jetStream) applyStreamEntries(mset *Stream, ce *CommittedEntry, isReco
 				if err != nil {
 					panic(err.Error())
 				}
+				// Ignore if we are recovering and we have already processed.
+				if isRecovering && mset.State().LastSeq > sp.LastSeq {
+					continue
+				}
+
 				s := js.server()
 				purged, err := mset.Purge()
 				if err != nil {
@@ -2774,7 +2782,7 @@ func (s *Server) jsClusteredStreamPurgeRequest(ci *ClientInfo, mset *Stream, str
 	}
 
 	if n := sa.Group.node; n != nil {
-		sp := &streamPurge{Stream: stream, Subject: subject, Reply: reply, Client: ci}
+		sp := &streamPurge{Stream: stream, LastSeq: mset.State().LastSeq, Subject: subject, Reply: reply, Client: ci}
 		n.Propose(encodeStreamPurge(sp))
 	} else if mset != nil {
 		var resp = JSApiStreamPurgeResponse{ApiResponse: ApiResponse{Type: JSApiStreamPurgeResponseType}}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1387,9 +1387,11 @@ func (js *jetStream) applyStreamEntries(mset *Stream, ce *CommittedEntry, isReco
 					panic(err.Error())
 				}
 				// Ignore if we are recovering and we have already processed.
-				if isRecovering && mset.State().LastSeq > sp.LastSeq {
-					// Make sure all messages from the purge are gone.
-					mset.store.Compact(sp.LastSeq)
+				if isRecovering {
+					if mset.State().FirstSeq <= sp.LastSeq {
+						// Make sure all messages from the purge are gone.
+						mset.store.Compact(sp.LastSeq + 1)
+					}
 					continue
 				}
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1388,6 +1388,8 @@ func (js *jetStream) applyStreamEntries(mset *Stream, ce *CommittedEntry, isReco
 				}
 				// Ignore if we are recovering and we have already processed.
 				if isRecovering && mset.State().LastSeq > sp.LastSeq {
+					// Make sure all messages from the purge are gone.
+					mset.store.Compact(sp.LastSeq)
 					continue
 				}
 

--- a/server/raft.go
+++ b/server/raft.go
@@ -2003,7 +2003,7 @@ func (n *raft) storeToWAL(ae *appendEntry) error {
 
 	// Sanity checking for now.
 	if ae.pindex != seq-1 {
-		panic(fmt.Sprintf("[%s] Placed an entry at the wrong index, ae is %+v, index is %d\n\n", n.s, ae, seq))
+		panic(fmt.Sprintf("[%s-%s] Placed an entry at the wrong index, ae is %+v, index is %d\n\n", n.s, n.group, ae, seq))
 	}
 
 	n.pterm = ae.term


### PR DESCRIPTION
Purge operations would be replayed on restart regardless if they had already been processed.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
