### PR TITLE
[Added] error when mirror/source stream prefix overlaps with stream subs

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1234,7 +1234,7 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, subject, re
 	}
 	// check prefix overlap with subjects
 	for _, pfx := range deliveryPrefixes {
-		if pfx == "*" || pfx == ">" || strings.Contains(pfx, ".*") || strings.HasSuffix(pfx, ".>") {
+		if !IsValidPublishSubject(pfx) {
 			resp.Error = &ApiError{Code: 400, Description: fmt.Sprintf("stream external delivery prefix %q must not contain wildcards", pfx)}
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

This change collects prefixes from mirror or sources, then checks them against collected subjects.

This does not work if the streams are in different accounts.
I can look into adding that as well. 
Just haven't yet as I was unsure why it was not done already.
Should I add it?

I am also wondering if this (already  present) check should be done for Sources as well? (since I added code to obtain the stream config there as well)
```
		if exists && cfg.MaxMsgSize > 0 && maxMsgSize > 0 && cfg.MaxMsgSize < maxMsgSize {
			resp.Error = &ApiError{Code: 400, Description: "stream mirror must have max message size >= source"}
			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
			return
		}
```