### PR TITLE
[IMPROVED] MQTT: add client id to client connection string

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -732,6 +732,10 @@ func (c *client) mqttParse(buf []byte) error {
 			var cp *mqttConnectProto
 			var sessp bool
 			rc, cp, err = c.mqttParseConnect(r, pl)
+			// Add the client id to the client's string, regardless of error.
+			// We may still get the client_id if the call above fails somewhere
+			// after parsing the client ID itself.
+			c.ncs.Store(fmt.Sprintf("%s - %q", c, c.mqtt.cid))
 			if trace && cp != nil {
 				c.traceInOp("CONNECT", errOrTrace(err, c.mqttConnectTrace(cp)))
 			}
@@ -744,6 +748,9 @@ func (c *client) mqttParse(buf []byte) error {
 				if err = s.mqttProcessConnect(c, cp, trace); err != nil {
 					err = fmt.Errorf("unable to connect: %v", err)
 				} else {
+					// Add this debug statement so users running in Debug mode
+					// will have the client id printed here for the first time.
+					c.Debugf("Client connected")
 					connected = true
 					rd = cp.rd
 				}


### PR DESCRIPTION
This way, any log statement for a client will include the client id,
similar to how the server now logs information about NATS clients
(such as language, version, connection name).

Also adding a debug statement once the client has successfully connected.

Here is how this will look like for a client with client id "client_0".
```
[69591] 2021/10/06 10:06:50.837977 [DBG] [::1]:57415 - mid:18 - Client connection created
[69591] 2021/10/06 10:06:50.839871 [DBG] [::1]:57415 - mid:18 - "client_0" - Client connected
[69591] 2021/10/06 10:07:00.627307 [DBG] [::1]:57415 - mid:18 - "client_0" - Client connection closed: Client Closed
```
All log statements will be affected, for instance here is an auth error:
```
[69591] 2021/10/06 10:09:48.618964 [DBG] [::1]:57424 - mid:23 - Client connection created
[69591] 2021/10/06 10:09:48.619015 [ERR] [::1]:57424 - mid:23 - "client_0" - authentication error - User "mqtt"
[69591] 2021/10/06 10:09:48.619026 [DBG] [::1]:57424 - mid:23 - "client_0" - Client connection closed: Authentication Failure
[69591] 2021/10/06 10:09:48.619038 [ERR] [::1]:57424 - mid:23 - "client_0" - unable to connect: authentication error
```

Resolves #2587

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
