### PR TITLE
Made test more predictable by waiting for leader after leader shutdown

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -1975,6 +1975,7 @@ func TestNoRaceJetStreamClusterMirrorExpirationAndMissingSequences(t *testing.T)
 	// Now shutdown the server with the mirror.
 	ms := c.streamLeader("$G", "M")
 	ms.Shutdown()
+	c.waitOnLeader()
 
 	// Send more messages but let them expire.
 	sendBatch(10)


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>
 
saw this in travis
```
=== RUN   TestNoRaceJetStreamClusterMirrorExpirationAndMissingSequences
    norace_test.go:1980: Unexpected publish error: nats: timeout
--- FAIL: TestNoRaceJetStreamClusterMirrorExpirationAndMissingSequences (11.75s)
```