### PR TITLE
[fixed] issue with concurrent account fetch when account was incomplete

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -110,9 +110,6 @@ var (
 	// ErrAccountResolverUpdateTooSoon is returned when we attempt an update too soon to last request.
 	ErrAccountResolverUpdateTooSoon = errors.New("account resolver update too soon")
 
-	// ErrAccountResolverSameClaims is returned when same claims have been fetched.
-	ErrAccountResolverSameClaims = errors.New("account resolver no new claims")
-
 	// ErrStreamImportAuthorization is returned when a stream import is not authorized.
 	ErrStreamImportAuthorization = errors.New("stream import not authorized")
 

--- a/server/reload.go
+++ b/server/reload.go
@@ -1391,8 +1391,7 @@ func (s *Server) reloadAuthorization() {
 				s.mu.Unlock()
 				accClaims, claimJWT, _ := s.fetchAccountClaims(accName)
 				if accClaims != nil {
-					err := s.updateAccountWithClaimJWT(acc, claimJWT)
-					if err != nil && err != ErrAccountResolverSameClaims {
+					if err := s.updateAccountWithClaimJWT(acc, claimJWT); err != nil {
 						s.Noticef("Reloaded: deleting account [bad claims]: %q", accName)
 						s.accounts.Delete(k)
 					}

--- a/server/server.go
+++ b/server/server.go
@@ -1318,9 +1318,12 @@ func (s *Server) updateAccountWithClaimJWT(acc *Account, claimJWT string) error 
 	if acc == nil {
 		return ErrMissingAccount
 	}
-	if acc.claimJWT != "" && acc.claimJWT == claimJWT && !acc.incomplete {
+	acc.mu.Lock()
+	sameClaim := acc.claimJWT != "" && acc.claimJWT == claimJWT && !acc.incomplete
+	acc.mu.Unlock()
+	if sameClaim {
 		s.Debugf("Requested account update for [%s], same claims detected", acc.Name)
-		return ErrAccountResolverSameClaims
+		return nil
 	}
 	accClaims, _, err := s.verifyAccountClaims(claimJWT)
 	if err == nil && accClaims != nil {
@@ -1332,9 +1335,13 @@ func (s *Server) updateAccountWithClaimJWT(acc *Account, claimJWT string) error 
 			acc.mu.Unlock()
 			return ErrAccountValidation
 		}
-		acc.claimJWT = claimJWT
 		acc.mu.Unlock()
 		s.UpdateAccountClaims(acc, accClaims)
+		acc.mu.Lock()
+		// needs to be set after update completed.
+		// This causes concurrent calls to return with sameClaim=true if the change is effective.
+		acc.claimJWT = claimJWT
+		acc.mu.Unlock()
 		return nil
 	}
 	return err
@@ -1409,10 +1416,7 @@ func (s *Server) fetchAccount(name string) (*Account, error) {
 	// registered and we should use this one.
 	if racc := s.registerAccount(acc); racc != nil {
 		// Update with the new claims in case they are new.
-		// Following call will ignore ErrAccountResolverSameClaims
-		// if claims are the same.
-		err = s.updateAccountWithClaimJWT(racc, claimJWT)
-		if err != nil && err != ErrAccountResolverSameClaims {
+		if err = s.updateAccountWithClaimJWT(racc, claimJWT); err != nil {
 			return nil, err
 		}
 		return racc, nil

--- a/server/server.go
+++ b/server/server.go
@@ -1318,9 +1318,9 @@ func (s *Server) updateAccountWithClaimJWT(acc *Account, claimJWT string) error 
 	if acc == nil {
 		return ErrMissingAccount
 	}
-	acc.mu.Lock()
+	acc.mu.RLock()
 	sameClaim := acc.claimJWT != "" && acc.claimJWT == claimJWT && !acc.incomplete
-	acc.mu.Unlock()
+	acc.mu.RUnlock()
 	if sameClaim {
 		s.Debugf("Requested account update for [%s], same claims detected", acc.Name)
 		return nil


### PR DESCRIPTION
This happened when a dummy (expired/incomplete) account was created during
a route operation. The dummy was to avoid fetching the account, which would
cause a lock inversion.
When a non route request required the account, we'd download it as it is
set to expired.
A concurrent request would result in ErrAccountResolverSameClaims which
the caller did not handle.
Fix is to remove ErrAccountResolverSameClaims.

Signed-off-by: Matthias Hanel <mh@synadia.com>
