### PR TITLE
Add workflow for stale issues

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,0 +1,17 @@
+name: stale-issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  - name: stale-issues
+    stale:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/stale@v8
+          with:
+            debug-only: true # Set until the behavior is tuned.
+            days-before-stale: 28 # Mark stale after 4 weeks (28 days) of inactivity
+            days-before-close: 7 # Close 1 week after marked `Stale` and without follow-up activity
+            exempt-all-milestones: true # Any issue/PR within a milestone will be omitted
+            #exempt-assigness: "foo,bar"  # Exempt issues/PRs assigned to particular users

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -4,14 +4,14 @@ on:
     - cron: "30 1 * * *"
 
 jobs:
-  - name: stale-issues
-    stale:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/stale@v8
-          with:
-            debug-only: true # Set until the behavior is tuned.
-            days-before-stale: 28 # Mark stale after 4 weeks (28 days) of inactivity
-            days-before-close: 7 # Close 1 week after marked `Stale` and without follow-up activity
-            exempt-all-milestones: true # Any issue/PR within a milestone will be omitted
-            #exempt-assigness: "foo,bar"  # Exempt issues/PRs assigned to particular users
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v8
+        with:
+          debug-only: true # Set until the behavior is tuned.
+          days-before-stale: 28 # Mark stale after 4 weeks (28 days) of inactivity
+          days-before-close: 7 # Close 1 week after marked `Stale` and without follow-up activity
+          exempt-all-milestones: true # Any issue/PR within a milestone will be omitted
+          #exempt-assigness: "foo,bar"  # Exempt issues/PRs assigned to particular users

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -11,7 +15,7 @@ jobs:
       - uses: actions/stale@v8
         with:
           debug-only: true # Set until the behavior is tuned.
-          days-before-stale: 28 # Mark stale after 4 weeks (28 days) of inactivity
-          days-before-close: 7 # Close 1 week after marked `Stale` and without follow-up activity
+          days-before-stale: 56 # Mark stale after 8 weeks (56 days) of inactivity
+          days-before-close: -1 # Disable auto-closing
           exempt-all-milestones: true # Any issue/PR within a milestone will be omitted
           #exempt-assigness: "foo,bar"  # Exempt issues/PRs assigned to particular users


### PR DESCRIPTION
This adds a workflow to mark issues and PRs stale after the configured period of time, followed by closing the issue/PR after a subsequent period of time if there was no additional activity.

The `debug-only` option is so currently, so even when merged, it will do a dry-run and not perform any actions. Once we inspect the initial logs of the effect of an initial run (impacting existing issues), we can adjust accordingly and then follow-up with making it active.

For the debug logs to be enabled, we do need to add a repository secret named `ACTIONS_STEP_DEBUG` with a value set to `true` per [this instruction](https://github.com/marketplace/actions/close-stale-issues#debugging).