### PR TITLE
[fixed] only become observer if the leaf config has raft not restricted

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -487,10 +487,17 @@ func (js *jetStream) setupMetaGroup() error {
 	// but do not form our own.
 	if ln := s.getOpts().LeafNode; len(ln.Remotes) > 0 {
 		sys := s.SystemAccount().GetName()
+	ENDFOR:
 		for _, r := range ln.Remotes {
 			if r.LocalAccount == sys {
+				for _, denySub := range r.DenyImports {
+					if subjectIsSubsetMatch(denySub, "$NRG.>") {
+						// raft group is denied, hence there won't be anything to observe
+						break ENDFOR
+					}
+				}
 				cfg.Observer = true
-				break
+				break ENDFOR
 			}
 		}
 	}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -491,7 +491,7 @@ func (js *jetStream) setupMetaGroup() error {
 		for _, r := range ln.Remotes {
 			if r.LocalAccount == sys {
 				for _, denySub := range r.DenyImports {
-					if subjectIsSubsetMatch(denySub, "$NRG.>") {
+					if subjectIsSubsetMatch(denySub, raftAllSubj) {
 						// raft group is denied, hence there won't be anything to observe
 						break ENDFOR
 					}

--- a/server/raft.go
+++ b/server/raft.go
@@ -1306,6 +1306,7 @@ func (n *raft) newInbox() string {
 }
 
 const (
+	raftAllSubj        = "$NRG.>"
 	raftVoteSubj       = "$NRG.V.%s"
 	raftAppendSubj     = "$NRG.AE.%s"
 	raftPropSubj       = "$NRG.P.%s"


### PR DESCRIPTION
If a subject in the system accounts leafnode deny_imports matches $NRG.>
then jetstream is explicitly disconnected and the server can become
leader.

Signed-off-by: Matthias Hanel <mh@synadia.com>
