### PR TITLE
Add Go 1.20 to Travis and Nightly images

### DIFF
--- a/.github/actions/nightly-release/action.yaml
+++ b/.github/actions/nightly-release/action.yaml
@@ -26,7 +26,7 @@ runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: "${{ inputs.go }}"
 

--- a/.github/workflows/cov.yaml
+++ b/.github/workflows/cov.yaml
@@ -21,9 +21,9 @@ jobs:
           ref: dev
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.19.x'
+          go-version: "1.20.x"
 
       - name: Run code coverage
         shell: bash --noprofile --norc -x -eo pipefail {0}

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -5,9 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        # This should be quoted or use .x, but should not be unquoted.
-        # Remember that a YAML bare float drops trailing zeroes.
-        go: ['1.19']
+        go: ["1.20"]
 
     env:
       GOPATH: /home/runner/work/nats-server
@@ -21,25 +19,19 @@ jobs:
           path: src/github.com/nats-io/nats-server
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{matrix.go}}
 
       - name: Install deps
         shell: bash --noprofile --norc -x -eo pipefail {0}
         run: |
-          go get -u honnef.co/go/tools/cmd/staticcheck
-          go get -u github.com/client9/misspell/cmd/misspell
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
 
       - name: Lint
         shell: bash --noprofile --norc -x -eo pipefail {0}
         run: |
-          GO_LIST=$(go list ./...)
-          go build
-          $(exit $(go fmt $GO_LIST | wc -l))
-          go vet $GO_LIST
-          find . -type f -name "*.go" | xargs $GOPATH/bin/misspell -error -locale US
-          $GOPATH/bin/staticcheck $GO_LIST
+          golangci-lint run
 
       - name: Run tests
         shell: bash --noprofile --norc -x -eo pipefail {0}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:
-          go: "1.19"
+          go: "1.20"
           workdir: src/github.com/nats-io/nats-server
           label: nightly
           hub_username: "${{ secrets.DOCKER_USERNAME }}"

--- a/.github/workflows/rc_nightly.yaml
+++ b/.github/workflows/rc_nightly.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:
-          go: "1.19"
+          go: "1.20"
           workdir: src/github.com/nats-io/nats-server
           label: nightly-main
           hub_username: "${{ secrets.DOCKER_USERNAME }}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ go:
 # This should be quoted or use .x, but should not be unquoted.
 # Remember that a YAML bare float drops trailing zeroes.
   - "1.19.12"
+  - "1.20.x"
+
 go_import_path: github.com/nats-io/nats-server
 
 addons:
@@ -50,4 +52,4 @@ deploy:
   script: curl -sL http://git.io/goreleaser | bash
   on:
     tags: true
-    condition: ($TRAVIS_GO_VERSION =~ 1.19) && ($TEST_SUITE = "compile")
+    condition: ($TRAVIS_GO_VERSION =~ 1.20) && ($TEST_SUITE = "compile")

--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.20-alpine AS builder
 
 ARG VERSION="nightly"
 

--- a/scripts/runTestsOnTravis.sh
+++ b/scripts/runTestsOnTravis.sh
@@ -7,11 +7,7 @@ if [ "$1" = "compile" ]; then
     go build;
 
     # Now run the linters.
-    # TODO: Pinning a specific commit here as there is a bugfix merged that 
-    # fixes gofmt on macOS Ventura, we can undo this and go back to the binary
-    # install script once there's a new tagged release that contains the fix.
-    # curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@6f7f8ae;
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3;
     golangci-lint run;
     if [ "$TRAVIS_TAG" != "" ]; then
         go test -race -v -run=TestVersionMatchesTag ./server -count=1 -vet=off


### PR DESCRIPTION
Picks up https://github.com/nats-io/nats-server/pull/4297 into main.  Includes: 

- Using Go 1.20 for the nightly images and Travis tests
- Drop Go 1.18
- Updates to GitHub Actions
- Upgrade to golang-ci