### PR TITLE
Fix 2445 / build on OpenBSD-6.9

### DIFF
--- a/server/disk_avail.go
+++ b/server/disk_avail.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows 
+// +build !windows
 // +build !openbsd
 
 package server

--- a/server/disk_avail_openbsd.go
+++ b/server/disk_avail_openbsd.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The NATS Authors
+// Copyright 2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build openbsd 
+// +build openbsd
 
 package server
 


### PR DESCRIPTION
 - [X] Link to issue, e.g. `Resolves #2445`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [ ] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

syscalls on OpenBSD look different then on other OSes.
The needed fields to get the available discspace are `F_bavail` and `F_bsize` on OpenBSD.
It's a a quite dirty build-fix that needs some refactoring. Why not refactor right now:
Golang has a different way to do build-constraints with the just released golang-1.17.
( “// +build” vs.  “//go:build”)

imo this crossplattform problems should be sorted out when golang-1.9 settles and project-wide plan how to solve multi-plattform-issues is discussed.

The complete nats-server builds and runs fine with this PR on OpenBSD-6.9

### Changes proposed in this pull request:

 - add correct syscalls for OpenBSD
 - do one more build-constraint in server/disk-avail.go
 
/cc @nats-io/core
