### PR TITLE
- Changes to make adding new mapping functions easier

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -4201,6 +4201,26 @@ func getMappingFunctionArgs(functionRegEx *regexp.Regexp, token string) []string
 	return nil
 }
 
+// Helper for mapping functions that take a wildcard index and an integer as arguments
+func transformIndexIntArgsHelper(token string, args []string, transformType int16) (int16, []int, int32, string, error) {
+	if len(args) < 2 {
+		return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionNotEnoughArguments}
+	}
+	if len(args) > 2 {
+		return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
+	}
+	i, err := strconv.Atoi(strings.Trim(args[0], " "))
+	if err != nil {
+		return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
+	}
+	mappingFunctionIntArg, err := strconv.Atoi(strings.Trim(args[1], " "))
+	if err != nil {
+		return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
+	}
+
+	return transformType, []int{i}, int32(mappingFunctionIntArg), "", nil
+}
+
 // Helper to ingest and index the transform destination token (e.g. $x or {{}}) in the token
 // returns a transformation type, and three function arguments: an array of source subject token indexes, and a single number (e.g. number of partitions, or a slice size), and a string (e.g.a split delimiter)
 
@@ -4263,85 +4283,25 @@ func indexPlaceHolders(token string) (int16, []int, int32, string, error) {
 			// SplitFromLeft(token, position)
 			args = getMappingFunctionArgs(splitFromLeftMappingFunctionRegEx, token)
 			if args != nil {
-				if len(args) < 2 {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionNotEnoughArguments}
-				}
-				if len(args) > 2 {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
-				}
-				i, err := strconv.Atoi(strings.Trim(args[0], " "))
-				if err != nil {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
-				}
-				mappingFunctionIntArg, err := strconv.Atoi(strings.Trim(args[1], " "))
-				if err != nil {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
-				}
-
-				return SplitFromLeft, []int{i}, int32(mappingFunctionIntArg), "", nil
+				return transformIndexIntArgsHelper(token, args, SplitFromLeft)
 			}
 
 			// SplitFromRight(token, position)
 			args = getMappingFunctionArgs(splitFromRightMappingFunctionRegEx, token)
 			if args != nil {
-				if len(args) < 2 {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionNotEnoughArguments}
-				}
-				if len(args) > 2 {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
-				}
-				i, err := strconv.Atoi(strings.Trim(args[0], " "))
-				if err != nil {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
-				}
-				mappingFunctionIntArg, err := strconv.Atoi(strings.Trim(args[1], " "))
-				if err != nil {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
-				}
-
-				return SplitFromRight, []int{i}, int32(mappingFunctionIntArg), "", nil
+				return transformIndexIntArgsHelper(token, args, SplitFromRight)
 			}
 
 			// SliceFromLeft(token, position)
 			args = getMappingFunctionArgs(sliceFromLeftMappingFunctionRegEx, token)
 			if args != nil {
-				if len(args) < 2 {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionNotEnoughArguments}
-				}
-				if len(args) > 2 {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
-				}
-				i, err := strconv.Atoi(strings.Trim(args[0], " "))
-				if err != nil {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
-				}
-				mappingFunctionIntArg, err := strconv.Atoi(strings.Trim(args[1], " "))
-				if err != nil {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
-				}
-
-				return SliceFromLeft, []int{i}, int32(mappingFunctionIntArg), "", nil
+				return transformIndexIntArgsHelper(token, args, SliceFromLeft)
 			}
 
 			// SliceFromRight(token, position)
 			args = getMappingFunctionArgs(sliceFromRightMappingFunctionRegEx, token)
 			if args != nil {
-				if len(args) < 2 {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionNotEnoughArguments}
-				}
-				if len(args) > 2 {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
-				}
-				i, err := strconv.Atoi(strings.Trim(args[0], " "))
-				if err != nil {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
-				}
-				mappingFunctionIntArg, err := strconv.Atoi(strings.Trim(args[1], " "))
-				if err != nil {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
-				}
-
-				return SliceFromRight, []int{i}, int32(mappingFunctionIntArg), "", nil
+				return transformIndexIntArgsHelper(token, args, SliceFromRight)
 			}
 
 			// split(token, deliminator)
@@ -4514,7 +4474,6 @@ func (tr *transform) transform(tokens []string) (string, error) {
 	}
 
 	var b strings.Builder
