### PR TITLE
[FIXED] JetStream: prevent panic on consumer assignment

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -591,7 +591,7 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 
 	// Hold mset lock here.
 	mset.mu.Lock()
-	if mset.client == nil || mset.store == nil {
+	if mset.client == nil || mset.store == nil || mset.consumers == nil {
 		mset.mu.Unlock()
 		return nil, errors.New("invalid stream")
 	}


### PR DESCRIPTION
It could be that while the routine processing the consumer assignment runs the stream is being stopped, which would lead to a panic.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
