### PR TITLE
Ignore expired accounts when computing reservations

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -2128,6 +2128,9 @@ func (js *jetStream) sufficientResources(limits map[string]JetStreamAccountLimit
 	// Since we know if we are here we are single server mode, check the account reservations.
 	var storeReserved, memReserved int64
 	for _, jsa := range js.accounts {
+		if jsa.account.IsExpired() {
+			continue
+		}
 		jsa.usageMu.RLock()
 		maxMemory, maxStore := totalMaxBytes(jsa.limits)
 		jsa.usageMu.RUnlock()


### PR DESCRIPTION
 - [X] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [ ] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #3420

I'm really not sure this change is sufficient for the general use but it fixes my issue. Please use it as a hint to understand the issue.

### Changes proposed in this pull request:

 - ignore expired accounts when jetstream computes the resources consumed before enabling a new account


/cc @nats-io/core
