### PR TITLE
[FIXED] JetStream: stream first/last sequence possibly reset

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1872,9 +1872,11 @@ func (fs *fileStore) removeMsg(seq uint64, secure, needFSLock bool) (bool, error
 	}
 
 	// If we emptied the current message block and the seq was state.First.Seq
-	// then we need to jump message blocks.
+	// then we need to jump message blocks. We will also write the index so
+	// we don't lose track of the first sequence.
 	if firstSeqNeedsUpdate {
 		fs.selectNextFirst()
+		fs.lmb.writeIndexInfo()
 	}
 	fs.mu.Unlock()
 
@@ -3472,7 +3474,7 @@ func (mb *msgBlock) indexNeedsUpdate() bool {
 }
 
 // Write index info to the appropriate file.
-// Lock should be held.
+// Filestore lock should be held.
 func (mb *msgBlock) writeIndexInfo() error {
 	// HEADER: magic version msgs bytes fseq fts lseq lts ndel checksum
 	var hdr [indexHdrSize]byte


### PR DESCRIPTION
A low-level Filestore issue would cause a new block to be created
when the last block was empty, but the index for the new block
would not be forced to be written on disk.

The observed issue could be that with a stream with a WorkQueue
retention policy, its first/last sequence values could be reset
after a pull subscriber would have consumed all messages and
the server was restarted without a clean shutdown.
This would cause the pull subscriber to "stall" until enough
new messages are sent to reach a stream sequence that catches
up with the consumer's view of the stream first sequence prior
to the restart.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
