### PR TITLE
[fixed] issue with invalid api prefix for source/mirror

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1291,7 +1291,7 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, subject, re
 	// check prefix overlap with subjects
 	for _, pfx := range deliveryPrefixes {
 		if !IsValidPublishSubject(pfx) {
-			resp.Error = &ApiError{Code: 400, Description: fmt.Sprintf("stream external delivery prefix %q must not contain wildcards", pfx)}
+			resp.Error = &ApiError{Code: 400, Description: fmt.Sprintf("stream external delivery prefix %q must be a valid subject without wildcards", pfx)}
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
@@ -1305,6 +1305,11 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, subject, re
 	}
 	// check if api prefixes overlap
 	for _, apiPfx := range apiPrefixes {
+		if !IsValidPublishSubject(apiPfx) {
+			resp.Error = &ApiError{Code: 400, Description: fmt.Sprintf("stream external api prefix %q must be a valid subject without wildcards", apiPfx)}
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+			return
+		}
 		if SubjectsCollide(apiPfx, JSApiPrefix) {
 			resp.Error = &ApiError{Code: 400, Description: fmt.Sprintf("stream external api prefix %q must not overlap with %s", apiPfx, JSApiPrefix)}
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))


### PR DESCRIPTION
addressed by failing

Signed-off-by: Matthias Hanel <mh@synadia.com>

```
ats --context=hub s add --creds keys/creds/OP/IMPORTER/iuser.creds --mirror aggregate crosspassxxx
? Storage backend file
? Retention Policy Limits
? Discard Policy Old
? Stream Messages Limit -1
? Message size limit -1
? Maximum message age limit -1
? Maximum individual message size -1
? Replicas 1
? Adjust mirror start No
? Import mirror from a different JetStream domain No
? Import mirror from a different account Yes
? Foreign account API prefix  $JS.spoke-1.API
X Sorry, your reply was invalid: Value is required
? Foreign account delivery prefix ff
nats: error: could not create Stream: stream external api prefix " $JS.spoke-1.API" must be a valid subject without wildcards
```