### PR TITLE
Handle SIGTERM on windows (close window event)

### DIFF
--- a/server/signal_windows.go
+++ b/server/signal_windows.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"golang.org/x/sys/windows/svc"
@@ -30,7 +31,7 @@ func (s *Server) handleSignals() {
 	}
 	c := make(chan os.Signal, 1)
 
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
 		for sig := range c {


### PR DESCRIPTION
Since Go 1.14, close window event on windows becomes [SIGTERM](https://github.com/golang/go/commit/5d1a95175e693f5be0bc31ae9e6a7873318925eb) which we are currently not handling so becomes a non graceful exit that could be more difficult to recover from sometimes. With this change, it now catches the `terminated` signal so exits gracefully:

```
[12616] 2021/09/01 16:31:50.537622 [INF] Server is ready
[12616] 2021/09/01 16:32:03.179669 [DBG] Trapped "terminated" signal
[12616] 2021/09/01 16:32:03.180442 [INF] Initiating Shutdown...
[12616] 2021/09/01 16:32:03.181038 [INF] Initiating JetStream Shutdown...
[12616] 2021/09/01 16:32:03.181038 [INF] JetStream Shutdown
[12616] 2021/09/01 16:32:03.182625 [DBG] Client accept loop exiting..
[12616] 2021/09/01 16:32:03.182969 [DBG] SYSTEM - System connection closed: Client Closed
[12616] 2021/09/01 16:32:03.182969 [INF] Server Exiting..
```

Related to #2397 

/cc @nats-io/core
