### PR TITLE
[FIXED] Getting varz from the http endpoint saw subscriptions always double for each fetch.

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1384,12 +1384,11 @@ func (s *Server) updateVarzRuntimeFields(v *Varz, forceUpdate bool, pcpu float64
 	v.OutBytes = atomic.LoadInt64(&s.outBytes)
 	v.SlowConsumers = atomic.LoadInt64(&s.slowConsumers)
 
+	// Make sure to reset in case we are re-using.
+	v.Subscriptions = 0
 	s.accounts.Range(func(k, val interface{}) bool {
 		acc := val.(*Account)
-		acc.sl.RLock()
-		v.Subscriptions += acc.sl.count
-		acc.sl.RUnlock()
-
+		v.Subscriptions += acc.sl.Count()
 		return true
 	})
 

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -198,6 +198,25 @@ func pollVarz(t *testing.T, s *Server, mode int, url string, opts *VarzOptions) 
 	return v
 }
 
+// https://github.com/nats-io/nats-server/issues/2170
+// Just the ever increasing subs part.
+func TestVarzSubscriptionsResetProperly(t *testing.T) {
+	// Run with JS to create a bunch of subs to start.
+	resetPreviousHTTPConnections()
+	opts := DefaultMonitorOptions()
+	opts.JetStream = true
+	s := RunServer(opts)
+
+	// This bug seems to only happen via the http endpoint, not direct calls.
+	// Every time you call it doubles.
+	url := fmt.Sprintf("http://127.0.0.1:%d/varz", s.MonitorAddr().Port)
+	osubs := pollVarz(t, s, 0, url, nil).Subscriptions
+	// Make sure we get same number back.
+	if v := pollVarz(t, s, 0, url, nil); v.Subscriptions != osubs {
+		t.Fatalf("Expected subs to stay the same, %d vs %d", osubs, v.Subscriptions)
+	}
+}
+
 func TestHandleVarz(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()


### PR DESCRIPTION

Resolves part of #2170

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