-	var transformedToken string
 
 	// We need to walk destination tokens and create the mapped subject pulling tokens or mapping functions
 	// This is slow and that is ok, transforms should have caching layer in front for mapping transforms
@@ -4522,11 +4481,11 @@ func (tr *transform) transform(tokens []string) (string, error) {
 	li := len(tr.dtokmftypes) - 1
 	for i, mfType := range tr.dtokmftypes {
 		if mfType == NoTransform {
-			transformedToken = tr.dtoks[i]
 			// Break if fwc
-			if len(transformedToken) == 1 && transformedToken[0] == fwc {
+			if len(tr.dtoks[i]) == 1 && tr.dtoks[i][0] == fwc {
 				break
 			}
+			b.WriteString(tr.dtoks[i])
 		} else {
 			switch mfType {
 			case Partition:
@@ -4537,80 +4496,77 @@ func (tr *transform) transform(tokens []string) (string, error) {
 				for _, sourceToken := range tr.dtokmftokindexesargs[i] {
 					keyForHashing = append(keyForHashing, []byte(tokens[sourceToken])...)
 				}
-				transformedToken = tr.getHashPartition(keyForHashing, int(tr.dtokmfintargs[i]))
+				b.WriteString(tr.getHashPartition(keyForHashing, int(tr.dtokmfintargs[i])))
 			case Wildcard: // simple substitution
-				transformedToken = tokens[tr.dtokmftokindexesargs[i][0]]
+				b.WriteString(tokens[tr.dtokmftokindexesargs[i][0]])
 			case SplitFromLeft:
 				sourceToken := tokens[tr.dtokmftokindexesargs[i][0]]
 				sourceTokenLen := len(sourceToken)
 				position := int(tr.dtokmfintargs[i])
 				if position > 0 && position < sourceTokenLen {
-					transformedToken = sourceToken[:position] + "." + sourceToken[position:]
+					b.WriteString(sourceToken[:position] + "." + sourceToken[position:])
 				} else { // too small to split at the requested position: don't split
-					transformedToken = sourceToken
+					b.WriteString(sourceToken)
 				}
 			case SplitFromRight:
 				sourceToken := tokens[tr.dtokmftokindexesargs[i][0]]
 				sourceTokenLen := len(sourceToken)
 				position := int(tr.dtokmfintargs[i])
 				if position > 0 && position < sourceTokenLen {
-					transformedToken = sourceToken[:sourceTokenLen-position] + "." + sourceToken[sourceTokenLen-position:]
+					b.WriteString(sourceToken[:sourceTokenLen-position] + "." + sourceToken[sourceTokenLen-position:])
 				} else { // too small to split at the requested position: don't split
-					transformedToken = sourceToken
+					b.WriteString(sourceToken)
 				}
 			case SliceFromLeft:
 				sourceToken := tokens[tr.dtokmftokindexesargs[i][0]]
 				sourceTokenLen := len(sourceToken)
 				sliceSize := int(tr.dtokmfintargs[i])
 				if sliceSize > 0 && sliceSize < sourceTokenLen {
-					transformedToken = ""
 					for i := 0; i+sliceSize <= sourceTokenLen; i += sliceSize {
 						if i != 0 {
-							transformedToken = transformedToken + "."
+							b.WriteString(".")
 						}
-						transformedToken = transformedToken + sourceToken[i:i+sliceSize]
+						b.WriteString(sourceToken[i : i+sliceSize])
 						if i+sliceSize != sourceTokenLen && i+sliceSize+sliceSize > sourceTokenLen {
-							transformedToken = transformedToken + "." + sourceToken[i+sliceSize:]
+							b.WriteString("." + sourceToken[i+sliceSize:])
 							break
 						}
 					}
 				} else { // too small to slice at the requested size: don't slice
-					transformedToken = sourceToken
+					b.WriteString(sourceToken)
 				}
 			case SliceFromRight:
 				sourceToken := tokens[tr.dtokmftokindexesargs[i][0]]
 				sourceTokenLen := len(sourceToken)
 				sliceSize := int(tr.dtokmfintargs[i])
 				if sliceSize > 0 && sliceSize < sourceTokenLen {
-					transformedToken = ""
 					remainder := sourceTokenLen % sliceSize
 					if remainder > 0 {
-						transformedToken = transformedToken + sourceToken[:remainder] + "."
+						b.WriteString(sourceToken[:remainder] + ".")
 					}
 					for i := remainder; i+sliceSize <= sourceTokenLen; i += sliceSize {
-						transformedToken = transformedToken + sourceToken[i:i+sliceSize]
+						b.WriteString(sourceToken[i : i+sliceSize])
 						if i+sliceSize < sourceTokenLen {
-							transformedToken = transformedToken + "."
+							b.WriteString(".")
 						}
 					}
 				} else { // too small to slice at the requested size: don't slice
-					transformedToken = sourceToken
+					b.WriteString(sourceToken)
 				}
 			case Split:
 				sourceToken := tokens[tr.dtokmftokindexesargs[i][0]]
 				splits := strings.Split(sourceToken, tr.dtokmfstringargs[i])
-				transformedToken = ""
 				for j, split := range splits {
 					if split != "" {
-						transformedToken = transformedToken + split
+						b.WriteString(split)
 					}
 					if j < len(splits)-1 && splits[j+1] != "" && j != 0 {
-						transformedToken = transformedToken + "."
+						b.WriteString(".")
 					}
 				}
 			}
 		}
-		b.WriteString(transformedToken)
+
 		if i < li {
 			b.WriteByte(btsep)
 		}

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -4204,21 +4204,21 @@ func getMappingFunctionArgs(functionRegEx *regexp.Regexp, token string) []string
 // Helper for mapping functions that take a wildcard index and an integer as arguments
 func transformIndexIntArgsHelper(token string, args []string, transformType int16) (int16, []int, int32, string, error) {
 	if len(args) < 2 {
-		return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionNotEnoughArguments}
+		return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrorMappingDestinationFunctionNotEnoughArguments}
 	}
 	if len(args) > 2 {
-		return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
+		return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrorMappingDestinationFunctionTooManyArguments}
 	}
 	i, err := strconv.Atoi(strings.Trim(args[0], " "))
 	if err != nil {
-		return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
+		return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
 	}
 	mappingFunctionIntArg, err := strconv.Atoi(strings.Trim(args[1], " "))
 	if err != nil {
-		return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
+		return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
 	}
 
-	return transformType, []int{i}, int32(mappingFunctionIntArg), "", nil
+	return transformType, []int{i}, int32(mappingFunctionIntArg), _EMPTY_, nil
 }
 
 // Helper to ingest and index the transform destination token (e.g. $x or {{}}) in the token
@@ -4231,7 +4231,8 @@ func indexPlaceHolders(token string) (int16, []int, int32, string, error) {
 		if token[0] == '$' { // simple non-partition mapping
 			tp, err := strconv.Atoi(token[1:])
 			if err != nil {
-				return NoTransform, []int{-1}, -1, "", nil // other things rely on tokens starting with $ so not an error just leave it as is
+				// other things rely on tokens starting with $ so not an error just leave it as is
+				return NoTransform, []int{-1}, -1, "", nil
 			}
 			return Wildcard, []int{tp}, -1, "", nil
 		}
@@ -4242,16 +4243,16 @@ func indexPlaceHolders(token string) (int16, []int, int32, string, error) {
 			args := getMappingFunctionArgs(wildcardMappingFunctionRegEx, token)
 			if args != nil {
 				if len(args) == 1 && args[0] == _EMPTY_ {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionNotEnoughArguments}
+					return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrorMappingDestinationFunctionNotEnoughArguments}
 				}
 				if len(args) == 1 {
 					tokenIndex, err := strconv.Atoi(strings.Trim(args[0], " "))
 					if err != nil {
-						return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
+						return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
 					}
-					return Wildcard, []int{tokenIndex}, -1, "", nil
+					return Wildcard, []int{tokenIndex}, -1, _EMPTY_, nil
 				} else {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionTooManyArguments}
+					return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrorMappingDestinationFunctionTooManyArguments}
 				}
 			}
 
