### PR TITLE
Improved publisher performance under some instances of asymmetric network latency clusters.

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2185,6 +2185,15 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 
 		case <-t.C:
 			doSnapshot()
+			// Check is we have preAcks left over if we have become the leader.
+			if isLeader {
+				mset.mu.Lock()
+				if mset.preAcks != nil {
+					mset.preAcks = nil
+				}
+				mset.mu.Unlock()
+			}
+
 		case <-uch:
 			// keep stream assignment current
 			sa = mset.streamAssignment()

--- a/server/raft.go
+++ b/server/raft.go
@@ -2092,7 +2092,7 @@ func (n *raft) runAsLeader() {
 					continue
 				}
 				n.sendAppendEntry(entries)
-				// We need to re-craete `entries` because there is a reference
+				// We need to re-create `entries` because there is a reference
 				// to it in the node's pae map.
 				entries = nil
 			}

--- a/server/stream.go
+++ b/server/stream.go
@@ -230,6 +230,9 @@ type stream struct {
 	sigq  *ipQueue[*cMsg]
 	csl   *Sublist
 
+	// For non limits policy streams when they process an ack before the actual msg.
+	preAcks map[uint64]struct{}
+
 	// TODO(dlc) - Hide everything below behind two pointers.
 	// Clustered mode.
 	sa         *streamAssignment
@@ -3995,7 +3998,16 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 	} else {
 		// Make sure to take into account any message assignments that we had to skip (clfs).
 		seq = lseq + 1 - clfs
-		err = store.StoreRawMsg(subject, hdr, msg, seq, ts)
+		// Check for preAcks and the need to skip vs store.
+		var shouldSkip bool
+		if _, shouldSkip = mset.preAcks[seq]; shouldSkip {
+			delete(mset.preAcks, seq)
+		}
+		if shouldSkip {
+			store.SkipMsg()
+		} else {
+			err = store.StoreRawMsg(subject, hdr, msg, seq, ts)
+		}
 	}
 
 	if err != nil {
@@ -4854,10 +4866,16 @@ func (mset *stream) ackMsg(o *consumer, seq uint64) {
 	if shouldRemove {
 		if _, err := mset.store.RemoveMsg(seq); err == ErrStoreEOF {
 			// This should be rare but I have seen it.
-			// The ack reached us before the actual msg with AckNone and InterestPolicy.
-			if n := mset.raftNode(); n != nil {
-				md := streamMsgDelete{Seq: seq, NoErase: true, Stream: mset.cfg.Name}
-				n.ForwardProposal(encodeMsgDelete(&md))
+			// The ack reached us before the actual msg.
+			var state StreamState
+			mset.store.FastState(&state)
+			if seq >= state.LastSeq {
+				mset.mu.Lock()
+				if mset.preAcks == nil {
+					mset.preAcks = make(map[uint64]struct{})
+				}
+				mset.preAcks[seq] = struct{}{}
+				mset.mu.Unlock()
 			}
 		}
 	}


### PR DESCRIPTION
Under asymmetric network latency based clusters, if a node in an R3 was replicating a consumer and the parent stream, which is interest policy based, but was the leader of neither, but the path from the stream leader was faster then the consumer leader a replicated ack could arrive before the message itself.

In this case we used to forward a delete message request to the stream leader which would then replicate that to all stream replicas, causing more work which could lead to increased publisher times on clients connected to the slow node.

Signed-off-by: Derek Collison <derek@nats.io>

