### PR TITLE
Tweak consumer replica scaling

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -213,14 +213,13 @@ var (
 
 // Calculate accurate replicas for the consumer config with the parent stream config.
 func (consCfg ConsumerConfig) replicas(strCfg *StreamConfig) int {
-	if consCfg.Replicas == 0 {
+	if consCfg.Replicas == 0 || consCfg.Replicas > strCfg.Replicas {
 		if !isDurableConsumer(&consCfg) && strCfg.Retention == LimitsPolicy {
 			return 1
 		}
 		return strCfg.Replicas
-	} else {
-		return consCfg.Replicas
 	}
+	return consCfg.Replicas
 }
 
 // Consumer is a jetstream consumer.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5996,11 +5996,11 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		// Need to remap any consumers.
 		for _, ca := range osa.consumers {
 			// Ephemerals are R=1, so only auto-remap durables, or R>1, unless stream is interest or workqueue policy.
-			numPeers := len(ca.Group.Peers)
-			if ca.Config.Durable != _EMPTY_ || numPeers > 1 || cfg.Retention != LimitsPolicy {
+			replicas := ca.Config.replicas(cfg)
+			if ca.Config.Durable != _EMPTY_ || replicas > 1 || cfg.Retention != LimitsPolicy {
 				cca := ca.copyGroup()
 				// Adjust preferred as needed.
-				if numPeers == 1 && len(rg.Peers) > 1 {
+				if replicas == 1 && len(rg.Peers) > 1 {
 					cca.Group.Preferred = ca.Group.Peers[0]
 				} else {
 					cca.Group.Preferred = _EMPTY_

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -14,7 +14,6 @@
 package server
 
 import (
-	"bytes"
 	"fmt"
 	"math/rand"
 	"net/url"
@@ -112,16 +111,16 @@ func require_Error(t *testing.T, err error, expected ...error) {
 	t.Fatalf("Expected one of %v, got '%v'", expected, err)
 }
 
-func require_Equal(t *testing.T, a, b string) {
+func require_Equal[T comparable](t *testing.T, a, b T) {
 	t.Helper()
-	if strings.Compare(a, b) != 0 {
+	if a != b {
 		t.Fatalf("require equal, but got: %v != %v", a, b)
 	}
 }
 
-func require_NotEqual(t *testing.T, a, b [32]byte) {
+func require_NotEqual[T comparable](t *testing.T, a, b T) {
 	t.Helper()
-	if bytes.Equal(a[:], b[:]) {
+	if a == b {
 		t.Fatalf("require not equal, but got: %v != %v", a, b)
 	}
 }


### PR DESCRIPTION
This should hopefully catch some consumer scaling situations more reliably. I've also added a test to test whether filtered consumers will scale properly even when the stream subject orphans them, which is what led me down this path to begin with.

Signed-off-by: Neil Twigg <neil@nats.io>