### PR TITLE
[changed] if max_request_batch and  max_batch is 0 respond with an error

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -390,7 +390,7 @@ func checkConsumerCfg(config *ConsumerConfig, srvLim *JSLimitOpts, cfg *StreamCo
 		}
 		if srvLim.MaxRequestBatch > 0 {
 			if config.MaxRequestBatch == 0 {
-				return NewJSConsumerMaxRequestBatchRequiredError()
+				return NewJSConsumerMaxRequestBatchRequiredError(srvLim.MaxRequestBatch)
 			} else if config.MaxRequestBatch > srvLim.MaxRequestBatch {
 				return NewJSConsumerMaxRequestBatchExceededError(srvLim.MaxRequestBatch)
 			}

--- a/server/errors.json
+++ b/server/errors.json
@@ -1240,10 +1240,10 @@
     "deprecates": ""
   },
   {
-    "constant": "JSConsumerMaxRequestBatchRequired",
+    "constant": "JSConsumerMaxRequestBatchRequiredF",
     "code": 400,
     "error_code": 10126,
-    "description": "consumer max request batch needs to be specified",
+    "description": "consumer max request batch needs to be specified and cannot be more than {limit}",
     "comment": "",
     "help": "",
     "url": "",

--- a/server/errors.json
+++ b/server/errors.json
@@ -1238,5 +1238,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerMaxRequestBatchRequired",
+    "code": 400,
+    "error_code": 10126,
+    "description": "consumer max request batch needs to be specified",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -119,8 +119,8 @@ const (
 	// JSConsumerMaxRequestBatchNegativeErr consumer max request batch needs to be > 0
 	JSConsumerMaxRequestBatchNegativeErr ErrorIdentifier = 10114
 
-	// JSConsumerMaxRequestBatchRequired consumer max request batch needs to be specified
-	JSConsumerMaxRequestBatchRequired ErrorIdentifier = 10126
+	// JSConsumerMaxRequestBatchRequiredF consumer max request batch needs to be specified and cannot be more than {limit}
+	JSConsumerMaxRequestBatchRequiredF ErrorIdentifier = 10126
 
 	// JSConsumerMaxRequestExpiresToSmall consumer max request expires needs to be >= 1ms
 	JSConsumerMaxRequestExpiresToSmall ErrorIdentifier = 10115
@@ -421,7 +421,7 @@ var (
 		JSConsumerMaxPendingAckPolicyRequiredErr:   {Code: 400, ErrCode: 10082, Description: "consumer requires ack policy for max ack pending"},
 		JSConsumerMaxRequestBatchExceededF:         {Code: 400, ErrCode: 10125, Description: "consumer max request batch exceeds server limit of {limit}"},
 		JSConsumerMaxRequestBatchNegativeErr:       {Code: 400, ErrCode: 10114, Description: "consumer max request batch needs to be > 0"},
-		JSConsumerMaxRequestBatchRequired:          {Code: 400, ErrCode: 10126, Description: "consumer max request batch needs to be specified"},
+		JSConsumerMaxRequestBatchRequiredF:         {Code: 400, ErrCode: 10126, Description: "consumer max request batch needs to be specified and cannot be more than {limit}"},
 		JSConsumerMaxRequestExpiresToSmall:         {Code: 400, ErrCode: 10115, Description: "consumer max request expires needs to be >= 1ms"},
 		JSConsumerMaxWaitingNegativeErr:            {Code: 400, ErrCode: 10087, Description: "consumer max waiting needs to be positive"},
 		JSConsumerNameExistErr:                     {Code: 400, ErrCode: 10013, Description: "consumer name already in use"},
@@ -949,14 +949,20 @@ func NewJSConsumerMaxRequestBatchNegativeError(opts ...ErrorOption) *ApiError {
 	return ApiErrors[JSConsumerMaxRequestBatchNegativeErr]
 }
 
-// NewJSConsumerMaxRequestBatchRequiredError creates a new JSConsumerMaxRequestBatchRequired error: "consumer max request batch needs to be specified"
-func NewJSConsumerMaxRequestBatchRequiredError(opts ...ErrorOption) *ApiError {
+// NewJSConsumerMaxRequestBatchRequiredError creates a new JSConsumerMaxRequestBatchRequiredF error: "consumer max request batch needs to be specified and cannot be more than {limit}"
+func NewJSConsumerMaxRequestBatchRequiredError(limit interface{}, opts ...ErrorOption) *ApiError {
 	eopts := parseOpts(opts)
 	if ae, ok := eopts.err.(*ApiError); ok {
 		return ae
 	}
 
-	return ApiErrors[JSConsumerMaxRequestBatchRequired]
+	e := ApiErrors[JSConsumerMaxRequestBatchRequiredF]
+	args := e.toReplacerArgs([]interface{}{"{limit}", limit})
+	return &ApiError{
+		Code:        e.Code,
+		ErrCode:     e.ErrCode,
+		Description: strings.NewReplacer(args...).Replace(e.Description),
+	}
 }
 
 // NewJSConsumerMaxRequestExpiresToSmallError creates a new JSConsumerMaxRequestExpiresToSmall error: "consumer max request expires needs to be >= 1ms"

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -119,6 +119,9 @@ const (
 	// JSConsumerMaxRequestBatchNegativeErr consumer max request batch needs to be > 0
 	JSConsumerMaxRequestBatchNegativeErr ErrorIdentifier = 10114
 
+	// JSConsumerMaxRequestBatchRequired consumer max request batch needs to be specified
+	JSConsumerMaxRequestBatchRequired ErrorIdentifier = 10126
+
 	// JSConsumerMaxRequestExpiresToSmall consumer max request expires needs to be >= 1ms
 	JSConsumerMaxRequestExpiresToSmall ErrorIdentifier = 10115
 
@@ -418,6 +421,7 @@ var (
 		JSConsumerMaxPendingAckPolicyRequiredErr:   {Code: 400, ErrCode: 10082, Description: "consumer requires ack policy for max ack pending"},
 		JSConsumerMaxRequestBatchExceededF:         {Code: 400, ErrCode: 10125, Description: "consumer max request batch exceeds server limit of {limit}"},
 		JSConsumerMaxRequestBatchNegativeErr:       {Code: 400, ErrCode: 10114, Description: "consumer max request batch needs to be > 0"},
+		JSConsumerMaxRequestBatchRequired:          {Code: 400, ErrCode: 10126, Description: "consumer max request batch needs to be specified"},
 		JSConsumerMaxRequestExpiresToSmall:         {Code: 400, ErrCode: 10115, Description: "consumer max request expires needs to be >= 1ms"},
 		JSConsumerMaxWaitingNegativeErr:            {Code: 400, ErrCode: 10087, Description: "consumer max waiting needs to be positive"},
 		JSConsumerNameExistErr:                     {Code: 400, ErrCode: 10013, Description: "consumer name already in use"},
@@ -943,6 +947,16 @@ func NewJSConsumerMaxRequestBatchNegativeError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSConsumerMaxRequestBatchNegativeErr]
+}
+
+// NewJSConsumerMaxRequestBatchRequiredError creates a new JSConsumerMaxRequestBatchRequired error: "consumer max request batch needs to be specified"
+func NewJSConsumerMaxRequestBatchRequiredError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSConsumerMaxRequestBatchRequired]
 }
 
 // NewJSConsumerMaxRequestExpiresToSmallError creates a new JSConsumerMaxRequestExpiresToSmall error: "consumer max request expires needs to be >= 1ms"

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -16679,7 +16679,7 @@ func TestJetStreamLimits(t *testing.T) {
 
 		ci, err := js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "dur1", AckPolicy: nats.AckExplicitPolicy})
 		require_Error(t, err)
-		require_Equal(t, err.Error(), "consumer max request batch needs to be specified")
+		require_Equal(t, err.Error(), "consumer max request batch needs to be specified and cannot be more than 250")
 
 		_, err = js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "dur2", AckPolicy: nats.AckExplicitPolicy, MaxRequestBatch: 500})
 		require_Error(t, err)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -16678,24 +16678,23 @@ func TestJetStreamLimits(t *testing.T) {
 		require_Equal(t, err.Error(), "duplicates window can not be larger then server limit of 1m0s")
 
 		ci, err := js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "dur1", AckPolicy: nats.AckExplicitPolicy})
