### PR TITLE
[FIXED] Consumer fixes and improvements on state management.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3816,7 +3816,7 @@ func (o *consumer) checkPending() {
 			return
 		}
 		// Check if these are no longer valid.
-		if seq < fseq {
+		if seq < fseq || seq <= o.asflr {
 			delete(o.pending, seq)
 			delete(o.rdc, seq)
 			o.removeFromRedeliverQueue(seq)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -19558,8 +19558,7 @@ func TestJetStreamPartialPurgeWithAckPending(t *testing.T) {
 
 	nmsgs := 100
 	for i := 0; i < nmsgs; i++ {
-		_, err := js.Publish("foo", []byte("OK"))
-		require_NoError(t, err)
+		sendStreamMsg(t, nc, "foo", "OK")
 	}
 	sub, err := js.PullSubscribe("foo", "dlc", nats.AckWait(time.Second))
 	require_NoError(t, err)
@@ -19583,8 +19582,7 @@ func TestJetStreamPartialPurgeWithAckPending(t *testing.T) {
 	require_True(t, ci.NumPending == 0)
 
 	for i := 0; i < nmsgs; i++ {
-		_, err := js.Publish("foo", []byte("OK"))
-		require_NoError(t, err)
+		sendStreamMsg(t, nc, "foo", "OK")
 	}
 
 	ci, err = js.ConsumerInfo("TEST", "dlc")
@@ -19666,8 +19664,7 @@ func TestJetStreamPurgeWithRedeliveredPending(t *testing.T) {
 
 	nmsgs := 100
 	for i := 0; i < nmsgs; i++ {
-		_, err := js.Publish("foo", []byte("OK"))
-		require_NoError(t, err)
+		sendStreamMsg(t, nc, "foo", "OK")
 	}
 	sub, err := js.PullSubscribe("foo", "dlc", nats.AckWait(time.Second))
 	require_NoError(t, err)
@@ -19715,8 +19712,7 @@ func TestJetStreamConsumerAckFloorWithExpired(t *testing.T) {
 
 	nmsgs := 100
 	for i := 0; i < nmsgs; i++ {
-		_, err := js.Publish("foo", []byte("OK"))
-		require_NoError(t, err)
+		sendStreamMsg(t, nc, "foo", "OK")
 	}
 	sub, err := js.PullSubscribe("foo", "dlc", nats.AckWait(time.Second))
 	require_NoError(t, err)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -19542,3 +19542,111 @@ func TestJetStreamRollup(t *testing.T) {
 	require_NoError(t, err)
 	require_True(t, cinfo.NumPending == 10)
 }
+
+func TestJetStreamPartialPurgeWithAckPending(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+	})
+	require_NoError(t, err)
+
+	nmsgs := 100
+	for i := 0; i < nmsgs; i++ {
+		_, err := js.Publish("foo", []byte("OK"))
+		require_NoError(t, err)
+	}
+	sub, err := js.PullSubscribe("foo", "dlc", nats.AckWait(time.Second))
+	require_NoError(t, err)
+
+	// Queue up all for ack pending.
+	_, err = sub.Fetch(nmsgs)
+	require_NoError(t, err)
+
+	keep := nmsgs / 2
+	require_NoError(t, js.PurgeStream("TEST", &nats.StreamPurgeRequest{Keep: uint64(keep)}))
+
+	// Should be able to be redelivered now.
+	time.Sleep(2 * time.Second)
+
+	ci, err := js.ConsumerInfo("TEST", "dlc")
+	require_NoError(t, err)
+	// Make sure we calculated correctly.
+	require_True(t, ci.AckFloor.Consumer == uint64(keep))
+	require_True(t, ci.AckFloor.Stream == uint64(keep))
+	require_True(t, ci.NumAckPending == keep)
+	require_True(t, ci.NumPending == 0)
+
+	for i := 0; i < nmsgs; i++ {
+		_, err := js.Publish("foo", []byte("OK"))
+		require_NoError(t, err)
+	}
+
+	ci, err = js.ConsumerInfo("TEST", "dlc")
+	require_NoError(t, err)
+	// Make sure we calculated correctly.
+	// Top 3 will be same.
+	require_True(t, ci.AckFloor.Consumer == uint64(keep))
+	require_True(t, ci.AckFloor.Stream == uint64(keep))
+	require_True(t, ci.NumAckPending == keep)
+	require_True(t, ci.NumPending == uint64(nmsgs))
+	require_True(t, ci.NumRedelivered == 0)
+
+	msgs, err := sub.Fetch(keep)
+	require_NoError(t, err)
+	require_True(t, len(msgs) == keep)
+
+	ci, err = js.ConsumerInfo("TEST", "dlc")
+	require_NoError(t, err)
+	// Make sure we calculated correctly.
+	require_True(t, ci.Delivered.Consumer == uint64(nmsgs+keep))
+	require_True(t, ci.Delivered.Stream == uint64(nmsgs))
+	require_True(t, ci.AckFloor.Consumer == uint64(keep))
+	require_True(t, ci.AckFloor.Stream == uint64(keep))
+	require_True(t, ci.NumAckPending == keep)
+	require_True(t, ci.NumPending == uint64(nmsgs))
+	require_True(t, ci.NumRedelivered == keep)
+
+	// Ack all.
+	for _, m := range msgs {
+		m.Ack()
+	}
+	nc.Flush()
+
+	ci, err = js.ConsumerInfo("TEST", "dlc")
+	require_NoError(t, err)
+	// Same for Delivered
+	require_True(t, ci.Delivered.Consumer == uint64(nmsgs+keep))
+	require_True(t, ci.Delivered.Stream == uint64(nmsgs))
+	require_True(t, ci.AckFloor.Consumer == uint64(nmsgs+keep))
+	require_True(t, ci.AckFloor.Stream == uint64(nmsgs))
+	require_True(t, ci.NumAckPending == 0)
+	require_True(t, ci.NumPending == uint64(nmsgs))
+	require_True(t, ci.NumRedelivered == 0)
+
+	msgs, err = sub.Fetch(nmsgs)
+	require_NoError(t, err)
+	require_True(t, len(msgs) == nmsgs)
+
+	// Ack all again
+	for _, m := range msgs {
+		m.Ack()
+	}
+	nc.Flush()
+
+	ci, err = js.ConsumerInfo("TEST", "dlc")
+	require_NoError(t, err)
+	// Make sure we calculated correctly.
+	require_True(t, ci.Delivered.Consumer == uint64(nmsgs*2+keep))
+	require_True(t, ci.Delivered.Stream == uint64(nmsgs*2))
+	require_True(t, ci.AckFloor.Consumer == uint64(nmsgs*2+keep))
+	require_True(t, ci.AckFloor.Stream == uint64(nmsgs*2))
+	require_True(t, ci.NumAckPending == 0)
+	require_True(t, ci.NumPending == 0)
+	require_True(t, ci.NumRedelivered == 0)
+}


### PR DESCRIPTION
Make sure to also cleanup pending if below our stream ack floor.
Make sure to clean up redelivered state on purge.
Make sure to update ack floors on messages being expired out from underneath of us.
Fixed bug that would lose ack pending state during partial stream purge.
Make sure we warn properly of consumer state update failures.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
