### PR TITLE
Error-checking & resilience for JetStream move

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -217,7 +217,7 @@ func (s *Server) checkStoreDir(cfg *JetStreamConfig) error {
 			// like streams and consumers.
 			if ok {
 				if !haveJetstreamDir {
-					err := os.Mkdir(filepath.Join(filepath.Dir(cfg.StoreDir), JetStreamStoreDir), 0750)
+					err := os.Mkdir(filepath.Join(filepath.Dir(cfg.StoreDir), JetStreamStoreDir), 0755)
 					if err != nil {
 						return err
 					}
@@ -244,7 +244,7 @@ func (s *Server) enableJetStream(cfg JetStreamConfig) error {
 
 	// FIXME(dlc) - Allow memory only operation?
 	if stat, err := os.Stat(cfg.StoreDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(cfg.StoreDir, 0750); err != nil {
+		if err := os.MkdirAll(cfg.StoreDir, 0755); err != nil {
 			return fmt.Errorf("could not create storage directory - %v", err)
 		}
 	} else {

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -207,11 +207,10 @@ func (s *Server) checkStoreDir(cfg *JetStreamConfig) error {
 		if accName := fi.Name(); accName != _EMPTY_ {
 			_, ok := s.accounts.Load(accName)
 			if !ok && s.AccountResolver() != nil && nkeys.IsValidPublicAccountKey(accName) {
-				if _, err := s.fetchAccount(accName); err != nil {
-					s.Errorf("Unable to resolve account %q: %v", accName, err)
-				} else {
-					ok = true
-				}
+				// Account is not local but matches the NKEY account public key,
+				// this is enough indication to move this directory, no need to
+				// fetch the account.
+				ok = true
 			}
 			// If this seems to be an account go ahead and move the directory. This will include all assets
 			// like streams and consumers.


### PR DESCRIPTION
Jetstream movement can fail, so return that error and abort start-up if there's
a failure in moving precious data, rather than serve without it.

Create the jetstream directory if needed.

~~Create directories for private data mode 0750 not 0755.~~

This does not handle a directory layout made with 2.2.3, but does support a
2.2.2 to 2.2.4 migration.  The empty directories made under 2.2.3 will still
hinder the renames we do here.

### Changes proposed in this pull request:

 - Create the jetstream dir if needed instead of assuming it exists
 - Check for errors and return them
 - ~~Use better permissions for jetstream storage~~

/cc @nats-io/core
