### PR TITLE
[FIXED] Issue #2205

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3998,8 +3998,9 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 			// We handle similarly to routes and use the same data structures.
 			// Leaf node delivery audience is different however.
 			// Also leaf nodes are always no echo, so we make sure we are not
-			// going to send back to ourselves here.
-			if c != sub.client && (c.kind != ROUTER || sub.client.isHubLeafNode()) {
+			// going to send back to ourselves here. For messages from routes we want
+			// to suppress in general unless we know from the hub or its a service reply.
+			if c != sub.client && (c.kind != ROUTER || sub.client.isHubLeafNode() || isServiceReply(c.pa.subject)) {
 				c.addSubToRouteTargets(sub)
 			}
 			continue

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -184,8 +184,8 @@ func (c *cluster) shutdown() {
 	for i, s := range c.servers {
 		sd := s.StoreDir()
 		s.Shutdown()
-		if cf := c.opts[i].ConfigFile; cf != "" {
-			os.RemoveAll(cf)
+		if cf := c.opts[i].ConfigFile; cf != _EMPTY_ {
+			os.Remove(cf)
 		}
 		if sd != _EMPTY_ {
 			os.RemoveAll(sd)
@@ -198,13 +198,17 @@ func shutdownCluster(c *cluster) {
 }
 
 func (c *cluster) randomServer() *Server {
+	return c.randomServerFromCluster(c.name)
+}
+
+func (c *cluster) randomServerFromCluster(cname string) *Server {
 	// Since these can be randomly shutdown in certain tests make sure they are running first.
 	// Copy our servers list and shuffle then walk looking for first running server.
 	cs := append(c.servers[:0:0], c.servers...)
 	rand.Shuffle(len(cs), func(i, j int) { cs[i], cs[j] = cs[j], cs[i] })
 
 	for _, s := range cs {
-		if s.Running() && s.ClusterName() == c.name {
+		if s.Running() && s.ClusterName() == cname {
 			return s
 		}
 	}


### PR DESCRIPTION
When a response was needed from a leafnode cluster back to a hub, we had rules to disallow.
That rule was a bit dated and since we have cluster origin for leafnode clusters and that
is checked before the message is actually sent we could remove the old rule.

Resolves: #2205 

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
