### PR TITLE
config: allow empty configs, but prevent bad configs

### DIFF
--- a/conf/parse.go
+++ b/conf/parse.go
@@ -137,17 +137,19 @@ func parse(data, fp string, pedantic bool) (p *parser, err error) {
 	}
 	p.pushContext(p.mapping)
 
+	var prevItem itemType
 	for {
 		it := p.next()
 		if it.typ == itemEOF {
+			if prevItem == itemKey {
+				return nil, fmt.Errorf("config is invalid (%s:%d:%d)", fp, it.line, it.pos)
+			}
 			break
 		}
+		prevItem = it.typ
 		if err := p.processItem(it, fp); err != nil {
 			return nil, err
 		}
-	}
-	if len(p.mapping) == 0 {
-		return nil, fmt.Errorf("config has no values or is empty")
 	}
 	return p, nil
 }

--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -1579,6 +1579,23 @@ func TestConfigCheck(t *testing.T) {
 			errorLine: 5,
 			errorPos:  6,
 		},
+		{
+			name:       "show warnings on empty configs without values",
+			config:     ``,
+			warningErr: errors.New(`config has no values or is empty`),
+			errorLine:  0,
+			errorPos:   0,
+			reason:     "",
+		},
+		{
+			name: "show warnings on empty configs without values and only comments",
+			config: `# Valid file but has no usable values.
+                                    `,
+			warningErr: errors.New(`config has no values or is empty`),
+			errorLine:  0,
+			errorPos:   0,
+			reason:     "",
+		},
 	}
 
 	checkConfig := func(config string) error {
@@ -1620,6 +1637,8 @@ func TestConfigCheck(t *testing.T) {
 					if test.reason != "" {
 						msg += ": " + test.reason
 					}
+				} else if test.warningErr != nil {
+					msg = expectedErr.Error()
 				} else {
 					msg = test.reason
 				}

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -2540,7 +2540,7 @@ func TestLeafNodeOperatorBadCfg(t *testing.T) {
 			cfg: `
 			port: -1
 			authorization {
-				users = [{user: "u", password: "p"}]}
+				users = [{user: "u", password: "p"}]
 			}`,
 		},
 		{
@@ -3876,9 +3876,9 @@ func TestLeafNodeInterestPropagationDaisychain(t *testing.T) {
 	aTmpl := `
 		port: %d
 		leafnodes {
-			port: %d
-		   }
-		}`
+		  port: %d
+		}
+		`
 
 	confA := createConfFile(t, []byte(fmt.Sprintf(aTmpl, -1, -1)))
 	sA, _ := RunServerWithConfig(confA)

--- a/server/opts.go
+++ b/server/opts.go
@@ -744,6 +744,9 @@ func (o *Options) ProcessConfigFile(configFile string) error {
 	// Collect all errors and warnings and report them all together.
 	errors := make([]error, 0)
 	warnings := make([]error, 0)
+	if len(m) == 0 {
+		warnings = append(warnings, fmt.Errorf("%s: config has no values or is empty", configFile))
+	}
 
 	// First check whether a system account has been defined,
 	// as that is a condition for other features to be enabled.


### PR DESCRIPTION
Allows again empty configs and improves support for detecting some types of invalid configs:

- Adds reporting the line with the bad key position that makes the config invalid.

```
nats-server: config is invalid (foo.conf:1:2)
nats-server: error parsing include file 'included.conf', config is invalid (included.conf:2:2)
```

- Fixes a few tests with trailing braces which were being handled as keys and ignored before.
