### PR TITLE
Guard account client map

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1236,6 +1236,7 @@ func (s *Server) registerAccountNoLock(acc *Account) *Account {
 	// Finish account setup and store.
 	s.setAccountSublist(acc)
 
+	acc.mu.Lock()
 	if acc.clients == nil {
 		acc.clients = make(map[*client]struct{})
 	}
@@ -1245,7 +1246,6 @@ func (s *Server) registerAccountNoLock(acc *Account) *Account {
 	// During config reload, it is possible that account was
 	// already created (global account), so use locking and
 	// make sure we create only if needed.
-	acc.mu.Lock()
 	// TODO(dlc)- Double check that we need this for GWs.
 	if acc.rm == nil && s.opts != nil && s.shouldTrackSubscriptions() {
 		acc.rm = make(map[string]int32)


### PR DESCRIPTION
Fixes race with account client map.

```
=== RUN   TestJetStreamOperatorAccounts
==================
WARNING: DATA RACE
Write at 0x00c002a482b8 by goroutine 146:
  github.com/nats-io/nats-server/server.(*Server).registerAccountNoLock()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1240 +0x71e
  github.com/nats-io/nats-server/server.(*Server).registerAccount()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1207 +0x5c
  github.com/nats-io/nats-server/server.(*Server).fetchAccount()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1410 +0x10c
  github.com/nats-io/nats-server/server.(*Server).lookupAccount()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1291 +0x30d
  github.com/nats-io/nats-server/server.(*Server).configAllJetStreamAccounts()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:481 +0x326
  github.com/nats-io/nats-server/server.(*Server).enableJetStreamAccounts()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:370 +0x17e
  github.com/nats-io/nats-server/server.(*Server).enableJetStream()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:216 +0xbdb
  github.com/nats-io/nats-server/server.(*Server).EnableJetStream()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:160 +0x313
  github.com/nats-io/nats-server/server.(*Server).Start()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1564 +0xdc5
Previous read at 0x00c002a482b8 by goroutine 289:
  github.com/nats-io/nats-server/server.(*Account).addClient()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/accounts.go:813 +0x84
  github.com/nats-io/nats-server/server.(*client).registerWithAccount()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/client.go:674 +0x186
  github.com/nats-io/nats-server/server.(*stream).internalLoop()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/stream.go:2675 +0xd7
Goroutine 146 (running) created at:
  github.com/nats-io/nats-server/server.RunServer()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server_test.go:84 +0xc9
  github.com/nats-io/nats-server/server.RunServerWithConfig()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server_test.go:106 +0x57
  github.com/nats-io/nats-server/server.TestJetStreamOperatorAccounts()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_test.go:11191 +0x516
  testing.tRunner()
      /home/travis/.gimme/versions/go1.16.2.linux.amd64/src/testing/testing.go:1194 +0x202
Goroutine 289 (running) created at:
  github.com/nats-io/nats-server/server.(*stream).setupSendCapabilities()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/stream.go:2648 +0x1aa
  github.com/nats-io/nats-server/server.(*Account).addStreamWithAssignment()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/stream.go:367 +0xfa4
  github.com/nats-io/nats-server/server.(*Account).addStream()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/stream.go:220 +0x4e
  github.com/nats-io/nats-server/server.(*Account).EnableJetStream()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:833 +0x2134
  github.com/nats-io/nats-server/server.(*Server).configJetStream()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:421 +0x1ae
  github.com/nats-io/nats-server/server.(*Server).updateAccountClaimsWithRefresh()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/accounts.go:3165 +0x4d29
  github.com/nats-io/nats-server/server.(*Server).UpdateAccountClaims()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/accounts.go:2817 +0x2da
  github.com/nats-io/nats-server/server.(*Server).buildInternalAccount()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/accounts.go:3270 +0x2ad
  github.com/nats-io/nats-server/server.(*Server).fetchAccount()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1405 +0xb1
  github.com/nats-io/nats-server/server.(*Server).lookupAccount()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1291 +0x30d
  github.com/nats-io/nats-server/server.(*Server).configAllJetStreamAccounts()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:481 +0x326
  github.com/nats-io/nats-server/server.(*Server).enableJetStreamAccounts()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:370 +0x17e
  github.com/nats-io/nats-server/server.(*Server).enableJetStream()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:216 +0xbdb
  github.com/nats-io/nats-server/server.(*Server).EnableJetStream()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:160 +0x313
  github.com/nats-io/nats-server/server.(*Server).Start()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1564 +0xdc5
==================
    testing.go:1093: race detected during execution of test
--- FAIL: TestJetStreamOperatorAccounts (0.20s)
```

This is what it looked like before.
```go
// accounts.go
func (a *Account) addClient(c *client) int {
	a.mu.Lock()
	n := len(a.clients) // Write guarded
	if a.clients != nil {
		a.clients[c] = struct{}{}
	}
	// ...
}

// server.go
func (s *Server) registerAccountNoLock(acc *Account) *Account {
	// ...

	// Unguarded
	if acc.clients == nil {
		acc.clients = make(map[*client]struct{}) 
	}

	acc.mu.Lock()
	// ...
}
```

I moved the mutex up a few lines earlier to guard the map check and initialization.