### PR TITLE
Don't set to nil on stop to avoid any panics accessing that map.

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -2508,7 +2508,6 @@ func (mset *stream) stop(deleteFlag, advisory bool) error {
 	for _, o := range mset.consumers {
 		obs = append(obs, o)
 	}
-	mset.consumers = nil
 	mset.mu.Unlock()
 
 	for _, o := range obs {


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
