### PR TITLE
[IMPROVED] DirectGet performance and memory usage for large streams.

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1232,6 +1232,8 @@ func (a *Account) EnableJetStream(limits map[string]JetStreamAccountLimits) erro
 			cfg.StreamConfig.Subjects = nil
 		}
 
+		s.Noticef("  Starting restore for stream '%s > %s'", a.Name, cfg.StreamConfig.Name)
+
 		// Add in the stream.
 		mset, err := a.addStream(&cfg.StreamConfig)
 		if err != nil {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -12338,10 +12338,14 @@ func TestJetStreamTemplatedErrorsBug(t *testing.T) {
 }
 
 func TestJetStreamServerEncryption(t *testing.T) {
-	conf := createConfFile(t, []byte(`
+	tmpl := `
 		listen: 127.0.0.1:-1
-		jetstream: {key: $JS_KEY}
-	`))
+		jetstream: {key: $JS_KEY, store_dir: '%s'}
+	`
+	storeDir := createDir(t, JetStreamStoreDir)
+	defer removeDir(t, storeDir)
+
+	conf := createConfFile(t, []byte(fmt.Sprintf(tmpl, storeDir)))
 	defer removeFile(t, conf)
 
 	os.Setenv("JS_KEY", "s3cr3t!!")


### PR DESCRIPTION
This PR is to improve the worst case lookup times for direct get by subject, e.g. KV.

When the number of blocks became very large, the linear scan walking backwards for the correct block, and the linear scan walking forward to find the previous entry to delete was becoming slow. This would become evident in > 100M messages or small block sizes, e.g. 4k.

We now use better indexing for lookups by soft tracking the first and last block per subject.
We also improve memory usage by some degree on very large stores by swapping out the per block subject info and swap out the indexing data structures more aggressively.

This approximately doubles the number of messages we can store and manage with direct gets.

More work to be done but this is a start.

Signed-off-by: Derek Collison <derek@nats.io>

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [ ] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [ ] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

### Changes proposed in this pull request:

 -
 -
 -

/cc @nats-io/core
