### PR TITLE
[CHANGED] Rate limit (some) similar warnings

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -5325,6 +5325,15 @@ func (c *client) Warnf(format string, v ...interface{}) {
 	c.srv.Warnf(format, v...)
 }
 
+func (c *client) RateLimitWarnf(format string, v ...interface{}) {
+	// Do the check before adding the client info to the format...
+	statement := fmt.Sprintf(format, v...)
+	if _, loaded := c.srv.rateLimitLogging.LoadOrStore(statement, time.Now().UnixNano()); loaded {
+		return
+	}
+	c.Warnf("%s", statement)
+}
+
 // Set the very first PING to a lower interval to capture the initial RTT.
 // After that the PING interval will be set to the user defined value.
 // Client lock should be held.

--- a/server/client.go
+++ b/server/client.go
@@ -5328,7 +5328,7 @@ func (c *client) Warnf(format string, v ...interface{}) {
 func (c *client) RateLimitWarnf(format string, v ...interface{}) {
 	// Do the check before adding the client info to the format...
 	statement := fmt.Sprintf(format, v...)
-	if _, loaded := c.srv.rateLimitLogging.LoadOrStore(statement, time.Now().UnixNano()); loaded {
+	if _, loaded := c.srv.rateLimitLogging.LoadOrStore(statement, time.Now()); loaded {
 		return
 	}
 	c.Warnf("%s", statement)

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -2269,7 +2269,7 @@ func (t *streamTemplate) processInboundTemplateMsg(_ *subscription, pc *client, 
 	t.mu.Unlock()
 
 	if atLimit {
-		c.Warnf("JetStream could not create stream for account %q on subject %q, at limit", acc.Name, subject)
+		c.RateLimitWarnf("JetStream could not create stream for account %q on subject %q, at limit", acc.Name, subject)
 		return
 	}
 
@@ -2280,7 +2280,7 @@ func (t *streamTemplate) processInboundTemplateMsg(_ *subscription, pc *client, 
 	mset, err := acc.addStream(&cfg)
 	if err != nil {
 		acc.validateStreams(t)
-		c.Warnf("JetStream could not create stream for account %q on subject %q", acc.Name, subject)
+		c.RateLimitWarnf("JetStream could not create stream for account %q on subject %q: %v", acc.Name, subject, err)
 		return
 	}
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5131,7 +5131,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	if !ok {
 		jsa.mu.RUnlock()
 		err := fmt.Errorf("no JetStream resource limits found account: %q", jsa.acc().Name)
-		s.Warnf(err.Error())
+		s.RateLimitWarnf(err.Error())
 		if canRespond {
 			var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
 			resp.Error = NewJSNoLimitsError()
@@ -5161,7 +5161,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	// If we have exceeded our account limits go ahead and return.
 	if exceeded {
 		err := fmt.Errorf("JetStream resource limits exceeded for account: %q", jsa.acc().Name)
-		s.Warnf(err.Error())
+		s.RateLimitWarnf(err.Error())
 		if canRespond {
 			var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
 			resp.Error = NewJSAccountResourcesExceededError()
@@ -5174,7 +5174,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	// Check msgSize if we have a limit set there. Again this works if it goes through but better to be pre-emptive.
 	if maxMsgSize >= 0 && (len(hdr)+len(msg)) > maxMsgSize {
 		err := fmt.Errorf("JetStream message size exceeds limits for '%s > %s'", jsa.acc().Name, mset.cfg.Name)
-		s.Warnf(err.Error())
+		s.RateLimitWarnf(err.Error())
 		if canRespond {
 			var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
 			resp.Error = NewJSStreamMessageExceedsMaximumError()
@@ -5188,7 +5188,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	// Again this works if it goes through but better to be pre-emptive.
 	if len(hdr) > math.MaxUint16 {
 		err := fmt.Errorf("JetStream header size exceeds limits for '%s > %s'", jsa.acc().Name, mset.cfg.Name)
-		s.Warnf(err.Error())
+		s.RateLimitWarnf(err.Error())
 		if canRespond {
 			var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
 			resp.Error = NewJSStreamHeaderExceedsMaximumError()

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -8199,7 +8199,7 @@ func TestJetStreamPanicDecodingConsumerState(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "JSC", 3)
 	defer c.shutdown()
 
-	rch := make(chan struct{}, 1)
+	rch := make(chan struct{}, 2)
 	nc, js := jsClientConnect(t, c.randomServer(),
 		nats.ReconnectWait(50*time.Millisecond),
 		nats.MaxReconnects(-1),

--- a/server/log.go
+++ b/server/log.go
@@ -208,7 +208,7 @@ func (s *Server) Warnf(format string, v ...interface{}) {
 
 func (s *Server) RateLimitWarnf(format string, v ...interface{}) {
 	statement := fmt.Sprintf(format, v...)
-	if _, loaded := s.rateLimitLogging.LoadOrStore(statement, time.Now().UnixNano()); loaded {
+	if _, loaded := s.rateLimitLogging.LoadOrStore(statement, time.Now()); loaded {
 		return
 	}
 	s.Warnf("%s", statement)

--- a/server/log.go
+++ b/server/log.go
@@ -14,9 +14,11 @@
 package server
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"sync/atomic"
+	"time"
 
 	srvlog "github.com/nats-io/nats-server/v2/logger"
 )
@@ -202,6 +204,14 @@ func (s *Server) Warnf(format string, v ...interface{}) {
 	s.executeLogCall(func(logger Logger, format string, v ...interface{}) {
 		logger.Warnf(format, v...)
 	}, format, v...)
+}
+
+func (s *Server) RateLimitWarnf(format string, v ...interface{}) {
+	statement := fmt.Sprintf(format, v...)
+	if _, loaded := s.rateLimitLogging.LoadOrStore(statement, time.Now().UnixNano()); loaded {
+		return
+	}
+	s.Warnf("%s", statement)
 }
 
 // Fatalf logs a fatal error

--- a/server/stream.go
+++ b/server/stream.go
@@ -1625,7 +1625,7 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 				mset.retryMirrorConsumer()
 			}
 		} else {
-			s.Warnf("Got error processing JetStream mirror msg: %v", err)
+			s.RateLimitWarnf("Got error processing JetStream mirror msg: %v", err)
 		}
 		if strings.Contains(err.Error(), "no space left") {
 			s.Errorf("JetStream out of space, will be DISABLED")
@@ -2236,7 +2236,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 			mset.cancelSourceConsumer(si.iname)
 			mset.retrySourceConsumer(si.iname)
 		} else {
-			s.Warnf("JetStream got an error processing inbound source msg: %v", err)
+			s.RateLimitWarnf("JetStream got an error processing inbound source msg: %v", err)
 		}
 		if strings.Contains(err.Error(), "no space left") {
 			s.Errorf("JetStream out of space, will be DISABLED")
@@ -3138,7 +3138,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 			response, _ = json.Marshal(resp)
 		}
 	} else if exceeded, apiErr := jsa.limitsExceeded(stype, tierName); exceeded {
-		s.Warnf("JetStream resource limits exceeded for account: %q", accName)
+		s.RateLimitWarnf("JetStream resource limits exceeded for account: %q", accName)
 		if canRespond {
 			resp.PubAck = &PubAck{Stream: name}
 			if apiErr == nil {


### PR DESCRIPTION
Some warnings, especially when dealing with JS limits that were
printed on a per-message basis, are now limited to ~1 per second
if the content of the warning is already found in a map.

This is also for "client" warnings, but the client porting of the
warning is not taken into account so that helps with reducing logging
for similar content, but coming from different clients.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
