### PR TITLE
Fix and test for RePub src ignored at runtime.

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -4330,7 +4330,7 @@ func (tr *transform) Match(subject string) (string, error) {
 		return _EMPTY_, ErrBadSubject
 	}
 
-	if isSubsetMatch(tts, tr.src) {
+	if (tr.src == "" || tr.src == ">") || isSubsetMatch(tts, tr.src) {
 		return tr.transform(tts)
 	}
 	return _EMPTY_, ErrNoTransforms

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -4315,6 +4315,12 @@ func newTransform(src, dest string) (*transform, error) {
 func (tr *transform) Match(subject string) (string, error) {
 	// TODO(dlc) - We could add in client here to allow for things like foo -> foo.$ACCOUNT
 
+	// Special case: matches any and no no-op transform. May not be legal config for some features
+	// but specific validations made at transform create time
+	if (tr.src == fwcs || tr.src == _EMPTY_) && (tr.dest == fwcs || tr.dest == _EMPTY_) {
+		return subject, nil
+	}
+
 	// Tokenize the subject. This should always be a literal subject.
 	tsa := [32]string{}
 	tts := tsa[:0]
@@ -4330,7 +4336,7 @@ func (tr *transform) Match(subject string) (string, error) {
 		return _EMPTY_, ErrBadSubject
 	}
 
-	if (tr.src == "" || tr.src == ">") || isSubsetMatch(tts, tr.src) {
+	if (tr.src == _EMPTY_ || tr.src == fwcs) || isSubsetMatch(tts, tr.src) {
 		return tr.transform(tts)
 	}
 	return _EMPTY_, ErrNoTransforms

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -17582,6 +17582,176 @@ func TestJetStreamStreamRepublishCycle(t *testing.T) {
 	expectFail()
 }
 
+func TestJetStreamStreamRepublishOneTokenMatch(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	if config := s.JetStreamConfig(); config != nil {
+		defer removeDir(t, config.StoreDir)
+	}
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	// Do by hand for now.
+	cfg := &StreamConfig{
+		Name:     "RPC",
+		Storage:  MemoryStorage,
+		Subjects: []string{"foo", "bar", "baz"},
+		RePublish: &RePublish{
+			Source:      "baz",
+			Destination: "bazmonitor",
+			HeadersOnly: true,
+		},
+	}
+	addStream(t, nc, cfg)
+
+	sub, err := nc.SubscribeSync("bazmonitor")
+	require_NoError(t, err)
+
+	msg, toSend := bytes.Repeat([]byte("Z"), 512), 100
+	for i := 0; i < toSend; i++ {
+		js.PublishAsync("baz", msg)
+	}
+	select {
+	case <-js.PublishAsyncComplete():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Did not receive completion signal")
+	}
+
+	checkSubsPending(t, sub, toSend)
+	m, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+
+	if len(m.Data) < 0 {
+		t.Fatalf("Expected msg data")
+	}
+}
+
+func TestJetStreamStreamRepublishMultiTokenMatch(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	if config := s.JetStreamConfig(); config != nil {
+		defer removeDir(t, config.StoreDir)
+	}
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	// Do by hand for now.
+	cfg := &StreamConfig{
+		Name:     "RPC",
+		Storage:  MemoryStorage,
+		Subjects: []string{"foo.>", "bar.>", "baz.>"},
+		RePublish: &RePublish{
+			Source:      "baz.a.doowop.>",
+			Destination: "bazmonitor.>",
+			HeadersOnly: true,
+		},
+	}
+	addStream(t, nc, cfg)
+
+	sub, err := nc.SubscribeSync("bazmonitor.>")
+	require_NoError(t, err)
+
+	msg, toSend := bytes.Repeat([]byte("Z"), 512), 100
+	for i := 0; i < toSend; i++ {
+		js.PublishAsync("baz.a.doowop.hamburger", msg)
+	}
+	select {
+	case <-js.PublishAsyncComplete():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Did not receive completion signal")
+	}
+
+	checkSubsPending(t, sub, toSend)
+	m, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+
+	if len(m.Data) < 0 {
+		t.Fatalf("Expected msg data")
+	}
+}
+
+func TestJetStreamStreamRepublishMultiTokenNoMatch(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	if config := s.JetStreamConfig(); config != nil {
+		defer removeDir(t, config.StoreDir)
+	}
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	// Do by hand for now.
+	cfg := &StreamConfig{
+		Name:     "RPC",
+		Storage:  MemoryStorage,
+		Subjects: []string{"foo.>", "bar.>", "baz.>"},
+		RePublish: &RePublish{
+			Source:      "baz.a.doowop.>",
+			Destination: "bazmonitor.>",
+			HeadersOnly: true,
+		},
+	}
+	addStream(t, nc, cfg)
+
+	sub, err := nc.SubscribeSync("bazmonitor.>")
+	require_NoError(t, err)
+
+	msg, toSend := bytes.Repeat([]byte("Z"), 512), 100
+	for i := 0; i < toSend; i++ {
+		js.PublishAsync("baz.b.doowop.hamburger", msg)
+	}
+	select {
+	case <-js.PublishAsyncComplete():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Did not receive completion signal")
+	}
+
+	checkSubsPending(t, sub, 0)
+	require_NoError(t, err)
+}
+
+func TestJetStreamStreamRepublishOneTokenNoMatch(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	if config := s.JetStreamConfig(); config != nil {
+		defer removeDir(t, config.StoreDir)
+	}
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	// Do by hand for now.
+	cfg := &StreamConfig{
+		Name:     "RPC",
+		Storage:  MemoryStorage,
+		Subjects: []string{"foo", "bar", "baz"},
+		RePublish: &RePublish{
+			Source:      "baz",
+			Destination: "bazmonitor",
+			HeadersOnly: true,
+		},
+	}
+	addStream(t, nc, cfg)
+
+	sub, err := nc.SubscribeSync("bazmonitor")
+	require_NoError(t, err)
+
+	msg, toSend := bytes.Repeat([]byte("Z"), 512), 100
+	for i := 0; i < toSend; i++ {
+		js.PublishAsync("foo", msg)
+	}
+	select {
+	case <-js.PublishAsyncComplete():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Did not receive completion signal")
+	}
+
+	checkSubsPending(t, sub, 0)
+	require_NoError(t, err)
+}
+
 func TestJetStreamStreamRepublishHeadersOnly(t *testing.T) {
 	s := RunBasicJetStreamServer()
 	if config := s.JetStreamConfig(); config != nil {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -17594,23 +17594,23 @@ func TestJetStreamStreamRepublishOneTokenMatch(t *testing.T) {
 
 	// Do by hand for now.
 	cfg := &StreamConfig{
-		Name:     "RPC",
+		Name:     "Stream1",
 		Storage:  MemoryStorage,
-		Subjects: []string{"foo", "bar", "baz"},
+		Subjects: []string{"one", "four"},
 		RePublish: &RePublish{
-			Source:      "baz",
-			Destination: "bazmonitor",
-			HeadersOnly: true,
+			Source:      "one",
+			Destination: "uno",
+			HeadersOnly: false,
 		},
 	}
 	addStream(t, nc, cfg)
 
-	sub, err := nc.SubscribeSync("bazmonitor")
+	sub, err := nc.SubscribeSync("uno")
 	require_NoError(t, err)
 
 	msg, toSend := bytes.Repeat([]byte("Z"), 512), 100
 	for i := 0; i < toSend; i++ {
-		js.PublishAsync("baz", msg)
+		js.PublishAsync("one", msg)
 	}
 	select {
 	case <-js.PublishAsyncComplete():
@@ -17622,7 +17622,7 @@ func TestJetStreamStreamRepublishOneTokenMatch(t *testing.T) {
 	m, err := sub.NextMsg(time.Second)
 	require_NoError(t, err)
 
-	if len(m.Data) < 0 {
+	if !(len(m.Data) > 0) {
 		t.Fatalf("Expected msg data")
 	}
 }
@@ -17639,23 +17639,23 @@ func TestJetStreamStreamRepublishMultiTokenMatch(t *testing.T) {
 
 	// Do by hand for now.
 	cfg := &StreamConfig{
-		Name:     "RPC",
+		Name:     "Stream1",
 		Storage:  MemoryStorage,
-		Subjects: []string{"foo.>", "bar.>", "baz.>"},
+		Subjects: []string{"one.>", "four.>"},
 		RePublish: &RePublish{
-			Source:      "baz.a.doowop.>",
-			Destination: "bazmonitor.>",
-			HeadersOnly: true,
+			Source:      "one.two.>",
+			Destination: "uno.dos.>",
+			HeadersOnly: false,
 		},
 	}
 	addStream(t, nc, cfg)
 
-	sub, err := nc.SubscribeSync("bazmonitor.>")
+	sub, err := nc.SubscribeSync("uno.dos.>")
 	require_NoError(t, err)
 
 	msg, toSend := bytes.Repeat([]byte("Z"), 512), 100
 	for i := 0; i < toSend; i++ {
-		js.PublishAsync("baz.a.doowop.hamburger", msg)
+		js.PublishAsync("one.two.three", msg)
 	}
 	select {
 	case <-js.PublishAsyncComplete():
@@ -17667,7 +17667,7 @@ func TestJetStreamStreamRepublishMultiTokenMatch(t *testing.T) {
 	m, err := sub.NextMsg(time.Second)
 	require_NoError(t, err)
 
-	if len(m.Data) < 0 {
+	if !(len(m.Data) > 0) {
 		t.Fatalf("Expected msg data")
 	}
 }
@@ -17684,23 +17684,23 @@ func TestJetStreamStreamRepublishMultiTokenNoMatch(t *testing.T) {
 
 	// Do by hand for now.
 	cfg := &StreamConfig{
-		Name:     "RPC",
+		Name:     "Stream1",
 		Storage:  MemoryStorage,
-		Subjects: []string{"foo.>", "bar.>", "baz.>"},
+		Subjects: []string{"one.>", "four.>"},
 		RePublish: &RePublish{
-			Source:      "baz.a.doowop.>",
-			Destination: "bazmonitor.>",
+			Source:      "one.two.>",
+			Destination: "uno.dos.>",
 			HeadersOnly: true,
 		},
 	}
 	addStream(t, nc, cfg)
 
-	sub, err := nc.SubscribeSync("bazmonitor.>")
+	sub, err := nc.SubscribeSync("uno.dos.>")
 	require_NoError(t, err)
 
 	msg, toSend := bytes.Repeat([]byte("Z"), 512), 100
 	for i := 0; i < toSend; i++ {
-		js.PublishAsync("baz.b.doowop.hamburger", msg)
+		js.PublishAsync("four.five.six", msg)
 	}
 	select {
 	case <-js.PublishAsyncComplete():
@@ -17724,23 +17724,23 @@ func TestJetStreamStreamRepublishOneTokenNoMatch(t *testing.T) {
 
 	// Do by hand for now.
 	cfg := &StreamConfig{
-		Name:     "RPC",
+		Name:     "Stream1",
 		Storage:  MemoryStorage,
-		Subjects: []string{"foo", "bar", "baz"},
+		Subjects: []string{"one", "four"},
 		RePublish: &RePublish{
-			Source:      "baz",
-			Destination: "bazmonitor",
+			Source:      "one",
+			Destination: "uno",
 			HeadersOnly: true,
 		},
 	}
 	addStream(t, nc, cfg)
 
-	sub, err := nc.SubscribeSync("bazmonitor")
+	sub, err := nc.SubscribeSync("uno")
 	require_NoError(t, err)
 
 	msg, toSend := bytes.Repeat([]byte("Z"), 512), 100
 	for i := 0; i < toSend; i++ {
-		js.PublishAsync("foo", msg)
+		js.PublishAsync("four", msg)
 	}
 	select {
 	case <-js.PublishAsyncComplete():

--- a/server/stream.go
+++ b/server/stream.go
@@ -3675,7 +3675,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 	var tlseq uint64
 	var thdrsOnly bool
 	if mset.tr != nil {
-		tsubj, _ = mset.tr.transformSubject(subject)
+		tsubj, _ = mset.tr.Match(subject)
 		if mset.cfg.RePublish != nil {
 			thdrsOnly = mset.cfg.RePublish.HeadersOnly
 		}


### PR DESCRIPTION
### Changes proposed in this pull request:

For a stream that is RePublish-enabled, the RePublish source configuration (RePublish message filter) was not being evaluated for each ingested message.  Every message ingested by stream would be (re)published.

This PR fixes and adds unit tests.

/cc @nats-io/core
