### PR TITLE
[FIXED] Never used clustered and filtered consumers consume too much disk storage under $SYS

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3066,6 +3066,11 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 					lastSnap = snap
 				}
 			}
+		} else {
+			// If we are here we may have no state but may be processing updates as a filtered consumer.
+			// Make sure the store does not grow too much, so similar to memory logic above, just compact.
+			_, _, applied := n.Progress()
+			n.Compact(applied)
 		}
 	}
 


### PR DESCRIPTION
When a filtered consumer who has no state, meaning no messages are being processed, it still will receive updates to properly track the delivered sequence as it relates to the entire stream.
Since we did not have state we were inadvertently skipping the compaction logic for the raft store.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #2885


/cc @nats-io/core
