### PR TITLE
Don't hold entire MQTT retained messages in memory

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -3219,11 +3219,7 @@ func (c *client) mqttHandlePubRetain() {
 				sseq: smr.Sequence,
 			}
 			// Add/update the map
-			oldSeq := asm.handleRetainedMsg(key, rf)
-			// If this is a new message on the same subject, delete the old one.
-			if oldSeq != 0 {
-				asm.deleteRetainedMsg(oldSeq)
-			}
+			asm.handleRetainedMsg(key, rf)
 		} else {
 			c.mu.Lock()
 			acc := c.acc

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -2975,8 +2975,8 @@ func TestMQTTRetainedMsgNetworkUpdates(t *testing.T) {
 		t.Run(test.subject, func(t *testing.T) {
 			for _, a := range test.order {
 				if a.add {
-					rm := &mqttRetainedMsg{sseq: a.seq}
-					asm.handleRetainedMsg(test.subject, rm)
+					rf := &mqttRetainedMsgRef{sseq: a.seq}
+					asm.handleRetainedMsg(test.subject, rf)
 				} else {
 					asm.handleRetainedMsgDel(test.subject, a.seq)
 				}
@@ -2988,8 +2988,8 @@ func TestMQTTRetainedMsgNetworkUpdates(t *testing.T) {
 	for _, subject := range []string{"foo.5", "foo.6"} {
 		t.Run("clear_"+subject, func(t *testing.T) {
 			// Now add a new message, which should clear the floor.
-			rm := &mqttRetainedMsg{sseq: 3}
-			asm.handleRetainedMsg(subject, rm)
+			rf := &mqttRetainedMsgRef{sseq: 3}
+			asm.handleRetainedMsg(subject, rf)
 			check(t, subject, true, 3, 0)
 			// Now do a non network delete and make sure it is gone.
 			asm.handleRetainedMsgDel(subject, 0)


### PR DESCRIPTION
This PR separates out the small amount of necessary metadata for retained messages (stream sequence, floor) from the message itself, instead accessing the messages themselves with KV-like access patterns.

This should save quite a bit of memory where there are lots of retained messages since we only now need to hold a small amount of metadata instead of the entire messages.

Signed-off-by: Neil Twigg <neil@nats.io>