### PR TITLE
[FIXED] Subjects collide would not properly return false.

### DIFF
--- a/server/sublist.go
+++ b/server/sublist.go
@@ -1215,10 +1215,18 @@ func SubjectsCollide(subj1, subj2 string) bool {
 	if !fwc1 && !fwc2 && len(toks1) != len(toks2) {
 		return false
 	}
+	if lt1, lt2 := len(toks1), len(toks2); lt1 != lt2 {
+		// If the shorter one only has partials then these will not collide.
+		if lt1 < lt2 && !fwc1 || lt2 < lt1 && !fwc2 {
+			return false
+		}
+	}
+
 	stop := len(toks1)
 	if len(toks2) < stop {
 		stop = len(toks2)
 	}
+
 	// We look for reasons to say no.
 	for i := 0; i < stop; i++ {
 		t1, t2 := toks1[i], toks2[i]
@@ -1226,6 +1234,7 @@ func SubjectsCollide(subj1, subj2 string) bool {
 			return false
 		}
 	}
+
 	return true
 }
 

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -1458,6 +1458,14 @@ func TestSublistMatchWithEmptyTokens(t *testing.T) {
 	}
 }
 
+func TestSublistSubjectCollide(t *testing.T) {
+	require_False(t, SubjectsCollide("foo.*", "foo.*.bar.>"))
+	require_False(t, SubjectsCollide("foo.*.bar.>", "foo.*"))
+	require_True(t, SubjectsCollide("foo.*", "foo.foo"))
+	require_True(t, SubjectsCollide("foo.*", "*.foo"))
+	require_True(t, SubjectsCollide("foo.bar.>", "*.bar.foo"))
+}
+
 // -- Benchmarks Setup --
 
 var benchSublistSubs []*subscription

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -70,7 +70,7 @@ func require_True(t *testing.T, b bool) {
 func require_False(t *testing.T, b bool) {
 	t.Helper()
 	if b {
-		t.Fatalf("require no false, but got true")
+		t.Fatalf("require false, but got true")
 	}
 }
 


### PR DESCRIPTION
When a subject with only partial wildcards was compared against a subject with a fwc but more tokens would incorrectly return true. e.g. `foo.*` vs `foo.bar.>`

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #3422 	

/cc @nats-io/core
