### PR TITLE
[IMPROVED] ConsumerInfo request processing.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1679,6 +1679,7 @@ func (fs *fileStore) FilteredState(sseq uint64, subj string) SimpleState {
 
 	// Tracking subject state.
 	fs.mu.RLock()
+	// TODO(dlc) - Optimize for 2.10 with avl tree and no atomics per block.
 	for _, mb := range fs.blks {
 		// Skip blocks that are less than our starting sequence.
 		if sseq > atomic.LoadUint64(&mb.last.seq) {


### PR DESCRIPTION
Do not re-calculate NumPending on all consumer info calls.

We noticed that consumer info calls were being called alot in some environments. When the consumer had a filtered subject with a wildcard and the stream had a high cardinality of subjects and was falling behind this could take a substantial amount of time.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
