### PR TITLE
[FIXED] TLS: default ciphers not set when tls enabled from command line

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -4342,6 +4342,7 @@ func overrideTLS(opts *Options) error {
 	tc.KeyFile = opts.TLSKey
 	tc.CaFile = opts.TLSCaCert
 	tc.Verify = opts.TLSVerify
+	tc.Ciphers = defaultCipherSuites()
 
 	var err error
 	opts.TLSConfig, err = GenTLSConfig(&tc)

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -1522,6 +1522,10 @@ func TestConfigureOptions(t *testing.T) {
 	if opts.TLSConfig == nil || !opts.TLS {
 		t.Fatal("Expected TLSConfig to be set")
 	}
+	// Check that we use default TLS ciphers
+	if !reflect.DeepEqual(opts.TLSConfig.CipherSuites, defaultCipherSuites()) {
+		t.Fatalf("Default ciphers not set, expected %v, got %v", defaultCipherSuites(), opts.TLSConfig.CipherSuites)
+	}
 }
 
 func TestClusterPermissionsConfig(t *testing.T) {


### PR DESCRIPTION
If running the server with command lines:
```
nats-server --tlsverify --tlscert "cert.pem" --tlskey "key.pem"
```
the default ciphers would not be set, however, they would using this
equivalent config:
```
tls: {
   verify: true
   cert_file: "cert.pem"
   key_file: "key.pem"
}
```

Reported by @DavidSimner

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
