### PR TITLE
Make test timeout more graceful

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -2494,7 +2494,7 @@ func TestJetStreamClusterScaleDownDuringServerOffline(t *testing.T) {
 	require_NoError(t, err)
 
 	s = c.restartServer(s)
-	checkFor(t, time.Second, 200*time.Millisecond, func() error {
+	checkFor(t, 2*time.Second, 500*time.Millisecond, func() error {
 		hs := s.healthz(nil)
 		if hs.Error != _EMPTY_ {
 			return errors.New(hs.Error)

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -2493,12 +2493,15 @@ func TestJetStreamClusterScaleDownDuringServerOffline(t *testing.T) {
 	})
 	require_NoError(t, err)
 
+	now := time.Now()
 	s = c.restartServer(s)
-	checkFor(t, 2*time.Second, 500*time.Millisecond, func() error {
+	checkFor(t, 10*time.Second, 500*time.Millisecond, func() error {
 		hs := s.healthz(nil)
 		if hs.Error != _EMPTY_ {
 			return errors.New(hs.Error)
 		}
 		return nil
 	})
+
+	fmt.Println("TOOK: ", time.Since(now))
 }


### PR DESCRIPTION
This test was flake'y on CI, but it didn't look like it was flake'y by itself, rather the CI wasn't fast enough and timeout was to short for it.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>

/cc @nats-io/core
