### PR TITLE
Set max payload in gofuzz test

### DIFF
--- a/server/fuzz.go
+++ b/server/fuzz.go
@@ -26,7 +26,7 @@ var defaultFuzzServerOptions = Options{
 }
 
 func dummyFuzzClient() *client {
-	return &client{srv: New(&defaultFuzzServerOptions), msubs: -1, mpay: -1, mcl: MAX_CONTROL_LINE_SIZE}
+	return &client{srv: New(&defaultFuzzServerOptions), msubs: -1, mpay: 1048576, mcl: MAX_CONTROL_LINE_SIZE}
 }
 
 func FuzzClient(data []byte) int {

--- a/server/fuzz.go
+++ b/server/fuzz.go
@@ -26,7 +26,7 @@ var defaultFuzzServerOptions = Options{
 }
 
 func dummyFuzzClient() *client {
-	return &client{srv: New(&defaultFuzzServerOptions), msubs: -1, mpay: 1048576, mcl: MAX_CONTROL_LINE_SIZE}
+	return &client{srv: New(&defaultFuzzServerOptions), msubs: -1, mpay: MAX_PAYLOAD_SIZE, mcl: MAX_CONTROL_LINE_SIZE}
 }
 
 func FuzzClient(data []byte) int {


### PR DESCRIPTION
This was causing the test to overrun mem limits.

Signed-off-by: Waldemar Quevedo <wally@nats.io>

/cc @nats-io/core
