### PR TITLE
fixed consumer restart on source filter update

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -1397,13 +1397,13 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 
 		// Check for Sources.
 		if len(cfg.Sources) > 0 || len(ocfg.Sources) > 0 {
-			current := make(map[string]struct{})
+			current := make(map[string]string)
 			for _, s := range ocfg.Sources {
-				current[s.iname] = struct{}{}
+				current[s.iname] = s.FilterSubject
 			}
 			for _, s := range cfg.Sources {
 				s.setIndexName()
-				if _, ok := current[s.iname]; !ok {
+				if oFilter, ok := current[s.iname]; !ok {
 					if mset.sources == nil {
 						mset.sources = make(map[string]*sourceInfo)
 					}
@@ -1412,6 +1412,13 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 					mset.sources[s.iname] = si
 					mset.setStartingSequenceForSource(s.iname)
 					mset.setSourceConsumer(s.iname, si.sseq+1)
+				} else if oFilter != s.FilterSubject {
+					if si, ok := mset.sources[s.iname]; ok {
+						mset.cancelSourceInfo(si)
+						// si.sseq is the last message we received
+						// if upstream has more messages, that we used to filter, now we get now
+						mset.setSourceConsumer(s.iname, si.sseq+1)
+					}
 				}
 				delete(current, s.iname)
 			}

--- a/server/stream.go
+++ b/server/stream.go
@@ -1414,7 +1414,6 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 					mset.setSourceConsumer(s.iname, si.sseq+1)
 				} else if oFilter != s.FilterSubject {
 					if si, ok := mset.sources[s.iname]; ok {
-						mset.cancelSourceInfo(si)
 						// si.sseq is the last message we received
 						// if upstream has more messages, that we used to filter, now we get now
 						mset.setSourceConsumer(s.iname, si.sseq+1)


### PR DESCRIPTION
When a stream source filter subject was updated, the internal consumer
was not re created

If the upstream stream contains a tail of previously filtered messages,
these will now be delivered

PLEASE check my method to restart and if my use of mset.setSourceConsumer(s.iname, si.sseq+1) is the right thing to do here. Test etc... look al right. just want to point this one out.