### PR TITLE
When checking replica count when updating retention, make sure stream assignment is set 

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -1787,7 +1787,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 		// a subsequent update to an existing tier will then move from existing past tier to existing new tier
 	}
 
-	if mset.isLeader() && ocfg.Retention != cfg.Retention && cfg.Retention == InterestPolicy {
+	if mset.isLeader() && mset.sa != nil && ocfg.Retention != cfg.Retention && cfg.Retention == InterestPolicy {
 		// Before we can update the retention policy for the consumer, we need
 		// the replica count of all consumers to match the stream.
 		for _, c := range mset.sa.consumers {


### PR DESCRIPTION
This should fix a panic found by @scottf:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x68 pc=0x10ce982]
goroutine 51 [running]:
github.com/nats-io/nats-server/v2/server.(*stream).updateWithAdvisory(0xc0000c6380, 0xc000510156?, 0x1)
        C:/nats/temp/nats-server/server/stream.go:1793 +0xa82
github.com/nats-io/nats-server/v2/server.(*stream).update(...)
        C:/nats/temp/nats-server/server/stream.go:1609
github.com/nats-io/nats-server/v2/server.(*Server).jsStreamUpdateRequest(0xc000184d80, 0x4d00000000000000?, 0xc0001d4c80, 0x64d6330f?, {0xc000510140, 0x1c}, {0xc00041c150, 0x11}, {0xc0003cc240, 0x100, ...})
        C:/nats/temp/nats-server/server/jetstream_api.go:1460 +0xbf2
github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch(0xc0001e6000, 0xc0001e2a80, 0xc0001d4c80, 0xc0001c2280, {0xc000510140, 0x1c}, {0xc00041c150, 0x11}, {0xc0003cc240, 0x100, ...})
        C:/nats/temp/nats-server/server/jetstream_api.go:768 +0x26a
github.com/nats-io/nats-server/v2/server.(*client).deliverMsg(0xc0001d4c80, 0x0, 0xc0001e2a80, 0x30?, {0xc000510120, 0x1c, 0x20}, {0xc00041c138, 0x11, 0x18}, ...)
        C:/nats/temp/nats-server/server/client.go:3421 +0xabe
github.com/nats-io/nats-server/v2/server.(*client).processMsgResults(0xc0001d4c80, 0xc0001c2280, 0xc0001ef3e0, {0xc0003cc240, 0x102, 0x120}, {0x0, 0x0, 0x243fb484c00?}, {0xc000510120, ...}, ...)
        C:/nats/temp/nats-server/server/client.go:4473 +0xb12
github.com/nats-io/nats-server/v2/server.(*client).processServiceImport(0xc0001d4c80, 0xc00015c480, 0xc0001c2000, {0xc00008255b, 0x83, 0xa5})
        C:/nats/temp/nats-server/server/client.go:4258 +0x11be
github.com/nats-io/nats-server/v2/server.(*Account).addServiceImportSub.func1(0xc0004a3018?, 0xb02705?, 0x0?, {0x1?, 0x0?}, {0x0?, 0x0?}, {0xc00008255b, 0x83, 0xa5})
        C:/nats/temp/nats-server/server/accounts.go:1993 +0x32
github.com/nats-io/nats-server/v2/server.(*client).deliverMsg(0xc0001d4c80, 0x0, 0xc0001f0000, 0x3100000020?, {0xc000082504, 0x1c, 0xfc}, {0xc000082521, 0x34, 0xdf}, ...)
        C:/nats/temp/nats-server/server/client.go:3419 +0xb69
github.com/nats-io/nats-server/v2/server.(*client).processMsgResults(0xc0001d4c80, 0xc0001c2000, 0xc0001ef050, {0xc00008255b, 0x83, 0xa5}, {0x0, 0x0, 0xc00006ab40?}, {0xc000082504, ...}, ...)
        C:/nats/temp/nats-server/server/client.go:4473 +0xb12
github.com/nats-io/nats-server/v2/server.(*client).processInboundClientMsg(0xc0001d4c80, {0xc00008255b, 0x83, 0xa5})
        C:/nats/temp/nats-server/server/client.go:3893 +0xc8c
github.com/nats-io/nats-server/v2/server.(*client).processInboundMsg(0xc0001d4c80?, {0xc00008255b?, 0x83?, 0xa5?})
        C:/nats/temp/nats-server/server/client.go:3732 +0x3d
github.com/nats-io/nats-server/v2/server.(*client).parse(0xc0001d4c80, {0xc000082500, 0xde, 0x100})
        C:/nats/temp/nats-server/server/parser.go:497 +0x210a
github.com/nats-io/nats-server/v2/server.(*client).readLoop(0xc0001d4c80, {0x0, 0x0, 0x0})
        C:/nats/temp/nats-server/server/client.go:1373 +0x1305
github.com/nats-io/nats-server/v2/server.(*Server).createClientEx.func1()
        C:/nats/temp/nats-server/server/server.go:3130 +0x29
github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
        C:/nats/temp/nats-server/server/server.go:3607 +0x1bd
created by github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine
        C:/nats/temp/nats-server/server/server.go:3603 +0x265
```

Signed-off-by: Neil Twigg <neil@nats.io>