### PR TITLE
Fix subject renaming for leaf connections and queued subs

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4307,6 +4307,16 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 				} else {
 					dsubj = append(_dsubj[:0], sub.im.to...)
 				}
+				// Make sure deliver is set if inbound from a route. (leaf is fixed on send)
+				if remapped && (c.kind == GATEWAY || c.kind == ROUTER) {
+					deliver = subj
+				}
+				// If we are mapping for a deliver subject we will reverse roles.
+				// The original subj we set from above is correct for the msg header,
+				// but we need to transform the deliver subject to properly route.
+				if len(deliver) > 0 {
+					dsubj, subj = subj, dsubj
+				}
 			}
 
 			mh := c.msgHeader(dsubj, creply, sub)

--- a/server/client.go
+++ b/server/client.go
@@ -4167,8 +4167,8 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 				dsubj = append(_dsubj[:0], sub.im.to...)
 			}
 
-			// Make sure deliver is set if inbound from a route. (leaf is fixed on send)
-			if remapped && (c.kind == GATEWAY || c.kind == ROUTER) {
+			// Make sure deliver is set if inbound from a route.
+			if remapped && (c.kind == GATEWAY || c.kind == ROUTER || c.kind == LEAF) {
 				deliver = subj
 			}
 			// If we are mapping for a deliver subject we will reverse roles.
@@ -4307,8 +4307,8 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 				} else {
 					dsubj = append(_dsubj[:0], sub.im.to...)
 				}
