### PR TITLE
Adding option to disable jetstream ascii art

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -367,13 +367,16 @@ func (s *Server) enableJetStream(cfg JetStreamConfig) error {
 		s.SetDefaultSystemAccount()
 	}
 
-	s.Noticef("    _ ___ _____ ___ _____ ___ ___   _   __  __")
-	s.Noticef(" _ | | __|_   _/ __|_   _| _ \\ __| /_\\ |  \\/  |")
-	s.Noticef("| || | _|  | | \\__ \\ | | |   / _| / _ \\| |\\/| |")
-	s.Noticef(" \\__/|___| |_| |___/ |_| |_|_\\___/_/ \\_\\_|  |_|")
-	s.Noticef("")
-	s.Noticef("         https://docs.nats.io/jetstream")
-	s.Noticef("")
+	opts := s.getOpts()
+	if !opts.DisableJetStreamBanner {
+		s.Noticef("    _ ___ _____ ___ _____ ___ ___   _   __  __")
+		s.Noticef(" _ | | __|_   _/ __|_   _| _ \\ __| /_\\ |  \\/  |")
+		s.Noticef("| || | _|  | | \\__ \\ | | |   / _| / _ \\| |\\/| |")
+		s.Noticef(" \\__/|___| |_| |___/ |_| |_|_\\___/_/ \\_\\_|  |_|")
+		s.Noticef("")
+		s.Noticef("         https://docs.nats.io/jetstream")
+		s.Noticef("")
+	}
 	s.Noticef("---------------- JETSTREAM ----------------")
 	s.Noticef("  Max Memory:      %s", friendlyBytes(cfg.MaxMemory))
 	s.Noticef("  Max Storage:     %s", friendlyBytes(cfg.MaxStore))
@@ -381,7 +384,7 @@ func (s *Server) enableJetStream(cfg JetStreamConfig) error {
 	if cfg.Domain != _EMPTY_ {
 		s.Noticef("  Domain:          %s", cfg.Domain)
 	}
-	opts := s.getOpts()
+
 	if ek := opts.JetStreamKey; ek != _EMPTY_ {
 		s.Noticef("  Encryption:      %s", opts.JetStreamCipher)
 	}

--- a/server/opts.go
+++ b/server/opts.go
@@ -347,6 +347,9 @@ type Options struct {
 	// CheckConfig configuration file syntax test was successful and exit.
 	CheckConfig bool `json:"-"`
 
+	// DisableJetStreamBanner will not print the ascii art on startup for JetStream enabled servers
+	DisableJetStreamBanner bool `json:"-"`
+
 	// ConnectErrorReports specifies the number of failed attempts
 	// at which point server should report the failure of an initial
 	// connection to a route, gateway or leaf node.


### PR DESCRIPTION
This option is not available in the config, and is only accessable to embeded servers where when using custom loggers can look pretty terrible

 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

### Changes proposed in this pull request:

 - Add ability to disable the jetstream ascii art banner on embeded servers as when using custom logging skews the ascii art.

```
INFO[2023-06-20T21:00:54-07:00] Starting JetStream                           
INFO[2023-06-20T21:00:54-07:00] _ ___ _____ ___ _____ ___ ___   _   __  __   
INFO[2023-06-20T21:00:54-07:00] _ | | __|_   _/ __|_   _| _ \ __| /_\ |  \/  | 
INFO[2023-06-20T21:00:54-07:00] | || | _|  | | \__ \ | | |   / _| / _ \| |\/| | 
INFO[2023-06-20T21:00:54-07:00] \__/|___| |_| |___/ |_| |_|_\___/_/ \_\_|  |_| 
INFO[2023-06-20T21:00:54-07:00]                                              
INFO[2023-06-20T21:00:54-07:00] https://docs.nats.io/jetstream               
INFO[2023-06-20T21:00:54-07:00]                                          
```
