### PR TITLE
[fixes] crash in checkJetStreamExports when there is no system account

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -223,7 +223,7 @@ func (s *Server) EnableJetStream(config *JetStreamConfig) error {
 // on the system account, and if not go ahead and set them up.
 func (s *Server) checkJetStreamExports() {
 	sacc := s.SystemAccount()
-	if sacc.getServiceExport(allJsExports[0]) == nil {
+	if sacc != nil && sacc.getServiceExport(allJsExports[0]) == nil {
 		s.setupJetStreamExports()
 	}
 }


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

test case (as per email from Ben) passes now without crash

```
 00:44:26  ~/repos/nats-server  crash-no-sys-acc-js *20  go run ./main.go -c /Users/matthiashanel/Downloads/nats-server.conf -n asdf
[32566] 2021/02/23 00:44:27.741177 [INF] Starting nats-server
[32566] 2021/02/23 00:44:27.741278 [INF]   Version:  2.2.0-beta.88
[32566] 2021/02/23 00:44:27.741281 [INF]   Git:      [not set]
[32566] 2021/02/23 00:44:27.741283 [DBG]   Go build: go1.14.1
[32566] 2021/02/23 00:44:27.741285 [INF]   Name:     asdf
[32566] 2021/02/23 00:44:27.741292 [INF]   ID:       NBHX3YTUYZQ6MZKTBXI63DX6IYGKFBLNVSGZ5SN4JUBUUQMC54NRSWRX
[32566] 2021/02/23 00:44:27.741297 [INF] Using configuration file: /Users/matthiashanel/Downloads/nats-server.conf
[32566] 2021/02/23 00:44:27.741299 [INF] Trusted Operators
[32566] 2021/02/23 00:44:27.741301 [INF]   System  : ""
[32566] 2021/02/23 00:44:27.741305 [INF]   Operator: "w7n.sh"
[32566] 2021/02/23 00:44:27.741324 [INF]   Issued  : 2021-02-22 15:37:04 -0500 EST
[32566] 2021/02/23 00:44:27.741327 [INF]   Expires : 1969-12-31 19:00:00 -0500 EST
[32566] 2021/02/23 00:44:27.742152 [TRC] SYSTEM - <<- [SUB $SYS._INBOX.sg8zkQLm.*  2]
[32566] 2021/02/23 00:44:27.742190 [TRC] SYSTEM - <<- [SUB $SYS.SERVER.ACCOUNT.*.CONNS  3]
[32566] 2021/02/23 00:44:27.742205 [TRC] SYSTEM - <<- [SUB $SYS._INBOX_.NBHX3YTUYZQ6MZKTBXI63DX6IYGKFBLNVSGZ5SN4JUBUUQMC54NRSWRX  4]
[32566] 2021/02/23 00:44:27.742215 [TRC] SYSTEM - <<- [SUB $SYS.REQ.ACCOUNT.NSUBS  5]
[32566] 2021/02/23 00:44:27.742220 [TRC] SYSTEM - <<- [SUB $SYS.SERVER.*.STATSZ  6]
[32566] 2021/02/23 00:44:27.742225 [TRC] SYSTEM - <<- [SUB $SYS.SERVER.*.SHUTDOWN  7]
[32566] 2021/02/23 00:44:27.742231 [TRC] SYSTEM - <<- [SUB $SYS.ACCOUNT.*.CLAIMS.UPDATE  8]
[32566] 2021/02/23 00:44:27.742239 [TRC] SYSTEM - <<- [SUB $SYS.REQ.ACCOUNT.*.CLAIMS.UPDATE  9]
[32566] 2021/02/23 00:44:27.742244 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.PING  10]
[32566] 2021/02/23 00:44:27.742264 [TRC] SYSTEM - <<- [PUB $SYS.SERVER.ACCOUNT.AB7Z4XUGW4LTMEN4RLBPOWCOF3MT7IH7IQNKP5GRI2VYPLFU2GPBVFJ3.CONNS  451]
[32566] 2021/02/23 00:44:27.742264 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.NBHX3YTUYZQ6MZKTBXI63DX6IYGKFBLNVSGZ5SN4JUBUUQMC54NRSWRX.SUBSZ  11]
[32566] 2021/02/23 00:44:27.742309 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.PING.SUBSZ  12]
[32566] 2021/02/23 00:44:27.742316 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.NBHX3YTUYZQ6MZKTBXI63DX6IYGKFBLNVSGZ5SN4JUBUUQMC54NRSWRX.CONNZ  13]
[32566] 2021/02/23 00:44:27.742281 [TRC] SYSTEM - <<- MSG_PAYLOAD: ["{\"type\":\"io.nats.server.advisory.v1.account_connections\",\"id\":\"JtsxC16mMJRDkA7TJy1PdY\",\"timestamp\":\"2021-02-23T05:44:27.742098Z\",\"server\":{\"name\":\"asdf\",\"host\":\"0.0.0.0\",\"id\":\"NBHX3YTUYZQ6MZKTBXI63DX6IYGKFBLNVSGZ5SN4JUBUUQMC54NRSWRX\",\"cluster\":\"jetstream\",\"ver\":\"2.2.0-beta.88\",\"seq\":2,\"jetstream\":true,\"time\":\"2021-02-23T00:44:27.742145-05:00\"},\"acc\":\"AB7Z4XUGW4LTMEN4RLBPOWCOF3MT7IH7IQNKP5GRI2VYPLFU2GPBVFJ3\",\"conns\":0,\"leafnodes\":0,\"total_conns\":0}"]
[32566] 2021/02/23 00:44:27.742324 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.PING.CONNZ  14]
[32566] 2021/02/23 00:44:27.742361 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.NBHX3YTUYZQ6MZKTBXI63DX6IYGKFBLNVSGZ5SN4JUBUUQMC54NRSWRX.ROUTEZ  15]
[32566] 2021/02/23 00:44:27.742377 [TRC] SYSTEM - <<- [PUB $SYS.ACCOUNT.AB7Z4XUGW4LTMEN4RLBPOWCOF3MT7IH7IQNKP5GRI2VYPLFU2GPBVFJ3.SERVER.CONNS  451]
[32566] 2021/02/23 00:44:27.742430 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.PING.ROUTEZ  16]
[32566] 2021/02/23 00:44:27.742436 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.NBHX3YTUYZQ6MZKTBXI63DX6IYGKFBLNVSGZ5SN4JUBUUQMC54NRSWRX.JSZ  17]
[32566] 2021/02/23 00:44:27.742441 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.PING.JSZ  18]
[32566] 2021/02/23 00:44:27.742442 [TRC] SYSTEM - <<- MSG_PAYLOAD: ["{\"type\":\"io.nats.server.advisory.v1.account_connections\",\"id\":\"JtsxC16mMJRDkA7TJy1PdY\",\"timestamp\":\"2021-02-23T05:44:27.742098Z\",\"server\":{\"name\":\"asdf\",\"host\":\"0.0.0.0\",\"id\":\"NBHX3YTUYZQ6MZKTBXI63DX6IYGKFBLNVSGZ5SN4JUBUUQMC54NRSWRX\",\"cluster\":\"jetstream\",\"ver\":\"2.2.0-beta.88\",\"seq\":3,\"jetstream\":true,\"time\":\"2021-02-23T00:44:27.742364-05:00\"},\"acc\":\"AB7Z4XUGW4LTMEN4RLBPOWCOF3MT7IH7IQNKP5GRI2VYPLFU2GPBVFJ3\",\"conns\":0,\"leafnodes\":0,\"total_conns\":0}"]
[32566] 2021/02/23 00:44:27.742446 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.NBHX3YTUYZQ6MZKTBXI63DX6IYGKFBLNVSGZ5SN4JUBUUQMC54NRSWRX.STATSZ  19]
[32566] 2021/02/23 00:44:27.742527 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.PING.STATSZ  20]
[32566] 2021/02/23 00:44:27.742537 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.NBHX3YTUYZQ6MZKTBXI63DX6IYGKFBLNVSGZ5SN4JUBUUQMC54NRSWRX.VARZ  21]
[32566] 2021/02/23 00:44:27.742542 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.PING.VARZ  22]
[32566] 2021/02/23 00:44:27.742546 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.NBHX3YTUYZQ6MZKTBXI63DX6IYGKFBLNVSGZ5SN4JUBUUQMC54NRSWRX.GATEWAYZ  23]
[32566] 2021/02/23 00:44:27.742556 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.PING.GATEWAYZ  24]
[32566] 2021/02/23 00:44:27.742560 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.NBHX3YTUYZQ6MZKTBXI63DX6IYGKFBLNVSGZ5SN4JUBUUQMC54NRSWRX.LEAFZ  25]
[32566] 2021/02/23 00:44:27.742593 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.PING.LEAFZ  26]
[32566] 2021/02/23 00:44:27.742597 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.NBHX3YTUYZQ6MZKTBXI63DX6IYGKFBLNVSGZ5SN4JUBUUQMC54NRSWRX.ACCOUNTZ  27]
[32566] 2021/02/23 00:44:27.742603 [TRC] SYSTEM - <<- [SUB $SYS.REQ.SERVER.PING.ACCOUNTZ  28]
[32566] 2021/02/23 00:44:27.742613 [TRC] SYSTEM - <<- [SUB $SYS.REQ.ACCOUNT.*.SUBSZ  29]
[32566] 2021/02/23 00:44:27.742627 [TRC] SYSTEM - <<- [SUB $SYS.REQ.ACCOUNT.*.CONNZ  30]
[32566] 2021/02/23 00:44:27.742631 [TRC] SYSTEM - <<- [SUB $SYS.REQ.ACCOUNT.*.LEAFZ  31]
[32566] 2021/02/23 00:44:27.742636 [TRC] SYSTEM - <<- [SUB $SYS.REQ.ACCOUNT.*.JSZ  32]
[32566] 2021/02/23 00:44:27.742640 [TRC] SYSTEM - <<- [SUB $SYS.REQ.ACCOUNT.*.INFO  33]
[32566] 2021/02/23 00:44:27.742644 [TRC] SYSTEM - <<- [SUB $SYS.REQ.ACCOUNT.*.CONNS  34]
[32566] 2021/02/23 00:44:27.742648 [TRC] SYSTEM - <<- [SUB $SYS.ACCOUNT.*.LEAFNODE.CONNECT  35]
[32566] 2021/02/23 00:44:27.742692 [TRC] SYSTEM - <<- [SUB $SYS.LATENCY.M2.sg8zkQLm  36]
[32566] 2021/02/23 00:44:27.742698 [TRC] SYSTEM - <<- [SUB $SYS.DEBUG.SUBSCRIBERS  37]
[32566] 2021/02/23 00:44:27.742724 [FTL] Not allowed to enable JetStream on the system account
exit status 1
 00:44:28  ✘ 1  ~/repos/nats-server  crash-no-sys-acc-js *20 
```