@@ -4259,24 +4260,24 @@ func indexPlaceHolders(token string) (int16, []int, int32, string, error) {
 			args = getMappingFunctionArgs(partitionMappingFunctionRegEx, token)
 			if args != nil {
 				if len(args) < 2 {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionNotEnoughArguments}
+					return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrorMappingDestinationFunctionNotEnoughArguments}
 				}
 				if len(args) >= 2 {
 					mappingFunctionIntArg, err := strconv.Atoi(strings.Trim(args[0], " "))
 					if err != nil {
-						return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
+						return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
 					}
 					var numPositions = len(args[1:])
 					tokenIndexes := make([]int, numPositions)
 					for ti, t := range args[1:] {
 						i, err := strconv.Atoi(strings.Trim(t, " "))
 						if err != nil {
-							return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
+							return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
 						}
 						tokenIndexes[ti] = i
 					}
 
-					return Partition, tokenIndexes, int32(mappingFunctionIntArg), "", nil
+					return Partition, tokenIndexes, int32(mappingFunctionIntArg), _EMPTY_, nil
 				}
 			}
 
@@ -4308,26 +4309,26 @@ func indexPlaceHolders(token string) (int16, []int, int32, string, error) {
 			args = getMappingFunctionArgs(splitMappingFunctionRegEx, token)
 			if args != nil {
 				if len(args) < 2 {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionNotEnoughArguments}
+					return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrorMappingDestinationFunctionNotEnoughArguments}
 				}
 				if len(args) > 2 {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
+					return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrorMappingDestinationFunctionTooManyArguments}
 				}
 				i, err := strconv.Atoi(strings.Trim(args[0], " "))
 				if err != nil {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
+					return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrorMappingDestinationFunctionInvalidArgument}
 				}
 				if strings.Contains(args[1], " ") || strings.Contains(args[1], ".") {
-					return BadTransform, []int{}, -1, "", &mappingDestinationErr{token: token, err: ErrorMappingDestinationFunctionInvalidArgument}
+					return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token: token, err: ErrorMappingDestinationFunctionInvalidArgument}
 				}
 
 				return Split, []int{i}, -1, args[1], nil
 			}
 
