### PR TITLE
[FIXED] Fix for #2403

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1998,7 +1998,7 @@ func (s *Server) setInfoHostPort() error {
 	// When this function is called, opts.Port is set to the actual listen
 	// port (if option was originally set to RANDOM), even during a config
 	// reload. So use of s.opts.Port is safe.
-	if s.opts.ClientAdvertise != "" {
+	if s.opts.ClientAdvertise != _EMPTY_ {
 		h, p, err := parseHostPort(s.opts.ClientAdvertise, s.opts.Port)
 		if err != nil {
 			return err


### PR DESCRIPTION
When we would expire msgs we held the stream readlock and called down into consumers. If the stream was interest policy and we had unacked messages we would try to reacquire the stream readlock to check for any remaining interest. If someone tried to acquire the write lock in between, it would not be able acquire it, but that would cause the second read lock to also block leading to a deadlock.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #2403 

/cc @nats-io/core
