### PR TITLE
Allow custom StreamSource heartbeat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,3 +19,5 @@ require (
 	github.com/golang/protobuf v1.4.2 // indirect
 	google.golang.org/protobuf v1.23.0 // indirect
 )
+
+replace github.com/nats-io/nats.go v1.28.0 => github.com/M4SS-Code/nats.go v1.28.1-stream-source-heartbeat

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/M4SS-Code/nats.go v1.28.1-stream-source-heartbeat h1:1RTa1e65JlQqnvcDaFFCVwDSE4Cy1S3+b5qkz/OdQvM=
+github.com/M4SS-Code/nats.go v1.28.1-stream-source-heartbeat/go.mod h1:XpbWUlOElGwTYbMR7imivs7jJj9GtK7ypv321Wp6pjc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=


### PR DESCRIPTION
 - [x] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Main issue: #4094  

### Changes proposed in this pull request:

- Added `Heartbeat` field to `StreamSource`
- Added `getMirrorHeartbeat` helper function
- Added `getStreamSourceHeartbeat` and `getSourceHeartbeat` helper functions
- Use `getMirrorHeartbeat` to define mirror heartbeat and related health checks
- Use `getStreamSourceHeartbeat` and `getSourceHeartbeat` to define stream sources heartbeat and related health checks

CC @paolobarbolini