### PR TITLE
Adjust nightly name if on a branch

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -20,10 +20,10 @@ dockers:
     skip_push: true
     dockerfile: docker/Dockerfile.nightly
     build_flag_templates:
-      - '--build-arg=VERSION=nightly-{{ time "20060102" }}'
+      - '--build-arg=VERSION={{ if index .Env "IMAGE_NAME"  }}{{ .Env.IMAGE_NAME }}{{ else if not (eq .Branch "main" "dev" "") }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}'
     image_templates:
       - synadia/nats-server:{{.Version}}
-      - synadia/nats-server:nightly
+      - synadia/nats-server:{{ if index .Env "IMAGE_NAME"  }}{{ .Env.IMAGE_NAME }}{{ else if not (eq .Branch "main" "dev" "") }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}
     extra_files:
       - docker/nats-server.conf
 
@@ -32,4 +32,4 @@ checksum:
   algorithm: sha256
 
 snapshot:
-  name_template: 'nightly-{{ time "20060102" }}'
+  name_template: '{{ if index .Env "IMAGE_NAME"  }}{{ .Env.IMAGE_NAME }}{{ else if not (eq .Branch "main" "dev" "") }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}'


### PR DESCRIPTION
If we're on a branch other than main or dev, then when building "nightly", build it with the name of the branch instead.  Overrideable via an env var.

It's a bit ugly because of limitations of goreleaser templating, we can't haul the expression out to be defined once, but it works.

Can build a custom Docker image with:

    goreleaser release --snapshot -p 2 -f .goreleaser-nightly.yml --clean