### PR TITLE
[FIXED] #2401

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -6615,6 +6615,21 @@ func TestJetStreamClusterLeafNodesWithoutJS(t *testing.T) {
 	testJS(sl, "HUB", true)
 }
 
+func TestJetStreamClusterLeafNodesWithSameDomainNames(t *testing.T) {
+	tmpl := strings.Replace(jsClusterAccountsTempl, "store_dir:", "domain: HUB, store_dir:", 1)
+	c := createJetStreamCluster(t, tmpl, "HUB", _EMPTY_, 3, 11233, true)
+	defer c.shutdown()
+
+	tmpl = strings.Replace(jsClusterTemplWithLeafNode, "store_dir:", "domain: HUB, store_dir:", 1)
+	lnc := c.createLeafNodesWithTemplateAndStartPort(tmpl, "SPOKE", 3, 11311)
+	defer lnc.shutdown()
+
+	//lncm := c.createLeafNodesWithTemplateMixedMode(tmpl, "SPOKE", 3, 2, true)
+	//defer lncm.shutdown()
+
+	c.waitOnPeerCount(6)
+}
+
 // Issue reported with superclusters and leafnodes where first few get next requests for pull susbcribers
 // have the wrong subject.
 func TestJetStreamClusterSuperClusterGetNextRewrite(t *testing.T) {

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -606,6 +606,7 @@ func (s *Server) startLeafNodeAcceptLoop() {
 		MaxPayload:    s.info.MaxPayload, // TODO(dlc) - Allow override?
 		Headers:       s.supportsHeaders(),
 		JetStream:     opts.JetStream,
+		Domain:        opts.JetStreamDomain,
 		Proto:         1, // Fixed for now.
 		InfoOnConnect: true,
 	}
@@ -1057,7 +1058,7 @@ func (c *client) processLeafnodeInfo(info *Info) {
 						c.Debugf("Error adding JetStream domain mapping: %v", err)
 					}
 				}
-			} else if hasJSDomain {
+			} else if hasJSDomain && opts.JetStreamDomain != info.Domain {
 				s.addInJSDenyAll(remote)
 			}
 


### PR DESCRIPTION
Leafnodes with same domain and shared system account should behave like flat jetstream network.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #2401 

/cc @nats-io/core
