### PR TITLE
Increasing test timeout

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -5015,7 +5015,7 @@ func (c *cluster) consumerLeader(account, stream, consumer string) *Server {
 
 func (c *cluster) waitOnStreamLeader(account, stream string) {
 	c.t.Helper()
-	expires := time.Now().Add(10 * time.Second)
+	expires := time.Now().Add(30 * time.Second)
 	for time.Now().Before(expires) {
 		if leader := c.streamLeader(account, stream); leader != nil {
 			time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

Same argument as with last changes. out of 453 tests ran with a 30 sec timeout (up from 10seconds) 22 would have failed.

```
> grep RUN  TestNoRaceJetStreamClusterStreamCreateAndLostQuorum.out | wc -l
     453
> grep "[(][12][0-9]" TestNoRaceJetStreamClusterStreamCreateAndLostQuorum.out | wc -l
      22
> grep "[(][12][0-9]" TestNoRaceJetStreamClusterStreamCreateAndLostQuorum.out
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (10.79s)
--- FAIL: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (20.72s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (14.84s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (10.09s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (10.63s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (12.06s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (10.11s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (10.72s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (10.20s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (10.05s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (11.42s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (12.42s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (12.01s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (10.38s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (16.81s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (13.23s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (10.41s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (14.64s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (10.03s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (14.51s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (10.60s)
--- PASS: TestNoRaceJetStreamClusterStreamCreateAndLostQuorum (14.40s)
```