### PR TITLE
Allow sources and mirrors to not be pre-defined.

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1050,7 +1050,7 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, subject, re
 			return
 		}
 
-		// Now make sure the other stream exists.
+		// We do not require other stream to exist anymore, but if we can see it check payloads.
 		var exists bool
 		var maxMsgSize int32
 
@@ -1064,12 +1064,7 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, subject, re
 			maxMsgSize = mset.cfg.MaxMsgSize
 			exists = true
 		}
-		if !exists {
-			resp.Error = &ApiError{Code: 400, Description: "stream mirror source must exist"}
-			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
-			return
-		}
-		if cfg.MaxMsgSize > 0 && maxMsgSize > 0 && cfg.MaxMsgSize < maxMsgSize {
+		if exists && cfg.MaxMsgSize > 0 && maxMsgSize > 0 && cfg.MaxMsgSize < maxMsgSize {
 			resp.Error = &ApiError{Code: 400, Description: "stream mirror must have max message size >= source"}
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -10441,11 +10441,8 @@ func TestJetStreamMirrorBasics(t *testing.T) {
 
 	// Clear subjects.
 	cfg.Subjects = nil
-	scr = createStream(cfg)
-	if scr.Error == nil || !strings.Contains(scr.Error.Description, "stream mirror source must exist") {
-		t.Fatalf("Expected error, got %+v", scr.Error)
-	}
 
+	// Source
 	scfg := &StreamConfig{
 		Name:     "S1",
 		Storage:  FileStorage,


### PR DESCRIPTION
Now will keep trying to establish contact.
Fixed bug where double source headers for sourced messages were causing issues.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
