### PR TITLE
[IMPROVED] Stream recovery and Memory Utilization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/klauspost/compress v1.14.4
 	github.com/minio/highwayhash v1.0.2
 	github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296
-	github.com/nats-io/nats.go v1.13.1-0.20220308171302-2f2f6968e98d
+	github.com/nats-io/nats.go v1.13.1-0.20220318132711-e0e03e374228
 	github.com/nats-io/nkeys v0.3.0
 	github.com/nats-io/nuid v1.0.1
 	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296 h1:vU9tpM3apjYlLLeY23zRWJ9Zktr5jp+mloR942LEOpY=
 github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
-github.com/nats-io/nats.go v1.13.1-0.20220308171302-2f2f6968e98d h1:zJf4l8Kp67RIZhoVeniSLZs69SHNgjLHz0aNsqPPlx8=
-github.com/nats-io/nats.go v1.13.1-0.20220308171302-2f2f6968e98d/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
+github.com/nats-io/nats.go v1.13.1-0.20220318132711-e0e03e374228 h1:czbQ9uYuV7dwLsh/0vpB+4rutgdLTYgoN5W5hf1S0eg=
+github.com/nats-io/nats.go v1.13.1-0.20220318132711-e0e03e374228/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=
 github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2535,16 +2535,13 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, _ *Account, subje
 		return
 	}
 
-	var subj string
-	var hdr []byte
-	var data []byte
-	var ts int64
-	seq := req.Seq
+	var svp StoreMsg
+	var sm *StoreMsg
 
 	if req.Seq > 0 {
-		subj, hdr, data, ts, err = mset.store.LoadMsg(req.Seq)
+		sm, err = mset.store.LoadMsg(req.Seq, &svp)
 	} else {
-		subj, seq, hdr, data, ts, err = mset.store.LoadLastMsg(req.LastFor)
+		sm, err = mset.store.LoadLastMsg(req.LastFor, &svp)
 	}
 	if err != nil {
 		resp.Error = NewJSNoMessageFoundError()
@@ -2552,11 +2549,11 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, _ *Account, subje
 		return
 	}
 	resp.Message = &StoredMsg{
-		Subject:  subj,
-		Sequence: seq,
-		Header:   hdr,
-		Data:     data,
-		Time:     time.Unix(0, ts).UTC(),
+		Subject:  sm.subj,
+		Sequence: sm.seq,
+		Header:   sm.hdr,
+		Data:     sm.msg,
+		Time:     time.Unix(0, sm.ts).UTC(),
 	}
 	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 }

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -11177,7 +11177,7 @@ func TestJetStreamRemovedPeersAndStreamsListAndDelete(t *testing.T) {
 	// Check behavior of stream info as well. We want it to return the stream is offline and not just timeout.
 	_, err = js.StreamInfo("GONE")
 	// FIXME(dlc) - Go client not putting nats: prefix on for stream but does for consumer.
-	require_Error(t, err, NewJSStreamOfflineError())
+	require_Error(t, err, NewJSStreamOfflineError(), errors.New("nats: stream is offline"))
 
 	// Same for Consumer
 	start = time.Now()

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -2594,13 +2594,13 @@ func TestJetStreamClusterUserSnapshotAndRestore(t *testing.T) {
 	}
 
 	// Create consumer with no state.
-	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Durable: "rip", AckPolicy: nats.AckExplicitPolicy, AckWait: time.Second})
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Durable: "rip", AckPolicy: nats.AckExplicitPolicy})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	// Create another consumer as well and give it a non-simplistic state.
-	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Durable: "dlc", AckPolicy: nats.AckExplicitPolicy, AckWait: time.Second})
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Durable: "dlc", AckPolicy: nats.AckExplicitPolicy, AckWait: 5 * time.Second})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2619,8 +2619,6 @@ func TestJetStreamClusterUserSnapshotAndRestore(t *testing.T) {
 			m.AckSync()
 		}
 	}
-	nc.Flush()
-	time.Sleep(500 * time.Millisecond)
 
 	// Snapshot consumer info.
 	ci, err := jsub.ConsumerInfo()
@@ -7067,13 +7065,14 @@ func TestJetStreamClusterDomainsAndSameNameSources(t *testing.T) {
 	}
 
 	// Now make sure we have 2 msgs in our sourced stream.
