### PR TITLE
Declare required JetStream resources in test

### DIFF
--- a/server/configs/js-op.conf
+++ b/server/configs/js-op.conf
@@ -7,6 +7,8 @@ server_name: "S1"
 # The test will cleanup this directory so if you change it search for the test.
 jetstream {
   store_dir: "/tmp/nats-server/js-op-test"
+  max_memory_store: 1073741824
+  max_file_store: 10737418240
 }
 
 operator = "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJqdGkiOiIyUkc0WjJKVzYzSUtBS1czSFg0SkpMQVhRN1ZSM0NKVlRQU1FHUVRCU0ZFQjVKTkNISUpRIiwiaWF0IjoxNjE2MTg2MjAxLCJpc3MiOiJPRDRNNklBQUtRU000RFFTTFdaSVZCQUNZVFlTMlM2WFFTN1U2N1hYWVhKNDRJTE5FMzVZUEdKSyIsIm5hbWUiOiJqcy10ZXN0Iiwic3ViIjoiT0Q0TTZJQUFLUVNNNERRU0xXWklWQkFDWVRZUzJTNlhRUzdVNjdYWFlYSjQ0SUxORTM1WVBHSksiLCJuYXRzIjp7InR5cGUiOiJvcGVyYXRvciIsInZlcnNpb24iOjJ9fQ.VkjSK2BlMmtYfVJSkC9aZEFvjg4BXzbd0oXkQa3Rlkhh8EuSRU7-Tp1zUm1SveBb6dZXsE51vhIQFQY66fO0Bw"


### PR DESCRIPTION
Currently, tests that use js-op.conf use dynamic JetStream limits,
calculated from the machine where the test is run. However, this file
also has an account JWT that requires an explicit amount of resources.
This causes some tests to pass on some machine, but not others.

This change explicitly declares the max storage and memory limits
JetStream requires to match the limits specified in the account JWT, so
that the host environment doesn't influence the tests.

tl;dr; Dynamic limits correctly determines MaxStore should be 2.75GB for my Linux laptop, but the account requires 10GB. This causes the test to fail. For `/tmp/nats/jetstream`, my laptop only has 3.8GB available because tmpfs is in memory, not disk.

/cc @nats-io/core
