### PR TITLE
[ADDED] JetStream: Ability to configure the per server max catchup bytes

### DIFF
--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -13066,3 +13066,92 @@ func TestJetStreamClusterReplicasChangeStreamInfo(t *testing.T) {
 
 	checkStreamInfo(js)
 }
+
+func TestJetStreamClusterMaxCatchup(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "MCB", 3)
+	defer c.shutdown()
+
+	for _, s := range c.servers {
+		s.gcbMu.RLock()
+		v := s.gcbOutMax
+		s.gcbMu.RUnlock()
+		if v != defaultMaxTotalCatchupOutBytes {
+			t.Fatalf("Server %v, expected max catchup to be %v, got %v", s, defaultMaxTotalCatchupOutBytes, v)
+		}
+	}
+
+	c.shutdown()
+
+	tmpl := `
+		listen: 127.0.0.1:-1
+		server_name: %s
+		jetstream: { max_catchup: 1KB, domain: ngs, max_mem_store: 256MB, max_file_store: 2GB, store_dir: '%s'}
+		leaf: { listen: 127.0.0.1:-1 }
+		cluster {
+			name: %s
+			listen: 127.0.0.1:%d
+			routes = [%s]
+		}
+	`
+	c = createJetStreamClusterWithTemplate(t, tmpl, "MCB", 3)
+	defer c.shutdown()
+
+	for _, s := range c.servers {
+		s.gcbMu.RLock()
+		v := s.gcbOutMax
+		s.gcbMu.RUnlock()
+		if v != 1024 {
+			t.Fatalf("Server %v, expected max catchup to be 1KB, got %v", s, v)
+		}
+	}
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+	// Close client now and will create new one
+	nc.Close()
+
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+
+	follower := c.randomNonStreamLeader(globalAccountName, "TEST")
+	follower.Shutdown()
+
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+
+	// Create new connection in case we would have been connected to follower.
+	nc, _ = jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	payload := string(make([]byte, 2048))
+	for i := 0; i < 1000; i++ {
+		sendStreamMsg(t, nc, "foo", payload)
+	}
+
+	// Cause snapshots on leader
+	mset, err := c.streamLeader(globalAccountName, "TEST").GlobalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	err = mset.raftNode().InstallSnapshot(mset.stateSnapshot())
+	require_NoError(t, err)
+
+	// Resart server and it should be able to catchup
+	follower = c.restartServer(follower)
+	c.waitOnStreamCurrent(follower, globalAccountName, "TEST")
+
+	// Config reload not supported
+	s := c.servers[0]
+	cfile := s.getOpts().ConfigFile
+	content, err := os.ReadFile(cfile)
+	require_NoError(t, err)
+	conf := string(content)
+	conf = strings.ReplaceAll(conf, "max_catchup: 1KB,", "max_catchup: 1MB,")
+	err = os.WriteFile(cfile, []byte(conf), 0644)
+	require_NoError(t, err)
+	err = s.Reload()
+	require_Error(t, err, fmt.Errorf("config reload not supported for JetStreamMaxCatchup: old=1024, new=1048576"))
+}

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -13067,7 +13067,7 @@ func TestJetStreamClusterReplicasChangeStreamInfo(t *testing.T) {
 	checkStreamInfo(js)
 }
 
