### PR TITLE
fix: clustered stream recovery, ensure PurgeEx is executed instead of full purge

### DIFF
--- a/server/store.go
+++ b/server/store.go
@@ -89,7 +89,7 @@ type StreamStore interface {
 	RemoveMsg(seq uint64) (bool, error)
 	EraseMsg(seq uint64) (bool, error)
 	Purge() (uint64, error)
-	PurgeEx(subject string, seq, keep uint64) (uint64, error)
+	PurgeEx(subject string, seq, keep, mseq uint64) (uint64, error)
 	Compact(seq uint64) (uint64, error)
 	Truncate(seq uint64) error
 	GetSeqFromTime(t time.Time) uint64

--- a/server/stream.go
+++ b/server/stream.go
@@ -1675,7 +1675,7 @@ func (mset *stream) purge(preq *JSApiStreamPurgeRequest) (purged uint64, err err
 	mset.mu.RUnlock()
 
 	if preq != nil {
-		purged, err = mset.store.PurgeEx(preq.Subject, preq.Sequence, preq.Keep)
+		purged, err = mset.store.PurgeEx(preq.Subject, preq.Sequence, preq.Keep, mset.lastSeq())
 	} else {
 		purged, err = mset.store.Purge()
 	}


### PR DESCRIPTION
 - [x] Link to issue, e.g. `Resolves #NNN`
 - [x] Documentation added (if applicable)
 - [x] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves https://github.com/nats-io/nats-server/issues/4196

### Changes proposed in this pull request:

I believe this is caused by the following code:

```go
// Ignore if we are recovering and we have already processed.
if isRecovering {
	if mset.State().FirstSeq <= sp.LastSeq {
		// Make sure all messages from the purge are gone.
		mset.store.Compact(sp.LastSeq + 1)
	}
	continue
}
```

Which was introduced in this PR: https://github.com/nats-io/nats-server/pull/1886

This was fine at the time, since at that point only full stream purges were supported. So this shortcut would not purge if was identified that it happened already.

However, since the introduction of more advanced purges in: https://github.com/nats-io/nats-server/pull/2296, purges can happen on: the whole stream, specific subjects, sequences, amount of messages to keep, etc.

But, this shortcut would always do a full stream purge on recovering, even if we only did a "partial" subject-based purge request.

This would result in any JetStream (/KV/OBJ) with partial purges to be fully purged upon restart of a node. Leading into inconsistent states across nodes, which can be observed when switching leaders.

This PR removes this shortcut, and just relies on the default purge-handling behaviour, added a test as well.