### PR TITLE
Skip processing consumer assignments after JS has shutdown

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1593,6 +1593,10 @@ func (o *consumer) deleteNotActive() {
 				defer ticker.Stop()
 				for range ticker.C {
 					js.mu.RLock()
+					if js.shuttingDown {
+						js.mu.RUnlock()
+						return
+					}
 					nca := js.consumerAssignment(acc, stream, name)
 					js.mu.RUnlock()
 					// Make sure this is not a new consumer with the same name.


### PR DESCRIPTION
This avoids following events happening after calling lame duck shutdown: 

```
[20] 2023/10/04 18:49:58.456838 [INF] JetStream Shutdown
...
[20] 2023/10/04 18:50:02.252947 [WRN] Consumer assignment for 'js > testStream:30 > P3xF2q4d00pYr4ACgNBf9F' not cleaned up, retrying
```

```
[21] 2023/10/01 04:42:23.552141 [INF] Initiating JetStream Shutdown...
[21] 2023/10/01 04:42:23.557252 [WRN] Consumer create failed, could not locate stream 'js > test:0 > A-0-1'
[21] 2023/10/01 04:42:23.557273 [WRN] Consumer create failed, could not locate stream 'js > test:0 > A-0-2'
[21] 2023/10/01 04:42:23.557278 [WRN] Consumer create failed, could not locate stream 'js > test:0 > A-0-3'
```