### PR TITLE
Increasing test timeout

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -3563,7 +3563,7 @@ func TestJetStreamClusterRemovePeer(t *testing.T) {
 	})
 
 	// Now check consumer info as well.
-	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+	checkFor(t, 20*time.Second, 100*time.Millisecond, func() error {
 		ci, err := js.ConsumerInfo("TEST", "cat")
 		if err != nil {
 			return fmt.Errorf("Could not fetch consumer info: %v", err)


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

Bumping to 20 for the same reason as the others.

Ran 100 tests and 16 would have failed without the increased timeout.
I believe that in this unit test we should wait longer as we remove a server from js.

```
> grep RUN testout | wc -l
     100
> grep -e "[(][6789]" -e "[(]1[0-9]" testout | wc -l
      16
> grep -e "[(][6789]" -e "[(]1[0-9]" testout
--- PASS: TestJetStreamClusterRemovePeer (6.08s)
--- PASS: TestJetStreamClusterRemovePeer (9.90s)
--- PASS: TestJetStreamClusterRemovePeer (7.64s)
--- PASS: TestJetStreamClusterRemovePeer (11.88s)
--- PASS: TestJetStreamClusterRemovePeer (8.57s)
--- PASS: TestJetStreamClusterRemovePeer (10.13s)
--- PASS: TestJetStreamClusterRemovePeer (7.98s)
--- PASS: TestJetStreamClusterRemovePeer (8.15s)
--- PASS: TestJetStreamClusterRemovePeer (7.64s)
--- PASS: TestJetStreamClusterRemovePeer (8.70s)
--- PASS: TestJetStreamClusterRemovePeer (6.50s)
--- PASS: TestJetStreamClusterRemovePeer (6.88s)
--- PASS: TestJetStreamClusterRemovePeer (6.53s)
--- PASS: TestJetStreamClusterRemovePeer (9.17s)
--- PASS: TestJetStreamClusterRemovePeer (8.15s)
--- PASS: TestJetStreamClusterRemovePeer (9.37s)
>
```