### PR TITLE
Initial support for zOS

### DIFF
--- a/server/pse/pse_zos.go
+++ b/server/pse/pse_zos.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build zos
+// +build zos
+
+package pse
+
+// This is a placeholder for now.
+func ProcUsage(pcpu *float64, rss, vss *int64) error {
+	*pcpu = 0.0
+	*rss = 0
+	*vss = 0
+
+	return nil
+}

--- a/server/pse/pse_zos.go
+++ b/server/pse/pse_zos.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The NATS Authors
+// Copyright 2023 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/server/sysmem/mem_zos.go
+++ b/server/sysmem/mem_zos.go
@@ -1,0 +1,22 @@
+// Copyright 2022 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build zos
+// +build zos
+
+package sysmem
+
+func Memory() int64 {
+	// TODO: We don't know the system memory
+	return 0
+}


### PR DESCRIPTION
zOS is an IBM Z (mainframe) operating system. In the days of yore, it was MVS.

 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves - the inability to build on zOS.

### Changes proposed in this pull request:

 - This PR adds a couple of files to allow building nats-server on zOS.

