### PR TITLE
[FIXED] A stream with interest retention had a clustered consumer could cause server panic.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2802,7 +2802,6 @@ func (o *consumer) stopWithFlags(dflag, sdflag, doSignal, advisory bool) error {
 	// non-leader consumers will need to restore state first.
 	if dflag && rp == InterestPolicy {
 		stop := mset.lastSeq()
-
 		o.mu.Lock()
 		if !o.isLeader() {
 			o.readStoredState()
@@ -2810,8 +2809,7 @@ func (o *consumer) stopWithFlags(dflag, sdflag, doSignal, advisory bool) error {
 		start := o.asflr
 		o.mu.Unlock()
 
-		rmseqs := make([]uint64, 0, stop-start+1)
-
+		var rmseqs []uint64
 		mset.mu.RLock()
 		for seq := start; seq <= stop; seq++ {
 			if !mset.checkInterest(seq, o) {


### PR DESCRIPTION
A clustered consumer on an interest retention policy it could cause the server to panic when the consumer was being deleted.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
