### PR TITLE
[FIXED] JetStream: consumer with deliver new may miss messages

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5446,6 +5446,26 @@ func (o *consumerFileStore) flushLoop() {
 	}
 }
 
+// SetStarting sets our starting stream sequence.
+func (o *consumerFileStore) SetStarting(sseq uint64) error {
+	o.mu.Lock()
+	o.state.Delivered.Stream = sseq
+	buf, err := o.encodeState()
+	o.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return o.writeState(buf)
+}
+
+// HasState returns if this store has a recorded state.
+func (o *consumerFileStore) HasState() bool {
+	o.mu.Lock()
+	_, err := os.Stat(o.ifn)
+	o.mu.Unlock()
+	return err == nil
+}
+
 // UpdateDelivered is called whenever a new message has been delivered.
 func (o *consumerFileStore) UpdateDelivered(dseq, sseq, dc uint64, ts int64) error {
 	o.mu.Lock()

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1272,7 +1272,7 @@ func (a *Account) EnableJetStream(limits map[string]JetStreamAccountLimits) erro
 			}
 			lseq := e.mset.lastSeq()
 			obs.mu.Lock()
-			_, err = obs.readStoredState(lseq)
+			err = obs.readStoredState(lseq)
 			obs.mu.Unlock()
 			if err != nil {
 				s.Warnf("    Error restoring consumer %q state: %v", cfg.Name, err)

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -31,11 +31,11 @@ import (
 
 func init() {
 	// Speed up raft for tests.
-	hbInterval = 200 * time.Millisecond
+	hbInterval = 50 * time.Millisecond
 	minElectionTimeout = 1 * time.Second
 	maxElectionTimeout = 3 * time.Second
 	lostQuorumInterval = time.Second
-	lostQuorumCheck = hbInterval
+	lostQuorumCheck = 4 * hbInterval
 }
 
 // Used to setup superclusters for tests.

--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -287,7 +287,7 @@ func TestJetStreamJWTMove(t *testing.T) {
 		require_NoError(t, err)
 		require_Equal(t, ci.Cluster.Name, "C1")
 
-		checkFor(t, 10*time.Second, 10*time.Millisecond, func() error {
+		checkFor(t, 15*time.Second, 50*time.Millisecond, func() error {
 			if si, err := js.StreamInfo("MOVE-ME"); err != nil {
 				return err
 			} else if si.Cluster.Name != "C2" {

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -1569,7 +1569,7 @@ func TestJetStreamSuperClusterConsumerDeliverNewBug(t *testing.T) {
 	require_NoError(t, err)
 
 	// Put messages in..
-	num := 200
+	num := 100
 	for i := 0; i < num; i++ {
 		js.PublishAsync("T", []byte("OK"))
 	}
@@ -1586,7 +1586,7 @@ func TestJetStreamSuperClusterConsumerDeliverNewBug(t *testing.T) {
 	})
 	require_NoError(t, err)
 
-	if ci.Delivered.Consumer != 0 || ci.Delivered.Stream != 200 {
+	if ci.Delivered.Consumer != 0 || ci.Delivered.Stream != 100 {
 		t.Fatalf("Incorrect consumer delivered info: %+v", ci.Delivered)
 	}
 
@@ -1603,7 +1603,7 @@ func TestJetStreamSuperClusterConsumerDeliverNewBug(t *testing.T) {
 	ci, err = js.ConsumerInfo("T", "d")
 	require_NoError(t, err)
 
-	if ci.Delivered.Consumer != 0 || ci.Delivered.Stream != 200 {
+	if ci.Delivered.Consumer != 0 || ci.Delivered.Stream != 100 {
 		t.Fatalf("Incorrect consumer delivered info: %+v", ci.Delivered)
 	}
 	if ci.NumPending != 0 {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -986,6 +986,19 @@ func (o *consumerMemStore) Update(state *ConsumerState) error {
 	return nil
 }
 
+// SetStarting sets our starting stream sequence.
+func (o *consumerMemStore) SetStarting(sseq uint64) error {
+	o.mu.Lock()
+	o.state.Delivered.Stream = sseq
+	o.mu.Unlock()
+	return nil
+}
+
+// HasState returns if this store has a recorded state.
+func (o *consumerMemStore) HasState() bool {
+	return false
+}
+
 func (o *consumerMemStore) UpdateDelivered(dseq, sseq, dc uint64, ts int64) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()

--- a/server/store.go
+++ b/server/store.go
@@ -170,6 +170,8 @@ type SnapshotResult struct {
 
 // ConsumerStore stores state on consumers for streams.
 type ConsumerStore interface {
+	SetStarting(sseq uint64) error
+	HasState() bool
 	UpdateDelivered(dseq, sseq, dc uint64, ts int64) error
 	UpdateAcks(dseq, sseq uint64) error
 	UpdateConfig(cfg *ConsumerConfig) error

--- a/server/stream.go
+++ b/server/stream.go
@@ -4307,7 +4307,7 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 			obs.setCreatedTime(cfg.Created)
 		}
 		obs.mu.Lock()
-		_, err = obs.readStoredState(lseq)
+		err = obs.readStoredState(lseq)
 		obs.mu.Unlock()
 		if err != nil {
 			mset.stop(true, false)


### PR DESCRIPTION
This could happen when a consumer had not sent anything to the
attached NATS subscription and there was a consumer leader
step down or server restart.

Stabilized code to set starting sequence numbers on true start versus recovered state.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
