### PR TITLE
JetStream additions

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -11801,10 +11801,6 @@ func TestJetStreamDomainInPubAck(t *testing.T) {
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
-	if !s.JetStreamEnabled() {
-		t.Fatalf("Expected JetStream to be enabled")
-	}
-
 	config := s.JetStreamConfig()
 	if config != nil {
 		defer removeDir(t, config.StoreDir)
@@ -11814,10 +11810,9 @@ func TestJetStreamDomainInPubAck(t *testing.T) {
 	defer nc.Close()
 
 	cfg := &nats.StreamConfig{
-		Name:         "TEST",
-		Storage:      nats.MemoryStorage,
-		Subjects:     []string{"foo"},
-		MaxConsumers: 1,
+		Name:     "TEST",
+		Storage:  nats.MemoryStorage,
+		Subjects: []string{"foo"},
 	}
 	if _, err := js.AddStream(cfg); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -11832,6 +11827,106 @@ func TestJetStreamDomainInPubAck(t *testing.T) {
 	json.Unmarshal(am.Data, &pa)
 	if pa.Domain != "HUB" {
 		t.Fatalf("Expected PubAck to have domain of %q, got %q", "HUB", pa.Domain)
+	}
+}
+
+func TestJetStreamPushConsumerInfo(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	defer s.Shutdown()
+
+	config := s.JetStreamConfig()
+	if config != nil {
+		defer removeDir(t, config.StoreDir)
+	}
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{
+		Name:     "TEST",
+		Storage:  nats.MemoryStorage,
+		Subjects: []string{"foo"},
+	}
+	if _, err := js.AddStream(cfg); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// We want to test extended consumer info for push based consumers.
+	// We need to do these by hand for now.
+	createConsumer := func(name, deliver string) {
+		t.Helper()
+		creq := CreateConsumerRequest{
+			Stream: "TEST",
+			Config: ConsumerConfig{
+				Durable:        name,
+				DeliverSubject: deliver,
+			},
+		}
+		req, err := json.Marshal(creq)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		resp, err := nc.Request(fmt.Sprintf(JSApiDurableCreateT, "TEST", name), req, time.Second)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		var ccResp JSApiConsumerCreateResponse
+		if err := json.Unmarshal(resp.Data, &ccResp); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if ccResp.ConsumerInfo == nil || ccResp.Error != nil {
+			t.Fatalf("Got a bad response %+v", ccResp)
+		}
+	}
+
+	consumerInfo := func(name string) *ConsumerInfo {
+		t.Helper()
+		resp, err := nc.Request(fmt.Sprintf(JSApiConsumerInfoT, "TEST", name), nil, time.Second)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		var cinfo JSApiConsumerInfoResponse
+		if err := json.Unmarshal(resp.Data, &cinfo); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if cinfo.ConsumerInfo == nil || cinfo.Error != nil {
+			t.Fatalf("Got a bad response %+v", cinfo)
+		}
+		return cinfo.ConsumerInfo
+	}
+
+	// First create a durable push and make sure we show now active status.
+	createConsumer("dlc", "d.X")
+	if ci := consumerInfo("dlc"); ci.Active != nil {
+		t.Fatalf("Expected active to be nil, got %+v\n", ci.Active)
+	}
+	// Now bind the deliver subject.
+	sub, _ := nc.SubscribeSync("d.X")
+	nc.Flush() // Make sure it registers.
+	// Check that its reported.
+	if ci := consumerInfo("dlc"); ci.Active == nil || ci.Active.Subject != "d.X" {
+		t.Fatalf("Expected active to be set and have subject %q, got %+v\n", "d.X", ci.Active)
+	}
+	sub.Unsubscribe()
+	nc.Flush() // Make sure it registers.
+	if ci := consumerInfo("dlc"); ci.Active != nil {
+		t.Fatalf("Expected active to be nil, got %+v\n", ci.Active)
+	}
+
+	// Now make sure we have queue groups indictated as needed.
+	createConsumer("ik", "d.Z")
+	// Now bind the deliver subject with a queue group.
+	sub, _ = nc.QueueSubscribeSync("d.Z", "g22")
+	defer sub.Unsubscribe()
+	nc.Flush() // Make sure it registers.
+	// Check that queue group reported.
+	if ci := consumerInfo("ik"); ci.Active == nil || ci.Active.Subject != "d.Z" || ci.Active.Queue != "g22" {
+		t.Fatalf("Expected active to be set and have subject %q and queue %q, got %+v\n", "d.Z", "g22", ci.Active)
+	}
+	sub.Unsubscribe()
+	nc.Flush() // Make sure it registers.
+	if ci := consumerInfo("ik"); ci.Active != nil {
+		t.Fatalf("Expected active to be nil, got %+v\n", ci.Active)
 	}
 }
 


### PR DESCRIPTION
This adds two items.

1. Domain information for PubAcks.
2. Active state for push consumers that details active subject and optionally queue group.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
