### PR TITLE
[FIXED] Losing stream sequence on multiple restarts and leader changes.

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -3102,6 +3102,7 @@ func TestFileStoreExpireMsgsOnStart(t *testing.T) {
 	}
 
 	checkNumBlks := func(expected int) {
+		t.Helper()
 		fs.mu.RLock()
 		n := len(fs.blks)
 		fs.mu.RUnlock()
@@ -3174,7 +3175,8 @@ func TestFileStoreExpireMsgsOnStart(t *testing.T) {
 	loadMsgs(500)
 	restartFS(ttl + 100*time.Millisecond)
 	checkState(0, 501, 500)
-	checkNumBlks(0)
+	// We actually hold onto the last one now to remember our starting sequence.
+	checkNumBlks(1)
 
 	// Now check partial expires and the fss tracking state.
 	// Small numbers is to keep them in one block.


### PR DESCRIPTION
When msgs were expired on restart recovery we could lose track on subsequent restarts of our starting sequence with no additional activity. If a leadership change happened or we were in R1 mode we would lose our starting sequence.

This could happen on low traffic streams with TTLs that frequently would empty the stream and when a server was down possibly before that event happened.

Thanks to @tbeets for the details on how to reproduce!

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
