### PR TITLE
Report correct consumer count in paged list response

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -6524,7 +6524,7 @@ LOOP:
 		})
 	}
 
-	resp.Total = len(resp.Consumers)
+	resp.Total = ocnt
 	resp.Limit = JSApiListLimit
 	resp.Offset = offset
 	resp.Missing = missingNames

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -5387,6 +5387,9 @@ func TestNoRaceJetStreamClusterConsumerListPaging(t *testing.T) {
 		if resp.Limit < len(resp.Consumers) {
 			t.Fatalf("Expected total limited to %d but got %d", resp.Limit, len(resp.Consumers))
 		}
+		if resp.Total != numConsumers {
+			t.Fatalf("Invalid total response: expected %d got %d", numConsumers, resp.Total)
+		}
 		return resp.Consumers
 	}
 
@@ -5416,6 +5419,9 @@ func TestNoRaceJetStreamClusterConsumerListPaging(t *testing.T) {
 		if resp.Limit < len(resp.Consumers) {
 			t.Fatalf("Expected total limited to %d but got %d", resp.Limit, len(resp.Consumers))
 		}
+		if resp.Total != numConsumers {
+			t.Fatalf("Invalid total response: expected %d got %d", numConsumers, resp.Total)
+		}
 		return resp.Consumers
 	}
 
@@ -5431,6 +5437,10 @@ func TestNoRaceJetStreamClusterConsumerListPaging(t *testing.T) {
 			}
 			results[name] = true
 		}
+	}
+
+	if len(results) != numConsumers {
+		t.Fatalf("Received %d / %d consumers", len(results), numConsumers)
 	}
 }
 


### PR DESCRIPTION
Previously the Total in paged responses would always equal the size of the first response this would stall paged clients after the first page.

Now correctly sets the total so paging continues, improves the test to verify these aspects of the report
