### PR TITLE
[FIXED] JetStream: servers may be reported as orphaned

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -1663,8 +1663,9 @@ func (s *Server) sendAccConnsUpdate(a *Account, subj ...string) {
 			Bytes: atomic.LoadInt64(&a.outBytes)},
 		SlowConsumers: atomic.LoadInt64(&a.slowConsumers),
 	}
-	// Set timer to fire again unless we are at zero.
-	if localConns == 0 {
+	// Set timer to fire again unless we are at zero, but only if the account
+	// is not configured for JetStream.
+	if localConns == 0 && !a.jetStreamConfiguredNoLock() {
 		clearTimer(&a.ctmr)
 	} else {
 		// Check to see if we have an HB running and update.

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1586,7 +1586,12 @@ func (a *Account) jetStreamConfigured() bool {
 		return false
 	}
 	a.mu.RLock()
-	defer a.mu.RUnlock()
+	jsc := a.jetStreamConfiguredNoLock()
+	a.mu.RUnlock()
+	return jsc
+}
+
+func (a *Account) jetStreamConfiguredNoLock() bool {
 	return len(a.jsLimits) > 0
 }
 


### PR DESCRIPTION
In some situations, a server may report that a remote server is
detected as orphaned (and the node is marked as offline). This is
because the orphaned detection relies on conns update to be received,
however, servers would suppress the update if an account does not
have any connections attached.

This PR ensures that the update is sent regardless if the account
is JS configured (not necessarily enabled at the moment).

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
