### PR TITLE
fix nightly builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v0.160.0
           args: release --snapshot --config .goreleaser-nightly.yml
 
       - name: images


### PR DESCRIPTION
goreleaser now only function with GO111MODULES on, as will
much of the go eco system soon and we will need to move also.

For now use a version that still supports it

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
