### PR TITLE
[IMPROVED] Optimize statsz locking and sending in standalone mode.

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -870,9 +870,7 @@ func (s *Server) createGateway(cfg *gatewayCfg, url *url.URL, conn net.Conn) {
 
 	// Announce ourselves again to new connections.
 	if solicit && s.EventsEnabled() {
-		s.mu.Lock()
-		s.sendStatsz(fmt.Sprintf(serverStatsSubj, s.info.ID))
-		s.mu.Unlock()
+		s.sendStatszUpdate()
 	}
 }
 


### PR DESCRIPTION
If we know we are in stand alone mode only send out statsz updates if we know we have external interest.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves: #4234 