### PR TITLE
Allow placement directives for meta controllers

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -2622,15 +2622,6 @@ func (g *srvGateway) getClusterHash() []byte {
 	return clusterHash
 }
 
-// Returns the route with given hash or nil if not found.
-func (s *Server) getRouteByHash(srvHash []byte) *client {
-	var route *client
-	if v, ok := s.routesByHash.Load(string(srvHash)); ok {
-		route = v.(*client)
-	}
-	return route
-}
-
 // Store this route in map with the key being the remote server's name hash
 // and the remote server's ID hash used by gateway replies mapping routing.
 func (s *Server) storeRouteByHash(srvNameHash, srvIDHash string, c *client) {

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1726,12 +1726,12 @@ func (s *Server) jsLeaderStepDownRequest(sub *subscription, c *client, subject, 
 		cn := req.Placement.Cluster
 		var peers []string
 		for _, p := range cc.meta.Peers() {
-			si, ok := s.nodeToInfo.Load(p.ID)
-			ni := si.(*nodeInfo)
-			if !ok || ni.offline || ni.cluster != cn {
-				continue
+			if si, ok := s.nodeToInfo.Load(p.ID); ok && si != nil {
+				if ni := si.(*nodeInfo); ni.offline || ni.cluster != cn {
+					continue
+				}
+				peers = append(peers, p.ID)
 			}
-			peers = append(peers, p.ID)
 		}
 		if len(peers) == 0 {
 			resp.Error = jsClusterNoPeersErr

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -48,7 +48,7 @@ type jetStreamCluster struct {
 	stepdown *subscription
 }
 
-// Used to guide placement of streams in clustered JetStream.
+// Used to guide placement of streams and meta controllers in clustered JetStream.
 type Placement struct {
 	Cluster string   `json:"cluster"`
 	Tags    []string `json:"tags,omitempty"`
@@ -295,10 +295,11 @@ func (s *Server) JetStreamClusterPeers() []string {
 	peers := cc.meta.Peers()
 	var nodes []string
 	for _, p := range peers {
-		if si, ok := s.nodeToInfo.Load(p.ID); !ok || si.(*nodeInfo).offline {
+		si, ok := s.nodeToInfo.Load(p.ID)
+		if !ok || si.(*nodeInfo).offline {
 			continue
 		}
-		nodes = append(nodes, p.ID)
+		nodes = append(nodes, si.(*nodeInfo).name)
 	}
 	return nodes
 }


### PR DESCRIPTION
Allow metacontroller leaders to be moved to specific clusters in a supercluster setup.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
