### PR TITLE
[FIXED] TLS map: panic for existing user but conn type not allowed

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -485,10 +485,10 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 				if u != _EMPTY_ {
 					usr, ok := s.users[u]
 					if !ok || !c.connectionTypeAllowed(usr.AllowedConnectionTypes) {
-						return _EMPTY_, ok
+						return _EMPTY_, false
 					}
 					user = usr
-					return usr.Username, ok
+					return usr.Username, true
 				}
 
 				if certDN == nil {


### PR DESCRIPTION
For TLS configuration with `verify_and_map` set to true, if a
connection connects and has a certificate with ID that matches
a user, but that user's `allowed_connection_types` is specified
and does not have the connection type in its list, then the
server will panic.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
