### PR TITLE
Set S2 writer concurrency to 1

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -572,13 +572,18 @@ func selectS2AutoModeBasedOnRTT(rtt time.Duration, rttThresholds []time.Duration
 // with a nil []s2.WriterOption, but not with a nil s2.WriterOption, so
 // this is more versatile.
 func s2WriterOptions(cm string) []s2.WriterOption {
+	_opts := [2]s2.WriterOption{}
+	opts := append(
+		_opts[:0],
+		s2.WriterConcurrency(1), // Stop asynchronous flushing in separate goroutines
+	)
 	switch cm {
 	case CompressionS2Uncompressed:
-		return []s2.WriterOption{s2.WriterUncompressed()}
+		return append(opts, s2.WriterUncompressed())
 	case CompressionS2Best:
-		return []s2.WriterOption{s2.WriterBestCompression()}
+		return append(opts, s2.WriterBestCompression())
 	case CompressionS2Better:
-		return []s2.WriterOption{s2.WriterBetterCompression()}
+		return append(opts, s2.WriterBetterCompression())
 	default:
 		return nil
 	}


### PR DESCRIPTION
By default the S2 library defaults to a concurrency level of `GOMAXPROCS`, which forces the library to run extra goroutines to manage asynchronous flushes.

As we only ever have one goroutine (the client writer) using a given S2 writer, reducing the concurrency down to 1 helps a bit with overheads, slightly reduces allocations and slightly improves throughput. 

Signed-off-by: Neil Twigg <neil@nats.io>