### PR TITLE
Do not use crypto rand for nonce generation.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -35,6 +35,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	mrand "math/rand"
+
 	"github.com/klauspost/compress/s2"
 	"github.com/minio/highwayhash"
 	"golang.org/x/crypto/chacha20"
@@ -420,7 +422,7 @@ func (fs *fileStore) genEncryptionKeys(context string) (aek cipher.AEAD, bek *ch
 
 	// Generate our nonce. Use same buffer to hold encrypted seed.
 	nonce := make([]byte, kek.NonceSize(), kek.NonceSize()+len(seed)+kek.Overhead())
-	rand.Read(nonce)
+	mrand.Read(nonce)
 	bek, err = chacha20.NewUnauthenticatedCipher(seed[:], nonce)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -458,7 +460,7 @@ func (fs *fileStore) writeStreamMeta() error {
 	// Encrypt if needed.
 	if fs.aek != nil {
 		nonce := make([]byte, fs.aek.NonceSize(), fs.aek.NonceSize()+len(b)+fs.aek.Overhead())
-		rand.Read(nonce)
+		mrand.Read(nonce)
 		b = fs.aek.Seal(nonce, nonce, b, nil)
 	}
 
@@ -2129,7 +2131,7 @@ func (mb *msgBlock) eraseMsg(seq uint64, ri, rl int) error {
 
 	// Randomize record
 	data := make([]byte, rl-emptyRecordLen)
-	rand.Read(data)
+	mrand.Read(data)
 
 	// Now write to underlying buffer.
 	var b bytes.Buffer
@@ -5010,7 +5012,7 @@ func (o *consumerFileStore) encryptState(buf []byte) []byte {
 	}
 	// TODO(dlc) - Optimize on space usage a bit?
 	nonce := make([]byte, o.aek.NonceSize(), o.aek.NonceSize()+len(buf)+o.aek.Overhead())
-	rand.Read(nonce)
+	mrand.Read(nonce)
 	return o.aek.Seal(nonce, nonce, buf, nil)
 }
 
@@ -5084,7 +5086,7 @@ func (cfs *consumerFileStore) writeConsumerMeta() error {
 	// Encrypt if needed.
 	if cfs.aek != nil {
 		nonce := make([]byte, cfs.aek.NonceSize(), cfs.aek.NonceSize()+len(b)+cfs.aek.Overhead())
-		rand.Read(nonce)
+		mrand.Read(nonce)
 		b = cfs.aek.Seal(nonce, nonce, b, nil)
 	}
 


### PR DESCRIPTION
Crypto rand is not needed for nonce generation and could drain entropy.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
