### PR TITLE
[FIXED] Adjusted test to correspond to new limit of 1024.

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -4084,7 +4084,7 @@ func TestNoRaceJetStreamConsumerFileStoreConcurrentDiskIO(t *testing.T) {
 	gmp := runtime.GOMAXPROCS(32)
 	defer runtime.GOMAXPROCS(gmp)
 
-	maxT := debug.SetMaxThreads(64)
+	maxT := debug.SetMaxThreads(1050) // 1024 now
 	defer debug.SetMaxThreads(maxT)
 
 	fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "MT", Storage: FileStorage})


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
