### PR TITLE
Add `logtime_utc` option

### DIFF
--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -125,7 +125,7 @@ func TestFileLogger(t *testing.T) {
 	file = createFileAtDir(t, tmpDir, "nats-server:log_")
 	file.Close()
 
-	logger = NewFileLogger(file.Name(), true, true, true, true)
+	logger = NewFileLogger(file.Name(), true, false, true, true)
 	defer logger.Close()
 	logger.Errorf("foo")
 

--- a/server/configs/reload/reload.conf
+++ b/server/configs/reload/reload.conf
@@ -6,6 +6,7 @@ port: 2233
 debug:         true # enable on reload
 trace:         true # enable on reload
 logtime:       true # enable on reload
+logtime_utc:   true # enable on reload
 
 log_file:         "nats-server.log" # change on reload
 pid_file:         "nats-server.pid" # change on reload

--- a/server/log.go
+++ b/server/log.go
@@ -66,7 +66,7 @@ func (s *Server) ConfigureLogger() {
 	}
 
 	if opts.LogFile != "" {
-		log = srvlog.NewFileLogger(opts.LogFile, opts.Logtime, opts.Debug, opts.Trace, true)
+		log = srvlog.NewFileLogger(opts.LogFile, opts.Logtime, opts.Debug, opts.Trace, true, srvlog.LogUTC(opts.LogtimeUTC))
 		if opts.LogSizeLimit > 0 {
 			if l, ok := log.(*srvlog.Logger); ok {
 				l.SetSizeLimit(opts.LogSizeLimit)
@@ -84,7 +84,7 @@ func (s *Server) ConfigureLogger() {
 		if err != nil || (stat.Mode()&os.ModeCharDevice) == 0 {
 			colors = false
 		}
-		log = srvlog.NewStdLogger(opts.Logtime, opts.Debug, opts.Trace, colors, true)
+		log = srvlog.NewStdLogger(opts.Logtime, opts.Debug, opts.Trace, colors, true, srvlog.LogUTC(opts.LogtimeUTC))
 	}
 
 	s.SetLoggerV2(log, opts.Debug, opts.Trace, opts.TraceVerbose)
@@ -154,8 +154,11 @@ func (s *Server) ReOpenLogFile() {
 	if opts.LogFile == "" {
 		s.Noticef("File log re-open ignored, not a file logger")
 	} else {
-		fileLog := srvlog.NewFileLogger(opts.LogFile,
-			opts.Logtime, opts.Debug, opts.Trace, true)
+		fileLog := srvlog.NewFileLogger(
+			opts.LogFile, opts.Logtime,
+			opts.Debug, opts.Trace, true,
+			srvlog.LogUTC(opts.LogtimeUTC),
+		)
 		s.SetLogger(fileLog, opts.Debug, opts.Trace)
 		if opts.LogSizeLimit > 0 {
 			fileLog.SetSizeLimit(opts.LogSizeLimit)

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -101,7 +101,7 @@ func TestReOpenLogFile(t *testing.T) {
 
 	// Set a File log
 	s.opts.LogFile = filepath.Join(t.TempDir(), "test.log")
-	fileLog := logger.NewFileLogger(s.opts.LogFile, s.opts.Logtime, s.opts.Debug, s.opts.Trace, true)
+	fileLog := logger.NewFileLogger(s.opts.LogFile, s.opts.Logtime, s.opts.Debug, s.opts.Trace, true, logger.LogUTC(s.opts.LogtimeUTC))
 	s.SetLogger(fileLog, false, false)
 	// Add some log
 	expectedStr := "This is a Notice"

--- a/server/opts.go
+++ b/server/opts.go
@@ -234,6 +234,7 @@ type Options struct {
 	NoHeaderSupport       bool          `json:"-"`
 	DisableShortFirstPing bool          `json:"-"`
 	Logtime               bool          `json:"-"`
+	LogtimeUTC            bool          `json:"-"`
 	MaxConn               int           `json:"max_connections"`
 	MaxSubs               int           `json:"max_subscriptions,omitempty"`
 	MaxSubTokens          uint8         `json:"-"`
@@ -805,6 +806,9 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 	case "logtime":
 		o.Logtime = v.(bool)
 		trackExplicitVal(o, &o.inConfig, "Logtime", o.Logtime)
+	case "logtime_utc":
+		o.LogtimeUTC = v.(bool)
+		trackExplicitVal(o, &o.inConfig, "LogtimeUTC", o.LogtimeUTC)
 	case "mappings", "maps":
 		gacc := NewAccount(globalAccountName)
 		o.Accounts = append(o.Accounts, gacc)
@@ -4805,6 +4809,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.BoolVar(&dbgAndTrcAndVerboseTrc, "DVV", false, "Enable Debug and Verbose Trace logging. (Traces system account as well)")
 	fs.BoolVar(&opts.Logtime, "T", true, "Timestamp log entries.")
 	fs.BoolVar(&opts.Logtime, "logtime", true, "Timestamp log entries.")
+	fs.BoolVar(&opts.LogtimeUTC, "logtime_utc", true, "Timestamps in UTC instead of local timezone.")
 	fs.StringVar(&opts.Username, "user", _EMPTY_, "Username required for connection.")
 	fs.StringVar(&opts.Password, "pass", _EMPTY_, "Password required for connection.")
 	fs.StringVar(&opts.Authorization, "auth", _EMPTY_, "Authorization token required for connection.")

--- a/server/reload.go
+++ b/server/reload.go
@@ -162,6 +162,17 @@ func (l *logtimeOption) Apply(server *Server) {
 	server.Noticef("Reloaded: logtime = %v", l.newValue)
 }
 
+// logtimeUTCOption implements the option interface for the `logtime_utc` setting.
+type logtimeUTCOption struct {
+	loggingOption
+	newValue bool
+}
+
+// Apply is a no-op because logging will be reloaded after options are applied.
+func (l *logtimeUTCOption) Apply(server *Server) {
+	server.Noticef("Reloaded: logtime_utc = %v", l.newValue)
+}
+
 // logfileOption implements the option interface for the `log_file` setting.
 type logfileOption struct {
 	loggingOption
@@ -1017,6 +1028,8 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 			diffOpts = append(diffOpts, &debugOption{newValue: newValue.(bool)})
 		case "logtime":
 			diffOpts = append(diffOpts, &logtimeOption{newValue: newValue.(bool)})
+		case "logtimeutc":
+			diffOpts = append(diffOpts, &logtimeUTCOption{newValue: newValue.(bool)})
 		case "logfile":
 			diffOpts = append(diffOpts, &logfileOption{newValue: newValue.(string)})
 		case "syslog":

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -308,6 +308,9 @@ func TestConfigReload(t *testing.T) {
 	if !updated.Logtime {
 		t.Fatal("Expected Logtime to be true")
 	}
+	if !updated.LogtimeUTC {
+		t.Fatal("Expected LogtimeUTC to be true")
+	}
 	if runtime.GOOS != "windows" {
 		if !updated.Syslog {
 			t.Fatal("Expected Syslog to be true")

--- a/server/signal_test.go
+++ b/server/signal_test.go
@@ -44,7 +44,7 @@ func TestSignalToReOpenLogFile(t *testing.T) {
 	defer s.Shutdown()
 
 	// Set the file log
-	fileLog := logger.NewFileLogger(s.opts.LogFile, s.opts.Logtime, s.opts.Debug, s.opts.Trace, true)
+	fileLog := logger.NewFileLogger(s.opts.LogFile, s.opts.Logtime, s.opts.Debug, s.opts.Trace, true, logger.LogUTC(s.opts.LogtimeUTC))
 	s.SetLogger(fileLog, false, false)
 
 	// Add a trace


### PR DESCRIPTION
Fixes #3826 by adding the `logtime_utc` configuration option for both the stdout and the file logger.

Signed-off-by: Neil Twigg <neil@nats.io>