### PR TITLE
[FIXED] Enforce HA asset limits during peer processing as well as assignments.

### DIFF
--- a/server/test_test.go
+++ b/server/test_test.go
@@ -106,11 +106,11 @@ func require_Error(t *testing.T, err error, expected ...error) {
 	}
 
 	for _, e := range expected {
-		if err == e || strings.Contains(e.Error(), eStr) {
+		if err == e || strings.Contains(eStr, e.Error()) || strings.Contains(e.Error(), eStr) {
 			return
 		}
 	}
-	t.Fatalf("Expected one of %+v, got '%v'", expected, err)
+	t.Fatalf("Expected one of %v, got '%v'", expected, err)
 }
 
 func require_Equal(t *testing.T, a, b string) {


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
