### PR TITLE
Relocated and renamed consts for CRLF and EMPTY

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -555,7 +555,7 @@ type MapDest struct {
 }
 
 func NewMapDest(subject string, weight uint8) *MapDest {
-	return &MapDest{subject, weight, _EMPTY_}
+	return &MapDest{subject, weight, EMPTY}
 }
 
 // destination is for internal representation for a weighted mapped destination.
@@ -616,7 +616,7 @@ func (a *Account) AddWeightedMappings(src string, dests ...*MapDest) error {
 		if err != nil {
 			return err
 		}
-		if d.Cluster == _EMPTY_ {
+		if d.Cluster == EMPTY {
 			m.dests = append(m.dests, &destination{tr, d.Weight})
 		} else {
 			// We have a cluster scoped filter.
@@ -1414,7 +1414,7 @@ func (a *Account) AddServiceImportWithClaim(destination *Account, from, to strin
 		return ErrMissingAccount
 	}
 	// Empty means use from.
-	if to == _EMPTY_ {
+	if to == EMPTY {
 		to = from
 	}
 	if !IsValidSubject(from) || !IsValidSubject(to) {
@@ -1550,7 +1550,7 @@ func (a *Account) NumPendingReverseResponses() int {
 
 // NumPendingAllResponses return the number of all responses outstanding for service exports.
 func (a *Account) NumPendingAllResponses() int {
-	return a.NumPendingResponses(_EMPTY_)
+	return a.NumPendingResponses(EMPTY)
 }
 
 // NumResponsesPending returns the number of responses outstanding for service exports
@@ -1560,7 +1560,7 @@ func (a *Account) NumPendingAllResponses() int {
 func (a *Account) NumPendingResponses(filter string) int {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
-	if filter == _EMPTY_ {
+	if filter == EMPTY {
 		return len(a.exports.responses)
 	}
 	se := a.getServiceExport(filter)
@@ -1826,7 +1826,7 @@ func (a *Account) addServiceImport(dest *Account, from, to string, claim *jwt.Im
 			from, dup.acc.Name, dup.to)
 	}
 
-	if to == _EMPTY_ {
+	if to == EMPTY {
 		to = from
 	}
 	// Check to see if we have a wildcard
@@ -2147,7 +2147,7 @@ func (a *Account) newServiceReply(tracking bool) []byte {
 		a.createRespWildcard()
 		createdSiReply = true
 	}
-	replyPre, isBoundToLeafnode := a.siReply, a.lds != _EMPTY_
+	replyPre, isBoundToLeafnode := a.siReply, a.lds != EMPTY
 	a.mu.Unlock()
 
 	// If we created the siReply and we are not bound to a leafnode
@@ -2312,7 +2312,7 @@ func (a *Account) addRespServiceImport(dest *Account, to string, osi *serviceImp
 		si.tracking = true
 		si.trackingHdr = header
 	}
-	isBoundToLeafnode := a.lds != _EMPTY_
+	isBoundToLeafnode := a.lds != EMPTY
 	a.mu.Unlock()
 
 	// We might not do individual subscriptions here like we do on configured imports.
@@ -2345,7 +2345,7 @@ func (a *Account) AddStreamImportWithClaim(account *Account, from, prefix string
 
 	// Check prefix if it exists and make sure its a literal.
 	// Append token separator if not already present.
-	if prefix != _EMPTY_ {
+	if prefix != EMPTY {
 		// Make sure there are no wildcards here, this prefix needs to be a literal
 		// since it will be prepended to a publish subject.
 		if !subjectIsLiteral(prefix) {
@@ -2375,7 +2375,7 @@ func (a *Account) AddMappedStreamImportWithClaim(account *Account, from, to stri
 		return ErrStreamImportAuthorization
 	}
 
-	if to == _EMPTY_ {
+	if to == EMPTY {
 		to = from
 	}
 
@@ -2664,7 +2664,7 @@ func isRevoked(revocations map[string]int64, subject string, issuedAt int64) boo
 // checkActivation will check the activation token for validity.
 // ea may only be nil in cases where revocation may not be checked, say triggered by expiration timer.
 func (a *Account) checkActivation(importAcc *Account, claim *jwt.Import, ea *exportAuth, expTimer bool) bool {
-	if claim == nil || claim.Token == _EMPTY_ {
+	if claim == nil || claim.Token == EMPTY {
 		return false
 	}
 	// Create a quick clone so we can inline Token JWT.
@@ -2710,7 +2710,7 @@ func (a *Account) checkActivation(importAcc *Account, claim *jwt.Import, ea *exp
 // the account or is an entry in the signing keys.
 func (a *Account) isIssuerClaimTrusted(claims *jwt.ActivationClaims) bool {
 	// if no issuer account, issuer is the account
-	if claims.IssuerAccount == _EMPTY_ {
+	if claims.IssuerAccount == EMPTY {
 		return true
 	}
 	// If the IssuerAccount is not us, then this is considered an error.
@@ -2913,7 +2913,7 @@ func (s *Server) AccountResolver() AccountResolver {
 // isClaimAccount returns if this account is backed by a JWT claim.
 // Lock should be held.
 func (a *Account) isClaimAccount() bool {
-	return a.claimJWT != _EMPTY_
+	return a.claimJWT != EMPTY
 }
 
 // updateAccountClaims will update an existing account with new claims.
@@ -2925,9 +2925,9 @@ func (s *Server) UpdateAccountClaims(a *Account, ac *jwt.AccountClaims) {
 
 func (a *Account) traceLabel() string {
 	if a == nil {
-		return _EMPTY_
+		return EMPTY
 	}
-	if a.nameTag != _EMPTY_ {
+	if a.nameTag != EMPTY {
 		return fmt.Sprintf("%s/%s", a.Name, a.nameTag)
 	}
 	return a.Name
@@ -3062,7 +3062,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 			sub := string(e.Subject)
 			if e.Latency != nil {
 				if err := a.TrackServiceExportWithSampling(sub, string(e.Latency.Results), int(e.Latency.Sampling)); err != nil {
-					hdrNote := _EMPTY_
+					hdrNote := EMPTY
 					if e.Latency.Sampling == jwt.Headers {
 						hdrNote = " (using headers)"
 					}
@@ -3134,7 +3134,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 		to := i.GetTo()
 		switch i.Type {
 		case jwt.Stream:
-			if i.LocalSubject != _EMPTY_ {
+			if i.LocalSubject != EMPTY {
 				// set local subject implies to is empty
 				to = string(i.LocalSubject)
 				s.Debugf("Adding stream import %s:%q for %s:%q", acc.traceLabel(), from, a.traceLabel(), to)
@@ -3148,7 +3148,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 				incompleteImports = append(incompleteImports, i)
 			}
 		case jwt.Service:
-			if i.LocalSubject != _EMPTY_ {
+			if i.LocalSubject != EMPTY {
 				from = string(i.LocalSubject)
 				to = string(i.Subject)
 			}
@@ -3324,7 +3324,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 		theJWT := c.opts.JWT
 		c.mu.Unlock()
 		// Check for being revoked here. We use ac one to avoid the account lock.
-		if ac.Revocations != nil && theJWT != _EMPTY_ {
+		if ac.Revocations != nil && theJWT != EMPTY {
 			if juc, err := jwt.DecodeUserClaims(theJWT); err != nil {
 				c.Debugf("User JWT not valid: %v", err)
 				c.authViolation()
@@ -3347,7 +3347,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 			}
 			sk := c.user.SigningKey
 			c.mu.Unlock()
-			if sk == _EMPTY_ {
+			if sk == EMPTY {
 				continue
 			}
 			if _, ok := alteredScope[sk]; ok {
@@ -3444,7 +3444,7 @@ func buildPermissionsFromJwt(uc *jwt.Permissions) *Permissions {
 // Helper to build internal NKeyUser.
 func buildInternalNkeyUser(uc *jwt.UserClaims, acts map[string]struct{}, acc *Account) *NkeyUser {
 	nu := &NkeyUser{Nkey: uc.Subject, Account: acc, AllowedConnectionTypes: acts}
-	if uc.IssuerAccount != _EMPTY_ {
+	if uc.IssuerAccount != EMPTY {
 		nu.SigningKey = uc.Issuer
 	}
 
@@ -3459,7 +3459,7 @@ func buildInternalNkeyUser(uc *jwt.UserClaims, acts map[string]struct{}, acc *Ac
 
 func fetchAccount(res AccountResolver, name string) (string, error) {
 	if !nkeys.IsValidPublicAccountKey(name) {
-		return _EMPTY_, fmt.Errorf("will only fetch valid account keys")
+		return EMPTY, fmt.Errorf("will only fetch valid account keys")
 	}
 	return res.Fetch(name)
 }
@@ -3513,7 +3513,7 @@ func (m *MemAccResolver) Fetch(name string) (string, error) {
 	if j, ok := m.sm.Load(name); ok {
 		return j.(string), nil
 	}
-	return _EMPTY_, ErrMissingAccount
+	return EMPTY, ErrMissingAccount
 }
 
 // Store will store the account jwt claims in the internal sync.Map.
@@ -3557,16 +3557,16 @@ func (ur *URLAccResolver) Fetch(name string) (string, error) {
 	url := ur.url + name
 	resp, err := ur.c.Get(url)
 	if err != nil {
-		return _EMPTY_, fmt.Errorf("could not fetch <%q>: %v", redactURLString(url), err)
+		return EMPTY, fmt.Errorf("could not fetch <%q>: %v", redactURLString(url), err)
 	} else if resp == nil {
-		return _EMPTY_, fmt.Errorf("could not fetch <%q>: no response", redactURLString(url))
+		return EMPTY, fmt.Errorf("could not fetch <%q>: no response", redactURLString(url))
 	} else if resp.StatusCode != http.StatusOK {
-		return _EMPTY_, fmt.Errorf("could not fetch <%q>: %v", redactURLString(url), resp.Status)
+		return EMPTY, fmt.Errorf("could not fetch <%q>: %v", redactURLString(url), resp.Status)
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return _EMPTY_, err
+		return EMPTY, err
 	}
 	return string(body), nil
 }
@@ -3589,25 +3589,25 @@ func (dr *DirAccResolver) Reload() error {
 
 func respondToUpdate(s *Server, respSubj string, acc string, message string, err error) {
 	if err == nil {
-		if acc == _EMPTY_ {
+		if acc == EMPTY {
 			s.Debugf("%s", message)
 		} else {
 			s.Debugf("%s - %s", message, acc)
 		}
 	} else {
-		if acc == _EMPTY_ {
+		if acc == EMPTY {
 			s.Errorf("%s - %s", message, err)
 		} else {
 			s.Errorf("%s - %s - %s", message, acc, err)
 		}
 	}
-	if respSubj == _EMPTY_ {
+	if respSubj == EMPTY {
 		return
 	}
 	server := &ServerInfo{}
 	response := map[string]interface{}{"server": server}
 	m := map[string]interface{}{}
-	if acc != _EMPTY_ {
+	if acc != EMPTY {
 		m["account"] = acc
 	}
 	if err == nil {
@@ -3619,11 +3619,11 @@ func respondToUpdate(s *Server, respSubj string, acc string, message string, err
 		m["description"] = fmt.Sprintf("%s - %v", message, err)
 		response["error"] = m
 	}
-	s.sendInternalMsgLocked(respSubj, _EMPTY_, server, response)
+	s.sendInternalMsgLocked(respSubj, EMPTY, server, response)
 }
 
 func handleListRequest(store *DirJWTStore, s *Server, reply string) {
-	if reply == _EMPTY_ {
+	if reply == EMPTY {
 		return
 	}
 	accIds := make([]string, 0, 1024)
@@ -3638,7 +3638,7 @@ func handleListRequest(store *DirJWTStore, s *Server, reply string) {
 		s.Debugf("list request responded with %d account ids", len(accIds))
 		server := &ServerInfo{}
 		response := map[string]interface{}{"server": server, "data": accIds}
-		s.sendInternalMsgLocked(reply, _EMPTY_, server, response)
+		s.sendInternalMsgLocked(reply, EMPTY, server, response)
 	}
 }
 
@@ -3665,7 +3665,7 @@ func handleDeleteRequest(store *DirJWTStore, s *Server, msg []byte, reply string
 		} else {
 			for _, entry := range accIds {
 				if acc, ok := entry.(string); !ok ||
-					acc == _EMPTY_ || !nkeys.IsValidPublicAccountKey(acc) {
+					acc == EMPTY || !nkeys.IsValidPublicAccountKey(acc) {
 					err = fmt.Errorf("malformed request")
 					break
 				} else if acc == sysAccName {
@@ -3676,7 +3676,7 @@ func handleDeleteRequest(store *DirJWTStore, s *Server, msg []byte, reply string
 		}
 	}
 	if err != nil {
-		respondToUpdate(s, reply, _EMPTY_, fmt.Sprintf("delete accounts request by %s failed", subj), err)
+		respondToUpdate(s, reply, EMPTY, fmt.Sprintf("delete accounts request by %s failed", subj), err)
 		return
 	}
 	errs := []string{}
@@ -3689,9 +3689,9 @@ func handleDeleteRequest(store *DirJWTStore, s *Server, msg []byte, reply string
 		}
 	}
 	if len(errs) == 0 {
-		respondToUpdate(s, reply, _EMPTY_, fmt.Sprintf("deleted %d accounts", passCnt), nil)
+		respondToUpdate(s, reply, EMPTY, fmt.Sprintf("deleted %d accounts", passCnt), nil)
 	} else {
-		respondToUpdate(s, reply, _EMPTY_, fmt.Sprintf("deleted %d accounts, failed for %d", passCnt, len(errs)),
+		respondToUpdate(s, reply, EMPTY, fmt.Sprintf("deleted %d accounts, failed for %d", passCnt, len(errs)),
 			errors.New(strings.Join(errs, "\n")))
 	}
 }
@@ -3711,7 +3711,7 @@ func getOperatorKeys(s *Server) (string, map[string]struct{}, bool, error) {
 		}
 	}
 	if len(keys) == 0 {
-		return _EMPTY_, nil, false, fmt.Errorf("no operator key found")
+		return EMPTY, nil, false, fmt.Errorf("no operator key found")
 	}
 	return op, keys, strict, nil
 }
@@ -3771,7 +3771,7 @@ func (dr *DirAccResolver) Start(s *Server) error {
 	for _, reqSub := range []string{accUpdateEventSubjOld, accUpdateEventSubjNew} {
 		// subscribe to account jwt update requests
 		if _, err := s.sysSubscribe(fmt.Sprintf(reqSub, "*"), func(_ *subscription, _ *client, _ *Account, subj, resp string, msg []byte) {
-			pubKey := _EMPTY_
+			pubKey := EMPTY
 			tk := strings.Split(subj, tsep)
 			if len(tk) == accUpdateTokensNew {
 				pubKey = tk[accReqAccIndex]
@@ -3818,7 +3818,7 @@ func (dr *DirAccResolver) Start(s *Server) error {
 	}
 	// respond to lookups with our version
 	if _, err := s.sysSubscribe(fmt.Sprintf(accLookupReqSubj, "*"), func(_ *subscription, _ *client, _ *Account, subj, reply string, msg []byte) {
-		if reply == _EMPTY_ {
+		if reply == EMPTY {
 			return
 		}
 		tk := strings.Split(subj, tsep)
@@ -3828,7 +3828,7 @@ func (dr *DirAccResolver) Start(s *Server) error {
 		if theJWT, err := dr.DirJWTStore.LoadAcc(tk[accReqAccIndex]); err != nil {
 			s.Errorf("Merging resulted in error: %v", err)
 		} else {
-			s.sendInternalMsgLocked(reply, _EMPTY_, nil, []byte(theJWT))
+			s.sendInternalMsgLocked(reply, EMPTY, nil, []byte(theJWT))
 		}
 	}); err != nil {
 		return fmt.Errorf("error setting up lookup request handling: %v", err)
@@ -3836,21 +3836,21 @@ func (dr *DirAccResolver) Start(s *Server) error {
 	// respond to pack requests with one or more pack messages
 	// an empty message signifies the end of the response responder
 	if _, err := s.sysSubscribeQ(accPackReqSubj, "responder", func(_ *subscription, _ *client, _ *Account, _, reply string, theirHash []byte) {
-		if reply == _EMPTY_ {
+		if reply == EMPTY {
 			return
 		}
 		ourHash := dr.DirJWTStore.Hash()
 		if bytes.Equal(theirHash, ourHash[:]) {
-			s.sendInternalMsgLocked(reply, _EMPTY_, nil, []byte{})
+			s.sendInternalMsgLocked(reply, EMPTY, nil, []byte{})
 			s.Debugf("pack request matches hash %x", ourHash[:])
 		} else if err := dr.DirJWTStore.PackWalk(1, func(partialPackMsg string) {
-			s.sendInternalMsgLocked(reply, _EMPTY_, nil, []byte(partialPackMsg))
+			s.sendInternalMsgLocked(reply, EMPTY, nil, []byte(partialPackMsg))
 		}); err != nil {
 			// let them timeout
 			s.Errorf("pack request error: %v", err)
 		} else {
 			s.Debugf("pack request hash %x - finished responding with hash %x", theirHash, ourHash)
-			s.sendInternalMsgLocked(reply, _EMPTY_, nil, []byte{})
+			s.sendInternalMsgLocked(reply, EMPTY, nil, []byte{})
 		}
 	}); err != nil {
 		return fmt.Errorf("error setting up pack request handling: %v", err)
@@ -3902,7 +3902,7 @@ func (dr *DirAccResolver) Start(s *Server) error {
 }
 
 func (dr *DirAccResolver) Fetch(name string) (string, error) {
-	if theJWT, err := dr.LoadAcc(name); theJWT != _EMPTY_ {
+	if theJWT, err := dr.LoadAcc(name); theJWT != EMPTY {
 		return theJWT, nil
 	} else {
 		dr.Lock()
@@ -3910,7 +3910,7 @@ func (dr *DirAccResolver) Fetch(name string) (string, error) {
 		to := dr.fetchTimeout
 		dr.Unlock()
 		if srv == nil {
-			return _EMPTY_, err
+			return EMPTY, err
 		}
 		return srv.fetch(dr, name, to) // lookup from other server
 	}
@@ -3973,14 +3973,14 @@ type CacheDirAccResolver struct {
 
 func (s *Server) fetch(res AccountResolver, name string, timeout time.Duration) (string, error) {
 	if s == nil {
-		return _EMPTY_, ErrNoAccountResolver
+		return EMPTY, ErrNoAccountResolver
 	}
 	respC := make(chan []byte, 1)
 	accountLookupRequest := fmt.Sprintf(accLookupReqSubj, name)
 	s.mu.Lock()
 	if s.sys == nil || s.sys.replies == nil {
 		s.mu.Unlock()
-		return _EMPTY_, fmt.Errorf("eventing shut down")
+		return EMPTY, fmt.Errorf("eventing shut down")
 	}
 	replySubj := s.newRespInbox()
 	replies := s.sys.replies
@@ -4057,7 +4057,7 @@ func (dr *CacheDirAccResolver) Start(s *Server) error {
 	for _, reqSub := range []string{accUpdateEventSubjOld, accUpdateEventSubjNew} {
 		// subscribe to account jwt update requests
 		if _, err := s.sysSubscribe(fmt.Sprintf(reqSub, "*"), func(_ *subscription, _ *client, _ *Account, subj, resp string, msg []byte) {
-			pubKey := _EMPTY_
+			pubKey := EMPTY
 			tk := strings.Split(subj, tsep)
 			if len(tk) == accUpdateTokensNew {
 				pubKey = tk[accReqAccIndex]
@@ -4208,13 +4208,13 @@ func (tr *transform) match(subject string) (string, error) {
 	}
 	tts = append(tts, subject[start:])
 	if !isValidLiteralSubject(tts) {
-		return _EMPTY_, ErrBadSubject
+		return EMPTY, ErrBadSubject
 	}
 
 	if isSubsetMatch(tts, tr.src) {
 		return tr.transform(tts)
 	}
-	return _EMPTY_, ErrNoTransforms
+	return EMPTY, ErrNoTransforms
 }
 
 // Do not need to match, just transform.

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -238,11 +238,11 @@ func TestNoAuthUser(t *testing.T) {
 		account string
 	}{
 		{"valid user/pwd", "bar:pwd2@", true, "BAR"},
-		{"invalid pwd", "bar:wrong@", false, _EMPTY_},
-		{"some token", "sometoken@", false, _EMPTY_},
-		{"user used without pwd", "bar@", false, _EMPTY_}, // will be treated as a token
-		{"user with empty password", "bar:@", false, _EMPTY_},
-		{"no user", _EMPTY_, true, "FOO"},
+		{"invalid pwd", "bar:wrong@", false, EMPTY},
+		{"some token", "sometoken@", false, EMPTY},
+		{"user used without pwd", "bar@", false, EMPTY}, // will be treated as a token
+		{"user with empty password", "bar:@", false, EMPTY},
+		{"no user", EMPTY, true, "FOO"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			url := fmt.Sprintf("nats://%s127.0.0.1:%d", test.usrInfo, o.Port)

--- a/server/client.go
+++ b/server/client.go
@@ -77,10 +77,10 @@ const (
 )
 
 const (
-	pingProto = "PING" + _CRLF_
-	pongProto = "PONG" + _CRLF_
-	errProto  = "-ERR '%s'" + _CRLF_
-	okProto   = "+OK" + _CRLF_
+	pingProto = "PING" + CR_LF
+	pongProto = "PONG" + CR_LF
+	errProto  = "-ERR '%s'" + CR_LF
+	okProto   = "+OK" + CR_LF
 )
 
 func init() {
@@ -425,7 +425,7 @@ func (c *client) String() (id string) {
 		return loaded.(string)
 	}
 
-	return _EMPTY_
+	return EMPTY
 }
 
 // GetNonce returns the nonce that was presented to the user on connection
@@ -486,7 +486,7 @@ func (c *client) clientType() int {
 }
 
 var clientTypeStringMap = map[int]string{
-	NON_CLIENT: _EMPTY_,
+	NON_CLIENT: EMPTY,
 	NATS:       "nats",
 	WS:         "websocket",
 	MQTT:       "mqtt",
@@ -496,7 +496,7 @@ func (c *client) clientTypeString() string {
 	if typeStringVal, ok := clientTypeStringMap[c.clientType()]; ok {
 		return typeStringVal
 	}
-	return _EMPTY_
+	return EMPTY
 }
 
 // This is the main subscription struct that indicates
@@ -608,11 +608,11 @@ func (c *client) initClient() {
 	var conn string
 	if c.nc != nil {
 		if addr := c.nc.RemoteAddr(); addr != nil {
-			if conn = addr.String(); conn != _EMPTY_ {
+			if conn = addr.String(); conn != EMPTY {
 				host, port, _ := net.SplitHostPort(conn)
 				iPort, _ := strconv.Atoi(port)
 				c.host, c.port = host, uint16(iPort)
-				if c.isWebsocket() && c.ws.clientIP != _EMPTY_ {
+				if c.isWebsocket() && c.ws.clientIP != EMPTY {
 					cip := c.ws.clientIP
 					// Surround IPv6 addresses with square brackets, as
 					// net.JoinHostPort would do...
@@ -757,11 +757,11 @@ func (c *client) applyAccountLimits() {
 	}
 	c.mpay = jwt.NoLimit
 	c.msubs = jwt.NoLimit
-	if c.opts.JWT != _EMPTY_ { // user jwt implies account
+	if c.opts.JWT != EMPTY { // user jwt implies account
 		if uc, _ := jwt.DecodeUserClaims(c.opts.JWT); uc != nil {
 			c.mpay = int32(uc.Limits.Payload)
 			c.msubs = int32(uc.Limits.Subs)
-			if uc.IssuerAccount != _EMPTY_ && uc.IssuerAccount != uc.Issuer {
+			if uc.IssuerAccount != EMPTY && uc.IssuerAccount != uc.Issuer {
 				if scope, ok := c.acc.signingKeys[uc.Issuer]; ok {
 					if userScope, ok := scope.(*jwt.UserScope); ok {
 						// if signing key disappeared or changed and we don't get here, the client will be disconnected
@@ -827,7 +827,7 @@ func (c *client) RegisterUser(user *User) {
 
 	// allows custom authenticators to set a username to be reported in
 	// server events and more
-	if user.Username != _EMPTY_ {
+	if user.Username != EMPTY {
 		c.opts.Username = user.Username
 	}
 
@@ -1757,24 +1757,24 @@ func (c *client) processConnect(arg []byte) error {
 
 	if c.kind == CLIENT {
 		var ncs string
-		if c.opts.Version != _EMPTY_ {
+		if c.opts.Version != EMPTY {
 			ncs = fmt.Sprintf("v%s", c.opts.Version)
 		}
-		if c.opts.Lang != _EMPTY_ {
-			if c.opts.Version == _EMPTY_ {
+		if c.opts.Lang != EMPTY {
+			if c.opts.Version == EMPTY {
 				ncs = c.opts.Lang
 			} else {
 				ncs = fmt.Sprintf("%s:%s", ncs, c.opts.Lang)
 			}
 		}
-		if c.opts.Name != _EMPTY_ {
-			if c.opts.Version == _EMPTY_ && c.opts.Lang == _EMPTY_ {
+		if c.opts.Name != EMPTY {
+			if c.opts.Version == EMPTY && c.opts.Lang == EMPTY {
 				ncs = c.opts.Name
 			} else {
 				ncs = fmt.Sprintf("%s:%s", ncs, c.opts.Name)
 			}
 		}
-		if ncs != _EMPTY_ {
+		if ncs != EMPTY {
 			c.ncs.Store(fmt.Sprintf("%s - %q", c, ncs))
 		}
 	}
@@ -1785,7 +1785,7 @@ func (c *client) processConnect(arg []byte) error {
 	}
 	// when not in operator mode, discard the jwt
 	if srv != nil && srv.trustedKeys == nil {
-		c.opts.JWT = _EMPTY_
+		c.opts.JWT = EMPTY
 	}
 	ujwt := c.opts.JWT
 
@@ -1808,7 +1808,7 @@ func (c *client) processConnect(arg []byte) error {
 		// Check for Auth
 		if ok := srv.checkAuthentication(c); !ok {
 			// We may fail here because we reached max limits on an account.
-			if ujwt != _EMPTY_ {
+			if ujwt != EMPTY {
 				c.mu.Lock()
 				acc := c.acc
 				c.mu.Unlock()
@@ -1825,7 +1825,7 @@ func (c *client) processConnect(arg []byte) error {
 
 		// Check for Account designation, we used to have this as an optional feature for dynamic
 		// sandbox environments. Now its considered an error.
-		if accountNew || account != _EMPTY_ {
+		if accountNew || account != EMPTY {
 			c.authViolation()
 			return ErrAuthentication
 		}
@@ -2562,7 +2562,7 @@ func (c *client) addShadowSubscriptions(acc *Account, sub *subscription) error {
 			continue
 		}
 		if subj == im.to {
-			ims = append(ims, ime{im, _EMPTY_, false})
+			ims = append(ims, ime{im, EMPTY, false})
 			continue
 		}
 		if tokensModified {
@@ -2573,10 +2573,10 @@ func (c *client) addShadowSubscriptions(acc *Account, sub *subscription) error {
 		imTokens := tokenizeSubjectIntoSlice(imTsa[:0], im.to)
 
 		if isSubsetMatchTokenized(tokens, imTokens) {
-			ims = append(ims, ime{im, _EMPTY_, true})
+			ims = append(ims, ime{im, EMPTY, true})
 		} else if hasWC {
 			if isSubsetMatchTokenized(imTokens, tokens) {
-				ims = append(ims, ime{im, _EMPTY_, false})
+				ims = append(ims, ime{im, EMPTY, false})
 			} else {
 				imTokensLen := len(imTokens)
 				for i, t := range tokens {
@@ -2649,7 +2649,7 @@ func (c *client) addShadowSub(sub *subscription, ime *ime) (*subscription, error
 			im.rtr = im.tr.reverse()
 		}
 		s := string(nsub.subject)
-		if ime.overlapSubj != _EMPTY_ {
+		if ime.overlapSubj != EMPTY {
 			s = ime.overlapSubj
 		}
 		subj, err := im.rtr.transformSubject(s)
@@ -2658,7 +2658,7 @@ func (c *client) addShadowSub(sub *subscription, ime *ime) (*subscription, error
 		}
 		nsub.subject = []byte(subj)
 	} else if !im.usePub || !ime.dyn {
-		if ime.overlapSubj != _EMPTY_ {
+		if ime.overlapSubj != EMPTY {
 			nsub.subject = []byte(ime.overlapSubj)
 		} else {
 			nsub.subject = []byte(im.from)
@@ -2932,7 +2932,7 @@ func (c *client) msgHeaderForRouteOrLeaf(subj, reply []byte, rt *routeTarget, ac
 		// If we are coming from a leaf with an origin cluster we need to handle differently
 		// if we can. We will send a route based LMSG which has origin cluster and headers
 		// by default.
-		if c.kind == LEAF && c.remoteCluster() != _EMPTY_ && rt.sub.client.route.lnoc {
+		if c.kind == LEAF && c.remoteCluster() != EMPTY && rt.sub.client.route.lnoc {
 			mh[0] = 'L'
 			mh = append(mh, c.remoteCluster()...)
 			mh = append(mh, ' ')
@@ -2996,7 +2996,7 @@ func (c *client) msgHeaderForRouteOrLeaf(subj, reply []byte, rt *routeTarget, ac
 	} else {
 		mh = append(mh, c.pa.szb...)
 	}
-	return append(mh, _CRLF_...)
+	return append(mh, CR_LF...)
 }
 
 // Create a message header for clients. Header aware.
@@ -3037,7 +3037,7 @@ func (c *client) msgHeader(subj, reply []byte, sub *subscription) []byte {
 	} else {
 		mh = append(mh, c.pa.szb...)
 	}
-	mh = append(mh, _CRLF_...)
+	mh = append(mh, CR_LF...)
 	return mh
 }
 
@@ -3730,11 +3730,11 @@ func removeHeaderIfPresent(hdr []byte, key string) []byte {
 	if index >= len(hdr) || hdr[index] != ':' {
 		return hdr
 	}
-	end := bytes.Index(hdr[start:], []byte(_CRLF_))
+	end := bytes.Index(hdr[start:], []byte(CR_LF))
 	if end < 0 {
 		return hdr
 	}
-	hdr = append(hdr[:start], hdr[start+end+len(_CRLF_):]...)
+	hdr = append(hdr[:start], hdr[start+end+len(CR_LF):]...)
 	if len(hdr) <= len(emptyHdrLine) {
 		return nil
 	}
@@ -4345,7 +4345,7 @@ sendToRoutesOrLeafs:
 			// The other is leaf to leaf.
 			if c.kind == LEAF {
 				src, dest := c.remoteCluster(), dc.remoteCluster()
-				if src != _EMPTY_ && src == dest {
+				if src != EMPTY && src == dest {
 					continue
 				}
 			}
@@ -5015,9 +5015,9 @@ func (c *client) pruneClosedSubFromPerAccountCache() {
 // Returns our service account for this request.
 func (ci *ClientInfo) serviceAccount() string {
 	if ci == nil {
-		return _EMPTY_
+		return EMPTY
 	}
-	if ci.Service != _EMPTY_ {
+	if ci.Service != EMPTY {
 		return ci.Service
 	}
 	return ci.Account
@@ -5088,7 +5088,7 @@ func (c *client) getClientInfo(detailed bool) *ClientInfo {
 }
 
 func (c *client) doTLSServerHandshake(typ string, tlsConfig *tls.Config, timeout float64, pCerts PinnedCertSet) error {
-	_, err := c.doTLSHandshake(typ, false, nil, tlsConfig, _EMPTY_, timeout, pCerts)
+	_, err := c.doTLSHandshake(typ, false, nil, tlsConfig, EMPTY, timeout, pCerts)
 	return err
 }
 
@@ -5112,12 +5112,12 @@ func (c *client) doTLSHandshake(typ string, solicit bool, url *url.URL, tlsConfi
 	// If we solicited, we will act like the client, otherwise the server.
 	if solicit {
 		c.Debugf("Starting TLS %s client handshake", typ)
-		if tlsConfig.ServerName == _EMPTY_ {
+		if tlsConfig.ServerName == EMPTY {
 			// If the given url is a hostname, use this hostname for the
 			// ServerName. If it is an IP, use the cfg's tlsName. If none
 			// is available, resort to current IP.
 			host = url.Hostname()
-			if tlsName != _EMPTY_ && net.ParseIP(host) != nil {
+			if tlsName != EMPTY && net.ParseIP(host) != nil {
 				host = tlsName
 			}
 			tlsConfig.ServerName = host

--- a/server/const.go
+++ b/server/const.go
@@ -91,11 +91,14 @@ const (
 	// DEFAULT_PING_MAX_OUT is maximum allowed pings outstanding before disconnect.
 	DEFAULT_PING_MAX_OUT = 2
 
-	// CR_LF string
+	// CR_LF string.
 	CR_LF = "\r\n"
-
+	
 	// LEN_CR_LF hold onto the computed size.
 	LEN_CR_LF = len(CR_LF)
+
+	// EMPTY is used to check for empty strings.
+	EMPTY = ""
 
 	// DEFAULT_FLUSH_DEADLINE is the write/flush deadlines.
 	DEFAULT_FLUSH_DEADLINE = 10 * time.Second

--- a/server/dirstore.go
+++ b/server/dirstore.go
@@ -37,27 +37,27 @@ const (
 
 // validatePathExists checks that the provided path exists and is a dir if requested
 func validatePathExists(path string, dir bool) (string, error) {
-	if path == _EMPTY_ {
-		return _EMPTY_, errors.New("path is not specified")
+	if path == EMPTY {
+		return EMPTY, errors.New("path is not specified")
 	}
 
 	abs, err := filepath.Abs(path)
 	if err != nil {
-		return _EMPTY_, fmt.Errorf("error parsing path [%s]: %v", abs, err)
+		return EMPTY, fmt.Errorf("error parsing path [%s]: %v", abs, err)
 	}
 
 	var finfo os.FileInfo
 	if finfo, err = os.Stat(abs); os.IsNotExist(err) {
-		return _EMPTY_, fmt.Errorf("the path [%s] doesn't exist", abs)
+		return EMPTY, fmt.Errorf("the path [%s] doesn't exist", abs)
 	}
 
 	mode := finfo.Mode()
 	if dir && mode.IsRegular() {
-		return _EMPTY_, fmt.Errorf("the path [%s] is not a directory", abs)
+		return EMPTY, fmt.Errorf("the path [%s] is not a directory", abs)
 	}
 
 	if !dir && mode.IsDir() {
-		return _EMPTY_, fmt.Errorf("the path [%s] is not a file", abs)
+		return EMPTY, fmt.Errorf("the path [%s] is not a file", abs)
 	}
 
 	return abs, nil
@@ -89,13 +89,13 @@ func newDir(dirPath string, create bool) (string, error) {
 	fullPath, err := validateDirPath(dirPath)
 	if err != nil {
 		if !create {
-			return _EMPTY_, err
+			return EMPTY, err
 		}
 		if err = os.MkdirAll(dirPath, defaultDirPerms); err != nil {
-			return _EMPTY_, err
+			return EMPTY, err
 		}
 		if fullPath, err = validateDirPath(dirPath); err != nil {
-			return _EMPTY_, err
+			return EMPTY, err
 		}
 	}
 	return fullPath, nil
@@ -256,7 +256,7 @@ func (store *DirJWTStore) Pack(maxJWTs int) (string, error) {
 	})
 	store.Unlock()
 	if err != nil {
-		return _EMPTY_, err
+		return EMPTY, err
 	} else {
 		return strings.Join(pack, "\n"), nil
 	}
@@ -313,7 +313,7 @@ func (store *DirJWTStore) PackWalk(maxJWTs int, cb func(partialPackMsg string)) 
 func (store *DirJWTStore) Merge(pack string) error {
 	newJWTs := strings.Split(pack, "\n")
 	for _, line := range newJWTs {
-		if line == _EMPTY_ { // ignore blank lines
+		if line == EMPTY { // ignore blank lines
 			continue
 		}
 		split := strings.Split(line, "|")
@@ -368,7 +368,7 @@ func (store *DirJWTStore) Reload() error {
 
 func (store *DirJWTStore) pathForKey(publicKey string) string {
 	if len(publicKey) < 2 {
-		return _EMPTY_
+		return EMPTY
 	}
 	fileName := fmt.Sprintf("%s%s", publicKey, fileExtension)
 	if store.shard {
@@ -384,10 +384,10 @@ func (store *DirJWTStore) pathForKey(publicKey string) string {
 func (store *DirJWTStore) load(publicKey string) (string, error) {
 	store.Lock()
 	defer store.Unlock()
-	if path := store.pathForKey(publicKey); path == _EMPTY_ {
-		return _EMPTY_, fmt.Errorf("invalid public key")
+	if path := store.pathForKey(publicKey); path == EMPTY {
+		return EMPTY, fmt.Errorf("invalid public key")
 	} else if data, err := ioutil.ReadFile(path); err != nil {
-		return _EMPTY_, err
+		return EMPTY, err
 	} else {
 		if store.expiration != nil {
 			store.expiration.updateTrack(publicKey)
@@ -467,7 +467,7 @@ func (store *DirJWTStore) save(publicKey string, theJWT string) error {
 	}
 	store.Lock()
 	path := store.pathForKey(publicKey)
-	if path == _EMPTY_ {
+	if path == EMPTY {
 		store.Unlock()
 		return fmt.Errorf("invalid public key")
 	}
@@ -494,7 +494,7 @@ func (store *DirJWTStore) saveIfNewer(publicKey string, theJWT string) error {
 		return fmt.Errorf("store is read-only")
 	}
 	path := store.pathForKey(publicKey)
-	if path == _EMPTY_ {
+	if path == EMPTY {
 		return fmt.Errorf("invalid public key")
 	}
 	dirPath := filepath.Dir(path)

--- a/server/events.go
+++ b/server/events.go
@@ -272,7 +272,7 @@ func (pm *pubMsg) returnToPool() {
 	if pm == nil {
 		return
 	}
-	pm.c, pm.sub, pm.rply, pm.si, pm.hdr, pm.msg = nil, _EMPTY_, _EMPTY_, nil, nil, nil
+	pm.c, pm.sub, pm.rply, pm.si, pm.hdr, pm.msg = nil, EMPTY, EMPTY, nil, nil, nil
 	pubMsgPool.Put(pm)
 }
 
@@ -396,10 +396,10 @@ RESET:
 				c.mu.Unlock()
 
 				// Add in NL
-				b = append(b, _CRLF_...)
+				b = append(b, CR_LF...)
 
 				// Check if we should set content-encoding
-				if contentHeader != _EMPTY_ {
+				if contentHeader != EMPTY {
 					b = c.setHeader(contentEncodingHeader, contentHeader, b)
 				}
 
@@ -462,13 +462,13 @@ func (s *Server) sendShutdownEvent() {
 	s.sys.replies = nil
 	// Send to the internal queue and mark as last.
 	si := &ServerInfo{}
-	sendq.push(newPubMsg(nil, subj, _EMPTY_, si, nil, si, noCompression, false, true))
+	sendq.push(newPubMsg(nil, subj, EMPTY, si, nil, si, noCompression, false, true))
 	s.mu.Unlock()
 }
 
 // Used to send an internal message to an arbitrary account.
 func (s *Server) sendInternalAccountMsg(a *Account, subject string, msg interface{}) error {
-	return s.sendInternalAccountMsgWithReply(a, subject, _EMPTY_, nil, msg, false)
+	return s.sendInternalAccountMsgWithReply(a, subject, EMPTY, nil, msg, false)
 }
 
 // Used to send an internal message with an optional reply to an arbitrary account.
@@ -514,7 +514,7 @@ func (s *Server) sendInternalResponse(subj string, response *ServerAPIResponse) 
 		s.mu.Unlock()
 		return
 	}
-	s.sys.sendq.push(newPubMsg(nil, subj, _EMPTY_, response.Server, nil, response, response.compress, false, false))
+	s.sys.sendq.push(newPubMsg(nil, subj, EMPTY, response.Server, nil, response, response.compress, false, false))
 	s.mu.Unlock()
 }
 
@@ -681,7 +681,7 @@ func (s *Server) sendStatsz(subj string) {
 		s.mu.Unlock()
 		js.mu.RLock()
 		c := js.config
-		c.StoreDir = _EMPTY_
+		c.StoreDir = EMPTY
 		jStat.Config = &c
 		js.mu.RUnlock()
 		jStat.Stats = js.usageStats()
@@ -712,7 +712,7 @@ func (s *Server) sendStatsz(subj string) {
 		s.mu.Lock()
 	}
 	// Send message.
-	s.sendInternalMsg(subj, _EMPTY_, &m.Server, &m)
+	s.sendInternalMsg(subj, EMPTY, &m.Server, &m)
 }
 
 // Send out our statz update.
@@ -766,7 +766,7 @@ func (s *Server) Node() string {
 	if s.sys != nil {
 		return s.sys.shash
 	}
-	return _EMPTY_
+	return EMPTY
 }
 
 // This will setup our system wide tracking subs.
@@ -876,7 +876,7 @@ func (s *Server) initEventTracking() {
 	}
 	extractAccount := func(subject string) (string, error) {
 		if tk := strings.Split(subject, tsep); len(tk) != accReqTokens {
-			return _EMPTY_, fmt.Errorf("subject %q is malformed", subject)
+			return EMPTY, fmt.Errorf("subject %q is malformed", subject)
 		} else {
 			return tk[accReqAccIndex], nil
 		}
@@ -900,7 +900,7 @@ func (s *Server) initEventTracking() {
 				if acc, err := extractAccount(subject); err != nil {
 					return nil, err
 				} else {
-					if ci, _, _, _, err := c.srv.getRequestInfo(c, msg); err == nil && ci.Account != _EMPTY_ {
+					if ci, _, _, _, err := c.srv.getRequestInfo(c, msg); err == nil && ci.Account != EMPTY {
 						// Make sure the accounts match.
 						if ci.Account != acc {
 							// Do not leak too much here.
@@ -1070,7 +1070,7 @@ func (s *Server) processRemoteServerShutdown(sid string) {
 }
 
 func (s *Server) sameDomain(domain string) bool {
-	return domain == _EMPTY_ || s.info.Domain == _EMPTY_ || domain == s.info.Domain
+	return domain == EMPTY || s.info.Domain == EMPTY || domain == s.info.Domain
 }
 
 // remoteServerShutdownEvent is called when we get an event from another server shutting down.
@@ -1288,7 +1288,7 @@ func (s *Server) leafNodeConnected(sub *subscription, _ *client, _ *Account, sub
 	}
 
 	s.mu.Lock()
-	na := m.Account == _EMPTY_ || !s.eventsEnabled() || !s.gateway.enabled
+	na := m.Account == EMPTY || !s.eventsEnabled() || !s.gateway.enabled
 	s.mu.Unlock()
 
 	if na {
@@ -1372,13 +1372,13 @@ type JszEventOptions struct {
 // returns true if the request does NOT apply to this server and can be ignored.
 // DO NOT hold the server lock when
 func (s *Server) filterRequest(fOpts *EventFilterOptions) bool {
-	if fOpts.Name != _EMPTY_ && !strings.Contains(s.info.Name, fOpts.Name) {
+	if fOpts.Name != EMPTY && !strings.Contains(s.info.Name, fOpts.Name) {
 		return true
 	}
-	if fOpts.Host != _EMPTY_ && !strings.Contains(s.info.Host, fOpts.Host) {
+	if fOpts.Host != EMPTY && !strings.Contains(s.info.Host, fOpts.Host) {
 		return true
 	}
-	if fOpts.Cluster != _EMPTY_ {
+	if fOpts.Cluster != EMPTY {
 		s.mu.Lock()
 		cluster := s.info.Cluster
 		s.mu.Unlock()
@@ -1394,7 +1394,7 @@ func (s *Server) filterRequest(fOpts *EventFilterOptions) bool {
 			}
 		}
 	}
-	if fOpts.Domain != _EMPTY_ && s.getOpts().JetStreamDomain != fOpts.Domain {
+	if fOpts.Domain != EMPTY && s.getOpts().JetStreamDomain != fOpts.Domain {
 		return true
 	}
 	return false
@@ -1436,7 +1436,7 @@ func (s *Server) statszReq(sub *subscription, c *client, _ *Account, subject, re
 	}
 
 	// No reply is a signal that we should use our normal broadcast subject.
-	if reply == _EMPTY_ {
+	if reply == EMPTY {
 		reply = fmt.Sprintf(serverStatsSubj, s.info.ID)
 	}
 
@@ -1447,7 +1447,7 @@ func (s *Server) statszReq(sub *subscription, c *client, _ *Account, subject, re
 				Server: &ServerInfo{},
 				Error:  &ApiError{Code: http.StatusBadRequest, Description: err.Error()},
 			}
-			s.sendInternalMsgLocked(reply, _EMPTY_, response.Server, response)
+			s.sendInternalMsgLocked(reply, EMPTY, response.Server, response)
 			return
 		} else if ignore := s.filterRequest(&opts.EventFilterOptions); ignore {
 			return
@@ -1468,7 +1468,7 @@ const (
 // This is not as formal as it could be. We see if anything has s2 or snappy first, then gzip.
 func getAcceptEncoding(hdr []byte) compressionType {
 	ae := strings.ToLower(string(getHeader(acceptEncodingHeader, hdr)))
-	if ae == _EMPTY_ {
+	if ae == EMPTY {
 		return noCompression
 	}
 	if strings.Contains(ae, "snappy") || strings.Contains(ae, "s2") {
@@ -1481,7 +1481,7 @@ func getAcceptEncoding(hdr []byte) compressionType {
 }
 
 func (s *Server) zReq(c *client, reply string, rmsg []byte, fOpts *EventFilterOptions, optz interface{}, respf func() (interface{}, error)) {
-	if !s.EventsEnabled() || reply == _EMPTY_ {
+	if !s.EventsEnabled() || reply == EMPTY {
 		return
 	}
 	response := &ServerAPIResponse{Server: &ServerInfo{}}
@@ -1623,7 +1623,7 @@ func (s *Server) sendLeafNodeConnect(a *Account) {
 func (s *Server) sendLeafNodeConnectMsg(accName string) {
 	subj := fmt.Sprintf(leafNodeConnectEventSubj, accName)
 	m := accNumConnsReq{Account: accName}
-	s.sendInternalMsg(subj, _EMPTY_, &m.Server, &m)
+	s.sendInternalMsg(subj, EMPTY, &m.Server, &m)
 }
 
 // sendAccConnsUpdate is called to send out our information on the
@@ -1664,7 +1664,7 @@ func (s *Server) sendAccConnsUpdate(a *Account, subj ...string) {
 		}
 	}
 	for _, sub := range subj {
-		msg := newPubMsg(nil, sub, _EMPTY_, &m.Server, nil, &m, noCompression, false, false)
+		msg := newPubMsg(nil, sub, EMPTY, &m.Server, nil, &m, noCompression, false, false)
 		sendQ.push(msg)
 	}
 	a.mu.Unlock()
@@ -1732,7 +1732,7 @@ func (s *Server) accountConnectEvent(c *client) {
 	c.mu.Unlock()
 
 	subj := fmt.Sprintf(connectEventSubj, c.acc.Name)
-	s.sendInternalMsgLocked(subj, _EMPTY_, &m.Server, &m)
+	s.sendInternalMsgLocked(subj, EMPTY, &m.Server, &m)
 }
 
 // accountDisconnectEvent will send an account client disconnect event if there is interest.
@@ -1794,7 +1794,7 @@ func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string)
 	c.mu.Unlock()
 
 	subj := fmt.Sprintf(disconnectEventSubj, accName)
-	s.sendInternalMsgLocked(subj, _EMPTY_, &m.Server, &m)
+	s.sendInternalMsgLocked(subj, EMPTY, &m.Server, &m)
 }
 
 func (s *Server) sendAuthErrorEvent(c *client) {
@@ -1846,7 +1846,7 @@ func (s *Server) sendAuthErrorEvent(c *client) {
 
 	s.mu.Lock()
 	subj := fmt.Sprintf(authErrorEventSubj, s.info.ID)
-	s.sendInternalMsg(subj, _EMPTY_, &m.Server, &m)
+	s.sendInternalMsg(subj, EMPTY, &m.Server, &m)
 	s.mu.Unlock()
 }
 
@@ -1857,7 +1857,7 @@ type msgHandler func(sub *subscription, client *client, acc *Account, subject, r
 
 // Create an internal subscription. sysSubscribeQ for queue groups.
 func (s *Server) sysSubscribe(subject string, cb msgHandler) (*subscription, error) {
-	return s.systemSubscribe(subject, _EMPTY_, false, nil, cb)
+	return s.systemSubscribe(subject, EMPTY, false, nil, cb)
 }
 
 // Create an internal subscription with queue
@@ -1867,7 +1867,7 @@ func (s *Server) sysSubscribeQ(subject, queue string, cb msgHandler) (*subscript
 
 // Create an internal subscription but do not forward interest.
 func (s *Server) sysSubscribeInternal(subject string, cb msgHandler) (*subscription, error) {
-	return s.systemSubscribe(subject, _EMPTY_, true, nil, cb)
+	return s.systemSubscribe(subject, EMPTY, true, nil, cb)
 }
 
 func (s *Server) systemSubscribe(subject, queue string, internalOnly bool, c *client, cb msgHandler) (*subscription, error) {
@@ -2211,7 +2211,7 @@ func (s *Server) nsubsRequest(sub *subscription, c *client, _ *Account, subject,
 			}
 		}
 	}
-	s.sendInternalMsgLocked(reply, _EMPTY_, nil, nsubs)
+	s.sendInternalMsgLocked(reply, EMPTY, nil, nsubs)
 }
 
 // Helper to grab account name for a client.
@@ -2228,7 +2228,7 @@ func issuerForClient(c *client) (issuerKey string) {
 		return
 	}
 	issuerKey = c.user.SigningKey
-	if issuerKey == _EMPTY_ && c.user.Account != nil {
+	if issuerKey == EMPTY && c.user.Account != nil {
 		issuerKey = c.user.Account.Name
 	}
 	return

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1588,7 +1588,7 @@ func TestSystemAccountWithBadRemoteLatencyUpdate(t *testing.T) {
 		ReqId:   "_INBOX.22",
 	}
 	b, _ := json.Marshal(&rl)
-	s.remoteLatencyUpdate(nil, nil, nil, "foo", _EMPTY_, b)
+	s.remoteLatencyUpdate(nil, nil, nil, "foo", EMPTY, b)
 }
 
 func TestSystemAccountWithGateways(t *testing.T) {
@@ -1683,11 +1683,11 @@ func TestSystemAccountNoAuthUser(t *testing.T) {
 		account string
 	}{
 		{"valid user/pwd", "admin:pwd@", true, "$SYS"},
-		{"invalid pwd", "admin:wrong@", false, _EMPTY_},
-		{"some token", "sometoken@", false, _EMPTY_},
-		{"user used without pwd", "admin@", false, _EMPTY_}, // will be treated as a token
-		{"user with empty password", "admin:@", false, _EMPTY_},
-		{"no user means global account", _EMPTY_, true, globalAccountName},
+		{"invalid pwd", "admin:wrong@", false, EMPTY},
+		{"some token", "sometoken@", false, EMPTY},
+		{"user used without pwd", "admin@", false, EMPTY}, // will be treated as a token
+		{"user with empty password", "admin:@", false, EMPTY},
+		{"no user means global account", EMPTY, true, globalAccountName},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			url := fmt.Sprintf("nats://%s127.0.0.1:%d", test.usrInfo, o.Port)

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -3131,7 +3131,7 @@ func TestFileStoreExpireMsgsOnStart(t *testing.T) {
 			errStr = fmt.Sprintf("deleted map does not match: %d vs %d", mb.dmap, mbc.dmap)
 		}
 		mb.mu.RUnlock()
-		if errStr != _EMPTY_ {
+		if errStr != EMPTY {
 			t.Fatal(errStr)
 		}
 	}

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -812,7 +812,7 @@ func (s *Server) createGateway(cfg *gatewayCfg, url *url.URL, conn net.Conn) {
 		if resetTLSName, err := c.doTLSHandshake("gateway", solicit, url, tlsConfig, tlsName, timeout, opts.Gateway.TLSPinnedCerts); err != nil {
 			if resetTLSName {
 				cfg.Lock()
-				cfg.tlsName = _EMPTY_
+				cfg.tlsName = EMPTY
 				cfg.Unlock()
 			}
 			c.mu.Unlock()
@@ -2870,7 +2870,7 @@ func (c *client) handleGatewayReply(msg []byte) (processed bool) {
 		}
 		buf = append(buf, szb...)
 		mhEnd := len(buf)
-		buf = append(buf, _CRLF_...)
+		buf = append(buf, CR_LF...)
 		buf = append(buf, msg...)
 
 		route.mu.Lock()

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -5307,7 +5307,7 @@ func TestGatewayPingPongReplyAcrossGateways(t *testing.T) {
 		nca.Publish(msg.Reply, []byte("sa reply"))
 		// And make sure that subS2 receives it...
 		msg = natsNexMsg(t, subSB, time.Second)
-		if string(msg.Data) != "sa reply" || msg.Reply != _EMPTY_ {
+		if string(msg.Data) != "sa reply" || msg.Reply != EMPTY {
 			t.Fatalf("Unexpected message from sa: %v", msg)
 		}
 	}

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -163,16 +163,16 @@ func (s *Server) EnableJetStream(config *JetStreamConfig) error {
 		if maxMem > 0 {
 			config.MaxMemory = maxMem
 		}
-		if domain != _EMPTY_ {
+		if domain != EMPTY {
 			config.Domain = domain
 		}
 		s.Debugf("JetStream creating dynamic configuration - %s memory, %s disk", friendlyBytes(config.MaxMemory), friendlyBytes(config.MaxStore))
-	} else if config.StoreDir != _EMPTY_ {
+	} else if config.StoreDir != EMPTY {
 		config.StoreDir = filepath.Join(config.StoreDir, JetStreamStoreDir)
 	}
 
 	cfg := *config
-	if cfg.StoreDir == _EMPTY_ {
+	if cfg.StoreDir == EMPTY {
 		cfg.StoreDir = filepath.Join(os.TempDir(), JetStreamStoreDir)
 	}
 
@@ -182,7 +182,7 @@ func (s *Server) EnableJetStream(config *JetStreamConfig) error {
 		return err
 	}
 
-	if ek := s.getOpts().JetStreamKey; ek != _EMPTY_ {
+	if ek := s.getOpts().JetStreamKey; ek != EMPTY {
 		s.Warnf("JetStream Encryption is Beta")
 	}
 
@@ -195,7 +195,7 @@ type keyGen func(context []byte) ([]byte, error)
 // Return a key generation function or nil if encryption not enabled.
 // keyGen defined in filestore.go - keyGen func(iv, context []byte) []byte
 func (s *Server) jsKeyGen(info string) keyGen {
-	if ek := s.getOpts().JetStreamKey; ek != _EMPTY_ {
+	if ek := s.getOpts().JetStreamKey; ek != EMPTY {
 		return func(context []byte) ([]byte, error) {
 			h := hmac.New(sha256.New, []byte(ek))
 			if _, err := h.Write([]byte(info)); err != nil {
@@ -274,7 +274,7 @@ func (s *Server) checkStoreDir(cfg *JetStreamConfig) error {
 			continue
 		}
 		// Let's see if this is an account.
-		if accName := fi.Name(); accName != _EMPTY_ {
+		if accName := fi.Name(); accName != EMPTY {
 			_, ok := s.accounts.Load(accName)
 			if !ok && s.AccountResolver() != nil && nkeys.IsValidPublicAccountKey(accName) {
 				// Account is not local but matches the NKEY account public key,
@@ -348,7 +348,7 @@ func (s *Server) enableJetStream(cfg JetStreamConfig) error {
 	s.Noticef("  Max Memory:      %s", friendlyBytes(cfg.MaxMemory))
 	s.Noticef("  Max Storage:     %s", friendlyBytes(cfg.MaxStore))
 	s.Noticef("  Store Directory: \"%s\"", cfg.StoreDir)
-	if cfg.Domain != _EMPTY_ {
+	if cfg.Domain != EMPTY {
 		s.Noticef("  Domain:          %s", cfg.Domain)
 	}
 	s.Noticef("-------------------------------------------")
@@ -577,14 +577,14 @@ func (a *Account) enableAllJetStreamServiceImportsAndMappings() error {
 	}
 
 	if !a.serviceImportExists(jsAllAPI) {
-		if err := a.AddServiceImport(s.SystemAccount(), jsAllAPI, _EMPTY_); err != nil {
+		if err := a.AddServiceImport(s.SystemAccount(), jsAllAPI, EMPTY); err != nil {
 			return fmt.Errorf("Error setting up jetstream service imports for account: %v", err)
 		}
 	}
 
 	// Check if we have a Domain specified.
 	// If so add in a subject mapping that will allow local connected clients to reach us here as well.
-	if opts := s.getOpts(); opts.JetStreamDomain != _EMPTY_ {
+	if opts := s.getOpts(); opts.JetStreamDomain != EMPTY {
 		mappings := generateJSMappingTable(opts.JetStreamDomain)
 		a.mu.RLock()
 		for _, m := range a.mappings {
@@ -683,7 +683,7 @@ func (s *Server) configAllJetStreamAccounts() error {
 	// This is important in resolver/operator models.
 	fis, _ := ioutil.ReadDir(js.config.StoreDir)
 	for _, fi := range fis {
-		if accName := fi.Name(); accName != _EMPTY_ {
+		if accName := fi.Name(); accName != EMPTY {
 			// Only load up ones not already loaded since they are processed above.
 			if _, ok := accounts.Load(accName); !ok {
 				if acc, err := s.lookupAccount(accName); err != nil && acc != nil {
@@ -793,7 +793,7 @@ func (s *Server) migrateEphemerals() {
 					if pr := o.pendingRequestReplies(); len(pr) > 0 {
 						o.mu.Lock()
 						for _, reply := range pr {
-							o.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
+							o.outq.send(newJSPubMsg(reply, EMPTY, EMPTY, hdr, nil, nil, 0))
 						}
 						o.mu.Unlock()
 					}
@@ -883,7 +883,7 @@ func (s *Server) StoreDir() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.js == nil {
-		return _EMPTY_
+		return EMPTY
 	}
 	return s.js.config.StoreDir
 }
@@ -1052,7 +1052,7 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 				s.Warnf("  Error unmarshalling StreamTemplate metafile: %v", err)
 				continue
 			}
-			cfg.Config.Name = _EMPTY_
+			cfg.Config.Name = EMPTY
 			if _, err := a.addStreamTemplate(&cfg); err != nil {
 				s.Warnf("  Error recreating StreamTemplate %q: %v", cfg.Name, err)
 				continue
@@ -1123,7 +1123,7 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 			continue
 		}
 
-		if cfg.Template != _EMPTY_ {
+		if cfg.Template != EMPTY {
 			if err := jsa.addStreamNameToTemplate(cfg.Template, cfg.Name); err != nil {
 				s.Warnf("  Error adding stream %q to template %q: %v", cfg.Name, cfg.Template, err)
 			}
@@ -1272,7 +1272,7 @@ func (a *Account) numStreams() int {
 
 // Streams will return all known streams.
 func (a *Account) streams() []*stream {
-	return a.filteredStreams(_EMPTY_)
+	return a.filteredStreams(EMPTY)
 }
 
 func (a *Account) filteredStreams(filter string) []*stream {
@@ -1289,7 +1289,7 @@ func (a *Account) filteredStreams(filter string) []*stream {
 
 	var msets []*stream
 	for _, mset := range jsa.streams {
-		if filter != _EMPTY_ {
+		if filter != EMPTY {
 			for _, subj := range mset.cfg.Subjects {
 				if SubjectsCollide(filter, subj) {
 					msets = append(msets, mset)
@@ -1484,7 +1484,7 @@ func (jsa *jsAccount) remoteUpdateUsage(sub *subscription, c *client, _ *Account
 	if li := strings.LastIndexByte(subject, btsep); li > 0 && li < len(subject) {
 		rnode = subject[li+1:]
 	}
-	if rnode == _EMPTY_ {
+	if rnode == EMPTY {
 		jsa.mu.Unlock()
 		s.Warnf("Received remote usage update with no remote node")
 		return
@@ -1574,7 +1574,7 @@ func (jsa *jsAccount) sendClusterUsageUpdate() {
 	le.PutUint64(b[16:], uint64(jsa.usage.api))
 	le.PutUint64(b[24:], uint64(jsa.usage.err))
 
-	jsa.sendq.push(newPubMsg(nil, jsa.updatesPub, _EMPTY_, nil, nil, b, noCompression, false, false))
+	jsa.sendq.push(newPubMsg(nil, jsa.updatesPub, EMPTY, nil, nil, b, noCompression, false, false))
 }
 
 func (js *jetStream) wouldExceedLimits(storeType StorageType, sz int) bool {
@@ -1843,7 +1843,7 @@ const (
 // Dynamically create a config with a tmp based directory (repeatable) and 75% of system memory.
 func (s *Server) dynJetStreamConfig(storeDir string, maxStore, maxMem int64) *JetStreamConfig {
 	jsc := &JetStreamConfig{}
-	if storeDir != _EMPTY_ {
+	if storeDir != EMPTY {
 		jsc.StoreDir = filepath.Join(storeDir, JetStreamStoreDir)
 	} else {
 		// Create one in tmp directory, but make it consistent for restarts.
@@ -2253,7 +2253,7 @@ func validateJetStreamOptions(o *Options) error {
 				} else {
 					for _, acc := range o.Accounts {
 						if a == acc.GetName() {
-							if acc.jsLimits != nil && domain != _EMPTY_ {
+							if acc.jsLimits != nil && domain != EMPTY {
 								return fmt.Errorf("default_js_domain contains account name %q with enabled JetStream", a)
 							}
 							found = true
@@ -2274,13 +2274,13 @@ func validateJetStreamOptions(o *Options) error {
 		}
 		for a, d := range o.JsAccDefaultDomain {
 			sacc := DEFAULT_SYSTEM_ACCOUNT
-			if o.SystemAccount != _EMPTY_ {
+			if o.SystemAccount != EMPTY {
 				sacc = o.SystemAccount
 			}
 			if a == sacc {
 				return fmt.Errorf("system account %q can not be in default_js_domain", a)
 			}
-			if d == _EMPTY_ {
+			if d == EMPTY {
 				continue
 			}
 			if sub := fmt.Sprintf(jsDomainAPI, d); !IsValidSubject(sub) {
@@ -2288,7 +2288,7 @@ func validateJetStreamOptions(o *Options) error {
 			}
 		}
 	}
-	if o.JetStreamDomain != _EMPTY_ {
+	if o.JetStreamDomain != EMPTY {
 		if subj := fmt.Sprintf(jsDomainAPI, o.JetStreamDomain); !IsValidSubject(subj) {
 			return fmt.Errorf("invalid domain name: derived %q is not a valid subject", subj)
 		}
@@ -2301,16 +2301,16 @@ func validateJetStreamOptions(o *Options) error {
 	if !o.JetStream || o.Cluster.Port == 0 {
 		return nil
 	}
-	if o.ServerName == _EMPTY_ {
+	if o.ServerName == EMPTY {
 		return fmt.Errorf("jetstream cluster requires `server_name` to be set")
 	}
-	if o.Cluster.Name == _EMPTY_ {
+	if o.Cluster.Name == EMPTY {
 		return fmt.Errorf("jetstream cluster requires `cluster.name` to be set")
 	}
 
 	h := strings.ToLower(o.JetStreamExtHint)
 	switch h {
-	case jsWillExtend, jsNoExtend, _EMPTY_:
+	case jsWillExtend, jsNoExtend, EMPTY:
 		o.JetStreamExtHint = h
 	default:
 		return fmt.Errorf("expected 'no_extend' for string value, got '%s'", h)

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -777,7 +777,7 @@ func (s *Server) setJetStreamExportSubs() error {
 
 func (s *Server) sendAPIResponse(ci *ClientInfo, acc *Account, subject, reply, request, response string) {
 	acc.trackAPI()
-	if reply != _EMPTY_ {
+	if reply != EMPTY {
 		s.sendInternalAccountMsg(nil, reply, response)
 	}
 	s.sendJetStreamAPIAuditAdvisory(ci, acc, subject, request, response)
@@ -785,7 +785,7 @@ func (s *Server) sendAPIResponse(ci *ClientInfo, acc *Account, subject, reply, r
 
 func (s *Server) sendAPIErrResponse(ci *ClientInfo, acc *Account, subject, reply, request, response string) {
 	acc.trackAPIErr()
-	if reply != _EMPTY_ {
+	if reply != EMPTY {
 		s.sendInternalAccountMsg(nil, reply, response)
 	}
 	s.sendJetStreamAPIAuditAdvisory(ci, acc, subject, request, response)
@@ -805,7 +805,7 @@ func (s *Server) sendDelayedAPIErrResponse(ci *ClientInfo, acc *Account, subject
 		case <-s.quitCh:
 		case <-time.After(errRespDelay):
 			acc.trackAPIErr()
-			if reply != _EMPTY_ {
+			if reply != EMPTY {
 				s.sendInternalAccountMsg(nil, reply, response)
 			}
 			s.sendJetStreamAPIAuditAdvisory(ci, acc, subject, request, response)
@@ -823,9 +823,9 @@ func (s *Server) getRequestInfo(c *client, raw []byte) (pci *ClientInfo, acc *Ac
 		}
 	}
 
-	if ci.Service != _EMPTY_ {
+	if ci.Service != EMPTY {
 		acc, _ = s.LookupAccount(ci.Service)
-	} else if ci.Account != _EMPTY_ {
+	} else if ci.Account != EMPTY {
 		acc, _ = s.LookupAccount(ci.Account)
 	} else {
 		// Direct $SYS access.
@@ -1234,7 +1234,7 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, _ *Account,
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
-		if cfg.Mirror.FilterSubject != _EMPTY_ {
+		if cfg.Mirror.FilterSubject != EMPTY {
 			resp.Error = NewJSMirrorWithSubjectFiltersError()
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
@@ -1260,10 +1260,10 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, _ *Account,
 			return
 		}
 		if cfg.Mirror.External != nil {
-			if cfg.Mirror.External.DeliverPrefix != _EMPTY_ {
+			if cfg.Mirror.External.DeliverPrefix != EMPTY {
 				deliveryPrefixes = append(deliveryPrefixes, cfg.Mirror.External.DeliverPrefix)
 			}
-			if cfg.Mirror.External.ApiPrefix != _EMPTY_ {
+			if cfg.Mirror.External.ApiPrefix != EMPTY {
 				apiPrefixes = append(apiPrefixes, cfg.Mirror.External.ApiPrefix)
 			}
 		}
@@ -1277,10 +1277,10 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, _ *Account,
 			if len(subs) > 0 {
 				streamSubs = append(streamSubs, subs...)
 			}
-			if src.External.DeliverPrefix != _EMPTY_ {
+			if src.External.DeliverPrefix != EMPTY {
 				deliveryPrefixes = append(deliveryPrefixes, src.External.DeliverPrefix)
 			}
-			if src.External.ApiPrefix != _EMPTY_ {
+			if src.External.ApiPrefix != EMPTY {
 				apiPrefixes = append(apiPrefixes, src.External.ApiPrefix)
 			}
 			if exists && cfg.MaxMsgSize > 0 && maxMsgSize > 0 && cfg.MaxMsgSize < maxMsgSize {
@@ -1475,7 +1475,7 @@ func (s *Server) jsStreamNamesRequest(sub *subscription, c *client, _ *Account, 
 			return
 		}
 		offset = req.Offset
-		if req.Subject != _EMPTY_ {
+		if req.Subject != EMPTY {
 			filter = req.Subject
 		}
 	}
@@ -1494,7 +1494,7 @@ func (s *Server) jsStreamNamesRequest(sub *subscription, c *client, _ *Account, 
 			if IsNatsErr(sa.err, JSClusterNotAssignedErr) {
 				continue
 			}
-			if filter != _EMPTY_ {
+			if filter != EMPTY {
 				// These could not have subjects auto-filled in since they are raw and unprocessed.
 				if len(sa.Config.Subjects) == 0 {
 					if SubjectsCollide(filter, sa.Config.Name) {
@@ -1602,7 +1602,7 @@ func (s *Server) jsStreamListRequest(sub *subscription, c *client, _ *Account, s
 			return
 		}
 		offset = req.Offset
-		if req.Subject != _EMPTY_ {
+		if req.Subject != EMPTY {
 			filter = req.Subject
 		}
 	}
@@ -1617,7 +1617,7 @@ func (s *Server) jsStreamListRequest(sub *subscription, c *client, _ *Account, s
 	// TODO(dlc) - Maybe hold these results for large results that we expect to be paged.
 	// TODO(dlc) - If this list is long maybe do this in a Go routine?
 	var msets []*stream
-	if filter == _EMPTY_ {
+	if filter == EMPTY {
 		msets = acc.streams()
 	} else {
 		msets = acc.filteredStreams(filter)
@@ -1777,7 +1777,7 @@ func (s *Server) jsStreamInfoRequest(sub *subscription, c *client, a *Account, s
 	}
 
 	// Check if they have asked for subject details.
-	if subjects != _EMPTY_ {
+	if subjects != EMPTY {
 		if mss := mset.store.SubjectsState(subjects); len(mss) > 0 {
 			if len(mss) > JSMaxSubjectDetails {
 				resp.StreamInfo = nil
@@ -2051,7 +2051,7 @@ func (s *Server) jsStreamRemovePeerRequest(sub *subscription, c *client, _ *Acco
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
-	if req.Peer == _EMPTY_ {
+	if req.Peer == EMPTY {
 		resp.Error = NewJSBadRequestError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
@@ -2143,7 +2143,7 @@ func (s *Server) jsLeaderServerRemoveRequest(sub *subscription, c *client, _ *Ac
 	}
 	js.mu.RUnlock()
 
-	if found == _EMPTY_ {
+	if found == EMPTY {
 		resp.Error = NewJSClusterServerNotMemberError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
@@ -2522,7 +2522,7 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, _ *Account, subje
 	}
 
 	// Check that we do not have both options set.
-	if req.Seq > 0 && req.LastFor != _EMPTY_ || req.Seq == 0 && req.LastFor == _EMPTY_ {
+	if req.Seq > 0 && req.LastFor != EMPTY || req.Seq == 0 && req.LastFor == EMPTY {
 		resp.Error = NewJSBadRequestError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
@@ -2714,7 +2714,7 @@ func (s *Server) jsStreamRestoreRequest(sub *subscription, c *client, _ *Account
 
 	stream := streamNameFromSubject(subject)
 
-	if stream != req.Config.Name && req.Config.Name == _EMPTY_ {
+	if stream != req.Config.Name && req.Config.Name == EMPTY {
 		req.Config.Name = stream
 	}
 
@@ -2794,7 +2794,7 @@ func (s *Server) processStreamRestore(ci *ClientInfo, acc *Account, cfg *StreamC
 	// FIXM(dlc) - Probably take out of network path eventually due to disk I/O?
 	processChunk := func(sub *subscription, c *client, _ *Account, subject, reply string, msg []byte) {
 		// We require reply subjects to communicate back failures, flow etc. If they do not have one log and cancel.
-		if reply == _EMPTY_ {
+		if reply == EMPTY {
 			sub.client.processUnsub(sub.sid)
 			resultCh <- result{
 				fmt.Errorf("restore for stream '%s > %s' requires reply subject for each chunk", acc.Name, streamName),
@@ -2833,7 +2833,7 @@ func (s *Server) processStreamRestore(ci *ClientInfo, acc *Account, cfg *StreamC
 		// Append chunk to temp file. Mark as issue if we encounter an error.
 		if n, err := tfile.Write(msg); n != len(msg) || err != nil {
 			resultCh <- result{err, reply}
-			if reply != _EMPTY_ {
+			if reply != EMPTY {
 				s.sendInternalAccountMsg(acc, reply, "-ERR 'storage failure during restore'")
 			}
 			return
@@ -3121,7 +3121,7 @@ func (s *Server) streamSnapshot(ci *ClientInfo, acc *Account, mset *stream, sr *
 		chunk = chunk[:n]
 		if err != nil {
 			if n > 0 {
-				mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, chunk, nil, 0))
+				mset.outq.send(newJSPubMsg(reply, EMPTY, EMPTY, nil, chunk, nil, 0))
 			}
 			break
 		}
@@ -3137,13 +3137,13 @@ func (s *Server) streamSnapshot(ci *ClientInfo, acc *Account, mset *stream, sr *
 			}
 		}
 		ackReply := fmt.Sprintf("%s.%d.%d", ackSubj, len(chunk), index)
-		mset.outq.send(newJSPubMsg(reply, _EMPTY_, ackReply, nil, chunk, nil, 0))
+		mset.outq.send(newJSPubMsg(reply, EMPTY, ackReply, nil, chunk, nil, 0))
 		atomic.AddInt32(&out, int32(len(chunk)))
 	}
 done:
 	// Send last EOF
 	// TODO(dlc) - place hash in header
-	mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, nil, nil, 0))
+	mset.outq.send(newJSPubMsg(reply, EMPTY, EMPTY, nil, nil, nil, 0))
 }
 
 // Request to create a durable consumer.
@@ -3244,7 +3244,7 @@ func (s *Server) jsConsumerCreate(sub *subscription, c *client, a *Account, subj
 			return
 		}
 		// Now check on requirements for durable request.
-		if req.Config.Durable == _EMPTY_ {
+		if req.Config.Durable == EMPTY {
 			resp.Error = NewJSConsumerDurableNameNotSetError()
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
@@ -3261,7 +3261,7 @@ func (s *Server) jsConsumerCreate(sub *subscription, c *client, a *Account, subj
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
-		if req.Config.Durable != _EMPTY_ {
+		if req.Config.Durable != EMPTY {
 			resp.Error = NewJSConsumerEphemeralWithDurableNameError()
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
@@ -3612,7 +3612,7 @@ func (s *Server) jsConsumerInfoRequest(sub *subscription, c *client, _ *Account,
 				}
 				return
 			}
-			if node != nil && (node.GroupLeader() != _EMPTY_ || node.HadPreviousLeader()) {
+			if node != nil && (node.GroupLeader() != EMPTY || node.HadPreviousLeader()) {
 				return
 			}
 			// If we are here we are a member and this is just a new consumer that does not have a leader yet.

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -6158,7 +6158,7 @@ func TestJetStreamClusterMixedMode(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 
-			c := createMixedModeCluster(t, test.tmpl, "MM5", _EMPTY_, 3, 2, true)
+			c := createMixedModeCluster(t, test.tmpl, "MM5", EMPTY, 3, 2, true)
 			defer c.shutdown()
 
 			// Client based API - Non-JS server.
@@ -6205,16 +6205,16 @@ func TestJetStreamClusterMixedMode(t *testing.T) {
 }
 
 func TestJetStreamClusterLeafnodeSpokes(t *testing.T) {
-	c := createJetStreamCluster(t, jsClusterTempl, "HUB", _EMPTY_, 3, 22020, false)
+	c := createJetStreamCluster(t, jsClusterTempl, "HUB", EMPTY, 3, 22020, false)
 	defer c.shutdown()
 
-	lnc1 := c.createLeafNodesWithStartPortAndDomain("R1", 3, 22110, _EMPTY_)
+	lnc1 := c.createLeafNodesWithStartPortAndDomain("R1", 3, 22110, EMPTY)
 	defer lnc1.shutdown()
 
-	lnc2 := c.createLeafNodesWithStartPortAndDomain("R2", 3, 22120, _EMPTY_)
+	lnc2 := c.createLeafNodesWithStartPortAndDomain("R2", 3, 22120, EMPTY)
 	defer lnc2.shutdown()
 
-	lnc3 := c.createLeafNodesWithStartPortAndDomain("R3", 3, 22130, _EMPTY_)
+	lnc3 := c.createLeafNodesWithStartPortAndDomain("R3", 3, 22130, EMPTY)
 	defer lnc3.shutdown()
 
 	// Wait on all peers.
@@ -6224,7 +6224,7 @@ func TestJetStreamClusterLeafnodeSpokes(t *testing.T) {
 	lnc3.shutdown()
 	c.waitOnPeerCount(9)
 
-	lnc3 = c.createLeafNodesWithStartPortAndDomain("LNC3", 3, 22130, _EMPTY_)
+	lnc3 = c.createLeafNodesWithStartPortAndDomain("LNC3", 3, 22130, EMPTY)
 	defer lnc3.shutdown()
 
 	c.waitOnPeerCount(12)
@@ -6430,7 +6430,7 @@ func TestJetStreamClusterSuperClusterAndSingleLeafNodeWithSharedSystemAccount(t 
 
 func TestJetStreamClusterLeafNodeDenyNoDupe(t *testing.T) {
 	tmpl := strings.Replace(jsClusterAccountsTempl, "store_dir:", "domain: CORE, store_dir:", 1)
-	c := createJetStreamCluster(t, tmpl, "CORE", _EMPTY_, 3, 18033, true)
+	c := createJetStreamCluster(t, tmpl, "CORE", EMPTY, 3, 18033, true)
 	defer c.shutdown()
 
 	tmpl = strings.Replace(jsClusterTemplWithSingleLeafNode, "store_dir:", "domain: SPOKE, store_dir:", 1)
@@ -6470,7 +6470,7 @@ func TestJetStreamClusterLeafNodeDenyNoDupe(t *testing.T) {
 
 // Multiple JS domains.
 func TestJetStreamClusterSingleLeafNodeWithoutSharedSystemAccount(t *testing.T) {
-	c := createJetStreamCluster(t, strings.Replace(jsClusterAccountsTempl, "store_dir", "domain: CORE, store_dir", 1), "HUB", _EMPTY_, 3, 14333, true)
+	c := createJetStreamCluster(t, strings.Replace(jsClusterAccountsTempl, "store_dir", "domain: CORE, store_dir", 1), "HUB", EMPTY, 3, 14333, true)
 	defer c.shutdown()
 
 	ln := c.createSingleLeafNodeNoSystemAccount()
@@ -6666,7 +6666,7 @@ func TestJetStreamClusterSingleLeafNodeWithoutSharedSystemAccount(t *testing.T) 
 func TestJetStreamClusterDomains(t *testing.T) {
 	// This adds in domain config option to template.
 	tmpl := strings.Replace(jsClusterAccountsTempl, "store_dir:", "domain: CORE, store_dir:", 1)
-	c := createJetStreamCluster(t, tmpl, "CORE", _EMPTY_, 3, 12232, true)
+	c := createJetStreamCluster(t, tmpl, "CORE", EMPTY, 3, 12232, true)
 	defer c.shutdown()
 
 	// This leafnode is a single server with no domain but sharing the system account.
@@ -6864,7 +6864,7 @@ func TestJetStreamClusterDomains(t *testing.T) {
 
 func TestJetStreamClusterDomainsWithNoJSHub(t *testing.T) {
 	// Create our hub cluster with no JetStream defined.
-	c := createMixedModeCluster(t, jsClusterAccountsTempl, "NOJS5", _EMPTY_, 0, 5, false)
+	c := createMixedModeCluster(t, jsClusterAccountsTempl, "NOJS5", EMPTY, 0, 5, false)
 	defer c.shutdown()
 
 	ln := c.createSingleLeafNodeNoSystemAccountAndEnablesJetStream()
@@ -6909,7 +6909,7 @@ func TestJetStreamClusterDomainsWithNoJSHub(t *testing.T) {
 	if err = json.Unmarshal(resp.Data, &si); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if si.Domain != _EMPTY_ {
+	if si.Domain != EMPTY {
 		t.Fatalf("Expected to have NO domain set but got %q", si.Domain)
 	}
 
@@ -6943,7 +6943,7 @@ func TestJetStreamClusterDomainsWithNoJSHub(t *testing.T) {
 func TestJetStreamClusterDomainsAndAPIResponses(t *testing.T) {
 	// This adds in domain config option to template.
 	tmpl := strings.Replace(jsClusterAccountsTempl, "store_dir:", "domain: CORE, store_dir:", 1)
-	c := createJetStreamCluster(t, tmpl, "CORE", _EMPTY_, 3, 12232, true)
+	c := createJetStreamCluster(t, tmpl, "CORE", EMPTY, 3, 12232, true)
 	defer c.shutdown()
 
 	// Now create spoke LN cluster.
@@ -6992,7 +6992,7 @@ func TestJetStreamClusterDomainsAndAPIResponses(t *testing.T) {
 // Issue #2202
 func TestJetStreamClusterDomainsAndSameNameSources(t *testing.T) {
 	tmpl := strings.Replace(jsClusterAccountsTempl, "store_dir:", "domain: CORE, store_dir:", 1)
-	c := createJetStreamCluster(t, tmpl, "CORE", _EMPTY_, 3, 9323, true)
+	c := createJetStreamCluster(t, tmpl, "CORE", EMPTY, 3, 9323, true)
 	defer c.shutdown()
 
 	tmpl = strings.Replace(jsClusterTemplWithSingleLeafNode, "store_dir:", "domain: SPOKE-1, store_dir:", 1)
@@ -7127,7 +7127,7 @@ func TestJetStreamClusterDomainsAndSameNameSources(t *testing.T) {
 // the server having set up appropriate defaults (default_js_domain. tested in leafnode_test.go)
 func TestJetStreamClusterSingleLeafNodeEnablingJetStream(t *testing.T) {
 	tmpl := strings.Replace(jsClusterAccountsTempl, "store_dir:", "domain: HUB, store_dir:", 1)
-	c := createJetStreamCluster(t, tmpl, "HUB", _EMPTY_, 3, 11322, true)
+	c := createJetStreamCluster(t, tmpl, "HUB", EMPTY, 3, 11322, true)
 	defer c.shutdown()
 
 	ln := c.createSingleLeafNodeNoSystemAccountAndEnablesJetStream()
@@ -7152,7 +7152,7 @@ func TestJetStreamClusterSingleLeafNodeEnablingJetStream(t *testing.T) {
 
 func TestJetStreamClusterLeafNodesWithoutJS(t *testing.T) {
 	tmpl := strings.Replace(jsClusterAccountsTempl, "store_dir:", "domain: HUB, store_dir:", 1)
-	c := createJetStreamCluster(t, tmpl, "HUB", _EMPTY_, 3, 11233, true)
+	c := createJetStreamCluster(t, tmpl, "HUB", EMPTY, 3, 11233, true)
 	defer c.shutdown()
 
 	testJS := func(s *Server, domain string, doDomainAPI bool) {
@@ -7206,7 +7206,7 @@ func TestJetStreamClusterLeafNodesWithoutJS(t *testing.T) {
 
 func TestJetStreamClusterLeafNodesWithSameDomainNames(t *testing.T) {
 	tmpl := strings.Replace(jsClusterAccountsTempl, "store_dir:", "domain: HUB, store_dir:", 1)
-	c := createJetStreamCluster(t, tmpl, "HUB", _EMPTY_, 3, 11233, true)
+	c := createJetStreamCluster(t, tmpl, "HUB", EMPTY, 3, 11233, true)
 	defer c.shutdown()
 
 	tmpl = strings.Replace(jsClusterTemplWithLeafNode, "store_dir:", "domain: HUB, store_dir:", 1)
@@ -7315,10 +7315,10 @@ func TestJetStreamClusterSuperClusterPullConsumerAndHeaders(t *testing.T) {
 }
 
 func TestJetStreamClusterLeafDifferentAccounts(t *testing.T) {
-	c := createJetStreamCluster(t, jsClusterAccountsTempl, "HUB", _EMPTY_, 2, 23133, false)
+	c := createJetStreamCluster(t, jsClusterAccountsTempl, "HUB", EMPTY, 2, 23133, false)
 	defer c.shutdown()
 
-	ln := c.createLeafNodesWithStartPortAndDomain("LN", 2, 22110, _EMPTY_)
+	ln := c.createLeafNodesWithStartPortAndDomain("LN", 2, 22110, EMPTY)
 	defer ln.shutdown()
 
 	// Wait on all peers.
@@ -7810,7 +7810,7 @@ func TestJetStreamClusterMsgIdDuplicateBug(t *testing.T) {
 
 func TestJetStreamClusterNilMsgWithHeaderThroughSourcedStream(t *testing.T) {
 	tmpl := strings.Replace(jsClusterAccountsTempl, "store_dir:", "domain: HUB, store_dir:", 1)
-	c := createJetStreamCluster(t, tmpl, "HUB", _EMPTY_, 3, 12232, true)
+	c := createJetStreamCluster(t, tmpl, "HUB", EMPTY, 3, 12232, true)
 	defer c.shutdown()
 
 	tmpl = strings.Replace(jsClusterTemplWithSingleLeafNode, "store_dir:", "domain: SPOKE, store_dir:", 1)
@@ -8825,7 +8825,7 @@ func TestJetStreamAccountLimitsAndRestart(t *testing.T) {
 
 func TestJetStreamClusterMixedModeColdStartPrune(t *testing.T) {
 	// Purposely make this unbalanced. Without changes this will never form a quorum to elect the meta-leader.
-	c := createMixedModeCluster(t, jsMixedModeGlobalAccountTempl, "MMCS5", _EMPTY_, 3, 4, false)
+	c := createMixedModeCluster(t, jsMixedModeGlobalAccountTempl, "MMCS5", EMPTY, 3, 4, false)
 	defer c.shutdown()
 
 	// Make sure we report cluster size.
@@ -9775,7 +9775,7 @@ func TestJetStreamSuperClusterPushConsumerInterest(t *testing.T) {
 		name  string
 		queue string
 	}{
-		{"non queue", _EMPTY_},
+		{"non queue", EMPTY},
 		{"queue", "queue"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -9792,7 +9792,7 @@ func TestJetStreamSuperClusterPushConsumerInterest(t *testing.T) {
 				require_NoError(t, err)
 
 				var sub *nats.Subscription
-				if test.queue != _EMPTY_ {
+				if test.queue != EMPTY {
 					sub, err = js.QueueSubscribeSync("foo", test.queue)
 				} else {
 					sub, err = js.SubscribeSync("foo", nats.Durable("dur"))
@@ -10633,7 +10633,7 @@ func TestJetStreamClusterStreamReplicaUpdateFunctionCheck(t *testing.T) {
 		c.waitOnConsumerLeader("$G", "TEST", "cat")
 		ci, err := js.ConsumerInfo("TEST", "cat")
 		require_NoError(t, err)
-		if ci.Cluster.Leader == _EMPTY_ {
+		if ci.Cluster.Leader == EMPTY {
 			t.Fatalf("Expected a consumer leader but got none in consumer info")
 		}
 		if len(ci.Cluster.Replicas)+1 != r {
@@ -11703,7 +11703,7 @@ var jsClusterImportsTempl = `
 func createMixedModeCluster(t *testing.T, tmpl string, clusterName, snPre string, numJsServers, numNonServers int, doJSConfig bool) *cluster {
 	t.Helper()
 
-	if clusterName == _EMPTY_ || numJsServers < 0 || numNonServers < 1 {
+	if clusterName == EMPTY || numJsServers < 0 || numNonServers < 1 {
 		t.Fatalf("Bad params")
 	}
 
@@ -11761,12 +11761,12 @@ func createJetStreamClusterExplicit(t *testing.T, clusterName string, numServers
 func createJetStreamClusterWithTemplate(t *testing.T, tmpl string, clusterName string, numServers int) *cluster {
 	startPorts := []int{7_022, 9_022, 11_022, 15_022}
 	port := startPorts[rand.Intn(len(startPorts))]
-	return createJetStreamCluster(t, tmpl, clusterName, _EMPTY_, numServers, port, true)
+	return createJetStreamCluster(t, tmpl, clusterName, EMPTY, numServers, port, true)
 }
 
 func createJetStreamCluster(t *testing.T, tmpl string, clusterName, snPre string, numServers int, portStart int, waitOnReady bool) *cluster {
 	t.Helper()
-	if clusterName == _EMPTY_ || numServers < 1 {
+	if clusterName == EMPTY || numServers < 1 {
 		t.Fatalf("Bad params")
 	}
 
@@ -11845,12 +11845,12 @@ func (c *cluster) createSingleLeafNodeNoSystemAccount() *Server {
 
 // This is tied to jsClusterAccountsTempl, so changes there to users needs to be reflected here.
 func (c *cluster) createSingleLeafNodeNoSystemAccountAndEnablesJetStream() *Server {
-	return c.createSingleLeafNodeNoSystemAccountAndEnablesJetStreamWithDomain(_EMPTY_, "nojs")
+	return c.createSingleLeafNodeNoSystemAccountAndEnablesJetStreamWithDomain(EMPTY, "nojs")
 }
 
 func (c *cluster) createSingleLeafNodeNoSystemAccountAndEnablesJetStreamWithDomain(domain, user string) *Server {
 	tmpl := jsClusterSingleLeafNodeLikeNGSTempl
-	if domain != _EMPTY_ {
+	if domain != EMPTY {
 		nsc := fmt.Sprintf("domain: %s, store_dir:", domain)
 		tmpl = strings.Replace(jsClusterSingleLeafNodeLikeNGSTempl, "store_dir:", nsc, 1)
 	}
@@ -11969,7 +11969,7 @@ func (c *cluster) createLeafNodesNoJS(clusterName string, numServers int) *clust
 }
 
 func (c *cluster) createLeafNodesWithStartPortAndDomain(clusterName string, numServers int, portStart int, domain string) *cluster {
-	if domain == _EMPTY_ {
+	if domain == EMPTY {
 		return c.createLeafNodesWithTemplateAndStartPort(jsClusterTemplWithLeafNode, clusterName, numServers, portStart)
 	}
 	tmpl := strings.Replace(jsClusterTemplWithLeafNode, "store_dir:", fmt.Sprintf(`domain: "%s", store_dir:`, domain), 1)
@@ -12254,7 +12254,7 @@ func (c *cluster) waitOnServerHealthz(s *Server) {
 	expires := time.Now().Add(30 * time.Second)
 	for time.Now().Before(expires) {
 		hs := s.healthz()
-		if hs.Status == "ok" && hs.Error == _EMPTY_ {
+		if hs.Status == "ok" && hs.Error == EMPTY {
 			return
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -3746,7 +3746,7 @@ func TestJetStreamEphemeralConsumerRecoveryAfterServerRestart(t *testing.T) {
 			t.Fatalf("Error looking up consumer %q", oname)
 		}
 		// Make sure config does not have durable.
-		if cfg := o.config(); cfg.Durable != _EMPTY_ {
+		if cfg := o.config(); cfg.Durable != EMPTY {
 			t.Fatalf("Expected no durable to be set")
 		}
 		// Wait for it to become active
@@ -12237,7 +12237,7 @@ func TestJetStreamSourceBasics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if shdr := m.Header.Get(JSStreamSource); shdr == _EMPTY_ {
+	if shdr := m.Header.Get(JSStreamSource); shdr == EMPTY {
 		t.Fatalf("Expected a header, got none")
 	} else if _, sseq := streamAndSeq(shdr); sseq != 26 {
 		t.Fatalf("Expected header sequence of 26, got %d", sseq)
@@ -12267,7 +12267,7 @@ func TestJetStreamSourceBasics(t *testing.T) {
 	if m, err = js.GetMsg("FMS2", 1); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if shdr := m.Header.Get(JSStreamSource); shdr == _EMPTY_ {
+	if shdr := m.Header.Get(JSStreamSource); shdr == EMPTY {
 		t.Fatalf("Expected a header, got none")
 	} else if _, sseq := streamAndSeq(shdr); sseq != 11 {
 		t.Fatalf("Expected header sequence of 11, got %d", sseq)
@@ -13379,7 +13379,7 @@ func TestJetStreamConsumerPushBound(t *testing.T) {
 	}
 
 	// Make sure pull consumers report PushBound as false by default.
-	createConsumer("rip", _EMPTY_)
+	createConsumer("rip", EMPTY)
 	if ci := consumerInfo("rip"); ci.PushBound {
 		t.Fatalf("Expected push bound to be false")
 	}
@@ -13925,7 +13925,7 @@ func TestJetStreamConsumerNoMsgPayload(t *testing.T) {
 	msg.Header.Set("name", "derek")
 	msg.Data = bytes.Repeat([]byte("A"), 128)
 	for i := 0; i < 10; i++ {
-		msg.Reply = _EMPTY_ // Fixed in Go client but not in embdedded on yet.
+		msg.Reply = EMPTY // Fixed in Go client but not in embdedded on yet.
 		_, err = js.PublishMsgAsync(msg)
 		require_NoError(t, err)
 	}

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -82,11 +82,11 @@ func validateTrustedOperators(o *Options) error {
 	if len(o.TrustedOperators) > 0 && len(o.TrustedKeys) > 0 {
 		return fmt.Errorf("conflicting options for 'TrustedKeys' and 'TrustedOperators'")
 	}
-	if o.SystemAccount != _EMPTY_ {
+	if o.SystemAccount != EMPTY {
 		foundSys := false
 		foundNonEmpty := false
 		for _, op := range o.TrustedOperators {
-			if op.SystemAccount != _EMPTY_ {
+			if op.SystemAccount != EMPTY {
 				foundNonEmpty = true
 			}
 			if op.SystemAccount == o.SystemAccount {
@@ -97,7 +97,7 @@ func validateTrustedOperators(o *Options) error {
 		if foundNonEmpty && !foundSys {
 			return fmt.Errorf("system_account in config and operator JWT must be identical")
 		}
-	} else if o.TrustedOperators[0].SystemAccount == _EMPTY_ {
+	} else if o.TrustedOperators[0].SystemAccount == EMPTY {
 		// In case the system account is neither defined in config nor in the first operator.
 		// If it would be needed due to the nats account resolver, raise an error.
 		switch o.AccountResolver.(type) {
@@ -148,7 +148,7 @@ func validateTrustedOperators(o *Options) error {
 			}
 		}
 		// ensure the system account (belonging to the operator can always connect)
-		if o.SystemAccount != _EMPTY_ {
+		if o.SystemAccount != EMPTY {
 			o.resolverPinnedAccounts[o.SystemAccount] = struct{}{}
 		}
 	}

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -4819,7 +4819,7 @@ func newUserEx(t *testing.T, accKp nkeys.KeyPair, scoped bool, issuerAccount str
 	uclaim := newJWTTestUserClaims()
 	uclaim.Subject = upub
 	uclaim.SetScoped(scoped)
-	if issuerAccount != _EMPTY_ {
+	if issuerAccount != EMPTY {
 		uclaim.IssuerAccount = issuerAccount
 	}
 	ujwt, err := uclaim.Encode(accKp)

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -593,8 +593,8 @@ func TestLeafNodeValidateAuthOptions(t *testing.T) {
 	}
 
 	// Check duplicate user names
-	opts.LeafNode.Username = _EMPTY_
-	opts.LeafNode.Password = _EMPTY_
+	opts.LeafNode.Username = EMPTY
+	opts.LeafNode.Password = EMPTY
 	opts.LeafNode.Users = append(opts.LeafNode.Users, &User{Username: "user", Password: "pwd"})
 	if _, err := NewServer(opts); err == nil || !strings.Contains(err.Error(), "duplicate user") {
 		t.Fatalf("Expected error about duplicate user, got %v", err)
@@ -3492,7 +3492,7 @@ func TestLeafNodeUnsubOnRouteDisconnect(t *testing.T) {
 	ro1 := DefaultOptions()
 	// DefaultOptions sets a cluster name, so make sure they are different.
 	// Also, we don't have r1 and r2 clustered in this test, so set port to 0.
-	ro1.Cluster.Name = _EMPTY_
+	ro1.Cluster.Name = EMPTY
 	ro1.Cluster.Port = 0
 	ro1.LeafNode.ReconnectInterval = 50 * time.Millisecond
 	ro1.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: urls}}
@@ -3500,7 +3500,7 @@ func TestLeafNodeUnsubOnRouteDisconnect(t *testing.T) {
 	defer r1.Shutdown()
 
 	ro2 := DefaultOptions()
-	ro1.Cluster.Name = _EMPTY_
+	ro1.Cluster.Name = EMPTY
 	ro2.Cluster.Port = 0
 	ro2.LeafNode.ReconnectInterval = 50 * time.Millisecond
 	// Have this one point only to l2
@@ -4501,8 +4501,8 @@ cluster: { name: clustL }
 `
 	for _, withDomain := range []bool{true, false} {
 		t.Run(fmt.Sprintf("with-domain:%t", withDomain), func(t *testing.T) {
-			jsDisabledDomainString := _EMPTY_
-			jsEnabledDomainString := _EMPTY_
+			jsDisabledDomainString := EMPTY
+			jsEnabledDomainString := EMPTY
 			if withDomain {
 				jsEnabledDomainString = `domain: "domain", `
 				jsDisabledDomainString = `domain: "domain"`
@@ -4696,7 +4696,7 @@ leafnodes: {
 		defer sHub.Shutdown()
 
 		noDomainFix := ""
-		if domain == _EMPTY_ {
+		if domain == EMPTY {
 			noDomainFix = `default_js_domain:{A:""}`
 		}
 
@@ -4780,7 +4780,7 @@ leafnodes: {
 			sHubUpd2.opts.LeafNode.Port,
 			fmt.Sprintf(`default_js_domain: {A:"%s"}`, domain))), 0664))
 
-		if domain != _EMPTY_ {
+		if domain != EMPTY {
 			// in case no domain name exists there are no additional guard rails, hence no error
 			// It is the users responsibility to get this edge case right
 			sHubUpd2.Shutdown()
@@ -4844,7 +4844,7 @@ leafnodes: {
 
 	test := func(domain string) {
 		noDomainFix := ""
-		if domain == _EMPTY_ {
+		if domain == EMPTY {
 			noDomainFix = `default_js_domain:{A:""}`
 		}
 

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -283,7 +283,7 @@ func (ms *memStore) filteredStateLocked(sseq uint64, subj string) SimpleState {
 	}
 
 	// Empty same as everything.
-	if subj == _EMPTY_ {
+	if subj == EMPTY {
 		subj = fwcs
 	}
 
@@ -339,7 +339,7 @@ func (ms *memStore) SubjectsState(subject string) map[string]SimpleState {
 
 	fss := make(map[string]SimpleState)
 	for subj, ss := range ms.fss {
-		if subject == _EMPTY_ || subject == fwcs || subjectIsSubsetMatch(subj, subject) {
+		if subject == EMPTY || subject == fwcs || subjectIsSubsetMatch(subj, subject) {
 			oss := fss[subj]
 			if oss.First == 0 { // New
 				fss[subj] = *ss
@@ -428,7 +428,7 @@ func (ms *memStore) expireMsgs() {
 // PurgeEx will remove messages based on subject filters, sequence and number of messages to keep.
 // Will return the number of purged messages.
 func (ms *memStore) PurgeEx(subject string, sequence, keep uint64) (purged uint64, err error) {
-	if subject == _EMPTY_ || subject == fwcs {
+	if subject == EMPTY || subject == fwcs {
 		if keep == 0 && (sequence == 0 || sequence == 1) {
 			return ms.Purge()
 		}
@@ -490,7 +490,7 @@ func (ms *memStore) Purge() (uint64, error) {
 	ms.mu.Unlock()
 
 	if cb != nil {
-		cb(-int64(purged), -bytes, 0, _EMPTY_)
+		cb(-int64(purged), -bytes, 0, EMPTY)
 	}
 
 	return purged, nil
@@ -541,7 +541,7 @@ func (ms *memStore) Compact(seq uint64) (uint64, error) {
 	ms.mu.Unlock()
 
 	if cb != nil {
-		cb(-int64(purged), -int64(bytes), 0, _EMPTY_)
+		cb(-int64(purged), -int64(bytes), 0, EMPTY)
 	}
 
 	return purged, nil
@@ -575,7 +575,7 @@ func (ms *memStore) Truncate(seq uint64) error {
 	ms.mu.Unlock()
 
 	if cb != nil {
-		cb(-int64(purged), -int64(bytes), 0, _EMPTY_)
+		cb(-int64(purged), -int64(bytes), 0, EMPTY)
 	}
 
 	return nil
@@ -603,7 +603,7 @@ func (ms *memStore) LoadMsg(seq uint64) (string, []byte, []byte, int64, error) {
 		if seq <= last {
 			err = ErrStoreMsgNotFound
 		}
-		return _EMPTY_, nil, nil, 0, err
+		return EMPTY, nil, nil, 0, err
 	}
 	return sm.subj, sm.hdr, sm.msg, sm.ts, nil
 }
@@ -617,13 +617,13 @@ func (ms *memStore) LoadLastMsg(subject string) (subj string, seq uint64, hdr, m
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
 
-	if subject == _EMPTY_ || subject == fwcs {
+	if subject == EMPTY || subject == fwcs {
 		sm, ok = ms.msgs[ms.state.LastSeq]
 	} else if ss := ms.filteredStateLocked(1, subject); ss.Msgs > 0 {
 		sm, ok = ms.msgs[ss.Last]
 	}
 	if !ok || sm == nil {
-		return _EMPTY_, 0, nil, nil, 0, ErrStoreMsgNotFound
+		return EMPTY, 0, nil, nil, 0, ErrStoreMsgNotFound
 	}
 	return sm.subj, sm.seq, sm.hdr, sm.msg, sm.ts, nil
 }
@@ -640,10 +640,10 @@ func (ms *memStore) LoadNextMsg(filter string, wc bool, start uint64) (subj stri
 
 	// If past the end no results.
 	if start > ms.state.LastSeq {
-		return _EMPTY_, ms.state.LastSeq, nil, nil, 0, ErrStoreEOF
+		return EMPTY, ms.state.LastSeq, nil, nil, 0, ErrStoreEOF
 	}
 
-	isAll := filter == _EMPTY_ || filter == fwcs
+	isAll := filter == EMPTY || filter == fwcs
 	subs := []string{filter}
 	if wc || isAll {
 		subs = subs[:0]
@@ -680,7 +680,7 @@ func (ms *memStore) LoadNextMsg(filter string, wc bool, start uint64) (subj stri
 			return sm.subj, nseq, sm.hdr, sm.msg, sm.ts, nil
 		}
 	}
-	return _EMPTY_, ms.state.LastSeq, nil, nil, 0, ErrStoreEOF
+	return EMPTY, ms.state.LastSeq, nil, nil, 0, ErrStoreEOF
 }
 
 // RemoveMsg will remove the message from this store.

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -190,7 +190,7 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 
 	if opts != nil {
 		// If no sort option given or sort is by uptime, then sort by cid
-		if opts.Sort == _EMPTY_ {
+		if opts.Sort == EMPTY {
 			sortOpt = ByCid
 		} else {
 			sortOpt = opts.Sort
@@ -201,7 +201,7 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 
 		// Auth specifics.
 		auth = opts.Username
-		if !auth && (user != _EMPTY_ || acc != _EMPTY_) {
+		if !auth && (user != EMPTY || acc != EMPTY) {
 			return nil, fmt.Errorf("filter by user or account only allowed with auth option")
 		}
 		user = opts.User
@@ -235,8 +235,8 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 			limit = 1
 		}
 		// If filtering by subject.
-		if opts.FilterSubject != _EMPTY_ && opts.FilterSubject != fwcs {
-			if acc == _EMPTY_ {
+		if opts.FilterSubject != EMPTY && opts.FilterSubject != fwcs {
+			if acc == EMPTY {
 				return nil, fmt.Errorf("filter by subject only valid with account filtering")
 			}
 			filter = opts.FilterSubject
@@ -257,9 +257,9 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 	var clist map[uint64]*client
 
 	// If this is an account scoped request from a no $SYS account.
-	isAccReq := acc != _EMPTY_ && opts.isAccountReq
+	isAccReq := acc != EMPTY && opts.isAccountReq
 
-	if acc != _EMPTY_ {
+	if acc != EMPTY {
 		var err error
 		a, err = s.lookupAccount(acc)
 		if err != nil {
@@ -356,15 +356,15 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 		if state == ConnOpen || state == ConnAll {
 			for _, client := range clist {
 				// If we have an account specified we need to filter.
-				if acc != _EMPTY_ && (client.acc == nil || client.acc.Name != acc) {
+				if acc != EMPTY && (client.acc == nil || client.acc.Name != acc) {
 					continue
 				}
 				// Do user filtering second
-				if user != _EMPTY_ && client.opts.Username != user {
+				if user != EMPTY && client.opts.Username != user {
 					continue
 				}
 				// Do mqtt client ID filtering next
-				if mqttCID != _EMPTY_ && client.getMQTTClientID() != mqttCID {
+				if mqttCID != EMPTY && client.getMQTTClientID() != mqttCID {
 					continue
 				}
 				openClients = append(openClients, client)
@@ -374,7 +374,7 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 	s.mu.Unlock()
 
 	// Filter by subject now if needed. We do this outside of server lock.
-	if filter != _EMPTY_ {
+	if filter != EMPTY {
 		var oc []*client
 		for _, c := range openClients {
 			c.mu.Lock()
@@ -433,15 +433,15 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 	}
 	for _, cc := range closedClients {
 		// If we have an account specified we need to filter.
-		if acc != _EMPTY_ && cc.acc != acc {
+		if acc != EMPTY && cc.acc != acc {
 			continue
 		}
 		// Do user filtering second
-		if user != _EMPTY_ && cc.user != user {
+		if user != EMPTY && cc.user != user {
 			continue
 		}
 		// Do mqtt client ID filtering next
-		if mqttCID != _EMPTY_ && cc.MQTTClient != mqttCID {
+		if mqttCID != EMPTY && cc.MQTTClient != mqttCID {
 			continue
 		}
 		// Copy if needed for any changes to the ConnInfo
@@ -1098,7 +1098,7 @@ func (s *Server) HandleIPQueuesz(w http.ResponseWriter, r *http.Request) {
 		inProgress := int(queue.inProgress())
 		if !all && (pending == 0 && inProgress == 0) {
 			return true
-		} else if qfilter != _EMPTY_ && !strings.Contains(name, qfilter) {
+		} else if qfilter != EMPTY && !strings.Contains(name, qfilter) {
 			return true
 		}
 		queues[name] = monitorIPQueue{Pending: pending, InProgress: inProgress}
@@ -1276,7 +1276,7 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 
 	// Calculate source url. If git set go directly to that tag, otherwise just main.
 	var srcUrl string
-	if gitCommit == _EMPTY_ {
+	if gitCommit == EMPTY {
 		srcUrl = "https://github.com/nats-io/nats-server"
 	} else {
 		srcUrl = fmt.Sprintf("https://github.com/nats-io/nats-server/tree/%s", gitCommit)
@@ -1732,11 +1732,11 @@ func getMonitorGWOptions(opts *GatewayzOptions) (string, bool) {
 	var name string
 	var accs bool
 	if opts != nil {
-		if opts.Name != _EMPTY_ {
+		if opts.Name != EMPTY {
 			name = opts.Name
 		}
 		accs = opts.Accounts
-		if !accs && opts.AccountName != _EMPTY_ {
+		if !accs && opts.AccountName != EMPTY {
 			accs = true
 		}
 	}
@@ -1749,7 +1749,7 @@ func getMonitorGWOptions(opts *GatewayzOptions) (string, bool) {
 func (s *Server) createOutboundsRemoteGatewayz(opts *GatewayzOptions, now time.Time) map[string]*RemoteGatewayz {
 	targetGWName, doAccs := getMonitorGWOptions(opts)
 
-	if targetGWName != _EMPTY_ {
+	if targetGWName != EMPTY {
 		c := s.getOutboundGatewayConnection(targetGWName)
 		if c == nil {
 			return nil
@@ -1810,7 +1810,7 @@ func createOutboundAccountsGatewayz(opts *GatewayzOptions, gw *gateway) []*Accou
 	if opts != nil {
 		accName = opts.AccountName
 	}
-	if accName != _EMPTY_ {
+	if accName != EMPTY {
 		ei, ok := gw.outsim.Load(accName)
 		if !ok {
 			return nil
@@ -1864,7 +1864,7 @@ func (s *Server) createInboundsRemoteGatewayz(opts *GatewayzOptions, now time.Ti
 	m := make(map[string][]*RemoteGatewayz)
 	for _, c := range conns {
 		c.mu.Lock()
-		if c.gw != nil && (targetGWName == _EMPTY_ || targetGWName == c.gw.name) {
+		if c.gw != nil && (targetGWName == EMPTY || targetGWName == c.gw.name) {
 			igws := m[c.gw.name]
 			if igws == nil {
 				igws = make([]*RemoteGatewayz, 0, 2)
@@ -1895,7 +1895,7 @@ func createInboundAccountsGatewayz(opts *GatewayzOptions, gw *gateway) []*Accoun
 	if opts != nil {
 		accName = opts.AccountName
 	}
-	if accName != _EMPTY_ {
+	if accName != EMPTY {
 		e, ok := gw.insim[accName]
 		if !ok {
 			return nil
@@ -1939,7 +1939,7 @@ func (s *Server) HandleGatewayz(w http.ResponseWriter, r *http.Request) {
 	}
 	gwName := r.URL.Query().Get("gw_name")
 	accName := r.URL.Query().Get("acc_name")
-	if accName != _EMPTY_ {
+	if accName != EMPTY {
 		accs = true
 	}
 
@@ -2583,7 +2583,7 @@ func (s *Server) raftNodeToClusterInfo(node RaftNode) *ClusterInfo {
 		peerList[i] = p.ID
 	}
 	group := &raftGroup{
-		Name:  _EMPTY_,
+		Name:  EMPTY,
 		Peers: peerList,
 		node:  node,
 	}
@@ -2766,7 +2766,7 @@ func (s *Server) HandleHealthz(w http.ResponseWriter, r *http.Request) {
 	s.mu.Unlock()
 
 	hs := s.healthz()
-	if hs.Error != _EMPTY_ {
+	if hs.Error != EMPTY {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}
 	b, err := json.Marshal(hs)
@@ -2793,7 +2793,7 @@ func (s *Server) healthz() *HealthStatus {
 			// We do more checking for clustered mode to allow for proper rolling updates.
 			// We will make sure that we have seen the meta leader and that we are current with all assets.
 			node := js.getMetaGroup()
-			if node.GroupLeader() == _EMPTY_ {
+			if node.GroupLeader() == EMPTY {
 				health.Status = "unavailable"
 				health.Error = "JetStream has not established contact with a meta leader"
 			} else if !node.Current() {

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -2956,7 +2956,7 @@ func TestMonitorGatewayz(t *testing.T) {
 	for pollMode := 0; pollMode < 2; pollMode++ {
 		g := pollGatewayz(t, s, pollMode, url, nil)
 		// Expect Name and port to be empty
-		if g.Name != _EMPTY_ || g.Port != 0 {
+		if g.Name != EMPTY || g.Port != 0 {
 			t.Fatalf("Expected no gateway, got %+v", g)
 		}
 	}
@@ -3538,7 +3538,7 @@ func TestMonitorRouteRTT(t *testing.T) {
 					return fmt.Errorf("Expected 1 route, got %v", len(rz.Routes))
 				}
 				ri := rz.Routes[0]
-				if ri.RTT == _EMPTY_ {
+				if ri.RTT == EMPTY {
 					return fmt.Errorf("Route's RTT not reported")
 				}
 				return nil
@@ -3891,7 +3891,7 @@ func TestMonitorAuthorizedUsers(t *testing.T) {
 			}
 			conn := connz.Conns[0]
 			au := conn.AuthorizedUser
-			if au == _EMPTY_ {
+			if au == EMPTY {
 				t.Fatal("AuthorizedUser is empty!")
 			}
 			if au != expected {

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -306,7 +306,7 @@ func testMQTTDefaultOptions() *Options {
 func testMQTTRunServer(t testing.TB, o *Options) *Server {
 	t.Helper()
 	o.NoLog = false
-	if o.StoreDir == _EMPTY_ {
+	if o.StoreDir == EMPTY {
 		o.StoreDir = createDir(t, "mqtt_js")
 	}
 	s, err := NewServer(o)
@@ -580,7 +580,7 @@ func TestMQTTParseOptions(t *testing.T) {
 			conf := createConfFile(t, []byte(test.content))
 			defer removeFile(t, conf)
 			o, err := ProcessConfigFile(conf)
-			if test.err != _EMPTY_ {
+			if test.err != EMPTY {
 				if err == nil || !strings.Contains(err.Error(), test.err) {
 					t.Fatalf("For content: %q, expected error about %q, got %v", test.content, test.err, err)
 				}
@@ -845,10 +845,10 @@ func mqttCreateConnectProto(ci *mqttConnInfo) []byte {
 			flags |= mqttConnFlagWillRetain
 		}
 	}
-	if ci.user != _EMPTY_ {
+	if ci.user != EMPTY {
 		flags |= mqttConnFlagUsernameFlag
 	}
-	if ci.pass != _EMPTY_ {
+	if ci.pass != EMPTY {
 		flags |= mqttConnFlagPasswordFlag
 	}
 
@@ -862,10 +862,10 @@ func mqttCreateConnectProto(ci *mqttConnInfo) []byte {
 		pkLen += 2 + len(ci.will.topic)
 		pkLen += 2 + len(ci.will.message)
 	}
-	if ci.user != _EMPTY_ {
+	if ci.user != EMPTY {
 		pkLen += 2 + len(ci.user)
 	}
-	if ci.pass != _EMPTY_ {
+	if ci.pass != EMPTY {
 		pkLen += 2 + len(ci.pass)
 	}
 
@@ -881,10 +881,10 @@ func mqttCreateConnectProto(ci *mqttConnInfo) []byte {
 		w.WriteBytes(ci.will.topic)
 		w.WriteBytes(ci.will.message)
 	}
-	if ci.user != _EMPTY_ {
+	if ci.user != EMPTY {
 		w.WriteString(ci.user)
 	}
-	if ci.pass != _EMPTY_ {
+	if ci.pass != EMPTY {
 		w.WriteBytes([]byte(ci.pass))
 	}
 	return w.Bytes()
@@ -1768,7 +1768,7 @@ func TestMQTTTopicAndSubjectConversion(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			res, err := mqttTopicToNATSPubSubject([]byte(test.mqttTopic))
-			if test.err != _EMPTY_ {
+			if test.err != EMPTY {
 				if err == nil || !strings.Contains(err.Error(), test.err) {
 					t.Fatalf("Expected error %q, got %q", test.err, err.Error())
 				}
@@ -2590,7 +2590,7 @@ func TestMQTTTrackPendingOverrun(t *testing.T) {
 	sub := &subscription{mqtt: &mqttSub{qos: 1}}
 
 	sess.ppi = 0xFFFF
-	pi, _ := sess.trackPending(1, _EMPTY_, sub)
+	pi, _ := sess.trackPending(1, EMPTY, sub)
 	if pi != 1 {
 		t.Fatalf("Expected 1, got %v", pi)
 	}
@@ -2599,13 +2599,13 @@ func TestMQTTTrackPendingOverrun(t *testing.T) {
 	for i := 1; i <= 0xFFFF; i++ {
 		sess.pending[uint16(i)] = p
 	}
-	pi, _ = sess.trackPending(1, _EMPTY_, sub)
+	pi, _ = sess.trackPending(1, EMPTY, sub)
 	if pi != 0 {
 		t.Fatalf("Expected 0, got %v", pi)
 	}
 
 	delete(sess.pending, 1234)
-	pi, _ = sess.trackPending(1, _EMPTY_, sub)
+	pi, _ = sess.trackPending(1, EMPTY, sub)
 	if pi != 1234 {
 		t.Fatalf("Expected 1234, got %v", pi)
 	}
@@ -3328,7 +3328,7 @@ func TestMQTTImportExport(t *testing.T) {
 func TestMQTTSessionMovingDomains(t *testing.T) {
 	tmpl := strings.Replace(jsClusterTemplWithLeafAndMQTT, "{{leaf}}", `leafnodes { listen: 127.0.0.1:-1 }`, 1)
 	tmpl = strings.Replace(tmpl, "store_dir:", "domain: HUB, store_dir:", 1)
-	c := createJetStreamCluster(t, tmpl, "HUB", _EMPTY_, 3, 22020, true)
+	c := createJetStreamCluster(t, tmpl, "HUB", EMPTY, 3, 22020, true)
 	defer c.shutdown()
 	c.waitOnLeader()
 
@@ -5389,7 +5389,7 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 
 		// Check that client ID is present
 		for _, conn := range c.Conns {
-			if conn.Type == clientTypeStringMap[MQTT] && conn.MQTTClient == _EMPTY_ {
+			if conn.Type == clientTypeStringMap[MQTT] && conn.MQTTClient == EMPTY {
 				t.Fatalf("Expected a client ID to be set, got %+v", conn)
 			}
 		}
@@ -5409,7 +5409,7 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 			t.Fatalf("Expected 2 connections in array, got %v", len(c.Conns))
 		}
 		for _, conn := range c.Conns {
-			if conn.MQTTClient == _EMPTY_ {
+			if conn.MQTTClient == EMPTY {
 				t.Fatalf("Expected a client ID, got %+v", conn)
 			}
 		}
@@ -5440,11 +5440,11 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 		{&ConnzOptions{MQTTClient: "conn1"}, "conn1"},
 		{&ConnzOptions{MQTTClient: "conn3", State: ConnClosed}, "conn3"},
 		{&ConnzOptions{MQTTClient: "conn4", State: ConnClosed}, "conn4"},
-		{&ConnzOptions{MQTTClient: "conn5"}, _EMPTY_},
+		{&ConnzOptions{MQTTClient: "conn5"}, EMPTY},
 		{json.RawMessage(`{"mqtt_client":"conn1"}`), "conn1"},
 		{json.RawMessage(fmt.Sprintf(`{"mqtt_client":"conn3", "state":%v}`, ConnClosed)), "conn3"},
 		{json.RawMessage(fmt.Sprintf(`{"mqtt_client":"conn4", "state":%v}`, ConnClosed)), "conn4"},
-		{json.RawMessage(`{"mqtt_client":"conn5"}`), _EMPTY_},
+		{json.RawMessage(`{"mqtt_client":"conn5"}`), EMPTY},
 	} {
 		t.Run("sys connz", func(t *testing.T) {
 			b, _ := json.Marshal(test.opt)
@@ -5466,7 +5466,7 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 			if err := json.Unmarshal(tmp, cz); err != nil {
 				t.Fatalf("Error unmarshalling connz: %v", err)
 			}
-			if test.cid == _EMPTY_ {
+			if test.cid == EMPTY {
 				if len(cz.Conns) != 0 {
 					t.Fatalf("Expected no connections, got %v", len(cz.Conns))
 				}

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -2365,7 +2365,7 @@ func TestNoRaceJetStreamFileStoreBufferReuse(t *testing.T) {
 
 	start := time.Now()
 	for i := 0; i < toSend; i++ {
-		m.Reply = _EMPTY_
+		m.Reply = EMPTY
 		switch i % 3 {
 		case 0:
 			m.Subject = "foo"
@@ -2609,7 +2609,7 @@ func TestNoRaceAccountConnz(t *testing.T) {
 		sub, _ := nc.ChanSubscribe(nats.NewInbox(), mch)
 
 		var req []byte
-		if filter != _EMPTY_ {
+		if filter != EMPTY {
 			req, _ = json.Marshal(&ConnzOptions{FilterSubject: filter})
 		}
 
@@ -2633,7 +2633,7 @@ func TestNoRaceAccountConnz(t *testing.T) {
 				cr := parseConnz(m.Data)
 				// For account scoped, NumConns and Total should be the same (sans limits and offsets).
 				// It Total should not include other accounts since that would leak information about the system.
-				if filter == _EMPTY_ && cr.NumConns != cr.Total {
+				if filter == EMPTY && cr.NumConns != cr.Total {
 					t.Fatalf("NumConns and Total should be same with account scoped connz, got %+v", cr)
 				}
 				for _, c := range cr.Conns {
@@ -2656,11 +2656,11 @@ func TestNoRaceAccountConnz(t *testing.T) {
 
 	doSysRequest := func(acc string, expected int) {
 		t.Helper()
-		doRequest("$SYS.REQ.SERVER.PING.CONNZ", acc, _EMPTY_, expected)
+		doRequest("$SYS.REQ.SERVER.PING.CONNZ", acc, EMPTY, expected)
 	}
 	doAccRequest := func(acc string, expected int) {
 		t.Helper()
-		doRequest("$SYS.REQ.ACCOUNT.PING.CONNZ", acc, _EMPTY_, expected)
+		doRequest("$SYS.REQ.ACCOUNT.PING.CONNZ", acc, EMPTY, expected)
 	}
 	doFiltered := func(acc, filter string, expected int) {
 		t.Helper()
@@ -2674,7 +2674,7 @@ func TestNoRaceAccountConnz(t *testing.T) {
 	doAccRequest("two", 20)
 
 	// Now check filtering.
-	doFiltered("one", _EMPTY_, 20)
+	doFiltered("one", EMPTY, 20)
 	doFiltered("one", ">", 20)
 	doFiltered("one", "bar", 10)
 	doFiltered("two", "bar", 0)
@@ -3130,7 +3130,7 @@ func TestNoRaceJetStreamClusterInterestPolicyAckNone(t *testing.T) {
 		durable string
 	}{
 		{"durable", "dlc"},
-		{"ephemeral", _EMPTY_},
+		{"ephemeral", EMPTY},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			c := createJetStreamClusterExplicit(t, "R3S", 3)
@@ -3387,7 +3387,7 @@ func TestNoRaceJetStreamClusterCorruptWAL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	ae, err := node.decodeAppendEntry(msg, nil, _EMPTY_)
+	ae, err := node.decodeAppendEntry(msg, nil, EMPTY)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -3411,7 +3411,7 @@ func TestNoRaceJetStreamClusterCorruptWAL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if _, _, err := fs.StoreMsg(_EMPTY_, nil, encoded); err != nil {
+	if _, _, err := fs.StoreMsg(EMPTY, nil, encoded); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	fs.Stop()
@@ -4025,7 +4025,7 @@ func TestNoRaceConsumerFileStoreConcurrentDiskIO(t *testing.T) {
 }
 
 func TestNoRaceJetStreamClusterHealthz(t *testing.T) {
-	c := createJetStreamCluster(t, jsClusterAccountsTempl, "HZ", _EMPTY_, 3, 23033, true)
+	c := createJetStreamCluster(t, jsClusterAccountsTempl, "HZ", EMPTY, 3, 23033, true)
 	defer c.shutdown()
 
 	nc1, js1 := jsClientConnect(t, c.randomServer(), nats.UserInfo("one", "p"))

--- a/server/ocsp.go
+++ b/server/ocsp.go
@@ -120,7 +120,7 @@ func (oc *OCSPMonitor) getCacheStatus() ([]byte, *ocsp.Response) {
 func (oc *OCSPMonitor) getLocalStatus() ([]byte, *ocsp.Response, error) {
 	opts := oc.srv.getOpts()
 	storeDir := opts.StoreDir
-	if storeDir == _EMPTY_ {
+	if storeDir == EMPTY {
 		return nil, nil, fmt.Errorf("store_dir not set")
 	}
 
@@ -212,7 +212,7 @@ func (oc *OCSPMonitor) getRemoteStatus() ([]byte, *ocsp.Response, error) {
 		return nil, nil, err
 	}
 
-	if storeDir := opts.StoreDir; storeDir != _EMPTY_ {
+	if storeDir := opts.StoreDir; storeDir != EMPTY {
 		key := fmt.Sprintf("%x", sha256.Sum256(oc.Leaf.Raw))
 		if err := oc.writeOCSPStatus(storeDir, key, raw); err != nil {
 			return nil, nil, fmt.Errorf("failed to write ocsp status: %w", err)
@@ -327,10 +327,10 @@ func (srv *Server) NewOCSPMonitor(config *tlsConfigKind) (*tls.Config, *OCSPMoni
 	)
 	if kind == kindStringMap[CLIENT] {
 		tcOpts = opts.tlsConfigOpts
-		if opts.TLSCert != _EMPTY_ {
+		if opts.TLSCert != EMPTY {
 			certFile = opts.TLSCert
 		}
-		if opts.TLSCaCert != _EMPTY_ {
+		if opts.TLSCaCert != EMPTY {
 			caFile = opts.TLSCaCert
 		}
 	}
@@ -505,7 +505,7 @@ func (srv *Server) NewOCSPMonitor(config *tlsConfigKind) (*tls.Config, *OCSPMoni
 func (s *Server) setupOCSPStapleStoreDir() error {
 	opts := s.getOpts()
 	storeDir := opts.StoreDir
-	if storeDir == _EMPTY_ {
+	if storeDir == EMPTY {
 		return nil
 	}
 	storeDir = filepath.Join(storeDir, defaultOCSPStoreDir)
@@ -790,11 +790,11 @@ func getOCSPIssuer(issuerCert string, chain [][]byte) ([]*x509.Certificate, erro
 	var issuers []*x509.Certificate
 	var err error
 	switch {
-	case len(chain) == 1 && issuerCert == _EMPTY_:
+	case len(chain) == 1 && issuerCert == EMPTY:
 		err = fmt.Errorf("ocsp ca required in chain or configuration")
-	case issuerCert != _EMPTY_:
+	case issuerCert != EMPTY:
 		issuers, err = parseCertPEM(issuerCert)
-	case len(chain) > 1 && issuerCert == _EMPTY_:
+	case len(chain) > 1 && issuerCert == EMPTY:
 		issuers, err = x509.ParseCertificates(chain[1])
 	default:
 		err = fmt.Errorf("invalid ocsp ca configuration")

--- a/server/opts.go
+++ b/server/opts.go
@@ -662,7 +662,7 @@ func configureSystemAccount(o *Options, m map[string]interface{}) (retErr error)
 // or was present but set to false.
 func (o *Options) ProcessConfigFile(configFile string) error {
 	o.ConfigFile = configFile
-	if configFile == _EMPTY_ {
+	if configFile == EMPTY {
 		return nil
 	}
 	m, err := conf.ParseFileWithChecks(configFile)
@@ -1017,7 +1017,7 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 				}
 			}
 			// In case "system_account" is defined as well, it takes precedence
-			if o.SystemAccount == _EMPTY_ {
+			if o.SystemAccount == EMPTY {
 				o.SystemAccount = o.TrustedOperators[0].SystemAccount
 			}
 		}
@@ -1406,7 +1406,7 @@ func parseCluster(v interface{}, opts *Options, errors *[]error, warnings *[]err
 				*errors = append(*errors, err)
 				continue
 			}
-			if auth.token != _EMPTY_ {
+			if auth.token != EMPTY {
 				err := &configErr{tk, "Cluster authorization does not support tokens"}
 				*errors = append(*errors, err)
 				continue
@@ -1569,7 +1569,7 @@ func parseGateway(v interface{}, o *Options, errors *[]error, warnings *[]error)
 				*errors = append(*errors, &configErr{tk, "Gateway authorization does not allow multiple users"})
 				continue
 			}
-			if auth.token != _EMPTY_ {
+			if auth.token != EMPTY {
 				err := &configErr{tk, "Gateway authorization does not support tokens"}
 				*errors = append(*errors, err)
 				continue
@@ -1756,7 +1756,7 @@ func parseJetStream(v interface{}, opts *Options, errors *[]error, warnings *[]e
 			switch strings.ToLower(mk) {
 			case "store", "store_dir", "storedir":
 				// StoreDir can be set at the top level as well so have to prevent ambiguous declarations.
-				if opts.StoreDir != _EMPTY_ {
+				if opts.StoreDir != EMPTY {
 					return &configErr{tk, "Duplicate 'store_dir' configuration"}
 				}
 				opts.StoreDir = mv.(string)
@@ -2677,7 +2677,7 @@ func parseAccounts(v interface{}, opts *Options, errors *[]error, warnings *[]er
 			*errors = append(*errors, &configErr{tk, msg})
 			continue
 		}
-		if service.to == _EMPTY_ {
+		if service.to == EMPTY {
 			service.to = service.sub
 		}
 		if err := service.acc.AddServiceImport(ta, service.to, service.sub); err != nil {
@@ -4566,14 +4566,14 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	})
 
 	// Process signal control.
-	if signal != _EMPTY_ {
+	if signal != EMPTY {
 		if err := processSignal(signal); err != nil {
 			return nil, err
 		}
 	}
 
 	// Parse config if given
-	if configFile != _EMPTY_ {
+	if configFile != EMPTY {
 		// This will update the options with values from the config file.
 		err := opts.ProcessConfigFile(configFile)
 		if err != nil {

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -2001,7 +2001,7 @@ func TestParseExport(t *testing.T) {
 	subscribe := func(nc *nats.Conn, subj string) {
 		t.Helper()
 		_, err := nc.Subscribe(subj, func(msg *nats.Msg) {
-			if msg.Reply != _EMPTY_ {
+			if msg.Reply != EMPTY {
 				msg.Respond(msg.Data)
 			}
 			if atomic.AddInt32(&count, 1) == expected {

--- a/server/parser.go
+++ b/server/parser.go
@@ -165,7 +165,7 @@ func (c *client) parse(buf []byte) error {
 					var ok bool
 					// Check here for NoAuthUser. If this is set allow non CONNECT protos as our first.
 					// E.g. telnet proto demos.
-					if noAuthUser := s.getOpts().NoAuthUser; noAuthUser != _EMPTY_ {
+					if noAuthUser := s.getOpts().NoAuthUser; noAuthUser != EMPTY {
 						s.mu.Lock()
 						user, exists := s.users[noAuthUser]
 						s.mu.Unlock()

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -25,13 +25,13 @@ func TestNRGAppendEntryEncode(t *testing.T) {
 		pindex: 0,
 	}
 
-	// Test leader should be _EMPTY_ or exactly idLen long
+	// Test leader should be EMPTY or exactly idLen long
 	ae.leader = "foo_bar_baz"
 	_, err := ae.encode(nil)
 	require_Error(t, err, errLeaderLen)
 
 	// Empty ok (noLeader)
-	ae.leader = noLeader // _EMPTY_
+	ae.leader = noLeader // EMPTY
 	_, err = ae.encode(nil)
 	require_NoError(t, err)
 
@@ -77,7 +77,7 @@ func TestNRGAppendEntryDecode(t *testing.T) {
 	// Truncate buffer first.
 	var node *raft
 	short := buf[0 : len(buf)-1024]
-	_, err = node.decodeAppendEntry(short, nil, _EMPTY_)
+	_, err = node.decodeAppendEntry(short, nil, EMPTY)
 	require_Error(t, err, errBadAppendEntry)
 
 	for i := 0; i < 100; i++ {
@@ -85,7 +85,7 @@ func TestNRGAppendEntryDecode(t *testing.T) {
 		bi := rand.Intn(len(b))
 		if b[bi] != 0 {
 			b[bi] = 0
-			_, err = node.decodeAppendEntry(b, nil, _EMPTY_)
+			_, err = node.decodeAppendEntry(b, nil, EMPTY)
 			require_Error(t, err, errBadAppendEntry)
 		}
 	}

--- a/server/reload.go
+++ b/server/reload.go
@@ -1069,13 +1069,13 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 				for _, oldRemote := range tmpOld.Remotes {
 					var found bool
 
-					if oldRemote.LocalAccount == _EMPTY_ {
+					if oldRemote.LocalAccount == EMPTY {
 						oldRemote.LocalAccount = globalAccountName
 					}
 
 					for _, newRemote := range tmpNew.Remotes {
 						// Bind to global account in case not defined.
-						if newRemote.LocalAccount == _EMPTY_ {
+						if newRemote.LocalAccount == EMPTY {
 							newRemote.LocalAccount = globalAccountName
 						}
 
@@ -1122,7 +1122,7 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 
 			// Check whether JS is being disabled and/or storage dir attempted to change.
 			if jsEnabled && modified {
-				if new == _EMPTY_ {
+				if new == EMPTY {
 					// This means that either JS is being disabled or it is using an temp dir.
 					// Allow the change but error in case JS was not disabled.
 					jsStoreDirChanged = true
@@ -1212,7 +1212,7 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 			}
 			fallthrough
 		case "noauthuser":
-			if oldValue != _EMPTY_ && newValue == _EMPTY_ {
+			if oldValue != EMPTY && newValue == EMPTY {
 				for _, user := range newOpts.Users {
 					if user.Username == oldValue {
 						return nil, fmt.Errorf("config reload not supported for %s: old=%v, new=%v",
@@ -1224,7 +1224,7 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 					field.Name, oldValue, newValue)
 			}
 		case "systemaccount":
-			if oldValue != DEFAULT_SYSTEM_ACCOUNT || newValue != _EMPTY_ {
+			if oldValue != DEFAULT_SYSTEM_ACCOUNT || newValue != EMPTY {
 				return nil, fmt.Errorf("config reload not supported for %s: old=%v, new=%v",
 					field.Name, oldValue, newValue)
 			}

--- a/server/route.go
+++ b/server/route.go
@@ -102,8 +102,8 @@ type connectInfo struct {
 
 // Route protocol constants
 const (
-	ConProto  = "CONNECT %s" + _CRLF_
-	InfoProto = "INFO %s" + _CRLF_
+	ConProto  = "CONNECT %s" + CR_LF
+	InfoProto = "INFO %s" + CR_LF
 )
 
 const (
@@ -813,7 +813,7 @@ func (s *Server) forwardNewRouteInfoToKnownServers(info *Info) {
 	// That being said, the info we get is the initial INFO which
 	// contains a nonce, but we now forward this to existing routes,
 	// so clear it now.
-	info.Nonce = _EMPTY_
+	info.Nonce = EMPTY
 	b, _ := json.Marshal(info)
 	infoJSON := []byte(fmt.Sprintf(InfoProto, b))
 
@@ -1300,7 +1300,7 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 	s.routeInfo.Nonce = string(nonce)
 	s.generateRouteInfoJSON()
 	// Clear now that it has been serialized. Will prevent nonce to be included in async INFO that we may send.
-	s.routeInfo.Nonce = _EMPTY_
+	s.routeInfo.Nonce = EMPTY
 	infoJSON := s.routeInfoJSON
 	authRequired := s.routeInfo.AuthRequired
 	tlsRequired := s.routeInfo.TLSRequired
@@ -1329,7 +1329,7 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 			tlsConfig = tlsConfig.Clone()
 		}
 		// Perform (server or client side) TLS handshake.
-		if _, err := c.doTLSHandshake("route", didSolicit, rURL, tlsConfig, _EMPTY_, opts.Cluster.TLSTimeout, opts.Cluster.TLSPinnedCerts); err != nil {
+		if _, err := c.doTLSHandshake("route", didSolicit, rURL, tlsConfig, EMPTY, opts.Cluster.TLSTimeout, opts.Cluster.TLSPinnedCerts); err != nil {
 			c.mu.Unlock()
 			return nil
 		}
@@ -1399,11 +1399,6 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 	return c
 }
 
-const (
-	_CRLF_  = "\r\n"
-	_EMPTY_ = ""
-)
-
 func (s *Server) addRoute(c *client, info *Info) (bool, bool) {
 	id := c.route.remoteID
 	sendInfo := false
@@ -1460,9 +1455,9 @@ func (s *Server) addRoute(c *client, info *Info) (bool, bool) {
 		// c.route.leafnodeURL, otherwise, when processing the disconnect, this
 		// would cause the leafnode URL for that remote server to be removed
 		// from our list. Same for gateway...
-		c.route.leafnodeURL, c.route.gatewayURL = _EMPTY_, _EMPTY_
+		c.route.leafnodeURL, c.route.gatewayURL = EMPTY, EMPTY
 		// Same for the route hash otherwise it would be removed from s.routesByHash.
-		c.route.hash, c.route.idHash = _EMPTY_, _EMPTY_
+		c.route.hash, c.route.idHash = EMPTY, EMPTY
 		c.mu.Unlock()
 
 		remote.mu.Lock()
@@ -1720,7 +1715,7 @@ func (s *Server) startRouteAcceptLoop() {
 	// taking into account possible advertise setting. Use the LeafNodeURLs
 	// and set this server's leafnode accept URL. This will be sent to
 	// routed servers.
-	if !opts.LeafNode.NoAdvertise && s.leafNodeInfo.IP != _EMPTY_ {
+	if !opts.LeafNode.NoAdvertise && s.leafNodeInfo.IP != EMPTY {
 		info.LeafNodeURLs = []string{s.leafNodeInfo.IP}
 	}
 	s.routeInfo = info
@@ -2014,12 +2009,12 @@ func (s *Server) removeRoute(c *client) {
 		}
 		// Remove the remote's gateway URL from our list and
 		// send update to inbound Gateway connections.
-		if gwURL != _EMPTY_ && s.removeGatewayURL(gwURL) {
+		if gwURL != EMPTY && s.removeGatewayURL(gwURL) {
 			s.sendAsyncGatewayInfo()
 		}
 		// Remove the remote's leafNode URL from
 		// our list and send update to LN connections.
-		if lnURL != _EMPTY_ && s.removeLeafNodeURL(lnURL) {
+		if lnURL != EMPTY && s.removeLeafNodeURL(lnURL) {
 			s.sendAsyncLeafNodeInfo()
 		}
 		s.removeRouteByHash(hash, idHash)
@@ -2029,7 +2024,7 @@ func (s *Server) removeRoute(c *client) {
 }
 
 func (s *Server) isDuplicateServerName(name string) bool {
-	if name == _EMPTY_ {
+	if name == EMPTY {
 		return false
 	}
 	s.mu.Lock()

--- a/server/sendq.go
+++ b/server/sendq.go
@@ -67,11 +67,11 @@ func (sq *sendq) internalLoop() {
 					c.pa.hdr = len(pm.hdr)
 					c.pa.hdb = []byte(strconv.Itoa(c.pa.hdr))
 					msg = append(pm.hdr, pm.msg...)
-					msg = append(msg, _CRLF_...)
+					msg = append(msg, CR_LF...)
 				} else {
 					c.pa.hdr = -1
 					c.pa.hdb = nil
-					msg = append(pm.msg, _CRLF_...)
+					msg = append(pm.msg, CR_LF...)
 				}
 				c.processInboundClientMsg(msg)
 				c.pa.szb = nil

--- a/server/server.go
+++ b/server/server.go
@@ -317,7 +317,7 @@ func NewServer(opts *Options) (*Server, error) {
 	pub, _ := kp.PublicKey()
 
 	serverName := pub
-	if opts.ServerName != _EMPTY_ {
+	if opts.ServerName != EMPTY {
 		serverName = opts.ServerName
 	}
 
@@ -383,11 +383,11 @@ func NewServer(opts *Options) (*Server, error) {
 
 	// If we have solicited leafnodes but no clustering and no clustername.
 	// However we may need a stable clustername so use the server name.
-	if len(opts.LeafNode.Remotes) > 0 && opts.Cluster.Port == 0 && opts.Cluster.Name == _EMPTY_ {
+	if len(opts.LeafNode.Remotes) > 0 && opts.Cluster.Port == 0 && opts.Cluster.Name == EMPTY {
 		opts.Cluster.Name = opts.ServerName
 	}
 
-	if opts.Cluster.Name != _EMPTY_ {
+	if opts.Cluster.Name != EMPTY {
 		// Also place into mapping cn with cnMu lock.
 		s.cnMu.Lock()
 		s.cn = opts.Cluster.Name
@@ -440,9 +440,9 @@ func NewServer(opts *Options) (*Server, error) {
 	}
 
 	// If we have a cluster definition but do not have a cluster name, create one.
-	if opts.Cluster.Port != 0 && opts.Cluster.Name == _EMPTY_ {
+	if opts.Cluster.Port != 0 && opts.Cluster.Name == EMPTY {
 		s.info.Cluster = nuid.Next()
-	} else if opts.Cluster.Name != _EMPTY_ {
+	} else if opts.Cluster.Name != EMPTY {
 		// Likewise here if we have a cluster name set.
 		s.info.Cluster = opts.Cluster.Name
 	}
@@ -493,7 +493,7 @@ func NewServer(opts *Options) (*Server, error) {
 	// In operator mode, when the account resolver depends on an external system and
 	// the system account can't be fetched, inject a temporary one.
 	if ar := s.accResolver; len(opts.TrustedOperators) == 1 && ar != nil &&
-		opts.SystemAccount != _EMPTY_ && opts.SystemAccount != DEFAULT_SYSTEM_ACCOUNT {
+		opts.SystemAccount != EMPTY && opts.SystemAccount != DEFAULT_SYSTEM_ACCOUNT {
 		if _, ok := ar.(*MemAccResolver); !ok {
 			s.mu.Unlock()
 			var a *Account
@@ -632,7 +632,7 @@ func (s *Server) setClusterName(name string) {
 
 // Return whether the cluster name is dynamic.
 func (s *Server) isClusterNameDynamic() bool {
-	return s.getOpts().Cluster.Name == _EMPTY_
+	return s.getOpts().Cluster.Name == EMPTY
 }
 
 // Returns our configured serverName.
@@ -771,7 +771,7 @@ func (s *Server) configureAccounts() error {
 		s.registerAccountNoLock(a)
 
 		// If we see an account defined using $SYS we will make sure that is set as system account.
-		if acc.Name == DEFAULT_SYSTEM_ACCOUNT && opts.SystemAccount == _EMPTY_ {
+		if acc.Name == DEFAULT_SYSTEM_ACCOUNT && opts.SystemAccount == EMPTY {
 			s.opts.SystemAccount = DEFAULT_SYSTEM_ACCOUNT
 		}
 	}
@@ -832,7 +832,7 @@ func (s *Server) configureAccounts() error {
 
 	// Set the system account if it was configured.
 	// Otherwise create a default one.
-	if opts.SystemAccount != _EMPTY_ {
+	if opts.SystemAccount != EMPTY {
 		// Lock may be acquired in lookupAccount, so release to call lookupAccount.
 		s.mu.Unlock()
 		acc, err := s.lookupAccount(opts.SystemAccount)
@@ -852,11 +852,11 @@ func (s *Server) configureAccounts() error {
 		// If we have defined a system account here check to see if its just us and the $G account.
 		// We would do this to add user/pass to the system account. If this is the case add in
 		// no-auth-user for $G.
-		if numAccounts == 2 && s.opts.NoAuthUser == _EMPTY_ {
+		if numAccounts == 2 && s.opts.NoAuthUser == EMPTY {
 			// If we come here from config reload, let's not recreate the fake user name otherwise
 			// it will cause currently clients to be disconnected.
 			uname := s.sysAccOnlyNoAuthUser
-			if uname == _EMPTY_ {
+			if uname == EMPTY {
 				// Create a unique name so we do not collide.
 				var b [8]byte
 				rn := rand.Int63()
@@ -1397,7 +1397,7 @@ func (s *Server) registerAccountNoLock(acc *Account) *Account {
 		if defDomain, ok := opts.JsAccDefaultDomain[accName]; ok {
 			if jsEnabled {
 				s.Warnf("Skipping Default Domain %q, set for JetStream enabled account %q", defDomain, accName)
-			} else if defDomain != _EMPTY_ {
+			} else if defDomain != EMPTY {
 				for src, dest := range generateJSMappingTable(defDomain) {
 					// flip src and dest around so the domain is inserted
 					s.Noticef("Adding default domain mapping %q -> %q to account %q %p", dest, src, accName, acc)
@@ -1480,7 +1480,7 @@ func (s *Server) updateAccountWithClaimJWT(acc *Account, claimJWT string) error 
 		return ErrMissingAccount
 	}
 	acc.mu.RLock()
-	sameClaim := acc.claimJWT != _EMPTY_ && acc.claimJWT == claimJWT && !acc.incomplete
+	sameClaim := acc.claimJWT != EMPTY && acc.claimJWT == claimJWT && !acc.incomplete
 	acc.mu.RUnlock()
 	if sameClaim {
 		s.Debugf("Requested account update for [%s], same claims detected", acc.Name)
@@ -1489,7 +1489,7 @@ func (s *Server) updateAccountWithClaimJWT(acc *Account, claimJWT string) error 
 	accClaims, _, err := s.verifyAccountClaims(claimJWT)
 	if err == nil && accClaims != nil {
 		acc.mu.Lock()
-		if acc.Issuer == _EMPTY_ {
+		if acc.Issuer == EMPTY {
 			acc.Issuer = accClaims.Issuer
 		}
 		if acc.Name != accClaims.Subject {
@@ -1513,7 +1513,7 @@ func (s *Server) updateAccountWithClaimJWT(acc *Account, claimJWT string) error 
 func (s *Server) fetchRawAccountClaims(name string) (string, error) {
 	accResolver := s.AccountResolver()
 	if accResolver == nil {
-		return _EMPTY_, ErrNoAccountResolver
+		return EMPTY, ErrNoAccountResolver
 	}
 	// Need to do actual Fetch
 	start := time.Now()
@@ -1536,12 +1536,12 @@ func (s *Server) fetchRawAccountClaims(name string) (string, error) {
 func (s *Server) fetchAccountClaims(name string) (*jwt.AccountClaims, string, error) {
 	claimJWT, err := s.fetchRawAccountClaims(name)
 	if err != nil {
-		return nil, _EMPTY_, err
+		return nil, EMPTY, err
 	}
 	var claim *jwt.AccountClaims
 	claim, claimJWT, err = s.verifyAccountClaims(claimJWT)
 	if claim != nil && claim.Subject != name {
-		return nil, _EMPTY_, ErrAccountValidation
+		return nil, EMPTY, ErrAccountValidation
 	}
 	return claim, claimJWT, err
 }
@@ -1550,15 +1550,15 @@ func (s *Server) fetchAccountClaims(name string) (*jwt.AccountClaims, string, er
 func (s *Server) verifyAccountClaims(claimJWT string) (*jwt.AccountClaims, string, error) {
 	accClaims, err := jwt.DecodeAccountClaims(claimJWT)
 	if err != nil {
-		return nil, _EMPTY_, err
+		return nil, EMPTY, err
 	}
 	if !s.isTrustedIssuer(accClaims.Issuer) {
-		return nil, _EMPTY_, ErrAccountValidation
+		return nil, EMPTY, ErrAccountValidation
 	}
 	vr := jwt.CreateValidationResults()
 	accClaims.Validate(vr)
 	if vr.IsBlocking(true) {
-		return nil, _EMPTY_, ErrAccountValidation
+		return nil, EMPTY, ErrAccountValidation
 	}
 	return accClaims, claimJWT, nil
 }
@@ -1600,7 +1600,7 @@ func (s *Server) Start() {
 	s.Noticef("Starting nats-server")
 
 	gc := gitCommit
-	if gc == _EMPTY_ {
+	if gc == EMPTY {
 		gc = "not set"
 	}
 
@@ -1611,7 +1611,7 @@ func (s *Server) Start() {
 	s.Noticef("  Version:  %s", VERSION)
 	s.Noticef("  Git:      [%s]", gc)
 	s.Debugf("  Go build: %s", s.info.GoVersion)
-	if clusterName != _EMPTY_ {
+	if clusterName != EMPTY {
 		s.Noticef("  Cluster:  %s", clusterName)
 	}
 	s.Noticef("  Name:     %s", s.info.Name)
@@ -1639,7 +1639,7 @@ func (s *Server) Start() {
 		s.StartProfiler()
 	}
 
-	if opts.ConfigFile != _EMPTY_ {
+	if opts.ConfigFile != EMPTY {
 		s.Noticef("Using configuration file: %s", opts.ConfigFile)
 	}
 
@@ -1653,7 +1653,7 @@ func (s *Server) Start() {
 		s.Noticef("  Issued  : %v", time.Unix(opc.IssuedAt, 0))
 		s.Noticef("  Expires : %v", time.Unix(opc.Expires, 0))
 	}
-	if hasOperators && opts.SystemAccount == _EMPTY_ {
+	if hasOperators && opts.SystemAccount == EMPTY {
 		s.Warnf("Trusted Operators should utilize a System Account")
 	}
 	if opts.MaxPayload > MAX_PAYLOAD_MAX_SIZE {
@@ -1672,7 +1672,7 @@ func (s *Server) Start() {
 	}
 
 	// Log the pid to a file.
-	if opts.PidFile != _EMPTY_ {
+	if opts.PidFile != EMPTY {
 		if err := s.logPid(); err != nil {
 			s.Fatalf("Could not write pidfile: %v", err)
 			return
@@ -1680,7 +1680,7 @@ func (s *Server) Start() {
 	}
 
 	// Setup system account which will start the eventing stack.
-	if sa := opts.SystemAccount; sa != _EMPTY_ {
+	if sa := opts.SystemAccount; sa != EMPTY {
 		if err := s.SetSystemAccount(sa); err != nil {
 			s.Fatalf("Can't set system account: %v", err)
 			return
@@ -1705,7 +1705,7 @@ func (s *Server) Start() {
 		}
 		// In operator mode, when the account resolver depends on an external system and
 		// the system account is the bootstrapping account, start fetching it.
-		if len(opts.TrustedOperators) == 1 && opts.SystemAccount != _EMPTY_ && opts.SystemAccount != DEFAULT_SYSTEM_ACCOUNT {
+		if len(opts.TrustedOperators) == 1 && opts.SystemAccount != EMPTY && opts.SystemAccount != DEFAULT_SYSTEM_ACCOUNT {
 			_, isMemResolver := ar.(*MemAccResolver)
 			if v, ok := s.accounts.Load(s.opts.SystemAccount); !isMemResolver && ok && v.(*Account).claimJWT == "" {
 				s.Noticef("Using bootstrapping system account")
@@ -1843,7 +1843,7 @@ func (s *Server) Start() {
 		})
 	}
 
-	if opts.PortsFileDir != _EMPTY_ {
+	if opts.PortsFileDir != EMPTY {
 		s.logPorts()
 	}
 
@@ -2005,7 +2005,7 @@ func (s *Server) Shutdown() {
 	// Wait for go routines to be done.
 	s.grWG.Wait()
 
-	if opts.PortsFileDir != _EMPTY_ {
+	if opts.PortsFileDir != EMPTY {
 		s.deletePortsFile(opts.PortsFileDir)
 	}
 
@@ -2137,7 +2137,7 @@ func (s *Server) setInfoHostPort() error {
 	// When this function is called, opts.Port is set to the actual listen
 	// port (if option was originally set to RANDOM), even during a config
 	// reload. So use of s.opts.Port is safe.
-	if s.opts.ClientAdvertise != _EMPTY_ {
+	if s.opts.ClientAdvertise != EMPTY {
 		h, p, err := parseHostPort(s.opts.ClientAdvertise, s.opts.Port)
 		if err != nil {
 			return err
@@ -2368,7 +2368,7 @@ func (s *Server) startMonitoring(secure bool) error {
 		Addr:           hp,
 		Handler:        mux,
 		MaxHeaderBytes: 1 << 20,
-		ErrorLog:       log.New(&captureHTTPServerLog{s, "monitoring: "}, _EMPTY_, 0),
+		ErrorLog:       log.New(&captureHTTPServerLog{s, "monitoring: "}, EMPTY, 0),
 	}
 	s.mu.Lock()
 	if s.shutdown {
@@ -2564,7 +2564,7 @@ func (s *Server) createClient(conn net.Conn) *client {
 			pre = nil
 		}
 		// Performs server-side TLS handshake.
-		if err := c.doTLSServerHandshake(_EMPTY_, opts.TLSConfig, opts.TLSTimeout, opts.TLSPinnedCerts); err != nil {
+		if err := c.doTLSServerHandshake(EMPTY, opts.TLSConfig, opts.TLSTimeout, opts.TLSPinnedCerts); err != nil {
 			c.mu.Unlock()
 			return nil
 		}
@@ -2936,7 +2936,7 @@ func (s *Server) readyForConnections(d time.Duration) error {
 		s.mu.Lock()
 		chk["server"] = info{ok: s.listener != nil, err: s.listenerErr}
 		chk["route"] = info{ok: (opts.Cluster.Port == 0 || s.routeListener != nil), err: s.routeListenerErr}
-		chk["gateway"] = info{ok: (opts.Gateway.Name == _EMPTY_ || s.gatewayListener != nil), err: s.gatewayListenerErr}
+		chk["gateway"] = info{ok: (opts.Gateway.Name == EMPTY || s.gatewayListener != nil), err: s.gatewayListenerErr}
 		chk["leafNode"] = info{ok: (opts.LeafNode.Port == 0 || s.leafNodeListener != nil), err: s.leafNodeListenerErr}
 		chk["websocket"] = info{ok: (opts.Websocket.Port == 0 || s.websocket.listener != nil), err: s.websocket.listenerErr}
 		chk["mqtt"] = info{ok: (opts.MQTT.Port == 0 || s.mqtt.listener != nil), err: s.mqtt.listenerErr}
@@ -3248,8 +3248,8 @@ func (s *Server) portFile(dirHint string) string {
 	if dirHint != "" {
 		dirname = dirHint
 	}
-	if dirname == _EMPTY_ {
-		return _EMPTY_
+	if dirname == EMPTY {
+		return EMPTY
 	}
 	return filepath.Join(dirname, fmt.Sprintf("%s_%d.ports", filepath.Base(os.Args[0]), os.Getpid()))
 }
@@ -3271,7 +3271,7 @@ func (s *Server) deletePortsFile(hintDir string) {
 func (s *Server) logPorts() {
 	opts := s.getOpts()
 	portsFile := s.portFile(opts.PortsFileDir)
-	if portsFile != _EMPTY_ {
+	if portsFile != EMPTY {
 		go func() {
 			info := s.PortsInfo(5 * time.Second)
 			if info == nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -97,7 +97,7 @@ func LoadConfig(configFile string) (opts *Options) {
 	if err != nil {
 		panic(fmt.Sprintf("Error processing configuration file: %v", err))
 	}
-	opts.NoSigs, opts.NoLog = true, opts.LogFile == _EMPTY_
+	opts.NoSigs, opts.NoLog = true, opts.LogFile == EMPTY
 	return
 }
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -319,7 +319,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 		return nil, err
 	}
 	// Check for template ownership if present.
-	if cfg.Template != _EMPTY_ && jsa.account != nil {
+	if cfg.Template != EMPTY && jsa.account != nil {
 		if !jsa.checkTemplateOwnership(cfg.Template, cfg.Name) {
 			jsa.mu.Unlock()
 			return nil, fmt.Errorf("stream not owned by template")
@@ -337,7 +337,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 			jsa.mu.Unlock()
 			return nil, fmt.Errorf("stream mirrors can not also contain other sources")
 		}
-		if cfg.Mirror.FilterSubject != _EMPTY_ {
+		if cfg.Mirror.FilterSubject != EMPTY {
 			jsa.mu.Unlock()
 			return nil, fmt.Errorf("stream mirrors can not contain filtered subjects")
 		}
@@ -416,7 +416,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 	}
 
 	// Create our pubAck template here. Better than json marshal each time on success.
-	if domain := s.getOpts().JetStreamDomain; domain != _EMPTY_ {
+	if domain := s.getOpts().JetStreamDomain; domain != EMPTY {
 		mset.pubAck = []byte(fmt.Sprintf("{%q:%q, %q:%q, %q:", "stream", cfg.Name, "domain", domain, "seq"))
 	} else {
 		mset.pubAck = []byte(fmt.Sprintf("{%q:%q, %q:", "stream", cfg.Name, "seq"))
@@ -508,7 +508,7 @@ func (mset *stream) setStreamAssignment(sa *streamAssignment) {
 	if mset.infoSub == nil {
 		isubj := fmt.Sprintf(clusterStreamInfoT, mset.jsa.acc(), mset.cfg.Name)
 		// Note below the way we subscribe here is so that we can send requests to ourselves.
-		mset.infoSub, _ = mset.srv.systemSubscribe(isubj, _EMPTY_, false, mset.sysc, mset.handleClusterStreamInfoRequest)
+		mset.infoSub, _ = mset.srv.systemSubscribe(isubj, EMPTY, false, mset.sysc, mset.handleClusterStreamInfoRequest)
 	}
 }
 
@@ -550,7 +550,7 @@ func (mset *stream) setLeader(isLeader bool) error {
 		// Clear catchup state
 		mset.clearAllCatchupPeers()
 		// Check on any fixup state and optionally clear.
-		if mset.isClustered() && mset.leader != _EMPTY_ && mset.leader != mset.node.GroupLeader() {
+		if mset.isClustered() && mset.leader != EMPTY && mset.leader != mset.node.GroupLeader() {
 			mset.clfs = 0
 		}
 	}
@@ -565,7 +565,7 @@ func (mset *stream) setLeader(isLeader bool) error {
 // Lock should be held.
 func (mset *stream) startClusterSubs() {
 	if mset.isClustered() && mset.syncSub == nil {
-		mset.syncSub, _ = mset.srv.systemSubscribe(mset.sa.Sync, _EMPTY_, false, mset.sysc, mset.handleClusterSyncRequest)
+		mset.syncSub, _ = mset.srv.systemSubscribe(mset.sa.Sync, EMPTY, false, mset.sysc, mset.handleClusterSyncRequest)
 	}
 }
 
@@ -675,7 +675,7 @@ func (mset *stream) rebuildDedupe() {
 		_, hdr, _, ts, err := mset.store.LoadMsg(seq)
 		var msgId string
 		if err == nil && len(hdr) > 0 {
-			if msgId = getMsgId(hdr); msgId != _EMPTY_ {
+			if msgId = getMsgId(hdr); msgId != EMPTY {
 				mset.storeMsgIdLocked(&ddentry{msgId, seq, ts})
 			}
 		}
@@ -942,10 +942,10 @@ func (jsa *jsAccount) configUpdateCheck(old, new *StreamConfig) (*StreamConfig, 
 		return nil, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration update can not change retention policy"))
 	}
 	// Can not have a template owner for now.
-	if old.Template != _EMPTY_ {
+	if old.Template != EMPTY {
 		return nil, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration update not allowed on template owned stream"))
 	}
-	if cfg.Template != _EMPTY_ {
+	if cfg.Template != EMPTY {
 		return nil, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration update can not be owned by a template"))
 	}
 	// Can not change from true to false.
@@ -1141,7 +1141,7 @@ func (mset *stream) purge(preq *JSApiStreamPurgeRequest) (purged uint64, err err
 	fseq := state.FirstSeq
 
 	// Check for filtered purge.
-	if preq != nil && preq.Subject != _EMPTY_ {
+	if preq != nil && preq.Subject != EMPTY {
 		ss := mset.store.FilteredState(state.FirstSeq, preq.Subject)
 		fseq = ss.First
 	}
@@ -1431,7 +1431,7 @@ func (mset *stream) processMirrorMsgs() {
 // Checks that the message is from our current direct consumer. We can not depend on sub comparison
 // since cross account imports break.
 func (si *sourceInfo) isCurrentSub(reply string) bool {
-	return si.cname != _EMPTY_ && strings.HasPrefix(reply, jsAckPre) && si.cname == tokenAt(reply, 4)
+	return si.cname != EMPTY && strings.HasPrefix(reply, jsAckPre) && si.cname == tokenAt(reply, 4)
 }
 
 // processInboundMirrorMsg handles processing messages bound for a stream.
@@ -1463,7 +1463,7 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 	if isControl {
 		var needsRetry bool
 		// Flow controls have reply subjects.
-		if m.rply != _EMPTY_ {
+		if m.rply != EMPTY {
 			mset.handleFlowControl(mset.mirror, m)
 		} else {
 			// For idle heartbeats make sure we did not miss anything and check if we are considered stalled.
@@ -1497,7 +1497,7 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 		// Ignore older messages.
 		mset.mu.Unlock()
 		return true
-	} else if mset.mirror.cname == _EMPTY_ {
+	} else if mset.mirror.cname == EMPTY {
 		mset.mirror.cname = tokenAt(m.rply, 4)
 		mset.mirror.dseq, mset.mirror.sseq = dseq, sseq
 	} else {
@@ -1529,10 +1529,10 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 			s.resourcesExeededError()
 			err = ApiErrors[JSInsufficientResourcesErr]
 		} else {
-			err = node.Propose(encodeStreamMsg(m.subj, _EMPTY_, m.hdr, m.msg, sseq-1, ts))
+			err = node.Propose(encodeStreamMsg(m.subj, EMPTY, m.hdr, m.msg, sseq-1, ts))
 		}
 	} else {
-		err = mset.processJetStreamMsg(m.subj, _EMPTY_, m.hdr, m.msg, sseq-1, ts)
+		err = mset.processJetStreamMsg(m.subj, EMPTY, m.hdr, m.msg, sseq-1, ts)
 	}
 	if err != nil {
 		if err == errLastSeqMismatch {
@@ -1601,7 +1601,7 @@ func (mset *stream) skipMsgs(start, end uint64) {
 	var entries []*Entry
 	for seq := start; seq <= end; seq++ {
 		if node != nil {
-			entries = append(entries, &Entry{EntryNormal, encodeStreamMsg(_EMPTY_, _EMPTY_, nil, nil, seq-1, 0)})
+			entries = append(entries, &Entry{EntryNormal, encodeStreamMsg(EMPTY, EMPTY, nil, nil, seq-1, 0)})
 			// So a single message does not get too big.
 			if len(entries) > 10_000 {
 				node.ProposeDirect(entries)
@@ -1649,7 +1649,7 @@ func (mset *stream) setupMirrorConsumer() error {
 	var deliverSubject string
 	ext := mset.cfg.Mirror.External
 
-	if ext != nil && ext.DeliverPrefix != _EMPTY_ {
+	if ext != nil && ext.DeliverPrefix != EMPTY {
 		deliverSubject = strings.ReplaceAll(ext.DeliverPrefix+syncSubject(".M"), "..", ".")
 	} else {
 		deliverSubject = syncSubject("$JS.M")
@@ -1731,7 +1731,7 @@ func (mset *stream) setupMirrorConsumer() error {
 		subject = strings.ReplaceAll(subject, "..", ".")
 	}
 
-	mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, nil, b, nil, 0))
+	mset.outq.send(newJSPubMsg(subject, EMPTY, reply, nil, b, nil, 0))
 
 	go func() {
 		select {
@@ -1769,7 +1769,7 @@ func (mset *stream) setupMirrorConsumer() error {
 				if err != nil {
 					mset.mirror.err = NewJSMirrorConsumerSetupFailedError(err, Unless(err))
 					mset.mirror.sub = nil
-					mset.mirror.cname = _EMPTY_
+					mset.mirror.cname = EMPTY
 				} else {
 					mset.mirror.err = nil
 					mset.mirror.sub = sub
@@ -1865,7 +1865,7 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64) {
 	var deliverSubject string
 	ext := ssi.External
 
-	if ext != nil && ext.DeliverPrefix != _EMPTY_ {
+	if ext != nil && ext.DeliverPrefix != EMPTY {
 		deliverSubject = strings.ReplaceAll(ext.DeliverPrefix+syncSubject(".S"), "..", ".")
 	} else {
 		deliverSubject = syncSubject("$JS.S")
@@ -1909,7 +1909,7 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64) {
 		req.Config.DeliverPolicy = DeliverByStartSequence
 	}
 	// Filters
-	if ssi.FilterSubject != _EMPTY_ {
+	if ssi.FilterSubject != EMPTY {
 		req.Config.FilterSubject = ssi.FilterSubject
 	}
 
@@ -1933,7 +1933,7 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64) {
 		subject = strings.ReplaceAll(subject, "..", ".")
 	}
 
-	mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, nil, b, nil, 0))
+	mset.outq.send(newJSPubMsg(subject, EMPTY, reply, nil, b, nil, 0))
 
 	go func() {
 		select {
@@ -2060,7 +2060,7 @@ func (mset *stream) sendFlowControlReply(reply string) {
 func (mset *stream) handleFlowControl(si *sourceInfo, m *inMsg) {
 	// If we are clustered we will send the flow control message through the replication stack.
 	if mset.isClustered() {
-		mset.node.Propose(encodeStreamMsg(_EMPTY_, m.rply, m.hdr, nil, 0, 0))
+		mset.node.Propose(encodeStreamMsg(EMPTY, m.rply, m.hdr, nil, 0, 0))
 	} else {
 		mset.outq.sendMsg(m.rply, nil)
 	}
@@ -2092,7 +2092,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 	if isControl {
 		var needsRetry bool
 		// Flow controls have reply subjects.
-		if m.rply != _EMPTY_ {
+		if m.rply != EMPTY {
 			mset.handleFlowControl(si, m)
 		} else {
 			// For idle heartbeats make sure we did not miss anything.
@@ -2120,7 +2120,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 		si.dseq++
 		si.sseq = sseq
 	} else if dseq > si.dseq {
-		if si.cname == _EMPTY_ {
+		if si.cname == EMPTY {
 			si.cname = tokenAt(m.rply, 4)
 			si.dseq, si.sseq = dseq, sseq
 		} else {
@@ -2152,9 +2152,9 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 	var err error
 	// If we are clustered we need to propose this message to the underlying raft group.
 	if node != nil {
-		err = mset.processClusteredInboundMsg(m.subj, _EMPTY_, hdr, msg)
+		err = mset.processClusteredInboundMsg(m.subj, EMPTY, hdr, msg)
 	} else {
-		err = mset.processJetStreamMsg(m.subj, _EMPTY_, hdr, msg, 0, 0)
+		err = mset.processJetStreamMsg(m.subj, EMPTY, hdr, msg, 0, 0)
 	}
 
 	if err != nil {
@@ -2207,7 +2207,7 @@ func streamAndSeqFromAckReply(reply string) (string, uint64) {
 	}
 	tokens = append(tokens, reply[start:])
 	if len(tokens) != expectedNumReplyTokens || tokens[0] != "$JS" || tokens[1] != "ACK" {
-		return _EMPTY_, 0
+		return EMPTY, 0
 	}
 	return tokens[2], uint64(parseAckReplyNum(tokens[5]))
 }
@@ -2220,7 +2220,7 @@ func streamAndSeq(shdr string) (string, uint64) {
 	// New version which is stream index name <SPC> sequence
 	fields := strings.Fields(shdr)
 	if len(fields) != 2 {
-		return _EMPTY_, 0
+		return EMPTY, 0
 	}
 	return fields[0], uint64(parseAckReplyNum(fields[1]))
 }
@@ -2272,7 +2272,7 @@ func (mset *stream) startingSequenceForSources() {
 	mset.sources = make(map[string]*sourceInfo)
 
 	for _, ssi := range mset.cfg.Sources {
-		if ssi.iname == _EMPTY_ {
+		if ssi.iname == EMPTY {
 			ssi.setIndexName()
 		}
 		qname := fmt.Sprintf("[ACC:%s] stream source '%s' from '%s' msgs", mset.acc.Name, mset.cfg.Name, ssi.Name)
@@ -2396,10 +2396,10 @@ func (mset *stream) stopSourceConsumers() {
 
 // Lock should be held.
 func (mset *stream) removeInternalConsumer(si *sourceInfo) {
-	if si == nil || si.cname == _EMPTY_ {
+	if si == nil || si.cname == EMPTY {
 		return
 	}
-	si.cname = _EMPTY_
+	si.cname = EMPTY
 }
 
 // Will unsubscribe from the stream.
@@ -2566,7 +2566,7 @@ func (mset *stream) checkMsgId(id string) *ddentry {
 	if !mset.ddloaded {
 		mset.rebuildDedupe()
 	}
-	if id == _EMPTY_ || len(mset.ddmap) == 0 {
+	if id == EMPTY || len(mset.ddmap) == 0 {
 		return nil
 	}
 	return mset.ddmap[id]
@@ -2666,7 +2666,7 @@ func getExpectedLastSeq(hdr []byte) uint64 {
 func getRollup(hdr []byte) string {
 	r := getHeader(JSMsgRollup, hdr)
 	if len(r) == 0 {
-		return _EMPTY_
+		return EMPTY
 	}
 	return strings.ToLower(string(r))
 }
@@ -2821,7 +2821,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		outq := mset.outq
 
 		// Dedupe detection.
-		if msgId = getMsgId(hdr); msgId != _EMPTY_ {
+		if msgId = getMsgId(hdr); msgId != EMPTY {
 			if dde := mset.checkMsgId(msgId); dde != nil {
 				mset.clfs++
 				mset.mu.Unlock()
@@ -2835,7 +2835,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		}
 
 		// Expected stream.
-		if sname := getExpectedStream(hdr); sname != _EMPTY_ && sname != name {
+		if sname := getExpectedStream(hdr); sname != EMPTY && sname != name {
 			mset.clfs++
 			mset.mu.Unlock()
 			if canRespond {
@@ -2860,8 +2860,8 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 			return fmt.Errorf("last sequence mismatch: %d vs %d", seq, mlseq)
 		}
 		// Expected last msgId.
-		if lmsgId := getExpectedLastMsgId(hdr); lmsgId != _EMPTY_ {
-			if mset.lmsgId == _EMPTY_ && !mset.ddloaded {
+		if lmsgId := getExpectedLastMsgId(hdr); lmsgId != EMPTY {
+			if mset.lmsgId == EMPTY && !mset.ddloaded {
 				mset.rebuildDedupe()
 			}
 			if lmsgId != mset.lmsgId {
@@ -2898,7 +2898,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 			}
 		}
 		// Check for any rollups.
-		if rollup := getRollup(hdr); rollup != _EMPTY_ {
+		if rollup := getRollup(hdr); rollup != EMPTY {
 			if !mset.cfg.AllowRollup || mset.cfg.DenyPurge {
 				mset.clfs++
 				mset.mu.Unlock()
@@ -2982,7 +2982,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 			// Assume no interest and check to disqualify.
 			noInterest = true
 			for _, o := range mset.consumers {
-				if o.cfg.FilterSubject == _EMPTY_ || subjectIsSubsetMatch(subject, o.cfg.FilterSubject) {
+				if o.cfg.FilterSubject == EMPTY || subjectIsSubsetMatch(subject, o.cfg.FilterSubject) {
 					noInterest = false
 					break
 				}
@@ -3007,7 +3007,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 			mset.outq.sendMsg(reply, response)
 		}
 		// If we have a msgId make sure to save.
-		if msgId != _EMPTY_ {
+		if msgId != EMPTY {
 			mset.storeMsgId(&ddentry{msgId, seq, ts})
 		}
 		return nil
@@ -3076,7 +3076,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 	} else {
 		// No errors, this is the normal path.
 		// If we have a msgId make sure to save.
-		if msgId != _EMPTY_ {
+		if msgId != EMPTY {
 			mset.storeMsgId(&ddentry{msgId, seq, ts})
 		}
 		if rollupSub {
@@ -3145,7 +3145,7 @@ func (pm *jsPubMsg) returnToPool() {
 	if pm == nil {
 		return
 	}
-	pm.subj, pm.dsubj, pm.reply, pm.hdr, pm.msg, pm.o = _EMPTY_, _EMPTY_, _EMPTY_, nil, nil, nil
+	pm.subj, pm.dsubj, pm.reply, pm.hdr, pm.msg, pm.o = EMPTY, EMPTY, EMPTY, nil, nil, nil
 	jsPubMsgPool.Put(pm)
 }
 
@@ -3163,7 +3163,7 @@ type jsOutQ struct {
 
 func (q *jsOutQ) sendMsg(subj string, msg []byte) {
 	if q != nil {
-		q.send(newJSPubMsg(subj, _EMPTY_, _EMPTY_, nil, msg, nil, 0))
+		q.send(newJSPubMsg(subj, EMPTY, EMPTY, nil, msg, nil, 0))
 	}
 }
 
@@ -3199,7 +3199,7 @@ func (mset *stream) setupSendCapabilities() {
 // Returns the associated account name.
 func (mset *stream) accName() string {
 	if mset == nil {
-		return _EMPTY_
+		return EMPTY
 	}
 	mset.mu.RLock()
 	acc := mset.acc
@@ -3210,7 +3210,7 @@ func (mset *stream) accName() string {
 // Name returns the stream name.
 func (mset *stream) name() string {
 	if mset == nil {
-		return _EMPTY_
+		return EMPTY
 	}
 	mset.mu.RLock()
 	defer mset.mu.RUnlock()
@@ -3273,7 +3273,7 @@ func (mset *stream) internalLoop() {
 						msg = append(msg, pm.msg...)
 					}
 				}
-				msg = append(msg, _CRLF_...)
+				msg = append(msg, CR_LF...)
 
 				didDeliver, _ := c.processInboundClientMsg(msg)
 				c.pa.szb = nil
@@ -3506,7 +3506,7 @@ func (mset *stream) numConsumers() int {
 
 func (mset *stream) setConsumer(o *consumer) {
 	mset.consumers[o.name] = o
-	if o.cfg.FilterSubject != _EMPTY_ {
+	if o.cfg.FilterSubject != EMPTY {
 		mset.numFilter++
 	}
 	if o.cfg.Direct {
@@ -3515,7 +3515,7 @@ func (mset *stream) setConsumer(o *consumer) {
 }
 
 func (mset *stream) removeConsumer(o *consumer) {
-	if o.cfg.FilterSubject != _EMPTY_ && mset.numFilter > 0 {
+	if o.cfg.FilterSubject != EMPTY && mset.numFilter > 0 {
 		mset.numFilter--
 	}
 	if o.cfg.Direct && mset.directs > 0 {
@@ -3578,7 +3578,7 @@ func (mset *stream) Store() StreamStore {
 // Lock should be held.
 func (mset *stream) partitionUnique(partition string) bool {
 	for _, o := range mset.consumers {
-		if o.cfg.FilterSubject == _EMPTY_ {
+		if o.cfg.FilterSubject == EMPTY {
 			return false
 		}
 		if subjectIsSubsetMatch(partition, o.cfg.FilterSubject) {
@@ -3750,7 +3750,7 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 	if err := os.Rename(sdir, ndir); err != nil {
 		return nil, err
 	}
-	if cfg.Template != _EMPTY_ {
+	if cfg.Template != EMPTY {
 		if err := jsa.addStreamNameToTemplate(cfg.Template, cfg.Name); err != nil {
 			return nil, err
 		}

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -145,7 +145,7 @@ func (s *Sublist) CacheEnabled() bool {
 // will not block when trying to send the notification. Its up to the caller to make
 // sure the channel send will not block.
 func (s *Sublist) RegisterNotification(subject string, notify chan<- bool) error {
-	return s.registerNotification(subject, _EMPTY_, notify)
+	return s.registerNotification(subject, EMPTY, notify)
 }
 
 func (s *Sublist) RegisterQueueNotification(subject, queue string, notify chan<- bool) error {
@@ -164,7 +164,7 @@ func (s *Sublist) registerNotification(subject, queue string, notify chan<- bool
 	r := s.Match(subject)
 
 	if len(r.psubs)+len(r.qsubs) > 0 {
-		if queue == _EMPTY_ {
+		if queue == EMPTY {
 			for _, sub := range r.psubs {
 				if string(sub.subject) == subject {
 					hasInterest = true
@@ -223,7 +223,7 @@ func chkAndRemove(key string, notify chan<- bool, ms map[string][]chan<- bool) b
 }
 
 func (s *Sublist) ClearNotification(subject string, notify chan<- bool) bool {
-	return s.clearNotification(subject, _EMPTY_, notify)
+	return s.clearNotification(subject, EMPTY, notify)
 }
 
 func (s *Sublist) ClearQueueNotification(subject, queue string, notify chan<- bool) bool {
@@ -322,7 +322,7 @@ func (s *Sublist) chkForRemoveNotification(subject, queue string) {
 		r := s.matchNoLock(subject)
 
 		if len(r.psubs)+len(r.qsubs) > 0 {
-			if queue == _EMPTY_ {
+			if queue == EMPTY {
 				for _, sub := range r.psubs {
 					if string(sub.subject) == subject {
 						hasInterest = true
@@ -1055,7 +1055,7 @@ func IsValidPublishSubject(subject string) bool {
 
 // IsValidSubject returns true if a subject is valid, false otherwise
 func IsValidSubject(subject string) bool {
-	if subject == _EMPTY_ {
+	if subject == EMPTY {
 		return false
 	}
 	sfwc := false
@@ -1225,7 +1225,7 @@ func tokenAt(subject string, index uint8) string {
 	if ti == index {
 		return subject[start:]
 	}
-	return _EMPTY_
+	return EMPTY
 }
 
 // use similar to append. meaning, the updated slice will be returned

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -265,10 +265,10 @@ func (c *cluster) shutdown() {
 	for i, s := range c.servers {
 		sd := s.StoreDir()
 		s.Shutdown()
-		if cf := c.opts[i].ConfigFile; cf != _EMPTY_ {
+		if cf := c.opts[i].ConfigFile; cf != EMPTY {
 			os.Remove(cf)
 		}
-		if sd != _EMPTY_ {
+		if sd != EMPTY {
 			sd = strings.TrimSuffix(sd, JetStreamStoreDir)
 			os.RemoveAll(sd)
 		}

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -1612,7 +1612,7 @@ func TestWSParseOptions(t *testing.T) {
 			conf := createConfFile(t, []byte(test.content))
 			defer removeFile(t, conf)
 			o, err := ProcessConfigFile(conf)
-			if test.err != _EMPTY_ {
+			if test.err != EMPTY {
 				if err == nil || !strings.Contains(err.Error(), test.err) {
 					t.Fatalf("For content: %q, expected error about %q, got %v", test.content, test.err, err)
 				}
@@ -1832,7 +1832,7 @@ func testNewWSClientWithError(t testing.TB, o testWSClientOptions) (net.Conn, *b
 	if len(o.extraHeaders) > 0 {
 		for hdr, values := range o.extraHeaders {
 			if len(values) == 0 {
-				req.Header.Set(hdr, _EMPTY_)
+				req.Header.Set(hdr, EMPTY)
 				continue
 			}
 			req.Header.Set(hdr, values[0])
@@ -3941,20 +3941,20 @@ func TestWSXForwardedFor(t *testing.T) {
 	}{
 		{"nil map", func() map[string][]string {
 			return nil
-		}, false, _EMPTY_},
+		}, false, EMPTY},
 		{"empty map", func() map[string][]string {
 			return make(map[string][]string)
-		}, false, _EMPTY_},
+		}, false, EMPTY},
 		{"header present empty value", func() map[string][]string {
 			m := make(map[string][]string)
 			m[wsXForwardedForHeader] = []string{}
 			return m
-		}, false, _EMPTY_},
+		}, false, EMPTY},
 		{"header present invalid IP", func() map[string][]string {
 			m := make(map[string][]string)
 			m[wsXForwardedForHeader] = []string{"not a valid IP"}
 			return m
-		}, false, _EMPTY_},
+		}, false, EMPTY},
 		{"header present one IP", func() map[string][]string {
 			m := make(map[string][]string)
 			m[wsXForwardedForHeader] = []string{"1.2.3.4"}


### PR DESCRIPTION
 - [x] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

### Changes proposed in this pull request:
The location for the `_EMPTY_` constant is not optimal. Further there was a duplicate const for CRLF. 

 - relocated consts CRLF and EMPTY
 - renamed EMPTY const

/cc @nats-io/core
