### PR TITLE
Do not fail healthz in single server mode on failed snapshot restore.

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -19991,7 +19991,7 @@ func TestJetStreamSnapshotRestoreStallAndHealthz(t *testing.T) {
 		t.Fatalf("Expected health to be ok, got %+v", hs)
 	}
 
-	// Simulate the stagingf directory for restores. This is normally cleaned up
+	// Simulate the staging directory for restores. This is normally cleaned up
 	// but since its at the root of the storage directory make sure healthz is not affected.
 	snapDir := filepath.Join(s.getJetStream().config.StoreDir, snapStagingDir)
 	require_NoError(t, os.MkdirAll(snapDir, defaultDirPerms))

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3083,6 +3083,9 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 		// Whip through account folders and pull each stream name.
 		fis, _ := os.ReadDir(sdir)
 		for _, fi := range fis {
+			if fi.Name() == snapStagingDir {
+				continue
+			}
 			acc, err := s.LookupAccount(fi.Name())
 			if err != nil {
 				health.Status = na

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -6397,8 +6397,8 @@ func TestNoRaceJetStreamConsumerCreateTimeNumPending(t *testing.T) {
 	case <-time.After(5 * time.Second):
 	}
 
-	// Should stay under 5ms now, but for Travis variability say 25ms.
-	threshold := 25 * time.Millisecond
+	// Should stay under 5ms now, but for Travis variability say 50ms.
+	threshold := 50 * time.Millisecond
 
 	start := time.Now()
 	_, err = js.PullSubscribe("events.*", "dlc")


### PR DESCRIPTION
In single server mode healthz could mistake a snapshot staging direct…ory during a restore as an account.
If the restore took a long time, stalled, or was aborted, would cause healthz to fail.

Signed-off-by: Derek Collison <derek@nats.io>