### PR TITLE
Consolidate test running logic

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -9,7 +9,6 @@ jobs:
 
     env:
       GOPATH: /home/runner/work/nats-server
-      GO111MODULE: "off"
 
     runs-on: ubuntu-latest
     steps:
@@ -19,32 +18,15 @@ jobs:
           path: src/github.com/nats-io/nats-server
 
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{matrix.go}}
 
-      - name: Install deps
-        shell: bash --noprofile --norc -x -eo pipefail {0}
-        run: |
-          go get -u honnef.co/go/tools/cmd/staticcheck
-          go get -u github.com/client9/misspell/cmd/misspell
+      - name: Install tools
+        run: make install-tools
 
       - name: Lint
-        shell: bash --noprofile --norc -x -eo pipefail {0}
-        run: |
-          GO_LIST=$(go list ./...)
-          go build
-          $(exit $(go fmt $GO_LIST | wc -l))
-          go vet $GO_LIST
-          find . -type f -name "*.go" | grep -v "/vendor/" | xargs $GOPATH/bin/misspell -error -locale US
-          $GOPATH/bin/staticcheck $GO_LIST
+        run: make lint
 
       - name: Run tests
-        shell: bash --noprofile --norc -x -eo pipefail {0}
-        run: |
-          set -e
-          go test -i ./...
-          go test -v -run=TestNoRace --failfast -p=1 ./...
-          # coverage via cov.sh disabled while just testing the waters
-          go test -v -race -p=1 --failfast ./...
-          set +e
+        run: make test-no-race test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,27 +9,16 @@ addons:
   apt:
     packages:
     - rpm
-env:
-- GO111MODULE=off
 go_import_path: github.com/nats-io/nats-server
 install:
-- go get github.com/nats-io/nats.go/
-- go get github.com/nats-io/nkeys
-- go get github.com/nats-io/jwt
-- go get -u honnef.co/go/tools/cmd/staticcheck
-- go get -u github.com/client9/misspell/cmd/misspell
+- make install-tools
 before_script:
-- GO_LIST=$(go list ./...)
-- go build
-- $(exit $(go fmt $GO_LIST | wc -l))
-- go vet $GO_LIST
-- find . -type f -name "*.go" | grep -v "/vendor/" | xargs misspell -error -locale US
-- staticcheck $GO_LIST
+- make lint
 script:
 - set -e
-- if [[ $TRAVIS_TAG ]]; then go test -v -run=TestVersionMatchesTag ./server; fi
-- if [[ ! $TRAVIS_TAG ]]; then go test -v -run=TestNoRace --failfast -p=1 ./...; fi
-- if [[ ! $TRAVIS_TAG ]]; then if [[ "$TRAVIS_GO_VERSION" =~ 1.15 ]]; then ./scripts/cov.sh TRAVIS; else go test -v -race -p=1 --failfast ./...; fi; fi
+- if [[ $TRAVIS_TAG ]]; then make test-tag; fi
+- if [[ ! $TRAVIS_TAG ]]; then make test-no-race; fi
+- if [[ ! $TRAVIS_TAG ]]; then if [[ "$TRAVIS_GO_VERSION" =~ 1.15 ]]; then ./scripts/cov.sh TRAVIS; else make test; fi; fi
 - set +e
 
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+export GO111MODULE := off
+
+.PHONY: install-tools
+install-tools:
+	go get -u honnef.co/go/tools/cmd/staticcheck
+	go get -u github.com/client9/misspell/cmd/misspell
+
+.PHONY: lint
+lint: goPkgs := $(shell GO111MODULE=$(GO111MODULE) go list ./...)
+lint:
+	if [ -n "$$(gofmt -l .)" ]; then exit 1; fi
+	find . -type f -name "*.go" | grep -v "/vendor/" | xargs misspell -error -locale US
+	go vet $(goPkgs)
+	staticcheck $(goPkgs)
+
+.PHONY: test-no-race
+test-no-race:
+	if [ "$$(ulimit -n)" -lt "8192" ]; then exit 1; fi
+	go test -v -run=TestNoRace -failfast -p=1 ./...
+.PHONY: test
+test:
+	if [ "$$(ulimit -n)" -lt "8192" ]; then exit 1; fi
+	go test -v -race -p=1 -failfast ./...
+.PHONY: test-tag
+test-tag:
+	if [ "$$(ulimit -n)" -lt "8192" ]; then exit 1; fi
+	go test -v -run=TestVersionMatchesTag ./server


### PR DESCRIPTION
Currently, we have different commands to run tests spread across
different YAML files and comments in Go files.

This change consolidates all the different commands, environment
variables, and OS limits into 1 file that Travis, GitHub, and engineers
can use to run tests.

This change doesn't require engineers to alter their workflow.

/cc @nats-io/core
