### PR TITLE
[FIXED] Do not panic when re-calculating first sequence for SimpleState when fseq moves ahead of old first.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5934,6 +5934,8 @@ func (mb *msgBlock) recalculateFirstForSubj(subj string, startSeq uint64, ss *Si
 	if startSlot >= len(mb.cache.idx) {
 		ss.First = ss.Last
 		return
+	} else if startSlot < 0 {
+		startSlot = 0
 	}
 
 	var le = binary.LittleEndian


### PR DESCRIPTION
When a lazy simple state has an outdated first that needs to be updated, if fseq had moved past it would panic.
This was not common but with latest fix prior in can become more common, hence why it showed up.

Signed-off-by: Derek Collison <derek@nats.io>

