### PR TITLE
[FIXED] JetStream: data race with account's jsLimits

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -635,17 +635,20 @@ func (s *Server) configJetStream(acc *Account) error {
 	if acc == nil {
 		return nil
 	}
-	if acc.jsLimits != nil {
+	acc.mu.RLock()
+	jsLimits := acc.jsLimits
+	acc.mu.RUnlock()
+	if jsLimits != nil {
 		// Check if already enabled. This can be during a reload.
 		if acc.JetStreamEnabled() {
 			if err := acc.enableAllJetStreamServiceImportsAndMappings(); err != nil {
 				return err
 			}
-			if err := acc.UpdateJetStreamLimits(acc.jsLimits); err != nil {
+			if err := acc.UpdateJetStreamLimits(jsLimits); err != nil {
 				return err
 			}
 		} else {
-			if err := acc.EnableJetStream(acc.jsLimits); err != nil {
+			if err := acc.EnableJetStream(jsLimits); err != nil {
 				return err
 			}
 			if s.gateway.enabled {

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -5747,7 +5747,7 @@ func TestMQTTConsumerReplicasOverride(t *testing.T) {
 		t.Helper()
 
 		o := cl.opts[0]
-		mc, r := testMQTTConnect(t, &mqttConnInfo{clientID: "test", cleanSess: false}, o.MQTT.Host, o.MQTT.Port)
+		mc, r := testMQTTConnectRetry(t, &mqttConnInfo{clientID: "test", cleanSess: false}, o.MQTT.Host, o.MQTT.Port, 5)
 		defer mc.Close()
 		testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, restarted)
 		testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})


### PR DESCRIPTION
Saw this data race report:
```
=== RUN   TestJetStreamJWTClusteredDeleteTierWithStreamAndMove
==================
WARNING: DATA RACE
Write at 0x00c000d88a60 by goroutine 86:
  github.com/nats-io/nats-server/v2/server.(*Server).updateAccountClaimsWithRefresh()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/accounts.go:3299 +0x4532
  github.com/nats-io/nats-server/v2/server.(*Server).UpdateAccountClaims()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/accounts.go:2932 +0x45
  github.com/nats-io/nats-server/v2/server.(*Server).updateAccountWithClaimJWT()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1490 +0x3b4
  github.com/nats-io/nats-server/v2/server.(*Server).updateAccount()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1463 +0x1f0
  github.com/nats-io/nats-server/v2/server.(*Server).lookupAccount()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1428 +0x168
  github.com/nats-io/nats-server/v2/server.(*Server).LookupAccount()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1448 +0x2b9
  github.com/nats-io/nats-server/v2/server.(*Server).getRequestInfo()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_api.go:834 +0x28d
  github.com/nats-io/nats-server/v2/server.(*Server).jsStreamCreateRequest()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_api.go:1183 +0xca
  github.com/nats-io/nats-server/v2/server.(*Server).jsStreamCreateRequest-fm()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_api.go:1179 +0xcc
  github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch.func1()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_api.go:717 +0x125
Previous read at 0x00c000d88a60 by goroutine 60:
  github.com/nats-io/nats-server/v2/server.(*Server).configJetStream()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:638 +0x59
  github.com/nats-io/nats-server/v2/server.(*Server).updateAccountClaimsWithRefresh()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/accounts.go:3332 +0x48b3
  github.com/nats-io/nats-server/v2/server.(*Server).UpdateAccountClaims()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/accounts.go:2932 +0x45
  github.com/nats-io/nats-server/v2/server.(*Server).updateAccountWithClaimJWT()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1490 +0x3b4
  github.com/nats-io/nats-server/v2/server.(*Server).updateAccount()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1463 +0x1f0
  github.com/nats-io/nats-server/v2/server.(*Server).lookupAccount()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1428 +0x168
  github.com/nats-io/nats-server/v2/server.(*Server).LookupAccount()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1448 +0x2c8
  github.com/nats-io/nats-server/v2/server.(*jetStream).processStreamAssignment()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:2422 +0x2b6
  github.com/nats-io/nats-server/v2/server.(*jetStream).applyMetaEntries()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:1416 +0x7e4
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:896 +0xc75
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster-fm()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:822 +0x39
Goroutine 86 (running) created at:
  github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_api.go:716 +0x8fc
  github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch-fm()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_api.go:658 +0xcc
  github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/client.go:3175 +0xbde
  github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/client.go:4168 +0xf9e
  github.com/nats-io/nats-server/v2/server.(*client).processInboundRoutedMsg()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/route.go:443 +0x2ce
  github.com/nats-io/nats-server/v2/server.(*client).processInboundMsg()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/client.go:3491 +0x79
  github.com/nats-io/nats-server/v2/server.(*client).parse()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/parser.go:497 +0x3886
  github.com/nats-io/nats-server/v2/server.(*client).readLoop()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/client.go:1229 +0x1669
  github.com/nats-io/nats-server/v2/server.(*Server).createRoute.func1()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/route.go:1372 +0x37
Goroutine 60 (running) created at:
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:3013 +0x86
  github.com/nats-io/nats-server/v2/server.(*jetStream).setupMetaGroup()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:621 +0x108a
  github.com/nats-io/nats-server/v2/server.(*Server).enableJetStreamClustering()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:514 +0x20a
  github.com/nats-io/nats-server/v2/server.(*Server).enableJetStream()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:401 +0x1168
  github.com/nats-io/nats-server/v2/server.(*Server).EnableJetStream()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream.go:207 +0x651
  github.com/nats-io/nats-server/v2/server.(*Server).Start()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:1746 +0x1804
  github.com/nats-io/nats-server/v2/server.RunServer·dwrap·3827()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server_test.go:90 +0x39
==================
    testing.go:1152: race detected during execution of test
--- FAIL: TestJetStreamJWTClusteredDeleteTierWithStreamAndMove (6.31s)
```

Also fixed an MQTT flapper.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>