### PR TITLE
[changed] pinned certs to check the server connected to as well

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -187,19 +187,6 @@ func (s *Server) checkAuthforWarnings() {
 		// Warning about using plaintext passwords.
 		s.Warnf("Plaintext passwords detected, use nkeys or bcrypt")
 	}
-	// only warn about client connections others use bidirectional TLS
-	if len(s.opts.TLSPinnedCerts) > 0 && !(s.opts.TLSVerify || s.opts.TLSMap) {
-		s.Warnf("Pinned Certs specified but no verify or verify_and_map that would require presenting a client cert")
-	}
-	if len(s.opts.Websocket.TLSPinnedCerts) > 0 && !(s.opts.Websocket.TLSMap) {
-		s.Warnf("Websocket Pinned Certs specified but no verify_and_map that would require presenting a client cert")
-	}
-	if len(s.opts.MQTT.TLSPinnedCerts) > 0 && !(s.opts.MQTT.TLSMap) {
-		s.Warnf("MQTT Pinned Certs specified but no verify_and_map that would require presenting a client cert")
-	}
-	if len(s.opts.LeafNode.TLSPinnedCerts) > 0 && !(s.opts.LeafNode.TLSMap) {
-		s.Warnf("Leaf Pinned Certs specified but verify_and_map that would require presenting a client cert")
-	}
 }
 
 // If Users or Nkeys options have definitions without an account defined,
@@ -360,7 +347,7 @@ func (s *Server) isClientAuthorized(c *client) bool {
 }
 
 // returns false if the client needs to be disconnected
