### PR TITLE
[FIXED] Properly process updates on a stream on restart.

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1264,6 +1264,16 @@ func (js *jetStream) applyMetaSnapshot(buf []byte) error {
 			js.processConsumerAssignment(ca)
 		}
 	}
+
+	// Perform updates on those in saChk. These were existing so make
+	// sure to process any changes.
+	for _, sa := range saChk {
+		if isRecovering {
+			js.setStreamAssignmentRecovering(sa)
+		}
+		js.processUpdateStreamAssignment(sa)
+	}
+
 	// Now do the deltas for existing stream's consumers.
 	for _, ca := range caDel {
 		if isRecovering {


### PR DESCRIPTION
During restart if the stream existed in the server's state but was also in a meta-snapshot delivered by the leader we would not process the update properly.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #3636 

/cc @nats-io/core
