### PR TITLE
[FIXED] JetStream: PullConsumer MaxWaiting==1 and Canceled requests

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -1531,7 +1531,7 @@ func TestNoRaceJetStreamClusterStreamCreateAndLostQuorum(t *testing.T) {
 	checkSubsPending(t, sub, 0)
 }
 
-func TestNoRaceJetStreamClusterSuperClusterMirrors(t *testing.T) {
+func TestNoRaceJetStreamSuperClusterMirrors(t *testing.T) {
 	sc := createJetStreamSuperCluster(t, 3, 3)
 	defer sc.shutdown()
 
@@ -1646,7 +1646,7 @@ func TestNoRaceJetStreamClusterSuperClusterMirrors(t *testing.T) {
 	})
 }
 
-func TestNoRaceJetStreamClusterMirrorMixedMode(t *testing.T) {
+func TestNoRaceJetStreamSuperClusterMixedModeMirrors(t *testing.T) {
 	// Unlike the similar sources test, this test is not reliably catching the bug
 	// that would cause mirrors to not have the expected messages count.
 	// Still, adding this test in case we have a regression and we are lucky in
@@ -1756,7 +1756,7 @@ func TestNoRaceJetStreamClusterMirrorMixedMode(t *testing.T) {
 	}
 }
 
-func TestNoRaceJetStreamClusterSuperClusterSources(t *testing.T) {
+func TestNoRaceJetStreamSuperClusterSources(t *testing.T) {
 
 	sc := createJetStreamSuperCluster(t, 3, 3)
 	defer sc.shutdown()
@@ -1955,7 +1955,7 @@ func TestNoRaceJetStreamClusterSourcesMuxd(t *testing.T) {
 
 }
 
-func TestNoRaceJetStreamClusterSourcesMuxdMixedMode(t *testing.T) {
+func TestNoRaceJetStreamSuperClusterMixedModeSources(t *testing.T) {
 	tmpl := `
 		listen: 127.0.0.1:-1
 		server_name: %s
@@ -2217,7 +2217,7 @@ func TestNoRaceLargeActiveOnReplica(t *testing.T) {
 	}
 }
 
-func TestNoRaceJetStreamClusterSuperClusterRIPStress(t *testing.T) {
+func TestNoRaceJetStreamSuperClusterRIPStress(t *testing.T) {
 	// Uncomment to run. Needs to be on a big machine.
 	skip(t)
 
@@ -2743,7 +2743,7 @@ func TestNoRaceJetStreamStalledMirrorsAfterExpire(t *testing.T) {
 
 // We will use JetStream helpers to create supercluster but this test is about exposing the ability to access
 // account scoped connz with subject interest filtering.
-func TestNoRaceAccountConnz(t *testing.T) {
+func TestNoRaceJetStreamSuperClusterAccountConnz(t *testing.T) {
 	// This has 4 different account, 3 general and system.
 	sc := createJetStreamSuperClusterWithTemplate(t, jsClusterAccountsTempl, 3, 3)
 	defer sc.shutdown()


### PR DESCRIPTION
There was an issue with MaxWaiting==1 that was causing a request
with expiration to actually not expire. This was because processWaiting
would not pick it up because wq.rp was actually equal to wq.wp
(that is, the read pointer was equal to write pointer for a slice
of capacity of 1).

The other issue was that when reaching the maximum of waiting pull
requests, a new request would evict an old one with a "408 Request Canceled".

There is no reason for that, instead the server will first try to
find some existing expired requests (since some of the expiration
is lazily done), but if none is expired, and the queue is full,
the server will return a "409 Exceeded MaxWaiting" to the new
request, and not a "408 Request Canceled" to an old one...

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
