### PR TITLE
[CHANGE] [AC] flip aud and sub for consistency

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1857,7 +1857,7 @@ func (c *client) updateSmap(sub *subscription, delta int32) {
 
 	n := c.leaf.smap[key]
 	// We will update if its a queue, if count is zero (or negative), or we were 0 and are N > 0.
-	update := sub.queue != nil || n == 0 || n+delta <= 0
+	update := sub.queue != nil || (n <= 0 && n+delta > 0) || (n > 0 && n+delta <= 0)
 	n += delta
 	if n > 0 {
 		c.leaf.smap[key] = n


### PR DESCRIPTION
The auth request, the `sub` for the JWT is `nats-authorization-request`, and the `aud` is the nkey, typically our JWTs have `sub` be an identity and the `aud` is just a string describing where this jwt is applicable.

/cc @nats-io/core
