### PR TITLE
[IMPROVED] $SYS.REQ.SERVER.PING.PROFILEZ always honored

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3657,11 +3657,6 @@ type ProfilezStatus struct {
 }
 
 func (s *Server) profilez(opts *ProfilezOptions) *ProfilezStatus {
-	if s.profiler == nil {
-		return &ProfilezStatus{
-			Error: "Profiling is not enabled",
-		}
-	}
 	if opts.Name == _EMPTY_ {
 		return &ProfilezStatus{
 			Error: "Profile name not specified",

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -4647,14 +4647,6 @@ func TestMonitorProfilez(t *testing.T) {
 	s := RunServer(DefaultOptions())
 	defer s.Shutdown()
 
-	// First of all, check that the profiles aren't accessible
-	// when profiling hasn't been started in the usual way.
-	if ps := s.profilez(&ProfilezOptions{
-		Name: "allocs", Debug: 0,
-	}); ps.Error == "" {
-		t.Fatal("Profile should not be accessible when profiling not started")
-	}
-
 	// Then start profiling.
 	s.StartProfiler()
 

--- a/server/server.go
+++ b/server/server.go
@@ -2093,6 +2093,9 @@ func (s *Server) Start() {
 	// Pprof http endpoint for the profiler.
 	if opts.ProfPort != 0 {
 		s.StartProfiler()
+	} else {
+		// Enable blocking profile even if no port defined since profiling is always possible over $SYS requests
+		runtime.SetBlockProfileRate(1)
 	}
 
 	if opts.ConfigFile != _EMPTY_ {


### PR DESCRIPTION

 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Remove the gate checking that the server is configured to have a profiling port enabled before returning profiling information in respose to a `$SYS.REQ.SERVER.PING.PROFILEZ` request