### PR TITLE
[Fixed] limits enforcement issues

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -329,6 +329,10 @@ func setConsumerConfigDefaults(config *ConsumerConfig, lim *JSLimitOpts, accLim 
 		}
 		config.MaxAckPending = accPending
 	}
+	// if applicable set max request batch size
+	if config.DeliverSubject == _EMPTY_ && config.MaxRequestBatch == 0 && lim.MaxRequestBatch > 0 {
+		config.MaxRequestBatch = lim.MaxRequestBatch
+	}
 }
 
 func (mset *stream) addConsumer(config *ConsumerConfig) (*consumer, error) {
@@ -387,6 +391,9 @@ func checkConsumerCfg(config *ConsumerConfig, srvLim *JSLimitOpts, cfg *StreamCo
 		}
 		if config.MaxRequestExpires != 0 && config.MaxRequestExpires < time.Millisecond {
 			return NewJSConsumerMaxRequestExpiresToSmallError()
+		}
+		if srvLim.MaxRequestBatch > 0 && config.MaxRequestBatch > srvLim.MaxRequestBatch {
+			return NewJSConsumerMaxRequestBatchExceededError(srvLim.MaxRequestBatch)
 		}
 	}
 	if srvLim.MaxAckPending > 0 && config.MaxAckPending > srvLim.MaxAckPending {

--- a/server/errors.json
+++ b/server/errors.json
@@ -1228,5 +1228,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerMaxRequestBatchExceededF",
+    "code": 400,
+    "error_code": 10125,
+    "description": "consumer max request batch exceeds server limit of {limit}",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -2191,9 +2191,9 @@ func (a *Account) addStreamTemplate(tc *StreamTemplateConfig) (*streamTemplate, 
 	// FIXME(dlc) - Hacky
 	tcopy := tc.deepCopy()
 	tcopy.Config.Name = "_"
-	cfg, err := checkStreamCfg(tcopy.Config, &s.getOpts().JetStreamLimits)
-	if err != nil {
-		return nil, err
+	cfg, apiErr := s.checkStreamCfg(tcopy.Config, a)
+	if apiErr != nil {
+		return nil, apiErr
 	}
 	tcopy.Config = &cfg
 	t := &streamTemplate{

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -13935,6 +13935,7 @@ func TestJetStreamMirrorSourceLoop(t *testing.T) {
 			Replicas: replicas,
 			Sources:  []*nats.StreamSource{{Name: "DECOY"}, {Name: "2"}},
 		})
+		require_NoError(t, err)
 		_, err = js.AddStream(&nats.StreamConfig{
 			Name:     "DECOY",
 			Subjects: []string{"baz"},

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -13923,3 +13923,51 @@ func (c *cluster) stableTotalSubs() (total int) {
 	return nsubs
 
 }
+
+func TestJetStreamMirrorSourceLoop(t *testing.T) {
+	test := func(t *testing.T, s *Server, replicas int) {
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+		// Create a source/mirror loop
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     "1",
+			Subjects: []string{"foo", "bar"},
+			Replicas: replicas,
+			Sources:  []*nats.StreamSource{{Name: "DECOY"}, {Name: "2"}},
+		})
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:     "DECOY",
+			Subjects: []string{"baz"},
+			Replicas: replicas,
+			Sources:  []*nats.StreamSource{{Name: "NOTTHERE"}},
+		})
+		require_NoError(t, err)
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:     "2",
+			Replicas: replicas,
+			Sources:  []*nats.StreamSource{{Name: "3"}},
+		})
+		require_NoError(t, err)
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:     "3",
+			Replicas: replicas,
+			Sources:  []*nats.StreamSource{{Name: "1"}},
+		})
+		require_Error(t, err)
+		require_Equal(t, err.Error(), "detected cycle")
+	}
+
+	t.Run("Single", func(t *testing.T) {
+		s := RunBasicJetStreamServer()
+		if config := s.JetStreamConfig(); config != nil {
+			defer removeDir(t, config.StoreDir)
+		}
+		defer s.Shutdown()
+		test(t, s, 1)
+	})
+	t.Run("Clustered", func(t *testing.T) {
+		c := createJetStreamClusterExplicit(t, "JSC", 5)
+		defer c.shutdown()
+		test(t, c.randomServer(), 2)
+	})
+}

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -113,6 +113,9 @@ const (
 	// JSConsumerMaxPendingAckPolicyRequiredErr consumer requires ack policy for max ack pending
 	JSConsumerMaxPendingAckPolicyRequiredErr ErrorIdentifier = 10082
 
+	// JSConsumerMaxRequestBatchExceededF consumer max request batch exceeds server limit of {limit}
+	JSConsumerMaxRequestBatchExceededF ErrorIdentifier = 10125
+
 	// JSConsumerMaxRequestBatchNegativeErr consumer max request batch needs to be > 0
 	JSConsumerMaxRequestBatchNegativeErr ErrorIdentifier = 10114
 
@@ -413,6 +416,7 @@ var (
 		JSConsumerMaxDeliverBackoffErr:             {Code: 400, ErrCode: 10116, Description: "max deliver is required to be > length of backoff values"},
 		JSConsumerMaxPendingAckExcessErrF:          {Code: 400, ErrCode: 10121, Description: "consumer max ack pending exceeds system limit of {limit}"},
 		JSConsumerMaxPendingAckPolicyRequiredErr:   {Code: 400, ErrCode: 10082, Description: "consumer requires ack policy for max ack pending"},
+		JSConsumerMaxRequestBatchExceededF:         {Code: 400, ErrCode: 10125, Description: "consumer max request batch exceeds server limit of {limit}"},
 		JSConsumerMaxRequestBatchNegativeErr:       {Code: 400, ErrCode: 10114, Description: "consumer max request batch needs to be > 0"},
 		JSConsumerMaxRequestExpiresToSmall:         {Code: 400, ErrCode: 10115, Description: "consumer max request expires needs to be >= 1ms"},
 		JSConsumerMaxWaitingNegativeErr:            {Code: 400, ErrCode: 10087, Description: "consumer max waiting needs to be positive"},
@@ -913,6 +917,22 @@ func NewJSConsumerMaxPendingAckPolicyRequiredError(opts ...ErrorOption) *ApiErro
 	}
 
 	return ApiErrors[JSConsumerMaxPendingAckPolicyRequiredErr]
+}
+
+// NewJSConsumerMaxRequestBatchExceededError creates a new JSConsumerMaxRequestBatchExceededF error: "consumer max request batch exceeds server limit of {limit}"
+func NewJSConsumerMaxRequestBatchExceededError(limit interface{}, opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	e := ApiErrors[JSConsumerMaxRequestBatchExceededF]
+	args := e.toReplacerArgs([]interface{}{"{limit}", limit})
+	return &ApiError{
+		Code:        e.Code,
+		ErrCode:     e.ErrCode,
+		Description: strings.NewReplacer(args...).Replace(e.Description),
+	}
 }
 
 // NewJSConsumerMaxRequestBatchNegativeError creates a new JSConsumerMaxRequestBatchNegativeErr error: "consumer max request batch needs to be > 0"

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -4201,6 +4201,9 @@ func TestJetStreamSnapshotsAPI(t *testing.T) {
 	opts.JetStream = true
 	opts.JetStreamDomain = "domain"
 	opts.StoreDir = tdir
+	maxStore := int64(1024 * 1024 * 1024)
+	opts.maxStoreSet = true
+	opts.JetStreamMaxStore = maxStore
 	rurl, _ := url.Parse(fmt.Sprintf("nats-leaf://%s:%d", lopts.LeafNode.Host, lopts.LeafNode.Port))
 	opts.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{rurl}}}
 
