### PR TITLE
Fixed a crash in MQTT outgoing PUBREL

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -2891,10 +2891,11 @@ func (sess *mqttSession) trackAsPubRel(pi uint16, jsAckSubject string) {
 
 	sseq, _, _ := ackReplyInfo(jsAckSubject)
 
-	var sseqToPi map[uint64]uint16
 	if sess.cpending == nil {
 		sess.cpending = make(map[string]map[uint64]uint16)
-	} else if sseqToPi = sess.cpending[jsDur]; sseqToPi == nil {
+	}
+	sseqToPi := sess.cpending[jsDur]
+	if sseqToPi == nil {
 		sseqToPi = make(map[uint64]uint16)
 		sess.cpending[jsDur] = sseqToPi
 	}


### PR DESCRIPTION
This really was a cut/paste/typo error, the `else` should not have been there. Came up in my testing.

The effect was that when there was a pending `PUBREL` in JetStream, and a matching client connects - we would sometimes attempt to deliver the PUBREL immediately once connected. `cpending` was already initialized, but the pubrel map was not (yet).