### PR TITLE
Adding missing entry to stream/consumer list

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -363,6 +363,7 @@ type JSApiStreamListResponse struct {
 	ApiResponse
 	ApiPaged
 	Streams []*StreamInfo `json:"streams"`
+	Missing []string      `json:"missing_stream_names,omitempty"`
 }
 
 const JSApiStreamListResponseType = "io.nats.jetstream.api.v1.stream_list_response"
@@ -560,6 +561,7 @@ type JSApiConsumerListResponse struct {
 	ApiResponse
 	ApiPaged
 	Consumers []*ConsumerInfo `json:"consumers"`
+	Missing   []string        `json:"missing_consumer_names,omitempty"`
 }
 
 const JSApiConsumerListResponseType = "io.nats.jetstream.api.v1.consumer_list_response"

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -363,7 +363,7 @@ type JSApiStreamListResponse struct {
 	ApiResponse
 	ApiPaged
 	Streams []*StreamInfo `json:"streams"`
-	Missing []string      `json:"missing_stream_names,omitempty"`
+	Missing []string      `json:"missing,omitempty"`
 }
 
 const JSApiStreamListResponseType = "io.nats.jetstream.api.v1.stream_list_response"
@@ -561,7 +561,7 @@ type JSApiConsumerListResponse struct {
 	ApiResponse
 	ApiPaged
 	Consumers []*ConsumerInfo `json:"consumers"`
-	Missing   []string        `json:"missing_consumer_names,omitempty"`
+	Missing   []string        `json:"missing,omitempty"`
 }
 
 const JSApiConsumerListResponseType = "io.nats.jetstream.api.v1.consumer_list_response"


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

As per request from RI, removing the error we used to get.
Instead return no error but a list of missing items by name.

In below example, you see the missing entry at the end of the json file.
`"missing_consumer_names":["fail"]}`
`"missing_stream_names":["fail-me"]}`
`"missing_stream_names":["fail-me"]}`

