### PR TITLE
Fix for performance degradation on durable consumers R>1.

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.2.1-RC11"
+	VERSION = "2.2.1-RC12"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -3419,7 +3419,7 @@ func (o *consumerFileStore) flushLoop() {
 	for {
 		select {
 		case <-fch:
-			time.Sleep(5 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 			select {
 			case <-qch:
 				return

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2666,7 +2666,7 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 			if err := js.applyConsumerEntries(o, ce, isLeader); err == nil {
 				ne, nb := n.Applied(ce.Index)
 				// If we have at least min entries to compact, go ahead and snapshot/compact.
-				if ne >= compactNumMin || nb > compactNumMin {
+				if nb > 0 && ne >= compactNumMin || nb > compactSizeMin {
 					doSnapshot()
 				}
 			} else {


### PR DESCRIPTION
There was a bug that would cause excessive snapshotting to occur causing performance degradation.
We also introduced a default max ack pending for ack explicit consumers.

/cc @nats-io/core
