### PR TITLE
[FIXED] JetStream: possible panic on peer remove on server shutdown

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1299,6 +1299,10 @@ func (js *jetStream) processAddPeer(peer string) {
 func (js *jetStream) processRemovePeer(peer string) {
 	js.mu.Lock()
 	s, cc := js.srv, js.cluster
+	if cc.meta == nil {
+		js.mu.Unlock()
+		return
+	}
 	isLeader := cc.isLeader()
 	// All nodes will check if this is them.
 	isUs := cc.meta.ID() == peer


### PR DESCRIPTION
This was discovered by new test TestJetStreamClusterRemovePeerByID. I saw this on Travis and repeating the test locally with -count=10 I was able to reproduce. The issue is cc.meta being nil but accessing cc.meta.ID() directly.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
