### PR TITLE
Return not ready for connection reason

### DIFF
--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -214,8 +214,8 @@ func TestAccountIsolationExportImport(t *testing.T) {
 			s := opTrustBasicSetup()
 			defer s.Shutdown()
 			go s.Start()
-			if !s.ReadyForConnections(5 * time.Second) {
-				t.Fatal("failed to be ready for connections")
+			if err := s.readyForConnections(5 * time.Second); err != nil {
+				t.Fatal(err)
 			}
 			buildMemAccResolver(s)
 
@@ -1689,8 +1689,8 @@ func TestAccountRequestReplyTrackLatency(t *testing.T) {
 	// Run server in Go routine. We need this one running for internal sending of msgs.
 	go s.Start()
 	// Wait for accept loop(s) to be started
-	if !s.ReadyForConnections(10 * time.Second) {
-		panic("Unable to start NATS Server in Go Routine")
+	if err := s.readyForConnections(10 * time.Second); err != nil {
+		t.Fatal(err)
 	}
 
 	cfoo, crFoo, _ := newClientForServer(s)

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -454,6 +454,7 @@ func (s *Server) startGatewayAcceptLoop() {
 	}
 	hp := net.JoinHostPort(opts.Gateway.Host, strconv.Itoa(port))
 	l, e := natsListen("tcp", hp)
+	s.gatewayListenerErr = e
 	if e != nil {
 		s.mu.Unlock()
 		s.Fatalf("Error listening on gateway port: %d - %v", opts.Gateway.Port, e)

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -460,6 +460,7 @@ func (s *Server) startLeafNodeAcceptLoop() {
 	}
 	hp := net.JoinHostPort(opts.LeafNode.Host, strconv.Itoa(port))
 	l, e := natsListen("tcp", hp)
+	s.leafNodeListenerErr = e
 	if e != nil {
 		s.mu.Unlock()
 		s.Fatalf("Error listening on leafnode port: %d - %v", opts.LeafNode.Port, e)

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -172,6 +172,7 @@ var (
 
 type srvMQTT struct {
 	listener     net.Listener
+	listenerErr  error
 	authOverride bool
 	sessmgr      mqttSessionManager
 }
@@ -345,6 +346,7 @@ func (s *Server) startMQTT() {
 	}
 	s.mqtt.sessmgr.sessions = make(map[string]*mqttAccountSessionManager)
 	hl, err = net.Listen("tcp", hp)
+	s.mqtt.listenerErr = err
 	if err != nil {
 		s.mu.Unlock()
 		s.Fatalf("Unable to listen for MQTT connections: %v", err)

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -216,8 +216,8 @@ func testMQTTRunServer(t testing.TB, o *Options) *Server {
 	l := &DummyLogger{}
 	s.SetLogger(l, true, true)
 	go s.Start()
-	if !s.ReadyForConnections(3 * time.Second) {
-		t.Fatal("Unable to start server")
+	if err := s.readyForConnections(3 * time.Second); err != nil {
+		t.Fatal(err)
 	}
 	return s
 }

--- a/server/route.go
+++ b/server/route.go
@@ -1653,6 +1653,7 @@ func (s *Server) startRouteAcceptLoop() {
 
 	hp := net.JoinHostPort(opts.Cluster.Host, strconv.Itoa(port))
 	l, e := natsListen("tcp", hp)
+	s.routeListenerErr = e
 	if e != nil {
 		s.mu.Unlock()
 		s.Fatalf("Error listening on router port: %d - %v", opts.Cluster.Port, e)

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1342,8 +1342,8 @@ func TestRouteIPResolutionAndRouteToSelf(t *testing.T) {
 	go func() {
 		s.Start()
 	}()
-	if !s.ReadyForConnections(time.Second) {
-		t.Fatalf("Failed to start server")
+	if err := s.readyForConnections(time.Second); err != nil {
+		t.Fatal(err)
 	}
 
 	select {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -84,8 +84,8 @@ func RunServer(opts *Options) *Server {
 	go s.Start()
 
 	// Wait for accept loop(s) to be started
-	if !s.ReadyForConnections(10 * time.Second) {
-		panic("Unable to start NATS Server in Go Routine")
+	if err := s.readyForConnections(10 * time.Second); err != nil {
+		panic(err)
 	}
 	return s
 }
@@ -1481,8 +1481,8 @@ func TestInsecureSkipVerifyWarning(t *testing.T) {
 			s.Start()
 			wg.Done()
 		}()
-		if !s.ReadyForConnections(time.Second) {
-			t.Fatal("Unable to start the server")
+		if err := s.readyForConnections(time.Second); err != nil {
+			t.Fatal(err)
 		}
 		select {
 		case w := <-l.warn:

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -16,7 +16,6 @@
 package server
 
 import (
-	"errors"
 	"testing"
 	"time"
 )
@@ -31,8 +30,8 @@ func TestRun(t *testing.T) {
 		errC <- Run(s)
 	}()
 	go func() {
-		if !s.ReadyForConnections(time.Second) {
-			started <- errors.New("failed to start in time")
+		if err := s.readyForConnections(time.Second); err != nil {
+			started <- err
 			return
 		}
 		s.Shutdown()

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -116,6 +116,7 @@ type srvWebsocket struct {
 	mu             sync.RWMutex
 	server         *http.Server
 	listener       net.Listener
+	listenerErr    error
 	tls            bool
 	allowedOrigins map[string]*allowedOrigin // host will be the key
 	sameOrigin     bool
@@ -961,6 +962,7 @@ func (s *Server) startWebsocketServer() {
 		proto = wsSchemePrefix
 		hl, err = net.Listen("tcp", hp)
 	}
+	s.websocket.listenerErr = err
 	if err != nil {
 		s.mu.Unlock()
 		s.Fatalf("Unable to listen for websocket connections: %v", err)


### PR DESCRIPTION
Currently, we use ReadyForConnections in server tests to wait for the
server to be ready. However, when this fails we don't get a clue about
why it failed.

This change adds a new unexported method called readyForConnections that
returns an error describing which checks failed. The exported
ReadyForConnections version works exactly as before. The unexported
version gets used in internal tests only.

Ulimit 256 too low error - before
```
panic: Unable to start NATS Server in Go Routine
```
Ulimit 256 too low error - with this change
```
panic: failed to be ready for connections after 10s: server(listen tcp 127.0.0.1:0: socket: too many open files)
```

At higher ulimit values, we still get the not ready panic, but for different
reasons.

Ulimit 65535 - before
```
panic: Unable to start NATS Server in Go Routine
```
Ulimit 65535 - with this change
```
panic: failed to be ready for connections after 10s: route(listen tcp 127.0.0.1:33230: bind: address already in use)
```

/cc @nats-io/core
