### PR TITLE
Improve JS when a leafnode cluster extends and shares a system account.

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3779,9 +3779,10 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 				ci = &cis
 				ci.Service = c.acc.Name
 			}
-		} else {
+		} else if c.kind != LEAF || c.pa.hdr < 0 || len(getHeader(ClientInfoHdr, msg[:c.pa.hdr])) == 0 {
 			ci = c.getClientInfo(share)
 		}
+
 		if ci != nil {
 			if b, _ := json.Marshal(ci); b != nil {
 				msg = c.setHeader(ClientInfoHdr, string(b), msg)


### PR DESCRIPTION
This PR improves the setup that has a remote leafnode cluster extending a cluster or supercluster and the JetStream domain. We want to ensure the remote cluster places correctly and does not try to elect its own leader.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
