### PR TITLE
[FIXED] Check for no_auth_user

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -538,7 +538,8 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			// but we set it here to be able to identify it in the logs.
 			c.opts.Username = user.Username
 		} else {
-			if (c.kind == CLIENT || c.kind == LEAF) && c.opts.Username == _EMPTY_ && noAuthUser != _EMPTY_ {
+			if (c.kind == CLIENT || c.kind == LEAF) && noAuthUser != _EMPTY_ &&
+				c.opts.Username == _EMPTY_ && c.opts.Password == _EMPTY_ && c.opts.Token == _EMPTY_ {
 				if u, exists := s.users[noAuthUser]; exists {
 					c.mu.Lock()
 					c.opts.Username = u.Username

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -14,12 +14,15 @@
 package server
 
 import (
+	"fmt"
 	"net/url"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/nats-io/jwt/v2"
+	"github.com/nats-io/nats.go"
 )
 
 func TestUserCloneNilPermissions(t *testing.T) {
@@ -210,5 +213,63 @@ func TestDNSAltNameMatching(t *testing.T) {
 		if dnsAltNameMatches(dnsAltNameLabels(test.altName), urlSet) != test.match {
 			t.Fatal("Test", idx, "Match miss match, expected:", test.match)
 		}
+	}
+}
+
+func TestNoAuthUser(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: "127.0.0.1:-1"
+		accounts {
+			FOO { users [{user: "foo", password: "pwd1"}] }
+			BAR { users [{user: "bar", password: "pwd2"}] }
+		}
+		no_auth_user: "foo"
+	`))
+	defer os.Remove(conf)
+	s, o := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	for _, test := range []struct {
+		name    string
+		usrInfo string
+		ok      bool
+		account string
+	}{
+		{"valid user/pwd", "bar:pwd2@", true, "BAR"},
+		{"invalid pwd", "bar:wrong@", false, _EMPTY_},
+		{"some token", "sometoken@", false, _EMPTY_},
+		{"user used without pwd", "bar@", false, _EMPTY_}, // will be treated as a token
+		{"user with empty password", "bar:@", false, _EMPTY_},
+		{"no user", _EMPTY_, true, "FOO"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			url := fmt.Sprintf("nats://%s127.0.0.1:%d", test.usrInfo, o.Port)
+			nc, err := nats.Connect(url)
+			if err != nil {
+				if test.ok {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				return
+			} else if !test.ok {
+				nc.Close()
+				t.Fatalf("Should have failed, did not")
+			}
+			var accName string
+			s.mu.Lock()
+			for _, c := range s.clients {
+				c.mu.Lock()
+				if c.acc != nil {
+					accName = c.acc.Name
+				}
+				c.mu.Unlock()
+				break
+			}
+			s.mu.Unlock()
+			nc.Close()
+			checkClientsCount(t, s, 0)
+			if accName != test.account {
+				t.Fatalf("The account should have been %q, got %q", test.account, accName)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Check for a no_auth_user should be done only when no authentication
at all is provided by the user. This was not the case. For instance,
if the user provided a token, the server would still check for
no_auth_user if users are defined. It was not really an issue since
the admin cannot configure users AND token, but it is better for
the application to fail if providing a token that is actually not
being used. If the admin configures a no_auth_user, this should
be used only when no authentication is provided.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
