### PR TITLE
Implement JSConsumerDeliveryNakAdvisory

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -204,6 +204,9 @@ const (
 	// JSAdvisoryConsumerMaxDeliveryExceedPre is a notification published when a message exceeds its delivery threshold.
 	JSAdvisoryConsumerMaxDeliveryExceedPre = "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES"
 
+	// JSAdvisoryConsumerMsgNakPre is a notification published when a message has been naked
+	JSAdvisoryConsumerMsgNakPre = "$JS.EVENT.ADVISORY.CONSUMER.MSG_NAKED"
+
 	// JSAdvisoryConsumerMsgTerminatedPre is a notification published when a message has been terminated.
 	JSAdvisoryConsumerMsgTerminatedPre = "$JS.EVENT.ADVISORY.CONSUMER.MSG_TERMINATED"
 

--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -110,6 +110,21 @@ type JSConsumerDeliveryExceededAdvisory struct {
 // JSConsumerDeliveryExceededAdvisoryType is the schema type for JSConsumerDeliveryExceededAdvisory
 const JSConsumerDeliveryExceededAdvisoryType = "io.nats.jetstream.advisory.v1.max_deliver"
 
+// JSConsumerDeliveryNakAdvisory is an advisory informing that a message was
+// naked by the consumer
+type JSConsumerDeliveryNakAdvisory struct {
+	TypedEvent
+	Stream      string `json:"stream"`
+	Consumer    string `json:"consumer"`
+	ConsumerSeq uint64 `json:"consumer_seq"`
+	StreamSeq   uint64 `json:"stream_seq"`
+	Deliveries  uint64 `json:"deliveries"`
+	Domain      string `json:"domain,omitempty"`
+}
+
+// JSConsumerDeliveryNakAdvisoryType is the schema type for JSConsumerDeliveryNakAdvisory
+const JSConsumerDeliveryNakAdvisoryType = "io.nats.jetstream.advisory.v1.nak"
+
 // JSConsumerDeliveryTerminatedAdvisory is an advisory informing that a message was
 // terminated by the consumer, so might be a candidate for DLQ handling
 type JSConsumerDeliveryTerminatedAdvisory struct {


### PR DESCRIPTION
Resolves #3072

### Changes proposed in this pull request:

 - add the advisory `JSAdvisoryConsumerMsgNakPre` will be triggered when a message is naked.

/cc @nats-io/core
