### PR TITLE
Set code owners, tweak PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nats-io/server

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,5 +13,3 @@ Resolves #
  -
  -
  -
-
-/cc @nats-io/core


### PR DESCRIPTION
This will remove the "cc" from the PR template (which typically doesn't work for outside contributors) and instead replaces it with a code owners file, which will mean that PRs against this repository will automatically request review from the new @nats-io/server team.

Signed-off-by: Neil Twigg <neil@nats.io>