### PR TITLE
fix error code for JSStreamHeaderExceedsMaximumErr

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -190,16 +190,6 @@
     "deprecates": ""
   },
   {
-    "constant": "JSStreamHeaderExceedsMaximumErr",
-    "code": 400,
-    "error_code": 10154,
-    "description": "header size exceeds maximum allowed of 64k",
-    "comment": "",
-    "help": "",
-    "url": "",
-    "deprecates": ""
-  },
-  {
     "constant": "JSStreamTemplateCreateErrF",
     "code": 500,
     "error_code": 10066,
@@ -1054,6 +1044,16 @@
     "code": 400,
     "error_code": 10107,
     "description": "consumer description is too long, maximum allowed is {max}",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSStreamHeaderExceedsMaximumErr",
+    "code": 400,
+    "error_code": 10097,
+    "description": "header size exceeds maximum allowed of 64k",
     "comment": "",
     "help": "",
     "url": "",

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -243,7 +243,7 @@ const (
 	JSStreamGeneralErrorF ErrorIdentifier = 10051
 
 	// JSStreamHeaderExceedsMaximumErr header size exceeds maximum allowed of 64k
-	JSStreamHeaderExceedsMaximumErr ErrorIdentifier = 10154
+	JSStreamHeaderExceedsMaximumErr ErrorIdentifier = 10097
 
 	// JSStreamInvalidConfigF Stream configuration validation error string ({err})
 	JSStreamInvalidConfigF ErrorIdentifier = 10052
@@ -405,7 +405,7 @@ var (
 		JSStreamExternalApiOverlapErrF:             {Code: 400, ErrCode: 10021, Description: "stream external api prefix {prefix} must not overlap with {subject}"},
 		JSStreamExternalDelPrefixOverlapsErrF:      {Code: 400, ErrCode: 10022, Description: "stream external delivery prefix {prefix} overlaps with stream subject {subject}"},
 		JSStreamGeneralErrorF:                      {Code: 500, ErrCode: 10051, Description: "{err}"},
-		JSStreamHeaderExceedsMaximumErr:            {Code: 400, ErrCode: 10154, Description: "header size exceeds maximum allowed of 64k"},
+		JSStreamHeaderExceedsMaximumErr:            {Code: 400, ErrCode: 10097, Description: "header size exceeds maximum allowed of 64k"},
 		JSStreamInvalidConfigF:                     {Code: 500, ErrCode: 10052, Description: "{err}"},
 		JSStreamInvalidErr:                         {Code: 500, ErrCode: 10096, Description: "stream not valid"},
 		JSStreamInvalidExternalDeliverySubjErrF:    {Code: 400, ErrCode: 10024, Description: "stream external delivery prefix {prefix} must not contain wildcards"},


### PR DESCRIPTION
Fixes an error code that was added that left a big gap in numbers, this has
not been released so should be safe.

`nats errors add server/errors.json` will assist in picking the next number 
when adding errors

`go generate` will now fail on gaps

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
