### PR TITLE
Tweak outbound queue memory test to only log if growth exceeds 10%

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -8313,18 +8313,15 @@ func TestNoRaceClientOutboundQueueMemory(t *testing.T) {
 	diff := float64(ha) - float64(hb)
 	inc := (diff / float64(hb)) * 100
 
-	fmt.Printf("Message size:       %.1fKB\n", ms/1024)
-	fmt.Printf("Subscribed clients: %d\n", len(clients))
-	fmt.Printf("Heap allocs before: %.1fMB\n", hb/1024/1024)
-	fmt.Printf("Heap allocs after:  %.1fMB\n", ha/1024/1024)
-	fmt.Printf("Heap allocs delta:  %.1f%%\n", inc)
+	if inc > 10 {
+		t.Logf("Message size:       %.1fKB\n", ms/1024)
+		t.Logf("Subscribed clients: %d\n", len(clients))
+		t.Logf("Heap allocs before: %.1fMB\n", hb/1024/1024)
+		t.Logf("Heap allocs after:  %.1fMB\n", ha/1024/1024)
+		t.Logf("Heap allocs delta:  %.1f%%\n", inc)
 
-	// TODO: What threshold makes sense here for a failure?
-	/*
-		if inc > 10 {
-			t.Fatalf("memory increase was %.1f%% (should be <= 10%%)", inc)
-		}
-	*/
+		t.Fatalf("memory increase was %.1f%% (should be <= 10%%)", inc)
+	}
 }
 
 func TestNoRaceJetStreamClusterLeafnodeConnectPerf(t *testing.T) {


### PR DESCRIPTION
This makes the `TestNoRaceClientOutboundQueueMemory` test useful and stops unnecessary logging.

Signed-off-by: Neil Twigg <neil@nats.io>