### PR TITLE
[FIXED] JetStream: possible panic on some rare cases

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3787,7 +3787,7 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 	defer s.grWG.Done()
 
 	if n == nil {
-		s.Warnf("No RAFT group for '%s > %s > %s'", o.acc.Name, ca.Stream, ca.Name, n.Group())
+		s.Warnf("No RAFT group for '%s > %s > %s'", o.acc.Name, ca.Stream, ca.Name)
 		return
 	}
 


### PR DESCRIPTION
Very difficult to reproduce. Had to run TestJetStreamSuperClusterMoveCancel in covermode=atomic on a slow machine to hit the condition where the monitorConsumer go routine is started by RAFT node is nil, which caused the warning message to produce the panic (since n is nil)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
