### PR TITLE
Send peer state when adding peers

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -1474,12 +1474,6 @@ func (n *raft) Peers() []*Peer {
 // Update our known set of peers.
 func (n *raft) UpdateKnownPeers(knownPeers []string) {
 	n.Lock()
-	// If this is a scale up, let the normal add peer logic take precedence.
-	// Otherwise if the new peers are slow to start we stall ourselves.
-	if len(knownPeers) > len(n.peers) {
-		n.Unlock()
-		return
-	}
 	// Process like peer state update.
 	ps := &peerState{knownPeers, len(knownPeers), n.extSt}
 	n.processPeerState(ps)


### PR DESCRIPTION
Currently `UpdateKnownPeers` doesn't send a peer state when a single peer add operation is taking place, but it seems like this can potentially race when there are lots of changes to the replica count happening in rapid succession. Sending the peer state in all cases seems to fix this issue and, so far in my testing, fixes the failground stream update replicas test.

Signed-off-by: Neil Twigg <neil@nats.io>