### PR TITLE
There were situations where invalid subjects could be assigned to streams.

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1115,6 +1115,33 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 				s.Warnf("  Error adding stream %q to template %q: %v", cfg.Name, cfg.Template, err)
 			}
 		}
+
+		// We had a bug that could allow subjects in that had prefix or suffix spaces. We check for that here
+		// and will patch them on the fly for now. We will warn about them.
+		var hadSubjErr bool
+		for i, subj := range cfg.StreamConfig.Subjects {
+			if !IsValidSubject(subj) {
+				s.Warnf("  Detected bad subject %q while adding stream %q, will attempt to repair", subj, cfg.Name)
+				if nsubj := strings.TrimSpace(subj); IsValidSubject(nsubj) {
+					s.Warnf("  Bad subject %q repaired to %q", subj, nsubj)
+					cfg.StreamConfig.Subjects[i] = nsubj
+				} else {
+					s.Warnf("  Error recreating stream %q: %v", cfg.Name, "invalid subject")
+					hadSubjErr = true
+					break
+				}
+			}
+		}
+		if hadSubjErr {
+			continue
+		}
+
+		// The other possible bug is assigning subjects to mirrors, so check for that and patch as well.
+		if cfg.StreamConfig.Mirror != nil && len(cfg.StreamConfig.Subjects) > 0 {
+			cfg.StreamConfig.Subjects = nil
+		}
+
+		// Add in the stream.
 		mset, err := a.addStream(&cfg.StreamConfig)
 		if err != nil {
 			s.Warnf("  Error recreating stream %q: %v", cfg.Name, err)

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1138,6 +1138,7 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 
 		// The other possible bug is assigning subjects to mirrors, so check for that and patch as well.
 		if cfg.StreamConfig.Mirror != nil && len(cfg.StreamConfig.Subjects) > 0 {
+			s.Warnf("  Detected subjects on a mirrored stream %q, will remove", cfg.Name)
 			cfg.StreamConfig.Subjects = nil
 		}
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -886,11 +886,11 @@ func checkStreamCfg(config *StreamConfig) (StreamConfig, error) {
 			if subjectIsSubsetMatch(subj, "$JS.API.>") {
 				return StreamConfig{}, fmt.Errorf("subjects overlap with jetstream api")
 			}
-
+			// Make sure the subject is valid.
 			if !IsValidSubject(subj) {
 				return StreamConfig{}, fmt.Errorf("invalid subject")
 			}
-
+			// Mark for duplicate check.
 			dset[subj] = struct{}{}
 		}
 	}


### PR DESCRIPTION
This will patch them on the fly during recovery. Specifically subjects with leading or trailing spaces and mirror streams with any subjects at all.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
