### PR TITLE
[FIXED] Scaling up an R1 stream would not replicate existing messages.

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -10676,20 +10676,33 @@ func TestJetStreamClusterStreamReplicaUpdateFunctionCheck(t *testing.T) {
 	checkSubsPending(t, sub, 3*numMsgs)
 
 	// Make sure cluster replicas are current.
-	for _, r := range si.Cluster.Replicas {
-		if !r.Current {
-			t.Fatalf("Expected replica to be current: %+v", r)
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		si, err = js.StreamInfo("TEST")
+		require_NoError(t, err)
+		for _, r := range si.Cluster.Replicas {
+			if !r.Current {
+				return fmt.Errorf("Expected replica to be current: %+v", r)
+			}
 		}
+		return nil
+	})
+
+	checkState := func(s *Server) {
+		t.Helper()
+		checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+			mset, err := s.GlobalAccount().lookupStream("TEST")
+			require_NoError(t, err)
+			state := mset.state()
+			if state.Msgs != uint64(3*numMsgs) || state.FirstSeq != 1 || state.LastSeq != 30 || state.Bytes != 1320 {
+				return fmt.Errorf("Wrong state: %+v for server: %v", state, s)
+			}
+			return nil
+		})
 	}
 
 	// Now check each indidvidual stream on each server to make sure replication occurred.
 	for _, s := range c.servers {
-		mset, err := s.GlobalAccount().lookupStream("TEST")
-		require_NoError(t, err)
-		state := mset.state()
-		if state.Msgs != uint64(3*numMsgs) || state.FirstSeq != 1 || state.LastSeq != 30 || state.Bytes != 1320 {
-			t.Fatalf("Wrong state: %+v", state)
-		}
+		checkState(s)
 	}
 }
 

--- a/server/raft.go
+++ b/server/raft.go
@@ -885,7 +885,7 @@ func (n *raft) encodeSnapshot(snap *snapshot) []byte {
 
 // SendSnapshot will send the latest snapshot as a normal AE.
 // Should only be used when the upper layers know this is most recent.
-// Used when restoring streams etc.
+// Used when restoring streams, moving a stream from R1 to R>1, etc.
 func (n *raft) SendSnapshot(data []byte) error {
 	n.sendAppendEntry([]*Entry{{EntrySnapshot, data}})
 	return nil

--- a/server/stream.go
+++ b/server/stream.go
@@ -557,6 +557,8 @@ func (mset *stream) setLeader(isLeader bool) error {
 	// Track group leader.
 	if mset.isClustered() {
 		mset.leader = mset.node.GroupLeader()
+	} else {
+		mset.leader = _EMPTY_
 	}
 	mset.mu.Unlock()
 	return nil


### PR DESCRIPTION
Also fixed a bug where we were incorrectly not spinning up the monitoring loop for a stream when going from 3->1->3.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #2955 

/cc @nats-io/core
