### PR TITLE
[FIXED] #2242.

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1190,6 +1190,10 @@ func (js *jetStream) createRaftGroup(rg *raftGroup, storage StorageType) error {
 
 	s, cc := js.srv, js.cluster
 
+	if cc == nil || cc.meta == nil {
+		return ErrJetStreamNotClustered
+	}
+
 	// If this is a single peer raft group or we are not a member return.
 	if len(rg.Peers) <= 1 || !rg.isMember(cc.meta.ID()) {
 		// Nothing to do here.


### PR DESCRIPTION
When we had a duplicate detected in R>1 mode we set the skip sequence indicator but were not using that when dealing with underlying store.

Resolves: #2242

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
