### PR TITLE
JetStream extended over a leafnode fixes.

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -511,7 +511,7 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			// but we set it here to be able to identify it in the logs.
 			c.opts.Username = user.Username
 		} else {
-			if c.kind == CLIENT && c.opts.Username == _EMPTY_ && noAuthUser != _EMPTY_ {
+			if (c.kind == CLIENT || c.kind == LEAF) && c.opts.Username == _EMPTY_ && noAuthUser != _EMPTY_ {
 				if u, exists := s.users[noAuthUser]; exists {
 					c.mu.Lock()
 					c.opts.Username = u.Username
@@ -970,7 +970,7 @@ func (s *Server) isLeafNodeAuthorized(c *client) bool {
 	}
 
 	// If leafnodes config has an authorization{} stanza, this takes precedence.
-	// The user in CONNECT mutch match. We will bind to the account associated
+	// The user in CONNECT must match. We will bind to the account associated
 	// with that user (from the leafnode's authorization{} config).
 	if opts.LeafNode.Username != _EMPTY_ {
 		return isAuthorized(opts.LeafNode.Username, opts.LeafNode.Password, opts.LeafNode.Account)
@@ -985,12 +985,12 @@ func (s *Server) isLeafNodeAuthorized(c *client) bool {
 						return u, true
 					}
 				}
-				return "", false
+				return _EMPTY_, false
 			})
 			if !found {
 				return false
 			}
-			if c.opts.Username != "" {
+			if c.opts.Username != _EMPTY_ {
 				s.Warnf("User %q found in connect proto, but user required from cert", c.opts.Username)
 			}
 			c.opts.Username = user.Username

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -228,7 +228,8 @@ func (s *Server) enableJetStream(cfg JetStreamConfig) error {
 	return nil
 }
 
-// This will check if we have a solicited leafnode that shares the system account.
+// This will check if we have a solicited leafnode that shares the system account
+// and is not denying subjects that would prevent extending JetStream.
 func (s *Server) hasSolicitLeafNodeSystemShare() bool {
 	sysAcc := s.SystemAccount().GetName()
 	for _, r := range s.getOpts().LeafNode.Remotes {

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -228,7 +228,7 @@ func (s *Server) enableJetStream(cfg JetStreamConfig) error {
 	return nil
 }
 
-// This will check if we have the a solicited leafnode that shares the system account.
+// This will check if we have a solicited leafnode that shares the system account.
 func (s *Server) hasSolicitLeafNodeSystemShare() bool {
 	sysAcc := s.SystemAccount().GetName()
 	for _, r := range s.getOpts().LeafNode.Remotes {

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -5558,6 +5558,44 @@ func TestJetStreamClusterSuperClusterAndLeafNodesWithSharedSystemAccount(t *test
 	// leafnodes should have been added into the overall peer count.
 	sc.waitOnPeerCount(8)
 
+	// Check here that we auto detect sharing system account as well and auto place the correct
+	// deny imports and exports.
+	ls := lnc.randomServer()
+	if ls == nil {
+		t.Fatalf("Expected a leafnode server, got none")
+	}
+	gacc := ls.globalAccount().GetName()
+
+	ls.mu.Lock()
+	var hasDE, hasDI bool
+	for _, ln := range ls.leafs {
+		ln.mu.Lock()
+		if ln.leaf.remote.RemoteLeafOpts.LocalAccount == gacc {
+			// Make sure we have the $JS.API denied in both.
+			for _, dsubj := range ln.leaf.remote.RemoteLeafOpts.DenyExports {
+				if dsubj == jsAllApi {
+					hasDE = true
+					break
+				}
+			}
+			for _, dsubj := range ln.leaf.remote.RemoteLeafOpts.DenyImports {
+				if dsubj == jsAllApi {
+					hasDI = true
+					break
+				}
+			}
+		}
+		ln.mu.Unlock()
+	}
+	ls.mu.Unlock()
+
+	if !hasDE {
+		t.Fatalf("No deny export on system account")
+	}
+	if !hasDI {
+		t.Fatalf("No deny import on system account")
+	}
+
 	// Make a stream by connecting to the leafnode cluster. Make sure placement is correct.
 	// Client based API
 	nc, js := jsClientConnect(t, lnc.randomServer())
@@ -5588,6 +5626,26 @@ func TestJetStreamClusterSuperClusterAndLeafNodesWithSharedSystemAccount(t *test
 	}
 	if si.Cluster.Name != pcn {
 		t.Fatalf("Expected default placement to be %q, got %q", pcn, si.Cluster.Name)
+	}
+}
+
+func TestJetStreamClusterLeafDifferentAccounts(t *testing.T) {
+	c := createJetStreamCluster(t, jsClusterAccountsTempl, "HUB", _EMPTY_, 2, 33133, false)
+	defer c.shutdown()
+
+	ln := c.createLeafNodesWithStartPort("LN", 2, 22110)
+	defer ln.shutdown()
+
+	// Wait on all peers.
+	c.waitOnPeerCount(4)
+
+	nc, js := jsClientConnect(t, ln.randomServer())
+	defer nc.Close()
+
+	// Make sure we can properly indentify the right account when the leader received the request.
+	// We need to map the client info header to the new account once received by the hub.
+	if _, err := js.AccountInfo(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
 	}
 }
 
@@ -5933,6 +5991,32 @@ func (sc *supercluster) shutdown() {
 		shutdownCluster(c)
 	}
 }
+
+var jsClusterAccountsTempl = `
+	listen: 127.0.0.1:-1
+	server_name: %s
+	jetstream: {max_mem_store: 256MB, max_file_store: 2GB, store_dir: "%s"}
+
+	leaf {
+		listen: 127.0.0.1:-1
+	}
+
+	cluster {
+		name: %s
+		listen: 127.0.0.1:%d
+		routes = [%s]
+	}
+
+	no_auth_user: u
+
+	accounts {
+		ONE {
+			users = [ { user: "u", pass: "s3cr3t!" } ]
+			jetstream: enabled
+		}
+		$SYS { users = [ { user: "admin", pass: "s3cr3t!" } ] }
+	}
+`
 
 var jsClusterTempl = `
 	listen: 127.0.0.1:-1
@@ -6342,7 +6426,7 @@ var jsClusterTemplWithLeafNode = `
 var jsLeafFrag = `
 	leaf {
 		remotes [
-			{ urls: [ %s ], deny_exports: ["$JS.API.>"], deny_imports: ["$JS.API.>"] }
+			{ urls: [ %s ] }
 			{ urls: [ %s ], account: "$SYS" }
 		]
 	}

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -125,11 +125,11 @@ func (s *Server) addInJSDeny(r *RemoteLeafOpts) {
 		}
 	}
 	if !hasDE {
-		s.Warnf("Adding deny export of %q for leafnode configuration on %q that bridges system account", jsAllApi, r.LocalAccount)
+		s.Noticef("Adding deny export of %q for leafnode configuration on %q that bridges system account", jsAllApi, r.LocalAccount)
 		r.DenyExports = append(r.DenyExports, jsAllApi)
 	}
 	if !hasDI {
-		s.Warnf("Adding deny import of %q for leafnode configuration on %q that bridges system account", jsAllApi, r.LocalAccount)
+		s.Noticef("Adding deny import of %q for leafnode configuration on %q that bridges system account", jsAllApi, r.LocalAccount)
 		r.DenyImports = append(r.DenyImports, jsAllApi)
 	}
 }
@@ -148,7 +148,7 @@ func (s *Server) checkForSystemRemoteLeaf(remotes []*RemoteLeafOpts) {
 		return
 	}
 
-	s.Warnf("Sharing the system account across a leafnode remote")
+	s.Noticef("Detected sharing of the system account across a leafnode")
 	for _, r := range remotes {
 		if r.LocalAccount != sysAcc {
 			s.addInJSDeny(r)

--- a/server/server.go
+++ b/server/server.go
@@ -98,7 +98,8 @@ type Info struct {
 	GatewayNRP        bool     `json:"gateway_nrp,omitempty"`         // Uses new $GNR. prefix for mapped replies
 
 	// LeafNode Specific
-	LeafNodeURLs []string `json:"leafnode_urls,omitempty"` // LeafNode URLs that the server can reconnect to.
+	LeafNodeURLs  []string `json:"leafnode_urls,omitempty"`  // LeafNode URLs that the server can reconnect to.
+	RemoteAccount string   `json:"remote_account,omitempty"` // Lets the other side know the remote account that they bind to.
 }
 
 // Server is our main struct.
@@ -155,7 +156,8 @@ type Server struct {
 		resolver    netResolver
 		dialTimeout time.Duration
 	}
-	leafRemoteCfgs []*leafNodeCfg
+	leafRemoteCfgs     []*leafNodeCfg
+	leafRemoteAccounts sync.Map
 
 	quitCh           chan struct{}
 	shutdownComplete chan struct{}
@@ -383,7 +385,7 @@ func NewServer(opts *Options) (*Server, error) {
 	}
 
 	// If we have a cluster definition but do not have a cluster name, create one.
-	if opts.Cluster.Port != 0 && opts.Cluster.Name == "" {
+	if opts.Cluster.Port != 0 && opts.Cluster.Name == _EMPTY_ {
 		s.info.Cluster = nuid.Next()
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -350,6 +350,12 @@ func NewServer(opts *Options) (*Server, error) {
 		return nil, fmt.Errorf("Error processing trusted operator keys")
 	}
 
+	// If we have solicited leafnodes but no clustering and no clustername.
+	// However we may need a stable clustername so use the server name.
+	if len(opts.LeafNode.Remotes) > 0 && opts.Cluster.Port == 0 && opts.Cluster.Name == _EMPTY_ {
+		opts.Cluster.Name = opts.ServerName
+	}
+
 	if opts.Cluster.Name != _EMPTY_ {
 		// Also place into mapping cn with cnMu lock.
 		s.cnMu.Lock()
@@ -387,6 +393,9 @@ func NewServer(opts *Options) (*Server, error) {
 	// If we have a cluster definition but do not have a cluster name, create one.
 	if opts.Cluster.Port != 0 && opts.Cluster.Name == _EMPTY_ {
 		s.info.Cluster = nuid.Next()
+	} else if opts.Cluster.Name != _EMPTY_ {
+		// Likewise here if we have a cluster name set.
+		s.info.Cluster = opts.Cluster.Name
 	}
 
 	// This is normally done in the AcceptLoop, once the

--- a/server/server.go
+++ b/server/server.go
@@ -524,7 +524,7 @@ func (s *Server) setClusterName(name string) {
 
 // Return whether the cluster name is dynamic.
 func (s *Server) isClusterNameDynamic() bool {
-	return s.getOpts().Cluster.Name == ""
+	return s.getOpts().Cluster.Name == _EMPTY_
 }
 
 // ClientURL returns the URL used to connect clients. Helpful in testing


### PR DESCRIPTION
We want to auto-suppress JetStream traffic on normal accounts when noticing the JetStream domain is extended.
We also now track remote accounts so that client info headers can be remapped if the accounts are different.

This PR does not have single leafnode as JetStream cluster extension yet.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
