### PR TITLE
Allow republish for mirroring/sourcing streams

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -1291,19 +1291,9 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 	if cfg.RePublish != nil {
 		// Check to make sure source is a valid subset of the subjects we have.
 		// Also make sure it does not form a cycle.
-		var srcValid bool
 		// Empty same as all.
 		if cfg.RePublish.Source == _EMPTY_ {
 			cfg.RePublish.Source = fwcs
-		}
-		for _, subj := range cfg.Subjects {
-			if SubjectsCollide(cfg.RePublish.Source, subj) {
-				srcValid = true
-				break
-			}
-		}
-		if !srcValid {
-			return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration for republish source is not valid subset of subjects"))
 		}
 		var formsCycle bool
 		for _, subj := range cfg.Subjects {


### PR DESCRIPTION
 - [X] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #4000

### Changes proposed in this pull request:

Removes the check on the republish filter needing to have an overlap with the listened subjects, as with the new stream subject transformation changes we do not assume anymore that the subjects in a stream must match the subjects being listened to.

This allows the use of republish for mirroring and/or sourcing streams