### PR TITLE
skip responses from non leaders in jsz

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -1155,6 +1155,8 @@ func (s *Server) statszReq(sub *subscription, _ *client, subject, reply string, 
 	s.mu.Unlock()
 }
 
+var errSkipZreq = errors.New("filtered response")
+
 func (s *Server) zReq(reply string, msg []byte, fOpts *EventFilterOptions, optz interface{}, respf func() (interface{}, error)) {
 	if !s.EventsEnabled() || reply == _EMPTY_ {
 		return
@@ -1172,6 +1174,9 @@ func (s *Server) zReq(reply string, msg []byte, fOpts *EventFilterOptions, optz 
 	}
 	if err == nil {
 		response["data"], err = respf()
+		if errors.Is(err, errSkipZreq) {
+			return
+		}
 		status = http.StatusInternalServerError
 	}
 	if err != nil {

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2357,7 +2357,7 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 		js, cc := s.getJetStreamCluster()
 		if js == nil {
 			// Ignore
-			return nil, ErrJetStreamNotEnabled
+			return nil, fmt.Errorf("%w: no cluster", errSkipZreq)
 		}
 		// So if we have JS but no clustering, we are the leader so allow.
 		if cc != nil {
@@ -2365,7 +2365,7 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 			isLeader := cc.isLeader()
 			js.mu.RUnlock()
 			if !isLeader {
-				return nil, errNotLeader
+				return nil, fmt.Errorf("%w: not leader", errSkipZreq)
 			}
 		}
 	}


### PR DESCRIPTION
Adds an error type and a check to avoid sending them
to clients

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
