### PR TITLE
Improved sparse consumers replay time.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2521,7 +2521,7 @@ func (o *consumer) getNextMsg() (subj string, hdr, msg []byte, sseq uint64, dc u
 	// Grab next message applicable to us.
 	subj, sseq, hdr, msg, ts, err = o.mset.store.LoadNextMsg(o.cfg.FilterSubject, o.filterWC, seq)
 
-	if sseq > 0 {
+	if sseq >= o.sseq {
 		o.sseq = sseq + 1
 		if err == ErrStoreEOF {
 			o.updateSkipped()

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1085,6 +1085,65 @@ func (fs *fileStore) GetSeqFromTime(t time.Time) uint64 {
 	return 0
 }
 
+// Find the first matching message.
+func (mb *msgBlock) firstMatching(filter string, wc bool, start uint64) (*fileStoredMsg, bool, error) {
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	isAll, subs := filter == _EMPTY_ || filter == fwcs, []string{filter}
+	// If we have a wildcard match against all tracked subjects we know about.
+	if wc || isAll {
+		subs = subs[:0]
+		for subj := range mb.fss {
+			if isAll || subjectIsSubsetMatch(subj, filter) {
+				subs = append(subs, subj)
+			}
+		}
+	}
+	fseq := mb.last.seq + 1
+	for _, subj := range subs {
+		ss := mb.fss[subj]
+		if ss == nil || start > ss.Last || ss.First >= fseq {
+			continue
+		}
+		if ss.First < start {
+			fseq = start
+		} else {
+			fseq = ss.First
+		}
+	}
+	if fseq > mb.last.seq {
+		return nil, false, ErrStoreMsgNotFound
+	}
+
+	if mb.cacheNotLoaded() {
+		if err := mb.loadMsgsWithLock(); err != nil {
+			return nil, false, err
+		}
+	}
+
+	for seq := fseq; seq <= mb.last.seq; seq++ {
+		llseq := mb.llseq
+		sm, err := mb.cacheLookup(seq)
+		if err != nil {
+			continue
+		}
+		expireOk := seq == mb.last.seq && mb.llseq == seq-1
+		if len(subs) == 1 && sm.subj == subs[0] {
+			return sm, expireOk, nil
+		}
+		for _, subj := range subs {
+			if sm.subj == subj {
+				return sm, expireOk, nil
+			}
+		}
+		// If we are here we did not match, so put the llseq back.
+		mb.llseq = llseq
+	}
+
+	return nil, false, ErrStoreMsgNotFound
+}
+
 // This will traverse a message block and generate the filtered pending.
 func (mb *msgBlock) filteredPending(subj string, wc bool, seq uint64) (total, first, last uint64) {
 	mb.mu.Lock()
@@ -1094,19 +1153,19 @@ func (mb *msgBlock) filteredPending(subj string, wc bool, seq uint64) (total, fi
 
 // This will traverse a message block and generate the filtered pending.
 // Lock should be held.
-func (mb *msgBlock) filteredPendingLocked(subj string, wc bool, seq uint64) (total, first, last uint64) {
+func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, seq uint64) (total, first, last uint64) {
 	if mb.fss == nil {
 		return 0, 0, 0
 	}
 
-	isAll := subj == _EMPTY_ || subj == fwcs
-	subs := []string{subj}
+	isAll := filter == _EMPTY_ || filter == fwcs
+	subs := []string{filter}
 	// If we have a wildcard match against all tracked subjects we know about.
 	if wc || isAll {
 		subs = subs[:0]
-		for fsubj := range mb.fss {
-			if isAll || subjectIsSubsetMatch(fsubj, subj) {
-				subs = append(subs, fsubj)
+		for subj := range mb.fss {
+			if isAll || subjectIsSubsetMatch(subj, filter) {
+				subs = append(subs, subj)
 			}
 		}
 	}
@@ -1155,10 +1214,9 @@ func (mb *msgBlock) filteredPendingLocked(subj string, wc bool, seq uint64) (tot
 			shouldExpire = true
 		}
 
-		subs = subs[i:]
 		var all, lseq uint64
 		// Grab last applicable sequence as a union of all applicable subjects.
-		for _, subj := range subs {
+		for _, subj := range subs[i:] {
 			if ss := mb.fss[subj]; ss != nil {
 				all += ss.Msgs
 				if ss.Last > lseq {
@@ -3481,16 +3539,13 @@ func (fs *fileStore) LoadNextMsg(filter string, wc bool, start uint64) (subj str
 		if start > atomic.LoadUint64(&mb.last.seq) {
 			continue
 		}
-		if _, f, _ := mb.filteredPending(filter, wc, start); f > 0 {
-			// We have some messages here, so just return the first one and we are good.
-			sm, expireOk, err := mb.fetchMsg(f)
-			if err != nil {
-				return _EMPTY_, 0, nil, nil, 0, err
-			}
-			if mb != fs.lmb && expireOk {
+		if sm, expireOk, err := mb.firstMatching(filter, wc, start); err == nil {
+			if expireOk && mb != fs.lmb {
 				mb.tryForceExpireCache()
 			}
-			return sm.subj, f, sm.hdr, sm.msg, sm.ts, nil
+			return sm.subj, sm.seq, sm.hdr, sm.msg, sm.ts, nil
+		} else if err != ErrStoreMsgNotFound {
+			return _EMPTY_, 0, nil, nil, 0, err
 		}
 	}
 

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -7077,6 +7077,7 @@ func TestJetStreamSimpleFileRecovery(t *testing.T) {
 		ostate[msetName] = info{mset.config(), mset.state(), obs}
 	}
 	pusage := acc.JetStreamUsage()
+	nc.Flush()
 
 	// Shutdown and restart and make sure things come back.
 	s.Shutdown()

--- a/server/store.go
+++ b/server/store.go
@@ -72,6 +72,7 @@ type StreamStore interface {
 	SkipMsg() uint64
 	LoadMsg(seq uint64) (subject string, hdr, msg []byte, ts int64, err error)
 	LoadLastMsg(subject string) (subj string, seq uint64, hdr, msg []byte, ts int64, err error)
+	LoadNextMsg(filter string, wc bool, start uint64) (subject string, seq uint64, hdr, msg []byte, ts int64, err error)
 	RemoveMsg(seq uint64) (bool, error)
 	EraseMsg(seq uint64) (bool, error)
 	Purge() (uint64, error)


### PR DESCRIPTION
When a stream has multiple subjects and a consumer filters the stream to a small and spread out list of messages the logic would do a linear scan looking for the next message for the filtered consumer.
This CL allows the store layer to utilize the per subject info to improve the times.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
