### PR TITLE
YAML engineering: quote go version string

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -5,7 +5,9 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [1.16]
+        # This should be quoted or use .x, but should not be unquoted.
+        # Remember that a YAML bare float drops trailing zeroes.
+        go: ['1.16']
 
     env:
       GOPATH: /home/runner/work/nats-server

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -24,7 +24,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          # This should be quoted or use .x, but should not be unquoted.
+          # Remember that a YAML bare float drops trailing zeroes.
+          go-version: '1.19'
 
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v3

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ vm:
 
 language: go
 go:
-- 1.19.5
+# This should be quoted or use .x, but should not be unquoted.
+# Remember that a YAML bare float drops trailing zeroes.
+- '1.19.5'
 
 addons:
   apt:


### PR DESCRIPTION
We're currently using Go 1.19; we'll switch to 1.20 when the NATS Maintainers
make the call to switch.  Prepare by making sure that 1.20 won't turn into 1.2
instead, by quoting the string to be updated and adding a warning.

/cc @nats-io/core
