### PR TITLE
Fix chaos tests build tags for Travis

### DIFF
--- a/scripts/runTestsOnTravis.sh
+++ b/scripts/runTestsOnTravis.sh
@@ -13,7 +13,7 @@ if [ "$1" = "compile" ]; then
     $(exit $(go fmt $GO_LIST | wc -l));
     go vet $GO_LIST;
     find . -type f -name "*.go" | xargs misspell -error -locale US;
-    staticcheck $GO_LIST
+    staticcheck -tags=js_chaos_tests $GO_LIST
     if [ "$TRAVIS_TAG" != "" ]; then
         go test -race -v -run=TestVersionMatchesTag ./server -count=1 -vet=off
     fi
@@ -35,7 +35,7 @@ elif [ "$1" = "js_tests" ]; then
     # tests by using the `skip_js_cluster_tests` and `skip_js_super_cluster_tests`
     # build tags.
 
-    go test -race -v -run=TestJetStream ./server -tags=skip_js_cluster_tests,skip_js_super_cluster_tests,skip_js_chaos_tests -count=1 -vet=off -timeout=30m -failfast
+    go test -race -v -run=TestJetStream ./server -tags=skip_js_cluster_tests,skip_js_super_cluster_tests -count=1 -vet=off -timeout=30m -failfast
 
 elif [ "$1" = "js_cluster_tests" ]; then
 
@@ -56,7 +56,7 @@ elif [ "$1" = "js_chaos_tests" ]; then
     # Run JetStream chaos tests. By convention, all JS cluster chaos
     # tests with `TestJetStreamChaos`.
 
-    go test -race -v -p=1 -run=TestJetStreamChaos ./server -count=1 -vet=off -timeout=30m -failfast
+    go test -race -v -p=1 -run=TestJetStreamChaos ./server -tags=js_chaos_tests -count=1 -vet=off -timeout=30m -failfast
 
 elif [ "$1" = "srv_pkg_non_js_tests" ]; then
 

--- a/scripts/runTestsOnTravis.sh
+++ b/scripts/runTestsOnTravis.sh
@@ -35,7 +35,7 @@ elif [ "$1" = "js_tests" ]; then
     # tests by using the `skip_js_cluster_tests` and `skip_js_super_cluster_tests`
     # build tags.
 
-    go test -race -v -run=TestJetStream ./server -tags=skip_js_cluster_tests,skip_js_super_cluster_tests,skip_js_cluster_chaos_tests -count=1 -vet=off -timeout=30m -failfast
+    go test -race -v -run=TestJetStream ./server -tags=skip_js_cluster_tests,skip_js_super_cluster_tests,skip_js_chaos_tests -count=1 -vet=off -timeout=30m -failfast
 
 elif [ "$1" = "js_cluster_tests" ]; then
 

--- a/server/jetstream_chaos_cluster_test.go
+++ b/server/jetstream_chaos_cluster_test.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !skip_js_tests && !skip_js_cluster_tests && !skip_js_chaos_tests
-// +build !skip_js_tests,!skip_js_cluster_tests,!skip_js_chaos_tests
+//go:build js_chaos_tests
+// +build js_chaos_tests
 
 package server
 

--- a/server/jetstream_chaos_helpers_test.go
+++ b/server/jetstream_chaos_helpers_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !skip_js_tests && !skip_js_cluster_tests && !skip_js_chaos_tests
+// +build !skip_js_tests,!skip_js_cluster_tests,!skip_js_chaos_tests
+
 package server
 
 import (

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -1315,13 +1315,6 @@ func (c *cluster) waitOnClusterReadyWithNumPeers(numPeersExpected int) {
 	}
 }
 
-func (c *cluster) waitOnClusterHealthz() {
-	c.t.Helper()
-	for _, cs := range c.servers {
-		c.waitOnServerHealthz(cs)
-	}
-}
-
 // Helper function to remove JetStream from a server.
 func (c *cluster) removeJetStream(s *Server) {
 	c.t.Helper()
@@ -1352,13 +1345,6 @@ func (c *cluster) removeJetStream(s *Server) {
 func (c *cluster) stopAll() {
 	c.t.Helper()
 	for _, s := range c.servers {
-		s.Shutdown()
-	}
-}
-
-func (c *cluster) stopSubset(toStop []*Server) {
-	c.t.Helper()
-	for _, s := range toStop {
 		s.Shutdown()
 	}
 }
@@ -1408,19 +1394,6 @@ func (c *cluster) stableTotalSubs() (total int) {
 	})
 	return nsubs
 
-}
-
-func (c *cluster) selectRandomServers(numServers int) []*Server {
-	c.t.Helper()
-	if numServers > len(c.servers) {
-		panic(fmt.Sprintf("Can't select %d servers in a cluster of %d", numServers, len(c.servers)))
-	}
-	var selectedServers []*Server
-	selectedServers = append(selectedServers, c.servers...)
-	rand.Shuffle(len(selectedServers), func(x, y int) {
-		selectedServers[x], selectedServers[y] = selectedServers[y], selectedServers[x]
-	})
-	return selectedServers[0:numServers]
 }
 
 func addStream(t *testing.T, nc *nats.Conn, cfg *StreamConfig) *StreamInfo {


### PR DESCRIPTION
 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

### Changes proposed in this pull request:

[[FIXED] Wrong flag in Travis to exclude chaos tests](https://github.com/nats-io/nats-server/commit/60b0180102c78a83afb3f5d10f466fccdfb730d5)  …
The `js_tests` build target was using the wrong tag to exclude chaos 
tests.
As a result, chaos tests would run as part of the default testing.

[Exclude chaos tests helpers from default build](https://github.com/nats-io/nats-server/commit/60ef3e228283673e85610bda5a223a2c70e91437)

/cc @nats-io/core
