### PR TITLE
allow custom authenticators to set a username

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -793,10 +793,17 @@ func (c *client) RegisterUser(user *User) {
 	} else {
 		c.setPermissions(user.Permissions)
 	}
+
+	// allows custom authenticators to set a username to be reported in
+	// server events and more
+	if user.Username != _EMPTY_ {
+		c.opts.Username = user.Username
+	}
+
 	c.mu.Unlock()
 }
 
-// RegisterNkey allows auth to call back into a new nkey
+// RegisterNkeyUser allows auth to call back into a new nkey
 // client with the authenticated user. This is used to map
 // any permissions into the client and setup accounts.
 func (c *client) RegisterNkeyUser(user *NkeyUser) error {


### PR DESCRIPTION
A custom authenticator can call `RegisterUser`, but the Username it sets on the 
User struct is never used, setting it here will allow a custom authenticator to declare
a username that will be seen in advisories, logs etc.

I am not sure if I should also do same for password - could not see any use case
for that but I am not super familiar with this code.

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
