### PR TITLE
Fix for a consumer recovery issue and update to healthz.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5164,7 +5164,7 @@ func (fs *fileStore) ConsumerStore(name string, cfg *ConsumerConfig) (ConsumerSt
 	if err := os.MkdirAll(odir, defaultDirPerms); err != nil {
 		return nil, fmt.Errorf("could not create consumer directory - %v", err)
 	}
-	csi := &FileConsumerInfo{ConsumerConfig: *cfg}
+	csi := &FileConsumerInfo{Name: name, Created: time.Now().UTC(), ConsumerConfig: *cfg}
 	o := &consumerFileStore{
 		fs:   fs,
 		cfg:  csi,

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1253,7 +1253,7 @@ func (a *Account) EnableJetStream(limits map[string]JetStreamAccountLimits) erro
 				// the consumer can reconnect. We will create it as a durable and switch it.
 				cfg.ConsumerConfig.Durable = ofi.Name()
 			}
-			obs, err := e.mset.addConsumer(&cfg.ConsumerConfig)
+			obs, err := e.mset.addConsumerWithAssignment(&cfg.ConsumerConfig, _EMPTY_, nil, true)
 			if err != nil {
 				s.Warnf("    Error adding consumer %q: %v", cfg.Name, err)
 				continue

--- a/server/stream.go
+++ b/server/stream.go
@@ -1453,19 +1453,22 @@ func allSubjects(cfg *StreamConfig, acc *Account) ([]string, bool) {
 	var seen map[string]bool
 
 	if cfg.Mirror != nil {
-		var subjs []string
-		seen = make(map[string]bool)
-		subjs, hasExt = acc.streamSourceSubjects(cfg.Mirror, seen)
+		subjs, localHasExt := acc.streamSourceSubjects(cfg.Mirror, make(map[string]bool))
 		if len(subjs) > 0 {
 			subjects = append(subjects, subjs...)
 		}
+		if localHasExt {
+			hasExt = true
+		}
 	} else if len(cfg.Sources) > 0 {
-		var subjs []string
 		seen = make(map[string]bool)
 		for _, si := range cfg.Sources {
-			subjs, hasExt = acc.streamSourceSubjects(si, seen)
+			subjs, localHasExt := acc.streamSourceSubjects(si, seen)
 			if len(subjs) > 0 {
 				subjects = append(subjects, subjs...)
+			}
+			if localHasExt {
+				hasExt = true
 			}
 		}
 	}
@@ -1566,6 +1569,7 @@ func (a *Account) streamSourceSubjectsNotClustered(streamName string, seen map[s
 			}
 		}
 	}
+
 	return subjects, hasExt
 }
 


### PR DESCRIPTION
We had an issue where a recovered consumer might not recover if a source based stream which housed the consumer filter subject was removed.

We now signal that we are recovering a consumer and if so skip the filtered subject check.

Also per ops re-worked healthz to test all assigned assets, just not those that we could recover.

Also various fixes found during @matthiashanel original diagnosis.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
