### PR TITLE
[CHANGED] Gateway: Detect duplicate names between clusters

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -201,6 +201,7 @@ const (
 	ClusterNameConflict
 	DuplicateRemoteLeafnodeConnection
 	DuplicateClientID
+	DuplicateServerName
 )
 
 // Some flags passed to processMsgResults

--- a/server/errors.go
+++ b/server/errors.go
@@ -181,6 +181,10 @@ var (
 
 	// ErrCertNotPinned is returned when pinned certs are set and the certificate is not in it
 	ErrCertNotPinned = errors.New("certificate not pinned")
+
+	// ErrDuplicateServerName is returned when processing a server remote connection and
+	// the server reports that this server name is already used in the cluster.
+	ErrDuplicateServerName = errors.New("duplicate server name")
 )
 
 // configErr is a configuration error.

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1013,6 +1013,13 @@ func (c *client) processGatewayInfo(info *Info) {
 			return
 		}
 
+		// Check for duplicate server name with servers in our cluster
+		if s.isDuplicateServerName(info.Name) {
+			c.Errorf("Remote server has a duplicate name: %q", info.Name)
+			c.closeConnection(DuplicateServerName)
+			return
+		}
+
 		// Possibly add URLs that we get from the INFO protocol.
 		if len(info.GatewayURLs) > 0 {
 			cfg.updateURLs(info.GatewayURLs)
@@ -1083,6 +1090,13 @@ func (c *client) processGatewayInfo(info *Info) {
 
 	} else if isFirstINFO {
 		// This is the first INFO of an inbound connection...
+
+		// Check for duplicate server name with servers in our cluster
+		if s.isDuplicateServerName(info.Name) {
+			c.Errorf("Remote server has a duplicate name: %q", info.Name)
+			c.closeConnection(DuplicateServerName)
+			return
+		}
 
 		s.registerInboundGatewayConnection(cid, c)
 		c.Noticef("Inbound gateway connection from %q (%s) registered", info.Gateway, info.ID)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2102,6 +2102,8 @@ func (reason ClosedState) String() string {
 		return "Duplicate Remote LeafNode Connection"
 	case DuplicateClientID:
 		return "Duplicate Client ID"
+	case DuplicateServerName:
+		return "Duplicate Server Name"
 	}
 
 	return "Unknown State"

--- a/server/server.go
+++ b/server/server.go
@@ -1613,10 +1613,14 @@ func (s *Server) Start() {
 
 	// Snapshot server options.
 	opts := s.getOpts()
+	clusterName := s.ClusterName()
 
 	s.Noticef("  Version:  %s", VERSION)
 	s.Noticef("  Git:      [%s]", gc)
 	s.Debugf("  Go build: %s", s.info.GoVersion)
+	if clusterName != _EMPTY_ {
+		s.Noticef("  Cluster:  %s", clusterName)
+	}
 	s.Noticef("  Name:     %s", s.info.Name)
 	if opts.JetStream {
 		s.Noticef("  Node:     %s", getHash(s.info.Name))


### PR DESCRIPTION
Gateway connection will be closed and error reported if a remote
has a name that is a duplicate of the local cluster.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
