### PR TITLE
resolver: improve signaling for missing account lookups

### DIFF
--- a/server/dirstore.go
+++ b/server/dirstore.go
@@ -288,6 +288,10 @@ func (store *DirJWTStore) PackWalk(maxJWTs int, cb func(partialPackMsg string)) 
 			if err != nil {
 				return err
 			}
+			if len(jwtBytes) == 0 {
+				// Skip if no contents in the JWT.
+				return nil
+			}
 			if exp != nil {
 				claim, err := jwt.DecodeGeneric(string(jwtBytes))
 				if err == nil && claim.Expires > 0 && claim.Expires < time.Now().Unix() {
@@ -406,6 +410,9 @@ func (store *DirJWTStore) load(publicKey string) (string, error) {
 // write that keeps hash of all jwt in sync
 // Assumes the lock is held. Does return true or an error never both.
 func (store *DirJWTStore) write(path string, publicKey string, theJWT string) (bool, error) {
+	if len(theJWT) == 0 {
+		return false, fmt.Errorf("invalid JWT")
+	}
 	var newHash *[sha256.Size]byte
 	if store.expiration != nil {
 		h := sha256.Sum256([]byte(theJWT))

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -6774,7 +6774,7 @@ func TestJWTAccountNATSResolverWrongCreds(t *testing.T) {
 
 	// Check that trying to connect with bad credentials should not hang until the fetch timeout
 	// and instead return a faster response when an account is not found.
-	_, err := nats.Connect(sC.ClientURL(), nats.UserCredentials(cCreds), nats.Timeout(1*time.Second))
+	_, err := nats.Connect(sC.ClientURL(), nats.UserCredentials(cCreds), nats.Timeout(500*time.Second))
 	if err != nil && !errors.Is(err, nats.ErrAuthorization) {
 		t.Fatalf("Expected auth error: %v", err)
 	}

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -3692,7 +3692,7 @@ func TestJWTAccountNATSResolverCrossClusterFetch(t *testing.T) {
 			listen: 127.0.0.1:-1
 			no_advertise: true
 		}
-    `, ojwt, syspub, dirAA)))
+       `, ojwt, syspub, dirAA)))
 	sAA, _ := RunServerWithConfig(confAA)
 	defer sAA.Shutdown()
 	// Create Server B (using no_advertise to prevent fail over)
@@ -3718,7 +3718,7 @@ func TestJWTAccountNATSResolverCrossClusterFetch(t *testing.T) {
 				nats-route://127.0.0.1:%d
 			]
 		}
-    `, ojwt, syspub, dirAB, sAA.opts.Cluster.Port)))
+       `, ojwt, syspub, dirAB, sAA.opts.Cluster.Port)))
 	sAB, _ := RunServerWithConfig(confAB)
 	defer sAB.Shutdown()
 	// Create Server C (using no_advertise to prevent fail over)
@@ -3744,7 +3744,7 @@ func TestJWTAccountNATSResolverCrossClusterFetch(t *testing.T) {
 			listen: 127.0.0.1:-1
 			no_advertise: true
 		}
-    `, ojwt, syspub, dirBA, sAA.opts.Gateway.Port)))
+       `, ojwt, syspub, dirBA, sAA.opts.Gateway.Port)))
 	sBA, _ := RunServerWithConfig(confBA)
 	defer sBA.Shutdown()
 	// Create Sever BA  (using no_advertise to prevent fail over)
@@ -3773,7 +3773,7 @@ func TestJWTAccountNATSResolverCrossClusterFetch(t *testing.T) {
 				{name: "clust-A", url: "nats://127.0.0.1:%d"},
 			]
 		}
-    `, ojwt, syspub, dirBB, sBA.opts.Cluster.Port, sAA.opts.Cluster.Port)))
+       `, ojwt, syspub, dirBB, sBA.opts.Cluster.Port, sAA.opts.Cluster.Port)))
 	sBB, _ := RunServerWithConfig(confBB)
 	defer sBB.Shutdown()
 	// Assert topology
