### PR TITLE
Optimise `needAck`

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2329,8 +2329,9 @@ func (o *consumer) needAck(sseq uint64) bool {
 	o.mu.RLock()
 
 	// Check first if we are filtered, and if so check if this is even applicable to us.
+	var svp StoreMsg
 	if o.isFiltered() && o.mset != nil {
-		var svp StoreMsg
+		svp.clear()
 		sm, err := o.mset.store.LoadMsg(sseq, &svp)
 		if err != nil || !o.isFilteredMatch(sm.subj) {
 			o.mu.RUnlock()

--- a/server/store.go
+++ b/server/store.go
@@ -547,7 +547,5 @@ func (sm *StoreMsg) clear() {
 	if sm == nil {
 		return
 	}
-	sm.subj = _EMPTY_
-	sm.hdr, sm.msg, sm.buf = sm.hdr[:0], sm.msg[:0], sm.buf[:0]
-	sm.seq, sm.ts = 0, 0
+	*sm = StoreMsg{_EMPTY_, sm.hdr[:0], sm.msg[:0], sm.buf[:0], 0, 0}
 }

--- a/server/store.go
+++ b/server/store.go
@@ -547,8 +547,7 @@ func (sm *StoreMsg) clear() {
 	if sm == nil {
 		return
 	}
-	*sm = StoreMsg{_EMPTY_, nil, nil, sm.buf, 0, 0}
-	if len(sm.buf) > 0 {
-		sm.buf = sm.buf[:0]
-	}
+	sm.subj = _EMPTY_
+	sm.hdr, sm.msg, sm.buf = sm.hdr[:0], sm.msg[:0], sm.buf[:0]
+	sm.seq, sm.ts = 0, 0
 }


### PR DESCRIPTION
This PR optimises the `needAck` function by pooling the `StoreMsg`s and reusing them. It turns out this is a hot path if there are lots of consumers on a stream, so using a `sync.Pool` here and reusing the existing slices pretty much eliminates the bulk of allocations on this path and almost completely eliminates GC pressure.

(Why it's pegging the CPU in the first place doing this is a mystery I'm still working on, but this improves things at least.)

CPU profile before:
<img width="1345" alt="Screenshot 2022-09-13 at 13 07 53" src="https://user-images.githubusercontent.com/310854/189901983-99bdba4e-1b62-4dfe-8130-2e6f0b164629.png">

CPU profile after:
<img width="1342" alt="Screenshot 2022-09-13 at 13 33 21" src="https://user-images.githubusercontent.com/310854/189902032-e6d4e743-fd16-4c1f-80df-46969da75f12.png">

Allocation profile before:
<img width="1345" alt="Screenshot 2022-09-13 at 13 34 40" src="https://user-images.githubusercontent.com/310854/189902272-b955bdfc-249c-4953-a899-00100f4644c7.png">

Allocation profile after:
<img width="1346" alt="Screenshot 2022-09-13 at 13 34 53" src="https://user-images.githubusercontent.com/310854/189902294-bde8ba7d-7304-4ec4-ba26-b55c8f9e0e4b.png">