### PR TITLE
[FIXED] JetStream: panic processing cluster consumer create

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2410,10 +2410,13 @@ func (wq *waitQueue) isFull() bool {
 }
 
 func (wq *waitQueue) isEmpty() bool {
-	return wq.n == 0
+	return wq.len() == 0
 }
 
 func (wq *waitQueue) len() int {
+	if wq == nil {
+		return 0
+	}
 	return wq.n
 }
 


### PR DESCRIPTION
Before PR #3099, `waitQueue.isEmpty()` returned `wq.len() == 0`
and `waitQueue.len()` was protecting against the pointer being
nil (and then return 0).

The change in #3099 caused `waitQueue.isEmpty()` to return `wq.n == 0`,
which means that if `wq` was nil, then it would crash.

This PR restores `waitQueue.isEmpty()` to return `wq.len() == 0` and
add the protection for waitQueue being nil in `len()` similar to
how it was prior to PR #3099.

Resolves #3117

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

