### PR TITLE
[FIXED] JetStream: BackOff redeliveries would always use first in list

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3130,7 +3130,7 @@ func (o *consumer) checkPending() {
 		}
 		elapsed, deadline := now-p.Timestamp, ttl
 		if len(o.cfg.BackOff) > 0 && o.rdc != nil {
-			dc := int(o.rdc[p.Sequence])
+			dc := int(o.rdc[seq])
 			if dc >= len(o.cfg.BackOff) {
 				dc = len(o.cfg.BackOff) - 1
 			}


### PR DESCRIPTION
If the consumer's sequence was not the same than the stream's sequence,
then the redelivery would always use the first duration from the
BackOff list.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
