### PR TITLE
add global log to decoupling log from server

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -178,13 +178,7 @@ type Server struct {
 	cproto     int64     // number of clients supporting async INFO
 	configTime time.Time // last time config was loaded
 
-	logging struct {
-		sync.RWMutex
-		logger      Logger
-		trace       int32
-		debug       int32
-		traceSysAcc int32
-	}
+	logging Logging
 
 	clientConnectURLs []string
 


### PR DESCRIPTION
 - [X] Link to issue, e.g. `Resolves #3173 `
 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

### Changes proposed in this pull request:

 - Add global logger 

/cc @nats-io/core
