### PR TITLE
Optimize consumer messages sequences for multiple subjects

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3295,6 +3295,11 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 					o.updateSkipped(uint64(filter.currentSeq))
 				}
 			}
+
+			// If we're sure that this filter has continuous sequence of messages, skip looking up other filters.
+			if nextSeq == sseq && err != ErrStoreEOF {
+				break
+			}
 		}
 
 	}


### PR DESCRIPTION
If consumer with multiple subjects encountered a sequnece of messages in a row from the same subject, it tried to load messages from other subjects in some cases.
This checks for that scenario and optimizes it by early returning.

I added a temporary instrumentation to check for how many times fetching new messages is called, and it seems that it cuts those calls according to assumptions. Though it being internal, it's really hard to show that in test.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>