### PR TITLE
[FIXED] JetStream: stream sources issue in mixed mode clusters

### DIFF
--- a/server/ipqueue.go
+++ b/server/ipqueue.go
@@ -191,6 +191,9 @@ func (q *ipQueue) len() int {
 // notified that there is something in the queue (reading from queue's `ch`)
 // may then get nothing if `drain()` is invoked before the `pop()` or `popOne()`.
 func (q *ipQueue) drain() {
+	if q == nil {
+		return
+	}
 	q.Lock()
 	if q.elts != nil {
 		q.resetAndReturnToPool(&q.elts)

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -5484,7 +5484,6 @@ func TestLeafNodeStreamAndShadowSubs(t *testing.T) {
 		}
 		defer ncl.Close()
 
-		fmt.Printf("@@IK: ------ sub to foo.*.baz -----\n")
 		// This will send an LS+ to the "hub" server.
 		sub, err := ncl.SubscribeSync("foo.*.baz")
 		if err != nil {

--- a/server/stream.go
+++ b/server/stream.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -231,6 +232,8 @@ type sourceInfo struct {
 	lreq  time.Time
 	qch   chan struct{}
 	grr   bool
+	sip   bool // setup in progress
+	wg    sync.WaitGroup
 }
 
 // Headers for published messages.
@@ -1281,13 +1284,12 @@ func (mset *stream) update(config *StreamConfig) error {
 						mset.sources = make(map[string]*sourceInfo)
 					}
 					mset.cfg.Sources = append(mset.cfg.Sources, s)
-					qname := fmt.Sprintf("[ACC:%s] stream source '%s' from '%s' msgs", mset.acc.Name, mset.cfg.Name, s.Name)
-					si := &sourceInfo{name: s.Name, iname: s.iname, msgs: mset.srv.newIPQueue(qname) /* of *inMsg */}
+					si := &sourceInfo{name: s.Name, iname: s.iname}
 					mset.sources[s.iname] = si
 					mset.setStartingSequenceForSource(s.iname)
 					mset.setSourceConsumer(s.iname, si.sseq+1)
 				}
-				delete(current, s.Name)
+				delete(current, s.iname)
 			}
 			// What is left in current needs to be deleted.
 			for iname := range current {
@@ -2047,43 +2049,77 @@ func (mset *stream) retrySourceConsumer(sname string) {
 	mset.retrySourceConsumerAtSeq(sname, si.sseq+1)
 }
 
+// Same than setSourceConsumer but simply issue a debug statement indicating
+// that there is a retry.
+//
 // Lock should be held.
-func (mset *stream) retrySourceConsumerAtSeq(sname string, seq uint64) {
-	if mset.client == nil {
-		return
-	}
+func (mset *stream) retrySourceConsumerAtSeq(iname string, seq uint64) {
 	s := mset.srv
 
 	s.Debugf("Retrying source consumer for '%s > %s'", mset.acc.Name, mset.cfg.Name)
 
-	// No longer configured.
-	if si := mset.sources[sname]; si == nil {
-		return
-	}
-	mset.setSourceConsumer(sname, seq)
+	// setSourceConsumer will check that the source is still configured.
+	mset.setSourceConsumer(iname, seq)
 }
 
 // Lock should be held.
-func (mset *stream) cancelSourceConsumer(sname string) {
-	if si := mset.sources[sname]; si != nil {
-		if si.sub != nil {
-			mset.unsubscribe(si.sub)
-			si.sub = nil
-		}
+func (mset *stream) cancelSourceConsumer(iname string) {
+	if si := mset.sources[iname]; si != nil {
+		mset.cancelSourceConsumerWithSourceInfo(si)
 		si.sseq, si.dseq = 0, 0
-		si.msgs.drain()
-		mset.removeInternalConsumer(si)
-		// If the go routine is still running close the quit chan.
-		if si.qch != nil {
-			close(si.qch)
-			si.qch = nil
-			// Need to set this here, not rely on processSourceMsgs()
-			// to do it, because if we call setSourceConsumer() before the
-			// go routine has returned (but was signaled to stop), then
-			// we would not restart it.
-			si.grr = false
-		}
 	}
+}
+
+// The `si` has been verified to be not nil and still present in mset.sources.
+// This is called either when it is a "final" cancel (when invoked from
+// cancelSourceConsumer), for instance when leadership is lost, or as a reset
+// when retrying/setting a source consumer.
+//
+// Lock should be held
+func (mset *stream) cancelSourceConsumerWithSourceInfo(si *sourceInfo) {
+	if si.sub != nil {
+		mset.unsubscribe(si.sub)
+		si.sub = nil
+	}
+	mset.removeInternalConsumer(si)
+	if si.qch != nil {
+		close(si.qch)
+		si.qch = nil
+	}
+	si.msgs.drain()
+	si.msgs.unregister()
+}
+
+const sourceConsumerRetryThreshold = 2 * time.Second
+
+// This will schedule a call to setSourceConsumer, taking into account the last
+// time it was retried and determine the soonest setSourceConsumer can be called
+// without tripping the sourceConsumerRetryThreshold.
+//
+// Lock held on entry
+func (mset *stream) scheduleSetSourceConsumerRetryAsap(si *sourceInfo, seq uint64) {
+	// We are trying to figure out how soon we can retry. setSourceConsumer will reject
+	// a retry if last was done less than "sourceConsumerRetryThreshold" ago.
+	next := sourceConsumerRetryThreshold - time.Since(si.lreq)
+	if next < 0 {
+		// It means that we have passed the threshold and so we are ready to go.
+		next = 0
+	}
+	// To make *sure* that the next request will not fail, add a bit of buffer
+	// and some randomness.
+	next += time.Duration(rand.Intn(50)) + 10*time.Millisecond
+	mset.scheduleSetSourceConsumerRetry(si.iname, seq, next)
+}
+
+// Simply schedules setSourceConsumer at the given delay.
+//
+// Does not require lock
+func (mset *stream) scheduleSetSourceConsumerRetry(iname string, seq uint64, delay time.Duration) {
+	time.AfterFunc(delay, func() {
+		mset.mu.Lock()
+		mset.setSourceConsumer(iname, seq)
+		mset.mu.Unlock()
+	})
 }
 
 // Lock should be held.
@@ -2092,20 +2128,21 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64) {
 	if si == nil {
 		return
 	}
-	if si.sub != nil {
-		mset.unsubscribe(si.sub)
-		si.sub = nil
-	}
-	// Need to delete the old one.
-	mset.removeInternalConsumer(si)
+	// Cancel previous instance if applicable
+	mset.cancelSourceConsumerWithSourceInfo(si)
 
-	// Do not set si.sseq to seq here. si.sseq will be set in processInboundSourceMsg
-	si.dseq = 0
-	si.last = time.Now()
 	ssi := mset.streamSource(iname)
 	if ssi == nil {
 		return
 	}
+
+	// We want to throttle here in terms of how fast we request new consumers,
+	// or if the previous is still in progress.
+	if last := time.Since(si.lreq); last < sourceConsumerRetryThreshold || si.sip {
+		mset.scheduleSetSourceConsumerRetryAsap(si, seq)
+		return
+	}
+	si.lreq = time.Now()
 
 	// Determine subjects etc.
 	var deliverSubject string
@@ -2116,18 +2153,6 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64) {
 	} else {
 		deliverSubject = syncSubject("$JS.S")
 	}
-
-	if !si.grr {
-		si.grr = true
-		si.qch = make(chan struct{})
-		mset.srv.startGoRoutine(func() { mset.processSourceMsgs(si) })
-	}
-
-	// We want to throttle here in terms of how fast we request new consumers.
-	if time.Since(si.lreq) < 2*time.Second {
-		return
-	}
-	si.lreq = time.Now()
 
 	req := &CreateConsumerRequest{
 		Stream: si.name,
@@ -2161,7 +2186,7 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64) {
 
 	respCh := make(chan *JSApiConsumerCreateResponse, 1)
 	reply := infoReplySubject()
-	crSub, _ := mset.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+	crSub, err := mset.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
 		mset.unsubscribeUnlocked(sub)
 		_, msg := c.msgParts(rmsg)
 		var ccr JSApiConsumerCreateResponse
@@ -2171,6 +2196,11 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64) {
 		}
 		respCh <- &ccr
 	})
+	if err != nil {
+		si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
+		mset.scheduleSetSourceConsumerRetryAsap(si, seq)
+		return
+	}
 
 	b, _ := json.Marshal(req)
 	subject := fmt.Sprintf(JSApiConsumerCreateT, si.name)
@@ -2179,74 +2209,103 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64) {
 		subject = strings.ReplaceAll(subject, "..", ".")
 	}
 
+	// We need to create the subscription that will receive the messages prior
+	// to sending the consumer create request, because in some complex topologies
+	// with gateways and optimistic mode, it is possible that the consumer starts
+	// delivering messages as soon as the consumer request is received.
+	qname := fmt.Sprintf("[ACC:%s] stream source '%s' from '%s' msgs", mset.acc.Name, mset.cfg.Name, si.name)
+	// Create a new queue each time
+	si.msgs = mset.srv.newIPQueue(qname) // of *inMsg
+	msgs := si.msgs
+	sub, err := mset.subscribeInternal(deliverSubject, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+		hdr, msg := c.msgParts(copyBytes(rmsg)) // Need to copy.
+		mset.queueInbound(msgs, subject, reply, hdr, msg)
+	})
+	if err != nil {
+		si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
+		mset.unsubscribeUnlocked(crSub)
+		mset.scheduleSetSourceConsumerRetryAsap(si, seq)
+		return
+	}
+	si.err = nil
+	si.sub = sub
+	si.sip = true
+
+	// Send the consumer create request
 	mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, nil, b, nil, 0))
 
 	go func() {
+
+		var retry bool
+		defer func() {
+			mset.mu.Lock()
+			// Check that this is still valid and if so, clear the "setup in progress" flag.
+			if si := mset.sources[iname]; si != nil {
+				si.sip = false
+				// If we need to retry, schedule now
+				if retry {
+					mset.scheduleSetSourceConsumerRetryAsap(si, seq)
+				}
+			}
+			mset.mu.Unlock()
+		}()
+
+		// Wait for previous processSourceMsgs go routine to be completely done.
+		// If none is running, this will not block.
+		si.wg.Wait()
+
 		select {
 		case ccr := <-respCh:
+			ready := sync.WaitGroup{}
 			mset.mu.Lock()
-			if si := mset.sources[iname]; si != nil {
+			// Check that it has not been removed or canceled (si.sub would be nil)
+			if si := mset.sources[iname]; si != nil && si.sub != nil {
 				si.err = nil
 				if ccr.Error != nil || ccr.ConsumerInfo == nil {
 					mset.srv.Warnf("JetStream error response for create source consumer: %+v", ccr.Error)
 					si.err = ccr.Error
-					// We will retry every 10 seconds or so
-					mset.cancelSourceConsumer(iname)
+					// Let's retry as soon as possible, but we are gated by sourceConsumerRetryThreshold
+					retry = true
 				} else {
 					if si.sseq != ccr.ConsumerInfo.Delivered.Stream {
 						si.sseq = ccr.ConsumerInfo.Delivered.Stream + 1
 					}
-
 					// Capture consumer name.
 					si.cname = ccr.ConsumerInfo.Name
-					// Now create sub to receive messages.
-					sub, err := mset.subscribeInternal(deliverSubject, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-						hdr, msg := c.msgParts(copyBytes(rmsg)) // Need to copy.
-						mset.queueInbound(si.msgs, subject, reply, hdr, msg)
-					})
-					if err != nil {
-						si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
-						si.sub = nil
-					} else {
-						si.err = nil
-						si.sub = sub
-						si.last = time.Now()
-					}
+					// Do not set si.sseq to seq here. si.sseq will be set in processInboundSourceMsg
+					si.dseq = 0
+					si.qch = make(chan struct{})
+					si.wg.Add(1)
+					ready.Add(1)
+					mset.srv.startGoRoutine(func() { mset.processSourceMsgs(si, &ready) })
 				}
 			}
 			mset.mu.Unlock()
-		case <-time.After(10 * time.Second):
+			ready.Wait()
+		case <-time.After(5 * time.Second):
 			mset.unsubscribeUnlocked(crSub)
-			return
+			// We already waited 5 seconds, let's retry now.
+			retry = true
 		}
 	}()
 }
 
