### PR TITLE
v2.11: Add digest to represent configuration state

### DIFF
--- a/conf/parse.go
+++ b/conf/parse.go
@@ -26,6 +26,7 @@ package conf
 // see parse_test.go for more examples.
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -35,6 +36,8 @@ import (
 	"time"
 	"unicode"
 )
+
+const _EMPTY_ = ""
 
 type parser struct {
 	mapping map[string]any
@@ -108,6 +111,44 @@ func ParseFileWithChecks(fp string) (map[string]any, error) {
 	return p.mapping, nil
 }
 
+// cleanupUsedEnvVars will recursively remove all already used
+// environment variables which might be in the parsed tree.
+func cleanupUsedEnvVars(m map[string]interface{}) {
+	for k, v := range m {
+		t := v.(*token)
+		if t.usedVariable {
+			delete(m, k)
+			continue
+		}
+		// Cleanup any other env var that is still in the map.
+		if tm, ok := t.value.(map[string]interface{}); ok {
+			cleanupUsedEnvVars(tm)
+		}
+	}
+}
+
+// ParseWithDigest returns the processed config and a digest
+// that represents the configuration.
+func ParseWithDigest(fp string) (map[string]interface{}, string, error) {
+	data, err := os.ReadFile(fp)
+	if err != nil {
+		return nil, _EMPTY_, err
+	}
+	p, err := parse(string(data), fp, true)
+	if err != nil {
+		return nil, _EMPTY_, err
+	}
+	// Filter out any environment variables before taking the digest.
+	cleanupUsedEnvVars(p.mapping)
+	digest := sha256.New()
+	e := json.NewEncoder(digest)
+	err = e.Encode(p.mapping)
+	if err != nil {
+		return nil, _EMPTY_, err
+	}
+	return p.mapping, fmt.Sprintf("sha256:%x", digest.Sum(nil)), nil
+}
+
 type token struct {
 	item         item
 	value        any
@@ -116,10 +157,15 @@ type token struct {
 }
 
 func (t *token) MarshalJSON() ([]byte, error) {
+	// Do not duplicate variable contents since
+	// they already have been expanded at this point.
+	if t.usedVariable {
+		return []byte("null"), nil
+	}
 	return json.Marshal(t.value)
 }
 
-func (t *token) Value() any {
+func (t *token) Value() interface{} {
 	return t.value
 }
 

--- a/conf/parse.go
+++ b/conf/parse.go
@@ -113,7 +113,7 @@ func ParseFileWithChecks(fp string) (map[string]any, error) {
 
 // cleanupUsedEnvVars will recursively remove all already used
 // environment variables which might be in the parsed tree.
-func cleanupUsedEnvVars(m map[string]interface{}) {
+func cleanupUsedEnvVars(m map[string]any) {
 	for k, v := range m {
 		t := v.(*token)
 		if t.usedVariable {
@@ -121,7 +121,7 @@ func cleanupUsedEnvVars(m map[string]interface{}) {
 			continue
 		}
 		// Cleanup any other env var that is still in the map.
-		if tm, ok := t.value.(map[string]interface{}); ok {
+		if tm, ok := t.value.(map[string]any); ok {
 			cleanupUsedEnvVars(tm)
 		}
 	}
@@ -129,7 +129,7 @@ func cleanupUsedEnvVars(m map[string]interface{}) {
 
 // ParseFileWithChecksDigest returns the processed config and a digest
 // that represents the configuration.
-func ParseFileWithChecksDigest(fp string) (map[string]interface{}, string, error) {
+func ParseFileWithChecksDigest(fp string) (map[string]any, string, error) {
 	data, err := os.ReadFile(fp)
 	if err != nil {
 		return nil, _EMPTY_, err
@@ -157,15 +157,10 @@ type token struct {
 }
 
 func (t *token) MarshalJSON() ([]byte, error) {
-	// Do not duplicate variable contents since
-	// they already have been expanded at this point.
-	if t.usedVariable {
-		return []byte("null"), nil
-	}
 	return json.Marshal(t.value)
 }
 
-func (t *token) Value() interface{} {
+func (t *token) Value() any {
 	return t.value
 }
 

--- a/conf/parse.go
+++ b/conf/parse.go
@@ -127,9 +127,9 @@ func cleanupUsedEnvVars(m map[string]interface{}) {
 	}
 }
 
-// ParseWithDigest returns the processed config and a digest
+// ParseFileWithChecksDigest returns the processed config and a digest
 // that represents the configuration.
-func ParseWithDigest(fp string) (map[string]interface{}, string, error) {
+func ParseFileWithChecksDigest(fp string) (map[string]interface{}, string, error) {
 	data, err := os.ReadFile(fp)
 	if err != nil {
 		return nil, _EMPTY_, err

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -874,3 +874,143 @@ func TestBlocks(t *testing.T) {
 		})
 	}
 }
+
+func TestParseDigest(t *testing.T) {
+	for _, test := range []struct {
+		input    string
+		includes map[string]string
+		digest   string
+	}{
+		{
+			`foo = bar`,
+			nil,
+			"sha256:226e49e13d16e5e8aa0d62e58cd63361bf097d3e2b2444aa3044334628a2e8de",
+		},
+		{
+			`# Comments and whitespace have no effect
+                        foo = bar
+                        `,
+			nil,
+			"sha256:226e49e13d16e5e8aa0d62e58cd63361bf097d3e2b2444aa3044334628a2e8de",
+		},
+		{
+			`# Syntax changes have no effect
+                        'foo': 'bar'
+                        `,
+			nil,
+			"sha256:226e49e13d16e5e8aa0d62e58cd63361bf097d3e2b2444aa3044334628a2e8de",
+		},
+		{
+			`# Syntax changes have no effect
+                        { 'foo': 'bar' }
+                        `,
+			nil,
+			"sha256:226e49e13d16e5e8aa0d62e58cd63361bf097d3e2b2444aa3044334628a2e8de",
+		},
+		{
+			`# substitutions
+                        BAR_USERS = { users = [ {user = "bar"} ]}
+                        hello = 'world'
+                        accounts {
+                          QUUX_USERS = [ { user: quux }]
+                          bar = $BAR_USERS
+                          quux = { users = $QUUX_USERS }
+                        }
+                        very { nested { env { VAR = 'NESTED', quux = $VAR }}}
+                        `,
+			nil,
+			"sha256:34f8faf3f269fe7509edc4742f20c8c4a7ad51fe21f8b361764314b533ac3ab5",
+		},
+		{
+			`# substitutions, same as previous one without env vars.
+                        hello = 'world'
+                        accounts {
+                          bar  = { users = [ { user = "bar" } ]}
+                          quux = { users = [ { user: quux   } ]}
+                        }
+                        very { nested { env { quux = 'NESTED' }}}
+                        `,
+			nil,
+			"sha256:34f8faf3f269fe7509edc4742f20c8c4a7ad51fe21f8b361764314b533ac3ab5",
+		},
+		{
+			`# substitutions
+                        BAR_USERS = { users = [ {user = "foo"} ]}
+                        bar = $BAR_USERS
+                        accounts {
+                          users = $BAR_USERS
+                        }
+                        `,
+			nil,
+			"sha256:f5d943b4ed22b80c6199203f8a7eaa8eb68ef7b2d46ef6b1b26f05e21f8beb13",
+		},
+		{
+			`# substitutions
+                        bar = { users = [ {user = "foo"} ]}
+                        accounts {
+                          users = { users = [ {user = "foo"} ]}
+                        }
+                        `,
+			nil,
+			"sha256:f5d943b4ed22b80c6199203f8a7eaa8eb68ef7b2d46ef6b1b26f05e21f8beb13",
+		},
+		{
+			`# includes
+			accounts {
+                          foo { include 'foo.conf'}
+                          bar { users = [{user = "bar"}] }
+                          quux { include 'quux.conf'}
+                        }
+                        `,
+			map[string]string{
+				"foo.conf":  ` users = [{user = "foo"}]`,
+				"quux.conf": ` users = [{user = "quux"}]`,
+			},
+			"sha256:e72d70c91b64b0f880f86decb95ec2600cbdcf8bdcd2355fce5ebc54a84a77e9",
+		},
+		{
+			`# includes
+			accounts {
+                          foo { include 'foo.conf'}
+                          bar { include 'bar.conf'}
+                          quux { include 'quux.conf'}
+                        }
+                        `,
+			map[string]string{
+				"foo.conf":  ` users = [{user = "foo"}]`,
+				"bar.conf":  ` users = [{user = "bar"}]`,
+				"quux.conf": ` users = [{user = "quux"}]`,
+			},
+			"sha256:e72d70c91b64b0f880f86decb95ec2600cbdcf8bdcd2355fce5ebc54a84a77e9",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			sdir := t.TempDir()
+			f, err := os.CreateTemp(sdir, "nats.conf-")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(f.Name(), []byte(test.input), 066); err != nil {
+				t.Error(err)
+			}
+			if test.includes != nil {
+				for includeFile, contents := range test.includes {
+					inf, err := os.Create(filepath.Join(sdir, includeFile))
+					if err != nil {
+						t.Fatal(err)
+					}
+					if err := os.WriteFile(inf.Name(), []byte(contents), 066); err != nil {
+						t.Error(err)
+					}
+				}
+			}
+			_, digest, err := ParseWithDigest(f.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if digest != test.digest {
+				t.Errorf("\ngot: %s\nexpected: %s", digest, test.digest)
+			}
+		})
+	}
+}

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -1004,7 +1004,7 @@ func TestParseDigest(t *testing.T) {
 					}
 				}
 			}
-			_, digest, err := ParseWithDigest(f.Name())
+			_, digest, err := ParseFileWithChecksDigest(f.Name())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func main() {
 	if err != nil {
 		server.PrintAndDie(fmt.Sprintf("%s: %s", exe, err))
 	} else if opts.CheckConfig {
-		fmt.Fprintf(os.Stderr, "%s: configuration file %s is valid\n", exe, opts.ConfigFile)
+		fmt.Fprintf(os.Stderr, "%s: configuration file %s is valid (%s)\n", exe, opts.ConfigFile, opts.ConfigDigest)
 		os.Exit(0)
 	}
 
@@ -120,7 +120,7 @@ func main() {
 		server.PrintAndDie(fmt.Sprintf("%s: %s", exe, err))
 	}
 
-	// Configure the logger based on the flags
+	// Configure the logger based on the flags.
 	s.ConfigureLogger()
 
 	// Start things up. Block here until done.

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func main() {
 	if err != nil {
 		server.PrintAndDie(fmt.Sprintf("%s: %s", exe, err))
 	} else if opts.CheckConfig {
-		fmt.Fprintf(os.Stderr, "%s: configuration file %s is valid (%s)\n", exe, opts.ConfigFile, opts.Digest())
+		fmt.Fprintf(os.Stderr, "%s: configuration file %s is valid (%s)\n", exe, opts.ConfigFile, opts.ConfigDigest())
 		os.Exit(0)
 	}
 

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func main() {
 	if err != nil {
 		server.PrintAndDie(fmt.Sprintf("%s: %s", exe, err))
 	} else if opts.CheckConfig {
-		fmt.Fprintf(os.Stderr, "%s: configuration file %s is valid (%s)\n", exe, opts.ConfigFile, opts.ConfigDigest)
+		fmt.Fprintf(os.Stderr, "%s: configuration file %s is valid (%s)\n", exe, opts.ConfigFile, opts.Digest())
 		os.Exit(0)
 	}
 

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1672,7 +1672,7 @@ func (s *Server) updateVarzConfigReloadableFields(v *Varz) {
 	v.TLSTimeout = opts.TLSTimeout
 	v.WriteDeadline = opts.WriteDeadline
 	v.ConfigLoadTime = s.configTime.UTC()
-	v.ConfigDigest = opts.ConfigDigest
+	v.ConfigDigest = opts.configDigest
 	// Update route URLs if applicable
 	if s.varzUpdateRouteURLs {
 		v.Cluster.URLs = urlsToStrings(opts.Routes)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1217,6 +1217,7 @@ type Varz struct {
 	Subscriptions         uint32                 `json:"subscriptions"`
 	HTTPReqStats          map[string]uint64      `json:"http_req_stats"`
 	ConfigLoadTime        time.Time              `json:"config_load_time"`
+	ConfigDigest          string                 `json:"config_digest"`
 	Tags                  jwt.TagList            `json:"tags,omitempty"`
 	TrustedOperatorsJwt   []string               `json:"trusted_operators_jwt,omitempty"`
 	TrustedOperatorsClaim []*jwt.OperatorClaims  `json:"trusted_operators_claim,omitempty"`
@@ -1671,6 +1672,7 @@ func (s *Server) updateVarzConfigReloadableFields(v *Varz) {
 	v.TLSTimeout = opts.TLSTimeout
 	v.WriteDeadline = opts.WriteDeadline
 	v.ConfigLoadTime = s.configTime.UTC()
+	v.ConfigDigest = opts.ConfigDigest
 	// Update route URLs if applicable
 	if s.varzUpdateRouteURLs {
 		v.Cluster.URLs = urlsToStrings(opts.Routes)

--- a/server/opts.go
+++ b/server/opts.go
@@ -914,7 +914,8 @@ func (o *Options) ProcessConfigString(data string) error {
 	return o.processConfigFile(_EMPTY_, m)
 }
 
-func (o *Options) Digest() string {
+// ConfigDigest returns the digest representing the configuration.
+func (o *Options) ConfigDigest() string {
 	return o.configDigest
 }
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -449,6 +449,9 @@ type Options struct {
 
 	// Used to mark that we had a top level authorization block.
 	authBlockDefined bool
+
+	// ConfigDigest represents the state of configuration.
+	ConfigDigest string
 }
 
 // WebsocketOpts are options for websocket
@@ -891,10 +894,11 @@ func (o *Options) ProcessConfigFile(configFile string) error {
 	if configFile == _EMPTY_ {
 		return nil
 	}
-	m, err := conf.ParseFileWithChecks(configFile)
+	m, digest, err := conf.ParseWithDigest(configFile)
 	if err != nil {
 		return err
 	}
+	o.ConfigDigest = digest
 
 	return o.processConfigFile(configFile, m)
 }

--- a/server/opts.go
+++ b/server/opts.go
@@ -450,8 +450,8 @@ type Options struct {
 	// Used to mark that we had a top level authorization block.
 	authBlockDefined bool
 
-	// ConfigDigest represents the state of configuration.
-	ConfigDigest string
+	// configDigest represents the state of configuration.
+	configDigest string
 }
 
 // WebsocketOpts are options for websocket
@@ -898,7 +898,7 @@ func (o *Options) ProcessConfigFile(configFile string) error {
 	if err != nil {
 		return err
 	}
-	o.ConfigDigest = digest
+	o.configDigest = digest
 
 	return o.processConfigFile(configFile, m)
 }
@@ -912,6 +912,10 @@ func (o *Options) ProcessConfigString(data string) error {
 	}
 
 	return o.processConfigFile(_EMPTY_, m)
+}
+
+func (o *Options) Digest() string {
+	return o.configDigest
 }
 
 func (o *Options) processConfigFile(configFile string, m map[string]any) error {

--- a/server/opts.go
+++ b/server/opts.go
@@ -894,7 +894,7 @@ func (o *Options) ProcessConfigFile(configFile string) error {
 	if configFile == _EMPTY_ {
 		return nil
 	}
-	m, digest, err := conf.ParseWithDigest(configFile)
+	m, digest, err := conf.ParseFileWithChecksDigest(configFile)
 	if err != nil {
 		return err
 	}

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -121,7 +121,7 @@ func TestConfigFile(t *testing.T) {
 		LameDuckDuration:      4 * time.Minute,
 		ConnectErrorReports:   86400,
 		ReconnectErrorReports: 5,
-		ConfigDigest:          "sha256:314adbd9997c1183f028f5b620362daa45893da76bac746136bfb48b2fd14996",
+		configDigest:          "sha256:314adbd9997c1183f028f5b620362daa45893da76bac746136bfb48b2fd14996",
 		authBlockDefined:      true,
 	}
 
@@ -143,7 +143,7 @@ func TestTLSConfigFile(t *testing.T) {
 		AuthTimeout:      1.0,
 		TLSTimeout:       2.0,
 		authBlockDefined: true,
-		ConfigDigest:     "sha256:cec986d37d7c09c86916d1ba4990cea1b8dadd49c86f9f782b455b47d07c2ac8",
+		configDigest:     "sha256:cec986d37d7c09c86916d1ba4990cea1b8dadd49c86f9f782b455b47d07c2ac8",
 	}
 	opts, err := ProcessConfigFile("./configs/tls.conf")
 	if err != nil {
@@ -289,7 +289,7 @@ func TestMergeOverrides(t *testing.T) {
 		ConnectErrorReports:   86400,
 		ReconnectErrorReports: 5,
 		authBlockDefined:      true,
-		ConfigDigest:          "sha256:314adbd9997c1183f028f5b620362daa45893da76bac746136bfb48b2fd14996",
+		configDigest:          "sha256:314adbd9997c1183f028f5b620362daa45893da76bac746136bfb48b2fd14996",
 	}
 	fopts, err := ProcessConfigFile("./configs/test.conf")
 	if err != nil {
@@ -367,7 +367,7 @@ func TestRouteFlagOverride(t *testing.T) {
 		},
 		Routes:       []*url.URL{rurl},
 		RoutesStr:    routeFlag,
-		ConfigDigest: "sha256:fe3c13f82637723989a9bbd0ad6d064b95d48971666af440d4196d9c0d3af979",
+		configDigest: "sha256:fe3c13f82637723989a9bbd0ad6d064b95d48971666af440d4196d9c0d3af979",
 	}
 
 	fopts, err := ProcessConfigFile("./configs/srv_a.conf")
@@ -408,7 +408,7 @@ func TestClusterFlagsOverride(t *testing.T) {
 			AuthTimeout: 0.5,
 		},
 		Routes:       []*url.URL{rurl},
-		ConfigDigest: "sha256:fe3c13f82637723989a9bbd0ad6d064b95d48971666af440d4196d9c0d3af979",
+		configDigest: "sha256:fe3c13f82637723989a9bbd0ad6d064b95d48971666af440d4196d9c0d3af979",
 	}
 
 	fopts, err := ProcessConfigFile("./configs/srv_a.conf")
@@ -445,7 +445,7 @@ func TestRouteFlagOverrideWithMultiple(t *testing.T) {
 		},
 		Routes:       rurls,
 		RoutesStr:    routeFlag,
-		ConfigDigest: "sha256:fe3c13f82637723989a9bbd0ad6d064b95d48971666af440d4196d9c0d3af979",
+		configDigest: "sha256:fe3c13f82637723989a9bbd0ad6d064b95d48971666af440d4196d9c0d3af979",
 	}
 
 	fopts, err := ProcessConfigFile("./configs/srv_a.conf")

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -121,6 +121,7 @@ func TestConfigFile(t *testing.T) {
 		LameDuckDuration:      4 * time.Minute,
 		ConnectErrorReports:   86400,
 		ReconnectErrorReports: 5,
+		ConfigDigest:          "sha256:314adbd9997c1183f028f5b620362daa45893da76bac746136bfb48b2fd14996",
 		authBlockDefined:      true,
 	}
 
@@ -142,6 +143,7 @@ func TestTLSConfigFile(t *testing.T) {
 		AuthTimeout:      1.0,
 		TLSTimeout:       2.0,
 		authBlockDefined: true,
+		ConfigDigest:     "sha256:cec986d37d7c09c86916d1ba4990cea1b8dadd49c86f9f782b455b47d07c2ac8",
 	}
 	opts, err := ProcessConfigFile("./configs/tls.conf")
 	if err != nil {
@@ -287,6 +289,7 @@ func TestMergeOverrides(t *testing.T) {
 		ConnectErrorReports:   86400,
 		ReconnectErrorReports: 5,
 		authBlockDefined:      true,
+		ConfigDigest:          "sha256:314adbd9997c1183f028f5b620362daa45893da76bac746136bfb48b2fd14996",
 	}
 	fopts, err := ProcessConfigFile("./configs/test.conf")
 	if err != nil {
@@ -362,8 +365,9 @@ func TestRouteFlagOverride(t *testing.T) {
 			Password:    "top_secret",
 			AuthTimeout: 0.5,
 		},
-		Routes:    []*url.URL{rurl},
-		RoutesStr: routeFlag,
+		Routes:       []*url.URL{rurl},
+		RoutesStr:    routeFlag,
+		ConfigDigest: "sha256:fe3c13f82637723989a9bbd0ad6d064b95d48971666af440d4196d9c0d3af979",
 	}
 
 	fopts, err := ProcessConfigFile("./configs/srv_a.conf")
@@ -403,7 +407,8 @@ func TestClusterFlagsOverride(t *testing.T) {
 			Password:    "top_secret",
 			AuthTimeout: 0.5,
 		},
-		Routes: []*url.URL{rurl},
+		Routes:       []*url.URL{rurl},
+		ConfigDigest: "sha256:fe3c13f82637723989a9bbd0ad6d064b95d48971666af440d4196d9c0d3af979",
 	}
 
 	fopts, err := ProcessConfigFile("./configs/srv_a.conf")
@@ -438,8 +443,9 @@ func TestRouteFlagOverrideWithMultiple(t *testing.T) {
 			Password:    "top_secret",
 			AuthTimeout: 0.5,
 		},
-		Routes:    rurls,
-		RoutesStr: routeFlag,
+		Routes:       rurls,
+		RoutesStr:    routeFlag,
+		ConfigDigest: "sha256:fe3c13f82637723989a9bbd0ad6d064b95d48971666af440d4196d9c0d3af979",
 	}
 
 	fopts, err := ProcessConfigFile("./configs/srv_a.conf")

--- a/server/reload.go
+++ b/server/reload.go
@@ -994,6 +994,13 @@ func (s *Server) Reload() error {
 		// TODO: Dump previous good config to a .bak file?
 		return err
 	}
+
+	// Use the digest from the configuration to detect whether unnecessary to apply reload.
+	if s.getOpts().ConfigDigest() != "" && newOpts.ConfigDigest() == s.getOpts().ConfigDigest() {
+		s.Noticef("Config reload skipped. No changes detected.")
+		return nil
+	}
+
 	return s.ReloadOptions(newOpts)
 }
 
@@ -1778,8 +1785,11 @@ func (s *Server) applyOptions(ctx *reloadContext, opts []option) {
 	if err := s.reloadOCSP(); err != nil {
 		s.Warnf("Can't restart OCSP features: %v", err)
 	}
-
-	s.Noticef("Reloaded server configuration (%s)", newOpts.configDigest)
+	var cd string
+	if newOpts.configDigest != "" {
+		cd = fmt.Sprintf("(%s)", newOpts.configDigest)
+	}
+	s.Noticef("Reloaded server configuration %s", cd)
 }
 
 // This will send a reset to the internal send loop.

--- a/server/reload.go
+++ b/server/reload.go
@@ -1628,7 +1628,9 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 				diffOpts = append(diffOpts, &profBlockRateReload{newValue: new})
 			}
 		case "configdigest":
-			newOpts.ConfigDigest = newValue.(string)
+			// skip changes in config digest, this is handled already while
+			// processing the config.
+			continue
 		default:
 			// TODO(ik): Implement String() on those options to have a nice print.
 			// %v is difficult to figure what's what, %+v print private fields and

--- a/server/reload.go
+++ b/server/reload.go
@@ -1779,7 +1779,7 @@ func (s *Server) applyOptions(ctx *reloadContext, opts []option) {
 		s.Warnf("Can't restart OCSP features: %v", err)
 	}
 
-	s.Noticef("Reloaded server configuration (%s)", newOpts.ConfigDigest)
+	s.Noticef("Reloaded server configuration (%s)", newOpts.configDigest)
 }
 
 // This will send a reset to the internal send loop.

--- a/server/reload.go
+++ b/server/reload.go
@@ -1627,6 +1627,8 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 			if new != old {
 				diffOpts = append(diffOpts, &profBlockRateReload{newValue: new})
 			}
+		case "configdigest":
+			newOpts.ConfigDigest = newValue.(string)
 		default:
 			// TODO(ik): Implement String() on those options to have a nice print.
 			// %v is difficult to figure what's what, %+v print private fields and
@@ -1775,7 +1777,7 @@ func (s *Server) applyOptions(ctx *reloadContext, opts []option) {
 		s.Warnf("Can't restart OCSP features: %v", err)
 	}
 
-	s.Noticef("Reloaded server configuration")
+	s.Noticef("Reloaded server configuration (%s)", newOpts.ConfigDigest)
 }
 
 // This will send a reset to the internal send loop.

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -152,7 +152,7 @@ func TestConfigReloadUnsupported(t *testing.T) {
 			Port: -1,
 		},
 		NoSigs:       true,
-		ConfigDigest: "sha256:3c5c4141f56274bcfa801f2d7326ec64d5eabddd9e6d4f9a06ed167315a57f55",
+		configDigest: "sha256:3c5c4141f56274bcfa801f2d7326ec64d5eabddd9e6d4f9a06ed167315a57f55",
 	}
 	setBaselineOptions(golden)
 
@@ -225,7 +225,7 @@ func TestConfigReloadInvalidConfig(t *testing.T) {
 			Port: -1,
 		},
 		NoSigs:       true,
-		ConfigDigest: "sha256:3c5c4141f56274bcfa801f2d7326ec64d5eabddd9e6d4f9a06ed167315a57f55",
+		configDigest: "sha256:3c5c4141f56274bcfa801f2d7326ec64d5eabddd9e6d4f9a06ed167315a57f55",
 	}
 	setBaselineOptions(golden)
 
@@ -289,7 +289,7 @@ func TestConfigReload(t *testing.T) {
 			Port: server.ClusterAddr().Port,
 		},
 		NoSigs:       true,
-		ConfigDigest: "sha256:3c5c4141f56274bcfa801f2d7326ec64d5eabddd9e6d4f9a06ed167315a57f55",
+		configDigest: "sha256:3c5c4141f56274bcfa801f2d7326ec64d5eabddd9e6d4f9a06ed167315a57f55",
 	}
 	setBaselineOptions(golden)
 

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -151,7 +151,8 @@ func TestConfigReloadUnsupported(t *testing.T) {
 			Host: "127.0.0.1",
 			Port: -1,
 		},
-		NoSigs: true,
+		NoSigs:       true,
+		ConfigDigest: "sha256:3c5c4141f56274bcfa801f2d7326ec64d5eabddd9e6d4f9a06ed167315a57f55",
 	}
 	setBaselineOptions(golden)
 
@@ -223,7 +224,8 @@ func TestConfigReloadInvalidConfig(t *testing.T) {
 			Host: "127.0.0.1",
 			Port: -1,
 		},
-		NoSigs: true,
+		NoSigs:       true,
+		ConfigDigest: "sha256:3c5c4141f56274bcfa801f2d7326ec64d5eabddd9e6d4f9a06ed167315a57f55",
 	}
 	setBaselineOptions(golden)
 
@@ -286,7 +288,8 @@ func TestConfigReload(t *testing.T) {
 			Host: "127.0.0.1",
 			Port: server.ClusterAddr().Port,
 		},
-		NoSigs: true,
+		NoSigs:       true,
+		ConfigDigest: "sha256:3c5c4141f56274bcfa801f2d7326ec64d5eabddd9e6d4f9a06ed167315a57f55",
 	}
 	setBaselineOptions(golden)
 
@@ -4054,6 +4057,11 @@ func TestConfigReloadAndVarz(t *testing.T) {
 	if v.MaxConn != DEFAULT_MAX_CONNECTIONS {
 		t.Fatalf("MaxConn should be %v, got %v", DEFAULT_MAX_CONNECTIONS, v.MaxConn)
 	}
+	got := v.ConfigDigest
+	expected := "sha256:7ea4cc5c6864139d814ce940a40ee6546b7ac5285eec3c390a4ce11e34dc1102"
+	if got != expected {
+		t.Fatalf("got: %v, expected: %v", got, expected)
+	}
 
 	changeCurrentConfigContentWithNewContent(t, conf, []byte(fmt.Sprintf(template, "max_connections: 10")))
 
@@ -4070,6 +4078,11 @@ func TestConfigReloadAndVarz(t *testing.T) {
 	}
 	if v.MaxConn != 10 {
 		t.Fatalf("MaxConn should be 10, got %v", v.MaxConn)
+	}
+	got = v.ConfigDigest
+	expected = "sha256:508a26309068f62c3022aa8951e712ed8ff5dd6f2360f727ad8242a2a233176e"
+	if got != expected {
+		t.Fatalf("got: %v, expected: %v", got, expected)
 	}
 }
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -106,7 +106,7 @@ func TestRouteConfig(t *testing.T) {
 			ConnectRetries: 2,
 		},
 		PidFile:          "/tmp/nats-server/nats_cluster_test.pid",
-		ConfigDigest:     "sha256:1a95b87d99ff3950ff3eb220ef6ffb5387c95fa606ed6976023ade266329c7b5",
+		configDigest:     "sha256:1a95b87d99ff3950ff3eb220ef6ffb5387c95fa606ed6976023ade266329c7b5",
 		authBlockDefined: true,
 	}
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -106,6 +106,7 @@ func TestRouteConfig(t *testing.T) {
 			ConnectRetries: 2,
 		},
 		PidFile:          "/tmp/nats-server/nats_cluster_test.pid",
+		ConfigDigest:     "sha256:1a95b87d99ff3950ff3eb220ef6ffb5387c95fa606ed6976023ade266329c7b5",
 		authBlockDefined: true,
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -2243,7 +2243,7 @@ func (s *Server) Start() {
 	}
 
 	if opts.ConfigFile != _EMPTY_ {
-		s.Noticef("Using configuration file: %s (%s)", opts.ConfigFile, opts.ConfigDigest)
+		s.Noticef("Using configuration file: %s (%s)", opts.ConfigFile, opts.configDigest)
 	}
 
 	hasOperators := len(opts.TrustedOperators) > 0

--- a/server/server.go
+++ b/server/server.go
@@ -2243,7 +2243,7 @@ func (s *Server) Start() {
 	}
 
 	if opts.ConfigFile != _EMPTY_ {
-		s.Noticef("Using configuration file: %s", opts.ConfigFile)
+		s.Noticef("Using configuration file: %s (%s)", opts.ConfigFile, opts.ConfigDigest)
 	}
 
 	hasOperators := len(opts.TrustedOperators) > 0

--- a/server/server.go
+++ b/server/server.go
@@ -2243,7 +2243,11 @@ func (s *Server) Start() {
 	}
 
 	if opts.ConfigFile != _EMPTY_ {
-		s.Noticef("Using configuration file: %s (%s)", opts.ConfigFile, opts.configDigest)
+		var cd string
+		if opts.configDigest != "" {
+			cd = fmt.Sprintf("(%s)", opts.configDigest)
+		}
+		s.Noticef("Using configuration file: %s %s", opts.ConfigFile, cd)
 	}
 
 	hasOperators := len(opts.TrustedOperators) > 0


### PR DESCRIPTION
Makes the server generate a digest representing the expanded version of the parsed configuration:

```
$ nats-server -c foo.conf -t
nats-server: configuration file configs/foo.conf is valid (sha256:e14d9fd914ee4a83c481c6bf97b44d7bc23d8f475f7f30af0c4e96ab4e5ad00c)
```

It can be inspected via `/varz`:

```
  "config_load_time": "2023-07-19T14:28:28.77128Z",
  "config_digest": "sha256:6a383afa5fa6e00262105fbf061cabf48db892d1aa677f491dbabe7894393413",
  "system_account": "$SYS"
```

And it is also logged at runtime making it possible to check whether the reload had side effects:
```
[1935] 2023/07/19 02:57:29.245020 [INF] Using configuration file: configs/foo.conf (sha256:6a383afa5fa6e00262105fbf061cabf48db892d1aa677f491dbabe7894393413)
...
[1935] 2023/07/19 02:58:06.993874 [DBG] Trapped "hangup" signal
...
[1935] 2023/07/19 02:58:06.996113 [INF] Reloaded server configuration (sha256:6a383afa5fa6e00262105fbf061cabf48db892d1aa677f491dbabe7894393413)
...
[1935] 2023/07/19 02:58:32.895492 [INF] Reloaded server configuration (sha256:a622fb453f3464b041de668b82229aef155175824f3c3a6d126a33268d172987)
[1935] 2023/07/19 02:58:44.615983 [DBG] Trapped "hangup" signal
...
[1935] 2023/07/19 02:58:44.617870 [INF] Reloaded server configuration (sha256:6a383afa5fa6e00262105fbf061cabf48db892d1aa677f491dbabe7894393413)
```

 - [x] Reloader tests
 - [x] Monitoring test
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)
