### PR TITLE
Don't allow compression on memory storage

### DIFF
--- a/server/memstore.go
+++ b/server/memstore.go
@@ -42,6 +42,9 @@ func newMemStore(cfg *StreamConfig) (*memStore, error) {
 	if cfg.Storage != MemoryStorage {
 		return nil, fmt.Errorf("memStore requires memory storage type in config")
 	}
+	if cfg.Compression != NoCompression {
+		return nil, fmt.Errorf("memory storage does not support compression")
+	}
 	ms := &memStore{
 		msgs: make(map[uint64]*StoreMsg),
 		fss:  make(map[string]*SimpleState),
@@ -58,6 +61,9 @@ func (ms *memStore) UpdateConfig(cfg *StreamConfig) error {
 	}
 	if cfg.Storage != MemoryStorage {
 		return fmt.Errorf("memStore requires memory storage type in config")
+	}
+	if cfg.Compression != NoCompression {
+		return fmt.Errorf("memory storage does not support compression")
 	}
 
 	ms.mu.Lock()

--- a/server/stream.go
+++ b/server/stream.go
@@ -1123,6 +1123,12 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 		}
 	}
 
+	// Compression is only support on the file store, so don't allow streams to be created
+	// that are using other storage backends like memory.
+	if cfg.Storage != FileStorage && cfg.Compression != NoCompression {
+		return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("compression is only supported with file storage"))
+	}
+
 	getStream := func(streamName string) (bool, StreamConfig) {
 		var exists bool
 		var cfg StreamConfig


### PR DESCRIPTION
Compression only works on file storage, so let's be explicit about that rather than having an ineffective configuration option when memory storage is selected.

Signed-off-by: Neil Twigg <neil@nats.io>