### PR TITLE
FIXES #2828. 

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1294,6 +1294,13 @@ func (o *consumer) updateConfig(cfg *ConsumerConfig) error {
 		return err
 	}
 
+	if o.store != nil {
+		// Update local state always.
+		if err := o.store.UpdateConfig(cfg); err != nil {
+			return err
+		}
+	}
+
 	// DeliverSubject
 	if cfg.DeliverSubject != o.cfg.DeliverSubject {
 		o.updateDeliverSubjectLocked(cfg.DeliverSubject)

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5074,6 +5074,17 @@ func encodeConsumerState(state *ConsumerState) []byte {
 	return buf[:n]
 }
 
+func (o *consumerFileStore) UpdateConfig(cfg *ConsumerConfig) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	// This is mostly unchecked here. We are assuming the upper layers have done sanity checking.
+	csi := o.cfg
+	csi.ConsumerConfig = *cfg
+
+	return o.writeConsumerMeta()
+}
+
 func (o *consumerFileStore) Update(state *ConsumerState) error {
 	// Sanity checks.
 	if state.AckFloor.Consumer > state.Delivered.Consumer {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -823,11 +823,10 @@ func (ms *memStore) Snapshot(_ time.Duration, _, _ bool) (*SnapshotResult, error
 }
 
 // No-ops.
-func (os *consumerMemStore) Update(_ *ConsumerState) error { return nil }
-
+func (os *consumerMemStore) Update(_ *ConsumerState) error                 { return nil }
 func (os *consumerMemStore) UpdateDelivered(_, _, _ uint64, _ int64) error { return nil }
-
-func (os *consumerMemStore) UpdateAcks(_, _ uint64) error { return nil }
+func (os *consumerMemStore) UpdateAcks(_, _ uint64) error                  { return nil }
+func (os *consumerMemStore) UpdateConfig(_ *ConsumerConfig) error          { return nil }
 
 func (os *consumerMemStore) Stop() error {
 	os.ms.decConsumers()

--- a/server/store.go
+++ b/server/store.go
@@ -154,6 +154,7 @@ type SnapshotResult struct {
 type ConsumerStore interface {
 	UpdateDelivered(dseq, sseq, dc uint64, ts int64) error
 	UpdateAcks(dseq, sseq uint64) error
+	UpdateConfig(cfg *ConsumerConfig) error
 	Update(*ConsumerState) error
 	State() (*ConsumerState, error)
 	Type() StorageType


### PR DESCRIPTION
The original design of the consumer and the subsequent storage layer did not allow for config updates.
Now that we do, we need to store the new config into our storage layer.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
