### PR TITLE
Update nsc go install to use go modules

### DIFF
--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -9,7 +9,7 @@ RUN mkdir -p src/github.com/nats-io && \
     cd natscli/nats && \
     go build -ldflags "-w -X main.version=${VERSION}" -o /nats
 
-RUN go install github.com/nats-io/nsc@latest
+RUN go install github.com/nats-io/nsc/v2@latest
 
 FROM alpine:latest
 


### PR DESCRIPTION
Use v2 form to fetch the nsc tool which is now supported in that repo.

/cc @nats-io/core
