### PR TITLE
[FIXED] Failure to store msg with `error opening msg block file [""]: open : no such file or directory`

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4911,6 +4911,11 @@ SKIP:
 		}
 		// Update blks slice.
 		fs.blks = copyMsgBlocks(fs.blks[deleted:])
+		if lb := len(fs.blks); lb == 0 {
+			fs.lmb = nil
+		} else {
+			fs.lmb = fs.blks[lb-1]
+		}
 	}
 
 	// Update top level accounting.


### PR DESCRIPTION
Under the right circumstances Compact could leave a dangling last msg block leading to `error opening msg block file [""]: open : no such file or directory`

When the compaction would not uplevel to a normal purge, but after completion all msg blocks were empty the mb.lmb was not cleared or reset properly.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #3652 

/cc @nats-io/core
