### PR TITLE
Utc time

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3153,7 +3153,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 		a.jsLimits = nil
 	}
 
-	a.updated = time.Now()
+	a.updated = time.Now().UTC()
 	a.mu.Unlock()
 
 	clients := gatherClients()

--- a/server/client.go
+++ b/server/client.go
@@ -975,7 +975,7 @@ func (c *client) writeLoop() {
 // will normally be called in the readLoop of the client who sent the
 // message that now is being delivered.
 func (c *client) flushClients(budget time.Duration) time.Time {
-	last := time.Now()
+	last := time.Now().UTC()
 
 	// Check pending clients for flush.
 	for cp := range c.pcd {
@@ -1615,7 +1615,7 @@ func (c *client) processConnect(arg []byte) error {
 		c.mu.Unlock()
 		return nil
 	}
-	c.last = time.Now()
+	c.last = time.Now().UTC()
 	// Estimate RTT to start.
 	if c.kind == CLIENT {
 		c.rtt = computeRTT(c.start)
@@ -2013,7 +2013,7 @@ func (c *client) sendRTTPingLocked() bool {
 
 // Assume the lock is held upon entry.
 func (c *client) sendPing() {
-	c.rttStart = time.Now()
+	c.rttStart = time.Now().UTC()
 	c.ping.out++
 	if c.trace {
 		c.traceOutOp("PING", nil)

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -946,7 +946,6 @@ func (o *consumer) config() ConsumerConfig {
 // Force expiration of all pending.
 // Lock should be held.
 func (o *consumer) forceExpirePending() {
-	now := time.Now().UnixNano()
 	var expired []uint64
 	for seq := range o.pending {
 		if !o.onRedeliverQueue(seq) {
@@ -958,7 +957,7 @@ func (o *consumer) forceExpirePending() {
 		o.rdq = append(o.rdq, expired...)
 		// Now we should update the timestamp here since we are redelivering.
 		// We will use an incrementing time to preserve order for any other redelivery.
-		off := now - o.pending[expired[0]].Timestamp
+		off := time.Now().UnixNano() - o.pending[expired[0]].Timestamp
 		for _, seq := range expired {
 			if p, ok := o.pending[seq]; ok && p != nil {
 				p.Timestamp += off

--- a/server/events.go
+++ b/server/events.go
@@ -294,7 +294,7 @@ RESET:
 				pm.si.ID = id
 				pm.si.Seq = atomic.AddUint64(seqp, 1)
 				pm.si.Version = VERSION
-				pm.si.Time = time.Now()
+				pm.si.Time = time.Now().UTC()
 				pm.si.JetStream = js
 			}
 			var b []byte
@@ -1434,7 +1434,7 @@ func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string)
 		TypedEvent: TypedEvent{
 			Type: DisconnectEventMsgType,
 			ID:   eid,
-			Time: now.UTC(),
+			Time: now,
 		},
 		Client: ClientInfo{
 			Start:     &c.start,
@@ -1477,13 +1477,13 @@ func (s *Server) sendAuthErrorEvent(c *client) {
 	}
 	eid := s.nextEventID()
 	s.mu.Unlock()
-	now := time.Now()
+	now := time.Now().UTC()
 	c.mu.Lock()
 	m := DisconnectEventMsg{
 		TypedEvent: TypedEvent{
 			Type: DisconnectEventMsgType,
 			ID:   eid,
-			Time: now.UTC(),
+			Time: now,
 		},
 		Client: ClientInfo{
 			Start:     &c.start,

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1635,7 +1635,7 @@ func TestSystemAccountWithGateways(t *testing.T) {
 }
 func TestServerEventsStatsZ(t *testing.T) {
 	serverStatsReqSubj := "$SYS.REQ.SERVER.%s.STATSZ"
-	preStart := time.Now()
+	preStart := time.Now().UTC()
 	// Add little bit of delay to make sure that time check
 	// between pre-start and actual start does not fail.
 	time.Sleep(5 * time.Millisecond)
@@ -1644,7 +1644,7 @@ func TestServerEventsStatsZ(t *testing.T) {
 	defer sb.Shutdown()
 	// Same between actual start and post start.
 	time.Sleep(5 * time.Millisecond)
-	postStart := time.Now()
+	postStart := time.Now().UTC()
 
 	url := fmt.Sprintf("nats://%s:%d", optsA.Host, optsA.Port)
 	ncs, err := nats.Connect(url, createUserCreds(t, sa, akp))

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -195,7 +195,7 @@ const (
 )
 
 func newFileStore(fcfg FileStoreConfig, cfg StreamConfig) (*fileStore, error) {
-	return newFileStoreWithCreated(fcfg, cfg, time.Now())
+	return newFileStoreWithCreated(fcfg, cfg, time.Now().UTC())
 }
 
 func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created time.Time) (*fileStore, error) {
@@ -3440,8 +3440,6 @@ func encodeConsumerState(state *ConsumerState) []byte {
 		buf = make([]byte, maxSize)
 	}
 
-	now := time.Now()
-
 	// Write header
 	buf[0] = magic
 	buf[1] = 2
@@ -3459,7 +3457,7 @@ func encodeConsumerState(state *ConsumerState) []byte {
 	// These are optional, but always write len. This is to avoid a truncate inline.
 	if len(state.Pending) > 0 {
 		// To save space we will use now rounded to seconds to be base timestamp.
-		mints := now.Round(time.Second).Unix()
+		mints := time.Now().Round(time.Second).Unix()
 		// Write minimum timestamp we found from above.
 		n += binary.PutVarint(buf[n:], mints)
 

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -718,7 +718,7 @@ func (s *Server) createGateway(cfg *gatewayCfg, url *url.URL, conn net.Conn) {
 	// Snapshot server options.
 	opts := s.getOpts()
 
-	now := time.Now()
+	now := time.Now().UTC()
 	c := &client{srv: s, nc: conn, start: now, last: now, kind: GATEWAY}
 
 	// Are we creating the gateway based on the configuration

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2203,7 +2203,7 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, subject, reply st
 		Sequence: req.Seq,
 		Header:   hdr,
 		Data:     msg,
-		Time:     time.Unix(0, ts),
+		Time:     time.Unix(0, ts).UTC(),
 	}
 	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 }
@@ -2368,13 +2368,13 @@ func (s *Server) processStreamRestore(ci *ClientInfo, acc *Account, cfg *StreamC
 	streamName := cfg.Name
 	s.Noticef("Starting restore for stream '%s > %s'", acc.Name, streamName)
 
-	start := time.Now()
+	start := time.Now().UTC()
 
 	s.publishAdvisory(acc, JSAdvisoryStreamRestoreCreatePre+"."+streamName, &JSRestoreCreateAdvisory{
 		TypedEvent: TypedEvent{
 			Type: JSRestoreCreateAdvisoryType,
 			ID:   nuid.Next(),
-			Time: time.Now().UTC(),
+			Time: start,
 		},
 		Stream: streamName,
 		Client: ci,
@@ -2481,18 +2481,18 @@ func (s *Server) processStreamRestore(ci *ClientInfo, acc *Account, cfg *StreamC
 					s.Warnf(errStr)
 				}
 
-				end := time.Now()
+				end := time.Now().UTC()
 
 				// TODO(rip) - Should this have the error code in it??
 				s.publishAdvisory(acc, JSAdvisoryStreamRestoreCompletePre+"."+streamName, &JSRestoreCompleteAdvisory{
 					TypedEvent: TypedEvent{
 						Type: JSRestoreCompleteAdvisoryType,
 						ID:   nuid.Next(),
-						Time: time.Now().UTC(),
+						Time: end,
 					},
 					Stream: streamName,
-					Start:  start.UTC(),
-					End:    end.UTC(),
+					Start:  start,
+					End:    end,
 					Bytes:  int64(total),
 					Client: ci,
 				})
@@ -2587,7 +2587,7 @@ func (s *Server) jsStreamSnapshotRequest(sub *subscription, c *client, subject, 
 			s.Noticef("Starting snapshot for stream '%s > %s'", mset.jsa.account.Name, mset.name())
 		}
 
-		start := time.Now()
+		start := time.Now().UTC()
 
 		sr, err := mset.snapshot(0, req.CheckMsgs, !req.NoConsumers)
 		if err != nil {
@@ -2617,17 +2617,17 @@ func (s *Server) jsStreamSnapshotRequest(sub *subscription, c *client, subject, 
 		// Now do the real streaming.
 		s.streamSnapshot(ci, acc, mset, sr, &req)
 
-		end := time.Now()
+		end := time.Now().UTC()
 
 		s.publishAdvisory(acc, JSAdvisoryStreamSnapshotCompletePre+"."+mset.name(), &JSSnapshotCompleteAdvisory{
 			TypedEvent: TypedEvent{
 				Type: JSSnapshotCompleteAdvisoryType,
 				ID:   nuid.Next(),
-				Time: time.Now().UTC(),
+				Time: end,
 			},
 			Stream: mset.name(),
-			Start:  start.UTC(),
-			End:    end.UTC(),
+			Start:  start,
+			End:    end,
 			Client: ci,
 		})
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3079,7 +3079,7 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 	// Pick a preferred leader.
 	rg.setPreferred()
 	// Sync subject for post snapshot sync.
-	sa := &streamAssignment{Group: rg, Sync: syncSubjForStream(), Config: cfg, Subject: subject, Reply: reply, Client: ci, Created: time.Now()}
+	sa := &streamAssignment{Group: rg, Sync: syncSubjForStream(), Config: cfg, Subject: subject, Reply: reply, Client: ci, Created: time.Now().UTC()}
 	cc.meta.Propose(encodeAddStreamAssignment(sa))
 }
 
@@ -3218,7 +3218,7 @@ func (s *Server) jsClusteredStreamRestoreRequest(ci *ClientInfo, acc *Account, r
 	}
 	// Pick a preferred leader.
 	rg.setPreferred()
-	sa := &streamAssignment{Group: rg, Sync: syncSubjForStream(), Config: cfg, Subject: subject, Reply: reply, Client: ci, Created: time.Now()}
+	sa := &streamAssignment{Group: rg, Sync: syncSubjForStream(), Config: cfg, Subject: subject, Reply: reply, Client: ci, Created: time.Now().UTC()}
 	// Now add in our restore state and pre-select a peer to handle the actual receipt of the snapshot.
 	sa.Restore = &req.State
 	cc.meta.Propose(encodeAddStreamAssignment(sa))

--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -1,3 +1,16 @@
+// Copyright 2020-2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -438,7 +438,7 @@ func TestJetStreamConsumerWithStartTime(t *testing.T) {
 			}
 
 			time.Sleep(10 * time.Millisecond)
-			startTime := time.Now()
+			startTime := time.Now().UTC()
 
 			for i := 0; i < toSend; i++ {
 				sendStreamMsg(t, nc, subj, fmt.Sprintf("MSG: %d", i+1))
@@ -1181,7 +1181,7 @@ func TestJetStreamCreateConsumer(t *testing.T) {
 			}
 
 			// StartPosition conflicts
-			now := time.Now()
+			now := time.Now().UTC()
 			if _, err := mset.addConsumer(&ConsumerConfig{
 				DeliverSubject: "A",
 				OptStartSeq:    1,
@@ -10534,7 +10534,7 @@ func TestJetStreamMirrorBasics(t *testing.T) {
 	})
 
 	// Make sure setting time works ok.
-	start := time.Now().Add(-2 * time.Hour)
+	start := time.Now().UTC().Add(-2 * time.Hour)
 	cfg = &StreamConfig{
 		Name:    "M4",
 		Storage: FileStorage,

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -610,7 +610,7 @@ func TestJWTAccountRenewFromResolver(t *testing.T) {
 	addAccountToMemResolver(s, apub, ajwt)
 	// Make sure the too quick update suppression does not bite us.
 	acc.mu.Lock()
-	acc.updated = time.Now().Add(-1 * time.Hour)
+	acc.updated = time.Now().UTC().Add(-1 * time.Hour)
 	acc.mu.Unlock()
 
 	// Do not update the account directly. The resolver should
@@ -2964,7 +2964,7 @@ func TestJWTAccountLimitsMaxConnsAfterExpired(t *testing.T) {
 	acc, _ := s.LookupAccount(fooPub)
 	acc.mu.Lock()
 	acc.expired = true
-	acc.updated = time.Now().Add(-2 * time.Second) // work around updating to quickly
+	acc.updated = time.Now().UTC().Add(-2 * time.Second) // work around updating to quickly
 	acc.mu.Unlock()
 
 	// Now update with new expiration and max connections lowered to 2

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -662,7 +662,7 @@ func (s *Server) createLeafNode(conn net.Conn, rURL *url.URL, remote *leafNodeCf
 	if maxSubs == 0 {
 		maxSubs = -1
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 
 	c := &client{srv: s, nc: conn, kind: LEAF, opts: defaultOpts, mpay: maxPay, msubs: maxSubs, start: now, last: now}
 	// Do not update the smap here, we need to do it in initLeafNodeSmapAndSendSubs

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -223,7 +223,7 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 	c := &Connz{
 		Offset: offset,
 		Limit:  limit,
-		Now:    time.Now(),
+		Now:    time.Now().UTC(),
 	}
 
 	// Open clients
@@ -678,7 +678,7 @@ type RouteInfo struct {
 // Routez returns a Routez struct containing information about routes.
 func (s *Server) Routez(routezOpts *RoutezOptions) (*Routez, error) {
 	rs := &Routez{Routes: []*RouteInfo{}}
-	rs.Now = time.Now()
+	rs.Now = time.Now().UTC()
 
 	if routezOpts == nil {
 		routezOpts = &RoutezOptions{}
@@ -859,7 +859,7 @@ func (s *Server) Subsz(opts *SubszOptions) (*Subsz, error) {
 	slStats := &SublistStats{}
 
 	// FIXME(dlc) - Make account aware.
-	sz := &Subsz{s.info.ID, time.Now(), slStats, 0, offset, limit, nil}
+	sz := &Subsz{s.info.ID, time.Now().UTC(), slStats, 0, offset, limit, nil}
 
 	if subdetail {
 		var raw [4096]*subscription
@@ -1347,7 +1347,7 @@ func (s *Server) updateVarzConfigReloadableFields(v *Varz) {
 // is done.
 // Server lock is held on entry.
 func (s *Server) updateVarzRuntimeFields(v *Varz, forceUpdate bool, pcpu float64, rss int64) {
-	v.Now = time.Now()
+	v.Now = time.Now().UTC()
 	v.Uptime = myUptime(time.Since(s.start))
 	v.Mem = rss
 	v.CPU = pcpu
@@ -1491,7 +1491,7 @@ type AccountGatewayz struct {
 // Gatewayz returns a Gatewayz struct containing information about gateways.
 func (s *Server) Gatewayz(opts *GatewayzOptions) (*Gatewayz, error) {
 	srvID := s.ID()
-	now := time.Now()
+	now := time.Now().UTC()
 	gw := s.gateway
 	gw.RLock()
 	if !gw.enabled {
@@ -1837,7 +1837,7 @@ func (s *Server) Leafz(opts *LeafzOptions) (*Leafz, error) {
 	}
 	return &Leafz{
 		ID:       s.ID(),
-		Now:      time.Now(),
+		Now:      time.Now().UTC(),
 		NumLeafs: len(leafnodes),
 		Leafs:    leafnodes,
 	}, nil
@@ -2045,7 +2045,7 @@ func (s *Server) HandleAccountz(w http.ResponseWriter, r *http.Request) {
 func (s *Server) Accountz(optz *AccountzOptions) (*Accountz, error) {
 	a := &Accountz{
 		ID:  s.ID(),
-		Now: time.Now(),
+		Now: time.Now().UTC(),
 	}
 	if sacc := s.SystemAccount(); sacc != nil {
 		a.SystemAccount = sacc.GetName()
@@ -2389,7 +2389,7 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 	}
 	jsi := &JSInfo{
 		ID:  s.ID(),
-		Now: time.Now(),
+		Now: time.Now().UTC(),
 	}
 	if !s.JetStreamEnabled() {
 		jsi.Disabled = true

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1068,7 +1068,7 @@ func TestConnzSortedByStopTimeClosedConn(t *testing.T) {
 
 	//Now adjust the Stop times for these with some random values.
 	s.mu.Lock()
-	now := time.Now()
+	now := time.Now().UTC()
 	ccs := s.closed.closedClients()
 	for _, cc := range ccs {
 		newStop := now.Add(time.Duration(rand.Int()%120) * -time.Minute)

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -374,7 +374,7 @@ func (s *Server) createMQTTClient(conn net.Conn) *client {
 	if maxSubs == 0 {
 		maxSubs = -1
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 
 	c := &client{srv: s, nc: conn, mpay: maxPay, msubs: maxSubs, start: now, last: now, mqtt: &mqtt{}}
 	c.headers = true

--- a/server/reload.go
+++ b/server/reload.go
@@ -698,7 +698,7 @@ func (s *Server) Reload() error {
 		return err
 	}
 	s.mu.Lock()
-	s.configTime = time.Now()
+	s.configTime = time.Now().UTC()
 	s.updateVarzConfigReloadableFields(s.varz)
 	s.mu.Unlock()
 	return nil

--- a/server/server.go
+++ b/server/server.go
@@ -315,7 +315,7 @@ func NewServer(opts *Options) (*Server, error) {
 		info.TLSAvailable = true
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 
 	s := &Server{
 		kp:           kp,
@@ -682,7 +682,7 @@ func (s *Server) configureAccounts() error {
 			acc.ic.acc = acc
 			acc.addAllServiceImportSubs()
 		}
-		acc.updated = time.Now()
+		acc.updated = time.Now().UTC()
 		return true
 	})
 
@@ -1177,7 +1177,7 @@ func (s *Server) createInternalClient(kind int) *client {
 	if kind != SYSTEM && kind != JETSTREAM && kind != ACCOUNT {
 		return nil
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	c := &client{srv: s, kind: kind, opts: internalOpts, msubs: -1, mpay: -1, start: now, last: now}
 	c.initClient()
 	c.echo = false
@@ -1246,7 +1246,7 @@ func (s *Server) registerAccountNoLock(acc *Account) *Account {
 		acc.lqws = make(map[string]int32)
 	}
 	acc.srv = s
-	acc.updated = time.Now()
+	acc.updated = time.Now().UTC()
 	acc.mu.Unlock()
 	s.accounts.Store(acc.Name, acc)
 	s.tmpAccounts.Delete(acc.Name)
@@ -2206,7 +2206,7 @@ func (s *Server) createClient(conn net.Conn) *client {
 	if maxSubs == 0 {
 		maxSubs = -1
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 
 	c := &client{srv: s, nc: conn, opts: defaultOpts, mpay: maxPay, msubs: maxSubs, start: now, last: now}
 
@@ -2360,7 +2360,7 @@ func (s *Server) createClient(conn net.Conn) *client {
 // This will save off a closed client in a ring buffer such that
 // /connz can inspect. Useful for debugging, etc.
 func (s *Server) saveClosedClient(c *client, nc net.Conn, reason ClosedState) {
-	now := time.Now()
+	now := time.Now().UTC()
 
 	s.accountDisconnectEvent(c, now, reason.String())
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1040,7 +1040,7 @@ func (s *Server) createWSClient(conn net.Conn, ws *websocket) *client {
 	if maxSubs == 0 {
 		maxSubs = -1
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 
 	c := &client{srv: s, nc: conn, opts: defaultOpts, mpay: maxPay, msubs: maxSubs, start: now, last: now, ws: ws}
 


### PR DESCRIPTION
I went through all structs with json fields and replaced them with a custom type UtcTime. 
From there I changed all occurrences of time.Time that end up in such a struct as well.
Because if was a different type the changes where rather large. 
Because these changes made it all the way to events/monitoring, the new type would break backwards compatibility for the embedding use case. (See commit one of this PR) 
Therefore I reverted and stuck with time.Time but added .UTC wherever it was missing.

If we wanted we could use the type (pasted below) in jetstream only where it does not interfere with embedding yet.
The implementation would make sure we use UTC when writing json and only accept times when in UTC.
Comments?  

```
// Time that assures json parsing only emits/accepts times in UTC
type UtcTime time.Time

func (t UtcTime) MarshalJSON() ([]byte, error) {
	return []byte(`"` + time.Time(t).UTC().Format(time.RFC3339Nano) + `"`), nil
}

func (t *UtcTime) UnmarshalJSON(data []byte) error {
	if len(data) <= 2 {
		return fmt.Errorf("time not formated properly: %q", (*time.Time)(t).String())
	}
	pt, err := time.Parse(time.RFC3339Nano, string(data[1:len(data)-1]))
	if err != nil {
		return err
	}
	if pt.Location() != time.UTC {
		return fmt.Errorf("time not in UTC: %q", (*time.Time)(t).String())
	}
	*t = UtcTime(pt)
	return nil
}
```

