### PR TITLE
If we moved a stream back to a cluster we were once at, the stream would be empty.

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -12135,6 +12135,75 @@ func TestJetStreamClusterMovingStreamsWithMirror(t *testing.T) {
 
 }
 
+func TestJetStreamClusterMovingStreamAndMoveBack(t *testing.T) {
+	sc := createJetStreamTaggedSuperCluster(t)
+	defer sc.shutdown()
+
+	nc, js := jsClientConnect(t, sc.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Replicas:  3,
+		Placement: &nats.Placement{Tags: []string{"cloud:aws"}},
+	})
+	require_NoError(t, err)
+
+	for i := 0; i < 1000; i++ {
+		_, err := js.PublishAsync("TEST", []byte("HELLO WORLD"))
+		require_NoError(t, err)
+	}
+	select {
+	case <-js.PublishAsyncComplete():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Did not receive completion signal")
+	}
+
+	_, err = js.UpdateStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Replicas:  3,
+		Placement: &nats.Placement{Tags: []string{"cloud:gcp"}},
+	})
+	require_NoError(t, err)
+
+	checkMove := func(cluster string) {
+		t.Helper()
+		checkFor(t, 30*time.Second, 100*time.Millisecond, func() error {
+			si, err := js.StreamInfo("TEST")
+			if err != nil {
+				return err
+			}
+			if si.Cluster.Name != cluster {
+				return fmt.Errorf("Wrong cluster: %q", si.Cluster.Name)
+			}
+			if si.Cluster.Leader == _EMPTY_ {
+				return fmt.Errorf("No leader yet")
+			} else if !strings.HasPrefix(si.Cluster.Leader, cluster) {
+				return fmt.Errorf("Wrong leader: %q", si.Cluster.Leader)
+			}
+			// Now we want to see that we shrink back to original.
+			if len(si.Cluster.Replicas) != 2 {
+				return fmt.Errorf("Expected %d replicas, got %d", 2, len(si.Cluster.Replicas))
+			}
+			if si.State.Msgs != 1000 {
+				return fmt.Errorf("Only see %d msgs", si.State.Msgs)
+			}
+			return nil
+		})
+	}
+
+	checkMove("C2")
+
+	_, err = js.UpdateStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Replicas:  3,
+		Placement: &nats.Placement{Tags: []string{"cloud:aws"}},
+	})
+	require_NoError(t, err)
+
+	checkMove("C1")
+}
+
 func TestJetStreamClusterMemoryConsumerInterestRetention(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()


### PR DESCRIPTION
The old raft node assignment would prevent proper catchup.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
