### PR TITLE
Lint warnings on `fmt.Print`, `fmt.Printf`, `fmt.Println`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
   disable-all: true
   enable:
     # - errcheck
+    - forbidigo
     - gofmt
     # - goimports
     - gosimple
@@ -39,6 +40,9 @@ linters-settings:
   errcheck:
     check-type-assertions: false
     check-blank: false
+  forbidigo:
+    forbid:
+      - ^fmt\.Print(f|ln)?$
   govet:
     check-shadowing: false
     settings:
@@ -58,3 +62,14 @@ linters-settings:
     simple: true
     range-loops: true
     for-loops: true
+
+issues:
+  exclude-rules:
+    - path: "main.go" # Excludes main usage
+      linters: [forbidigo]
+    - source: "nats-server: v%s" # Excludes PrintServerAndExit
+      linters: [forbidigo]
+    - path: "server/opts.go" # Excludes TLS usage options
+      linters: [forbidigo]
+    - path: "_test.go" # Excludes unit tests
+      linters: [forbidigo]


### PR DESCRIPTION
This will create linter warnings on `fmt.Print`, `fmt.Printf` and `fmt.Println`, except for in unit tests and a couple sanctioned places.

Signed-off-by: Neil Twigg <neil@nats.io>