### PR TITLE
Raft changes and inbound stream msgs out of fastpath for non-clients.

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -271,6 +271,8 @@ type client struct {
 	trace bool
 	echo  bool
 
+	internal bool
+
 	tags    jwt.TagList
 	nameTag string
 }
@@ -562,6 +564,7 @@ func (c *client) initClient() {
 
 	c.subs = make(map[string]*subscription)
 	c.echo = true
+	c.internal = true
 
 	c.setTraceLevel()
 
@@ -3026,7 +3029,7 @@ func (c *client) deliverMsg(sub *subscription, subject, reply, mh, msg []byte, g
 	client.outBytes += msgSize
 
 	// Check for internal subscriptions.
-	if sub.icb != nil {
+	if sub.icb != nil && c.internal {
 		if gwrply {
 			// Note that we keep track of the GW routed reply in the destination
 			// connection (`client`). The routed reply subject is in `c.pa.reply`,

--- a/server/client.go
+++ b/server/client.go
@@ -270,8 +270,7 @@ type client struct {
 
 	trace bool
 	echo  bool
-
-	internal bool
+	noIcb bool
 
 	tags    jwt.TagList
 	nameTag string
@@ -564,7 +563,6 @@ func (c *client) initClient() {
 
 	c.subs = make(map[string]*subscription)
 	c.echo = true
-	c.internal = true
 
 	c.setTraceLevel()
 
@@ -3029,7 +3027,7 @@ func (c *client) deliverMsg(sub *subscription, subject, reply, mh, msg []byte, g
 	client.outBytes += msgSize
 
 	// Check for internal subscriptions.
-	if sub.icb != nil && c.internal {
+	if sub.icb != nil && !c.noIcb {
 		if gwrply {
 			// Note that we keep track of the GW routed reply in the destination
 			// connection (`client`). The routed reply subject is in `c.pa.reply`,

--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.2.0-RC.4"
+	VERSION = "2.2.0-RC.5"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1964,7 +1964,7 @@ func (o *consumer) deliverMsg(dsubj, subj string, hdr, msg []byte, seq, dc uint6
 
 	// If we are ack none and mset is interest only we should make sure stream removes interest.
 	if ap == AckNone && mset.cfg.Retention == InterestPolicy && !mset.checkInterest(seq, o) {
-		mset.store.RemoveMsg(seq)
+		mset.rmch <- seq
 	}
 
 	if ap == AckExplicit || ap == AckAll {
@@ -2460,6 +2460,7 @@ func (o *consumer) stopWithFlags(dflag, doSignal, advisory bool) error {
 			seqs = append(seqs, seq)
 		}
 		o.mu.Unlock()
+
 		// Sort just to keep pending sparse array state small.
 		sort.Slice(seqs, func(i, j int) bool { return seqs[i] < seqs[j] })
 		for _, seq := range seqs {

--- a/server/events.go
+++ b/server/events.go
@@ -91,6 +91,7 @@ type internal struct {
 	sendq    chan *pubMsg
 	resetCh  chan struct{}
 	wg       sync.WaitGroup
+	sq       *sendq
 	orphMax  time.Duration
 	chkOrph  time.Duration
 	statsz   time.Duration

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2789,7 +2789,7 @@ func (s *Server) streamSnapshot(ci *ClientInfo, acc *Account, mset *stream, sr *
 		chunk = chunk[:n]
 		if err != nil {
 			if n > 0 {
-				mset.sendq <- &jsPubMsg{reply, _EMPTY_, _EMPTY_, nil, chunk, nil, 0}
+				mset.outq.send(&jsPubMsg{reply, _EMPTY_, _EMPTY_, nil, chunk, nil, 0, nil})
 			}
 			break
 		}
@@ -2804,15 +2804,14 @@ func (s *Server) streamSnapshot(ci *ClientInfo, acc *Account, mset *stream, sr *
 			case <-time.After(10 * time.Millisecond):
 			}
 		}
-		// TODO(dlc) - Might want these moved off sendq if we have contention.
 		ackReply := fmt.Sprintf("%s.%d.%d", ackSubj, len(chunk), index)
-		mset.sendq <- &jsPubMsg{reply, _EMPTY_, ackReply, nil, chunk, nil, 0}
+		mset.outq.send(&jsPubMsg{reply, _EMPTY_, ackReply, nil, chunk, nil, 0, nil})
 		atomic.AddInt32(&out, int32(len(chunk)))
 	}
 done:
 	// Send last EOF
 	// TODO(dlc) - place hash in header
-	mset.sendq <- &jsPubMsg{reply, _EMPTY_, _EMPTY_, nil, nil, nil, 0}
+	mset.outq.send(&jsPubMsg{reply, _EMPTY_, _EMPTY_, nil, nil, nil, 0, nil})
 }
 
 // Request to create a durable consumer.

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1651,7 +1651,11 @@ func (s *Server) jsStreamLeaderStepDownRequest(sub *subscription, c *client, sub
 	}
 
 	// Call actual stepdown.
-	mset.raftNode().StepDown()
+	if mset != nil {
+		if node := mset.raftNode(); node != nil {
+			node.StepDown()
+		}
+	}
 
 	resp.Success = true
 	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -3118,7 +3118,7 @@ func TestJetStreamClusterNoQuorumStepdown(t *testing.T) {
 	c.randomNonStreamLeader("$G", "NO-Q").Shutdown()
 
 	// This should eventually have us stepdown as leader since we would have lost quorum with R=2.
-	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+	checkFor(t, 5*time.Second, 500*time.Millisecond, func() error {
 		if sl := c.streamLeader("$G", "NO-Q"); sl == nil {
 			return nil
 		}

--- a/server/sendq.go
+++ b/server/sendq.go
@@ -1,0 +1,134 @@
+// Copyright 2020-2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"strconv"
+	"sync"
+	"time"
+)
+
+type outMsg struct {
+	subj string
+	rply string
+	hdr  []byte
+	msg  []byte
+	next *outMsg
+}
+
+type sendq struct {
+	mu    sync.Mutex
+	mch   chan struct{}
+	head  *outMsg
+	tail  *outMsg
+	s     *Server
+	msgs  int
+	bytes int
+}
+
+func (s *Server) newSendQ() *sendq {
+	sq := &sendq{s: s, mch: make(chan struct{}, 1)}
+	s.startGoRoutine(sq.internalLoop)
+	return sq
+}
+
+func (sq *sendq) internalLoop() {
+	sq.mu.Lock()
+	s, mch := sq.s, sq.mch
+	sq.mu.Unlock()
+
+	defer s.grWG.Done()
+
+	c := s.createInternalSystemClient()
+	c.registerWithAccount(s.SystemAccount())
+	c.internal = false
+
+	defer c.closeConnection(ClientClosed)
+
+	for s.isRunning() {
+		select {
+		case <-s.quitCh:
+			return
+		case <-mch:
+			for pm := sq.pending(); pm != nil; {
+				c.pa.subject = []byte(pm.subj)
+				c.pa.size = len(pm.msg) + len(pm.hdr)
+				c.pa.szb = []byte(strconv.Itoa(c.pa.size))
+				c.pa.reply = []byte(pm.rply)
+				var msg []byte
+				if len(pm.hdr) > 0 {
+					c.pa.hdr = len(pm.hdr)
+					c.pa.hdb = []byte(strconv.Itoa(c.pa.hdr))
+					msg = append(pm.hdr, pm.msg...)
+					msg = append(msg, _CRLF_...)
+				} else {
+					c.pa.hdr = -1
+					c.pa.hdb = nil
+					msg = append(pm.msg, _CRLF_...)
+				}
+				c.processInboundClientMsg(msg)
+				c.pa.szb = nil
+				// Do this here to nil out below vs up in for loop.
+				next := pm.next
+				pm.next, pm.hdr, pm.msg = nil, nil, nil
+				if pm = next; pm == nil {
+					pm = sq.pending()
+				}
+			}
+			c.flushClients(10 * time.Millisecond)
+		}
+	}
+}
+
+func (sq *sendq) pending() *outMsg {
+	sq.mu.Lock()
+	head := sq.head
+	sq.head, sq.tail = nil, nil
+	sq.msgs, sq.bytes = 0, 0
+	sq.mu.Unlock()
+	return head
+}
+
+func (sq *sendq) send(subj, rply string, hdr, msg []byte) (int, int) {
+	out := &outMsg{subj, rply, nil, nil, nil}
+	// We will copy these for now.
+	if len(hdr) > 0 {
+		hdr = append(hdr[:0:0], hdr...)
+		out.hdr = hdr
+	}
+	if len(msg) > 0 {
+		msg = append(msg[:0:0], msg...)
+		out.msg = msg
+	}
+	sq.mu.Lock()
+
+	sq.msgs++
+	sq.bytes += len(subj) + len(rply) + len(hdr) + len(msg)
+
+	if sq.head == nil {
+		sq.head = out
+	} else {
+		sq.tail.next = out
+	}
+	sq.tail = out
+	msgs, bytes := sq.msgs, sq.bytes
+	sq.mu.Unlock()
+
+	select {
+	case sq.mch <- struct{}{}:
+	default:
+	}
+
+	return msgs, bytes
+}

--- a/server/sendq.go
+++ b/server/sendq.go
@@ -108,19 +108,19 @@ func (sq *sendq) send(subj, rply string, hdr, msg []byte) {
 		msg = append(msg[:0:0], msg...)
 		out.msg = msg
 	}
-	sq.mu.Lock()
 
-	var doKick bool
+	sq.mu.Lock()
+	var notify bool
 	if sq.head == nil {
 		sq.head = out
-		doKick = true
+		notify = true
 	} else {
 		sq.tail.next = out
 	}
 	sq.tail = out
 	sq.mu.Unlock()
 
-	if doKick {
+	if notify {
 		select {
 		case sq.mch <- struct{}{}:
 		default:

--- a/server/server.go
+++ b/server/server.go
@@ -1120,6 +1120,7 @@ func (s *Server) setSystemAccount(acc *Account) error {
 		replies: make(map[string]msgHandler),
 		sendq:   make(chan *pubMsg, internalSendQLen),
 		resetCh: make(chan struct{}),
+		sq:      s.newSendQ(),
 		statsz:  eventsHBInterval,
 		orphMax: 5 * eventsHBInterval,
 		chkOrph: 3 * eventsHBInterval,


### PR DESCRIPTION
Move raft comms off of internal sendq. Move our stream msg processing out of Go routines servicing routes and gateways.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
