### PR TITLE
Switch to `golangci-lint`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,7 @@ linters:
   disable-all: true
   enable:
     # - errcheck
-    # - gofmt
+    - gofmt
     # - goimports
     - gosimple
     - govet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,60 @@
+# Config file for golangci-lint
+run:
+  concurrency: 4
+  deadline: 1m
+  issues-exit-code: 1
+  tests: true
+  skip-dirs:
+    - .github
+    - doc
+    - docker
+    - logos
+    - scripts
+    - util
+  modules-download-mode: readonly
+
+output:
+  format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true
+
+linters:
+  disable-all: true
+  enable:
+    # - errcheck
+    # - gofmt
+    # - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    # - maligned
+    - megacheck
+    - misspell
+    # - prealloc
+    - staticcheck
+    # - unparam
+    - unused
+
+linters-settings:
+  errcheck:
+    check-type-assertions: false
+    check-blank: false
+  govet:
+    check-shadowing: false
+    settings:
+      printf:
+        funcs:
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+  gofmt:
+    simple: true
+  misspell:
+    locale: US
+  unparam:
+    check-exported: false
+  prealloc:
+    simple: true
+    range-loops: true
+    for-loops: true

--- a/conf/lex.go
+++ b/conf/lex.go
@@ -17,7 +17,7 @@
 
 // The format supported is less restrictive than today's formats.
 // Supports mixed Arrays [], nested Maps {}, multiple comment types (# and //)
-// Also supports key value assigments using '=' or ':' or whiteSpace()
+// Also supports key value assignments using '=' or ':' or whiteSpace()
 //   e.g. foo = 2, foo : 2, foo 2
 // maps can be assigned with no key separator as well
 // semicolons as value terminators in key/value assignments are optional

--- a/conf/parse.go
+++ b/conf/parse.go
@@ -18,7 +18,7 @@ package conf
 
 // The format supported is less restrictive than today's formats.
 // Supports mixed Arrays [], nested Maps {}, multiple comment types (# and //)
-// Also supports key value assigments using '=' or ':' or whiteSpace()
+// Also supports key value assignments using '=' or ':' or whiteSpace()
 //   e.g. foo = 2, foo : 2, foo 2
 // maps can be assigned with no key separator as well
 // semicolons as value terminators in key/value assignments are optional

--- a/scripts/runTestsOnTravis.sh
+++ b/scripts/runTestsOnTravis.sh
@@ -7,7 +7,11 @@ if [ "$1" = "compile" ]; then
     go build;
 
     # Now run the linters.
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
+    # TODO: Pinning a specific commit here as there is a bugfix merged that 
+    # fixes gofmt on macOS Ventura, we can undo this and go back to the binary
+    # install script once there's a new tagged release that contains the fix.
+    # curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@6f7f8ae;
     golangci-lint run;
     if [ "$TRAVIS_TAG" != "" ]; then
         go test -race -v -run=TestVersionMatchesTag ./server -count=1 -vet=off

--- a/scripts/runTestsOnTravis.sh
+++ b/scripts/runTestsOnTravis.sh
@@ -3,17 +3,12 @@
 set -e
 
 if [ "$1" = "compile" ]; then
-
-    # We will compile and run some vet, spelling and some other checks.
-
-    go install honnef.co/go/tools/cmd/staticcheck@latest;
-    go install github.com/client9/misspell/cmd/misspell@latest;
-    GO_LIST=$(go list ./...);
+    # First check that NATS builds.
     go build;
