### PR TITLE
Remap subject only for service imports

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2027,7 +2027,9 @@ func (a *Account) createRespWildcard() []byte {
 	a.mu.Unlock()
 
 	// Create subscription and internal callback for all the wildcard response subjects.
-	c.processSub(wcsub, nil, []byte(sid), a.processServiceImportResponse, false)
+	if sub, err := c.processSub(wcsub, nil, []byte(sid), a.processServiceImportResponse, false); err == nil {
+		sub.rsi = true
+	}
 
 	return pre
 }

--- a/server/client.go
+++ b/server/client.go
@@ -472,7 +472,8 @@ func (c *client) clientType() int {
 // to optionally have an opts section for non-normal stuff.
 type subscription struct {
 	client  *client
-	im      *streamImport   // This is for import stream support.
+	im      *streamImport // This is for import stream support.
+	rsi     bool
 	shadow  []*subscription // This is to track shadowed accounts.
 	icb     msgHandler
 	subject []byte
@@ -3885,7 +3886,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 		}
 
 		// Remap to the original subject if internal.
-		if sub.icb != nil {
+		if sub.icb != nil && sub.rsi {
 			subj = subject
 		}
 


### PR DESCRIPTION
Also optimized a test that was taking too long to run.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

/cc @nats-io/core
