### PR TITLE
[ADDED] Symlink for deb/rpm packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,6 +52,10 @@ nfpms:
     formats:
     - deb
     - rpm
+    contents:
+    - src: /usr/bin/nats-server
+      dst: /usr/local/bin/nats-server
+      type: "symlink"
 
 archives:
   - name_template: '{{.ProjectName}}-{{.Tag}}-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}'


### PR DESCRIPTION
Since v2.7.4 and due to an update of the goreleaser tool, the
server is now installed under "/usr/bin" instead of "/usr/local/bin".

We keep the install in "/usr/bin" but this PR adds symlink so that
"/usr/local/bin" still points to the nats-server.

Resolves #3239

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
