### PR TITLE
Snapshot and Compaction Improvements

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -500,13 +500,15 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			// but we set it here to be able to identify it in the logs.
 			c.opts.Username = user.Username
 		} else {
-			if c.kind == CLIENT && c.opts.Username == "" && noAuthUser != "" {
+			if c.kind == CLIENT && c.opts.Username == _EMPTY_ && noAuthUser != _EMPTY_ {
 				if u, exists := s.users[noAuthUser]; exists {
+					c.mu.Lock()
 					c.opts.Username = u.Username
 					c.opts.Password = u.Password
+					c.mu.Unlock()
 				}
 			}
-			if c.opts.Username != "" {
+			if c.opts.Username != _EMPTY_ {
 				user, ok = s.users[c.opts.Username]
 				if !ok || !c.connectionTypeAllowed(user.AllowedConnectionTypes) {
 					s.mu.Unlock()

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -665,7 +665,7 @@ func (o *consumer) setLeader(isLeader bool) {
 			return
 		}
 		// Setup the internal sub for next message requests.
-		if !o.isPushMode() {
+		if o.isPullMode() {
 			if o.reqSub, err = o.subscribeInternal(o.nextMsgSubj, o.processNextMsgReq); err != nil {
 				o.mu.Unlock()
 				o.deleteWithoutAdvisory()

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1472,10 +1472,13 @@ func (o *consumer) processAckMsg(sseq, dseq, dc uint64, doSample bool) {
 	o.updateAcks(dseq, sseq)
 
 	mset := o.mset
+	clustered := o.node != nil
 	o.mu.Unlock()
 
 	// Let the owning stream know if we are interest or workqueue retention based.
-	if mset != nil && mset.cfg.Retention != LimitsPolicy {
+	// If this consumer is clustered this will be handled by processReplicatedAck
+	// after the ack has propagated.
+	if !clustered && mset != nil && mset.cfg.Retention != LimitsPolicy {
 		if sagap > 1 {
 			// FIXME(dlc) - This is very inefficient, will need to fix.
 			for seq := sseq; seq > sseq-sagap; seq-- {

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -249,23 +249,23 @@ const (
 	FileStoreMaxBlkSize = maxBlockSize
 )
 
-func newFileStore(fcfg FileStoreConfig, cfg StreamConfig) (*fileStore, bool, error) {
+func newFileStore(fcfg FileStoreConfig, cfg StreamConfig) (*fileStore, error) {
 	return newFileStoreWithCreated(fcfg, cfg, time.Now())
 }
 
-func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created time.Time) (*fileStore, bool, error) {
+func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created time.Time) (*fileStore, error) {
 	if cfg.Name == "" {
-		return nil, false, fmt.Errorf("name required")
+		return nil, fmt.Errorf("name required")
 	}
 	if cfg.Storage != FileStorage {
-		return nil, false, fmt.Errorf("fileStore requires file storage type in config")
+		return nil, fmt.Errorf("fileStore requires file storage type in config")
 	}
 	// Default values.
 	if fcfg.BlockSize == 0 {
 		fcfg.BlockSize = dynBlkSize(cfg.Retention, cfg.MaxBytes)
 	}
 	if fcfg.BlockSize > maxBlockSize {
-		return nil, false, fmt.Errorf("filestore max block size is %s", friendlyBytes(maxBlockSize))
+		return nil, fmt.Errorf("filestore max block size is %s", friendlyBytes(maxBlockSize))
 	}
 	if fcfg.CacheExpire == 0 {
 		fcfg.CacheExpire = defaultCacheBufferExpiration
@@ -274,21 +274,17 @@ func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created tim
 		fcfg.SyncInterval = defaultSyncInterval
 	}
 
-	// Track if we created this vs restored.
-	var bootstrap bool
-
 	// Check the directory
 	if stat, err := os.Stat(fcfg.StoreDir); os.IsNotExist(err) {
-		bootstrap = true
 		if err := os.MkdirAll(fcfg.StoreDir, 0755); err != nil {
-			return nil, bootstrap, fmt.Errorf("could not create storage directory - %v", err)
+			return nil, fmt.Errorf("could not create storage directory - %v", err)
 		}
 	} else if stat == nil || !stat.IsDir() {
-		return nil, bootstrap, fmt.Errorf("store directory is not a directory")
+		return nil, fmt.Errorf("storage directory is not a directory")
 	}
 	tmpfile, err := ioutil.TempFile(fcfg.StoreDir, "_test_")
 	if err != nil {
-		return nil, bootstrap, fmt.Errorf("storage directory is not writable")
+		return nil, fmt.Errorf("storage directory is not writable")
 	}
 	os.Remove(tmpfile.Name())
 
@@ -307,35 +303,35 @@ func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created tim
 	mdir := path.Join(fcfg.StoreDir, msgDir)
 	odir := path.Join(fcfg.StoreDir, consumerDir)
 	if err := os.MkdirAll(mdir, 0755); err != nil {
-		return nil, bootstrap, fmt.Errorf("could not create message storage directory - %v", err)
+		return nil, fmt.Errorf("could not create message storage directory - %v", err)
 	}
 	if err := os.MkdirAll(odir, 0755); err != nil {
-		return nil, bootstrap, fmt.Errorf("could not create message storage directory - %v", err)
+		return nil, fmt.Errorf("could not create message storage directory - %v", err)
 	}
 
 	// Create highway hash for message blocks. Use sha256 of directory as key.
 	key := sha256.Sum256([]byte(cfg.Name))
 	fs.hh, err = highwayhash.New64(key[:])
 	if err != nil {
-		return nil, bootstrap, fmt.Errorf("could not create hash: %v", err)
+		return nil, fmt.Errorf("could not create hash: %v", err)
 	}
 
 	// Recover our state.
 	if err := fs.recoverMsgs(); err != nil {
-		return nil, bootstrap, err
+		return nil, err
 	}
 
 	// Write our meta data iff does not exist.
 	meta := path.Join(fcfg.StoreDir, JetStreamMetaFile)
 	if _, err := os.Stat(meta); err != nil && os.IsNotExist(err) {
 		if err := fs.writeStreamMeta(); err != nil {
-			return nil, bootstrap, err
+			return nil, err
 		}
 	}
 
 	fs.syncTmr = time.AfterFunc(fs.fcfg.SyncInterval, fs.syncBlocks)
 
-	return fs, bootstrap, nil
+	return fs, nil
 }
 
 func (fs *fileStore) UpdateConfig(cfg *StreamConfig) error {

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -37,7 +37,7 @@ import (
 
 func TestFileStoreBasics(t *testing.T) {
 	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestFileStoreBasics(t *testing.T) {
 
 func TestFileStoreMsgHeaders(t *testing.T) {
 	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -137,14 +137,14 @@ func TestFileStoreBasicWriteMsgsAndRestore(t *testing.T) {
 
 	fcfg := FileStoreConfig{StoreDir: storeDir}
 
-	if _, _, err := newFileStore(fcfg, StreamConfig{Storage: MemoryStorage}); err == nil {
+	if _, err := newFileStore(fcfg, StreamConfig{Storage: MemoryStorage}); err == nil {
 		t.Fatalf("Expected an error with wrong type")
 	}
-	if _, _, err := newFileStore(fcfg, StreamConfig{Storage: FileStorage}); err == nil {
+	if _, err := newFileStore(fcfg, StreamConfig{Storage: FileStorage}); err == nil {
 		t.Fatalf("Expected an error with no name")
 	}
 
-	fs, _, err := newFileStore(fcfg, StreamConfig{Name: "dlc", Storage: FileStorage})
+	fs, err := newFileStore(fcfg, StreamConfig{Name: "dlc", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestFileStoreBasicWriteMsgsAndRestore(t *testing.T) {
 	}
 
 	// Restart
-	fs, _, err = newFileStore(fcfg, StreamConfig{Name: "dlc", Storage: FileStorage})
+	fs, err = newFileStore(fcfg, StreamConfig{Name: "dlc", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestFileStoreBasicWriteMsgsAndRestore(t *testing.T) {
 	fs.Stop()
 
 	// Restart
-	fs, _, err = newFileStore(fcfg, StreamConfig{Name: "dlc", Storage: FileStorage})
+	fs, err = newFileStore(fcfg, StreamConfig{Name: "dlc", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -231,7 +231,7 @@ func TestFileStoreBasicWriteMsgsAndRestore(t *testing.T) {
 	fs.Purge()
 	fs.Stop()
 
-	fs, _, err = newFileStore(fcfg, StreamConfig{Name: "dlc", Storage: FileStorage})
+	fs, err = newFileStore(fcfg, StreamConfig{Name: "dlc", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestFileStoreBasicWriteMsgsAndRestore(t *testing.T) {
 	fs.RemoveMsg(seq)
 
 	fs.Stop()
-	fs, _, err = newFileStore(fcfg, StreamConfig{Name: "dlc", Storage: FileStorage})
+	fs, err = newFileStore(fcfg, StreamConfig{Name: "dlc", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestFileStoreSelectNextFirst(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestFileStoreSkipMsg(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -344,7 +344,7 @@ func TestFileStoreSkipMsg(t *testing.T) {
 	// Make sure we recover same state.
 	fs.Stop()
 
-	fs, _, err = newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -378,7 +378,7 @@ func TestFileStoreSkipMsg(t *testing.T) {
 	// Make sure we recover same state.
 	fs.Stop()
 
-	fs, _, err = newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -399,7 +399,7 @@ func TestFileStoreWriteExpireWrite(t *testing.T) {
 	defer os.RemoveAll(storeDir)
 
 	cexp := 10 * time.Millisecond
-	fs, _, err := newFileStore(
+	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 256, CacheExpire: cexp},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
@@ -432,7 +432,7 @@ func TestFileStoreWriteExpireWrite(t *testing.T) {
 	// Make sure we recover same state.
 	fs.Stop()
 
-	fs, _, err = newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -463,7 +463,7 @@ func TestFileStoreMsgLimit(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxMsgs: 10})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxMsgs: 10})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -507,7 +507,7 @@ func TestFileStoreBytesLimit(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxBytes: int64(maxBytes)})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxBytes: int64(maxBytes)})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -552,7 +552,7 @@ func TestFileStoreAgeLimit(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxAge: maxAge})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxAge: maxAge})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -599,7 +599,7 @@ func TestFileStoreTimeStamps(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -630,7 +630,7 @@ func TestFileStorePurge(t *testing.T) {
 	defer os.RemoveAll(storeDir)
 
 	blkSize := uint64(64 * 1024)
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: blkSize}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: blkSize}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -683,7 +683,7 @@ func TestFileStorePurge(t *testing.T) {
 	// Make sure we recover same state.
 	fs.Stop()
 
-	fs, _, err = newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: blkSize}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: blkSize}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -722,7 +722,7 @@ func TestFileStorePurge(t *testing.T) {
 	purgeDir := path.Join(fs.fcfg.StoreDir, purgeDir)
 	os.Rename(pdir, purgeDir)
 
-	fs, _, err = newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: blkSize}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: blkSize}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -747,7 +747,7 @@ func TestFileStoreCompact(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -792,7 +792,7 @@ func TestFileStoreStreamTruncate(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(
+	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 350},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
@@ -846,7 +846,7 @@ func TestFileStoreStreamTruncate(t *testing.T) {
 
 	// Make sure we can recover same state.
 	fs.Stop()
-	fs, _, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -862,7 +862,7 @@ func TestFileStoreRemovePartialRecovery(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -891,7 +891,7 @@ func TestFileStoreRemovePartialRecovery(t *testing.T) {
 	// Make sure we recover same state.
 	fs.Stop()
 
-	fs, _, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -908,7 +908,7 @@ func TestFileStoreRemoveOutOfOrderRecovery(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -948,7 +948,7 @@ func TestFileStoreRemoveOutOfOrderRecovery(t *testing.T) {
 	// Make sure we recover same state.
 	fs.Stop()
 
-	fs, _, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -976,7 +976,7 @@ func TestFileStoreAgeLimitRecovery(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(
+	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, CacheExpire: 1 * time.Millisecond},
 		StreamConfig{Name: "zzz", Storage: FileStorage, MaxAge: maxAge},
 	)
@@ -997,7 +997,7 @@ func TestFileStoreAgeLimitRecovery(t *testing.T) {
 	}
 	fs.Stop()
 
-	fs, _, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxAge: maxAge})
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxAge: maxAge})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1022,7 +1022,7 @@ func TestFileStoreBitRot(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1068,7 +1068,7 @@ func TestFileStoreBitRot(t *testing.T) {
 	// Make sure we can restore.
 	fs.Stop()
 
-	fs, _, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1085,7 +1085,7 @@ func TestFileStoreEraseMsg(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1144,7 +1144,7 @@ func TestFileStoreEraseAndNoIndexRecovery(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1176,7 +1176,7 @@ func TestFileStoreEraseAndNoIndexRecovery(t *testing.T) {
 	ifn := path.Join(storeDir, msgDir, fmt.Sprintf(indexScan, 1))
 	os.Remove(ifn)
 
-	fs, _, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1201,7 +1201,7 @@ func TestFileStoreMeta(t *testing.T) {
 
 	mconfig := StreamConfig{Name: "ZZ-22-33", Storage: FileStorage, Subjects: []string{"foo.*"}, Replicas: 22}
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, mconfig)
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, mconfig)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1295,7 +1295,7 @@ func TestFileStoreWriteAndReadSameBlock(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(
+	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
@@ -1322,7 +1322,7 @@ func TestFileStoreAndRetrieveMultiBlock(t *testing.T) {
 	subj, msg := "foo", []byte("Hello World!")
 	storedMsgSize := fileStoreMsgSize(subj, nil, msg)
 
-	fs, _, err := newFileStore(
+	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 4 * storedMsgSize},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
@@ -1339,7 +1339,7 @@ func TestFileStoreAndRetrieveMultiBlock(t *testing.T) {
 	}
 	fs.Stop()
 
-	fs, _, err = newFileStore(
+	fs, err = newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 4 * storedMsgSize},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
@@ -1363,7 +1363,7 @@ func TestFileStoreCollapseDmap(t *testing.T) {
 	subj, msg := "foo", []byte("Hello World!")
 	storedMsgSize := fileStoreMsgSize(subj, nil, msg)
 
-	fs, _, err := newFileStore(
+	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 4 * storedMsgSize},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
@@ -1438,7 +1438,7 @@ func TestFileStoreReadCache(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir, CacheExpire: 100 * time.Millisecond}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, CacheExpire: 100 * time.Millisecond}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1492,7 +1492,7 @@ func TestFileStorePartialCacheExpiration(t *testing.T) {
 
 	cexp := 10 * time.Millisecond
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir, CacheExpire: cexp}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, CacheExpire: cexp}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1518,7 +1518,7 @@ func TestFileStorePartialIndexes(t *testing.T) {
 
 	cexp := 10 * time.Millisecond
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir, CacheExpire: cexp}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, CacheExpire: cexp}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1566,7 +1566,7 @@ func TestFileStoreSnapshot(t *testing.T) {
 
 	subj, msg := "foo", []byte("Hello Snappy!")
 
-	fs, _, err := newFileStore(
+	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
@@ -1649,7 +1649,7 @@ func TestFileStoreSnapshot(t *testing.T) {
 			fd.Close()
 		}
 
-		fsr, _, err := newFileStore(
+		fsr, err := newFileStore(
 			FileStoreConfig{StoreDir: rstoreDir},
 			StreamConfig{Name: "zzz", Storage: FileStorage},
 		)
@@ -1739,7 +1739,7 @@ func TestFileStoreConsumer(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1866,7 +1866,7 @@ func TestFileStoreWriteFailures(t *testing.T) {
 	defer os.RemoveAll(storeDir)
 
 	subj, msg := "foo", []byte("Hello Write Failures!")
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1902,7 +1902,7 @@ func TestFileStoreWriteFailures(t *testing.T) {
 	// Make sure we recover same state.
 	fs.Stop()
 
-	fs, _, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1961,7 +1961,7 @@ func TestFileStorePerf(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(
+	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
@@ -1985,7 +1985,7 @@ func TestFileStorePerf(t *testing.T) {
 
 	fmt.Printf("Restoring..\n")
 	start = time.Now()
-	fs, _, err = newFileStore(
+	fs, err = newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
@@ -2033,7 +2033,7 @@ func TestFileStorePerf(t *testing.T) {
 
 	fs.Stop()
 
-	fs, _, err = newFileStore(
+	fs, err = newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
@@ -2060,7 +2060,7 @@ func TestFileStorePerf(t *testing.T) {
 	fmt.Printf("%.0f msgs/sec\n", float64(toStore)/tt.Seconds())
 	fmt.Printf("%s per sec\n", friendlyBytes(int64(float64(toStore*storedMsgSize)/tt.Seconds())))
 
-	fs, _, err = newFileStore(
+	fs, err = newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
@@ -2101,7 +2101,7 @@ func TestFileStoreReadBackMsgPerf(t *testing.T) {
 	defer os.RemoveAll(storeDir)
 	fmt.Printf("StoreDir is %q\n", storeDir)
 
-	fs, _, err := newFileStore(
+	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
@@ -2151,7 +2151,7 @@ func TestFileStoreStoreLimitRemovePerf(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(
+	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
@@ -2208,7 +2208,7 @@ func TestFileStorePubPerfWithSmallBlkSize(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(
+	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: FileStoreMinBlkSize},
 		StreamConfig{Name: "zzz", Storage: FileStorage},
 	)
@@ -2234,7 +2234,7 @@ func TestFileStoreConsumerRedeliveredLost(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2301,7 +2301,7 @@ func TestFileStoreConsumerFlusher(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2336,7 +2336,7 @@ func TestFileStoreConsumerDeliveredUpdates(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2394,7 +2394,7 @@ func TestFileStoreConsumerDeliveredAndAckUpdates(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2511,7 +2511,7 @@ func TestFileStoreStreamStateDeleted(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2563,7 +2563,7 @@ func TestFileStoreConsumerPerf(t *testing.T) {
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2644,7 +2644,7 @@ func TestFileStoreStreamIndexBug(t *testing.T) {
 // Reported by Ivan.
 func TestFileStoreStreamDeleteCacheBug(t *testing.T) {
 	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
-	fs, _, err := newFileStore(FileStoreConfig{StoreDir: storeDir, CacheExpire: 50 * time.Millisecond}, StreamConfig{Name: "zzz", Storage: FileStorage})
+	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, CacheExpire: 50 * time.Millisecond}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -996,7 +996,6 @@ func (js *jetStream) applyMetaEntries(entries []*Entry, isRecovering bool) (bool
 					return didSnap, didRemove, err
 				}
 				if isRecovering {
-					panic("winner")
 					js.setStreamAssignmentResponded(sa)
 				}
 				js.processStreamRemoval(sa)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -218,7 +218,8 @@ func (s *Server) JetStreamSnapshotMeta() error {
 	if !cc.isLeader() {
 		return errNotLeader
 	}
-	return cc.meta.Snapshot(js.metaSnapshot())
+
+	return cc.meta.InstallSnapshot(js.metaSnapshot())
 }
 
 func (s *Server) JetStreamStepdownStream(account, stream string) error {
@@ -274,11 +275,7 @@ func (s *Server) JetStreamSnapshotStream(account, stream string) error {
 	n := mset.node
 	mset.mu.RUnlock()
 
-	n.PausePropose()
-	err = n.Snapshot(mset.stateSnapshot())
-	n.ResumePropose()
-
-	return err
+	return n.InstallSnapshot(mset.stateSnapshot())
 }
 
 func (s *Server) JetStreamClusterPeers() []string {
@@ -460,9 +457,10 @@ func (js *jetStream) setupMetaGroup() error {
 
 	// Setup our WAL for the metagroup.
 	sysAcc := s.SystemAccount()
-	stateDir := path.Join(js.config.StoreDir, sysAcc.Name, defaultStoreDirName, defaultMetaGroupName)
-	fs, bootstrap, err := newFileStore(
-		FileStoreConfig{StoreDir: stateDir, BlockSize: defaultMetaFSBlkSize},
+	storeDir := path.Join(js.config.StoreDir, sysAcc.Name, defaultStoreDirName, defaultMetaGroupName)
+
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: storeDir, BlockSize: defaultMetaFSBlkSize},
 		StreamConfig{Name: defaultMetaGroupName, Storage: FileStorage},
 	)
 	if err != nil {
@@ -470,11 +468,10 @@ func (js *jetStream) setupMetaGroup() error {
 		return err
 	}
 
-	cfg := &RaftConfig{Name: defaultMetaGroupName, Store: stateDir, Log: fs}
+	cfg := &RaftConfig{Name: defaultMetaGroupName, Store: storeDir, Log: fs}
 
-	if bootstrap {
+	if _, err := readPeerState(storeDir); err != nil {
 		s.Noticef("JetStream cluster bootstrapping")
-		// FIXME(dlc) - Make this real.
 		peers := s.ActivePeers()
 		s.Debugf("JetStream cluster initial peers: %+v", peers)
 		if err := s.bootstrapRaftNode(cfg, peers, false); err != nil {
@@ -483,6 +480,7 @@ func (js *jetStream) setupMetaGroup() error {
 	} else {
 		s.Noticef("JetStream cluster recovering state")
 	}
+
 	// Start up our meta node.
 	n, err := s.startRaftNode(cfg)
 	if err != nil {
@@ -521,6 +519,26 @@ func (js *jetStream) server() *Server {
 	s := js.srv
 	js.mu.RUnlock()
 	return s
+}
+
+// Will respond if we do not think we have a metacontroller leader.
+func (js *jetStream) isLeaderless() bool {
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+
+	cc := js.cluster
+	if cc == nil {
+		return false
+	}
+
+	// If we don't have a leader.
+	if cc.meta.GroupLeader() == _EMPTY_ {
+		// Make sure we have been running for enough time.
+		if time.Since(cc.meta.Created()) > lostQuorumInterval {
+			return true
+		}
+	}
+	return false
 }
 
 // Will respond iff we are a member and we know we have no leader.
@@ -657,14 +675,16 @@ func (cc *jetStreamCluster) isConsumerLeader(account, stream, consumer string) b
 		return false
 	}
 	// Check if we are the leader of this raftGroup assigned to this consumer.
+	ca := sa.consumers[consumer]
+	if ca == nil {
+		return false
+	}
+	rg := ca.Group
 	ourID := cc.meta.ID()
-	for _, ca := range sa.consumers {
-		rg := ca.Group
-		for _, peer := range rg.Peers {
-			if peer == ourID {
-				if len(rg.Peers) == 1 || (rg.node != nil && rg.node.Leader()) {
-					return true
-				}
+	for _, peer := range rg.Peers {
+		if peer == ourID {
+			if len(rg.Peers) == 1 || (rg.node != nil && rg.node.Leader()) {
+				return true
 			}
 		}
 	}
@@ -672,12 +692,7 @@ func (cc *jetStreamCluster) isConsumerLeader(account, stream, consumer string) b
 }
 
 func (js *jetStream) monitorCluster() {
-	const (
-		compactInterval  = 5 * time.Minute
-		compactSizeLimit = 64 * 1024
-	)
-
-	s, cc, n := js.server(), js.cluster, js.getMetaGroup()
+	s, n := js.server(), js.getMetaGroup()
 	qch, lch, ach := n.QuitC(), n.LeadChangeC(), n.ApplyC()
 
 	defer s.grWG.Done()
@@ -685,25 +700,17 @@ func (js *jetStream) monitorCluster() {
 	s.Debugf("Starting metadata monitor")
 	defer s.Debugf("Exiting metadata monitor")
 
+	const compactInterval = 2 * time.Minute
 	t := time.NewTicker(compactInterval)
 	defer t.Stop()
 
-	isLeader := cc.isLeader()
-
+	var isLeader bool
 	var lastSnap []byte
-	var snapout bool
 
-	// Only to be called from leader.
-	attemptSnapshot := func() {
-		if snapout {
-			return
-		}
-		n.PausePropose()
-		defer n.ResumePropose()
+	doSnapshot := func() {
 		if snap := js.metaSnapshot(); !bytes.Equal(lastSnap, snap) {
-			if err := n.Snapshot(snap); err == nil {
+			if err := n.InstallSnapshot(snap); err == nil {
 				lastSnap = snap
-				snapout = true
 			}
 		}
 	}
@@ -726,28 +733,22 @@ func (js *jetStream) monitorCluster() {
 			// FIXME(dlc) - Deal with errors.
 			if hadSnapshot, didRemoval, err := js.applyMetaEntries(ce.Entries, isRecovering); err == nil {
 				n.Applied(ce.Index)
-				if hadSnapshot {
-					snapout = false
-					if !isRecovering {
-						n.Compact(ce.Index)
-					}
-				}
-				if didRemoval {
-					attemptSnapshot()
+				if (hadSnapshot && !isRecovering) || didRemoval {
+					// Since we received one make sure we have our own since we do not store
+					// our meta state outside of raft.
+					doSnapshot()
 				}
 			}
-			if isLeader && !snapout {
-				_, b := n.Size()
-				if b > compactSizeLimit {
-					attemptSnapshot()
+			// See if we could save some memory here.
+			if lastSnap != nil {
+				if _, b := n.Size(); b > uint64(len(lastSnap)*4) {
+					doSnapshot()
 				}
 			}
 		case isLeader = <-lch:
 			js.processLeaderChange(isLeader)
 		case <-t.C:
-			if isLeader && !snapout {
-				attemptSnapshot()
-			}
+			doSnapshot()
 		}
 	}
 }
@@ -795,6 +796,9 @@ func (js *jetStream) metaSnapshot() []byte {
 }
 
 func (js *jetStream) applyMetaSnapshot(buf []byte, isRecovering bool) error {
+	if len(buf) == 0 {
+		return nil
+	}
 	jse, err := s2.Decode(nil, buf)
 	if err != nil {
 		return err
@@ -803,6 +807,7 @@ func (js *jetStream) applyMetaSnapshot(buf []byte, isRecovering bool) error {
 	if err = json.Unmarshal(jse, &wsas); err != nil {
 		return err
 	}
+
 	// Build our new version here outside of js.
 	streams := make(map[string]map[string]*streamAssignment)
 	for _, wsa := range wsas {
@@ -991,6 +996,7 @@ func (js *jetStream) applyMetaEntries(entries []*Entry, isRecovering bool) (bool
 					return didSnap, didRemove, err
 				}
 				if isRecovering {
+					panic("winner")
 					js.setStreamAssignmentResponded(sa)
 				}
 				js.processStreamRemoval(sa)
@@ -1087,21 +1093,18 @@ func (js *jetStream) createRaftGroup(rg *raftGroup) error {
 		return errors.New("shutting down")
 	}
 
-	stateDir := path.Join(js.config.StoreDir, sysAcc.Name, defaultStoreDirName, rg.Name)
-	fs, bootstrap, err := newFileStore(
-		FileStoreConfig{StoreDir: stateDir, BlockSize: 32 * 1024 * 1024},
-		StreamConfig{Name: rg.Name, Storage: FileStorage, Replicas: 2},
-	)
+	storeDir := path.Join(js.config.StoreDir, sysAcc.Name, defaultStoreDirName, rg.Name)
+	ms, err := newMemStore(&StreamConfig{Name: rg.Name, Storage: MemoryStorage})
 	if err != nil {
-		s.Errorf("Error creating filestore: %v", err)
+		s.Errorf("Error creating memstore: %v", err)
 		return err
 	}
+	cfg := &RaftConfig{Name: rg.Name, Store: storeDir, Log: ms}
 
-	cfg := &RaftConfig{Name: rg.Name, Store: stateDir, Log: fs}
-
-	if bootstrap {
+	if _, err := readPeerState(storeDir); err != nil {
 		s.bootstrapRaftNode(cfg, rg.Peers, true)
 	}
+
 	n, err := s.startRaftNode(cfg)
 	if err != nil {
 		s.Debugf("Error creating raft group: %v", err)
@@ -1150,14 +1153,14 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment) {
 
 	qch, lch, ach := n.QuitC(), n.LeadChangeC(), n.ApplyC()
 
-	const (
-		compactInterval  = 10 * time.Minute
-		compactSizeLimit = 64 * 1024 * 1024
-		compactMinWait   = 5 * time.Second
-	)
-
 	s.Debugf("Starting stream monitor for '%s > %s'", sa.Client.Account, sa.Config.Name)
 	defer s.Debugf("Exiting stream monitor for '%s > %s'", sa.Client.Account, sa.Config.Name)
+
+	const (
+		compactInterval  = 2 * time.Minute
+		compactSizeLimit = 32 * 1024 * 1024
+		compactNumLimit  = 4096
+	)
 
 	t := time.NewTicker(compactInterval)
 	defer t.Stop()
@@ -1173,30 +1176,16 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment) {
 		return
 	}
 
-	var (
-		lastSnap   []byte
-		snapout    bool
-		lastFailed time.Time
-	)
+	var lastSnap []byte
 
-	// Only to be called from leader.
-	attemptSnapshot := func() {
-		if mset == nil || isRestore || snapout {
+	// Should only to be called from leader.
+	doSnapshot := func() {
+		if mset == nil || isRestore {
 			return
 		}
-		n.PausePropose()
-		defer n.ResumePropose()
 		if snap := mset.stateSnapshot(); !bytes.Equal(lastSnap, snap) {
-			if !lastFailed.IsZero() && time.Since(lastFailed) <= compactMinWait {
-				s.Debugf("Stream compaction delayed")
-				return
-			}
-			if err := n.Snapshot(snap); err != nil {
-				lastFailed = time.Now()
-			} else {
+			if err := n.InstallSnapshot(snap); err == nil {
 				lastSnap = snap
-				snapout = true
-				lastFailed = time.Time{}
 			}
 		}
 	}
@@ -1204,11 +1193,52 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment) {
 	// We will establish a restoreDoneCh no matter what. Will never be triggered unless
 	// we replace with the restore chan.
 	restoreDoneCh := make(<-chan error)
-
 	isRecovering := true
 
 	for {
 		select {
+		case <-s.quitCh:
+			return
+		case <-qch:
+			return
+		case ce := <-ach:
+			// No special processing needed for when we are caught up on restart.
+			if ce == nil {
+				isRecovering = false
+				continue
+			}
+			// Apply our entries.
+			if err := js.applyStreamEntries(mset, ce, isRecovering); err == nil {
+				n.Applied(ce.Index)
+				if !isLeader {
+					// If over 32MB go ahead and compact if not the leader.
+					if m, b := n.Size(); m > compactNumLimit || b > compactSizeLimit {
+						n.Compact(ce.Index)
+					}
+				}
+			} else {
+				s.Warnf("Error applying entries to '%s > %s'", sa.Client.Account, sa.Config.Name)
+			}
+			if isLeader && lastSnap != nil {
+				// If over 32MB go ahead and compact if not the leader.
+				if m, b := n.Size(); m > compactNumLimit || b > compactSizeLimit {
+					doSnapshot()
+				}
+			}
+		case isLeader = <-lch:
+			if isLeader && isRestore {
+				acc, _ := s.LookupAccount(sa.Client.Account)
+				restoreDoneCh = s.processStreamRestore(sa.Client, acc, sa.Config.Name, _EMPTY_, sa.Reply, _EMPTY_)
+			} else {
+				if !isLeader && n.GroupLeader() != noLeader {
+					js.setStreamAssignmentResponded(sa)
+				}
+				js.processStreamLeaderChange(mset, isLeader)
+			}
+		case <-t.C:
+			if isLeader {
+				doSnapshot()
+			}
 		case err := <-restoreDoneCh:
 			// We have completed a restore from snapshot on this server. The stream assignment has
 			// already been assigned but the replicas will need to catch up out of band. Consumers
@@ -1252,8 +1282,11 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment) {
 			if !isLeader {
 				panic("Finished restore but not leader")
 			}
+			// Trigger the stream followers to catchup.
+			if n := mset.raftNode(); n != nil {
+				n.SendSnapshot(mset.stateSnapshot())
+			}
 			js.processStreamLeaderChange(mset, isLeader)
-			attemptSnapshot()
 
 			// Check to see if we have restored consumers here.
 			// These are not currently assigned so we will need to do so here.
@@ -1288,7 +1321,11 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment) {
 							js.mu.RUnlock()
 							if ca == nil {
 								s.Warnf("Consumer assignment has not been assigned, retrying")
-								meta.ForwardProposal(addEntry)
+								if meta != nil {
+									meta.ForwardProposal(addEntry)
+								} else {
+									return
+								}
 							} else {
 								return
 							}
@@ -1296,67 +1333,20 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment) {
 					}()
 				}
 			}
-		case <-s.quitCh:
-			return
-		case <-qch:
-			return
-		case ce := <-ach:
-			// No special processing needed for when we are caught up on restart.
-			if ce == nil {
-				isRecovering = false
-				continue
-			}
-			if mset == nil && isRestore {
-				isRestore = false
-				sa.Restore = nil
-				if mset, err = acc.addStreamWithAssignment(sa.Config, nil, sa); err != nil {
-					s.Warnf("Could not add stream after restore '%s > %s': %v", sa.Client.Account, sa.Config.Name, err)
-					return
-				}
-			}
-			// Apply our entries.
-			if hadSnapshot, didRemove, err := js.applyStreamEntries(mset, ce, isRecovering); err == nil {
-				n.Applied(ce.Index)
-				if hadSnapshot {
-					snapout = false
-				}
-				if isLeader && didRemove {
-					attemptSnapshot()
-				}
-			} else {
-				s.Warnf("Error applying entries to '%s > %s'", sa.Client.Account, sa.Config.Name)
-			}
-			if isLeader && !snapout {
-				if _, b := n.Size(); b > compactSizeLimit {
-					attemptSnapshot()
-				}
-			}
-		case isLeader = <-lch:
-			if isLeader && isRestore {
-				acc, _ := s.LookupAccount(sa.Client.Account)
-				restoreDoneCh = s.processStreamRestore(sa.Client, acc, sa.Config.Name, _EMPTY_, sa.Reply, _EMPTY_)
-			} else {
-				if !isLeader && n.GroupLeader() != noLeader {
-					js.setStreamAssignmentResponded(sa)
-				}
-				js.processStreamLeaderChange(mset, isLeader)
-			}
-		case <-t.C:
-			if isLeader {
-				attemptSnapshot()
-			}
 		}
 	}
 }
 
-func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isRecovering bool) (bool, bool, error) {
-	var didSnap, didRemove bool
+func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isRecovering bool) error {
 	for _, e := range ce.Entries {
 		if e.Type == EntrySnapshot {
 			if !isRecovering {
-				mset.processSnapshot(e.Data)
+				var snap streamSnapshot
+				if err := json.Unmarshal(e.Data, &snap); err != nil {
+					return err
+				}
+				mset.processSnapshot(&snap)
 			}
-			didSnap = true
 		} else if e.Type == EntryRemovePeer {
 			js.mu.RLock()
 			ourID := js.cluster.meta.ID()
@@ -1364,7 +1354,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 			if peer := string(e.Data); peer == ourID {
 				mset.stop(true, false)
 			}
-			return false, false, nil
+			return nil
 		} else {
 			buf := e.Data
 			switch entryOp(buf[0]) {
@@ -1387,7 +1377,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 						s := js.srv
 						s.Errorf("JetStream out of space, will be DISABLED")
 						js.srv.DisableJetStream()
-						return didSnap, didRemove, err
+						return err
 					}
 				}
 			case deleteMsgOp:
@@ -1406,7 +1396,6 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				if err != nil && !isRecovering {
 					s.Debugf("JetStream cluster failed to delete msg %d from stream %q for account %q: %v", md.Seq, md.Stream, md.Client.Account, err)
 				}
-				didRemove = removed
 
 				js.mu.RLock()
 				isLeader := cc.isStreamLeader(md.Client.Account, md.Stream)
@@ -1444,7 +1433,6 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				if err != nil {
 					s.Warnf("JetStream cluster failed to purge stream %q for account %q: %v", sp.Stream, sp.Client.Account, err)
 				}
-				didRemove = purged > 0
 
 				js.mu.RLock()
 				isLeader := js.cluster.isStreamLeader(sp.Client.Account, sp.Stream)
@@ -1466,7 +1454,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 			}
 		}
 	}
-	return didSnap, didRemove, nil
+	return nil
 }
 
 // Returns the PeerInfo for all replicas of a raft node. This is different than node.Peers()
@@ -2101,7 +2089,7 @@ func (js *jetStream) processClusterCreateConsumer(ca *consumerAssignment) {
 	}
 
 	if err != nil {
-		js.srv.Debugf("Consumer create failed for '%s > %s > %s': %v\n", ca.Client.Account, ca.Stream, ca.Name, err)
+		s.Debugf("Consumer create failed for '%s > %s > %s': %v\n", ca.Client.Account, ca.Stream, ca.Name, err)
 		ca.err = err
 		if rg.node != nil {
 			rg.node.Delete()
@@ -2251,7 +2239,7 @@ func (o *consumer) raftNode() RaftNode {
 }
 
 func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
-	s, n := js.server(), o.raftNode()
+	s, cc, n := js.server(), js.cluster, o.raftNode()
 	defer s.grWG.Done()
 
 	if n == nil {
@@ -2261,19 +2249,34 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 
 	qch, lch, ach := n.QuitC(), n.LeadChangeC(), n.ApplyC()
 
-	const (
-		compactInterval  = 1 * time.Minute
-		compactSizeLimit = 8 * 1024 * 1024
-	)
-
 	s.Debugf("Starting consumer monitor for '%s > %s > %s", o.acc.Name, ca.Stream, ca.Name)
 	defer s.Debugf("Exiting consumer monitor for '%s > %s > %s'", o.acc.Name, ca.Stream, ca.Name)
+
+	js.mu.RLock()
+	isLeader := cc.isConsumerLeader(ca.Client.Account, ca.Stream, ca.Name)
+	js.mu.RUnlock()
+
+	const (
+		compactInterval  = 2 * time.Minute
+		compactSizeLimit = 4 * 1024 * 1024
+		compactNumLimit  = 4096
+	)
 
 	t := time.NewTicker(compactInterval)
 	defer t.Stop()
 
-	// Our last applied.
-	last := uint64(0)
+	var lastSnap []byte
+
+	// Should only to be called from leader.
+	doSnapshot := func() {
+		if state, err := o.store.State(); err == nil && state != nil {
+			if snap := encodeConsumerState(state); !bytes.Equal(lastSnap, snap) {
+				if err := n.InstallSnapshot(snap); err == nil {
+					lastSnap = snap
+				}
+			}
+		}
+	}
 
 	for {
 		select {
@@ -2288,9 +2291,16 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 			}
 			if _, err := js.applyConsumerEntries(o, ce); err == nil {
 				n.Applied(ce.Index)
-				last = ce.Index
-				if _, b := n.Size(); b > compactSizeLimit {
-					n.Compact(last)
+				// If over 4MB go ahead and compact if not the leader.
+				if !isLeader {
+					if m, b := n.Size(); m > compactNumLimit || b > compactSizeLimit {
+						n.Compact(ce.Index)
+					}
+				}
+			}
+			if isLeader && lastSnap != nil {
+				if _, b := n.Size(); b > uint64(len(lastSnap)*4) {
+					doSnapshot()
 				}
 			}
 		case isLeader := <-lch:
@@ -2299,9 +2309,8 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 			}
 			js.processConsumerLeaderChange(o, isLeader)
 		case <-t.C:
-			// TODO(dlc) - We should have this delayed a bit to not race the invariants.
-			if last != 0 {
-				n.Compact(last)
+			if isLeader {
+				doSnapshot()
 			}
 		}
 	}
@@ -3598,19 +3607,13 @@ func (mset *stream) isCatchingUp() bool {
 }
 
 // Process a stream snapshot.
-func (mset *stream) processSnapshot(buf []byte) {
-	var snap streamSnapshot
-	if err := json.Unmarshal(buf, &snap); err != nil {
-		// Log error.
-		return
-	}
-
+func (mset *stream) processSnapshot(snap *streamSnapshot) {
 	// Update any deletes, etc.
-	mset.processSnapshotDeletes(&snap)
+	mset.processSnapshotDeletes(snap)
 
 	mset.mu.Lock()
 	state := mset.store.State()
-	sreq := mset.calculateSyncRequest(&state, &snap)
+	sreq := mset.calculateSyncRequest(&state, snap)
 	s, subject, n := mset.srv, mset.sa.Sync, mset.node
 	mset.mu.Unlock()
 
@@ -3654,7 +3657,8 @@ RETRY:
 	if sreq == nil {
 		mset.mu.Lock()
 		state := mset.store.State()
-		sreq = mset.calculateSyncRequest(&state, &snap)
+		sreq = mset.calculateSyncRequest(&state, snap)
+
 		mset.mu.Unlock()
 		if sreq == nil {
 			return

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -2774,6 +2774,7 @@ func TestJetStreamClusterRestartAndRemoveAdvisories(t *testing.T) {
 	defer usub.Unsubscribe()
 	nc.Flush()
 
+	checkSubsPending(t, csub, 0)
 	checkSubsPending(t, sub, 0)
 	checkSubsPending(t, usub, 0)
 
@@ -3495,7 +3496,7 @@ func TestJetStreamClusterStreamPerf(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	numConnections := 2
+	numConnections := 4
 	var conns []nats.JetStream
 	for i := 0; i < numConnections; i++ {
 		s := c.randomServer()
@@ -3504,7 +3505,7 @@ func TestJetStreamClusterStreamPerf(t *testing.T) {
 	}
 
 	toSend := 100000
-	numProducers := 10
+	numProducers := 8
 
 	payload := []byte("Hello JSC")
 

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -172,9 +172,8 @@ func TestJetStreamClusterSingleReplicaStreams(t *testing.T) {
 	sl := c.streamLeader("$G", "TEST")
 	sl.Shutdown()
 	c.restartServer(sl)
-	c.waitOnStreamLeader("$G", "TEST")
-	time.Sleep(500 * time.Millisecond)
 
+	c.waitOnStreamLeader("$G", "TEST")
 	si, err = js.StreamInfo("TEST")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -184,8 +183,6 @@ func TestJetStreamClusterSingleReplicaStreams(t *testing.T) {
 	}
 	// Now durable consumer.
 	c.waitOnConsumerLeader("$G", "TEST", "dlc")
-	time.Sleep(500 * time.Millisecond)
-
 	if _, err = js.ConsumerInfo("TEST", "dlc"); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -610,8 +607,8 @@ func TestJetStreamClusterMetaSnapshotsAndCatchup(t *testing.T) {
 	// Shut one down.
 	rs := c.randomServer()
 	rs.Shutdown()
-	c.waitOnLeader()
 
+	c.waitOnLeader()
 	s := c.leader()
 
 	// Client based API
@@ -630,7 +627,6 @@ func TestJetStreamClusterMetaSnapshotsAndCatchup(t *testing.T) {
 	}
 
 	c.leader().JetStreamSnapshotMeta()
-	time.Sleep(250 * time.Millisecond)
 
 	rs = c.restartServer(rs)
 	c.checkClusterFormed()
@@ -641,16 +637,9 @@ func TestJetStreamClusterMetaSnapshotsAndCatchup(t *testing.T) {
 
 	for i := 0; i < numStreams; i++ {
 		sn := fmt.Sprintf("T-%d", i+1)
-		resp, err := nc.Request(fmt.Sprintf(JSApiStreamDeleteT, sn), nil, time.Second)
+		err := js.DeleteStream(sn)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
-		}
-		var dResp JSApiStreamDeleteResponse
-		if err := json.Unmarshal(resp.Data, &dResp); err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		if !dResp.Success || dResp.Error != nil {
-			t.Fatalf("Got a bad response %+v", dResp.Error)
 		}
 	}
 
@@ -1589,11 +1578,17 @@ func TestJetStreamClusterExtendedStreamInfo(t *testing.T) {
 		t.Fatalf("Expected %d replicas, got %d", 2, len(si.Cluster.Replicas))
 	}
 
+	// Faster timeout since we loop below checking for condition.
+	js2, err := nc.JetStream(nats.MaxWait(10 * time.Millisecond))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
 	// We may need to wait a bit for peers to catch up.
 	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
 		for _, peer := range si.Cluster.Replicas {
 			if !peer.Current {
-				if si, err = js.StreamInfo("TEST"); err != nil {
+				if si, err = js2.StreamInfo("TEST"); err != nil {
 					t.Fatalf("Could not retrieve stream info")
 				}
 				return fmt.Errorf("Expected replica to be current: %+v", peer)
@@ -1658,11 +1653,12 @@ func TestJetStreamClusterExtendedStreamInfo(t *testing.T) {
 	if len(si.Cluster.Replicas) != 2 {
 		t.Fatalf("Expected %d replicas, got %d", 2, len(si.Cluster.Replicas))
 	}
+
 	// We may need to wait a bit for peers to catch up.
 	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
 		for _, peer := range si.Cluster.Replicas {
 			if !peer.Current {
-				if si, err = js.StreamInfo("TEST"); err != nil {
+				if si, err = js2.StreamInfo("TEST"); err != nil {
 					t.Fatalf("Could not retrieve stream info")
 				}
 				return fmt.Errorf("Expected replica to be current: %+v", peer)
@@ -1885,7 +1881,13 @@ func TestJetStreamClusterUserSnapshotAndRestore(t *testing.T) {
 		}
 	}
 
-	// Create a consumer as well and give it a non-simplistic state.
+	// Create consumer with no state.
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Durable: "rip", AckPolicy: nats.AckExplicitPolicy, AckWait: time.Second})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Create another consumer as well and give it a non-simplistic state.
 	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Durable: "dlc", AckPolicy: nats.AckExplicitPolicy, AckWait: time.Second})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -1914,9 +1916,9 @@ func TestJetStreamClusterUserSnapshotAndRestore(t *testing.T) {
 			m.Ack()
 		}
 	}
+	nc.Flush()
 
 	// Snapshot consumer info.
-	time.Sleep(100 * time.Millisecond)
 	ci, err := jsub.ConsumerInfo()
 	if err != nil {
 		t.Fatalf("Unexpected error getting consumer info: %v", err)
@@ -2069,9 +2071,9 @@ func TestJetStreamClusterUserSnapshotAndRestore(t *testing.T) {
 	start := 101
 	end := toSend
 	for i := start; i <= end; i++ {
-		m, err := jsub.NextMsg(time.Second)
+		m, err := jsub.NextMsg(2 * time.Second)
 		if err != nil {
-			t.Fatalf("Unexpected error getting msg: %v", err)
+			t.Fatalf("Unexpected error getting msg [%d]: %v", i, err)
 		}
 		meta, err := m.MetaData()
 		if err != nil {
@@ -2086,6 +2088,37 @@ func TestJetStreamClusterUserSnapshotAndRestore(t *testing.T) {
 	// Check that redelivered come in now..
 	redelivered := 50/3 + 1
 	checkSubsPending(t, jsub, redelivered)
+
+	// Now make sure the other server was properly caughtup.
+	// Need to call this by hand for now.
+	rmsg, err = nc.Request(fmt.Sprintf(JSApiStreamLeaderStepDownT, "TEST"), nil, time.Second)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	var sdResp JSApiStreamLeaderStepDownResponse
+	if err := json.Unmarshal(rmsg.Data, &sdResp); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if sdResp.Error != nil {
+		t.Fatalf("Unexpected error: %+v", sdResp.Error)
+	}
+
+	c.waitOnStreamLeader("$G", "TEST")
+	si, err = js.StreamInfo("TEST")
+	if err != nil {
+		t.Fatalf("Unexpected error: %+v", err)
+	}
+	if si.State.Msgs != uint64(toSend) {
+		t.Fatalf("Unexpected stream info: %+v", si)
+	}
+
+	// Check idle consumer
+	c.waitOnConsumerLeader("$G", "TEST", "rip")
+
+	// Now check for the consumer being recreated.
+	if _, err := js.ConsumerInfo("TEST", "rip"); err != nil {
+		t.Fatalf("Unexpected error: %+v", err)
+	}
 }
 
 func TestJetStreamClusterAccountInfoAndLimits(t *testing.T) {
@@ -3013,7 +3046,7 @@ func TestJetStreamClusterRemovePeer(t *testing.T) {
 	})
 }
 
-func TestJetStreamClusterStepDown(t *testing.T) {
+func TestJetStreamClusterStreamLeaderStepDown(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "RNS", 3)
 	defer c.shutdown()
 
@@ -3141,11 +3174,22 @@ func TestJetStreamClusterRemoveServer(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	checkSubsPending(t, sub, toSend)
+	ci, err := sub.ConsumerInfo()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	cname := ci.Name
 
 	sl := c.streamLeader("$G", "TEST")
 	c.removeJetStream(sl)
 
 	c.waitOnStreamLeader("$G", "TEST")
+
+	// Faster timeout since we loop below checking for condition.
+	js, err = nc.JetStream(nats.MaxWait(10 * time.Millisecond))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 
 	// Check the stream info is eventually correct.
 	checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
@@ -3165,8 +3209,9 @@ func TestJetStreamClusterRemoveServer(t *testing.T) {
 	})
 
 	// Now do consumer.
+	c.waitOnConsumerLeader("$G", "TEST", cname)
 	checkFor(t, 5*time.Second, 50*time.Millisecond, func() error {
-		ci, err := sub.ConsumerInfo()
+		ci, err := js.ConsumerInfo("TEST", cname)
 		if err != nil {
 			return fmt.Errorf("Could not fetch consumer info: %v", err)
 		}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -83,6 +83,10 @@ func (ms *memStore) UpdateConfig(cfg *StreamConfig) error {
 // Stores a raw message with expected sequence number and timestamp.
 // Lock should be held.
 func (ms *memStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts int64) error {
+	if ms.msgs == nil {
+		return ErrStoreClosed
+	}
+
 	// Check if we are discarding new messages when we reach the limit.
 	if ms.cfg.Discard == DiscardNew {
 		if ms.cfg.MaxMsgs > 0 && ms.state.Msgs >= uint64(ms.cfg.MaxMsgs) {

--- a/server/server.go
+++ b/server/server.go
@@ -1647,8 +1647,9 @@ func (s *Server) Start() {
 // Shutdown will shutdown the server instance by kicking out the AcceptLoop
 // and closing all associated clients.
 func (s *Server) Shutdown() {
-	// Shutdown our raftnodes. If we are the leader we will attempt to transfer.
-	s.shutdownRaftNodes()
+	// Transfer off any raft nodes that we are a leader.
+	s.transferRaftLeaders()
+
 	// Shutdown the eventing system as needed.
 	// This is done first to send out any messages for
 	// account status. We will also clean up any

--- a/server/stream.go
+++ b/server/stream.go
@@ -1347,7 +1347,10 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 
 		mset.mu.Lock()
 		for _, o := range mset.consumers {
-			if o.isLeader() {
+			o.mu.RLock()
+			isLeader := o.isLeader()
+			o.mu.RUnlock()
+			if isLeader {
 				obs = append(obs, o)
 			}
 		}

--- a/server/stream.go
+++ b/server/stream.go
@@ -943,7 +943,7 @@ func (mset *stream) setupStore(fsCfg *FileStoreConfig) error {
 		}
 		mset.store = ms
 	case FileStorage:
-		fs, _, err := newFileStoreWithCreated(*fsCfg, mset.cfg, mset.created)
+		fs, err := newFileStoreWithCreated(*fsCfg, mset.cfg, mset.created)
 		if err != nil {
 			mset.mu.Unlock()
 			return err


### PR DESCRIPTION
Previously we did a snapshot and compaction strategy that would require pauses to the proposals from clients which was not ideal. This changes that to a raft node maintained external snapshots that do not require pauses. We also moved to memory based WALs for streams and consumers.

Various other bug fixes, data race fixes and stability improvements.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
