### PR TITLE
Fix `TestNoRaceJetStreamStreamInfoSubjectDetailsLimits` for changes in nats.go

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -4227,7 +4227,7 @@ func TestNoRaceJetStreamStreamInfoSubjectDetailsLimits(t *testing.T) {
 		  default: {
 			jetstream: true
 			users: [ {user: me, password: pwd} ]
-			limits { max_payload: 256 }
+			limits { max_payload: 512 }
 		  }
 		}
 	`, t.TempDir())))
@@ -4244,11 +4244,11 @@ func TestNoRaceJetStreamStreamInfoSubjectDetailsLimits(t *testing.T) {
 	// Make sure to flush so we process the 2nd INFO.
 	nc.Flush()
 
-	// Make sure we cannot send larger than 256 bytes.
+	// Make sure we cannot send larger than 512 bytes.
 	// But we can receive larger.
 	sub, err := nc.SubscribeSync("foo")
 	require_NoError(t, err)
-	err = nc.Publish("foo", []byte(strings.Repeat("A", 300)))
+	err = nc.Publish("foo", []byte(strings.Repeat("A", 600)))
 	require_Error(t, err, nats.ErrMaxPayload)
 	sub.Unsubscribe()
 


### PR DESCRIPTION
There are changes in recent versions of nats.go that seemingly increase the size of the stream info and cause this test to fail consistently with `norace_test.go:4259: require no error, but got: nats: maximum payload exceeded`. Fix the test to use larger limits and payloads so we are not sensitive to this when nats.go is upgraded.

Signed-off-by: Neil Twigg <neil@nats.io>