### PR TITLE
Run tests using Go 1.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: go
 go:
 # This should be quoted or use .x, but should not be unquoted.
 # Remember that a YAML bare float drops trailing zeroes.
-  - "1.19.12"
+  - "1.21.x"
   - "1.20.x"
 
 go_import_path: github.com/nats-io/nats-server


### PR DESCRIPTION
 Flips the order to test with ~~Go 1.20~~ Go 1.21 instead of Go 1.19