### PR TITLE
[FIXED] Restore of encrypted filestore with no main key could cause dataloss

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -759,6 +759,7 @@ func (js *jetStream) setupMetaGroup() error {
 		s.Errorf("Error creating filestore: %v", err)
 		return err
 	}
+
 	// Register our server.
 	fs.registerServer(s)
 


### PR DESCRIPTION
When restoring a filestore with no key generator but it was encrypted, fail to restore.

Signed-off-by: Derek Collison <derek@nats.io>