@@ -12070,7 +12073,7 @@ func TestJetStreamMirrorUpdatePreventsSubjects(t *testing.T) {
 	require_NoError(t, err)
 
 	_, err = js.UpdateStream(&nats.StreamConfig{Name: "MIRROR", Mirror: &nats.StreamSource{Name: "ORIGINAL"}, Subjects: []string{"x"}})
-	if err == nil || err.Error() != "stream mirrors may not have subjects" {
+	if err == nil || err.Error() != "stream mirrors can not contain subjects" {
 		t.Fatalf("Expected to not be able to put subjects on a stream, got: %+v", err)
 	}
 }
@@ -13511,9 +13514,9 @@ func TestJetStreamLongStreamNamesAndPubAck(t *testing.T) {
 	nc, js := jsClientConnect(t, s)
 	defer nc.Close()
 
-	data := make([]byte, 256)
+	data := make([]byte, 255)
 	rand.Read(data)
-	stream := base64.StdEncoding.EncodeToString(data)[:256]
+	stream := base64.StdEncoding.EncodeToString(data)[:255]
 
 	cfg := &nats.StreamConfig{
 		Name:     stream,
@@ -16573,6 +16576,83 @@ func TestJetStreamCrossAccounts(t *testing.T) {
 	}
 }
 
+func TestJetStreamInvalidRestoreRequests(t *testing.T) {
+	test := func(t *testing.T, s *Server, replica int) {
+		nc := natsConnect(t, s.ClientURL())
+		// test invalid stream config in restore request
+		require_fail := func(cfg StreamConfig, errDesc string) {
+			t.Helper()
+			rreq := &JSApiStreamRestoreRequest{
+				Config: cfg,
+			}
+			req, err := json.Marshal(rreq)
+			require_NoError(t, err)
+			rmsg, err := nc.Request(fmt.Sprintf(JSApiStreamRestoreT, "fail"), req, time.Second)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			var rresp JSApiStreamRestoreResponse
+			json.Unmarshal(rmsg.Data, &rresp)
+			require_True(t, rresp.Error != nil)
+			require_Equal(t, rresp.Error.Description, errDesc)
+		}
+		require_fail(StreamConfig{Name: "fail", MaxBytes: 1024, Storage: FileStorage, Replicas: 6},
+			"maximum replicas is 5")
+		require_fail(StreamConfig{Name: "fail", MaxBytes: 2 * 1012 * 1024, Storage: FileStorage, Replicas: replica},
+			"insufficient storage resources available")
+		js, err := nc.JetStream()
+		require_NoError(t, err)
+		_, err = js.AddStream(&nats.StreamConfig{Name: "stream", MaxBytes: 1024, Storage: nats.FileStorage, Replicas: 1})
+		require_NoError(t, err)
+		require_fail(StreamConfig{Name: "fail", MaxBytes: 1024, Storage: FileStorage},
+			"maximum number of streams reached")
+	}
+
+	commonAccSection := `
+		no_auth_user: u
+		accounts {
+			ONE {
+				users = [ { user: "u", pass: "s3cr3t!" } ]
+				jetstream: {
+					max_store: 1Mb
+					max_streams: 1
+				}
+			}
+			$SYS { users = [ { user: "admin", pass: "s3cr3t!" } ] }
+		}`
+
+	t.Run("clustered", func(t *testing.T) {
+		c := createJetStreamClusterWithTemplate(t, `
+			listen: 127.0.0.1:-1
+			server_name: %s
+			jetstream: {
+				max_mem_store: 2MB,
+				max_file_store: 8MB,
+				store_dir: '%s',
+			}
+			cluster {
+				name: %s
+				listen: 127.0.0.1:%d
+				routes = [%s]
+			}`+commonAccSection, "clust", 3)
+		defer c.shutdown()
+		s := c.randomServer()
+		test(t, s, 3)
+	})
+	t.Run("single", func(t *testing.T) {
+		storeDir := createDir(t, JetStreamStoreDir)
+		defer removeDir(t, storeDir)
+		conf := createConfFile(t, []byte(fmt.Sprintf(`
+			listen: 127.0.0.1:-1
+			jetstream: {max_mem_store: 2MB, max_file_store: 8MB, store_dir: '%s'}
+			%s`, storeDir, commonAccSection)))
+		defer removeFile(t, conf)
+		s, _ := RunServerWithConfig(conf)
+		defer s.Shutdown()
+		test(t, s, 1)
+	})
+}
+
 func TestJetStreamLimits(t *testing.T) {
 	test := func(t *testing.T, s *Server) {
 		nc := natsConnect(t, s.ClientURL())
@@ -16585,9 +16665,9 @@ func TestJetStreamLimits(t *testing.T) {
 		require_NoError(t, err)
 		require_True(t, si.Config.Duplicates == time.Minute)
 
-		si, err = js.AddStream(&nats.StreamConfig{Name: "bar", Duplicates: 500 * time.Millisecond})
+		si, err = js.AddStream(&nats.StreamConfig{Name: "bar", Duplicates: 1500 * time.Millisecond})
 		require_NoError(t, err)
-		require_True(t, si.Config.Duplicates == 500*time.Millisecond)
+		require_True(t, si.Config.Duplicates == 1500*time.Millisecond)
 
 		_, err = js.UpdateStream(&nats.StreamConfig{Name: "bar", Duplicates: 2 * time.Minute})
 		require_Error(t, err)
@@ -16600,10 +16680,16 @@ func TestJetStreamLimits(t *testing.T) {
 		ci, err := js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "dur1", AckPolicy: nats.AckExplicitPolicy})
 		require_NoError(t, err)
 		require_True(t, ci.Config.MaxAckPending == 1000)
+		require_True(t, ci.Config.MaxRequestBatch == 250)
+
+		ci, err = js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "dur2", AckPolicy: nats.AckExplicitPolicy, MaxRequestBatch: 500})
+		require_Error(t, err)
+		require_Equal(t, err.Error(), "consumer max request batch exceeds server limit of 250")
 
 		ci, err = js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "dur2", AckPolicy: nats.AckExplicitPolicy, MaxAckPending: 500})
 		require_NoError(t, err)
 		require_True(t, ci.Config.MaxAckPending == 500)
