### PR TITLE
[FIXED] JetStream: possible lockup due to a return prior to unlock

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -2701,11 +2701,11 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 		} else {
 			// Let them know we are the leader.
 			ar := &appendEntryResponse{n.term, n.pindex, n.id, false, _EMPTY_}
-			n.Unlock()
 			n.debug("AppendEntry ignoring old term from another leader")
 			n.sendRPC(ae.reply, _EMPTY_, ar.encode(arbuf))
 		}
 		// Always return here from processing.
+		n.Unlock()
 		return
 	}
 


### PR DESCRIPTION
This would happen in situation where a node receives an append
entry with a term higher than the node's (current leader).

This was introduced by moving a return [here](https://github.com/nats-io/nats-server/pull/3100/files#diff-0a3d4e9b87bb3880bdb735fa489ef618b571de3370dae31d8f509b26e2fb852eR2709) in PR #3100.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
