### PR TITLE
Skip SystemLimitsPlacement if we can't get the desired leader

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -38,17 +38,22 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
-func checkFor(t *testing.T, totalWait, sleepDur time.Duration, f func() error) {
-	t.Helper()
+func checkForErr(totalWait, sleepDur time.Duration, f func() error) error {
 	timeout := time.Now().Add(totalWait)
 	var err error
 	for time.Now().Before(timeout) {
 		err = f()
 		if err == nil {
-			return
+			return nil
 		}
 		time.Sleep(sleepDur)
 	}
+	return err
+}
+
+func checkFor(t *testing.T, totalWait, sleepDur time.Duration, f func() error) {
+	t.Helper()
+	err := checkForErr(totalWait, sleepDur, f)
 	if err != nil {
 		t.Fatal(err.Error())
 	}


### PR DESCRIPTION
The system limit placement tests can fail if we can't get a specific server to be the leader. There is currently no way to force a specific server to be the leader, so we have to rely on chance for this to happen.

The main change here is that if we can't pick the right leader, then we'll skip the test instead of fail the test. I also added some more checks to `TestJetStreamSystemLimitsPlacement`.

I can't use the current JetStream cluster helpers because those assume that every server in the cluster is identical. However, the point of these tests is to verify the behavior when servers are configured differently. There may be a way to start the cluster and update individual servers after the fact, based on [this test](https://github.com/nats-io/nats-server/blob/ee98a814694820d9eeb9a2646a9aa5ee1ea346d0/server/jetstream_cluster_test.go#L10793). I could investigate this further.

For the current change, I ran `go test -v -count=100 -run=SystemLimitsPlacement &>> test.log` in 5 different shell invocations.

Here are some results from the logs.
```
$ grep -E "^--- PASS: TestJetStreamSuperClusterSystemLimitsPlacement" test.log | wc -l
500

$ grep -E "^--- PASS: TestJetStreamSystemLimitsPlacement" test.log | wc -l
475
$ grep -E "^--- SKIP: TestJetStreamSystemLimitsPlacement" test.log | wc -l
25

$ grep "FAIL" test.log | wc -l
0
```
5% of the time, `TestJetStreamSystemLimitsPlacement` wasn't able to pick the desired server to be leader. In those cases, we skip that test.

Besides those skipped tests, there were no failures in the 500 runs.