### PR TITLE
Remove msgs from interest based stream on consumer snapshot.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 The NATS Authors
+// Copyright 2019-2023 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
Make sure to cleanup stream messages on a follower consumer for an interest based stream when the consumer leader sends a state snapshot.

When we would receive a state snapshot vs individual replicated acks we would not remove the stream's messages.

Signed-off-by: Derek Collison <derek@nats.io>
