### PR TITLE
fixes a nil panic on jsz

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2474,6 +2474,10 @@ func (s *Server) accountDetail(jsa *jsAccount, optStreams, optConsumers, optCfg 
 			if optConsumers {
 				for _, consumer := range stream.getPublicConsumers() {
 					cInfo := consumer.info()
+					if cInfo == nil {
+						continue
+					}
+
 					if !optCfg {
 						cInfo.Config = nil
 					}


### PR DESCRIPTION
Appears what happens is that the getPublicConsumers()
is called which produces a list of consumers and that
between the time the list is made and the Info() is
called the ephemeral was removed.

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
