### PR TITLE
Stream subject transform improvements

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1830,7 +1830,7 @@ func (a *Account) addServiceImport(dest *Account, from, to string, claim *jwt.Im
 			// Create a transform. Do so in reverse such that $ symbols only exist in to
 			if tr, err = NewSubjectTransform(to, transformTokenize(from)); err != nil {
 				a.mu.Unlock()
-				return nil, fmt.Errorf("failed to create mapping transform for service import subject %q to %q: %v",
+				return nil, fmt.Errorf("failed to create mapping transform for service import subject from %q to %q: %v",
 					from, to, err)
 			} else {
 				// un-tokenize and reverse transform so we get the transform needed
@@ -2376,7 +2376,7 @@ func (a *Account) AddMappedStreamImportWithClaim(account *Account, from, to stri
 		} else {
 			// Create a transform
 			if tr, err = NewSubjectTransform(from, transformTokenize(to)); err != nil {
-				return fmt.Errorf("failed to create mapping transform for stream import subject %q to %q: %v",
+				return fmt.Errorf("failed to create mapping transform for stream import subject from %q to %q: %v",
 					from, to, err)
 			}
 			to, _ = transformUntokenize(to)

--- a/server/stream.go
+++ b/server/stream.go
@@ -429,11 +429,9 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 		for i, ssi := range cfg.Sources {
 			ssi.setIndexName(i)
 			// check the filter, if any, is valid
-			if ssi.FilterSubject != _EMPTY_ {
-				if !IsValidSubject(ssi.FilterSubject) {
-					jsa.mu.Unlock()
-					return nil, fmt.Errorf("subject filter '%s' for the source %w", ssi.FilterSubject, ErrBadSubject)
-				}
+			if ssi.FilterSubject != _EMPTY_ && !IsValidSubject(ssi.FilterSubject) {
+				jsa.mu.Unlock()
+				return nil, fmt.Errorf("subject filter '%s' for the source %w", ssi.FilterSubject, ErrBadSubject)
 			}
 			// check the transform, if any, is valid
 			if ssi.SubjectTransformDest != _EMPTY_ {
@@ -1646,7 +1644,8 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 			return fmt.Errorf("stream configuration for subject transform from '%s' to '%s' %w", cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination, err)
 		}
 		mset.itr = tr
-	} else if ocfg.SubjectTransform != nil && cfg.SubjectTransform != nil && (ocfg.SubjectTransform.Source != cfg.SubjectTransform.Source || ocfg.SubjectTransform.Destination != cfg.SubjectTransform.Destination) {
+	} else if ocfg.SubjectTransform != nil && cfg.SubjectTransform != nil &&
+		(ocfg.SubjectTransform.Source != cfg.SubjectTransform.Source || ocfg.SubjectTransform.Destination != cfg.SubjectTransform.Destination) {
 		tr, err := NewSubjectTransform(cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination)
 		if err != nil {
 			mset.mu.Unlock()


### PR DESCRIPTION
Improve checking that subject filters and destination transforms are valid subjects.
Improve error messages when bad filters/transforms are encountered.
Cover all cases of updating an existing stream's subject transform or sources

/cc @nats-io/core
