### PR TITLE
[FIXED] Service import/export cycles causing stack overflow

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2141,15 +2141,8 @@ func (a *Account) processServiceImportResponse(sub *subscription, c *client, _ *
 	}
 	a.mu.RUnlock()
 
-	old := c.pa.subject
-	if c.kind == CLIENT || c.kind == LEAF {
-		// reset state to prior to service invocation (code to reset c.pa.subject to old may not be necessary)
-		c.pa.subject = []byte(si.to)
-	}
-
 	// Send for normal processing.
 	c.processServiceImport(si, a, msg)
-	c.pa.subject = old
 }
 
 // Will create the response prefix for fast generation of responses.

--- a/server/parser.go
+++ b/server/parser.go
@@ -48,7 +48,7 @@ type pubArg struct {
 	queues  [][]byte
 	size    int
 	hdr     int
-	psi     *serviceImport
+	psi     []*serviceImport
 }
 
 // Parser constants


### PR DESCRIPTION
There was a way to detect a cycle but I believe it needs to be
a stack of "si" not just the one before invoking processServiceImport.

Changes in #3393 would solve issue reported with test TestAccountImportCycle,
but would not address the new reported issue represented by new test
TestLeafNodeSvcImportExportCycle. This current approach seems to solve
all known cases.

Resolves #3397
Replaces #3393
