### PR TITLE
Adding server limits (max ack pending/dedupe window) to js config

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -1188,5 +1188,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerMaxPendingAckExcess",
+    "code": 400,
+    "error_code": 10121,
+    "description": "consumer max ack pending exceeds server limit",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -2145,7 +2145,7 @@ func (a *Account) addStreamTemplate(tc *StreamTemplateConfig) (*streamTemplate, 
 	// FIXME(dlc) - Hacky
 	tcopy := tc.deepCopy()
 	tcopy.Config.Name = "_"
-	cfg, err := checkStreamCfg(tcopy.Config)
+	cfg, err := checkStreamCfg(tcopy.Config, &s.getOpts().JetStreamLimits)
 	if err != nil {
 		return nil, err
 	}

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -2,9 +2,7 @@
 
 package server
 
-import (
-	"strings"
-)
+import "strings"
 
 const (
 	// JSAccountResourcesExceededErr resource limits exceeded for account
@@ -108,6 +106,9 @@ const (
 
 	// JSConsumerMaxDeliverBackoffErr max deliver is required to be > length of backoff values
 	JSConsumerMaxDeliverBackoffErr ErrorIdentifier = 10116
+
+	// JSConsumerMaxPendingAckExcess consumer max ack pending exceeds server limit
+	JSConsumerMaxPendingAckExcess ErrorIdentifier = 10121
 
 	// JSConsumerMaxPendingAckPolicyRequiredErr consumer requires ack policy for max ack pending
 	JSConsumerMaxPendingAckPolicyRequiredErr ErrorIdentifier = 10082
@@ -401,6 +402,7 @@ var (
 		JSConsumerInvalidPolicyErrF:                {Code: 400, ErrCode: 10094, Description: "{err}"},
 		JSConsumerInvalidSamplingErrF:              {Code: 400, ErrCode: 10095, Description: "failed to parse consumer sampling configuration: {err}"},
 		JSConsumerMaxDeliverBackoffErr:             {Code: 400, ErrCode: 10116, Description: "max deliver is required to be > length of backoff values"},
+		JSConsumerMaxPendingAckExcess:              {Code: 400, ErrCode: 10121, Description: "consumer max ack pending exceeds server limit"},
 		JSConsumerMaxPendingAckPolicyRequiredErr:   {Code: 400, ErrCode: 10082, Description: "consumer requires ack policy for max ack pending"},
 		JSConsumerMaxRequestBatchNegativeErr:       {Code: 400, ErrCode: 10114, Description: "consumer max request batch needs to be > 0"},
 		JSConsumerMaxRequestExpiresToSmall:         {Code: 400, ErrCode: 10115, Description: "consumer max request expires needs to be >= 1ms"},
@@ -873,6 +875,16 @@ func NewJSConsumerMaxDeliverBackoffError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSConsumerMaxDeliverBackoffErr]
+}
+
+// NewJSConsumerMaxPendingAckExcessError creates a new JSConsumerMaxPendingAckExcess error: "consumer max ack pending exceeds server limit"
+func NewJSConsumerMaxPendingAckExcessError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSConsumerMaxPendingAckExcess]
 }
 
 // NewJSConsumerMaxPendingAckPolicyRequiredError creates a new JSConsumerMaxPendingAckPolicyRequiredErr error: "consumer requires ack policy for max ack pending"

--- a/server/reload.go
+++ b/server/reload.go
@@ -885,7 +885,7 @@ func imposeOrder(value interface{}) error {
 		sort.Strings(value.AllowedOrigins)
 	case string, bool, uint8, int, int32, int64, time.Duration, float64, nil, LeafNodeOpts, ClusterOpts, *tls.Config, PinnedCertSet,
 		*URLAccResolver, *MemAccResolver, *DirAccResolver, *CacheDirAccResolver, Authentication, MQTTOpts, jwt.TagList,
-		*OCSPConfig, map[string]string:
+		*OCSPConfig, map[string]string, JSLimitOpts:
 		// explicitly skipped types
 	default:
 		// this will fail during unit tests


### PR DESCRIPTION
Also shifting consumer config check to jsConsumerCreate as in clustered
mode this was enforced in the wrong place

Signed-off-by: Matthias Hanel <mh@synadia.com>

This is the cherry picket commit from https://github.com/nats-io/nats-server/pull/2950