### PR TITLE
[IMPROVED] Pull request logic

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3102,10 +3102,6 @@ func (o *consumer) loopAndGatherMsgs(qch chan struct{}) {
 
 		// On error either wait or return.
 		if err != nil || pmsg == nil {
-			// If we are stalled here in pull mode, invalidate all requests that have had deliveries.
-			if err == errMaxAckPending && o.isPullMode() {
-				o.processWaiting(true)
-			}
 			if err == ErrStoreMsgNotFound || err == ErrStoreEOF || err == errMaxAckPending || err == errPartialCache {
 				goto waitForMsgs
 			} else {
@@ -3128,7 +3124,7 @@ func (o *consumer) loopAndGatherMsgs(qch chan struct{}) {
 		}
 		// Calculate payload size. This can be calculated on client side.
 		// We do not include transport subject here since not generally known on client.
-		sz = len(pmsg.subj) + +len(ackReply) + len(pmsg.hdr) + len(pmsg.msg)
+		sz = len(pmsg.subj) + len(ackReply) + len(pmsg.hdr) + len(pmsg.msg)
 
 		if o.isPushMode() {
 			dsubj = o.dsubj

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -17398,8 +17398,8 @@ func TestJetStreamPullMaxBytes(t *testing.T) {
 	req = &JSApiConsumerGetNextRequest{Batch: 1_000, MaxBytes: msz * 4, NoWait: true}
 	jreq, _ = json.Marshal(req)
 	nc.PublishRequest(subj, reply, jreq)
-	checkSubsPending(t, sub, 5)
-	for i := 0; i < 5; i++ {
+	checkSubsPending(t, sub, 4)
+	for i := 0; i < 4; i++ {
 		m, err = sub.NextMsg(time.Second)
 		require_NoError(t, err)
 		require_True(t, len(m.Data) == dsz)
@@ -17410,12 +17410,12 @@ func TestJetStreamPullMaxBytes(t *testing.T) {
 	req = &JSApiConsumerGetNextRequest{Batch: 1_000, MaxBytes: msz, NoWait: true}
 	jreq, _ = json.Marshal(req)
 	nc.PublishRequest(subj, reply, jreq)
-	checkSubsPending(t, sub, 2)
+	checkSubsPending(t, sub, 1)
 	m, err = sub.NextMsg(time.Second)
 	require_NoError(t, err)
 	require_True(t, len(m.Data) == dsz)
 	require_True(t, len(m.Header) == 0)
-	checkSubsPending(t, sub, 1)
+	checkSubsPending(t, sub, 0)
 }
 
 func TestJetStreamStreamRepublishCycle(t *testing.T) {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -17327,8 +17327,8 @@ func TestJetStreamPullMaxBytes(t *testing.T) {
 	require_NoError(t, err)
 
 	// Put in ~2MB, each ~100k
-	msz := 99_980
-	total, msg := 20, []byte(strings.Repeat("Z", msz))
+	msz, dsz := 100_000, 99_950
+	total, msg := 20, []byte(strings.Repeat("Z", dsz))
 
 	for i := 0; i < total; i++ {
 		if _, err := js.Publish("TEST", msg); err != nil {
@@ -17377,7 +17377,7 @@ func TestJetStreamPullMaxBytes(t *testing.T) {
 
 	m, err = sub.NextMsg(time.Second)
 	require_NoError(t, err)
-	require_True(t, len(m.Data) == msz)
+	require_True(t, len(m.Data) == dsz)
 	require_True(t, len(m.Header) == 0)
 	checkSubsPending(t, sub, 0)
 
@@ -17389,33 +17389,33 @@ func TestJetStreamPullMaxBytes(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		m, err = sub.NextMsg(time.Second)
 		require_NoError(t, err)
-		require_True(t, len(m.Data) == msz)
+		require_True(t, len(m.Data) == dsz)
 		require_True(t, len(m.Header) == 0)
 	}
 	checkSubsPending(t, sub, 0)
 
 	// Now ask for large batch but make sure we are limited by batch size.
-	req = &JSApiConsumerGetNextRequest{Batch: 1_000, MaxBytes: msz * 5, NoWait: true}
+	req = &JSApiConsumerGetNextRequest{Batch: 1_000, MaxBytes: msz * 4, NoWait: true}
 	jreq, _ = json.Marshal(req)
 	nc.PublishRequest(subj, reply, jreq)
 	checkSubsPending(t, sub, 5)
 	for i := 0; i < 5; i++ {
 		m, err = sub.NextMsg(time.Second)
 		require_NoError(t, err)
-		require_True(t, len(m.Data) == msz)
+		require_True(t, len(m.Data) == dsz)
 		require_True(t, len(m.Header) == 0)
 	}
 	checkSubsPending(t, sub, 0)
 
-	req = &JSApiConsumerGetNextRequest{Batch: 1_000, MaxBytes: msz + 20, NoWait: true}
+	req = &JSApiConsumerGetNextRequest{Batch: 1_000, MaxBytes: msz, NoWait: true}
 	jreq, _ = json.Marshal(req)
 	nc.PublishRequest(subj, reply, jreq)
-	checkSubsPending(t, sub, 1)
+	checkSubsPending(t, sub, 2)
 	m, err = sub.NextMsg(time.Second)
 	require_NoError(t, err)
-	require_True(t, len(m.Data) == msz)
+	require_True(t, len(m.Data) == dsz)
 	require_True(t, len(m.Header) == 0)
-	checkSubsPending(t, sub, 0)
+	checkSubsPending(t, sub, 1)
 }
 
 func TestJetStreamStreamRepublishCycle(t *testing.T) {

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -5584,3 +5584,90 @@ func TestNoRaceJetStreamSuperClusterStreamMoveLongRTT(t *testing.T) {
 		return nil
 	})
 }
+
+// https://github.com/nats-io/nats-server/issues/3455
+func TestNoRaceJetStreamConcurrentPullConsumerBatch(t *testing.T) {
+	s := RunBasicJetStreamServer()
+	if config := s.JetStreamConfig(); config != nil {
+		defer removeDir(t, config.StoreDir)
+	}
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"ORDERS.*"},
+		Storage:   nats.MemoryStorage,
+		Retention: nats.WorkQueuePolicy,
+	})
+	require_NoError(t, err)
+
+	toSend := int32(100_000)
+
+	for i := 0; i < 100_000; i++ {
+		subj := fmt.Sprintf("ORDERS.%d", i+1)
+		js.PublishAsync(subj, []byte("BUY"))
+	}
+	select {
+	case <-js.PublishAsyncComplete():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Did not receive completion signal")
+	}
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:       "PROCESSOR",
+		AckPolicy:     nats.AckExplicitPolicy,
+		MaxAckPending: 5000,
+	})
+	require_NoError(t, err)
+
+	nc, js = jsClientConnect(t, s)
+	defer nc.Close()
+
+	sub1, err := js.PullSubscribe(_EMPTY_, _EMPTY_, nats.Bind("TEST", "PROCESSOR"))
+	require_NoError(t, err)
+
+	nc, js = jsClientConnect(t, s)
+	defer nc.Close()
+
+	sub2, err := js.PullSubscribe(_EMPTY_, _EMPTY_, nats.Bind("TEST", "PROCESSOR"))
+	require_NoError(t, err)
+
+	startCh := make(chan bool)
+
+	var received int32
+
+	wg := sync.WaitGroup{}
+
+	fetchSize := 1000
+	fetch := func(sub *nats.Subscription) {
+		<-startCh
+		defer wg.Done()
+
+		for {
+			msgs, err := sub.Fetch(fetchSize, nats.MaxWait(time.Second))
+			if atomic.AddInt32(&received, int32(len(msgs))) >= toSend {
+				break
+			}
+			// We should always receive a full batch here if not last competing fetch.
+			if err != nil || len(msgs) != fetchSize {
+				break
+			}
+			for _, m := range msgs {
+				m.Ack()
+			}
+		}
+	}
+
+	wg.Add(2)
+
+	go fetch(sub1)
+	go fetch(sub2)
+
+	close(startCh)
+
+	wg.Wait()
+	require_True(t, received == toSend)
+}


### PR DESCRIPTION
Prepping for pull consumer increased usage in clients.

1. Do better accounting on per message basis of bytes used for MaxBytes in pull requests.
2. Always used the MaxBytes allowed unless first delivery.
3. Fixed bug that would cause us to expire one shots on hitting max ack pending.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #3455 

/cc @nats-io/core
