### PR TITLE
Fixed lock inversion by not using account lock to get the name

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -893,7 +893,7 @@ type SubDetail struct {
 func newSubDetail(sub *subscription) SubDetail {
 	sd := newClientSubDetail(sub)
 	if sub.client.acc != nil {
-		sd.Account = sub.client.acc.GetName()
+		sd.Account = sub.client.acc.Name
 	}
 	return sd
 }


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [ ] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [ ] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

### Changes proposed in this pull request:

 -
 -
 -

/cc @nats-io/core
