### PR TITLE
[FIXED] Existing subs would be sent to leafnodes even though they violated permissions.

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1670,7 +1670,8 @@ func (s *Server) initLeafNodeSmapAndSendSubs(c *client) {
 	c.leaf.smap = make(map[string]int32)
 	for _, sub := range subs {
 		subj := string(sub.subject)
-		if c.isSpokeLeafNode() && !c.canSubscribe(subj) {
+		// Check perms regardless of role.
+		if !c.canSubscribe(subj) {
 			c.Debugf("Not permitted to subscribe to %q on behalf of %s%s", subj, accName, accNTag)
 			continue
 		}
@@ -1970,6 +1971,7 @@ func (c *client) processLeafSub(argo []byte) (err error) {
 	if checkPerms && subjectIsLiteral(string(sub.subject)) && !c.pubAllowedFullCheck(string(sub.subject), true, true) {
 		c.mu.Unlock()
 		c.leafSubPermViolation(sub.subject)
+		c.Debugf(fmt.Sprintf("Permissions Violation for Subscription to %q", sub.subject))
 		return nil
 	}
 


### PR DESCRIPTION
The LS+ would be sent for existing subscriptions upon leafnode connect but then would be silently denied due to permissions violations. This would make it tough for anyone with only access to the leafnode to understand why a request might be getting NoResponders.

We now do not allow existing subs to pass, so a trace log on the leafnode would not show an LS+ for the service subject.
If the LS+ does get through we debug log that it was denied.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
