### PR TITLE
Suppress leaderless claims if JetStream just started.

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -106,6 +106,8 @@ type jetStream struct {
 	cluster       *jetStreamCluster
 	accounts      map[string]*jsAccount
 	apiSubs       *Sublist
+	started       time.Time
+
 	// System level request to purge a stream move
 	accountPurge   *subscription
 	metaRecovering bool
@@ -408,6 +410,9 @@ func (s *Server) enableJetStream(cfg JetStreamConfig) error {
 			return err
 		}
 	}
+
+	// Mark when we are up and running.
+	js.setStarted()
 
 	return nil
 }
@@ -742,6 +747,13 @@ func (s *Server) configAllJetStreamAccounts() error {
 	}
 
 	return nil
+}
+
+// Mark our started time.
+func (js *jetStream) setStarted() {
+	js.mu.Lock()
+	defer js.mu.Unlock()
+	js.started = time.Now()
 }
 
 func (js *jetStream) isEnabled() bool {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -689,8 +689,14 @@ func (js *jetStream) isGroupLeaderless(rg *raftGroup) bool {
 	}
 	// If we don't have a leader.
 	if rg.node.GroupLeader() == _EMPTY_ {
+		// Threshold for jetstream startup.
+		const startupThreshold = 2 * time.Second
+
 		if rg.node.HadPreviousLeader() {
-			return true
+			// Make sure we have been running long enough to intelligently determine this.
+			if time.Since(js.started) > startupThreshold {
+				return true
+			}
 		}
 		// Make sure we have been running for enough time.
 		if time.Since(rg.node.Created()) > lostQuorumInterval {


### PR DESCRIPTION
Only complain about leaderless group with previous leader if we know JetStream has been running for some threshold.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
