### PR TITLE
[IMPROVED] Raft layer improvements

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -436,11 +436,9 @@ func (cc *jetStreamCluster) isStreamCurrent(account, stream string) bool {
 
 // isStreamHealthy will determine if the stream is up to date or very close.
 // For R1 it will make sure the stream is present on this server.
+// Read lock should be held.
 func (js *jetStream) isStreamHealthy(account, stream string) bool {
-	js.mu.RLock()
-	defer js.mu.RUnlock()
 	cc := js.cluster
-
 	if cc == nil {
 		// Non-clustered mode
 		return true
@@ -480,11 +478,9 @@ func (js *jetStream) isStreamHealthy(account, stream string) bool {
 
 // isConsumerCurrent will determine if the consumer is up to date.
 // For R1 it will make sure the consunmer is present on this server.
+// Read lock should be held.
 func (js *jetStream) isConsumerCurrent(account, stream, consumer string) bool {
-	js.mu.RLock()
-	defer js.mu.RUnlock()
 	cc := js.cluster
-
 	if cc == nil {
 		// Non-clustered mode
 		return true

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -2242,14 +2242,15 @@ func TestJetStreamClusterMemLeaderRestart(t *testing.T) {
 
 	// Make sure that we have a META leader (there can always be a re-election)
 	c.waitOnLeader()
+	c.waitOnStreamLeader(globalAccountName, "foo")
 
 	// Should still have quorum and a new leader
-	checkFor(t, time.Second, 200*time.Millisecond, func() error {
+	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
 		osi, err = jsc.StreamInfo("foo")
 		if err != nil {
 			return fmt.Errorf("expected healthy stream asset, got %s", err.Error())
 		}
-		if osi.Cluster.Leader == "" {
+		if osi.Cluster.Leader == _EMPTY_ {
 			return fmt.Errorf("expected healthy stream asset with new leader")
 		}
 		if osi.State.Msgs != uint64(toSend) {

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3125,6 +3125,11 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 	// Range across all accounts, the streams assigned to them, and the consumers.
 	// If they are assigned to this server check their status.
 	ourID := meta.ID()
+
+	// TODO(dlc) - Might be better here to not hold the lock the whole time.
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+
 	for acc, asa := range cc.streams {
 		for stream, sa := range asa {
 			if sa.Group.isMember(ourID) {


### PR DESCRIPTION
Two changes here.

1. Revert of a change regarding handling of leadership transfer entries that caused instability in some tests and a bad upgrade experience.

2. Make sure if we detect that a stream or a consumer is already running the monitoring routines that we do not stop the underlying raft group since it will be being used in the monitor routine and would stall that asset.

Signed-off-by: Derek Collison <derek@nats.io>


