### PR TITLE
Fix for #2329.

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -3419,11 +3419,13 @@ func (s *Server) jsConsumerInfoRequest(sub *subscription, c *client, subject, re
 				resp.Error = ApiErrors[JSClusterNotAvailErr]
 				// Delaying an error response gives the leader a chance to respond before us
 				s.sendDelayedAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp), ca.Group)
-			} else if rg := ca.Group; rg != nil && rg.node != nil && rg.isMember(cc.meta.ID()) {
-				// Check here if we are a member and this is just a new consumer that does not have a leader yet.
-				if rg.node.GroupLeader() == _EMPTY_ && !rg.node.HadPreviousLeader() {
-					resp.Error = ApiErrors[JSConsumerNotFoundErr]
-					s.sendDelayedAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp), nil)
+			} else if ca != nil {
+				if rg := ca.Group; rg != nil && rg.node != nil && rg.isMember(cc.meta.ID()) {
+					// Check here if we are a member and this is just a new consumer that does not have a leader yet.
+					if rg.node.GroupLeader() == _EMPTY_ && !rg.node.HadPreviousLeader() {
+						resp.Error = ApiErrors[JSConsumerNotFoundErr]
+						s.sendDelayedAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp), nil)
+					}
 				}
 			}
 			return


### PR DESCRIPTION
When we created a filestore we would figure out if we should track by subject based on stream config.
This would cause bad results when a stream was updated to multiple subjects or wildcards.

This change tightens when and what we track per subject but turns it on all the time now, meaning we can update streams and track by subject behaviors will now work.

Resolves #2329 

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
