### PR TITLE
Fix race condition in hashing stream snapshots

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7100,9 +7100,11 @@ func (fs *fileStore) streamSnapshot(w io.WriteCloser, state *StreamState, includ
 			buf, err = fs.aek.Open(nil, buf[:ns], buf[ns:len(buf)-highwayhash.Size64], nil)
 			if err == nil {
 				// Redo hash checksum at end on plaintext.
+				fs.mu.Lock()
 				hh.Reset()
 				hh.Write(buf)
 				buf = fs.hh.Sum(buf)
+				fs.mu.Unlock()
 			}
 		}
 		if err == nil && writeFile(msgPre+streamStreamStateFile, buf) != nil {


### PR DESCRIPTION
The `streamSnapshot` function was not holding the filestore lock while resetting and using the hasher. This created a data race and also resulted in flakes in `TestFileStoreSnapshot`.

Signed-off-by: Neil Twigg <neil@nats.io>