### PR TITLE
Switch Gateway JS accounts to interest-only mode + some other fixes

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1072,7 +1072,26 @@ func (c *client) processGatewayInfo(info *Info) {
 		// connect events to switch those accounts into interest only mode.
 		s.mu.Lock()
 		s.ensureGWsInterestOnlyForLeafNodes()
+		js := s.js
 		s.mu.Unlock()
+
+		// Switch JetStream accounts to interest-only mode.
+		if js != nil {
+			var accounts []*Account
+			js.mu.Lock()
+			if len(js.accounts) > 0 {
+				accounts = make([]*Account, 0, len(js.accounts))
+				for acc := range js.accounts {
+					accounts = append(accounts, acc)
+				}
+			}
+			js.mu.Unlock()
+			for _, acc := range accounts {
+				if acc.JetStreamEnabled() {
+					s.switchAccountToInterestMode(acc.GetName())
+				}
+			}
+		}
 	}
 }
 

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -374,8 +374,13 @@ func (s *Server) configJetStream(acc *Account) error {
 			if err := acc.UpdateJetStreamLimits(acc.jsLimits); err != nil {
 				return err
 			}
-		} else if err := acc.EnableJetStream(acc.jsLimits); err != nil {
-			return err
+		} else {
+			if err := acc.EnableJetStream(acc.jsLimits); err != nil {
+				return err
+			}
+			if s.gateway.enabled {
+				s.switchAccountToInterestMode(acc.GetName())
+			}
 		}
 		acc.jsLimits = nil
 	} else if acc != s.SystemAccount() {

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -1324,7 +1324,7 @@ func TestNoRaceJetStreamWorkQueueLoadBalance(t *testing.T) {
 	}
 }
 
-func TestJetStreamClusterLargeStreamInlineCatchup(t *testing.T) {
+func TestNoRaceJetStreamClusterLargeStreamInlineCatchup(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "LSS", 3)
 	defer c.shutdown()
 
@@ -1396,7 +1396,7 @@ func TestJetStreamClusterLargeStreamInlineCatchup(t *testing.T) {
 	})
 }
 
-func TestJetStreamClusterStreamCreateAndLostQuorum(t *testing.T) {
+func TestNoRaceJetStreamClusterStreamCreateAndLostQuorum(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R5S", 3)
 	defer c.shutdown()
 
@@ -1437,7 +1437,7 @@ func TestJetStreamClusterStreamCreateAndLostQuorum(t *testing.T) {
 	checkSubsPending(t, sub, 0)
 }
 
-func TestJetStreamClusterMirrors(t *testing.T) {
+func TestNoRaceJetStreamClusterSuperClusterMirrors(t *testing.T) {
 	sc := createJetStreamSuperCluster(t, 3, 3)
 	defer sc.shutdown()
 
@@ -1571,7 +1571,7 @@ func TestJetStreamClusterMirrors(t *testing.T) {
 	})
 }
 
-func TestJetStreamClusterSources(t *testing.T) {
+func TestNoRaceJetStreamClusterSuperClusterSources(t *testing.T) {
 	sc := createJetStreamSuperCluster(t, 3, 3)
 	defer sc.shutdown()
 


### PR DESCRIPTION
- Fixed the close of a TLS connection which starting Go 1.16
set the deadline to 5 seconds.

- Fixed an issue with setHeader that was causing these error messages
```
=== RUN   TestServiceImportReplyMatchCycleMultiHops
nats: message could not decode headers on connection [4] for subscription on "foo"
--- PASS: TestServiceImportReplyMatchCycleMultiHops (0.04s)
```

- Fixed names of tests in norace_test.go since they must start with
TestNoRace in order to make sure that we execute them in Travis:
```
go test -v -run=TestNoRace --failfast -p=1 ./...
```

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
