### PR TITLE
ADDED hard_delete option on resolver configuration

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -4049,18 +4049,14 @@ func (dr *DirAccResolver) apply(opts ...DirResOption) error {
 	return nil
 }
 
-func NewDirAccResolver(path string, limit int64, syncInterval time.Duration, delete bool, opts ...DirResOption) (*DirAccResolver, error) {
+func NewDirAccResolver(path string, limit int64, syncInterval time.Duration, delete deleteType, opts ...DirResOption) (*DirAccResolver, error) {
 	if limit == 0 {
 		limit = math.MaxInt64
 	}
 	if syncInterval <= 0 {
 		syncInterval = time.Minute
 	}
-	deleteType := NoDelete
-	if delete {
-		deleteType = RenameDeleted
-	}
-	store, err := NewExpiringDirJWTStore(path, false, true, deleteType, 0, limit, false, 0, nil)
+	store, err := NewExpiringDirJWTStore(path, false, true, delete, 0, limit, false, 0, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
 - [x] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #3782

### Changes proposed in this pull request:

 - Add hard_delete option in the resolver config and use it to set the deleteType in NewDirAccResolver

/cc @nats-io/core
