### PR TITLE
Fix TestJetStreamParallelConsumerCreation race

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -1504,6 +1504,7 @@ func TestJetStreamParallelConsumerCreation(t *testing.T) {
 			// Make them all fire at once.
 			<-startCh
 
+			var err error
 			_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
 				Durable:  "dlc",
 				Replicas: 3,


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write at 0x00c0000a94d0 by goroutine 189:
  github.com/nats-io/nats-server/v2/server.TestJetStreamParallelConsumerCreation.func1()
      ./nats-dev/src/github.com/nats-io/nats-server/server/jetstream_cluster_3_test.go:1507 +0x1ec

Previous write at 0x00c0000a94d0 by goroutine 180:
  github.com/nats-io/nats-server/v2/server.TestJetStreamParallelConsumerCreation.func1()
      ./nats-dev/src/github.com/nats-io/nats-server/server/jetstream_cluster_3_test.go:1507 +0x1ec

Goroutine 189 (running) created at:
  github.com/nats-io/nats-server/v2/server.TestJetStreamParallelConsumerCreation()
      ./nats-dev/src/github.com/nats-io/nats-server/server/jetstream_cluster_3_test.go:1497 +0x360
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1629 +0x40

Goroutine 180 (running) created at:
  github.com/nats-io/nats-server/v2/server.TestJetStreamParallelConsumerCreation()
      ./nats-dev/src/github.com/nats-io/nats-server/server/jetstream_cluster_3_test.go:1497 +0x360
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1629 +0x40
==================

``` 
/cc @nats-io/core
