### PR TITLE
Allow overriding target branch in on-demand nightly image builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,10 +1,14 @@
 name: "NATS Server Nightly: DEV"
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Override image branch (optional)"
+        type: string
+        required: false
 
   schedule:
     - cron: "40 4 * * *"
-
 
 jobs:
   nightly_release:
@@ -14,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: src/github.com/nats-io/nats-server
-          ref: dev
+          ref: ${{ inputs.target || 'dev' }}
 
       - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:

--- a/.github/workflows/rc_nightly.yaml
+++ b/.github/workflows/rc_nightly.yaml
@@ -1,10 +1,14 @@
 name: "NATS Server Nightly: MAIN"
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Override image branch (optional)"
+        type: string
+        required: false
 
   schedule:
     - cron: "40 4 * * *"
-
 
 jobs:
   nightly_main_release:
@@ -14,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: src/github.com/nats-io/nats-server
-          ref: main
+          ref: ${{ inputs.target || 'main' }}
 
       - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:


### PR DESCRIPTION
This allows us to manually specify a branch to build the nightly image from when dispatching builds manually.

Signed-off-by: Neil Twigg <neil@nats.io>