### PR TITLE
[FIXED] Do not spin on multi-leader with same term.

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -2927,7 +2927,8 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 
 	// Are we receiving from another leader.
 	if n.state == Leader {
-		if ae.term > n.term {
+		// If we are the same we should step down to break the tie.
+		if ae.term >= n.term {
 			n.term = ae.term
 			n.vote = noVote
 			n.writeTermVote()


### PR DESCRIPTION
If we see another leader with same term we should step down, otherwise we could spin with catchups and WAL truncates.

Signed-off-by: Derek Collison <derek@nats.io>