### PR TITLE
Allow consumers to request only headers to be delivered

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -222,6 +222,7 @@ const (
 	JSLastStreamSeq       = "Nats-Last-Stream"
 	JSConsumerStalled     = "Nats-Consumer-Stalled"
 	JSMsgRollup           = "Nats-Rollup"
+	JSMsgSize             = "Nats-Msg-Size"
 )
 
 // Rollups, can be subject only or all messages.


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
