### PR TITLE
[fixed] sub issue across leaf node connections -  bad sub  ref count

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1651,6 +1651,7 @@ func (c *client) processLeafUnsub(arg []byte) error {
 	}
 
 	updateGWs := false
+	spoke := c.isSpokeLeafNode()
 	// We store local subs by account and subject and optionally queue name.
 	// LS- will have the arg exactly as the key.
 	sub, ok := c.subs[string(arg)]
@@ -1661,11 +1662,13 @@ func (c *client) processLeafUnsub(arg []byte) error {
 		updateGWs = srv.gateway.enabled
 	}
 
-	// If we are routing subtract from the route map for the associated account.
-	srv.updateRouteSubscriptionMap(acc, sub, -1)
-	// Gateways
-	if updateGWs {
-		srv.gatewayUpdateSubInterest(acc.Name, sub, -1)
+	if !spoke {
+		// If we are routing subtract from the route map for the associated account.
+		srv.updateRouteSubscriptionMap(acc, sub, -1)
+		// Gateways
+		if updateGWs {
+			srv.gatewayUpdateSubInterest(acc.Name, sub, -1)
+		}
 	}
 	// Now check on leafnode updates for other leaf nodes.
 	srv.updateLeafNodes(acc, sub, -1)


### PR DESCRIPTION
This was caused by not sending subs across leaf node connections in some
cases but sending unsub in all cases. This imbalance caused
subscriptions to go away too soon. (ref count was off)

Signed-off-by: Matthias Hanel <mh@synadia.com>

The test TestJetStreamClusterInterestRetention failed locally for me, but that happened even without changes in this PR

```
client.go  (5 usages found)
    closeConnection  (2 usages found) ---- added as part of PR
        4585 srv.updateRouteSubscriptionMap(acc, sub, -1) . 
        4606 srv.updateRouteSubscriptionMap(acc, esub.sub, -(esub.n))
    processSubEx  (1 usage found) ---- does not call with client.kind LEAF
        2437 srv.updateRouteSubscriptionMap(acc, sub, 1)
    processUnsub  (1 usage found) ---- does not call with client.kind LEAF
        2776 srv.updateRouteSubscriptionMap(acc, sub, -1)
    unsubscribe  (1 usage found) ---- does not call with client.kind LEAF
        2709 c.srv.updateRouteSubscriptionMap(nsub.im.acc, nsub, -1)
leafnode.go  (2 usages found)
    processLeafSub  (1 usage found)
        1610 srv.updateRouteSubscriptionMap(acc, sub, 1) ---- check already existed
    processLeafUnsub  (1 usage found)
        1667 srv.updateRouteSubscriptionMap(acc, sub, -1) ---- added as part of PR
server.go  (1 usage found)
    updateRemoteSubscription  (1 usage found)
        3368 s.updateRouteSubscriptionMap(acc, sub, delta) ---- see callers below

client.go  (3 usages found)
    addShadowSub  (1 usage found) ------- It is my understanding from the call that this won't be called for client.kind LEAF
        2562 c.srv.updateRemoteSubscription(im.acc, &nsub, 1)
    deliverMsg  (2 usages found) ------- the below invocations are only done for client.kind == CLIENT || client.kind == SYSTEM
        3015 defer srv.updateRemoteSubscription(client.acc, sub, -1)
        3023 srv.updateRemoteSubscription(client.acc, sub, -1)
```
