### PR TITLE
Fix TestNoRaceJetStreamSparseConsumers

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -4321,14 +4321,14 @@ func TestNoRaceJetStreamSparseConsumers(t *testing.T) {
 
 			// We will purposely place foo msgs near the beginning, then in middle, then at the end.
 			for n := 0; n < 2; n++ {
-				_, err = js.PublishAsync("foo", msg)
+				_, err = js.PublishAsync("foo", msg, nats.StallWait(800*time.Millisecond))
 				require_NoError(t, err)
 
 				for i := 0; i < 1_000_000; i++ {
-					_, err = js.PublishAsync("bar", msg)
+					_, err = js.PublishAsync("bar", msg, nats.StallWait(800*time.Millisecond))
 					require_NoError(t, err)
 				}
-				_, err = js.PublishAsync("foo", msg)
+				_, err = js.PublishAsync("foo", msg, nats.StallWait(800*time.Millisecond))
 				require_NoError(t, err)
 			}
 			select {


### PR DESCRIPTION
 This is the same fix as in https://github.com/nats-io/nats-server/pull/4500

This means it adds `StallWait` to `PublishAsync`, as that's seems to be the only
reason why this test fails.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>