### PR TITLE
Enable global account on non-js servers in mixed mode.

### DIFF
--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1604,7 +1604,7 @@ func TestSystemAccountWithGateways(t *testing.T) {
 
 	// If this tests fails with wrong number after 10 seconds we may have
 	// added a new inititial subscription for the eventing system.
-	checkExpectedSubs(t, 39, sa)
+	checkExpectedSubs(t, 40, sa)
 
 	// Create a client on B and see if we receive the event
 	urlb := fmt.Sprintf("nats://%s:%d", ob.Host, ob.Port)

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -906,6 +906,10 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 		return fmt.Errorf("jetstream account not registered")
 	}
 
+	if s.SystemAccount() == a {
+		return fmt.Errorf("jetstream can not be enabled on the system account")
+	}
+
 	s.mu.Lock()
 	sendq := s.sys.sendq
 	s.mu.Unlock()
@@ -922,13 +926,6 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 		return NewJSNotEnabledError()
 	}
 
-	if s.SystemAccount() == a {
-		return fmt.Errorf("jetstream can not be enabled on the system account")
-	}
-
-	if limits == nil {
-		limits = dynamicJSAccountLimits
-	}
 	a.assignJetStreamLimits(limits)
 
 	js.mu.Lock()

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1286,7 +1286,7 @@ func TestLeafNodePermissions(t *testing.T) {
 	// Create a sub on ">" on LN1
 	subAll := natsSubSync(t, nc1, ">")
 	// this should be registered in LN2 (there is 1 sub for LN1 $LDS subject) + SYS IMPORTS
-	checkSubs(ln2.globalAccount(), 6)
+	checkSubs(ln2.globalAccount(), 8)
 
 	// Check deny export clause from messages published from LN2
 	for _, test := range []struct {
@@ -1313,7 +1313,7 @@ func TestLeafNodePermissions(t *testing.T) {
 
 	subAll.Unsubscribe()
 	// Goes down by 1.
-	checkSubs(ln2.globalAccount(), 5)
+	checkSubs(ln2.globalAccount(), 7)
 
 	// We used to make sure we would not do subscriptions however that
 	// was incorrect. We need to check publishes, not the subscriptions.
@@ -1338,7 +1338,7 @@ func TestLeafNodePermissions(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			sub := natsSubSync(t, nc2, test.subSubject)
-			checkSubs(ln2.globalAccount(), 6)
+			checkSubs(ln2.globalAccount(), 8)
 
 			if !test.ok {
 				nc1.Publish(test.pubSubject, []byte("msg"))
@@ -1346,13 +1346,12 @@ func TestLeafNodePermissions(t *testing.T) {
 					t.Fatalf("Did not expect to get the message")
 				}
 			} else {
-				checkSubs(ln1.globalAccount(), 6)
+				checkSubs(ln1.globalAccount(), 7)
 				nc1.Publish(test.pubSubject, []byte("msg"))
 				natsNexMsg(t, sub, time.Second)
 			}
 			sub.Unsubscribe()
-			checkSubs(ln1.globalAccount(), 5)
-
+			checkSubs(ln1.globalAccount(), 6)
 		})
 	}
 }
