### PR TITLE
Small fix to nats-server-hardened.service

### DIFF
--- a/util/nats-server-hardened.service
+++ b/util/nats-server-hardened.service
@@ -12,7 +12,8 @@ Group=nats
 
 # Hardening
 CapabilityBoundingSet=
-LimitNOFILE=800000 # JetStream requires 2 FDs open per stream.
+# JetStream requires 2 FDs open per stream.
+LimitNOFILE=800000
 LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true


### PR DESCRIPTION
Importing as is would have reported:
```
/etc/systemd/system/nats.service:15: Failed to parse resource value, ignoring: 800000 # JetStream requires 2 FDs open per stream.
```

/cc @nats-io/core
