### PR TITLE
Fix RAFT WAL repair.

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.5.1-beta.4"
+	VERSION = "2.5.1-beta.5"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original


### PR DESCRIPTION
When we stored a message in the raft layer in a wrong position (state corrupt), we would panic, leaving the message there.
On restart we would truncate the WAL and try to repair, but we truncated to the wrong index of the bad entry.

This change also includes additional changes to truncateWAL and also reduces the conditional for panic on storeMsg.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
