### PR TITLE
[fixed] step down timing, consumer stream seqno, clear redelivery

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1266,7 +1266,7 @@ func (a *Account) EnableJetStream(limits map[string]JetStreamAccountLimits) erro
 			}
 			lseq := e.mset.lastSeq()
 			obs.mu.Lock()
-			err = obs.readStoredState(lseq)
+			_, err = obs.readStoredState(lseq)
 			obs.mu.Unlock()
 			if err != nil {
 				s.Warnf("    Error restoring consumer %q state: %v", cfg.Name, err)

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1835,6 +1835,9 @@ func (s *Server) jsStreamLeaderStepDownRequest(sub *subscription, c *client, _ *
 	// Call actual stepdown.
 	if mset != nil {
 		if node := mset.raftNode(); node != nil {
+			mset.setLeader(false)
+			// TODO (mh) eventually make sure all go routines exited and all channels are cleared
+			time.Sleep(250 * time.Millisecond)
 			node.StepDown()
 		}
 	}
@@ -1937,6 +1940,9 @@ func (s *Server) jsConsumerLeaderStepDownRequest(sub *subscription, c *client, _
 
 	// Call actual stepdown.
 	if n := o.raftNode(); n != nil {
+		o.setLeader(false)
+		// TODO (mh) eventually make sure all go routines exited and all channels are cleared
+		time.Sleep(250 * time.Millisecond)
 		n.StepDown()
 	}
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5899,7 +5899,7 @@ func (mset *stream) processSnapshot(snap *streamSnapshot) (e error) {
 			o.mu.Lock()
 			if o.isLeader() {
 				// This expects mset lock to be held.
-				o.setInitialPendingAndStart()
+				o.setInitialPendingAndStart(false)
 			}
 			o.mu.Unlock()
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -3380,7 +3380,7 @@ func (s *Server) lameDuckMode() {
 
 	// If we are running any raftNodes transfer leaders.
 	if hadTransfers := s.transferRaftLeaders(); hadTransfers {
-		// They will tranfer leadership quickly, but wait here for a second.
+		// They will transfer leadership quickly, but wait here for a second.
 		select {
 		case <-time.After(time.Second):
 		case <-s.quitCh:

--- a/server/stream.go
+++ b/server/stream.go
@@ -4192,7 +4192,7 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 			obs.setCreatedTime(cfg.Created)
 		}
 		obs.mu.Lock()
-		err = obs.readStoredState(lseq)
+		_, err = obs.readStoredState(lseq)
 		obs.mu.Unlock()
 		if err != nil {
 			mset.stop(true, false)


### PR DESCRIPTION
Step down timing for consumers or streams.
Signals loss of leadership and sleeps before stepping down.
This makes it less likely that messages are being processed during step
down.

When becoming leader, consumer stream seqno got reset,
even though the consumer existed already.

Proper cleanup of redelivery data structures and timer

Signed-off-by: Matthias Hanel <mh@synadia.com>
