### PR TITLE
[ADDED] In-process connections

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -199,6 +199,7 @@ type Options struct {
 	ServerName            string        `json:"server_name"`
 	Host                  string        `json:"addr"`
 	Port                  int           `json:"port"`
+	DontListen            bool          `json:"dont_listen"`
 	ClientAdvertise       string        `json:"-"`
 	Trace                 bool          `json:"-"`
 	Debug                 bool          `json:"-"`
@@ -4283,6 +4284,9 @@ func MergeOptions(fileOpts, flagOpts *Options) *Options {
 	}
 	if flagOpts.Host != "" {
 		opts.Host = flagOpts.Host
+	}
+	if flagOpts.DontListen {
+		opts.DontListen = flagOpts.DontListen
 	}
 	if flagOpts.ClientAdvertise != "" {
 		opts.ClientAdvertise = flagOpts.ClientAdvertise

--- a/server/server.go
+++ b/server/server.go
@@ -2948,6 +2948,8 @@ func (s *Server) ProfilerAddr() *net.TCPAddr {
 }
 
 func (s *Server) readyForConnections(d time.Duration) error {
+	end := time.Now().Add(d)
+
 	// Wait for startup. At this point AcceptLoop will only just be
 	// starting, so we'll still check for the presence of listeners
 	// after this.
@@ -2968,7 +2970,6 @@ func (s *Server) readyForConnections(d time.Duration) error {
 	}
 	chk := make(map[string]info)
 
-	end := time.Now().Add(d)
 	for time.Now().Before(end) {
 		s.mu.Lock()
 		chk["server"] = info{ok: s.listener != nil || opts.DontListen, err: s.listenerErr}

--- a/server/server.go
+++ b/server/server.go
@@ -2119,6 +2119,7 @@ func (s *Server) InProcessConn() (net.Conn, error) {
 	pl, pr := net.Pipe()
 	if !s.startGoRoutine(func() {
 		s.createClient(pl)
+		s.grWG.Done()
 	}) {
 		pl.Close()
 		pr.Close()

--- a/server/server.go
+++ b/server/server.go
@@ -2972,7 +2972,7 @@ func (s *Server) readyForConnections(d time.Duration) error {
 	chk := make(map[string]info)
 
 	for time.Now().Before(end) {
-		s.mu.Lock()
+		s.mu.RLock()
 		chk["server"] = info{ok: s.listener != nil || opts.DontListen, err: s.listenerErr}
 		chk["route"] = info{ok: (opts.Cluster.Port == 0 || s.routeListener != nil), err: s.routeListenerErr}
 		chk["gateway"] = info{ok: (opts.Gateway.Name == _EMPTY_ || s.gatewayListener != nil), err: s.gatewayListenerErr}

--- a/server/server.go
+++ b/server/server.go
@@ -2113,8 +2113,10 @@ func (s *Server) AcceptLoop(clr chan struct{}) {
 	clr = nil
 }
 
-// InProcessConn returns a connection to the server which can
-// be used in-process when DontListen is set.
+// InProcessConn returns an in-process connection to the server,
+// avoiding the need to use a TCP listener for local connectivity
+// within the same process. This can be used regardless of the
+// state of the DontListen option.
 func (s *Server) InProcessConn() (net.Conn, error) {
 	pl, pr := net.Pipe()
 	created := true


### PR DESCRIPTION
This PR adds three things:
1.  `InProcessConn()` function to `Server` which builds a `net.Pipe` to get a connection to the NATS server without using TCP sockets
2. `DontListen` option which tells the NATS server not to listen on the usual TCP listener
3. `startupComplete` channel, which is closed right before we start `AcceptLoop`, and `readyForConnections` will wait for it

The main motivation for this is that we have an application that can run either in a monolith (single-process) mode or a polylith (multi-process) mode. We'd like to be able to use NATS for both modes for simplicity, but the monolith mode has to be able to cater for a variety of platforms where opening socket connections either doesn't make sense (mobile) or just isn't possible (WASM). These changes will allow us to use NATS entirely in-process instead.

An accompanying PR nats-io/nats.go#774 adds support to the client side.

This is my first PR to this project so apologies in advance if I've missed anything obvious anywhere.

/cc @nats-io/core
