### PR TITLE
Minor fixes and optimizations for snapshots.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -4227,7 +4227,7 @@ func (o *consumer) stopWithFlags(dflag, sdflag, doSignal, advisory bool) error {
 			n.Delete()
 		} else {
 			// Try to install snapshot on clean exit
-			if o.store != nil {
+			if o.store != nil && n.NeedSnapshot() {
 				if snap, err := o.store.EncodedState(); err == nil {
 					n.InstallSnapshot(snap)
 				}

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -1606,7 +1606,6 @@ func TestJetStreamClusterStreamSnapshotCatchup(t *testing.T) {
 	sendBatch(2)
 
 	sl := c.streamLeader("$G", "TEST")
-
 	sl.Shutdown()
 	c.waitOnStreamLeader("$G", "TEST")
 
@@ -1645,9 +1644,12 @@ func TestJetStreamClusterStreamSnapshotCatchup(t *testing.T) {
 	mset, err = sl.GlobalAccount().lookupStream("TEST")
 	require_NoError(t, err)
 
-	if nstate := mset.stateWithDetail(true); !reflect.DeepEqual(ostate, nstate) {
-		t.Fatalf("States do not match after recovery: %+v vs %+v", ostate, nstate)
-	}
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		if nstate := mset.stateWithDetail(true); !reflect.DeepEqual(ostate, nstate) {
+			return fmt.Errorf("States do not match after recovery: %+v vs %+v", ostate, nstate)
+		}
+		return nil
+	})
 }
 
 func TestJetStreamClusterDeleteMsg(t *testing.T) {

--- a/server/stream.go
+++ b/server/stream.go
@@ -4478,7 +4478,7 @@ func (mset *stream) stop(deleteFlag, advisory bool) error {
 		if deleteFlag {
 			n.Delete()
 			sa = mset.sa
-		} else {
+		} else if n.NeedSnapshot() {
 			// Attempt snapshot on clean exit.
 			n.InstallSnapshot(mset.stateSnapshotLocked())
 			n.Stop()


### PR DESCRIPTION
We were snapshotting more then needed, so double check that we should be doing this at the stream and consumer level. At the raft level, we should have always been compacting the WAL to last+1, so made that consistent. Also fixed bug that would not skip last if more items behind the snapshot.

Signed-off-by: Derek Collison <derek@nats.io>
