### PR TITLE
Fix for #2243. We were not allowing replicated acks processing for work queues.

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2850,7 +2850,7 @@ func (o *consumer) processReplicatedAck(dseq, sseq uint64) {
 	o.mu.RLock()
 
 	mset := o.mset
-	if mset == nil || mset.cfg.Retention != InterestPolicy {
+	if mset == nil || mset.cfg.Retention == LimitsPolicy {
 		o.mu.RUnlock()
 		return
 	}


### PR DESCRIPTION
Resolves: #2243 

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
