### PR TITLE
[FIXED] Maximum Deliveries update has no effect

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1418,6 +1418,11 @@ func (acc *Account) checkNewConsumerConfig(cfg, ncfg *ConsumerConfig) error {
 		}
 	}
 
+	// Check if BackOff is defined, MaxDeliver is within range.
+	if lbo := len(ncfg.BackOff); lbo > 0 && ncfg.MaxDeliver <= lbo {
+		return NewJSConsumerMaxDeliverBackoffError()
+	}
+
 	return nil
 }
 
@@ -1465,9 +1470,13 @@ func (o *consumer) updateConfig(cfg *ConsumerConfig) error {
 		sampleFreq, _ := strconv.Atoi(s)
 		o.sfreq = int32(sampleFreq)
 	}
+	// Set MaxDeliver if changed
+	if cfg.MaxDeliver != o.cfg.MaxDeliver {
+		o.maxdc = uint64(cfg.MaxDeliver)
+	}
 
 	// Record new config for others that do not need special handling.
-	// Allowed but considered no-op, [Description, MaxDeliver, SampleFrequency, MaxWaiting, HeadersOnly]
+	// Allowed but considered no-op, [Description, SampleFrequency, MaxWaiting, HeadersOnly]
 	o.cfg = *cfg
 
 	return nil

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -9240,6 +9240,67 @@ func TestJetStreamClusterConsumerUpdates(t *testing.T) {
 	t.Run("Clustered", func(t *testing.T) { testConsumerUpdate(t, c.randomServer(), 2) })
 }
 
