### PR TITLE
Do not require CONNECT when no_auth_user defined, don't complain about password for internal clients.

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -171,16 +171,19 @@ func (p *Permissions) clone() *Permissions {
 // Lock is assumed held.
 func (s *Server) checkAuthforWarnings() {
 	warn := false
-	if s.opts.Password != "" && !isBcrypt(s.opts.Password) {
+	if s.opts.Password != _EMPTY_ && !isBcrypt(s.opts.Password) {
 		warn = true
 	}
 	for _, u := range s.users {
 		// Skip warn if using TLS certs based auth
 		// unless a password has been left in the config.
-		if u.Password == "" && s.opts.TLSMap {
+		if u.Password == _EMPTY_ && s.opts.TLSMap {
 			continue
 		}
-
+		// Check if this is our internal sys client created on the fly.
+		if s.sysAccOnlyNoAuthUser != _EMPTY_ && u.Username == s.sysAccOnlyNoAuthUser {
+			continue
+		}
 		if !isBcrypt(u.Password) {
 			warn = true
 			break
@@ -1142,7 +1145,7 @@ func validateAllowedConnectionTypes(m map[string]struct{}) error {
 }
 
 func validateNoAuthUser(o *Options, noAuthUser string) error {
-	if noAuthUser == "" {
+	if noAuthUser == _EMPTY_ {
 		return nil
 	}
 	if len(o.TrustedOperators) > 0 {

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -282,7 +282,7 @@ func TestNoAuthUserNoConnectProto(t *testing.T) {
 		accounts {
 			A { users [{user: "foo", password: "pwd"}] }
 		}
-		authorization { timeout: 1s }
+		authorization { timeout: 1 }
 		no_auth_user: "foo"
 	`))
 	defer os.Remove(conf)

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -15,11 +15,13 @@ package server
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
@@ -272,4 +274,47 @@ func TestNoAuthUser(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNoAuthUserNoConnectProto(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: "127.0.0.1:-1"
+		accounts {
+			A { users [{user: "foo", password: "pwd"}] }
+		}
+		authorization { timeout: 1s }
+		no_auth_user: "foo"
+	`))
+	defer os.Remove(conf)
+	s, o := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	checkClients := func(n int) {
+		t.Helper()
+		time.Sleep(100 * time.Millisecond)
+		if nc := s.NumClients(); nc != n {
+			t.Fatalf("Expected %d clients, got %d", n, nc)
+		}
+	}
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", o.Host, o.Port))
+	require_NoError(t, err)
+	defer conn.Close()
+	checkClientsCount(t, s, 1)
+
+	// With no auth user we should not require a CONNECT.
+	// Make sure we are good on not sending CONN first.
+	_, err = conn.Write([]byte("PUB foo 2\r\nok\r\n"))
+	require_NoError(t, err)
+	checkClients(1)
+	conn.Close()
+
+	// Now make sure we still do get timed out though.
+	conn, err = net.Dial("tcp", fmt.Sprintf("%s:%d", o.Host, o.Port))
+	require_NoError(t, err)
+	defer conn.Close()
+	checkClientsCount(t, s, 1)
+
+	time.Sleep(1200 * time.Millisecond)
+	checkClientsCount(t, s, 0)
 }

--- a/server/opts.go
+++ b/server/opts.go
@@ -663,7 +663,7 @@ func configureSystemAccount(o *Options, m map[string]interface{}) (retErr error)
 // or was present but set to false.
 func (o *Options) ProcessConfigFile(configFile string) error {
 	o.ConfigFile = configFile
-	if configFile == "" {
+	if configFile == _EMPTY_ {
 		return nil
 	}
 	m, err := conf.ParseFileWithChecks(configFile)
@@ -1018,7 +1018,7 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 				}
 			}
 			// In case "system_account" is defined as well, it takes precedence
-			if o.SystemAccount == "" {
+			if o.SystemAccount == _EMPTY_ {
 				o.SystemAccount = o.TrustedOperators[0].SystemAccount
 			}
 		}

--- a/server/parser.go
+++ b/server/parser.go
@@ -147,8 +147,7 @@ func (c *client) parse(buf []byte) error {
 	// proper CONNECT if needed.
 	authSet := c.awaitingAuth()
 	// Snapshot max control line as well.
-	mcl := c.mcl
-	trace := c.trace
+	s, mcl, trace := c.srv, c.mcl, c.trace
 	c.mu.Unlock()
 
 	// Move to loop instead of range syntax to allow jumping of i
@@ -160,7 +159,24 @@ func (c *client) parse(buf []byte) error {
 			c.op = b
 			if b != 'C' && b != 'c' {
 				if authSet {
-					goto authErr
+					if s == nil {
+						goto authErr
+					}
+					var ok bool
+					// Check here for NoAuthUser. If this is set allow non CONNECT protos as our first.
+					// E.g. telnet proto demos.
+					if noAuthUser := s.getOpts().NoAuthUser; noAuthUser != _EMPTY_ {
+						s.mu.Lock()
+						user, exists := s.users[noAuthUser]
+						s.mu.Unlock()
+						if exists {
+							c.RegisterUser(user)
+							ok = true
+						}
+					}
+					if !ok {
+						goto authErr
+					}
 				}
 				// If the connection is a gateway connection, make sure that
 				// if this is an inbound, it starts with a CONNECT.

--- a/server/parser.go
+++ b/server/parser.go
@@ -171,7 +171,11 @@ func (c *client) parse(buf []byte) error {
 						s.mu.Unlock()
 						if exists {
 							c.RegisterUser(user)
-							ok = true
+							c.mu.Lock()
+							c.clearAuthTimer()
+							c.flags.set(connectReceived)
+							c.mu.Unlock()
+							authSet, ok = false, true
 						}
 					}
 					if !ok {


### PR DESCRIPTION
Resolves #2810 and also allows telnet demo for protocol to demo.nats.io to work again.
 
/cc @nats-io/core