-	si, err := js.StreamInfo("S")
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if si.State.Msgs != 2 {
-		t.Fatalf("Expected 2 msgs, got %d", si.State.Msgs)
-	}
+	checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+		si, err := js.StreamInfo("S")
+		require_NoError(t, err)
+		if si.State.Msgs != 2 {
+			return fmt.Errorf("Expected 2 msgs, got %d", si.State.Msgs)
+		}
+		return nil
+	})
 
 	// Make sure we can see our external information.
 	// This not in the Go client yet so manual for now.
@@ -10301,7 +10300,7 @@ func TestJetStreamClusterNAKBackoffs(t *testing.T) {
 	if elapsed < time.Second {
 		t.Fatalf("Took too short to redeliver, expected ~1s but got %v", elapsed)
 	}
-	if elapsed > 2*time.Second {
+	if elapsed > 3*time.Second {
 		t.Fatalf("Took too long to redeliver, expected ~1s but got %v", elapsed)
 	}
 
@@ -11313,6 +11312,73 @@ func TestJetStreamDuplicateRoutesDisruptJetStreamMetaGroup(t *testing.T) {
 
 	checkClusterFormed(t, c.servers...)
 	c.waitOnClusterReady()
+}
+
+func TestJetStreamDuplicateMsgIdsOnCatchupAndLeaderTakeover(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "JSC", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	// Shutdown a non-leader.
+	nc.Close()
+	sr := c.randomNonStreamLeader("$G", "TEST")
+	sr.Shutdown()
+
+	nc, js = jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	m := nats.NewMsg("TEST")
+	m.Data = []byte("OK")
+
+	n := 10
+	for i := 0; i < n; i++ {
+		m.Header.Set(JSMsgId, strconv.Itoa(i))
+		_, err := js.PublishMsg(m)
+		require_NoError(t, err)
+	}
+
+	m.Header.Set(JSMsgId, "8")
+	pa, err := js.PublishMsg(m)
+	require_NoError(t, err)
+	if !pa.Duplicate {
+		t.Fatalf("Expected msg to be a duplicate")
+	}
+
+	// Now force a snapshot, want to test catchup above RAFT layer.
+	sl := c.streamLeader("$G", "TEST")
+	mset, err := sl.GlobalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	if node := mset.raftNode(); node == nil {
+		t.Fatalf("Could not get stream group name")
+	} else if err := node.InstallSnapshot(mset.stateSnapshot()); err != nil {
+		t.Fatalf("Error installing snapshot: %v", err)
+	}
+
+	// Now restart
+	sr = c.restartServer(sr)
+	c.waitOnStreamCurrent(sr, "$G", "TEST")
+
+	// Now make them the leader.
+	for sr != c.streamLeader("$G", "TEST") {
+		_, err = nc.Request(fmt.Sprintf(JSApiStreamLeaderStepDownT, "TEST"), nil, time.Second)
+		require_NoError(t, err)
+		c.waitOnStreamLeader("$G", "TEST")
+	}
+
+	// Make sure this gets rejected.
+	pa, err = js.PublishMsg(m)
+	require_NoError(t, err)
+	if !pa.Duplicate {
+		t.Fatalf("Expected msg to be a duplicate")
+	}
 }
 
 // Support functions

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -7339,10 +7339,9 @@ gateway {
 				if s := getStreams(js); len(s) != 1 {
 					st.Fatalf("unexpected stream count, got=%d, want=1", len(s))
 				}
-
-				err = js.DeleteStream(streamName)
-				require_NoError(st, err)
 			}
+			// Delete regardless.
+			js.DeleteStream(streamName)
 		})
 	}
 }


### PR DESCRIPTION
Under certain circumstances a stream that was still trying to catch up at the upper layers above NRG could be elected leader staling consumers.

Improved memory usage through JetStream storage layer.

Previously we would rely more heavily on Go's garbage collector since when we loaded a block for an underlying stream we would pass references upward to avoid copies.

Now we always copy when passing back to the upper layers which allows us to not only expire our cache blocks but pool and reuse them.

The upper layers also had changes made to allow the pooling layer at that level to interoperate with the storage layer.

/cc @nats-io/core
