### PR TITLE
[ADDED] Custom Muxer for websocket httpserver

### DIFF
--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -3158,6 +3158,7 @@ func TestLeafNodeWSAuth(t *testing.T) {
 		websocket {
 			port: -1
 			no_tls: true
+			endpoint: "/"
 		}
 		leafnodes {
 			port: -1

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -6016,6 +6016,7 @@ func TestMQTTWebsocket(t *testing.T) {
 		websocket {
 			listen: "127.0.0.1:-1"
 			no_tls: true
+			endpoint: "/"
 		}
 	`
 	s, o, conf := runReloadServerWithContent(t, []byte(fmt.Sprintf(template, tdir, jwt.ConnectionTypeMqtt, "")))

--- a/server/opts.go
+++ b/server/opts.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -512,6 +513,15 @@ type WebsocketOpts struct {
 
 	// Snapshot of configured TLS options.
 	tlsConfigOpts *TLSConfigOpts
+
+	// If nil, will create a new ServeMux when websocket is being
+	// created.  Otherwise, it uses the provided muxer so that
+	// embedding a NATs powered websocket in an existing webapp is
+	// possible
+	Muxer *http.ServeMux
+
+	// Endpoint string of the websocket.  Defaults to "/"
+	Endpoint string
 }
 
 // MQTTOpts are options for MQTT

--- a/server/opts.go
+++ b/server/opts.go
@@ -4832,6 +4832,8 @@ func parseWebsocket(v any, o *Options, errors *[]error) error {
 			o.Websocket.Advertise = mv.(string)
 		case "no_tls":
 			o.Websocket.NoTLS = mv.(bool)
+		case "endpoint":
+			o.Websocket.Endpoint = mv.(string)
 		case "tls":
 			tc, err := parseTLS(tk, true)
 			if err != nil {

--- a/server/reload.go
+++ b/server/reload.go
@@ -1552,8 +1552,10 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 			// Similar to gateways
 			tmpOld := oldValue.(WebsocketOpts)
 			tmpNew := newValue.(WebsocketOpts)
-			tmpOld.TLSConfig, tmpOld.tlsConfigOpts = nil, nil
-			tmpNew.TLSConfig, tmpNew.tlsConfigOpts = nil, nil
+
+			tmpOld.TLSConfig, tmpOld.tlsConfigOpts, tmpOld.Muxer = nil, nil, nil
+			tmpNew.TLSConfig, tmpNew.tlsConfigOpts, tmpNew.Muxer = nil, nil, nil
+
 			// If there is really a change prevents reload.
 			if !reflect.DeepEqual(tmpOld, tmpNew) {
 				// See TODO(ik) note below about printing old/new values.

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -4065,6 +4065,7 @@ func TestWSReloadTLSConfig(t *testing.T) {
 	template := `
 		listen: "127.0.0.1:-1"
 		websocket {
+			endpoint: "/"
 			listen: "127.0.0.1:-1"
 			tls {
 				cert_file: '%s'

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -2674,6 +2674,7 @@ func TestWSAdvertise(t *testing.T) {
 	checkInfo([]string{"host1:1234"})
 
 	// Restart with another advertise and check that it gets updated
+	o2.Websocket.Muxer = nil
 	o2.Websocket.Advertise = "host3:9012"
 	s2 = RunServer(o2)
 	defer s2.Shutdown()


### PR DESCRIPTION
Closes #3994 

 - [X] Link to issue, e.g. `Resolves #3994`
 - https://github.com/nats-io/nats-server/issues/3994
 - [x] Documentation added (if applicable)
 - [x] Tests added
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

### Changes proposed in this pull request

This PR adds the ability to provide the HTTP Server powering the Websocket with a custom muxer.  The reason for this change is that it allows people to add a NATs powered websocket to an existing webapp without having multiple ports.  Sample code below

### Example usage

```go
package main

import (
	"fmt"
	"net/http"

	"github.com/nats-io/nats-server/v2/server"
)

func main() {
	mux := http.NewServeMux()

	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		w.WriteHeader(200)
		_, _ = w.Write([]byte("hello"))
	})

	wsOpts := server.WebsocketOpts{
		Port:     8000,
		Muxer:    mux,
		Endpoint: "/ws",
		NoTLS:    true,
	}

	s, err := server.NewServer(
		&server.Options{
			Port:      0,
			Websocket: wsOpts,
			Debug:     true,
		},
	)
	if err != nil {
		server.PrintAndDie(fmt.Sprintf("%s: %s", "nats-server", err))
	}

	s.ConfigureLogger()

	if err := server.Run(s); err != nil {
		server.PrintAndDie(err.Error())
	}

	s.WaitForShutdown()
}

```

#### Custom Endpoint usage
```bash
nats-server on  feat/websocket-mux via 🐹 v1.20.2 
❯ http localhost:8000   
HTTP/1.1 200 OK
Content-Length: 5
Content-Type: text/plain; charset=utf-8
Date: Tue, 02 May 2023 15:40:08 GMT

hello
```

#### Websocket usage
```bash
nats-server on  feat/websocket-mux via 🐹 v1.20.2 
❯ websocat ws://localhost:8000/ws
INFO {"server_id":"ND476XYY3IBTTTUYKTX7QIY55ZRBBOTYDQYAXNVGDVX4GGZPW6CBHJXN","server_name":"ND476XYY3IBTTTUYKTX7QIY55ZRBBOTYDQYAXNVGDVX4GGZPW6CBHJXN","version":"2.9.17-beta.3","proto":1,"go":"go1.20.2","host":"0.0.0.0","port":4222,"headers":true,"max_payload":1048576,"client_id":4,"client_ip":"::1"} 
^C
```