### PR TITLE
[Added] account specific monitoring endpoint(s)

### DIFF
--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1239,14 +1239,15 @@ func TestAccountReqMonitoring(t *testing.T) {
 	sacc, sakp := createAccount(s)
 	s.setSystemAccount(sacc)
 	s.EnableJetStream(nil)
+	unusedAcc, _ := createAccount(s)
 	acc, akp := createAccount(s)
-	if acc == nil {
-		t.Fatalf("did not create account")
-	}
 	acc.EnableJetStream(nil)
-	subsz := fmt.Sprintf(accReqSubj, acc.Name, "SUBSZ")
-	connz := fmt.Sprintf(accReqSubj, acc.Name, "CONNZ")
-	jsz := fmt.Sprintf(accReqSubj, acc.Name, "JSZ")
+	subsz := fmt.Sprintf(accDirectReqSubj, acc.Name, "SUBSZ")
+	connz := fmt.Sprintf(accDirectReqSubj, acc.Name, "CONNZ")
+	jsz := fmt.Sprintf(accDirectReqSubj, acc.Name, "JSZ")
+
+	pStatz := fmt.Sprintf(accPingReqSubj, "STATZ")
+	statz := func(name string) string { return fmt.Sprintf(accDirectReqSubj, name, "STATZ") }
 	// Create system account connection to query
 	url := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
 	ncSys, err := nats.Connect(url, createUserCreds(t, s, sakp))
@@ -1261,42 +1262,88 @@ func TestAccountReqMonitoring(t *testing.T) {
 	}
 	defer nc.Close()
 	// query SUBSZ for account
-	if resp, err := ncSys.Request(subsz, nil, time.Second); err != nil {
-		t.Fatalf("Error on request: %v", err)
-	} else if !strings.Contains(string(resp.Data), `"num_subscriptions":3,`) {
-		t.Fatalf("unexpected subs count (expected 3): %v", string(resp.Data))
-	}
+	resp, err := ncSys.Request(subsz, nil, time.Second)
+	require_NoError(t, err)
+	require_Contains(t, string(resp.Data), `"num_subscriptions":4,`)
 	// create a subscription
-	if sub, err := nc.Subscribe("foo", func(msg *nats.Msg) {}); err != nil {
-		t.Fatalf("error on subscribe %v", err)
-	} else {
-		defer sub.Unsubscribe()
-	}
-	nc.Flush()
+	sub, err := nc.Subscribe("foo", func(msg *nats.Msg) {})
+	require_NoError(t, err)
+	defer sub.Unsubscribe()
+
+	require_NoError(t, nc.Flush())
 	// query SUBSZ for account
-	if resp, err := ncSys.Request(subsz, nil, time.Second); err != nil {
-		t.Fatalf("Error on request: %v", err)
-	} else if !strings.Contains(string(resp.Data), `"num_subscriptions":4,`) {
-		t.Fatalf("unexpected subs count (expected 4): %v", string(resp.Data))
-	} else if !strings.Contains(string(resp.Data), `"subject":"foo"`) {
-		t.Fatalf("expected subscription foo: %v", string(resp.Data))
-	}
+	resp, err = ncSys.Request(subsz, nil, time.Second)
+	require_NoError(t, err)
+	require_Contains(t, string(resp.Data), `"num_subscriptions":5,`, `"subject":"foo"`)
 	// query connections for account
-	if resp, err := ncSys.Request(connz, nil, time.Second); err != nil {
-		t.Fatalf("Error on request: %v", err)
-	} else if !strings.Contains(string(resp.Data), `"num_connections":1,`) {
-		t.Fatalf("unexpected subs count (expected 1): %v", string(resp.Data))
-	} else if !strings.Contains(string(resp.Data), `"total":1,`) {
-		t.Fatalf("unexpected subs count (expected 1): %v", string(resp.Data))
-	}
+	resp, err = ncSys.Request(connz, nil, time.Second)
+	require_NoError(t, err)
+	require_Contains(t, string(resp.Data), `"num_connections":1,`, `"total":1,`)
 	// query connections for js account
-	if resp, err := ncSys.Request(jsz, nil, time.Second); err != nil {
-		t.Fatalf("Error on request: %v", err)
-	} else if !strings.Contains(string(resp.Data), `"memory":0,`) {
-		t.Fatalf("jetstream should be enabled but empty: %v", string(resp.Data))
-	} else if !strings.Contains(string(resp.Data), `"storage":0,`) {
-		t.Fatalf("jetstream should be enabled but empty: %v", string(resp.Data))
+	resp, err = ncSys.Request(jsz, nil, time.Second)
+	require_NoError(t, err)
+	require_Contains(t, string(resp.Data), `"memory":0,`, `"storage":0,`)
+	// query statz/conns for account
+	resp, err = ncSys.Request(statz(acc.Name), nil, time.Second)
+	require_NoError(t, err)
+	respContentAcc := []string{`"conns":1,`, `"total_conns":1`, `"slow_consumers":0`, `"sent":{"msgs":0,"bytes":0}`,
+		`"received":{"msgs":0,"bytes":0}`, fmt.Sprintf(`"acc":"%s"`, acc.Name)}
+	require_Contains(t, string(resp.Data), respContentAcc...)
+
+	rIb := ncSys.NewRespInbox()
+	rSub, err := ncSys.SubscribeSync(rIb)
+	require_NoError(t, err)
+	require_NoError(t, ncSys.PublishRequest(pStatz, rIb, nil))
+	minRespContentForBothAcc := []string{`"conns":1,`, `"total_conns":1`, `"slow_consumers":0`, `"acc":"`}
+	// expect one response per account
+	for i := 0; i < 2; i++ {
+		m, err := rSub.NextMsg(time.Second)
+		require_NoError(t, err)
+		// due to ordering skip check for sent/received etc..
+		require_Contains(t, string(m.Data), minRespContentForBothAcc...)
 	}
+
+	// Test ping with filter by account name
+	require_NoError(t, ncSys.PublishRequest(pStatz, rIb, []byte(fmt.Sprintf(`{"accounts":["%s"]}`, sacc.Name))))
+	m, err := rSub.NextMsg(time.Second)
+	require_NoError(t, err)
+	require_Contains(t, string(m.Data), minRespContentForBothAcc...)
+
+	require_NoError(t, ncSys.PublishRequest(pStatz, rIb, []byte(fmt.Sprintf(`{"accounts":["%s"]}`, acc.Name))))
+	m, err = rSub.NextMsg(time.Second)
+	require_NoError(t, err)
+	require_Contains(t, string(m.Data), respContentAcc...)
+
+	// Test include unused for statz and ping of statz
+	unusedContent := []string{`"conns":0,`, `"total_conns":0`, `"slow_consumers":0`,
+		fmt.Sprintf(`"acc":"%s"`, unusedAcc.Name)}
+
+	resp, err = ncSys.Request(statz(unusedAcc.Name),
+		[]byte(fmt.Sprintf(`{"accounts":["%s"], "include_unused":true}`, unusedAcc.Name)),
+		time.Second)
+	require_NoError(t, err)
+	require_Contains(t, string(resp.Data), unusedContent...)
+
+	require_NoError(t, ncSys.PublishRequest(pStatz, rIb,
+		[]byte(fmt.Sprintf(`{"accounts":["%s"], "include_unused":true}`, unusedAcc.Name))))
+	m, err = rSub.NextMsg(time.Second)
+	require_NoError(t, err)
+	require_Contains(t, string(m.Data), unusedContent...)
+
+	require_NoError(t, ncSys.PublishRequest(pStatz, rIb, []byte(fmt.Sprintf(`{"accounts":["%s"]}`, unusedAcc.Name))))
+	_, err = rSub.NextMsg(200 * time.Millisecond)
+	require_Error(t, err)
+
+	// Test ping from within account
+	ib := nc.NewRespInbox()
+	rSub, err = nc.SubscribeSync(ib)
+	require_NoError(t, err)
+	require_NoError(t, nc.PublishRequest(pStatz, ib, nil))
+	resp, err = rSub.NextMsg(time.Second)
+	require_NoError(t, err)
+	require_Contains(t, string(resp.Data), respContentAcc...)
+	_, err = rSub.NextMsg(200 * time.Millisecond)
+	require_Error(t, err)
 }
 
 func TestAccountReqInfo(t *testing.T) {
@@ -1312,7 +1359,7 @@ func TestAccountReqInfo(t *testing.T) {
 	ajwt1, _ := nac1.Encode(oKp)
 	addAccountToMemResolver(s, pub1, ajwt1)
 	s.LookupAccount(pub1)
-	info1 := fmt.Sprintf(accReqSubj, pub1, "INFO")
+	info1 := fmt.Sprintf(accDirectReqSubj, pub1, "INFO")
 	// Now add an account with service imports.
 	akp2, _ := nkeys.CreateAccount()
 	pub2, _ := akp2.PublicKey()
@@ -1321,7 +1368,7 @@ func TestAccountReqInfo(t *testing.T) {
 	ajwt2, _ := nac2.Encode(oKp)
 	addAccountToMemResolver(s, pub2, ajwt2)
 	s.LookupAccount(pub2)
-	info2 := fmt.Sprintf(accReqSubj, pub2, "INFO")
+	info2 := fmt.Sprintf(accDirectReqSubj, pub2, "INFO")
 	// Create system account connection to query
 	url := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
 	ncSys, err := nats.Connect(url, createUserCreds(t, s, sakp))
@@ -1369,7 +1416,7 @@ func TestAccountReqInfo(t *testing.T) {
 		t.Fatalf("Unmarshalling failed: %v", err)
 	} else if len(info.Exports) != 1 {
 		t.Fatalf("Unexpected value: %v", info.Exports)
-	} else if len(info.Imports) != 2 {
+	} else if len(info.Imports) != 3 {
 		t.Fatalf("Unexpected value: %+v", info.Imports)
 	} else if info.Exports[0].Subject != "req.*" {
 		t.Fatalf("Unexpected value: %v", info.Exports)
@@ -1377,7 +1424,7 @@ func TestAccountReqInfo(t *testing.T) {
 		t.Fatalf("Unexpected value: %v", info.Exports)
 	} else if info.Exports[0].ResponseType != jwt.ResponseTypeSingleton {
 		t.Fatalf("Unexpected value: %v", info.Exports)
-	} else if info.SubCnt != 2 {
+	} else if info.SubCnt != 3 {
 		t.Fatalf("Unexpected value: %v", info.SubCnt)
 	} else {
 		checkCommon(&info, &srv, pub1, ajwt1)
@@ -1390,7 +1437,7 @@ func TestAccountReqInfo(t *testing.T) {
 		t.Fatalf("Unmarshalling failed: %v", err)
 	} else if len(info.Exports) != 0 {
 		t.Fatalf("Unexpected value: %v", info.Exports)
-	} else if len(info.Imports) != 3 {
+	} else if len(info.Imports) != 4 {
 		t.Fatalf("Unexpected value: %+v", info.Imports)
 	}
 	// Here we need to find our import
@@ -1408,7 +1455,7 @@ func TestAccountReqInfo(t *testing.T) {
 		t.Fatalf("Unexpected value: %+v", si)
 	} else if si.Account != pub1 {
 		t.Fatalf("Unexpected value: %+v", si)
-	} else if info.SubCnt != 3 {
+	} else if info.SubCnt != 4 {
 		t.Fatalf("Unexpected value: %+v", si)
 	} else {
 		checkCommon(&info, &srv, pub2, ajwt2)
@@ -1611,7 +1658,7 @@ func TestSystemAccountWithGateways(t *testing.T) {
 
 	// If this tests fails with wrong number after 10 seconds we may have
 	// added a new inititial subscription for the eventing system.
-	checkExpectedSubs(t, 40, sa)
+	checkExpectedSubs(t, 47, sa)
 
 	// Create a client on B and see if we receive the event
 	urlb := fmt.Sprintf("nats://%s:%d", ob.Host, ob.Port)
@@ -2108,6 +2155,8 @@ func TestServerEventsPingMonitorz(t *testing.T) {
 			[]string{"now", "leafs"}},
 		{"ACCOUNTZ", &AccountzOptions{Account: sysAcc}, &Accountz{},
 			[]string{"now", "account_detail"}},
+		{"ACC_STATZ", &AccountStatzOptions{Accounts: []string{sysAcc}}, &Accountz{},
+			[]string{"now", "account_statz"}},
 		{"LEAFZ", &LeafzOptions{Account: sysAcc}, &Leafz{},
 			[]string{"now", "leafs"}},
 
@@ -2123,6 +2172,8 @@ func TestServerEventsPingMonitorz(t *testing.T) {
 			[]string{"now", "routes"}},
 
 		{"JSZ", nil, &JSzOptions{}, []string{"now", "disabled"}},
+
+		{"HEALTHZ", nil, &JSzOptions{}, []string{"status"}},
 	}
 
 	for i, test := range tests {

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -3948,7 +3948,7 @@ func TestJetStreamClusterPeerEvacuationAndStreamReassignment(t *testing.T) {
 			})
 		}
 		// Now wait until the stream is now current.
-		checkFor(t, 20*time.Second, 100*time.Millisecond, func() error {
+		checkFor(t, 50*time.Second, 100*time.Millisecond, func() error {
 			si, err := js.StreamInfo("TEST", nats.MaxWait(time.Second))
 			if err != nil {
 				return fmt.Errorf("could not fetch stream info: %v", err)

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -516,7 +516,7 @@ func TestJetStreamSuperClusterConnectionCount(t *testing.T) {
 
 	sysNc := natsConnect(t, sc.randomServer().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
 	defer sysNc.Close()
-	_, err := sysNc.Request(fmt.Sprintf(accReqSubj, "ONE", "CONNS"), nil, 100*time.Millisecond)
+	_, err := sysNc.Request(fmt.Sprintf(accDirectReqSubj, "ONE", "CONNS"), nil, 100*time.Millisecond)
 	// this is a timeout as the server only responds when it has connections....
 	// not convinced this should be that way, but also not the issue to investigate.
 	require_True(t, err == nats.ErrTimeout)
@@ -561,7 +561,7 @@ func TestJetStreamSuperClusterConnectionCount(t *testing.T) {
 	// There should be no active NATS CLIENT connections, but we still need
 	// to wait a little bit...
 	checkFor(t, 2*time.Second, 15*time.Millisecond, func() error {
-		_, err := sysNc.Request(fmt.Sprintf(accReqSubj, "ONE", "CONNS"), nil, 100*time.Millisecond)
+		_, err := sysNc.Request(fmt.Sprintf(accDirectReqSubj, "ONE", "CONNS"), nil, 100*time.Millisecond)
 		if err != nats.ErrTimeout {
 			return fmt.Errorf("Expected timeout, got %v", err)
 		}
@@ -2087,6 +2087,7 @@ func TestJetStreamSuperClusterMovingStreamAndMoveBack(t *testing.T) {
 
 			checkMove := func(cluster string) {
 				t.Helper()
+				sc.waitOnStreamLeader("$G", "TEST")
 				checkFor(t, 20*time.Second, 100*time.Millisecond, func() error {
 					si, err := js.StreamInfo("TEST")
 					if err != nil {

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1306,7 +1306,7 @@ func TestLeafNodePermissions(t *testing.T) {
 	// Create a sub on ">" on LN1
 	subAll := natsSubSync(t, nc1, ">")
 	// this should be registered in LN2 (there is 1 sub for LN1 $LDS subject) + SYS IMPORTS
-	checkSubs(ln2.globalAccount(), 8)
+	checkSubs(ln2.globalAccount(), 10)
 
 	// Check deny export clause from messages published from LN2
 	for _, test := range []struct {
@@ -1333,7 +1333,7 @@ func TestLeafNodePermissions(t *testing.T) {
 
 	subAll.Unsubscribe()
 	// Goes down by 1.
-	checkSubs(ln2.globalAccount(), 7)
+	checkSubs(ln2.globalAccount(), 9)
 
 	// We used to make sure we would not do subscriptions however that
 	// was incorrect. We need to check publishes, not the subscriptions.
@@ -1358,7 +1358,7 @@ func TestLeafNodePermissions(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			sub := natsSubSync(t, nc2, test.subSubject)
-			checkSubs(ln2.globalAccount(), 8)
+			checkSubs(ln2.globalAccount(), 10)
 
 			if !test.ok {
 				nc1.Publish(test.pubSubject, []byte("msg"))
@@ -1366,12 +1366,12 @@ func TestLeafNodePermissions(t *testing.T) {
 					t.Fatalf("Did not expect to get the message")
 				}
 			} else {
-				checkSubs(ln1.globalAccount(), 7)
+				checkSubs(ln1.globalAccount(), 9)
 				nc1.Publish(test.pubSubject, []byte("msg"))
 				natsNexMsg(t, sub, time.Second)
 			}
 			sub.Unsubscribe()
-			checkSubs(ln1.globalAccount(), 6)
+			checkSubs(ln1.globalAccount(), 8)
 		})
 	}
 }
@@ -1492,8 +1492,8 @@ func TestLeafNodeExportPermissionsNotForSpecialSubs(t *testing.T) {
 	// The deny is totally restrictive, but make sure that we still accept the $LDS, $GR and _GR_ go from LN1.
 	checkFor(t, time.Second, 15*time.Millisecond, func() error {
 		// We should have registered the 3 subs from the accepting leafnode.
-		if n := ln2.globalAccount().TotalSubs(); n != 7 {
-			return fmt.Errorf("Expected %d subs, got %v", 7, n)
+		if n := ln2.globalAccount().TotalSubs(); n != 8 {
+			return fmt.Errorf("Expected %d subs, got %v", 8, n)
 		}
 		return nil
 	})
@@ -3395,7 +3395,7 @@ func TestLeafNodeRouteSubWithOrigin(t *testing.T) {
 	r1.Shutdown()
 	checkFor(t, time.Second, 15*time.Millisecond, func() error {
 		acc := l2.GlobalAccount()
-		if n := acc.TotalSubs(); n != 3 {
+		if n := acc.TotalSubs(); n != 4 {
 			return fmt.Errorf("Account %q should have 3 subs, got %v", acc.GetName(), n)
 		}
 		return nil

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2193,7 +2193,9 @@ func (s *Server) AccountStatz(opts *AccountStatzOptions) (*AccountStatz, error) 
 			if acc, ok := s.accounts.Load(a); ok {
 				acc := acc.(*Account)
 				acc.mu.RLock()
-				stz.Accounts = append(stz.Accounts, acc.accConns())
+				if opts.IncludeUnused || acc.numLocalConnections() != 0 {
+					stz.Accounts = append(stz.Accounts, acc.accConns())
+				}
 				acc.mu.RUnlock()
 			}
 		}

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -3854,7 +3854,7 @@ func TestMonitorLeafz(t *testing.T) {
 				t.Fatalf("RTT not tracked?")
 			}
 			// LDS should be only one.
-			if ln.NumSubs != 3 || len(ln.Subs) != 3 {
+			if ln.NumSubs != 4 || len(ln.Subs) != 4 {
 				t.Fatalf("Expected 3 subs, got %v (%v)", ln.NumSubs, ln.Subs)
 			}
 		}
@@ -3864,28 +3864,26 @@ func TestMonitorLeafz(t *testing.T) {
 func TestMonitorAccountz(t *testing.T) {
 	s := RunServer(DefaultMonitorOptions())
 	defer s.Shutdown()
-	body := string(readBody(t, fmt.Sprintf("http://127.0.0.1:%d/accountz", s.MonitorAddr().Port)))
-	if !strings.Contains(body, `$G`) {
-		t.Fatalf("Body missing value. Contains: %s", body)
-	} else if !strings.Contains(body, `$SYS`) {
-		t.Fatalf("Body missing value. Contains: %s", body)
-	} else if !strings.Contains(body, `"accounts": [`) {
-		t.Fatalf("Body missing value. Contains: %s", body)
-	} else if !strings.Contains(body, `"system_account": "$SYS"`) {
-		t.Fatalf("Body missing value. Contains: %s", body)
-	}
-	body = string(readBody(t, fmt.Sprintf("http://127.0.0.1:%d/accountz?acc=$SYS", s.MonitorAddr().Port)))
-	if !strings.Contains(body, `"account_detail": {`) {
-		t.Fatalf("Body missing value. Contains: %s", body)
-	} else if !strings.Contains(body, `"account_name": "$SYS",`) {
-		t.Fatalf("Body missing value. Contains: %s", body)
-	} else if !strings.Contains(body, `"subscriptions": 36,`) {
-		t.Fatalf("Body missing value. Contains: %s", body)
-	} else if !strings.Contains(body, `"is_system": true,`) {
-		t.Fatalf("Body missing value. Contains: %s", body)
-	} else if !strings.Contains(body, `"system_account": "$SYS"`) {
-		t.Fatalf("Body missing value. Contains: %s", body)
-	}
+	body := string(readBody(t, fmt.Sprintf("http://127.0.0.1:%d%s", s.MonitorAddr().Port, AccountzPath)))
+	require_Contains(t, body, `$G`)
+	require_Contains(t, body, `$SYS`)
+	require_Contains(t, body, `"accounts": [`)
+	require_Contains(t, body, `"system_account": "$SYS"`)
+
+	body = string(readBody(t, fmt.Sprintf("http://127.0.0.1:%d%s?acc=$SYS", s.MonitorAddr().Port, AccountzPath)))
+	require_Contains(t, body, `"account_detail": {`)
+	require_Contains(t, body, `"account_name": "$SYS",`)
+	require_Contains(t, body, `"subscriptions": 42,`)
+	require_Contains(t, body, `"is_system": true,`)
+	require_Contains(t, body, `"system_account": "$SYS"`)
+
+	body = string(readBody(t, fmt.Sprintf("http://127.0.0.1:%d%s?unused=1", s.MonitorAddr().Port, AccountStatzPath)))
+	require_Contains(t, body, `"acc": "$G"`)
+	require_Contains(t, body, `"acc": "$SYS"`)
+	require_Contains(t, body, `"sent": {`)
+	require_Contains(t, body, `"received": {`)
+	require_Contains(t, body, `"total_conns": 0,`)
+	require_Contains(t, body, `"leafnodes": 0,`)
 }
 
 func TestMonitorAuthorizedUsers(t *testing.T) {

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -3873,7 +3873,7 @@ func TestMonitorAccountz(t *testing.T) {
 	body = string(readBody(t, fmt.Sprintf("http://127.0.0.1:%d%s?acc=$SYS", s.MonitorAddr().Port, AccountzPath)))
 	require_Contains(t, body, `"account_detail": {`)
 	require_Contains(t, body, `"account_name": "$SYS",`)
-	require_Contains(t, body, `"subscriptions": 42,`)
+	require_Contains(t, body, `"subscriptions": 40,`)
 	require_Contains(t, body, `"is_system": true,`)
 	require_Contains(t, body, `"system_account": "$SYS"`)
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1095,7 +1095,7 @@ func TestRouteNoCrashOnAddingSubToRoute(t *testing.T) {
 
 	// Make sure all subs are registered in s.
 	checkFor(t, time.Second, 15*time.Millisecond, func() error {
-		if ts := s.globalAccount().TotalSubs() - 3; ts != int(numRoutes) {
+		if ts := s.globalAccount().TotalSubs() - 4; ts != int(numRoutes) {
 			return fmt.Errorf("Not all %d routed subs were registered: %d", numRoutes, ts)
 		}
 		return nil

--- a/server/server.go
+++ b/server/server.go
@@ -2267,18 +2267,19 @@ func (s *Server) StartMonitoring() error {
 
 // HTTP endpoints
 const (
-	RootPath     = "/"
-	VarzPath     = "/varz"
-	ConnzPath    = "/connz"
-	RoutezPath   = "/routez"
-	GatewayzPath = "/gatewayz"
-	LeafzPath    = "/leafz"
-	SubszPath    = "/subsz"
-	StackszPath  = "/stacksz"
-	AccountzPath = "/accountz"
-	JszPath      = "/jsz"
-	HealthzPath  = "/healthz"
-	IPQueuesPath = "/ipqueuesz"
+	RootPath         = "/"
+	VarzPath         = "/varz"
+	ConnzPath        = "/connz"
+	RoutezPath       = "/routez"
+	GatewayzPath     = "/gatewayz"
+	LeafzPath        = "/leafz"
+	SubszPath        = "/subsz"
+	StackszPath      = "/stacksz"
+	AccountzPath     = "/accountz"
+	AccountStatzPath = "/accstatz"
+	JszPath          = "/jsz"
+	HealthzPath      = "/healthz"
+	IPQueuesPath     = "/ipqueuesz"
 )
 
 func (s *Server) basePath(p string) string {
@@ -2381,6 +2382,8 @@ func (s *Server) startMonitoring(secure bool) error {
 	mux.HandleFunc(s.basePath(StackszPath), s.HandleStacksz)
 	// Accountz
 	mux.HandleFunc(s.basePath(AccountzPath), s.HandleAccountz)
+	// Accstatz
+	mux.HandleFunc(s.basePath(AccountStatzPath), s.HandleAccountStatz)
 	// Jsz
 	mux.HandleFunc(s.basePath(JszPath), s.HandleJsz)
 	// Healthz


### PR DESCRIPTION
Added http monitoring endpoint /accstatz
It responds with a list of statz for all accounts with local connections
the argument "unused=1" can be provided to get statz for all accounts
This endpoint is also exposed as nats request under:

This monitoring endpoint is exposed via the system account.
`$SYS.REQ.ACCOUNT.*.STATZ`
Each server will respond with connection statistics for the requested
account. The format of the data section is a list (size 1) identical to the event
`$SYS.ACCOUNT.%s.SERVER.CONNS` which is sent periodically as well as on
connect/disconnect. Unless requested by options, server without the account, 
or server where the account has no local connections, will not respond. 

A PING endpoint exists as well. The response format is identical to
$SYS.REQ.ACCOUNT.*.STATZ
(however the data section will contain more than one account, if they exist)
In addition to general filter options the request takes a list of accounts and
an argument to include accounts without local connections (disabled by default)
`$SYS.REQ.ACCOUNT.PING.STATZ`

Each account has a new system account import where the local subject
`$SYS.REQ.ACCOUNT.PING.STATZ` essentially responds as if
the importing account name was used for `$SYS.REQ.ACCOUNT.*.STATZ`

The only difference between requesting `ACCOUNT.PING.STATZ` from within
the system account and an account is that the later can only retrieve
statz for the account the client requests from.

Also exposed the monitoring /healthz via the system account under
`$SYS.REQ.SERVER.*.HEALTHZ`
`$SYS.REQ.SERVER.PING.HEALTHZ`
No dedicated options are available for these.
`HEALTHZ` also accept general filter options.

Signed-off-by: Matthias Hanel <mh@synadia.com>
