### PR TITLE
Fix lock issue in filestore

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -3509,7 +3509,7 @@ func (fs *fileStore) removeMsg(seq uint64, secure, viaLimits, needFSLock bool) (
 	}
 
 	cb := fs.scb
-	fs.mu.Unlock()
+	fsUnlock()
 
 	// Storage updates.
 	if cb != nil {


### PR DESCRIPTION
This should hopefully fix a panic on unlock of unlocked mutex in the file store.

Signed-off-by: Neil Twigg <neil@nats.io>