+		require_True(t, ci.Config.MaxRequestBatch == 250)
 
 		_, err = js.UpdateConsumer("foo", &nats.ConsumerConfig{Durable: "dur2", AckPolicy: nats.AckExplicitPolicy, MaxAckPending: 2000})
 		require_Error(t, err)
@@ -16622,7 +16708,7 @@ func TestJetStreamLimits(t *testing.T) {
 				max_mem_store: 2MB,
 				max_file_store: 8MB,
 				store_dir: '%s',
-				limits: {duplicate_window: "1m"}
+				limits: {duplicate_window: "1m", max_request_batch: 250}
 			}
 			cluster {
 				name: %s
@@ -16659,7 +16745,7 @@ func TestJetStreamLimits(t *testing.T) {
 				max_mem_store: 2MB,
 				max_file_store: 8MB,
 				store_dir: '%s',
-				limits: {duplicate_window: "1m"}
+				limits: {duplicate_window: "1m", max_request_batch: 250}
 			}
 			no_auth_user: u
 			accounts {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -16682,7 +16682,7 @@ func TestJetStreamLimits(t *testing.T) {
 		require_True(t, ci.Config.MaxAckPending == 1000)
 		require_True(t, ci.Config.MaxRequestBatch == 250)
 
-		ci, err = js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "dur2", AckPolicy: nats.AckExplicitPolicy, MaxRequestBatch: 500})
+		_, err = js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "dur2", AckPolicy: nats.AckExplicitPolicy, MaxRequestBatch: 500})
 		require_Error(t, err)
 		require_Equal(t, err.Error(), "consumer max request batch exceeds server limit of 250")
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -185,9 +185,10 @@ type RemoteLeafOpts struct {
 }
 
 type JSLimitOpts struct {
-	MaxAckPending int
-	MaxHAAssets   int
-	Duplicates    time.Duration
+	MaxRequestBatch int
+	MaxAckPending   int
+	MaxHAAssets     int
+	Duplicates      time.Duration
 }
 
 // Options block for nats-server.
@@ -1818,6 +1819,8 @@ func parseJetStreamLimits(v interface{}, opts *Options, errors *[]error, warning
 			lim.MaxAckPending = int(mv.(int64))
 		case "max_ha_assets":
 			lim.MaxHAAssets = int(mv.(int64))
+		case "max_request_batch":
+			lim.MaxRequestBatch = int(mv.(int64))
 		case "duplicate_window":
 			var err error
 			lim.Duplicates, err = time.ParseDuration(mv.(string))


### PR DESCRIPTION
stream create had checks that stream restore did not have.
Moved code into commonly used function checkStreamCfg.
Also introduced (cluster/non clustered) StreamLimitsCheck functions to
perform checks specific to clustered /non clustered data structures.

Checking for valid stream config and limits/reservations before
receiving all the data. Now fails the request right away.

Added a jetstream limit "max_request_batch" to limit fetch batch size

Shortened max name length from 256 to 255, more common file name limit

Added check for loop in cyclic source stream configurations

features related to limits

Signed-off-by: Matthias Hanel <mh@synadia.com>
