### PR TITLE
Fixed local issuer determination for OCSP Staple, issue #3773

### DIFF
--- a/server/certstore/certstore.go
+++ b/server/certstore/certstore.go
@@ -15,6 +15,7 @@ package certstore
 
 import (
 	"crypto"
+	"crypto/x509"
 	"io"
 	"runtime"
 	"strings"
@@ -80,6 +81,16 @@ func ParseCertMatchBy(certMatchBy string) (MatchByType, error) {
 		return 0, ErrBadMatchByType
 	}
 	return certMatchByType, nil
+}
+
+func GetLeafIssuer(leaf *x509.Certificate, vOpts x509.VerifyOptions) (issuer *x509.Certificate) {
+	chains, err := leaf.Verify(vOpts)
+	if err != nil || len(chains) == 0 {
+		issuer = nil
+	} else {
+		issuer = chains[0][1]
+	}
+	return
 }
 
 // credential provides access to a public key and is a crypto.Signer.

--- a/server/client.go
+++ b/server/client.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/klauspost/compress/s2"
+
 	"github.com/nats-io/jwt/v2"
 )
 
@@ -212,7 +213,6 @@ const (
 	DuplicateServerName
 	MinimumVersionRequired
 	ClusterNamesIdentical
-	FailedOCSPPeerVerification
 )
 
 // Some flags passed to processMsgResults

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2401,8 +2401,6 @@ func (reason ClosedState) String() string {
 		return "Minimum Version Required"
 	case ClusterNamesIdentical:
 		return "Cluster Names Identical"
-	case FailedOCSPPeerVerification:
-		return "Failed OCSP Peer Verification"
 	}
 
 	return "Unknown State"

--- a/test/configs/certs/ocsp_peer/mini-ca/misc/misconfig_TestServer1_bundle.pem
+++ b/test/configs/certs/ocsp_peer/mini-ca/misc/misconfig_TestServer1_bundle.pem
@@ -1,0 +1,186 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            3c:c4:82:66:f8:5d:a6:b6:c7:66:e1:b2:01:3f:e0:72:fc:72:61:33
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Intermediate CA 1
+        Validity
+            Not Before: May  1 19:33:37 2023 GMT
+            Not After : Apr 28 19:33:37 2033 GMT
+        Subject: C=US, ST=WA, L=Tacoma, O=Testnats, CN=TestServer1
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:af:26:5c:50:c0:fa:62:b5:fd:3d:c1:9e:26:51:
+                    58:62:04:37:b0:b5:6a:9b:6a:e3:22:3c:cd:ee:3c:
+                    e7:8b:d3:e2:4c:08:1a:4d:63:c1:81:20:f4:53:a5:
+                    5d:2f:d2:71:d8:af:e3:26:95:b4:27:14:46:7f:e2:
+                    0a:73:12:a7:0e:ff:99:5a:29:f5:d0:65:96:b1:d1:
+                    96:7f:0c:43:b8:71:f2:4b:21:e1:97:6c:1b:01:e5:
+                    38:1a:39:44:72:d5:19:20:87:fe:90:4f:3b:97:f2:
+                    7d:bd:57:97:4d:9d:56:50:89:5b:79:29:7a:3a:13:
+                    97:08:61:c2:0c:a6:02:49:c9:8a:41:ab:8e:9f:25:
+                    c9:33:18:f8:92:64:58:04:cc:a3:9d:cf:d4:d2:bd:
+                    20:ab:8b:9d:55:df:fb:5b:23:ac:95:12:fa:6f:07:
+                    93:3f:0e:03:86:c4:9b:25:06:21:9b:03:96:32:b8:
+                    e0:0f:63:e2:1d:34:d1:41:35:19:09:c1:a0:dc:26:
+                    b9:c8:66:fa:87:67:22:6e:0c:a6:e7:0f:24:64:b1:
+                    4f:84:05:ef:ad:8e:1b:f2:f4:38:87:d3:e3:48:a5:
+                    82:e0:66:89:1d:92:9a:59:67:a4:1d:03:6f:4d:a5:
+                    fb:3b:c0:0b:73:a7:ab:8f:b4:10:25:8e:69:42:76:
+                    82:5f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                43:16:E6:03:AF:37:B2:7B:BD:B3:C8:A2:9C:95:D7:FA:32:F8:9E:6F
+            X509v3 Authority Key Identifier: 
+                B5:91:6E:4F:64:B7:16:84:76:F9:B4:BE:99:CE:60:95:98:1A:8E:9D
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            Netscape Cert Type: 
+                SSL Client, SSL Server
+            X509v3 Key Usage: critical
+                Digital Signature, Non Repudiation, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://127.0.0.1:18888/intermediate1_crl.der
+            Authority Information Access: 
+                OCSP - URI:http://127.0.0.1:18888/
+            X509v3 Subject Alternative Name: 
+                DNS:localhost, IP Address:127.0.0.1
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        a3:87:9f:05:e4:38:61:f7:c4:5b:17:13:4b:2c:9d:a2:4d:e6:
+        ad:93:54:c5:a3:00:27:0b:5c:45:c5:bd:f8:b6:a7:5a:2a:ec:
+        dc:9b:59:8a:c7:59:e7:b9:86:f7:27:be:45:0d:d9:86:76:cf:
+        00:71:ad:aa:cc:73:50:8c:68:63:b0:e2:3a:59:dd:85:fa:0d:
+        f0:82:51:05:79:e6:d5:0e:0b:bb:ed:23:65:8f:d0:8b:01:df:
+        86:74:bc:3a:22:90:e4:59:44:91:d5:44:d8:21:4d:4e:10:72:
+        0a:12:2e:4a:20:5f:15:e7:16:0b:6f:76:f3:04:1f:da:44:50:
+        3b:c3:b3:0f:fa:05:cf:6e:64:9c:65:e2:0d:38:28:31:c3:c3:
+        b6:66:ef:80:d3:c4:5f:e9:f9:01:e9:ce:e6:99:46:a0:9d:ce:
+        90:63:77:d2:85:21:d7:88:32:55:38:fe:10:07:69:cd:c8:06:
+        b7:6f:49:98:bf:cd:be:4f:ab:44:ea:78:af:ab:01:c8:3e:fa:
+        d9:54:bc:59:28:db:03:9b:1c:ee:e4:c3:ed:f3:97:30:c6:40:
+        33:76:84:40:b2:b8:4d:b4:ca:a9:2d:d1:4d:17:92:ea:c0:c9:
+        cb:f6:b1:d7:d3:c7:e6:75:15:00:ff:c7:d9:54:63:27:19:5c:
+        96:a5:e5:d9
+-----BEGIN CERTIFICATE-----
+MIIEYjCCA0qgAwIBAgIUPMSCZvhdprbHZuGyAT/gcvxyYTMwDQYJKoZIhvcNAQEL
+BQAwWjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldBMQ8wDQYDVQQHDAZUYWNvbWEx
+ETAPBgNVBAoMCFRlc3RuYXRzMRowGAYDVQQDDBFJbnRlcm1lZGlhdGUgQ0EgMTAe
+Fw0yMzA1MDExOTMzMzdaFw0zMzA0MjgxOTMzMzdaMFQxCzAJBgNVBAYTAlVTMQsw
+CQYDVQQIDAJXQTEPMA0GA1UEBwwGVGFjb21hMREwDwYDVQQKDAhUZXN0bmF0czEU
+MBIGA1UEAwwLVGVzdFNlcnZlcjEwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQCvJlxQwPpitf09wZ4mUVhiBDewtWqbauMiPM3uPOeL0+JMCBpNY8GBIPRT
+pV0v0nHYr+MmlbQnFEZ/4gpzEqcO/5laKfXQZZax0ZZ/DEO4cfJLIeGXbBsB5Tga
+OURy1Rkgh/6QTzuX8n29V5dNnVZQiVt5KXo6E5cIYcIMpgJJyYpBq46fJckzGPiS
+ZFgEzKOdz9TSvSCri51V3/tbI6yVEvpvB5M/DgOGxJslBiGbA5YyuOAPY+IdNNFB
+NRkJwaDcJrnIZvqHZyJuDKbnDyRksU+EBe+tjhvy9DiH0+NIpYLgZokdkppZZ6Qd
+A29Npfs7wAtzp6uPtBAljmlCdoJfAgMBAAGjggEkMIIBIDAdBgNVHQ4EFgQUQxbm
+A683snu9s8iinJXX+jL4nm8wHwYDVR0jBBgwFoAUtZFuT2S3FoR2+bS+mc5glZga
+jp0wDAYDVR0TAQH/BAIwADARBglghkgBhvhCAQEEBAMCBsAwDgYDVR0PAQH/BAQD
+AgXgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjA9BgNVHR8ENjA0MDKg
+MKAuhixodHRwOi8vMTI3LjAuMC4xOjE4ODg4L2ludGVybWVkaWF0ZTFfY3JsLmRl
+cjAzBggrBgEFBQcBAQQnMCUwIwYIKwYBBQUHMAGGF2h0dHA6Ly8xMjcuMC4wLjE6
+MTg4ODgvMBoGA1UdEQQTMBGCCWxvY2FsaG9zdIcEfwAAATANBgkqhkiG9w0BAQsF
+AAOCAQEAo4efBeQ4YffEWxcTSyydok3mrZNUxaMAJwtcRcW9+LanWirs3JtZisdZ
+57mG9ye+RQ3ZhnbPAHGtqsxzUIxoY7DiOlndhfoN8IJRBXnm1Q4Lu+0jZY/QiwHf
+hnS8OiKQ5FlEkdVE2CFNThByChIuSiBfFecWC2928wQf2kRQO8OzD/oFz25knGXi
+DTgoMcPDtmbvgNPEX+n5AenO5plGoJ3OkGN30oUh14gyVTj+EAdpzcgGt29JmL/N
+vk+rROp4r6sByD762VS8WSjbA5sc7uTD7fOXMMZAM3aEQLK4TbTKqS3RTReS6sDJ
+y/ax19PH5nUVAP/H2VRjJxlclqXl2Q==
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            3c:d7:16:fb:15:99:81:4e:53:f8:80:7c:b6:7c:77:a6:06:a4:3e:ea
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Root CA
+        Validity
+            Not Before: May  1 19:01:43 2023 GMT
+            Not After : Apr 28 19:01:43 2033 GMT
+        Subject: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Intermediate CA 2
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:da:5f:ff:1d:f7:8d:1a:9e:9a:f3:2b:68:8f:c1:
+                    0c:33:06:41:00:c9:3e:e4:1a:e1:e0:70:6a:f5:2f:
+                    ad:df:f3:e9:99:ed:c5:d7:aa:93:13:37:ff:47:aa:
+                    f3:c5:89:f7:b7:ad:3a:47:e5:9c:4e:9f:8c:e2:41:
+                    ed:a4:7c:9d:88:32:ae:f5:8a:84:9f:0c:18:a0:b3:
+                    fe:8e:dc:2a:88:6a:f5:2f:9c:86:92:fa:7b:6e:b3:
+                    5a:78:67:53:0b:21:6c:0d:6c:80:1a:0e:1e:ee:06:
+                    c4:d2:e7:24:c6:e5:74:be:1e:2e:17:55:2b:e5:9f:
+                    0b:a0:58:cc:fe:bf:53:37:f7:dc:95:88:f4:77:a6:
+                    59:b4:b8:7c:a2:4b:b7:6a:67:aa:84:dc:29:f1:f9:
+                    d7:89:05:4d:0b:f3:8b:2d:52:99:57:ed:6f:11:9e:
+                    af:28:a3:61:44:c2:ec:6e:7f:9f:3d:0b:dc:f7:19:
+                    6d:14:8a:a5:b8:b6:29:02:34:90:b4:96:c1:cb:a7:
+                    42:46:97:cf:8d:59:fd:17:b1:a6:27:a7:7b:8a:47:
+                    6f:fa:03:24:1c:12:25:ee:34:d6:5c:da:45:98:23:
+                    30:e1:48:c9:9a:df:37:aa:1b:70:6c:b2:0f:95:39:
+                    d6:6d:3e:25:20:a8:07:2c:48:57:0c:99:52:cb:89:
+                    08:41
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                75:55:E2:8E:E7:AD:A5:DD:80:3D:C9:33:0B:2C:A2:57:77:ED:15:AC
+            X509v3 Authority Key Identifier: 
+                C3:12:42:BA:A9:D8:4D:E0:C3:3E:BA:D7:47:41:A6:09:2F:6D:B4:E1
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://127.0.0.1:8888/root_crl.der
+            Authority Information Access: 
+                OCSP - URI:http://127.0.0.1:8888/
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        1f:c6:fc:1c:a1:a5:6d:76:f0:7d:28:1f:e1:15:ab:86:e0:c3:
+        dd:a0:17:96:0a:c0:16:32:52:37:a4:b6:ad:24:d7:fd:3c:01:
+        34:3b:a9:a2:ea:81:05:e7:06:5f:a3:af:7b:fa:b2:a9:c3:63:
+        89:bb:0c:70:48:e9:73:cc:33:64:cd:b3:71:88:d1:d1:a1:5a:
+        22:a6:ed:03:46:8e:9a:c0:92:37:46:9b:e5:37:78:a5:43:d5:
+        46:99:1b:34:40:27:8f:95:dd:c6:9a:55:d9:60:25:8d:b8:e9:
+        6e:c9:b3:ee:e8:f0:d9:11:ef:4e:ae:1e:03:70:03:60:66:fd:
+        ab:b0:f4:74:b6:27:7c:7a:96:9d:86:58:5f:5c:d3:04:ab:16:
+        57:12:53:51:c7:93:ca:0b:4e:67:27:2d:b7:20:79:b6:b7:8c:
+        e7:c3:d9:25:5e:25:63:cf:93:f0:6e:31:c0:d5:4f:05:1c:8d:
+        14:1b:6a:d5:01:b6:7a:09:6f:38:f3:e5:e2:5a:e4:e2:42:d5:
+        8a:8d:de:ef:73:25:85:3c:e3:a9:ef:f7:f7:23:4f:d3:27:c2:
+        3a:c6:c0:6f:2a:9b:1e:fe:fc:31:73:10:e1:08:62:98:2b:6d:
+        2f:cc:ab:dd:3a:65:c2:00:7f:29:18:32:cd:8f:56:a9:1d:86:
+        f1:5e:60:55
+-----BEGIN CERTIFICATE-----
+MIIECTCCAvGgAwIBAgIUPNcW+xWZgU5T+IB8tnx3pgakPuowDQYJKoZIhvcNAQEL
+BQAwUDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldBMQ8wDQYDVQQHDAZUYWNvbWEx
+ETAPBgNVBAoMCFRlc3RuYXRzMRAwDgYDVQQDDAdSb290IENBMB4XDTIzMDUwMTE5
+MDE0M1oXDTMzMDQyODE5MDE0M1owWjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldB
+MQ8wDQYDVQQHDAZUYWNvbWExETAPBgNVBAoMCFRlc3RuYXRzMRowGAYDVQQDDBFJ
+bnRlcm1lZGlhdGUgQ0EgMjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+ANpf/x33jRqemvMraI/BDDMGQQDJPuQa4eBwavUvrd/z6ZntxdeqkxM3/0eq88WJ
+97etOkflnE6fjOJB7aR8nYgyrvWKhJ8MGKCz/o7cKohq9S+chpL6e26zWnhnUwsh
+bA1sgBoOHu4GxNLnJMbldL4eLhdVK+WfC6BYzP6/Uzf33JWI9HemWbS4fKJLt2pn
+qoTcKfH514kFTQvziy1SmVftbxGeryijYUTC7G5/nz0L3PcZbRSKpbi2KQI0kLSW
+wcunQkaXz41Z/Rexpiene4pHb/oDJBwSJe401lzaRZgjMOFIyZrfN6obcGyyD5U5
+1m0+JSCoByxIVwyZUsuJCEECAwEAAaOB0DCBzTAdBgNVHQ4EFgQUdVXijuetpd2A
+PckzCyyiV3ftFawwHwYDVR0jBBgwFoAUwxJCuqnYTeDDPrrXR0GmCS9ttOEwEgYD
+VR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwMwYDVR0fBCwwKjAooCag
+JIYiaHR0cDovLzEyNy4wLjAuMTo4ODg4L3Jvb3RfY3JsLmRlcjAyBggrBgEFBQcB
+AQQmMCQwIgYIKwYBBQUHMAGGFmh0dHA6Ly8xMjcuMC4wLjE6ODg4OC8wDQYJKoZI
+hvcNAQELBQADggEBAB/G/ByhpW128H0oH+EVq4bgw92gF5YKwBYyUjektq0k1/08
+ATQ7qaLqgQXnBl+jr3v6sqnDY4m7DHBI6XPMM2TNs3GI0dGhWiKm7QNGjprAkjdG
+m+U3eKVD1UaZGzRAJ4+V3caaVdlgJY246W7Js+7o8NkR706uHgNwA2Bm/auw9HS2
+J3x6lp2GWF9c0wSrFlcSU1HHk8oLTmcnLbcgeba3jOfD2SVeJWPPk/BuMcDVTwUc
+jRQbatUBtnoJbzjz5eJa5OJC1YqN3u9zJYU846nv9/cjT9MnwjrGwG8qmx7+/DFz
+EOEIYpgrbS/Mq906ZcIAfykYMs2PVqkdhvFeYFU=
+-----END CERTIFICATE-----

