### PR TITLE
[CHANGED] LeafNode: remotes from same server binding to same hub account

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -624,6 +624,9 @@ type ClientOpts struct {
 	// Routes and Leafnodes only
 	Import *SubjectPermission `json:"import,omitempty"`
 	Export *SubjectPermission `json:"export,omitempty"`
+
+	// Leafnodes
+	RemoteAccount string `json:"remote_account,omitempty"`
 }
 
 var defaultOpts = ClientOpts{Verbose: true, Pedantic: true, Echo: true}


### PR DESCRIPTION
Previously, the server would reject a second remote leafnode connection from the same server if it was binding to the same account on the hub even if the remote was using different local accounts.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
