### PR TITLE
[ADDED] Full StreamSource (filters, transforms) functionality to stream mirror

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -1423,7 +1423,7 @@
     "constant": "JSSourceMultipleFiltersNotAllowed",
     "code": 400,
     "error_code": 10144,
-    "description": "source with multiple subject filters cannot also have a single subject filter",
+    "description": "source with multiple subject transforms cannot also have a single subject filter",
     "comment": "",
     "help": "",
     "url": "",

--- a/server/errors.json
+++ b/server/errors.json
@@ -1478,5 +1478,35 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSMirrorMultipleFiltersNotAllowed",
+    "code": 400,
+    "error_code": 10150,
+    "description": "mirror with multiple subject transforms cannot also have a single subject filter",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSMirrorInvalidSubjectFilter",
+    "code": 400,
+    "error_code": 10151,
+    "description": "mirror subject filter is invalid",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSMirrorOverlappingSubjectFilters",
+    "code": 400,
+    "error_code": 10152,
+    "description": "mirror subject filters can not overlap",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -234,16 +234,16 @@ const (
 	JSMirrorInvalidStreamName ErrorIdentifier = 10142
 
 	// JSMirrorInvalidSubjectFilter mirror subject filter is invalid
-	JSMirrorInvalidSubjectFilter ErrorIdentifier = 10149
+	JSMirrorInvalidSubjectFilter ErrorIdentifier = 10151
 
 	// JSMirrorMaxMessageSizeTooBigErr stream mirror must have max message size >= source
 	JSMirrorMaxMessageSizeTooBigErr ErrorIdentifier = 10030
 
 	// JSMirrorMultipleFiltersNotAllowed mirror with multiple subject transforms cannot also have a single subject filter
-	JSMirrorMultipleFiltersNotAllowed ErrorIdentifier = 10148
+	JSMirrorMultipleFiltersNotAllowed ErrorIdentifier = 10150
 
 	// JSMirrorOverlappingSubjectFilters mirror subject filters can not overlap
-	JSMirrorOverlappingSubjectFilters ErrorIdentifier = 10150
+	JSMirrorOverlappingSubjectFilters ErrorIdentifier = 10152
 
 	// JSMirrorWithFirstSeqErr stream mirrors can not have first sequence configured
 	JSMirrorWithFirstSeqErr ErrorIdentifier = 10143
@@ -537,10 +537,10 @@ var (
 		JSMemoryResourcesExceededErr:               {Code: 500, ErrCode: 10028, Description: "insufficient memory resources available"},
 		JSMirrorConsumerSetupFailedErrF:            {Code: 500, ErrCode: 10029, Description: "{err}"},
 		JSMirrorInvalidStreamName:                  {Code: 400, ErrCode: 10142, Description: "mirrored stream name is invalid"},
-		JSMirrorInvalidSubjectFilter:               {Code: 400, ErrCode: 10149, Description: "mirror subject filter is invalid"},
+		JSMirrorInvalidSubjectFilter:               {Code: 400, ErrCode: 10151, Description: "mirror subject filter is invalid"},
 		JSMirrorMaxMessageSizeTooBigErr:            {Code: 400, ErrCode: 10030, Description: "stream mirror must have max message size >= source"},
-		JSMirrorMultipleFiltersNotAllowed:          {Code: 400, ErrCode: 10148, Description: "mirror with multiple subject transforms cannot also have a single subject filter"},
-		JSMirrorOverlappingSubjectFilters:          {Code: 400, ErrCode: 10150, Description: "mirror subject filters can not overlap"},
+		JSMirrorMultipleFiltersNotAllowed:          {Code: 400, ErrCode: 10150, Description: "mirror with multiple subject transforms cannot also have a single subject filter"},
+		JSMirrorOverlappingSubjectFilters:          {Code: 400, ErrCode: 10152, Description: "mirror subject filters can not overlap"},
 		JSMirrorWithFirstSeqErr:                    {Code: 400, ErrCode: 10143, Description: "stream mirrors can not have first sequence configured"},
 		JSMirrorWithSourcesErr:                     {Code: 400, ErrCode: 10031, Description: "stream mirrors can not also contain other sources"},
 		JSMirrorWithStartSeqAndTimeErr:             {Code: 400, ErrCode: 10032, Description: "stream mirrors can not have both start seq and start time configured"},

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -233,8 +233,17 @@ const (
 	// JSMirrorInvalidStreamName mirrored stream name is invalid
 	JSMirrorInvalidStreamName ErrorIdentifier = 10142
 
+	// JSMirrorInvalidSubjectFilter mirror subject filter is invalid
+	JSMirrorInvalidSubjectFilter ErrorIdentifier = 10149
+
 	// JSMirrorMaxMessageSizeTooBigErr stream mirror must have max message size >= source
 	JSMirrorMaxMessageSizeTooBigErr ErrorIdentifier = 10030
+
+	// JSMirrorMultipleFiltersNotAllowed mirror with multiple subject transforms cannot also have a single subject filter
+	JSMirrorMultipleFiltersNotAllowed ErrorIdentifier = 10148
+
+	// JSMirrorOverlappingSubjectFilters mirror subject filters can not overlap
+	JSMirrorOverlappingSubjectFilters ErrorIdentifier = 10150
 
 	// JSMirrorWithFirstSeqErr stream mirrors can not have first sequence configured
 	JSMirrorWithFirstSeqErr ErrorIdentifier = 10143
@@ -305,7 +314,7 @@ const (
 	// JSSourceMaxMessageSizeTooBigErr stream source must have max message size >= target
 	JSSourceMaxMessageSizeTooBigErr ErrorIdentifier = 10046
 
-	// JSSourceMultipleFiltersNotAllowed source with multiple subject filters cannot also have a single subject filter
+	// JSSourceMultipleFiltersNotAllowed source with multiple subject transforms cannot also have a single subject filter
 	JSSourceMultipleFiltersNotAllowed ErrorIdentifier = 10144
 
 	// JSSourceOverlappingSubjectFilters source filters can not overlap
@@ -528,7 +537,10 @@ var (
 		JSMemoryResourcesExceededErr:               {Code: 500, ErrCode: 10028, Description: "insufficient memory resources available"},
 		JSMirrorConsumerSetupFailedErrF:            {Code: 500, ErrCode: 10029, Description: "{err}"},
 		JSMirrorInvalidStreamName:                  {Code: 400, ErrCode: 10142, Description: "mirrored stream name is invalid"},
+		JSMirrorInvalidSubjectFilter:               {Code: 400, ErrCode: 10149, Description: "mirror subject filter is invalid"},
 		JSMirrorMaxMessageSizeTooBigErr:            {Code: 400, ErrCode: 10030, Description: "stream mirror must have max message size >= source"},
+		JSMirrorMultipleFiltersNotAllowed:          {Code: 400, ErrCode: 10148, Description: "mirror with multiple subject transforms cannot also have a single subject filter"},
+		JSMirrorOverlappingSubjectFilters:          {Code: 400, ErrCode: 10150, Description: "mirror subject filters can not overlap"},
 		JSMirrorWithFirstSeqErr:                    {Code: 400, ErrCode: 10143, Description: "stream mirrors can not have first sequence configured"},
 		JSMirrorWithSourcesErr:                     {Code: 400, ErrCode: 10031, Description: "stream mirrors can not also contain other sources"},
 		JSMirrorWithStartSeqAndTimeErr:             {Code: 400, ErrCode: 10032, Description: "stream mirrors can not have both start seq and start time configured"},
@@ -552,7 +564,7 @@ var (
 		JSSourceInvalidSubjectFilter:               {Code: 400, ErrCode: 10145, Description: "source subject filter is invalid"},
 		JSSourceInvalidTransformDestination:        {Code: 400, ErrCode: 10146, Description: "source transform destination is invalid"},
 		JSSourceMaxMessageSizeTooBigErr:            {Code: 400, ErrCode: 10046, Description: "stream source must have max message size >= target"},
-		JSSourceMultipleFiltersNotAllowed:          {Code: 400, ErrCode: 10144, Description: "source with multiple subject filters cannot also have a single subject filter"},
+		JSSourceMultipleFiltersNotAllowed:          {Code: 400, ErrCode: 10144, Description: "source with multiple subject transforms cannot also have a single subject filter"},
 		JSSourceOverlappingSubjectFilters:          {Code: 400, ErrCode: 10147, Description: "source filters can not overlap"},
 		JSStorageResourcesExceededErr:              {Code: 500, ErrCode: 10047, Description: "insufficient storage resources available"},
 		JSStreamAssignmentErrF:                     {Code: 500, ErrCode: 10048, Description: "{err}"},
@@ -1451,6 +1463,16 @@ func NewJSMirrorInvalidStreamNameError(opts ...ErrorOption) *ApiError {
 	return ApiErrors[JSMirrorInvalidStreamName]
 }
 
+// NewJSMirrorInvalidSubjectFilterError creates a new JSMirrorInvalidSubjectFilter error: "mirror subject filter is invalid"
+func NewJSMirrorInvalidSubjectFilterError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMirrorInvalidSubjectFilter]
+}
+
 // NewJSMirrorMaxMessageSizeTooBigError creates a new JSMirrorMaxMessageSizeTooBigErr error: "stream mirror must have max message size >= source"
 func NewJSMirrorMaxMessageSizeTooBigError(opts ...ErrorOption) *ApiError {
 	eopts := parseOpts(opts)
@@ -1459,6 +1481,26 @@ func NewJSMirrorMaxMessageSizeTooBigError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSMirrorMaxMessageSizeTooBigErr]
+}
+
+// NewJSMirrorMultipleFiltersNotAllowedError creates a new JSMirrorMultipleFiltersNotAllowed error: "mirror with multiple subject transforms cannot also have a single subject filter"
+func NewJSMirrorMultipleFiltersNotAllowedError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMirrorMultipleFiltersNotAllowed]
+}
+
+// NewJSMirrorOverlappingSubjectFiltersError creates a new JSMirrorOverlappingSubjectFilters error: "mirror subject filters can not overlap"
+func NewJSMirrorOverlappingSubjectFiltersError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMirrorOverlappingSubjectFilters]
 }
 
 // NewJSMirrorWithFirstSeqError creates a new JSMirrorWithFirstSeqErr error: "stream mirrors can not have first sequence configured"
