### PR TITLE
[CHANGED] Profiler: Start profile_port earlier

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1541,6 +1541,11 @@ func (s *Server) Start() {
 	s.grRunning = true
 	s.grMu.Unlock()
 
+	// Pprof http endpoint for the profiler.
+	if opts.ProfPort != 0 {
+		s.StartProfiler()
+	}
+
 	if opts.ConfigFile != _EMPTY_ {
 		s.Noticef("Using configuration file: %s", opts.ConfigFile)
 	}
@@ -1738,11 +1743,6 @@ func (s *Server) Start() {
 		s.startGoRoutine(func() {
 			s.StartRouting(clientListenReady)
 		})
-	}
-
-	// Pprof http endpoint for the profiler.
-	if opts.ProfPort != 0 {
-		s.StartProfiler()
 	}
 
 	if opts.PortsFileDir != _EMPTY_ {


### PR DESCRIPTION
Enables use of pprof to investigate server startup.

Co-authored-by: Ivan Kozlovic <ivan@synadia.com>
Signed-off-by: Ben Werthmann <ben@synadia.com>

 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)


/cc @nats-io/core
