### PR TITLE
Implement overflow placement for JetStream streams.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The NATS Authors
+// Copyright 2019-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -2104,8 +2104,8 @@ func (o *consumer) processNextMsgReq(_ *subscription, c *client, _ *Account, _, 
 		sendBatch(&wr)
 	} else {
 		// Check for API outstanding requests.
-		if apiOut := atomic.AddInt64(&js.apiCalls, 1); apiOut > maxJSApiOut {
-			atomic.AddInt64(&js.apiCalls, -1)
+		if apiOut := atomic.AddInt64(&js.apiInflight, 1); apiOut > maxJSApiOut {
+			atomic.AddInt64(&js.apiInflight, -1)
 			sendErr(503, "JetStream API limit exceeded")
 			s.Warnf("JetStream API limit exceeded: %d calls outstanding", apiOut)
 			return
@@ -2115,7 +2115,7 @@ func (o *consumer) processNextMsgReq(_ *subscription, c *client, _ *Account, _, 
 			o.mu.Lock()
 			sendBatch(&wr)
 			o.mu.Unlock()
-			atomic.AddInt64(&js.apiCalls, -1)
+			atomic.AddInt64(&js.apiInflight, -1)
 		}()
 	}
 }

--- a/server/errors.json
+++ b/server/errors.json
@@ -1108,5 +1108,15 @@
     "help": "Returned when the delivery subject on a Push Consumer is not a valid NATS Subject",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSStreamMaxBytesRequired",
+    "code": 400,
+    "error_code": 10113,
+    "description": "account requires a stream config to have max bytes set",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The NATS Authors
+// Copyright 2020-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -652,8 +652,8 @@ func (js *jetStream) apiDispatch(sub *subscription, c *client, acc *Account, sub
 	// If we are here we have received this request over a non client connection.
 	// We need to make sure not to block. We will spin a Go routine per but also make
 	// sure we do not have too many outstanding.
-	if apiOut := atomic.AddInt64(&js.apiCalls, 1); apiOut > maxJSApiOut {
-		atomic.AddInt64(&js.apiCalls, -1)
+	if apiOut := atomic.AddInt64(&js.apiInflight, 1); apiOut > maxJSApiOut {
+		atomic.AddInt64(&js.apiInflight, -1)
 		ci, acc, _, msg, err := s.getRequestInfo(c, rmsg)
 		if err == nil {
 			resp := &ApiResponse{Type: JSApiOverloadedType, Error: NewJSInsufficientResourcesError()}
@@ -678,7 +678,7 @@ func (js *jetStream) apiDispatch(sub *subscription, c *client, acc *Account, sub
 	// Dispatch the API call to its own Go routine.
 	go func() {
 		jsub.icb(sub, client, acc, subject, reply, rmsg)
-		atomic.AddInt64(&js.apiCalls, -1)
+		atomic.AddInt64(&js.apiInflight, -1)
 	}()
 }
 
@@ -817,7 +817,9 @@ func (a *Account) trackAPI() {
 		jsa.usage.api++
 		jsa.apiTotal++
 		jsa.sendClusterUsageUpdate()
+		js := jsa.js
 		jsa.mu.Unlock()
+		atomic.AddInt64(&js.apiTotal, 1)
 	}
 }
 
@@ -834,6 +836,7 @@ func (a *Account) trackAPIErr() {
 		jsa.sendClusterUsageUpdate()
 		js := jsa.js
 		jsa.mu.Unlock()
+		atomic.AddInt64(&js.apiTotal, 1)
 		atomic.AddInt64(&js.apiErrors, 1)
 	}
 }
@@ -1113,7 +1116,7 @@ func (s *Server) jsonResponse(v interface{}) string {
 }
 
 // Request to create a stream.
-func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, a *Account, subject, reply string, rmsg []byte) {
+func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
@@ -1286,6 +1289,14 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, a *Account,
 		}
 	}
 
