### PR TITLE
[FIXED] #2642

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -3623,7 +3623,7 @@ func TestNoRaceJetStreamClusterStreamReset(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	// Do a hard reset here by hand.
-	mset.resetClusteredState()
+	mset.resetClusteredState(nil)
 
 	// Wait til we have the consumer leader re-elected.
 	c.waitOnConsumerLeader("$G", "TEST", "d1")

--- a/server/store.go
+++ b/server/store.go
@@ -439,3 +439,10 @@ func (p DeliverPolicy) MarshalJSON() ([]byte, error) {
 func isOutOfSpaceErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "no space left")
 }
+
+// For when our upper layer catchup detects its missing messages from the beginning of the stream.
+var errFirstSequenceMismatch = errors.New("first sequence mismatch")
+
+func isClusterResetErr(err error) bool {
+	return err == errLastSeqMismatch || err == ErrStoreEOF || err == errFirstSequenceMismatch
+}

--- a/server/stream.go
+++ b/server/stream.go
@@ -500,6 +500,13 @@ func (mset *stream) setStreamAssignment(sa *streamAssignment) {
 	}
 }
 
+// IsLeader will return if we are the current leader.
+func (mset *stream) IsLeader() bool {
+	mset.mu.Lock()
+	defer mset.mu.Unlock()
+	return mset.isLeader()
+}
+
 // Lock should be held.
 func (mset *stream) isLeader() bool {
 	if mset.isClustered() {


### PR DESCRIPTION
There was a bug that would erase the sync subject for upper level catchup for streams.
Raft layer repair was ok but if that was compacted it gets kicked up to the upper layers which would fail.
Users would see "Catchup stalled" messages repeatedly and consumers that had their leaders attached to that replica would also stop working.

Changes were put in to repair the corrupt state after the fact as well, regardless of presence of fix.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #2642 

/cc @nats-io/core
