### PR TITLE
[ADDED] Ability to express the max_file_store and max_memory_store as a string (100M, etc..)

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -1691,12 +1691,40 @@ func getInterfaceValue(v interface{}) (int64, error) {
 		return 0, fmt.Errorf("must be int64 or string")
 	}
 
-	i, err := strconv.Atoi(v.(string))
+	num, err := stringStorageSize(v.(string))
 	if err != nil {
-		return 0, fmt.Errorf("must represent an int64")
+		return 0, err
 	}
 
-	return int64(i), nil
+	return int64(num), nil
+}
+
+func stringStorageSize(s string) (int, error) {
+	suffix := strings.ToUpper(s[len(s)-1:])
+	prefix := s[:len(s)-1]
+	var num int
+	var err error
+	switch suffix {
+	case "K":
+		num, err = strconv.Atoi(prefix)
+		num = num * 1024
+	case "M":
+		num, err = strconv.Atoi(prefix)
+		num = num * 1048576
+	case "G":
+		num, err = strconv.Atoi(prefix)
+		num = num * 1073741824
+	case "T":
+		num, err = strconv.Atoi(prefix)
+		num = num * 1099511627776
+	default:
+		return 0, fmt.Errorf("sizes defined as strings must end in K, M, G, T")
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	return num, nil
 }
 
 // Parse enablement of jetstream for a server.

--- a/server/opts.go
+++ b/server/opts.go
@@ -1765,7 +1765,7 @@ func parseJetStream(v interface{}, opts *Options, errors *[]error, warnings *[]e
 				if err != nil {
 					return &configErr{tk, fmt.Sprintf("max_file_store %s", err)}
 				}
-				opts.JetStreamMaxStore, err = getStorageSize(s)
+				opts.JetStreamMaxStore = s
 				opts.maxStoreSet = true
 			case "domain":
 				opts.JetStreamDomain = mv.(string)

--- a/server/opts.go
+++ b/server/opts.go
@@ -1696,31 +1696,22 @@ func getStorageSize(v interface{}) (int64, error) {
 		return 0, nil
 	}
 
-	suffix := strings.ToUpper(s[len(s)-1:])
+	suffix := s[len(s)-1:]
 	prefix := s[:len(s)-1]
-	var num int
-	var err error
-	switch suffix {
-	case "K":
-		num, err = strconv.Atoi(prefix)
-		num = num * 1024
-	case "M":
-		num, err = strconv.Atoi(prefix)
-		num = num * 1024 * 1024
-	case "G":
-		num, err = strconv.Atoi(prefix)
-		num = num * 1024 * 1024 * 1024
-	case "T":
-		num, err = strconv.Atoi(prefix)
-		num = num * 1024 * 1024 * 1024 * 1024
-	default:
-		return 0, fmt.Errorf("sizes defined as strings must end in K, M, G, T")
-	}
+	num, err := strconv.ParseInt(prefix, 10, 64)
 	if err != nil {
 		return 0, err
 	}
 
-	return int64(num), nil
+	suffixMap := map[string]int64{"K": 10, "M": 20, "G": 30, "T": 40}
+
+	mult, ok := suffixMap[suffix]
+	if !ok {
+		return 0, fmt.Errorf("sizes defined as strings must end in K, M, G, T")
+	}
+	num *= 1 << mult
+
+	return num, nil
 }
 
 // Parse enablement of jetstream for a server.

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -3257,7 +3257,7 @@ func TestMaxSubTokens(t *testing.T) {
 	}
 }
 
-func TestStringStoreSize(t *testing.T) {
+func TestGetStorageSize(t *testing.T) {
 	tt := []struct {
 		input string
 		want  int64
@@ -3269,11 +3269,12 @@ func TestStringStoreSize(t *testing.T) {
 		{"1T", 1099511627776, false},
 		{"1L", 0, true},
 		{"TT", 0, true},
+		{"", 0, false},
 	}
 
 	for _, v := range tt {
 		var testErr bool
-		got, err := getInterfaceValue(v.input)
+		got, err := getStorageSize(v.input)
 		if err != nil {
 			testErr = true
 		}

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -3256,3 +3256,31 @@ func TestMaxSubTokens(t *testing.T) {
 		t.Fatal("Did not get the permissions error")
 	}
 }
+
+func TestStringStoreSize(t *testing.T) {
+	tt := []struct {
+		input string
+		want  int64
+		err   bool
+	}{
+		{"1K", 1024, false},
+		{"1M", 1048576, false},
+		{"1G", 1073741824, false},
+		{"1T", 1099511627776, false},
+		{"1L", 0, true},
+		{"TT", 0, true},
+	}
+
+	for _, v := range tt {
+		var testErr bool
+		got, err := getInterfaceValue(v.input)
+		if err != nil {
+			testErr = true
+		}
+
+		if got != v.want || v.err != testErr {
+			t.Errorf("Got: %v, want %v with error: %v", got, v.want, testErr)
+		}
+	}
+
+}


### PR DESCRIPTION
Resolves #2754

### Changes proposed in this pull request:

 - Adds a function to check if max_file_store is a string or int64. Possibly could be reused again.

/cc @nats-io/core
