### PR TITLE
[ADDED] Monitoring: ClientID (for MQTT clients) on connection events

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1895,7 +1895,11 @@ func (c *client) authViolation() {
 	} else {
 		c.Errorf(ErrAuthentication.Error())
 	}
-	c.sendErr("Authorization Violation")
+	if c.isMqtt() {
+		c.mqttEnqueueConnAck(mqttConnAckRCNotAuthorized, false)
+	} else {
+		c.sendErr("Authorization Violation")
+	}
 	c.closeConnection(AuthenticationViolation)
 }
 

--- a/server/events.go
+++ b/server/events.go
@@ -188,7 +188,7 @@ type ClientInfo struct {
 	Tags       jwt.TagList   `json:"tags,omitempty"`
 	Kind       string        `json:"kind,omitempty"`
 	ClientType string        `json:"client_type,omitempty"`
-	ClientID   string        `json:"client_id,omitempty"` // So far used only by MQTT clients
+	MQTTClient string        `json:"client_id,omitempty"` // This is the MQTT client ID
 }
 
 // ServerStats hold various statistics that we will periodically send out.
@@ -1636,7 +1636,7 @@ func (s *Server) accountConnectEvent(c *client) {
 			NameTag:    c.nameTag,
 			Kind:       c.kindString(),
 			ClientType: c.clientTypeString(),
-			ClientID:   c.getClientID(),
+			MQTTClient: c.getMQTTClientID(),
 		},
 	}
 	c.mu.Unlock()
@@ -1688,7 +1688,7 @@ func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string)
 			NameTag:    c.nameTag,
 			Kind:       c.kindString(),
 			ClientType: c.clientTypeString(),
-			ClientID:   c.getClientID(),
+			MQTTClient: c.getMQTTClientID(),
 		},
 		Sent: DataStats{
 			Msgs:  atomic.LoadInt64(&c.inMsgs),
@@ -1740,7 +1740,7 @@ func (s *Server) sendAuthErrorEvent(c *client) {
 			NameTag:    c.nameTag,
 			Kind:       c.kindString(),
 			ClientType: c.clientTypeString(),
-			ClientID:   c.getClientID(),
+			MQTTClient: c.getMQTTClientID(),
 		},
 		Sent: DataStats{
 			Msgs:  c.inMsgs,

--- a/server/events.go
+++ b/server/events.go
@@ -188,6 +188,7 @@ type ClientInfo struct {
 	Tags       jwt.TagList   `json:"tags,omitempty"`
 	Kind       string        `json:"kind,omitempty"`
 	ClientType string        `json:"client_type,omitempty"`
+	ClientID   string        `json:"client_id,omitempty"` // So far used only by MQTT clients
 }
 
 // ServerStats hold various statistics that we will periodically send out.
@@ -1635,6 +1636,7 @@ func (s *Server) accountConnectEvent(c *client) {
 			NameTag:    c.nameTag,
 			Kind:       c.kindString(),
 			ClientType: c.clientTypeString(),
+			ClientID:   c.getClientID(),
 		},
 	}
 	c.mu.Unlock()
@@ -1686,6 +1688,7 @@ func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string)
 			NameTag:    c.nameTag,
 			Kind:       c.kindString(),
 			ClientType: c.clientTypeString(),
