### PR TITLE
v2.9.x: Change CI and nightlies to use Go 1.20

### DIFF
--- a/.github/actions/nightly-release/action.yaml
+++ b/.github/actions/nightly-release/action.yaml
@@ -26,7 +26,7 @@ runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: "${{ inputs.go }}"
 

--- a/.github/workflows/cov.yaml
+++ b/.github/workflows/cov.yaml
@@ -21,9 +21,9 @@ jobs:
           ref: dev
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: "1.20.x"
 
       - name: Run code coverage
         shell: bash --noprofile --norc -x -eo pipefail {0}

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -5,8 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [1.16]
-
+        go: ["1.20"]
     env:
       GOPATH: /home/runner/work/nats-server
       GO111MODULE: "on"
@@ -19,25 +18,19 @@ jobs:
           path: src/github.com/nats-io/nats-server
 
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: ${{matrix.go}}
 
       - name: Install deps
         shell: bash --noprofile --norc -x -eo pipefail {0}
         run: |
-          go get -u honnef.co/go/tools/cmd/staticcheck
-          go get -u github.com/client9/misspell/cmd/misspell
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
 
       - name: Lint
         shell: bash --noprofile --norc -x -eo pipefail {0}
         run: |
-          GO_LIST=$(go list ./...)
-          go build
-          $(exit $(go fmt $GO_LIST | wc -l))
-          go vet $GO_LIST
-          find . -type f -name "*.go" | xargs $GOPATH/bin/misspell -error -locale US
-          $GOPATH/bin/staticcheck $GO_LIST
+          golangci-lint run
 
       - name: Run tests
         shell: bash --noprofile --norc -x -eo pipefail {0}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:
-          go: "1.19"
+          go: "1.20"
           workdir: src/github.com/nats-io/nats-server
           label: nightly
           hub_username: "${{ secrets.DOCKER_USERNAME }}"

--- a/.github/workflows/rc_nightly.yaml
+++ b/.github/workflows/rc_nightly.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:
-          go: "1.19"
+          go: "1.20"
           workdir: src/github.com/nats-io/nats-server
           label: nightly-main
           hub_username: "${{ secrets.DOCKER_USERNAME }}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ vm:
 language: go
 go:
   - "1.20.x"
-  - "1.19.12"
 
 go_import_path: github.com/nats-io/nats-server
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ vm:
 
 language: go
 go:
+  - "1.20.x"
   - "1.19.12"
+
 go_import_path: github.com/nats-io/nats-server
 
 addons:
@@ -48,4 +50,4 @@ deploy:
   script: curl -sL http://git.io/goreleaser | bash
   on:
     tags: true
-    condition: ($TRAVIS_GO_VERSION =~ 1.19) && ($TEST_SUITE = "compile")
+    condition: ($TRAVIS_GO_VERSION =~ 1.20) && ($TEST_SUITE = "compile")

--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.20-alpine AS builder
 
 ARG VERSION="nightly"
 

--- a/scripts/runTestsOnTravis.sh
+++ b/scripts/runTestsOnTravis.sh
@@ -7,11 +7,7 @@ if [ "$1" = "compile" ]; then
     go build;
 
     # Now run the linters.
-    # TODO: Pinning a specific commit here as there is a bugfix merged that 
-    # fixes gofmt on macOS Ventura, we can undo this and go back to the binary
-    # install script once there's a new tagged release that contains the fix.
-    # curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@6f7f8ae;
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3;
     golangci-lint run;
     if [ "$TRAVIS_TAG" != "" ]; then
         go test -race -v -run=TestVersionMatchesTag ./server -count=1 -vet=off

