### PR TITLE
Allow clustered JetStream to allow duplicate stream creation calls.

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3502,7 +3502,7 @@ func (c *client) processInboundClientMsg(msg []byte) (bool, bool) {
 	}
 
 	// Now check for reserved replies. These are used for service imports.
-	if len(c.pa.reply) > 0 && isReservedReply(c.pa.reply) {
+	if c.kind == CLIENT && len(c.pa.reply) > 0 && isReservedReply(c.pa.reply) {
 		c.replySubjectViolation(c.pa.reply)
 		return false, true
 	}

--- a/server/const.go
+++ b/server/const.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.5.1-beta.1"
+	VERSION = "2.5.1-beta.2"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -178,6 +178,9 @@ func TestSystemAccount(t *testing.T) {
 	if s.sys.client == nil {
 		t.Fatalf("Expected sys.client to be non-nil")
 	}
+
+	s.sys.client.mu.Lock()
+	defer s.sys.client.mu.Unlock()
 	if s.sys.client.echo {
 		t.Fatalf("Internal clients should always have echo false")
 	}

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1494,7 +1494,7 @@ func (jsa *jsAccount) sendClusterUsageUpdate() {
 	le.PutUint64(b[16:], uint64(jsa.usage.api))
 	le.PutUint64(b[24:], uint64(jsa.usage.err))
 	if jsa.sendq != nil {
-		jsa.sendq <- &pubMsg{nil, jsa.updatesPub, _EMPTY_, nil, b, noCompression, false}
+		jsa.sendq <- &pubMsg{nil, jsa.updatesPub, _EMPTY_, nil, nil, b, noCompression, false, false}
 	}
 }
 

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -304,6 +304,7 @@ const JSApiAccountInfoResponseType = "io.nats.jetstream.api.v1.account_info_resp
 type JSApiStreamCreateResponse struct {
 	ApiResponse
 	*StreamInfo
+	DidCreate bool `json:"did_create,omitempty"`
 }
 
 const JSApiStreamCreateResponseType = "io.nats.jetstream.api.v1.stream_create_response"
@@ -1274,6 +1275,7 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, a *Account,
 		return
 	}
 	resp.StreamInfo = &StreamInfo{Created: mset.createdTime(), State: mset.state(), Config: mset.config()}
+	resp.DidCreate = true
 	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 }
 

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -1415,12 +1415,12 @@ func TestJetStreamClusterDoubleAdd(t *testing.T) {
 	if _, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Replicas: 2}); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	// Check double add fails.
-	if _, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Replicas: 2}); err == nil || err == nats.ErrTimeout {
-		t.Fatalf("Expected error but got none or timeout")
+	// Streams should allow double add.
+	if _, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Replicas: 2}); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// Do Consumers too.
+	// Check Consumers.
 	cfg := &nats.ConsumerConfig{Durable: "dlc", AckPolicy: nats.AckExplicitPolicy}
 	if _, err := js.AddConsumer("TEST", cfg); err != nil {
 		t.Fatalf("Unexpected error: %v", err)


### PR DESCRIPTION
This makes the behavior consistent with single server mode.

Resolves #2528

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
