### PR TITLE
Direct access to JetStream resources when a leafnode connection is down.

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -79,6 +79,9 @@ var (
 	// and it has the same cluster name as the hub cluster.
 	ErrLeafNodeHasSameClusterName = errors.New("remote leafnode has same cluster name")
 
+	// ErrLeafNodeDisabled is when we disable leafnodes.
+	ErrLeafNodeDisabled = errors.New("leafnodes disabled")
+
 	// ErrConnectedToWrongPort represents an error condition when a connection is attempted
 	// to the wrong listen port (for instance a LeafNode to a client port, etc...)
 	ErrConnectedToWrongPort = errors.New("attempted to connect to wrong port")

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -924,6 +924,31 @@ func (c *cluster) createLeafNodesWithTemplateAndStartPort(template, clusterName 
 	return lc
 }
 
+// Helper function to close and disable leafnodes.
+func (s *Server) closeAndDisableLeafnodes() {
+	var leafs []*client
+	s.mu.Lock()
+	for _, ln := range s.leafs {
+		leafs = append(leafs, ln)
+	}
+	// Disable leafnodes for now.
+	s.leafNodeEnabled = false
+	s.mu.Unlock()
+
+	for _, ln := range leafs {
+		ln.closeConnection(Revocation)
+	}
+}
+
+// Helper to set the remote migrate feature.
+func (s *Server) setJetStreamMigrateOnRemoteLeaf() {
+	s.mu.Lock()
+	for _, cfg := range s.leafRemoteCfgs {
+		cfg.JetStreamClusterMigrate = true
+	}
+	s.mu.Unlock()
+}
+
 // Will add in the mapping for the account to each server.
 func (c *cluster) addSubjectMapping(account, src, dest string) {
 	c.t.Helper()

--- a/server/opts.go
+++ b/server/opts.go
@@ -182,6 +182,12 @@ type RemoteLeafOpts struct {
 	}
 
 	tlsConfigOpts *TLSConfigOpts
+
+	// If we are clustered and our local account has JetStream, if apps are accessing
+	// a stream or consumer leader through this LN and it gets dropped, the apps will
+	// not be able to work. This tells the system to migrate the leaders away from this server.
+	// This only changes leader for R>1 assets.
+	JetStreamClusterMigrate bool `json:"jetstream_cluster_migrate,omitempty"`
 }
 
 type JSLimitOpts struct {
@@ -2252,6 +2258,8 @@ func parseRemoteLeafNodes(v interface{}, errors *[]error, warnings *[]error) ([]
 				remote.Websocket.Compression = v.(bool)
 			case "ws_no_masking", "websocket_no_masking":
 				remote.Websocket.NoMasking = v.(bool)
+			case "jetstream_cluster_migrate", "js_cluster_migrate":
+				remote.JetStreamClusterMigrate = true
 			default:
 				if !tk.IsUsedVariable() {
 					err := &unknownConfigFieldErr{


### PR DESCRIPTION
This allows a soliciting leafnode config to ask that any JetStream cluster assets that are a current leader have the leader stepdown. This will allow a new leader to take over and service direct access.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #3178 

/cc @nats-io/core
