### PR TITLE
reload: Allow re-enabling JS after it was disabled

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -228,7 +228,7 @@ func (s *Server) restartJetStream() error {
 		MaxStore:  opts.JetStreamMaxStore,
 	}
 	s.Noticef("Restarting JetStream")
-	err := s.enableJetStream(cfg)
+	err := s.EnableJetStream(&cfg)
 	if err != nil {
 		s.Warnf("Can't start JetStream: %v", err)
 		return s.DisableJetStream()


### PR DESCRIPTION
Allow disable/re-enable JS at runtime with HUP.

```
[1717] 2021/03/12 09:44:12.370469 [INF] Using configuration file: my.conf
[1717] 2021/03/12 09:44:12.371519 [INF] Starting JetStream
[1717] 2021/03/12 09:44:12.371882 [WRN]     _ ___ _____ ___ _____ ___ ___   _   __  __
[1717] 2021/03/12 09:44:12.371889 [WRN]  _ | | __|_   _/ __|_   _| _ \ __| /_\ |  \/  |
[1717] 2021/03/12 09:44:12.371894 [WRN] | || | _|  | | \__ \ | | |   / _| / _ \| |\/| |
[1717] 2021/03/12 09:44:12.371897 [WRN]  \__/|___| |_| |___/ |_| |_|_\___/_/ \_\_|  |_|
[1717] 2021/03/12 09:44:12.371900 [WRN] 
[1717] 2021/03/12 09:44:12.371905 [WRN]       https://github.com/nats-io/jetstream
[1717] 2021/03/12 09:44:12.371908 [INF] 
[1717] 2021/03/12 09:44:12.371910 [INF] ---------------- JETSTREAM ----------------
[1717] 2021/03/12 09:44:12.371916 [INF]   Max Memory:      512 MB
[1717] 2021/03/12 09:44:12.371920 [INF]   Max Storage:     512 MB
[1717] 2021/03/12 09:44:12.371924 [INF]   Store Directory: "./nodes/A"
[1717] 2021/03/12 09:44:12.371927 [INF] -------------------------------------------
[1717] 2021/03/12 09:44:12.372504 [INF] Starting http monitor on 0.0.0.0:8222
[1717] 2021/03/12 09:44:12.372575 [INF] Listening for client connections on 0.0.0.0:4222
[1717] 2021/03/12 09:44:12.372977 [INF] Server is ready
[1717] 2021/03/12 09:44:18.771078 [INF] Reloaded server configuration
[1717] 2021/03/12 09:44:22.050741 [INF] Reloaded: jetstream
[1717] 2021/03/12 09:44:22.050762 [INF] Initiating JetStream Shutdown...
[1717] 2021/03/12 09:44:22.050810 [INF] JetStream Shutdown
[1717] 2021/03/12 09:44:22.050824 [INF] Reloaded server configuration
[1717] 2021/03/12 09:44:26.523267 [INF] Reloaded: jetstream
[1717] 2021/03/12 09:44:26.523288 [INF] Restarting JetStream
[1717] 2021/03/12 09:44:26.523557 [WRN]     _ ___ _____ ___ _____ ___ ___   _   __  __
[1717] 2021/03/12 09:44:26.523568 [WRN]  _ | | __|_   _/ __|_   _| _ \ __| /_\ |  \/  |
[1717] 2021/03/12 09:44:26.523573 [WRN] | || | _|  | | \__ \ | | |   / _| / _ \| |\/| |
[1717] 2021/03/12 09:44:26.523577 [WRN]  \__/|___| |_| |___/ |_| |_|_\___/_/ \_\_|  |_|
[1717] 2021/03/12 09:44:26.523582 [WRN] 
[1717] 2021/03/12 09:44:26.523586 [WRN]       https://github.com/nats-io/jetstream
[1717] 2021/03/12 09:44:26.523591 [INF] 
[1717] 2021/03/12 09:44:26.523596 [INF] ---------------- JETSTREAM ----------------
[1717] 2021/03/12 09:44:26.523606 [INF]   Max Memory:      512 MB
[1717] 2021/03/12 09:44:26.523612 [INF]   Max Storage:     512 MB
[1717] 2021/03/12 09:44:26.523619 [INF]   Store Directory: "./nodes/A/"
[1717] 2021/03/12 09:44:26.523623 [INF] -------------------------------------------
[1717] 2021/03/12 09:44:26.524113 [INF] Reloaded server configuration
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

/cc @nats-io/core