### PR TITLE
Update Slack invite URL for Slack badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you are interested in contributing to NATS, read about our...
 [Docker-Image]: https://img.shields.io/docker/pulls/_/nats.svg
 [Docker-Url]: https://hub.docker.com/_/nats
 [Slack-Image]: https://img.shields.io/badge/chat-on%20slack-green
-[Slack-Url]: https://join.slack.com/t/natsio/shared_invite/zt-41e6tnmb-qCt63606MKR1YxIHZf4ICA
+[Slack-Url]: https://slack.nats.io
 [Fossa-Url]: https://app.fossa.io/projects/git%2Bgithub.com%2Fnats-io%2Fnats-server?ref=badge_shield
 [Fossa-Image]: https://app.fossa.io/api/projects/git%2Bgithub.com%2Fnats-io%2Fnats-server.svg?type=shield
 [Build-Status-Url]: https://travis-ci.com/github/nats-io/nats-server


### PR DESCRIPTION
This badge was using an old expired invite URL for NATS Slack. Updating to the general slack.nats.io URL for invites

