### PR TITLE
[fixed] version parsing issue that got tripped by extra .

### DIFF
--- a/server/jwt.go
+++ b/server/jwt.go
@@ -112,7 +112,8 @@ func validateTrustedOperators(o *Options) error {
 			return fmt.Errorf("system_account in config and operator JWT must be identical")
 		}
 	}
-	srvMajor, srvMinor, srvUpdate, _ := jwt.ParseServerVersion(strings.Split(VERSION, "-")[0])
+	ver := strings.Split(strings.Split(VERSION, "-")[0], ".RC")[0]
+	srvMajor, srvMinor, srvUpdate, _ := jwt.ParseServerVersion(ver)
 	for _, opc := range o.TrustedOperators {
 		if major, minor, update, err := jwt.ParseServerVersion(opc.AssertServerVersion); err != nil {
 			return fmt.Errorf("operator %s expects version %s got error instead: %s",


### PR DESCRIPTION
This broke due to the RC portion 2.2.1.RC1 without -

Signed-off-by: Matthias Hanel <mh@synadia.com>

old code assumed - as separator between version and RC