### PR TITLE
[FIXED] Report config error if "token" defined for cluster{} and gateway{}

### DIFF
--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -1474,6 +1474,35 @@ func TestConfigCheck(t *testing.T) {
                         `,
 			err: fmt.Errorf(`Duplicate 'store_dir' configuration`),
 		},
+		{
+			name: "token not supported in cluster",
+			config: `
+				cluster {
+					port: -1
+					authorization {
+						token: "my_token"
+					}
+				}
+			`,
+			err:       fmt.Errorf("Cluster authorization does not support tokens"),
+			errorLine: 4,
+			errorPos:  6,
+		},
+		{
+			name: "token not supported in gateway",
+			config: `
+				gateway {
+					port: -1
+					name: "A"
+					authorization {
+						token: "my_token"
+					}
+				}
+			`,
+			err:       fmt.Errorf("Gateway authorization does not support tokens"),
+			errorLine: 5,
+			errorPos:  6,
+		},
 	}
 
 	checkConfig := func(config string) error {

--- a/server/opts.go
+++ b/server/opts.go
@@ -1364,6 +1364,11 @@ func parseCluster(v interface{}, opts *Options, errors *[]error, warnings *[]err
 				*errors = append(*errors, err)
 				continue
 			}
+			if auth.token != _EMPTY_ {
+				err := &configErr{tk, "Cluster authorization does not support tokens"}
+				*errors = append(*errors, err)
+				continue
+			}
 			opts.Cluster.Username = auth.user
 			opts.Cluster.Password = auth.pass
 			opts.Cluster.AuthTimeout = auth.timeout
@@ -1504,6 +1509,11 @@ func parseGateway(v interface{}, o *Options, errors *[]error, warnings *[]error)
 			}
 			if auth.users != nil {
 				*errors = append(*errors, &configErr{tk, "Gateway authorization does not allow multiple users"})
+				continue
+			}
+			if auth.token != _EMPTY_ {
+				err := &configErr{tk, "Gateway authorization does not support tokens"}
+				*errors = append(*errors, err)
 				continue
 			}
 			o.Gateway.Username = auth.user


### PR DESCRIPTION
Authentication token has never been supported for cluster and
gateway (and leafnode). There is not even a Token option in
ClusterOpts or GatewayOpts.

However, the parsing of the configuration was not rejecting this
misconfiguration, making users believe that token was used for
authentication.

Documentation will also be fixed since it is reported there that
token is supported, which again, has never been the case.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
