### PR TITLE
Fix race condition in `clientHasMovedToDifferentAccount`

### DIFF
--- a/server/reload.go
+++ b/server/reload.go
@@ -2009,6 +2009,8 @@ func (s *Server) clientHasMovedToDifferentAccount(c *client) bool {
 		nu *NkeyUser
 		u  *User
 	)
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.opts.Nkey != "" {
 		if s.nkeys != nil {
 			nu = s.nkeys[c.opts.Nkey]
@@ -2021,12 +2023,10 @@ func (s *Server) clientHasMovedToDifferentAccount(c *client) bool {
 		return false
 	}
 	// Get the current account name
-	c.mu.Lock()
 	var curAccName string
 	if c.acc != nil {
 		curAccName = c.acc.Name
 	}
-	c.mu.Unlock()
 	if nu != nil && nu.Account != nil {
 		return curAccName != nu.Account.Name
 	} else if u != nil && u.Account != nil {

--- a/server/reload.go
+++ b/server/reload.go
@@ -2011,11 +2011,11 @@ func (s *Server) clientHasMovedToDifferentAccount(c *client) bool {
 	)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.opts.Nkey != "" {
+	if c.opts.Nkey != _EMPTY_ {
 		if s.nkeys != nil {
 			nu = s.nkeys[c.opts.Nkey]
 		}
-	} else if c.opts.Username != "" {
+	} else if c.opts.Username != _EMPTY_ {
 		if s.users != nil {
 			u = s.users[c.opts.Username]
 		}


### PR DESCRIPTION
Fixes #4560. The client lock needs to be held before accessing the `c.opts`.

Signed-off-by: Neil Twigg <neil@nats.io>