### PR TITLE
[IMPROVED] Don't copy pending on needAck check.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2410,7 +2410,7 @@ func (o *consumer) needAck(sseq uint64, subj string) bool {
 			o.mu.RUnlock()
 			return false
 		}
-		state, err := o.store.State()
+		state, err := o.store.BorrowState()
 		if err != nil || state == nil {
 			// Fall back to what we track internally for now.
 			needAck := sseq > o.asflr && !o.isFiltered()

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4070,13 +4070,14 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 						}
 						panic(err.Error())
 					}
-					if err := o.store.UpdateDelivered(dseq, sseq, dc, ts); err != nil {
-						panic(err.Error())
-					}
-					// Update activity.
+					// Make sure to update delivered under the lock.
 					o.mu.Lock()
+					err = o.store.UpdateDelivered(dseq, sseq, dc, ts)
 					o.ldt = time.Now()
 					o.mu.Unlock()
+					if err != nil {
+						panic(err.Error())
+					}
 				}
 			case updateAcksOp:
 				dseq, sseq, err := decodeAckUpdate(buf[1:])

--- a/server/store.go
+++ b/server/store.go
@@ -177,6 +177,7 @@ type ConsumerStore interface {
 	UpdateConfig(cfg *ConsumerConfig) error
 	Update(*ConsumerState) error
 	State() (*ConsumerState, error)
+	BorrowState() (*ConsumerState, error)
 	EncodedState() ([]byte, error)
 	Type() StorageType
 	Stop() error


### PR DESCRIPTION
When determining whether we need an ack, no need to copy since under consumer lock.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
