### PR TITLE
Evaluate service imports when publishing advisories

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3127,8 +3127,8 @@ var needFlush = struct{}{}
 // deliverMsg will deliver a message to a matching subscription and its underlying client.
 // We process all connection/client types. mh is the part that will be protocol/client specific.
 func (c *client) deliverMsg(prodIsMQTT bool, sub *subscription, acc *Account, subject, reply, mh, msg []byte, gwrply bool) bool {
-	// Check sub client and check echo. Only do this if not an internal sub.
-	if sub.client == nil || (c == sub.client && !sub.client.echo && sub.icb == nil) {
+	// Check sub client and check echo. Only do this if not a service import.
+	if sub.client == nil || (c == sub.client && !sub.client.echo && !sub.si) {
 		return false
 	}
 

--- a/server/client.go
+++ b/server/client.go
@@ -3127,19 +3127,13 @@ var needFlush = struct{}{}
 // deliverMsg will deliver a message to a matching subscription and its underlying client.
 // We process all connection/client types. mh is the part that will be protocol/client specific.
 func (c *client) deliverMsg(prodIsMQTT bool, sub *subscription, acc *Account, subject, reply, mh, msg []byte, gwrply bool) bool {
-	// Check sub client and check echo
-	if sub.client == nil || c == sub.client && !sub.client.echo {
+	// Check sub client and check echo. Only do this if not an internal sub.
+	if sub.client == nil || (c == sub.client && !sub.client.echo && sub.icb == nil) {
 		return false
 	}
 
 	client := sub.client
 	client.mu.Lock()
-
-	// Check echo
-	if c == client && !client.echo {
-		client.mu.Unlock()
-		return false
-	}
 
 	// Check if we have a subscribe deny clause. This will trigger us to check the subject
 	// for a match against the denied subjects.


### PR DESCRIPTION
This should fix #4275 by allowing advisories to be copied into other accounts via service imports.

Signed-off-by: Neil Twigg <neil@nats.io>