### PR TITLE
[FIXED] Seqset encode bug that could cause bad stream state snapshots

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -5677,6 +5678,7 @@ func TestFileStoreInitialFirstSeq(t *testing.T) {
 func TestFileStoreRecaluclateFirstForSubjBug(t *testing.T) {
 	fs, err := newFileStore(FileStoreConfig{StoreDir: t.TempDir()}, StreamConfig{Name: "zzz", Subjects: []string{"*"}, Storage: FileStorage})
 	require_NoError(t, err)
+	defer fs.Stop()
 
 	fs.StoreMsg("foo", nil, nil) // 1
 	fs.StoreMsg("bar", nil, nil) // 2
@@ -5704,4 +5706,40 @@ func TestFileStoreRecaluclateFirstForSubjBug(t *testing.T) {
 	mb.recalculateFirstForSubj("foo", 1, ss)
 	// Make sure it was update properly.
 	require_True(t, *ss == SimpleState{Msgs: 1, First: 3, Last: 3, firstNeedsUpdate: false})
+}
+
+func TestFileStoreStreamEncoderDecoder(t *testing.T) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir()},
+		StreamConfig{Name: "zzz", Subjects: []string{"*"}, MaxMsgsPer: 2, Storage: FileStorage},
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	const seed = 2222222
+	prand := rand.New(rand.NewSource(seed))
+
+	tick := time.NewTicker(time.Second)
+	defer tick.Stop()
+	done := time.NewTimer(10 * time.Second)
+
+	msg := bytes.Repeat([]byte("ABC"), 33) // ~100bytes
+
+	for running := true; running; {
+		select {
+		case <-tick.C:
+			var state StreamState
+			fs.FastState(&state)
+			snap, err := fs.EncodedStreamState(0)
+			require_NoError(t, err)
+			ss, err := DecodeStreamState(snap)
+			require_True(t, len(ss.Deleted) > 0)
+			require_NoError(t, err)
+		case <-done.C:
+			running = false
+		default:
+			key := strconv.Itoa(prand.Intn(256_000))
+			fs.StoreMsg(key, nil, msg)
+		}
+	}
 }

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -8730,7 +8730,7 @@ func TestNoRaceBinaryStreamSnapshotEncodingBasic(t *testing.T) {
 	require_True(t, ss.LastSeq == 3000)
 	require_True(t, ss.Msgs == 1000)
 	// We should have collapsed all these into 2 delete blocks.
-	require_True(t, len(ss.Deleted) == 2)
+	require_True(t, len(ss.Deleted) <= 2)
 	require_True(t, ss.Deleted.NumDeleted() == 2000)
 }
 

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -8765,7 +8765,7 @@ func TestNoRaceFilestoreBinaryStreamSnapshotEncodingLargeGaps(t *testing.T) {
 	require_True(t, ss.FirstSeq == 1)
 	require_True(t, ss.LastSeq == 20_000)
 	require_True(t, ss.Msgs == 2)
-	require_True(t, len(ss.Deleted) == 2)
+	require_True(t, len(ss.Deleted) <= 2)
 	require_True(t, ss.Deleted.NumDeleted() == 19_998)
 }
 


### PR DESCRIPTION
This would cause decode to spin and lock up the server.

This fixes the encode bug (a delete and clear node bug in avl/seqset). Also addressed receiving a bad snapshot, etc.
