### PR TITLE
Add error codes for all consumer creation errors

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -758,5 +758,295 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerConfigRequiredErr",
+    "code": 400,
+    "error_code": 10078,
+    "description": "consumer config required",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerDeliverToWildcardsErr",
+    "code": 400,
+    "error_code": 10079,
+    "description": "consumer deliver subject has wildcards",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerPushMaxWaitingErr",
+    "code": 400,
+    "error_code": 10080,
+    "description": "consumer in push mode can not set max waiting",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerDeliverCycleErr",
+    "code": 400,
+    "error_code": 10081,
+    "description": "consumer deliver subject forms a cycle",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerMaxPendingAckPolicyRequiredErr",
+    "code": 400,
+    "error_code": 10082,
+    "description": "consumer requires ack policy for max ack pending",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerSmallHeartbeatErr",
+    "code": 400,
+    "error_code": 10083,
+    "description": "consumer idle heartbeat needs to be \u003e= 100ms",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerPullRequiresAckErr",
+    "code": 400,
+    "error_code": 10084,
+    "description": "consumer in pull mode requires explicit ack policy",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerPullNotDurableErr",
+    "code": 400,
+    "error_code": 10085,
+    "description": "consumer in pull mode requires a durable name",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerPullWithRateLimitErr",
+    "code": 400,
+    "error_code": 10086,
+    "description": "consumer in pull mode can not have rate limit set",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerMaxWaitingNegativeErr",
+    "code": 400,
+    "error_code": 10087,
+    "description": "consumer max waiting needs to be positive",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerHBRequiresPushErr",
+    "code": 400,
+    "error_code": 10088,
+    "description": "consumer idle heartbeat requires a push based consumer",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerFCRequiresPushErr",
+    "code": 400,
+    "error_code": 10089,
+    "description": "consumer flow control requires a push based consumer",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerDirectRequiresPushErr",
+    "code": 400,
+    "error_code": 10090,
+    "description": "consumer direct requires a push based consumer",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerDirectRequiresEphemeralErr",
+    "code": 400,
+    "error_code": 10091,
+    "description": "consumer direct requires an ephemeral consumer",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerOnMappedErr",
+    "code": 400,
+    "error_code": 10092,
+    "description": "consumer direct on a mapped consumer",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerFilterNotSubsetErr",
+    "code": 400,
+    "error_code": 10093,
+    "description": "consumer filter subject is not a valid subset of the interest subjects",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerInvalidPolicyErrF",
+    "code": 400,
+    "error_code": 10094,
+    "description": "{err}",
+    "comment": "Generic delivery policy error",
+    "help": "Error returned for impossible deliver policies when combined with start sequences etc",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerInvalidSamplingErrF",
+    "code": 400,
+    "error_code": 10095,
+    "description": "failed to parse consumer sampling configuration: {err}",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSStreamInvalidErr",
+    "code": 500,
+    "error_code": 10096,
+    "description": "stream not valid",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSStreamMaximumConsumersReachedErr",
+    "code": 400,
+    "error_code": 10097,
+    "description": "maximum consumers limit reached",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerWQRequiresExplicitAckErr",
+    "code": 400,
+    "error_code": 10098,
+    "description": "workqueue stream requires explicit ack",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerWQMultipleUnfilteredErr",
+    "code": 400,
+    "error_code": 10099,
+    "description": "multiple non-filtered consumers not allowed on workqueue stream",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerWQConsumerNotUniqueErr",
+    "code": 400,
+    "error_code": 10100,
+    "description": "filtered consumer not unique on workqueue stream",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerWQConsumerNotDeliverAllErr",
+    "code": 400,
+    "error_code": 10101,
+    "description": "consumer must be deliver all on workqueue stream",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerNameTooLongErrF",
+    "code": 400,
+    "error_code": 10102,
+    "description": "consumer name is too long, maximum allowed is {max}",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerBadDurableNameErr",
+    "code": 400,
+    "error_code": 10103,
+    "description": "durable name can not contain '.', '*', '\u003e'",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerStoreFailedErrF",
+    "code": 500,
+    "error_code": 10104,
+    "description": "error creating store for consumer: {err}",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerExistingActiveErr",
+    "code": 400,
+    "error_code": 10105,
+    "description": "consumer already exists and is still active",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerReplacementWithDifferentNameErr",
+    "code": 400,
+    "error_code": 10106,
+    "description": "consumer replacement durable config not the same",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2546,7 +2546,10 @@ func (js *jetStream) processClusterCreateConsumer(ca *consumerAssignment, state 
 	}
 
 	if err != nil {
-		s.Warnf("Consumer create failed for '%s > %s > %s': %v\n", ca.Client.serviceAccount(), ca.Stream, ca.Name, err)
+		if IsNatsErr(err, JSConsumerStoreFailedErrF) {
+			s.Warnf("Consumer create failed for '%s > %s > %s': %v", ca.Client.serviceAccount(), ca.Stream, ca.Name, err)
+		}
+
 		js.mu.Lock()
 
 		ca.err = err

--- a/server/jetstream_errors.go
+++ b/server/jetstream_errors.go
@@ -18,7 +18,6 @@ func IsNatsErr(err error, ids ...ErrorIdentifier) bool {
 		return false
 	}
 
-	found := false
 	for _, id := range ids {
 		ae, ok := ApiErrors[id]
 		if !ok || ae == nil {
@@ -26,11 +25,11 @@ func IsNatsErr(err error, ids ...ErrorIdentifier) bool {
 		}
 
 		if ce.ErrCode == ae.ErrCode {
-			found = true
+			return true
 		}
 	}
 
-	return found
+	return false
 }
 
 // ApiError is included in all responses if there was an error.

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -42,8 +42,26 @@ const (
 	// JSClusterUnSupportFeatureErr not currently supported in clustered mode
 	JSClusterUnSupportFeatureErr ErrorIdentifier = 10036
 
+	// JSConsumerBadDurableNameErr durable name can not contain '.', '*', '>'
+	JSConsumerBadDurableNameErr ErrorIdentifier = 10103
+
+	// JSConsumerConfigRequiredErr consumer config required
+	JSConsumerConfigRequiredErr ErrorIdentifier = 10078
+
 	// JSConsumerCreateErrF General consumer creation failure string ({err})
 	JSConsumerCreateErrF ErrorIdentifier = 10012
+
+	// JSConsumerDeliverCycleErr consumer deliver subject forms a cycle
+	JSConsumerDeliverCycleErr ErrorIdentifier = 10081
+
+	// JSConsumerDeliverToWildcardsErr consumer deliver subject has wildcards
+	JSConsumerDeliverToWildcardsErr ErrorIdentifier = 10079
+
+	// JSConsumerDirectRequiresEphemeralErr consumer direct requires an ephemeral consumer
+	JSConsumerDirectRequiresEphemeralErr ErrorIdentifier = 10091
+
+	// JSConsumerDirectRequiresPushErr consumer direct requires a push based consumer
+	JSConsumerDirectRequiresPushErr ErrorIdentifier = 10090
 
 	// JSConsumerDurableNameNotInSubjectErr consumer expected to be durable but no durable name set in subject
 	JSConsumerDurableNameNotInSubjectErr ErrorIdentifier = 10016
@@ -60,11 +78,74 @@ const (
 	// JSConsumerEphemeralWithDurableNameErr consumer expected to be ephemeral but a durable name was set in request
 	JSConsumerEphemeralWithDurableNameErr ErrorIdentifier = 10020
 
+	// JSConsumerExistingActiveErr consumer already exists and is still active
+	JSConsumerExistingActiveErr ErrorIdentifier = 10105
+
+	// JSConsumerFCRequiresPushErr consumer flow control requires a push based consumer
+	JSConsumerFCRequiresPushErr ErrorIdentifier = 10089
+
+	// JSConsumerFilterNotSubsetErr consumer filter subject is not a valid subset of the interest subjects
+	JSConsumerFilterNotSubsetErr ErrorIdentifier = 10093
+
+	// JSConsumerHBRequiresPushErr consumer idle heartbeat requires a push based consumer
+	JSConsumerHBRequiresPushErr ErrorIdentifier = 10088
+
+	// JSConsumerInvalidPolicyErrF Generic delivery policy error ({err})
+	JSConsumerInvalidPolicyErrF ErrorIdentifier = 10094
+
+	// JSConsumerInvalidSamplingErrF failed to parse consumer sampling configuration: {err}
+	JSConsumerInvalidSamplingErrF ErrorIdentifier = 10095
+
+	// JSConsumerMaxPendingAckPolicyRequiredErr consumer requires ack policy for max ack pending
+	JSConsumerMaxPendingAckPolicyRequiredErr ErrorIdentifier = 10082
+
+	// JSConsumerMaxWaitingNegativeErr consumer max waiting needs to be positive
+	JSConsumerMaxWaitingNegativeErr ErrorIdentifier = 10087
+
 	// JSConsumerNameExistErr consumer name already in use
 	JSConsumerNameExistErr ErrorIdentifier = 10013
 
+	// JSConsumerNameTooLongErrF consumer name is too long, maximum allowed is {max}
+	JSConsumerNameTooLongErrF ErrorIdentifier = 10102
+
 	// JSConsumerNotFoundErr consumer not found
 	JSConsumerNotFoundErr ErrorIdentifier = 10014
+
+	// JSConsumerOnMappedErr consumer direct on a mapped consumer
+	JSConsumerOnMappedErr ErrorIdentifier = 10092
+
+	// JSConsumerPullNotDurableErr consumer in pull mode requires a durable name
+	JSConsumerPullNotDurableErr ErrorIdentifier = 10085
+
+	// JSConsumerPullRequiresAckErr consumer in pull mode requires explicit ack policy
+	JSConsumerPullRequiresAckErr ErrorIdentifier = 10084
+
+	// JSConsumerPullWithRateLimitErr consumer in pull mode can not have rate limit set
+	JSConsumerPullWithRateLimitErr ErrorIdentifier = 10086
+
+	// JSConsumerPushMaxWaitingErr consumer in push mode can not set max waiting
+	JSConsumerPushMaxWaitingErr ErrorIdentifier = 10080
+
+	// JSConsumerReplacementWithDifferentNameErr consumer replacement durable config not the same
+	JSConsumerReplacementWithDifferentNameErr ErrorIdentifier = 10106
+
+	// JSConsumerSmallHeartbeatErr consumer idle heartbeat needs to be >= 100ms
+	JSConsumerSmallHeartbeatErr ErrorIdentifier = 10083
+
+	// JSConsumerStoreFailedErrF error creating store for consumer: {err}
+	JSConsumerStoreFailedErrF ErrorIdentifier = 10104
+
+	// JSConsumerWQConsumerNotDeliverAllErr consumer must be deliver all on workqueue stream
+	JSConsumerWQConsumerNotDeliverAllErr ErrorIdentifier = 10101
+
+	// JSConsumerWQConsumerNotUniqueErr filtered consumer not unique on workqueue stream
+	JSConsumerWQConsumerNotUniqueErr ErrorIdentifier = 10100
+
+	// JSConsumerWQMultipleUnfilteredErr multiple non-filtered consumers not allowed on workqueue stream
+	JSConsumerWQMultipleUnfilteredErr ErrorIdentifier = 10099
+
+	// JSConsumerWQRequiresExplicitAckErr workqueue stream requires explicit ack
+	JSConsumerWQRequiresExplicitAckErr ErrorIdentifier = 10098
 
 	// JSInsufficientResourcesErr insufficient resources
 	JSInsufficientResourcesErr ErrorIdentifier = 10023
@@ -159,11 +240,17 @@ const (
 	// JSStreamInvalidConfigF Stream configuration validation error string ({err})
 	JSStreamInvalidConfigF ErrorIdentifier = 10052
 
+	// JSStreamInvalidErr stream not valid
+	JSStreamInvalidErr ErrorIdentifier = 10096
+
 	// JSStreamInvalidExternalDeliverySubjErrF stream external delivery prefix {prefix} must not contain wildcards
 	JSStreamInvalidExternalDeliverySubjErrF ErrorIdentifier = 10024
 
 	// JSStreamLimitsErrF General stream limits exceeded error string ({err})
 	JSStreamLimitsErrF ErrorIdentifier = 10053
+
+	// JSStreamMaximumConsumersReachedErr maximum consumers limit reached
+	JSStreamMaximumConsumersReachedErr ErrorIdentifier = 10097
 
 	// JSStreamMessageExceedsMaximumErr message size exceeds maximum allowed
 	JSStreamMessageExceedsMaximumErr ErrorIdentifier = 10054
@@ -247,14 +334,41 @@ var (
 		JSClusterServerNotMemberErr:                {Code: 400, ErrCode: 10044, Description: "server is not a member of the cluster"},
 		JSClusterTagsErr:                           {Code: 400, ErrCode: 10011, Description: "tags placement not supported for operation"},
 		JSClusterUnSupportFeatureErr:               {Code: 503, ErrCode: 10036, Description: "not currently supported in clustered mode"},
+		JSConsumerBadDurableNameErr:                {Code: 400, ErrCode: 10103, Description: "durable name can not contain '.', '*', '>'"},
+		JSConsumerConfigRequiredErr:                {Code: 400, ErrCode: 10078, Description: "consumer config required"},
 		JSConsumerCreateErrF:                       {Code: 500, ErrCode: 10012, Description: "{err}"},
+		JSConsumerDeliverCycleErr:                  {Code: 400, ErrCode: 10081, Description: "consumer deliver subject forms a cycle"},
+		JSConsumerDeliverToWildcardsErr:            {Code: 400, ErrCode: 10079, Description: "consumer deliver subject has wildcards"},
+		JSConsumerDirectRequiresEphemeralErr:       {Code: 400, ErrCode: 10091, Description: "consumer direct requires an ephemeral consumer"},
+		JSConsumerDirectRequiresPushErr:            {Code: 400, ErrCode: 10090, Description: "consumer direct requires a push based consumer"},
 		JSConsumerDurableNameNotInSubjectErr:       {Code: 400, ErrCode: 10016, Description: "consumer expected to be durable but no durable name set in subject"},
 		JSConsumerDurableNameNotMatchSubjectErr:    {Code: 400, ErrCode: 10017, Description: "consumer name in subject does not match durable name in request"},
 		JSConsumerDurableNameNotSetErr:             {Code: 400, ErrCode: 10018, Description: "consumer expected to be durable but a durable name was not set"},
 		JSConsumerEphemeralWithDurableInSubjectErr: {Code: 400, ErrCode: 10019, Description: "consumer expected to be ephemeral but detected a durable name set in subject"},
 		JSConsumerEphemeralWithDurableNameErr:      {Code: 400, ErrCode: 10020, Description: "consumer expected to be ephemeral but a durable name was set in request"},
+		JSConsumerExistingActiveErr:                {Code: 400, ErrCode: 10105, Description: "consumer already exists and is still active"},
+		JSConsumerFCRequiresPushErr:                {Code: 400, ErrCode: 10089, Description: "consumer flow control requires a push based consumer"},
+		JSConsumerFilterNotSubsetErr:               {Code: 400, ErrCode: 10093, Description: "consumer filter subject is not a valid subset of the interest subjects"},
+		JSConsumerHBRequiresPushErr:                {Code: 400, ErrCode: 10088, Description: "consumer idle heartbeat requires a push based consumer"},
+		JSConsumerInvalidPolicyErrF:                {Code: 400, ErrCode: 10094, Description: "{err}"},
+		JSConsumerInvalidSamplingErrF:              {Code: 400, ErrCode: 10095, Description: "failed to parse consumer sampling configuration: {err}"},
+		JSConsumerMaxPendingAckPolicyRequiredErr:   {Code: 400, ErrCode: 10082, Description: "consumer requires ack policy for max ack pending"},
+		JSConsumerMaxWaitingNegativeErr:            {Code: 400, ErrCode: 10087, Description: "consumer max waiting needs to be positive"},
 		JSConsumerNameExistErr:                     {Code: 400, ErrCode: 10013, Description: "consumer name already in use"},
+		JSConsumerNameTooLongErrF:                  {Code: 400, ErrCode: 10102, Description: "consumer name is too long, maximum allowed is {max}"},
 		JSConsumerNotFoundErr:                      {Code: 404, ErrCode: 10014, Description: "consumer not found"},
+		JSConsumerOnMappedErr:                      {Code: 400, ErrCode: 10092, Description: "consumer direct on a mapped consumer"},
+		JSConsumerPullNotDurableErr:                {Code: 400, ErrCode: 10085, Description: "consumer in pull mode requires a durable name"},
+		JSConsumerPullRequiresAckErr:               {Code: 400, ErrCode: 10084, Description: "consumer in pull mode requires explicit ack policy"},
+		JSConsumerPullWithRateLimitErr:             {Code: 400, ErrCode: 10086, Description: "consumer in pull mode can not have rate limit set"},
+		JSConsumerPushMaxWaitingErr:                {Code: 400, ErrCode: 10080, Description: "consumer in push mode can not set max waiting"},
+		JSConsumerReplacementWithDifferentNameErr:  {Code: 400, ErrCode: 10106, Description: "consumer replacement durable config not the same"},
+		JSConsumerSmallHeartbeatErr:                {Code: 400, ErrCode: 10083, Description: "consumer idle heartbeat needs to be >= 100ms"},
+		JSConsumerStoreFailedErrF:                  {Code: 500, ErrCode: 10104, Description: "error creating store for consumer: {err}"},
+		JSConsumerWQConsumerNotDeliverAllErr:       {Code: 400, ErrCode: 10101, Description: "consumer must be deliver all on workqueue stream"},
+		JSConsumerWQConsumerNotUniqueErr:           {Code: 400, ErrCode: 10100, Description: "filtered consumer not unique on workqueue stream"},
+		JSConsumerWQMultipleUnfilteredErr:          {Code: 400, ErrCode: 10099, Description: "multiple non-filtered consumers not allowed on workqueue stream"},
+		JSConsumerWQRequiresExplicitAckErr:         {Code: 400, ErrCode: 10098, Description: "workqueue stream requires explicit ack"},
 		JSInsufficientResourcesErr:                 {Code: 503, ErrCode: 10023, Description: "insufficient resources"},
 		JSInvalidJSONErr:                           {Code: 400, ErrCode: 10025, Description: "invalid JSON"},
 		JSMaximumConsumersLimitErr:                 {Code: 400, ErrCode: 10026, Description: "maximum consumers limit reached"},
@@ -286,8 +400,10 @@ var (
 		JSStreamExternalDelPrefixOverlapsErrF:      {Code: 400, ErrCode: 10022, Description: "stream external delivery prefix {prefix} overlaps with stream subject {subject}"},
 		JSStreamGeneralErrorF:                      {Code: 500, ErrCode: 10051, Description: "{err}"},
 		JSStreamInvalidConfigF:                     {Code: 500, ErrCode: 10052, Description: "{err}"},
+		JSStreamInvalidErr:                         {Code: 500, ErrCode: 10096, Description: "stream not valid"},
 		JSStreamInvalidExternalDeliverySubjErrF:    {Code: 400, ErrCode: 10024, Description: "stream external delivery prefix {prefix} must not contain wildcards"},
 		JSStreamLimitsErrF:                         {Code: 500, ErrCode: 10053, Description: "{err}"},
+		JSStreamMaximumConsumersReachedErr:         {Code: 400, ErrCode: 10097, Description: "maximum consumers limit reached"},
 		JSStreamMessageExceedsMaximumErr:           {Code: 400, ErrCode: 10054, Description: "message size exceeds maximum allowed"},
 		JSStreamMirrorNotUpdatableErr:              {Code: 400, ErrCode: 10055, Description: "Mirror configuration can not be updated"},
 		JSStreamMismatchErr:                        {Code: 400, ErrCode: 10056, Description: "stream name in subject does not match request"},


### PR DESCRIPTION
I wanted to supress some logging of consumer create
errors that just isn't needed and would be really
annoying on large networks, so I added many constants
and updated all errors.

I think only JSConsumerStoreFailedErrF is worth logging
on large networks else there would be quite a lot of
logs generated that one just cannot act on

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
