### PR TITLE
Fix raft issue where pindex of follower was off by 1

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -2218,7 +2218,7 @@ func (n *raft) sendSnapshotToFollower(subject string) (uint64, error) {
 	var state StreamState
 	n.wal.FastState(&state)
 	if snap.lastIndex < state.FirstSeq && state.FirstSeq != 0 {
-		snap.lastIndex = state.FirstSeq
+		snap.lastIndex = state.FirstSeq - 1
 		ae.pindex = snap.lastIndex
 	}
 	encoding, err := ae.encode(nil)


### PR DESCRIPTION
introduced by 57395bba027cfc67fd4647c750ca121b5e9cb67a

Signed-off-by: Matthias Hanel <mh@synadia.com>

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [ ] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [ ] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

### Changes proposed in this pull request:

 -
 -
 -

/cc @nats-io/core
