### PR TITLE
Allow system account to respond with jetstream not enabled.

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -270,7 +270,8 @@ type ApiResponse struct {
 	Error *ApiError `json:"error,omitempty"`
 }
 
-// ToError checks if the response has a error and if it does converts it to an error avoiding the pitfalls described by https://yourbasic.org/golang/gotcha-why-nil-error-not-equal-nil/
+// ToError checks if the response has a error and if it does converts it to an error avoiding
+// the pitfalls described by https://yourbasic.org/golang/gotcha-why-nil-error-not-equal-nil/
 func (r *ApiResponse) ToError() error {
 	if r.Error == nil {
 		return nil
@@ -607,13 +608,17 @@ const defaultMaxJSApiOut = int64(4096)
 var maxJSApiOut = defaultMaxJSApiOut
 
 func (js *jetStream) apiDispatch(sub *subscription, c *client, acc *Account, subject, reply string, rmsg []byte) {
-	hdr, _ := c.msgParts(rmsg)
-	if len(getHeader(ClientInfoHdr, hdr)) == 0 {
-		return
-	}
 	js.mu.RLock()
 	s, rr := js.srv, js.apiSubs.Match(subject)
 	js.mu.RUnlock()
+
+	hdr, _ := c.msgParts(rmsg)
+	if len(getHeader(ClientInfoHdr, hdr)) == 0 {
+		// Check of this is the system account. We will let these through.
+		if s.SystemAccount() != acc {
+			return
+		}
+	}
 
 	// Shortcircuit.
 	if len(rr.psubs)+len(rr.qsubs) == 0 {

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -9427,6 +9427,19 @@ func TestJetStreamClusterKVMultipleConcurrentCreate(t *testing.T) {
 	time.Sleep(time.Second)
 }
 
+func TestJetStreamClusterAccountInfoForSystemAccount(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	// Client based API
+	nc, js := jsClientConnect(t, c.randomServer(), nats.UserInfo("admin", "s3cr3t!"))
+	defer nc.Close()
+
+	if _, err := js.AccountInfo(); err != nats.ErrJetStreamNotEnabled {
+		t.Fatalf("Expected a not enabled error for system account, got %v", err)
+	}
+}
+
 // Support functions
 
 // Used to setup superclusters for tests.


### PR DESCRIPTION
Makes interactions with nats cli a bit better.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
