### PR TITLE
[Fixed] leaf node subscription permission negotiation.

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -124,17 +124,18 @@ const (
 
 // Some client state represented as flags
 const (
-	connectReceived   clientFlag = 1 << iota // The CONNECT proto has been received
-	infoReceived                             // The INFO protocol has been received
-	firstPongSent                            // The first PONG has been sent
-	handshakeComplete                        // For TLS clients, indicate that the handshake is complete
-	flushOutbound                            // Marks client as having a flushOutbound call in progress.
-	noReconnect                              // Indicate that on close, this connection should not attempt a reconnect
-	closeConnection                          // Marks that closeConnection has already been called.
-	connMarkedClosed                         // Marks that markConnAsClosed has already been called.
-	writeLoopStarted                         // Marks that the writeLoop has been started.
-	skipFlushOnClose                         // Marks that flushOutbound() should not be called on connection close.
-	expectConnect                            // Marks if this connection is expected to send a CONNECT
+	connectReceived        clientFlag = 1 << iota // The CONNECT proto has been received
+	infoReceived                                  // The INFO protocol has been received
+	firstPongSent                                 // The first PONG has been sent
+	handshakeComplete                             // For TLS clients, indicate that the handshake is complete
+	flushOutbound                                 // Marks client as having a flushOutbound call in progress.
+	noReconnect                                   // Indicate that on close, this connection should not attempt a reconnect
+	closeConnection                               // Marks that closeConnection has already been called.
+	connMarkedClosed                              // Marks that markConnAsClosed has already been called.
+	writeLoopStarted                              // Marks that the writeLoop has been started.
+	skipFlushOnClose                              // Marks that flushOutbound() should not be called on connection close.
+	expectConnect                                 // Marks if this connection is expected to send a CONNECT
+	connectProcessFinished                        // Marks if this connection has finished the connect process.
 )
 
 // set the flag (would be equivalent to set the boolean to true)

--- a/server/client.go
+++ b/server/client.go
@@ -2953,6 +2953,7 @@ func (c *client) deliverMsg(sub *subscription, subject, reply, mh, msg []byte, g
 	if client.kind == LEAF && client.perms != nil {
 		if !client.pubAllowed(string(subject)) {
 			client.mu.Unlock()
+			client.Debugf("Not permitted to publish to %q", subject)
 			return false
 		}
 	}

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2185,10 +2185,7 @@ func (s *Server) leafNodeResumeConnectProcess(c *client) {
 			c.mu.Unlock()
 			return
 		}
-		if !c.ping.tmr.Stop() {
-			<-c.ping.tmr.C
-			c.ping.tmr = nil
-		}
+		clearTimer(&c.ping.tmr)
 		closed := c.isClosed()
 		c.mu.Unlock()
 		if !closed {
@@ -2223,10 +2220,7 @@ func (s *Server) leafNodeFinishConnectProcess(c *client) {
 	// Capture account before releasing lock
 	acc := c.acc
 	// cancel connectProcessTimeout
-	if !c.ping.tmr.Stop() {
-		<-c.ping.tmr.C
-		c.ping.tmr = nil
-	}
+	clearTimer(&c.ping.tmr)
 	c.mu.Unlock()
 
 	// Make sure we register with the account here.

--- a/server/server.go
+++ b/server/server.go
@@ -86,8 +86,8 @@ type Info struct {
 	Import        *SubjectPermission `json:"import,omitempty"`
 	Export        *SubjectPermission `json:"export,omitempty"`
 	LNOC          bool               `json:"lnoc,omitempty"`
-	InfoOnConnect bool               `json:"info_on_connect,omitempty"` // When true the server will respond connect to with an INFO
-	ConnectInfo   bool               `json:"connect_info,omitempty"`    // When true this is the servers response to CONNECT
+	InfoOnConnect bool               `json:"info_on_connect,omitempty"` // When true the server will respond to CONNECT with an INFO
+	ConnectInfo   bool               `json:"connect_info,omitempty"`    // When true this is the server INFO response to CONNECT
 
 	// Gateways Specific
 	Gateway           string   `json:"gateway,omitempty"`             // Name of the origin Gateway (sent by gateway's INFO)

--- a/server/server.go
+++ b/server/server.go
@@ -83,9 +83,11 @@ type Info struct {
 	LameDuckMode      bool     `json:"ldm,omitempty"`
 
 	// Route Specific
-	Import *SubjectPermission `json:"import,omitempty"`
-	Export *SubjectPermission `json:"export,omitempty"`
-	LNOC   bool               `json:"lnoc,omitempty"`
+	Import        *SubjectPermission `json:"import,omitempty"`
+	Export        *SubjectPermission `json:"export,omitempty"`
+	LNOC          bool               `json:"lnoc,omitempty"`
+	InfoOnConnect bool               `json:"info_on_connect,omitempty"` // When true the server will respond connect to with an INFO
+	ConnectInfo   bool               `json:"connect_info,omitempty"`    // When true this is the servers response to CONNECT
 
 	// Gateways Specific
 	Gateway           string   `json:"gateway,omitempty"`             // Name of the origin Gateway (sent by gateway's INFO)


### PR DESCRIPTION
On connect all subscription where sent by the soliciting leaf node.
If creds contains sub deny permissions, the leaf node would be
disconnected.
This waits for the permissions to be exchanged and checks permissions
before sending subscriptions.

Signed-off-by: Matthias Hanel <mh@synadia.com>


split up leafNodeFinishConnectProcess into two functions.
When expecting multiple messages in a row, use a buffer to store everything after the left most match.
This can be used a lot more. But there are unrelated tests that rely on the old behavior. (will address separately)