### PR TITLE
[FIXED] Raft groups could continually spin trying to catch up.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1599,9 +1599,10 @@ func (o *consumer) needAck(sseq uint64) bool {
 		}
 		state, err := o.store.State()
 		if err != nil || state == nil {
-			o.mu.RUnlock()
 			// Fall back to what we track internally for now.
-			return sseq > o.asflr
+			needsAck := sseq > o.asflr
+			o.mu.RUnlock()
+			return needsAck
 		}
 		asflr, osseq = state.AckFloor.Stream, o.sseq
 		pending = state.Pending

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1109,9 +1109,9 @@ func (o *consumer) processAck(_ *subscription, c *client, subject, reply string,
 
 	switch {
 	case len(msg) == 0, bytes.Equal(msg, AckAck), bytes.Equal(msg, AckOK):
-		o.ackMsg(sseq, dseq, dc)
+		o.processAckMsg(sseq, dseq, dc, true)
 	case bytes.HasPrefix(msg, AckNext):
-		o.ackMsg(sseq, dseq, dc)
+		o.processAckMsg(sseq, dseq, dc, true)
 		// processNextMsgReq can be invoked from an internal subscription or from here.
 		// Therefore, it has to call msgParts(), so we can't simply pass msg[len(AckNext):]
 		// with current c.pa.hdr because it would cause a panic.  We will save the current
@@ -1497,11 +1497,6 @@ func (o *consumer) sampleAck(sseq, dseq, dc uint64) {
 	}
 
 	o.sendAdvisory(o.ackEventT, j)
-}
-
-// Process an ack for a message.
-func (o *consumer) ackMsg(sseq, dseq, dc uint64) {
-	o.processAckMsg(sseq, dseq, dc, true)
 }
 
 func (o *consumer) processAckMsg(sseq, dseq, dc uint64, doSample bool) {

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1605,7 +1605,8 @@ func (o *consumer) needAck(sseq uint64) bool {
 		state, err := o.store.State()
 		if err != nil || state == nil {
 			o.mu.RUnlock()
-			return false
+			// Fall back to what we track internally for now.
+			return sseq > o.asflr
 		}
 		asflr, osseq = state.AckFloor.Stream, o.sseq
 		pending = state.Pending

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2379,6 +2379,7 @@ func (js *jetStream) processConsumerAssignment(ca *consumerAssignment) {
 		ourID = cc.meta.ID()
 	}
 	var isMember bool
+
 	if ca.Group != nil && ourID != _EMPTY_ {
 		isMember = ca.Group.isMember(ourID)
 	}
@@ -4032,9 +4033,11 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 	// We need to set the ephemeral here before replicating.
 	var oname string
 	if !isDurableConsumer(cfg) {
-		// We chose to have ephemerals be R=1.
-		rg.Peers = []string{rg.Preferred}
-		rg.Name = groupNameForConsumer(rg.Peers, rg.Storage)
+		// We chose to have ephemerals be R=1 unless stream is interest or workqueue.
+		if sa.Config.Retention == LimitsPolicy {
+			rg.Peers = []string{rg.Preferred}
+			rg.Name = groupNameForConsumer(rg.Peers, rg.Storage)
+		}
 		// Make sure name is unique.
 		for {
 			oname = createConsumerName()

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -2064,7 +2064,6 @@ func TestJetStreamClusterMirrorAndSourceWorkQueues(t *testing.T) {
 			return fmt.Errorf("Expected 1 msg for %q, got %d", "M", si.State.Msgs)
 		}
 		if si, _ := js.StreamInfo("S"); si.State.Msgs != 1 {
-			fmt.Printf("si.State is %+v\n", si.State)
 			return fmt.Errorf("Expected 1 msg for %q, got %d", "S", si.State.Msgs)
 		}
 		return nil


### PR DESCRIPTION
In certain scenarios a follower could get stuck in an endless loop trying to catchup because the leader would not send a snapshot when the log was empty and the requested sequence was exactly the first sequence of the log, which would be lastIndex+1 for a used but empty store.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
