### PR TITLE
[FIXED] Websocket: do not generate empty frames + LN corruption

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2007,9 +2007,6 @@ func (c *client) leafNodeSolicitWSConnection(opts *Options, rURL *url.URL, remot
 		}
 	}
 
-	var req *http.Request
-	var wsKey string
-
 	// For http request, we need the passed URL to contain either http or https scheme.
 	scheme := "http"
 	if tlsRequired {
@@ -2028,7 +2025,7 @@ func (c *client) leafNodeSolicitWSConnection(opts *Options, rURL *url.URL, remot
 	}
 	ustr := fmt.Sprintf("%s://%s%s", scheme, rURL.Host, path)
 	u, _ := url.Parse(ustr)
-	req = &http.Request{
+	req := &http.Request{
 		Method:     "GET",
 		URL:        u,
 		Proto:      "HTTP/1.1",

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1235,12 +1235,17 @@ func (c *client) wsCollapsePtoNB() (net.Buffers, int64) {
 					continue
 				}
 				for len(b) > 0 {
-					endFrame(fhIdx, total)
+					endStart := total != 0
+					if endStart {
+						endFrame(fhIdx, total)
+					}
 					total = len(b)
 					if total >= mfs {
 						total = mfs
 					}
-					fhIdx = startFrame()
+					if endStart {
+						fhIdx = startFrame()
+					}
 					bufs = append(bufs, b[:total])
 					b = b[total:]
 				}


### PR DESCRIPTION
- It was possible that when the server was sending frames to a
webbrowser, it would send empty frames. While technically not wrong,
prevent that from happening.
- Not copying enqueued buffers could cause corruption with LN+WS.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
