### PR TITLE
Add a config modification callback to createJetStreamCluster

### DIFF
--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -5712,12 +5712,7 @@ func TestJWTClusteredJetStreamTiersChange(t *testing.T) {
 		DiskStorage: 1500, MemoryStorage: 0, Consumer: 1, Streams: 1}
 	accJwt1 := encodeClaim(t, accClaim, aExpPub)
 	accCreds := newUser(t, accKp)
-
 	start := time.Now()
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
-	dirSrv := createDir(t, "srv")
-	defer removeDir(t, dirSrv)
 
 	tmlp := `
 		listen: 127.0.0.1:-1
@@ -5803,12 +5798,7 @@ func TestJWTClusteredJetStreamDeleteTierWithStreamAndMove(t *testing.T) {
 		DiskStorage: 3000, MemoryStorage: 0, Consumer: 1, Streams: 1}
 	accJwt1 := encodeClaim(t, accClaim, aExpPub)
 	accCreds := newUser(t, accKp)
-
 	start := time.Now()
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
-	dirSrv := createDir(t, "srv")
-	defer removeDir(t, dirSrv)
 
 	tmlp := `
 		listen: 127.0.0.1:-1
@@ -5822,16 +5812,17 @@ func TestJWTClusteredJetStreamDeleteTierWithStreamAndMove(t *testing.T) {
 			listen: 127.0.0.1:%d
 			routes = [%s]
 		}
-	` + fmt.Sprintf(`
-		operator: %s
-		system_account: %s
-		resolver: {
-			type: full
-			dir: '%s'
-		}
-	`, ojwt, syspub, dirSrv)
-
-	c := createJetStreamClusterWithTemplate(t, tmlp, "cluster", 3)
+	`
+	c := createJetStreamClusterWithTemplateAndModHook(t, tmlp, "cluster", 3,
+		func(serverName, clustername, storeDir, conf string) string {
+			return conf + fmt.Sprintf(`
+				operator: %s
+				system_account: %s
+				resolver: {
+					type: full
+					dir: '%s/jwt'
+				}`, ojwt, syspub, storeDir)
+		})
 	defer c.shutdown()
 
 	updateJwt(t, c.randomServer().ClientURL(), sysCreds, sysJwt, 3)

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -5731,16 +5731,17 @@ func TestJWTClusteredJetStreamTiersChange(t *testing.T) {
 			listen: 127.0.0.1:%d
 			routes = [%s]
 		}
-	` + fmt.Sprintf(`
-		operator: %s
-		system_account: %s
-		resolver: {
-			type: full
-			dir: '%s'
-		}
-	`, ojwt, syspub, dirSrv)
-
-	c := createJetStreamClusterWithTemplate(t, tmlp, "cluster", 3)
+	`
+	c := createJetStreamClusterWithTemplateAndModHook(t, tmlp, "cluster", 3,
+		func(serverName, clustername, storeDir, conf string) string {
+			return conf + fmt.Sprintf(`
+				operator: %s
+				system_account: %s
+				resolver: {
+					type: full
+					dir: '%s/jwt'
+				}`, ojwt, syspub, storeDir)
+		})
 	defer c.shutdown()
 
 	updateJwt(t, c.randomServer().ClientURL(), sysCreds, sysJwt, 3)


### PR DESCRIPTION
named createJetStreamClusterAndModHook allowing the generated config to
be altered prior to server start

Signed-off-by: Matthias Hanel <mh@synadia.com>

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [ ] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [ ] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

### Changes proposed in this pull request:

 -
 -
 -

/cc @nats-io/core
