### PR TITLE
Use Go 1.21 for nightlies, Dockerfile, code coverage, bump `go.mod` version to Go 1.20

### DIFF
--- a/.github/workflows/cov.yaml
+++ b/.github/workflows/cov.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20.x"
+          go-version: "1.21.x"
 
       - name: Run code coverage
         shell: bash --noprofile --norc -x -eo pipefail {0}

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ["1.20"]
+        go: ["1.21"]
 
     env:
       GOPATH: /home/runner/work/nats-server

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:
-          go: "1.20"
+          go: "1.21"
           workdir: src/github.com/nats-io/nats-server
           label: nightly
           hub_username: "${{ secrets.DOCKER_USERNAME }}"

--- a/.github/workflows/rc_nightly.yaml
+++ b/.github/workflows/rc_nightly.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:
-          go: "1.20"
+          go: "1.21"
           workdir: src/github.com/nats-io/nats-server
           label: nightly-main
           hub_username: "${{ secrets.DOCKER_USERNAME }}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ vm:
 
 language: go
 go:
-# This should be quoted or use .x, but should not be unquoted.
-# Remember that a YAML bare float drops trailing zeroes.
+  # This should be quoted or use .x, but should not be unquoted.
+  # Remember that a YAML bare float drops trailing zeroes.
   - "1.21.x"
   - "1.20.x"
 
@@ -41,7 +41,7 @@ jobs:
     - name: "Run all tests from all other packages"
       env: TEST_SUITE=non_srv_pkg_tests
     - name: "Compile with older Go release"
-      go: "1.19.12"
+      go: "1.20"
       env: TEST_SUITE=build_only
 
 script: ./scripts/runTestsOnTravis.sh $TEST_SUITE
@@ -52,4 +52,4 @@ deploy:
   script: curl -sL http://git.io/goreleaser | bash
   on:
     tags: true
-    condition: ($TRAVIS_GO_VERSION =~ 1.20) && ($TEST_SUITE = "compile")
+    condition: ($TRAVIS_GO_VERSION =~ 1.21) && ($TEST_SUITE = "compile")

--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine AS builder
+FROM golang:1.21-alpine AS builder
 
 ARG VERSION="nightly"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nats-io/nats-server/v2
 
-go 1.19
+go 1.20
 
 require (
 	github.com/klauspost/compress v1.16.7


### PR DESCRIPTION
As Go 1.19 is no longer in support, we will target Go 1.21 and Go 1.20 instead for 2.10.

Signed-off-by: Neil Twigg <neil@nats.io>