### PR TITLE
Add account, stream and consumer name to consumer alignment cleanup warning

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1362,7 +1362,7 @@ func (o *consumer) deleteNotActive() {
 					js.mu.RUnlock()
 					if ca != nil {
 						if fs {
-							s.Warnf("Consumer assignment not cleaned up, retrying")
+							s.Warnf("Consumer assignment not cleaned up for account: '%s', stream: '%s', consumer: '%s', retrying", acc, stream, name)
 							meta.ForwardProposal(removeEntry)
 						}
 						fs = true


### PR DESCRIPTION
 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

### Changes proposed in this pull request:

 - Adds account, stream and consumer names to the consumer assignment not cleaned up warning


/cc @nats-io/core
