### PR TITLE
Add filesystem locking on jetstream fileStore instances.

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -5714,3 +5714,27 @@ func TestFileStoreRecaluclateFirstForSubjBug(t *testing.T) {
 	// Make sure it was update properly.
 	require_True(t, *ss == SimpleState{Msgs: 1, First: 3, Last: 3, firstNeedsUpdate: false})
 }
+
+func TestFileStoreLockFileSystem(t *testing.T) {
+	dir := t.TempDir()
+
+	fs0, err0 := newFileStore(FileStoreConfig{StoreDir: dir}, StreamConfig{Name: "zzz", Subjects: []string{"*"}, Storage: FileStorage})
+	require_NoError(t, err0)
+	fs0.Stop()
+
+	fs1, err1 := newFileStore(FileStoreConfig{StoreDir: dir}, StreamConfig{Name: "zzz", Subjects: []string{"*"}, Storage: FileStorage})
+	require_NoError(t, err1)
+	fs1.Stop()
+}
+
+func TestFileStoreLockFileSystemConflict(t *testing.T) {
+	dir := t.TempDir()
+
+	fs0, err0 := newFileStore(FileStoreConfig{StoreDir: dir}, StreamConfig{Name: "zzz", Subjects: []string{"*"}, Storage: FileStorage})
+	require_NoError(t, err0)
+
+	_, err1 := newFileStore(FileStoreConfig{StoreDir: dir}, StreamConfig{Name: "zzz", Subjects: []string{"*"}, Storage: FileStorage})
+	require_Error(t, err1)
+
+	fs0.Stop()
+}

--- a/server/filestore_unix.go
+++ b/server/filestore_unix.go
@@ -1,0 +1,33 @@
+// Copyright 2023 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+// +build !windows
+
+package server
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// Acquire filesystem-level lock for the filestore to ensure exclusive access
+// for this server instance.
+func lockFile(f *os.File) error {
+	err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		return fmt.Errorf("lock `%s': %v", f.Name(), err)
+	}
+	return nil
+}

--- a/server/filestore_windows.go
+++ b/server/filestore_windows.go
@@ -1,0 +1,42 @@
+// Copyright 2023 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package server
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// Acquire filesystem-level lock for the filestore to ensure exclusive access
+// for this server instance.
+func lockFile(f *os.File) error {
+	var (
+		modkernel32  = syscall.NewLazyDLL("kernel32.dll")
+		prLockFileEx = modkernel32.NewProc("LockFileEx")
+		ol           = unsafe.Pointer(new(syscall.Overlapped))
+	)
+
+	a := prLockFileEx.Addr()
+	h := syscall.Handle(f.Fd())
+	r, _, e := syscall.Syscall6(a, 6, uintptr(h), 0x3, 0, ^uintptr(0), ^uintptr(0), uintptr(ol))
+	if r == 0 {
+		return fmt.Errorf("lock `%s': %v", f.Name(), error(e))
+	}
+	return nil
+}


### PR DESCRIPTION
 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current ~main~ dev
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project

