### PR TITLE
MQTT: delete the session record even on restart with clean flag

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -621,7 +621,7 @@ func (js *jetStream) apiDispatch(sub *subscription, c *client, acc *Account, sub
 	jsub := rr.psubs[0]
 
 	// If this is directly from a client connection ok to do in place.
-	if c.kind == CLIENT {
+	if c.kind != ROUTER && c.kind != GATEWAY {
 		jsub.icb(sub, c, acc, subject, reply, rmsg)
 		return
 	}


### PR DESCRIPTION
When a session record exists and is currently not connected, if
the user reconnects with the same client ID but with now the
clean flag set, we are required to clear the state. In earlier
implementation (where we were using a stream per session), we
were not deleting the stream to be created right away. Since now
we just have a message per session, it is ok to delete that
message when clearing the existing session that is going to be
replaced.

Also made apiDispatch execute in place for any connection that
is not ROUTER or GATEWAY.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
