### PR TITLE
Bad redelivered values on consumer state should not panic.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4099,12 +4099,9 @@ func decodeConsumerState(buf []byte) (*ConsumerState, error) {
 	if numRedelivered := readLen(); numRedelivered > 0 {
 		state.Redelivered = make(map[uint64]uint64, numRedelivered)
 		for i := 0; i < int(numRedelivered); i++ {
-			seq := readSeq()
-			n := readCount()
-			if seq == 0 || n == 0 {
-				return nil, errCorruptState
+			if seq, n := readSeq(), readCount(); seq > 0 && n > 0 {
+				state.Redelivered[seq] = n
 			}
-			state.Redelivered[seq] = n
 		}
 	}
 

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -2882,3 +2882,12 @@ func TestFileStoreStreamFailToRollBug(t *testing.T) {
 		t.Fatalf("Expected block to be <= 512, got %d", blkSize)
 	}
 }
+
+// We had a case where a consumer state had a redelivered record that had seq of 0.
+// This was causing the server to panic.
+func TestBadConsumerState(t *testing.T) {
+	bs := []byte("\x16\x02\x01\x01\x03\x02\x01\x98\xf4\x8a\x8a\f\x01\x03\x86\xfa\n\x01\x00\x01")
+	if cs, err := decodeConsumerState(bs); err != nil || cs == nil {
+		t.Fatalf("Expected to not throw error, got %v and %+v", err, cs)
+	}
+}


### PR DESCRIPTION

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
