### PR TITLE
[added] filter system requests by JS domain 

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -1077,6 +1077,7 @@ type EventFilterOptions struct {
 	Cluster string   `json:"cluster,omitempty"`     // filter by cluster name
 	Host    string   `json:"host,omitempty"`        // filter by host name
 	Tags    []string `json:"tags,omitempty"`        // filter by tags (must match all tags)
+	Domain  string   `json:"domain,omitempty"`      // filter by JS domain
 }
 
 // StatszEventOptions are options passed to Statsz
@@ -1142,13 +1143,13 @@ type JszEventOptions struct {
 // returns true if the request does NOT apply to this server and can be ignored.
 // DO NOT hold the server lock when
 func (s *Server) filterRequest(fOpts *EventFilterOptions) bool {
-	if fOpts.Name != "" && !strings.Contains(s.info.Name, fOpts.Name) {
+	if fOpts.Name != _EMPTY_ && !strings.Contains(s.info.Name, fOpts.Name) {
 		return true
 	}
-	if fOpts.Host != "" && !strings.Contains(s.info.Host, fOpts.Host) {
+	if fOpts.Host != _EMPTY_ && !strings.Contains(s.info.Host, fOpts.Host) {
 		return true
 	}
-	if fOpts.Cluster != "" {
+	if fOpts.Cluster != _EMPTY_ {
 		s.mu.Lock()
 		cluster := s.info.Cluster
 		s.mu.Unlock()
@@ -1163,6 +1164,9 @@ func (s *Server) filterRequest(fOpts *EventFilterOptions) bool {
 				return true
 			}
 		}
+	}
+	if fOpts.Domain != _EMPTY_ && s.getOpts().JetStreamDomain != fOpts.Domain {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

```
> nats -s nats://admin:admin@localhost:4222 req '$SYS.REQ.SERVER.PING.JSZ' '{"domain":"leaf"}'
18:15:51 Sending request on "$SYS.REQ.SERVER.PING.JSZ"
18:15:51 Received on "_INBOX.VT8qToDYRhQEugeQoLnKqq.tN0mZqav" rtt 1.109964ms
{"data":{"server_id":"NAJPDFSKAT4QLMJHYPWYQZ3ENUNCNFEM2VUZQ2BHH4XG2XM3MVKQXVRD","now":"2021-05-07T22:15:51.795782Z","config":{"max_memory":51539607552,"max_storage":544531544064,"store_dir":"store_leaf_1/jetstream","domain":"leaf"},"memory":0,"storage":0,"api":{"total":0,"errors":0},"current_api_calls":0},"server":{"name":"leaf-server-1","host":"0.0.0.0","id":"NAJPDFSKAT4QLMJHYPWYQZ3ENUNCNFEM2VUZQ2BHH4XG2XM3MVKQXVRD","cluster":"leaf","ver":"2.2.3-beta.8","seq":17,"jetstream":true,"time":"2021-05-07T22:15:51.795797Z"}}

> nats -s nats://admin:admin@localhost:4222 req '$SYS.REQ.SERVER.PING.JSZ' '{"domain":"hub"}'
18:15:57 Sending request on "$SYS.REQ.SERVER.PING.JSZ"
18:15:57 Received on "_INBOX.V208I1kObjZ7zQ0oq02HfQ.Glg2kHFF" rtt 796.238µs
{"data":{"server_id":"NADESZWP7UUW3BIGPNHWBPSAEMH5U7ATVEI63E6GELZQGJPQQTNJGNWU","now":"2021-05-07T22:15:57.289507Z","config":{"max_memory":51539607552,"max_storage":544531544064,"store_dir":"store_server_1/jetstream","domain":"hub"},"memory":0,"storage":0,"api":{"total":0,"errors":0},"current_api_calls":0,"meta_cluster":{"name":"hub","leader":"hub-server-1","replicas":[{"name":"hub-server-2","current":true,"active":468253000},{"name":"hub-server-3","current":true,"active":468255000}]}},"server":{"name":"hub-server-1","host":"0.0.0.0","id":"NADESZWP7UUW3BIGPNHWBPSAEMH5U7ATVEI63E6GELZQGJPQQTNJGNWU","cluster":"hub","ver":"2.2.3-beta.8","seq":36,"jetstream":true,"time":"2021-05-07T22:15:57.289561Z"}}

```