### PR TITLE
[IMPROVED] Stream with multiple subjects and consumer with filter

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -981,6 +981,12 @@ func (fs *fileStore) recoverMsgs() error {
 	if len(fs.blks) > 0 {
 		sort.Slice(fs.blks, func(i, j int) bool { return fs.blks[i].index < fs.blks[j].index })
 		fs.lmb = fs.blks[len(fs.blks)-1]
+		// Update our sfilter for the last block since we could have only see one subject during recovery.
+		if len(fs.cfg.Subjects) == 1 {
+			fs.lmb.sfilter = fs.cfg.Subjects[0]
+		} else {
+			fs.lmb.sfilter = _EMPTY_
+		}
 	} else {
 		_, err = fs.newMsgBlockForWrite()
 	}


### PR DESCRIPTION
This is more of a regression introduced in v2.7.3 (with PR #2848).
When the store has a list of subjects, finding the next message
to deliver would go through the subjects map and have to match
to find out if it is a subset (if the filter had a wildcard).
In situations where there were lots of subjects (for instance 1
message per subject), but the consumer did not filter on anything
specific, then this processing was becoming slow.

We now check that if the stream has a single subject (even with
wildcard) and the consumer filters on that exact subject, then
we can do a linear scan. We also do a linear scan if the number
of messages in the block is 1/2 the number of subjects in the
subjects map.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
