### PR TITLE
[FIXED] Consumer NumPending bug

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -443,7 +443,7 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 	}
 	if maxc > 0 && len(mset.consumers) >= maxc {
 		mset.mu.Unlock()
-		return nil, ApiErrors[JSStreamMaximumConsumersReachedErr]
+		return nil, ApiErrors[JSMaximumConsumersLimitErr]
 	}
 
 	// Check on stream type conflicts with WorkQueues.

--- a/server/errors.json
+++ b/server/errors.json
@@ -950,16 +950,6 @@
     "deprecates": ""
   },
   {
-    "constant": "JSStreamMaximumConsumersReachedErr",
-    "code": 400,
-    "error_code": 10097,
-    "description": "maximum consumers limit reached",
-    "comment": "",
-    "help": "",
-    "url": "",
-    "deprecates": ""
-  },
-  {
     "constant": "JSConsumerWQRequiresExplicitAckErr",
     "code": 400,
     "error_code": 10098,

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -249,9 +249,6 @@ const (
 	// JSStreamLimitsErrF General stream limits exceeded error string ({err})
 	JSStreamLimitsErrF ErrorIdentifier = 10053
 
-	// JSStreamMaximumConsumersReachedErr maximum consumers limit reached
-	JSStreamMaximumConsumersReachedErr ErrorIdentifier = 10097
-
 	// JSStreamMessageExceedsMaximumErr message size exceeds maximum allowed
 	JSStreamMessageExceedsMaximumErr ErrorIdentifier = 10054
 
@@ -403,7 +400,6 @@ var (
 		JSStreamInvalidErr:                         {Code: 500, ErrCode: 10096, Description: "stream not valid"},
 		JSStreamInvalidExternalDeliverySubjErrF:    {Code: 400, ErrCode: 10024, Description: "stream external delivery prefix {prefix} must not contain wildcards"},
 		JSStreamLimitsErrF:                         {Code: 500, ErrCode: 10053, Description: "{err}"},
-		JSStreamMaximumConsumersReachedErr:         {Code: 400, ErrCode: 10097, Description: "maximum consumers limit reached"},
 		JSStreamMessageExceedsMaximumErr:           {Code: 400, ErrCode: 10054, Description: "message size exceeds maximum allowed"},
 		JSStreamMirrorNotUpdatableErr:              {Code: 400, ErrCode: 10055, Description: "Mirror configuration can not be updated"},
 		JSStreamMismatchErr:                        {Code: 400, ErrCode: 10056, Description: "stream name in subject does not match request"},


### PR DESCRIPTION
Fix for a consumer's num pending being stuck at 1.

We were trying to protect the sgap uint64 from wrapping, but in some cases the consumers is eager and can get a message before we sgap++.

Instead of slowing things down and synchronizing ++ then --, we allow it to wrap temporarily and have and adjustedPending() func that will set to zero for reporting.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
