### PR TITLE
Add small tolerance in stream health check

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3105,7 +3105,7 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 		for stream, sa := range asa {
 			if sa.Group.isMember(ourID) {
 				// Make sure we can look up
-				if !cc.isStreamCurrent(acc, stream) {
+				if !cc.isStreamHealthy(acc, stream) {
 					health.Status = na
 					health.Error = fmt.Sprintf("JetStream stream '%s > %s' is not current", acc, stream)
 					return health


### PR DESCRIPTION
If messages are being async published faster than the cluster can apply Raft updates, then the `HEALTHZ` check will report unhealthy, even if we are still making forward progress. This might cause problems in instances where hosting infrastructure will restart the NATS Server if it reports an unhealthy state for a certain period of time, for example.

Adding a slight tolerance to the health check should improve this situation and report only if we are provably not making forward progress. There's also a unit test that demonstrates the problem.

Signed-off-by: Neil Twigg <neil@nats.io>

/cc @nats-io/core 