### PR TITLE
[FIXED] JetStream: possible lock inversion

### DIFF
--- a/locksordering.txt
+++ b/locksordering.txt
@@ -2,6 +2,9 @@ Here is the list of some established lock ordering.
 
 In this list, A -> B means that you can have A.Lock() then B.Lock(), not the opposite.
 
-jetStream -> jsAccount -> Server -> client-> Account
+jetStream -> jsAccount -> Server -> client -> Account
 
-stream -> consumer
+jetStream -> jsAccount -> stream -> consumer
+
+A lock to protect jetstream account's usage has been introduced: jsAccount.usageMu.
+This lock is independent and can be invoked under any other lock: jsAccount -> jsa.usageMu, stream -> jsa.usageMu, etc...

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -520,9 +520,9 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 		return nil, NewJSConsumerConfigRequiredError()
 	}
 
-	jsa.mu.RLock()
+	jsa.usageMu.RLock()
 	selectedLimits, limitsFound := jsa.limits[tierName]
-	jsa.mu.RUnlock()
+	jsa.usageMu.RUnlock()
 	if !limitsFound {
 		return nil, NewJSNoLimitsError()
 	}

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -849,12 +849,12 @@ func (a *Account) trackAPI() {
 	jsa := a.js
 	a.mu.RUnlock()
 	if jsa != nil {
-		jsa.mu.Lock()
+		jsa.usageMu.Lock()
 		jsa.usageApi++
 		jsa.apiTotal++
 		jsa.sendClusterUsageUpdate()
 		atomic.AddInt64(&jsa.js.apiTotal, 1)
-		jsa.mu.Unlock()
+		jsa.usageMu.Unlock()
 	}
 }
 
@@ -863,7 +863,7 @@ func (a *Account) trackAPIErr() {
 	jsa := a.js
 	a.mu.RUnlock()
 	if jsa != nil {
-		jsa.mu.Lock()
+		jsa.usageMu.Lock()
 		jsa.usageApi++
 		jsa.apiTotal++
 		jsa.usageErr++
@@ -871,7 +871,7 @@ func (a *Account) trackAPIErr() {
 		jsa.sendClusterUsageUpdate()
 		atomic.AddInt64(&jsa.js.apiTotal, 1)
 		atomic.AddInt64(&jsa.js.apiErrors, 1)
-		jsa.mu.Unlock()
+		jsa.usageMu.Unlock()
 	}
 }
 

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2576,6 +2576,7 @@ func (s *Server) accountDetail(jsa *jsAccount, optStreams, optConsumers, optCfg 
 	if acc.nameTag != "" {
 		name = acc.nameTag
 	}
+	jsa.usageMu.RLock()
 	totalMem, totalStore := jsa.storageTotals()
 	detail := AccountDetail{
 		Name: name,
@@ -2590,6 +2591,7 @@ func (s *Server) accountDetail(jsa *jsAccount, optStreams, optConsumers, optCfg 
 		},
 		Streams: make([]StreamDetail, 0, len(jsa.streams)),
 	}
+	jsa.usageMu.RUnlock()
 	var streams []*stream
 	if optStreams {
 		for _, stream := range jsa.streams {


### PR DESCRIPTION
When updating usage, there is a lock inversion in that the jetStream
lock was acquired while under the stream's (mset) lock, which is
not correct. Also, updateUsage was locking the jsAccount lock, which
again, is not really correct since jsAccount contains streams, so
it should be jsAccount->stream, not the other way around.

Removed the locking of jetStream to check for clustered state since
js.clustered is immutable.

Replaced using jsAccount lock to update usage with a dedicated lock.

Originally moved all the update/limit fields in jsAccount to new
structure to make sure that I would see all code that is updating
or reading those fields, and also all functions so that I could
make sure that I use the new lock when calling these. Once that
works was done, and to reduce code changes, I put the fields back
into jsAccount (although I grouped them under the new usageMu mutex
field).

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
