### PR TITLE
Remove TestNoRace tests from code coverage

### DIFF
--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -8,10 +8,10 @@ go get github.com/wadey/gocovmerge
 
 rm -rf ./cov
 mkdir cov
-go test -v -failfast -covermode=atomic -coverprofile=./cov/conf.out ./conf -timeout=20m
-go test -v -failfast -covermode=atomic -coverprofile=./cov/log.out ./logger -timeout=20m
-go test -v -failfast -covermode=atomic -coverprofile=./cov/server.out ./server -timeout=20m
-go test -v -failfast -covermode=atomic -coverprofile=./cov/test.out -coverpkg=./server ./test -timeout=20m
+go test -v -failfast -covermode=atomic -coverprofile=./cov/conf.out -run='Test[^NoRace]' ./conf -timeout=20m
+go test -v -failfast -covermode=atomic -coverprofile=./cov/log.out -run='Test[^NoRace]' ./logger -timeout=20m
+go test -v -failfast -covermode=atomic -coverprofile=./cov/server.out -run='Test[^NoRace]' ./server -timeout=20m
+go test -v -failfast -covermode=atomic -coverprofile=./cov/test.out -coverpkg=./server -run='Test[^NoRace]' ./test -timeout=20m
 gocovmerge ./cov/*.out > acc.out
 rm -rf ./cov
 


### PR DESCRIPTION
The "TestNoRace" can be very expensive memory/cpu wise.

When running test coverage, we do it with `-covermode=atomic` which is a bit similar to `-race` in that the runtime adds tracking that causes memory overhead. So we will remove those from code coverage.
It saves about 2min of running the code coverage tests by excluding those, but server package code coverage falls by a bit more than 1%.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
