### PR TITLE
Add `profilez` server endpoint

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -949,6 +949,10 @@ func (s *Server) initEventTracking() {
 			optz := &HealthzEventOptions{}
 			s.zReq(c, reply, msg, &optz.EventFilterOptions, optz, func() (interface{}, error) { return s.healthz(&optz.HealthzOptions), nil })
 		},
+		"PROFILEZ": func(sub *subscription, c *client, _ *Account, subject, reply string, msg []byte) {
+			optz := &ProfilezEventOptions{}
+			s.zReq(c, reply, msg, &optz.EventFilterOptions, optz, func() (interface{}, error) { return s.profilez(&optz.ProfilezOptions), nil })
+		},
 	}
 	for name, req := range monSrvc {
 		subject = fmt.Sprintf(serverDirectReqSubj, s.info.ID, name)
@@ -1571,6 +1575,12 @@ type JszEventOptions struct {
 // In the context of system events, HealthzEventOptions are options passed to Healthz
 type HealthzEventOptions struct {
 	HealthzOptions
+	EventFilterOptions
+}
+
+// In the context of system events, ProfilezEventOptions are options passed to Profilez
+type ProfilezEventOptions struct {
+	ProfilezOptions
 	EventFilterOptions
 }
 

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1661,7 +1661,7 @@ func TestSystemAccountWithGateways(t *testing.T) {
 
 	// If this tests fails with wrong number after 10 seconds we may have
 	// added a new inititial subscription for the eventing system.
-	checkExpectedSubs(t, 50, sa)
+	checkExpectedSubs(t, 52, sa)
 
 	// Create a client on B and see if we receive the event
 	urlb := fmt.Sprintf("nats://%s:%d", ob.Host, ob.Port)


### PR DESCRIPTION
This PR adds a `profilez` endpoint to the system account, which accepts two parameters: `profile` for the name of the profile (i.e. `allocs`, `block`, `goroutine`, `heap`, `mutex`, `threadcreate`) and `debug` for the return format (defaults to `0`, which is usually gzipped for `go tool pprof`).

It will only be possible to query this endpoint if `PROF_PORT` is already enabled, otherwise it will return a `Profiling is not enabled` error.

Signed-off-by: Neil Twigg <neil@nats.io>

/cc @nats-io/core
