### PR TITLE
[IMPROVED] Make error actionable when adding operator+leafnodes

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -276,7 +276,10 @@ func validateLeafNode(o *Options) error {
 		}
 		for _, r := range o.LeafNode.Remotes {
 			if !nkeys.IsValidPublicAccountKey(r.LocalAccount) {
-				return fmt.Errorf("operator mode requires account nkeys in remotes")
+				return fmt.Errorf(
+					"operator mode requires account nkeys in remotes. " +
+						"Please add an `account` key to each remote in your `leafnodes` section, to assign it to an account. " +
+						"Each account value should be a 56 character public key, starting with the letter 'A'")
 			}
 		}
 		if o.LeafNode.Port != 0 && o.LeafNode.Account != "" && !nkeys.IsValidPublicAccountKey(o.LeafNode.Account) {

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -2483,7 +2483,9 @@ func TestLeafNodeOperatorBadCfg(t *testing.T) {
 			authorization {
 				account: notankey
 			}`,
-		`operator mode requires account nkeys in remotes`: `remotes: [{url: u}]`,
+		("operator mode requires account nkeys in remotes. " +
+			"Please add an `account` key to each remote in your `leafnodes` section, to assign it to an account. " +
+			"Each account value should be a 56 character public key, starting with the letter 'A'"): `remotes: [{url: u}]`,
 	} {
 		t.Run(errorText, func(t *testing.T) {
 			conf := createConfFile(t, []byte(fmt.Sprintf(`


### PR DESCRIPTION
There are many examples in the documentation for one half of this configuration or the other,
but none which configure a leafnode remote on an operator-authenticated cluster.

The error "operator mode requires account nkeys in remotes." is not very clear or actionable.
It was only chance googling that led us to https://github.com/nats-io/k8s/pull/286 and gave us a hint about what we needed to do.

 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

/cc @nats-io/core
