### PR TITLE
Fix TestNoRaceJetStreamInterestStreamCheckInterestRaceBug

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -7154,7 +7154,7 @@ func TestNoRaceJetStreamInterestStreamCheckInterestRaceBug(t *testing.T) {
 
 	numToSend := 10_000
 	for i := 0; i < numToSend; i++ {
-		_, err := js.PublishAsync("foo", nil)
+		_, err := js.PublishAsync("foo", nil, nats.StallWait(800*time.Millisecond))
 		require_NoError(t, err)
 	}
 	select {


### PR DESCRIPTION
This flakes sometimes as stalled, and it seems that a similar value for `StallWait` starts to surface errors both on `main` and `dev`. Not sure why it's happening in this test specifically, but it does not seem to be an issue beyond timing. Performance might be worth looking up as a follow-up.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>