### PR TITLE
Added in /healthz endpoint.

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -10383,6 +10383,7 @@ func (sc *supercluster) randomServer() *Server {
 
 var jsClusterAccountsTempl = `
 	listen: 127.0.0.1:-1
+
 	server_name: %s
 	jetstream: {max_mem_store: 256MB, max_file_store: 2GB, store_dir: "%s"}
 


### PR DESCRIPTION
Used for health and liveness probes for environments like k8s.

Currently this code returns a 200 and `{ "status": "ok" }` iff all configured ports are open
and if JetStream is configured and we have contact with the meta leader and its current and all streams are up to date.

If we are not current we return a 503 at first error and a `{ "status": "unavailable", "error": "DESCRIPTION" }` body.

We can do much more but this feels like a decent start to test with upgrading servers in a k8s environment that is running JetStream.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
