### PR TITLE
ensure correct error handling in non clustered stream add

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1275,7 +1275,7 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, subject, re
 
 	mset, err := acc.addStream(&cfg)
 	if err != nil {
-		resp.Error = ApiErrors[JSStreamCreateErrF].NewT("{err}", err)
+		resp.Error = ApiErrors[JSStreamCreateErrF].ErrOrNewT(err, "{err}", err)
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}


### PR DESCRIPTION
The addStream() can return an ApiErr but we did not handle
that leading to errors like 'stream name already in use (10058)' instead
of just 'stream name already in use' with the correct error code 10058 set

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
