### PR TITLE
[FIXED] Fixed an issue with consumer states growing and causing instability.

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -2776,8 +2776,8 @@ func TestFileStoreConsumerDeliveredAndAckUpdates(t *testing.T) {
 			}
 		}
 
-		testAck(1, 100, 1, 100)
-		testAck(3, 130, 1, 100)
+		testAck(1, 100, 1, 109)
+		testAck(3, 130, 1, 109)
 		testAck(2, 110, 3, 149) // We do not track explicit state on previous stream floors, so we take last known -1
 		testAck(5, 165, 3, 149)
 		testAck(4, 150, 5, 165)

--- a/server/raft.go
+++ b/server/raft.go
@@ -3108,12 +3108,14 @@ func (n *raft) processAppendEntryResponse(ar *appendEntryResponse) {
 		n.trackResponse(ar)
 	} else if ar.term > n.term {
 		// False here and they have a higher term.
+		n.Lock()
 		n.term = ar.term
 		n.vote = noVote
 		n.writeTermVote()
 		n.warn("Detected another leader with higher term, will stepdown and reset")
 		n.stepdown.push(noLeader)
 		n.resetWAL()
+		n.Unlock()
 	} else if ar.reply != _EMPTY_ {
 		n.catchupFollower(ar)
 	}

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The NATS Authors
+// Copyright 2019-2023 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -50,14 +50,6 @@ func RunRandClientPortServer() *Server {
 	opts := DefaultTestOptions
 	opts.Port = -1
 	return RunServer(&opts)
-}
-
-// Used to setup clusters of clusters for tests.
-type cluster struct {
-	servers []*Server
-	opts    []*Options
-	name    string
-	t       testing.TB
 }
 
 func require_True(t *testing.T, b bool) {
@@ -276,6 +268,11 @@ func (c *cluster) shutdown() {
 	if c == nil {
 		return
 	}
+	// Stop any proxies.
+	for _, np := range c.nproxies {
+		np.stop()
+	}
+	// Shutdown and cleanup servers.
 	for i, s := range c.servers {
 		sd := s.StoreDir()
 		s.Shutdown()


### PR DESCRIPTION
Under certain circumstances, a replicated consumer configured for explicit ack could have the consumer state for the replicas grow very large with ack pending that should have been cleared.

This bug could trip from an off by one bug during out of order acks, but would only manifest if the ack pending did not reach 0 which would clear and reset the ack floor properly and mask the issue.

Also in this PR is some work on the general test framework to introduce network proxy for emulating RTT and throughput into the base cluster vs just the gateway connections.

Signed-off-by: Derek Collison <derek@nats.io>