--- a/test/configs/certs/ocsp_peer/mini-ca/misc/trust_config1_bundle.pem
+++ b/test/configs/certs/ocsp_peer/mini-ca/misc/trust_config1_bundle.pem
@@ -1,0 +1,264 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            3c:d7:16:fb:15:99:81:4e:53:f8:80:7c:b6:7c:77:a6:06:a4:3e:ea
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Root CA
+        Validity
+            Not Before: May  1 19:01:43 2023 GMT
+            Not After : Apr 28 19:01:43 2033 GMT
+        Subject: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Intermediate CA 2
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:da:5f:ff:1d:f7:8d:1a:9e:9a:f3:2b:68:8f:c1:
+                    0c:33:06:41:00:c9:3e:e4:1a:e1:e0:70:6a:f5:2f:
+                    ad:df:f3:e9:99:ed:c5:d7:aa:93:13:37:ff:47:aa:
+                    f3:c5:89:f7:b7:ad:3a:47:e5:9c:4e:9f:8c:e2:41:
+                    ed:a4:7c:9d:88:32:ae:f5:8a:84:9f:0c:18:a0:b3:
+                    fe:8e:dc:2a:88:6a:f5:2f:9c:86:92:fa:7b:6e:b3:
+                    5a:78:67:53:0b:21:6c:0d:6c:80:1a:0e:1e:ee:06:
+                    c4:d2:e7:24:c6:e5:74:be:1e:2e:17:55:2b:e5:9f:
+                    0b:a0:58:cc:fe:bf:53:37:f7:dc:95:88:f4:77:a6:
+                    59:b4:b8:7c:a2:4b:b7:6a:67:aa:84:dc:29:f1:f9:
+                    d7:89:05:4d:0b:f3:8b:2d:52:99:57:ed:6f:11:9e:
+                    af:28:a3:61:44:c2:ec:6e:7f:9f:3d:0b:dc:f7:19:
+                    6d:14:8a:a5:b8:b6:29:02:34:90:b4:96:c1:cb:a7:
+                    42:46:97:cf:8d:59:fd:17:b1:a6:27:a7:7b:8a:47:
+                    6f:fa:03:24:1c:12:25:ee:34:d6:5c:da:45:98:23:
+                    30:e1:48:c9:9a:df:37:aa:1b:70:6c:b2:0f:95:39:
+                    d6:6d:3e:25:20:a8:07:2c:48:57:0c:99:52:cb:89:
+                    08:41
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                75:55:E2:8E:E7:AD:A5:DD:80:3D:C9:33:0B:2C:A2:57:77:ED:15:AC
+            X509v3 Authority Key Identifier: 
+                C3:12:42:BA:A9:D8:4D:E0:C3:3E:BA:D7:47:41:A6:09:2F:6D:B4:E1
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://127.0.0.1:8888/root_crl.der
+            Authority Information Access: 
+                OCSP - URI:http://127.0.0.1:8888/
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        1f:c6:fc:1c:a1:a5:6d:76:f0:7d:28:1f:e1:15:ab:86:e0:c3:
+        dd:a0:17:96:0a:c0:16:32:52:37:a4:b6:ad:24:d7:fd:3c:01:
+        34:3b:a9:a2:ea:81:05:e7:06:5f:a3:af:7b:fa:b2:a9:c3:63:
+        89:bb:0c:70:48:e9:73:cc:33:64:cd:b3:71:88:d1:d1:a1:5a:
+        22:a6:ed:03:46:8e:9a:c0:92:37:46:9b:e5:37:78:a5:43:d5:
+        46:99:1b:34:40:27:8f:95:dd:c6:9a:55:d9:60:25:8d:b8:e9:
+        6e:c9:b3:ee:e8:f0:d9:11:ef:4e:ae:1e:03:70:03:60:66:fd:
+        ab:b0:f4:74:b6:27:7c:7a:96:9d:86:58:5f:5c:d3:04:ab:16:
+        57:12:53:51:c7:93:ca:0b:4e:67:27:2d:b7:20:79:b6:b7:8c:
+        e7:c3:d9:25:5e:25:63:cf:93:f0:6e:31:c0:d5:4f:05:1c:8d:
+        14:1b:6a:d5:01:b6:7a:09:6f:38:f3:e5:e2:5a:e4:e2:42:d5:
+        8a:8d:de:ef:73:25:85:3c:e3:a9:ef:f7:f7:23:4f:d3:27:c2:
+        3a:c6:c0:6f:2a:9b:1e:fe:fc:31:73:10:e1:08:62:98:2b:6d:
+        2f:cc:ab:dd:3a:65:c2:00:7f:29:18:32:cd:8f:56:a9:1d:86:
+        f1:5e:60:55
+-----BEGIN CERTIFICATE-----
+MIIECTCCAvGgAwIBAgIUPNcW+xWZgU5T+IB8tnx3pgakPuowDQYJKoZIhvcNAQEL
+BQAwUDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldBMQ8wDQYDVQQHDAZUYWNvbWEx
+ETAPBgNVBAoMCFRlc3RuYXRzMRAwDgYDVQQDDAdSb290IENBMB4XDTIzMDUwMTE5
+MDE0M1oXDTMzMDQyODE5MDE0M1owWjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldB
+MQ8wDQYDVQQHDAZUYWNvbWExETAPBgNVBAoMCFRlc3RuYXRzMRowGAYDVQQDDBFJ
+bnRlcm1lZGlhdGUgQ0EgMjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+ANpf/x33jRqemvMraI/BDDMGQQDJPuQa4eBwavUvrd/z6ZntxdeqkxM3/0eq88WJ
+97etOkflnE6fjOJB7aR8nYgyrvWKhJ8MGKCz/o7cKohq9S+chpL6e26zWnhnUwsh
+bA1sgBoOHu4GxNLnJMbldL4eLhdVK+WfC6BYzP6/Uzf33JWI9HemWbS4fKJLt2pn
+qoTcKfH514kFTQvziy1SmVftbxGeryijYUTC7G5/nz0L3PcZbRSKpbi2KQI0kLSW
+wcunQkaXz41Z/Rexpiene4pHb/oDJBwSJe401lzaRZgjMOFIyZrfN6obcGyyD5U5
+1m0+JSCoByxIVwyZUsuJCEECAwEAAaOB0DCBzTAdBgNVHQ4EFgQUdVXijuetpd2A
+PckzCyyiV3ftFawwHwYDVR0jBBgwFoAUwxJCuqnYTeDDPrrXR0GmCS9ttOEwEgYD
+VR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwMwYDVR0fBCwwKjAooCag
+JIYiaHR0cDovLzEyNy4wLjAuMTo4ODg4L3Jvb3RfY3JsLmRlcjAyBggrBgEFBQcB
+AQQmMCQwIgYIKwYBBQUHMAGGFmh0dHA6Ly8xMjcuMC4wLjE6ODg4OC8wDQYJKoZI
+hvcNAQELBQADggEBAB/G/ByhpW128H0oH+EVq4bgw92gF5YKwBYyUjektq0k1/08
+ATQ7qaLqgQXnBl+jr3v6sqnDY4m7DHBI6XPMM2TNs3GI0dGhWiKm7QNGjprAkjdG
+m+U3eKVD1UaZGzRAJ4+V3caaVdlgJY246W7Js+7o8NkR706uHgNwA2Bm/auw9HS2
+J3x6lp2GWF9c0wSrFlcSU1HHk8oLTmcnLbcgeba3jOfD2SVeJWPPk/BuMcDVTwUc
+jRQbatUBtnoJbzjz5eJa5OJC1YqN3u9zJYU846nv9/cjT9MnwjrGwG8qmx7+/DFz
+EOEIYpgrbS/Mq906ZcIAfykYMs2PVqkdhvFeYFU=
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            27:5e:cf:7e:be:aa:02:b9:a9:c7:42:30:43:fe:0e:80:05:91:dd:0b
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Root CA
+        Validity
+            Not Before: May  1 18:57:57 2023 GMT
+            Not After : Apr 28 18:57:57 2033 GMT
+        Subject: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Root CA
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:e2:21:6b:9f:ef:48:b9:de:22:fb:5b:37:09:68:
+                    c7:b5:92:57:52:24:ef:85:00:e8:71:85:4d:0f:5b:
+                    8c:c6:e7:4f:19:f6:e3:0b:70:a3:41:7e:71:d4:0f:
+                    d6:fd:f2:1a:ca:aa:57:91:76:9a:b2:82:62:60:ce:
+                    f2:00:2e:d4:bc:58:d3:60:30:42:a6:28:b2:50:7b:
+                    58:01:9f:fb:0a:65:b0:40:d6:7c:e2:b7:da:8d:19:
+                    d9:a5:51:d2:46:7e:14:46:ab:fa:df:ce:fe:84:08:
+                    98:63:46:1d:4d:8a:77:57:67:da:16:8b:32:0c:7c:
+                    41:e2:a5:ec:ee:7d:20:28:eb:03:5f:f5:e6:05:d8:
+                    8b:96:78:6f:ae:29:9a:50:f7:dc:96:31:86:81:b1:
+                    78:e8:eb:ef:5d:bb:ed:42:ec:94:c6:54:46:ec:05:
+                    6f:1b:0c:36:24:c6:a8:06:7e:5c:56:b8:43:3b:11:
+                    f4:06:0a:05:15:19:3b:1f:c8:67:31:eb:3b:5b:2a:
+                    15:0a:7b:f9:6b:e4:10:ee:44:be:19:d8:db:44:01:
+                    fa:3a:56:f5:6c:4e:f3:60:aa:e4:cd:b2:ad:77:07:
+                    45:ef:f1:d7:f5:fa:52:84:5c:03:4e:72:e0:a9:91:
+                    c5:d9:d6:0a:84:33:98:31:f2:02:5b:3f:10:15:65:
+                    76:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                C3:12:42:BA:A9:D8:4D:E0:C3:3E:BA:D7:47:41:A6:09:2F:6D:B4:E1
+            X509v3 Authority Key Identifier: 
+                C3:12:42:BA:A9:D8:4D:E0:C3:3E:BA:D7:47:41:A6:09:2F:6D:B4:E1
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://127.0.0.1:8888/root_crl.der
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        22:79:1a:b9:5d:fa:f5:c9:a3:88:22:c4:92:e6:64:6d:ce:a5:
+        ae:2e:69:48:6a:9e:d5:11:c5:bb:b0:de:38:1b:5b:04:85:60:
+        d6:64:14:ed:c2:62:02:7d:ad:d2:17:ad:ef:40:27:2b:50:59:
+        4a:ff:88:c6:b3:16:5c:55:30:d9:23:bd:4f:0f:34:b7:7b:ed:
+        7a:e1:f3:39:35:e9:18:6d:70:b1:2b:2a:e2:e5:cd:a1:54:8a:
+        f9:f4:95:81:29:84:3f:95:2f:48:e0:35:3e:d9:cb:84:4d:3d:
+        3e:3c:0e:8d:24:42:5f:19:e6:06:a5:87:ae:ba:af:07:02:e7:
+        6a:83:0a:89:d4:a4:38:ce:05:6e:f6:15:f1:7a:53:bb:50:28:
+        89:51:3f:f2:54:f1:d3:c4:28:07:a1:3e:55:e5:84:b8:df:58:
+        af:c3:e7:81:c2:08:9c:35:e4:c4:86:75:a8:17:99:2c:a6:7f:
+        46:30:9b:23:55:c5:d8:e2:6a:e4:08:a1:8b:dc:bc:5b:86:95:
+        4a:79:fe:a6:93:3d:1a:5b:10:9a:2f:6a:45:2f:5d:c9:fa:95:
+        2e:66:eb:52:df:88:a7:5f:42:8f:5f:46:07:79:8b:a7:49:82:
+        d3:81:c6:3e:c2:5a:15:c4:83:69:30:49:4d:6e:ea:05:1e:d8:
+        dc:29:ac:17
+-----BEGIN CERTIFICATE-----
+MIIDyDCCArCgAwIBAgIUJ17Pfr6qArmpx0IwQ/4OgAWR3QswDQYJKoZIhvcNAQEL
+BQAwUDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldBMQ8wDQYDVQQHDAZUYWNvbWEx
+ETAPBgNVBAoMCFRlc3RuYXRzMRAwDgYDVQQDDAdSb290IENBMB4XDTIzMDUwMTE4
+NTc1N1oXDTMzMDQyODE4NTc1N1owUDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldB
+MQ8wDQYDVQQHDAZUYWNvbWExETAPBgNVBAoMCFRlc3RuYXRzMRAwDgYDVQQDDAdS
+b290IENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4iFrn+9Iud4i
++1s3CWjHtZJXUiTvhQDocYVND1uMxudPGfbjC3CjQX5x1A/W/fIayqpXkXaasoJi
+YM7yAC7UvFjTYDBCpiiyUHtYAZ/7CmWwQNZ84rfajRnZpVHSRn4URqv6387+hAiY
+Y0YdTYp3V2faFosyDHxB4qXs7n0gKOsDX/XmBdiLlnhvrimaUPfcljGGgbF46Ovv
+XbvtQuyUxlRG7AVvGww2JMaoBn5cVrhDOxH0BgoFFRk7H8hnMes7WyoVCnv5a+QQ
+7kS+GdjbRAH6Olb1bE7zYKrkzbKtdwdF7/HX9fpShFwDTnLgqZHF2dYKhDOYMfIC
+Wz8QFWV21wIDAQABo4GZMIGWMB0GA1UdDgQWBBTDEkK6qdhN4MM+utdHQaYJL220
+4TAfBgNVHSMEGDAWgBTDEkK6qdhN4MM+utdHQaYJL2204TAPBgNVHRMBAf8EBTAD
+AQH/MA4GA1UdDwEB/wQEAwIBhjAzBgNVHR8ELDAqMCigJqAkhiJodHRwOi8vMTI3
+LjAuMC4xOjg4ODgvcm9vdF9jcmwuZGVyMA0GCSqGSIb3DQEBCwUAA4IBAQAieRq5
+Xfr1yaOIIsSS5mRtzqWuLmlIap7VEcW7sN44G1sEhWDWZBTtwmICfa3SF63vQCcr
+UFlK/4jGsxZcVTDZI71PDzS3e+164fM5NekYbXCxKyri5c2hVIr59JWBKYQ/lS9I
+4DU+2cuETT0+PA6NJEJfGeYGpYeuuq8HAudqgwqJ1KQ4zgVu9hXxelO7UCiJUT/y
+VPHTxCgHoT5V5YS431ivw+eBwgicNeTEhnWoF5kspn9GMJsjVcXY4mrkCKGL3Lxb
+hpVKef6mkz0aWxCaL2pFL13J+pUuZutS34inX0KPX0YHeYunSYLTgcY+wloVxINp
+MElNbuoFHtjcKawX
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            55:57:db:45:43:06:ce:52:63:59:b9:5a:26:78:fd:0d:94:68:95:9c
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Root CA
+        Validity
+            Not Before: May  1 19:01:15 2023 GMT
+            Not After : Apr 28 19:01:15 2033 GMT
+        Subject: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Intermediate CA 1
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:bc:c6:84:2d:c2:ab:5d:05:d7:65:a8:e2:15:74:
+                    d8:f2:f1:55:11:45:93:96:4c:a5:dc:cb:44:f5:f4:
+                    14:7e:46:02:59:e8:ae:78:59:69:21:58:f7:16:38:
+                    b9:c2:c2:60:d8:76:ab:a1:39:ba:0b:a3:03:17:e4:
+                    a1:cb:5d:1a:0c:62:71:24:64:b0:00:f0:6f:4c:af:
+                    08:62:8c:dc:4f:e0:d7:d4:55:2c:db:36:fc:a9:aa:
+                    d7:58:27:e4:99:cb:dc:29:d9:ea:35:16:cb:2e:be:
+                    04:b2:82:58:f4:e5:5c:07:db:12:8e:e3:3c:9a:5e:
+                    90:4b:c5:a3:d4:21:96:5f:e1:8f:f7:cb:9e:db:e0:
+                    10:a0:6c:a2:1e:30:17:6c:32:9f:7b:43:a4:9f:d3:
+                    6b:33:1b:18:cd:a4:ad:33:48:a3:98:b0:2b:c8:22:
+                    74:17:71:d8:f1:64:21:55:e1:33:bc:7f:74:5f:a5:
+                    a6:a2:9b:58:2f:db:ed:c7:c1:e5:36:2e:86:26:ad:
+                    c6:fe:b8:00:85:6e:7c:ed:fd:4a:c6:a0:d9:b2:3f:
+                    4e:bd:fa:08:52:c8:5d:31:13:86:bd:3f:ec:7a:d8:
+                    3a:15:e2:71:af:ec:00:88:7e:a6:e8:e1:9d:ab:57:
+                    5a:8a:1f:f8:e2:4d:29:58:53:79:25:f0:9e:d9:18:
+                    40:27
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B5:91:6E:4F:64:B7:16:84:76:F9:B4:BE:99:CE:60:95:98:1A:8E:9D
+            X509v3 Authority Key Identifier: 
+                C3:12:42:BA:A9:D8:4D:E0:C3:3E:BA:D7:47:41:A6:09:2F:6D:B4:E1
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://127.0.0.1:8888/root_crl.der
+            Authority Information Access: 
+                OCSP - URI:http://127.0.0.1:8888/
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        b1:48:16:3b:d7:91:d0:4d:54:09:cb:ab:c7:41:4f:35:12:8b:
+        a6:e8:84:11:49:a9:04:91:41:25:7c:02:38:b2:19:a0:e9:2e:
+        d5:d6:7a:26:c1:1a:f8:f1:c6:51:92:68:af:c8:6e:5b:df:28:
+        40:b8:99:94:d5:43:7d:e3:68:75:94:26:56:11:21:9e:50:b3:
+        36:7b:f8:5f:33:76:64:71:04:26:2b:bb:2c:83:33:89:ba:74:
+        c1:e9:9d:eb:c0:86:4b:4d:6f:f8:4d:55:5a:3d:f6:55:95:33:
+        0f:b8:f0:53:2b:93:a6:da:8d:5c:1a:e8:30:22:55:67:44:6e:
+        17:c4:57:05:0d:ce:fc:61:dd:b1:3c:b0:66:55:f4:42:d0:ce:
+        94:7d:6a:82:bd:32:ed:2f:21:ff:c7:70:ff:48:9d:10:4a:71:
+        be:a8:37:e5:0f:f4:79:1e:7d:a2:f1:6a:6b:2c:e8:03:20:ce:
+        80:94:d2:38:80:bc:7e:56:c5:77:62:94:c0:b7:40:11:4d:ba:
+        98:4b:2e:52:03:66:68:36:ab:d1:0f:3e:b5:92:a3:95:9d:a4:
+        ea:d3:8a:14:41:6d:86:24:89:aa:d7:29:20:c8:52:d5:bf:8d:
+        3b:09:52:dd:89:8c:2c:85:40:b5:9f:cc:47:63:ca:3a:e0:c9:
+        91:5c:43:a9
+-----BEGIN CERTIFICATE-----
+MIIECTCCAvGgAwIBAgIUVVfbRUMGzlJjWblaJnj9DZRolZwwDQYJKoZIhvcNAQEL
+BQAwUDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldBMQ8wDQYDVQQHDAZUYWNvbWEx
+ETAPBgNVBAoMCFRlc3RuYXRzMRAwDgYDVQQDDAdSb290IENBMB4XDTIzMDUwMTE5
+MDExNVoXDTMzMDQyODE5MDExNVowWjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldB
+MQ8wDQYDVQQHDAZUYWNvbWExETAPBgNVBAoMCFRlc3RuYXRzMRowGAYDVQQDDBFJ
+bnRlcm1lZGlhdGUgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+ALzGhC3Cq10F12Wo4hV02PLxVRFFk5ZMpdzLRPX0FH5GAlnornhZaSFY9xY4ucLC
+YNh2q6E5ugujAxfkoctdGgxicSRksADwb0yvCGKM3E/g19RVLNs2/Kmq11gn5JnL
+3CnZ6jUWyy6+BLKCWPTlXAfbEo7jPJpekEvFo9Qhll/hj/fLntvgEKBsoh4wF2wy
+n3tDpJ/TazMbGM2krTNIo5iwK8gidBdx2PFkIVXhM7x/dF+lpqKbWC/b7cfB5TYu
+hiatxv64AIVufO39Ssag2bI/Tr36CFLIXTEThr0/7HrYOhXica/sAIh+pujhnatX
+Woof+OJNKVhTeSXwntkYQCcCAwEAAaOB0DCBzTAdBgNVHQ4EFgQUtZFuT2S3FoR2
++bS+mc5glZgajp0wHwYDVR0jBBgwFoAUwxJCuqnYTeDDPrrXR0GmCS9ttOEwEgYD
+VR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwMwYDVR0fBCwwKjAooCag
+JIYiaHR0cDovLzEyNy4wLjAuMTo4ODg4L3Jvb3RfY3JsLmRlcjAyBggrBgEFBQcB
+AQQmMCQwIgYIKwYBBQUHMAGGFmh0dHA6Ly8xMjcuMC4wLjE6ODg4OC8wDQYJKoZI
+hvcNAQELBQADggEBALFIFjvXkdBNVAnLq8dBTzUSi6bohBFJqQSRQSV8AjiyGaDp
+LtXWeibBGvjxxlGSaK/IblvfKEC4mZTVQ33jaHWUJlYRIZ5QszZ7+F8zdmRxBCYr
+uyyDM4m6dMHpnevAhktNb/hNVVo99lWVMw+48FMrk6bajVwa6DAiVWdEbhfEVwUN
+zvxh3bE8sGZV9ELQzpR9aoK9Mu0vIf/HcP9InRBKcb6oN+UP9HkefaLxamss6AMg
+zoCU0jiAvH5WxXdilMC3QBFNuphLLlIDZmg2q9EPPrWSo5WdpOrTihRBbYYkiarX
+KSDIUtW/jTsJUt2JjCyFQLWfzEdjyjrgyZFcQ6k=
+-----END CERTIFICATE-----

