### PR TITLE
[added] operator option to ensure user are signed by certain accounts

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/nats-io/jwt/v2"
@@ -591,7 +592,8 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 		}
 		if pinnedAcounts != nil {
 			if _, ok := pinnedAcounts[issuer]; !ok {
-				c.Debugf("Account not listed as operator pinned account")
+				c.Debugf("Account %s not listed as operator pinned account", issuer)
+				atomic.AddUint64(&s.pinnedAccFail, 1)
 				return false
 			}
 		}

--- a/server/auth.go
+++ b/server/auth.go
@@ -393,10 +393,11 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 		return true
 	}
 	var (
-		username   string
-		password   string
-		token      string
-		noAuthUser string
+		username      string
+		password      string
+		token         string
+		noAuthUser    string
+		pinnedAcounts map[string]struct{}
 	)
 	tlsMap := opts.TLSMap
 	if c.kind == CLIENT {
@@ -441,7 +442,7 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 
 	// Check if we have trustedKeys defined in the server. If so we require a user jwt.
 	if s.trustedKeys != nil {
-		if c.opts.JWT == "" {
+		if c.opts.JWT == _EMPTY_ {
 			s.mu.Unlock()
 			c.Debugf("Authentication requires a user JWT")
 			return false
@@ -460,12 +461,13 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			c.Debugf("User JWT no longer valid: %+v", vr)
 			return false
 		}
+		pinnedAcounts = opts.resolverPinnedAccounts
 	}
 
 	// Check if we have nkeys or users for client.
 	hasNkeys := len(s.nkeys) > 0
 	hasUsers := len(s.users) > 0
-	if hasNkeys && c.opts.Nkey != "" {
+	if hasNkeys && c.opts.Nkey != _EMPTY_ {
 		nkey, ok = s.nkeys[c.opts.Nkey]
 		if !ok || !c.connectionTypeAllowed(nkey.AllowedConnectionTypes) {
 			s.mu.Unlock()
@@ -477,17 +479,17 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			authorized := checkClientTLSCertSubject(c, func(u string, certDN *ldap.DN, _ bool) (string, bool) {
 				// First do literal lookup using the resulting string representation
 				// of RDNSequence as implemented by the pkix package from Go.
-				if u != "" {
+				if u != _EMPTY_ {
 					usr, ok := s.users[u]
 					if !ok || !c.connectionTypeAllowed(usr.AllowedConnectionTypes) {
-						return "", ok
+						return _EMPTY_, ok
 					}
 					user = usr
 					return usr.Username, ok
 				}
 
 				if certDN == nil {
-					return "", false
+					return _EMPTY_, false
 				}
 
 				// Look through the accounts for a DN that is equal to the one
@@ -520,13 +522,13 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 						return usr.Username, true
 					}
 				}
-				return "", false
+				return _EMPTY_, false
 			})
 			if !authorized {
 				s.mu.Unlock()
 				return false
 			}
-			if c.opts.Username != "" {
+			if c.opts.Username != _EMPTY_ {
 				s.Warnf("User %q found in connect proto, but user required from cert", c.opts.Username)
 			}
 			// Already checked that the client didn't send a user in connect
@@ -584,8 +586,14 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			return false
 		}
 		issuer := juc.Issuer
-		if juc.IssuerAccount != "" {
+		if juc.IssuerAccount != _EMPTY_ {
 			issuer = juc.IssuerAccount
+		}
+		if pinnedAcounts != nil {
+			if _, ok := pinnedAcounts[issuer]; !ok {
+				c.Debugf("Account not listed as operator pinned account")
+				return false
+			}
 		}
 		if acc, err = s.LookupAccount(issuer); acc == nil {
 			c.Debugf("Account JWT lookup error: %v", err)
@@ -617,7 +625,7 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 		// FIXME: if BearerToken is only for WSS, need check for server with that port enabled
 		if !juc.BearerToken {
 			// Verify the signature against the nonce.
-			if c.opts.Sig == "" {
+			if c.opts.Sig == _EMPTY_ {
 				c.Debugf("Signature missing")
 				return false
 			}
@@ -677,7 +685,7 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 	}
 
 	if nkey != nil {
-		if c.opts.Sig == "" {
+		if c.opts.Sig == _EMPTY_ {
 			c.Debugf("Signature missing")
 			return false
 		}
@@ -715,9 +723,9 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 	}
 
 	if c.kind == CLIENT {
-		if token != "" {
+		if token != _EMPTY_ {
 			return comparePasswords(token, c.opts.Token)
-		} else if username != "" {
+		} else if username != _EMPTY_ {
 			if username != c.opts.Username {
 				return false
 			}

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -144,6 +144,17 @@ func validateTrustedOperators(o *Options) error {
 			return fmt.Errorf("trusted Keys %q are required to be a valid public operator nkey", key)
 		}
 	}
+	if len(o.resolverPinnedAccounts) > 0 {
+		for key := range o.resolverPinnedAccounts {
+			if !nkeys.IsValidPublicAccountKey(key) {
+				return fmt.Errorf("pinned account key %q is not a valid public account nkey", key)
+			}
+		}
+		// ensure the system account (belonging to the operator can always connect)
+		if o.SystemAccount != _EMPTY_ {
+			o.resolverPinnedAccounts[o.SystemAccount] = struct{}{}
+		}
+	}
 	return nil
 }
 

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1119,6 +1119,7 @@ type Varz struct {
 	TrustedOperatorsJwt   []string              `json:"trusted_operators_jwt,omitempty"`
 	TrustedOperatorsClaim []*jwt.OperatorClaims `json:"trusted_operators_claim,omitempty"`
 	SystemAccount         string                `json:"system_account,omitempty"`
+	PinnedAccountFail     uint64                `json:"pinned_account_fails,omitempty"`
 }
 
 // JetStreamVarz contains basic runtime information about jetstream
@@ -1455,6 +1456,7 @@ func (s *Server) updateVarzRuntimeFields(v *Varz, forceUpdate bool, pcpu float64
 	v.OutMsgs = atomic.LoadInt64(&s.outMsgs)
 	v.OutBytes = atomic.LoadInt64(&s.outBytes)
 	v.SlowConsumers = atomic.LoadInt64(&s.slowConsumers)
+	v.PinnedAccountFail = atomic.LoadUint64(&s.pinnedAccFail)
 
 	// Make sure to reset in case we are re-using.
 	v.Subscriptions = 0

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -3200,3 +3200,26 @@ func TestQueuePermissions(t *testing.T) {
 
 	}
 }
+
+func TestResolverPinnedAccountsFail(t *testing.T) {
+	cfgFmt := `
+		operator: %s
+		resolver: URL(foo.bar)
+		resolver_pinned_accounts: [%s]
+	`
+	dirSrv := createDir(t, "srv")
+	defer removeDir(t, dirSrv)
+
+	conf := createConfFile(t, []byte(fmt.Sprintf(cfgFmt, ojwt, "f")))
+	defer removeFile(t, conf)
+	srv, err := NewServer(LoadConfig(conf))
+	defer srv.Shutdown()
+	require_Error(t, err)
+	require_Contains(t, err.Error(), " is not a valid public account nkey")
+
+	conf = createConfFile(t, []byte(fmt.Sprintf(cfgFmt, ojwt, "1, x")))
+	defer removeFile(t, conf)
+	_, err = ProcessConfigFile(conf)
+	require_Error(t, err)
+	require_Contains(t, "parsing resolver_pinned_accounts: unsupported type")
+}

--- a/server/server.go
+++ b/server/server.go
@@ -262,6 +262,9 @@ type Server struct {
 	// the server will create a fake user and add it to the list of users.
 	// Keep track of what that user name is for config reload purposes.
 	sysAccOnlyNoAuthUser string
+
+	// How often user logon fails due to the issuer account not being pinned.
+	pinnedAccFail uint64
 }
 
 // For tracking JS nodes.


### PR DESCRIPTION
option name: resolver_pinned_accounts
Contains a list of public account nkeys.
Connecting user of leaf nodes need to be signed by this.
The system account will always be able to connect.

Signed-off-by: Matthias Hanel <mh@synadia.com>
