### PR TITLE
[FIXED] Consumer with no activity can lose quorum

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1760,7 +1760,7 @@ func (o *consumer) readStoredState() error {
 		return nil
 	}
 	state, err := o.store.State()
-	if err == nil && state != nil {
+	if err == nil && state != nil && state.Delivered.Consumer != 0 {
 		o.applyState(state)
 		if len(o.rdc) > 0 {
 			o.checkRedelivered()

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5509,11 +5509,10 @@ func (o *consumerFileStore) State() (*ConsumerState, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	var state *ConsumerState
+	state := &ConsumerState{}
 
 	// See if we have a running state or if we need to read in from disk.
 	if o.state.Delivered.Consumer != 0 {
-		state = &ConsumerState{}
 		state.Delivered = o.state.Delivered
 		state.AckFloor = o.state.AckFloor
 		if len(o.state.Pending) > 0 {

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1892,7 +1892,7 @@ func TestFileStoreConsumer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexepected error: %v", err)
 	}
-	if state, err := o.State(); state != nil || err != nil {
+	if state, err := o.State(); err != nil || state.Delivered.Consumer != 0 {
 		t.Fatalf("Unexpected state or error: %v", err)
 	}
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3106,11 +3106,6 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 					lastSnap = snap
 				}
 			}
-		} else {
-			// If we are here we may have no state but may be processing updates as a filtered consumer.
-			// Make sure the store does not grow too much, so similar to memory logic above, just compact.
-			_, _, applied := n.Progress()
-			n.Compact(applied)
 		}
 	}
 


### PR DESCRIPTION
When a consumer has no state we are now compacting the log, but were not snapshotting.

This caused issues on leader change and losing quorum.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #2913 

/cc @nats-io/core
