### PR TITLE
MQTT clustering

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3606,10 +3606,10 @@ func (c *client) setHeader(key, value string, msg []byte) []byte {
 	// Put the original message back.
 	// FIXME(dlc) - This is inefficient.
 	bb.Write(msg[omi:])
-	nsize := bb.Len()
-	// MQTT producers don't have CRLF
-	if !c.isMqtt() {
-		nsize -= LEN_CR_LF
+	nsize := bb.Len() - LEN_CR_LF
+	// MQTT producers don't have CRLF, so add it back.
+	if c.isMqtt() {
+		nsize += LEN_CR_LF
 	}
 	// Update pubArgs
 	// If others will use this later we need to save and restore original.

--- a/server/client.go
+++ b/server/client.go
@@ -117,6 +117,8 @@ var readLoopReportThreshold = readLoopReport
 // Represent client booleans with a bitmask
 type clientFlag uint16
 
+const hdrLine = "NATS/1.0\r\n"
+
 // Some client state represented as flags
 const (
 	connectReceived   clientFlag = 1 << iota // The CONNECT proto has been received
@@ -1033,7 +1035,7 @@ func (c *client) readLoop(pre []byte) {
 
 	defer func() {
 		if c.isMqtt() {
-			s.mqttHandleWill(c)
+			s.mqttHandleClosedClient(c)
 		}
 		// These are used only in the readloop, so we can set them to nil
 		// on exit of the readLoop.
@@ -3353,7 +3355,9 @@ func (c *client) selectMappedSubject() bool {
 }
 
 // processInboundClientMsg is called to process an inbound msg from a client.
-func (c *client) processInboundClientMsg(msg []byte) bool {
+// Return if the message was delivered, and if the message was not delivered
+// due to a permission issue.
+func (c *client) processInboundClientMsg(msg []byte) (bool, bool) {
 	// Update statistics
 	// The msg includes the CR_LF, so pull back out for accounting.
 	c.in.msgs++
@@ -3362,24 +3366,24 @@ func (c *client) processInboundClientMsg(msg []byte) bool {
 	// Check that client (could be here with SYSTEM) is not publishing on reserved "$GNR" prefix.
 	if c.kind == CLIENT && hasGWRoutedReplyPrefix(c.pa.subject) {
 		c.pubPermissionViolation(c.pa.subject)
-		return false
+		return false, true
 	}
 
 	// Mostly under testing scenarios.
 	if c.srv == nil || c.acc == nil {
-		return false
+		return false, false
 	}
 
 	// Check pub permissions
 	if c.perms != nil && (c.perms.pub.allow != nil || c.perms.pub.deny != nil) && !c.pubAllowed(string(c.pa.subject)) {
 		c.pubPermissionViolation(c.pa.subject)
-		return false
+		return false, true
 	}
 
 	// Now check for reserved replies. These are used for service imports.
 	if len(c.pa.reply) > 0 && isReservedReply(c.pa.reply) {
 		c.replySubjectViolation(c.pa.reply)
-		return false
+		return false, true
 	}
 
 	if c.opts.Verbose {
@@ -3393,7 +3397,7 @@ func (c *client) processInboundClientMsg(msg []byte) bool {
 
 	// Check if this client's gateway replies map is not empty
 	if atomic.LoadInt32(&c.cgwrt) > 0 && c.handleGWReplyMap(msg) {
-		return true
+		return true, false
 	}
 
 	// If we have an exported service and we are doing remote tracking, check this subject
@@ -3489,7 +3493,7 @@ func (c *client) processInboundClientMsg(msg []byte) bool {
 		c.mu.Unlock()
 	}
 
-	return didDeliver
+	return didDeliver, false
 }
 
 // Return the subscription for this reply subject. Only look at normal subs for this client.
@@ -3586,7 +3590,6 @@ func removeHeaderIfPresent(hdr []byte, key string) []byte {
 // from the inbound go routine. We will update the pubArgs.
 // This will replace any previously set header and not add to it per normal spec.
 func (c *client) setHeader(key, value string, msg []byte) []byte {
-	const hdrLine = "NATS/1.0\r\n"
 	var bb bytes.Buffer
 	var omi int
 	// Write original header if present.
@@ -3603,7 +3606,11 @@ func (c *client) setHeader(key, value string, msg []byte) []byte {
 	// Put the original message back.
 	// FIXME(dlc) - This is inefficient.
 	bb.Write(msg[omi:])
-	nsize := bb.Len() - LEN_CR_LF
+	nsize := bb.Len()
+	// MQTT producers don't have CRLF
+	if !c.isMqtt() {
+		nsize -= LEN_CR_LF
+	}
 	// Update pubArgs
 	// If others will use this later we need to save and restore original.
 	c.pa.hdr = nhdr

--- a/server/events.go
+++ b/server/events.go
@@ -391,7 +391,9 @@ func (s *Server) sendInternalAccountMsg(a *Account, subject string, msg interfac
 
 	// Replace our client with the account's internal client.
 	if a != nil {
+		a.mu.Lock()
 		c = a.internalClient()
+		a.mu.Unlock()
 	}
 
 	sendq <- &pubMsg{c, subject, _EMPTY_, nil, msg, false}

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -57,68 +57,11 @@ type FileStreamInfo struct {
 	StreamConfig
 }
 
-// Need an alias (which does not have MarshalJSON/UnmarshalJSON) to avoid
-// recursive calls which would lead to stack overflow.
-type fileStreamInfoAlias FileStreamInfo
-
-// We will use this struct definition to serialize/deserialize FileStreamInfo
-// object. This embeds FileStreamInfo (the alias to prevent recursive calls)
-// and makes the non-public options public so they can be persisted/recovered.
-type fileStreamInfoJSON struct {
-	fileStreamInfoAlias
-	Internal       bool `json:"internal,omitempty"`
-	AllowNoSubject bool `json:"allow_no_subject,omitempty"`
-}
-
-func (fsi FileStreamInfo) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&fileStreamInfoJSON{
-		fileStreamInfoAlias(fsi),
-		fsi.internal,
-		fsi.allowNoSubject,
-	})
-}
-
-func (fsi *FileStreamInfo) UnmarshalJSON(b []byte) error {
-	fsiJSON := &fileStreamInfoJSON{}
-	if err := json.Unmarshal(b, &fsiJSON); err != nil {
-		return err
-	}
-	*fsi = FileStreamInfo(fsiJSON.fileStreamInfoAlias)
-	fsi.internal = fsiJSON.Internal
-	fsi.allowNoSubject = fsiJSON.AllowNoSubject
-	return nil
-}
-
 // File ConsumerInfo is used for creating consumer stores.
 type FileConsumerInfo struct {
 	Created time.Time
 	Name    string
 	ConsumerConfig
-}
-
-// See fileStreamInfoAlias, etc.. for details on how this all work.
-type fileConsumerInfoAlias FileConsumerInfo
-
-type fileConsumerInfoJSON struct {
-	fileConsumerInfoAlias
-	AllowNoInterest bool `json:"allow_no_interest,omitempty"`
-}
-
-func (fci FileConsumerInfo) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&fileConsumerInfoJSON{
-		fileConsumerInfoAlias(fci),
-		fci.allowNoInterest,
-	})
-}
-
-func (fci *FileConsumerInfo) UnmarshalJSON(b []byte) error {
-	fciJSON := &fileConsumerInfoJSON{}
-	if err := json.Unmarshal(b, &fciJSON); err != nil {
-		return err
-	}
-	*fci = FileConsumerInfo(fciJSON.fileConsumerInfoAlias)
-	fci.allowNoInterest = fciJSON.AllowNoInterest
-	return nil
 }
 
 type fileStore struct {

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -2305,10 +2305,12 @@ func hasGWRoutedReplyPrefix(subj []byte) bool {
 // Evaluates if the given reply should be mapped or not.
 func (g *srvGateway) shouldMapReplyForGatewaySend(c *client, acc *Account, reply []byte) bool {
 	// If the reply is a service reply (_R_), we will use the account's internal
-	// clientinstead of the client handed to us. This client holds the wildcard
+	// client instead of the client handed to us. This client holds the wildcard
 	// for all service replies.
 	if isServiceReply(reply) {
+		acc.mu.Lock()
 		c = acc.internalClient()
+		acc.mu.Unlock()
 	}
 	// If for this client there is a recent matching subscription interest
 	// then we will map.

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1378,12 +1378,6 @@ func (s *Server) jsStreamInfoRequest(sub *subscription, c *client, subject, repl
 		return
 	}
 	config := mset.config()
-	// Some streams are created without subject (for instance MQTT streams),
-	// but "nats" tooling would then fail to display them since it uses
-	// validation and expect the config's Subjects to not be empty.
-	if config.allowNoSubject && len(config.Subjects) == 0 {
-		config.Subjects = []string{">"}
-	}
 
 	js, _ := s.getJetStreamCluster()
 
@@ -1787,11 +1781,6 @@ func (s *Server) jsStreamDeleteRequest(sub *subscription, c *client, subject, re
 	mset, err := acc.lookupStream(stream)
 	if err != nil {
 		resp.Error = jsNotFoundError(err)
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
-		return
-	}
-	if mset.config().internal {
-		resp.Error = &ApiError{Code: 403, Description: "not allowed to delete internal stream"}
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
@@ -2997,11 +2986,6 @@ func (s *Server) jsConsumerDeleteRequest(sub *subscription, c *client, subject, 
 	mset, err := acc.lookupStream(stream)
 	if err != nil {
 		resp.Error = jsNotFoundError(err)
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
-		return
-	}
-	if mset.config().internal {
-		resp.Error = &ApiError{Code: 403, Description: "not allowed to delete consumer of internal stream"}
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2081,7 +2081,7 @@ func (js *jetStream) processClusterCreateConsumer(ca *consumerAssignment) {
 	if o != nil {
 		if o.isDurable() && o.isPushMode() {
 			ocfg := o.config()
-			if configsEqualSansDelivery(ocfg, *ca.Config) && (ocfg.allowNoInterest || o.hasNoLocalInterest()) {
+			if configsEqualSansDelivery(ocfg, *ca.Config) && o.hasNoLocalInterest() {
 				o.updateDeliverSubject(ca.Config.DeliverSubject)
 			}
 		}

--- a/server/opts.go
+++ b/server/opts.go
@@ -364,15 +364,20 @@ type MQTTOpts struct {
 	// a client is redelivered as a DUPLICATE if the server has not
 	// received the PUBACK on the original Packet Identifier.
 	// The value has to be positive.
-	// Zero will cause the server to use the default value (1 hour).
+	// Zero will cause the server to use the default value (30 seconds).
 	// Note that changes to this option is applied only to new MQTT subscriptions.
 	AckWait time.Duration
 
 	// MaxAckPending is the amount of QoS 1 messages the server can send to
-	// a session without receiving any PUBACK for those messages.
+	// a subscription without receiving any PUBACK for those messages.
 	// The valid range is [0..65535].
-	// Zero will cause the server to use the default value (1024).
-	// Note that changes to this option is applied only to new MQTT sessions.
+	// The total of subscriptions' MaxAckPending on a given session cannot
+	// exceed 65535. Attempting to create a subscription that would bring
+	// the total above the limit would result in the server returning 0x80
+	// in the SUBACK for this subscription.
+	// Due to how the NATS Server handles the MQTT "#" wildcard, each
+	// subscription ending with "#" will use 2 times the MaxAckPending value.
+	// Note that changes to this option is applied only to new subscriptions.
 	MaxAckPending uint16
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -2511,11 +2511,7 @@ func (s *Server) removeClient(c *client) {
 		if updateProtoInfoCount {
 			s.cproto--
 		}
-		mqtt := c.isMqtt()
 		s.mu.Unlock()
-		if mqtt {
-			s.mqttHandleClosedClient(c)
-		}
 	case ROUTER:
 		s.removeRoute(c)
 	case GATEWAY:

--- a/server/stream.go
+++ b/server/stream.go
@@ -52,12 +52,6 @@ type StreamConfig struct {
 	Template     string          `json:"template_owner,omitempty"`
 	Duplicates   time.Duration   `json:"duplicate_window,omitempty"`
 	Placement    *Placement      `json:"placement,omitempty"`
-
-	// These are non public configuration options.
-	// If you add new options, check fileStreamInfoJSON in order for them to
-	// be properly persisted/recovered, if needed.
-	internal       bool
-	allowNoSubject bool
 }
 
 const JSApiPubAckResponseType = "io.nats.jetstream.api.v1.pub_ack_response"
@@ -647,9 +641,7 @@ func checkStreamCfg(config *StreamConfig) (StreamConfig, error) {
 	}
 
 	if len(cfg.Subjects) == 0 {
-		if !cfg.allowNoSubject {
-			cfg.Subjects = append(cfg.Subjects, cfg.Name)
-		}
+		cfg.Subjects = append(cfg.Subjects, cfg.Name)
 	} else {
 		// We can allow overlaps, but don't allow direct duplicates.
 		dset := make(map[string]struct{}, len(cfg.Subjects))
@@ -1433,7 +1425,7 @@ func (mset *stream) internalSendLoop() {
 				msg = append(pm.msg, _CRLF_...)
 			}
 
-			didDeliver := c.processInboundClientMsg(msg)
+			didDeliver, _ := c.processInboundClientMsg(msg)
 			c.pa.szb = nil
 			c.flushClients(0)
 


### PR DESCRIPTION
Made changes needed to support JetStream clustering.
I am no longer making any call to direct stream/consumer internal APIs.
I have no longer the need for "internal/no_interest/no_subject" private stream/consumer configuration properties, so I have removed them and remove the JSON marshaller that was added to persist those (since they were not exported).

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
