### PR TITLE
Fixed issues with leafnode compression negotiation

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -3999,10 +3999,7 @@ func TestJetStreamClusterLeafnodePlusDaisyChainSetup(t *testing.T) {
 		server_name: %s
 		jetstream: {max_mem_store: 256MB, max_file_store: 2GB, domain: CLOUD, store_dir: '%s'}
 
-		leaf {
-			listen: 127.0.0.1:-1
-			compression: off
-		}
+		leaf { listen: 127.0.0.1:-1 }
 
 		cluster {
 			name: %s
@@ -4059,7 +4056,7 @@ func TestJetStreamClusterLeafnodePlusDaisyChainSetup(t *testing.T) {
 	var leafFrag = `
 			leaf {
 				listen: 127.0.0.1:-1
-				remotes [ { urls: [ %s ], account: "T", compression:off }, { urls: [ %s ], account: "F", compression: off } ]
+				remotes [ { urls: [ %s ], account: "T" }, { urls: [ %s ], account: "F" } ]
 			}`
 
 	genLeafTmpl := func(tmpl string, c *cluster) string {


### PR DESCRIPTION
When a server would send an asynchronous INFO to a remote server it would incorrectly contain compression information that could cause issues with one side thinking that the connection should be compressed while the other side was not.

It also caused the authentication timer to be incorrectly set which would cause a disconnect.

Signed-off-by: Ivan Kozlovic <ijkozlovic@gmail.com>
