### PR TITLE
Fix races in TestJetStreamPushConsumerFlowControl

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2022,6 +2022,7 @@ func (o *consumer) deliverMsg(dsubj, subj string, hdr, msg []byte, seq, dc uint6
 	o.dseq++
 
 	pmsg := &jsPubMsg{dsubj, subj, o.ackReply(seq, dseq, dc, ts, o.sgap), hdr, msg, o, seq, nil}
+	pmsgSize := pmsg.size()
 	mset := o.mset
 	ap := o.cfg.AckPolicy
 
@@ -2042,7 +2043,7 @@ func (o *consumer) deliverMsg(dsubj, subj string, hdr, msg []byte, seq, dc uint6
 
 	// Flow control.
 	if o.maxpb > 0 {
-		o.pbytes += pmsg.size()
+		o.pbytes += pmsgSize
 		if o.needFlowControl() {
 			o.sendFlowControl()
 		}

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -7084,7 +7084,9 @@ func TestJetStreamPushConsumerFlowControl(t *testing.T) {
 	} else if obs := mset.lookupConsumer("dlc"); obs == nil {
 		t.Fatalf("Error looking up stream: %v", err)
 	} else {
+		obs.mu.Lock()
 		obs.setMaxPendingBytes(16 * 1024)
+		obs.mu.Unlock()
 	}
 
 	msgSize := 1024


### PR DESCRIPTION
This test has been flaking on CI and also locally.

```
$ go test -count=1 -race -run TestJetStreamPushConsumerFlowControl

==================
WARNING: DATA RACE
Write at 0x00c000022400 by goroutine 8:
  github.com/nats-io/nats-server/v2/server.(*consumer).setMaxPendingBytes()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:2004 +0x11
39
  github.com/nats-io/nats-server/v2/server.TestJetStreamPushConsumerFlowControl()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_test.go:7087
 +0x10fe
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1123 +0x202

Previous read at 0x00c000022400 by goroutine 37:
  github.com/nats-io/nats-server/v2/server.(*consumer).loopAndGatherMsgs()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:1894 +0x14
f6

Goroutine 8 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1168 +0x5bb
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1439 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1123 +0x202
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1437 +0x612
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1345 +0x3b3
  github.com/nats-io/nats-server/v2/server.TestMain()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/sublist_test.go:1448 +
0x384
  main.main()
      _testmain.go:2447 +0x271

Goroutine 37 (running) created at:
  github.com/nats-io/nats-server/v2/server.(*consumer).setLeader()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:709 +0x596
  github.com/nats-io/nats-server/v2/server.(*stream).addConsumerWithAssignment()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:589 +0x1f8
5
  github.com/nats-io/nats-server/v2/server.(*stream).addConsumer()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:240 +0x108
9
  github.com/nats-io/nats-server/v2/server.(*Server).jsConsumerCreate()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:2929
+0x1063
  github.com/nats-io/nats-server/v2/server.(*Server).jsDurableCreateRequest()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:2824
+0xb9
  github.com/nats-io/nats-server/v2/server.(*Server).jsDurableCreateRequest-fm()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:2823
+0x26
  github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:654 +
0xbcb
  github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch-fm()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:633 +
0xb1
  github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3044 +0x507
  github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:4015 +0x7ca
  github.com/nats-io/nats-server/v2/server.(*client).processServiceImport()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3836 +0x1115
  github.com/nats-io/nats-server/v2/server.(*Account).addServiceImportSub.func1()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/accounts.go:1840 +0x78
  github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3042 +0x62c
  github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:4015 +0x7ca
  github.com/nats-io/nats-server/v2/server.(*client).processInboundClientMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3479 +0xdee
  github.com/nats-io/nats-server/v2/server.(*client).processInboundMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3343 +0xbe
  github.com/nats-io/nats-server/v2/server.(*client).parse()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/parser.go:476 +0x412f
  github.com/nats-io/nats-server/v2/server.(*client).readLoop()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:1115 +0x86f
  github.com/nats-io/nats-server/v2/server.(*Server).createClient.func1()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/server.go:2346 +0x5c
==================
==================
WARNING: DATA RACE
Write at 0x00c00021a4b0 by goroutine 35:
  github.com/nats-io/nats-server/v2/server.(*stream).internalLoop()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/stream.go:2388 +0x1026

Previous read at 0x00c00021a4b0 by goroutine 37:
  github.com/nats-io/nats-server/v2/server.(*jsPubMsg).size()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/stream.go:2275 +0x936
  github.com/nats-io/nats-server/v2/server.(*consumer).deliverMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:2045 +0x5a
e
  github.com/nats-io/nats-server/v2/server.(*consumer).loopAndGatherMsgs()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:1955 +0xc2
e

Goroutine 35 (running) created at:
  github.com/nats-io/nats-server/v2/server.(*stream).setupSendCapabilities()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/stream.go:2332 +0x1aa
  github.com/nats-io/nats-server/v2/server.(*Account).addStreamWithAssignment()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/stream.go:351 +0xf0f
  github.com/nats-io/nats-server/v2/server.(*Account).addStream()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/stream.go:210 +0x770
  github.com/nats-io/nats-server/v2/server.(*Server).jsStreamCreateRequest()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:1194
+0x74a
  github.com/nats-io/nats-server/v2/server.(*Server).jsStreamCreateRequest-fm()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:1098
+0xb1
  github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:654 +
0xbcb
  github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch-fm()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:633 +
0xb1
  github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3044 +0x507
  github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:4015 +0x7ca
  github.com/nats-io/nats-server/v2/server.(*client).processServiceImport()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3836 +0x1115
  github.com/nats-io/nats-server/v2/server.(*Account).addServiceImportSub.func1()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/accounts.go:1840 +0x78
  github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3042 +0x62c
  github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:4015 +0x7ca
  github.com/nats-io/nats-server/v2/server.(*client).processInboundClientMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3479 +0xdee
  github.com/nats-io/nats-server/v2/server.(*client).processInboundMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3343 +0xbe
  github.com/nats-io/nats-server/v2/server.(*client).parse()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/parser.go:476 +0x412f
  github.com/nats-io/nats-server/v2/server.(*client).readLoop()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:1115 +0x86f
  github.com/nats-io/nats-server/v2/server.(*Server).createClient.func1()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/server.go:2346 +0x5c

Goroutine 37 (running) created at:
  github.com/nats-io/nats-server/v2/server.(*consumer).setLeader()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:709 +0x596
  github.com/nats-io/nats-server/v2/server.(*stream).addConsumerWithAssignment()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:589 +0x1f8
5
  github.com/nats-io/nats-server/v2/server.(*stream).addConsumer()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:240 +0x108
9
  github.com/nats-io/nats-server/v2/server.(*Server).jsConsumerCreate()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:2929
+0x1063
  github.com/nats-io/nats-server/v2/server.(*Server).jsDurableCreateRequest()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:2824
+0xb9
  github.com/nats-io/nats-server/v2/server.(*Server).jsDurableCreateRequest-fm()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:2823
+0x26
  github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:654 +
0xbcb
  github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch-fm()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:633 +
0xb1
  github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3044 +0x507
  github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:4015 +0x7ca
  github.com/nats-io/nats-server/v2/server.(*client).processServiceImport()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3836 +0x1115
  github.com/nats-io/nats-server/v2/server.(*Account).addServiceImportSub.func1()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/accounts.go:1840 +0x78
  github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3042 +0x62c
  github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:4015 +0x7ca
  github.com/nats-io/nats-server/v2/server.(*client).processInboundClientMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3479 +0xdee
  github.com/nats-io/nats-server/v2/server.(*client).processInboundMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3343 +0xbe
  github.com/nats-io/nats-server/v2/server.(*client).parse()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/parser.go:476 +0x412f
  github.com/nats-io/nats-server/v2/server.(*client).readLoop()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:1115 +0x86f
  github.com/nats-io/nats-server/v2/server.(*Server).createClient.func1()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/server.go:2346 +0x5c
==================
==================
WARNING: DATA RACE
Write at 0x00c00021a4c8 by goroutine 35:
  github.com/nats-io/nats-server/v2/server.(*stream).internalLoop()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/stream.go:2388 +0x1057

Previous read at 0x00c00021a4c8 by goroutine 37:
  github.com/nats-io/nats-server/v2/server.(*jsPubMsg).size()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/stream.go:2275 +0x95d
  github.com/nats-io/nats-server/v2/server.(*consumer).deliverMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:2045 +0x5a
e
  github.com/nats-io/nats-server/v2/server.(*consumer).loopAndGatherMsgs()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:1955 +0xc2
e

Goroutine 35 (running) created at:
  github.com/nats-io/nats-server/v2/server.(*stream).setupSendCapabilities()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/stream.go:2332 +0x1aa
  github.com/nats-io/nats-server/v2/server.(*Account).addStreamWithAssignment()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/stream.go:351 +0xf0f
  github.com/nats-io/nats-server/v2/server.(*Account).addStream()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/stream.go:210 +0x770
  github.com/nats-io/nats-server/v2/server.(*Server).jsStreamCreateRequest()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:1194
+0x74a
  github.com/nats-io/nats-server/v2/server.(*Server).jsStreamCreateRequest-fm()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:1098
+0xb1
  github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:654 +
0xbcb
  github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch-fm()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:633 +
0xb1
  github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3044 +0x507
  github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:4015 +0x7ca
  github.com/nats-io/nats-server/v2/server.(*client).processServiceImport()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3836 +0x1115
  github.com/nats-io/nats-server/v2/server.(*Account).addServiceImportSub.func1()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/accounts.go:1840 +0x78
  github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3042 +0x62c
  github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:4015 +0x7ca
  github.com/nats-io/nats-server/v2/server.(*client).processInboundClientMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3479 +0xdee
  github.com/nats-io/nats-server/v2/server.(*client).processInboundMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3343 +0xbe
  github.com/nats-io/nats-server/v2/server.(*client).parse()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/parser.go:476 +0x412f
  github.com/nats-io/nats-server/v2/server.(*client).readLoop()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:1115 +0x86f
  github.com/nats-io/nats-server/v2/server.(*Server).createClient.func1()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/server.go:2346 +0x5c

Goroutine 37 (running) created at:
  github.com/nats-io/nats-server/v2/server.(*consumer).setLeader()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:709 +0x596
  github.com/nats-io/nats-server/v2/server.(*stream).addConsumerWithAssignment()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:589 +0x1f8
5
  github.com/nats-io/nats-server/v2/server.(*stream).addConsumer()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/consumer.go:240 +0x108
9
  github.com/nats-io/nats-server/v2/server.(*Server).jsConsumerCreate()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:2929
+0x1063
  github.com/nats-io/nats-server/v2/server.(*Server).jsDurableCreateRequest()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:2824
+0xb9
  github.com/nats-io/nats-server/v2/server.(*Server).jsDurableCreateRequest-fm()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:2823
+0x26
  github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:654 +
0xbcb
  github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch-fm()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/jetstream_api.go:633 +
0xb1
  github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3044 +0x507
  github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:4015 +0x7ca
  github.com/nats-io/nats-server/v2/server.(*client).processServiceImport()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3836 +0x1115
  github.com/nats-io/nats-server/v2/server.(*Account).addServiceImportSub.func1()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/accounts.go:1840 +0x78
  github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3042 +0x62c
  github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:4015 +0x7ca
  github.com/nats-io/nats-server/v2/server.(*client).processInboundClientMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3479 +0xdee
  github.com/nats-io/nats-server/v2/server.(*client).processInboundMsg()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:3343 +0xbe
  github.com/nats-io/nats-server/v2/server.(*client).parse()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/parser.go:476 +0x412f
  github.com/nats-io/nats-server/v2/server.(*client).readLoop()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/client.go:1115 +0x86f
  github.com/nats-io/nats-server/v2/server.(*Server).createClient.func1()
      /home/jaime/Developer/go/src/github.com/nats-io/nats-server/server/server.go:2346 +0x5c
==================
--- FAIL: TestJetStreamPushConsumerFlowControl (1.09s)
    testing.go:1038: race detected during execution of test
FAIL
exit status 1
FAIL    github.com/nats-io/nats-server/v2/server        1.106s
```