### PR TITLE
Adding account purge operation

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -94,20 +94,22 @@ type JetStreamAPIStats struct {
 // This is for internal accounting for JetStream for this server.
 type jetStream struct {
 	// These are here first because of atomics on 32bit systems.
-	apiInflight    int64
-	apiTotal       int64
-	apiErrors      int64
-	memReserved    int64
-	storeReserved  int64
-	memUsed        int64
-	storeUsed      int64
-	clustered      int32
-	mu             sync.RWMutex
-	srv            *Server
-	config         JetStreamConfig
-	cluster        *jetStreamCluster
-	accounts       map[string]*jsAccount
-	apiSubs        *Sublist
+	apiInflight   int64
+	apiTotal      int64
+	apiErrors     int64
+	memReserved   int64
+	storeReserved int64
+	memUsed       int64
+	storeUsed     int64
+	clustered     int32
+	mu            sync.RWMutex
+	srv           *Server
+	config        JetStreamConfig
+	cluster       *jetStreamCluster
+	accounts      map[string]*jsAccount
+	apiSubs       *Sublist
+	// System level request to purge a stream move
+	accountPurge   *subscription
 	metaRecovering bool
 	standAlone     bool
 	disabled       bool
@@ -689,6 +691,21 @@ func (s *Server) configAllJetStreamAccounts() error {
 		return nil
 	}
 
+	if s.sys != nil {
+		// clustered stream removal will perform this cleanup as well
+		// this is mainly for initial cleanup
+		saccName := s.sys.account.Name
+		accStoreDirs, _ := ioutil.ReadDir(js.config.StoreDir)
+		for _, acc := range accStoreDirs {
+			if accName := acc.Name(); accName != saccName {
+				// no op if not empty
+				accDir := filepath.Join(js.config.StoreDir, accName)
+				os.Remove(filepath.Join(accDir, streamsDir))
+				os.Remove(accDir)
+			}
+		}
+	}
+
 	var jsAccounts []*Account
 	s.accounts.Range(func(k, v interface{}) bool {
 		jsAccounts = append(jsAccounts, v.(*Account))
@@ -741,6 +758,12 @@ func (js *jetStream) setJetStreamStandAlone(isStandAlone bool) {
 	js.mu.Lock()
 	defer js.mu.Unlock()
 	js.standAlone = isStandAlone
+
+	if isStandAlone {
+		js.accountPurge, _ = js.srv.systemSubscribe(JSApiAccountPurge, _EMPTY_, false, nil, js.srv.jsLeaderAccountPurgeRequest)
+	} else if js.accountPurge != nil {
+		js.srv.sysUnsubscribe(js.accountPurge)
+	}
 }
 
 // JetStreamEnabled reports if jetstream is enabled for this server.
@@ -879,7 +902,12 @@ func (s *Server) shutdownJetStream() {
 			accounts = append(accounts, a)
 		}
 	}
+	accPurgeSub := js.accountPurge
 	js.mu.RUnlock()
+
+	if accPurgeSub != nil {
+		s.sysUnsubscribe(accPurgeSub)
+	}
 
 	for _, a := range accounts {
 		a.removeJetStream()
@@ -1052,7 +1080,8 @@ func (a *Account) EnableJetStream(limits map[string]JetStreamAccountLimits) erro
 		// Just need to make sure we can write to the directory.
 		// Remove the directory will create later if needed.
 		os.RemoveAll(sdir)
-
+		// when empty remove parent directory, which may have been created as well
+		os.Remove(jsa.storeDir)
 	} else {
 		// Restore any state here.
 		s.Debugf("Recovering JetStream state for account %q", a.Name)

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -895,7 +895,7 @@ func (s *Server) shutdownJetStream() {
 	var _a [512]*Account
 	accounts := _a[:0]
 
-	js.mu.RLock()
+	js.mu.Lock()
 	// Collect accounts.
 	for _, jsa := range js.accounts {
 		if a := jsa.acc(); a != nil {
@@ -903,7 +903,8 @@ func (s *Server) shutdownJetStream() {
 		}
 	}
 	accPurgeSub := js.accountPurge
-	js.mu.RUnlock()
+	js.accountPurge = nil
+	js.mu.Unlock()
 
 	if accPurgeSub != nil {
 		s.sysUnsubscribe(accPurgeSub)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -914,11 +915,11 @@ func (js *jetStream) monitorCluster() {
 					js.clearMetaRecovering()
 
 					// Process any removes that are still valid after recovery.
-					for _, sa := range rm.streams {
-						js.processStreamRemoval(sa)
-					}
 					for _, ca := range rm.consumers {
 						js.processConsumerRemoval(ca)
+					}
+					for _, sa := range rm.streams {
+						js.processStreamRemoval(sa)
 					}
 					// Clear.
 					rm = nil
@@ -1077,16 +1078,15 @@ func (js *jetStream) metaSnapshot() []byte {
 }
 
 func (js *jetStream) applyMetaSnapshot(buf []byte) error {
-	if len(buf) == 0 {
-		return nil
-	}
-	jse, err := s2.Decode(nil, buf)
-	if err != nil {
-		return err
-	}
 	var wsas []writeableStreamAssignment
-	if err = json.Unmarshal(jse, &wsas); err != nil {
-		return err
+	if len(buf) != 0 {
+		jse, err := s2.Decode(nil, buf)
+		if err != nil {
+			return err
+		}
+		if err = json.Unmarshal(jse, &wsas); err != nil {
+			return err
+		}
 	}
 
 	// Build our new version here outside of js.
@@ -1146,6 +1146,8 @@ func (js *jetStream) applyMetaSnapshot(buf []byte) error {
 		}
 	}
 	isRecovering := js.metaRecovering
+	storeDir := js.config.StoreDir
+	srv := js.srv
 	js.mu.Unlock()
 
 	// Do removals first.
@@ -1181,6 +1183,20 @@ func (js *jetStream) applyMetaSnapshot(buf []byte) error {
 			js.setConsumerAssignmentRecovering(ca)
 		}
 		js.processConsumerAssignment(ca)
+	}
+
+	// Delete directories not part of snapshot
+	sysAcc := srv.SystemAccount().GetName()
+	if de, err := os.ReadDir(storeDir); err == nil {
+		for _, entry := range de {
+			acc := entry.Name()
+			if acc == sysAcc {
+				continue
+			}
+			if _, found := streams[acc]; !found {
+				os.RemoveAll(filepath.Join(storeDir, acc))
+			}
+		}
 	}
 
 	return nil
@@ -2573,6 +2589,23 @@ func (js *jetStream) processStreamAssignment(sa *streamAssignment) bool {
 		return false
 	}
 
+	js.mu.Lock()
+	accStreams := cc.streams[accName]
+	if accStreams == nil {
+		accStreams = make(map[string]*streamAssignment)
+	} else if osa := accStreams[stream]; osa != nil && osa != sa {
+		// Copy over private existing state from former SA.
+		sa.Group.node = osa.Group.node
+		sa.consumers = osa.consumers
+		sa.responded = osa.responded
+		sa.err = osa.err
+	}
+
+	// Update our state.
+	accStreams[stream] = sa
+	cc.streams[accName] = accStreams
+	js.mu.Unlock()
+
 	acc, err := s.LookupAccount(accName)
 	if err != nil {
 		ll := fmt.Sprintf("Account [%s] lookup for stream create failed: %v", accName, err)
@@ -2591,23 +2624,6 @@ func (js *jetStream) processStreamAssignment(sa *streamAssignment) bool {
 		}
 		return false
 	}
-
-	js.mu.Lock()
-	accStreams := cc.streams[acc.Name]
-	if accStreams == nil {
-		accStreams = make(map[string]*streamAssignment)
-	} else if osa := accStreams[stream]; osa != nil && osa != sa {
-		// Copy over private existing state from former SA.
-		sa.Group.node = osa.Group.node
-		sa.consumers = osa.consumers
-		sa.responded = osa.responded
-		sa.err = osa.err
-	}
-
-	// Update our state.
-	accStreams[stream] = sa
-	cc.streams[acc.Name] = accStreams
-	js.mu.Unlock()
 
 	var didRemove bool
 
@@ -2651,11 +2667,7 @@ func (js *jetStream) processUpdateStreamAssignment(sa *streamAssignment) {
 		return
 	}
 
-	acc, err := s.LookupAccount(sa.Client.serviceAccount())
-	if err != nil {
-		// TODO(dlc) - log error
-		return
-	}
+	accName := sa.Client.serviceAccount()
 	stream := sa.Config.Name
 
 	js.mu.Lock()
@@ -2670,7 +2682,7 @@ func (js *jetStream) processUpdateStreamAssignment(sa *streamAssignment) {
 		isMember = sa.Group.isMember(ourID)
 	}
 
-	accStreams := cc.streams[acc.Name]
+	accStreams := cc.streams[accName]
 	if accStreams == nil {
 		js.mu.Unlock()
 		return
@@ -2693,7 +2705,7 @@ func (js *jetStream) processUpdateStreamAssignment(sa *streamAssignment) {
 
 	// Update our state.
 	accStreams[stream] = sa
-	cc.streams[acc.Name] = accStreams
+	cc.streams[accName] = accStreams
 
 	// Make sure we respond if we are a member.
 	if isMember {
@@ -2703,6 +2715,12 @@ func (js *jetStream) processUpdateStreamAssignment(sa *streamAssignment) {
 		sa.Group.node = nil
 	}
 	js.mu.Unlock()
+
+	acc, err := s.LookupAccount(accName)
+	if err != nil {
+		s.Warnf("Update Stream Account %s, error on lookup: %v", accName, err)
+		return
+	}
 
 	// Check if this is for us..
 	if isMember {
@@ -3058,6 +3076,7 @@ func (js *jetStream) processClusterDeleteStream(sa *streamAssignment, isMember, 
 	}
 	js.mu.RUnlock()
 
+	stopped := false
 	var resp = JSApiStreamDeleteResponse{ApiResponse: ApiResponse{Type: JSApiStreamDeleteResponseType}}
 	var err error
 	var acc *Account
@@ -3066,6 +3085,7 @@ func (js *jetStream) processClusterDeleteStream(sa *streamAssignment, isMember, 
 	if acc, _ = s.LookupAccount(sa.Client.serviceAccount()); acc != nil {
 		if mset, _ := acc.lookupStream(sa.Config.Name); mset != nil {
 			err = mset.stop(true, wasLeader)
+			stopped = true
 		}
 	}
 
@@ -3074,6 +3094,24 @@ func (js *jetStream) processClusterDeleteStream(sa *streamAssignment, isMember, 
 		sa.Group.node.Delete()
 	}
 
+	// Cleanup in case account does not exist or node was nil
+	if sacc := s.SystemAccount(); sacc != nil {
+		os.RemoveAll(filepath.Join(js.config.StoreDir, sacc.GetName(), defaultStoreDirName, sa.Group.Name))
+		// cleanup dependent consumer groups
+		if !stopped {
+			for _, ca := range sa.consumers {
+				os.RemoveAll(filepath.Join(js.config.StoreDir, sacc.GetName(), defaultStoreDirName, ca.Group.Name))
+			}
+		}
+	}
+	accDir := filepath.Join(js.config.StoreDir, sa.Client.serviceAccount())
+	streamDir := filepath.Join(accDir, streamsDir)
+	os.RemoveAll(filepath.Join(streamDir, sa.Config.Name))
+
+	// no op if not empty
+	os.Remove(streamDir)
+	os.Remove(accDir)
+
 	// Normally we want only the leader to respond here, but if we had no leader then all members will respond to make
 	// sure we get feedback to the user.
 	if !isMember || (hadLeader && !wasLeader) {
@@ -3081,6 +3119,11 @@ func (js *jetStream) processClusterDeleteStream(sa *streamAssignment, isMember, 
 		if !(offline && isMetaLeader) {
 			return
 		}
+	}
+
+	// Do not respond if the account does not exist any longer
+	if acc == nil {
+		return
 	}
 
 	if err != nil {
@@ -3109,26 +3152,6 @@ func (js *jetStream) processConsumerAssignment(ca *consumerAssignment) {
 	js.mu.RUnlock()
 
 	if s == nil || noMeta {
-		return
-	}
-
-	acc, err := s.LookupAccount(accName)
-	if err != nil {
-		ll := fmt.Sprintf("Account [%s] lookup for consumer create failed: %v", accName, err)
-		if isMember {
-			// If we can not lookup the account and we are a member, send this result back to the metacontroller leader.
-			result := &consumerAssignmentResult{
-				Account:  accName,
-				Stream:   stream,
-				Consumer: consumerName,
-				Response: &JSApiConsumerCreateResponse{ApiResponse: ApiResponse{Type: JSApiConsumerCreateResponseType}},
-			}
-			result.Response.Error = NewJSNoAccountError()
-			s.sendInternalMsgLocked(consumerAssignmentSubj, _EMPTY_, nil, result)
-			s.Warnf(ll)
-		} else {
-			s.Debugf(ll)
-		}
 		return
 	}
 
@@ -3165,6 +3188,26 @@ func (js *jetStream) processConsumerAssignment(ca *consumerAssignment) {
 	// Ok to replace an existing one, we check on process call below.
 	sa.consumers[ca.Name] = ca
 	js.mu.Unlock()
+
+	acc, err := s.LookupAccount(accName)
+	if err != nil {
+		ll := fmt.Sprintf("Account [%s] lookup for consumer create failed: %v", accName, err)
+		if isMember {
+			// If we can not lookup the account and we are a member, send this result back to the metacontroller leader.
+			result := &consumerAssignmentResult{
+				Account:  accName,
+				Stream:   stream,
+				Consumer: consumerName,
+				Response: &JSApiConsumerCreateResponse{ApiResponse: ApiResponse{Type: JSApiConsumerCreateResponseType}},
+			}
+			result.Response.Error = NewJSNoAccountError()
+			s.sendInternalMsgLocked(consumerAssignmentSubj, _EMPTY_, nil, result)
+			s.Warnf(ll)
+		} else {
+			s.Debugf(ll)
+		}
+		return
+	}
 
 	// Check if this is for us..
 	if isMember {
@@ -3499,10 +3542,20 @@ func (js *jetStream) processClusterDeleteConsumer(ca *consumerAssignment, isMemb
 		ca.Group.node.Delete()
 	}
 
+	// Cleanup in case account does not exist or node was nil
+	if sacc := s.SystemAccount(); sacc != nil {
+		os.RemoveAll(filepath.Join(js.config.StoreDir, sacc.GetName(), defaultStoreDirName, ca.Group.Name))
+	}
+
 	if !wasLeader || ca.Reply == _EMPTY_ {
 		if !(offline && isMetaLeader) {
 			return
 		}
+	}
+
+	// Do not respond if the account does not exist any longer
+	if acc == nil {
+		return
 	}
 
 	if err != nil {
@@ -4277,6 +4330,9 @@ func (js *jetStream) startUpdatesSub() {
 	if cc.peerStreamCancelMove == nil {
 		cc.peerStreamCancelMove, _ = s.systemSubscribe(JSApiServerStreamCancelMove, _EMPTY_, false, c, s.jsLeaderServerStreamCancelMoveRequest)
 	}
+	if js.accountPurge == nil {
+		js.accountPurge, _ = s.systemSubscribe(JSApiAccountPurge, _EMPTY_, false, c, s.jsLeaderAccountPurgeRequest)
+	}
 }
 
 // Lock should be held.
@@ -4305,6 +4361,10 @@ func (js *jetStream) stopUpdatesSub() {
 	if cc.peerStreamCancelMove != nil {
 		cc.s.sysUnsubscribe(cc.peerStreamCancelMove)
 		cc.peerStreamCancelMove = nil
+	}
+	if js.accountPurge != nil {
+		cc.s.sysUnsubscribe(js.accountPurge)
+		js.accountPurge = nil
 	}
 }
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -4198,6 +4198,7 @@ func (mset *stream) stop(deleteFlag, advisory bool) error {
 	// Remove from our account map.
 	jsa.mu.Lock()
 	delete(jsa.streams, mset.cfg.Name)
+	accName := jsa.account.Name
 	jsa.mu.Unlock()
 
 	// Clean up consumers.
@@ -4318,6 +4319,12 @@ func (mset *stream) stop(deleteFlag, advisory bool) error {
 			return err
 		}
 		js.releaseStreamResources(&mset.cfg)
+
+		// cleanup directories after the stream
+		accDir := filepath.Join(js.config.StoreDir, accName)
+		// no op if not empty
+		os.Remove(filepath.Join(accDir, streamsDir))
+		os.Remove(accDir)
 	} else if err := store.Stop(); err != nil {
 		return err
 	}


### PR DESCRIPTION
The new request is available for the system account.
The subject to send the request to is `$JS.API.ACCOUNT.PURGE.*`
With the name of the account to purge instead of the wildcard.

Also added directory cleanup code such that server do not
end up with empty streams directories and account dirs that
only contain streams

Also adding ACCOUNT to leaf node domain rewrite table

Addresses #3186 and #3306 by providing a way to
get rid of the streams for existing and non existing accounts