### PR TITLE
[IMPROVED] Protect against concurrent creation of streams and consumers.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -299,6 +299,8 @@ type consumer struct {
 	prOk      bool
 	uch       chan struct{}
 	retention RetentionPolicy
+
+	monitorWg sync.WaitGroup
 	inMonitor bool
 
 	// R>1 proposals
@@ -4559,8 +4561,8 @@ func (o *consumer) clearMonitorRunning() {
 
 // Test whether we are in the monitor routine.
 func (o *consumer) isMonitorRunning() bool {
-	o.mu.Lock()
-	defer o.mu.Unlock()
+	o.mu.RLock()
+	defer o.mu.RUnlock()
 	return o.inMonitor
 }
 

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -137,6 +137,7 @@ type jsAccount struct {
 	js        *jetStream
 	account   *Account
 	storeDir  string
+	inflight  sync.Map
 	streams   map[string]*stream
 	templates map[string]*streamTemplate
 	store     TemplateStore

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -436,8 +436,11 @@ func (cc *jetStreamCluster) isStreamCurrent(account, stream string) bool {
 
 // isStreamHealthy will determine if the stream is up to date or very close.
 // For R1 it will make sure the stream is present on this server.
-// Read lock should be held.
-func (cc *jetStreamCluster) isStreamHealthy(account, stream string) bool {
+func (js *jetStream) isStreamHealthy(account, stream string) bool {
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+	cc := js.cluster
+
 	if cc == nil {
 		// Non-clustered mode
 		return true
@@ -477,8 +480,11 @@ func (cc *jetStreamCluster) isStreamHealthy(account, stream string) bool {
 
 // isConsumerCurrent will determine if the consumer is up to date.
 // For R1 it will make sure the consunmer is present on this server.
-// Read lock should be held.
-func (cc *jetStreamCluster) isConsumerCurrent(account, stream, consumer string) bool {
+func (js *jetStream) isConsumerCurrent(account, stream, consumer string) bool {
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+	cc := js.cluster
+
 	if cc == nil {
 		// Non-clustered mode
 		return true

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2486,41 +2486,42 @@ func (mset *stream) resetClusteredState(err error) bool {
 
 	// Preserve our current state and messages unless we have a first sequence mismatch.
 	shouldDelete := err == errFirstSequenceMismatch
+
+	mset.monitorWg.Wait()
+	mset.resetAndWaitOnConsumers()
+	// Stop our stream.
 	mset.stop(shouldDelete, false)
 
 	if sa != nil {
-		s.Warnf("Resetting stream cluster state for '%s > %s'", sa.Client.serviceAccount(), sa.Config.Name)
 		js.mu.Lock()
+		s.Warnf("Resetting stream cluster state for '%s > %s'", sa.Client.serviceAccount(), sa.Config.Name)
+		// Now wipe groups from assignments.
 		sa.Group.node = nil
-		js.mu.Unlock()
-		go js.restartClustered(acc, sa)
-	}
-	return true
-}
-
-// This will reset the stream and consumers.
-// Should be done in separate go routine.
-func (js *jetStream) restartClustered(acc *Account, sa *streamAssignment) {
-	// Check and collect consumers first.
-	js.mu.RLock()
-	var consumers []*consumerAssignment
-	if cc := js.cluster; cc != nil && cc.meta != nil {
-		ourID := cc.meta.ID()
-		for _, ca := range sa.consumers {
-			if rg := ca.Group; rg != nil && rg.isMember(ourID) {
-				rg.node = nil // Erase group raft/node state.
-				consumers = append(consumers, ca)
+		var consumers []*consumerAssignment
+		if cc := js.cluster; cc != nil && cc.meta != nil {
+			ourID := cc.meta.ID()
+			for _, ca := range sa.consumers {
+				if rg := ca.Group; rg != nil && rg.isMember(ourID) {
+					rg.node = nil // Erase group raft/node state.
+					consumers = append(consumers, ca)
+				}
 			}
 		}
-	}
-	js.mu.RUnlock()
+		js.mu.Unlock()
 
-	// Reset stream.
-	js.processClusterCreateStream(acc, sa)
-	// Reset consumers.
-	for _, ca := range consumers {
-		js.processClusterCreateConsumer(ca, nil, false)
+		// restart in a separate Go routine.
+		// This will reset the stream and consumers.
+		go func() {
+			// Reset stream.
+			js.processClusterCreateStream(acc, sa)
+			// Reset consumers.
+			for _, ca := range consumers {
+				js.processClusterCreateConsumer(ca, nil, false)
+			}
+		}()
 	}
+
+	return true
 }
 
 func isControlHdr(hdr []byte) bool {
@@ -3974,6 +3975,7 @@ func (js *jetStream) processClusterCreateConsumer(ca *consumerAssignment, state 
 			// Clustered consumer.
 			// Start our monitoring routine if needed.
 			if !alreadyRunning && !o.isMonitorRunning() {
+				o.monitorWg.Add(1)
 				s.startGoRoutine(func() { js.monitorConsumer(o, ca) })
 			}
 			// For existing consumer, only send response if not recovering.
@@ -4171,6 +4173,8 @@ func (o *consumer) raftNode() RaftNode {
 func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 	s, n, cc := js.server(), o.raftNode(), js.cluster
 	defer s.grWG.Done()
+
+	defer o.monitorWg.Done()
 
 	if n == nil {
 		s.Warnf("No RAFT group for '%s > %s > %s'", o.acc.Name, ca.Stream, ca.Name)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3129,7 +3129,7 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 		for stream, sa := range asa {
 			if sa.Group.isMember(ourID) {
 				// Make sure we can look up
-				if !cc.isStreamHealthy(acc, stream) {
+				if !js.isStreamHealthy(acc, stream) {
 					health.Status = na
 					health.Error = fmt.Sprintf("JetStream stream '%s > %s' is not current", acc, stream)
 					return health
@@ -3137,7 +3137,7 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 				// Now check consumers.
 				for consumer, ca := range sa.consumers {
 					if ca.Group.isMember(ourID) {
-						if !cc.isConsumerCurrent(acc, stream, consumer) {
+						if !js.isConsumerCurrent(acc, stream, consumer) {
 							health.Status = na
 							health.Error = fmt.Sprintf("JetStream consumer '%s > %s > %s' is not current", acc, stream, consumer)
 							return health

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -3607,7 +3607,7 @@ func TestNoRaceJetStreamClusterCorruptWAL(t *testing.T) {
 	fs = o.raftNode().(*raft).wal.(*fileStore)
 	state = fs.State()
 	err = fs.Truncate(state.FirstSeq)
-	require_NoError(t, err)
+	require_True(t, err == nil || err == ErrInvalidSequence)
 	state = fs.State()
 
 	sub, err = js.PullSubscribe("foo", "dlc")

--- a/server/stream.go
+++ b/server/stream.go
@@ -374,7 +374,10 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 		ifwg.Wait()
 	} else {
 		ifwg.Add(1)
-		defer ifwg.Done()
+		defer func() {
+			jsa.inflight.Delete(cfg.Name)
+			ifwg.Done()
+		}()
 	}
 
 	js, isClustered := jsa.jetStreamAndClustered()

--- a/server/stream.go
+++ b/server/stream.go
@@ -367,16 +367,15 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 	}
 
 	// Make sure we are ok when these are done in parallel.
-	var wg sync.WaitGroup
-	v, loaded := jsa.inflight.LoadOrStore(cfg.Name, &wg)
-	ifwg := v.(*sync.WaitGroup)
+	v, loaded := jsa.inflight.LoadOrStore(cfg.Name, &sync.WaitGroup{})
+	wg := v.(*sync.WaitGroup)
 	if loaded {
-		ifwg.Wait()
+		wg.Wait()
 	} else {
-		ifwg.Add(1)
+		wg.Add(1)
 		defer func() {
 			jsa.inflight.Delete(cfg.Name)
-			ifwg.Done()
+			wg.Done()
 		}()
 	}
 


### PR DESCRIPTION
Also make sure we have exited monitoring routines when doing resets for both streams and consumers.

Signed-off-by: Derek Collison <derek@nats.io>