### PR TITLE
[fixed] issue where verify_and_map: true in leaf node config was not used

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -992,9 +992,14 @@ func (s *Server) isLeafNodeAuthorized(c *client) bool {
 				s.Warnf("User %q found in connect proto, but user required from cert", c.opts.Username)
 			}
 			c.opts.Username = user.Username
+			// EMPTY will result in $G
+			accName := _EMPTY_
+			if user.Account != nil {
+				accName = user.Account.GetName()
+			}
 			// This will authorize since are using an existing user,
 			// but it will also register with proper account.
-			return isAuthorized(user.Username, user.Password, user.Account.GetName())
+			return isAuthorized(user.Username, user.Password, accName)
 		}
 
 		// This is expected to be a very small array.

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1701,9 +1701,14 @@ func TestLeafNodeTLSVerifyAndMapCfgPass(t *testing.T) {
 		return nil
 	})
 	// Make sure that the user name in the url was ignored and a warning printed
-	for w := range l.triggerChan {
-		if w == `User "user-provided-in-url" found in connect proto, but user required from cert` {
-			break
+	for {
+		select {
+		case w := <-l.triggerChan:
+			if w == `User "user-provided-in-url" found in connect proto, but user required from cert` {
+				return
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("Did not get expected warning")
 		}
 	}
 }

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1723,7 +1723,7 @@ func TestLeafNodeTLSVerifyAndMapCfgFail(t *testing.T) {
 	srvB, _ := RunServerWithConfig(confB)
 	defer srvB.Shutdown()
 
-	// Now make sure that the leaf node connection is up and the correct account was picked
+	// Now make sure that the leaf node connection is down
 	checkFor(t, 10*time.Second, 10*time.Millisecond, func() error {
 		for _, srv := range []*Server{srvA, srvB} {
 			if nln := srv.NumLeafNodes(); nln != 0 {

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1619,6 +1619,127 @@ func TestLeafNodeTLSVerifyAndMap(t *testing.T) {
 	}
 }
 
+type chanLogger struct {
+	DummyLogger
+	triggerChan chan string
+}
+
+func (l *chanLogger) Warnf(format string, v ...interface{}) {
+	l.triggerChan <- fmt.Sprintf(format, v...)
+}
+
+func (l *chanLogger) Errorf(format string, v ...interface{}) {
+	l.triggerChan <- fmt.Sprintf(format, v...)
+}
+
+const (
+	testLeafNodeTLSVerifyAndMapSrvA = `
+listen: 127.0.0.1:-1
+leaf {
+	listen: "127.0.0.1:-1"
+	tls {
+		cert_file: "../test/configs/certs/server-cert.pem"
+		key_file:  "../test/configs/certs/server-key.pem"
+		ca_file:   "../test/configs/certs/ca.pem"
+		timeout: 2
+		verify_and_map: true
+	}
+	authorization {
+		users [{
+			user: "%s"
+		}]
+	}
+}
+`
+	testLeafNodeTLSVerifyAndMapSrvB = `
+listen: -1
+leaf {
+	remotes [
+		{
+			url: "tls://user-provided-in-url@localhost:%d"
+			tls {
+				cert_file: "../test/configs/certs/server-cert.pem"
+				key_file:  "../test/configs/certs/server-key.pem"
+				ca_file:   "../test/configs/certs/ca.pem"
+			}
+		}
+	]
+}`
+)
+
+func TestLeafNodeTLSVerifyAndMapCfgPass(t *testing.T) {
+	l := &chanLogger{triggerChan: make(chan string, 100)}
+	defer close(l.triggerChan)
+
+	confA := createConfFile(t, []byte(fmt.Sprintf(testLeafNodeTLSVerifyAndMapSrvA, "localhost")))
+	defer os.Remove(confA)
+	srvA, optsA := RunServerWithConfig(confA)
+	defer srvA.Shutdown()
+	srvA.SetLogger(l, true, true)
+
+	confB := createConfFile(t, []byte(fmt.Sprintf(testLeafNodeTLSVerifyAndMapSrvB, optsA.LeafNode.Port)))
+	defer os.Remove(confB)
+	srvB, _ := RunServerWithConfig(confB)
+	defer srvB.Shutdown()
+
+	// Now make sure that the leaf node connection is up and the correct account was picked
+	checkFor(t, 10*time.Second, 10*time.Millisecond, func() error {
+		for _, srv := range []*Server{srvA, srvB} {
+			if nln := srv.NumLeafNodes(); nln != 1 {
+				return fmt.Errorf("Number of leaf nodes is %d", nln)
+			}
+			if leafz, err := srv.Leafz(nil); err != nil {
+				if len(leafz.Leafs) != 1 {
+					return fmt.Errorf("Number of leaf nodes returned by LEAFZ is not one: %d", len(leafz.Leafs))
+				} else if leafz.Leafs[0].Account != DEFAULT_GLOBAL_ACCOUNT {
+					return fmt.Errorf("Account used is not $G: %s", leafz.Leafs[0].Account)
+				}
+			}
+		}
+		return nil
+	})
+	// Make sure that the user name in the url was ignored and a warning printed
+	for w := range l.triggerChan {
+		if w == `User "user-provided-in-url" found in connect proto, but user required from cert` {
+			break
+		}
+	}
+}
+
+func TestLeafNodeTLSVerifyAndMapCfgFail(t *testing.T) {
+	l := &chanLogger{triggerChan: make(chan string, 100)}
+	defer close(l.triggerChan)
+
+	// use certificate with SAN localhost, but configure the server to not accept it
+	// instead provide a name matching the user (to be matched by failed
+	confA := createConfFile(t, []byte(fmt.Sprintf(testLeafNodeTLSVerifyAndMapSrvA, "user-provided-in-url")))
+	defer os.Remove(confA)
+	srvA, optsA := RunServerWithConfig(confA)
+	defer srvA.Shutdown()
+	srvA.SetLogger(l, true, true)
+
+	confB := createConfFile(t, []byte(fmt.Sprintf(testLeafNodeTLSVerifyAndMapSrvB, optsA.LeafNode.Port)))
+	defer os.Remove(confB)
+	srvB, _ := RunServerWithConfig(confB)
+	defer srvB.Shutdown()
+
+	// Now make sure that the leaf node connection is up and the correct account was picked
+	checkFor(t, 10*time.Second, 10*time.Millisecond, func() error {
+		for _, srv := range []*Server{srvA, srvB} {
+			if nln := srv.NumLeafNodes(); nln != 0 {
+				return fmt.Errorf("Number of leaf nodes is %d", nln)
+			}
+		}
+		return nil
+	})
+	// Make sure that the connection was closed for the right reason
+	for w := range l.triggerChan {
+		if strings.Contains(w, ErrAuthentication.Error()) {
+			break
+		}
+	}
+}
+
 func TestLeafNodeOriginClusterInfo(t *testing.T) {
 	hopts := DefaultOptions()
 	hopts.ServerName = "hub"

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1722,7 +1722,9 @@ func TestLeafNodeTLSVerifyAndMapCfgFail(t *testing.T) {
 
 	confB := createConfFile(t, []byte(fmt.Sprintf(testLeafNodeTLSVerifyAndMapSrvB, optsA.LeafNode.Port)))
 	defer os.Remove(confB)
-	srvB, _ := RunServerWithConfig(confB)
+	ob := LoadConfig(confB)
+	ob.LeafNode.ReconnectInterval = 50 * time.Millisecond
+	srvB := RunServer(ob)
 	defer srvB.Shutdown()
 
 	// Now make sure that the leaf node connection is down

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1742,9 +1742,14 @@ func TestLeafNodeTLSVerifyAndMapCfgFail(t *testing.T) {
 		return nil
 	})
 	// Make sure that the connection was closed for the right reason
-	for w := range l.triggerChan {
-		if strings.Contains(w, ErrAuthentication.Error()) {
-			break
+	for {
+		select {
+		case w := <-l.triggerChan:
+			if strings.Contains(w, ErrAuthentication.Error()) {
+				return
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("Did not get expected warning")
 		}
 	}
 }

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1679,7 +1679,9 @@ func TestLeafNodeTLSVerifyAndMapCfgPass(t *testing.T) {
 
 	confB := createConfFile(t, []byte(fmt.Sprintf(testLeafNodeTLSVerifyAndMapSrvB, optsA.LeafNode.Port)))
 	defer os.Remove(confB)
-	srvB, _ := RunServerWithConfig(confB)
+	ob := LoadConfig(confB)
+	ob.LeafNode.ReconnectInterval = 50 * time.Millisecond
+	srvB := RunServer(ob)
 	defer srvB.Shutdown()
 
 	// Now make sure that the leaf node connection is up and the correct account was picked

--- a/server/opts.go
+++ b/server/opts.go
@@ -1596,6 +1596,7 @@ func parseLeafNodes(v interface{}, opts *Options, errors *[]error, warnings *[]e
 				continue
 			}
 			opts.LeafNode.TLSTimeout = tc.Timeout
+			opts.LeafNode.TLSMap = tc.Map
 		case "leafnode_advertise", "advertise":
 			opts.LeafNode.Advertise = mv.(string)
 		case "no_advertise":


### PR DESCRIPTION
This broke the setup in such a way that any connect relying on this would have failed.
This also fixes an issue where specifying no account did not result in using $G.

Signed-off-by: Matthias Hanel <mh@synadia.com>
