### PR TITLE
Fixed a leak of internal clients for JetStream consumers.

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4701,7 +4701,7 @@ func (c *client) closeConnection(reason ClosedState) {
 		srv.removeClient(c)
 
 		// Update remote subscriptions.
-		if acc != nil && (kind == CLIENT || kind == LEAF) {
+		if acc != nil && (kind == CLIENT || kind == LEAF || kind == JETSTREAM) {
 			qsubs := map[string]*qsub{}
 			for _, sub := range subs {
 				// Call unsubscribe here to cleanup shadow subscriptions and such.

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -2695,6 +2695,8 @@ func TestNoRaceJetStreamClusterExtendedStreamPurge(t *testing.T) {
 			js.DeleteStream("KV")
 			// Do manually for now.
 			nc.Request(fmt.Sprintf(JSApiStreamCreateT, cfg.Name), req, time.Second)
+			c.waitOnStreamLeader("$G", "KV")
+
 			if _, err := js.StreamInfo("KV"); err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}


### PR DESCRIPTION
We were not properly unregistering from the account on cleanup.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
