### PR TITLE
Fix for latency tracking bug.

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1175,7 +1175,11 @@ func (m1 *ServiceLatency) NATSTotalTime() time.Duration {
 // m1 TotalLatency is correct, so use that.
 // Will use those to back into NATS latency.
 func (m1 *ServiceLatency) merge(m2 *ServiceLatency) {
-	m1.SystemLatency = m1.ServiceLatency - (m2.ServiceLatency + m2.Responder.RTT)
+	rtt := time.Duration(0)
+	if m2.Responder != nil {
+		rtt = m2.Responder.RTT
+	}
+	m1.SystemLatency = m1.ServiceLatency - (m2.ServiceLatency + rtt)
 	m1.ServiceLatency = m2.ServiceLatency
 	m1.Responder = m2.Responder
 	sanitizeLatencyMetric(m1)

--- a/server/client.go
+++ b/server/client.go
@@ -3843,7 +3843,7 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 	// Send tracking info here if we are tracking this response.
 	// This is always a response.
 	var didSendTL bool
-	if si.tracking {
+	if si.tracking && !si.didDeliver {
 		// Stamp that we attempted delivery.
 		si.didDeliver = true
 		didSendTL = acc.sendTrackingLatency(si, c)

--- a/server/const.go
+++ b/server/const.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.6.4"
+	VERSION = "2.6.5-beta"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/opts.go
+++ b/server/opts.go
@@ -1247,12 +1247,12 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 			o.Tags.Add(v...)
 		case []interface{}:
 			for _, t := range v {
-				if t, ok := t.(token); ok {
-					if t, ok := t.Value().(string); ok {
-						o.Tags.Add(t)
+				if token, ok := t.(token); ok {
+					if ts, ok := token.Value().(string); ok {
+						o.Tags.Add(ts)
 						continue
 					} else {
-						err = &configErr{tk, fmt.Sprintf("error parsing tags: unsupported type %T where string is expected", t)}
+						err = &configErr{tk, fmt.Sprintf("error parsing tags: unsupported type %T where string is expected", token)}
 					}
 				} else {
 					err = &configErr{tk, fmt.Sprintf("error parsing tags: unsupported type %T", t)}


### PR DESCRIPTION
The bug occurs when latency tracking is on, a requestor and responder are not connected to the same server, and the responder sends two responses for a single request.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
