### PR TITLE
Detect exact duplicates for URLs for routes, gateways or leafnodes.

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -1502,7 +1502,7 @@ func parseURLs(a []interface{}, typ string, warnings *[]error) (urls []*url.URL,
 				field: sURL,
 				configErr: configErr{
 					token:  tk,
-					reason: "Duplicate entry detected",
+					reason: fmt.Sprintf("Duplicate %s entry detected", typ),
 				},
 			}
 			*warnings = append(*warnings, err)


### PR DESCRIPTION
If misconfigured could prevent the JetStream system from electing a leader. We will skip the entry and warn to the log.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
