### PR TITLE
FIXED Clustered streams with seq mismatch state on store failures.

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -2753,12 +2753,13 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 	}
 
 	if err != nil {
-		// If we did not succeed put those values back.
+		// If we did not succeed put those values back and increment clfs in case we are clustered.
 		mset.mu.Lock()
 		var state StreamState
 		mset.store.FastState(&state)
 		mset.lseq = state.LastSeq
 		mset.lmsgId = olmsgId
+		mset.clfs++
 		mset.mu.Unlock()
 
 		if err != ErrStoreClosed {


### PR DESCRIPTION
We did account for high level failure properly but were not properly accounting for low level store failures. When in clustered mode we need to account for the failure properly, and we use clfs for that, just needed updating on low level store failure.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
