### PR TITLE
A true no wait pull request was not considering redeliveries.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2374,7 +2374,7 @@ func (o *consumer) processNextMsgReq(_ *subscription, c *client, _ *Account, _, 
 
 	// If the request is for noWait and we have pending requests already, check if we have room.
 	if noWait {
-		msgsPending := o.adjustedPending()
+		msgsPending := o.adjustedPending() + uint64(len(o.rdq))
 		// If no pending at all, decide what to do with request.
 		// If no expires was set then fail.
 		if msgsPending == 0 && expires.IsZero() {

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4900,9 +4900,8 @@ func (o *consumerFileStore) UpdateDelivered(dseq, sseq, dc uint64, ts int64) err
 			if p = o.state.Pending[sseq]; p != nil {
 				p.Sequence, p.Timestamp = dseq, ts
 			}
-		}
-		// Add to pending if needed.
-		if p == nil {
+		} else {
+			// Add to pending.
 			o.state.Pending[sseq] = &Pending{dseq, ts}
 		}
 		// Update delivered as needed.


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
