### PR TITLE
[FIXED #2708] Removing a source depending on timing could cause a server panic.

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -1787,6 +1787,9 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64) {
 	si.sseq, si.dseq = seq, 0
 	si.last = time.Now()
 	ssi := mset.streamSource(iname)
+	if ssi == nil {
+		return
+	}
 
 	// Determine subjects etc.
 	var deliverSubject string


### PR DESCRIPTION
Tried to write several tests to re-create but believe this is very timing dependent. Based on excellent report I can track it down to the fix that is here, that one liner, but could not create a test to show behavior, but obvious that ssi was gone at that point and we did not check for nil.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #2708

/cc @nats-io/core
