### PR TITLE
assign default to MaxAckPending when AckExplicit -or- AckAll

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -351,7 +351,7 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 		config.MaxDeliver = -1
 	}
 	// Set proper default for max ack pending if we are ack explicit and none has been set.
-	if config.AckPolicy == AckExplicit && config.MaxAckPending == 0 {
+	if (config.AckPolicy == AckExplicit || config.AckPolicy == AckAll) && config.MaxAckPending == 0 {
 		config.MaxAckPending = JsDefaultMaxAckPending
 	}
 


### PR DESCRIPTION
 - [ ] Tests added
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Explicitly sets MaxAckPending when not supplied to AckExplicit or AckAll, not just AckExplicit

/cc @nats-io/core
