### PR TITLE
[FIXED] JetStream: Pull requests closed due to max_bytes were silent

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2619,11 +2619,10 @@ func (o *consumer) nextWaiting(sz int) *waitingRequest {
 					wr.n = 1
 				}
 			} else {
-				// If we have not delivered anything to the requestor let them know.
-				if wr.d == 0 {
-					hdr := []byte("NATS/1.0 409 Message Size Exceeds MaxBytes\r\n\r\n")
-					o.outq.send(newJSPubMsg(wr.reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
-				}
+				// Since we can't send that message to the requestor, we need to
+				// notify that we are closing the request.
+				hdr := []byte("NATS/1.0 409 Message Size Exceeds MaxBytes\r\n\r\n")
+				o.outq.send(newJSPubMsg(wr.reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
 				// Remove the current one, no longer valid due to max bytes limit.
 				o.waiting.removeCurrent()
 				if o.node != nil {


### PR DESCRIPTION
If the client pull requests has a max_bytes value and the server cannot deliver a single message (because size is too big), it is sending a 409 to signal that to the client library. However, if it sends at least a message then it would close the request without notifying the client with a 409, which would cause the client library to have to wait for its expiration/timeout.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
