### PR TITLE
[FIXED] JetStream: Mirrors would fail to be recovered

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1164,9 +1164,7 @@ func (a *Account) EnableJetStream(limits map[string]JetStreamAccountLimits) erro
 		}
 
 		// We had a bug that set a default de dupe window on mirror, despite that being not a valid config
-		if cfg.Mirror != nil && cfg.StreamConfig.Duplicates != 0 {
-			cfg.StreamConfig.Duplicates = 0
-		}
+		fixCfgMirrorWithDedupWindow(&cfg.StreamConfig)
 
 		// We had a bug that could allow subjects in that had prefix or suffix spaces. We check for that here
 		// and will patch them on the fly for now. We will warn about them.
@@ -2581,4 +2579,14 @@ func validateJetStreamOptions(o *Options) error {
 		return fmt.Errorf("expected 'no_extend' for string value, got '%s'", h)
 	}
 	return nil
+}
+
+// We had a bug that set a default de dupe window on mirror, despite that being not a valid config
+func fixCfgMirrorWithDedupWindow(cfg *StreamConfig) {
+	if cfg == nil || cfg.Mirror == nil {
+		return
+	}
+	if cfg.Duplicates != 0 {
+		cfg.Duplicates = 0
+	}
 }

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1018,6 +1018,7 @@ func (js *jetStream) applyMetaSnapshot(buf []byte, isRecovering bool) error {
 	// Build our new version here outside of js.
 	streams := make(map[string]map[string]*streamAssignment)
 	for _, wsa := range wsas {
+		fixCfgMirrorWithDedupWindow(wsa.Config)
 		as := streams[wsa.Client.serviceAccount()]
 		if as == nil {
 			as = make(map[string]*streamAssignment)
@@ -5226,6 +5227,10 @@ func encodeDeleteStreamAssignment(sa *streamAssignment) []byte {
 func decodeStreamAssignment(buf []byte) (*streamAssignment, error) {
 	var sa streamAssignment
 	err := json.Unmarshal(buf, &sa)
+	if err != nil {
+		return nil, err
+	}
+	fixCfgMirrorWithDedupWindow(sa.Config)
 	return &sa, err
 }
 


### PR DESCRIPTION
This is a continuation of PR #3060, but extends to clustering.

Verified with manual test that a mirror created with v2.7.4 has
the duplicates window set and on restart with main would still
complain about use of dedup in cluster mode. The mirror stream
was recovered but showing as R1.
With this fix, a restart of the cluster - with existing data -
will properly recover the stream as an R3 and messages that
were published while in a bad state are synchronized.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
Signed-off-by: Matthias Hanel mh@synadia.com
