### PR TITLE
Use testing.TempDir() where possible

### DIFF
--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -25,8 +25,6 @@ import (
 	"testing"
 )
 
-var tempRoot = filepath.Join(os.TempDir(), "nats-server")
-
 func TestStdLogger(t *testing.T) {
 	logger := NewStdLogger(false, false, false, false, false)
 
@@ -104,10 +102,7 @@ func TestStdLoggerTraceWithOutDebug(t *testing.T) {
 }
 
 func TestFileLogger(t *testing.T) {
-	tmpDir := createDir(t, "_nats-server")
-	defer removeDir(t, tmpDir)
-
-	file := createFileAtDir(t, tmpDir, "nats-server:log_")
+	file := createFileAtDir(t, t.TempDir(), "nats-server:log_")
 	file.Close()
 
 	logger := NewFileLogger(file.Name(), false, false, false, false)
@@ -126,7 +121,7 @@ func TestFileLogger(t *testing.T) {
 		t.Fatalf("Expected '%s', received '%s'\n", "[INFO] foo", string(buf))
 	}
 
-	file = createFileAtDir(t, tmpDir, "nats-server:log_")
+	file = createFileAtDir(t, t.TempDir(), "nats-server:log_")
 	file.Close()
 
 	logger = NewFileLogger(file.Name(), true, true, true, true)
@@ -176,8 +171,7 @@ func TestFileLoggerSizeLimit(t *testing.T) {
 	}
 	logger.Close()
 
-	tmpDir := createDir(t, "nats-server")
-	defer removeDir(t, tmpDir)
+	tmpDir := t.TempDir()
 
 	file := createFileAtDir(t, tmpDir, "log_")
 	file.Close()
@@ -210,10 +204,7 @@ func TestFileLoggerSizeLimit(t *testing.T) {
 		t.Fatalf("Should be statement about rotated log and backup name, got %s", content)
 	}
 
-	// Remove all files
-	removeDir(t, tmpDir)
-	tmpDir = createDir(t, "nats-server")
-	defer removeDir(t, tmpDir)
+	tmpDir = t.TempDir()
 
 	// Recreate logger and don't set a limit
 	file = createFileAtDir(t, tmpDir, "log_")
@@ -325,18 +316,6 @@ func expectOutput(t *testing.T, f func(), expected string) {
 	}
 }
 
-func createDir(t *testing.T, prefix string) string {
-	t.Helper()
-	if err := os.MkdirAll(tempRoot, 0700); err != nil {
-		t.Fatal(err)
-	}
-	dir, err := os.MkdirTemp(tempRoot, prefix)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return dir
-}
-
 func createFileAtDir(t *testing.T, dir, prefix string) *os.File {
 	t.Helper()
 	f, err := os.CreateTemp(dir, prefix)
@@ -344,11 +323,4 @@ func createFileAtDir(t *testing.T, dir, prefix string) *os.File {
 		t.Fatal(err)
 	}
 	return f
-}
-
-func removeDir(t *testing.T, dir string) {
-	t.Helper()
-	if err := os.RemoveAll(dir); err != nil {
-		t.Fatal(err)
-	}
 }

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -337,7 +337,6 @@ func TestAccountIsolationExportImport(t *testing.T) {
 			`,
 				c.exp, c.imp,
 			)))
-			defer removeFile(t, cf)
 			s, _ := RunServerWithConfig(cf)
 			defer s.Shutdown()
 
@@ -381,12 +380,8 @@ func TestMultiAccountsIsolation(t *testing.T) {
 			]
 		}
 	}`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
 	defer s.Shutdown()
 
 	// Create a connection for CLIENT and subscribe on orders.>
@@ -472,7 +467,6 @@ func TestNewAccountAndRequireNewAlwaysError(t *testing.T) {
 			B: { users: [ {user: ub, password: pb} ] },
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -537,7 +531,6 @@ func accountNameExists(name string, accounts []*Account) bool {
 
 func TestAccountSimpleConfig(t *testing.T) {
 	confFileName := createConfFile(t, []byte(`accounts = [foo, bar]`))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error processing config file: %v", err)
@@ -554,7 +547,6 @@ func TestAccountSimpleConfig(t *testing.T) {
 
 	// Make sure double entries is an error.
 	confFileName = createConfFile(t, []byte(`accounts = [foo, foo]`))
-	defer removeFile(t, confFileName)
 	_, err = ProcessConfigFile(confFileName)
 	if err == nil {
 		t.Fatalf("Expected an error with double account entries")
@@ -578,7 +570,6 @@ func TestAccountParseConfig(t *testing.T) {
       }
     }
     `))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error processing config file: %v", err)
@@ -628,7 +619,6 @@ func TestAccountParseConfigDuplicateUsers(t *testing.T) {
       }
     }
     `))
-	defer removeFile(t, confFileName)
 	_, err := ProcessConfigFile(confFileName)
 	if err == nil {
 		t.Fatalf("Expected an error with double user entries")
@@ -736,7 +726,6 @@ func TestImportExportConfigFailures(t *testing.T) {
       }
     }
     `))
-	defer removeFile(t, cf)
 	if _, err := ProcessConfigFile(cf); err == nil {
 		t.Fatalf("Expected an error with import from unknown account")
 	}
@@ -748,7 +737,6 @@ func TestImportExportConfigFailures(t *testing.T) {
       }
     }
     `))
-	defer removeFile(t, cf)
 	if _, err := ProcessConfigFile(cf); err == nil {
 		t.Fatalf("Expected an error with import of a service with no account")
 	}
@@ -760,7 +748,6 @@ func TestImportExportConfigFailures(t *testing.T) {
       }
     }
     `))
-	defer removeFile(t, cf)
 	if _, err := ProcessConfigFile(cf); err == nil {
 		t.Fatalf("Expected an error with import of a service with wildcard subject")
 	}
@@ -772,7 +759,6 @@ func TestImportExportConfigFailures(t *testing.T) {
       }
     }
     `))
-	defer removeFile(t, cf)
 	if _, err := ProcessConfigFile(cf); err == nil {
 		t.Fatalf("Expected an error with export with unknown keyword")
 	}
@@ -784,7 +770,6 @@ func TestImportExportConfigFailures(t *testing.T) {
       }
     }
     `))
-	defer removeFile(t, cf)
 	if _, err := ProcessConfigFile(cf); err == nil {
 		t.Fatalf("Expected an error with import with unknown keyword")
 	}
@@ -796,7 +781,6 @@ func TestImportExportConfigFailures(t *testing.T) {
       }
     }
     `))
-	defer removeFile(t, cf)
 	if _, err := ProcessConfigFile(cf); err == nil {
 		t.Fatalf("Expected an error with export with account")
 	}
@@ -1024,7 +1008,6 @@ func TestStreamImportLengthBug(t *testing.T) {
 	  }
 	}
 	`))
-	defer removeFile(t, cf)
 	if _, err := ProcessConfigFile(cf); err == nil {
 		t.Fatalf("Expected an error with import with wildcard prefix")
 	}
@@ -2196,7 +2179,6 @@ func TestAccountMapsUsers(t *testing.T) {
       }
     }
     `))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Unexpected error parsing config file: %v", err)
@@ -2306,7 +2288,6 @@ func TestAccountGlobalDefault(t *testing.T) {
 
 	// Make sure we can not define one in a config file either.
 	confFileName := createConfFile(t, []byte(`accounts { $G {} }`))
-	defer removeFile(t, confFileName)
 
 	if _, err := ProcessConfigFile(confFileName); err == nil {
 		t.Fatalf("Expected an error parsing config file with reserved account")
@@ -2840,7 +2821,6 @@ func TestGlobalAccountRouteMappingsConfiguration(t *testing.T) {
 		bar.*.*: RAB.$2.$1
     }
     `))
-	defer removeFile(t, cf)
 
 	s, _ := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -2895,7 +2875,6 @@ func TestAccountRouteMappingsConfiguration(t *testing.T) {
 		}
 	}
     `))
-	defer removeFile(t, cf)
 
 	s, _ := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -2925,7 +2904,6 @@ func TestAccountRouteMappingsWithLossInjection(t *testing.T) {
 		bar: { dest: bar, weight: 0% }
     }
     `))
-	defer removeFile(t, cf)
 
 	s, _ := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -2962,7 +2940,6 @@ func TestAccountRouteMappingsWithOriginClusterFilter(t *testing.T) {
 		foo: { dest: bar, cluster: SYN, weight: 100% }
     }
     `))
-	defer removeFile(t, cf)
 
 	s, _ := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -3007,7 +2984,6 @@ func TestAccountServiceImportWithRouteMappings(t *testing.T) {
       }
     }
     `))
-	defer removeFile(t, cf)
 
 	s, opts := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -3058,7 +3034,6 @@ func TestAccountImportsWithWildcardSupport(t *testing.T) {
       }
     }
     `))
-	defer removeFile(t, cf)
 
 	s, opts := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -3151,7 +3126,6 @@ func TestAccountImportsWithWildcardSupportStreamAndService(t *testing.T) {
       }
     }
     `))
-	defer removeFile(t, cf)
 
 	s, opts := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -3345,7 +3319,6 @@ func TestAccountSystemPermsWithGlobalAccess(t *testing.T) {
 			$SYS { users = [ { user: "admin", pass: "s3cr3t!" } ] }
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -3388,7 +3361,6 @@ accounts: {
 
 func TestImportSubscriptionPartialOverlapWithPrefix(t *testing.T) {
 	cf := createConfFile(t, []byte(fmt.Sprintf(importSubscriptionOverlapTemplate, ">", ">", "prefix: myprefix")))
-	defer removeFile(t, cf)
 
 	s, opts := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -3417,7 +3389,6 @@ func TestImportSubscriptionPartialOverlapWithPrefix(t *testing.T) {
 
 func TestImportSubscriptionPartialOverlapWithTransform(t *testing.T) {
 	cf := createConfFile(t, []byte(fmt.Sprintf(importSubscriptionOverlapTemplate, "*.*.>", "*.*.>", "to: myprefix.$2.$1.>")))
-	defer removeFile(t, cf)
 
 	s, opts := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -3463,7 +3434,6 @@ func TestAccountLimitsServerConfig(t *testing.T) {
 		}
 	}
     `))
-	defer removeFile(t, cf)
 
 	s, _ := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -3505,7 +3475,6 @@ func TestAccountUserSubPermsWithQueueGroups(t *testing.T) {
 		}
 	]}
     `))
-	defer removeFile(t, cf)
 
 	s, _ := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -3552,7 +3521,6 @@ func TestAccountImportCycle(t *testing.T) {
 	}
 	`
 	cf := createConfFile(t, []byte(fmt.Sprintf(tmpl, _EMPTY_, _EMPTY_)))
-	defer removeFile(t, cf)
 	s, _ := RunServerWithConfig(cf)
 	defer s.Shutdown()
 	ncCp, err := nats.Connect(s.ClientURL(), nats.UserInfo("cp", "cp"))

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -227,7 +226,6 @@ func TestNoAuthUser(t *testing.T) {
 		}
 		no_auth_user: "foo"
 	`))
-	defer os.Remove(conf)
 	s, o := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -285,7 +283,6 @@ func TestNoAuthUserNoConnectProto(t *testing.T) {
 		authorization { timeout: 1 }
 		no_auth_user: "foo"
 	`))
-	defer os.Remove(conf)
 	s, o := RunServerWithConfig(conf)
 	defer s.Shutdown()
 

