### PR TITLE
upgrade nightlies to go 1.16

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v2

--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine AS builder
+FROM golang:1.16-alpine AS builder
 
 ARG VERSION="nightly"
 


### PR DESCRIPTION
Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
