### PR TITLE
fix uses for embedded action in nightly build

### DIFF
--- a/.github/workflows/rc_nightly.yaml
+++ b/.github/workflows/rc_nightly.yaml
@@ -16,7 +16,7 @@ jobs:
           path: src/github.com/nats-io/nats-server
           ref: main
 
-      - uses: src/github.com/nats-io/nats-server/.github/actions/nightly-release
+      - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:
           go: "1.19"
           label: nightly-main


### PR DESCRIPTION
The uses option requires a path that start with . for local files
