### PR TITLE
Set incomplete error when cluster list fails

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4127,6 +4127,7 @@ LOOP:
 			return
 		case <-notActive.C:
 			s.Warnf("Did not receive all consumer info results for %q", acc)
+			resp.Error = NewJSClusterIncompleteError()
 			break LOOP
 		case ci := <-rc:
 			resp.Consumers = append(resp.Consumers, ci)


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

This is what is done in `jsClusteredStreamListRequest` as well
