### PR TITLE
Run gofmt -s to simplify code

### DIFF
--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -108,7 +108,7 @@ func TestUserCloneNil(t *testing.T) {
 
 func TestUserUnknownAllowedConnectionType(t *testing.T) {
 	o := DefaultOptions()
-	o.Users = []*User{&User{
+	o.Users = []*User{{
 		Username:               "user",
 		Password:               "pwd",
 		AllowedConnectionTypes: testCreateAllowedConnectionTypes([]string{jwt.ConnectionTypeStandard, "someNewType"}),
@@ -133,7 +133,7 @@ func TestUserUnknownAllowedConnectionType(t *testing.T) {
 	}
 	// Same with NKey user now.
 	o.Users = nil
-	o.Nkeys = []*NkeyUser{&NkeyUser{
+	o.Nkeys = []*NkeyUser{{
 		Nkey:                   "somekey",
 		AllowedConnectionTypes: testCreateAllowedConnectionTypes([]string{jwt.ConnectionTypeStandard, "someNewType"}),
 	}}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1938,11 +1938,11 @@ func TestFileStoreConsumer(t *testing.T) {
 
 	// We should sanity check pending here as well, so will check if a pending value is below
 	// ack floor or above delivered.
-	state.Pending = map[uint64]*Pending{70: &Pending{70, tn}}
+	state.Pending = map[uint64]*Pending{70: {70, tn}}
 	shouldFail()
-	state.Pending = map[uint64]*Pending{140: &Pending{140, tn}}
+	state.Pending = map[uint64]*Pending{140: {140, tn}}
 	shouldFail()
-	state.Pending = map[uint64]*Pending{72: &Pending{72, tn}} // exact on floor should fail
+	state.Pending = map[uint64]*Pending{72: {72, tn}} // exact on floor should fail
 	shouldFail()
 
 	// Put timestamps a second apart.

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -5107,13 +5107,13 @@ func (c *delayedWriteConn) Write(b []byte) (int, error) {
 func TestGatewaySendReplyAcrossGateways(t *testing.T) {
 	ob := testDefaultOptionsForGateway("B")
 	ob.Accounts = []*Account{NewAccount("ACC")}
-	ob.Users = []*User{&User{Username: "user", Password: "pwd", Account: ob.Accounts[0]}}
+	ob.Users = []*User{{Username: "user", Password: "pwd", Account: ob.Accounts[0]}}
 	sb := runGatewayServer(ob)
 	defer sb.Shutdown()
 
 	oa1 := testGatewayOptionsFromToWithServers(t, "A", "B", sb)
 	oa1.Accounts = []*Account{NewAccount("ACC")}
-	oa1.Users = []*User{&User{Username: "user", Password: "pwd", Account: oa1.Accounts[0]}}
+	oa1.Users = []*User{{Username: "user", Password: "pwd", Account: oa1.Accounts[0]}}
 	sa1 := runGatewayServer(oa1)
 	defer sa1.Shutdown()
 
@@ -5128,7 +5128,7 @@ func TestGatewaySendReplyAcrossGateways(t *testing.T) {
 	// route.
 	oa2 := testGatewayOptionsFromToWithServers(t, "A", "B", sb)
 	oa2.Accounts = []*Account{NewAccount("ACC")}
-	oa2.Users = []*User{&User{Username: "user", Password: "pwd", Account: oa2.Accounts[0]}}
+	oa2.Users = []*User{{Username: "user", Password: "pwd", Account: oa2.Accounts[0]}}
 	oa2.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", oa1.Cluster.Host, oa1.Cluster.Port))
 	sa2 := runGatewayServer(oa2)
 	defer sa2.Shutdown()
@@ -5249,13 +5249,13 @@ func TestGatewaySendReplyAcrossGateways(t *testing.T) {
 func TestGatewayPingPongReplyAcrossGateways(t *testing.T) {
 	ob := testDefaultOptionsForGateway("B")
 	ob.Accounts = []*Account{NewAccount("ACC")}
-	ob.Users = []*User{&User{Username: "user", Password: "pwd", Account: ob.Accounts[0]}}
+	ob.Users = []*User{{Username: "user", Password: "pwd", Account: ob.Accounts[0]}}
 	sb := runGatewayServer(ob)
 	defer sb.Shutdown()
 
 	oa1 := testGatewayOptionsFromToWithServers(t, "A", "B", sb)
 	oa1.Accounts = []*Account{NewAccount("ACC")}
-	oa1.Users = []*User{&User{Username: "user", Password: "pwd", Account: oa1.Accounts[0]}}
+	oa1.Users = []*User{{Username: "user", Password: "pwd", Account: oa1.Accounts[0]}}
 	sa1 := runGatewayServer(oa1)
 	defer sa1.Shutdown()
 
@@ -5270,7 +5270,7 @@ func TestGatewayPingPongReplyAcrossGateways(t *testing.T) {
 	// route.
 	oa2 := testGatewayOptionsFromToWithServers(t, "A", "B", sb)
 	oa2.Accounts = []*Account{NewAccount("ACC")}
-	oa2.Users = []*User{&User{Username: "user", Password: "pwd", Account: oa2.Accounts[0]}}
+	oa2.Users = []*User{{Username: "user", Password: "pwd", Account: oa2.Accounts[0]}}
 	oa2.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", oa1.Cluster.Host, oa1.Cluster.Port))
 	sa2 := runGatewayServer(oa2)
 	defer sa2.Shutdown()

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -4494,7 +4494,7 @@ func TestJetStreamClusterMirrorAndSourcesFilteredConsumers(t *testing.T) {
 	// Create downstream now.
 	_, err = js.AddStream(&nats.StreamConfig{
 		Name:    "S",
-		Sources: []*nats.StreamSource{&nats.StreamSource{Name: "O1"}, &nats.StreamSource{Name: "O2"}},
+		Sources: []*nats.StreamSource{{Name: "O1"}, {Name: "O2"}},
 	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -4517,7 +4517,7 @@ func TestJetStreamClusterMirrorAndSourcesFilteredConsumers(t *testing.T) {
 	cfg := StreamConfig{
 		Name:    "SCA",
 		Storage: FileStorage,
-		Sources: []*StreamSource{&StreamSource{
+		Sources: []*StreamSource{{
 			Name: "ORIGIN",
 			External: &ExternalStream{
 				ApiPrefix:     "RI.JS.API",
@@ -4601,7 +4601,7 @@ func TestJetStreamCrossAccountMirrorsAndSources(t *testing.T) {
 	_, err = js2.AddStream(&nats.StreamConfig{
 		Name: "MY_SOURCE_TEST",
 		Sources: []*nats.StreamSource{
-			&nats.StreamSource{
+			{
 				Name: "TEST",
 				External: &nats.ExternalStream{
 					APIPrefix:     "RI.JS.API",
@@ -4931,7 +4931,7 @@ func TestJetStreamClusterSuperClusterEphemeralCleanup(t *testing.T) {
 			if _, err := js2.AddStream(&nats.StreamConfig{
 				Name:     test.sourceName,
 				Storage:  nats.FileStorage,
-				Sources:  []*nats.StreamSource{&nats.StreamSource{Name: test.streamName}},
+				Sources:  []*nats.StreamSource{{Name: test.streamName}},
 				Replicas: 1,
 			}); err != nil {
 				t.Fatalf("Error adding source stream: %v", err)
@@ -5023,7 +5023,7 @@ func TestJetStreamSuperClusterDirectConsumersBrokenGateways(t *testing.T) {
 	_, err = js.AddStream(&nats.StreamConfig{
 		Name:      "S",
 		Placement: &nats.Placement{Cluster: "C2"},
-		Sources:   []*nats.StreamSource{&nats.StreamSource{Name: "TEST"}},
+		Sources:   []*nats.StreamSource{{Name: "TEST"}},
 	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -10807,7 +10807,7 @@ func TestJetStreamMirrorAndSourcesFilteredConsumers(t *testing.T) {
 	// Create Mirror now.
 	_, err = js.AddStream(&nats.StreamConfig{
 		Name:    "S",
-		Sources: []*nats.StreamSource{&nats.StreamSource{Name: "O1"}, &nats.StreamSource{Name: "O2"}},
+		Sources: []*nats.StreamSource{{Name: "O1"}, {Name: "O2"}},
 	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -11049,9 +11049,9 @@ func TestJetStreamSourceBasics(t *testing.T) {
 		Name:    "MS",
 		Storage: FileStorage,
 		Sources: []*StreamSource{
-			&StreamSource{Name: "foo"},
-			&StreamSource{Name: "bar"},
-			&StreamSource{Name: "baz"},
+			{Name: "foo"},
+			{Name: "bar"},
+			{Name: "baz"},
 		},
 	}
 
@@ -11078,9 +11078,9 @@ func TestJetStreamSourceBasics(t *testing.T) {
 		Name: "MS",
 		Sources: []*nats.StreamSource{
 			// Keep foo, bar, remove baz, add dlc
-			&nats.StreamSource{Name: "foo"},
-			&nats.StreamSource{Name: "bar"},
-			&nats.StreamSource{Name: "dlc"},
+			{Name: "foo"},
+			{Name: "bar"},
+			{Name: "dlc"},
 		},
 	}
 	if _, err := js.UpdateStream(ncfg); err != nil {
@@ -11099,7 +11099,7 @@ func TestJetStreamSourceBasics(t *testing.T) {
 		Name:    "FMS",
 		Storage: FileStorage,
 		Sources: []*StreamSource{
-			&StreamSource{Name: "TEST", OptStartSeq: 26},
+			{Name: "TEST", OptStartSeq: 26},
 		},
 	}
 	createStream(cfg)
@@ -11132,7 +11132,7 @@ func TestJetStreamSourceBasics(t *testing.T) {
 		Name:    "FMS2",
 		Storage: FileStorage,
 		Sources: []*StreamSource{
-			&StreamSource{Name: "TEST", OptStartSeq: 11, FilterSubject: "dlc"},
+			{Name: "TEST", OptStartSeq: 11, FilterSubject: "dlc"},
 		},
 	}
 	createStream(cfg)

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -506,7 +506,7 @@ func TestLeafNodeValidateAuthOptions(t *testing.T) {
 	opts := DefaultOptions()
 	opts.LeafNode.Username = "user1"
 	opts.LeafNode.Password = "pwd"
-	opts.LeafNode.Users = []*User{&User{Username: "user", Password: "pwd"}}
+	opts.LeafNode.Users = []*User{{Username: "user", Password: "pwd"}}
 	if _, err := NewServer(opts); err == nil || !strings.Contains(err.Error(),
 		"can not have a single user/pass and a users array") {
 		t.Fatalf("Expected error about mixing single/multi users, got %v", err)
@@ -1103,7 +1103,7 @@ func TestLeafNodeRemoteIsHub(t *testing.T) {
 	ob1.LeafNode.Port = -1
 	u, _ := url.Parse(fmt.Sprintf("nats://127.0.0.1:%d", lno.LeafNode.Port))
 	ob1.LeafNode.Remotes = []*RemoteLeafOpts{
-		&RemoteLeafOpts{
+		{
 			URLs: []*url.URL{u},
 			Hub:  true,
 		},
@@ -1526,7 +1526,7 @@ func TestLeafNodeTLSVerifyAndMap(t *testing.T) {
 	accName := "MyAccount"
 	acc := NewAccount(accName)
 	certUserName := "CN=example.com,OU=NATS.io"
-	users := []*User{&User{Username: certUserName, Account: acc}}
+	users := []*User{{Username: certUserName, Account: acc}}
 
 	for _, test := range []struct {
 		name        string
@@ -1960,7 +1960,7 @@ func TestLeafNodeLoopDetectedDueToReconnect(t *testing.T) {
 	ol := DefaultOptions()
 	ol.Cluster.Name = "cde"
 	ol.LeafNode.ReconnectInterval = 50 * time.Millisecond
-	ol.LeafNode.Remotes = []*RemoteLeafOpts{&RemoteLeafOpts{URLs: []*url.URL{aurl}}}
+	ol.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{aurl}}}
 	sl := RunServer(ol)
 	defer sl.Shutdown()
 
@@ -2074,7 +2074,7 @@ func TestLeafNodeNoDuplicateWithinCluster(t *testing.T) {
 
 	oLeaf1 := DefaultOptions()
 	oLeaf1.ServerName = "leaf1"
-	oLeaf1.LeafNode.Remotes = []*RemoteLeafOpts{&RemoteLeafOpts{URLs: []*url.URL{u}}}
+	oLeaf1.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{u}}}
 	leaf1 := RunServer(oLeaf1)
 	defer leaf1.Shutdown()
 
@@ -2082,7 +2082,7 @@ func TestLeafNodeNoDuplicateWithinCluster(t *testing.T) {
 
 	oLeaf2 := DefaultOptions()
 	oLeaf2.ServerName = "leaf2"
-	oLeaf2.LeafNode.Remotes = []*RemoteLeafOpts{&RemoteLeafOpts{URLs: []*url.URL{u}}}
+	oLeaf2.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{u}}}
 	oLeaf2.Routes = RoutesFromStr(leaf1ClusterURL)
 	leaf2 := RunServer(oLeaf2)
 	defer leaf2.Shutdown()
@@ -2184,7 +2184,7 @@ func TestLeafNodeLMsgSplit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error parsing url: %v", err)
 	}
-	remoteLeafs := []*RemoteLeafOpts{&RemoteLeafOpts{URLs: []*url.URL{u1, u2}}}
+	remoteLeafs := []*RemoteLeafOpts{{URLs: []*url.URL{u1, u2}}}
 
 	oLeaf1 := DefaultOptions()
 	oLeaf1.LeafNode.Remotes = remoteLeafs
@@ -2281,7 +2281,7 @@ func TestLeafNodeRouteParseLSUnsub(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error parsing url: %v", err)
 	}
-	remoteLeafs := []*RemoteLeafOpts{&RemoteLeafOpts{URLs: []*url.URL{u2}}}
+	remoteLeafs := []*RemoteLeafOpts{{URLs: []*url.URL{u2}}}
 
 	oLeaf2 := DefaultOptions()
 	oLeaf2.LeafNode.Remotes = remoteLeafs
@@ -3017,7 +3017,7 @@ func TestLeafNodeStreamImport(t *testing.T) {
 	o1.LeafNode.Port = -1
 	accA := NewAccount("A")
 	o1.Accounts = []*Account{accA}
-	o1.Users = []*User{&User{Username: "a", Password: "a", Account: accA}}
+	o1.Users = []*User{{Username: "a", Password: "a", Account: accA}}
 	o1.LeafNode.Account = "A"
 	o1.NoAuthUser = "a"
 	s1 := RunServer(o1)
@@ -3037,13 +3037,13 @@ func TestLeafNodeStreamImport(t *testing.T) {
 	}
 
 	o2.Accounts = []*Account{accB, accC}
-	o2.Users = []*User{&User{Username: "b", Password: "b", Account: accB}, &User{Username: "c", Password: "c", Account: accC}}
+	o2.Users = []*User{{Username: "b", Password: "b", Account: accB}, {Username: "c", Password: "c", Account: accC}}
 	o2.NoAuthUser = "b"
 	u, err := url.Parse(fmt.Sprintf("nats://127.0.0.1:%d", o1.LeafNode.Port))
 	if err != nil {
 		t.Fatalf("Error parsing url: %v", err)
 	}
-	o2.LeafNode.Remotes = []*RemoteLeafOpts{&RemoteLeafOpts{URLs: []*url.URL{u}, LocalAccount: "C"}}
+	o2.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{u}, LocalAccount: "C"}}
 	s2 := RunServer(o2)
 	defer s2.Shutdown()
 

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -2631,7 +2631,7 @@ func TestMonitorGateway(t *testing.T) {
 	u1, _ := url.Parse("nats://ivan:pwd@localhost:1234")
 	u2, _ := url.Parse("nats://localhost:1235")
 	opts.Gateway.Gateways = []*RemoteGatewayOpts{
-		&RemoteGatewayOpts{
+		{
 			Name:       "B",
 			TLSTimeout: 1,
 			URLs: []*url.URL{
@@ -2803,7 +2803,7 @@ func TestMonitorLeafNode(t *testing.T) {
 	opts.Accounts = []*Account{NewAccount("acc")}
 	u, _ := url.Parse("nats://ivan:pwd@localhost:1234")
 	opts.LeafNode.Remotes = []*RemoteLeafOpts{
-		&RemoteLeafOpts{
+		{
 			LocalAccount: "acc",
 			URLs:         []*url.URL{u},
 			TLSTimeout:   1,

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -283,14 +283,14 @@ func TestMQTTValidateOptions(t *testing.T) {
 		{"mqtt disabled", func() *Options { return nmqtto.Clone() }, ""},
 		{"mqtt username not allowed if users specified", func() *Options {
 			o := mqtto.Clone()
-			o.Users = []*User{&User{Username: "abc", Password: "pwd"}}
+			o.Users = []*User{{Username: "abc", Password: "pwd"}}
 			o.MQTT.Username = "b"
 			o.MQTT.Password = "pwd"
 			return o
 		}, "mqtt authentication username not compatible with presence of users/nkeys"},
 		{"mqtt token not allowed if users specified", func() *Options {
 			o := mqtto.Clone()
-			o.Nkeys = []*NkeyUser{&NkeyUser{Nkey: "abc"}}
+			o.Nkeys = []*NkeyUser{{Nkey: "abc"}}
 			o.MQTT.Token = "mytoken"
 			return o
 		}, "mqtt authentication token not compatible with presence of users/nkeys"},
@@ -757,7 +757,7 @@ func TestMQTTRequiresJSEnabled(t *testing.T) {
 	o := testMQTTDefaultOptions()
 	acc := NewAccount("mqtt")
 	o.Accounts = []*Account{acc}
-	o.Users = []*User{&User{Username: "mqtt", Account: acc}}
+	o.Users = []*User{{Username: "mqtt", Account: acc}}
 	s := testMQTTRunServer(t, o)
 	defer testMQTTShutdownServer(s)
 
@@ -797,7 +797,7 @@ func TestMQTTTLSVerifyAndMap(t *testing.T) {
 	accName := "MyAccount"
 	acc := NewAccount(accName)
 	certUserName := "CN=example.com,OU=NATS.io"
-	users := []*User{&User{Username: certUserName, Account: acc}}
+	users := []*User{{Username: certUserName, Account: acc}}
 
 	for _, test := range []struct {
 		name        string
@@ -1225,7 +1225,7 @@ func TestMQTTJWTWithAllowedConnectionTypes(t *testing.T) {
 }
 
 func TestMQTTUsersAuth(t *testing.T) {
-	users := []*User{&User{Username: "user", Password: "pwd"}}
+	users := []*User{{Username: "user", Password: "pwd"}}
 	for _, test := range []struct {
 		name string
 		opts func() *Options
@@ -1302,7 +1302,7 @@ func TestMQTTUsersAuth(t *testing.T) {
 
 func TestMQTTNoAuthUserValidation(t *testing.T) {
 	o := testMQTTDefaultOptions()
-	o.Users = []*User{&User{Username: "user", Password: "pwd"}}
+	o.Users = []*User{{Username: "user", Password: "pwd"}}
 	// Should fail because it is not part of o.Users.
 	o.MQTT.NoAuthUser = "notfound"
 	if _, err := NewServer(o); err == nil || !strings.Contains(err.Error(), "not present as user") {
@@ -1337,10 +1337,10 @@ func TestMQTTNoAuthUser(t *testing.T) {
 			mqttAcc := NewAccount("mqtt")
 			o.Accounts = []*Account{normalAcc, mqttAcc}
 			o.Users = []*User{
-				&User{Username: "noauth", Password: "pwd", Account: normalAcc},
-				&User{Username: "user", Password: "pwd", Account: normalAcc},
-				&User{Username: "mqttnoauth", Password: "pwd", Account: mqttAcc},
-				&User{Username: "mqttuser", Password: "pwd", Account: mqttAcc},
+				{Username: "noauth", Password: "pwd", Account: normalAcc},
+				{Username: "user", Password: "pwd", Account: normalAcc},
+				{Username: "mqttnoauth", Password: "pwd", Account: mqttAcc},
+				{Username: "mqttuser", Password: "pwd", Account: mqttAcc},
 			}
 			o.NoAuthUser = "noauth"
 			if test.override {
@@ -2053,7 +2053,7 @@ func TestMQTTSub(t *testing.T) {
 			defer mc.Close()
 			testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
 
-			testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: test.mqttSubTopic, qos: 0}}, []byte{0})
+			testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: test.mqttSubTopic, qos: 0}}, []byte{0})
 			testMQTTFlush(t, mc, nil, r)
 
 			natsPub(t, nc, test.natsPubSubject, []byte("msg"))
@@ -2092,8 +2092,8 @@ func TestMQTTSubQoS(t *testing.T) {
 	mqttTopic := "foo/bar"
 
 	// Subscribe with QoS 1
-	testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "foo/#", qos: 1}}, []byte{1})
-	testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: mqttTopic, qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "foo/#", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: mqttTopic, qos: 1}}, []byte{1})
 	testMQTTFlush(t, mc, nil, r)
 
 	// Publish from NATS, which means QoS 0
@@ -2147,16 +2147,16 @@ func TestMQTTSubDups(t *testing.T) {
 
 	// Test with single SUBSCRIBE protocol but multiple filters
 	filters := []*mqttFilter{
-		&mqttFilter{filter: "foo", qos: 1},
-		&mqttFilter{filter: "foo", qos: 0},
+		{filter: "foo", qos: 1},
+		{filter: "foo", qos: 0},
 	}
 	testMQTTSub(t, 1, mc, r, filters, []byte{1, 0})
 	testMQTTFlush(t, mc, nil, r)
 
 	// And also with separate SUBSCRIBE protocols
-	testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "bar", qos: 0}}, []byte{0})
+	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "bar", qos: 0}}, []byte{0})
 	// Ask for QoS 2 but server will downgrade to 1
-	testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "bar", qos: 2}}, []byte{1})
+	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "bar", qos: 2}}, []byte{1})
 	testMQTTFlush(t, mc, nil, r)
 
 	// Publish and test msg received only once
@@ -2192,7 +2192,7 @@ func TestMQTTSubDups(t *testing.T) {
 
 	// Now subscribe on "foo/#" which means that a PUBLISH on "foo" will be received
 	// by this subscription and also the one on "foo".
-	testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "foo/#", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "foo/#", qos: 1}}, []byte{1})
 	testMQTTFlush(t, mc, nil, r)
 
 	// Publish and test msg received twice
@@ -2242,7 +2242,7 @@ func TestMQTTSubDups(t *testing.T) {
 	checkWCSub(1)
 
 	// Sub again on same subject with lower QoS
-	testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "foo/#", qos: 0}}, []byte{0})
+	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "foo/#", qos: 0}}, []byte{0})
 	testMQTTFlush(t, mc, nil, r)
 
 	// Publish and test msg received twice
@@ -2265,7 +2265,7 @@ func TestMQTTSubWithSpaces(t *testing.T) {
 	defer mc.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
 
-	testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "foo bar", qos: 0}}, []byte{mqttSubAckFailure})
+	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "foo bar", qos: 0}}, []byte{mqttSubAckFailure})
 }
 
 func TestMQTTSubCaseSensitive(t *testing.T) {
@@ -2281,7 +2281,7 @@ func TestMQTTSubCaseSensitive(t *testing.T) {
 	defer mc.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
 
-	testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "Foo/Bar", qos: 0}}, []byte{0})
+	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "Foo/Bar", qos: 0}}, []byte{0})
 	testMQTTFlush(t, mc, nil, r)
 
 	testMQTTPublish(t, mcp, r, 0, false, false, "Foo/Bar", 0, []byte("msg"))
@@ -2354,11 +2354,11 @@ func TestMQTTPubSubMatrix(t *testing.T) {
 				ns = natsSubSync(t, nc, "foo")
 			}
 			if test.mqttSubQoS0 {
-				testMQTTSub(t, 1, mc1, r1, []*mqttFilter{&mqttFilter{filter: "foo", qos: 0}}, []byte{0})
+				testMQTTSub(t, 1, mc1, r1, []*mqttFilter{{filter: "foo", qos: 0}}, []byte{0})
 				testMQTTFlush(t, mc1, nil, r1)
 			}
 			if test.mqttSubQoS1 {
-				testMQTTSub(t, 1, mc2, r2, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+				testMQTTSub(t, 1, mc2, r2, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 				testMQTTFlush(t, mc2, nil, r2)
 			}
 
@@ -2405,7 +2405,7 @@ func TestMQTTPreventSubWithMQTTSubPrefix(t *testing.T) {
 	defer mc.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
 	testMQTTSub(t, 1, mc, r,
-		[]*mqttFilter{&mqttFilter{filter: strings.ReplaceAll(mqttSubPrefix, ".", "/") + "foo/bar", qos: 1}},
+		[]*mqttFilter{{filter: strings.ReplaceAll(mqttSubPrefix, ".", "/") + "foo/bar", qos: 1}},
 		[]byte{mqttSubAckFailure})
 }
 
@@ -2417,7 +2417,7 @@ func TestMQTTSubWithNATSStream(t *testing.T) {
 	mc, r := testMQTTConnect(t, &mqttConnInfo{cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
 	defer mc.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
-	testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "foo/bar", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "foo/bar", qos: 1}}, []byte{1})
 	testMQTTFlush(t, mc, nil, r)
 
 	mcp, rp := testMQTTConnect(t, &mqttConnInfo{cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
@@ -2517,7 +2517,7 @@ func TestMQTTSubRestart(t *testing.T) {
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
 
 	// Start an MQTT subscription QoS=1 on "foo"
-	testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 	testMQTTFlush(t, mc, nil, r)
 
 	// Now start a NATS subscription on ">" (anything that would match the JS consumer delivery subject)
@@ -2532,7 +2532,7 @@ func TestMQTTSubRestart(t *testing.T) {
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
 
 	// Restart an MQTT subscription QoS=1 on "foo"
-	testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 	testMQTTFlush(t, mc, nil, r)
 
 	pc, pr := testMQTTConnect(t, &mqttConnInfo{clientID: "pub", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
@@ -2545,7 +2545,7 @@ func TestMQTTSubRestart(t *testing.T) {
 	testMQTTCheckPubMsg(t, mc, r, "foo", mqttPubQos1, []byte("msg1"))
 
 	// Now "restart" the subscription but as a Qos0
-	testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 0}}, []byte{0})
+	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "foo", qos: 0}}, []byte{0})
 	testMQTTFlush(t, mc, nil, r)
 
 	// Publish a message QoS
@@ -2567,7 +2567,7 @@ func TestMQTTSubPropagation(t *testing.T) {
 	defer mc.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
 
-	testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "foo/#", qos: 0}}, []byte{0})
+	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "foo/#", qos: 0}}, []byte{0})
 	testMQTTFlush(t, mc, nil, r)
 
 	// Because in MQTT foo/# means foo.> but also foo, check that this is propagated
@@ -2611,7 +2611,7 @@ func TestMQTTCluster(t *testing.T) {
 					defer mc.Close()
 					testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
 
-					testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "foo/#", qos: test.subQos}}, []byte{test.subQos})
+					testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "foo/#", qos: test.subQos}}, []byte{test.subQos})
 					testMQTTFlush(t, mc, nil, r)
 
 					check := func(mc net.Conn, r *mqttReader, o *Options, s *Server) {
@@ -2705,7 +2705,7 @@ func TestMQTTClusterRetainedMsg(t *testing.T) {
 	defer mc.Close()
 	testMQTTCheckConnAck(t, rc, mqttConnAckRCConnectionAccepted, false)
 
-	testMQTTSub(t, 1, mc, rc, []*mqttFilter{&mqttFilter{filter: "foo/#", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mc, rc, []*mqttFilter{{filter: "foo/#", qos: 1}}, []byte{1})
 	testMQTTFlush(t, mc, nil, rc)
 
 	// Create a publisher from server 2.
@@ -2722,7 +2722,7 @@ func TestMQTTClusterRetainedMsg(t *testing.T) {
 	mc2, rc2 := testMQTTConnect(t, &mqttConnInfo{cleanSess: true}, srv1Opts.MQTT.Host, srv1Opts.MQTT.Port)
 	defer mc2.Close()
 	testMQTTCheckConnAck(t, rc2, mqttConnAckRCConnectionAccepted, false)
-	testMQTTSub(t, 1, mc2, rc2, []*mqttFilter{&mqttFilter{filter: "foo/#", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mc2, rc2, []*mqttFilter{{filter: "foo/#", qos: 1}}, []byte{1})
 	testMQTTCheckPubMsg(t, mc2, rc2, "foo/bar", mqttPubQos1|mqttPubFlagRetain, []byte("retained"))
 	testMQTTDisconnect(t, mc2, nil)
 
@@ -2738,7 +2738,7 @@ func TestMQTTClusterRetainedMsg(t *testing.T) {
 	mc, rc = testMQTTConnect(t, &mqttConnInfo{clientID: "sub", cleanSess: false}, srv2Opts.MQTT.Host, srv2Opts.MQTT.Port)
 	defer mc.Close()
 	testMQTTCheckConnAck(t, rc, mqttConnAckRCConnectionAccepted, true)
-	testMQTTSub(t, 1, mc, rc, []*mqttFilter{&mqttFilter{filter: "foo/#", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mc, rc, []*mqttFilter{{filter: "foo/#", qos: 1}}, []byte{1})
 	// The retained message should not be delivered.
 	testMQTTExpectNothing(t, rc)
 	// Now disconnect and reconnect back to first server
@@ -2750,7 +2750,7 @@ func TestMQTTClusterRetainedMsg(t *testing.T) {
 	mc, rc = testMQTTConnect(t, &mqttConnInfo{clientID: "sub", cleanSess: false}, srv1Opts.MQTT.Host, srv1Opts.MQTT.Port)
 	defer mc.Close()
 	testMQTTCheckConnAck(t, rc, mqttConnAckRCConnectionAccepted, true)
-	testMQTTSub(t, 1, mc, rc, []*mqttFilter{&mqttFilter{filter: "foo/#", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mc, rc, []*mqttFilter{{filter: "foo/#", qos: 1}}, []byte{1})
 	testMQTTExpectNothing(t, rc)
 }
 
@@ -2858,7 +2858,7 @@ func TestMQTTClusterReplicasCount(t *testing.T) {
 			mc, rc := testMQTTConnect(t, &mqttConnInfo{clientID: "sub", cleanSess: false}, o.MQTT.Host, o.MQTT.Port)
 			defer mc.Close()
 			testMQTTCheckConnAck(t, rc, mqttConnAckRCConnectionAccepted, false)
-			testMQTTSub(t, 1, mc, rc, []*mqttFilter{&mqttFilter{filter: "foo/#", qos: 1}}, []byte{1})
+			testMQTTSub(t, 1, mc, rc, []*mqttFilter{{filter: "foo/#", qos: 1}}, []byte{1})
 			testMQTTFlush(t, mc, nil, rc)
 
 			nc := natsConnect(t, s.ClientURL())
@@ -2972,7 +2972,7 @@ func TestMQTTUnsub(t *testing.T) {
 	defer mc.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
 
-	testMQTTSub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 0}}, []byte{0})
+	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "foo", qos: 0}}, []byte{0})
 	testMQTTFlush(t, mc, nil, r)
 
 	// Publish and test msg received
@@ -2980,7 +2980,7 @@ func TestMQTTUnsub(t *testing.T) {
 	testMQTTCheckPubMsg(t, mc, r, "foo", 0, []byte("msg"))
 
 	// Unsubscribe
-	testMQTTUnsub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "foo"}})
+	testMQTTUnsub(t, 1, mc, r, []*mqttFilter{{filter: "foo"}})
 
 	// Publish and test msg not received
 	testMQTTPublish(t, mcp, r, 0, false, false, "foo", 0, []byte("msg"))
@@ -2988,8 +2988,8 @@ func TestMQTTUnsub(t *testing.T) {
 
 	// Use of wildcards subs
 	filters := []*mqttFilter{
-		&mqttFilter{filter: "foo/bar", qos: 0},
-		&mqttFilter{filter: "foo/#", qos: 0},
+		{filter: "foo/bar", qos: 0},
+		{filter: "foo/#", qos: 0},
 	}
 	testMQTTSub(t, 1, mc, r, filters, []byte{0, 0})
 	testMQTTFlush(t, mc, nil, r)
@@ -3000,14 +3000,14 @@ func TestMQTTUnsub(t *testing.T) {
 	testMQTTCheckPubMsg(t, mc, r, "foo/bar", 0, []byte("msg"))
 
 	// Unsub the wildcard one
-	testMQTTUnsub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "foo/#"}})
+	testMQTTUnsub(t, 1, mc, r, []*mqttFilter{{filter: "foo/#"}})
 	// Publish and check that message received once
 	testMQTTPublish(t, mcp, r, 0, false, false, "foo/bar", 0, []byte("msg"))
 	testMQTTCheckPubMsg(t, mc, r, "foo/bar", 0, []byte("msg"))
 	testMQTTExpectNothing(t, r)
 
 	// Unsub last
-	testMQTTUnsub(t, 1, mc, r, []*mqttFilter{&mqttFilter{filter: "foo/bar"}})
+	testMQTTUnsub(t, 1, mc, r, []*mqttFilter{{filter: "foo/bar"}})
 	// Publish and test msg not received
 	testMQTTPublish(t, mcp, r, 0, false, false, "foo/bar", 0, []byte("msg"))
 	testMQTTExpectNothing(t, r)
@@ -3083,7 +3083,7 @@ func TestMQTTWill(t *testing.T) {
 			defer mcs.Close()
 			testMQTTCheckConnAck(t, rs, mqttConnAckRCConnectionAccepted, false)
 
-			testMQTTSub(t, 1, mcs, rs, []*mqttFilter{&mqttFilter{filter: "will/#", qos: 1}}, []byte{1})
+			testMQTTSub(t, 1, mcs, rs, []*mqttFilter{{filter: "will/#", qos: 1}}, []byte{1})
 			testMQTTFlush(t, mcs, nil, rs)
 
 			mc, r := testMQTTConnect(t,
@@ -3161,7 +3161,7 @@ func TestMQTTWillRetain(t *testing.T) {
 			defer mcs.Close()
 			testMQTTCheckConnAck(t, rs, mqttConnAckRCConnectionAccepted, false)
 
-			testMQTTSub(t, 1, mcs, rs, []*mqttFilter{&mqttFilter{filter: "will/#", qos: test.subQoS}}, []byte{test.subQoS})
+			testMQTTSub(t, 1, mcs, rs, []*mqttFilter{{filter: "will/#", qos: test.subQoS}}, []byte{test.subQoS})
 			pflags, _ := testMQTTGetPubMsg(t, mcs, rs, "will/topic", willMsg)
 			if pflags&mqttPubFlagRetain == 0 {
 				t.Fatalf("expected retain flag to be set, it was not: %v", pflags)
@@ -3232,7 +3232,7 @@ func TestMQTTWillRetainPermViolation(t *testing.T) {
 	defer mcs.Close()
 	testMQTTCheckConnAck(t, rs, mqttConnAckRCConnectionAccepted, false)
 
-	testMQTTSub(t, 1, mcs, rs, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mcs, rs, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 	pflags, _ := testMQTTGetPubMsg(t, mcs, rs, "foo", []byte("bye"))
 	if pflags&mqttPubFlagRetain == 0 {
 		t.Fatalf("expected retain flag to be set, it was not: %v", pflags)
@@ -3267,7 +3267,7 @@ func TestMQTTWillRetainPermViolation(t *testing.T) {
 	defer mcs.Close()
 	testMQTTCheckConnAck(t, rs, mqttConnAckRCConnectionAccepted, false)
 
-	testMQTTSub(t, 1, mcs, rs, []*mqttFilter{&mqttFilter{filter: "bar", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mcs, rs, []*mqttFilter{{filter: "bar", qos: 1}}, []byte{1})
 	// No Will should be published since it should not have been stored in the first place.
 	testMQTTExpectNothing(t, rs)
 	testMQTTDisconnect(t, mcs, nil)
@@ -3281,7 +3281,7 @@ func TestMQTTWillRetainPermViolation(t *testing.T) {
 	defer mcs.Close()
 	testMQTTCheckConnAck(t, rs, mqttConnAckRCConnectionAccepted, false)
 
-	testMQTTSub(t, 1, mcs, rs, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mcs, rs, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 	testMQTTExpectNothing(t, rs)
 	testMQTTDisconnect(t, mcs, nil)
 }
@@ -3313,7 +3313,7 @@ func TestMQTTPublishRetain(t *testing.T) {
 			defer mc2.Close()
 			testMQTTCheckConnAck(t, rs2, mqttConnAckRCConnectionAccepted, false)
 
-			testMQTTSub(t, 1, mc2, rs2, []*mqttFilter{&mqttFilter{filter: "foo/#", qos: 1}}, []byte{1})
+			testMQTTSub(t, 1, mc2, rs2, []*mqttFilter{{filter: "foo/#", qos: 1}}, []byte{1})
 
 			if test.subGetsIt {
 				pflags, _ := testMQTTGetPubMsg(t, mc2, rs2, "foo", []byte(test.expectedValue))
@@ -3361,7 +3361,7 @@ func TestMQTTPublishRetainPermViolation(t *testing.T) {
 	defer mc2.Close()
 	testMQTTCheckConnAck(t, rs2, mqttConnAckRCConnectionAccepted, false)
 
-	testMQTTSub(t, 1, mc2, rs2, []*mqttFilter{&mqttFilter{filter: "bar", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mc2, rs2, []*mqttFilter{{filter: "bar", qos: 1}}, []byte{1})
 	testMQTTExpectNothing(t, rs2)
 
 	testMQTTDisconnect(t, mc1, nil)
@@ -3391,7 +3391,7 @@ func TestMQTTPublishViolation(t *testing.T) {
 	mc, rc := testMQTTConnect(t, ci, o.MQTT.Host, o.MQTT.Port)
 	defer mc.Close()
 	testMQTTCheckConnAck(t, rc, mqttConnAckRCConnectionAccepted, false)
-	testMQTTSub(t, 1, mc, rc, []*mqttFilter{&mqttFilter{filter: "foo/+", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mc, rc, []*mqttFilter{{filter: "foo/+", qos: 1}}, []byte{1})
 	testMQTTFlush(t, mc, nil, rc)
 
 	ci.clientID = "pub"
@@ -3424,7 +3424,7 @@ func TestMQTTPublishViolation(t *testing.T) {
 	mc, rc = testMQTTConnect(t, ci, o.MQTT.Host, o.MQTT.Port)
 	defer mc.Close()
 	testMQTTCheckConnAck(t, rc, mqttConnAckRCConnectionAccepted, true)
-	testMQTTSub(t, 1, mc, rc, []*mqttFilter{&mqttFilter{filter: "foo/+", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, mc, rc, []*mqttFilter{{filter: "foo/+", qos: 1}}, []byte{1})
 	testMQTTExpectNothing(t, rc)
 }
 
@@ -3489,9 +3489,9 @@ func TestMQTTPersistedSession(t *testing.T) {
 
 	testMQTTSub(t, 1, c, r,
 		[]*mqttFilter{
-			&mqttFilter{filter: "foo/#", qos: 1},
-			&mqttFilter{filter: "bar", qos: 1},
-			&mqttFilter{filter: "baz", qos: 0},
+			{filter: "foo/#", qos: 1},
+			{filter: "bar", qos: 1},
+			{filter: "baz", qos: 0},
 		},
 		[]byte{1, 1, 0})
 	testMQTTFlush(t, c, nil, r)
@@ -3553,7 +3553,7 @@ func TestMQTTPersistedSession(t *testing.T) {
 
 	// Now unsub "bar" and verify that message published on this topic
 	// is not received.
-	testMQTTUnsub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "bar"}})
+	testMQTTUnsub(t, 1, c, r, []*mqttFilter{{filter: "bar"}})
 	natsPub(t, nc, "bar", []byte("msg5"))
 	testMQTTExpectNothing(t, r)
 
@@ -3589,7 +3589,7 @@ func TestMQTTPersistedSession(t *testing.T) {
 	testMQTTCheckPubMsg(t, c, r, "baz", 0, []byte("msg9"))
 
 	// Have the sub client send a subscription downgrading the qos1 subscription.
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo/#", qos: 0}}, []byte{0})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo/#", qos: 0}}, []byte{0})
 	testMQTTFlush(t, c, nil, r)
 
 	nc.Close()
@@ -3685,7 +3685,7 @@ func TestMQTTRecoverSessionAndAddNewSub(t *testing.T) {
 	defer c.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
 	// Now add sub and make sure it does not crash
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 	testMQTTFlush(t, c, nil, r)
 
 	// Now repeat with a new client but without server restart.
@@ -3699,7 +3699,7 @@ func TestMQTTRecoverSessionAndAddNewSub(t *testing.T) {
 	c2, r2 = testMQTTConnect(t, cisub2, o.MQTT.Host, o.MQTT.Port)
 	defer c2.Close()
 	testMQTTCheckConnAck(t, r2, mqttConnAckRCConnectionAccepted, true)
-	testMQTTSub(t, 1, c2, r2, []*mqttFilter{&mqttFilter{filter: "bar", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c2, r2, []*mqttFilter{{filter: "bar", qos: 1}}, []byte{1})
 	testMQTTFlush(t, c2, nil, r2)
 }
 
@@ -3714,7 +3714,7 @@ func TestMQTTRecoverSessionWithSubAndClientResendSub(t *testing.T) {
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
 
 	// Have a client send a SUBSCRIBE protocol for foo, QoS1
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 	testMQTTDisconnect(t, c, nil)
 	c.Close()
 
@@ -3737,7 +3737,7 @@ func TestMQTTRecoverSessionWithSubAndClientResendSub(t *testing.T) {
 
 	// For applications that restart, it is possible (likely) that they
 	// will resend their SUBSCRIBE protocols, so do so now:
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 	testMQTTFlush(t, c, nil, r)
 
 	checkNumSub := func(clientID string) {
@@ -3778,14 +3778,14 @@ func TestMQTTRecoverSessionWithSubAndClientResendSub(t *testing.T) {
 	c, r = testMQTTConnect(t, cisub2, o.MQTT.Host, o.MQTT.Port)
 	defer c.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 	testMQTTDisconnect(t, c, nil)
 	c.Close()
 	// Restart client
 	c, r = testMQTTConnect(t, cisub2, o.MQTT.Host, o.MQTT.Port)
 	defer c.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 	testMQTTFlush(t, c, nil, r)
 	// Check client subs
 	checkNumSub("sub2")
@@ -3941,13 +3941,13 @@ func TestMQTTPersistRetainedMsg(t *testing.T) {
 	defer c.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
 
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 	testMQTTCheckPubMsg(t, c, r, "foo", mqttPubFlagRetain|mqttPubQos1, []byte("foo2"))
 
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "baz", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "baz", qos: 1}}, []byte{1})
 	testMQTTCheckPubMsg(t, c, r, "baz", mqttPubFlagRetain, []byte("baz1"))
 
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "bar", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "bar", qos: 1}}, []byte{1})
 	testMQTTExpectNothing(t, r)
 
 	testMQTTDisconnect(t, c, nil)
@@ -3964,7 +3964,7 @@ func TestMQTTConnAckFirstPacket(t *testing.T) {
 	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
 	defer c.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 0}}, []byte{0})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 0}}, []byte{0})
 	testMQTTDisconnect(t, c, nil)
 	c.Close()
 
@@ -4022,7 +4022,7 @@ func TestMQTTRedeliveryAckWait(t *testing.T) {
 	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
 	defer c.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 
 	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
 	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
@@ -4101,7 +4101,7 @@ func TestMQTTAckWaitConfigChange(t *testing.T) {
 	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
 	defer c.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 
 	sendMsg := func(topic, payload string) {
 		t.Helper()
@@ -4148,7 +4148,7 @@ func TestMQTTAckWaitConfigChange(t *testing.T) {
 	}
 
 	// Create new subscription
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "bar", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "bar", qos: 1}}, []byte{1})
 	sendMsg("bar", "msg2")
 	testMQTTCheckPubMsgNoAck(t, c, r, "bar", mqttPubQos1, []byte("msg2"))
 	start = time.Now()
@@ -4169,7 +4169,7 @@ func TestMQTTUnsubscribeWithPendingAcks(t *testing.T) {
 	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
 	defer c.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 
 	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
 	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
@@ -4188,7 +4188,7 @@ func TestMQTTUnsubscribeWithPendingAcks(t *testing.T) {
 		testMQTTCheckPubMsgNoAck(t, c, r, "foo", flags, []byte("msg"))
 	}
 
-	testMQTTUnsub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo"}})
+	testMQTTUnsub(t, 1, c, r, []*mqttFilter{{filter: "foo"}})
 	testMQTTFlush(t, c, nil, r)
 
 	mc := testMQTTGetClient(t, s, "sub")
@@ -4215,7 +4215,7 @@ func TestMQTTMaxAckPending(t *testing.T) {
 	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
 	defer c.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 
 	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
 	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
@@ -4314,8 +4314,8 @@ func TestMQTTMaxAckPendingForMultipleSubs(t *testing.T) {
 	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
 	defer c.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "bar", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "bar", qos: 1}}, []byte{1})
 
 	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
 	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
@@ -4367,36 +4367,36 @@ func TestMQTTMaxAckPendingOverLimit(t *testing.T) {
 	mc.mu.Unlock()
 
 	// After this one, total would be 20000
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 	checkTMax(sess, 20000)
 	// This one will count for 2, so total will be 60000
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "bar/#", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "bar/#", qos: 1}}, []byte{1})
 	checkTMax(sess, 60000)
 
 	// This should fail
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "bar", qos: 1}}, []byte{mqttSubAckFailure})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "bar", qos: 1}}, []byte{mqttSubAckFailure})
 	checkTMax(sess, 60000)
 
 	// Remove the one with wildcard
-	testMQTTUnsub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "bar/#"}})
+	testMQTTUnsub(t, 1, c, r, []*mqttFilter{{filter: "bar/#"}})
 	checkTMax(sess, 20000)
 
 	// Now we could add 2 more without wildcards
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "bar", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "bar", qos: 1}}, []byte{1})
 	checkTMax(sess, 40000)
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "baz", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "baz", qos: 1}}, []byte{1})
 	checkTMax(sess, 60000)
 
 	// Again, this one should fail
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "bat", qos: 1}}, []byte{mqttSubAckFailure})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "bat", qos: 1}}, []byte{mqttSubAckFailure})
 	checkTMax(sess, 60000)
 
 	// Now remove all and check that we are at 0
-	testMQTTUnsub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo"}})
+	testMQTTUnsub(t, 1, c, r, []*mqttFilter{{filter: "foo"}})
 	checkTMax(sess, 40000)
-	testMQTTUnsub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "bar"}})
+	testMQTTUnsub(t, 1, c, r, []*mqttFilter{{filter: "bar"}})
 	checkTMax(sess, 20000)
-	testMQTTUnsub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "baz"}})
+	testMQTTUnsub(t, 1, c, r, []*mqttFilter{{filter: "baz"}})
 	checkTMax(sess, 0)
 }
 
@@ -4431,7 +4431,7 @@ func TestMQTTConfigReload(t *testing.T) {
 	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
 	defer c.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 
 	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
 	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
@@ -4459,7 +4459,7 @@ func TestMQTTConfigReload(t *testing.T) {
 	c, r = testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
 	defer c.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
 
 	cipub = &mqttConnInfo{clientID: "pub", cleanSess: true}
 	cp, rp = testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
@@ -4481,7 +4481,7 @@ func TestMQTTConfigReload(t *testing.T) {
 
 	// Reload will have effect only on new subscriptions.
 	// Create a new subscription, and we should not be able to get the 2 messages.
-	testMQTTSub(t, 1, c, r, []*mqttFilter{&mqttFilter{filter: "bar", qos: 1}}, []byte{1})
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "bar", qos: 1}}, []byte{1})
 
 	testMQTTPublish(t, cp, rp, 1, false, false, "bar", 1, []byte("msg3"))
 	testMQTTPublish(t, cp, rp, 1, false, false, "bar", 1, []byte("msg4"))
@@ -4559,7 +4559,7 @@ func mqttBenchPubQoS0(b *testing.B, subject, payload string, numSubs int) {
 		cs, brs := testMQTTConnect(b, ci, o.MQTT.Host, o.MQTT.Port)
 		testMQTTCheckConnAck(b, brs, mqttConnAckRCConnectionAccepted, false)
 
-		testMQTTSub(b, 1, cs, brs, []*mqttFilter{&mqttFilter{filter: subject, qos: 0}}, []byte{0})
+		testMQTTSub(b, 1, cs, brs, []*mqttFilter{{filter: subject, qos: 0}}, []byte{0})
 		testMQTTFlush(b, cs, nil, brs)
 
 		w := &mqttWriter{}
@@ -4639,7 +4639,7 @@ func mqttBenchPubQoS1(b *testing.B, subject, payload string, numSubs int) {
 		cs, brs := testMQTTConnect(b, ci, o.MQTT.Host, o.MQTT.Port)
 		testMQTTCheckConnAck(b, brs, mqttConnAckRCConnectionAccepted, false)
 
-		testMQTTSub(b, 1, cs, brs, []*mqttFilter{&mqttFilter{filter: subject, qos: 1}}, []byte{1})
+		testMQTTSub(b, 1, cs, brs, []*mqttFilter{{filter: subject, qos: 1}}, []byte{1})
 		testMQTTFlush(b, cs, nil, brs)
 
 		w := &mqttWriter{}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1365,7 +1365,7 @@ func TestGetRandomIP(t *testing.T) {
 	}
 
 	// Check IP exclusions
-	excludedIPs := map[string]struct{}{"1.2.3.4:4222": struct{}{}}
+	excludedIPs := map[string]struct{}{"1.2.3.4:4222": {}}
 	for i := 0; i < 100; i++ {
 		ip, err := s.getRandomIP(resolver, "localhost:4222", excludedIPs)
 		if err != nil {
@@ -1394,7 +1394,7 @@ func TestGetRandomIP(t *testing.T) {
 
 	// Now check that exclusion takes into account the port number.
 	resolver.ips = []string{"127.0.0.1"}
-	excludedIPs = map[string]struct{}{"127.0.0.1:4222": struct{}{}}
+	excludedIPs = map[string]struct{}{"127.0.0.1:4222": {}}
 	for i := 0; i < 100; i++ {
 		if _, err := s.getRandomIP(resolver, "localhost:4223", excludedIPs); err == errNoIPAvail {
 			t.Fatal("Should not have failed")
@@ -1638,7 +1638,7 @@ func TestConnectErrorReports(t *testing.T) {
 	// Now try with leaf nodes
 	opts.Cluster.Port = 0
 	opts.Routes = nil
-	opts.LeafNode.Remotes = []*RemoteLeafOpts{&RemoteLeafOpts{URLs: []*url.URL{remoteURLs[0]}}}
+	opts.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{remoteURLs[0]}}}
 	opts.LeafNode.ReconnectInterval = 15 * time.Millisecond
 	s = RunServer(opts)
 	defer s.Shutdown()
@@ -1684,7 +1684,7 @@ func TestConnectErrorReports(t *testing.T) {
 	opts.Gateway.Name = "A"
 	opts.Gateway.Port = -1
 	opts.Gateway.Gateways = []*RemoteGatewayOpts{
-		&RemoteGatewayOpts{
+		{
 			Name: "B",
 			URLs: remoteURLs,
 		},
@@ -1810,7 +1810,7 @@ func TestReconnectErrorReports(t *testing.T) {
 	opts.Cluster.Port = 0
 	opts.Routes = nil
 	u, _ := url.Parse(fmt.Sprintf("nats://127.0.0.1:%d", csOpts.LeafNode.Port))
-	opts.LeafNode.Remotes = []*RemoteLeafOpts{&RemoteLeafOpts{URLs: []*url.URL{u}}}
+	opts.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{u}}}
 	opts.LeafNode.ReconnectInterval = 15 * time.Millisecond
 	s = RunServer(opts)
 	defer s.Shutdown()
@@ -1869,7 +1869,7 @@ func TestReconnectErrorReports(t *testing.T) {
 	remoteGWPort := cs.GatewayAddr().Port
 	u, _ = url.Parse(fmt.Sprintf("nats://127.0.0.1:%d", remoteGWPort))
 	opts.Gateway.Gateways = []*RemoteGatewayOpts{
-		&RemoteGatewayOpts{
+		{
 			Name: "B",
 			URLs: []*url.URL{u},
 		},

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -95,11 +95,11 @@ func createClusterEx(t *testing.T, doAccounts bool, gwSolicit time.Duration, wai
 
 		// Setup users
 		users := []*User{
-			&User{Username: "dlc", Password: "pass", Permissions: nil, Account: dlc},
-			&User{Username: "ngs", Password: "pass", Permissions: nil, Account: ngs},
-			&User{Username: "foo", Password: "pass", Permissions: nil, Account: foo},
-			&User{Username: "bar", Password: "pass", Permissions: nil, Account: bar},
-			&User{Username: "sys", Password: "pass", Permissions: nil, Account: sys},
+			{Username: "dlc", Password: "pass", Permissions: nil, Account: dlc},
+			{Username: "ngs", Password: "pass", Permissions: nil, Account: ngs},
+			{Username: "foo", Password: "pass", Permissions: nil, Account: foo},
+			{Username: "bar", Password: "pass", Permissions: nil, Account: bar},
+			{Username: "sys", Password: "pass", Permissions: nil, Account: sys},
 		}
 		return accounts, users
 	}

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -1523,14 +1523,14 @@ func TestWSValidateOptions(t *testing.T) {
 		}, "keys configuration is required"},
 		{"websocket username not allowed if users specified", func() *Options {
 			o := wso.Clone()
-			o.Nkeys = []*NkeyUser{&NkeyUser{Nkey: "abc"}}
+			o.Nkeys = []*NkeyUser{{Nkey: "abc"}}
 			o.Websocket.Username = "b"
 			o.Websocket.Password = "pwd"
 			return o
 		}, "websocket authentication username not compatible with presence of users/nkeys"},
 		{"websocket token not allowed if users specified", func() *Options {
 			o := wso.Clone()
-			o.Nkeys = []*NkeyUser{&NkeyUser{Nkey: "abc"}}
+			o.Nkeys = []*NkeyUser{{Nkey: "abc"}}
 			o.Websocket.Token = "mytoken"
 			return o
 		}, "websocket authentication token not compatible with presence of users/nkeys"},
@@ -2083,7 +2083,7 @@ func TestWSTLSVerifyAndMap(t *testing.T) {
 	accName := "MyAccount"
 	acc := NewAccount(accName)
 	certUserName := "CN=example.com,OU=NATS.io"
-	users := []*User{&User{Username: certUserName, Account: acc}}
+	users := []*User{{Username: certUserName, Account: acc}}
 
 	for _, test := range []struct {
 		name        string
@@ -3217,7 +3217,7 @@ func TestWSBindToProperAccount(t *testing.T) {
 }
 
 func TestWSUsersAuth(t *testing.T) {
-	users := []*User{&User{Username: "user", Password: "pwd"}}
+	users := []*User{{Username: "user", Password: "pwd"}}
 	for _, test := range []struct {
 		name string
 		opts func() *Options
@@ -3302,7 +3302,7 @@ func TestWSUsersAuth(t *testing.T) {
 
 func TestWSNoAuthUserValidation(t *testing.T) {
 	o := testWSOptions()
-	o.Users = []*User{&User{Username: "user", Password: "pwd"}}
+	o.Users = []*User{{Username: "user", Password: "pwd"}}
 	// Should fail because it is not part of o.Users.
 	o.Websocket.NoAuthUser = "notfound"
 	if _, err := NewServer(o); err == nil || !strings.Contains(err.Error(), "not present as user") {
@@ -3336,10 +3336,10 @@ func TestWSNoAuthUser(t *testing.T) {
 			websocketAcc := NewAccount("websocket")
 			o.Accounts = []*Account{normalAcc, websocketAcc}
 			o.Users = []*User{
-				&User{Username: "noauth", Password: "pwd", Account: normalAcc},
-				&User{Username: "user", Password: "pwd", Account: normalAcc},
-				&User{Username: "wsnoauth", Password: "pwd", Account: websocketAcc},
-				&User{Username: "wsuser", Password: "pwd", Account: websocketAcc},
+				{Username: "noauth", Password: "pwd", Account: normalAcc},
+				{Username: "user", Password: "pwd", Account: normalAcc},
+				{Username: "wsnoauth", Password: "pwd", Account: websocketAcc},
+				{Username: "wsuser", Password: "pwd", Account: websocketAcc},
 			}
 			o.NoAuthUser = "noauth"
 			if test.override {
@@ -3406,7 +3406,7 @@ func TestWSNkeyAuth(t *testing.T) {
 			"no filtering, wrong nkey",
 			func() *Options {
 				o := testWSOptions()
-				o.Nkeys = []*NkeyUser{&NkeyUser{Nkey: pub}}
+				o.Nkeys = []*NkeyUser{{Nkey: pub}}
 				return o
 			},
 			badpub, badkp, "-ERR 'Authorization Violation'",
@@ -3415,7 +3415,7 @@ func TestWSNkeyAuth(t *testing.T) {
 			"no filtering, correct nkey",
 			func() *Options {
 				o := testWSOptions()
-				o.Nkeys = []*NkeyUser{&NkeyUser{Nkey: pub}}
+				o.Nkeys = []*NkeyUser{{Nkey: pub}}
 				return o
 			},
 			pub, nkp, "",
@@ -3425,11 +3425,11 @@ func TestWSNkeyAuth(t *testing.T) {
 			func() *Options {
 				o := testWSOptions()
 				o.Nkeys = []*NkeyUser{
-					&NkeyUser{
+					{
 						Nkey:                   pub,
 						AllowedConnectionTypes: testCreateAllowedConnectionTypes([]string{jwt.ConnectionTypeStandard}),
 					},
-					&NkeyUser{
+					{
 						Nkey:                   wspub,
 						AllowedConnectionTypes: testCreateAllowedConnectionTypes([]string{jwt.ConnectionTypeWebsocket}),
 					},
@@ -3443,8 +3443,8 @@ func TestWSNkeyAuth(t *testing.T) {
 			func() *Options {
 				o := testWSOptions()
 				o.Nkeys = []*NkeyUser{
-					&NkeyUser{Nkey: pub},
-					&NkeyUser{
+					{Nkey: pub},
+					{
 						Nkey:                   wspub,
 						AllowedConnectionTypes: testCreateAllowedConnectionTypes([]string{jwt.ConnectionTypeStandard, jwt.ConnectionTypeWebsocket}),
 					},
@@ -3458,7 +3458,7 @@ func TestWSNkeyAuth(t *testing.T) {
 			func() *Options {
 				o := testWSOptions()
 				o.Nkeys = []*NkeyUser{
-					&NkeyUser{
+					{
 						Nkey:                   wspub,
 						AllowedConnectionTypes: testCreateAllowedConnectionTypes([]string{jwt.ConnectionTypeStandard, jwt.ConnectionTypeWebsocket}),
 					},

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -715,11 +715,11 @@ func createClusterEx(t *testing.T, doAccounts bool, gwSolicit time.Duration, wai
 
 		// Setup users
 		users := []*server.User{
-			&server.User{Username: "dlc", Password: "pass", Permissions: nil, Account: dlc},
-			&server.User{Username: "ngs", Password: "pass", Permissions: nil, Account: ngs},
-			&server.User{Username: "foo", Password: "pass", Permissions: nil, Account: foo},
-			&server.User{Username: "bar", Password: "pass", Permissions: nil, Account: bar},
-			&server.User{Username: "sys", Password: "pass", Permissions: nil, Account: sys},
+			{Username: "dlc", Password: "pass", Permissions: nil, Account: dlc},
+			{Username: "ngs", Password: "pass", Permissions: nil, Account: ngs},
+			{Username: "foo", Password: "pass", Permissions: nil, Account: foo},
+			{Username: "bar", Password: "pass", Permissions: nil, Account: bar},
+			{Username: "sys", Password: "pass", Permissions: nil, Account: sys},
 		}
 		return accounts, users
 	}

--- a/test/system_services_test.go
+++ b/test/system_services_test.go
@@ -272,7 +272,7 @@ func runSolicitLeafServerWithSystemToURL(surl string) (*server.Server, *server.O
 	o.Accounts = []*server.Account{server.NewAccount("$SYS"), fooAcc}
 	o.SystemAccount = "$SYS"
 	o.Users = []*server.User{
-		&server.User{Username: "foo", Password: "pass", Permissions: nil, Account: fooAcc},
+		{Username: "foo", Password: "pass", Permissions: nil, Account: fooAcc},
 	}
 	rurl, _ := url.Parse(surl)
 	sysUrl, _ := url.Parse(strings.Replace(surl, rurl.User.Username(), "sys", -1))


### PR DESCRIPTION
This runs `gofmt -s -w .` at the root of this repo. `gofmt` is part of the default Go distribution and it's what `go fmt` runs under the hood.

/cc @nats-io/core
