### PR TITLE
Fix jwt based user/activation token revocation and granularity

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/minio/highwayhash v1.0.1 h1:dZ6IIu8Z14VlC0VpfKofAhCy74wu/Qb5gcn52yWoz
 github.com/minio/highwayhash v1.0.1/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296 h1:vU9tpM3apjYlLLeY23zRWJ9Zktr5jp+mloR942LEOpY=
 github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
-github.com/nats-io/nats.go v1.13.1-0.20211122170419-d7c1d78a50fc h1:SHr4MUUZJ/fAC0uSm2OzWOJYsHpapmR86mpw7q1qPXU=
-github.com/nats-io/nats.go v1.13.1-0.20211122170419-d7c1d78a50fc/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d h1:GRSmEJutHkdoxKsRypP575IIdoXe7Bm6yHQF6GcDBnA=
 github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2261,6 +2261,9 @@ func (s *Server) accountInfo(accName string) (*AccountInfo, error) {
 		}
 	}
 	collectRevocations := func(revocations map[string]int64) map[string]time.Time {
+		if len(revocations) == 0 {
+			return nil
+		}
 		rev := map[string]time.Time{}
 		for k, v := range a.usersRevoked {
 			rev[k] = time.Unix(v, 0)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2261,11 +2261,12 @@ func (s *Server) accountInfo(accName string) (*AccountInfo, error) {
 		}
 	}
 	collectRevocations := func(revocations map[string]int64) map[string]time.Time {
-		if len(revocations) == 0 {
+		l := len(revocations)
+		if l == 0 {
 			return nil
 		}
-		rev := map[string]time.Time{}
-		for k, v := range a.usersRevoked {
+		rev := make(map[string]time.Time, l)
+		for k, v := range revocations {
 			rev[k] = time.Unix(v, 0)
 		}
 		return rev


### PR DESCRIPTION

user and activation token did not honor the jwt value for all * on
connect.

activation token where not re evaluated when the export revoked a key.
In part this is a consistency measure so servers that already have an
account and servers that don't behave the same way.

in jwt activation token revocations are stored per export.
The server stored them per account, thus effectively merging
revocations. Now they are stored per export inside the server too.

fixes nats-io/nsc/issues/442

Signed-off-by: Matthias Hanel <mh@synadia.com>

