### PR TITLE
Make TERM exit 1 as pre v2.2 series

### DIFF
--- a/server/signal.go
+++ b/server/signal.go
@@ -59,7 +59,7 @@ func (s *Server) handleSignals() {
 
 					if !ldm {
 						s.Shutdown()
-						os.Exit(0)
+						os.Exit(1)
 					}
 				case syscall.SIGUSR1:
 					// File log re-open for rotating file logs.


### PR DESCRIPTION
Before 2.2 series, the TERM signal used to not be handled by the server, so it would not have been a clean exit. In 2.2, it was changed to process TERM signal as a clean exit but this affects the behavior of some tools that were expecting TERM to be exit 1.

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

/cc @nats-io/core
