### PR TITLE
De-flake `TestJetStreamClusterAccountPurge`

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -3738,6 +3738,8 @@ func TestJetStreamClusterAccountPurge(t *testing.T) {
 	updateJwt(t, c.randomServer().ClientURL(), sysCreds, sysJwt, 3)
 	updateJwt(t, c.randomServer().ClientURL(), sysCreds, accJwt, 3)
 
+	c.waitOnAccount(accpub)
+
 	createTestData := func(t *testing.T) {
 		nc, js := jsClientConnect(t, c.randomNonLeader(), nats.UserCredentials(accCreds))
 		defer nc.Close()

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -1435,6 +1435,25 @@ func (c *cluster) waitOnLeader() {
 	c.t.Fatalf("Expected a cluster leader, got none")
 }
 
+func (c *cluster) waitOnAccount(account string) {
+	c.t.Helper()
+	expires := time.Now().Add(40 * time.Second)
+	for time.Now().Before(expires) {
+		found := true
+		for _, s := range c.servers {
+			acc, err := s.fetchAccount(account)
+			found = found && err == nil && acc != nil
+		}
+		if found {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+		continue
+	}
+
+	c.t.Fatalf("Expected account %q to exist but didn't", account)
+}
+
 // Helper function to check that a cluster is formed
 func (c *cluster) waitOnClusterReady() {
 	c.t.Helper()


### PR DESCRIPTION
This adds a new `waitForAccount` test helper that ensures that an account exists across the cluster, and updates `TestJetStreamClusterAccountPurge` to use it after submitting new JWTs. This should prevent `require no error, but got: nats: JetStream not enabled for account` errors.

Signed-off-by: Neil Twigg <neil@nats.io>