### PR TITLE
Use `TempDir` in more tests

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -3138,10 +3138,12 @@ func TestNoRaceJetStreamFileStoreCompaction(t *testing.T) {
 }
 
 func TestNoRaceJetStreamEncryptionEnabledOnRestartWithExpire(t *testing.T) {
-	conf := createConfFile(t, []byte(`
+	conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
-		jetstream: enabled
-	`))
+		jetstream {
+			store_dir = %q
+		}
+	`, t.TempDir())))
 
 	s, _ := RunServerWithConfig(conf)
 	defer s.Shutdown()
@@ -4217,9 +4219,11 @@ func TestNoRaceJetStreamClusterHealthz(t *testing.T) {
 // Also test that we will fail at some point and the user can fall back to
 // an orderedconsumer like we do with watch for KV Keys() call.
 func TestNoRaceJetStreamStreamInfoSubjectDetailsLimits(t *testing.T) {
-	conf := createConfFile(t, []byte(`
+	conf := createConfFile(t, []byte(fmt.Sprintf(`
 		listen: 127.0.0.1:-1
-		jetstream: enabled
+		jetstream {
+			store_dir = %q
+		}
 		accounts: {
 		  default: {
 			jetstream: true
@@ -4227,7 +4231,7 @@ func TestNoRaceJetStreamStreamInfoSubjectDetailsLimits(t *testing.T) {
 			limits { max_payload: 256 }
 		  }
 		}
-	`))
+	`, t.TempDir())))
 
 	s, _ := RunServerWithConfig(conf)
 	if config := s.JetStreamConfig(); config != nil {

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1592,7 +1592,7 @@ func testTLSRoutesCertificateImplicitAllow(t *testing.T, pass bool) {
 }
 
 func TestSubjectRenameViaJetStreamAck(t *testing.T) {
-	s := RunRandClientPortServer()
+	s := RunRandClientPortServer(t)
 	defer s.Shutdown()
 	errChan := make(chan error)
 	defer close(errChan)

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -45,9 +45,10 @@ func testDefaultClusterOptionsForLeafNodes() *Options {
 	return &o
 }
 
-func RunRandClientPortServer() *Server {
+func RunRandClientPortServer(t *testing.T) *Server {
 	opts := DefaultTestOptions
 	opts.Port = -1
+	opts.StoreDir = t.TempDir()
 	return RunServer(&opts)
 }
 


### PR DESCRIPTION
This uses `TempDir` in more tests. Some were trying to manage the directory manually, others were just not managing a directory at all. There may be more that need doing.

Signed-off-by: Neil Twigg <neil@nats.io>