### PR TITLE
Adding unique_placement_prefix to ensure matching tags are not used twice

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4049,6 +4049,7 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 	}
 
 	var nodes []wn
+	// peers is a randomized list
 	s, peers := cc.s, cc.meta.Peers()
 
 	// Map existing.
@@ -4062,6 +4063,18 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 			ep[p] = struct{}{}
 		}
 	}
+
+	uniqueTagPrefix := s.getOpts().JetStreamLimits.UniquePlacementTagPrefix
+	if uniqueTagPrefix != _EMPTY_ {
+		for _, tag := range tags {
+			if strings.HasPrefix(tag, uniqueTagPrefix) {
+				// disable uniqueness check of explicitly listed in tags
+				uniqueTagPrefix = _EMPTY_
+				break
+			}
+		}
+	}
+	var uniqueTags = make(map[string]struct{})
 
 	for _, p := range peers {
 		si, ok := s.nodeToInfo.Load(p.ID)
@@ -4118,6 +4131,23 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 		// Otherwise check if we have enough room if maxBytes set.
 		if maxBytes > 0 && maxBytes > available {
 			continue
+		}
+
+		if uniqueTagPrefix != _EMPTY_ {
+			// default requires the unique prefix to be present
+			isUnique := false
+			for _, t := range ni.tags {
+				if strings.HasPrefix(t, uniqueTagPrefix) {
+					if _, ok := uniqueTags[t]; !ok {
+						uniqueTags[t] = struct{}{}
+						isUnique = true
+					}
+					break
+				}
+			}
+			if !isUnique {
+				continue
+			}
 		}
 		// Add to our list of potential nodes.
 		nodes = append(nodes, wn{p.ID, available})

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4064,7 +4064,7 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 		}
 	}
 
