### PR TITLE
Stubs for WebAssembly

### DIFF
--- a/server/disk_avail_wasm.go
+++ b/server/disk_avail_wasm.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The NATS Authors
+// Copyright 2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,28 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows && !openbsd && !wasm
-// +build !windows,!openbsd,!wasm
+//go:build wasm
+// +build wasm
 
 package server
 
-import (
-	"os"
-	"syscall"
-)
-
 func diskAvailable(storeDir string) int64 {
-	var ba int64
-	if _, err := os.Stat(storeDir); os.IsNotExist(err) {
-		os.MkdirAll(storeDir, defaultDirPerms)
-	}
-	var fs syscall.Statfs_t
-	if err := syscall.Statfs(storeDir, &fs); err == nil {
-		// Estimate 75% of available storage.
-		ba = int64(uint64(fs.Bavail) * uint64(fs.Bsize) / 4 * 3)
-	} else {
-		// Used 1TB default as a guess if all else fails.
-		ba = JetStreamMaxStoreDefault
-	}
-	return ba
+	return JetStreamMaxStoreDefault
 }

--- a/server/pse/pse_wasm.go
+++ b/server/pse/pse_wasm.go
@@ -1,0 +1,23 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pse
+
+// This is a placeholder for now.
+func ProcUsage(pcpu *float64, rss, vss *int64) error {
+	*pcpu = 0.0
+	*rss = 0
+	*vss = 0
+
+	return nil
+}

--- a/server/pse/pse_wasm.go
+++ b/server/pse/pse_wasm.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The NATS Authors
+// Copyright 2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -10,6 +10,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//go:build wasm
+// +build wasm
 
 package pse
 

--- a/server/signal.go
+++ b/server/signal.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !wasm
+// +build !windows,!wasm
 
 package server
 

--- a/server/signal_wasm.go
+++ b/server/signal_wasm.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build wasm
+// +build wasm
+
 package server
 
 func (s *Server) handleSignals() {

--- a/server/signal_wasm.go
+++ b/server/signal_wasm.go
@@ -1,0 +1,22 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+func (s *Server) handleSignals() {
+
+}
+
+func ProcessSignal(command Command, service string) error {
+	return nil
+}

--- a/server/sysmem/mem_wasm.go
+++ b/server/sysmem/mem_wasm.go
@@ -1,0 +1,21 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build wasm
+
+package sysmem
+
+func Memory() int64 {
+	// TODO: We don't know the system memory
+	return 0
+}

--- a/server/sysmem/mem_wasm.go
+++ b/server/sysmem/mem_wasm.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The NATS Authors
+// Copyright 2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build wasm
 // +build wasm
 
 package sysmem


### PR DESCRIPTION
This should allow NATS Server to build under the `js/wasm` target.

/cc @nats-io/core
