### PR TITLE
Adding jwt request callout to auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/klauspost/compress v1.13.4
 	github.com/minio/highwayhash v1.0.1
-	github.com/nats-io/jwt/v2 v2.2.0
+	github.com/nats-io/jwt/v2 v2.2.1-0.20211214201657-b87bc9cf336d
 	github.com/nats-io/nats.go v1.13.1-0.20211122170419-d7c1d78a50fc
 	github.com/nats-io/nkeys v0.3.0
 	github.com/nats-io/nuid v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/minio/highwayhash v1.0.1 h1:dZ6IIu8Z14VlC0VpfKofAhCy74wu/Qb5gcn52yWoz
 github.com/minio/highwayhash v1.0.1/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/nats-io/jwt/v2 v2.2.0 h1:Yg/4WFK6vsqMudRg91eBb7Dh6XeVcDMPHycDE8CfltE=
 github.com/nats-io/jwt/v2 v2.2.0/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
+github.com/nats-io/jwt/v2 v2.2.1-0.20211214201657-b87bc9cf336d h1:pEd1mO/uRGMOA5mG318nWsRY5/D+HKNaH/kxt6EP6GI=
+github.com/nats-io/jwt/v2 v2.2.1-0.20211214201657-b87bc9cf336d/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
 github.com/nats-io/nats.go v1.13.1-0.20211122170419-d7c1d78a50fc h1:SHr4MUUZJ/fAC0uSm2OzWOJYsHpapmR86mpw7q1qPXU=
 github.com/nats-io/nats.go v1.13.1-0.20211122170419-d7c1d78a50fc/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -79,6 +79,7 @@ type Account struct {
 	limits
 	expired      bool
 	incomplete   bool
+	canObtainJWT bool
 	signingKeys  map[string]jwt.Scope
 	srv          *Server // server this account is registered with (possibly nil)
 	lds          string  // loop detection subject for leaf nodes
@@ -2944,6 +2945,8 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 			removeList = append(removeList, m.src)
 		}
 	}
+	// TODO Obtain real value from JWT
+	a.canObtainJWT = true
 	a.mu.Unlock()
 
 	for sub, wm := range ac.Mappings {

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -79,7 +79,6 @@ type Account struct {
 	limits
 	expired      bool
 	incomplete   bool
-	canObtainJWT bool
 	signingKeys  map[string]jwt.Scope
 	srv          *Server // server this account is registered with (possibly nil)
 	lds          string  // loop detection subject for leaf nodes
@@ -2945,8 +2944,6 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 			removeList = append(removeList, m.src)
 		}
 	}
