### PR TITLE
Remove '-s' flag from ldflags from the build

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -5,7 +5,7 @@ builds:
     id: nats-server
     binary: nats-server
     ldflags:
-      - -s -w -X github.com/nats-io/nats-server/server.gitCommit={{.ShortCommit}}
+      - -w -X github.com/nats-io/nats-server/server.gitCommit={{.ShortCommit}}
     env:
       - GO111MODULE=off
       - CGO_ENABLED=0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
 - main: ./main.go
   binary: nats-server
   ldflags:
-    - -s -w -X github.com/nats-io/nats-server/server.gitCommit={{.ShortCommit}}
+    - -w -X github.com/nats-io/nats-server/server.gitCommit={{.ShortCommit}}
   env:
     - GO111MODULE=off
     - CGO_ENABLED=0

--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -7,7 +7,7 @@ RUN mkdir -p src/github.com/nats-io && \
     cd src/github.com/nats-io/ && \
     git clone https://github.com/nats-io/natscli.git && \
     cd natscli/nats && \
-    go build -ldflags "-s -w -X main.version=${VERSION}" -o /nats
+    go build -ldflags "-w -X main.version=${VERSION}" -o /nats
 
 RUN go get github.com/nats-io/nsc
 


### PR DESCRIPTION
This retains the symbols (but still removes the dwarf info).

This increases the executable size by ~8% (test on my laptop):

$ go build -ldflags '-w' -o nats-server
-rwxrwxr-x 1 yzhao yzhao 11911273 Jul 28 15:52 nats-server

$ go build -ldflags '-s -w' -o nats-server
-rwxrwxr-x 1 yzhao yzhao 11128832 Jul 28 15:52 nats-server

Symbols are very useful during debugging. It would be great that if the
NATS team consider including symbols.

Resolves #2366

### Changes proposed in this pull request:


/cc @nats-io/core