+	// Check for MaxBytes required.
+	if acc.maxBytesRequired() && cfg.MaxBytes <= 0 {
+		resp.Error = NewJSStreamMaxBytesRequiredError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+
+	// Hand off to cluster for processing.
 	if s.JetStreamIsClustered() {
 		s.jsClusteredStreamRequest(ci, acc, subject, reply, rmsg, &cfg)
 		return

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -817,9 +817,8 @@ func (a *Account) trackAPI() {
 		jsa.usage.api++
 		jsa.apiTotal++
 		jsa.sendClusterUsageUpdate()
-		js := jsa.js
+		atomic.AddInt64(&jsa.js.apiTotal, 1)
 		jsa.mu.Unlock()
-		atomic.AddInt64(&js.apiTotal, 1)
 	}
 }
 
@@ -834,10 +833,9 @@ func (a *Account) trackAPIErr() {
 		jsa.usage.err++
 		jsa.apiErrors++
 		jsa.sendClusterUsageUpdate()
-		js := jsa.js
+		atomic.AddInt64(&jsa.js.apiTotal, 1)
+		atomic.AddInt64(&jsa.js.apiErrors, 1)
 		jsa.mu.Unlock()
-		atomic.AddInt64(&js.apiTotal, 1)
-		atomic.AddInt64(&js.apiErrors, 1)
 	}
 }
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3394,7 +3394,12 @@ func (js *jetStream) processStreamAssignmentResults(sub *subscription, c *client
 				// If we have additional clusters to try we can retry.
 				if ci != nil && len(ci.Alternates) > 0 {
 					if rg := js.createGroupForStream(ci, cfg); rg != nil {
-						s.Warnf("Retrying cluster placement for stream '%s > %s'", result.Account, result.Stream)
+						if org := sa.Group; org != nil && len(org.Peers) > 0 {
+							s.Warnf("Retrying cluster placement for stream '%s > %s' due to insufficient resources in cluster %q",
+								result.Account, result.Stream, s.clusterNameForNode(org.Peers[0]))
+						} else {
+							s.Warnf("Retrying cluster placement for stream '%s > %s' due to insufficient resources", result.Account, result.Stream)
+						}
 						// Pick a new preferred leader.
 						rg.setPreferred()
 						// Get rid of previous attempt.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -310,7 +310,12 @@ func (s *Server) JetStreamClusterPeers() []string {
 	var nodes []string
 	for _, p := range peers {
 		si, ok := s.nodeToInfo.Load(p.ID)
-		if !ok || si.(nodeInfo).offline || !si.(nodeInfo).js {
+		if !ok || si == nil {
+			continue
+		}
+		ni := si.(nodeInfo)
+		// Ignore if offline, no JS, or no current stats have been received.
+		if ni.offline || !ni.js || ni.stats == nil {
 			continue
 		}
 		nodes = append(nodes, si.(nodeInfo).name)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3604,7 +3604,7 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 	}
 
 	var maxBytes uint64
-	if cfg != nil && cfg.MaxBytes > 0 {
+	if cfg.MaxBytes > 0 {
 		maxBytes = uint64(cfg.MaxBytes)
 	}
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The NATS Authors
+// Copyright 2020-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -831,6 +831,10 @@ func (js *jetStream) monitorCluster() {
 				}
 			}
 		case isLeader = <-lch:
+			// We want to make sure we are updated on statsz so ping the extended cluster.
+			if isLeader {
+				s.sendInternalMsgLocked(serverStatsPingReqSubj, _EMPTY_, nil, nil)
+			}
 			js.processLeaderChange(isLeader)
 			if isLeader && !beenLeader {
 				beenLeader = true
@@ -2167,6 +2171,7 @@ func (js *jetStream) processStreamAssignment(sa *streamAssignment) bool {
 		js.mu.Lock()
 		if node := sa.Group.node; node != nil {
 			node.ProposeRemovePeer(ourID)
+			didRemove = true
 		}
 		sa.Group.node = nil
 		sa.err = nil
@@ -3354,6 +3359,11 @@ type streamAssignmentResult struct {
 	Update   bool                        `json:"is_update,omitempty"`
 }
 
+// Determine if this is an insufficient resources error type.
+func isInsufficientResourcesErr(err *ApiError) bool {
+	return err != nil && IsNatsErr(err, JSInsufficientResourcesErr, JSMemoryResourcesExceededErr, JSStorageResourcesExceededErr)
+}
+
 // Process error results of stream and consumer assignments.
 // Success will be handled by stream leader.
 func (js *jetStream) processStreamAssignmentResults(sub *subscription, c *client, _ *Account, subject, reply string, msg []byte) {
@@ -3375,6 +3385,30 @@ func (js *jetStream) processStreamAssignmentResults(sub *subscription, c *client
 
 	// FIXME(dlc) - suppress duplicates?
 	if sa := js.streamAssignment(result.Account, result.Stream); sa != nil {
+		canDelete := !result.Update && time.Since(sa.Created) < 5*time.Second
+
+		// See if we should retry in case this cluster is full but there are others.
+		if cfg, ci := sa.Config, sa.Client; cfg != nil && ci != nil && isInsufficientResourcesErr(result.Response.Error) && canDelete {
+			// If cluster is defined we can not retry.
+			if cfg.Placement == nil || cfg.Placement.Cluster == _EMPTY_ {
+				// If we have additional clusters to try we can retry.
+				if ci != nil && len(ci.Alternates) > 0 {
+					if rg := js.createGroupForStream(ci, cfg); rg != nil {
+						s.Warnf("Retrying cluster placement for stream '%s > %s'", result.Account, result.Stream)
+						// Pick a new preferred leader.
+						rg.setPreferred()
+						// Get rid of previous attempt.
+						cc.meta.Propose(encodeDeleteStreamAssignment(sa))
+						// Propose new.
+						sa.Group, sa.err = rg, nil
+						cc.meta.Propose(encodeAddStreamAssignment(sa))
+						return
+					}
+				}
+			}
+		}
+
+		// Respond to the user here.
 		var resp string
 		if result.Response != nil {
 			resp = s.jsonResponse(result.Response)
@@ -3385,11 +3419,8 @@ func (js *jetStream) processStreamAssignmentResults(sub *subscription, c *client
 			sa.responded = true
 			js.srv.sendAPIErrResponse(sa.Client, acc, sa.Subject, sa.Reply, _EMPTY_, resp)
 		}
-		// Here we will remove this assignment, so this needs to only execute when we are sure
-		// this is what we want to do.
-		// TODO(dlc) - Could have mixed results, should track per peer.
-		// Set sa.err while we are deleting so we will not respond to list/names requests.
-		if !result.Update && time.Since(sa.Created) < 5*time.Second {
+		// Remove this assignment if possible.
+		if canDelete {
 			sa.err = NewJSClusterNotAssignedError()
 			cc.meta.Propose(encodeDeleteStreamAssignment(sa))
 		}
@@ -3562,31 +3593,77 @@ func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, removePe
 }
 
 // selectPeerGroup will select a group of peers to start a raft group.
-// TODO(dlc) - For now randomly select. Can be way smarter.
-func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string) []string {
-	var nodes []string
-	peers := cc.meta.Peers()
-	s := cc.s
+func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamConfig) []string {
+	if cluster == _EMPTY_ || cfg == nil {
+		return nil
+	}
+
+	var maxBytes uint64
+	if cfg != nil && cfg.MaxBytes > 0 {
+		maxBytes = uint64(cfg.MaxBytes)
+	}
+
+	// Used for weighted sorting based on availability.
+	type wn struct {
+		id    string
+		avail uint64
+	}
+
+	var nodes []wn
+	s, peers := cc.s, cc.meta.Peers()
 
 	for _, p := range peers {
-		// If we know its offline or it is not in our list it probably shutdown, so don't consider.
-		if si, ok := s.nodeToInfo.Load(p.ID); !ok || si.(nodeInfo).offline {
+		si, ok := s.nodeToInfo.Load(p.ID)
+		if !ok || si == nil {
 			continue
 		}
-		if cluster != _EMPTY_ {
-			if s.clusterNameForNode(p.ID) == cluster {
-				nodes = append(nodes, p.ID)
-			}
-		} else {
-			nodes = append(nodes, p.ID)
+		ni := si.(nodeInfo)
+		// Only select from the designated named cluster.
+		// If we know its offline or we do not have config or stats don't consider.
+		if ni.cluster != cluster || ni.offline || ni.cfg == nil || ni.stats == nil {
+			continue
 		}
+
+		var available uint64
+		switch cfg.Storage {
+		case MemoryStorage:
+			used := ni.stats.ReservedMemory
+			if ni.stats.Memory > used {
+				used = ni.stats.Memory
+			}
+			if ni.cfg.MaxMemory > int64(used) {
+				available = uint64(ni.cfg.MaxMemory) - used
+			}
+		case FileStorage:
+			used := ni.stats.ReservedStore
+			if ni.stats.Store > used {
+				used = ni.stats.Store
+			}
+			if ni.cfg.MaxStore > int64(used) {
+				available = uint64(ni.cfg.MaxStore) - used
+			}
+		}
+
+		// Check if we have enveough room if maxBytes set.
+		if maxBytes > 0 && maxBytes > available {
+			continue
+		}
+		// Add to our list of potential nodes.
+		nodes = append(nodes, wn{p.ID, available})
 	}
+
+	// If we could not select enough peers, fail.
 	if len(nodes) < r {
 		return nil
 	}
-	// Don't depend on range to randomize.
-	rand.Shuffle(len(nodes), func(i, j int) { nodes[i], nodes[j] = nodes[j], nodes[i] })
-	return nodes[:r]
+	// Sort based on available from most to least.
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].avail > nodes[j].avail })
+
+	var results []string
+	for _, r := range nodes[:r] {
+		results = append(results, r.id)
+	}
+	return results
 }
 
 func groupNameForStream(peers []string, storage StorageType) string {
@@ -3609,22 +3686,33 @@ func groupName(prefix string, peers []string, storage StorageType) string {
 
 // createGroupForStream will create a group for assignment for the stream.
 // Lock should be held.
-func (cc *jetStreamCluster) createGroupForStream(ci *ClientInfo, cfg *StreamConfig) *raftGroup {
+func (js *jetStream) createGroupForStream(ci *ClientInfo, cfg *StreamConfig) *raftGroup {
 	replicas := cfg.Replicas
 	if replicas == 0 {
 		replicas = 1
 	}
-	cluster := ci.Cluster
-	if cfg.Placement != nil && cfg.Placement.Cluster != _EMPTY_ {
+
+	// Default connected cluster from the request origin.
+	cc, cluster := js.cluster, ci.Cluster
+	// If specified, override the default.
+	clusterDefined := cfg.Placement != nil && cfg.Placement.Cluster != _EMPTY_
+	if clusterDefined {
 		cluster = cfg.Placement.Cluster
 	}
-	// Need to create a group here.
-	// TODO(dlc) - Can be way smarter here.
-	peers := cc.selectPeerGroup(replicas, cluster)
-	if len(peers) == 0 {
-		return nil
+	clusters := []string{cluster}
+	if !clusterDefined {
+		clusters = append(clusters, ci.Alternates...)
 	}
-	return &raftGroup{Name: groupNameForStream(peers, cfg.Storage), Storage: cfg.Storage, Peers: peers}
+
+	// Need to create a group here.
+	for _, cn := range clusters {
+		peers := cc.selectPeerGroup(replicas, cn, cfg)
+		if len(peers) < replicas {
+			continue
+		}
+		return &raftGroup{Name: groupNameForStream(peers, cfg.Storage), Storage: cfg.Storage, Peers: peers}
+	}
+	return nil
 }
 
 func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject, reply string, rmsg []byte, config *StreamConfig) {
@@ -3670,8 +3758,8 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 		return
 	}
 
-	// Check for stream limits here before proposing.
-	if err := jsa.checkLimits(cfg); err != nil {
+	// Check for account limits here before proposing.
+	if err := jsa.checkAccountLimits(cfg); err != nil {
 		resp.Error = NewJSStreamLimitsError(err, Unless(err))
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return
@@ -3681,6 +3769,7 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 	js.mu.Lock()
 	defer js.mu.Unlock()
 
+	// If this stream already exists, turn this into a stream info call.
 	if sa := js.streamAssignment(acc.Name, cfg.Name); sa != nil {
 		// If they are the same then we will forward on as a stream info request.
 		// This now matches single server behavior.
@@ -3700,8 +3789,9 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 		resp.Error = NewJSStreamNameExistError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return
+	}
 
-	} else if cfg.Sealed {
+	if cfg.Sealed {
 		resp.Error = NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration for create can not be sealed"))
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return
@@ -3721,7 +3811,7 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 	}
 
 	// Raft group selection and placement.
-	rg := cc.createGroupForStream(ci, cfg)
+	rg := js.createGroupForStream(ci, cfg)
 	if rg == nil {
 		resp.Error = NewJSInsufficientResourcesError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
@@ -3873,7 +3963,12 @@ func (s *Server) jsClusteredStreamPurgeRequest(
 	s.sendAPIResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(resp))
 }
 
-func (s *Server) jsClusteredStreamRestoreRequest(ci *ClientInfo, acc *Account, req *JSApiStreamRestoreRequest, stream, subject, reply string, rmsg []byte) {
+func (s *Server) jsClusteredStreamRestoreRequest(
+	ci *ClientInfo,
+	acc *Account,
+	req *JSApiStreamRestoreRequest,
+	stream, subject, reply string, rmsg []byte) {
+
 	js, cc := s.getJetStreamCluster()
 	if js == nil || cc == nil {
 		return
@@ -3892,7 +3987,7 @@ func (s *Server) jsClusteredStreamRestoreRequest(ci *ClientInfo, acc *Account, r
 	}
 
 	// Raft group selection and placement.
-	rg := cc.createGroupForStream(ci, cfg)
+	rg := js.createGroupForStream(ci, cfg)
 	if rg == nil {
 		resp.Error = NewJSInsufficientResourcesError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -10898,7 +10898,7 @@ func (c *cluster) waitOnLeader() {
 	expires := time.Now().Add(40 * time.Second)
 	for time.Now().Before(expires) {
 		if leader := c.leader(); leader != nil {
-			time.Sleep(250 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
@@ -10926,7 +10926,7 @@ func (c *cluster) waitOnClusterReadyWithNumPeers(numPeersExpected int) {
 	// Now make sure we have all peers.
 	for leader != nil && time.Now().Before(expires) {
 		if len(leader.JetStreamClusterPeers()) == numPeersExpected {
-			time.Sleep(250 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 			return
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The NATS Authors
+// Copyright 2020-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -143,9 +143,7 @@ func TestJetStreamClusterStreamLimitWithAccountDefaults(t *testing.T) {
 		Replicas: 2,
 		MaxBytes: 15 * 1024 * 1024,
 	})
-	if err == nil || !strings.Contains(err.Error(), "insufficient storage") {
-		t.Fatalf("Expected %v but got %v", ApiErrors[JSStorageResourcesExceededErr], err)
-	}
+	require_Error(t, err, NewJSInsufficientResourcesError(), NewJSStorageResourcesExceededError())
 }
 
 func TestJetStreamClusterSingleReplicaStreams(t *testing.T) {
@@ -966,20 +964,17 @@ func TestJetStreamClusterMaxBytesForStream(t *testing.T) {
 	// Stream config.
 	cfg := &nats.StreamConfig{
 		Name:     "TEST",
-		Subjects: []string{"foo", "bar"},
 		Replicas: 2,
+		MaxBytes: 2 * 1024 * 1024 * 1024, // 2GB
 	}
-	// 2GB
-	cfg.MaxBytes = 2 * 1024 * 1024 * 1024
-	if _, err := js.AddStream(cfg); err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	_, err = js.AddStream(cfg)
+	require_NoError(t, err)
+
 	// Make sure going over the single server limit though is enforced (for now).
+	cfg.Name = "TEST2"
 	cfg.MaxBytes *= 2
 	_, err = js.AddStream(cfg)
-	if err == nil || !strings.Contains(err.Error(), "insufficient storage resources") {
-		t.Fatalf("Expected %q error, got %q", "insufficient storage resources", err.Error())
-	}
+	require_Error(t, err, NewJSInsufficientResourcesError(), NewJSStorageResourcesExceededError())
 }
 
 func TestJetStreamClusterStreamPublishWithActiveConsumers(t *testing.T) {
@@ -9764,6 +9759,146 @@ func TestJetStreamSuperClusterPushConsumerInterest(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterOverflowPlacement(t *testing.T) {
+	sc := createJetStreamSuperClusterWithTemplate(t, jsClusterMaxBytesTempl, 3, 3)
+	defer sc.shutdown()
+
+	pcn := "C2"
+	s := sc.clusterForName(pcn).randomServer()
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	// With this setup, we opted in for requiring MaxBytes, so this should error.
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "foo",
+		Replicas: 3,
+	})
+	require_Error(t, err, NewJSStreamMaxBytesRequiredError())
+
+	// R=2 on purpose to leave one server empty.
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "foo",
+		Replicas: 2,
+		MaxBytes: 2 * 1024 * 1024 * 1024,
+	})
+	require_NoError(t, err)
+
+	// Now try to add another that will overflow the current cluster's reservation.
+	// Since we asked explicitly for the same cluster this should fail.
+	// Note this will not be testing the peer picker since the update has probably not made it to the meta leader.
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:      "bar",
+		Replicas:  3,
+		MaxBytes:  2 * 1024 * 1024 * 1024,
+		Placement: &nats.Placement{Cluster: pcn},
+	})
+	require_Error(t, err, NewJSInsufficientResourcesError(), NewJSStorageResourcesExceededError())
+
+	// Now test actual overflow placement. So try again with no placement designation.
+	// This will test the peer picker's logic since they are updated at this point and the meta leader
+	// knows it can not place it in C2.
+	si, err := js.AddStream(&nats.StreamConfig{
+		Name:     "bar",
+		Replicas: 3,
+		MaxBytes: 2 * 1024 * 1024 * 1024,
+	})
+	require_NoError(t, err)
+
+	// Make sure we did not get place into C2.
+	falt := si.Cluster.Name
+	if falt == pcn {
+		t.Fatalf("Expected to be placed in another cluster besides %q, but got %q", pcn, falt)
+	}
+
+	// One more time that should spill over again to our last cluster.
+	si, err = js.AddStream(&nats.StreamConfig{
+		Name:     "baz",
+		Replicas: 3,
+		MaxBytes: 2 * 1024 * 1024 * 1024,
+	})
+	require_NoError(t, err)
+
+	// Make sure we did not get place into C2.
+	if salt := si.Cluster.Name; salt == pcn || salt == falt {
+		t.Fatalf("Expected to be placed in last cluster besides %q or %q, but got %q", pcn, falt, salt)
+	}
+
+	// Now place a stream of R1 into C2 which should have space.
+	si, err = js.AddStream(&nats.StreamConfig{
+		Name:     "dlc",
+		MaxBytes: 2 * 1024 * 1024 * 1024,
+	})
+	require_NoError(t, err)
+
+	if si.Cluster.Name != pcn {
+		t.Fatalf("Expected to be placed in our origin cluster %q, but got %q", pcn, si.Cluster.Name)
+	}
+}
+
+func TestJetStreamClusterConcurrentOverflow(t *testing.T) {
+	sc := createJetStreamSuperClusterWithTemplate(t, jsClusterMaxBytesTempl, 3, 3)
+	defer sc.shutdown()
+
+	pcn := "C2"
+
+	startCh := make(chan bool)
+	var wg sync.WaitGroup
+	var swg sync.WaitGroup
+
+	start := func(name string) {
+		wg.Add(1)
+		defer wg.Done()
+
+		s := sc.clusterForName(pcn).randomServer()
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		swg.Done()
+		<-startCh
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     name,
+			Replicas: 3,
+			MaxBytes: 2 * 1024 * 1024 * 1024,
+		})
+		require_NoError(t, err)
+	}
+
+	swg.Add(2)
+	go start("foo")
+	go start("bar")
+	swg.Wait()
+	// Now start both at same time.
+	close(startCh)
+	wg.Wait()
+}
+
+func TestJetStreamClusterBalancedPlacement(t *testing.T) {
+	c := createJetStreamClusterWithTemplate(t, jsClusterMaxBytesTempl, "CB", 5)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// We have 10GB (2GB X 5) available.
+	// Use MaxBytes for ease of test (used works too) and place 5 1GB streams with R=2.
+	for i := 1; i <= 5; i++ {
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     fmt.Sprintf("S-%d", i),
+			Replicas: 2,
+			MaxBytes: 1 * 1024 * 1024 * 1024,
+		})
+		require_NoError(t, err)
+	}
+	// Make sure the next one fails properly.
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "FAIL",
+		Replicas: 2,
+		MaxBytes: 1 * 1024 * 1024 * 1024,
+	})
+	require_Error(t, err, NewJSInsufficientResourcesError(), NewJSStorageResourcesExceededError())
+}
+
 // Support functions
 
 // Used to setup superclusters for tests.
@@ -9827,6 +9962,36 @@ var jsClusterTempl = `
 
 	# For access to system account.
 	accounts { $SYS { users = [ { user: "admin", pass: "s3cr3t!" } ] } }
+`
+
+var jsClusterMaxBytesTempl = `
+	listen: 127.0.0.1:-1
+	server_name: %s
+	jetstream: {max_mem_store: 256MB, max_file_store: 2GB, store_dir: "%s"}
+
+	leaf {
+		listen: 127.0.0.1:-1
+	}
+
+	cluster {
+		name: %s
+		listen: 127.0.0.1:%d
+		routes = [%s]
+	}
+
+	no_auth_user: u
+
+	accounts {
+		$U {
+			users = [ { user: "u", pass: "p" } ]
+			jetstream: {
+				max_mem:   128MB
+				max_file:  8GB
+				max_bytes: true // Forces streams to indicate max_bytes.
+			}
+		}
+		$SYS { users = [ { user: "admin", pass: "s3cr3t!" } ] }
+	}
 `
 
 var jsSuperClusterTempl = `
@@ -10733,10 +10898,10 @@ func (c *cluster) waitOnLeader() {
 	expires := time.Now().Add(40 * time.Second)
 	for time.Now().Before(expires) {
 		if leader := c.leader(); leader != nil {
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(250 * time.Millisecond)
 			return
 		}
-		time.Sleep(25 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	c.t.Fatalf("Expected a cluster leader, got none")
@@ -10751,7 +10916,7 @@ func (c *cluster) waitOnClusterReady() {
 func (c *cluster) waitOnClusterReadyWithNumPeers(numPeersExpected int) {
 	c.t.Helper()
 	var leader *Server
-	expires := time.Now().Add(20 * time.Second)
+	expires := time.Now().Add(40 * time.Second)
 	for time.Now().Before(expires) {
 		if leader = c.leader(); leader != nil {
 			break
@@ -10761,10 +10926,10 @@ func (c *cluster) waitOnClusterReadyWithNumPeers(numPeersExpected int) {
 	// Now make sure we have all peers.
 	for leader != nil && time.Now().Before(expires) {
 		if len(leader.JetStreamClusterPeers()) == numPeersExpected {
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(250 * time.Millisecond)
 			return
 		}
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	peersSeen := len(leader.JetStreamClusterPeers())

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -263,6 +263,9 @@ const (
 	// JSStreamLimitsErrF General stream limits exceeded error string ({err})
 	JSStreamLimitsErrF ErrorIdentifier = 10053
 
+	// JSStreamMaxBytesRequired account requires a stream config to have max bytes set
+	JSStreamMaxBytesRequired ErrorIdentifier = 10113
+
 	// JSStreamMessageExceedsMaximumErr message size exceeds maximum allowed
 	JSStreamMessageExceedsMaximumErr ErrorIdentifier = 10054
 
@@ -427,6 +430,7 @@ var (
 		JSStreamInvalidErr:                         {Code: 500, ErrCode: 10096, Description: "stream not valid"},
 		JSStreamInvalidExternalDeliverySubjErrF:    {Code: 400, ErrCode: 10024, Description: "stream external delivery prefix {prefix} must not contain wildcards"},
 		JSStreamLimitsErrF:                         {Code: 500, ErrCode: 10053, Description: "{err}"},
+		JSStreamMaxBytesRequired:                   {Code: 400, ErrCode: 10113, Description: "account requires a stream config to have max bytes set"},
 		JSStreamMessageExceedsMaximumErr:           {Code: 400, ErrCode: 10054, Description: "message size exceeds maximum allowed"},
 		JSStreamMirrorNotUpdatableErr:              {Code: 400, ErrCode: 10055, Description: "Mirror configuration can not be updated"},
 		JSStreamMismatchErr:                        {Code: 400, ErrCode: 10056, Description: "stream name in subject does not match request"},
@@ -1455,6 +1459,16 @@ func NewJSStreamLimitsError(err error, opts ...ErrorOption) *ApiError {
 		ErrCode:     e.ErrCode,
 		Description: strings.NewReplacer(args...).Replace(e.Description),
 	}
+}
+
+// NewJSStreamMaxBytesRequiredError creates a new JSStreamMaxBytesRequired error: "account requires a stream config to have max bytes set"
+func NewJSStreamMaxBytesRequiredError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSStreamMaxBytesRequired]
 }
 
 // NewJSStreamMessageExceedsMaximumError creates a new JSStreamMessageExceedsMaximumErr error: "message size exceeds maximum allowed"

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2019 The NATS Authors
+// Copyright 2013-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -2417,11 +2417,10 @@ type JSInfo struct {
 	Disabled bool            `json:"disabled,omitempty"`
 	Config   JetStreamConfig `json:"config,omitempty"`
 	JetStreamStats
-	APICalls  int64            `json:"current_api_calls"`
-	Streams   int              `json:"total_streams,omitempty"`
-	Consumers int              `json:"total_consumers,omitempty"`
-	Messages  uint64           `json:"total_messages,omitempty"`
-	Bytes     uint64           `json:"total_message_bytes,omitempty"`
+	Streams   int              `json:"streams"`
+	Consumers int              `json:"consumers"`
+	Messages  uint64           `json:"messages"`
+	Bytes     uint64           `json:"bytes"`
 	Meta      *MetaClusterInfo `json:"meta_cluster,omitempty"`
 
 	// aggregate raft info
@@ -2576,7 +2575,6 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 		accounts = append(accounts, info)
 	}
 	s.js.mu.RUnlock()
-	jsi.APICalls = atomic.LoadInt64(&s.js.apiCalls)
 
 	if mg := s.js.getMetaGroup(); mg != nil {
 		if ci := s.raftNodeToClusterInfo(mg); ci != nil {

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2020 The NATS Authors
+// Copyright 2013-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -4012,6 +4012,7 @@ func TestMonitorJsz(t *testing.T) {
 			}
 			ACC {
 				users [{user: usr, password: pwd}]
+				// In clustered mode, these reservations will not impact any one server.
 				jetstream: {max_store: 4Mb, max_memory: 5Mb}
 			}
 			BCC_TO_HAVE_ONE_EXTRA {
@@ -4086,12 +4087,6 @@ func TestMonitorJsz(t *testing.T) {
 			}
 			if info.Messages != 1 {
 				t.Fatalf("expected one message but got %d", info.Messages)
-			}
-			if info.ReservedStore != 4*1024*1024 {
-				t.Fatalf("expected 4Mb reserved, got %d bytes", info.ReservedStore)
-			}
-			if info.ReservedMemory != 5*1024*1024 {
-				t.Fatalf("expected 5Mb reserved, got %d bytes", info.ReservedStore)
 			}
 		}
 	})
@@ -4205,110 +4200,6 @@ func TestMonitorJsz(t *testing.T) {
 			}
 		}
 	})
-}
-
-func TestMonitorJszAccountReserves(t *testing.T) {
-	readJsInfo := func(url string) *JSInfo {
-		t.Helper()
-		body := readBody(t, url)
-		info := &JSInfo{}
-		err := json.Unmarshal(body, info)
-		require_NoError(t, err)
-		return info
-	}
-	tmpDir := createDir(t, "srv")
-	defer removeDir(t, tmpDir)
-	tmplCfg := `
-		listen: 127.0.0.1:-1
-		http_port: 7501
-		system_account: SYS
-		jetstream: {
-			store_dir: %s
-		}
-		accounts {
-			SYS { users [{user: sys, password: pwd}] }
-			ACC {
-				users [{user: usr, password: pwd}]
-				%s
-			}
-		}`
-
-	conf := createConfFile(t, []byte(fmt.Sprintf(tmplCfg, tmpDir, "jetstream: enabled")))
-	defer removeFile(t, conf)
-	s, _ := RunServerWithConfig(conf)
-	defer s.Shutdown()
-	checkForJSClusterUp(t, s)
-
-	nc := natsConnect(t, fmt.Sprintf("nats://usr:pwd@127.0.0.1:%d", s.opts.Port))
-	defer nc.Close()
-	js, err := nc.JetStream(nats.MaxWait(5 * time.Second))
-	require_NoError(t, err)
-	for _, v := range []struct {
-		subject string
-		storage nats.StorageType
-	}{
-		{"file", nats.FileStorage},
-		{"mem", nats.MemoryStorage}} {
-		_, err = js.AddStream(&nats.StreamConfig{
-			Name:     v.subject,
-			Subjects: []string{v.subject},
-			Replicas: 1,
-			Storage:  v.storage,
-		})
-		require_NoError(t, err)
-		require_NoError(t, nc.Flush())
-	}
-
-	send := func() {
-		for _, subj := range []string{"file", "mem"} {
-			_, err = js.Publish(subj, []byte("hello world "+subj))
-			require_NoError(t, err)
-		}
-		require_NoError(t, nc.Flush())
-	}
-
-	test := func(msgs, reservedMemory, reservedStore uint64, totalIsReserveUsd bool) {
-		t.Helper()
-		info := readJsInfo(fmt.Sprintf("http://127.0.0.1:%d/jsz", s.opts.HTTPPort))
-		if info.Streams != 2 {
-			t.Fatalf("expected stream count to be 1 but got %d", info.Streams)
-		}
-		if info.Messages != msgs {
-			t.Fatalf("expected one message but got %d", info.Messages)
-		}
-		if info.ReservedStore != reservedStore {
-			t.Fatalf("expected %d bytes reserved, got %d bytes", reservedStore, info.ReservedStore)
-		}
-		if info.ReservedMemory != reservedMemory {
-			t.Fatalf("expected %d bytes reserved, got %d bytes", reservedMemory, info.ReservedStore)
-		}
-		if info.Memory == 0 {
-			t.Fatalf("memory expected to be not 0")
-		}
-		if info.Store == 0 {
-			t.Fatalf("store expected to be not 0")
-		}
-		memory, store := uint64(0), uint64(0)
-		if totalIsReserveUsd {
-			memory = info.Memory
-			store = info.Store
-		}
-		if info.ReservedMemoryUsed != memory {
-			t.Fatalf("expected %d bytes reserved memory used, got %d bytes", memory, info.ReservedMemoryUsed)
-		}
-		if info.ReserveStoreUsed != store {
-			t.Fatalf("expected %d bytes reserved store used, got %d bytes", store, info.ReserveStoreUsed)
-		}
-	}
-
-	send()
-	test(2, 0, 0, false)
-	reloadUpdateConfig(t, s, conf, fmt.Sprintf(tmplCfg, tmpDir, "jetstream: {max_mem: 4Mb, max_store: 5Mb}"))
-	test(2, 4*1024*1024, 5*1024*1024, true)
-	send()
-	test(4, 4*1024*1024, 5*1024*1024, true)
-	reloadUpdateConfig(t, s, conf, fmt.Sprintf(tmplCfg, tmpDir, "jetstream: enabled"))
-	test(4, 0, 0, false)
 }
 
 func TestMonitorReloadTLSConfig(t *testing.T) {

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -3164,6 +3164,8 @@ func TestMQTTLeafnodeWithoutJSToClusterWithJSNoSharedSysAcc(t *testing.T) {
 		checkFor(t, 10*time.Second, 50*time.Millisecond, func() error {
 			for _, s := range cluster {
 				if s.JetStreamIsLeader() {
+					// Need to wait for usage updates now to propagate to meta leader.
+					time.Sleep(250 * time.Millisecond)
 					return nil
 				}
 			}
@@ -3180,13 +3182,9 @@ func TestMQTTLeafnodeWithoutJSToClusterWithJSNoSharedSysAcc(t *testing.T) {
 			lno.Accounts = append(lno.Accounts, NewAccount("unused-account"))
 			fallthrough
 		case 1:
-			lno.JsAccDefaultDomain = map[string]string{
-				"$G": "",
-			}
+			lno.JsAccDefaultDomain = map[string]string{"$G": ""}
 		case 2:
-			lno.JsAccDefaultDomain = map[string]string{
-				"$G": o1.JetStreamDomain,
-			}
+			lno.JsAccDefaultDomain = map[string]string{"$G": o1.JetStreamDomain}
 		case 3:
 			// turn off jetstream in $G by adding another account and set mqtt domain option
 			lno.Accounts = append(lno.Accounts, NewAccount("unused-account"))

--- a/server/opts.go
+++ b/server/opts.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The NATS Authors
+// Copyright 2012-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -1601,7 +1601,7 @@ func parseGateway(v interface{}, o *Options, errors *[]error, warnings *[]error)
 	return nil
 }
 
-var dynamicJSAccountLimits = &JetStreamAccountLimits{-1, -1, -1, -1}
+var dynamicJSAccountLimits = &JetStreamAccountLimits{-1, -1, -1, -1, false}
 
 // Parses jetstream account limits for an account. Simple setup with boolen is allowed, and we will
 // use dynamic account limits.
@@ -1626,7 +1626,7 @@ func parseJetStreamForAccount(v interface{}, acc *Account, errors *[]error, warn
 			return &configErr{tk, fmt.Sprintf("Expected 'enabled' or 'disabled' for string value, got '%s'", vv)}
 		}
 	case map[string]interface{}:
-		jsLimits := &JetStreamAccountLimits{-1, -1, -1, -1}
+		jsLimits := &JetStreamAccountLimits{-1, -1, -1, -1, false}
 		for mk, mv := range vv {
 			tk, mv = unwrapValue(mv, &lt)
 			switch strings.ToLower(mk) {
@@ -1654,6 +1654,12 @@ func parseJetStreamForAccount(v interface{}, acc *Account, errors *[]error, warn
 					return &configErr{tk, fmt.Sprintf("Expected a parseable size for %q, got %v", mk, mv)}
 				}
 				jsLimits.MaxConsumers = int(vv)
+			case "max_bytes_required", "max_stream_bytes", "max_bytes":
+				vv, ok := mv.(bool)
+				if !ok {
+					return &configErr{tk, fmt.Sprintf("Expected a parseable bool for %q, got %v", mk, mv)}
+				}
+				jsLimits.MaxBytesRequired = bool(vv)
 			default:
 				if !tk.IsUsedVariable() {
 					err := &unknownConfigFieldErr{

--- a/server/route.go
+++ b/server/route.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2020 The NATS Authors
+// Copyright 2013-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -1422,7 +1422,7 @@ func (s *Server) addRoute(c *client, info *Info) (bool, bool) {
 		s.remotes[id] = c
 		// check to be consistent and future proof. but will be same domain
 		if s.sameDomain(info.Domain) {
-			s.nodeToInfo.Store(c.route.hash, nodeInfo{c.route.remoteName, s.info.Cluster, info.Domain, id, false, info.JetStream})
+			s.nodeToInfo.Store(c.route.hash, nodeInfo{c.route.remoteName, s.info.Cluster, info.Domain, id, nil, nil, false, info.JetStream})
 		}
 		c.mu.Lock()
 		c.route.connectURLs = info.ClientConnectURLs


### PR DESCRIPTION
This allows stream placement to overflow to adjacent clusters.
We also do more balanced placement based on resources (store or mem). We can continue to expand this as well.
We also introduce an account requirement that stream configs contain a MaxBytes value.

We now track account limits and server limits more distinctly, and do not reserver server resources based on account limits themselves.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