@@ -6591,4 +6591,191 @@ func TestServerOperatorModeNoAuthRequired(t *testing.T) {
 	defer nc.Close()
 
 	require_True(t, nc.AuthRequired())
+}
+
+func TestJWTAccountNATSResolverWrongCreds(t *testing.T) {
+	require_NoLocalOrRemoteConnections := func(account string, srvs ...*Server) {
+		t.Helper()
+		for _, srv := range srvs {
+			if acc, ok := srv.accounts.Load(account); ok {
+				checkAccClientsCount(t, acc.(*Account), 0)
+			}
+		}
+	}
+	connect := func(url string, credsfile string, acc string, srvs ...*Server) {
+		t.Helper()
+		nc := natsConnect(t, url, nats.UserCredentials(credsfile), nats.Timeout(5*time.Second))
+		nc.Close()
+		require_NoLocalOrRemoteConnections(acc, srvs...)
+	}
+	createAccountAndUser := func(limit bool, done chan struct{}, pubKey, jwt1, jwt2, creds *string) {
+		t.Helper()
+		kp, _ := nkeys.CreateAccount()
+		*pubKey, _ = kp.PublicKey()
+		claim := jwt.NewAccountClaims(*pubKey)
+		var err error
+		*jwt1, err = claim.Encode(oKp)
+		require_NoError(t, err)
+		*jwt2, err = claim.Encode(oKp)
+		require_NoError(t, err)
+		ukp, _ := nkeys.CreateUser()
+		seed, _ := ukp.Seed()
+		upub, _ := ukp.PublicKey()
+		uclaim := newJWTTestUserClaims()
+		uclaim.Subject = upub
+		ujwt, err := uclaim.Encode(kp)
+		require_NoError(t, err)
+		*creds = genCredsFile(t, ujwt, seed)
+		done <- struct{}{}
+	}
+	// Create Accounts and corresponding user creds.
+	doneChan := make(chan struct{}, 4)
+	defer close(doneChan)
+	var syspub, sysjwt, dummy1, sysCreds string
+	createAccountAndUser(false, doneChan, &syspub, &sysjwt, &dummy1, &sysCreds)
+
+	var apub, ajwt1, ajwt2, aCreds string
+	createAccountAndUser(true, doneChan, &apub, &ajwt1, &ajwt2, &aCreds)
+
+	var bpub, bjwt1, bjwt2, bCreds string
+	createAccountAndUser(true, doneChan, &bpub, &bjwt1, &bjwt2, &bCreds)
+
+	// The one that is going to be missing.
+	var cpub, cjwt1, cjwt2, cCreds string
+	createAccountAndUser(true, doneChan, &cpub, &cjwt1, &cjwt2, &cCreds)
+	for i := 0; i < cap(doneChan); i++ {
+		<-doneChan
+	}
+	// Create one directory for each server
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	dirC := t.TempDir()
+
+	// Store accounts on servers A and B, then let C sync on its own.
+	writeJWT(t, dirA, apub, ajwt1)
+	writeJWT(t, dirB, bpub, bjwt1)
+
+	/////////////////////////////////////////
+	//                                     //
+	//   Server A: has creds from client A //
+	//                                     //
+	/////////////////////////////////////////
+	confA := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: 127.0.0.1:-1
+		server_name: srv-A
+		operator: %s
+		system_account: %s
+                debug: true
+		resolver: {
+			type: full
+			dir: '%s'
+			allow_delete: true
+			timeout: "1.5s"
+			interval: "200ms"
+		}
+		resolver_preload: {
+			%s: %s
+		}
+		cluster {
+			name: clust
+			listen: 127.0.0.1:-1
+			no_advertise: true
+		}
+       `, ojwt, syspub, dirA, apub, ajwt1)))
+	sA, _ := RunServerWithConfig(confA)
+	defer sA.Shutdown()
+	require_JWTPresent(t, dirA, apub)
+
+	/////////////////////////////////////////
+	//                                     //
+	//   Server B: has creds from client B //
+	//                                     //
+	/////////////////////////////////////////
+	confB := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: 127.0.0.1:-1
+		server_name: srv-B
+		operator: %s
+		system_account: %s
+		resolver: {
+			type: full
+			dir: '%s'
+			allow_delete: true
+			timeout: "1.5s"
+			interval: "200ms"
+		}
+		cluster {
+			name: clust
+			listen: 127.0.0.1:-1
+			no_advertise: true
+			routes [
+				nats-route://127.0.0.1:%d
+			]
+		}
+        `, ojwt, syspub, dirB, sA.opts.Cluster.Port)))
+	sB, _ := RunServerWithConfig(confB)
+	defer sB.Shutdown()
+
+	/////////////////////////////////////////
+	//                                     //
+	//   Server C: has no creds            //
+	//                                     //
+	/////////////////////////////////////////
+	fmtC := `
+		listen: 127.0.0.1:-1
+		server_name: srv-C
+		operator: %s
+		system_account: %s
+		resolver: {
+			type: full
+			dir: '%s'
+			allow_delete: true
+			timeout: "1.5s"
+			interval: "200ms"
+		}
+		cluster {
+			name: clust
+			listen: 127.0.0.1:-1
+			no_advertise: true
+			routes [
+				nats-route://127.0.0.1:%d
+			]
+		}
+    `
+	confClongTTL := createConfFile(t, []byte(fmt.Sprintf(fmtC, ojwt, syspub, dirC, sA.opts.Cluster.Port)))
+	sC, _ := RunServerWithConfig(confClongTTL) // use long ttl to assure it is not kicking
+	defer sC.Shutdown()
+
+	// startup cluster
+	checkClusterFormed(t, sA, sB, sC)
+	time.Sleep(1 * time.Second) // wait for the protocol to converge
+	// // Check all accounts
+	require_JWTPresent(t, dirA, apub) // was already present on startup
+	require_JWTPresent(t, dirB, apub) // was copied from server A
+	require_JWTPresent(t, dirA, bpub) // was copied from server B
+	require_JWTPresent(t, dirB, bpub) // was already present on startup
+
+	// There should be no state about the missing account.
+	require_JWTAbsent(t, dirA, cpub)
+	require_JWTAbsent(t, dirB, cpub)
+	require_JWTAbsent(t, dirC, cpub)
+
+	// system account client can connect to every server
+	connect(sA.ClientURL(), sysCreds, "")
+	connect(sB.ClientURL(), sysCreds, "")
+	connect(sC.ClientURL(), sysCreds, "")
+
+	// A and B clients can connect to any server.
+	connect(sA.ClientURL(), aCreds, "")
+	connect(sB.ClientURL(), aCreds, "")
+	connect(sC.ClientURL(), aCreds, "")
+	connect(sA.ClientURL(), bCreds, "")
+	connect(sB.ClientURL(), bCreds, "")
+	connect(sC.ClientURL(), bCreds, "")
+
+	// Check that trying to connect with bad credentials should not hang until the fetch timeout
+	// and instead return a faster response when an account is not found.
+	_, err := nats.Connect(sC.ClientURL(), nats.UserCredentials(cCreds), nats.Timeout(1*time.Second))
+	if err != nil && !errors.Is(err, nats.ErrAuthorization) {
+		t.Fatalf("Expected auth error: %v", err)
+	}
 }

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -3747,7 +3747,7 @@ func TestJWTAccountNATSResolverCrossClusterFetch(t *testing.T) {
        `, ojwt, syspub, dirBA, sAA.opts.Gateway.Port)))
 	sBA, _ := RunServerWithConfig(confBA)
 	defer sBA.Shutdown()
-	// Create Sever BA  (using no_advertise to prevent fail over)
+	// Create Server BA (using no_advertise to prevent fail over)
 	confBB := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
 		server_name: srv-B-B


### PR DESCRIPTION
When using the account resolver and a JWT is not found, the client could often get an i/o timeout error due to not receiving a timely response before the account resolver fetch request times out.  In this PR, instead of waiting for the fetch request to timeout, a resolver without JWTs will notify as well that it could not find a matching JWT, waiting for a response from all servers ~~but with a delay to let resolver that do have the JWT to respond first~~.

Also included in this PR is some cleanup to the logs emitted by the resolver.

 - [X] Tests added
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)
