### PR TITLE
[FIXED] Suppress some JetStream advisories

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2530,7 +2530,9 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, _ *Account, subje
 		Data:     sm.msg,
 		Time:     time.Unix(0, sm.ts).UTC(),
 	}
-	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+
+	// Don't send response through API layer for this call.
+	s.sendInternalAccountMsg(nil, reply, s.jsonResponse(resp))
 }
 
 // Request to purge a stream.

--- a/server/stream.go
+++ b/server/stream.go
@@ -1302,6 +1302,11 @@ func (jsa *jsAccount) configUpdateCheck(old, new *StreamConfig, s *Server) (*Str
 
 // Update will allow certain configuration properties of an existing stream to be updated.
 func (mset *stream) update(config *StreamConfig) error {
+	return mset.updateWithAdvisory(config, true)
+}
+
+// Update will allow certain configuration properties of an existing stream to be updated.
+func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) error {
 	mset.mu.RLock()
 	ocfg := mset.cfg
 	s := mset.srv
@@ -1395,7 +1400,7 @@ func (mset *stream) update(config *StreamConfig) error {
 	mset.cfg = *cfg
 
 	// If we are the leader never suppress update advisory, simply send.
-	if mset.isLeader() {
+	if mset.isLeader() && sendAdvisory {
 		mset.sendUpdateAdvisoryLocked()
 	}
 	mset.mu.Unlock()


### PR DESCRIPTION
Suppress consumer and stream advisories on server restart and any direct stream get message advisory.

Resolves #3155 

/cc @nats-io/core
