### PR TITLE
[IMPROVED] Consumer updates

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -6687,7 +6687,10 @@ func (o *consumerFileStore) UpdateDelivered(dseq, sseq, dc uint64, ts int64) err
 			if o.state.Redelivered == nil {
 				o.state.Redelivered = make(map[uint64]uint64)
 			}
-			o.state.Redelivered[sseq] = dc - 1
+			// Only update if greater then what we already have.
+			if o.state.Redelivered[sseq] < dc {
+				o.state.Redelivered[sseq] = dc - 1
+			}
 		}
 	} else {
 		// For AckNone just update delivered and ackfloor at the same time.

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -5784,9 +5784,6 @@ func TestJetStreamClusterConsumerDeliverNewMaxRedeliveriesAndServerRestart(t *te
 		t.Fatalf("Expected timeout, got msg=%+v err=%v", msg, err)
 	}
 
-	// Give a chance to things to be persisted
-	time.Sleep(300 * time.Millisecond)
-
 	// Check server restart
 	nc.Close()
 	c.stopAll()

--- a/server/stream.go
+++ b/server/stream.go
@@ -4485,7 +4485,7 @@ func (mset *stream) delete() error {
 // Internal function to stop or delete the stream.
 func (mset *stream) stop(deleteFlag, advisory bool) error {
 	mset.mu.RLock()
-	js, jsa := mset.js, mset.jsa
+	js, jsa, name := mset.js, mset.jsa, mset.cfg.Name
 	mset.mu.RUnlock()
 
 	if jsa == nil {
@@ -4494,7 +4494,7 @@ func (mset *stream) stop(deleteFlag, advisory bool) error {
 
 	// Remove from our account map first.
 	jsa.mu.Lock()
-	delete(jsa.streams, mset.cfg.Name)
+	delete(jsa.streams, name)
 	accName := jsa.account.Name
 	jsa.mu.Unlock()
 


### PR DESCRIPTION
Make sure to process consumer entries on recovery in case state was not committed.
And sync other consumers when taking over as leader but no need to process snapshots when we are in fact the leader.
Do not let the consumer redelivered count go down on re-applying state on restarts.

Signed-off-by: Derek Collison <derek@nats.io>
