### PR TITLE
[FIXED] Server might crash on pull consumer delete.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3130,10 +3130,14 @@ func (o *consumer) suppressDeletion() {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
+	if o.closed {
+		return
+	}
+
 	if o.isPushMode() && o.dtmr != nil {
 		// if dtmr is not nil we have started the countdown, simply reset to threshold.
 		o.dtmr.Reset(o.dthresh)
-	} else if o.isPullMode() {
+	} else if o.isPullMode() && o.waiting != nil {
 		// Pull mode always has timer running, just update last on waiting queue.
 		o.waiting.last = time.Now()
 	}


### PR DESCRIPTION
If a pull consumer with an inactivity threshold ack'd a msg then immediately deleted the consumer, the server could crash.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #3657 

/cc @nats-io/core
