### PR TITLE
Fix for JS reload and exports

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -828,6 +828,9 @@ func (s *Server) addSystemAccountExports(sacc *Account) {
 	if err := sacc.AddServiceExport(accSubsSubj, nil); err != nil {
 		s.Errorf("Error adding system service export for %q: %v", accSubsSubj, err)
 	}
+	if s.JetStreamEnabled() {
+		s.checkJetStreamExports()
+	}
 }
 
 // accountClaimUpdate will receive claim updates for accounts.

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -333,7 +333,6 @@ func (s *Server) DisableJetStream() error {
 			}
 			// Once here we can forward our proposal to remove ourselves.
 			meta.ProposeRemovePeer(meta.ID())
-			time.Sleep(250 * time.Millisecond)
 			meta.Delete()
 		}
 	}

--- a/server/reload.go
+++ b/server/reload.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The NATS Authors
+// Copyright 2017-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
Fixes the following issue that occurs during reload after JS got disabled:

```
[88019] 2021/03/14 14:37:36.994423 [DBG] Starting metadata monitor
[88019] 2021/03/14 14:37:36.994490 [ERR] Error setting up jetstream service imports for account: service import not authorized
[88019] 2021/03/14 14:37:36.994497 [INF] Reloaded server configuration
```
