### PR TITLE
Removed ephemeral consumer migration.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2608,8 +2608,6 @@ func (wq *waitQueue) compact() {
 // Return the replies for our pending requests.
 // No-op if push consumer or invalid etc.
 func (o *consumer) pendingRequestReplies() []string {
-	o.mu.RLock()
-	defer o.mu.RUnlock()
 	if o.waiting == nil {
 		return nil
 	}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -6111,7 +6111,8 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 		// We need to set the ephemeral here before replicating.
 		if !isDurableConsumer(cfg) {
 			// We chose to have ephemerals be R=1 unless stream is interest or workqueue.
-			if sa.Config.Retention == LimitsPolicy {
+			// Consumer can override.
+			if sa.Config.Retention == LimitsPolicy && cfg.Replicas <= 1 {
 				rg.Peers = []string{rg.Preferred}
 				rg.Name = groupNameForConsumer(rg.Peers, rg.Storage)
 			}

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -611,6 +611,7 @@ func TestJetStreamClusterUserGivenConsNameWithLeaderChange(t *testing.T) {
 			Name:              consName,
 			FilterSubject:     "foo",
 			InactiveThreshold: time.Hour,
+			Replicas:          3,
 		},
 	}
 	subj := fmt.Sprintf(JSApiConsumerCreateExT, "TEST", consName, "foo")
@@ -651,6 +652,7 @@ func TestJetStreamClusterUserGivenConsNameWithLeaderChange(t *testing.T) {
 	time.Sleep(250 * time.Millisecond)
 
 	// Wait for new leader
+	c.waitOnStreamLeader(globalAccountName, "TEST")
 	c.waitOnConsumerLeader(globalAccountName, "TEST", consName)
 
 	// Make sure we can still consume.

--- a/server/server.go
+++ b/server/server.go
@@ -1886,9 +1886,9 @@ func (s *Server) Shutdown() {
 	if s == nil {
 		return
 	}
-	// This is for clustered JetStream and ephemeral consumers.
-	// No-op if not clustered or not running JetStream.
-	s.migrateEphemerals()
+	// This is for JetStream R1 Pull Consumers to allow signaling
+	// that pending pull requests are invalid.
+	s.signalPullConsumers()
 
 	// Transfer off any raft nodes that we are a leader by stepping them down.
 	s.stepdownRaftNodes()


### PR DESCRIPTION
We still will signal R1 pull consumers with pending requests.
Also fixed a bug that would not honor replicas for new style named consumers.


/cc @nats-io/core
