### PR TITLE
test: fix TestMQTTTLSVerifyAndMap on Go 1.21

### DIFF
--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -1028,7 +1028,7 @@ func TestMQTTTLSVerifyAndMap(t *testing.T) {
 			if !test.provideCert {
 				if err == nil {
 					t.Fatal("Expected error, did not get one")
-				} else if !strings.Contains(err.Error(), "bad certificate") {
+				} else if !strings.Contains(err.Error(), "bad certificate") && !strings.Contains(err.Error(), "certificate required") {
 					t.Fatalf("Unexpected error: %v", err)
 				}
 				return


### PR DESCRIPTION
Reported error changed slightly in Go 1.21

```
=== RUN   TestMQTTTLSVerifyAndMap
=== RUN   TestMQTTTLSVerifyAndMap/no_filtering,_client_does_not_provide_cert
    mqtt_test.go:1033: Unexpected error: Error reading: remote error: tls: certificate required
--- FAIL: TestMQTTTLSVerifyAndMap (0.04s)
```