-		require_NoError(t, err)
-		require_True(t, ci.Config.MaxAckPending == 1000)
-		require_True(t, ci.Config.MaxRequestBatch == 250)
+		require_Error(t, err)
+		require_Equal(t, err.Error(), "consumer max request batch needs to be specified")
 
 		_, err = js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "dur2", AckPolicy: nats.AckExplicitPolicy, MaxRequestBatch: 500})
 		require_Error(t, err)
 		require_Equal(t, err.Error(), "consumer max request batch exceeds server limit of 250")
 
-		ci, err = js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "dur2", AckPolicy: nats.AckExplicitPolicy, MaxAckPending: 500})
+		ci, err = js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "dur2", AckPolicy: nats.AckExplicitPolicy, MaxAckPending: 500, MaxRequestBatch: 250})
 		require_NoError(t, err)
 		require_True(t, ci.Config.MaxAckPending == 500)
 		require_True(t, ci.Config.MaxRequestBatch == 250)
 
-		_, err = js.UpdateConsumer("foo", &nats.ConsumerConfig{Durable: "dur2", AckPolicy: nats.AckExplicitPolicy, MaxAckPending: 2000})
+		_, err = js.UpdateConsumer("foo", &nats.ConsumerConfig{Durable: "dur2", AckPolicy: nats.AckExplicitPolicy, MaxAckPending: 2000, MaxRequestBatch: 250})
 		require_Error(t, err)
 		require_Equal(t, err.Error(), "consumer max ack pending exceeds system limit of 1000")
 
-		_, err = js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "dur3", AckPolicy: nats.AckExplicitPolicy, MaxAckPending: 2000})
+		_, err = js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "dur3", AckPolicy: nats.AckExplicitPolicy, MaxAckPending: 2000, MaxRequestBatch: 250})
 		require_Error(t, err)
 		require_Equal(t, err.Error(), "consumer max ack pending exceeds system limit of 1000")
 	}


### PR DESCRIPTION
instead if setting a default value. This is to fail early during
consumer creation, not during fetch with a too large value.

Signed-off-by: Matthias Hanel <mh@synadia.com>
