### PR TITLE
NOT DONE, only to exchange state

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -920,6 +920,7 @@ func (s *Server) processRemoteServerShutdown(sid string) {
 	delete(s.sys.servers, sid)
 }
 
+// returns true if the server's domain and the domain argument are either not set or identical
 func (s *Server) sameDomain(domain string) bool {
 	return domain == _EMPTY_ || s.info.Domain == _EMPTY_ || domain == s.info.Domain
 }


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

This is only to show you where I think the problem came from. (where I added !s.sameDomain(info.Domain))
Implications of this are that perhaps domain needs to be settable without JS.

The unit test should work, but now I have issues reproducing the original issue again.
Tested by wrapping (!s.sameDomain(info.Domain || true)
