### PR TITLE
Fix to issues  #3524 and #3521

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,57 +28,61 @@ var usageStr = `
 Usage: nats-server [options]
 
 Server Options:
-    -a, --addr, --net <host>         Bind to host address (default: 0.0.0.0)
-    -p, --port <port>                Use port for clients (default: 4222)
-    -n, --name <server_name>         Server name (default: auto)
-    -P, --pid <file>                 File to store PID
-    -m, --http_port <port>           Use port for http monitoring
-    -ms,--https_port <port>          Use port for https monitoring
-    -c, --config <file>              Configuration file
-    -t                               Test configuration and exit
-    -sl,--signal <signal>[=<pid>]    Send signal to nats-server process (stop, quit, reopen, reload)
-                                     <pid> can be either a PID (e.g. 1) or the path to a PID file (e.g. /var/run/nats-server.pid)
-        --client_advertise <string>  Client URL to advertise to other servers
+    -a, --addr, --net <host>                        Bind to host address (default: 0.0.0.0)
+    -p, --port <port>                               Use port for clients (default: 4222)
+    -n, --name, --server_name <server_name>         Server name (default: auto)
+    -P, --pid <file>                                File to store PID
+    -m, --http_port <port>                          Use port for http monitoring
+    -ms,--https_port <port>                         Use port for https monitoring
+    -c, --config <file>                             Configuration file
+    -t                                              Test configuration and exit
+    -sl,--signal <signal>[=<pid>]                   Send signal to nats-server process (stop, quit, reopen, reload)
+                                                    <pid> can be either a PID (e.g. 1) or the path to a PID file (e.g. /var/run/nats-server.pid)
+        --client_advertise <string>                 Client URL to advertise to other servers
+        --ports_file_dir <dir>                      Creates a ports file in the specified directory (<executable_name>_<pid>.ports).
 
 Logging Options:
-    -l, --log <file>                 File to redirect log output
-    -T, --logtime                    Timestamp log entries (default: true)
-    -s, --syslog                     Log to syslog or windows event log
-    -r, --remote_syslog <addr>       Syslog server addr (udp://localhost:514)
-    -D, --debug                      Enable debugging output
-    -V, --trace                      Trace the raw protocol
-    -VV                              Verbose trace (traces system account as well)
-    -DV                              Debug and trace
-    -DVV                             Debug and verbose trace (traces system account as well)
-
+    -l, --log <file>                                File to redirect log output
+    -T, --logtime                                   Timestamp log entries (default: true)
+    -s, --syslog                                    Log to syslog or windows event log
+    -r, --remote_syslog <addr>                      Syslog server addr (udp://localhost:514)
+    -D, --debug                                     Enable debugging output
+    -V, --trace                                     Trace the raw protocol
+    -VV                                             Verbose trace (traces system account as well)
+    -DV                                             Debug and trace
+    -DVV                                            Debug and verbose trace (traces system account as well)
+        --log_size_limit <size-limit>               Logfile size limit (default: auto)
+        --max_traced_msg_len <len>                  Maximum printable length for traced messages (default: unlimited)
 JetStream Options:
-    -js, --jetstream                 Enable JetStream functionality.
-    -sd, --store_dir <dir>           Set the storage directory.
+    -js, --jetstream                                Enable JetStream functionality.
+    -sd, --store_dir <dir>                          Set the storage directory.
 
 Authorization Options:
-        --user <user>                User required for connections
-        --pass <password>            Password required for connections
-        --auth <token>               Authorization token required for connections
+        --user <user>                               User required for connections
+        --pass <password>                           Password required for connections
+        --auth <token>                              Authorization token required for connections
 
 TLS Options:
-        --tls                        Enable TLS, do not verify clients (default: false)
-        --tlscert <file>             Server certificate file
-        --tlskey <file>              Private key for server certificate
-        --tlsverify                  Enable TLS, verify client certificates
-        --tlscacert <file>           Client certificate CA for verification
+        --tls                                       Enable TLS, do not verify clients (default: false)
+        --tlscert <file>                            Server certificate file
+        --tlskey <file>                             Private key for server certificate
+        --tlsverify                                 Enable TLS, verify client certificates
+        --tlscacert <file>                          Client certificate CA for verification
 
 Cluster Options:
-        --routes <rurl-1, rurl-2>    Routes to solicit and connect
-        --cluster <cluster-url>      Cluster URL for solicited routes
-        --cluster_name <string>      Cluster Name, if not set one will be dynamically generated
-        --no_advertise <bool>        Do not advertise known cluster information to clients
-        --cluster_advertise <string> Cluster URL to advertise to other servers
-        --connect_retries <number>   For implicit routes, number of connect retries
-
+        --routes <rurl-1, rurl-2>                   Routes to solicit and connect
+        --cluster <cluster-url>                     Cluster URL for solicited routes
+        --cluster_name <string>                     Cluster Name, if not set one will be dynamically generated
+        --no_advertise <bool>                       Do not advertise known cluster information to clients
+        --cluster_advertise <string>                Cluster URL to advertise to other servers
+        --connect_retries <number>                  For implicit routes, number of connect retries
+        --cluster_listen <url>                      Cluster url from which members can solicit routes.
 Common Options:
-    -h, --help                       Show this message
-    -v, --version                    Show version
-        --help_tls                   TLS help
+    -h, --help                                      Show this message
+    -v, --version                                   Show version
+        --help_tls                                  TLS help
+Profiling Options:
+        --profile <port>                            Profiling HTTP port.
 `
 
 // usage will print out the flag options for the server.


### PR DESCRIPTION
### description
* The usage message for nats core does not contain all the exisitng options for setting up the server
* Also some flags we missing

### Adding resolve to issues:
https://github.com/nats-io/nats-server/issues/3521
https://github.com/nats-io/nats-server/issues/3524
### Changes proposed in this pull request:
Updates the usage guide for nats server

