### PR TITLE
Default to essential ClientInfo for JetStream

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1812,19 +1812,7 @@ func (a *Account) addServiceImport(dest *Account, from, to string, claim *jwt.Im
 		rt = se.respType
 		lat = se.latency
 	}
-	s := dest.srv
 	dest.mu.RUnlock()
-
-	// Track if this maps us to the system account.
-	// We will always share information with them.
-	var isSysAcc bool
-	if s != nil {
-		s.mu.Lock()
-		if s.sys != nil && dest == s.sys.account {
-			isSysAcc = true
-		}
-		s.mu.Unlock()
-	}
 
 	a.mu.Lock()
 	if a.imports.services == nil {
@@ -1862,8 +1850,7 @@ func (a *Account) addServiceImport(dest *Account, from, to string, claim *jwt.Im
 			}
 		}
 	}
-	// Turn on sharing by default if importing from system services.
-	share := isSysAcc
+	var share bool
 	if claim != nil {
 		share = claim.Share
 	}

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1963,6 +1963,7 @@ func (o *consumer) readStoredState(slseq uint64) error {
 }
 
 // Apply the consumer stored state.
+// Lock should be held.
 func (o *consumer) applyState(state *ConsumerState) {
 	if state == nil {
 		return
@@ -1993,6 +1994,7 @@ func (o *consumer) applyState(state *ConsumerState) {
 }
 
 // Sets our store state from another source. Used in clustered mode on snapshot restore.
+// Lock should be held.
 func (o *consumer) setStoreState(state *ConsumerState) error {
 	if state == nil || o.store == nil {
 		return nil

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3246,7 +3246,9 @@ func (js *jetStream) processClusterCreateConsumer(ca *consumerAssignment, state 
 
 	// If we have an initial state set apply that now.
 	if state != nil && o != nil {
+		o.mu.Lock()
 		err = o.setStoreState(state)
+		o.mu.Unlock()
 	}
 	if err != nil {
 		if IsNatsErr(err, JSConsumerStoreFailedErrF) {


### PR DESCRIPTION
We did default to full sharing for an export from the system account, the main one being JetStream. 

As part of this process moved server to RW lock.

Was also going to replace json encoder/decoder but I ran several experiments with my top choices and results are not what I wanted them to be. We should do custom marshallers in a follow up PR.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
