### PR TITLE
server: expire display Never instead of 1970

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1663,7 +1663,12 @@ func (s *Server) Start() {
 		s.Noticef("  System  : %q", opc.Audience)
 		s.Noticef("  Operator: %q", opc.Name)
 		s.Noticef("  Issued  : %v", time.Unix(opc.IssuedAt, 0))
-		s.Noticef("  Expires : %v", time.Unix(opc.Expires, 0))
+		switch opc.Expires {
+		case 0:
+			s.Noticef("  Expires : Never")
+		default:
+			s.Noticef("  Expires : %v", time.Unix(opc.Expires, 0))
+		}
 	}
 	if hasOperators && opts.SystemAccount == _EMPTY_ {
 		s.Warnf("Trusted Operators should utilize a System Account")


### PR DESCRIPTION
When using `Trusted Operators` the output is showing 1970 as expire date:

```
[87502] 2022/09/07 20:27:20.600022 [INF] Trusted Operators
[87502] 2022/09/07 20:27:20.600024 [INF]   System  : ""
[87502] 2022/09/07 20:27:20.600026 [INF]   Operator: "my_org"
[87502] 2022/09/07 20:27:20.600056 [INF]   Issued  : 2022-09-06 20:24:43 +0200 CEST
[87502] 2022/09/07 20:27:20.600060 [INF]   Expires : 1970-01-01 01:00:00 +0100 CET
```

this patch replaces the Expires null date with "Never"