### PR TITLE
Fix monitoring server connz idle time sorting

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -492,7 +492,7 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 	case ByLast:
 		sort.Sort(sort.Reverse(byLast{pconns}))
 	case ByIdle:
-		sort.Sort(sort.Reverse(byIdle{pconns}))
+		sort.Sort(sort.Reverse(byIdle{pconns, c.Now}))
 	case ByUptime:
 		sort.Sort(byUptime{pconns, time.Now()})
 	case ByStop:

--- a/server/monitor_sort_opts.go
+++ b/server/monitor_sort_opts.go
@@ -92,12 +92,13 @@ func (l byLast) Less(i, j int) bool {
 }
 
 // Idle time
-type byIdle struct{ ConnInfos }
+type byIdle struct {
+	ConnInfos
+	now time.Time
+}
 
 func (l byIdle) Less(i, j int) bool {
-	ii := l.ConnInfos[i].LastActivity.Sub(l.ConnInfos[i].Start)
-	ij := l.ConnInfos[j].LastActivity.Sub(l.ConnInfos[j].Start)
-	return ii < ij
+	return l.now.Sub(l.ConnInfos[i].LastActivity) < l.now.Sub(l.ConnInfos[j].LastActivity)
 }
 
 // Uptime


### PR DESCRIPTION
 - [x] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [x] Tests added
 - [ ] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #4462 

### Changes proposed in this pull request:

 - Changed how [`byIdle`](https://github.com/nats-io/nats-server/blob/887a4ae692292c4efd95539993b7d665fea78ec5/server/monitor_sort_opts.go#L97) struct compares the idle times (was subtracting the start time from the last activity time).
 - Added tests for `byIdle`.
 - Changed and simplified the test [`TestConnzSortedByIdle`](https://github.com/nats-io/nats-server/blob/8a9f441c40c43e5a5786506174d810bc559748aa/server/monitor_test.go#L1185) (No need for the clients to publish and subscribe if we are manually changing the client's `last` time, and we only need to test the sorting order). Also the test was not catching the problem because the clients `start` time was the same, now every client has a different start time.
