### PR TITLE
add unique_tag to JetStreamConfig for varz/jsz visibility

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -43,6 +43,7 @@ type JetStreamConfig struct {
 	StoreDir   string `json:"store_dir,omitempty"`
 	Domain     string `json:"domain,omitempty"`
 	CompressOK bool   `json:"compress_ok,omitempty"`
+	UniqueTag  string `json:"unique_tag,omitempty"`
 }
 
 // Statistics about JetStream for this server.
@@ -174,10 +175,10 @@ func (s *Server) EnableJetStream(config *JetStreamConfig) error {
 
 	s.Noticef("Starting JetStream")
 	if config == nil || config.MaxMemory <= 0 || config.MaxStore <= 0 {
-		var storeDir, domain string
+		var storeDir, domain, uniqueTag string
 		var maxStore, maxMem int64
 		if config != nil {
-			storeDir, domain = config.StoreDir, config.Domain
+			storeDir, domain, uniqueTag = config.StoreDir, config.Domain, config.UniqueTag
 			maxStore, maxMem = config.MaxStore, config.MaxMemory
 		}
 		config = s.dynJetStreamConfig(storeDir, maxStore, maxMem)
@@ -186,6 +187,9 @@ func (s *Server) EnableJetStream(config *JetStreamConfig) error {
 		}
 		if domain != _EMPTY_ {
 			config.Domain = domain
+		}
+		if uniqueTag != _EMPTY_ {
+			config.UniqueTag = uniqueTag
 		}
 		s.Debugf("JetStream creating dynamic configuration - %s memory, %s disk", friendlyBytes(config.MaxMemory), friendlyBytes(config.MaxStore))
 	} else if config.StoreDir != _EMPTY_ {

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -4116,13 +4116,15 @@ func TestMonitorJsz(t *testing.T) {
 			max_mem_store: 10Mb
 			max_file_store: 10Mb
 			store_dir: '%s'
+			unique_tag: az
 		}
 		cluster {
 			name: cluster_name
 			listen: 127.0.0.1:%d
 			routes: [nats-route://127.0.0.1:%d]
 		}
-		server_name: server_%d `, test.port, test.mport, tmpDir, test.cport, test.routed, test.port)))
+		server_name: server_%d
+        server_tags: [ "az:%d" ] `, test.port, test.mport, tmpDir, test.cport, test.routed, test.port, test.port)))
 		defer removeFile(t, cf)
 
 		s, _ := RunServerWithConfig(cf)
@@ -4390,6 +4392,14 @@ func TestMonitorJsz(t *testing.T) {
 			info := readJsInfo(url + "?acc=DOES_NOT_EXIT")
 			if len(info.AccountDetails) != 0 {
 				t.Fatalf("expected no account to be returned by %s but got %v", url, info)
+			}
+		}
+	})
+	t.Run("unique-tag-exists", func(t *testing.T) {
+		for _, url := range []string{monUrl1, monUrl2} {
+			info := readJsInfo(url)
+			if len(info.Config.UniqueTag) == 0 {
+				t.Fatalf("expected unique_tag to be returned by %s but got %v", url, info)
 			}
 		}
 	})

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -4124,7 +4124,7 @@ func TestMonitorJsz(t *testing.T) {
 			routes: [nats-route://127.0.0.1:%d]
 		}
 		server_name: server_%d
-        server_tags: [ "az:%d" ] `, test.port, test.mport, tmpDir, test.cport, test.routed, test.port, test.port)))
+		server_tags: [ "az:%d" ] `, test.port, test.mport, tmpDir, test.cport, test.routed, test.port, test.port)))
 		defer removeFile(t, cf)
 
 		s, _ := RunServerWithConfig(cf)

--- a/server/server.go
+++ b/server/server.go
@@ -1769,6 +1769,7 @@ func (s *Server) Start() {
 			MaxStore:   opts.JetStreamMaxStore,
 			Domain:     opts.JetStreamDomain,
 			CompressOK: true,
+			UniqueTag:  opts.JetStreamUniqueTag,
 		}
 		if err := s.EnableJetStream(cfg); err != nil {
 			s.Fatalf("Can't start JetStream: %v", err)


### PR DESCRIPTION
Surface unique_tag (if set as a JetStream option on a server) in varz and jsz.  This provides an operational debugging and configuration validation data point (e.g. unique_tag MUST be uniform across all servers in a SuperCluster).

/cc @nats-io/core
