### PR TITLE
[CHANGED] JetStream: lower default consumer's maximum ack pending

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -295,7 +295,7 @@ const (
 	// outstanding.
 	JsFlowControlMaxPending = 1 * 1024 * 1024
 	// JsDefaultMaxAckPending is set for consumers with explicit ack that do not set the max ack pending.
-	JsDefaultMaxAckPending = 20_000
+	JsDefaultMaxAckPending = 1000
 )
 
 // Helper function to set consumer config defaults from above.


### PR DESCRIPTION
The default value is lowered from 20,000 to 1,000. This does not
seem to have a performance degradation impact, but may help
with scalability at scale.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
