### PR TITLE
Updates to PR #3611

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -554,6 +554,9 @@ func (a *Account) RoutedSubs() int {
 func (a *Account) TotalSubs() int {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
+	if a.sl == nil {
+		return 0
+	}
 	return int(a.sl.Count())
 }
 

--- a/server/route.go
+++ b/server/route.go
@@ -1906,21 +1906,19 @@ func (c *client) isSolicitedRoute() bool {
 // Save the first hostname found in route URLs. This will be used in gossip mode
 // when trying to create a TLS connection by setting the tlsConfig.ServerName.
 // Lock is held on entry
-func (s *Server) saveRouteTLSName() {
-	var tlsName string
-	for _, u := range s.getOpts().Routes {
-		if tlsName == _EMPTY_ && net.ParseIP(u.Hostname()) == nil {
-			tlsName = u.Hostname()
+func (s *Server) saveRouteTLSName(routes []*url.URL) {
+	for _, u := range routes {
+		if s.routeTLSName == _EMPTY_ && net.ParseIP(u.Hostname()) == nil {
+			s.routeTLSName = u.Hostname()
 		}
 	}
-	s.routeTLSName = tlsName
 }
 
 // Start connection process to provided routes. Each route connection will
 // be started in a dedicated go routine.
 // Lock is held on entry
 func (s *Server) solicitRoutes(routes []*url.URL) {
-	s.saveRouteTLSName()
+	s.saveRouteTLSName(routes)
 	for _, r := range routes {
 		route := r
 		s.startGoRoutine(func() { s.connectToRoute(route, true, true) })

--- a/server/server.go
+++ b/server/server.go
@@ -2912,9 +2912,7 @@ func (s *Server) numSubscriptions() uint32 {
 	var subs int
 	s.accounts.Range(func(k, v interface{}) bool {
 		acc := v.(*Account)
-		if acc.sl != nil {
-			subs += acc.TotalSubs()
-		}
+		subs += acc.TotalSubs()
 		return true
 	})
 	return uint32(subs)


### PR DESCRIPTION
- Save the TLS name only if not already set
- Use the passed URLs slice instead of using s.getOpts().Routes
- Enhanced the test
- Fixed an unrelated DATA RACE report

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
