### PR TITLE
Reduce sliding window for direct consumers and catchup stream windows.

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.2.1.RC5"
+	VERSION = "2.2.1.RC6"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -237,7 +237,7 @@ const (
 	JsDeleteWaitTimeDefault = 5 * time.Second
 	// JsFlowControlMaxPending specifies default pending bytes during flow control that can be
 	// outstanding.
-	JsFlowControlMaxPending = 4 * 1024 * 1024
+	JsFlowControlMaxPending = 1 * 1024 * 1024
 )
 
 func (mset *stream) addConsumer(config *ConsumerConfig) (*consumer, error) {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4416,7 +4416,7 @@ func (mset *stream) runCatchup(sendSubject string, sreq *streamSyncRequest) {
 	s := mset.srv
 	defer s.grWG.Done()
 
-	const maxOutBytes = int64(4 * 1024 * 1024) // 4MB for now.
+	const maxOutBytes = int64(2 * 1024 * 1024) // 2MB for now.
 	const maxOutMsgs = int32(16384)
 	outb := int64(0)
 	outm := int32(0)

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -4054,26 +4054,15 @@ func TestJetStreamClusterSuperClusterPeerReassign(t *testing.T) {
 	defer nc.Close()
 
 	pcn := "C2"
-	cfg := StreamConfig{
+
+	// Create a stream in C2 that sources TEST
+	_, err := js.AddStream(&nats.StreamConfig{
 		Name:      "TEST",
+		Placement: &nats.Placement{Cluster: pcn},
 		Replicas:  3,
-		Storage:   FileStorage,
-		Placement: &Placement{Cluster: pcn},
-	}
-	req, err := json.Marshal(cfg)
+	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
-	}
-	resp, err := nc.Request(fmt.Sprintf(JSApiStreamCreateT, cfg.Name), req, time.Second)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	var scResp JSApiStreamCreateResponse
-	if err := json.Unmarshal(resp.Data, &scResp); err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if scResp.StreamInfo == nil || scResp.Error != nil {
-		t.Fatalf("Did not receive correct response: %+v", scResp.Error)
 	}
 
 	// Send in 10 messages.

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -5157,6 +5157,7 @@ func (sc *supercluster) leader() *Server {
 }
 
 func (sc *supercluster) waitOnLeader() {
+	sc.t.Helper()
 	expires := time.Now().Add(5 * time.Second)
 	for time.Now().Before(expires) {
 		for _, c := range sc.clusters {
@@ -5167,7 +5168,6 @@ func (sc *supercluster) waitOnLeader() {
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
-
 	sc.t.Fatalf("Expected a cluster leader, got none")
 }
 


### PR DESCRIPTION
Remove another possible wire blocking operation in raft.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
