### PR TITLE
[ADDED] Ability to drop partial wildcard tokens in some subject transforms

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -630,7 +630,7 @@ func (a *Account) AddWeightedMappings(src string, dests ...*MapDest) error {
 		if err != nil {
 			return err
 		}
-		tr, err := NewSubjectTransform(src, d.Subject, false)
+		tr, err := NewSubjectTransform(src, d.Subject)
 		if err != nil {
 			return err
 		}
@@ -661,7 +661,7 @@ func (a *Account) AddWeightedMappings(src string, dests ...*MapDest) error {
 				// We need to make the appropriate markers for the wildcards etc.
 				dest = transformTokenize(dest)
 			}
-			tr, err := NewSubjectTransform(src, dest, false)
+			tr, err := NewSubjectTransform(src, dest)
 			if err != nil {
 				return nil, err
 			}
@@ -1903,7 +1903,7 @@ func (a *Account) addServiceImport(dest *Account, from, to string, claim *jwt.Im
 		} else {
 			to, _ = transformUntokenize(to)
 			// Create a transform. Do so in reverse such that $ symbols only exist in to
-			if tr, err = NewSubjectTransform(to, transformTokenize(from), true); err != nil {
+			if tr, err = NewSubjectTransformStrict(to, transformTokenize(from)); err != nil {
 				a.mu.Unlock()
 				return nil, fmt.Errorf("failed to create mapping transform for service import subject from %q to %q: %v",
 					from, to, err)
@@ -2459,7 +2459,7 @@ func (a *Account) AddMappedStreamImportWithClaim(account *Account, from, to stri
 			usePub = true
 		} else {
 			// Create a transform
-			if tr, err = NewSubjectTransform(from, transformTokenize(to), true); err != nil {
+			if tr, err = NewSubjectTransformStrict(from, transformTokenize(to)); err != nil {
 				return fmt.Errorf("failed to create mapping transform for stream import subject from %q to %q: %v",
 					from, to, err)
 			}

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -630,7 +630,7 @@ func (a *Account) AddWeightedMappings(src string, dests ...*MapDest) error {
 		if err != nil {
 			return err
 		}
-		tr, err := NewSubjectTransform(src, d.Subject)
+		tr, err := NewSubjectTransform(src, d.Subject, false)
 		if err != nil {
 			return err
 		}
@@ -661,7 +661,7 @@ func (a *Account) AddWeightedMappings(src string, dests ...*MapDest) error {
 				// We need to make the appropriate markers for the wildcards etc.
 				dest = transformTokenize(dest)
 			}
-			tr, err := NewSubjectTransform(src, dest)
+			tr, err := NewSubjectTransform(src, dest, false)
 			if err != nil {
 				return nil, err
 			}
@@ -1903,7 +1903,7 @@ func (a *Account) addServiceImport(dest *Account, from, to string, claim *jwt.Im
 		} else {
 			to, _ = transformUntokenize(to)
 			// Create a transform. Do so in reverse such that $ symbols only exist in to
-			if tr, err = NewSubjectTransform(to, transformTokenize(from)); err != nil {
+			if tr, err = NewSubjectTransform(to, transformTokenize(from), true); err != nil {
 				a.mu.Unlock()
 				return nil, fmt.Errorf("failed to create mapping transform for service import subject from %q to %q: %v",
 					from, to, err)
@@ -2256,7 +2256,7 @@ func (si *serviceImport) isRespServiceImport() bool {
 	return si != nil && si.response
 }
 
-// Sets the response theshold timer for a service export.
+// Sets the response threshold timer for a service export.
 // Account lock should be held
 func (se *serviceExport) setResponseThresholdTimer() {
 	if se.rtmr != nil {
@@ -2459,7 +2459,7 @@ func (a *Account) AddMappedStreamImportWithClaim(account *Account, from, to stri
 			usePub = true
 		} else {
 			// Create a transform
-			if tr, err = NewSubjectTransform(from, transformTokenize(to)); err != nil {
+			if tr, err = NewSubjectTransform(from, transformTokenize(to), true); err != nil {
 				return fmt.Errorf("failed to create mapping transform for stream import subject from %q to %q: %v",
 					from, to, err)
 			}

--- a/server/errors.go
+++ b/server/errors.go
@@ -219,6 +219,9 @@ var (
 
 	// ErrorMappingDestinationFunctionTooManyArguments is returned when the mapping destination function is passed too many arguments
 	ErrorMappingDestinationFunctionTooManyArguments = fmt.Errorf("%w: too many arguments passed to the function", ErrInvalidMappingDestination)
+
+	// ErrorMappingDestinationFunctionNotSupportedForImport is returned when you try to use a mapping function other than wildcard in a transform that needs to be reversible (i.e. an import)
+	ErrorMappingDestinationFunctionNotSupportedForImport = fmt.Errorf("%w: the only mapping function allowed for import transforms is {{Wildcard()}}", ErrInvalidMappingDestination)
 )
 
 // mappingDestinationErr is a type of subject mapping destination error

--- a/server/stream.go
+++ b/server/stream.go
@@ -457,7 +457,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 			}
 			// check the transform, if any, is valid
 			if ssi.SubjectTransformDest != _EMPTY_ {
-				if _, err = NewSubjectTransform(ssi.FilterSubject, ssi.SubjectTransformDest); err != nil {
+				if _, err = NewSubjectTransform(ssi.FilterSubject, ssi.SubjectTransformDest, false); err != nil {
 					jsa.mu.Unlock()
 					return nil, fmt.Errorf("subject transform from '%s' to '%s' for the source %w", ssi.FilterSubject, ssi.SubjectTransformDest, err)
 				}
@@ -511,7 +511,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 
 	// Check for input subject transform
 	if cfg.SubjectTransform != nil {
-		tr, err := NewSubjectTransform(cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination)
+		tr, err := NewSubjectTransform(cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination, false)
 		if err != nil {
 			jsa.mu.Unlock()
 			return nil, fmt.Errorf("stream subject transform from '%s' to '%s' %w", cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination, err)
@@ -521,7 +521,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 
 	// Check for RePublish.
 	if cfg.RePublish != nil {
-		tr, err := NewSubjectTransform(cfg.RePublish.Source, cfg.RePublish.Destination)
+		tr, err := NewSubjectTransform(cfg.RePublish.Source, cfg.RePublish.Destination, false)
 		if err != nil {
 			jsa.mu.Unlock()
 			return nil, fmt.Errorf("stream republish transform from '%s' to '%s' %w", cfg.RePublish.Source, cfg.RePublish.Destination, err)
@@ -1370,7 +1370,7 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 		if formsCycle {
 			return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration for republish destination forms a cycle"))
 		}
-		if _, err := NewSubjectTransform(cfg.RePublish.Source, cfg.RePublish.Destination); err != nil {
+		if _, err := NewSubjectTransform(cfg.RePublish.Source, cfg.RePublish.Destination, false); err != nil {
 			return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration for republish with transform from '%s' to '%s' not valid", cfg.RePublish.Source, cfg.RePublish.Destination))
 		}
 	}
@@ -1602,7 +1602,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 					// Check for transform.
 					if s.SubjectTransformDest != _EMPTY_ {
 						var err error
-						if si.tr, err = NewSubjectTransform(s.FilterSubject, s.SubjectTransformDest); err != nil {
+						if si.tr, err = NewSubjectTransform(s.FilterSubject, s.SubjectTransformDest, false); err != nil {
 							mset.mu.Unlock()
 							return fmt.Errorf("stream source subject transform from '%s' to '%s' %w", s.FilterSubject, s.SubjectTransformDest, err)
 						}
@@ -1643,7 +1643,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 		if cfg.RePublish.Destination == _EMPTY_ {
 			cfg.RePublish.Destination = fwcs
 		}
-		tr, err := NewSubjectTransform(cfg.RePublish.Source, cfg.RePublish.Destination)
+		tr, err := NewSubjectTransform(cfg.RePublish.Source, cfg.RePublish.Destination, false)
 		if err != nil {
 			mset.mu.Unlock()
 			return fmt.Errorf("stream configuration for republish from '%s' to '%s' %w", cfg.RePublish.Source, cfg.RePublish.Destination, err)
@@ -1656,7 +1656,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 
 	// Check for changes to subject transform
 	if ocfg.SubjectTransform == nil && cfg.SubjectTransform != nil {
-		tr, err := NewSubjectTransform(cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination)
+		tr, err := NewSubjectTransform(cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination, false)
 		if err != nil {
 			mset.mu.Unlock()
 			return fmt.Errorf("stream configuration for subject transform from '%s' to '%s' %w", cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination, err)
@@ -1664,7 +1664,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 		mset.itr = tr
 	} else if ocfg.SubjectTransform != nil && cfg.SubjectTransform != nil &&
 		(ocfg.SubjectTransform.Source != cfg.SubjectTransform.Source || ocfg.SubjectTransform.Destination != cfg.SubjectTransform.Destination) {
-		tr, err := NewSubjectTransform(cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination)
+		tr, err := NewSubjectTransform(cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination, false)
 		if err != nil {
 			mset.mu.Unlock()
 			return fmt.Errorf("stream configuration for subject transform from '%s' to '%s' %w", cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination, err)
@@ -2992,7 +2992,7 @@ func (mset *stream) startingSequenceForSources() {
 		si := &sourceInfo{name: ssi.Name, iname: ssi.iname, sf: ssi.FilterSubject}
 		// Check for transform.
 		if ssi.SubjectTransformDest != _EMPTY_ {
-			si.tr, _ = NewSubjectTransform(ssi.FilterSubject, ssi.SubjectTransformDest) // can not return an error because validated in AddStream
+			si.tr, _ = NewSubjectTransform(ssi.FilterSubject, ssi.SubjectTransformDest, false) // can not return an error because validated in AddStream
 		}
 
 		mset.sources[ssi.iname] = si

--- a/server/stream.go
+++ b/server/stream.go
@@ -457,7 +457,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 			}
 			// check the transform, if any, is valid
 			if ssi.SubjectTransformDest != _EMPTY_ {
-				if _, err = NewSubjectTransform(ssi.FilterSubject, ssi.SubjectTransformDest, false); err != nil {
+				if _, err = NewSubjectTransform(ssi.FilterSubject, ssi.SubjectTransformDest); err != nil {
 					jsa.mu.Unlock()
 					return nil, fmt.Errorf("subject transform from '%s' to '%s' for the source %w", ssi.FilterSubject, ssi.SubjectTransformDest, err)
 				}
@@ -511,7 +511,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 
 	// Check for input subject transform
 	if cfg.SubjectTransform != nil {
-		tr, err := NewSubjectTransform(cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination, false)
+		tr, err := NewSubjectTransform(cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination)
 		if err != nil {
 			jsa.mu.Unlock()
 			return nil, fmt.Errorf("stream subject transform from '%s' to '%s' %w", cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination, err)
@@ -521,7 +521,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 
 	// Check for RePublish.
 	if cfg.RePublish != nil {
-		tr, err := NewSubjectTransform(cfg.RePublish.Source, cfg.RePublish.Destination, false)
+		tr, err := NewSubjectTransform(cfg.RePublish.Source, cfg.RePublish.Destination)
 		if err != nil {
 			jsa.mu.Unlock()
 			return nil, fmt.Errorf("stream republish transform from '%s' to '%s' %w", cfg.RePublish.Source, cfg.RePublish.Destination, err)
@@ -1370,7 +1370,7 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 		if formsCycle {
 			return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration for republish destination forms a cycle"))
 		}
-		if _, err := NewSubjectTransform(cfg.RePublish.Source, cfg.RePublish.Destination, false); err != nil {
+		if _, err := NewSubjectTransform(cfg.RePublish.Source, cfg.RePublish.Destination); err != nil {
 			return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration for republish with transform from '%s' to '%s' not valid", cfg.RePublish.Source, cfg.RePublish.Destination))
 		}
 	}
@@ -1602,7 +1602,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 					// Check for transform.
 					if s.SubjectTransformDest != _EMPTY_ {
 						var err error
-						if si.tr, err = NewSubjectTransform(s.FilterSubject, s.SubjectTransformDest, false); err != nil {
+						if si.tr, err = NewSubjectTransform(s.FilterSubject, s.SubjectTransformDest); err != nil {
 							mset.mu.Unlock()
 							return fmt.Errorf("stream source subject transform from '%s' to '%s' %w", s.FilterSubject, s.SubjectTransformDest, err)
 						}
@@ -1643,7 +1643,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 		if cfg.RePublish.Destination == _EMPTY_ {
 			cfg.RePublish.Destination = fwcs
 		}
-		tr, err := NewSubjectTransform(cfg.RePublish.Source, cfg.RePublish.Destination, false)
+		tr, err := NewSubjectTransform(cfg.RePublish.Source, cfg.RePublish.Destination)
 		if err != nil {
 			mset.mu.Unlock()
 			return fmt.Errorf("stream configuration for republish from '%s' to '%s' %w", cfg.RePublish.Source, cfg.RePublish.Destination, err)
@@ -1656,7 +1656,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 
 	// Check for changes to subject transform
 	if ocfg.SubjectTransform == nil && cfg.SubjectTransform != nil {
-		tr, err := NewSubjectTransform(cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination, false)
+		tr, err := NewSubjectTransform(cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination)
 		if err != nil {
 			mset.mu.Unlock()
 			return fmt.Errorf("stream configuration for subject transform from '%s' to '%s' %w", cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination, err)
@@ -1664,7 +1664,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 		mset.itr = tr
 	} else if ocfg.SubjectTransform != nil && cfg.SubjectTransform != nil &&
 		(ocfg.SubjectTransform.Source != cfg.SubjectTransform.Source || ocfg.SubjectTransform.Destination != cfg.SubjectTransform.Destination) {
-		tr, err := NewSubjectTransform(cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination, false)
+		tr, err := NewSubjectTransform(cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination)
 		if err != nil {
 			mset.mu.Unlock()
 			return fmt.Errorf("stream configuration for subject transform from '%s' to '%s' %w", cfg.SubjectTransform.Source, cfg.SubjectTransform.Destination, err)
@@ -2992,7 +2992,7 @@ func (mset *stream) startingSequenceForSources() {
 		si := &sourceInfo{name: ssi.Name, iname: ssi.iname, sf: ssi.FilterSubject}
 		// Check for transform.
 		if ssi.SubjectTransformDest != _EMPTY_ {
-			si.tr, _ = NewSubjectTransform(ssi.FilterSubject, ssi.SubjectTransformDest, false) // can not return an error because validated in AddStream
+			si.tr, _ = NewSubjectTransform(ssi.FilterSubject, ssi.SubjectTransformDest) // can not return an error because validated in AddStream
 		}
 
 		mset.sources[ssi.iname] = si

--- a/server/subject_transform.go
+++ b/server/subject_transform.go
@@ -320,7 +320,7 @@ func transformUntokenize(subject string) (string, []string) {
 	var nda []string
 
 	for _, token := range strings.Split(subject, tsep) {
-		if args := getMappingFunctionArgs(wildcardMappingFunctionRegEx, token); (len(token) > 1 && token[0] == '$' && token[1] >= '1' && token[1] <= '9') || (args != nil && len(args) == 1 && args[0] != _EMPTY_) {
+		if args := getMappingFunctionArgs(wildcardMappingFunctionRegEx, token); (len(token) > 1 && token[0] == '$' && token[1] >= '1' && token[1] <= '9') || (len(args) == 1 && args[0] != _EMPTY_) {
 			phs = append(phs, token)
 			nda = append(nda, pwcs)
 		} else {

--- a/server/subject_transform.go
+++ b/server/subject_transform.go
@@ -69,7 +69,9 @@ type SubjectTransformer interface {
 	TransformTokenizedSubject(tokens []string) string
 }
 
-func NewSubjectTransform(src, dest string) (*subjectTransform, error) {
+func NewSubjectTransform(src, dest string, strict bool) (*subjectTransform, error) {
+	// strict = true for import subject mappings that need to be reversible
+	// (meaning can only use the Wildcard function and must use all the pwcs that are present in the source)
 	// No source given is equivalent to the source being ">"
 	if src == _EMPTY_ {
 		src = fwcs
@@ -106,6 +108,12 @@ func NewSubjectTransform(src, dest string) (*subjectTransform, error) {
 				return nil, err
 			}
 
+			if strict {
+				if tranformType != NoTransform && tranformType != Wildcard {
+					return nil, &mappingDestinationErr{token, ErrorMappingDestinationFunctionNotSupportedForImport}
+				}
+			}
+
 			if tranformType == NoTransform {
 				dtokMappingFunctionTypes = append(dtokMappingFunctionTypes, NoTransform)
 				dtokMappingFunctionTokenIndexes = append(dtokMappingFunctionTokenIndexes, []int{-1})
@@ -128,7 +136,7 @@ func NewSubjectTransform(src, dest string) (*subjectTransform, error) {
 
 			}
 		}
-		if nphs < npwcs {
+		if strict && nphs < npwcs {
 			// not all wildcards are being used in the destination
 			return nil, &mappingDestinationErr{dest, ErrMappingDestinationNotUsingAllWildcards}
 		}
@@ -304,14 +312,15 @@ func transformTokenize(subject string) string {
 // Helper function to go from transform destination to a subject with partial wildcards and ordered list of placeholders
 // E.g.:
 //
-//	"bar" -> "bar", []
-//	"foo.$2.$1" -> "foo.*.*", ["$2","$1"]
+//		"bar" -> "bar", []
+//		"foo.$2.$1" -> "foo.*.*", ["$2","$1"]
+//	    "foo.{{wildcard(2)}}.{{wildcard(1)}}" -> "foo.*.*", ["{{wildcard(2)}}","{{wildcard(1)}}"]
 func transformUntokenize(subject string) (string, []string) {
 	var phs []string
 	var nda []string
 
 	for _, token := range strings.Split(subject, tsep) {
-		if len(token) > 1 && token[0] == '$' && token[1] >= '1' && token[1] <= '9' {
+		if args := getMappingFunctionArgs(wildcardMappingFunctionRegEx, token); (len(token) > 1 && token[0] == '$' && token[1] >= '1' && token[1] <= '9') || (args != nil && len(args) == 1 && args[0] != _EMPTY_) {
 			phs = append(phs, token)
 			nda = append(nda, pwcs)
 		} else {
@@ -496,7 +505,7 @@ func (tr *subjectTransform) TransformTokenizedSubject(tokens []string) string {
 // Reverse a subjectTransform.
 func (tr *subjectTransform) reverse() *subjectTransform {
 	if len(tr.dtokmftokindexesargs) == 0 {
-		rtr, _ := NewSubjectTransform(tr.dest, tr.src)
+		rtr, _ := NewSubjectTransform(tr.dest, tr.src, true)
 		return rtr
 	}
 	// If we are here we need to dynamically get the correct reverse
@@ -516,6 +525,6 @@ func (tr *subjectTransform) reverse() *subjectTransform {
 		}
 	}
 	ndest := strings.Join(nda, tsep)
-	rtr, _ := NewSubjectTransform(nsrc, ndest)
+	rtr, _ := NewSubjectTransform(nsrc, ndest, true)
 	return rtr
 }

--- a/server/subject_transform.go
+++ b/server/subject_transform.go
@@ -69,7 +69,7 @@ type SubjectTransformer interface {
 	TransformTokenizedSubject(tokens []string) string
 }
 
-func NewSubjectTransform(src, dest string, strict bool) (*subjectTransform, error) {
+func NewSubjectTransformWithStrict(src, dest string, strict bool) (*subjectTransform, error) {
 	// strict = true for import subject mappings that need to be reversible
 	// (meaning can only use the Wildcard function and must use all the pwcs that are present in the source)
 	// No source given is equivalent to the source being ">"
@@ -152,6 +152,14 @@ func NewSubjectTransform(src, dest string, strict bool) (*subjectTransform, erro
 		dtokmfintargs:        dtokMappingFunctionIntArgs,
 		dtokmfstringargs:     dtokMappingFunctionStringArgs,
 	}, nil
+}
+
+func NewSubjectTransform(src, dest string) (*subjectTransform, error) {
+	return NewSubjectTransformWithStrict(src, dest, false)
+}
+
+func NewSubjectTransformStrict(src, dest string) (*subjectTransform, error) {
+	return NewSubjectTransformWithStrict(src, dest, true)
 }
 
 func getMappingFunctionArgs(functionRegEx *regexp.Regexp, token string) []string {
@@ -505,7 +513,7 @@ func (tr *subjectTransform) TransformTokenizedSubject(tokens []string) string {
 // Reverse a subjectTransform.
 func (tr *subjectTransform) reverse() *subjectTransform {
 	if len(tr.dtokmftokindexesargs) == 0 {
-		rtr, _ := NewSubjectTransform(tr.dest, tr.src, true)
+		rtr, _ := NewSubjectTransformStrict(tr.dest, tr.src)
 		return rtr
 	}
 	// If we are here we need to dynamically get the correct reverse
@@ -525,6 +533,6 @@ func (tr *subjectTransform) reverse() *subjectTransform {
 		}
 	}
 	ndest := strings.Join(nda, tsep)
-	rtr, _ := NewSubjectTransform(nsrc, ndest, true)
+	rtr, _ := NewSubjectTransformStrict(nsrc, ndest)
 	return rtr
 }

--- a/server/subject_transform_test.go
+++ b/server/subject_transform_test.go
@@ -102,7 +102,7 @@ func TestSubjectTransformHelpers(t *testing.T) {
 	}
 
 	newReversibleTransform := func(src, dest string) *subjectTransform {
-		tr, err := NewSubjectTransform(src, dest, true)
+		tr, err := NewSubjectTransformStrict(src, dest)
 		if err != nil {
 			t.Fatalf("Error getting reversible transform: %s to %s", src, dest)
 		}
@@ -121,7 +121,7 @@ func TestSubjectTransformHelpers(t *testing.T) {
 func TestSubjectTransforms(t *testing.T) {
 	shouldErr := func(src, dest string, strict bool) {
 		t.Helper()
-		if _, err := NewSubjectTransform(src, dest, strict); err != ErrBadSubject && !errors.Is(err, ErrInvalidMappingDestination) {
+		if _, err := NewSubjectTransformWithStrict(src, dest, strict); err != ErrBadSubject && !errors.Is(err, ErrInvalidMappingDestination) {
 			t.Fatalf("Did not get an error for src=%q and dest=%q", src, dest)
 		}
 	}
@@ -152,7 +152,7 @@ func TestSubjectTransforms(t *testing.T) {
 
 	shouldBeOK := func(src, dest string, strict bool) *subjectTransform {
 		t.Helper()
-		tr, err := NewSubjectTransform(src, dest, strict)
+		tr, err := NewSubjectTransformWithStrict(src, dest, strict)
 		if err != nil {
 			t.Fatalf("Got an error %v for src=%q and dest=%q", err, src, dest)
 		}

--- a/server/subject_transform_test.go
+++ b/server/subject_transform_test.go
@@ -73,58 +73,107 @@ func TestPlaceHolderIndex(t *testing.T) {
 	}
 }
 
+func TestSubjectTransformHelpers(t *testing.T) {
+	equals := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i, v := range a {
+			if v != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	filter, placeHolders := transformUntokenize("bar")
+	if filter != "bar" || len(placeHolders) != 0 {
+		t.Fatalf("transformUntokenize for not returning expected result")
+	}
+
+	filter, placeHolders = transformUntokenize("foo.$2.$1")
+	if filter != "foo.*.*" || !equals(placeHolders, []string{"$2", "$1"}) {
+		t.Fatalf("transformUntokenize for not returning expected result")
+	}
+
+	filter, placeHolders = transformUntokenize("foo.{{wildcard(2)}}.{{wildcard(1)}}")
+	if filter != "foo.*.*" || !equals(placeHolders, []string{"{{wildcard(2)}}", "{{wildcard(1)}}"}) {
+		t.Fatalf("transformUntokenize for not returning expected result")
+	}
+
+	newReversibleTransform := func(src, dest string) *subjectTransform {
+		tr, err := NewSubjectTransform(src, dest, true)
+		if err != nil {
+			t.Fatalf("Error getting reversible transform: %s to %s", src, dest)
+		}
+		return tr
+	}
+
+	tr := newReversibleTransform("foo.*.*", "bar.$2.{{Wildcard(1)}}")
+	subject := "foo.b.a"
+	transformed := tr.TransformSubject(subject)
+	reverse := tr.reverse()
+	if reverse.TransformSubject(transformed) != subject {
+		t.Fatal("Reversed transform subject not matching")
+	}
+}
+
 func TestSubjectTransforms(t *testing.T) {
-	shouldErr := func(src, dest string) {
+	shouldErr := func(src, dest string, strict bool) {
 		t.Helper()
-		if _, err := NewSubjectTransform(src, dest); err != ErrBadSubject && !errors.Is(err, ErrInvalidMappingDestination) {
+		if _, err := NewSubjectTransform(src, dest, strict); err != ErrBadSubject && !errors.Is(err, ErrInvalidMappingDestination) {
 			t.Fatalf("Did not get an error for src=%q and dest=%q", src, dest)
 		}
 	}
 
-	shouldErr("foo.*.*", "bar.$2") // Must place all pwcs.
-
 	// Must be valid subjects.
-	shouldErr("foo", "")
-	shouldErr("foo..", "bar")
+	shouldErr("foo", "", false)
+	shouldErr("foo..", "bar", false)
 
 	// Wildcards are allowed in src, but must be matched by token placements on the other side.
 	// e.g. foo.* -> bar.$1.
-	// Need to have as many pwcs as placements on other side.
-	shouldErr("foo.*", "bar.*")
-	shouldErr("foo.*", "bar.$2")                   // Bad pwc token identifier
-	shouldErr("foo.*", "bar.$1.>")                 // fwcs have to match.
-	shouldErr("foo.>", "bar.baz")                  // fwcs have to match.
-	shouldErr("foo.*.*", "bar.$2")                 // Must place all pwcs.
-	shouldErr("foo.*", "foo.$foo")                 // invalid $ value
-	shouldErr("foo.*", "foo.{{wildcard(2)}}")      // Mapping function being passed an out of range wildcard index
-	shouldErr("foo.*", "foo.{{unimplemented(1)}}") // Mapping trying to use an unknown mapping function
-	shouldErr("foo.*", "foo.{{partition(10)}}")    // Not enough arguments passed to the mapping function
-	shouldErr("foo.*", "foo.{{wildcard(foo)}}")    // Invalid argument passed to the mapping function
-	shouldErr("foo.*", "foo.{{wildcard()}}")       // Not enough arguments passed to the mapping function
-	shouldErr("foo.*", "foo.{{wildcard(1,2)}}")    // Too many arguments passed to the mapping function
-	shouldErr("foo.*", "foo.{{ wildcard5) }}")     // Bad mapping function
-	shouldErr("foo.*", "foo.{{splitLeft(2,2}}")    // arg out of range
+	// Need to have as many pwcs as placements on other side
 
-	shouldBeOK := func(src, dest string) *subjectTransform {
+	shouldErr("foo.*", "bar.*", false)
+	shouldErr("foo.*", "bar.$2", false)                   // Bad pwc token identifier
+	shouldErr("foo.*", "bar.$1.>", false)                 // fwcs have to match.
+	shouldErr("foo.>", "bar.baz", false)                  // fwcs have to match.
+	shouldErr("foo.*.*", "bar.$2", true)                  // Must place all pwcs.
+	shouldErr("foo.*", "foo.$foo", true)                  // invalid $ value
+	shouldErr("foo.*", "bar.{{Partition(2,1)}}", true)    // can only use Wildcard function (and old-style $x) in import transform
+	shouldErr("foo.*", "foo.{{wildcard(2)}}", false)      // Mapping function being passed an out of range wildcard index
+	shouldErr("foo.*", "foo.{{unimplemented(1)}}", false) // Mapping trying to use an unknown mapping function
+	shouldErr("foo.*", "foo.{{partition(10)}}", false)    // Not enough arguments passed to the mapping function
+	shouldErr("foo.*", "foo.{{wildcard(foo)}}", false)    // Invalid argument passed to the mapping function
+	shouldErr("foo.*", "foo.{{wildcard()}}", false)       // Not enough arguments passed to the mapping function
+	shouldErr("foo.*", "foo.{{wildcard(1,2)}}", false)    // Too many arguments passed to the mapping function
+	shouldErr("foo.*", "foo.{{ wildcard5) }}", false)     // Bad mapping function
+	shouldErr("foo.*", "foo.{{splitLeft(2,2}}", false)    // arg out of range
+
+	shouldBeOK := func(src, dest string, strict bool) *subjectTransform {
 		t.Helper()
-		tr, err := NewSubjectTransform(src, dest)
+		tr, err := NewSubjectTransform(src, dest, strict)
 		if err != nil {
 			t.Fatalf("Got an error %v for src=%q and dest=%q", err, src, dest)
 		}
 		return tr
 	}
 
-	shouldBeOK("foo", "bar")
-	shouldBeOK("foo.*.bar.*.baz", "req.$2.$1")
-	shouldBeOK("baz.>", "mybaz.>")
-	shouldBeOK("*", "{{splitfromleft(1,1)}}")
-	shouldBeOK("", "prefix.>")
-	shouldBeOK("*.*", "{{partition(10,1,2)}}")
-	shouldBeOK("foo.*.*", "foo.{{wildcard(1)}}.{{wildcard(2)}}.{{partition(5,1,2)}}")
+	shouldBeOK("foo.*", "bar.{{Wildcard(1)}}", true)
+
+	shouldBeOK("foo.*.*", "bar.$2", false)              // don't have to use all pwcs.
+	shouldBeOK("foo.*.*", "bar.{{wildcard(1)}}", false) // don't have to use all pwcs.
+	shouldBeOK("foo", "bar", false)
+	shouldBeOK("foo.*.bar.*.baz", "req.$2.$1", false)
+	shouldBeOK("baz.>", "mybaz.>", false)
+	shouldBeOK("*", "{{splitfromleft(1,1)}}", false)
+	shouldBeOK("", "prefix.>", false)
+	shouldBeOK("*.*", "{{partition(10,1,2)}}", false)
+	shouldBeOK("foo.*.*", "foo.{{wildcard(1)}}.{{wildcard(2)}}.{{partition(5,1,2)}}", false)
 
 	shouldMatch := func(src, dest, sample, expected string) {
 		t.Helper()
-		tr := shouldBeOK(src, dest)
+		tr := shouldBeOK(src, dest, false)
 		s, err := tr.Match(sample)
 		if err != nil {
 			t.Fatalf("Got an error %v when expecting a match for %q to %q", err, sample, expected)
@@ -137,6 +186,7 @@ func TestSubjectTransforms(t *testing.T) {
 	shouldMatch("", "prefix.>", "foo", "prefix.foo")
 	shouldMatch("foo", "bar", "foo", "bar")
 	shouldMatch("foo.*.bar.*.baz", "req.$2.$1", "foo.A.bar.B.baz", "req.B.A")
+	shouldMatch("foo.*.bar.*.baz", "req.{{wildcard(2)}}.{{wildcard(1)}}", "foo.A.bar.B.baz", "req.B.A")
 	shouldMatch("baz.>", "my.pre.>", "baz.1.2.3", "my.pre.1.2.3")
 	shouldMatch("baz.>", "foo.bar.>", "baz.1.2.3", "foo.bar.1.2.3")
 	shouldMatch("*", "foo.bar.$1", "foo", "foo.bar.foo")


### PR DESCRIPTION

 - [X] Tests added
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

### Changes proposed in this pull request:

There is currently a blanket requirement that subject transforms destinations MUST use ALL of the partial wildcards defined in the source of the transform. This is because the subject transformed defined for imports must be 'reversible' and therefore the destination transform must use all of the partial wildcard tokens defined in the source of the transform.

This reversing of a transform is only used for transforms used by imports, where in any case it doesn't make sense to use any transform other than Wildcard.

This PR:
- relaxes this requirement to only apply when the transform is used by an import, adding the ability to drop a wildcard token in transforms other than as part of an import.
- Improves transform reverse to support both legacy style wildcards $X and the new transform function {{Wildcard(X)}}- Improves reversible transform checking to only allow the use of wildcards in the destination.