### PR TITLE
[FIXED] Failed route TLS handshake would leave failed conn's lock, locked

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -1333,6 +1333,7 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 		}
 		// Perform (server or client side) TLS handshake.
 		if _, err := c.doTLSHandshake("route", didSolicit, rURL, tlsConfig, _EMPTY_, opts.Cluster.TLSTimeout, opts.Cluster.TLSPinnedCerts); err != nil {
+			c.mu.Unlock()
 			return nil
 		}
 	}


### PR DESCRIPTION
This is a regression introduced in v2.2.6.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

/cc @nats-io/core
