### PR TITLE
[FIXED] Fix for server panic when consumer state was not decoded correctly.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -6535,6 +6535,7 @@ func (o *consumerFileStore) stateWithCopy(doCopy bool) (*ConsumerState, error) {
 	return state, nil
 }
 
+// Decode consumer state.
 func decodeConsumerState(buf []byte) (*ConsumerState, error) {
 	version, err := checkConsumerHeader(buf)
 	if err != nil {
@@ -6602,7 +6603,8 @@ func decodeConsumerState(buf []byte) (*ConsumerState, error) {
 				dseq = readSeq()
 			}
 			ts := readTimeStamp()
-			if ts == -1 {
+			// Check the state machine for corruption, not the value which could be -1.
+			if bi == -1 {
 				return nil, errCorruptState
 			}
 			// Adjust seq back.

--- a/server/store.go
+++ b/server/store.go
@@ -205,6 +205,7 @@ type ConsumerState struct {
 	Redelivered map[uint64]uint64 `json:"redelivered,omitempty"`
 }
 
+// Encode consumer state.
 func encodeConsumerState(state *ConsumerState) []byte {
 	var hdr [seqsHdrSize]byte
 	var buf []byte
@@ -238,7 +239,7 @@ func encodeConsumerState(state *ConsumerState) []byte {
 
 	// These are optional, but always write len. This is to avoid a truncate inline.
 	if len(state.Pending) > 0 {
-		// To save space we will use now rounded to seconds to be base timestamp.
+		// To save space we will use now rounded to seconds to be our base timestamp.
 		mints := time.Now().Round(time.Second).Unix()
 		// Write minimum timestamp we found from above.
 		n += binary.PutVarint(buf[n:], mints)
@@ -248,7 +249,7 @@ func encodeConsumerState(state *ConsumerState) []byte {
 			n += binary.PutUvarint(buf[n:], v.Sequence-adflr)
 			// Downsample to seconds to save on space.
 			// Subsecond resolution not needed for recovery etc.
-			ts := v.Timestamp / 1_000_000_000
+			ts := v.Timestamp / int64(time.Second)
 			n += binary.PutVarint(buf[n:], mints-ts)
 		}
 	}


### PR DESCRIPTION
The bug was when a timestamp for the pending state was exactly -1 which could happen based on timing of the redlivered pending items which would set pending.Timestamp into the future potentially and the timing on the encodeConsumerState call.

Minor fixes to raft.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #3535 

/cc @nats-io/core
