### PR TITLE
Fix memory bloat when adding source to the stream

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -2850,10 +2850,8 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 // Generate a new style source header.
 func (si *sourceInfo) genSourceHeader(reply string) string {
 	var b strings.Builder
-	// strip the source index number from the iname
-	name := si.iname[strings.IndexRune(si.iname, ':')+1:]
 
-	b.WriteString(name)
+	b.WriteString(si.iname)
 	b.WriteByte(' ')
 	// Grab sequence as text here from reply subject.
 	var tsa [expectedNumReplyTokens]string


### PR DESCRIPTION
Stream subject mapping added index prefix to Nats-Stream-Source which was stripped when retrieving that header. That caused startingSequenceForSources to iterate over the whole stream because of
name mismatch. Stripping was removed in this commit.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>
