### PR TITLE
[IMPROVED] JetStream: reduce unnecessary leader election

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -651,9 +651,8 @@ const defaultMaxJSApiOut = int64(4096)
 var maxJSApiOut = defaultMaxJSApiOut
 
 func (js *jetStream) apiDispatch(sub *subscription, c *client, acc *Account, subject, reply string, rmsg []byte) {
-	js.mu.RLock()
+	// No lock needed, those are immutable.
 	s, rr := js.srv, js.apiSubs.Match(subject)
-	js.mu.RUnlock()
 
 	hdr, _ := c.msgParts(rmsg)
 	if len(getHeader(ClientInfoHdr, hdr)) == 0 {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -645,6 +645,16 @@ func TestJetStreamConsumerMaxDeliveries(t *testing.T) {
 	}
 }
 
+func TestJetStreamNextReqFromMsg(t *testing.T) {
+	bef := time.Now()
+	expires, _, _, _, _, err := nextReqFromMsg([]byte(`{"expires":5000000000}`)) // nanoseconds
+	require_NoError(t, err)
+	now := time.Now()
+	if expires.Before(bef.Add(5*time.Second)) || expires.After(now.Add(5*time.Second)) {
+		t.Fatal("Expires out of expected range")
+	}
+}
+
 func TestJetStreamPullConsumerDelayedFirstPullWithReplayOriginal(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -7241,7 +7251,7 @@ func TestJetStreamSuperClusterSystemLimitsPlacement(t *testing.T) {
 	}
 }
 
-func TestStreamLimitUpdate(t *testing.T) {
+func TestJetStreamStreamLimitUpdate(t *testing.T) {
 	s := RunBasicJetStreamServer()
 	if config := s.JetStreamConfig(); config != nil {
 		defer removeDir(t, config.StoreDir)
@@ -15699,7 +15709,7 @@ func TestJetStreamPullConsumerHeartBeats(t *testing.T) {
 	}
 }
 
-func TestStorageReservedBytes(t *testing.T) {
+func TestJetStreamStorageReservedBytes(t *testing.T) {
 	const systemLimit = 1024
 	opts := DefaultTestOptions
 	opts.Port = -1

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -3557,6 +3557,7 @@ func TestNoRaceJetStreamClusterStreamReset(t *testing.T) {
 	minElectionTimeout = 250 * time.Millisecond
 	maxElectionTimeout = time.Second
 	hbInterval = 50 * time.Millisecond
+	defer setDefaultRaftTimeouts()
 
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/raft.go
+++ b/server/raft.go
@@ -1544,9 +1544,7 @@ func (n *raft) resetElectionTimeout() {
 }
 
 func (n *raft) resetElectionTimeoutWithLock() {
-	n.Lock()
-	n.resetElect(randElectionTimeout())
-	n.Unlock()
+	n.resetElectWithLock(randElectionTimeout())
 }
 
 // Lock should be held.
@@ -1591,7 +1589,7 @@ func (n *raft) run() {
 			select {
 			case <-s.quitCh:
 				return
-			case <-time.After(50 * time.Millisecond):
+			case <-time.After(100 * time.Millisecond):
 				s.RateLimitWarnf("Waiting for routing to established...")
 			}
 		} else {


### PR DESCRIPTION
- Wait of some sort of routing to be in place before starting
the raft run loop
- Remove use of lock in apiDispatch that was not necessary but
could have cause a route to block, causing memory growth, etc..

Unrelated rename of some tests so that they start with TestJetStream
and TestJetStreamCluster for cluster tests, fixed some flappers
and ensure that tests that change RAFT timeouts put them back
to default values on exit.