--- a/server/client.go
+++ b/server/client.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -5304,7 +5305,10 @@ func (c *client) doTLSHandshake(typ string, solicit bool, url *url.URL, tlsConfi
 		if solicit {
 			// Based on type of error, possibly clear the saved tlsName
 			// See: https://github.com/nats-io/nats-server/issues/1256
-			if _, ok := err.(x509.HostnameError); ok {
+			// NOTE: As of Go 1.20, the HostnameError is wrapped so cannot
+			// type assert to check directly.
+			var hostnameErr x509.HostnameError
+			if errors.As(err, &hostnameErr) {
 				if host == tlsName {
 					resetTLSName = true
 				}

--- a/test/gateway_test.go
+++ b/test/gateway_test.go
@@ -605,89 +605,96 @@ func TestGatewayTLSMixedIPAndDNS(t *testing.T) {
 	server.SetGatewaysSolicitDelay(5 * time.Millisecond)
 	defer server.ResetGatewaysSolicitDelay()
 
-	confA1 := createConfFile(t, []byte(`
-		listen: 127.0.0.1:-1
-		gateway {
-			name: "A"
-			listen: "127.0.0.1:-1"
-			tls {
-				cert_file: "./configs/certs/server-iponly.pem"
-				key_file:  "./configs/certs/server-key-iponly.pem"
-				ca_file:   "./configs/certs/ca.pem"
-				timeout: 2
+	// Run this test extra times to make sure not flaky since it
+	// on solicit time.
+	for i := 0; i < 10; i++ {
+		t.Run("", func(t *testing.T) {
+			confA1 := createConfFile(t, []byte(`
+			listen: 127.0.0.1:-1
+			server_name: A1
+			gateway {
+				name: "A"
+				listen: "127.0.0.1:-1"
+				tls {
+					cert_file: "./configs/certs/server-iponly.pem"
+					key_file:  "./configs/certs/server-key-iponly.pem"
+					ca_file:   "./configs/certs/ca.pem"
+					timeout: 2
+				}
 			}
-		}
-		cluster {
-			listen: "127.0.0.1:-1"
-		}
-	`))
-	srvA1, optsA1 := RunServerWithConfig(confA1)
-	defer srvA1.Shutdown()
+			cluster {
+				listen: "127.0.0.1:-1"
+			}`))
+			srvA1, optsA1 := RunServerWithConfig(confA1)
+			defer srvA1.Shutdown()
 
-	confA2Template := `
-		listen: 127.0.0.1:-1
-		gateway {
-			name: "A"
-			listen: "localhost:-1"
-			tls {
-				cert_file: "./configs/certs/server-cert.pem"
-				key_file:  "./configs/certs/server-key.pem"
-				ca_file:   "./configs/certs/ca.pem"
-				timeout: 2
+			confA2Template := `
+			listen: 127.0.0.1:-1
+			server_name: A2
+			gateway {
+				name: "A"
+				listen: "localhost:-1"
+				tls {
+					cert_file: "./configs/certs/server-cert.pem"
+					key_file:  "./configs/certs/server-key.pem"
+					ca_file:   "./configs/certs/ca.pem"
+					timeout: 2
+				}
 			}
-		}
-		cluster {
-			listen: "127.0.0.1:-1"
-			routes [
-				"nats://%s:%d"
-			]
-		}
-	`
-	confA2 := createConfFile(t, []byte(fmt.Sprintf(confA2Template,
-		optsA1.Cluster.Host, optsA1.Cluster.Port)))
-	srvA2, optsA2 := RunServerWithConfig(confA2)
-	defer srvA2.Shutdown()
+			cluster {
+				listen: "127.0.0.1:-1"
+				routes [
+					"nats://%s:%d"
+				]
+			}`
+			confA2 := createConfFile(t, []byte(fmt.Sprintf(confA2Template,
+				optsA1.Cluster.Host, optsA1.Cluster.Port)))
+			srvA2, optsA2 := RunServerWithConfig(confA2)
+			defer srvA2.Shutdown()
 
-	checkClusterFormed(t, srvA1, srvA2)
+			checkClusterFormed(t, srvA1, srvA2)
 
-	// Create a GW connection to cluster "A". Don't use the helper since we need verification etc.
-	o := DefaultTestOptions
-	o.Port = -1
-	o.Gateway.Name = "B"
-	o.Gateway.Host = "127.0.0.1"
-	o.Gateway.Port = -1
+			// Create a GW connection to cluster "A". Don't use the helper since we need verification etc.
+			o := DefaultTestOptions
+			o.Port = -1
+			o.ServerName = "B1"
+			o.Gateway.Name = "B"
+			o.Gateway.Host = "127.0.0.1"
+			o.Gateway.Port = -1
 
-	tc := &server.TLSConfigOpts{}
-	tc.CertFile = "./configs/certs/server-cert.pem"
-	tc.KeyFile = "./configs/certs/server-key.pem"
-	tc.CaFile = "./configs/certs/ca.pem"
-	tc.Timeout = 2.0
-	tlsConfig, err := server.GenTLSConfig(tc)
-	if err != nil {
-		t.Fatalf("Error generating TLS config: %v", err)
+			tc := &server.TLSConfigOpts{}
+			tc.CertFile = "./configs/certs/server-cert.pem"
+			tc.KeyFile = "./configs/certs/server-key.pem"
+			tc.CaFile = "./configs/certs/ca.pem"
+			tc.Timeout = 2.0
+			tlsConfig, err := server.GenTLSConfig(tc)
+			if err != nil {
+				t.Fatalf("Error generating TLS config: %v", err)
+			}
+			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+			tlsConfig.RootCAs = tlsConfig.ClientCAs
+
+			o.Gateway.TLSConfig = tlsConfig.Clone()
+
+			rurl, _ := url.Parse(fmt.Sprintf("nats://%s:%d", optsA2.Gateway.Host, optsA2.Gateway.Port))
+			remote := &server.RemoteGatewayOpts{Name: "A", URLs: []*url.URL{rurl}}
+			remote.TLSConfig = tlsConfig.Clone()
+			o.Gateway.Gateways = []*server.RemoteGatewayOpts{remote}
+
+			srvB := RunServer(&o)
+			defer srvB.Shutdown()
+
+			waitForOutboundGateways(t, srvB, 1, 10*time.Second)
+			waitForOutboundGateways(t, srvA1, 1, 10*time.Second)
+			waitForOutboundGateways(t, srvA2, 1, 10*time.Second)
+
+			// Now kill off srvA2 and force serverB to connect to srvA1.
+			srvA2.Shutdown()
+
+			// Make sure this works.
+			waitForOutboundGateways(t, srvB, 1, 30*time.Second)
+		})
 	}
-	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-	tlsConfig.RootCAs = tlsConfig.ClientCAs
-
-	o.Gateway.TLSConfig = tlsConfig.Clone()
-
-	rurl, _ := url.Parse(fmt.Sprintf("nats://%s:%d", optsA2.Gateway.Host, optsA2.Gateway.Port))
-	remote := &server.RemoteGatewayOpts{Name: "A", URLs: []*url.URL{rurl}}
-	remote.TLSConfig = tlsConfig.Clone()
-	o.Gateway.Gateways = []*server.RemoteGatewayOpts{remote}
-
-	srvB := RunServer(&o)
-	defer srvB.Shutdown()
-
-	waitForOutboundGateways(t, srvB, 1, 10*time.Second)
-	waitForOutboundGateways(t, srvA1, 1, 10*time.Second)
-	waitForOutboundGateways(t, srvA2, 1, 10*time.Second)
-
-	// Now kill off srvA2 and force serverB to connect to srvA1.
-	srvA2.Shutdown()
-
-	// Make sure this works.
-	waitForOutboundGateways(t, srvB, 1, 10*time.Second)
 }
 
 func TestGatewayAdvertiseInCluster(t *testing.T) {


### PR DESCRIPTION
Includes fix for test `TestGatewayTLSMixedIPAndDNS ` that was breaking in Go 1.20.