### PR TITLE
Suppress varz jetstream output if not enabled

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1052,8 +1052,8 @@ type Varz struct {
 
 // JetStreamVarz contains basic runtime information about jetstream
 type JetStreamVarz struct {
-	Config JetStreamConfig `json:"config"`
-	Stats  *JetStreamStats `json:"stats"`
+	Config *JetStreamConfig `json:"config,omitempty"`
+	Stats  *JetStreamStats  `json:"stats,omitempty"`
 }
 
 // ClusterOptsVarz contains monitoring cluster information
@@ -1288,8 +1288,9 @@ func (s *Server) createVarz(pcpu float64, rss int64) *Varz {
 	}
 	if s.js != nil {
 		s.js.mu.RLock()
+		cfg := s.js.config
 		varz.JetStream = JetStreamVarz{
-			Config: s.js.config,
+			Config: &cfg,
 		}
 		s.js.mu.RUnlock()
 	}


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

What it used to look like:
```
  "jetstream": {
    "config": {
      "max_memory": 0,
      "max_storage": 0
    },
    "stats": null
  },
```
What this will be now 
```
"jetstream": {},
```

Test
 ```
> nats-server -m 5222 &
[1] 84077
[84077] 2021/03/15 16:02:38.676376 [INF] Starting nats-server
[84077] 2021/03/15 16:02:38.676616 [INF]   Version:  2.2.0
[84077] 2021/03/15 16:02:38.676627 [INF]   Git:      [not set]
[84077] 2021/03/15 16:02:38.676737 [INF]   Name:     NDQKXZJBFFVO3XUIWIEXVBI3CWTDIIT3PP7DORBGNCG5Y5UZQB4FHQQN
[84077] 2021/03/15 16:02:38.676747 [INF]   ID:       NDQKXZJBFFVO3XUIWIEXVBI3CWTDIIT3PP7DORBGNCG5Y5UZQB4FHQQN
[84077] 2021/03/15 16:02:38.678096 [INF] Starting http monitor on 0.0.0.0:5222
[84077] 2021/03/15 16:02:38.678295 [INF] Listening for client connections on 0.0.0.0:4222
[84077] 2021/03/15 16:02:38.679013 [INF] Server is ready
> curl http://localhost:5222/varz | grep jetstream
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1219  100  1219    0     0  87071      0 --:--:-- --:--:-- --:--:-- 87071
  "jetstream": {},
>
```