### PR TITLE
fix timer not being stopped prior to reset

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -3161,7 +3161,10 @@ func (s *Server) startGWReplyMapExpiration() {
 			case cttl := <-s.gwrm.ch:
 				ttl = cttl
 				if !t.Stop() {
-					<-t.C
+					select {
+					case <-t.C:
+					default:
+					}
 				}
 				t.Reset(ttl)
 			case <-s.quitCh:


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

Minor thing I noticed after having stared too long at profiles...
In this one case, as per go doc, the timer needs to be stopped.

from https://pkg.go.dev/time#Timer.Reset :
If a program has already received a value from t.C, the timer is known to have expired and the channel drained, so t.Reset can be used directly. If a program has not yet received a value from t.C, however, the timer must be stopped and—if Stop reports that the timer expired before being stopped—the channel explicitly drained:
```
if !t.Stop() {
	<-t.C
}
t.Reset(d)
```