### PR TITLE
Bump ordered consumer flow control window back up.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -295,7 +295,7 @@ const (
 	JsDeleteWaitTimeDefault = 5 * time.Second
 	// JsFlowControlMaxPending specifies default pending bytes during flow control that can be
 	// outstanding.
-	JsFlowControlMaxPending = 16 * 1024 * 1024
+	JsFlowControlMaxPending = 32 * 1024 * 1024
 	// JsDefaultMaxAckPending is set for consumers with explicit ack that do not set the max ack pending.
 	JsDefaultMaxAckPending = 1000
 )


### PR DESCRIPTION
Have seen some small dips in some global systems that @ripienaar has been running and I have been testing. Originally bumped it down due to some instability but that was not associated with this in the end.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
