### PR TITLE
Add support for filtering Connections by client kind (Client, Leafnode etc)

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -384,7 +384,7 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 				}
 
 				// Do client kind filtering
-				if kind != _EMPTY_ && client.kindString() != kind {
+				if kind != _EMPTY_ && !strings.EqualFold(client.kindString(), kind) {
 					continue
 				}
 


### PR DESCRIPTION
This PR adds support for `kind` in `*ConnzOptions`, which allows a `Connz` user to filter returned connections by it's `kind` field, namely `Client` or `Leafnode`.

This should help monitoring solutions better separate leaf node and regular client connections.
