### PR TITLE
[FIXED] MQTT fixes and improvements

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -42,6 +42,7 @@ const globalAccountName = DEFAULT_GLOBAL_ACCOUNT
 // Account are subject namespace definitions. By default no messages are shared between accounts.
 // You can share via Exports and Imports of Streams and Services.
 type Account struct {
+	gwReplyMapping
 	Name         string
 	Nkey         string
 	Issuer       string
@@ -1839,7 +1840,7 @@ func (a *Account) addServiceImportSub(si *serviceImport) error {
 	cb := func(sub *subscription, c *client, subject, reply string, msg []byte) {
 		c.processServiceImport(si, a, msg)
 	}
-	_, err := c.processSubEx([]byte(subject), nil, []byte(sid), cb, true, true)
+	_, err := c.processSubEx([]byte(subject), nil, []byte(sid), cb, true, true, false)
 
 	return err
 }
@@ -2039,9 +2040,7 @@ func (a *Account) createRespWildcard() []byte {
 	a.mu.Unlock()
 
 	// Create subscription and internal callback for all the wildcard response subjects.
-	if sub, err := c.processSub(wcsub, nil, []byte(sid), a.processServiceImportResponse, false); err == nil {
-		sub.rsi = true
-	}
+	c.processSubEx(wcsub, nil, []byte(sid), a.processServiceImportResponse, false, false, true)
 
 	return pre
 }

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -5975,10 +5975,10 @@ func TestGatewayReplyMapTracking(t *testing.T) {
 	check := func(t *testing.T, expectedIndicator int32, expectLenMap int, expectedSrvMapEmpty bool) {
 		t.Helper()
 		bc.mu.Lock()
-		mapIndicator := atomic.LoadInt32(&bc.cgwrt)
+		mapIndicator := atomic.LoadInt32(&bc.gwReplyMapping.check)
 		var lenMap int
-		if bc.gwrm != nil {
-			lenMap = len(bc.gwrm)
+		if bc.gwReplyMapping.mapping != nil {
+			lenMap = len(bc.gwReplyMapping.mapping)
 		}
 		bc.mu.Unlock()
 		if mapIndicator != expectedIndicator {

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -176,6 +176,20 @@ var (
 	errMQTTTopicFilterCannotBeEmpty = errors.New("topic filter cannot be empty")
 	errMQTTMalformedVarInt          = errors.New("malformed variable int")
 	errMQTTSecondConnectPacket      = errors.New("received a second CONNECT packet")
+	errMQTTServerNameMustBeSet      = errors.New("mqtt requires server name to be explicitly set")
+	errMQTTUserMixWithUsersNKeys    = errors.New("mqtt authentication username not compatible with presence of users/nkeys")
+	errMQTTTokenMixWIthUsersNKeys   = errors.New("mqtt authentication token not compatible with presence of users/nkeys")
+	errMQTTAckWaitMustBePositive    = errors.New("ack wait must be a positive value")
+	errMQTTStandaloneNeedsJetStream = errors.New("mqtt requires JetStream to be enabled if running in standalone mode")
+	errMQTTConnFlagReserved         = errors.New("connect flags reserved bit not set to 0")
+	errMQTTWillAndRetainFlag        = errors.New("if Will flag is set to 0, Will Retain flag must be 0 too")
+	errMQTTPasswordFlagAndNoUser    = errors.New("password flag set but username flag is not")
+	errMQTTCIDEmptyNeedsCleanFlag   = errors.New("when client ID is empty, clean session flag must be set to 1")
+	errMQTTEmptyWillTopic           = errors.New("empty Will topic not allowed")
+	errMQTTEmptyUsername            = errors.New("empty user name not allowed")
+	errMQTTTopicIsEmpty             = errors.New("topic cannot be empty")
+	errMQTTPacketIdentifierIsZero   = errors.New("packet identifier cannot be 0")
+	errMQTTUnsupportedCharacters    = errors.New("characters ' ' and '.' not supported for MQTT topics")
 )
 
 type srvMQTT struct {
@@ -508,6 +522,11 @@ func validateMQTTOptions(o *Options) error {
 	if mo.Port == 0 {
 		return nil
 	}
+	// We have to force the server name to be explicitly set. There are conditions
+	// where we need a unique, repeatable name.
+	if o.ServerName == _EMPTY_ {
+		return errMQTTServerNameMustBeSet
+	}
 	// If there is a NoAuthUser, we need to have Users defined and
 	// the user to be present.
 	if mo.NoAuthUser != _EMPTY_ {
@@ -518,18 +537,22 @@ func validateMQTTOptions(o *Options) error {
 	// Token/Username not possible if there are users/nkeys
 	if len(o.Users) > 0 || len(o.Nkeys) > 0 {
 		if mo.Username != _EMPTY_ {
-			return fmt.Errorf("mqtt authentication username not compatible with presence of users/nkeys")
+			return errMQTTUserMixWithUsersNKeys
 		}
 		if mo.Token != _EMPTY_ {
-			return fmt.Errorf("mqtt authentication token not compatible with presence of users/nkeys")
+			return errMQTTTokenMixWIthUsersNKeys
 		}
 	}
 	if mo.AckWait < 0 {
-		return fmt.Errorf("ack wait must be a positive value")
+		return errMQTTAckWaitMustBePositive
 	}
-	// If standalone and there is no JS enabled, then it won't work...
-	if o.Cluster.Port == 0 && o.Gateway.Port == 0 && !o.JetStream {
-		return fmt.Errorf("mqtt requires JetStream to be enabled if running in standalone mode")
+	// If strictly standalone and there is no JS enabled, then it won't work...
+	// For leafnodes, we could either have remote(s) and it would be ok, or no
+	// remote but accept from a remote side that has "hub" property set, which
+	// then would ok too. So we fail only if we have no leafnode config at all.
+	if !o.JetStream && o.Cluster.Port == 0 && o.Gateway.Port == 0 &&
+		o.LeafNode.Port == 0 && len(o.LeafNode.Remotes) == 0 {
+		return errMQTTStandaloneNeedsJetStream
 	}
 	return nil
 }
@@ -974,16 +997,10 @@ func (s *Server) mqttCreateAccountSessionManager(acc *Account, quitCh chan struc
 	// Using ephemeral consumer is too risky because if this server were to be
 	// disconnected from the rest for few seconds, then the leader would remove
 	// the consumer, so even after a reconnect, we would not longer receive
-	// retained messages. So delete any existing durable that we have for that
-	// and recreate here. In non cluster mode, we will use the retained messages
-	// stream name as the name, since it will be unique for this account and
-	// we will know what is the name on restart.
-	rmDurName := mqttRetainedMsgsStreamName
-	// In cluster mode, we will add our id (server name hash) since there may
-	// be many of those durables (1 per node).
-	if s.JetStreamIsClustered() {
-		rmDurName += "_" + jsa.id
-	}
+	// retained messages. Delete any existing durable that we have for that
+	// and recreate here.
+	// The name for the durable is $MQTT_rmsgs_<server name hash> (which is jsa.id)
+	rmDurName := mqttRetainedMsgsStreamName + "_" + jsa.id
 	resp, err := jsa.deleteConsumer(mqttRetainedMsgsStreamName, rmDurName)
 	// If error other than "not found" then fail, otherwise proceed with creating
 	// the durable consumer.
@@ -2189,7 +2206,7 @@ func (c *client) mqttParseConnect(r *mqttReader, pl int) (byte, *mqttConnectProt
 
 	// Spec [MQTT-3.1.2-3]
 	if cp.flags&mqttConnFlagReserved != 0 {
-		return 0, nil, fmt.Errorf("connect flags reserved bit not set to 0")
+		return 0, nil, errMQTTConnFlagReserved
 	}
 
 	var hasWill bool
@@ -2203,7 +2220,7 @@ func (c *client) mqttParseConnect(r *mqttReader, pl int) (byte, *mqttConnectProt
 		}
 		// Spec [MQTT-3.1.2-15]
 		if wretain {
-			return 0, nil, fmt.Errorf("if Will flag is set to 0, Will Retain flag must be 0 too")
+			return 0, nil, errMQTTWillAndRetainFlag
 		}
 	} else {
 		// Spec [MQTT-3.1.2-14]
@@ -2219,7 +2236,7 @@ func (c *client) mqttParseConnect(r *mqttReader, pl int) (byte, *mqttConnectProt
 	hasPassword := cp.flags&mqttConnFlagPasswordFlag != 0
 	// Spec [MQTT-3.1.2-22]
 	if !hasUser && hasPassword {
-		return 0, nil, fmt.Errorf("password flag set but username flag is not")
+		return 0, nil, errMQTTPasswordFlagAndNoUser
 	}
 
 	// Keep alive
@@ -2244,7 +2261,7 @@ func (c *client) mqttParseConnect(r *mqttReader, pl int) (byte, *mqttConnectProt
 	// Spec [MQTT-3.1.3-7]
 	if cp.clientID == _EMPTY_ {
 		if cp.flags&mqttConnFlagCleanSession == 0 {
-			return mqttConnAckRCIdentifierRejected, nil, fmt.Errorf("when client ID is empty, clean session flag must be set to 1")
+			return mqttConnAckRCIdentifierRejected, nil, errMQTTCIDEmptyNeedsCleanFlag
 		}
 		// Spec [MQTT-3.1.3-6]
 		cp.clientID = nuid.Next()
@@ -2267,10 +2284,10 @@ func (c *client) mqttParseConnect(r *mqttReader, pl int) (byte, *mqttConnectProt
 			return 0, nil, err
 		}
 		if len(topic) == 0 {
-			return 0, nil, fmt.Errorf("empty Will topic not allowed")
+			return 0, nil, errMQTTEmptyWillTopic
 		}
 		if !utf8.Valid(topic) {
-			return 0, nil, fmt.Errorf("invalide utf8 for Will topic %q", topic)
+			return 0, nil, fmt.Errorf("invalid utf8 for Will topic %q", topic)
 		}
 		cp.will.topic = topic
 		// Convert MQTT topic to NATS subject
@@ -2291,7 +2308,7 @@ func (c *client) mqttParseConnect(r *mqttReader, pl int) (byte, *mqttConnectProt
 			return 0, nil, err
 		}
 		if c.opts.Username == _EMPTY_ {
-			return mqttConnAckRCBadUserOrPassword, nil, fmt.Errorf("empty user name not allowed")
+			return mqttConnAckRCBadUserOrPassword, nil, errMQTTEmptyUsername
 		}
 		// Spec [MQTT-3.1.3-11]
 		if !utf8.ValidString(c.opts.Username) {
@@ -2580,7 +2597,7 @@ func (c *client) mqttParsePub(r *mqttReader, pl int, pp *mqttPublish) error {
 		return err
 	}
 	if len(pp.topic) == 0 {
-		return fmt.Errorf("topic cannot be empty")
+		return errMQTTTopicIsEmpty
 	}
 	// Convert the topic to a NATS subject. This call will also check that
 	// there is no MQTT wildcards (Spec [MQTT-3.3.2-2] and [MQTT-4.7.1-1])
@@ -2858,7 +2875,7 @@ func mqttParsePubAck(r *mqttReader, pl int) (uint16, error) {
 		return 0, err
 	}
 	if pi == 0 {
-		return 0, fmt.Errorf("packet identifier cannot be 0")
+		return 0, errMQTTPacketIdentifierIsZero
 	}
 	return pi, nil
 }
@@ -3558,7 +3575,7 @@ func mqttToNATSSubjectConversion(mt []byte, wcOk bool) ([]byte, error) {
 			}
 		case btsep, ' ':
 			// As of now, we cannot support '.' or ' ' in the MQTT topic/filter.
-			return nil, fmt.Errorf("characters ' ' and '.' not supported for MQTT topics")
+			return nil, errMQTTUnsupportedCharacters
 		case mqttSingleLevelWC, mqttMultiLevelWC:
 			if !wcOk {
 				// Spec [MQTT-3.3.2-2] and [MQTT-4.7.1-1]

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1230,6 +1230,7 @@ func TestAcceptError(t *testing.T) {
 
 func TestServerShutdownDuringStart(t *testing.T) {
 	o := DefaultOptions()
+	o.ServerName = "server"
 	o.DisableShortFirstPing = true
 	o.Accounts = []*Account{NewAccount("$SYS")}
 	o.SystemAccount = "$SYS"


### PR DESCRIPTION
Some issues that have been fixed would manifest by timeouts on
connect, unexpected memory usage on high publish message rate.

Some details:
- Replies were not always GW routed properly because we were looking
at the wrong connection's rsubs
- GW routed replies would not be found because they were tracked
in the subscription's client object, which may not be the same used
to send the reply
- Increased the mqtt timeout to wait for JS replies since in some
tests it was sometimes taking more than the original 2 seconds
- Incoming gateway messages destined for an MQTT internal subscription
may have been rejected as a no interest if the account had service imports
- Don't use time.After(), instead create explicit timer so it can
be stopped when not timing out.
- Unnecessary copy of a slice since we were converting to a string anyway.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
