### PR TITLE
[Fixed] missing unlock and added a warning trace

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2276,10 +2276,11 @@ func (js *jetStream) processConsumerAssignment(ca *consumerAssignment) {
 		return
 	}
 
-	acc, err := s.LookupAccount(ca.Client.serviceAccount())
+	accName := ca.Client.serviceAccount()
+	acc, err := s.LookupAccount(accName)
 	if err != nil {
 		js.mu.Unlock()
-		s.Warnf("Account lookup for consumer create failed: %v", err)
+		s.Warnf("Account [%s] lookup for consumer create failed: %v", accName, err)
 		return
 	}
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2278,7 +2278,8 @@ func (js *jetStream) processConsumerAssignment(ca *consumerAssignment) {
 
 	acc, err := s.LookupAccount(ca.Client.serviceAccount())
 	if err != nil {
-		// TODO(dlc) - log error
+		js.mu.Unlock()
+		s.Warnf("Account lookup for consumer create failed: %v", err)
 		return
 	}
 


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

```
[4295] 2021/03/31 19:08:52.377093 [WRN] Account [AAODZMQUUPCOJW7RG7FJWR5FGZJE45GXHPUH45ZYFJGHMOQXMLBHPOQY] lookup for consumer create failed: fetching jwt timed out
```