### PR TITLE
[CHANGED] Reduce print for an account subs limit to every 2 sec

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1896,7 +1896,10 @@ func (c *client) maxConnExceeded() {
 }
 
 func (c *client) maxSubsExceeded() {
-	c.sendErrAndErr(ErrTooManySubs.Error())
+	if c.acc.shouldLogMaxSubErr() {
+		c.Errorf(ErrTooManySubs.Error())
+	}
+	c.sendErr(ErrTooManySubs.Error())
 }
 
 func (c *client) maxPayloadViolation(sz int, max int32) {

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"net/url"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -2516,4 +2517,59 @@ func TestClientLimits(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClientClampMaxSubsErrReport(t *testing.T) {
+	maxSubLimitReportThreshold = int64(100 * time.Millisecond)
+	defer func() { maxSubLimitReportThreshold = defaultMaxSubLimitReportThreshold }()
+
+	o1 := DefaultOptions()
+	o1.MaxSubs = 1
+	o1.LeafNode.Host = "127.0.0.1"
+	o1.LeafNode.Port = -1
+	s1 := RunServer(o1)
+	defer s1.Shutdown()
+
+	l := &captureErrorLogger{errCh: make(chan string, 10)}
+	s1.SetLogger(l, false, false)
+
+	o2 := DefaultOptions()
+	u, _ := url.Parse(fmt.Sprintf("nats://127.0.0.1:%d", o1.LeafNode.Port))
+	o2.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{u}}}
+	s2 := RunServer(o2)
+	defer s2.Shutdown()
+
+	checkLeafNodeConnected(t, s1)
+	checkLeafNodeConnected(t, s2)
+
+	nc := natsConnect(t, s2.ClientURL())
+	natsSubSync(t, nc, "foo")
+	natsSubSync(t, nc, "bar")
+
+	// Make sure we receive only 1
+	check := func() {
+		t.Helper()
+		for i := 0; i < 2; i++ {
+			select {
+			case errStr := <-l.errCh:
+				if i > 0 {
+					t.Fatalf("Should not have logged a second time: %s", errStr)
+				}
+				if !strings.Contains(errStr, "maximum subscriptions") {
+					t.Fatalf("Unexpected error: %s", errStr)
+				}
+			case <-time.After(300 * time.Millisecond):
+				if i == 0 {
+					t.Fatal("Error should have been logged")
+				}
+			}
+		}
+	}
+	check()
+
+	// The above will have waited long enough to clear the report threshold.
+	// So create two new subs and check again that we get only 1 report.
+	natsSubSync(t, nc, "baz")
+	natsSubSync(t, nc, "bat")
+	check()
 }


### PR DESCRIPTION
We could make it for all limits by having a map of error types
instead of applying just to max subs.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

/cc @nats-io/core
