### PR TITLE
Ignore `subject_transform_dest` in stream sourcing

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -11575,7 +11575,7 @@ func TestJetStreamMirrorBasics(t *testing.T) {
 	createStreamServerStreamConfig(&StreamConfig{
 		Name:    "M5",
 		Storage: FileStorage,
-		Mirror:  &StreamSource{Name: "S1", FilterSubject: "foo", SubjectTransformDest: "foo2"},
+		Mirror:  &StreamSource{Name: "S1", SubjectTransforms: []SubjectTransformConfig{{Source: "foo", Destination: "foo2"}}},
 	}, 0)
 
 	createStreamServerStreamConfig(&StreamConfig{
@@ -11688,7 +11688,7 @@ func TestJetStreamSourceBasics(t *testing.T) {
 		Name:    "MS",
 		Storage: FileStorage,
 		Sources: []*StreamSource{
-			{Name: "foo", SubjectTransformDest: "foo2.>"},
+			{Name: "foo", SubjectTransforms: []SubjectTransformConfig{{Source: ">", Destination: "foo2.>"}}},
 			{Name: "bar"},
 			{Name: "baz"},
 		},
@@ -11770,7 +11770,7 @@ func TestJetStreamSourceBasics(t *testing.T) {
 		Name:    "FMS2",
 		Storage: FileStorage,
 		Sources: []*StreamSource{
-			{Name: "TEST", OptStartSeq: 11, FilterSubject: "dlc", SubjectTransformDest: "dlc2"},
+			{Name: "TEST", OptStartSeq: 11, SubjectTransforms: []SubjectTransformConfig{{Source: "dlc", Destination: "dlc2"}}},
 		},
 	}
 	createStream(cfg)

--- a/server/stream.go
+++ b/server/stream.go
@@ -186,7 +186,7 @@ type StreamSourceInfo struct {
 	Active               time.Duration            `json:"active"`
 	Error                *ApiError                `json:"error,omitempty"`
 	FilterSubject        string                   `json:"filter_subject,omitempty"`
-	SubjectTransformDest string                   `json:"subject_transform_dest,omitempty"`
+	SubjectTransformDest string                   `json:"-"`
 	SubjectTransforms    []SubjectTransformConfig `json:"subject_transforms,omitempty"`
 }
 
@@ -196,7 +196,7 @@ type StreamSource struct {
 	OptStartSeq          uint64                   `json:"opt_start_seq,omitempty"`
 	OptStartTime         *time.Time               `json:"opt_start_time,omitempty"`
 	FilterSubject        string                   `json:"filter_subject,omitempty"`
-	SubjectTransformDest string                   `json:"subject_transform_dest,omitempty"`
+	SubjectTransformDest string                   `json:"-"`
 	SubjectTransforms    []SubjectTransformConfig `json:"subject_transforms,omitempty"`
 	External             *ExternalStream          `json:"external,omitempty"`
 


### PR DESCRIPTION
This is a safer (less lines of code touched) alternative to #4557 for now, which simply ignores the `subject_transform_dest` field in the API and the stream assignments. We'll still look to merge the other PR to clean up but will do so post-release when we have more time to test it.

Signed-off-by: Neil Twigg <neil@nats.io>