### PR TITLE
Report an error if we fail to load an account on a stream assignment.

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -600,6 +600,7 @@ var (
 	jsClusterNoPeersErr    = &ApiError{Code: 400, Description: "no suitable peers for placement"}
 	jsServerNotMemberErr   = &ApiError{Code: 400, Description: "server is not a member of the cluster"}
 	jsNoMessageFoundErr    = &ApiError{Code: 404, Description: "no message found"}
+	jsNoAccountErr         = &ApiError{Code: 503, Description: "account not found"}
 )
 
 // For easier handling of exports and imports.

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -5284,6 +5284,26 @@ func TestJetStreamClusterServerLimits(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterAccountLoadFailure(t *testing.T) {
+	c := createJetStreamClusterWithTemplate(t, jsClusterLimitsTempl, "R3L", 3)
+	defer c.shutdown()
+
+	// Client based API
+	nc, js := jsClientConnect(t, c.leader())
+	defer nc.Close()
+
+	// Remove the "ONE" account from non-leader
+	s := c.randomNonLeader()
+	s.mu.Lock()
+	s.accounts.Delete("ONE")
+	s.mu.Unlock()
+
+	_, err := js.AddStream(&nats.StreamConfig{Name: "F", Replicas: 3})
+	if err == nil || !strings.Contains(err.Error(), "account not found") {
+		t.Fatalf("Expected an 'account not found' error but got %v", err)
+	}
+}
+
 // Support functions
 
 // Used to setup superclusters for tests.


### PR DESCRIPTION
We expected an account load to not fail but this is possible with resolvers.
If we can not load the account report back to the metaleader the error.

Consumers overlay the same peer group and need to exist prior, so I believe we only need to check on creating a stream, not on update or creating a consumer.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
