### PR TITLE
rename copy to other with param …

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -557,7 +557,7 @@ func (a *Account) AddMapping(src, dest string) error {
 	return a.AddWeightedMappings(src, NewMapDest(dest, 100))
 }
 
-// AddWeightedMapping will add in a weighted mappings for the destinations.
+// AddWeightedMappings will add in a weighted mappings for the destinations.
 // TODO(dlc) - Allow cluster filtering
 func (a *Account) AddWeightedMappings(src string, dests ...*MapDest) error {
 	a.mu.Lock()
@@ -1516,7 +1516,7 @@ func (a *Account) NumPendingAllResponses() int {
 	return a.NumPendingResponses("")
 }
 
-// NumResponsesPending returns the number of responses outstanding for service exports
+// NumPendingResponses returns the number of responses outstanding for service exports
 // on this account. An empty filter string returns all responses regardless of which export.
 // If you specify the filter we will only return ones that are for that export.
 // NOTE this is only for what this server is tracking.
@@ -2843,7 +2843,7 @@ func (a *Account) isClaimAccount() bool {
 	return a.claimJWT != ""
 }
 
-// updateAccountClaims will update an existing account with new claims.
+// UpdateAccountClaims will update an existing account with new claims.
 // This will replace any exports or imports previously defined.
 // Lock MUST NOT be held upon entry.
 func (s *Server) UpdateAccountClaims(a *Account, ac *jwt.AccountClaims) {

--- a/server/auth.go
+++ b/server/auth.go
@@ -274,31 +274,31 @@ func (s *Server) buildNkeysAndUsersFromOptions(nko []*NkeyUser, uo []*User) (map
 	if nko != nil {
 		nkeys = make(map[string]*NkeyUser, len(nko))
 		for _, u := range nko {
-			copy := u.clone()
+			copyUser := u.clone()
 			if u.Account != nil {
 				if v, ok := s.accounts.Load(u.Account.Name); ok {
-					copy.Account = v.(*Account)
+					copyUser.Account = v.(*Account)
 				}
 			}
-			if copy.Permissions != nil {
-				validateResponsePermissions(copy.Permissions)
+			if copyUser.Permissions != nil {
+				validateResponsePermissions(copyUser.Permissions)
 			}
-			nkeys[u.Nkey] = copy
+			nkeys[u.Nkey] = copyUser
 		}
 	}
 	if uo != nil {
 		users = make(map[string]*User, len(uo))
 		for _, u := range uo {
-			copy := u.clone()
+			copyUser := u.clone()
 			if u.Account != nil {
 				if v, ok := s.accounts.Load(u.Account.Name); ok {
-					copy.Account = v.(*Account)
+					copyUser.Account = v.(*Account)
 				}
 			}
-			if copy.Permissions != nil {
-				validateResponsePermissions(copy.Permissions)
+			if copyUser.Permissions != nil {
+				validateResponsePermissions(copyUser.Permissions)
 			}
-			users[u.Username] = copy
+			users[u.Username] = copyUser
 		}
 	}
 	s.assignGlobalAccountToOrphanUsers(nkeys, users)

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -683,8 +683,8 @@ func TestSystemAccountInternalSubscriptions(t *testing.T) {
 	received := make(chan *nats.Msg)
 	// Create message callback handler.
 	cb := func(sub *subscription, _ *client, subject, reply string, msg []byte) {
-		copy := append([]byte(nil), msg...)
-		received <- &nats.Msg{Subject: subject, Reply: reply, Data: copy}
+		copyMsg := append([]byte(nil), msg...)
+		received <- &nats.Msg{Subject: subject, Reply: reply, Data: copyMsg}
 	}
 
 	// Now create an internal subscription
@@ -757,8 +757,8 @@ func TestSystemAccountConnectionUpdatesStopAfterNoLocal(t *testing.T) {
 	// Listen for updates to the new account connection activity.
 	received := make(chan *nats.Msg, 10)
 	cb := func(sub *subscription, _ *client, subject, reply string, msg []byte) {
-		copy := append([]byte(nil), msg...)
-		received <- &nats.Msg{Subject: subject, Reply: reply, Data: copy}
+		copyMsg := append([]byte(nil), msg...)
+		received <- &nats.Msg{Subject: subject, Reply: reply, Data: copyMsg}
 	}
 	subj := fmt.Sprintf(accConnsEventSubjOld, pub)
 	sub, err := sa.sysSubscribe(subj, cb)

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -799,8 +799,8 @@ func (s *Server) JetStreamConfig() *JetStreamConfig {
 	var c *JetStreamConfig
 	s.mu.Lock()
 	if s.js != nil {
-		copy := s.js.config
-		c = &(copy)
+		copyConf := s.js.config
+		c = &(copyConf)
 	}
 	s.mu.Unlock()
 	return c
@@ -1760,10 +1760,10 @@ type streamTemplate struct {
 }
 
 func (t *StreamTemplateConfig) deepCopy() *StreamTemplateConfig {
-	copy := *t
+	copyTConf := *t
 	cfg := *t.Config
-	copy.Config = &cfg
-	return &copy
+	copyTConf.Config = &cfg
+	return &copyTConf
 }
 
 // addStreamTemplate will add a stream template to this account that allows auto-creation of streams.


### PR DESCRIPTION
    1. the keyword copy is builtin func ,rename copy to other with param as prefix
    2. fix some func note

/cc @nats-io/core
