### PR TITLE
Fixed data race in setSourceConsumer

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -1817,7 +1817,7 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64) {
 	respCh := make(chan *JSApiConsumerCreateResponse, 1)
 	reply := infoReplySubject()
 	crSub, _ := mset.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-		mset.unsubscribe(sub)
+		mset.unsubscribeUnlocked(sub)
 		_, msg := c.msgParts(rmsg)
 		var ccr JSApiConsumerCreateResponse
 		if err := json.Unmarshal(msg, &ccr); err != nil {
@@ -1871,7 +1871,7 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64) {
 			}
 			mset.mu.Unlock()
 		case <-time.After(10 * time.Second):
-			mset.unsubscribe(crSub)
+			mset.unsubscribeUnlocked(crSub)
 			return
 		}
 	}()


### PR DESCRIPTION
Call to mset.unsubscribe() need to use the version that uses
locking when invoked from the subscription callback or from the
go routine when the 10secs have elapsed.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
