### PR TITLE
When writing a msg after the fss state was expired we would count the msg twice.

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -5399,7 +5399,7 @@ func TestNoRaceJetStreamFileStoreLargeKVAccessTiming(t *testing.T) {
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: blkSize, CacheExpire: 5 * time.Second},
-		StreamConfig{Name: "zzz", Storage: FileStorage, MaxMsgsPer: 1},
+		StreamConfig{Name: "zzz", Subjects: []string{"KV.STREAM_NAME.*"}, Storage: FileStorage, MaxMsgsPer: 1},
 	)
 	require_NoError(t, err)
 	defer fs.Stop()


### PR DESCRIPTION
This was due to the fact that we updated the accounting and then checked if we needed to load state which would then fallback to generating the state on the fly.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
