### PR TITLE
JetStream API Changes

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1707,14 +1707,6 @@ func (a *Account) serviceImportShadowed(from string) bool {
 	return false
 }
 
-// Internal check to see if a service import exists.
-func (a *Account) serviceImportExists(from string) bool {
-	a.mu.RLock()
-	dup := a.imports.services[from]
-	a.mu.RUnlock()
-	return dup != nil
-}
-
 // Add a service import.
 // This does no checks and should only be called by the msg processing code.
 // Use AddServiceImport from above if responding to user input or config changes, etc.

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1680,12 +1680,14 @@ func (o *consumer) processNextMsgReq(_ *subscription, c *client, _, reply string
 	if wr.noWait {
 		if o.maxp > 0 && len(o.pending) >= o.maxp {
 			sendErr(409, "Exceeded MaxAckPending")
+			return
 		}
 		o.mu.Unlock()
 		empty := mset.state().Msgs == 0
 		o.mu.Lock()
 		if empty {
 			sendErr(404, "No Messages")
+			return
 		}
 	}
 

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1257,8 +1257,8 @@ func TestAccountReqMonitoring(t *testing.T) {
 	// query SUBSZ for account
 	if resp, err := ncSys.Request(subsz, nil, time.Second); err != nil {
 		t.Fatalf("Error on request: %v", err)
-	} else if !strings.Contains(string(resp.Data), `"num_subscriptions":25,`) {
-		t.Fatalf("unexpected subs count (expected 0): %v", string(resp.Data))
+	} else if !strings.Contains(string(resp.Data), `"num_subscriptions":1,`) {
+		t.Fatalf("unexpected subs count (expected 1): %v", string(resp.Data))
 	}
 	// create a subscription
 	if sub, err := nc.Subscribe("foo", func(msg *nats.Msg) {}); err != nil {
@@ -1270,8 +1270,8 @@ func TestAccountReqMonitoring(t *testing.T) {
 	// query SUBSZ for account
 	if resp, err := ncSys.Request(subsz, nil, time.Second); err != nil {
 		t.Fatalf("Error on request: %v", err)
-	} else if !strings.Contains(string(resp.Data), `"num_subscriptions":26,`) {
-		t.Fatalf("unexpected subs count (expected 26): %v", string(resp.Data))
+	} else if !strings.Contains(string(resp.Data), `"num_subscriptions":2,`) {
+		t.Fatalf("unexpected subs count (expected 2): %v", string(resp.Data))
 	} else if !strings.Contains(string(resp.Data), `"subject":"foo"`) {
 		t.Fatalf("expected subscription foo: %v", string(resp.Data))
 	}

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -667,7 +667,9 @@ func (js *jetStream) apiDispatch(sub *subscription, c *client, subject, reply st
 	}
 
 	// If we are here we can properly dispatch this API call.
-	// Copy the message and the client. Client for the pubArgs.
+	// Copy the message and the client. Client for the pubArgs
+	// but note the JSAPI only uses the hdr index to piece apart
+	// the header from the msg body. No other references are needed.
 	// FIXME(dlc) - Should cleanup eventually and make sending
 	// and receiving internal messages more formal.
 	rmsg = append(rmsg[:0:0], rmsg...)

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -631,6 +631,11 @@ func (js *jetStream) apiDispatch(sub *subscription, c *client, subject, reply st
 	rr := js.apiSubs.Match(subject)
 	js.mu.RUnlock()
 
+	// Shortcircuit.
+	if len(rr.psubs)+len(rr.qsubs) == 0 {
+		return
+	}
+
 	// We should only have psubs and only 1 per result.
 	// FIXME(dlc) - Should we respond here with NoResponders or error?
 	if len(rr.psubs) != 1 {

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -2891,8 +2891,8 @@ func TestJetStreamClusterExtendedAccountInfo(t *testing.T) {
 	if ai.Streams != 3 || ai.Consumers != 3 {
 		t.Fatalf("AccountInfo not correct: %+v", ai)
 	}
-	if ai.API.Total < 10 {
-		t.Fatalf("Expected at least 10 total API calls, got %d", ai.API.Total)
+	if ai.API.Total < 9 {
+		t.Fatalf("Expected at least 9 total API calls, got %d", ai.API.Total)
 	}
 
 	// Now do a failure to make sure we track API errors.

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -2887,12 +2887,15 @@ func TestJetStreamClusterExtendedAccountInfo(t *testing.T) {
 		return info.JetStreamAccountStats
 	}
 
+	// Wait to accumulate.
+	time.Sleep(250 * time.Millisecond)
+
 	ai := getAccountInfo()
 	if ai.Streams != 3 || ai.Consumers != 3 {
 		t.Fatalf("AccountInfo not correct: %+v", ai)
 	}
-	if ai.API.Total < 9 {
-		t.Fatalf("Expected at least 9 total API calls, got %d", ai.API.Total)
+	if ai.API.Total < 8 {
+		t.Fatalf("Expected at least 8 total API calls, got %d", ai.API.Total)
 	}
 
 	// Now do a failure to make sure we track API errors.

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -4006,14 +4006,14 @@ func TestMonitorJsz(t *testing.T) {
 			if len(info.AccountDetails) != 0 {
 				t.Fatalf("expected no account to be returned by %s but got %v", url, info)
 			}
-			if info.StreamCnt == 0 {
-				t.Fatalf("expected stream count to be 2 but got %d", info.StreamCnt)
+			if info.Streams == 0 {
+				t.Fatalf("expected stream count to be 2 but got %d", info.Streams)
 			}
-			if info.ConsumerCnt == 0 {
-				t.Fatalf("expected consumer count to be 2 but got %d", info.ConsumerCnt)
+			if info.Consumers == 0 {
+				t.Fatalf("expected consumer count to be 2 but got %d", info.Consumers)
 			}
-			if info.MessageCnt != 1 {
-				t.Fatalf("expected one message but got %d", info.MessageCnt)
+			if info.Messages != 1 {
+				t.Fatalf("expected one message but got %d", info.Messages)
 			}
 		}
 	})

--- a/server/stream.go
+++ b/server/stream.go
@@ -2550,8 +2550,6 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 	}
 
 	sd := path.Join(jsa.storeDir, snapsDir)
-	defer os.RemoveAll(sd)
-
 	if _, err := os.Stat(sd); os.IsNotExist(err) {
 		if err := os.MkdirAll(sd, 0755); err != nil {
 			return nil, fmt.Errorf("could not create snapshots directory - %v", err)
@@ -2566,6 +2564,7 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 			return nil, fmt.Errorf("could not create snapshots directory - %v", err)
 		}
 	}
+	defer os.RemoveAll(sdir)
 
 	tr := tar.NewReader(s2.NewReader(r))
 	for {
@@ -2608,6 +2607,11 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 	}
 	// Move into the correct place here.
 	ndir := path.Join(jsa.storeDir, streamsDir, cfg.Name)
+	// Remove old one if for some reason is here.
+	if _, err := os.Stat(ndir); !os.IsNotExist(err) {
+		os.RemoveAll(ndir)
+	}
+	// Move into new location.
 	if err := os.Rename(sdir, ndir); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In clustered JetStream we need to move API calls out of routes/gateways/leafnodes path.

This moves from explicit imports and subscriptions to one wildcard subscription and a single wildcard export.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
