### PR TITLE
Updates to Pull Consumers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/klauspost/compress v1.13.4
 	github.com/minio/highwayhash v1.0.1
 	github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296
-	github.com/nats-io/nats.go v1.13.1-0.20211122170419-d7c1d78a50fc
+	github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d
 	github.com/nats-io/nkeys v0.3.0
 	github.com/nats-io/nuid v1.0.1
 	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296 h1:vU9tpM3apjYlLL
 github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
 github.com/nats-io/nats.go v1.13.1-0.20211122170419-d7c1d78a50fc h1:SHr4MUUZJ/fAC0uSm2OzWOJYsHpapmR86mpw7q1qPXU=
 github.com/nats-io/nats.go v1.13.1-0.20211122170419-d7c1d78a50fc/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
+github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d h1:GRSmEJutHkdoxKsRypP575IIdoXe7Bm6yHQF6GcDBnA=
+github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=
 github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1580,7 +1580,7 @@ func (o *consumer) checkPendingRequests() {
 	if o.mset == nil || o.outq == nil {
 		return
 	}
-	hdr := []byte("NATS/1.0 409 Request Invalid\r\n\r\n")
+	hdr := []byte("NATS/1.0 409 Leadership Change\r\n\r\n")
 	for reply := range o.prm {
 		o.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
 	}

--- a/server/events.go
+++ b/server/events.go
@@ -1135,6 +1135,7 @@ func (s *Server) remoteServerUpdate(sub *subscription, c *client, _ *Account, su
 	node := string(getHash(si.Name))
 	s.nodeToInfo.Store(node, nodeInfo{
 		si.Name,
+		si.Version,
 		si.Cluster,
 		si.Domain,
 		si.ID,
@@ -1176,7 +1177,7 @@ func (s *Server) processNewServer(si *ServerInfo) {
 		node := string(getHash(si.Name))
 		// Only update if non-existent
 		if _, ok := s.nodeToInfo.Load(node); !ok {
-			s.nodeToInfo.Store(node, nodeInfo{si.Name, si.Cluster, si.Domain, si.ID, nil, nil, false, si.JetStream})
+			s.nodeToInfo.Store(node, nodeInfo{si.Name, si.Version, si.Cluster, si.Domain, si.ID, nil, nil, false, si.JetStream})
 		}
 	}
 	// Announce ourselves..

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -786,7 +786,7 @@ func (s *Server) migrateEphemerals() {
 	js.mu.Unlock()
 
 	// In case we have stale pending requests.
-	hdr := []byte("NATS/1.0 409 Request Invalid\r\n\r\n")
+	hdr := []byte("NATS/1.0 409 Consumer Migration\r\n\r\n")
 
 	// Process the consumers.
 	for _, ca := range consumers {

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -785,12 +785,22 @@ func (s *Server) migrateEphemerals() {
 	}
 	js.mu.Unlock()
 
+	// In case we have stale pending requests.
+	hdr := []byte("NATS/1.0 409 Request Invalid\r\n\r\n")
+
 	// Process the consumers.
 	for _, ca := range consumers {
 		// Locate the consumer itself.
 		if acc, err := s.LookupAccount(ca.Client.Account); err == nil && acc != nil {
 			if mset, err := acc.lookupStream(ca.Stream); err == nil && mset != nil {
 				if o := mset.lookupConsumer(ca.Name); o != nil {
+					if pr := o.pendingRequestReplies(); len(pr) > 0 {
+						o.mu.Lock()
+						for _, reply := range pr {
+							o.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
+						}
+						o.mu.Unlock()
+					}
 					state := o.readStoreState()
 					o.deleteWithoutAdvisory()
 					js.mu.Lock()

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -63,6 +63,7 @@ type Placement struct {
 // Define types of the entry.
 type entryOp uint8
 
+// ONLY ADD TO THE END, DO NOT INSERT IN BETWEEN WILL BREAK SERVER INTEROP.
 const (
 	// Meta ops.
 	assignStreamOp entryOp = iota

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -73,15 +73,18 @@ const (
 	streamMsgOp
 	purgeStreamOp
 	deleteMsgOp
-	// Consumer ops
+	// Consumer ops.
 	updateDeliveredOp
 	updateAcksOp
 	// Compressed consumer assignments.
 	assignCompressedConsumerOp
 	// Filtered Consumer skip.
 	updateSkipOp
-	// Update Stream
+	// Update Stream.
 	updateStreamOp
+	// For updating information on pending pull requests.
+	addPendingRequest
+	removePendingRequest
 )
 
 // raftGroups are controlled by the metagroup controller.
@@ -3142,6 +3145,23 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 					o.sseq = le.Uint64(buf[1:])
 				}
 				o.mu.Unlock()
+			case addPendingRequest:
+				if !o.isLeader() {
+					o.mu.Lock()
+					if o.prm == nil {
+						o.prm = make(map[string]struct{})
+					}
+					o.prm[string(buf[1:])] = struct{}{}
+					o.mu.Unlock()
+				}
+			case removePendingRequest:
+				if !o.isLeader() {
+					o.mu.Lock()
+					if o.prm != nil {
+						delete(o.prm, string(buf[1:]))
+					}
+					o.mu.Unlock()
+				}
 			default:
 				panic(fmt.Sprintf("JetStream Cluster Unknown group entry op type! %v", entryOp(buf[0])))
 			}

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -10049,6 +10049,138 @@ func TestJetStreamClusterPullPerf(t *testing.T) {
 	fmt.Printf("%.0f mb/s\n\n", float64(si.State.Bytes/(1024*1024))/tt.Seconds())
 }
 
+// Test that we get the right signaling when a consumer leader change occurs for any pending requests.
+func TestJetStreamClusterPullConsumerLeaderChange(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "JSC", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Replicas: 3,
+		Subjects: []string{"foo"},
+	})
+	require_NoError(t, err)
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:       "dlc",
+		AckPolicy:     nats.AckExplicitPolicy,
+		FilterSubject: "foo",
+	})
+	require_NoError(t, err)
+
+	rsubj := fmt.Sprintf(JSApiRequestNextT, "TEST", "dlc")
+	sub, err := nc.SubscribeSync("reply")
+	require_NoError(t, err)
+	defer sub.Unsubscribe()
+
+	// Queue up a request that can live for a bit.
+	req := &JSApiConsumerGetNextRequest{Expires: 2 * time.Second}
+	jreq, err := json.Marshal(req)
+	require_NoError(t, err)
+	err = nc.PublishRequest(rsubj, "reply", jreq)
+	require_NoError(t, err)
+	// Make sure request is recorded and replicated.
+	time.Sleep(100 * time.Millisecond)
+	checkSubsPending(t, sub, 0)
+
+	// Now have consumer leader change and make sure we get signaled that our request is not valid.
+	_, err = nc.Request(fmt.Sprintf(JSApiConsumerLeaderStepDownT, "TEST", "dlc"), nil, time.Second)
+	require_NoError(t, err)
+	c.waitOnConsumerLeader("$G", "TEST", "dlc")
+	checkSubsPending(t, sub, 1)
+	m, err := sub.NextMsg(0)
+	require_NoError(t, err)
+	// Make sure this is an alert that tells us our request is no longer valid.
+	if m.Header.Get("Status") != "409" {
+		t.Fatalf("Expected a 409 status code, got %q", m.Header.Get("Status"))
+	}
+
+	// Add a few messages to the stream to fulfill a request.
+	for i := 0; i < 10; i++ {
+		_, err := js.Publish("foo", []byte("HELLO"))
+		require_NoError(t, err)
+	}
+	req = &JSApiConsumerGetNextRequest{Batch: 10, Expires: 10 * time.Second}
+	jreq, err = json.Marshal(req)
+	require_NoError(t, err)
+	err = nc.PublishRequest(rsubj, "reply", jreq)
+	require_NoError(t, err)
+	checkSubsPending(t, sub, 10)
+	// Drain this sub.
+	for _, err := sub.NextMsg(0); err == nil; _, err = sub.NextMsg(0) {
+	}
+	// Now do a leader change again, make sure we do not get anything about that request.
+	_, err = nc.Request(fmt.Sprintf(JSApiConsumerLeaderStepDownT, "TEST", "dlc"), nil, time.Second)
+	require_NoError(t, err)
+	c.waitOnConsumerLeader("$G", "TEST", "dlc")
+	checkSubsPending(t, sub, 0)
+
+	// Make sure we do not get anything if we expire, etc.
+	req = &JSApiConsumerGetNextRequest{Batch: 10, Expires: 250 * time.Millisecond}
+	jreq, err = json.Marshal(req)
+	require_NoError(t, err)
+	err = nc.PublishRequest(rsubj, "reply", jreq)
+	require_NoError(t, err)
+	// Let it expire.
+	time.Sleep(300 * time.Millisecond)
+	checkSubsPending(t, sub, 1)
+
+	// Now do a leader change again, make sure we do not get anything about that request.
+	_, err = nc.Request(fmt.Sprintf(JSApiConsumerLeaderStepDownT, "TEST", "dlc"), nil, time.Second)
+	require_NoError(t, err)
+	c.waitOnConsumerLeader("$G", "TEST", "dlc")
+	checkSubsPending(t, sub, 1)
+}
+
+func TestJetStreamClusterEphemeralPullConsumerServerShutdown(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "JSC", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Replicas: 2,
+		Subjects: []string{"foo"},
+	})
+	require_NoError(t, err)
+
+	ci, err := js.AddConsumer("TEST", &nats.ConsumerConfig{
+		AckPolicy:     nats.AckExplicitPolicy,
+		FilterSubject: "foo",
+	})
+	require_NoError(t, err)
+
+	rsubj := fmt.Sprintf(JSApiRequestNextT, "TEST", ci.Name)
+	sub, err := nc.SubscribeSync("reply")
+	require_NoError(t, err)
+	defer sub.Unsubscribe()
+
+	// Queue up a request that can live for a bit.
+	req := &JSApiConsumerGetNextRequest{Expires: 2 * time.Second}
+	jreq, err := json.Marshal(req)
+	require_NoError(t, err)
+	err = nc.PublishRequest(rsubj, "reply", jreq)
+	require_NoError(t, err)
+	// Make sure request is recorded and replicated.
+	time.Sleep(100 * time.Millisecond)
+	checkSubsPending(t, sub, 0)
+
+	// Now shutdown the server where this ephemeral lives.
+	c.consumerLeader("$G", "TEST", ci.Name).Shutdown()
+	checkSubsPending(t, sub, 1)
+	m, err := sub.NextMsg(0)
+	require_NoError(t, err)
+	// Make sure this is an alert that tells us our request is no longer valid.
+	if m.Header.Get("Status") != "409" {
+		t.Fatalf("Expected a 409 status code, got %q", m.Header.Get("Status"))
+	}
+}
+
 // Support functions
 
 // Used to setup superclusters for tests.

--- a/server/route.go
+++ b/server/route.go
@@ -1422,7 +1422,8 @@ func (s *Server) addRoute(c *client, info *Info) (bool, bool) {
 		s.remotes[id] = c
 		// check to be consistent and future proof. but will be same domain
 		if s.sameDomain(info.Domain) {
-			s.nodeToInfo.Store(c.route.hash, nodeInfo{c.route.remoteName, s.info.Cluster, info.Domain, id, nil, nil, false, info.JetStream})
+			s.nodeToInfo.Store(c.route.hash,
+				nodeInfo{c.route.remoteName, s.info.Version, s.info.Cluster, info.Domain, id, nil, nil, false, info.JetStream})
 		}
 		c.mu.Lock()
 		c.route.connectURLs = info.ClientConnectURLs

--- a/server/server.go
+++ b/server/server.go
@@ -283,6 +283,7 @@ type srvIPQueueLogger struct {
 // For tracking JS nodes.
 type nodeInfo struct {
 	name    string
+	version string
 	cluster string
 	domain  string
 	id      string
@@ -407,6 +408,7 @@ func NewServer(opts *Options) (*Server, error) {
 		ourNode := string(getHash(serverName))
 		s.nodeToInfo.Store(ourNode, nodeInfo{
 			serverName,
+			VERSION,
 			opts.Cluster.Name,
 			opts.JetStreamDomain,
 			info.ID,
@@ -527,6 +529,39 @@ func NewServer(opts *Options) (*Server, error) {
 	s.handleSignals()
 
 	return s, nil
+}
+
+var semVerRe = regexp.MustCompile(`\Av?([0-9]+)\.?([0-9]+)?\.?([0-9]+)?`)
+
+func versionComponents(version string) (major, minor, patch int, err error) {
+	m := semVerRe.FindStringSubmatch(version)
+	if m == nil {
+		return 0, 0, 0, errors.New("invalid semver")
+	}
+	major, err = strconv.Atoi(m[1])
+	if err != nil {
+		return -1, -1, -1, err
+	}
+	minor, err = strconv.Atoi(m[2])
+	if err != nil {
+		return -1, -1, -1, err
+	}
+	patch, err = strconv.Atoi(m[3])
+	if err != nil {
+		return -1, -1, -1, err
+	}
+	return major, minor, patch, err
+}
+
+func versionAtLeast(version string, emajor, eminor, epatch int) bool {
+	major, minor, patch, err := versionComponents(version)
+	if err != nil {
+		return false
+	}
+	if major < emajor || minor < eminor || patch < epatch {
+		return false
+	}
+	return true
 }
 
 func (s *Server) logRejectedTLSConns() {


### PR DESCRIPTION
This change fixes a break in behavior for one-shot pull batch requests and formalizes pull requests and their associated behaviors. We also now can expire out of order and we will expire on a leader change for the consumer as that state is shared for pending requests between leaders and followers, only if >= 2.7.1

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
