### PR TITLE
Fix for data race when changing retention policy

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2667,12 +2667,16 @@ func (o *consumer) processAckMsg(sseq, dseq, dc uint64, doSample bool) {
 
 	mset := o.mset
 	clustered := o.node != nil
+
+	// In case retention changes for a stream, this ought to have been updated
+	// using the consumer lock to avoid a race.
+	retention := o.retention
 	o.mu.Unlock()
 
 	// Let the owning stream know if we are interest or workqueue retention based.
 	// If this consumer is clustered this will be handled by processReplicatedAck
 	// after the ack has propagated.
-	if !clustered && mset != nil && mset.cfg.Retention != LimitsPolicy {
+	if !clustered && mset != nil && retention != LimitsPolicy {
 		if sagap > 1 {
 			// FIXME(dlc) - This is very inefficient, will need to fix.
 			for seq := sseq; seq > sseq-sagap; seq-- {


### PR DESCRIPTION
Should fix following data race:
```
WARNING: DATA RACE
Write at 0x00c0006c3cf8 by goroutine 65593:
  github.com/nats-io/nats-server/v2/server.(*stream).updateWithAdvisory()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/stream.go:1907 +0x19c6
  github.com/nats-io/nats-server/v2/server.(*jetStream).processClusterUpdateStream()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:3448 +0xde5
  github.com/nats-io/nats-server/v2/server.(*jetStream).processUpdateStreamAssignment()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:3344 +0x904
  github.com/nats-io/nats-server/v2/server.(*jetStream).applyMetaEntries()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:1949 +0xcd6
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/jetstream_cluster.go:1344 +0xde4
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster-fm()
      <autogenerated>:1 +0x33
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/server.go:3609 +0x277
Previous read at 0x00c0006c3cf8 by goroutine 66031:
  github.com/nats-io/nats-server/v2/server.(*consumer).processAckMsg()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/consumer.go:2675 +0x78a
  github.com/nats-io/nats-server/v2/server.(*consumer).processAck()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/consumer.go:1951 +0x2c6
  github.com/nats-io/nats-server/v2/server.(*consumer).processInboundAcks()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/consumer.go:3683 +0x56a
  github.com/nats-io/nats-server/v2/server.(*consumer).setLeader.func4()
      /home/travis/gopath/src/github.com/nats-io/nats-server/server/consumer.go:1262 +0x44
```