### PR TITLE
Auth-Callout connect events

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2022 The NATS Authors
+// Copyright 2018-2023 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -958,13 +958,9 @@ func (a *Account) removeClient(c *client) int {
 	a.mu.Unlock()
 
 	if c != nil && c.srv != nil && removed {
-		c.srv.mu.Lock()
-		doRemove := a != c.srv.gacc
-		c.srv.mu.Unlock()
-		if doRemove {
-			c.srv.accConnsUpdate(a)
-		}
+		c.srv.accConnsUpdate(a)
 	}
+
 	return n
 }
 

--- a/server/events.go
+++ b/server/events.go
@@ -1919,10 +1919,11 @@ func (a *Account) statz() *AccountStat {
 
 // accConnsUpdate is called whenever there is a change to the account's
 // number of active connections, or during a heartbeat.
+// We will not send for $G.
 func (s *Server) accConnsUpdate(a *Account) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if !s.eventsEnabled() || a == nil {
+	if !s.eventsEnabled() || a == nil || a == s.gacc {
 		return
 	}
 	s.sendAccConnsUpdate(a, fmt.Sprintf(accConnsEventSubjOld, a.Name), fmt.Sprintf(accConnsEventSubjNew, a.Name))

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1675,12 +1675,10 @@ func TestSystemAccountWithGateways(t *testing.T) {
 	require_NoError(t, err)
 	msgs[1], err = sub.NextMsg(time.Second)
 	require_NoError(t, err)
-	msgs[2], err = sub.NextMsg(time.Second)
-	require_NoError(t, err)
 	// TODO: There is a race currently that can cause the server to process the
 	// system event *after* the subscription on "A" has been registered, and so
 	// the "nca" client would receive its own CONNECT message.
-	msgs[3], _ = sub.NextMsg(250 * time.Millisecond)
+	msgs[2], _ = sub.NextMsg(250 * time.Millisecond)
 
 	findMsgs := func(sub string) []*nats.Msg {
 		rMsgs := []*nats.Msg{}
@@ -1708,10 +1706,6 @@ func TestSystemAccountWithGateways(t *testing.T) {
 
 	connsMsgA := findMsgs(fmt.Sprintf("$SYS.ACCOUNT.%s.SERVER.CONNS", sa.SystemAccount().Name))
 	if len(connsMsgA) != 1 {
-		t.Fatal("Expected a message")
-	}
-	connsMsgG := findMsgs("$SYS.ACCOUNT.$G.SERVER.CONNS")
-	if len(connsMsgG) != 1 {
 		t.Fatal("Expected a message")
 	}
 }


### PR DESCRIPTION
Make sure connection events during auth callouts are correct.

Fixed one extraneous account update for $G. We sent for the addition before switching but suppressed the change back to 0. We now suppress all for $G as was designed.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
