### PR TITLE
[FIXED] Setting initial min on dmap caused subtle bugs with dmap. 

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -8736,10 +8736,10 @@ func TestNoRaceBinaryStreamSnapshotEncodingBasic(t *testing.T) {
 	ss, err := DecodeStreamState(snap)
 	require_NoError(t, err)
 
-	require_True(t, ss.FirstSeq == 1)
-	require_True(t, ss.LastSeq == 3000)
-	require_True(t, ss.Msgs == 1000)
-	require_True(t, ss.Deleted.NumDeleted() == 2000)
+	require_Equal(t, ss.FirstSeq, 1)
+	require_Equal(t, ss.LastSeq, 3000)
+	require_Equal(t, ss.Msgs, 1000)
+	require_Equal(t, ss.Deleted.NumDeleted(), 2000)
 }
 
 func TestNoRaceFilestoreBinaryStreamSnapshotEncodingLargeGaps(t *testing.T) {


### PR DESCRIPTION
Under heavy load with max msgs per subject of 1 the dmap, when considered empty and resetting the initial min, could cause lookup misses that would lead to excess messages in a stream and longer restore issues.

Signed-off-by: Derek Collison <derek@nats.io>
