### PR TITLE
systemd service files: use correct special target

### DIFF
--- a/util/nats-server-hardened.service
+++ b/util/nats-server-hardened.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=NATS Server
-After=network.target ntp.service
+After=network-online.target ntp.service
 
 [Service]
 Type=simple

--- a/util/nats-server.service
+++ b/util/nats-server.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=NATS Server
-After=network.target ntp.service
+After=network-online.target ntp.service
 
 [Service]
 PrivateTmp=true


### PR DESCRIPTION
Per systemd.special(7) and
<https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/> the target we want for ordering starting up the nats server is `network-online`, not `network`.

We want to be able to listen for incoming connections, and possibly connect outwards for setting up routes or connecting to external account resolvers.

Without this change, nats server start-up is subject to system-dependent race-conditions for working networking.

Signed-off-by: Phil Pennock <pdp@nats.io>
