### PR TITLE
JS: BackOff list caused too frequent checkPending() calls

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -10682,8 +10682,11 @@ func TestJetStreamClusterStreamTagPlacement(t *testing.T) {
 
 	reset := func(s *Server) {
 		s.mu.Lock()
-		s.sys.resetCh <- struct{}{}
+		rch := s.sys.resetCh
 		s.mu.Unlock()
+		if rch != nil {
+			rch <- struct{}{}
+		}
 		s.sendStatszUpdate()
 	}
 


### PR DESCRIPTION
Since the "next" timer value is set to the AckWait value, which
is the first element in the BackOff list if present, the check
would possibly happen at this interval, even when we were past
the first redelivery and the backoff interval had increased.

The end-user would still see the redelivery be done at the durations
indicated by the BackOff list, but internally, we would be checking
at the initial BackOff's ack wait.

I added a test that uses the store's interface to detect how many
times the checkPending() function is invoked. For this test it
should have been invoked twice, but without the fix it was invoked
15 times.

Also fixed an unrelated test that could possibly deadlock causing
tests to be aborted due to inactivity on Travis.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
