### PR TITLE
[Do not merge] Ordered consumer stall test

### DIFF
--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -114,6 +114,8 @@ var jsClusterAccountsTempl = `
 var jsClusterTempl = `
 	listen: 127.0.0.1:-1
 	server_name: %s
+	#debug: true
+	log_file: /tmp/logs/nats-server/%s
 	jetstream: {max_mem_store: 256MB, max_file_store: 2GB, store_dir: '%s'}
 
 	leaf {
@@ -671,7 +673,7 @@ func createJetStreamClusterAndModHook(t *testing.T, tmpl string, clusterName, sn
 	for cp := portStart; cp < portStart+numServers; cp++ {
 		storeDir := createDir(t, JetStreamStoreDir)
 		sn := fmt.Sprintf("%sS-%d", snPre, cp-portStart+1)
-		conf := fmt.Sprintf(tmpl, sn, storeDir, clusterName, cp, routeConfig)
+		conf := fmt.Sprintf(tmpl, sn, sn, storeDir, clusterName, cp, routeConfig)
 		if modify != nil {
 			conf = modify(sn, clusterName, storeDir, conf)
 		}


### PR DESCRIPTION
This PR adds a repro for a stalled ordered consumer (in presence of server restarts).

**It is not intended as actual pull request**. This code would require further changes before is in shape to merge.
It is provided as means to investigate the underlying issue. 

Run command and example output:

```
$ go test -race -run=TestJetStreamOrderedConsumerWithClusterRestarts ./server  -count=1 -vet=off -timeout=30m -failfast -v
=== RUN   TestJetStreamOrderedConsumerWithClusterRestarts
Consumed and ACKed 100/20000, restarting servers
Consumed and ACKed 200/20000, restarting servers
Consumed and ACKed 300/20000, restarting servers
nats: timeout on connection [16] for subscription on "foo"
Consumed and ACKed 400/20000, restarting servers
Consumed and ACKed 500/20000, restarting servers
Consumed and ACKed 600/20000, restarting servers
Consumed and ACKed 700/20000, restarting servers
Consumed and ACKed 800/20000, restarting servers
Consumed and ACKed 900/20000, restarting servers
Consumed and ACKed 1000/20000, restarting servers
Consumed and ACKed 1100/20000, restarting servers
AckSync error, message sequence 1101, attempt 0/12: nats: no responders available for request
AckSync error, message sequence 1101, attempt 1/12: nats: no responders available for request
AckSync error, message sequence 1101, attempt 2/12: nats: no responders available for request
AckSync error, message sequence 1101, attempt 3/12: nats: no responders available for request
AckSync error, message sequence 1101, attempt 4/12: nats: no responders available for request
AckSync error, message sequence 1101, attempt 5/12: nats: no responders available for request
AckSync error, message sequence 1101, attempt 6/12: nats: no responders available for request
AckSync error, message sequence 1101, attempt 7/12: nats: no responders available for request
AckSync error, message sequence 1101, attempt 8/12: nats: no responders available for request
AckSync error, message sequence 1101, attempt 9/12: nats: no responders available for request
AckSync error, message sequence 1101, attempt 10/12: nats: no responders available for request
AckSync error, message sequence 1101, attempt 11/12: nats: no responders available for request
AckSync error, message sequence 1101, attempt 12/12: nats: no responders available for request
    jetstream_cluster_test.go:6173: Exceeded max retries for AckSync: nats: no responders available for request
--- FAIL: TestJetStreamOrderedConsumerWithClusterRestarts (59.61s)
FAIL
FAIL    github.com/nats-io/nats-server/v2/server        59.903s
FAIL
```

In some cases, the test may fail quickly (after ~100 messages). In other cases it may take longer (3k+ messages).
But I've never seen it complete successfully, even with large retry delays.

In a couple of rare cases, I have seen the test fail with a different error (the one I was originally chasing):

```
NextMsg error, message sequence 3301, attempt 20/20: nats: invalid subscription
```
