### PR TITLE
Do not start up if failing to open `_META_` store or unable to decrypt encrypted stream meta files

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1241,7 +1241,7 @@ func (a *Account) EnableJetStream(limits map[string]JetStreamAccountLimits) erro
 					osc, convertingCiphers = ChaCha, true
 				}
 				if err != nil {
-					s.Warnf("  Error decrypting our stream metafile: %v", err)
+					s.Fatalf("  Error decrypting our stream metafile: %v", err)
 					continue
 				}
 			}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -756,7 +756,7 @@ func (js *jetStream) setupMetaGroup() error {
 		s.jsKeyGen(defaultMetaGroupName),
 	)
 	if err != nil {
-		s.Errorf("Error creating filestore: %v", err)
+		s.Fatalf("Error creating filestore: %v", err)
 		return err
 	}
 	// Register our server.


### PR DESCRIPTION
It's probably better to do this when we can't decrypt (i.e. because the encryption config has disappeared from under us) so that we don't lose data by recreating assets.

Signed-off-by: Neil Twigg <neil@nats.io>