### PR TITLE
Add logfile_max_num feature

### DIFF
--- a/server/log.go
+++ b/server/log.go
@@ -72,14 +72,14 @@ func (s *Server) ConfigureLogger() {
 				l.SetSizeLimit(opts.LogSizeLimit)
 			}
 		}
-		if opts.LogMaxArchives > 0 {
+		if opts.LogMaxFiles > 0 {
 			if l, ok := log.(*srvlog.Logger); ok {
-				al := int(opts.LogMaxArchives)
-				if int64(al) != opts.LogMaxArchives {
+				al := int(opts.LogMaxFiles)
+				if int64(al) != opts.LogMaxFiles {
 					// set to default (no max) on overflow
 					al = 0
 				}
-				l.SetArchiveLimit(al)
+				l.SetMaxNumFiles(al)
 			}
 		}
 	} else if opts.RemoteSyslog != "" {

--- a/server/log.go
+++ b/server/log.go
@@ -72,6 +72,16 @@ func (s *Server) ConfigureLogger() {
 				l.SetSizeLimit(opts.LogSizeLimit)
 			}
 		}
+		if opts.LogMaxArchives > 0 {
+			if l, ok := log.(*srvlog.Logger); ok {
+				al := int(opts.LogMaxArchives)
+				if int64(al) != opts.LogMaxArchives {
+					// set to default (no max) on overflow
+					al = 0
+				}
+				l.SetArchiveLimit(al)
+			}
+		}
 	} else if opts.RemoteSyslog != "" {
 		log = srvlog.NewRemoteSysLogger(opts.RemoteSyslog, opts.Debug, opts.Trace)
 	} else if syslog {

--- a/server/opts.go
+++ b/server/opts.go
@@ -311,6 +311,7 @@ type Options struct {
 	PortsFileDir          string            `json:"-"`
 	LogFile               string            `json:"-"`
 	LogSizeLimit          int64             `json:"-"`
+	LogMaxArchives        int64             `json:"-"`
 	Syslog                bool              `json:"-"`
 	RemoteSyslog          string            `json:"-"`
 	Routes                []*url.URL        `json:"-"`
@@ -999,6 +1000,8 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 		o.LogFile = v.(string)
 	case "logfile_size_limit", "log_size_limit":
 		o.LogSizeLimit = v.(int64)
+	case "logfile_max_archives", "log_max_archives":
+		o.LogMaxArchives = v.(int64)
 	case "syslog":
 		o.Syslog = v.(bool)
 		trackExplicitVal(o, &o.inConfig, "Syslog", o.Syslog)

--- a/server/opts.go
+++ b/server/opts.go
@@ -311,7 +311,7 @@ type Options struct {
 	PortsFileDir          string            `json:"-"`
 	LogFile               string            `json:"-"`
 	LogSizeLimit          int64             `json:"-"`
-	LogMaxArchives        int64             `json:"-"`
+	LogMaxFiles           int64             `json:"-"`
 	Syslog                bool              `json:"-"`
 	RemoteSyslog          string            `json:"-"`
 	Routes                []*url.URL        `json:"-"`
@@ -1000,8 +1000,8 @@ func (o *Options) processConfigFileLine(k string, v interface{}, errors *[]error
 		o.LogFile = v.(string)
 	case "logfile_size_limit", "log_size_limit":
 		o.LogSizeLimit = v.(int64)
-	case "logfile_max_archives", "log_max_archives":
-		o.LogMaxArchives = v.(int64)
+	case "logfile_max_num", "log_max_num":
+		o.LogMaxFiles = v.(int64)
 	case "syslog":
 		o.Syslog = v.(bool)
 		trackExplicitVal(o, &o.inConfig, "Syslog", o.Syslog)

--- a/test/log_test.go
+++ b/test/log_test.go
@@ -39,7 +39,7 @@ func TestLogMaxArchives(t *testing.T) {
 		totEntriesExpected int
 	}{
 		{
-			"Default implicit, no max archives, expect 0 purged archives",
+			"Default implicit, no max logs, expect 0 purged logs",
 			`
 				port: -1
 				log_file: %s
@@ -48,52 +48,52 @@ func TestLogMaxArchives(t *testing.T) {
 			9,
 		},
 		{
-			"Default explicit, no max archives, expect 0 purged archives",
+			"Default explicit, no max logs, expect 0 purged logs",
 			`
 				port: -1
 				log_file: %s
 				logfile_size_limit: 100
-				logfile_max_archives: 0
+				logfile_max_num: 0
 			`,
 			9,
 		},
 		{
-			"Default explicit - negative val, no max archives, expect 0 purged archives",
+			"Default explicit - negative val, no max logs, expect 0 purged logs",
 			`
 				port: -1
 				log_file: %s
 				logfile_size_limit: 100
-				logfile_max_archives: -42
+				logfile_max_num: -42
 			`,
 			9,
 		},
 		{
-			"1-archive limit, expect 7 purged archives",
+			"1-max num, expect 8 purged logs",
 			`
 				port: -1
 				log_file: %s
 				logfile_size_limit: 100
-				logfile_max_archives: 1
+				logfile_max_num: 1
 			`,
-			2,
+			1,
 		},
 		{
-			"5-archive limit, expect 4 purged archives",
+			"5-max num, expect 4 purged logs; use opt alias",
 			`
 				port: -1
 				log_file: %s
-				logfile_size_limit: 100
-				logfile_max_archives: 5
+				log_size_limit: 100
+				log_max_num: 5
 			`,
-			6,
+			5,
 		},
 		{
-			"100-archive limit, expect 0 purged archives",
+			"100-max num, expect 0 purged logs",
 			`
 				port: -1
 				log_file: %s
 				logfile_size_limit: 100
-				logfile_max_archives: 100
+				logfile_max_num: 100
 			`,
 			9,
 		},
@@ -117,6 +117,8 @@ func TestLogMaxArchives(t *testing.T) {
 				t.Fatalf("No NATS Server object returned")
 			}
 			s.Shutdown()
+			// Windows filesystem can be a little pokey on the flush, so wait a bit after shutdown...
+			time.Sleep(500 * time.Millisecond)
 			entries, err := os.ReadDir(d)
 			if err != nil {
 				t.Fatalf("Error reading dir: %v", err)

--- a/test/log_test.go
+++ b/test/log_test.go
@@ -1,0 +1,129 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+)
+
+func RunServerWithLogging(opts *server.Options) *server.Server {
+	if opts == nil {
+		opts = &DefaultTestOptions
+	}
+	opts.NoLog = false
+	opts.Cluster.PoolSize = -1
+	opts.Cluster.Compression.Mode = server.CompressionOff
+	opts.LeafNode.Compression.Mode = server.CompressionOff
+	s, err := server.NewServer(opts)
+	if err != nil || s == nil {
+		panic(fmt.Sprintf("No NATS Server object returned: %v", err))
+	}
+	s.ConfigureLogger()
+	go s.Start()
+	if !s.ReadyForConnections(10 * time.Second) {
+		panic("Unable to start NATS Server in Go Routine")
+	}
+	return s
+}
+
+func TestLogMaxArchives(t *testing.T) {
+	// With logfile_size_limit set to small 100 characters, plain startup rotates 8 times
+	for _, test := range []struct {
+		name               string
+		config             string
+		totEntriesExpected int
+	}{
+		{
+			"Default implicit, no max archives, expect 0 purged archives",
+			`
+				port: -1
+				log_file: %s
+				logfile_size_limit: 100
+			`,
+			9,
+		},
+		{
+			"Default explicit, no max archives, expect 0 purged archives",
+			`
+				port: -1
+				log_file: %s
+				logfile_size_limit: 100
+				logfile_max_archives: 0
+			`,
+			9,
+		},
+		{
+			"Default explicit - negative val, no max archives, expect 0 purged archives",
+			`
+				port: -1
+				log_file: %s
+				logfile_size_limit: 100
+				logfile_max_archives: -42
+			`,
+			9,
+		},
+		{
+			"1-archive limit, expect 7 purged archives",
+			`
+				port: -1
+				log_file: %s
+				logfile_size_limit: 100
+				logfile_max_archives: 1
+			`,
+			2,
+		},
+		{
+			"5-archive limit, expect 4 purged archives",
+			`
+				port: -1
+				log_file: %s
+				logfile_size_limit: 100
+				logfile_max_archives: 5
+			`,
+			6,
+		},
+		{
+			"100-archive limit, expect 0 purged archives",
+			`
+				port: -1
+				log_file: %s
+				logfile_size_limit: 100
+				logfile_max_archives: 100
+			`,
+			9,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			d, err := os.MkdirTemp("", "logtest")
+			if err != nil {
+				t.Fatalf("Error creating temp dir: %v", err)
+			}
+			content := fmt.Sprintf(test.config, filepath.Join(d, "nats-server.log"))
+			// server config does not like plain windows backslash
+			if runtime.GOOS == "windows" {
+				content = filepath.ToSlash(content)
+			}
+			opts, err := server.ProcessConfigFile(createConfFile(t, []byte(content)))
+			if err != nil {
+				t.Fatalf("Error processing config file: %v", err)
+			}
+			s := RunServerWithLogging(opts)
+			if s == nil {
+				t.Fatalf("No NATS Server object returned")
+			}
+			s.Shutdown()
+			entries, err := os.ReadDir(d)
+			if err != nil {
+				t.Fatalf("Error reading dir: %v", err)
+			}
+			if len(entries) != test.totEntriesExpected {
+				t.Fatalf("Expected %d log files, got %d", test.totEntriesExpected, len(entries))
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Changes proposed in this pull request:

NATS Server 2.9 has `logfile_size_limit` option which allows the operator to set an optional byte limit on the NATS Server log file which when met causes a "rotation" such that the current log file is renamed (original file name appended with a time stamp to nanosecond accuracy) and a new log file is instantiated.

This PR is a new `logfile_max_num` companion option (alias `log_max_num`) which allows the operator to designate that the server should prune the **total number of log files** -- the currently active log file plus backups -- to the maximum setting. 

A max value of `0` (the implicit default) or a negative number has meaning of unlimited log files (no maximum) as this is an opt-in feature.

A max value of `1` is effectively a truncate-only logging pattern as any backup made at rotation will subsequently be purged.

A max value of `2` will maintain the active log file plus the latest backup.  And so on...

> The currently active log file is never purged.  Only backups are purged.  

When enabled, backup log deletion is evaluated inline after each successful rotation event.  To be considered for log deletion, backup log files MUST adhere to the file naming format used in log rotation as well as agree with the current `logfile` name and location.  Any other files or sub-directories in the log directory will be ignored.  E.g. if an operator makes a manual copy of the log file to `logfile.bak` that file will not be evaluated as a backup.

### Typical use case:

This feature is useful in a constrained hosting environment for NATS Server, for example an embedded, edge-compute, or IoT device scenario, in which _more featureful_ platform or operating system log management features do not exist or the complexity is not required.
