### PR TITLE
Pin nsc version from nightly

### DIFF
--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -9,7 +9,7 @@ RUN mkdir -p src/github.com/nats-io && \
     cd natscli/nats && \
     go build -ldflags "-w -X main.version=${VERSION}" -o /nats
 
-RUN go install github.com/nats-io/nsc@latest
+RUN go install github.com/nats-io/nsc@2.7.5
 
 FROM alpine:latest
 


### PR DESCRIPTION
Lookup for `go install github.com/nats-io/nsc@latest` started failing in the repo so pinning to latest version in the builds for now.

```
NATS @ ~ () $ time go install github.com/nats-io/nsc@latest
go: github.com/nats-io/nsc@latest: no matching versions for query "latest"

real	0m58.402s
user	0m0.020s
sys	0m0.021s
NATS @ ~ () $ time go install github.com/nats-io/nsc@2.7.5
go: downloading github.com/nats-io/nsc v0.0.0-20221206222106-35db9400b257
go: downloading github.com/nats-io/cliprompts/v2 v2.0.0-20191226174129-372d79b36768
go: downloading github.com/briandowns/spinner v0.0.0-20181029155426-195c31b675a7
go: downloading github.com/blang/semver v3.5.1+incompatible
go: downloading github.com/nats-io/jwt v1.2.3-0.20210314221642-a826c77dc9d2
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: downloading github.com/nats-io/jwt/v2 v2.3.1-0.20221202180456-83b58fd54838
go: downloading github.com/rhysd/go-github-selfupdate v1.2.2
go: downloading github.com/spf13/cobra v0.0.3
go: downloading github.com/spf13/pflag v1.0.3
go: downloading github.com/cpuguy83/go-md2man v1.0.10
go: downloading gopkg.in/yaml.v2 v2.2.8
go: downloading github.com/fatih/color v1.9.0
go: downloading github.com/AlecAivazis/survey/v2 v2.0.4
go: downloading github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
go: downloading github.com/google/go-github/v30 v30.1.0
go: downloading github.com/tcnksm/go-gitconfig v0.1.2
go: downloading github.com/ulikunitz/xz v0.5.8
go: downloading golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890
go: downloading github.com/mattn/go-colorable v0.1.4
go: downloading github.com/mattn/go-isatty v0.0.11
go: downloading golang.org/x/net v0.0.0-20220906165146-f3363e06e74c
go: downloading github.com/google/go-querystring v1.0.0

real	1m6.126s
user	0m10.526s
sys	0m2.071s
```

/cc @nats-io/core
