### PR TITLE
A stream name is tied to its identity and can not be changed on a restore.

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -2949,25 +2949,17 @@ func TestJetStreamClusterUserSnapshotAndRestoreConfigChanges(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// Change name.
+	// Now change subjects.
 	ncfg := &StreamConfig{
-		Name:     "TEST2",
-		Subjects: []string{"foo"},
+		Name:     "TEST",
+		Subjects: []string{"bar", "baz"},
 		Storage:  FileStorage,
 		Replicas: 2,
 	}
-	if si := restore(ncfg, state, snap); si.Config.Name != "TEST2" {
-		t.Fatalf("Did not get expected stream info: %+v", si)
-	}
-	if err := js.DeleteStream("TEST2"); err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	// Now change subjects.
-	ncfg.Subjects = []string{"bar", "baz"}
 	if si := restore(ncfg, state, snap); !reflect.DeepEqual(si.Config.Subjects, ncfg.Subjects) {
 		t.Fatalf("Did not get expected stream info: %+v", si)
 	}
-	if err := js.DeleteStream("TEST2"); err != nil {
+	if err := js.DeleteStream("TEST"); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	// Storage
@@ -2975,7 +2967,7 @@ func TestJetStreamClusterUserSnapshotAndRestoreConfigChanges(t *testing.T) {
 	if si := restore(ncfg, state, snap); !reflect.DeepEqual(si.Config.Subjects, ncfg.Subjects) {
 		t.Fatalf("Did not get expected stream info: %+v", si)
 	}
-	if err := js.DeleteStream("TEST2"); err != nil {
+	if err := js.DeleteStream("TEST"); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	// Now replicas

--- a/server/stream.go
+++ b/server/stream.go
@@ -3631,6 +3631,11 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 		return nil, err
 	}
 
+	// Check to make sure names match.
+	if fcfg.Name != cfg.Name {
+		return nil, errors.New("stream names do not match")
+	}
+
 	// See if this stream already exists.
 	if _, err := a.lookupStream(cfg.Name); err == nil {
 		return nil, NewJSStreamNameExistError()


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
