### PR TITLE
Added CORS support for the monitoring server

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2313,6 +2313,7 @@ func ResponseHandler(w http.ResponseWriter, r *http.Request, data []byte) {
 	} else {
 		// Otherwise JSON
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Write(data)
 	}
 }

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -157,7 +157,14 @@ func readBodyEx(t *testing.T, url string, status int, content string) []byte {
 	}
 	ct := resp.Header.Get("Content-Type")
 	if ct != content {
-		stackFatalf(t, "Expected %s content-type, got %s\n", content, ct)
+		stackFatalf(t, "Expected %q content-type, got %q\n", content, ct)
+	}
+	// Check the CORS header for "application/json" requests only.
+	if ct == appJSONContent {
+		acao := resp.Header.Get("Access-Control-Allow-Origin")
+		if acao != "*" {
+			stackFatalf(t, "Expected with %q Content-Type an Access-Control-Allow-Origin header with value %q, got %q\n", appJSONContent, "*", acao)
+		}
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
 - [x] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [x] Tests added
 - [ ] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #4422 

### Changes proposed in this pull request:

 - Added `Access-Control-Allow-Origin` header to allow CORS requests for the monitoring server
 - Added a check in the tests for the header when the `Content-Type` is `application/json`
