### PR TITLE
fixes the msg get audit event

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2415,13 +2415,14 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, _ *Account, subje
 
 	var subj string
 	var hdr []byte
+	var data []byte
 	var ts int64
 	seq := req.Seq
 
 	if req.Seq > 0 {
-		subj, hdr, msg, ts, err = mset.store.LoadMsg(req.Seq)
+		subj, hdr, data, ts, err = mset.store.LoadMsg(req.Seq)
 	} else {
-		subj, seq, hdr, msg, ts, err = mset.store.LoadLastMsg(req.LastFor)
+		subj, seq, hdr, data, ts, err = mset.store.LoadLastMsg(req.LastFor)
 	}
 	if err != nil {
 		resp.Error = NewJSNoMessageFoundError()
@@ -2432,7 +2433,7 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, _ *Account, subje
 		Subject:  subj,
 		Sequence: seq,
 		Header:   hdr,
-		Data:     msg,
+		Data:     data,
 		Time:     time.Unix(0, ts).UTC(),
 	}
 	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))


### PR DESCRIPTION
We resused msg variable for both the request
and later the data loaded from the stream.

The data thus replaces the request and the audit
had the data as both request and response

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
