### PR TITLE
Do not gather full state for snapshots

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5748,7 +5748,8 @@ func (fs *fileStore) Snapshot(deadline time.Duration, checkMsgs, includeConsumer
 	}
 
 	// We can add to our stream while snapshotting but not delete anything.
-	state := fs.State()
+	var state StreamState
+	fs.FastState(&state)
 
 	// Stream in separate Go routine.
 	go fs.streamSnapshot(pw, &state, includeConsumers)


### PR DESCRIPTION
This avoids full state outputs for streams with many deleted items

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
