### PR TITLE
[FIXED] JetStream: File store memory usage

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4782,7 +4782,11 @@ func (fs *fileStore) Compact(seq uint64) (uint64, error) {
 			if err = os.WriteFile(smb.mfn, nbuf, defaultFilePerms); err != nil {
 				goto SKIP
 			}
+			// Make sure to remove fss state.
 			smb.fss = nil
+			if smb.sfn != _EMPTY_ {
+				os.Remove(smb.sfn)
+			}
 			smb.clearCacheAndOffset()
 			smb.rbytes = uint64(len(nbuf))
 		}

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1819,7 +1819,7 @@ func (fs *fileStore) newMsgBlockForWrite() (*msgBlock, error) {
 	ts := time.Now().UnixNano()
 	// Race detector wants these protected.
 	mb.mu.Lock()
-	mb.llts, mb.lwts = ts, ts
+	mb.llts, mb.lwts = 0, ts
 	// Remember our last sequence number.
 	mb.first.seq = fs.state.LastSeq + 1
 	mb.last.seq = fs.state.LastSeq


### PR DESCRIPTION
The write cache may be pinned for longer than needed when creating
a new write block. This could be seen in some benchmark tests.

The old block cache would be kept for 5 more seconds, which, with
a fast rate of inserts could start to show in some memory profiling.

This was a change introduced in https://github.com/nats-io/nats-server/pull/3351
which was different than code in v2.8.4

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>