### PR TITLE
Bump version to 2.9.16-RC.9

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -41,7 +41,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.9.16-RC.8"
+	VERSION = "2.9.16-RC.9"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original


### PR DESCRIPTION
Signed-off-by: Neil Twigg <neil@nats.io>