### PR TITLE
[FIXED] Make sure to reset election timer on catching up

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -1814,6 +1814,7 @@ func (n *raft) runAsFollower() {
 				if n.catchupStalled() {
 					n.cancelCatchup()
 				}
+				n.resetElectionTimeout()
 				n.Unlock()
 			} else {
 				n.switchToCandidate()


### PR DESCRIPTION
Thanks to @yuzhou-nj for the catch and fix.

Signed-off-by: Derek Collison <derek@nats.io>

Resolves #4363 

