### PR TITLE
Fixed goreleaser ldflags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
 - main: ./main.go
   binary: nats-server
   ldflags:
-    - -w -X github.com/nats-io/nats-server/server.gitCommit={{.ShortCommit}}
+    - -w -X github.com/nats-io/nats-server/v2/server.gitCommit={{.ShortCommit}}
   env:
     - GO111MODULE=on
     - CGO_ENABLED=0

--- a/server/const.go
+++ b/server/const.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.7.0"
+	VERSION = "2.7.1-beta01"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original


### PR DESCRIPTION
Since we moved to go modules, the path must include the `/v2`.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
