### PR TITLE
Fix some system service imports going missing after reload

### DIFF
--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -2700,6 +2700,42 @@ func TestConfigReloadAccountUsers(t *testing.T) {
 	})
 }
 
+func TestConfigReloadAccountWithNoChanges(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+	listen: "127.0.0.1:-1"
+        system_account: sys
+	accounts {
+		A {
+			users = [{ user: a }]
+		}
+		B {
+			users = [{ user: b }]
+		}
+		C {
+			users = [{ user: c }]
+		}
+		sys {
+			users = [{ user: sys }]
+		}
+	}
+	`))
+	s, _ := RunServerWithConfig(conf)
+	defer s.Shutdown()
+	before := s.NumSubscriptions()
+	s.Reload()
+	after := s.NumSubscriptions()
+	if before != after {
+		t.Errorf("Number of subscriptions changed after reload: %d -> %d", before, after)
+	}
+
+	before = s.NumSubscriptions()
+	s.Reload()
+	after = s.NumSubscriptions()
+	if before != after {
+		t.Errorf("Number of subscriptions changed after reload: %d -> %d", before, after)
+	}
+}
+
 func TestConfigReloadAccountNKeyUsers(t *testing.T) {
 	conf := createConfFile(t, []byte(`
 	listen: "127.0.0.1:-1"

--- a/server/server.go
+++ b/server/server.go
@@ -900,6 +900,9 @@ func (s *Server) configureAccounts(reloading bool) (map[string]struct{}, error) 
 			c.processUnsub(sid)
 		}
 		acc.addAllServiceImportSubs()
+		s.mu.Unlock()
+		s.registerSystemImports(acc)
+		s.mu.Lock()
 	}
 
 	// Set the system account if it was configured.


### PR DESCRIPTION
On reload some of the imports from the system account where going missing on reload, this adds them back after a reload:

```
$SYS.REQ.SERVER.PING.CONNZ
$SYS.REQ.ACCOUNT.PING.STATZ
$SYS.REQ.ACCOUNT.PING.CONNZ
```
