### PR TITLE
Updates to preacks when multiple consumers are mutually exclusive

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -4357,14 +4357,15 @@ func (o *consumer) stopWithFlags(dflag, sdflag, doSignal, advisory bool) error {
 		}
 
 		var rmseqs []uint64
-		mset.mu.RLock()
+		mset.mu.Lock()
 		for seq := start; seq <= stop; seq++ {
-			if !mset.checkInterest(seq, o) {
+			if mset.noInterest(seq, o) {
 				rmseqs = append(rmseqs, seq)
 			}
 		}
-		mset.mu.RUnlock()
+		mset.mu.Unlock()
 
+		// These can be removed.
 		for _, seq := range rmseqs {
 			mset.store.RemoveMsg(seq)
 		}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7609,7 +7609,7 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 	ddloaded := mset.ddloaded
 	tierName := mset.tier
 
-	if mset.hasAllPreAcks(seq) {
+	if mset.hasAllPreAcks(seq, subj) {
 		mset.clearAllPreAcks(seq)
 		// Mark this to be skipped
 		subj, ts = _EMPTY_, 0


### PR DESCRIPTION
When consumers where mutually exclusive and acks came in before a message we did not properly cleanup the messages.

Signed-off-by: Derek Collison <derek@nats.io>
