### PR TITLE
Store JetStream Config in node info map

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -685,6 +685,7 @@ func (s *Server) sendStatsz(subj string) {
 		if v, ok := s.nodeToInfo.Load(ourNode); ok && v != nil {
 			ni := v.(nodeInfo)
 			ni.stats = jStat.Stats
+			ni.cfg = jStat.Config
 			s.nodeToInfo.Store(ourNode, ni)
 		}
 		// Metagroup info.


### PR DESCRIPTION
Currently, we don't update the JetStream configuration in `Server.nodeToInfo`. This can cause a problem if the user doesn't explicitly configure JetStream `MaxStore` or `MaxMem`. It's a problem because some code expects `MaxStore=-1` to be resolved to a real non-negative amount of bytes. Specifically, this check fails: https://github.com/nats-io/nats-server/blob/main/server/jetstream_cluster.go#L3683

This is what the call stack looks like.

* `jetStreamCluster.selectPeerGroup` - returns nil because `ni.cfg.MaxStore > int64(used)` is false because `MaxStore=-1`
* `jetStream.createGroupForStream` - returns nil because `selectPeerGroup` returned nil
* `Server.jsClusteredStreamRequest` - returns "insufficient resources"

The included test fails to `js.AddStream` with the error "insufficient resources" on the main branch, but passes on this branch.