### PR TITLE
[FIXED] #2332 Peer info reports that had large last active values.

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4665,9 +4665,9 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 
 	for _, rp := range peers {
 		if rp.ID != id && rg.isMember(rp.ID) {
-			lastSeen := now.Sub(rp.Last)
-			if lastSeen < 0 {
-				lastSeen = 1
+			var lastSeen time.Duration
+			if now.After(rp.Last) && rp.Last.Unix() != 0 {
+				lastSeen = now.Sub(rp.Last)
 			}
 			current := rp.Current
 			if current && lastSeen > lostQuorumInterval {

--- a/server/raft.go
+++ b/server/raft.go
@@ -1245,11 +1245,15 @@ func (n *raft) Peers() []*Peer {
 
 	var peers []*Peer
 	for id, ps := range n.peers {
+		var lag uint64
+		if n.commit > ps.li {
+			lag = n.commit - ps.li
+		}
 		p := &Peer{
 			ID:      id,
 			Current: id == n.leader || ps.li >= n.applied,
 			Last:    time.Unix(0, ps.ts),
-			Lag:     n.commit - ps.li,
+			Lag:     lag,
 		}
 		peers = append(peers, p)
 	}


### PR DESCRIPTION
Also put in safety for lag going upside down as well.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #2332 

/cc @nats-io/core
