### PR TITLE
Fixed wrong error check

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4005,7 +4005,7 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 	cfg := &ccfg
 
 	selectedLimits, tier, _, apiErr := acc.selectLimits(&ccfg)
-	if err != nil {
+	if apiErr != nil {
 		resp.Error = apiErr
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

Noticed the failure when I removed the `t.Skip()` in my test :-(