### PR TITLE
Don't require TLS for in-process connection

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2617,6 +2617,13 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 		info.AuthRequired = false
 	}
 
+	// Check to see if this is an in-process connection with tls_required.
+	// If so, set as not required, but available.
+	if inProcess && info.TLSRequired {
+		info.TLSRequired = false
+		info.TLSAvailable = true
+	}
+
 	s.totalClients++
 	s.mu.Unlock()
 
@@ -2667,7 +2674,7 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 	}
 	s.clients[c.cid] = c
 
-	tlsRequired := info.TLSRequired && !inProcess
+	tlsRequired := info.TLSRequired
 	s.mu.Unlock()
 
 	// Re-Grab lock

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -72,6 +72,26 @@ func TestTLSConnection(t *testing.T) {
 	}
 }
 
+// TestTLSInProcessConnection checks that even if TLS is enabled on the server,
+// that an in-process connection that does *not* use TLS still connects successfully.
+func TestTLSInProcessConnection(t *testing.T) {
+	srv, opts := RunServerWithConfig("./configs/tls.conf")
+	defer srv.Shutdown()
+
+	nc, err := nats.Connect("", nats.InProcessServer(srv), nats.UserInfo(opts.Username, opts.Password))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if nc.TLSRequired() {
+		t.Fatalf("Shouldn't have required TLS for in-process connection")
+	}
+
+	if _, err = nc.TLSConnectionState(); err == nil {
+		t.Fatal("Should have got an error retrieving TLS connection state")
+	}
+}
+
 func TestTLSClientCertificate(t *testing.T) {
 	srv, opts := RunServerWithConfig("./configs/tlsverify.conf")
 	defer srv.Shutdown()


### PR DESCRIPTION
This should fix a bug where in-process connections expect TLS over the `net.Pipe` if TLS is configured.

Signed-off-by: Neil Twigg <neil@nats.io>