### PR TITLE
Added test for system account update as well

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2959,8 +2959,12 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 		a.RemoveMapping(rmMapping)
 	}
 
-	// Re-register system imports.
-	s.registerSystemImports(a)
+	// Re-register system exports/imports.
+	if a == s.SystemAccount() {
+		s.addSystemAccountExports(a)
+	} else {
+		s.registerSystemImports(a)
+	}
 
 	gatherClients := func() []*client {
 		a.mu.RLock()


### PR DESCRIPTION
Updating the system account could wipe the account connz export.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