-    $(exit $(go fmt $GO_LIST | wc -l));
-    go vet $GO_LIST;
-    find . -type f -name "*.go" | xargs misspell -error -locale US;
-    staticcheck -tags=js_chaos_tests $GO_LIST
+
+    # Now run the linters.
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
+    golangci-lint run;
     if [ "$TRAVIS_TAG" != "" ]; then
         go test -race -v -run=TestVersionMatchesTag ./server -count=1 -vet=off
     fi

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3857,7 +3857,7 @@ func (dr *DirAccResolver) Start(s *Server) error {
 	for _, reqSub := range []string{accUpdateEventSubjOld, accUpdateEventSubjNew} {
 		// subscribe to account jwt update requests
 		if _, err := s.sysSubscribe(fmt.Sprintf(reqSub, "*"), func(_ *subscription, _ *client, _ *Account, subj, resp string, msg []byte) {
-			pubKey := _EMPTY_
+			var pubKey string
 			tk := strings.Split(subj, tsep)
 			if len(tk) == accUpdateTokensNew {
 				pubKey = tk[accReqAccIndex]
@@ -4143,7 +4143,7 @@ func (dr *CacheDirAccResolver) Start(s *Server) error {
 	for _, reqSub := range []string{accUpdateEventSubjOld, accUpdateEventSubjNew} {
 		// subscribe to account jwt update requests
 		if _, err := s.sysSubscribe(fmt.Sprintf(reqSub, "*"), func(_ *subscription, _ *client, _ *Account, subj, resp string, msg []byte) {
-			pubKey := _EMPTY_
+			var pubKey string
 			tk := strings.Split(subj, tsep)
 			if len(tk) == accUpdateTokensNew {
 				pubKey = tk[accReqAccIndex]

--- a/server/auth.go
+++ b/server/auth.go
@@ -758,7 +758,6 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) boo
 			if len(allowedConnTypes) == 0 {
 				return false
 			}
-			err = nil
 		}
 		if !c.connectionTypeAllowed(allowedConnTypes) {
 			c.Debugf("Connection type not allowed")

--- a/server/dirstore_test.go
+++ b/server/dirstore_test.go
@@ -763,7 +763,6 @@ func TestExpirationUpdate(t *testing.T) {
 	createTestAccount(t, dirStore, 1, accountKey)
 	nh = dirStore.Hash()
 	require_NotEqual(t, h, nh)
-	h = nh
 
 	time.Sleep(1500 * time.Millisecond)
 	f, err = os.ReadDir(dir)
@@ -838,6 +837,7 @@ func TestRemove(t *testing.T) {
 		RenameDeleted: {0, 1},
 		NoDelete:      {1, 0},
 	} {
+		deleteType, test := deleteType, test // fixes govet capturing loop variables
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
 			dir := t.TempDir()

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7113,7 +7113,6 @@ RETRY:
 	})
 	if err != nil {
 		s.Errorf("Could not subscribe to stream catchup: %v", err)
-		err = nil
 		goto RETRY
 	}
 	// Send our sync request.

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -1074,7 +1074,7 @@ func TestJetStreamClusterSourceWithOptStartTime(t *testing.T) {
 		_, err = js.AddStream(&nats.StreamConfig{
 			Name:     "SOURCE",
 			Replicas: replicas,
-			Sources: []*nats.StreamSource{&nats.StreamSource{
+			Sources: []*nats.StreamSource{{
 				Name:         "TEST",
 				OptStartTime: &yesterday,
 			}},

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -1101,18 +1101,6 @@ func jsClientConnectEx(t testing.TB, s *Server, domain string, opts ...nats.Opti
 	return nc, js
 }
 
-func jsClientConnectCluster(t testing.TB, c *cluster, opts ...nats.Option) (*nats.Conn, nats.JetStreamContext) {
-	t.Helper()
-
-	serverURLs := make([]string, len(c.servers))
-
-	for i, s := range c.servers {
-		serverURLs[i] = s.ClientURL()
-	}
-	url := strings.Join(serverURLs, ",")
-	return jsClientConnectURL(t, url, opts...)
-}
-
 func jsClientConnectURL(t testing.TB, url string, opts ...nats.Option) (*nats.Conn, nats.JetStreamContext) {
 	t.Helper()
 
@@ -1734,12 +1722,4 @@ func (b *bitset) String() string {
 	}
 	sb.WriteString("\n")
 	return sb.String()
-}
-
-func toIndentedJsonString(v interface{}) string {
-	jsonBytes, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return fmt.Sprintf("Marshal error: %s", err)
-	}
-	return string(jsonBytes)
 }

--- a/server/jetstream_leafnode_test.go
+++ b/server/jetstream_leafnode_test.go
@@ -645,8 +645,8 @@ cluster: { name: clustL }
 `
 	for _, withDomain := range []bool{true, false} {
 		t.Run(fmt.Sprintf("with-domain:%t", withDomain), func(t *testing.T) {
-			jsDisabledDomainString := _EMPTY_
-			jsEnabledDomainString := _EMPTY_
+			var jsDisabledDomainString string
+			var jsEnabledDomainString string
 			if withDomain {
 				jsEnabledDomainString = `domain: "domain", `
 				jsDisabledDomainString = `domain: "domain"`

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -7603,9 +7603,7 @@ func TestJetStreamRequestAPI(t *testing.T) {
 
 	// This will get the current information about usage and limits for this account.
 	resp, err := nc.Request(JSApiAccountInfo, nil, time.Second)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	require_NoError(t, err)
 	var info JSApiAccountInfoResponse
 	if err := json.Unmarshal(resp.Data, &info); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -7691,6 +7689,9 @@ func TestJetStreamRequestAPI(t *testing.T) {
 
 	// Make sure list names works.
 	resp, err = nc.Request(JSApiStreams, nil, time.Second)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 	var namesResponse JSApiStreamNamesResponse
 	if err = json.Unmarshal(resp.Data, &namesResponse); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -7714,6 +7715,7 @@ func TestJetStreamRequestAPI(t *testing.T) {
 
 	// Now do detailed version.
 	resp, err = nc.Request(JSApiStreamList, nil, time.Second)
+	require_NoError(t, err)
 	var listResponse JSApiStreamListResponse
 	if err = json.Unmarshal(resp.Data, &listResponse); err != nil {
 		t.Fatalf("Unexpected error: %v", err)

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -3347,7 +3347,6 @@ func (c *client) mqttParseSubsOrUnsubs(r *mqttReader, b byte, pl int, sub bool) 
 		filter, err := mqttFilterToNATSSubject(topic)
 		if err != nil {
 			c.Errorf("invalid topic %q: %v", topic, err)
-			err = nil
 		}
 		if sub {
 			qos, err = r.readByte("QoS")

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -3039,7 +3039,7 @@ func TestMQTTClusterReplicasCount(t *testing.T) {
 				t.Run(sname, func(t *testing.T) {
 					si, err := js.StreamInfo(sname)
 					if err != nil {
-						t.Fatalf("Error geting stream info: %v", err)
+						t.Fatalf("Error getting stream info: %v", err)
 					}
 					if si.Config.Replicas != test.replicas {
 						t.Fatalf("Expected %v replicas, got %v", test.replicas, si.Config.Replicas)

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -3570,7 +3570,7 @@ func TestNoRaceJetStreamClusterCorruptWAL(t *testing.T) {
 	// Let's put a non-contigous AppendEntry into the system.
 	ae.pindex += 10
 	// Add in delivered record.
-	ae.entries = []*Entry{&Entry{EntryNormal, dentry(1000, 1000, 1, time.Now().UnixNano())}}
+	ae.entries = []*Entry{{EntryNormal, dentry(1000, 1000, 1, time.Now().UnixNano())}}
 	encoded, err := ae.encode(nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -161,7 +161,7 @@ func TestTLSConfigFile(t *testing.T) {
 		t.Fatalf("Expected MinVersion of 1.2 [%v], got [%v]", tls.VersionTLS12, tlsConfig.MinVersion)
 	}
 	//lint:ignore SA1019 We want to retry on a bunch of errors here.
-	if !tlsConfig.PreferServerCipherSuites {
+	if !tlsConfig.PreferServerCipherSuites { // nolint:staticcheck
 		t.Fatal("Expected PreferServerCipherSuites to be true")
 	}
 	// Verify hostname is correct in certificate

--- a/server/route.go
+++ b/server/route.go
@@ -652,7 +652,7 @@ func (c *client) processRouteInfo(info *Info) {
 		if sendInfo {
 			// The incoming INFO from the route will have IP set
 			// if it has Cluster.Advertise. In that case, use that
-			// otherwise contruct it from the remote TCP address.
+			// otherwise construct it from the remote TCP address.
 			if info.IP == "" {
 				// Need to get the remote IP address.
 				c.mu.Lock()

--- a/server/server.go
+++ b/server/server.go
@@ -3597,7 +3597,7 @@ func (s *Server) acceptError(acceptName string, err error, tmpDelay time.Duratio
 		return -1
 	}
 	//lint:ignore SA1019 We want to retry on a bunch of errors here.
-	if ne, ok := err.(net.Error); ok && ne.Temporary() {
+	if ne, ok := err.(net.Error); ok && ne.Temporary() { // nolint:staticcheck
 		s.Errorf("Temporary %s Accept Error(%v), sleeping %dms", acceptName, ne, tmpDelay/time.Millisecond)
 		select {
 		case <-time.After(tmpDelay):

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -2084,7 +2084,6 @@ func TestWSPubSub(t *testing.T) {
 					ok = 1
 					continue
 				} else if ok == 1 && bytes.Contains(line, []byte("from nats")) {
-					ok = 2
 					break
 				}
 			}

--- a/test/test.go
+++ b/test/test.go
@@ -408,7 +408,6 @@ func expectLeftMostResult(t tLogger, c net.Conn, re *regexp.Regexp, buf *[]byte)
 			}
 			*buf = append(*buf, recv()...)
 		} else {
-			emptyCnt = 0
 			cutIdx := strings.Index(string(*buf), string(result)) + len(result)
 			*buf = (*buf)[cutIdx:]
 			return result


### PR DESCRIPTION
This replaces the separate linters in `runTestsOnTravis.sh` with the more modern `golangci-lint`. This is the recommended approach now and also means that the `gopls` language server stands a much better chance of picking up the same issues that CI will.

It also adds a `.golangci-lint.yml` file to control the linter behaviours, as well as fixing a few things in the code that it yelled about.

There are more linters we can enable in the future if we want to — I commented out a few but they can be addressed in separate PRs.

Signed-off-by: Neil Twigg <neil@nats.io>

/cc @nats-io/core 