### PR TITLE
Prevent non-exported messages from leaking into importer account

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -2503,23 +2503,19 @@ func (c *client) addShadowSub(sub *subscription, ime *ime) (*subscription, error
 	nsub := *sub // copy
 	nsub.im = im
 
-	// Check if we need to change shadow subscription's subject.
-	if !im.usePub {
-		if ime.dyn {
-			if im.rtr == nil {
-				im.rtr = im.tr.reverse()
-			}
-			subj, err := im.rtr.transformSubject(string(nsub.subject))
-			if err != nil {
-				return nil, err
-			}
-			nsub.subject = []byte(subj)
-		} else {
-			nsub.subject = []byte(im.from)
+	if !im.usePub && ime.dyn {
+		if im.rtr == nil {
+			im.rtr = im.tr.reverse()
 		}
-	} else if !ime.dyn {
+		subj, err := im.rtr.transformSubject(string(nsub.subject))
+		if err != nil {
+			return nil, err
+		}
+		nsub.subject = []byte(subj)
+	} else if !im.usePub || !ime.dyn {
 		nsub.subject = []byte(im.from)
 	}
+	// Else use original subject
 	c.Debugf("Creating import subscription on %q from account %q", nsub.subject, im.acc.Name)
 
 	if err := im.acc.sl.Insert(&nsub); err != nil {

--- a/server/client.go
+++ b/server/client.go
@@ -2517,6 +2517,8 @@ func (c *client) addShadowSub(sub *subscription, ime *ime) (*subscription, error
 		} else {
 			nsub.subject = []byte(im.from)
 		}
+	} else if !ime.dyn {
+		nsub.subject = []byte(im.from)
 	}
 	c.Debugf("Creating import subscription on %q from account %q", nsub.subject, im.acc.Name)
 


### PR DESCRIPTION
Currently when someone imports a subject with a wildcard, uses an empty string for `LocalSubject`, and if the importer account subscribes to `>`, then non-exported messages from the exported account leak to the importer account.

This happens because a shadow subscription is created on `>` (subscriber subject), instead of the import subject. From what I could see, I think these are the relevant code sections in master, in chronological order.

1. https://github.com/nats-io/nats-server/blob/master/server/accounts.go#L2272-L2283
    (value of `usePub` relevant)
2. https://github.com/nats-io/nats-server/blob/master/server/client.go#L2466-L2469
    (value of `ime.dyn` relevant [boolean value of `ime{}`])
3. https://github.com/nats-io/nats-server/blob/master/server/client.go#L2507-L2520
    (subscription created here based on `usePub` and `ime.dyn`)

This change allows the shadow subscription to be created for the import subject, instead of the subscription subject.

/cc @nats-io/core