### PR TITLE
Remove snapshotting of cores and maxprocs.

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,8 +134,6 @@ func main() {
 		s.Warnf("Failed to set GOMAXPROCS: %v", err)
 	} else {
 		defer undo()
-		// Reset these from the snapshots from init for monitor.go
-		server.SnapshotMonitorInfo()
 	}
 
 	s.WaitForShutdown()

--- a/server/events.go
+++ b/server/events.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -603,7 +604,7 @@ func (s *Server) updateServerUsage(v *ServerStats) {
 	defer s.mu.Lock()
 	var vss int64
 	pse.ProcUsage(&v.CPU, &v.Mem, &vss)
-	v.Cores = numCores
+	v.Cores = runtime.NumCPU()
 }
 
 // Generate a route stat for our statz update.

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -36,19 +36,6 @@ import (
 	"github.com/nats-io/nats-server/v2/server/pse"
 )
 
-// Snapshot this
-var numCores int
-var maxProcs int
-
-func SnapshotMonitorInfo() {
-	numCores = runtime.NumCPU()
-	maxProcs = runtime.GOMAXPROCS(0)
-}
-
-func init() {
-	SnapshotMonitorInfo()
-}
-
 // Connz represents detailed information on current client connections.
 type Connz struct {
 	ID       string      `json:"server_id"`
@@ -1528,8 +1515,8 @@ func (s *Server) createVarz(pcpu float64, rss int64) *Varz {
 		},
 		Start:                 s.start,
 		MaxSubs:               opts.MaxSubs,
-		Cores:                 numCores,
-		MaxProcs:              maxProcs,
+		Cores:                 runtime.NumCPU(),
+		MaxProcs:              runtime.GOMAXPROCS(0),
 		Tags:                  opts.Tags,
 		TrustedOperatorsJwt:   opts.operatorJWT,
 		TrustedOperatorsClaim: opts.TrustedOperators,


### PR DESCRIPTION
We used to snapshot to avoid runtime costs, but with containers etc. probably easiest to call at runtime.
Don't think it is as expensive as it once was either.

Signed-off-by: Derek Collison <derek@nats.io>