### PR TITLE
A few small optimizations

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4288,26 +4288,29 @@ func (fs *fileStore) State() StreamState {
 	state.NumSubjects = fs.numSubjects()
 	state.Deleted = nil // make sure.
 
-	cur := fs.state.FirstSeq
+	if numDeleted := int((state.LastSeq - state.FirstSeq + 1) - state.Msgs); numDeleted > 0 {
+		state.Deleted = make([]uint64, 0, numDeleted)
+		cur := fs.state.FirstSeq
 
-	for _, mb := range fs.blks {
-		mb.mu.Lock()
-		fseq := mb.first.seq
-		// Account for messages missing from the head.
-		if fseq > cur {
-			for seq := cur; seq < fseq; seq++ {
-				state.Deleted = append(state.Deleted, seq)
+		for _, mb := range fs.blks {
+			mb.mu.Lock()
+			fseq := mb.first.seq
+			// Account for messages missing from the head.
+			if fseq > cur {
+				for seq := cur; seq < fseq; seq++ {
+					state.Deleted = append(state.Deleted, seq)
+				}
 			}
-		}
-		cur = mb.last.seq + 1 // Expected next first.
-		for seq := range mb.dmap {
-			if seq < fseq {
-				delete(mb.dmap, seq)
-			} else {
-				state.Deleted = append(state.Deleted, seq)
+			cur = mb.last.seq + 1 // Expected next first.
+			for seq := range mb.dmap {
+				if seq < fseq {
+					delete(mb.dmap, seq)
+				} else {
+					state.Deleted = append(state.Deleted, seq)
+				}
 			}
+			mb.mu.Unlock()
 		}
-		mb.mu.Unlock()
 	}
 	fs.mu.RUnlock()
 

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -873,8 +873,7 @@ func (ms *memStore) State() StreamState {
 
 	// Calculate interior delete details.
 	if state.LastSeq > state.FirstSeq {
-		state.NumDeleted = int((state.LastSeq - state.FirstSeq) - state.Msgs + 1)
-		if state.NumDeleted > 0 {
+		if state.NumDeleted = int((state.LastSeq - state.FirstSeq) - state.Msgs + 1); state.NumDeleted > 0 {
 			state.Deleted = make([]uint64, 0, state.NumDeleted)
 			// TODO(dlc) - Too Simplistic, once state is updated to allow runs etc redo.
 			for seq := state.FirstSeq + 1; seq < ms.state.LastSeq; seq++ {


### PR DESCRIPTION
1. Only snapshot with minSnap time window like consumers and meta. Make it consistent for all to 5s.
2. Only snapshot at the end of processing all entries pending vs inside the loop.
3. Use fast state when calculating sync request, do not need deleted details there.
4. Only hold on to so many raft pending in memory, will fetch from WAL

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