-	uniqueTagPrefix := s.getOpts().JetStreamLimits.UniquePlacementTagPrefix
+	uniqueTagPrefix := s.getOpts().JetStreamUniqueTag
 	if uniqueTagPrefix != _EMPTY_ {
 		for _, tag := range tags {
 			if strings.HasPrefix(tag, uniqueTagPrefix) {

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -4563,6 +4563,85 @@ func TestJetStreamClusterSuperClusterMetaPlacement(t *testing.T) {
 	}
 }
 
+func TestJetStreamUniquePlacementTag(t *testing.T) {
+	tmlp := `
+		listen: 127.0.0.1:-1
+		server_name: %s
+		jetstream: {max_mem_store: 256MB, max_file_store: 2GB, store_dir: '%s', limits: {unique_placement_prefix: az}}
+		leaf {listen: 127.0.0.1:-1}
+		cluster {
+			name: %s
+			listen: 127.0.0.1:%d
+			routes = [%s]
+		}
+		# For access to system account.
+		accounts { $SYS { users = [ { user: "admin", pass: "s3cr3t!" } ] } }
+	`
+	s := createJetStreamSuperClusterWithTemplateAndModHook(t, tmlp, 5, 2,
+		func(serverName, clustername, storeDir, conf string) string {
+			azTag := map[string]string{
+				"C1-S1": "az:same",
+				"C1-S2": "az:same",
+				"C1-S3": "az:same",
+				"C1-S4": "az:same",
+				"C1-S5": "az:same",
+				"C2-S1": "az:1",
+				"C2-S2": "az:2",
+				"C2-S3": "az:1",
+				"C2-S4": "az:2",
+				"C2-S5": "az:1",
+			}
+			return conf + fmt.Sprintf("\nserver_tags: [cloud:%s-tag, %s]\n", clustername, azTag[serverName])
+		})
+	defer s.shutdown()
+
+	nc := natsConnect(t, s.randomServer().ClientURL())
+	defer nc.Close()
+
+	js, err := nc.JetStream()
+	require_NoError(t, err)
+
+	for i, test := range []struct {
+		placement *nats.Placement
+		replicas  int
+		fail      bool
+		cluster   string
+	}{
+		// these pass because replica count is 1
+		{&nats.Placement{Tags: []string{"az:same"}}, 1, false, "C1"},
+		{&nats.Placement{Tags: []string{"cloud:C1-tag", "az:same"}}, 1, false, "C1"},
+		{&nats.Placement{Tags: []string{"cloud:C1-tag"}}, 1, false, "C1"},
+		// pass because az is set, which disables the filter
+		{&nats.Placement{Tags: []string{"az:same"}}, 2, false, "C1"},
+		{&nats.Placement{Tags: []string{"cloud:C1-tag", "az:same"}}, 2, false, "C1"},
+		// fails because this cluster only has the same az
+		{&nats.Placement{Tags: []string{"cloud:C1-tag"}}, 2, true, ""},
+		// fails because no 3 unique tags exist
+		{&nats.Placement{Tags: []string{"cloud:C2-tag"}}, 3, true, ""},
+		{nil, 3, true, ""},
+		// pass because replica count is low enough
+		{nil, 2, false, "C2"},
+		{&nats.Placement{Tags: []string{"cloud:C2-tag"}}, 2, false, "C2"},
+		// pass because az is provided
+		{&nats.Placement{Tags: []string{"az:1"}}, 3, false, "C2"},
+		{&nats.Placement{Tags: []string{"az:2"}}, 2, false, "C2"},
+	} {
+		name := fmt.Sprintf("test-%d", i)
+		t.Run(name, func(t *testing.T) {
+			ci, err := js.AddStream(&nats.StreamConfig{Name: name, Replicas: test.replicas, Placement: test.placement})
+			if test.fail {
+				require_Error(t, err)
+				require_Equal(t, err.Error(), "insufficient resources")
+				return
+			}
+			require_NoError(t, err)
+			if test.cluster != _EMPTY_ {
+				require_Equal(t, ci.Cluster.Name, test.cluster)
+			}
+		})
+	}
+}
+
 func TestJetStreamClusterSuperClusterBasics(t *testing.T) {
 	sc := createJetStreamSuperCluster(t, 3, 3)
 	defer sc.shutdown()

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -4567,7 +4567,7 @@ func TestJetStreamUniquePlacementTag(t *testing.T) {
 	tmlp := `
 		listen: 127.0.0.1:-1
 		server_name: %s
-		jetstream: {max_mem_store: 256MB, max_file_store: 2GB, store_dir: '%s', limits: {unique_placement_prefix: az}}
+		jetstream: {max_mem_store: 256MB, max_file_store: 2GB, store_dir: '%s', unique_tag: az}
 		leaf {listen: 127.0.0.1:-1}
 		cluster {
 			name: %s

--- a/server/opts.go
+++ b/server/opts.go
@@ -178,8 +178,9 @@ type RemoteLeafOpts struct {
 }
 
 type JSLimitOpts struct {
-	MaxAckPending int
-	Duplicates    time.Duration
+	MaxAckPending            int
+	Duplicates               time.Duration
+	UniquePlacementTagPrefix string
 }
 
 // Options block for nats-server.
@@ -1813,6 +1814,8 @@ func parseJetStreamLimits(v interface{}, opts *Options, errors *[]error, warning
 			if err != nil {
 				*errors = append(*errors, err)
 			}
+		case "unique_placement_prefix":
+			lim.UniquePlacementTagPrefix = strings.ToLower(strings.TrimSpace(mv.(string)))
 		default:
 			if !tk.IsUsedVariable() {
 				err := &unknownConfigFieldErr{

--- a/server/opts.go
+++ b/server/opts.go
@@ -178,9 +178,9 @@ type RemoteLeafOpts struct {
 }
 
 type JSLimitOpts struct {
-	MaxAckPending            int
-	Duplicates               time.Duration
-	UniquePlacementTagPrefix string
+	MaxAckPending int
+	Duplicates    time.Duration
+	UniqueTag     string
 }
 
 // Options block for nats-server.
@@ -232,6 +232,7 @@ type Options struct {
 	JetStreamDomain       string        `json:"-"`
 	JetStreamExtHint      string        `json:"-"`
 	JetStreamKey          string        `json:"-"`
+	JetStreamUniqueTag    string
 	JetStreamLimits       JSLimitOpts
 	StoreDir              string            `json:"-"`
 	JsAccDefaultDomain    map[string]string `json:"-"` // account to domain name mapping
@@ -1814,8 +1815,6 @@ func parseJetStreamLimits(v interface{}, opts *Options, errors *[]error, warning
 			if err != nil {
 				*errors = append(*errors, err)
 			}
-		case "unique_placement_prefix":
-			lim.UniquePlacementTagPrefix = strings.ToLower(strings.TrimSpace(mv.(string)))
 		default:
 			if !tk.IsUsedVariable() {
 				err := &unknownConfigFieldErr{
@@ -1889,6 +1888,8 @@ func parseJetStream(v interface{}, opts *Options, errors *[]error, warnings *[]e
 				if err := parseJetStreamLimits(tk, opts, errors, warnings); err != nil {
 					return err
 				}
+			case "unique_tag":
+				opts.JetStreamUniqueTag = strings.ToLower(strings.TrimSpace(mv.(string)))
 			default:
 				if !tk.IsUsedVariable() {
 					err := &unknownConfigFieldErr{


### PR DESCRIPTION

Allows to not place a stream in the same availability zone twice

Signed-off-by: Matthias Hanel <mh@synadia.com>
