### PR TITLE
[FIXED] Websocket: print correct random port instead of `0`

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -965,15 +965,15 @@ func (s *Server) startWebsocketServer() {
 		s.Fatalf("Unable to listen for websocket connections: %v", err)
 		return
 	}
-	s.Noticef("Listening for websocket clients on %s://%s:%d", proto, o.Host, port)
+	if port == 0 {
+		o.Port = hl.Addr().(*net.TCPAddr).Port
+	}
+	s.Noticef("Listening for websocket clients on %s://%s:%d", proto, o.Host, o.Port)
 	if proto == wsSchemePrefix {
 		s.Warnf("Websocket not configured with TLS. DO NOT USE IN PRODUCTION!")
 	}
 
 	s.websocket.tls = proto == "wss"
-	if port == 0 {
-		s.opts.Websocket.Port = hl.Addr().(*net.TCPAddr).Port
-	}
 	s.websocket.connectURLs, err = s.getConnectURLs(o.Advertise, o.Host, o.Port)
 	if err != nil {
 		s.Fatalf("Unable to get websocket connect URLs: %v", err)


### PR DESCRIPTION
When a random port is selected (likely in tests), the banner would
print the port as `0` instead of its real value.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
