### PR TITLE
Updates to the way meta indexing is handled for filestore.

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -971,8 +971,8 @@ func (mset *stream) lastSeqAndCLFS() (uint64, uint64) {
 }
 
 func (mset *stream) clearCLFS() uint64 {
-	mset.mu.Lock()
-	defer mset.mu.Unlock()
+	mset.clMu.Lock()
+	defer mset.clMu.Unlock()
 	clfs := mset.clfs
 	mset.clfs, mset.clseq = 0, 0
 	return clfs


### PR DESCRIPTION
Historically we kept indexing information, either by sequence or by subject, as a per msg block operation. These were the "*.idx" and "*.fss" indexing files. When streams became very large this could have an impact on recovery time. Also, for encryption the fast path for determining if the indexing was current would require loading and decrypting the complete block.

This design moves to a more traditional WAL and snapshot approach. The snapshots for the complete stream, including summary information, global per subject information maps (PSIM) and per msg block details including summary and dmap, are processed asynchronously. The snapshot includes the msg block and has for the last record hash that was considered in the snapshot. On recovery the snapshot is read and processed and any additional records past the point of the snapshot itself are processed. To this end, any non-system removal of a message has to be expressed as a delete tombstone that is always added the the fs.lmb file. These are processed on recovery and our indexing layer knows to skip them.

Changing to this method drastically improves startup and recovery times, and has simplified the code. Some normal performance benefits have been seen as well.

Signed-off-by: Derek Collison <derek@nats.io>

