### PR TITLE
[FIXED] Service import response invoking svc import

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2141,6 +2141,9 @@ func (a *Account) processServiceImportResponse(sub *subscription, c *client, _ *
 	}
 	a.mu.RUnlock()
 
+	// reset state to prior to service invocation
+	c.pa.subject = []byte(si.to)
+
 	// Send for normal processing.
 	c.processServiceImport(si, a, msg)
 }

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2141,11 +2141,15 @@ func (a *Account) processServiceImportResponse(sub *subscription, c *client, _ *
 	}
 	a.mu.RUnlock()
 
-	// reset state to prior to service invocation
-	c.pa.subject = []byte(si.to)
+	old := c.pa.subject
+	if c.kind == CLIENT || c.kind == LEAF {
+		// reset state to prior to service invocation (code to reset c.pa.subject to old may not be necessary)
+		c.pa.subject = []byte(si.to)
+	}
 
 	// Send for normal processing.
 	c.processServiceImport(si, a, msg)
+	c.pa.subject = old
 }
 
 // Will create the response prefix for fast generation of responses.

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -3524,3 +3524,57 @@ func TestAccountUserSubPermsWithQueueGroups(t *testing.T) {
 	// Expect no msgs.
 	checkSubsPending(t, qsub, 0)
 }
+
+func TestAccountImportCycle(t *testing.T) {
+	cf := createConfFile(t, []byte(`
+               port: -1
+               accounts: {
+                 CP: {
+                       users: [
+                         {user: cp, password: cp},
+                       ],
+                       exports: [
+                         {service: "q1.>", response_type: Singleton},
+                         {service: "q2.>", response_type: Singleton},
+                       ],
+                 },
+                 A: {
+                       users: [
+                         {user: a, password: a},
+                       ],
+                       imports: [
+                         {service: {account: CP, subject: "q1.>"}},
+                         {service: {account: CP, subject: "q2.>"}},
+                       ]
+                 },
+               }
+    `))
+	defer removeFile(t, cf)
+	s, _ := RunServerWithConfig(cf)
+	defer s.Shutdown()
+	ncCp, err := nats.Connect(s.ClientURL(), nats.UserInfo("cp", "cp"))
+	require_NoError(t, err)
+	defer ncCp.Close()
+	ncA, err := nats.Connect(s.ClientURL(), nats.UserInfo("a", "a"))
+	require_NoError(t, err)
+	defer ncA.Close()
+	// setup reply
+	subCp, err := ncCp.SubscribeSync("q1.>")
+	require_NoError(t, err)
+	require_NoError(t, err)
+	// setup requestor and send reply
+	ib := "q2.inbox"
+	subAResp, err := ncA.SubscribeSync(ib)
+	require_NoError(t, err)
+	// send request
+	err = ncA.PublishRequest("q1.a", ib, []byte("test"))
+	require_NoError(t, err)
+	// reply
+	mReq, err := subCp.NextMsg(time.Second)
+	require_NoError(t, err)
+	err = mReq.Respond([]byte("reply"))
+	require_NoError(t, err)
+	mRep, err := subAResp.NextMsg(time.Second)
+	require_NoError(t, err)
+	require_Contains(t, string(mRep.Data), "reply")
+}

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -3561,7 +3561,6 @@ func TestAccountImportCycle(t *testing.T) {
 	// setup reply
 	subCp, err := ncCp.SubscribeSync("q1.>")
 	require_NoError(t, err)
-	require_NoError(t, err)
 	// setup requestor and send reply
 	ib := "q2.inbox"
 	subAResp, err := ncA.SubscribeSync(ib)

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -6951,6 +6951,7 @@ func TestJetStreamClusterDomainsWithNoJSHub(t *testing.T) {
 
 // Issue #2205
 func TestJetStreamClusterDomainsAndAPIResponses(t *testing.T) {
+	t.SkipNow()
 	// This adds in domain config option to template.
 	tmpl := strings.Replace(jsClusterAccountsTempl, "store_dir:", "domain: CORE, store_dir:", 1)
 	c := createJetStreamCluster(t, tmpl, "CORE", _EMPTY_, 3, 12232, true)

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -6951,7 +6951,6 @@ func TestJetStreamClusterDomainsWithNoJSHub(t *testing.T) {
 
 // Issue #2205
 func TestJetStreamClusterDomainsAndAPIResponses(t *testing.T) {
-	t.SkipNow()
 	// This adds in domain config option to template.
 	tmpl := strings.Replace(jsClusterAccountsTempl, "store_dir:", "domain: CORE, store_dir:", 1)
 	c := createJetStreamCluster(t, tmpl, "CORE", _EMPTY_, 3, 12232, true)


### PR DESCRIPTION
past processing the import response, c.pa was not reset to the
appropriate state, which lead to an unintended recursion.
(see traces with comments for detail)

The initial change had no check for client/leaf but one unit test failed `TestJetStreamClusterDomainsAndAPIResponses`
So now I only reset the state for client/leaf node. 
But I'm not 100% sure why not doing it for routes/gateway would matter.
We are done with the response, so we shouldn't keep the re-written subject around.

To be on the safe side we also added a reset when we did make the switch.
Don't think it's strictly necessary, but we didn't want to risk it.

added traces with explanations
```
start
processMsgResults dsubj: 'q1.a' reply: 'q2.inbox'
deliverMsg 'q1.a' reply: 'q2.inbox'
import sub subject: 'q1.a' reply 'q2.inbox'
processServiceImport deliver '' to 'q1.a' subject 'q1.a'  <------ ref1 for later
processMsgResults dsubj: 'q1.a' reply: '_R_.EJnM3R.wAPT4u'
received request: q1.a will respond to: _R_.EJnM3R.wAPT4u
processMsgResults dsubj: '_R_.EJnM3R.wAPT4u' reply: ''    <------ ref2 for later
deliverMsg '_R_.EJnM3R.wAPT4u' reply: ''
processServiceImportResponse _R_.EJnM3R.wAPT4u &{acc:0xc0001e1680 claim:<nil> se:0xc0000958b0 sid:[] from:_R_.EJnM3R.wAPT4u to:q2.inbox tr:<nil> ts:1661282551977096000 rt:0 latency:<nil> m1:<nil> rc:<nil> usePub:false response:true invalid:false share:false tracking:false didDeliver:false trackingHdr:map[]}
processServiceImport deliver '' to 'q2.inbox' subject '_R_.EJnM3R.wAPT4u' <----- service reply inside requesting account, would expect subject == q2.inbox similar to ref1
processMsgResults dsubj: 'q2.inbox' reply: ''                             <----- no reply, looks ok
deliverMsg 'q2.inbox' reply: ''
import sub subject: 'q2.inbox' reply '' .  <----- service reply triggers the next import service invocation  
processServiceImport deliver '' to '_R_.EJnM3R.wAPT4u' subject '_R_.EJnM3R.wAPT4u' <----- did not expect to see this subject. would expect q2.inbox, which would be similar ref1
processMsgResults dsubj: '_R_.EJnM3R.wAPT4u' reply: '' .  <----- next recursion step, goto ref2
```
