### PR TITLE
Enable opt-in flow control for push based consumers.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -579,6 +579,7 @@ func (mb *msgBlock) rebuildState() (*LostStreamData, error) {
 					truncate(index)
 					return gatherLost(lbuf - index), errBadMsg
 				}
+				copy(mb.lchk[0:], checksum)
 			}
 
 			if mb.first.seq == 0 {

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -180,6 +180,11 @@ const (
 	jsAckT   = "$JS.ACK.%s.%s"
 	jsAckPre = "$JS.ACK."
 
+	// jsFlowControlT is the template for flow control messages.
+	jsFlowControlT = "$JS.FC.%s.%s.%d"
+	// jsFlowControl is for FC responses.
+	jsFlowControl = "$JS.FC.*.*.*"
+
 	// JSAdvisoryPrefix is a prefix for all JetStream advisories.
 	JSAdvisoryPrefix = "$JS.EVENT.ADVISORY"
 

--- a/server/signal.go
+++ b/server/signal.go
@@ -40,7 +40,7 @@ func (s *Server) handleSignals() {
 	}
 	c := make(chan os.Signal, 1)
 
-	signal.Notify(c, syscall.SIGINT, syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGHUP)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGHUP)
 
 	go func() {
 		for {
@@ -48,7 +48,7 @@ func (s *Server) handleSignals() {
 			case sig := <-c:
 				s.Debugf("Trapped %q signal", sig)
 				switch sig {
-				case syscall.SIGINT:
+				case syscall.SIGINT, syscall.SIGTERM:
 					s.Shutdown()
 					os.Exit(0)
 				case syscall.SIGUSR1:

--- a/server/stream.go
+++ b/server/stream.go
@@ -2268,6 +2268,13 @@ type jsPubMsg struct {
 	next  *jsPubMsg
 }
 
+func (pm *jsPubMsg) size() int {
+	if pm == nil {
+		return 0
+	}
+	return len(pm.subj) + len(pm.reply) + len(pm.hdr) + len(pm.msg)
+}
+
 // Forms a linked list for sending internal system messages.
 type jsOutQ struct {
 	mu   sync.Mutex


### PR DESCRIPTION
Enable slow start flow control for push based consumers using flow control messages.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
