### PR TITLE
Run coverage, but push to coverall only after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ script:
 - if [[ ! $TRAVIS_TAG ]]; then go test -v -run=TestNoRace --failfast -p=1 -timeout 20m ./...; fi
 - if [[ ! $TRAVIS_TAG ]]; then if [[ "$TRAVIS_GO_VERSION" =~ 1.15 ]]; then ./scripts/cov.sh TRAVIS; else go test -v -race -p=1 --failfast -timeout 20m ./...; fi; fi
 - set +e
+after_success:
+- if [[ ! $TRAVIS_TAG ]]; then if [[ "$TRAVIS_GO_VERSION" =~ 1.15 ]]; then $HOME/gopath/bin/goveralls -coverprofile=acc.out -service travis-ci; fi; fi
 
 deploy:
   provider: script

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -15,10 +15,9 @@ go test -v -failfast -covermode=atomic -coverprofile=./cov/test.out -coverpkg=./
 gocovmerge ./cov/*.out > acc.out
 rm -rf ./cov
 
-# If we have an arg, assume travis run and push to coveralls. Otherwise launch browser results
-if [[ -n $1 ]]; then
-    $HOME/gopath/bin/goveralls -coverprofile=acc.out -service travis-ci
-    rm -rf ./acc.out
-else
+# Without argument, launch browser results. We are going to push to coveralls only
+# from Travis.yml and after success of the build (and result of pushing will not affect
+# build result).
+if [[ $1 == "" ]]; then
     go tool cover -html=acc.out
 fi


### PR DESCRIPTION
This will ensure that we get the matrix run green before pushing
results to coveralls, but also that if for some reason coveralls
has a problem, this is not making our build status red.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
