### PR TITLE
skips jsz on non js machines when leader only requested

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2617,6 +2617,10 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 
 	js := s.getJetStream()
 	if js == nil || !js.isEnabled() {
+		if opts.LeaderOnly {
+			return nil, fmt.Errorf("%w: not leader", errSkipZreq)
+		}
+
 		jsi.Disabled = true
 		return jsi, nil
 	}


### PR DESCRIPTION
This is a regression introduced in 055703f4fabc46eb9722193f9ecbed8803795228
that leads to panics in management tooling

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
