### PR TITLE
[FIXED] JetStream stream catchup issues and deadlock

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -851,6 +851,13 @@ func (s *Server) shutdownJetStream() {
 	s.Noticef("Initiating JetStream Shutdown...")
 	defer s.Noticef("JetStream Shutdown")
 
+	// If we have folks blocked on sync requests, unblock.
+	// Send 1 is enough, but use select in case they were all present.
+	select {
+	case s.syncOutSem <- struct{}{}:
+	default:
+	}
+
 	var _a [512]*Account
 	accounts := _a[:0]
 

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -3670,6 +3670,11 @@ func TestJetStreamClusterPeerOffline(t *testing.T) {
 }
 
 func TestJetStreamClusterNoQuorumStepdown(t *testing.T) {
+	// Make this shorter for the test.
+	old := lostQuorumInterval
+	lostQuorumInterval = hbIntervalDefault * 3
+	defer func() { lostQuorumInterval = old }()
+
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -359,8 +359,8 @@ func TestJetStreamAutoTuneFSConfig(t *testing.T) {
 
 	testBlkSize("foo", 1, 0, FileStoreMinBlkSize)
 	testBlkSize("foo", 1, 512, FileStoreMinBlkSize)
-	testBlkSize("foo", 1, 1024*1024, 262200)
-	testBlkSize("foo", 1, 8*1024*1024, 2097200)
+	testBlkSize("foo", 1, 1024*1024, defaultMediumBlockSize)
+	testBlkSize("foo", 1, 8*1024*1024, defaultMediumBlockSize)
 	testBlkSize("foo_bar_baz", -1, 32*1024*1024*1024, FileStoreMaxBlkSize)
 }
 

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2734,14 +2734,18 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 			filterIdx = i
 		}
 		jsa.mu.RLock()
-		jsi.Streams += len(jsa.streams)
+		streams := make([]*stream, 0, len(jsa.streams))
 		for _, stream := range jsa.streams {
+			streams = append(streams, stream)
+		}
+		jsa.mu.RUnlock()
+		jsi.Streams += len(streams)
+		for _, stream := range streams {
 			streamState := stream.state()
 			jsi.Messages += streamState.Msgs
 			jsi.Bytes += streamState.Bytes
 			jsi.Consumers += streamState.Consumers
 		}
-		jsa.mu.RUnlock()
 	}
 
 	// filter logic

--- a/server/raft.go
+++ b/server/raft.go
@@ -70,6 +70,7 @@ type RaftNode interface {
 	Created() time.Time
 	Stop()
 	Delete()
+	Wipe()
 }
 
 type WAL interface {
@@ -231,7 +232,7 @@ const (
 	minCampaignTimeoutDefault = 100 * time.Millisecond
 	maxCampaignTimeoutDefault = 8 * minCampaignTimeoutDefault
 	hbIntervalDefault         = 500 * time.Millisecond
-	lostQuorumIntervalDefault = hbIntervalDefault * 5
+	lostQuorumIntervalDefault = hbIntervalDefault * 20 // 10 seconds
 )
 
 var (
@@ -1123,7 +1124,6 @@ func (n *raft) Leader() bool {
 	return isLeader
 }
 
-// Reports our catching up state.
 func (n *raft) isCatchingUp() bool {
 	n.RLock()
 	defer n.RUnlock()
@@ -1433,6 +1433,20 @@ func (n *raft) shutdown(shouldDelete bool) {
 			wal.Stop()
 		}
 	}
+}
+
+// Wipe will force a on disk state reset and the call Delete().
+// Useful in case we have been stopped before this point.
+func (n *raft) Wipe() {
+	n.RLock()
+	wal := n.wal
+	n.RUnlock()
+	// Delete our underlying storage.
+	if wal != nil {
+		wal.Delete()
+	}
+	// Now call delete.
+	n.Delete()
 }
 
 // Lock should be held (due to use of random generator)
@@ -2520,6 +2534,7 @@ func (n *raft) handleAppendEntry(sub *subscription, c *client, _ *Account, subje
 	} else {
 		n.warn("AppendEntry failed to be placed on internal channel: corrupt entry")
 	}
+	n.resetElectionTimeout()
 }
 
 // Lock should be held.
