### PR TITLE
[fixed] jetstream unique server name requirement across domains

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -157,6 +157,7 @@ type ServerInfo struct {
 	Host      string    `json:"host"`
 	ID        string    `json:"id"`
 	Cluster   string    `json:"cluster,omitempty"`
+	Domain    string    `json:"domain,omitempty"`
 	Version   string    `json:"ver"`
 	Seq       uint64    `json:"seq"`
 	JetStream bool      `json:"jetstream"`
@@ -270,6 +271,7 @@ RESET:
 	id := s.info.ID
 	host := s.info.Host
 	servername := s.info.Name
+	domain := s.info.Domain
 	seqp := &s.sys.seq
 	js := s.info.JetStream
 	cluster := s.info.Cluster
@@ -294,6 +296,7 @@ RESET:
 		case pm := <-sendq:
 			if pm.si != nil {
 				pm.si.Name = servername
+				pm.si.Domain = domain
 				pm.si.Host = host
 				pm.si.Cluster = cluster
 				pm.si.ID = id
@@ -917,6 +920,10 @@ func (s *Server) processRemoteServerShutdown(sid string) {
 	delete(s.sys.servers, sid)
 }
 
+func (s *Server) sameDomain(domain string) bool {
+	return domain == _EMPTY_ || s.info.Domain == _EMPTY_ || domain == s.info.Domain
+}
+
 // remoteServerShutdownEvent is called when we get an event from another server shutting down.
 func (s *Server) remoteServerShutdown(sub *subscription, _ *client, _ *Account, subject, reply string, msg []byte) {
 	s.mu.Lock()
@@ -929,13 +936,8 @@ func (s *Server) remoteServerShutdown(sub *subscription, _ *client, _ *Account, 
 		s.Debugf("Received remote server shutdown on bad subject %q", subject)
 		return
 	}
-
-	sid := toks[serverSubjectIndex]
-	if su := s.sys.servers[sid]; su != nil {
-		s.processRemoteServerShutdown(sid)
-	}
-
 	if len(msg) == 0 {
+		s.Errorf("Remote server sent invalid (empty) shutdown message to %q", subject)
 		return
 	}
 
@@ -946,8 +948,15 @@ func (s *Server) remoteServerShutdown(sub *subscription, _ *client, _ *Account, 
 		return
 	}
 	// Additional processing here.
-	node := string(getHash(si.Name))
-	s.nodeToInfo.Store(node, nodeInfo{si.Name, si.Cluster, si.ID, true, true})
+	if s.sameDomain(si.Domain) {
+		node := string(getHash(si.Name))
+		s.nodeToInfo.Store(node, nodeInfo{si.Name, si.Cluster, si.ID, true, true})
+
+		sid := toks[serverSubjectIndex]
+		if su := s.sys.servers[sid]; su != nil {
+			s.processRemoteServerShutdown(sid)
+		}
+	}
 }
 
 // remoteServerUpdate listens for statsz updates from other servers.
@@ -958,8 +967,10 @@ func (s *Server) remoteServerUpdate(sub *subscription, _ *client, _ *Account, su
 		return
 	}
 	si := ssm.Server
-	node := string(getHash(si.Name))
-	s.nodeToInfo.Store(node, nodeInfo{si.Name, si.Cluster, si.ID, false, si.JetStream})
+	if s.sameDomain(si.Domain) {
+		node := string(getHash(si.Name))
+		s.nodeToInfo.Store(node, nodeInfo{si.Name, si.Cluster, si.ID, false, si.JetStream})
+	}
 }
 
 // updateRemoteServer is called when we have an update from a remote server.
@@ -989,8 +1000,10 @@ func (s *Server) processNewServer(ms *ServerInfo) {
 	// connect update to make sure they switch this account to interest only mode.
 	s.ensureGWsInterestOnlyForLeafNodes()
 	// Add to our nodeToName
-	node := string(getHash(ms.Name))
-	s.nodeToInfo.Store(node, nodeInfo{ms.Name, ms.Cluster, ms.ID, false, ms.JetStream})
+	if s.sameDomain(ms.Domain) {
+		node := string(getHash(ms.Name))
+		s.nodeToInfo.Store(node, nodeInfo{ms.Name, ms.Cluster, ms.ID, false, ms.JetStream})
+	}
 	// Announce ourselves..
 	s.sendStatsz(fmt.Sprintf(serverStatsSubj, s.info.ID))
 }

--- a/server/events.go
+++ b/server/events.go
@@ -968,10 +968,11 @@ func (s *Server) remoteServerUpdate(sub *subscription, _ *client, _ *Account, su
 		return
 	}
 	si := ssm.Server
-	if s.sameDomain(si.Domain) {
-		node := string(getHash(si.Name))
-		s.nodeToInfo.Store(node, nodeInfo{si.Name, si.Cluster, si.ID, false, si.JetStream})
+	if !s.sameDomain(si.Domain) {
+		return
 	}
+	node := string(getHash(si.Name))
+	s.nodeToInfo.Store(node, nodeInfo{si.Name, si.Cluster, si.ID, false, si.JetStream})
 }
 
 // updateRemoteServer is called when we have an update from a remote server.

--- a/server/events.go
+++ b/server/events.go
@@ -948,14 +948,15 @@ func (s *Server) remoteServerShutdown(sub *subscription, _ *client, _ *Account, 
 		return
 	}
 	// Additional processing here.
-	if s.sameDomain(si.Domain) {
-		node := string(getHash(si.Name))
-		s.nodeToInfo.Store(node, nodeInfo{si.Name, si.Cluster, si.ID, true, true})
+	if !s.sameDomain(si.Domain) {
+		return
+	}
+	node := string(getHash(si.Name))
+	s.nodeToInfo.Store(node, nodeInfo{si.Name, si.Cluster, si.ID, true, true})
 
-		sid := toks[serverSubjectIndex]
-		if su := s.sys.servers[sid]; su != nil {
-			s.processRemoteServerShutdown(sid)
-		}
+	sid := toks[serverSubjectIndex]
+	if su := s.sys.servers[sid]; su != nil {
+		s.processRemoteServerShutdown(sid)
 	}
 }
 

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1198,7 +1198,7 @@ func (s *Server) setLeafNodeInfoHostPortAndIP() error {
 // (this solves the stale connection situation). An error is returned to help the
 // remote detect the misconfiguration when the duplicate is the result of that
 // misconfiguration.
-func (s *Server) addLeafNodeConnection(c *client, srvName string, checkForDup bool) {
+func (s *Server) addLeafNodeConnection(c *client, srvName string, clusterName string, checkForDup bool) {
 	var accName string
 	c.mu.Lock()
 	cid := c.cid
@@ -1217,7 +1217,8 @@ func (s *Server) addLeafNodeConnection(c *client, srvName string, checkForDup bo
 			// is more about replacing stale connections than detecting loops.
 			// We have code for the loop detection elsewhere, which also delays
 			// attempt to reconnect.
-			if !ol.isSolicitedLeafNode() && ol.leaf.remoteServer == srvName && ol.acc.Name == accName {
+			if !ol.isSolicitedLeafNode() && ol.leaf.remoteServer == srvName &&
+				ol.leaf.remoteCluster == clusterName && ol.acc.Name == accName {
 				old = ol
 			}
 			ol.mu.Unlock()
@@ -1350,7 +1351,7 @@ func (c *client) processLeafNodeConnect(s *Server, arg []byte, lang string) erro
 	c.mu.Unlock()
 
 	// Add in the leafnode here since we passed through auth at this point.
-	s.addLeafNodeConnection(c, proto.Name, true)
+	s.addLeafNodeConnection(c, proto.Name, proto.Cluster, true)
 
 	// If we have permissions bound to this leafnode we need to send then back to the
 	// origin server for local enforcement.
@@ -2440,7 +2441,7 @@ func (s *Server) leafNodeFinishConnectProcess(c *client) {
 
 	// Make sure we register with the account here.
 	c.registerWithAccount(acc)
-	s.addLeafNodeConnection(c, _EMPTY_, false)
+	s.addLeafNodeConnection(c, _EMPTY_, _EMPTY_, false)
 	s.initLeafNodeSmapAndSendSubs(c)
 	if sendSysConnectEvent {
 		s.sendLeafNodeConnect(acc)

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1198,7 +1198,7 @@ func (s *Server) setLeafNodeInfoHostPortAndIP() error {
 // (this solves the stale connection situation). An error is returned to help the
 // remote detect the misconfiguration when the duplicate is the result of that
 // misconfiguration.
-func (s *Server) addLeafNodeConnection(c *client, srvName string, clusterName string, checkForDup bool) {
+func (s *Server) addLeafNodeConnection(c *client, srvName, clusterName string, checkForDup bool) {
 	var accName string
 	c.mu.Lock()
 	cid := c.cid

--- a/server/route.go
+++ b/server/route.go
@@ -1420,7 +1420,10 @@ func (s *Server) addRoute(c *client, info *Info) (bool, bool) {
 	if !exists {
 		s.routes[c.cid] = c
 		s.remotes[id] = c
-		s.nodeToInfo.Store(c.route.hash, nodeInfo{c.route.remoteName, s.info.Cluster, id, false, info.JetStream})
+		// check to be consistent and future proof. but will be same domain
+		if s.sameDomain(info.Domain) {
+			s.nodeToInfo.Store(c.route.hash, nodeInfo{c.route.remoteName, s.info.Cluster, id, false, info.JetStream})
+		}
 		c.mu.Lock()
 		c.route.connectURLs = info.ClientConnectURLs
 		c.route.wsConnURLs = info.WSConnectURLs
@@ -1691,6 +1694,7 @@ func (s *Server) startRouteAcceptLoop() {
 		GatewayURL:   s.getGatewayURL(),
 		Headers:      s.supportsHeaders(),
 		Cluster:      s.info.Cluster,
+		Domain:       s.info.Domain,
 		Dynamic:      s.isClusterNameDynamic(),
 		LNOC:         true,
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -79,6 +79,7 @@ type Info struct {
 	Nonce             string   `json:"nonce,omitempty"`
 	Cluster           string   `json:"cluster,omitempty"`
 	Dynamic           bool     `json:"cluster_dynamic,omitempty"`
+	Domain            string   `json:"domain,omitempty"`
 	ClientConnectURLs []string `json:"connect_urls,omitempty"`    // Contains URLs a client can connect to.
 	WSConnectURLs     []string `json:"ws_connect_urls,omitempty"` // Contains URLs a ws client can connect to.
 	LameDuckMode      bool     `json:"ldm,omitempty"`
@@ -250,7 +251,7 @@ type Server struct {
 	rnMu      sync.RWMutex
 	raftNodes map[string]RaftNode
 
-	// For mapping from a raft node name back to a server name and cluster.
+	// For mapping from a raft node name back to a server name and cluster. Node has to be in the same domain.
 	nodeToInfo sync.Map
 
 	// For out of resources to not log errors too fast.
@@ -331,6 +332,7 @@ func NewServer(opts *Options) (*Server, error) {
 		JetStream:    opts.JetStream,
 		Headers:      !opts.NoHeaderSupport,
 		Cluster:      opts.Cluster.Name,
+		Domain:       opts.JetStreamDomain,
 	}
 
 	if tlsReq && !info.TLSRequired {


### PR DESCRIPTION
including domain in server info
adding check for cluster name in duplicate leaf node connection check

This does not address non unique domains in the same domain, say within super cluster.

Signed-off-by: Matthias Hanel <mh@synadia.com>

---

By using the hash of the server name to compute a shortened identifier, jetstream introduced the need for unique server names (say across an entire super cluster)
```
node := string(getHash(si.Name))
s.nodeToInfo.Store(node, nodeInfo{si.Name, si.Cluster, si.ID, false, si.JetStream})
```

Short of changing how this key is computed, say by using a truncated server Id or the hash of domain+cluster+server. server names have to be unique. This change only addresses the need for unique server names across domains.

When this change is accepted, I'll add domain to jsm server info as well.