### PR TITLE
Add `first_seq` to `StreamConfig`

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -417,12 +417,11 @@ func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created tim
 	}
 
 	// If the stream has an initial sequence number then make sure we
-	// have purged up until that point. Checking the number of blocks
-	// is a cheap way of checking if the stream looks new-ish, rather
-	// than re-running a potentially expensive set of dirty closes on
-	// an existing stream. A new stream should have 1 block (as the
-	// lmb has already been created) but account for 0 just in case.
-	if len(fs.blks) <= 1 && cfg.FirstSeq > 0 {
+	// have purged up until that point. We will do this only if the
+	// recovered first sequence number is before our configured first
+	// sequence.
+	fs.FastState(&fs.state)
+	if cfg.FirstSeq > 0 && fs.state.FirstSeq <= cfg.FirstSeq {
 		if _, err := fs.purge(cfg.FirstSeq); err != nil {
 			return nil, err
 		}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -45,6 +45,9 @@ func newMemStore(cfg *StreamConfig) (*memStore, error) {
 	if cfg.Storage != MemoryStorage {
 		return nil, fmt.Errorf("memStore requires memory storage type in config")
 	}
+	if cfg.FirstSeq > 0 {
+		return nil, fmt.Errorf("setting the initial sequence is not supported by memory store")
+	}
 	ms := &memStore{
 		msgs: make(map[uint64]*StoreMsg),
 		fss:  make(map[string]*SimpleState),

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -45,14 +45,16 @@ func newMemStore(cfg *StreamConfig) (*memStore, error) {
 	if cfg.Storage != MemoryStorage {
 		return nil, fmt.Errorf("memStore requires memory storage type in config")
 	}
-	if cfg.FirstSeq > 0 {
-		return nil, fmt.Errorf("setting the initial sequence is not supported by memory store")
-	}
 	ms := &memStore{
 		msgs: make(map[uint64]*StoreMsg),
 		fss:  make(map[string]*SimpleState),
 		maxp: cfg.MaxMsgsPer,
 		cfg:  *cfg,
+	}
+	if cfg.FirstSeq > 0 {
+		if _, err := ms.purge(cfg.FirstSeq); err != nil {
+			return nil, err
+		}
 	}
 
 	return ms, nil
@@ -669,11 +671,22 @@ func (ms *memStore) PurgeEx(subject string, sequence, keep uint64) (purged uint6
 // Purge will remove all messages from this store.
 // Will return the number of purged messages.
 func (ms *memStore) Purge() (uint64, error) {
+	ms.mu.RLock()
+	first := ms.state.LastSeq + 1
+	ms.mu.RUnlock()
+	return ms.purge(first)
+}
+
+func (ms *memStore) purge(fseq uint64) (uint64, error) {
 	ms.mu.Lock()
 	purged := uint64(len(ms.msgs))
 	cb := ms.scb
 	bytes := int64(ms.state.Bytes)
-	ms.state.FirstSeq = ms.state.LastSeq + 1
+	if fseq < ms.state.LastSeq {
+		return 0, fmt.Errorf("partial purges not supported on memory store")
+	}
+	ms.state.FirstSeq = fseq
+	ms.state.LastSeq = fseq - 1
 	ms.state.FirstTime = time.Time{}
 	ms.state.Bytes = 0
 	ms.state.Msgs = 0

--- a/server/stream.go
+++ b/server/stream.go
@@ -58,6 +58,7 @@ type StreamConfig struct {
 	Mirror       *StreamSource    `json:"mirror,omitempty"`
 	Sources      []*StreamSource  `json:"sources,omitempty"`
 	Compression  StoreCompression `json:"compression"`
+	FirstSeq     uint64           `json:"first_seq,omitempty"`
 
 	// Allow applying a subject transform to incoming messages before doing anything else
 	SubjectTransform *SubjectTransformConfig `json:"subject_transform,omitempty"`


### PR DESCRIPTION
This allows specifying `first_seq` in the stream config when creating a stream. 

Signed-off-by: Neil Twigg <neil@nats.io>