### PR TITLE
[FIXED] Allow any type of ack to suppress auto-cleanup of consumer.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -853,7 +853,7 @@ func (o *consumer) updateInactiveThreshold(cfg *ConsumerConfig) {
 	// Ephemerals will always have inactive thresholds.
 	if !o.isDurable() && cfg.InactiveThreshold <= 0 {
 		// Add in 1 sec of jitter above and beyond the default of 5s.
-		o.dthresh = cfg.InactiveThreshold + 100*time.Millisecond + time.Duration(rand.Int63n(900))*time.Millisecond
+		o.dthresh = JsDeleteWaitTimeDefault + 100*time.Millisecond + time.Duration(rand.Int63n(900))*time.Millisecond
 		// Only stamp config with default sans jitter.
 		cfg.InactiveThreshold = JsDeleteWaitTimeDefault
 	} else if cfg.InactiveThreshold > 0 {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -14634,7 +14634,8 @@ func TestJetStreamPullConsumerCrossAccountExpires(t *testing.T) {
 		return nil
 	})
 	// Now make sure the ephemeral goes away too.
-	checkFor(t, 5*time.Second, 10*time.Millisecond, func() error {
+	// Ephemerals have jitter by default of up to 1s.
+	checkFor(t, 6*time.Second, 10*time.Millisecond, func() error {
 		_, err := js.ConsumerInfo("PC", ci.Name)
 		if err == nil {
 			return fmt.Errorf("Consumer still present")


### PR DESCRIPTION
Also modified some of the auto-cleanup logic for pull consumers.
 
Signed-off-by: Derek Collison <derek@nats.io>

Resolves #3630 

/cc @nats-io/core
