### PR TITLE
Don't recycle buffer more than once

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4001,9 +4001,6 @@ func (mb *msgBlock) flushPendingMsgsLocked() (*LostStreamData, error) {
 			dst = make([]byte, lob)
 		}
 		mb.bek.XORKeyStream(dst, buf)
-		if cap(buf) <= defaultLargeBlockSize {
-			recycleMsgBlockBuf(buf)
-		}
 		buf = dst
 	}
 


### PR DESCRIPTION
This should fix a panic with overlapping slices ending up in the message block buffer pool.

Signed-off-by: Neil Twigg <neil@nats.io>