### PR TITLE
Fix for multiple concurrent ephemeral consumer requests with max consumers set.

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4050,14 +4050,12 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 	ca := &consumerAssignment{Group: rg, Stream: stream, Name: oname, Config: cfg, Subject: subject, Reply: reply, Client: ci, Created: time.Now().UTC()}
 	eca := encodeAddConsumerAssignment(ca)
 
-	// Mark this as pending if a durable.
-	if isDurableConsumer(cfg) {
-		if sa.consumers == nil {
-			sa.consumers = make(map[string]*consumerAssignment)
-		}
-		ca.pending = true
-		sa.consumers[ca.Name] = ca
+	// Mark this as pending.
+	if sa.consumers == nil {
+		sa.consumers = make(map[string]*consumerAssignment)
 	}
+	ca.pending = true
+	sa.consumers[ca.Name] = ca
 
 	// Do formal proposal.
 	cc.meta.Propose(eca)

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -7340,7 +7340,7 @@ func TestJetStreamClusterSourceAndMirrorConsumersLeaderChange(t *testing.T) {
 
 	// Now make sure we only have a single direct consumer on our origin streams.
 	// Pick one at random.
-	name := fmt.Sprintf("O%d", rand.Intn(numStreams))
+	name := fmt.Sprintf("O%d", rand.Intn(numStreams-1)+1)
 	c1.waitOnStreamLeader("$G", name)
 	s := c1.streamLeader("$G", name)
 	a, err := s.lookupAccount("$G")
@@ -7351,6 +7351,7 @@ func TestJetStreamClusterSourceAndMirrorConsumersLeaderChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+
 	checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
 		if ndc := mset.numDirectConsumers(); ndc != 1 {
 			return fmt.Errorf("Stream %q wanted 1 direct consumer, got %d", name, ndc)


### PR DESCRIPTION
Bug that did not limit ephemeral consumers when in clustered mode and with multiple concurrent requests.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
