### PR TITLE
Fixes for supercluster startup and JetStream clustering.

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 The NATS Authors
+// Copyright 2018-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -567,7 +567,8 @@ func (s *Server) heartbeatStatsz() {
 
 // This should be wrapChk() to setup common locking.
 func (s *Server) startStatszTimer() {
-	s.sys.stmr = time.AfterFunc(s.sys.statsz, s.wrapChk(s.heartbeatStatsz))
+	// Send out the first one only after a second.
+	s.sys.stmr = time.AfterFunc(time.Second, s.wrapChk(s.heartbeatStatsz))
 }
 
 // Start a ticker that will fire periodically and check for orphaned servers.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -610,6 +610,10 @@ func (cc *jetStreamCluster) isStreamLeader(account, stream string) bool {
 	if cc == nil {
 		return true
 	}
+	if cc.meta == nil {
+		return false
+	}
+
 	var sa *streamAssignment
 	if as := cc.streams[account]; as != nil {
 		sa = as[stream]
@@ -639,6 +643,10 @@ func (cc *jetStreamCluster) isConsumerLeader(account, stream, consumer string) b
 	if cc == nil {
 		return true
 	}
+	if cc.meta == nil {
+		return false
+	}
+
 	var sa *streamAssignment
 	if as := cc.streams[account]; as != nil {
 		sa = as[stream]

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1936,7 +1936,7 @@ func (js *jetStream) processClusterDeleteStream(sa *streamAssignment, isMember, 
 func (js *jetStream) processConsumerAssignment(ca *consumerAssignment) {
 	js.mu.Lock()
 	s, cc := js.srv, js.cluster
-	if s == nil || cc == nil {
+	if s == nil || cc == nil || cc.meta == nil {
 		// TODO(dlc) - debug at least
 		js.mu.Unlock()
 		return

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -3097,7 +3097,7 @@ func TestJetStreamClusterStepDown(t *testing.T) {
 	}
 
 	checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
-		ci, err := sub.ConsumerInfo()
+		ci, err := js.ConsumerInfo("TEST", "cat")
 		if err != nil {
 			return fmt.Errorf("Could not fetch consumer info: %v", err)
 		}

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -2563,7 +2563,7 @@ func TestJetStreamClusterNoQuorumStepdown(t *testing.T) {
 	}
 	// Consumer too. Since we do not know if the consumer leader was not the one shutdown
 	// we should wait for a bit for the system to detect.
-	adv, _ = csub.NextMsg(time.Second)
+	adv, _ = csub.NextMsg(5 * time.Second)
 	if adv == nil {
 		t.Fatalf("Expected to receive a consumer quorum lost advisory")
 	}
@@ -2989,7 +2989,7 @@ func TestJetStreamClusterRemovePeer(t *testing.T) {
 
 	// Now check consumer info as well.
 	checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
-		ci, err := sub.ConsumerInfo()
+		ci, err := js.ConsumerInfo("TEST", "cat")
 		if err != nil {
 			return fmt.Errorf("Could not fetch consumer info: %v", err)
 		}


### PR DESCRIPTION
For larger superclusters we send out our server information after a short delay on startup.
For determining leaderless status for API calls make sure the raft node has been running for long enough.
    
Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
