### PR TITLE
fix sleep in unit test to ensure updates have propagated

### DIFF
--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -5769,7 +5769,7 @@ func TestJWTClusteredJetStreamTiers(t *testing.T) {
 	_, err = js.Publish("testR1-2", msg[:])
 	require_NoError(t, err)
 
-	time.Sleep(1700 * time.Millisecond) // wait for update timer to synchronize totals
+	time.Sleep(2000 * time.Millisecond) // wait for update timer to synchronize totals
 
 	// test exceeding tiered storage limit
 	_, err = js.Publish("testR1-1", []byte("1"))


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

ran without and this and -race, spotted the issues
ran with this and -race, no issue in 40 min