### PR TITLE
Fixed issue that we would stage snapshot restores in temporary storage.

### DIFF
--- a/server/dirstore.go
+++ b/server/dirstore.go
@@ -91,7 +91,7 @@ func newDir(dirPath string, create bool) (string, error) {
 		if !create {
 			return "", err
 		}
-		if err = os.MkdirAll(dirPath, 0755); err != nil {
+		if err = os.MkdirAll(dirPath, defaultDirPerms); err != nil {
 			return "", err
 		}
 		if fullPath, err = validateDirPath(dirPath); err != nil {
@@ -424,7 +424,7 @@ func (store *DirJWTStore) write(path string, publicKey string, theJWT string) (b
 			}
 		}
 	}
-	if err := ioutil.WriteFile(path, []byte(theJWT), 0644); err != nil {
+	if err := ioutil.WriteFile(path, []byte(theJWT), defaultFilePerms); err != nil {
 		return false, err
 	} else if store.expiration != nil {
 		store.expiration.track(publicKey, newHash, theJWT)
@@ -473,7 +473,7 @@ func (store *DirJWTStore) save(publicKey string, theJWT string) error {
 	}
 	dirPath := filepath.Dir(path)
 	if _, err := validateDirPath(dirPath); err != nil {
-		if err := os.MkdirAll(dirPath, 0755); err != nil {
+		if err := os.MkdirAll(dirPath, defaultDirPerms); err != nil {
 			store.Unlock()
 			return err
 		}
@@ -499,7 +499,7 @@ func (store *DirJWTStore) saveIfNewer(publicKey string, theJWT string) error {
 	}
 	dirPath := filepath.Dir(path)
 	if _, err := validateDirPath(dirPath); err != nil {
-		if err := os.MkdirAll(dirPath, 0755); err != nil {
+		if err := os.MkdirAll(dirPath, defaultDirPerms); err != nil {
 			return err
 		}
 	}

--- a/server/disk_avail.go
+++ b/server/disk_avail.go
@@ -23,7 +23,7 @@ import (
 func diskAvailable(storeDir string) int64 {
 	var ba int64
 	if _, err := os.Stat(storeDir); os.IsNotExist(err) {
-		os.MkdirAll(storeDir, 0755)
+		os.MkdirAll(storeDir, defaultDirPerms)
 	}
 	var fs syscall.Statfs_t
 	if err := syscall.Statfs(storeDir, &fs); err == nil {

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -216,7 +216,7 @@ func (s *Server) checkStoreDir(cfg *JetStreamConfig) error {
 			// like streams and consumers.
 			if ok {
 				if !haveJetstreamDir {
-					err := os.Mkdir(filepath.Join(filepath.Dir(cfg.StoreDir), JetStreamStoreDir), 0755)
+					err := os.Mkdir(filepath.Join(filepath.Dir(cfg.StoreDir), JetStreamStoreDir), defaultDirPerms)
 					if err != nil {
 						return err
 					}
@@ -243,7 +243,7 @@ func (s *Server) enableJetStream(cfg JetStreamConfig) error {
 
 	// FIXME(dlc) - Allow memory only operation?
 	if stat, err := os.Stat(cfg.StoreDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(cfg.StoreDir, 0755); err != nil {
+		if err := os.MkdirAll(cfg.StoreDir, defaultDirPerms); err != nil {
 			return fmt.Errorf("could not create storage directory - %v", err)
 		}
 	} else {
@@ -866,7 +866,7 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 
 	sdir := path.Join(jsa.storeDir, streamsDir)
 	if _, err := os.Stat(sdir); os.IsNotExist(err) {
-		if err := os.MkdirAll(sdir, 0755); err != nil {
+		if err := os.MkdirAll(sdir, defaultDirPerms); err != nil {
 			return fmt.Errorf("could not create storage streams directory - %v", err)
 		}
 	}

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -861,6 +861,9 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 		}
 	}
 
+	// Clean up any old snapshots that were orphaned while staging.
+	os.RemoveAll(path.Join(js.config.StoreDir, snapStagingDir))
+
 	sdir := path.Join(jsa.storeDir, streamsDir)
 	if _, err := os.Stat(sdir); os.IsNotExist(err) {
 		if err := os.MkdirAll(sdir, 0755); err != nil {
@@ -1615,6 +1618,8 @@ const (
 	JetStreamMaxStoreDefault = 1024 * 1024 * 1024 * 1024
 	// JetStreamMaxMemDefault is only used when we can't determine system memory. 256MB
 	JetStreamMaxMemDefault = 1024 * 1024 * 256
+	// snapshot staging for restores.
+	snapStagingDir = ".snap-staging"
 )
 
 // Dynamically create a config with a tmp based directory (repeatable) and 75% of system memory.

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2632,7 +2632,7 @@ func (s *Server) processStreamRestore(ci *ClientInfo, acc *Account, cfg *StreamC
 
 	snapDir := path.Join(js.config.StoreDir, snapStagingDir)
 	if _, err := os.Stat(snapDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(snapDir, 0755); err != nil {
+		if err := os.MkdirAll(snapDir, defaultDirPerms); err != nil {
 			resp.Error = &ApiError{Code: 503, Description: "JetStream unable to create temp storage for restore"}
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return nil

--- a/server/stream.go
+++ b/server/stream.go
@@ -3240,7 +3240,7 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 
 	sd := path.Join(jsa.storeDir, snapsDir)
 	if _, err := os.Stat(sd); os.IsNotExist(err) {
-		if err := os.MkdirAll(sd, 0755); err != nil {
+		if err := os.MkdirAll(sd, defaultDirPerms); err != nil {
 			return nil, fmt.Errorf("could not create snapshots directory - %v", err)
 		}
 	}
@@ -3249,7 +3249,7 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 		return nil, err
 	}
 	if _, err := os.Stat(sdir); os.IsNotExist(err) {
-		if err := os.MkdirAll(sdir, 0755); err != nil {
+		if err := os.MkdirAll(sdir, defaultDirPerms); err != nil {
 			return nil, fmt.Errorf("could not create snapshots directory - %v", err)
 		}
 	}
@@ -3266,7 +3266,7 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 		}
 		fpath := path.Join(sdir, filepath.Clean(hdr.Name))
 		pdir := filepath.Dir(fpath)
-		os.MkdirAll(pdir, 0750)
+		os.MkdirAll(pdir, defaultDirPerms)
 		fd, err := os.OpenFile(fpath, os.O_CREATE|os.O_RDWR, 0600)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This did not work when using our default docker image which does not have /tmp by default.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
