### PR TITLE
[FIXED] JetStream: subject overlap error should be returned

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -402,7 +402,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 	// Check for overlapping subjects. These are not allowed for now.
 	if jsa.subjectsOverlap(cfg.Subjects) {
 		jsa.mu.Unlock()
-		return nil, fmt.Errorf("subjects overlap with an existing stream")
+		return nil, NewJSStreamSubjectOverlapError()
 	}
 
 	if !hasTier {


### PR DESCRIPTION
In standalone mode, when attempting to create a stream which has
subjects that overlap with an existing stream, the generic
stream create error "10049" was returned instead of the more
accurate "10065" error code corresponding to subject overlap,
as it was the case in clustered mode.

Resolves #3362

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
