### PR TITLE
[fixing] subscription issue when subscribing to a super set of deny_i…

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -900,6 +900,25 @@ func (c *client) setPermissions(perms *Permissions) {
 	}
 }
 
+// Merge client.perms structure with additional pub deny permissions
+// Lock is held on entry.
+func (c *client) mergePubDenyPermissions(denyPubs []string) {
+	if len(denyPubs) == 0 {
+		return
+	}
+	if c.perms == nil {
+		c.perms = &permissions{}
+		c.perms.pcache = make(map[string]bool)
+	}
+	if c.perms.pub.deny == nil {
+		c.perms.pub.deny = NewSublistWithCache()
+	}
+	for _, pubSubject := range denyPubs {
+		sub := &subscription{subject: []byte(pubSubject)}
+		c.perms.pub.deny.Insert(sub)
+	}
+}
+
 // Check to see if we have an expiration for the user JWT via base claims.
 // FIXME(dlc) - Clear on connect with new JWT.
 func (c *client) setExpiration(claims *jwt.ClaimsData, validFor time.Duration) {


### PR DESCRIPTION
…mport

If the subscription was foo. > but the server also had an import deny of foo.bar
It was legal to send the subscription. But the other server was unaware
of the restriction and sent the message anyway. The check of the
incoming message did not happen.

Fixing by ignoring messages the server is not supposed to receive.
And exchange deny_import so that the non soliciting leaf node knows to not
send these messages in the first place.

NB. merging of deny_ export/import with perms from INFO happens in processLeafnodeInfo

Signed-off-by: Matthias Hanel <mh@synadia.com>


