### PR TITLE
Allow switching from limits-based to interest-based retention in stream update

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -6980,7 +6980,7 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 	} else {
 		nca := ca.copyGroup()
 
-		rBefore := ca.Config.replicas(sa.Config)
+		rBefore := nca.Config.replicas(sa.Config)
 		rAfter := cfg.replicas(sa.Config)
 
 		var curLeader string

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -14,7 +14,6 @@
 package server
 
 import (
-	"bytes"
 	"fmt"
 	"math/rand"
 	"net/url"
@@ -112,17 +111,17 @@ func require_Error(t *testing.T, err error, expected ...error) {
 	t.Fatalf("Expected one of %v, got '%v'", expected, err)
 }
 
-func require_Equal(t *testing.T, a, b string) {
+func require_Equal[T comparable](t *testing.T, a, b T) {
 	t.Helper()
-	if strings.Compare(a, b) != 0 {
-		t.Fatalf("require equal, but got: %v != %v", a, b)
+	if a != b {
+		t.Fatalf("require %T equal, but got: %v != %v", a, a, b)
 	}
 }
 
-func require_NotEqual(t *testing.T, a, b [32]byte) {
+func require_NotEqual[T comparable](t *testing.T, a, b T) {
 	t.Helper()
-	if bytes.Equal(a[:], b[:]) {
-		t.Fatalf("require not equal, but got: %v != %v", a, b)
+	if a == b {
+		t.Fatalf("require %T not equal, but got: %v != %v", a, a, b)
 	}
 }
 


### PR DESCRIPTION
This should make it possible to switch from limits-based retention to interest-based retention on an existing stream.

Signed-off-by: Neil Twigg <neil@nats.io>