### PR TITLE
Fixed consumer dlv count and num pending wrong due to redeliveries

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2542,7 +2542,7 @@ func (o *consumer) getNextMsg() (subj string, hdr, msg []byte, sseq uint64, dc u
 			}
 		}
 		// Fallback if all redeliveries are gone.
-		seq = o.sseq
+		seq, dc = o.sseq, 1
 	}
 
 	// Check if we have max pending.


### PR DESCRIPTION
Introduced by #2848, so should not have impacted existing releases.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
