### PR TITLE
fix crash on shutdown with meta being nil

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -774,6 +774,10 @@ func (s *Server) migrateEphemerals() {
 	var consumers []*consumerAssignment
 
 	js.mu.Lock()
+	if cc.meta == nil {
+		js.mu.Unlock()
+		return
+	}
 	ourID := cc.meta.ID()
 	for _, asa := range cc.streams {
 		for _, sa := range asa {


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

fixes 
```
--- FAIL: TestJetStreamSystemLimitsPlacement (2.99s)
    --- PASS: TestJetStreamSystemLimitsPlacement/file_create_large_stream_on_small_server (0.00s)
    --- PASS: TestJetStreamSystemLimitsPlacement/memory_create_large_stream_on_small_server (0.00s)
    --- PASS: TestJetStreamSystemLimitsPlacement/file_create_large_stream_on_medium_server (0.00s)
    --- PASS: TestJetStreamSystemLimitsPlacement/memory_create_large_stream_on_medium_server (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x88 pc=0x8fed6e]
goroutine 193037 [running]:
testing.tRunner.func1.2(0x10003a0, 0x17d2360)
	/home/travis/.gimme/versions/go1.16.15.linux.amd64/src/testing/testing.go:1153 +0x332
testing.tRunner.func1(0xc00045cd80)
	/home/travis/.gimme/versions/go1.16.15.linux.amd64/src/testing/testing.go:1156 +0x4b6
panic(0x10003a0, 0x17d2360)
	/home/travis/.gimme/versions/go1.16.15.linux.amd64/src/runtime/panic.go:965 +0x1b9
github.com/nats-io/nats-server/v2/server.(*Server).migrateEphemerals(0xc001e7ac00)
	/home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:777 +0xae
github.com/nats-io/nats-server/v2/server.(*Server).Shutdown(0xc001e7ac00)
	/home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1845 +0x7d
github.com/nats-io/nats-server/v2/server.TestJetStreamSystemLimitsPlacement(0xc00045cd80)
	/home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_test.go:7057 +0xd45
testing.tRunner(0xc00045cd80, 0x1184678)
	/home/travis/.gimme/versions/go1.16.15.linux.amd64/src/testing/testing.go:1203 +0xe5
created by testing.(*T).Run
	/home/travis/.gimme/versions/go1.16.15.linux.amd64/src/testing/testing.go:1248 +0x2b3
FAIL	github.com/nats-io/nats-server/v2/server	443.756s
FAIL
```