@@ -1472,8 +1471,8 @@ func TestLeafNodeExportPermissionsNotForSpecialSubs(t *testing.T) {
 	// The deny is totally restrictive, but make sure that we still accept the $LDS, $GR and _GR_ go from LN1.
 	checkFor(t, time.Second, 15*time.Millisecond, func() error {
 		// We should have registered the 3 subs from the accepting leafnode.
-		if n := ln2.globalAccount().TotalSubs(); n != 5 {
-			return fmt.Errorf("Expected %d subs, got %v", 5, n)
+		if n := ln2.globalAccount().TotalSubs(); n != 7 {
+			return fmt.Errorf("Expected %d subs, got %v", 7, n)
 		}
 		return nil
 	})
@@ -3320,8 +3319,8 @@ func TestLeafNodeRouteSubWithOrigin(t *testing.T) {
 	r1.Shutdown()
 	checkFor(t, time.Second, 15*time.Millisecond, func() error {
 		acc := l2.GlobalAccount()
-		if n := acc.TotalSubs(); n != 2 {
-			return fmt.Errorf("Account %q should have 2 subs, got %v", acc.GetName(), n)
+		if n := acc.TotalSubs(); n != 3 {
+			return fmt.Errorf("Account %q should have 3 subs, got %v", acc.GetName(), n)
 		}
 		return nil
 	})

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1095,7 +1095,7 @@ func TestRouteNoCrashOnAddingSubToRoute(t *testing.T) {
 
 	// Make sure all subs are registered in s.
 	checkFor(t, time.Second, 15*time.Millisecond, func() error {
-		if ts := s.globalAccount().TotalSubs() - 2; ts != int(numRoutes) {
+		if ts := s.globalAccount().TotalSubs() - 3; ts != int(numRoutes) {
 			return fmt.Errorf("Not all %d routed subs were registered: %d", numRoutes, ts)
 		}
 		return nil

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -440,7 +440,7 @@ func TestLeafNodeAndRoutes(t *testing.T) {
 	lc := createLeafConn(t, optsA.LeafNode.Host, optsA.LeafNode.Port)
 	defer lc.Close()
 
-	leafSend, leafExpect := setupLeaf(t, lc, 3)
+	leafSend, leafExpect := setupLeaf(t, lc, 4)
 	leafSend("PING\r\n")
 	leafExpect(pongRe)
 
@@ -834,7 +834,7 @@ func TestLeafNodeGatewaySendsSystemEvent(t *testing.T) {
 	defer lc.Close()
 
 	// This is for our global responses since we are setting up GWs above.
-	leafSend, leafExpect := setupLeaf(t, lc, 5)
+	leafSend, leafExpect := setupLeaf(t, lc, 6)
 	leafSend("PING\r\n")
 	leafExpect(pongRe)
 
@@ -878,14 +878,14 @@ func TestLeafNodeGatewayInterestPropagation(t *testing.T) {
 	buf := leafExpect(infoRe)
 	buf = infoRe.ReplaceAll(buf, []byte(nil))
 	foundFoo := false
-	for count := 0; count != 7; {
+	for count := 0; count != 8; {
 		// skip first time if we still have data (buf from above may already have some left)
 		if count != 0 || len(buf) == 0 {
 			buf = append(buf, leafExpect(anyRe)...)
 		}
 		count += len(lsubRe.FindAllSubmatch(buf, -1))
-		if count > 7 {
-			t.Fatalf("Expected %v matches, got %v (buf=%s)", 7, count, buf)
+		if count > 8 {
+			t.Fatalf("Expected %v matches, got %v (buf=%s)", 8, count, buf)
 		}
 		if strings.Contains(string(buf), "foo") {
 			foundFoo = true
@@ -937,7 +937,7 @@ func TestLeafNodeWithRouteAndGateway(t *testing.T) {
 	defer lc.Close()
 
 	// This is for our global responses since we are setting up GWs above.
-	leafSend, leafExpect := setupLeaf(t, lc, 5)
+	leafSend, leafExpect := setupLeaf(t, lc, 6)
 	leafSend("PING\r\n")
 	leafExpect(pongRe)
 
@@ -996,7 +996,7 @@ func TestLeafNodeWithGatewaysAndStaggeredStart(t *testing.T) {
 	lc := createLeafConn(t, opts.LeafNode.Host, opts.LeafNode.Port)
 	defer lc.Close()
 
-	leafSend, leafExpect := setupLeaf(t, lc, 5)
+	leafSend, leafExpect := setupLeaf(t, lc, 6)
 	leafSend("PING\r\n")
 	leafExpect(pongRe)
 
@@ -1036,7 +1036,7 @@ func TestLeafNodeWithGatewaysServerRestart(t *testing.T) {
 	lc := createLeafConn(t, opts.LeafNode.Host, opts.LeafNode.Port)
 	defer lc.Close()
 
-	leafSend, leafExpect := setupLeaf(t, lc, 5)
+	leafSend, leafExpect := setupLeaf(t, lc, 6)
 	leafSend("PING\r\n")
 	leafExpect(pongRe)
 
@@ -1070,7 +1070,7 @@ func TestLeafNodeWithGatewaysServerRestart(t *testing.T) {
 	lc = createLeafConn(t, opts.LeafNode.Host, opts.LeafNode.Port)
 	defer lc.Close()
 
-	_, leafExpect = setupLeaf(t, lc, 5)
+	_, leafExpect = setupLeaf(t, lc, 6)
 
 	// Now wait on GW solicit to fire
 	time.Sleep(500 * time.Millisecond)
@@ -2659,7 +2659,7 @@ func TestLeafNodeSwitchGatewayToInterestModeOnly(t *testing.T) {
 	defer lc.Close()
 
 	// This is for our global responses since we are setting up GWs above.
-	leafSend, leafExpect := setupLeaf(t, lc, 5)
+	leafSend, leafExpect := setupLeaf(t, lc, 6)
 	leafSend("PING\r\n")
 	leafExpect(pongRe)
 }


### PR DESCRIPTION
If we are in a simple mixed-mode setup with just the global account and system account and we are clustered go ahead and enable JS on $G.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
