### PR TITLE
Fix peer randomisation when creating consumers groups for replica=1

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5950,8 +5950,9 @@ func (cc *jetStreamCluster) createGroupForConsumer(cfg *ConsumerConfig, sa *stre
 		return nil
 	}
 	if cfg.Replicas > 0 && cfg.Replicas != len(peers) {
-		peers = peers[:cfg.Replicas]
+		// First shuffle the peers and then select to account for replica = 1.
 		rand.Shuffle(len(peers), func(i, j int) { peers[i], peers[j] = peers[j], peers[i] })
+		peers = peers[:cfg.Replicas]
 	}
 	storage := sa.Config.Storage
 	if cfg.MemoryStorage {


### PR DESCRIPTION
Signed-off-by: Deepak <sah.sslpu@gmail.com>

 - [x] Link to issue, e.g. `Resolves #NNN`
 - [n/a] Documentation added (if applicable)
 - [n/a] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #3469

### Changes proposed in this pull request:

 -
 -
 -

/cc @nats-io/core
