### PR TITLE
Fixed linter issues

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -1015,7 +1015,7 @@ func (s *Server) isLeafNodeAuthorized(c *client) bool {
 }
 
 // Support for bcrypt stored passwords and tokens.
-var validBcryptPrefix = regexp.MustCompile(`^\$2[a,b,x,y]{1}\$\d{2}\$.*`)
+var validBcryptPrefix = regexp.MustCompile(`^\$2[abxy]\$\d{2}\$.*`)
 
 // isBcrypt checks whether the given password or token is bcrypted.
 func isBcrypt(password string) bool {

--- a/server/client.go
+++ b/server/client.go
@@ -1881,7 +1881,7 @@ func (c *client) queueOutbound(data []byte) bool {
 		atomic.AddInt64(&c.srv.slowConsumers, 1)
 		c.Noticef("Slow Consumer Detected: MaxPending of %d Exceeded", c.out.mp)
 		c.markConnAsClosed(SlowConsumerPendingBytes)
-		return referenced
+		return false
 	}
 
 	if c.out.p == nil && len(data) < maxBufSize {
@@ -4568,7 +4568,7 @@ func (c *client) closeConnection(reason ClosedState) {
 				srv.updateRouteSubscriptionMap(acc, esub.sub, -(esub.n))
 				srv.updateLeafNodes(acc, esub.sub, -(esub.n))
 			}
-			if prev := acc.removeClient(c); prev == 1 && srv != nil {
+			if prev := acc.removeClient(c); prev == 1 {
 				srv.decActiveAccounts()
 			}
 		}
@@ -4917,7 +4917,7 @@ func (c *client) doTLSHandshake(typ string, solicit bool, url *url.URL, tlsConfi
 	// The connection still may have been closed on success handshake due
 	// to a race with tls timeout. If that the case, return error indicating
 	// that the connection is closed.
-	if err == nil && c.isClosed() {
+	if c.isClosed() {
 		err = ErrConnectionClosed
 	}
 

--- a/server/dirstore.go
+++ b/server/dirstore.go
@@ -568,7 +568,7 @@ type expirationTracker struct {
 	wg           sync.WaitGroup
 }
 
-func (pq *expirationTracker) Len() int { return len(pq.heap) }
+func (q *expirationTracker) Len() int { return len(q.heap) }
 
 func (q *expirationTracker) Less(i, j int) bool {
 	pq := q.heap

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2154,10 +2154,10 @@ func (s *Server) accountInfo(accName string) (*AccountInfo, error) {
 		if v != nil {
 			imp.Invalid = v.invalid
 			imp.Import = jwt.Import{
-				Subject: jwt.Subject(v.from),
-				Account: v.acc.Name,
-				Type:    jwt.Stream,
-				To:      jwt.Subject(v.to),
+				Subject:      jwt.Subject(v.from),
+				Account:      v.acc.Name,
+				Type:         jwt.Stream,
+				LocalSubject: jwt.RenamingSubject(v.to),
 			}
 		}
 		imports = append(imports, imp)

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -2748,20 +2748,20 @@ func generatePubPerms(perms *Permissions) *perm {
 	if perms.Publish.Allow != nil {
 		p = &perm{}
 		p.allow = NewSublistWithCache()
-	}
-	for _, pubSubject := range perms.Publish.Allow {
-		sub := &subscription{subject: []byte(pubSubject)}
-		p.allow.Insert(sub)
+		for _, pubSubject := range perms.Publish.Allow {
+			sub := &subscription{subject: []byte(pubSubject)}
+			p.allow.Insert(sub)
+		}
 	}
 	if len(perms.Publish.Deny) > 0 {
 		if p == nil {
 			p = &perm{}
 		}
 		p.deny = NewSublistWithCache()
-	}
-	for _, pubSubject := range perms.Publish.Deny {
-		sub := &subscription{subject: []byte(pubSubject)}
-		p.deny.Insert(sub)
+		for _, pubSubject := range perms.Publish.Deny {
+			sub := &subscription{subject: []byte(pubSubject)}
+			p.deny.Insert(sub)
+		}
 	}
 	return p
 }

--- a/server/route.go
+++ b/server/route.go
@@ -1917,6 +1917,7 @@ func (c *client) processRouteConnect(srv *Server, arg []byte, lang string) error
 		return ErrWrongGateway
 	}
 	var perms *RoutePermissions
+	//TODO this check indicates srv may be nil. see srv usage below
 	if srv != nil {
 		perms = srv.getOpts().Cluster.Permissions
 	}
@@ -1939,7 +1940,7 @@ func (c *client) processRouteConnect(srv *Server, arg []byte, lang string) error
 			}
 		}
 		if shouldReject {
-			errTxt := fmt.Sprintf("Rejecting connection, cluster name %q does not match %q", proto.Cluster, srv.info.Cluster)
+			errTxt := fmt.Sprintf("Rejecting connection, cluster name %q does not match %q", proto.Cluster, clusterName)
 			c.Errorf(errTxt)
 			c.sendErr(errTxt)
 			c.closeConnection(ClusterNameConflict)

--- a/server/server.go
+++ b/server/server.go
@@ -765,6 +765,7 @@ func (s *Server) checkResolvePreloads() {
 		claims, err := jwt.DecodeAccountClaims(v)
 		if err != nil {
 			s.Errorf("Preloaded account [%s] not valid", k)
+			continue
 		}
 		// Check if it is expired.
 		vr := jwt.CreateValidationResults()
@@ -1954,13 +1955,13 @@ func (s *Server) StartProfiler() {
 	hp := net.JoinHostPort(opts.Host, strconv.Itoa(port))
 
 	l, err := net.Listen("tcp", hp)
-	s.Noticef("profiling port: %d", l.Addr().(*net.TCPAddr).Port)
 
 	if err != nil {
 		s.mu.Unlock()
 		s.Fatalf("error starting profiler: %s", err)
 		return
 	}
+	s.Noticef("profiling port: %d", l.Addr().(*net.TCPAddr).Port)
 
 	srv := &http.Server{
 		Addr:           hp,


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>
```
From top 
accounts.go: 
    se is never nil
    complained about differing receiver names (I only fixed a few of these. To keep the change smaller )
    unnecessary conversion
    unused constant
    acc will be nil
    p is always nil
    complaining about errors starting with lower case (There are more. I only changed one of these)
    receiver name again
    jwt overloaded the package. (there are more than this one, but only fixed a few to keep this change smaller)

auth.go
    regex was bad , is not part of the regex. {n} is only needed when n > 1

client.go
    return is always false
    srv is never nil (scroll up quite far)
    err is never nil  (scroll up quite far)

dirstore.go
    differing receiver name

jetstream_cluster.go
    || threw off the linter thought both conditions where possible
    err is not set after being checked (scroll up quite far) essentially only else branch will be taken
    
monitor.go
    switched to non deprecated value

mqtt.go
    for depends on the if, thus moved for into the if

route.go
    srv.info.Cluster == clusterName. the name only changes if shouldreject == false

server.go
    claims was nil when err != nil
    l == nil if err != nil
```