### PR TITLE
v2.10: Use Go 1.21 in nightlies, update rand usage

### DIFF
--- a/.github/workflows/cov.yaml
+++ b/.github/workflows/cov.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20.x"
+          go-version: "1.21.x"
 
       - name: Run code coverage
         shell: bash --noprofile --norc -x -eo pipefail {0}

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ["1.20"]
+        go: ["1.21"]
 
     env:
       GOPATH: /home/runner/work/nats-server

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:
-          go: "1.20"
+          go: "1.21"
           workdir: src/github.com/nats-io/nats-server
           label: nightly
           hub_username: "${{ secrets.DOCKER_USERNAME }}"

--- a/.github/workflows/rc_nightly.yaml
+++ b/.github/workflows/rc_nightly.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:
-          go: "1.20"
+          go: "1.21"
           workdir: src/github.com/nats-io/nats-server
           label: nightly-main
           hub_username: "${{ secrets.DOCKER_USERNAME }}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ vm:
 
 language: go
 go:
-# This should be quoted or use .x, but should not be unquoted.
-# Remember that a YAML bare float drops trailing zeroes.
+  # This should be quoted or use .x, but should not be unquoted.
+  # Remember that a YAML bare float drops trailing zeroes.
   - "1.21.x"
   - "1.20.x"
 
@@ -41,7 +41,7 @@ jobs:
     - name: "Run all tests from all other packages"
       env: TEST_SUITE=non_srv_pkg_tests
     - name: "Compile with older Go release"
-      go: "1.19.12"
+      go: "1.20"
       env: TEST_SUITE=build_only
 
 script: ./scripts/runTestsOnTravis.sh $TEST_SUITE
@@ -52,4 +52,4 @@ deploy:
   script: curl -sL http://git.io/goreleaser | bash
   on:
     tags: true
-    condition: ($TRAVIS_GO_VERSION =~ 1.20) && ($TEST_SUITE = "compile")
+    condition: ($TRAVIS_GO_VERSION =~ 1.21) && ($TEST_SUITE = "compile")

--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine AS builder
+FROM golang:1.21-alpine AS builder
 
 ARG VERSION="nightly"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nats-io/nats-server/v2
 
-go 1.19
+go 1.20
 
 require (
 	github.com/klauspost/compress v1.16.7

--- a/server/client.go
+++ b/server/client.go
@@ -91,10 +91,6 @@ const (
 	tlsHandshakeMQTT = "mqtt"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 const (
 	// Scratch buffer size for the processMsg() calls.
 	msgScratchSize  = 1024

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -236,7 +236,6 @@ func TestJetStreamConsumerMultipleConsumersSingleFilter(t *testing.T) {
 	}
 
 	// Publish with random intervals, while consumers are active.
-	rand.Seed(time.Now().UnixNano())
 	var wg sync.WaitGroup
 	for _, subject := range subjects {
 		wg.Add(subject.messages)
@@ -348,7 +347,6 @@ func TestJetStreamConsumerMultipleConsumersMultipleFilters(t *testing.T) {
 	}
 
 	// Publish with random intervals, while consumers are active.
-	rand.Seed(time.Now().UnixNano())
 	var wg sync.WaitGroup
 	for _, subject := range subjects {
 		wg.Add(subject.messages)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -20396,7 +20396,7 @@ func TestJetStreamPullConsumerBatchCompleted(t *testing.T) {
 
 	msgSize := 128
 	msg := make([]byte, msgSize)
-	rand.Read(msg)
+	crand.Read(msg)
 
 	for i := 0; i < 10; i++ {
 		_, err := js.Publish("foo", msg)
@@ -20462,7 +20462,7 @@ func TestJetStreamConsumerAndStreamMetadata(t *testing.T) {
 
 	// Test max.
 	data := make([]byte, JSMaxMetadataLen/100)
-	rand.Read(data)
+	crand.Read(data)
 	bigValue := base64.StdEncoding.EncodeToString(data)
 
 	bigMetadata := make(map[string]string, 101)

--- a/server/nkey_test.go
+++ b/server/nkey_test.go
@@ -274,7 +274,7 @@ func BenchmarkNonceGeneration(b *testing.B) {
 func BenchmarkPublicVerify(b *testing.B) {
 	data := make([]byte, nonceRawLen)
 	nonce := make([]byte, nonceLen)
-	mrand.Read(data)
+	crand.Read(data)
 	base64.RawURLEncoding.Encode(nonce, data)
 
 	user, err := nkeys.CreateUser()


### PR DESCRIPTION
- Use Go 1.21 in nightlies
- Both rand.Seed and rand.Read are both deprecated, remove its use to fix staticcheck errors

```go
server/client.go:95:2: SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative 
  has been available since Go 1.0: As of Go 1.20 there is no reason to call Seed with a random value. 
  Programs that call Seed with a known value to get a specific sequence of results should use 
  New(NewSource(seed)) to obtain a local random generator. (staticcheck)

server/jetstream_test.go:20399:2: SA1019: rand.Read has been deprecated since Go 1.20 
  because it shouldn't be used: For almost all use cases, crypto/rand.Read is more appropriate. (staticcheck)
```