### PR TITLE
[FIXED] Weighted subject mappings updates not applied

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -707,8 +707,8 @@ func (a *Account) AddWeightedMappings(src string, dests ...*MapDest) error {
 	}
 
 	// Replace an old one if it exists.
-	for i, m := range a.mappings {
-		if m.src == src {
+	for i, em := range a.mappings {
+		if em.src == src {
 			a.mappings[i] = m
 			return nil
 		}


### PR DESCRIPTION
Suppose an account is updated to have the following weighted mapping:
```
foo -> bar 40%
```
The server automatically adds foo -> foo at 60%. Sending messages to "foo" will result in the expected distribution of 60% messages going to "foo" and 40% going to bar.

However, if a successive update is pushed to the server(s):
```
foo -> bar 40%
foo -> baz 60%
```
The subject mapping should now be as described, that is, no more mapping from "foo" to "foo" and 40% to bar and 60% to baz, however, what was happening is that the server would always use the original mapping.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
