### PR TITLE
When reading state, even on consumer init, should lock.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -749,7 +749,9 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 
 	if o.store != nil && o.store.HasState() {
 		// Restore our saved state.
+		o.mu.Lock()
 		o.readStoredState(0)
+		o.mu.Unlock()
 	} else {
 		// Select starting sequence number
 		o.selectStartingSeqNo()


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
