### PR TITLE
Add Raft goroutine labels, tweak logging

### DIFF
--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -115,7 +115,7 @@ func (c *cluster) createRaftGroupWithPeers(name string, servers []*Server, smf s
 		require_NoError(c.t, err)
 		cfg := &RaftConfig{Name: name, Store: c.t.TempDir(), Log: fs}
 		s.bootstrapRaftNode(cfg, peers, true)
-		n, err := s.startRaftNode(globalAccountName, cfg)
+		n, err := s.startRaftNode(globalAccountName, cfg, pprofLabels{})
 		require_NoError(c.t, err)
 		sm := smf(s, cfg, n)
 		sg = append(sg, sm)
@@ -230,7 +230,7 @@ func (a *stateAdder) restart() {
 	if err != nil {
 		panic(err)
 	}
-	a.n, err = a.s.startRaftNode(globalAccountName, a.cfg)
+	a.n, err = a.s.startRaftNode(globalAccountName, a.cfg, pprofLabels{})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This adds some more debugging information to the Raft goroutines in pprof and improves the logging when a consumer was already running.

Example:
```
1 @ 0x1025b1838 0x1025c2ac8 0x102a47d1c 0x102a47244 0x102a858e0 0x1025e5ad4
# labels: {"account":"$SYS", "group":"_meta_", "type":"metaleader"}
#	0x102a47d1b	github.com/nats-io/nats-server/v2/server.(*raft).runAsFollower+0xbb		server/raft.go:1795
#	0x102a47243	github.com/nats-io/nats-server/v2/server.(*raft).run+0x2c3			server/raft.go:1715
#	0x102a858df	github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1+0x17f	server/server.go:3609

1 @ 0x1025b1838 0x1025c2ac8 0x102a47d1c 0x102a47244 0x102a858e0 0x1025e5ad4
# labels: {"account":"$G", "group":"S-R3M-hn5zv7o3", "stream":"benchstream", "type":"stream"}
#	0x102a47d1b	github.com/nats-io/nats-server/v2/server.(*raft).runAsFollower+0xbb		server/raft.go:1795
#	0x102a47243	github.com/nats-io/nats-server/v2/server.(*raft).run+0x2c3			server/raft.go:1715
#	0x102a858df	github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1+0x17f	server/server.go:3609

1 @ 0x1025b1838 0x1025c2ac8 0x102a49b60 0x102a47250 0x102a858e0 0x1025e5ad4
# labels: {"account":"$G", "consumer":"foobar", "group":"C-R3M-djqHTUCq", "stream":"benchstream", "type":"consumer"}
#	0x102a49b5f	github.com/nats-io/nats-server/v2/server.(*raft).runAsLeader+0x4bf		server/raft.go:2198
#	0x102a4724f	github.com/nats-io/nats-server/v2/server.(*raft).run+0x2cf			server/raft.go:1719
#	0x102a858df	github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1+0x17f	server/server.go:3609
```

Signed-off-by: Neil Twigg <neil@nats.io>