### PR TITLE
Replace verbose API error detail with concise message

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2380,7 +2380,8 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 			errs = append(errs, e)
 		}
 		if peers == nil {
-			resp.Error = NewJSClusterNoPeersError(&errs)
+			// per-cluster errs helpful for development debug, but concise message sufficient for API return
+			resp.Error = NewJSClusterNoPeersError(fmt.Errorf("no clusters match placement criteria for move"))
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5247,7 +5247,8 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		if len(peerSet) == 0 {
 			nrg, err := js.createGroupForStream(ci, newCfg)
 			if err != nil {
-				resp.Error = NewJSClusterNoPeersError(err)
+				// err helpful for development debug, but concise message sufficient for API return
+				resp.Error = NewJSClusterNoPeersError(fmt.Errorf("cluster does not match placement criteria for move"))
 				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 				return
 			}


### PR DESCRIPTION
Re-placement (move) errors due to no match generated extreme-verbosity API error detail.  This PR opts for brief API error detail instead.  The mechanisms that collect verbose detail left in place if/when needed in a custom build.  

Simplification made in two places as there are two implementations of move -- one as a side effect of a stream update and the other a direct call to new move API.

/cc @nats-io/core
