### PR TITLE
[FIXED] JetStream: data race on shutdown

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -863,7 +863,7 @@ func (o *consumer) subscribeInternal(subject string, cb msgHandler) (*subscripti
 	if c == nil {
 		return nil, fmt.Errorf("invalid consumer")
 	}
-	if !c.srv.eventsEnabled() {
+	if !c.srv.EventsEnabled() {
 		return nil, ErrNoSysAccount
 	}
 	if cb == nil {

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1885,7 +1885,7 @@ func (t *streamTemplate) createTemplateSubscriptions() error {
 		return fmt.Errorf("template not enabled")
 	}
 	c := t.tc
-	if !c.srv.eventsEnabled() {
+	if !c.srv.EventsEnabled() {
 		return ErrNoSysAccount
 	}
 	sid := 1


### PR DESCRIPTION
Replaced use of eventsEnabled() with EventsEnabled() that will
check under server lock. Also found another reference when
creating templates.

Resolves #2588

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
