### PR TITLE
support always presenting a nonce to clients

### DIFF
--- a/server/nkey.go
+++ b/server/nkey.go
@@ -33,7 +33,7 @@ func (s *Server) NonceRequired() bool {
 // nonceRequired tells us if we should send a nonce.
 // Lock should be held on entry.
 func (s *Server) nonceRequired() bool {
-	return len(s.nkeys) > 0 || s.trustedKeys != nil
+	return s.opts.AlwaysEnableNonce || len(s.nkeys) > 0 || s.trustedKeys != nil
 }
 
 // Generate a nonce for INFO challenge.

--- a/server/opts.go
+++ b/server/opts.go
@@ -262,6 +262,11 @@ type Options struct {
 	AccountResolver          AccountResolver       `json:"-"`
 	AccountResolverTLSConfig *tls.Config           `json:"-"`
 
+	// AlwaysEnableNonce will always present a nonce to new connections
+	// typically used by custom Authentication implementations who embeds
+	// the server and so not presented as a configuration option
+	AlwaysEnableNonce bool
+
 	CustomClientAuthentication Authentication `json:"-"`
 	CustomRouterAuthentication Authentication `json:"-"`
 


### PR DESCRIPTION
The nonce feature is useful to custom authentication plugins
but at present there is no way to enable a nonce to be presented
other than by setting nkey accounts etc.

This enables the nonce to always be presented in those situations.
Since its primarily useful to embedded scenarios there is no corresponding
configuration file behavior for this flag.

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