-				// Make sure deliver is set if inbound from a route. (leaf is fixed on send)
-				if remapped && (c.kind == GATEWAY || c.kind == ROUTER) {
+				// Make sure deliver is set if inbound from a route.
+				if remapped && (c.kind == GATEWAY || c.kind == ROUTER || c.kind == LEAF) {
 					deliver = subj
 				}
 				// If we are mapping for a deliver subject we will reverse roles.

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -12322,7 +12322,10 @@ func TestJetStreamClusterImportConsumerStreamSubjectRemap(t *testing.T) {
 		IM: {
 			users: [ {user: im, password: pwd} ]
 			imports [
-				{ stream:  { account: JS, subject: "deliver.ORDERS.*" }}
+				{ stream:  { account: JS, subject: "deliver.ORDERS.route" }}
+				{ stream:  { account: JS, subject: "deliver.ORDERS.gateway" }}
+				{ stream:  { account: JS, subject: "deliver.ORDERS.leaf1" }}
+				{ stream:  { account: JS, subject: "deliver.ORDERS.leaf2" }}
 				{ service: {account: JS, subject: "$JS.FC.>" }}
 			]
 		},
@@ -12332,83 +12335,93 @@ func TestJetStreamClusterImportConsumerStreamSubjectRemap(t *testing.T) {
 		listen: 127.0.0.1:-1
 	}`
 
-	c := createJetStreamSuperClusterWithTemplate(t, template, 3, 2)
-	defer c.shutdown()
+	test := func(t *testing.T, queue bool) {
+		c := createJetStreamSuperClusterWithTemplate(t, template, 3, 2)
+		defer c.shutdown()
 
-	s := c.randomServer()
-	nc, js := jsClientConnect(t, s, nats.UserInfo("js", "pwd"))
-	defer nc.Close()
+		s := c.randomServer()
+		nc, js := jsClientConnect(t, s, nats.UserInfo("js", "pwd"))
+		defer nc.Close()
 
-	_, err := js.AddStream(&nats.StreamConfig{
-		Name:      "ORDERS",
-		Subjects:  []string{"foo"}, // The JS subject.
-		Replicas:  3,
-		Placement: &nats.Placement{Cluster: "C1"},
-	})
-	require_NoError(t, err)
-
-	_, err = js.Publish("foo", []byte("OK"))
-	require_NoError(t, err)
-
-	for dur, deliver := range map[string]string{
-		"dur-route":   "deliver.ORDERS.route",
-		"dur-gateway": "deliver.ORDERS.gateway",
-		"dur-leaf-1":  "deliver.ORDERS.leaf1",
-		"dur-leaf-2":  "deliver.ORDERS.leaf2",
-	} {
-		_, err = js.AddConsumer("ORDERS", &nats.ConsumerConfig{
-			Durable:        dur,
-			DeliverSubject: deliver,
-			AckPolicy:      nats.AckExplicitPolicy,
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:      "ORDERS",
+			Subjects:  []string{"foo"}, // The JS subject.
+			Replicas:  3,
+			Placement: &nats.Placement{Cluster: "C1"},
 		})
 		require_NoError(t, err)
-	}
 
-	test := func(t *testing.T, s *Server, dSubj string) {
-		nc2, err := nats.Connect(s.ClientURL(), nats.UserInfo("im", "pwd"))
-		require_NoError(t, err)
-		defer nc2.Close()
-
-		sub, err := nc2.SubscribeSync(dSubj)
+		_, err = js.Publish("foo", []byte("OK"))
 		require_NoError(t, err)
 
-		m, err := sub.NextMsg(time.Second)
-		require_NoError(t, err)
-
-		if m.Subject != "foo" {
-			t.Fatalf("Subject not mapped correctly across account boundary, expected %q got %q", "foo", m.Subject)
+		for dur, deliver := range map[string]string{
+			"dur-route":   "deliver.ORDERS.route",
+			"dur-gateway": "deliver.ORDERS.gateway",
+			"dur-leaf-1":  "deliver.ORDERS.leaf1",
+			"dur-leaf-2":  "deliver.ORDERS.leaf2",
+		} {
+			cfg := &nats.ConsumerConfig{
+				Durable:        dur,
+				DeliverSubject: deliver,
+				AckPolicy:      nats.AckExplicitPolicy,
+			}
+			if queue {
+				cfg.DeliverGroup = "queue"
+			}
+			_, err = js.AddConsumer("ORDERS", cfg)
+			require_NoError(t, err)
 		}
-		require_False(t, strings.Contains(m.Reply, "@"))
-	}
 
-	t.Run("route", func(t *testing.T) {
-		// pick random non consumer leader so we receive via route
-		s := c.clusterForName("C1").randomNonConsumerLeader("JS", "ORDERS", "dur-route")
-		test(t, s, "deliver.ORDERS.route")
-	})
-	t.Run("gateway", func(t *testing.T) {
-		// pick server with inbound gateway from consumer leader, so we receive from gateway and have no route in between
-		scl := c.clusterForName("C1").consumerLeader("JS", "ORDERS", "dur-gateway")
-		var sfound *Server
-		for _, s := range c.clusterForName("C2").servers {
-			s.mu.Lock()
-			for _, c := range s.gateway.in {
-				if c.GetName() == scl.info.ID {
-					sfound = s
+		testCase := func(t *testing.T, s *Server, dSubj string) {
+			nc2, err := nats.Connect(s.ClientURL(), nats.UserInfo("im", "pwd"))
+			require_NoError(t, err)
+			defer nc2.Close()
+
+			var sub *nats.Subscription
+			if queue {
+				sub, err = nc2.QueueSubscribeSync(dSubj, "queue")
+			} else {
+				sub, err = nc2.SubscribeSync(dSubj)
+			}
+			require_NoError(t, err)
+
+			m, err := sub.NextMsg(time.Second)
+			require_NoError(t, err)
+
+			if m.Subject != "foo" {
+				t.Fatalf("Subject not mapped correctly across account boundary, expected %q got %q", "foo", m.Subject)
+			}
+			require_False(t, strings.Contains(m.Reply, "@"))
+		}
+
+		t.Run("route", func(t *testing.T) {
+			// pick random non consumer leader so we receive via route
+			s := c.clusterForName("C1").randomNonConsumerLeader("JS", "ORDERS", "dur-route")
+			testCase(t, s, "deliver.ORDERS.route")
+		})
+		t.Run("gateway", func(t *testing.T) {
+			// pick server with inbound gateway from consumer leader, so we receive from gateway and have no route in between
+			scl := c.clusterForName("C1").consumerLeader("JS", "ORDERS", "dur-gateway")
+			var sfound *Server
+			for _, s := range c.clusterForName("C2").servers {
+				s.mu.Lock()
+				for _, c := range s.gateway.in {
+					if c.GetName() == scl.info.ID {
+						sfound = s
+						break
+					}
+				}
+				s.mu.Unlock()
+				if sfound != nil {
 					break
 				}
 			}
-			s.mu.Unlock()
-			if sfound != nil {
-				break
-			}
-		}
-		test(t, sfound, "deliver.ORDERS.gateway")
-	})
-	t.Run("leaf-post-export", func(t *testing.T) {
-		// create leaf node server connected post export/import
-		scl := c.clusterForName("C1").consumerLeader("JS", "ORDERS", "dur-leaf-1")
-		cf := createConfFile(t, []byte(fmt.Sprintf(`
+			testCase(t, sfound, "deliver.ORDERS.gateway")
+		})
+		t.Run("leaf-post-export", func(t *testing.T) {
+			// create leaf node server connected post export/import
+			scl := c.clusterForName("C1").consumerLeader("JS", "ORDERS", "dur-leaf-1")
+			cf := createConfFile(t, []byte(fmt.Sprintf(`
 			port: -1
 			leafnodes {
 				remotes [ { url: "nats://im:pwd@127.0.0.1:%d" } ]
@@ -12418,26 +12431,26 @@ func TestJetStreamClusterImportConsumerStreamSubjectRemap(t *testing.T) {
 				password: pwd
 			}
 		`, scl.getOpts().LeafNode.Port)))
-		defer removeFile(t, cf)
-		s, _ := RunServerWithConfig(cf)
-		defer s.Shutdown()
-		checkLeafNodeConnected(t, scl)
-		test(t, s, "deliver.ORDERS.leaf1")
-	})
-	t.Run("leaf-pre-export", func(t *testing.T) {
-		// create leaf node server connected pre export, perform export/import on leaf node server
-		scl := c.clusterForName("C1").consumerLeader("JS", "ORDERS", "dur-leaf-2")
-		cf := createConfFile(t, []byte(fmt.Sprintf(`
+			defer removeFile(t, cf)
+			s, _ := RunServerWithConfig(cf)
+			defer s.Shutdown()
+			checkLeafNodeConnected(t, scl)
+			testCase(t, s, "deliver.ORDERS.leaf1")
+		})
+		t.Run("leaf-pre-export", func(t *testing.T) {
+			// create leaf node server connected pre export, perform export/import on leaf node server
+			scl := c.clusterForName("C1").consumerLeader("JS", "ORDERS", "dur-leaf-2")
+			cf := createConfFile(t, []byte(fmt.Sprintf(`
 			port: -1
 			leafnodes {
-				remotes [ { url: "nats://im:pwd@127.0.0.1:%d", account: JS2 } ]
+				remotes [ { url: "nats://js:pwd@127.0.0.1:%d", account: JS2 } ]
 			}
 			accounts: {
 				JS2: {
 					users: [ {user: js, password: pwd} ]
 					exports [
 						# This is streaming to a delivery subject for a push based consumer.
-						{ stream: "deliver.ORDERS.*" }
+						{ stream: "deliver.ORDERS.leaf2" }
 						# This is to ack received messages. This is a service to support sync ack.
 						{ service: "$JS.ACK.ORDERS.*.>" }
 						# To support ordered consumers, flow control.
@@ -12447,17 +12460,25 @@ func TestJetStreamClusterImportConsumerStreamSubjectRemap(t *testing.T) {
 				IM2: {
 					users: [ {user: im, password: pwd} ]
 					imports [
-						{ stream:  { account: JS2, subject: "deliver.ORDERS.*" }}
+						{ stream:  { account: JS2, subject: "deliver.ORDERS.leaf2" }}
 						{ service: {account: JS2, subject: "$JS.FC.>" }}
 					]
 				},
 			}
 		`, scl.getOpts().LeafNode.Port)))
-		defer removeFile(t, cf)
-		s, _ := RunServerWithConfig(cf)
-		defer s.Shutdown()
-		checkLeafNodeConnected(t, scl)
-		test(t, s, "deliver.ORDERS.leaf2")
+			defer removeFile(t, cf)
+			s, _ := RunServerWithConfig(cf)
+			defer s.Shutdown()
+			checkLeafNodeConnected(t, scl)
+			testCase(t, s, "deliver.ORDERS.leaf2")
+		})
+	}
+
+	t.Run("noQueue", func(t *testing.T) {
+		test(t, false)
+	})
+	t.Run("queue", func(t *testing.T) {
+		test(t, true)
 	})
 }
 


### PR DESCRIPTION
change in `server/client.go` essentially copies the added code from the non queue part.
Both section of code add a check for leaf connections. (original unit test was wrong).
