### PR TITLE
Increasing the timeout of waitOnClusterReady

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -5136,7 +5136,7 @@ func (c *cluster) waitOnLeader() {
 func (c *cluster) waitOnClusterReady() {
 	c.t.Helper()
 	var leader *Server
-	expires := time.Now().Add(10 * time.Second)
+	expires := time.Now().Add(20 * time.Second)
 	for time.Now().Before(expires) {
 		if leader = c.leader(); leader != nil {
 			break


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>
 
Same argument as yesterday for `waitOnStreamCurrent`. 
I noticed `TestNoRaceJetStreamClusterStreamCreateAndLostQuorum` fail on travis.
So I ran it locally 300 times.
While doing so I had the timeout of waitOnClusterReady set to 20 seconds (from 10 seconds).
Out of 300 tests, 15 only passed because of the increased timeout. 
```
> grep RUN testout | wc -l
     300
> grep "[(].....s[)]" testout -o | wc -l
      15
> grep "[(].....s[)]" testout -o
(10.26s)
(12.50s)
(10.80s)
(11.09s)
(11.21s)
(12.63s)
(15.58s)
(11.98s)
(14.06s)
(12.85s)
(14.56s)
(10.38s)
(11.01s)
(11.37s)
(11.12s)
>
```