### PR TITLE
Allow nats-server to run as system user on Windows

### DIFF
--- a/server/service_windows.go
+++ b/server/service_windows.go
@@ -109,11 +109,11 @@ func Run(server *Server) error {
 		server.Start()
 		return nil
 	}
-	isInteractive, err := svc.IsAnInteractiveSession()
+	isWindowsService, err := svc.IsWindowsService()
 	if err != nil {
 		return err
 	}
-	if isInteractive {
+	if !isWindowsService {
 		server.Start()
 		return nil
 	}
@@ -125,6 +125,6 @@ func isWindowsService() bool {
 	if dockerized {
 		return false
 	}
-	isInteractive, _ := svc.IsAnInteractiveSession()
-	return !isInteractive
+	isWindowsService, _ := svc.IsWindowsService()
+	return isWindowsService
 }


### PR DESCRIPTION
Trying to run nats-server as nt_authority/system, the process would immediately exit with error: "The service process could not connect to the service controller."
This is now fixed

 - [X] Link to issue: None reported
 - [X] Documentation added: N/A
 - [X] Tests added: N/A (No functionality changes)
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

### Changes proposed in this pull request:

 - Stopped using Deprecated method IsAnInteractiveSession (https://pkg.go.dev/golang.org/x/sys/windows/svc#IsAnInteractiveSession)
 - Replaced Deprecated method with suggested one (IsWindowsService)
(https://pkg.go.dev/golang.org/x/sys/windows/svc#IsWindowsService)

/cc @nats-io/core

### Reproduction steps
In order to start a command prompt as nt_authority you can use the following command:
```cmd
PS> psexec -s -i cmd.exe
```
PSExec tool can be found here ([https://docs.microsoft.com/en-us/sysinternals/downloads/psexec](https://docs.microsoft.com/en-us/sysinternals/downloads/psexec))

**cmd output before changes:**
```cmd
C:\nats_IsAnInteractiveSession>whoami
nt authority\system

C:\nats_IsAnInteractiveSession>nats-server.exe -v
nats-server: v2.7.4

C:\nats_IsAnInteractiveSession>nats-server.exe
The service process could not connect to the service controller.
```

**cmd output after changes:**
```cmd
C:\nats_IsWindowsService>whoami
nt authority\system

C:\nats_IsWindowsService>nats-server.exe -v
nats-server: v2.7.4

C:\nats_IsWindowsService>nats-server.exe
[12580] 2022/04/11 10:50:56.739321 [←[32mINF←[0m] Starting nats-server
[12580] 2022/04/11 10:50:56.740421 [←[32mINF←[0m]   Version:  2.7.4
[12580] 2022/04/11 10:50:56.742057 [←[32mINF←[0m]   Git:      [not set]
[12580] 2022/04/11 10:50:56.742608 [←[32mINF←[0m]   Name:     NC6K5LCGMBO7PNQ3HZKCQCVMZVSBF552ELGQ7QMK24FD32ZLUXPZ35DU
[12580] 2022/04/11 10:50:56.743154 [←[32mINF←[0m]   ID:       NC6K5LCGMBO7PNQ3HZKCQCVMZVSBF552ELGQ7QMK24FD32ZLUXPZ35DU
[12580] 2022/04/11 10:50:56.745350 [←[32mINF←[0m] Listening for client connections on 0.0.0.0:4222
[12580] 2022/04/11 10:50:56.751411 [←[32mINF←[0m] Server is ready
```

Addendum:
Not sure exactly why this fixes it, but was discovered as a solution for an issue we had at the company I work at since we run nats both as a service and not as a service under different users.
