### PR TITLE
fix: Prevent nil map assignment panic if disk is full

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -3160,7 +3160,9 @@ func (mb *msgBlock) writeMsgRecord(rl, seq uint64, subj string, mhdr, msg []byte
 
 	// Check if we are tracking per subject for our simple state.
 	if len(subj) > 0 && !mb.noTrack {
-		mb.ensurePerSubjectInfoLoaded()
+		if err := mb.ensurePerSubjectInfoLoaded(); err != nil {
+			return fmt.Errorf("error loading fss: %w", err)
+		}
 		if ss := mb.fss[subj]; ss != nil {
 			ss.Msgs++
 			ss.Last = seq


### PR DESCRIPTION
If the server is unable to write to disk, there is a failure mode that results in the fss map being nil when writing message block data to it, resulting in a panic. This fix checks whether an error is returned by the function that loads the fss map, and if so, returns an error to prevent future assignment.

This issue was brought up in matrix-org/dendrite#2796. I'm not sure if it's appropriate to return early if an error is encountered, or to simply allocate the map and continue with the function. Or perhaps I could add an explicit check for whether the error returned is an "out of space" error and only return in that instance. Please let me know if there's a better alternative, thanks!

 - [x] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)


### Changes proposed in this pull request:

 - Fix panic that occurs when disk is full

/cc @nats-io/core