```bash
 ~/test/list-issue  nats -s localhost:4222 c report drei --trace
18:34:32 >>> $JS.API.STREAM.INFO.drei


18:34:32 <<< $JS.API.STREAM.INFO.drei
{"type":"io.nats.jetstream.api.v1.stream_info_response","config":{"name":"drei","subjects":["drei"],"retention":"limits","max_consumers":-1,"max_msgs":-1,"max_bytes":-1,"max_age":0,"max_msgs_per_subject":-1,"max_msg_size":-1,"discard":"old","storage":"file","num_replicas":1,"duplicate_window":120000000000,"sealed":false,"deny_delete":false,"deny_purge":false,"allow_rollup_hdrs":false},"created":"2021-12-01T21:50:44.129716Z","state":{"messages":0,"bytes":0,"first_seq":1,"first_ts":"1970-01-01T00:00:00Z","last_seq":0,"last_ts":"0001-01-01T00:00:00Z","consumer_count":2},"domain":"hub","cluster":{"name":"hub","leader":"hub-server-1"}}

18:34:32 >>> $JS.API.STREAM.INFO.drei


18:34:32 <<< $JS.API.STREAM.INFO.drei
{"type":"io.nats.jetstream.api.v1.stream_info_response","config":{"name":"drei","subjects":["drei"],"retention":"limits","max_consumers":-1,"max_msgs":-1,"max_bytes":-1,"max_age":0,"max_msgs_per_subject":-1,"max_msg_size":-1,"discard":"old","storage":"file","num_replicas":1,"duplicate_window":120000000000,"sealed":false,"deny_delete":false,"deny_purge":false,"allow_rollup_hdrs":false},"created":"2021-12-01T21:50:44.129716Z","state":{"messages":0,"bytes":0,"first_seq":1,"first_ts":"1970-01-01T00:00:00Z","last_seq":0,"last_ts":"0001-01-01T00:00:00Z","consumer_count":2},"domain":"hub","cluster":{"name":"hub","leader":"hub-server-1"}}

18:34:32 >>> $JS.API.CONSUMER.LIST.drei
{"offset":0}

18:34:36 <<< $JS.API.CONSUMER.LIST.drei
{"type":"io.nats.jetstream.api.v1.consumer_list_response","total":1,"offset":0,"limit":256,"consumers":[{"stream_name":"drei","name":"dur","created":"2021-12-01T23:15:46.697564Z","config":{"durable_name":"dur","deliver_policy":"all","ack_policy":"explicit","ack_wait":30000000000,"max_deliver":-1,"replay_policy":"original","max_waiting":512,"max_ack_pending":20000},"delivered":{"consumer_seq":0,"stream_seq":0},"ack_floor":{"consumer_seq":0,"stream_seq":0},"num_ack_pending":0,"num_redelivered":0,"num_waiting":0,"num_pending":0,"cluster":{"name":"hub","leader":"hub-server-1"}}],"missing_consumer_names":["fail"]}

18:34:36 >>> $JS.API.CONSUMER.INFO.drei.dur


18:34:36 <<< $JS.API.CONSUMER.INFO.drei.dur
{"type":"io.nats.jetstream.api.v1.consumer_info_response","stream_name":"drei","name":"dur","created":"2021-12-01T23:15:46.697564Z","config":{"durable_name":"dur","deliver_policy":"all","ack_policy":"explicit","ack_wait":30000000000,"max_deliver":-1,"replay_policy":"original","max_waiting":512,"max_ack_pending":20000},"delivered":{"consumer_seq":0,"stream_seq":0},"ack_floor":{"consumer_seq":0,"stream_seq":0},"num_ack_pending":0,"num_redelivered":0,"num_waiting":0,"num_pending":0,"cluster":{"name":"hub","leader":"hub-server-1"}}

╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                   Consumer report for drei with 2 consumers                                   │
├──────────┬──────┬────────────┬──────────┬─────────────┬─────────────┬─────────────┬───────────┬───────────────┤
│ Consumer │ Mode │ Ack Policy │ Ack Wait │ Ack Pending │ Redelivered │ Unprocessed │ Ack Floor │ Cluster       │
├──────────┼──────┼────────────┼──────────┼─────────────┼─────────────┼─────────────┼───────────┼───────────────┤
│ dur      │ Pull │ Explicit   │ 30.00s   │ 0           │ 0           │ 0           │ 0         │ hub-server-1* │
╰──────────┴──────┴────────────┴──────────┴─────────────┴─────────────┴─────────────┴───────────┴───────────────╯

 ~/test/list-issue  nats -s localhost:4222 s report --trace
Obtaining Stream stats

18:34:42 >>> $JS.API.STREAM.LIST
{"offset":0}

18:34:46 <<< $JS.API.STREAM.LIST
{"type":"io.nats.jetstream.api.v1.stream_list_response","total":2,"offset":0,"limit":256,"streams":[{"config":{"name":"drei","subjects":["drei"],"retention":"limits","max_consumers":-1,"max_msgs":-1,"max_bytes":-1,"max_age":0,"max_msgs_per_subject":-1,"max_msg_size":-1,"discard":"old","storage":"file","num_replicas":1,"duplicate_window":120000000000,"sealed":false,"deny_delete":false,"deny_purge":false,"allow_rollup_hdrs":false},"created":"2021-12-01T21:50:44.129716Z","state":{"messages":0,"bytes":0,"first_seq":1,"first_ts":"1970-01-01T00:00:00Z","last_seq":0,"last_ts":"0001-01-01T00:00:00Z","consumer_count":2},"cluster":{"name":"hub","leader":"hub-server-1"}},{"config":{"name":"test","subjects":["test"],"retention":"limits","max_consumers":-1,"max_msgs":-1,"max_bytes":-1,"max_age":0,"max_msgs_per_subject":-1,"max_msg_size":-1,"discard":"old","storage":"file","num_replicas":1,"duplicate_window":120000000000,"sealed":false,"deny_delete":false,"deny_purge":false,"allow_rollup_hdrs":false},"created":"2021-12-01T21:50:15.598479Z","state":{"messages":0,"bytes":0,"first_seq":1,"first_ts":"1970-01-01T00:00:00Z","last_seq":0,"last_ts":"0001-01-01T00:00:00Z","consumer_count":0},"cluster":{"name":"hub","leader":"hub-server-3"}}],"missing_stream_names":["fail-me"]}

╭──────────────────────────────────────────────────────────────────────────────────╮
│                                  Stream Report                                   │
├────────┬─────────┬───────────┬──────────┬───────┬──────┬─────────┬───────────────┤
│ Stream │ Storage │ Consumers │ Messages │ Bytes │ Lost │ Deleted │ Replicas      │
├────────┼─────────┼───────────┼──────────┼───────┼──────┼─────────┼───────────────┤
│ drei   │ File    │ 2         │ 0        │ 0 B   │ 0    │ 0       │ hub-server-1* │
│ test   │ File    │ 0         │ 0        │ 0 B   │ 0    │ 0       │ hub-server-3* │
╰────────┴─────────┴───────────┴──────────┴───────┴──────┴─────────┴───────────────╯

 ~/test/list-issue  nats -s localhost:4222 s ls --trace
18:34:54 >>> $JS.API.STREAM.LIST
{"offset":0}

18:34:58 <<< $JS.API.STREAM.LIST
{"type":"io.nats.jetstream.api.v1.stream_list_response","total":2,"offset":0,"limit":256,"streams":[{"config":{"name":"drei","subjects":["drei"],"retention":"limits","max_consumers":-1,"max_msgs":-1,"max_bytes":-1,"max_age":0,"max_msgs_per_subject":-1,"max_msg_size":-1,"discard":"old","storage":"file","num_replicas":1,"duplicate_window":120000000000,"sealed":false,"deny_delete":false,"deny_purge":false,"allow_rollup_hdrs":false},"created":"2021-12-01T21:50:44.129716Z","state":{"messages":0,"bytes":0,"first_seq":1,"first_ts":"1970-01-01T00:00:00Z","last_seq":0,"last_ts":"0001-01-01T00:00:00Z","consumer_count":2},"cluster":{"name":"hub","leader":"hub-server-1"}},{"config":{"name":"test","subjects":["test"],"retention":"limits","max_consumers":-1,"max_msgs":-1,"max_bytes":-1,"max_age":0,"max_msgs_per_subject":-1,"max_msg_size":-1,"discard":"old","storage":"file","num_replicas":1,"duplicate_window":120000000000,"sealed":false,"deny_delete":false,"deny_purge":false,"allow_rollup_hdrs":false},"created":"2021-12-01T21:50:15.598479Z","state":{"messages":0,"bytes":0,"first_seq":1,"first_ts":"1970-01-01T00:00:00Z","last_seq":0,"last_ts":"0001-01-01T00:00:00Z","consumer_count":0},"cluster":{"name":"hub","leader":"hub-server-3"}}],"missing_stream_names":["fail-me"]}

╭───────────────────────────────────────────────────────────────────────────╮
│                                  Streams                                  │
├──────┬─────────────┬─────────────────────┬──────────┬──────┬──────────────┤
│ Name │ Description │ Created             │ Messages │ Size │ Last Message │
├──────┼─────────────┼─────────────────────┼──────────┼──────┼──────────────┤
│ drei │             │ 2021-12-01 21:12:44 │ 0        │ 0 B  │ never        │
│ test │             │ 2021-12-01 21:12:15 │ 0        │ 0 B  │ never        │
╰──────┴─────────────┴─────────────────────┴──────────┴──────┴──────────────╯

 ~/test/list-issue 
```

I basically modified the server to not include consumer/streams with the prefix "fail"
```
diff --git a/server/jetstream_cluster.go b/server/jetstream_cluster.go
index a69431a0..9eae73fb 100644
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4008,6 +4008,9 @@ LOOP:
                        resp.Missing = missingNames
                        break LOOP
                case si := <-rc:
+                       if strings.HasPrefix(si.Config.Name, "fail") {
+                               continue
+                       }
                        delete(sent, si.Config.Name)
                        resp.Streams = append(resp.Streams, si)
                        // Check to see if we are done.
@@ -4145,6 +4148,9 @@ LOOP:
                        resp.Missing = missingNames
                        break LOOP
                case ci := <-rc:
+                       if strings.HasPrefix(ci.Name, "fail") {
+                               continue
+                       }
                        delete(sent, ci.Name)
                        resp.Consumers = append(resp.Consumers, ci)
                        // Check to see if we are done.
```