### PR TITLE
[FIXED] JetStream: send "bad request" response for malformed API requ…

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -664,6 +664,11 @@ func (js *jetStream) apiDispatch(sub *subscription, c *client, acc *Account, sub
 
 	// Shortcircuit.
 	if len(rr.psubs)+len(rr.qsubs) == 0 {
+		ci, acc, _, msg, err := s.getRequestInfo(c, rmsg)
+		if err == nil {
+			resp := &ApiResponse{Type: JSApiOverloadedType, Error: NewJSBadRequestError()}
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		}
 		return
 	}
 

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -11659,6 +11659,35 @@ func TestJetStreamClusterMemoryConsumerCompactVsSnapshot(t *testing.T) {
 
 }
 
+func TestJetStreamClusterSendBadRequestResponseOnInvalidAPIRequest(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	if config := s.JetStreamConfig(); config != nil {
+		defer removeDir(t, config.StoreDir)
+	}
+	defer s.Shutdown()
+
+	c := createJetStreamClusterExplicit(t, "JSC", 3)
+	defer c.shutdown()
+
+	checkBadRequest := func(t *testing.T, s *Server) {
+		nc := natsConnect(t, s.ClientURL())
+		defer nc.Close()
+
+		// Send a consumer info but with a bad consumer name.
+		// Use low-level here to by-bass validity checks done in the client library.
+		msg, err := nc.Request(fmt.Sprintf(JSApiConsumerInfoT, "BAD_REQUESTS", "bad.consumer.name"), nil, time.Second)
+		require_NoError(t, err)
+
+		var resp JSApiConsumerInfoResponse
+		err = json.Unmarshal(msg.Data, &resp)
+		require_NoError(t, err)
+		require_Error(t, resp.Error, NewJSBadRequestError())
+	}
+
+	t.Run("Single", func(t *testing.T) { checkBadRequest(t, s) })
+	t.Run("Clustered", func(t *testing.T) { checkBadRequest(t, c.randomServer()) })
+}
+
 // Support functions
 
 // Used to setup superclusters for tests.


### PR DESCRIPTION
…ests

An example was a "consumer info" request with a consumer name that
had tokens, which is illegal. This results in the request being
dropped in apiDispatch() because there was no interest.
The server will now return a "bad request" error in such case.

Resolves #2995

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
