### PR TITLE
fix unit test that did not fail when header was modified

### DIFF
--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -82,8 +82,9 @@ func TestNRGAppendEntryDecode(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		b := copyBytes(buf)
-		bi := rand.Intn(len(b))
-		if b[bi] != 0 {
+		// modifying the header (idx < 42) will not result in an error by decodeAppendEntry
+		bi := 42 + rand.Intn(len(b)-42)
+		if b[bi] != 0 && bi != 40 {
 			b[bi] = 0
 			_, err = node.decodeAppendEntry(b, nil, _EMPTY_)
 			require_Error(t, err, errBadAppendEntry)


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

I sampled on which index errors happened. All where below 42

for reference: 

```go
// This can not be used post the wire level callback since we do not copy.
func (n *raft) decodeAppendEntry(msg []byte, sub *subscription, reply string) (*appendEntry, error) {
	if len(msg) < appendEntryBaseLen {
		return nil, errBadAppendEntry
	}

	var le = binary.LittleEndian
	ae := &appendEntry{
		leader: string(msg[:idLen]),
		term:   le.Uint64(msg[8:]),
		commit: le.Uint64(msg[16:]),
		pterm:  le.Uint64(msg[24:]),
		pindex: le.Uint64(msg[32:]),
	}
	// Decode Entries.
	ne, ri := int(le.Uint16(msg[40:])), 42
	for i, max := 0, len(msg); i < ne; i++ {
		if ri >= max-1 {
			return nil, errBadAppendEntry
		}
		le := int(le.Uint32(msg[ri:]))
		ri += 4
		if le <= 0 || ri+le > max {
			return nil, errBadAppendEntry
		}
		etype := EntryType(msg[ri])
		ae.entries = append(ae.entries, &Entry{etype, msg[ri+1 : ri+le]})
		ri += le
	}
	ae.reply = reply
	ae.sub = sub
	ae.buf = msg
	return ae, nil
}
```