--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -1602,7 +1602,6 @@ func TestConfigCheck(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			conf := createConfFile(t, []byte(test.config))
-			defer removeFile(t, conf)
 			err := checkConfig(conf)
 			var expectedErr error
 

--- a/server/dirstore_test.go
+++ b/server/dirstore_test.go
@@ -65,7 +65,7 @@ func init() {
 
 func TestShardedDirStoreWriteAndReadonly(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
 
 	store, err := NewDirJWTStore(dir, true, false)
 	require_NoError(t, err)
@@ -118,7 +118,7 @@ func TestShardedDirStoreWriteAndReadonly(t *testing.T) {
 
 func TestUnshardedDirStoreWriteAndReadonly(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
 
 	store, err := NewDirJWTStore(dir, false, false)
 	require_NoError(t, err)
@@ -179,7 +179,7 @@ func TestNoCreateRequiresDir(t *testing.T) {
 
 func TestCreateMakesDir(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
 
 	fullPath := filepath.Join(dir, "a/b")
 
@@ -197,9 +197,9 @@ func TestCreateMakesDir(t *testing.T) {
 
 func TestShardedDirStorePackMerge(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
-	dir2 := createDir(t, "jwtstore_test")
-	dir3 := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
+	dir2 := t.TempDir()
+	dir3 := t.TempDir()
 
 	store, err := NewDirJWTStore(dir, true, false)
 	require_NoError(t, err)
@@ -272,8 +272,8 @@ func TestShardedDirStorePackMerge(t *testing.T) {
 
 func TestShardedToUnsharedDirStorePackMerge(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
-	dir2 := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
+	dir2 := t.TempDir()
 
 	store, err := NewDirJWTStore(dir, true, false)
 	require_NoError(t, err)
@@ -331,7 +331,7 @@ func TestShardedToUnsharedDirStorePackMerge(t *testing.T) {
 
 func TestMergeOnlyOnNewer(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
 
 	dirStore, err := NewDirJWTStore(dir, true, false)
 	require_NoError(t, err)
@@ -404,7 +404,7 @@ func assertStoreSize(t *testing.T, dirStore *DirJWTStore, length int) {
 
 func TestExpiration(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
 
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*50, 10, true, 0, nil)
 	require_NoError(t, err)
@@ -441,7 +441,7 @@ func TestExpiration(t *testing.T) {
 
 func TestLimit(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
 
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*100, 5, true, 0, nil)
 	require_NoError(t, err)
@@ -483,7 +483,7 @@ func TestLimit(t *testing.T) {
 
 func TestLimitNoEvict(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
 
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*50, 2, false, 0, nil)
 	require_NoError(t, err)
@@ -535,7 +535,7 @@ func TestLimitNoEvict(t *testing.T) {
 
 func TestLruLoad(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*100, 2, true, 0, nil)
 	require_NoError(t, err)
 	defer dirStore.Close()
@@ -567,7 +567,7 @@ func TestLruLoad(t *testing.T) {
 
 func TestLruVolume(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
 
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*50, 2, true, 0, nil)
 	require_NoError(t, err)
@@ -609,7 +609,7 @@ func TestLruVolume(t *testing.T) {
 
 func TestLru(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
 
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*50, 2, true, 0, nil)
 	require_NoError(t, err)
@@ -658,7 +658,7 @@ func TestLru(t *testing.T) {
 
 func TestReload(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
 	notificationChan := make(chan struct{}, 5)
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*100, 2, true, 0, func(publicKey string) {
 		notificationChan <- struct{}{}
@@ -719,7 +719,7 @@ func TestReload(t *testing.T) {
 
 func TestExpirationUpdate(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
 
 	dirStore, err := NewExpiringDirJWTStore(dir, false, false, NoDelete, time.Millisecond*50, 10, true, 0, nil)
 	require_NoError(t, err)
@@ -777,7 +777,7 @@ func TestExpirationUpdate(t *testing.T) {
 
 func TestTTL(t *testing.T) {
 	t.Parallel()
-	dir := createDir(t, "jwtstore_test")
+	dir := t.TempDir()
 	require_OneJWT := func() {
 		t.Helper()
 		f, err := os.ReadDir(dir)
@@ -840,7 +840,7 @@ func TestRemove(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
-			dir := createDir(t, "jwtstore_test")
+			dir := t.TempDir()
 			require_OneJWT := func() {
 				t.Helper()
 				f, err := os.ReadDir(dir)
@@ -893,7 +893,7 @@ func TestNotificationOnPack(t *testing.T) {
 		}
 		notificationChan <- struct{}{}
 	}
-	dirPack := createDir(t, "jwtstore_test")
+	dirPack := t.TempDir()
 	packStore, err := NewExpiringDirJWTStore(dirPack, false, false, NoDelete, infDur, 0, true, 0, notification)
 	require_NoError(t, err)
 	// prefill the store with data
@@ -908,7 +908,7 @@ func TestNotificationOnPack(t *testing.T) {
 	packStore.Close()
 	hash := packStore.Hash()
 	for _, shard := range []bool{true, false, true, false} {
-		dirMerge := createDir(t, "jwtstore_test")
+		dirMerge := t.TempDir()
 		mergeStore, err := NewExpiringDirJWTStore(dirMerge, shard, false, NoDelete, infDur, 0, true, 0, notification)
 		require_NoError(t, err)
 		// set
@@ -948,7 +948,7 @@ func TestNotificationOnPackWalk(t *testing.T) {
 	const iterCnt = 8
 	store := [storeCnt]*DirJWTStore{}
 	for i := 0; i < storeCnt; i++ {
-		dirMerge := createDir(t, "jwtstore_test")
+		dirMerge := t.TempDir()
 		mergeStore, err := NewExpiringDirJWTStore(dirMerge, true, false, NoDelete, infDur, 0, true, 0, nil)
 		require_NoError(t, err)
 		store[i] = mergeStore

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -470,11 +469,9 @@ func TestSystemAccountingWithLeafNodes(t *testing.T) {
 	}
 	seed, _ := kp.Seed()
 	mycreds := genCredsFile(t, ujwt, seed)
-	defer removeFile(t, mycreds)
 
 	// Create a server that solicits a leafnode connection.
-	sl, slopts, lnconf := runSolicitWithCredentials(t, opts, mycreds)
-	defer removeFile(t, lnconf)
+	sl, slopts, _ := runSolicitWithCredentials(t, opts, mycreds)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, s)
@@ -1165,7 +1162,6 @@ func TestSystemAccountFromConfig(t *testing.T) {
     `
 
 	conf := createConfFile(t, []byte(fmt.Sprintf(confTemplate, opub, apub, ts.URL)))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -1720,7 +1716,6 @@ func TestSystemAccountNoAuthUser(t *testing.T) {
 			}
 		}
 	`))
-	defer os.Remove(conf)
 	s, o := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -1782,7 +1777,6 @@ func TestServerAccountConns(t *testing.T) {
 			   SYS: {users: [{user: s, password: s}]}
 			   ACC: {users: [{user: a, password: a}]}
 	   }`))
-	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -2404,7 +2398,6 @@ func TestServerEventsFilteredByTag(t *testing.T) {
 		}
 		no_auth_user: b
     `))
-	defer removeFile(t, confA)
 	sA, _ := RunServerWithConfig(confA)
 	defer sA.Shutdown()
 	confB := createConfFile(t, []byte(fmt.Sprintf(`
@@ -2429,7 +2422,6 @@ func TestServerEventsFilteredByTag(t *testing.T) {
 		}
 		no_auth_user: b
     `, sA.opts.Cluster.Port)))
-	defer removeFile(t, confB)
 	sB, _ := RunServerWithConfig(confB)
 	defer sB.Shutdown()
 	checkClusterFormed(t, sA, sB)

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -37,8 +37,7 @@ import (
 )
 
 func TestFileStoreBasics(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -106,8 +105,7 @@ func TestFileStoreBasics(t *testing.T) {
 }
 
 func TestFileStoreMsgHeaders(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -138,8 +136,7 @@ func TestFileStoreMsgHeaders(t *testing.T) {
 }
 
 func TestFileStoreBasicWriteMsgsAndRestore(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fcfg := FileStoreConfig{StoreDir: storeDir}
 
@@ -271,8 +268,7 @@ func TestFileStoreBasicWriteMsgsAndRestore(t *testing.T) {
 }
 
 func TestFileStoreSelectNextFirst(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -310,8 +306,7 @@ func TestFileStoreSelectNextFirst(t *testing.T) {
 }
 
 func TestFileStoreSkipMsg(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 256}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -399,8 +394,7 @@ func TestFileStoreSkipMsg(t *testing.T) {
 }
 
 func TestFileStoreWriteExpireWrite(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	cexp := 10 * time.Millisecond
 	fs, err := newFileStore(
@@ -464,8 +458,7 @@ func TestFileStoreWriteExpireWrite(t *testing.T) {
 }
 
 func TestFileStoreMsgLimit(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxMsgs: 10})
 	if err != nil {
@@ -501,8 +494,7 @@ func TestFileStoreMsgLimit(t *testing.T) {
 }
 
 func TestFileStoreMsgLimitBug(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxMsgs: 1})
 	if err != nil {
@@ -530,8 +522,7 @@ func TestFileStoreBytesLimit(t *testing.T) {
 	toStore := uint64(1024)
 	maxBytes := storedMsgSize * toStore
 
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage, MaxBytes: int64(maxBytes)})
 	if err != nil {
@@ -574,8 +565,7 @@ func TestFileStoreBytesLimit(t *testing.T) {
 func TestFileStoreAgeLimit(t *testing.T) {
 	maxAge := 250 * time.Millisecond
 
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 256},
@@ -635,8 +625,7 @@ func TestFileStoreAgeLimit(t *testing.T) {
 }
 
 func TestFileStoreTimeStamps(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -665,8 +654,7 @@ func TestFileStoreTimeStamps(t *testing.T) {
 }
 
 func TestFileStorePurge(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	blkSize := uint64(64 * 1024)
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: blkSize}, StreamConfig{Name: "zzz", Storage: FileStorage})
@@ -782,8 +770,7 @@ func TestFileStorePurge(t *testing.T) {
 }
 
 func TestFileStoreCompact(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	prf := func(context []byte) ([]byte, error) {
 		h := hmac.New(sha256.New, []byte("dlc22"))
@@ -855,8 +842,7 @@ func TestFileStoreCompact(t *testing.T) {
 }
 
 func TestFileStoreCompactLastPlusOne(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 8192, AsyncFlush: false}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -889,8 +875,7 @@ func TestFileStoreCompactLastPlusOne(t *testing.T) {
 }
 
 func TestFileStoreCompactMsgCountBug(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -931,8 +916,7 @@ func TestFileStoreCompactMsgCountBug(t *testing.T) {
 func TestFileStoreCompactPerf(t *testing.T) {
 	t.SkipNow()
 
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 8192, AsyncFlush: true}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -967,8 +951,7 @@ func TestFileStoreCompactPerf(t *testing.T) {
 }
 
 func TestFileStoreStreamTruncate(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	prf := func(context []byte) ([]byte, error) {
 		h := hmac.New(sha256.New, []byte("dlc22"))
@@ -1056,8 +1039,7 @@ func TestFileStoreStreamTruncate(t *testing.T) {
 }
 
 func TestFileStoreRemovePartialRecovery(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -1107,8 +1089,7 @@ func TestFileStoreRemovePartialRecovery(t *testing.T) {
 }
 
 func TestFileStoreRemoveOutOfOrderRecovery(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -1181,8 +1162,7 @@ func TestFileStoreRemoveOutOfOrderRecovery(t *testing.T) {
 func TestFileStoreAgeLimitRecovery(t *testing.T) {
 	maxAge := 10 * time.Millisecond
 
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, CacheExpire: 1 * time.Millisecond},
@@ -1226,8 +1206,7 @@ func TestFileStoreAgeLimitRecovery(t *testing.T) {
 }
 
 func TestFileStoreBitRot(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -1295,8 +1274,7 @@ func TestFileStoreBitRot(t *testing.T) {
 }
 
 func TestFileStoreEraseMsg(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -1357,8 +1335,7 @@ func TestFileStoreEraseMsg(t *testing.T) {
 }
 
 func TestFileStoreEraseAndNoIndexRecovery(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -1411,8 +1388,7 @@ func TestFileStoreEraseAndNoIndexRecovery(t *testing.T) {
 }
 
 func TestFileStoreMeta(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	mconfig := StreamConfig{Name: "ZZ-22-33", Storage: FileStorage, Subjects: []string{"foo.*"}, Replicas: 22}
 
@@ -1508,8 +1484,7 @@ func TestFileStoreMeta(t *testing.T) {
 }
 
 func TestFileStoreWriteAndReadSameBlock(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -1531,8 +1506,7 @@ func TestFileStoreWriteAndReadSameBlock(t *testing.T) {
 }
 
 func TestFileStoreAndRetrieveMultiBlock(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	subj, msg := "foo", []byte("Hello World!")
 	storedMsgSize := fileStoreMsgSize(subj, nil, msg)
@@ -1572,8 +1546,7 @@ func TestFileStoreAndRetrieveMultiBlock(t *testing.T) {
 }
 
 func TestFileStoreCollapseDmap(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	subj, msg := "foo", []byte("Hello World!")
 	storedMsgSize := fileStoreMsgSize(subj, nil, msg)
@@ -1649,8 +1622,7 @@ func TestFileStoreReadCache(t *testing.T) {
 	subj, msg := "foo.bar", make([]byte, 1024)
 	storedMsgSize := fileStoreMsgSize(subj, nil, msg)
 
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, CacheExpire: 100 * time.Millisecond}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -1700,8 +1672,7 @@ func TestFileStoreReadCache(t *testing.T) {
 }
 
 func TestFileStorePartialCacheExpiration(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	cexp := 10 * time.Millisecond
 
@@ -1725,8 +1696,7 @@ func TestFileStorePartialCacheExpiration(t *testing.T) {
 }
 
 func TestFileStorePartialIndexes(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	cexp := 10 * time.Millisecond
 
@@ -1772,8 +1742,7 @@ func TestFileStorePartialIndexes(t *testing.T) {
 }
 
 func TestFileStoreSnapshot(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	subj, msg := "foo", []byte("Hello Snappy!")
 
@@ -1836,8 +1805,7 @@ func TestFileStoreSnapshot(t *testing.T) {
 		r := bytes.NewReader(snap)
 		tr := tar.NewReader(s2.NewReader(r))
 
-		rstoreDir := createDir(t, JetStreamStoreDir)
-		defer removeDir(t, rstoreDir)
+		rstoreDir := t.TempDir()
 
 		for {
 			hdr, err := tr.Next()
@@ -1960,8 +1928,7 @@ func TestFileStoreSnapshot(t *testing.T) {
 }
 
 func TestFileStoreConsumer(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2140,10 +2107,13 @@ func TestFileStoreWriteFailures(t *testing.T) {
 	if stat, err := os.Stat(tdir); err != nil || !stat.IsDir() {
 		t.SkipNow()
 	}
-	defer removeDir(t, tdir)
 
 	storeDir := filepath.Join(tdir, JetStreamStoreDir)
-	os.MkdirAll(storeDir, 0755)
+	err := os.MkdirAll(storeDir, 0755)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer removeDir(t, storeDir)
 
 	subj, msg := "foo", []byte("Hello Write Failures!")
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
@@ -2239,8 +2209,7 @@ func TestFileStorePerf(t *testing.T) {
 		friendlyBytes(int64(toStore*storedMsgSize)),
 	)
 
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, AsyncFlush: true},
@@ -2378,8 +2347,7 @@ func TestFileStoreReadBackMsgPerf(t *testing.T) {
 		friendlyBytes(int64(toStore*storedMsgSize)),
 	)
 
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -2427,8 +2395,7 @@ func TestFileStoreStoreLimitRemovePerf(t *testing.T) {
 	// 1GB
 	toStore := 1 * 1024 * 1024 * 1024 / storedMsgSize
 
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -2483,8 +2450,7 @@ func TestFileStorePubPerfWithSmallBlkSize(t *testing.T) {
 		friendlyBytes(int64(toStore*storedMsgSize)),
 	)
 
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: FileStoreMinBlkSize},
@@ -2508,8 +2474,7 @@ func TestFileStorePubPerfWithSmallBlkSize(t *testing.T) {
 
 // Saw this manifest from a restart test with max delivered set for JetStream.
 func TestFileStoreConsumerRedeliveredLost(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2578,8 +2543,7 @@ func TestFileStoreConsumerRedeliveredLost(t *testing.T) {
 }
 
 func TestFileStoreConsumerFlusher(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2612,8 +2576,7 @@ func TestFileStoreConsumerFlusher(t *testing.T) {
 }
 
 func TestFileStoreConsumerDeliveredUpdates(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2669,8 +2632,7 @@ func TestFileStoreConsumerDeliveredUpdates(t *testing.T) {
 }
 
 func TestFileStoreConsumerDeliveredAndAckUpdates(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2785,8 +2747,7 @@ func TestFileStoreConsumerDeliveredAndAckUpdates(t *testing.T) {
 }
 
 func TestFileStoreStreamStateDeleted(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2835,8 +2796,7 @@ func TestFileStoreStreamStateDeleted(t *testing.T) {
 // We have reports that sometimes under load a stream could complain about a storage directory
 // not being empty.
 func TestFileStoreStreamDeleteDirNotEmpty(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2871,8 +2831,7 @@ func TestFileStoreConsumerPerf(t *testing.T) {
 	// Comment out to run, holding place for now.
 	t.SkipNow()
 
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2939,8 +2898,7 @@ func TestFileStoreConsumerPerf(t *testing.T) {
 func TestFileStoreStreamIndexBug(t *testing.T) {
 	// https://github.com/nats-io/jetstream/issues/406
 	badIdxBytes, _ := base64.StdEncoding.DecodeString("FgGBkw7D/f8/772iDPDIgbU=")
-	dir := createDir(t, "js-bad-idx-")
-	defer removeDir(t, dir)
+	dir := t.TempDir()
 	fn := filepath.Join(dir, "1.idx")
 	os.WriteFile(fn, badIdxBytes, 0644)
 	mb := &msgBlock{index: 1, ifn: fn}
@@ -2951,8 +2909,7 @@ func TestFileStoreStreamIndexBug(t *testing.T) {
 
 // Reported by Ivan.
 func TestFileStoreStreamDeleteCacheBug(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, CacheExpire: 50 * time.Millisecond}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -2979,8 +2936,7 @@ func TestFileStoreStreamDeleteCacheBug(t *testing.T) {
 
 // https://github.com/nats-io/nats-server/issues/2068
 func TestFileStoreStreamPurgeAndDirtyRestartBug(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "zzz", Storage: FileStorage})
 	if err != nil {
@@ -3039,8 +2995,7 @@ func TestFileStoreStreamPurgeAndDirtyRestartBug(t *testing.T) {
 
 // rip
 func TestFileStoreStreamFailToRollBug(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 512},
@@ -3096,8 +3051,7 @@ func TestBadConsumerState(t *testing.T) {
 }
 
 func TestFileStoreExpireMsgsOnStart(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	ttl := 250 * time.Millisecond
 	cfg := StreamConfig{Name: "ORDERS", Subjects: []string{"orders.*"}, Storage: FileStorage, MaxAge: ttl}
@@ -3326,8 +3280,7 @@ func TestFileStoreExpireMsgsOnStart(t *testing.T) {
 }
 
 func TestFileStoreSparseCompaction(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	cfg := StreamConfig{Name: "KV", Subjects: []string{"kv.>"}, Storage: FileStorage}
 	var fs *fileStore
@@ -3459,8 +3412,7 @@ func TestFileStoreSparseCompaction(t *testing.T) {
 }
 
 func TestFileStoreSparseCompactionWithInteriorDeletes(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	cfg := StreamConfig{Name: "KV", Subjects: []string{"kv.>"}, Storage: FileStorage}
 	var fs *fileStore
@@ -3505,8 +3457,7 @@ func TestFileStoreSparseCompactionWithInteriorDeletes(t *testing.T) {
 // This is because we would not break out of iterator across more message blocks.
 // Issue #2622
 func TestFileStorePurgeExKeepOneBug(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 128},
@@ -3540,8 +3491,7 @@ func TestFileStorePurgeExKeepOneBug(t *testing.T) {
 }
 
 func TestFileStoreRemoveLastWriteIndex(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "TEST", Storage: FileStorage})
 	if err != nil {
@@ -3570,8 +3520,7 @@ func TestFileStoreRemoveLastWriteIndex(t *testing.T) {
 }
 
 func TestFileStoreFilteredPendingBug(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "TEST", Storage: FileStorage})
 	if err != nil {
@@ -3601,8 +3550,7 @@ func TestFileStoreFetchPerf(t *testing.T) {
 	// Comment out to run.
 	t.SkipNow()
 
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir, BlockSize: 8192, AsyncFlush: true}, StreamConfig{Name: "TEST", Storage: FileStorage})
 	if err != nil {
@@ -3633,8 +3581,7 @@ func TestFileStoreFetchPerf(t *testing.T) {
 // For things like raft log when we compact and have a message block that could reclaim > 50% of space for block we want to do that.
 // https://github.com/nats-io/nats-server/issues/2936
 func TestFileStoreCompactReclaimHeadSpace(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 1024 * 1024},
@@ -3796,8 +3743,7 @@ func TestFileStoreCompactReclaimHeadSpace(t *testing.T) {
 }
 
 func TestFileStoreRememberLastMsgTime(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	var fs *fileStore
 	getFS := func() *fileStore {
@@ -3904,8 +3850,7 @@ func (fs *fileStore) getFirstBlock() *msgBlock {
 }
 
 func TestFileStoreRebuildStateDmapAccountingBug(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 1024 * 1024},
@@ -3957,8 +3902,7 @@ func TestFileStoreRebuildStateDmapAccountingBug(t *testing.T) {
 }
 
 func TestFileStorePurgeExWithSubject(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Storage: FileStorage},
@@ -3980,8 +3924,7 @@ func TestFileStorePurgeExWithSubject(t *testing.T) {
 // For instance, with encryption and an expiring stream that has no messages, when a restart happens the decrypt will fail
 // since their are extra bytes, and this could lead to a stream sequence reset to zero.
 func TestFileStoreShortIndexWriteBug(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	// Encrypted mode shows, but could effect non-encrypted mode.
 	prf := func(context []byte) ([]byte, error) {
@@ -4045,8 +3988,7 @@ func TestFileStoreShortIndexWriteBug(t *testing.T) {
 }
 
 func TestFileStoreDoubleCompactWithWriteInBetweenEncryptedBug(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(storeDir)
+	storeDir := t.TempDir()
 
 	prf := func(context []byte) ([]byte, error) {
 		h := hmac.New(sha256.New, []byte("dlc22"))
@@ -4091,8 +4033,7 @@ func TestFileStoreDoubleCompactWithWriteInBetweenEncryptedBug(t *testing.T) {
 // possibly still have a non-zero counter from previous writes.
 // Happens when all messages expire and the are flushed and then subsequent writes occur.
 func TestFileStoreEncryptedKeepIndexNeedBekResetBug(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(storeDir)
+	storeDir := t.TempDir()
 
 	prf := func(context []byte) ([]byte, error) {
 		h := hmac.New(sha256.New, []byte("dlc22"))
@@ -4162,8 +4103,7 @@ func (fs *fileStore) reportMeta() (hasPSIM, hasAnyFSS bool) {
 }
 
 func TestFileStoreExpireSubjectMeta(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 1024, CacheExpire: time.Second},
@@ -4228,8 +4168,7 @@ func TestFileStoreExpireSubjectMeta(t *testing.T) {
 }
 
 func TestFileStoreMaxMsgsPerSubject(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 128, CacheExpire: time.Second},
@@ -4261,8 +4200,7 @@ func TestFileStoreMaxMsgsPerSubject(t *testing.T) {
 }
 
 func TestFileStoreSubjectStateCacheExpiration(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 32, CacheExpire: time.Second},
@@ -4322,8 +4260,7 @@ func TestFileStoreSubjectStateCacheExpiration(t *testing.T) {
 }
 
 func TestFileStoreEncryptedAES(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(storeDir)
+	storeDir := t.TempDir()
 
 	prf := func(context []byte) ([]byte, error) {
 		h := hmac.New(sha256.New, []byte("dlc22"))
@@ -4387,8 +4324,7 @@ func TestFileStoreEncryptedAES(t *testing.T) {
 
 // Make sure we do not go through block loads when we know no subjects will exists, e.g. raft.
 func TestFileStoreNoFSSWhenNoSubjects(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -4431,8 +4367,7 @@ func TestFileStoreNoFSSWhenNoSubjects(t *testing.T) {
 }
 
 func TestFileStoreNoFSSBugAfterRemoveFirst(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir, BlockSize: 8 * 1024 * 1024, CacheExpire: 200 * time.Millisecond},
@@ -4475,8 +4410,7 @@ func TestFileStoreNoFSSBugAfterRemoveFirst(t *testing.T) {
 }
 
 func TestFileStoreNoFSSAfterRecover(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -4516,8 +4450,7 @@ func TestFileStoreNoFSSAfterRecover(t *testing.T) {
 }
 
 func TestFileStoreFSSCloseAndKeepOnExpireOnRecoverBug(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(storeDir)
+	storeDir := t.TempDir()
 
 	ttl := 100 * time.Millisecond
 	fs, err := newFileStore(
@@ -4547,8 +4480,7 @@ func TestFileStoreFSSCloseAndKeepOnExpireOnRecoverBug(t *testing.T) {
 }
 
 func TestFileStoreFSSBadStateBug(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(storeDir)
+	storeDir := t.TempDir()
 
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -4592,8 +4524,7 @@ func TestFileStoreFSSBadStateBug(t *testing.T) {
 }
 
 func TestFileStoreFSSExpireNumPendingBug(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(storeDir)
+	storeDir := t.TempDir()
 
 	cexp := 100 * time.Millisecond
 	fs, err := newFileStore(

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -6324,7 +6324,6 @@ func TestGatewayTLSConfigReload(t *testing.T) {
 		}
 	`
 	confA := createConfFile(t, []byte(fmt.Sprintf(template, "")))
-	defer removeFile(t, confA)
 
 	srvA, optsA := RunServerWithConfig(confA)
 	defer srvA.Shutdown()
@@ -6377,7 +6376,6 @@ func TestGatewayTLSConfigReloadForRemote(t *testing.T) {
 		}
 	`
 	confB := createConfFile(t, []byte(fmt.Sprintf(template, optsA.Gateway.Port, "")))
-	defer removeFile(t, confB)
 
 	srvB, _ := RunServerWithConfig(confB)
 	defer srvB.Shutdown()
@@ -6404,7 +6402,6 @@ func TestGatewayAuthDiscovered(t *testing.T) {
 			authorization: { user: gwuser, password: changeme }
 		}
 	`))
-	defer removeFile(t, confA)
 	srvA, optsA := RunServerWithConfig(confA)
 	defer srvA.Shutdown()
 
@@ -6419,7 +6416,6 @@ func TestGatewayAuthDiscovered(t *testing.T) {
 			]
 		}
 	`, optsA.Gateway.Port)))
-	defer removeFile(t, confB)
 	srvB, _ := RunServerWithConfig(confB)
 	defer srvB.Shutdown()
 
@@ -6439,8 +6435,7 @@ func TestTLSGatewaysCertificateImplicitAllowFail(t *testing.T) {
 
 func testTLSGatewaysCertificateImplicitAllow(t *testing.T, pass bool) {
 	// Base config for the servers
-	cfg := createFile(t, "cfg")
-	defer removeFile(t, cfg.Name())
+	cfg := createFileAtDir(t, t.TempDir(), "cfg")
 	cfg.WriteString(fmt.Sprintf(`
 		gateway {
 		  tls {

--- a/server/jetstream_benchmark_consume_test.go
+++ b/server/jetstream_benchmark_consume_test.go
@@ -308,7 +308,7 @@ func BenchmarkJetStreamConsume(b *testing.B) {
 							}
 							var connectURL string
 							if bc.clusterSize == 1 {
-								s := RunBasicJetStreamServer()
+								s := RunBasicJetStreamServer(b)
 								defer s.Shutdown()
 								connectURL = s.ClientURL()
 							} else {

--- a/server/jetstream_benchmark_kv_test.go
+++ b/server/jetstream_benchmark_kv_test.go
@@ -184,7 +184,7 @@ func BenchmarkJetStreamKV(b *testing.B) {
 							}
 							var connectURL string
 							if bc.clusterSize == 1 {
-								s := RunBasicJetStreamServer()
+								s := RunBasicJetStreamServer(b)
 								defer s.Shutdown()
 								connectURL = s.ClientURL()
 							} else {

--- a/server/jetstream_benchmark_publish_test.go
+++ b/server/jetstream_benchmark_publish_test.go
@@ -200,7 +200,7 @@ func BenchmarkJetStreamPublish(b *testing.B) {
 							var connectURL string
 
 							if bc.clusterSize == 1 {
-								s := RunBasicJetStreamServer()
+								s := RunBasicJetStreamServer(b)
 								defer s.Shutdown()
 								connectURL = s.ClientURL()
 							} else {

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -412,7 +412,7 @@ func createJetStreamSuperClusterWithTemplateAndModHook(t *testing.T, tmpl string
 		routeConfig := strings.Join(routes, ",")
 
 		for si := 0; si < numServersPer; si++ {
-			storeDir := createDir(t, JetStreamStoreDir)
+			storeDir := t.TempDir()
 			sn := fmt.Sprintf("%s-S%d", cn, si+1)
 			bconf := fmt.Sprintf(tmpl, sn, storeDir, cn, cp+si, routeConfig)
 			conf := fmt.Sprintf(jsSuperClusterTempl, bconf, cn, gp, gwconf)
@@ -639,7 +639,7 @@ func createMixedModeCluster(t testing.TB, tmpl string, clusterName, snPre string
 	c := &cluster{servers: make([]*Server, 0, numServers), opts: make([]*Options, 0, numServers), name: clusterName}
 
 	for cp := startClusterPort; cp < startClusterPort+numServers; cp++ {
-		storeDir := createDir(t, JetStreamStoreDir)
+		storeDir := t.TempDir()
 
 		sn := fmt.Sprintf("%sS-%d", snPre, cp-startClusterPort+1)
 		conf := fmt.Sprintf(tmpl, sn, storeDir, clusterName, cp, routeConfig)
@@ -724,7 +724,7 @@ func createJetStreamClusterAndModHook(t testing.TB, tmpl string, clusterName, sn
 	c := &cluster{servers: make([]*Server, 0, numServers), opts: make([]*Options, 0, numServers), name: clusterName}
 
 	for cp := portStart; cp < portStart+numServers; cp++ {
-		storeDir := createDir(t, JetStreamStoreDir)
+		storeDir := t.TempDir()
 		sn := fmt.Sprintf("%sS-%d", snPre, cp-portStart+1)
 		conf := fmt.Sprintf(tmpl, sn, storeDir, clusterName, cp, routeConfig)
 		if modify != nil {
@@ -748,7 +748,7 @@ func createJetStreamClusterAndModHook(t testing.TB, tmpl string, clusterName, sn
 func (c *cluster) addInNewServer() *Server {
 	c.t.Helper()
 	sn := fmt.Sprintf("S-%d", len(c.servers)+1)
-	storeDir, _ := os.MkdirTemp(tempRoot, JetStreamStoreDir)
+	storeDir := c.t.TempDir()
 	seedRoute := fmt.Sprintf("nats-route://127.0.0.1:%d", c.opts[0].Cluster.Port)
 	conf := fmt.Sprintf(jsClusterTempl, sn, storeDir, c.name, -1, seedRoute)
 	s, o := RunServerWithConfig(createConfFile(c.t, []byte(conf)))
@@ -764,7 +764,7 @@ func (c *cluster) createSingleLeafNodeNoSystemAccount() *Server {
 	lno := as.getOpts().LeafNode
 	ln1 := fmt.Sprintf("nats://one:p@%s:%d", lno.Host, lno.Port)
 	ln2 := fmt.Sprintf("nats://two:p@%s:%d", lno.Host, lno.Port)
-	conf := fmt.Sprintf(jsClusterSingleLeafNodeTempl, createDir(c.t, JetStreamStoreDir), ln1, ln2)
+	conf := fmt.Sprintf(jsClusterSingleLeafNodeTempl, c.t.TempDir(), ln1, ln2)
 	s, o := RunServerWithConfig(createConfFile(c.t, []byte(conf)))
 	c.servers = append(c.servers, s)
 	c.opts = append(c.opts, o)
@@ -788,7 +788,7 @@ func (c *cluster) createSingleLeafNodeNoSystemAccountAndEnablesJetStreamWithDoma
 	as := c.randomServer()
 	lno := as.getOpts().LeafNode
 	ln := fmt.Sprintf("nats://%s:p@%s:%d", user, lno.Host, lno.Port)
-	conf := fmt.Sprintf(tmpl, createDir(c.t, JetStreamStoreDir), ln)
+	conf := fmt.Sprintf(tmpl, c.t.TempDir(), ln)
 	s, o := RunServerWithConfig(createConfFile(c.t, []byte(conf)))
 	c.servers = append(c.servers, s)
 	c.opts = append(c.opts, o)
@@ -923,7 +923,7 @@ func (c *cluster) createLeafNode(extend bool) *Server {
 func (c *cluster) createLeafNodeWithTemplate(name, template string) *Server {
 	c.t.Helper()
 	tmpl := c.createLeafSolicit(template)
-	conf := fmt.Sprintf(tmpl, name, createDir(c.t, JetStreamStoreDir))
+	conf := fmt.Sprintf(tmpl, name, c.t.TempDir())
 	s, o := RunServerWithConfig(createConfFile(c.t, []byte(conf)))
 	c.servers = append(c.servers, s)
 	c.opts = append(c.opts, o)

--- a/server/jetstream_leafnode_test.go
+++ b/server/jetstream_leafnode_test.go
@@ -100,30 +100,26 @@ func TestJetStreamLeafNodeUniqueServerNameCrossJSDomain(t *testing.T) {
 		}
     `
 	t.Run("same-domain", func(t *testing.T) {
-		confA := createConfFile(t, []byte(fmt.Sprintf(tmplA, name, createDir(t, JetStreamStoreDir))))
-		defer removeFile(t, confA)
+		confA := createConfFile(t, []byte(fmt.Sprintf(tmplA, name, t.TempDir())))
 		sA, oA := RunServerWithConfig(confA)
 		defer sA.Shutdown()
 		// using same domain as sA
-		confL := createConfFile(t, []byte(fmt.Sprintf(tmplL, name, createDir(t, JetStreamStoreDir), "hub",
+		confL := createConfFile(t, []byte(fmt.Sprintf(tmplL, name, t.TempDir(), "hub",
 			fmt.Sprintf("nats://y:p@127.0.0.1:%d", oA.LeafNode.Port),
 			fmt.Sprintf("nats://admin:s3cr3t!@127.0.0.1:%d", oA.LeafNode.Port))))
-		defer removeFile(t, confL)
 		sL, _ := RunServerWithConfig(confL)
 		defer sL.Shutdown()
 		// as server name uniqueness is violates, sL.ID() is the expected value
 		test(sA, sL.ID(), sA, sL)
 	})
 	t.Run("different-domain", func(t *testing.T) {
-		confA := createConfFile(t, []byte(fmt.Sprintf(tmplA, name, createDir(t, JetStreamStoreDir))))
-		defer removeFile(t, confA)
+		confA := createConfFile(t, []byte(fmt.Sprintf(tmplA, name, t.TempDir())))
 		sA, oA := RunServerWithConfig(confA)
 		defer sA.Shutdown()
 		// using different domain as sA
-		confL := createConfFile(t, []byte(fmt.Sprintf(tmplL, name, createDir(t, JetStreamStoreDir), "spoke",
+		confL := createConfFile(t, []byte(fmt.Sprintf(tmplL, name, t.TempDir(), "spoke",
 			fmt.Sprintf("nats://y:p@127.0.0.1:%d", oA.LeafNode.Port),
 			fmt.Sprintf("nats://admin:s3cr3t!@127.0.0.1:%d", oA.LeafNode.Port))))
-		defer removeFile(t, confL)
 		sL, _ := RunServerWithConfig(confL)
 		defer sL.Shutdown()
 		checkLeafNodeConnectedCount(t, sL, 2)
@@ -156,12 +152,9 @@ func TestJetStreamLeafNodeJwtPermsAndJSDomains(t *testing.T) {
 		j.Sub.Deny.Add("subdeny")
 		j.Pub.Deny.Add("pubdeny")
 	})
-	defer removeFile(t, lnCreds)
 	unlimitedCreds := createUserWithLimit(t, accKp, noExpiration, nil)
-	defer removeFile(t, unlimitedCreds)
 
 	sysCreds := createUserWithLimit(t, sysKp, noExpiration, nil)
-	defer removeFile(t, sysCreds)
 
 	tmplA := `
 operator: %s
@@ -204,14 +197,12 @@ leafnodes:{
 
 	confA := createConfFile(t, []byte(fmt.Sprintf(tmplA, ojwt, sysPub,
 		sysPub, sysJwt, accPub, accJwt,
-		createDir(t, JetStreamStoreDir))))
-	defer removeFile(t, confA)
+		t.TempDir())))
 	sA, _ := RunServerWithConfig(confA)
 	defer sA.Shutdown()
 
-	confL := createConfFile(t, []byte(fmt.Sprintf(tmplL, createDir(t, JetStreamStoreDir),
+	confL := createConfFile(t, []byte(fmt.Sprintf(tmplL, t.TempDir(),
 		sA.opts.LeafNode.Port, lnCreds, sA.opts.LeafNode.Port, sysCreds)))
-	defer removeFile(t, confL)
 	sL, _ := RunServerWithConfig(confL)
 	defer sL.Shutdown()
 
@@ -411,17 +402,13 @@ leafnodes:{
 		{false, true},
 		{false, false}} {
 		t.Run(fmt.Sprintf("%t-%t", testCase.same, testCase.leafFunctionPreJoin), func(t *testing.T) {
-			sd1 := createDir(t, JetStreamStoreDir)
-			defer os.RemoveAll(sd1)
+			sd1 := t.TempDir()
 			confA := createConfFile(t, []byte(fmt.Sprintf(tmplA, sd1)))
-			defer removeFile(t, confA)
 			sA, _ := RunServerWithConfig(confA)
 			defer sA.Shutdown()
 
-			sd2 := createDir(t, JetStreamStoreDir)
-			defer os.RemoveAll(sd2)
+			sd2 := t.TempDir()
 			confB := createConfFile(t, []byte(fmt.Sprintf(tmplB, sd2)))
-			defer removeFile(t, confB)
 			sB, _ := RunServerWithConfig(confB)
 			defer sB.Shutdown()
 
@@ -444,19 +431,15 @@ leafnodes:{
 				hint = fmt.Sprintf("extension_hint: %s", strings.ToUpper(jsNoExtend))
 			}
 
-			sd3 := createDir(t, JetStreamStoreDir)
-			defer os.RemoveAll(sd3)
+			sd3 := t.TempDir()
 			// deliberately pick server sA and proxy
 			confLA := createConfFile(t, []byte(fmt.Sprintf(tmplLA, sd3, hint, sA.opts.LeafNode.Port, lPort)))
-			defer removeFile(t, confLA)
 			sLA, _ := RunServerWithConfig(confLA)
 			defer sLA.Shutdown()
 
-			sd4 := createDir(t, JetStreamStoreDir)
-			defer os.RemoveAll(sd4)
+			sd4 := t.TempDir()
 			// deliberately pick server sA and proxy
 			confLB := createConfFile(t, []byte(fmt.Sprintf(tmplLB, sd4, hint, sA.opts.LeafNode.Port, lPort)))
-			defer removeFile(t, confLB)
 			sLB, _ := RunServerWithConfig(confLB)
 			defer sLB.Shutdown()
 
@@ -673,22 +656,17 @@ cluster: { name: clustL }
 				jsDisabledDomainString = "extension_hint: will_extend"
 			}
 
-			sd1 := createDir(t, JetStreamStoreDir)
-			defer os.RemoveAll(sd1)
+			sd1 := t.TempDir()
 			confA := createConfFile(t, []byte(fmt.Sprintf(tmplA, jsEnabledDomainString, sd1)))
-			defer removeFile(t, confA)
 			sA, _ := RunServerWithConfig(confA)
 			defer sA.Shutdown()
 
-			sd2 := createDir(t, JetStreamStoreDir)
-			defer os.RemoveAll(sd2)
+			sd2 := t.TempDir()
 			confB := createConfFile(t, []byte(fmt.Sprintf(tmplB, jsEnabledDomainString, sd2)))
-			defer removeFile(t, confB)
 			sB, _ := RunServerWithConfig(confB)
 			defer sB.Shutdown()
 
 			confC := createConfFile(t, []byte(fmt.Sprintf(tmplC, jsDisabledDomainString)))
-			defer removeFile(t, confC)
 			sC, _ := RunServerWithConfig(confC)
 			defer sC.Shutdown()
 
@@ -696,11 +674,9 @@ cluster: { name: clustL }
 			c := cluster{t: t, servers: []*Server{sA, sB, sC}}
 			c.waitOnPeerCount(2)
 
-			sd3 := createDir(t, JetStreamStoreDir)
-			defer os.RemoveAll(sd3)
+			sd3 := t.TempDir()
 			// deliberately pick server sC (no JS) to connect to
 			confLA := createConfFile(t, []byte(fmt.Sprintf(tmplLA, jsEnabledDomainString, sd3, sC.opts.LeafNode.Port, sC.opts.LeafNode.Port)))
-			defer removeFile(t, confLA)
 			sLA, _ := RunServerWithConfig(confLA)
 			defer sLA.Shutdown()
 
@@ -776,11 +752,9 @@ leafnodes:{
 		pl.Sub.Deny.Add(jsAllAPI)
 	})
 
-	sd := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(sd)
+	sd := t.TempDir()
 
 	confL := createConfFile(t, []byte(fmt.Sprintf(tmplL, sd, creds, creds)))
-	defer removeFile(t, confL)
 	opts := LoadConfig(confL)
 	sL, err := NewServer(opts)
 	require_NoError(t, err)
@@ -852,7 +826,6 @@ leafnodes: {
 
 	test := func(domain string, sysShared bool) {
 		confHub := createConfFile(t, []byte(fmt.Sprintf(tmplHub, -1, "disabled", "disabled", -1, "")))
-		defer removeFile(t, confHub)
 		sHub, _ := RunServerWithConfig(confHub)
 		defer sHub.Shutdown()
 
@@ -866,10 +839,8 @@ leafnodes: {
 			sys = fmt.Sprintf(`{url:nats://s1:s1@127.0.0.1:%d, account: SYS}`, sHub.opts.LeafNode.Port)
 		}
 
-		sdLeaf := createDir(t, JetStreamStoreDir)
-		defer os.RemoveAll(sdLeaf)
+		sdLeaf := t.TempDir()
 		confL := createConfFile(t, []byte(fmt.Sprintf(tmplL, domain, sdLeaf, sHub.opts.LeafNode.Port, sys, noDomainFix)))
-		defer removeFile(t, confL)
 		sLeaf, _ := RunServerWithConfig(confL)
 		defer sLeaf.Shutdown()
 
@@ -910,8 +881,7 @@ leafnodes: {
 		require_NoError(t, err)
 
 		// Enable jetstream in hub.
-		sdHub := createDir(t, JetStreamStoreDir)
-		defer os.RemoveAll(sdHub)
+		sdHub := t.TempDir()
 		jsEnabled := fmt.Sprintf(`{ domain: "%s", store_dir: '%s', max_mem: 100Mb, max_file: 100Mb }`, domain, sdHub)
 		require_NoError(t, os.WriteFile(confHub, []byte(fmt.Sprintf(tmplHub,
 			sHubUpd1.opts.Port,
@@ -1012,21 +982,17 @@ leafnodes: {
 		sysKp, syspub := createKey(t)
 		sysJwt := encodeClaim(t, jwt.NewAccountClaims(syspub), syspub)
 		sysCreds := newUser(t, sysKp)
-		defer removeFile(t, sysCreds)
 
 		aKp, aPub := createKey(t)
 		aClaim := jwt.NewAccountClaims(aPub)
 		aJwt := encodeClaim(t, aClaim, aPub)
 		aCreds := newUser(t, aKp)
-		defer removeFile(t, aCreds)
 
 		confHub := createConfFile(t, []byte(fmt.Sprintf(tmplHub, -1, ojwt, syspub, syspub, sysJwt, aPub, aJwt, -1, "")))
-		defer removeFile(t, confHub)
 		sHub, _ := RunServerWithConfig(confHub)
 		defer sHub.Shutdown()
 
-		sdLeaf := createDir(t, JetStreamStoreDir)
-		defer os.RemoveAll(sdLeaf)
+		sdLeaf := t.TempDir()
 		confL := createConfFile(t, []byte(fmt.Sprintf(tmplL,
 			domain,
 			sdLeaf,
@@ -1035,7 +1001,6 @@ leafnodes: {
 			sHub.opts.LeafNode.Port,
 			sysCreds,
 			noDomainFix)))
-		defer removeFile(t, confL)
 		sLeaf, _ := RunServerWithConfig(confL)
 		defer sLeaf.Shutdown()
 
@@ -1151,17 +1116,13 @@ leafnodes: {
 default_js_domain: {B:"DHUB"}
 `
 
-	sd1 := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(sd1)
+	sd1 := t.TempDir()
 	confHub1 := createConfFile(t, []byte(fmt.Sprintf(tmplHub1, sd1)))
-	defer removeFile(t, confHub1)
 	sHub1, _ := RunServerWithConfig(confHub1)
 	defer sHub1.Shutdown()
 
-	sd2 := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(sd2)
+	sd2 := t.TempDir()
 	confHub2 := createConfFile(t, []byte(fmt.Sprintf(tmplHub2, sd2)))
-	defer removeFile(t, confHub2)
 	sHub2, _ := RunServerWithConfig(confHub2)
 	defer sHub2.Shutdown()
 
@@ -1169,17 +1130,13 @@ default_js_domain: {B:"DHUB"}
 	c1 := cluster{t: t, servers: []*Server{sHub1, sHub2}}
 	c1.waitOnPeerCount(2)
 
-	sd3 := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(sd3)
+	sd3 := t.TempDir()
 	confLeaf1 := createConfFile(t, []byte(fmt.Sprintf(tmplL1, sd3, sHub1.getOpts().LeafNode.Port, sHub1.getOpts().LeafNode.Port)))
-	defer removeFile(t, confLeaf1)
 	sLeaf1, _ := RunServerWithConfig(confLeaf1)
 	defer sLeaf1.Shutdown()
 
-	sd4 := createDir(t, JetStreamStoreDir)
-	defer os.RemoveAll(sd4)
-	confLeaf2 := createConfFile(t, []byte(fmt.Sprintf(tmplL2, sd3, sHub1.getOpts().LeafNode.Port, sHub1.getOpts().LeafNode.Port)))
-	defer removeFile(t, confLeaf2)
+	sd4 := t.TempDir()
+	confLeaf2 := createConfFile(t, []byte(fmt.Sprintf(tmplL2, sd4, sHub1.getOpts().LeafNode.Port, sHub1.getOpts().LeafNode.Port)))
 	sLeaf2, _ := RunServerWithConfig(confLeaf2)
 	defer sLeaf2.Shutdown()
 
@@ -1243,7 +1200,6 @@ func TestLeafNodeSvcImportExportCycle(t *testing.T) {
 		listen: "127.0.0.1:-1"
 	}
 	`, accounts)))
-	defer os.Remove(hconf)
 	s, o := RunServerWithConfig(hconf)
 	defer s.Shutdown()
 
@@ -1264,8 +1220,7 @@ func TestLeafNodeSvcImportExportCycle(t *testing.T) {
 			}
 		]
 	}
-	`, accounts, createDir(t, JetStreamStoreDir), o.LeafNode.Port)))
-	defer os.Remove(lconf)
+	`, accounts, t.TempDir(), o.LeafNode.Port)))
 	sl, so := RunServerWithConfig(lconf)
 	defer sl.Shutdown()
 

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -444,13 +444,13 @@ func TestJetStreamSuperClusterInterestOnlyMode(t *testing.T) {
 			gateways = [{name: %s, urls: ["nats://127.0.0.1:%d"]}]
 		}
 	`
-	storeDir1 := createDir(t, JetStreamStoreDir)
+	storeDir1 := t.TempDir()
 	conf1 := createConfFile(t, []byte(fmt.Sprintf(template,
 		"S1", storeDir1, "", 23222, "A", 23222, "A", 11222, "B", 11223)))
 	s1, o1 := RunServerWithConfig(conf1)
 	defer s1.Shutdown()
 
-	storeDir2 := createDir(t, JetStreamStoreDir)
+	storeDir2 := t.TempDir()
 	conf2 := createConfFile(t, []byte(fmt.Sprintf(template,
 		"S2", storeDir2, "", 23223, "B", 23223, "B", 11223, "A", 11222)))
 	s2, o2 := RunServerWithConfig(conf2)
@@ -2274,7 +2274,6 @@ func TestJetStreamSuperClusterImportConsumerStreamSubjectRemap(t *testing.T) {
 				password: pwd
 			}
 		`, scl.getOpts().LeafNode.Port)))
-			defer removeFile(t, cf)
 			s, _ := RunServerWithConfig(cf)
 			defer s.Shutdown()
 			checkLeafNodeConnected(t, scl)
@@ -2309,7 +2308,6 @@ func TestJetStreamSuperClusterImportConsumerStreamSubjectRemap(t *testing.T) {
 				},
 			}
 		`, scl.getOpts().LeafNode.Port)))
-			defer removeFile(t, cf)
 			s, _ := RunServerWithConfig(cf)
 			defer s.Shutdown()
 			checkLeafNodeConnected(t, scl)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -50,9 +50,6 @@ import (
 
 func TestJetStreamBasicNilConfig(t *testing.T) {
 	s := RunRandClientPortServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
 	defer s.Shutdown()
 
 	if err := s.EnableJetStream(nil); err != nil {
@@ -88,12 +85,11 @@ func TestJetStreamBasicNilConfig(t *testing.T) {
 	}
 }
 
-func RunBasicJetStreamServer() *Server {
+func RunBasicJetStreamServer(tb testing.TB) *Server {
 	opts := DefaultTestOptions
 	opts.Port = -1
 	opts.JetStream = true
-	tdir, _ := os.MkdirTemp(tempRoot, "jstests-storedir-")
-	opts.StoreDir = tdir
+	opts.StoreDir = tb.TempDir()
 	return RunServer(&opts)
 }
 
@@ -126,10 +122,7 @@ func clientConnectWithOldRequest(t *testing.T, s *Server) *nats.Conn {
 }
 
 func TestJetStreamEnableAndDisableAccount(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Global in simple setup should be enabled already.
@@ -202,12 +195,8 @@ func TestJetStreamAddStream(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -270,12 +259,8 @@ func TestJetStreamAddStreamDiscardNew(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -319,13 +304,9 @@ func TestJetStreamAutoTuneFSConfig(t *testing.T) {
 	s := RunRandClientPortServer()
 	defer s.Shutdown()
 
-	jsconfig := &JetStreamConfig{MaxMemory: -1, MaxStore: 128 * 1024 * 1024}
+	jsconfig := &JetStreamConfig{MaxMemory: -1, MaxStore: 128 * 1024 * 1024, StoreDir: t.TempDir()}
 	if err := s.EnableJetStream(jsconfig); err != nil {
 		t.Fatalf("Expected no error, got %v", err)
-	}
-
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
 	}
 
 	maxMsgSize := int32(512)
@@ -367,10 +348,7 @@ func TestJetStreamAutoTuneFSConfig(t *testing.T) {
 }
 
 func TestJetStreamConsumerAndStreamDescriptions(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	descr := "foo asset"
@@ -418,10 +396,7 @@ func TestJetStreamConsumerAndStreamDescriptions(t *testing.T) {
 }
 
 func TestJetStreamPubAck(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	sname := "PUBACK"
@@ -473,12 +448,8 @@ func TestJetStreamConsumerWithStartTime(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			fsCfg := &FileStoreConfig{BlockSize: 100}
 			mset, err := s.GlobalAccount().addStreamWithStore(c.mconfig, fsCfg)
@@ -544,12 +515,8 @@ func TestJetStreamConsumerWithMultipleStartOptions(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -593,12 +560,8 @@ func TestJetStreamConsumerMaxDeliveries(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -667,12 +630,8 @@ func TestJetStreamPullConsumerDelayedFirstPullWithReplayOriginal(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -716,12 +675,8 @@ func TestJetStreamConsumerAckFloorFill(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -788,12 +743,8 @@ func TestJetStreamNoPanicOnRaceBetweenShutdownAndConsumerDelete(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -854,12 +805,8 @@ func TestJetStreamAddStreamMaxMsgSize(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -887,10 +834,7 @@ func TestJetStreamAddStreamMaxMsgSize(t *testing.T) {
 }
 
 func TestJetStreamAddStreamCanonicalNames(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	acc := s.GlobalAccount()
@@ -912,10 +856,7 @@ func TestJetStreamAddStreamCanonicalNames(t *testing.T) {
 }
 
 func TestJetStreamAddStreamBadSubjects(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -946,10 +887,7 @@ func TestJetStreamAddStreamBadSubjects(t *testing.T) {
 }
 
 func TestJetStreamMaxConsumers(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -988,10 +926,7 @@ func TestJetStreamAddStreamOverlappingSubjects(t *testing.T) {
 		Subjects: []string{"foo", "bar", "baz.*", "foo.bar.baz.>"},
 	}
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	acc := s.GlobalAccount()
@@ -1019,10 +954,7 @@ func TestJetStreamAddStreamOverlappingSubjects(t *testing.T) {
 }
 
 func TestJetStreamAddStreamOverlapWithJSAPISubjects(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	acc := s.GlobalAccount()
@@ -1052,10 +984,7 @@ func TestJetStreamAddStreamSameConfigOK(t *testing.T) {
 		Storage:  MemoryStorage,
 	}
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	acc := s.GlobalAccount()
@@ -1094,12 +1023,8 @@ func TestJetStreamBasicAckPublish(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -1131,12 +1056,8 @@ func TestJetStreamStateTimestamps(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -1174,12 +1095,8 @@ func TestJetStreamNoAckStream(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			// We can use NoAck to suppress acks even when reply subjects are present.
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -1213,12 +1130,8 @@ func TestJetStreamCreateConsumer(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -1323,12 +1236,8 @@ func TestJetStreamBasicDeliverSubject(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -1483,12 +1392,8 @@ func TestJetStreamBasicWorkQueue(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -1581,12 +1486,8 @@ func TestJetStreamWorkQueueMaxWaiting(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -1680,12 +1581,8 @@ func TestJetStreamWorkQueueWrapWaiting(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -1766,12 +1663,8 @@ func TestJetStreamWorkQueueRequest(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -1890,12 +1783,8 @@ func TestJetStreamSubjectFiltering(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -1966,12 +1855,8 @@ func TestJetStreamWorkQueueSubjectFiltering(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -2039,12 +1924,8 @@ func TestJetStreamWildcardSubjectFiltering(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -2155,12 +2036,8 @@ func TestJetStreamWorkQueueAckAndNext(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -2228,12 +2105,8 @@ func TestJetStreamWorkQueueRequestBatch(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -2327,12 +2200,8 @@ func TestJetStreamWorkQueueRetentionStream(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -2446,12 +2315,8 @@ func TestJetStreamAckAllRedelivery(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -2532,12 +2397,8 @@ func TestJetStreamAckReplyStreamPending(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -2683,12 +2544,8 @@ func TestJetStreamAckReplyStreamPendingWithAcks(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -2756,12 +2613,8 @@ func TestJetStreamWorkQueueAckWaitRedelivery(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -2860,12 +2713,8 @@ func TestJetStreamWorkQueueNakRedelivery(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -2939,12 +2788,8 @@ func TestJetStreamWorkQueueWorkingIndicator(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -3026,12 +2871,8 @@ func TestJetStreamWorkQueueTerminateDelivery(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -3120,15 +2961,8 @@ func TestJetStreamWorkQueueTerminateDelivery(t *testing.T) {
 }
 
 func TestJetStreamConsumerAckAck(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
-
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
 
 	mname := "ACK-ACK"
 	mset, err := s.GlobalAccount().addStream(&StreamConfig{Name: mname, Storage: MemoryStorage})
@@ -3170,10 +3004,7 @@ func TestJetStreamConsumerAckAck(t *testing.T) {
 }
 
 func TestJetStreamAckNext(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	mname := "ACKNXT"
@@ -3265,10 +3096,7 @@ func TestJetStreamAckNext(t *testing.T) {
 }
 
 func TestJetStreamPublishDeDupe(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	mname := "DeDupe"
@@ -3428,10 +3256,7 @@ func getPubAckResponse(msg []byte) *JSPubAckResponse {
 }
 
 func TestJetStreamPublishExpect(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	mname := "EXPECT"
@@ -3533,10 +3358,7 @@ func TestJetStreamPublishExpect(t *testing.T) {
 }
 
 func TestJetStreamPullConsumerRemoveInterest(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	mname := "MYS-PULL"
@@ -3619,10 +3441,7 @@ func TestJetStreamPullConsumerRemoveInterest(t *testing.T) {
 }
 
 func TestJetStreamConsumerRateLimit(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	mname := "RATELIMIT"
@@ -3696,10 +3515,7 @@ func TestJetStreamConsumerRateLimit(t *testing.T) {
 }
 
 func TestJetStreamEphemeralConsumerRecoveryAfterServerRestart(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	mname := "MYS"
@@ -3798,10 +3614,7 @@ func TestJetStreamEphemeralConsumerRecoveryAfterServerRestart(t *testing.T) {
 }
 
 func TestJetStreamConsumerMaxDeliveryAndServerRestart(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	mname := "MYS"
@@ -3938,10 +3751,7 @@ func TestJetStreamConsumerMaxDeliveryAndServerRestart(t *testing.T) {
 }
 
 func TestJetStreamDeleteConsumerAndServerRestart(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	sendSubj := "MYQ"
@@ -3988,10 +3798,7 @@ func TestJetStreamDeleteConsumerAndServerRestart(t *testing.T) {
 }
 
 func TestJetStreamRedeliveryAfterServerRestart(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	sendSubj := "MYQ"
@@ -4064,10 +3871,7 @@ func TestJetStreamRedeliveryAfterServerRestart(t *testing.T) {
 }
 
 func TestJetStreamSnapshots(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	mname := "MY-STREAM"
@@ -4173,12 +3977,9 @@ func TestJetStreamSnapshots(t *testing.T) {
 	}
 
 	// Now try restoring to a different
-	s2 := RunBasicJetStreamServer()
+	s2 := RunBasicJetStreamServer(t)
 	defer s2.Shutdown()
 
-	if config := s2.JetStreamConfig(); config != nil && config.StoreDir != "" {
-		defer removeDir(t, config.StoreDir)
-	}
 	acc = s2.GlobalAccount()
 	r.Reset(snapshot)
 	mset, err = acc.RestoreStream(&info.cfg, r)
@@ -4213,10 +4014,9 @@ func TestJetStreamSnapshotsAPI(t *testing.T) {
 	opts := DefaultTestOptions
 	opts.ServerName = "S"
 	opts.Port = -1
-	tdir := createDir(t, "jstests-storedir-")
 	opts.JetStream = true
 	opts.JetStreamDomain = "domain"
-	opts.StoreDir = tdir
+	opts.StoreDir = t.TempDir()
 	maxStore := int64(1024 * 1024 * 1024)
 	opts.maxStoreSet = true
 	opts.JetStreamMaxStore = maxStore
@@ -4227,10 +4027,6 @@ func TestJetStreamSnapshotsAPI(t *testing.T) {
 	defer s.Shutdown()
 
 	checkLeafNodeConnected(t, s)
-
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
 
 	mname := "MY-STREAM"
 	subjects := []string{"foo", "bar", "baz"}
@@ -4580,10 +4376,7 @@ func TestJetStreamPubAckPerf(t *testing.T) {
 	// Comment out to run, holding place for now.
 	t.SkipNow()
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -4608,10 +4401,7 @@ func TestJetStreamPubPerfWithFullStream(t *testing.T) {
 	// Comment out to run, holding place for now.
 	t.SkipNow()
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -4646,10 +4436,7 @@ func TestJetStreamSnapshotsAPIPerf(t *testing.T) {
 	// Comment out to run, holding place for now.
 	t.SkipNow()
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	cfg := StreamConfig{
@@ -4726,12 +4513,8 @@ func TestJetStreamActiveDelivery(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil && config.StoreDir != "" {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -4785,12 +4568,8 @@ func TestJetStreamEphemeralConsumers(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -4863,12 +4642,8 @@ func TestJetStreamConsumerReconnect(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -4974,12 +4749,8 @@ func TestJetStreamDurableConsumerReconnect(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -5086,12 +4857,8 @@ func TestJetStreamDurableConsumerReconnectWithOnlyPending(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -5187,12 +4954,8 @@ func TestJetStreamDurableFilteredSubjectConsumerReconnect(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -5336,12 +5099,8 @@ func TestJetStreamConsumerInactiveNoDeadlock(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -5396,12 +5155,8 @@ func TestJetStreamMetadata(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -5503,12 +5258,8 @@ func TestJetStreamRedeliverCount(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -5566,10 +5317,7 @@ func TestJetStreamRedeliverCount(t *testing.T) {
 // late with no interest the redelivery attempt is removed and we do
 // not get the message back.
 func TestJetStreamRedeliverAndLateAck(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	mset, err := s.GlobalAccount().addStream(&StreamConfig{Name: "LA", Storage: MemoryStorage})
@@ -5608,10 +5356,7 @@ func TestJetStreamRedeliverAndLateAck(t *testing.T) {
 
 // https://github.com/nats-io/nats-server/issues/1502
 func TestJetStreamPendingNextTimer(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	mset, err := s.GlobalAccount().addStream(&StreamConfig{Name: "NT", Storage: MemoryStorage, Subjects: []string{"ORDERS.*"}})
@@ -5664,12 +5409,8 @@ func TestJetStreamCanNotNakAckd(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -5742,12 +5483,8 @@ func TestJetStreamStreamPurge(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -5804,12 +5541,8 @@ func TestJetStreamStreamPurgeWithConsumer(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -5899,12 +5632,8 @@ func TestJetStreamStreamPurgeWithConsumerAndRedelivery(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -5987,12 +5716,8 @@ func TestJetStreamInterestRetentionStream(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -6135,12 +5860,8 @@ func TestJetStreamInterestRetentionStreamWithFilteredConsumers(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -6225,12 +5946,8 @@ func TestJetStreamInterestRetentionWithWildcardsAndFilteredConsumers(t *testing.
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -6281,12 +5998,8 @@ func TestJetStreamInterestRetentionStreamWithDurableRestart(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -6431,12 +6144,8 @@ func TestJetStreamConsumerReplayRate(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -6552,12 +6261,8 @@ func TestJetStreamConsumerReplayRateNoAck(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -6614,12 +6319,8 @@ func TestJetStreamConsumerReplayQuit(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -6666,9 +6367,6 @@ func TestJetStreamConsumerReplayQuit(t *testing.T) {
 
 func TestJetStreamSystemLimits(t *testing.T) {
 	s := RunRandClientPortServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
 	defer s.Shutdown()
 
 	if _, _, err := s.JetStreamReservedResources(); err == nil {
@@ -6679,7 +6377,7 @@ func TestJetStreamSystemLimits(t *testing.T) {
 	bacc, _ := s.LookupOrRegisterAccount("BAR")
 	zacc, _ := s.LookupOrRegisterAccount("BAZ")
 
-	jsconfig := &JetStreamConfig{MaxMemory: 1024, MaxStore: 8192}
+	jsconfig := &JetStreamConfig{MaxMemory: 1024, MaxStore: 8192, StoreDir: t.TempDir()}
 	if err := s.EnableJetStream(jsconfig); err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -7032,10 +6730,7 @@ func TestJetStreamSystemLimitsPlacement(t *testing.T) {
 }
 
 func TestJetStreamStreamLimitUpdate(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	err := s.GlobalAccount().UpdateJetStreamLimits(map[string]JetStreamAccountLimits{
@@ -7072,10 +6767,7 @@ func TestJetStreamStreamLimitUpdate(t *testing.T) {
 }
 
 func TestJetStreamStreamStorageTrackingAndLimits(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	gacc := s.GlobalAccount()
@@ -7208,10 +6900,7 @@ func TestJetStreamStreamStorageTrackingAndLimits(t *testing.T) {
 }
 
 func TestJetStreamStreamFileTrackingAndLimits(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	gacc := s.GlobalAccount()
@@ -7330,10 +7019,7 @@ func TestJetStreamStreamFileTrackingAndLimits(t *testing.T) {
 }
 
 func TestJetStreamTieredLimits(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	gacc := s.GlobalAccount()
@@ -7385,10 +7071,7 @@ type info struct {
 func TestJetStreamSimpleFileRecovery(t *testing.T) {
 	base := runtime.NumGoroutine()
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	acc := s.GlobalAccount()
@@ -7501,10 +7184,7 @@ func TestJetStreamSimpleFileRecovery(t *testing.T) {
 }
 
 func TestJetStreamPushConsumerFlowControl(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -7604,10 +7284,7 @@ func TestJetStreamPushConsumerFlowControl(t *testing.T) {
 }
 
 func TestJetStreamFlowControlRequiresHeartbeats(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -7627,10 +7304,7 @@ func TestJetStreamFlowControlRequiresHeartbeats(t *testing.T) {
 }
 
 func TestJetStreamPushConsumerIdleHeartbeats(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -7700,10 +7374,7 @@ func TestJetStreamPushConsumerIdleHeartbeats(t *testing.T) {
 }
 
 func TestJetStreamPushConsumerIdleHeartbeatsWithFilterSubject(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -7762,10 +7433,7 @@ func TestJetStreamPushConsumerIdleHeartbeatsWithFilterSubject(t *testing.T) {
 }
 
 func TestJetStreamPushConsumerIdleHeartbeatsWithNoInterest(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -7824,10 +7492,7 @@ func TestJetStreamPushConsumerIdleHeartbeatsWithNoInterest(t *testing.T) {
 }
 
 func TestJetStreamInfoAPIWithHeaders(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -7854,10 +7519,7 @@ func TestJetStreamInfoAPIWithHeaders(t *testing.T) {
 }
 
 func TestJetStreamRequestAPI(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -8373,10 +8035,7 @@ func TestJetStreamRequestAPI(t *testing.T) {
 }
 
 func TestJetStreamFilteredStreamNames(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -8447,12 +8106,8 @@ func TestJetStreamUpdateStream(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil && config.StoreDir != "" {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -8672,12 +8327,8 @@ func TestJetStreamDeleteMsg(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil && config.StoreDir != "" {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -8838,10 +8489,7 @@ func TestJetStreamLimitLockBug(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 
-			s := RunBasicJetStreamServer()
-			if config := s.JetStreamConfig(); config != nil && config.StoreDir != "" {
-				defer removeDir(t, config.StoreDir)
-			}
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
@@ -8889,10 +8537,7 @@ func TestJetStreamNextMsgNoInterest(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
 
 			cfg := &StreamConfig{Name: "foo", Storage: FileStorage}
@@ -8976,12 +8621,8 @@ func TestJetStreamMsgHeaders(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -9056,10 +8697,7 @@ func TestJetStreamMsgHeaders(t *testing.T) {
 }
 
 func TestJetStreamTemplateBasics(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	acc := s.GlobalAccount()
@@ -9127,10 +8765,7 @@ func TestJetStreamTemplateBasics(t *testing.T) {
 }
 
 func TestJetStreamTemplateFileStoreRecovery(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	acc := s.GlobalAccount()
@@ -9326,10 +8961,7 @@ func clientConnectToServerWithUP(t *testing.T, opts *Options, user, pass string)
 }
 
 func TestJetStreamCanNotEnableOnSystemAccount(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	sa := s.SystemAccount()
@@ -9356,7 +8988,6 @@ func TestJetStreamMultipleAccountsBasics(t *testing.T) {
 			},
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	if config := s.JetStreamConfig(); config != nil {
@@ -9514,7 +9145,6 @@ func TestJetStreamServerResourcesConfig(t *testing.T) {
 		listen: 127.0.0.1:-1
 		jetstream: {max_mem_store: 2GB, max_file_store: 1TB}
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -9542,11 +9172,8 @@ func TestJetStreamServerResourcesConfig(t *testing.T) {
 // created that way and therefore 2.2.3 would start and not recognize the existing accounts,
 // streams and consumers.
 func TestJetStreamStoreDirectoryFix(t *testing.T) {
-	sd := filepath.Join(os.TempDir(), "sd_test")
-	defer removeDir(t, sd)
-
+	sd := t.TempDir()
 	conf := createConfFile(t, []byte(fmt.Sprintf("listen: 127.0.0.1:-1\njetstream: {store_dir: %q}\n", sd)))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -9604,10 +9231,7 @@ func TestJetStreamStoreDirectoryFix(t *testing.T) {
 }
 
 func TestJetStreamPushConsumersPullError(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -9641,10 +9265,7 @@ func TestJetStreamPushConsumersPullError(t *testing.T) {
 }
 
 func TestJetStreamPullConsumerMaxWaitingOfOne(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -9693,10 +9314,7 @@ func TestJetStreamPullConsumerMaxWaitingOfOne(t *testing.T) {
 }
 
 func TestJetStreamPullConsumerMaxWaiting(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -9732,10 +9350,7 @@ func TestJetStreamPubPerf(t *testing.T) {
 	// Comment out to run, holding place for now.
 	t.SkipNow()
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	acc := s.GlobalAccount()
@@ -9797,10 +9412,7 @@ func TestJetStreamPubWithAsyncResponsePerf(t *testing.T) {
 	// Comment out to run, holding place for now.
 	t.SkipNow()
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	acc := s.GlobalAccount()
@@ -9836,10 +9448,7 @@ func TestJetStreamPubWithSyncPerf(t *testing.T) {
 	// Comment out to run, holding place for now.
 	t.SkipNow()
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -9867,10 +9476,7 @@ func TestJetStreamConsumerPerf(t *testing.T) {
 	// Comment out to run, holding place for now.
 	t.SkipNow()
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	acc := s.GlobalAccount()
@@ -9928,10 +9534,7 @@ func TestJetStreamConsumerAckFileStorePerf(t *testing.T) {
 	// Comment out to run, holding place for now.
 	t.SkipNow()
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	acc := s.GlobalAccount()
@@ -9998,10 +9601,7 @@ func TestJetStreamPubSubPerf(t *testing.T) {
 	// Comment out to run, holding place for now.
 	t.SkipNow()
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	acc := s.GlobalAccount()
@@ -10076,12 +9676,8 @@ func TestJetStreamAckExplicitMsgRemoval(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -10220,7 +9816,7 @@ func TestJetStreamAckExplicitMsgRemoval(t *testing.T) {
 // should the stream later be edited to expand into more subjects the consumer
 // still gets what was actually requested
 func TestJetStreamConsumerFilterSubject(t *testing.T) {
-	s := RunBasicJetStreamServer()
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	sc := &StreamConfig{Name: "MY_STREAM", Subjects: []string{"foo"}}
@@ -10270,10 +9866,7 @@ func TestJetStreamStoredMsgsDontDisappearAfterCacheExpiration(t *testing.T) {
 		Retention: InterestPolicy,
 	}
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	mset, err := s.GlobalAccount().addStreamWithStore(sc, &FileStoreConfig{BlockSize: 128, CacheExpire: 15 * time.Millisecond})
@@ -10366,12 +9959,8 @@ func TestJetStreamConsumerUpdateRedelivery(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -10538,12 +10127,8 @@ func TestJetStreamConsumerMaxAckPending(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -10666,12 +10251,8 @@ func TestJetStreamPullConsumerMaxAckPending(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -10763,12 +10344,8 @@ func TestJetStreamPullConsumerMaxAckPendingRedeliveries(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -10973,7 +10550,6 @@ func TestJetStreamAccountImportBasics(t *testing.T) {
 			},
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	if config := s.JetStreamConfig(); config != nil {
@@ -11101,7 +10677,6 @@ func TestJetStreamAccountImportAll(t *testing.T) {
 			},
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	if config := s.JetStreamConfig(); config != nil {
@@ -11170,7 +10745,6 @@ func TestJetStreamServerReload(t *testing.T) {
 		no_auth_user: ub
 		system_account: SYS
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	if config := s.JetStreamConfig(); config != nil {
@@ -11245,7 +10819,6 @@ func TestJetStreamConfigReloadWithGlobalAccount(t *testing.T) {
 		jetstream: enabled
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, "pwd")))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	if config := s.JetStreamConfig(); config != nil {
@@ -11325,12 +10898,8 @@ func TestJetStreamMaxMsgsPerSubject(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			if err != nil {
@@ -11607,10 +11176,7 @@ func TestJetStreamLastSequenceBySubject(t *testing.T) {
 }
 
 func TestJetStreamFilteredConsumersWithWiderFilter(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -11662,10 +11228,7 @@ func TestJetStreamFilteredConsumersWithWiderFilter(t *testing.T) {
 }
 
 func TestJetStreamMirrorAndSourcesFilteredConsumers(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -11757,10 +11320,7 @@ func TestJetStreamMirrorAndSourcesFilteredConsumers(t *testing.T) {
 }
 
 func TestJetStreamMirrorBasics(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -11916,10 +11476,7 @@ func TestJetStreamMirrorBasics(t *testing.T) {
 }
 
 func TestJetStreamMirrorUpdatePreventsSubjects(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -11939,10 +11496,7 @@ func TestJetStreamMirrorUpdatePreventsSubjects(t *testing.T) {
 }
 
 func TestJetStreamSourceBasics(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -12162,7 +11716,6 @@ func TestJetStreamServerDomainConfig(t *testing.T) {
 		listen: 127.0.0.1:-1
 		jetstream: {domain: "HUB"}
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -12185,7 +11738,6 @@ func TestJetStreamServerDomainConfigButDisabled(t *testing.T) {
 		listen: 127.0.0.1:-1
 		jetstream: {domain: "HUB", enabled: false}
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -12205,7 +11757,6 @@ func TestJetStreamDomainInPubAck(t *testing.T) {
 		listen: 127.0.0.1:-1
 		jetstream: {domain: "HUB"}
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	config := s.JetStreamConfig()
@@ -12240,10 +11791,7 @@ func TestJetStreamDomainInPubAck(t *testing.T) {
 
 // Issue #2213
 func TestJetStreamDirectConsumersBeingReported(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -12313,10 +11861,7 @@ func TestJetStreamDirectConsumersBeingReported(t *testing.T) {
 
 // https://github.com/nats-io/nats-server/issues/2290
 func TestJetStreamTemplatedErrorsBug(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -12355,11 +11900,9 @@ func TestJetStreamServerEncryption(t *testing.T) {
 				listen: 127.0.0.1:-1
 				jetstream: {key: $JS_KEY, store_dir: '%s' %s}
 			`
-			storeDir := createDir(t, JetStreamStoreDir)
-			defer removeDir(t, storeDir)
+			storeDir := t.TempDir()
 
 			conf := createConfFile(t, []byte(fmt.Sprintf(tmpl, storeDir, c.cstr)))
-			defer removeFile(t, conf)
 
 			os.Setenv("JS_KEY", "s3cr3t!!")
 			defer os.Unsetenv("JS_KEY")
@@ -12371,7 +11914,6 @@ func TestJetStreamServerEncryption(t *testing.T) {
 			if config == nil {
 				t.Fatalf("Expected config but got none")
 			}
-			defer removeDir(t, config.StoreDir)
 
 			// Client based API
 			nc, js := jsClientConnect(t, s)
@@ -12516,7 +12058,7 @@ func TestJetStreamServerEncryption(t *testing.T) {
 			}
 
 			// Run new server w/o encryption. Make sure we can restore properly (meaning encryption was stripped etc).
-			ns := RunBasicJetStreamServer()
+			ns := RunBasicJetStreamServer(t)
 			defer ns.Shutdown()
 
 			nacc := ns.GlobalAccount()
@@ -12554,10 +12096,7 @@ func TestJetStreamServerEncryption(t *testing.T) {
 
 // User report of bug.
 func TestJetStreamConsumerBadNumPending(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -12637,10 +12176,7 @@ func TestJetStreamConsumerBadNumPending(t *testing.T) {
 func TestJetStreamDeliverLastPerSubject(t *testing.T) {
 	for _, st := range []StorageType{FileStorage, MemoryStorage} {
 		t.Run(st.String(), func(t *testing.T) {
-			s := RunBasicJetStreamServer()
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
 
 			// Client for API requests.
@@ -12776,10 +12312,7 @@ func TestJetStreamDeliverLastPerSubject(t *testing.T) {
 }
 
 func TestJetStreamDeliverLastPerSubjectNumPending(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -12824,10 +12357,7 @@ func TestJetStreamDeliverLastPerSubjectNumPending(t *testing.T) {
 // We had a report of a consumer delete crashing the server when in interest retention mode.
 // This I believe is only really possible in clustered mode, but we will force the issue here.
 func TestJetStreamConsumerCleanupWithRetentionPolicy(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -12893,10 +12423,7 @@ func TestJetStreamConsumerCleanupWithRetentionPolicy(t *testing.T) {
 
 // Issue #2392
 func TestJetStreamPurgeEffectsConsumerDelivery(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -12944,10 +12471,7 @@ func TestJetStreamPurgeEffectsConsumerDelivery(t *testing.T) {
 
 // Issue #2403
 func TestJetStreamExpireCausesDeadlock(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -13012,10 +12536,7 @@ func TestJetStreamConsumerPendingBugWithKV(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 
-			s := RunBasicJetStreamServer()
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
 
 			// Client based API
@@ -13059,10 +12580,7 @@ func TestJetStreamConsumerPendingBugWithKV(t *testing.T) {
 
 // Issue #2420
 func TestJetStreamDefaultMaxMsgsPer(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -13085,10 +12603,7 @@ func TestJetStreamDefaultMaxMsgsPer(t *testing.T) {
 
 // Issue #2423
 func TestJetStreamBadConsumerCreateErr(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -13120,11 +12635,7 @@ func TestJetStreamBadConsumerCreateErr(t *testing.T) {
 }
 
 func TestJetStreamConsumerPushBound(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -13227,11 +12738,7 @@ func TestJetStreamConsumerPushBound(t *testing.T) {
 
 // Got a report of memory leaking, tracked it to internal clients for consumers.
 func TestJetStreamConsumerInternalClientLeak(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -13288,11 +12795,7 @@ func TestJetStreamConsumerInternalClientLeak(t *testing.T) {
 }
 
 func TestJetStreamConsumerEventingRaceOnShutdown(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s, nats.NoReconnect())
@@ -13328,11 +12831,7 @@ func TestJetStreamConsumerEventingRaceOnShutdown(t *testing.T) {
 // Got a report of streams that expire all messages while the server is down report errors when clients reconnect
 // and try to send new messages.
 func TestJetStreamExpireAllWhileServerDown(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -13383,11 +12882,7 @@ func TestJetStreamExpireAllWhileServerDown(t *testing.T) {
 }
 
 func TestJetStreamLongStreamNamesAndPubAck(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -13407,11 +12902,7 @@ func TestJetStreamPerSubjectPending(t *testing.T) {
 	for _, st := range []nats.StorageType{nats.FileStorage, nats.MemoryStorage} {
 		t.Run(st.String(), func(t *testing.T) {
 
-			s := RunBasicJetStreamServer()
-			config := s.JetStreamConfig()
-			if config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
 
 			nc, js := jsClientConnect(t, s)
@@ -13464,11 +12955,7 @@ func TestJetStreamPerSubjectPending(t *testing.T) {
 }
 
 func TestJetStreamPublishExpectNoMsg(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -13512,11 +12999,7 @@ func TestJetStreamPublishExpectNoMsg(t *testing.T) {
 }
 
 func TestJetStreamPullLargeBatchExpired(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -13558,11 +13041,7 @@ func TestJetStreamPullLargeBatchExpired(t *testing.T) {
 }
 
 func TestJetStreamNegativeDupeWindow(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -13591,11 +13070,7 @@ func TestJetStreamNegativeDupeWindow(t *testing.T) {
 
 // Issue #2551
 func TestJetStreamMirroredConsumerFailAfterRestart(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -13678,10 +13153,8 @@ func TestJetStreamDisabledLimitsEnforcementJWT(t *testing.T) {
 	claim.Limits.JetStreamLimits = limits1
 	aJwt1, err := claim.Encode(oKp)
 	require_NoError(t, err)
-	dir := createDir(t, "srv")
-	defer removeDir(t, dir)
-	storeDir1 := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir1)
+	dir := t.TempDir()
+	storeDir1 := t.TempDir()
 	conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: -1
 		jetstream: {store_dir: '%s'}
@@ -13692,7 +13165,6 @@ func TestJetStreamDisabledLimitsEnforcementJWT(t *testing.T) {
 		}
 		system_account: %s
     `, storeDir1, ojwt, dir, sysPub)))
-	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 	updateJwt(s.ClientURL(), sysKp, aPub, aJwt1)
@@ -13710,7 +13182,7 @@ func TestJetStreamDisabledLimitsEnforcementJWT(t *testing.T) {
 }
 
 func TestJetStreamDisabledLimitsEnforcement(t *testing.T) {
-	storeDir1 := createDir(t, JetStreamStoreDir)
+	storeDir1 := t.TempDir()
 	conf1 := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		jetstream: {max_mem_store: 256MB, max_file_store: 2GB, store_dir: '%s'}
@@ -13744,11 +13216,7 @@ func TestJetStreamDisabledLimitsEnforcement(t *testing.T) {
 }
 
 func TestJetStreamConsumerNoMsgPayload(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -13790,11 +13258,7 @@ func TestJetStreamConsumerNoMsgPayload(t *testing.T) {
 
 // Issue #2607
 func TestJetStreamPurgeAndFilteredConsumers(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -13859,11 +13323,7 @@ func TestJetStreamPurgeAndFilteredConsumers(t *testing.T) {
 
 // Issue #2662
 func TestJetStreamLargeExpiresAndServerRestart(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -13912,11 +13372,7 @@ func TestJetStreamLargeExpiresAndServerRestart(t *testing.T) {
 // Bug that was reported showing memstore not handling max per subject of 1.
 func TestJetStreamMessagePerSubjectKeepBug(t *testing.T) {
 	test := func(t *testing.T, keep int64, store nats.StorageType) {
-		s := RunBasicJetStreamServer()
-		config := s.JetStreamConfig()
-		if config != nil {
-			defer removeDir(t, config.StoreDir)
-		}
+		s := RunBasicJetStreamServer(t)
 		defer s.Shutdown()
 
 		nc, js := jsClientConnect(t, s)
@@ -13954,11 +13410,7 @@ func TestJetStreamMessagePerSubjectKeepBug(t *testing.T) {
 }
 
 func TestJetStreamInvalidDeliverSubject(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -13974,7 +13426,7 @@ func TestJetStreamInvalidDeliverSubject(t *testing.T) {
 }
 
 func TestJetStreamMemoryCorruption(t *testing.T) {
-	s := RunBasicJetStreamServer()
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -14038,11 +13490,8 @@ func TestJetStreamMemoryCorruption(t *testing.T) {
 }
 
 func TestJetStreamRecoverBadStreamSubjects(t *testing.T) {
-	s := RunBasicJetStreamServer()
+	s := RunBasicJetStreamServer(t)
 	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
 	sd := config.StoreDir
 	s.Shutdown()
 
@@ -14070,11 +13519,8 @@ func TestJetStreamRecoverBadStreamSubjects(t *testing.T) {
 }
 
 func TestJetStreamRecoverBadMirrorConfigWithSubjects(t *testing.T) {
-	s := RunBasicJetStreamServer()
+	s := RunBasicJetStreamServer(t)
 	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
 	defer s.Shutdown()
 	sd := config.StoreDir
 
@@ -14135,7 +13581,6 @@ func TestJetStreamCrossAccountsDeliverSubjectInterest(t *testing.T) {
 			},
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	if config := s.JetStreamConfig(); config != nil {
@@ -14196,10 +13641,7 @@ func TestJetStreamCrossAccountsDeliverSubjectInterest(t *testing.T) {
 }
 
 func TestJetStreamPullConsumerRequestCleanup(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -14237,10 +13679,7 @@ func TestJetStreamPullConsumerRequestCleanup(t *testing.T) {
 }
 
 func TestJetStreamPullConsumerRequestMaximums(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, _ := jsClientConnect(t, s)
@@ -14292,10 +13731,7 @@ func TestJetStreamPullConsumerRequestMaximums(t *testing.T) {
 }
 
 func TestJetStreamEphemeralPullConsumers(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -14360,10 +13796,7 @@ func TestJetStreamEphemeralPullConsumers(t *testing.T) {
 }
 
 func TestJetStreamEphemeralPullConsumersInactiveThresholdAndNoWait(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -14416,7 +13849,6 @@ func TestJetStreamPullConsumerCrossAccountExpires(t *testing.T) {
 			},
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	if config := s.JetStreamConfig(); config != nil {
@@ -14617,7 +14049,6 @@ func TestJetStreamPullConsumerCrossAccountExpiresNoDataRace(t *testing.T) {
 			},
 		}
 	`))
-	defer removeFile(t, conf)
 
 	test := func() {
 		s, _ := RunServerWithConfig(conf)
@@ -14693,7 +14124,6 @@ func TestJetStreamPullConsumerCrossAccountsAndLeafNodes(t *testing.T) {
 		}
 		leaf { listen: "127.0.0.1:-1" }
 	`))
-	defer removeFile(t, conf)
 
 	s, o := RunServerWithConfig(conf)
 	if config := s.JetStreamConfig(); config != nil {
@@ -14717,7 +14147,6 @@ func TestJetStreamPullConsumerCrossAccountsAndLeafNodes(t *testing.T) {
 		# bind local A to IU account on other side of LN.
 		leaf { remotes [ { url: nats://mh:bar@127.0.0.1:%d; account: A } ] }
 	`, o.LeafNode.Port)))
-	defer removeFile(t, conf2)
 
 	s2, _ := RunServerWithConfig(conf2)
 	defer s2.Shutdown()
@@ -14793,10 +14222,7 @@ func TestJetStreamPullConsumerCrossAccountsAndLeafNodes(t *testing.T) {
 //     They expect to wait up to a given time for any messages but will return once they have any to deliver, so parital fills.
 //  4. Try, which never waits at all ever.
 func TestJetStreamPullConsumersOneShotBehavior(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -14904,10 +14330,7 @@ func TestJetStreamPullConsumersOneShotBehavior(t *testing.T) {
 }
 
 func TestJetStreamPullConsumersMultipleRequestsExpireOutOfOrder(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -14962,10 +14385,7 @@ func TestJetStreamPullConsumersMultipleRequestsExpireOutOfOrder(t *testing.T) {
 }
 
 func TestJetStreamConsumerUpdateSurvival(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -15013,10 +14433,7 @@ func TestJetStreamConsumerUpdateSurvival(t *testing.T) {
 }
 
 func TestJetStreamNakRedeliveryWithNoWait(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -15105,12 +14522,8 @@ func TestJetStreamMaxMsgsPerSubjectWithDiscardNew(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			s := RunBasicJetStreamServer()
+			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()
-
-			if config := s.JetStreamConfig(); config != nil {
-				defer removeDir(t, config.StoreDir)
-			}
 
 			mset, err := s.GlobalAccount().addStream(c.mconfig)
 			require_NoError(t, err)
@@ -15160,10 +14573,7 @@ func TestJetStreamMaxMsgsPerSubjectWithDiscardNew(t *testing.T) {
 }
 
 func TestJetStreamStreamInfoSubjectsDetails(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -15223,10 +14633,7 @@ func TestJetStreamStreamInfoSubjectsDetails(t *testing.T) {
 }
 
 func TestJetStreamStreamInfoSubjectsDetailsWithDeleteAndPurge(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -15312,10 +14719,7 @@ func TestJetStreamStreamInfoSubjectsDetailsWithDeleteAndPurge(t *testing.T) {
 }
 
 func TestJetStreamStreamInfoSubjectsDetailsAfterRestart(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -15372,10 +14776,7 @@ func TestJetStreamStreamInfoSubjectsDetailsAfterRestart(t *testing.T) {
 
 // Issue #2836
 func TestJetStreamInterestRetentionBug(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -15420,10 +14821,7 @@ func TestJetStreamInterestRetentionBug(t *testing.T) {
 // pending, but when we sent the next message and got blocked, if that msg would
 // exceed the outstanding FC we would become stalled.
 func TestJetStreamFlowControlStall(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -15449,10 +14847,7 @@ func TestJetStreamFlowControlStall(t *testing.T) {
 }
 
 func TestJetStreamConsumerPendingCountWithRedeliveries(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -15515,10 +14910,7 @@ func TestJetStreamConsumerPendingCountWithRedeliveries(t *testing.T) {
 }
 
 func TestJetStreamPullConsumerHeartBeats(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -15645,14 +15037,9 @@ func TestJetStreamStorageReservedBytes(t *testing.T) {
 	opts.JetStream = true
 	opts.JetStreamMaxMemory = systemLimit
 	opts.JetStreamMaxStore = systemLimit
-	tdir, _ := os.MkdirTemp(tempRoot, "jstests-storedir-")
-	opts.StoreDir = tdir
+	opts.StoreDir = t.TempDir()
 	opts.HTTPPort = -1
 	s := RunServer(&opts)
-
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -15852,10 +15239,7 @@ func TestJetStreamStorageReservedBytes(t *testing.T) {
 }
 
 func TestJetStreamRecoverStreamWithDeletedMessagesNonCleanShutdown(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -15896,10 +15280,7 @@ func TestJetStreamRecoverStreamWithDeletedMessagesNonCleanShutdown(t *testing.T)
 }
 
 func TestJetStreamRestoreBadStream(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, _ := jsClientConnect(t, s)
@@ -15956,10 +15337,7 @@ func TestJetStreamRestoreBadStream(t *testing.T) {
 }
 
 func TestJetStreamConsumerAckSampling(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -16041,10 +15419,7 @@ func TestJetStreamConsumerAckSampling(t *testing.T) {
 }
 
 func TestJetStreamConsumerAckSamplingSpecifiedUsingUpdateConsumer(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -16095,10 +15470,7 @@ func TestJetStreamConsumerAckSamplingSpecifiedUsingUpdateConsumer(t *testing.T) 
 }
 
 func TestJetStreamConsumerMaxDeliverUpdate(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -16163,25 +15535,21 @@ func TestJetStreamRemoveExternalSource(t *testing.T) {
 	lu, err := url.Parse(fmt.Sprintf("nats://127.0.0.1:%d", ho.LeafNode.Port))
 	require_NoError(t, err)
 
-	tdir, _ := os.MkdirTemp(tempRoot, "jstests-storedir-")
-	defer removeDir(t, tdir)
 	lo1 := DefaultTestOptions
 	lo1.Port = 4111 //-1
 	lo1.ServerName = "a-leaf"
 	lo1.JetStream = true
-	lo1.StoreDir = tdir
+	lo1.StoreDir = t.TempDir()
 	lo1.JetStreamDomain = "a-leaf"
 	lo1.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{lu}}}
 	l1 := RunServer(&lo1)
 	defer l1.Shutdown()
 
-	tdir, _ = os.MkdirTemp(tempRoot, "jstests-storedir-")
-	defer removeDir(t, tdir)
 	lo2 := DefaultTestOptions
 	lo2.Port = 2111 //-1
 	lo2.ServerName = "b-leaf"
 	lo2.JetStream = true
-	lo2.StoreDir = tdir
+	lo2.StoreDir = t.TempDir()
 	lo2.JetStreamDomain = "b-leaf"
 	lo2.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{lu}}}
 	l2 := RunServer(&lo2)
@@ -16340,10 +15708,7 @@ func TestJetStreamRemoveExternalSource(t *testing.T) {
 }
 
 func TestJetStreamAddStreamWithFilestoreFailure(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Cause failure to create stream with filestore.
@@ -16370,10 +15735,7 @@ func (s *checkFastState) FastState(state *StreamState) {
 }
 
 func TestJetStreamBackOffCheckPending(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	mset, err := s.GlobalAccount().addStream(&StreamConfig{Name: "TEST", Subjects: []string{"foo"}})
@@ -16456,7 +15818,6 @@ func TestJetStreamCrossAccounts(t *testing.T) {
                ]
            }
 		}`))
-	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	if config := s.JetStreamConfig(); config != nil {
 		defer removeDir(t, config.StoreDir)
@@ -16680,13 +16041,11 @@ func TestJetStreamInvalidRestoreRequests(t *testing.T) {
 		test(t, s, 3)
 	})
 	t.Run("single", func(t *testing.T) {
-		storeDir := createDir(t, JetStreamStoreDir)
-		defer removeDir(t, storeDir)
+		storeDir := t.TempDir()
 		conf := createConfFile(t, []byte(fmt.Sprintf(`
 			listen: 127.0.0.1:-1
 			jetstream: {max_mem_store: 2MB, max_file_store: 8MB, store_dir: '%s'}
 			%s`, storeDir, commonAccSection)))
-		defer removeFile(t, conf)
 		s, _ := RunServerWithConfig(conf)
 		defer s.Shutdown()
 		test(t, s, 1)
@@ -16796,10 +16155,8 @@ func TestJetStreamLimits(t *testing.T) {
 				$SYS { users = [ { user: "admin", pass: "s3cr3t!" } ] }
 			}`
 		limitsTest := func(t *testing.T, tmpl string) {
-			storeDir := createDir(t, JetStreamStoreDir)
-			defer removeDir(t, storeDir)
+			storeDir := t.TempDir()
 			conf := createConfFile(t, []byte(fmt.Sprintf(tmpl, storeDir)))
-			defer removeFile(t, conf)
 			s, opts := RunServerWithConfig(conf)
 			defer s.Shutdown()
 			require_True(t, opts.JetStreamLimits.Duplicates == time.Minute)
@@ -16863,13 +16220,11 @@ func TestJetStreamConsumerStreamUpdate(t *testing.T) {
 		})
 	})
 	t.Run("single", func(t *testing.T) {
-		storeDir := createDir(t, JetStreamStoreDir)
-		defer removeDir(t, storeDir)
+		storeDir := t.TempDir()
 		conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		jetstream: {max_mem_store: 2MB, max_file_store: 8MB, store_dir: '%s'}`,
 			storeDir)))
-		defer removeFile(t, conf)
 		s, _ := RunServerWithConfig(conf)
 		defer s.Shutdown()
 		test(t, s, 1)
@@ -16877,8 +16232,7 @@ func TestJetStreamConsumerStreamUpdate(t *testing.T) {
 }
 
 func TestJetStreamImportReload(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
@@ -16894,7 +16248,6 @@ func TestJetStreamImportReload(t *testing.T) {
 				imports: [{stream: {subject: news.>, account: account_a}}]
 			}
 		}`, storeDir)))
-	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -16940,10 +16293,7 @@ func TestJetStreamImportReload(t *testing.T) {
 }
 
 func TestJetStreamRecoverSealedAfterServerRestart(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -17005,7 +16355,6 @@ func TestJetStreamImportConsumerStreamSubjectRemapSingle(t *testing.T) {
 			},
 		}
 	`))
-	defer removeFile(t, conf)
 
 	test := func(t *testing.T, queue bool) {
 		s, _ := RunServerWithConfig(conf)
@@ -17090,10 +16439,7 @@ func TestJetStreamImportConsumerStreamSubjectRemapSingle(t *testing.T) {
 }
 
 func TestJetStreamWorkQueueSourceRestart(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -17192,10 +16538,7 @@ func TestJetStreamWorkQueueSourceRestart(t *testing.T) {
 }
 
 func TestJetStreamWorkQueueSourceNamingRestart(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -17312,10 +16655,7 @@ func TestJetStreamDisabledHealthz(t *testing.T) {
 }
 
 func TestJetStreamPullMaxBytes(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -17419,10 +16759,7 @@ func TestJetStreamPullMaxBytes(t *testing.T) {
 }
 
 func TestJetStreamStreamRepublishCycle(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, _ := jsClientConnect(t, s)
@@ -17475,10 +16812,7 @@ func TestJetStreamStreamRepublishCycle(t *testing.T) {
 }
 
 func TestJetStreamStreamRepublishOneTokenMatch(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -17520,10 +16854,7 @@ func TestJetStreamStreamRepublishOneTokenMatch(t *testing.T) {
 }
 
 func TestJetStreamStreamRepublishMultiTokenMatch(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -17565,10 +16896,7 @@ func TestJetStreamStreamRepublishMultiTokenMatch(t *testing.T) {
 }
 
 func TestJetStreamStreamRepublishAnySubjectMatch(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -17609,10 +16937,7 @@ func TestJetStreamStreamRepublishAnySubjectMatch(t *testing.T) {
 }
 
 func TestJetStreamStreamRepublishMultiTokenNoMatch(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -17649,10 +16974,7 @@ func TestJetStreamStreamRepublishMultiTokenNoMatch(t *testing.T) {
 }
 
 func TestJetStreamStreamRepublishOneTokenNoMatch(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -17689,10 +17011,7 @@ func TestJetStreamStreamRepublishOneTokenNoMatch(t *testing.T) {
 }
 
 func TestJetStreamStreamRepublishHeadersOnly(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -17736,10 +17055,7 @@ func TestJetStreamStreamRepublishHeadersOnly(t *testing.T) {
 }
 
 func TestJetStreamConsumerDeliverNewNotConsumingBeforeRestart(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -17808,10 +17124,7 @@ func TestJetStreamConsumerDeliverNewNotConsumingBeforeRestart(t *testing.T) {
 }
 
 func TestJetStreamConsumerNumPendingWithMaxPerSubjectGreaterThanOne(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -17862,10 +17175,7 @@ func TestJetStreamConsumerNumPendingWithMaxPerSubjectGreaterThanOne(t *testing.T
 }
 
 func TestJetStreamMsgGetNoAdvisory(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -17893,10 +17203,7 @@ func TestJetStreamMsgGetNoAdvisory(t *testing.T) {
 }
 
 func TestJetStreamDirectMsgGet(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, _ := jsClientConnect(t, s)
@@ -17988,10 +17295,7 @@ func TestJetStreamDirectMsgGet(t *testing.T) {
 // This allows support for a get next given a sequence as a starting.
 // This allows these to be chained together if needed for sparse streams.
 func TestJetStreamDirectMsgGetNext(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, _ := jsClientConnect(t, s)
@@ -18049,10 +17353,7 @@ func TestJetStreamDirectMsgGetNext(t *testing.T) {
 }
 
 func TestJetStreamConsumerInactiveThreshold(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -18122,10 +17423,7 @@ func TestJetStreamConsumerInactiveThreshold(t *testing.T) {
 }
 
 func TestJetStreamConsumerAndStreamNamesWithPathSeparators(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -18148,10 +17446,7 @@ func TestJetStreamConsumerAndStreamNamesWithPathSeparators(t *testing.T) {
 }
 
 func TestJetStreamConsumerUpdateFilterSubject(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -18217,10 +17512,7 @@ func TestJetStreamConsumerUpdateFilterSubject(t *testing.T) {
 // So after a message is delivered, the request, if still outstanding, effectively
 // goes to the end of the queue of requests pending.
 func TestJetStreamConsumerPullConsumerFIFO(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -18274,10 +17566,7 @@ func TestJetStreamConsumerPullConsumerFIFO(t *testing.T) {
 
 // Make sure that when we reach an ack limit that we follow one shot semantics.
 func TestJetStreamConsumerPullConsumerOneShotOnMaxAckLimit(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -18311,10 +17600,7 @@ func TestJetStreamConsumerPullConsumerOneShotOnMaxAckLimit(t *testing.T) {
 ///////////////////////////////////////////////////////////////////////////
 
 func Benchmark__JetStreamPubWithAck(b *testing.B) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(b)
 	defer s.Shutdown()
 
 	mset, err := s.GlobalAccount().addStream(&StreamConfig{Name: "foo"})
@@ -18342,10 +17628,7 @@ func Benchmark__JetStreamPubWithAck(b *testing.B) {
 }
 
 func Benchmark____JetStreamPubNoAck(b *testing.B) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(b)
 	defer s.Shutdown()
 
 	mset, err := s.GlobalAccount().addStream(&StreamConfig{Name: "foo"})
@@ -18376,10 +17659,7 @@ func Benchmark____JetStreamPubNoAck(b *testing.B) {
 }
 
 func Benchmark_JetStreamPubAsyncAck(b *testing.B) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(b)
 	defer s.Shutdown()
 
 	mset, err := s.GlobalAccount().addStream(&StreamConfig{Name: "foo"})
@@ -18432,10 +17712,7 @@ func Benchmark____JetStreamSubNoAck(b *testing.B) {
 		return
 	}
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(b)
 	defer s.Shutdown()
 
 	mname := "foo"
@@ -18493,10 +17770,7 @@ func benchJetStreamWorkersAndBatch(b *testing.B, numWorkers, batchSize int) {
 		return
 	}
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer os.RemoveAll(config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(b)
 	defer s.Shutdown()
 
 	mname := "MSET22"
@@ -18586,10 +17860,7 @@ func TestJetStreamKVMemoryStorePerf(t *testing.T) {
 	// Comment out to run, holding place for now.
 	t.SkipNow()
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -18624,10 +17895,7 @@ func TestJetStreamKVMemoryStoreDirectGetPerf(t *testing.T) {
 	// Comment out to run, holding place for now.
 	t.SkipNow()
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -18665,10 +17933,7 @@ func TestJetStreamKVMemoryStoreDirectGetPerf(t *testing.T) {
 func TestJetStreamMultiplePullPerf(t *testing.T) {
 	skip(t)
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -18745,10 +18010,7 @@ func TestJetStreamMultiplePullPerf(t *testing.T) {
 }
 
 func TestJetStreamMirrorUpdatesNotSupported(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -18788,7 +18050,6 @@ func TestJetStreamDirectGetBySubject(t *testing.T) {
 			},
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	if config := s.JetStreamConfig(); config != nil {
@@ -18873,10 +18134,7 @@ func TestJetStreamDirectGetBySubject(t *testing.T) {
 }
 
 func TestJetStreamProperErrorDueToOverlapSubjects(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
@@ -18919,12 +18177,10 @@ func TestJetStreamServerCipherConvert(t *testing.T) {
 		listen: 127.0.0.1:-1
 		jetstream: {key: s3cr3t, store_dir: '%s', cipher: %s}
 	`
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	// Create a stream and a consumer under one cipher, and restart the server with a new cipher.
 	conf := createConfFile(t, []byte(fmt.Sprintf(tmpl, storeDir, "AES")))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -18964,7 +18220,6 @@ func TestJetStreamServerCipherConvert(t *testing.T) {
 	s.Shutdown()
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(tmpl, storeDir, "ChaCha")))
-	defer removeFile(t, conf)
 
 	s, _ = RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -18996,10 +18251,7 @@ func TestJetStreamServerCipherConvert(t *testing.T) {
 }
 
 func TestJetStreamConsumerDeliverNewMaxRedeliveriesAndServerRestart(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -19055,10 +18307,7 @@ func TestJetStreamConsumerDeliverNewMaxRedeliveriesAndServerRestart(t *testing.T
 }
 
 func TestJetStreamConsumerPendingLowerThanStreamFirstSeq(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -19128,10 +18377,7 @@ func TestJetStreamConsumerPendingLowerThanStreamFirstSeq(t *testing.T) {
 }
 
 func TestJetStreamAllowDirectAfterUpdate(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -19170,10 +18416,7 @@ func TestJetStreamAllowDirectAfterUpdate(t *testing.T) {
 
 // Bug when stream's consumer config does not force filestore to track per subject information.
 func TestJetStreamConsumerEOFBugNewFileStore(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -19259,7 +18502,6 @@ func TestJetStreamSubjectBasedFilteredConsumers(t *testing.T) {
 			},
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	if config := s.JetStreamConfig(); config != nil {
@@ -19360,10 +18602,7 @@ func TestJetStreamSubjectBasedFilteredConsumers(t *testing.T) {
 }
 
 func TestJetStreamStreamSubjectsOverlap(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -19391,7 +18630,7 @@ func TestJetStreamStreamSubjectsOverlap(t *testing.T) {
 }
 
 func TestJetStreamSuppressAllowDirect(t *testing.T) {
-	s := RunBasicJetStreamServer()
+	s := RunBasicJetStreamServer(t)
 	if config := s.JetStreamConfig(); config != nil {
 		defer removeDir(t, config.StoreDir)
 	}
@@ -19425,7 +18664,7 @@ func TestJetStreamSuppressAllowDirect(t *testing.T) {
 }
 
 func TestJetStreamPullConsumerNoAck(t *testing.T) {
-	s := RunBasicJetStreamServer()
+	s := RunBasicJetStreamServer(t)
 	if config := s.JetStreamConfig(); config != nil {
 		defer removeDir(t, config.StoreDir)
 	}

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -41,8 +41,6 @@ var (
 	// This matches ./configs/nkeys/op.jwt
 	ojwt = "eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5In0.eyJhdWQiOiJURVNUUyIsImV4cCI6MTg1OTEyMTI3NSwianRpIjoiWE5MWjZYWVBIVE1ESlFSTlFPSFVPSlFHV0NVN01JNVc1SlhDWk5YQllVS0VRVzY3STI1USIsImlhdCI6MTU0Mzc2MTI3NSwiaXNzIjoiT0NBVDMzTVRWVTJWVU9JTUdOR1VOWEo2NkFIMlJMU0RBRjNNVUJDWUFZNVFNSUw2NU5RTTZYUUciLCJuYW1lIjoiU3luYWRpYSBDb21tdW5pY2F0aW9ucyBJbmMuIiwibmJmIjoxNTQzNzYxMjc1LCJzdWIiOiJPQ0FUMzNNVFZVMlZVT0lNR05HVU5YSjY2QUgyUkxTREFGM01VQkNZQVk1UU1JTDY1TlFNNlhRRyIsInR5cGUiOiJvcGVyYXRvciIsIm5hdHMiOnsic2lnbmluZ19rZXlzIjpbIk9EU0tSN01ZRlFaNU1NQUo2RlBNRUVUQ1RFM1JJSE9GTFRZUEpSTUFWVk40T0xWMllZQU1IQ0FDIiwiT0RTS0FDU1JCV1A1MzdEWkRSVko2NTdKT0lHT1BPUTZLRzdUNEhONk9LNEY2SUVDR1hEQUhOUDIiLCJPRFNLSTM2TFpCNDRPWTVJVkNSNlA1MkZaSlpZTVlXWlZXTlVEVExFWjVUSzJQTjNPRU1SVEFCUiJdfX0.hyfz6E39BMUh0GLzovFfk3wT4OfualftjdJ_eYkLfPvu5tZubYQ_Pn9oFYGCV_6yKy3KMGhWGUCyCdHaPhalBw"
 	oKp  nkeys.KeyPair
-
-	tempRoot = filepath.Join(os.TempDir(), "nats-server")
 )
 
 func init() {
@@ -1583,7 +1581,6 @@ func TestJWTAccountURLResolver(t *testing.T) {
 				}
 			`
 			conf := createConfFile(t, []byte(fmt.Sprintf(confTemplate, ojwt, ts.URL)))
-			defer removeFile(t, conf)
 
 			s, opts := RunServerWithConfig(conf)
 			pub, _ := kp.PublicKey()
@@ -1629,7 +1626,6 @@ func TestJWTAccountURLResolverTimeout(t *testing.T) {
 		resolver: URL("%s%s")
     `
 	conf := createConfFile(t, []byte(fmt.Sprintf(confTemplate, ts.URL, basePath)))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	pub, _ := kp.PublicKey()
@@ -1666,7 +1662,6 @@ func TestJWTAccountURLResolverNoFetchOnReload(t *testing.T) {
 		resolver: URL("%s/ngs/v1/accounts/jwt/")
     `
 	conf := createConfFile(t, []byte(fmt.Sprintf(confTemplate, ojwt, ts.URL)))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -1773,7 +1768,6 @@ func TestJWTAccountURLResolverFetchFailureInServer1(t *testing.T) {
 		operator: %s
 		resolver: URL("%s/A/")
     `, ojwt, ts.URL)))
-	defer removeFile(t, confA)
 	sA := RunServer(LoadConfig(confA))
 	defer sA.Shutdown()
 	// server observed one fetch on startup
@@ -1871,7 +1865,6 @@ func TestJWTAccountURLResolverFetchFailurePushReorder(t *testing.T) {
 		resolver: URL("%s/A/")
 		system_account: %s
     `, ojwt, ts.URL, syspub)))
-	defer removeFile(t, confA)
 	sA := RunServer(LoadConfig(confA))
 	defer sA.Shutdown()
 	// server observed one fetch on startup
@@ -1972,7 +1965,6 @@ func TestJWTAccountURLResolverPermanentFetchFailure(t *testing.T) {
 		resolver: URL("%s/A/")
 		system_account: %s
     `, ojwt, ts.URL, syspub)))
-	defer removeFile(t, confA)
 	o := LoadConfig(confA)
 	sA := RunServer(o)
 	defer sA.Shutdown()
@@ -2059,7 +2051,6 @@ func TestJWTAccountURLResolverFetchFailureInCluster(t *testing.T) {
 		t.Fatalf("Error generating user JWT: %v", err)
 	}
 	creds := genCredsFile(t, uJwt, uSeed)
-	defer removeFile(t, creds)
 	// Simulate an account server that drops the first request to /B/acc
 	chanImpA := make(chan struct{}, 4)
 	defer close(chanImpA)
@@ -2110,7 +2101,6 @@ func TestJWTAccountURLResolverFetchFailureInCluster(t *testing.T) {
 			listen: 127.0.0.1:-1
 		}
     `, ojwt, ts.URL)))
-	defer removeFile(t, confA)
 	sA := RunServer(LoadConfig(confA))
 	defer sA.Shutdown()
 	// Create Server B (using no_advertise to prevent failover)
@@ -2127,7 +2117,6 @@ func TestJWTAccountURLResolverFetchFailureInCluster(t *testing.T) {
 			]
 		}
     `, ojwt, ts.URL, sA.opts.Cluster.Port)))
-	defer removeFile(t, confB)
 	sB := RunServer(LoadConfig(confB))
 	defer sB.Shutdown()
 	// startup cluster
@@ -2215,7 +2204,6 @@ func TestJWTAccountURLResolverReturnDifferentOperator(t *testing.T) {
 		t.Fatalf("Error generating user JWT: %v", err)
 	}
 	creds := genCredsFile(t, uJwt, uSeed)
-	defer removeFile(t, creds)
 	// Simulate an account server that was hijacked/mis configured
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(ajwt))
@@ -2227,7 +2215,6 @@ func TestJWTAccountURLResolverReturnDifferentOperator(t *testing.T) {
 		operator: %s
 		resolver: URL("%s/A/")
     `, ojwt, ts.URL)))
-	defer removeFile(t, confA)
 	sA, _ := RunServerWithConfig(confA)
 	defer sA.Shutdown()
 	// Create first client, directly connects to A
@@ -3154,11 +3141,10 @@ func TestJWTBearerWithBadIssuerToken(t *testing.T) {
 func TestJWTExpiredUserCredentialsRenewal(t *testing.T) {
 	createTmpFile := func(t *testing.T, content []byte) string {
 		t.Helper()
-		conf := createFile(t, "")
+		conf := createFileAtDir(t, t.TempDir(), "")
 		fName := conf.Name()
 		conf.Close()
 		if err := os.WriteFile(fName, content, 0666); err != nil {
-			removeFile(t, fName)
 			t.Fatalf("Error writing conf file: %v", err)
 		}
 		return fName
@@ -3212,7 +3198,6 @@ func TestJWTExpiredUserCredentialsRenewal(t *testing.T) {
 		t.Fatalf("Error encoding credentials: %v", err)
 	}
 	chainedFile := createTmpFile(t, creds)
-	defer removeFile(t, chainedFile)
 
 	rch := make(chan bool)
 
@@ -3319,22 +3304,6 @@ func require_JWTEqual(t *testing.T, dir string, pub string, jwt string) {
 	content, err := os.ReadFile(filepath.Join(dir, pub+".jwt"))
 	require_NoError(t, err)
 	require_Equal(t, string(content), jwt)
-}
-
-func createDir(t testing.TB, prefix string) string {
-	t.Helper()
-	err := os.MkdirAll(tempRoot, 0700)
-	require_NoError(t, err)
-	dir, err := os.MkdirTemp(tempRoot, prefix)
-	require_NoError(t, err)
-	return dir
-}
-
-func createFile(t testing.TB, prefix string) *os.File {
-	t.Helper()
-	err := os.MkdirAll(tempRoot, 0700)
-	require_NoError(t, err)
-	return createFileAtDir(t, tempRoot, prefix)
 }
 
 func createFileAtDir(t testing.TB, dir, prefix string) *os.File {
@@ -3459,18 +3428,10 @@ func TestJWTAccountNATSResolverFetch(t *testing.T) {
 	for i := 0; i < cap(doneChan); i++ {
 		<-doneChan
 	}
-	defer removeFile(t, sysCreds)
-	defer removeFile(t, aCreds)
-	defer removeFile(t, bCreds)
-	defer removeFile(t, cCreds)
-	defer removeFile(t, dCreds)
 	// Create one directory for each server
-	dirA := createDir(t, "srv-a")
-	defer removeDir(t, dirA)
-	dirB := createDir(t, "srv-b")
-	defer removeDir(t, dirB)
-	dirC := createDir(t, "srv-c")
-	defer removeDir(t, dirC)
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	dirC := t.TempDir()
 	// simulate a restart of the server by storing files in them
 	// Server A/B will completely sync, so after startup each server
 	// will contain the union off all stored/configured jwt
@@ -3499,7 +3460,6 @@ func TestJWTAccountNATSResolverFetch(t *testing.T) {
 			no_advertise: true
 		}
     `, ojwt, syspub, dirA, cpub, cjwt1)))
-	defer removeFile(t, confA)
 	sA, _ := RunServerWithConfig(confA)
 	defer sA.Shutdown()
 	// during startup resolver_preload causes the directory to contain data
@@ -3525,7 +3485,6 @@ func TestJWTAccountNATSResolverFetch(t *testing.T) {
 			]
 		}
     `, ojwt, syspub, dirB, sA.opts.Cluster.Port)))
-	defer removeFile(t, confB)
 	sB, _ := RunServerWithConfig(confB)
 	defer sB.Shutdown()
 	// Create Server C (using no_advertise to prevent fail over)
@@ -3550,9 +3509,7 @@ func TestJWTAccountNATSResolverFetch(t *testing.T) {
 		}
     `
 	confClongTTL := createConfFile(t, []byte(fmt.Sprintf(fmtC, ojwt, syspub, dirC, 10000, sA.opts.Cluster.Port)))
-	defer removeFile(t, confClongTTL)
 	confCshortTTL := createConfFile(t, []byte(fmt.Sprintf(fmtC, ojwt, syspub, dirC, 1000, sA.opts.Cluster.Port)))
-	defer removeFile(t, confCshortTTL)
 	sC, _ := RunServerWithConfig(confClongTTL) // use long ttl to assure it is not kicking
 	defer sC.Shutdown()
 	// startup cluster
@@ -3702,18 +3659,11 @@ func TestJWTAccountNATSResolverCrossClusterFetch(t *testing.T) {
 	for i := 0; i < cap(doneChan); i++ {
 		<-doneChan
 	}
-	defer removeFile(t, sysCreds)
-	defer removeFile(t, aCreds)
-	defer removeFile(t, bCreds)
 	// Create one directory for each server
-	dirAA := createDir(t, "srv-a-a")
-	defer removeDir(t, dirAA)
-	dirAB := createDir(t, "srv-a-b")
-	defer removeDir(t, dirAB)
-	dirBA := createDir(t, "srv-b-a")
-	defer removeDir(t, dirBA)
-	dirBB := createDir(t, "srv-b-b")
-	defer removeDir(t, dirBB)
+	dirAA := t.TempDir()
+	dirAB := t.TempDir()
+	dirBA := t.TempDir()
+	dirBB := t.TempDir()
 	// simulate a restart of the server by storing files in them
 	// Server AA & AB will completely sync
 	// Server BA & BB will completely sync
@@ -3741,7 +3691,6 @@ func TestJWTAccountNATSResolverCrossClusterFetch(t *testing.T) {
 			no_advertise: true
 		}
     `, ojwt, syspub, dirAA)))
-	defer removeFile(t, confAA)
 	sAA, _ := RunServerWithConfig(confAA)
 	defer sAA.Shutdown()
 	// Create Server B (using no_advertise to prevent fail over)
@@ -3768,7 +3717,6 @@ func TestJWTAccountNATSResolverCrossClusterFetch(t *testing.T) {
 			]
 		}
     `, ojwt, syspub, dirAB, sAA.opts.Cluster.Port)))
-	defer removeFile(t, confAB)
 	sAB, _ := RunServerWithConfig(confAB)
 	defer sAB.Shutdown()
 	// Create Server C (using no_advertise to prevent fail over)
@@ -3795,7 +3743,6 @@ func TestJWTAccountNATSResolverCrossClusterFetch(t *testing.T) {
 			no_advertise: true
 		}
     `, ojwt, syspub, dirBA, sAA.opts.Gateway.Port)))
-	defer removeFile(t, confBA)
 	sBA, _ := RunServerWithConfig(confBA)
 	defer sBA.Shutdown()
 	// Create Sever BA  (using no_advertise to prevent fail over)
@@ -3825,7 +3772,6 @@ func TestJWTAccountNATSResolverCrossClusterFetch(t *testing.T) {
 			]
 		}
     `, ojwt, syspub, dirBB, sBA.opts.Cluster.Port, sAA.opts.Cluster.Port)))
-	defer removeFile(t, confBB)
 	sBB, _ := RunServerWithConfig(confBB)
 	defer sBB.Shutdown()
 	// Assert topology
@@ -3916,7 +3862,6 @@ func TestJWTUserLimits(t *testing.T) {
 			%s: %s
 		}
     `, ojwt, aPub, aJwt)))
-	defer removeFile(t, conf)
 	sA, _ := RunServerWithConfig(conf)
 	defer sA.Shutdown()
 	for _, v := range []struct {
@@ -3951,7 +3896,6 @@ func TestJWTUserLimits(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			creds := createUserWithLimit(t, kp, doNotExpire, v.f)
-			defer removeFile(t, creds)
 			if c, err := nats.Connect(sA.ClientURL(), nats.UserCredentials(creds)); err == nil {
 				c.Close()
 				if !v.pass {
@@ -3984,7 +3928,6 @@ func TestJWTTimeExpiration(t *testing.T) {
 			%s: %s
 		}
     `, ojwt, aPub, aJwt)))
-	defer removeFile(t, conf)
 	sA, _ := RunServerWithConfig(conf)
 	defer sA.Shutdown()
 	for _, l := range []string{"", "Europe/Berlin", "America/New_York"} {
@@ -4000,7 +3943,6 @@ func TestJWTTimeExpiration(t *testing.T) {
 					j.Locale = l
 				}
 			})
-			defer removeFile(t, creds)
 			disconnectChan := make(chan struct{})
 			defer close(disconnectChan)
 			errChan := make(chan struct{})
@@ -4037,7 +3979,6 @@ func TestJWTTimeExpiration(t *testing.T) {
 		creds := createUserWithLimit(t, kp, doNotExpire, func(j *jwt.UserPermissionLimits) {
 			j.Times = []jwt.TimeRange{newTimeRange(start1, validFor), newTimeRange(start2, validFor)}
 		})
-		defer removeFile(t, creds)
 		errChan := make(chan struct{})
 		defer close(errChan)
 		reConnectChan := make(chan struct{})
@@ -4074,7 +4015,6 @@ func TestJWTTimeExpiration(t *testing.T) {
 	t.Run("lower jwt expiration overwrites time", func(t *testing.T) {
 		start := time.Now()
 		creds := createUserWithLimit(t, kp, start.Add(validFor), func(j *jwt.UserPermissionLimits) { j.Times = []jwt.TimeRange{newTimeRange(start, 2*validFor)} })
-		defer removeFile(t, creds)
 		disconnectChan := make(chan struct{})
 		defer close(disconnectChan)
 		errChan := make(chan struct{})
@@ -4144,7 +4084,6 @@ func TestJWTSysImportForDifferentAccount(t *testing.T) {
 			%s: %s
 		}
     `, ojwt, sysPub, sysPub, sysJwt, aPub, aJwt)))
-	defer removeFile(t, conf)
 	sA, _ := RunServerWithConfig(conf)
 	defer sA.Shutdown()
 
@@ -4198,7 +4137,6 @@ func TestJWTSysImportFromNothing(t *testing.T) {
 			%s: %s
 		}
     `, ojwt, sysPub, sysPub, sysJwt, aPub, aJwt)))
-	defer removeFile(t, conf)
 	sA, _ := RunServerWithConfig(conf)
 	defer sA.Shutdown()
 
@@ -4262,7 +4200,6 @@ func TestJWTSysImportOverwritePublic(t *testing.T) {
 			%s: %s
 		}
     `, ojwt, sysPub, sysPub, sysJwt, aPub, aJwt)))
-	defer removeFile(t, conf)
 	sA, _ := RunServerWithConfig(conf)
 	defer sA.Shutdown()
 
@@ -4308,7 +4245,6 @@ func TestJWTSysImportOverwriteToken(t *testing.T) {
 			%s: %s
 		}
     `, ojwt, sysPub, sysPub, sysJwt, aPub, aJwt)))
-	defer removeFile(t, conf)
 	sA, _ := RunServerWithConfig(conf)
 	defer sA.Shutdown()
 
@@ -4335,14 +4271,12 @@ func TestJWTLimits(t *testing.T) {
 			%s: %s
 		}
     `, ojwt, aPub, aJwt)))
-	defer removeFile(t, conf)
 	sA, _ := RunServerWithConfig(conf)
 	defer sA.Shutdown()
 	errChan := make(chan struct{})
 	defer close(errChan)
 	t.Run("subs", func(t *testing.T) {
 		creds := createUserWithLimit(t, kp, doNotExpire, func(j *jwt.UserPermissionLimits) { j.Subs = 1 })
-		defer removeFile(t, creds)
 		c := natsConnect(t, sA.ClientURL(), nats.UserCredentials(creds),
 			nats.DisconnectErrHandler(func(conn *nats.Conn, err error) {
 				if e := conn.LastError(); e != nil && strings.Contains(e.Error(), "maximum subscriptions exceeded") {
@@ -4361,7 +4295,6 @@ func TestJWTLimits(t *testing.T) {
 	})
 	t.Run("payload", func(t *testing.T) {
 		creds := createUserWithLimit(t, kp, doNotExpire, func(j *jwt.UserPermissionLimits) { j.Payload = 5 })
-		defer removeFile(t, creds)
 		c := natsConnect(t, sA.ClientURL(), nats.UserCredentials(creds))
 		defer c.Close()
 		if err := c.Flush(); err != nil {
@@ -4448,7 +4381,6 @@ func TestJWTLimitsTemplate(t *testing.T) {
 			%s: %s
 		}
     `, ojwt, aPub, aJwt)))
-	defer removeFile(t, conf)
 	sA, _ := RunServerWithConfig(conf)
 	defer sA.Shutdown()
 	errChan := make(chan struct{})
@@ -4466,8 +4398,6 @@ func TestJWTLimitsTemplate(t *testing.T) {
 	ujwt, err := uclaim.Encode(aSignScopedKp)
 	require_NoError(t, err)
 	creds := genCredsFile(t, ujwt, seed)
-
-	defer removeFile(t, creds)
 
 	t.Run("pass", func(t *testing.T) {
 		c := natsConnect(t, sA.ClientURL(), nats.UserCredentials(creds))
@@ -4507,7 +4437,6 @@ func TestJWTNoOperatorMode(t *testing.T) {
 			defer sA.Shutdown()
 			kp, _ := nkeys.CreateAccount()
 			creds := createUserWithLimit(t, kp, time.Now().Add(time.Hour), nil)
-			defer removeFile(t, creds)
 			url := sA.ClientURL()
 			if login {
 				url = fmt.Sprintf("nats://u:pwd@%s:%d", sA.opts.Host, sA.opts.Port)
@@ -4575,12 +4504,7 @@ func TestJWTUserRevocation(t *testing.T) {
 		for i := 0; i < cap(doneChan); i++ {
 			<-doneChan
 		}
-		defer removeFile(t, sysCreds)
-		defer removeFile(t, dummyCreds)
-		defer removeFile(t, aCreds1)
-		defer removeFile(t, aCreds2)
-		dirSrv := createDir(t, "srv")
-		defer removeDir(t, dirSrv)
+		dirSrv := t.TempDir()
 		conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		operator: %s
@@ -4590,7 +4514,6 @@ func TestJWTUserRevocation(t *testing.T) {
 			dir: '%s'
 		}
     `, ojwt, syspub, dirSrv)))
-		defer removeFile(t, conf)
 		srv, _ := RunServerWithConfig(conf)
 		defer srv.Shutdown()
 		updateJwt(t, srv.ClientURL(), sysCreds, sysjwt, 1) // update system account jwt
@@ -4645,7 +4568,6 @@ func TestJWTActivationRevocation(t *testing.T) {
 		sysKp, syspub := createKey(t)
 		sysJwt := encodeClaim(t, jwt.NewAccountClaims(syspub), syspub)
 		sysCreds := newUser(t, sysKp)
-		defer removeFile(t, sysCreds)
 
 		aExpKp, aExpPub := createKey(t)
 		aExpClaim := jwt.NewAccountClaims(aExpPub)
@@ -4688,11 +4610,8 @@ func TestJWTActivationRevocation(t *testing.T) {
 		})
 		aImpJwt := encodeClaim(t, aImpClaim, aImpPub)
 		aImpCreds := newUser(t, aImpKp)
-		defer removeFile(t, aExpCreds)
-		defer removeFile(t, aImpCreds)
 
-		dirSrv := createDir(t, "srv")
-		defer removeDir(t, dirSrv)
+		dirSrv := t.TempDir()
 		conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		operator: %s
@@ -4702,12 +4621,10 @@ func TestJWTActivationRevocation(t *testing.T) {
 			dir: '%s'
 		}
     `, ojwt, syspub, dirSrv)))
-		defer removeFile(t, conf)
 
 		t.Run("token-expired-on-connect", func(t *testing.T) {
 			srv, _ := RunServerWithConfig(conf)
 			defer srv.Shutdown()
-			defer removeDir(t, dirSrv) // clean jwt directory
 
 			updateJwt(t, srv.ClientURL(), sysCreds, sysJwt, 1)   // update system account jwt
 			updateJwt(t, srv.ClientURL(), sysCreds, aExp2Jwt, 1) // set account jwt without revocation
@@ -4731,7 +4648,6 @@ func TestJWTActivationRevocation(t *testing.T) {
 		t.Run("token-expired-on-update", func(t *testing.T) {
 			srv, _ := RunServerWithConfig(conf)
 			defer srv.Shutdown()
-			defer removeDir(t, dirSrv) // clean jwt directory
 
 			updateJwt(t, srv.ClientURL(), sysCreds, sysJwt, 1)   // update system account jwt
 			updateJwt(t, srv.ClientURL(), sysCreds, aExp1Jwt, 1) // set account jwt without revocation
@@ -4799,12 +4715,9 @@ func TestJWTAccountFetchTimeout(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			var syspub, sysjwt, sysCreds string
 			createAccountAndUser(&syspub, &sysjwt, &sysCreds)
-			defer removeFile(t, sysCreds)
 			var apub, ajwt1, aCreds1 string
 			createAccountAndUser(&apub, &ajwt1, &aCreds1)
-			defer removeFile(t, aCreds1)
-			dirSrv := createDir(t, "srv")
-			defer removeDir(t, dirSrv)
+			dirSrv := t.TempDir()
 			conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		operator: %s
@@ -4815,7 +4728,6 @@ func TestJWTAccountFetchTimeout(t *testing.T) {
 			dir: '%s'
 		}
     `, ojwt, syspub, cfg, dirSrv)))
-			defer removeFile(t, conf)
 			srv, _ := RunServerWithConfig(conf)
 			defer srv.Shutdown()
 			updateJwt(t, srv.ClientURL(), sysCreds, sysjwt, 1) // update system account jwt
@@ -4881,12 +4793,9 @@ func TestJWTAccountOps(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			var syspub, sysjwt, sysCreds string
 			createAccountAndUser(&syspub, &sysjwt, &sysCreds)
-			defer removeFile(t, sysCreds)
 			var apub, ajwt1, aCreds1 string
 			createAccountAndUser(&apub, &ajwt1, &aCreds1)
-			defer removeFile(t, aCreds1)
-			dirSrv := createDir(t, "srv")
-			defer removeDir(t, dirSrv)
+			dirSrv := t.TempDir()
 			conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		operator: %s
@@ -4898,7 +4807,6 @@ func TestJWTAccountOps(t *testing.T) {
     `, opJwt, syspub, cfg, dirSrv)))
 			disconnectErrChan := make(chan struct{}, 1)
 			defer close(disconnectErrChan)
-			defer removeFile(t, conf)
 			srv, _ := RunServerWithConfig(conf)
 			defer srv.Shutdown()
 			updateJwt(t, srv.ClientURL(), sysCreds, sysjwt, 1) // update system account jwt
@@ -4988,7 +4896,6 @@ func TestJWTHeader(t *testing.T) {
 	sysKp, syspub := createKey(t)
 	sysJwt := encodeClaim(t, jwt.NewAccountClaims(syspub), syspub)
 	sysCreds := newUser(t, sysKp)
-	defer removeFile(t, sysCreds)
 
 	test := func(share bool) {
 		aExpKp, aExpPub := createKey(t)
@@ -5005,7 +4912,6 @@ func TestJWTHeader(t *testing.T) {
 		})
 		aExpJwt := encodeClaim(t, aExpClaim, aExpPub)
 		aExpCreds := newUser(t, aExpKp)
-		defer removeFile(t, aExpCreds)
 
 		aImpKp, aImpPub := createKey(t)
 		aImpClaim := jwt.NewAccountClaims(aImpPub)
@@ -5018,10 +4924,8 @@ func TestJWTHeader(t *testing.T) {
 		})
 		aImpJwt := encodeClaim(t, aImpClaim, aImpPub)
 		aImpCreds := newUser(t, aImpKp)
-		defer removeFile(t, aImpCreds)
 
-		dirSrv := createDir(t, "srv")
-		defer removeDir(t, dirSrv)
+		dirSrv := t.TempDir()
 		conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		operator: %s
@@ -5031,7 +4935,6 @@ func TestJWTHeader(t *testing.T) {
 			dir: '%s'
 		}
     `, ojwt, syspub, dirSrv)))
-		defer removeFile(t, conf)
 		srv, _ := RunServerWithConfig(conf)
 		defer srv.Shutdown()
 		updateJwt(t, srv.ClientURL(), sysCreds, sysJwt, 1) // update system account jwt
@@ -5120,7 +5023,6 @@ func TestJWTAccountImportsWithWildcardSupport(t *testing.T) {
 		system_account: %s
 		%s
 		`, ojwt, aExpPub, aExpJwt, aImpPub, aImpJwt, aSysPub, aSysJwt, aSysPub, jsSetting)))
-		defer removeFile(t, cf)
 
 		s, opts := RunServerWithConfig(cf)
 		defer s.Shutdown()
@@ -5174,7 +5076,6 @@ func TestJWTAccountImportsWithWildcardSupport(t *testing.T) {
 	}
 	t.Run("To", func(t *testing.T) {
 		aExpPub, aExpJwt, aExpCreds := createExporter()
-		defer removeFile(t, aExpCreds)
 		aImpKp, aImpPub := createKey(t)
 		aImpClaim := jwt.NewAccountClaims(aImpPub)
 		aImpClaim.Name = "Import"
@@ -5191,14 +5092,12 @@ func TestJWTAccountImportsWithWildcardSupport(t *testing.T) {
 		})
 		aImpJwt := encodeClaim(t, aImpClaim, aImpPub)
 		aImpCreds := newUser(t, aImpKp)
-		defer removeFile(t, aImpCreds)
 		test(aExpPub, aExpJwt, aExpCreds, aImpPub, aImpJwt, aImpCreds, false,
 			"$request.1.$in.2.bar", "$events.1.$in.2.bar",
 			"my.request.1.2.bar", "prefix.$events.1.$in.2.bar")
 	})
 	t.Run("LocalSubject-No-Reorder", func(t *testing.T) {
 		aExpPub, aExpJwt, aExpCreds := createExporter()
-		defer removeFile(t, aExpCreds)
 		aImpKp, aImpPub := createKey(t)
 		aImpClaim := jwt.NewAccountClaims(aImpPub)
 		aImpClaim.Name = "Import"
@@ -5215,7 +5114,6 @@ func TestJWTAccountImportsWithWildcardSupport(t *testing.T) {
 		})
 		aImpJwt := encodeClaim(t, aImpClaim, aImpPub)
 		aImpCreds := newUser(t, aImpKp)
-		defer removeFile(t, aImpCreds)
 		test(aExpPub, aExpJwt, aExpCreds, aImpPub, aImpJwt, aImpCreds, false,
 			"$request.1.$in.2.bar", "$events.1.$in.2.bar",
 			"my.request.1.2.bar", "my.events.1.2.bar")
@@ -5224,7 +5122,6 @@ func TestJWTAccountImportsWithWildcardSupport(t *testing.T) {
 		for _, jsEnabled := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%t", jsEnabled), func(t *testing.T) {
 				aExpPub, aExpJwt, aExpCreds := createExporter()
-				defer removeFile(t, aExpCreds)
 				aImpKp, aImpPub := createKey(t)
 				aImpClaim := jwt.NewAccountClaims(aImpPub)
 				aImpClaim.Name = "Import"
@@ -5241,7 +5138,6 @@ func TestJWTAccountImportsWithWildcardSupport(t *testing.T) {
 				})
 				aImpJwt := encodeClaim(t, aImpClaim, aImpPub)
 				aImpCreds := newUser(t, aImpKp)
-				defer removeFile(t, aImpCreds)
 				test(aExpPub, aExpJwt, aExpCreds, aImpPub, aImpJwt, aImpCreds, jsEnabled,
 					"$request.2.$in.1.bar", "$events.1.$in.2.bar",
 					"my.request.1.2.bar", "my.events.2.1.bar")
@@ -5254,7 +5150,6 @@ func TestJWTAccountTokenImportMisuse(t *testing.T) {
 	sysKp, syspub := createKey(t)
 	sysJwt := encodeClaim(t, jwt.NewAccountClaims(syspub), syspub)
 	sysCreds := newUser(t, sysKp)
-	defer removeFile(t, sysCreds)
 
 	aExpKp, aExpPub := createKey(t)
 	aExpClaim := jwt.NewAccountClaims(aExpPub)
@@ -5270,7 +5165,6 @@ func TestJWTAccountTokenImportMisuse(t *testing.T) {
 	})
 	aExpJwt := encodeClaim(t, aExpClaim, aExpPub)
 	aExpCreds := newUser(t, aExpKp)
-	defer removeFile(t, aExpCreds)
 
 	createImportingAccountClaim := func(aImpKp nkeys.KeyPair, aExpPub string, ac *jwt.ActivationClaims) (string, string) {
 		t.Helper()
@@ -5312,7 +5206,6 @@ func TestJWTAccountTokenImportMisuse(t *testing.T) {
 			operator: %s
 			resolver: URL("%s/A/")
 		`, ojwt, ts.URL)))
-		defer removeFile(t, cf)
 
 		s, opts := RunServerWithConfig(cf)
 		defer s.Shutdown()
@@ -5324,8 +5217,7 @@ func TestJWTAccountTokenImportMisuse(t *testing.T) {
 
 	testNatsResolver := func(aImpJwt string) {
 		t.Helper()
-		dirSrv := createDir(t, "srv")
-		defer removeDir(t, dirSrv)
+		dirSrv := t.TempDir()
 		cf := createConfFile(t, []byte(fmt.Sprintf(`
 			listen: 127.0.0.1:-1
 			operator: %s
@@ -5352,7 +5244,6 @@ func TestJWTAccountTokenImportMisuse(t *testing.T) {
 		ac.ImportType = jwt.Stream
 
 		aImpJwt, aImpCreds := createImportingAccountClaim(aImpKp, aExpPub, ac)
-		defer removeFile(t, aImpCreds)
 		testConnect(aExpPub, aExpJwt, aExpCreds, aImpPub, aImpJwt, aImpCreds)
 		testNatsResolver(aImpJwt)
 	})
@@ -5365,7 +5256,6 @@ func TestJWTAccountTokenImportMisuse(t *testing.T) {
 		ac.ImportType = jwt.Stream
 
 		aImpJwt, aImpCreds := createImportingAccountClaim(aImpKp, aExpPub, ac)
-		defer removeFile(t, aImpCreds)
 		testConnect(aExpPub, aExpJwt, aExpCreds, aImpPub, aImpJwt, aImpCreds)
 		testNatsResolver(aImpJwt)
 	})
@@ -5378,7 +5268,6 @@ func TestJWTAccountTokenImportMisuse(t *testing.T) {
 		ac.ImportType = jwt.Stream
 
 		aImpJwt, aImpCreds := createImportingAccountClaim(aImpKp, aExpPub, ac)
-		defer removeFile(t, aImpCreds)
 		testConnect(aExpPub, aExpJwt, aExpCreds, aImpPub, aImpJwt, aImpCreds)
 		testNatsResolver(aImpJwt)
 	})
@@ -5397,7 +5286,6 @@ func TestJWTResponseThreshold(t *testing.T) {
 	aExpJwt := encodeClaim(t, aExpClaim, aExpPub)
 	aExpCreds := newUser(t, aExpKp)
 
-	defer removeFile(t, aExpCreds)
 	aImpKp, aImpPub := createKey(t)
 	aImpClaim := jwt.NewAccountClaims(aImpPub)
 	aImpClaim.Name = "Import"
@@ -5408,7 +5296,6 @@ func TestJWTResponseThreshold(t *testing.T) {
 	})
 	aImpJwt := encodeClaim(t, aImpClaim, aImpPub)
 	aImpCreds := newUser(t, aImpKp)
-	defer removeFile(t, aImpCreds)
 
 	cf := createConfFile(t, []byte(fmt.Sprintf(`
 		port: -1
@@ -5419,7 +5306,6 @@ func TestJWTResponseThreshold(t *testing.T) {
 			%s : "%s"
 		}
 		`, ojwt, aExpPub, aExpJwt, aImpPub, aImpJwt)))
-	defer removeFile(t, cf)
 
 	s, opts := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -5460,7 +5346,6 @@ func TestJWTJetStreamTiers(t *testing.T) {
 	sysKp, syspub := createKey(t)
 	sysJwt := encodeClaim(t, jwt.NewAccountClaims(syspub), syspub)
 	sysCreds := newUser(t, sysKp)
-	defer removeFile(t, sysCreds)
 
 	accKp, accPub := createKey(t)
 	accClaim := jwt.NewAccountClaims(accPub)
@@ -5472,11 +5357,9 @@ func TestJWTJetStreamTiers(t *testing.T) {
 
 	start := time.Now()
 
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
-	dirSrv := createDir(t, "srv")
-	defer removeDir(t, dirSrv)
+	dirSrv := t.TempDir()
 	cf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		server_name: s1
@@ -5491,7 +5374,6 @@ func TestJWTJetStreamTiers(t *testing.T) {
 			dir: '%s'
 		}
 	`, storeDir, ojwt, syspub, dirSrv)))
-	defer removeFile(t, cf)
 
 	s, _ := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -5571,7 +5453,6 @@ func TestJWTJetStreamMaxAckPending(t *testing.T) {
 	sysKp, syspub := createKey(t)
 	sysJwt := encodeClaim(t, jwt.NewAccountClaims(syspub), syspub)
 	sysCreds := newUser(t, sysKp)
-	defer removeFile(t, sysCreds)
 
 	accKp, accPub := createKey(t)
 	accClaim := jwt.NewAccountClaims(accPub)
@@ -5585,11 +5466,9 @@ func TestJWTJetStreamMaxAckPending(t *testing.T) {
 
 	start := time.Now()
 
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
-	dirSrv := createDir(t, "srv")
-	defer removeDir(t, dirSrv)
+	dirSrv := t.TempDir()
 	cf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		server_name: s1
@@ -5604,7 +5483,6 @@ func TestJWTJetStreamMaxAckPending(t *testing.T) {
 			dir: '%s'
 		}
 	`, storeDir, ojwt, syspub, dirSrv)))
-	defer removeFile(t, cf)
 
 	s, _ := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -5653,7 +5531,6 @@ func TestJWTJetStreamMaxStreamBytes(t *testing.T) {
 	sysKp, syspub := createKey(t)
 	sysJwt := encodeClaim(t, jwt.NewAccountClaims(syspub), syspub)
 	sysCreds := newUser(t, sysKp)
-	defer removeFile(t, sysCreds)
 
 	accKp, accPub := createKey(t)
 	accClaim := jwt.NewAccountClaims(accPub)
@@ -5668,11 +5545,9 @@ func TestJWTJetStreamMaxStreamBytes(t *testing.T) {
 
 	start := time.Now()
 
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
-	dirSrv := createDir(t, "srv")
-	defer removeDir(t, dirSrv)
+	dirSrv := t.TempDir()
 	cf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		server_name: s1
@@ -5687,7 +5562,6 @@ func TestJWTJetStreamMaxStreamBytes(t *testing.T) {
 			dir: '%s'
 		}
 	`, storeDir, ojwt, syspub, dirSrv)))
-	defer removeFile(t, cf)
 
 	s, _ := RunServerWithConfig(cf)
 	defer s.Shutdown()
@@ -5769,7 +5643,6 @@ func TestJWTQueuePermissions(t *testing.T) {
 		resolver_preload = {
 			%s : %s
 		}`, ojwt, aExpPub, aExpJwt)))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received unexpected error %s", err)
@@ -5793,7 +5666,6 @@ func TestJWTQueuePermissions(t *testing.T) {
 	} {
 		t.Run(test.permType+test.queue, func(t *testing.T) {
 			usrCreds := newUser(t, test.permType)
-			defer removeFile(t, usrCreds)
 			nc, err := nats.Connect(fmt.Sprintf("nats://127.0.0.1:%d", opts.Port),
 				nats.ErrorHandler(func(conn *nats.Conn, s *nats.Subscription, err error) {
 					errChan <- err
@@ -5835,7 +5707,6 @@ func TestJWScopedSigningKeys(t *testing.T) {
 	sysKp, syspub := createKey(t)
 	sysJwt := encodeClaim(t, jwt.NewAccountClaims(syspub), syspub)
 	sysCreds := newUser(t, sysKp)
-	defer removeFile(t, sysCreds)
 
 	_, aExpPub := createKey(t)
 	accClaim := jwt.NewAccountClaims(aExpPub)
@@ -5853,14 +5724,10 @@ func TestJWScopedSigningKeys(t *testing.T) {
 	accJwt := encodeClaim(t, accClaim, aExpPub)
 
 	aNonScopedCreds := newUserEx(t, aSignNonScopedKp, false, aExpPub)
-	defer removeFile(t, aNonScopedCreds)
 	aBadScopedCreds := newUserEx(t, aSignScopedKp, false, aExpPub)
-	defer removeFile(t, aBadScopedCreds)
 	aScopedCreds := newUserEx(t, aSignScopedKp, true, aExpPub)
-	defer removeFile(t, aScopedCreds)
 
-	dirSrv := createDir(t, "srv")
-	defer removeDir(t, dirSrv)
+	dirSrv := t.TempDir()
 	cf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		operator: %s
@@ -5870,7 +5737,6 @@ func TestJWScopedSigningKeys(t *testing.T) {
 			dir: '%s'
 		}
     `, ojwt, syspub, dirSrv)))
-	defer removeFile(t, cf)
 	s, opts := RunServerWithConfig(cf)
 	defer s.Shutdown()
 
@@ -6014,15 +5880,10 @@ func TestJWTStrictSigningKeys(t *testing.T) {
 	require_NoError(t, err)
 
 	uBadBadCreds := newUserEx(t, aBadBadKp, false, aBadPub)
-	defer removeFile(t, uBadBadCreds)
 	uBadGoodCreds := newUserEx(t, aBadGoodKp, false, aBadPub)
-	defer removeFile(t, uBadGoodCreds)
 	uGoodBadCreds := newUserEx(t, aGoodBadKp, false, aGoodPub)
-	defer removeFile(t, uGoodBadCreds)
 	uGoodGoodCreds := newUserEx(t, aGoodGoodKp, false, aGoodPub)
-	defer removeFile(t, uGoodGoodCreds)
 	uSysCreds := newUserEx(t, aSysKp, false, aSysPub)
-	defer removeFile(t, uSysCreds)
 
 	connectTest := func(url string) {
 		for _, test := range []struct {
@@ -6045,8 +5906,7 @@ func TestJWTStrictSigningKeys(t *testing.T) {
 	}
 
 	t.Run("resolver", func(t *testing.T) {
-		dirSrv := createDir(t, "srv")
-		defer removeDir(t, dirSrv)
+		dirSrv := t.TempDir()
 		cf := createConfFile(t, []byte(fmt.Sprintf(`
 		port: -1
 		operator = %s
@@ -6058,7 +5918,6 @@ func TestJWTStrictSigningKeys(t *testing.T) {
 			%s : "%s"
 		}
 		`, oJwt, dirSrv, aSysPub, aSysJwt)))
-		defer removeFile(t, cf)
 		s, _ := RunServerWithConfig(cf)
 		defer s.Shutdown()
 		url := s.ClientURL()
@@ -6072,8 +5931,6 @@ func TestJWTStrictSigningKeys(t *testing.T) {
 	})
 
 	t.Run("mem-resolver", func(t *testing.T) {
-		dirSrv := createDir(t, "srv")
-		defer removeDir(t, dirSrv)
 		cf := createConfFile(t, []byte(fmt.Sprintf(`
 		port: -1
 		operator = %s
@@ -6084,7 +5941,6 @@ func TestJWTStrictSigningKeys(t *testing.T) {
 			%s : "%s"
 		}
 		`, oJwt, aSysPub, aSysJwt, aBadPub, aBadJwt, aGoodPub, aGoodJwt)))
-		defer removeFile(t, cf)
 		s, _ := RunServerWithConfig(cf)
 		defer s.Shutdown()
 		connectTest(s.ClientURL())
@@ -6134,7 +5990,6 @@ func TestJWTAccountProtectedImport(t *testing.T) {
 	t.Run("pass", func(t *testing.T) {
 		exportKp, exportPub, exportJWT, _, importKp, importPub, importJWT, srvcSub, strmSub := setupAccounts(true)
 		cf := createConfFile(t, []byte(fmt.Sprintf(srvFmt, ojwt, exportPub, exportJWT, importPub, importJWT)))
-		defer removeFile(t, cf)
 		s, _ := RunServerWithConfig(cf)
 		defer s.Shutdown()
 		ncExp := natsConnect(t, s.ClientURL(), createUserCreds(t, s, exportKp))
@@ -6171,7 +6026,6 @@ func TestJWTAccountProtectedImport(t *testing.T) {
 	t.Run("fail", func(t *testing.T) {
 		exportKp, exportPub, exportJWT, _, importKp, importPub, importJWT, srvcSub, strmSub := setupAccounts(false)
 		cf := createConfFile(t, []byte(fmt.Sprintf(srvFmt, ojwt, exportPub, exportJWT, importPub, importJWT)))
-		defer removeFile(t, cf)
 		s, _ := RunServerWithConfig(cf)
 		defer s.Shutdown()
 		ncExp := natsConnect(t, s.ClientURL(), createUserCreds(t, s, exportKp))
@@ -6209,15 +6063,13 @@ func TestJWTAccountProtectedImport(t *testing.T) {
 	})
 	t.Run("reload-off-2-on", func(t *testing.T) {
 		exportKp, exportPub, exportJWTOn, exportJWTOff, importKp, _, importJWT, srvcSub, strmSub := setupAccounts(false)
-		dirSrv := createDir(t, "srv")
-		defer removeDir(t, dirSrv)
+		dirSrv := t.TempDir()
 		// set up system account. Relying bootstrapping system account to not create JWT
 		sysAcc, err := nkeys.CreateAccount()
 		require_NoError(t, err)
 		sysPub, err := sysAcc.PublicKey()
 		require_NoError(t, err)
 		sysUsrCreds := newUserEx(t, sysAcc, false, sysPub)
-		defer removeFile(t, sysUsrCreds)
 		cf := createConfFile(t, []byte(fmt.Sprintf(`
 		port: -1
 		operator = %s
@@ -6226,7 +6078,6 @@ func TestJWTAccountProtectedImport(t *testing.T) {
 			type: full
 			dir: '%s'
 		}`, ojwt, sysPub, dirSrv)))
-		defer removeFile(t, cf)
 		s, _ := RunServerWithConfig(cf)
 		defer s.Shutdown()
 		updateJwt(t, s.ClientURL(), sysUsrCreds, importJWT, 1)
@@ -6281,7 +6132,6 @@ func TestJWTMappings(t *testing.T) {
 	sysKp, syspub := createKey(t)
 	sysJwt := encodeClaim(t, jwt.NewAccountClaims(syspub), syspub)
 	sysCreds := newUser(t, sysKp)
-	defer removeFile(t, sysCreds)
 
 	// create two jwt, one with and one without mapping
 	aKp, aPub := createKey(t)
@@ -6294,8 +6144,7 @@ func TestJWTMappings(t *testing.T) {
 	aClaim.AddMapping("foo2", jwt.WeightedMapping{Subject: "bar2"})
 	aJwtMap2 := encodeClaim(t, aClaim, aPub)
 
-	dirSrv := createDir(t, "srv")
-	defer removeDir(t, dirSrv)
+	dirSrv := t.TempDir()
 	conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		operator: %s
@@ -6305,7 +6154,6 @@ func TestJWTMappings(t *testing.T) {
 			dir: '%s'
 		}
     `, ojwt, syspub, dirSrv)))
-	defer removeFile(t, conf)
 	srv, _ := RunServerWithConfig(conf)
 	defer srv.Shutdown()
 	updateJwt(t, srv.ClientURL(), sysCreds, sysJwt, 1) // update system account jwt
@@ -6346,11 +6194,7 @@ func TestJWTOperatorPinnedAccounts(t *testing.T) {
 		kps[i], pubs[i] = createKey(t)
 		jwts[i] = encodeClaim(t, jwt.NewAccountClaims(pubs[i]), pubs[i])
 	}
-	sysCreds := newUser(t, kps[0]) // index 0 is handled as system account
-	defer removeFile(t, sysCreds)
-
-	dirSrv := createDir(t, "srv")
-	defer removeDir(t, dirSrv)
+	newUser(t, kps[0]) // index 0 is handled as system account
 
 	cfgCommon := fmt.Sprintf(`
 		listen: 127.0.0.1:-1
@@ -6367,7 +6211,6 @@ func TestJWTOperatorPinnedAccounts(t *testing.T) {
 		resolver_pinned_accounts: [%s, %s]
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(cfgFmt, pubs[1], pubs[2])))
-	defer removeFile(t, conf)
 	srv, _ := RunServerWithConfig(conf)
 	defer srv.Shutdown()
 
@@ -6405,8 +6248,7 @@ func TestJWTOperatorPinnedAccounts(t *testing.T) {
 }
 
 func TestJWTNoSystemAccountButNatsResolver(t *testing.T) {
-	dirSrv := createDir(t, "srv")
-	defer removeDir(t, dirSrv)
+	dirSrv := t.TempDir()
 	for _, resType := range []string{"full", "cache"} {
 		t.Run(resType, func(t *testing.T) {
 			conf := createConfFile(t, []byte(fmt.Sprintf(`
@@ -6416,7 +6258,6 @@ func TestJWTNoSystemAccountButNatsResolver(t *testing.T) {
 				type: %s
 				dir: '%s'
 			}`, ojwt, resType, dirSrv)))
-			defer removeFile(t, conf)
 			opts := LoadConfig(conf)
 			s, err := NewServer(opts)
 			// Since the server cannot be stopped, since it did not start,
@@ -6431,8 +6272,7 @@ func TestJWTNoSystemAccountButNatsResolver(t *testing.T) {
 
 func TestJWTAccountConnzAccessAfterClaimUpdate(t *testing.T) {
 	skp, spub := createKey(t)
-	screds := newUser(t, skp)
-	defer removeFile(t, screds)
+	newUser(t, skp)
 
 	sclaim := jwt.NewAccountClaims(spub)
 	sclaim.AddMapping("foo.bar", jwt.WeightedMapping{Subject: "foo.baz"})
@@ -6440,15 +6280,13 @@ func TestJWTAccountConnzAccessAfterClaimUpdate(t *testing.T) {
 
 	// create two jwt, one with and one without mapping
 	akp, apub := createKey(t)
-	creds := newUser(t, akp)
-	defer removeFile(t, creds)
+	newUser(t, akp)
 	claim := jwt.NewAccountClaims(apub)
 	jwt1 := encodeClaim(t, claim, apub)
 	claim.AddMapping("foo.bar", jwt.WeightedMapping{Subject: "foo.baz"})
 	jwt2 := encodeClaim(t, claim, apub)
 
-	dirSrv := createDir(t, "srv")
-	defer removeDir(t, dirSrv)
+	dirSrv := t.TempDir()
 
 	conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
@@ -6459,7 +6297,6 @@ func TestJWTAccountConnzAccessAfterClaimUpdate(t *testing.T) {
 			dir: '%s'
 		}
     `, ojwt, spub, dirSrv)))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -2632,7 +2632,6 @@ func TestMonitorClusterURLs(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, "nats://"+s2ClusterHostPort, "")))
-	defer removeFile(t, conf)
 	s1, _ := RunServerWithConfig(conf)
 	defer s1.Shutdown()
 
@@ -3249,7 +3248,6 @@ func TestMonitorGatewayzAccounts(t *testing.T) {
 		}
 		no_sys_acc = true
 	`, accounts)))
-	defer removeFile(t, bConf)
 
 	sb, ob := RunServerWithConfig(bConf)
 	defer sb.Shutdown()
@@ -3274,7 +3272,6 @@ func TestMonitorGatewayzAccounts(t *testing.T) {
 		}
 		no_sys_acc = true
 	`, accounts, sb.GatewayAddr().Port)))
-	defer removeFile(t, aConf)
 
 	sa, oa := RunServerWithConfig(aConf)
 	defer sa.Shutdown()
@@ -3651,7 +3648,6 @@ func TestMonitorOpJWT(t *testing.T) {
 	resolver = MEMORY
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 	sa, _ := RunServerWithConfig(conf)
 	defer sa.Shutdown()
 
@@ -3692,7 +3688,6 @@ func TestMonitorLeafz(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 	sb, ob := RunServerWithConfig(conf)
 	defer sb.Shutdown()
 
@@ -3711,9 +3706,7 @@ func TestMonitorLeafz(t *testing.T) {
 		return acc, creds
 	}
 	acc1, mycreds1 := createAcc(t)
-	defer removeFile(t, mycreds1)
 	acc2, mycreds2 := createAcc(t)
-	defer removeFile(t, mycreds2)
 
 	content = `
 		port: -1
@@ -3751,7 +3744,6 @@ func TestMonitorLeafz(t *testing.T) {
 		acc1.Name, ob.LeafNode.Port, mycreds1,
 		acc2.Name, ob.LeafNode.Port, mycreds2)
 	conf = createConfFile(t, []byte(config))
-	defer removeFile(t, conf)
 	sa, oa := RunServerWithConfig(conf)
 	defer sa.Shutdown()
 
@@ -4092,8 +4084,7 @@ func TestMonitorJsz(t *testing.T) {
 		{7500, 7501, 7502, 5502},
 		{5500, 5501, 5502, 7502},
 	} {
-		tmpDir := createDir(t, fmt.Sprintf("srv_%d", test.port))
-		defer removeDir(t, tmpDir)
+		tmpDir := t.TempDir()
 		cf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:%d
 		http: 127.0.0.1:%d
@@ -4123,7 +4114,6 @@ func TestMonitorJsz(t *testing.T) {
 			routes: [nats-route://127.0.0.1:%d]
 		}
 		server_name: server_%d `, test.port, test.mport, tmpDir, test.cport, test.routed, test.port)))
-		defer removeFile(t, cf)
 
 		s, _ := RunServerWithConfig(cf)
 		defer s.Shutdown()
@@ -4369,7 +4359,6 @@ func TestMonitorReloadTLSConfig(t *testing.T) {
 	conf := createConfFile(t, []byte(fmt.Sprintf(template,
 		"../test/configs/certs/server-noip.pem",
 		"../test/configs/certs/server-key-noip.pem")))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -308,7 +308,7 @@ func testMQTTRunServer(t testing.TB, o *Options) *Server {
 	t.Helper()
 	o.NoLog = false
 	if o.StoreDir == _EMPTY_ {
-		o.StoreDir = createDir(t, "mqtt_js")
+		o.StoreDir = t.TempDir()
 	}
 	s, err := NewServer(o)
 	if err != nil {
@@ -362,7 +362,6 @@ func TestMQTTServerNameRequired(t *testing.T) {
 			port: -1
 		}
 	`))
-	defer removeFile(t, conf)
 	o, err := ProcessConfigFile(conf)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -383,7 +382,6 @@ func TestMQTTStandaloneRequiresJetStream(t *testing.T) {
 			}
 		}
 	`))
-	defer removeFile(t, conf)
 	o, err := ProcessConfigFile(conf)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -405,7 +403,6 @@ func TestMQTTConfig(t *testing.T) {
 			}
 		}
 	`))
-	defer removeFile(t, conf)
 	s, o := RunServerWithConfig(conf)
 	defer testMQTTShutdownServer(s)
 	if o.MQTT.TLSConfig == nil {
@@ -579,7 +576,6 @@ func TestMQTTParseOptions(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			conf := createConfFile(t, []byte(test.content))
-			defer removeFile(t, conf)
 			o, err := ProcessConfigFile(conf)
 			if test.err != _EMPTY_ {
 				if err == nil || !strings.Contains(err.Error(), test.err) {
@@ -3208,7 +3204,7 @@ func TestMQTTLeafnodeWithoutJSToClusterWithJSNoSharedSysAcc(t *testing.T) {
 		if len(lno.Accounts) > 0 {
 			lno.JetStream = true
 			lno.JetStreamDomain = "OTHER"
-			lno.StoreDir = createDir(t, "mqtt_js_ln")
+			lno.StoreDir = t.TempDir()
 		}
 
 		// Use RoutesFromStr() to make an array of urls
@@ -3303,7 +3299,6 @@ func TestMQTTImportExport(t *testing.T) {
 		}
 		no_auth_user: device
 	`))
-	defer os.Remove(conf)
 	defer os.RemoveAll("org_dir")
 
 	s, o := RunServerWithConfig(conf)
@@ -3727,7 +3722,6 @@ func TestMQTTWillRetainPermViolation(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, "foo")))
-	defer removeFile(t, conf)
 
 	s, o := RunServerWithConfig(conf)
 	defer testMQTTShutdownServer(s)
@@ -4966,7 +4960,6 @@ func TestMQTTConfigReload(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, `"5s"`, `10000`)))
-	defer removeFile(t, conf)
 
 	s, o := RunServerWithConfig(conf)
 	defer testMQTTShutdownServer(s)
@@ -5096,7 +5089,6 @@ func TestMQTTWebsocketToMQTTPort(t *testing.T) {
 			no_tls: true
 		}
 	`))
-	defer removeFile(t, conf)
 	s, o := RunServerWithConfig(conf)
 	defer testMQTTShutdownServer(s)
 
@@ -5140,7 +5132,6 @@ func TestMQTTWebsocket(t *testing.T) {
 		}
 	`
 	s, o, conf := runReloadServerWithContent(t, []byte(fmt.Sprintf(template, jwt.ConnectionTypeMqtt, "")))
-	defer removeFile(t, conf)
 	defer testMQTTShutdownServer(s)
 
 	cisub := &mqttConnInfo{clientID: "sub", user: "mqtt", pass: "pwd", ws: true}
@@ -5203,7 +5194,6 @@ func TestMQTTPartial(t *testing.T) {
 			no_tls: true
 		}
 	`))
-	defer removeFile(t, conf)
 	s, o := RunServerWithConfig(conf)
 	defer testMQTTShutdownServer(s)
 
@@ -5259,7 +5249,6 @@ func TestMQTTWebsocketTLS(t *testing.T) {
 			}
 		}
 	`))
-	defer removeFile(t, conf)
 	s, o := RunServerWithConfig(conf)
 	defer testMQTTShutdownServer(s)
 
@@ -5408,7 +5397,6 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 		}
 		system_account: "SYS"
 	`))
-	defer os.Remove(conf)
 	s, o := RunServerWithConfig(conf)
 	defer testMQTTShutdownServer(s)
 
@@ -5690,7 +5678,6 @@ func TestMQTTStreamReplicasConfigReload(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(tmpl, 3)))
-	defer removeFile(t, conf)
 	s, o := RunServerWithConfig(conf)
 	defer testMQTTShutdownServer(s)
 
@@ -5871,7 +5858,6 @@ func TestMQTTConsumerReplicasReload(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(tmpl, 3, "false")))
-	defer removeFile(t, conf)
 	s, o := RunServerWithConfig(conf)
 	defer testMQTTShutdownServer(s)
 
@@ -6034,7 +6020,6 @@ func TestMQTTConsumerInactiveThreshold(t *testing.T) {
 		accounts { $SYS { users = [ { user: "admin", pass: "s3cr3t!" } ] } }
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(tmpl, "0.2s")))
-	defer removeFile(t, conf)
 	s, o := RunServerWithConfig(conf)
 	defer testMQTTShutdownServer(s)
 

--- a/server/nkey_test.go
+++ b/server/nkey_test.go
@@ -234,7 +234,6 @@ func TestMixedClientConfig(t *testing.T) {
         {user: alice, password: foo}
       ]
     }`))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error processing config file: %v", err)

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -1091,10 +1091,7 @@ func TestNoRaceAcceptLoopsDoNotLeaveOpenedConn(t *testing.T) {
 }
 
 func TestNoRaceJetStreamDeleteStreamManyConsumers(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	mname := "MYS"
@@ -1123,10 +1120,7 @@ func TestNoRaceJetStreamDeleteStreamManyConsumers(t *testing.T) {
 // This is not limited to the case above, its just the one that exposed it.
 // This test is to show that issue and that the fix works, meaning we no longer swap c.acc.
 func TestNoRaceJetStreamServiceImportAccountSwapIssue(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client based API
@@ -1200,10 +1194,7 @@ func TestNoRaceJetStreamServiceImportAccountSwapIssue(t *testing.T) {
 }
 
 func TestNoRaceJetStreamAPIStreamListPaging(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Create 2X limit
@@ -1267,10 +1258,7 @@ func TestNoRaceJetStreamAPIStreamListPaging(t *testing.T) {
 }
 
 func TestNoRaceJetStreamAPIConsumerListPaging(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	sname := "MYSTREAM"
@@ -1333,7 +1321,7 @@ func TestNoRaceJetStreamAPIConsumerListPaging(t *testing.T) {
 }
 
 func TestNoRaceJetStreamWorkQueueLoadBalance(t *testing.T) {
-	s := RunBasicJetStreamServer()
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	mname := "MY_MSG_SET"
@@ -2047,10 +2035,7 @@ func TestNoRaceJetStreamClusterExtendedStreamPurgeStall(t *testing.T) {
 		}
 	}
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -2377,10 +2362,7 @@ func TestNoRaceJetStreamSuperClusterRIPStress(t *testing.T) {
 }
 
 func TestNoRaceJetStreamSlowFilteredInititalPendingAndFirstMsg(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Create directly here to force multiple blocks, etc.
@@ -2530,10 +2512,7 @@ func TestNoRaceJetStreamFileStoreBufferReuse(t *testing.T) {
 	// Uncomment to run. Needs to be on a big machine.
 	skip(t)
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	cfg := &StreamConfig{Name: "TEST", Subjects: []string{"foo", "bar", "baz"}, Storage: FileStorage}
@@ -2873,11 +2852,7 @@ func TestNoRaceJetStreamSuperClusterAccountConnz(t *testing.T) {
 }
 
 func TestNoRaceCompressedConnz(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, _ := jsClientConnect(t, s)
@@ -3105,11 +3080,7 @@ func TestNoRaceJetStreamClusterExtendedStreamPurge(t *testing.T) {
 }
 
 func TestNoRaceJetStreamFileStoreCompaction(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -3161,7 +3132,6 @@ func TestNoRaceJetStreamEncryptionEnabledOnRestartWithExpire(t *testing.T) {
 		listen: 127.0.0.1:-1
 		jetstream: enabled
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -3210,7 +3180,6 @@ func TestNoRaceJetStreamEncryptionEnabledOnRestartWithExpire(t *testing.T) {
 
 	ncs := fmt.Sprintf("\nlisten: 127.0.0.1:-1\njetstream: {key: %q, store_dir: %q}\n", "s3cr3t!", config.StoreDir)
 	conf = createConfFile(t, []byte(ncs))
-	defer removeFile(t, conf)
 
 	// Try to drain entropy to see if effects startup time.
 	drain := make([]byte, 32*1024*1024) // Pull 32Mb of crypto rand.
@@ -3231,11 +3200,7 @@ func TestNoRaceJetStreamOrderedConsumerMissingMsg(t *testing.T) {
 	// Uncomment to run. Needs to be on a big machine. Do not want as part of Travis tests atm.
 	skip(t)
 
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -3388,7 +3353,7 @@ func TestNoRaceJetStreamClusterInterestPolicyAckNone(t *testing.T) {
 // There was a bug in the filestore compact code that would cause a store
 // with JSExpectedLastSubjSeq to fail with "wrong last sequence: 0"
 func TestNoRaceJetStreamLastSubjSeqAndFilestoreCompact(t *testing.T) {
-	s := RunBasicJetStreamServer()
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client based API
@@ -4058,11 +4023,7 @@ func TestNoRaceJetStreamClusterStreamDropCLFS(t *testing.T) {
 }
 
 func TestNoRaceJetStreamMemstoreWithLargeInteriorDeletes(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	config := s.JetStreamConfig()
-	if config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	// Client for API requests.
@@ -4115,8 +4076,7 @@ func TestNoRaceJetStreamMemstoreWithLargeInteriorDeletes(t *testing.T) {
 // cleanup too many consumers at the same time.
 // https://github.com/nats-io/nats-server/issues/2742
 func TestNoRaceJetStreamConsumerFileStoreConcurrentDiskIO(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	// Artificially adjust our environment for this test.
 	gmp := runtime.GOMAXPROCS(32)
@@ -4253,7 +4213,6 @@ func TestNoRaceJetStreamStreamInfoSubjectDetailsLimits(t *testing.T) {
 		  }
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	if config := s.JetStreamConfig(); config != nil {
@@ -4324,10 +4283,7 @@ func TestNoRaceJetStreamStreamInfoSubjectDetailsLimits(t *testing.T) {
 }
 
 func TestNoRaceJetStreamSparseConsumers(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -4402,10 +4358,7 @@ func TestNoRaceJetStreamSparseConsumers(t *testing.T) {
 }
 
 func TestNoRaceJetStreamConsumerFilterPerfDegradation(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, _ := jsClientConnect(t, s)
@@ -4459,8 +4412,7 @@ func TestNoRaceJetStreamConsumerFilterPerfDegradation(t *testing.T) {
 }
 
 func TestNoRaceJetStreamFileStoreKeyFileCleanup(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	prf := func(context []byte) ([]byte, error) {
 		h := hmac.New(sha256.New, []byte("dlc22"))
@@ -4592,10 +4544,7 @@ func TestNoRaceJetStreamMsgIdPerfDuringCatchup(t *testing.T) {
 func TestNoRaceJetStreamRebuildDeDupeAndMemoryPerf(t *testing.T) {
 	skip(t)
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -4676,10 +4625,7 @@ func TestNoRaceJetStreamRebuildDeDupeAndMemoryPerf(t *testing.T) {
 func TestNoRaceJetStreamMemoryUsageOnLimitedStreamWithMirror(t *testing.T) {
 	skip(t)
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)
@@ -4729,10 +4675,7 @@ func TestNoRaceJetStreamMemoryUsageOnLimitedStreamWithMirror(t *testing.T) {
 func TestNoRaceJetStreamOrderedConsumerLongRTTPerformance(t *testing.T) {
 	skip(t)
 
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, _ := jsClientConnect(t, s)
@@ -5392,8 +5335,7 @@ func TestNoRaceJetStreamClusterStreamNamesAndInfosMoreThanAPILimit(t *testing.T)
 }
 
 func TestNoRaceJetStreamFileStoreLargeKVAccessTiming(t *testing.T) {
-	storeDir := createDir(t, JetStreamStoreDir)
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	blkSize := uint64(4 * 1024)
 	// Compensate for slower IO on MacOSX
@@ -5451,10 +5393,7 @@ func TestNoRaceJetStreamFileStoreLargeKVAccessTiming(t *testing.T) {
 }
 
 func TestNoRaceJetStreamKVLock(t *testing.T) {
-	s := RunBasicJetStreamServer()
-	if config := s.JetStreamConfig(); config != nil {
-		defer removeDir(t, config.StoreDir)
-	}
+	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
 	nc, js := jsClientConnect(t, s)

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
@@ -880,7 +881,6 @@ func TestNkeyUsersConfig(t *testing.T) {
         {nkey: "UA3C5TBZYK5GJQJRWPMU6NFY5JNAEVQB2V2TUZFZDHFJFUYVKTTUOFKZ"}
       ]
     }`))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v", err)
@@ -959,7 +959,6 @@ func TestTlsPinnedCertificates(t *testing.T) {
 				"a8f407340dcc719864214b85ed96f98d16cbffa8f509d9fa4ca237b7bb3f9c32"]
 		}
 	}`))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v", err)
@@ -1033,7 +1032,6 @@ func TestNkeyUsersDefaultPermissionsConfig(t *testing.T) {
 			t.Fatal("Has unexpected Publish permission")
 		}
 	}
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v", err)
@@ -1094,7 +1092,6 @@ func TestNkeyUsersWithPermsConfig(t *testing.T) {
         }
       ]
     }`))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v", err)
@@ -1128,7 +1125,6 @@ func TestNkeyUsersWithPermsConfig(t *testing.T) {
 
 func TestBadNkeyConfig(t *testing.T) {
 	confFileName := "nkeys_bad.conf"
-	defer removeFile(t, confFileName)
 	content := `
     authorization {
       users = [ {nkey: "Ufoo"}]
@@ -1143,7 +1139,6 @@ func TestBadNkeyConfig(t *testing.T) {
 
 func TestNkeyWithPassConfig(t *testing.T) {
 	confFileName := "nkeys_pass.conf"
-	defer removeFile(t, confFileName)
 	content := `
     authorization {
       users = [
@@ -1160,7 +1155,6 @@ func TestNkeyWithPassConfig(t *testing.T) {
 
 func TestTokenWithUserPass(t *testing.T) {
 	confFileName := "test.conf"
-	defer removeFile(t, confFileName)
 	content := `
 	authorization={
 		user: user
@@ -1181,7 +1175,6 @@ func TestTokenWithUserPass(t *testing.T) {
 
 func TestTokenWithUsers(t *testing.T) {
 	confFileName := "test.conf"
-	defer removeFile(t, confFileName)
 	content := `
 	authorization={
 		token: $2a$11$whatever
@@ -1203,7 +1196,6 @@ func TestTokenWithUsers(t *testing.T) {
 
 func TestParseWriteDeadline(t *testing.T) {
 	confFile := "test.conf"
-	defer removeFile(t, confFile)
 	if err := os.WriteFile(confFile, []byte("write_deadline: \"1x\""), 0666); err != nil {
 		t.Fatalf("Error writing config file: %v", err)
 	}
@@ -1353,7 +1345,6 @@ func TestMalformedClusterAddress(t *testing.T) {
 
 func TestPanic(t *testing.T) {
 	conf := createConfFile(t, []byte(`port: "this_string_trips_a_panic"`))
-	defer removeFile(t, conf)
 	opts, err := ProcessConfigFile(conf)
 	if err == nil {
 		t.Fatalf("Expected an error reading config file: got %+v", opts)
@@ -1366,7 +1357,6 @@ func TestPanic(t *testing.T) {
 
 func TestPingIntervalOld(t *testing.T) {
 	conf := createConfFile(t, []byte(`ping_interval: 5`))
-	defer removeFile(t, conf)
 	opts := &Options{}
 	err := opts.ProcessConfigFile(conf)
 	if err == nil {
@@ -1389,7 +1379,6 @@ func TestPingIntervalOld(t *testing.T) {
 
 func TestPingIntervalNew(t *testing.T) {
 	conf := createConfFile(t, []byte(`ping_interval: "5m"`))
-	defer removeFile(t, conf)
 	opts := &Options{}
 	if err := opts.ProcessConfigFile(conf); err != nil {
 		t.Fatalf("expected no error")
@@ -1638,7 +1627,6 @@ func TestClusterPermissionsConfig(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, "")))
-	defer removeFile(t, conf)
 	opts, err := ProcessConfigFile(conf)
 	if err != nil {
 		if cerr, ok := err.(*processConfigErr); ok && len(cerr.Errors()) > 0 {
@@ -1673,7 +1661,6 @@ func TestClusterPermissionsConfig(t *testing.T) {
 			}
 		}
 	`)))
-	defer removeFile(t, conf)
 	opts, err = ProcessConfigFile(conf)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -1974,7 +1961,6 @@ func TestParseExport(t *testing.T) {
 		t.Fatal("Failed startup")
 	}
 	defer s.Shutdown()
-	defer removeFile(t, f)
 	connect := func(user string) *nats.Conn {
 		nc, err := nats.Connect(fmt.Sprintf("nats://%s:pwd@%s:%d", user, o.Host, o.Port))
 		require_NoError(t, err)
@@ -2106,8 +2092,8 @@ func TestParsingGateways(t *testing.T) {
 		]
 	}
 	`
-	file := "server_config_gateways.conf"
-	defer removeFile(t, file)
+
+	file := filepath.Join(t.TempDir(), "server_config_gateways.conf")
 	if err := os.WriteFile(file, []byte(content), 0600); err != nil {
 		t.Fatalf("Error writing config file: %v", err)
 	}
@@ -2360,8 +2346,8 @@ func TestParsingGatewaysErrors(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			file := fmt.Sprintf("server_config_gateways_%s.conf", test.name)
-			defer removeFile(t, file)
+			fileName := fmt.Sprintf("server_config_gateways_%s.conf", test.name)
+			file := filepath.Join(t.TempDir(), fileName)
 			if err := os.WriteFile(file, []byte(test.content), 0600); err != nil {
 				t.Fatalf("Error writing config file: %v", err)
 			}
@@ -2395,7 +2381,6 @@ func TestParsingLeafNodesListener(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 	opts, err := ProcessConfigFile(conf)
 	if err != nil {
 		t.Fatalf("Error processing file: %v", err)
@@ -2437,7 +2422,6 @@ func TestParsingLeafNodeRemotes(t *testing.T) {
 		}
 		`
 		conf := createConfFile(t, []byte(content))
-		defer removeFile(t, conf)
 		opts, err := ProcessConfigFile(conf)
 		if err != nil {
 			t.Fatalf("Error processing file: %v", err)
@@ -2477,7 +2461,6 @@ func TestParsingLeafNodeRemotes(t *testing.T) {
 		}
 		`
 		conf := createConfFile(t, []byte(content))
-		defer removeFile(t, conf)
 		opts, err := ProcessConfigFile(conf)
 		if err != nil {
 			t.Fatalf("Error processing file: %v", err)
@@ -2518,7 +2501,6 @@ func TestParsingLeafNodeRemotes(t *testing.T) {
 		}
 		`
 		conf := createConfFile(t, []byte(fmt.Sprintf(content, confURLs)))
-		defer removeFile(t, conf)
 
 		s, _ := RunServerWithConfig(conf)
 		defer s.Shutdown()
@@ -2564,14 +2546,9 @@ func TestParsingLeafNodeRemotes(t *testing.T) {
 }
 
 func TestLargeMaxControlLine(t *testing.T) {
-	confFileName := "big_mcl.conf"
-	defer removeFile(t, confFileName)
-	content := `
-    max_control_line = 3000000000
-    `
-	if err := os.WriteFile(confFileName, []byte(content), 0666); err != nil {
-		t.Fatalf("Error writing config file: %v", err)
-	}
+	confFileName := createConfFile(t, []byte(`
+		max_control_line = 3000000000
+	`))
 	if _, err := ProcessConfigFile(confFileName); err == nil {
 		t.Fatalf("Expected an error from too large of a max_control_line entry")
 	}
@@ -2581,7 +2558,6 @@ func TestLargeMaxPayload(t *testing.T) {
 	confFileName := createConfFile(t, []byte(`
 		max_payload = 3000000000
 	`))
-	defer removeFile(t, confFileName)
 	if _, err := ProcessConfigFile(confFileName); err == nil {
 		t.Fatalf("Expected an error from too large of a max_payload entry")
 	}
@@ -2590,7 +2566,6 @@ func TestLargeMaxPayload(t *testing.T) {
 		max_payload = 100000
 		max_pending = 50000
 	`))
-	defer removeFile(t, confFileName)
 	o := LoadConfig(confFileName)
 	s, err := NewServer(o)
 	if err == nil || !strings.Contains(err.Error(), "cannot be higher") {
@@ -2608,7 +2583,6 @@ func TestHandleUnknownTopLevelConfigurationField(t *testing.T) {
 			id: "me"
 		}
 	`))
-	defer removeFile(t, conf)
 
 	// Verify that we get an error because of unknown "streaming" field.
 	opts := &Options{}
@@ -2646,7 +2620,6 @@ func TestSublistNoCacheConfig(t *testing.T) {
 	confFileName := createConfFile(t, []byte(`
       disable_sublist_cache: true
     `))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v", err)
@@ -2671,7 +2644,6 @@ func TestSublistNoCacheConfigOnAccounts(t *testing.T) {
 	  }
 	  no_sys_acc = true
     `))
-	defer removeFile(t, confFileName)
 
 	s, _ := RunServerWithConfig(confFileName)
 	defer s.Shutdown()
@@ -2741,54 +2713,42 @@ func TestParsingResponsePermissions(t *testing.T) {
 
 	// Check defaults
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, "", "")))
-	defer removeFile(t, conf)
 	check(t, conf, "", DEFAULT_ALLOW_RESPONSE_MAX_MSGS, DEFAULT_ALLOW_RESPONSE_EXPIRATION)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: 10", "")))
-	defer removeFile(t, conf)
 	check(t, conf, "", 10, DEFAULT_ALLOW_RESPONSE_EXPIRATION)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "", "ttl: 5s")))
-	defer removeFile(t, conf)
 	check(t, conf, "", DEFAULT_ALLOW_RESPONSE_MAX_MSGS, 5*time.Second)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: 0", "")))
-	defer removeFile(t, conf)
 	check(t, conf, "", DEFAULT_ALLOW_RESPONSE_MAX_MSGS, DEFAULT_ALLOW_RESPONSE_EXPIRATION)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "", `ttl: "0s"`)))
-	defer removeFile(t, conf)
 	check(t, conf, "", DEFAULT_ALLOW_RESPONSE_MAX_MSGS, DEFAULT_ALLOW_RESPONSE_EXPIRATION)
 
 	// Check normal values
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: 10", `ttl: "5s"`)))
-	defer removeFile(t, conf)
 	check(t, conf, "", 10, 5*time.Second)
 
 	// Check negative values ok
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: -1", `ttl: "5s"`)))
-	defer removeFile(t, conf)
 	check(t, conf, "", -1, 5*time.Second)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: 10", `ttl: "-1s"`)))
-	defer removeFile(t, conf)
 	check(t, conf, "", 10, -1*time.Second)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: -1", `ttl: "-1s"`)))
-	defer removeFile(t, conf)
 	check(t, conf, "", -1, -1*time.Second)
 
 	// Check parsing errors
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "unknown_field: 123", "")))
-	defer removeFile(t, conf)
 	check(t, conf, "Unknown field", 0, 0)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: 10", "ttl: 123")))
-	defer removeFile(t, conf)
 	check(t, conf, "not a duration string", 0, 0)
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(template, "max: 10", "ttl: xyz")))
-	defer removeFile(t, conf)
 	check(t, conf, "error parsing expires", 0, 0)
 }
 
@@ -2912,7 +2872,6 @@ func TestNoAuthUserCode(t *testing.T) {
 			]
 		}
 	`))
-	defer removeFile(t, confFileName)
 	defer os.Unsetenv("NO_AUTH_USER")
 
 	for _, user := range []string{"a", "b", "b"} {
@@ -2962,7 +2921,6 @@ const operatorJwtWithSysAccAndUrlResolver = `
 
 func TestReadOperatorJWT(t *testing.T) {
 	confFileName := createConfFile(t, []byte(operatorJwtWithSysAccAndUrlResolver))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received unexpected error %s", err)
@@ -2993,7 +2951,6 @@ func TestReadOperatorJWTSystemAccountMatch(t *testing.T) {
 	confFileName := createConfFile(t, []byte(operatorJwtWithSysAccAndMemResolver+`
 		system_account: ADSPOYMHXJN6JVYQCLRZ5XQ5IUN6A3S33XA4NV4VH74423U7U7YR4YVW
 	`))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received unexpected error %s", err)
@@ -3009,7 +2966,6 @@ func TestReadOperatorJWTSystemAccountMismatch(t *testing.T) {
 	confFileName := createConfFile(t, []byte(operatorJwtWithSysAccAndMemResolver+`
 		system_account: ADXJJCDCSRSMCOV25FXQW7R4QOG7R763TVEXBNWJHLBMBGWOJYG5XZBG
 	`))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received unexpected error %s", err)
@@ -3036,7 +2992,6 @@ func TestReadOperatorAssertVersion(t *testing.T) {
 		operator: %s
 		resolver: MEM
 	`, jwt)))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received unexpected error %s", err)
@@ -3061,7 +3016,6 @@ func TestReadOperatorAssertVersionFail(t *testing.T) {
 		operator: %s
 		resolver: MEM
 	`, jwt)))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received unexpected error %s", err)
@@ -3087,7 +3041,6 @@ func TestClusterNameAndGatewayNameConflict(t *testing.T) {
 			listen: 127.0.0.1:-1
 		}
 	`))
-	defer removeFile(t, conf)
 
 	opts, err := ProcessConfigFile(conf)
 	if err != nil {
@@ -3157,7 +3110,6 @@ func TestQueuePermissions(t *testing.T) {
 	} {
 		t.Run(test.permType+test.queue, func(t *testing.T) {
 			confFileName := createConfFile(t, []byte(fmt.Sprintf(cfgFmt, test.permType)))
-			defer removeFile(t, confFileName)
 			opts, err := ProcessConfigFile(confFileName)
 			if err != nil {
 				t.Fatalf("Received unexpected error %s", err)
@@ -3207,18 +3159,13 @@ func TestResolverPinnedAccountsFail(t *testing.T) {
 		resolver: URL(foo.bar)
 		resolver_pinned_accounts: [%s]
 	`
-	dirSrv := createDir(t, "srv")
-	defer removeDir(t, dirSrv)
-
 	conf := createConfFile(t, []byte(fmt.Sprintf(cfgFmt, ojwt, "f")))
-	defer removeFile(t, conf)
 	srv, err := NewServer(LoadConfig(conf))
 	defer srv.Shutdown()
 	require_Error(t, err)
 	require_Contains(t, err.Error(), " is not a valid public account nkey")
 
 	conf = createConfFile(t, []byte(fmt.Sprintf(cfgFmt, ojwt, "1, x")))
-	defer removeFile(t, conf)
 	_, err = ProcessConfigFile(conf)
 	require_Error(t, err)
 	require_Contains(t, "parsing resolver_pinned_accounts: unsupported type")
@@ -3229,7 +3176,6 @@ func TestMaxSubTokens(t *testing.T) {
 		listen: 127.0.0.1:-1
 		max_sub_tokens: 4
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -3351,7 +3297,6 @@ func TestAuthorizationAndAccountsMisconfigurations(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			conf := createConfFile(t, []byte(test.config))
-			defer removeFile(t, conf)
 			if _, err := ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), test.err) {
 				t.Fatalf("Expected error %q, got %q", test.err, err.Error())
 			}

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -66,11 +66,10 @@ func newOptionsFromContent(t *testing.T, content []byte) (*Options, string) {
 
 func createConfFile(t testing.TB, content []byte) string {
 	t.Helper()
-	conf := createFile(t, "")
+	conf := createFileAtDir(t, t.TempDir(), "")
 	fName := conf.Name()
 	conf.Close()
 	if err := os.WriteFile(fName, content, 0666); err != nil {
-		removeFile(t, fName)
 		t.Fatalf("Error writing conf file: %v", err)
 	}
 	return fName
@@ -127,7 +126,6 @@ func TestConfigReloadNoConfigFile(t *testing.T) {
 // does not support reloading.
 func TestConfigReloadUnsupported(t *testing.T) {
 	server, _, config := newServerWithConfig(t, "./configs/reload/test.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	loaded := server.ConfigTime()
@@ -178,7 +176,6 @@ func TestConfigReloadUnsupported(t *testing.T) {
 // server is changed to support change of listen spec).
 func TestConfigReloadUnsupportedHotSwapping(t *testing.T) {
 	server, _, config := newServerWithContent(t, []byte("listen: 127.0.0.1:-1"))
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	loaded := server.ConfigTime()
@@ -201,7 +198,6 @@ func TestConfigReloadUnsupportedHotSwapping(t *testing.T) {
 // Ensure Reload returns an error when reloading from a bad config file.
 func TestConfigReloadInvalidConfig(t *testing.T) {
 	server, _, config := newServerWithConfig(t, "./configs/reload/test.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	loaded := server.ConfigTime()
@@ -250,7 +246,6 @@ func TestConfigReloadInvalidConfig(t *testing.T) {
 // Ensure Reload returns nil and the config is changed on success.
 func TestConfigReload(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/test.conf")
-	defer removeFile(t, config)
 	defer removeFile(t, "nats-server.pid")
 	defer removeFile(t, "nats-server.log")
 	defer server.Shutdown()
@@ -380,7 +375,6 @@ func TestConfigReload(t *testing.T) {
 // ensure reconnect succeeds when the client provides a cert.
 func TestConfigReloadRotateTLS(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/tls_test.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -435,7 +429,6 @@ func TestConfigReloadRotateTLS(t *testing.T) {
 // reconnect fails, then ensure reconnect succeeds when using secure.
 func TestConfigReloadEnableTLS(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/basic.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -467,7 +460,6 @@ func TestConfigReloadEnableTLS(t *testing.T) {
 // without secure.
 func TestConfigReloadDisableTLS(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/tls_test.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -503,7 +495,6 @@ func TestConfigReloadDisableTLS(t *testing.T) {
 // then ensure reconnect succeeds when using the correct credentials.
 func TestConfigReloadRotateUserAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/single_user_authentication_1.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -566,7 +557,6 @@ func TestConfigReloadRotateUserAuthentication(t *testing.T) {
 // ensure reconnect succeeds when using the correct credentials.
 func TestConfigReloadEnableUserAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/basic.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -628,7 +618,6 @@ func TestConfigReloadEnableUserAuthentication(t *testing.T) {
 // with no credentials succeeds.
 func TestConfigReloadDisableUserAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/single_user_authentication_1.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -662,7 +651,6 @@ func TestConfigReloadDisableUserAuthentication(t *testing.T) {
 // ensure reconnect succeeds when using the correct token.
 func TestConfigReloadRotateTokenAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/token_authentication_1.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	disconnected := make(chan struct{})
@@ -720,7 +708,6 @@ func TestConfigReloadRotateTokenAuthentication(t *testing.T) {
 // succeeds when using the correct token.
 func TestConfigReloadEnableTokenAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/basic.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -782,7 +769,6 @@ func TestConfigReloadEnableTokenAuthentication(t *testing.T) {
 // with no token succeeds.
 func TestConfigReloadDisableTokenAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/token_authentication_1.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -816,7 +802,6 @@ func TestConfigReloadDisableTokenAuthentication(t *testing.T) {
 // ensure reconnect succeeds when using the correct credentials.
 func TestConfigReloadRotateUsersAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/multiple_users_1.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -904,7 +889,6 @@ func TestConfigReloadRotateUsersAuthentication(t *testing.T) {
 // succeeds when using the correct credentials.
 func TestConfigReloadEnableUsersAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/basic.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -966,7 +950,6 @@ func TestConfigReloadEnableUsersAuthentication(t *testing.T) {
 // with no credentials succeeds.
 func TestConfigReloadDisableUsersAuthentication(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/multiple_users_1.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -1000,7 +983,6 @@ func TestConfigReloadDisableUsersAuthentication(t *testing.T) {
 // closed and publishes fail, then ensure the new permissions succeed.
 func TestConfigReloadChangePermissions(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/authorization_1.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	addr := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
@@ -1234,7 +1216,6 @@ func TestConfigReloadChangePermissions(t *testing.T) {
 // host.
 func TestConfigReloadClusterHostUnsupported(t *testing.T) {
 	server, _, config := runReloadServerWithConfig(t, "./configs/reload/srv_a_1.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Attempt to change cluster listen host.
@@ -1250,7 +1231,6 @@ func TestConfigReloadClusterHostUnsupported(t *testing.T) {
 // port.
 func TestConfigReloadClusterPortUnsupported(t *testing.T) {
 	server, _, config := runReloadServerWithConfig(t, "./configs/reload/srv_a_1.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Attempt to change cluster listen port.
@@ -1268,11 +1248,9 @@ func TestConfigReloadClusterPortUnsupported(t *testing.T) {
 // longer flow until reloading with the correct credentials.
 func TestConfigReloadEnableClusterAuthorization(t *testing.T) {
 	srvb, srvbOpts, srvbConfig := runReloadServerWithConfig(t, "./configs/reload/srv_b_1.conf")
-	defer removeFile(t, srvbConfig)
 	defer srvb.Shutdown()
 
 	srva, srvaOpts, srvaConfig := runReloadServerWithConfig(t, "./configs/reload/srv_a_1.conf")
-	defer removeFile(t, srvaConfig)
 	defer srva.Shutdown()
 
 	checkClusterFormed(t, srva, srvb)
@@ -1366,11 +1344,9 @@ func TestConfigReloadEnableClusterAuthorization(t *testing.T) {
 // still flow.
 func TestConfigReloadDisableClusterAuthorization(t *testing.T) {
 	srvb, srvbOpts, srvbConfig := runReloadServerWithConfig(t, "./configs/reload/srv_b_2.conf")
-	defer removeFile(t, srvbConfig)
 	defer srvb.Shutdown()
 
-	srva, srvaOpts, srvaConfig := runReloadServerWithConfig(t, "./configs/reload/srv_a_2.conf")
-	defer removeFile(t, srvaConfig)
+	srva, srvaOpts, _ := runReloadServerWithConfig(t, "./configs/reload/srv_a_2.conf")
 	defer srva.Shutdown()
 
 	checkClusterFormed(t, srva, srvb)
@@ -1446,12 +1422,10 @@ func TestConfigReloadDisableClusterAuthorization(t *testing.T) {
 // reloading with a different route and ensuring messages flow through the new
 // cluster.
 func TestConfigReloadClusterRoutes(t *testing.T) {
-	srvb, srvbOpts, srvbConfig := runReloadServerWithConfig(t, "./configs/reload/srv_b_1.conf")
-	defer removeFile(t, srvbConfig)
+	srvb, srvbOpts, _ := runReloadServerWithConfig(t, "./configs/reload/srv_b_1.conf")
 	defer srvb.Shutdown()
 
 	srva, srvaOpts, srvaConfig := runReloadServerWithConfig(t, "./configs/reload/srv_a_1.conf")
-	defer removeFile(t, srvaConfig)
 	defer srva.Shutdown()
 
 	checkClusterFormed(t, srva, srvb)
@@ -1553,7 +1527,6 @@ func TestConfigReloadClusterRemoveSolicitedRoutes(t *testing.T) {
 	defer srvb.Shutdown()
 
 	srva, srvaOpts, srvaConfig := runReloadServerWithConfig(t, "./configs/reload/srv_a_1.conf")
-	defer removeFile(t, srvaConfig)
 	defer srva.Shutdown()
 
 	checkClusterFormed(t, srva, srvb)
@@ -1641,7 +1614,6 @@ func TestConfigReloadClusterAdvertise(t *testing.T) {
 			listen: "0.0.0.0:-1"
 		}
 	`))
-	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	orgClusterPort := s.ClusterAddr().Port
@@ -1713,7 +1685,6 @@ func TestConfigReloadClusterNoAdvertise(t *testing.T) {
 			listen: "0.0.0.0:-1"
 		}
 	`))
-	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	s.mu.Lock()
@@ -1764,7 +1735,6 @@ func TestConfigReloadClusterName(t *testing.T) {
 			listen: "0.0.0.0:-1"
 		}
 	`))
-	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	// Update config with a new cluster name.
@@ -1783,7 +1753,6 @@ func TestConfigReloadClusterName(t *testing.T) {
 
 func TestConfigReloadMaxSubsUnsupported(t *testing.T) {
 	s, _, conf := runReloadServerWithContent(t, []byte(`max_subs: 1`))
-	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	if err := os.WriteFile(conf, []byte(`max_subs: 10`), 0666); err != nil {
@@ -1796,7 +1765,6 @@ func TestConfigReloadMaxSubsUnsupported(t *testing.T) {
 
 func TestConfigReloadClientAdvertise(t *testing.T) {
 	s, _, conf := runReloadServerWithContent(t, []byte(`listen: "0.0.0.0:-1"`))
-	defer removeFile(t, conf)
 	defer s.Shutdown()
 
 	orgPort := s.Addr().(*net.TCPAddr).Port
@@ -1843,7 +1811,6 @@ func TestConfigReloadClientAdvertise(t *testing.T) {
 // max connections of one, and ensuring one client is disconnected.
 func TestConfigReloadMaxConnections(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/basic.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Make two connections.
@@ -1898,7 +1865,6 @@ func TestConfigReloadMaxConnections(t *testing.T) {
 // and disconnects the client.
 func TestConfigReloadMaxPayload(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/basic.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	addr := fmt.Sprintf("nats://%s:%d", opts.Host, server.Addr().(*net.TCPAddr).Port)
@@ -2016,7 +1982,6 @@ func TestConfigReloadClusterWorks(t *testing.T) {
 			]
 		}`
 	confB := createConfFile(t, []byte(fmt.Sprintf(confBTemplate, 3)))
-	defer removeFile(t, confB)
 
 	confATemplate := `
 		listen: -1
@@ -2032,7 +1997,6 @@ func TestConfigReloadClusterWorks(t *testing.T) {
 			]
 		}`
 	confA := createConfFile(t, []byte(fmt.Sprintf(confATemplate, 3)))
-	defer removeFile(t, confA)
 
 	srvb, _ := RunServerWithConfig(confB)
 	defer srvb.Shutdown()
@@ -2094,7 +2058,6 @@ func TestConfigReloadClusterPerms(t *testing.T) {
 		no_sys_acc: true
 	`
 	confA := createConfFile(t, []byte(fmt.Sprintf(confATemplate, `"foo"`, `"foo"`)))
-	defer removeFile(t, confA)
 	srva, _ := RunServerWithConfig(confA)
 	defer srva.Shutdown()
 
@@ -2117,7 +2080,6 @@ func TestConfigReloadClusterPerms(t *testing.T) {
 		no_sys_acc: true
 	`
 	confB := createConfFile(t, []byte(fmt.Sprintf(confBTemplate, `"foo"`, `"foo"`, srva.ClusterAddr().Port)))
-	defer removeFile(t, confB)
 	srvb, _ := RunServerWithConfig(confB)
 	defer srvb.Shutdown()
 
@@ -2292,7 +2254,6 @@ func TestConfigReloadClusterPermsImport(t *testing.T) {
 		no_sys_acc: true
 	`
 	confA := createConfFile(t, []byte(fmt.Sprintf(confATemplate, `["foo", "bar"]`)))
-	defer removeFile(t, confA)
 	srva, _ := RunServerWithConfig(confA)
 	defer srva.Shutdown()
 
@@ -2307,7 +2268,6 @@ func TestConfigReloadClusterPermsImport(t *testing.T) {
 		no_sys_acc: true
 	`
 	confB := createConfFile(t, []byte(fmt.Sprintf(confBTemplate, srva.ClusterAddr().Port)))
-	defer removeFile(t, confB)
 	srvb, _ := RunServerWithConfig(confB)
 	defer srvb.Shutdown()
 
@@ -2389,7 +2349,6 @@ func TestConfigReloadClusterPermsExport(t *testing.T) {
 		no_sys_acc: true
 	`
 	confA := createConfFile(t, []byte(fmt.Sprintf(confATemplate, `["foo", "bar"]`)))
-	defer removeFile(t, confA)
 	srva, _ := RunServerWithConfig(confA)
 	defer srva.Shutdown()
 
@@ -2404,7 +2363,6 @@ func TestConfigReloadClusterPermsExport(t *testing.T) {
 		no_sys_acc: true
 	`
 	confB := createConfFile(t, []byte(fmt.Sprintf(confBTemplate, srva.ClusterAddr().Port)))
-	defer removeFile(t, confB)
 	srvb, _ := RunServerWithConfig(confB)
 	defer srvb.Shutdown()
 
@@ -2485,7 +2443,6 @@ func TestConfigReloadClusterPermsOldServer(t *testing.T) {
 		}
 	`
 	confA := createConfFile(t, []byte(fmt.Sprintf(confATemplate, `["foo", "bar"]`)))
-	defer removeFile(t, confA)
 	srva, _ := RunServerWithConfig(confA)
 	defer srva.Shutdown()
 
@@ -2571,7 +2528,6 @@ func TestConfigReloadAccountUsers(t *testing.T) {
 		}
 	}
 	`))
-	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -2756,7 +2712,6 @@ func TestConfigReloadAccountNKeyUsers(t *testing.T) {
 		}
 	}
 	`))
-	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -2902,7 +2857,6 @@ func TestConfigReloadAccountStreamsImportExport(t *testing.T) {
 	// nats.io account imports "foo.*" from synadia
 	// nats.io account imports "private.natsio.*" from synadia with prefix "ivan"
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, `"foo.*"`, `"xxx"`, `"foo.*"`, `"ivan"`)))
-	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -3093,7 +3047,6 @@ func TestConfigReloadAccountServicesImportExport(t *testing.T) {
 		port: -1
 	}
 	`))
-	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -3244,7 +3197,6 @@ func TestConfigReloadNotPreventedByGateways(t *testing.T) {
 		no_sys_acc: true
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(confTemplate, "", "5")))
-	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -3647,7 +3599,6 @@ func TestConfigReloadBoolFlags(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			conf := createConfFile(t, []byte(fmt.Sprintf(template, test.content)))
-			defer removeFile(t, conf)
 
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			var args []string
@@ -3678,7 +3629,6 @@ func TestConfigReloadBoolFlags(t *testing.T) {
 
 func TestConfigReloadMaxControlLineWithClients(t *testing.T) {
 	server, opts, config := runReloadServerWithConfig(t, "./configs/reload/basic.conf")
-	defer removeFile(t, config)
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
@@ -3729,7 +3679,6 @@ func TestConfigReloadIgnoreCustomAuth(t *testing.T) {
 	conf := createConfFile(t, []byte(`
 		port: -1
 	`))
-	defer removeFile(t, conf)
 	opts := LoadConfig(conf)
 
 	ca := &testCustomAuth{}
@@ -3755,7 +3704,6 @@ func TestConfigReloadLeafNodeRandomPort(t *testing.T) {
 			port: -1
 		}
 	`))
-	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -3791,7 +3739,6 @@ func TestConfigReloadLeafNodeWithTLS(t *testing.T) {
 		}
 	`
 	conf1 := createConfFile(t, []byte(fmt.Sprintf(template, "")))
-	defer removeFile(t, conf1)
 	s1, o1 := RunServerWithConfig(conf1)
 	defer s1.Shutdown()
 
@@ -3815,7 +3762,6 @@ func TestConfigReloadLeafNodeWithTLS(t *testing.T) {
 			]
 		}
 	`, u.String())))
-	defer removeFile(t, conf2)
 	o2, err := ProcessConfigFile(conf2)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -3863,7 +3809,6 @@ func TestConfigReloadLeafNodeWithRemotesNoChanges(t *testing.T) {
 	`
 	config := fmt.Sprintf(template, "A")
 	conf := createConfFile(t, []byte(config))
-	defer removeFile(t, conf)
 	o, err := ProcessConfigFile(conf)
 	if err != nil {
 		t.Fatalf("Error processing config file: %v", err)
@@ -3886,7 +3831,6 @@ func TestConfigReloadAndVarz(t *testing.T) {
 		%s
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, "")))
-	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -3927,7 +3871,6 @@ func TestConfigReloadConnectErrReports(t *testing.T) {
 		%s
 	`
 	conf := createConfFile(t, []byte(fmt.Sprintf(template, "", "")))
-	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -4071,7 +4014,6 @@ func TestConfigReloadAccountResolverTLSConfig(t *testing.T) {
 			ca_file: "../test/configs/certs/ca.pem"
 		}
 	`)))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -4158,7 +4100,6 @@ func TestLoggingReload(t *testing.T) {
 	`
 
 	conf := createConfFile(t, []byte(commonCfg))
-	defer removeFile(t, conf)
 
 	defer removeFile(t, "off-pre.log")
 	defer removeFile(t, "on.log")
@@ -4244,7 +4185,6 @@ func TestReloadValidate(t *testing.T) {
 			]
 		}
 	`))
-	defer removeFile(t, confFileName)
 	srv, _ := RunServerWithConfig(confFileName)
 	if srv == nil {
 		t.Fatal("Server did not start")
@@ -4289,7 +4229,6 @@ func TestConfigReloadAccounts(t *testing.T) {
 		}
 	}
 	`))
-	defer removeFile(t, conf)
 	s, o := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -4432,7 +4371,6 @@ func TestConfigReloadDefaultSystemAccount(t *testing.T) {
 		}
 	}
 	`))
-	defer removeFile(t, conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -4484,7 +4422,6 @@ func TestConfigReloadAccountMappings(t *testing.T) {
 		}
 	}
 	`))
-	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -4545,7 +4482,6 @@ func TestConfigReloadWithSysAccountOnly(t *testing.T) {
 			}
 		}
 	`))
-	defer os.Remove(conf)
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1448,8 +1448,7 @@ func TestTLSRoutesCertificateImplicitAllowFail(t *testing.T) {
 
 func testTLSRoutesCertificateImplicitAllow(t *testing.T, pass bool) {
 	// Base config for the servers
-	cfg := createFile(t, "cfg")
-	defer removeFile(t, cfg.Name())
+	cfg := createFileAtDir(t, t.TempDir(), "cfg")
 	cfg.WriteString(fmt.Sprintf(`
 		cluster {
 		  tls {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1603,10 +1603,9 @@ func TestConnectErrorReports(t *testing.T) {
 		t.Fatalf("Expected default value to be %v, got %v", DEFAULT_CONNECT_ERROR_REPORTS, ra)
 	}
 
-	tmpFile := createFile(t, "")
+	tmpFile := createFileAtDir(t, t.TempDir(), "")
 	log := tmpFile.Name()
 	tmpFile.Close()
-	defer removeFile(t, log)
 
 	remoteURLs := RoutesFromStr("nats://127.0.0.1:1234")
 
@@ -1755,10 +1754,9 @@ func TestReconnectErrorReports(t *testing.T) {
 		t.Fatalf("Expected default value to be %v, got %v", DEFAULT_RECONNECT_ERROR_REPORTS, ra)
 	}
 
-	tmpFile := createFile(t, "")
+	tmpFile := createFileAtDir(t, t.TempDir(), "")
 	log := tmpFile.Name()
 	tmpFile.Close()
-	defer removeFile(t, log)
 
 	csOpts := DefaultOptions()
 	csOpts.Cluster.Port = -1
@@ -1941,17 +1939,13 @@ func TestReconnectErrorReports(t *testing.T) {
 }
 
 func TestServerLogsConfigurationFile(t *testing.T) {
-	tmpDir := createDir(t, "_nats-server")
-	defer removeDir(t, tmpDir)
-
-	file := createFileAtDir(t, tmpDir, "nats_server_log_")
+	file := createFileAtDir(t, t.TempDir(), "nats_server_log_")
 	file.Close()
 
 	conf := createConfFile(t, []byte(fmt.Sprintf(`
 	port: -1
 	logfile: '%s'
 	`, file.Name())))
-	defer removeFile(t, conf)
 
 	o := LoadConfig(conf)
 	o.ConfigFile = file.Name()

--- a/server/signal_test.go
+++ b/server/signal_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
@@ -31,9 +32,7 @@ import (
 )
 
 func TestSignalToReOpenLogFile(t *testing.T) {
-	logFile := "test.log"
-	defer removeFile(t, logFile)
-	defer removeFile(t, logFile+".bak")
+	logFile := filepath.Join(t.TempDir(), "test.log")
 	opts := &Options{
 		Host:    "127.0.0.1",
 		Port:    -1,

--- a/server/trust_test.go
+++ b/server/trust_test.go
@@ -84,7 +84,6 @@ func TestTrustedKeysOptions(t *testing.T) {
 
 func TestTrustConfigOption(t *testing.T) {
 	confFileName := createConfFile(t, []byte(fmt.Sprintf("trusted = %q", t1)))
-	defer removeFile(t, confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Error parsing config: %v", err)
@@ -97,7 +96,6 @@ func TestTrustConfigOption(t *testing.T) {
 	}
 
 	confFileName = createConfFile(t, []byte(fmt.Sprintf("trusted = [%q, %q]", t1, t2)))
-	defer removeFile(t, confFileName)
 	opts, err = ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Error parsing config: %v", err)
@@ -114,7 +112,6 @@ func TestTrustConfigOption(t *testing.T) {
 
 	// Now do a bad one.
 	confFileName = createConfFile(t, []byte(fmt.Sprintf("trusted = [%q, %q]", t1, "bad")))
-	defer removeFile(t, confFileName)
 	_, err = ProcessConfigFile(confFileName)
 	if err == nil {
 		t.Fatalf("Expected an error parsing trust keys with a bad key")

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -1609,7 +1609,6 @@ func TestWSParseOptions(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			conf := createConfFile(t, []byte(test.content))
-			defer removeFile(t, conf)
 			o, err := ProcessConfigFile(conf)
 			if test.err != _EMPTY_ {
 				if err == nil || !strings.Contains(err.Error(), test.err) {
@@ -3393,7 +3392,6 @@ func TestWSBindToProperAccount(t *testing.T) {
 			no_tls: true
 		}
 	`, jwt.ConnectionTypeStandard, strings.ToLower(jwt.ConnectionTypeWebsocket)))) // on purpose use lower case to ensure that it is converted.
-	defer removeFile(t, conf)
 	s, o := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -3866,7 +3864,6 @@ func TestWSReloadTLSConfig(t *testing.T) {
 	conf := createConfFile(t, []byte(fmt.Sprintf(template,
 		"../test/configs/certs/server-noip.pem",
 		"../test/configs/certs/server-key-noip.pem")))
-	defer removeFile(t, conf)
 
 	s, o := RunServerWithConfig(conf)
 	defer s.Shutdown()

--- a/test/accounts_cycles_test.go
+++ b/test/accounts_cycles_test.go
@@ -37,7 +37,6 @@ func TestAccountCycleService(t *testing.T) {
 		  }
 		}
 	`))
-	defer removeFile(t, conf)
 
 	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), server.ErrImportFormsCycle.Error()) {
 		t.Fatalf("Expected an error on cycle service import, got none")
@@ -55,7 +54,6 @@ func TestAccountCycleService(t *testing.T) {
 		  }
 		}
 	`))
-	defer removeFile(t, conf)
 
 	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), server.ErrImportFormsCycle.Error()) {
 		t.Fatalf("Expected an error on cycle service import, got none")
@@ -77,7 +75,6 @@ func TestAccountCycleService(t *testing.T) {
 		  }
 		}
 	`))
-	defer removeFile(t, conf)
 
 	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), server.ErrImportFormsCycle.Error()) {
 		t.Fatalf("Expected an error on cycle service import, got none")
@@ -97,7 +94,6 @@ func TestAccountCycleStream(t *testing.T) {
 		  }
 		}
 	`))
-	defer removeFile(t, conf)
 	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), server.ErrImportFormsCycle.Error()) {
 		t.Fatalf("Expected an error on cyclic import, got none")
 	}
@@ -116,7 +112,6 @@ func TestAccountCycleStreamWithMapping(t *testing.T) {
 		  }
 		}
 	`))
-	defer removeFile(t, conf)
 	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), server.ErrImportFormsCycle.Error()) {
 		t.Fatalf("Expected an error on cyclic import, got none")
 	}
@@ -139,7 +134,6 @@ func TestAccountCycleNonCycleStreamWithMapping(t *testing.T) {
 		  }
 		}
 	`))
-	defer removeFile(t, conf)
 	if _, err := server.ProcessConfigFile(conf); err != nil {
 		t.Fatalf("Expected no error but got %s", err)
 	}
@@ -158,7 +152,6 @@ func TestAccountCycleServiceCycleWithMapping(t *testing.T) {
 		  }
 		}
 	`))
-	defer removeFile(t, conf)
 	if _, err := server.ProcessConfigFile(conf); err == nil || !strings.Contains(err.Error(), server.ErrImportFormsCycle.Error()) {
 		t.Fatalf("Expected an error on cycle service import, got none")
 	}
@@ -181,7 +174,6 @@ func TestAccountCycleServiceNonCycle(t *testing.T) {
 		  }
 		}
 	`))
-	defer removeFile(t, conf)
 
 	if _, err := server.ProcessConfigFile(conf); err != nil {
 		t.Fatalf("Expected no error but got %s", err)
@@ -208,7 +200,6 @@ func TestAccountCycleServiceNonCycleChain(t *testing.T) {
 		  }
 		}
 	`))
-	defer removeFile(t, conf)
 
 	if _, err := server.ProcessConfigFile(conf); err != nil {
 		t.Fatalf("Expected no error but got %s", err)
@@ -231,7 +222,6 @@ func TestServiceImportReplyMatchCycle(t *testing.T) {
 		}
 		no_auth_user: d
 	`))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -275,7 +265,6 @@ func TestServiceImportReplyMatchCycleMultiHops(t *testing.T) {
 		}
 		no_auth_user: d
 	`))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -360,7 +349,6 @@ func TestAccountSubjectMapping(t *testing.T) {
     		"foo.*.*" : "foo.$1.{{wildcard(2)}}.{{partition(10,1,2)}}"
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -443,7 +431,6 @@ func TestAccountImportSubjectMapping(t *testing.T) {
 		  }
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 

--- a/test/client_auth_test.go
+++ b/test/client_auth_test.go
@@ -15,7 +15,6 @@ package test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/nats-io/nats.go"
@@ -65,18 +64,14 @@ func TestMultipleUserAuth(t *testing.T) {
 const testToken = "$2a$05$3sSWEVA1eMCbV0hWavDjXOx.ClBjI6u1CuUdLqf22cbJjXsnzz8/."
 
 func TestTokenInConfig(t *testing.T) {
-	confFileName := "test.conf"
-	defer removeFile(t, confFileName)
-	content := `
+	content := []byte(`
 	listen: 127.0.0.1:4567
 	authorization={
 		token: ` + testToken + `
 		timeout: 5
-	}`
-	if err := os.WriteFile(confFileName, []byte(content), 0666); err != nil {
-		t.Fatalf("Error writing config file: %v", err)
-	}
-	s, opts := RunServerWithConfig(confFileName)
+	}`)
+	conf := createConfFile(t, content)
+	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
 	url := fmt.Sprintf("nats://test@%s:%d/", opts.Host, opts.Port)

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -542,7 +542,6 @@ func TestClusterNameOption(t *testing.T) {
 			listen: 127.0.0.1:-1
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -563,7 +562,6 @@ func TestEphemeralClusterName(t *testing.T) {
 			listen: 127.0.0.1:-1
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -600,7 +598,6 @@ func TestClusterNameConflictsDropRoutes(t *testing.T) {
 			listen: 127.0.0.1:5244
 		}
 	`))
-	defer removeFile(t, conf)
 
 	s1, _ := RunServerWithConfig(conf)
 	defer s1.Shutdown()
@@ -614,7 +611,6 @@ func TestClusterNameConflictsDropRoutes(t *testing.T) {
 			routes = [nats-route://127.0.0.1:5244]
 		}
 	`))
-	defer removeFile(t, conf2)
 
 	s2, _ := RunServerWithConfig(conf2)
 	defer s2.Shutdown()
@@ -635,7 +631,6 @@ func TestClusterNameDynamicNegotiation(t *testing.T) {
 		listen: 127.0.0.1:-1
 		cluster {listen: 127.0.0.1:5244}
 	`))
-	defer removeFile(t, conf)
 
 	seed, _ := RunServerWithConfig(conf)
 	defer seed.Shutdown()
@@ -647,7 +642,6 @@ func TestClusterNameDynamicNegotiation(t *testing.T) {
 			routes = [nats-route://127.0.0.1:5244]
 		}
 	`))
-	defer removeFile(t, oconf)
 
 	// Create a random number of additional servers, up to 20.
 	numServers := rand.Intn(20) + 1

--- a/test/gateway_test.go
+++ b/test/gateway_test.go
@@ -621,7 +621,6 @@ func TestGatewayTLSMixedIPAndDNS(t *testing.T) {
 			listen: "127.0.0.1:-1"
 		}
 	`))
-	defer removeFile(t, confA1)
 	srvA1, optsA1 := RunServerWithConfig(confA1)
 	defer srvA1.Shutdown()
 
@@ -646,7 +645,6 @@ func TestGatewayTLSMixedIPAndDNS(t *testing.T) {
 	`
 	confA2 := createConfFile(t, []byte(fmt.Sprintf(confA2Template,
 		optsA1.Cluster.Host, optsA1.Cluster.Port)))
-	defer removeFile(t, confA2)
 	srvA2, optsA2 := RunServerWithConfig(confA2)
 	defer srvA2.Shutdown()
 

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -1138,7 +1138,6 @@ func TestLeafNodeBasicAuth(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -1205,7 +1204,6 @@ func TestLeafNodeTLS(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -1244,7 +1242,6 @@ func TestLeafNodeTLSConnCloseEarly(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -1293,7 +1290,6 @@ func TestLeafNodeTLSMixIP(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -1311,7 +1307,6 @@ func TestLeafNodeTLSMixIP(t *testing.T) {
 	}
 	`
 	slconf := createConfFile(t, []byte(fmt.Sprintf(slContent, opts.LeafNode.Port, opts.LeafNode.Port)))
-	defer removeFile(t, slconf)
 
 	// This will fail but we want to make sure in the correct way, not with
 	// TLS issue because we used an IP for serverName.
@@ -1387,8 +1382,7 @@ func runSolicitWithCredentials(t *testing.T, opts *server.Options, creds string)
 }
 
 func TestLeafNodeOperatorModel(t *testing.T) {
-	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer removeFile(t, conf)
+	s, opts, _ := runLeafNodeOperatorServer(t)
 	defer s.Shutdown()
 
 	// Make sure we get disconnected without proper credentials etc.
@@ -1415,18 +1409,15 @@ func TestLeafNodeOperatorModel(t *testing.T) {
 	}
 	seed, _ := kp.Seed()
 	mycreds := genCredsFile(t, ujwt, seed)
-	defer removeFile(t, mycreds)
 
-	sl, _, lnconf := runSolicitWithCredentials(t, opts, mycreds)
-	defer removeFile(t, lnconf)
+	sl, _, _ := runSolicitWithCredentials(t, opts, mycreds)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, s)
 }
 
 func TestLeafNodeUserPermsForConnection(t *testing.T) {
-	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer removeFile(t, conf)
+	s, opts, _ := runLeafNodeOperatorServer(t)
 	defer s.Shutdown()
 
 	// Setup account and a user that will be used by the remote leaf node server.
@@ -1446,7 +1437,6 @@ func TestLeafNodeUserPermsForConnection(t *testing.T) {
 	}
 	seed, _ := kp.Seed()
 	mycreds := genCredsFile(t, ujwt, seed)
-	defer removeFile(t, mycreds)
 
 	content := `
 		port: -1
@@ -1463,7 +1453,6 @@ func TestLeafNodeUserPermsForConnection(t *testing.T) {
 		`
 	config := fmt.Sprintf(content, opts.LeafNode.Port, mycreds)
 	lnconf := createConfFile(t, []byte(config))
-	defer removeFile(t, lnconf)
 	sl, _ := RunServerWithConfig(lnconf)
 	defer sl.Shutdown()
 
@@ -1524,8 +1513,7 @@ func TestLeafNodeUserPermsForConnection(t *testing.T) {
 func TestLeafNodeMultipleAccounts(t *testing.T) {
 	// So we will create a main server with two accounts. The remote server, acting as a leaf node, will simply have
 	// the $G global account and no auth. Make sure things work properly here.
-	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer removeFile(t, conf)
+	s, opts, _ := runLeafNodeOperatorServer(t)
 	defer s.Shutdown()
 
 	// Setup the two accounts for this server.
@@ -1544,10 +1532,8 @@ func TestLeafNodeMultipleAccounts(t *testing.T) {
 	// Create the leaf node server using the first account.
 	seed, _ := kp1.Seed()
 	mycreds := genCredsFile(t, ujwt1, seed)
-	defer removeFile(t, mycreds)
 
-	sl, lopts, lnconf := runSolicitWithCredentials(t, opts, mycreds)
-	defer removeFile(t, lnconf)
+	sl, lopts, _ := runSolicitWithCredentials(t, opts, mycreds)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, s)
@@ -1586,8 +1572,7 @@ func TestLeafNodeMultipleAccounts(t *testing.T) {
 }
 
 func TestLeafNodeOperatorAndPermissions(t *testing.T) {
-	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer os.Remove(conf)
+	s, opts, _ := runLeafNodeOperatorServer(t)
 	defer s.Shutdown()
 
 	acc, akp := createAccount(t, s)
@@ -1602,7 +1587,6 @@ func TestLeafNodeOperatorAndPermissions(t *testing.T) {
 	}
 	seed, _ := kp.Seed()
 	srvcreds := genCredsFile(t, srvujwt, seed)
-	defer os.Remove(srvcreds)
 
 	// Create connection for SRV
 	srvnc, err := nats.Connect(s.ClientURL(), nats.UserCredentials(srvcreds))
@@ -1635,7 +1619,6 @@ func TestLeafNodeOperatorAndPermissions(t *testing.T) {
 		t.Fatalf("Error generating user JWT: %v", err)
 	}
 	leafcreds := genCredsFile(t, leafujwt, seed)
-	defer os.Remove(leafcreds)
 
 	content := `
 		port: -1
@@ -1651,7 +1634,6 @@ func TestLeafNodeOperatorAndPermissions(t *testing.T) {
 		`
 	config := fmt.Sprintf(content, opts.LeafNode.Port, leafcreds)
 	lnconf := createConfFile(t, []byte(config))
-	defer os.Remove(lnconf)
 	sl, _ := RunServerWithConfig(lnconf)
 	defer sl.Shutdown()
 
@@ -1736,8 +1718,7 @@ func TestLeafNodeOperatorAndPermissions(t *testing.T) {
 }
 
 func TestLeafNodeSignerUser(t *testing.T) {
-	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer removeFile(t, conf)
+	s, opts, _ := runLeafNodeOperatorServer(t)
 	defer s.Shutdown()
 
 	// Setup the two accounts for this server.
@@ -1802,10 +1783,8 @@ func TestLeafNodeSignerUser(t *testing.T) {
 	// Create the leaf node server using the first account.
 	seed, _ := kp1.Seed()
 	mycreds := genCredsFile(t, ujwt1, seed)
-	defer removeFile(t, mycreds)
 
-	sl, _, lnconf := runSolicitWithCredentials(t, opts, mycreds)
-	defer removeFile(t, lnconf)
+	sl, _, _ := runSolicitWithCredentials(t, opts, mycreds)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, s)
@@ -1814,8 +1793,7 @@ func TestLeafNodeSignerUser(t *testing.T) {
 func TestLeafNodeExportsImports(t *testing.T) {
 	// So we will create a main server with two accounts. The remote server, acting as a leaf node, will simply have
 	// the $G global account and no auth. Make sure things work properly here.
-	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer removeFile(t, conf)
+	s, opts, _ := runLeafNodeOperatorServer(t)
 	defer s.Shutdown()
 
 	// Setup the two accounts for this server.
@@ -1866,10 +1844,8 @@ func TestLeafNodeExportsImports(t *testing.T) {
 	// Create the leaf node server using the first account.
 	seed, _ := kp1.Seed()
 	mycreds := genCredsFile(t, ujwt1, seed)
-	defer removeFile(t, mycreds)
 
-	sl, lopts, lnconf := runSolicitWithCredentials(t, opts, mycreds)
-	defer removeFile(t, lnconf)
+	sl, lopts, _ := runSolicitWithCredentials(t, opts, mycreds)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, s)
@@ -1940,7 +1916,6 @@ func TestLeafNodeExportImportComplexSetup(t *testing.T) {
 	}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 	s1, s1Opts := RunServerWithConfig(conf)
 	defer s1.Shutdown()
 
@@ -2025,10 +2000,8 @@ func TestLeafNodeExportImportComplexSetup(t *testing.T) {
 	// Create the leaf node server using the first account.
 	seed, _ := kp1.Seed()
 	mycreds := genCredsFile(t, ujwt1, seed)
-	defer removeFile(t, mycreds)
 
-	sl, lopts, lnconf := runSolicitWithCredentials(t, s1Opts, mycreds)
-	defer removeFile(t, lnconf)
+	sl, lopts, _ := runSolicitWithCredentials(t, s1Opts, mycreds)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, s1)
@@ -2361,8 +2334,7 @@ func TestLeafNodeAdvertise(t *testing.T) {
 }
 
 func TestLeafNodeConnectionLimitsSingleServer(t *testing.T) {
-	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer removeFile(t, conf)
+	s, opts, _ := runLeafNodeOperatorServer(t)
 	defer s.Shutdown()
 
 	// Setup account and a user that will be used by the remote leaf node server.
@@ -2392,7 +2364,6 @@ func TestLeafNodeConnectionLimitsSingleServer(t *testing.T) {
 	}
 	seed, _ := kp.Seed()
 	mycreds := genCredsFile(t, ujwt, seed)
-	defer removeFile(t, mycreds)
 
 	checkAccConnectionCounts := func(t *testing.T, expected int) {
 		t.Helper()
@@ -2419,8 +2390,7 @@ func TestLeafNodeConnectionLimitsSingleServer(t *testing.T) {
 		})
 	}
 
-	sl, _, lnconf := runSolicitWithCredentials(t, opts, mycreds)
-	defer removeFile(t, lnconf)
+	sl, _, _ := runSolicitWithCredentials(t, opts, mycreds)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnections(t, s, 1)
@@ -2432,8 +2402,7 @@ func TestLeafNodeConnectionLimitsSingleServer(t *testing.T) {
 		t.Fatalf("Expected 1 for total connections, got %d", nc)
 	}
 
-	s2, _, lnconf2 := runSolicitWithCredentials(t, opts, mycreds)
-	defer removeFile(t, lnconf2)
+	s2, _, _ := runSolicitWithCredentials(t, opts, mycreds)
 	defer s2.Shutdown()
 	checkLeafNodeConnections(t, s, 2)
 	checkAccConnectionCounts(t, 2)
@@ -2450,16 +2419,14 @@ func TestLeafNodeConnectionLimitsSingleServer(t *testing.T) {
 	}
 
 	// Now add back the second one as #3.
-	s3, _, lnconf3 := runSolicitWithCredentials(t, opts, mycreds)
-	defer removeFile(t, lnconf3)
+	s3, _, _ := runSolicitWithCredentials(t, opts, mycreds)
 	defer s3.Shutdown()
 	checkLeafNodeConnections(t, s, 2)
 
 	checkAccConnectionCounts(t, 2)
 
 	// Once we are here we should not be able to create anymore. Limit == 2.
-	s4, _, lnconf4 := runSolicitWithCredentials(t, opts, mycreds)
-	defer removeFile(t, lnconf4)
+	s4, _, _ := runSolicitWithCredentials(t, opts, mycreds)
 	defer s4.Shutdown()
 
 	checkAccConnectionCounts(t, 2)
@@ -2496,7 +2463,6 @@ func TestLeafNodeConnectionLimitsCluster(t *testing.T) {
     }
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 	s1, s1Opts := RunServerWithConfig(conf)
 	defer s1.Shutdown()
 
@@ -2563,18 +2529,15 @@ func TestLeafNodeConnectionLimitsCluster(t *testing.T) {
 	}
 	seed, _ := kp.Seed()
 	mycreds := genCredsFile(t, ujwt, seed)
-	defer removeFile(t, mycreds)
 
 	loop := maxleafs / 2
 
 	// Now create maxleafs/2 leaf node servers on each operator server.
 	for i := 0; i < loop; i++ {
-		sl1, _, lnconf1 := runSolicitWithCredentials(t, s1Opts, mycreds)
-		defer removeFile(t, lnconf1)
+		sl1, _, _ := runSolicitWithCredentials(t, s1Opts, mycreds)
 		defer sl1.Shutdown()
 
-		sl2, _, lnconf2 := runSolicitWithCredentials(t, s2Opts, mycreds)
-		defer removeFile(t, lnconf2)
+		sl2, _, _ := runSolicitWithCredentials(t, s2Opts, mycreds)
 		defer sl2.Shutdown()
 	}
 
@@ -2604,16 +2567,14 @@ func TestLeafNodeConnectionLimitsCluster(t *testing.T) {
 	checkAccLFCount(acc2, true, loop)
 
 	// Now that we are here we should not be allowed anymore leaf nodes.
-	l, _, lnconf := runSolicitWithCredentials(t, s1Opts, mycreds)
-	defer removeFile(t, lnconf)
+	l, _, _ := runSolicitWithCredentials(t, s1Opts, mycreds)
 	defer l.Shutdown()
 
 	checkAccLFCount(acc, false, maxleafs)
 	// Should still be at loop size.
 	checkLeafNodeConnections(t, s1, loop)
 
-	l, _, lnconf = runSolicitWithCredentials(t, s2Opts, mycreds)
-	defer removeFile(t, lnconf)
+	l, _, _ = runSolicitWithCredentials(t, s2Opts, mycreds)
 	defer l.Shutdown()
 	checkAccLFCount(acc2, false, maxleafs)
 	// Should still be at loop size.
@@ -2856,8 +2817,7 @@ func TestLeafNodeServiceImportResponderOnLeaf(t *testing.T) {
 }
 
 func TestLeafNodeSendsAccountingEvents(t *testing.T) {
-	s, opts, conf := runLeafNodeOperatorServer(t)
-	defer removeFile(t, conf)
+	s, opts, _ := runLeafNodeOperatorServer(t)
 	defer s.Shutdown()
 
 	// System account
@@ -2892,10 +2852,8 @@ func TestLeafNodeSendsAccountingEvents(t *testing.T) {
 	}
 	seed, _ := kp.Seed()
 	mycreds := genCredsFile(t, ujwt, seed)
-	defer removeFile(t, mycreds)
 
-	sl, _, lnconf := runSolicitWithCredentials(t, opts, mycreds)
-	defer removeFile(t, lnconf)
+	sl, _, _ := runSolicitWithCredentials(t, opts, mycreds)
 	defer sl.Shutdown()
 
 	// Wait for connect event
@@ -3113,7 +3071,6 @@ func TestLeafNodeDefaultPort(t *testing.T) {
 			]
 		}
 	`))
-	defer removeFile(t, conf)
 
 	sl, _ := RunServerWithConfig(conf)
 	defer sl.Shutdown()
@@ -3257,7 +3214,6 @@ func TestLeafNodeMultipleRemoteURLs(t *testing.T) {
 	config := fmt.Sprintf(content, opts.LeafNode.Port, opts.LeafNode.Port)
 	conf := createConfFile(t, []byte(config))
 	sl, _ := RunServerWithConfig(conf)
-	defer removeFile(t, conf)
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, s)
@@ -3705,7 +3661,6 @@ func TestServiceExportWithMultipleAccounts(t *testing.T) {
 			listen: "127.0.0.1:-1"
 		}
 	`))
-	defer removeFile(t, confA)
 
 	srvA, optsA := RunServerWithConfig(confA)
 	defer srvA.Shutdown()
@@ -3746,7 +3701,6 @@ func TestServiceExportWithMultipleAccounts(t *testing.T) {
 	`
 
 	confB := createConfFile(t, []byte(fmt.Sprintf(bConfigTemplate, optsA.LeafNode.Port)))
-	defer removeFile(t, confB)
 
 	srvB, optsB := RunServerWithConfig(confB)
 	defer srvB.Shutdown()
@@ -3826,7 +3780,6 @@ func TestServiceExportWithLeafnodeRestart(t *testing.T) {
 		    }
 		}
 	`))
-	defer removeFile(t, confG)
 
 	srvG, optsG := RunServerWithConfig(confG)
 	defer srvG.Shutdown()
@@ -3877,7 +3830,6 @@ func TestServiceExportWithLeafnodeRestart(t *testing.T) {
 	`
 
 	confE := createConfFile(t, []byte(fmt.Sprintf(eConfigTemplate, optsG.LeafNode.Port)))
-	defer removeFile(t, confE)
 
 	srvE, optsE := RunServerWithConfig(confE)
 	defer srvE.Shutdown()
@@ -4006,7 +3958,6 @@ func TestLeafNodeOriginClusterSingleHub(t *testing.T) {
 	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
 	`
 	lconf1 := createConfFile(t, []byte(fmt.Sprintf(c1, opts.LeafNode.Port)))
-	defer removeFile(t, lconf1)
 
 	ln1, lopts1 := RunServerWithConfig(lconf1)
 	defer ln1.Shutdown()
@@ -4017,7 +3968,6 @@ func TestLeafNodeOriginClusterSingleHub(t *testing.T) {
 	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
 	`
 	lconf2 := createConfFile(t, []byte(fmt.Sprintf(c2, lopts1.Cluster.Port, opts.LeafNode.Port)))
-	defer removeFile(t, lconf2)
 
 	ln2, _ := RunServerWithConfig(lconf2)
 	defer ln2.Shutdown()
@@ -4096,7 +4046,6 @@ func TestLeafNodeOriginCluster(t *testing.T) {
 	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
 	`
 	lconf1 := createConfFile(t, []byte(fmt.Sprintf(c1, ca.opts[0].LeafNode.Port)))
-	defer removeFile(t, lconf1)
 
 	ln1, lopts1 := RunServerWithConfig(lconf1)
 	defer ln1.Shutdown()
@@ -4108,7 +4057,6 @@ func TestLeafNodeOriginCluster(t *testing.T) {
 	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
 	`
 	lconf2 := createConfFile(t, []byte(fmt.Sprintf(c2, lopts1.Cluster.Port, ca.opts[1].LeafNode.Port)))
-	defer removeFile(t, lconf2)
 
 	ln2, _ := RunServerWithConfig(lconf2)
 	defer ln2.Shutdown()
@@ -4120,7 +4068,6 @@ func TestLeafNodeOriginCluster(t *testing.T) {
 	leafnodes { remotes = [{ url: nats-leaf://127.0.0.1:%d }] }
 	`
 	lconf3 := createConfFile(t, []byte(fmt.Sprintf(c3, lopts1.Cluster.Port, ca.opts[2].LeafNode.Port)))
-	defer removeFile(t, lconf3)
 
 	ln3, _ := RunServerWithConfig(lconf3)
 	defer ln3.Shutdown()
@@ -4325,7 +4272,6 @@ func TestLeafNodeAndGatewaysStreamAndShadowSubs(t *testing.T) {
 			}
 		}
 	`))
-	defer removeFile(t, conf1)
 	s1, o1 := RunServerWithConfig(conf1)
 	defer s1.Shutdown()
 
@@ -4354,7 +4300,6 @@ func TestLeafNodeAndGatewaysStreamAndShadowSubs(t *testing.T) {
 			]
 		}
 	`, o1.Gateway.Port)))
-	defer removeFile(t, conf2)
 	s2, o2 := RunServerWithConfig(conf2)
 	defer s2.Shutdown()
 
@@ -4395,7 +4340,6 @@ func TestLeafNodeAndGatewaysStreamAndShadowSubs(t *testing.T) {
 			]
 		}
 	`, o1.LeafNode.Port)))
-	defer removeFile(t, conf3)
 	s3, o3 := RunServerWithConfig(conf3)
 	defer s3.Shutdown()
 

--- a/test/new_routes_test.go
+++ b/test/new_routes_test.go
@@ -1676,7 +1676,6 @@ func TestNewRouteLeafNodeOriginSupport(t *testing.T) {
 	no_sys_acc: true
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -1690,7 +1689,6 @@ func TestNewRouteLeafNodeOriginSupport(t *testing.T) {
 	no_sys_acc: true
 	`
 	lconf := createConfFile(t, []byte(fmt.Sprintf(lcontent, opts.LeafNode.Port)))
-	defer removeFile(t, lconf)
 
 	ln, _ := RunServerWithConfig(lconf)
 	defer ln.Shutdown()

--- a/test/norace_test.go
+++ b/test/norace_test.go
@@ -51,7 +51,6 @@ func TestNoRaceRouteSendSubs(t *testing.T) {
 			no_sys_acc: true
 	`
 	cfa := createConfFile(t, []byte(fmt.Sprintf(template, "")))
-	defer removeFile(t, cfa)
 	srvA, optsA := RunServerWithConfig(cfa)
 	srvA.Shutdown()
 	optsA.DisableShortFirstPing = true

--- a/test/ocsp_test.go
+++ b/test/ocsp_test.go
@@ -253,7 +253,6 @@ func TestOCSPMustStapleAutoDoesNotShutdown(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -535,7 +534,6 @@ func TestOCSPClient(t *testing.T) {
 			test.configure()
 			content := test.config
 			conf := createConfFile(t, []byte(content))
-			defer removeFile(t, conf)
 			s, opts := RunServerWithConfig(conf)
 			defer s.Shutdown()
 
@@ -593,7 +591,6 @@ func TestOCSPReloadRotateTLSCertWithNoURL(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -684,8 +681,7 @@ func TestOCSPReloadRotateTLSCertDisableMustStaple(t *testing.T) {
 	addr := fmt.Sprintf("http://%s", ocspr.Addr)
 	setOCSPStatus(t, addr, serverCert, ocsp.Good)
 
-	storeDir := createDir(t, "_ocsp")
-	defer removeDir(t, storeDir)
+	storeDir := t.TempDir()
 
 	originalContent := `
 		port: -1
@@ -702,7 +698,6 @@ func TestOCSPReloadRotateTLSCertDisableMustStaple(t *testing.T) {
 
 	content := fmt.Sprintf(originalContent, storeDir)
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -895,7 +890,6 @@ func TestOCSPReloadRotateTLSCertEnableMustStaple(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -990,12 +984,9 @@ func TestOCSPCluster(t *testing.T) {
 	setOCSPStatus(t, addr, "configs/certs/ocsp/server-status-request-url-08-cert.pem", ocsp.Good)
 
 	// Store Dirs
-	storeDirA := createDir(t, "_ocspA")
-	defer removeDir(t, storeDirA)
-	storeDirB := createDir(t, "_ocspB")
-	defer removeDir(t, storeDirB)
-	storeDirC := createDir(t, "_ocspC")
-	defer removeDir(t, storeDirC)
+	storeDirA := t.TempDir()
+	storeDirB := t.TempDir()
+	storeDirC := t.TempDir()
 
 	// Seed server configuration
 	srvConfA := `
@@ -1027,7 +1018,6 @@ func TestOCSPCluster(t *testing.T) {
 	`
 	srvConfA = fmt.Sprintf(srvConfA, storeDirA)
 	sconfA := createConfFile(t, []byte(srvConfA))
-	defer removeFile(t, sconfA)
 	srvA, optsA := RunServerWithConfig(sconfA)
 	defer srvA.Shutdown()
 
@@ -1064,7 +1054,6 @@ func TestOCSPCluster(t *testing.T) {
 	`
 	srvConfB = fmt.Sprintf(srvConfB, storeDirB, optsA.Cluster.Port)
 	conf := createConfFile(t, []byte(srvConfB))
-	defer removeFile(t, conf)
 	srvB, optsB := RunServerWithConfig(conf)
 	defer srvB.Shutdown()
 
@@ -1131,7 +1120,6 @@ func TestOCSPCluster(t *testing.T) {
 	`
 	srvConfC = fmt.Sprintf(srvConfC, storeDirC, optsA.Cluster.Port)
 	conf = createConfFile(t, []byte(srvConfC))
-	defer removeFile(t, conf)
 	srvC, optsC := RunServerWithConfig(conf)
 	defer srvC.Shutdown()
 
@@ -1264,12 +1252,9 @@ func TestOCSPLeaf(t *testing.T) {
 	setOCSPStatus(t, addr, "configs/certs/ocsp/server-status-request-url-08-cert.pem", ocsp.Good)
 
 	// Store Dirs
-	storeDirA := createDir(t, "_ocspA")
-	defer removeDir(t, storeDirA)
-	storeDirB := createDir(t, "_ocspB")
-	defer removeDir(t, storeDirB)
-	storeDirC := createDir(t, "_ocspC")
-	defer removeDir(t, storeDirC)
+	storeDirA := t.TempDir()
+	storeDirB := t.TempDir()
+	storeDirC := t.TempDir()
 
 	// LeafNode server configuration
 	srvConfA := `
@@ -1300,7 +1285,6 @@ func TestOCSPLeaf(t *testing.T) {
 	`
 	srvConfA = fmt.Sprintf(srvConfA, storeDirA)
 	sconfA := createConfFile(t, []byte(srvConfA))
-	defer removeFile(t, sconfA)
 	srvA, optsA := RunServerWithConfig(sconfA)
 	defer srvA.Shutdown()
 
@@ -1332,7 +1316,6 @@ func TestOCSPLeaf(t *testing.T) {
 	`
 	srvConfB = fmt.Sprintf(srvConfB, storeDirB, optsA.LeafNode.Port)
 	conf := createConfFile(t, []byte(srvConfB))
-	defer removeFile(t, conf)
 	srvB, optsB := RunServerWithConfig(conf)
 	defer srvB.Shutdown()
 
@@ -1393,7 +1376,6 @@ func TestOCSPLeaf(t *testing.T) {
 	`
 	srvConfC = fmt.Sprintf(srvConfC, storeDirC, optsA.LeafNode.Port)
 	conf = createConfFile(t, []byte(srvConfC))
-	defer removeFile(t, conf)
 	srvC, optsC := RunServerWithConfig(conf)
 	defer srvC.Shutdown()
 
@@ -1535,12 +1517,9 @@ func TestOCSPGateway(t *testing.T) {
 	setOCSPStatus(t, addr, "configs/certs/ocsp/server-status-request-url-08-cert.pem", ocsp.Good)
 
 	// Store Dirs
-	storeDirA := createDir(t, "_ocspA")
-	defer removeDir(t, storeDirA)
-	storeDirB := createDir(t, "_ocspB")
-	defer removeDir(t, storeDirB)
-	storeDirC := createDir(t, "_ocspC")
-	defer removeDir(t, storeDirC)
+	storeDirA := t.TempDir()
+	storeDirB := t.TempDir()
+	storeDirC := t.TempDir()
 
 	// Gateway server configuration
 	srvConfA := `
@@ -1572,7 +1551,6 @@ func TestOCSPGateway(t *testing.T) {
 	`
 	srvConfA = fmt.Sprintf(srvConfA, storeDirA)
 	sconfA := createConfFile(t, []byte(srvConfA))
-	defer removeFile(t, sconfA)
 	srvA, optsA := RunServerWithConfig(sconfA)
 	defer srvA.Shutdown()
 
@@ -1615,7 +1593,6 @@ func TestOCSPGateway(t *testing.T) {
 	`
 	srvConfB = fmt.Sprintf(srvConfB, storeDirB, optsA.Gateway.Port)
 	conf := createConfFile(t, []byte(srvConfB))
-	defer removeFile(t, conf)
 	srvB, optsB := RunServerWithConfig(conf)
 	defer srvB.Shutdown()
 
@@ -1679,7 +1656,6 @@ func TestOCSPGateway(t *testing.T) {
 	`
 	srvConfC = fmt.Sprintf(srvConfC, storeDirC, optsA.Gateway.Port)
 	conf = createConfFile(t, []byte(srvConfC))
-	defer removeFile(t, conf)
 	srvC, optsC := RunServerWithConfig(conf)
 	defer srvC.Shutdown()
 
@@ -1841,7 +1817,6 @@ func TestOCSPGatewayIntermediate(t *testing.T) {
 	`
 	srvConfA = fmt.Sprintf(srvConfA, addr)
 	sconfA := createConfFile(t, []byte(srvConfA))
-	defer removeFile(t, sconfA)
 	srvA, optsA := RunServerWithConfig(sconfA)
 	defer srvA.Shutdown()
 
@@ -1875,7 +1850,6 @@ func TestOCSPGatewayIntermediate(t *testing.T) {
 	`
 	srvConfB = fmt.Sprintf(srvConfB, addr, optsA.Gateway.Port)
 	conf := createConfFile(t, []byte(srvConfB))
-	defer removeFile(t, conf)
 	srvB, optsB := RunServerWithConfig(conf)
 	defer srvB.Shutdown()
 
@@ -2133,7 +2107,6 @@ func TestOCSPCustomConfig(t *testing.T) {
 			test.configure()
 			content := test.config
 			conf := createConfFile(t, []byte(content))
-			defer removeFile(t, conf)
 			s, opts := RunServerWithConfig(conf)
 			defer s.Shutdown()
 
@@ -2195,7 +2168,6 @@ func TestOCSPCustomConfigReloadDisable(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -2297,7 +2269,6 @@ func TestOCSPCustomConfigReloadEnable(t *testing.T) {
 		}
 	`
 	conf := createConfFile(t, []byte(content))
-	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -2599,14 +2570,10 @@ func TestOCSPSuperCluster(t *testing.T) {
 	setOCSPStatus(t, addr, "configs/certs/ocsp/server-cert.pem", ocsp.Good)
 
 	// Store Dirs
-	storeDirA := createDir(t, "_ocspA")
-	defer removeDir(t, storeDirA)
-	storeDirB := createDir(t, "_ocspB")
-	defer removeDir(t, storeDirB)
-	storeDirC := createDir(t, "_ocspC")
-	defer removeDir(t, storeDirC)
-	storeDirD := createDir(t, "_ocspD")
-	defer removeDir(t, storeDirD)
+	storeDirA := t.TempDir()
+	storeDirB := t.TempDir()
+	storeDirC := t.TempDir()
+	storeDirD := t.TempDir()
 
 	// Gateway server configuration
 	srvConfA := `
@@ -2656,7 +2623,6 @@ func TestOCSPSuperCluster(t *testing.T) {
 	`
 	srvConfA = fmt.Sprintf(srvConfA, storeDirA)
 	sconfA := createConfFile(t, []byte(srvConfA))
-	defer removeFile(t, sconfA)
 	srvA, optsA := RunServerWithConfig(sconfA)
 	defer srvA.Shutdown()
 
@@ -2710,7 +2676,6 @@ func TestOCSPSuperCluster(t *testing.T) {
 	`
 	srvConfB = fmt.Sprintf(srvConfB, storeDirB, optsA.Cluster.Port)
 	conf := createConfFile(t, []byte(srvConfB))
-	defer removeFile(t, conf)
 	srvB, optsB := RunServerWithConfig(conf)
 	defer srvB.Shutdown()
 
@@ -2775,7 +2740,6 @@ func TestOCSPSuperCluster(t *testing.T) {
 	`
 	srvConfC = fmt.Sprintf(srvConfC, storeDirC, optsA.Gateway.Port)
 	conf = createConfFile(t, []byte(srvConfC))
-	defer removeFile(t, conf)
 	srvC, optsC := RunServerWithConfig(conf)
 	defer srvC.Shutdown()
 
@@ -2838,7 +2802,6 @@ func TestOCSPSuperCluster(t *testing.T) {
 	`
 	srvConfD = fmt.Sprintf(srvConfD, addr, storeDirD, optsA.Gateway.Port, optsC.Gateway.Port)
 	conf = createConfFile(t, []byte(srvConfD))
-	defer removeFile(t, conf)
 	srvD, _ := RunServerWithConfig(conf)
 	defer srvD.Shutdown()
 

--- a/test/operator_test.go
+++ b/test/operator_test.go
@@ -357,7 +357,6 @@ func TestReloadDoesNotWipeAccountsWithOperatorMode(t *testing.T) {
 	`
 	contents := strings.Replace(fmt.Sprintf(cf, "", sysPub, sysPub, sysJWT, accPub, accJWT), "\n\t", "\n", -1)
 	conf := createConfFile(t, []byte(contents))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -367,7 +366,6 @@ func TestReloadDoesNotWipeAccountsWithOperatorMode(t *testing.T) {
 	contents2 := strings.Replace(fmt.Sprintf(cf, routeStr, sysPub, sysPub, sysJWT, accPub, accJWT), "\n\t", "\n", -1)
 
 	conf2 := createConfFile(t, []byte(contents2))
-	defer removeFile(t, conf2)
 
 	s2, opts2 := RunServerWithConfig(conf2)
 	defer s2.Shutdown()
@@ -481,7 +479,6 @@ func TestReloadDoesUpdateAccountsWithMemoryResolver(t *testing.T) {
 	`
 	contents := strings.Replace(fmt.Sprintf(cf, "", sysPub, sysPub, sysJWT, accPub, accJWT), "\n\t", "\n", -1)
 	conf := createConfFile(t, []byte(contents))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -573,7 +570,6 @@ func TestReloadFailsWithBadAccountsWithMemoryResolver(t *testing.T) {
 	`
 	contents := strings.Replace(fmt.Sprintf(cf, "", sysPub, sysPub, sysJWT, apub, ajwt), "\n\t", "\n", -1)
 	conf := createConfFile(t, []byte(contents))
-	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -637,7 +633,6 @@ func TestConnsRequestDoesNotLoadAccountCheckingConnLimits(t *testing.T) {
 	`
 	contents := strings.Replace(fmt.Sprintf(cf, "", sysPub, sysPub, sysJWT, accPub, accJWT), "\n\t", "\n", -1)
 	conf := createConfFile(t, []byte(contents))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -647,7 +642,6 @@ func TestConnsRequestDoesNotLoadAccountCheckingConnLimits(t *testing.T) {
 	contents2 := strings.Replace(fmt.Sprintf(cf, routeStr, sysPub, sysPub, sysJWT, accPub, accJWT), "\n\t", "\n", -1)
 
 	conf2 := createConfFile(t, []byte(contents2))
-	defer removeFile(t, conf2)
 
 	s2, _ := RunServerWithConfig(conf2)
 	defer s2.Shutdown()

--- a/test/pid_test.go
+++ b/test/pid_test.go
@@ -22,10 +22,7 @@ import (
 func TestPidFile(t *testing.T) {
 	opts := DefaultTestOptions
 
-	tmpDir := createDir(t, "_nats-server")
-	defer removeDir(t, tmpDir)
-
-	file := createFileAtDir(t, tmpDir, "nats-server:pid_")
+	file := createFileAtDir(t, t.TempDir(), "nats-server:pid_")
 	file.Close()
 	opts.PidFile = file.Name()
 

--- a/test/ports_test.go
+++ b/test/ports_test.go
@@ -45,7 +45,7 @@ func portFile(dirname string) string {
 }
 
 func TestPortsFile(t *testing.T) {
-	portFileDir := createDir(t, "")
+	portFileDir := t.TempDir()
 
 	opts := DefaultTestOptions
 	opts.PortsFileDir = portFileDir
@@ -123,8 +123,7 @@ func TestPortsFile(t *testing.T) {
 // the location of the ports file is changed from dir A to dir B.
 func TestPortsFileReload(t *testing.T) {
 	// make a temp dir
-	tempDir := createDir(t, "")
-	defer removeDir(t, tempDir)
+	tempDir := t.TempDir()
 
 	// make child temp dir A
 	dirA := filepath.Join(tempDir, "A")

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -1101,11 +1101,10 @@ func TestRouteBasicPermissions(t *testing.T) {
 
 func createConfFile(t testing.TB, content []byte) string {
 	t.Helper()
-	conf := createFile(t, "")
+	conf := createFileAtDir(t, t.TempDir(), "")
 	fName := conf.Name()
 	conf.Close()
 	if err := os.WriteFile(fName, content, 0666); err != nil {
-		removeFile(t, fName)
 		t.Fatalf("Error writing conf file: %v", err)
 	}
 	return fName
@@ -1151,7 +1150,6 @@ func TestRoutesOnlyImportOrExport(t *testing.T) {
 				}
 			}
 		`, c)))
-		defer removeFile(t, cf)
 		s, _ := RunServerWithConfig(cf)
 		s.Shutdown()
 	}

--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -744,7 +744,6 @@ func TestServiceLatencyWithJWT(t *testing.T) {
 	`
 	contents := strings.Replace(fmt.Sprintf(cf, "", sysPub, sysPub, sysJWT, svcPub, svcJWT, accPub, accJWT), "\n\t", "\n", -1)
 	conf := createConfFile(t, []byte(contents))
-	defer removeFile(t, conf)
 
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -754,7 +753,6 @@ func TestServiceLatencyWithJWT(t *testing.T) {
 	contents2 := strings.Replace(fmt.Sprintf(cf, routeStr, sysPub, sysPub, sysJWT, svcPub, svcJWT, accPub, accJWT), "\n\t", "\n", -1)
 
 	conf2 := createConfFile(t, []byte(contents2))
-	defer removeFile(t, conf2)
 
 	s2, opts2 := RunServerWithConfig(conf2)
 	defer s2.Shutdown()
@@ -1178,7 +1176,6 @@ func TestServiceLatencyOldRequestStyleSingleServer(t *testing.T) {
 
 		system_account: SYS
 	`))
-	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -1244,7 +1241,6 @@ func TestServiceAndStreamStackOverflow(t *testing.T) {
 		  }
 		}
 	`))
-	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -1423,7 +1419,6 @@ func TestServiceLatencyRequestorSharesConfig(t *testing.T) {
 
 		system_account: SYS
 	`))
-	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -1534,7 +1529,6 @@ func TestServiceLatencyLossTest(t *testing.T) {
 		}
 		system_account: SYS
 	`))
-	defer removeFile(t, conf)
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
 
@@ -1721,7 +1715,6 @@ func TestServiceLatencyHeaderTriggered(t *testing.T) {
 
 				system_account: SYS
 			`, v.shared)))
-			defer removeFile(t, conf)
 			srv, opts := RunServerWithConfig(conf)
 			defer srv.Shutdown()
 
@@ -1807,15 +1800,16 @@ func TestServiceLatencyMissingResults(t *testing.T) {
 		  }
 		}
 	`))
-	defer removeFile(t, accConf)
+
+	// This relies on a specific behavior of testing.T.TempDir(), called by `createConfFile`
+	accConfRelPath := fmt.Sprintf("../%s/%s", filepath.Base(filepath.Dir(accConf)), filepath.Base(accConf))
 
 	s1Conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		server_name: s1
 		cluster { port: -1 }
-		include %q
-	`, filepath.Base(accConf))))
-	defer removeFile(t, s1Conf)
+		include %s
+	`, accConfRelPath)))
 
 	s1, opts1 := RunServerWithConfig(s1Conf)
 	defer s1.Shutdown()
@@ -1827,9 +1821,8 @@ func TestServiceLatencyMissingResults(t *testing.T) {
 			port: -1
 			routes = [ nats-route://127.0.0.1:%d ]
 		}
-		include %q
-	`, opts1.Cluster.Port, filepath.Base(accConf))))
-	defer removeFile(t, s2Conf)
+		include %s
+	`, opts1.Cluster.Port, accConfRelPath)))
 
 	s2, opts2 := RunServerWithConfig(s2Conf)
 	defer s2.Shutdown()

--- a/test/services_test.go
+++ b/test/services_test.go
@@ -42,7 +42,6 @@ var basicMASetupContents = []byte(`
 
 func TestServiceImportWithStreamed(t *testing.T) {
 	conf := createConfFile(t, basicMASetupContents)
-	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -140,7 +139,6 @@ func TestServiceImportWithStreamed(t *testing.T) {
 
 func TestServiceImportWithStreamedResponseAndEOF(t *testing.T) {
 	conf := createConfFile(t, basicMASetupContents)
-	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -224,7 +222,6 @@ func TestServiceExportsResponseFiltering(t *testing.T) {
 		    }
 		}
 	`))
-	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -292,7 +289,6 @@ func TestServiceExportsAutoDirectCleanup(t *testing.T) {
 		    }
 		}
 	`))
-	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -390,7 +386,6 @@ func TestServiceExportsPruningCleanup(t *testing.T) {
 		    }
 		}
 	`))
-	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -479,7 +474,6 @@ func TestServiceExportsResponseThreshold(t *testing.T) {
 		    },
 		}
 	`))
-	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -525,7 +519,6 @@ func TestServiceExportsResponseThresholdChunked(t *testing.T) {
 		    }
 		}
 	`))
-	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()
@@ -588,7 +581,6 @@ func TestServiceAllowResponsesPerms(t *testing.T) {
 		    }
 		}
 	`))
-	defer removeFile(t, conf)
 
 	srv, opts := RunServerWithConfig(conf)
 	defer srv.Shutdown()

--- a/test/test.go
+++ b/test/test.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -31,8 +30,6 @@ import (
 
 	"github.com/nats-io/nats-server/v2/server"
 )
-
-var tempRoot = filepath.Join(os.TempDir(), "nats-server")
 
 // So we can pass tests and benchmarks..
 type tLogger interface {
@@ -638,26 +635,6 @@ func nextServerOpts(opts *server.Options) *server.Options {
 	return nopts
 }
 
-func createDir(t testing.TB, prefix string) string {
-	t.Helper()
-	if err := os.MkdirAll(tempRoot, 0700); err != nil {
-		t.Fatal(err)
-	}
-	dir, err := os.MkdirTemp(tempRoot, prefix)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return dir
-}
-
-func createFile(t testing.TB, prefix string) *os.File {
-	t.Helper()
-	if err := os.MkdirAll(tempRoot, 0700); err != nil {
-		t.Fatal(err)
-	}
-	return createFileAtDir(t, tempRoot, prefix)
-}
-
 func createFileAtDir(t testing.TB, dir, prefix string) *os.File {
 	t.Helper()
 	f, err := os.CreateTemp(dir, prefix)
@@ -665,18 +642,4 @@ func createFileAtDir(t testing.TB, dir, prefix string) *os.File {
 		t.Fatal(err)
 	}
 	return f
-}
-
-func removeDir(t testing.TB, dir string) {
-	t.Helper()
-	if err := os.RemoveAll(dir); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func removeFile(t testing.TB, p string) {
-	t.Helper()
-	if err := os.Remove(p); err != nil {
-		t.Fatal(err)
-	}
 }

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -151,7 +151,6 @@ func TestTLSClientCertificateCheckWithAllowedConnectionTypes(t *testing.T) {
 			]
 		}
 	`))
-	defer removeFile(t, conf)
 	s, o := RunServerWithConfig(conf)
 	defer s.Shutdown()
 
@@ -1180,7 +1179,6 @@ func TestTLSHandshakeFailureMemUsage(t *testing.T) {
 				}
 			`)
 			conf := createConfFile(t, []byte(content))
-			defer removeFile(t, conf)
 			s, opts := RunServerWithConfig(conf)
 			defer s.Shutdown()
 
@@ -1517,7 +1515,6 @@ func TestTLSClientAuthWithRDNSequence(t *testing.T) {
 				}
 			`)
 			conf := createConfFile(t, []byte(content))
-			defer removeFile(t, conf)
 			s, opts := RunServerWithConfig(conf)
 			defer s.Shutdown()
 
@@ -1637,7 +1634,6 @@ func TestTLSClientAuthWithRDNSequenceReordered(t *testing.T) {
 				}
 			`)
 			conf := createConfFile(t, []byte(content))
-			defer removeFile(t, conf)
 			s, opts := RunServerWithConfig(conf)
 			defer s.Shutdown()
 
@@ -1770,7 +1766,6 @@ func TestTLSClientSVIDAuth(t *testing.T) {
 				}
 			`)
 			conf := createConfFile(t, []byte(content))
-			defer removeFile(t, conf)
 			s, opts := RunServerWithConfig(conf)
 			defer s.Shutdown()
 
@@ -1821,7 +1816,6 @@ func TestTLSPinnedCertsClient(t *testing.T) {
 	}`
 
 	confFileName := createConfFile(t, []byte(fmt.Sprintf(tmpl, "aaaaaaaa09fde09451411ba3b42c0f74727d61a974c69fd3cf5257f39c75f0e9")))
-	defer removeFile(t, confFileName)
 	srv, o := RunServerWithConfig(confFileName)
 	defer srv.Shutdown()
 
@@ -1891,8 +1885,6 @@ func TestTLSConnectionRate(t *testing.T) {
 	`
 
 	confFileName := createConfFile(t, []byte(config))
-	defer removeFile(t, confFileName)
-
 	srv, _ := RunServerWithConfig(confFileName)
 	logger := newCaptureWarnLogger()
 	srv.SetLogger(logger, false, false)
@@ -1951,12 +1943,10 @@ func TestTLSPinnedCertsRoute(t *testing.T) {
 	}`
 
 	confSeed := createConfFile(t, []byte(tmplSeed))
-	defer removeFile(t, confSeed)
 	srvSeed, o := RunServerWithConfig(confSeed)
 	defer srvSeed.Shutdown()
 
 	confSrv := createConfFile(t, []byte(fmt.Sprintf(tmplSrv, o.Cluster.Port, "89386860ea1222698ea676fc97310bdf2bff6f7e2b0420fac3b3f8f5a08fede5")))
-	defer removeFile(t, confSrv)
 	srv, _ := RunServerWithConfig(confSrv)
 	defer srv.Shutdown()
 


### PR DESCRIPTION
Rather than relying on manual deferred cleanup of files, switch most tests to use testing.TempDir() which is automatically cleaned up.

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [x] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

### Changes proposed in this pull request:

 - Change test utility methods to use `testing.TempDir()`
 - Remove (now superfluous) deferred directory and file cleanup

/cc @nats-io/core
