### PR TITLE
Fixed data race between UpdateConfif() and subjString

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -374,7 +374,7 @@ func (fs *fileStore) UpdateConfig(cfg *StreamConfig) error {
 	old_cfg := fs.cfg
 	// Messages block reference fs.cfg.Subjects (in subjString) under the
 	// mb's lock, not fs' lock. So do the switch here under all existing
-	// message blocks' lock.
+	// message blocks' lock in order to silence the DATA RACE detector.
 	fs.lockAllMsgBlocks()
 	fs.cfg = new_cfg
 	fs.unlockAllMsgBlocks()


### PR DESCRIPTION
A message block is checking the filestore's cfg.Subjects to see
if it can "intern" the subject or not. The problem is that this
is done under the message block's lock, but not the filestore.
However, during a stream configuration update, the filestore's
cfg field is switched to a new one, causing the datarace.

By making sure we do the switch under all message blocks lock,
we remove the data race (that could be reproduce by running th
test TestJetStreamClusterMoveCancel with -count=10).

We investigating the use of a string interning library but it
showed a little performance degradation that this approach does
not suffer from.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
