### PR TITLE
test: fix TestFileStoreNewWriteIndexInfo hanging

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -5478,9 +5478,16 @@ func TestFileStoreNewWriteIndexInfo(t *testing.T) {
 
 		mb.mu.Lock()
 		start := time.Now()
-		require_NoError(t, mb.writeIndexInfoLocked())
+		err = mb.writeIndexInfoLocked()
+		if err != nil {
+			mb.mu.Unlock()
+			t.Fatalf("Unexpected error: %v", err)
+		}
 		elapsed := time.Since(start)
-		require_True(t, elapsed < time.Millisecond)
+		if elapsed > time.Millisecond {
+			mb.mu.Unlock()
+			t.Fatalf("Unexpected elapsed time: %v", elapsed)
+		}
 		fi, err := os.Stat(mb.ifn)
 		mb.mu.Unlock()
 


### PR DESCRIPTION
`t.Fatalf` being called while holding a lock would sometimes leave builds hanging until test timeout.

```
=== RUN   TestFileStoreNewWriteIndexInfo/AES-GCM-None
=== RUN   TestFileStoreNewWriteIndexInfo/AES-GCM-S2
    filestore_test.go:5483: require true, but got false
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
```