### PR TITLE
Cross account JetStream pull consumers.

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3586,15 +3586,19 @@ func removeHeaderIfPresent(hdr []byte, key string) []byte {
 	if start < 0 {
 		return hdr
 	}
+	index := start + len(key)
+	if index >= len(hdr) || hdr[index] != ':' {
+		return hdr
+	}
 	end := bytes.Index(hdr[start:], []byte(_CRLF_))
 	if end < 0 {
 		return hdr
 	}
-	nhdr := append(hdr[:start], hdr[start+end+len(_CRLF_):]...)
-	if len(nhdr) <= len(emptyHdrLine) {
+	hdr = append(hdr[:start], hdr[start+end+len(_CRLF_):]...)
+	if len(hdr) <= len(emptyHdrLine) {
 		return nil
 	}
-	return nhdr
+	return hdr
 }
 
 // Generate a new header based on optional original header and key value.

--- a/server/client.go
+++ b/server/client.go
@@ -3583,7 +3583,8 @@ func (c *client) setupResponseServiceImport(acc *Account, si *serviceImport, tra
 // Will remove a header if present.
 func removeHeaderIfPresent(hdr []byte, key string) []byte {
 	start := bytes.Index(hdr, []byte(key))
-	if start < 0 {
+	// key can't be first and we want to check that it is preceded by a '\n'
+	if start < 1 || hdr[start-1] != '\n' {
 		return hdr
 	}
 	index := start + len(key)

--- a/server/stream.go
+++ b/server/stream.go
@@ -1726,7 +1726,13 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		}
 	}
 
-	// Process msg headers if present.
+	// If we have received this message across an account we may have request information attached.
+	// For now remove. TODO(dlc) - Should this be opt-in or opt-out?
+	if len(hdr) > 0 {
+		hdr = removeHeaderIfPresent(hdr, ClientInfoHdr)
+	}
+
+	// Process additional msg headers if still present.
 	var msgId string
 	if len(hdr) > 0 {
 		msgId = getMsgId(hdr)


### PR DESCRIPTION
Reply subject rewrite behaviors when crossing accounts via service imports would break JetStream pull consumers.
For now make special case. Need longer term solution for opt-in or opt-opt of reply subject rewrite.

Also do not store request info headers into JetStream streams.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
