### PR TITLE
[FIXED] Monitoring: tls configuration not updated on reload

### DIFF
--- a/server/events_test.go
+++ b/server/events_test.go
@@ -2257,7 +2257,7 @@ func TestServerEventsFilteredByTag(t *testing.T) {
 			listen: -1
 			no_advertise: true
 			routes [
-				nats-route://localhost:%d
+				nats-route://127.0.0.1:%d
 			]
 		}
 		system_account: SYS

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -8732,7 +8732,7 @@ func TestJetStreamClusterMirrorAndSourceCrossNonNeighboringDomain(t *testing.T) 
 		system_account = SYS
 		no_auth_user: a1
 		leafnodes: {
-			listen: localhost:-1
+			listen: 127.0.0.1:-1
 		}
 	`, storeDir1)))
 	s1, _ := RunServerWithConfig(conf1)
@@ -8748,8 +8748,8 @@ func TestJetStreamClusterMirrorAndSourceCrossNonNeighboringDomain(t *testing.T) 
 		system_account = SYS
 		no_auth_user: a1
 		leafnodes:{
-			remotes:[{ url:nats://a1:a1@localhost:%d, account: A},
-					 { url:nats://s1:s1@localhost:%d, account: SYS}]
+			remotes:[{ url:nats://a1:a1@127.0.0.1:%d, account: A},
+					 { url:nats://s1:s1@127.0.0.1:%d, account: SYS}]
 		}
 	`, storeDir2, s1.opts.LeafNode.Port, s1.opts.LeafNode.Port)))
 	s2, _ := RunServerWithConfig(conf2)
@@ -8765,8 +8765,8 @@ func TestJetStreamClusterMirrorAndSourceCrossNonNeighboringDomain(t *testing.T) 
 		system_account = SYS
 		no_auth_user: a1
 		leafnodes:{
-			remotes:[{ url:nats://a1:a1@localhost:%d, account: A},
-					 { url:nats://s1:s1@localhost:%d, account: SYS}]
+			remotes:[{ url:nats://a1:a1@127.0.0.1:%d, account: A},
+					 { url:nats://s1:s1@127.0.0.1:%d, account: SYS}]
 		}
 	`, storeDir3, s1.opts.LeafNode.Port, s1.opts.LeafNode.Port)))
 	s3, _ := RunServerWithConfig(conf3)

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -3911,9 +3911,9 @@ resolver_preload: {
   %s: %s
   %s: %s
 }
-listen: localhost:-1
+listen: 127.0.0.1:-1
 leafnodes: {
-	listen: localhost:-1
+	listen: 127.0.0.1:-1
 }
 jetstream :{
     domain: "cluster"
@@ -3924,7 +3924,7 @@ jetstream :{
 `
 
 	tmplL := `
-listen: localhost:-1
+listen: 127.0.0.1:-1
 accounts :{
     A:{   jetstream: enable, users:[ {user:a1,password:a1}]},
     SYS:{ users:[ {user:s1,password:s1}]},
@@ -3937,8 +3937,8 @@ jetstream: {
     max_file: 50Mb
 }
 leafnodes:{
-    remotes:[{ url:nats://localhost:%d, account: A, credentials: %s},
-			 { url:nats://localhost:%d, account: SYS, credentials: %s}]
+    remotes:[{ url:nats://127.0.0.1:%d, account: A, credentials: %s},
+			 { url:nats://127.0.0.1:%d, account: SYS, credentials: %s}]
 }
 `
 
@@ -3961,7 +3961,7 @@ leafnodes:{
 	ncA := natsConnect(t, sA.ClientURL(), nats.UserCredentials(unlimitedCreds))
 	defer ncA.Close()
 
-	ncL := natsConnect(t, fmt.Sprintf("nats://a1:a1@localhost:%d", sL.opts.Port))
+	ncL := natsConnect(t, fmt.Sprintf("nats://a1:a1@127.0.0.1:%d", sL.opts.Port))
 	defer ncL.Close()
 
 	test := func(subject string, cSub, cPub *nats.Conn, remoteServerForSub *Server, accName string, pass bool) {

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1112,7 +1112,7 @@ func (s *Server) startWebsocketServer() {
 		Addr:        hp,
 		Handler:     mux,
 		ReadTimeout: o.HandshakeTimeout,
-		ErrorLog:    log.New(&wsCaptureHTTPServerLog{s}, _EMPTY_, 0),
+		ErrorLog:    log.New(&captureHTTPServerLog{s, "websocket: "}, _EMPTY_, 0),
 	}
 	s.websocket.server = hs
 	s.websocket.listener = hl
@@ -1237,24 +1237,6 @@ func (s *Server) createWSClient(conn net.Conn, ws *websocket) *client {
 	c.mu.Unlock()
 
 	return c
-}
-
-type wsCaptureHTTPServerLog struct {
-	s *Server
-}
-
-func (cl *wsCaptureHTTPServerLog) Write(p []byte) (int, error) {
-	var buf [128]byte
-	var b = buf[:0]
-
-	copy(b, []byte("websocket :"))
-	offset := 0
-	if bytes.HasPrefix(p, []byte("http:")) {
-		offset = 6
-	}
-	b = append(b, p[offset:]...)
-	cl.s.Errorf(string(b))
-	return len(p), nil
 }
 
 func (c *client) wsCollapsePtoNB() (net.Buffers, int64) {

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -2366,6 +2366,10 @@ func TestWSHandshakeTimeout(t *testing.T) {
 	// Check that server logs error
 	select {
 	case e := <-logger.errCh:
+		// Check that log starts with "websocket: "
+		if !strings.HasPrefix(e, "websocket: ") {
+			t.Fatalf("Wrong log line start: %s", e)
+		}
 		if !strings.Contains(e, "timeout") {
 			t.Fatalf("Unexpected error: %v", e)
 		}


### PR DESCRIPTION
When creating the http server, we need to provide a TLS configuration.
After a config reload, the new TLS config would not be reflected.

We had the same issue with Websocket and was fixed with the use
of tls.Config.GetConfigForClient API, which makes the TLS handshake
to ask for a TLS config. That fix for websocket was simply not applied
to the HTTPs monitoring case.

I have also fixed some flappers due to the use of localhost instead
of 127.0.0.1 (connections possibly would resolve to some IPv6 address
that the server would not accept, etc..)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
