### PR TITLE
Add back existing HealthzOptions.JSEnabled field

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2631,6 +2631,8 @@ type JSzOptions struct {
 
 // HealthzOptions are options passed to Healthz
 type HealthzOptions struct {
+	// Deprecated: Use JSEnabledOnly instead
+	JSEnabled     bool `json:"js-enabled,omitempty"`
 	JSEnabledOnly bool `json:"js-enabled-only,omitempty"`
 	JSServerOnly  bool `json:"js-server-only,omitempty"`
 }
@@ -2985,7 +2987,8 @@ func (s *Server) HandleHealthz(w http.ResponseWriter, r *http.Request) {
 	}
 
 	hs := s.healthz(&HealthzOptions{
-		JSEnabledOnly: jsEnabledOnly || jsEnabled,
+		JSEnabled:     jsEnabled,
+		JSEnabledOnly: jsEnabledOnly,
 		JSServerOnly:  jsServerOnly,
 	})
 	if hs.Error != _EMPTY_ {
@@ -3031,7 +3034,7 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 		return health
 	}
 	// Only check if JS is enabled, skip meta and asset check.
-	if opts.JSEnabledOnly {
+	if opts.JSEnabledOnly || opts.JSEnabled {
 		return health
 	}
 


### PR DESCRIPTION
This fixes a backwards incompat change introduced in #3704 for library usage as well as using the healthz NATS API which depends on the JSON payload.

Signed-off-by: Byron Ruth <byron@nats.io>

/cc @nats-io/core