--- a/test/configs/certs/ocsp_peer/mini-ca/misc/trust_config2_bundle.pem
+++ b/test/configs/certs/ocsp_peer/mini-ca/misc/trust_config2_bundle.pem
@@ -1,0 +1,264 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            3c:d7:16:fb:15:99:81:4e:53:f8:80:7c:b6:7c:77:a6:06:a4:3e:ea
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Root CA
+        Validity
+            Not Before: May  1 19:01:43 2023 GMT
+            Not After : Apr 28 19:01:43 2033 GMT
+        Subject: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Intermediate CA 2
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:da:5f:ff:1d:f7:8d:1a:9e:9a:f3:2b:68:8f:c1:
+                    0c:33:06:41:00:c9:3e:e4:1a:e1:e0:70:6a:f5:2f:
+                    ad:df:f3:e9:99:ed:c5:d7:aa:93:13:37:ff:47:aa:
+                    f3:c5:89:f7:b7:ad:3a:47:e5:9c:4e:9f:8c:e2:41:
+                    ed:a4:7c:9d:88:32:ae:f5:8a:84:9f:0c:18:a0:b3:
+                    fe:8e:dc:2a:88:6a:f5:2f:9c:86:92:fa:7b:6e:b3:
+                    5a:78:67:53:0b:21:6c:0d:6c:80:1a:0e:1e:ee:06:
+                    c4:d2:e7:24:c6:e5:74:be:1e:2e:17:55:2b:e5:9f:
+                    0b:a0:58:cc:fe:bf:53:37:f7:dc:95:88:f4:77:a6:
+                    59:b4:b8:7c:a2:4b:b7:6a:67:aa:84:dc:29:f1:f9:
+                    d7:89:05:4d:0b:f3:8b:2d:52:99:57:ed:6f:11:9e:
+                    af:28:a3:61:44:c2:ec:6e:7f:9f:3d:0b:dc:f7:19:
+                    6d:14:8a:a5:b8:b6:29:02:34:90:b4:96:c1:cb:a7:
+                    42:46:97:cf:8d:59:fd:17:b1:a6:27:a7:7b:8a:47:
+                    6f:fa:03:24:1c:12:25:ee:34:d6:5c:da:45:98:23:
+                    30:e1:48:c9:9a:df:37:aa:1b:70:6c:b2:0f:95:39:
+                    d6:6d:3e:25:20:a8:07:2c:48:57:0c:99:52:cb:89:
+                    08:41
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                75:55:E2:8E:E7:AD:A5:DD:80:3D:C9:33:0B:2C:A2:57:77:ED:15:AC
+            X509v3 Authority Key Identifier: 
+                C3:12:42:BA:A9:D8:4D:E0:C3:3E:BA:D7:47:41:A6:09:2F:6D:B4:E1
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://127.0.0.1:8888/root_crl.der
+            Authority Information Access: 
+                OCSP - URI:http://127.0.0.1:8888/
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        1f:c6:fc:1c:a1:a5:6d:76:f0:7d:28:1f:e1:15:ab:86:e0:c3:
+        dd:a0:17:96:0a:c0:16:32:52:37:a4:b6:ad:24:d7:fd:3c:01:
+        34:3b:a9:a2:ea:81:05:e7:06:5f:a3:af:7b:fa:b2:a9:c3:63:
+        89:bb:0c:70:48:e9:73:cc:33:64:cd:b3:71:88:d1:d1:a1:5a:
+        22:a6:ed:03:46:8e:9a:c0:92:37:46:9b:e5:37:78:a5:43:d5:
+        46:99:1b:34:40:27:8f:95:dd:c6:9a:55:d9:60:25:8d:b8:e9:
+        6e:c9:b3:ee:e8:f0:d9:11:ef:4e:ae:1e:03:70:03:60:66:fd:
+        ab:b0:f4:74:b6:27:7c:7a:96:9d:86:58:5f:5c:d3:04:ab:16:
+        57:12:53:51:c7:93:ca:0b:4e:67:27:2d:b7:20:79:b6:b7:8c:
+        e7:c3:d9:25:5e:25:63:cf:93:f0:6e:31:c0:d5:4f:05:1c:8d:
+        14:1b:6a:d5:01:b6:7a:09:6f:38:f3:e5:e2:5a:e4:e2:42:d5:
+        8a:8d:de:ef:73:25:85:3c:e3:a9:ef:f7:f7:23:4f:d3:27:c2:
+        3a:c6:c0:6f:2a:9b:1e:fe:fc:31:73:10:e1:08:62:98:2b:6d:
+        2f:cc:ab:dd:3a:65:c2:00:7f:29:18:32:cd:8f:56:a9:1d:86:
+        f1:5e:60:55
+-----BEGIN CERTIFICATE-----
+MIIECTCCAvGgAwIBAgIUPNcW+xWZgU5T+IB8tnx3pgakPuowDQYJKoZIhvcNAQEL
+BQAwUDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldBMQ8wDQYDVQQHDAZUYWNvbWEx
+ETAPBgNVBAoMCFRlc3RuYXRzMRAwDgYDVQQDDAdSb290IENBMB4XDTIzMDUwMTE5
+MDE0M1oXDTMzMDQyODE5MDE0M1owWjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldB
+MQ8wDQYDVQQHDAZUYWNvbWExETAPBgNVBAoMCFRlc3RuYXRzMRowGAYDVQQDDBFJ
+bnRlcm1lZGlhdGUgQ0EgMjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+ANpf/x33jRqemvMraI/BDDMGQQDJPuQa4eBwavUvrd/z6ZntxdeqkxM3/0eq88WJ
+97etOkflnE6fjOJB7aR8nYgyrvWKhJ8MGKCz/o7cKohq9S+chpL6e26zWnhnUwsh
+bA1sgBoOHu4GxNLnJMbldL4eLhdVK+WfC6BYzP6/Uzf33JWI9HemWbS4fKJLt2pn
+qoTcKfH514kFTQvziy1SmVftbxGeryijYUTC7G5/nz0L3PcZbRSKpbi2KQI0kLSW
+wcunQkaXz41Z/Rexpiene4pHb/oDJBwSJe401lzaRZgjMOFIyZrfN6obcGyyD5U5
+1m0+JSCoByxIVwyZUsuJCEECAwEAAaOB0DCBzTAdBgNVHQ4EFgQUdVXijuetpd2A
+PckzCyyiV3ftFawwHwYDVR0jBBgwFoAUwxJCuqnYTeDDPrrXR0GmCS9ttOEwEgYD
+VR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwMwYDVR0fBCwwKjAooCag
+JIYiaHR0cDovLzEyNy4wLjAuMTo4ODg4L3Jvb3RfY3JsLmRlcjAyBggrBgEFBQcB
+AQQmMCQwIgYIKwYBBQUHMAGGFmh0dHA6Ly8xMjcuMC4wLjE6ODg4OC8wDQYJKoZI
+hvcNAQELBQADggEBAB/G/ByhpW128H0oH+EVq4bgw92gF5YKwBYyUjektq0k1/08
+ATQ7qaLqgQXnBl+jr3v6sqnDY4m7DHBI6XPMM2TNs3GI0dGhWiKm7QNGjprAkjdG
+m+U3eKVD1UaZGzRAJ4+V3caaVdlgJY246W7Js+7o8NkR706uHgNwA2Bm/auw9HS2
+J3x6lp2GWF9c0wSrFlcSU1HHk8oLTmcnLbcgeba3jOfD2SVeJWPPk/BuMcDVTwUc
+jRQbatUBtnoJbzjz5eJa5OJC1YqN3u9zJYU846nv9/cjT9MnwjrGwG8qmx7+/DFz
+EOEIYpgrbS/Mq906ZcIAfykYMs2PVqkdhvFeYFU=
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            55:57:db:45:43:06:ce:52:63:59:b9:5a:26:78:fd:0d:94:68:95:9c
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Root CA
+        Validity
+            Not Before: May  1 19:01:15 2023 GMT
+            Not After : Apr 28 19:01:15 2033 GMT
+        Subject: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Intermediate CA 1
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:bc:c6:84:2d:c2:ab:5d:05:d7:65:a8:e2:15:74:
+                    d8:f2:f1:55:11:45:93:96:4c:a5:dc:cb:44:f5:f4:
+                    14:7e:46:02:59:e8:ae:78:59:69:21:58:f7:16:38:
+                    b9:c2:c2:60:d8:76:ab:a1:39:ba:0b:a3:03:17:e4:
+                    a1:cb:5d:1a:0c:62:71:24:64:b0:00:f0:6f:4c:af:
+                    08:62:8c:dc:4f:e0:d7:d4:55:2c:db:36:fc:a9:aa:
+                    d7:58:27:e4:99:cb:dc:29:d9:ea:35:16:cb:2e:be:
+                    04:b2:82:58:f4:e5:5c:07:db:12:8e:e3:3c:9a:5e:
+                    90:4b:c5:a3:d4:21:96:5f:e1:8f:f7:cb:9e:db:e0:
+                    10:a0:6c:a2:1e:30:17:6c:32:9f:7b:43:a4:9f:d3:
+                    6b:33:1b:18:cd:a4:ad:33:48:a3:98:b0:2b:c8:22:
+                    74:17:71:d8:f1:64:21:55:e1:33:bc:7f:74:5f:a5:
+                    a6:a2:9b:58:2f:db:ed:c7:c1:e5:36:2e:86:26:ad:
+                    c6:fe:b8:00:85:6e:7c:ed:fd:4a:c6:a0:d9:b2:3f:
+                    4e:bd:fa:08:52:c8:5d:31:13:86:bd:3f:ec:7a:d8:
+                    3a:15:e2:71:af:ec:00:88:7e:a6:e8:e1:9d:ab:57:
+                    5a:8a:1f:f8:e2:4d:29:58:53:79:25:f0:9e:d9:18:
+                    40:27
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B5:91:6E:4F:64:B7:16:84:76:F9:B4:BE:99:CE:60:95:98:1A:8E:9D
+            X509v3 Authority Key Identifier: 
+                C3:12:42:BA:A9:D8:4D:E0:C3:3E:BA:D7:47:41:A6:09:2F:6D:B4:E1
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://127.0.0.1:8888/root_crl.der
+            Authority Information Access: 
+                OCSP - URI:http://127.0.0.1:8888/
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        b1:48:16:3b:d7:91:d0:4d:54:09:cb:ab:c7:41:4f:35:12:8b:
+        a6:e8:84:11:49:a9:04:91:41:25:7c:02:38:b2:19:a0:e9:2e:
+        d5:d6:7a:26:c1:1a:f8:f1:c6:51:92:68:af:c8:6e:5b:df:28:
+        40:b8:99:94:d5:43:7d:e3:68:75:94:26:56:11:21:9e:50:b3:
+        36:7b:f8:5f:33:76:64:71:04:26:2b:bb:2c:83:33:89:ba:74:
+        c1:e9:9d:eb:c0:86:4b:4d:6f:f8:4d:55:5a:3d:f6:55:95:33:
+        0f:b8:f0:53:2b:93:a6:da:8d:5c:1a:e8:30:22:55:67:44:6e:
+        17:c4:57:05:0d:ce:fc:61:dd:b1:3c:b0:66:55:f4:42:d0:ce:
+        94:7d:6a:82:bd:32:ed:2f:21:ff:c7:70:ff:48:9d:10:4a:71:
+        be:a8:37:e5:0f:f4:79:1e:7d:a2:f1:6a:6b:2c:e8:03:20:ce:
+        80:94:d2:38:80:bc:7e:56:c5:77:62:94:c0:b7:40:11:4d:ba:
+        98:4b:2e:52:03:66:68:36:ab:d1:0f:3e:b5:92:a3:95:9d:a4:
+        ea:d3:8a:14:41:6d:86:24:89:aa:d7:29:20:c8:52:d5:bf:8d:
+        3b:09:52:dd:89:8c:2c:85:40:b5:9f:cc:47:63:ca:3a:e0:c9:
+        91:5c:43:a9
+-----BEGIN CERTIFICATE-----
+MIIECTCCAvGgAwIBAgIUVVfbRUMGzlJjWblaJnj9DZRolZwwDQYJKoZIhvcNAQEL
+BQAwUDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldBMQ8wDQYDVQQHDAZUYWNvbWEx
+ETAPBgNVBAoMCFRlc3RuYXRzMRAwDgYDVQQDDAdSb290IENBMB4XDTIzMDUwMTE5
+MDExNVoXDTMzMDQyODE5MDExNVowWjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldB
+MQ8wDQYDVQQHDAZUYWNvbWExETAPBgNVBAoMCFRlc3RuYXRzMRowGAYDVQQDDBFJ
+bnRlcm1lZGlhdGUgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+ALzGhC3Cq10F12Wo4hV02PLxVRFFk5ZMpdzLRPX0FH5GAlnornhZaSFY9xY4ucLC
+YNh2q6E5ugujAxfkoctdGgxicSRksADwb0yvCGKM3E/g19RVLNs2/Kmq11gn5JnL
+3CnZ6jUWyy6+BLKCWPTlXAfbEo7jPJpekEvFo9Qhll/hj/fLntvgEKBsoh4wF2wy
+n3tDpJ/TazMbGM2krTNIo5iwK8gidBdx2PFkIVXhM7x/dF+lpqKbWC/b7cfB5TYu
+hiatxv64AIVufO39Ssag2bI/Tr36CFLIXTEThr0/7HrYOhXica/sAIh+pujhnatX
+Woof+OJNKVhTeSXwntkYQCcCAwEAAaOB0DCBzTAdBgNVHQ4EFgQUtZFuT2S3FoR2
++bS+mc5glZgajp0wHwYDVR0jBBgwFoAUwxJCuqnYTeDDPrrXR0GmCS9ttOEwEgYD
+VR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwMwYDVR0fBCwwKjAooCag
+JIYiaHR0cDovLzEyNy4wLjAuMTo4ODg4L3Jvb3RfY3JsLmRlcjAyBggrBgEFBQcB
+AQQmMCQwIgYIKwYBBQUHMAGGFmh0dHA6Ly8xMjcuMC4wLjE6ODg4OC8wDQYJKoZI
+hvcNAQELBQADggEBALFIFjvXkdBNVAnLq8dBTzUSi6bohBFJqQSRQSV8AjiyGaDp
+LtXWeibBGvjxxlGSaK/IblvfKEC4mZTVQ33jaHWUJlYRIZ5QszZ7+F8zdmRxBCYr
+uyyDM4m6dMHpnevAhktNb/hNVVo99lWVMw+48FMrk6bajVwa6DAiVWdEbhfEVwUN
+zvxh3bE8sGZV9ELQzpR9aoK9Mu0vIf/HcP9InRBKcb6oN+UP9HkefaLxamss6AMg
+zoCU0jiAvH5WxXdilMC3QBFNuphLLlIDZmg2q9EPPrWSo5WdpOrTihRBbYYkiarX
+KSDIUtW/jTsJUt2JjCyFQLWfzEdjyjrgyZFcQ6k=
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            27:5e:cf:7e:be:aa:02:b9:a9:c7:42:30:43:fe:0e:80:05:91:dd:0b
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Root CA
+        Validity
+            Not Before: May  1 18:57:57 2023 GMT
+            Not After : Apr 28 18:57:57 2033 GMT
+        Subject: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Root CA
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:e2:21:6b:9f:ef:48:b9:de:22:fb:5b:37:09:68:
+                    c7:b5:92:57:52:24:ef:85:00:e8:71:85:4d:0f:5b:
+                    8c:c6:e7:4f:19:f6:e3:0b:70:a3:41:7e:71:d4:0f:
+                    d6:fd:f2:1a:ca:aa:57:91:76:9a:b2:82:62:60:ce:
+                    f2:00:2e:d4:bc:58:d3:60:30:42:a6:28:b2:50:7b:
+                    58:01:9f:fb:0a:65:b0:40:d6:7c:e2:b7:da:8d:19:
+                    d9:a5:51:d2:46:7e:14:46:ab:fa:df:ce:fe:84:08:
+                    98:63:46:1d:4d:8a:77:57:67:da:16:8b:32:0c:7c:
+                    41:e2:a5:ec:ee:7d:20:28:eb:03:5f:f5:e6:05:d8:
+                    8b:96:78:6f:ae:29:9a:50:f7:dc:96:31:86:81:b1:
+                    78:e8:eb:ef:5d:bb:ed:42:ec:94:c6:54:46:ec:05:
+                    6f:1b:0c:36:24:c6:a8:06:7e:5c:56:b8:43:3b:11:
+                    f4:06:0a:05:15:19:3b:1f:c8:67:31:eb:3b:5b:2a:
+                    15:0a:7b:f9:6b:e4:10:ee:44:be:19:d8:db:44:01:
+                    fa:3a:56:f5:6c:4e:f3:60:aa:e4:cd:b2:ad:77:07:
+                    45:ef:f1:d7:f5:fa:52:84:5c:03:4e:72:e0:a9:91:
+                    c5:d9:d6:0a:84:33:98:31:f2:02:5b:3f:10:15:65:
+                    76:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                C3:12:42:BA:A9:D8:4D:E0:C3:3E:BA:D7:47:41:A6:09:2F:6D:B4:E1
+            X509v3 Authority Key Identifier: 
+                C3:12:42:BA:A9:D8:4D:E0:C3:3E:BA:D7:47:41:A6:09:2F:6D:B4:E1
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://127.0.0.1:8888/root_crl.der
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        22:79:1a:b9:5d:fa:f5:c9:a3:88:22:c4:92:e6:64:6d:ce:a5:
+        ae:2e:69:48:6a:9e:d5:11:c5:bb:b0:de:38:1b:5b:04:85:60:
+        d6:64:14:ed:c2:62:02:7d:ad:d2:17:ad:ef:40:27:2b:50:59:
+        4a:ff:88:c6:b3:16:5c:55:30:d9:23:bd:4f:0f:34:b7:7b:ed:
+        7a:e1:f3:39:35:e9:18:6d:70:b1:2b:2a:e2:e5:cd:a1:54:8a:
+        f9:f4:95:81:29:84:3f:95:2f:48:e0:35:3e:d9:cb:84:4d:3d:
+        3e:3c:0e:8d:24:42:5f:19:e6:06:a5:87:ae:ba:af:07:02:e7:
+        6a:83:0a:89:d4:a4:38:ce:05:6e:f6:15:f1:7a:53:bb:50:28:
+        89:51:3f:f2:54:f1:d3:c4:28:07:a1:3e:55:e5:84:b8:df:58:
+        af:c3:e7:81:c2:08:9c:35:e4:c4:86:75:a8:17:99:2c:a6:7f:
+        46:30:9b:23:55:c5:d8:e2:6a:e4:08:a1:8b:dc:bc:5b:86:95:
+        4a:79:fe:a6:93:3d:1a:5b:10:9a:2f:6a:45:2f:5d:c9:fa:95:
+        2e:66:eb:52:df:88:a7:5f:42:8f:5f:46:07:79:8b:a7:49:82:
+        d3:81:c6:3e:c2:5a:15:c4:83:69:30:49:4d:6e:ea:05:1e:d8:
+        dc:29:ac:17
+-----BEGIN CERTIFICATE-----
+MIIDyDCCArCgAwIBAgIUJ17Pfr6qArmpx0IwQ/4OgAWR3QswDQYJKoZIhvcNAQEL
+BQAwUDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldBMQ8wDQYDVQQHDAZUYWNvbWEx
+ETAPBgNVBAoMCFRlc3RuYXRzMRAwDgYDVQQDDAdSb290IENBMB4XDTIzMDUwMTE4
+NTc1N1oXDTMzMDQyODE4NTc1N1owUDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldB
+MQ8wDQYDVQQHDAZUYWNvbWExETAPBgNVBAoMCFRlc3RuYXRzMRAwDgYDVQQDDAdS
+b290IENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4iFrn+9Iud4i
++1s3CWjHtZJXUiTvhQDocYVND1uMxudPGfbjC3CjQX5x1A/W/fIayqpXkXaasoJi
+YM7yAC7UvFjTYDBCpiiyUHtYAZ/7CmWwQNZ84rfajRnZpVHSRn4URqv6387+hAiY
+Y0YdTYp3V2faFosyDHxB4qXs7n0gKOsDX/XmBdiLlnhvrimaUPfcljGGgbF46Ovv
+XbvtQuyUxlRG7AVvGww2JMaoBn5cVrhDOxH0BgoFFRk7H8hnMes7WyoVCnv5a+QQ
+7kS+GdjbRAH6Olb1bE7zYKrkzbKtdwdF7/HX9fpShFwDTnLgqZHF2dYKhDOYMfIC
+Wz8QFWV21wIDAQABo4GZMIGWMB0GA1UdDgQWBBTDEkK6qdhN4MM+utdHQaYJL220
+4TAfBgNVHSMEGDAWgBTDEkK6qdhN4MM+utdHQaYJL2204TAPBgNVHRMBAf8EBTAD
+AQH/MA4GA1UdDwEB/wQEAwIBhjAzBgNVHR8ELDAqMCigJqAkhiJodHRwOi8vMTI3
+LjAuMC4xOjg4ODgvcm9vdF9jcmwuZGVyMA0GCSqGSIb3DQEBCwUAA4IBAQAieRq5
+Xfr1yaOIIsSS5mRtzqWuLmlIap7VEcW7sN44G1sEhWDWZBTtwmICfa3SF63vQCcr
+UFlK/4jGsxZcVTDZI71PDzS3e+164fM5NekYbXCxKyri5c2hVIr59JWBKYQ/lS9I
+4DU+2cuETT0+PA6NJEJfGeYGpYeuuq8HAudqgwqJ1KQ4zgVu9hXxelO7UCiJUT/y
+VPHTxCgHoT5V5YS431ivw+eBwgicNeTEhnWoF5kspn9GMJsjVcXY4mrkCKGL3Lxb
+hpVKef6mkz0aWxCaL2pFL13J+pUuZutS34inX0KPX0YHeYunSYLTgcY+wloVxINp
+MElNbuoFHtjcKawX
+-----END CERTIFICATE-----

