### PR TITLE
[FIXED] LeafNode: connecting using websocket and no_auth_user

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -608,6 +608,11 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 
 	if !ao {
 		noAuthUser = opts.NoAuthUser
+		// If a leaf connects using websocket, and websocket{} block has a no_auth_user
+		// use that one instead.
+		if c.kind == LEAF && c.isWebsocket() && opts.Websocket.NoAuthUser != _EMPTY_ {
+			noAuthUser = opts.Websocket.NoAuthUser
+		}
 		username = opts.Username
 		password = opts.Password
 		token = opts.Authorization


### PR DESCRIPTION
If the `no_auth_user` is set in the `websocket{}` block and a server creates a leafnode connection using the websocket port, and does not provide credentials, that no_auth_user should be used, but was not.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
