### PR TITLE
[FIXED] LeafNode: TLS Handshake when remote does not have a tls{} block

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1160,6 +1160,12 @@ func (c *client) processLeafnodeInfo(info *Info) {
 	// So check only for non websocket connections and for configurations
 	// where the TLS Handshake was not done first.
 	if didSolicit && !c.flags.isSet(handshakeComplete) && !c.isWebsocket() && !remote.TLSHandshakeFirst {
+		// If the server requires TLS, we need to set this in the remote
+		// otherwise if there is no TLS configuration block for the remote,
+		// the solicit side will not attempt to perform the TLS handshake.
+		if firstINFO && info.TLSRequired {
+			remote.TLS = true
+		}
 		if _, err := c.leafClientHandshakeIfNeeded(remote, opts); err != nil {
 			c.mu.Unlock()
 			return


### PR DESCRIPTION
If a leafnode remote configuration does not have a tls{} block but connect to a hub that requires TLS, the handshake between the two servers will fail. A simple workaround is to add in the remote configuration an empty tls{} block.

This issue was introduced in v2.10.0 due to some refactoring in order to support compression.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
