### PR TITLE
[FIXED] Do not allow overlap between multiple subjects for a stream.

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -19410,3 +19410,21 @@ func TestJetStreamSubjectBasedFilteredConsumers(t *testing.T) {
 	_, err = nc.Request(ecSubj, req, 500*time.Millisecond)
 	require_Error(t, err, nats.ErrTimeout)
 }
+
+func TestJetStreamStreamSubjectsOverlap(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	if config := s.JetStreamConfig(); config != nil {
+		defer removeDir(t, config.StoreDir)
+	}
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo.*", "foo.A"},
+	})
+	require_Error(t, err)
+	require_True(t, strings.Contains(err.Error(), "overlaps"))
+}

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -19427,4 +19427,18 @@ func TestJetStreamStreamSubjectsOverlap(t *testing.T) {
 	})
 	require_Error(t, err)
 	require_True(t, strings.Contains(err.Error(), "overlaps"))
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo.*"},
+	})
+	require_NoError(t, err)
+
+	_, err = js.UpdateStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo.*", "foo.A"},
+	})
+	require_Error(t, err)
+	require_True(t, strings.Contains(err.Error(), "overlaps"))
+
 }


### PR DESCRIPTION
We detected overlap between different streams for subjects but not same stream with multiple subjects configured.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
