### PR TITLE
Fixed JS cluster prefix name for Travis run

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -11702,7 +11702,7 @@ func TestJetStreamClusterRePublishUpdateNotSupported(t *testing.T) {
 	t.Run("Clustered", func(t *testing.T) { test(t, c.randomServer(), "clustered", 3) })
 }
 
-func TestJetStreamDirectGetFromLeafnode(t *testing.T) {
+func TestJetStreamClusterDirectGetFromLeafnode(t *testing.T) {
 	tmpl := strings.Replace(jsClusterAccountsTempl, "store_dir:", "domain: CORE, store_dir:", 1)
 	c := createJetStreamCluster(t, tmpl, "CORE", _EMPTY_, 3, 19022, true)
 	defer c.shutdown()


### PR DESCRIPTION
Related to PR #3329 that added the test but with incorrect name prefix in order to run on Travis.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
