### PR TITLE
extend peer info and cluster info with node IDs

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4143,18 +4143,16 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 
 	if rg == nil || rg.node == nil {
 		return &ClusterInfo{
-			Name:     s.ClusterName(),
-			Leader:   s.Name(),
-			LeaderID: s.ID(),
+			Name:   s.ClusterName(),
+			Leader: &PeerInfo{Name: s.Name(), ID: s.ID(), Active: 0, Current: true},
 		}
 	}
 	n := rg.node
 
 	leader := n.GroupLeader()
 	ci := &ClusterInfo{
-		Name:     s.ClusterName(),
-		Leader:   s.serverNameForNode(leader),
-		LeaderID: s.serverIdForNode(leader),
+		Name:   s.ClusterName(),
+		Leader: &PeerInfo{Name: s.serverNameForNode(leader), ID: s.serverIdForNode(leader), Active: 0, Current: true},
 	}
 
 	now := time.Now()

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1535,7 +1535,7 @@ func (s *Server) replicas(node RaftNode) []*PeerInfo {
 	for _, rp := range node.Peers() {
 		if sir, ok := s.nodeToInfo.Load(rp.ID); ok && sir != nil {
 			si := sir.(*nodeInfo)
-			pi := &PeerInfo{Name: si.name, Current: rp.Current, Active: now.Sub(rp.Last), Offline: si.offline, Lag: rp.Lag}
+			pi := &PeerInfo{Name: si.name, ID: si.id, Current: rp.Current, Active: now.Sub(rp.Last), Offline: si.offline, Lag: rp.Lag}
 			replicas = append(replicas, pi)
 		}
 	}
@@ -4143,15 +4143,18 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 
 	if rg == nil || rg.node == nil {
 		return &ClusterInfo{
-			Name:   s.ClusterName(),
-			Leader: s.Name(),
+			Name:     s.ClusterName(),
+			Leader:   s.Name(),
+			LeaderID: s.ID(),
 		}
 	}
 	n := rg.node
 
+	leader := n.GroupLeader()
 	ci := &ClusterInfo{
-		Name:   s.ClusterName(),
-		Leader: s.serverNameForNode(n.GroupLeader()),
+		Name:     s.ClusterName(),
+		Leader:   s.serverNameForNode(leader),
+		LeaderID: s.serverIdForNode(leader),
 	}
 
 	now := time.Now()
@@ -4166,7 +4169,7 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 			}
 			if sir, ok := s.nodeToInfo.Load(rp.ID); ok && sir != nil {
 				si := sir.(*nodeInfo)
-				pi := &PeerInfo{Name: si.name, Current: current, Offline: si.offline, Active: lastSeen, Lag: rp.Lag}
+				pi := &PeerInfo{Name: si.name, ID: si.id, Current: current, Offline: si.offline, Active: lastSeen, Lag: rp.Lag}
 				ci.Replicas = append(ci.Replicas, pi)
 			}
 		}

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -4330,7 +4330,7 @@ func TestJetStreamCrossAccountMirrorsAndSources(t *testing.T) {
 		t.Fatalf("Did not receive correct response: %+v", scResp.Error)
 	}
 
-	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+	checkFor(t, 4*time.Second, 100*time.Millisecond, func() error {
 		si, err := js2.StreamInfo("MY_SOURCE_TEST")
 		if err != nil {
 			t.Fatalf("Could not retrieve stream info")

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2388,6 +2388,7 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 		}
 		return s.js.clusterInfo(group)
 	}
+
 	jsi := &JSInfo{
 		ID:  s.ID(),
 		Now: time.Now().UTC(),

--- a/server/raft.go
+++ b/server/raft.go
@@ -437,6 +437,15 @@ func (s *Server) startRaftNode(cfg *RaftConfig) (RaftNode, error) {
 	return n, nil
 }
 
+// Maps node names back to server ids.
+func (s *Server) serverIdForNode(node string) string {
+	if si, ok := s.nodeToInfo.Load(node); ok && si != nil {
+		return si.(*nodeInfo).id
+	}
+
+	return _EMPTY_
+}
+
 // Maps node names back to server names.
 func (s *Server) serverNameForNode(node string) string {
 	if si, ok := s.nodeToInfo.Load(node); ok && si != nil {

--- a/server/stream.go
+++ b/server/stream.go
@@ -87,8 +87,7 @@ type StreamInfo struct {
 // that make up the stream or consumer.
 type ClusterInfo struct {
 	Name     string      `json:"name,omitempty"`
-	Leader   string      `json:"leader,omitempty"`
-	LeaderID string      `json:"leader_id,omitempty"`
+	Leader   *PeerInfo   `json:"leader,omitempty"`
 	Replicas []*PeerInfo `json:"replicas,omitempty"`
 }
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -88,6 +88,7 @@ type StreamInfo struct {
 type ClusterInfo struct {
 	Name     string      `json:"name,omitempty"`
 	Leader   string      `json:"leader,omitempty"`
+	LeaderID string      `json:"leader_id,omitempty"`
 	Replicas []*PeerInfo `json:"replicas,omitempty"`
 }
 
@@ -95,6 +96,7 @@ type ClusterInfo struct {
 // are supporting the stream or consumer.
 type PeerInfo struct {
 	Name    string        `json:"name"`
+	ID      string        `json:"id"`
 	Current bool          `json:"current"`
 	Offline bool          `json:"offline,omitempty"`
 	Active  time.Duration `json:"active"`


### PR DESCRIPTION
In order to make meta peer removal safe we prefer to operate on IDs
rather than names, we would therefor need to be able to get the ID
of an offline node, with this change we report the IDs - even of
offline nodes - and so we can build the UI around IDs even for
nodes that are not around any more

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
