### PR TITLE
Consumer Updates.

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -866,6 +866,15 @@ func (s *Server) processRemoteServerShutdown(sid string) {
 		v.(*Account).removeRemoteServer(sid)
 		return true
 	})
+	// Update any state in nodeInfo.
+	s.nodeToInfo.Range(func(k, v interface{}) bool {
+		si := v.(*nodeInfo)
+		if si.id == sid {
+			si.offline = true
+			return false
+		}
+		return true
+	})
 }
 
 // remoteServerShutdownEvent is called when we get an event from another server shutting down.

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -662,7 +662,7 @@ func (js *jetStream) apiDispatch(sub *subscription, c *client, subject, reply st
 		} else {
 			s.Warnf(badAPIRequestT, rmsg)
 		}
-		s.Warnf("JetStream API Overloaded: %d calls outstanding", apiOut)
+		s.Warnf("JetStream API limit exceeded: %d calls outstanding", apiOut)
 		return
 	}
 
@@ -678,8 +678,8 @@ func (js *jetStream) apiDispatch(sub *subscription, c *client, subject, reply st
 
 	// Dispatch the API call to its own Go routine.
 	go func() {
-		defer atomic.AddInt64(&js.apiCalls, -1)
 		jsub.icb(sub, client, subject, reply, rmsg)
+		atomic.AddInt64(&js.apiCalls, -1)
 	}()
 }
 

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -4958,8 +4958,13 @@ func (c *cluster) waitOnClusterReady() {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
+
 	c.shutdown()
-	c.t.Fatalf("Expected a cluster leader and fully formed cluster")
+	if leader == nil {
+		c.t.Fatalf("Expected a cluster leader and fully formed cluster, no leader")
+	} else {
+		c.t.Fatalf("Expected a fully formed cluster, only %d of %d peers seen", len(leader.JetStreamClusterPeers()), len(c.servers))
+	}
 }
 
 // Helper function to check that a cluster is formed
@@ -5008,5 +5013,4 @@ func (c *cluster) restartAll() {
 		}
 	}
 	c.waitOnClusterReady()
-	c.waitOnLeader()
 }

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -2187,7 +2187,7 @@ func TestJetStreamClusterUserSnapshotAndRestore(t *testing.T) {
 		}
 	}
 	nc.Flush()
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	// Snapshot consumer info.
 	ci, err := jsub.ConsumerInfo()

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -2945,7 +2945,9 @@ func TestJetStreamClusterPeerRemovalAPI(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	req = &JSApiMetaServerRemoveRequest{Server: c.serverByName("S-2").ID()}
+	rs := c.randomNonLeader()
+
+	req = &JSApiMetaServerRemoveRequest{Server: rs.ID()}
 	jsreq, err = json.Marshal(req)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -2970,12 +2972,12 @@ func TestJetStreamClusterPeerRemovalAPI(t *testing.T) {
 	if err := json.Unmarshal(madv.Data, &adv); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if adv.Server != "S-2" {
-		t.Fatalf("Expected advisory about S-2 being removed, got %+v", adv)
+	if adv.Server != rs.Name() {
+		t.Fatalf("Expected advisory about %s being removed, got %+v", rs.Name(), adv)
 	}
 
 	for _, s := range ml.JetStreamClusterPeers() {
-		if s == "S-2" {
+		if s == rs.Name() {
 			t.Fatalf("Still in the peer list")
 		}
 	}

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -10490,7 +10490,7 @@ func TestJetStreamMirrorBasics(t *testing.T) {
 	// Now create our second mirror stream.
 	createStreamOk(cfg)
 
-	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
 		si, err := js2.StreamInfo("M2")
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -1397,7 +1397,7 @@ func TestJetStreamClusterLargeStreamInlineCatchup(t *testing.T) {
 }
 
 func TestJetStreamClusterStreamCreateAndLostQuorum(t *testing.T) {
-	c := createJetStreamClusterExplicit(t, "R5S", 5)
+	c := createJetStreamClusterExplicit(t, "R5S", 3)
 	defer c.shutdown()
 
 	// Client based API
@@ -1410,7 +1410,7 @@ func TestJetStreamClusterStreamCreateAndLostQuorum(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	if _, err := js.AddStream(&nats.StreamConfig{Name: "NO-LQ-START", Replicas: 5}); err != nil {
+	if _, err := js.AddStream(&nats.StreamConfig{Name: "NO-LQ-START", Replicas: 3}); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	c.waitOnStreamLeader("$G", "NO-LQ-START")
@@ -1432,8 +1432,8 @@ func TestJetStreamClusterStreamCreateAndLostQuorum(t *testing.T) {
 	nc.Flush()
 
 	c.restartAll()
-
 	c.waitOnStreamLeader("$G", "NO-LQ-START")
+
 	checkSubsPending(t, sub, 0)
 }
 


### PR DESCRIPTION
Make sure to not process next message (batch) requests inline if non client connection.
Added an index to the redeliver queue for large rdq scenarios.
Cleanup service exports and imports for JetStream.

/cc @nats-io/core
