### PR TITLE
Fix race condition in HTTP monitoring shutdown

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2362,7 +2362,6 @@ func (s *Server) startMonitoring(secure bool) error {
 			}
 		}
 		srv.Close()
-		srv.Handler = nil
 		s.mu.Lock()
 		s.httpHandler = nil
 		s.mu.Unlock()


### PR DESCRIPTION
I'm somewhat frequently seeing this data race in the [nats-io/prometheus-nats-exporter](https://github.com/nats-io/prometheus-nats-exporter/runs/4888499652?check_suite_focus=true) CI.
```
=== RUN   TestStreamingServerInfoMetricLabels
==================
WARNING: DATA RACE
Write at 0x00c0001f6010 by goroutine 57:
  github.com/nats-io/nats-server/v2/server.(*Server).startMonitoring.func1()
      C:/Users/runneradmin/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.7.0/server/server.go:2365 +0x98

Previous read at 0x00c0001f6010 by goroutine 118:
  net/http.serverHandler.ServeHTTP()
      C:/hostedtoolcache/windows/go/1.16.13/x64/src/net/http/server.go:2861 +0x49
  net/http.(*conn).serve()
      C:/hostedtoolcache/windows/go/1.16.13/x64/src/net/http/server.go:1933 +0x89d

Goroutine 57 (running) created at:
  github.com/nats-io/nats-server/v2/server.(*Server).startMonitoring()
      C:/Users/runneradmin/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.7.0/server/server.go:2355 +0x1ac4
  github.com/nats-io/nats-server/v2/server.(*Server).StartMonitoring()
      C:/Users/runneradmin/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.7.0/server/server.go:2211 +0xc9
  github.com/nats-io/nats-server/v2/server.(*Server).Start()
      C:/Users/runneradmin/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.7.0/server/server.go:1668 +0xf4b

Goroutine 118 (running) created at:
  net/http.(*Server).Serve()
      C:/hostedtoolcache/windows/go/1.16.13/x64/src/net/http/server.go:2994 +0x644
  github.com/nats-io/nats-server/v2/server.(*Server).startMonitoring.func1()
      C:/Users/runneradmin/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.7.0/server/server.go:2356 +0x5d
==================
Error:     testing.go:1092: race detected during execution of test
--- FAIL: TestStreamingServerInfoMetricLabels (0.39s)
```

There is a race between
write: https://github.com/nats-io/nats-server/blob/main/server/server.go#L2365
```
// srv.Handler is set to http.NewServeMux() a few lines earlier.
srv.Handler = nil
```
read: https://github.com/golang/go/blob/go1.16.13/src/net/http/server.go#L2861
```
handler := sh.srv.Handler
```

This change avoids the race by not writing to `srv.Handler`.