### PR TITLE
Fix shutdown deadlock in TestJetStreamClusterMemLeaderRestart

### DIFF
--- a/server/memstore.go
+++ b/server/memstore.go
@@ -684,6 +684,7 @@ func (ms *memStore) purge(fseq uint64) (uint64, error) {
 	cb := ms.scb
 	bytes := int64(ms.state.Bytes)
 	if fseq < ms.state.LastSeq {
+		ms.mu.Unlock()
 		return 0, fmt.Errorf("partial purges not supported on memory store")
 	}
 	ms.state.FirstSeq = fseq


### PR DESCRIPTION
While shutting down a server an error during purge from a memory stream would cause a deadlock sometimes, this would sometimes show up in the `TestJetStreamClusterMemLeaderRestart` while tearing down the cluster.

This was introduced in https://github.com/nats-io/nats-server/commit/4d8d01949b04e20d6ec167e195504a2dcc3a87e2 so only relates to v2.10.