### PR TITLE
On RaftNode shutdown, wait for raft specific go routines

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -2536,11 +2536,13 @@ func (mset *stream) stop(deleteFlag, advisory bool) error {
 
 	// Cluster cleanup
 	if n := mset.node; n != nil {
+		mset.mu.Unlock()
 		if deleteFlag {
 			n.Delete()
 		} else {
 			n.Stop()
 		}
+		mset.mu.Lock()
 	}
 
 	// Send stream delete advisory after the consumers.


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

some of the routines checked for having RaftNode. 
This check was moved to where the go routine is started.

QuitC now returns the waitgroup used for the RaftNode.
Figured tat wherever the channel is used, the waitgroup needs to be decremented. 
