### PR TITLE
Add missing `RUnlock` in `needAck`

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2343,6 +2343,7 @@ func (o *consumer) needAck(sseq uint64, subj string) bool {
 		if subj == _EMPTY_ {
 			var svp StoreMsg
 			if _, err := o.mset.store.LoadMsg(sseq, &svp); err != nil {
+				o.mu.RUnlock()
 				return false
 			}
 			subj = svp.subj


### PR DESCRIPTION
We don't seem to release the read lock if `LoadMsg` fails, which could result in unexpected lock contention.

Spotted by [ashumkin](https://github.com/ashumkin).

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

/cc @nats-io/core