### PR TITLE
[FIXED] Dynamic account limits would limit based on single server limits.

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2382,7 +2382,7 @@ func (s *Server) raftNodeToClusterInfo(node RaftNode) *ClusterInfo {
 	}
 	peers := node.Peers()
 	peerList := make([]string, len(peers))
-	for i, p := range node.Peers() {
+	for i, p := range peers {
 		peerList[i] = p.ID
 	}
 	group := &raftGroup{


### PR DESCRIPTION
When checking limits we would check total ask against the server limits if limits were not set.
We were also dynamically setting account limits based on a single server limit.

Signed-off-by: Derek Collison <derek@nats.io>

