### PR TITLE
Set startup time with env NATS_STARTUP_DELAY

### DIFF
--- a/server/service_windows.go
+++ b/server/service_windows.go
@@ -68,8 +68,7 @@ func (w *winServiceWrapper) Execute(args []string, changes <-chan svc.ChangeRequ
 	go w.server.Start()
 
 	if v, exists := os.LookupEnv("NATS_STARTUP_DELAY"); exists {
-		delay, err := time.ParseDuration(v)
-		if err == nil {
+		if delay, err := time.ParseDuration(v); err == nil {
 			startupDelay = delay
 		} else {
 			w.server.Errorf("Failed to parse \"%v\" as a duration for startup: %s", v, err)

--- a/server/service_windows.go
+++ b/server/service_windows.go
@@ -42,6 +42,7 @@ type winServiceWrapper struct {
 }
 
 var dockerized = false
+var startupDelay = 10 * time.Second
 
 func init() {
 	if v, exists := os.LookupEnv("NATS_DOCKERIZED"); exists && v == "1" {
@@ -66,8 +67,16 @@ func (w *winServiceWrapper) Execute(args []string, changes <-chan svc.ChangeRequ
 	status <- svc.Status{State: svc.StartPending}
 	go w.server.Start()
 
+	if v, exists := os.LookupEnv("NATS_STARTUP_DELAY"); exists {
+		delay, err := time.ParseDuration(v)
+		if err == nil {
+			startupDelay = delay
+		} else {
+			w.server.Errorf("Failed to parse \"%v\" as a duration for startup: %s", v, err)
+		}
+	}
 	// Wait for accept loop(s) to be started
-	if !w.server.ReadyForConnections(10 * time.Second) {
+	if !w.server.ReadyForConnections(startupDelay) {
 		// Failed to start.
 		return false, 1
 	}

--- a/server/service_windows_test.go
+++ b/server/service_windows_test.go
@@ -1,0 +1,123 @@
+// Copyright 2012-2019 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package server
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+// TestWinServiceWrapper reproduces the tests for service,
+// with extra complication for windows API
+func TestWinServiceWrapper(t *testing.T) {
+	/*
+		Since the windows API can't be tested through just the Run func,
+		a basic mock checks the intractions of the server, as happens in svc.Run.
+		This test checks :
+		- that the service fails to start within an unreasonable timeframe (serverC)
+		- that the service signals its state correctly to windows with svc.StartPending (mockC)
+		- that no other signal is sent to the windows service API(mockC)
+	*/
+	var (
+		wsw     = &winServiceWrapper{New(DefaultOptions())}
+		args    = make([]string, 0)
+		serverC = make(chan error, 1)
+		mockC   = make(chan error, 1)
+		changes = make(chan svc.ChangeRequest)
+		status  = make(chan svc.Status)
+	)
+	time.Sleep(time.Millisecond)
+	os.Setenv("NATS_STARTUP_DELAY", "1ms") // purposedly small
+	// prepare mock expectations
+	wsm := &winSvcMock{status: status}
+	wsm.Expect(svc.StartPending)
+	go func() {
+		mockC <- wsm.Listen(50*time.Millisecond, t)
+		close(mockC)
+	}()
+
+	go func() { // ensure failure with these conditions
+		_, exitCode := wsw.Execute(args, changes, status)
+		if exitCode == 0 { // expect error
+			serverC <- errors.New("Should have exitCode != 0")
+		}
+		wsw.server.Shutdown()
+		close(serverC)
+	}()
+
+	for expectedErrs := 2; expectedErrs >= 0; {
+		select {
+		case err := <-mockC:
+			if err != nil {
+				t.Fatalf("windows.svc mock: %v", err)
+			} else {
+				expectedErrs--
+			}
+		case err := <-serverC:
+			if err != nil {
+				t.Fatalf("Server behavior: %v", err)
+			} else {
+				expectedErrs--
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("Test timed out")
+		}
+	}
+}
+
+// winSvcMock mocks part of the golang.org/x/sys/windows/svc
+// execution stack, listening to svc.Status on its chan.
+type winSvcMock struct {
+	status     chan svc.Status
+	expectedSt []svc.State
+}
+
+// Expect allows to prepare a winSvcMock to recieve a specific type of StatusMessage
+func (w *winSvcMock) Expect(st svc.State) {
+	w.expectedSt = append(w.expectedSt, st)
+}
+
+// Listen is the mock's mainloop, expectes messages to comply with previous Expect().
+func (w *winSvcMock) Listen(dur time.Duration, t *testing.T) error {
+	t.Helper()
+	timeout := time.NewTimer(dur)
+	defer timeout.Stop()
+	for idx, state := range w.expectedSt {
+		select {
+		case status := <-w.status:
+			if status.State == state {
+				t.Logf("message %d on status, OK\n", idx)
+				continue
+			} else {
+				return fmt.Errorf("message to winsock: expected %v, got %v", state, status.State)
+			}
+		case <-timeout.C:
+			return errors.New("Mock timed out")
+		}
+	}
+	select {
+	case <-timeout.C:
+		return nil
+	case st := <-w.status:
+		return fmt.Errorf("extra message to winsock: got %v", st)
+
+	}
+}


### PR DESCRIPTION
The startup delay when starting as a service under windows was set to 10 seconds.

This value was fixed and hardcoded since before JetStream. On (some) Windows systems, this leads to service startup failures, as the store dir sorting may be hindered by an important load, or slowed down by increased accesses times, typically from security software influence.

This commit allows overriding the startup delay using an environment variable NATS_STARTUP_DELAY. This variable is checked outside init() to allow reporting into the service log.

Any value can be used (even lower than the initial 10s). Bare NATS start can be far faster than 10s. Ops may want to setup this env var to lower values in order to trigger an error on stricter constraints.

 - [x] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #3742 

### Changes proposed in this pull request:

 - make max startup delay of server a variable
 - set this duration from NATS_STARTUP_DELAY environment variable ("30s" for instance)
 - in case of failure to parse or failure to retrieve value, default to 10 seconds
 - log parsing errors of variable into system log with the winservice instance (for alerting) 

/cc @nats-io/core

Note : I could not add tests for this change, setting the value of the env var  to low delays shows the change appears to have the expected behavior. 
