### PR TITLE
Set active for Sources and Mirrors to -1 on no contact

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -1286,7 +1286,15 @@ func (mset *stream) sourceInfo(si *sourceInfo) *StreamSourceInfo {
 	if si == nil {
 		return nil
 	}
-	ssi := &StreamSourceInfo{Name: si.name, Lag: si.lag, Active: time.Since(si.last), Error: si.err}
+
+	ssi := &StreamSourceInfo{Name: si.name, Lag: si.lag, Error: si.err}
+	// If we have not heard from the source, set Active to -1.
+	if si.last.IsZero() {
+		ssi.Active = -1
+	} else {
+		ssi.Active = time.Since(si.last)
+	}
+
 	var ext *ExternalStream
 	if mset.cfg.Mirror != nil {
 		ext = mset.cfg.Mirror.External


### PR DESCRIPTION
If we had not heard from a source or mirror we would still calculated active.
This would wrap and create a large number which overflowed JSON's 2^53 limit.
This would cause schema violations in the NATS cli.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