+func TestJetStreamClusterConsumerMaxDeliverUpdate(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "JSC", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Replicas: 3})
+	require_NoError(t, err)
+
+	maxDeliver := 2
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:       "ard",
+		AckPolicy:     nats.AckExplicitPolicy,
+		FilterSubject: "foo",
+		MaxDeliver:    maxDeliver,
+	})
+	require_NoError(t, err)
+
+	sub, err := js.PullSubscribe("foo", "ard")
+	require_NoError(t, err)
+
+	_, err = js.Publish("foo", []byte("Hello"))
+	require_NoError(t, err)
+
+	for i := 0; i <= maxDeliver; i++ {
+		msgs, err := sub.Fetch(2, nats.MaxWait(10*time.Millisecond))
+		if i < maxDeliver {
+			require_NoError(t, err)
+			require_Len(t, 1, len(msgs))
+			_ = msgs[0].Nak()
+		} else {
+			require_Error(t, err, nats.ErrTimeout)
+		}
+	}
+
+	// update maxDeliver
+	maxDeliver = maxDeliver + 1
+	_, err = js.UpdateConsumer("TEST", &nats.ConsumerConfig{
+		Durable:       "ard",
+		AckPolicy:     nats.AckExplicitPolicy,
+		FilterSubject: "foo",
+		MaxDeliver:    maxDeliver,
+	})
+	require_NoError(t, err)
+
+	_, err = js.Publish("foo", []byte("Hello"))
+	require_NoError(t, err)
+
+	for i := 0; i <= maxDeliver; i++ {
+		msgs, err := sub.Fetch(2, nats.MaxWait(10*time.Millisecond))
+		if i < maxDeliver {
+			require_NoError(t, err)
+			require_Len(t, 1, len(msgs))
+			_ = msgs[0].Nak()
+		} else {
+			require_Error(t, err, nats.ErrTimeout)
+		}
+	}
+}
+
 func TestJetStreamClusterAccountReservations(t *testing.T) {
 	c := createJetStreamClusterWithTemplate(t, jsClusterMaxBytesAccountLimitTempl, "C1", 3)
 	defer c.shutdown()

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -16301,19 +16301,23 @@ func TestJetStreamConsumerMaxDeliverUpdate(t *testing.T) {
 	sub, err := js.PullSubscribe("foo", "ard")
 	require_NoError(t, err)
 
-	_, err = js.Publish("foo", []byte("Hello"))
-	require_NoError(t, err)
-
-	for i := 0; i <= maxDeliver; i++ {
-		msgs, err := sub.Fetch(2, nats.MaxWait(10*time.Millisecond))
-		if i < maxDeliver {
-			require_NoError(t, err)
-			require_Len(t, 1, len(msgs))
-			_ = msgs[0].Nak()
-		} else {
-			require_Error(t, err, nats.ErrTimeout)
+	checkMaxDeliver := func() {
+		t.Helper()
+		for i := 0; i <= maxDeliver; i++ {
+			msgs, err := sub.Fetch(2, nats.MaxWait(100*time.Millisecond))
+			if i < maxDeliver {
+				require_NoError(t, err)
+				require_Len(t, 1, len(msgs))
+				_ = msgs[0].Nak()
+			} else {
+				require_Error(t, err, nats.ErrTimeout)
+			}
 		}
 	}
+
+	_, err = js.Publish("foo", []byte("Hello"))
+	require_NoError(t, err)
+	checkMaxDeliver()
 
 	// update maxDeliver
 	maxDeliver = maxDeliver + 1
@@ -16327,17 +16331,7 @@ func TestJetStreamConsumerMaxDeliverUpdate(t *testing.T) {
 
 	_, err = js.Publish("foo", []byte("Hello"))
 	require_NoError(t, err)
-
-	for i := 0; i <= maxDeliver; i++ {
-		msgs, err := sub.Fetch(2, nats.MaxWait(10*time.Millisecond))
-		if i < maxDeliver {
-			require_NoError(t, err)
-			require_Len(t, 1, len(msgs))
-			_ = msgs[0].Nak()
-		} else {
-			require_Error(t, err, nats.ErrTimeout)
-		}
-	}
+	checkMaxDeliver()
 }
 
 func TestJetStreamRemoveExternalSource(t *testing.T) {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -16276,7 +16276,7 @@ func TestJetStreamConsumerAckSamplingSpecifiedUsingUpdateConsumer(t *testing.T) 
 	}
 }
 
-func TestJetStreamConsumerMaxDeliveryUpdate(t *testing.T) {
+func TestJetStreamConsumerMaxDeliverUpdate(t *testing.T) {
 	s := RunBasicJetStreamServer()
 	if config := s.JetStreamConfig(); config != nil {
 		defer removeDir(t, config.StoreDir)
@@ -16287,67 +16287,6 @@ func TestJetStreamConsumerMaxDeliveryUpdate(t *testing.T) {
 	defer nc.Close()
 
 	_, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}})
-	require_NoError(t, err)
-
-	maxDeliver := 2
-	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
-		Durable:       "ard",
-		AckPolicy:     nats.AckExplicitPolicy,
-		FilterSubject: "foo",
-		MaxDeliver:    maxDeliver,
-	})
-	require_NoError(t, err)
-
-	sub, err := js.PullSubscribe("foo", "ard")
-	require_NoError(t, err)
-
-	_, err = js.Publish("foo", []byte("Hello"))
-	require_NoError(t, err)
-
-	for i := 0; i <= maxDeliver; i++ {
-		msgs, err := sub.Fetch(2, nats.MaxWait(10*time.Millisecond))
-		if i < maxDeliver {
-			require_NoError(t, err)
-			require_Len(t, 1, len(msgs))
-			_ = msgs[0].Nak()
-		} else {
-			require_Error(t, err, nats.ErrTimeout)
-		}
-	}
-
-	// update maxDeliver
-	maxDeliver = maxDeliver + 1
-	_, err = js.UpdateConsumer("TEST", &nats.ConsumerConfig{
-		Durable:       "ard",
-		AckPolicy:     nats.AckExplicitPolicy,
-		FilterSubject: "foo",
-		MaxDeliver:    maxDeliver,
-	})
-	require_NoError(t, err)
-
-	_, err = js.Publish("foo", []byte("Hello"))
-	require_NoError(t, err)
-
-	for i := 0; i <= maxDeliver; i++ {
-		msgs, err := sub.Fetch(2, nats.MaxWait(10*time.Millisecond))
-		if i < maxDeliver {
-			require_NoError(t, err)
-			require_Len(t, 1, len(msgs))
-			_ = msgs[0].Nak()
-		} else {
-			require_Error(t, err, nats.ErrTimeout)
-		}
-	}
-}
-
-func TestJetStreamClusterConsumerMaxDeliveryUpdate(t *testing.T) {
-	c := createJetStreamClusterExplicit(t, "JSC", 3)
-	defer c.shutdown()
-
-	nc, js := jsClientConnect(t, c.randomServer())
-	defer nc.Close()
-
-	_, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Replicas: 3})
 	require_NoError(t, err)
 
 	maxDeliver := 2

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -16320,7 +16320,7 @@ func TestJetStreamConsumerMaxDeliverUpdate(t *testing.T) {
 	checkMaxDeliver()
 
 	// update maxDeliver
-	maxDeliver = maxDeliver + 1
+	maxDeliver++
 	_, err = js.UpdateConsumer("TEST", &nats.ConsumerConfig{
 		Durable:       "ard",
 		AckPolicy:     nats.AckExplicitPolicy,


### PR DESCRIPTION
Resolves https://github.com/nats-io/nats-server/issues/3264

### Changes proposed in this pull request:

 - On update check if BackOff is defined, MaxDeliver is within range
 - Set `o.maxdc` to the new value
 - Add tests