### PR TITLE
Fix for isGroupLeaderless when JS not available (due to shutdown)

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -739,7 +739,7 @@ func (js *jetStream) isLeaderless() bool {
 
 // Will respond iff we are a member and we know we have no leader.
 func (js *jetStream) isGroupLeaderless(rg *raftGroup) bool {
-	if rg == nil {
+	if rg == nil || js == nil {
 		return false
 	}
 	js.mu.RLock()


### PR DESCRIPTION
Fix for the following panic that can happen when using the API while shutting down a node:
```
[7] 2023/01/30 19:40:10.189635 [INF] Initiating JetStream Shutdown...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x4c pc=0x844fa6]

goroutine 1011 [running]:
github.com/nats-io/nats-server/v2/server.(*jetStream).isGroupLeaderless(0x0, 0xc0000688a0)
	/go/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:745 +0x46
github.com/nats-io/nats-server/v2/server.(*stream).handleClusterStreamInfoRequest(0xc0000cdc00, 0xc0001ff1f0?, 0x452ba9?, 0x1d?, {0x0?, 0x0?}, {0xc00e5f99c0, 0x1d}, {0xc010d30040, 0x0, ...})
	/go/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:7549 +0x1ba
github.com/nats-io/nats-server/v2/server.(*client).deliverMsg(0xc00b13b300, 0x0, 0xc0002e0000, 0x2?, {0xc010d30009, 0x15, 0xfff7}, {0xc010d3001f, 0x1d, 0xffe1}, ...)
	/go/src/github.com/nats-io/nats-server/server/client.go:3194 +0xade
github.com/nats-io/nats-server/v2/server.(*client).processMsgResults(0xc00b13b300, 0xc0000d1440, 0xc000bb6510, {0xc010d30040, 0x2, 0xffc0}, {0x0, 0x0, 0xc00f321bc0?}, {0xc010d30009, ...}, ...)
	/go/src/github.com/nats-io/nats-server/server/client.go:4239 +0xb10
github.com/nats-io/nats-server/v2/server.(*client).processInboundRoutedMsg(0xc00b13b300, {0xc010d30040, 0x2, 0xffc0})
	/go/src/github.com/nats-io/nats-server/server/route.go:443 +0x159
github.com/nats-io/nats-server/v2/server.(*client).processInboundMsg(0xc00b13b300?, {0xc010d30040?, 0x39?, 0xfffb?})
	/go/src/github.com/nats-io/nats-server/server/client.go:3509 +0x36
github.com/nats-io/nats-server/v2/server.(*client).parse(0xc00b13b300, {0xc010d30000, 0x42, 0x10000})
	/go/src/github.com/nats-io/nats-server/server/parser.go:497 +0x210a
github.com/nats-io/nats-server/v2/server.(*client).readLoop(0xc00b13b300, {0x0, 0x0, 0x0})
	/go/src/github.com/nats-io/nats-server/server/client.go:1238 +0xf36
github.com/nats-io/nats-server/v2/server.(*Server).createRoute.func1()
	/go/src/github.com/nats-io/nats-server/server/route.go:1378 +0x25
created by github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine
	/go/src/github.com/nats-io/nats-server/server/server.go:3083 +0x85
```

Signed-off-by: Waldemar Quevedo <wally@nats.io>

/cc @nats-io/core
