### PR TITLE
[FIXED] JetStream: User given named ephemeral lost after migration

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -873,7 +873,9 @@ func (s *Server) migrateEphemerals() {
 					cc.meta.ForwardProposal(encodeDeleteConsumerAssignment(ca))
 					// Encode state and new name.
 					ca.State = state
-					ca.Name = createConsumerName()
+					if ca.Config.Name == _EMPTY_ {
+						ca.Name = createConsumerName()
+					}
 					addEntry := encodeAddConsumerAssignmentCompressed(ca)
 					cc.meta.ForwardProposal(addEntry)
 					js.mu.Unlock()

--- a/server/server.go
+++ b/server/server.go
@@ -1886,12 +1886,12 @@ func (s *Server) Shutdown() {
 	if s == nil {
 		return
 	}
-	// Transfer off any raft nodes that we are a leader by stepping them down.
-	s.stepdownRaftNodes()
-
 	// This is for clustered JetStream and ephemeral consumers.
 	// No-op if not clustered or not running JetStream.
 	s.migrateEphemerals()
+
+	// Transfer off any raft nodes that we are a leader by stepping them down.
+	s.stepdownRaftNodes()
 
 	// Shutdown the eventing system as needed.
 	// This is done first to send out any messages for


### PR DESCRIPTION
If an ephemeral was given a name by the user, if the consumer leader was then shutdown, the ephemeral would be migrated using a server generated new name instead of keeping the user given name.

Also, in some cases the migration would not even occur. This was likely due to the fact that RAFT node(s) were shutdown prior to the ephemeral migration code was invoked.

Resolves #3550

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
