### PR TITLE
Changes to IPQueues

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -433,6 +433,7 @@ RESET:
 					// there is a chance that the process will exit before the
 					// writeLoop has a chance to send it.
 					c.flushClients(time.Second)
+					sendq.recycle(&msgs)
 					return
 				}
 				pm.returnToPool()

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2787,7 +2787,7 @@ func (s *Server) processStreamRestore(ci *ClientInfo, acc *Account, cfg *StreamC
 
 	// For signaling to upper layers.
 	resultCh := make(chan result, 1)
-	activeQ := newIPQueue() // of int
+	activeQ := s.newIPQueue(fmt.Sprintf("[ACC:%s] stream '%s' restore", acc.Name, streamName)) // of int
 
 	var total int
 
@@ -2866,6 +2866,7 @@ func (s *Server) processStreamRestore(ci *ClientInfo, acc *Account, cfg *StreamC
 			tfile.Close()
 			os.Remove(tfile.Name())
 			sub.client.processUnsub(sub.sid)
+			activeQ.unregister()
 		}()
 
 		const activityInterval = 5 * time.Second

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -921,7 +921,7 @@ func (s *Server) mqttCreateAccountSessionManager(acc *Account, quitCh chan struc
 
 	id := string(getHash(s.Name()))
 	replicas := s.mqttDetermineReplicas()
-	qname := fmt.Sprintf("MQTT account %q send", accName)
+	qname := fmt.Sprintf("[ACC:%s] MQTT ", accName)
 	as := &mqttAccountSessionManager{
 		sessions:   make(map[string]*mqttSession),
 		sessByHash: make(map[string]*mqttSession),
@@ -932,11 +932,11 @@ func (s *Server) mqttCreateAccountSessionManager(acc *Account, quitCh chan struc
 			id:     id,
 			c:      c,
 			rplyr:  mqttJSARepliesPrefix + id + ".",
-			sendq:  newIPQueue(ipQueue_Logger(qname, s.ipqLog)), // of *mqttJSPubMsg
+			sendq:  s.newIPQueue(qname + "send"), // of *mqttJSPubMsg
 			nuid:   nuid.New(),
 			quitCh: quitCh,
 		},
-		sp: newIPQueue(), // of uint64
+		sp: s.newIPQueue(qname + "sp"), // of uint64
 	}
 	// TODO record domain name in as here
 

--- a/server/sendq.go
+++ b/server/sendq.go
@@ -32,7 +32,7 @@ type sendq struct {
 }
 
 func (s *Server) newSendQ() *sendq {
-	sq := &sendq{s: s, q: newIPQueue(ipQueue_Logger("Send", s.ipqLog))}
+	sq := &sendq{s: s, q: s.newIPQueue("SendQ")}
 	s.startGoRoutine(sq.internalLoop)
 	return sq
 }


### PR DESCRIPTION
Removed the warnings, instead have a sync.Map where they are
registered/unregistered and can be inspected with an undocumented
monitor page.
Added the notion of "in progress" which is the number of messages
that have been pop()'ed. When recycle() is invoked this count
goes down.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
