### PR TITLE
Enables 0s deduplication window duration when the stream has sources

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -805,29 +805,31 @@ func (mset *stream) rebuildDedupe() {
 
 	mset.ddloaded = true
 
-	// We have some messages. Lookup starting sequence by duplicate time window.
-	sseq := mset.store.GetSeqFromTime(time.Now().Add(-mset.cfg.Duplicates))
-	if sseq == 0 {
-		return
-	}
-
-	var smv StoreMsg
-	var state StreamState
-	mset.store.FastState(&state)
-
-	for seq := sseq; seq <= state.LastSeq; seq++ {
-		sm, err := mset.store.LoadMsg(seq, &smv)
-		if err != nil {
-			continue
+	if mset.cfg.Duplicates != time.Duration(0) {
+		// We have some messages. Lookup starting sequence by duplicate time window.
+		sseq := mset.store.GetSeqFromTime(time.Now().Add(-mset.cfg.Duplicates))
+		if sseq == 0 {
+			return
 		}
-		var msgId string
-		if len(sm.hdr) > 0 {
-			if msgId = getMsgId(sm.hdr); msgId != _EMPTY_ {
-				mset.storeMsgIdLocked(&ddentry{msgId, sm.seq, sm.ts})
+
+		var smv StoreMsg
+		var state StreamState
+		mset.store.FastState(&state)
+
+		for seq := sseq; seq <= state.LastSeq; seq++ {
+			sm, err := mset.store.LoadMsg(seq, &smv)
+			if err != nil {
+				continue
 			}
-		}
-		if seq == state.LastSeq {
-			mset.lmsgId = msgId
+			var msgId string
+			if len(sm.hdr) > 0 {
+				if msgId = getMsgId(sm.hdr); msgId != _EMPTY_ {
+					mset.storeMsgIdLocked(&ddentry{msgId, sm.seq, sm.ts})
+				}
+			}
+			if seq == state.LastSeq {
+				mset.lmsgId = msgId
+			}
 		}
 	}
 }
@@ -1023,7 +1025,7 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 	if cfg.MaxConsumers == 0 {
 		cfg.MaxConsumers = -1
 	}
-	if cfg.Duplicates == 0 && cfg.Mirror == nil {
+	if cfg.Duplicates == 0 && cfg.Mirror == nil && len(cfg.Sources) == 0 {
 		maxWindow := StreamDefaultDuplicatesWindow
 		if lim.Duplicates > 0 && maxWindow > lim.Duplicates {
 			maxWindow = lim.Duplicates
@@ -3486,13 +3488,15 @@ func (mset *stream) storeMsgId(dde *ddentry) {
 // storeMsgIdLocked will store the message id for duplicate detection.
 // Lock should he held.
 func (mset *stream) storeMsgIdLocked(dde *ddentry) {
-	if mset.ddmap == nil {
-		mset.ddmap = make(map[string]*ddentry)
-	}
-	mset.ddmap[dde.id] = dde
-	mset.ddarr = append(mset.ddarr, dde)
-	if mset.ddtmr == nil {
-		mset.ddtmr = time.AfterFunc(mset.cfg.Duplicates, mset.purgeMsgIds)
+	if mset.cfg.Duplicates != time.Duration(0) {
+		if mset.ddmap == nil {
+			mset.ddmap = make(map[string]*ddentry)
+		}
+		mset.ddmap[dde.id] = dde
+		mset.ddarr = append(mset.ddarr, dde)
+		if mset.ddtmr == nil {
+			mset.ddtmr = time.AfterFunc(mset.cfg.Duplicates, mset.purgeMsgIds)
+		}
 	}
 }
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -805,7 +805,7 @@ func (mset *stream) rebuildDedupe() {
 
 	mset.ddloaded = true
 
-	if mset.cfg.Duplicates != time.Duration(0) {
+	if mset.cfg.Duplicates > time.Duration(0) {
 		// We have some messages. Lookup starting sequence by duplicate time window.
 		sseq := mset.store.GetSeqFromTime(time.Now().Add(-mset.cfg.Duplicates))
 		if sseq == 0 {
@@ -3488,7 +3488,7 @@ func (mset *stream) storeMsgId(dde *ddentry) {
 // storeMsgIdLocked will store the message id for duplicate detection.
 // Lock should he held.
 func (mset *stream) storeMsgIdLocked(dde *ddentry) {
-	if mset.cfg.Duplicates != time.Duration(0) {
+	if mset.cfg.Duplicates > time.Duration(0) {
 		if mset.ddmap == nil {
 			mset.ddmap = make(map[string]*ddentry)
 		}


### PR DESCRIPTION
 - [X] Link to issue, e.g. `Resolves #NNN`
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #4459

Allows the user to set the deduplication window duration to 0s when the stream has sources defined. Remember that if the stream in question is also listening on subjects as well as sourcing the deduplication window is the same for sourced and listened messages.