### PR TITLE
Record details about the asset a particular raft stream belongs to

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2016,7 +2016,7 @@ func (js *jetStream) createRaftGroup(accName string, rg *raftGroup, storage Stor
 	if storage == FileStorage {
 		fs, err := newFileStoreWithCreated(
 			FileStoreConfig{StoreDir: storeDir, BlockSize: defaultMediumBlockSize, AsyncFlush: false, SyncInterval: 5 * time.Minute, srv: s},
-			StreamConfig{Name: rg.Name, Storage: FileStorage},
+			StreamConfig{Name: rg.Name, Storage: FileStorage, Metadata: labels},
 			time.Now().UTC(),
 			s.jsKeyGen(s.getOpts().JetStreamKey, rg.Name),
 			s.jsKeyGen(s.getOpts().JetStreamOldKey, rg.Name),


### PR DESCRIPTION
I often encounter sisutation where one of the Raft streams are growing out of control or streams that just wont recover correctly, being able to walk backward from these streams back to their managed asset will help a lot with debugging activities

Signed-off-by: R.I.Pienaar <rip@devco.net>
