### PR TITLE
fix to  bug  #3522 - update usage guide message in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ var usageStr = `
 Usage: nats-server [options]
 
 Server Options:
-    -a, --addr,--net <host>          Bind to host address (default: 0.0.0.0)
+    -a, --addr, --net <host>         Bind to host address (default: 0.0.0.0)
     -p, --port <port>                Use port for clients (default: 4222)
     -n, --name <server_name>         Server name (default: auto)
     -P, --pid <file>                 File to store PID

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ var usageStr = `
 Usage: nats-server [options]
 
 Server Options:
-    -a, --addr <host>                Bind to host address (default: 0.0.0.0)
+    -a, --addr,--net <host>          Bind to host address (default: 0.0.0.0)
     -p, --port <port>                Use port for clients (default: 4222)
     -n, --name <server_name>         Server name (default: auto)
     -P, --pid <file>                 File to store PID


### PR DESCRIPTION
### description
The usage message for nats core does not contain all the exisitng options for setting up the host

### Adding resolve to issue:
https://github.com/nats-io/nats-server/issues/3522
### Changes proposed in this pull request:
Updates the usage guide for nats server

