### PR TITLE
test: fix TestClusterTLSMixedIPAndDNS test in +go1.20

### DIFF
--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -3528,7 +3528,7 @@ func TestClusterTLSMixedIPAndDNS(t *testing.T) {
 	bConfigTemplate := `
 		listen: 127.0.0.1:-1
 		leafnodes {
-			listen: "localhost:-1"
+			listen: "127.0.0.1:-1"
 			tls {
 				cert_file: "./configs/certs/server-cert.pem"
 				key_file:  "./configs/certs/server-key.pem"


### PR DESCRIPTION
Test would fail now with the leafnode not being able to connect due to the following:

```
[4257] [INF] 127.0.0.1:63538 - lid:6 - Leafnode connection created for account: $G 
[4257] [INF] 127.0.0.1:63547 - lid:6 - Leafnode connection created 
[4257] [DBG] 127.0.0.1:63547 - lid:6 - Starting TLS leafnode server handshake
[4257] [DBG] 127.0.0.1:63538 - lid:6 - Starting TLS leafnode client handshake
[4257] [ERR] 127.0.0.1:63538 - lid:6 - TLS leafnode handshake error: x509: certificate is not valid for any names, but wanted to match localhost
[4257] [INF] 127.0.0.1:63538 - lid:6 - Leafnode connection closed: TLS Handshake Failure - Account: $G
[4257] [ERR] 127.0.0.1:63547 - lid:6 - TLS leafnode handshake error: remote error: tls: bad certificate
[4257] [INF] 127.0.0.1:63547 - lid:6 - Leafnode connection closed: TLS Handshake Failure
```