### PR TITLE
Add optional DeliverTo field to ConsumerGetNextRequest JS API

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -505,9 +505,10 @@ const JSApiConsumerListResponseType = "io.nats.jetstream.api.v1.consumer_list_re
 
 // JSApiConsumerGetNextRequest is for getting next messages for pull based consumers.
 type JSApiConsumerGetNextRequest struct {
-	Expires time.Time `json:"expires,omitempty"`
-	Batch   int       `json:"batch,omitempty"`
-	NoWait  bool      `json:"no_wait,omitempty"`
+	Expires   time.Time `json:"expires,omitempty"`
+	Batch     int       `json:"batch,omitempty"`
+	NoWait    bool      `json:"no_wait,omitempty"`
+	DeliverTo string    `json:"deliver_to,omitempty"`
 }
 
 // JSApiStreamTemplateCreateResponse for creating templates.


### PR DESCRIPTION
This adds a `DeliverTo` which can be used to signal the server where the next message should be delivered after sending the next message request.  This way when a client makes a request to pull messages, it can receive the response from a different response handler than the subscription that is processing the messages.

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

/cc @nats-io/core