### PR TITLE
Check if connection name was already set when storing it

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1801,7 +1801,7 @@ func (c *client) processConnect(arg []byte) error {
 			}
 		}
 		if ncs != _EMPTY_ {
-			c.ncs.Store(fmt.Sprintf("%s - %q", c, ncs))
+			c.ncs.CompareAndSwap(nil, fmt.Sprintf("%s - %q", c, ncs))
 		}
 	}
 


### PR DESCRIPTION
Same change from https://github.com/nats-io/nats-server/pull/3824 but to main branch instead.
/cc @nats-io/core
