### PR TITLE
[added] value to JS stats showing memory used from accounts with reservations

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -49,14 +49,14 @@ type JetStreamConfig struct {
 }
 
 type JetStreamStats struct {
-	Memory            uint64            `json:"memory"`
-	Store             uint64            `json:"storage"`
-	MemoryReserveUsed uint64            `json:"reserved_memory_used,omitempty"`
-	StoreReserveUsed  uint64            `json:"reserved_storage_used,omitempty"`
-	Accounts          int               `json:"accounts,omitempty"`
-	API               JetStreamAPIStats `json:"api"`
-	ReservedMemory    uint64            `json:"reserved_memory,omitempty"`
-	ReservedStore     uint64            `json:"reserved_storage,omitempty"`
+	Memory             uint64            `json:"memory"`
+	Store              uint64            `json:"storage"`
+	ReservedMemoryUsed uint64            `json:"reserved_memory_used,omitempty"`
+	ReserveStoreUsed   uint64            `json:"reserved_storage_used,omitempty"`
+	Accounts           int               `json:"accounts,omitempty"`
+	API                JetStreamAPIStats `json:"api"`
+	ReservedMemory     uint64            `json:"reserved_memory,omitempty"`
+	ReservedStore      uint64            `json:"reserved_storage,omitempty"`
 }
 
 type JetStreamAccountLimits struct {
@@ -1301,17 +1301,17 @@ func (a *Account) UpdateJetStreamLimits(limits *JetStreamAccountLimits) error {
 	js.releaseResources(&jsaLimits)
 	js.reserveResources(limits)
 	if jsaLimits.MaxMemory >= 0 && limits.MaxMemory < 0 {
-		// we had a reserve and am now dropping it
+		// we had a reserve and are now dropping it
 		atomic.AddInt64(&js.memTotalRes, -jsa.memTotal)
 	} else if jsaLimits.MaxMemory < 0 && limits.MaxMemory >= 0 {
-		// we had no reserve and am now adding it
+		// we had no reserve and are now adding it
 		atomic.AddInt64(&js.memTotalRes, jsa.memTotal)
 	}
 	if jsaLimits.MaxStore >= 0 && limits.MaxStore < 0 {
-		// we had a reserve and am now dropping it
+		// we had a reserve and are now dropping it
 		atomic.AddInt64(&js.storeTotalRes, -jsa.storeTotal)
 	} else if jsaLimits.MaxStore < 0 && limits.MaxStore >= 0 {
-		// we had no reserve and am now adding it
+		// we had no reserve and are now adding it
 		atomic.AddInt64(&js.storeTotalRes, jsa.storeTotal)
 	}
 	js.mu.Unlock()
@@ -1691,8 +1691,8 @@ func (js *jetStream) usageStats() *JetStreamStats {
 	stats.API.Errors = (uint64)(atomic.LoadInt64(&js.apiErrors))
 	stats.Memory = (uint64)(atomic.LoadInt64(&js.memTotal))
 	stats.Store = (uint64)(atomic.LoadInt64(&js.storeTotal))
-	stats.MemoryReserveUsed = (uint64)(atomic.LoadInt64(&js.memTotalRes))
-	stats.StoreReserveUsed = (uint64)(atomic.LoadInt64(&js.storeTotalRes))
+	stats.ReservedMemoryUsed = (uint64)(atomic.LoadInt64(&js.memTotalRes))
+	stats.ReserveStoreUsed = (uint64)(atomic.LoadInt64(&js.storeTotalRes))
 	return &stats
 }
 

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -3928,7 +3928,7 @@ func checkForJSClusterUp(t *testing.T, servers ...*Server) {
 	})
 }
 
-func TestMonitorJsz2(t *testing.T) {
+func TestMonitorJsz(t *testing.T) {
 	readJsInfo := func(url string) *JSInfo {
 		t.Helper()
 		body := readBody(t, url)
@@ -4240,11 +4240,11 @@ func TestMonitorJszAccountReserves(t *testing.T) {
 			memory = info.Memory
 			store = info.Store
 		}
-		if info.MemoryReserveUsed != memory {
-			t.Fatalf("expected %d bytes reserved memory used, got %d bytes", memory, info.MemoryReserveUsed)
+		if info.ReservedMemoryUsed != memory {
+			t.Fatalf("expected %d bytes reserved memory used, got %d bytes", memory, info.ReservedMemoryUsed)
 		}
-		if info.StoreReserveUsed != store {
-			t.Fatalf("expected %d bytes reserved store used, got %d bytes", store, info.StoreReserveUsed)
+		if info.ReserveStoreUsed != store {
+			t.Fatalf("expected %d bytes reserved store used, got %d bytes", store, info.ReserveStoreUsed)
 		}
 	}
 

--- a/server/reload.go
+++ b/server/reload.go
@@ -1614,7 +1614,6 @@ func (s *Server) reloadAuthorization() {
 
 	// We will double check all JetStream configs on a reload.
 	if checkJetStream {
-		s.getJetStream().clearResources()
 		if err := s.enableJetStreamAccounts(); err != nil {
 			s.Errorf(err.Error())
 		}


### PR DESCRIPTION
[fixed] reservations accounting issue on reload introduced by:
commit: bfb726e8e979e0b44497b34e54a6209174d1c14b
clearResources appeared to have been a workaround and broke
reload for non global accounts

Signed-off-by: Matthias Hanel <mh@synadia.com>

As @ripienaar pointed out [here](https://github.com/nats-io/nats-server/pull/2539/files#r712878686), memory/storage in combination with dynamic accounts where cumbersome. 
So I added more values so to show how much of total usage accounted to accounts with reservations. 
If you want I can add another pair of values that are `totalused-reservedused`, but had a hard time finding a name for that.

When writing the unit test I noticed bad reservation values after a reload.
This was introduced by this [commit](https://github.com/nats-io/nats-server/commit/bfb726e8e979e0b44497b34e54a6209174d1c14b). 
By setting the limits for the global account, `s.configJetStream(gacc);` should actually do something and make the manual call for `gacc.EnableJetStream(nil)` obsolete. 
With that call gone, `s.getJetStream().clearResources()` was not needed anymore as `configJetStream` does the right thing with respect to updates.

Please note that the unit test modified with the original commit is untouched and still works.