### PR TITLE
Fixed a test that was causing others to flap

### DIFF
--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1726,7 +1726,9 @@ func TestSystemAccountNoAuthUser(t *testing.T) {
 
 func TestServerAccountConns(t *testing.T) {
 	// speed up hb
+	orgHBInterval := eventsHBInterval
 	eventsHBInterval = time.Millisecond * 100
+	defer func() { eventsHBInterval = orgHBInterval }()
 	conf := createConfFile(t, []byte(`
 	   host: 127.0.0.1
 	   port: -1


### PR DESCRIPTION
The test was lowering the eventsHBInterval to low value but not
restoring its original value. This would cause some servers to
be considered "orphan" and the shutdown event sent causing their
raft node to be considered "offline", which then would result
in some tests failing with "insufficient resources".

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
