### PR TITLE
Shut down RAFT groups when disabling JetStream

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -578,6 +578,9 @@ func (s *Server) DisableJetStream() error {
 	// Normal shutdown.
 	s.shutdownJetStream()
 
+	// Shut down the RAFT groups.
+	s.shutdownRaftNodes()
+
 	return nil
 }
 


### PR DESCRIPTION
This PR modifies `DisableJetStream` (which is called when we run out of disk space, when we are peer-removed or when we reload config with JS disabled) to stop all of the RAFT groups, ensuring that we no longer have interest for those groups. 

As a result, this fixes a memory leak that can happen if JS gets disabled on a node in an active cluster.

Signed-off-by: Neil Twigg <neil@nats.io>