### PR TITLE
Fix setting `InactivityThreshold` on existing durable consumer

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -786,7 +786,7 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 	o.nextMsgSubj = fmt.Sprintf(JSApiRequestNextT, mn, o.name)
 
 	// If the user has set the inactive threshold, set that up here.
-	o.cfg.InactiveThreshold = o.updateInactiveThresholdLocked(o.cfg.InactiveThreshold, false)
+	o.cfg.InactiveThreshold = o.updateInactiveThresholdLocked(o.cfg.InactiveThreshold)
 
 	if o.isPushMode() {
 		if !o.isDurable() {
@@ -1517,7 +1517,7 @@ func (o *consumer) updateConfig(cfg *ConsumerConfig) error {
 
 	// Set InactiveThreshold if changed.
 	if cfg.InactiveThreshold != o.cfg.InactiveThreshold {
-		cfg.InactiveThreshold = o.updateInactiveThresholdLocked(cfg.InactiveThreshold, true)
+		cfg.InactiveThreshold = o.updateInactiveThresholdLocked(cfg.InactiveThreshold)
 	}
 
 	// Record new config for others that do not need special handling.
@@ -1530,26 +1530,34 @@ func (o *consumer) updateConfig(cfg *ConsumerConfig) error {
 // updateInactiveThresholdLocked sets the dthres and either resets the
 // dtmr (if there is one) or forcibly starts one, depending on the value
 // of the "forceStart" parameter. It then returns what the final value
-// for InactiveThreshold will be (so that the jittery default for ephemeral
-// consumers can be captured in config).
-func (o *consumer) updateInactiveThresholdLocked(threshold time.Duration, forceStart bool) time.Duration {
-	started := o.dtmr != nil
+// for InactiveThreshold will be (so that the non-jittery default for
+// ephemeral consumers can be captured in config).
+func (o *consumer) updateInactiveThresholdLocked(threshold time.Duration) time.Duration {
+	if threshold == o.dthresh {
+		// If the threshold hasn't changed, don't do anything. It would
+		// be surprising to reset it just because some other part of the
+		// config was updated.
+		return threshold
+	}
 	defer func() {
-		if forceStart || started {
-			stopAndClearTimer(&o.dtmr)
+		stopAndClearTimer(&o.dtmr)
+		if threshold > 0 {
 			o.dtmr = time.AfterFunc(o.dthresh, func() { o.deleteNotActive() })
 		}
 	}()
-	if threshold > 0 {
+	if o.isDurable() || threshold > 0 {
+		// Allow either:
+		// * setting durable consumers to zero or non-zero
+		// * setting ephemeral consumers to non-zero
 		o.dthresh = threshold
-	} else if !o.isDurable() {
+		return threshold
+	} else {
 		// Ephemerals will always have inactive thresholds.
 		// Add in 1 sec of jitter above and beyond the default of 5s.
 		o.dthresh = JsDeleteWaitTimeDefault + time.Duration(rand.Int63n(1000))*time.Millisecond
 		// Only stamp config with default sans jitter.
 		return JsDeleteWaitTimeDefault
 	}
-	return threshold
 }
 
 // This is a config change for the delivery subject for a
@@ -4177,7 +4185,7 @@ func (o *consumer) switchToEphemeral() {
 	o.cfg.Durable = _EMPTY_
 	store, ok := o.store.(*consumerFileStore)
 	rr := o.acc.sl.Match(o.cfg.DeliverSubject)
-	o.updateInactiveThresholdLocked(o.cfg.InactiveThreshold, true)
+	o.updateInactiveThresholdLocked(o.cfg.InactiveThreshold)
 	o.mu.Unlock()
 
 	// Update interest

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -786,7 +786,7 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 	o.nextMsgSubj = fmt.Sprintf(JSApiRequestNextT, mn, o.name)
 
 	// If the user has set the inactive threshold, set that up here.
-	o.cfg.InactiveThreshold = o.updateInactiveThresholdLocked(o.cfg.InactiveThreshold)
+	o.cfg.InactiveThreshold = o.updateInactiveThresholdLocked(o.cfg.InactiveThreshold, false)
 
 	if o.isPushMode() {
 		if !o.isDurable() {
@@ -1517,7 +1517,7 @@ func (o *consumer) updateConfig(cfg *ConsumerConfig) error {
 
 	// Set InactiveThreshold if changed.
 	if cfg.InactiveThreshold != o.cfg.InactiveThreshold {
-		cfg.InactiveThreshold = o.updateInactiveThresholdLocked(cfg.InactiveThreshold)
+		cfg.InactiveThreshold = o.updateInactiveThresholdLocked(cfg.InactiveThreshold, true)
 	}
 
 	// Record new config for others that do not need special handling.
@@ -1532,34 +1532,24 @@ func (o *consumer) updateConfig(cfg *ConsumerConfig) error {
 // of the "forceStart" parameter. It then returns what the final value
 // for InactiveThreshold will be (so that the jittery default for ephemeral
 // consumers can be captured in config).
-func (o *consumer) updateInactiveThresholdLocked(threshold time.Duration) time.Duration {
-	origThresh := o.dthresh
+func (o *consumer) updateInactiveThresholdLocked(threshold time.Duration, forceStart bool) time.Duration {
+	started := o.dtmr != nil
 	defer func() {
-		if origThresh == o.dthresh {
-			// Nothing has changed, so don't do anything.
-			return
-		}
-		// Otherwise, reset the timer, and if the new threshold is greater
-		// than zero, start it again from this point.
-		stopAndClearTimer(&o.dtmr)
-		if o.dthresh > 0 {
+		if forceStart || started {
+			stopAndClearTimer(&o.dtmr)
 			o.dtmr = time.AfterFunc(o.dthresh, func() { o.deleteNotActive() })
 		}
 	}()
-	if o.isDurable() || threshold > 0 {
-		// Allow setting a durable consumer threshold to either a specific
-		// value or to 0 (effectively disabling it). Also allow setting an
-		// ephemeral consumer to a non-zero value.
+	if threshold > 0 {
 		o.dthresh = threshold
-		return threshold
-	} else {
-		// Ephemerals will always have inactive thresholds, so if none
-		// has been supplied then we'll generate one. Add in 1 sec of
-		// jitter above and beyond the default of 5s.
+	} else if !o.isDurable() {
+		// Ephemerals will always have inactive thresholds.
+		// Add in 1 sec of jitter above and beyond the default of 5s.
 		o.dthresh = JsDeleteWaitTimeDefault + time.Duration(rand.Int63n(1000))*time.Millisecond
 		// Only stamp config with default sans jitter.
 		return JsDeleteWaitTimeDefault
 	}
+	return threshold
 }
 
 // This is a config change for the delivery subject for a
@@ -4187,7 +4177,7 @@ func (o *consumer) switchToEphemeral() {
 	o.cfg.Durable = _EMPTY_
 	store, ok := o.store.(*consumerFileStore)
 	rr := o.acc.sl.Match(o.cfg.DeliverSubject)
-	o.updateInactiveThresholdLocked(o.cfg.InactiveThreshold)
+	o.updateInactiveThresholdLocked(o.cfg.InactiveThreshold, true)
 	o.mu.Unlock()
 
 	// Update interest

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -786,7 +786,7 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 	o.nextMsgSubj = fmt.Sprintf(JSApiRequestNextT, mn, o.name)
 
 	// If the user has set the inactive threshold, set that up here.
-	o.cfg.InactiveThreshold = o.updateInactiveThresholdLocked(o.cfg.InactiveThreshold, false)
+	o.cfg.InactiveThreshold = o.updateInactiveThresholdLocked(o.cfg.InactiveThreshold)
 
 	if o.isPushMode() {
 		if !o.isDurable() {
@@ -1517,7 +1517,7 @@ func (o *consumer) updateConfig(cfg *ConsumerConfig) error {
 
 	// Set InactiveThreshold if changed.
 	if cfg.InactiveThreshold != o.cfg.InactiveThreshold {
-		cfg.InactiveThreshold = o.updateInactiveThresholdLocked(cfg.InactiveThreshold, true)
+		cfg.InactiveThreshold = o.updateInactiveThresholdLocked(cfg.InactiveThreshold)
 	}
 
 	// Record new config for others that do not need special handling.
@@ -1532,24 +1532,34 @@ func (o *consumer) updateConfig(cfg *ConsumerConfig) error {
 // of the "forceStart" parameter. It then returns what the final value
 // for InactiveThreshold will be (so that the jittery default for ephemeral
 // consumers can be captured in config).
-func (o *consumer) updateInactiveThresholdLocked(threshold time.Duration, forceStart bool) time.Duration {
-	started := o.dtmr != nil
+func (o *consumer) updateInactiveThresholdLocked(threshold time.Duration) time.Duration {
+	origThresh := o.dthresh
 	defer func() {
-		if forceStart || started {
-			stopAndClearTimer(&o.dtmr)
+		if origThresh == o.dthresh {
+			// Nothing has changed, so don't do anything.
+			return
+		}
+		// Otherwise, reset the timer, and if the new threshold is greater
+		// than zero, start it again from this point.
+		stopAndClearTimer(&o.dtmr)
+		if o.dthresh > 0 {
 			o.dtmr = time.AfterFunc(o.dthresh, func() { o.deleteNotActive() })
 		}
 	}()
-	if threshold > 0 {
+	if o.isDurable() || threshold > 0 {
+		// Allow setting a durable consumer threshold to either a specific
+		// value or to 0 (effectively disabling it). Also allow setting an
+		// ephemeral consumer to a non-zero value.
 		o.dthresh = threshold
-	} else if !o.isDurable() {
-		// Ephemerals will always have inactive thresholds.
-		// Add in 1 sec of jitter above and beyond the default of 5s.
+		return threshold
+	} else {
+		// Ephemerals will always have inactive thresholds, so if none
+		// has been supplied then we'll generate one. Add in 1 sec of
+		// jitter above and beyond the default of 5s.
 		o.dthresh = JsDeleteWaitTimeDefault + time.Duration(rand.Int63n(1000))*time.Millisecond
 		// Only stamp config with default sans jitter.
 		return JsDeleteWaitTimeDefault
 	}
-	return threshold
 }
 
 // This is a config change for the delivery subject for a
@@ -4177,7 +4187,7 @@ func (o *consumer) switchToEphemeral() {
 	o.cfg.Durable = _EMPTY_
 	store, ok := o.store.(*consumerFileStore)
 	rr := o.acc.sl.Match(o.cfg.DeliverSubject)
-	o.updateInactiveThresholdLocked(o.cfg.InactiveThreshold, true)
+	o.updateInactiveThresholdLocked(o.cfg.InactiveThreshold)
 	o.mu.Unlock()
 
 	// Update interest

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -1003,7 +1003,7 @@ func TestJetStreamSuperClusterEphemeralCleanup(t *testing.T) {
 			}
 			cons := mset.getConsumers()[0]
 			cons.mu.Lock()
-			cons.updateInactiveThresholdLocked(1250*time.Millisecond, false)
+			cons.dthresh = 1250 * time.Millisecond
 			active := cons.active
 			dtimerSet := cons.dtmr != nil
 			deliver := cons.cfg.DeliverSubject

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -1003,7 +1003,7 @@ func TestJetStreamSuperClusterEphemeralCleanup(t *testing.T) {
 			}
 			cons := mset.getConsumers()[0]
 			cons.mu.Lock()
-			cons.dthresh = 1250 * time.Millisecond
+			cons.updateInactiveThresholdLocked(1250*time.Millisecond, false)
 			active := cons.active
 			dtimerSet := cons.dtmr != nil
 			deliver := cons.cfg.DeliverSubject

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -18123,15 +18123,12 @@ func TestJetStreamConsumerInactiveThreshold(t *testing.T) {
 		t.Fatalf("Did not receive completion signal")
 	}
 
-	waitOnCleanup := func(ci *nats.ConsumerInfo, shouldBeDeleted bool) {
+	waitOnCleanup := func(ci *nats.ConsumerInfo) {
 		t.Helper()
 		checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
 			_, err := js.ConsumerInfo(ci.Stream, ci.Name)
-			switch {
-			case shouldBeDeleted && err == nil:
+			if err == nil {
 				return fmt.Errorf("Consumer still present")
-			case !shouldBeDeleted && err != nil:
-				return fmt.Errorf("Consumer should be present")
 			}
 			return nil
 		})
@@ -18147,7 +18144,7 @@ func TestJetStreamConsumerInactiveThreshold(t *testing.T) {
 		InactiveThreshold: 50 * time.Millisecond,
 	})
 	require_NoError(t, err)
-	waitOnCleanup(ci, true)
+	waitOnCleanup(ci)
 
 	// Ephemeral Pull
 	ci, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
@@ -18155,7 +18152,7 @@ func TestJetStreamConsumerInactiveThreshold(t *testing.T) {
 		InactiveThreshold: 50 * time.Millisecond,
 	})
 	require_NoError(t, err)
-	waitOnCleanup(ci, true)
+	waitOnCleanup(ci)
 
 	// Support InactiveThresholds for Durables as well.
 
@@ -18166,7 +18163,7 @@ func TestJetStreamConsumerInactiveThreshold(t *testing.T) {
 		InactiveThreshold: 50 * time.Millisecond,
 	})
 	require_NoError(t, err)
-	waitOnCleanup(ci, true)
+	waitOnCleanup(ci)
 
 	// Durable Push (no bind to deliver subject) with an activity
 	// threshold set after creation
@@ -18181,23 +18178,7 @@ func TestJetStreamConsumerInactiveThreshold(t *testing.T) {
 		InactiveThreshold: 50 * time.Millisecond,
 	})
 	require_NoError(t, err)
-	waitOnCleanup(ci, true)
-
-	// Durable Push (no bind to deliver subject) with an activity
-	// threshold removed after creation
-	ci, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
-		Durable:           "d1",
-		DeliverSubject:    "_no_bind_",
-		InactiveThreshold: 50 * time.Millisecond,
-	})
-	require_NoError(t, err)
-	_, err = js.UpdateConsumer("TEST", &nats.ConsumerConfig{
-		Durable:           "d1",
-		DeliverSubject:    "_no_bind_",
-		InactiveThreshold: 0,
-	})
-	require_NoError(t, err)
-	waitOnCleanup(ci, false)
+	waitOnCleanup(ci)
 
 	// Durable Pull
 	ci, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
@@ -18206,7 +18187,7 @@ func TestJetStreamConsumerInactiveThreshold(t *testing.T) {
 		InactiveThreshold: 50 * time.Millisecond,
 	})
 	require_NoError(t, err)
-	waitOnCleanup(ci, true)
+	waitOnCleanup(ci)
 
 	// Durable Pull with an inactivity threshold set after creation
 	ci, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
@@ -18220,22 +18201,7 @@ func TestJetStreamConsumerInactiveThreshold(t *testing.T) {
 		InactiveThreshold: 50 * time.Millisecond,
 	})
 	require_NoError(t, err)
-	waitOnCleanup(ci, true)
-
-	// Durable Pull with an inactivity threshold removed after creation
-	ci, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
-		Durable:           "d2",
-		AckPolicy:         nats.AckExplicitPolicy,
-		InactiveThreshold: 50 * time.Millisecond,
-	})
-	require_NoError(t, err)
-	_, err = js.UpdateConsumer("TEST", &nats.ConsumerConfig{
-		Durable:           "d3",
-		AckPolicy:         nats.AckExplicitPolicy,
-		InactiveThreshold: 0,
-	})
-	require_NoError(t, err)
-	waitOnCleanup(ci, false)
+	waitOnCleanup(ci)
 }
 
 func TestJetStreamConsumerAndStreamNamesWithPathSeparators(t *testing.T) {


### PR DESCRIPTION
Beforehand, the threshold and timer weren't resetting properly when an existing durable consumer was updated with a new `InactivityThreshold` so consumers wouldn't get cleaned up until the NATS Server was restarted. This PR refactors that to use a common function both when the consumer is set up and when it is updated, which effectively fixes the bug. It also updates the unit tests to verify that it works both ways.

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

/cc @nats-io/core