### PR TITLE
Rate limit frequent debug log lines

### DIFF
--- a/server/log.go
+++ b/server/log.go
@@ -214,6 +214,14 @@ func (s *Server) RateLimitWarnf(format string, v ...interface{}) {
 	s.Warnf("%s", statement)
 }
 
+func (s *Server) RateLimitDebugf(format string, v ...interface{}) {
+	statement := fmt.Sprintf(format, v...)
+	if _, loaded := s.rateLimitLogging.LoadOrStore(statement, time.Now()); loaded {
+		return
+	}
+	s.Debugf("%s", statement)
+}
+
 // Fatalf logs a fatal error
 func (s *Server) Fatalf(format string, v ...interface{}) {
 	s.executeLogCall(func(logger Logger, format string, v ...interface{}) {

--- a/server/stream.go
+++ b/server/stream.go
@@ -3966,7 +3966,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 
 		switch err {
 		case ErrMaxMsgs, ErrMaxBytes, ErrMaxMsgsPerSubject, ErrMsgTooLarge:
-			s.Debugf("JetStream failed to store a msg on stream '%s > %s': %v", accName, name, err)
+			s.RateLimitDebugf("JetStream failed to store a msg on stream '%s > %s': %v", accName, name, err)
 		case ErrStoreClosed:
 		default:
 			s.Errorf("JetStream failed to store a msg on stream '%s > %s': %v", accName, name, err)


### PR DESCRIPTION
With the increase use of subject based limits not being able to store due to limits exceeded happens frequently and makes running the server in debug quite noisy, so we rate limit this log line even in debug

Signed-off-by: R.I.Pienaar <rip@devco.net>

/cc @nats-io/core
