### PR TITLE
Calling out to the storage update should not hold lock.

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.2.1-RC8"
+	VERSION = "2.2.1-RC9"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4486,6 +4486,9 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 	for _, rp := range peers {
 		if rp.ID != id && rg.isMember(rp.ID) {
 			lastSeen := now.Sub(rp.Last)
+			if lastSeen < 0 {
+				lastSeen = 1
+			}
 			current := rp.Current
 			if current && lastSeen > lostQuorumInterval {
 				current = false

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -3369,7 +3369,7 @@ func TestAccountNATSResolverFetch(t *testing.T) {
 	}
 	connect := func(url string, credsfile string, acc string, srvs ...*Server) {
 		t.Helper()
-		nc := natsConnect(t, url, nats.UserCredentials(credsfile))
+		nc := natsConnect(t, url, nats.UserCredentials(credsfile), nats.Timeout(5*time.Second))
 		nc.Close()
 		require_NoLocalOrRemoteConnections(acc, srvs...)
 	}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -492,8 +492,11 @@ func (ms *memStore) removeMsg(seq uint64, secure bool) bool {
 	}
 
 	if ms.scb != nil {
+		// We do not want to hold any locks here.
+		ms.mu.Unlock()
 		delta := int64(ss)
 		ms.scb(-1, -delta, seq, sm.subj)
+		ms.mu.Lock()
 	}
 
 	return ok


### PR DESCRIPTION
We had lock inversion with consumers. Not best solution but good for now.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
