### PR TITLE
Report observer mode in replica state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/nats-io/nats-server/v2
 
+replace github.com/nats-io/nats.go => github.com/nats-io/nats.go v1.30.1-0.20230925101945-66fd3c30ab7b
+
 go 1.20
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/nats-io/jwt/v2 v2.5.2 h1:DhGH+nKt+wIkDxM6qnVSKjokq5t59AZV5HRcFW0zJwU=
 github.com/nats-io/jwt/v2 v2.5.2/go.mod h1:24BeQtRwxRV8ruvC4CojXlx/WQ/VjuwlYiH+vu/+ibI=
-github.com/nats-io/nats.go v1.29.0 h1:dSXZ+SZeGyTdHVYeXimeq12FsIpb9dM8CJ2IZFiHcyE=
-github.com/nats-io/nats.go v1.29.0/go.mod h1:XpbWUlOElGwTYbMR7imivs7jJj9GtK7ypv321Wp6pjc=
+github.com/nats-io/nats.go v1.30.1-0.20230925101945-66fd3c30ab7b h1:Ah3/w4+xttYxf40CtdYPYwVpW/sVppLblSE7NOKhLQg=
+github.com/nats-io/nats.go v1.30.1-0.20230925101945-66fd3c30ab7b/go.mod h1:dcfhUgmQNN4GJEfIb2f9R7Fow+gzBF4emzDHrVBd5qM=
 github.com/nats-io/nkeys v0.4.5 h1:Zdz2BUlFm4fJlierwvGK+yl20IAKUm7eV6AAZXEhkPk=
 github.com/nats-io/nkeys v0.4.5/go.mod h1:XUkxdLPTufzlihbamfzQ7mw/VGx6ObUs+0bN5sNvt64=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=

--- a/server/raft.go
+++ b/server/raft.go
@@ -90,10 +90,11 @@ type WAL interface {
 }
 
 type Peer struct {
-	ID      string
-	Current bool
-	Last    time.Time
-	Lag     uint64
+	ID       string
+	Current  bool
+	Observer bool
+	Last     time.Time
+	Lag      uint64
 }
 
 type RaftState uint8
@@ -1463,10 +1464,11 @@ func (n *raft) Peers() []*Peer {
 			lag = n.commit - ps.li
 		}
 		p := &Peer{
-			ID:      id,
-			Current: id == n.leader || ps.li >= n.applied,
-			Last:    time.Unix(0, ps.ts),
-			Lag:     lag,
+			ID:       id,
+			Current:  id == n.leader || ps.li >= n.applied,
+			Observer: n.observer,
+			Last:     time.Unix(0, ps.ts),
+			Lag:      lag,
 		}
 		peers = append(peers, p)
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -168,12 +168,13 @@ type ClusterInfo struct {
 // PeerInfo shows information about all the peers in the cluster that
 // are supporting the stream or consumer.
 type PeerInfo struct {
-	Name    string        `json:"name"`
-	Current bool          `json:"current"`
-	Offline bool          `json:"offline,omitempty"`
-	Active  time.Duration `json:"active"`
-	Lag     uint64        `json:"lag,omitempty"`
-	Peer    string        `json:"peer"`
+	Name     string        `json:"name"`
+	Current  bool          `json:"current"`
+	Observer bool          `json:"observer,omitempty"`
+	Offline  bool          `json:"offline,omitempty"`
+	Active   time.Duration `json:"active"`
+	Lag      uint64        `json:"lag,omitempty"`
+	Peer     string        `json:"peer"`
 	// For migrations.
 	cluster string
 }


### PR DESCRIPTION
Currently we don't surface anything through the JS API that reports whether a node is in observer state or not (i.e. because of LDM or because of `js_cluster_migrate`). In part this is because nodes don't currently track whether other nodes in the group are observers or not.

This branch adds a new proposal type to the Raft layer to signal when a node enters or leaves observer mode. We then use this to bubble up the observer state through the stream and consumer state, which the CLI can use to render the state. This should make it possible to debug whether a clustered asset is leaderless and/or not voting because all of the nodes are observers.

**This PR has a one or two things to clean up before merge** — namely we need to merge changes to nats.go first to remove the `replace` from `go.mod`, the JS API schema and CLI also need changes for this too.

Signed-off-by: Neil Twigg <neil@nats.io>