### PR TITLE
Update docker nightly builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: src/github.com/nats-io/nats-server
-          ref: ${{ inputs.target || 'dev' }}
+          ref: ${{ inputs.target || 'main' }}
 
       - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:

--- a/.github/workflows/rc_nightly.yaml
+++ b/.github/workflows/rc_nightly.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: src/github.com/nats-io/nats-server
-          ref: ${{ inputs.target || 'main' }}
+          ref: ${{ inputs.target || 'v2.9.22' }}
 
       - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:


### PR DESCRIPTION
main is now the contents of the dev branch, the old nightly-main points to the last release for now.