### PR TITLE
Consumer pending gets stuck.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1115,7 +1115,7 @@ func (mb *msgBlock) filteredPendingLocked(subj string, wc bool, seq uint64) (tot
 	for i, subj := range subs {
 		// If the starting seq is less then or equal that means we want all and we do not need to load any messages.
 		ss := mb.fss[subj]
-		if ss == nil {
+		if ss == nil || seq > ss.Last {
 			continue
 		}
 


### PR DESCRIPTION
Under certain scenarios the pending for a consumer could appear to get stuck.

Under the covers we were calculating pending per msg block incorrectly when a single message existed beyond the requested sequence.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
