### PR TITLE
Adds in per subject tracking and limits for streams.

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1043,7 +1043,6 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 				s.Warnf("    Error restoring Consumer state: %v", err)
 			}
 		}
-		mset.clearFilterIndex()
 	}
 
 	// Make sure to cleanup and old remaining snapshots.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2848,7 +2848,6 @@ func (o *consumer) processReplicatedAck(dseq, sseq uint64) {
 	o.store.UpdateAcks(dseq, sseq)
 
 	o.mu.RLock()
-
 	mset := o.mset
 	if mset == nil || mset.cfg.Retention == LimitsPolicy {
 		o.mu.RUnlock()
@@ -4457,7 +4456,7 @@ func (mset *stream) processSnapshot(snap *streamSnapshot) {
 		for _, o := range mset.consumers {
 			o.mu.Lock()
 			if o.isLeader() {
-				o.setInitialPending()
+				o.setInitialPendingAndStart()
 			}
 			o.mu.Unlock()
 		}

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -2087,7 +2087,7 @@ func TestJetStreamClusterWorkQueueRetention(t *testing.T) {
 	}
 
 	// Make sure the messages are removed.
-	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
 		si, err := js.StreamInfo("FOO")
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
@@ -4789,6 +4789,10 @@ func TestJetStreamClusterMirrorAndSourcesFilteredConsumers(t *testing.T) {
 	expectFail("M", "baz")
 	expectFail("M", "baz.1.2")
 	expectFail("M", "apple")
+
+	// Make sure wider scoped subjects work as well.
+	createConsumer("M", "*")
+	createConsumer("M", ">")
 
 	// Now do some sources.
 	if _, err := js.AddStream(&nats.StreamConfig{Name: "O1", Subjects: []string{"foo.*"}}); err != nil {
@@ -7975,7 +7979,7 @@ func jsClientConnect(t *testing.T, s *Server, opts ...nats.Option) (*nats.Conn, 
 
 func checkSubsPending(t *testing.T, sub *nats.Subscription, numExpected int) {
 	t.Helper()
-	checkFor(t, 5*time.Second, 20*time.Millisecond, func() error {
+	checkFor(t, 10*time.Second, 20*time.Millisecond, func() error {
 		if nmsgs, _, err := sub.Pending(); err != nil || nmsgs != numExpected {
 			return fmt.Errorf("Did not receive correct number of messages: %d vs %d", nmsgs, numExpected)
 		}

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -10787,6 +10787,82 @@ func TestJetStreamConfigReloadWithGlobalAccount(t *testing.T) {
 	checkJSAccount()
 }
 
+// Test that we properly enfore per subject msg limits.
+func TestJetStreamMaxMsgsPerSubject(t *testing.T) {
+	const maxPer = 5
+	msc := StreamConfig{
+		Name:       "TEST",
+		Subjects:   []string{"foo", "bar", "baz.*"},
+		Storage:    MemoryStorage,
+		MaxMsgsPer: maxPer,
+	}
+	fsc := msc
+	fsc.Storage = FileStorage
+
+	cases := []struct {
+		name    string
+		mconfig *StreamConfig
+	}{
+		{"MemoryStore", &msc},
+		{"FileStore", &fsc},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := RunBasicJetStreamServer()
+			defer s.Shutdown()
+
+			if config := s.JetStreamConfig(); config != nil {
+				defer removeDir(t, config.StoreDir)
+			}
+
+			mset, err := s.GlobalAccount().addStream(c.mconfig)
+			if err != nil {
+				t.Fatalf("Unexpected error adding stream: %v", err)
+			}
+			defer mset.delete()
+
+			// Client for API requests.
+			nc, js := jsClientConnect(t, s)
+			defer nc.Close()
+
+			pubAndCheck := func(subj string, num int, expectedNumMsgs uint64) {
+				t.Helper()
+				for i := 0; i < num; i++ {
+					if _, err = js.Publish(subj, []byte("TSLA")); err != nil {
+						t.Fatalf("Unexpected publish error: %v", err)
+					}
+				}
+				si, err := js.StreamInfo("TEST")
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				if si.State.Msgs != expectedNumMsgs {
+					t.Fatalf("Expected %d msgs, got %d", expectedNumMsgs, si.State.Msgs)
+				}
+			}
+
+			pubAndCheck("foo", 1, 1)
+			pubAndCheck("foo", 4, 5)
+			// Now make sure our per subject limits kick in..
+			pubAndCheck("foo", 2, 5)
+			pubAndCheck("baz.22", 5, 10)
+			pubAndCheck("baz.33", 5, 15)
+			// We are maxed so totals should be same no matter what we add here.
+			pubAndCheck("baz.22", 5, 15)
+			pubAndCheck("baz.33", 5, 15)
+
+			// Now purge and make sure all is still good.
+			mset.purge()
+			pubAndCheck("foo", 1, 1)
+			pubAndCheck("foo", 4, 5)
+			pubAndCheck("baz.22", 5, 10)
+			pubAndCheck("baz.33", 5, 15)
+		})
+	}
+
+}
+
 func TestJetStreamFilteredConsumersWithWiderFilter(t *testing.T) {
 	s := RunBasicJetStreamServer()
 	defer s.Shutdown()

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -2062,7 +2062,7 @@ func TestJetStreamSlowFilteredInititalPendingAndFirstMsg(t *testing.T) {
 	})
 
 	// Threshold for taking too long.
-	const thresh = 20 * time.Millisecond
+	const thresh = 30 * time.Millisecond
 
 	var dindex int
 	testConsumerCreate := func(subj string, startSeq, expectedNumPending uint64) {

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -1756,7 +1756,7 @@ func TestNoRaceJetStreamClusterSourcesMuxd(t *testing.T) {
 
 }
 
-func TestJetStreamClusterMirrorExpirationAndMissingSequences(t *testing.T) {
+func TestNoRaceJetStreamClusterMirrorExpirationAndMissingSequences(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "MMS", 9)
 	defer c.shutdown()
 
@@ -2001,7 +2001,7 @@ func TestNoRaceJetStreamClusterSuperClusterRIPStress(t *testing.T) {
 	}
 }
 
-func TestJetStreamSlowFilteredInititalPendingAndFirstMsg(t *testing.T) {
+func TestNoRaceJetStreamSlowFilteredInititalPendingAndFirstMsg(t *testing.T) {
 	s := RunBasicJetStreamServer()
 	defer s.Shutdown()
 

--- a/server/store.go
+++ b/server/store.go
@@ -45,6 +45,8 @@ var (
 	ErrMaxMsgs = errors.New("maximum messages exceeded")
 	// ErrMaxBytes is returned when we have discard new as a policy and we reached the bytes limit.
 	ErrMaxBytes = errors.New("maximum bytes exceeded")
+	// ErrMaxMsgsPerSubject is returned when we have discard new as a policy and we reached the message limit per subject.
+	ErrMaxMsgsPerSubject = errors.New("maximum messages per subject exceeded")
 	// ErrStoreSnapshotInProgress is returned when RemoveMsg or EraseMsg is called
 	// while a snapshot is in progress.
 	ErrStoreSnapshotInProgress = errors.New("snapshot in progress")

--- a/server/store.go
+++ b/server/store.go
@@ -75,7 +75,7 @@ type StreamStore interface {
 	Compact(seq uint64) (uint64, error)
 	Truncate(seq uint64) error
 	GetSeqFromTime(t time.Time) uint64
-	NumFilteredPending(sseq uint64, subject string) uint64
+	FilteredState(sseq uint64, subject string) SimpleState
 	State() StreamState
 	FastState(*StreamState)
 	Type() StorageType
@@ -123,6 +123,13 @@ type StreamState struct {
 	Deleted    []uint64        `json:"deleted,omitempty"`
 	Lost       *LostStreamData `json:"lost,omitempty"`
 	Consumers  int             `json:"consumer_count"`
+}
+
+// SimpleState for filtered subject specific state.
+type SimpleState struct {
+	Msgs  uint64 `json:"messages"`
+	First uint64 `json:"first_seq"`
+	Last  uint64 `json:"last_seq"`
 }
 
 // LostStreamData indicates msgs that have been lost.

--- a/server/stream.go
+++ b/server/stream.go
@@ -2322,16 +2322,6 @@ func (mset *stream) setupStore(fsCfg *FileStoreConfig) error {
 	return nil
 }
 
-// Clears out any filtered index from filestores.
-func (mset *stream) clearFilterIndex() {
-	mset.mu.Lock()
-	defer mset.mu.Unlock()
-
-	if fs, ok := mset.store.(*fileStore); ok {
-		fs.clearFilterIndex()
-	}
-}
-
 // Called for any updates to the underlying stream. We pass through the bytes to the
 // jetstream account. We do local processing for stream pending for consumers, but only
 // for removals.

--- a/server/stream.go
+++ b/server/stream.go
@@ -44,9 +44,10 @@ type StreamConfig struct {
 	MaxConsumers int             `json:"max_consumers"`
 	MaxMsgs      int64           `json:"max_msgs"`
 	MaxBytes     int64           `json:"max_bytes"`
-	Discard      DiscardPolicy   `json:"discard"`
 	MaxAge       time.Duration   `json:"max_age"`
+	MaxMsgsPer   int64           `json:"max_msgs_per_subject"`
 	MaxMsgSize   int32           `json:"max_msg_size,omitempty"`
+	Discard      DiscardPolicy   `json:"discard"`
 	Storage      StorageType     `json:"storage"`
 	Replicas     int             `json:"num_replicas"`
 	NoAck        bool            `json:"no_ack,omitempty"`


### PR DESCRIPTION
Streams have always allowed multiple subjects however setting initial pending and selecting starting sequence number needed to be furthered optimized.

We also introduce per subject message limits.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
