### PR TITLE
test: update TestNoRaceJetStreamServiceImportAccountSwapIssue flake

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -1171,7 +1171,7 @@ func TestNoRaceJetStreamServiceImportAccountSwapIssue(t *testing.T) {
 
 	// Pull messages flow.
 	var received int
-	for time.Now().Before(timeout) {
+	for time.Now().Before(timeout.Add(2 * time.Second)) {
 		if msgs, err := sub.Fetch(1, nats.MaxWait(200*time.Millisecond)); err == nil {
 			for _, m := range msgs {
 				received++


### PR DESCRIPTION
Let pull consumer in test fetch messages for slightly longer instead of at the same time as the producer, to avoid failing due to missing a few messages:

```
=== RUN   TestNoRaceJetStreamServiceImportAccountSwapIssue
    norace_test.go:1194: Expected to receive 14982 msgs, only got 14981
--- FAIL: TestNoRaceJetStreamServiceImportAccountSwapIssue (3.03s)
```