### PR TITLE
introducing max_age/dupe_window minimum value of 100ms.

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -3332,7 +3332,7 @@ func TestJetStreamPublishDeDupe(t *testing.T) {
 	expect(4)
 
 	cfg = mset.config()
-	cfg.Duplicates = 25 * time.Millisecond
+	cfg.Duplicates = 100 * time.Millisecond
 	if err := mset.update(&cfg); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -8782,12 +8782,12 @@ func TestJetStreamUpdateStream(t *testing.T) {
 
 			// Now do age.
 			cfg = *c.mconfig
-			cfg.MaxAge = time.Millisecond
+			cfg.MaxAge = 100 * time.Millisecond
 			if err := mset.update(&cfg); err != nil {
 				t.Fatalf("Unexpected error %v", err)
 			}
 			// Just wait a bit for expiration.
-			time.Sleep(25 * time.Millisecond)
+			time.Sleep(200 * time.Millisecond)
 			if mset.config().MaxAge != cfg.MaxAge {
 				t.Fatalf("Expected the change to take effect, %d vs %d", mset.config().MaxAge, cfg.MaxAge)
 			}

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -2501,7 +2501,7 @@ func TestNoRaceJetStreamStalledMirrorsAfterExpire(t *testing.T) {
 		Name:     "TEST",
 		Subjects: []string{"foo.*"},
 		Replicas: 1,
-		MaxAge:   250 * time.Microsecond,
+		MaxAge:   100 * time.Millisecond,
 	}
 
 	if _, err := js.AddStream(cfg); err != nil {

--- a/server/stream.go
+++ b/server/stream.go
@@ -900,6 +900,9 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 			cfg.Duplicates = maxWindow
 		}
 	}
+	if cfg.MaxAge > 0 && cfg.MaxAge < 100*time.Millisecond {
+		return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("max age needs to be >= 100ms"))
+	}
 	if cfg.Duplicates < 0 {
 		return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("duplicates window can not be negative"))
 	}
@@ -909,6 +912,9 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 	}
 	if lim.Duplicates > 0 && cfg.Duplicates > lim.Duplicates {
 		return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("duplicates window can not be larger then server limit of %v", lim.Duplicates.String()))
+	}
+	if cfg.Duplicates > 0 && cfg.Duplicates < 100*time.Millisecond {
+		return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("duplicates window needs to be >= 100ms"))
 	}
 
 	if cfg.DenyPurge && cfg.AllowRollup {


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

Added minimum values of 100ms (used elsewhere as well)