### PR TITLE
[ADD] account specific in/out msgs/bytes stats to CONNS

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -49,6 +49,7 @@ var maxSubLimitReportThreshold = defaultMaxSubLimitReportThreshold
 // Account are subject namespace definitions. By default no messages are shared between accounts.
 // You can share via Exports and Imports of Streams and Services.
 type Account struct {
+	stats
 	gwReplyMapping
 	Name         string
 	Nkey         string

--- a/server/client.go
+++ b/server/client.go
@@ -1522,7 +1522,9 @@ func (c *client) handleWriteTimeout(written, attempted int64, numChunks int) boo
 
 	// Slow consumer here..
 	atomic.AddInt64(&c.srv.slowConsumers, 1)
-	atomic.AddInt64(&c.acc.slowConsumers, 1)
+	if c.acc != nil {
+		atomic.AddInt64(&c.acc.slowConsumers, 1)
+	}
 	c.Noticef("Slow Consumer Detected: WriteDeadline of %v exceeded with %d chunks of %d total bytes.",
 		c.out.wdl, numChunks, attempted)
 
@@ -1985,7 +1987,9 @@ func (c *client) queueOutbound(data []byte) {
 		// checking current pb+len(data) and then add to pb.
 		c.out.pb -= int64(len(data))
 		atomic.AddInt64(&c.srv.slowConsumers, 1)
-		atomic.AddInt64(&c.acc.slowConsumers, 1)
+		if c.acc != nil {
+			atomic.AddInt64(&c.acc.slowConsumers, 1)
+		}
 		c.Noticef("Slow Consumer Detected: MaxPending of %d Exceeded", c.out.mp)
 		c.markConnAsClosed(SlowConsumerPendingBytes)
 		return
@@ -3184,8 +3188,10 @@ func (c *client) deliverMsg(sub *subscription, acc *Account, subject, reply, mh,
 	}
 
 	// We don't count internal deliveries so we update server statistics here.
-	atomic.AddInt64(&acc.outMsgs, 1)
-	atomic.AddInt64(&acc.outBytes, msgSize)
+	if acc != nil {
+		atomic.AddInt64(&acc.outMsgs, 1)
+		atomic.AddInt64(&acc.outBytes, msgSize)
+	}
 	atomic.AddInt64(&srv.outMsgs, 1)
 	atomic.AddInt64(&srv.outBytes, msgSize)
 

--- a/server/client.go
+++ b/server/client.go
@@ -1257,6 +1257,10 @@ func (c *client) readLoop(pre []byte) {
 		if c.in.msgs > 0 {
 			atomic.AddInt64(&c.inMsgs, int64(c.in.msgs))
 			atomic.AddInt64(&c.inBytes, int64(c.in.bytes))
+			if acc != nil {
+				atomic.AddInt64(&acc.inMsgs, int64(c.in.msgs))
+				atomic.AddInt64(&acc.inBytes, int64(c.in.bytes))
+			}
 			atomic.AddInt64(&s.inMsgs, int64(c.in.msgs))
 			atomic.AddInt64(&s.inBytes, int64(c.in.bytes))
 		}
@@ -1518,6 +1522,7 @@ func (c *client) handleWriteTimeout(written, attempted int64, numChunks int) boo
 
 	// Slow consumer here..
 	atomic.AddInt64(&c.srv.slowConsumers, 1)
+	atomic.AddInt64(&c.acc.slowConsumers, 1)
 	c.Noticef("Slow Consumer Detected: WriteDeadline of %v exceeded with %d chunks of %d total bytes.",
 		c.out.wdl, numChunks, attempted)
 
@@ -1980,6 +1985,7 @@ func (c *client) queueOutbound(data []byte) {
 		// checking current pb+len(data) and then add to pb.
 		c.out.pb -= int64(len(data))
 		atomic.AddInt64(&c.srv.slowConsumers, 1)
+		atomic.AddInt64(&c.acc.slowConsumers, 1)
 		c.Noticef("Slow Consumer Detected: MaxPending of %d Exceeded", c.out.mp)
 		c.markConnAsClosed(SlowConsumerPendingBytes)
 		return
@@ -3178,6 +3184,8 @@ func (c *client) deliverMsg(sub *subscription, acc *Account, subject, reply, mh,
 	}
 
 	// We don't count internal deliveries so we update server statistics here.
+	atomic.AddInt64(&acc.outMsgs, 1)
+	atomic.AddInt64(&acc.outBytes, msgSize)
 	atomic.AddInt64(&srv.outMsgs, 1)
 	atomic.AddInt64(&srv.outBytes, msgSize)
 

--- a/server/events.go
+++ b/server/events.go
@@ -138,11 +138,14 @@ const DisconnectEventMsgType = "io.nats.server.advisory.v1.client_disconnect"
 // updates in the absence of any changes.
 type AccountNumConns struct {
 	TypedEvent
-	Server     ServerInfo `json:"server"`
-	Account    string     `json:"acc"`
-	Conns      int        `json:"conns"`
-	LeafNodes  int        `json:"leafnodes"`
-	TotalConns int        `json:"total_conns"`
+	Server        ServerInfo `json:"server"`
+	Account       string     `json:"acc"`
+	Conns         int        `json:"conns"`
+	LeafNodes     int        `json:"leafnodes"`
+	TotalConns    int        `json:"total_conns"`
+	Sent          DataStats  `json:"sent"`
+	Received      DataStats  `json:"received"`
+	SlowConsumers int64      `json:"slow_consumers"`
 }
 
 const AccountNumConnsMsgType = "io.nats.server.advisory.v1.account_connections"
@@ -1644,6 +1647,7 @@ func (s *Server) sendAccConnsUpdate(a *Account, subj ...string) {
 	eid := s.nextEventID()
 	a.mu.Lock()
 	localConns := a.numLocalConnections()
+	leafConns := a.numLocalLeafNodes()
 	m := &AccountNumConns{
 		TypedEvent: TypedEvent{
 			Type: AccountNumConnsMsgType,
@@ -1652,8 +1656,15 @@ func (s *Server) sendAccConnsUpdate(a *Account, subj ...string) {
 		},
 		Account:    a.Name,
 		Conns:      localConns,
-		LeafNodes:  a.numLocalLeafNodes(),
-		TotalConns: localConns + a.numLocalLeafNodes(),
+		LeafNodes:  leafConns,
+		TotalConns: localConns + leafConns,
+		Received: DataStats{
+			Msgs:  atomic.LoadInt64(&a.inMsgs),
+			Bytes: atomic.LoadInt64(&a.inBytes)},
+		Sent: DataStats{
+			Msgs:  atomic.LoadInt64(&a.outMsgs),
+			Bytes: atomic.LoadInt64(&a.outBytes)},
+		SlowConsumers: atomic.LoadInt64(&a.slowConsumers),
 	}
 	// Set timer to fire again unless we are at zero.
 	if localConns == 0 {

--- a/server/reload.go
+++ b/server/reload.go
@@ -964,7 +964,7 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 		if optName != "accounts" && optName != "users" {
 			if changed := !reflect.DeepEqual(oldValue, newValue); !changed {
 				// Check to make sure we are running JetStream if we think we should be.
-				if strings.ToLower(field.Name) == "jetstream" && newValue.(bool) {
+				if optName == "jetstream" && newValue.(bool) {
 					if !jsEnabled {
 						diffOpts = append(diffOpts, &jetStreamOption{newValue: true})
 					}

--- a/server/reload.go
+++ b/server/reload.go
@@ -957,16 +957,19 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 			return nil, err
 		}
 
-		if changed := !reflect.DeepEqual(oldValue, newValue); !changed {
-			// Check to make sure we are running JetStream if we think we should be.
-			if strings.ToLower(field.Name) == "jetstream" && newValue.(bool) {
-				if !jsEnabled {
-					diffOpts = append(diffOpts, &jetStreamOption{newValue: true})
+		optName := strings.ToLower(field.Name)
+		if optName != "accounts" && optName != "users" {
+			if changed := !reflect.DeepEqual(oldValue, newValue); !changed {
+				// Check to make sure we are running JetStream if we think we should be.
+				if strings.ToLower(field.Name) == "jetstream" && newValue.(bool) {
+					if !jsEnabled {
+						diffOpts = append(diffOpts, &jetStreamOption{newValue: true})
+					}
 				}
+				continue
 			}
-			continue
 		}
-		switch optName := strings.ToLower(field.Name); optName {
+		switch optName {
 		case "traceverbose":
 			diffOpts = append(diffOpts, &traceVerboseOption{newValue: newValue.(bool)})
 		case "trace":

--- a/server/reload.go
+++ b/server/reload.go
@@ -958,6 +958,9 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 		}
 
 		optName := strings.ToLower(field.Name)
+		// accounts and users (referencing accounts) will always differ as accounts
+		// contain internal state, say locks etc..., so we don't bother here.
+		// This also avoids races with atomic stats counters
 		if optName != "accounts" && optName != "users" {
 			if changed := !reflect.DeepEqual(oldValue, newValue); !changed {
 				// Check to make sure we are running JetStream if we think we should be.


### PR DESCRIPTION
This subject $SYS.ACCOUNT.%s.SERVER.CONNS will now respond with account
specific datastats for Received and sent messages as well as number of slow
consumers for the account.

Signed-off-by: Matthias Hanel <mh@synadia.com>

Benchmarks ran are `PubSub` and `Pub0b_Payload` 3 times each.
Without then with this change.
The impact seems small enough to prefer the straight forward solution. 
If deemed not so, I can try to also delete the server counter and aggregate its value from account based ones.

First set of 3 is without this change.
```
> go test -v -vet=off -bench='PubSub$' -run=X
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats-server/v2/test
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark_____________PubSub
Benchmark_____________PubSub-16    	 5629795	       203.8 ns/op
Benchmark__DenyMsgNoWCPubSub
Benchmark__DenyMsgNoWCPubSub-16    	 5474841	       203.9 ns/op
Benchmark_DenyMsgYesWCPubSub
Benchmark_DenyMsgYesWCPubSub-16    	 5560723	       206.4 ns/op
PASS
ok  	github.com/nats-io/nats-server/v2/test	4.631s
> go test -v -vet=off -bench='PubSub$' -run=X
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats-server/v2/test
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark_____________PubSub
Benchmark_____________PubSub-16    	 5586711	       203.5 ns/op
Benchmark__DenyMsgNoWCPubSub
Benchmark__DenyMsgNoWCPubSub-16    	 5466132	       205.7 ns/op
Benchmark_DenyMsgYesWCPubSub
Benchmark_DenyMsgYesWCPubSub-16    	 5449238	       206.3 ns/op
PASS
ok  	github.com/nats-io/nats-server/v2/test	4.617s
> go test -v -vet=off -bench='PubSub$' -run=X
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats-server/v2/test
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark_____________PubSub
Benchmark_____________PubSub-16    	 5619054	       204.3 ns/op
Benchmark__DenyMsgNoWCPubSub
Benchmark__DenyMsgNoWCPubSub-16    	 5584328	       205.3 ns/op
Benchmark_DenyMsgYesWCPubSub
Benchmark_DenyMsgYesWCPubSub-16    	 5423282	       208.1 ns/op
PASS
ok  	github.com/nats-io/nats-server/v2/test	4.647s
> go test -v -vet=off -bench="Pub0b_Payload" -run=X
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats-server/v2/test
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark______Pub0b_Payload
Benchmark______Pub0b_Payload-16    	15054192	        67.94 ns/op	 161.91 MB/s
Benchmark__AuthPub0b_Payload
Benchmark__AuthPub0b_Payload-16    	 7577354	       149.2 ns/op	  73.72 MB/s
PASS
ok  	github.com/nats-io/nats-server/v2/test	2.818s
> go test -v -vet=off -bench="Pub0b_Payload" -run=X
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats-server/v2/test
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark______Pub0b_Payload
Benchmark______Pub0b_Payload-16    	15259664	        67.75 ns/op	 162.37 MB/s
Benchmark__AuthPub0b_Payload
Benchmark__AuthPub0b_Payload-16    	 7556667	       149.9 ns/op	  73.39 MB/s
PASS
ok  	github.com/nats-io/nats-server/v2/test	2.838s
> go test -v -vet=off -bench="Pub0b_Payload" -run=X
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats-server/v2/test
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark______Pub0b_Payload
Benchmark______Pub0b_Payload-16    	15028556	        68.19 ns/op	 161.31 MB/s
Benchmark__AuthPub0b_Payload
Benchmark__AuthPub0b_Payload-16    	 7491639	       149.5 ns/op	  73.56 MB/s
PASS
ok  	github.com/nats-io/nats-server/v2/test	2.814s
```

Second set of 3 is with this change.
```
> git stash apply
Auto-merging server/events_test.go
Auto-merging server/client.go
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   ../server/accounts.go
	modified:   ../server/client.go
	modified:   ../server/events.go
	modified:   ../server/events_test.go

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	../dist/
	../vendor/

no changes added to commit (use "git add" and/or "git commit -a")
> go test -v -vet=off -bench='PubSub$' -run=X
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats-server/v2/test
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark_____________PubSub
Benchmark_____________PubSub-16    	 5527941	       203.8 ns/op
Benchmark__DenyMsgNoWCPubSub
Benchmark__DenyMsgNoWCPubSub-16    	 5517493	       204.6 ns/op
Benchmark_DenyMsgYesWCPubSub
Benchmark_DenyMsgYesWCPubSub-16    	 5486712	       210.7 ns/op
PASS
ok  	github.com/nats-io/nats-server/v2/test	4.712s
> go test -v -vet=off -bench='PubSub$' -run=X
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats-server/v2/test
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark_____________PubSub
Benchmark_____________PubSub-16    	 5561923	       204.8 ns/op
Benchmark__DenyMsgNoWCPubSub
Benchmark__DenyMsgNoWCPubSub-16    	 5458404	       204.9 ns/op
Benchmark_DenyMsgYesWCPubSub
Benchmark_DenyMsgYesWCPubSub-16    	 5397844	       205.2 ns/op
PASS
ok  	github.com/nats-io/nats-server/v2/test	4.597s
> go test -v -vet=off -bench='PubSub$' -run=X
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats-server/v2/test
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark_____________PubSub
Benchmark_____________PubSub-16    	 5502734	       204.0 ns/op
Benchmark__DenyMsgNoWCPubSub
Benchmark__DenyMsgNoWCPubSub-16    	 5579556	       205.4 ns/op
Benchmark_DenyMsgYesWCPubSub
Benchmark_DenyMsgYesWCPubSub-16    	 5502544	       215.5 ns/op
PASS
ok  	github.com/nats-io/nats-server/v2/test	4.682s
> go test -v -vet=off -bench="Pub0b_Payload" -run=X
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats-server/v2/test
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark______Pub0b_Payload
Benchmark______Pub0b_Payload-16    	15086301	        67.56 ns/op	 162.83 MB/s
Benchmark__AuthPub0b_Payload
Benchmark__AuthPub0b_Payload-16    	 7361306	       148.4 ns/op	  74.13 MB/s
PASS
ok  	github.com/nats-io/nats-server/v2/test	2.779s
> go test -v -vet=off -bench="Pub0b_Payload" -run=X
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats-server/v2/test
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark______Pub0b_Payload
Benchmark______Pub0b_Payload-16    	15156819	        67.78 ns/op	 162.30 MB/s
Benchmark__AuthPub0b_Payload
Benchmark__AuthPub0b_Payload-16    	 7549778	       148.5 ns/op	  74.09 MB/s
PASS
ok  	github.com/nats-io/nats-server/v2/test	2.810s
> go test -v -vet=off -bench="Pub0b_Payload" -run=X
goos: darwin
goarch: amd64
pkg: github.com/nats-io/nats-server/v2/test
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark______Pub0b_Payload
Benchmark______Pub0b_Payload-16    	15042363	        67.78 ns/op	 162.28 MB/s
Benchmark__AuthPub0b_Payload
Benchmark__AuthPub0b_Payload-16    	 7392249	       149.7 ns/op	  73.48 MB/s
PASS
ok  	github.com/nats-io/nats-server/v2/test	2.797s
>
```