### PR TITLE
Fix for data race in memstore.LoadNextMsg

### DIFF
--- a/server/memstore.go
+++ b/server/memstore.go
@@ -913,8 +913,8 @@ func (ms *memStore) LoadLastMsg(subject string, smp *StoreMsg) (*StoreMsg, error
 // LoadNextMsg will find the next message matching the filter subject starting at the start sequence.
 // The filter subject can be a wildcard.
 func (ms *memStore) LoadNextMsg(filter string, wc bool, start uint64, smp *StoreMsg) (*StoreMsg, uint64, error) {
-	ms.mu.RLock()
-	defer ms.mu.RUnlock()
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
 
 	if start < ms.state.FirstSeq {
 		start = ms.state.FirstSeq
@@ -1063,6 +1063,7 @@ func (ms *memStore) removeSeqPerSubject(subj string, seq uint64) {
 }
 
 // Will recalulate the first sequence for this subject in this block.
+// Lock should be held.
 func (ms *memStore) recalculateFirstForSubj(subj string, startSeq uint64, ss *SimpleState) {
 	for tseq := startSeq + 1; tseq <= ss.Last; tseq++ {
 		if sm := ms.msgs[tseq]; sm != nil && sm.subj == subj {


### PR DESCRIPTION
Fix for a data race that was found in memory storage while working on a fix for https://github.com/nats-io/nats-server/pull/4551

```
WARNING: DATA RACE
Read at 0x00c0000a6e38 by goroutine 412:
  github.com/nats-io/nats-server/v2/server.(*memStore).LoadNextMsg()
      /Users/wallyqs/repos/nats-dev/src/github.com/nats-io/nats-server/server/memstore.go:954 +0x644
  github.com/nats-io/nats-server/v2/server.(*consumer).getNextMsg()
      /Users/wallyqs/repos/nats-dev/src/github.com/nats-io/nats-server/server/consumer.go:3413 +0xb22
  github.com/nats-io/nats-server/v2/server.(*consumer).loopAndGatherMsgs()
      /Users/wallyqs/repos/nats-dev/src/github.com/nats-io/nats-server/server/consumer.go:3824 +0x484
  github.com/nats-io/nats-server/v2/server.(*consumer).setLeader.func3()
      /Users/wallyqs/repos/nats-dev/src/github.com/nats-io/nats-server/server/consumer.go:1259 +0x44

Previous write at 0x00c0000a6e38 by goroutine 336:
  github.com/nats-io/nats-server/v2/server.(*memStore).recalculateFirstForSubj()
      /Users/wallyqs/repos/nats-dev/src/github.com/nats-io/nats-server/server/memstore.go:1070 +0x6a5
  github.com/nats-io/nats-server/v2/server.(*memStore).LoadNextMsg()
      /Users/wallyqs/repos/nats-dev/src/github.com/nats-io/nats-server/server/memstore.go:955 +0x653
  github.com/nats-io/nats-server/v2/server.(*consumer).getNextMsg()
      /Users/wallyqs/repos/nats-dev/src/github.com/nats-io/nats-server/server/consumer.go:3413 +0xb22
  github.com/nats-io/nats-server/v2/server.(*consumer).loopAndGatherMsgs()
      /Users/wallyqs/repos/nats-dev/src/github.com/nats-io/nats-server/server/consumer.go:3824 +0x484
  github.com/nats-io/nats-server/v2/server.(*consumer).setLeader.func3()
      /Users/wallyqs/repos/nats-dev/src/github.com/nats-io/nats-server/server/consumer.go:1259 +0x44
```
