### PR TITLE
ocsp: add more config options to customize OCSP

### DIFF
--- a/server/reload.go
+++ b/server/reload.go
@@ -582,6 +582,15 @@ func (jso jetStreamOption) IsJetStreamChange() bool {
 	return true
 }
 
+type ocspOption struct {
+	noopOption
+	newValue *OCSPConfig
+}
+
+func (a *ocspOption) Apply(s *Server) {
+	s.Noticef("Reloaded: OCSP")
+}
+
 // connectErrorReports implements the option interface for the `connect_error_reports`
 // setting.
 type connectErrorReports struct {
@@ -1213,6 +1222,8 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 				return nil, fmt.Errorf("config reload not supported for %s: old=%v, new=%v",
 					field.Name, oldValue, newValue)
 			}
+		case "ocspconfig":
+			diffOpts = append(diffOpts, &ocspOption{newValue: newValue.(*OCSPConfig)})
 		default:
 			// TODO(ik): Implement String() on those options to have a nice print.
 			// %v is difficult to figure what's what, %+v print private fields and


### PR DESCRIPTION
Allows configuration of OCSP mode and responder url via the config file if not present in the TLS cert:

```hcl
ocsp {
  mode: must # always, never, auto
  url: "http://ocsp.example.net"
}
```

By default, when ocsp is enabled it runs in `auto` mode but there are a few other different OCSP modes that control the behavior on whether OCSP should be enforced and server should shutdown if the cert runs with a revoked staple.

| Mode   | Description                                                           | Server shutdowns when revoked |
| --------- | ---- | ----- |
| auto   | Enables OCSP Stapling when it has the must staple/status_request flag | No                            |
| must   | Enables OCSP Staping when it has the must staple/status_request flag  | Yes                           |
| always | Enables OCSP Stapling for all certificates                            | Yes                           |
| never  | Disables OCSP Stapling even if must staple flag is present            | No                            |


Signed-off-by: Waldemar Quevedo <wally@synadia.com>

/cc @nats-io/core
