### PR TITLE
apply Go 1.21 loopvar fixes

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3233,6 +3233,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 	for sub, wm := range ac.Mappings {
 		mappings := make([]*MapDest, len(wm))
 		for i, m := range wm {
+			m := m
 			mappings[i] = &MapDest{
 				Subject: string(m.Subject),
 				Weight:  m.GetWeight(),

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5139,6 +5139,7 @@ func (fs *fileStore) State() StreamState {
 		cur := fs.state.FirstSeq
 
 		for _, mb := range fs.blks {
+			mb := mb
 			mb.mu.Lock()
 			fseq := mb.first.seq
 			// Account for messages missing from the head.

--- a/server/reload.go
+++ b/server/reload.go
@@ -1098,6 +1098,7 @@ func imposeOrder(value interface{}) error {
 			return value[i].Name < value[j].Name
 		})
 		for _, a := range value {
+			a := a
 			sort.Slice(a.imports.streams, func(i, j int) bool {
 				return a.imports.streams[i].acc.Name < a.imports.streams[j].acc.Name
 			})
@@ -2193,6 +2194,7 @@ func (s *Server) reloadClusterPoolAndAccounts(co *clusterOption, opts *Options) 
 		protosSent := 0
 		s.accAddedReqID = nuid.Next()
 		for _, an := range co.accsAdded {
+			an := an
 			if s.accRoutes == nil {
 				s.accRoutes = make(map[string]map[string]*client)
 			}
@@ -2340,6 +2342,7 @@ func (s *Server) reloadClusterPoolAndAccounts(co *clusterOption, opts *Options) 
 		// For accounts that no longer have a dedicated route, we need to send
 		// the subsriptions on the existing pooled routes for those accounts.
 		for _, an := range co.accsRemoved {
+			an := an
 			if a, ok := s.accounts.Load(an); ok {
 				acc := a.(*Account)
 				acc.mu.Lock()

--- a/server/server.go
+++ b/server/server.go
@@ -3664,6 +3664,7 @@ func (s *Server) getNonLocalIPsIfHostIsIPAny(host string, all bool) (bool, []str
 	var ips []string
 	ifaces, _ := net.Interfaces()
 	for _, i := range ifaces {
+		i := i
 		addrs, _ := i.Addrs()
 		for _, addr := range addrs {
 			switch v := addr.(type) {
@@ -3697,6 +3698,7 @@ func resolveHostPorts(addr net.Listener) []string {
 		var ip net.IP
 		ifaces, _ := net.Interfaces()
 		for _, i := range ifaces {
+			i := i
 			addrs, _ := i.Addrs()
 			for _, addr := range addrs {
 				switch v := addr.(type) {


### PR DESCRIPTION
Applies some of the loopvar fixes that Go 1.21 will find:

```sh
GOEXPERIMENT=loopvar go1.21rc2 build -gcflags=all=-d=loopvar=2 
server/accounts.go:3235:10: loop variable m now per-iteration, stack-allocated
server/server.go:3666:9: loop variable i now per-iteration, stack-allocated
server/server.go:3699:10: loop variable i now per-iteration, stack-allocated
server/filestore.go:5141:10: loop variable mb now per-iteration, stack-allocated
server/reload.go:1100:10: loop variable a now per-iteration, stack-allocated
server/reload.go:2195:10: loop variable an now per-iteration, stack-allocated
server/reload.go:2342:10: loop variable an now per-iteration, stack-allocated
```
