### PR TITLE
[FIXED] JetStream: Some nodes may never be reported as offline

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1669,12 +1669,7 @@ func (a *Account) jetStreamConfigured() bool {
 		return false
 	}
 	a.mu.RLock()
-	jsc := a.jetStreamConfiguredNoLock()
-	a.mu.RUnlock()
-	return jsc
-}
-
-func (a *Account) jetStreamConfiguredNoLock() bool {
+	defer a.mu.RUnlock()
 	return len(a.jsLimits) > 0
 }
 

--- a/server/jetstream_cluster_test.go
+++ b/server/jetstream_cluster_test.go
@@ -12096,7 +12096,10 @@ func TestJetStreamClusterNoOrphanedDueToNoConnection(t *testing.T) {
 	checkSysServers()
 	nc.Close()
 
-	time.Sleep(7 * eventsHBInterval)
+	s.mu.RLock()
+	val := (s.sys.orphMax / eventsHBInterval) + 2
+	s.mu.RUnlock()
+	time.Sleep(val * eventsHBInterval)
 	checkSysServers()
 }
 


### PR DESCRIPTION
In some rare situations, it is possible that nodes are added
to the cluster but are not properly tracked and not shown as
offline when they exit the cluster.

Relates to #3258

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
