### PR TITLE
Reduce length of some clustering tests

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1633,8 +1633,10 @@ func currentPeerCount(ci *ClusterInfo, peerSet []string, leaderId string) (curre
 	return
 }
 
+const defaultScaleDownDelayTicks = 2
+
 // how many migration tracker ticks of delay to induce
-const scaleDownDelayTicks = 2
+var scaleDownDelayTicks = defaultScaleDownDelayTicks
 
 // Monitor our stream node for this stream.
 func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnapshot bool) {

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -2869,6 +2869,10 @@ func TestJetStreamSuperClusterMoveCancel(t *testing.T) {
 }
 
 func TestJetStreamSuperClusterDoubleStreamMove(t *testing.T) {
+	// Shorten this test by factor of 2.
+	scaleDownDelayTicks = 0
+	defer func() { scaleDownDelayTicks = defaultScaleDownDelayTicks }()
+
 	server := map[string]struct{}{}
 	sc := createJetStreamSuperClusterWithTemplateAndModHook(t, jsClusterTempl, 4, 2,
 		func(serverName, clusterName, storeDir, conf string) string {
@@ -3069,6 +3073,10 @@ func TestJetStreamSuperClusterDoubleStreamMove(t *testing.T) {
 }
 
 func TestJetStreamSuperClusterPeerEvacuationAndStreamReassignment(t *testing.T) {
+	// Shorten this test by factor of 2.
+	scaleDownDelayTicks = 0
+	defer func() { scaleDownDelayTicks = defaultScaleDownDelayTicks }()
+
 	s := createJetStreamSuperClusterWithTemplateAndModHook(t, jsClusterTempl, 4, 2,
 		func(serverName, clusterName, storeDir, conf string) string {
 			return fmt.Sprintf("%s\nserver_tags: [cluster:%s, server:%s]", conf, clusterName, serverName)


### PR DESCRIPTION
Since PR #3381, the 2 tests modified here would take twice as
long (around 245 seconds) to complete.
Talking with Matthias, he suggested using a variable instead of
a const and set it to 0 for those 2 tests since they don't really
need that to be set.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
