### PR TITLE
Bump tests code coverage timeout

### DIFF
--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -8,10 +8,10 @@ go get github.com/wadey/gocovmerge
 
 rm -rf ./cov
 mkdir cov
-go test -v -failfast -covermode=atomic -coverprofile=./cov/conf.out ./conf
-go test -v -failfast -covermode=atomic -coverprofile=./cov/log.out ./logger
-go test -v -failfast -covermode=atomic -coverprofile=./cov/server.out ./server
-go test -v -failfast -covermode=atomic -coverprofile=./cov/test.out -coverpkg=./server ./test
+go test -v -failfast -covermode=atomic -coverprofile=./cov/conf.out ./conf -timeout=20m
+go test -v -failfast -covermode=atomic -coverprofile=./cov/log.out ./logger -timeout=20m
+go test -v -failfast -covermode=atomic -coverprofile=./cov/server.out ./server -timeout=20m
+go test -v -failfast -covermode=atomic -coverprofile=./cov/test.out -coverpkg=./server ./test -timeout=20m
 gocovmerge ./cov/*.out > acc.out
 rm -rf ./cov
 


### PR DESCRIPTION
Default of 10 minute (per package) seem to no longer be enough,
so bumping to 20 minutes, as it is on non code coverage runs.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
