### PR TITLE
Rework startupComplete gate from PR #2360

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -6140,6 +6140,8 @@ func TestJetStreamClusterDomains(t *testing.T) {
 		strings.ReplaceAll(jsClusterTemplWithSingleLeafNode, "store_dir:", "extension_hint: will_extend, domain: CORE, store_dir:"))
 	defer ln.Shutdown()
 
+	checkLeafNodeConnectedCount(t, ln, 2)
+
 	// This shows we have extended this system.
 	c.waitOnPeerCount(4)
 	if ml := c.leader(); ml == ln {
@@ -6150,6 +6152,8 @@ func TestJetStreamClusterDomains(t *testing.T) {
 	tmpl = strings.Replace(jsClusterTemplWithSingleLeafNode, "store_dir:", "domain: SPOKE, store_dir:", 1)
 	spoke := c.createLeafNodeWithTemplate("LN-SPOKE", tmpl)
 	defer spoke.Shutdown()
+
+	checkLeafNodeConnectedCount(t, spoke, 2)
 
 	// Should be the same, should not extend the CORE domain.
 	c.waitOnPeerCount(4)
@@ -6642,6 +6646,8 @@ func TestJetStreamClusterLeafNodesWithoutJS(t *testing.T) {
 
 	ln := c.createLeafNodeWithTemplate("LN-SYS-S-NOJS", jsClusterTemplWithSingleLeafNodeNoJS)
 	defer ln.Shutdown()
+
+	checkLeafNodeConnectedCount(t, ln, 2)
 
 	// Check that we can access JS in the $G account on the cluster through the leafnode.
 	testJS(ln, "HUB", true)

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -3017,7 +3017,7 @@ func TestMQTTClusterReplicasCount(t *testing.T) {
 				s = cl.randomServer()
 			}
 
-			mc, rc := testMQTTConnect(t, &mqttConnInfo{clientID: "sub", cleanSess: false}, o.MQTT.Host, o.MQTT.Port)
+			mc, rc := testMQTTConnectRetry(t, &mqttConnInfo{clientID: "sub", cleanSess: false}, o.MQTT.Host, o.MQTT.Port, 5)
 			defer mc.Close()
 			testMQTTCheckConnAck(t, rc, mqttConnAckRCConnectionAccepted, false)
 			testMQTTSub(t, 1, mc, rc, []*mqttFilter{{filter: "foo/#", qos: 1}}, []byte{1})


### PR DESCRIPTION
The "InProcess" change make readyForConnections() possibly return
much faster than it used to, which could cause tests to fail.

Restore the original behavior, but in case of DontListen option
wait on the startupComplete gate.

Also fixed some missing checks for leafnode connections.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>