### PR TITLE
Remove flag that strips dwarf symbols

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -5,7 +5,7 @@ builds:
     id: nats-server
     binary: nats-server
     ldflags:
-      - -w -X github.com/nats-io/nats-server/server.gitCommit={{.ShortCommit}}
+      - -X github.com/nats-io/nats-server/server.gitCommit={{.ShortCommit}}
     env:
       - GO111MODULE=off
       - CGO_ENABLED=0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
 - main: ./main.go
   binary: nats-server
   ldflags:
-    - -w -X github.com/nats-io/nats-server/server.gitCommit={{.ShortCommit}}
+    - -X github.com/nats-io/nats-server/server.gitCommit={{.ShortCommit}}
   env:
     - GO111MODULE=off
     - CGO_ENABLED=0

--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -7,7 +7,7 @@ RUN mkdir -p src/github.com/nats-io && \
     cd src/github.com/nats-io/ && \
     git clone https://github.com/nats-io/natscli.git && \
     cd natscli/nats && \
-    go build -ldflags "-w -X main.version=${VERSION}" -o /nats
+    go build -ldflags "-X main.version=${VERSION}" -o /nats
 
 RUN go get github.com/nats-io/nsc
 


### PR DESCRIPTION
Dwarf symbols are used by debugging tools to get the layout of the data structure, and many other runtime information.
For example gdb needs the calling convention information to figure out how to invoke a function.

The increase in executable size is high though, current size of the dwarf symbols built from the mainline is ~3MB.
Or the executable file built with `go build` is ~15MB, and `go build -ldflags "-w"` is ~12MB.

Let me know if this is acceptable.