-			return BadTransform, []int{}, -1, "", &mappingDestinationErr{token, ErrUnknownMappingDestinationFunction}
+			return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrUnknownMappingDestinationFunction}
 		}
 	}
-	return NoTransform, []int{-1}, -1, "", nil
+	return NoTransform, []int{-1}, -1, _EMPTY_, nil
 }
 
 // SubjectTransformer transforms subjects using mappings
@@ -4378,12 +4379,10 @@ func newTransform(src, dest string) (*transform, error) {
 			}
 
 			if tranformType == NoTransform {
-				{
-					dtokMappingFunctionTypes = append(dtokMappingFunctionTypes, NoTransform)
-					dtokMappingFunctionTokenIndexes = append(dtokMappingFunctionTokenIndexes, []int{-1})
-					dtokMappingFunctionIntArgs = append(dtokMappingFunctionIntArgs, -1)
-					dtokMappingFunctionStringArgs = append(dtokMappingFunctionStringArgs, "")
-				}
+				dtokMappingFunctionTypes = append(dtokMappingFunctionTypes, NoTransform)
+				dtokMappingFunctionTokenIndexes = append(dtokMappingFunctionTokenIndexes, []int{-1})
+				dtokMappingFunctionIntArgs = append(dtokMappingFunctionIntArgs, -1)
+				dtokMappingFunctionStringArgs = append(dtokMappingFunctionStringArgs, "")
 			} else {
 				nphs++
 				// Now build up our runtime mapping from dest to source tokens.

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -50,47 +50,54 @@ func simpleAccountServer(t *testing.T) (*Server, *Account, *Account) {
 
 func TestPlaceHolderIndex(t *testing.T) {
 	testString := "$1"
-	indexes, nbPartitions, err := placeHolderIndex(testString)
+	transformType, indexes, nbPartitions, _, err := indexPlaceHolders(testString)
+	var position int32
 
-	if err != nil || len(indexes) != 1 || indexes[0] != 1 || nbPartitions != -1 {
+	if err != nil || transformType != Wildcard || len(indexes) != 1 || indexes[0] != 1 || nbPartitions != -1 {
 		t.Fatalf("Error parsing %s", testString)
 	}
 
 	testString = "{{partition(10,1,2,3)}}"
 
-	indexes, nbPartitions, err = placeHolderIndex(testString)
+	transformType, indexes, nbPartitions, _, err = indexPlaceHolders(testString)
 
-	if err != nil || !reflect.DeepEqual(indexes, []int{1, 2, 3}) || nbPartitions != 10 {
+	if err != nil || transformType != Partition || !reflect.DeepEqual(indexes, []int{1, 2, 3}) || nbPartitions != 10 {
 		t.Fatalf("Error parsing %s", testString)
 	}
 
-	testString = "{{ partition(10,1,2,3) }}"
+	testString = "{{ Partition (10,1,2,3) }}"
 
-	indexes, nbPartitions, err = placeHolderIndex(testString)
+	transformType, indexes, nbPartitions, _, err = indexPlaceHolders(testString)
 
-	if err != nil || !reflect.DeepEqual(indexes, []int{1, 2, 3}) || nbPartitions != 10 {
-		t.Fatalf("Error parsing %s", testString)
-	}
-
-	testString = "{{partition (10,1,2,3)}}"
-
-	indexes, nbPartitions, err = placeHolderIndex(testString)
-
-	if err != nil || !reflect.DeepEqual(indexes, []int{1, 2, 3}) || nbPartitions != 10 {
+	if err != nil || transformType != Partition || !reflect.DeepEqual(indexes, []int{1, 2, 3}) || nbPartitions != 10 {
 		t.Fatalf("Error parsing %s", testString)
 	}
 
 	testString = "{{wildcard(2)}}"
-	indexes, nbPartitions, err = placeHolderIndex(testString)
+	transformType, indexes, nbPartitions, _, err = indexPlaceHolders(testString)
 
-	if err != nil || len(indexes) != 1 || indexes[0] != 2 || nbPartitions != -1 {
+	if err != nil || transformType != Wildcard || len(indexes) != 1 || indexes[0] != 2 || nbPartitions != -1 {
 		t.Fatalf("Error parsing %s", testString)
 	}
 
-	testString = "{{ wildcard (2) }}"
-	indexes, nbPartitions, err = placeHolderIndex(testString)
+	testString = "{{SplitFromLeft(2,1)}}"
+	transformType, indexes, position, _, err = indexPlaceHolders(testString)
 
-	if err != nil || len(indexes) != 1 || indexes[0] != 2 || nbPartitions != -1 {
+	if err != nil || transformType != SplitFromLeft || len(indexes) != 1 || indexes[0] != 2 || position != 1 {
+		t.Fatalf("Error parsing %s", testString)
+	}
+
+	testString = "{{SplitFromRight(3,2)}}"
+	transformType, indexes, position, _, err = indexPlaceHolders(testString)
+
+	if err != nil || transformType != SplitFromRight || len(indexes) != 1 || indexes[0] != 3 || position != 2 {
+		t.Fatalf("Error parsing %s", testString)
+	}
+
+	testString = "{{SliceFromLeft(2,2)}}"
+	transformType, indexes, sliceSize, _, err := indexPlaceHolders(testString)
+
+	if err != nil || transformType != SliceFromLeft || len(indexes) != 1 || indexes[0] != 2 || sliceSize != 2 {
 		t.Fatalf("Error parsing %s", testString)
 	}
 }
@@ -3290,6 +3297,7 @@ func TestSubjectTransforms(t *testing.T) {
 	shouldErr("foo.*", "foo.{{wildcard()}}")       // Not enough arguments passed to the mapping function
 	shouldErr("foo.*", "foo.{{wildcard(1,2)}}")    // Too many arguments passed to the mapping function
 	shouldErr("foo.*", "foo.{{ wildcard5) }}")     // Bad mapping function
+	shouldErr("foo.*", "foo.{{splitLeft(2,2}}")    // arg out of range
 
 	shouldBeOK := func(src, dest string) *transform {
 		t.Helper()
@@ -3303,6 +3311,7 @@ func TestSubjectTransforms(t *testing.T) {
 	shouldBeOK("foo", "bar")
 	shouldBeOK("foo.*.bar.*.baz", "req.$2.$1")
 	shouldBeOK("baz.>", "mybaz.>")
+	shouldBeOK("*", "{{splitfromleft(1,1)}}")
 
 	shouldMatch := func(src, dest, sample, expected string) {
 		t.Helper()
@@ -3321,6 +3330,12 @@ func TestSubjectTransforms(t *testing.T) {
 	shouldMatch("baz.>", "my.pre.>", "baz.1.2.3", "my.pre.1.2.3")
 	shouldMatch("baz.>", "foo.bar.>", "baz.1.2.3", "foo.bar.1.2.3")
 	shouldMatch("*", "foo.bar.$1", "foo", "foo.bar.foo")
+	shouldMatch("*", "{{splitfromleft(1,3)}}", "12345", "123.45")
+	shouldMatch("*", "{{SplitFromRight(1,3)}}", "12345", "12.345")
+	shouldMatch("*", "{{SliceFromLeft(1,3)}}", "1234567890", "123.456.789.0")
+	shouldMatch("*", "{{SliceFromRight(1,3)}}", "1234567890", "1.234.567.890")
+	shouldMatch("*", "{{split(1,-)}}", "-abc-def--ghi-", "abc.def.ghi")
+	shouldMatch("*.*", "{{split(2,-)}}.{{splitfromleft(1,2)}}", "foo.-abc-def--ghij-", "abc.def.ghij.fo.o") // combo + checks split for multiple instance of deliminator and deliminator being at the start or end
 }
 
 func TestAccountSystemPermsWithGlobalAccess(t *testing.T) {

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -1140,7 +1140,13 @@ func ValidateMappingDestination(subject string) error {
 		}
 
 		if length > 4 && t[0] == '{' && t[1] == '{' && t[length-2] == '}' && t[length-1] == '}' {
-			if !partitionMappingFunctionRegEx.MatchString(t) && !wildcardMappingFunctionRegEx.MatchString(t) {
+			if !partitionMappingFunctionRegEx.MatchString(t) &&
+				!wildcardMappingFunctionRegEx.MatchString(t) &&
+				!splitFromLeftMappingFunctionRegEx.MatchString(t) &&
+				!splitFromRightMappingFunctionRegEx.MatchString(t) &&
+				!sliceFromLeftMappingFunctionRegEx.MatchString(t) &&
+				!sliceFromRightMappingFunctionRegEx.MatchString(t) &&
+				!splitMappingFunctionRegEx.MatchString(t) {
 				return &mappingDestinationErr{t, ErrUnknownMappingDestinationFunction}
 			} else {
 				continue

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -669,6 +669,8 @@ func TestValidateDestinationSubject(t *testing.T) {
 	checkError(ValidateMappingDestination("foo.{{ wildcard(1) }}"), nil, t)
 	checkError(ValidateMappingDestination("foo.{{wildcard( 1 )}}"), nil, t)
 	checkError(ValidateMappingDestination("foo.{{partition(2,1)}}"), nil, t)
+	checkError(ValidateMappingDestination("foo.{{SplitFromLeft(2,1)}}"), nil, t)
+	checkError(ValidateMappingDestination("foo.{{SplitFromRight(2,1)}}"), nil, t)
 	checkError(ValidateMappingDestination("foo.{{unknown(1)}}"), ErrInvalidMappingDestination, t)
 	checkError(ValidateMappingDestination("foo..}"), ErrInvalidMappingDestination, t)
 	checkError(ValidateMappingDestination("foo. bar}"), ErrInvalidMappingDestinationSubject, t)


### PR DESCRIPTION
- Adds new subject mapping functions:
```go
{{SplitFromLeft(wildcard index, position)}}
{{SplitFromRight(wildcard index, position)}}
{{SliceFromLeft(wildcard index, slice size)}}
{{SliceFromRight(wildcard index, slice size)}}
{{Split(wildcard index, deliminator)}}
```

Examples:
```go
	shouldMatch("*", "{{splitfromleft(1,3)}}", "12345", "123.45")
	shouldMatch("*", "{{SplitFromRight(1,3)}}", "12345", "12.345")
	shouldMatch("*", "{{SliceFromLeft(1,3)}}", "1234567890", "123.456.789.0")
	shouldMatch("*", "{{SliceFromRight(1,3)}}", "1234567890", "1.234.567.890")
	shouldMatch("*", "{{split(1,-)}}", "-abc-def--ghi-", "abc.def.ghi")
	shouldMatch("*.*", "{{split(2,-)}}.{{splitfromleft(1,2)}}", "foo.-abc-def--ghij-", "abc.def.ghij.fo.o")
```

- Subject mapping functions can now be all lower case or Pascal case (or a combination): e.g. splitfromleft, SplitFromLeft, splitFromleft, etc...

 - [ ] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

/cc @nats-io/core
