### PR TITLE
[Adding] (fetch) timeout to nats resolver

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3784,10 +3784,10 @@ func (dr *DirAccResolver) Store(name, jwt string) error {
 	return dr.saveIfNewer(name, jwt)
 }
 
-type dirResOption func(s *DirAccResolver) error
+type DirResOption func(s *DirAccResolver) error
 
 // limits the amount of time spent waiting for an account fetch to complete
-func FetchTimeout(to time.Duration) dirResOption {
+func FetchTimeout(to time.Duration) DirResOption {
 	return func(r *DirAccResolver) error {
 		if to <= time.Duration(0) {
 			return fmt.Errorf("Fetch timeout %v is too smal", to)
@@ -3797,7 +3797,7 @@ func FetchTimeout(to time.Duration) dirResOption {
 	}
 }
 
-func (dr *DirAccResolver) apply(opts ...dirResOption) error {
+func (dr *DirAccResolver) apply(opts ...DirResOption) error {
 	for _, o := range opts {
 		if err := o(dr); err != nil {
 			return err
@@ -3806,7 +3806,7 @@ func (dr *DirAccResolver) apply(opts ...dirResOption) error {
 	return nil
 }
 
-func NewDirAccResolver(path string, limit int64, syncInterval time.Duration, delete bool, opts ...dirResOption) (*DirAccResolver, error) {
+func NewDirAccResolver(path string, limit int64, syncInterval time.Duration, delete bool, opts ...DirResOption) (*DirAccResolver, error) {
 	if limit == 0 {
 		limit = math.MaxInt64
 	}
@@ -3883,7 +3883,7 @@ func (s *Server) fetch(res AccountResolver, name string, timeout time.Duration) 
 	return theJWT, err
 }
 
-func NewCacheDirAccResolver(path string, limit int64, ttl time.Duration, opts ...dirResOption) (*CacheDirAccResolver, error) {
+func NewCacheDirAccResolver(path string, limit int64, ttl time.Duration, opts ...DirResOption) (*CacheDirAccResolver, error) {
 	if limit <= 0 {
 		limit = 1_000
 	}

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3321,8 +3321,6 @@ func buildInternalNkeyUser(uc *jwt.UserClaims, acts map[string]struct{}, acc *Ac
 	return nu
 }
 
-const fetchTimeout = 2 * time.Second
-
 func fetchAccount(res AccountResolver, name string) (string, error) {
 	if !nkeys.IsValidPublicAccountKey(name) {
 		return "", fmt.Errorf("will only fetch valid account keys")
@@ -3412,7 +3410,7 @@ func NewURLAccResolver(url string) (*URLAccResolver, error) {
 	}
 	ur := &URLAccResolver{
 		url: url,
-		c:   &http.Client{Timeout: fetchTimeout, Transport: tr},
+		c:   &http.Client{Timeout: DEFAULT_ACCOUNT_FETCH_TIMEOUT, Transport: tr},
 	}
 	return ur, nil
 }
@@ -3442,6 +3440,7 @@ type DirAccResolver struct {
 	*DirJWTStore
 	*Server
 	syncInterval time.Duration
+	fetchTimeout time.Duration
 }
 
 func (dr *DirAccResolver) IsTrackingUpdate() bool {
@@ -3772,11 +3771,12 @@ func (dr *DirAccResolver) Fetch(name string) (string, error) {
 	} else {
 		dr.Lock()
 		srv := dr.Server
+		to := dr.fetchTimeout
 		dr.Unlock()
 		if srv == nil {
 			return "", err
 		}
-		return srv.fetch(dr, name) // lookup from other server
+		return srv.fetch(dr, name, to) // lookup from other server
 	}
 }
 
@@ -3784,7 +3784,29 @@ func (dr *DirAccResolver) Store(name, jwt string) error {
 	return dr.saveIfNewer(name, jwt)
 }
 
-func NewDirAccResolver(path string, limit int64, syncInterval time.Duration, delete bool) (*DirAccResolver, error) {
+type dirResOption func(s *DirAccResolver) error
+
+// limits the amount of time spent waiting for an account fetch to complete
+func FetchTimeout(to time.Duration) dirResOption {
+	return func(r *DirAccResolver) error {
+		if to <= time.Duration(0) {
+			return fmt.Errorf("Fetch timeout %v is too smal", to)
+		}
+		r.fetchTimeout = to
+		return nil
+	}
+}
+
+func (dr *DirAccResolver) apply(opts ...dirResOption) error {
+	for _, o := range opts {
+		if err := o(dr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func NewDirAccResolver(path string, limit int64, syncInterval time.Duration, delete bool, opts ...dirResOption) (*DirAccResolver, error) {
 	if limit == 0 {
 		limit = math.MaxInt64
 	}
@@ -3799,7 +3821,12 @@ func NewDirAccResolver(path string, limit int64, syncInterval time.Duration, del
 	if err != nil {
 		return nil, err
 	}
-	return &DirAccResolver{store, nil, syncInterval}, nil
+
+	res := &DirAccResolver{store, nil, syncInterval, DEFAULT_ACCOUNT_FETCH_TIMEOUT}
+	if err := res.apply(opts...); err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // Caching resolver using nats for lookups and making use of a directory for storage
@@ -3808,7 +3835,7 @@ type CacheDirAccResolver struct {
 	ttl time.Duration
 }
 
-func (s *Server) fetch(res AccountResolver, name string) (string, error) {
+func (s *Server) fetch(res AccountResolver, name string, timeout time.Duration) (string, error) {
 	if s == nil {
 		return "", ErrNoAccountResolver
 	}
@@ -3842,7 +3869,7 @@ func (s *Server) fetch(res AccountResolver, name string) (string, error) {
 	select {
 	case <-quit:
 		err = errors.New("fetching jwt failed due to shutdown")
-	case <-time.After(fetchTimeout):
+	case <-time.After(timeout):
 		err = errors.New("fetching jwt timed out")
 	case m := <-respC:
 		if err = res.Store(name, string(m)); err == nil {
@@ -3856,7 +3883,7 @@ func (s *Server) fetch(res AccountResolver, name string) (string, error) {
 	return theJWT, err
 }
 
-func NewCacheDirAccResolver(path string, limit int64, ttl time.Duration, _ ...dirJWTStoreOption) (*CacheDirAccResolver, error) {
+func NewCacheDirAccResolver(path string, limit int64, ttl time.Duration, opts ...dirResOption) (*CacheDirAccResolver, error) {
 	if limit <= 0 {
 		limit = 1_000
 	}
@@ -3864,7 +3891,11 @@ func NewCacheDirAccResolver(path string, limit int64, ttl time.Duration, _ ...di
 	if err != nil {
 		return nil, err
 	}
-	return &CacheDirAccResolver{DirAccResolver{store, nil, 0}, ttl}, nil
+	res := &CacheDirAccResolver{DirAccResolver{store, nil, 0, DEFAULT_ACCOUNT_FETCH_TIMEOUT}, ttl}
+	if err := res.apply(opts...); err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 func (dr *CacheDirAccResolver) Start(s *Server) error {

--- a/server/const.go
+++ b/server/const.go
@@ -200,4 +200,7 @@ const (
 
 	// DEFAULT GLOBAL_ACCOUNT
 	DEFAULT_GLOBAL_ACCOUNT = "$G"
+
+	// DEFAULT_FETCH_TIMEOUT is the default time that the system will wait for an account fetch to return.
+	DEFAULT_ACCOUNT_FETCH_TIMEOUT = 2 * time.Second
 )

--- a/server/opts.go
+++ b/server/opts.go
@@ -924,7 +924,7 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 			limit := int64(0)
 			ttl := time.Duration(0)
 			sync := time.Duration(0)
-			opts := []dirResOption{}
+			opts := []DirResOption{}
 			var err error
 			if v, ok := v["dir"]; ok {
 				_, v := unwrapValue(v, &lt)

--- a/server/opts.go
+++ b/server/opts.go
@@ -924,6 +924,7 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 			limit := int64(0)
 			ttl := time.Duration(0)
 			sync := time.Duration(0)
+			opts := []dirResOption{}
 			var err error
 			if v, ok := v["dir"]; ok {
 				_, v := unwrapValue(v, &lt)
@@ -949,6 +950,13 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 				_, v := unwrapValue(v, &lt)
 				sync, err = time.ParseDuration(v.(string))
 			}
+			if v, ok := v["timeout"]; err == nil && ok {
+				_, v := unwrapValue(v, &lt)
+				var to time.Duration
+				if to, err = time.ParseDuration(v.(string)); err == nil {
+					opts = append(opts, FetchTimeout(to))
+				}
+			}
 			if err != nil {
 				*errors = append(*errors, &configErr{tk, err.Error()})
 				return
@@ -970,12 +978,12 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 				if del {
 					*errors = append(*errors, &configErr{tk, "CACHE does not accept allow_delete"})
 				}
-				res, err = NewCacheDirAccResolver(dir, limit, ttl)
+				res, err = NewCacheDirAccResolver(dir, limit, ttl, opts...)
 			case "FULL":
 				if ttl != 0 {
 					*errors = append(*errors, &configErr{tk, "FULL does not accept ttl"})
 				}
-				res, err = NewDirAccResolver(dir, limit, sync, del)
+				res, err = NewDirAccResolver(dir, limit, sync, del, opts...)
 			}
 			if err != nil {
 				*errors = append(*errors, &configErr{tk, err.Error()})


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

Just in case as per our conversation
The change in signature to NewCacheDirAccResolver and NewDirAccResolver are backwards compatible.
I left URLAccResolver unchanged for now.
The resolver being public, made this a little more involved