### PR TITLE
FIXED #2836

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -2923,10 +2923,10 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		if numConsumers == 0 {
 			noInterest = true
 		} else if mset.numFilter > 0 {
-			// Assume none.
+			// Assume no interest and check to disqualify.
 			noInterest = true
 			for _, o := range mset.consumers {
-				if o.cfg.FilterSubject != _EMPTY_ && subjectIsSubsetMatch(subject, o.cfg.FilterSubject) {
+				if o.cfg.FilterSubject == _EMPTY_ || subjectIsSubsetMatch(subject, o.cfg.FilterSubject) {
 					noInterest = false
 					break
 				}


### PR DESCRIPTION
When a consumer had no filtered subject and was attached to an interest policy retention stream we could incorrectly drop messages.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
