### PR TITLE
better error when peer selection fails

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -80,10 +80,10 @@
     "deprecates": ""
   },
   {
-    "constant": "JSClusterNoPeersErr",
+    "constant": "JSClusterNoPeersErrF",
     "code": 400,
     "error_code": 10005,
-    "description": "no suitable peers for placement",
+    "description": "no suitable peers for placement: {err}",
     "comment": "",
     "help": "",
     "url": "",

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4245,7 +4245,9 @@ func (js *jetStream) processStreamAssignmentResults(sub *subscription, c *client
 			if cfg.Placement == nil || cfg.Placement.Cluster == _EMPTY_ {
 				// If we have additional clusters to try we can retry.
 				if ci != nil && len(ci.Alternates) > 0 {
-					if rg := js.createGroupForStream(ci, cfg); rg != nil {
+					if rg, err := js.createGroupForStream(ci, cfg); err != nil {
+						s.Warnf("Retrying cluster placement for stream '%s > %s' failed due to placement error: %+v", result.Account, result.Stream, err)
+					} else {
 						if org := sa.Group; org != nil && len(org.Peers) > 0 {
 							s.Warnf("Retrying cluster placement for stream '%s > %s' due to insufficient resources in cluster %q",
 								result.Account, result.Stream, s.clusterNameForNode(org.Peers[0]))
@@ -4476,11 +4478,44 @@ func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, removePe
 	return false
 }
 
+type selectPeerError struct {
+	cluster      string
+	clusterPeers int
+	offline      int
+	excludeTag   int
+	noTagMatch   int
+	noSpace      int
+	uniqueTag    int
+	misc         int
+}
+
+func (e *selectPeerError) Error() string {
+	return fmt.Sprintf(`peer selection cluster '%s' with %d peers
+offline: %d
+excludeTag: %d
+noTagMatch: %d
+noSpace: %d
+uniqueTag: %d
+misc: %d
+`,
+		e.cluster, e.clusterPeers, e.offline, e.excludeTag, e.noTagMatch, e.noSpace, e.uniqueTag, e.misc)
+}
+
+type selectPeerErrors []*selectPeerError
+
+func (e *selectPeerErrors) Error() string {
+	errors := make([]string, len(*e))
+	for i, err := range *e {
+		errors[i] = err.Error()
+	}
+	return strings.Join(errors, "\n")
+}
+
 // selectPeerGroup will select a group of peers to start a raft group.
 // when peers exist already the unique tag prefix check for the replaceFirstExisting will be skipped
-func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamConfig, existing []string, replaceFirstExisting int) (re []string) {
+func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamConfig, existing []string, replaceFirstExisting int) ([]string, *selectPeerError) {
 	if cluster == _EMPTY_ || cfg == nil {
-		return nil
+		return nil, &selectPeerError{cluster: cluster, misc: 1}
 	}
 
 	var maxBytes uint64
@@ -4515,28 +4550,28 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 			}
 		}
 	}
-	var uniqueTags = make(map[string]struct{})
+	var uniqueTags = make(map[string]*nodeInfo)
 
-	checkUniqueTag := func(ni *nodeInfo) bool {
-		// default requires the unique prefix to be present
-		isUnique := false
+	checkUniqueTag := func(ni *nodeInfo) (bool, *nodeInfo) {
 		for _, t := range ni.tags {
 			if strings.HasPrefix(t, uniqueTagPrefix) {
-				if _, ok := uniqueTags[t]; !ok {
-					uniqueTags[t] = struct{}{}
-					isUnique = true
+				if n, ok := uniqueTags[t]; !ok {
+					uniqueTags[t] = ni
+					return true, ni
+				} else {
+					return false, n
 				}
-				break
 			}
 		}
-		return isUnique
+		// default requires the unique prefix to be present
+		return false, nil
 	}
 
 	// Map existing.
 	var ep map[string]struct{}
 	if le := len(existing); le > 0 {
 		if le >= r {
-			return existing
+			return existing[:r], nil
 		}
 		ep = make(map[string]struct{})
 		for i, p := range existing {
@@ -4556,17 +4591,30 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 
 	maxHaAssets := s.getOpts().JetStreamLimits.MaxHAAssets
 
+	// An error is a result of multiple individual placement decisions.
+	// Which is why we keep taps on how often which one happened.
+	err := selectPeerError{cluster: cluster}
+
 	// Shuffle them up.
 	rand.Shuffle(len(peers), func(i, j int) { peers[i], peers[j] = peers[j], peers[i] })
 	for _, p := range peers {
 		si, ok := s.nodeToInfo.Load(p.ID)
 		if !ok || si == nil {
+			err.misc++
 			continue
 		}
 		ni := si.(nodeInfo)
 		// Only select from the designated named cluster.
-		// If we know its offline or we do not have config or stats don't consider.
-		if ni.cluster != cluster || ni.offline || ni.cfg == nil || ni.stats == nil {
+		if ni.cluster != cluster {
+			s.Debugf("Peer selection: discard %s@%s reason: not target cluster %s", ni.name, ni.cluster, cluster)
+			continue
+		}
+		err.clusterPeers++
+
+		// If we know its offline or we do not have config or err don't consider.
+		if ni.offline || ni.cfg == nil || ni.stats == nil {
+			s.Debugf("Peer selection: discard %s@%s reason: offline", ni.name, ni.cluster)
+			err.offline++
 			continue
 		}
 
@@ -4578,6 +4626,9 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 		}
 
 		if ni.tags.Contains(jsExcludePlacement) {
+			s.Debugf("Peer selection: discard %s@%s tags: %v reason: %s present",
+				ni.name, ni.cluster, ni.tags, jsExcludePlacement)
+			err.excludeTag++
 			continue
 		}
 
@@ -4586,10 +4637,13 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 			for _, t := range tags {
 				if !ni.tags.Contains(t) {
 					matched = false
+					s.Debugf("Peer selection: discard %s@%s tags: %v reason: mandatory tag %s not present",
+						ni.name, ni.cluster, ni.tags, t)
 					break
 				}
 			}
 			if !matched {
+				err.noTagMatch++
 				continue
 			}
 		}
@@ -4620,19 +4674,31 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 
 		// Otherwise check if we have enough room if maxBytes set.
 		if maxBytes > 0 && maxBytes > available {
-			s.Warnf("%s@%s (Max Bytes: %d) exceeds available %s storage of %d bytes",
+			s.Warnf("Peer selection: discard %s@%s (Max Bytes: %d) exceeds available %s storage of %d bytes",
 				ni.name, ni.cluster, maxBytes, cfg.Storage.String(), available)
+			err.noSpace++
 			continue
 		}
 		// HAAssets contain _meta_ which we want to ignore
 		if maxHaAssets > 0 && ni.stats != nil && ni.stats.HAAssets > maxHaAssets {
-			s.Warnf("%s@%s (HA Asset Count: %d) exceeds max ha asset limit of %d for stream placement",
+			s.Warnf("Peer selection: discard %s@%s (HA Asset Count: %d) exceeds max ha asset limit of %d for stream placement",
 				ni.name, ni.cluster, ni.stats.HAAssets, maxHaAssets)
+			err.misc++
 			continue
 		}
 
-		if uniqueTagPrefix != _EMPTY_ && !checkUniqueTag(&ni) {
-			continue
+		if uniqueTagPrefix != _EMPTY_ {
+			if unique, owner := checkUniqueTag(&ni); !unique {
+				if owner != nil {
+					s.Debugf("Peer selection: discard %s@%s tags:%v reason: unique prefix %s owned by %s@%s",
+						ni.name, ni.cluster, ni.tags, owner.name, owner.cluster)
+				} else {
+					s.Debugf("Peer selection: discard %s@%s tags:%v reason: unique prefix %s not present",
+						ni.name, ni.cluster, ni.tags)
+				}
+				err.uniqueTag++
+				continue
+			}
 		}
 		// Add to our list of potential nodes.
 		nodes = append(nodes, wn{p.ID, available, ha})
@@ -4640,7 +4706,9 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 
 	// If we could not select enough peers, fail.
 	if len(nodes) < (r - len(existing)) {
-		return nil
+		s.Debugf("Peer selection: required %d nodes but found %d (cluster: %s replica: %d existing: %v/%d peers: %d result-peers: %d err: %+v)",
+			(r - len(existing)), len(nodes), cluster, r, existing, replaceFirstExisting, len(peers), len(nodes), err)
+		return nil, &err
 	}
 	// Sort based on available from most to least.
 	sort.Slice(nodes, func(i, j int) bool { return nodes[i].avail > nodes[j].avail })
@@ -4658,7 +4726,7 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 	for _, r := range nodes[:r] {
 		results = append(results, r.id)
 	}
-	return results
+	return results, nil
 }
 
 func groupNameForStream(peers []string, storage StorageType) string {
@@ -4705,7 +4773,7 @@ func tieredStreamAndReservationCount(asa map[string]*streamAssignment, tier stri
 
 // createGroupForStream will create a group for assignment for the stream.
 // Lock should be held.
-func (js *jetStream) createGroupForStream(ci *ClientInfo, cfg *StreamConfig) *raftGroup {
+func (js *jetStream) createGroupForStream(ci *ClientInfo, cfg *StreamConfig) (*raftGroup, *selectPeerErrors) {
 	replicas := cfg.Replicas
 	if replicas == 0 {
 		replicas = 1
@@ -4724,14 +4792,16 @@ func (js *jetStream) createGroupForStream(ci *ClientInfo, cfg *StreamConfig) *ra
 	}
 
 	// Need to create a group here.
+	errFirst := selectPeerErrors{}
 	for _, cn := range clusters {
-		peers := cc.selectPeerGroup(replicas, cn, cfg, nil, 0)
+		peers, err := cc.selectPeerGroup(replicas, cn, cfg, nil, 0)
 		if len(peers) < replicas {
+			errFirst = append(errFirst, err)
 			continue
 		}
-		return &raftGroup{Name: groupNameForStream(peers, cfg.Storage), Storage: cfg.Storage, Peers: peers, Cluster: cn}
+		return &raftGroup{Name: groupNameForStream(peers, cfg.Storage), Storage: cfg.Storage, Peers: peers, Cluster: cn}, nil
 	}
-	return nil
+	return nil, &errFirst
 }
 
 func (acc *Account) selectLimits(cfg *StreamConfig) (*JetStreamAccountLimits, string, *jsAccount, *ApiError) {
@@ -4847,9 +4917,9 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 	}
 
 	// Raft group selection and placement.
-	rg := js.createGroupForStream(ci, cfg)
-	if rg == nil {
-		resp.Error = NewJSInsufficientResourcesError()
+	rg, err := js.createGroupForStream(ci, cfg)
+	if err != nil {
+		resp.Error = NewJSClusterNoPeersError(err)
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return
 	}
@@ -5016,9 +5086,9 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 	if isReplicaChange {
 		// We are adding new peers here.
 		if newCfg.Replicas > len(rg.Peers) {
-			peers := cc.selectPeerGroup(newCfg.Replicas, rg.Cluster, newCfg, rg.Peers, 0)
-			if len(peers) != newCfg.Replicas {
-				resp.Error = NewJSInsufficientResourcesError()
+			peers, err := cc.selectPeerGroup(newCfg.Replicas, rg.Cluster, newCfg, rg.Peers, 0)
+			if err != nil {
+				resp.Error = NewJSClusterNoPeersError(err)
 				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 				return
 			}
@@ -5089,9 +5159,9 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		}
 	} else if isMoveRequest {
 		if len(peerSet) == 0 {
-			nrg := js.createGroupForStream(ci, newCfg)
-			if nrg == nil {
-				resp.Error = NewJSInsufficientResourcesError()
+			nrg, err := js.createGroupForStream(ci, newCfg)
+			if err != nil {
+				resp.Error = NewJSClusterNoPeersError(err)
 				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 				return
 			}
@@ -5275,9 +5345,9 @@ func (s *Server) jsClusteredStreamRestoreRequest(
 	}
 
 	// Raft group selection and placement.
-	rg := js.createGroupForStream(ci, cfg)
-	if rg == nil {
-		resp.Error = NewJSInsufficientResourcesError()
+	rg, err := js.createGroupForStream(ci, cfg)
+	if err != nil {
+		resp.Error = NewJSClusterNoPeersError(err)
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return
 	}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4484,7 +4484,7 @@ type selectPeerError struct {
 	offline      int
 	excludeTag   int
 	noTagMatch   int
-	noSpace      int
+	noStorage    int
 	uniqueTag    int
 	misc         int
 }
@@ -4494,11 +4494,11 @@ func (e *selectPeerError) Error() string {
 offline: %d
 excludeTag: %d
 noTagMatch: %d
-noSpace: %d
+noStorage: %d
 uniqueTag: %d
 misc: %d
 `,
-		e.cluster, e.clusterPeers, e.offline, e.excludeTag, e.noTagMatch, e.noSpace, e.uniqueTag, e.misc)
+		e.cluster, e.clusterPeers, e.offline, e.excludeTag, e.noTagMatch, e.noStorage, e.uniqueTag, e.misc)
 }
 
 type selectPeerErrors []*selectPeerError
@@ -4676,7 +4676,7 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 		if maxBytes > 0 && maxBytes > available {
 			s.Warnf("Peer selection: discard %s@%s (Max Bytes: %d) exceeds available %s storage of %d bytes",
 				ni.name, ni.cluster, maxBytes, cfg.Storage.String(), available)
-			err.noSpace++
+			err.noStorage++
 			continue
 		}
 		// HAAssets contain _meta_ which we want to ignore

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -148,7 +148,7 @@ func TestJetStreamClusterStreamLimitWithAccountDefaults(t *testing.T) {
 		Replicas: 2,
 		MaxBytes: 15 * 1024 * 1024,
 	})
-	require_Error(t, err, NewJSInsufficientResourcesError(), NewJSStorageResourcesExceededError())
+	require_Contains(t, err.Error(), "no suitable peers for placement")
 }
 
 func TestJetStreamClusterSingleReplicaStreams(t *testing.T) {
@@ -1047,7 +1047,7 @@ func TestJetStreamClusterMaxBytesForStream(t *testing.T) {
 	cfg.Name = "TEST2"
 	cfg.MaxBytes *= 2
 	_, err = js.AddStream(cfg)
-	require_Error(t, err, NewJSInsufficientResourcesError(), NewJSStorageResourcesExceededError())
+	require_Contains(t, err.Error(), "no suitable peers for placement")
 }
 
 func TestJetStreamClusterStreamPublishWithActiveConsumers(t *testing.T) {
@@ -3634,7 +3634,8 @@ func TestJetStreamClusterPeerExclusionTag(t *testing.T) {
 		c.Subjects = []string{c.Name}
 		_, err := js.AddStream(&c)
 		require_Error(t, err)
-		require_Contains(t, err.Error(), "insufficient resources")
+		require_Contains(t, err.Error(), "no suitable peers for placement", "3 peers",
+			"excludeTag: 1", "offline: 0", "uniqueTag: 0")
 	}
 
 	// Test update failure
@@ -3645,8 +3646,8 @@ func TestJetStreamClusterPeerExclusionTag(t *testing.T) {
 	cfg.Replicas = 3
 	_, err = js.UpdateStream(cfg)
 	require_Error(t, err)
-	require_Contains(t, err.Error(), "insufficient resources")
-
+	require_Contains(t, err.Error(), "no suitable peers for placement", "3 peers",
+		"excludeTag: 1", "offline: 0", "uniqueTag: 0")
 	// Test tag reload removing !jetstream tag, and allowing placement again
 
 	srv := c.serverByName("S-1")
@@ -9398,7 +9399,7 @@ func TestJetStreamClusterBalancedPlacement(t *testing.T) {
 		Replicas: 2,
 		MaxBytes: 1 * 1024 * 1024 * 1024,
 	})
-	require_Error(t, err, NewJSInsufficientResourcesError(), NewJSStorageResourcesExceededError())
+	require_Contains(t, err.Error(), "no suitable peers for placement")
 }
 
 func TestJetStreamClusterConsumerPendingBug(t *testing.T) {

--- a/server/jetstream_leafnode_test.go
+++ b/server/jetstream_leafnode_test.go
@@ -484,7 +484,7 @@ leafnodes:{
 					require_NoError(t, err)
 				} else {
 					require_Error(t, err)
-					require_Contains(t, err.Error(), "insufficient resources")
+					require_Contains(t, err.Error(), "no suitable peers for placement")
 				}
 				ncL := natsConnect(t, fmt.Sprintf("nats://a1:a1@127.0.0.1:%d", sLA.opts.Port))
 				defer ncL.Close()
@@ -499,7 +499,7 @@ leafnodes:{
 					require_NoError(t, err)
 				} else {
 					require_Error(t, err)
-					require_Contains(t, err.Error(), "insufficient resources")
+					require_Contains(t, err.Error(), "no suitable peers for placement")
 				}
 			}
 			clusterLnCnt := func(expected int) error {

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -5753,8 +5754,8 @@ func TestMQTTStreamReplicasInsufficientResources(t *testing.T) {
 
 	select {
 	case e := <-l.errCh:
-		if !strings.Contains(e, NewJSInsufficientResourcesError().Description) {
-			t.Fatalf("Expected error regarding insufficient resources, got %v", e)
+		if !strings.Contains(e, fmt.Sprintf("%d", NewJSClusterNoPeersError(errors.New("")).ErrCode)) {
+			t.Fatalf("Expected error regarding no peers error, got %v", e)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatalf("Did not get the error regarding replicas count")


### PR DESCRIPTION
It is pretty hard to diagnose what went wrong when not enough peers for
an operation where found. This change now returns counts of reasons why
peers where discarded.

**This is a first shot at this and we don't want to reveal too much information.
So please let me know if you think I'm showing too much and/or should
change the format. The intent is that whoever sees this error, has enough 
information to why it failed, without having to rely on logging.**

Changed the error to `JSClusterNoPeers` as it seems more appropriate
of an error for that operation. Not having enough resources is one of
the conditions for a peer not being considered. But so is having a non
matching tag. Which is why `JSClusterNoPeers` seems more appropriate
In addition, `JSClusterNoPeers` was already used as error after one call
to `selectPeerGroup` already.

example:
```
no suitable peers for placement: peer selection cluster 'C' with 3 peers
offline: 0
excludeTag: 1
noTagMatch: 2
noSpace: 0
uniqueTag: 0
misc: 0
```

Examle for mqtt:
```
mid:12 - "mqtt" - unable to connect: create sessions stream for account "$G":
no suitable peers for placement: peer selection cluster 'MQTT' with 3 peers
        offline: 0
        excludeTag: 0
        noTagMatch: 0
        noSpace: 0
        uniqueTag: 0
        misc: 0
         (10005)
```
Signed-off-by: Matthias Hanel <mh@synadia.com>
