### PR TITLE
[fixed] crash when using nats-resolver without system account

### DIFF
--- a/server/jwt.go
+++ b/server/jwt.go
@@ -114,10 +114,9 @@ func validateTrustedOperators(o *Options) error {
 	} else if o.TrustedOperators[0].SystemAccount == _EMPTY_ {
 		// In case the system account is neither defined in config nor in the first operator.
 		// If it would be needed due to the nats account resolver, raise an error.
-		_, okDir := o.AccountResolver.(*DirAccResolver)
-		_, okCAcheDir := o.AccountResolver.(*CacheDirAccResolver)
-		if okDir || okCAcheDir {
-			return fmt.Errorf("using nats based account resolver - the system account needs to be specified in config or the operator jwt")
+		switch o.AccountResolver.(type) {
+		case *DirAccResolver, *CacheDirAccResolver:
+			return fmt.Errorf("using nats based account resolver - the system account needs to be specified in configuration or the operator jwt")
 		}
 	}
 	ver := strings.Split(strings.Split(VERSION, "-")[0], ".RC")[0]

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -96,11 +96,11 @@ func validateTrustedOperators(o *Options) error {
 	if len(o.TrustedOperators) > 0 && len(o.TrustedKeys) > 0 {
 		return fmt.Errorf("conflicting options for 'TrustedKeys' and 'TrustedOperators'")
 	}
-	if o.SystemAccount != "" {
+	if o.SystemAccount != _EMPTY_ {
 		foundSys := false
 		foundNonEmpty := false
 		for _, op := range o.TrustedOperators {
-			if op.SystemAccount != "" {
+			if op.SystemAccount != _EMPTY_ {
 				foundNonEmpty = true
 			}
 			if op.SystemAccount == o.SystemAccount {
@@ -110,6 +110,14 @@ func validateTrustedOperators(o *Options) error {
 		}
 		if foundNonEmpty && !foundSys {
 			return fmt.Errorf("system_account in config and operator JWT must be identical")
+		}
+	} else if o.TrustedOperators[0].SystemAccount == _EMPTY_ {
+		// In case the system account is neither defined in config nor in the first operator.
+		// If it would be needed due to the nats account resolver, raise an error.
+		_, okDir := o.AccountResolver.(*DirAccResolver)
+		_, okCAcheDir := o.AccountResolver.(*CacheDirAccResolver)
+		if okDir || okCAcheDir {
+			return fmt.Errorf("using nats based account resolver - the system account needs to be specified in config or the operator jwt")
 		}
 	}
 	ver := strings.Split(strings.Split(VERSION, "-")[0], ".RC")[0]

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -5757,6 +5757,7 @@ func TestJWTNoSystemAccountButNatsResolver(t *testing.T) {
 			s, err := NewServer(opts)
 			s.Shutdown()
 			require_Error(t, err)
+			require_Contains(t, err.Error(), "the system account needs to be specified in configuration or the operator jwt")
 		})
 	}
 }

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -5739,3 +5739,24 @@ func TestJWTMappings(t *testing.T) {
 	require_Len(t, 1, updateJwt(t, srv.ClientURL(), sysCreds, aJwtNoM, 1))
 	test("foo2", "bar2", true)
 }
+
+func TestJWTNoSystemAccountButNatsResolver(t *testing.T) {
+	dirSrv := createDir(t, "srv")
+	defer removeDir(t, dirSrv)
+	for _, resType := range []string{"full", "cache"} {
+		t.Run(resType, func(t *testing.T) {
+			conf := createConfFile(t, []byte(fmt.Sprintf(`
+			listen: -1
+			operator: %s
+			resolver: {
+				type: %s
+				dir: %s
+			}`, ojwt, resType, dirSrv)))
+			defer removeFile(t, conf)
+			opts := LoadConfig(conf)
+			s, err := NewServer(opts)
+			s.Shutdown()
+			require_Error(t, err)
+		})
+	}
+}

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/nkeys"
+
 	jwt "github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 )
@@ -2402,6 +2404,10 @@ func TestLeafNodeRouteParseLSUnsub(t *testing.T) {
 }
 
 func TestLeafNodeOperatorBadCfg(t *testing.T) {
+	sysAcc, err := nkeys.CreateAccount()
+	require_NoError(t, err)
+	sysAccPk, err := sysAcc.PublicKey()
+	require_NoError(t, err)
 	tmpDir := createDir(t, "_nats-server")
 	defer removeDir(t, tmpDir)
 	for errorText, cfg := range map[string]string{
@@ -2421,6 +2427,7 @@ func TestLeafNodeOperatorBadCfg(t *testing.T) {
 			conf := createConfFile(t, []byte(fmt.Sprintf(`
 		port: -1
 		operator: %s
+		system_account: %s
 		resolver: {
 			type: cache
 			dir: %s
@@ -2428,7 +2435,7 @@ func TestLeafNodeOperatorBadCfg(t *testing.T) {
 		leafnodes: {
 			%s
 		}
-	`, ojwt, tmpDir, cfg)))
+	`, ojwt, sysAccPk, tmpDir, cfg)))
 			defer removeFile(t, conf)
 			opts := LoadConfig(conf)
 			s, err := NewServer(opts)

--- a/server/server.go
+++ b/server/server.go
@@ -1664,6 +1664,9 @@ func (s *Server) Start() {
 // Shutdown will shutdown the server instance by kicking out the AcceptLoop
 // and closing all associated clients.
 func (s *Server) Shutdown() {
+	if s == nil {
+		return
+	}
 	// Transfer off any raft nodes that we are a leader by shutting them all down.
 	s.shutdownRaftNodes()
 


### PR DESCRIPTION
Fixes #2160 
Will raise an error instead

Signed-off-by: Matthias Hanel <mh@synadia.com>

Also noticed that s.Shutdown relied on s being not nil.