### PR TITLE
Don't fail if auto setting of maxprocs fails.

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,9 +123,10 @@ func main() {
 	// Adjust MAXPROCS if running under linux/cgroups quotas.
 	undo, err := maxprocs.Set(maxprocs.Logger(s.Debugf))
 	if err != nil {
-		server.PrintAndDie(fmt.Sprintf("failed to set GOMAXPROCS: %v", err))
+		s.Warnf("Failed to set GOMAXPROCS: %v", err)
+	} else {
+		defer undo()
 	}
-	defer undo()
 
 	s.WaitForShutdown()
 }


### PR DESCRIPTION
Can fail in some embedded systems.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
