### PR TITLE
[FIXED] Using partition with multiple wildcard token positions

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -4431,7 +4431,9 @@ func newTransform(src, dest string) (*transform, error) {
 				dtokMappingFunctionIntArgs = append(dtokMappingFunctionIntArgs, -1)
 				dtokMappingFunctionStringArgs = append(dtokMappingFunctionStringArgs, _EMPTY_)
 			} else {
-				nphs++
+				// We might combine multiple tokens into one, for example with a partition
+				nphs += len(transformArgWildcardIndexes)
+
 				// Now build up our runtime mapping from dest to source tokens.
 				var stis []int
 				for _, wildcardIndex := range transformArgWildcardIndexes {

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -3303,6 +3303,8 @@ func TestSubjectTransforms(t *testing.T) {
 	shouldBeOK("foo", "bar")
 	shouldBeOK("foo.*.bar.*.baz", "req.$2.$1")
 	shouldBeOK("baz.>", "mybaz.>")
+	shouldBeOK("*.*", "{{partition(10,1,2)}}")
+	shouldBeOK("foo.*.*", "foo.{{wildcard(1)}}.{{wildcard(2)}}.{{partition(5,1,2)}}")
 	shouldBeOK("*", "{{splitfromleft(1,1)}}")
 
 	shouldMatch := func(src, dest, sample, expected string) {


### PR DESCRIPTION
Resolves https://github.com/nats-io/nats-server/issues/3868 (and https://github.com/nats-io/natscli/issues/703)

When using a `{{partition(10,1,2)}}` with multiple wildcard token positions, because of the `nphs++` it would only count as one wildcard being used.

/cc @nats-io/core
