### PR TITLE
Remove OCSP debug log on reload

### DIFF
--- a/server/ocsp_peer.go
+++ b/server/ocsp_peer.go
@@ -139,13 +139,13 @@ func (s *Server) plugTLSOCSPPeer(config *tlsConfigKind) (*tls.Config, bool, erro
 	if config == nil || config.tlsConfig == nil {
 		return nil, false, errors.New(certidp.ErrUnableToPlugTLSEmptyConfig)
 	}
-	s.Debugf(certidp.DbgPlugTLSForKind, config.kind)
 	kind := config.kind
 	isSpoke := config.isLeafSpoke
 	tcOpts := config.tlsOpts
 	if tcOpts == nil || tcOpts.OCSPPeerConfig == nil || !tcOpts.OCSPPeerConfig.Verify {
 		return nil, false, nil
 	}
+	s.Debugf(certidp.DbgPlugTLSForKind, config.kind)
 	// peer is a tls client
 	if kind == kindStringMap[CLIENT] || (kind == kindStringMap[LEAF] && !isSpoke) {
 		if !tcOpts.Verify {


### PR DESCRIPTION
When reloading TLS we would always be logging the attempt to plug OCSP:

```
[42801] 2023/08/30 14:52:33.766638 [INF] Reloaded: authorization users
[42801] 2023/08/30 14:52:33.766648 [INF] Reloaded: accounts
[42801] 2023/08/30 14:52:33.766652 [INF] Reloaded: tls = enabled
[42801] 2023/08/30 14:52:33.766756 [DBG] Plugging TLS OCSP peer for [Client]
[42801] 2023/08/30 14:52:33.766763 [INF] Reloaded server configuration
```