### PR TITLE
[FIX] remove extra system headers on direct gets

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3968,6 +3968,19 @@ func (c *client) setupResponseServiceImport(acc *Account, si *serviceImport, tra
 	return rsi
 }
 
+func removeStreamIdentityHeaders(hdr []byte) []byte {
+	if hdr == nil {
+		return hdr
+	}
+	if idx := bytes.Index(hdr, []byte(JSHeaderPrefix)); idx == -1 {
+		return hdr
+	}
+	for _, h := range []string{JSStream, JSSequence, JSTimeStamp, JSSubject} {
+		hdr = removeHeaderIfPresent(hdr, h)
+	}
+	return hdr
+}
+
 // Will remove a header if present.
 func removeHeaderIfPresent(hdr []byte, key string) []byte {
 	start := bytes.Index(hdr, []byte(key))


### PR DESCRIPTION
[FIX] direct get APIs can contain duplicate `Nats-Stream`, `Nats-Sequence`, `Nats-Time-Stamp` and `Nats-Subject` headers because it simply appends JSON bytes to existing headers. If the message was onboarded on a republish, this will contain the above system headers. Since headers are not ordered and can contain multiple values for the same header, this can break KV clients and create ambiguity on the stream that yielded the message.


 - [X] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current main (`git pull --rebase origin main`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/nats-server/blob/main/LICENSE)

Resolves #4573

### Changes proposed in this pull request:

 - remove extra `Nats-Stream`, `Nats-Sequence`, `Nats-Time-Stamp` and `Nats-Subject`  that may be present on the stream message when using direct get apis
