### PR TITLE
Added in ability to get per subject details via StreamInfo.

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -1148,5 +1148,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSStreamInfoMaxSubjectsErr",
+    "code": 500,
+    "error_code": 10117,
+    "description": "subject details would exceed maximum allowed",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -260,6 +260,9 @@ const (
 	// JSStreamHeaderExceedsMaximumErr header size exceeds maximum allowed of 64k
 	JSStreamHeaderExceedsMaximumErr ErrorIdentifier = 10097
 
+	// JSStreamInfoMaxSubjectsErr subject details would exceed maximum allowed
+	JSStreamInfoMaxSubjectsErr ErrorIdentifier = 10117
+
 	// JSStreamInvalidConfigF Stream configuration validation error string ({err})
 	JSStreamInvalidConfigF ErrorIdentifier = 10052
 
@@ -438,6 +441,7 @@ var (
 		JSStreamExternalDelPrefixOverlapsErrF:      {Code: 400, ErrCode: 10022, Description: "stream external delivery prefix {prefix} overlaps with stream subject {subject}"},
 		JSStreamGeneralErrorF:                      {Code: 500, ErrCode: 10051, Description: "{err}"},
 		JSStreamHeaderExceedsMaximumErr:            {Code: 400, ErrCode: 10097, Description: "header size exceeds maximum allowed of 64k"},
+		JSStreamInfoMaxSubjectsErr:                 {Code: 500, ErrCode: 10117, Description: "subject details would exceed maximum allowed"},
 		JSStreamInvalidConfigF:                     {Code: 500, ErrCode: 10052, Description: "{err}"},
 		JSStreamInvalidErr:                         {Code: 500, ErrCode: 10096, Description: "stream not valid"},
 		JSStreamInvalidExternalDeliverySubjErrF:    {Code: 400, ErrCode: 10024, Description: "stream external delivery prefix {prefix} must not contain wildcards"},
@@ -1443,6 +1447,16 @@ func NewJSStreamHeaderExceedsMaximumError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSStreamHeaderExceedsMaximumErr]
+}
+
+// NewJSStreamInfoMaxSubjectsError creates a new JSStreamInfoMaxSubjectsErr error: "subject details would exceed maximum allowed"
+func NewJSStreamInfoMaxSubjectsError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSStreamInfoMaxSubjectsErr]
 }
 
 // NewJSStreamInvalidConfigError creates a new JSStreamInvalidConfigF error: "{err}"

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -754,6 +754,7 @@ func (ms *memStore) FastState(state *StreamState) {
 		state.NumDeleted = int((state.LastSeq - state.FirstSeq) - state.Msgs + 1)
 	}
 	state.Consumers = ms.consumers
+	state.NumSubjects = len(ms.fss)
 	ms.mu.RUnlock()
 }
 
@@ -763,6 +764,7 @@ func (ms *memStore) State() StreamState {
 
 	state := ms.state
 	state.Consumers = ms.consumers
+	state.NumSubjects = len(ms.fss)
 	state.Deleted = nil
 
 	// Calculate interior delete details.

--- a/server/store.go
+++ b/server/store.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The NATS Authors
+// Copyright 2019-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -119,17 +119,18 @@ const (
 
 // StreamState is information about the given stream.
 type StreamState struct {
-	Msgs       uint64            `json:"messages"`
-	Bytes      uint64            `json:"bytes"`
-	FirstSeq   uint64            `json:"first_seq"`
-	FirstTime  time.Time         `json:"first_ts"`
-	LastSeq    uint64            `json:"last_seq"`
-	LastTime   time.Time         `json:"last_ts"`
-	Subjects   map[string]uint64 `json:"subjects,omitempty"`
-	NumDeleted int               `json:"num_deleted,omitempty"`
-	Deleted    []uint64          `json:"deleted,omitempty"`
-	Lost       *LostStreamData   `json:"lost,omitempty"`
-	Consumers  int               `json:"consumer_count"`
+	Msgs        uint64            `json:"messages"`
+	Bytes       uint64            `json:"bytes"`
+	FirstSeq    uint64            `json:"first_seq"`
+	FirstTime   time.Time         `json:"first_ts"`
+	LastSeq     uint64            `json:"last_seq"`
+	LastTime    time.Time         `json:"last_ts"`
+	NumSubjects int               `json:"num_subjects,omitempty"`
+	Subjects    map[string]uint64 `json:"subjects,omitempty"`
+	NumDeleted  int               `json:"num_deleted,omitempty"`
+	Deleted     []uint64          `json:"deleted,omitempty"`
+	Lost        *LostStreamData   `json:"lost,omitempty"`
+	Consumers   int               `json:"consumer_count"`
 }
 
 // SimpleState for filtered subject specific state.

--- a/server/store.go
+++ b/server/store.go
@@ -119,16 +119,17 @@ const (
 
 // StreamState is information about the given stream.
 type StreamState struct {
-	Msgs       uint64          `json:"messages"`
-	Bytes      uint64          `json:"bytes"`
-	FirstSeq   uint64          `json:"first_seq"`
-	FirstTime  time.Time       `json:"first_ts"`
-	LastSeq    uint64          `json:"last_seq"`
-	LastTime   time.Time       `json:"last_ts"`
-	NumDeleted int             `json:"num_deleted,omitempty"`
-	Deleted    []uint64        `json:"deleted,omitempty"`
-	Lost       *LostStreamData `json:"lost,omitempty"`
-	Consumers  int             `json:"consumer_count"`
+	Msgs       uint64            `json:"messages"`
+	Bytes      uint64            `json:"bytes"`
+	FirstSeq   uint64            `json:"first_seq"`
+	FirstTime  time.Time         `json:"first_ts"`
+	LastSeq    uint64            `json:"last_seq"`
+	LastTime   time.Time         `json:"last_ts"`
+	Subjects   map[string]uint64 `json:"subjects,omitempty"`
+	NumDeleted int               `json:"num_deleted,omitempty"`
+	Deleted    []uint64          `json:"deleted,omitempty"`
+	Lost       *LostStreamData   `json:"lost,omitempty"`
+	Consumers  int               `json:"consumer_count"`
 }
 
 // SimpleState for filtered subject specific state.


### PR DESCRIPTION
Note that we went with a simpler approach vs message per result or a paged api. We will place the subject details (just msg count) into the stream info state. Since NATS as a system can limit payloads of any msg entering the system, but the system itself can send any size message to any client, we allow this to proceed. We artificially limit it to 100k, and for items like KV we can fall back to the watcher/ordered consumer pattern as needed.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
