### PR TITLE
Add server name / remote server name to routez

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -738,6 +738,7 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 // Routez represents detailed information on current client connections.
 type Routez struct {
 	ID        string             `json:"server_id"`
+	Name      string             `json:"server_name"`
 	Now       time.Time          `json:"now"`
 	Import    *SubjectPermission `json:"import,omitempty"`
 	Export    *SubjectPermission `json:"export,omitempty"`
@@ -757,6 +758,7 @@ type RoutezOptions struct {
 type RouteInfo struct {
 	Rid          uint64             `json:"rid"`
 	RemoteID     string             `json:"remote_id"`
+	RemoteName   string             `json:"remote_name"`
 	DidSolicit   bool               `json:"did_solicit"`
 	IsConfigured bool               `json:"is_configured"`
 	IP           string             `json:"ip"`
@@ -798,6 +800,7 @@ func (s *Server) Routez(routezOpts *RoutezOptions) (*Routez, error) {
 		rs.Import = perms.Import
 		rs.Export = perms.Export
 	}
+	rs.Name = s.getOpts().ServerName
 
 	// Walk the list
 	for _, r := range s.routes {
@@ -805,6 +808,7 @@ func (s *Server) Routez(routezOpts *RoutezOptions) (*Routez, error) {
 		ri := &RouteInfo{
 			Rid:          r.cid,
 			RemoteID:     r.route.remoteID,
+			RemoteName:   r.route.remoteName,
 			DidSolicit:   r.route.didSolicit,
 			IsConfigured: r.route.routeType == Explicit,
 			InMsgs:       atomic.LoadInt64(&r.inMsgs),


### PR DESCRIPTION
Add server name to routez info:

```js
{
  "server_id": "NAXUYR7XZFPBQPJGV5HNWIXLOCLBSA2GOQEPGP47AFY62XHWPREKCXWL",
  "server_name": "nats-burn-0",
  "now": "2023-04-14T19:47:52.057269Z",
  "num_routes": 2,
  "routes": [ 
    {
      "rid": 51,
      "remote_id": "NACPYGKLPWMYM7YZA3NCYQ5HL2EKGVKFKNGGE6ECD5LMO26JC3T3TARR",
      "remote_name": "nats-burn-1",
      "did_solicit": true,
      "is_configured": true,
      "ip": "127.0.0.1",
      "port": 57889,
      "start": "2023-04-14T12:47:43.475646-07:00",
      "last_activity": "2023-04-14T19:47:51.983756Z",
      "rtt": "178µs",
      "uptime": "8s",
      "idle": "0s",
      "pending_size": 0,
      "in_msgs": 210,
      "out_msgs": 154,
      "in_bytes": 31854,
      "out_bytes": 15150,
      "subscriptions": 134
    },
    {
      "rid": 53,
      "remote_id": "NCTOFS2M5IVGKYRGYOWP3Q5SQNPGCPMCIIJWOEH5SOIH3XQKRBKP7ITJ",
      "remote_name": "nats-burn-2",
      "did_solicit": true,
      "is_configured": true,
      "ip": "127.0.0.1",
      "port": 57905,
      "start": "2023-04-14T12:47:44.275914-07:00",
      "last_activity": "2023-04-14T19:47:52.022301Z",
      "rtt": "152µs",
      "uptime": "7s",
      "idle": "0s",
      "pending_size": 0,
      "in_msgs": 179,
      "out_msgs": 48,
      "in_bytes": 25629,
      "out_bytes": 7573,
      "subscriptions": 100
    }
  ]
}
```