### PR TITLE
Replace listers with receive only channels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,3 +13,5 @@ require (
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1
 )
+
+replace github.com/nats-io/nats.go => ../nats.go

--- a/vendor/github.com/nats-io/nats.go/js.go
+++ b/vendor/github.com/nats-io/nats.go/js.go
@@ -52,6 +52,9 @@ const (
 	// apiConsumerListT is used to return all detailed consumer information
 	apiConsumerListT = "CONSUMER.LIST.%s"
 
+	// apiConsumerNamesT is used to return a list with all consumer names for the stream.
+	apiConsumerNamesT = "CONSUMER.NAMES.%s"
+
 	// apiStreams can lookup a stream by subject.
 	apiStreams = "STREAM.NAMES"
 
@@ -332,13 +335,21 @@ func ExpectLastMsgId(id string) PubOpt {
 // MaxWait sets the maximum amount of time we will wait for a response.
 type MaxWait time.Duration
 
-func (ttl MaxWait) configurePublish(opts *pubOpts) error {
+func (ttl MaxWait) configureJSContext(js *js) error {
+	js.wait = time.Duration(ttl)
+	return nil
+}
+
+// AckWait sets the maximum amount of time we will wait for an ack.
+type AckWait time.Duration
+
+func (ttl AckWait) configurePublish(opts *pubOpts) error {
 	opts.ttl = time.Duration(ttl)
 	return nil
 }
 
-func (ttl MaxWait) configureJSContext(js *js) error {
-	js.wait = time.Duration(ttl)
+func (ttl AckWait) configureSubscribe(opts *subOpts) error {
+	opts.cfg.AckWait = time.Duration(ttl)
 	return nil
 }
 
@@ -485,6 +496,11 @@ func (js *js) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg, opts []
 	isPullMode := o.pull > 0
 	if cb != nil && isPullMode {
 		return nil, ErrPullModeNotAllowed
+	}
+
+	badPullAck := o.cfg.AckPolicy == AckNonePolicy || o.cfg.AckPolicy == AckAllPolicy
+	if isPullMode && badPullAck {
+		return nil, fmt.Errorf("invalid ack mode for pull consumers: %s", o.cfg.AckPolicy)
 	}
 
 	var (
@@ -686,18 +702,6 @@ type subOpts struct {
 	cfg *ConsumerConfig
 }
 
-// Durable defines the consumer name for JetStream durable subscribers.
-func Durable(name string) SubOpt {
-	return subOptFn(func(opts *subOpts) error {
-		if strings.Contains(name, ".") {
-			return ErrInvalidDurableName
-		}
-
-		opts.cfg.Durable = name
-		return nil
-	})
-}
-
 // Pull defines the batch size of messages that will be received
 // when using pull based JetStream consumers.
 func Pull(batchSize int) SubOpt {
@@ -726,6 +730,18 @@ func PullDirect(stream, consumer string, batchSize int) SubOpt {
 func ManualAck() SubOpt {
 	return subOptFn(func(opts *subOpts) error {
 		opts.mack = true
+		return nil
+	})
+}
+
+// Durable defines the consumer name for JetStream durable subscribers.
+func Durable(name string) SubOpt {
+	return subOptFn(func(opts *subOpts) error {
+		if strings.Contains(name, ".") {
+			return ErrInvalidDurableName
+		}
+
+		opts.cfg.Durable = name
 		return nil
 	})
 }
@@ -794,6 +810,20 @@ func AckAll() SubOpt {
 func AckExplicit() SubOpt {
 	return subOptFn(func(opts *subOpts) error {
 		opts.cfg.AckPolicy = AckExplicitPolicy
+		return nil
+	})
+}
+
+func MaxDeliver(n int) SubOpt {
+	return subOptFn(func(opts *subOpts) error {
+		opts.cfg.MaxDeliver = n
+		return nil
+	})
+}
+
+func MaxAckPending(n int) SubOpt {
+	return subOptFn(func(opts *subOpts) error {
+		opts.cfg.MaxAckPending = n
 		return nil
 	})
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,7 +7,7 @@ github.com/minio/highwayhash
 # github.com/nats-io/jwt/v2 v2.0.0-20210208203759-ff814ca5f813
 ## explicit
 github.com/nats-io/jwt/v2
-# github.com/nats-io/nats.go v1.10.1-0.20210228004050-ed743748acac
+# github.com/nats-io/nats.go v1.10.1-0.20210228004050-ed743748acac => ../nats.go
 ## explicit
 github.com/nats-io/nats.go
 github.com/nats-io/nats.go/encoders/builtin
@@ -37,3 +37,4 @@ golang.org/x/sys/windows/svc/mgr
 # golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1
 ## explicit
 golang.org/x/time/rate
+# github.com/nats-io/nats.go => ../nats.go


### PR DESCRIPTION
This uses the following two APIs from JSM instead of the listers, which have been removed.

```
type JetStreamManager interface {
	// StreamsInfo can be used to retrieve a list of StreamInfo objects.
	StreamsInfo(ctx context.Context) <-chan *StreamInfo

	// ConsumersInfo is used to retrieve a list of ConsumerInfo objects.
	ConsumersInfo(ctx context.Context, stream string) <-chan *ConsumerInfo
}
```

Waiting on https://github.com/nats-io/nats.go/pull/659 to be merged first. Then I can update this branch.