### PR TITLE
fix signing key template processing dropping allow

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -514,8 +514,8 @@ func processUserPermissionsTemplate(lim jwt.UserPermissionLimits, ujwt *jwt.User
 		return emittedList, nil
 	}
 
-	subAllowWasEmpty := len(lim.Permissions.Sub.Allow) > 0
-	pubAllowWasEmpty := len(lim.Permissions.Pub.Allow) > 0
+	subAllowWasNotEmpty := len(lim.Permissions.Sub.Allow) > 0
+	pubAllowWasNotEmpty := len(lim.Permissions.Pub.Allow) > 0
 
 	var err error
 	if lim.Permissions.Sub.Allow, err = applyTemplate(lim.Permissions.Sub.Allow, false); err != nil {
@@ -528,11 +528,11 @@ func processUserPermissionsTemplate(lim jwt.UserPermissionLimits, ujwt *jwt.User
 		return jwt.UserPermissionLimits{}, err
 	}
 
-	// if pub/sub allow where not empty, but are empty post template processing, add in a deny to compensate
-	if subAllowWasEmpty && len(lim.Permissions.Sub.Allow) == 0 {
+	// if pub/sub allow were not empty, but are empty post template processing, add in a "deny >" to compensate
+	if subAllowWasNotEmpty && len(lim.Permissions.Sub.Allow) == 0 {
 		lim.Permissions.Sub.Deny.Add(">")
 	}
-	if pubAllowWasEmpty && len(lim.Permissions.Pub.Allow) == 0 {
+	if pubAllowWasNotEmpty && len(lim.Permissions.Pub.Allow) == 0 {
 		lim.Permissions.Pub.Deny.Add(">")
 	}
 	return lim, nil

--- a/server/auth.go
+++ b/server/auth.go
@@ -513,6 +513,10 @@ func processUserPermissionsTemplate(lim jwt.UserPermissionLimits, ujwt *jwt.User
 		}
 		return emittedList, nil
 	}
+
+	subAllowWasEmpty := len(lim.Permissions.Sub.Allow) > 0
+	pubAllowWasEmpty := len(lim.Permissions.Pub.Allow) > 0
+
 	var err error
 	if lim.Permissions.Sub.Allow, err = applyTemplate(lim.Permissions.Sub.Allow, false); err != nil {
 		return jwt.UserPermissionLimits{}, err
@@ -522,6 +526,14 @@ func processUserPermissionsTemplate(lim jwt.UserPermissionLimits, ujwt *jwt.User
 		return jwt.UserPermissionLimits{}, err
 	} else if lim.Permissions.Pub.Deny, err = applyTemplate(lim.Permissions.Pub.Deny, true); err != nil {
 		return jwt.UserPermissionLimits{}, err
+	}
+
+	// if pub/sub allow where not empty, but are empty post template processing, add in a deny to compensate
+	if subAllowWasEmpty && len(lim.Permissions.Sub.Allow) == 0 {
+		lim.Permissions.Sub.Deny.Add(">")
+	}
+	if pubAllowWasEmpty && len(lim.Permissions.Pub.Allow) == 0 {
+		lim.Permissions.Pub.Deny.Add(">")
 	}
 	return lim, nil
 }

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -4416,8 +4416,10 @@ func TestJwtTemplates(t *testing.T) {
 	test(resLim.Pub.Deny, []string{"foo1.acc1", "foo1.acc2", "foo2.acc1", "foo2.acc2"})
 
 	require_True(t, len(resLim.Sub.Allow) == 0)
-	require_True(t, len(resLim.Sub.Deny) == 1)
+	require_True(t, len(resLim.Sub.Deny) == 2)
 	require_Contains(t, resLim.Sub.Deny[0], fmt.Sprintf("foo.myname.%s.accname.%s.bar", upub, aPub))
+	// added in to compensate for sub allow not resolving
+	require_Contains(t, resLim.Sub.Deny[1], fmt.Sprintf(">"))
 
 	lim.Pub.Deny.Add("{{tag(NOT_THERE)}}")
 	_, err = processUserPermissionsTemplate(lim, uclaim, acc)

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -4419,7 +4419,7 @@ func TestJwtTemplates(t *testing.T) {
 	require_True(t, len(resLim.Sub.Deny) == 2)
 	require_Contains(t, resLim.Sub.Deny[0], fmt.Sprintf("foo.myname.%s.accname.%s.bar", upub, aPub))
 	// added in to compensate for sub allow not resolving
-	require_Contains(t, resLim.Sub.Deny[1], fmt.Sprintf(">"))
+	require_Contains(t, resLim.Sub.Deny[1], ">")
 
 	lim.Pub.Deny.Add("{{tag(NOT_THERE)}}")
 	_, err = processUserPermissionsTemplate(lim, uclaim, acc)


### PR DESCRIPTION
Scoped signing keys allow for optional values in allow rules
If an allow rule therefore gets removed because a tag is not present,
the removal needs to be compensated by adding in a deny >

Signed-off-by: Matthias Hanel <mh@synadia.com>
