### PR TITLE
[ADDED] Logs to healthcheck handler

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2768,6 +2768,7 @@ func (s *Server) HandleHealthz(w http.ResponseWriter, r *http.Request) {
 
 	hs := s.healthz()
 	if hs.Error != _EMPTY_ {
+		s.Warnf("Healthcheck failed: %q", hs.Error)
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}
 	b, err := json.Marshal(hs)


### PR DESCRIPTION
Kubernetes probes don't use nor log the reponse body of health
endpoints. This means that for some reason a nats node running in
Kubernetes becomes on a Not Ready state we won't have a way to know why
other than to manually access the cluster and call the /healthz endpoint
manually and see the error.

This change adds an error log so we can observe what is going wrong with
a nats node that is not ready.

Signed-off-by: Samuel Torres <samuel.torres@form3.tech>

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [ ] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [ ] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

### Changes proposed in this pull request:

 - Add error logging to healthcheck endpoint 

/cc @nats-io/core
