### PR TITLE
Check not really needed here, so removed

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -2243,9 +2243,6 @@ func (mset *stream) subscribeInternal(subject string, cb msgHandler) (*subscript
 	if c == nil {
 		return nil, fmt.Errorf("invalid stream")
 	}
-	if !c.srv.eventsEnabled() {
-		return nil, ErrNoSysAccount
-	}
 	if cb == nil {
 		return nil, fmt.Errorf("undefined message handler")
 	}


### PR DESCRIPTION
Was showing a data race.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