@@ -1715,7 +1757,7 @@ func NewJSSourceMaxMessageSizeTooBigError(opts ...ErrorOption) *ApiError {
 	return ApiErrors[JSSourceMaxMessageSizeTooBigErr]
 }
 
-// NewJSSourceMultipleFiltersNotAllowedError creates a new JSSourceMultipleFiltersNotAllowed error: "source with multiple subject filters cannot also have a single subject filter"
+// NewJSSourceMultipleFiltersNotAllowedError creates a new JSSourceMultipleFiltersNotAllowed error: "source with multiple subject transforms cannot also have a single subject filter"
 func NewJSSourceMultipleFiltersNotAllowedError(opts ...ErrorOption) *ApiError {
 	eopts := parseOpts(opts)
 	if ae, ok := eopts.err.(*ApiError); ok {

--- a/server/stream.go
+++ b/server/stream.go
@@ -481,7 +481,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 				if st.Destination != _EMPTY_ {
 					if _, err = NewSubjectTransform(st.Source, st.Destination); err != nil {
 						jsa.mu.Unlock()
-						return nil, fmt.Errorf("subject transform from '%s' to '%s' for the mirror %w", st.Source, st.Destination, err)
+						return nil, fmt.Errorf("subject transform from '%s' to '%s' for the mirror: %w", st.Source, st.Destination, err)
 					}
 				}
 			}

--- a/server/stream.go
+++ b/server/stream.go
@@ -458,7 +458,37 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 		}
 	}
 
