### PR TITLE
fix jwt unit test by ensuring activation issue time is > expiration

### DIFF
--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -4326,8 +4326,14 @@ func TestJWTActivationRevocation(t *testing.T) {
 		aExp1Jwt := encodeClaim(t, aExpClaim, aExpPub)
 		aExpCreds := newUser(t, aExpKp)
 
-		time.Sleep(1100 * time.Millisecond)
 		aImpKp, aImpPub := createKey(t)
+
+		ac := &jwt.ActivationClaims{}
+		ac.Subject = aImpPub
+		ac.ImportSubject = "foo"
+		ac.ImportType = jwt.Stream
+		token, err := ac.Encode(aExpKp)
+		require_NoError(t, err)
 
 		revPubKey := aImpPub
 		if all {
@@ -4339,13 +4345,6 @@ func TestJWTActivationRevocation(t *testing.T) {
 
 		aExpClaim.Exports[0].ClearRevocation(revPubKey)
 		aExp3Jwt := encodeClaim(t, aExpClaim, aExpPub)
-
-		ac := &jwt.ActivationClaims{}
-		ac.Subject = aImpPub
-		ac.ImportSubject = "foo"
-		ac.ImportType = jwt.Stream
-		token, err := ac.Encode(aExpKp)
-		require_NoError(t, err)
 
 		aImpClaim := jwt.NewAccountClaims(aImpPub)
 		aImpClaim.Name = "Import"


### PR DESCRIPTION
fixed by moving activation token generation ahead of:
`aExpClaim.Exports[0].RevokeAt(revPubKey, time.Now())`

Signed-off-by: Matthias Hanel <mh@synadia.com>

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [ ] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [ ] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

### Changes proposed in this pull request:

 -
 -
 -

/cc @nats-io/core
