### PR TITLE
Add vcsinfo when building with goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,8 @@
 project_name: nats-server
 
+gomod:
+  proxy: true
+
 release:
   github:
     owner: nats-io
@@ -11,8 +14,10 @@ changelog:
   skip: true
 
 builds:
-- main: ./main.go
+- main: .
   binary: nats-server
+  flags:
+  - -trimpath
   ldflags:
     - -w -X github.com/nats-io/nats-server/v2/server.gitCommit={{.ShortCommit}}
   env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,5 @@
 project_name: nats-server
 
-gomod:
-  proxy: true
-
 release:
   github:
     owner: nats-io


### PR DESCRIPTION
Currently in Go, a release that is built via `go build` will always be labeled with its version as being `(devel)` (even if building from the [git tag commit](https://github.com/golang/go/issues/50603)):

```sh
go version -m /usr/local/bin/nats-server  | grep nats-server/v2
	dep	github.com/nats-io/nats-server/v2	(devel)	

```

And in order to include the release version in the binary it has to be built using `go install`:

```sh
go install github.com/nats-io/nats-server/v2@v2.9.15 | grep nats-server/v2
	path	github.com/nats-io/nats-server/v2
	mod	github.com/nats-io/nats-server/v2	v2.9.15	h1:MuwEJheIwpvFgqvbs20W8Ish2azcygjf4Z0liVu2I4c=
```

~~We use `goreleaser` for the release and building for many platforms, so in order to enable adding the correct version metadata, we need to enable building via the proxy which works as follows:
https://goreleaser.com/cookbooks/build-go-modules/~~

*Updated*: Removed building with the go mod proxy and just changed to build the package which is going to be enough to fix the trivy / grype issues.

This also adds the `trimpath` build flag to remove the filesystem paths from where the binary was built.

This should help reducing some of the false positives from vulnerability scanners which are not matching with the proper version of the binary as in #3992  with a `malformed version` warning.

Fixes #3992 