### PR TITLE
Annotate CPU and goroutine profiles

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -2373,7 +2373,14 @@ func (mset *stream) setupMirrorConsumer() error {
 				mirror.qch = make(chan struct{})
 				mirror.wg.Add(1)
 				ready.Add(1)
-				if !mset.srv.startGoRoutine(func() { mset.processMirrorMsgs(mirror, &ready) }) {
+				if !mset.srv.startGoRoutine(
+					func() { mset.processMirrorMsgs(mirror, &ready) },
+					pprofLabels{
+						"type":    "mirror",
+						"account": mset.acc.Name,
+						"stream":  mset.cfg.Name,
+					},
+				) {
 					ready.Done()
 				}
 			}
@@ -2671,7 +2678,14 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64, startTime time.T
 					si.qch = make(chan struct{})
 					si.wg.Add(1)
 					ready.Add(1)
-					if !mset.srv.startGoRoutine(func() { mset.processSourceMsgs(si, &ready) }) {
+					if !mset.srv.startGoRoutine(
+						func() { mset.processSourceMsgs(si, &ready) },
+						pprofLabels{
+							"type":    "source",
+							"account": mset.acc.Name,
+							"stream":  mset.cfg.Name,
+						},
+					) {
 						ready.Done()
 					}
 				}


### PR DESCRIPTION
This allows the CPU and goroutine profiles to be annotated with information that allows us to break down load based on accounts, streams and consumers. We could probably add more labels elsewhere for other purposes too. It makes it easier to spot whether there are certain assets that are responsible for heavy CPU usage, i.e. snapshotting certain stream states.

Signed-off-by: Neil Twigg <neil@nats.io>