### PR TITLE
[FIXED] Skip TestMQTTQoS2InflightMsgsDeliveredAfterUnsubscribe, see c…

### DIFF
--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -4893,6 +4893,12 @@ func TestMQTTRedeliveryAckWait(t *testing.T) {
 //   - After one is PUBCOMP-ed, and one is PUBREC-ed, Unsubscribe.
 //   - See that the remaining 2 are fully delivered.
 func TestMQTTQoS2InflightMsgsDeliveredAfterUnsubscribe(t *testing.T) {
+	// This test has proven flaky on Travis, so skip for now. Line 4926, the 3rd
+	// testMQTTCheckPubMsgNoAck sometimes returns `data1`, instead of `data3`
+	// that we are expecting. It must be a retry since we did not acknowledge
+	// `data1` until later.
+	t.Skip()
+
 	o := testMQTTDefaultOptions()
 	o.MQTT.AckWait = 10 * time.Millisecond
 	s := testMQTTRunServer(t, o)


### PR DESCRIPTION
`TestMQTTQoS2InflightMsgsDeliveredAfterUnsubscribe` was flaky on TravisCI.

At this point it was there to illustrate a design issue with MQTT 3.1.1 QoS support, and much of it is disabled since it'd be failing anyway. Disabling the test until it can be _fully_ applicable/enabled.