### PR TITLE
[fixing] leafnode missing retry and service export interest propagation

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1846,9 +1846,16 @@ func (a *Account) addServiceImportSub(si *serviceImport) error {
 	cb := func(sub *subscription, c *client, subject, reply string, msg []byte) {
 		c.processServiceImport(si, a, msg)
 	}
-	_, err := c.processSubEx([]byte(subject), nil, []byte(sid), cb, true, true, false)
-
-	return err
+	sub, err := c.processSubEx([]byte(subject), nil, []byte(sid), cb, true, true, false)
+	if err != nil {
+		return err
+	}
+	// Leafnodes introduce a new way to introduce messages into the system. Therefore forward import subscription
+	// This is similar to what initLeafNodeSmapAndSendSubs does
+	// TODO we need to consider performing this update as we get client subscriptions.
+	//      This behaviour would result in subscription propagation only where actually used.
+	a.srv.updateLeafNodes(a, sub, 1)
+	return nil
 }
 
 // Remove all the subscriptions associated with service imports.

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1853,7 +1853,7 @@ func (a *Account) addServiceImportSub(si *serviceImport) error {
 	// Leafnodes introduce a new way to introduce messages into the system. Therefore forward import subscription
 	// This is similar to what initLeafNodeSmapAndSendSubs does
 	// TODO we need to consider performing this update as we get client subscriptions.
-	//      This behaviour would result in subscription propagation only where actually used.
+	//      This behavior would result in subscription propagation only where actually used.
 	a.srv.updateLeafNodes(a, sub, 1)
 	return nil
 }

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -816,7 +816,7 @@ func (s *Server) createLeafNode(conn net.Conn, rURL *url.URL, remote *leafNodeCf
 			// has not yet been pushed, or the request failed for other reasons.
 			// remote needs to be set or retry won't happen
 			c.leaf.remote = remote
-			c.closeConnection(AuthenticationViolation)
+			c.closeConnection(MissingAccount)
 			s.Errorf("No local account %s found for solicited leaf node connection", lacc)
 			return nil
 		}

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -817,7 +817,7 @@ func (s *Server) createLeafNode(conn net.Conn, rURL *url.URL, remote *leafNodeCf
 			// remote needs to be set or retry won't happen
 			c.leaf.remote = remote
 			c.closeConnection(MissingAccount)
-			s.Errorf("No local account %s found for solicited leaf node connection", lacc)
+			s.Errorf("Unable to lookup account %s for solicited leafnode connection: %v", lacc, err)
 			return nil
 		}
 		remoteSuffix = fmt.Sprintf(" for account: %s", acc.traceLabel())

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -797,7 +797,6 @@ func (s *Server) createLeafNode(conn net.Conn, rURL *url.URL, remote *leafNodeCf
 	var acc *Account
 	var remoteSuffix string
 	if remote != nil {
-		// TODO: Decide what should be the optimal behavior here.
 		// For now, if lookup fails, we will constantly try
 		// to recreate this LN connection.
 
@@ -813,8 +812,12 @@ func (s *Server) createLeafNode(conn net.Conn, rURL *url.URL, remote *leafNodeCf
 		var err error
 		acc, err = s.LookupAccount(lacc)
 		if err != nil {
-			s.Errorf("No local account %q for leafnode: %v", lacc, err)
-			c.closeConnection(MissingAccount)
+			// An account not existing is something that can happen with nats/http account resolver and the account
+			// has not yet been pushed, or the request failed for other reasons.
+			// remote needs to be set or retry won't happen
+			c.leaf.remote = remote
+			c.closeConnection(AuthenticationViolation)
+			s.Errorf("No local account %s found for solicited leaf node connection", lacc)
 			return nil
 		}
 		remoteSuffix = fmt.Sprintf(" for account: %s", acc.traceLabel())

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -388,7 +388,7 @@ func TestLeafNodeAccountNotFound(t *testing.T) {
 	// Wait for report of error
 	select {
 	case e := <-l.errCh:
-		if !strings.Contains(e, "No local account") {
+		if !strings.Contains(e, "Unable to lookup account") {
 			t.Fatalf("Expected error about no local account, got %s", e)
 		}
 	case <-time.After(2 * time.Second):

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -395,6 +395,8 @@ func TestLeafNodeAccountNotFound(t *testing.T) {
 		t.Fatalf("Did not get the error")
 	}
 
+	// TODO below test is bogus. Instead add the account, do a reload, and make sure the connection works.
+
 	// For now, sa would try to recreate the connection for ever.
 	// Check that lid is increasing...
 	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {


### PR DESCRIPTION
A missing account on initial connect attempt caused the leaf node
connection to never be established.

An account service import subscription was not propagated along leaf
node connections.

Signed-off-by: Matthias Hanel <mh@synadia.com>

I manually tested that this new behavior works.
I created issue #2289 to modify the unit test later. (discussed with Derek)