### PR TITLE
[CHANGED] Check that max_payload is not greater than max_pending

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -68,6 +68,11 @@ const (
 	// something different if > 1MB payloads are needed.
 	MAX_PAYLOAD_SIZE = (1024 * 1024)
 
+	// MAX_PAYLOAD_MAX_SIZE is the size at which the server will warn about
+	// max_payload being too high. In the future, the server may enforce/reject
+	// max_payload above this value.
+	MAX_PAYLOAD_MAX_SIZE = (8 * 1024 * 1024)
+
 	// MAX_PENDING_SIZE is the maximum outbound pending bytes per client.
 	MAX_PENDING_SIZE = (64 * 1024 * 1024)
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -841,7 +841,7 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 		}
 		o.MaxControlLine = int32(v.(int64))
 	case "max_payload":
-		if v.(int64) > 64*1024*1024 {
+		if v.(int64) > 1<<31-1 {
 			err := &configErr{tk, fmt.Sprintf("%s value is too big", k)}
 			*errors = append(*errors, err)
 			return

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -2578,16 +2578,26 @@ func TestLargeMaxControlLine(t *testing.T) {
 }
 
 func TestLargeMaxPayload(t *testing.T) {
-	confFileName := "big_mp.conf"
+	confFileName := createConfFile(t, []byte(`
+		max_payload = 3000000000
+	`))
 	defer removeFile(t, confFileName)
-	content := `
-    max_payload = 3000000000
-    `
-	if err := ioutil.WriteFile(confFileName, []byte(content), 0666); err != nil {
-		t.Fatalf("Error writing config file: %v", err)
-	}
 	if _, err := ProcessConfigFile(confFileName); err == nil {
 		t.Fatalf("Expected an error from too large of a max_payload entry")
+	}
+
+	confFileName = createConfFile(t, []byte(`
+		max_payload = 100000
+		max_pending = 50000
+	`))
+	defer removeFile(t, confFileName)
+	o := LoadConfig(confFileName)
+	s, err := NewServer(o)
+	if err == nil || !strings.Contains(err.Error(), "cannot be higher") {
+		if s != nil {
+			s.Shutdown()
+		}
+		t.Fatalf("Unexpected error: %v", err)
 	}
 }
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1029,6 +1029,7 @@ func TestRoutePermsAppliedOnInboundAndOutboundRoute(t *testing.T) {
 
 func TestRouteSendLocalSubsWithLowMaxPending(t *testing.T) {
 	optsA := DefaultOptions()
+	optsA.MaxPayload = 1024
 	optsA.MaxPending = 1024
 	optsA.NoSystemAccount = true
 	srvA := RunServer(optsA)

--- a/server/server.go
+++ b/server/server.go
@@ -1549,7 +1549,8 @@ func (s *Server) Start() {
 		s.Warnf("Trusted Operators should utilize a System Account")
 	}
 	if opts.MaxPayload > MAX_PAYLOAD_MAX_SIZE {
-		s.Warnf("Maximum payloads over 8MB are generally discouraged and could lead to poor performance")
+		s.Warnf("Maximum payloads over %v are generally discouraged and could lead to poor performance",
+			friendlyBytes(int64(MAX_PAYLOAD_MAX_SIZE)))
 	}
 
 	// If we have a memory resolver, check the accounts here for validation exceptions.

--- a/server/server.go
+++ b/server/server.go
@@ -599,6 +599,10 @@ func validateOptions(o *Options) error {
 		return fmt.Errorf("lame duck grace period (%v) should be strictly lower than lame duck duration (%v)",
 			o.LameDuckGracePeriod, o.LameDuckDuration)
 	}
+	if int64(o.MaxPayload) > o.MaxPending {
+		return fmt.Errorf("max_payload (%v) cannot be higher than max_pending (%v)",
+			o.MaxPayload, o.MaxPending)
+	}
 	// Check that the trust configuration is correct.
 	if err := validateTrustedOperators(o); err != nil {
 		return err

--- a/server/server.go
+++ b/server/server.go
@@ -1548,6 +1548,9 @@ func (s *Server) Start() {
 	if hasOperators && opts.SystemAccount == _EMPTY_ {
 		s.Warnf("Trusted Operators should utilize a System Account")
 	}
+	if opts.MaxPayload > MAX_PAYLOAD_MAX_SIZE {
+		s.Warnf("Maximum payloads over 8MB are generally discouraged and could lead to poor performance")
+	}
 
 	// If we have a memory resolver, check the accounts here for validation exceptions.
 	// This allows them to be logged right away vs when they are accessed via a client.


### PR DESCRIPTION
This is related to PR #2407. Since the 64MB pending size is actually
configurable, we should fail only if max_payload is greater than
the configured max_pending. This is done in validateOptions() which
covers both config file and direct options in embedded cases.
The check in opts.go is reverted to max int32 since at this point
we don't know if/what max_pending will be, so we simply check
that it is not more than a int32.

For the next minor release, we could have another change that
imposes a lower limit to max_payload (regardless if max_pending
is higher).

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

/cc @nats-io/core
