### PR TITLE
[IMPROVED] Websocket: added client IP from X-Forwarded-For header

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -610,7 +610,13 @@ func (c *client) initClient() {
 			if conn = addr.String(); conn != _EMPTY_ {
 				host, port, _ := net.SplitHostPort(conn)
 				iPort, _ := strconv.Atoi(port)
-				c.host, c.port = host, uint16(iPort)
+				c.port = uint16(iPort)
+				if c.isWebsocket() && c.ws.clientIP != _EMPTY_ {
+					c.host = c.ws.clientIP
+					conn = net.JoinHostPort(c.host, port)
+				} else {
+					c.host = host
+				}
 				// Now that we have extracted host and port, escape
 				// the string because it is going to be used in Sprintf
 				conn = strings.ReplaceAll(conn, "%", "%%")


### PR DESCRIPTION
This is for cases when there is a proxy (Nginx, HAProxy, etc..)
between the client and the NATS Server. If this header is present,
the first IP is the one of the originating client and will be
used as the host/IP in server's representation of the client host.

Resolves #2514

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
