### PR TITLE
Updated LEAFZ names to use remoteServer name/id and added is_spoke

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -888,13 +888,7 @@ func (s *Server) createLeafNode(conn net.Conn, rURL *url.URL, remote *leafNodeCf
 	}
 	now := time.Now().UTC()
 
-	var clientOpts = ClientOpts{
-		Name:     opts.ServerName,
-		Verbose:  defaultOpts.Verbose,
-		Pedantic: defaultOpts.Pedantic,
-		Echo:     defaultOpts.Echo,
-	}
-	c := &client{srv: s, nc: conn, kind: LEAF, opts: clientOpts, mpay: maxPay, msubs: maxSubs, start: now, last: now}
+	c := &client{srv: s, nc: conn, kind: LEAF, opts: defaultOpts, mpay: maxPay, msubs: maxSubs, start: now, last: now}
 	// Do not update the smap here, we need to do it in initLeafNodeSmapAndSendSubs
 	c.leaf = &leaf{}
 

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2095,6 +2095,7 @@ type LeafzOptions struct {
 // LeafInfo has detailed information on each remote leafnode connection.
 type LeafInfo struct {
 	Name     string   `json:"name"`
+	IsSpoke  bool     `json:"is_spoke"`
 	Account  string   `json:"account"`
 	IP       string   `json:"ip"`
 	Port     int      `json:"port"`
@@ -2134,7 +2135,8 @@ func (s *Server) Leafz(opts *LeafzOptions) (*Leafz, error) {
 		for _, ln := range lconns {
 			ln.mu.Lock()
 			lni := &LeafInfo{
-				Name:     ln.opts.Name,
+				Name:     ln.leaf.remoteServer,
+				IsSpoke:  ln.isSpokeLeafNode(),
 				Account:  ln.acc.Name,
 				IP:       ln.host,
 				Port:     int(ln.port),

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -3678,6 +3678,7 @@ func TestMonitorOpJWT(t *testing.T) {
 
 func TestMonitorLeafz(t *testing.T) {
 	content := `
+	server_name: "hub"
 	listen: "127.0.0.1:-1"
 	http: "127.0.0.1:-1"
 	operator = "../test/configs/nkeys/op.jwt"
@@ -3817,8 +3818,11 @@ func TestMonitorLeafz(t *testing.T) {
 			} else {
 				t.Fatalf("Expected account to be %q or %q, got %q", acc1.Name, acc2.Name, ln.Account)
 			}
-			if ln.Name != leafName {
-				t.Fatalf("Expected name to be %q, got %q", leafName, ln.Name)
+			if ln.Name != "hub" {
+				t.Fatalf("Expected name to be %q, got %q", "hub", ln.Name)
+			}
+			if !ln.IsSpoke {
+				t.Fatal("Expected leafnode connection to be spoke")
 			}
 			if ln.RTT == "" {
 				t.Fatalf("RTT not tracked?")
@@ -3910,6 +3914,9 @@ func TestMonitorLeafz(t *testing.T) {
 			}
 			if ln.Name != leafName {
 				t.Fatalf("Expected name to be %q, got %q", leafName, ln.Name)
+			}
+			if ln.IsSpoke {
+				t.Fatal("Expected leafnode connection to be hub")
 			}
 			if ln.RTT == "" {
 				t.Fatalf("RTT not tracked?")


### PR DESCRIPTION
This is a followup on #3923 that improves LEAFZ names to use `ln.leaf.remoteServer` instead of the connection name.

I've also added `is_spoke` to the leafz LeafInfo struct so that we can easily tell if a leaf connection is a hub or spoke.
