### PR TITLE
[FIXED] Deadlock with stream mirrors

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.6.0"
+	VERSION = "2.6.1"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2360,7 +2360,7 @@ func (o *consumer) deliverMsg(dsubj, subj string, hdr, msg []byte, seq, dc uint6
 	// If we are ack none and mset is interest only we should make sure stream removes interest.
 	if ap == AckNone && mset.cfg.Retention != LimitsPolicy {
 		if o.node == nil || o.cfg.Direct {
-			mset.amch <- seq
+			mset.ackq.push(seq)
 		} else {
 			o.updateAcks(dseq, seq)
 		}


### PR DESCRIPTION
Fix for deadlock with stream mirrors or sources where origin is interest or workqueue policy.
This would cause an interaction with channels and locks that could cause a deadlock.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
