### PR TITLE
Assign signal subscription to consumer when created

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -4347,7 +4347,9 @@ func (o *consumer) signalSub() *subscription {
 	if subject == _EMPTY_ {
 		subject = fwcs
 	}
-	return &subscription{subject: []byte(subject), icb: o.processStreamSignal}
+	sub := &subscription{subject: []byte(subject), icb: o.processStreamSignal}
+	o.sigSub = sub
+	return sub
 }
 
 // This is what will be called when our parent stream wants to kick us regarding a new message.


### PR DESCRIPTION
`consumer.sigSub` was never actually assigned, so subjects were evaluated and created every time `signalSub` was called, as 
```
	if o.sigSub != nil {
		return o.sigSub
	}
```
was never true.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>

/cc @nats-io/core
