### PR TITLE
Fix data race in `setStreamAssignment` by ensuring JS lock held

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -747,6 +747,7 @@ func (mset *stream) streamAssignment() *streamAssignment {
 
 func (mset *stream) setStreamAssignment(sa *streamAssignment) {
 	var node RaftNode
+	var peers []string
 
 	mset.mu.RLock()
 	js := mset.js
@@ -756,6 +757,7 @@ func (mset *stream) setStreamAssignment(sa *streamAssignment) {
 		js.mu.RLock()
 		if sa.Group != nil {
 			node = sa.Group.node
+			peers = sa.Group.Peers
 		}
 		js.mu.RUnlock()
 	}
@@ -771,7 +773,7 @@ func (mset *stream) setStreamAssignment(sa *streamAssignment) {
 	// Set our node.
 	mset.node = node
 	if mset.node != nil {
-		mset.node.UpdateKnownPeers(sa.Group.Peers)
+		mset.node.UpdateKnownPeers(peers)
 	}
 
 	// Setup our info sub here as well for all stream members. This is now by design.


### PR DESCRIPTION
`addStreamWithAssignment` did not hold the JS lock at the point of calling `setStreamAssignment`, which could result in a data race accessing the Raft group peers from the stream assignment on line 774.

Signed-off-by: Neil Twigg <neil@nats.io>