### PR TITLE
[FIXED] If a truncate for a raft WAL failed we could spin.

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1008,7 +1008,7 @@ func (js *jetStream) monitorCluster() {
 		if hash := highwayhash.Sum(snap, key); !bytes.Equal(hash[:], lastSnap) {
 			if err := n.InstallSnapshot(snap); err == nil {
 				lastSnap, lastSnapTime = hash[:], time.Now()
-			} else {
+			} else if err != errNoSnapAvailable {
 				s.Warnf("Error snapshotting JetStream cluster state: %v", err)
 			}
 		}
@@ -1887,7 +1887,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 		if !bytes.Equal(hash[:], lastSnap) || ne >= compactNumMin || nb >= compactSizeMin {
 			if err := n.InstallSnapshot(snap); err == nil {
 				lastSnap, lastSnapTime = hash[:], time.Now()
-			} else {
+			} else if err != errNoSnapAvailable {
 				s.Warnf("Failed to install snapshot for '%s > %s' [%s]: %v", mset.acc.Name, mset.name(), n.Group(), err)
 			}
 		}
@@ -4051,7 +4051,7 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 			if !bytes.Equal(hash[:], lastSnap) || ne >= compactNumMin || nb >= compactSizeMin {
 				if err := n.InstallSnapshot(snap); err == nil {
 					lastSnap, lastSnapTime = hash[:], time.Now()
-				} else {
+				} else if err != errNoSnapAvailable {
 					s.Warnf("Failed to install snapshot for '%s > %s > %s' [%s]: %v", o.acc.Name, ca.Stream, ca.Name, n.Group(), err)
 				}
 			}


### PR DESCRIPTION
When the truncate failed we would continue to process append entries without changing state.
This could result in raft stores filling up disks and systems becoming unresponsive.

The server log could also fill up with warnings similar to this one.

```[WRN] RAFT [z3WIzPtj - S-R2F-76KY41ow] Wrong index, ae is &{leader:z3WIzPtj term:1 commit:100 pterm:1 pindex:100 entries: 1}, index stored was 115, n.pindex is 100```

Signed-off-by: Derek Collison <derek@nats.io>
