### PR TITLE
Fix JWT tests JS store dir

### DIFF
--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -128,14 +128,14 @@ func TestJetStreamJWTLimits(t *testing.T) {
 	defer removeDir(t, dir)
 	conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
-		jetstream: {max_mem_store: 10Mb, max_file_store: 10Mb}
+		jetstream: {max_mem_store: 10Mb, max_file_store: 10Mb, store_dir: "%s"}
 		operator: %s
 		resolver: {
 			type: full
 			dir: '%s'
 		}
 		system_account: %s
-    `, ojwt, dir, sysPub)))
+    `, dir, ojwt, dir, sysPub)))
 	defer removeFile(t, conf)
 	s, opts := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -174,14 +174,14 @@ func TestJetStreamJWTLimits(t *testing.T) {
 	s.Shutdown()
 	conf = createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:%d
-		jetstream: {max_mem_store: 20Mb, max_file_store: 20Mb}
+		jetstream: {max_mem_store: 20Mb, max_file_store: 20Mb, store_dir: "%s"}
 		operator: %s
 		resolver: {
 			type: full
 			dir: '%s'
 		}
 		system_account: %s
-    `, port, ojwt, dir, sysPub)))
+    `, port, dir, ojwt, dir, sysPub)))
 	defer removeFile(t, conf)
 	s, _ = RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -890,7 +890,7 @@ func TestJetStreamJWTSysAccUpdateMixedMode(t *testing.T) {
 	require_NoError(t, err)
 }
 
-func TestJetStreamExpiredAccountNotCountedTowardLimits(t *testing.T) {
+func TestJetStreamJWTExpiredAccountNotCountedTowardLimits(t *testing.T) {
 	op, _ := nkeys.CreateOperator()
 	opPk, _ := op.PublicKey()
 	sk, _ := nkeys.CreateOperator()
@@ -940,7 +940,7 @@ func TestJetStreamExpiredAccountNotCountedTowardLimits(t *testing.T) {
 	conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		operator: %s
-		jetstream: {max_mem_store: 10Mb, max_file_store: 10Mb}
+		jetstream: {max_mem_store: 10Mb, max_file_store: 10Mb, store_dir: "%s"}
 		system_account: %s
 		resolver: {
 			type: full
@@ -948,7 +948,7 @@ func TestJetStreamExpiredAccountNotCountedTowardLimits(t *testing.T) {
 			dir: '%s'
 			timeout: "500ms"
 		}
-    `, opJwt, syspub, dirSrv)))
+    `, opJwt, dirSrv, syspub, dirSrv)))
 	defer removeFile(t, conf)
 
 	s, _ := RunServerWithConfig(conf)
@@ -991,7 +991,7 @@ func TestJetStreamExpiredAccountNotCountedTowardLimits(t *testing.T) {
 	require_True(t, ai.Limits.MaxMemory == 7*1024*1024)
 }
 
-func TestJetStreamDeletedAccountDoesNotLeakSubscriptions(t *testing.T) {
+func TestJetStreamJWTDeletedAccountDoesNotLeakSubscriptions(t *testing.T) {
 	op, _ := nkeys.CreateOperator()
 	opPk, _ := op.PublicKey()
 	sk, _ := nkeys.CreateOperator()
@@ -1115,7 +1115,7 @@ func TestJetStreamDeletedAccountDoesNotLeakSubscriptions(t *testing.T) {
 	checkNumSubs(beforeCreate + 1)
 }
 
-func TestJetStreamDeletedAccountIsReEnabled(t *testing.T) {
+func TestJetStreamJWTDeletedAccountIsReEnabled(t *testing.T) {
 	op, _ := nkeys.CreateOperator()
 	opPk, _ := op.PublicKey()
 	sk, _ := nkeys.CreateOperator()
@@ -1166,7 +1166,7 @@ func TestJetStreamDeletedAccountIsReEnabled(t *testing.T) {
 	conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		operator: %s
-		jetstream: {max_mem_store: 10Mb, max_file_store: 10Mb, store_dir: %v}
+		jetstream: {max_mem_store: 10Mb, max_file_store: 10Mb, store_dir: "%s"}
 		system_account: %s
 		resolver: {
 			type: full


### PR DESCRIPTION
This was causing longer than necessary startup times since by default they would have been using the same temporary directory and the extra account lookup failures due to a previous JS run using different accounts and leaving those artifacts in the shared folder. Also renamed some of these tests to be possible to run them via `-run TestJetStreamJWT`.

Signed-off-by: Waldemar Quevedo <wally@nats.io>