### PR TITLE
hitting an account limit left an outgoing leaf node conn in bad state

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2530,12 +2530,12 @@ func (s *Server) leafNodeFinishConnectProcess(c *client) {
 	if err := c.registerWithAccount(acc); err != nil {
 		c.Errorf("Registering leaf with account %s resulted in error: %v", acc.Name, err)
 		c.closeConnection(ProtocolViolation)
-	} else {
-		s.addLeafNodeConnection(c, _EMPTY_, _EMPTY_, false)
-		s.initLeafNodeSmapAndSendSubs(c)
-		if sendSysConnectEvent {
-			s.sendLeafNodeConnect(acc)
-		}
+		return
+	}
+	s.addLeafNodeConnection(c, _EMPTY_, _EMPTY_, false)
+	s.initLeafNodeSmapAndSendSubs(c)
+	if sendSysConnectEvent {
+		s.sendLeafNodeConnect(acc)
 	}
 
 	// The above functions are not atomically under the client

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2528,6 +2528,10 @@ func (s *Server) leafNodeFinishConnectProcess(c *client) {
 
 	// Make sure we register with the account here.
 	if err := c.registerWithAccount(acc); err != nil {
+		if err == ErrTooManyAccountConnections {
+			c.maxAccountConnExceeded()
+			return
+		}
 		c.Errorf("Registering leaf with account %s resulted in error: %v", acc.Name, err)
 		c.closeConnection(ProtocolViolation)
 		return

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2527,11 +2527,15 @@ func (s *Server) leafNodeFinishConnectProcess(c *client) {
 	c.mu.Unlock()
 
 	// Make sure we register with the account here.
-	c.registerWithAccount(acc)
-	s.addLeafNodeConnection(c, _EMPTY_, _EMPTY_, false)
-	s.initLeafNodeSmapAndSendSubs(c)
-	if sendSysConnectEvent {
-		s.sendLeafNodeConnect(acc)
+	if err := c.registerWithAccount(acc); err != nil {
+		c.Errorf("Registering leaf with account %s resulted in error: %v", acc.Name, err)
+		c.closeConnection(ProtocolViolation)
+	} else {
+		s.addLeafNodeConnection(c, _EMPTY_, _EMPTY_, false)
+		s.initLeafNodeSmapAndSendSubs(c)
+		if sendSysConnectEvent {
+			s.sendLeafNodeConnect(acc)
+		}
 	}
 
 	// The above functions are not atomically under the client


### PR DESCRIPTION
since no error was traced or the connection closed, subscriptions where
not forwarded

Signed-off-by: Matthias Hanel <mh@synadia.com>

What caused the error on my end was the local accounts leaf node count.
Apparently, the count applies to leaf node connections accepted as well as initiated/connected. (See in the traces below.)
My expectation was that it only applies to accepted connections.

```
[30765] 2021/11/30 15:55:56.958332 [WRN] ACHE74YJWQW3MGM6KGYU4I7R37FWPI2VHR2ZVZTDURHRCXZFDIZOS3CN MaxTotalLeafNodesReached true
goroutine 1431 [running]:
runtime/debug.Stack()
	/Users/matthiashanel/.gimme/versions/go1.17.darwin.amd64/src/runtime/debug/stack.go:24 +0x65
runtime/debug.PrintStack()
	/Users/matthiashanel/.gimme/versions/go1.17.darwin.amd64/src/runtime/debug/stack.go:16 +0x19
github.com/nats-io/nats-server/v2/server.(*Account).MaxTotalLeafNodesReached(0xc0001e6b40)
	/Users/matthiashanel/repos/nats-server/server/accounts.go:464 +0x15d
github.com/nats-io/nats-server/v2/server.(*client).registerWithAccount(0xc0002cb300, 0xc0001e6b40)
	/Users/matthiashanel/repos/nats-server/server/client.go:705 +0x155
github.com/nats-io/nats-server/v2/server.(*Server).leafNodeFinishConnectProcess(0xc000204000, 0xc0002cb300)
	/Users/matthiashanel/repos/nats-server/server/leafnode.go:2504 +0x185
github.com/nats-io/nats-server/v2/server.(*client).processLeafnodeInfo(0xc0002cb300, 0xc000770700)
	/Users/matthiashanel/repos/nats-server/server/leafnode.go:1036 +0x876
github.com/nats-io/nats-server/v2/server.(*client).processInfo(0xc0002cb300, {0xc000898805, 0x251, 0x3fb})
	/Users/matthiashanel/repos/nats-server/server/client.go:1626 +0x90
github.com/nats-io/nats-server/v2/server.(*client).parse(0xc0002cb300, {0xc000898800, 0x2f0, 0xc00000e5d0})
	/Users/matthiashanel/repos/nats-server/server/parser.go:1043 +0x3fb6
github.com/nats-io/nats-server/v2/server.(*client).readLoop(0xc0002cb300, {0x0, 0x0, 0x0})
	/Users/matthiashanel/repos/nats-server/server/client.go:1214 +0xe1f
github.com/nats-io/nats-server/v2/server.(*Server).createLeafNode.func1()
	/Users/matthiashanel/repos/nats-server/server/leafnode.go:905 +0x29
created by github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine
	/Users/matthiashanel/repos/nats-server/server/server.go:2888 +0x87
[30765] 2021/11/30 15:55:56.958467 [WRN] 3.17.227.219:7422 - lid:200 - Registering leaf with account ACHE74YJWQW3MGM6KGYU4I7R37FWPI2VHR2ZVZTDURHRCXZFDIZOS3CN resulted in error: maximum account active connections exceeded
[30765] 2021/11/30 15:55:56.958475 [INF] 3.17.227.219:7422 - lid:200 - Leafnode connection closed: Maximum Connections Exceeded account: ACHE74YJWQW3MGM6KGYU4I7R37FWPI2VHR2ZVZTDURHRCXZFDIZOS3CN/my-sys
```

traces with this fix
```
[32322] 2021/11/30 16:25:02.471460 [INF] 3.17.227.219:7422 - lid:5 - Leafnode connection created for account: AB2P6OLEGTQMDLH6QV4AVWN2GI6EUV5GJ2BMZEYG7I6D7GRJXGR7IGKR/my-acc
[32322] 2021/11/30 16:25:02.476933 [INF] 3.143.185.177:7422 - lid:6 - Leafnode connection created for account: ACHE74YJWQW3MGM6KGYU4I7R37FWPI2VHR2ZVZTDURHRCXZFDIZOS3CN/my-sys
[32322] 2021/11/30 16:25:02.726331 [ERR] 3.17.227.219:7422 - lid:5 - Registering leaf with account AB2P6OLEGTQMDLH6QV4AVWN2GI6EUV5GJ2BMZEYG7I6D7GRJXGR7IGKR resulted in error: maximum account active connections exceeded
[32322] 2021/11/30 16:25:02.726363 [INF] 3.17.227.219:7422 - lid:5 - Leafnode connection closed: Protocol Violation account: AB2P6OLEGTQMDLH6QV4AVWN2GI6EUV5GJ2BMZEYG7I6D7GRJXGR7IGKR/my-acc
[32322] 2021/11/30 16:25:02.728380 [ERR] 3.143.185.177:7422 - lid:6 - Registering leaf with account ACHE74YJWQW3MGM6KGYU4I7R37FWPI2VHR2ZVZTDURHRCXZFDIZOS3CN resulted in error: maximum account active connections exceeded
[32322] 2021/11/30 16:25:02.728400 [INF] 3.143.185.177:7422 - lid:6 - Leafnode connection closed: Protocol Violation account: ACHE74YJWQW3MGM6KGYU4I7R37FWPI2VHR2ZVZTDURHRCXZFDIZOS3CN/my-sys
[32322] 2021/11/30 16:25:03.769598 [INF] 3.17.227.219:7422 - lid:7 - Leafnode connection created for account: AB2P6OLEGTQMDLH6QV4AVWN2GI6EUV5GJ2BMZEYG7I6D7GRJXGR7IGKR/my-acc
[32322] 2021/11/30 16:25:03.775241 [INF] 3.17.227.219:7422 - lid:8 - Leafnode connection created for account: ACHE74YJWQW3MGM6KGYU4I7R37FWPI2VHR2ZVZTDURHRCXZFDIZOS3CN/my-sys
[32322] 2021/11/30 16:25:03.892418 [ERR] 3.17.227.219:7422 - lid:7 - Registering leaf with account AB2P6OLEGTQMDLH6QV4AVWN2GI6EUV5GJ2BMZEYG7I6D7GRJXGR7IGKR resulted in error: maximum account active connections exceeded
[32322] 2021/11/30 16:25:03.892459 [INF] 3.17.227.219:7422 - lid:7 - Leafnode connection closed: Protocol Violation account: AB2P6OLEGTQMDLH6QV4AVWN2GI6EUV5GJ2BMZEYG7I6D7GRJXGR7IGKR/my-acc
[32322] 2021/11/30 16:25:03.898442 [ERR] 3.17.227.219:7422 - lid:8 - Registering leaf with account ACHE74YJWQW3MGM6KGYU4I7R37FWPI2VHR2ZVZTDURHRCXZFDIZOS3CN resulted in error: maximum account active connections exceeded
[32322] 2021/11/30 16:25:03.898481 [INF] 3.17.227.219:7422 - lid:8 - Leafnode connection closed: Protocol Violation account: ACHE74YJWQW3MGM6KGYU4I7R37FWPI2VHR2ZVZTDURHRCXZFDIZOS3CN/my-sys
[32322] 2021/11/30 16:25:04.937837 [INF] 3.143.185.177:7422 - lid:9 - Leafnode connection created for account: AB2P6OLEGTQMDLH6QV4AVWN2GI6EUV5GJ2BMZEYG7I6D7GRJXGR7IGKR/my-acc
[32322] 2021/11/30 16:25:04.939560 [INF] 3.143.185.177:7422 - lid:10 - Leafnode connection created for account: ACHE74YJWQW3MGM6KGYU4I7R37FWPI2VHR2ZVZTDURHRCXZFDIZOS3CN/my-sys
```