-func (mset *stream) processSourceMsgs(si *sourceInfo) {
+func (mset *stream) processSourceMsgs(si *sourceInfo, ready *sync.WaitGroup) {
 	s := mset.srv
-	defer s.grWG.Done()
+	defer func() {
+		si.wg.Done()
+		s.grWG.Done()
+	}()
 
-	if si == nil {
-		return
-	}
-
-	// Grab stream messages queue, quit channel and this go routine quit channel.
+	// Grab some stream and sourceInfo values now...
 	mset.mu.Lock()
-	msgs, qch, siqch := si.msgs, mset.qch, si.qch
+	msgs, qch, siqch, iname := si.msgs, mset.qch, si.qch, si.iname
 	// Set the last seen as now so that we don't fail at the first check.
 	si.last = time.Now()
 	mset.mu.Unlock()
 
-	defer func() {
-		mset.mu.Lock()
-		si.grr = false
-		// Close ONLY if the quit channel is the same than when we were started
-		if si.qch != nil && si.qch == siqch {
-			close(si.qch)
-			si.qch = nil
-		}
-		mset.mu.Unlock()
-	}()
+	// Signal the caller that we have captured the above fields.
+	ready.Done()
 
 	t := time.NewTicker(sourceHealthCheckInterval)
 	defer t.Stop()
@@ -2270,7 +2329,7 @@ func (mset *stream) processSourceMsgs(si *sourceInfo) {
 			msgs.recycle(&ims)
 		case <-t.C:
 			mset.mu.RLock()
-			iname, isLeader := si.iname, mset.isLeader()
+			isLeader := mset.isLeader()
 			stalled := time.Since(si.last) > 3*sourceHealthCheckInterval
 			mset.mu.RUnlock()
 			// No longer leader.
@@ -2282,7 +2341,11 @@ func (mset *stream) processSourceMsgs(si *sourceInfo) {
 			}
 			// We are stalled.
 			if stalled {
-				mset.retrySourceConsumer(iname)
+				mset.mu.Lock()
+				// We don't need to schedule here, we are going to simply
+				// call setSourceConsumer with the current state+1.
+				mset.setSourceConsumer(iname, si.sseq+1)
+				mset.mu.Unlock()
 			}
 		}
 	}
@@ -2319,7 +2382,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 
 	// If we are no longer the leader cancel this subscriber.
 	if !mset.isLeader() {
-		mset.cancelSourceConsumer(si.name)
+		mset.cancelSourceConsumer(si.iname)
 		mset.mu.Unlock()
 		return false
 	}
@@ -2406,18 +2469,24 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 
 	if err != nil {
 		s := mset.srv
-		if err == errLastSeqMismatch {
-			mset.mu.Lock()
-			mset.cancelSourceConsumer(si.iname)
-			mset.mu.Unlock()
-			mset.retrySourceConsumer(si.iname)
-		} else {
-			s.RateLimitWarnf("JetStream got an error processing inbound source msg: %v", err)
-		}
 		if strings.Contains(err.Error(), "no space left") {
 			s.Errorf("JetStream out of space, will be DISABLED")
 			s.DisableJetStream()
+		} else {
+			mset.mu.RLock()
+			accName, sname, iname := mset.acc.Name, mset.cfg.Name, si.iname
+			mset.mu.RUnlock()
+			// Log some warning for errors other than errLastSeqMismatch
+			if err != errLastSeqMismatch {
+				s.RateLimitWarnf("Error processing inbound source %q for '%s' > '%s': %v",
+					iname, accName, sname, err)
+			}
+			// Retry in all type of errors.
+			// This will make sure the source is still in mset.sources map,
+			// find the last sequence and then call setSourceConsumer.
+			mset.retrySourceConsumer(iname)
 		}
+		return false
 	}
 
 	return true
@@ -2525,8 +2594,7 @@ func (mset *stream) startingSequenceForSources() {
 		if ssi.iname == _EMPTY_ {
 			ssi.setIndexName()
 		}
-		qname := fmt.Sprintf("[ACC:%s] stream source '%s' from '%s' msgs", mset.acc.Name, mset.cfg.Name, ssi.Name)
-		si := &sourceInfo{name: ssi.Name, iname: ssi.iname, msgs: mset.srv.newIPQueue(qname) /* of *inMsg */}
+		si := &sourceInfo{name: ssi.Name, iname: ssi.iname}
 		mset.sources[ssi.iname] = si
 	}
 
@@ -2585,7 +2653,7 @@ func (mset *stream) setupSourceConsumers() error {
 	// Reset if needed.
 	for _, si := range mset.sources {
 		if si.sub != nil {
-			mset.cancelSourceConsumer(si.name)
+			mset.cancelSourceConsumer(si.iname)
 		}
 	}
 
@@ -2631,17 +2699,7 @@ func (mset *stream) subscribeToStream() error {
 // Lock should be held.
 func (mset *stream) stopSourceConsumers() {
 	for _, si := range mset.sources {
-		if si.sub != nil {
-			mset.unsubscribe(si.sub)
-		}
-		// Need to delete the old one.
-		mset.removeInternalConsumer(si)
-		// If the go routine is still running close the quit chan.
-		if si.qch != nil {
-			close(si.qch)
-			si.qch = nil
-		}
-		si.msgs.unregister()
+		mset.cancelSourceConsumerWithSourceInfo(si)
 	}
 }
 


### PR DESCRIPTION
The main issue was that in mixed-mode, the interest through gateway
may still be in optimistic mode, which when creating the source
consumer would start delivery before we had a chance to setup
the subscription to receive those messages.

The approach is to create the subscription prior to sending
the consumer create request. Also refactored a bit the code in
the hope to make the retries a bit more bullet proof.

We may also look at making sure that gateways are switched to
interest-mode when detecting a mixed-mode setup.

Also fixed a defect that could cause a source to be canceled
when updating a stream.

Resolves https://github.com/nats-io/nats-server/issues/2801

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
