### PR TITLE
Stop using UTC for time in flushClients

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1144,7 +1144,7 @@ func (c *client) writeLoop() {
 // sent to during processing. We pass in a budget as a time.Duration
 // for how much time to spend in place flushing for this client.
 func (c *client) flushClients(budget time.Duration) time.Time {
-	last := time.Now().UTC()
+	last := time.Now()
 
 	// Check pending clients for flush.
 	for cp := range c.pcd {


### PR DESCRIPTION
In #1943 it was adopted to use `UTC()` in some timestamps, but an unintended side effect from this is that it strips  the monotonic time (https://github.com/golang/go/commit/e5646b23dee5eb6f896a3eef45959aa130857988), so it can be prone to clock skews when subtracting time in other areas of the code.
