### PR TITLE
[FIXED] JetStream: possible panic checking for group leader less

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -658,6 +658,9 @@ func (js *jetStream) isGroupLeaderless(rg *raftGroup) bool {
 	cc := js.cluster
 
 	// If we are not a member we can not say..
+	if cc.meta == nil {
+		return false
+	}
 	if !rg.isMember(cc.meta.ID()) {
 		return false
 	}


### PR DESCRIPTION
Got this stack:
```
goroutine 247945 [running]:
github.com/nats-io/nats-server/v2/server.(*jetStream).isGroupLeaderless(0xc004794e70, 0xc0031b0300)
	/home/runner/work/nats-server/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:661 +0xc2
github.com/nats-io/nats-server/v2/server.(*Server).jsMsgDeleteRequest(0xc001dc9388, 0xc003e6de30, 0xc00222b980, 0xc001454f70, {0xc000668930, 0x24}, {0xc0011dbdb8, 0x11}, {0xc000da93f0, 0xa6, ...})
	/home/runner/work/nats-server/src/github.com/nats-io/nats-server/server/jetstream_api.go:2335 +0x67d
github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch.func1()
	/home/runner/work/nats-server/src/github.com/nats-io/nats-server/server/jetstream_api.go:716 +0x85
created by github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch
	/home/runner/work/nats-server/src/github.com/nats-io/nats-server/server/jetstream_api.go:715 +0x5c5
```

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
