### PR TITLE
[FIXED] Panic when monitoring enabled on non 64bit architectures

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -107,7 +107,10 @@ type Info struct {
 
 // Server is our main struct.
 type Server struct {
+	// Fields accessed with atomic operations need to be 64-bit aligned
 	gcid uint64
+	// How often user logon fails due to the issuer account not being pinned.
+	pinnedAccFail uint64
 	stats
 	mu                  sync.Mutex
 	kp                  nkeys.KeyPair
@@ -265,9 +268,6 @@ type Server struct {
 	// the server will create a fake user and add it to the list of users.
 	// Keep track of what that user name is for config reload purposes.
 	sysAccOnlyNoAuthUser string
-
-	// How often user logon fails due to the issuer account not being pinned.
-	pinnedAccFail uint64
 
 	// This is a central logger for IPQueues when the number of pending
 	// messages reaches a certain thresold (per queue)


### PR DESCRIPTION
This is due to an unaligned 64-bit atomic operation. Move the
field at top of structure with 64-bit aligned preceding fields.

Resolves #2011

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
