### PR TITLE
Make sure we snapshot initial consumer info during consumer creation.

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -3244,7 +3244,7 @@ func (s *Server) jsConsumerCreate(sub *subscription, c *client, a *Account, subj
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
-	resp.ConsumerInfo = o.info()
+	resp.ConsumerInfo = o.initialInfo()
 	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 }
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3292,6 +3292,9 @@ func (js *jetStream) processConsumerLeaderChange(o *consumer, isLeader bool) {
 	}
 
 	if !isLeader || hasResponded {
+		if isLeader {
+			o.clearInitialInfo()
+		}
 		return
 	}
 
@@ -3300,7 +3303,7 @@ func (js *jetStream) processConsumerLeaderChange(o *consumer, isLeader bool) {
 		resp.Error = NewJSConsumerCreateError(err, Unless(err))
 		s.sendAPIErrResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
 	} else {
-		resp.ConsumerInfo = o.info()
+		resp.ConsumerInfo = o.initialInfo()
 		s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
 		if node := o.raftNode(); node != nil {
 			o.sendCreateAdvisory()


### PR DESCRIPTION
In certain circumstances, mostly with direct push based consumers, the consumer info returned by the js.Subscribe() calls could have a consumer info that already reflects delivering some, possibly all the original pending messages.

This change makes the initial pending state correct in those situations.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
