### PR TITLE
fix and test for clustered mem store asset no-quorum if leader restarted

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -951,15 +951,6 @@ func (n *raft) InstallSnapshot(data []byte) error {
 		return errCatchupsRunning
 	}
 
-	// We don't store snapshots for memory based WALs.
-	// This matches loadSnapshot logic now.
-	// But we should compact.
-	if _, ok := n.wal.(*memStore); ok {
-		n.wal.Compact(n.applied)
-		n.Unlock()
-		return nil
-	}
-
 	var state StreamState
 	n.wal.FastState(&state)
 


### PR DESCRIPTION
Resolves [Issue #3712](https://github.com/nats-io/nats-server/issues/3712)

If the leader peer of a clustered memory-store stream was restarted, stream would become no quorum after the peer returned.

/cc @nats-io/core
