### PR TITLE
[Adding] max_ha_assets to limit placement on server with more ha assets

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4126,6 +4126,14 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 
 		// Otherwise check if we have enough room if maxBytes set.
 		if maxBytes > 0 && maxBytes > available {
+			s.Warnf("%s@%s (Max Bytes: %d) exceeds available %s storage of %d bytes",
+				ni.name, ni.cluster, maxBytes, cfg.Storage.String(), available)
+			continue
+		}
+		// HAAssets contain _meta_ which we want to ignore
+		if maxHaAssets > 0 && ni.stats != nil && ni.stats.HAAssets > maxHaAssets {
+			s.Warnf("%s@%s (HA Asset Count: %d) exceeds max ha asset limit of %d for stream placement",
+				ni.name, ni.cluster, ni.stats.HAAssets, maxHaAssets)
 			continue
 		}
 
@@ -4144,13 +4152,6 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 			if !isUnique {
 				continue
 			}
-		}
-
-		// HAAssets contain _meta_ which we want to ignore
-		if maxHaAssets > 0 && ni.stats != nil && ni.stats.HAAssets > maxHaAssets {
-			s.Warnf("%s@%s (ha asset count: %d) exceeds max ha asset limit of %d for stream placement",
-				ni.name, ni.cluster, ni.stats.HAAssets, maxHaAssets)
-			continue
 		}
 		// Add to our list of potential nodes.
 		nodes = append(nodes, wn{p.ID, available})
@@ -5326,7 +5327,7 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 						if stats := ni.stats; stats != nil && stats.HAAssets > maxHaAssets {
 							resp.Error = NewJSInsufficientResourcesError()
 							s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
-							s.Warnf("%s@%s (ha asset count: %d) exceeds max ha asset limit of %d"+
+							s.Warnf("%s@%s (HA Asset Count: %d) exceeds max ha asset limit of %d"+
 								" for (durable) consumer %s placement on stream %s",
 								ni.name, ni.cluster, ni.stats.HAAssets, maxHaAssets, oname, stream)
 							return

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5299,14 +5299,12 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 		// Inherit cluster from stream.
 		rg.Cluster = sa.Group.Cluster
 
-		check := true
 		// We need to set the ephemeral here before replicating.
 		if !isDurableConsumer(cfg) {
 			// We chose to have ephemerals be R=1 unless stream is interest or workqueue.
 			if sa.Config.Retention == LimitsPolicy {
 				rg.Peers = []string{rg.Preferred}
 				rg.Name = groupNameForConsumer(rg.Peers, rg.Storage)
-				check = false
 			}
 			// Make sure name is unique.
 			for {
@@ -5319,7 +5317,7 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 				break
 			}
 		}
-		if check {
+		if len(rg.Peers) > 1 {
 			if maxHaAssets := s.getOpts().JetStreamLimits.MaxHAAssets; maxHaAssets != 0 {
 				for _, peer := range rg.Peers {
 					if ni, ok := s.nodeToInfo.Load(peer); ok {

--- a/server/opts.go
+++ b/server/opts.go
@@ -186,8 +186,8 @@ type RemoteLeafOpts struct {
 
 type JSLimitOpts struct {
 	MaxAckPending int
+	MaxHAAssets   int
 	Duplicates    time.Duration
-	UniqueTag     string
 }
 
 // Options block for nats-server.
@@ -1816,6 +1816,8 @@ func parseJetStreamLimits(v interface{}, opts *Options, errors *[]error, warning
 		switch strings.ToLower(mk) {
 		case "max_ack_pending":
 			lim.MaxAckPending = int(mv.(int64))
+		case "max_ha_assets":
+			lim.MaxHAAssets = int(mv.(int64))
 		case "duplicate_window":
 			var err error
 			lim.Duplicates, err = time.ParseDuration(mv.(string))


### PR DESCRIPTION
server running more than max_ha_assets #raft nodes will not be used to
place new streams and fail if not enough free server can be found.
Durable Consumer creation on such server will fail as their peer size is
bound to the same set as their stream.

This also avoids updating placement where no new placement is needed.

Signed-off-by: Matthias Hanel <mh@synadia.com>
