### PR TITLE
[FIXED] Handling of subject rewrites for subjects to a globally routed subject.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -822,7 +822,7 @@ func (o *consumer) unsubscribe(sub *subscription) {
 // We need to make sure we protect access to the outq.
 // Do all advisory sends here.
 func (o *consumer) sendAdvisory(subj string, msg []byte) {
-	o.outq.send(&jsPubMsg{subj, subj, _EMPTY_, nil, msg, nil, 0, nil})
+	o.outq.send(&jsPubMsg{subj, _EMPTY_, _EMPTY_, nil, msg, nil, 0, nil})
 }
 
 func (o *consumer) sendDeleteAdvisoryLocked() {

--- a/server/stream.go
+++ b/server/stream.go
@@ -657,7 +657,7 @@ func (mset *stream) sendCreateAdvisory() {
 	}
 
 	subj := JSAdvisoryStreamCreatedPre + "." + name
-	outq.send(&jsPubMsg{subj, subj, _EMPTY_, nil, j, nil, 0, nil})
+	outq.send(&jsPubMsg{subj, _EMPTY_, _EMPTY_, nil, j, nil, 0, nil})
 }
 
 func (mset *stream) sendDeleteAdvisoryLocked() {
@@ -680,7 +680,7 @@ func (mset *stream) sendDeleteAdvisoryLocked() {
 	j, err := json.Marshal(m)
 	if err == nil {
 		subj := JSAdvisoryStreamDeletedPre + "." + mset.cfg.Name
-		mset.outq.send(&jsPubMsg{subj, subj, _EMPTY_, nil, j, nil, 0, nil})
+		mset.outq.send(&jsPubMsg{subj, _EMPTY_, _EMPTY_, nil, j, nil, 0, nil})
 	}
 }
 
@@ -703,7 +703,7 @@ func (mset *stream) sendUpdateAdvisoryLocked() {
 	j, err := json.Marshal(m)
 	if err == nil {
 		subj := JSAdvisoryStreamUpdatedPre + "." + mset.cfg.Name
-		mset.outq.send(&jsPubMsg{subj, subj, _EMPTY_, nil, j, nil, 0, nil})
+		mset.outq.send(&jsPubMsg{subj, _EMPTY_, _EMPTY_, nil, j, nil, 0, nil})
 	}
 }
 
@@ -1765,15 +1765,16 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64) {
 func (mset *stream) processSourceMsgs(si *sourceInfo) {
 	s := mset.srv
 	defer s.grWG.Done()
+
+	if si == nil {
+		return
+	}
+
 	defer func() {
 		mset.mu.Lock()
 		si.grr = false
 		mset.mu.Unlock()
 	}()
-
-	if si == nil {
-		return
-	}
 
 	// Grab stream quit channel.
 	mset.mu.Lock()


### PR DESCRIPTION
We were seeing results where subject rewrite for JetStream was not working properly when the reply subject to a leafnode was a globally routed subject.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
