### PR TITLE
[FIXED] Do not warn if consumer replicas configured to 0

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -5111,7 +5111,9 @@ func (mset *stream) checkConsumerReplication() {
 	s, acc := mset.srv, mset.acc
 	for _, o := range mset.consumers {
 		o.mu.RLock()
-		if mset.cfg.Replicas != o.cfg.Replicas {
+		// Consumer replicas 0 can be a legit config for the replicas and we will inherit from the stream
+		// when this is the case.
+		if mset.cfg.Replicas != o.cfg.Replicas && o.cfg.Replicas != 0 {
 			s.Errorf("consumer '%s > %s > %s' MUST match replication (%d vs %d) of stream with interest policy",
 				acc, mset.cfg.Name, o.cfg.Name, mset.cfg.Replicas, o.cfg.Replicas)
 		}


### PR DESCRIPTION
If a consumer had an older configuration with replicas of 0, we do not need to warn for an interest policy stream since the replicas will be inherited from the parent stream.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
