### PR TITLE
Fix flapping test - TestNoRaceJetStreamClusterCorruptWAL

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -3459,7 +3459,9 @@ func TestNoRaceJetStreamClusterCorruptWAL(t *testing.T) {
 	}
 
 	// This will cause us to stepdown and truncate our WAL.
-	fetchMsgs(t, sub, 100, 5*time.Second)
+	if _, err = sub.Fetch(100); err != nil {
+		t.Fatal(err)
+	}
 
 	checkFor(t, 20*time.Second, 500*time.Millisecond, func() error {
 		// Make sure we changed leaders.


### PR DESCRIPTION
This test was using fetch and failing if the complete batch was not filled.
This has nothing to do with the test, we just want to make sure the leader steps down and there were no low level errors on the fetch.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
