### PR TITLE
Updates to memory retention in filestore.

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -2383,6 +2383,9 @@ type jsOutQ struct {
 }
 
 func (q *jsOutQ) pending() *jsPubMsg {
+	if q == nil {
+		return nil
+	}
 	q.mu.Lock()
 	head := q.head
 	q.head, q.tail = nil, nil
@@ -2391,6 +2394,9 @@ func (q *jsOutQ) pending() *jsPubMsg {
 }
 
 func (q *jsOutQ) send(msg *jsPubMsg) {
+	if q == nil || msg == nil {
+		return
+	}
 	q.mu.Lock()
 	var notify bool
 	if q.head == nil {


### PR DESCRIPTION
Updates to memory pressure.
    
    1. Release cache during heavy writes when we move to a new block if no read activity.
    2. If we detect a linear scan reading dump the cache on the last seq read for the mb.
    
Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
