### PR TITLE
Make large batch requests expire more efficiently.

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.5.1-beta.2"
+	VERSION = "2.5.1-beta.3"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2089,6 +2089,7 @@ func (o *consumer) expireWaiting() int {
 	now := time.Now()
 	for wr := o.waiting.peek(); wr != nil; wr = o.waiting.peek() {
 		if !wr.expires.IsZero() && now.After(wr.expires) {
+			wr.n = 0 // Force removal by setting requests left to 0.
 			o.waiting.pop()
 			expired++
 			continue
@@ -2103,6 +2104,7 @@ func (o *consumer) expireWaiting() int {
 			break
 		}
 		// No more interest so go ahead and remove this one from our list.
+		wr.n = 0 // Force removal by setting requests left to 0.
 		o.waiting.pop()
 		expired++
 	}


### PR DESCRIPTION
Thanks to @wallyqs for tracking down.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
