### PR TITLE
Keep jetstream on while using empty config file and reloading

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -4305,6 +4305,9 @@ func MergeOptions(fileOpts, flagOpts *Options) *Options {
 	if flagOpts.RoutesStr != "" {
 		mergeRoutes(&opts, flagOpts)
 	}
+	if flagOpts.JetStream {
+		fileOpts.JetStream = flagOpts.JetStream
+	}
 	return &opts
 }
 


### PR DESCRIPTION
 - [X] #3003
 - [] Documentation added (if applicable)
 - [] Tests added
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

### Changes proposed in this pull request:
- merge the `JetStream` in function `MergeOptions`.

/cc @nats-io/core
