### PR TITLE
Fix Consumer not getting messages after filter update

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1591,6 +1591,15 @@ func (o *consumer) updateConfig(cfg *ConsumerConfig) error {
 		}
 	}
 
+	if o.cfg.FilterSubject != cfg.FilterSubject {
+		if cfg.FilterSubject != _EMPTY_ {
+			o.filterWC = subjectHasWildcard(cfg.FilterSubject)
+		}
+		o.mset.mu.Lock()
+		o.mset.swapSigSubs(o, cfg.FilterSubject)
+		o.mset.mu.Unlock()
+	}
+
 	// Record new config for others that do not need special handling.
 	// Allowed but considered no-op, [Description, SampleFrequency, MaxWaiting, HeadersOnly]
 	o.cfg = *cfg

--- a/server/stream.go
+++ b/server/stream.go
@@ -4665,6 +4665,33 @@ func (mset *stream) removeConsumerAsLeader(o *consumer) {
 	}
 }
 
+// swapSigSubs will update signal Subs for a new subject filter.
+// Lock should be held.
+func (mset *stream) swapSigSubs(o *consumer, newFilter string) {
+	subject := newFilter
+	if subject == _EMPTY_ {
+		subject = fwcs
+	}
+
+	mset.clsMu.Lock()
+	if o.sigSub != nil {
+		o.mset.csl.Remove(o.sigSub)
+	}
+	sub := &subscription{subject: []byte(subject), icb: o.processStreamSignal}
+	mset.csl.Insert(sub)
+	mset.clsMu.Unlock()
+
+	o.sigSub = sub
+
+	// Decrement numFilter if old filter was an actual filter.
+	if o.cfg.FilterSubject != _EMPTY_ && mset.numFilter > 0 {
+		mset.numFilter--
+	}
+	if newFilter != _EMPTY_ {
+		mset.numFilter++
+	}
+}
+
 // lookupConsumer will retrieve a consumer by name.
 func (mset *stream) lookupConsumer(name string) *consumer {
 	mset.mu.RLock()


### PR DESCRIPTION
Found during work on multiple filters


After consumer filter update:
1. Wildcard bool was not updated
2. Sublist for consumers was not updated

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>

/cc @nats-io/core
