### PR TITLE
Use new consumer create subject when single subject filter specified in `SubjectFilters`

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -2893,6 +2893,9 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64, startTime time.T
 	if req.Config.FilterSubject != _EMPTY_ {
 		req.Config.Name = fmt.Sprintf("src-%s", createConsumerName())
 		subject = fmt.Sprintf(JSApiConsumerCreateExT, si.name, req.Config.Name, req.Config.FilterSubject)
+	} else if len(req.Config.FilterSubjects) == 1 {
+		req.Config.Name = fmt.Sprintf("src-%s", createConsumerName())
+		subject = fmt.Sprintf(JSApiConsumerCreateExT, si.name, req.Config.Name, req.Config.FilterSubjects[0])
 	} else {
 		subject = fmt.Sprintf(JSApiConsumerCreateT, si.name)
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -2895,7 +2895,11 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64, startTime time.T
 		subject = fmt.Sprintf(JSApiConsumerCreateExT, si.name, req.Config.Name, req.Config.FilterSubject)
 	} else if len(req.Config.FilterSubjects) == 1 {
 		req.Config.Name = fmt.Sprintf("src-%s", createConsumerName())
-		subject = fmt.Sprintf(JSApiConsumerCreateExT, si.name, req.Config.Name, req.Config.FilterSubjects[0])
+		// It is necessary to switch to using FilterSubject here as the extended consumer
+		// create API checks for it, so as to not accidentally allow multiple filtered subjects.
+		req.Config.FilterSubject = req.Config.FilterSubjects[0]
+		req.Config.FilterSubjects = nil
+		subject = fmt.Sprintf(JSApiConsumerCreateExT, si.name, req.Config.Name, req.Config.FilterSubject)
 	} else {
 		subject = fmt.Sprintf(JSApiConsumerCreateT, si.name)
 	}


### PR DESCRIPTION
This fixes an issue where specifying a single subject filter, i.e. in `SubjectFilters` or `SubjectTransforms`, instead of using `SubjectFilter` would result in the old consumer create subject being incorrectly used.

Signed-off-by: Neil Twigg <neil@nats.io>