### PR TITLE
De-flake `TestJetStreamClusterConsumerMaxDeliveryNumAckPendingBug`

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -5403,8 +5403,8 @@ func TestJetStreamClusterConsumerMaxDeliveryNumAckPendingBug(t *testing.T) {
 	// Created can skew a small bit due to server restart, this is expected.
 	now := time.Now()
 	cia.Created, cib.Created = now, now
-	// might not be push bound yet.
-	cib.PushBound = cia.PushBound
+	// Clear any disagreement on push bound.
+	cia.PushBound, cib.PushBound = false, false
 	checkConsumerInfo(cia, cib)
 }
 


### PR DESCRIPTION
This test flakes quite often on the final consumer info check because of one consumer reporting `PushBound` and the other not. By clearing both, this should clear up the disagreement.

Signed-off-by: Neil Twigg <neil@nats.io>