-	// Setup our internal indexed names here for sources and check if the transform (if any) is valid.
+	// If mirror, check if the transforms (if any) are valid.
+	if cfg.Mirror != nil {
+		if len(cfg.Mirror.SubjectTransforms) == 0 {
+			if cfg.Mirror.FilterSubject != _EMPTY_ && !IsValidSubject(cfg.Mirror.FilterSubject) {
+				jsa.mu.Unlock()
+				return nil, fmt.Errorf("subject filter '%s' for the mirror %w", cfg.Mirror.FilterSubject, ErrBadSubject)
+			}
+			if cfg.Mirror.SubjectTransformDest != _EMPTY_ {
+				if _, err = NewSubjectTransform(cfg.Mirror.FilterSubject, cfg.Mirror.SubjectTransformDest); err != nil {
+					jsa.mu.Unlock()
+					return nil, fmt.Errorf("subject transform from '%s' to '%s' for the mirror %w", cfg.Mirror.FilterSubject, cfg.Mirror.SubjectTransformDest, err)
+				}
+			}
+		} else {
+			for _, st := range cfg.Mirror.SubjectTransforms {
+				if st.Source != _EMPTY_ && !IsValidSubject(st.Source) {
+					jsa.mu.Unlock()
+					return nil, fmt.Errorf("subject filter '%s' for the mirror %w", st.Source, ErrBadSubject)
+				}
+				// check the transform, if any, is valid
+				if st.Destination != _EMPTY_ {
+					if _, err = NewSubjectTransform(st.Source, st.Destination); err != nil {
+						jsa.mu.Unlock()
+						return nil, fmt.Errorf("subject transform from '%s' to '%s' for the mirror %w", st.Source, st.Destination, err)
+					}
+				}
+			}
+		}
+	}
+
+	// Setup our internal indexed names here for sources and check if the transforms (if any) are valid.
 	for _, ssi := range cfg.Sources {
 		if len(ssi.SubjectTransforms) == 0 {
 			// check the filter, if any, is valid
@@ -1209,10 +1239,23 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 		}
 		if len(cfg.Subjects) > 0 {
 			return StreamConfig{}, NewJSMirrorWithSubjectsError()
-
 		}
 		if len(cfg.Sources) > 0 {
 			return StreamConfig{}, NewJSMirrorWithSourcesError()
+		}
+		if (cfg.Mirror.FilterSubject != _EMPTY_ || cfg.Mirror.SubjectTransformDest != _EMPTY_) && len(cfg.Mirror.SubjectTransforms) != 0 {
+			return StreamConfig{}, NewJSMirrorMultipleFiltersNotAllowedError()
+		}
+		// Check subject filters overlap.
+		for outer, tr := range cfg.Mirror.SubjectTransforms {
+			if !IsValidSubject(tr.Source) {
+				return StreamConfig{}, NewJSMirrorInvalidSubjectFilterError()
+			}
+			for inner, innertr := range cfg.Mirror.SubjectTransforms {
+				if inner != outer && subjectIsSubsetMatch(tr.Source, innertr.Source) {
+					return StreamConfig{}, NewJSMirrorOverlappingSubjectFiltersError()
+				}
+			}
 		}
 		// Do not perform checks if External is provided, as it could lead to
 		// checking against itself (if sourced stream name is the same on different JetStream)
@@ -1303,12 +1346,13 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 				}
 			}
 			continue
