### PR TITLE
Don't set block profile rate

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2093,9 +2093,6 @@ func (s *Server) Start() {
 	// Pprof http endpoint for the profiler.
 	if opts.ProfPort != 0 {
 		s.StartProfiler()
-	} else {
-		// Enable blocking profile even if no port defined since profiling is always possible over $SYS requests
-		runtime.SetBlockProfileRate(1)
 	}
 
 	if opts.ConfigFile != _EMPTY_ {
@@ -2696,9 +2693,6 @@ func (s *Server) StartProfiler() {
 	}
 	s.profiler = l
 	s.profilingServer = srv
-
-	// Enable blocking profile
-	runtime.SetBlockProfileRate(1)
 
 	go func() {
 		// if this errors out, it's probably because the server is being shutdown


### PR DESCRIPTION
We rarely benefit from block profiles and in many cases a mutex profile will tell us what we need to know. Additionally, setting the block profile rate to `1` has the special meaning of capturing every single blocking event, which can have a fairly significant negative impact on publish performance.

Signed-off-by: Neil Twigg <neil@nats.io>