### PR TITLE
Don't compact past `applied` in `InstallSnapshot`

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -976,7 +976,7 @@ func (n *raft) InstallSnapshot(data []byte) error {
 	// Remember our latest snapshot file.
 	n.snapfile = sfile
 
-	if _, err := n.wal.Compact(snap.lastIndex + 1); err != nil {
+	if _, err := n.wal.Compact(snap.lastIndex); err != nil {
 		n.setWriteErrLocked(err)
 		n.Unlock()
 		return err


### PR DESCRIPTION
This seems to be an off-by-one again, in this case `snap.lastIndex` is already set to `n.applied` so we'll compact up to but not including the applied entry.

With this, `TestJetStreamClusterStreamCatchupNoState` no longer churns on `Wrong index, ae is...` in RAFT indefinitely.