### PR TITLE
[FIXED] Daisy chained leafnodes sometimes would not propagate interest

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -958,7 +958,7 @@ func (a *Account) isLeafNodeClusterIsolated(cluster string) bool {
 	if len(a.leafClusters) > 1 {
 		return false
 	}
-	return a.leafClusters[cluster] > 0
+	return a.leafClusters[cluster] == uint64(a.nleafs)
 }
 
 // Helper function to remove leaf nodes. If number of leafnodes gets large

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -436,8 +436,8 @@ func checkLeafNodeConnectedCount(t testing.TB, s *Server, lnCons int) {
 	t.Helper()
 	checkFor(t, 5*time.Second, 15*time.Millisecond, func() error {
 		if nln := s.NumLeafNodes(); nln != lnCons {
-			return fmt.Errorf("Expected %d connected leafnode(s) for server %q, got %d",
-				lnCons, s.ID(), nln)
+			return fmt.Errorf("Expected %d connected leafnode(s) for server %v, got %d",
+				lnCons, s, nln)
 		}
 		return nil
 	})


### PR DESCRIPTION
When we were optimizing for single cluster and large numbers of leafnodes we inadvertently broke a daisy chained scenario where a server was a spoke and a hub within a single hub server.

So interest on D would not propagate properly to server A as a publisher.

```
     B
   /    \
A       C -- D (SUB)
 |
PUB
```


