### PR TITLE
zero-state condition on stream peer re-assignment

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.9.9"
+	VERSION = "2.9.10-dev"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -2178,7 +2178,7 @@ func TestServerEventsPingMonitorz(t *testing.T) {
 		{"JSZ", nil, &JSzOptions{}, []string{"now", "disabled"}},
 
 		{"HEALTHZ", nil, &JSzOptions{}, []string{"status"}},
-		{"HEALTHZ", &HealthzOptions{JSEnabled: true}, &JSzOptions{}, []string{"status"}},
+		{"HEALTHZ", &HealthzOptions{JSEnabledOnly: true}, &JSzOptions{}, []string{"status"}},
 		{"HEALTHZ", &HealthzOptions{JSServerOnly: true}, &JSzOptions{}, []string{"status"}},
 	}
 

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -406,8 +406,8 @@ func TestJetStreamClusterDeleteConsumerWhileServerDown(t *testing.T) {
 	s = c.restartServer(s)
 	checkFor(t, time.Second, 200*time.Millisecond, func() error {
 		hs := s.healthz(&HealthzOptions{
-			JSEnabled:    true,
-			JSServerOnly: false,
+			JSEnabledOnly: false,
+			JSServerOnly:  false,
 		})
 		if hs.Error != _EMPTY_ {
 			return errors.New(hs.Error)
@@ -448,8 +448,8 @@ func TestJetStreamClusterDeleteConsumerWhileServerDown(t *testing.T) {
 	s = c.restartServer(s)
 	checkFor(t, time.Second, 200*time.Millisecond, func() error {
 		hs := s.healthz(&HealthzOptions{
-			JSEnabled:    true,
-			JSServerOnly: false,
+			JSEnabledOnly: false,
+			JSServerOnly:  false,
 		})
 		if hs.Error != _EMPTY_ {
 			return errors.New(hs.Error)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -17365,14 +17365,19 @@ func TestJetStreamWorkQueueSourceNamingRestart(t *testing.T) {
 }
 
 func TestJetStreamDisabledHealthz(t *testing.T) {
-	s := RunRandClientPortServer()
+	s := RunBasicJetStreamServer()
+	if config := s.JetStreamConfig(); config != nil {
+		defer removeDir(t, config.StoreDir)
+	}
 	defer s.Shutdown()
 
-	if s.JetStreamEnabled() {
-		t.Fatalf("Expected JetStream to be disabled")
+	if !s.JetStreamEnabled() {
+		t.Fatalf("Expected JetStream to be enabled")
 	}
 
-	hs := s.healthz(&HealthzOptions{JSEnabled: true})
+	s.DisableJetStream()
+
+	hs := s.healthz(&HealthzOptions{JSEnabledOnly: true})
 	if hs.Status == "unavailable" && hs.Error == NewJSNotEnabledError().Error() {
 		return
 	}


### PR DESCRIPTION
Fix and test that resolves a zero-state condition on stream peer re-assignment regression (peer rejoining it's former group). 

/cc @nats-io/core
