### PR TITLE
[FIXED] Accounts Export/Import isolation with overlap subjects

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -2667,7 +2667,7 @@ func (c *client) addShadowSub(sub *subscription, ime *ime) (*subscription, error
 			return nil, err
 		}
 		nsub.subject = []byte(subj)
-	} else if !im.usePub || !ime.dyn {
+	} else if !im.usePub || (im.usePub && ime.overlapSubj != _EMPTY_) || !ime.dyn {
 		if ime.overlapSubj != _EMPTY_ {
 			nsub.subject = []byte(ime.overlapSubj)
 		} else {


### PR DESCRIPTION
I tracked down this issue to have been introduced with PR #2369,
but the code also touched PR #1891 and PR #3088.

I added a test as described in issue #3108 but did not need
JetStream to demonstrate the issue. With the proposed fix, all
tests that were added in aforementioned PRs still pass, including
the new test.

Resolves #3108

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
