### PR TITLE
Prevent pull batch larger than max ack pending

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1637,6 +1637,11 @@ func (o *consumer) processNextMsgReq(_ *subscription, c *client, _, reply string
 		return
 	}
 
+	if o.maxp > 0 && batchSize > o.maxp {
+		sendErr(409, "Exceeded MaxAckPending")
+		return
+	}
+
 	// In case we have to queue up this request.
 	wr := waitingRequest{client: c, reply: reply, n: batchSize, noWait: noWait, expires: expires}
 


### PR DESCRIPTION
Noticed that when making a batch request, it was possible to ask for a batch larger than ack pending so resulting in redeliveries as part of the batch.

Signed-off-by: Waldemar Quevedo <wally@synadia.com>
