### PR TITLE
[CHANGED] ConsumerInfo's SequencePair replaced with SequenceInfo

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -37,8 +37,8 @@ type ConsumerInfo struct {
 	Name           string          `json:"name"`
 	Created        time.Time       `json:"created"`
 	Config         *ConsumerConfig `json:"config,omitempty"`
-	Delivered      SequencePair    `json:"delivered"`
-	AckFloor       SequencePair    `json:"ack_floor"`
+	Delivered      SequenceInfo    `json:"delivered"`
+	AckFloor       SequenceInfo    `json:"ack_floor"`
 	NumAckPending  int             `json:"num_ack_pending"`
 	NumRedelivered int             `json:"num_redelivered"`
 	NumWaiting     int             `json:"num_waiting"`
@@ -69,6 +69,13 @@ type ConsumerConfig struct {
 
 	// Don't add to general clients.
 	Direct bool `json:"direct,omitempty"`
+}
+
+// SequenceInfo has both the consumer and the stream sequence and last activity.
+type SequenceInfo struct {
+	Consumer uint64     `json:"consumer_seq"`
+	Stream   uint64     `json:"stream_seq"`
+	Last     *time.Time `json:"last_active,omitempty"`
 }
 
 type CreateConsumerRequest struct {
@@ -1494,11 +1501,11 @@ func (o *consumer) info() *ConsumerInfo {
 		Name:    o.name,
 		Created: o.created,
 		Config:  &cfg,
-		Delivered: SequencePair{
+		Delivered: SequenceInfo{
 			Consumer: o.dseq - 1,
 			Stream:   o.sseq - 1,
 		},
-		AckFloor: SequencePair{
+		AckFloor: SequenceInfo{
 			Consumer: o.adflr,
 			Stream:   o.asflr,
 		},

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -2499,7 +2499,7 @@ func TestFileStoreConsumerDeliveredUpdates(t *testing.T) {
 		if state == nil {
 			t.Fatalf("No state available")
 		}
-		expected := SequencePair{dseq, sseq, nil}
+		expected := SequencePair{dseq, sseq}
 		if state.Delivered != expected {
 			t.Fatalf("Unexpected state, wanted %+v, got %+v", expected, state.Delivered)
 		}
@@ -2560,7 +2560,7 @@ func TestFileStoreConsumerDeliveredAndAckUpdates(t *testing.T) {
 		if state == nil {
 			t.Fatalf("No state available")
 		}
-		expected := SequencePair{dseq, sseq, nil}
+		expected := SequencePair{dseq, sseq}
 		if state.Delivered != expected {
 			t.Fatalf("Unexpected delivered state, wanted %+v, got %+v", expected, state.Delivered)
 		}
@@ -2600,7 +2600,7 @@ func TestFileStoreConsumerDeliveredAndAckUpdates(t *testing.T) {
 		if len(state.Pending) != pending {
 			t.Fatalf("Expected %d pending, got %d pending", pending, len(state.Pending))
 		}
-		eflr := SequencePair{dflr, sflr, nil}
+		eflr := SequencePair{dflr, sflr}
 		if state.AckFloor != eflr {
 			t.Fatalf("Unexpected ack floor state, wanted %+v, got %+v", eflr, state.AckFloor)
 		}

--- a/server/store.go
+++ b/server/store.go
@@ -163,9 +163,8 @@ type ConsumerStore interface {
 
 // SequencePair has both the consumer and the stream sequence. They point to same message.
 type SequencePair struct {
-	Consumer uint64     `json:"consumer_seq"`
-	Stream   uint64     `json:"stream_seq"`
-	Last     *time.Time `json:"last_active,omitempty"`
+	Consumer uint64 `json:"consumer_seq"`
+	Stream   uint64 `json:"stream_seq"`
 }
 
 // ConsumerState represents a stored state for a consumer.


### PR DESCRIPTION
This change was made in a previous PR wit this commit:
https://github.com/nats-io/nats-server/pull/2438/commits/9405b77e464dccf3be051b8c750a2354a088c5df

After some discussions, we agreed that the original approach
is best, so using a dedicated object SequenceInfo for ConsumerInfo.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
