### PR TITLE
js: msgblock close fix

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -118,6 +118,7 @@ type msgBlock struct {
 	fch     chan struct{}
 	qch     chan struct{}
 	lchk    [8]byte
+	closed  bool
 }
 
 // Write through caching layer that is also used on loading messages.
@@ -3176,9 +3177,10 @@ func (mb *msgBlock) close(sync bool) {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
 
-	if mb.qch == nil {
+	if mb.closed {
 		return
 	}
+	mb.closed = true
 
 	// Close cache
 	mb.clearCacheAndOffset()

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -182,13 +182,14 @@ func (c *cluster) shutdown() {
 		return
 	}
 	for i, s := range c.servers {
+		sd := s.StoreDir()
+		s.Shutdown()
 		if cf := c.opts[i].ConfigFile; cf != "" {
 			os.RemoveAll(cf)
 		}
-		if sd := s.StoreDir(); sd != "" {
+		if sd != _EMPTY_ {
 			os.RemoveAll(sd)
 		}
-		s.Shutdown()
 	}
 }
 


### PR DESCRIPTION
This fixes the issue of sometimes file descriptors remaining open after shutdown in tests. Also swaps order of cleaning up resource directory in cluster tests to prevent artifacts from previous tests remain in temp storage dir.

/cc @nats-io/core
