### PR TITLE
Increasing unit test timeout for waitOnStreamCurrent from 10 to 30 sec

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -5048,7 +5048,7 @@ func (c *cluster) streamLeader(account, stream string) *Server {
 
 func (c *cluster) waitOnStreamCurrent(s *Server, account, stream string) {
 	c.t.Helper()
-	expires := time.Now().Add(10 * time.Second)
+	expires := time.Now().Add(30 * time.Second)
 	for time.Now().Before(expires) {
 		if s.JetStreamIsStreamCurrent(account, stream) {
 			time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

With the latest change I still see the large run times (10sec> runtime <30sec)
Even though I increase the timeout quite drastically, most tests stay below 3 seconds (#49) and 5 seconds (#24) )
In this run of 100 tests 85 tests stay below 10seconds, and the remaining 15 would have failed without the change.

When running this on travis I found a crash ([PR is out](https://github.com/nats-io/nats-server/pull/1978)) and 4 failures of the unit test `TestNoRaceJetStreamClusterSuperClusterSources`.  Getting to green builds rather quickly now.

```
grep "[^(]....s[)]" testout
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (12.44s)
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (14.76s)
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (26.40s)
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (24.19s)
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (13.12s)
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (21.85s)
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (10.92s)
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (10.48s)
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (28.59s)
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (11.08s)
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (26.94s)
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (16.94s)
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (14.83s)
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (11.56s)
--- PASS: TestNoRaceJetStreamClusterLargeStreamInlineCatchup (10.89s)
```