-func (s *Server) matchesPinnedCert(c *client, tlsPinnedCerts PinnedCertSet) bool {
+func (c *client) matchesPinnedCert(tlsPinnedCerts PinnedCertSet) bool {
 	if tlsPinnedCerts == nil {
 		return true
 	}
@@ -407,14 +394,12 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 		noAuthUser string
 	)
 	tlsMap := opts.TLSMap
-	tlsPinnedCerts := opts.TLSPinnedCerts
 	if c.kind == CLIENT {
 		switch c.clientType() {
 		case MQTT:
 			mo := &opts.MQTT
 			// Always override TLSMap.
 			tlsMap = mo.TLSMap
-			tlsPinnedCerts = mo.TLSPinnedCerts
 			// The rest depends on if there was any auth override in
 			// the mqtt's config.
 			if s.mqtt.authOverride {
@@ -428,7 +413,6 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			wo := &opts.Websocket
 			// Always override TLSMap.
 			tlsMap = wo.TLSMap
-			tlsPinnedCerts = wo.TLSPinnedCerts
 			// The rest depends on if there was any auth override in
 			// the websocket's config.
 			if s.websocket.authOverride {
@@ -441,11 +425,6 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 		}
 	} else {
 		tlsMap = opts.LeafNode.TLSMap
-		tlsPinnedCerts = opts.LeafNode.TLSPinnedCerts
-	}
-	if !s.matchesPinnedCert(c, tlsPinnedCerts) {
-		s.mu.Unlock()
-		return false
 	}
 	if !authRequired {
 		// TODO(dlc) - If they send us credentials should we fail?
@@ -915,10 +894,6 @@ func (s *Server) isRouterAuthorized(c *client) bool {
 		return s.opts.CustomRouterAuthentication.Check(c)
 	}
 
-	if !s.matchesPinnedCert(c, opts.Cluster.TLSPinnedCerts) {
-		return false
-	}
-
 	if opts.Cluster.TLSMap || opts.Cluster.TLSCheckKnownURLs {
 		return checkClientTLSCertSubject(c, func(user string, _ *ldap.DN, isDNSAltName bool) (string, bool) {
 			if user == "" {
@@ -953,10 +928,6 @@ func (s *Server) isRouterAuthorized(c *client) bool {
 func (s *Server) isGatewayAuthorized(c *client) bool {
 	// Snapshot server options.
 	opts := s.getOpts()
-
-	if !s.matchesPinnedCert(c, opts.Gateway.TLSPinnedCerts) {
-		return false
-	}
 
 	// Check whether TLS map is enabled, otherwise use single user/pass.
 	if opts.Gateway.TLSMap || opts.Gateway.TLSCheckKnownURLs {
@@ -1018,10 +989,6 @@ func (s *Server) isLeafNodeAuthorized(c *client) bool {
 			return false
 		}
 		return s.registerLeafWithAccount(c, account)
-	}
-
-	if !s.matchesPinnedCert(c, opts.LeafNode.TLSPinnedCerts) {
-		return false
 	}
 
 	// If leafnodes config has an authorization{} stanza, this takes precedence.

--- a/server/auth.go
+++ b/server/auth.go
@@ -387,6 +387,11 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			authRequired = s.websocket.authOverride
 		}
 	}
+	if !authRequired {
+		// TODO(dlc) - If they send us credentials should we fail?
+		s.mu.Unlock()
+		return true
+	}
 	var (
 		username   string
 		password   string
@@ -425,11 +430,6 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 		}
 	} else {
 		tlsMap = opts.LeafNode.TLSMap
-	}
-	if !authRequired {
-		// TODO(dlc) - If they send us credentials should we fail?
-		s.mu.Unlock()
-		return true
 	}
 
 	if !ao {

--- a/server/client.go
+++ b/server/client.go
@@ -4929,21 +4929,21 @@ func (c *client) getClientInfo(detailed bool) *ClientInfo {
 	return &ci
 }
 
-func (c *client) doTLSServerHandshake(typ string, tlsConfig *tls.Config, timeout float64) error {
-	_, err := c.doTLSHandshake(typ, false, nil, tlsConfig, _EMPTY_, timeout)
+func (c *client) doTLSServerHandshake(typ string, tlsConfig *tls.Config, timeout float64, pCerts PinnedCertSet) error {
+	_, err := c.doTLSHandshake(typ, false, nil, tlsConfig, _EMPTY_, timeout, pCerts)
 	return err
 }
 
-func (c *client) doTLSClientHandshake(typ string, url *url.URL, tlsConfig *tls.Config, tlsName string, timeout float64) (bool, error) {
-	return c.doTLSHandshake(typ, true, url, tlsConfig, tlsName, timeout)
+func (c *client) doTLSClientHandshake(typ string, url *url.URL, tlsConfig *tls.Config, tlsName string, timeout float64, pCerts PinnedCertSet) (bool, error) {
+	return c.doTLSHandshake(typ, true, url, tlsConfig, tlsName, timeout, pCerts)
 }
 
-// Performs eithe server or client side (if solicit is true) TLS Handshake.
+// Performs either server or client side (if solicit is true) TLS Handshake.
 // On error, the TLS handshake error has been logged and the connection
 // has been closed.
 //
 // Lock is held on entry.
-func (c *client) doTLSHandshake(typ string, solicit bool, url *url.URL, tlsConfig *tls.Config, tlsName string, timeout float64) (bool, error) {
+func (c *client) doTLSHandshake(typ string, solicit bool, url *url.URL, tlsConfig *tls.Config, tlsName string, timeout float64, pCerts PinnedCertSet) (bool, error) {
 	var host string
 	var resetTLSName bool
 	var err error
@@ -5004,6 +5004,13 @@ func (c *client) doTLSHandshake(typ string, solicit bool, url *url.URL, tlsConfi
 		// Returning any error is fine. Since the connection is closed ErrConnectionClosed
 		// is appropriate.
 		return resetTLSName, ErrConnectionClosed
+	}
+
+	if !c.matchesPinnedCert(pCerts) {
+		c.closeConnection(TLSHandshakeError)
+		// Grab the lock before returning since the caller was holding the lock on entry
+		c.mu.Lock()
+		return false, ErrConnectionClosed
 	}
 
 	// Reset the read deadline

--- a/server/client.go
+++ b/server/client.go
@@ -4993,7 +4993,7 @@ func (c *client) doTLSHandshake(typ string, solicit bool, url *url.URL, tlsConfi
 			}
 		}
 	} else if !c.matchesPinnedCert(pCerts) {
-		err = ErrConnectionClosed
+		err = ErrCertNotPinned
 	}
 
 	if err != nil {

--- a/server/errors.go
+++ b/server/errors.go
@@ -211,6 +211,9 @@ var (
 
 	// ErrReplicasNotSupported is returned when a stream with replicas > 1 in non-clustered mode.
 	ErrReplicasNotSupported = errors.New("replicas > 1 not supported in non-clustered mode")
+
+	// ErrReplicasNotSupported is returned when a stream with replicas > 1 in non-clustered mode.
+	ErrCertNotPinned = errors.New("certificate not pinned")
 )
 
 // configErr is a configuration error.

--- a/server/errors.go
+++ b/server/errors.go
@@ -212,7 +212,7 @@ var (
 	// ErrReplicasNotSupported is returned when a stream with replicas > 1 in non-clustered mode.
 	ErrReplicasNotSupported = errors.New("replicas > 1 not supported in non-clustered mode")
 
-	// ErrReplicasNotSupported is returned when a stream with replicas > 1 in non-clustered mode.
+	// ErrCertNotPinned is returned when pinned certs are set and the certificate is not in it
 	ErrCertNotPinned = errors.New("certificate not pinned")
 )
 

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -801,7 +801,7 @@ func (s *Server) createGateway(cfg *gatewayCfg, url *url.URL, conn net.Conn) {
 		}
 
 		// Perform (either server or client side) TLS handshake.
-		if resetTLSName, err := c.doTLSHandshake("gateway", solicit, url, tlsConfig, tlsName, timeout); err != nil {
+		if resetTLSName, err := c.doTLSHandshake("gateway", solicit, url, tlsConfig, tlsName, timeout, opts.Gateway.TLSPinnedCerts); err != nil {
 			if resetTLSName {
 				cfg.Lock()
 				cfg.tlsName = _EMPTY_

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2360,7 +2360,7 @@ func (s *Server) leafNodeResumeConnectProcess(c *client) {
 			rURL := remote.getCurrentURL()
 
 			// Perform the client-side TLS handshake.
-			if resetTLSName, err := c.doTLSClientHandshake("leafnode", rURL, tlsConfig, tlsName, tlsTimeout, c.srv.getOpts().TLSPinnedCerts); err != nil {
+			if resetTLSName, err := c.doTLSClientHandshake("leafnode", rURL, tlsConfig, tlsName, tlsTimeout, c.srv.getOpts().LeafNode.TLSPinnedCerts); err != nil {
 				// Check if we need to reset the remote's TLS name.
 				if resetTLSName {
 					remote.Lock()

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -898,7 +898,7 @@ func (s *Server) createLeafNode(conn net.Conn, rURL *url.URL, remote *leafNodeCf
 		// Check to see if we need to spin up TLS.
 		if !c.isWebsocket() && info.TLSRequired {
 			// Perform server-side TLS handshake.
-			if err := c.doTLSServerHandshake("leafnode", opts.LeafNode.TLSConfig, opts.LeafNode.TLSTimeout); err != nil {
+			if err := c.doTLSServerHandshake("leafnode", opts.LeafNode.TLSConfig, opts.LeafNode.TLSTimeout, opts.LeafNode.TLSPinnedCerts); err != nil {
 				c.mu.Unlock()
 				return nil
 			}
@@ -2220,7 +2220,7 @@ func (c *client) leafNodeSolicitWSConnection(opts *Options, rURL *url.URL, remot
 	// Do TLS here as needed.
 	if tlsRequired {
 		// Perform the client-side TLS handshake.
-		if resetTLSName, err := c.doTLSClientHandshake("leafnode", rURL, tlsConfig, tlsName, tlsTimeout); err != nil {
+		if resetTLSName, err := c.doTLSClientHandshake("leafnode", rURL, tlsConfig, tlsName, tlsTimeout, opts.LeafNode.TLSPinnedCerts); err != nil {
 			// Check if we need to reset the remote's TLS name.
 			if resetTLSName {
 				remote.Lock()
@@ -2360,7 +2360,7 @@ func (s *Server) leafNodeResumeConnectProcess(c *client) {
 			rURL := remote.getCurrentURL()
 
 			// Perform the client-side TLS handshake.
-			if resetTLSName, err := c.doTLSClientHandshake("leafnode", rURL, tlsConfig, tlsName, tlsTimeout); err != nil {
+			if resetTLSName, err := c.doTLSClientHandshake("leafnode", rURL, tlsConfig, tlsName, tlsTimeout, c.srv.getOpts().TLSPinnedCerts); err != nil {
 				// Check if we need to reset the remote's TLS name.
 				if resetTLSName {
 					remote.Lock()

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -472,7 +472,7 @@ func (s *Server) createMQTTClient(conn net.Conn) *client {
 		}
 
 		// Perform server-side TLS handshake.
-		if err := c.doTLSServerHandshake("mqtt", opts.MQTT.TLSConfig, opts.MQTT.TLSTimeout); err != nil {
+		if err := c.doTLSServerHandshake("mqtt", opts.MQTT.TLSConfig, opts.MQTT.TLSTimeout, opts.MQTT.TLSPinnedCerts); err != nil {
 			c.mu.Unlock()
 			return nil
 		}

--- a/server/reload.go
+++ b/server/reload.go
@@ -710,13 +710,13 @@ func (s *Server) Reload() error {
 	disconnectClients := []*client{}
 	checkClients := func(kind int, clients map[uint64]*client, set PinnedCertSet) {
 		for _, c := range clients {
-			if c.kind == kind && !c.matchesPinnedCert(set) {
+			if (c.kind == kind || (c.kind == CLIENT && c.clientType() == kind)) && !c.matchesPinnedCert(set) {
 				disconnectClients = append(disconnectClients, c)
 			}
 		}
 	}
 	if !reflect.DeepEqual(newOpts.TLSPinnedCerts, curOpts.TLSPinnedCerts) {
-		checkClients(CLIENT, s.clients, newOpts.TLSPinnedCerts)
+		checkClients(NATS, s.clients, newOpts.TLSPinnedCerts)
 	}
 	if !reflect.DeepEqual(newOpts.MQTT.TLSPinnedCerts, curOpts.MQTT.TLSPinnedCerts) {
 		checkClients(MQTT, s.clients, newOpts.MQTT.TLSPinnedCerts)

--- a/server/route.go
+++ b/server/route.go
@@ -1332,8 +1332,7 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 			tlsConfig = tlsConfig.Clone()
 		}
 		// Perform (server or client side) TLS handshake.
-		if _, err := c.doTLSHandshake("route", didSolicit, rURL, tlsConfig, _EMPTY_, opts.Cluster.TLSTimeout); err != nil {
-			c.mu.Unlock()
+		if _, err := c.doTLSHandshake("route", didSolicit, rURL, tlsConfig, _EMPTY_, opts.Cluster.TLSTimeout, opts.Cluster.TLSPinnedCerts); err != nil {
 			return nil
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -2353,7 +2353,7 @@ func (s *Server) createClient(conn net.Conn) *client {
 			pre = nil
 		}
 		// Performs server-side TLS handshake.
-		if err := c.doTLSServerHandshake(_EMPTY_, opts.TLSConfig, opts.TLSTimeout); err != nil {
+		if err := c.doTLSServerHandshake(_EMPTY_, opts.TLSConfig, opts.TLSTimeout, opts.TLSPinnedCerts); err != nil {
 			c.mu.Unlock()
 			return nil
 		}


### PR DESCRIPTION
on reload clients with removed pinned certs will be disconnected.
The check happens only on tls handshake now.

Signed-off-by: Matthias Hanel <mh@synadia.com>
