### PR TITLE
[CHANGED] Flush in place only if producer and consumer are client connections

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1005,7 +1005,8 @@ func (c *client) flushClients(budget time.Duration) time.Time {
 			continue
 		}
 
-		if budget > 0 && cp.out.lft < 2*budget && cp.flushOutbound() {
+		// Try to flush in place, if producer and consumer are client.
+		if c.kind == CLIENT && cp.kind == CLIENT && budget > 0 && cp.out.lft < 2*budget && cp.flushOutbound() {
 			budget -= cp.out.lft
 		} else {
 			cp.flushSignal()

--- a/server/client.go
+++ b/server/client.go
@@ -981,10 +981,18 @@ func (c *client) writeLoop() {
 
 // flushClients will make sure to flush any clients we may have
 // sent to during processing. We pass in a budget as a time.Duration
-// for how much time to spend in place flushing for this client. This
-// will normally be called in the readLoop of the client who sent the
-// message that now is being delivered.
+// for how much time to spend in place flushing for this client.
 func (c *client) flushClients(budget time.Duration) time.Time {
+	return c.flushClientsWithCheck(budget, false)
+}
+
+// flushClientsWithCheck will make sure to flush any clients we may have
+// sent to during processing. We pass in a budget as a time.Duration
+// for how much time to spend in place flushing for this client.
+// The 'clientsKindOnly' boolean indicates whether to check kind of client
+// and pending client to run flushOutbound in flushClientsWithCheck.
+// flushOutbound could be block caller when pending client is 'stuck'
+func (c *client) flushClientsWithCheck(budget time.Duration, clientsKindOnly bool) time.Time {
 	last := time.Now().UTC()
 
 	// Check pending clients for flush.
@@ -1005,8 +1013,7 @@ func (c *client) flushClients(budget time.Duration) time.Time {
 			continue
 		}
 
-		// Try to flush in place, if producer and consumer are client.
-		if c.kind == CLIENT && cp.kind == CLIENT && budget > 0 && cp.out.lft < 2*budget && cp.flushOutbound() {
+		if budget > 0 && (!clientsKindOnly || c.kind == CLIENT && cp.kind == CLIENT) && cp.out.lft < 2*budget && cp.flushOutbound() {
 			budget -= cp.out.lft
 		} else {
 			cp.flushSignal()
@@ -1158,7 +1165,7 @@ func (c *client) readLoop(pre []byte) {
 		}
 
 		// Flush, or signal to writeLoop to flush to socket.
-		last := c.flushClients(budget)
+		last := c.flushClientsWithCheck(budget, true)
 
 		// Update activity, check read buffer size.
 		c.mu.Lock()

--- a/server/client.go
+++ b/server/client.go
@@ -991,7 +991,8 @@ func (c *client) flushClients(budget time.Duration) time.Time {
 // for how much time to spend in place flushing for this client.
 // The 'clientsKindOnly' boolean indicates whether to check kind of client
 // and pending client to run flushOutbound in flushClientsWithCheck.
-// flushOutbound could be block caller when pending client is 'stuck'
+// flushOutbound() could block the caller up to the write deadline when
+// the receiving client cannot drain data from the socket fast enough.
 func (c *client) flushClientsWithCheck(budget time.Duration, clientsKindOnly bool) time.Time {
 	last := time.Now().UTC()
 


### PR DESCRIPTION
 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [ ] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [ ] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #2082

### Changes proposed in this pull request:

 - flushing outbound is not to block the client read loop
 -
 -

/cc @nats-io/core
