### PR TITLE
[FIXED] Solicited route may not retry to reconnect

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4937,7 +4937,10 @@ func (c *client) reconnect() {
 		return
 	}
 	if c.route != nil {
-		retryImplicit = c.route.retry
+		// A route is marked as solicited if it was given an URL to connect to,
+		// which would be the case even with implicit (due to gossip), so mark this
+		// as a retry for a route that is solicited and not explicit.
+		retryImplicit = c.route.retry || (c.route.didSolicit && c.route.routeType == Implicit)
 	}
 	kind := c.kind
 	if kind == GATEWAY {


### PR DESCRIPTION
Originally, only solicited routes were retried in case of a disconnect, but that was before gossip protocol was introduced. Since then, two servers that connect to each other due to gossip should retry to reconnect if the connection breaks, even if the route is not explicit. However, server will retry only once or more accurately, ConnectRetries+1.

This PR solves the issue that the reconnect attempt was not initiated for a "solicited route" that was not explicit.

Maybe related to #3571

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
