### PR TITLE
Fixed panic on stream create failure (with filestore)

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -16210,6 +16210,23 @@ func TestJetStreamRemoveExternalSource(t *testing.T) {
 	checkStreamMsgs(jsa, "queue", 20)
 }
 
+func TestJetStreamAddStreamWithFilestoreFailure(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	if config := s.JetStreamConfig(); config != nil {
+		defer removeDir(t, config.StoreDir)
+	}
+	defer s.Shutdown()
+
+	// Cause failure to create stream with filestore.
+	// In one of ipQueue changes, this could cause a panic, so verify that we get
+	// a failure to create, but no panic.
+	if _, err := s.globalAccount().addStreamWithStore(
+		&StreamConfig{Name: "TEST"},
+		&FileStoreConfig{BlockSize: 2 * maxBlockSize}); err == nil {
+		t.Fatal("Expected failure, did not get one")
+	}
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // Simple JetStream Benchmarks
 ///////////////////////////////////////////////////////////////////////////

--- a/server/stream.go
+++ b/server/stream.go
@@ -3174,6 +3174,13 @@ func (q *jsOutQ) send(msg *jsPubMsg) {
 	q.push(msg)
 }
 
+func (q *jsOutQ) unregister() {
+	if q == nil {
+		return
+	}
+	q.ipQueue.unregister()
+}
+
 // StoredMsg is for raw access to messages in a stream.
 type StoredMsg struct {
 	Subject  string    `json:"subject"`


### PR DESCRIPTION
This was introduced by the change for ipQueues in #2931.
The (*ipQueue).unregister() was written with a protection for
the ipQueue to be nil, however, mset.outq is actually not a bare
ipQueue but a jsOutQ that embeds a pointer to an ipQueue. So we
need to implement register() for jsOutQ.

Added a test that reproduced the issue, but found it with a flapping
test (TestJetStreamLongStreamNamesAndPubAck) that failed due to
a file name too long.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