-		}
-		if src.External.DeliverPrefix != _EMPTY_ {
-			deliveryPrefixes = append(deliveryPrefixes, src.External.DeliverPrefix)
-		}
-		if src.External.ApiPrefix != _EMPTY_ {
-			apiPrefixes = append(apiPrefixes, src.External.ApiPrefix)
+		} else {
+			if src.External.DeliverPrefix != _EMPTY_ {
+				deliveryPrefixes = append(deliveryPrefixes, src.External.DeliverPrefix)
+			}
+			if src.External.ApiPrefix != _EMPTY_ {
+				apiPrefixes = append(apiPrefixes, src.External.ApiPrefix)
+			}
 		}
 	}
 
@@ -2167,6 +2211,23 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 	js, stype := mset.js, mset.cfg.Storage
 	mset.mu.Unlock()
 
+	// Do the subject transform if there's one
+	if mset.mirror.tr != nil {
+		m.subj = mset.mirror.tr.TransformSubject(m.subj)
+	} else {
+		for _, tr := range mset.mirror.trs {
+			if tr == nil {
+				continue
+			} else {
+				tsubj, err := tr.Match(m.subj)
+				if err == nil {
+					m.subj = tsubj
+					break
+				}
+			}
+		}
+	}
+
 	s := mset.srv
 	var err error
 	if node != nil {
@@ -2377,7 +2438,19 @@ func (mset *stream) setupMirrorConsumer() error {
 	// Filters
 	if mset.cfg.Mirror.FilterSubject != _EMPTY_ {
 		req.Config.FilterSubject = mset.cfg.Mirror.FilterSubject
+		if mset.cfg.Mirror.SubjectTransformDest != _EMPTY_ {
+			mirror.tr, _ = NewSubjectTransform(mset.cfg.Mirror.FilterSubject, mset.cfg.Mirror.SubjectTransformDest)
+		}
 	}
+
+	var filters []string
+	for _, tr := range mset.cfg.Mirror.SubjectTransforms {
+		// will not fail as already checked before that the transform will work
+		subjectTransform, _ := NewSubjectTransform(tr.Source, tr.Destination)
+		mirror.trs = append(mirror.trs, subjectTransform)
+		filters = append(filters, tr.Source)
+	}
+	req.Config.FilterSubjects = filters
 
 	respCh := make(chan *JSApiConsumerCreateResponse, 1)
 	reply := infoReplySubject()

--- a/server/stream.go
+++ b/server/stream.go
@@ -475,7 +475,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 			for _, st := range cfg.Mirror.SubjectTransforms {
 				if st.Source != _EMPTY_ && !IsValidSubject(st.Source) {
 					jsa.mu.Unlock()
-					return nil, fmt.Errorf("subject filter '%s' for the mirror %w", st.Source, ErrBadSubject)
+					return nil, fmt.Errorf("invalid subject transform source '%s' for the mirror: %w", st.Source, ErrBadSubject)
 				}
 				// check the transform, if any, is valid
 				if st.Destination != _EMPTY_ {

--- a/server/stream.go
+++ b/server/stream.go
@@ -3270,7 +3270,6 @@ func (mset *stream) startingSequenceForSources() {
 		} else {
 			var trs []*subjectTransform
 			for _, str := range ssi.SubjectTransforms {
-				var err error
 				tr, err := NewSubjectTransform(str.Source, str.Destination)
 				if err != nil {
 					mset.srv.Errorf("Unable to get subject transform for source: %v", err)


### PR DESCRIPTION

 - [X] Tests added
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Follow up to #4276 extending to Mirror the full StreamSource functionality.