### PR TITLE
Adds deterministic bucketing (i.e. 'partitioning') to subject mapping

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -4125,19 +4125,20 @@ type transform struct {
 // Helper to pull raw place holder index. Returns -1 if not a place holder.
 func placeHolderIndex(token string) ([]int, int32) {
 	if len(token) > 1 {
-		var tp int
-		var tphnb int32
+		//var tp int
 		if token[0] == '$' {
-			if n, err := fmt.Sscanf(token, "$%d", &tp); err == nil && n == 1 {
-				return []int{tp}, -1
+
+			bucketingParts := strings.Split(token[1:], "%")
+			if len(bucketingParts) == 1 { // simple non-bucket mapping
+				tp, err := strconv.Atoi(bucketingParts[0])
+				if err == nil {
+					return []int{tp}, -1
+				}
 			}
-		}
-		if token[0] == '#' {
-			colunmSeparatedParts := strings.Split(token[1:], ":")
-			if len(colunmSeparatedParts) == 2 {
-				n, err := fmt.Sscanf(colunmSeparatedParts[1], "%d", &tphnb) // get the number of bucket
-				if err == nil && n == 1 {
-					tokenIndexes := strings.Split(colunmSeparatedParts[0], "+")
+			if len(bucketingParts) == 2 { // mapping to a bucket
+				tphnb, err := strconv.Atoi(bucketingParts[1])
+				if err == nil {
+					tokenIndexes := strings.Split(bucketingParts[0], "+")
 					var numPositions = len(tokenIndexes)
 					tps := make([]int, numPositions)
 					for ti, t := range tokenIndexes {
@@ -4148,10 +4149,12 @@ func placeHolderIndex(token string) ([]int, int32) {
 							return []int{-1}, -1
 						}
 					}
-					return tps, tphnb
+					return tps, int32(tphnb)
 				}
 			}
+
 		}
+
 	}
 	return []int{-1}, -1
 }
@@ -4194,7 +4197,7 @@ func newTransform(src, dest string) (*transform, error) {
 					stis = append(stis, sti[position])
 				}
 				dtpi = append(dtpi, stis)
-				dtpinb = append(dtpinb, int32(nb))
+				dtpinb = append(dtpinb, nb)
 			} else {
 				dtpi = append(dtpi, []int{-1})
 				dtpinb = append(dtpinb, -1)

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -4200,10 +4200,9 @@ func newTransform(src, dest string) (*transform, error) {
 				dtpinb = append(dtpinb, -1)
 			}
 		}
-		// NOTE(JNM) - Not sure why this check was there, nor sure if it is safe to comment out, but it's totally valid to have unequal sizes with the bucket mapping
-		//if nphs != npwcs {
-		//	return nil, ErrBadSubject
-		//}
+		if nphs < npwcs {
+			return nil, ErrBadSubject
+		}
 	}
 
 	return &transform{src: src, dest: dest, dtoks: dtokens, stoks: stokens, dtpi: dtpi, dtpinb: dtpinb}, nil
@@ -4287,9 +4286,6 @@ func (tr *transform) transform(tokens []string) (string, error) {
 				var keyForHashing string
 				for _, sourceToken := range tr.dtpi[i] {
 					keyForHashing = keyForHashing + tokens[sourceToken]
-					// uncomment below for 'repeat the hashed tokens' behavior
-					//b.WriteString(tokens[sourceToken])
-					//b.WriteByte(btsep)
 				}
 				token = tr.getHashBucket(keyForHashing, int(tr.dtpinb[i]))
 			} else { // back to normal substitution


### PR DESCRIPTION
 Add the ability to deterministically map one or more subject tokens to a 'bucket' (or 'partition') number (uses a hashing to map the value of the token(s) to a bucket number. Works everywhere subject mapping is used (i.e. account mappings and account imports).

Mapping syntax: `$<token number(s)>%<number of buckets>`

So `$1%10` maps to the value of the bucket number (i.e. a number between `0` and `9`) for the value of $1.

You can map the values of more than one subject token using `+`, e.g.: mapping `foo.*.* : foo.$1.$2.$1+2%10` means map the combination of $1 and $2 over 10 buckets. This example will translate subject `foo.a.1` to `foo.a.1.5` (bucket number is 5).

- [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)
/cc @nats-io/core
