### PR TITLE
[FIXED] ConsumerInfo in clustered mode during setup returned NotFound.

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -364,6 +364,11 @@ RESET:
 					contentHeader = "identity"
 				}
 			}
+			// Optional Echo
+			replaceEcho := c.echo != pm.echo
+			if replaceEcho {
+				c.echo = !c.echo
+			}
 			c.mu.Unlock()
 
 			// Add in NL
@@ -386,11 +391,15 @@ RESET:
 				c.traceMsg(b)
 			}
 
-			// Optional Echo
-			c.echo = pm.echo
 			// Process like a normal inbound msg.
 			c.processInboundClientMsg(b)
-			c.echo = false
+
+			// Put echo back if needed.
+			if replaceEcho {
+				c.mu.Lock()
+				c.echo = !c.echo
+				c.mu.Unlock()
+			}
 
 			// See if we are doing graceful shutdown.
 			if !pm.last {

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -8380,7 +8380,9 @@ func TestJetStreamRaceOnRAFTCreate(t *testing.T) {
 	for i := 0; i < size; i++ {
 		go func() {
 			defer wg.Done()
-			js.PullSubscribe("foo", "shared")
+			if _, err := js.PullSubscribe("foo", "shared"); err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
 		}()
 	}
 	wg.Wait()


### PR DESCRIPTION
This change returns an info in those states now to better support client logic when binding consumers.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
