### PR TITLE
Miscellaneous JetStream benchmark improvements

### DIFF
--- a/server/jetstream_benchmark_test.go
+++ b/server/jetstream_benchmark_test.go
@@ -563,11 +563,6 @@ func BenchmarkJetStreamPublish(b *testing.B) {
 					b.Run(
 						name,
 						func(b *testing.B) {
-							// Skip short runs, benchmark gets re-executed with a larger N
-							if b.N < bc.minMessages {
-								b.ResetTimer()
-								return
-							}
 
 							subjects := make([]string, bc.numSubjects)
 							for i := 0; i < bc.numSubjects; i++ {
@@ -869,12 +864,6 @@ func BenchmarkJetStreamInterestStreamWithLimit(b *testing.B) {
 								b.Run(
 									limitDescription,
 									func(b *testing.B) {
-										// Stop timer during setup
-										b.StopTimer()
-										b.ResetTimer()
-
-										// Set size of each operation, for throughput calculation
-										b.SetBytes(messageSize)
 
 										// Print benchmark parameters
 										if verbose {
@@ -970,7 +959,6 @@ func BenchmarkJetStreamKV(b *testing.B) {
 		kvName    = "BUCKET"
 		keyPrefix = "K_"
 		seed      = 12345
-		minOps    = 1_000
 	)
 
 	runKVGet := func(b *testing.B, kv nats.KeyValue, keys []string) int {
@@ -1097,11 +1085,6 @@ func BenchmarkJetStreamKV(b *testing.B) {
 					b.Run(
 						wName,
 						func(b *testing.B) {
-							// Skip short runs, benchmark gets re-executed with a larger N
-							if b.N < minOps {
-								b.ResetTimer()
-								return
-							}
 
 							if verbose {
 								b.Logf("Running %s workload %s with %d messages", wName, bName, b.N)


### PR DESCRIPTION
 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [x] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #

### Changes proposed in this pull request:

Miscellaneous fixes and improvements to server JetStream benchmarks.
Reviewers: notice the PR is broken down in 5 commit, each one is trivial to review individually, but they can be definitely squashed before merging for easier cherry-picking.
