### PR TITLE
Export the subject transformer

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -4225,6 +4225,20 @@ func placeHolderIndex(token string) ([]int, int32, error) {
 	return []int{-1}, -1, nil
 }
 
+// SubjectTransformer transforms subjects using mappings
+//
+// This API is not part of the public API and not subject to SemVer protections
+type SubjectTransformer interface {
+	TransformSubject(string) (string, error)
+}
+
+// NewSubjectTransformer creates a new SubjectTransformer
+//
+// This API is not part of the public API and not subject to SemVer protections
+func NewSubjectTransformer(src, dest string) (SubjectTransformer, error) {
+	return newTransform(src, dest)
+}
+
 // newTransform will create a new transform checking the src and dest subjects for accuracy.
 func newTransform(src, dest string) (*transform, error) {
 	// Both entries need to be valid subjects.
@@ -4305,8 +4319,10 @@ func (tr *transform) match(subject string) (string, error) {
 	return _EMPTY_, ErrNoTransforms
 }
 
-// Do not need to match, just transform.
-func (tr *transform) transformSubject(subject string) (string, error) {
+// TransformSubject do not need to match, just transform.
+//
+// This API is not part of the public API and not subject to SemVer protections
+func (tr *transform) TransformSubject(subject string) (string, error) {
 	// Tokenize the subject.
 	tsa := [32]string{}
 	tts := tsa[:0]

--- a/server/client.go
+++ b/server/client.go
@@ -2662,7 +2662,7 @@ func (c *client) addShadowSub(sub *subscription, ime *ime) (*subscription, error
 		if ime.overlapSubj != _EMPTY_ {
 			s = ime.overlapSubj
 		}
-		subj, err := im.rtr.transformSubject(s)
+		subj, err := im.rtr.TransformSubject(s)
 		if err != nil {
 			return nil, err
 		}
@@ -2943,7 +2943,7 @@ func (c *client) msgHeaderForRouteOrLeaf(subj, reply []byte, rt *routeTarget, ac
 		// Remap subject if its a shadow subscription, treat like a normal client.
 		if rt.sub.im != nil {
 			if rt.sub.im.tr != nil {
-				to, _ := rt.sub.im.tr.transformSubject(string(subj))
+				to, _ := rt.sub.im.tr.TransformSubject(string(subj))
 				subj = []byte(to)
 			} else if !rt.sub.im.usePub {
 				subj = []byte(rt.sub.im.to)
@@ -3894,7 +3894,7 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 
 	if si.tr != nil {
 		// FIXME(dlc) - This could be slow, may want to look at adding cache to bare transforms?
-		to, _ = si.tr.transformSubject(subject)
+		to, _ = si.tr.TransformSubject(subject)
 	} else if si.usePub {
 		to = subject
 	}
@@ -4138,7 +4138,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 				continue
 			}
 			if sub.im.tr != nil {
-				to, _ := sub.im.tr.transformSubject(string(subject))
+				to, _ := sub.im.tr.TransformSubject(string(subject))
 				dsubj = append(_dsubj[:0], to...)
 			} else if sub.im.usePub {
 				dsubj = append(_dsubj[:0], subj...)
@@ -4279,7 +4279,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 					continue
 				}
 				if sub.im.tr != nil {
-					to, _ := sub.im.tr.transformSubject(string(subject))
+					to, _ := sub.im.tr.TransformSubject(string(subject))
 					dsubj = append(_dsubj[:0], to...)
 				} else if sub.im.usePub {
 					dsubj = append(_dsubj[:0], subj...)

--- a/server/stream.go
+++ b/server/stream.go
@@ -3471,7 +3471,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 	var tsubj string
 	var tlseq uint64
 	if mset.tr != nil {
-		tsubj, _ = mset.tr.transformSubject(subject)
+		tsubj, _ = mset.tr.TransformSubject(subject)
 	}
 	republish := tsubj != _EMPTY_
 


### PR DESCRIPTION
This exports the one key function of the subject transformer
allowing external tools to be written to test mappings are
valid and see how they would interact without the hassle of
configuring a serrver

The APIs are specifically marked as being unsupported and
having kept the transform struct itself unexported one can
not cast from the interface to the real implementation

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
