### PR TITLE
[FIXED] #2402

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2759,7 +2759,8 @@ func (o *consumer) hasNoLocalInterest() bool {
 // This is when the underlying stream has been purged.
 // sseq is the new first seq for the stream after purge.
 func (o *consumer) purge(sseq uint64) {
-	if sseq == 0 {
+	// Do not update our state unless we know we are the leader.
+	if sseq == 0 || !o.isLeader() {
 		return
 	}
 

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -154,6 +154,7 @@ const (
 	// For snapshots and restores. The ack will have additional tokens.
 	jsSnapshotAckT    = "$JS.SNAPSHOT.ACK.%s.%s"
 	jsRestoreDeliverT = "$JS.SNAPSHOT.RESTORE.%s.%s"
+	jsSnapshotAPI     = "$JS.SNAPSHOT.>"
 
 	// JSApiStreamRemovePeer is the endpoint to remove a peer from a clustered stream and its consumers.
 	// Will return JSON response.
@@ -184,11 +185,13 @@ const (
 	// when they ACK/NAK, etc a message.
 	jsAckT   = "$JS.ACK.%s.%s"
 	jsAckPre = "$JS.ACK."
+	jsAckAPI = "$JS.ACK.>"
 
 	// jsFlowControl is for flow control subjects.
 	jsFlowControlPre = "$JS.FC."
 	// jsFlowControl is for FC responses.
-	jsFlowControl = "$JS.FC.%s.%s.*"
+	jsFlowControl    = "$JS.FC.%s.%s.*"
+	jsFlowControlAPI = "$JS.FC.>"
 
 	// JSAdvisoryPrefix is a prefix for all JetStream advisories.
 	JSAdvisoryPrefix = "$JS.EVENT.ADVISORY"

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -7790,20 +7790,8 @@ func TestJetStreamPanicDecodingConsumerState(t *testing.T) {
 		t.Fatalf("Error creating stream: %v", err)
 	}
 
-	if _, err := js.AddConsumer("TEST", &nats.ConsumerConfig{
-		Durable:       "durable",
-		DeliverPolicy: nats.DeliverAllPolicy,
-		AckPolicy:     nats.AckExplicitPolicy,
-		ReplayPolicy:  nats.ReplayInstantPolicy,
-		FilterSubject: "ORDERS.created",
-		AckWait:       time.Second * 30,
-		MaxDeliver:    -1,
-		MaxAckPending: 1000,
-	}); err != nil {
-		t.Fatalf("Error creating consumer: %v", err)
-	}
+	sub, err := js.PullSubscribe("ORDERS.created", "durable", nats.MaxAckPending(1000))
 
-	sub, err := js.PullSubscribe("ORDERS.created", "durable", nats.Bind("TEST", "durable"))
 	if err != nil {
 		t.Fatalf("Error creating pull subscriber: %v", err)
 	}

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -7763,6 +7763,102 @@ func TestJetStreamClusterMaxConsumersMultipleConcurrentRequests(t *testing.T) {
 	}
 }
 
+func TestJetStreamPanicDecodingConsumerState(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "JSC", 3)
+	defer c.shutdown()
+
+	rch := make(chan struct{}, 1)
+	nc, js := jsClientConnect(t, c.randomServer(),
+		nats.ReconnectWait(50*time.Millisecond),
+		nats.MaxReconnects(-1),
+		nats.ReconnectHandler(func(_ *nats.Conn) {
+			rch <- struct{}{}
+		}),
+	)
+	defer nc.Close()
+
+	if _, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"ORDERS.*"},
+		Storage:   nats.FileStorage,
+		Replicas:  3,
+		Retention: nats.WorkQueuePolicy,
+		Discard:   nats.DiscardNew,
+		MaxMsgs:   -1,
+		MaxAge:    time.Hour * 24 * 365,
+	}); err != nil {
+		t.Fatalf("Error creating stream: %v", err)
+	}
+
+	if _, err := js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:       "durable",
+		DeliverPolicy: nats.DeliverAllPolicy,
+		AckPolicy:     nats.AckExplicitPolicy,
+		ReplayPolicy:  nats.ReplayInstantPolicy,
+		FilterSubject: "ORDERS.created",
+		AckWait:       time.Second * 30,
+		MaxDeliver:    -1,
+		MaxAckPending: 1000,
+	}); err != nil {
+		t.Fatalf("Error creating consumer: %v", err)
+	}
+
+	sub, err := js.PullSubscribe("ORDERS.created", "durable", nats.Bind("TEST", "durable"))
+	if err != nil {
+		t.Fatalf("Error creating pull subscriber: %v", err)
+	}
+
+	sendMsg := func(subject string) {
+		t.Helper()
+		if _, err := js.Publish(subject, []byte("msg")); err != nil {
+			t.Fatalf("Error on publish: %v", err)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		sendMsg("ORDERS.something")
+		sendMsg("ORDERS.created")
+	}
+
+	for total := 0; total != 100; {
+		msgs, err := sub.Fetch(100-total, nats.MaxWait(2*time.Second))
+		if err != nil {
+			t.Fatalf("Failed to fetch message: %v", err)
+		}
+		for _, m := range msgs {
+			m.Ack()
+			total++
+		}
+	}
+
+	c.stopAll()
+	c.restartAllSamePorts()
+	c.waitOnStreamLeader("$G", "TEST")
+	c.waitOnConsumerLeader("$G", "TEST", "durable")
+
+	select {
+	case <-rch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Did not reconnect")
+	}
+
+	for i := 0; i < 100; i++ {
+		sendMsg("ORDERS.something")
+		sendMsg("ORDERS.created")
+	}
+
+	for total := 0; total != 100; {
+		msgs, err := sub.Fetch(100-total, nats.MaxWait(2*time.Second))
+		if err != nil {
+			t.Fatalf("Error on fetch: %v", err)
+		}
+		for _, m := range msgs {
+			m.Ack()
+			total++
+		}
+	}
+}
+
 // Support functions
 
 // Used to setup superclusters for tests.
@@ -8734,6 +8830,18 @@ func (c *cluster) restartAll() {
 			s, o := RunServerWithConfig(opts.ConfigFile)
 			c.servers[i] = s
 			c.opts[i] = o
+		}
+	}
+	c.waitOnClusterReady()
+}
+
+func (c *cluster) restartAllSamePorts() {
+	c.t.Helper()
+	for i, s := range c.servers {
+		if !s.Running() {
+			opts := c.opts[i]
+			s := RunServer(opts)
+			c.servers[i] = s
 		}
 	}
 	c.waitOnClusterReady()


### PR DESCRIPTION
Tighten deny clauses for JetStream over leafnodes when separating domains.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #2402 (for now)

/cc @nats-io/core
