### PR TITLE
Fix for when consumer would stop working due to errPartialCache returned from fileStore.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2353,7 +2353,7 @@ func (o *consumer) loopAndGatherMsgs(qch chan struct{}) {
 
 		// On error either wait or return.
 		if err != nil {
-			if err == ErrStoreMsgNotFound || err == ErrStoreEOF || err == errMaxAckPending {
+			if err == ErrStoreMsgNotFound || err == ErrStoreEOF || err == errMaxAckPending || err == errPartialCache {
 				goto waitForMsgs
 			} else {
 				o.mu.Unlock()


### PR DESCRIPTION
Stabilize filestore to eliminate sporadic errPartialCache errors under certain situations.

The filestore would release a msgBlock lock while trying to load a cache block if it thought it needed to flush pending data. With async false, this should be very rare but was possible after careful inspection and could lead under the right conditions to a consumer getting an errPartialCache returned trying to load a message.

Resolves #2732 (Hopefully)

/cc @nats-io/core
