### PR TITLE
[FIXED] update of R1 Consumer in clustered setup.

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2920,6 +2920,10 @@ func (js *jetStream) processClusterCreateConsumer(ca *consumerAssignment, state 
 		// Start our monitoring routine.
 		if rg.node == nil {
 			// Single replica consumer, process manually here.
+			js.mu.Lock()
+			// to force response in case we think we have responded before.
+			ca.responded = false
+			js.mu.Unlock()
 			js.processConsumerLeaderChange(o, true)
 		} else {
 			if !alreadyRunning {


### PR DESCRIPTION
missing reply caused timeout

Signed-off-by: Matthias Hanel <mh@synadia.com>

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [ ] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [ ] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

### Changes proposed in this pull request:

 -
 -
 -

/cc @nats-io/core
