### PR TITLE
[FIXED] Fix for a regression in behavior.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5731,6 +5731,7 @@ func (mb *msgBlock) removeSeqPerSubject(subj string, seq uint64) {
 		} else {
 			ss.First = ss.Last
 		}
+		ss.firstNeedsUpdate = false
 		mb.fssNeedsWrite = true // Mark dirty
 		return
 	}

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -19912,3 +19912,59 @@ func TestJetStreamStreamUpdateWithExternalSource(t *testing.T) {
 	require_Error(t, err)
 	require_True(t, strings.Contains(err.Error(), "does not overlap"))
 }
+
+func TestJetStreamKVHistoryRegression(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	for _, storage := range []nats.StorageType{nats.FileStorage, nats.MemoryStorage} {
+		t.Run(storage.String(), func(t *testing.T) {
+			js.DeleteKeyValue("TEST")
+
+			kv, err := js.CreateKeyValue(&nats.KeyValueConfig{
+				Bucket:  "TEST",
+				History: 4,
+				Storage: storage,
+			})
+			require_NoError(t, err)
+
+			r1, err := kv.Create("foo", []byte("a"))
+			require_NoError(t, err)
+
+			_, err = kv.Update("foo", []byte("ab"), r1)
+			require_NoError(t, err)
+
+			err = kv.Delete("foo")
+			require_NoError(t, err)
+
+			_, err = kv.Create("foo", []byte("abc"))
+			require_NoError(t, err)
+
+			err = kv.Delete("foo")
+			require_NoError(t, err)
+
+			history, err := kv.History("foo")
+			require_NoError(t, err)
+			require_True(t, len(history) == 4)
+
+			_, err = kv.Update("foo", []byte("abcd"), history[len(history)-1].Revision())
+			require_NoError(t, err)
+
+			err = kv.Purge("foo")
+			require_NoError(t, err)
+
+			_, err = kv.Create("foo", []byte("abcde"))
+			require_NoError(t, err)
+
+			err = kv.Purge("foo")
+			require_NoError(t, err)
+
+			history, err = kv.History("foo")
+			require_NoError(t, err)
+			require_True(t, len(history) == 1)
+		})
+	}
+}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1004,6 +1004,7 @@ func (ms *memStore) removeSeqPerSubject(subj string, seq uint64) {
 		} else {
 			ss.First = ss.Last
 		}
+		ss.firstNeedsUpdate = false
 	} else {
 		ss.firstNeedsUpdate = seq == ss.First || ss.firstNeedsUpdate
 	}


### PR DESCRIPTION
When tracking information per subject went from >1 back to only 1 we needed to make sure we cleared firstNeedsUpdate.

Thanks to @scottf for finding it.

Signed-off-by: Derek Collison <derek@nats.io>

