### PR TITLE
fix unit test crashing when leader was nil caused by quorum reformation

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -6456,6 +6456,10 @@ func (c *cluster) waitOnPeerCount(n int) {
 	c.t.Helper()
 	c.waitOnLeader()
 	leader := c.leader()
+	for leader == nil {
+		c.waitOnLeader()
+		leader = c.leader()
+	}
 	expires := time.Now().Add(10 * time.Second)
 	for time.Now().Before(expires) {
 		peers := leader.JetStreamClusterPeers()


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

Locally had a crash in leader.JetStreamClusterPeers() where the first access to `s.mu` would crash.
Probably caused by leadership change between awaiting a leader and retrieving it.
Not worried about waiting forever as waitOnLeader will fail if there's none in time.