### PR TITLE
[FIXED] LeafNode with "wss://.." url was not always initiating TLS

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1384,3 +1384,7 @@ func (c *client) wsCollapsePtoNB() (net.Buffers, int64) {
 func isWSURL(u *url.URL) bool {
 	return strings.HasPrefix(strings.ToLower(u.Scheme), wsSchemePrefix)
 }
+
+func isWSSURL(u *url.URL) bool {
+	return strings.HasPrefix(strings.ToLower(u.Scheme), wsSchemePrefixTLS)
+}


### PR DESCRIPTION
If the remote did not have any TLS configuration, the URL scheme
"wss://" was not used as the indicating that the connection should
be attempted as a TLS connection, causing "invalid websocket connection"
in the server attempting to create the remote leafnode connection.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
