### PR TITLE
[IMPROVED] Loaded server and low on resources like FDs.

### DIFF
--- a/server/jetstream_errors.go
+++ b/server/jetstream_errors.go
@@ -28,7 +28,7 @@ func parseOpts(opts []ErrorOption) *errOpts {
 
 type ErrorIdentifier uint16
 
-// IsNatsErr determines if a error matches ID, if multiple IDs are given if the error matches any of these the function will be true
+// IsNatsErr determines if an error matches ID, if multiple IDs are given if the error matches any of these the function will be true
 func IsNatsErr(err error, ids ...ErrorIdentifier) bool {
 	if err == nil {
 		return false

--- a/server/raft.go
+++ b/server/raft.go
@@ -964,7 +964,8 @@ func (n *raft) InstallSnapshot(data []byte) error {
 
 	if err := ioutil.WriteFile(sfile, n.encodeSnapshot(snap), 0640); err != nil {
 		n.Unlock()
-		n.setWriteErr(err)
+		// We could set write err here, but if this is a temporary situation, too many open files etc.
+		// we want to retry and snapshots are not fatal.
 		return err
 	}
 
@@ -3244,7 +3245,7 @@ func (n *raft) readTermVote() (term uint64, voted string, err error) {
 // Lock should be held.
 func (n *raft) setWriteErrLocked(err error) {
 	// Ignore if already set.
-	if n.werr == err {
+	if n.werr == err || err == nil {
 		return
 	}
 	// Ignore non-write errors.

--- a/server/stream.go
+++ b/server/stream.go
@@ -456,7 +456,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 
 	if err := mset.setupStore(fsCfg); err != nil {
 		mset.stop(true, false)
-		return nil, err
+		return nil, NewJSStreamStoreFailedError(err)
 	}
 
 	// Create our pubAck template here. Better than json marshal each time on success.
@@ -4063,8 +4063,8 @@ func (mset *stream) removeConsumer(o *consumer) {
 
 // lookupConsumer will retrieve a consumer by name.
 func (mset *stream) lookupConsumer(name string) *consumer {
-	mset.mu.Lock()
-	defer mset.mu.Unlock()
+	mset.mu.RLock()
+	defer mset.mu.RUnlock()
 	return mset.consumers[name]
 }
 


### PR DESCRIPTION
This is to help improve when a server/system is under heavy load with low resources, CPU/MEM or FDs.
If the user wants to try to stabilize by deleting a stream possibly with lots of consumers.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #3167 

/cc @nats-io/core
