### PR TITLE
[FIXED] Sealed streams would not recover on server restart.

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1355,6 +1355,13 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, _ *Account,
 		return
 	}
 
+	// Can't create a stream with a sealed state.
+	if cfg.Sealed {
+		resp.Error = NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration for create can not be sealed"))
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+
 	// Hand off to cluster for processing.
 	if s.JetStreamIsClustered() {
 		s.jsClusteredStreamRequest(ci, acc, subject, reply, rmsg, &cfg)

--- a/server/stream.go
+++ b/server/stream.go
@@ -289,11 +289,6 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 		return nil, NewJSStreamInvalidConfigError(err, Unless(err))
 	}
 
-	// Can't create a stream with a sealed state.
-	if cfg.Sealed {
-		return nil, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration for create can not be sealed"))
-	}
-
 	singleServerMode := !s.JetStreamIsClustered() && s.standAloneMode()
 	if singleServerMode && cfg.Replicas > 1 {
 		return nil, ApiErrors[JSStreamReplicasNotSupportedErr]


### PR DESCRIPTION
Not allowing sealed streams to be created meant we could not recover on server restart.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
