### PR TITLE
[FIXED] JetStream: stream mirror updates not rejected in standalone

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -1448,21 +1448,18 @@ func TestJetStreamClusterStreamExtendedUpdates(t *testing.T) {
 		return si
 	}
 
-	expectError := func() {
-		if _, err := js.UpdateStream(cfg); err == nil {
-			t.Fatalf("Expected error and got none")
-		}
-	}
-
-	// Subjects
+	// Subjects can be updated
 	cfg.Subjects = []string{"bar", "baz"}
 	if si := updateStream(); !reflect.DeepEqual(si.Config.Subjects, cfg.Subjects) {
 		t.Fatalf("Did not get expected stream info: %+v", si)
 	}
-	// Mirror changes
-	cfg.Replicas = 3
+	// Mirror changes are not supported for now
+	cfg.Subjects = nil
 	cfg.Mirror = &nats.StreamSource{Name: "ORDERS"}
-	expectError()
+	if _, err := js.UpdateStream(cfg); err == nil ||
+		!strings.Contains(NewJSStreamMirrorNotUpdatableError().Error(), err.Error()) {
+		t.Fatalf("Expected error %q, got %q", NewJSStreamMirrorNotUpdatableError(), err)
+	}
 }
 
 func TestJetStreamClusterDoubleAdd(t *testing.T) {

--- a/server/stream.go
+++ b/server/stream.go
@@ -1246,6 +1246,10 @@ func (jsa *jsAccount) configUpdateCheck(old, new *StreamConfig, s *Server) (*Str
 	if !cfg.DenyPurge && old.DenyPurge {
 		return nil, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration update can not cancel deny purge"))
 	}
+	// Check for mirror changes which are not allowed.
+	if !reflect.DeepEqual(cfg.Mirror, old.Mirror) {
+		return nil, NewJSStreamMirrorNotUpdatableError()
+	}
 
 	// Do some adjustments for being sealed.
 	if cfg.Sealed {

--- a/server/stream.go
+++ b/server/stream.go
@@ -2010,6 +2010,16 @@ func (mset *stream) setupMirrorConsumer() error {
 	if mset.outq == nil {
 		return errors.New("outq required")
 	}
+	// We use to prevent update of a mirror configuration in cluster
+	// mode but not in standalone. This is now fixed. However, without
+	// rejecting the update, it could be that if the source stream was
+	// removed and then later the mirrored stream config changed to
+	// remove mirror configuration, this function would panic when
+	// accessing mset.cfg.Mirror fields. Adding this protection in case
+	// we allow in the future the mirror config to be changed (removed).
+	if mset.cfg.Mirror == nil {
+		return errors.New("invalid mirror configuration")
+	}
 
 	// If this is the first time
 	if mset.mirror == nil {


### PR DESCRIPTION
Updates to stream mirror config are rejected in cluster mode, but
were not in standalone. This PR adds the check in standalone mode.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
