### PR TITLE
[FIXED] MQTT retained message in cluster mode may not be delivered

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -1516,6 +1516,12 @@ func (as *mqttAccountSessionManager) handleRetainedMsg(key string, rm *mqttRetai
 			erm.sseq = rm.sseq
 			// Clear the floor
 			erm.floor = 0
+			// If sub is nil, it means that it was removed from sublist following a
+			// network delete. So need to add it now.
+			if erm.sub == nil {
+				erm.sub = &subscription{subject: []byte(key)}
+				as.sl.Insert(erm.sub)
+			}
 			return oldSeq
 		}
 	}
@@ -1541,6 +1547,7 @@ func (as *mqttAccountSessionManager) handleRetainedMsgDel(subject string, seq ui
 	if erm, ok := as.retmsgs[subject]; ok {
 		if erm.sub != nil {
 			as.sl.Remove(erm.sub)
+			erm.sub = nil
 		}
 		// If processing a delete request from the network, then seq will be > 0.
 		// If that is the case and it is greater or equal to what we have, we need


### PR DESCRIPTION
In cluster mode, a sub connects to server 1, another on server 2.
A publisher connects to server 2 and publishes a retained message.
If both subs restart they would properly receive the retained message.

However, if the publisher sens an empty message that "removes" the
retained message for this topic, and then consumer that connects to
server 1 restarts, it would not receive the retained message as it
should.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
