### PR TITLE
Use an account protected method to check for service imports for Gateways.

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -2953,7 +2953,7 @@ func (c *client) processInboundGatewayMsg(msg []byte) {
 	// Check if this is a service reply subject (_R_)
 	noInterest := len(r.psubs) == 0
 	checkNoInterest := true
-	if acc.imports.services != nil {
+	if acc.NumServiceImports() > 0 {
 		if isServiceReply(c.pa.subject) {
 			checkNoInterest = false
 		} else {


### PR DESCRIPTION
This avoids a potential data race when reloading accounts.

Signed-off-by: Derek Collison <derek@nats.io>