### PR TITLE
Nightly: set Go version to 1.17 and use latest goreleaser

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -23,12 +23,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.160.0
+          version: latest
           args: release --snapshot --config .goreleaser-nightly.yml
 
       - name: images


### PR DESCRIPTION
[ci skip]

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
