### PR TITLE
Fix current consumers not getting messages after purge

### DIFF
--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -1075,6 +1075,7 @@ func TestIsSubsetMatch(t *testing.T) {
 		test    string
 		result  bool
 	}{
+		{"foo.bar", "foo.bar", true},
 		{"foo.*", ">", true},
 		{"foo.*", "*.*", true},
 		{"foo.*", "foo.*", true},


### PR DESCRIPTION
Until now, purge updated all consumers sequences
even if purge subject was only a subset of given consumer filter. Because of that, even messages from not purged subjects were not fetched or properly accounted for existing consumers.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>

/cc @nats-io/core
