### PR TITLE
test: update TestWSTLSVerifyClientCert for go1.21

### DIFF
--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -2202,7 +2202,7 @@ func TestWSTLSVerifyClientCert(t *testing.T) {
 			if !test.provideCert {
 				if err == nil {
 					t.Fatal("Expected error, did not get one")
-				} else if !strings.Contains(err.Error(), "bad certificate") {
+				} else if !strings.Contains(err.Error(), "bad certificate") && !strings.Contains(err.Error(), "certificate required") {
 					t.Fatalf("Unexpected error: %v", err)
 				}
 				return
@@ -2306,7 +2306,7 @@ func TestWSTLSVerifyAndMap(t *testing.T) {
 			if !test.provideCert {
 				if err == nil {
 					t.Fatal("Expected error, did not get one")
-				} else if !strings.Contains(err.Error(), "bad certificate") {
+				} else if !strings.Contains(err.Error(), "bad certificate") && !strings.Contains(err.Error(), "certificate required") {
 					t.Fatalf("Unexpected error: %v", err)
 				}
 				return


### PR DESCRIPTION
Similar to #4380 , this TLS error message changed in Go 1.21.