### PR TITLE
[FIXED] Parsing of strings starting with numbers and K/G/etc.. suffix

### DIFF
--- a/conf/lex.go
+++ b/conf/lex.go
@@ -1009,9 +1009,19 @@ func lexConvenientNumber(lx *lexer) stateFn {
 	case r == 'b' || r == 'B' || r == 'i' || r == 'I':
 		return lexConvenientNumber
 	}
-	lx.backup()
-	lx.emit(itemInteger)
-	return lx.pop()
+	if isNL(r) || r == eof || r == mapEnd || r == optValTerm || r == mapValTerm || isWhitespace(r) || unicode.IsDigit(r) {
+		lx.backup()
+		lx.emit(itemInteger)
+		return lx.pop()
+	}
+	// This is not a number, so we have to backup to the start and consider
+	// this to be a string
+	pos, start := lx.pos, lx.start
+	for i := pos; i > start; i-- {
+		lx.backup()
+	}
+	lx.stringStateFn = lexString
+	return lexString
 }
 
 // lexDateAfterYear consumes a full Zulu Datetime in ISO8601 format.

--- a/conf/lex_test.go
+++ b/conf/lex_test.go
@@ -306,6 +306,30 @@ func TestConvenientIntegerValues(t *testing.T) {
 	}
 	lx = lex("foo = -1GB ")
 	expect(t, lx, expectedItems)
+
+	expectedItems = []item{
+		{itemKey, "foo", 1, 0},
+		{itemString, "1Ghz", 1, 6},
+		{itemEOF, "", 1, 0},
+	}
+	lx = lex("foo = 1Ghz")
+	expect(t, lx, expectedItems)
+
+	expectedItems = []item{
+		{itemKey, "foo", 1, 0},
+		{itemString, "2Pie", 1, 6},
+		{itemEOF, "", 1, 0},
+	}
+	lx = lex("foo = 2Pie")
+	expect(t, lx, expectedItems)
+
+	expectedItems = []item{
+		{itemKey, "foo", 1, 0},
+		{itemString, "3Mbs", 1, 6},
+		{itemEOF, "", 1, 0},
+	}
+	lx = lex("foo = 3Mbs,")
+	expect(t, lx, expectedItems)
 }
 
 func TestSimpleKeyFloatValues(t *testing.T) {

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -122,6 +122,16 @@ func TestEnvVariableStringStartingWithNumber(t *testing.T) {
 	}
 }
 
+func TestEnvVariableStringStartingWithNumberAndSizeUnit(t *testing.T) {
+	ex := map[string]interface{}{
+		"foo": "3Gyz",
+	}
+	evar := "__UNIQ22__"
+	os.Setenv(evar, "3Gyz")
+	defer os.Unsetenv(evar)
+	test(t, fmt.Sprintf("foo = $%s", evar), ex)
+}
+
 func TestEnvVariableStringStartingWithNumberUsingQuotes(t *testing.T) {
 	ex := map[string]interface{}{
 		"foo": "3xyz",


### PR DESCRIPTION
If a configuration variable starts with numbers and has a character
that such as K/k/G/g/etc.. it would assume that it was a number
(expressed in Kb, Gb, etc..).

This PR checks that if the special characters are not the suffix,
that is, the variable does not end after those characters, then
the parsing will treat the whole thing as a string.

Resolves #3431

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
