### PR TITLE
Publish and consume JS benchmarks

### DIFF
--- a/server/events_test.go
+++ b/server/events_test.go
@@ -423,13 +423,13 @@ func runSolicitWithCredentials(t *testing.T, opts *Options, creds string) (*Serv
 }
 
 // Helper function to check that a leaf node has connected to our server.
-func checkLeafNodeConnected(t *testing.T, s *Server) {
+func checkLeafNodeConnected(t testing.TB, s *Server) {
 	t.Helper()
 	checkLeafNodeConnectedCount(t, s, 1)
 }
 
 // Helper function to check that a leaf node has connected to n server.
-func checkLeafNodeConnectedCount(t *testing.T, s *Server, lnCons int) {
+func checkLeafNodeConnectedCount(t testing.TB, s *Server, lnCons int) {
 	t.Helper()
 	checkFor(t, 5*time.Second, 15*time.Millisecond, func() error {
 		if nln := s.NumLeafNodes(); nln != lnCons {

--- a/server/jetstream_benchmark_consume_test.go
+++ b/server/jetstream_benchmark_consume_test.go
@@ -1,0 +1,404 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !skip_js_tests && !skip_js_cluster_tests
+// +build !skip_js_tests,!skip_js_cluster_tests
+
+package server
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func BenchmarkJetStreamConsume(b *testing.B) {
+
+	const (
+		verbose        = false
+		streamName     = "S"
+		subject        = "s"
+		seed           = 12345
+		publishTimeout = 30 * time.Second
+	)
+
+	runSyncPushConsumer := func(b *testing.B, js nats.JetStreamContext, streamName, subject string) (int, int, int) {
+		const nextMsgTimeout = 3 * time.Second
+
+		subOpts := []nats.SubOpt{
+			nats.BindStream(streamName),
+		}
+		sub, err := js.SubscribeSync("", subOpts...)
+		if err != nil {
+			b.Fatalf("Failed to subscribe: %v", err)
+		}
+		defer sub.Unsubscribe()
+
+		bitset := NewBitset(uint64(b.N))
+		uniqueConsumed, duplicates, errors := 0, 0, 0
+
+		b.ResetTimer()
+
+		for uniqueConsumed < b.N {
+			msg, err := sub.NextMsg(nextMsgTimeout)
+			if err != nil {
+				b.Fatalf("No more messages (received: %d/%d)", uniqueConsumed, b.N)
+			}
+
+			metadata, mdErr := msg.Metadata()
+			if mdErr != nil {
+				errors++
+				continue
+			}
+
+			ackErr := msg.Ack()
+			if ackErr != nil {
+				errors++
+				continue
+			}
+
+			seq := metadata.Sequence.Stream
+
+			index := seq - 1
+			if bitset.get(index) {
+				duplicates++
+				continue
+			}
+
+			uniqueConsumed++
+			bitset.set(index, true)
+			b.SetBytes(int64(len(msg.Data)))
+
+			if verbose && uniqueConsumed%1000 == 0 {
+				b.Logf("Consumed: %d/%d", bitset.count(), b.N)
+			}
+		}
+
+		b.StopTimer()
+
+		return uniqueConsumed, duplicates, errors
+	}
+
+	runAsyncPushConsumer := func(b *testing.B, js nats.JetStreamContext, streamName, subject string, ordered, durable bool) (int, int, int) {
+		const timeout = 3 * time.Minute
+		bitset := NewBitset(uint64(b.N))
+		doneCh := make(chan bool, 1)
+		uniqueConsumed, duplicates, errors := 0, 0, 0
+
+		handleMsg := func(msg *nats.Msg) {
+			metadata, mdErr := msg.Metadata()
+			if mdErr != nil {
+				// fmt.Printf("Metadata error: %v\n", mdErr)
+				errors++
+				return
+			}
+
+			// Ordered defaults to AckNone policy, don't try to ACK
+			if !ordered {
+				ackErr := msg.Ack()
+				if ackErr != nil {
+					// fmt.Printf("Ack error: %v\n", ackErr)
+					errors++
+					return
+				}
+			}
+
+			seq := metadata.Sequence.Stream
+
+			index := seq - 1
+			if bitset.get(index) {
+				duplicates++
+				return
+			}
+
+			uniqueConsumed++
+			bitset.set(index, true)
+			b.SetBytes(int64(len(msg.Data)))
+
+			if uniqueConsumed == b.N {
+				msg.Sub.Unsubscribe()
+				doneCh <- true
+			}
+			if verbose && uniqueConsumed%1000 == 0 {
+				b.Logf("Consumed %d/%d", uniqueConsumed, b.N)
+			}
+		}
+
+		subOpts := []nats.SubOpt{
+			nats.BindStream(streamName),
+		}
+
+		if ordered {
+			subOpts = append(subOpts, nats.OrderedConsumer())
+		}
+
+		if durable {
+			subOpts = append(subOpts, nats.Durable("c"))
+		}
+
+		sub, err := js.Subscribe("", handleMsg, subOpts...)
+		if err != nil {
+			b.Fatalf("Failed to subscribe: %v", err)
+		}
+		defer sub.Unsubscribe()
+
+		b.ResetTimer()
+
+		select {
+		case <-doneCh:
+			b.StopTimer()
+		case <-time.After(timeout):
+			b.Fatalf("Timeout, %d/%d received, %d errors", uniqueConsumed, b.N, errors)
+		}
+
+		return uniqueConsumed, duplicates, errors
+	}
+
+	runPullConsumer := func(b *testing.B, js nats.JetStreamContext, streamName, subject string, durable bool) (int, int, int) {
+		const fetchMaxWait = nats.MaxWait(3 * time.Second)
+		const fetchMaxMessages = 1000
+
+		bitset := NewBitset(uint64(b.N))
+		uniqueConsumed, duplicates, errors := 0, 0, 0
+
+		subOpts := []nats.SubOpt{
+			nats.BindStream(streamName),
+		}
+
+		consumerName := "" // Default ephemeral
+		if durable {
+			consumerName = "c" // Durable
+		}
+
+		sub, err := js.PullSubscribe("", consumerName, subOpts...)
+		if err != nil {
+			b.Fatalf("Failed to subscribe: %v", err)
+		}
+		defer sub.Unsubscribe()
+
+		b.ResetTimer()
+
+	fetchLoop:
+		for {
+			msgs, err := sub.Fetch(fetchMaxMessages, fetchMaxWait)
+			if err != nil {
+				b.Fatalf("Failed to fetch: %v", err)
+			}
+
+		processMsgsLoop:
+			for _, msg := range msgs {
+				metadata, mdErr := msg.Metadata()
+				if mdErr != nil {
+					errors++
+					continue processMsgsLoop
+				}
+
+				ackErr := msg.Ack()
+				if ackErr != nil {
+					errors++
+					continue processMsgsLoop
+				}
+
+				seq := metadata.Sequence.Stream
+
+				index := seq - 1
+				if bitset.get(index) {
+					duplicates++
+					continue processMsgsLoop
+				}
+
+				uniqueConsumed++
+				bitset.set(index, true)
+				b.SetBytes(int64(len(msg.Data)))
+
+				if uniqueConsumed == b.N {
+					msg.Sub.Unsubscribe()
+					break fetchLoop
+				}
+
+				if verbose && uniqueConsumed%1000 == 0 {
+					b.Logf("Consumed %d/%d", uniqueConsumed, b.N)
+				}
+			}
+		}
+
+		b.StopTimer()
+
+		return uniqueConsumed, duplicates, errors
+	}
+
+	type ConsumerType string
+	const (
+		PushSync         ConsumerType = "PUSH[Sync,Ephemeral]"
+		PushAsync        ConsumerType = "PUSH[Async,Ephemeral]"
+		PushAsyncOrdered ConsumerType = "PUSH[Async,Ordered]"
+		PushAsyncDurable ConsumerType = "PUSH[Async,Durable]"
+		PullDurable      ConsumerType = "PULL[Durable]"
+		PullEphemeral    ConsumerType = "PULL[Ephemeral]"
+	)
+
+	benchmarksCases := []struct {
+		clusterSize int
+		replicas    int
+		messageSize int
+		minMessages int
+	}{
+		{1, 1, 10, 1_000_000}, // Single node, 10B messages, ~10MiB minimum
+		{1, 1, 1024, 100_000}, // Single node, 1KB messages, ~100MiB minimum
+		{3, 3, 10, 1_000_000}, // Cluster, R3, 10B messages, ~10MiB minimum
+		{3, 3, 1024, 100_000}, // Cluster, R3, 1KB messages, ~100MiB minimum
+	}
+
+	//Each of the cases above is run with each of the consumer types
+	consumerTypes := []ConsumerType{
+		PushSync,
+		PushAsync,
+		PushAsyncOrdered,
+		PushAsyncDurable,
+		PullDurable,
+		PullEphemeral,
+	}
+
+	for _, bc := range benchmarksCases {
+
+		name := fmt.Sprintf(
+			"N=%d,R=%d,MsgSz=%db",
+			bc.clusterSize,
+			bc.replicas,
+			bc.messageSize,
+		)
+
+		b.Run(
+			name,
+			func(b *testing.B) {
+
+				for _, ct := range consumerTypes {
+					name := fmt.Sprintf(
+						"%v",
+						ct,
+					)
+					b.Run(
+						name,
+						func(b *testing.B) {
+							// Skip short runs, benchmark gets re-executed with a larger N
+							if b.N < bc.minMessages {
+								b.ResetTimer()
+								return
+							}
+
+							if verbose {
+								b.Logf("Running %s with %d messages", name, b.N)
+							}
+
+							if verbose {
+								b.Logf("Setting up %d nodes", bc.clusterSize)
+							}
+							var connectURL string
+							if bc.clusterSize == 1 {
+								s := RunBasicJetStreamServer()
+								defer s.Shutdown()
+								connectURL = s.ClientURL()
+							} else {
+								cl := createJetStreamClusterExplicit(b, "BENCH_PUB", bc.clusterSize)
+								defer cl.shutdown()
+								cl.waitOnClusterReadyWithNumPeers(bc.clusterSize)
+								cl.waitOnLeader()
+								connectURL = cl.randomServer().ClientURL()
+							}
+
+							nc, js := jsClientConnectURL(b, connectURL)
+							defer nc.Close()
+
+							if verbose {
+								b.Logf("Creating stream with R=%d", bc.replicas)
+							}
+							streamConfig := &nats.StreamConfig{
+								Name:     streamName,
+								Subjects: []string{subject},
+								Replicas: bc.replicas,
+							}
+							if _, err := js.AddStream(streamConfig); err != nil {
+								b.Fatalf("Error creating stream: %v", err)
+							}
+
+							rng := rand.New(rand.NewSource(int64(seed)))
+							message := make([]byte, bc.messageSize)
+							publishedCount := 0
+							for publishedCount < b.N {
+								rng.Read(message)
+								_, err := js.PublishAsync(subject, message)
+								if err != nil {
+									continue
+								} else {
+									publishedCount++
+								}
+							}
+
+							select {
+							case <-js.PublishAsyncComplete():
+								if verbose {
+									b.Logf("Published %d messages", b.N)
+								}
+							case <-time.After(publishTimeout):
+								b.Fatalf("Publish timed out")
+							}
+
+							// Discard time spent during setup
+							// Consumer may reset again further in
+							b.ResetTimer()
+
+							var consumed, duplicates, errors int
+
+							const (
+								ordered   = true
+								unordered = false
+								durable   = true
+								ephemeral = false
+							)
+
+							switch ct {
+							case PushSync:
+								consumed, duplicates, errors = runSyncPushConsumer(b, js, streamName, subject)
+							case PushAsync:
+								consumed, duplicates, errors = runAsyncPushConsumer(b, js, streamName, subject, unordered, ephemeral)
+							case PushAsyncOrdered:
+								consumed, duplicates, errors = runAsyncPushConsumer(b, js, streamName, subject, ordered, ephemeral)
+							case PushAsyncDurable:
+								consumed, duplicates, errors = runAsyncPushConsumer(b, js, streamName, subject, unordered, durable)
+							case PullDurable:
+								consumed, duplicates, errors = runPullConsumer(b, js, streamName, subject, durable)
+							case PullEphemeral:
+								consumed, duplicates, errors = runPullConsumer(b, js, streamName, subject, ephemeral)
+							default:
+								b.Fatalf("Unknown consumer type: %v", ct)
+							}
+
+							// Benchmark ends here, (consumer may have stopped earlier)
+							b.StopTimer()
+
+							if consumed != b.N {
+								b.Fatalf("Something doesn't add up: %d != %d", consumed, b.N)
+							}
+
+							b.ReportMetric(float64(duplicates)*100/float64(b.N), "%dupe")
+							b.ReportMetric(float64(errors)*100/float64(b.N), "%error")
+						},
+					)
+				}
+			},
+		)
+	}
+}

--- a/server/jetstream_benchmark_publish_test.go
+++ b/server/jetstream_benchmark_publish_test.go
@@ -1,0 +1,274 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !skip_js_tests && !skip_js_cluster_tests
+// +build !skip_js_tests,!skip_js_cluster_tests
+
+package server
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func BenchmarkJetStreamPublish(b *testing.B) {
+
+	const (
+		verbose = false
+		seed    = 12345
+	)
+
+	runSyncPublisher := func(b *testing.B, js nats.JetStreamContext, messageSize int, subjects []string) (int, int) {
+		published, errors := 0, 0
+		rng := rand.New(rand.NewSource(int64(seed)))
+		message := make([]byte, messageSize)
+
+		b.ResetTimer()
+
+		for i := 1; i <= b.N; i++ {
+			rng.Read(message) // TODO may skip this?
+			subject := subjects[rng.Intn(len(subjects))]
+			_, pubErr := js.Publish(subject, message)
+			if pubErr != nil {
+				errors++
+			} else {
+				published++
+				b.SetBytes(int64(messageSize))
+			}
+
+			if verbose && i%1000 == 0 {
+				b.Logf("Published %d/%d, %d errors", i, b.N, errors)
+			}
+		}
+
+		b.StopTimer()
+
+		return published, errors
+	}
+
+	runAsyncPublisher := func(b *testing.B, js nats.JetStreamContext, messageSize int, subjects []string, asyncWindow int) (int, int) {
+		const publishCompleteMaxWait = 30 * time.Second
+		rng := rand.New(rand.NewSource(int64(seed)))
+		message := make([]byte, messageSize)
+		pending := make([]nats.PubAckFuture, 0, asyncWindow)
+		published, errors := 0, 0
+
+		b.ResetTimer()
+
+		for i := 1; i <= b.N; i++ {
+			rng.Read(message) // TODO may skip this?
+			subject := subjects[rng.Intn(len(subjects))]
+			pubAckFuture, err := js.PublishAsync(subject, message)
+			if err != nil {
+				errors++
+				continue
+			}
+			pending = append(pending, pubAckFuture)
+
+			// Regularly trim the list of pending
+			if i%asyncWindow == 0 {
+				newPending := make([]nats.PubAckFuture, 0, asyncWindow)
+				for _, pubAckFuture := range pending {
+					select {
+					case <-pubAckFuture.Ok():
+						published++
+						b.SetBytes(int64(messageSize))
+					case <-pubAckFuture.Err():
+						errors++
+					default:
+						// This pubAck is still pending, keep it
+						newPending = append(newPending, pubAckFuture)
+					}
+				}
+				pending = newPending
+			}
+
+			if verbose && i%1000 == 0 {
+				b.Logf("Published %d/%d, %d errors", i, b.N, errors)
+			}
+		}
+
+		// All published, wait for completed
+		select {
+		case <-js.PublishAsyncComplete():
+		case <-time.After(publishCompleteMaxWait):
+			b.Fatalf("Publish timed out")
+		}
+
+		// Clear whatever is left pending
+		for _, pubAckFuture := range pending {
+			select {
+			case <-pubAckFuture.Ok():
+				published++
+				b.SetBytes(int64(messageSize))
+			case <-pubAckFuture.Err():
+				errors++
+			default:
+				b.Fatalf("PubAck is still pending after publish completed")
+			}
+		}
+
+		b.StopTimer()
+
+		return published, errors
+	}
+
+	type PublishType string
+	const (
+		Sync  PublishType = "Sync"
+		Async PublishType = "Async"
+	)
+
+	benchmarksCases := []struct {
+		clusterSize int
+		replicas    int
+		messageSize int
+		numSubjects int
+		minMessages int
+	}{
+		{1, 1, 10, 1, 1_000_000}, // Single node, 10B messages, ~10MB minimum
+		{1, 1, 1024, 1, 500_000}, // Single node, 1KB messages, ~500MB minimum
+		{3, 3, 10, 1, 500_000},   // 3-nodes cluster, R=3, 10B messages, ~5MB minimum
+		{3, 3, 1024, 1, 100_000}, // 3-nodes cluster, R=3, 10B messages, ~100MB minimum
+	}
+
+	// All the cases above are run with each of the publisher cases below
+	publisherCases := []struct {
+		pType       PublishType
+		asyncWindow int
+	}{
+		{Sync, -1},
+		{Async, 1000},
+		{Async, 4000},
+		{Async, 8000},
+	}
+
+	for _, bc := range benchmarksCases {
+		name := fmt.Sprintf(
+			"N=%d,R=%d,MsgSz=%db,Subjs=%d",
+			bc.clusterSize,
+			bc.replicas,
+			bc.messageSize,
+			bc.numSubjects,
+		)
+
+		b.Run(
+			name,
+			func(b *testing.B) {
+
+				for _, pc := range publisherCases {
+					name := fmt.Sprintf("%v", pc.pType)
+					if pc.pType == Async && pc.asyncWindow > 0 {
+						name = fmt.Sprintf("%s[W:%d]", name, pc.asyncWindow)
+					}
+
+					b.Run(
+						name,
+						func(b *testing.B) {
+							// Skip short runs, benchmark gets re-executed with a larger N
+							if b.N < bc.minMessages {
+								b.ResetTimer()
+								return
+							}
+
+							subjects := make([]string, bc.numSubjects)
+							for i := 0; i < bc.numSubjects; i++ {
+								subjects[i] = fmt.Sprintf("s-%d", i+1)
+							}
+
+							if verbose {
+								b.Logf("Running %s with %d ops", name, b.N)
+							}
+
+							if verbose {
+								b.Logf("Setting up %d nodes", bc.clusterSize)
+							}
+							var connectURL string
+
+							if bc.clusterSize == 1 {
+								s := RunBasicJetStreamServer()
+								defer s.Shutdown()
+								connectURL = s.ClientURL()
+							} else {
+								cl := createJetStreamClusterExplicit(b, "BENCH_PUB", bc.clusterSize)
+								defer cl.shutdown()
+								cl.waitOnClusterReadyWithNumPeers(bc.clusterSize)
+								cl.waitOnLeader()
+								connectURL = cl.randomServer().ClientURL()
+							}
+
+							nc, err := nats.Connect(connectURL)
+							if err != nil {
+								b.Fatalf("Failed to create client: %v", err)
+							}
+							defer nc.Close()
+
+							jsOpts := []nats.JSOpt{
+								nats.MaxWait(10 * time.Second),
+							}
+
+							if pc.asyncWindow > 0 && pc.pType == Async {
+								jsOpts = append(jsOpts, nats.PublishAsyncMaxPending(pc.asyncWindow))
+							}
+
+							js, err := nc.JetStream(jsOpts...)
+							if err != nil {
+								b.Fatalf("Unexpected error getting JetStream context: %v", err)
+							}
+
+							if verbose {
+								b.Logf("Creating stream with R=%d and %d input subjects", bc.replicas, bc.numSubjects)
+							}
+							streamConfig := &nats.StreamConfig{
+								Name:     "S",
+								Subjects: subjects,
+								Replicas: bc.replicas,
+							}
+							if _, err := js.AddStream(streamConfig); err != nil {
+								b.Fatalf("Error creating stream: %v", err)
+							}
+
+							if verbose {
+								b.Logf("Running %v publisher with message size: %dB", pc.pType, bc.messageSize)
+							}
+
+							// Benchmark starts here
+							b.ResetTimer()
+
+							var published, errors int
+							switch pc.pType {
+							case Sync:
+								published, errors = runSyncPublisher(b, js, bc.messageSize, subjects)
+							case Async:
+								published, errors = runAsyncPublisher(b, js, bc.messageSize, subjects, pc.asyncWindow)
+							}
+
+							// Benchmark ends here
+							b.StopTimer()
+
+							if published+errors != b.N {
+								b.Fatalf("Something doesn't add up: %d + %d != %d", published, errors, b.N)
+							}
+
+							b.ReportMetric(float64(errors)*100/float64(b.N), "%error")
+						},
+					)
+				}
+			},
+		)
+	}
+}

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -618,7 +618,7 @@ var jsClusterImportsTempl = `
 	}
 `
 
-func createMixedModeCluster(t *testing.T, tmpl string, clusterName, snPre string, numJsServers, numNonServers int, doJSConfig bool) *cluster {
+func createMixedModeCluster(t testing.TB, tmpl string, clusterName, snPre string, numJsServers, numNonServers int, doJSConfig bool) *cluster {
 	t.Helper()
 
 	if clusterName == _EMPTY_ || numJsServers < 0 || numNonServers < 1 {
@@ -672,27 +672,27 @@ func createMixedModeCluster(t *testing.T, tmpl string, clusterName, snPre string
 
 // This will create a cluster that is explicitly configured for the routes, etc.
 // and also has a defined clustername. All configs for routes and cluster name will be the same.
-func createJetStreamClusterExplicit(t *testing.T, clusterName string, numServers int) *cluster {
+func createJetStreamClusterExplicit(t testing.TB, clusterName string, numServers int) *cluster {
 	return createJetStreamClusterWithTemplate(t, jsClusterTempl, clusterName, numServers)
 }
 
-func createJetStreamClusterWithTemplate(t *testing.T, tmpl string, clusterName string, numServers int) *cluster {
+func createJetStreamClusterWithTemplate(t testing.TB, tmpl string, clusterName string, numServers int) *cluster {
 	return createJetStreamClusterWithTemplateAndModHook(t, tmpl, clusterName, numServers, nil)
 }
 
-func createJetStreamClusterWithTemplateAndModHook(t *testing.T, tmpl string, clusterName string, numServers int, modify modifyCb) *cluster {
+func createJetStreamClusterWithTemplateAndModHook(t testing.TB, tmpl string, clusterName string, numServers int, modify modifyCb) *cluster {
 	startPorts := []int{7_022, 9_022, 11_022, 15_022}
 	port := startPorts[rand.Intn(len(startPorts))]
 	return createJetStreamClusterAndModHook(t, tmpl, clusterName, _EMPTY_, numServers, port, true, modify)
 }
 
-func createJetStreamCluster(t *testing.T, tmpl string, clusterName, snPre string, numServers int, portStart int, waitOnReady bool) *cluster {
+func createJetStreamCluster(t testing.TB, tmpl string, clusterName, snPre string, numServers int, portStart int, waitOnReady bool) *cluster {
 	return createJetStreamClusterAndModHook(t, tmpl, clusterName, snPre, numServers, portStart, waitOnReady, nil)
 }
 
 type modifyCb func(serverName, clusterName, storeDir, conf string) string
 
-func createJetStreamClusterAndModHook(t *testing.T, tmpl string, clusterName, snPre string, numServers int, portStart int, waitOnReady bool, modify modifyCb) *cluster {
+func createJetStreamClusterAndModHook(t testing.TB, tmpl string, clusterName, snPre string, numServers int, portStart int, waitOnReady bool, modify modifyCb) *cluster {
 	t.Helper()
 	if clusterName == _EMPTY_ || numServers < 1 {
 		t.Fatalf("Bad params")
@@ -1043,7 +1043,7 @@ var skip = func(t *testing.T) {
 	t.SkipNow()
 }
 
-func jsClientConnect(t *testing.T, s *Server, opts ...nats.Option) (*nats.Conn, nats.JetStreamContext) {
+func jsClientConnect(t testing.TB, s *Server, opts ...nats.Option) (*nats.Conn, nats.JetStreamContext) {
 	t.Helper()
 	nc, err := nats.Connect(s.ClientURL(), opts...)
 	if err != nil {
@@ -1056,7 +1056,7 @@ func jsClientConnect(t *testing.T, s *Server, opts ...nats.Option) (*nats.Conn, 
 	return nc, js
 }
 
-func jsClientConnectEx(t *testing.T, s *Server, domain string, opts ...nats.Option) (*nats.Conn, nats.JetStreamContext) {
+func jsClientConnectEx(t testing.TB, s *Server, domain string, opts ...nats.Option) (*nats.Conn, nats.JetStreamContext) {
 	t.Helper()
 	nc, err := nats.Connect(s.ClientURL(), opts...)
 	if err != nil {
@@ -1069,7 +1069,7 @@ func jsClientConnectEx(t *testing.T, s *Server, domain string, opts ...nats.Opti
 	return nc, js
 }
 
-func jsClientConnectCluster(t *testing.T, c *cluster, opts ...nats.Option) (*nats.Conn, nats.JetStreamContext) {
+func jsClientConnectCluster(t testing.TB, c *cluster, opts ...nats.Option) (*nats.Conn, nats.JetStreamContext) {
 	t.Helper()
 
 	var sb strings.Builder
@@ -1082,7 +1082,7 @@ func jsClientConnectCluster(t *testing.T, c *cluster, opts ...nats.Option) (*nat
 	return jsClientConnectURL(t, sb.String(), opts...)
 }
 
-func jsClientConnectURL(t *testing.T, url string, opts ...nats.Option) (*nats.Conn, nats.JetStreamContext) {
+func jsClientConnectURL(t testing.TB, url string, opts ...nats.Option) (*nats.Conn, nats.JetStreamContext) {
 	t.Helper()
 
 	nc, err := nats.Connect(url, opts...)

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -1072,14 +1072,13 @@ func jsClientConnectEx(t testing.TB, s *Server, domain string, opts ...nats.Opti
 func jsClientConnectCluster(t testing.TB, c *cluster, opts ...nats.Option) (*nats.Conn, nats.JetStreamContext) {
 	t.Helper()
 
-	var sb strings.Builder
+	serverURLs := make([]string, len(c.servers))
 
-	for _, s := range c.servers {
-		sb.WriteString(s.ClientURL())
-		sb.WriteString(",")
+	for i, s := range c.servers {
+		serverURLs[i] = s.ClientURL()
 	}
-
-	return jsClientConnectURL(t, sb.String(), opts...)
+	url := strings.Join(serverURLs, ",")
+	return jsClientConnectURL(t, url, opts...)
 }
 
 func jsClientConnectURL(t testing.TB, url string, opts ...nats.Option) (*nats.Conn, nats.JetStreamContext) {

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -1619,3 +1619,90 @@ func (np *netProxy) stop() {
 		}
 	}
 }
+
+// Bitset, aka bitvector, allows tracking of large number of bits efficiently
+type bitset struct {
+	// Bit map storage
+	bitmap []uint8
+	// Number of bits currently set to 1
+	currentCount uint64
+	// Number of bits stored
+	size uint64
+}
+
+func NewBitset(size uint64) *bitset {
+	byteSize := (size + 7) / 8 //Round up to the nearest byte
+
+	return &bitset{
+		bitmap:       make([]uint8, int(byteSize)),
+		size:         size,
+		currentCount: 0,
+	}
+}
+
+func (b *bitset) get(index uint64) bool {
+	if index >= b.size {
+		panic(fmt.Sprintf("Index %d out of bounds, size %d", index, b.size))
+	}
+	byteIndex := index / 8
+	bitIndex := uint(index % 8)
+	bit := (b.bitmap[byteIndex] & (uint8(1) << bitIndex))
+	return bit != 0
+}
+
+func (b *bitset) set(index uint64, value bool) {
+	if index >= b.size {
+		panic(fmt.Sprintf("Index %d out of bounds, size %d", index, b.size))
+	}
+	byteIndex := index / 8
+	bitIndex := uint(index % 8)
+	byteMask := uint8(1) << bitIndex
+	isSet := (b.bitmap[byteIndex] & (uint8(1) << bitIndex)) != 0
+	if value {
+		b.bitmap[byteIndex] |= byteMask
+		if !isSet {
+			b.currentCount += 1
+		}
+	} else {
+		b.bitmap[byteIndex] &= ^byteMask
+		if isSet {
+			b.currentCount -= 1
+		}
+	}
+}
+
+func (b *bitset) count() uint64 {
+	return b.currentCount
+}
+
+func (b *bitset) String() string {
+	const block = 8 // 8 bytes, 64 bits per line
+	sb := strings.Builder{}
+
+	sb.WriteString(fmt.Sprintf("Bits set: %d/%d\n", b.currentCount, b.size))
+	for i := 0; i < len(b.bitmap); i++ {
+		if i%block == 0 {
+			if i > 0 {
+				sb.WriteString("\n")
+			}
+			sb.WriteString(fmt.Sprintf("[%4d] ", i*8))
+		}
+		for j := uint8(0); j < 8; j++ {
+			if b.bitmap[i]&(1<<j) > 0 {
+				sb.WriteString("1")
+			} else {
+				sb.WriteString("0")
+			}
+		}
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func toIndentedJsonString(v interface{}) string {
+	jsonBytes, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("Marshal error: %s", err)
+	}
+	return string(jsonBytes)
+}

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -3330,28 +3330,28 @@ func createDir(t testing.TB, prefix string) string {
 	return dir
 }
 
-func createFile(t *testing.T, prefix string) *os.File {
+func createFile(t testing.TB, prefix string) *os.File {
 	t.Helper()
 	err := os.MkdirAll(tempRoot, 0700)
 	require_NoError(t, err)
 	return createFileAtDir(t, tempRoot, prefix)
 }
 
-func createFileAtDir(t *testing.T, dir, prefix string) *os.File {
+func createFileAtDir(t testing.TB, dir, prefix string) *os.File {
 	t.Helper()
 	f, err := os.CreateTemp(dir, prefix)
 	require_NoError(t, err)
 	return f
 }
 
-func removeDir(t *testing.T, dir string) {
+func removeDir(t testing.TB, dir string) {
 	t.Helper()
 	if err := os.RemoveAll(dir); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func removeFile(t *testing.T, p string) {
+func removeFile(t testing.TB, p string) {
 	t.Helper()
 	if err := os.Remove(p); err != nil {
 		t.Fatal(err)

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -64,7 +64,7 @@ func newOptionsFromContent(t *testing.T, content []byte) (*Options, string) {
 	return opts, tmpFile
 }
 
-func createConfFile(t *testing.T, content []byte) string {
+func createConfFile(t testing.TB, content []byte) string {
 	t.Helper()
 	conf := createFile(t, "")
 	fName := conf.Name()

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -285,7 +285,7 @@ func TestServerRoutesWithAuthAndBCrypt(t *testing.T) {
 }
 
 // Helper function to check that a cluster is formed
-func checkClusterFormed(t *testing.T, servers ...*Server) {
+func checkClusterFormed(t testing.TB, servers ...*Server) {
 	t.Helper()
 	expectedNumRoutes := len(servers) - 1
 	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -50,7 +50,7 @@ func checkForErr(totalWait, sleepDur time.Duration, f func() error) error {
 	return err
 }
 
-func checkFor(t *testing.T, totalWait, sleepDur time.Duration, f func() error) {
+func checkFor(t testing.TB, totalWait, sleepDur time.Duration, f func() error) {
 	t.Helper()
 	err := checkForErr(totalWait, sleepDur, f)
 	if err != nil {

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -57,7 +57,7 @@ type cluster struct {
 	servers []*Server
 	opts    []*Options
 	name    string
-	t       *testing.T
+	t       testing.TB
 }
 
 func require_True(t *testing.T, b bool) {

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Helper function to check that a cluster is formed
-func checkClusterFormed(t *testing.T, servers ...*server.Server) {
+func checkClusterFormed(t testing.TB, servers ...*server.Server) {
 	t.Helper()
 	expectedNumRoutes := len(servers) - 1
 	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -1099,7 +1099,7 @@ func TestRouteBasicPermissions(t *testing.T) {
 	}
 }
 
-func createConfFile(t *testing.T, content []byte) string {
+func createConfFile(t testing.TB, content []byte) string {
 	t.Helper()
 	conf := createFile(t, "")
 	fName := conf.Name()

--- a/test/test.go
+++ b/test/test.go
@@ -638,7 +638,7 @@ func nextServerOpts(opts *server.Options) *server.Options {
 	return nopts
 }
 
-func createDir(t *testing.T, prefix string) string {
+func createDir(t testing.TB, prefix string) string {
 	t.Helper()
 	if err := os.MkdirAll(tempRoot, 0700); err != nil {
 		t.Fatal(err)
@@ -650,7 +650,7 @@ func createDir(t *testing.T, prefix string) string {
 	return dir
 }
 
-func createFile(t *testing.T, prefix string) *os.File {
+func createFile(t testing.TB, prefix string) *os.File {
 	t.Helper()
 	if err := os.MkdirAll(tempRoot, 0700); err != nil {
 		t.Fatal(err)
@@ -658,7 +658,7 @@ func createFile(t *testing.T, prefix string) *os.File {
 	return createFileAtDir(t, tempRoot, prefix)
 }
 
-func createFileAtDir(t *testing.T, dir, prefix string) *os.File {
+func createFileAtDir(t testing.TB, dir, prefix string) *os.File {
 	t.Helper()
 	f, err := os.CreateTemp(dir, prefix)
 	if err != nil {
@@ -667,14 +667,14 @@ func createFileAtDir(t *testing.T, dir, prefix string) *os.File {
 	return f
 }
 
-func removeDir(t *testing.T, dir string) {
+func removeDir(t testing.TB, dir string) {
 	t.Helper()
 	if err := os.RemoveAll(dir); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func removeFile(t *testing.T, p string) {
+func removeFile(t testing.TB, p string) {
 	t.Helper()
 	if err := os.Remove(p); err != nil {
 		t.Fatal(err)

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/time/rate"
 )
 
-func checkFor(t *testing.T, totalWait, sleepDur time.Duration, f func() error) {
+func checkFor(t testing.TB, totalWait, sleepDur time.Duration, f func() error) {
 	t.Helper()
 	timeout := time.Now().Add(totalWait)
 	var err error


### PR DESCRIPTION
 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [x] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit => 4 atomic commits for easier review and cherry-pick
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

### Changes proposed in this pull request:

 - Minor refactoring of test utilities
 - Jetstream publish benchmark (sync/async, small/medium messages, single-server/cluster, ...)
 - Jetstream consume benchmark (push/pull, ordered/unordered, durable/ephemeral, small/medium messages, single-server/cluster, ...)

Example (localhost) output:
```
❯❯❯ go test --run BenchmarkJetStream --bench BenchmarkJetStream -timeout 30m
goos: darwin
goarch: arm64
pkg: github.com/nats-io/nats-server/v2/server
BenchmarkJetStreamConsume/N=1,R=1,MsgSz=10b/PUSH[Sync,Ephemeral]-8               1000000              1459 ns/op           6.85 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=1,R=1,MsgSz=10b/PUSH[Async,Ephemeral]-8              1000000              1123 ns/op           8.90 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=1,R=1,MsgSz=10b/PUSH[Async,Ordered]-8                1952527               633.6 ns/op        15.78 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=1,R=1,MsgSz=10b/PUSH[Async,Durable]-8                1000000              1125 ns/op           8.89 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=1,R=1,MsgSz=10b/PULL[Durable]-8                      1000000              1794 ns/op           5.57 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=1,R=1,MsgSz=10b/PULL[Ephemeral]-8                    1000000              1831 ns/op           5.46 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=1,R=1,MsgSz=1024b/PUSH[Sync,Ephemeral]-8             1000000              1771 ns/op         578.15 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=1,R=1,MsgSz=1024b/PUSH[Async,Ephemeral]-8            1000000              1255 ns/op         815.64 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=1,R=1,MsgSz=1024b/PUSH[Async,Ordered]-8              1404806              1242 ns/op         824.75 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=1,R=1,MsgSz=1024b/PUSH[Async,Durable]-8              1000000              1335 ns/op         766.99 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=1,R=1,MsgSz=1024b/PULL[Durable]-8                    1000000              2084 ns/op         491.47 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=1,R=1,MsgSz=1024b/PULL[Ephemeral]-8                  1000000              2117 ns/op         483.79 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=3,R=3,MsgSz=10b/PUSH[Sync,Ephemeral]-8               1000000              2259 ns/op           4.43 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=3,R=3,MsgSz=10b/PUSH[Async,Ephemeral]-8              1000000              1570 ns/op           6.37 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=3,R=3,MsgSz=10b/PUSH[Async,Ordered]-8                1640319               737.1 ns/op        13.57 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=3,R=3,MsgSz=10b/PUSH[Async,Durable]-8                1000000              2041 ns/op           4.90 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=3,R=3,MsgSz=10b/PULL[Durable]-8                      1000000              3031 ns/op           3.30 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=3,R=3,MsgSz=10b/PULL[Ephemeral]-8                    1000000              2606 ns/op           3.84 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=3,R=3,MsgSz=1024b/PUSH[Sync,Ephemeral]-8             1000000              2686 ns/op         381.30 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=3,R=3,MsgSz=1024b/PUSH[Async,Ephemeral]-8            1000000              2272 ns/op         450.72 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=3,R=3,MsgSz=1024b/PUSH[Async,Ordered]-8              1000000              1352 ns/op         757.18 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=3,R=3,MsgSz=1024b/PUSH[Async,Durable]-8              1000000              2797 ns/op         366.17 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=3,R=3,MsgSz=1024b/PULL[Durable]-8                    1000000              3743 ns/op         273.61 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamConsume/N=3,R=3,MsgSz=1024b/PULL[Ephemeral]-8                  1000000              3744 ns/op         273.50 MB/s             0 %dupe                 0 %error
BenchmarkJetStreamPublish/N=1,R=1,MsgSz=10b,Subjs=1/Sync-8                       1000000             32488 ns/op           0.31 MB/s             0 %error
BenchmarkJetStreamPublish/N=1,R=1,MsgSz=10b,Subjs=1/Async[W:1000]-8              1000000              3516 ns/op           2.84 MB/s             0 %error
BenchmarkJetStreamPublish/N=1,R=1,MsgSz=10b,Subjs=1/Async[W:4000]-8             --- FAIL: BenchmarkJetStreamPublish/N=1,R=1,MsgSz=10b,Subjs=1/Async[W:4000]-8
    jetstream_benchmark_publish_test.go:118: PubAck is still pending after publish completed
BenchmarkJetStreamPublish/N=1,R=1,MsgSz=10b,Subjs=1/Async[W:8000]-8              1000000              3480 ns/op           2.87 MB/s             0 %error
--- FAIL: BenchmarkJetStreamPublish/N=1,R=1,MsgSz=10b,Subjs=1
BenchmarkJetStreamPublish/N=1,R=1,MsgSz=1024b,Subjs=1/Sync-8                     1000000             35596 ns/op          28.77 MB/s             0 %error
BenchmarkJetStreamPublish/N=1,R=1,MsgSz=1024b,Subjs=1/Async[W:1000]-8            1000000              5400 ns/op         189.62 MB/s             0 %error
BenchmarkJetStreamPublish/N=1,R=1,MsgSz=1024b,Subjs=1/Async[W:4000]-8            1000000              5395 ns/op         189.79 MB/s             0 %error
BenchmarkJetStreamPublish/N=1,R=1,MsgSz=1024b,Subjs=1/Async[W:8000]-8            1000000              5628 ns/op         181.96 MB/s             0 %error
BenchmarkJetStreamPublish/N=3,R=3,MsgSz=10b,Subjs=1/Sync-8                       1000000            114017 ns/op           0.09 MB/s             0 %error
BenchmarkJetStreamPublish/N=3,R=3,MsgSz=10b,Subjs=1/Async[W:1000]-8              1000000             11553 ns/op           0.87 MB/s             0 %error
BenchmarkJetStreamPublish/N=3,R=3,MsgSz=10b,Subjs=1/Async[W:4000]-8              1000000             11325 ns/op           0.88 MB/s             0 %error
BenchmarkJetStreamPublish/N=3,R=3,MsgSz=10b,Subjs=1/Async[W:8000]-8              1000000             15430 ns/op           0.65 MB/s             0 %error
BenchmarkJetStreamPublish/N=3,R=3,MsgSz=1024b,Subjs=1/Sync-8                     1000000            127856 ns/op           8.01 MB/s             0 %error
BenchmarkJetStreamPublish/N=3,R=3,MsgSz=1024b,Subjs=1/Async[W:1000]-8            1000000             22669 ns/op          45.17 MB/s             0 %error
BenchmarkJetStreamPublish/N=3,R=3,MsgSz=1024b,Subjs=1/Async[W:4000]-8            1000000             22425 ns/op          45.66 MB/s             0 %error
BenchmarkJetStreamPublish/N=3,R=3,MsgSz=1024b,Subjs=1/Async[W:8000]-8            1000000             18886 ns/op          54.22 MB/s             0 %error
-
```

/cc @nats-io/core
