### PR TITLE
[FIXED] #2548

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5178,6 +5178,9 @@ func (o *consumerFileStore) copyRedelivered() map[uint64]uint64 {
 	return redelivered
 }
 
+// Type returns the type of the underlying store.
+func (o *consumerFileStore) Type() StorageType { return FileStorage }
+
 // State retrieves the state from the state file.
 // This is not expected to be called in high performance code, only on startup.
 func (o *consumerFileStore) State() (*ConsumerState, error) {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -840,6 +840,9 @@ func (os *consumerMemStore) StreamDelete() error {
 
 func (os *consumerMemStore) State() (*ConsumerState, error) { return nil, nil }
 
+// Type returns the type of the underlying store.
+func (os *consumerMemStore) Type() StorageType { return MemoryStorage }
+
 // Templates
 type templateMemStore struct{}
 

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -3242,3 +3242,57 @@ func TestNoRaceJetStreamLastSubjSeqAndFilestoreCompact(t *testing.T) {
 		}
 	}
 }
+
+// Issue #2548
+func TestNoRaceJetStreamClusterMemoryStreamConsumerRaftGrowth(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "memory-leak",
+		Subjects:  []string{"memory-leak"},
+		Retention: nats.LimitsPolicy,
+		MaxMsgs:   1000,
+		Discard:   nats.DiscardOld,
+		MaxAge:    time.Minute,
+		Storage:   nats.MemoryStorage,
+		Replicas:  3,
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	_, err = js.QueueSubscribe("memory-leak", "q1", func(msg *nats.Msg) {
+		time.Sleep(1 * time.Second)
+		msg.Ack()
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Send 10k (Must be > 8192 which is compactNumMin from monitorConsumer.
+	msg := []byte("NATS is a connective technology that powers modern distributed systems.")
+	for i := 0; i < 10_000; i++ {
+		if _, err := js.Publish("memory-leak", msg); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	}
+
+	// We will verify here that the underlying raft layer for the leader is not > 8192
+	cl := c.consumerLeader("$G", "memory-leak", "q1")
+	mset, err := cl.GlobalAccount().lookupStream("memory-leak")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	o := mset.lookupConsumer("q1")
+	if o == nil {
+		t.Fatalf("Error looking up consumer %q", "q1")
+	}
+	node := o.raftNode().(*raft)
+	if ms := node.wal.(*memStore); ms.State().Msgs > 8192 {
+		t.Fatalf("Did not compact the raft memory WAL")
+	}
+}

--- a/server/store.go
+++ b/server/store.go
@@ -156,6 +156,7 @@ type ConsumerStore interface {
 	UpdateAcks(dseq, sseq uint64) error
 	Update(*ConsumerState) error
 	State() (*ConsumerState, error)
+	Type() StorageType
 	Stop() error
 	Delete() error
 	StreamDelete() error


### PR DESCRIPTION
Replicated durable consumers that were backed by a memory store were bypassing snapshotting which also did compaction of the raft WAL.
This change adapts for memory store backed consumers by compacting the raft WAL directly on snapshot logic.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #2548 

/cc @nats-io/core