--- a/test/configs/certs/ocsp_peer/mini-ca/misc/trust_config3_bundle.pem
+++ b/test/configs/certs/ocsp_peer/mini-ca/misc/trust_config3_bundle.pem
@@ -1,0 +1,264 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            55:57:db:45:43:06:ce:52:63:59:b9:5a:26:78:fd:0d:94:68:95:9c
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Root CA
+        Validity
+            Not Before: May  1 19:01:15 2023 GMT
+            Not After : Apr 28 19:01:15 2033 GMT
+        Subject: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Intermediate CA 1
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:bc:c6:84:2d:c2:ab:5d:05:d7:65:a8:e2:15:74:
+                    d8:f2:f1:55:11:45:93:96:4c:a5:dc:cb:44:f5:f4:
+                    14:7e:46:02:59:e8:ae:78:59:69:21:58:f7:16:38:
+                    b9:c2:c2:60:d8:76:ab:a1:39:ba:0b:a3:03:17:e4:
+                    a1:cb:5d:1a:0c:62:71:24:64:b0:00:f0:6f:4c:af:
+                    08:62:8c:dc:4f:e0:d7:d4:55:2c:db:36:fc:a9:aa:
+                    d7:58:27:e4:99:cb:dc:29:d9:ea:35:16:cb:2e:be:
+                    04:b2:82:58:f4:e5:5c:07:db:12:8e:e3:3c:9a:5e:
+                    90:4b:c5:a3:d4:21:96:5f:e1:8f:f7:cb:9e:db:e0:
+                    10:a0:6c:a2:1e:30:17:6c:32:9f:7b:43:a4:9f:d3:
+                    6b:33:1b:18:cd:a4:ad:33:48:a3:98:b0:2b:c8:22:
+                    74:17:71:d8:f1:64:21:55:e1:33:bc:7f:74:5f:a5:
+                    a6:a2:9b:58:2f:db:ed:c7:c1:e5:36:2e:86:26:ad:
+                    c6:fe:b8:00:85:6e:7c:ed:fd:4a:c6:a0:d9:b2:3f:
+                    4e:bd:fa:08:52:c8:5d:31:13:86:bd:3f:ec:7a:d8:
+                    3a:15:e2:71:af:ec:00:88:7e:a6:e8:e1:9d:ab:57:
+                    5a:8a:1f:f8:e2:4d:29:58:53:79:25:f0:9e:d9:18:
+                    40:27
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B5:91:6E:4F:64:B7:16:84:76:F9:B4:BE:99:CE:60:95:98:1A:8E:9D
+            X509v3 Authority Key Identifier: 
+                C3:12:42:BA:A9:D8:4D:E0:C3:3E:BA:D7:47:41:A6:09:2F:6D:B4:E1
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://127.0.0.1:8888/root_crl.der
+            Authority Information Access: 
+                OCSP - URI:http://127.0.0.1:8888/
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        b1:48:16:3b:d7:91:d0:4d:54:09:cb:ab:c7:41:4f:35:12:8b:
+        a6:e8:84:11:49:a9:04:91:41:25:7c:02:38:b2:19:a0:e9:2e:
+        d5:d6:7a:26:c1:1a:f8:f1:c6:51:92:68:af:c8:6e:5b:df:28:
+        40:b8:99:94:d5:43:7d:e3:68:75:94:26:56:11:21:9e:50:b3:
+        36:7b:f8:5f:33:76:64:71:04:26:2b:bb:2c:83:33:89:ba:74:
+        c1:e9:9d:eb:c0:86:4b:4d:6f:f8:4d:55:5a:3d:f6:55:95:33:
+        0f:b8:f0:53:2b:93:a6:da:8d:5c:1a:e8:30:22:55:67:44:6e:
+        17:c4:57:05:0d:ce:fc:61:dd:b1:3c:b0:66:55:f4:42:d0:ce:
+        94:7d:6a:82:bd:32:ed:2f:21:ff:c7:70:ff:48:9d:10:4a:71:
+        be:a8:37:e5:0f:f4:79:1e:7d:a2:f1:6a:6b:2c:e8:03:20:ce:
+        80:94:d2:38:80:bc:7e:56:c5:77:62:94:c0:b7:40:11:4d:ba:
+        98:4b:2e:52:03:66:68:36:ab:d1:0f:3e:b5:92:a3:95:9d:a4:
+        ea:d3:8a:14:41:6d:86:24:89:aa:d7:29:20:c8:52:d5:bf:8d:
+        3b:09:52:dd:89:8c:2c:85:40:b5:9f:cc:47:63:ca:3a:e0:c9:
+        91:5c:43:a9
+-----BEGIN CERTIFICATE-----
+MIIECTCCAvGgAwIBAgIUVVfbRUMGzlJjWblaJnj9DZRolZwwDQYJKoZIhvcNAQEL
+BQAwUDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldBMQ8wDQYDVQQHDAZUYWNvbWEx
+ETAPBgNVBAoMCFRlc3RuYXRzMRAwDgYDVQQDDAdSb290IENBMB4XDTIzMDUwMTE5
+MDExNVoXDTMzMDQyODE5MDExNVowWjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldB
+MQ8wDQYDVQQHDAZUYWNvbWExETAPBgNVBAoMCFRlc3RuYXRzMRowGAYDVQQDDBFJ
+bnRlcm1lZGlhdGUgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+ALzGhC3Cq10F12Wo4hV02PLxVRFFk5ZMpdzLRPX0FH5GAlnornhZaSFY9xY4ucLC
+YNh2q6E5ugujAxfkoctdGgxicSRksADwb0yvCGKM3E/g19RVLNs2/Kmq11gn5JnL
+3CnZ6jUWyy6+BLKCWPTlXAfbEo7jPJpekEvFo9Qhll/hj/fLntvgEKBsoh4wF2wy
+n3tDpJ/TazMbGM2krTNIo5iwK8gidBdx2PFkIVXhM7x/dF+lpqKbWC/b7cfB5TYu
+hiatxv64AIVufO39Ssag2bI/Tr36CFLIXTEThr0/7HrYOhXica/sAIh+pujhnatX
+Woof+OJNKVhTeSXwntkYQCcCAwEAAaOB0DCBzTAdBgNVHQ4EFgQUtZFuT2S3FoR2
++bS+mc5glZgajp0wHwYDVR0jBBgwFoAUwxJCuqnYTeDDPrrXR0GmCS9ttOEwEgYD
+VR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwMwYDVR0fBCwwKjAooCag
+JIYiaHR0cDovLzEyNy4wLjAuMTo4ODg4L3Jvb3RfY3JsLmRlcjAyBggrBgEFBQcB
+AQQmMCQwIgYIKwYBBQUHMAGGFmh0dHA6Ly8xMjcuMC4wLjE6ODg4OC8wDQYJKoZI
+hvcNAQELBQADggEBALFIFjvXkdBNVAnLq8dBTzUSi6bohBFJqQSRQSV8AjiyGaDp
+LtXWeibBGvjxxlGSaK/IblvfKEC4mZTVQ33jaHWUJlYRIZ5QszZ7+F8zdmRxBCYr
+uyyDM4m6dMHpnevAhktNb/hNVVo99lWVMw+48FMrk6bajVwa6DAiVWdEbhfEVwUN
+zvxh3bE8sGZV9ELQzpR9aoK9Mu0vIf/HcP9InRBKcb6oN+UP9HkefaLxamss6AMg
+zoCU0jiAvH5WxXdilMC3QBFNuphLLlIDZmg2q9EPPrWSo5WdpOrTihRBbYYkiarX
+KSDIUtW/jTsJUt2JjCyFQLWfzEdjyjrgyZFcQ6k=
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            3c:d7:16:fb:15:99:81:4e:53:f8:80:7c:b6:7c:77:a6:06:a4:3e:ea
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Root CA
+        Validity
+            Not Before: May  1 19:01:43 2023 GMT
+            Not After : Apr 28 19:01:43 2033 GMT
+        Subject: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Intermediate CA 2
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:da:5f:ff:1d:f7:8d:1a:9e:9a:f3:2b:68:8f:c1:
+                    0c:33:06:41:00:c9:3e:e4:1a:e1:e0:70:6a:f5:2f:
+                    ad:df:f3:e9:99:ed:c5:d7:aa:93:13:37:ff:47:aa:
+                    f3:c5:89:f7:b7:ad:3a:47:e5:9c:4e:9f:8c:e2:41:
+                    ed:a4:7c:9d:88:32:ae:f5:8a:84:9f:0c:18:a0:b3:
+                    fe:8e:dc:2a:88:6a:f5:2f:9c:86:92:fa:7b:6e:b3:
+                    5a:78:67:53:0b:21:6c:0d:6c:80:1a:0e:1e:ee:06:
+                    c4:d2:e7:24:c6:e5:74:be:1e:2e:17:55:2b:e5:9f:
+                    0b:a0:58:cc:fe:bf:53:37:f7:dc:95:88:f4:77:a6:
+                    59:b4:b8:7c:a2:4b:b7:6a:67:aa:84:dc:29:f1:f9:
+                    d7:89:05:4d:0b:f3:8b:2d:52:99:57:ed:6f:11:9e:
+                    af:28:a3:61:44:c2:ec:6e:7f:9f:3d:0b:dc:f7:19:
+                    6d:14:8a:a5:b8:b6:29:02:34:90:b4:96:c1:cb:a7:
+                    42:46:97:cf:8d:59:fd:17:b1:a6:27:a7:7b:8a:47:
+                    6f:fa:03:24:1c:12:25:ee:34:d6:5c:da:45:98:23:
+                    30:e1:48:c9:9a:df:37:aa:1b:70:6c:b2:0f:95:39:
+                    d6:6d:3e:25:20:a8:07:2c:48:57:0c:99:52:cb:89:
+                    08:41
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                75:55:E2:8E:E7:AD:A5:DD:80:3D:C9:33:0B:2C:A2:57:77:ED:15:AC
+            X509v3 Authority Key Identifier: 
+                C3:12:42:BA:A9:D8:4D:E0:C3:3E:BA:D7:47:41:A6:09:2F:6D:B4:E1
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://127.0.0.1:8888/root_crl.der
+            Authority Information Access: 
+                OCSP - URI:http://127.0.0.1:8888/
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        1f:c6:fc:1c:a1:a5:6d:76:f0:7d:28:1f:e1:15:ab:86:e0:c3:
+        dd:a0:17:96:0a:c0:16:32:52:37:a4:b6:ad:24:d7:fd:3c:01:
+        34:3b:a9:a2:ea:81:05:e7:06:5f:a3:af:7b:fa:b2:a9:c3:63:
+        89:bb:0c:70:48:e9:73:cc:33:64:cd:b3:71:88:d1:d1:a1:5a:
+        22:a6:ed:03:46:8e:9a:c0:92:37:46:9b:e5:37:78:a5:43:d5:
+        46:99:1b:34:40:27:8f:95:dd:c6:9a:55:d9:60:25:8d:b8:e9:
+        6e:c9:b3:ee:e8:f0:d9:11:ef:4e:ae:1e:03:70:03:60:66:fd:
+        ab:b0:f4:74:b6:27:7c:7a:96:9d:86:58:5f:5c:d3:04:ab:16:
+        57:12:53:51:c7:93:ca:0b:4e:67:27:2d:b7:20:79:b6:b7:8c:
+        e7:c3:d9:25:5e:25:63:cf:93:f0:6e:31:c0:d5:4f:05:1c:8d:
+        14:1b:6a:d5:01:b6:7a:09:6f:38:f3:e5:e2:5a:e4:e2:42:d5:
+        8a:8d:de:ef:73:25:85:3c:e3:a9:ef:f7:f7:23:4f:d3:27:c2:
+        3a:c6:c0:6f:2a:9b:1e:fe:fc:31:73:10:e1:08:62:98:2b:6d:
+        2f:cc:ab:dd:3a:65:c2:00:7f:29:18:32:cd:8f:56:a9:1d:86:
+        f1:5e:60:55
+-----BEGIN CERTIFICATE-----
+MIIECTCCAvGgAwIBAgIUPNcW+xWZgU5T+IB8tnx3pgakPuowDQYJKoZIhvcNAQEL
+BQAwUDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldBMQ8wDQYDVQQHDAZUYWNvbWEx
+ETAPBgNVBAoMCFRlc3RuYXRzMRAwDgYDVQQDDAdSb290IENBMB4XDTIzMDUwMTE5
+MDE0M1oXDTMzMDQyODE5MDE0M1owWjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldB
+MQ8wDQYDVQQHDAZUYWNvbWExETAPBgNVBAoMCFRlc3RuYXRzMRowGAYDVQQDDBFJ
+bnRlcm1lZGlhdGUgQ0EgMjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+ANpf/x33jRqemvMraI/BDDMGQQDJPuQa4eBwavUvrd/z6ZntxdeqkxM3/0eq88WJ
+97etOkflnE6fjOJB7aR8nYgyrvWKhJ8MGKCz/o7cKohq9S+chpL6e26zWnhnUwsh
+bA1sgBoOHu4GxNLnJMbldL4eLhdVK+WfC6BYzP6/Uzf33JWI9HemWbS4fKJLt2pn
+qoTcKfH514kFTQvziy1SmVftbxGeryijYUTC7G5/nz0L3PcZbRSKpbi2KQI0kLSW
+wcunQkaXz41Z/Rexpiene4pHb/oDJBwSJe401lzaRZgjMOFIyZrfN6obcGyyD5U5
+1m0+JSCoByxIVwyZUsuJCEECAwEAAaOB0DCBzTAdBgNVHQ4EFgQUdVXijuetpd2A
+PckzCyyiV3ftFawwHwYDVR0jBBgwFoAUwxJCuqnYTeDDPrrXR0GmCS9ttOEwEgYD
+VR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwMwYDVR0fBCwwKjAooCag
+JIYiaHR0cDovLzEyNy4wLjAuMTo4ODg4L3Jvb3RfY3JsLmRlcjAyBggrBgEFBQcB
+AQQmMCQwIgYIKwYBBQUHMAGGFmh0dHA6Ly8xMjcuMC4wLjE6ODg4OC8wDQYJKoZI
+hvcNAQELBQADggEBAB/G/ByhpW128H0oH+EVq4bgw92gF5YKwBYyUjektq0k1/08
+ATQ7qaLqgQXnBl+jr3v6sqnDY4m7DHBI6XPMM2TNs3GI0dGhWiKm7QNGjprAkjdG
+m+U3eKVD1UaZGzRAJ4+V3caaVdlgJY246W7Js+7o8NkR706uHgNwA2Bm/auw9HS2
+J3x6lp2GWF9c0wSrFlcSU1HHk8oLTmcnLbcgeba3jOfD2SVeJWPPk/BuMcDVTwUc
+jRQbatUBtnoJbzjz5eJa5OJC1YqN3u9zJYU846nv9/cjT9MnwjrGwG8qmx7+/DFz
+EOEIYpgrbS/Mq906ZcIAfykYMs2PVqkdhvFeYFU=
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            27:5e:cf:7e:be:aa:02:b9:a9:c7:42:30:43:fe:0e:80:05:91:dd:0b
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Root CA
+        Validity
+            Not Before: May  1 18:57:57 2023 GMT
+            Not After : Apr 28 18:57:57 2033 GMT
+        Subject: C=US, ST=WA, L=Tacoma, O=Testnats, CN=Root CA
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:e2:21:6b:9f:ef:48:b9:de:22:fb:5b:37:09:68:
+                    c7:b5:92:57:52:24:ef:85:00:e8:71:85:4d:0f:5b:
+                    8c:c6:e7:4f:19:f6:e3:0b:70:a3:41:7e:71:d4:0f:
+                    d6:fd:f2:1a:ca:aa:57:91:76:9a:b2:82:62:60:ce:
+                    f2:00:2e:d4:bc:58:d3:60:30:42:a6:28:b2:50:7b:
+                    58:01:9f:fb:0a:65:b0:40:d6:7c:e2:b7:da:8d:19:
+                    d9:a5:51:d2:46:7e:14:46:ab:fa:df:ce:fe:84:08:
+                    98:63:46:1d:4d:8a:77:57:67:da:16:8b:32:0c:7c:
+                    41:e2:a5:ec:ee:7d:20:28:eb:03:5f:f5:e6:05:d8:
+                    8b:96:78:6f:ae:29:9a:50:f7:dc:96:31:86:81:b1:
+                    78:e8:eb:ef:5d:bb:ed:42:ec:94:c6:54:46:ec:05:
+                    6f:1b:0c:36:24:c6:a8:06:7e:5c:56:b8:43:3b:11:
+                    f4:06:0a:05:15:19:3b:1f:c8:67:31:eb:3b:5b:2a:
+                    15:0a:7b:f9:6b:e4:10:ee:44:be:19:d8:db:44:01:
+                    fa:3a:56:f5:6c:4e:f3:60:aa:e4:cd:b2:ad:77:07:
+                    45:ef:f1:d7:f5:fa:52:84:5c:03:4e:72:e0:a9:91:
+                    c5:d9:d6:0a:84:33:98:31:f2:02:5b:3f:10:15:65:
+                    76:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                C3:12:42:BA:A9:D8:4D:E0:C3:3E:BA:D7:47:41:A6:09:2F:6D:B4:E1
+            X509v3 Authority Key Identifier: 
+                C3:12:42:BA:A9:D8:4D:E0:C3:3E:BA:D7:47:41:A6:09:2F:6D:B4:E1
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://127.0.0.1:8888/root_crl.der
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        22:79:1a:b9:5d:fa:f5:c9:a3:88:22:c4:92:e6:64:6d:ce:a5:
+        ae:2e:69:48:6a:9e:d5:11:c5:bb:b0:de:38:1b:5b:04:85:60:
+        d6:64:14:ed:c2:62:02:7d:ad:d2:17:ad:ef:40:27:2b:50:59:
+        4a:ff:88:c6:b3:16:5c:55:30:d9:23:bd:4f:0f:34:b7:7b:ed:
+        7a:e1:f3:39:35:e9:18:6d:70:b1:2b:2a:e2:e5:cd:a1:54:8a:
+        f9:f4:95:81:29:84:3f:95:2f:48:e0:35:3e:d9:cb:84:4d:3d:
+        3e:3c:0e:8d:24:42:5f:19:e6:06:a5:87:ae:ba:af:07:02:e7:
+        6a:83:0a:89:d4:a4:38:ce:05:6e:f6:15:f1:7a:53:bb:50:28:
+        89:51:3f:f2:54:f1:d3:c4:28:07:a1:3e:55:e5:84:b8:df:58:
+        af:c3:e7:81:c2:08:9c:35:e4:c4:86:75:a8:17:99:2c:a6:7f:
+        46:30:9b:23:55:c5:d8:e2:6a:e4:08:a1:8b:dc:bc:5b:86:95:
+        4a:79:fe:a6:93:3d:1a:5b:10:9a:2f:6a:45:2f:5d:c9:fa:95:
+        2e:66:eb:52:df:88:a7:5f:42:8f:5f:46:07:79:8b:a7:49:82:
+        d3:81:c6:3e:c2:5a:15:c4:83:69:30:49:4d:6e:ea:05:1e:d8:
+        dc:29:ac:17
+-----BEGIN CERTIFICATE-----
+MIIDyDCCArCgAwIBAgIUJ17Pfr6qArmpx0IwQ/4OgAWR3QswDQYJKoZIhvcNAQEL
+BQAwUDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldBMQ8wDQYDVQQHDAZUYWNvbWEx
+ETAPBgNVBAoMCFRlc3RuYXRzMRAwDgYDVQQDDAdSb290IENBMB4XDTIzMDUwMTE4
+NTc1N1oXDTMzMDQyODE4NTc1N1owUDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldB
+MQ8wDQYDVQQHDAZUYWNvbWExETAPBgNVBAoMCFRlc3RuYXRzMRAwDgYDVQQDDAdS
+b290IENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4iFrn+9Iud4i
++1s3CWjHtZJXUiTvhQDocYVND1uMxudPGfbjC3CjQX5x1A/W/fIayqpXkXaasoJi
+YM7yAC7UvFjTYDBCpiiyUHtYAZ/7CmWwQNZ84rfajRnZpVHSRn4URqv6387+hAiY
+Y0YdTYp3V2faFosyDHxB4qXs7n0gKOsDX/XmBdiLlnhvrimaUPfcljGGgbF46Ovv
+XbvtQuyUxlRG7AVvGww2JMaoBn5cVrhDOxH0BgoFFRk7H8hnMes7WyoVCnv5a+QQ
+7kS+GdjbRAH6Olb1bE7zYKrkzbKtdwdF7/HX9fpShFwDTnLgqZHF2dYKhDOYMfIC
+Wz8QFWV21wIDAQABo4GZMIGWMB0GA1UdDgQWBBTDEkK6qdhN4MM+utdHQaYJL220
+4TAfBgNVHSMEGDAWgBTDEkK6qdhN4MM+utdHQaYJL2204TAPBgNVHRMBAf8EBTAD
+AQH/MA4GA1UdDwEB/wQEAwIBhjAzBgNVHR8ELDAqMCigJqAkhiJodHRwOi8vMTI3
+LjAuMC4xOjg4ODgvcm9vdF9jcmwuZGVyMA0GCSqGSIb3DQEBCwUAA4IBAQAieRq5
+Xfr1yaOIIsSS5mRtzqWuLmlIap7VEcW7sN44G1sEhWDWZBTtwmICfa3SF63vQCcr
+UFlK/4jGsxZcVTDZI71PDzS3e+164fM5NekYbXCxKyri5c2hVIr59JWBKYQ/lS9I
+4DU+2cuETT0+PA6NJEJfGeYGpYeuuq8HAudqgwqJ1KQ4zgVu9hXxelO7UCiJUT/y
+VPHTxCgHoT5V5YS431ivw+eBwgicNeTEhnWoF5kspn9GMJsjVcXY4mrkCKGL3Lxb
+hpVKef6mkz0aWxCaL2pFL13J+pUuZutS34inX0KPX0YHeYunSYLTgcY+wloVxINp
+MElNbuoFHtjcKawX
+-----END CERTIFICATE-----

--- a/test/ocsp_test.go
+++ b/test/ocsp_test.go
@@ -3454,7 +3454,6 @@ func TestOCSPLocalIssuerDetermination(t *testing.T) {
 	serverCert := "configs/certs/ocsp_peer/mini-ca/server1/TestServer1_cert.pem"
 
 	var (
-		// errExpectedNoStaple = fmt.Errorf("expected no staple")
 		errMissingStaple = fmt.Errorf("missing OCSP Staple from server")
 	)
 


### PR DESCRIPTION
Resolves problems of [issue #3773](https://github.com/nats-io/nats-server/issues/3773).  

With this fix, NATS Server will locally determine it's own certificate's issuer from either the configured server certificate (bundle of leaf cert plus optional intermediate CA certs) or from the configured server CA trust store, as follows: 

1. The operator may provide the server's certificate issuer in the second position of the server's certificate configuration (typically `cert_file` but may be `cert_store` on the Windows platform).  If a candidate issuer is found here it is PKI validated as the actual issuer of the server's cert else a hard error.

2. If not found in [1], NATS Server will seek to create at least one verified chain with its configured trust store (typically `ca_file` but could by the system trust store if not configured).  It will derive the issuer from the first verified chain.  If no verified chain can be formed it is a hard error.
