### PR TITLE
Fix for data race when disabling JS running out of resources

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -493,8 +493,16 @@ func (s *Server) configAllJetStreamAccounts() error {
 // JetStreamEnabled reports if jetstream is enabled.
 func (s *Server) JetStreamEnabled() bool {
 	s.mu.Lock()
-	enabled := s.js != nil && !s.js.disabled
+	js := s.js
 	s.mu.Unlock()
+
+	var enabled bool
+	if js != nil {
+		js.mu.RLock()
+		enabled = !js.disabled
+		js.mu.RUnlock()
+	}
+
 	return enabled
 }
 


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write at 0x00c00050ae00 by goroutine 344:
  github.com/nats-io/nats-server/v2/server.(*Server).setJetStreamDisabled()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/jetstream.go:289 +0xbb
  github.com/nats-io/nats-server/v2/server.(*Server).DisableJetStream()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/jetstream.go:321 +0x76

Previous read at 0x00c00050ae00 by goroutine 61:
  github.com/nats-io/nats-server/v2/server.(*raft).outOfResources()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/raft.go:467 +0xab
  github.com/nats-io/nats-server/v2/server.(*raft).handleAppendEntry()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/raft.go:2300 +0x3c
  github.com/nats-io/nats-server/v2/server.(*raft).handleAppendEntry-fm()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/raft.go:2299 +0xc4
  github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/client.go:3064 +0x507
  github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/client.go:4036 +0x7f8
  github.com/nats-io/nats-server/v2/server.(*client).processInboundRoutedMsg()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/route.go:443 +0x328
  github.com/nats-io/nats-server/v2/server.(*client).processInboundMsg()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/client.go:3365 +0x95
  github.com/nats-io/nats-server/v2/server.(*client).parse()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/parser.go:476 +0x412f
  github.com/nats-io/nats-server/v2/server.(*client).readLoop()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/client.go:1150 +0x833
  github.com/nats-io/nats-server/v2/server.(*Server).createRoute.func1()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/route.go:1373 +0x52

Goroutine 344 (running) created at:
  github.com/nats-io/nats-server/v2/server.(*Server).handleOutOfSpace()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/jetstream.go:297 +0xdc
  github.com/nats-io/nats-server/v2/server.(*raft).setWriteErrLocked()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/raft.go:2934 +0xb6
  github.com/nats-io/nats-server/v2/server.(*raft).setWriteErr()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/raft.go:2942 +0x96
  github.com/nats-io/nats-server/v2/server.(*raft).InstallSnapshot()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/raft.go:879 +0x9f2
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster.func1()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:751 +0x161
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:782 +0x61a
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster-fm()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:730 +0x4a

Goroutine 61 (running) created at:
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/server.go:2741 +0xcc
  github.com/nats-io/nats-server/v2/server.(*Server).createRoute()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/route.go:1373 +0x81c
  github.com/nats-io/nats-server/v2/server.(*Server).startRouteAcceptLoop.func1()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/route.go:1754 +0x5e
  github.com/nats-io/nats-server/v2/server.(*Server).acceptConnections.func1()
      /Users/secret/nats-dev/src/github.com/nats-io/nats-server/server/server.go:1918 +0x57
==================      
```