### PR TITLE
fixing crash when disabling already shut down server

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -288,6 +288,10 @@ func (s *Server) DisableJetStream() error {
 	if s.JetStreamIsClustered() {
 		isLeader := s.JetStreamIsLeader()
 		js, cc := s.getJetStreamCluster()
+		if js == nil {
+			s.shutdownJetStream()
+			return nil
+		}
 		js.mu.RLock()
 		meta := cc.meta
 		js.mu.RUnlock()


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

getJetStreamCluster returns nil when `server.shutdown == true`.
I manually call shutdown to keep the change small and future proof (more conditions where nil is returned)

Error in travis:
```
=== RUN   TestJetStreamClusterExtendedStreamInfo
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xb178ba]
goroutine 120333 [running]:
github.com/nats-io/nats-server/server.(*Server).DisableJetStream(0xc00e05aa80, 0x0, 0x0)
/home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:291 +0xfa
created by github.com/nats-io/nats-server/server.(*Server).handleOutOfSpace
/home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:262 +0xd1
FAIL	github.com/nats-io/nats-server/server	91.762s
=== RUN   TestPSEmulation
--- PASS: TestPSEmulation (0.01s)
PASS
```