### PR TITLE
Allow for MQTT QoS-1 consumers to be auto cleaned up

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -3622,6 +3622,9 @@ func (sess *mqttSession) processJSConsumer(c *client, subject, sid string,
 		if r := opts.MQTT.ConsumerReplicas; r > 0 {
 			cc.Replicas = r
 		}
+		if opts.MQTT.ConsumerInactiveThreshold > 0 {
+			cc.InactiveThreshold = opts.MQTT.ConsumerInactiveThreshold
+		}
 		if err := sess.createConsumer(cc); err != nil {
 			c.Errorf("Unable to add JetStream consumer for subscription on %q: err=%v", subject, err)
 			return nil, nil, err

--- a/server/opts.go
+++ b/server/opts.go
@@ -431,6 +431,10 @@ type MQTTOpts struct {
 	// Note that existing consumers are not modified.
 	ConsumerMemoryStorage bool
 
+	// If specified will have the system auto-cleanup the consumers after being
+	// inactive for the specified amount of time.
+	ConsumerInactiveThreshold time.Duration
+
 	// Timeout for the authentication process.
 	AuthTimeout float64
 
@@ -4191,6 +4195,9 @@ func parseMQTT(v interface{}, o *Options, errors *[]error, warnings *[]error) er
 			o.MQTT.ConsumerReplicas = int(mv.(int64))
 		case "consumer_memory_storage":
 			o.MQTT.ConsumerMemoryStorage = mv.(bool)
+		case "consumer_inactive_threshold", "consumer_auto_cleanup":
+			o.MQTT.ConsumerInactiveThreshold = parseDuration("consumer_inactive_threshold", tk, mv, errors, warnings)
+
 		default:
 			if !tk.IsUsedVariable() {
 				err := &unknownConfigFieldErr{


### PR DESCRIPTION
A server can configure the mqtt section to designate orphaned inactive consumers for auto cleanup.
Several users have reported a buildup of orphaned consumers from MQTT software they can not change or update.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
