### PR TITLE
[FIXED] `allow_non_tls` is lost after server reload

### DIFF
--- a/server/reload.go
+++ b/server/reload.go
@@ -206,7 +206,7 @@ type tlsOption struct {
 func (t *tlsOption) Apply(server *Server) {
 	server.mu.Lock()
 	tlsRequired := t.newValue != nil
-	server.info.TLSRequired = tlsRequired
+	server.info.TLSRequired = tlsRequired && !server.getOpts().AllowNonTLS
 	message := "disabled"
 	if tlsRequired {
 		server.info.TLSVerify = (t.newValue.ClientAuth == tls.RequireAndVerifyClientCert)


### PR DESCRIPTION
The server would reset its INFO's TLSRequired to the presence of a TLS configuration without checking for the allow_non_tls option.

Resolves #3581

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
