### PR TITLE
[FIXED] Fast routed JetStream API requests were dropped

### DIFF
--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -1100,16 +1100,6 @@ func (c *cluster) randomNonStreamLeader(account, stream string) *Server {
 	return nil
 }
 
-func (c *cluster) randomStreamNotAssigned(account, stream string) *Server {
-	c.t.Helper()
-	for _, s := range c.servers {
-		if !s.JetStreamIsStreamAssigned(account, stream) {
-			return s
-		}
-	}
-	return nil
-}
-
 func (c *cluster) streamLeader(account, stream string) *Server {
 	c.t.Helper()
 	for _, s := range c.servers {

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -3855,61 +3855,6 @@ func TestNoRaceJetStreamClusterStreamReset(t *testing.T) {
 	c.waitOnConsumerLeader("$G", "TEST", "d1")
 }
 
-// Issue #2644
-func TestNoRaceJetStreamPullConsumerAPIOutUnlock(t *testing.T) {
-	c := createJetStreamClusterExplicit(t, "R3S", 3)
-	defer c.shutdown()
-
-	// Client based API
-	nc, js := jsClientConnect(t, c.randomServer())
-	defer nc.Close()
-
-	_, err := js.AddStream(&nats.StreamConfig{
-		Name:      "TEST",
-		Subjects:  []string{"foo"},
-		Retention: nats.WorkQueuePolicy,
-	})
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	if _, err = js.PullSubscribe("foo", "dlc"); err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	for i := 0; i < 100; i++ {
-		if _, err := js.PublishAsync("foo", []byte("OK")); err != nil {
-			t.Fatalf("Unexpected publish error: %v", err)
-		}
-	}
-	select {
-	case <-js.PublishAsyncComplete():
-	case <-time.After(time.Second):
-		t.Fatalf("Did not receive completion signal")
-	}
-
-	// Force to go through route to use the Go routines, etc.
-	s := c.randomStreamNotAssigned("$G", "TEST")
-	if s == nil {
-		t.Fatalf("Did not get a server")
-	}
-
-	nc, _ = jsClientConnect(t, s)
-	defer nc.Close()
-
-	// Set this low to trigger error.
-	maxJSApiOut = 5
-	defer func() { maxJSApiOut = defaultMaxJSApiOut }()
-
-	nsubj := fmt.Sprintf(JSApiRequestNextT, "TEST", "dlc")
-	for i := 0; i < 500; i++ {
-		if err := nc.PublishRequest(nsubj, "bar", nil); err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-	}
-	nc.Flush()
-}
-
 // Reports of high cpu on compaction for a KV store.
 func TestNoRaceJetStreamKeyValueCompaction(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)

--- a/server/server.go
+++ b/server/server.go
@@ -285,6 +285,9 @@ type Server struct {
 
 	// Total outbound syncRequests
 	syncOutSem chan struct{}
+
+	// Queue to process JS API requests that come from routes (or gateways)
+	jsAPIRoutedReqs *ipQueue
 }
 
 // For tracking JS nodes.


### PR DESCRIPTION
If a JS API request is received from a non client connection, it
was processed in its own go routine. To reduce the number of
such go routine, we were limiting the number of outstanding routines
to 4096. However, in some situations, it was possible to issue
many requests at the same time that would then cause those requests
to be dropped.

(an example was an MQTT benchmark tool that would create 5000
sessions, each with one QoS1 R1 consumer (with the use of consumer_replicas=1).
On abrupt exit of the tool, the consumers and their sessions needed
to be deleted. Since would cause fast incoming delete consumer requests
which would cause the original code to drop some of them)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
