### PR TITLE
Allow optional compression in raft and stream catchup, move improvements for streams and consumers

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -33,7 +33,7 @@ const (
 	defaultSolicitGatewaysDelay         = time.Second
 	defaultGatewayConnectDelay          = time.Second
 	defaultGatewayReconnectDelay        = time.Second
-	defaultGatewayRecentSubExpiration   = 250 * time.Millisecond
+	defaultGatewayRecentSubExpiration   = 2 * time.Second
 	defaultGatewayMaxRUnsubBeforeSwitch = 1000
 
 	oldGWReplyPrefix    = "$GR."

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -38,10 +38,11 @@ import (
 // JetStreamConfig determines this server's configuration.
 // MaxMemory and MaxStore are in bytes.
 type JetStreamConfig struct {
-	MaxMemory int64  `json:"max_memory"`
-	MaxStore  int64  `json:"max_storage"`
-	StoreDir  string `json:"store_dir,omitempty"`
-	Domain    string `json:"domain,omitempty"`
+	MaxMemory  int64  `json:"max_memory"`
+	MaxStore   int64  `json:"max_storage"`
+	StoreDir   string `json:"store_dir,omitempty"`
+	Domain     string `json:"domain,omitempty"`
+	CompressOK bool   `json:"compress_ok,omitempty"`
 }
 
 // Statistics about JetStream for this server.

--- a/server/server.go
+++ b/server/server.go
@@ -434,7 +434,7 @@ func NewServer(opts *Options) (*Server, error) {
 			opts.JetStreamDomain,
 			info.ID,
 			opts.Tags,
-			&JetStreamConfig{MaxMemory: opts.JetStreamMaxMemory, MaxStore: opts.JetStreamMaxStore},
+			&JetStreamConfig{MaxMemory: opts.JetStreamMaxMemory, MaxStore: opts.JetStreamMaxStore, CompressOK: true},
 			nil,
 			false, true,
 		})
@@ -1758,10 +1758,11 @@ func (s *Server) Start() {
 			s.Fatalf("Not allowed to enable JetStream on the system account")
 		}
 		cfg := &JetStreamConfig{
-			StoreDir:  opts.StoreDir,
-			MaxMemory: opts.JetStreamMaxMemory,
-			MaxStore:  opts.JetStreamMaxStore,
-			Domain:    opts.JetStreamDomain,
+			StoreDir:   opts.StoreDir,
+			MaxMemory:  opts.JetStreamMaxMemory,
+			MaxStore:   opts.JetStreamMaxStore,
+			Domain:     opts.JetStreamDomain,
+			CompressOK: true,
 		}
 		if err := s.EnableJetStream(cfg); err != nil {
 			s.Fatalf("Can't start JetStream: %v", err)

--- a/server/stream.go
+++ b/server/stream.go
@@ -225,18 +225,19 @@ type stream struct {
 
 	// TODO(dlc) - Hide everything below behind two pointers.
 	// Clustered mode.
-	sa       *streamAssignment
-	node     RaftNode
-	catchup  bool
-	syncSub  *subscription
-	infoSub  *subscription
-	clMu     sync.Mutex
-	clseq    uint64
-	clfs     uint64
-	leader   string
-	lqsent   time.Time
-	catchups map[string]uint64
-	uch      chan struct{}
+	sa         *streamAssignment
+	node       RaftNode
+	catchup    bool
+	syncSub    *subscription
+	infoSub    *subscription
+	clMu       sync.Mutex
+	clseq      uint64
+	clfs       uint64
+	leader     string
+	lqsent     time.Time
+	catchups   map[string]uint64
+	uch        chan struct{}
+	compressOK bool
 
 	// Direct get subscription.
 	directSub *subscription


### PR DESCRIPTION
We will not optionally compress raft traffic and stream catchup messages iff all peers support it. Current threshold (fixed atm) is 4k for review.

Improved stream and consumer moves.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
