### PR TITLE
[FIXED] Conditional failures for stream messages could cause stream resets #2666

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1752,7 +1752,11 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 
 				// Process the actual message here.
 				if err := mset.processJetStreamMsg(subject, reply, hdr, msg, lseq, ts); err != nil {
-					return err
+					// Only return in place if we are going to reset stream or we are out of space.
+					if isClusterResetErr(err) || isOutOfSpaceErr(err) {
+						return err
+					}
+					s.Debugf("Apply stream entries error processing message: %v", err)
 				}
 			case deleteMsgOp:
 				md, err := decodeMsgDelete(buf[1:])

--- a/server/raft.go
+++ b/server/raft.go
@@ -85,11 +85,6 @@ type WAL interface {
 	Delete() error
 }
 
-type LeadChange struct {
-	Leader   bool
-	Previous string
-}
-
 type Peer struct {
 	ID      string
 	Current bool


### PR DESCRIPTION
When encountering errors for sequence mismatches that were benign we were returning an error and not processing the rest of the entries. This would lead to more severe sequence mismatches later on that would cause stream resets.

Also added code to deal with server restarts and the internal clfs fixup states which should have been reset properly.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #2666 

/cc @nats-io/core
