### PR TITLE
[Fixed] missing export jsAllApi on system account update

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2927,6 +2927,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 				s.Errorf("Error setting up jetstream service exports: %v", err)
 			}
 		}
+		s.checkJetStreamExports()
 	}
 
 	for _, e := range ac.Exports {


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

Yesterday this unit test used to pass for me locally. So this is smth new.
 
`jsAllApi` is not included in `allJsExports`.
On update we would then loose the `jsAllApi` subscription.
Because of this enableAllJetStreamServiceImports would fail (export not found) when adding the import for `jsAllApi` of the system account.

Additionally, the export `jsAllApi` overlaps with the other exports (in pairs below). (Overlapping exports are smth. we prohibit in jwt)  

The solution could also be adding `jsAllApi` to `allJsExports`. 
I was not sure what's best, so I picked calling `checkJetStreamExports `
Opinions?

```
// For easier handling of exports and imports.
var allJsExports = []string{
	JSApiAccountInfo,
	JSApiTemplateCreate,
	JSApiTemplates,
	JSApiTemplateInfo,
	JSApiTemplateDelete,
	JSApiStreamCreate,
	JSApiStreamUpdate,
	JSApiStreams,
	JSApiStreamList,
	JSApiStreamInfo,
	JSApiStreamDelete,
	JSApiStreamPurge,
	JSApiStreamSnapshot,
	JSApiStreamRestore,
	JSApiStreamRemovePeer,
	JSApiStreamLeaderStepDown,
	JSApiConsumerLeaderStepDown,
	JSApiMsgDelete,
	JSApiMsgGet,
	JSApiConsumerCreate,
	JSApiDurableCreate,
	JSApiConsumers,
	JSApiConsumerList,
	JSApiConsumerInfo,
	JSApiConsumerDelete,
}
```

```
// enableAllJetStreamServiceImports turns on all service imports for jetstream for this account.
func (a *Account) enableAllJetStreamServiceImports() error {
	a.mu.RLock()
	s := a.srv
	a.mu.RUnlock()

	if s == nil {
		return fmt.Errorf("jetstream account not registered")
	}

	if !a.serviceImportExists(jsAllApi) {
		if err := a.AddServiceImport(s.SystemAccount(), jsAllApi, _EMPTY_); err != nil {
			return fmt.Errorf("Error setting up jetstream service imports for account: %v", err)
		}
	}

	return nil
}
```