### PR TITLE
[ADDED] Checking HEALTHZ for specific accounts/stream

### DIFF
--- a/server/events_test.go
+++ b/server/events_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -1973,6 +1974,401 @@ func TestServerEventsStatsZ(t *testing.T) {
 		if sr.Name != "A_SRV" {
 			t.Fatalf("Expected server B's route to A to have Name set to %q, got %q", "A_SRV", sr.Name)
 		}
+	}
+}
+
+func TestServerEventsHealthZSingleServer(t *testing.T) {
+	type healthzResp struct {
+		Healthz HealthStatus `json:"data"`
+		Server  ServerInfo   `json:"server"`
+	}
+	cfg := fmt.Sprintf(`listen: 127.0.0.1:-1
+
+	jetstream: {max_mem_store: 256MB, max_file_store: 2GB, store_dir: '%s'}
+
+	no_auth_user: one
+
+	accounts {
+		ONE { users = [ { user: "one", pass: "p" } ]; jetstream: enabled }
+		$SYS { users = [ { user: "admin", pass: "s3cr3t!" } ] }
+	}`, t.TempDir())
+
+	serverHealthzReqSubj := "$SYS.REQ.SERVER.%s.HEALTHZ"
+	s, _ := RunServerWithConfig(createConfFile(t, []byte(cfg)))
+	defer s.Shutdown()
+
+	ncs, err := nats.Connect(s.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error connecting to cluster: %v", err)
+	}
+
+	defer ncs.Close()
+	ncAcc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer ncAcc.Close()
+	js, err := ncAcc.JetStream()
+	if err != nil {
+		t.Fatalf("Error creating JetStream context: %v", err)
+	}
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "test",
+		Subjects: []string{"foo"},
+	})
+	if err != nil {
+		t.Fatalf("Error creating stream: %v", err)
+	}
+	_, err = js.AddConsumer("test", &nats.ConsumerConfig{
+		Name: "cons",
+	})
+	if err != nil {
+		t.Fatalf("Error creating consumer: %v", err)
+	}
+
+	subj := fmt.Sprintf(serverHealthzReqSubj, s.ID())
+
+	tests := []struct {
+		name           string
+		req            *HealthzEventOptions
+		expectedStatus string
+		expectedError  string
+	}{
+		{
+			name:           "no parameters",
+			expectedStatus: "ok",
+		},
+		{
+			name: "with js enabled only",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					JSEnabledOnly: true,
+				},
+			},
+			expectedStatus: "ok",
+		},
+		{
+			name: "with server only",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					JSServerOnly: true,
+				},
+			},
+			expectedStatus: "ok",
+		},
+		{
+			name: "with account name",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					Account: "ONE",
+				},
+			},
+			expectedStatus: "ok",
+		},
+		{
+			name: "with account name and stream",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					Account: "ONE",
+					Stream:  "test",
+				},
+			},
+			expectedStatus: "ok",
+		},
+		{
+			name: "with stream only",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					Stream: "test",
+				},
+			},
+			expectedStatus: "error",
+			expectedError:  "Bad request:",
+		},
+		{
+			name: "account not found",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					Account: "abc",
+				},
+			},
+			expectedStatus: "unavailable",
+			expectedError:  `account "abc" not found`,
+		},
+		{
+			name: "stream not found",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					Account: "ONE",
+					Stream:  "abc",
+				},
+			},
+			expectedStatus: "unavailable",
+			expectedError:  `stream "abc" not found`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var body []byte
+			var err error
+			if test.req != nil {
+				body, err = json.Marshal(test.req)
+				if err != nil {
+					t.Fatalf("Error marshaling request body: %v", err)
+				}
+			}
+			msg, err := ncs.Request(subj, body, 1*time.Second)
+			if err != nil {
+				t.Fatalf("Error trying to request healthz: %v", err)
+			}
+			var health healthzResp
+			if err := json.Unmarshal(msg.Data, &health); err != nil {
+				t.Fatalf("Error unmarshalling the statz json: %v", err)
+			}
+			if health.Healthz.Status != test.expectedStatus {
+				t.Errorf("Invalid healthz status; want: %q; got: %q", test.expectedStatus, health.Healthz.Status)
+			}
+			if test.expectedError == "" {
+				if health.Healthz.Error != "" {
+					t.Errorf("HealthZ error: %s", health.Healthz.Error)
+				}
+			} else {
+				if !strings.Contains(health.Healthz.Error, test.expectedError) {
+					t.Errorf("Expected error to contain: %q, got: %s", test.expectedError, health.Healthz.Error)
+				}
+			}
+		})
+	}
+}
+
+func TestServerEventsHealthZClustered(t *testing.T) {
+	type healthzResp struct {
+		Healthz HealthStatus `json:"data"`
+		Server  ServerInfo   `json:"server"`
+	}
+	serverHealthzReqSubj := "$SYS.REQ.SERVER.%s.HEALTHZ"
+	c := createJetStreamClusterWithTemplate(t, jsClusterAccountsTempl, "JSC", 3)
+	defer c.shutdown()
+
+	ncs, err := nats.Connect(c.randomServer().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error connecting to cluster: %v", err)
+	}
+
+	defer ncs.Close()
+	ncAcc, err := nats.Connect(c.randomServer().ClientURL())
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer ncAcc.Close()
+	js, err := ncAcc.JetStream()
+	if err != nil {
+		t.Fatalf("Error creating JetStream context: %v", err)
+	}
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "test",
+		Subjects: []string{"foo"},
+	})
+	if err != nil {
+		t.Fatalf("Error creating stream: %v", err)
+	}
+	_, err = js.AddConsumer("test", &nats.ConsumerConfig{
+		Name: "cons",
+	})
+	if err != nil {
+		t.Fatalf("Error creating consumer: %v", err)
+	}
+
+	subj := fmt.Sprintf(serverHealthzReqSubj, c.servers[0].ID())
+	pingSubj := fmt.Sprintf(serverHealthzReqSubj, "PING")
+
+	tests := []struct {
+		name           string
+		req            *HealthzEventOptions
+		expectedStatus string
+		expectedError  string
+	}{
+		{
+			name:           "no parameters",
+			expectedStatus: "ok",
+		},
+		{
+			name: "with js enabled only",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					JSEnabledOnly: true,
+				},
+			},
+			expectedStatus: "ok",
+		},
+		{
+			name: "with server only",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					JSServerOnly: true,
+				},
+			},
+			expectedStatus: "ok",
+		},
+		{
+			name: "with account name",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					Account: "ONE",
+				},
+			},
+			expectedStatus: "ok",
+		},
+		{
+			name: "with account name and stream",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					Account: "ONE",
+					Stream:  "test",
+				},
+			},
+			expectedStatus: "ok",
+		},
+		{
+			name: "with stream only",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					Stream: "test",
+				},
+			},
+			expectedStatus: "error",
+			expectedError:  "Bad request:",
+		},
+		{
+			name: "account not found",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					Account: "abc",
+				},
+			},
+			expectedStatus: "unavailable",
+			expectedError:  `account "abc" not found`,
+		},
+		{
+			name: "stream not found",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					Account: "ONE",
+					Stream:  "abc",
+				},
+			},
+			expectedStatus: "unavailable",
+			expectedError:  `stream "abc" not found`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var body []byte
+			var err error
+			if test.req != nil {
+				body, err = json.Marshal(test.req)
+				if err != nil {
+					t.Fatalf("Error marshaling request body: %v", err)
+				}
+			}
+			msg, err := ncs.Request(subj, body, 1*time.Second)
+			if err != nil {
+				t.Fatalf("Error trying to request healthz: %v", err)
+			}
+			var health healthzResp
+			if err := json.Unmarshal(msg.Data, &health); err != nil {
+				t.Fatalf("Error unmarshalling the statz json: %v", err)
+			}
+			if health.Healthz.Status != test.expectedStatus {
+				t.Errorf("Invalid healthz status; want: %q; got: %q", test.expectedStatus, health.Healthz.Status)
+			}
+			if test.expectedError == "" {
+				if health.Healthz.Error != "" {
+					t.Errorf("HealthZ error: %s", health.Healthz.Error)
+				}
+			} else {
+				if !strings.Contains(health.Healthz.Error, test.expectedError) {
+					t.Errorf("Expected error to contain: %q, got: %s", test.expectedError, health.Healthz.Error)
+				}
+			}
+
+			reply := ncs.NewRespInbox()
+			sub, err := ncs.SubscribeSync(reply)
+			if err != nil {
+				t.Fatalf("Error creating subscription: %v", err)
+			}
+			defer sub.Unsubscribe()
+
+			// now PING all servers
+			if err := ncs.PublishRequest(pingSubj, reply, body); err != nil {
+				t.Fatalf("Publish error: %v", err)
+			}
+			for i := 0; i < 3; i++ {
+				msg, err := sub.NextMsg(1 * time.Second)
+				if err != nil {
+					t.Fatalf("Error fetching healthz PING response: %v", err)
+				}
+				var health healthzResp
+				if err := json.Unmarshal(msg.Data, &health); err != nil {
+					t.Fatalf("Error unmarshalling the statz json: %v", err)
+				}
+				if health.Healthz.Status != test.expectedStatus {
+					t.Errorf("Invalid healthz status; want: %q; got: %q", test.expectedStatus, health.Healthz.Status)
+				}
+				if test.expectedError == "" {
+					if health.Healthz.Error != "" {
+						t.Errorf("HealthZ error: %s", health.Healthz.Error)
+					}
+				} else {
+					if !strings.Contains(health.Healthz.Error, test.expectedError) {
+						t.Errorf("Expected error to contain: %q, got: %s", test.expectedError, health.Healthz.Error)
+					}
+				}
+			}
+			if _, err := sub.NextMsg(50 * time.Millisecond); !errors.Is(err, nats.ErrTimeout) {
+				t.Fatalf("Expected timeout error; got: %v", err)
+			}
+		})
+	}
+}
+
+func TestServerEventsHealthZJetStreamNotEnabled(t *testing.T) {
+	type healthzResp struct {
+		Healthz HealthStatus `json:"data"`
+		Server  ServerInfo   `json:"server"`
+	}
+	cfg := `listen: 127.0.0.1:-1
+
+	accounts {
+		$SYS { users = [ { user: "admin", pass: "s3cr3t!" } ] }
+	}`
+
+	serverHealthzReqSubj := "$SYS.REQ.SERVER.%s.HEALTHZ"
+	s, _ := RunServerWithConfig(createConfFile(t, []byte(cfg)))
+	defer s.Shutdown()
+
+	ncs, err := nats.Connect(s.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	if err != nil {
+		t.Fatalf("Error connecting to cluster: %v", err)
+	}
+
+	defer ncs.Close()
+
+	subj := fmt.Sprintf(serverHealthzReqSubj, s.ID())
+
+	msg, err := ncs.Request(subj, nil, 1*time.Second)
+	if err != nil {
+		t.Fatalf("Error trying to request healthz: %v", err)
+	}
+	var health healthzResp
+	if err := json.Unmarshal(msg.Data, &health); err != nil {
+		t.Fatalf("Error unmarshalling the statz json: %v", err)
+	}
+	if health.Healthz.Status != "ok" {
+		t.Errorf("Invalid healthz status; want: %q; got: %q", "ok", health.Healthz.Status)
+	}
+	if health.Healthz.Error != "" {
+		t.Errorf("HealthZ error: %s", health.Healthz.Error)
 	}
 }
 

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2647,9 +2647,11 @@ type JSzOptions struct {
 // HealthzOptions are options passed to Healthz
 type HealthzOptions struct {
 	// Deprecated: Use JSEnabledOnly instead
-	JSEnabled     bool `json:"js-enabled,omitempty"`
-	JSEnabledOnly bool `json:"js-enabled-only,omitempty"`
-	JSServerOnly  bool `json:"js-server-only,omitempty"`
+	JSEnabled     bool   `json:"js-enabled,omitempty"`
+	JSEnabledOnly bool   `json:"js-enabled-only,omitempty"`
+	JSServerOnly  bool   `json:"js-server-only,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Stream        string `json:"stream,omitempty"`
 }
 
 // ProfilezOptions are options passed to Profilez
@@ -3038,6 +3040,8 @@ func (s *Server) HandleHealthz(w http.ResponseWriter, r *http.Request) {
 		JSEnabled:     jsEnabled,
 		JSEnabledOnly: jsEnabledOnly,
 		JSServerOnly:  jsServerOnly,
+		Account:       r.URL.Query().Get("account"),
+		Stream:        r.URL.Query().Get("stream"),
 	})
 	if hs.Error != _EMPTY_ {
 		s.Warnf("Healthcheck failed: %q", hs.Error)
@@ -3058,6 +3062,12 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 	// set option defaults
 	if opts == nil {
 		opts = &HealthzOptions{}
+	}
+
+	if opts.Account == "" && opts.Stream != "" {
+		health.Status = "error"
+		health.Error = fmt.Sprintf("Bad request: %q must not be empty when checking stream health", "account")
+		return health
 	}
 
 	if err := s.readyForConnections(time.Millisecond); err != nil {
@@ -3098,7 +3108,20 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 		sdir := js.config.StoreDir
 		// Whip through account folders and pull each stream name.
 		fis, _ := os.ReadDir(sdir)
+		var accFound, streamFound bool
+		if opts.Account == "" {
+			accFound = true
+		}
+		if opts.Stream == "" {
+			streamFound = true
+		}
 		for _, fi := range fis {
+			if opts.Account != "" {
+				if fi.Name() != opts.Account {
+					continue
+				}
+				accFound = true
+			}
 			acc, err := s.LookupAccount(fi.Name())
 			if err != nil {
 				health.Status = na
@@ -3107,6 +3130,12 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 			}
 			sfis, _ := os.ReadDir(filepath.Join(sdir, fi.Name(), "streams"))
 			for _, sfi := range sfis {
+				if opts.Stream != "" {
+					if sfi.Name() != opts.Stream {
+						continue
+					}
+					streamFound = true
+				}
 				stream := sfi.Name()
 				if _, err := acc.lookupStream(stream); err != nil {
 					health.Status = na
@@ -3114,6 +3143,14 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 					return health
 				}
 			}
+		}
+		if !accFound {
+			health.Status = na
+			health.Error = fmt.Sprintf("JetStream account %q not found", opts.Account)
+		}
+		if !streamFound {
+			health.Status = na
+			health.Error = fmt.Sprintf("JetStream stream %q not found on account %q", opts.Stream, opts.Account)
 		}
 		return health
 	}
@@ -3147,11 +3184,44 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 	ourID := meta.ID()
 
 	// Copy the meta layer so we do not need to hold the js read lock for an extended period of time.
+	var streams map[string]map[string]*streamAssignment
 	js.mu.RLock()
-	streams := make(map[string]map[string]*streamAssignment, len(cc.streams))
-	for acc, asa := range cc.streams {
+	if opts.Account == "" {
+		streams = make(map[string]map[string]*streamAssignment, len(cc.streams))
+		for acc, asa := range cc.streams {
+			nasa := make(map[string]*streamAssignment)
+			for stream, sa := range asa {
+				if sa.Group.isMember(ourID) {
+					csa := sa.copyGroup()
+					csa.consumers = make(map[string]*consumerAssignment)
+					for consumer, ca := range sa.consumers {
+						if ca.Group.isMember(ourID) {
+							csa.consumers[consumer] = ca.copyGroup()
+						}
+					}
+					nasa[stream] = csa
+				}
+			}
+			streams[acc] = nasa
+		}
+	} else {
+		streams = make(map[string]map[string]*streamAssignment, 1)
+		asa, ok := cc.streams[opts.Account]
+		if !ok {
+			health.Status = na
+			health.Error = fmt.Sprintf("JetStream account %q not found", opts.Account)
+			js.mu.RUnlock()
+			return health
+		}
 		nasa := make(map[string]*streamAssignment)
-		for stream, sa := range asa {
+		if opts.Stream != "" {
+			sa, ok := asa[opts.Stream]
+			if !ok {
+				health.Status = na
+				health.Error = fmt.Sprintf("JetStream stream %q not found on account %q", opts.Stream, opts.Account)
+				js.mu.RUnlock()
+				return health
+			}
 			if sa.Group.isMember(ourID) {
 				csa := sa.copyGroup()
 				csa.consumers = make(map[string]*consumerAssignment)
@@ -3160,10 +3230,23 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 						csa.consumers[consumer] = ca.copyGroup()
 					}
 				}
-				nasa[stream] = csa
+				nasa[opts.Stream] = csa
+			}
+		} else {
+			for stream, sa := range asa {
+				if sa.Group.isMember(ourID) {
+					csa := sa.copyGroup()
+					csa.consumers = make(map[string]*consumerAssignment)
+					for consumer, ca := range sa.consumers {
+						if ca.Group.isMember(ourID) {
+							csa.consumers[consumer] = ca.copyGroup()
+						}
+					}
+					nasa[stream] = csa
+				}
 			}
 		}
-		streams[acc] = nasa
+		streams[opts.Account] = nasa
 	}
 	js.mu.RUnlock()
 


### PR DESCRIPTION
This PR adds `account` and `stream` options to `HEALTHZ` system request and `/healthz` monitoring endpoint.
It allows for checking health of a specific stream, without having to rely on other streams, which (when under stress) may not have reached consensus yet and would return an error.

/cc @wallyqs 