### PR TITLE
Direct stream access enhancements

### DIFF
--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -1257,11 +1257,13 @@ func (c *cluster) waitOnClusterReadyWithNumPeers(numPeersExpected int) {
 	}
 
 	if leader == nil {
+		c.shutdown()
 		c.t.Fatalf("Failed to elect a meta-leader")
 	}
 
 	peersSeen := len(leader.JetStreamClusterPeers())
 	c.shutdown()
+
 	if leader == nil {
 		c.t.Fatalf("Expected a cluster leader and fully formed cluster, no leader")
 	} else {

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -2536,7 +2536,16 @@ func TestJetStreamSuperClusterStreamDirectGetMirrorQueueGroup(t *testing.T) {
 	}
 	addStream(t, nc, cfg)
 
-	// Since last one was an R3, check and wait for subscription.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("M2")
+		require_NoError(t, err)
+		if si.State.Msgs != uint64(num) {
+			return fmt.Errorf("Expected %d msgs, got state: %d", num, si.State.Msgs)
+		}
+		return nil
+	})
+
+	// Since last one was an R3, check and wait for the direct subscription.
 	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
 		sl := sc.clusterForName("C3").streamLeader("$G", "M2")
 		if mset, err := sl.GlobalAccount().lookupStream("M2"); err == nil {

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -3984,17 +3984,10 @@ func TestMonitorAuthorizedUsers(t *testing.T) {
 // Helper function to check that a JS cluster is formed
 func checkForJSClusterUp(t *testing.T, servers ...*Server) {
 	t.Helper()
-	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
-		for _, s := range servers {
-			if !s.JetStreamEnabled() {
-				return fmt.Errorf("jetstream not enabled")
-			}
-			if !s.JetStreamIsCurrent() {
-				return fmt.Errorf("jetstream not current")
-			}
-		}
-		return nil
-	})
+	// We will use the other JetStream helpers here.
+	c := &cluster{t: t, servers: servers}
+	c.checkClusterFormed()
+	c.waitOnClusterReady()
 }
 
 func TestMonitorJszNonJszServer(t *testing.T) {

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -3167,8 +3167,10 @@ func TestMQTTLeafnodeWithoutJSToClusterWithJSNoSharedSysAcc(t *testing.T) {
 			for _, s := range cluster {
 				if s.JetStreamIsLeader() {
 					// Need to wait for usage updates now to propagate to meta leader.
-					time.Sleep(250 * time.Millisecond)
-					return nil
+					if len(s.JetStreamClusterPeers()) == len(cluster) {
+						time.Sleep(100 * time.Millisecond)
+						return nil
+					}
 				}
 			}
 			return fmt.Errorf("no leader yet")

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -5309,7 +5309,7 @@ func TestNoRaceJetStreamClusterDirectAccessAllPeersSubs(t *testing.T) {
 	for _, s := range c.servers {
 		mset, err := s.GlobalAccount().lookupStream("TEST")
 		require_NoError(t, err)
-		checkFor(t, 5*time.Second, 500*time.Millisecond, func() error {
+		checkFor(t, 10*time.Second, 500*time.Millisecond, func() error {
 			mset.mu.RLock()
 			ok := mset.directSub != nil
 			mset.mu.RUnlock()


### PR DESCRIPTION
As direct access becomes more important through materialized views like KeyValue, and having alternatives to a full blown JetStream consumers is important in future hybrid architectures, this PR introduces two enhancements.

Both of these are opt in and will be easily identified by clients.

1. DirectAccess now uses a queue group and the system allows non-leader replicas to participate.
2. Mirrors can now optionally be a part of the origin's group.

So for the second, this could allow a KV store with multiple mirrors to have a single subject to retrieve a message that operates in a single queue group. Since these are cluster aware, meaning we prefer the ones closer first and only move to a nearby cluster when no interest exists, adding a stream mirror when a large amount of traffic is direct retrieval, like geo diverse KVs, this would instantly improve latency and scale.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
