### PR TITLE
On stream create, change AllowDirect set test on MaxMsgsPer to > 0

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -1202,7 +1202,7 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 	}
 
 	// Here we will auto set direct gets if MaxMsgsPerSubject is set.
-	if cfg.MaxMsgsPer != 0 {
+	if cfg.MaxMsgsPer > 0 {
 		cfg.AllowDirect = true
 	}
 


### PR DESCRIPTION
Resolves #3336:

On stream create, MaxMsgsPer is checked for values != 0 and sets AllowDirect to true if test is true. Unset or explicit 0 in stream request initializes MaxMsgsPer to -1 so test will always be true. Test instead for > 0 (an explicit configuration of messages per subject limit).

Changes made:

Change test from !=0 to >0.

/cc @nats-io/core
