### PR TITLE
Update goreleaser to include vcsinfo in nightly

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -1,7 +1,7 @@
 project_name: nats-server
 
 builds:
-  - main: ./main.go
+  - main: .
     id: nats-server
     binary: nats-server
     ldflags:


### PR DESCRIPTION
 By using the package instead of a .go file the resulting build will include the versioning information starting from Go 1.18:

Before:

```sh
go version -m ./dist/nats-server_darwin_amd64_v1/nats-server
./dist/nats-server_darwin_amd64_v1/nats-server: go1.19.5
	path	command-line-arguments
	dep	github.com/klauspost/compress	v1.16.3	h1:XuJt9zzcnaz6a16/OU53ZjWp/v7/42WcR5t2a0PcNQY=
	dep	github.com/minio/highwayhash	v1.0.2	h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
	dep	github.com/nats-io/jwt/v2	v2.4.1	h1:Y35W1dgbbz2SQUYDPCaclXcuqleVmpbRa7646Jf2EX4=
	dep	github.com/nats-io/nats-server/v2	(devel)	
	dep	github.com/nats-io/nkeys	v0.4.4	h1:xvBJ8d69TznjcQl9t6//Q5xXuVhyYiSos6RPtvQNTwA=
	dep	github.com/nats-io/nuid	v1.0.1	h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
	dep	go.uber.org/automaxprocs	v1.5.1	h1:e1YG66Lrk73dn4qhg8WFSvhF0JuFQF0ERIp4rpuV8Qk=
	dep	golang.org/x/crypto	v0.7.0	h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
	dep	golang.org/x/sys	v0.6.0	h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
	dep	golang.org/x/time	v0.3.0	h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
	build	-compiler=gc
	build	-ldflags="-w -X github.com/nats-io/nats-server/v2/server.gitCommit=0033f330"
	build	CGO_ENABLED=0
	build	GOARCH=amd64
	build	GOOS=darwin
	build	GOAMD64=v1
```

After:

```sh
 go version -m ./dist/nats-server_darwin_amd64_v1/nats-server
./dist/nats-server_darwin_amd64_v1/nats-server: go1.19.5
	path	github.com/nats-io/nats-server/v2
	mod	github.com/nats-io/nats-server/v2	(devel)	
	dep	github.com/klauspost/compress	v1.16.3	h1:XuJt9zzcnaz6a16/OU53ZjWp/v7/42WcR5t2a0PcNQY=
	dep	github.com/minio/highwayhash	v1.0.2	h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
	dep	github.com/nats-io/jwt/v2	v2.4.1	h1:Y35W1dgbbz2SQUYDPCaclXcuqleVmpbRa7646Jf2EX4=
	dep	github.com/nats-io/nkeys	v0.4.4	h1:xvBJ8d69TznjcQl9t6//Q5xXuVhyYiSos6RPtvQNTwA=
	dep	github.com/nats-io/nuid	v1.0.1	h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
	dep	go.uber.org/automaxprocs	v1.5.1	h1:e1YG66Lrk73dn4qhg8WFSvhF0JuFQF0ERIp4rpuV8Qk=
	dep	golang.org/x/crypto	v0.7.0	h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
	dep	golang.org/x/sys	v0.6.0	h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
	dep	golang.org/x/time	v0.3.0	h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
	build	-compiler=gc
	build	-ldflags="-w -X github.com/nats-io/nats-server/v2/server.gitCommit=0033f330"
	build	CGO_ENABLED=0
	build	GOARCH=amd64
	build	GOOS=darwin
	build	GOAMD64=v1
	build	vcs=git
	build	vcs.revision=0033f3309b258530bae2675c5cbf710916bd6980
	build	vcs.time=2023-03-24T20:23:34Z
```

Eventually we could use this to remove some of the ldflags and [set it automatically](https://github.com/wallyqs/nats-server/commit/46666e59b94375dea78c784ca64c0ed72808c415) via [debug#ReadBuildInfo](https://pkg.go.dev/runtime/debug#ReadBuildInfo), but for now we could just stamp it into the binary.
