### PR TITLE
Allow to Reload Nats Config through monitor http

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2301,6 +2301,7 @@ const (
 	AccountStatzPath = "/accstatz"
 	JszPath          = "/jsz"
 	HealthzPath      = "/healthz"
+	ReloadzPath      = "/reloadz"
 	IPQueuesPath     = "/ipqueuesz"
 )
 
@@ -2410,6 +2411,8 @@ func (s *Server) startMonitoring(secure bool) error {
 	mux.HandleFunc(s.basePath(JszPath), s.HandleJsz)
 	// Healthz
 	mux.HandleFunc(s.basePath(HealthzPath), s.HandleHealthz)
+	// Reloadz
+	mux.HandleFunc(s.basePath(ReloadzPath), s.HandleReload)
 	// IPQueuesz
 	mux.HandleFunc(s.basePath(IPQueuesPath), s.HandleIPQueuesz)
 


### PR DESCRIPTION
### Changes proposed in this pull request:

Allow to reload the config with a http call to the monitor server.
The route is: /reloadz following the same pattern of the other routes.

TODO:
- [ ] Only allow post/put method. 
- [ ] Update the reloader service to support http call: https://github.com/nats-io/nack
- [ ] ~~Allow to reload the config with an internal API call... $SYS.REQ.SERVER.RELOADZ~~

/cc @nats-io/core
