### PR TITLE
Adjust minimum workload of JetStream benchmarks

### DIFF
--- a/server/jetstream_benchmark_consume_test.go
+++ b/server/jetstream_benchmark_consume_test.go
@@ -256,10 +256,10 @@ func BenchmarkJetStreamConsume(b *testing.B) {
 		messageSize int
 		minMessages int
 	}{
-		{1, 1, 10, 1_000_000}, // Single node, 10B messages, ~10MiB minimum
-		{1, 1, 1024, 100_000}, // Single node, 1KB messages, ~100MiB minimum
-		{3, 3, 10, 1_000_000}, // Cluster, R3, 10B messages, ~10MiB minimum
-		{3, 3, 1024, 100_000}, // Cluster, R3, 1KB messages, ~100MiB minimum
+		{1, 1, 10, 100_000}, // Single node, 10B messages, ~1MiB minimum
+		{1, 1, 1024, 1_000}, // Single node, 1KB messages, ~1MiB minimum
+		{3, 3, 10, 100_000}, // Cluster, R3, 10B messages, ~1MiB minimum
+		{3, 3, 1024, 1_000}, // Cluster, R3, 1KB messages, ~1MiB minimum
 	}
 
 	//Each of the cases above is run with each of the consumer types

--- a/server/jetstream_benchmark_kv_test.go
+++ b/server/jetstream_benchmark_kv_test.go
@@ -31,7 +31,7 @@ func BenchmarkJetStreamKV(b *testing.B) {
 		kvNamePrefix = "B_"
 		keyPrefix    = "K_"
 		seed         = 12345
-		minOps       = 100_000
+		minOps       = 1_000
 	)
 
 	runKVGet := func(b *testing.B, kvs []nats.KeyValue, keys []string) int {

--- a/server/jetstream_benchmark_publish_test.go
+++ b/server/jetstream_benchmark_publish_test.go
@@ -140,10 +140,10 @@ func BenchmarkJetStreamPublish(b *testing.B) {
 		numSubjects int
 		minMessages int
 	}{
-		{1, 1, 10, 1, 1_000_000}, // Single node, 10B messages, ~10MB minimum
-		{1, 1, 1024, 1, 500_000}, // Single node, 1KB messages, ~500MB minimum
-		{3, 3, 10, 1, 500_000},   // 3-nodes cluster, R=3, 10B messages, ~5MB minimum
-		{3, 3, 1024, 1, 100_000}, // 3-nodes cluster, R=3, 10B messages, ~100MB minimum
+		{1, 1, 10, 1, 100_000}, // Single node, 10B messages, ~1MB minimum
+		{1, 1, 1024, 1, 1_000}, // Single node, 1KB messages, ~1MB minimum
+		{3, 3, 10, 1, 100_000}, // 3-nodes cluster, R=3, 10B messages, ~1MB minimum
+		{3, 3, 1024, 1, 1_000}, // 3-nodes cluster, R=3, 10B messages, ~1MB minimum
 	}
 
 	// All the cases above are run with each of the publisher cases below


### PR DESCRIPTION
Lower minimum amount of data / number of operations so that benchmarks  can run in reasonable time.

Minimum amount of work should be controlled via `-benchtime` flag. But  due to these hardcoded limits, some tests were taking too long.

e.g. Running for 2 minutes even with `-benchtime` set to 1 second.

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

### Changes proposed in this pull request:

 - Lower the minimum hardcoded amount of work in JS benchmarks

In some cases, the hardcoded minimum was too high, leading to a benchmark taking **minutes**, even if `-benchtime=1s` (or similar). 

/cc @nats-io/core