### PR TITLE
Bump GH Actions versions (Go; node12 deprecation)

### DIFF
--- a/.github/workflows/cov.yaml
+++ b/.github/workflows/cov.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           path: src/github.com/nats-io/nats-server
           ref: dev
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: '1.19.x'
 
       - name: Run code coverage
         shell: bash --noprofile --norc -x -eo pipefail {0}
@@ -38,7 +38,7 @@ jobs:
           infile: acc.out
 
       - name: Coveralls
-        uses: coverallsapp/github-action@1.1.3
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           path-to-lcov: coverage.lcov

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         # This should be quoted or use .x, but should not be unquoted.
         # Remember that a YAML bare float drops trailing zeroes.
-        go: ['1.16']
+        go: ['1.19']
 
     env:
       GOPATH: /home/runner/work/nats-server
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           path: src/github.com/nats-io/nats-server
 
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: ${{matrix.go}}
 


### PR DESCRIPTION
Bump various GitHub Actions versions to move away from those using the deprecated node.js 12 runtime, and so remove the warnings.

For the coveralls action, I switched to just `@v2`, per their example docs and as we do for most actions, instead of major.minor.patch.

For Golang, update one 1.16 to 1.19, and quote the remaining unquoted instances, even though they had `.x` in there so had to parse as strings, because we're just switching to always-quoting for consistency.