-	// TODO Obtain real value from JWT
-	a.canObtainJWT = true
 	a.mu.Unlock()
 
 	for sub, wm := range ac.Mappings {

--- a/server/auth.go
+++ b/server/auth.go
@@ -403,14 +403,14 @@ func (s *Server) onboardingCallout(c *client, opts *Options) bool {
 	msgChan := make(chan string)
 	defer close(msgChan)
 	ib := s.newRespInbox()
-	sub, err := s.sysSubscribe(ib, func(_ *subscription, _ *client, acc *Account, subject, reply string, rmsg []byte) {
+	sub, err := acc.subscribeInternal(ib, func(_ *subscription, _ *client, acc *Account, subject, reply string, rmsg []byte) {
 		msgChan <- string(rmsg)
 	})
 	if err != nil {
 		c.Debugf("Authentication requires a user JWT - Setup failure %s", signupName)
 		return false
 	}
-	defer s.sysUnsubscribe(sub)
+	defer sub.client.processUnsub(sub.sid)
 	var hdr map[string]string
 	ci := c.getClientInfo(true)
 	// TODO clear out account in ci? the value of $G may be confusing

--- a/server/auth.go
+++ b/server/auth.go
@@ -478,7 +478,7 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			defer close(msgChan)
 			ib := s.newRespInbox()
 			sub, err := s.sysSubscribe(ib, func(_ *subscription, _ *client, acc *Account, subject, reply string, rmsg []byte) {
-				msgChan <- rmsg
+				msgChan <- copyBytes(rmsg)
 			})
 			if err != nil {
 				c.Debugf("Authentication requires a user JWT - Setup failure %s", signupName)

--- a/server/auth.go
+++ b/server/auth.go
@@ -433,7 +433,8 @@ func (s *Server) onboardingCallout(c *client, opts *Options) bool {
 	} else {
 		dest = c.opts.Nkey
 	}
-	to := secondsToDuration(opts.AuthTimeout) - time.Now().Sub(c.start)
+
+	to := secondsToDuration(opts.AuthTimeout) - time.Since(c.start)
 	if to <= 0 {
 		c.Debugf("Authentication requires a user JWT - Token Request Timed Out Immediately: %s", signupName)
 		return false

--- a/server/auth.go
+++ b/server/auth.go
@@ -404,7 +404,7 @@ func (s *Server) onboardingCallout(c *client, opts *Options) bool {
 	defer close(msgChan)
 	ib := s.newRespInbox()
 	sub, err := s.sysSubscribe(ib, func(_ *subscription, _ *client, acc *Account, subject, reply string, rmsg []byte) {
-		msgChan <- string(copyBytes(rmsg))
+		msgChan <- string(rmsg)
 	})
 	if err != nil {
 		c.Debugf("Authentication requires a user JWT - Setup failure %s", signupName)

--- a/server/auth.go
+++ b/server/auth.go
@@ -369,6 +369,9 @@ func (c *client) matchesPinnedCert(tlsPinnedCerts PinnedCertSet) bool {
 	return true
 }
 
+// JWT Tag value for Account JWT Tag, enabling on-boarding services
+const featureTagOnboard = "nats-onboard-jwt"
+
 func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) bool {
 	var (
 		nkey *NkeyUser
@@ -467,9 +470,9 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			}
 			acc.mu.RLock()
 			signupName := fmt.Sprintf("Account: %s/%s", acc.Name, acc.nameTag)
-			canObtainJWT := acc.canObtainJWT
+			featOnboard := acc.tags.Contains(featureTagOnboard)
 			acc.mu.RUnlock()
-			if !canObtainJWT {
+			if !featOnboard {
 				c.Debugf("Authentication requires a user JWT")
 				return false
 			}

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -5889,7 +5889,7 @@ func TestJWTSignupFromSysAcc(t *testing.T) {
 
 	ncIssuer := natsConnect(t, s.ClientURL(), createUserCreds(t, s, fromKey))
 	defer ncIssuer.Close()
-	ncIssuer.Subscribe("$jwt.request.*", func(msg *nats.Msg) {
+	ncIssuer.Subscribe(fmt.Sprintf(onboardSubjFmt, "*"), func(msg *nats.Msg) {
 		if !strings.HasPrefix(string(msg.Data), "shared-secret") {
 			errChan <- fmt.Errorf("request info not present")
 			return
@@ -5915,7 +5915,7 @@ func TestJWTSignupFromSysAcc(t *testing.T) {
 			errChan <- err
 			return
 		}
-		if ri, ok := msg.Header["Nats-Request-Info"]; !ok {
+		if ri, ok := msg.Header[ClientInfoHdr]; !ok {
 			errChan <- fmt.Errorf("request info not present")
 			return
 		} else {

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -5847,6 +5847,7 @@ func TestJWTNoSystemAccountButNatsResolver(t *testing.T) {
 func TestJWTSignupFromSysAcc(t *testing.T) {
 	fromKey, from := createKey(t)
 	fromClaim := jwt.NewAccountClaims(from)
+	fromClaim.Tags.Add(featureTagOnboard) // required for this test to work
 	fromJWT := encodeClaim(t, fromClaim, "")
 
 	_, to := createKey(t)

--- a/server/server.go
+++ b/server/server.go
@@ -77,6 +77,7 @@ type Info struct {
 	IP                string   `json:"ip,omitempty"`
 	CID               uint64   `json:"client_id,omitempty"`
 	ClientIP          string   `json:"client_ip,omitempty"`
+	JWT               string   `json:"client_jwt,omitempty"` // If the server requested the JWT on behalf of the client, communicate the obtained JWT back to the client
 	Nonce             string   `json:"nonce,omitempty"`
 	Cluster           string   `json:"cluster,omitempty"`
 	Dynamic           bool     `json:"cluster_dynamic,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/klauspost/compress/s2
 # github.com/minio/highwayhash v1.0.1
 ## explicit
 github.com/minio/highwayhash
-# github.com/nats-io/jwt/v2 v2.2.0
+# github.com/nats-io/jwt/v2 v2.2.1-0.20211214201657-b87bc9cf336d
 ## explicit
 github.com/nats-io/jwt/v2
 # github.com/nats-io/nats.go v1.13.1-0.20211122170419-d7c1d78a50fc


### PR DESCRIPTION
This calls out to a signup service and informs the client of the jwt.
If the client provides an account id, that is where the request will go.
If non is provided, try the system account as global default.

In order to signal an account's willingness to partake in this, the pressence of this tag is needed in the account jwt:
nats-onboard-jwt

This takes the value of token and an optional nkey and calls the service with it.
A client will have to add the account option.
It will have to obtain the jwt from the info block, so that reconnects do not require obtaining a new jwt
Other than that the only thing needed is to forget the jwt once you receive ErrAuthExpired.

Signed-off-by: Matthias Hanel <mh@synadia.com>

I tested this out end to end without issues.

Changes to my local nats.go, are small, but not complete.
What is missing is restoring state on ErrAuthExpired

```
diff --git a/nats.go b/nats.go
index 6f9067c..c1c9204 100644
--- a/nats.go
+++ b/nats.go
@@ -439,6 +439,9 @@ type Options struct {

        // InboxPrefix allows the default _INBOX prefix to be customized
        InboxPrefix string
+
+       // Account name to send jwt requests to
+       Account string
 }

 const (
@@ -666,6 +669,7 @@ type serverInfo struct {
        MaxPayload   int64    `json:"max_payload"`
        CID          uint64   `json:"client_id,omitempty"`
        ClientIP     string   `json:"client_ip,omitempty"`
+       JWT          string   `json:"client_jwt,omitempty"`
        Nonce        string   `json:"nonce,omitempty"`
        Cluster      string   `json:"cluster,omitempty"`
        ConnectURLs  []string `json:"connect_urls,omitempty"`
@@ -698,6 +702,7 @@ type connectInfo struct {
        Echo         bool   `json:"echo"`
        Headers      bool   `json:"headers"`
        NoResponders bool   `json:"no_responders"`
+       Account      string `json:"account"`
 }

 // MsgHandler is a callback function that processes messages delivered to
@@ -1124,6 +1129,17 @@ func CustomInboxPrefix(p string) Option {
        }
 }

+// DrainTimeout is an Option to set the timeout for draining a connection.
+func Account(a string) Option {
+       return func(o *Options) error {
+               if !nkeys.IsValidPublicAccountKey(a) {
+                       return fmt.Errorf("Invalid Account Id")
+               }
+               o.Account = a
+               return nil
+       }
+}
+
 // Handler processing

 // SetDisconnectHandler will set the disconnect event handler.
@@ -2073,7 +2089,7 @@ func (nc *Conn) connectProto() (string, error) {
        // If our server does not support headers then we can't do them or no responders.
        hdrs := nc.info.Headers
        cinfo := connectInfo{o.Verbose, o.Pedantic, ujwt, nkey, sig, user, pass, token,
-               o.Secure, o.Name, LangString, Version, clientProtoInfo, !o.NoEcho, hdrs, hdrs}
+               o.Secure, o.Name, LangString, Version, clientProtoInfo, !o.NoEcho, hdrs, hdrs, o.Account}

        b, err := json.Marshal(cinfo)
        if err != nil {
@@ -2953,6 +2969,16 @@ func (nc *Conn) processInfo(info string) error {
                return err
        }

+       // bootstrap into jwt environment.
+       if nc.Opts.UserJWT == nil && ncInfo.JWT != "" {
+               j := ncInfo.JWT
+               nc.Opts.UserJWT = func() (string, error) {
+                       return j, nil
+               }
+               // We allow to set an nkey and retrieve the matching jwt. Thus, clear nkey.
+               nc.Opts.Nkey = ""
+       }
+
        // Copy content into connection's info structure.
        nc.info = ncInfo
        // The array could be empty/not present on initial connect,
```
