### PR TITLE
Adding tracing facility

### DIFF
--- a/server/client_test.go
+++ b/server/client_test.go
@@ -65,13 +65,13 @@ func (c *testAsyncClient) close() {
 }
 
 func (c *testAsyncClient) parse(proto []byte) error {
-	err := c.client.parse(proto)
+	err := c.client.parse(proto, dummyTCtx)
 	c.client.flushClients(0)
 	return err
 }
 
 func (c *testAsyncClient) parseAndClose(proto []byte) {
-	c.client.parse(proto)
+	c.client.parse(proto, dummyTCtx)
 	c.client.flushClients(0)
 	c.closeConnection(ClientClosed)
 }
@@ -123,7 +123,7 @@ func genAsyncParser(c *client) (func(string), chan bool) {
 		for {
 			select {
 			case cs := <-pab:
-				c.parse(cs)
+				c.parse(cs, dummyTCtx)
 				c.flushClients(0)
 			case <-quit:
 				return

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -849,7 +849,7 @@ func (o *consumer) handleClusterConsumerInfoRequest(sub *subscription, c *client
 }
 
 // Lock should be held.
-func (o *consumer) subscribeInternal(subject string, cb msgHandler) (*subscription, error) {
+func (o *consumer) subscribeInternal(subject string, cb internalMsgHandler) (*subscription, error) {
 	c := o.client
 	if c == nil {
 		return nil, fmt.Errorf("invalid consumer")
@@ -864,7 +864,7 @@ func (o *consumer) subscribeInternal(subject string, cb msgHandler) (*subscripti
 	o.sid++
 
 	// Now create the subscription
-	return c.processSub([]byte(subject), nil, []byte(strconv.Itoa(o.sid)), cb, false)
+	return c.processSub([]byte(subject), nil, []byte(strconv.Itoa(o.sid)), wrapIntoMsgHandler(cb), false)
 }
 
 // Unsubscribe from our subscription.

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1933,7 +1933,7 @@ func (t *streamTemplate) createTemplateSubscriptions() error {
 	return nil
 }
 
-func (t *streamTemplate) processInboundTemplateMsg(_ *subscription, pc *client, acc *Account, subject, reply string, msg []byte) {
+func (t *streamTemplate) processInboundTemplateMsg(_ *subscription, pc *client, acc *Account, subject, reply string, msg []byte, tCtx *traceCtx) {
 	if t == nil || t.jsa == nil {
 		return
 	}
@@ -1976,7 +1976,7 @@ func (t *streamTemplate) processInboundTemplateMsg(_ *subscription, pc *client, 
 	}
 
 	// Process this message directly by invoking mset.
-	mset.processInboundJetStreamMsg(nil, pc, acc, subject, reply, msg)
+	mset.processInboundJetStreamMsg(nil, pc, acc, subject, reply, msg, tCtx)
 }
 
 // lookupStreamTemplate looks up the names stream template.

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -2,7 +2,9 @@
 
 package server
 
-import "strings"
+import (
+	"strings"
+)
 
 const (
 	// JSAccountResourcesExceededErr resource limits exceeded for account

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -974,6 +974,9 @@ func (c *client) processLeafnodeInfo(info *Info) {
 		} else {
 			c.leaf.remoteServer = info.Name
 		}
+		if info.ID != _EMPTY_ {
+			c.leaf.remoteId = info.ID
+		}
 		c.leaf.remoteDomain = info.Domain
 		c.leaf.remoteCluster = info.Cluster
 	}

--- a/server/opts.go
+++ b/server/opts.go
@@ -747,13 +747,22 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 			*errors = append(*errors, err)
 			return
 		}
-	case "msg_trace":
+	case "operator_msg_trace":
 		tp, err := parseMsgTracePolicies(tk, errors, warnings, true)
 		if err != nil {
 			*errors = append(*errors, err)
 			return
 		}
 		o.MsgTracePolicy = tp
+	case "msg_trace":
+		gacc := NewAccount(globalAccountName)
+		o.Accounts = append(o.Accounts, gacc)
+		tp, err := parseMsgTracePolicies(tk, errors, warnings, true)
+		if err != nil {
+			*errors = append(*errors, err)
+			return
+		}
+		gacc.traces = tp
 	case "ping_probes":
 		gacc := NewAccount(globalAccountName)
 		o.Accounts = append(o.Accounts, gacc)

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -3226,7 +3226,7 @@ func TestResolverPinnedAccountsFail(t *testing.T) {
 
 func TestTracePolicy(t *testing.T) {
 	cfgFmt := `
-		msg_trace: {
+		operator_msg_trace: {
 			foo: {Subject: foo, Freq: 0.1}
 			bar: {Subject: foo, Freq: 0.5, NotSubject: bar, Probes: ["connz", "accountz"]}
 		}
@@ -3246,6 +3246,11 @@ func TestTracePolicy(t *testing.T) {
 			E: {
 				ping_probes: ["connz", "accountz"]
 			}
+		}
+		# $G settings
+		ping_probes: all
+		msg_trace: {
+			baz: {Subject: bazzz}
 		}
 	`
 
@@ -3296,6 +3301,18 @@ func TestTracePolicy(t *testing.T) {
 	a = accs["E"]
 	require_True(t, a.pingProbes != nil)
 	require_True(t, *a.pingProbes == probes{Connz: true, Accountz: true})
+
+	s, err := NewServer(opts)
+	require_NoError(t, err)
+
+	trc, ok = s.gacc.traces["baz"]
+	require_True(t, ok)
+	require_Equal(t, trc.Subject, "bazzz")
+	require_True(t, s.gacc.pingProbes != nil)
+	require_True(t, !s.gacc.pingProbes.Varz)
+	require_True(t, s.gacc.pingProbes.Accountz)
+	require_True(t, s.gacc.pingProbes.Msg)
+	require_True(t, s.gacc.pingProbes.Connz)
 }
 
 func TestMaxSubTokens(t *testing.T) {

--- a/server/parser.go
+++ b/server/parser.go
@@ -131,11 +131,11 @@ const (
 	INFO_ARG
 )
 
-func (c *client) parse(buf []byte) error {
+func (c *client) parse(buf []byte, tCtx *traceCtx) error {
 	// Branch out to mqtt clients. c.mqtt is immutable, but should it become
 	// an issue (say data race detection), we could branch outside in readLoop
 	if c.isMqtt() {
-		return c.mqttParse(buf)
+		return c.mqttParse(buf, tCtx)
 	}
 	var i int
 	var b byte
@@ -474,7 +474,7 @@ func (c *client) parse(buf []byte) error {
 				c.traceMsg(c.msgBuf)
 			}
 
-			c.processInboundMsg(c.msgBuf)
+			c.processInboundMsg(c.msgBuf, tCtx)
 			c.argBuf, c.msgBuf, c.header = nil, nil, nil
 			c.drop, c.as, c.state = 0, i+1, OP_START
 			// Drop all pub args

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -26,49 +26,51 @@ func dummyRouteClient() *client {
 	return &client{srv: New(&defaultServerOptions), kind: ROUTER}
 }
 
+var dummyTCtx = &traceCtx{}
+
 func TestParsePing(t *testing.T) {
 	c := dummyClient()
 	if c.state != OP_START {
 		t.Fatalf("Expected OP_START vs %d\n", c.state)
 	}
 	ping := []byte("PING\r\n")
-	err := c.parse(ping[:1])
+	err := c.parse(ping[:1], dummyTCtx)
 	if err != nil || c.state != OP_P {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(ping[1:2])
+	err = c.parse(ping[1:2], dummyTCtx)
 	if err != nil || c.state != OP_PI {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(ping[2:3])
+	err = c.parse(ping[2:3], dummyTCtx)
 	if err != nil || c.state != OP_PIN {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(ping[3:4])
+	err = c.parse(ping[3:4], dummyTCtx)
 	if err != nil || c.state != OP_PING {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(ping[4:5])
+	err = c.parse(ping[4:5], dummyTCtx)
 	if err != nil || c.state != OP_PING {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(ping[5:6])
+	err = c.parse(ping[5:6], dummyTCtx)
 	if err != nil || c.state != OP_START {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(ping)
+	err = c.parse(ping, dummyTCtx)
 	if err != nil || c.state != OP_START {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
 	// Should tolerate spaces
 	ping = []byte("PING  \r")
-	err = c.parse(ping)
+	err = c.parse(ping, dummyTCtx)
 	if err != nil || c.state != OP_PING {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
 	c.state = OP_START
 	ping = []byte("PING  \r  \n")
-	err = c.parse(ping)
+	err = c.parse(ping, dummyTCtx)
 	if err != nil || c.state != OP_START {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -80,34 +82,34 @@ func TestParsePong(t *testing.T) {
 		t.Fatalf("Expected OP_START vs %d\n", c.state)
 	}
 	pong := []byte("PONG\r\n")
-	err := c.parse(pong[:1])
+	err := c.parse(pong[:1], dummyTCtx)
 	if err != nil || c.state != OP_P {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(pong[1:2])
+	err = c.parse(pong[1:2], dummyTCtx)
 	if err != nil || c.state != OP_PO {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(pong[2:3])
+	err = c.parse(pong[2:3], dummyTCtx)
 	if err != nil || c.state != OP_PON {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(pong[3:4])
+	err = c.parse(pong[3:4], dummyTCtx)
 	if err != nil || c.state != OP_PONG {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(pong[4:5])
+	err = c.parse(pong[4:5], dummyTCtx)
 	if err != nil || c.state != OP_PONG {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(pong[5:6])
+	err = c.parse(pong[5:6], dummyTCtx)
 	if err != nil || c.state != OP_START {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
 	if c.ping.out != 0 {
 		t.Fatalf("Unexpected ping.out value: %d vs 0\n", c.ping.out)
 	}
-	err = c.parse(pong)
+	err = c.parse(pong, dummyTCtx)
 	if err != nil || c.state != OP_START {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -116,13 +118,13 @@ func TestParsePong(t *testing.T) {
 	}
 	// Should tolerate spaces
 	pong = []byte("PONG  \r")
-	err = c.parse(pong)
+	err = c.parse(pong, dummyTCtx)
 	if err != nil || c.state != OP_PONG {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
 	c.state = OP_START
 	pong = []byte("PONG  \r  \n")
-	err = c.parse(pong)
+	err = c.parse(pong, dummyTCtx)
 	if err != nil || c.state != OP_START {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -134,7 +136,7 @@ func TestParsePong(t *testing.T) {
 	c.state = OP_START
 	c.ping.out = 10
 	pong = []byte("PONG\r\n")
-	err = c.parse(pong)
+	err = c.parse(pong, dummyTCtx)
 	if err != nil || c.state != OP_START {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -146,7 +148,7 @@ func TestParsePong(t *testing.T) {
 func TestParseConnect(t *testing.T) {
 	c := dummyClient()
 	connect := []byte("CONNECT {\"verbose\":false,\"pedantic\":true,\"tls_required\":false}\r\n")
-	err := c.parse(connect)
+	err := c.parse(connect, dummyTCtx)
 	if err != nil || c.state != OP_START {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -159,7 +161,7 @@ func TestParseConnect(t *testing.T) {
 func TestParseSub(t *testing.T) {
 	c := dummyClient()
 	sub := []byte("SUB foo 1\r")
-	err := c.parse(sub)
+	err := c.parse(sub, dummyTCtx)
 	if err != nil || c.state != SUB_ARG {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -179,7 +181,7 @@ func TestParsePub(t *testing.T) {
 	c := dummyClient()
 
 	pub := []byte("PUB foo 5\r\nhello\r")
-	err := c.parse(pub)
+	err := c.parse(pub, dummyTCtx)
 	if err != nil || c.state != MSG_END_N {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -197,7 +199,7 @@ func TestParsePub(t *testing.T) {
 	c.argBuf, c.msgBuf, c.state = nil, nil, OP_START
 
 	pub = []byte("PUB foo.bar INBOX.22 11\r\nhello world\r")
-	err = c.parse(pub)
+	err = c.parse(pub, dummyTCtx)
 	if err != nil || c.state != MSG_END_N {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -216,7 +218,7 @@ func TestParsePub(t *testing.T) {
 
 	// This is the case when data has more bytes than expected by size.
 	pub = []byte("PUB foo.bar 11\r\nhello world hello world\r")
-	err = c.parse(pub)
+	err = c.parse(pub, dummyTCtx)
 	if err == nil {
 		t.Fatalf("Expected an error parsing longer than expected message body")
 	}
@@ -230,7 +232,7 @@ func TestParsePubSizeOverflow(t *testing.T) {
 	c := dummyClient()
 
 	pub := []byte("PUB foo 3333333333333333333333333333333333333333333333333333333333333333\r\n")
-	if err := c.parse(pub); err == nil {
+	if err := c.parse(pub, dummyTCtx); err == nil {
 		t.Fatalf("Expected an error")
 	}
 }
@@ -312,7 +314,7 @@ func TestParseHeaderPub(t *testing.T) {
 	c.headers = true
 
 	hpub := []byte("HPUB foo 12 17\r\nname:derek\r\nHELLO\r")
-	if err := c.parse(hpub); err != nil || c.state != MSG_END_N {
+	if err := c.parse(hpub, dummyTCtx); err != nil || c.state != MSG_END_N {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
 	if !bytes.Equal(c.pa.subject, []byte("foo")) {
@@ -335,7 +337,7 @@ func TestParseHeaderPub(t *testing.T) {
 	c.argBuf, c.msgBuf, c.state = nil, nil, OP_START
 
 	hpub = []byte("HPUB foo INBOX.22 12 17\r\nname:derek\r\nHELLO\r")
-	if err := c.parse(hpub); err != nil || c.state != MSG_END_N {
+	if err := c.parse(hpub, dummyTCtx); err != nil || c.state != MSG_END_N {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
 	if !bytes.Equal(c.pa.subject, []byte("foo")) {
@@ -358,7 +360,7 @@ func TestParseHeaderPub(t *testing.T) {
 	c.argBuf, c.msgBuf, c.state = nil, nil, OP_START
 
 	hpub = []byte("HPUB foo INBOX.22 0 5\r\nHELLO\r")
-	if err := c.parse(hpub); err != nil || c.state != MSG_END_N {
+	if err := c.parse(hpub, dummyTCtx); err != nil || c.state != MSG_END_N {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
 	if !bytes.Equal(c.pa.subject, []byte("foo")) {
@@ -450,7 +452,7 @@ func TestParseRoutedHeaderMsg(t *testing.T) {
 	c := dummyRouteClient()
 
 	pub := []byte("HMSG $foo foo 10 8\r\nXXXhello\r")
-	if err := c.parse(pub); err == nil {
+	if err := c.parse(pub, dummyTCtx); err == nil {
 		t.Fatalf("Expected an error")
 	}
 
@@ -458,7 +460,7 @@ func TestParseRoutedHeaderMsg(t *testing.T) {
 	c.argBuf, c.msgBuf, c.state = nil, nil, OP_START
 
 	pub = []byte("HMSG $foo foo 3 8\r\nXXXhello\r")
-	err := c.parse(pub)
+	err := c.parse(pub, dummyTCtx)
 	if err != nil || c.state != MSG_END_N {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -482,7 +484,7 @@ func TestParseRoutedHeaderMsg(t *testing.T) {
 	c.argBuf, c.msgBuf, c.state = nil, nil, OP_START
 
 	pub = []byte("HMSG $G foo.bar INBOX.22 3 14\r\nOK:hello world\r")
-	err = c.parse(pub)
+	err = c.parse(pub, dummyTCtx)
 	if err != nil || c.state != MSG_END_N {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -506,7 +508,7 @@ func TestParseRoutedHeaderMsg(t *testing.T) {
 	c.argBuf, c.msgBuf, c.state = nil, nil, OP_START
 
 	pub = []byte("HMSG $G foo.bar + reply baz 3 14\r\nOK:hello world\r")
-	err = c.parse(pub)
+	err = c.parse(pub, dummyTCtx)
 	if err != nil || c.state != MSG_END_N {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -536,7 +538,7 @@ func TestParseRoutedHeaderMsg(t *testing.T) {
 	c.argBuf, c.msgBuf, c.state = nil, nil, OP_START
 
 	pub = []byte("HMSG $G foo.bar | baz 3 14\r\nOK:hello world\r")
-	err = c.parse(pub)
+	err = c.parse(pub, dummyTCtx)
 	if err != nil || c.state != MSG_END_N {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -567,12 +569,12 @@ func TestParseRouteMsg(t *testing.T) {
 	c := dummyRouteClient()
 
 	pub := []byte("MSG $foo foo 5\r\nhello\r")
-	err := c.parse(pub)
+	err := c.parse(pub, dummyTCtx)
 	if err == nil {
 		t.Fatalf("Expected an error, got none")
 	}
 	pub = []byte("RMSG $foo foo 5\r\nhello\r")
-	err = c.parse(pub)
+	err = c.parse(pub, dummyTCtx)
 	if err != nil || c.state != MSG_END_N {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -593,7 +595,7 @@ func TestParseRouteMsg(t *testing.T) {
 	c.argBuf, c.msgBuf, c.state = nil, nil, OP_START
 
 	pub = []byte("RMSG $G foo.bar INBOX.22 11\r\nhello world\r")
-	err = c.parse(pub)
+	err = c.parse(pub, dummyTCtx)
 	if err != nil || c.state != MSG_END_N {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -614,7 +616,7 @@ func TestParseRouteMsg(t *testing.T) {
 	c.argBuf, c.msgBuf, c.state = nil, nil, OP_START
 
 	pub = []byte("RMSG $G foo.bar + reply baz 11\r\nhello world\r")
-	err = c.parse(pub)
+	err = c.parse(pub, dummyTCtx)
 	if err != nil || c.state != MSG_END_N {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -638,7 +640,7 @@ func TestParseRouteMsg(t *testing.T) {
 	c.argBuf, c.msgBuf, c.state = nil, nil, OP_START
 
 	pub = []byte("RMSG $G foo.bar | baz 11\r\nhello world\r")
-	err = c.parse(pub)
+	err = c.parse(pub, dummyTCtx)
 	if err != nil || c.state != MSG_END_N {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -663,14 +665,14 @@ func TestParseMsgSpace(t *testing.T) {
 	c := dummyRouteClient()
 
 	// Ivan bug he found
-	if err := c.parse([]byte("MSG \r\n")); err == nil {
+	if err := c.parse([]byte("MSG \r\n"), dummyTCtx); err == nil {
 		t.Fatalf("Expected parse error for MSG <SPC>")
 	}
 
 	c = dummyClient()
 
 	// Anything with an M from a client should parse error
-	if err := c.parse([]byte("M")); err == nil {
+	if err := c.parse([]byte("M"), dummyTCtx); err == nil {
 		t.Fatalf("Expected parse error for M* from a client")
 	}
 }
@@ -694,7 +696,7 @@ func TestShouldFail(t *testing.T) {
 	}
 	for _, proto := range wrongProtos {
 		c := dummyClient()
-		if err := c.parse([]byte(proto)); err == nil {
+		if err := c.parse([]byte(proto), dummyTCtx); err == nil {
 			t.Fatalf("Should have received a parse error for: %v", proto)
 		}
 	}
@@ -704,7 +706,7 @@ func TestShouldFail(t *testing.T) {
 	for _, proto := range wrongProtos {
 		c := dummyClient()
 		c.kind = ROUTER
-		if err := c.parse([]byte(proto)); err == nil {
+		if err := c.parse([]byte(proto), dummyTCtx); err == nil {
 			t.Fatalf("Should have received a parse error for: %v", proto)
 		}
 	}
@@ -788,23 +790,23 @@ func TestParseOK(t *testing.T) {
 		t.Fatalf("Expected OP_START vs %d\n", c.state)
 	}
 	okProto := []byte("+OK\r\n")
-	err := c.parse(okProto[:1])
+	err := c.parse(okProto[:1], dummyTCtx)
 	if err != nil || c.state != OP_PLUS {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(okProto[1:2])
+	err = c.parse(okProto[1:2], dummyTCtx)
 	if err != nil || c.state != OP_PLUS_O {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(okProto[2:3])
+	err = c.parse(okProto[2:3], dummyTCtx)
 	if err != nil || c.state != OP_PLUS_OK {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(okProto[3:4])
+	err = c.parse(okProto[3:4], dummyTCtx)
 	if err != nil || c.state != OP_PLUS_OK {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
-	err = c.parse(okProto[4:5])
+	err = c.parse(okProto[4:5], dummyTCtx)
 	if err != nil || c.state != OP_START {
 		t.Fatalf("Unexpected: %d : %v\n", c.state, err)
 	}
@@ -840,7 +842,7 @@ func TestMaxControlLine(t *testing.T) {
 			// First try with a partial:
 			// PUB foo.bar.baz 2\r\nok\r\n
 			// .............^
-			err := c.parse(pub[:14])
+			err := c.parse(pub[:14], dummyTCtx)
 			switch test.shouldFail {
 			case true:
 				if !ErrorIs(err, ErrMaxControlLine) {
@@ -854,7 +856,7 @@ func TestMaxControlLine(t *testing.T) {
 
 			// Now with full protocol (no split) and we should still enforce.
 			c = setupClient()
-			err = c.parse(pub)
+			err = c.parse(pub, dummyTCtx)
 			switch test.shouldFail {
 			case true:
 				if !ErrorIs(err, ErrMaxControlLine) {

--- a/server/raft.go
+++ b/server/raft.go
@@ -1392,7 +1392,7 @@ const (
 
 // Our internal subscribe.
 // Lock should be held.
-func (n *raft) subscribe(subject string, cb msgHandler) (*subscription, error) {
+func (n *raft) subscribe(subject string, cb internalMsgHandler) (*subscription, error) {
 	return n.s.systemSubscribe(subject, _EMPTY_, false, n.c, cb)
 }
 

--- a/server/reload.go
+++ b/server/reload.go
@@ -885,7 +885,7 @@ func imposeOrder(value interface{}) error {
 		sort.Strings(value.AllowedOrigins)
 	case string, bool, uint8, int, int32, int64, time.Duration, float64, nil, LeafNodeOpts, ClusterOpts, *tls.Config, PinnedCertSet,
 		*URLAccResolver, *MemAccResolver, *DirAccResolver, *CacheDirAccResolver, Authentication, MQTTOpts, jwt.TagList,
-		*OCSPConfig, map[string]string:
+		*OCSPConfig, map[string]string, map[string]Trace:
 		// explicitly skipped types
 	default:
 		// this will fail during unit tests

--- a/server/sendq.go
+++ b/server/sendq.go
@@ -51,6 +51,8 @@ func (sq *sendq) internalLoop() {
 	c.registerWithAccount(s.SystemAccount())
 	c.noIcb = true
 
+	tCtx := newTraceCtx("sendq", s)
+
 	defer c.closeConnection(ClientClosed)
 
 	for s.isRunning() {
@@ -74,7 +76,7 @@ func (sq *sendq) internalLoop() {
 					c.pa.hdb = nil
 					msg = append(pm.msg, _CRLF_...)
 				}
-				c.processInboundClientMsg(msg)
+				c.processInboundClientMsg(msg, tCtx)
 				c.pa.szb = nil
 				// Do this here to nil out below vs up in for loop.
 				next := pm.next

--- a/server/server.go
+++ b/server/server.go
@@ -686,6 +686,9 @@ func (s *Server) configureAccounts() error {
 			// We use this for selecting between multiple weighted destinations.
 			a.prand = rand.New(rand.NewSource(time.Now().UnixNano()))
 		}
+		if acc.pingProbes != nil {
+			a.pingProbes = acc.pingProbes
+		}
 		acc.sl = nil
 		acc.clients = nil
 		s.registerAccountNoLock(a)

--- a/server/server.go
+++ b/server/server.go
@@ -689,6 +689,9 @@ func (s *Server) configureAccounts() error {
 		if acc.pingProbes != nil {
 			a.pingProbes = acc.pingProbes
 		}
+		if acc.traces != nil {
+			a.traces = acc.traces
+		}
 		acc.sl = nil
 		acc.clients = nil
 		s.registerAccountNoLock(a)

--- a/server/server.go
+++ b/server/server.go
@@ -2525,7 +2525,7 @@ func (s *Server) saveClosedClient(c *client, nc net.Conn, reason ClosedState) {
 	c.mu.Lock()
 
 	cc := &closedClient{}
-	cc.fill(c, nc, now)
+	cc.fill(c, nc, now, true)
 	cc.Stop = &now
 	cc.Reason = reason.String()
 

--- a/server/split_test.go
+++ b/server/split_test.go
@@ -35,13 +35,13 @@ func TestSplitBufferSubOp(t *testing.T) {
 	subop1 := subop[:6]
 	subop2 := subop[6:]
 
-	if err := c.parse(subop1); err != nil {
+	if err := c.parse(subop1, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != SUB_ARG {
 		t.Fatalf("Expected SUB_ARG state vs %d\n", c.state)
 	}
-	if err := c.parse(subop2); err != nil {
+	if err := c.parse(subop2, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != OP_START {
@@ -69,7 +69,7 @@ func TestSplitBufferUnsubOp(t *testing.T) {
 	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
 
 	subop := []byte("SUB foo 1024\r\n")
-	if err := c.parse(subop); err != nil {
+	if err := c.parse(subop, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != OP_START {
@@ -80,13 +80,13 @@ func TestSplitBufferUnsubOp(t *testing.T) {
 	unsubop1 := unsubop[:8]
 	unsubop2 := unsubop[8:]
 
-	if err := c.parse(unsubop1); err != nil {
+	if err := c.parse(unsubop1, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != UNSUB_ARG {
 		t.Fatalf("Expected UNSUB_ARG state vs %d\n", c.state)
 	}
-	if err := c.parse(unsubop2); err != nil {
+	if err := c.parse(unsubop2, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != OP_START {
@@ -109,31 +109,31 @@ func TestSplitBufferPubOp(t *testing.T) {
 	pub6 := pub[25:33]
 	pub7 := pub[33:]
 
-	if err := c.parse(pub1); err != nil {
+	if err := c.parse(pub1, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != OP_PU {
 		t.Fatalf("Expected OP_PU state vs %d\n", c.state)
 	}
-	if err := c.parse(pub2); err != nil {
+	if err := c.parse(pub2, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != PUB_ARG {
 		t.Fatalf("Expected OP_PU state vs %d\n", c.state)
 	}
-	if err := c.parse(pub3); err != nil {
+	if err := c.parse(pub3, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != PUB_ARG {
 		t.Fatalf("Expected OP_PU state vs %d\n", c.state)
 	}
-	if err := c.parse(pub4); err != nil {
+	if err := c.parse(pub4, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != PUB_ARG {
 		t.Fatalf("Expected PUB_ARG state vs %d\n", c.state)
 	}
-	if err := c.parse(pub5); err != nil {
+	if err := c.parse(pub5, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != MSG_PAYLOAD {
@@ -150,13 +150,13 @@ func TestSplitBufferPubOp(t *testing.T) {
 	if c.pa.size != 11 {
 		t.Fatalf("PUB arg msg size incorrect: %d\n", c.pa.size)
 	}
-	if err := c.parse(pub6); err != nil {
+	if err := c.parse(pub6, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != MSG_PAYLOAD {
 		t.Fatalf("Expected MSG_PAYLOAD state vs %d\n", c.state)
 	}
-	if err := c.parse(pub7); err != nil {
+	if err := c.parse(pub7, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != MSG_END_N {
@@ -170,13 +170,13 @@ func TestSplitBufferPubOp2(t *testing.T) {
 	pub1 := pub[:30]
 	pub2 := pub[30:]
 
-	if err := c.parse(pub1); err != nil {
+	if err := c.parse(pub1, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != MSG_PAYLOAD {
 		t.Fatalf("Expected MSG_PAYLOAD state vs %d\n", c.state)
 	}
-	if err := c.parse(pub2); err != nil {
+	if err := c.parse(pub2, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != OP_START {
@@ -189,7 +189,7 @@ func TestSplitBufferPubOp3(t *testing.T) {
 	pubAll := []byte("PUB foo bar 11\r\nhello world\r\n")
 	pub := pubAll[:16]
 
-	if err := c.parse(pub); err != nil {
+	if err := c.parse(pub, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if !bytes.Equal(c.pa.subject, []byte("foo")) {
@@ -215,7 +215,7 @@ func TestSplitBufferPubOp4(t *testing.T) {
 	pubAll := []byte("PUB foo 11\r\nhello world\r\n")
 	pub := pubAll[:12]
 
-	if err := c.parse(pub); err != nil {
+	if err := c.parse(pub, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if !bytes.Equal(c.pa.subject, []byte("foo")) {
@@ -244,7 +244,7 @@ func TestSplitBufferPubOp5(t *testing.T) {
 	// Split between \r and \n
 	pub := pubAll[:len(pubAll)-1]
 
-	if err := c.parse(pub); err != nil {
+	if err := c.parse(pub, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.msgBuf == nil {
@@ -267,14 +267,14 @@ func TestSplitConnectArg(t *testing.T) {
 	c3 := connectAll[22 : len(connectAll)-2]
 	c4 := connectAll[len(connectAll)-2:]
 
-	if err := c.parse(c1); err != nil {
+	if err := c.parse(c1, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.argBuf != nil {
 		t.Fatalf("Unexpected argBug placeholder.\n")
 	}
 
-	if err := c.parse(c2); err != nil {
+	if err := c.parse(c2, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.argBuf == nil {
@@ -284,7 +284,7 @@ func TestSplitConnectArg(t *testing.T) {
 		t.Fatalf("argBuf not correct, received %q, wanted %q\n", argJSON[:14], c.argBuf)
 	}
 
-	if err := c.parse(c3); err != nil {
+	if err := c.parse(c3, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.argBuf == nil {
@@ -295,7 +295,7 @@ func TestSplitConnectArg(t *testing.T) {
 			argJSON[:len(argJSON)-2], c.argBuf)
 	}
 
-	if err := c.parse(c4); err != nil {
+	if err := c.parse(c4, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.argBuf != nil {
@@ -312,36 +312,36 @@ func TestSplitDanglingArgBuf(t *testing.T) {
 
 	// SUB
 	subop := []byte("SUB foo 1\r\n")
-	c.parse(subop[:6])
-	c.parse(subop[6:])
+	c.parse(subop[:6], dummyTCtx)
+	c.parse(subop[6:], dummyTCtx)
 	if c.argBuf != nil {
 		t.Fatalf("Expected c.argBuf to be nil: %q\n", c.argBuf)
 	}
 
 	// UNSUB
 	unsubop := []byte("UNSUB 1024\r\n")
-	c.parse(unsubop[:8])
-	c.parse(unsubop[8:])
+	c.parse(unsubop[:8], dummyTCtx)
+	c.parse(unsubop[8:], dummyTCtx)
 	if c.argBuf != nil {
 		t.Fatalf("Expected c.argBuf to be nil: %q\n", c.argBuf)
 	}
 
 	// PUB
 	pubop := []byte("PUB foo.bar INBOX.22 11\r\nhello world\r\n")
-	c.parse(pubop[:22])
-	c.parse(pubop[22:25])
+	c.parse(pubop[:22], dummyTCtx)
+	c.parse(pubop[22:25], dummyTCtx)
 	if c.argBuf == nil {
 		t.Fatal("Expected a non-nil argBuf!")
 	}
-	c.parse(pubop[25:])
+	c.parse(pubop[25:], dummyTCtx)
 	if c.argBuf != nil {
 		t.Fatalf("Expected c.argBuf to be nil: %q\n", c.argBuf)
 	}
 
 	// MINUS_ERR
 	errop := []byte("-ERR Too Long\r\n")
-	c.parse(errop[:8])
-	c.parse(errop[8:])
+	c.parse(errop[:8], dummyTCtx)
+	c.parse(errop[8:], dummyTCtx)
 	if c.argBuf != nil {
 		t.Fatalf("Expected c.argBuf to be nil: %q\n", c.argBuf)
 	}
@@ -349,16 +349,16 @@ func TestSplitDanglingArgBuf(t *testing.T) {
 	// CONNECT_ARG
 	connop := []byte("CONNECT {\"verbose\":false,\"tls_required\":false," +
 		"\"user\":\"test\",\"pedantic\":true,\"pass\":\"pass\"}\r\n")
-	c.parse(connop[:22])
-	c.parse(connop[22:])
+	c.parse(connop[:22], dummyTCtx)
+	c.parse(connop[22:], dummyTCtx)
 	if c.argBuf != nil {
 		t.Fatalf("Expected c.argBuf to be nil: %q\n", c.argBuf)
 	}
 
 	// INFO_ARG
 	infoop := []byte("INFO {\"server_id\":\"id\"}\r\n")
-	c.parse(infoop[:8])
-	c.parse(infoop[8:])
+	c.parse(infoop[:8], dummyTCtx)
+	c.parse(infoop[8:], dummyTCtx)
 	if c.argBuf != nil {
 		t.Fatalf("Expected c.argBuf to be nil: %q\n", c.argBuf)
 	}
@@ -366,15 +366,15 @@ func TestSplitDanglingArgBuf(t *testing.T) {
 	// MSG (the client has to be a ROUTE)
 	c = &client{msubs: -1, mpay: -1, subs: make(map[string]*subscription), kind: ROUTER}
 	msgop := []byte("RMSG $foo foo 5\r\nhello\r\n")
-	c.parse(msgop[:5])
-	c.parse(msgop[5:10])
+	c.parse(msgop[:5], dummyTCtx)
+	c.parse(msgop[5:10], dummyTCtx)
 	if c.argBuf == nil {
 		t.Fatal("Expected a non-nil argBuf")
 	}
 	if string(c.argBuf) != "$foo " {
 		t.Fatalf("Expected argBuf to be \"$foo \", got %q", string(c.argBuf))
 	}
-	c.parse(msgop[10:])
+	c.parse(msgop[10:], dummyTCtx)
 	if c.argBuf != nil {
 		t.Fatalf("Expected argBuf to be nil: %q", c.argBuf)
 	}
@@ -385,7 +385,7 @@ func TestSplitDanglingArgBuf(t *testing.T) {
 	c.state = OP_START
 	// Parse up-to somewhere in the middle of the payload.
 	// Verify that we have saved the MSG_ARG info
-	c.parse(msgop[:23])
+	c.parse(msgop[:23], dummyTCtx)
 	if c.argBuf == nil {
 		t.Fatal("Expected a non-nil argBuf")
 	}
@@ -405,7 +405,7 @@ func TestSplitDanglingArgBuf(t *testing.T) {
 	if c.msgBuf == nil || string(c.msgBuf) != "hello\r" {
 		t.Fatalf("Expected msgBuf to be \"hello\r\", got %q", c.msgBuf)
 	}
-	c.parse(msgop[23:])
+	c.parse(msgop[23:], dummyTCtx)
 	// At the end, we should have cleaned-up both arg and msg buffers.
 	if c.argBuf != nil {
 		t.Fatalf("Expected argBuf to be nil: %q", c.argBuf)
@@ -456,37 +456,37 @@ func TestSplitBufferMsgOp(t *testing.T) {
 	msg7 := msg[37:40]
 	msg8 := msg[40:]
 
-	if err := c.parse(msg1); err != nil {
+	if err := c.parse(msg1, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != OP_M {
 		t.Fatalf("Expected OP_M state vs %d\n", c.state)
 	}
-	if err := c.parse(msg2); err != nil {
+	if err := c.parse(msg2, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != MSG_ARG {
 		t.Fatalf("Expected MSG_ARG state vs %d\n", c.state)
 	}
-	if err := c.parse(msg3); err != nil {
+	if err := c.parse(msg3, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != MSG_ARG {
 		t.Fatalf("Expected MSG_ARG state vs %d\n", c.state)
 	}
-	if err := c.parse(msg4); err != nil {
+	if err := c.parse(msg4, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != MSG_ARG {
 		t.Fatalf("Expected MSG_ARG state vs %d\n", c.state)
 	}
-	if err := c.parse(msg5); err != nil {
+	if err := c.parse(msg5, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != MSG_ARG {
 		t.Fatalf("Expected MSG_ARG state vs %d\n", c.state)
 	}
-	if err := c.parse(msg6); err != nil {
+	if err := c.parse(msg6, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != MSG_PAYLOAD {
@@ -503,13 +503,13 @@ func TestSplitBufferMsgOp(t *testing.T) {
 	if c.pa.size != 11 {
 		t.Fatalf("MSG arg msg size incorrect: %d\n", c.pa.size)
 	}
-	if err := c.parse(msg7); err != nil {
+	if err := c.parse(msg7, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != MSG_PAYLOAD {
 		t.Fatalf("Expected MSG_PAYLOAD state vs %d\n", c.state)
 	}
-	if err := c.parse(msg8); err != nil {
+	if err := c.parse(msg8, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != MSG_END_N {
@@ -520,7 +520,7 @@ func TestSplitBufferMsgOp(t *testing.T) {
 func TestSplitBufferLeafMsgArg(t *testing.T) {
 	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription), kind: LEAF}
 	msg := []byte("LMSG foo + bar baz 11\r\n")
-	if err := c.parse(msg); err != nil {
+	if err := c.parse(msg, dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != MSG_PAYLOAD {
@@ -545,7 +545,7 @@ func TestSplitBufferLeafMsgArg(t *testing.T) {
 
 	// overwrite msg with payload
 	n := copy(msg, []byte("fffffffffff"))
-	if err := c.parse(msg[:n]); err != nil {
+	if err := c.parse(msg[:n], dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != MSG_END_R {
@@ -555,7 +555,7 @@ func TestSplitBufferLeafMsgArg(t *testing.T) {
 
 	// Finish processing
 	copy(msg, []byte("\r\n"))
-	if err := c.parse(msg[:2]); err != nil {
+	if err := c.parse(msg[:2], dummyTCtx); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)
 	}
 	if c.state != OP_START {

--- a/server/trace.go
+++ b/server/trace.go
@@ -1,0 +1,962 @@
+// Copyright 2021-2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/textproto"
+	"strings"
+	"time"
+)
+
+// Structs used for json serialization of a trace
+type TraceMsg struct {
+	CtxName string `json:"ctx_name,omitempty"`
+	// contains a value corresponding to a TraceSubscription or TraceStore entry with ref set.
+	// When not present or empty, the message originated from a client.
+	MsgRef            string               `json:"msg_ref,omitempty"`
+	StreamRef         string               `json:"stream_ref,omitempty"`
+	StreamType        string               `json:"stream_type,omitempty"`
+	ConsumerRef       string               `json:"consumer_ref,omitempty"`
+	Acc               string               `json:"acc"`
+	SubjectPreMapping string               `json:"subject_pre_mapping,omitempty"`
+	SubjectMatched    string               `json:"subject_matched,omitempty"`
+	Reply             string               `json:"reply_subject,omitempty"`
+	Client            *TraceClient         `json:"client,omitempty"`
+	Subscriptions     []*TraceSubscription `json:"subscriptions,omitempty"`
+	Stores            []*TraceStore        `json:"stores,omitempty"`
+	ProcessingStart   string               `json:"processing_start,omitempty"`
+	ProcessingDur     string               `json:"processing_duration,omitempty"`
+	// Contains Info objects for probes
+	AssociatedInfo *AssociatedTraceInfo `json:"associated_info,omitempty"`
+}
+
+type TraceClient struct {
+	Type     string `json:"type,omitempty"`
+	Kind     string `json:"kind,omitempty"`
+	Name     string `json:"name,omitempty"`
+	ClientId uint64 `json:"client_id,omitempty"`
+	ServerId string `json:"server_id,omitempty"`
+}
+
+type TraceSubscription struct {
+	Sub        string       `json:"subscription"`
+	ImportTo   string       `json:"import_to,omitempty"`
+	ImportSub  string       `json:"import_subscription,omitempty"`
+	SubClient  *TraceClient `json:"client,omitempty"`
+	Acc        string       `json:"acc"`
+	Queue      string       `json:"queue,omitempty"` //todo queue sub across gateway
+	PubSubject string       `json:"subject,omitempty"`
+	Reply      string       `json:"reply_subject,omitempty"`
+	Ref        string       `json:"ref,omitempty"`
+	// When present, contains the reason why the send to the subscription did NOT happen
+	NoSendReason string `json:"no_send_reason,omitempty"`
+}
+
+type TraceStore struct {
+	StreamSubs []string `json:"stream_subjects"`
+	Acc        string   `json:"acc"`
+	PubSubject string   `json:"subject,omitempty"`
+	Ref        string   `json:"ref,omitempty"`
+	// under certain circumstances, this may reference the message that TraceStore is in.
+	// Specifically in the same document, it is possible for a TraceSubscription to exist that is referenced by this.
+	MsgRef     string `json:"msg_ref,omitempty"`
+	StreamRef  string `json:"stream_ref,omitempty"`
+	StreamType string `json:"stream_type,omitempty"`
+	StreamRepl int    `json:"stream_repl,omitempty"`
+	JsMsgId    string `json:"js_msg_id,omitempty"`
+	DidStore   bool   `json:"did_store,omitempty"`
+	// When present, contains the reason why the store did NOT happen
+	NoStoreReason string `json:"no_store_reason,omitempty"`
+}
+
+type AssociatedTraceInfo struct {
+	ConnInfo    []*ConnInfo    `json:"connz,omitempty"`
+	AccountInfo []*AccountInfo `json:"accountz,omitempty"`
+	Varz        *Varz          `json:"varz,omitempty"`
+	Msg         []byte         `json:"msg,omitempty"`
+	Header      http.Header    `json:"header,omitempty"`
+}
+
+// Header used for tracing
+// When present, the message will not actually be delivered to subscriber/JetStream or across accounts.
+// This header only requires presence, but can contain a list of comma separated probe names.
+// The message body can contain a comma separated list of server ids to filter which server respond.
+// (use if your setup limits response messages)
+const TracePing = "Nats-Ping"
+
+// Tracing System Header.
+const TraceHeader = "Nats-Trace"
+
+// Content of TraceHeader
+type traceHeader struct {
+	Ref    string           `json:"msg_ref,omitempty"`
+	Traces []*selectedTrace `json:"traces,omitempty"`
+}
+
+// Tracing rule that fired.
+type selectedTrace struct {
+	Name string `json:"name"`
+	// include always. not all policies may be present in every server.
+	TrcSubj  string `json:"trc_subj"`
+	LocalAcc string `json:"local_acc,omitempty"`
+	probes   `json:"probes,omitempty"`
+	sendAcc  *Account
+}
+
+func (trc *selectedTrace) IsOperatorTrace() bool {
+	return trc.LocalAcc == _EMPTY_
+}
+
+// multiple selected traces that share the actual trace message but vary on the details
+type traceGroup struct {
+	traces   []*selectedTrace
+	traceMsg TraceMsg
+}
+
+// A tracing context is per receive loop. Do not access concurrently!!!
+type traceCtx struct {
+	hasTrace      bool
+	trcHdrSet     bool
+	srv           *Server
+	rnd           *rand.Rand
+	traceStart    time.Time
+	ctxName       string
+	global        traceGroup // no matter how many traces match, the message will always be the same
+	pub           traceGroup
+	hdr           traceGroup // temporary trace group for header
+	pubAcc        *Account
+	importedStrms map[*streamImport]*traceGroup
+	exportedSrvcs map[*serviceImport]*traceGroup
+
+	liftedTraces []*selectedTrace
+
+	stream   *stream
+	consumer *consumer
+	Msg      []byte
+	Header   http.Header
+}
+
+func newTraceCtx(loopName string, srv *Server) *traceCtx {
+	return &traceCtx{
+		srv:     srv,
+		rnd:     rand.New(rand.NewSource(time.Now().UnixNano())),
+		ctxName: loopName,
+		global:  traceGroup{traces: make([]*selectedTrace, 0, 10)},
+		pub:     traceGroup{traces: make([]*selectedTrace, 0, 10)},
+	}
+}
+
+// config structs and functions
+type Trace struct {
+	trigger
+	probes
+	TrcSubject string // Where to send a trace to.
+}
+
+type trigger struct {
+	Subject    string
+	NotSubject string
+	SampleFreq float64
+}
+
+type probes struct {
+	Connz    bool `json:"trc_connz,omitempty"`
+	Accountz bool `json:"trc_accountz,omitempty"`
+	Varz     bool `json:"trc_varz,omitempty"`
+	Msg      bool `json:"trc_msg,omitempty"`
+}
+
+func (t trigger) hasTrigger() bool {
+	return t == trigger{}
+}
+
+func (trc *probes) fillTraceProbes(items []string, errOnUnknown, privilegedProbes bool) error {
+	for _, v := range items {
+		switch strings.ToLower(v) {
+		case "all":
+			*trc = probes{true, true, privilegedProbes, !privilegedProbes}
+		case "connz":
+			trc.Connz = true
+		case "accountz":
+			trc.Accountz = true
+		case "varz":
+			if !privilegedProbes {
+				return fmt.Errorf("varz only valid for operator")
+			}
+			trc.Varz = true
+		case "msg":
+			if privilegedProbes {
+				return fmt.Errorf("msg only valid for account")
+			}
+			trc.Msg = true
+		default:
+			if errOnUnknown {
+				return fmt.Errorf("unknown trace item")
+			}
+		}
+	}
+	return nil
+}
+
+// collect info applicable to a particular trace
+func (tCtx *traceCtx) traceInfo(t *selectedTrace, tMsg *TraceMsg, accInfoCache map[string]*AccountInfo, connInfoCache map[uint64]*ConnInfo, now time.Time) *AssociatedTraceInfo {
+	if !t.Accountz && !t.Connz && !t.Varz && !t.Msg {
+		return nil
+	}
+	var err error
+	var ok bool
+	var accInfo []*AccountInfo
+	if t.Accountz {
+		accInfo = make([]*AccountInfo, 0, 1+len(tMsg.Subscriptions))
+		accSet := make(map[string]struct{})
+
+		var ai *AccountInfo
+		if ai, ok = accInfoCache[tMsg.Acc]; !ok {
+			ai, err = tCtx.srv.accountInfoByName(tMsg.Acc)
+			if err != nil {
+				tCtx.srv.Errorf("Unexpected error during trace account info gathering: %s", err)
+			}
+		}
+		if ai != nil {
+			accInfoCache[tMsg.Acc] = ai
+			accSet[tMsg.Acc] = struct{}{}
+			accInfo = append(accInfo, ai)
+		}
+		for _, s := range tMsg.Subscriptions {
+			if _, ok := accSet[s.Acc]; ok {
+				continue
+			}
+			if ai, ok = accInfoCache[s.Acc]; !ok {
+				ai, err = tCtx.srv.accountInfoByName(s.Acc)
+				if err != nil {
+					tCtx.srv.Errorf("Unexpected error during trace account info gathering: %s", err)
+					continue
+				}
+				accInfoCache[s.Acc] = ai
+			}
+			accSet[tMsg.Acc] = struct{}{}
+			accInfo = append(accInfo, ai)
+		}
+	}
+	var connInfo []*ConnInfo
+	if t.Connz {
+		connInfo = make([]*ConnInfo, 0, 1+len(tMsg.Subscriptions))
+		connSet := make(map[uint64]struct{})
+
+		var ci *ConnInfo
+		if tMsg.Client != nil {
+			if ci, ok = connInfoCache[tMsg.Client.ClientId]; !ok {
+				if c := tCtx.srv.getClient(tMsg.Client.ClientId); c == nil {
+					tCtx.srv.Errorf("Client not found during trace conn info gathering")
+				} else {
+					ci = &ConnInfo{}
+					c.mu.Lock()
+					ci.fill(c, c.nc, now, true)
+					c.mu.Unlock()
+					connInfoCache[tMsg.Client.ClientId] = ci
+				}
+			}
+		}
+		if ci != nil {
+			connInfoCache[tMsg.Client.ClientId] = ci
+			connSet[tMsg.Client.ClientId] = struct{}{}
+			connInfo = append(connInfo, ci)
+		}
+		for _, s := range tMsg.Subscriptions {
+			if s.SubClient == nil {
+				continue
+			}
+			if _, ok := connSet[s.SubClient.ClientId]; ok {
+				continue
+			}
+			if ci, ok = connInfoCache[s.SubClient.ClientId]; !ok {
+				if c := tCtx.srv.getClient(s.SubClient.ClientId); c == nil {
+					tCtx.srv.Errorf("Client not found during trace conn info gathering")
+					continue
+				} else {
+					ci = &ConnInfo{}
+					c.mu.Lock()
+					ci.fill(c, c.nc, now, true)
+					c.mu.Unlock()
+					connInfoCache[s.SubClient.ClientId] = ci
+				}
+			}
+			if ci != nil {
+				connSet[s.SubClient.ClientId] = struct{}{}
+				connInfo = append(connInfo, ci)
+			}
+		}
+	}
+	var varInfo *Varz
+	if t.Varz {
+		varInfo, err = tCtx.srv.Varz(nil)
+		if err != nil {
+			tCtx.srv.Errorf("Unexpected error during trace varz info gathering: %s", err)
+		}
+	}
+	var msg []byte
+	var hdr http.Header
+	if t.Msg {
+		msg = tCtx.Msg
+		hdr = tCtx.Header
+	}
+	return &AssociatedTraceInfo{connInfo, accInfo, varInfo, msg, hdr}
+}
+
+// Send to all traces sharing the same trace message but possibly differ in trace level
+func (tCtx *traceCtx) traceGroupSend(group *traceGroup, accInfoSet map[string]*AccountInfo, connInfoSet map[uint64]*ConnInfo, now time.Time, start time.Time, ctxName string) {
+	if len(group.traces) == 0 {
+		return
+	}
+	for _, t := range group.traces {
+		tMsg := group.traceMsg
+		tMsg.CtxName = ctxName
+		tMsg.ProcessingStart = start.String()
+		tMsg.ProcessingDur = now.Sub(start).String()
+		tMsg.AssociatedInfo = tCtx.traceInfo(t, &tMsg, accInfoSet, connInfoSet, now)
+		si := &ServerInfo{}
+		tCtx.srv.sendInternalAccountMsgWithSi(t.sendAcc, t.TrcSubj, si, &ServerAPIResponse{Server: si, Data: &tMsg})
+	}
+}
+
+// Completes an ongoing trace by sending all trace messages
+func (tCtx *traceCtx) traceMsgCompletion(send bool) {
+	if !tCtx.hasTrace {
+		tCtx.consumer = nil
+		tCtx.stream = nil
+		tCtx.trcHdrSet = false
+		return
+	}
+	now := time.Now().UTC()
+	connInfoSet := map[uint64]*ConnInfo{}
+	accInfoSet := map[string]*AccountInfo{}
+	if len(tCtx.global.traces) > 0 {
+		if send {
+			tCtx.traceGroupSend(&tCtx.global, accInfoSet, connInfoSet, now, tCtx.traceStart, tCtx.ctxName)
+		}
+		tCtx.global.traces = []*selectedTrace{}
+		tCtx.global.traceMsg = TraceMsg{}
+	}
+	if len(tCtx.hdr.traces) > 0 {
+		if send {
+			tCtx.hdr.traceMsg = tCtx.pub.traceMsg
+			tCtx.traceGroupSend(&tCtx.hdr, accInfoSet, connInfoSet, now, tCtx.traceStart, tCtx.ctxName)
+		}
+		tCtx.hdr.traces = []*selectedTrace{}
+		tCtx.hdr.traceMsg = TraceMsg{}
+	}
+	if len(tCtx.pub.traces) > 0 {
+		if send {
+			tCtx.traceGroupSend(&tCtx.pub, accInfoSet, connInfoSet, now, tCtx.traceStart, tCtx.ctxName)
+		}
+		tCtx.pub.traces = []*selectedTrace{}
+		tCtx.pubAcc = nil
+		tCtx.pub.traceMsg = TraceMsg{}
+	}
+	for k, tGrp := range tCtx.importedStrms {
+		if send {
+			tCtx.traceGroupSend(tGrp, accInfoSet, connInfoSet, now, tCtx.traceStart, tCtx.ctxName)
+		}
+		tGrp.traces = []*selectedTrace{}
+		delete(tCtx.importedStrms, k)
+	}
+	for k, tGrp := range tCtx.exportedSrvcs {
+		if send {
+			tCtx.traceGroupSend(tGrp, accInfoSet, connInfoSet, now, tCtx.traceStart, tCtx.ctxName)
+		}
+		tGrp.traces = []*selectedTrace{}
+		delete(tCtx.exportedSrvcs, k)
+	}
+	tCtx.liftedTraces = []*selectedTrace{}
+	tCtx.hasTrace = false
+	tCtx.trcHdrSet = false
+	tCtx.consumer = nil
+	tCtx.stream = nil
+	tCtx.Msg = nil
+	tCtx.Header = nil
+	tCtx.traceStart = time.Time{}
+}
+
+func (tCtx *traceCtx) traceCtxMarshal(msgRef string, filterAcc *Account, filterSvc *serviceImport, filterStrm *streamImport) ([]byte, error) {
+	if !tCtx.hasTrace {
+		return nil, nil
+	}
+	var _iad [30]*selectedTrace
+	hdr := &traceHeader{Ref: msgRef, Traces: _iad[:0]}
+	hdr.Traces = append(hdr.Traces, tCtx.global.traces...)
+	if tg, ok := tCtx.importedStrms[filterStrm]; ok {
+		hdr.Traces = append(hdr.Traces, tg.traces...)
+	} else if tg, ok := tCtx.exportedSrvcs[filterSvc]; ok {
+		hdr.Traces = append(hdr.Traces, tg.traces...)
+	} else if tCtx.pubAcc == filterAcc {
+		hdr.Traces = append(hdr.Traces, tCtx.pub.traces...)
+	}
+	if len(hdr.Traces) > 0 || hdr.Ref != _EMPTY_ {
+		return json.Marshal(hdr)
+	} else {
+		return nil, nil
+	}
+}
+
+func (c *client) traceSetHeader(tCtx *traceCtx, dmsg []byte, msgRef string, acc *Account, rc *client, filterSvc *serviceImport, filterStrm *streamImport) ([]byte, bool) {
+	if !tCtx.hasTrace {
+		return dmsg, false
+	}
+	hset := false
+	if cnt, _ := tCtx.traceCtxMarshal(msgRef, acc, filterSvc, filterStrm); cnt != nil {
+		if rc.kind == ROUTER || rc.kind == GATEWAY || rc.kind == JETSTREAM || rc.kind == SYSTEM {
+			dmsg = c.setHeader(TraceHeader, string(cnt), dmsg)
+			hset = true
+		}
+	}
+	if !hset && msgRef != _EMPTY_ {
+		dmsg = c.setHeader(TraceHeader, fmt.Sprintf(`{"msg_ref":"%s"}`, msgRef), dmsg)
+		hset = true
+	}
+	return dmsg, hset
+}
+
+func (tCtx *traceCtx) evalTrace(name string, policy Trace, filterAcc string, pubSubject string) string {
+	if policy.SampleFreq != 0 && tCtx.rnd.Float64() > policy.SampleFreq {
+		return _EMPTY_
+	}
+	// optimize for not being smaller scope. Say: Subject ">" and NotSubject "_INBOX_.>"
+	if policy.NotSubject != _EMPTY_ && subjectIsSubsetMatch(pubSubject, policy.NotSubject) {
+		return _EMPTY_
+	}
+	if policy.Subject != _EMPTY_ && !subjectIsSubsetMatch(pubSubject, policy.Subject) {
+		return _EMPTY_
+	}
+	subj := policy.TrcSubject
+	if subj == _EMPTY_ {
+		if filterAcc == _EMPTY_ {
+			subj = fmt.Sprintf(serverTrcEvent, tCtx.srv.ID(), name)
+		} else {
+			subj = fmt.Sprintf(accTrcEvent, filterAcc, name)
+		}
+	}
+	// Do not trace messages sent to this trace's trace subject
+	if pubSubject == subj {
+		subj = _EMPTY_
+	}
+	return subj
+}
+
+// evaluates which traces apply to a message and if so, if they were added or carried over.
+// In other words, where traces requesting the message content, added or where already added by another server?
+func (tCtx *traceCtx) evalTraces(acc *Account, accName, pubSubject string, msgTrcPolicies map[string]Trace, tracePolicies []*selectedTrace) (bool, []*selectedTrace) {
+	if len(msgTrcPolicies) == 0 {
+		return false, tracePolicies
+	}
+	firstMsg := false
+FOR_ACCOUNT_POLICY:
+	for name, policy := range msgTrcPolicies {
+		for _, v := range tracePolicies {
+			if v.LocalAcc == accName && name == v.Name {
+				v.sendAcc = acc
+				// skip evaluating and just carry over. Also prioritize tracing setting at point of origin
+				continue FOR_ACCOUNT_POLICY
+			}
+		}
+		// We may be here because this is the point of origin, or because subsequent server have additional tracing
+		if subj := tCtx.evalTrace(name, policy, accName, pubSubject); subj != _EMPTY_ {
+			firstMsg = firstMsg || policy.Msg
+			tracePolicies = append(tracePolicies, &selectedTrace{
+				Name:     name,
+				probes:   policy.probes,
+				TrcSubj:  subj,
+				LocalAcc: accName,
+				sendAcc:  acc})
+		}
+	}
+	return firstMsg, tracePolicies
+}
+
+func (tCtx *traceCtx) evalHdrTraces(acc *Account, trcSubj string, trcLvel []string, msgBody []byte) []*selectedTrace {
+	if acc.pingProbes == nil || trcSubj == _EMPTY_ {
+		return nil
+	}
+	// Messages with TracePing set have a comma separated list of server id's as message body.
+	if body := strings.Trim(string(msgBody), "\r\n\t "); len(body) > 0 {
+		// When present, only server listed will emit a trace message.
+		found := false
+		filterIds := strings.Split(body, ",")
+		for _, id := range filterIds {
+			if strings.TrimSpace(strings.ToLower(id)) == strings.ToLower(tCtx.srv.ID()) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil
+		}
+	}
+	connz := acc.pingProbes.Connz
+	accountz := acc.pingProbes.Accountz
+	varz := acc.pingProbes.Varz
+	msg := acc.pingProbes.Msg
+	tmpPol := &Trace{}
+	if err := tmpPol.fillTraceProbes(trcLvel, true, false); err != nil {
+		tCtx.srv.Warnf("Trace Subject warn level Parsing error: %s", err)
+		return nil
+	}
+	return []*selectedTrace{{TrcSubj: trcSubj, sendAcc: acc, probes: probes{
+		Connz:    connz && tmpPol.Connz,
+		Accountz: accountz && tmpPol.Accountz,
+		Varz:     varz && tmpPol.Varz,
+		Msg:      msg && tmpPol.Msg}}}
+}
+
+// Gather JS traces
+// This does NOT evaluate rules, it simply records JS data for Messages already traced
+// This call must be matched by a call to traceMsgCompletion.
+func (tCtx *traceCtx) traceJsMsgStore(msg []byte, hdr []byte, subj, reply, msgId string, msgC *client, msgCAcc *Account, mset *stream) (string, []*TraceStore, bool) {
+	if len(hdr) == 0 {
+		return _EMPTY_, nil, false
+	}
+	if isHeaderSet(TracePing, hdr) {
+		msgC.Errorf("Header %s not expected to appear here", TracePing)
+		return _EMPTY_, nil, false
+	}
+	var _ia1 [8]*selectedTrace
+	trcHeader := traceHeader{Traces: _ia1[:0]}
+	// Read and Enforce (system) policy header rules
+	if policies := getHeader(TraceHeader, hdr); len(policies) > 0 {
+		if err := json.Unmarshal(policies, &trcHeader); err != nil {
+			msgC.Errorf("Badly formatted header: %s", TraceHeader)
+		}
+	}
+	// skip if already happened
+	canComplete := false
+	if !tCtx.hasTrace {
+		tCtx.tracePub(msgC, msgCAcc, subj, reply, msg, trcHeader.Traces, false, "", trcHeader.Ref, nil)
+		canComplete = true
+	}
+	// TODO evaluate JetStream specific queries, like trace all messages stored in a stream
+	if !tCtx.hasTrace {
+		return _EMPTY_, nil, false
+	}
+	if mset.acc == tCtx.srv.SystemAccount() {
+		return _EMPTY_, nil, false
+	}
+
+	var b [8]byte
+	rn := rand.Int63()
+	for i, l := 0, rn; i < len(b); i++ {
+		b[i] = digits[l%base]
+		l /= base
+	}
+	msgRef := string(b[:])
+
+	var _ia [8]*TraceStore
+	subs := _ia[:0]
+	if len(tCtx.global.traces) > 0 {
+		s := &TraceStore{
+			Acc:        mset.acc.Name,
+			StreamRef:  mset.cfg.Name,
+			StreamType: mset.store.Type().String(),
+			StreamRepl: mset.cfg.Replicas,
+			PubSubject: subj,
+			MsgRef:     trcHeader.Ref,
+			Ref:        msgRef,
+			StreamSubs: mset.cfg.Subjects,
+			JsMsgId:    msgId,
+		}
+		tCtx.global.traceMsg.Stores = append(tCtx.global.traceMsg.Stores, s)
+		subs = append(subs, s)
+	}
+	if len(tCtx.pub.traces) > 0 || len(tCtx.hdr.traces) > 0 {
+		s := &TraceStore{
+			Acc:        mset.acc.Name,
+			StreamRef:  mset.cfg.Name,
+			StreamType: mset.store.Type().String(),
+			StreamRepl: mset.cfg.Replicas,
+			PubSubject: subj,
+			MsgRef:     trcHeader.Ref,
+			Ref:        msgRef,
+			StreamSubs: mset.cfg.Subjects,
+			JsMsgId:    msgId,
+		}
+		tCtx.pub.traceMsg.Stores = append(tCtx.pub.traceMsg.Stores, s)
+		subs = append(subs, s)
+	}
+	return msgRef, subs, canComplete
+}
+
+// conditionally capture header and message content
+func condCaputeMsg(firstMsg bool, hdrStart int, msg []byte) (http.Header, []byte) {
+	if !firstMsg {
+		return nil, nil
+	}
+	var h http.Header
+	if hdrStart < 0 {
+		hdrStart = 0
+	} else {
+		tp := textproto.NewReader(bufio.NewReader(bytes.NewReader(msg[:hdrStart])))
+		tp.ReadLine() // skip over first line, contains version
+		if mimeHeader, err := tp.ReadMIMEHeader(); err == nil {
+			h = http.Header(mimeHeader)
+		}
+	}
+	return h, msg[hdrStart : len(msg)-2] // strip \r\n
+}
+
+// Gather publisher traces
+func (tCtx *traceCtx) tracePub(msgC *client, msgAcc *Account, pubSubject, reply string, msg []byte, tracePolicies []*selectedTrace, trcHdrSet bool, trcSubj, trcRef string, trcLvel []string) {
+	srv := tCtx.srv
+	if srv == nil {
+		return
+	}
+	tCtx.trcHdrSet = trcHdrSet
+	// In case storage in JetStream needs to be monitored in detail, only return if msgC.kind == Client
+	if msgAcc == srv.SystemAccount() {
+		return
+	}
+	opts := srv.getOpts()
+
+	msgAccName := msgAcc.Name
+
+	var _ia1 [4]*selectedTrace
+	var _ia2 [4]*selectedTrace
+	var _ia3 [4]*selectedTrace
+	globalTracePolicies := _ia1[:0]
+	pubAccTracePolicies := _ia2[:0]
+	liftedTraces := _ia3[:0]
+
+	for _, v := range tracePolicies {
+		if v.LocalAcc == _EMPTY_ {
+			v.sendAcc = srv.SystemAccount()
+			globalTracePolicies = append(globalTracePolicies, v)
+		} else if v.LocalAcc == msgAccName {
+			v.sendAcc = msgAcc
+			pubAccTracePolicies = append(pubAccTracePolicies, v)
+		} else if v.LocalAcc != _EMPTY_ && msgC.kind != CLIENT {
+			if msgAcc == srv.SystemAccount() {
+				if a, err := srv.lookupAccount(v.LocalAcc); err == nil {
+					v.sendAcc = a
+				}
+			}
+			if v.sendAcc == nil {
+				v.LocalAcc = msgAccName
+				v.sendAcc = msgAcc
+			}
+			pubAccTracePolicies = append(pubAccTracePolicies, v)
+		} else {
+			liftedTraces = append(liftedTraces, v)
+		}
+	}
+	tCtx.liftedTraces = liftedTraces
+	_, globalTracePolicies = tCtx.evalTraces(srv.SystemAccount(), "", pubSubject, opts.MsgTracePolicy, globalTracePolicies)
+	firstMsg := false
+	firstMsg, pubAccTracePolicies = tCtx.evalTraces(msgAcc, msgAccName, pubSubject, msgAcc.traces, pubAccTracePolicies)
+
+	// Turn this into an eval Hdr Traces call
+	_, msgBody := msgC.msgParts(msg)
+	hdrTracePolicies := tCtx.evalHdrTraces(msgAcc, trcSubj, trcLvel, msgBody)
+
+	refServerId := _EMPTY_
+	if len(globalTracePolicies) > 0 || len(pubAccTracePolicies) > 0 || len(hdrTracePolicies) > 0 {
+		if tCtx.traceStart.IsZero() {
+			tCtx.traceStart = time.Now().UTC()
+		}
+		switch {
+		case msgC.leaf != nil:
+			refServerId = msgC.leaf.remoteId
+		case msgC.route != nil:
+			refServerId = msgC.route.remoteID
+		case msgC.gw != nil:
+			refServerId = msgC.opts.Name
+		}
+		if msgC.kind == JETSTREAM && refServerId == _EMPTY_ {
+			refServerId = srv.ID()
+		}
+	}
+	if len(globalTracePolicies) > 0 {
+		tCtx.global.traces = globalTracePolicies
+		tCtx.global.traceMsg = TraceMsg{
+			Client: &TraceClient{
+				Type:     msgC.clientTypeString(),
+				Kind:     msgC.kindString(),
+				Name:     msgC.GetName(),
+				ClientId: msgC.cid,
+				ServerId: refServerId,
+			},
+			Acc:               msgAccName,
+			SubjectMatched:    pubSubject,
+			SubjectPreMapping: string(msgC.pa.mapped),
+			Subscriptions:     make([]*TraceSubscription, 0, 4),
+			MsgRef:            trcRef,
+			Reply:             reply,
+		}
+		tCtx.hasTrace = true
+		if tCtx.stream != nil {
+			tCtx.global.traceMsg.StreamType = tCtx.stream.store.Type().String()
+			tCtx.global.traceMsg.StreamRef = tCtx.stream.name()
+		}
+		if tCtx.consumer != nil {
+			tCtx.global.traceMsg.ConsumerRef = tCtx.consumer.name
+		}
+	}
+	if len(pubAccTracePolicies) > 0 || len(hdrTracePolicies) > 0 {
+		tCtx.hdr.traces = hdrTracePolicies
+		tCtx.pub.traces = pubAccTracePolicies
+		tCtx.pub.traceMsg = TraceMsg{
+			Client: &TraceClient{
+				Type:     msgC.clientTypeString(),
+				Kind:     msgC.kindString(),
+				Name:     msgC.GetName(),
+				ClientId: msgC.cid,
+				ServerId: refServerId,
+			},
+			Acc:               msgAccName,
+			SubjectMatched:    pubSubject,
+			SubjectPreMapping: string(msgC.pa.mapped),
+			Subscriptions:     make([]*TraceSubscription, 0, 4),
+			MsgRef:            trcRef,
+			Reply:             reply,
+		}
+		tCtx.pubAcc = msgAcc
+		tCtx.hasTrace = true
+		if tCtx.stream != nil {
+			tCtx.pub.traceMsg.StreamType = tCtx.stream.store.Type().String()
+			tCtx.pub.traceMsg.StreamRef = tCtx.stream.name()
+		}
+		if tCtx.consumer != nil {
+			tCtx.pub.traceMsg.ConsumerRef = tCtx.consumer.name
+		}
+		tCtx.Header, tCtx.Msg = condCaputeMsg(firstMsg, msgC.pa.hdr, msg)
+	}
+}
+
+// Gathers subscriber traces
+// When necessary, returns a message id to include in TraceHeader
+func (tCtx *traceCtx) traceSub(c *client, sub *subscription, acc *Account, subject, reply, msg []byte) (string, []*TraceSubscription) {
+	if sub.client.kind == ACCOUNT || tCtx.srv == nil {
+		return _EMPTY_, nil
+	}
+	// In case storage in JetStream needs to be monitored in detail, only return if msgC.kind == Client
+	if acc == tCtx.srv.SystemAccount() {
+		return _EMPTY_, nil
+	}
+	var trc *traceGroup
+	var importFound bool
+	subAccName := acc.Name
+	subAcc := acc
+	subTo := _EMPTY_
+	subImp := _EMPTY_
+	pubSubj := string(subject)
+	subscription := string(sub.subject)
+	if sub.im != nil {
+		subTo = sub.im.to
+		subImp = sub.im.from
+		if sub.im.tr != nil {
+			subImp, subTo = sub.im.tr.src, sub.im.tr.dest
+		}
+		subAcc = sub.client.acc
+		subAccName = subAcc.Name
+		// Determine if import tracing is needed
+		trc, importFound = tCtx.importedStrms[sub.im]
+		if !importFound {
+			firstMsg, tracePolicies := tCtx.evalTraces(subAcc, subAccName, pubSubj, sub.client.acc.traces, tCtx.liftedTraces)
+			if len(tracePolicies) > 0 {
+				tCtx.Header, tCtx.Msg = condCaputeMsg(firstMsg, c.pa.hdr, msg)
+				trc = &traceGroup{
+					traces:   tracePolicies,
+					traceMsg: TraceMsg{Acc: acc.Name, Reply: string(reply)},
+				}
+				if tCtx.importedStrms == nil {
+					tCtx.importedStrms = make(map[*streamImport]*traceGroup)
+				}
+				tCtx.importedStrms[sub.im] = trc
+				tCtx.hasTrace = true
+			}
+		}
+	} else if c.pa.psi != nil {
+		subTo = c.pa.psi.to
+		subImp = c.pa.psi.from
+		if c.pa.psi.tr != nil {
+			subImp, subTo = c.pa.psi.tr.src, c.pa.psi.tr.dest
+		}
+		subAcc = acc //sub.client.acc
+		subAccName = subAcc.Name
+		// Determine if import tracing is needed
+		trc, importFound = tCtx.exportedSrvcs[c.pa.psi]
+		if !importFound {
+			firstMsg, tracePolicies := tCtx.evalTraces(subAcc, subAccName, pubSubj, subAcc.traces, tCtx.liftedTraces)
+			if len(tracePolicies) > 0 {
+				tCtx.Header, tCtx.Msg = condCaputeMsg(firstMsg, c.pa.hdr, msg)
+				trc = &traceGroup{
+					traces:   tracePolicies,
+					traceMsg: TraceMsg{Acc: c.acc.Name, Reply: string(reply)},
+				}
+				if tCtx.exportedSrvcs == nil {
+					tCtx.exportedSrvcs = make(map[*serviceImport]*traceGroup)
+				}
+				tCtx.exportedSrvcs[c.pa.psi] = trc
+				tCtx.hasTrace = true
+			}
+		}
+	}
+	var _ia [2]*TraceSubscription
+	var tSubs []*TraceSubscription
+	msgRef := _EMPTY_
+	refServerId := _EMPTY_
+	if tCtx.hasTrace {
+		if tCtx.traceStart.IsZero() {
+			tCtx.traceStart = time.Now().UTC()
+		}
+		switch {
+		case sub.client.leaf != nil:
+			refServerId = sub.client.leaf.remoteId
+		case sub.client.route != nil:
+			refServerId = sub.client.route.remoteID
+		case sub.client.gw != nil:
+			refServerId = sub.client.opts.Name
+		}
+		// JetStream means reference to self
+		if (sub.client.kind == JETSTREAM || sub.client.kind == SYSTEM) && refServerId == _EMPTY_ {
+			refServerId = c.srv.ID()
+		}
+		if refServerId != _EMPTY_ {
+			var b [8]byte
+			rn := rand.Int63()
+			for i, l := 0, rn; i < len(b); i++ {
+				b[i] = digits[l%base]
+				l /= base
+			}
+			msgRef = string(b[:])
+		}
+		tSubs = _ia[:0]
+	}
+	if len(tCtx.global.traces) > 0 || (trc != nil && len(trc.traces) > 0) {
+		trcSub := &TraceSubscription{
+			Acc: subAccName,
+			SubClient: &TraceClient{
+				Type:     sub.client.clientTypeString(),
+				Kind:     sub.client.kindString(),
+				Name:     sub.client.GetName(),
+				ClientId: sub.client.cid,
+				ServerId: refServerId,
+			},
+			Queue:      string(sub.queue),
+			Sub:        subscription,
+			PubSubject: pubSubj,
+			ImportTo:   subTo,
+			ImportSub:  subImp,
+			Ref:        msgRef,
+			Reply:      string(reply),
+		}
+		tSubs = append(tSubs, trcSub)
+		if len(tCtx.global.traces) > 0 {
+			tCtx.global.traceMsg.Subscriptions = append(tCtx.global.traceMsg.Subscriptions, trcSub)
+		}
+		if trc != nil && len(trc.traces) > 0 {
+			trc.traceMsg.Subscriptions = append(trc.traceMsg.Subscriptions, trcSub)
+		}
+		tCtx.hasTrace = true
+	}
+	if len(tCtx.pub.traces) > 0 || len(tCtx.hdr.traces) > 0 {
+		var trcSub *TraceSubscription
+		if tCtx.pubAcc == subAcc {
+			trcSub = &TraceSubscription{
+				Acc: subAccName,
+				SubClient: &TraceClient{
+					Type:     sub.client.clientTypeString(),
+					Kind:     sub.client.kindString(),
+					Name:     sub.client.GetName(),
+					ClientId: sub.client.cid,
+					ServerId: refServerId,
+				},
+				Queue:      string(sub.queue),
+				Sub:        subscription,
+				PubSubject: pubSubj,
+				ImportTo:   subTo,
+				ImportSub:  subImp,
+				Ref:        msgRef,
+				Reply:      string(reply),
+			}
+		} else {
+			var tc *TraceClient
+			if refServerId != _EMPTY_ {
+				tc = &TraceClient{ServerId: refServerId}
+			}
+			trcSub = &TraceSubscription{
+				Acc:        subAccName,
+				ImportSub:  subImp,
+				Sub:        subImp, // For easier handling, set subscription to what the import would be
+				SubClient:  tc,
+				Ref:        msgRef,
+				PubSubject: pubSubj,
+				Reply:      string(reply),
+			}
+		}
+		tSubs = append(tSubs, trcSub)
+		tCtx.pub.traceMsg.Subscriptions = append(tCtx.pub.traceMsg.Subscriptions, trcSub)
+		tCtx.hasTrace = true
+	}
+	return msgRef, tSubs
+}
+
+// Gathers pub traces for the message. This call must be matched by a call to traceMsgCompletion.
+// This call also checks and enforces tracing header. When an error happens, msgC may be altered and/or closed.
+// returns (possibly modified) msg
+func (tCtx *traceCtx) traceMsg(msg []byte, subj, reply string, msgC *client, msgCAcc *Account) []byte {
+	var _ia1 [8]*selectedTrace
+	trcHeader := traceHeader{Traces: _ia1[:0]}
+	trcHdrSet := false
+	trcSubj := _EMPTY_
+	trcLvl := []string{}
+	srv := msgC.srv
+	if tCtx == nil {
+		srv.Errorf("Trace context is required")
+		return msg
+	}
+	// Check if tracing is enabled on the message and additional sanity checks
+	if msgC.pa.hdr > 0 {
+		if val := getHeader(TracePing, msg[:msgC.pa.hdr]); len(val) > 0 || isHeaderSet(TracePing, msg[:msgC.pa.hdr]) {
+			trcSubj = reply
+			trcHdrSet = true
+			if m := strings.TrimSpace(string(val)); len(m) > 0 && len(trcSubj) > 0 {
+				trcLvl = strings.Split(m, ",")
+			}
+		}
+		// Read and Enforce (system) policy header rules
+		if policies := getHeader(TraceHeader, msg[:msgC.pa.hdr]); len(policies) > 0 {
+			// TODO if we where to allow clients to present the trace header, we can monitor responses across connections
+			if msgC.kind == CLIENT {
+				msgC.Errorf("Not allowed to set header: %s", TraceHeader)
+				msgC.closeConnection(ProtocolViolation)
+				return msg
+			}
+			if err := json.Unmarshal(policies, &trcHeader); err != nil {
+				msgC.Errorf("Badly formatted header: %s", TraceHeader)
+				msg = msgC.setHeader(TraceHeader, "", msg)
+				trcSubj = _EMPTY_
+			}
+			if msgC.kind == LEAF && len(trcHeader.Traces) != 0 {
+				msgC.Errorf("Leaf nodes only allowed to set header without traces: %s", TraceHeader)
+				msgC.closeConnection(ProtocolViolation)
+				return msg
+			}
+		}
+	}
+	tCtx.tracePub(msgC, msgCAcc, subj, reply, msg, trcHeader.Traces, trcHdrSet, trcSubj, trcHeader.Ref, trcLvl)
+	return msg
+}

--- a/server/trace_test.go
+++ b/server/trace_test.go
@@ -1,0 +1,2326 @@
+// Copyright 2021-2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func getOkTraceBody(t *testing.T, msg *nats.Msg) (*ServerInfo, *TraceMsg) {
+	t.Helper()
+	tMsg := ServerAPIResponse{Data: &TraceMsg{}}
+	require_NoError(t, json.Unmarshal(msg.Data, &tMsg))
+	require_True(t, tMsg.Error == nil)
+	// basic server info sanity check
+	require_True(t, tMsg.Server.Name != _EMPTY_)
+	require_True(t, tMsg.Server.ID != _EMPTY_)
+	require_True(t, tMsg.Server.Version != _EMPTY_)
+	require_True(t, tMsg.Server.Seq != 0)
+	require_True(t, tMsg.Server.Time.Before(time.Now()))
+
+	//TODO uncomment to see server trace messages
+	//LogServerApiResponse(t, msg)
+
+	return tMsg.Server, tMsg.Data.(*TraceMsg)
+}
+
+func LogServerApiResponse(t *testing.T, msg *nats.Msg) {
+	t.Helper()
+	tMsg := ServerAPIResponse{}
+	data := msg.Data
+	err := json.Unmarshal(data, &tMsg)
+	require_NoError(t, err)
+	data, err = json.MarshalIndent(&tMsg, "", "  ")
+	require_NoError(t, err)
+	t.Logf("ServerAPIResponse %s:\n%s\n", msg.Subject, string(data))
+}
+
+func requie_BasicSubNatsClient(t *testing.T, tSub *TraceSubscription, acc string, subscription, msgSubject, queue, importTo string) {
+	t.Helper()
+	require_Equal(t, tSub.Acc, acc)
+	require_Equal(t, tSub.SubClient.Kind, "Client")
+	require_Equal(t, tSub.SubClient.Type, "nats")
+	require_True(t, tSub.SubClient.ClientId != 0)
+	require_Equal(t, tSub.Sub, subscription)
+	require_Equal(t, tSub.PubSubject, msgSubject)
+	require_Equal(t, tSub.Queue, queue)
+	require_Equal(t, tSub.ImportTo, importTo)
+}
+
+func requie_BasicPubNatsClient(t *testing.T, tMsg *TraceMsg, acc string) {
+	t.Helper()
+	require_Equal(t, tMsg.Acc, acc)
+	require_Equal(t, tMsg.Client.Kind, "Client")
+	require_Equal(t, tMsg.Client.Type, "nats")
+	require_True(t, tMsg.Client.ClientId != 0)
+}
+
+func TestMessageTraceOperatorSimpleServer(t *testing.T) {
+	storeDir := createDir(t, JetStreamStoreDir)
+	confA := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: -1
+		system_account: SYS
+		server_name: srv-A
+		jetstream: {max_mem_store: 10Mb, max_file_store: 10Mb, store_dir: %s }
+		msg_trace: {
+			trace_particular_subject_always: {Subject: always, Probes: [connz, accountz, varz] }
+		}
+		accounts: {
+			SYS: {users: [ {user: sys, password: sys}]}
+			ACC: {users: [ {user: acc, password: acc}]}
+			MAP: {
+				users: [ {user: map, password: map}]
+				mappings: {map.*: "$1"}
+			}
+			EXP_STRM: {
+				users: [ {user: exp_strm, password: exp_strm}]
+				exports: [{stream: >}]
+			}
+			IMP_STRM: {
+				users: [ {user: imp_strm, password: imp_strm}]
+				imports: [{stream: {account: EXP_STRM, subject: *}, to: imported.$1}]
+			}
+			EXP_SVC: {
+				users: [ {user: exp_svc, password: exp_svc}]
+				exports: [{service: svc.>}]
+			}
+			IMP_SVC: {
+				users: [ {user: imp_svc, password: imp_svc}]
+				imports: [{service: {account: EXP_SVC, subject: svc.*}, to: *}]
+			}
+
+			SVC_CHAIN1: {
+				users: [ {user: svc_chain1, password: svc_chain1}]
+				exports: [{service: svc1.>}]
+			}
+			SVC_CHAIN2: {
+				users: [ {user: svc_chain2, password: svc_chain2}]
+				imports: [{service: {account: SVC_CHAIN1, subject: svc1.*}, to: svc2.*}]
+				exports: [{service: svc2.>}]
+			}
+			SVC_CHAIN3: {
+				users: [ {user: svc_chain3, password: svc_chain3}]
+				imports: [{service: {account: SVC_CHAIN2, subject: svc2.*}, to: *}]
+			}
+
+			JS_ACC {
+				users: [ {user: js_acc, password: js_acc}]
+				jetstream: {max_mem: 5Mb, max_store: 5Mb, max_streams: -1, max_consumers: -1}
+			}
+		}
+    `, storeDir)))
+	defer removeFile(t, confA)
+	sA, _ := RunServerWithConfig(confA)
+	defer sA.Shutdown()
+
+	ncSys := natsConnect(t, sA.ClientURL(), nats.UserInfo("sys", "sys"))
+	defer ncSys.Close()
+
+	s, err := ncSys.SubscribeSync(fmt.Sprintf(serverTrcEvent, "*", "trace_particular_subject_always"))
+	require_NoError(t, err)
+	require_NoError(t, ncSys.Flush())
+
+	createAccountConnPair := func(accUser1, accUser2 string) (*nats.Conn, *nats.Conn) {
+		t.Helper()
+		ncPub := natsConnect(t, sA.ClientURL(), nats.UserInfo(accUser1, accUser1))
+		require_NoError(t, ncPub.Flush())
+		ncSub := natsConnect(t, sA.ClientURL(), nats.UserInfo(accUser2, accUser2))
+		require_NoError(t, ncSub.Flush())
+		return ncPub, ncSub
+	}
+	require_TimeoutOnPolicy := func() {
+		t.Helper()
+		_, err := s.NextMsg(250 * time.Millisecond)
+		require_True(t, err == nats.ErrTimeout)
+	}
+	sendTestData := func(nc *nats.Conn, subjects ...string) {
+		t.Helper()
+		for _, subj := range subjects {
+			require_NoError(t, nc.Publish(subj, nil))
+		}
+		require_NoError(t, nc.Flush())
+	}
+	recvTestData := func(sub *nats.Subscription, num int) {
+		t.Helper()
+		for i := 0; i < num; i++ {
+			_, err := sub.NextMsg(time.Second)
+			require_NoError(t, err)
+		}
+	}
+
+	t.Run("no-sub", func(t *testing.T) {
+		ncPub, ncSub := createAccountConnPair("acc", "acc")
+		defer ncPub.Close()
+		defer ncSub.Close()
+		sendTestData(ncPub, "never", "always")
+
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tMsg := getOkTraceBody(t, msg)
+
+		require_True(t, len(tMsg.Subscriptions) == 0)
+		requie_BasicPubNatsClient(t, tMsg, "ACC")
+		require_Equal(t, tMsg.SubjectMatched, "always")
+		require_True(t, len(tMsg.AssociatedInfo.AccountInfo) == 1)
+		require_True(t, len(tMsg.AssociatedInfo.ConnInfo) == 1)
+		require_TimeoutOnPolicy()
+	})
+	// next two tests are almost identical, only differ if same or different connection
+	testWithSub := func(ncPub, ncSub *nats.Conn) *TraceMsg {
+		sub, err := ncSub.SubscribeSync(">")
+		require_NoError(t, err)
+		require_NoError(t, ncSub.Flush())
+
+		sendTestData(ncPub, "never", "always")
+		recvTestData(sub, 2)
+
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tMsg := getOkTraceBody(t, msg)
+
+		require_True(t, len(tMsg.Subscriptions) == 1)
+		requie_BasicSubNatsClient(t, tMsg.Subscriptions[0], "ACC", ">", "always", "", "")
+
+		requie_BasicPubNatsClient(t, tMsg, "ACC")
+		require_Equal(t, tMsg.SubjectMatched, "always")
+
+		require_TimeoutOnPolicy()
+		return tMsg
+	}
+	t.Run("with-sub-different-con", func(t *testing.T) {
+		ncPub, ncSub := createAccountConnPair("acc", "acc")
+		defer ncPub.Close()
+		defer ncSub.Close()
+		tMsg := testWithSub(ncPub, ncSub)
+		require_True(t, tMsg.Client.ClientId != tMsg.Subscriptions[0].SubClient.ClientId)
+		require_True(t, len(tMsg.AssociatedInfo.AccountInfo) == 1)
+		require_True(t, len(tMsg.AssociatedInfo.ConnInfo) == 2)
+	})
+	t.Run("with-sub-same-Con", func(t *testing.T) {
+		ncPub, ncSub := createAccountConnPair("acc", "acc")
+		ncPub.Close()
+		defer ncSub.Close()
+		tMsg := testWithSub(ncSub, ncSub)
+		require_True(t, tMsg.Client.ClientId == tMsg.Subscriptions[0].SubClient.ClientId)
+		require_True(t, len(tMsg.AssociatedInfo.AccountInfo) == 1)
+		require_True(t, len(tMsg.AssociatedInfo.ConnInfo) == 1)
+	})
+	t.Run("no-echo", func(t *testing.T) {
+		nc := natsConnect(t, sA.ClientURL(), nats.UserInfo("acc", "acc"), nats.NoEcho())
+		defer nc.Close()
+		sub, err := nc.SubscribeSync(">")
+		require_NoError(t, err)
+		require_NoError(t, nc.Flush())
+		err = nc.Publish("always", nil)
+		require_NoError(t, err)
+		require_NoError(t, nc.Flush())
+		_, err = sub.NextMsg(time.Second / 4)
+		require_True(t, err == nats.ErrTimeout)
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+		_, tMsg := getOkTraceBody(t, msg)
+		require_True(t, len(tMsg.Subscriptions) == 1)
+		require_Equal(t, tMsg.Subscriptions[0].NoSendReason, "client disallows echo")
+
+	})
+	t.Run("with-queue-sub", func(t *testing.T) {
+		ncPub, ncSub := createAccountConnPair("acc", "acc")
+		defer ncPub.Close()
+		defer ncSub.Close()
+		ch := make(chan *nats.Msg, 3)
+		defer close(ch)
+		sub1, err := ncSub.ChanQueueSubscribe(">", "queue", ch)
+		require_NoError(t, err)
+		defer sub1.Unsubscribe()
+		sub2, err := ncSub.ChanQueueSubscribe(">", "queue", ch)
+		require_NoError(t, err)
+		defer sub2.Unsubscribe()
+		require_NoError(t, ncSub.Flush())
+
+		sendTestData(ncPub, "never", "always")
+		cnt := 0
+	BREAK_FOR:
+		for {
+			select {
+			case <-ch:
+				cnt++
+			case <-time.After(time.Second / 4):
+				break BREAK_FOR
+			}
+		}
+		require_True(t, cnt == 2)
+
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tMsg := getOkTraceBody(t, msg)
+
+		require_True(t, len(tMsg.Subscriptions) == 1)
+		requie_BasicSubNatsClient(t, tMsg.Subscriptions[0], "ACC", ">", "always", "queue", "")
+
+		requie_BasicPubNatsClient(t, tMsg, "ACC")
+		require_Equal(t, tMsg.SubjectMatched, "always")
+
+		require_TimeoutOnPolicy()
+	})
+	t.Run("mapped-sub", func(t *testing.T) {
+		ncPub, ncSub := createAccountConnPair("map", "map")
+		defer ncPub.Close()
+		defer ncSub.Close()
+
+		sub, err := ncSub.SubscribeSync(">")
+		require_NoError(t, err)
+		require_NoError(t, ncSub.Flush())
+
+		sendTestData(ncPub, "map.always")
+		recvTestData(sub, 1)
+
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tMsg := getOkTraceBody(t, msg)
+
+		require_True(t, len(tMsg.Subscriptions) == 1)
+		requie_BasicSubNatsClient(t, tMsg.Subscriptions[0], "MAP", ">", "always", "", "")
+
+		requie_BasicPubNatsClient(t, tMsg, "MAP")
+		require_Equal(t, tMsg.SubjectMatched, "always")
+		require_Equal(t, tMsg.SubjectPreMapping, "map.always")
+		require_True(t, len(tMsg.AssociatedInfo.AccountInfo) == 1)
+		require_True(t, len(tMsg.AssociatedInfo.ConnInfo) == 2)
+		require_TimeoutOnPolicy()
+	})
+	t.Run("js-sub", func(t *testing.T) {
+		ncPub, ncSub := createAccountConnPair("js_acc", "js_acc")
+		defer ncPub.Close()
+		defer ncSub.Close()
+
+		js, err := ncSub.JetStream()
+		require_NoError(t, err)
+
+		_, err = js.AddStream(&nats.StreamConfig{Name: "S1", Subjects: []string{"always"}})
+		require_NoError(t, err)
+		defer js.DeleteStream("S1")
+
+		sendTestData(ncPub, "always")
+
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tMsg := getOkTraceBody(t, msg)
+
+		require_True(t, len(tMsg.Subscriptions) == 1)
+		require_Equal(t, tMsg.Subscriptions[0].Acc, "JS_ACC")
+		require_Equal(t, tMsg.Subscriptions[0].PubSubject, "always")
+		require_True(t, tMsg.Subscriptions[0].SubClient != nil)
+		require_Equal(t, tMsg.Subscriptions[0].SubClient.Kind, "JetStream")
+
+		require_True(t, len(tMsg.Stores) == 1)
+		require_Equal(t, tMsg.Stores[0].Acc, "JS_ACC")
+		require_Equal(t, tMsg.Stores[0].PubSubject, "always")
+		require_Equal(t, tMsg.Stores[0].StreamRef, "S1")
+		require_True(t, tMsg.Stores[0].StreamType == "File")
+		require_True(t, tMsg.Stores[0].StreamRepl == 1)
+		require_True(t, tMsg.Stores[0].DidStore)
+		require_Equal(t, tMsg.Subscriptions[0].Ref, tMsg.Stores[0].MsgRef)
+		require_TimeoutOnPolicy()
+
+		jsSub, err := js.SubscribeSync("always", nats.ManualAck())
+		require_NoError(t, err)
+		require_NoError(t, ncSub.Flush())
+		m, err := jsSub.NextMsg(time.Second)
+		require_NoError(t, err)
+		msg, err = s.NextMsg(time.Second)
+		require_NoError(t, err)
+		getOkTraceBody(t, msg)
+		// make sure there are no additional trace messages
+		require_TimeoutOnPolicy()
+
+		// Nack so we can retrieve the message again
+		require_NoError(t, m.Nak())
+		_, err = jsSub.NextMsg(time.Second)
+		require_NoError(t, err)
+		msg, err = s.NextMsg(time.Second)
+		require_NoError(t, err)
+		getOkTraceBody(t, msg)
+
+		require_TimeoutOnPolicy()
+	})
+	t.Run("import-stream", func(t *testing.T) {
+		ncPub, ncSub := createAccountConnPair("exp_strm", "imp_strm")
+		defer ncPub.Close()
+		defer ncSub.Close()
+
+		sub1, err := ncSub.SubscribeSync(">")
+		require_NoError(t, err)
+		require_NoError(t, ncSub.Flush())
+
+		sendTestData(ncPub, "always")
+		recvTestData(sub1, 1)
+
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tMsg := getOkTraceBody(t, msg)
+
+		require_True(t, len(tMsg.Subscriptions) == 1)
+		requie_BasicSubNatsClient(t, tMsg.Subscriptions[0], "IMP_STRM", "*", "imported.always", "", "imported.$1")
+		requie_BasicPubNatsClient(t, tMsg, "EXP_STRM")
+		require_Equal(t, tMsg.SubjectMatched, "always")
+
+		require_True(t, len(tMsg.AssociatedInfo.AccountInfo) == 2)
+		require_True(t, len(tMsg.AssociatedInfo.ConnInfo) == 2)
+		require_TimeoutOnPolicy()
+	})
+	t.Run("import-service", func(t *testing.T) {
+		ncPub, ncSub := createAccountConnPair("imp_svc", "exp_svc")
+		defer ncPub.Close()
+		defer ncSub.Close()
+
+		sub, err := ncSub.SubscribeSync(">")
+		require_NoError(t, err)
+		require_NoError(t, ncSub.Flush())
+
+		sendTestData(ncPub, "always")
+		recvTestData(sub, 1)
+
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tMsg := getOkTraceBody(t, msg)
+
+		require_True(t, len(tMsg.Subscriptions) == 1)
+		requie_BasicSubNatsClient(t, tMsg.Subscriptions[0], "EXP_SVC", ">", "svc.always", "", "svc.$1")
+		requie_BasicPubNatsClient(t, tMsg, "IMP_SVC")
+		require_Equal(t, tMsg.SubjectMatched, "always")
+
+		require_True(t, len(tMsg.AssociatedInfo.AccountInfo) == 2)
+		require_True(t, len(tMsg.AssociatedInfo.ConnInfo) == 2)
+		require_TimeoutOnPolicy()
+	})
+	t.Run("service-chain-1", func(t *testing.T) {
+		ncPub, ncSub := createAccountConnPair("svc_chain3", "svc_chain1")
+		defer ncPub.Close()
+		defer ncSub.Close()
+
+		sub, err := ncSub.SubscribeSync(">")
+		require_NoError(t, err)
+		require_NoError(t, ncSub.Flush())
+
+		sendTestData(ncPub, "always")
+		recvTestData(sub, 1)
+
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tmsg := getOkTraceBody(t, msg)
+		require_TimeoutOnPolicy()
+
+		require_Equal(t, tmsg.Acc, "SVC_CHAIN3")
+		require_True(t, len(tmsg.Subscriptions) == 1)
+		require_Equal(t, tmsg.Subscriptions[0].Acc, "SVC_CHAIN1")
+		require_True(t, len(tmsg.AssociatedInfo.AccountInfo) == 2)
+		require_True(t, len(tmsg.AssociatedInfo.ConnInfo) == 2)
+	})
+	t.Run("service-chain-2", func(t *testing.T) {
+		// This time have another subscriber in chain2
+		ncMid := natsConnect(t, sA.ClientURL(), nats.UserInfo("svc_chain2", "svc_chain2"))
+		require_NoError(t, ncMid.Flush())
+		sMid, err := ncMid.SubscribeSync(">")
+		require_NoError(t, err)
+
+		ncPub, ncSub := createAccountConnPair("svc_chain3", "svc_chain1")
+		defer ncPub.Close()
+		defer ncSub.Close()
+
+		sub, err := ncSub.SubscribeSync(">")
+		require_NoError(t, err)
+		require_NoError(t, ncSub.Flush())
+
+		sendTestData(ncPub, "always")
+		recvTestData(sMid, 1)
+		recvTestData(sub, 1)
+
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tmsg := getOkTraceBody(t, msg)
+		require_TimeoutOnPolicy()
+
+		require_Equal(t, tmsg.Acc, "SVC_CHAIN3")
+
+		require_True(t, len(tmsg.Subscriptions) == 2)
+		accs := map[string]struct{}{}
+		for _, sub := range tmsg.Subscriptions {
+			accs[sub.Acc] = struct{}{}
+			require_Equal(t, sub.SubClient.Kind, "Client")
+		}
+		_, ok := accs["SVC_CHAIN1"]
+		require_True(t, ok)
+		_, ok = accs["SVC_CHAIN2"]
+		require_True(t, ok)
+
+		require_True(t, len(tmsg.AssociatedInfo.AccountInfo) == 3)
+		require_True(t, len(tmsg.AssociatedInfo.ConnInfo) == 3)
+	})
+}
+
+func TestMessageTraceAccountSimpleServer(t *testing.T) {
+	storeDir := createDir(t, JetStreamStoreDir)
+	confA := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: -1
+		system_account: SYS
+		server_name: srv-A
+		jetstream: {max_mem_store: 10Mb, max_file_store: 10Mb, store_dir: %s }
+		accounts: {
+			SYS: {users: [ {user: sys, password: sys}]}
+			ACC: {
+				users: [ {user: acc, password: acc}]
+				msg_trace: {
+					trace_particular_subject_always: {Subject: always, Probes: [connz]}
+					capture_msg: {Subject: capture, Probes: [msg]}
+				}
+				ping_probes: connz
+			}
+			MAP: {
+				users: [ {user: map, password: map}]
+				mappings: {map.*: "$1"}
+				msg_trace: {
+					trace_particular_subject_always: {Subject: always}
+				}
+			}
+			EXP_STRM: {
+				users: [ {user: exp_strm, password: exp_strm}]
+				exports: [{stream: >}]
+				msg_trace: {
+					trace_particular_subject_always: {Subject: always}
+				}
+			}
+			IMP_STRM: {
+				users: [ {user: imp_strm, password: imp_strm}]
+				imports: [{stream: {account: EXP_STRM, subject: *}, to: imported.$1}]
+				msg_trace: {
+					trace_particular_subject_always: {Subject: imported.always}
+				}
+			}
+			EXP_SVC: {
+				users: [ {user: exp_svc, password: exp_svc}]
+				exports: [{service: svc.>}]
+				msg_trace: {
+					trace_particular_subject_always: {Subject: svc.always}
+				}
+			}
+			IMP_SVC: {
+				users: [ {user: imp_svc, password: imp_svc}]
+				imports: [{service: {account: EXP_SVC, subject: svc.*}, to: *}]
+				msg_trace: {
+					trace_particular_subject_always: {Subject: always}
+				}
+			}
+			JS_ACC {
+				users: [ {user: js_acc, password: js_acc}]
+				jetstream: {max_mem: 5Mb, max_store: 5Mb, max_streams: -1, max_consumers: -1}
+				ping_probes: enabled
+			}
+		}
+    `, storeDir)))
+	defer removeFile(t, confA)
+	sA, _ := RunServerWithConfig(confA)
+	defer sA.Shutdown()
+
+	createTrcSubExt := func(accUser string, traceSubj string) (*nats.Conn, *nats.Subscription) {
+		ncSys := natsConnect(t, sA.ClientURL(), nats.UserInfo(accUser, accUser))
+		s, err := ncSys.SubscribeSync(traceSubj)
+		require_NoError(t, err)
+		require_NoError(t, ncSys.Flush())
+		return ncSys, s
+	}
+	createTrcSub := func(accUser string) (*nats.Conn, *nats.Subscription) {
+		return createTrcSubExt(accUser, fmt.Sprintf(accTrcEvent, strings.ToUpper(accUser), "trace_particular_subject_always"))
+	}
+
+	createAccountConnPair := func(accUser1, accUser2 string) (*nats.Conn, *nats.Conn) {
+		t.Helper()
+		ncPub := natsConnect(t, sA.ClientURL(), nats.UserInfo(accUser1, accUser1), nats.Name("ncpub"))
+		require_NoError(t, ncPub.Flush())
+		ncSub := natsConnect(t, sA.ClientURL(), nats.UserInfo(accUser2, accUser2), nats.Name("ncsub"))
+		require_NoError(t, ncSub.Flush())
+		return ncPub, ncSub
+	}
+	require_TimeoutOnPolicy := func(s *nats.Subscription) {
+		t.Helper()
+		_, err := s.NextMsg(250 * time.Millisecond)
+		require_True(t, err == nats.ErrTimeout)
+	}
+	require_AccountOnlyClient := func(fMsg *TraceMsg, acc string) {
+		t.Helper()
+		require_Equal(t, fMsg.Acc, acc)
+		require_True(t, fMsg.Client == nil)
+		require_Equal(t, fMsg.SubjectMatched, "")
+		require_Equal(t, fMsg.SubjectPreMapping, "")
+	}
+	sendTestData := func(nc *nats.Conn, subjects ...string) {
+		t.Helper()
+		for _, subj := range subjects {
+			require_NoError(t, nc.Publish(subj, nil))
+		}
+		require_NoError(t, nc.Flush())
+	}
+	recvTestData := func(sub *nats.Subscription, num int) {
+		t.Helper()
+		for i := 0; i < num; i++ {
+			_, err := sub.NextMsg(time.Second)
+			require_NoError(t, err)
+		}
+	}
+
+	t.Run("no-sub", func(t *testing.T) {
+		trcCon, s := createTrcSub("acc")
+		defer trcCon.Close()
+		ncPub, ncSub := createAccountConnPair("acc", "acc")
+		defer ncPub.Close()
+		defer ncSub.Close()
+		sendTestData(ncPub, "never", "always")
+
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tMsg := getOkTraceBody(t, msg)
+
+		require_True(t, len(tMsg.Subscriptions) == 0)
+		requie_BasicPubNatsClient(t, tMsg, "ACC")
+		require_Equal(t, tMsg.SubjectMatched, "always")
+
+		require_TimeoutOnPolicy(s)
+	})
+	// next two tests are almost identical, only differ if same or different connection
+	testWithSub := func(ncPub, ncSub *nats.Conn) *TraceMsg {
+		trcCon, s := createTrcSub("acc")
+		defer trcCon.Close()
+		sub, err := ncSub.SubscribeSync(">")
+		require_NoError(t, err)
+		require_NoError(t, ncSub.Flush())
+
+		sendTestData(ncPub, "never", "always")
+		recvTestData(sub, 2)
+
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tMsg := getOkTraceBody(t, msg)
+
+		require_True(t, len(tMsg.Subscriptions) == 1)
+		requie_BasicSubNatsClient(t, tMsg.Subscriptions[0], "ACC", ">", "always", "", "")
+
+		requie_BasicPubNatsClient(t, tMsg, "ACC")
+		require_Equal(t, tMsg.SubjectMatched, "always")
+
+		require_TimeoutOnPolicy(s)
+		return tMsg
+	}
+	t.Run("with-sub-different-con", func(t *testing.T) {
+		ncPub, ncSub := createAccountConnPair("acc", "acc")
+		defer ncPub.Close()
+		defer ncSub.Close()
+		tMsg := testWithSub(ncPub, ncSub)
+		require_True(t, tMsg.Client.ClientId != tMsg.Subscriptions[0].SubClient.ClientId)
+		require_True(t, len(tMsg.AssociatedInfo.ConnInfo) == 2)
+	})
+	t.Run("with-sub-same-Con", func(t *testing.T) {
+		ncPub, ncSub := createAccountConnPair("acc", "acc")
+		ncPub.Close()
+		defer ncSub.Close()
+		tMsg := testWithSub(ncSub, ncSub)
+		require_True(t, tMsg.Client.ClientId == tMsg.Subscriptions[0].SubClient.ClientId)
+		require_True(t, len(tMsg.AssociatedInfo.ConnInfo) == 1)
+	})
+	t.Run("with-queue-sub", func(t *testing.T) {
+		trcCon, s := createTrcSub("acc")
+		defer trcCon.Close()
+		ncPub, ncSub := createAccountConnPair("acc", "acc")
+		defer ncPub.Close()
+		defer ncSub.Close()
+		sub, err := ncSub.QueueSubscribeSync(">", "queue")
+		require_NoError(t, err)
+		require_NoError(t, ncSub.Flush())
+
+		sendTestData(ncPub, "never", "always")
+		recvTestData(sub, 2)
+
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tMsg := getOkTraceBody(t, msg)
+
+		require_True(t, len(tMsg.Subscriptions) == 1)
+		requie_BasicSubNatsClient(t, tMsg.Subscriptions[0], "ACC", ">", "always", "queue", "")
+
+		requie_BasicPubNatsClient(t, tMsg, "ACC")
+		require_Equal(t, tMsg.SubjectMatched, "always")
+
+		require_TimeoutOnPolicy(s)
+	})
+	t.Run("header-no-sub", func(t *testing.T) {
+		ncPub, ncSub := createAccountConnPair("acc", "acc")
+		defer ncPub.Close()
+		defer ncSub.Close()
+		// expecting at least one message, even without subscriber
+		msg, err := ncPub.RequestMsg(&nats.Msg{
+			Subject: "foo",
+			Header: nats.Header{
+				TracePing: []string{""},
+			}}, time.Second/4)
+		require_NoError(t, err)
+		_, tMsg := getOkTraceBody(t, msg)
+		require_True(t, tMsg.AssociatedInfo == nil)
+		require_True(t, len(tMsg.Subscriptions) == 0)
+	})
+	t.Run("header-trigger", func(t *testing.T) {
+		ncPub, ncSub := createAccountConnPair("acc", "acc")
+		defer ncPub.Close()
+		defer ncSub.Close()
+		sub, err := ncSub.SubscribeSync("foo")
+		require_NoError(t, err)
+		require_NoError(t, ncSub.Flush())
+		t.Run("no-request", func(t *testing.T) {
+			// expected to trigger a trace
+			require_NoError(t, ncPub.PublishMsg(&nats.Msg{
+				Subject: "foo",
+				Header: nats.Header{
+					TracePing: []string{""},
+				}}))
+			require_NoError(t, err)
+		})
+		t.Run("no-probes", func(t *testing.T) {
+			// expected to trigger a trace
+			msg, err := ncPub.RequestMsg(&nats.Msg{
+				Subject: "foo",
+				Header: nats.Header{
+					TracePing: []string{""},
+				}}, time.Second/4)
+			require_NoError(t, err)
+			_, tMsg := getOkTraceBody(t, msg)
+			require_True(t, tMsg.AssociatedInfo == nil)
+		})
+		t.Run("with-probes", func(t *testing.T) {
+			// expected to trigger a trace
+			msg, err := ncPub.RequestMsg(&nats.Msg{
+				Subject: "foo",
+				Header: nats.Header{
+					TracePing: []string{"connz,accountz"},
+				}}, time.Second/4)
+			require_NoError(t, err)
+			_, tMsg := getOkTraceBody(t, msg)
+			require_True(t, len(tMsg.AssociatedInfo.ConnInfo) == 2)
+			// permission to grant accountz info was not granted by config
+			require_True(t, len(tMsg.AssociatedInfo.AccountInfo) == 0)
+			require_True(t, len(tMsg.Subscriptions) == 1)
+			require_Equal(t, tMsg.Subscriptions[0].NoSendReason, "trace Message is not delivered to Clients")
+		})
+		// The trace message sent is not expected to be received
+		_, err = sub.NextMsg(time.Second / 4)
+		require_True(t, err == nats.ErrTimeout)
+	})
+	t.Run("header-jetstream", func(t *testing.T) {
+		ncPub, ncSub := createAccountConnPair("js_acc", "js_acc")
+		defer ncPub.Close()
+		defer ncSub.Close()
+
+		js, err := ncSub.JetStream()
+		require_NoError(t, err)
+
+		_, err = js.AddStream(&nats.StreamConfig{Name: "S2", Subjects: []string{"foo"}})
+		require_NoError(t, err)
+		defer js.DeleteStream("S2")
+
+		sub, err := js.SubscribeSync("foo")
+		require_NoError(t, err)
+		require_NoError(t, ncSub.Flush())
+
+		msg, err := ncPub.RequestMsg(&nats.Msg{
+			Subject: "foo",
+			Header: nats.Header{
+				TracePing: []string{""},
+			}}, time.Second)
+		require_NoError(t, err)
+
+		_, err = sub.NextMsg(time.Second / 4)
+		require_True(t, err == nats.ErrTimeout)
+
+		_, tMsg := getOkTraceBody(t, msg)
+
+		require_True(t, len(tMsg.Subscriptions) == 1)
+		require_Equal(t, tMsg.Subscriptions[0].Acc, "JS_ACC")
+		require_Equal(t, tMsg.Subscriptions[0].PubSubject, "foo")
+		require_Equal(t, tMsg.Subscriptions[0].Sub, "foo")
+		require_Equal(t, tMsg.Subscriptions[0].SubClient.Kind, "JetStream")
+		require_Equal(t, tMsg.Subscriptions[0].NoSendReason, "trace Message is not delivered to JetStream")
+	})
+	t.Run("capture-msg", func(t *testing.T) {
+		trcCon, s := createTrcSubExt("acc", fmt.Sprintf(accTrcEvent, "ACC", "capture_msg"))
+		defer trcCon.Close()
+		ncPub, ncSub := createAccountConnPair("acc", "acc")
+		defer ncPub.Close()
+		defer ncSub.Close()
+		// expecting at least one message, even without subscriber
+		data := "somedata"
+		_, err := ncPub.RequestMsg(&nats.Msg{
+			Subject: "capture",
+			Data:    []byte(data),
+			Header: nats.Header{
+				"hello": []string{"world"},
+			}}, time.Second/4)
+		require_True(t, err == nats.ErrNoResponders)
+
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+		_, tMsg := getOkTraceBody(t, msg)
+
+		require_True(t, tMsg.AssociatedInfo != nil)
+		require_Equal(t, string(tMsg.AssociatedInfo.Msg), data)
+		require_True(t, len(tMsg.AssociatedInfo.Header) == 1)
+		require_Equal(t, tMsg.AssociatedInfo.Header.Get("hello"), "world")
+		require_Contains(t, tMsg.Reply, "_INBOX.")
+		require_TimeoutOnPolicy(s)
+	})
+	t.Run("mapped-sub", func(t *testing.T) {
+		trcCon, s := createTrcSub("map")
+		defer trcCon.Close()
+		ncPub, ncSub := createAccountConnPair("map", "map")
+		defer ncPub.Close()
+		defer ncSub.Close()
+
+		sub, err := ncSub.SubscribeSync(">")
+		require_NoError(t, err)
+		require_NoError(t, ncSub.Flush())
+
+		sendTestData(ncPub, "map.always")
+		recvTestData(sub, 1)
+
+		msg, err := s.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tMsg := getOkTraceBody(t, msg)
+
+		require_True(t, len(tMsg.Subscriptions) == 1)
+		requie_BasicSubNatsClient(t, tMsg.Subscriptions[0], "MAP", ">", "always", "", "")
+
+		requie_BasicPubNatsClient(t, tMsg, "MAP")
+		require_Equal(t, tMsg.SubjectMatched, "always")
+		require_Equal(t, tMsg.SubjectPreMapping, "map.always")
+
+		require_TimeoutOnPolicy(s)
+	})
+	t.Run("import-stream", func(t *testing.T) {
+		// ensure that accounts only see what they should be seeing
+		trcConExp, sExp := createTrcSub("exp_strm")
+		defer trcConExp.Close()
+		trcConImp, sImp := createTrcSub("imp_strm")
+		defer trcConImp.Close()
+		ncPub, ncSub := createAccountConnPair("exp_strm", "imp_strm")
+		defer ncPub.Close()
+		defer ncSub.Close()
+
+		sub1, err := ncSub.SubscribeSync(">")
+		require_NoError(t, err)
+		require_NoError(t, ncSub.Flush())
+
+		sendTestData(ncPub, "always")
+		recvTestData(sub1, 1)
+
+		msgExp, err := sExp.NextMsg(time.Second)
+		require_NoError(t, err)
+		_, tMsgExp := getOkTraceBody(t, msgExp)
+
+		require_True(t, len(tMsgExp.Subscriptions) == 1)
+		require_True(t, *tMsgExp.Subscriptions[0] == TraceSubscription{Acc: "IMP_STRM", ImportSub: "*", Sub: "*", PubSubject: "imported.always"})
+
+		requie_BasicPubNatsClient(t, tMsgExp, "EXP_STRM")
+		require_Equal(t, tMsgExp.SubjectMatched, "always")
+
+		require_TimeoutOnPolicy(sExp)
+
+		msgImp, err := sImp.NextMsg(time.Second)
+		require_NoError(t, err)
+		_, tMsgImp := getOkTraceBody(t, msgImp)
+
+		require_True(t, tMsgImp.Client == nil)
+
+		require_TimeoutOnPolicy(sImp)
+		require_AccountOnlyClient(tMsgImp, "EXP_STRM")
+
+		require_True(t, len(tMsgImp.Subscriptions) == 1)
+		requie_BasicSubNatsClient(t, tMsgImp.Subscriptions[0], "IMP_STRM", "*", "imported.always", "", "imported.$1")
+	})
+	t.Run("import-service", func(t *testing.T) {
+		trcConExp, sExp := createTrcSub("exp_svc")
+		defer trcConExp.Close()
+		trcConImp, sImp := createTrcSub("imp_svc")
+		defer trcConImp.Close()
+		ncPub, ncSub := createAccountConnPair("imp_svc", "exp_svc")
+		defer ncPub.Close()
+		defer ncSub.Close()
+
+		sub, err := ncSub.SubscribeSync(">")
+		require_NoError(t, err)
+		require_NoError(t, ncSub.Flush())
+
+		sendTestData(ncPub, "always")
+		recvTestData(sub, 1)
+
+		msgExp, err := sExp.NextMsg(time.Second)
+		require_NoError(t, err)
+		_, tMsgExp := getOkTraceBody(t, msgExp)
+
+		require_True(t, len(tMsgExp.Subscriptions) == 1)
+		requie_BasicSubNatsClient(t, tMsgExp.Subscriptions[0], "EXP_SVC", ">", "svc.always", "", "svc.$1")
+
+		require_AccountOnlyClient(tMsgExp, "IMP_SVC")
+
+		require_TimeoutOnPolicy(sExp)
+
+		msgImp, err := sImp.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tMsgImp := getOkTraceBody(t, msgImp)
+		require_TimeoutOnPolicy(sImp)
+
+		requie_BasicPubNatsClient(t, tMsgImp, "IMP_SVC")
+		require_True(t, len(tMsgImp.Subscriptions) == 1)
+		require_True(t, *tMsgImp.Subscriptions[0] == TraceSubscription{Acc: "EXP_SVC", ImportSub: "*", Sub: "*", PubSubject: "svc.always"})
+		require_TimeoutOnPolicy(sImp)
+	})
+}
+
+func TestMessageTraceOperatorTrcSubjectOverwrite(t *testing.T) {
+	confA := createConfFile(t, []byte(`
+		listen: -1
+		system_account: SYS
+		server_name: srv-A
+		msg_trace: {
+			trace_name: {Subject: foo, trace_subject "send.trace.here"}
+		}
+		accounts: {
+			SYS: {users: [ {user: sys, password: sys}]}
+			ACC: {
+				users: [ {user: acc, password: acc}]
+				msg_trace: {
+					trace_name: {Subject: foo, trace_subject "send.trace.there"}
+				}
+			}
+		}
+		no_auth_user: acc
+    `))
+	defer removeFile(t, confA)
+	sA, _ := RunServerWithConfig(confA)
+	defer sA.Shutdown()
+
+	ncSys := natsConnect(t, sA.ClientURL(), nats.UserInfo("sys", "sys"))
+	defer ncSys.Close()
+
+	subSync, err := ncSys.SubscribeSync("send.trace.here")
+	require_NoError(t, err)
+	require_NoError(t, ncSys.Flush())
+
+	nc := natsConnect(t, sA.ClientURL())
+	subAcc, err := nc.SubscribeSync("send.trace.there")
+	require_NoError(t, err)
+	require_NoError(t, nc.Publish("foo", nil))
+
+	for _, sub := range []*nats.Subscription{subSync, subAcc} {
+		msg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		_, tMsg := getOkTraceBody(t, msg)
+		require_Equal(t, tMsg.SubjectMatched, "foo")
+	}
+}
+
+func TestMessageTraceFreq(t *testing.T) {
+	// ensure enough overlap between account and operator trace such that,
+	// even with a margin of error, some messages have to trigger traces by operator and account.
+	// this also makes sure tracing messages are not subject to their own tracing rules.
+	// Operator can see all traffic, including tracing traffic from accounts
+	// Account can sample its tracing traffic, if it did not originate from the same tracing rule.
+	confA := createConfFile(t, []byte(`
+		listen: -1
+		system_account: SYS
+		server_name: srv-A
+		msg_trace: {
+			trace_most_the_time: {Freq: 0.8}
+		}
+		accounts: {
+			SYS: {users: [ {user: sys, password: sys}]}
+			ACC: {
+				users: [ {user: acc, password: acc}]
+				msg_trace: {
+					trace_mostly: {Freq: 0.8}
+				}
+			}
+		}
+		no_auth_user: acc
+    `))
+	defer removeFile(t, confA)
+	sA, _ := RunServerWithConfig(confA)
+	defer sA.Shutdown()
+
+	pubCnt := 10000
+	subFmt := "pub.%d"
+
+	ncSys := natsConnect(t, sA.ClientURL(), nats.UserInfo("sys", "sys"))
+	defer ncSys.Close()
+	msgChanSys := make(chan *nats.Msg, 4*pubCnt)
+	defer close(msgChanSys)
+	sysAcc, err := ncSys.ChanSubscribe(fmt.Sprintf(serverTrcEvent, "*", "trace_most_the_time"), msgChanSys)
+	defer sysAcc.Unsubscribe()
+	require_NoError(t, err)
+	require_NoError(t, ncSys.Flush())
+
+	ncAcc := natsConnect(t, sA.ClientURL(), nats.UserInfo("acc", "acc"))
+	defer ncAcc.Close()
+	msgChanAcc := make(chan *nats.Msg, pubCnt)
+	defer close(msgChanAcc)
+	accTrcSubj := fmt.Sprintf(accTrcEvent, "ACC", "trace_mostly")
+	subAcc, err := ncAcc.ChanSubscribe(accTrcSubj, msgChanAcc)
+	defer subAcc.Unsubscribe()
+	require_NoError(t, err)
+	require_NoError(t, ncAcc.Flush())
+
+	nc := natsConnect(t, sA.ClientURL())
+	for i := 0; i < pubCnt; i++ {
+		require_NoError(t, nc.Publish(fmt.Sprintf(subFmt, i), nil))
+	}
+
+	// Retrieve account trace messages
+	inCnt := 0
+	lastIdx := -1
+FOR_MSG_ACC:
+	for {
+		select {
+		case m := <-msgChanAcc:
+			_, tMsg := getOkTraceBody(t, m)
+			var idx int
+			inCnt++
+			scanCnt, err := fmt.Sscanf(tMsg.SubjectMatched, subFmt, &idx)
+			require_NoError(t, err)
+			require_True(t, scanCnt == 1)
+			require_True(t, idx > lastIdx)
+			lastIdx = idx
+		case <-time.After(time.Second):
+			break FOR_MSG_ACC
+		}
+	}
+	require_True(t, inCnt > ((pubCnt/100*80)-(pubCnt/10))) // half - 10%
+	require_True(t, inCnt < ((pubCnt/100*80)+(pubCnt/10))) // half + 10%
+
+	// Retrieve operator trace messages
+	inCntAccTrc := 0
+	inCntOpTrc := 0
+	lastIdxOpTrc := -1
+	r1 := regexp.MustCompile(`\$SYS.*ACCOUNT.*CONN`)
+	r2 := regexp.MustCompile(`\$SYS.SERVER.*STATSZ`)
+
+FOR_MSG_OP:
+	for {
+		select {
+		case m := <-msgChanSys:
+			if _, tMsg := getOkTraceBody(t, m); tMsg.SubjectMatched == accTrcSubj {
+				inCntAccTrc++
+			} else if r1.MatchString(tMsg.SubjectMatched) || r2.MatchString(tMsg.SubjectMatched) {
+				// skip as these are system messages we didn't cause and thus shouldn't count
+			} else {
+				inCntOpTrc++
+				var idx int
+				scanCnt, err := fmt.Sscanf(tMsg.SubjectMatched, subFmt, &idx)
+				if err != nil {
+					require_Contains(t, tMsg.SubjectMatched, "$SYS")
+				}
+				require_True(t, scanCnt == 1)
+				require_True(t, idx > lastIdxOpTrc)
+				lastIdxOpTrc = idx
+			}
+		case <-time.After(time.Second):
+			break FOR_MSG_OP
+		}
+	}
+	// Make sure we got 80% of the account traffic
+	require_True(t, inCntOpTrc > ((pubCnt/100*80)-(pubCnt/10))) // 80% - 10%
+	require_True(t, inCntOpTrc < ((pubCnt/100*80)+(pubCnt/10))) // 80% + 10%
+	// Make sure we got 80% of the account tracing traffic
+	require_True(t, inCntAccTrc > ((inCnt/100*80)-(inCnt/10))) // 80% - 10%
+	require_True(t, inCntAccTrc < ((inCnt/100*80)+(inCnt/10))) // 80% + 10%
+}
+
+func TestMessageTraceOperatorCrossServer(t *testing.T) {
+	test := func(sA, sB *Server, expectKind string) {
+		ncSys := natsConnect(t, sA.ClientURL(), nats.UserInfo("sys", "sys"))
+		defer ncSys.Close()
+		subTrc1, err := ncSys.SubscribeSync(fmt.Sprintf(serverTrcEvent, "*", "trc1"))
+		require_NoError(t, err)
+		// Also test for trace accumulation
+		subTrc2, err := ncSys.SubscribeSync(fmt.Sprintf(serverTrcEvent, "*", "trc2"))
+		require_NoError(t, err)
+		require_NoError(t, ncSys.Flush())
+
+		ncB := natsConnect(t, sB.ClientURL())
+		defer ncB.Close()
+		sub, err := ncB.SubscribeSync("foo")
+		require_NoError(t, err)
+		require_NoError(t, ncB.Flush())
+
+		ncA := natsConnect(t, sA.ClientURL())
+		defer ncA.Close()
+		require_NoError(t, ncA.Publish("foo", []byte("helloworld")))
+
+		_, err = sub.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		// trc1 observes two messages. one for each server.
+		// this is happening despite trc1 not being defined in srv-B
+		msgA, err := subTrc1.NextMsg(time.Second)
+		require_NoError(t, err)
+		siA, m1 := getOkTraceBody(t, msgA)
+		require_Equal(t, siA.Name, "srv-A")
+		require_Equal(t, siA.ID, sA.ID())
+		require_True(t, len(m1.Subscriptions) == 1)
+		for _, v := range m1.Subscriptions {
+			require_Equal(t, v.SubClient.Kind, expectKind)
+			require_Equal(t, v.Acc, "ACC1")
+			require_Equal(t, v.SubClient.ServerId, sB.ID())
+		}
+
+		msgB, err := subTrc1.NextMsg(time.Second)
+		require_NoError(t, err)
+		siB, m2 := getOkTraceBody(t, msgB)
+		require_Equal(t, siB.Name, "srv-B")
+		require_Equal(t, siB.ID, sB.ID())
+		require_True(t, len(m2.Subscriptions) == 1)
+		for _, v := range m2.Subscriptions {
+			require_Equal(t, v.SubClient.Kind, "Client")
+		}
+
+		// make suer we only get two
+		_, err = subTrc1.NextMsg(time.Second / 4)
+		require_True(t, err == nats.ErrTimeout)
+
+		// trace 2 only applies on the leaf node server
+		msg2A, err := subTrc2.NextMsg(time.Second)
+		require_NoError(t, err)
+		si2A, m3 := getOkTraceBody(t, msg2A)
+		require_Equal(t, si2A.Name, "srv-B")
+		require_Equal(t, si2A.ID, sB.ID())
+		require_True(t, len(m3.Subscriptions) == 1)
+		for _, v := range m3.Subscriptions {
+			require_Equal(t, v.SubClient.Kind, "Client")
+		}
+		// make sure we only get one
+		_, err = subTrc2.NextMsg(time.Second / 4)
+		require_True(t, err == nats.ErrTimeout)
+	}
+
+	srvATmpl := `
+			listen: -1
+			system_account: SYS
+			server_name: srv-A
+			msg_trace: {
+				trc1: {Subject: foo}
+			}
+			accounts: {
+				SYS: {users: [ {user: sys, password: sys}]}
+				ACC1: {users: [ {user: acc, password: acc}]}
+			}
+			no_auth_user: acc
+`
+	srvBTmpl := `
+			listen: -1
+			system_account: SYS
+			server_name: srv-B
+			accounts: {
+				SYS: {users: [ {user: sys, password: sys}]}
+				ACC1: {users: [ {user: acc, password: acc}]}
+			}
+			no_auth_user: acc
+`
+
+	t.Run("leaf", func(t *testing.T) {
+		confA := createConfFile(t, []byte(fmt.Sprintf(`
+			%s
+			leafnodes: {
+				listen: localhost:-1
+			}
+		`, srvATmpl)))
+		defer removeFile(t, confA)
+		sA, _ := RunServerWithConfig(confA)
+		defer sA.Shutdown()
+
+		// because leaf nodes bridge authentication domains, traces will be re-evaluated and have to be explicitly listed
+		confB := createConfFile(t, []byte(fmt.Sprintf(`
+			%s
+			leafnodes: {
+				remotes:[{ url:nats://acc:acc@localhost:%d, account: ACC1},
+						 { url:nats://sys:sys@localhost:%d, account: SYS}]
+			}
+			msg_trace: {
+				trc1: {Subject: foo}
+				trc2: {Subject: foo}
+			}
+		`, srvBTmpl, sA.opts.LeafNode.Port, sA.opts.LeafNode.Port)))
+		defer removeFile(t, confB)
+		sB, _ := RunServerWithConfig(confB)
+		defer sB.Shutdown()
+		checkLeafNodeConnectedCount(t, sB, 2)
+		checkLeafNodeConnectedCount(t, sA, 2)
+
+		test(sA, sB, "Leafnode")
+	})
+	t.Run("route", func(t *testing.T) {
+		confA := createConfFile(t, []byte(fmt.Sprintf(`
+			%s
+			cluster: {
+				name: C1
+				listen: localhost:-1
+			}
+		`, srvATmpl)))
+		defer removeFile(t, confA)
+		sA, _ := RunServerWithConfig(confA)
+		defer sA.Shutdown()
+
+		confB := createConfFile(t, []byte(fmt.Sprintf(`
+			%s
+			cluster: {
+				name: C1
+				listen: localhost:-1
+				routes = [
+					nats-route://127.0.0.1:%d
+				]
+			}
+			msg_trace: {
+				trc2: {Subject: foo}
+			}
+		`, srvBTmpl, sA.opts.Cluster.Port)))
+		defer removeFile(t, confB)
+		sB, _ := RunServerWithConfig(confB)
+		defer sB.Shutdown()
+		checkClusterFormed(t, sA, sB)
+
+		test(sA, sB, "Router")
+	})
+	t.Run("gateway", func(t *testing.T) {
+		confA := createConfFile(t, []byte(fmt.Sprintf(`
+			%s
+			gateway: {
+				name: GA
+				listen: localhost:-1
+			}
+		`, srvATmpl)))
+		defer removeFile(t, confA)
+		sA, _ := RunServerWithConfig(confA)
+		defer sA.Shutdown()
+
+		confB := createConfFile(t, []byte(fmt.Sprintf(`
+			%s
+			gateway: {
+				name: GB
+				listen: localhost:-1
+				gateways: [
+					{name: "GA", url: "nats://127.0.0.1:%d"},
+				]
+			}
+			msg_trace: {
+				trc2: {Subject: foo}
+			}
+		`, srvBTmpl, sA.opts.Gateway.Port)))
+		defer removeFile(t, confB)
+		sB, _ := RunServerWithConfig(confB)
+		defer sB.Shutdown()
+		waitForOutboundGateways(t, sB, 1, 5*time.Second)
+		waitForInboundGateways(t, sA, 1, 5*time.Second)
+		test(sA, sB, "Gateway")
+	})
+}
+
+func TestMessageTraceSubjectAccountCrossServer(t *testing.T) {
+	test := func(sA, sB *Server, expectKind string) {
+		ncB := natsConnect(t, sB.ClientURL())
+		defer ncB.Close()
+		sub, err := ncB.SubscribeSync("foo")
+		require_NoError(t, err)
+		//TODO I wonder if I should see queue names in the first trace message from server A
+		subq1, err := ncB.QueueSubscribeSync("foo", "q1")
+		require_NoError(t, err)
+		subq2, err := ncB.QueueSubscribeSync("foo", "q2")
+		require_NoError(t, err)
+		require_NoError(t, ncB.Flush())
+
+		ncA := natsConnect(t, sA.ClientURL())
+		defer ncA.Close()
+		ib := nats.NewInbox()
+		subTrc, err := ncA.SubscribeSync(ib)
+		require_NoError(t, err)
+		require_NoError(t, ncA.PublishMsg(&nats.Msg{
+			Subject: "foo",
+			Reply:   ib,
+			Header:  nats.Header{TracePing: []string{""}},
+		}))
+		_, err = sub.NextMsg(time.Second)
+		require_True(t, err == nats.ErrTimeout)
+		_, err = subq1.NextMsg(time.Second)
+		require_True(t, err == nats.ErrTimeout)
+		_, err = subq2.NextMsg(time.Second)
+		require_True(t, err == nats.ErrTimeout)
+
+		msgA, err := subTrc.NextMsg(time.Second)
+		require_NoError(t, err)
+		siA, mA := getOkTraceBody(t, msgA)
+		require_Equal(t, siA.Name, "srv-A")
+		require_True(t, len(mA.Subscriptions) == 1)
+		require_Equal(t, mA.Subscriptions[0].SubClient.ServerId, sB.ID())
+		require_Equal(t, mA.Subscriptions[0].NoSendReason, "")
+		msgB, err := subTrc.NextMsg(time.Second)
+		require_NoError(t, err)
+		siB, mB := getOkTraceBody(t, msgB)
+		require_Equal(t, siB.Name, "srv-B")
+		require_True(t, len(mB.Subscriptions) == 3)
+		for _, s := range mB.Subscriptions {
+			require_Equal(t, s.NoSendReason, "trace Message is not delivered to Clients")
+		}
+		// make sure we only get one
+		_, err = subTrc.NextMsg(time.Second / 4)
+		require_True(t, err == nats.ErrTimeout)
+
+		// test filtering, send so server A, but filter for server B
+		require_NoError(t, ncA.PublishMsg(&nats.Msg{
+			Subject: "foo",
+			Reply:   ib,
+			Header:  nats.Header{TracePing: []string{""}},
+			Data:    []byte(sB.ID()),
+		}))
+		msgC, err := subTrc.NextMsg(time.Second)
+		require_NoError(t, err)
+		siC, _ := getOkTraceBody(t, msgC)
+		require_Equal(t, siC.Name, "srv-B")
+
+		_, err = subTrc.NextMsg(time.Second / 4)
+		require_True(t, err == nats.ErrTimeout)
+	}
+
+	srvATmpl := `
+			listen: -1
+			system_account: SYS
+			server_name: srv-A
+			accounts: {
+				SYS: {users: [ {user: sys, password: sys}]}
+				ACC1: {
+					users: [ {user: acc, password: acc}]
+					ping_probes: enabled
+				}
+			}
+			no_auth_user: acc
+`
+	srvBTmpl := `
+			listen: -1
+			system_account: SYS
+			server_name: srv-B
+			accounts: {
+				SYS: {users: [ {user: sys, password: sys}]}
+				ACC1: {
+					users: [ {user: acc, password: acc}]
+				    ping_probes: enabled
+				}
+			}
+			no_auth_user: acc
+`
+
+	t.Run("leaf", func(t *testing.T) {
+		confA := createConfFile(t, []byte(fmt.Sprintf(`
+			%s
+			leafnodes: {
+				listen: localhost:-1
+			}
+		`, srvATmpl)))
+		defer removeFile(t, confA)
+		sA, _ := RunServerWithConfig(confA)
+		defer sA.Shutdown()
+
+		// because leaf nodes bridge authentication domains, traces will be re-evaluated and have to be explicitly listed
+		confB := createConfFile(t, []byte(fmt.Sprintf(`
+			%s
+			leafnodes: {
+				remotes:[{ url:nats://acc:acc@localhost:%d, account: ACC1},
+						 { url:nats://sys:sys@localhost:%d, account: SYS}]
+			}
+		`, srvBTmpl, sA.opts.LeafNode.Port, sA.opts.LeafNode.Port)))
+		defer removeFile(t, confB)
+		sB, _ := RunServerWithConfig(confB)
+		defer sB.Shutdown()
+		checkLeafNodeConnectedCount(t, sB, 2)
+		checkLeafNodeConnectedCount(t, sA, 2)
+
+		test(sA, sB, "Leafnode")
+	})
+	t.Run("route", func(t *testing.T) {
+		confA := createConfFile(t, []byte(fmt.Sprintf(`
+			%s
+			cluster: {
+				name: C1
+				listen: localhost:-1
+			}
+		`, srvATmpl)))
+		defer removeFile(t, confA)
+		sA, _ := RunServerWithConfig(confA)
+		defer sA.Shutdown()
+
+		confB := createConfFile(t, []byte(fmt.Sprintf(`
+			%s
+			cluster: {
+				name: C1
+				listen: localhost:-1
+				routes = [
+					nats-route://127.0.0.1:%d
+				]
+			}
+		`, srvBTmpl, sA.opts.Cluster.Port)))
+		defer removeFile(t, confB)
+		sB, _ := RunServerWithConfig(confB)
+		defer sB.Shutdown()
+		checkClusterFormed(t, sA, sB)
+
+		test(sA, sB, "Router")
+	})
+	t.Run("gateway", func(t *testing.T) {
+		confA := createConfFile(t, []byte(fmt.Sprintf(`
+			%s
+			gateway: {
+				name: GA
+				listen: localhost:-1
+			}
+		`, srvATmpl)))
+		defer removeFile(t, confA)
+		sA, _ := RunServerWithConfig(confA)
+		defer sA.Shutdown()
+
+		confB := createConfFile(t, []byte(fmt.Sprintf(`
+			%s
+			gateway: {
+				name: GB
+				listen: localhost:-1
+				gateways: [
+					{name: "GA", url: "nats://127.0.0.1:%d"},
+				]
+			}
+		`, srvBTmpl, sA.opts.Gateway.Port)))
+		defer removeFile(t, confB)
+		sB, _ := RunServerWithConfig(confB)
+		defer sB.Shutdown()
+		waitForOutboundGateways(t, sB, 1, 5*time.Second)
+		waitForInboundGateways(t, sA, 1, 5*time.Second)
+		test(sA, sB, "Gateway")
+	})
+}
+
+func TestMessageTraceOperatorClusterStream(t *testing.T) {
+	confA := createConfFile(t, []byte(`
+		listen: -1
+		system_account: SYS
+		server_name: srv-A
+		msg_trace: {
+			trc1: {Subject: foo}
+		}
+		accounts: {
+			SYS: {users: [ {user: sys, password: sys}]}
+			EXP: {
+				users: [ {user: exp, password: exp}]
+				exports: [{stream: >}]
+			}
+			IMP1: {
+				users: [ {user: imp1, password: imp1}]
+				imports: [{stream: {account: EXP, subject: >}}]
+			}
+			IMP2: {
+				users: [ {user: imp2, password: imp2}]
+				imports: [{stream: {account: EXP, subject: >}}]
+			}
+		}
+		no_auth_user: exp
+		cluster: {
+			name: C1
+			listen: localhost:-1
+		}
+    `))
+	defer removeFile(t, confA)
+	sA, _ := RunServerWithConfig(confA)
+	defer sA.Shutdown()
+
+	confB := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: -1
+		system_account: SYS
+		server_name: srv-B
+		accounts: {
+			SYS: {users: [ {user: sys, password: sys}]}
+			EXP: {
+				users: [ {user: exp, password: exp}]
+				exports: [{stream: >}]
+			}
+			IMP1: {
+				users: [ {user: imp1, password: imp1}]
+				imports: [{stream: {account: EXP, subject: >}}]
+			}
+			IMP2: {
+				users: [ {user: imp2, password: imp2}]
+				imports: [{stream: {account: EXP, subject: >}}]
+			}
+		}
+		no_auth_user: exp
+		cluster: {
+			name: C1
+			listen: localhost:-1
+			routes = [
+				nats-route://127.0.0.1:%d
+			]
+		}
+    `, sA.opts.Cluster.Port)))
+	defer removeFile(t, confB)
+	sB, _ := RunServerWithConfig(confB)
+	defer sB.Shutdown()
+	checkClusterFormed(t, sA, sB)
+
+	ncSys := natsConnect(t, sA.ClientURL(), nats.UserInfo("sys", "sys"))
+	defer ncSys.Close()
+	subTrc1, err := ncSys.SubscribeSync(fmt.Sprintf(serverTrcEvent, "*", "trc1"))
+	require_NoError(t, err)
+
+	var subs []*nats.Subscription
+	for _, s := range []*Server{sA, sB} {
+		ncBExp := natsConnect(t, s.ClientURL(), nats.UserInfo("exp", "exp"))
+		defer ncBExp.Close()
+		subExp1, err := ncBExp.SubscribeSync("*")
+		require_NoError(t, err)
+		subExp2, err := ncBExp.SubscribeSync("*")
+		require_NoError(t, err)
+		require_NoError(t, ncBExp.Flush())
+
+		ncBImp1 := natsConnect(t, s.ClientURL(), nats.UserInfo("imp1", "imp1"))
+		defer ncBImp1.Close()
+		subImp1, err := ncBImp1.SubscribeSync("*")
+		require_NoError(t, err)
+		subImp2, err := ncBImp1.SubscribeSync("*")
+		require_NoError(t, err)
+		require_NoError(t, ncBImp1.Flush())
+
+		ncBImp2 := natsConnect(t, s.ClientURL(), nats.UserInfo("imp2", "imp2"))
+		defer ncBImp2.Close()
+		subImp3, err := ncBImp2.SubscribeSync("*")
+		require_NoError(t, err)
+		subImp4, err := ncBImp2.SubscribeSync("*")
+		require_NoError(t, err)
+		require_NoError(t, ncBImp2.Flush())
+
+		subs = append(subs, subExp1, subExp2, subImp1, subImp2, subImp3, subImp4)
+	}
+
+	ncA := natsConnect(t, sA.ClientURL())
+	defer ncA.Close()
+	require_NoError(t, ncA.Publish("foo", []byte("helloworld")))
+
+	for _, sub := range subs {
+		_, err = sub.NextMsg(time.Second)
+		require_NoError(t, err)
+	}
+	for _, sub := range subs {
+		_, err = sub.NextMsg(time.Second / 4)
+		require_True(t, err == nats.ErrTimeout)
+	}
+
+	msg1, err := subTrc1.NextMsg(time.Second)
+	require_NoError(t, err)
+	si1, m1 := getOkTraceBody(t, msg1)
+	require_Equal(t, si1.Name, "srv-A")
+	require_True(t, len(m1.Subscriptions) == 7)
+	routerCnt := 0
+	accCnt := map[string]int{}
+	for _, v := range m1.Subscriptions {
+		if v.SubClient.ServerId == _EMPTY_ {
+			require_Equal(t, v.SubClient.Kind, "Client")
+			accCnt[v.Acc]++
+		} else {
+			require_Equal(t, v.SubClient.Kind, "Router")
+			require_Equal(t, v.Acc, "EXP")
+			require_Equal(t, v.SubClient.ServerId, sB.ID())
+			routerCnt++
+
+			_, ok := sA.routes[v.SubClient.ClientId]
+			require_True(t, ok)
+		}
+	}
+	require_True(t, len(sA.routes) == 1)
+	require_True(t, routerCnt == 1)
+	require_True(t, len(accCnt) == 3)
+	for _, v := range accCnt {
+		require_True(t, v == 2)
+	}
+	accCnt = map[string]int{}
+
+	msg2, err := subTrc1.NextMsg(time.Second)
+	require_NoError(t, err)
+	si2, m2 := getOkTraceBody(t, msg2)
+	require_Equal(t, si2.Name, "srv-B")
+	_, ok := sB.routes[m2.Client.ClientId]
+	require_True(t, ok)
+	require_True(t, len(sB.routes) == 1)
+	require_True(t, len(m2.Subscriptions) == 6)
+	for _, v := range m2.Subscriptions {
+		require_Equal(t, v.SubClient.Kind, "Client")
+		accCnt[v.Acc]++
+	}
+	require_True(t, len(accCnt) == 3)
+	for _, v := range accCnt {
+		require_True(t, v == 2)
+	}
+
+	// make suer we only get two
+	_, err = subTrc1.NextMsg(time.Second / 4)
+	require_True(t, err == nats.ErrTimeout)
+}
+
+func TestMessageTraceOperatorLeafStream(t *testing.T) {
+	// This test is a bit more complex as messages are sent back (after import in B)
+	confA := createConfFile(t, []byte(`
+		listen: -1
+		system_account: SYS
+		server_name: srv-A
+		msg_trace: {
+			trc1: {Subject: foo}
+		}
+		accounts: {
+			SYS: {users: [ {user: sys, password: sys}]}
+			EXP: {
+				users: [ {user: exp, password: exp}]
+				exports: [{stream: foo}]
+			}
+			IMP1: {
+				users: [ {user: imp1, password: imp1}]
+				imports: [{stream: {account: EXP, subject: foo}}]
+			}
+			IMP2: {
+				users: [ {user: imp2, password: imp2}]
+				imports: [{stream: {account: EXP, subject: foo}}]
+			}
+		}
+		no_auth_user: exp
+		leafnodes: {
+			listen: localhost:-1
+		}
+    `))
+	defer removeFile(t, confA)
+	sA, _ := RunServerWithConfig(confA)
+	defer sA.Shutdown()
+
+	confB := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: -1
+		system_account: SYS
+		server_name: srv-B
+		msg_trace: {
+			trc1: {Subject: foo}
+		}
+		accounts: {
+			SYS: {users: [ {user: sys, password: sys}]}
+			EXP: {
+				users: [ {user: exp, password: exp}]
+				exports: [{stream: foo}]
+			}
+			IMP1: {
+				users: [ {user: imp1, password: imp1}]
+				imports: [{stream: {account: EXP, subject: foo} }]
+			}
+			IMP2: {
+				users: [ {user: imp2, password: imp2}]
+				imports: [{stream: {account: EXP, subject: foo}}]
+			}
+		}
+		no_auth_user: exp
+		leafnodes: {
+			remotes:[{ url:nats://exp:exp@localhost:%d, account: EXP},
+					 { url:nats://sys:sys@localhost:%d, account: SYS},
+					 { url:nats://imp1:imp1@localhost:%d, account: IMP1},
+					 { url:nats://imp2:imp2@localhost:%d, account: IMP2}]
+		}
+    `, sA.opts.LeafNode.Port, sA.opts.LeafNode.Port, sA.opts.LeafNode.Port, sA.opts.LeafNode.Port)))
+	defer removeFile(t, confB)
+	sB, _ := RunServerWithConfig(confB)
+	defer sB.Shutdown()
+	checkLeafNodeConnectedCount(t, sB, 4)
+	checkLeafNodeConnectedCount(t, sA, 4)
+
+	ncSys := natsConnect(t, sA.ClientURL(), nats.UserInfo("sys", "sys"))
+	defer ncSys.Close()
+	subTrc1, err := ncSys.SubscribeSync(fmt.Sprintf(serverTrcEvent, "*", "trc1"))
+	require_NoError(t, err)
+
+	var subs []*nats.Subscription
+	for _, s := range []*Server{sA, sB} {
+		ncBExp := natsConnect(t, s.ClientURL(), nats.UserInfo("exp", "exp"))
+		defer ncBExp.Close()
+		subExp1, err := ncBExp.SubscribeSync("*")
+		require_NoError(t, err)
+		subExp2, err := ncBExp.SubscribeSync("*")
+		require_NoError(t, err)
+		require_NoError(t, ncBExp.Flush())
+
+		ncBImp1 := natsConnect(t, s.ClientURL(), nats.UserInfo("imp1", "imp1"))
+		defer ncBImp1.Close()
+		subImp1, err := ncBImp1.SubscribeSync("*")
+		require_NoError(t, err)
+		subImp2, err := ncBImp1.SubscribeSync("*")
+		require_NoError(t, err)
+		require_NoError(t, ncBImp1.Flush())
+
+		ncBImp2 := natsConnect(t, s.ClientURL(), nats.UserInfo("imp2", "imp2"))
+		defer ncBImp2.Close()
+		subImp3, err := ncBImp2.SubscribeSync("*")
+		require_NoError(t, err)
+		subImp4, err := ncBImp2.SubscribeSync("*")
+		require_NoError(t, err)
+		require_NoError(t, ncBImp2.Flush())
+
+		// Put in subImp* subscription twice, as messages are duplicated due to
+		// EXP being in a remote and importing being processed twice
+		subs = append(subs, subExp1, subExp2, subImp1, subImp2, subImp3, subImp4, subImp1, subImp2, subImp3, subImp4)
+	}
+
+	ncA := natsConnect(t, sA.ClientURL())
+	defer ncA.Close()
+	require_NoError(t, ncA.Publish("foo", []byte("helloworld")))
+
+	for _, sub := range subs {
+		_, err = sub.NextMsg(time.Second)
+		require_NoError(t, err)
+	}
+	for _, sub := range subs {
+		_, err = sub.NextMsg(time.Second / 4)
+		require_True(t, err == nats.ErrTimeout)
+	}
+
+	msgs := map[string][]*TraceMsg{}
+	for i := 0; i < 6; i++ {
+		msg1, err := subTrc1.NextMsg(time.Second)
+		require_NoError(t, err)
+		si, m1 := getOkTraceBody(t, msg1)
+		msgs[si.Name] = append(msgs[si.Name], m1)
+	}
+
+	m1 := msgs["srv-A"][0]
+	require_True(t, len(m1.Subscriptions) == 9)
+	leafnodeCnt := 0
+	accCnt := map[string]int{}
+	for _, v := range m1.Subscriptions {
+		if v.SubClient.ServerId == _EMPTY_ {
+			require_Equal(t, v.SubClient.Kind, "Client")
+		} else {
+			require_Equal(t, v.SubClient.Kind, "Leafnode")
+			require_Equal(t, v.SubClient.ServerId, sB.ID())
+			leafnodeCnt++
+
+			_, ok := sA.leafs[v.SubClient.ClientId]
+			require_True(t, ok)
+		}
+		accCnt[v.Acc]++
+	}
+	require_True(t, leafnodeCnt == 3)
+	require_True(t, len(accCnt) == 3)
+	for _, v := range accCnt {
+		require_True(t, v == 3)
+	}
+	accCnt = map[string]int{}
+
+	// These next two messages are incoming from srv-B, a consequence of EXP being in a remote
+	// and imported on the other side as well. These two messages are the messages that got imported and then sent back
+	for _, m := range msgs["srv-A"][1:] {
+		require_Equal(t, m.Client.Kind, "Leafnode")
+		_, ok := sA.leafs[m.Client.ClientId]
+		require_True(t, ok)
+		require_Contains(t, m.Acc, "IMP")
+		require_True(t, len(m.Subscriptions) == 2)
+		for _, s := range m.Subscriptions {
+			require_Equal(t, s.SubClient.Kind, "Client")
+			require_Equal(t, s.Acc, m.Acc)
+		}
+	}
+
+	msgsByAcc := map[string]*TraceMsg{}
+	for _, m := range msgs["srv-B"] {
+		msgsByAcc[m.Acc] = m
+	}
+	require_True(t, len(msgsByAcc) == 3)
+
+	for _, m := range msgsByAcc {
+		require_Equal(t, m.Client.Kind, "Leafnode")
+		_, ok := sB.leafs[m.Client.ClientId]
+		require_True(t, ok)
+		if m.Acc == "EXP" {
+			continue
+		}
+		require_Contains(t, m.Acc, "IMP")
+		require_True(t, len(m.Subscriptions) == 2)
+		for _, s := range m.Subscriptions {
+			require_Equal(t, s.SubClient.Kind, "Client")
+			require_Equal(t, s.Acc, m.Acc)
+		}
+	}
+
+	m := msgsByAcc["EXP"]
+	require_True(t, len(m.Subscriptions) == 8)
+	for _, v := range m.Subscriptions {
+		accCnt[v.Acc]++
+	}
+	require_True(t, accCnt["IMP1"] == 3)
+	require_True(t, accCnt["IMP2"] == 3)
+	require_True(t, accCnt["EXP"] == 2)
+
+	// make suer we only get two
+	_, err = subTrc1.NextMsg(time.Second / 4)
+	require_True(t, err == nats.ErrTimeout)
+}
+
+func TestMessageTraceOperatorClusterService(t *testing.T) {
+	confA := createConfFile(t, []byte(`
+		listen: -1
+		system_account: SYS
+		server_name: srv-A
+		msg_trace: {
+			trc1: {Subject: foo}
+		}
+		accounts: {
+			SYS: {users: [ {user: sys, password: sys}]}
+			EXP: {
+				users: [ {user: exp, password: exp}]
+				exports: [{service: >}]
+			}
+			IMP: {
+				users: [ {user: imp, password: imp}]
+				imports: [{service: {account: EXP, subject: >}, to: >}]
+			}
+		}
+		no_auth_user: exp
+		cluster: {
+			name: C1
+			listen: localhost:-1
+		}
+    `))
+	defer removeFile(t, confA)
+	sA, _ := RunServerWithConfig(confA)
+	defer sA.Shutdown()
+
+	confB := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: -1
+		system_account: SYS
+		server_name: srv-B
+		msg_trace: {
+			trc1: {Subject: foo, Probes: accountz}
+		}
+		accounts: {
+			SYS: {users: [ {user: sys, password: sys}]}
+			EXP: {
+				users: [ {user: exp, password: exp}]
+				exports: [{service: >}]
+			}
+			IMP: {
+				users: [ {user: imp, password: imp}]
+				imports: [{service: {account: EXP, subject: >}}]
+			}
+		}
+		no_auth_user: exp
+		cluster: {
+			name: C1
+			listen: localhost:-1
+			routes = [
+				nats-route://127.0.0.1:%d
+			]
+		}
+    `, sA.opts.Cluster.Port)))
+	defer removeFile(t, confB)
+	sB, _ := RunServerWithConfig(confB)
+	defer sB.Shutdown()
+	checkClusterFormed(t, sA, sB)
+
+	ncSys := natsConnect(t, sA.ClientURL(), nats.UserInfo("sys", "sys"))
+	defer ncSys.Close()
+	subTrc1, err := ncSys.SubscribeSync(fmt.Sprintf(serverTrcEvent, "*", "trc1"))
+	require_NoError(t, err)
+
+	var subs []*nats.Subscription
+	for _, s := range []*Server{sA, sB} {
+		ncBExp := natsConnect(t, s.ClientURL(), nats.UserInfo("exp", "exp"))
+		defer ncBExp.Close()
+		subExp1, err := ncBExp.SubscribeSync("*")
+		require_NoError(t, err)
+		require_NoError(t, ncBExp.Flush())
+
+		ncBImp1 := natsConnect(t, s.ClientURL(), nats.UserInfo("imp", "imp"))
+		defer ncBImp1.Close()
+		subImp1, err := ncBImp1.SubscribeSync("*")
+		require_NoError(t, err)
+
+		subs = append(subs, subExp1, subImp1)
+	}
+
+	ncA := natsConnect(t, sA.ClientURL(), nats.UserInfo("imp", "imp"))
+	defer ncA.Close()
+	require_NoError(t, ncA.Publish("foo", []byte("helloworld")))
+
+	for _, sub := range subs {
+		_, err = sub.NextMsg(time.Second)
+		require_NoError(t, err)
+	}
+	for _, sub := range subs {
+		_, err = sub.NextMsg(time.Second / 4)
+		require_True(t, err == nats.ErrTimeout)
+	}
+
+	msg1, err := subTrc1.NextMsg(time.Second)
+	require_NoError(t, err)
+	si1, m1 := getOkTraceBody(t, msg1)
+	require_Equal(t, si1.Name, "srv-A")
+	require_True(t, len(m1.Subscriptions) == 4)
+	routerCnt := 0
+	accCnt := map[string]int{}
+	for _, v := range m1.Subscriptions {
+		if v.SubClient.ServerId == _EMPTY_ {
+			require_Equal(t, v.SubClient.Kind, "Client")
+		} else {
+			require_Equal(t, v.SubClient.Kind, "Router")
+			require_Equal(t, v.SubClient.ServerId, sB.ID())
+			routerCnt++
+
+			_, ok := sA.routes[v.SubClient.ClientId]
+			require_True(t, ok)
+		}
+		accCnt[v.Acc]++
+	}
+	require_True(t, len(sA.routes) == 1)
+	require_True(t, routerCnt == 2)
+	require_True(t, len(accCnt) == 2)
+	for _, v := range accCnt {
+		require_True(t, v == 2)
+	}
+	accCnt = map[string]int{}
+
+	msg2, err := subTrc1.NextMsg(time.Second)
+	require_NoError(t, err)
+	si2, m2 := getOkTraceBody(t, msg2)
+	require_Equal(t, si2.Name, "srv-B")
+	_, ok := sB.routes[m2.Client.ClientId]
+	require_True(t, ok)
+	require_True(t, len(sB.routes) == 1)
+	require_True(t, len(m2.Subscriptions) == 1)
+	for _, v := range m2.Subscriptions {
+		require_Equal(t, v.SubClient.Kind, "Client")
+		accCnt[v.Acc]++
+	}
+
+	// make suer we only get two
+	msg3, err := subTrc1.NextMsg(time.Second / 4)
+	require_NoError(t, err)
+	si3, m3 := getOkTraceBody(t, msg3)
+	require_Equal(t, si3.Name, "srv-B")
+	_, ok = sB.routes[m3.Client.ClientId]
+	require_True(t, ok)
+	require_True(t, len(sB.routes) == 1)
+	require_True(t, len(m3.Subscriptions) == 1)
+	for _, v := range m3.Subscriptions {
+		require_Equal(t, v.SubClient.Kind, "Client")
+		require_Equal(t, v.Sub, "*")
+		accCnt[v.Acc]++
+	}
+
+	// Ensure that there was a subscribing client from each account
+	require_True(t, len(accCnt) == 2)
+	for _, v := range accCnt {
+		require_True(t, v == 1)
+	}
+
+	// make suer we only get three
+	_, err = subTrc1.NextMsg(time.Second / 4)
+	require_True(t, err == nats.ErrTimeout)
+}
+
+func TestMessageTraceAccountHeaderLeafStream(t *testing.T) {
+	// This test is a bit more complex as messages are sent back (after import in B)
+	confA := createConfFile(t, []byte(`
+		listen: -1
+		system_account: SYS
+		server_name: srv-A
+		accounts: {
+			SYS: {users: [ {user: sys, password: sys}]}
+			EXP1: {
+				users: [ {user: exp, password: exp}]
+				exports: [{stream: foo}]
+				ping_probes: enabled
+			}
+			IMP1: {
+				users: [ {user: imp1, password: imp1}]
+				imports: [{stream: {account: EXP1, subject: foo}}]
+			}
+		}
+		no_auth_user: exp
+		leafnodes: {
+			listen: localhost:-1
+		}
+    `))
+	defer removeFile(t, confA)
+	sA, _ := RunServerWithConfig(confA)
+	defer sA.Shutdown()
+
+	confB := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: -1
+		system_account: SYS
+		server_name: srv-B
+		accounts: {
+			SYS: {users: [ {user: sys, password: sys}]}
+			EXP2: {
+				users: [ {user: exp, password: exp}]
+				exports: [{stream: foo}]
+				ping_probes: enabled
+			}
+			IMP2: {
+				users: [ {user: imp1, password: imp1}]
+				imports: [{stream: {account: EXP2, subject: foo} }]
+			}
+		}
+		no_auth_user: exp
+		leafnodes: {
+			remotes:[{ url:nats://exp:exp@localhost:%d, account: EXP2},
+					 { url:nats://sys:sys@localhost:%d, account: SYS}]
+		}
+    `, sA.opts.LeafNode.Port, sA.opts.LeafNode.Port)))
+	defer removeFile(t, confB)
+	sB, _ := RunServerWithConfig(confB)
+	defer sB.Shutdown()
+	checkLeafNodeConnectedCount(t, sB, 2)
+	checkLeafNodeConnectedCount(t, sA, 2)
+
+	ncTrc := natsConnect(t, sA.ClientURL())
+	defer ncTrc.Close()
+	ib := nats.NewInbox()
+	subTrc, err := ncTrc.SubscribeSync(ib)
+	require_NoError(t, err)
+	require_NoError(t, ncTrc.Flush())
+
+	var subs []*nats.Subscription
+	for _, s := range []*Server{sA, sB} {
+		ncBExp := natsConnect(t, s.ClientURL(), nats.UserInfo("exp", "exp"))
+		defer ncBExp.Close()
+		subExp1, err := ncBExp.SubscribeSync("*")
+		require_NoError(t, err)
+		require_NoError(t, ncBExp.Flush())
+
+		ncBImp1 := natsConnect(t, s.ClientURL(), nats.UserInfo("imp1", "imp1"))
+		defer ncBImp1.Close()
+		subImp1, err := ncBImp1.SubscribeSync("*")
+		require_NoError(t, err)
+		require_NoError(t, ncBImp1.Flush())
+
+		// Put in subImp* subscription twice, as messages are duplicated due to
+		// EXP being in a remote and importing being processed twice
+		subs = append(subs, subExp1, subImp1)
+	}
+
+	ncA := natsConnect(t, sA.ClientURL())
+	defer ncA.Close()
+	require_NoError(t, ncA.PublishMsg(&nats.Msg{
+		Subject: "foo",
+		Reply:   ib,
+		Header: nats.Header{
+			TracePing: []string{""},
+		}}))
+	require_NoError(t, ncA.Flush())
+
+	// ensure the message is not received
+	for _, sub := range subs {
+		_, err := sub.NextMsg(time.Second / 4)
+		require_True(t, err == nats.ErrTimeout)
+	}
+
+	// test both responses
+	msgRef := _EMPTY_
+	msg1, err := subTrc.NextMsg(time.Second)
+	require_NoError(t, err)
+	si1, m1 := getOkTraceBody(t, msg1)
+	require_Equal(t, si1.Name, "srv-A")
+	require_Equal(t, m1.Acc, "EXP1")
+	require_Equal(t, m1.Client.Kind, "Client")
+	require_True(t, len(m1.Subscriptions) == 3)
+	for _, s := range m1.Subscriptions {
+		switch s.Acc {
+		case "IMP1":
+			require_Equal(t, s.NoSendReason, "trace Message is not delivered to foreign account")
+		case "EXP1":
+			if s.SubClient.Kind == "Leafnode" {
+				msgRef = s.Ref
+				require_Equal(t, s.NoSendReason, "")
+			} else {
+				require_Equal(t, s.NoSendReason, "trace Message is not delivered to Clients")
+			}
+		default:
+			require_True(t, false)
+		}
+	}
+	msg2, err := subTrc.NextMsg(time.Second)
+	require_NoError(t, err)
+	si2, m2 := getOkTraceBody(t, msg2)
+	require_Equal(t, si2.Name, "srv-B")
+	require_Equal(t, m2.Acc, "EXP2")
+	require_Equal(t, m2.Client.Kind, "Leafnode")
+	require_Equal(t, m2.Client.ServerId, sA.ID())
+	require_Equal(t, m2.MsgRef, msgRef)
+	require_True(t, len(m2.Subscriptions) == 2)
+	for _, s := range m2.Subscriptions {
+		switch s.Acc {
+		case "IMP2":
+			require_Equal(t, s.NoSendReason, "trace Message is not delivered to foreign account")
+		case "EXP2":
+			require_Equal(t, s.NoSendReason, "trace Message is not delivered to Clients")
+		default:
+			require_True(t, false)
+		}
+	}
+	// make suer we only get two
+	_, err = subTrc.NextMsg(time.Second / 4)
+	require_True(t, err == nats.ErrTimeout)
+}
+
+func TestMessageTraceAccountJSCluster(t *testing.T) {
+	rtUrlFmt := "nats-route://127.0.0.1:%d, nats-route://127.0.0.1:%d"
+	srv := []*Server{}
+	for _, v := range []struct {
+		name  string
+		rport int
+		rUrls string
+	}{{"srv-A", 7222, fmt.Sprintf(rtUrlFmt, 7223, 7224)},
+		{"srv-B", 7223, fmt.Sprintf(rtUrlFmt, 7222, 7224)},
+		{"srv-C", 7224, fmt.Sprintf(rtUrlFmt, 7222, 7223)}} {
+		storeDir := createDir(t, JetStreamStoreDir)
+		conf := createConfFile(t, []byte(fmt.Sprintf(`
+			listen: -1
+			system_account: SYS
+			server_name: %s
+			jetstream: { max_mem_store: 10Mb, max_file_store: 10Mb, store_dir: %s }
+			accounts: {
+				SYS: { users: [ {user: sys, password: sys}]}
+				ACC: {
+					users: [ {user: acc, password: acc}]
+					jetstream: enabled
+					msg_trace: { all: {Subject: foo } }
+				}
+			}
+			no_auth_user = acc
+			cluster: { name: cluster, listen: 127.0.0.1:%d, routes = [%s]}
+		`, v.name, storeDir, v.rport, v.rUrls)))
+		defer removeFile(t, conf)
+		s, _ := RunServerWithConfig(conf)
+		defer s.Shutdown()
+		srv = append(srv, s)
+	}
+	checkClusterFormed(t, srv...)
+	checkForJSClusterUp(t, srv...)
+
+	trcCon := natsConnect(t, srv[0].ClientURL())
+	trcSub, err := trcCon.SubscribeSync(fmt.Sprintf(accTrcEvent, "ACC", "all"))
+	require_NoError(t, err)
+
+	js, err := trcCon.JetStream()
+	require_NoError(t, err)
+
+	_, err = js.AddStream(&nats.StreamConfig{Name: "STREAM", Subjects: []string{"foo"}, Replicas: 3})
+	require_NoError(t, err)
+	defer js.DeleteStream("S2")
+	_, err = js.AddConsumer("STREAM", &nats.ConsumerConfig{Durable: "DURABLE", DeliverSubject: "deliver"})
+	require_NoError(t, err)
+
+	var nonLdrSrv *Server
+	for _, v := range srv {
+		if v.JetStreamIsStreamLeader("ACC", "STREAM") ||
+			v.JetStreamIsConsumerLeader("ACC", "STREAM", "DURABLE") {
+			continue
+		}
+		nonLdrSrv = v
+		break
+	}
+
+	testCon := natsConnect(t, nonLdrSrv.ClientURL())
+	defer testCon.Close()
+	require_NoError(t, testCon.Publish("foo", nil))
+
+	msgs := map[string][]*TraceMsg{}
+	for i := 0; i < 5; i++ {
+		msg1, err := trcSub.NextMsg(time.Second)
+		require_NoError(t, err)
+		_, m := getOkTraceBody(t, msg1)
+		msgs[m.MsgRef] = append(msgs[m.MsgRef], m)
+	}
+	_, err = trcSub.NextMsg(time.Second)
+	require_True(t, err == nats.ErrTimeout)
+
+	js, err = testCon.JetStream()
+	require_NoError(t, err)
+	sub, err := js.SubscribeSync("foo", nats.Durable("DURABLE"))
+	require_NoError(t, err)
+	_, err = sub.NextMsg(time.Second)
+	require_NoError(t, err)
+
+	for i := 0; i < 2; i++ {
+		msg1, err := trcSub.NextMsg(time.Second)
+		require_NoError(t, err)
+		_, m := getOkTraceBody(t, msg1)
+		msgs[m.MsgRef] = append(msgs[m.MsgRef], m)
+	}
+	_, err = trcSub.NextMsg(time.Second)
+	require_True(t, err == nats.ErrTimeout)
+
+	require_True(t, len(msgs[""]) == 1)
+	m1 := msgs[""][0]
+	require_Equal(t, m1.Client.Kind, "Client")
+	require_Equal(t, m1.Subscriptions[0].SubClient.Kind, "Router")
+	require_True(t, len(msgs[m1.Subscriptions[0].Ref]) == 1)
+	m2 := msgs[m1.Subscriptions[0].Ref][0]
+	require_Equal(t, m2.Client.Kind, "Router")
+	require_Equal(t, m2.Subscriptions[0].SubClient.Kind, "JetStream")
+	require_True(t, len(msgs[m2.Subscriptions[0].Ref]) == 3)
+	// check stream
+	storeCnt := 0
+	var m3 *TraceMsg
+	for _, m := range msgs[m2.Subscriptions[0].Ref] {
+		require_Equal(t, m.Client.Kind, "JetStream")
+		require_Equal(t, m.Stores[0].StreamRef, "STREAM")
+		if m.Stores[0].DidStore {
+			storeCnt++
+		}
+		if m, ok := msgs[m.Stores[0].Ref]; ok {
+			m3 = m[0]
+		}
+	}
+	require_True(t, storeCnt == 3)
+	// check stream/consumer
+	require_Equal(t, m3.Subscriptions[0].SubClient.Kind, "Router")
+	require_True(t, len(msgs[m3.Subscriptions[0].Ref]) == 1)
+	require_Equal(t, m3.StreamRef, "STREAM")
+	require_Equal(t, m3.ConsumerRef, "DURABLE")
+
+	m4 := msgs[m3.Subscriptions[0].Ref][0]
+	require_Equal(t, m4.Client.Kind, "Router")
+	require_Equal(t, m4.Subscriptions[0].SubClient.Kind, "Client")
+
+	require_True(t, m1.Client.ClientId == m4.Subscriptions[0].SubClient.ClientId)
+}
+
+func TestMessageTraceAccountJSMirror(t *testing.T) {
+	rtUrlFmt := "nats-route://127.0.0.1:%d, nats-route://127.0.0.1:%d"
+	srv := []*Server{}
+	for _, v := range []struct {
+		name  string
+		rport int
+		rUrls string
+	}{{"srv-A", 7222, fmt.Sprintf(rtUrlFmt, 7223, 7224)},
+		{"srv-B", 7223, fmt.Sprintf(rtUrlFmt, 7222, 7224)},
+		{"srv-C", 7224, fmt.Sprintf(rtUrlFmt, 7222, 7223)}} {
+		storeDir := createDir(t, JetStreamStoreDir)
+		conf := createConfFile(t, []byte(fmt.Sprintf(`
+			listen: -1
+			system_account: SYS
+			server_name: %s
+			jetstream: { max_mem_store: 10Mb, max_file_store: 10Mb, store_dir: %s }
+			accounts: {
+				SYS: { users: [ {user: sys, password: sys}]}
+				ACC: {
+					users: [ {user: acc, password: acc}]
+					jetstream: enabled
+					msg_trace: { all: {Subject: foo } }
+				}
+			}
+			no_auth_user = acc
+			cluster: { name: cluster, listen: 127.0.0.1:%d, routes = [%s]}
+		`, v.name, storeDir, v.rport, v.rUrls)))
+		defer removeFile(t, conf)
+		s, _ := RunServerWithConfig(conf)
+		defer s.Shutdown()
+		srv = append(srv, s)
+	}
+	checkClusterFormed(t, srv...)
+	checkForJSClusterUp(t, srv...)
+
+	trcCon := natsConnect(t, srv[0].ClientURL())
+	trcSub, err := trcCon.SubscribeSync(fmt.Sprintf(accTrcEvent, "ACC", "all"))
+	require_NoError(t, err)
+
+	for _, s := range srv {
+		checkSubInterest(t, s, "ACC", fmt.Sprintf(accTrcEvent, "ACC", "all"), time.Second)
+	}
+
+	js, err := trcCon.JetStream()
+	require_NoError(t, err)
+
+	_, err = js.AddStream(&nats.StreamConfig{Name: "STREAM", Subjects: []string{"foo"}, Replicas: 1})
+	require_NoError(t, err)
+	_, err = js.AddStream(&nats.StreamConfig{Name: "MIRROR", Mirror: &nats.StreamSource{Name: "STREAM"}, Replicas: 1})
+	require_NoError(t, err)
+	_, err = js.AddStream(&nats.StreamConfig{Name: "SOURCE", Sources: []*nats.StreamSource{{Name: "MIRROR"}}, Replicas: 1})
+	require_NoError(t, err)
+
+	var ldrSrv *Server
+	for _, v := range srv {
+		if v.JetStreamIsStreamLeader("ACC", "STREAM") {
+			ldrSrv = v
+			break
+		}
+	}
+
+	require_NoError(t, trcCon.Flush())
+
+	testCon := natsConnect(t, ldrSrv.ClientURL(), nats.Name("TESTNAME"))
+	defer testCon.Close()
+	testCon.SubscribeSync("foo")
+	require_NoError(t, testCon.Flush())
+	require_NoError(t, testCon.Publish("foo", nil))
+
+	// Because this is a cluster, streams may be located on the same server or not.
+	// This is why no explicit message count is coded.
+	msgs := map[string]*TraceMsg{}
+	for i := 0; i < 7; i++ {
+		msg1, err := trcSub.NextMsg(time.Second)
+		if err == nats.ErrTimeout {
+			break
+		}
+		_, m := getOkTraceBody(t, msg1)
+		msgs[m.MsgRef] = m
+	}
+	consumers := 0
+	streams := map[string]struct{}{}
+	for _, v := range msgs {
+		if len(v.Stores) == 1 && v.Stores[0].DidStore {
+			streams[v.Stores[0].StreamRef] = struct{}{}
+		} else if v.ConsumerRef != _EMPTY_ {
+			consumers++
+		}
+	}
+	require_True(t, len(streams) == 3)
+	require_True(t, consumers == 2)
+}

--- a/server/trace_test.go
+++ b/server/trace_test.go
@@ -80,7 +80,7 @@ func TestMessageTraceOperatorSimpleServer(t *testing.T) {
 		system_account: SYS
 		server_name: srv-A
 		jetstream: {max_mem_store: 10Mb, max_file_store: 10Mb, store_dir: %s }
-		msg_trace: {
+		operator_msg_trace: {
 			trace_particular_subject_always: {Subject: always, Probes: [connz, accountz, varz] }
 		}
 		accounts: {
@@ -917,7 +917,7 @@ func TestMessageTraceOperatorTrcSubjectOverwrite(t *testing.T) {
 		listen: -1
 		system_account: SYS
 		server_name: srv-A
-		msg_trace: {
+		operator_msg_trace: {
 			trace_name: {Subject: foo, trace_subject "send.trace.here"}
 		}
 		accounts: {
@@ -966,7 +966,7 @@ func TestMessageTraceFreq(t *testing.T) {
 		listen: -1
 		system_account: SYS
 		server_name: srv-A
-		msg_trace: {
+		operator_msg_trace: {
 			trace_most_the_time: {Freq: 0.8}
 		}
 		accounts: {
@@ -1142,7 +1142,7 @@ func TestMessageTraceOperatorCrossServer(t *testing.T) {
 			listen: -1
 			system_account: SYS
 			server_name: srv-A
-			msg_trace: {
+			operator_msg_trace: {
 				trc1: {Subject: foo}
 			}
 			accounts: {
@@ -1180,7 +1180,7 @@ func TestMessageTraceOperatorCrossServer(t *testing.T) {
 				remotes:[{ url:nats://acc:acc@localhost:%d, account: ACC1},
 						 { url:nats://sys:sys@localhost:%d, account: SYS}]
 			}
-			msg_trace: {
+			operator_msg_trace: {
 				trc1: {Subject: foo}
 				trc2: {Subject: foo}
 			}
@@ -1214,7 +1214,7 @@ func TestMessageTraceOperatorCrossServer(t *testing.T) {
 					nats-route://127.0.0.1:%d
 				]
 			}
-			msg_trace: {
+			operator_msg_trace: {
 				trc2: {Subject: foo}
 			}
 		`, srvBTmpl, sA.opts.Cluster.Port)))
@@ -1246,7 +1246,7 @@ func TestMessageTraceOperatorCrossServer(t *testing.T) {
 					{name: "GA", url: "nats://127.0.0.1:%d"},
 				]
 			}
-			msg_trace: {
+			operator_msg_trace: {
 				trc2: {Subject: foo}
 			}
 		`, srvBTmpl, sA.opts.Gateway.Port)))
@@ -1443,7 +1443,7 @@ func TestMessageTraceOperatorClusterStream(t *testing.T) {
 		listen: -1
 		system_account: SYS
 		server_name: srv-A
-		msg_trace: {
+		operator_msg_trace: {
 			trc1: {Subject: foo}
 		}
 		accounts: {
@@ -1608,7 +1608,7 @@ func TestMessageTraceOperatorLeafStream(t *testing.T) {
 		listen: -1
 		system_account: SYS
 		server_name: srv-A
-		msg_trace: {
+		operator_msg_trace: {
 			trc1: {Subject: foo}
 		}
 		accounts: {
@@ -1639,7 +1639,7 @@ func TestMessageTraceOperatorLeafStream(t *testing.T) {
 		listen: -1
 		system_account: SYS
 		server_name: srv-B
-		msg_trace: {
+		operator_msg_trace: {
 			trc1: {Subject: foo}
 		}
 		accounts: {
@@ -1806,7 +1806,7 @@ func TestMessageTraceOperatorClusterService(t *testing.T) {
 		listen: -1
 		system_account: SYS
 		server_name: srv-A
-		msg_trace: {
+		operator_msg_trace: {
 			trc1: {Subject: foo}
 		}
 		accounts: {
@@ -1834,7 +1834,7 @@ func TestMessageTraceOperatorClusterService(t *testing.T) {
 		listen: -1
 		system_account: SYS
 		server_name: srv-B
-		msg_trace: {
+		operator_msg_trace: {
 			trc1: {Subject: foo, Probes: accountz}
 		}
 		accounts: {

--- a/server/trace_test.go
+++ b/server/trace_test.go
@@ -1166,7 +1166,7 @@ func TestMessageTraceOperatorCrossServer(t *testing.T) {
 		confA := createConfFile(t, []byte(fmt.Sprintf(`
 			%s
 			leafnodes: {
-				listen: localhost:-1
+				listen: 127.0.0.1:-1
 			}
 		`, srvATmpl)))
 		defer removeFile(t, confA)
@@ -1177,8 +1177,8 @@ func TestMessageTraceOperatorCrossServer(t *testing.T) {
 		confB := createConfFile(t, []byte(fmt.Sprintf(`
 			%s
 			leafnodes: {
-				remotes:[{ url:nats://acc:acc@localhost:%d, account: ACC1},
-						 { url:nats://sys:sys@localhost:%d, account: SYS}]
+				remotes:[{ url:nats://acc:acc@127.0.0.1:%d, account: ACC1},
+						 { url:nats://sys:sys@127.0.0.1:%d, account: SYS}]
 			}
 			operator_msg_trace: {
 				trc1: {Subject: foo}
@@ -1198,7 +1198,7 @@ func TestMessageTraceOperatorCrossServer(t *testing.T) {
 			%s
 			cluster: {
 				name: C1
-				listen: localhost:-1
+				listen: 127.0.0.1:-1
 			}
 		`, srvATmpl)))
 		defer removeFile(t, confA)
@@ -1209,7 +1209,7 @@ func TestMessageTraceOperatorCrossServer(t *testing.T) {
 			%s
 			cluster: {
 				name: C1
-				listen: localhost:-1
+				listen: 127.0.0.1:-1
 				routes = [
 					nats-route://127.0.0.1:%d
 				]
@@ -1230,7 +1230,7 @@ func TestMessageTraceOperatorCrossServer(t *testing.T) {
 			%s
 			gateway: {
 				name: GA
-				listen: localhost:-1
+				listen: 127.0.0.1:-1
 			}
 		`, srvATmpl)))
 		defer removeFile(t, confA)
@@ -1241,7 +1241,7 @@ func TestMessageTraceOperatorCrossServer(t *testing.T) {
 			%s
 			gateway: {
 				name: GB
-				listen: localhost:-1
+				listen: 127.0.0.1:-1
 				gateways: [
 					{name: "GA", url: "nats://127.0.0.1:%d"},
 				]
@@ -1355,7 +1355,7 @@ func TestMessageTraceSubjectAccountCrossServer(t *testing.T) {
 		confA := createConfFile(t, []byte(fmt.Sprintf(`
 			%s
 			leafnodes: {
-				listen: localhost:-1
+				listen: 127.0.0.1:-1
 			}
 		`, srvATmpl)))
 		defer removeFile(t, confA)
@@ -1366,8 +1366,8 @@ func TestMessageTraceSubjectAccountCrossServer(t *testing.T) {
 		confB := createConfFile(t, []byte(fmt.Sprintf(`
 			%s
 			leafnodes: {
-				remotes:[{ url:nats://acc:acc@localhost:%d, account: ACC1},
-						 { url:nats://sys:sys@localhost:%d, account: SYS}]
+				remotes:[{ url:nats://acc:acc@127.0.0.1:%d, account: ACC1},
+						 { url:nats://sys:sys@127.0.0.1:%d, account: SYS}]
 			}
 		`, srvBTmpl, sA.opts.LeafNode.Port, sA.opts.LeafNode.Port)))
 		defer removeFile(t, confB)
@@ -1383,7 +1383,7 @@ func TestMessageTraceSubjectAccountCrossServer(t *testing.T) {
 			%s
 			cluster: {
 				name: C1
-				listen: localhost:-1
+				listen: 127.0.0.1:-1
 			}
 		`, srvATmpl)))
 		defer removeFile(t, confA)
@@ -1394,7 +1394,7 @@ func TestMessageTraceSubjectAccountCrossServer(t *testing.T) {
 			%s
 			cluster: {
 				name: C1
-				listen: localhost:-1
+				listen: 127.0.0.1:-1
 				routes = [
 					nats-route://127.0.0.1:%d
 				]
@@ -1412,7 +1412,7 @@ func TestMessageTraceSubjectAccountCrossServer(t *testing.T) {
 			%s
 			gateway: {
 				name: GA
-				listen: localhost:-1
+				listen: 127.0.0.1:-1
 			}
 		`, srvATmpl)))
 		defer removeFile(t, confA)
@@ -1423,7 +1423,7 @@ func TestMessageTraceSubjectAccountCrossServer(t *testing.T) {
 			%s
 			gateway: {
 				name: GB
-				listen: localhost:-1
+				listen: 127.0.0.1:-1
 				gateways: [
 					{name: "GA", url: "nats://127.0.0.1:%d"},
 				]
@@ -1464,7 +1464,7 @@ func TestMessageTraceOperatorClusterStream(t *testing.T) {
 		no_auth_user: exp
 		cluster: {
 			name: C1
-			listen: localhost:-1
+			listen: 127.0.0.1:-1
 		}
     `))
 	defer removeFile(t, confA)
@@ -1493,7 +1493,7 @@ func TestMessageTraceOperatorClusterStream(t *testing.T) {
 		no_auth_user: exp
 		cluster: {
 			name: C1
-			listen: localhost:-1
+			listen: 127.0.0.1:-1
 			routes = [
 				nats-route://127.0.0.1:%d
 			]
@@ -1628,7 +1628,7 @@ func TestMessageTraceOperatorLeafStream(t *testing.T) {
 		}
 		no_auth_user: exp
 		leafnodes: {
-			listen: localhost:-1
+			listen: 127.0.0.1:-1
 		}
     `))
 	defer removeFile(t, confA)
@@ -1659,10 +1659,10 @@ func TestMessageTraceOperatorLeafStream(t *testing.T) {
 		}
 		no_auth_user: exp
 		leafnodes: {
-			remotes:[{ url:nats://exp:exp@localhost:%d, account: EXP},
-					 { url:nats://sys:sys@localhost:%d, account: SYS},
-					 { url:nats://imp1:imp1@localhost:%d, account: IMP1},
-					 { url:nats://imp2:imp2@localhost:%d, account: IMP2}]
+			remotes:[{ url:nats://exp:exp@127.0.0.1:%d, account: EXP},
+					 { url:nats://sys:sys@127.0.0.1:%d, account: SYS},
+					 { url:nats://imp1:imp1@127.0.0.1:%d, account: IMP1},
+					 { url:nats://imp2:imp2@127.0.0.1:%d, account: IMP2}]
 		}
     `, sA.opts.LeafNode.Port, sA.opts.LeafNode.Port, sA.opts.LeafNode.Port, sA.opts.LeafNode.Port)))
 	defer removeFile(t, confB)
@@ -1823,7 +1823,7 @@ func TestMessageTraceOperatorClusterService(t *testing.T) {
 		no_auth_user: exp
 		cluster: {
 			name: C1
-			listen: localhost:-1
+			listen: 127.0.0.1:-1
 		}
     `))
 	defer removeFile(t, confA)
@@ -1851,7 +1851,7 @@ func TestMessageTraceOperatorClusterService(t *testing.T) {
 		no_auth_user: exp
 		cluster: {
 			name: C1
-			listen: localhost:-1
+			listen: 127.0.0.1:-1
 			routes = [
 				nats-route://127.0.0.1:%d
 			]
@@ -1983,7 +1983,7 @@ func TestMessageTraceAccountHeaderLeafStream(t *testing.T) {
 		}
 		no_auth_user: exp
 		leafnodes: {
-			listen: localhost:-1
+			listen: 127.0.0.1:-1
 		}
     `))
 	defer removeFile(t, confA)
@@ -2008,8 +2008,8 @@ func TestMessageTraceAccountHeaderLeafStream(t *testing.T) {
 		}
 		no_auth_user: exp
 		leafnodes: {
-			remotes:[{ url:nats://exp:exp@localhost:%d, account: EXP2},
-					 { url:nats://sys:sys@localhost:%d, account: SYS}]
+			remotes:[{ url:nats://exp:exp@127.0.0.1:%d, account: EXP2},
+					 { url:nats://sys:sys@127.0.0.1:%d, account: SYS}]
 		}
     `, sA.opts.LeafNode.Port, sA.opts.LeafNode.Port)))
 	defer removeFile(t, confB)


### PR DESCRIPTION
Adds msg_trace (trace rule name to trace) to operator and accounts.
    enables tracing for operator and accounts.
Adds ping_probes option (array of probe names) to accounts,
    enabling header based tracing.
Adds Nats-Ping header and ping_probes option (array of probe names) to
    accounts, enabling tracing by Nats-Ping header.

Nats-Ping header can be empty (default) or contain a list of probe names
When set, the message will not be handed to subscriber/jetstream/other
accounts.
Optionally the message body can contain a list of server ids to filter
responding servers on.

Still missing: handling responses, jwt integration & dynamic tracing
(settable via system account API). Settle on what to use as trigger.

This basically works by having a single trace context per receive loop.
With this context we call tracing functions for pub/sub/store.
After handling of an incoming message is done we call complete to send
traces.
