### PR TITLE
config: make parsing configurations without usable values invalid

### DIFF
--- a/conf/parse.go
+++ b/conf/parse.go
@@ -146,7 +146,9 @@ func parse(data, fp string, pedantic bool) (p *parser, err error) {
 			return nil, err
 		}
 	}
-
+	if len(p.mapping) == 0 {
+		return nil, fmt.Errorf("config has no values or is empty")
+	}
 	return p, nil
 }
 

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -403,3 +403,30 @@ func TestParserNoInfiniteLoop(t *testing.T) {
 		}
 	}
 }
+
+func TestParseWithNoValues(t *testing.T) {
+	for _, test := range []string{
+		``,
+		`aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`,
+		`              aaaaaaaaaaaaaaaaaaaaaaaaaaa`,
+		`     aaaaaaaaaaaaaaaaaaaaaaaaaaa         `,
+		`
+                # just comments with no values
+                # is also invalid.
+                `,
+		`
+                # with comments and no spaces to create key values
+                # is also an invalid config.
+                aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+                `,
+		`
+                a,a,a,a,a,a,a,a,a,a,a
+                `,
+	} {
+		if _, err := parse(test, "", true); err == nil {
+			t.Fatal("expected an error")
+		} else if !strings.Contains(err.Error(), "config has no values or is empty") {
+			t.Fatal("expected invalid conf error")
+		}
+	}
+}


### PR DESCRIPTION
This makes configuration files that are empty, or read and processed by the parser but with no detected values now return an error.
