### PR TITLE
fixed unit test where after a server shutdown no quorum existed

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -9249,6 +9249,8 @@ func TestJetStreamClusterStreamUpdateSyncBug(t *testing.T) {
 	// Shutdown a server. The bug is that the update wiped the sync subject used to cacthup a stream that has the RAFT layer snapshotted.
 	nsl := c.randomNonStreamLeader("$G", "TEST")
 	nsl.Shutdown()
+	// make sure a leader exists
+	c.waitOnStreamLeader("$G", "TEST")
 
 	for i := 0; i < toSend*4; i++ {
 		if _, err := js.PublishAsync("foo", msg); err != nil {


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

Ran this test 80 times locally. passed every single time