### PR TITLE
Changes to leafnodes and JetStream

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1273,6 +1273,9 @@ func (js *jetStream) disableJetStream(jsa *jsAccount) error {
 // jetStreamConfigured reports whether the account has JetStream configured, regardless of this
 // servers JetStream status.
 func (a *Account) jetStreamConfigured() bool {
+	if a == nil {
+		return false
+	}
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.jsLimits != nil

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -830,7 +830,7 @@ const badAPIRequestT = "Malformed JetStream API Request: %q"
 func (a *Account) checkJetStream() (enabled, shouldError bool) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
-	return a.js != nil, a.nleafs == 0
+	return a.js != nil, a.nleafs+a.nrleafs == 0
 }
 
 // Request for current usage and limits for this account.
@@ -876,6 +876,7 @@ func (s *Server) jsAccountInfoRequest(sub *subscription, c *client, subject, rep
 	if err != nil {
 		return
 	}
+
 	s.sendAPIResponse(ci, acc, subject, reply, string(msg), string(b))
 }
 


### PR DESCRIPTION
These changes are to properly allow a setup where a hub cluster has JetStream as a capability but an account does not.

We were incorrectly shutting things down via deny clauses when detecting the remote side/hub had JetStream capabilities.
This change moves that logic to the remote side and is signalled off the connect message which let's the remote side know
if the local leafnode account has JetStream enabled.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
