### PR TITLE
Make sure the jetstream accounts use the name as the key to the map.

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1077,18 +1077,20 @@ func (c *client) processGatewayInfo(info *Info) {
 
 		// Switch JetStream accounts to interest-only mode.
 		if js != nil {
-			var accounts []*Account
+			var accounts []string
 			js.mu.Lock()
 			if len(js.accounts) > 0 {
-				accounts = make([]*Account, 0, len(js.accounts))
-				for acc := range js.accounts {
-					accounts = append(accounts, acc)
+				accounts = make([]string, 0, len(js.accounts))
+				for accName := range js.accounts {
+					accounts = append(accounts, accName)
 				}
 			}
 			js.mu.Unlock()
-			for _, acc := range accounts {
-				if acc.JetStreamEnabled() {
-					s.switchAccountToInterestMode(acc.GetName())
+			for _, accName := range accounts {
+				if acc, err := s.LookupAccount(accName); err == nil && acc != nil {
+					if acc.JetStreamEnabled() {
+						s.switchAccountToInterestMode(acc.GetName())
+					}
 				}
 			}
 		}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3225,7 +3225,7 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		return
 	}
 	var newCfg *StreamConfig
-	if jsa := js.accounts[acc]; jsa != nil {
+	if jsa := js.accounts[acc.Name]; jsa != nil {
 		if ncfg, err := jsa.configUpdateCheck(osa.Config, cfg); err != nil {
 			resp.Error = jsError(err)
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2341,7 +2341,7 @@ func (s *Server) JszAccount(opts *JSzOptions) (*AccountDetail, error) {
 		return nil, fmt.Errorf("account %q not found", acc)
 	}
 	s.js.mu.RLock()
-	jsa, ok := s.js.accounts[account.(*Account)]
+	jsa, ok := s.js.accounts[account.(*Account).Name]
 	s.js.mu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("account %q not jetstream enabled", acc)


### PR DESCRIPTION
This prevents possible double adds under reload or restart scenarios.

Signed-off-by: Derek Collison <derek@nats.io>


/cc @nats-io/core
