### PR TITLE
[FIXED] - Message cleanup for interest stream and no-ack consumers in clustered mode.

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -2121,7 +2121,7 @@ func TestJetStreamClusterMirrorAndSourceWorkQueues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	// Allow sync consumers to connect.
+	// Allow direct sync consumers to connect.
 	time.Sleep(500 * time.Millisecond)
 
 	if _, err = js.Publish("foo", []byte("ok")); err != nil {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -6189,7 +6189,7 @@ func TestJetStreamInterestRetentionStreamWithDurableRestart(t *testing.T) {
 
 			checkNumMsgs := func(numExpected int) {
 				t.Helper()
-				checkFor(t, 200*time.Millisecond, 10*time.Millisecond, func() error {
+				checkFor(t, time.Second, 50*time.Millisecond, func() error {
 					if state := mset.state(); state.Msgs != uint64(numExpected) {
 						return fmt.Errorf("Expected %d messages, got %d", numExpected, state.Msgs)
 					}


### PR DESCRIPTION
Fixed a bug when an interest retention stream with noack consumers is in clustered mode.
We were not properly propagating the ack state and proper cleanup of the stream messages.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #2488 (Related)

/cc @nats-io/core
