### PR TITLE
[FIXED] Account resolver TLS configuration

### DIFF
--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -1556,7 +1556,18 @@ func TestAccountURLResolver(t *testing.T) {
 			})
 			var ts *httptest.Server
 			if test.useTLS {
-				ts = httptest.NewTLSServer(hf)
+				tc := &TLSConfigOpts{
+					CertFile: "../test/configs/certs/server-cert.pem",
+					KeyFile:  "../test/configs/certs/server-key.pem",
+					CaFile:   "../test/configs/certs/ca.pem",
+				}
+				tlsConfig, err := GenTLSConfig(tc)
+				if err != nil {
+					t.Fatalf("Error generating tls config: %v", err)
+				}
+				ts = httptest.NewUnstartedServer(hf)
+				ts.TLS = tlsConfig
+				ts.StartTLS()
 			} else {
 				ts = httptest.NewServer(hf)
 			}
@@ -1567,7 +1578,9 @@ func TestAccountURLResolver(t *testing.T) {
 				listen: -1
 				resolver: URL("%s/ngs/v1/accounts/jwt/")
 				resolver_tls {
-					insecure: true
+					cert_file: "../test/configs/certs/client-cert.pem"
+					key_file: "../test/configs/certs/client-key.pem"
+					ca_file: "../test/configs/certs/ca.pem"
 				}
 			`
 			conf := createConfFile(t, []byte(fmt.Sprintf(confTemplate, ojwt, ts.URL)))

--- a/server/opts.go
+++ b/server/opts.go
@@ -1105,11 +1105,16 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 			*errors = append(*errors, err)
 			return
 		}
-		if o.AccountResolverTLSConfig, err = GenTLSConfig(tc); err != nil {
+		tlsConfig, err := GenTLSConfig(tc)
+		if err != nil {
 			err := &configErr{tk, err.Error()}
 			*errors = append(*errors, err)
 			return
 		}
+		o.AccountResolverTLSConfig = tlsConfig
+		// GenTLSConfig loads the CA file into ClientCAs, but since this will
+		// be used as a client connection, we need to set RootCAs.
+		o.AccountResolverTLSConfig.RootCAs = tlsConfig.ClientCAs
 	case "resolver_preload":
 		mp, ok := v.(map[string]interface{})
 		if !ok {


### PR DESCRIPTION
The RootCAs was not properly set, which could prevent the server
to create a TLS connection to the account resolver with an error
such as:
```
x509: certificate signed by unknown authority
```

Resolves #1207

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
