### PR TITLE
Reduce allocations in WebSockets

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -346,23 +346,20 @@ func nbPoolGet(sz int) []byte {
 	}
 }
 
-func nbPoolPut(in []byte) {
-	ca := cap(in)
-	for in = in[:ca]; ca >= nbPoolSizeSmall; ca = cap(in) {
-		switch {
-		case ca >= nbPoolSizeLarge:
-			b := (*[nbPoolSizeLarge]byte)(in[0:nbPoolSizeLarge:nbPoolSizeLarge])
-			nbPoolLarge.Put(b)
-			in = in[nbPoolSizeLarge:]
-		case ca >= nbPoolSizeMedium:
-			b := (*[nbPoolSizeMedium]byte)(in[0:nbPoolSizeMedium:nbPoolSizeMedium])
-			nbPoolMedium.Put(b)
-			in = in[nbPoolSizeMedium:]
-		case ca >= nbPoolSizeSmall:
-			b := (*[nbPoolSizeSmall]byte)(in[0:nbPoolSizeSmall:nbPoolSizeSmall])
-			nbPoolSmall.Put(b)
-			in = in[nbPoolSizeSmall:]
-		}
+func nbPoolPut(b []byte) {
+	switch cap(b) {
+	case nbPoolSizeSmall:
+		b := (*[nbPoolSizeSmall]byte)(b[0:nbPoolSizeSmall])
+		nbPoolSmall.Put(b)
+	case nbPoolSizeMedium:
+		b := (*[nbPoolSizeMedium]byte)(b[0:nbPoolSizeMedium])
+		nbPoolMedium.Put(b)
+	case nbPoolSizeLarge:
+		b := (*[nbPoolSizeLarge]byte)(b[0:nbPoolSizeLarge])
+		nbPoolLarge.Put(b)
+	default:
+		// Ignore frames that are the wrong size, this might happen
+		// with WebSocket/MQTT messages as they are framed
 	}
 }
 

--- a/server/client.go
+++ b/server/client.go
@@ -346,20 +346,23 @@ func nbPoolGet(sz int) []byte {
 	}
 }
 
-func nbPoolPut(b []byte) {
-	switch cap(b) {
-	case nbPoolSizeSmall:
-		b := (*[nbPoolSizeSmall]byte)(b[0:nbPoolSizeSmall])
-		nbPoolSmall.Put(b)
-	case nbPoolSizeMedium:
-		b := (*[nbPoolSizeMedium]byte)(b[0:nbPoolSizeMedium])
-		nbPoolMedium.Put(b)
-	case nbPoolSizeLarge:
-		b := (*[nbPoolSizeLarge]byte)(b[0:nbPoolSizeLarge])
-		nbPoolLarge.Put(b)
-	default:
-		// Ignore frames that are the wrong size, this might happen
-		// with WebSocket/MQTT messages as they are framed
+func nbPoolPut(in []byte) {
+	ca := cap(in)
+	for in = in[:ca]; ca >= nbPoolSizeSmall; ca = cap(in) {
+		switch {
+		case ca >= nbPoolSizeLarge:
+			b := (*[nbPoolSizeLarge]byte)(in[0:nbPoolSizeLarge:nbPoolSizeLarge])
+			nbPoolLarge.Put(b)
+			in = in[nbPoolSizeLarge:]
+		case ca >= nbPoolSizeMedium:
+			b := (*[nbPoolSizeMedium]byte)(in[0:nbPoolSizeMedium:nbPoolSizeMedium])
+			nbPoolMedium.Put(b)
+			in = in[nbPoolSizeMedium:]
+		case ca >= nbPoolSizeSmall:
+			b := (*[nbPoolSizeSmall]byte)(in[0:nbPoolSizeSmall:nbPoolSizeSmall])
+			nbPoolSmall.Put(b)
+			in = in[nbPoolSizeSmall:]
+		}
 	}
 }
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1340,7 +1340,9 @@ func (c *client) wsCollapsePtoNB() (net.Buffers, int64) {
 			if mask {
 				wsMaskBuf(key, p)
 			}
-			bufs = append(bufs, h, p)
+			if ol > 0 {
+				bufs = append(bufs, h, p)
+			}
 			csz = len(h) + ol
 		}
 		// Add to pb the compressed data size (including headers), but

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1345,6 +1345,11 @@ func (c *client) wsCollapsePtoNB() (net.Buffers, int64) {
 			}
 			csz = len(h) + ol
 		}
+		// Make sure that the compressor no longer holds a reference to
+		// the bytes.Buffer, so that the underlying memory gets cleaned
+		// up after flushOutbound/flushAndClose. For this to be safe, we
+		// always cp.Reset(...) before reusing the compressor again.
+		cp.Reset(nil)
 		// Add to pb the compressed data size (including headers), but
 		// remove the original uncompressed data size that was added
 		// during the queueing.


### PR DESCRIPTION
This PR primarily does two things:

1. ~~Updates the buffer pool to allow reclaiming buffers that have been grown beyond their original capacity by slicing them up into capacities we can make use of~~ (reverted for now);
2. Updates the WebSocket code to remove extra copies, instead drawing straight from the compression buffer, which is reset on each call.

With `nats bench ... --pub=1 --sub=3 --msgs=100000 --size=1024` over non-TLS WebSockets, we have gone from:
* `174,688 msgs/sec ~ 170.59 MB/sec` up to `834,240 msgs/sec ~ 814.69 MB/sec`
* 40GB of `wsCollapsePtoNB` allocations down to 10MB
* 13GB of `flate.NewWriter` allocations down to 3.63MB

Signed-off-by: Neil Twigg <neil@nats.io>