### PR TITLE
Tweak logic for sending leaf node subscription updates

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1857,7 +1857,7 @@ func (c *client) updateSmap(sub *subscription, delta int32) {
 
 	n := c.leaf.smap[key]
 	// We will update if its a queue, if count is zero (or negative), or we were 0 and are N > 0.
-	update := sub.queue != nil || n == 0 || n+delta <= 0
+	update := sub.queue != nil || (n <= 0 && n+delta > 0) || (n > 0 && n+delta <= 0)
 	n += delta
 	if n > 0 {
 		c.leaf.smap[key] = n


### PR DESCRIPTION
Currently the logic here doesn't feel too tight — currently we are only checking movement upward if `n` is exactly 0, and movement downward can be triggered again even if we're already below 0.

This new line should be clearer and more explicit that we're trying to capture *transitions* to/from +ve and -ve only.

Signed-off-by: Neil Twigg <neil@nats.io>

/cc @nats-io/core
