### PR TITLE
Fix FirstSeq not being updated with filestore when purging subject

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5098,7 +5098,8 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 					if mb.isEmpty() {
 						fs.removeMsgBlock(mb)
 						i--
-						firstSeqNeedsUpdate = seq == fs.state.FirstSeq
+						// keep flag set, if set previously
+						firstSeqNeedsUpdate = firstSeqNeedsUpdate || seq == fs.state.FirstSeq
 					} else if seq == fs.state.FirstSeq {
 						fs.state.FirstSeq = mb.first.seq // new one.
 						fs.state.FirstTime = time.Unix(0, mb.first.ts).UTC()

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -4020,6 +4020,7 @@ func TestFileStorePurgeExWithSubject(t *testing.T) {
 		require_True(t, int(p) == total)
 		require_True(t, int(p) == total)
 		require_True(t, fs.State().Msgs == 1)
+		require_True(t, fs.State().FirstSeq == 201)
 	})
 }
 


### PR DESCRIPTION
Resolves https://github.com/nats-io/nats-server/issues/4041

Keeps `firstSeqNeedsUpdate` set if set previously, to ensure the FirstSeq gets updated.