### PR TITLE
[changed] default account fetch timeout to be smaller as client timeout

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -202,5 +202,5 @@ const (
 	DEFAULT_GLOBAL_ACCOUNT = "$G"
 
 	// DEFAULT_FETCH_TIMEOUT is the default time that the system will wait for an account fetch to return.
-	DEFAULT_ACCOUNT_FETCH_TIMEOUT = 2 * time.Second
+	DEFAULT_ACCOUNT_FETCH_TIMEOUT = 1900 * time.Millisecond
 )


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

changes this (account for creds has not been pushed):
```bash
nats --server localhost:4222 --creds ~/test/jetstream-leaf-nodes-demo/keys/creds/OP/NOPUSH/nopush.creds sub foo
nats: error: read tcp 127.0.0.1:49279->127.0.0.1:4222: i/o timeout, try --help
```

to that:
```bash
nats --server localhost:4222 --creds ~/test/jetstream-leaf-nodes-demo/keys/creds/OP/NOPUSH/nopush.creds sub foo
nats: error: nats: Authorization Violation, try --help
```