### PR TITLE
When rebuilding the complete filestore state we need to do this in a go routine.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -3171,7 +3171,9 @@ checkCache:
 			mb.mu.Unlock()
 			var ld *LostStreamData
 			if ld, err = mb.rebuildState(); ld != nil {
-				fs.rebuildState(ld)
+				// We do not know if fs is locked or not at this point.
+				// This should be an exceptional condition so do so in Go routine.
+				go fs.rebuildState(ld)
 			}
 			mb.mu.Lock()
 		}


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
