### PR TITLE
Allow control messages like heartbeats to pass the old sub test.

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -1438,10 +1438,6 @@ func TestNoRaceJetStreamClusterStreamCreateAndLostQuorum(t *testing.T) {
 }
 
 func TestNoRaceJetStreamClusterSuperClusterMirrors(t *testing.T) {
-	// These pass locally but are flaky on Travis.
-	// Disable for now.
-	skip(t)
-
 	sc := createJetStreamSuperCluster(t, 3, 3)
 	defer sc.shutdown()
 


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
