### PR TITLE
[FIXED] Edge condition handling in {{Split()}} subject mapping function

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -4581,7 +4581,7 @@ func (tr *transform) transform(tokens []string) (string, error) {
 					if split != _EMPTY_ {
 						b.WriteString(split)
 					}
-					if j < len(splits)-1 && splits[j+1] != _EMPTY_ && j != 0 {
+					if j < len(splits)-1 && splits[j+1] != _EMPTY_ && !(j == 0 && split == _EMPTY_) {
 						b.WriteString(tsep)
 					}
 				}

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -3335,6 +3335,7 @@ func TestSubjectTransforms(t *testing.T) {
 	shouldMatch("*", "{{SliceFromLeft(1,3)}}", "1234567890", "123.456.789.0")
 	shouldMatch("*", "{{SliceFromRight(1,3)}}", "1234567890", "1.234.567.890")
 	shouldMatch("*", "{{split(1,-)}}", "-abc-def--ghi-", "abc.def.ghi")
+	shouldMatch("*", "{{split(1,-)}}", "abc-def--ghi-", "abc.def.ghi")
 	shouldMatch("*.*", "{{split(2,-)}}.{{splitfromleft(1,2)}}", "foo.-abc-def--ghij-", "abc.def.ghij.fo.o") // combo + checks split for multiple instance of deliminator and deliminator being at the start or end
 }
 


### PR DESCRIPTION
 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves a small bug in the {{Split()}} subject  mapping function - and of course I just noticed that bug right after 2.9.0 is released :(

/cc @nats-io/core
