### PR TITLE
Consolidate temporary test files and directories

### DIFF
--- a/server/configs/cluster.conf
+++ b/server/configs/cluster.conf
@@ -9,7 +9,7 @@ authorization {
   timeout:  1
 }
 
-pid_file: '/tmp/nats_cluster_test.pid'
+pid_file: '/tmp/nats-server/nats_cluster_test.pid'
 
 cluster {
   host: 127.0.0.1

--- a/server/configs/js-op.conf
+++ b/server/configs/js-op.conf
@@ -6,7 +6,7 @@ server_name: "S1"
 
 # The test will cleanup this directory so if you change it search for the test.
 jetstream {
-  store_dir: "/tmp/js-op-test"
+  store_dir: "/tmp/nats-server/js-op-test"
 }
 
 operator = "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJqdGkiOiIyUkc0WjJKVzYzSUtBS1czSFg0SkpMQVhRN1ZSM0NKVlRQU1FHUVRCU0ZFQjVKTkNISUpRIiwiaWF0IjoxNjE2MTg2MjAxLCJpc3MiOiJPRDRNNklBQUtRU000RFFTTFdaSVZCQUNZVFlTMlM2WFFTN1U2N1hYWVhKNDRJTE5FMzVZUEdKSyIsIm5hbWUiOiJqcy10ZXN0Iiwic3ViIjoiT0Q0TTZJQUFLUVNNNERRU0xXWklWQkFDWVRZUzJTNlhRUzdVNjdYWFlYSjQ0SUxORTM1WVBHSksiLCJuYXRzIjp7InR5cGUiOiJvcGVyYXRvciIsInZlcnNpb24iOjJ9fQ.VkjSK2BlMmtYfVJSkC9aZEFvjg4BXzbd0oXkQa3Rlkhh8EuSRU7-Tp1zUm1SveBb6dZXsE51vhIQFQY66fO0Bw"
@@ -17,7 +17,7 @@ system_account = "AD4M34OPRUPWDYTIQLWKMEZZM5MK7PQQDSKNELCZDRZZEVFWOWPLFTUE"
 resolver {
     type: full
     # Directory in which the account jwt will be stored
-    dir: "/tmp/js-op-test/jwts"
+    dir: "/tmp/nats-server/js-op-test/jwts"
     allow_delete: true
     interval: "10s"
 }

--- a/server/configs/test.conf
+++ b/server/configs/test.conf
@@ -22,7 +22,7 @@ syslog: true
 remote_syslog: "udp://foo.com:33"
 
 # pid file
-pid_file: "/tmp/nats-server.pid"
+pid_file: "/tmp/nats-server/nats-server.pid"
 
 # prof_port
 prof_port: 6543

--- a/server/dirstore_test.go
+++ b/server/dirstore_test.go
@@ -90,8 +90,7 @@ func require_Len(t *testing.T, a, b int) {
 
 func TestShardedDirStoreWriteAndReadonly(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
 
 	store, err := NewDirJWTStore(dir, true, false)
 	require_NoError(t, err)
@@ -144,8 +143,7 @@ func TestShardedDirStoreWriteAndReadonly(t *testing.T) {
 
 func TestUnshardedDirStoreWriteAndReadonly(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
 
 	store, err := NewDirJWTStore(dir, false, false)
 	require_NoError(t, err)
@@ -206,12 +204,11 @@ func TestNoCreateRequiresDir(t *testing.T) {
 
 func TestCreateMakesDir(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
 
 	fullPath := filepath.Join(dir, "a/b")
 
-	_, err = os.Stat(fullPath)
+	_, err := os.Stat(fullPath)
 	require_Error(t, err)
 	require_True(t, os.IsNotExist(err))
 
@@ -225,12 +222,9 @@ func TestCreateMakesDir(t *testing.T) {
 
 func TestShardedDirStorePackMerge(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
-	dir2, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
-	dir3, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
+	dir2 := createDir(t, "jwtstore_test")
+	dir3 := createDir(t, "jwtstore_test")
 
 	store, err := NewDirJWTStore(dir, true, false)
 	require_NoError(t, err)
@@ -303,10 +297,8 @@ func TestShardedDirStorePackMerge(t *testing.T) {
 
 func TestShardedToUnsharedDirStorePackMerge(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
-	dir2, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
+	dir2 := createDir(t, "jwtstore_test")
 
 	store, err := NewDirJWTStore(dir, true, false)
 	require_NoError(t, err)
@@ -364,8 +356,7 @@ func TestShardedToUnsharedDirStorePackMerge(t *testing.T) {
 
 func TestMergeOnlyOnNewer(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
 
 	dirStore, err := NewDirJWTStore(dir, true, false)
 	require_NoError(t, err)
@@ -438,8 +429,7 @@ func assertStoreSize(t *testing.T, dirStore *DirJWTStore, length int) {
 
 func TestExpiration(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
 
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*50, 10, true, 0, nil)
 	require_NoError(t, err)
@@ -476,8 +466,7 @@ func TestExpiration(t *testing.T) {
 
 func TestLimit(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
 
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*100, 5, true, 0, nil)
 	require_NoError(t, err)
@@ -519,8 +508,7 @@ func TestLimit(t *testing.T) {
 
 func TestLimitNoEvict(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
 
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*50, 2, false, 0, nil)
 	require_NoError(t, err)
@@ -572,8 +560,7 @@ func TestLimitNoEvict(t *testing.T) {
 
 func TestLruLoad(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*100, 2, true, 0, nil)
 	require_NoError(t, err)
 	defer dirStore.Close()
@@ -605,8 +592,7 @@ func TestLruLoad(t *testing.T) {
 
 func TestLruVolume(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
 
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*50, 2, true, 0, nil)
 	require_NoError(t, err)
@@ -648,8 +634,7 @@ func TestLruVolume(t *testing.T) {
 
 func TestLru(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
 
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*50, 2, true, 0, nil)
 	require_NoError(t, err)
@@ -698,8 +683,7 @@ func TestLru(t *testing.T) {
 
 func TestReload(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
 	notificationChan := make(chan struct{}, 5)
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*100, 2, true, 0, func(publicKey string) {
 		notificationChan <- struct{}{}
@@ -760,8 +744,7 @@ func TestReload(t *testing.T) {
 
 func TestExpirationUpdate(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
 
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*50, 10, true, 0, nil)
 	require_NoError(t, err)
@@ -819,8 +802,7 @@ func TestExpirationUpdate(t *testing.T) {
 
 func TestTTL(t *testing.T) {
 	t.Parallel()
-	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dir := createDir(t, "jwtstore_test")
 	require_OneJWT := func() {
 		t.Helper()
 		f, err := ioutil.ReadDir(dir)
@@ -883,8 +865,7 @@ func TestRemove(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
-			dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-			require_NoError(t, err)
+			dir := createDir(t, "jwtstore_test")
 			require_OneJWT := func() {
 				t.Helper()
 				f, err := ioutil.ReadDir(dir)
@@ -937,8 +918,7 @@ func TestNotificationOnPack(t *testing.T) {
 		}
 		notificationChan <- struct{}{}
 	}
-	dirPack, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-	require_NoError(t, err)
+	dirPack := createDir(t, "jwtstore_test")
 	packStore, err := NewExpiringDirJWTStore(dirPack, false, false, NoDelete, infDur, 0, true, 0, notification)
 	require_NoError(t, err)
 	// prefill the store with data
@@ -953,8 +933,7 @@ func TestNotificationOnPack(t *testing.T) {
 	packStore.Close()
 	hash := packStore.Hash()
 	for _, shard := range []bool{true, false, true, false} {
-		dirMerge, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-		require_NoError(t, err)
+		dirMerge := createDir(t, "jwtstore_test")
 		mergeStore, err := NewExpiringDirJWTStore(dirMerge, shard, false, NoDelete, infDur, 0, true, 0, notification)
 		require_NoError(t, err)
 		// set
@@ -994,8 +973,7 @@ func TestNotificationOnPackWalk(t *testing.T) {
 	const iterCnt = 8
 	store := [storeCnt]*DirJWTStore{}
 	for i := 0; i < storeCnt; i++ {
-		dirMerge, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
-		require_NoError(t, err)
+		dirMerge := createDir(t, "jwtstore_test")
 		mergeStore, err := NewExpiringDirJWTStore(dirMerge, true, false, NoDelete, infDur, 0, true, 0, nil)
 		require_NoError(t, err)
 		store[i] = mergeStore

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestFileStoreBasics(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -102,7 +102,7 @@ func TestFileStoreBasics(t *testing.T) {
 }
 
 func TestFileStoreMsgHeaders(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -131,7 +131,7 @@ func TestFileStoreMsgHeaders(t *testing.T) {
 }
 
 func TestFileStoreBasicWriteMsgsAndRestore(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -265,7 +265,7 @@ func TestFileStoreBasicWriteMsgsAndRestore(t *testing.T) {
 }
 
 func TestFileStoreSelectNextFirst(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -305,7 +305,7 @@ func TestFileStoreSelectNextFirst(t *testing.T) {
 }
 
 func TestFileStoreSkipMsg(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -394,7 +394,7 @@ func TestFileStoreSkipMsg(t *testing.T) {
 }
 
 func TestFileStoreWriteExpireWrite(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -459,7 +459,7 @@ func TestFileStoreWriteExpireWrite(t *testing.T) {
 }
 
 func TestFileStoreMsgLimit(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -497,7 +497,7 @@ func TestFileStoreMsgLimit(t *testing.T) {
 }
 
 func TestFileStoreMsgLimitBug(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -526,7 +526,7 @@ func TestFileStoreBytesLimit(t *testing.T) {
 	toStore := uint64(1024)
 	maxBytes := storedMsgSize * toStore
 
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -571,7 +571,7 @@ func TestFileStoreBytesLimit(t *testing.T) {
 func TestFileStoreAgeLimit(t *testing.T) {
 	maxAge := 10 * time.Millisecond
 
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -618,7 +618,7 @@ func TestFileStoreAgeLimit(t *testing.T) {
 }
 
 func TestFileStoreTimeStamps(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -648,7 +648,7 @@ func TestFileStoreTimeStamps(t *testing.T) {
 }
 
 func TestFileStorePurge(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -766,7 +766,7 @@ func TestFileStorePurge(t *testing.T) {
 }
 
 func TestFileStoreCompact(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -811,7 +811,7 @@ func TestFileStoreCompact(t *testing.T) {
 }
 
 func TestFileStoreCompactLastPlusOne(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -848,7 +848,7 @@ func TestFileStoreCompactLastPlusOne(t *testing.T) {
 func TestFileStoreCompactPerf(t *testing.T) {
 	t.SkipNow()
 
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -885,7 +885,7 @@ func TestFileStoreCompactPerf(t *testing.T) {
 }
 
 func TestFileStoreStreamTruncate(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -955,7 +955,7 @@ func TestFileStoreStreamTruncate(t *testing.T) {
 }
 
 func TestFileStoreRemovePartialRecovery(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -1001,7 +1001,7 @@ func TestFileStoreRemovePartialRecovery(t *testing.T) {
 }
 
 func TestFileStoreRemoveOutOfOrderRecovery(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -1069,7 +1069,7 @@ func TestFileStoreRemoveOutOfOrderRecovery(t *testing.T) {
 func TestFileStoreAgeLimitRecovery(t *testing.T) {
 	maxAge := 10 * time.Millisecond
 
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -1115,7 +1115,7 @@ func TestFileStoreAgeLimitRecovery(t *testing.T) {
 }
 
 func TestFileStoreBitRot(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -1178,7 +1178,7 @@ func TestFileStoreBitRot(t *testing.T) {
 }
 
 func TestFileStoreEraseMsg(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -1237,7 +1237,7 @@ func TestFileStoreEraseMsg(t *testing.T) {
 }
 
 func TestFileStoreEraseAndNoIndexRecovery(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -1292,7 +1292,7 @@ func TestFileStoreEraseAndNoIndexRecovery(t *testing.T) {
 }
 
 func TestFileStoreMeta(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -1388,7 +1388,7 @@ func TestFileStoreMeta(t *testing.T) {
 }
 
 func TestFileStoreWriteAndReadSameBlock(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -1412,7 +1412,7 @@ func TestFileStoreWriteAndReadSameBlock(t *testing.T) {
 }
 
 func TestFileStoreAndRetrieveMultiBlock(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -1453,7 +1453,7 @@ func TestFileStoreAndRetrieveMultiBlock(t *testing.T) {
 }
 
 func TestFileStoreCollapseDmap(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -1531,7 +1531,7 @@ func TestFileStoreReadCache(t *testing.T) {
 	subj, msg := "foo.bar", make([]byte, 1024)
 	storedMsgSize := fileStoreMsgSize(subj, nil, msg)
 
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -1583,7 +1583,7 @@ func TestFileStoreReadCache(t *testing.T) {
 }
 
 func TestFileStorePartialCacheExpiration(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -1609,7 +1609,7 @@ func TestFileStorePartialCacheExpiration(t *testing.T) {
 }
 
 func TestFileStorePartialIndexes(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -1657,7 +1657,7 @@ func TestFileStorePartialIndexes(t *testing.T) {
 }
 
 func TestFileStoreSnapshot(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -1722,7 +1722,7 @@ func TestFileStoreSnapshot(t *testing.T) {
 		r := bytes.NewReader(snap)
 		tr := tar.NewReader(s2.NewReader(r))
 
-		rstoreDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+		rstoreDir := createDir(t, JetStreamStoreDir)
 		defer os.RemoveAll(rstoreDir)
 
 		for {
@@ -1832,7 +1832,7 @@ func TestFileStoreSnapshot(t *testing.T) {
 }
 
 func TestFileStoreConsumer(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -2054,7 +2054,7 @@ func TestFileStorePerf(t *testing.T) {
 		friendlyBytes(int64(toStore*storedMsgSize)),
 	)
 
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -2193,7 +2193,7 @@ func TestFileStoreReadBackMsgPerf(t *testing.T) {
 		friendlyBytes(int64(toStore*storedMsgSize)),
 	)
 
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 	fmt.Printf("StoreDir is %q\n", storeDir)
@@ -2244,7 +2244,7 @@ func TestFileStoreStoreLimitRemovePerf(t *testing.T) {
 	// 1GB
 	toStore := 1 * 1024 * 1024 * 1024 / storedMsgSize
 
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -2301,7 +2301,7 @@ func TestFileStorePubPerfWithSmallBlkSize(t *testing.T) {
 		friendlyBytes(int64(toStore*storedMsgSize)),
 	)
 
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -2327,7 +2327,7 @@ func TestFileStorePubPerfWithSmallBlkSize(t *testing.T) {
 
 // Saw this manifest from a restart test with max delivered set for JetStream.
 func TestFileStoreConsumerRedeliveredLost(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -2394,7 +2394,7 @@ func TestFileStoreConsumerRedeliveredLost(t *testing.T) {
 }
 
 func TestFileStoreConsumerFlusher(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -2429,7 +2429,7 @@ func TestFileStoreConsumerFlusher(t *testing.T) {
 }
 
 func TestFileStoreConsumerDeliveredUpdates(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -2487,7 +2487,7 @@ func TestFileStoreConsumerDeliveredUpdates(t *testing.T) {
 }
 
 func TestFileStoreConsumerDeliveredAndAckUpdates(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -2604,7 +2604,7 @@ func TestFileStoreConsumerDeliveredAndAckUpdates(t *testing.T) {
 }
 
 func TestFileStoreStreamStateDeleted(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -2656,7 +2656,7 @@ func TestFileStoreConsumerPerf(t *testing.T) {
 	// Comment out to run, holding place for now.
 	t.SkipNow()
 
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
 	defer os.RemoveAll(storeDir)
 
@@ -2728,7 +2728,7 @@ func TestFileStoreConsumerPerf(t *testing.T) {
 func TestFileStoreStreamIndexBug(t *testing.T) {
 	// https://github.com/nats-io/jetstream/issues/406
 	badIdxBytes, _ := base64.StdEncoding.DecodeString("FgGBkw7D/f8/772iDPDIgbU=")
-	dir, _ := ioutil.TempDir("", "js-bad-idx-")
+	dir := createDir(t, "js-bad-idx-")
 	defer os.RemoveAll(dir)
 	fn := path.Join(dir, "1.idx")
 	ioutil.WriteFile(fn, badIdxBytes, 0644)
@@ -2740,7 +2740,7 @@ func TestFileStoreStreamIndexBug(t *testing.T) {
 
 // Reported by Ivan.
 func TestFileStoreStreamDeleteCacheBug(t *testing.T) {
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir := createDir(t, JetStreamStoreDir)
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, CacheExpire: 50 * time.Millisecond}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -4821,13 +4821,13 @@ func TestJetStreamClusterSuperClusterInterestOnlyMode(t *testing.T) {
 			gateways = [{name: %s, urls: ["nats://127.0.0.1:%d"]}]
 		}
 	`
-	storeDir1, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir1 := createDir(t, JetStreamStoreDir)
 	conf1 := createConfFile(t, []byte(fmt.Sprintf(template,
 		"S1", storeDir1, "", 33222, "A", 33222, "A", 11222, "B", 11223)))
 	s1, o1 := RunServerWithConfig(conf1)
 	defer s1.Shutdown()
 
-	storeDir2, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir2 := createDir(t, JetStreamStoreDir)
 	conf2 := createConfFile(t, []byte(fmt.Sprintf(template,
 		"S2", storeDir2, "", 33223, "B", 33223, "B", 11223, "A", 11222)))
 	s2, o2 := RunServerWithConfig(conf2)
@@ -5397,7 +5397,7 @@ func createJetStreamSuperCluster(t *testing.T, numServersPer, numClusters int) *
 		routeConfig := strings.Join(routes, ",")
 
 		for si := 0; si < numServersPer; si++ {
-			storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+			storeDir := createDir(t, JetStreamStoreDir)
 			sn := fmt.Sprintf("%s-S%d", cn, si+1)
 			bconf := fmt.Sprintf(jsClusterTempl, sn, storeDir, cn, cp+si, routeConfig)
 			conf := fmt.Sprintf(jsSuperClusterTempl, bconf, cn, gp, gwconf)
@@ -5582,7 +5582,7 @@ func createJetStreamClusterWithTemplate(t *testing.T, tmpl string, clusterName s
 	c := &cluster{servers: make([]*Server, 0, numServers), opts: make([]*Options, 0, numServers), name: clusterName}
 
 	for cp := startClusterPort; cp < startClusterPort+numServers; cp++ {
-		storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+		storeDir := createDir(t, JetStreamStoreDir)
 		sn := fmt.Sprintf("S-%d", cp-startClusterPort+1)
 		conf := fmt.Sprintf(tmpl, sn, storeDir, clusterName, cp, routeConfig)
 		s, o := RunServerWithConfig(createConfFile(t, []byte(conf)))
@@ -5601,7 +5601,7 @@ func createJetStreamClusterWithTemplate(t *testing.T, tmpl string, clusterName s
 func (c *cluster) addInNewServer() *Server {
 	c.t.Helper()
 	sn := fmt.Sprintf("S-%d", len(c.servers)+1)
-	storeDir, _ := ioutil.TempDir("", JetStreamStoreDir)
+	storeDir, _ := ioutil.TempDir(tempRoot, JetStreamStoreDir)
 	seedRoute := fmt.Sprintf("nats-route://127.0.0.1:%d", c.opts[0].Cluster.Port)
 	conf := fmt.Sprintf(jsClusterTempl, sn, storeDir, c.name, -1, seedRoute)
 	s, o := RunServerWithConfig(createConfFile(c.t, []byte(conf)))

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -83,7 +83,7 @@ func RunBasicJetStreamServer() *Server {
 	opts := DefaultTestOptions
 	opts.Port = -1
 	opts.JetStream = true
-	tdir, _ := ioutil.TempDir(os.TempDir(), "jstests-storedir-")
+	tdir, _ := ioutil.TempDir(tempRoot, "jstests-storedir-")
 	opts.StoreDir = tdir
 	return RunServer(&opts)
 }
@@ -4140,7 +4140,7 @@ func TestJetStreamSnapshotsAPI(t *testing.T) {
 	opts := DefaultTestOptions
 	opts.ServerName = "S"
 	opts.Port = -1
-	tdir, _ := ioutil.TempDir(os.TempDir(), "jstests-storedir-")
+	tdir := createDir(t, "jstests-storedir-")
 	opts.JetStream = true
 	opts.StoreDir = tdir
 	rurl, _ := url.Parse(fmt.Sprintf("nats-leaf://%s:%d", lopts.LeafNode.Host, lopts.LeafNode.Port))

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/url"
@@ -2317,10 +2316,7 @@ func TestLeafNodeRouteParseLSUnsub(t *testing.T) {
 }
 
 func TestLeafNodeOperatorBadCfg(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "_nats-server")
-	if err != nil {
-		t.Fatal("Could not create tmp dir")
-	}
+	tmpDir := createDir(t, "_nats-server")
 	defer os.RemoveAll(tmpDir)
 	for errorText, cfg := range map[string]string{
 		"operator mode does not allow specifying user in leafnode config": `

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -188,15 +188,9 @@ func TestFileLoggerSizeLimitAndReopen(t *testing.T) {
 	s := &Server{opts: &Options{}}
 	defer s.SetLogger(nil, false, false)
 
-	tmpDir, err := ioutil.TempDir("", "nats-server")
-	if err != nil {
-		t.Fatal("Could not create tmp dir")
-	}
+	tmpDir := createDir(t, "nats-server")
 	defer os.RemoveAll(tmpDir)
-	file, err := ioutil.TempFile(tmpDir, "log_")
-	if err != nil {
-		t.Fatalf("Could not create the temp file: %v", err)
-	}
+	file := createFileAtDir(t, tmpDir, "log_")
 	file.Close()
 
 	// Set a File log

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
@@ -103,7 +104,7 @@ func TestConfigFile(t *testing.T) {
 		Logtime:               false,
 		HTTPPort:              8222,
 		HTTPBasePath:          "/nats",
-		PidFile:               "/tmp/nats-server.pid",
+		PidFile:               filepath.Join(tempRoot, "nats-server.pid"),
 		ProfPort:              6543,
 		Syslog:                true,
 		RemoteSyslog:          "udp://foo.com:33",
@@ -260,7 +261,7 @@ func TestMergeOverrides(t *testing.T) {
 		Logtime:        false,
 		HTTPPort:       DEFAULT_HTTP_PORT,
 		HTTPBasePath:   DEFAULT_HTTP_BASE_PATH,
-		PidFile:        "/tmp/nats-server.pid",
+		PidFile:        filepath.Join(tempRoot, "nats-server.pid"),
 		ProfPort:       6789,
 		Syslog:         true,
 		RemoteSyslog:   "udp://foo.com:33",
@@ -1167,7 +1168,7 @@ func TestOptionsClone(t *testing.T) {
 		Logtime:        false,
 		HTTPPort:       DEFAULT_HTTP_PORT,
 		HTTPBasePath:   DEFAULT_HTTP_BASE_PATH,
-		PidFile:        "/tmp/nats-server.pid",
+		PidFile:        filepath.Join(tempRoot, "nats-server.pid"),
 		ProfPort:       6789,
 		Syslog:         true,
 		RemoteSyslog:   "udp://foo.com:33",
@@ -1838,7 +1839,7 @@ func TestParseExport(t *testing.T) {
 			}
 			accI1 {
 				imports [{
-					service { 
+					service {
 						account accE
 						subject foo.accI1
 					}
@@ -1852,7 +1853,7 @@ func TestParseExport(t *testing.T) {
 				users [{
 					user u1
 					password pwd
-				}], 
+				}],
 			}
 			accI2 {
 				imports [{
@@ -2950,7 +2951,7 @@ func TestQueuePermissions(t *testing.T) {
 		listen: 127.0.0.1:-1
 		no_auth_user: u
 		authorization {
-			users [{ 
+			users [{
 				user: u, password: pwd, permissions: { sub: { %s: ["foo.> *.dev"] } }
 			}]
 		}`

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -67,10 +67,7 @@ func newOptionsFromContent(t *testing.T, content []byte) (*Options, string) {
 
 func createConfFile(t *testing.T, content []byte) string {
 	t.Helper()
-	conf, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("Error creating conf file: %v", err)
-	}
+	conf := createFile(t, "")
 	fName := conf.Name()
 	conf.Close()
 	if err := ioutil.WriteFile(fName, content, 0666); err != nil {

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -80,7 +81,7 @@ func TestRouteConfig(t *testing.T) {
 			NoAdvertise:    true,
 			ConnectRetries: 2,
 		},
-		PidFile: "/tmp/nats_cluster_test.pid",
+		PidFile: filepath.Join(tempRoot, "nats_cluster_test.pid"),
 	}
 
 	// Setup URLs

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1577,10 +1577,7 @@ func TestConnectErrorReports(t *testing.T) {
 		t.Fatalf("Expected default value to be %v, got %v", DEFAULT_CONNECT_ERROR_REPORTS, ra)
 	}
 
-	tmpFile, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("Error creating temp file: %v", err)
-	}
+	tmpFile := createFile(t, "")
 	log := tmpFile.Name()
 	tmpFile.Close()
 	defer os.Remove(log)
@@ -1732,10 +1729,7 @@ func TestReconnectErrorReports(t *testing.T) {
 		t.Fatalf("Expected default value to be %v, got %v", DEFAULT_RECONNECT_ERROR_REPORTS, ra)
 	}
 
-	tmpFile, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("Error creating temp file: %v", err)
-	}
+	tmpFile := createFile(t, "")
 	log := tmpFile.Name()
 	tmpFile.Close()
 	defer os.Remove(log)
@@ -1919,16 +1913,10 @@ func TestReconnectErrorReports(t *testing.T) {
 }
 
 func TestServerLogsConfigurationFile(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "_nats-server")
-	if err != nil {
-		t.Fatal("Could not create tmp dir")
-	}
+	tmpDir := createDir(t, "_nats-server")
 	defer os.RemoveAll(tmpDir)
 
-	file, err := ioutil.TempFile(tmpDir, "nats_server_log_")
-	if err != nil {
-		t.Fatalf("Could not create the temp file: %v", err)
-	}
+	file := createFileAtDir(t, tmpDir, "nats_server_log_")
 	file.Close()
 
 	conf := createConfFile(t, []byte(fmt.Sprintf(`

--- a/test/pid_test.go
+++ b/test/pid_test.go
@@ -23,16 +23,10 @@ import (
 func TestPidFile(t *testing.T) {
 	opts := DefaultTestOptions
 
-	tmpDir, err := ioutil.TempDir("", "_nats-server")
-	if err != nil {
-		t.Fatal("Could not create tmp dir")
-	}
+	tmpDir := createDir(t, "_nats-server")
 	defer os.RemoveAll(tmpDir)
 
-	file, err := ioutil.TempFile(tmpDir, "nats-server:pid_")
-	if err != nil {
-		t.Fatalf("Unable to create temp file: %v", err)
-	}
+	file := createFileAtDir(t, tmpDir, "nats-server:pid_")
 	file.Close()
 	opts.PidFile = file.Name()
 

--- a/test/ports_test.go
+++ b/test/ports_test.go
@@ -46,7 +46,7 @@ func portFile(dirname string) string {
 }
 
 func TestPortsFile(t *testing.T) {
-	portFileDir := os.TempDir()
+	portFileDir := createDir(t, "")
 
 	opts := DefaultTestOptions
 	opts.PortsFileDir = portFileDir
@@ -124,10 +124,7 @@ func TestPortsFile(t *testing.T) {
 // the location of the ports file is changed from dir A to dir B.
 func TestPortsFileReload(t *testing.T) {
 	// make a temp dir
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Error creating temp director (%s): %v", tempDir, err)
-	}
+	tempDir := createDir(t, "")
 	defer os.RemoveAll(tempDir)
 
 	// make child temp dir A

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -1083,10 +1083,7 @@ func TestRouteBasicPermissions(t *testing.T) {
 
 func createConfFile(t *testing.T, content []byte) string {
 	t.Helper()
-	conf, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatalf("Error creating conf file: %v", err)
-	}
+	conf := createFile(t, "")
 	fName := conf.Name()
 	conf.Close()
 	if err := ioutil.WriteFile(fName, content, 0666); err != nil {

--- a/test/test.go
+++ b/test/test.go
@@ -19,7 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
+	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -29,6 +32,8 @@ import (
 
 	"github.com/nats-io/nats-server/v2/server"
 )
+
+var tempRoot = filepath.Join(os.TempDir(), "nats-server")
 
 // So we can pass tests and benchmarks..
 type tLogger interface {
@@ -553,4 +558,33 @@ func nextServerOpts(opts *server.Options) *server.Options {
 	nopts.Cluster.Port++
 	nopts.HTTPPort++
 	return nopts
+}
+
+func createDir(t *testing.T, prefix string) string {
+	t.Helper()
+	if err := os.MkdirAll(tempRoot, 0700); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := ioutil.TempDir(tempRoot, prefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func createFile(t *testing.T, prefix string) *os.File {
+	t.Helper()
+	if err := os.MkdirAll(tempRoot, 0700); err != nil {
+		t.Fatal(err)
+	}
+	return createFileAtDir(t, tempRoot, prefix)
+}
+
+func createFileAtDir(t *testing.T, dir, prefix string) *os.File {
+	t.Helper()
+	f, err := ioutil.TempFile(dir, prefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f
 }

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -799,10 +799,7 @@ func TestTLSRoutesCertificateImplicitAllowFail(t *testing.T) {
 func testTLSRoutesCertificateImplicitAllow(t *testing.T, pass bool) {
 	t.Helper()
 	// Base config for the servers
-	cfg, err := ioutil.TempFile("", "cfg")
-	if err != nil {
-		t.Fatal(err)
-	}
+	cfg := createFile(t, "cfg")
 	defer os.Remove(cfg.Name())
 	cfg.WriteString(fmt.Sprintf(`
 		cluster {
@@ -816,7 +813,7 @@ func testTLSRoutesCertificateImplicitAllow(t *testing.T, pass bool) {
 		  }
 		}
 	`, !pass)) // set insecure to skip verification on the outgoing end
-	if err = cfg.Sync(); err != nil {
+	if err := cfg.Sync(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -870,10 +867,7 @@ func TestTLSGatewaysCertificateImplicitAllowFail(t *testing.T) {
 func testTLSGatewaysCertificateImplicitAllow(t *testing.T, pass bool) {
 	t.Helper()
 	// Base config for the servers
-	cfg, err := ioutil.TempFile("", "cfg")
-	if err != nil {
-		t.Fatal(err)
-	}
+	cfg := createFile(t, "cfg")
 	defer os.Remove(cfg.Name())
 	cfg.WriteString(fmt.Sprintf(`
 		gateway {
@@ -887,7 +881,7 @@ func testTLSGatewaysCertificateImplicitAllow(t *testing.T, pass bool) {
 		  }
 		}
 	`, !pass)) // set insecure to skip verification on the outgoing end
-	if err = cfg.Sync(); err != nil {
+	if err := cfg.Sync(); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Currently, temporary test files and directories are written to lots of different paths within the OS's temp dir. This makes it hard to know which files are from nats-server and which are unrelated. This in turn makes it hard to clean up nats-server test files.

Instead, this change puts temporary test files into two directories:
* TMPDIR/nats - used to test defaults
* TMPDIR/nats-server - used repo name to hold everything else

**Before change** - After 1 `go test ./...` (every subsequent test run grows the number of files in this directory):
```
$ ls /tmp
173187694  758384159           jetstream222581463  jetstream731178586      nats
275273063  770437285           jetstream297313931  jetstream921343952      v1cWZsv
282940336  804279746           jetstream360981205  jetstream941867353
301967458  932809039           jetstream364189665  jetstream965947266
569229948  994643904           jetstream382173071  jetstream974025059
582056346  dbus-Y76rQ4hRym     jetstream581541160  jwtstore_test117547623
669643602  jetstream106609228  jetstream633157918  jwtstore_test317659565
683294450  jetstream121232723  jetstream658654030  jwtstore_test712025896
```

**After change** - After 1 `go test ./...`:
```
$ ls
dbus-Y76rQ4hRym  v1cWZsv
nats
nats-server
```

/cc @nats-io/core
