### PR TITLE
fix consumer subject validation on recovery

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -446,9 +446,14 @@ func checkConsumerCfg(
 	}
 
 	// As best we can make sure the filtered subject is valid.
-	if config.FilterSubject != _EMPTY_ && !isRecovering {
-		subjects, hasExt := allSubjects(cfg, acc)
-		if !validFilteredSubject(config.FilterSubject, subjects) && !hasExt {
+	if config.FilterSubject != _EMPTY_ {
+		subjects := copyStrings(cfg.Subjects)
+		// explicitly skip validFilteredSubject when recovering
+		hasExt := isRecovering
+		if !isRecovering {
+			subjects, hasExt = gatherSourceMirrorSubjects(subjects, cfg, acc)
+		}
+		if !hasExt && !validFilteredSubject(config.FilterSubject, subjects) {
 			return NewJSConsumerFilterNotSubsetError()
 		}
 	}

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -5477,7 +5477,7 @@ func TestJetStreamClusterSourcesUpdateOriginError(t *testing.T) {
 			} else if tsi.State.Msgs != msgsTest {
 				return fmt.Errorf("received %d msgs from TEST, expected %d", tsi.State.Msgs, msgsTest)
 			} else if msi.State.Msgs != msgsM {
-				return fmt.Errorf("received %d msgs from TEST, expected %d", msi.State.Msgs, msgsM)
+				return fmt.Errorf("received %d msgs from M, expected %d", msi.State.Msgs, msgsM)
 			}
 			return nil
 		})

--- a/server/stream.go
+++ b/server/stream.go
@@ -1612,8 +1612,7 @@ func (mset *stream) sourcesInfo() (sis []*StreamSourceInfo) {
 	return sis
 }
 
-func allSubjects(cfg *StreamConfig, acc *Account) ([]string, bool) {
-	subjects := copyStrings(cfg.Subjects)
+func gatherSourceMirrorSubjects(subjects []string, cfg *StreamConfig, acc *Account) ([]string, bool) {
 	var hasExt bool
 	var seen map[string]bool
 


### PR DESCRIPTION
This fixes an issue introduced in #3080
The consumer filter subject check was skipped on recovery.

The intent was to bypass the upstream stream subjects.
But it also filtered the downstream stream subject.
This became a problem when the downstream was itself an upstream.

Then during recover, the stream subject was not checked, which
lead to delivery of filtered messages that should never have been
delivered.

Signed-off-by: Matthias Hanel <mh@synadia.com>

-- Detail explanation --

he issue was was introduced by
```
commit f702e279ab4de56f907db10a563a64407fd64831
Author: Derek Collison <derek@nats.io>
Date:   Tue Apr 26 17:06:43 2022 -0700

    Fix for a consumer recovery issue.
    Also update healthz to check all assets that are assigned, not just running.

    Signed-off-by: Derek Collison <derek@nats.io>
```

In `checkConsumerCfg` we basically skip filter subject validation by adding `&& !isRecovering` to the existing code
```
	// As best we can make sure the filtered subject is valid.
	if config.FilterSubject != _EMPTY_ && !isRecovering {
		subjects, hasExt := allSubjects(cfg, acc)
		if !validFilteredSubject(config.FilterSubject, subjects) && !hasExt {
			return NewJSConsumerFilterNotSubsetError()
		}
	}
```

I believe this was added to compensate for
```
// We had a scenario where a consumer would not recover properly on restart due to
// the cluster state not being set properly when checking source subjects.
func TestJetStreamSuperClusterStateOnRestartPreventsConsumerRecovery(t *testing.T) {
```

From the test I'd say the original issue was caused by deleting upstream
```
	// Pull source out from underneath the downstream stream.
	err = js.DeleteStream("SOURCE")
	require_NoError(t, err)
```

The original fix may be too broad here.
It intended to cover upstream filter subject validation.
But it also caused to skip the subject validation of the downstream.
This change always checks the downstream subject validation and skips upstream when in recovery mode
