### PR TITLE
Port https://github.com/nats-io/nats-server/pull/3887 to dev

### DIFF
--- a/server/subject_transform.go
+++ b/server/subject_transform.go
@@ -109,7 +109,7 @@ func NewSubjectTransform(src, dest string) (*subjectTransform, error) {
 				dtokMappingFunctionIntArgs = append(dtokMappingFunctionIntArgs, -1)
 				dtokMappingFunctionStringArgs = append(dtokMappingFunctionStringArgs, _EMPTY_)
 			} else {
-				nphs++
+				nphs += len(transformArgWildcardIndexes)
 				// Now build up our runtime mapping from dest to source tokens.
 				var stis []int
 				for _, wildcardIndex := range transformArgWildcardIndexes {

--- a/server/subject_transform_test.go
+++ b/server/subject_transform_test.go
@@ -119,6 +119,8 @@ func TestSubjectTransforms(t *testing.T) {
 	shouldBeOK("baz.>", "mybaz.>")
 	shouldBeOK("*", "{{splitfromleft(1,1)}}")
 	shouldBeOK("", "prefix.>")
+	shouldBeOK("*.*", "{{partition(10,1,2)}}")
+	shouldBeOK("foo.*.*", "foo.{{wildcard(1)}}.{{wildcard(2)}}.{{partition(5,1,2)}}")
 
 	shouldMatch := func(src, dest, sample, expected string) {
 		t.Helper()


### PR DESCRIPTION

 - [X] Tests added
 - [X] Branch rebased on top of current dev (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Applies https://github.com/nats-io/nats-server/pull/3887 to dev (since I noticed the merge of main to dev of that PR effectively made it disappear (because stream transform changes included extracting transforms from accounts.go)