### PR TITLE
Fixed a quorum formation issue that caused truncation

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -3726,7 +3726,7 @@ func TestJetStreamClusterRemoveServer(t *testing.T) {
 	}
 
 	// Check the stream info is eventually correct.
-	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+	checkFor(t, 20*time.Second, 100*time.Millisecond, func() error {
 		si, err := js.StreamInfo("TEST")
 		if err != nil {
 			return fmt.Errorf("Could not fetch stream info: %v", err)
@@ -3744,7 +3744,7 @@ func TestJetStreamClusterRemoveServer(t *testing.T) {
 
 	// Now do consumer.
 	c.waitOnConsumerLeader("$G", "TEST", cname)
-	checkFor(t, 5*time.Second, 50*time.Millisecond, func() error {
+	checkFor(t, 20*time.Second, 50*time.Millisecond, func() error {
 		ci, err := js.ConsumerInfo("TEST", cname)
 		if err != nil {
 			return fmt.Errorf("Could not fetch consumer info: %v", err)
@@ -4971,7 +4971,7 @@ func (c *cluster) waitOnPeerCount(n int) {
 	c.t.Helper()
 	c.waitOnLeader()
 	leader := c.leader()
-	expires := time.Now().Add(10 * time.Second)
+	expires := time.Now().Add(20 * time.Second)
 	for time.Now().Before(expires) {
 		peers := leader.JetStreamClusterPeers()
 		if len(peers) == n {
@@ -4984,7 +4984,7 @@ func (c *cluster) waitOnPeerCount(n int) {
 
 func (c *cluster) waitOnConsumerLeader(account, stream, consumer string) {
 	c.t.Helper()
-	expires := time.Now().Add(10 * time.Second)
+	expires := time.Now().Add(20 * time.Second)
 	for time.Now().Before(expires) {
 		if leader := c.consumerLeader(account, stream, consumer); leader != nil {
 			time.Sleep(100 * time.Millisecond)
@@ -5053,7 +5053,7 @@ func (c *cluster) waitOnStreamCurrent(s *Server, account, stream string) {
 
 func (c *cluster) waitOnServerCurrent(s *Server) {
 	c.t.Helper()
-	expires := time.Now().Add(5 * time.Second)
+	expires := time.Now().Add(20 * time.Second)
 	for time.Now().Before(expires) {
 		if s.JetStreamIsCurrent() {
 			time.Sleep(100 * time.Millisecond)
@@ -5112,7 +5112,7 @@ func (c *cluster) expectNoLeader() {
 
 func (c *cluster) waitOnLeader() {
 	c.t.Helper()
-	expires := time.Now().Add(5 * time.Second)
+	expires := time.Now().Add(20 * time.Second)
 	for time.Now().Before(expires) {
 		if leader := c.leader(); leader != nil {
 			time.Sleep(100 * time.Millisecond)

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -3530,7 +3530,7 @@ func TestJetStreamClusterRemovePeer(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+	checkFor(t, 20*time.Second, 100*time.Millisecond, func() error {
 		si, err := js.StreamInfo("TEST")
 		if err != nil {
 			return fmt.Errorf("Could not fetch stream info: %v", err)
@@ -4351,7 +4351,7 @@ func TestJetStreamCrossAccountMirrorsAndSources(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+	checkFor(t, 20*time.Second, 100*time.Millisecond, func() error {
 		si, err := js2.StreamInfo("MY_MIRROR_TEST")
 		if err != nil {
 			t.Fatalf("Could not retrieve stream info")
@@ -4393,7 +4393,7 @@ func TestJetStreamCrossAccountMirrorsAndSources(t *testing.T) {
 		t.Fatalf("Did not receive correct response: %+v", scResp.Error)
 	}
 
-	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+	checkFor(t, 20*time.Second, 100*time.Millisecond, func() error {
 		si, err := js2.StreamInfo("MY_SOURCE_TEST")
 		if err != nil {
 			t.Fatalf("Could not retrieve stream info")

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -1721,6 +1721,7 @@ func TestJetStreamClusterExtendedStreamInfo(t *testing.T) {
 	}
 
 	oldLeader = c.restartServer(oldLeader)
+	c.waitOnStreamLeader("$G", "TEST")
 	c.waitOnStreamCurrent(oldLeader, "$G", "TEST")
 
 	// Re-request.
@@ -3717,6 +3718,7 @@ func TestJetStreamClusterRemoveServer(t *testing.T) {
 	sl := c.streamLeader("$G", "TEST")
 	c.removeJetStream(sl)
 
+	c.waitOnLeader()
 	c.waitOnStreamLeader("$G", "TEST")
 
 	// Faster timeout since we loop below checking for condition.
@@ -5112,7 +5114,7 @@ func (c *cluster) expectNoLeader() {
 
 func (c *cluster) waitOnLeader() {
 	c.t.Helper()
-	expires := time.Now().Add(20 * time.Second)
+	expires := time.Now().Add(40 * time.Second)
 	for time.Now().Before(expires) {
 		if leader := c.leader(); leader != nil {
 			time.Sleep(100 * time.Millisecond)

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -1373,7 +1373,7 @@ func TestNoRaceJetStreamClusterLargeStreamInlineCatchup(t *testing.T) {
 	c.waitOnStreamCurrent(sr, "$G", "TEST")
 
 	// Ask other servers to stepdown as leader so that sr becomes the leader.
-	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+	checkFor(t, 20*time.Second, 200*time.Millisecond, func() error {
 		c.waitOnStreamLeader("$G", "TEST")
 		if sl := c.streamLeader("$G", "TEST"); sl != sr {
 			sl.JetStreamStepdownStream("$G", "TEST")


### PR DESCRIPTION
When a new leader is elected it has to give everyone a chance to reply,
so that we can observe rejections with higher term.

The maximum election timeout is 7.5 seconds.
The new behavior of waiting for the election timeout caused unit tests
to fail. Hence upping the timeout there as well.

Signed-off-by: Matthias Hanel <mh@synadia.com>

Unit test wise this might cause more failures due to the altered timing. (only ran locally so far)
I am also missing the knowledge to implement the TODO that I added. 
But if we could, this would speed things back up for cases where the leader does not change.