### PR TITLE
Stream mirror sources filter

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -2535,6 +2535,7 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64, startTime time.T
 	// Determine subjects etc.
 	var deliverSubject string
 	ext := ssi.External
+	filter := ssi.FilterSubject
 
 	if ext != nil && ext.DeliverPrefix != _EMPTY_ {
 		deliverSubject = strings.ReplaceAll(ext.DeliverPrefix+syncSubject(".S"), "..", ".")
@@ -2552,6 +2553,7 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64, startTime time.T
 			Heartbeat:      sourceHealthCheckInterval,
 			FlowControl:    true,
 			Direct:         true,
+			FilterSubject:  filter,
 		},
 	}
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -2231,6 +2231,7 @@ func (mset *stream) setupMirrorConsumer() error {
 	// Determine subjects etc.
 	var deliverSubject string
 	ext := mset.cfg.Mirror.External
+	filter := mset.cfg.Mirror.FilterSubject
 
 	if ext != nil && ext.DeliverPrefix != _EMPTY_ {
 		deliverSubject = strings.ReplaceAll(ext.DeliverPrefix+syncSubject(".M"), "..", ".")
@@ -2256,6 +2257,7 @@ func (mset *stream) setupMirrorConsumer() error {
 			Heartbeat:      sourceHealthCheckInterval,
 			FlowControl:    true,
 			Direct:         true,
+			FilterSubject:  filter,
 		},
 	}
 


### PR DESCRIPTION
 - [x] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #4082 

### Changes proposed in this pull request:

 - Forward `Mirror.FilterSubject` to `CreateConsumerRequest` inside `setupMirrorConsumer`
 - Forward `ssi.FilterSubject` to `CreateConsumerRequest` inside `setSourceConsumer`

I splitted the commits in two just because they can be seen as two differente `feat`s. If you would rather keep into a single commit, I can squash them without problems.

CC @paolobarbolini