### PR TITLE
[IMPROVED] Make install snapshot errors rate limited for when catching up

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -3089,7 +3089,9 @@ func (fs *fileStore) rebuildFirst() {
 	isEmpty := fmb.msgs == 0
 	fmb.mu.RUnlock()
 	if isEmpty {
+		fmb.mu.Lock()
 		fs.removeMsgBlock(fmb)
+		fmb.mu.Unlock()
 	}
 	fs.selectNextFirst()
 	fs.rebuildStateLocked(ld)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2229,7 +2229,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 		if err := n.InstallSnapshot(mset.stateSnapshot()); err == nil {
 			lastState, lastSnapTime = curState, time.Now()
 		} else if err != errNoSnapAvailable && err != errNodeClosed {
-			s.Warnf("Failed to install snapshot for '%s > %s' [%s]: %v", mset.acc.Name, mset.name(), n.Group(), err)
+			s.RateLimitWarnf("Failed to install snapshot for '%s > %s' [%s]: %v", mset.acc.Name, mset.name(), n.Group(), err)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>