### PR TITLE
[IMPROVED] Consumer snapshot logic in clustered mode and disk usage.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1867,6 +1867,25 @@ func (o *consumer) readStoreState() *ConsumerState {
 	if o.store == nil {
 		return nil
 	}
+	if o.store.Type() == MemoryStorage {
+		state := o.liveState()
+		// Need to copy pending and rdc since we pass this up.
+		if len(state.Pending) > 0 {
+			pending := make(map[uint64]*Pending, len(state.Pending))
+			for seq, p := range state.Pending {
+				pending[seq] = &Pending{p.Sequence, p.Timestamp}
+			}
+			state.Pending = pending
+		}
+		if len(state.Redelivered) > 0 {
+			redelivered := make(map[uint64]uint64, len(state.Redelivered))
+			for seq, dc := range state.Redelivered {
+				redelivered[seq] = dc
+			}
+			state.Redelivered = redelivered
+		}
+		return state
+	}
 	state, _ := o.store.State()
 	return state
 }
@@ -1887,14 +1906,9 @@ func (o *consumer) writeStoreState() error {
 	return o.writeStoreStateUnlocked()
 }
 
-// Update our state to the store.
 // Lock should be held.
-func (o *consumer) writeStoreStateUnlocked() error {
-	if o.store == nil {
-		return nil
-	}
-
-	state := ConsumerState{
+func (o *consumer) liveState() *ConsumerState {
+	return &ConsumerState{
 		Delivered: SequencePair{
 			Consumer: o.dseq - 1,
 			Stream:   o.sseq - 1,
@@ -1906,7 +1920,15 @@ func (o *consumer) writeStoreStateUnlocked() error {
 		Pending:     o.pending,
 		Redelivered: o.rdc,
 	}
-	return o.store.Update(&state)
+}
+
+// Update our state to the store.
+// Lock should be held.
+func (o *consumer) writeStoreStateUnlocked() error {
+	if o.store == nil {
+		return nil
+	}
+	return o.store.Update(o.liveState())
 }
 
 // Returns an initial info. Only applicable for non-clustered consumers.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1507,11 +1507,13 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 
 	const (
 		compactInterval = 2 * time.Minute
-		compactSizeMin  = 32 * 1024 * 1024
+		compactSizeMin  = 8 * 1024 * 1024
 		compactNumMin   = 65536
 	)
 
-	t := time.NewTicker(compactInterval)
+	// Spread these out for large numbers on server restart.
+	rci := time.Duration(rand.Int63n(int64(time.Minute)))
+	t := time.NewTicker(compactInterval + rci)
 	defer t.Stop()
 
 	js.mu.RLock()
@@ -3104,28 +3106,43 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 
 	const (
 		compactInterval = 2 * time.Minute
-		compactSizeMin  = 8 * 1024 * 1024
-		compactNumMin   = 8192
+		compactSizeMin  = 64 * 1024 // What is stored here is always small for consumers.
+		compactNumMin   = 1024
+		minSnapDelta    = 2 * time.Second
 	)
 
-	t := time.NewTicker(compactInterval)
+	// Spread these out for large numbers on server restart.
+	rci := time.Duration(rand.Int63n(int64(time.Minute)))
+	t := time.NewTicker(compactInterval + rci)
 	defer t.Stop()
 
-	st := o.store.Type()
 	var lastSnap []byte
+	var lastSnapTime time.Time
 
-	doSnapshot := func() {
-		// Memory store consumers do not keep state in the store itself.
-		// Just compact to our applied index.
-		if st == MemoryStorage {
-			_, _, applied := n.Progress()
-			n.Compact(applied)
-		} else if state, err := o.store.State(); err == nil && state != nil {
-			// FileStore version.
-			if snap := encodeConsumerState(state); !bytes.Equal(lastSnap, snap) {
-				if err := n.InstallSnapshot(snap); err == nil {
-					lastSnap = snap
-				}
+	doSnapshot := func(force bool) {
+		// Bail if trying too fast and not in a forced situation.
+		if !force && time.Since(lastSnapTime) < minSnapDelta {
+			return
+		}
+
+		// Check several things to see if we need a snapshot.
+		needSnap := force || n.NeedSnapshot()
+		if !needSnap {
+			// Check if we should compact etc. based on size of log.
+			ne, nb := n.Size()
+			needSnap = nb > 0 && ne >= compactNumMin || nb > compactSizeMin
+		}
+
+		state := o.readStoreState()
+		if state == nil {
+			s.Warnf("Failed to get state for '%s > %s > %s' [%s]", o.acc.Name, ca.Stream, ca.Name, n.Group())
+		}
+
+		if snap := encodeConsumerState(state); !bytes.Equal(lastSnap, snap) || needSnap {
+			if err := n.InstallSnapshot(snap); err == nil {
+				lastSnap, lastSnapTime = snap, time.Now()
+			} else {
+				s.Warnf("Failed to install snapshot for '%s > %s > %s' [%s]: %v", o.acc.Name, ca.Stream, ca.Name, n.Group(), err)
 			}
 		}
 	}
@@ -3147,7 +3164,7 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 				if cei == nil {
 					recovering = false
 					if n.NeedSnapshot() {
-						doSnapshot()
+						doSnapshot(true)
 					}
 					continue
 				}
@@ -3156,7 +3173,7 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 					ne, nb := n.Applied(ce.Index)
 					// If we have at least min entries to compact, go ahead and snapshot/compact.
 					if nb > 0 && ne >= compactNumMin || nb > compactSizeMin {
-						doSnapshot()
+						doSnapshot(false)
 					}
 				} else {
 					s.Warnf("Error applying consumer entries to '%s > %s'", ca.Client.serviceAccount(), ca.Name)
@@ -3168,10 +3185,10 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 				js.setConsumerAssignmentRecovering(ca)
 			}
 			if err := js.processConsumerLeaderChange(o, isLeader); err == nil && isLeader {
-				doSnapshot()
+				doSnapshot(true)
 			}
 		case <-t.C:
-			doSnapshot()
+			doSnapshot(false)
 		}
 	}
 }

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -3284,9 +3284,12 @@ func TestNoRaceJetStreamClusterMemoryStreamConsumerRaftGrowth(t *testing.T) {
 		t.Fatalf("Error looking up consumer %q", "q1")
 	}
 	node := o.raftNode().(*raft)
-	if ms := node.wal.(*memStore); ms.State().Msgs > 8192 {
-		t.Fatalf("Did not compact the raft memory WAL")
-	}
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		if ms := node.wal.(*memStore); ms.State().Msgs > 8192 {
+			return fmt.Errorf("Did not compact the raft memory WAL")
+		}
+		return nil
+	})
 }
 
 func TestNoRaceJetStreamClusterCorruptWAL(t *testing.T) {


### PR DESCRIPTION
Also fixed a bug that could cause memory based replicated consumers to potentially no longer work after snapshots and server restarts.

The snapshot logic would allow non-state changing updates to continuously grow the raft logs. We also were too conservative on when we snapshotted and why.

Also added in ability to have FileStore.Compact() reclaim space from the block file from the head of last changed block.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #2936 

/cc @nats-io/core
