### PR TITLE
[CHANGED] MQTT no longer requires server name to be set

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -197,6 +197,7 @@ var (
 	errMQTTTopicFilterCannotBeEmpty = errors.New("topic filter cannot be empty")
 	errMQTTMalformedVarInt          = errors.New("malformed variable int")
 	errMQTTSecondConnectPacket      = errors.New("received a second CONNECT packet")
+	errMQTTServerNameMustBeSet      = errors.New("mqtt requires server name to be explicitly set")
 	errMQTTUserMixWithUsersNKeys    = errors.New("mqtt authentication username not compatible with presence of users/nkeys")
 	errMQTTTokenMixWIthUsersNKeys   = errors.New("mqtt authentication token not compatible with presence of users/nkeys")
 	errMQTTAckWaitMustBePositive    = errors.New("ack wait must be a positive value")
@@ -596,6 +597,11 @@ func validateMQTTOptions(o *Options) error {
 	// If no port is defined, we don't care about other options
 	if mo.Port == 0 {
 		return nil
+	}
+	// We have to force the server name to be explicitly set and be unique when
+	// in cluster mode.
+	if o.ServerName == _EMPTY_ && o.Cluster.Port != 0 {
+		return errMQTTServerNameMustBeSet
 	}
 	// If there is a NoAuthUser, we need to have Users defined and
 	// the user to be present.

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -197,7 +197,6 @@ var (
 	errMQTTTopicFilterCannotBeEmpty = errors.New("topic filter cannot be empty")
 	errMQTTMalformedVarInt          = errors.New("malformed variable int")
 	errMQTTSecondConnectPacket      = errors.New("received a second CONNECT packet")
-	errMQTTServerNameMustBeSet      = errors.New("mqtt requires server name to be explicitly set")
 	errMQTTUserMixWithUsersNKeys    = errors.New("mqtt authentication username not compatible with presence of users/nkeys")
 	errMQTTTokenMixWIthUsersNKeys   = errors.New("mqtt authentication token not compatible with presence of users/nkeys")
 	errMQTTAckWaitMustBePositive    = errors.New("ack wait must be a positive value")
@@ -597,11 +596,6 @@ func validateMQTTOptions(o *Options) error {
 	// If no port is defined, we don't care about other options
 	if mo.Port == 0 {
 		return nil
-	}
-	// We have to force the server name to be explicitly set. There are conditions
-	// where we need a unique, repeatable name.
-	if o.ServerName == _EMPTY_ {
-		return errMQTTServerNameMustBeSet
 	}
 	// If there is a NoAuthUser, we need to have Users defined and
 	// the user to be present.

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -600,7 +600,7 @@ func validateMQTTOptions(o *Options) error {
 	}
 	// We have to force the server name to be explicitly set and be unique when
 	// in cluster mode.
-	if o.ServerName == _EMPTY_ && o.Cluster.Port != 0 {
+	if o.ServerName == _EMPTY_ && (o.Cluster.Port != 0 || o.Gateway.Port != 0) {
 		return errMQTTServerNameMustBeSet
 	}
 	// If there is a NoAuthUser, we need to have Users defined and

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -373,6 +373,37 @@ func testMQTTDefaultTLSOptions(t *testing.T, verify bool) *Options {
 	return o
 }
 
+func TestMQTTServerNameRequired(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		cluster {
+			port: -1
+		}
+		mqtt {
+			port: -1
+		}
+	`))
+	o, err := ProcessConfigFile(conf)
+	if err != nil {
+		t.Fatalf("Error processing config file: %v", err)
+	}
+	if _, err := NewServer(o); err == nil || err.Error() != errMQTTServerNameMustBeSet.Error() {
+		t.Fatalf("Expected error about requiring server name to be set, got %v %v", err, o.Cluster.Port)
+	}
+
+	conf = createConfFile(t, []byte(`
+		mqtt {
+			port: -1
+		}
+	`))
+	o, err = ProcessConfigFile(conf)
+	if err != nil {
+		t.Fatalf("Error processing config file: %v", err)
+	}
+	if _, err := NewServer(o); err == nil || err.Error() != errMQTTStandaloneNeedsJetStream.Error() {
+		t.Fatalf(`Expected errMQTTStandaloneNeedsJetStream ("next in line"), got %v`, err)
+	}
+}
+
 func TestMQTTStandaloneRequiresJetStream(t *testing.T) {
 	conf := createConfFile(t, []byte(`
 		server_name: mqtt

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -387,7 +387,7 @@ func TestMQTTServerNameRequired(t *testing.T) {
 		t.Fatalf("Error processing config file: %v", err)
 	}
 	if _, err := NewServer(o); err == nil || err.Error() != errMQTTServerNameMustBeSet.Error() {
-		t.Fatalf("Expected error about requiring server name to be set, got %v %v", err, o.Cluster.Port)
+		t.Fatalf("Expected error about requiring server name to be set, got %v", err)
 	}
 
 	conf = createConfFile(t, []byte(`

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -373,21 +373,6 @@ func testMQTTDefaultTLSOptions(t *testing.T, verify bool) *Options {
 	return o
 }
 
-func TestMQTTServerNameRequired(t *testing.T) {
-	conf := createConfFile(t, []byte(`
-		mqtt {
-			port: -1
-		}
-	`))
-	o, err := ProcessConfigFile(conf)
-	if err != nil {
-		t.Fatalf("Error processing config file: %v", err)
-	}
-	if _, err := NewServer(o); err == nil || err.Error() != errMQTTServerNameMustBeSet.Error() {
-		t.Fatalf("Expected error about requiring server name to be set, got %v", err)
-	}
-}
-
 func TestMQTTStandaloneRequiresJetStream(t *testing.T) {
 	conf := createConfFile(t, []byte(`
 		server_name: mqtt


### PR DESCRIPTION
It was required because it was required by JetStream, but JetStream now auto-generates a default name.