### PR TITLE
Cleaning up unused accounts

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -199,4 +199,7 @@ const (
 
 	// DEFAULT GLOBAL_ACCOUNT
 	DEFAULT_GLOBAL_ACCOUNT = "$G"
+
+	// MAX_UNUSED_ACCOUNTS is the limit of unused accounts we hold on to prior to cleanup
+	MAX_UNUSED_ACCOUNTS = 1024
 )

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -32,17 +32,17 @@ import (
 )
 
 type ConsumerInfo struct {
-	Stream         string         `json:"stream_name"`
-	Name           string         `json:"name"`
-	Created        time.Time      `json:"created"`
-	Config         ConsumerConfig `json:"config"`
-	Delivered      SequencePair   `json:"delivered"`
-	AckFloor       SequencePair   `json:"ack_floor"`
-	NumAckPending  int            `json:"num_ack_pending"`
-	NumRedelivered int            `json:"num_redelivered"`
-	NumWaiting     int            `json:"num_waiting"`
-	NumPending     uint64         `json:"num_pending"`
-	Cluster        *ClusterInfo   `json:"cluster,omitempty"`
+	Stream         string          `json:"stream_name"`
+	Name           string          `json:"name"`
+	Created        time.Time       `json:"created"`
+	Config         *ConsumerConfig `json:"config,omitempty"`
+	Delivered      SequencePair    `json:"delivered"`
+	AckFloor       SequencePair    `json:"ack_floor"`
+	NumAckPending  int             `json:"num_ack_pending"`
+	NumRedelivered int             `json:"num_redelivered"`
+	NumWaiting     int             `json:"num_waiting"`
+	NumPending     uint64          `json:"num_pending"`
+	Cluster        *ClusterInfo    `json:"cluster,omitempty"`
 }
 
 type ConsumerConfig struct {
@@ -1324,11 +1324,12 @@ func (o *Consumer) Info() *ConsumerInfo {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
 
+	cfg := o.config
 	info := &ConsumerInfo{
 		Stream:  o.stream,
 		Name:    o.name,
 		Created: o.created,
-		Config:  o.config,
+		Config:  &cfg,
 		Delivered: SequencePair{
 			Consumer: o.dseq - 1,
 			Stream:   o.sseq - 1,

--- a/server/events.go
+++ b/server/events.go
@@ -678,6 +678,10 @@ func (s *Server) initEventTracking() {
 			optz := &AccountzEventOptions{}
 			s.zReq(reply, msg, &optz.EventFilterOptions, optz, func() (interface{}, error) { return s.Accountz(&optz.AccountzOptions) })
 		},
+		"JSZ": func(sub *subscription, _ *client, subject, reply string, msg []byte) {
+			optz := &JszEventOptions{}
+			s.zReq(reply, msg, &optz.EventFilterOptions, optz, func() (interface{}, error) { return s.Jsz(&optz.JSzOptions) })
+		},
 	}
 	for name, req := range monSrvc {
 		subject = fmt.Sprintf(serverDirectReqSubj, s.info.ID, name)
@@ -728,6 +732,17 @@ func (s *Server) initEventTracking() {
 				} else {
 					optz.LeafzOptions.Account = acc
 					return s.Leafz(&optz.LeafzOptions)
+				}
+			})
+		},
+		"JSZ": func(sub *subscription, _ *client, subject, reply string, msg []byte) {
+			optz := &JszEventOptions{}
+			s.zReq(reply, msg, &optz.EventFilterOptions, optz, func() (interface{}, error) {
+				if acc, err := extractAccount(subject); err != nil {
+					return nil, err
+				} else {
+					optz.Account = acc
+					return s.JszAccount(&optz.JSzOptions)
 				}
 			})
 		},
@@ -1033,6 +1048,12 @@ type LeafzEventOptions struct {
 // In the context of system events, AccountzEventOptions are options passed to Accountz
 type AccountzEventOptions struct {
 	AccountzOptions
+	EventFilterOptions
+}
+
+// In the context of system events, JszEventOptions are options passed to Jsz
+type JszEventOptions struct {
+	JSzOptions
 	EventFilterOptions
 }
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -227,6 +227,7 @@ type Options struct {
 	AllowNonTLS           bool          `json:"-"`
 	WriteDeadline         time.Duration `json:"-"`
 	MaxClosedClients      int           `json:"-"`
+	MaxUnusedAccounts     int           `json:"-"`
 	LameDuckDuration      time.Duration `json:"-"`
 	LameDuckGracePeriod   time.Duration `json:"-"`
 
@@ -3983,6 +3984,9 @@ func setBaselineOptions(opts *Options) {
 	}
 	if opts.MaxClosedClients == 0 {
 		opts.MaxClosedClients = DEFAULT_MAX_CLOSED_CLIENTS
+	}
+	if opts.MaxUnusedAccounts == 0 {
+		opts.MaxUnusedAccounts = MAX_UNUSED_ACCOUNTS
 	}
 	if opts.LameDuckDuration == 0 {
 		opts.LameDuckDuration = DEFAULT_LAME_DUCK_DURATION

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -61,6 +61,7 @@ func TestDefaultOptions(t *testing.T) {
 		MaxPending:          MAX_PENDING_SIZE,
 		WriteDeadline:       DEFAULT_FLUSH_DEADLINE,
 		MaxClosedClients:    DEFAULT_MAX_CLOSED_CLIENTS,
+		MaxUnusedAccounts:   MAX_UNUSED_ACCOUNTS,
 		LameDuckDuration:    DEFAULT_LAME_DUCK_DURATION,
 		LameDuckGracePeriod: DEFAULT_LAME_DUCK_GRACE_PERIOD,
 		LeafNode: LeafNodeOpts{

--- a/server/server.go
+++ b/server/server.go
@@ -2003,6 +2003,7 @@ const (
 	SubszPath    = "/subsz"
 	StackszPath  = "/stacksz"
 	AccountzPath = "/accountz"
+	JszPath      = "/jsz"
 )
 
 func (s *Server) basePath(p string) string {
@@ -2082,7 +2083,8 @@ func (s *Server) startMonitoring(secure bool) error {
 	mux.HandleFunc(s.basePath(StackszPath), s.HandleStacksz)
 	// Accountz
 	mux.HandleFunc(s.basePath(AccountzPath), s.HandleAccountz)
-
+	// Jsz
+	mux.HandleFunc(s.basePath(JszPath), s.HandleJsz)
 	// Do not set a WriteTimeout because it could cause cURL/browser
 	// to return empty response or unable to display page if the
 	// server needs more time to build the response.


### PR DESCRIPTION
So far, having exports or js means cleanup is skipped

Signed-off-by: Matthias Hanel <mh@synadia.com>

These are the beginnings of account removal.
So far accounts with jetstream or exports are skipped.

If you approve of this one I'd look into that next. 
(suggestions on how to remove in the presence of jetstream are welcome)
For accounts with exports I'd check if the account can just be removed and importer set to incomplete.