### PR TITLE
[FIXED] LeafNode interest propagation with imports/exports

### DIFF
--- a/server/sublist.go
+++ b/server/sublist.go
@@ -1369,7 +1369,7 @@ func matchLiteral(literal, subject string) bool {
 }
 
 func addLocalSub(sub *subscription, subs *[]*subscription, includeLeafHubs bool) {
-	if sub != nil && sub.client != nil && sub.im == nil {
+	if sub != nil && sub.client != nil {
 		kind := sub.client.kind
 		if kind == CLIENT || kind == SYSTEM || kind == JETSTREAM || kind == ACCOUNT ||
 			(includeLeafHubs && sub.client.isHubLeafNode() /* implied kind==LEAF */) {


### PR DESCRIPTION
When using subscriptions through import/exports, the server with
a leafnode connection would properly send the interest over, but
if the connection is recreated, this would not happen.

In case of JetStream where that happens under the cover, message
flow would stop after the leafnode restart because the subscriptions
would be created on recovery of the JetStream assets but *before*
the LeafNode connection could be established.

Resolves https://github.com/nats-io/nats-server/issues/3024
Resolves https://github.com/nats-io/nats-server/issues/3027
Resolves https://github.com/nats-io/nats-server/issues/3009

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>