### PR TITLE
test: fix TestAccountImportCycle flake

### DIFF
--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -3432,11 +3432,13 @@ func TestAccountImportCycle(t *testing.T) {
 	// setup requestor
 	ib := "q2.inbox"
 	subAResp, err := ncA.SubscribeSync(ib)
+	ncA.Flush()
 	require_NoError(t, err)
 	req := func() {
 		t.Helper()
 		// send request
 		err = ncA.PublishRequest("q1.a", ib, []byte("test"))
+		ncA.Flush()
 		require_NoError(t, err)
 		mRep, err := subAResp.NextMsg(time.Second)
 		require_NoError(t, err)


### PR DESCRIPTION
Add extra flushes to make test more precise and try to avoid timeouts

```
=== RUN   TestAccountImportCycle
    accounts_test.go:3447: require no error, but got: nats: timeout
--- FAIL: TestAccountImportCycle (1.01s)
```
