### PR TITLE
Fix monitor consumer condition

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4005,7 +4005,7 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 		}
 
 		// Check several things to see if we need a snapshot.
-		if !force && !n.NeedSnapshot() {
+		if !force || !n.NeedSnapshot() {
 			// Check if we should compact etc. based on size of log.
 			if ne, nb := n.Size(); ne < compactNumMin && nb < compactSizeMin {
 				return


### PR DESCRIPTION
commit e9a983c802fb81060ca0e806d288dfdafcdf68b8 simplified condition around checking if we need a snapshot, but with a different logic outcome (intentional). This reverts the change.

```diff
-  if needSnap := force && n.NeedSnapshot(); !needSnap {
+. if !force && !n.NeedSnapshot() {
```
This is a different condition.


/cc @nats-io/core
