### PR TITLE
During peer removal, try to remap any stream or consumer assets.

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -2112,6 +2112,8 @@ func (n *raft) applyCommit(index uint64) error {
 				}
 			}
 			n.writePeerState(&peerState{n.peerNames(), n.csz})
+			// We pass these up as well.
+			committed = append(committed, e)
 		case EntryRemovePeer:
 			peer := string(e.Data)
 			n.debug("Removing peer %q", peer)


### PR DESCRIPTION
Also if we do not have room trap add peer and process there.
Also fixed a bug that would treat ephemerals the same as durables during remapping after peer removal.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
