### PR TITLE
[FIXED] JetStream: Scale down of consumer to R1 would not get a response

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3537,7 +3537,11 @@ func (js *jetStream) processClusterCreateConsumer(ca *consumerAssignment, state 
 				// Need to clear from rg too.
 				js.mu.Lock()
 				rg.node = nil
+				client, subject, reply := ca.Client, ca.Subject, ca.Reply
 				js.mu.Unlock()
+				var resp = JSApiConsumerCreateResponse{ApiResponse: ApiResponse{Type: JSApiConsumerCreateResponseType}}
+				resp.ConsumerInfo = o.info()
+				s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
 				return
 			}
 		}


### PR DESCRIPTION
Updating a consumer configuration from say R3 to R1 would work but no response was received by the client sending the request.

Resolves #3493

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
