### PR TITLE
Push consumer idle heartbeats

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1958,7 +1958,7 @@ func (o *consumer) loopAndGatherMsgs(qch chan struct{}) {
 		case <-mch:
 			// Messages are waiting.
 		case <-hbc:
-			hdr := []byte("NATS/1.0 200 Idle Heartbeat\r\n\r\n")
+			hdr := []byte("NATS/1.0 100 Idle Heartbeat\r\n\r\n")
 			outq.send(&jsPubMsg{odsubj, odsubj, _EMPTY_, hdr, nil, nil, 0, nil})
 		}
 	}

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -7098,8 +7098,8 @@ func TestJetStreamPushConsumerIdleHeartbeats(t *testing.T) {
 		return nil
 	})
 	m, _ := sub.NextMsg(0)
-	if m.Header.Get("Status") != "200" {
-		t.Fatalf("Expected a 200 status code, got %q", m.Header.Get("Status"))
+	if m.Header.Get("Status") != "100" {
+		t.Fatalf("Expected a 100 status code, got %q", m.Header.Get("Status"))
 	}
 	if m.Header.Get("Description") != "Idle Heartbeat" {
 		t.Fatalf("Wrong description , got %q", m.Header.Get("Description"))
@@ -10558,6 +10558,9 @@ func TestJetStreamMirrorBasics(t *testing.T) {
 	createStreamOk(scfg)
 	// Now create our mirror stream.
 	createStreamOk(cfg)
+
+	// For now wait for the consumer state to register.
+	time.Sleep(250 * time.Millisecond)
 
 	// Send 100 messages.
 	for i := 0; i < 100; i++ {

--- a/server/raft.go
+++ b/server/raft.go
@@ -1254,8 +1254,11 @@ func (n *raft) resetElect(et time.Duration) {
 	if n.elect == nil {
 		n.elect = time.NewTimer(et)
 	} else {
-		if !n.elect.Stop() && len(n.elect.C) > 0 {
-			<-n.elect.C
+		if !n.elect.Stop() {
+			select {
+			case <-n.elect.C:
+			default:
+			}
 		}
 		n.elect.Reset(et)
 	}


### PR DESCRIPTION
Allow an option to push based consumers to have idle heartbeats delivered.
This allows an endpoint to know the consumer is still alive.
    
Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
