### PR TITLE
js: add per account reserved mem/store bytes

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2700,6 +2700,11 @@ func (s *Server) accountDetail(jsa *jsAccount, optStreams, optConsumers, optCfg 
 		},
 		Streams: make([]StreamDetail, 0, len(jsa.streams)),
 	}
+	if reserved, ok := jsa.limits[_EMPTY_]; ok {
+		detail.JetStreamStats.ReservedMemory = uint64(reserved.MaxMemory)
+		detail.JetStreamStats.ReservedStore = uint64(reserved.MaxStore)
+	}
+
 	jsa.usageMu.RUnlock()
 	var streams []*stream
 	if optStreams {

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -4205,6 +4205,41 @@ func TestMonitorJsz(t *testing.T) {
 			}
 		}
 	})
+	t.Run("accounts reserved metrics", func(t *testing.T) {
+		for _, url := range []string{monUrl1, monUrl2} {
+			info := readJsInfo(url + "?accounts=true&acc=ACC")
+			if len(info.AccountDetails) != 1 {
+				t.Fatalf("expected single account")
+			}
+			acc := info.AccountDetails[0]
+			got := int(acc.ReservedMemory)
+			expected := 5242880
+			if got != expected {
+				t.Errorf("Expected: %v, got: %v", expected, got)
+			}
+			got = int(acc.ReservedStore)
+			expected = 4194304
+			if got != expected {
+				t.Errorf("Expected: %v, got: %v", expected, got)
+			}
+
+			info = readJsInfo(url + "?accounts=true&acc=BCC_TO_HAVE_ONE_EXTRA")
+			if len(info.AccountDetails) != 1 {
+				t.Fatalf("expected single account")
+			}
+			acc = info.AccountDetails[0]
+			got = int(acc.ReservedMemory)
+			expected = -1
+			if got != expected {
+				t.Errorf("Expected: %v, got: %v", expected, got)
+			}
+			got = int(acc.ReservedStore)
+			expected = -1
+			if got != expected {
+				t.Errorf("Expected: %v, got: %v", expected, got)
+			}
+		}
+	})
 	t.Run("offset-too-big", func(t *testing.T) {
 		for _, url := range []string{monUrl1, monUrl2} {
 			info := readJsInfo(url + "?accounts=true&offset=10")


### PR DESCRIPTION
This makes the `reserved_memory` and `reserved_storage` quotas for an account to be filled. For example given the following configuration:

```hcl
accounts {
  sys {
    users = [{ user: 'sys', pass: 'sys' }]
  }
  a {
    users = [{ user: 'foo', pass: 'foo' }]
    jetstream {
      max_mem: 500mi
      max_store: 1gi
    }
  }
```

Now making a request to `http://127.0.0.1:8222/jsz?accounts=true` it would make the reserved_memory and reserved_storage show up instead of 0s:

```js
"account_details": [
    {
      "name": "a",
      "id": "a",
      "memory": 0,
      "storage": 28956,
      "reserved_memory": 524288000,
      "reserved_storage": 1073741824,
      "accounts": 0,
      "ha_assets": 0,
      "api": {
        "total": 0,
        "errors": 0
      }
    }
  ]
```

Also fixes `$SYS.REQ.ACCOUNT.*.JSZ`:

```
nats req -s 'nats://sys:sys@127.0.0.1:4222' '$SYS.REQ.ACCOUNT.a.JSZ' '{"streams": true, "consumers":true}'
09:21:33 Sending request on "$SYS.REQ.ACCOUNT.a.JSZ"
09:21:33 Received with rtt 228µs
{"server":{"name":"NBAUUNWTIZHQZ6K5TGZJWO6PJ2LQSMKT3FR2BQWBMDYDUXC37SWPVAJ4","host":"0.0.0.0","id":"NBAUUNWTIZHQZ6K5TGZJWO6PJ2LQSMKT3FR2BQWBMDYDUXC37SWPVAJ4","ver":"2.9.0-RC.16","seq":128,"jetstream":true,"time":"2022-09-03T16:21:33.1023Z"},"data":{"name":"a","id":"a","memory":0,"storage":28956,"reserved_memory":524288000,"reserved_storage":1073741824,"accounts":0,"ha_assets":0,"api":{"total":0,"errors":0},"stream_detail":[{"name":"foo","cluster":{"leader":"NBAUUNWTIZHQZ6K5TGZJWO6PJ2LQSMKT3FR2BQWBMDYDUXC37SWPVAJ4"},"state":{"messages":762,"bytes":28956,"first_seq":1,"first_ts":"2022-09-02T22:00:17.334501Z","last_seq":762,"last_ts":"2022-09-03T16:12:31.677082Z","num_subjects":1,"consumer_count":0}}]}}
```

Signed-off-by: Waldemar Quevedo <wally@nats.io>

/cc @nats-io/core
