### PR TITLE
Aggressive cache expiration was hindering performance

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.2.1-RC12"
+	VERSION = "2.2.1-RC14"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2013,6 +2013,7 @@ func (o *consumer) loopAndGatherMsgs(qch chan struct{}) {
 	)
 
 	o.mu.Lock()
+	s := o.srv
 	if o.replay {
 		// consumer is closed when mset is set to nil.
 		if o.mset == nil {
@@ -2073,6 +2074,7 @@ func (o *consumer) loopAndGatherMsgs(qch chan struct{}) {
 				goto waitForMsgs
 			} else {
 				o.mu.Unlock()
+				s.Errorf("Received an error looking up message for consumer: %v", err)
 				return
 			}
 		}

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -9442,7 +9442,7 @@ func TestJetStreamPubSubPerf(t *testing.T) {
 	nc := clientConnectToServer(t, s)
 	defer nc.Close()
 
-	var toSend = 1000000
+	var toSend = 1_000_000
 	var received int
 	done := make(chan bool)
 


### PR DESCRIPTION
When publishing and receiving from a stream concurrently performance was hindered due to aggressive cache expiration.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
