### PR TITLE
Do not limit expansion of new peers

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -5519,7 +5519,7 @@ func TestJetStreamClusterMixedMode(t *testing.T) {
 }
 
 func TestJetStreamClusterLeafnodeSpokes(t *testing.T) {
-	c := createJetStreamClusterExplicit(t, "HUB", 3)
+	c := createJetStreamCluster(t, jsClusterTempl, "HUB", _EMPTY_, 3, 22020, false)
 	defer c.shutdown()
 
 	lnc1 := c.createLeafNodesWithStartPort("R1", 3, 22110)
@@ -6367,7 +6367,7 @@ func (c *cluster) waitOnPeerCount(n int) {
 	c.t.Helper()
 	c.waitOnLeader()
 	leader := c.leader()
-	expires := time.Now().Add(20 * time.Second)
+	expires := time.Now().Add(10 * time.Second)
 	for time.Now().Before(expires) {
 		peers := leader.JetStreamClusterPeers()
 		if len(peers) == n {

--- a/server/raft.go
+++ b/server/raft.go
@@ -238,7 +238,6 @@ var (
 	errNotLeader       = errors.New("raft: not leader")
 	errAlreadyLeader   = errors.New("raft: already leader")
 	errNilCfg          = errors.New("raft: no config given")
-	errUnknownPeer     = errors.New("raft: unknown peer")
 	errCorruptPeers    = errors.New("raft: corrupt peer state")
 	errStepdownFailed  = errors.New("raft: stepdown failed")
 	errEntryLoadFailed = errors.New("raft: could not load entry from WAL")
@@ -2065,6 +2064,7 @@ func (n *raft) applyCommit(index uint64) error {
 		case EntryAddPeer:
 			newPeer := string(e.Data)
 			n.debug("Added peer %q", newPeer)
+
 			if _, ok := n.peers[newPeer]; !ok {
 				// We are not tracking this one automatically so we need to bump cluster size.
 				n.peers[newPeer] = &lps{time.Now().UnixNano(), 0}
@@ -2167,12 +2167,6 @@ func (n *raft) trackPeer(peer string) error {
 	var needPeerUpdate bool
 	if n.state == Leader {
 		if _, ok := n.peers[peer]; !ok {
-			// This is someone new, if we have registered all of the peers already
-			// this is an error.
-			if len(n.peers) >= n.csz {
-				n.Unlock()
-				return errUnknownPeer
-			}
 			needPeerUpdate = true
 		}
 	}


### PR DESCRIPTION
Under scenarios where peers would not be known prior to the metagroup leader being elected, they would artificially not be allowed to properly be added.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
