### PR TITLE
Allow more time in `TestNoRaceSeqSetEncodeLarge`

### DIFF
--- a/server/avl/norace_test.go
+++ b/server/avl/norace_test.go
@@ -96,7 +96,7 @@ func TestNoRaceSeqSetEncodeLarge(t *testing.T) {
 	defer debug.SetGCPercent(gcp)
 
 	// In general should be about the same, but can see some variability.
-	expected := 500 * time.Microsecond
+	expected := time.Millisecond
 
 	start := time.Now()
 	b, err := ss.Encode(nil)


### PR DESCRIPTION
In CI this is typically < 700uS, but quite often > 500uS.

Signed-off-by: Neil Twigg <neil@nats.io>