### PR TITLE
[FIX] #2388

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -831,6 +831,7 @@ func (s *Server) jsAccountInfoRequest(sub *subscription, c *client, _ *Account, 
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
+
 	ci, acc, _, msg, err := s.getRequestInfo(c, rmsg)
 	if err != nil {
 		s.Warnf(badAPIRequestT, msg)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -292,7 +292,7 @@ func (s *Server) JetStreamClusterPeers() []string {
 	var nodes []string
 	for _, p := range peers {
 		si, ok := s.nodeToInfo.Load(p.ID)
-		if !ok || si.(nodeInfo).offline {
+		if !ok || si.(nodeInfo).offline || !si.(nodeInfo).js {
 			continue
 		}
 		nodes = append(nodes, si.(nodeInfo).name)

--- a/server/reload.go
+++ b/server/reload.go
@@ -1345,6 +1345,9 @@ func (s *Server) applyOptions(ctx *reloadContext, opts []option) {
 				s.Warnf("Can't start JetStream: %v", err)
 			}
 		}
+		// Make sure to reset the internal loop's version of JS.
+		s.resetInternalLoopInfo()
+		s.sendStatszUpdate()
 	}
 
 	// For remote gateways and leafnodes, make sure that their TLS configuration
@@ -1366,6 +1369,21 @@ func (s *Server) applyOptions(ctx *reloadContext, opts []option) {
 	}
 
 	s.Noticef("Reloaded server configuration")
+}
+
+// This will send a reset to the internal send loop.
+func (s *Server) resetInternalLoopInfo() {
+	var resetCh chan struct{}
+	s.mu.Lock()
+	if s.sys != nil {
+		// can't hold the lock as go routine reading it may be waiting for lock as well
+		resetCh = s.sys.resetCh
+	}
+	s.mu.Unlock()
+
+	if resetCh != nil {
+		resetCh <- struct{}{}
+	}
 }
 
 // Update all cached debug and trace settings for every client

--- a/server/route.go
+++ b/server/route.go
@@ -1422,7 +1422,7 @@ func (s *Server) addRoute(c *client, info *Info) (bool, bool) {
 		s.remotes[id] = c
 		// check to be consistent and future proof. but will be same domain
 		if s.sameDomain(info.Domain) {
-			s.nodeToInfo.Store(c.route.hash, nodeInfo{c.route.remoteName, s.info.Cluster, id, false, info.JetStream})
+			s.nodeToInfo.Store(c.route.hash, nodeInfo{c.route.remoteName, s.info.Cluster, info.Domain, id, false, info.JetStream})
 		}
 		c.mu.Lock()
 		c.route.connectURLs = info.ClientConnectURLs

--- a/server/server.go
+++ b/server/server.go
@@ -264,9 +264,11 @@ type Server struct {
 	sysAccOnlyNoAuthUser string
 }
 
+// For tracking JS nodes.
 type nodeInfo struct {
 	name    string
 	cluster string
+	domain  string
 	id      string
 	offline bool
 	js      bool
@@ -380,7 +382,7 @@ func NewServer(opts *Options) (*Server, error) {
 
 	// Place ourselves in some lookup maps.
 	ourNode := string(getHash(serverName))
-	s.nodeToInfo.Store(ourNode, nodeInfo{serverName, opts.Cluster.Name, info.ID, false, opts.JetStream})
+	s.nodeToInfo.Store(ourNode, nodeInfo{serverName, opts.Cluster.Name, opts.JetStreamDomain, info.ID, false, opts.JetStream})
 
 	s.routeResolver = opts.Cluster.resolver
 	if s.routeResolver == nil {


### PR DESCRIPTION
Allow non-JS leafnode(s) to access a HUB transparently. Also tests for mixed mode.

Mixed mode should always configure a JS block for the server and specify domain and disable the servers they do not want to do JS.
e.g. jetstream: {domain: "SPOKE", enabled: false}

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #2388

### Changes proposed in this pull request:

 -
 -
 -

/cc @nats-io/core
