### PR TITLE
[FIXED] JetStream: WorkQueue not preventing overlapping consumers

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -4675,7 +4675,8 @@ func (mset *stream) partitionUnique(partition string) bool {
 		if o.cfg.FilterSubject == _EMPTY_ {
 			return false
 		}
-		if subjectIsSubsetMatch(partition, o.cfg.FilterSubject) {
+		if subjectIsSubsetMatch(partition, o.cfg.FilterSubject) ||
+			subjectIsSubsetMatch(o.cfg.FilterSubject, partition) {
 			return false
 		}
 	}


### PR DESCRIPTION
A stream with a WorkQueue retention policy is supposed to allow more than one consumer if they user filtered subjects, but those subjects should not overlap.

There was an issue that if a new consumer had a filter subject "wider" than an existing one, the error was not detected and the new consumer was incorrectly accepted.

Resolves #3639

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
