### PR TITLE
Check errors when removing test directories and files

### DIFF
--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -106,7 +106,7 @@ func TestStdLoggerTraceWithOutDebug(t *testing.T) {
 
 func TestFileLogger(t *testing.T) {
 	tmpDir := createDir(t, "_nats-server")
-	defer os.RemoveAll(tmpDir)
+	defer removeDir(t, tmpDir)
 
 	file := createFileAtDir(t, tmpDir, "nats-server:log_")
 	file.Close()
@@ -178,7 +178,7 @@ func TestFileLoggerSizeLimit(t *testing.T) {
 	logger.Close()
 
 	tmpDir := createDir(t, "nats-server")
-	defer os.RemoveAll(tmpDir)
+	defer removeDir(t, tmpDir)
 
 	file := createFileAtDir(t, tmpDir, "log_")
 	file.Close()
@@ -212,9 +212,9 @@ func TestFileLoggerSizeLimit(t *testing.T) {
 	}
 
 	// Remove all files
-	os.RemoveAll(tmpDir)
+	removeDir(t, tmpDir)
 	tmpDir = createDir(t, "nats-server")
-	defer os.RemoveAll(tmpDir)
+	defer removeDir(t, tmpDir)
 
 	// Recreate logger and don't set a limit
 	file = createFileAtDir(t, tmpDir, "log_")
@@ -345,4 +345,11 @@ func createFileAtDir(t *testing.T, dir, prefix string) *os.File {
 		t.Fatal(err)
 	}
 	return f
+}
+
+func removeDir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -282,7 +281,7 @@ func TestAccountIsolationExportImport(t *testing.T) {
 			`,
 				c.exp, c.imp,
 			)))
-			defer os.Remove(cf)
+			defer removeFile(t, cf)
 			s, _ := RunServerWithConfig(cf)
 			defer s.Shutdown()
 
@@ -486,7 +485,7 @@ func accountNameExists(name string, accounts []*Account) bool {
 
 func TestAccountSimpleConfig(t *testing.T) {
 	confFileName := createConfFile(t, []byte(`accounts = [foo, bar]`))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error processing config file: %v", err)
@@ -503,7 +502,7 @@ func TestAccountSimpleConfig(t *testing.T) {
 
 	// Make sure double entries is an error.
 	confFileName = createConfFile(t, []byte(`accounts = [foo, foo]`))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	_, err = ProcessConfigFile(confFileName)
 	if err == nil {
 		t.Fatalf("Expected an error with double account entries")
@@ -527,7 +526,7 @@ func TestAccountParseConfig(t *testing.T) {
       }
     }
     `))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error processing config file: %v", err)
@@ -577,7 +576,7 @@ func TestAccountParseConfigDuplicateUsers(t *testing.T) {
       }
     }
     `))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	_, err := ProcessConfigFile(confFileName)
 	if err == nil {
 		t.Fatalf("Expected an error with double user entries")
@@ -685,7 +684,7 @@ func TestImportExportConfigFailures(t *testing.T) {
       }
     }
     `))
-	defer os.Remove(cf)
+	defer removeFile(t, cf)
 	if _, err := ProcessConfigFile(cf); err == nil {
 		t.Fatalf("Expected an error with import from unknown account")
 	}
@@ -697,7 +696,7 @@ func TestImportExportConfigFailures(t *testing.T) {
       }
     }
     `))
-	defer os.Remove(cf)
+	defer removeFile(t, cf)
 	if _, err := ProcessConfigFile(cf); err == nil {
 		t.Fatalf("Expected an error with import of a service with no account")
 	}
@@ -709,7 +708,7 @@ func TestImportExportConfigFailures(t *testing.T) {
       }
     }
     `))
-	defer os.Remove(cf)
+	defer removeFile(t, cf)
 	if _, err := ProcessConfigFile(cf); err == nil {
 		t.Fatalf("Expected an error with import of a service with wildcard subject")
 	}
@@ -721,7 +720,7 @@ func TestImportExportConfigFailures(t *testing.T) {
       }
     }
     `))
-	defer os.Remove(cf)
+	defer removeFile(t, cf)
 	if _, err := ProcessConfigFile(cf); err == nil {
 		t.Fatalf("Expected an error with export with unknown keyword")
 	}
@@ -733,7 +732,7 @@ func TestImportExportConfigFailures(t *testing.T) {
       }
     }
     `))
-	defer os.Remove(cf)
+	defer removeFile(t, cf)
 	if _, err := ProcessConfigFile(cf); err == nil {
 		t.Fatalf("Expected an error with import with unknown keyword")
 	}
@@ -745,7 +744,7 @@ func TestImportExportConfigFailures(t *testing.T) {
       }
     }
     `))
-	defer os.Remove(cf)
+	defer removeFile(t, cf)
 	if _, err := ProcessConfigFile(cf); err == nil {
 		t.Fatalf("Expected an error with export with account")
 	}
@@ -973,7 +972,7 @@ func TestStreamImportLengthBug(t *testing.T) {
 	  }
 	}
 	`))
-	defer os.Remove(cf)
+	defer removeFile(t, cf)
 	if _, err := ProcessConfigFile(cf); err == nil {
 		t.Fatalf("Expected an error with import with wildcard prefix")
 	}
@@ -1810,7 +1809,8 @@ func TestAccountRequestReplyTrackLatency(t *testing.T) {
 
 // This will test for leaks in the remote latency tracking via client.rrTracking
 func TestAccountTrackLatencyRemoteLeaks(t *testing.T) {
-	optsA, _ := ProcessConfigFile("./configs/seed.conf")
+	optsA, err := ProcessConfigFile("./configs/seed.conf")
+	require_NoError(t, err)
 	optsA.NoSigs, optsA.NoLog = true, true
 	optsA.ServerName = "A"
 	srvA := RunServer(optsA)
@@ -2144,7 +2144,7 @@ func TestAccountMapsUsers(t *testing.T) {
       }
     }
     `))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Unexpected error parsing config file: %v", err)
@@ -2254,7 +2254,7 @@ func TestAccountGlobalDefault(t *testing.T) {
 
 	// Make sure we can not define one in a config file either.
 	confFileName := createConfFile(t, []byte(`accounts { $G {} }`))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 
 	if _, err := ProcessConfigFile(confFileName); err == nil {
 		t.Fatalf("Expected an error parsing config file with reserved account")
@@ -2788,7 +2788,7 @@ func TestGlobalAccountRouteMappingsConfiguration(t *testing.T) {
 		bar.*.*: RAB.$2.$1
     }
     `))
-	defer os.Remove(cf)
+	defer removeFile(t, cf)
 
 	s, _ := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -2843,7 +2843,7 @@ func TestAccountRouteMappingsConfiguration(t *testing.T) {
 		}
 	}
     `))
-	defer os.Remove(cf)
+	defer removeFile(t, cf)
 
 	s, _ := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -2873,7 +2873,7 @@ func TestAccountRouteMappingsWithLossInjection(t *testing.T) {
 		bar: { dest: bar, weight: 0% }
     }
     `))
-	defer os.Remove(cf)
+	defer removeFile(t, cf)
 
 	s, _ := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -2910,7 +2910,7 @@ func TestAccountRouteMappingsWithOriginClusterFilter(t *testing.T) {
 		foo: { dest: bar, cluster: SYN, weight: 100% }
     }
     `))
-	defer os.Remove(cf)
+	defer removeFile(t, cf)
 
 	s, _ := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -2955,7 +2955,7 @@ func TestAccountServiceImportWithRouteMappings(t *testing.T) {
       }
     }
     `))
-	defer os.Remove(cf)
+	defer removeFile(t, cf)
 
 	s, opts := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -3006,7 +3006,7 @@ func TestAccountImportsWithWildcardSupport(t *testing.T) {
       }
     }
     `))
-	defer os.Remove(cf)
+	defer removeFile(t, cf)
 
 	s, opts := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -3099,7 +3099,7 @@ func TestAccountImportsWithWildcardSupportStreamAndService(t *testing.T) {
       }
     }
     `))
