### PR TITLE
Fixed expected pid path in options

### DIFF
--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
@@ -104,7 +103,7 @@ func TestConfigFile(t *testing.T) {
 		Logtime:               false,
 		HTTPPort:              8222,
 		HTTPBasePath:          "/nats",
-		PidFile:               filepath.Join(tempRoot, "nats-server.pid"),
+		PidFile:               "/tmp/nats-server/nats-server.pid",
 		ProfPort:              6543,
 		Syslog:                true,
 		RemoteSyslog:          "udp://foo.com:33",
@@ -261,7 +260,7 @@ func TestMergeOverrides(t *testing.T) {
 		Logtime:        false,
 		HTTPPort:       DEFAULT_HTTP_PORT,
 		HTTPBasePath:   DEFAULT_HTTP_BASE_PATH,
-		PidFile:        filepath.Join(tempRoot, "nats-server.pid"),
+		PidFile:        "/tmp/nats-server/nats-server.pid",
 		ProfPort:       6789,
 		Syslog:         true,
 		RemoteSyslog:   "udp://foo.com:33",
@@ -1168,7 +1167,7 @@ func TestOptionsClone(t *testing.T) {
 		Logtime:        false,
 		HTTPPort:       DEFAULT_HTTP_PORT,
 		HTTPBasePath:   DEFAULT_HTTP_BASE_PATH,
-		PidFile:        filepath.Join(tempRoot, "nats-server.pid"),
+		PidFile:        "/tmp/nats-server/nats-server.pid",
 		ProfPort:       6789,
 		Syslog:         true,
 		RemoteSyslog:   "udp://foo.com:33",

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -81,7 +80,7 @@ func TestRouteConfig(t *testing.T) {
 			NoAdvertise:    true,
 			ConnectRetries: 2,
 		},
-		PidFile: filepath.Join(tempRoot, "nats_cluster_test.pid"),
+		PidFile: "/tmp/nats-server/nats_cluster_test.pid",
 	}
 
 	// Setup URLs


### PR DESCRIPTION
This was introduced by PR #2071.

On some tests, options are loaded based on a config file that has
the pid set to "/tm/nats-server/nats-server.pid", however, the
expected option's pid path was set based on tmpRoot. The problem
is that on macOS, that value would be "/var/folders/xxx" which
would not match.
So this PR simply reverts the changes to the expected pid file
name: it simply needs to match was in the test.conf file.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
