### PR TITLE
[ADDED] Monitoring: Routez's individual route has now more info

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -749,10 +749,14 @@ type RouteInfo struct {
 	IsConfigured bool               `json:"is_configured"`
 	IP           string             `json:"ip"`
 	Port         int                `json:"port"`
+	Start        time.Time          `json:"start"`
+	LastActivity time.Time          `json:"last_activity"`
+	RTT          string             `json:"rtt,omitempty"`
+	Uptime       string             `json:"uptime"`
+	Idle         string             `json:"idle"`
 	Import       *SubjectPermission `json:"import,omitempty"`
 	Export       *SubjectPermission `json:"export,omitempty"`
 	Pending      int                `json:"pending_size"`
-	RTT          string             `json:"rtt,omitempty"`
 	InMsgs       int64              `json:"in_msgs"`
 	OutMsgs      int64              `json:"out_msgs"`
 	InBytes      int64              `json:"in_bytes"`
@@ -799,6 +803,10 @@ func (s *Server) Routez(routezOpts *RoutezOptions) (*Routez, error) {
 			Import:       r.opts.Import,
 			Export:       r.opts.Export,
 			RTT:          r.getRTT().String(),
+			Start:        r.start,
+			LastActivity: r.last,
+			Uptime:       myUptime(rs.Now.Sub(r.start)),
+			Idle:         myUptime(rs.Now.Sub(r.last)),
 		}
 
 		if len(r.subs) > 0 {

--- a/server/route.go
+++ b/server/route.go
@@ -1289,7 +1289,7 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 		}
 	}
 
-	c := &client{srv: s, nc: conn, opts: ClientOpts{}, kind: ROUTER, msubs: -1, mpay: -1, route: r}
+	c := &client{srv: s, nc: conn, opts: ClientOpts{}, kind: ROUTER, msubs: -1, mpay: -1, route: r, start: time.Now()}
 
 	// Grab server variables
 	s.mu.Lock()


### PR DESCRIPTION
Added Start, LastActivity, Uptime and Idle that we normally have
in a Connz for non route connections. This info can be useful
to determine if a route is recent, etc..

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
