### PR TITLE
Better startup logging to help debug RAFT to streams/consumers.

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1171,7 +1171,7 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 		}
 
 		state := mset.state()
-		s.Noticef("  Restored %s messages for stream %q", comma(int64(state.Msgs)), fi.Name())
+		s.Noticef("  Restored %s messages for stream '%s > %s'", comma(int64(state.Msgs)), mset.accName(), mset.name())
 
 		// Now do the consumers.
 		odir := path.Join(sdir, fi.Name(), consumerDir)
@@ -1181,7 +1181,7 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 	for _, e := range consumers {
 		ofis, _ := ioutil.ReadDir(e.odir)
 		if len(ofis) > 0 {
-			s.Noticef("  Recovering %d consumers for stream - %q", len(ofis), e.mset.name())
+			s.Noticef("  Recovering %d consumers for stream - '%s > %s'", len(ofis), e.mset.accName(), e.mset.name())
 		}
 		for _, ofi := range ofis {
 			metafile := path.Join(e.odir, ofi.Name(), JetStreamMetaFile)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1476,14 +1476,14 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment) {
 	defer s.grWG.Done()
 
 	if n == nil {
-		s.Warnf("No RAFT group for '%s > %s", sa.Client.serviceAccount(), sa.Config.Name)
+		s.Warnf("No RAFT group for '%s > %s'", sa.Client.serviceAccount(), sa.Config.Name)
 		return
 	}
 
 	qch, lch, aq := n.QuitC(), n.LeadChangeC(), n.ApplyQ()
 
-	s.Debugf("Starting stream monitor for '%s > %s'", sa.Client.serviceAccount(), sa.Config.Name)
-	defer s.Debugf("Exiting stream monitor for '%s > %s'", sa.Client.serviceAccount(), sa.Config.Name)
+	s.Debugf("Starting stream monitor for '%s > %s' [%s]", sa.Client.serviceAccount(), sa.Config.Name, n.Group())
+	defer s.Debugf("Exiting stream monitor for '%s > %s' [%s]", sa.Client.serviceAccount(), sa.Config.Name, n.Group())
 
 	// Make sure we do not leave the apply channel to fill up and block the raft layer.
 	defer func() {
@@ -3038,8 +3038,8 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 
 	qch, lch, aq := n.QuitC(), n.LeadChangeC(), n.ApplyQ()
 
-	s.Debugf("Starting consumer monitor for '%s > %s > %s", o.acc.Name, ca.Stream, ca.Name)
-	defer s.Debugf("Exiting consumer monitor for '%s > %s > %s'", o.acc.Name, ca.Stream, ca.Name)
+	s.Debugf("Starting consumer monitor for '%s > %s > %s' [%s]", o.acc.Name, ca.Stream, ca.Name, n.Group())
+	defer s.Debugf("Exiting consumer monitor for '%s > %s > %s' [%s]", o.acc.Name, ca.Stream, ca.Name, n.Group())
 
 	const (
 		compactInterval = 2 * time.Minute

--- a/server/stream.go
+++ b/server/stream.go
@@ -3140,6 +3140,17 @@ func (mset *stream) setupSendCapabilities() {
 	go mset.internalLoop()
 }
 
+// Returns the associated account name.
+func (mset *stream) accName() string {
+	if mset == nil {
+		return _EMPTY_
+	}
+	mset.mu.RLock()
+	acc := mset.acc
+	mset.mu.RUnlock()
+	return acc.Name
+}
+
 // Name returns the stream name.
 func (mset *stream) name() string {
 	if mset == nil {


### PR DESCRIPTION
In the process of working on #2885 with a user, I was struggling to map $SYS directories to consumer names.

This change allows a bit better logging on startup to more easily map a RAFT log directory etc to the stream/consumer.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
