### PR TITLE
Fix updating a non unique consumer on workqueue stream not returning an error

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -5266,9 +5266,13 @@ func (mset *stream) Store() StreamStore {
 
 // Determines if the new proposed partition is unique amongst all consumers.
 // Lock should be held.
-func (mset *stream) partitionUnique(partitions []string) bool {
+func (mset *stream) partitionUnique(name string, partitions []string) bool {
 	for _, partition := range partitions {
-		for _, o := range mset.consumers {
+		for n, o := range mset.consumers {
+			// Skip the consumer being checked.
+			if n == name {
+				continue
+			}
 			if o.subjf == nil {
 				return false
 			}


### PR DESCRIPTION
This is a possible fix for #4653.

Changes made:
1. Added tests for creating and updating consumers on a work queue stream with overlapping subjects.
2. Check for overlapping subjects before [updating](https://github.com/nats-io/nats-server/blob/a25af02c7348d1e39cce66a5c275e1740fb0ca81/server/consumer.go#L770) the consumer config.
3. Changed [`func (*stream).partitionUnique(partitions []string) bool`](https://github.com/nats-io/nats-server/blob/a25af02c7348d1e39cce66a5c275e1740fb0ca81/server/stream.go#L5269) to accept the consumer name being checked so we can skip it while checking for overlapping subjects (Required for [`FilterSubjects`](https://github.com/nats-io/nats-server/blob/a25af02c7348d1e39cce66a5c275e1740fb0ca81/server/consumer.go#L75) updates), wasn't needed before because the checks were made on creation only. 

There's only 1 thing that I'm not sure about.

In the [current work queue stream conflict checks](https://github.com/nats-io/nats-server/blob/a25af02c7348d1e39cce66a5c275e1740fb0ca81/server/consumer.go#L796), the consumer config `Direct` is being checked if `false`, should we also make this check before the update?

Signed-off-by: Pierre Mdawar <pierre@mdawar.dev>