+			ClientID:   c.getClientID(),
 		},
 		Sent: DataStats{
 			Msgs:  atomic.LoadInt64(&c.inMsgs),
@@ -1737,6 +1740,7 @@ func (s *Server) sendAuthErrorEvent(c *client) {
 			NameTag:    c.nameTag,
 			Kind:       c.kindString(),
 			ClientType: c.clientTypeString(),
+			ClientID:   c.getClientID(),
 		},
 		Sent: DataStats{
 			Msgs:  c.inMsgs,

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -592,7 +592,7 @@ func (c *client) isMqtt() bool {
 // If this is an MQTT client, returns the session client ID,
 // otherwise returns the empty string.
 // Lock held on entry
-func (c *client) getClientID() string {
+func (c *client) getMQTTClientID() string {
 	if !c.isMqtt() {
 		return _EMPTY_
 	}

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -318,6 +318,7 @@ type mqtt struct {
 	pp   *mqttPublish
 	asm  *mqttAccountSessionManager // quick reference to account session manager, immutable after processConnect()
 	sess *mqttSession               // quick reference to session, immutable after processConnect()
+	cid  string                     // client ID
 }
 
 type mqttPending struct {
@@ -327,10 +328,9 @@ type mqttPending struct {
 }
 
 type mqttConnectProto struct {
-	clientID string
-	rd       time.Duration
-	will     *mqttWill
-	flags    byte
+	rd    time.Duration
+	will  *mqttWill
+	flags byte
 }
 
 type mqttIOReader interface {
@@ -587,6 +587,16 @@ func validateMQTTOptions(o *Options) error {
 // Lock held on entry.
 func (c *client) isMqtt() bool {
 	return c.mqtt != nil
+}
+
+// If this is an MQTT client, returns the session client ID,
+// otherwise returns the empty string.
+// Lock held on entry
+func (c *client) getClientID() string {
+	if !c.isMqtt() {
+		return _EMPTY_
+	}
+	return c.mqtt.cid
 }
 
 // Parse protocols inside the given buffer.
@@ -2420,21 +2430,21 @@ func (c *client) mqttParseConnect(r *mqttReader, pl int) (byte, *mqttConnectProt
 	// Spec [MQTT-3.1.3-1]: client ID, will topic, will message, username, password
 
 	// Client ID
-	cp.clientID, err = r.readString("client ID")
+	c.mqtt.cid, err = r.readString("client ID")
 	if err != nil {
 		return 0, nil, err
 	}
 	// Spec [MQTT-3.1.3-7]
-	if cp.clientID == _EMPTY_ {
+	if c.mqtt.cid == _EMPTY_ {
 		if cp.flags&mqttConnFlagCleanSession == 0 {
 			return mqttConnAckRCIdentifierRejected, nil, errMQTTCIDEmptyNeedsCleanFlag
 		}
 		// Spec [MQTT-3.1.3-6]
-		cp.clientID = nuid.Next()
+		c.mqtt.cid = nuid.Next()
 	}
 	// Spec [MQTT-3.1.3-4] and [MQTT-3.1.3-9]
-	if !utf8.ValidString(cp.clientID) {
-		return mqttConnAckRCIdentifierRejected, nil, fmt.Errorf("invalid utf8 for client ID: %q", cp.clientID)
+	if !utf8.ValidString(c.mqtt.cid) {
+		return mqttConnAckRCIdentifierRejected, nil, fmt.Errorf("invalid utf8 for client ID: %q", c.mqtt.cid)
 	}
 
 	if hasWill {
@@ -2494,7 +2504,7 @@ func (c *client) mqttParseConnect(r *mqttReader, pl int) (byte, *mqttConnectProt
 }
 
 func (c *client) mqttConnectTrace(cp *mqttConnectProto) string {
-	trace := fmt.Sprintf("clientID=%s", cp.clientID)
+	trace := fmt.Sprintf("clientID=%s", c.mqtt.cid)
 	if cp.rd > 0 {
 		trace += fmt.Sprintf(" keepAlive=%v", cp.rd)
 	}
@@ -2538,19 +2548,21 @@ func (s *Server) mqttProcessConnect(c *client, cp *mqttConnectProto, trace bool)
 	}
 
 	c.mu.Lock()
+	cid := c.mqtt.cid
 	c.clearAuthTimer()
 	c.mu.Unlock()
 	if !s.isClientAuthorized(c) {
-		c.Errorf(ErrAuthentication.Error())
-		sendConnAck(mqttConnAckRCNotAuthorized, false)
-		c.closeConnection(AuthenticationViolation)
+		if trace {
+			c.traceOutOp("CONNACK", []byte(fmt.Sprintf("sp=%v rc=%v", false, mqttConnAckRCNotAuthorized)))
+		}
+		c.authViolation()
 		return ErrAuthentication
 	}
 	// Now that we are are authenticated, we have the client bound to the account.
 	// Get the account's level MQTT sessions manager. If it does not exists yet,
 	// this will create it along with the streams where sessions and messages
 	// are stored.
-	asm, err := s.getOrCreateMQTTAccountSessionManager(cp.clientID, c)
+	asm, err := s.getOrCreateMQTTAccountSessionManager(cid, c)
 	if err != nil {
 		return err
 	}
@@ -2570,11 +2582,11 @@ CHECK:
 	asm.mu.Lock()
 	// Check if different applications keep trying to connect with the same
 	// client ID at the same time.
-	if tm, ok := asm.flappers[cp.clientID]; ok {
+	if tm, ok := asm.flappers[cid]; ok {
 		// If the last time it tried to connect was more than 1 sec ago,
 		// then accept and remove from flappers map.
 		if time.Now().UnixNano()-tm > int64(mqttSessJailDur) {
-			asm.removeSessFromFlappers(cp.clientID)
+			asm.removeSessFromFlappers(cid)
 		} else {
 			// Will hold this client for a second and then close it. We
 			// do this so that if the client has a reconnect feature we
@@ -2590,21 +2602,21 @@ CHECK:
 	// evict the old client just yet. So try again to see if the state clears, but
 	// if it does not, then we have no choice but to fail the new client instead of
 	// the old one.
-	if _, ok := asm.sessLocked[cp.clientID]; ok {
+	if _, ok := asm.sessLocked[cid]; ok {
 		asm.mu.Unlock()
 		if locked++; locked == 10 {
-			return fmt.Errorf("other session with client ID %q is in the process of connecting", cp.clientID)
+			return fmt.Errorf("other session with client ID %q is in the process of connecting", cid)
 		}
 		time.Sleep(100 * time.Millisecond)
 		goto CHECK
 	}
 
 	// Register this client ID the "locked" map for the duration if this function.
-	asm.sessLocked[cp.clientID] = struct{}{}
+	asm.sessLocked[cid] = struct{}{}
 	// And remove it on exit, regardless of error or not.
 	defer func() {
 		asm.mu.Lock()
-		delete(asm.sessLocked, cp.clientID)
+		delete(asm.sessLocked, cid)
 		asm.mu.Unlock()
 	}()
 
@@ -2613,13 +2625,13 @@ CHECK:
 	// Session present? Assume false, will be set to true only when applicable.
 	sessp := false
 	// Do we have an existing session for this client ID
-	es, exists := asm.sessions[cp.clientID]
+	es, exists := asm.sessions[cid]
 	asm.mu.Unlock()
 
 	// The session is not in the map, but may be on disk, so try to recover
 	// or create the stream if not.
 	if !exists {
-		es, exists, err = asm.createOrRestoreSession(cp.clientID, s.getOpts())
+		es, exists, err = asm.createOrRestoreSession(cid, s.getOpts())
 		if err != nil {
 			return err
 		}
@@ -2655,9 +2667,9 @@ CHECK:
 			ec.mu.Unlock()
 			// Add to the map of the flappers
 			asm.mu.Lock()
-			asm.addSessToFlappers(cp.clientID)
+			asm.addSessToFlappers(cid)
 			asm.mu.Unlock()
-			c.Warnf("Replacing old client %q since both have the same client ID %q", ec, cp.clientID)
+			c.Warnf("Replacing old client %q since both have the same client ID %q", ec, cid)
 			// Close old client in separate go routine
 			go ec.closeConnection(DuplicateClientID)
 		}

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -649,7 +649,7 @@ func testMQTTGetClient(t testing.TB, s *Server, clientID string) *client {
 	s.mu.Lock()
 	for _, c := range s.clients {
 		c.mu.Lock()
-		if c.isMqtt() && c.mqtt.cp != nil && c.mqtt.cp.clientID == clientID {
+		if c.isMqtt() && c.mqtt.cid == clientID {
 			mc = c
 		}
 		c.mu.Unlock()
@@ -5064,6 +5064,191 @@ func TestMQTTTransferSessionStreamsToMuxed(t *testing.T) {
 	}
 	if cons, ok := ps2.Cons["foo"]; !ok || !reflect.DeepEqual(cons, ps.Cons["foo"]) {
 		t.Fatalf("Unexpected session record, %+v vs %+v", ps2, ps)
+	}
+}
+
+func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: "127.0.0.1:-1"
+		http: "127.0.0.1:-1"
+		server_name: "mqtt"
+		jetstream: enabled
+		accounts {
+			MQTT {
+				jetstream: enabled
+				users: [{user: "mqtt", password: "pwd"}]
+			}
+			SYS {
+				users: [{user: "sys", password: "pwd"}]
+			}
+		}
+		mqtt {
+			listen: "127.0.0.1:-1"
+		}
+		system_account: "SYS"
+	`))
+	defer os.Remove(conf)
+	s, o := RunServerWithConfig(conf)
+	defer testMQTTShutdownServer(s)
+
+	nc := natsConnect(t, s.ClientURL(), nats.UserInfo("sys", "pwd"))
+	defer nc.Close()
+
+	accConn := natsSubSync(t, nc, fmt.Sprintf(connectEventSubj, "MQTT"))
+	accDisc := natsSubSync(t, nc, fmt.Sprintf(disconnectEventSubj, "MQTT"))
+	accAuth := natsSubSync(t, nc, fmt.Sprintf(authErrorEventSubj, s.ID()))
+	natsFlush(t, nc)
+
+	checkConnEvent := func(data []byte, expected string) {
+		t.Helper()
+		var ce ConnectEventMsg
+		json.Unmarshal(data, &ce)
+		if ce.Client.ClientID != expected {
+			t.Fatalf("Expected client ID %q, got this connect event: %+v", expected, ce)
+		}
+	}
+	checkDiscEvent := func(data []byte, expected string) {
+		t.Helper()
+		var de DisconnectEventMsg
+		json.Unmarshal(data, &de)
+		if de.Client.ClientID != expected {
+			t.Fatalf("Expected client ID %q, got this disconnect event: %+v", expected, de)
+		}
+	}
+
+	c1, r1 := testMQTTConnect(t, &mqttConnInfo{user: "mqtt", pass: "pwd", clientID: "conn1", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	defer c1.Close()
+	testMQTTCheckConnAck(t, r1, mqttConnAckRCConnectionAccepted, false)
+
+	cm := natsNexMsg(t, accConn, time.Second)
+	checkConnEvent(cm.Data, "conn1")
+
+	c2, r2 := testMQTTConnect(t, &mqttConnInfo{user: "mqtt", pass: "pwd", clientID: "conn2", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	defer c2.Close()
+	testMQTTCheckConnAck(t, r2, mqttConnAckRCConnectionAccepted, false)
+
+	cm = natsNexMsg(t, accConn, time.Second)
+	checkConnEvent(cm.Data, "conn2")
+
+	c3, r3 := testMQTTConnect(t, &mqttConnInfo{user: "mqtt", pass: "pwd", clientID: "conn3", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	defer c3.Close()
+	testMQTTCheckConnAck(t, r3, mqttConnAckRCConnectionAccepted, false)
+
+	cm = natsNexMsg(t, accConn, time.Second)
+	checkConnEvent(cm.Data, "conn3")
+
+	testMQTTDisconnect(t, c3, nil)
+	cm = natsNexMsg(t, accDisc, time.Second)
+	checkDiscEvent(cm.Data, "conn3")
+
+	// Now try a bad auth
+	c4, r4 := testMQTTConnect(t, &mqttConnInfo{clientID: "conn4", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	defer c4.Close()
+	testMQTTCheckConnAck(t, r4, mqttConnAckRCNotAuthorized, false)
+	// This will generate an auth error, which is a disconnect event
+	cm = natsNexMsg(t, accAuth, time.Second)
+	checkDiscEvent(cm.Data, "conn4")
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/", s.MonitorAddr().Port)
+	for mode := 0; mode < 2; mode++ {
+		c := pollConz(t, s, mode, url+"connz", nil)
+		if c.Conns == nil || len(c.Conns) != 3 {
+			t.Fatalf("Expected 3 connections in array, got %v", len(c.Conns))
+		}
+
+		// Check that client ID is present
+		for _, conn := range c.Conns {
+			if conn.Type == clientTypeStringMap[MQTT] && conn.ClientID == _EMPTY_ {
+				t.Fatalf("Expected a client ID to be set, got %+v", conn)
+			}
+		}
+
+		// Check that we can select based on client ID:
+		c = pollConz(t, s, mode, url+"connz?client_id=conn2", &ConnzOptions{ClientID: "conn2"})
+		if c.Conns == nil || len(c.Conns) != 1 {
+			t.Fatalf("Expected 1 connection in array, got %v", len(c.Conns))
+		}
+		if c.Conns[0].ClientID != "conn2" {
+			t.Fatalf("Unexpected client ID: %+v", c.Conns[0])
+		}
+
+		// Check that we have the closed ones
+		c = pollConz(t, s, mode, url+"connz?state=closed", &ConnzOptions{State: ConnClosed})
+		if c.Conns == nil || len(c.Conns) != 2 {
+			t.Fatalf("Expected 2 connections in array, got %v", len(c.Conns))
+		}
+		for _, conn := range c.Conns {
+			if conn.ClientID == _EMPTY_ {
+				t.Fatalf("Expected a client ID, got %+v", conn)
+			}
+		}
+
+		// Check that we can select with client ID for closed state
+		c = pollConz(t, s, mode, url+"connz?state=closed&client_id=conn3", &ConnzOptions{State: ConnClosed, ClientID: "conn3"})
+		if c.Conns == nil || len(c.Conns) != 1 {
+			t.Fatalf("Expected 1 connection in array, got %v", len(c.Conns))
+		}
+		if c.Conns[0].ClientID != "conn3" {
+			t.Fatalf("Unexpected client ID: %+v", c.Conns[0])
+		}
+		// Check that we can select with client ID for closed state (but in this case not found)
+		c = pollConz(t, s, mode, url+"connz?state=closed&client_id=conn5", &ConnzOptions{State: ConnClosed, ClientID: "conn5"})
+		if len(c.Conns) != 0 {
+			t.Fatalf("Expected 0 connection in array, got %v", len(c.Conns))
+		}
+	}
+
+	reply := nc.NewRespInbox()
+	replySub := natsSubSync(t, nc, reply)
+
+	// Test system events now
+	for _, test := range []struct {
+		opt interface{}
+		cid string
+	}{
+		{&ConnzOptions{ClientID: "conn1"}, "conn1"},
+		{&ConnzOptions{ClientID: "conn3", State: ConnClosed}, "conn3"},
+		{&ConnzOptions{ClientID: "conn4", State: ConnClosed}, "conn4"},
+		{&ConnzOptions{ClientID: "conn5"}, _EMPTY_},
+		{json.RawMessage(`{"client_id":"conn1"}`), "conn1"},
+		{json.RawMessage(fmt.Sprintf(`{"client_id":"conn3", "state":%v}`, ConnClosed)), "conn3"},
+		{json.RawMessage(fmt.Sprintf(`{"client_id":"conn4", "state":%v}`, ConnClosed)), "conn4"},
+		{json.RawMessage(`{"client_id":"conn5"}`), _EMPTY_},
+	} {
+		t.Run("sys connz", func(t *testing.T) {
+			b, _ := json.Marshal(test.opt)
+
+			// set a header to make sure request parsing knows to ignore them
+			nc.PublishMsg(&nats.Msg{
+				Subject: fmt.Sprintf("%s.CONNZ", serverStatsPingReqSubj),
+				Reply:   reply,
+				Data:    b,
+			})
+
+			msg := natsNexMsg(t, replySub, time.Second)
+			var response ServerAPIResponse
+			if err := json.Unmarshal(msg.Data, &response); err != nil {
+				t.Fatalf("Error unmarshalling response json: %v", err)
+			}
+			tmp, _ := json.Marshal(response.Data)
+			cz := &Connz{}
+			if err := json.Unmarshal(tmp, cz); err != nil {
+				t.Fatalf("Error unmarshalling connz: %v", err)
+			}
+			if test.cid == _EMPTY_ {
+				if len(cz.Conns) != 0 {
+					t.Fatalf("Expected no connections, got %v", len(cz.Conns))
+				}
+				return
+			}
+			if len(cz.Conns) != 1 {
+				t.Fatalf("Expected single connection, got %v", len(cz.Conns))
+			}
+			conn := cz.Conns[0]
+			if conn.ClientID != test.cid {
+				t.Fatalf("Expected client ID %q, got %q", test.cid, conn.ClientID)
+			}
+		})
 	}
 }
 

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -5103,7 +5103,7 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 		t.Helper()
 		var ce ConnectEventMsg
 		json.Unmarshal(data, &ce)
-		if ce.Client.ClientID != expected {
+		if ce.Client.MQTTClient != expected {
 			t.Fatalf("Expected client ID %q, got this connect event: %+v", expected, ce)
 		}
 	}
@@ -5111,7 +5111,7 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 		t.Helper()
 		var de DisconnectEventMsg
 		json.Unmarshal(data, &de)
-		if de.Client.ClientID != expected {
+		if de.Client.MQTTClient != expected {
 			t.Fatalf("Expected client ID %q, got this disconnect event: %+v", expected, de)
 		}
 	}
@@ -5158,17 +5158,17 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 
 		// Check that client ID is present
 		for _, conn := range c.Conns {
-			if conn.Type == clientTypeStringMap[MQTT] && conn.ClientID == _EMPTY_ {
+			if conn.Type == clientTypeStringMap[MQTT] && conn.MQTTClient == _EMPTY_ {
 				t.Fatalf("Expected a client ID to be set, got %+v", conn)
 			}
 		}
 
 		// Check that we can select based on client ID:
-		c = pollConz(t, s, mode, url+"connz?client_id=conn2", &ConnzOptions{ClientID: "conn2"})
+		c = pollConz(t, s, mode, url+"connz?mqtt_client=conn2", &ConnzOptions{MQTTClient: "conn2"})
 		if c.Conns == nil || len(c.Conns) != 1 {
 			t.Fatalf("Expected 1 connection in array, got %v", len(c.Conns))
 		}
-		if c.Conns[0].ClientID != "conn2" {
+		if c.Conns[0].MQTTClient != "conn2" {
 			t.Fatalf("Unexpected client ID: %+v", c.Conns[0])
 		}
 
@@ -5178,21 +5178,21 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 			t.Fatalf("Expected 2 connections in array, got %v", len(c.Conns))
 		}
 		for _, conn := range c.Conns {
-			if conn.ClientID == _EMPTY_ {
+			if conn.MQTTClient == _EMPTY_ {
 				t.Fatalf("Expected a client ID, got %+v", conn)
 			}
 		}
 
 		// Check that we can select with client ID for closed state
-		c = pollConz(t, s, mode, url+"connz?state=closed&client_id=conn3", &ConnzOptions{State: ConnClosed, ClientID: "conn3"})
+		c = pollConz(t, s, mode, url+"connz?state=closed&mqtt_client=conn3", &ConnzOptions{State: ConnClosed, MQTTClient: "conn3"})
 		if c.Conns == nil || len(c.Conns) != 1 {
 			t.Fatalf("Expected 1 connection in array, got %v", len(c.Conns))
 		}
-		if c.Conns[0].ClientID != "conn3" {
+		if c.Conns[0].MQTTClient != "conn3" {
 			t.Fatalf("Unexpected client ID: %+v", c.Conns[0])
 		}
 		// Check that we can select with client ID for closed state (but in this case not found)
-		c = pollConz(t, s, mode, url+"connz?state=closed&client_id=conn5", &ConnzOptions{State: ConnClosed, ClientID: "conn5"})
+		c = pollConz(t, s, mode, url+"connz?state=closed&mqtt_client=conn5", &ConnzOptions{State: ConnClosed, MQTTClient: "conn5"})
 		if len(c.Conns) != 0 {
 			t.Fatalf("Expected 0 connection in array, got %v", len(c.Conns))
 		}
@@ -5206,14 +5206,14 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 		opt interface{}
 		cid string
 	}{
-		{&ConnzOptions{ClientID: "conn1"}, "conn1"},
-		{&ConnzOptions{ClientID: "conn3", State: ConnClosed}, "conn3"},
-		{&ConnzOptions{ClientID: "conn4", State: ConnClosed}, "conn4"},
-		{&ConnzOptions{ClientID: "conn5"}, _EMPTY_},
-		{json.RawMessage(`{"client_id":"conn1"}`), "conn1"},
-		{json.RawMessage(fmt.Sprintf(`{"client_id":"conn3", "state":%v}`, ConnClosed)), "conn3"},
-		{json.RawMessage(fmt.Sprintf(`{"client_id":"conn4", "state":%v}`, ConnClosed)), "conn4"},
-		{json.RawMessage(`{"client_id":"conn5"}`), _EMPTY_},
+		{&ConnzOptions{MQTTClient: "conn1"}, "conn1"},
+		{&ConnzOptions{MQTTClient: "conn3", State: ConnClosed}, "conn3"},
+		{&ConnzOptions{MQTTClient: "conn4", State: ConnClosed}, "conn4"},
+		{&ConnzOptions{MQTTClient: "conn5"}, _EMPTY_},
+		{json.RawMessage(`{"mqtt_client":"conn1"}`), "conn1"},
+		{json.RawMessage(fmt.Sprintf(`{"mqtt_client":"conn3", "state":%v}`, ConnClosed)), "conn3"},
+		{json.RawMessage(fmt.Sprintf(`{"mqtt_client":"conn4", "state":%v}`, ConnClosed)), "conn4"},
+		{json.RawMessage(`{"mqtt_client":"conn5"}`), _EMPTY_},
 	} {
 		t.Run("sys connz", func(t *testing.T) {
 			b, _ := json.Marshal(test.opt)
@@ -5245,8 +5245,8 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 				t.Fatalf("Expected single connection, got %v", len(cz.Conns))
 			}
 			conn := cz.Conns[0]
-			if conn.ClientID != test.cid {
-				t.Fatalf("Expected client ID %q, got %q", test.cid, conn.ClientID)
+			if conn.MQTTClient != test.cid {
+				t.Fatalf("Expected client ID %q, got %q", test.cid, conn.MQTTClient)
 			}
 		})
 	}


### PR DESCRIPTION
ClientID has been added to various monitoring objects. Also, added
the ability to filter connections on `client_id`.

On auth violation, the proper code was not invoked, which meant
that no disconnect event (with auth reason) would be published.

Resolves #2270

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
