### PR TITLE
[fixed] crash in unit test caused by *ConsumerStore.State()

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -2368,6 +2368,9 @@ func TestFileStoreConsumerRedeliveredLost(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexepected error: %v", err)
 		}
+		if state == nil {
+			t.Fatalf("Did not recover state")
+		}
 		if len(state.Redelivered) == 0 {
 			t.Fatalf("Did not recover redelivered")
 		}


### PR DESCRIPTION
returning nil, nil

Signed-off-by: Matthias Hanel <mh@synadia.com>

crash report indicates that state was nil.
looking at the memory store implementation, returning nil, nil seems legit, so the test needed to be fixed.

```
--- FAIL: TestFileStoreConsumerRedeliveredLost (0.02s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1169413]
goroutine 6977 [running]:
testing.tRunner.func1.2(0x137dbe0, 0x1b1c700)
	/home/travis/.gimme/versions/go1.16.6.linux.amd64/src/testing/testing.go:1143 +0x49f
testing.tRunner.func1(0xc000503200)
	/home/travis/.gimme/versions/go1.16.6.linux.amd64/src/testing/testing.go:1146 +0x695
panic(0x137dbe0, 0x1b1c700)
	/home/travis/.gimme/versions/go1.16.6.linux.amd64/src/runtime/panic.go:971 +0x499
github.com/nats-io/nats-server/server.TestFileStoreConsumerRedeliveredLost.func1()
	/home/travis/gopath/src/github.com/nats-io/nats-server/server/filestore_test.go:2371 +0x293
github.com/nats-io/nats-server/server.TestFileStoreConsumerRedeliveredLost(0xc000503200)
	/home/travis/gopath/src/github.com/nats-io/nats-server/server/filestore_test.go:2396 +0x7f9
testing.tRunner(0xc000503200, 0x14e2758)
	/home/travis/.gimme/versions/go1.16.6.linux.amd64/src/testing/testing.go:1193 +0x203
created by testing.(*T).Run
	/home/travis/.gimme/versions/go1.16.6.linux.amd64/src/testing/testing.go:1238 +0x5d8
FAIL	github.com/nats-io/nats-server/server	21.800s
```