### PR TITLE
Add a system account responder for IDZ along with STATSZ etc.

### DIFF
--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1664,7 +1664,7 @@ func TestSystemAccountWithGateways(t *testing.T) {
 
 	// If this tests fails with wrong number after 10 seconds we may have
 	// added a new inititial subscription for the eventing system.
-	checkExpectedSubs(t, 45, sa)
+	checkExpectedSubs(t, 47, sa)
 
 	// Create a client on B and see if we receive the event
 	urlb := fmt.Sprintf("nats://%s:%d", ob.Host, ob.Port)


### PR DESCRIPTION
This will avoid write locks and any non-static data.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
