### PR TITLE
Add raft query parameter to /jsz to include raft group info

### DIFF
--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -4310,6 +4310,9 @@ func TestMonitorJsz(t *testing.T) {
 			if info.AccountDetails[0].Streams[0].Consumer[0].Config != nil {
 				t.Fatal("Config expected to not be present")
 			}
+			if len(info.AccountDetails[0].Streams[0].ConsumerRaftGroups) != 0 {
+				t.Fatalf("expected consumer raft groups to not be returned by %s but got %v", url, info)
+			}
 		}
 	})
 	t.Run("config", func(t *testing.T) {
@@ -4390,6 +4393,31 @@ func TestMonitorJsz(t *testing.T) {
 			info := readJsInfo(url)
 			if len(info.Config.UniqueTag) == 0 {
 				t.Fatalf("expected unique_tag to be returned by %s but got %v", url, info)
+			}
+		}
+	})
+	t.Run("raftgroups", func(t *testing.T) {
+		for _, url := range []string{monUrl1, monUrl2} {
+			info := readJsInfo(url + "?acc=ACC&consumers=true&raft=true")
+			if len(info.AccountDetails) != 1 {
+				t.Fatalf("expected account ACC to be returned by %s but got %v", url, info)
+			}
+			if len(info.AccountDetails[0].Streams[0].Consumer) == 0 {
+				t.Fatalf("expected consumers to be returned by %s but got %v", url, info)
+			}
+			if len(info.AccountDetails[0].Streams[0].ConsumerRaftGroups) == 0 {
+				t.Fatalf("expected consumer raft groups to be returned by %s but got %v", url, info)
+			}
+			srgroup := info.AccountDetails[0].Streams[0].RaftGroup
+			if len(srgroup) == 0 {
+				t.Fatal("expected stream raft group info to be included")
+			}
+			crgroup := info.AccountDetails[0].Streams[0].ConsumerRaftGroups[0]
+			if crgroup.Name != "my-consumer-replicated" {
+				t.Fatalf("expected consumer name to be included in raft group info, got: %v", crgroup.Name)
+			}
+			if len(crgroup.RaftGroup) == 0 {
+				t.Fatal("expected consumer raft group info to be included")
 			}
 		}
 	})


### PR DESCRIPTION
This adds a new `raft` query parameter to be able to map a stream/consumer name with its active raft group:

```
/jsz?consumers=1&raft=1
```

```js
 "stream_raft_group": "S-R3F-8Qml10Ei",
"consumer_raft_groups": [
  {
    "name": "1",
    "raft_group": "C-R3F-5c87s2aq"
  },
  {
    "name": "10",
    "raft_group": "C-R3F-PF8WWIue"
  },
  {
    "name": "100",
    "raft_group": "C-R3F-r58xhrRe"
  },
  {
    "name": "12",
    "raft_group": "C-R3F-faSs9EY1"
  },
```