-func TestJetStreamClusterMaxCatchup(t *testing.T) {
+func TestJetStreamClusterMaxOutstandingCatchup(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "MCB", 3)
 	defer c.shutdown()
 
@@ -13076,7 +13076,7 @@ func TestJetStreamClusterMaxCatchup(t *testing.T) {
 		v := s.gcbOutMax
 		s.gcbMu.RUnlock()
 		if v != defaultMaxTotalCatchupOutBytes {
-			t.Fatalf("Server %v, expected max catchup to be %v, got %v", s, defaultMaxTotalCatchupOutBytes, v)
+			t.Fatalf("Server %v, expected max_outstanding_catchup to be %v, got %v", s, defaultMaxTotalCatchupOutBytes, v)
 		}
 	}
 
@@ -13085,7 +13085,7 @@ func TestJetStreamClusterMaxCatchup(t *testing.T) {
 	tmpl := `
 		listen: 127.0.0.1:-1
 		server_name: %s
-		jetstream: { max_catchup: 1KB, domain: ngs, max_mem_store: 256MB, max_file_store: 2GB, store_dir: '%s'}
+		jetstream: { max_outstanding_catchup: 1KB, domain: ngs, max_mem_store: 256MB, max_file_store: 2GB, store_dir: '%s'}
 		leaf: { listen: 127.0.0.1:-1 }
 		cluster {
 			name: %s
@@ -13101,7 +13101,7 @@ func TestJetStreamClusterMaxCatchup(t *testing.T) {
 		v := s.gcbOutMax
 		s.gcbMu.RUnlock()
 		if v != 1024 {
-			t.Fatalf("Server %v, expected max catchup to be 1KB, got %v", s, v)
+			t.Fatalf("Server %v, expected max_outstanding_catchup to be 1KB, got %v", s, v)
 		}
 	}
 
@@ -13149,7 +13149,7 @@ func TestJetStreamClusterMaxCatchup(t *testing.T) {
 	content, err := os.ReadFile(cfile)
 	require_NoError(t, err)
 	conf := string(content)
-	conf = strings.ReplaceAll(conf, "max_catchup: 1KB,", "max_catchup: 1MB,")
+	conf = strings.ReplaceAll(conf, "max_outstanding_catchup: 1KB,", "max_outstanding_catchup: 1MB,")
 	err = os.WriteFile(cfile, []byte(conf), 0644)
 	require_NoError(t, err)
 	err = s.Reload()

--- a/server/opts.go
+++ b/server/opts.go
@@ -255,6 +255,7 @@ type Options struct {
 	JetStreamCipher       StoreCipher   `json:"-"`
 	JetStreamUniqueTag    string
 	JetStreamLimits       JSLimitOpts
+	JetStreamMaxCatchup   int64
 	StoreDir              string            `json:"-"`
 	JsAccDefaultDomain    map[string]string `json:"-"` // account to domain name mapping
 	Websocket             WebsocketOpts     `json:"-"`
@@ -1948,6 +1949,12 @@ func parseJetStream(v interface{}, opts *Options, errors *[]error, warnings *[]e
 				}
 			case "unique_tag":
 				opts.JetStreamUniqueTag = strings.ToLower(strings.TrimSpace(mv.(string)))
+			case "max_catchup", "max_catchup_bytes", "max_total_catchup_bytes":
+				s, err := getStorageSize(mv)
+				if err != nil {
+					return &configErr{tk, fmt.Sprintf("%s %s", strings.ToLower(mk), err)}
+				}
+				opts.JetStreamMaxCatchup = s
 			default:
 				if !tk.IsUsedVariable() {
 					err := &unknownConfigFieldErr{

--- a/server/opts.go
+++ b/server/opts.go
@@ -1949,7 +1949,7 @@ func parseJetStream(v interface{}, opts *Options, errors *[]error, warnings *[]e
 				}
 			case "unique_tag":
 				opts.JetStreamUniqueTag = strings.ToLower(strings.TrimSpace(mv.(string)))
-			case "max_catchup", "max_catchup_bytes", "max_total_catchup_bytes":
+			case "max_outstanding_catchup":
 				s, err := getStorageSize(mv)
 				if err != nil {
 					return &configErr{tk, fmt.Sprintf("%s %s", strings.ToLower(mk), err)}

--- a/server/server.go
+++ b/server/server.go
@@ -279,8 +279,9 @@ type Server struct {
 	rateLimitLoggingCh chan time.Duration
 
 	// Total outstanding catchup bytes in flight.
-	gcbMu  sync.RWMutex
-	gcbOut int64
+	gcbMu     sync.RWMutex
+	gcbOut    int64
+	gcbOutMax int64 // Taken from JetStreamMaxCatchup or defaultMaxTotalCatchupOutBytes
 	// A global chanel to kick out stalled catchup sequences.
 	gcbKick chan struct{}
 


### PR DESCRIPTION
The original value was hardcoded to 128MB and 32MB per stream. The
per-server limit is lowered to 32MB but is configurable with
a new configuration parameter:
```
jetstream {
   max_catchup: 8MB
}
```

The per-stream limit was also lowered from 32MB/128,000msgs to
8MB/32,000 messages.

Tests have shown no difference in performance for fast links.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
