### PR TITLE
[fixed] deletion of js mappings on account jwt update

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3178,7 +3178,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 		// We do not have JS enabled for this server, but the account has it enabled so setup
 		// our imports properly. This allows this server to proxy JS traffic correctly.
 		s.checkJetStreamExports()
-		a.enableAllJetStreamServiceImports()
+		a.enableAllJetStreamServiceImportsAndMappings()
 	}
 
 	for i, c := range clients {

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -477,8 +477,8 @@ func (s *Server) enableJetStreamAccounts() error {
 	return nil
 }
 
-// enableAllJetStreamServiceImports turns on all service imports for jetstream for this account.
-func (a *Account) enableAllJetStreamServiceImports() error {
+// enableAllJetStreamServiceImportsAndMappings turns on all service imports and mappings for jetstream for this account.
+func (a *Account) enableAllJetStreamServiceImportsAndMappings() error {
 	a.mu.RLock()
 	s := a.srv
 	a.mu.RUnlock()
@@ -490,6 +490,26 @@ func (a *Account) enableAllJetStreamServiceImports() error {
 	if !a.serviceImportExists(jsAllAPI) {
 		if err := a.AddServiceImport(s.SystemAccount(), jsAllAPI, _EMPTY_); err != nil {
 			return fmt.Errorf("Error setting up jetstream service imports for account: %v", err)
+		}
+	}
+
+	// Check if we have a Domain specified.
+	// If so add in a subject mapping that will allow local connected clients to reach us here as well.
+	if opts := s.getOpts(); opts.JetStreamDomain != _EMPTY_ {
+		src := fmt.Sprintf(jsDomainAPI, opts.JetStreamDomain)
+		found := false
+		a.mu.RLock()
+		for _, m := range a.mappings {
+			if src == m.src {
+				found = true
+				break
+			}
+		}
+		a.mu.RUnlock()
+		if !found {
+			if err := a.AddMapping(src, jsAllAPI); err != nil {
+				s.Errorf("Error adding JetStream domain mapping: %v", err)
+			}
 		}
 	}
 
@@ -505,7 +525,7 @@ func (a *Account) enableJetStreamInfoServiceImportOnly() error {
 		return nil
 	}
 
-	return a.enableAllJetStreamServiceImports()
+	return a.enableAllJetStreamServiceImportsAndMappings()
 }
 
 func (s *Server) configJetStream(acc *Account) error {
@@ -515,7 +535,7 @@ func (s *Server) configJetStream(acc *Account) error {
 	if acc.jsLimits != nil {
 		// Check if already enabled. This can be during a reload.
 		if acc.JetStreamEnabled() {
-			if err := acc.enableAllJetStreamServiceImports(); err != nil {
+			if err := acc.enableAllJetStreamServiceImportsAndMappings(); err != nil {
 				return err
 			}
 			if err := acc.UpdateJetStreamLimits(acc.jsLimits); err != nil {
@@ -843,23 +863,13 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 	a.mu.Unlock()
 
 	// Create the proper imports here.
-	if err := a.enableAllJetStreamServiceImports(); err != nil {
+	if err := a.enableAllJetStreamServiceImportsAndMappings(); err != nil {
 		return err
 	}
 
 	s.Debugf("Enabled JetStream for account %q", a.Name)
 	s.Debugf("  Max Memory:      %s", friendlyBytes(limits.MaxMemory))
 	s.Debugf("  Max Storage:     %s", friendlyBytes(limits.MaxStore))
-
-	// Check if we have a Domain specified.
-	// If so add in a subject mapping that will allow local connected clients to reach us here as well.
-	opts := s.getOpts()
-	if opts.JetStreamDomain != _EMPTY_ {
-		src := fmt.Sprintf(jsDomainAPI, opts.JetStreamDomain)
-		if err := a.AddMapping(src, jsAllAPI); err != nil {
-			s.Debugf("Error adding JetStream domain mapping: %v", err)
-		}
-	}
 
 	// Clean up any old snapshots that were orphaned while staging.
 	os.RemoveAll(path.Join(js.config.StoreDir, snapStagingDir))

--- a/server/server.go
+++ b/server/server.go
@@ -1613,7 +1613,7 @@ func (s *Server) Start() {
 			acc.mu.RUnlock()
 			if hasJs {
 				s.checkJetStreamExports()
-				acc.enableAllJetStreamServiceImports()
+				acc.enableAllJetStreamServiceImportsAndMappings()
 			}
 			return true
 		})


### PR DESCRIPTION
fixed by moving setting of the mappings into a common function that is
also called when the jwt is updated

Signed-off-by: Matthias Hanel <mh@synadia.com>

Below code would not receive a message without the change.

```
> [124] 2021/05/24 15:27:04.263472 [INF] Starting nats-server
[124] 2021/05/24 15:27:04.263663 [INF]   Version:  2.2.5
[124] 2021/05/24 15:27:04.263672 [INF]   Git:      [not set]
[124] 2021/05/24 15:27:04.263682 [INF]   Name:     s1
...
[124] 2021/05/24 15:27:04.267934 [INF] ---------------- JETSTREAM ----------------
[124] 2021/05/24 15:27:04.267954 [INF]   Max Memory:      48.00 GB
[124] 2021/05/24 15:27:04.267989 [INF]   Max Storage:     498.61 GB
[124] 2021/05/24 15:27:04.268022 [INF]   Store Directory: "store_server_1/jetstream"
[124] 2021/05/24 15:27:04.268033 [INF]   Domain:          hub
[124] 2021/05/24 15:27:04.268058 [INF] -------------------------------------------
[124] 2021/05/24 15:27:04.278935 [INF]   Restored 10 messages for Stream "aggregate"
[124] 2021/05/24 15:27:04.279104 [INF]   Recovering 1 Consumers for Stream - "aggregate"
[124] 2021/05/24 15:27:04.280964 [INF] Listening for client connections on 0.0.0.0:4222
[124] 2021/05/24 15:27:04.281601 [INF] Server is ready
> nats --server localhost:4222 --creds keys/creds/OP/IMPORT/imp.creds consumer next aggregate DUR --js-api-prefix=from.test.API --trace
15:27:08 >>> from.test.API.CONSUMER.INFO.aggregate.DUR


15:27:08 <<< from.test.API.CONSUMER.INFO.aggregate.DUR: nats: no responders available for request

15:27:08 >>> from.test.API.CONSUMER.MSG.NEXT.aggregate.DUR:
{"expires":5000000000,"batch":1}

[15:27:08] subj: test / tries: 1 / cons seq: 3 / str seq: 3 / pending: 7

hw

Acknowledged message

> nsc edit account -n IMPORT --tag foolllff
[ OK ] added tag "foolllff"
[ OK ] edited account "IMPORT"
> nsc edit account -n EXPORT --tag foolllfff
[ OK ] added tag "foolllfff"
[ OK ] edited account "EXPORT"
> nsc push -A
[ OK ] push to nats-server "nats://localhost:4222" using system account "SYS":
       [ OK ] push EXPORT to nats-server with nats account resolver:
              [ OK ] pushed "EXPORT" to nats-server s1: jwt updated
              [ OK ] pushed to a total of 1 nats-server
       [ OK ] push IMPORT to nats-server with nats account resolver:
              [ OK ] pushed "IMPORT" to nats-server s1: jwt updated
              [ OK ] pushed to a total of 1 nats-server
       [ OK ] push SYS to nats-server with nats account resolver:
              [ OK ] pushed "SYS" to nats-server s1: jwt updated
              [ OK ] pushed to a total of 1 nats-server
>nats --server localhost:4222 --creds keys/creds/OP/IMPORT/imp.creds consumer next aggregate DUR --js-api-prefix=from.test.API --trace
15:27:33 >>> from.test.API.CONSUMER.INFO.aggregate.DUR


15:27:33 <<< from.test.API.CONSUMER.INFO.aggregate.DUR: nats: no responders available for request

15:27:33 >>> from.test.API.CONSUMER.MSG.NEXT.aggregate.DUR:
{"expires":5000000000,"batch":1}

[15:27:33] subj: test / tries: 1 / cons seq: 4 / str seq: 4 / pending: 6

hw

Acknowledged message

>
```