### PR TITLE
The server's Start() used to block but no longer does. 

### DIFF
--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -269,7 +269,7 @@ func TestAccountIsolationExportImport(t *testing.T) {
 			// Setup NATS server.
 			s := opTrustBasicSetup()
 			defer s.Shutdown()
-			go s.Start()
+			s.Start()
 			if err := s.readyForConnections(5 * time.Second); err != nil {
 				t.Fatal(err)
 			}
@@ -1733,7 +1733,7 @@ func TestAccountRequestReplyTrackLatency(t *testing.T) {
 	defer s.Shutdown()
 
 	// Run server in Go routine. We need this one running for internal sending of msgs.
-	go s.Start()
+	s.Start()
 	// Wait for accept loop(s) to be started
 	if err := s.readyForConnections(10 * time.Second); err != nil {
 		t.Fatal(err)

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -319,7 +319,7 @@ func testMQTTRunServer(t testing.TB, o *Options) *Server {
 	}
 	l := &DummyLogger{}
 	s.SetLogger(l, true, true)
-	go s.Start()
+	s.Start()
 	if err := s.readyForConnections(3 * time.Second); err != nil {
 		testMQTTShutdownServer(s)
 		t.Fatal(err)

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -586,7 +586,7 @@ func TestBlockedShutdownOnRouteAcceptLoopFailure(t *testing.T) {
 	opts.Cluster.Port = 7222
 
 	s := New(opts)
-	go s.Start()
+	s.Start()
 	// Wait a second
 	time.Sleep(time.Second)
 	ch := make(chan bool)
@@ -1343,9 +1343,7 @@ func TestRouteIPResolutionAndRouteToSelf(t *testing.T) {
 	defer s.Shutdown()
 	l := &routeHostLookupLogger{errCh: make(chan string, 1), ch: make(chan bool, 1)}
 	s.SetLogger(l, true, true)
-	go func() {
-		s.Start()
-	}()
+	s.Start()
 	if err := s.readyForConnections(time.Second); err != nil {
 		t.Fatal(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1614,8 +1614,10 @@ func (s *Server) fetchAccount(name string) (*Account, error) {
 	return acc, nil
 }
 
-// Start up the server, this will block.
-// Start via a Go routine if needed.
+// Start up the server, this will not block.
+//
+// WaitForShutdown can be used to block and wait for the server to shutdown properly if needed
+// after calling s.Shutdown()
 func (s *Server) Start() {
 	s.Noticef("Starting nats-server")
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -86,7 +86,7 @@ func RunServer(opts *Options) *Server {
 	}
 
 	// Run server in Go routine.
-	go s.Start()
+	s.Start()
 
 	// Wait for accept loop(s) to be started
 	if err := s.readyForConnections(10 * time.Second); err != nil {

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -2497,7 +2497,7 @@ func TestWSAdvertise(t *testing.T) {
 	defer s.Shutdown()
 	l := &captureFatalLogger{fatalCh: make(chan string, 1)}
 	s.SetLogger(l, false, false)
-	go s.Start()
+	s.Start()
 	select {
 	case e := <-l.fatalCh:
 		if !strings.Contains(e, "Unable to get websocket connect URLs") {

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -406,6 +406,8 @@ func TestClusterDoubleMsgs(t *testing.T) {
 	sendB("PING\r\n")
 	expectB(pongRe)
 
+	time.Sleep(10 * time.Millisecond)
+
 	matches = expectMsgsA2(2)
 	checkMsg(t, matches[0], "foo", "", "", "2", "ok")
 	checkForPubSids(t, matches, pSids)


### PR DESCRIPTION
This updates tests and the function comment.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #4110 

