### PR TITLE
[FIXED] JetStream: possible panic on leadership change notices

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3635,14 +3635,20 @@ func (js *jetStream) stopUpdatesSub() {
 func (js *jetStream) processLeaderChange(isLeader bool) {
 	if isLeader {
 		js.srv.Noticef("Self is new JetStream cluster metadata leader")
-	} else if node := js.getMetaGroup().GroupLeader(); node == _EMPTY_ {
-		js.srv.Noticef("JetStream cluster no metadata leader")
-	} else if srv := js.srv.serverNameForNode(node); srv == _EMPTY_ {
-		js.srv.Noticef("JetStream cluster new remote metadata leader")
-	} else if clst := js.srv.clusterNameForNode(node); clst == _EMPTY_ {
-		js.srv.Noticef("JetStream cluster new metadata leader: %s", srv)
 	} else {
-		js.srv.Noticef("JetStream cluster new metadata leader: %s/%s", srv, clst)
+		var node string
+		if meta := js.getMetaGroup(); meta != nil {
+			node = meta.GroupLeader()
+		}
+		if node == _EMPTY_ {
+			js.srv.Noticef("JetStream cluster no metadata leader")
+		} else if srv := js.srv.serverNameForNode(node); srv == _EMPTY_ {
+			js.srv.Noticef("JetStream cluster new remote metadata leader")
+		} else if clst := js.srv.clusterNameForNode(node); clst == _EMPTY_ {
+			js.srv.Noticef("JetStream cluster new metadata leader: %s", srv)
+		} else {
+			js.srv.Noticef("JetStream cluster new metadata leader: %s/%s", srv, clst)
+		}
 	}
 
 	js.mu.Lock()


### PR DESCRIPTION
I got this panic in a test:
```
=== RUN   TestJetStreamClusterAccountLoadFailure
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x78 pc=0xb1501b]
goroutine 47853 [running]:
github.com/nats-io/nats-server/v2/server.(*jetStream).processLeaderChange(0xc000b60580, 0x0)
	/home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:3638 +0x9b
github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster(0xc000b60580)
	/home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:853 +0x60f
created by github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine
	/home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:3017 +0x87
FAIL	github.com/nats-io/nats-server/v2/server	227.888s
```

which from that branch would point to function processLeaderChange()
line:
```
} else if node := js.getMetaGroup().GroupLeader(); node == _EMPTY_ {
```
which I guess meant that getMetaGroup() was returning `nil`.

Refactored a bit to get the group leader in 2 steps.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
