### PR TITLE
[fixed] tls timeout now accepts units

### DIFF
--- a/server/configs/tls.conf
+++ b/server/configs/tls.conf
@@ -5,7 +5,7 @@ listen: 127.0.0.1:4443
 tls {
   cert_file:  "./configs/certs/server.pem"
   key_file:   "./configs/certs/key.pem"
-  timeout:    2
+  timeout:    "2s"
 }
 
 authorization {

--- a/server/opts.go
+++ b/server/opts.go
@@ -3552,6 +3552,14 @@ func parseTLS(v interface{}, isClientCtx bool) (t *TLSConfigOpts, retErr error) 
 				at = float64(mv)
 			case float64:
 				at = mv
+			case string:
+				d, err := time.ParseDuration(mv)
+				if err != nil {
+					return nil, &configErr{tk, fmt.Sprintf("error parsing tls config, 'timeout' %s", err)}
+				}
+				at = d.Seconds()
+			default:
+				return nil, &configErr{tk, "error parsing tls config, 'timeout' wrong type"}
 			}
 			tc.Timeout = at
 		case "pinned_certs":


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

ran into trying to set with units this the other day.
didn't work and didn't cause an error, so made it work