### PR TITLE
[adding] jetstream info to statsz

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -199,7 +199,7 @@ type ServerStats struct {
 	SlowConsumers    int64          `json:"slow_consumers"`
 	Routes           []*RouteStat   `json:"routes,omitempty"`
 	Gateways         []*GatewayStat `json:"gateways,omitempty"`
-	JetStream        *JetStreamStat `json:"jetstream,omitempty"`
+	JetStream        *JetStreamVarz `json:"jetstream,omitempty"`
 }
 
 // RouteStat holds route statistics.
@@ -218,13 +218,6 @@ type GatewayStat struct {
 	Sent       DataStats `json:"sent"`
 	Received   DataStats `json:"received"`
 	NumInbound int       `json:"inbound_connections"`
-}
-
-// JetStreamStat holds Jetstream statistics and process information.
-type JetStreamStat struct {
-	Config JetStreamConfig `json:"config,omitempty"`
-	Meta   *ClusterInfo    `json:"meta_cluster,omitempty"`
-	JetStreamStats
 }
 
 // DataStats reports how may msg and bytes. Applicable for both sent and received.
@@ -557,12 +550,14 @@ func (s *Server) sendStatsz(subj string) {
 	m.Stats.NumSubs = s.numSubscriptions()
 
 	if js := s.js; js != nil {
-		jStat := &JetStreamStat{}
+		jStat := &JetStreamVarz{}
 		s.mu.Unlock()
 		js.mu.RLock()
-		jStat.Config = js.config
+		c := js.config
+		c.StoreDir = _EMPTY_
+		jStat.Config = &c
 		js.mu.RUnlock()
-		jStat.JetStreamStats = *js.usageStats()
+		jStat.Stats = js.usageStats()
 		if mg := js.getMetaGroup(); mg != nil {
 			if mg.Leader() {
 				jStat.Meta = s.raftNodeToClusterInfo(mg)

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -81,6 +81,7 @@ type jetStream struct {
 	memReserved   int64
 	storeReserved int64
 	apiCalls      int64
+	apiErrorCalls int64
 	memTotal      int64
 	storeTotal    int64
 	mu            sync.RWMutex
@@ -1544,27 +1545,13 @@ func (js *jetStream) dynamicAccountLimits() *JetStreamAccountLimits {
 // Report on JetStream stats and usage for this server.
 func (js *jetStream) usageStats() *JetStreamStats {
 	var stats JetStreamStats
-
-	var _jsa [512]*jsAccount
-	accounts := _jsa[:0]
-
 	js.mu.RLock()
-	for _, jsa := range js.accounts {
-		accounts = append(accounts, jsa)
-	}
+	stats.Accounts = len(js.accounts)
 	js.mu.RUnlock()
-
-	stats.Accounts = len(accounts)
-
-	// Collect account information.
-	for _, jsa := range accounts {
-		jsa.mu.RLock()
-		stats.Memory += uint64(jsa.usage.mem)
-		stats.Store += uint64(jsa.usage.store)
-		stats.API.Total += jsa.usage.api
-		stats.API.Errors += jsa.usage.err
-		jsa.mu.RUnlock()
-	}
+	stats.API.Total = (uint64)(atomic.LoadInt64(&js.apiCalls))
+	stats.API.Errors = (uint64)(atomic.LoadInt64(&js.apiErrorCalls))
+	stats.Memory = (uint64)(atomic.LoadInt64(&js.memTotal))
+	stats.Store = (uint64)(atomic.LoadInt64(&js.storeTotal))
 	return &stats
 }
 

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -81,7 +81,7 @@ type jetStream struct {
 	memReserved   int64
 	storeReserved int64
 	apiCalls      int64
-	apiErrorCalls int64
+	apiErrors     int64
 	memTotal      int64
 	storeTotal    int64
 	mu            sync.RWMutex
@@ -1549,7 +1549,7 @@ func (js *jetStream) usageStats() *JetStreamStats {
 	stats.Accounts = len(js.accounts)
 	js.mu.RUnlock()
 	stats.API.Total = (uint64)(atomic.LoadInt64(&js.apiCalls))
-	stats.API.Errors = (uint64)(atomic.LoadInt64(&js.apiErrorCalls))
+	stats.API.Errors = (uint64)(atomic.LoadInt64(&js.apiErrors))
 	stats.Memory = (uint64)(atomic.LoadInt64(&js.memTotal))
 	stats.Store = (uint64)(atomic.LoadInt64(&js.storeTotal))
 	return &stats

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -818,7 +818,9 @@ func (a *Account) trackAPIErr() {
 		jsa.usage.err++
 		jsa.apiErrors++
 		jsa.sendClusterUsageUpdate()
+		js := jsa.js
 		jsa.mu.Unlock()
+		atomic.AddInt64(&js.apiErrorCalls, 1)
 	}
 }
 

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -820,7 +820,7 @@ func (a *Account) trackAPIErr() {
 		jsa.sendClusterUsageUpdate()
 		js := jsa.js
 		jsa.mu.Unlock()
-		atomic.AddInt64(&js.apiErrorCalls, 1)
+		atomic.AddInt64(&js.apiErrors, 1)
 	}
 }
 

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1054,6 +1054,7 @@ type Varz struct {
 type JetStreamVarz struct {
 	Config *JetStreamConfig `json:"config,omitempty"`
 	Stats  *JetStreamStats  `json:"stats,omitempty"`
+	Meta   *ClusterInfo     `json:"meta,omitempty"`
 }
 
 // ClusterOptsVarz contains monitoring cluster information
@@ -1431,6 +1432,9 @@ func (s *Server) updateVarzRuntimeFields(v *Varz, forceUpdate bool, pcpu float64
 		// FIXME(dlc) - We have lock inversion that needs to be fixed up properly.
 		s.mu.Unlock()
 		v.JetStream.Stats = s.js.usageStats()
+		if mg := s.js.getMetaGroup(); mg != nil {
+			v.JetStream.Meta = s.raftNodeToClusterInfo(mg)
+		}
 		s.mu.Lock()
 	}
 }

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2371,6 +2371,24 @@ func (s *Server) JszAccount(opts *JSzOptions) (*AccountDetail, error) {
 	return s.accountDetail(jsa, opts.Streams, opts.Consumer, opts.Config), nil
 }
 
+// helper to get cluster info from node via dummy group
+func (s *Server) raftNodeToClusterInfo(node RaftNode) *ClusterInfo {
+	if node == nil {
+		return nil
+	}
+	peers := node.Peers()
+	peerList := make([]string, len(peers))
+	for i, p := range node.Peers() {
+		peerList[i] = p.ID
+	}
+	group := &raftGroup{
+		Name:  "",
+		Peers: peerList,
+		node:  node,
+	}
+	return s.js.clusterInfo(group)
+}
+
 // Jsz returns a Jsz structure containing information about JetStream.
 func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 	// set option defaults
@@ -2405,23 +2423,6 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 		}
 	}
 
-	// helper to get cluster info from node via dummy group
-	toClusterInfo := func(node RaftNode) *ClusterInfo {
-		if node == nil {
-			return nil
-		}
-		peers := node.Peers()
-		peerList := make([]string, len(peers))
-		for i, p := range node.Peers() {
-			peerList[i] = p.ID
-		}
-		group := &raftGroup{
-			Name:  "",
-			Peers: peerList,
-			node:  node,
-		}
-		return s.js.clusterInfo(group)
-	}
 	jsi := &JSInfo{
 		ID:  s.ID(),
 		Now: time.Now().UTC(),
@@ -2437,10 +2438,12 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 	for _, info := range s.js.accounts {
 		accounts = append(accounts, info)
 	}
-	jsi.APICalls = atomic.LoadInt64(&s.js.apiCalls)
 	s.js.mu.RUnlock()
+	jsi.APICalls = atomic.LoadInt64(&s.js.apiCalls)
 
-	jsi.Meta = toClusterInfo(s.js.getMetaGroup())
+	jsi.Meta = s.raftNodeToClusterInfo(s.js.getMetaGroup())
+	jsi.JetStreamStats = *s.js.usageStats()
+
 	filterIdx := -1
 	for i, jsa := range accounts {
 		if jsa.acc().GetName() == opts.Account {
@@ -2448,10 +2451,6 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 		}
 		jsa.mu.RLock()
 		jsi.Streams += len(jsa.streams)
-		jsi.Memory += uint64(jsa.usage.mem)
-		jsi.Store += uint64(jsa.usage.store)
-		jsi.API.Total += jsa.usage.api
-		jsi.API.Errors += jsa.usage.err
 		for _, stream := range jsa.streams {
 			streamState := stream.state()
 			jsi.Messages += streamState.Msgs

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2382,7 +2382,7 @@ func (s *Server) raftNodeToClusterInfo(node RaftNode) *ClusterInfo {
 		peerList[i] = p.ID
 	}
 	group := &raftGroup{
-		Name:  "",
+		Name:  _EMPTY_,
 		Peers: peerList,
 		node:  node,
 	}


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

This also removes iterating over all accounts for usage.
I Inlined `JetStreamStats` in order to have a similar layout to jsm, but can change that.

@ripienaar we had to leave out a few values as they required iterating over all accounts.


sample output single server no data 
```
{
    "server": {
        "cluster": "cluster-spoke-2",
        "host": "localhost",
        "id": "NCOWTDXMZW4XMV335NLVDXO3LHWGHB3G6UACJJ5PHH5I32QDHG5WBJLX",
        "jetstream": true,
        "name": "srv-4262",
        "seq": 29,
        "time": "2021-06-08T21:35:08.273028Z",
        "ver": "2.2.6"
    },
    "statsz": {
        "active_accounts": 3,
        "connections": 1,
        "cores": 16,
        "cpu": 0.2,
        "jetstream": {
            "accounts": 3,
            "api": {
                "errors": 0,
                "total": 0
            },
            "config": {
                "domain": "spoke-2",
                "max_memory": 51539607552,
                "max_storage": 540083272704,
                "store_dir": "s3-1/jetstream"
            },
            "memory": 0,
            "meta_cluster": {
                "name": "cluster-spoke-2"
            },
            "storage": 0
        },
        "mem": 42909696,
        "received": {
            "bytes": 3178,
            "msgs": 6
        },
        "sent": {
            "bytes": 2358,
            "msgs": 8
        },
        "slow_consumers": 0,
        "start": "2021-06-08T21:34:47.248127Z",
        "subscriptions": 138,
        "total_connections": 1
    }
}
```

sample output cluster leader and 1 45byte message
```
{
    "server": {
        "cluster": "cluster-hub",
        "host": "localhost",
        "id": "NANDEXM6IA2SZG7MU2L4TTUH3HSIMB5L7I4QR7EFHIAW2YLVOBY2HJSW",
        "jetstream": true,
        "name": "srv-4222",
        "seq": 539,
        "time": "2021-06-08T21:52:24.202863Z",
        "ver": "2.2.6"
    },
    "statsz": {
        "active_accounts": 6,
        "connections": 0,
        "cores": 16,
        "cpu": 1.5,
        "jetstream": {
            "accounts": 3,
            "api": {
                "errors": 0,
                "total": 0
            },
            "config": {
                "domain": "hub",
                "max_memory": 51539607552,
                "max_storage": 540112739328,
                "store_dir": "s1-1/jetstream"
            },
            "memory": 0,
            "meta_cluster": {
                "leader": "srv-4222",
                "name": "cluster-hub",
                "replicas": [
                    {
                        "active": 475834000,
                        "current": true,
                        "name": "srv-4232"
                    },
                    {
                        "active": 475896000,
                        "current": true,
                        "name": "srv-4282"
                    }
                ]
            },
            "storage": 45
        },
        "mem": 108953600,
        "received": {
            "bytes": 739258,
            "msgs": 3634
        },
        "routes": [
            {
                "name": "srv-4282",
                "pending": 0,
                "received": {
                    "bytes": 235277,
                    "msgs": 1358
                },
                "rid": 18,
                "sent": {
                    "bytes": 186264,
                    "msgs": 1369
                }
            },
            {
                "name": "srv-4232",
                "pending": 0,
                "received": {
                    "bytes": 503082,
                    "msgs": 2218
                },
                "rid": 20,
                "sent": {
                    "bytes": 236132,
                    "msgs": 1854
                }
            }
        ],
        "sent": {
            "bytes": 480647,
            "msgs": 3732
        },
        "slow_consumers": 0,
        "start": "2021-06-08T21:48:33.177211Z",
        "subscriptions": 313,
        "total_connections": 62
    }
}
```

sample output cluster follower and 1 45byte message
```
{
    "server": {
        "cluster": "cluster-hub",
        "host": "localhost",
        "id": "NAYMQ6KWLTW6STUO234IBIZGGBYVO4PN4M7QID3JWRIXH3XID44KEYOE",
        "jetstream": true,
        "name": "srv-4282",
        "seq": 78,
        "time": "2021-06-08T21:52:24.211899Z",
        "ver": "2.2.6"
    },
    "statsz": {
        "active_accounts": 6,
        "connections": 0,
        "cores": 16,
        "cpu": 7.8,
        "jetstream": {
            "accounts": 3,
            "api": {
                "errors": 0,
                "total": 0
            },
            "config": {
                "domain": "hub",
                "max_memory": 51539607552,
                "max_storage": 540112739328,
                "store_dir": "s1-3/jetstream"
            },
            "memory": 0,
            "meta_cluster": {
                "leader": "srv-4222",
                "name": "cluster-hub"
            },
            "storage": 0
        },
        "mem": 110059520,
        "received": {
            "bytes": 1179140,
            "msgs": 7800
        },
        "routes": [
            {
                "name": "srv-4232",
                "pending": 0,
                "received": {
                    "bytes": 798973,
                    "msgs": 6016
                },
                "rid": 13,
                "sent": {
                    "bytes": 286484,
                    "msgs": 3257
                }
            },
            {
                "name": "srv-4222",
                "pending": 0,
                "received": {
                    "bytes": 187350,
                    "msgs": 1370
                },
                "rid": 15,
                "sent": {
                    "bytes": 236249,
                    "msgs": 1359
                }
            }
        ],
        "sent": {
            "bytes": 1359098,
            "msgs": 6394
        },
        "slow_consumers": 0,
        "start": "2021-06-08T21:48:33.181571Z",
        "subscriptions": 366,
        "total_connections": 2
    }
}
```