### PR TITLE
Fix for consumer on restore being deleted

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.2.2-beta.8"
+	VERSION = "2.2.2-beta.10"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original


### PR DESCRIPTION
New code dealing with concurrent consumer requests inadvertently broke tests that were restoring consumers with same config.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
