### PR TITLE
If dirty flag set always write consumer state.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5013,7 +5013,7 @@ func (o *consumerFileStore) Stop() error {
 	}
 
 	var err error
-	if o.dirty && !o.writing {
+	if o.dirty {
 		var buf []byte
 		// Make sure to write this out..
 		if buf, err = o.encodeState(); err == nil && len(buf) > 0 {


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
