### PR TITLE
Due to internal limits the actual maximum payload size is 64Mb. Beyon…

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -841,7 +841,7 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 		}
 		o.MaxControlLine = int32(v.(int64))
 	case "max_payload":
-		if v.(int64) > 1<<31-1 {
+		if v.(int64) > 64*1024*1024 {
 			err := &configErr{tk, fmt.Sprintf("%s value is too big", k)}
 			*errors = append(*errors, err)
 			return


### PR DESCRIPTION
…d that the subscribing process is unable to receive the messages, so adjusting the maximum size the server allows you to set for `max_payload`.

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [ ] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

### Changes proposed in this pull request:

 - There was an existing check on the value specified in the configuration for `max_payload`, adjusted the max value to be 64MB

/cc @nats-io/core
