### PR TITLE
[FIXED] JetStream: possible deadlock during consumer leadership change

### DIFF
--- a/locksordering.txt
+++ b/locksordering.txt
@@ -3,3 +3,5 @@ Here is the list of some established lock ordering.
 In this list, A -> B means that you can have A.Lock() then B.Lock(), not the opposite.
 
 jetStream -> jsAccount -> Server -> client-> Account
+
+stream -> consumer

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1227,8 +1227,9 @@ func (a *Account) EnableJetStream(limits *JetStreamAccountLimits) error {
 			if !cfg.Created.IsZero() {
 				obs.setCreatedTime(cfg.Created)
 			}
+			lseq := e.mset.lastSeq()
 			obs.mu.Lock()
-			err = obs.readStoredState()
+			err = obs.readStoredState(lseq)
 			obs.mu.Unlock()
 			if err != nil {
 				s.Warnf("    Error restoring consumer state: %v", err)


### PR DESCRIPTION
Would possibly show up when a consumer leader changes for a consumer
that had redelivered messages and for instance messages were inbound
on the stream.

Resolves #2912

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
