### PR TITLE
Make pull consumers FIFO per message, not per request.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2467,12 +2467,19 @@ func (wq *waitQueue) peek() *waitingRequest {
 }
 
 // pop will return the next request and move the read cursor.
+// This will now place a request that still has pending items at the ends of the list.
 func (wq *waitQueue) pop() *waitingRequest {
 	wr := wq.peek()
 	if wr != nil {
 		wr.d++
 		wr.n--
-		if wr.n <= 0 {
+
+		// Always remove current now on a pop, and move to end if still valid.
+		// If we were the only one don't need to remove since this can be a no-op.
+		if wr.n > 0 && wq.n > 1 {
+			wq.removeCurrent()
+			wq.add(wr)
+		} else if wr.n <= 0 {
 			wq.removeCurrent()
 		}
 	}

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3052,6 +3052,10 @@ func (o *consumer) loopAndGatherMsgs(qch chan struct{}) {
 
 		// On error either wait or return.
 		if err != nil || pmsg == nil {
+			// If we are stalled here in pull mode, invalidate all requests that have had deliveries.
+			if err == errMaxAckPending && o.isPullMode() {
+				o.processWaiting(true)
+			}
 			if err == ErrStoreMsgNotFound || err == ErrStoreEOF || err == errMaxAckPending || err == errPartialCache {
 				goto waitForMsgs
 			} else {


### PR DESCRIPTION
This effectively means that requests with batch > 1 will process a message and go to the end of the line.

Signed-off-by: Derek Collison <derek@nats.io>

Ivan, this was considered incorrect behavior hence no option etc.

/cc @nats-io/core
