### PR TITLE
Memory store compression

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7358,7 +7358,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 		jsa.usage[tierName] = t
 	}
 	if st == MemoryStorage {
-		total := t.total.store + int64(memStoreMsgSize(subject, hdr, msg)*uint64(rf))
+		total := t.total.store + int64(memStoreMsgSize(subject, hdr, uint64(len(msg)))*uint64(rf))
 		if jsaLimits.MaxMemory > 0 && total > jsaLimits.MaxMemory {
 			exceeded = true
 		}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -40,7 +40,12 @@ type memStore struct {
 
 type memStoreMsg struct {
 	*StoreMsg
-	origMsgSz uint64 // Size of the message prior to compression
+	origMsgSz []byte // Uvarint, size of the message prior to compression
+}
+
+func (m *memStoreMsg) OrigMsgSz() uint64 {
+	sz, _ := binary.Uvarint(m.origMsgSz)
+	return sz
 }
 
 func newMemStore(cfg *StreamConfig) (*memStore, error) {
@@ -142,7 +147,7 @@ func (ms *memStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts int
 				ms.recalculateFirstForSubj(subj, ss.First, ss)
 			}
 			sm, ok := ms.msgs[ss.First]
-			if !ok || memStoreMsgSize(sm.subj, sm.hdr, sm.origMsgSz) < uint64(len(msg)+len(hdr)) {
+			if !ok || memStoreMsgSize(sm.subj, sm.hdr, sm.OrigMsgSz()) < uint64(len(msg)+len(hdr)) {
 				return ErrMaxBytes
 			}
 		}
@@ -189,7 +194,7 @@ func (ms *memStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts int
 	sm.msg = sm.buf[len(hdr):]
 	ms.msgs[seq] = &memStoreMsg{
 		StoreMsg:  sm,
-		origMsgSz: origsz,
+		origMsgSz: binary.AppendUvarint(nil, origsz),
 	}
 	ms.state.Msgs++
 	ms.state.Bytes += memStoreMsgSize(subj, hdr, origsz)
@@ -740,7 +745,7 @@ func (ms *memStore) Compact(seq uint64) (uint64, error) {
 
 		for seq := seq - 1; seq > 0; seq-- {
 			if sm := ms.msgs[seq]; sm != nil {
-				bytes += memStoreMsgSize(sm.subj, sm.hdr, sm.origMsgSz)
+				bytes += memStoreMsgSize(sm.subj, sm.hdr, sm.OrigMsgSz())
 				purged++
 				delete(ms.msgs, seq)
 				ms.removeSeqPerSubject(sm.subj, seq)
@@ -784,7 +789,7 @@ func (ms *memStore) reset() error {
 	if cb != nil {
 		for _, sm := range ms.msgs {
 			purged++
-			bytes += memStoreMsgSize(sm.subj, sm.hdr, sm.origMsgSz)
+			bytes += memStoreMsgSize(sm.subj, sm.hdr, sm.OrigMsgSz())
 		}
 	}
 
@@ -828,7 +833,7 @@ func (ms *memStore) Truncate(seq uint64) error {
 	for i := ms.state.LastSeq; i > seq; i-- {
 		if sm := ms.msgs[i]; sm != nil {
 			purged++
-			bytes += memStoreMsgSize(sm.subj, sm.hdr, sm.origMsgSz)
+			bytes += memStoreMsgSize(sm.subj, sm.hdr, sm.OrigMsgSz())
 			delete(ms.msgs, i)
 			ms.removeSeqPerSubject(sm.subj, i)
 		}
@@ -1093,7 +1098,7 @@ func (ms *memStore) removeMsg(seq uint64, secure bool) bool {
 		return false
 	}
 
-	ss = memStoreMsgSize(sm.subj, sm.hdr, sm.origMsgSz)
+	ss = memStoreMsgSize(sm.subj, sm.hdr, sm.OrigMsgSz())
 
 	delete(ms.msgs, seq)
 	if ms.state.Msgs > 0 {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -40,8 +40,7 @@ type memStore struct {
 
 type memStoreMsg struct {
 	*StoreMsg
-	compression StoreCompression // The compression algorithm used
-	origMsgSz   uint64           // Size of the message prior to compression
+	origMsgSz uint64 // Size of the message prior to compression
 }
 
 func newMemStore(cfg *StreamConfig) (*memStore, error) {
@@ -189,9 +188,8 @@ func (ms *memStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts int
 	}
 	sm.msg = sm.buf[len(hdr):]
 	ms.msgs[seq] = &memStoreMsg{
-		StoreMsg:    sm,
-		compression: ms.cfg.Compression,
-		origMsgSz:   origsz,
+		StoreMsg:  sm,
+		origMsgSz: origsz,
 	}
 	ms.state.Msgs++
 	ms.state.Bytes += memStoreMsgSize(subj, hdr, origsz)
@@ -889,7 +887,7 @@ func (ms *memStore) LoadMsg(seq uint64, smp *StoreMsg) (*StoreMsg, error) {
 	sm.copy(smp)
 
 	// Decompress the message if needed.
-	if c, err := sm.compression.Decompress(smp.msg); err != nil {
+	if c, err := ms.cfg.Compression.Decompress(smp.msg); err != nil {
 		return nil, err
 	} else {
 		smp.msg = c

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -156,7 +156,7 @@ func TestMemStoreBytesLimit(t *testing.T) {
 }
 
 func TestMemStoreAgeLimit(t *testing.T) {
-	maxAge := 10 * time.Millisecond
+	maxAge := 250 * time.Millisecond
 
 	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
 		cfg.MaxAge = maxAge

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -22,704 +22,744 @@ import (
 	"time"
 )
 
-func TestMemStoreBasics(t *testing.T) {
-	ms, err := newMemStore(&StreamConfig{Storage: MemoryStorage})
-	if err != nil {
-		t.Fatalf("Unexpected error creating store: %v", err)
-	}
-
-	subj, msg := "foo", []byte("Hello World")
-	now := time.Now().UnixNano()
-	if seq, ts, err := ms.StoreMsg(subj, nil, msg); err != nil {
-		t.Fatalf("Error storing msg: %v", err)
-	} else if seq != 1 {
-		t.Fatalf("Expected sequence to be 1, got %d", seq)
-	} else if ts < now || ts > now+int64(time.Millisecond) {
-		t.Fatalf("Expected timestamp to be current, got %v", ts-now)
-	}
-
-	state := ms.State()
-	if state.Msgs != 1 {
-		t.Fatalf("Expected 1 msg, got %d", state.Msgs)
-	}
-	expectedSize := memStoreMsgSize(subj, nil, msg)
-	if state.Bytes != expectedSize {
-		t.Fatalf("Expected %d bytes, got %d", expectedSize, state.Bytes)
-	}
-	sm, err := ms.LoadMsg(1, nil)
-	if err != nil {
-		t.Fatalf("Unexpected error looking up msg: %v", err)
-	}
-	if sm.subj != subj {
-		t.Fatalf("Subjects don't match, original %q vs %q", subj, sm.subj)
-	}
-	if !bytes.Equal(sm.msg, msg) {
-		t.Fatalf("Msgs don't match, original %q vs %q", msg, sm.msg)
+func testMemStoreAllPermutations(t *testing.T, fn func(t *testing.T, cfg StreamConfig)) {
+	for _, cfg := range []StreamConfig{
+		{Compression: NoCompression},
+		{Compression: S2Compression},
+	} {
+		cfg.Storage = MemoryStorage
+		subtestName := cfg.Compression.String()
+		t.Run(subtestName, func(t *testing.T) {
+			fn(t, cfg)
+		})
 	}
 }
 
+func TestMemStoreBasics(t *testing.T) {
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		ms, err := newMemStore(&cfg)
+		if err != nil {
+			t.Fatalf("Unexpected error creating store: %v", err)
+		}
+
+		subj, msg := "foo", []byte("Hello World")
+		now := time.Now().UnixNano()
+		if seq, ts, err := ms.StoreMsg(subj, nil, msg); err != nil {
+			t.Fatalf("Error storing msg: %v", err)
+		} else if seq != 1 {
+			t.Fatalf("Expected sequence to be 1, got %d", seq)
+		} else if ts < now || ts > now+int64(time.Millisecond) {
+			t.Fatalf("Expected timestamp to be current, got %v", ts-now)
+		}
+
+		state := ms.State()
+		if state.Msgs != 1 {
+			t.Fatalf("Expected 1 msg, got %d", state.Msgs)
+		}
+		expectedSize := memStoreMsgSize(subj, nil, uint64(len(msg)))
+		if state.Bytes != expectedSize {
+			t.Fatalf("Expected %d bytes, got %d", expectedSize, state.Bytes)
+		}
+		sm, err := ms.LoadMsg(1, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error looking up msg: %v", err)
+		}
+		if sm.subj != subj {
+			t.Fatalf("Subjects don't match, original %q vs %q", subj, sm.subj)
+		}
+		if !bytes.Equal(sm.msg, msg) {
+			t.Fatalf("Msgs don't match, original %q vs %q", msg, sm.msg)
+		}
+	})
+}
+
 func TestMemStoreMsgLimit(t *testing.T) {
-	ms, err := newMemStore(&StreamConfig{Storage: MemoryStorage, MaxMsgs: 10})
-	if err != nil {
-		t.Fatalf("Unexpected error creating store: %v", err)
-	}
-	subj, msg := "foo", []byte("Hello World")
-	for i := 0; i < 10; i++ {
-		ms.StoreMsg(subj, nil, msg)
-	}
-	state := ms.State()
-	if state.Msgs != 10 {
-		t.Fatalf("Expected %d msgs, got %d", 10, state.Msgs)
-	}
-	if _, _, err := ms.StoreMsg(subj, nil, msg); err != nil {
-		t.Fatalf("Error storing msg: %v", err)
-	}
-	state = ms.State()
-	if state.Msgs != 10 {
-		t.Fatalf("Expected %d msgs, got %d", 10, state.Msgs)
-	}
-	if state.LastSeq != 11 {
-		t.Fatalf("Expected the last sequence to be 11 now, but got %d", state.LastSeq)
-	}
-	if state.FirstSeq != 2 {
-		t.Fatalf("Expected the first sequence to be 2 now, but got %d", state.FirstSeq)
-	}
-	// Make sure we can not lookup seq 1.
-	if _, err := ms.LoadMsg(1, nil); err == nil {
-		t.Fatalf("Expected error looking up seq 1 but got none")
-	}
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		cfg.MaxMsgs = 10
+		ms, err := newMemStore(&cfg)
+		if err != nil {
+			t.Fatalf("Unexpected error creating store: %v", err)
+		}
+		subj, msg := "foo", []byte("Hello World")
+		for i := 0; i < 10; i++ {
+			ms.StoreMsg(subj, nil, msg)
+		}
+		state := ms.State()
+		if state.Msgs != 10 {
+			t.Fatalf("Expected %d msgs, got %d", 10, state.Msgs)
+		}
+		if _, _, err := ms.StoreMsg(subj, nil, msg); err != nil {
+			t.Fatalf("Error storing msg: %v", err)
+		}
+		state = ms.State()
+		if state.Msgs != 10 {
+			t.Fatalf("Expected %d msgs, got %d", 10, state.Msgs)
+		}
+		if state.LastSeq != 11 {
+			t.Fatalf("Expected the last sequence to be 11 now, but got %d", state.LastSeq)
+		}
+		if state.FirstSeq != 2 {
+			t.Fatalf("Expected the first sequence to be 2 now, but got %d", state.FirstSeq)
+		}
+		// Make sure we can not lookup seq 1.
+		if _, err := ms.LoadMsg(1, nil); err == nil {
+			t.Fatalf("Expected error looking up seq 1 but got none")
+		}
+	})
 }
 
 func TestMemStoreBytesLimit(t *testing.T) {
 	subj, msg := "foo", make([]byte, 512)
-	storedMsgSize := memStoreMsgSize(subj, nil, msg)
+	storedMsgSize := memStoreMsgSize(subj, nil, uint64(len(msg)))
 
 	toStore := uint64(1024)
 	maxBytes := storedMsgSize * toStore
 
-	ms, err := newMemStore(&StreamConfig{Storage: MemoryStorage, MaxBytes: int64(maxBytes)})
-	if err != nil {
-		t.Fatalf("Unexpected error creating store: %v", err)
-	}
-
-	for i := uint64(0); i < toStore; i++ {
-		ms.StoreMsg(subj, nil, msg)
-	}
-	state := ms.State()
-	if state.Msgs != toStore {
-		t.Fatalf("Expected %d msgs, got %d", toStore, state.Msgs)
-	}
-	if state.Bytes != storedMsgSize*toStore {
-		t.Fatalf("Expected bytes to be %d, got %d", storedMsgSize*toStore, state.Bytes)
-	}
-
-	// Now send 10 more and check that bytes limit enforced.
-	for i := 0; i < 10; i++ {
-		if _, _, err := ms.StoreMsg(subj, nil, msg); err != nil {
-			t.Fatalf("Error storing msg: %v", err)
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		cfg.MaxBytes = int64(maxBytes)
+		ms, err := newMemStore(&cfg)
+		if err != nil {
+			t.Fatalf("Unexpected error creating store: %v", err)
 		}
-	}
-	state = ms.State()
-	if state.Msgs != toStore {
-		t.Fatalf("Expected %d msgs, got %d", toStore, state.Msgs)
-	}
-	if state.Bytes != storedMsgSize*toStore {
-		t.Fatalf("Expected bytes to be %d, got %d", storedMsgSize*toStore, state.Bytes)
-	}
-	if state.FirstSeq != 11 {
-		t.Fatalf("Expected first sequence to be 11, got %d", state.FirstSeq)
-	}
-	if state.LastSeq != toStore+10 {
-		t.Fatalf("Expected last sequence to be %d, got %d", toStore+10, state.LastSeq)
-	}
+
+		for i := uint64(0); i < toStore; i++ {
+			ms.StoreMsg(subj, nil, msg)
+		}
+		state := ms.State()
+		if state.Msgs != toStore {
+			t.Fatalf("Expected %d msgs, got %d", toStore, state.Msgs)
+		}
+		if state.Bytes != storedMsgSize*toStore {
+			t.Fatalf("Expected bytes to be %d, got %d", storedMsgSize*toStore, state.Bytes)
+		}
+
+		// Now send 10 more and check that bytes limit enforced.
+		for i := 0; i < 10; i++ {
+			if _, _, err := ms.StoreMsg(subj, nil, msg); err != nil {
+				t.Fatalf("Error storing msg: %v", err)
+			}
+		}
+		state = ms.State()
+		if state.Msgs != toStore {
+			t.Fatalf("Expected %d msgs, got %d", toStore, state.Msgs)
+		}
+		if state.Bytes != storedMsgSize*toStore {
+			t.Fatalf("Expected bytes to be %d, got %d", storedMsgSize*toStore, state.Bytes)
+		}
+		if state.FirstSeq != 11 {
+			t.Fatalf("Expected first sequence to be 11, got %d", state.FirstSeq)
+		}
+		if state.LastSeq != toStore+10 {
+			t.Fatalf("Expected last sequence to be %d, got %d", toStore+10, state.LastSeq)
+		}
+	})
 }
 
 func TestMemStoreAgeLimit(t *testing.T) {
 	maxAge := 10 * time.Millisecond
-	ms, err := newMemStore(&StreamConfig{Storage: MemoryStorage, MaxAge: maxAge})
-	if err != nil {
-		t.Fatalf("Unexpected error creating store: %v", err)
-	}
-	// Store some messages. Does not really matter how many.
-	subj, msg := "foo", []byte("Hello World")
-	toStore := 100
-	for i := 0; i < toStore; i++ {
-		ms.StoreMsg(subj, nil, msg)
-	}
-	state := ms.State()
-	if state.Msgs != uint64(toStore) {
-		t.Fatalf("Expected %d msgs, got %d", toStore, state.Msgs)
-	}
-	checkExpired := func(t *testing.T) {
-		t.Helper()
-		checkFor(t, time.Second, maxAge, func() error {
-			state = ms.State()
-			if state.Msgs != 0 {
-				return fmt.Errorf("Expected no msgs, got %d", state.Msgs)
-			}
-			if state.Bytes != 0 {
-				return fmt.Errorf("Expected no bytes, got %d", state.Bytes)
-			}
-			return nil
-		})
-	}
-	// Let them expire
-	checkExpired(t)
-	// Now add some more and make sure that timer will fire again.
-	for i := 0; i < toStore; i++ {
-		ms.StoreMsg(subj, nil, msg)
-	}
-	state = ms.State()
-	if state.Msgs != uint64(toStore) {
-		t.Fatalf("Expected %d msgs, got %d", toStore, state.Msgs)
-	}
-	checkExpired(t)
+
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		cfg.MaxAge = maxAge
+		ms, err := newMemStore(&cfg)
+		if err != nil {
+			t.Fatalf("Unexpected error creating store: %v", err)
+		}
+		// Store some messages. Does not really matter how many.
+		subj, msg := "foo", []byte("Hello World")
+		toStore := 100
+		for i := 0; i < toStore; i++ {
+			ms.StoreMsg(subj, nil, msg)
+		}
+		state := ms.State()
+		if state.Msgs != uint64(toStore) {
+			t.Fatalf("Expected %d msgs, got %d", toStore, state.Msgs)
+		}
+		checkExpired := func(t *testing.T) {
+			t.Helper()
+			checkFor(t, time.Second, maxAge, func() error {
+				state = ms.State()
+				if state.Msgs != 0 {
+					return fmt.Errorf("Expected no msgs, got %d", state.Msgs)
+				}
+				if state.Bytes != 0 {
+					return fmt.Errorf("Expected no bytes, got %d", state.Bytes)
+				}
+				return nil
+			})
+		}
+		// Let them expire
+		checkExpired(t)
+		// Now add some more and make sure that timer will fire again.
+		for i := 0; i < toStore; i++ {
+			ms.StoreMsg(subj, nil, msg)
+		}
+		state = ms.State()
+		if state.Msgs != uint64(toStore) {
+			t.Fatalf("Expected %d msgs, got %d", toStore, state.Msgs)
+		}
+		checkExpired(t)
+	})
 }
 
 func TestMemStoreTimeStamps(t *testing.T) {
-	ms, err := newMemStore(&StreamConfig{Storage: MemoryStorage})
-	if err != nil {
-		t.Fatalf("Unexpected error creating store: %v", err)
-	}
-	last := time.Now().UnixNano()
-	subj, msg := "foo", []byte("Hello World")
-	for i := 0; i < 10; i++ {
-		time.Sleep(5 * time.Microsecond)
-		ms.StoreMsg(subj, nil, msg)
-	}
-	var smv StoreMsg
-	for seq := uint64(1); seq <= 10; seq++ {
-		sm, err := ms.LoadMsg(seq, &smv)
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		ms, err := newMemStore(&cfg)
 		if err != nil {
-			t.Fatalf("Unexpected error looking up msg: %v", err)
+			t.Fatalf("Unexpected error creating store: %v", err)
 		}
-		// These should be different
-		if sm.ts <= last {
-			t.Fatalf("Expected different timestamps, got %v", sm.ts)
+		last := time.Now().UnixNano()
+		subj, msg := "foo", []byte("Hello World")
+		for i := 0; i < 10; i++ {
+			time.Sleep(5 * time.Microsecond)
+			ms.StoreMsg(subj, nil, msg)
 		}
-		last = sm.ts
-	}
+		var smv StoreMsg
+		for seq := uint64(1); seq <= 10; seq++ {
+			sm, err := ms.LoadMsg(seq, &smv)
+			if err != nil {
+				t.Fatalf("Unexpected error looking up msg: %v", err)
+			}
+			// These should be different
+			if sm.ts <= last {
+				t.Fatalf("Expected different timestamps, got %v", sm.ts)
+			}
+			last = sm.ts
+		}
+	})
 }
 
 func TestMemStorePurge(t *testing.T) {
-	ms, err := newMemStore(&StreamConfig{Storage: MemoryStorage})
-	if err != nil {
-		t.Fatalf("Unexpected error creating store: %v", err)
-	}
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		ms, err := newMemStore(&cfg)
+		if err != nil {
+			t.Fatalf("Unexpected error creating store: %v", err)
+		}
 
-	subj, msg := "foo", []byte("Hello World")
-	for i := 0; i < 10; i++ {
-		ms.StoreMsg(subj, nil, msg)
-	}
-	if state := ms.State(); state.Msgs != 10 {
-		t.Fatalf("Expected 10 msgs, got %d", state.Msgs)
-	}
-	ms.Purge()
-	if state := ms.State(); state.Msgs != 0 {
-		t.Fatalf("Expected no msgs, got %d", state.Msgs)
-	}
+		subj, msg := "foo", []byte("Hello World")
+		for i := 0; i < 10; i++ {
+			ms.StoreMsg(subj, nil, msg)
+		}
+		if state := ms.State(); state.Msgs != 10 {
+			t.Fatalf("Expected 10 msgs, got %d", state.Msgs)
+		}
+		ms.Purge()
+		if state := ms.State(); state.Msgs != 0 {
+			t.Fatalf("Expected no msgs, got %d", state.Msgs)
+		}
+	})
 }
 
 func TestMemStoreCompact(t *testing.T) {
-	ms, err := newMemStore(&StreamConfig{Storage: MemoryStorage})
-	if err != nil {
-		t.Fatalf("Unexpected error creating store: %v", err)
-	}
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		ms, err := newMemStore(&cfg)
+		if err != nil {
+			t.Fatalf("Unexpected error creating store: %v", err)
+		}
 
-	subj, msg := "foo", []byte("Hello World")
-	for i := 0; i < 10; i++ {
-		ms.StoreMsg(subj, nil, msg)
-	}
-	if state := ms.State(); state.Msgs != 10 {
-		t.Fatalf("Expected 10 msgs, got %d", state.Msgs)
-	}
-	n, err := ms.Compact(6)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if n != 5 {
-		t.Fatalf("Expected to have purged 5 msgs, got %d", n)
-	}
-	state := ms.State()
-	if state.Msgs != 5 {
-		t.Fatalf("Expected 5 msgs, got %d", state.Msgs)
-	}
-	if state.FirstSeq != 6 {
-		t.Fatalf("Expected first seq of 6, got %d", state.FirstSeq)
-	}
-	// Now test that compact will also reset first if seq > last
-	n, err = ms.Compact(100)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if n != 5 {
-		t.Fatalf("Expected to have purged 5 msgs, got %d", n)
-	}
-	if state = ms.State(); state.FirstSeq != 100 {
-		t.Fatalf("Expected first seq of 100, got %d", state.FirstSeq)
-	}
+		subj, msg := "foo", []byte("Hello World")
+		for i := 0; i < 10; i++ {
+			ms.StoreMsg(subj, nil, msg)
+		}
+		if state := ms.State(); state.Msgs != 10 {
+			t.Fatalf("Expected 10 msgs, got %d", state.Msgs)
+		}
+		n, err := ms.Compact(6)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if n != 5 {
+			t.Fatalf("Expected to have purged 5 msgs, got %d", n)
+		}
+		state := ms.State()
+		if state.Msgs != 5 {
+			t.Fatalf("Expected 5 msgs, got %d", state.Msgs)
+		}
+		if state.FirstSeq != 6 {
+			t.Fatalf("Expected first seq of 6, got %d", state.FirstSeq)
+		}
+		// Now test that compact will also reset first if seq > last
+		n, err = ms.Compact(100)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if n != 5 {
+			t.Fatalf("Expected to have purged 5 msgs, got %d", n)
+		}
+		if state = ms.State(); state.FirstSeq != 100 {
+			t.Fatalf("Expected first seq of 100, got %d", state.FirstSeq)
+		}
+	})
 }
 
 func TestMemStoreEraseMsg(t *testing.T) {
-	ms, err := newMemStore(&StreamConfig{Storage: MemoryStorage})
-	if err != nil {
-		t.Fatalf("Unexpected error creating store: %v", err)
-	}
-	subj, msg := "foo", []byte("Hello World")
-	ms.StoreMsg(subj, nil, msg)
-	sm, err := ms.LoadMsg(1, nil)
-	if err != nil {
-		t.Fatalf("Unexpected error looking up msg: %v", err)
-	}
-	if !bytes.Equal(msg, sm.msg) {
-		t.Fatalf("Expected same msg, got %q vs %q", sm.msg, msg)
-	}
-	if removed, _ := ms.EraseMsg(1); !removed {
-		t.Fatalf("Expected erase msg to return success")
-	}
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		ms, err := newMemStore(&cfg)
+		if err != nil {
+			t.Fatalf("Unexpected error creating store: %v", err)
+		}
+		subj, msg := "foo", []byte("Hello World")
+		ms.StoreMsg(subj, nil, msg)
+		sm, err := ms.LoadMsg(1, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error looking up msg: %v", err)
+		}
+		if !bytes.Equal(msg, sm.msg) {
+			t.Fatalf("Expected same msg, got %q vs %q", sm.msg, msg)
+		}
+		if removed, _ := ms.EraseMsg(1); !removed {
+			t.Fatalf("Expected erase msg to return success")
+		}
+	})
 }
 
 func TestMemStoreMsgHeaders(t *testing.T) {
-	ms, err := newMemStore(&StreamConfig{Storage: MemoryStorage})
-	if err != nil {
-		t.Fatalf("Unexpected error creating store: %v", err)
-	}
-	subj, hdr, msg := "foo", []byte("name:derek"), []byte("Hello World")
-	if sz := int(memStoreMsgSize(subj, hdr, msg)); sz != (len(subj) + len(hdr) + len(msg) + 16) {
-		t.Fatalf("Wrong size for stored msg with header")
-	}
-	ms.StoreMsg(subj, hdr, msg)
-	sm, err := ms.LoadMsg(1, nil)
-	if err != nil {
-		t.Fatalf("Unexpected error looking up msg: %v", err)
-	}
-	if !bytes.Equal(msg, sm.msg) {
-		t.Fatalf("Expected same msg, got %q vs %q", sm.msg, msg)
-	}
-	if !bytes.Equal(hdr, sm.hdr) {
-		t.Fatalf("Expected same hdr, got %q vs %q", sm.hdr, hdr)
-	}
-	if removed, _ := ms.EraseMsg(1); !removed {
-		t.Fatalf("Expected erase msg to return success")
-	}
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		ms, err := newMemStore(&cfg)
+		if err != nil {
+			t.Fatalf("Unexpected error creating store: %v", err)
+		}
+		subj, hdr, msg := "foo", []byte("name:derek"), []byte("Hello World")
+		if sz := int(memStoreMsgSize(subj, hdr, uint64(len(msg)))); sz != (len(subj) + len(hdr) + len(msg) + 16) {
+			t.Fatalf("Wrong size for stored msg with header")
+		}
+		ms.StoreMsg(subj, hdr, msg)
+		sm, err := ms.LoadMsg(1, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error looking up msg: %v", err)
+		}
+		if !bytes.Equal(msg, sm.msg) {
+			t.Fatalf("Expected same msg, got %q vs %q", sm.msg, msg)
+		}
+		if !bytes.Equal(hdr, sm.hdr) {
+			t.Fatalf("Expected same hdr, got %q vs %q", sm.hdr, hdr)
+		}
+		if removed, _ := ms.EraseMsg(1); !removed {
+			t.Fatalf("Expected erase msg to return success")
+		}
+	})
 }
 
 func TestMemStoreStreamStateDeleted(t *testing.T) {
-	ms, err := newMemStore(&StreamConfig{Storage: MemoryStorage})
-	if err != nil {
-		t.Fatalf("Unexpected error creating store: %v", err)
-	}
-
-	subj, toStore := "foo", uint64(10)
-	for i := uint64(1); i <= toStore; i++ {
-		msg := []byte(fmt.Sprintf("[%08d] Hello World!", i))
-		if _, _, err := ms.StoreMsg(subj, nil, msg); err != nil {
-			t.Fatalf("Error storing msg: %v", err)
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		ms, err := newMemStore(&cfg)
+		if err != nil {
+			t.Fatalf("Unexpected error creating store: %v", err)
 		}
-	}
-	state := ms.State()
-	if len(state.Deleted) != 0 {
-		t.Fatalf("Expected deleted to be empty")
-	}
-	// Now remove some interior messages.
-	var expected []uint64
-	for seq := uint64(2); seq < toStore; seq += 2 {
-		ms.RemoveMsg(seq)
-		expected = append(expected, seq)
-	}
-	state = ms.State()
-	if !reflect.DeepEqual(state.Deleted, expected) {
-		t.Fatalf("Expected deleted to be %+v, got %+v\n", expected, state.Deleted)
-	}
-	// Now fill the gap by deleting 1 and 3
-	ms.RemoveMsg(1)
-	ms.RemoveMsg(3)
-	expected = expected[2:]
-	state = ms.State()
-	if !reflect.DeepEqual(state.Deleted, expected) {
-		t.Fatalf("Expected deleted to be %+v, got %+v\n", expected, state.Deleted)
-	}
-	if state.FirstSeq != 5 {
-		t.Fatalf("Expected first seq to be 5, got %d", state.FirstSeq)
-	}
-	ms.Purge()
-	if state = ms.State(); len(state.Deleted) != 0 {
-		t.Fatalf("Expected no deleted after purge, got %+v\n", state.Deleted)
-	}
+
+		subj, toStore := "foo", uint64(10)
+		for i := uint64(1); i <= toStore; i++ {
+			msg := []byte(fmt.Sprintf("[%08d] Hello World!", i))
+			if _, _, err := ms.StoreMsg(subj, nil, msg); err != nil {
+				t.Fatalf("Error storing msg: %v", err)
+			}
+		}
+		state := ms.State()
+		if len(state.Deleted) != 0 {
+			t.Fatalf("Expected deleted to be empty")
+		}
+		// Now remove some interior messages.
+		var expected []uint64
+		for seq := uint64(2); seq < toStore; seq += 2 {
+			ms.RemoveMsg(seq)
+			expected = append(expected, seq)
+		}
+		state = ms.State()
+		if !reflect.DeepEqual(state.Deleted, expected) {
+			t.Fatalf("Expected deleted to be %+v, got %+v\n", expected, state.Deleted)
+		}
+		// Now fill the gap by deleting 1 and 3
+		ms.RemoveMsg(1)
+		ms.RemoveMsg(3)
+		expected = expected[2:]
+		state = ms.State()
+		if !reflect.DeepEqual(state.Deleted, expected) {
+			t.Fatalf("Expected deleted to be %+v, got %+v\n", expected, state.Deleted)
+		}
+		if state.FirstSeq != 5 {
+			t.Fatalf("Expected first seq to be 5, got %d", state.FirstSeq)
+		}
+		ms.Purge()
+		if state = ms.State(); len(state.Deleted) != 0 {
+			t.Fatalf("Expected no deleted after purge, got %+v\n", state.Deleted)
+		}
+	})
 }
 
 func TestMemStoreStreamTruncate(t *testing.T) {
-	ms, err := newMemStore(&StreamConfig{Storage: MemoryStorage})
-	if err != nil {
-		t.Fatalf("Unexpected error creating store: %v", err)
-	}
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		ms, err := newMemStore(&cfg)
+		if err != nil {
+			t.Fatalf("Unexpected error creating store: %v", err)
+		}
 
-	tseq := uint64(50)
+		tseq := uint64(50)
 
-	subj, toStore := "foo", uint64(100)
-	for i := uint64(1); i < tseq; i++ {
-		_, _, err := ms.StoreMsg(subj, nil, []byte("ok"))
-		require_NoError(t, err)
-	}
-	subj = "bar"
-	for i := tseq; i <= toStore; i++ {
-		_, _, err := ms.StoreMsg(subj, nil, []byte("ok"))
-		require_NoError(t, err)
-	}
+		subj, toStore := "foo", uint64(100)
+		for i := uint64(1); i < tseq; i++ {
+			_, _, err := ms.StoreMsg(subj, nil, []byte("ok"))
+			require_NoError(t, err)
+		}
+		subj = "bar"
+		for i := tseq; i <= toStore; i++ {
+			_, _, err := ms.StoreMsg(subj, nil, []byte("ok"))
+			require_NoError(t, err)
+		}
 
-	if state := ms.State(); state.Msgs != toStore {
-		t.Fatalf("Expected %d msgs, got %d", toStore, state.Msgs)
-	}
+		if state := ms.State(); state.Msgs != toStore {
+			t.Fatalf("Expected %d msgs, got %d", toStore, state.Msgs)
+		}
 
-	// Check that sequence has to be interior.
-	if err := ms.Truncate(toStore + 1); err != ErrInvalidSequence {
-		t.Fatalf("Expected err of '%v', got '%v'", ErrInvalidSequence, err)
-	}
+		// Check that sequence has to be interior.
+		if err := ms.Truncate(toStore + 1); err != ErrInvalidSequence {
+			t.Fatalf("Expected err of '%v', got '%v'", ErrInvalidSequence, err)
+		}
 
-	if err := ms.Truncate(tseq); err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if state := ms.State(); state.Msgs != tseq {
-		t.Fatalf("Expected %d msgs, got %d", tseq, state.Msgs)
-	}
+		if err := ms.Truncate(tseq); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if state := ms.State(); state.Msgs != tseq {
+			t.Fatalf("Expected %d msgs, got %d", tseq, state.Msgs)
+		}
 
-	// Now make sure we report properly if we have some deleted interior messages.
-	ms.RemoveMsg(10)
-	ms.RemoveMsg(20)
-	ms.RemoveMsg(30)
-	ms.RemoveMsg(40)
+		// Now make sure we report properly if we have some deleted interior messages.
+		ms.RemoveMsg(10)
+		ms.RemoveMsg(20)
+		ms.RemoveMsg(30)
+		ms.RemoveMsg(40)
 
-	tseq = uint64(25)
-	if err := ms.Truncate(tseq); err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	state := ms.State()
-	if state.Msgs != tseq-2 {
-		t.Fatalf("Expected %d msgs, got %d", tseq-2, state.Msgs)
-	}
-	if state.NumSubjects != 1 {
-		t.Fatalf("Expected only 1 subject, got %d", state.NumSubjects)
-	}
-	expected := []uint64{10, 20}
-	if !reflect.DeepEqual(state.Deleted, expected) {
-		t.Fatalf("Expected deleted to be %+v, got %+v\n", expected, state.Deleted)
-	}
+		tseq = uint64(25)
+		if err := ms.Truncate(tseq); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		state := ms.State()
+		if state.Msgs != tseq-2 {
+			t.Fatalf("Expected %d msgs, got %d", tseq-2, state.Msgs)
+		}
+		if state.NumSubjects != 1 {
+			t.Fatalf("Expected only 1 subject, got %d", state.NumSubjects)
+		}
+		expected := []uint64{10, 20}
+		if !reflect.DeepEqual(state.Deleted, expected) {
+			t.Fatalf("Expected deleted to be %+v, got %+v\n", expected, state.Deleted)
+		}
+	})
 }
 
 func TestMemStorePurgeExWithSubject(t *testing.T) {
-	ms, err := newMemStore(&StreamConfig{Storage: MemoryStorage})
-	require_NoError(t, err)
-
-	for i := 0; i < 100; i++ {
-		_, _, err = ms.StoreMsg("foo", nil, nil)
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		ms, err := newMemStore(&cfg)
 		require_NoError(t, err)
-	}
 
-	// This should purge all.
-	ms.PurgeEx("foo", 1, 0)
-	require_True(t, ms.State().Msgs == 0)
+		for i := 0; i < 100; i++ {
+			_, _, err = ms.StoreMsg("foo", nil, nil)
+			require_NoError(t, err)
+		}
+
+		// This should purge all.
+		ms.PurgeEx("foo", 1, 0)
+		require_True(t, ms.State().Msgs == 0)
+	})
 }
 
 func TestMemStoreUpdateMaxMsgsPerSubject(t *testing.T) {
-	cfg := &StreamConfig{
-		Name:       "TEST",
-		Storage:    MemoryStorage,
-		Subjects:   []string{"foo"},
-		MaxMsgsPer: 10,
-	}
-	ms, err := newMemStore(cfg)
-	require_NoError(t, err)
-
-	// Make sure this is honored on an update.
-	cfg.MaxMsgsPer = 50
-	err = ms.UpdateConfig(cfg)
-	require_NoError(t, err)
-
-	numStored := 22
-	for i := 0; i < numStored; i++ {
-		_, _, err = ms.StoreMsg("foo", nil, nil)
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		cfg.Name = "TEST"
+		cfg.Subjects = []string{"foo"}
+		cfg.MaxMsgsPer = 10
+		ms, err := newMemStore(&cfg)
 		require_NoError(t, err)
-	}
 
-	ss := ms.SubjectsState("foo")["foo"]
-	if ss.Msgs != uint64(numStored) {
-		t.Fatalf("Expected to have %d stored, got %d", numStored, ss.Msgs)
-	}
+		// Make sure this is honored on an update.
+		cfg.MaxMsgsPer = 50
+		err = ms.UpdateConfig(&cfg)
+		require_NoError(t, err)
 
-	// Now make sure we trunk if setting to lower value.
-	cfg.MaxMsgsPer = 10
-	err = ms.UpdateConfig(cfg)
-	require_NoError(t, err)
+		numStored := 22
+		for i := 0; i < numStored; i++ {
+			_, _, err = ms.StoreMsg("foo", nil, nil)
+			require_NoError(t, err)
+		}
 
-	ss = ms.SubjectsState("foo")["foo"]
-	if ss.Msgs != 10 {
-		t.Fatalf("Expected to have %d stored, got %d", 10, ss.Msgs)
-	}
+		ss := ms.SubjectsState("foo")["foo"]
+		if ss.Msgs != uint64(numStored) {
+			t.Fatalf("Expected to have %d stored, got %d", numStored, ss.Msgs)
+		}
+
+		// Now make sure we trunk if setting to lower value.
+		cfg.MaxMsgsPer = 10
+		err = ms.UpdateConfig(&cfg)
+		require_NoError(t, err)
+
+		ss = ms.SubjectsState("foo")["foo"]
+		if ss.Msgs != 10 {
+			t.Fatalf("Expected to have %d stored, got %d", 10, ss.Msgs)
+		}
+	})
 }
 
 func TestMemStoreStreamTruncateReset(t *testing.T) {
-	cfg := &StreamConfig{
-		Name:     "TEST",
-		Storage:  MemoryStorage,
-		Subjects: []string{"foo"},
-	}
-	ms, err := newMemStore(cfg)
-	require_NoError(t, err)
-
-	subj, msg := "foo", []byte("Hello World")
-	for i := 0; i < 1000; i++ {
-		_, _, err := ms.StoreMsg(subj, nil, msg)
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		cfg.Name = "TEST"
+		cfg.Subjects = []string{"foo"}
+		ms, err := newMemStore(&cfg)
 		require_NoError(t, err)
-	}
 
-	// Reset everything
-	require_NoError(t, ms.Truncate(0))
+		subj, msg := "foo", []byte("Hello World")
+		for i := 0; i < 1000; i++ {
+			_, _, err := ms.StoreMsg(subj, nil, msg)
+			require_NoError(t, err)
+		}
 
-	state := ms.State()
-	require_True(t, state.Msgs == 0)
-	require_True(t, state.Bytes == 0)
-	require_True(t, state.FirstSeq == 0)
-	require_True(t, state.LastSeq == 0)
-	require_True(t, state.NumSubjects == 0)
-	require_True(t, state.NumDeleted == 0)
+		// Reset everything
+		require_NoError(t, ms.Truncate(0))
 
-	for i := 0; i < 1000; i++ {
-		_, _, err := ms.StoreMsg(subj, nil, msg)
-		require_NoError(t, err)
-	}
+		state := ms.State()
+		require_True(t, state.Msgs == 0)
+		require_True(t, state.Bytes == 0)
+		require_True(t, state.FirstSeq == 0)
+		require_True(t, state.LastSeq == 0)
+		require_True(t, state.NumSubjects == 0)
+		require_True(t, state.NumDeleted == 0)
 
-	state = ms.State()
-	require_True(t, state.Msgs == 1000)
-	require_True(t, state.Bytes == 30000)
-	require_True(t, state.FirstSeq == 1)
-	require_True(t, state.LastSeq == 1000)
-	require_True(t, state.NumSubjects == 1)
-	require_True(t, state.NumDeleted == 0)
+		for i := 0; i < 1000; i++ {
+			_, _, err := ms.StoreMsg(subj, nil, msg)
+			require_NoError(t, err)
+		}
+
+		state = ms.State()
+		require_True(t, state.Msgs == 1000)
+		require_True(t, state.Bytes == 30000)
+		require_True(t, state.FirstSeq == 1)
+		require_True(t, state.LastSeq == 1000)
+		require_True(t, state.NumSubjects == 1)
+		require_True(t, state.NumDeleted == 0)
+	})
 }
 
 func TestMemStoreStreamCompactMultiBlockSubjectInfo(t *testing.T) {
-	cfg := &StreamConfig{
-		Name:     "TEST",
-		Storage:  MemoryStorage,
-		Subjects: []string{"foo.*"},
-	}
-	ms, err := newMemStore(cfg)
-	require_NoError(t, err)
-
-	for i := 0; i < 1000; i++ {
-		subj := fmt.Sprintf("foo.%d", i)
-		_, _, err := ms.StoreMsg(subj, nil, []byte("Hello World"))
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		cfg.Name = "TEST"
+		cfg.Subjects = []string{"foo.*"}
+		ms, err := newMemStore(&cfg)
 		require_NoError(t, err)
-	}
 
-	// Compact such that we know we throw blocks away from the beginning.
-	deleted, err := ms.Compact(501)
-	require_NoError(t, err)
-	require_True(t, deleted == 500)
+		for i := 0; i < 1000; i++ {
+			subj := fmt.Sprintf("foo.%d", i)
+			_, _, err := ms.StoreMsg(subj, nil, []byte("Hello World"))
+			require_NoError(t, err)
+		}
 
-	// Make sure we adjusted for subjects etc.
-	state := ms.State()
-	require_True(t, state.NumSubjects == 500)
+		// Compact such that we know we throw blocks away from the beginning.
+		deleted, err := ms.Compact(501)
+		require_NoError(t, err)
+		require_True(t, deleted == 500)
+
+		// Make sure we adjusted for subjects etc.
+		state := ms.State()
+		require_True(t, state.NumSubjects == 500)
+	})
 }
 
 func TestMemStoreSubjectsTotals(t *testing.T) {
-	cfg := &StreamConfig{
-		Name:     "TEST",
-		Storage:  MemoryStorage,
-		Subjects: []string{"*.*"},
-	}
-	ms, err := newMemStore(cfg)
-	require_NoError(t, err)
-
-	fmap := make(map[int]int)
-	bmap := make(map[int]int)
-
-	var m map[int]int
-	var ft string
-
-	for i := 0; i < 10_000; i++ {
-		// Flip coin for prefix
-		if rand.Intn(2) == 0 {
-			ft, m = "foo", fmap
-		} else {
-			ft, m = "bar", bmap
-		}
-		dt := rand.Intn(100)
-		subj := fmt.Sprintf("%s.%d", ft, dt)
-		m[dt]++
-
-		_, _, err := ms.StoreMsg(subj, nil, []byte("Hello World"))
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		cfg.Name = "TEST"
+		cfg.Subjects = []string{"*.*"}
+		ms, err := newMemStore(&cfg)
 		require_NoError(t, err)
-	}
 
-	// Now test SubjectsTotal
-	for dt, total := range fmap {
-		subj := fmt.Sprintf("foo.%d", dt)
-		m := ms.SubjectsTotals(subj)
-		if m[subj] != uint64(total) {
-			t.Fatalf("Expected %q to have %d total, got %d", subj, total, m[subj])
-		}
-	}
+		fmap := make(map[int]int)
+		bmap := make(map[int]int)
 
-	// Check fmap.
-	if st := ms.SubjectsTotals("foo.*"); len(st) != len(fmap) {
-		t.Fatalf("Expected %d subjects for %q, got %d", len(fmap), "foo.*", len(st))
-	} else {
-		expected := 0
-		for _, n := range fmap {
-			expected += n
-		}
-		received := uint64(0)
-		for _, n := range st {
-			received += n
-		}
-		if received != uint64(expected) {
-			t.Fatalf("Expected %d total but got %d", expected, received)
-		}
-	}
+		var m map[int]int
+		var ft string
 
-	// Check bmap.
-	if st := ms.SubjectsTotals("bar.*"); len(st) != len(bmap) {
-		t.Fatalf("Expected %d subjects for %q, got %d", len(bmap), "bar.*", len(st))
-	} else {
-		expected := 0
-		for _, n := range bmap {
-			expected += n
-		}
-		received := uint64(0)
-		for _, n := range st {
-			received += n
-		}
-		if received != uint64(expected) {
-			t.Fatalf("Expected %d total but got %d", expected, received)
-		}
-	}
+		for i := 0; i < 10_000; i++ {
+			// Flip coin for prefix
+			if rand.Intn(2) == 0 {
+				ft, m = "foo", fmap
+			} else {
+				ft, m = "bar", bmap
+			}
+			dt := rand.Intn(100)
+			subj := fmt.Sprintf("%s.%d", ft, dt)
+			m[dt]++
 
-	// All with pwc match.
-	if st, expected := ms.SubjectsTotals("*.*"), len(bmap)+len(fmap); len(st) != expected {
-		t.Fatalf("Expected %d subjects for %q, got %d", expected, "*.*", len(st))
-	}
+			_, _, err := ms.StoreMsg(subj, nil, []byte("Hello World"))
+			require_NoError(t, err)
+		}
+
+		// Now test SubjectsTotal
+		for dt, total := range fmap {
+			subj := fmt.Sprintf("foo.%d", dt)
+			m := ms.SubjectsTotals(subj)
+			if m[subj] != uint64(total) {
+				t.Fatalf("Expected %q to have %d total, got %d", subj, total, m[subj])
+			}
+		}
+
+		// Check fmap.
+		if st := ms.SubjectsTotals("foo.*"); len(st) != len(fmap) {
+			t.Fatalf("Expected %d subjects for %q, got %d", len(fmap), "foo.*", len(st))
+		} else {
+			expected := 0
+			for _, n := range fmap {
+				expected += n
+			}
+			received := uint64(0)
+			for _, n := range st {
+				received += n
+			}
+			if received != uint64(expected) {
+				t.Fatalf("Expected %d total but got %d", expected, received)
+			}
+		}
+
+		// Check bmap.
+		if st := ms.SubjectsTotals("bar.*"); len(st) != len(bmap) {
+			t.Fatalf("Expected %d subjects for %q, got %d", len(bmap), "bar.*", len(st))
+		} else {
+			expected := 0
+			for _, n := range bmap {
+				expected += n
+			}
+			received := uint64(0)
+			for _, n := range st {
+				received += n
+			}
+			if received != uint64(expected) {
+				t.Fatalf("Expected %d total but got %d", expected, received)
+			}
+		}
+
+		// All with pwc match.
+		if st, expected := ms.SubjectsTotals("*.*"), len(bmap)+len(fmap); len(st) != expected {
+			t.Fatalf("Expected %d subjects for %q, got %d", expected, "*.*", len(st))
+		}
+	})
 }
 
 func TestMemStoreNumPending(t *testing.T) {
-	cfg := &StreamConfig{
-		Name:     "TEST",
-		Storage:  MemoryStorage,
-		Subjects: []string{"*.*.*.*"},
-	}
-	ms, err := newMemStore(cfg)
-	require_NoError(t, err)
+	testMemStoreAllPermutations(t, func(t *testing.T, cfg StreamConfig) {
+		if cfg.Compression != NoCompression {
+			t.SkipNow() // This test is very very slow with compression for some reason
+		}
 
-	tokens := []string{"foo", "bar", "baz"}
-	genSubj := func() string {
-		return fmt.Sprintf("%s.%s.%s.%s",
-			tokens[rand.Intn(len(tokens))],
-			tokens[rand.Intn(len(tokens))],
-			tokens[rand.Intn(len(tokens))],
-			tokens[rand.Intn(len(tokens))],
-		)
-	}
-
-	for i := 0; i < 50_000; i++ {
-		subj := genSubj()
-		_, _, err := ms.StoreMsg(subj, nil, []byte("Hello World"))
+		cfg.Name = "TEST"
+		cfg.Subjects = []string{"*.*.*.*"}
+		ms, err := newMemStore(&cfg)
 		require_NoError(t, err)
-	}
 
-	state := ms.State()
-
-	// Scan one by one for sanity check against other calculations.
-	sanityCheck := func(sseq uint64, filter string) SimpleState {
-		t.Helper()
-		var ss SimpleState
-		var smv StoreMsg
-		// For here we know 0 is invalid, set to 1.
-		if sseq == 0 {
-			sseq = 1
+		tokens := []string{"foo", "bar", "baz"}
+		genSubj := func() string {
+			return fmt.Sprintf("%s.%s.%s.%s",
+				tokens[rand.Intn(len(tokens))],
+				tokens[rand.Intn(len(tokens))],
+				tokens[rand.Intn(len(tokens))],
+				tokens[rand.Intn(len(tokens))],
+			)
 		}
-		for seq := sseq; seq <= state.LastSeq; seq++ {
-			sm, err := ms.LoadMsg(seq, &smv)
-			if err != nil {
-				t.Logf("Encountered error %v loading sequence: %d", err, seq)
-				continue
+
+		for i := 0; i < 50_000; i++ {
+			subj := genSubj()
+			_, _, err := ms.StoreMsg(subj, nil, []byte("Hello World"))
+			require_NoError(t, err)
+		}
+
+		state := ms.State()
+
+		// Scan one by one for sanity check against other calculations.
+		sanityCheck := func(sseq uint64, filter string) SimpleState {
+			t.Helper()
+			var ss SimpleState
+			var smv StoreMsg
+			// For here we know 0 is invalid, set to 1.
+			if sseq == 0 {
+				sseq = 1
 			}
-			if subjectIsSubsetMatch(sm.subj, filter) {
-				ss.Msgs++
-				ss.Last = seq
-				if ss.First == 0 || seq < ss.First {
-					ss.First = seq
+			for seq := sseq; seq <= state.LastSeq; seq++ {
+				sm, err := ms.LoadMsg(seq, &smv)
+				if err != nil {
+					t.Logf("Encountered error %v loading sequence: %d", err, seq)
+					continue
 				}
-			}
-		}
-		return ss
-	}
-
-	check := func(sseq uint64, filter string) {
-		t.Helper()
-		np, lvs := ms.NumPending(sseq, filter, false)
-		ss := ms.FilteredState(sseq, filter)
-		sss := sanityCheck(sseq, filter)
-		if lvs != state.LastSeq {
-			t.Fatalf("Expected NumPending to return valid through last of %d but got %d", state.LastSeq, lvs)
-		}
-		if ss.Msgs != np {
-			t.Fatalf("NumPending of %d did not match ss.Msgs of %d", np, ss.Msgs)
-		}
-		if ss != sss {
-			t.Fatalf("Failed sanity check, expected %+v got %+v", sss, ss)
-		}
-	}
-
-	sanityCheckLastOnly := func(sseq uint64, filter string) SimpleState {
-		t.Helper()
-		var ss SimpleState
-		var smv StoreMsg
-		// For here we know 0 is invalid, set to 1.
-		if sseq == 0 {
-			sseq = 1
-		}
-		seen := make(map[string]bool)
-		for seq := state.LastSeq; seq >= sseq; seq-- {
-			sm, err := ms.LoadMsg(seq, &smv)
-			if err != nil {
-				t.Logf("Encountered error %v loading sequence: %d", err, seq)
-				continue
-			}
-			if !seen[sm.subj] && subjectIsSubsetMatch(sm.subj, filter) {
-				ss.Msgs++
-				if ss.Last == 0 {
+				if subjectIsSubsetMatch(sm.subj, filter) {
+					ss.Msgs++
 					ss.Last = seq
+					if ss.First == 0 || seq < ss.First {
+						ss.First = seq
+					}
 				}
-				if ss.First == 0 || seq < ss.First {
-					ss.First = seq
-				}
-				seen[sm.subj] = true
+			}
+			return ss
+		}
+
+		check := func(sseq uint64, filter string) {
+			t.Helper()
+			np, lvs := ms.NumPending(sseq, filter, false)
+			ss := ms.FilteredState(sseq, filter)
+			sss := sanityCheck(sseq, filter)
+			if lvs != state.LastSeq {
+				t.Fatalf("Expected NumPending to return valid through last of %d but got %d", state.LastSeq, lvs)
+			}
+			if ss.Msgs != np {
+				t.Fatalf("NumPending of %d did not match ss.Msgs of %d", np, ss.Msgs)
+			}
+			if ss != sss {
+				t.Fatalf("Failed sanity check, expected %+v got %+v", sss, ss)
 			}
 		}
-		return ss
-	}
 
-	checkLastOnly := func(sseq uint64, filter string) {
-		t.Helper()
-		np, lvs := ms.NumPending(sseq, filter, true)
-		ss := sanityCheckLastOnly(sseq, filter)
-		if lvs != state.LastSeq {
-			t.Fatalf("Expected NumPending to return valid through last of %d but got %d", state.LastSeq, lvs)
+		sanityCheckLastOnly := func(sseq uint64, filter string) SimpleState {
+			t.Helper()
+			var ss SimpleState
+			var smv StoreMsg
+			// For here we know 0 is invalid, set to 1.
+			if sseq == 0 {
+				sseq = 1
+			}
+			seen := make(map[string]bool)
+			for seq := state.LastSeq; seq >= sseq; seq-- {
+				sm, err := ms.LoadMsg(seq, &smv)
+				if err != nil {
+					t.Logf("Encountered error %v loading sequence: %d", err, seq)
+					continue
+				}
+				if !seen[sm.subj] && subjectIsSubsetMatch(sm.subj, filter) {
+					ss.Msgs++
+					if ss.Last == 0 {
+						ss.Last = seq
+					}
+					if ss.First == 0 || seq < ss.First {
+						ss.First = seq
+					}
+					seen[sm.subj] = true
+				}
+			}
+			return ss
 		}
-		if ss.Msgs != np {
-			t.Fatalf("NumPending of %d did not match ss.Msgs of %d", np, ss.Msgs)
-		}
-	}
 
-	startSeqs := []uint64{0, 1, 2, 200, 444, 555, 2222, 8888, 12_345, 28_222, 33_456, 44_400, 49_999}
-	checkSubs := []string{"foo.>", "*.bar.>", "foo.bar.*.baz", "*.bar.>", "*.foo.bar.*", "foo.foo.bar.baz"}
-
-	for _, filter := range checkSubs {
-		for _, start := range startSeqs {
-			check(start, filter)
-			checkLastOnly(start, filter)
+		checkLastOnly := func(sseq uint64, filter string) {
+			t.Helper()
+			np, lvs := ms.NumPending(sseq, filter, true)
+			ss := sanityCheckLastOnly(sseq, filter)
+			if lvs != state.LastSeq {
+				t.Fatalf("Expected NumPending to return valid through last of %d but got %d", state.LastSeq, lvs)
+			}
+			if ss.Msgs != np {
+				t.Fatalf("NumPending of %d did not match ss.Msgs of %d", np, ss.Msgs)
+			}
 		}
-	}
+
+		startSeqs := []uint64{0, 1, 2, 200, 444, 555, 2222, 8888, 12_345, 28_222, 33_456, 44_400, 49_999}
+		checkSubs := []string{"foo.>", "*.bar.>", "foo.bar.*.baz", "*.bar.>", "*.foo.bar.*", "foo.foo.bar.baz"}
+
+		for _, filter := range checkSubs {
+			for _, start := range startSeqs {
+				check(start, filter)
+				checkLastOnly(start, filter)
+			}
+		}
+	})
 }
 
 func TestMemStoreInitialFirstSeq(t *testing.T) {

--- a/server/store_compression.go
+++ b/server/store_compression.go
@@ -1,0 +1,182 @@
+// Copyright 2019-2023 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/klauspost/compress/s2"
+)
+
+type StoreCompression uint8
+
+const (
+	NoCompression StoreCompression = iota
+	S2Compression
+)
+
+func (alg StoreCompression) String() string {
+	switch alg {
+	case NoCompression:
+		return "None"
+	case S2Compression:
+		return "S2"
+	default:
+		return "Unknown StoreCompression"
+	}
+}
+
+func (alg StoreCompression) MarshalJSON() ([]byte, error) {
+	var str string
+	switch alg {
+	case S2Compression:
+		str = "s2"
+	case NoCompression:
+		str = "none"
+	default:
+		return nil, fmt.Errorf("unknown compression algorithm")
+	}
+	return json.Marshal(str)
+}
+
+func (alg *StoreCompression) UnmarshalJSON(b []byte) error {
+	var str string
+	if err := json.Unmarshal(b, &str); err != nil {
+		return err
+	}
+	switch str {
+	case "s2":
+		*alg = S2Compression
+	case "none":
+		*alg = NoCompression
+	default:
+		return fmt.Errorf("unknown compression algorithm")
+	}
+	return nil
+}
+
+type CompressionInfo struct {
+	Algorithm    StoreCompression
+	OriginalSize uint64
+}
+
+func (c *CompressionInfo) MarshalMetadata() []byte {
+	b := make([]byte, 14) // 4 + potentially up to 10 for uint64
+	b[0], b[1], b[2] = 'c', 'm', 'p'
+	b[3] = byte(c.Algorithm)
+	n := binary.PutUvarint(b[4:], c.OriginalSize)
+	return b[:4+n]
+}
+
+func (c *CompressionInfo) UnmarshalMetadata(b []byte) (int, error) {
+	c.Algorithm = NoCompression
+	c.OriginalSize = 0
+	if len(b) < 5 { // 4 + min 1 for uvarint uint64
+		return 0, nil
+	}
+	if b[0] != 'c' || b[1] != 'm' || b[2] != 'p' {
+		return 0, nil
+	}
+	var n int
+	c.Algorithm = StoreCompression(b[3])
+	c.OriginalSize, n = binary.Uvarint(b[4:])
+	if n <= 0 {
+		return 0, fmt.Errorf("metadata incomplete")
+	}
+	return 4 + n, nil
+}
+
+func (alg StoreCompression) Compress(buf []byte) ([]byte, error) {
+	var output bytes.Buffer
+	var writer io.WriteCloser
+	switch alg {
+	case NoCompression:
+		return buf, nil
+	case S2Compression:
+		writer = s2.NewWriter(&output)
+	default:
+		return nil, fmt.Errorf("compression algorithm not known")
+	}
+
+	// Compress the block content, but don't compress the checksum.
+	// We will preserve it at the end of the block as-is.
+	if n, err := io.Copy(writer, bytes.NewReader(buf)); err != nil {
+		return nil, fmt.Errorf("error writing to compression writer: %w", err)
+	} else if bodyLen := len(buf); n != int64(bodyLen) {
+		return nil, fmt.Errorf("short write on body (%d != %d)", n, bodyLen)
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("error closing compression writer: %w", err)
+	}
+
+	return output.Bytes(), nil
+}
+
+func (alg StoreCompression) Decompress(buf []byte) ([]byte, error) {
+	var reader io.ReadCloser
+	switch alg {
+	case NoCompression:
+		return buf, nil
+	case S2Compression:
+		reader = io.NopCloser(s2.NewReader(bytes.NewReader(buf)))
+	default:
+		return nil, fmt.Errorf("compression algorithm not known")
+	}
+
+	// Decompress the block content. The checksum isn't compressed so
+	// we can preserve it from the end of the block as-is.
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("error reading compression reader: %w", err)
+	}
+	if err := reader.Close(); err != nil {
+		return nil, fmt.Errorf("error closing compression reader: %w", err)
+	}
+
+	return output, nil
+}
+
+// CompressWithChecksum compresses the given buffer, preserving the checksum
+// bytes at the end of the buffer.
+func (alg StoreCompression) CompressWithChecksum(buf []byte) ([]byte, error) {
+	if len(buf) < checksumSize {
+		return nil, fmt.Errorf("uncompressed buffer is too short")
+	}
+	bodyLen := len(buf) - checksumSize
+	checksum := buf[bodyLen:]
+	compressed, err := alg.Compress(buf[:bodyLen])
+	if err != nil {
+		return nil, fmt.Errorf("error compressing: %w", err)
+	}
+	return append(compressed, checksum[:]...), nil
+}
+
+// DecompressWithChecksum decompresses the given buffer, preserving the checksum
+// bytes at the end of the buffer.
+func (alg StoreCompression) DecompressWithChecksum(buf []byte) ([]byte, error) {
+	if len(buf) < checksumSize {
+		return nil, fmt.Errorf("compressed buffer is too short")
+	}
+	bodyLen := len(buf) - checksumSize
+	checksum := buf[bodyLen:]
+	decompressed, err := alg.Decompress(buf[:bodyLen])
+	if err != nil {
+		return nil, fmt.Errorf("error decompressing: %w", err)
+	}
+	return append(decompressed, checksum[:]...), nil
+}


### PR DESCRIPTION
This PR adds compression support to the memory store. It is much simpler than that of the file store as it compresses on a per-message level rather than a per-block level, therefore it's expected that savings will be modest by comparison.

As the memory store was previously tracking the stream-level `max_bytes` accounting by using the size of the `msg` buffer, I've had to wrap the `StoreMsg` inside another struct which contains the original buffer size as well as the compression algorithm used. Otherwise the accounting goes wrong and the limits are not enforced correctly.

It also moves various functions and types for both file and memory store compression into their own file for clarity, and updated the memory store unit tests to include a compressed permutation, as we already did with the filestore tests.

Signed-off-by: Neil Twigg <neil@nats.io>