### PR TITLE
[FIXED] JetStream: possible deadlock due to lock inversion

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1307,6 +1307,7 @@ func (a *Account) JetStreamUsage() JetStreamAccountStats {
 	var stats JetStreamAccountStats
 	if jsa != nil {
 		js := jsa.js
+		js.mu.RLock()
 		jsa.mu.RLock()
 		stats.Memory = uint64(jsa.memTotal)
 		stats.Store = uint64(jsa.storeTotal)
@@ -1316,13 +1317,11 @@ func (a *Account) JetStreamUsage() JetStreamAccountStats {
 			Errors: jsa.apiErrors,
 		}
 		if cc := jsa.js.cluster; cc != nil {
-			js.mu.RLock()
 			sas := cc.streams[aname]
 			stats.Streams = len(sas)
 			for _, sa := range sas {
 				stats.Consumers += len(sa.consumers)
 			}
-			js.mu.RUnlock()
 		} else {
 			stats.Streams = len(jsa.streams)
 			for _, mset := range jsa.streams {
@@ -1331,6 +1330,7 @@ func (a *Account) JetStreamUsage() JetStreamAccountStats {
 		}
 		stats.Limits = jsa.limits
 		jsa.mu.RUnlock()
+		js.mu.RUnlock()
 	}
 	return stats
 }

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1187,6 +1187,7 @@ func (rg *raftGroup) setPreferred() {
 // createRaftGroup is called to spin up this raft group if needed.
 func (js *jetStream) createRaftGroup(rg *raftGroup, storage StorageType) error {
 	js.mu.Lock()
+	defer js.mu.Unlock()
 	s, cc := js.srv, js.cluster
 	if cc == nil || cc.meta == nil {
 		js.mu.Unlock()
@@ -1196,20 +1197,15 @@ func (js *jetStream) createRaftGroup(rg *raftGroup, storage StorageType) error {
 	// If this is a single peer raft group or we are not a member return.
 	if len(rg.Peers) <= 1 || !rg.isMember(cc.meta.ID()) {
 		// Nothing to do here.
-		js.mu.Unlock()
 		return nil
 	}
 
 	// Check if we already have this assigned.
-	// This server lock is not normal server lock, so ok to hold js lock here.
 	if node := s.lookupRaftNode(rg.Name); node != nil {
 		s.Debugf("JetStream cluster already has raft group %q assigned", rg.Name)
 		rg.node = node
-		js.mu.Unlock()
 		return nil
 	}
-	// Make sure to release lock here since below we will want the server lock.
-	js.mu.Unlock()
 
 	s.Debugf("JetStream cluster creating raft group:%+v", rg)
 
@@ -1251,10 +1247,7 @@ func (js *jetStream) createRaftGroup(rg *raftGroup, storage StorageType) error {
 		s.Debugf("Error creating raft group: %v", err)
 		return err
 	}
-	// js lock needs to be held here for assignment.
-	js.mu.Lock()
 	rg.node = n
-	js.mu.Unlock()
 
 	// See if we are preferred and should start campaign immediately.
 	if n.ID() == rg.Preferred {

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1262,6 +1262,8 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 func (s *Server) updateJszVarz(js *jetStream, v *JetStreamVarz, doConfig bool) {
 	if doConfig {
 		js.mu.RLock()
+		// We want to snapshot the config since it will then be available outside
+		// of the js lock. So make a copy first, then point to this copy.
 		cfg := js.config
 		v.Config = &cfg
 		js.mu.RUnlock()


### PR DESCRIPTION
The locking is jetStream->Server, not the otherway around. There
was few places where lock inversion could have caused deadlock.

Also, a change made recently to solve a deadlock was causing
a race that is demonstrated with TestJetStreamRaceOnRAFTCreate.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
