### PR TITLE
[Fixed] race on unlocked cfg access

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1844,7 +1844,9 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 			if len(ci.Replicas)+1 != len(rg.Peers) {
 				continue
 			}
+			mset.mu.RLock()
 			replicas := mset.cfg.Replicas
+			mset.mu.RUnlock()
 			if len(rg.Peers) <= replicas {
 				stopMigrationMonitoring()
 				continue
@@ -1874,7 +1876,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 				}
 			}
 			// If all are current we are good, or if we have some offline and we have a quorum.
-			if quorum := mset.cfg.Replicas/2 + 1; currentCount >= quorum {
+			if quorum := replicas/2 + 1; currentCount >= quorum {
 				stopMigrationMonitoring()
 				// Remove the old peers and transfer leadership.
 				time.AfterFunc(2*time.Second, func() { js.removeOldPeers(mset, firstPeer, newPeerSet) })


### PR DESCRIPTION
write originated in updateWithAdvisory while holding the lock

Signed-off-by: Matthias Hanel <mh@synadia.com>


```
WARNING: DATA RACE
Write at 0x00c0029c23f8 by goroutine 170:
  github.com/nats-io/nats-server/v2/server.(*stream).updateWithAdvisory()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/stream.go:1413 +0x63d
  github.com/nats-io/nats-server/v2/server.(*jetStream).processClusterCreateStream()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:2775 +0x4a4
  github.com/nats-io/nats-server/v2/server.(*jetStream).processStreamAssignment()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:2523 +0xaf9
  github.com/nats-io/nats-server/v2/server.(*jetStream).applyMetaEntries()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:1444 +0x7dc
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:925 +0xbf0
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster-fm()
      <autogenerated>:1 +0x39
Previous read at 0x00c0029c23f8 by goroutine 179:
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorStream()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:1847 +0x13a8
  github.com/nats-io/nats-server/v2/server.(*jetStream).processClusterCreateStream.func1()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:2829 +0x5d

```