### PR TITLE
[FIXED] JetStream/Cluster: Stream names/infos would return bad response

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1520,7 +1520,12 @@ func (s *Server) jsStreamNamesRequest(sub *subscription, c *client, _ *Account, 
 		numStreams = len(resp.Streams)
 		if offset > numStreams {
 			offset = numStreams
-			resp.Streams = resp.Streams[:offset]
+		}
+		if offset > 0 {
+			resp.Streams = resp.Streams[offset:]
+		}
+		if len(resp.Streams) > JSApiNamesLimit {
+			resp.Streams = resp.Streams[:JSApiNamesLimit]
 		}
 	} else {
 		msets := acc.filteredStreams(filter)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5358,7 +5358,7 @@ LOOP:
 		})
 	}
 
-	resp.Total = len(resp.Streams)
+	resp.Total = scnt
 	resp.Limit = JSApiListLimit
 	resp.Offset = offset
 	resp.Missing = missingNames


### PR DESCRIPTION
If there are more stream names that the current limit of 1024, getting
the list of names would return them all instead of using pagination.

For "stream infos", the Total amount returned would be the API limit
instead of the actual number of streams.

Resolves https://github.com/nats-io/natscli/issues/541

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
