### PR TITLE
Add hardened systemd service

### DIFF
--- a/util/nats-server-hardened.service
+++ b/util/nats-server-hardened.service
@@ -1,0 +1,61 @@
+[Unit]
+Description=NATS Server
+After=network.target ntp.service
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/nats-server -c /etc/nats-server.conf
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s SIGINT $MAINPID
+User=nats
+Group=nats
+
+# Hardening
+CapabilityBoundingSet=
+LimitNOFILE=800000 # JetStream requires 2 FDs open per stream.
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+PrivateUsers=true
+ProcSubset=pid
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+ReadOnlyPaths=
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallFilter=@system-service ~@privileged ~@resources
+UMask=0077
+
+# If you have systemd >= 247
+ProtectProc=invisible
+
+# If you have systemd >= 248
+PrivateIPC=true
+
+# Optional: writable directory for JetStream.
+ReadWritePaths=/var/lib/nats
+
+# Optional: resource control.
+# Replace weights by values that make sense for your situation.
+# For a list of all options see:
+# https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
+#CPUAccounting=true
+#CPUWeight=100 # of 10000
+#IOAccounting=true
+#IOWeight=100 # of 10000
+#MemoryAccounting=true
+#MemoryMax=1GB
+#IPAccounting=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [x] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #

### Changes proposed in this pull request:

I'm working on adding a [NATS service to NixOS](https://github.com/NixOS/nixpkgs/pull/128189). During this process I found that the recommended systemd service definition does not contain any systemd hardening options. In NixOS more and more services have hardening options applied (where possible). Giving services the least amount of privileges makes sense to me.

This PR adds a second systemd service file that has hardening options applied. Tested this on my machine with basic pub/sub and with (JetStream) streams (to verify files can be accessed by NATS). Reason for adding a second file is to give users a choice between a bare-bones service definition or a hardened definition. Having the hardening options in this repo could also serve as documentation about the capabilities/privileges that NATS needs.

I would like to hear your opinion on this. Via this PR I would also like to get feedback about the used systemd hardening options. I'm unsure if I tightened the capabilities/privileges too much.

/cc @nats-io/core
