### PR TITLE
Stream Alternates

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -6079,6 +6079,8 @@ func (js *jetStream) streamAlternates(ci *ClientInfo, stream string) []StreamAlt
 	defer js.mu.RUnlock()
 
 	s, cc := js.srv, js.cluster
+	// Track our domain.
+	domain := s.getOpts().JetStreamDomain
 
 	// No clustering just return nil.
 	if cc == nil {
@@ -6102,7 +6104,7 @@ func (js *jetStream) streamAlternates(ci *ClientInfo, stream string) []StreamAlt
 	for _, sa := range cc.streams[acc.Name] {
 		// Add in ourselves and any mirrors.
 		if sa.Config.Name == stream || (sa.Config.Mirror != nil && sa.Config.Mirror.Name == stream) {
-			alts = append(alts, StreamAlternate{Name: sa.Config.Name, Cluster: sa.Group.Cluster})
+			alts = append(alts, StreamAlternate{Name: sa.Config.Name, Domain: domain, Cluster: sa.Group.Cluster})
 		}
 	}
 	// If just us don't fill in.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -6067,6 +6067,57 @@ func (mset *stream) checkClusterInfo(ci *ClusterInfo) {
 	}
 }
 
+// Return a list of alternates, ranked by preference order to the request, of stream mirrors.
+// This allows clients to select or get more information about read replicas that could be a
+// better option to connect to versus the original source.
+func (js *jetStream) streamAlternates(ci *ClientInfo, stream string) []StreamAlternate {
+	if js == nil {
+		return nil
+	}
+
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+
+	s, cc := js.srv, js.cluster
+
+	// No clustering just return nil.
+	if cc == nil {
+		return nil
+	}
+	acc, _ := s.LookupAccount(ci.serviceAccount())
+	if acc == nil {
+		return nil
+	}
+
+	// Collect our ordering first for clusters.
+	weights := make(map[string]int)
+	all := []string{ci.Cluster}
+	all = append(all, ci.Alternates...)
+
+	for i := 0; i < len(all); i++ {
+		weights[all[i]] = len(all) - i
+	}
+
+	var alts []StreamAlternate
+	for _, sa := range cc.streams[acc.Name] {
+		// Add in ourselves and any mirrors.
+		if sa.Config.Name == stream || (sa.Config.Mirror != nil && sa.Config.Mirror.Name == stream) {
+			alts = append(alts, StreamAlternate{Name: sa.Config.Name, Cluster: sa.Group.Cluster})
+		}
+	}
+	// If just us don't fill in.
+	if len(alts) == 1 {
+		return nil
+	}
+
+	// Sort based on our weights that originate from the request itself.
+	sort.Slice(alts, func(i, j int) bool {
+		return weights[alts[i].Cluster] > weights[alts[j].Cluster]
+	})
+
+	return alts
+}
+
 func (mset *stream) handleClusterStreamInfoRequest(sub *subscription, c *client, _ *Account, subject, reply string, _ []byte) {
 	mset.mu.RLock()
 	sysc, js, sa, config := mset.sysc, mset.srv.js, mset.sa, mset.cfg

--- a/server/stream.go
+++ b/server/stream.go
@@ -96,13 +96,19 @@ type PubAck struct {
 
 // StreamInfo shows config and current state for this stream.
 type StreamInfo struct {
-	Config  StreamConfig        `json:"config"`
-	Created time.Time           `json:"created"`
-	State   StreamState         `json:"state"`
-	Domain  string              `json:"domain,omitempty"`
-	Cluster *ClusterInfo        `json:"cluster,omitempty"`
-	Mirror  *StreamSourceInfo   `json:"mirror,omitempty"`
-	Sources []*StreamSourceInfo `json:"sources,omitempty"`
+	Config     StreamConfig        `json:"config"`
+	Created    time.Time           `json:"created"`
+	State      StreamState         `json:"state"`
+	Domain     string              `json:"domain,omitempty"`
+	Cluster    *ClusterInfo        `json:"cluster,omitempty"`
+	Mirror     *StreamSourceInfo   `json:"mirror,omitempty"`
+	Sources    []*StreamSourceInfo `json:"sources,omitempty"`
+	Alternates []StreamAlternate   `json:"alternates,omitempty"`
+}
+
+type StreamAlternate struct {
+	Name    string `json:"name"`
+	Cluster string `json:"cluster"`
 }
 
 // ClusterInfo shows information about the underlying set of servers

--- a/server/stream.go
+++ b/server/stream.go
@@ -108,6 +108,7 @@ type StreamInfo struct {
 
 type StreamAlternate struct {
 	Name    string `json:"name"`
+	Domain  string `json:"domain,omitempty"`
 	Cluster string `json:"cluster"`
 }
 


### PR DESCRIPTION
This introduces stream alternates as an optional part of StreamInfo.

Alternates provide a priority list of mirrors and the source in relation to where the request originated.
So if a stream S has 2 mirrors, and we receive a user request for the stream info for S, it will include a sorted list of itself, since it could be the closest, and all mirrors, allowing clients to select read replicas if so desired.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
