### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
 - GO111MODULE=off
 go_import_path: github.com/nats-io/nats-server
 install:
-- GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@2021.1.2
-- GO111MODULE=on go get github.com/client9/misspell/cmd/misspell@v0.3.4
+- GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@latest
+- GO111MODULE=on go install github.com/client9/misspell/cmd/misspell@latest
 before_script:
 - GO_LIST=$(go list ./...)
 - go build

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ vm:
 
 language: go
 go:
+- 1.17.x
 - 1.16.x
-- 1.15.x
 addons:
   apt:
     packages:
@@ -17,11 +17,8 @@ env:
 - GO111MODULE=off
 go_import_path: github.com/nats-io/nats-server
 install:
-- go get github.com/nats-io/nats.go/
-- go get github.com/nats-io/nkeys
-- go get github.com/nats-io/jwt
-- go get -u honnef.co/go/tools/cmd/staticcheck
-- go get -u github.com/client9/misspell/cmd/misspell
+- GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@2021.1.2
+- GO111MODULE=on go get github.com/client9/misspell/cmd/misspell@v0.3.4
 before_script:
 - GO_LIST=$(go list ./...)
 - go build
@@ -33,10 +30,10 @@ script:
 - set -e
 - if [[ $TRAVIS_TAG ]]; then go test -v -run=TestVersionMatchesTag ./server; fi
 - if [[ ! $TRAVIS_TAG ]]; then go test -v -run=TestNoRace --failfast -p=1 -timeout 20m ./...; fi
-- if [[ ! $TRAVIS_TAG ]]; then if [[ "$TRAVIS_GO_VERSION" =~ 1.15 ]]; then ./scripts/cov.sh TRAVIS; else go test -v -race -p=1 --failfast -timeout 20m ./...; fi; fi
+- if [[ ! $TRAVIS_TAG ]]; then if [[ "$TRAVIS_GO_VERSION" =~ 1.16 ]]; then ./scripts/cov.sh TRAVIS; else go test -v -race -p=1 --failfast -timeout 20m ./...; fi; fi
 - set +e
 after_success:
-- if [[ ! $TRAVIS_TAG ]]; then if [[ "$TRAVIS_GO_VERSION" =~ 1.15 ]]; then $HOME/gopath/bin/goveralls -coverprofile=acc.out -service travis-ci; fi; fi
+- if [[ ! $TRAVIS_TAG ]]; then if [[ "$TRAVIS_GO_VERSION" =~ 1.16 ]]; then $HOME/gopath/bin/goveralls -coverprofile=acc.out -service travis-ci; fi; fi
 
 deploy:
   provider: script

--- a/conf/fuzz.go
+++ b/conf/fuzz.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build gofuzz
 // +build gofuzz
 
 package conf

--- a/logger/syslog.go
+++ b/logger/syslog.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package logger

--- a/logger/syslog_test.go
+++ b/logger/syslog_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package logger

--- a/logger/syslog_windows_test.go
+++ b/logger/syslog_windows_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package logger

--- a/server/disk_avail.go
+++ b/server/disk_avail.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
-// +build !openbsd
+//go:build !windows && !openbsd
+// +build !windows,!openbsd
 
 package server
 

--- a/server/disk_avail_openbsd.go
+++ b/server/disk_avail_openbsd.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build openbsd
 // +build openbsd
 
 package server

--- a/server/disk_avail_windows.go
+++ b/server/disk_avail_windows.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package server

--- a/server/fuzz.go
+++ b/server/fuzz.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build gofuzz
 // +build gofuzz
 
 package server

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !race
 // +build !race
 
 package server

--- a/server/pse/pse_freebsd.go
+++ b/server/pse/pse_freebsd.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !amd64
 // +build !amd64
 
 package pse

--- a/server/pse/pse_rumprun.go
+++ b/server/pse/pse_rumprun.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build rumprun
 // +build rumprun
 
 package pse

--- a/server/pse/pse_windows.go
+++ b/server/pse/pse_windows.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package pse

--- a/server/pse/pse_windows_test.go
+++ b/server/pse/pse_windows_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package pse

--- a/server/service.go
+++ b/server/service.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package server

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package server

--- a/server/signal.go
+++ b/server/signal.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package server

--- a/server/signal_test.go
+++ b/server/signal_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package server

--- a/server/sysmem/mem_bsd.go
+++ b/server/sysmem/mem_bsd.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build freebsd || openbsd || dragonfly || netbsd
 // +build freebsd openbsd dragonfly netbsd
 
 package sysmem

--- a/server/sysmem/mem_darwin.go
+++ b/server/sysmem/mem_darwin.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build darwin
 // +build darwin
 
 package sysmem

--- a/server/sysmem/mem_linux.go
+++ b/server/sysmem/mem_linux.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build linux
 // +build linux
 
 package sysmem

--- a/server/sysmem/mem_windows.go
+++ b/server/sysmem/mem_windows.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package sysmem

--- a/server/sysmem/sysctl.go
+++ b/server/sysmem/sysctl.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build darwin || freebsd || openbsd || dragonfly || netbsd
 // +build darwin freebsd openbsd dragonfly netbsd
 
 package sysmem

--- a/test/fanout_test.go
+++ b/test/fanout_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !race
 // +build !race
 
 package test

--- a/test/norace_test.go
+++ b/test/norace_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !race
 // +build !race
 
 package test


### PR DESCRIPTION
- Add Go 1.17
- Fix go fmt from Go 1.17 (build directives)
- Download version of misspell and staticcheck instead of doing
"go get" since current staticcheck would be broken without go.mod

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
