### PR TITLE
[fixed] subscription on wildcard import that is not a subset

### DIFF
--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -3294,3 +3294,86 @@ func TestAccountSystemPermsWithGlobalAccess(t *testing.T) {
 	}
 	defer sc.Close()
 }
+
+const importSubscriptionOverlapTemplate = `
+listen: 127.0.0.1:-1
+accounts: {
+  ACCOUNT_X: {
+	users: [
+	  {user: publisher}
+	]
+	exports: [
+	  {stream: %s}
+	]
+  },
+  ACCOUNT_Y: {
+	users: [
+	  {user: subscriber}
+	]
+	imports: [
+	  {stream: {account: ACCOUNT_X, subject: %s }, %s}
+	]
+  }
+}`
+
+func TestImportSubscriptionPartialOverlapWithPrefix(t *testing.T) {
+	cf := createConfFile(t, []byte(fmt.Sprintf(importSubscriptionOverlapTemplate, ">", ">", "prefix: myprefix")))
+	defer removeFile(t, cf)
+
+	s, opts := RunServerWithConfig(cf)
+	defer s.Shutdown()
+
+	ncX := natsConnect(t, fmt.Sprintf("nats://%s:%s@127.0.0.1:%d", "publisher", "", opts.Port))
+	defer ncX.Close()
+
+	ncY := natsConnect(t, fmt.Sprintf("nats://%s:%s@127.0.0.1:%d", "subscriber", "", opts.Port))
+	defer ncY.Close()
+
+	for _, subj := range []string{">", "myprefix.*", "myprefix.>", "myprefix.test", "*.>", "*.*", "*.test"} {
+		t.Run(subj, func(t *testing.T) {
+			sub, err := ncY.SubscribeSync(subj)
+			sub.AutoUnsubscribe(1)
+			require_NoError(t, err)
+			require_NoError(t, ncY.Flush())
+
+			ncX.Publish("test", []byte("hello"))
+
+			m, err := sub.NextMsg(time.Second)
+			require_NoError(t, err)
+			require_True(t, string(m.Data) == "hello")
+		})
+	}
+}
+
+func TestImportSubscriptionPartialOverlapWithTransform(t *testing.T) {
+	cf := createConfFile(t, []byte(fmt.Sprintf(importSubscriptionOverlapTemplate, "*.*.>", "*.*.>", " to: myprefix.$2.$1.>")))
+	defer removeFile(t, cf)
+
+	s, opts := RunServerWithConfig(cf)
+	defer s.Shutdown()
+
+	ncX := natsConnect(t, fmt.Sprintf("nats://%s:%s@127.0.0.1:%d", "publisher", "", opts.Port))
+	defer ncX.Close()
+
+	ncY := natsConnect(t, fmt.Sprintf("nats://%s:%s@127.0.0.1:%d", "subscriber", "", opts.Port))
+	defer ncY.Close()
+
+	for _, subj := range []string{">", "*.*.*.>", "*.2.*.>", "*.*.1.>", "*.2.1.>", "*.*.*.*", "*.2.1.*", "*.*.*.test",
+		"*.*.1.test", "*.2.*.test", "*.2.1.test", "myprefix.*.*.*", "myprefix.>", "myprefix.*.>", "myprefix.*.*.>",
+		"myprefix.2.>", "myprefix.2.1.>", "myprefix.*.1.>", "myprefix.2.*.>", "myprefix.2.1.*", "myprefix.*.*.test",
+		"myprefix.2.1.test"} {
+		t.Run(subj, func(t *testing.T) {
+			sub, err := ncY.SubscribeSync(subj)
+			sub.AutoUnsubscribe(1)
+			require_NoError(t, err)
+			require_NoError(t, ncY.Flush())
+
+			ncX.Publish("1.2.test", []byte("hello"))
+
+			m, err := sub.NextMsg(time.Second)
+			require_NoError(t, err)
+			require_True(t, string(m.Data) == "hello")
+			require_Equal(t, m.Subject, "myprefix.2.1.test")
+		})
+	}
+}

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -3346,7 +3346,7 @@ func TestImportSubscriptionPartialOverlapWithPrefix(t *testing.T) {
 }
 
 func TestImportSubscriptionPartialOverlapWithTransform(t *testing.T) {
-	cf := createConfFile(t, []byte(fmt.Sprintf(importSubscriptionOverlapTemplate, "*.*.>", "*.*.>", " to: myprefix.$2.$1.>")))
+	cf := createConfFile(t, []byte(fmt.Sprintf(importSubscriptionOverlapTemplate, "*.*.>", "*.*.>", "to: myprefix.$2.$1.>")))
 	defer removeFile(t, cf)
 
 	s, opts := RunServerWithConfig(cf)

--- a/server/client.go
+++ b/server/client.go
@@ -2509,9 +2509,10 @@ func (c *client) addShadowSubscriptions(acc *Account, sub *subscription) error {
 		for _, tk := range tokens {
 			if tk == pwcs {
 				hasWC = true
+				break
 			}
 		}
-		if tokens[len(tokens)-1] == fwcs {
+		if !hasWC && tokens[len(tokens)-1] == fwcs {
 			hasWC = true
 		}
 	}
@@ -2524,7 +2525,7 @@ func (c *client) addShadowSubscriptions(acc *Account, sub *subscription) error {
 			continue
 		}
 		if subj == im.to {
-			ims = append(ims, ime{im, "", false})
+			ims = append(ims, ime{im, _EMPTY_, false})
 			continue
 		}
 		if tokensModified {
@@ -2537,10 +2538,10 @@ func (c *client) addShadowSubscriptions(acc *Account, sub *subscription) error {
 		tokenizeSubjectIntoSlice(im.to, &imTokens)
 
 		if isSubsetMatchTokenized(tokens, imTokens) {
-			ims = append(ims, ime{im, "", true})
+			ims = append(ims, ime{im, _EMPTY_, true})
 		} else if hasWC {
 			if isSubsetMatchTokenized(imTokens, tokens) {
-				ims = append(ims, ime{im, "", false})
+				ims = append(ims, ime{im, _EMPTY_, false})
 			} else {
 				imTokensLen := len(imTokens)
 				for i, t := range tokens {

--- a/server/client.go
+++ b/server/client.go
@@ -2504,8 +2504,7 @@ func (c *client) addShadowSubscriptions(acc *Account, sub *subscription) error {
 	acc.mu.RLock()
 	subj := string(sub.subject)
 	if len(acc.imports.streams) > 0 {
-		tokens = tsa[:0]
-		tokenizeSubjectIntoSlice(subj, &tokens)
+		tokens = tokenizeSubjectIntoSlice(tsa[:0], subj)
 		for _, tk := range tokens {
 			if tk == pwcs {
 				hasWC = true
@@ -2530,12 +2529,10 @@ func (c *client) addShadowSubscriptions(acc *Account, sub *subscription) error {
 		}
 		if tokensModified {
 			// re-tokenize subj to overwrite modifications from a previous iteration
-			tokens = tsa[:0]
-			tokenizeSubjectIntoSlice(subj, &tokens)
+			tokens = tokenizeSubjectIntoSlice(tsa[:0], subj)
 			tokensModified = false
 		}
-		imTokens := imTsa[:0]
-		tokenizeSubjectIntoSlice(im.to, &imTokens)
+		imTokens := tokenizeSubjectIntoSlice(imTsa[:0], im.to)
 
 		if isSubsetMatchTokenized(tokens, imTokens) {
 			ims = append(ims, ime{im, _EMPTY_, true})

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -29,6 +29,7 @@ import (
 // Common byte variables for wildcards and token separator.
 const (
 	pwc   = '*'
+	pwcs  = "*"
 	fwc   = '>'
 	fwcs  = ">"
 	tsep  = "."
@@ -1186,39 +1187,41 @@ func tokenAt(subject string, index uint8) string {
 	return _EMPTY_
 }
 
+func tokenizeSubjectIntoSlice(subject string, tts *[]string) {
+	start := 0
+	for i := 0; i < len(subject); i++ {
+		if subject[i] == btsep {
+			*tts = append(*tts, subject[start:i])
+			start = i + 1
+		}
+	}
+	*tts = append(*tts, subject[start:])
+}
+
 // Calls into the function isSubsetMatch()
 func subjectIsSubsetMatch(subject, test string) bool {
 	tsa := [32]string{}
 	tts := tsa[:0]
-	start := 0
-	for i := 0; i < len(subject); i++ {
-		if subject[i] == btsep {
-			tts = append(tts, subject[start:i])
-			start = i + 1
-		}
-	}
-	tts = append(tts, subject[start:])
+	tokenizeSubjectIntoSlice(subject, &tts)
 	return isSubsetMatch(tts, test)
 }
 
 // This will test a subject as an array of tokens against a test subject
-// and determine if the tokens are matched. Both test subject and tokens
-// may contain wildcards. So foo.* is a subset match of [">", "*.*", "foo.*"],
-// but not of foo.bar, etc.
+// Calls into the function isSubsetMatchTokenized
 func isSubsetMatch(tokens []string, test string) bool {
 	tsa := [32]string{}
 	tts := tsa[:0]
-	start := 0
-	for i := 0; i < len(test); i++ {
-		if test[i] == btsep {
-			tts = append(tts, test[start:i])
-			start = i + 1
-		}
-	}
-	tts = append(tts, test[start:])
+	tokenizeSubjectIntoSlice(test, &tts)
+	return isSubsetMatchTokenized(tokens, tts)
+}
 
+// This will test a subject as an array of tokens against a test subject (also encoded as array of tokens)
+// and determine if the tokens are matched. Both test subject and tokens
+// may contain wildcards. So foo.* is a subset match of [">", "*.*", "foo.*"],
+// but not of foo.bar, etc.
+func isSubsetMatchTokenized(tokens, test []string) bool {
 	// Walk the target tokens
-	for i, t2 := range tts {
+	for i, t2 := range test {
 		if i >= len(tokens) {
 			return false
 		}
@@ -1241,7 +1244,7 @@ func isSubsetMatch(tokens []string, test string) bool {
 			if !m {
 				return false
 			}
-			if i >= len(tts) {
+			if i >= len(test) {
 				return true
 			}
 			continue
@@ -1250,7 +1253,7 @@ func isSubsetMatch(tokens []string, test string) bool {
 			return false
 		}
 	}
-	return len(tokens) == len(tts)
+	return len(tokens) == len(test)
 }
 
 // matchLiteral is used to test literal subjects, those that do not have any

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -1203,8 +1203,7 @@ func tokenizeSubjectIntoSlice(tts []string, subject string) []string {
 // Calls into the function isSubsetMatch()
 func subjectIsSubsetMatch(subject, test string) bool {
 	tsa := [32]string{}
-	tts := tsa[:0]
-	tts = tokenizeSubjectIntoSlice(tts, subject)
+	tts := tokenizeSubjectIntoSlice(tsa[:0], subject)
 	return isSubsetMatch(tts, test)
 }
 
@@ -1212,8 +1211,7 @@ func subjectIsSubsetMatch(subject, test string) bool {
 // Calls into the function isSubsetMatchTokenized
 func isSubsetMatch(tokens []string, test string) bool {
 	tsa := [32]string{}
-	tts := tsa[:0]
-	tts = tokenizeSubjectIntoSlice(tts, test)
+	tts := tokenizeSubjectIntoSlice(tsa[:0], test)
 	return isSubsetMatchTokenized(tokens, tts)
 }
 

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -1187,22 +1187,24 @@ func tokenAt(subject string, index uint8) string {
 	return _EMPTY_
 }
 
-func tokenizeSubjectIntoSlice(subject string, tts *[]string) {
+// use similar to append. meaning, the updated slice will be returned
+func tokenizeSubjectIntoSlice(tts []string, subject string) []string {
 	start := 0
 	for i := 0; i < len(subject); i++ {
 		if subject[i] == btsep {
-			*tts = append(*tts, subject[start:i])
+			tts = append(tts, subject[start:i])
 			start = i + 1
 		}
 	}
-	*tts = append(*tts, subject[start:])
+	tts = append(tts, subject[start:])
+	return tts
 }
 
 // Calls into the function isSubsetMatch()
 func subjectIsSubsetMatch(subject, test string) bool {
 	tsa := [32]string{}
 	tts := tsa[:0]
-	tokenizeSubjectIntoSlice(subject, &tts)
+	tts = tokenizeSubjectIntoSlice(tts, subject)
 	return isSubsetMatch(tts, test)
 }
 
@@ -1211,7 +1213,7 @@ func subjectIsSubsetMatch(subject, test string) bool {
 func isSubsetMatch(tokens []string, test string) bool {
 	tsa := [32]string{}
 	tts := tsa[:0]
-	tokenizeSubjectIntoSlice(test, &tts)
+	tts = tokenizeSubjectIntoSlice(tts, test)
 	return isSubsetMatchTokenized(tokens, tts)
 }
 


### PR DESCRIPTION
fixes #2361
The subject used was not a subset of the import. Nor the other way
around. Instead it is an overlap that needs to be dynamically computed.

Signed-off-by: Matthias Hanel <mh@synadia.com>

I added more unit tests for transforms and discovered another test involving ">".
Took care to not iterate over subj more often than necessary. 
Part of this was to support better re-use of tokenized subjects.