### PR TITLE
AuthCallout request should include TLS data when client is NATS WS client

### DIFF
--- a/server/auth_callout_test.go
+++ b/server/auth_callout_test.go
@@ -155,7 +155,14 @@ func (at *authTest) Connect(clientOptions ...nats.Option) *nats.Conn {
 func (at *authTest) WSNewClient(clientOptions ...nats.Option) (*nats.Conn, error) {
 	pi := at.srv.PortsInfo(10 * time.Millisecond)
 	require_False(at.t, pi == nil)
-	conn, err := nats.Connect(strings.Replace(pi.WebSocket[0], "127.0.0.1", "localhost", 1), clientOptions...)
+
+	// test cert is SAN to DNS localhost, not local IPs returned by server in test environments
+	wssUrl := strings.Replace(pi.WebSocket[0], "127.0.0.1", "localhost", 1)
+
+	// Seeing 127.0.1.1 in some test environments...
+	wssUrl = strings.Replace(wssUrl, "127.0.1.1", "localhost", 1)
+
+	conn, err := nats.Connect(wssUrl, clientOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/server/auth_callout_test.go
+++ b/server/auth_callout_test.go
@@ -1486,14 +1486,14 @@ func TestAuthCalloutWSClientTLSCerts(t *testing.T) {
 	`
 	handler := func(m *nats.Msg) {
 		user, si, ci, _, ctls := decodeAuthRequest(t, m.Data)
-		require_True(t, si.Name == "T")
-		require_True(t, ci.Host == "127.0.0.1")
-		require_True(t, ctls != nil)
+		require_Equal(t, si.Name, "T")
+		require_Equal(t, ci.Host, "127.0.0.1")
+		require_NotEqual(t, ctls, nil)
 		// Zero since we are verified and will be under verified chains.
-		require_True(t, len(ctls.Certs) == 0)
-		require_True(t, len(ctls.VerifiedChains) == 1)
+		require_Equal(t, len(ctls.Certs), 0)
+		require_Equal(t, len(ctls.VerifiedChains), 1)
 		// Since we have a CA.
-		require_True(t, len(ctls.VerifiedChains[0]) == 2)
+		require_Equal(t, len(ctls.VerifiedChains[0]), 2)
 		blk, _ := pem.Decode([]byte(ctls.VerifiedChains[0][0]))
 		cert, err := x509.ParseCertificate(blk.Bytes)
 		require_NoError(t, err)
@@ -1523,6 +1523,6 @@ func TestAuthCalloutWSClientTLSCerts(t *testing.T) {
 	require_NoError(t, err)
 	userInfo := response.Data.(*UserInfo)
 
-	require_True(t, userInfo.UserID == "dlc")
-	require_True(t, userInfo.Account == "FOO")
+	require_Equal(t, userInfo.UserID, "dlc")
+	require_Equal(t, userInfo.Account, "FOO")
 }

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -561,12 +561,13 @@ func (ci *ConnInfo) fill(client *client, nc net.Conn, now time.Time, auth bool) 
 	// Exclude clients that are still doing handshake so we don't block in
 	// ConnectionState().
 	if client.flags.isSet(handshakeComplete) && nc != nil {
-		conn := nc.(*tls.Conn)
-		cs := conn.ConnectionState()
-		ci.TLSVersion = tlsVersion(cs.Version)
-		ci.TLSCipher = tlsCipher(cs.CipherSuite)
-		if auth && len(cs.PeerCertificates) > 0 {
-			ci.TLSPeerCerts = makePeerCerts(cs.PeerCertificates)
+		if conn, ok := nc.(*tls.Conn); ok {
+			cs := conn.ConnectionState()
+			ci.TLSVersion = tlsVersion(cs.Version)
+			ci.TLSCipher = tlsCipher(cs.CipherSuite)
+			if auth && len(cs.PeerCertificates) > 0 {
+				ci.TLSPeerCerts = makePeerCerts(cs.PeerCertificates)
+			}
 		}
 	}
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1234,12 +1234,14 @@ func (s *Server) createWSClient(conn net.Conn, ws *websocket) *client {
 		return nil
 	}
 	s.clients[c.cid] = c
-
-	// Websocket clients do TLS in the websocket http server.
-	// So no TLS here...
 	s.mu.Unlock()
 
 	c.mu.Lock()
+	// Websocket clients do TLS in the websocket http server.
+	// So no TLS initiation here...
+	if _, ok := conn.(*tls.Conn); ok {
+		c.flags.set(handshakeComplete)
+	}
 
 	if c.isClosed() {
 		c.mu.Unlock()


### PR DESCRIPTION
Make sure the client handshake flag is set when TLS handshake is made as part of WebSocket connection/upgrade (notionally HTTPS) rather than as part of the NATS protocol TLS initiation chain.  AuthCallout tests the flag when building the data for the AuthCallout service request.

Added AuthCallout unit test for NATS WS client auth that requires the TLS data.