-	defer os.Remove(cf)
+	defer removeFile(t, cf)
 
 	s, opts := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -3275,7 +3275,7 @@ func TestAccountSystemPermsWithGlobalAccess(t *testing.T) {
 			$SYS { users = [ { user: "admin", pass: "s3cr3t!" } ] }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 

--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -16,7 +16,6 @@ package server
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 )
@@ -1488,7 +1487,7 @@ func TestConfigCheck(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			conf := createConfFile(t, []byte(test.config))
-			defer os.Remove(conf)
+			defer removeFile(t, conf)
 			err := checkConfig(conf)
 			var expectedErr error
 

--- a/server/dirstore_test.go
+++ b/server/dirstore_test.go
@@ -726,7 +726,7 @@ func TestReload(t *testing.T) {
 	for k := range files {
 		hash = dirStore.Hash()
 		require_False(t, bytes.Equal(hash[:], emptyHash[:]))
-		os.Remove(k)
+		removeFile(t, k)
 		err = dirStore.Reload()
 		require_NoError(t, err)
 		assertStoreSize(t, dirStore, len(files)-1)

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -464,11 +463,11 @@ func TestSystemAccountingWithLeafNodes(t *testing.T) {
 	}
 	seed, _ := kp.Seed()
 	mycreds := genCredsFile(t, ujwt, seed)
-	defer os.Remove(mycreds)
+	defer removeFile(t, mycreds)
 
 	// Create a server that solicits a leafnode connection.
 	sl, slopts, lnconf := runSolicitWithCredentials(t, opts, mycreds)
-	defer os.Remove(lnconf)
+	defer removeFile(t, lnconf)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, s)
@@ -1159,7 +1158,7 @@ func TestSystemAccountFromConfig(t *testing.T) {
     `
 
 	conf := createConfFile(t, []byte(fmt.Sprintf(confTemplate, opub, apub, ts.URL)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -2229,7 +2228,7 @@ func TestServerEventsFilteredByTag(t *testing.T) {
 		}
 		no_auth_user: b
     `))
-	defer os.Remove(confA)
+	defer removeFile(t, confA)
 	sA, _ := RunServerWithConfig(confA)
 	defer sA.Shutdown()
 	confB := createConfFile(t, []byte(fmt.Sprintf(`
@@ -2254,7 +2253,7 @@ func TestServerEventsFilteredByTag(t *testing.T) {
 		}
 		no_auth_user: b
     `, sA.opts.Cluster.Port)))
-	defer os.Remove(confB)
+	defer removeFile(t, confB)
 	sB, _ := RunServerWithConfig(confB)
 	defer sB.Shutdown()
 	checkClusterFormed(t, sA, sB)

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -133,7 +133,7 @@ func TestFileStoreMsgHeaders(t *testing.T) {
 func TestFileStoreBasicWriteMsgsAndRestore(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fcfg := FileStoreConfig{StoreDir: storeDir}
 
@@ -267,7 +267,7 @@ func TestFileStoreBasicWriteMsgsAndRestore(t *testing.T) {
 func TestFileStoreSelectNextFirst(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -307,7 +307,7 @@ func TestFileStoreSelectNextFirst(t *testing.T) {
 func TestFileStoreSkipMsg(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -396,7 +396,7 @@ func TestFileStoreSkipMsg(t *testing.T) {
 func TestFileStoreWriteExpireWrite(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	cexp := 10 * time.Millisecond
 	fs, err := newFileStore(
@@ -461,7 +461,7 @@ func TestFileStoreWriteExpireWrite(t *testing.T) {
 func TestFileStoreMsgLimit(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxMsgs: 10})
 	if err != nil {
@@ -499,7 +499,7 @@ func TestFileStoreMsgLimit(t *testing.T) {
 func TestFileStoreMsgLimitBug(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxMsgs: 1})
 	if err != nil {
@@ -528,7 +528,7 @@ func TestFileStoreBytesLimit(t *testing.T) {
 
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxBytes: int64(maxBytes)})
 	if err != nil {
@@ -573,7 +573,7 @@ func TestFileStoreAgeLimit(t *testing.T) {
 
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxAge: maxAge})
 	if err != nil {
@@ -620,7 +620,7 @@ func TestFileStoreAgeLimit(t *testing.T) {
 func TestFileStoreTimeStamps(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -650,7 +650,7 @@ func TestFileStoreTimeStamps(t *testing.T) {
 func TestFileStorePurge(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	blkSize := uint64(64 * 1024)
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: blkSize}, StreamConfig{Name: "zzz", Storage: FileStorage})
@@ -768,7 +768,7 @@ func TestFileStorePurge(t *testing.T) {
 func TestFileStoreCompact(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -813,7 +813,7 @@ func TestFileStoreCompact(t *testing.T) {
 func TestFileStoreCompactLastPlusOne(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 8192, AsyncFlush: false}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -850,7 +850,7 @@ func TestFileStoreCompactPerf(t *testing.T) {
 
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 8192, AsyncFlush: true}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -887,7 +887,7 @@ func TestFileStoreCompactPerf(t *testing.T) {
 func TestFileStoreStreamTruncate(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 350},
@@ -957,7 +957,7 @@ func TestFileStoreStreamTruncate(t *testing.T) {
 func TestFileStoreRemovePartialRecovery(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -1003,7 +1003,7 @@ func TestFileStoreRemovePartialRecovery(t *testing.T) {
 func TestFileStoreRemoveOutOfOrderRecovery(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -1071,7 +1071,7 @@ func TestFileStoreAgeLimitRecovery(t *testing.T) {
 
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, CacheExpire: 1 * time.Millisecond},
@@ -1117,7 +1117,7 @@ func TestFileStoreAgeLimitRecovery(t *testing.T) {
 func TestFileStoreBitRot(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -1180,7 +1180,7 @@ func TestFileStoreBitRot(t *testing.T) {
 func TestFileStoreEraseMsg(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -1239,7 +1239,7 @@ func TestFileStoreEraseMsg(t *testing.T) {
 func TestFileStoreEraseAndNoIndexRecovery(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -1271,7 +1271,7 @@ func TestFileStoreEraseAndNoIndexRecovery(t *testing.T) {
 	// Stop and remove the index file.
 	fs.Stop()
 	ifn := path.Join(storeDir, msgDir, fmt.Sprintf(indexScan, 1))
-	os.Remove(ifn)
+	removeFile(t, ifn)
 
 	fs, err = newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -1294,7 +1294,7 @@ func TestFileStoreEraseAndNoIndexRecovery(t *testing.T) {
 func TestFileStoreMeta(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	mconfig := StreamConfig{Name: "ZZ-22-33", Storage: FileStorage, Subjects: []string{"foo.*"}, Replicas: 22}
 
@@ -1390,7 +1390,7 @@ func TestFileStoreMeta(t *testing.T) {
 func TestFileStoreWriteAndReadSameBlock(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -1414,7 +1414,7 @@ func TestFileStoreWriteAndReadSameBlock(t *testing.T) {
 func TestFileStoreAndRetrieveMultiBlock(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	subj, msg := "foo", []byte("Hello World!")
 	storedMsgSize := fileStoreMsgSize(subj, nil, msg)
@@ -1455,7 +1455,7 @@ func TestFileStoreAndRetrieveMultiBlock(t *testing.T) {
 func TestFileStoreCollapseDmap(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	subj, msg := "foo", []byte("Hello World!")
 	storedMsgSize := fileStoreMsgSize(subj, nil, msg)
@@ -1533,7 +1533,7 @@ func TestFileStoreReadCache(t *testing.T) {
 
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, CacheExpire: 100 * time.Millisecond}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -1585,7 +1585,7 @@ func TestFileStoreReadCache(t *testing.T) {
 func TestFileStorePartialCacheExpiration(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	cexp := 10 * time.Millisecond
 
@@ -1611,7 +1611,7 @@ func TestFileStorePartialCacheExpiration(t *testing.T) {
 func TestFileStorePartialIndexes(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	cexp := 10 * time.Millisecond
 
@@ -1659,7 +1659,7 @@ func TestFileStorePartialIndexes(t *testing.T) {
 func TestFileStoreSnapshot(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	subj, msg := "foo", []byte("Hello Snappy!")
 
@@ -1723,7 +1723,7 @@ func TestFileStoreSnapshot(t *testing.T) {
 		tr := tar.NewReader(s2.NewReader(r))
 
 		rstoreDir := createDir(t, JetStreamStoreDir)
-		defer os.RemoveAll(rstoreDir)
+		defer removeDir(t, rstoreDir)
 
 		for {
 			hdr, err := tr.Next()
@@ -1834,7 +1834,7 @@ func TestFileStoreSnapshot(t *testing.T) {
 func TestFileStoreConsumer(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -1955,7 +1955,7 @@ func TestFileStoreWriteFailures(t *testing.T) {
 	if stat, err := os.Stat(tdir); err != nil || !stat.IsDir() {
 		t.SkipNow()
 	}
-	defer os.RemoveAll(tdir)
+	defer removeDir(t, tdir)
 
 	storeDir := path.Join(tdir, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
@@ -2056,7 +2056,7 @@ func TestFileStorePerf(t *testing.T) {
 
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -2195,7 +2195,7 @@ func TestFileStoreReadBackMsgPerf(t *testing.T) {
 
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 	fmt.Printf("StoreDir is %q\n", storeDir)
 
 	fs, err := newFileStore(
@@ -2246,7 +2246,7 @@ func TestFileStoreStoreLimitRemovePerf(t *testing.T) {
 
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -2303,7 +2303,7 @@ func TestFileStorePubPerfWithSmallBlkSize(t *testing.T) {
 
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: FileStoreMinBlkSize},
@@ -2329,7 +2329,7 @@ func TestFileStorePubPerfWithSmallBlkSize(t *testing.T) {
 func TestFileStoreConsumerRedeliveredLost(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2396,7 +2396,7 @@ func TestFileStoreConsumerRedeliveredLost(t *testing.T) {
 func TestFileStoreConsumerFlusher(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2431,7 +2431,7 @@ func TestFileStoreConsumerFlusher(t *testing.T) {
 func TestFileStoreConsumerDeliveredUpdates(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2489,7 +2489,7 @@ func TestFileStoreConsumerDeliveredUpdates(t *testing.T) {
 func TestFileStoreConsumerDeliveredAndAckUpdates(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2606,7 +2606,7 @@ func TestFileStoreConsumerDeliveredAndAckUpdates(t *testing.T) {
 func TestFileStoreStreamStateDeleted(t *testing.T) {
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2658,7 +2658,7 @@ func TestFileStoreConsumerPerf(t *testing.T) {
 
 	storeDir := createDir(t, JetStreamStoreDir)
 	os.MkdirAll(storeDir, 0755)
-	defer os.RemoveAll(storeDir)
+	defer removeDir(t, storeDir)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2729,7 +2729,7 @@ func TestFileStoreStreamIndexBug(t *testing.T) {
 	// https://github.com/nats-io/jetstream/issues/406
 	badIdxBytes, _ := base64.StdEncoding.DecodeString("FgGBkw7D/f8/772iDPDIgbU=")
 	dir := createDir(t, "js-bad-idx-")
-	defer os.RemoveAll(dir)
+	defer removeDir(t, dir)
 	fn := path.Join(dir, "1.idx")
 	ioutil.WriteFile(fn, badIdxBytes, 0644)
 	mb := &msgBlock{index: 1, ifn: fn}

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -6353,7 +6352,7 @@ func TestGatewayTLSConfigReload(t *testing.T) {
 		}
 	`
 	confA := createConfFile(t, []byte(fmt.Sprintf(template, "")))
-	defer os.Remove(confA)
+	defer removeFile(t, confA)
 
 	srvA, optsA := RunServerWithConfig(confA)
 	defer srvA.Shutdown()
@@ -6406,7 +6405,7 @@ func TestGatewayTLSConfigReloadForRemote(t *testing.T) {
 		}
 	`
 	confB := createConfFile(t, []byte(fmt.Sprintf(template, optsA.Gateway.Port, "")))
-	defer os.Remove(confB)
+	defer removeFile(t, confB)
 
 	srvB, _ := RunServerWithConfig(confB)
 	defer srvB.Shutdown()
@@ -6433,7 +6432,7 @@ func TestGatewayAuthDiscovered(t *testing.T) {
 			authorization: { user: gwuser, password: changeme }
 		}
 	`))
-	defer os.Remove(confA)
+	defer removeFile(t, confA)
 	srvA, optsA := RunServerWithConfig(confA)
 	defer srvA.Shutdown()
 
@@ -6448,7 +6447,7 @@ func TestGatewayAuthDiscovered(t *testing.T) {
 			]
 		}
 	`, optsA.Gateway.Port)))
-	defer os.Remove(confB)
+	defer removeFile(t, confB)
 	srvB, _ := RunServerWithConfig(confB)
 	defer srvB.Shutdown()
 

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"os"
 	"path"
 	"reflect"
 	"strings"
@@ -38,7 +37,7 @@ func TestJetStreamClusterConfig(t *testing.T) {
 		jetstream: {max_mem_store: 16GB, max_file_store: 10TB, store_dir: "%s"}
 		cluster { listen: 127.0.0.1:-1 }
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	check := func(errStr string) {
 		t.Helper()
@@ -59,7 +58,7 @@ func TestJetStreamClusterConfig(t *testing.T) {
 		jetstream: {max_mem_store: 16GB, max_file_store: 10TB, store_dir: "%s"}
 		cluster { listen: 127.0.0.1:-1 }
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	check("requires `cluster.name`")
 }
@@ -5161,7 +5160,7 @@ func TestJetStreamClusterMultiRestartBug(t *testing.T) {
 	s := c.randomServer()
 	opts := s.getOpts()
 	s.Shutdown()
-	os.RemoveAll(opts.StoreDir)
+	removeDir(t, opts.StoreDir)
 
 	// Then restart it.
 	c.restartAll()

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -43,7 +43,7 @@ func TestJetStreamBasicNilConfig(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	if err := s.EnableJetStream(nil); err != nil {
@@ -121,7 +121,7 @@ func TestJetStreamEnableAndDisableAccount(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	// Global in simple setup should be enabled already.
@@ -198,7 +198,7 @@ func TestJetStreamAddStream(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -266,7 +266,7 @@ func TestJetStreamAddStreamDiscardNew(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -317,7 +317,7 @@ func TestJetStreamAutoTuneFSConfig(t *testing.T) {
 	}
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	maxMsgSize := int32(512)
@@ -363,7 +363,7 @@ func TestJetStreamPubAck(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	sname := "PUBACK"
@@ -419,7 +419,7 @@ func TestJetStreamConsumerWithStartTime(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			fsCfg := &FileStoreConfig{BlockSize: 100}
@@ -490,7 +490,7 @@ func TestJetStreamConsumerWithMultipleStartOptions(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -539,7 +539,7 @@ func TestJetStreamConsumerMaxDeliveries(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -603,7 +603,7 @@ func TestJetStreamPullConsumerDelayedFirstPullWithReplayOriginal(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -652,7 +652,7 @@ func TestJetStreamConsumerAckFloorFill(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -724,7 +724,7 @@ func TestJetStreamNoPanicOnRaceBetweenShutdownAndConsumerDelete(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -790,7 +790,7 @@ func TestJetStreamAddStreamMaxMsgSize(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -845,7 +845,7 @@ func TestJetStreamAddStreamBadSubjects(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	// Client for API requests.
@@ -880,7 +880,7 @@ func TestJetStreamAddStreamMaxConsumers(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	nc := clientConnectToServer(t, s)
@@ -915,7 +915,7 @@ func TestJetStreamAddStreamOverlappingSubjects(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	acc := s.GlobalAccount()
@@ -947,7 +947,7 @@ func TestJetStreamAddStreamOverlapWithJSAPISubjects(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	acc := s.GlobalAccount()
@@ -981,7 +981,7 @@ func TestJetStreamAddStreamSameConfigOK(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	acc := s.GlobalAccount()
@@ -1024,7 +1024,7 @@ func TestJetStreamBasicAckPublish(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -1061,7 +1061,7 @@ func TestJetStreamStateTimestamps(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -1104,7 +1104,7 @@ func TestJetStreamNoAckStream(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			// We can use NoAck to suppress acks even when reply subjects are present.
@@ -1143,7 +1143,7 @@ func TestJetStreamCreateConsumer(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -1263,7 +1263,7 @@ func TestJetStreamBasicDeliverSubject(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -1423,7 +1423,7 @@ func TestJetStreamBasicWorkQueue(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -1521,7 +1521,7 @@ func TestJetStreamWorkQueueMaxWaiting(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -1620,7 +1620,7 @@ func TestJetStreamWorkQueueWrapWaiting(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -1706,7 +1706,7 @@ func TestJetStreamWorkQueueRequest(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -1819,7 +1819,7 @@ func TestJetStreamSubjectFiltering(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -1895,7 +1895,7 @@ func TestJetStreamWorkQueueSubjectFiltering(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -1968,7 +1968,7 @@ func TestJetStreamWildcardSubjectFiltering(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -2084,7 +2084,7 @@ func TestJetStreamWorkQueueAckAndNext(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -2157,7 +2157,7 @@ func TestJetStreamWorkQueueRequestBatch(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -2256,7 +2256,7 @@ func TestJetStreamWorkQueueRetentionStream(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -2378,7 +2378,7 @@ func TestJetStreamAckAllRedelivery(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -2464,7 +2464,7 @@ func TestJetStreamAckReplyStreamPending(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -2615,7 +2615,7 @@ func TestJetStreamAckReplyStreamPendingWithAcks(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -2688,7 +2688,7 @@ func TestJetStreamWorkQueueAckWaitRedelivery(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -2792,7 +2792,7 @@ func TestJetStreamWorkQueueNakRedelivery(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -2870,7 +2870,7 @@ func TestJetStreamWorkQueueWorkingIndicator(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -2957,7 +2957,7 @@ func TestJetStreamWorkQueueTerminateDelivery(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -3051,11 +3051,11 @@ func TestJetStreamConsumerAckAck(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mname := "ACK-ACK"
@@ -3102,7 +3102,7 @@ func TestJetStreamAckNext(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mname := "ACKNXT"
@@ -3198,7 +3198,7 @@ func TestJetStreamPublishDeDupe(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mname := "DeDupe"
@@ -3362,7 +3362,7 @@ func TestJetStreamPublishExpect(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mname := "EXPECT"
@@ -3458,7 +3458,7 @@ func TestJetStreamPullConsumerRemoveInterest(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mname := "MYS-PULL"
@@ -3544,7 +3544,7 @@ func TestJetStreamConsumerRateLimit(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mname := "RATELIMIT"
@@ -3622,7 +3622,7 @@ func TestJetStreamEphemeralConsumerRecoveryAfterServerRestart(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mname := "MYS"
@@ -3725,7 +3725,7 @@ func TestJetStreamConsumerMaxDeliveryAndServerRestart(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mname := "MYS"
@@ -3866,7 +3866,7 @@ func TestJetStreamDeleteConsumerAndServerRestart(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	sendSubj := "MYQ"
@@ -3917,7 +3917,7 @@ func TestJetStreamRedeliveryAfterServerRestart(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	sendSubj := "MYQ"
@@ -3994,7 +3994,7 @@ func TestJetStreamSnapshots(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mname := "MY-STREAM"
@@ -4104,7 +4104,7 @@ func TestJetStreamSnapshots(t *testing.T) {
 	defer s2.Shutdown()
 
 	if config := s2.JetStreamConfig(); config != nil && config.StoreDir != "" {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 	acc = s2.GlobalAccount()
 	r.Reset(snapshot)
@@ -4152,7 +4152,7 @@ func TestJetStreamSnapshotsAPI(t *testing.T) {
 	checkLeafNodeConnected(t, s)
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mname := "MY-STREAM"
@@ -4458,7 +4458,7 @@ func TestJetStreamSnapshotsAPIPerf(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	cfg := StreamConfig{
@@ -4539,7 +4539,7 @@ func TestJetStreamActiveDelivery(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil && config.StoreDir != "" {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -4598,7 +4598,7 @@ func TestJetStreamEphemeralConsumers(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -4676,7 +4676,7 @@ func TestJetStreamConsumerReconnect(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -4787,7 +4787,7 @@ func TestJetStreamDurableConsumerReconnect(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -4899,7 +4899,7 @@ func TestJetStreamDurableConsumerReconnectWithOnlyPending(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -5000,7 +5000,7 @@ func TestJetStreamDurableFilteredSubjectConsumerReconnect(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -5149,7 +5149,7 @@ func TestJetStreamConsumerInactiveNoDeadlock(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -5210,7 +5210,7 @@ func TestJetStreamMetadata(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -5317,7 +5317,7 @@ func TestJetStreamRedeliverCount(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -5380,7 +5380,7 @@ func TestJetStreamRedeliverAndLateAck(t *testing.T) {
 
 	// Forced cleanup of all persisted state.
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mset, err := s.GlobalAccount().addStream(&StreamConfig{Name: "LA", Storage: MemoryStorage})
@@ -5424,7 +5424,7 @@ func TestJetStreamPendingNextTimer(t *testing.T) {
 
 	// Forced cleanup of all persisted state.
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mset, err := s.GlobalAccount().addStream(&StreamConfig{Name: "NT", Storage: MemoryStorage, Subjects: []string{"ORDERS.*"}})
@@ -5481,7 +5481,7 @@ func TestJetStreamCanNotNakAckd(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -5559,7 +5559,7 @@ func TestJetStreamStreamPurge(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -5621,7 +5621,7 @@ func TestJetStreamStreamPurgeWithConsumer(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -5716,7 +5716,7 @@ func TestJetStreamStreamPurgeWithConsumerAndRedelivery(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -5804,7 +5804,7 @@ func TestJetStreamInterestRetentionStream(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -5949,7 +5949,7 @@ func TestJetStreamInterestRetentionStreamWithFilteredConsumers(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -6039,7 +6039,7 @@ func TestJetStreamInterestRetentionWithWildcardsAndFilteredConsumers(t *testing.
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -6095,7 +6095,7 @@ func TestJetStreamInterestRetentionStreamWithDurableRestart(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -6245,7 +6245,7 @@ func TestJetStreamConsumerReplayRate(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -6366,7 +6366,7 @@ func TestJetStreamConsumerReplayRateNoAck(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -6428,7 +6428,7 @@ func TestJetStreamConsumerReplayQuit(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -6479,7 +6479,7 @@ func TestJetStreamSystemLimits(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	if _, _, err := s.JetStreamReservedResources(); err == nil {
@@ -6651,7 +6651,7 @@ func TestJetStreamStreamStorageTrackingAndLimits(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	gacc := s.GlobalAccount()
@@ -6780,7 +6780,7 @@ func TestJetStreamStreamFileTrackingAndLimits(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	gacc := s.GlobalAccount()
@@ -6918,7 +6918,7 @@ func TestJetStreamSimpleFileRecovery(t *testing.T) {
 	}
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	acc := s.GlobalAccount()
@@ -7037,7 +7037,7 @@ func TestJetStreamPushConsumerFlowControl(t *testing.T) {
 
 	// Forced cleanup of all persisted state.
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	// Client for API requests.
@@ -7141,7 +7141,7 @@ func TestJetStreamPushConsumerIdleHeartbeats(t *testing.T) {
 
 	// Forced cleanup of all persisted state.
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	// Client for API requests.
@@ -7216,7 +7216,7 @@ func TestJetStreamPushConsumerIdleHeartbeatsWithFilterSubject(t *testing.T) {
 
 	// Forced cleanup of all persisted state.
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	// Client for API requests.
@@ -7280,7 +7280,7 @@ func TestJetStreamPushConsumerIdleHeartbeatsWithNoInterest(t *testing.T) {
 
 	// Forced cleanup of all persisted state.
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	// Client for API requests.
@@ -7344,7 +7344,7 @@ func TestJetStreamInfoAPIWithHeaders(t *testing.T) {
 
 	// Forced cleanup of all persisted state.
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	// Client for API requests.
@@ -7376,7 +7376,7 @@ func TestJetStreamRequestAPI(t *testing.T) {
 
 	// Forced cleanup of all persisted state.
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	// Client for API requests.
@@ -7927,7 +7927,7 @@ func TestJetStreamFilteredStreamNames(t *testing.T) {
 
 	// Forced cleanup of all persisted state.
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	// Client for API requests.
@@ -8002,7 +8002,7 @@ func TestJetStreamUpdateStream(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil && config.StoreDir != "" {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -8227,7 +8227,7 @@ func TestJetStreamDeleteMsg(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil && config.StoreDir != "" {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -8391,7 +8391,7 @@ func TestJetStreamLimitLockBug(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil && config.StoreDir != "" {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -8443,7 +8443,7 @@ func TestJetStreamNextMsgNoInterest(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			cfg := &StreamConfig{Name: "foo", Storage: FileStorage}
@@ -8531,7 +8531,7 @@ func TestJetStreamMsgHeaders(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -8611,7 +8611,7 @@ func TestJetStreamTemplateBasics(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	acc := s.GlobalAccount()
@@ -8683,7 +8683,7 @@ func TestJetStreamTemplateFileStoreRecovery(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	acc := s.GlobalAccount()
@@ -8883,7 +8883,7 @@ func TestJetStreamCanNotEnableOnSystemAccount(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	sa := s.SystemAccount()
@@ -8910,13 +8910,13 @@ func TestJetStreamMultipleAccountsBasics(t *testing.T) {
 			},
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	if !s.JetStreamEnabled() {
@@ -9069,7 +9069,7 @@ func TestJetStreamServerResourcesConfig(t *testing.T) {
 		listen: 127.0.0.1:-1
 		jetstream: {max_mem_store: 2GB, max_file_store: 1TB}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -9079,7 +9079,7 @@ func TestJetStreamServerResourcesConfig(t *testing.T) {
 	}
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	gb := int64(1024 * 1024 * 1024)
@@ -9097,7 +9097,7 @@ func TestJetStreamPushConsumersPullError(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	nc, js := jsClientConnect(t, s)
@@ -9159,7 +9159,7 @@ func TestJetStreamPubPerf(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	acc := s.GlobalAccount()
@@ -9218,7 +9218,7 @@ func TestJetStreamPubWithAsyncResponsePerf(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	acc := s.GlobalAccount()
@@ -9258,7 +9258,7 @@ func TestJetStreamPubWithSyncPerf(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	nc, js := jsClientConnect(t, s)
@@ -9290,7 +9290,7 @@ func TestJetStreamConsumerPerf(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	acc := s.GlobalAccount()
@@ -9352,7 +9352,7 @@ func TestJetStreamConsumerAckFileStorePerf(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	acc := s.GlobalAccount()
@@ -9423,7 +9423,7 @@ func TestJetStreamPubSubPerf(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	acc := s.GlobalAccount()
@@ -9502,7 +9502,7 @@ func TestJetStreamAckExplicitMsgRemoval(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -9696,7 +9696,7 @@ func TestJetStreamStoredMsgsDontDisappearAfterCacheExpiration(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mset, err := s.GlobalAccount().addStreamWithStore(sc, &FileStoreConfig{BlockSize: 128, CacheExpire: 15 * time.Millisecond})
@@ -9793,7 +9793,7 @@ func TestJetStreamConsumerUpdateRedelivery(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -9965,7 +9965,7 @@ func TestJetStreamConsumerMaxAckPending(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -10093,7 +10093,7 @@ func TestJetStreamPullConsumerMaxAckPending(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -10200,7 +10200,7 @@ func TestJetStreamPullConsumerMaxAckPendingRedeliveries(t *testing.T) {
 			defer s.Shutdown()
 
 			if config := s.JetStreamConfig(); config != nil {
-				defer os.RemoveAll(config.StoreDir)
+				defer removeDir(t, config.StoreDir)
 			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -10278,7 +10278,7 @@ func TestJetStreamDeliveryAfterServerRestart(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mset, err := s.GlobalAccount().addStream(&StreamConfig{
@@ -10407,13 +10407,13 @@ func TestJetStreamAccountImportBasics(t *testing.T) {
 			},
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	acc, err := s.LookupAccount("JS")
@@ -10536,13 +10536,13 @@ func TestJetStreamAccountImportAll(t *testing.T) {
 			},
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	acc, err := s.LookupAccount("JS")
@@ -10606,13 +10606,13 @@ func TestJetStreamServerReload(t *testing.T) {
 		no_auth_user: ub
 		system_account: SYS
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	if !s.JetStreamEnabled() {
@@ -10682,13 +10682,13 @@ func TestJetStreamConfigReloadWithGlobalAccount(t *testing.T) {
 		jetstream: enabled
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, "pwd")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	// Client for API requests.
@@ -10746,7 +10746,7 @@ func TestJetStreamMirrorAndSourcesFilteredConsumers(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	// Client for API requests.
@@ -10842,7 +10842,7 @@ func TestJetStreamMirrorBasics(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	// Client for API requests.
@@ -11002,7 +11002,7 @@ func TestJetStreamSourceBasics(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	// Client for API requests.
@@ -11166,7 +11166,7 @@ func TestJetStreamOperatorAccounts(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	nc, js := jsClientConnect(t, s, nats.UserCredentials("./configs/one.creds"))

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -22,7 +22,6 @@ import (
 	"math/rand"
 	"net"
 	"net/url"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -105,7 +104,7 @@ func TestLeafNodeTLSWithCerts(t *testing.T) {
 			}
 		}
 	`))
-	defer os.Remove(conf1)
+	defer removeFile(t, conf1)
 	s1, o1 := RunServerWithConfig(conf1)
 	defer s1.Shutdown()
 
@@ -129,7 +128,7 @@ func TestLeafNodeTLSWithCerts(t *testing.T) {
 			]
 		}
 	`, u.String())))
-	defer os.Remove(conf2)
+	defer removeFile(t, conf2)
 	o2, err := ProcessConfigFile(conf2)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -160,7 +159,7 @@ func TestLeafNodeTLSRemoteWithNoCerts(t *testing.T) {
 			}
 		}
 	`))
-	defer os.Remove(conf1)
+	defer removeFile(t, conf1)
 	s1, o1 := RunServerWithConfig(conf1)
 	defer s1.Shutdown()
 
@@ -182,7 +181,7 @@ func TestLeafNodeTLSRemoteWithNoCerts(t *testing.T) {
 			]
 		}
 	`, u.String())))
-	defer os.Remove(conf2)
+	defer removeFile(t, conf2)
 	o2, err := ProcessConfigFile(conf2)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -226,7 +225,7 @@ func TestLeafNodeTLSRemoteWithNoCerts(t *testing.T) {
 			]
 		}
 	`, u.String())))
-	defer os.Remove(conf3)
+	defer removeFile(t, conf3)
 	o3, err := ProcessConfigFile(conf3)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -256,7 +255,7 @@ func TestLeafNodeTLSRemoteWithNoCerts(t *testing.T) {
 			]
 		}
 	`, u.String())))
-	defer os.Remove(conf4)
+	defer removeFile(t, conf4)
 	o4, err := ProcessConfigFile(conf4)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -294,7 +293,7 @@ func TestLeafNodeAccountNotFound(t *testing.T) {
 	u, _ := url.Parse(fmt.Sprintf("nats://127.0.0.1:%d", ob.LeafNode.Port))
 
 	logFileName := createConfFile(t, []byte(""))
-	defer os.Remove(logFileName)
+	defer removeFile(t, logFileName)
 
 	oa := DefaultOptions()
 	oa.LeafNode.ReconnectInterval = 15 * time.Millisecond
@@ -364,13 +363,13 @@ func TestLeafNodeBasicAuthFailover(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(content, "")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	sb1, ob1 := RunServerWithConfig(conf)
 	defer sb1.Shutdown()
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(content, fmt.Sprintf("routes: [nats://127.0.0.1:%d]", ob1.Cluster.Port))))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	sb2, _ := RunServerWithConfig(conf)
 	defer sb2.Shutdown()
@@ -393,7 +392,7 @@ func TestLeafNodeBasicAuthFailover(t *testing.T) {
 	}
 	`
 	conf = createConfFile(t, []byte(fmt.Sprintf(content, ob1.LeafNode.Port)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	sa, _ := RunServerWithConfig(conf)
 	defer sa.Shutdown()
@@ -561,7 +560,7 @@ func TestLeafNodeBasicAuthSingleton(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			conf := createConfFile(t, []byte(fmt.Sprintf(template, test.userSpec)))
-			defer os.Remove(conf)
+			defer removeFile(t, conf)
 			s1, o1 := RunServerWithConfig(conf)
 			defer s1.Shutdown()
 
@@ -585,7 +584,7 @@ func TestLeafNodeBasicAuthSingleton(t *testing.T) {
 					remotes = [ { url: "nats-leaf://%s%s:%d" } ]
 				}
 			`, test.lnURLCreds, o1.LeafNode.Host, o1.LeafNode.Port)))
-			defer os.Remove(conf)
+			defer removeFile(t, conf)
 			s2, _ := RunServerWithConfig(conf)
 			defer s2.Shutdown()
 
@@ -644,7 +643,7 @@ func TestLeafNodeBasicAuthMultiple(t *testing.T) {
             }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s1, o1 := RunServerWithConfig(conf)
 	defer s1.Shutdown()
 
@@ -655,7 +654,7 @@ func TestLeafNodeBasicAuthMultiple(t *testing.T) {
 			remotes = [{url: "nats-leaf://wron:user@%s:%d"}]
 		}
 	`, o1.LeafNode.Host, o1.LeafNode.Port)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s2, _ := RunServerWithConfig(conf)
 	defer s2.Shutdown()
 	// Give a chance for s2 to attempt to connect and make sure that s1
@@ -697,7 +696,7 @@ func TestLeafNodeBasicAuthMultiple(t *testing.T) {
 			]
 		}
 	`, o1.LeafNode.Host, o1.LeafNode.Port, o1.LeafNode.Host, o1.LeafNode.Port)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s2, o2 := RunServerWithConfig(conf)
 	defer s2.Shutdown()
 
@@ -743,7 +742,7 @@ func TestLeafNodeBasicAuthMultiple(t *testing.T) {
 			]
 		}
 	`, o1.LeafNode.Host, o1.LeafNode.Port)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s3, _ := RunServerWithConfig(conf)
 	defer s3.Shutdown()
 }
@@ -1671,13 +1670,13 @@ func TestLeafNodeTLSVerifyAndMapCfgPass(t *testing.T) {
 	defer close(l.triggerChan)
 
 	confA := createConfFile(t, []byte(fmt.Sprintf(testLeafNodeTLSVerifyAndMapSrvA, "localhost")))
-	defer os.Remove(confA)
+	defer removeFile(t, confA)
 	srvA, optsA := RunServerWithConfig(confA)
 	defer srvA.Shutdown()
 	srvA.SetLogger(l, true, true)
 
 	confB := createConfFile(t, []byte(fmt.Sprintf(testLeafNodeTLSVerifyAndMapSrvB, optsA.LeafNode.Port)))
-	defer os.Remove(confB)
+	defer removeFile(t, confB)
 	ob := LoadConfig(confB)
 	ob.LeafNode.ReconnectInterval = 50 * time.Millisecond
 	srvB := RunServer(ob)
@@ -1719,13 +1718,13 @@ func TestLeafNodeTLSVerifyAndMapCfgFail(t *testing.T) {
 	// use certificate with SAN localhost, but configure the server to not accept it
 	// instead provide a name matching the user (to be matched by failed
 	confA := createConfFile(t, []byte(fmt.Sprintf(testLeafNodeTLSVerifyAndMapSrvA, "user-provided-in-url")))
-	defer os.Remove(confA)
+	defer removeFile(t, confA)
 	srvA, optsA := RunServerWithConfig(confA)
 	defer srvA.Shutdown()
 	srvA.SetLogger(l, true, true)
 
 	confB := createConfFile(t, []byte(fmt.Sprintf(testLeafNodeTLSVerifyAndMapSrvB, optsA.LeafNode.Port)))
-	defer os.Remove(confB)
+	defer removeFile(t, confB)
 	ob := LoadConfig(confB)
 	ob.LeafNode.ReconnectInterval = 50 * time.Millisecond
 	srvB := RunServer(ob)
@@ -1768,7 +1767,7 @@ func TestLeafNodeOriginClusterInfo(t *testing.T) {
 		}
 	`, hopts.LeafNode.Port)))
 
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	opts, err := ProcessConfigFile(conf)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -1810,7 +1809,7 @@ func TestLeafNodeOriginClusterInfo(t *testing.T) {
 		}
 	`, hopts.LeafNode.Port)))
 
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	opts, err = ProcessConfigFile(conf)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -2025,7 +2024,7 @@ func TestLeafNodeTwoRemotesBindToSameAccount(t *testing.T) {
 	}
 	`
 	lconf := createConfFile(t, []byte(fmt.Sprintf(conf, opts.LeafNode.Port, opts.LeafNode.Port)))
-	defer os.Remove(lconf)
+	defer removeFile(t, lconf)
 
 	lopts, err := ProcessConfigFile(lconf)
 	if err != nil {
@@ -2317,7 +2316,7 @@ func TestLeafNodeRouteParseLSUnsub(t *testing.T) {
 
 func TestLeafNodeOperatorBadCfg(t *testing.T) {
 	tmpDir := createDir(t, "_nats-server")
-	defer os.RemoveAll(tmpDir)
+	defer removeDir(t, tmpDir)
 	for errorText, cfg := range map[string]string{
 		"operator mode does not allow specifying user in leafnode config": `
 			port: -1
@@ -2343,7 +2342,7 @@ func TestLeafNodeOperatorBadCfg(t *testing.T) {
 			%s
 		}
 	`, ojwt, tmpDir, cfg)))
-			defer os.Remove(conf)
+			defer removeFile(t, conf)
 			opts := LoadConfig(conf)
 			s, err := NewServer(opts)
 			if err == nil {
@@ -2372,7 +2371,7 @@ func TestLeafNodeTLSConfigReload(t *testing.T) {
 		}
 	`
 	confA := createConfFile(t, []byte(fmt.Sprintf(template, "")))
-	defer os.Remove(confA)
+	defer removeFile(t, confA)
 
 	srvA, optsA := RunServerWithConfig(confA)
 	defer srvA.Shutdown()
@@ -2395,7 +2394,7 @@ func TestLeafNodeTLSConfigReload(t *testing.T) {
 			]
 		}
 	`, optsA.LeafNode.Port)))
-	defer os.Remove(confB)
+	defer removeFile(t, confB)
 
 	optsB, err := ProcessConfigFile(confB)
 	if err != nil {
@@ -2443,7 +2442,7 @@ func TestLeafNodeTLSConfigReloadForRemote(t *testing.T) {
 			}
 		}
 	`))
-	defer os.Remove(confA)
+	defer removeFile(t, confA)
 
 	srvA, optsA := RunServerWithConfig(confA)
 	defer srvA.Shutdown()
@@ -2467,7 +2466,7 @@ func TestLeafNodeTLSConfigReloadForRemote(t *testing.T) {
 		}
 	`
 	confB := createConfFile(t, []byte(fmt.Sprintf(template, optsA.LeafNode.Port, "")))
-	defer os.Remove(confB)
+	defer removeFile(t, confB)
 
 	srvB, _ := RunServerWithConfig(confB)
 	defer srvB.Shutdown()
@@ -2724,7 +2723,7 @@ func TestLeafNodeWSRemoteCompressAndMaskingOptions(t *testing.T) {
 					]
 				}
 			`, test.compStr, test.noMaskStr)))
-			defer os.Remove(conf)
+			defer removeFile(t, conf)
 			o, err := ProcessConfigFile(conf)
 			if err != nil {
 				t.Fatalf("Error loading conf: %v", err)
@@ -2874,7 +2873,7 @@ func TestLeafNodeWSAuth(t *testing.T) {
 			port: -1
 		}
 	`, jwt.ConnectionTypeStandard, jwt.ConnectionTypeLeafnode)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	o, err := ProcessConfigFile(conf)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -144,8 +144,8 @@ func TestReOpenLogFile(t *testing.T) {
 
 	// Set a File log
 	s.opts.LogFile = "test.log"
-	defer os.Remove(s.opts.LogFile)
-	defer os.Remove(s.opts.LogFile + ".bak")
+	defer removeFile(t, s.opts.LogFile)
+	defer removeFile(t, s.opts.LogFile+".bak")
 	fileLog := logger.NewFileLogger(s.opts.LogFile, s.opts.Logtime, s.opts.Debug, s.opts.Trace, true)
 	s.SetLogger(fileLog, false, false)
 	// Add some log
@@ -189,7 +189,7 @@ func TestFileLoggerSizeLimitAndReopen(t *testing.T) {
 	defer s.SetLogger(nil, false, false)
 
 	tmpDir := createDir(t, "nats-server")
-	defer os.RemoveAll(tmpDir)
+	defer removeDir(t, tmpDir)
 	file := createFileAtDir(t, tmpDir, "log_")
 	file.Close()
 

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"reflect"
 	"runtime"
 	"sort"
@@ -2540,7 +2539,7 @@ func TestMonitorClusterURLs(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, "nats://"+s2ClusterHostPort, "")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s1, _ := RunServerWithConfig(conf)
 	defer s1.Shutdown()
 
@@ -3101,7 +3100,7 @@ func TestMonitorGatewayzAccounts(t *testing.T) {
 		}
 		no_sys_acc = true
 	`, accounts)))
-	defer os.Remove(bConf)
+	defer removeFile(t, bConf)
 
 	sb, ob := RunServerWithConfig(bConf)
 	defer sb.Shutdown()
@@ -3126,7 +3125,7 @@ func TestMonitorGatewayzAccounts(t *testing.T) {
 		}
 		no_sys_acc = true
 	`, accounts, sb.GatewayAddr().Port)))
-	defer os.Remove(aConf)
+	defer removeFile(t, aConf)
 
 	sa, oa := RunServerWithConfig(aConf)
 	defer sa.Shutdown()
@@ -3503,7 +3502,7 @@ func TestMonitorOpJWT(t *testing.T) {
 	resolver = MEMORY
 	`
 	conf := createConfFile(t, []byte(content))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	sa, _ := RunServerWithConfig(conf)
 	defer sa.Shutdown()
 
@@ -3544,7 +3543,7 @@ func TestMonitorLeafz(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	sb, ob := RunServerWithConfig(conf)
 	defer sb.Shutdown()
 
@@ -3563,9 +3562,9 @@ func TestMonitorLeafz(t *testing.T) {
 		return acc, creds
 	}
 	acc1, mycreds1 := createAcc(t)
-	defer os.Remove(mycreds1)
+	defer removeFile(t, mycreds1)
 	acc2, mycreds2 := createAcc(t)
-	defer os.Remove(mycreds2)
+	defer removeFile(t, mycreds2)
 
 	content = `
 		port: -1
@@ -3603,7 +3602,7 @@ func TestMonitorLeafz(t *testing.T) {
 		acc1.Name, ob.LeafNode.Port, mycreds1,
 		acc2.Name, ob.LeafNode.Port, mycreds2)
 	conf = createConfFile(t, []byte(config))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	sa, oa := RunServerWithConfig(conf)
 	defer sa.Shutdown()
 
@@ -3929,7 +3928,7 @@ func TestMonitorJsz(t *testing.T) {
 		{5500, 5501, 5502, 7502},
 	} {
 		tmpDir := createDir(t, fmt.Sprintf("srv_%d", test.port))
-		defer os.RemoveAll(tmpDir)
+		defer removeDir(t, tmpDir)
 		cf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:%d
 		http: 127.0.0.1:%d
@@ -3958,7 +3957,7 @@ func TestMonitorJsz(t *testing.T) {
 			routes: [nats-route://127.0.0.1:%d]
 		}
 		server_name: server_%d `, test.port, test.mport, tmpDir, test.cport, test.routed, test.port)))
-		defer os.Remove(cf)
+		defer removeFile(t, cf)
 
 		s, _ := RunServerWithConfig(cf)
 		defer s.Shutdown()

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -264,7 +264,7 @@ func TestMQTTConfig(t *testing.T) {
 			}
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s, o := RunServerWithConfig(conf)
 	defer testMQTTShutdownServer(s)
 	if o.MQTT.TLSConfig == nil {
@@ -438,7 +438,7 @@ func TestMQTTParseOptions(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			conf := createConfFile(t, []byte(test.content))
-			defer os.Remove(conf)
+			defer removeFile(t, conf)
 			o, err := ProcessConfigFile(conf)
 			if test.err != _EMPTY_ {
 				if err == nil || !strings.Contains(err.Error(), test.err) {
@@ -3196,7 +3196,7 @@ func TestMQTTWillRetainPermViolation(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, "foo")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, o := RunServerWithConfig(conf)
 	defer testMQTTShutdownServer(s)
@@ -4410,7 +4410,7 @@ func TestMQTTConfigReload(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, `"5s"`, `10000`)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, o := RunServerWithConfig(conf)
 	defer testMQTTShutdownServer(s)

--- a/server/nkey_test.go
+++ b/server/nkey_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	mrand "math/rand"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -213,7 +212,7 @@ func TestMixedClientConfig(t *testing.T) {
         {user: alice, password: foo}
       ]
     }`))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error processing config file: %v", err)

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -22,7 +22,6 @@ import (
 	"math/rand"
 	"net"
 	"net/url"
-	"os"
 	"runtime"
 	"runtime/debug"
 	"sync"
@@ -100,7 +99,8 @@ func TestNoRaceAvoidSlowConsumerBigMessages(t *testing.T) {
 }
 
 func TestNoRaceRoutedQueueAutoUnsubscribe(t *testing.T) {
-	optsA, _ := ProcessConfigFile("./configs/seed.conf")
+	optsA, err := ProcessConfigFile("./configs/seed.conf")
+	require_NoError(t, err)
 	optsA.NoSigs, optsA.NoLog = true, true
 	optsA.NoSystemAccount = true
 	srvA := RunServer(optsA)
@@ -1079,7 +1079,7 @@ func TestNoRaceJetStreamDeleteStreamManyConsumers(t *testing.T) {
 	defer s.Shutdown()
 
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	mname := "MYS"
@@ -1108,7 +1108,7 @@ func TestNoRaceJetStreamAPIStreamListPaging(t *testing.T) {
 
 	// Forced cleanup of all persisted state.
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	// Create 2X limit
@@ -1177,7 +1177,7 @@ func TestNoRaceJetStreamAPIConsumerListPaging(t *testing.T) {
 
 	// Forced cleanup of all persisted state.
 	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
+		defer removeDir(t, config.StoreDir)
 	}
 
 	sname := "MYSTREAM"

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -878,7 +878,7 @@ func TestNkeyUsersConfig(t *testing.T) {
         {nkey: "UA3C5TBZYK5GJQJRWPMU6NFY5JNAEVQB2V2TUZFZDHFJFUYVKTTUOFKZ"}
       ]
     }`))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v", err)
@@ -943,7 +943,7 @@ func TestNkeyUsersDefaultPermissionsConfig(t *testing.T) {
 			t.Fatal("Has unexpected Publish permission")
 		}
 	}
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v", err)
@@ -1004,7 +1004,7 @@ func TestNkeyUsersWithPermsConfig(t *testing.T) {
         }
       ]
     }`))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v", err)
@@ -1038,7 +1038,7 @@ func TestNkeyUsersWithPermsConfig(t *testing.T) {
 
 func TestBadNkeyConfig(t *testing.T) {
 	confFileName := "nkeys_bad.conf"
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	content := `
     authorization {
       users = [ {nkey: "Ufoo"}]
@@ -1053,7 +1053,7 @@ func TestBadNkeyConfig(t *testing.T) {
 
 func TestNkeyWithPassConfig(t *testing.T) {
 	confFileName := "nkeys_pass.conf"
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	content := `
     authorization {
       users = [
@@ -1070,7 +1070,7 @@ func TestNkeyWithPassConfig(t *testing.T) {
 
 func TestTokenWithUserPass(t *testing.T) {
 	confFileName := "test.conf"
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	content := `
 	authorization={
 		user: user
@@ -1091,7 +1091,7 @@ func TestTokenWithUserPass(t *testing.T) {
 
 func TestTokenWithUsers(t *testing.T) {
 	confFileName := "test.conf"
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	content := `
 	authorization={
 		token: $2a$11$whatever
@@ -1113,7 +1113,7 @@ func TestTokenWithUsers(t *testing.T) {
 
 func TestParseWriteDeadline(t *testing.T) {
 	confFile := "test.conf"
-	defer os.Remove(confFile)
+	defer removeFile(t, confFile)
 	if err := ioutil.WriteFile(confFile, []byte("write_deadline: \"1x\""), 0666); err != nil {
 		t.Fatalf("Error writing config file: %v", err)
 	}
@@ -1124,7 +1124,7 @@ func TestParseWriteDeadline(t *testing.T) {
 	if !strings.Contains(err.Error(), "parsing") {
 		t.Fatalf("Expected error related to parsing, got %v", err)
 	}
-	os.Remove(confFile)
+	removeFile(t, confFile)
 	if err := ioutil.WriteFile(confFile, []byte("write_deadline: \"1s\""), 0666); err != nil {
 		t.Fatalf("Error writing config file: %v", err)
 	}
@@ -1135,7 +1135,7 @@ func TestParseWriteDeadline(t *testing.T) {
 	if opts.WriteDeadline != time.Second {
 		t.Fatalf("Expected write_deadline to be 1s, got %v", opts.WriteDeadline)
 	}
-	os.Remove(confFile)
+	removeFile(t, confFile)
 	oldStdout := os.Stdout
 	_, w, _ := os.Pipe()
 	defer func() {
@@ -1263,7 +1263,7 @@ func TestMalformedClusterAddress(t *testing.T) {
 
 func TestPanic(t *testing.T) {
 	conf := createConfFile(t, []byte(`port: "this_string_trips_a_panic"`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	opts, err := ProcessConfigFile(conf)
 	if err == nil {
 		t.Fatalf("Expected an error reading config file: got %+v", opts)
@@ -1276,7 +1276,7 @@ func TestPanic(t *testing.T) {
 
 func TestPingIntervalOld(t *testing.T) {
 	conf := createConfFile(t, []byte(`ping_interval: 5`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	opts := &Options{}
 	err := opts.ProcessConfigFile(conf)
 	if err == nil {
@@ -1299,7 +1299,7 @@ func TestPingIntervalOld(t *testing.T) {
 
 func TestPingIntervalNew(t *testing.T) {
 	conf := createConfFile(t, []byte(`ping_interval: "5m"`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	opts := &Options{}
 	if err := opts.ProcessConfigFile(conf); err != nil {
 		t.Fatalf("expected no error")
@@ -1544,7 +1544,7 @@ func TestClusterPermissionsConfig(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, "")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	opts, err := ProcessConfigFile(conf)
 	if err != nil {
 		if cerr, ok := err.(*processConfigErr); ok && len(cerr.Errors()) > 0 {
@@ -1579,7 +1579,7 @@ func TestClusterPermissionsConfig(t *testing.T) {
 			}
 		}
 	`)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	opts, err = ProcessConfigFile(conf)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -1659,7 +1659,7 @@ func TestClusterPermissionsConfig(t *testing.T) {
 			}
 		`, perms)))
 		_, err := ProcessConfigFile(conf)
-		os.Remove(conf)
+		removeFile(t, conf)
 		if err == nil {
 			t.Fatalf("Expected failure for permissions %s", perms)
 		}
@@ -1677,7 +1677,7 @@ func TestClusterPermissionsConfig(t *testing.T) {
 			}
 		`, perms)))
 		_, err := ProcessConfigFile(conf)
-		os.Remove(conf)
+		removeFile(t, conf)
 		if err == nil {
 			t.Fatalf("Expected failure for permissions %s", perms)
 		}
@@ -1785,7 +1785,7 @@ func TestParseServiceLatency(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			f := createConfFile(t, []byte(c.conf))
 			opts, err := ProcessConfigFile(f)
-			os.Remove(f)
+			removeFile(t, f)
 			switch {
 			case c.wantErr && err == nil:
 				t.Fatalf("Expected ProcessConfigFile to fail, but didn't")
@@ -1880,7 +1880,7 @@ func TestParseExport(t *testing.T) {
 		t.Fatal("Failed startup")
 	}
 	defer s.Shutdown()
-	defer os.Remove(f)
+	defer removeFile(t, f)
 	connect := func(user string) *nats.Conn {
 		nc, err := nats.Connect(fmt.Sprintf("nats://%s:pwd@%s:%d", user, o.Host, o.Port))
 		require_NoError(t, err)
@@ -2004,7 +2004,7 @@ func TestParsingGateways(t *testing.T) {
 	}
 	`
 	file := "server_config_gateways.conf"
-	defer os.Remove(file)
+	defer removeFile(t, file)
 	if err := ioutil.WriteFile(file, []byte(content), 0600); err != nil {
 		t.Fatalf("Error writing config file: %v", err)
 	}
@@ -2257,7 +2257,7 @@ func TestParsingGatewaysErrors(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			file := fmt.Sprintf("server_config_gateways_%s.conf", test.name)
-			defer os.Remove(file)
+			defer removeFile(t, file)
 			if err := ioutil.WriteFile(file, []byte(test.content), 0600); err != nil {
 				t.Fatalf("Error writing config file: %v", err)
 			}
@@ -2291,7 +2291,7 @@ func TestParsingLeafNodesListener(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	opts, err := ProcessConfigFile(conf)
 	if err != nil {
 		t.Fatalf("Error processing file: %v", err)
@@ -2329,7 +2329,7 @@ func TestParsingLeafNodeRemotes(t *testing.T) {
 		}
 		`
 		conf := createConfFile(t, []byte(content))
-		defer os.Remove(conf)
+		defer removeFile(t, conf)
 		opts, err := ProcessConfigFile(conf)
 		if err != nil {
 			t.Fatalf("Error processing file: %v", err)
@@ -2369,7 +2369,7 @@ func TestParsingLeafNodeRemotes(t *testing.T) {
 		}
 		`
 		conf := createConfFile(t, []byte(content))
-		defer os.Remove(conf)
+		defer removeFile(t, conf)
 		opts, err := ProcessConfigFile(conf)
 		if err != nil {
 			t.Fatalf("Error processing file: %v", err)
@@ -2388,7 +2388,7 @@ func TestParsingLeafNodeRemotes(t *testing.T) {
 
 func TestLargeMaxControlLine(t *testing.T) {
 	confFileName := "big_mcl.conf"
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	content := `
     max_control_line = 3000000000
     `
@@ -2402,7 +2402,7 @@ func TestLargeMaxControlLine(t *testing.T) {
 
 func TestLargeMaxPayload(t *testing.T) {
 	confFileName := "big_mp.conf"
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	content := `
     max_payload = 3000000000
     `
@@ -2421,7 +2421,7 @@ func TestHandleUnknownTopLevelConfigurationField(t *testing.T) {
 			id: "me"
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	// Verify that we get an error because of unknown "streaming" field.
 	opts := &Options{}
@@ -2459,7 +2459,7 @@ func TestSublistNoCacheConfig(t *testing.T) {
 	confFileName := createConfFile(t, []byte(`
       disable_sublist_cache: true
     `))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v", err)
@@ -2484,7 +2484,7 @@ func TestSublistNoCacheConfigOnAccounts(t *testing.T) {
 	  }
 	  no_sys_acc = true
     `))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 
 	s, _ := RunServerWithConfig(confFileName)
 	defer s.Shutdown()
@@ -2554,54 +2554,54 @@ func TestParsingResponsePermissions(t *testing.T) {
 
 	// Check defaults
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, "", "")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	check(t, conf, "", DEFAULT_ALLOW_RESPONSE_MAX_MSGS, DEFAULT_ALLOW_RESPONSE_EXPIRATION)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: 10", "")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	check(t, conf, "", 10, DEFAULT_ALLOW_RESPONSE_EXPIRATION)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "", "ttl: 5s")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	check(t, conf, "", DEFAULT_ALLOW_RESPONSE_MAX_MSGS, 5*time.Second)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: 0", "")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	check(t, conf, "", DEFAULT_ALLOW_RESPONSE_MAX_MSGS, DEFAULT_ALLOW_RESPONSE_EXPIRATION)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "", `ttl: "0s"`)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	check(t, conf, "", DEFAULT_ALLOW_RESPONSE_MAX_MSGS, DEFAULT_ALLOW_RESPONSE_EXPIRATION)
 
 	// Check normal values
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: 10", `ttl: "5s"`)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	check(t, conf, "", 10, 5*time.Second)
 
 	// Check negative values ok
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: -1", `ttl: "5s"`)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	check(t, conf, "", -1, 5*time.Second)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: 10", `ttl: "-1s"`)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	check(t, conf, "", 10, -1*time.Second)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: -1", `ttl: "-1s"`)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	check(t, conf, "", -1, -1*time.Second)
 
 	// Check parsing errors
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "unknown_field: 123", "")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	check(t, conf, "Unknown field", 0, 0)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: 10", "ttl: 123")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	check(t, conf, "not a duration string", 0, 0)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: 10", "ttl: xyz")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	check(t, conf, "error parsing expires", 0, 0)
 }
 
@@ -2725,7 +2725,7 @@ func TestNoAuthUserCode(t *testing.T) {
 			]
 		}
 	`))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	defer os.Unsetenv("NO_AUTH_USER")
 
 	for _, user := range []string{"a", "b", "b"} {
@@ -2775,7 +2775,7 @@ const operatorJwtWithSysAccAndUrlResolver = `
 
 func TestReadOperatorJWT(t *testing.T) {
 	confFileName := createConfFile(t, []byte(operatorJwtWithSysAccAndUrlResolver))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received unexpected error %s", err)
@@ -2806,7 +2806,7 @@ func TestReadOperatorJWTSystemAccountMatch(t *testing.T) {
 	confFileName := createConfFile(t, []byte(operatorJwtWithSysAccAndMemResolver+`
 		system_account: ADSPOYMHXJN6JVYQCLRZ5XQ5IUN6A3S33XA4NV4VH74423U7U7YR4YVW
 	`))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received unexpected error %s", err)
@@ -2822,7 +2822,7 @@ func TestReadOperatorJWTSystemAccountMismatch(t *testing.T) {
 	confFileName := createConfFile(t, []byte(operatorJwtWithSysAccAndMemResolver+`
 		system_account: ADXJJCDCSRSMCOV25FXQW7R4QOG7R763TVEXBNWJHLBMBGWOJYG5XZBG
 	`))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received unexpected error %s", err)
@@ -2849,7 +2849,7 @@ func TestReadOperatorAssertVersion(t *testing.T) {
 		operator: %s
 		resolver: MEM
 	`, jwt)))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received unexpected error %s", err)
@@ -2874,7 +2874,7 @@ func TestReadOperatorAssertVersionFail(t *testing.T) {
 		operator: %s
 		resolver: MEM
 	`, jwt)))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received unexpected error %s", err)
@@ -2900,7 +2900,7 @@ func TestClusterNameAndGatewayNameConflict(t *testing.T) {
 			listen: 127.0.0.1:-1
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	opts, err := ProcessConfigFile(conf)
 	if err != nil {
@@ -2970,7 +2970,7 @@ func TestQueuePermissions(t *testing.T) {
 	} {
 		t.Run(test.permType+test.queue, func(t *testing.T) {
 			confFileName := createConfFile(t, []byte(fmt.Sprintf(cfgFmt, test.permType)))
-			defer os.Remove(confFileName)
+			defer removeFile(t, confFileName)
 			opts, err := ProcessConfigFile(confFileName)
 			if err != nil {
 				t.Fatalf("Received unexpected error %s", err)

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -71,7 +71,7 @@ func createConfFile(t *testing.T, content []byte) string {
 	fName := conf.Name()
 	conf.Close()
 	if err := ioutil.WriteFile(fName, content, 0666); err != nil {
-		os.Remove(fName)
+		removeFile(t, fName)
 		t.Fatalf("Error writing conf file: %v", err)
 	}
 	return fName
@@ -128,7 +128,7 @@ func TestConfigReloadNoConfigFile(t *testing.T) {
 // does not support reloading.
 func TestConfigReloadUnsupported(t *testing.T) {
 	server, _, config := newServerWithConfig(t, "./configs/reload/test.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	loaded := server.ConfigTime()
@@ -179,7 +179,7 @@ func TestConfigReloadUnsupported(t *testing.T) {
 // server is changed to support change of listen spec).
 func TestConfigReloadUnsupportedHotSwapping(t *testing.T) {
 	server, _, config := newServerWithContent(t, []byte("listen: 127.0.0.1:-1"))
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	loaded := server.ConfigTime()
@@ -202,7 +202,7 @@ func TestConfigReloadUnsupportedHotSwapping(t *testing.T) {
 // Ensure Reload returns an error when reloading from a bad config file.
 func TestConfigReloadInvalidConfig(t *testing.T) {
 	server, _, config := newServerWithConfig(t, "./configs/reload/test.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	loaded := server.ConfigTime()
@@ -251,9 +251,9 @@ func TestConfigReloadInvalidConfig(t *testing.T) {
 // Ensure Reload returns nil and the config is changed on success.
 func TestConfigReload(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/test.conf")
-	defer os.Remove(config)
-	defer os.Remove("nats-server.pid")
-	defer os.Remove("nats-server.log")
+	defer removeFile(t, config)
+	defer removeFile(t, "nats-server.pid")
+	defer removeFile(t, "nats-server.log")
 	defer server.Shutdown()
 
 	dir := filepath.Dir(config)
@@ -265,7 +265,7 @@ func TestConfigReload(t *testing.T) {
 		`)
 	}
 	platformConf := filepath.Join(dir, "platform.conf")
-	defer os.Remove(platformConf)
+	defer removeFile(t, platformConf)
 	if err := ioutil.WriteFile(platformConf, content, 0666); err != nil {
 		t.Fatalf("Unable to write config file: %v", err)
 	}
@@ -381,7 +381,7 @@ func TestConfigReload(t *testing.T) {
 // ensure reconnect succeeds when the client provides a cert.
 func TestConfigReloadRotateTLS(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/tls_test.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -436,7 +436,7 @@ func TestConfigReloadRotateTLS(t *testing.T) {
 // reconnect fails, then ensure reconnect succeeds when using secure.
 func TestConfigReloadEnableTLS(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/basic.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -468,7 +468,7 @@ func TestConfigReloadEnableTLS(t *testing.T) {
 // without secure.
 func TestConfigReloadDisableTLS(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/tls_test.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -504,7 +504,7 @@ func TestConfigReloadDisableTLS(t *testing.T) {
 // then ensure reconnect succeeds when using the correct credentials.
 func TestConfigReloadRotateUserAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/single_user_authentication_1.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -567,7 +567,7 @@ func TestConfigReloadRotateUserAuthentication(t *testing.T) {
 // ensure reconnect succeeds when using the correct credentials.
 func TestConfigReloadEnableUserAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/basic.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -629,7 +629,7 @@ func TestConfigReloadEnableUserAuthentication(t *testing.T) {
 // with no credentials succeeds.
 func TestConfigReloadDisableUserAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/single_user_authentication_1.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -663,7 +663,7 @@ func TestConfigReloadDisableUserAuthentication(t *testing.T) {
 // ensure reconnect succeeds when using the correct token.
 func TestConfigReloadRotateTokenAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/token_authentication_1.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	disconnected := make(chan struct{})
@@ -721,7 +721,7 @@ func TestConfigReloadRotateTokenAuthentication(t *testing.T) {
 // succeeds when using the correct token.
 func TestConfigReloadEnableTokenAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/basic.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -783,7 +783,7 @@ func TestConfigReloadEnableTokenAuthentication(t *testing.T) {
 // with no token succeeds.
 func TestConfigReloadDisableTokenAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/token_authentication_1.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -817,7 +817,7 @@ func TestConfigReloadDisableTokenAuthentication(t *testing.T) {
 // ensure reconnect succeeds when using the correct credentials.
 func TestConfigReloadRotateUsersAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/multiple_users_1.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -905,7 +905,7 @@ func TestConfigReloadRotateUsersAuthentication(t *testing.T) {
 // succeeds when using the correct credentials.
 func TestConfigReloadEnableUsersAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/basic.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -967,7 +967,7 @@ func TestConfigReloadEnableUsersAuthentication(t *testing.T) {
 // with no credentials succeeds.
 func TestConfigReloadDisableUsersAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/multiple_users_1.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -1001,7 +1001,7 @@ func TestConfigReloadDisableUsersAuthentication(t *testing.T) {
 // closed and publishes fail, then ensure the new permissions succeed.
 func TestConfigReloadChangePermissions(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/authorization_1.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	addr := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
@@ -1235,7 +1235,7 @@ func TestConfigReloadChangePermissions(t *testing.T) {
 // host.
 func TestConfigReloadClusterHostUnsupported(t *testing.T) {
 	server, _, config := runReloadServerWithConfig(t, "./configs/reload/srv_a_1.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Attempt to change cluster listen host.
@@ -1251,7 +1251,7 @@ func TestConfigReloadClusterHostUnsupported(t *testing.T) {
 // port.
 func TestConfigReloadClusterPortUnsupported(t *testing.T) {
 	server, _, config := runReloadServerWithConfig(t, "./configs/reload/srv_a_1.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Attempt to change cluster listen port.
@@ -1269,11 +1269,11 @@ func TestConfigReloadClusterPortUnsupported(t *testing.T) {
 // longer flow until reloading with the correct credentials.
 func TestConfigReloadEnableClusterAuthorization(t *testing.T) {
 	srvb, srvbOpts, srvbConfig := runReloadServerWithConfig(t, "./configs/reload/srv_b_1.conf")
-	defer os.Remove(srvbConfig)
+	defer removeFile(t, srvbConfig)
 	defer srvb.Shutdown()
 
 	srva, srvaOpts, srvaConfig := runReloadServerWithConfig(t, "./configs/reload/srv_a_1.conf")
-	defer os.Remove(srvaConfig)
+	defer removeFile(t, srvaConfig)
 	defer srva.Shutdown()
 
 	checkClusterFormed(t, srva, srvb)
@@ -1338,7 +1338,6 @@ func TestConfigReloadEnableClusterAuthorization(t *testing.T) {
 
 	// Reload Server A with correct route credentials.
 	changeCurrentConfigContent(t, srvaConfig, "./configs/reload/srv_a_2.conf")
-	defer os.Remove(srvaConfig)
 	if err := srva.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
 	}
@@ -1368,11 +1367,11 @@ func TestConfigReloadEnableClusterAuthorization(t *testing.T) {
 // still flow.
 func TestConfigReloadDisableClusterAuthorization(t *testing.T) {
 	srvb, srvbOpts, srvbConfig := runReloadServerWithConfig(t, "./configs/reload/srv_b_2.conf")
-	defer os.Remove(srvbConfig)
+	defer removeFile(t, srvbConfig)
 	defer srvb.Shutdown()
 
 	srva, srvaOpts, srvaConfig := runReloadServerWithConfig(t, "./configs/reload/srv_a_2.conf")
-	defer os.Remove(srvaConfig)
+	defer removeFile(t, srvaConfig)
 	defer srva.Shutdown()
 
 	checkClusterFormed(t, srva, srvb)
@@ -1449,11 +1448,11 @@ func TestConfigReloadDisableClusterAuthorization(t *testing.T) {
 // cluster.
 func TestConfigReloadClusterRoutes(t *testing.T) {
 	srvb, srvbOpts, srvbConfig := runReloadServerWithConfig(t, "./configs/reload/srv_b_1.conf")
-	defer os.Remove(srvbConfig)
+	defer removeFile(t, srvbConfig)
 	defer srvb.Shutdown()
 
 	srva, srvaOpts, srvaConfig := runReloadServerWithConfig(t, "./configs/reload/srv_a_1.conf")
-	defer os.Remove(srvaConfig)
+	defer removeFile(t, srvaConfig)
 	defer srva.Shutdown()
 
 	checkClusterFormed(t, srva, srvb)
@@ -1555,7 +1554,7 @@ func TestConfigReloadClusterRemoveSolicitedRoutes(t *testing.T) {
 	defer srvb.Shutdown()
 
 	srva, srvaOpts, srvaConfig := runReloadServerWithConfig(t, "./configs/reload/srv_a_1.conf")
-	defer os.Remove(srvaConfig)
+	defer removeFile(t, srvaConfig)
 	defer srva.Shutdown()
 
 	checkClusterFormed(t, srva, srvb)
@@ -1603,7 +1602,6 @@ func TestConfigReloadClusterRemoveSolicitedRoutes(t *testing.T) {
 
 	// Now change config for server A to not solicit a route to server B.
 	changeCurrentConfigContent(t, srvaConfig, "./configs/reload/srv_a_4.conf")
-	defer os.Remove(srvaConfig)
 	if err := srva.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
 	}
@@ -1644,7 +1642,7 @@ func TestConfigReloadClusterAdvertise(t *testing.T) {
 			listen: "0.0.0.0:-1"
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	orgClusterPort := s.ClusterAddr().Port
@@ -1716,7 +1714,7 @@ func TestConfigReloadClusterNoAdvertise(t *testing.T) {
 			listen: "0.0.0.0:-1"
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	s.mu.Lock()
@@ -1767,7 +1765,7 @@ func TestConfigReloadClusterName(t *testing.T) {
 			listen: "0.0.0.0:-1"
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	// Update config with a new cluster name.
@@ -1786,7 +1784,7 @@ func TestConfigReloadClusterName(t *testing.T) {
 
 func TestConfigReloadMaxSubsUnsupported(t *testing.T) {
 	s, _, conf := runReloadServerWithContent(t, []byte(`max_subs: 1`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	if err := ioutil.WriteFile(conf, []byte(`max_subs: 10`), 0666); err != nil {
@@ -1799,7 +1797,7 @@ func TestConfigReloadMaxSubsUnsupported(t *testing.T) {
 
 func TestConfigReloadClientAdvertise(t *testing.T) {
 	s, _, conf := runReloadServerWithContent(t, []byte(`listen: "0.0.0.0:-1"`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	orgPort := s.Addr().(*net.TCPAddr).Port
@@ -1846,7 +1844,7 @@ func TestConfigReloadClientAdvertise(t *testing.T) {
 // max connections of one, and ensuring one client is disconnected.
 func TestConfigReloadMaxConnections(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/basic.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Make two connections.
@@ -1901,7 +1899,7 @@ func TestConfigReloadMaxConnections(t *testing.T) {
 // and disconnects the client.
 func TestConfigReloadMaxPayload(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/basic.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	addr := fmt.Sprintf("nats://%s:%d", opts.Host, server.Addr().(*net.TCPAddr).Port)
@@ -1966,11 +1964,9 @@ func TestConfigReloadMaxPayload(t *testing.T) {
 func TestConfigReloadRotateFiles(t *testing.T) {
 	server, _, config := runReloadServerWithConfig(t, "./configs/reload/file_rotate.conf")
 	defer func() {
-		os.Remove(config)
-		os.Remove("log.txt")
-		os.Remove("nats-server.pid")
-		os.Remove("log1.txt")
-		os.Remove("nats-server1.pid")
+		removeFile(t, config)
+		removeFile(t, "log1.txt")
+		removeFile(t, "nats-server1.pid")
 	}()
 	defer server.Shutdown()
 
@@ -2002,12 +1998,8 @@ func TestConfigReloadRotateFiles(t *testing.T) {
 	}
 
 	// Check that the old files can be removed after rename.
-	if err := os.Remove("log_old.txt"); err != nil {
-		t.Fatalf("Error reloading config, cannot delete file: %v", err)
-	}
-	if err := os.Remove("nats-server_old.pid"); err != nil {
-		t.Fatalf("Error reloading config, cannot delete file: %v", err)
-	}
+	removeFile(t, "log_old.txt")
+	removeFile(t, "nats-server_old.pid")
 }
 
 func TestConfigReloadClusterWorks(t *testing.T) {
@@ -2025,7 +2017,7 @@ func TestConfigReloadClusterWorks(t *testing.T) {
 			]
 		}`
 	confB := createConfFile(t, []byte(fmt.Sprintf(confBTemplate, 3)))
-	defer os.Remove(confB)
+	defer removeFile(t, confB)
 
 	confATemplate := `
 		listen: -1
@@ -2041,7 +2033,7 @@ func TestConfigReloadClusterWorks(t *testing.T) {
 			]
 		}`
 	confA := createConfFile(t, []byte(fmt.Sprintf(confATemplate, 3)))
-	defer os.Remove(confA)
+	defer removeFile(t, confA)
 
 	srvb, _ := RunServerWithConfig(confB)
 	defer srvb.Shutdown()
@@ -2103,7 +2095,7 @@ func TestConfigReloadClusterPerms(t *testing.T) {
 		no_sys_acc: true
 	`
 	confA := createConfFile(t, []byte(fmt.Sprintf(confATemplate, `"foo"`, `"foo"`)))
-	defer os.Remove(confA)
+	defer removeFile(t, confA)
 	srva, _ := RunServerWithConfig(confA)
 	defer srva.Shutdown()
 
@@ -2126,7 +2118,7 @@ func TestConfigReloadClusterPerms(t *testing.T) {
 		no_sys_acc: true
 	`
 	confB := createConfFile(t, []byte(fmt.Sprintf(confBTemplate, `"foo"`, `"foo"`, srva.ClusterAddr().Port)))
-	defer os.Remove(confB)
+	defer removeFile(t, confB)
 	srvb, _ := RunServerWithConfig(confB)
 	defer srvb.Shutdown()
 
@@ -2301,7 +2293,7 @@ func TestConfigReloadClusterPermsImport(t *testing.T) {
 		no_sys_acc: true
 	`
 	confA := createConfFile(t, []byte(fmt.Sprintf(confATemplate, `["foo", "bar"]`)))
-	defer os.Remove(confA)
+	defer removeFile(t, confA)
 	srva, _ := RunServerWithConfig(confA)
 	defer srva.Shutdown()
 
@@ -2316,7 +2308,7 @@ func TestConfigReloadClusterPermsImport(t *testing.T) {
 		no_sys_acc: true
 	`
 	confB := createConfFile(t, []byte(fmt.Sprintf(confBTemplate, srva.ClusterAddr().Port)))
-	defer os.Remove(confB)
+	defer removeFile(t, confB)
 	srvb, _ := RunServerWithConfig(confB)
 	defer srvb.Shutdown()
 
@@ -2398,7 +2390,7 @@ func TestConfigReloadClusterPermsExport(t *testing.T) {
 		no_sys_acc: true
 	`
 	confA := createConfFile(t, []byte(fmt.Sprintf(confATemplate, `["foo", "bar"]`)))
-	defer os.Remove(confA)
+	defer removeFile(t, confA)
 	srva, _ := RunServerWithConfig(confA)
 	defer srva.Shutdown()
 
@@ -2413,7 +2405,7 @@ func TestConfigReloadClusterPermsExport(t *testing.T) {
 		no_sys_acc: true
 	`
 	confB := createConfFile(t, []byte(fmt.Sprintf(confBTemplate, srva.ClusterAddr().Port)))
-	defer os.Remove(confB)
+	defer removeFile(t, confB)
 	srvb, _ := RunServerWithConfig(confB)
 	defer srvb.Shutdown()
 
@@ -2494,7 +2486,7 @@ func TestConfigReloadClusterPermsOldServer(t *testing.T) {
 		}
 	`
 	confA := createConfFile(t, []byte(fmt.Sprintf(confATemplate, `["foo", "bar"]`)))
-	defer os.Remove(confA)
+	defer removeFile(t, confA)
 	srva, _ := RunServerWithConfig(confA)
 	defer srva.Shutdown()
 
@@ -2580,7 +2572,7 @@ func TestConfigReloadAccountUsers(t *testing.T) {
 		}
 	}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -2765,7 +2757,7 @@ func TestConfigReloadAccountNKeyUsers(t *testing.T) {
 		}
 	}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -2911,7 +2903,7 @@ func TestConfigReloadAccountStreamsImportExport(t *testing.T) {
 	// nats.io account imports "foo.*" from synadia
 	// nats.io account imports "private.natsio.*" from synadia with prefix "ivan"
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, `"foo.*"`, `"xxx"`, `"foo.*"`, `"ivan"`)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -3102,7 +3094,7 @@ func TestConfigReloadAccountServicesImportExport(t *testing.T) {
 		port: -1
 	}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -3253,7 +3245,7 @@ func TestConfigReloadNotPreventedByGateways(t *testing.T) {
 		no_sys_acc: true
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(confTemplate, "", "5")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -3271,7 +3263,7 @@ func TestConfigReloadBoolFlags(t *testing.T) {
 	defer func() { FlagSnapshot = nil }()
 
 	logfile := "logtime.log"
-	defer os.Remove(logfile)
+	defer removeFile(t, logfile)
 	template := `
 		listen: "127.0.0.1:-1"
 		logfile: "logtime.log"
@@ -3656,7 +3648,7 @@ func TestConfigReloadBoolFlags(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			conf := createConfFile(t, []byte(fmt.Sprintf(template, test.content)))
-			defer os.Remove(conf)
+			defer removeFile(t, conf)
 
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			var args []string
@@ -3687,7 +3679,7 @@ func TestConfigReloadBoolFlags(t *testing.T) {
 
 func TestConfigReloadMaxControlLineWithClients(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/basic.conf")
-	defer os.Remove(config)
+	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -3738,7 +3730,7 @@ func TestConfigReloadIgnoreCustomAuth(t *testing.T) {
 	conf := createConfFile(t, []byte(`
 		port: -1
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	opts := LoadConfig(conf)
 
 	ca := &testCustomAuth{}
@@ -3764,7 +3756,7 @@ func TestConfigReloadLeafNodeRandomPort(t *testing.T) {
 			port: -1
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -3800,7 +3792,7 @@ func TestConfigReloadLeafNodeWithTLS(t *testing.T) {
 		}
 	`
 	conf1 := createConfFile(t, []byte(fmt.Sprintf(template, "")))
-	defer os.Remove(conf1)
+	defer removeFile(t, conf1)
 	s1, o1 := RunServerWithConfig(conf1)
 	defer s1.Shutdown()
 
@@ -3824,7 +3816,7 @@ func TestConfigReloadLeafNodeWithTLS(t *testing.T) {
 			]
 		}
 	`, u.String())))
-	defer os.Remove(conf2)
+	defer removeFile(t, conf2)
 	o2, err := ProcessConfigFile(conf2)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -3857,7 +3849,7 @@ func TestConfigReloadLeafNodeWithRemotesNoChanges(t *testing.T) {
 	  }
 	`
 	conf1 := createConfFile(t, []byte(fmt.Sprintf(template, "")))
-	defer os.Remove(conf1)
+	defer removeFile(t, conf1)
 	s1, o1 := RunServerWithConfig(conf1)
 	defer s1.Shutdown()
 
@@ -3882,7 +3874,7 @@ func TestConfigReloadLeafNodeWithRemotesNoChanges(t *testing.T) {
 	`
 	config := fmt.Sprintf(template2, "A", u.String())
 	conf2 := createConfFile(t, []byte(config))
-	defer os.Remove(conf2)
+	defer removeFile(t, conf2)
 	o2, err := ProcessConfigFile(conf2)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -3912,7 +3904,7 @@ func TestConfigReloadAndVarz(t *testing.T) {
 		%s
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, "")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -3953,7 +3945,7 @@ func TestConfigReloadConnectErrReports(t *testing.T) {
 		%s
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, "", "")))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -4084,7 +4076,7 @@ func TestConfigReloadAccountResolverTLSConfig(t *testing.T) {
 			insecure: true
 		}
 	`)))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -4171,7 +4163,7 @@ func TestLoggingReload(t *testing.T) {
 	`
 
 	conf := createConfFile(t, []byte(commonCfg))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -4216,12 +4208,12 @@ func TestLoggingReload(t *testing.T) {
 		nc.Close()
 	}
 
-	defer os.Remove("off-pre.log")
+	defer removeFile(t, "off-pre.log")
 	reload("log_file: off-pre.log")
 
 	traffic(10) // generate NO trace/debug entries in off-pre.log
 
-	defer os.Remove("on.log")
+	defer removeFile(t, "on.log")
 	reload(`
 		log_file: on.log
 		debug: true
@@ -4230,7 +4222,7 @@ func TestLoggingReload(t *testing.T) {
 
 	traffic(10) // generate trace/debug entries in on.log
 
-	defer os.Remove("off-post.log")
+	defer removeFile(t, "off-post.log")
 	reload(`
 		log_file: off-post.log
 		debug: false
@@ -4256,7 +4248,7 @@ func TestReloadValidate(t *testing.T) {
 			]
 		}
 	`))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	srv, _ := RunServerWithConfig(confFileName)
 	if srv == nil {
 		t.Fatal("Server did not start")
@@ -4301,7 +4293,7 @@ func TestConfigReloadAccounts(t *testing.T) {
 		}
 	}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s, o := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -4444,7 +4436,7 @@ func TestConfigReloadDefaultSystemAccount(t *testing.T) {
 		}
 	}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -4496,7 +4488,7 @@ func TestConfigReloadAccountMappings(t *testing.T) {
 		}
 	}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -109,7 +109,8 @@ func TestClusterAdvertise(t *testing.T) {
 		ch <- nil
 	}()
 
-	optsA, _ := ProcessConfigFile("./configs/seed.conf")
+	optsA, err := ProcessConfigFile("./configs/seed.conf")
+	require_NoError(t, err)
 	optsA.NoSigs, optsA.NoLog = true, true
 	srvA := RunServer(optsA)
 	defer srvA.Shutdown()
@@ -153,7 +154,8 @@ func TestClusterAdvertiseErrorOnStartup(t *testing.T) {
 }
 
 func TestClientAdvertise(t *testing.T) {
-	optsA, _ := ProcessConfigFile("./configs/seed.conf")
+	optsA, err := ProcessConfigFile("./configs/seed.conf")
+	require_NoError(t, err)
 	optsA.NoSigs, optsA.NoLog = true, true
 
 	srvA := RunServer(optsA)
@@ -184,8 +186,10 @@ func TestClientAdvertise(t *testing.T) {
 }
 
 func TestServerRoutesWithClients(t *testing.T) {
-	optsA, _ := ProcessConfigFile("./configs/srv_a.conf")
-	optsB, _ := ProcessConfigFile("./configs/srv_b.conf")
+	optsA, err := ProcessConfigFile("./configs/srv_a.conf")
+	require_NoError(t, err)
+	optsB, err := ProcessConfigFile("./configs/srv_b.conf")
+	require_NoError(t, err)
 
 	optsA.NoSigs, optsA.NoLog = true, true
 	optsB.NoSigs, optsB.NoLog = true, true
@@ -226,8 +230,10 @@ func TestServerRoutesWithClients(t *testing.T) {
 }
 
 func TestServerRoutesWithAuthAndBCrypt(t *testing.T) {
-	optsA, _ := ProcessConfigFile("./configs/srv_a_bcrypt.conf")
-	optsB, _ := ProcessConfigFile("./configs/srv_b_bcrypt.conf")
+	optsA, err := ProcessConfigFile("./configs/srv_a_bcrypt.conf")
+	require_NoError(t, err)
+	optsB, err := ProcessConfigFile("./configs/srv_b_bcrypt.conf")
+	require_NoError(t, err)
 
 	optsA.NoSigs, optsA.NoLog = true, true
 	optsB.NoSigs, optsB.NoLog = true, true
@@ -305,7 +311,8 @@ func nextServerOpts(opts *Options) *Options {
 }
 
 func TestSeedSolicitWorks(t *testing.T) {
-	optsSeed, _ := ProcessConfigFile("./configs/seed.conf")
+	optsSeed, err := ProcessConfigFile("./configs/seed.conf")
+	require_NoError(t, err)
 
 	optsSeed.NoSigs, optsSeed.NoLog = true, true
 	optsSeed.NoSystemAccount = true
@@ -362,7 +369,8 @@ func TestSeedSolicitWorks(t *testing.T) {
 }
 
 func TestTLSSeedSolicitWorks(t *testing.T) {
-	optsSeed, _ := ProcessConfigFile("./configs/seed_tls.conf")
+	optsSeed, err := ProcessConfigFile("./configs/seed_tls.conf")
+	require_NoError(t, err)
 
 	optsSeed.NoSigs, optsSeed.NoLog = true, true
 	optsSeed.NoSystemAccount = true
@@ -419,7 +427,8 @@ func TestTLSSeedSolicitWorks(t *testing.T) {
 }
 
 func TestChainedSolicitWorks(t *testing.T) {
-	optsSeed, _ := ProcessConfigFile("./configs/seed.conf")
+	optsSeed, err := ProcessConfigFile("./configs/seed.conf")
+	require_NoError(t, err)
 
 	optsSeed.NoSigs, optsSeed.NoLog = true, true
 	optsSeed.NoSystemAccount = true
@@ -492,7 +501,8 @@ func checkExpectedSubs(t *testing.T, expected int, servers ...*Server) {
 }
 
 func TestTLSChainedSolicitWorks(t *testing.T) {
-	optsSeed, _ := ProcessConfigFile("./configs/seed_tls.conf")
+	optsSeed, err := ProcessConfigFile("./configs/seed_tls.conf")
+	require_NoError(t, err)
 
 	optsSeed.NoSigs, optsSeed.NoLog = true, true
 	optsSeed.NoSystemAccount = true
@@ -551,7 +561,8 @@ func TestTLSChainedSolicitWorks(t *testing.T) {
 }
 
 func TestRouteTLSHandshakeError(t *testing.T) {
-	optsSeed, _ := ProcessConfigFile("./configs/seed_tls.conf")
+	optsSeed, err := ProcessConfigFile("./configs/seed_tls.conf")
+	require_NoError(t, err)
 	optsSeed.NoLog = true
 	optsSeed.NoSigs = true
 	srvSeed := RunServer(optsSeed)
@@ -875,10 +886,12 @@ func TestServerPoolUpdatedWhenRouteGoesAway(t *testing.T) {
 }
 
 func TestRouteFailedConnRemovedFromTmpMap(t *testing.T) {
-	optsA, _ := ProcessConfigFile("./configs/srv_a.conf")
+	optsA, err := ProcessConfigFile("./configs/srv_a.conf")
+	require_NoError(t, err)
 	optsA.NoSigs, optsA.NoLog = true, true
 
-	optsB, _ := ProcessConfigFile("./configs/srv_b.conf")
+	optsB, err := ProcessConfigFile("./configs/srv_b.conf")
+	require_NoError(t, err)
 	optsB.NoSigs, optsB.NoLog = true, true
 
 	srvA := New(optsA)
@@ -935,7 +948,8 @@ func TestRoutePermsAppliedOnInboundAndOutboundRoute(t *testing.T) {
 		},
 	}
 
-	optsA, _ := ProcessConfigFile("./configs/seed.conf")
+	optsA, err := ProcessConfigFile("./configs/seed.conf")
+	require_NoError(t, err)
 	optsA.NoLog = true
 	optsA.NoSigs = true
 	optsA.Cluster.Permissions = perms

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1580,7 +1580,7 @@ func TestConnectErrorReports(t *testing.T) {
 	tmpFile := createFile(t, "")
 	log := tmpFile.Name()
 	tmpFile.Close()
-	defer os.Remove(log)
+	defer removeFile(t, log)
 
 	remoteURLs := RoutesFromStr("nats://127.0.0.1:1234")
 
@@ -1633,7 +1633,7 @@ func TestConnectErrorReports(t *testing.T) {
 	}
 
 	s.Shutdown()
-	os.Remove(log)
+	removeFile(t, log)
 
 	// Now try with leaf nodes
 	opts.Cluster.Port = 0
@@ -1676,7 +1676,7 @@ func TestConnectErrorReports(t *testing.T) {
 	}
 
 	s.Shutdown()
-	os.Remove(log)
+	removeFile(t, log)
 
 	// Now try with gateways
 	opts.LeafNode.Remotes = nil
@@ -1732,7 +1732,7 @@ func TestReconnectErrorReports(t *testing.T) {
 	tmpFile := createFile(t, "")
 	log := tmpFile.Name()
 	tmpFile.Close()
-	defer os.Remove(log)
+	defer removeFile(t, log)
 
 	csOpts := DefaultOptions()
 	csOpts.Cluster.Port = -1
@@ -1797,7 +1797,7 @@ func TestReconnectErrorReports(t *testing.T) {
 	}
 
 	s.Shutdown()
-	os.Remove(log)
+	removeFile(t, log)
 
 	// Now try with leaf nodes
 	csOpts.Cluster.Port = 0
@@ -1853,7 +1853,7 @@ func TestReconnectErrorReports(t *testing.T) {
 	}
 
 	s.Shutdown()
-	os.Remove(log)
+	removeFile(t, log)
 
 	// Now try with gateways
 	csOpts.LeafNode.Port = 0
@@ -1914,7 +1914,7 @@ func TestReconnectErrorReports(t *testing.T) {
 
 func TestServerLogsConfigurationFile(t *testing.T) {
 	tmpDir := createDir(t, "_nats-server")
-	defer os.RemoveAll(tmpDir)
+	defer removeDir(t, tmpDir)
 
 	file := createFileAtDir(t, tmpDir, "nats_server_log_")
 	file.Close()
@@ -1923,7 +1923,7 @@ func TestServerLogsConfigurationFile(t *testing.T) {
 	port: -1
 	logfile: "%s"
 	`, file.Name())))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	o := LoadConfig(conf)
 	o.ConfigFile = file.Name()

--- a/server/signal_test.go
+++ b/server/signal_test.go
@@ -32,8 +32,8 @@ import (
 
 func TestSignalToReOpenLogFile(t *testing.T) {
 	logFile := "test.log"
-	defer os.Remove(logFile)
-	defer os.Remove(logFile + ".bak")
+	defer removeFile(t, logFile)
+	defer removeFile(t, logFile+".bak")
 	opts := &Options{
 		Host:    "127.0.0.1",
 		Port:    -1,

--- a/server/trust_test.go
+++ b/server/trust_test.go
@@ -15,7 +15,6 @@ package server
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 )
@@ -85,7 +84,7 @@ func TestTrustedKeysOptions(t *testing.T) {
 
 func TestTrustConfigOption(t *testing.T) {
 	confFileName := createConfFile(t, []byte(fmt.Sprintf("trusted = %q", t1)))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Error parsing config: %v", err)
@@ -98,7 +97,7 @@ func TestTrustConfigOption(t *testing.T) {
 	}
 
 	confFileName = createConfFile(t, []byte(fmt.Sprintf("trusted = [%q, %q]", t1, t2)))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	opts, err = ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Error parsing config: %v", err)
@@ -115,7 +114,7 @@ func TestTrustConfigOption(t *testing.T) {
 
 	// Now do a bad one.
 	confFileName = createConfFile(t, []byte(fmt.Sprintf("trusted = [%q, %q]", t1, "bad")))
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	_, err = ProcessConfigFile(confFileName)
 	if err == nil {
 		t.Fatalf("Expected an error parsing trust keys with a bad key")

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -29,7 +29,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -1485,7 +1484,7 @@ func TestWSParseOptions(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			conf := createConfFile(t, []byte(test.content))
-			defer os.Remove(conf)
+			defer removeFile(t, conf)
 			o, err := ProcessConfigFile(conf)
 			if test.err != _EMPTY_ {
 				if err == nil || !strings.Contains(err.Error(), test.err) {
@@ -3188,7 +3187,7 @@ func TestWSBindToProperAccount(t *testing.T) {
 			no_tls: true
 		}
 	`, jwt.ConnectionTypeStandard, strings.ToLower(jwt.ConnectionTypeWebsocket)))) // on purpose use lower case to ensure that it is converted.
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s, o := RunServerWithConfig(conf)
 	defer s.Shutdown()
 

--- a/test/accounts_cycles_test.go
+++ b/test/accounts_cycles_test.go
@@ -15,7 +15,6 @@ package test
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -37,7 +36,7 @@ func TestAccountCycleService(t *testing.T) {
 		  }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), server.ErrImportFormsCycle.Error()) {
 		t.Fatalf("Expected an error on cycle service import, got none")
@@ -55,7 +54,7 @@ func TestAccountCycleService(t *testing.T) {
 		  }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), server.ErrImportFormsCycle.Error()) {
 		t.Fatalf("Expected an error on cycle service import, got none")
@@ -77,7 +76,7 @@ func TestAccountCycleService(t *testing.T) {
 		  }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), server.ErrImportFormsCycle.Error()) {
 		t.Fatalf("Expected an error on cycle service import, got none")
@@ -97,7 +96,7 @@ func TestAccountCycleStream(t *testing.T) {
 		  }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), server.ErrImportFormsCycle.Error()) {
 		t.Fatalf("Expected an error on cyclic import, got none")
 	}
@@ -116,7 +115,7 @@ func TestAccountCycleStreamWithMapping(t *testing.T) {
 		  }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), server.ErrImportFormsCycle.Error()) {
 		t.Fatalf("Expected an error on cyclic import, got none")
 	}
@@ -139,7 +138,7 @@ func TestAccountCycleNonCycleStreamWithMapping(t *testing.T) {
 		  }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	if _, err := server.ProcessConfigFile(conf); err != nil {
 		t.Fatalf("Expected no error but got %s", err)
 	}
@@ -158,7 +157,7 @@ func TestAccountCycleServiceCycleWithMapping(t *testing.T) {
 		  }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), server.ErrImportFormsCycle.Error()) {
 		t.Fatalf("Expected an error on cycle service import, got none")
 	}
@@ -181,7 +180,7 @@ func TestAccountCycleServiceNonCycle(t *testing.T) {
 		  }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	if _, err := server.ProcessConfigFile(conf); err != nil {
 		t.Fatalf("Expected no error but got %s", err)
@@ -208,7 +207,7 @@ func TestAccountCycleServiceNonCycleChain(t *testing.T) {
 		  }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	if _, err := server.ProcessConfigFile(conf); err != nil {
 		t.Fatalf("Expected no error but got %s", err)
@@ -231,7 +230,7 @@ func TestServiceImportReplyMatchCycle(t *testing.T) {
 		}
 		no_auth_user: d
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -275,7 +274,7 @@ func TestServiceImportReplyMatchCycleMultiHops(t *testing.T) {
 		}
 		no_auth_user: d
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()

--- a/test/client_auth_test.go
+++ b/test/client_auth_test.go
@@ -16,7 +16,6 @@ package test
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/nats-io/nats.go"
@@ -67,7 +66,7 @@ const testToken = "$2a$05$3sSWEVA1eMCbV0hWavDjXOx.ClBjI6u1CuUdLqf22cbJjXsnzz8/."
 
 func TestTokenInConfig(t *testing.T) {
 	confFileName := "test.conf"
-	defer os.Remove(confFileName)
+	defer removeFile(t, confFileName)
 	content := `
 	listen: 127.0.0.1:4567
 	authorization={

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -543,7 +542,7 @@ func TestClusterNameOption(t *testing.T) {
 			listen: 127.0.0.1:-1
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -564,7 +563,7 @@ func TestEphemeralClusterName(t *testing.T) {
 			listen: 127.0.0.1:-1
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -601,7 +600,7 @@ func TestClusterNameConflictsDropRoutes(t *testing.T) {
 			listen: 127.0.0.1:5244
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s1, _ := RunServerWithConfig(conf)
 	defer s1.Shutdown()
@@ -615,7 +614,7 @@ func TestClusterNameConflictsDropRoutes(t *testing.T) {
 			routes = [nats-route://127.0.0.1:5244]
 		}
 	`))
-	defer os.Remove(conf2)
+	defer removeFile(t, conf2)
 
 	s2, _ := RunServerWithConfig(conf2)
 	defer s2.Shutdown()
@@ -636,7 +635,7 @@ func TestClusterNameDynamicNegotiation(t *testing.T) {
 		listen: 127.0.0.1:-1
 		cluster {listen: 127.0.0.1:5244}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	seed, _ := RunServerWithConfig(conf)
 	defer seed.Shutdown()
@@ -648,7 +647,7 @@ func TestClusterNameDynamicNegotiation(t *testing.T) {
 			routes = [nats-route://127.0.0.1:5244]
 		}
 	`))
-	defer os.Remove(oconf)
+	defer removeFile(t, oconf)
 
 	// Create a random number of additional servers, up to 20.
 	numServers := rand.Intn(20) + 1

--- a/test/gateway_test.go
+++ b/test/gateway_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -597,7 +596,7 @@ func TestGatewayTLSMixedIPAndDNS(t *testing.T) {
 			listen: "127.0.0.1:-1"
 		}
 	`))
-	defer os.Remove(confA1)
+	defer removeFile(t, confA1)
 	srvA1, optsA1 := RunServerWithConfig(confA1)
 	defer srvA1.Shutdown()
 
@@ -622,7 +621,7 @@ func TestGatewayTLSMixedIPAndDNS(t *testing.T) {
 	`
 	confA2 := createConfFile(t, []byte(fmt.Sprintf(confA2Template,
 		optsA1.Cluster.Host, optsA1.Cluster.Port)))
-	defer os.Remove(confA2)
+	defer removeFile(t, confA2)
 	srvA2, optsA2 := RunServerWithConfig(confA2)
 	defer srvA2.Shutdown()
 

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -1124,7 +1124,7 @@ func TestLeafNodeBasicAuth(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -1190,7 +1190,7 @@ func TestLeafNodeTLS(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -1229,7 +1229,7 @@ func TestLeafNodeTLSConnCloseEarly(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -1278,7 +1278,7 @@ func TestLeafNodeTLSMixIP(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -1296,7 +1296,7 @@ func TestLeafNodeTLSMixIP(t *testing.T) {
 	}
 	`
 	slconf := createConfFile(t, []byte(fmt.Sprintf(slContent, opts.LeafNode.Port, opts.LeafNode.Port)))
-	defer os.Remove(slconf)
+	defer removeFile(t, slconf)
 
 	// This will fail but we want to make sure in the correct way, not with
 	// TLS issue because we used an IP for serverName.
@@ -1372,7 +1372,7 @@ func runSolicitWithCredentials(t *testing.T, opts *server.Options, creds string)
 
 func TestLeafNodeOperatorModel(t *testing.T) {
 	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	// Make sure we get disconnected without proper credentials etc.
@@ -1399,10 +1399,10 @@ func TestLeafNodeOperatorModel(t *testing.T) {
 	}
 	seed, _ := kp.Seed()
 	mycreds := genCredsFile(t, ujwt, seed)
-	defer os.Remove(mycreds)
+	defer removeFile(t, mycreds)
 
 	sl, _, lnconf := runSolicitWithCredentials(t, opts, mycreds)
-	defer os.Remove(lnconf)
+	defer removeFile(t, lnconf)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, s)
@@ -1410,7 +1410,7 @@ func TestLeafNodeOperatorModel(t *testing.T) {
 
 func TestLeafNodeUserPermsForConnection(t *testing.T) {
 	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	// Setup account and a user that will be used by the remote leaf node server.
@@ -1428,7 +1428,7 @@ func TestLeafNodeUserPermsForConnection(t *testing.T) {
 	}
 	seed, _ := kp.Seed()
 	mycreds := genCredsFile(t, ujwt, seed)
-	defer os.Remove(mycreds)
+	defer removeFile(t, mycreds)
 
 	content := `
 		port: -1
@@ -1445,7 +1445,7 @@ func TestLeafNodeUserPermsForConnection(t *testing.T) {
 		`
 	config := fmt.Sprintf(content, opts.LeafNode.Port, mycreds)
 	lnconf := createConfFile(t, []byte(config))
-	defer os.Remove(lnconf)
+	defer removeFile(t, lnconf)
 	sl, _ := RunServerWithConfig(lnconf)
 	defer sl.Shutdown()
 
@@ -1508,7 +1508,7 @@ func TestLeafNodeMultipleAccounts(t *testing.T) {
 	// So we will create a main server with two accounts. The remote server, acting as a leaf node, will simply have
 	// the $G global account and no auth. Make sure things work properly here.
 	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	// Setup the two accounts for this server.
@@ -1527,10 +1527,10 @@ func TestLeafNodeMultipleAccounts(t *testing.T) {
 	// Create the leaf node server using the first account.
 	seed, _ := kp1.Seed()
 	mycreds := genCredsFile(t, ujwt1, seed)
-	defer os.Remove(mycreds)
+	defer removeFile(t, mycreds)
 
 	sl, lopts, lnconf := runSolicitWithCredentials(t, opts, mycreds)
-	defer os.Remove(lnconf)
+	defer removeFile(t, lnconf)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, s)
@@ -1575,7 +1575,7 @@ func TestLeafNodeMultipleAccounts(t *testing.T) {
 
 func TestLeafNodeSignerUser(t *testing.T) {
 	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	// Setup the two accounts for this server.
@@ -1640,10 +1640,10 @@ func TestLeafNodeSignerUser(t *testing.T) {
 	// Create the leaf node server using the first account.
 	seed, _ := kp1.Seed()
 	mycreds := genCredsFile(t, ujwt1, seed)
-	defer os.Remove(mycreds)
+	defer removeFile(t, mycreds)
 
 	sl, _, lnconf := runSolicitWithCredentials(t, opts, mycreds)
-	defer os.Remove(lnconf)
+	defer removeFile(t, lnconf)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, s)
@@ -1653,7 +1653,7 @@ func TestLeafNodeExportsImports(t *testing.T) {
 	// So we will create a main server with two accounts. The remote server, acting as a leaf node, will simply have
 	// the $G global account and no auth. Make sure things work properly here.
 	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	// Setup the two accounts for this server.
@@ -1704,10 +1704,10 @@ func TestLeafNodeExportsImports(t *testing.T) {
 	// Create the leaf node server using the first account.
 	seed, _ := kp1.Seed()
 	mycreds := genCredsFile(t, ujwt1, seed)
-	defer os.Remove(mycreds)
+	defer removeFile(t, mycreds)
 
 	sl, lopts, lnconf := runSolicitWithCredentials(t, opts, mycreds)
-	defer os.Remove(lnconf)
+	defer removeFile(t, lnconf)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, s)
@@ -1783,7 +1783,7 @@ func TestLeafNodeExportImportComplexSetup(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s1, s1Opts := RunServerWithConfig(conf)
 	defer s1.Shutdown()
 
@@ -1868,10 +1868,10 @@ func TestLeafNodeExportImportComplexSetup(t *testing.T) {
 	// Create the leaf node server using the first account.
 	seed, _ := kp1.Seed()
 	mycreds := genCredsFile(t, ujwt1, seed)
-	defer os.Remove(mycreds)
+	defer removeFile(t, mycreds)
 
 	sl, lopts, lnconf := runSolicitWithCredentials(t, s1Opts, mycreds)
-	defer os.Remove(lnconf)
+	defer removeFile(t, lnconf)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, s1)
@@ -2205,7 +2205,7 @@ func TestLeafNodeAdvertise(t *testing.T) {
 
 func TestLeafNodeConnectionLimitsSingleServer(t *testing.T) {
 	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	// Setup account and a user that will be used by the remote leaf node server.
@@ -2235,7 +2235,7 @@ func TestLeafNodeConnectionLimitsSingleServer(t *testing.T) {
 	}
 	seed, _ := kp.Seed()
 	mycreds := genCredsFile(t, ujwt, seed)
-	defer os.Remove(mycreds)
+	defer removeFile(t, mycreds)
 
 	checkAccConnectionCounts := func(t *testing.T, expected int) {
 		t.Helper()
@@ -2263,7 +2263,7 @@ func TestLeafNodeConnectionLimitsSingleServer(t *testing.T) {
 	}
 
 	sl, _, lnconf := runSolicitWithCredentials(t, opts, mycreds)
-	defer os.Remove(lnconf)
+	defer removeFile(t, lnconf)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnections(t, s, 1)
@@ -2276,7 +2276,7 @@ func TestLeafNodeConnectionLimitsSingleServer(t *testing.T) {
 	}
 
 	s2, _, lnconf2 := runSolicitWithCredentials(t, opts, mycreds)
-	defer os.Remove(lnconf2)
+	defer removeFile(t, lnconf2)
 	defer s2.Shutdown()
 	checkLeafNodeConnections(t, s, 2)
 	checkAccConnectionCounts(t, 2)
@@ -2294,7 +2294,7 @@ func TestLeafNodeConnectionLimitsSingleServer(t *testing.T) {
 
 	// Now add back the second one as #3.
 	s3, _, lnconf3 := runSolicitWithCredentials(t, opts, mycreds)
-	defer os.Remove(lnconf3)
+	defer removeFile(t, lnconf3)
 	defer s3.Shutdown()
 	checkLeafNodeConnections(t, s, 2)
 
@@ -2302,7 +2302,7 @@ func TestLeafNodeConnectionLimitsSingleServer(t *testing.T) {
 
 	// Once we are here we should not be able to create anymore. Limit == 2.
 	s4, _, lnconf4 := runSolicitWithCredentials(t, opts, mycreds)
-	defer os.Remove(lnconf4)
+	defer removeFile(t, lnconf4)
 	defer s4.Shutdown()
 
 	checkAccConnectionCounts(t, 2)
@@ -2339,7 +2339,7 @@ func TestLeafNodeConnectionLimitsCluster(t *testing.T) {
     }
 	`
 	conf := createConfFile(t, []byte(content))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	s1, s1Opts := RunServerWithConfig(conf)
 	defer s1.Shutdown()
 
@@ -2406,18 +2406,18 @@ func TestLeafNodeConnectionLimitsCluster(t *testing.T) {
 	}
 	seed, _ := kp.Seed()
 	mycreds := genCredsFile(t, ujwt, seed)
-	defer os.Remove(mycreds)
+	defer removeFile(t, mycreds)
 
 	loop := maxleafs / 2
 
 	// Now create maxleafs/2 leaf node servers on each operator server.
 	for i := 0; i < loop; i++ {
 		sl1, _, lnconf1 := runSolicitWithCredentials(t, s1Opts, mycreds)
-		defer os.Remove(lnconf1)
+		defer removeFile(t, lnconf1)
 		defer sl1.Shutdown()
 
 		sl2, _, lnconf2 := runSolicitWithCredentials(t, s2Opts, mycreds)
-		defer os.Remove(lnconf2)
+		defer removeFile(t, lnconf2)
 		defer sl2.Shutdown()
 	}
 
@@ -2448,7 +2448,7 @@ func TestLeafNodeConnectionLimitsCluster(t *testing.T) {
 
 	// Now that we are here we should not be allowed anymore leaf nodes.
 	l, _, lnconf := runSolicitWithCredentials(t, s1Opts, mycreds)
-	defer os.Remove(lnconf)
+	defer removeFile(t, lnconf)
 	defer l.Shutdown()
 
 	checkAccLFCount(acc, false, maxleafs)
@@ -2456,7 +2456,7 @@ func TestLeafNodeConnectionLimitsCluster(t *testing.T) {
 	checkLeafNodeConnections(t, s1, loop)
 
 	l, _, lnconf = runSolicitWithCredentials(t, s2Opts, mycreds)
-	defer os.Remove(lnconf)
+	defer removeFile(t, lnconf)
 	defer l.Shutdown()
 	checkAccLFCount(acc2, false, maxleafs)
 	// Should still be at loop size.
@@ -2697,7 +2697,7 @@ func TestLeafNodeServiceImportResponderOnLeaf(t *testing.T) {
 
 func TestLeafNodeSendsAccountingEvents(t *testing.T) {
 	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	// System account
@@ -2732,10 +2732,10 @@ func TestLeafNodeSendsAccountingEvents(t *testing.T) {
 	}
 	seed, _ := kp.Seed()
 	mycreds := genCredsFile(t, ujwt, seed)
-	defer os.Remove(mycreds)
+	defer removeFile(t, mycreds)
 
 	sl, _, lnconf := runSolicitWithCredentials(t, opts, mycreds)
-	defer os.Remove(lnconf)
+	defer removeFile(t, lnconf)
 	defer sl.Shutdown()
 
 	// Wait for connect event
@@ -2953,7 +2953,7 @@ func TestLeafNodeDefaultPort(t *testing.T) {
 			]
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	sl, _ := RunServerWithConfig(conf)
 	defer sl.Shutdown()
@@ -3097,7 +3097,7 @@ func TestLeafNodeMultipleRemoteURLs(t *testing.T) {
 	config := fmt.Sprintf(content, opts.LeafNode.Port, opts.LeafNode.Port)
 	conf := createConfFile(t, []byte(config))
 	sl, _ := RunServerWithConfig(conf)
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, s)
@@ -3545,7 +3545,7 @@ func TestServiceExportWithMultipleAccounts(t *testing.T) {
 			listen: "127.0.0.1:-1"
 		}
 	`))
-	defer os.Remove(confA)
+	defer removeFile(t, confA)
 
 	srvA, optsA := RunServerWithConfig(confA)
 	defer srvA.Shutdown()
@@ -3586,7 +3586,7 @@ func TestServiceExportWithMultipleAccounts(t *testing.T) {
 	`
 
 	confB := createConfFile(t, []byte(fmt.Sprintf(bConfigTemplate, optsA.LeafNode.Port)))
-	defer os.Remove(confB)
+	defer removeFile(t, confB)
 
 	srvB, optsB := RunServerWithConfig(confB)
 	defer srvB.Shutdown()
@@ -3666,7 +3666,7 @@ func TestServiceExportWithLeafnodeRestart(t *testing.T) {
 		    }
 		}
 	`))
-	defer os.Remove(confG)
+	defer removeFile(t, confG)
 
 	srvG, optsG := RunServerWithConfig(confG)
 	defer srvG.Shutdown()
@@ -3717,7 +3717,7 @@ func TestServiceExportWithLeafnodeRestart(t *testing.T) {
 	`
 
 	confE := createConfFile(t, []byte(fmt.Sprintf(eConfigTemplate, optsG.LeafNode.Port)))
-	defer os.Remove(confE)
+	defer removeFile(t, confE)
 
 	srvE, optsE := RunServerWithConfig(confE)
 	defer srvE.Shutdown()
@@ -3846,7 +3846,7 @@ func TestLeafNodeOriginClusterSingleHub(t *testing.T) {
 	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
 	`
 	lconf1 := createConfFile(t, []byte(fmt.Sprintf(c1, opts.LeafNode.Port)))
-	defer os.Remove(lconf1)
+	defer removeFile(t, lconf1)
 
 	ln1, lopts1 := RunServerWithConfig(lconf1)
 	defer ln1.Shutdown()
@@ -3857,7 +3857,7 @@ func TestLeafNodeOriginClusterSingleHub(t *testing.T) {
 	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
 	`
 	lconf2 := createConfFile(t, []byte(fmt.Sprintf(c2, lopts1.Cluster.Port, opts.LeafNode.Port)))
-	defer os.Remove(lconf2)
+	defer removeFile(t, lconf2)
 
 	ln2, _ := RunServerWithConfig(lconf2)
 	defer ln2.Shutdown()
@@ -3936,7 +3936,7 @@ func TestLeafNodeOriginCluster(t *testing.T) {
 	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
 	`
 	lconf1 := createConfFile(t, []byte(fmt.Sprintf(c1, ca.opts[0].LeafNode.Port)))
-	defer os.Remove(lconf1)
+	defer removeFile(t, lconf1)
 
 	ln1, lopts1 := RunServerWithConfig(lconf1)
 	defer ln1.Shutdown()
@@ -3948,7 +3948,7 @@ func TestLeafNodeOriginCluster(t *testing.T) {
 	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
 	`
 	lconf2 := createConfFile(t, []byte(fmt.Sprintf(c2, lopts1.Cluster.Port, ca.opts[1].LeafNode.Port)))
-	defer os.Remove(lconf2)
+	defer removeFile(t, lconf2)
 
 	ln2, _ := RunServerWithConfig(lconf2)
 	defer ln2.Shutdown()
@@ -3960,7 +3960,7 @@ func TestLeafNodeOriginCluster(t *testing.T) {
 	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
 	`
 	lconf3 := createConfFile(t, []byte(fmt.Sprintf(c3, lopts1.Cluster.Port, ca.opts[2].LeafNode.Port)))
-	defer os.Remove(lconf3)
+	defer removeFile(t, lconf3)
 
 	ln3, _ := RunServerWithConfig(lconf3)
 	defer ln3.Shutdown()
@@ -4163,7 +4163,7 @@ func TestLeafNodeStreamAndShadowSubs(t *testing.T) {
 			}
 		}
 	`))
-	defer os.Remove(conf1)
+	defer removeFile(t, conf1)
 	s1, o1 := RunServerWithConfig(conf1)
 	defer s1.Shutdown()
 
@@ -4192,7 +4192,7 @@ func TestLeafNodeStreamAndShadowSubs(t *testing.T) {
 			]
 		}
 	`, o1.Gateway.Port)))
-	defer os.Remove(conf2)
+	defer removeFile(t, conf2)
 	s2, o2 := RunServerWithConfig(conf2)
 	defer s2.Shutdown()
 
@@ -4233,7 +4233,7 @@ func TestLeafNodeStreamAndShadowSubs(t *testing.T) {
 			]
 		}
 	`, o1.LeafNode.Port)))
-	defer os.Remove(conf3)
+	defer removeFile(t, conf3)
 	s3, o3 := RunServerWithConfig(conf3)
 	defer s3.Shutdown()
 

--- a/test/new_routes_test.go
+++ b/test/new_routes_test.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -1685,7 +1684,7 @@ func TestNewRouteLeafNodeOriginSupport(t *testing.T) {
 	no_sys_acc: true
 	`
 	conf := createConfFile(t, []byte(content))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -1699,7 +1698,7 @@ func TestNewRouteLeafNodeOriginSupport(t *testing.T) {
 	no_sys_acc: true
 	`
 	lconf := createConfFile(t, []byte(fmt.Sprintf(lcontent, opts.LeafNode.Port)))
-	defer os.Remove(lconf)
+	defer removeFile(t, lconf)
 
 	ln, _ := RunServerWithConfig(lconf)
 	defer ln.Shutdown()

--- a/test/norace_test.go
+++ b/test/norace_test.go
@@ -23,7 +23,6 @@ import (
 	"math/rand"
 	"net"
 	"net/url"
-	"os"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -51,7 +50,7 @@ func TestNoRaceRouteSendSubs(t *testing.T) {
 			no_sys_acc: true
 	`
 	cfa := createConfFile(t, []byte(fmt.Sprintf(template, "")))
-	defer os.Remove(cfa)
+	defer removeFile(t, cfa)
 	srvA, optsA := RunServerWithConfig(cfa)
 	srvA.Shutdown()
 	optsA.DisableShortFirstPing = true

--- a/test/operator_test.go
+++ b/test/operator_test.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -364,7 +363,7 @@ func TestReloadDoesNotWipeAccountsWithOperatorMode(t *testing.T) {
 	`
 	contents := strings.Replace(fmt.Sprintf(cf, "", sysPub, sysPub, sysJWT, accPub, accJWT), "\n\t", "\n", -1)
 	conf := createConfFile(t, []byte(contents))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -374,7 +373,7 @@ func TestReloadDoesNotWipeAccountsWithOperatorMode(t *testing.T) {
 	contents2 := strings.Replace(fmt.Sprintf(cf, routeStr, sysPub, sysPub, sysJWT, accPub, accJWT), "\n\t", "\n", -1)
 
 	conf2 := createConfFile(t, []byte(contents2))
-	defer os.Remove(conf2)
+	defer removeFile(t, conf2)
 
 	s2, opts2 := RunServerWithConfig(conf2)
 	defer s2.Shutdown()
@@ -488,7 +487,7 @@ func TestReloadDoesUpdateAccountsWithMemoryResolver(t *testing.T) {
 	`
 	contents := strings.Replace(fmt.Sprintf(cf, "", sysPub, sysPub, sysJWT, accPub, accJWT), "\n\t", "\n", -1)
 	conf := createConfFile(t, []byte(contents))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -580,7 +579,7 @@ func TestReloadFailsWithBadAccountsWithMemoryResolver(t *testing.T) {
 	`
 	contents := strings.Replace(fmt.Sprintf(cf, "", sysPub, sysPub, sysJWT, apub, ajwt), "\n\t", "\n", -1)
 	conf := createConfFile(t, []byte(contents))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -644,7 +643,7 @@ func TestConnsRequestDoesNotLoadAccountCheckingConnLimits(t *testing.T) {
 	`
 	contents := strings.Replace(fmt.Sprintf(cf, "", sysPub, sysPub, sysJWT, accPub, accJWT), "\n\t", "\n", -1)
 	conf := createConfFile(t, []byte(contents))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -654,7 +653,7 @@ func TestConnsRequestDoesNotLoadAccountCheckingConnLimits(t *testing.T) {
 	contents2 := strings.Replace(fmt.Sprintf(cf, routeStr, sysPub, sysPub, sysJWT, accPub, accJWT), "\n\t", "\n", -1)
 
 	conf2 := createConfFile(t, []byte(contents2))
-	defer os.Remove(conf2)
+	defer removeFile(t, conf2)
 
 	s2, _ := RunServerWithConfig(conf2)
 	defer s2.Shutdown()

--- a/test/pid_test.go
+++ b/test/pid_test.go
@@ -24,7 +24,7 @@ func TestPidFile(t *testing.T) {
 	opts := DefaultTestOptions
 
 	tmpDir := createDir(t, "_nats-server")
-	defer os.RemoveAll(tmpDir)
+	defer removeDir(t, tmpDir)
 
 	file := createFileAtDir(t, tmpDir, "nats-server:pid_")
 	file.Close()

--- a/test/ports_test.go
+++ b/test/ports_test.go
@@ -125,7 +125,7 @@ func TestPortsFile(t *testing.T) {
 func TestPortsFileReload(t *testing.T) {
 	// make a temp dir
 	tempDir := createDir(t, "")
-	defer os.RemoveAll(tempDir)
+	defer removeDir(t, tempDir)
 
 	// make child temp dir A
 	dirA := filepath.Join(tempDir, "A")

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"os"
 	"runtime"
 	"strconv"
 	"sync"
@@ -1087,7 +1086,7 @@ func createConfFile(t *testing.T, content []byte) string {
 	fName := conf.Name()
 	conf.Close()
 	if err := ioutil.WriteFile(fName, content, 0666); err != nil {
-		os.Remove(fName)
+		removeFile(t, fName)
 		t.Fatalf("Error writing conf file: %v", err)
 	}
 	return fName
@@ -1133,7 +1132,7 @@ func TestRoutesOnlyImportOrExport(t *testing.T) {
 				}
 			}
 		`, c)))
-		defer os.Remove(cf)
+		defer removeFile(t, cf)
 		s, _ := RunServerWithConfig(cf)
 		s.Shutdown()
 	}

--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -19,7 +19,6 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
-	"os"
 	"path"
 	"strings"
 	"sync"
@@ -746,7 +745,7 @@ func TestServiceLatencyWithJWT(t *testing.T) {
 	`
 	contents := strings.Replace(fmt.Sprintf(cf, "", sysPub, sysPub, sysJWT, svcPub, svcJWT, accPub, accJWT), "\n\t", "\n", -1)
 	conf := createConfFile(t, []byte(contents))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -756,7 +755,7 @@ func TestServiceLatencyWithJWT(t *testing.T) {
 	contents2 := strings.Replace(fmt.Sprintf(cf, routeStr, sysPub, sysPub, sysJWT, svcPub, svcJWT, accPub, accJWT), "\n\t", "\n", -1)
 
 	conf2 := createConfFile(t, []byte(contents2))
-	defer os.Remove(conf2)
+	defer removeFile(t, conf2)
 
 	s2, opts2 := RunServerWithConfig(conf2)
 	defer s2.Shutdown()
@@ -1180,7 +1179,7 @@ func TestServiceLatencyOldRequestStyleSingleServer(t *testing.T) {
 
 		system_account: SYS
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -1246,7 +1245,7 @@ func TestServiceAndStreamStackOverflow(t *testing.T) {
 		  }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -1425,7 +1424,7 @@ func TestServiceLatencyRequestorSharesConfig(t *testing.T) {
 
 		system_account: SYS
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -1537,7 +1536,7 @@ func TestServiceLatencyLossTest(t *testing.T) {
 		}
 		system_account: SYS
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
 
@@ -1724,7 +1723,7 @@ func TestServiceLatencyHeaderTriggered(t *testing.T) {
 
 				system_account: SYS
 			`, v.shared)))
-			defer os.Remove(conf)
+			defer removeFile(t, conf)
 			srv, opts := RunServerWithConfig(conf)
 			defer srv.Shutdown()
 
@@ -1805,7 +1804,7 @@ func TestServiceLatencyMissingResults(t *testing.T) {
 		  }
 		}
 	`))
-	defer os.Remove(accConf)
+	defer removeFile(t, accConf)
 
 	s1Conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
@@ -1813,7 +1812,7 @@ func TestServiceLatencyMissingResults(t *testing.T) {
 		cluster { port: -1 }
 		include %q
 	`, path.Base(accConf))))
-	defer os.Remove(s1Conf)
+	defer removeFile(t, s1Conf)
 
 	s1, opts1 := RunServerWithConfig(s1Conf)
 	defer s1.Shutdown()
@@ -1827,7 +1826,7 @@ func TestServiceLatencyMissingResults(t *testing.T) {
 		}
 		include %q
 	`, opts1.Cluster.Port, path.Base(accConf))))
-	defer os.Remove(s2Conf)
+	defer removeFile(t, s2Conf)
 
 	s2, opts2 := RunServerWithConfig(s2Conf)
 	defer s2.Shutdown()

--- a/test/services_test.go
+++ b/test/services_test.go
@@ -16,7 +16,6 @@ package test
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -43,7 +42,7 @@ var basicMASetupContents = []byte(`
 
 func TestServiceImportWithStreamed(t *testing.T) {
 	conf := createConfFile(t, basicMASetupContents)
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -141,7 +140,7 @@ func TestServiceImportWithStreamed(t *testing.T) {
 
 func TestServiceImportWithStreamedResponseAndEOF(t *testing.T) {
 	conf := createConfFile(t, basicMASetupContents)
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -225,7 +224,7 @@ func TestServiceExportsResponseFiltering(t *testing.T) {
 		    }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -293,7 +292,7 @@ func TestServiceExportsAutoDirectCleanup(t *testing.T) {
 		    }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -391,7 +390,7 @@ func TestServiceExportsPruningCleanup(t *testing.T) {
 		    }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -480,7 +479,7 @@ func TestServiceExportsResponseThreshold(t *testing.T) {
 		    },
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -526,7 +525,7 @@ func TestServiceExportsResponseThresholdChunked(t *testing.T) {
 		    }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -589,7 +588,7 @@ func TestServiceAllowResponsesPerms(t *testing.T) {
 		    }
 		}
 	`))
-	defer os.Remove(conf)
+	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()

--- a/test/test.go
+++ b/test/test.go
@@ -588,3 +588,17 @@ func createFileAtDir(t *testing.T, dir, prefix string) *os.File {
 	}
 	return f
 }
+
+func removeDir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func removeFile(t *testing.T, p string) {
+	t.Helper()
+	if err := os.Remove(p); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/url"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -800,7 +799,7 @@ func testTLSRoutesCertificateImplicitAllow(t *testing.T, pass bool) {
 	t.Helper()
 	// Base config for the servers
 	cfg := createFile(t, "cfg")
-	defer os.Remove(cfg.Name())
+	defer removeFile(t, cfg.Name())
 	cfg.WriteString(fmt.Sprintf(`
 		cluster {
 		  tls {
@@ -868,7 +867,7 @@ func testTLSGatewaysCertificateImplicitAllow(t *testing.T, pass bool) {
 	t.Helper()
 	// Base config for the servers
 	cfg := createFile(t, "cfg")
-	defer os.Remove(cfg.Name())
+	defer removeFile(t, cfg.Name())
 	cfg.WriteString(fmt.Sprintf(`
 		gateway {
 		  tls {
@@ -1311,7 +1310,7 @@ func TestTLSHandshakeFailureMemUsage(t *testing.T) {
 				}
 			`)
 			conf := createConfFile(t, []byte(content))
-			defer os.Remove(conf)
+			defer removeFile(t, conf)
 			s, opts := RunServerWithConfig(conf)
 			defer s.Shutdown()
 
@@ -1648,7 +1647,7 @@ func TestTLSClientAuthWithRDNSequence(t *testing.T) {
 				}
 			`)
 			conf := createConfFile(t, []byte(content))
-			defer os.Remove(conf)
+			defer removeFile(t, conf)
 			s, opts := RunServerWithConfig(conf)
 			defer s.Shutdown()
 
@@ -1768,7 +1767,7 @@ func TestTLSClientAuthWithRDNSequenceReordered(t *testing.T) {
 				}
 			`)
 			conf := createConfFile(t, []byte(content))
-			defer os.Remove(conf)
+			defer removeFile(t, conf)
 			s, opts := RunServerWithConfig(conf)
 			defer s.Shutdown()
 
@@ -1901,7 +1900,7 @@ func TestTLSClientSVIDAuth(t *testing.T) {
 				}
 			`)
 			conf := createConfFile(t, []byte(content))
-			defer os.Remove(conf)
+			defer removeFile(t, conf)
 			s, opts := RunServerWithConfig(conf)
 			defer s.Shutdown()
 


### PR DESCRIPTION
Currently in tests, we have calls to `os.Remove` and `os.RemoveAll` where we don't check the returned error. This hides useful error messages when tests fail to run, such as "too many open files".

This change checks for more filesystem related errors and calls `t.Fatal` if there is an error.

Call updates
* `os.Remove(path)` gets updated to `removeFile(t, path)`
* `os.RemoveAll(path)` gets updated to `removeDir(t, path)`

Other minor changes:
* In `reload_test.go/TestConfigReloadEnableClusterAuthorization` and `reload_test.go/TestConfigReloadClusterRemoveSolicitedRoutes`, we were double removing files, resulting in an error. This change only removes that file once.
* In `reload_test.go/TestConfigReloadRotateFiles`, we were removing files that don't exist, resulting in an error. This change remove those unneeded calls.
* Some calls to `ProcessConfigFile` were ignoring the returned error. This change checks the error.

**Before change**
```
$ go test -p=1 -count=1 ./server/

--- FAIL: TestJetStreamTemplateFileStoreRecovery (10.35s)
panic: Unable to start NATS Server in Go Routine [recovered]
        panic: Unable to start NATS Server in Go Routine

```

**After change** - now "too many open files" error is surfaced. This is a good clue to set `ulimit` higher. (Higher `ulimit` fixes the panic.)
```
$ go test -p=1 -count=1 ./server/
--- FAIL: TestJetStreamTemplateFileStoreRecovery (10.58s)
    panic.go:965: open /tmp/nats-server/jstests-storedir-883699902: too many open files
--- FAIL: TestJetStreamSingleInstanceRemoteAccess (10.00s)
panic: Unable to start NATS Server in Go Routine [recovered]
        panic: Unable to start NATS Server in Go Routine
```

/cc @nats-io/core