### PR TITLE
fix formatting of raft debug log

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3695,7 +3695,8 @@ func (n *raft) processVoteRequest(vr *voteRequest) error {
 	// If this is a higher term go ahead and stepdown.
 	if vr.term > n.term {
 		if n.state != Follower {
-			n.debug("Stepping down from %s, detected higher term: %d vs %d", vr.term, n.term, strings.ToLower(n.state.String()))
+			n.debug("Stepping down from %s, detected higher term: %d vs %d",
+				strings.ToLower(n.state.String()), vr.term, n.term)
 			n.stepdown.push(noLeader)
 			n.term = vr.term
 		}


### PR DESCRIPTION
Fixes this entry showing up:

```
[36571] 2023/04/22 06:53:37.278744 [DBG] RAFT [2DfzK1X6 - C-R3F-bzb7ShZ0] Stepping down from %!s(uint64=66), detected higher term: 65 vs %!d(string=leader)
```