@@ -2626,8 +2641,6 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 		}
 		n.stepdown.push(ae.leader)
 	}
-
-	n.resetElectionTimeout()
 
 	// Catching up state.
 	catchingUp := n.catchup != nil
@@ -2896,6 +2909,14 @@ func (n *raft) handleAppendEntryResponse(sub *subscription, c *client, _ *Accoun
 	ar := n.decodeAppendEntryResponse(msg)
 	ar.reply = reply
 	n.resp.push(ar)
+	if ar.success {
+		n.Lock()
+		// Update peer's last index.
+		if ps := n.peers[ar.peer]; ps != nil && ar.index > ps.li {
+			ps.li = ar.index
+		}
+		n.Unlock()
+	}
 }
 
 func (n *raft) buildAppendEntry(entries []*Entry) *appendEntry {

--- a/server/server.go
+++ b/server/server.go
@@ -276,6 +276,15 @@ type Server struct {
 	// To limit logging frequency
 	rateLimitLogging   sync.Map
 	rateLimitLoggingCh chan time.Duration
+
+	// Total outstanding catchup bytes in flight.
+	gcbMu  sync.RWMutex
+	gcbOut int64
+	// A global chanel to kick out stalled catchup sequences.
+	gcbKick chan struct{}
+
+	// Total outbound syncRequests
+	syncOutSem chan struct{}
 }
 
 // For tracking JS nodes.
@@ -377,6 +386,13 @@ func NewServer(opts *Options) (*Server, error) {
 		httpReqStats:       make(map[string]uint64), // Used to track HTTP requests
 		rateLimitLoggingCh: make(chan time.Duration, 1),
 		leafNodeEnabled:    opts.LeafNode.Port != 0 || len(opts.LeafNode.Remotes) > 0,
+		syncOutSem:         make(chan struct{}, maxConcurrentSyncRequests),
+	}
+
+	// Fill up the maximum in flight syncRequests for this server.
+	// Used in JetStream catchup semantics.
+	for i := 0; i < maxConcurrentSyncRequests; i++ {
+		s.syncOutSem <- struct{}{}
 	}
 
 	if opts.TLSRateLimit > 0 {

--- a/server/stream.go
+++ b/server/stream.go
@@ -532,6 +532,9 @@ func (mset *stream) setStreamAssignment(sa *streamAssignment) {
 
 	// Set our node.
 	mset.node = sa.Group.node
+	if mset.node != nil {
+		mset.node.UpdateKnownPeers(sa.Group.Peers)
+	}
 
 	// Setup our info sub here as well for all stream members. This is now by design.
 	if mset.infoSub == nil {
@@ -693,11 +696,12 @@ func (mset *stream) autoTuneFileStorageBlockSize(fsCfg *FileStoreConfig) {
 	if m := blkSize % 100; m != 0 {
 		blkSize += 100 - m
 	}
-	if blkSize < FileStoreMinBlkSize {
+	if blkSize <= FileStoreMinBlkSize {
 		blkSize = FileStoreMinBlkSize
-	}
-	if blkSize > FileStoreMaxBlkSize {
+	} else if blkSize >= FileStoreMaxBlkSize {
 		blkSize = FileStoreMaxBlkSize
+	} else {
+		blkSize = defaultMediumBlockSize
 	}
 	fsCfg.BlockSize = uint64(blkSize)
 }


### PR DESCRIPTION
- A stream could become leader when it should not, causing
messages to be lost.
- A catchup could stall because the server sending data
could bail out of the runCatchup routine but still send
the EOF signal.
- Deadlock with monitoring of Jsz
    
Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
Signed-off-by: Derek Collison <derek@nats.io>