### PR TITLE
Disable JS on restart if on invalid state

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -228,7 +228,13 @@ func (s *Server) restartJetStream() error {
 		MaxStore:  opts.JetStreamMaxStore,
 	}
 	s.Noticef("Restarting JetStream")
-	return s.enableJetStream(cfg)
+	err := s.enableJetStream(cfg)
+	if err != nil {
+		s.Warnf("Can't start JetStream: %v", err)
+		return s.DisableJetStream()
+	}
+
+	return nil
 }
 
 // checkStreamExports will check if we have the JS exports setup


### PR DESCRIPTION
When re-enabling a JS server that got auto shutdown due to reaching an invalid state, sending HUP while still being in the invalid state could 'brick' JS for an account (for example due to a file system issue):

```
[85085] 2021/03/10 01:37:38.220246 [ERR] JetStream out of space, will be DISABLED
[85085] 2021/03/10 01:37:38.475190 [INF] Initiating JetStream Shutdown...
[85085] 2021/03/10 01:37:38.477821 [INF] JetStream Shutdown
[85085] 2021/03/10 01:38:17.746407 [INF] Reloaded: jetstream
[85085] 2021/03/10 01:38:17.746422 [INF] Restarting JetStream
[85085] 2021/03/10 01:38:17.746471 [WRN] Can't start JetStream: storage directory is not writable
[85085] 2021/03/10 01:38:17.746720 [INF] Reloaded server configuration
```

Then from the natscli would always get the following 503:

```
nats: error: could not load Stream S1: JetStream not enabled for account
```

To prevent that condition, we re disable the JS instance from the server, so result would be now like:

```
[73053] 2021/03/10 01:22:32.266911 [INF] JetStream cluster new stream leader for '$G > S1'
[73053] 2021/03/10 01:24:32.148860 [ERR] JetStream out of space, will be DISABLED
[73053] 2021/03/10 01:24:32.403893 [INF] Initiating JetStream Shutdown...
[73053] 2021/03/10 01:24:32.404090 [INF] JetStream Shutdown





[73053] 2021/03/10 01:26:52.180856 [INF] Reloaded: jetstream
[73053] 2021/03/10 01:26:52.180869 [INF] Restarting JetStream
[73053] 2021/03/10 01:26:52.181218 [WRN]     _ ___ _____ ___ _____ ___ ___   _   __  __
[73053] 2021/03/10 01:26:52.181225 [WRN]  _ | | __|_   _/ __|_   _| _ \ __| /_\ |  \/  |
[73053] 2021/03/10 01:26:52.181227 [WRN] | || | _|  | | \__ \ | | |   / _| / _ \| |\/| |
[73053] 2021/03/10 01:26:52.181229 [WRN]  \__/|___| |_| |___/ |_| |_|_\___/_/ \_\_|  |_|
[73053] 2021/03/10 01:26:52.181230 [WRN] 
[73053] 2021/03/10 01:26:52.181232 [WRN]       https://github.com/nats-io/jetstream
[73053] 2021/03/10 01:26:52.181234 [INF] 
[73053] 2021/03/10 01:26:52.181235 [INF] ---------------- JETSTREAM ----------------
[73053] 2021/03/10 01:26:52.181241 [INF]   Max Memory:      -1 B
[73053] 2021/03/10 01:26:52.181243 [INF]   Max Storage:     -1 B
[73053] 2021/03/10 01:26:52.181246 [INF]   Store Directory: "./nodes/D"
[73053] 2021/03/10 01:26:52.181247 [INF] -------------------------------------------
[73053] 2021/03/10 01:26:52.183453 [INF] Starting JetStream cluster
[73053] 2021/03/10 01:26:52.183463 [INF] Creating JetStream metadata controller
[73053] 2021/03/10 01:26:52.184536 [INF] JetStream cluster bootstrapping
[73053] 2021/03/10 01:26:52.185575 [INF] Reloaded server configuration
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

/cc @nats-io/core
