### PR TITLE
Improvements to stream and consumer move.

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1696,6 +1696,10 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 			// Process our leader change.
 			js.processStreamLeaderChange(mset, isLeader)
 
+			// We may receive a leader change after the stream assignment which would cancel us
+			// monitoring for this closely. So re-assess our state here as well.
+			migrating, peerGroup = mset.isMigrating()
+
 			// Check for migrations here. We set the state on the stream assignment update below.
 			if isLeader && migrating {
 				if peerGroup == oldPeerGroup {

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -11765,8 +11765,6 @@ func TestJetStreamClusterMemoryConsumerCompactVsSnapshot(t *testing.T) {
 
 // This will test our ability to move streams and consumers between clusters.
 func TestJetStreamClusterMovingStreamsAndConsumers(t *testing.T) {
-	skip(t)
-
 	sc := createJetStreamTaggedSuperCluster(t)
 	defer sc.shutdown()
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -407,7 +407,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 		consumers: make(map[string]*consumer),
 		msgs:      s.newIPQueue(qpfx + "messages"), // of *inMsg
 		qch:       make(chan struct{}),
-		uch:       make(chan struct{}, 1),
+		uch:       make(chan struct{}, 4),
 	}
 
 	// For no-ack consumers when we are interest retention.


### PR DESCRIPTION
During elected stepdown and transfer allow the new leader to take over before we stepdown.
We could receive a leader change, so make sure to also check migration state.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
