### PR TITLE
Don't need to store domain in mqttJSA structure

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -228,7 +228,6 @@ type mqttJSA struct {
 	replies sync.Map
 	nuid    *nuid.NUID
 	quitCh  chan struct{}
-	domain  string
 }
 
 type mqttJSPubMsg struct {
@@ -890,7 +889,6 @@ func (s *Server) mqttCreateAccountSessionManager(acc *Account, quitCh chan struc
 			sendq:  make(chan *mqttJSPubMsg, 8192),
 			nuid:   nuid.New(),
 			quitCh: quitCh,
-			domain: s.getOpts().JetStreamDomain,
 		},
 	}
 
@@ -1867,7 +1865,7 @@ func (as *mqttAccountSessionManager) createOrRestoreSession(clientID string, opt
 	// with the same client ID moves to the other domain, then there won't be
 	// conflict of session message in one domain updating the session's stream
 	// in others.
-	hash := string(getHash(as.jsa.domain + clientID))
+	hash := string(getHash(opts.JetStreamDomain + clientID))
 	sname := mqttSessionsStreamNamePrefix + hash
 	cfg := &StreamConfig{
 		Name:      sname,


### PR DESCRIPTION
At the time where we need the domain to construct the session hash,
we have access to server options. So use that instead of storing
the domain in the internal mqtt structure.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
