### PR TITLE
[added] check for mirror stream return error when  de dupe window is set

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1240,7 +1240,11 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, subject, re
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
-
+		if cfg.Duplicates != time.Duration(0) {
+			resp.Error = &ApiError{Code: 400, Description: "stream mirrors do not make use of a de-duplication window"}
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+			return
+		}
 		// We do not require other stream to exist anymore, but if we can see it check payloads.
 		exists, maxMsgSize, subs := hasStream(cfg.Mirror.Name)
 		if len(subs) > 0 {


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

Noticed this in natscli, where I removed the interactive question. 
For an actual check RI preferred doing this here. 