### PR TITLE
systemd: use SIGUSR2 for shutdown, for LDM

### DIFF
--- a/util/nats-server-hardened.service
+++ b/util/nats-server-hardened.service
@@ -9,6 +9,9 @@ ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s SIGINT $MAINPID
 User=nats
 Group=nats
+# The nats-server uses SIGUSR2 to trigger using Lame Duck Mode (LDM) shutdown
+KillSignal=SIGUSR2
+# You might want to adjust TimeoutStopSec too.
 
 # Hardening
 CapabilityBoundingSet=

--- a/util/nats-server.service
+++ b/util/nats-server.service
@@ -10,6 +10,9 @@ ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s SIGINT $MAINPID
 User=nats
 Group=nats
+# The nats-server uses SIGUSR2 to trigger using Lame Duck Mode (LDM) shutdown
+KillSignal=SIGUSR2
+# You might want to adjust TimeoutStopSec too.
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Changes proposed in this pull request:

 - tell systemd to use SIGUSR2 for shutdown, to trigger Lame Duck Mode in nats-server
