### PR TITLE
Removed debug.PrintStack() from apiDispatch [ci skip]

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -21,7 +21,6 @@ import (
 	"math/rand"
 	"os"
 	"path"
-	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -608,7 +607,6 @@ func (js *jetStream) apiDispatch(sub *subscription, c *client, subject, reply st
 
 	// Shortcircuit.
 	if len(rr.psubs)+len(rr.qsubs) == 0 {
-		debug.PrintStack()
 		return
 	}
 


### PR DESCRIPTION
It was introduced by mistake in PR #2324 which I had reported
but failed to be actually removed before PR was merged:
https://github.com/nats-io/nats-server/pull/2324#pullrequestreview-695163635

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

/cc @nats-io/core
