### PR TITLE
Add error and its check for collision with JS API

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -1313,7 +1313,7 @@
     "constant": "JSStreamApiPrefixOverlapError",
     "code": 400,
     "error_code": 10133,
-    "description": "stream subject {subject} must not overlap with {apiprefix}",
+    "description": "stream subject {subject} and API {apiprefix} subjects overlap",
     "comment": "",
     "help": "",
     "url": "",

--- a/server/errors.json
+++ b/server/errors.json
@@ -1308,5 +1308,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSStreamApiPrefixOverlapError",
+    "code": 400,
+    "error_code": 10133,
+    "description": "stream subject {subject} must not overlap with {apiprefix}",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -263,6 +263,9 @@ const (
 	// JSStorageResourcesExceededErr insufficient storage resources available
 	JSStorageResourcesExceededErr ErrorIdentifier = 10047
 
+	// JSStreamApiPrefixOverlapError stream subject {subject} must not overlap with {apiprefix}
+	JSStreamApiPrefixOverlapError ErrorIdentifier = 10133
+
 	// JSStreamAssignmentErrF Generic stream assignment error string ({err})
 	JSStreamAssignmentErrF ErrorIdentifier = 10048
 
@@ -487,6 +490,7 @@ var (
 		JSSourceConsumerSetupFailedErrF:            {Code: 500, ErrCode: 10045, Description: "{err}"},
 		JSSourceMaxMessageSizeTooBigErr:            {Code: 400, ErrCode: 10046, Description: "stream source must have max message size >= target"},
 		JSStorageResourcesExceededErr:              {Code: 500, ErrCode: 10047, Description: "insufficient storage resources available"},
+		JSStreamApiPrefixOverlapError:              {Code: 400, ErrCode: 10133, Description: "stream subject {subject} must not overlap with {apiprefix}"},
 		JSStreamAssignmentErrF:                     {Code: 500, ErrCode: 10048, Description: "{err}"},
 		JSStreamCreateErrF:                         {Code: 500, ErrCode: 10049, Description: "{err}"},
 		JSStreamDeleteErrF:                         {Code: 500, ErrCode: 10050, Description: "{err}"},
@@ -1499,6 +1503,22 @@ func NewJSStorageResourcesExceededError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSStorageResourcesExceededErr]
+}
+
+// NewJSStreamApiPrefixOverlapError creates a new JSStreamApiPrefixOverlapError error: "stream subject {subject} must not overlap with {apiprefix}"
+func NewJSStreamApiPrefixOverlapError(apiprefix interface{}, subject interface{}, opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	e := ApiErrors[JSStreamApiPrefixOverlapError]
+	args := e.toReplacerArgs([]interface{}{"{apiprefix}", apiprefix, "{subject}", subject})
+	return &ApiError{
+		Code:        e.Code,
+		ErrCode:     e.ErrCode,
+		Description: strings.NewReplacer(args...).Replace(e.Description),
+	}
 }
 
 // NewJSStreamAssignmentError creates a new JSStreamAssignmentErrF error: "{err}"

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -263,7 +263,7 @@ const (
 	// JSStorageResourcesExceededErr insufficient storage resources available
 	JSStorageResourcesExceededErr ErrorIdentifier = 10047
 
-	// JSStreamApiPrefixOverlapError stream subject {subject} must not overlap with {apiprefix}
+	// JSStreamApiPrefixOverlapError stream subject {subject} and API {apiprefix} subjects overlap
 	JSStreamApiPrefixOverlapError ErrorIdentifier = 10133
 
 	// JSStreamAssignmentErrF Generic stream assignment error string ({err})
@@ -490,7 +490,7 @@ var (
 		JSSourceConsumerSetupFailedErrF:            {Code: 500, ErrCode: 10045, Description: "{err}"},
 		JSSourceMaxMessageSizeTooBigErr:            {Code: 400, ErrCode: 10046, Description: "stream source must have max message size >= target"},
 		JSStorageResourcesExceededErr:              {Code: 500, ErrCode: 10047, Description: "insufficient storage resources available"},
-		JSStreamApiPrefixOverlapError:              {Code: 400, ErrCode: 10133, Description: "stream subject {subject} must not overlap with {apiprefix}"},
+		JSStreamApiPrefixOverlapError:              {Code: 400, ErrCode: 10133, Description: "stream subject {subject} and API {apiprefix} subjects overlap"},
 		JSStreamAssignmentErrF:                     {Code: 500, ErrCode: 10048, Description: "{err}"},
 		JSStreamCreateErrF:                         {Code: 500, ErrCode: 10049, Description: "{err}"},
 		JSStreamDeleteErrF:                         {Code: 500, ErrCode: 10050, Description: "{err}"},
@@ -1505,7 +1505,7 @@ func NewJSStorageResourcesExceededError(opts ...ErrorOption) *ApiError {
 	return ApiErrors[JSStorageResourcesExceededErr]
 }
 
-// NewJSStreamApiPrefixOverlapError creates a new JSStreamApiPrefixOverlapError error: "stream subject {subject} must not overlap with {apiprefix}"
+// NewJSStreamApiPrefixOverlapError creates a new JSStreamApiPrefixOverlapError error: "stream subject {subject} and API {apiprefix} subjects overlap"
 func NewJSStreamApiPrefixOverlapError(apiprefix interface{}, subject interface{}, opts ...ErrorOption) *ApiError {
 	eopts := parseOpts(opts)
 	if ae, ok := eopts.err.(*ApiError); ok {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -1081,6 +1081,7 @@ func TestJetStreamAddStreamOverlapWithJSAPISubjects(t *testing.T) {
 	expectErr(acc.addStream(&StreamConfig{Name: "a", Subjects: []string{"$JS.API.foo", "$JS.API.bar"}}))
 	expectErr(acc.addStream(&StreamConfig{Name: "b", Subjects: []string{"$JS.API.>"}}))
 	expectErr(acc.addStream(&StreamConfig{Name: "c", Subjects: []string{"$JS.API.*"}}))
+	expectErr(acc.addStream(&StreamConfig{Name: "d", Subjects: []string{"$JS.>"}}))
 
 	// Events and Advisories etc should be ok.
 	if _, err := acc.addStream(&StreamConfig{Name: "a", Subjects: []string{"$JS.EVENT.>"}}); err != nil {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -1082,6 +1082,7 @@ func TestJetStreamAddStreamOverlapWithJSAPISubjects(t *testing.T) {
 	expectErr(acc.addStream(&StreamConfig{Name: "b", Subjects: []string{"$JS.API.>"}}))
 	expectErr(acc.addStream(&StreamConfig{Name: "c", Subjects: []string{"$JS.API.*"}}))
 	expectErr(acc.addStream(&StreamConfig{Name: "d", Subjects: []string{"$JS.>"}}))
+	expectErr(acc.addStream(&StreamConfig{Name: "e", Subjects: []string{">"}}))
 
 	// Ensure that all the API subject may be ingested into a stream if Ack is disabled
 	expectOK := func(s *stream, err error) {
@@ -1097,6 +1098,7 @@ func TestJetStreamAddStreamOverlapWithJSAPISubjects(t *testing.T) {
 	expectOK(acc.addStream(&StreamConfig{Name: "b", NoAck: true, Subjects: []string{"$JS.API.>"}}))
 	expectOK(acc.addStream(&StreamConfig{Name: "c", NoAck: true, Subjects: []string{"$JS.API.*"}}))
 	expectOK(acc.addStream(&StreamConfig{Name: "d", NoAck: true, Subjects: []string{"$JS.>"}}))
+	expectOK(acc.addStream(&StreamConfig{Name: "e", NoAck: true, Subjects: []string{">"}}))
 
 	// Events and Advisories etc should be ok.
 	expectOK(acc.addStream(&StreamConfig{Name: "a", Subjects: []string{"$JS.EVENT.>"}}))

--- a/server/stream.go
+++ b/server/stream.go
@@ -1147,6 +1147,12 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 		}
 	}
 
+	for _, subj := range cfg.Subjects {
+		if SubjectsCollide(subj, JSApiPrefix) {
+			return StreamConfig{}, NewJSStreamApiPrefixOverlapError(JSApiPrefix, subj)
+		}
+	}
+
 	// cycle check for source cycle
 	toVisit := []*StreamConfig{&cfg}
 	visited := make(map[string]struct{})

--- a/server/stream.go
+++ b/server/stream.go
@@ -1205,8 +1205,10 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 				return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("duplicate subjects detected"))
 			}
 			// Also check to make sure we do not overlap with our $JS API subjects.
-			if subjectIsSubsetMatch(subj, "$JS.API.>") {
-				return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("subjects overlap with jetstream api"))
+			if !cfg.NoAck { // unless Ack is disabled
+				if subjectIsSubsetMatch(subj, "$JS.API.>") {
+					return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("subjects overlap with jetstream api"))
+				}
 			}
 			// Make sure the subject is valid.
 			if !IsValidSubject(subj) {

--- a/server/stream.go
+++ b/server/stream.go
@@ -1147,9 +1147,12 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 		}
 	}
 
-	for _, subj := range cfg.Subjects {
-		if SubjectsCollide(subj, JSApiPrefix) {
-			return StreamConfig{}, NewJSStreamApiPrefixOverlapError(JSApiPrefix, subj)
+	// if Ack is on, forbid a creating stream that would respond Acks in lieu of the API.
+	if !cfg.NoAck {
+		for _, subj := range cfg.Subjects {
+			if SubjectsCollide(subj, JSApiPrefix) {
+				return StreamConfig{}, NewJSStreamApiPrefixOverlapError(JSApiPrefix, subj)
+			}
 		}
 	}
 


### PR DESCRIPTION
 - [X] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [x] Tests added
 - [ ] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #3531

### Changes proposed in this pull request:

 - check for collision with JS API when account creates a stream
 - New error for this case

/cc @nats-io/core
