### PR TITLE
[ADDED] LeafNode: TLSHandshakeFirst option

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1752,7 +1752,11 @@ func (c *client) markConnAsClosed(reason ClosedState) {
 	// we use Noticef on create, so use that too for delete.
 	if c.srv != nil {
 		if c.kind == LEAF {
-			c.Noticef("%s connection closed: %s account: %s", c.kindString(), reason, c.acc.traceLabel())
+			if c.acc != nil {
+				c.Noticef("%s connection closed: %s - Account: %s", c.kindString(), reason, c.acc.traceLabel())
+			} else {
+				c.Noticef("%s connection closed: %s", c.kindString(), reason)
+			}
 		} else if c.kind == ROUTER || c.kind == GATEWAY {
 			c.Noticef("%s connection closed: %s", c.kindString(), reason)
 		} else { // Client, System, Jetstream, and Account connections.


### PR DESCRIPTION
A new field in `tls{}` blocks force the server to do TLS handshake before sending the INFO protocol.
```
leafnodes {
   port: 7422
   tls {
      cert_file: ...
      ...
      handshake_first: true
   }
   remotes [
       {
         url: tls://host:7423
         tls {
            ...
            handshake_first: true
         }
       }
   ]
}
```
Note that if `handshake_first` is set in the "accept" side, the first `tls{}` block in the example above, a server trying to create a LeafNode connection to this server would need to have `handshake_first` set to true inside the `tls{}` block of the corresponding remote.

Configuration reload of leafnodes is generally not supported, but TLS certificates can be reloaded and the support for this new field was also added.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>