### PR TITLE
Can't recover stream on restart with deleted msg error.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4426,6 +4426,10 @@ func (mb *msgBlock) generatePerSubjectInfo() error {
 	for seq := fseq; seq <= lseq; seq++ {
 		sm, err := mb.cacheLookup(seq)
 		if err != nil {
+			// Since we are walking by sequence we can ignore some errors that are benign to rebuilding our state.
+			if err == ErrStoreMsgNotFound || err == errDeletedMsg {
+				continue
+			}
 			return err
 		}
 		if sm != nil && len(sm.subj) > 0 {

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -315,17 +315,17 @@ func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created tim
 	// Always track per subject information.
 	fs.tms = true
 
+	// Recover our message state.
+	if err := fs.recoverMsgs(); err != nil {
+		return nil, err
+	}
+
 	// Write our meta data iff does not exist.
 	meta := path.Join(fcfg.StoreDir, JetStreamMetaFile)
 	if _, err := os.Stat(meta); err != nil && os.IsNotExist(err) {
 		if err := fs.writeStreamMeta(); err != nil {
 			return nil, err
 		}
-	}
-
-	// Recover our message state.
-	if err := fs.recoverMsgs(); err != nil {
-		return nil, err
 	}
 
 	// If we expect to be encrypted check that what we are restoring is not plaintext.
@@ -4429,6 +4429,9 @@ func (mb *msgBlock) generatePerSubjectInfo() error {
 			// Since we are walking by sequence we can ignore some errors that are benign to rebuilding our state.
 			if err == ErrStoreMsgNotFound || err == errDeletedMsg {
 				continue
+			}
+			if err == errNoCache {
+				return nil
 			}
 			return err
 		}


### PR DESCRIPTION
Fixed a bug that would not recover a stream properly after a non-clean shutdown with deleted messages.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
