### PR TITLE
NoAck allowed now on pull consumers

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -400,8 +400,8 @@ func checkConsumerCfg(
 			return NewJSConsumerSmallHeartbeatError()
 		}
 	} else {
-		// Pull mode / work queue mode require explicit ack.
-		if config.AckPolicy == AckNone {
+		// Pull mode with work queue retention from the stream requires an explicit ack.
+		if config.AckPolicy == AckNone && cfg.Retention == WorkQueuePolicy {
 			return NewJSConsumerPullRequiresAckError()
 		}
 		if config.RateLimit > 0 {


### PR DESCRIPTION
Still required for WorkQueue retention policy streams.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
