### PR TITLE
[FIXED] MQTT: asset placement in origin cluster

### DIFF
--- a/server/dirstore_test.go
+++ b/server/dirstore_test.go
@@ -44,7 +44,7 @@ func require_False(t *testing.T, b bool) {
 	}
 }
 
-func require_NoError(t *testing.T, err error) {
+func require_NoError(t testing.TB, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("require no error, but got: %v", err)

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -3309,7 +3309,7 @@ func require_JWTEqual(t *testing.T, dir string, pub string, jwt string) {
 	require_Equal(t, string(content), jwt)
 }
 
-func createDir(t *testing.T, prefix string) string {
+func createDir(t testing.TB, prefix string) string {
 	t.Helper()
 	err := os.MkdirAll(tempRoot, 0700)
 	require_NoError(t, err)


### PR DESCRIPTION
In a setup with shared system account and a cluster of leaf nodes,
the JS requests did not contain the origin cluster, which caused
assets to possibly be created in the HUB. With this change, the
assets will be created in the origin cluster.

Also, removed use of acc.JetStreamEnabled() but instead fail
start of the server if mqtt is enabled in standalone mode and JS
is not enabled. If JS is enabled, we will get proper error if
account has no JS enabled.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
