### PR TITLE
Raft state machine tweaks

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -1499,11 +1499,13 @@ func (n *raft) Delete() {
 }
 
 func (n *raft) shutdown(shouldDelete bool) {
-	if n.State() == Closed {
+	// Needs to be a Swap operation in order to prevent races if
+	// more than one caller hits shutdown() at once, the returned
+	// value will be the previous state.
+	if n.state.Swap(int32(Closed)) == int32(Closed) {
 		return
 	}
 
-	n.state.Store(int32(Closed))
 	n.Lock()
 
 	close(n.quit)

--- a/server/raft.go
+++ b/server/raft.go
@@ -651,12 +651,11 @@ func (s *Server) transferRaftLeaders() bool {
 // Propose will propose a new entry to the group.
 // This should only be called on the leader.
 func (n *raft) Propose(data []byte) error {
-	n.RLock()
 	if state := n.State(); state != Leader {
-		n.RUnlock()
 		n.debug("Proposal ignored, not leader (state: %v)", state)
 		return errNotLeader
 	}
+	n.RLock()
 	// Error if we had a previous write error.
 	if werr := n.werr; werr != nil {
 		n.RUnlock()
@@ -672,12 +671,11 @@ func (n *raft) Propose(data []byte) error {
 // ProposeDirect will propose entries directly.
 // This should only be called on the leader.
 func (n *raft) ProposeDirect(entries []*Entry) error {
-	n.RLock()
 	if state := n.State(); state != Leader {
-		n.RUnlock()
 		n.debug("Direct proposal ignored, not leader (state: %v)", state)
 		return errNotLeader
 	}
+	n.RLock()
 	// Error if we had a previous write error.
 	if werr := n.werr; werr != nil {
 		n.RUnlock()
@@ -704,11 +702,10 @@ func (n *raft) ForwardProposal(entry []byte) error {
 
 // ProposeAddPeer is called to add a peer to the group.
 func (n *raft) ProposeAddPeer(peer string) error {
-	n.RLock()
 	if n.State() != Leader {
-		n.RUnlock()
 		return errNotLeader
 	}
+	n.RLock()
 	// Error if we had a previous write error.
 	if werr := n.werr; werr != nil {
 		n.RUnlock()
@@ -792,11 +789,10 @@ func (n *raft) AdjustBootClusterSize(csz int) error {
 // AdjustClusterSize will change the cluster set size.
 // Must be the leader.
 func (n *raft) AdjustClusterSize(csz int) error {
-	n.Lock()
 	if n.State() != Leader {
-		n.Unlock()
 		return errNotLeader
 	}
+	n.Lock()
 	// Same floor as bootstrap.
 	if csz < 2 {
 		csz = 2
@@ -814,12 +810,13 @@ func (n *raft) AdjustClusterSize(csz int) error {
 // PauseApply will allow us to pause processing of append entries onto our
 // external apply chan.
 func (n *raft) PauseApply() error {
-	n.Lock()
-	defer n.Unlock()
-
 	if n.State() == Leader {
 		return errAlreadyLeader
 	}
+
+	n.Lock()
+	defer n.Unlock()
+
 	// If we are currently a candidate make sure we step down.
 	if n.State() == Candidate {
 		n.stepdown.push(noLeader)
@@ -942,11 +939,11 @@ func (n *raft) SendSnapshot(data []byte) error {
 // all of the log entries up to and including index. This should not be called with
 // entries that have been applied to the FSM but have not been applied to the raft state.
 func (n *raft) InstallSnapshot(data []byte) error {
-	n.Lock()
 	if n.State() == Closed {
-		n.Unlock()
 		return errNodeClosed
 	}
+
+	n.Lock()
 
 	if werr := n.werr; werr != nil {
 		n.Unlock()
@@ -1502,11 +1499,12 @@ func (n *raft) Delete() {
 }
 
 func (n *raft) shutdown(shouldDelete bool) {
-	n.Lock()
 	if n.State() == Closed {
-		n.Unlock()
 		return
 	}
+
+	n.state.Store(int32(Closed))
+	n.Lock()
 
 	close(n.quit)
 	if c := n.c; c != nil {
@@ -1521,7 +1519,6 @@ func (n *raft) shutdown(shouldDelete bool) {
 		}
 		c.closeConnection(InternalClient)
 	}
-	n.state.Store(int32(Closed))
 	s, g, wal := n.s, n.group, n.wal
 
 	// Delete our peer state and vote state and any snapshots.
@@ -2152,11 +2149,11 @@ func (n *raft) handleForwardedProposal(sub *subscription, c *client, _ *Account,
 }
 
 func (n *raft) runAsLeader() {
-	n.RLock()
 	if n.State() == Closed {
-		n.RUnlock()
 		return
 	}
+
+	n.RLock()
 	psubj, rpsubj := n.psubj, n.rpsubj
 	n.RUnlock()
 
@@ -2670,11 +2667,11 @@ func (n *raft) applyCommit(index uint64) error {
 
 // Used to track a success response and apply entries.
 func (n *raft) trackResponse(ar *appendEntryResponse) {
-	n.Lock()
 	if n.State() == Closed {
-		n.Unlock()
 		return
 	}
+
+	n.Lock()
 
 	// Update peer's last index.
 	if ps := n.peers[ar.peer]; ps != nil && ar.index > ps.li {
@@ -3594,8 +3591,6 @@ func (n *raft) setWriteErrLocked(err error) {
 
 // Helper to check if we are closed when we do not hold a lock already.
 func (n *raft) isClosed() bool {
-	n.RLock()
-	defer n.RUnlock()
 	return n.State() == Closed
 }
 
@@ -3872,11 +3867,13 @@ const (
 )
 
 func (n *raft) switchToFollower(leader string) {
-	n.Lock()
-	defer n.Unlock()
 	if n.State() == Closed {
 		return
 	}
+
+	n.Lock()
+	defer n.Unlock()
+
 	n.debug("Switching to follower")
 
 	n.lxfer = false
@@ -3885,11 +3882,13 @@ func (n *raft) switchToFollower(leader string) {
 }
 
 func (n *raft) switchToCandidate() {
-	n.Lock()
-	defer n.Unlock()
 	if n.State() == Closed {
 		return
 	}
+
+	n.Lock()
+	defer n.Unlock()
+
 	// If we are catching up or are in observer mode we can not switch.
 	if n.observer || n.paused {
 		return
@@ -3912,11 +3911,12 @@ func (n *raft) switchToCandidate() {
 }
 
 func (n *raft) switchToLeader() {
-	n.Lock()
 	if n.State() == Closed {
-		n.Unlock()
 		return
 	}
+
+	n.Lock()
+
 	n.debug("Switching to leader")
 
 	var state StreamState

--- a/server/raft.go
+++ b/server/raft.go
@@ -2951,6 +2951,7 @@ func (n *raft) updateLeader(newLeader string) {
 	if !n.pleader && newLeader != noLeader {
 		n.pleader = true
 	}
+	n.isLeader.Store(newLeader == n.id)
 }
 
 // processAppendEntry will process an appendEntry.

--- a/server/raft.go
+++ b/server/raft.go
@@ -133,8 +133,7 @@ type raft struct {
 	wtype    StorageType
 	track    bool
 	werr     error
-	state    RaftState
-	isLeader atomic.Bool
+	state    atomic.Int32 // RaftState
 	hh       hash.Hash64
 	snapfile string
 	csz      int
@@ -382,7 +381,6 @@ func (s *Server) startRaftNode(accName string, cfg *RaftConfig, labels pprofLabe
 		wal:      cfg.Log,
 		wtype:    cfg.Log.Type(),
 		track:    cfg.Track,
-		state:    Follower,
 		csz:      ps.clusterSize,
 		qn:       ps.clusterSize/2 + 1,
 		hash:     hash,
@@ -654,7 +652,7 @@ func (s *Server) transferRaftLeaders() bool {
 // This should only be called on the leader.
 func (n *raft) Propose(data []byte) error {
 	n.RLock()
-	if state := n.state; state != Leader {
+	if state := n.State(); state != Leader {
 		n.RUnlock()
 		n.debug("Proposal ignored, not leader (state: %v)", state)
 		return errNotLeader
@@ -675,9 +673,9 @@ func (n *raft) Propose(data []byte) error {
 // This should only be called on the leader.
 func (n *raft) ProposeDirect(entries []*Entry) error {
 	n.RLock()
-	if n.state != Leader {
+	if state := n.State(); state != Leader {
 		n.RUnlock()
-		n.debug("Direct proposal ignored, not leader (state: %v)", n.state)
+		n.debug("Direct proposal ignored, not leader (state: %v)", state)
 		return errNotLeader
 	}
 	// Error if we had a previous write error.
@@ -707,7 +705,7 @@ func (n *raft) ForwardProposal(entry []byte) error {
 // ProposeAddPeer is called to add a peer to the group.
 func (n *raft) ProposeAddPeer(peer string) error {
 	n.RLock()
-	if n.state != Leader {
+	if n.State() != Leader {
 		n.RUnlock()
 		return errNotLeader
 	}
@@ -742,7 +740,7 @@ func (n *raft) doRemovePeerAsLeader(peer string) {
 func (n *raft) ProposeRemovePeer(peer string) error {
 	n.RLock()
 	prop, subj := n.prop, n.rpsubj
-	isLeader := n.state == Leader
+	isLeader := n.State() == Leader
 	werr := n.werr
 	n.RUnlock()
 
@@ -795,7 +793,7 @@ func (n *raft) AdjustBootClusterSize(csz int) error {
 // Must be the leader.
 func (n *raft) AdjustClusterSize(csz int) error {
 	n.Lock()
-	if n.state != Leader {
+	if n.State() != Leader {
 		n.Unlock()
 		return errNotLeader
 	}
@@ -819,11 +817,11 @@ func (n *raft) PauseApply() error {
 	n.Lock()
 	defer n.Unlock()
 
-	if n.state == Leader {
+	if n.State() == Leader {
 		return errAlreadyLeader
 	}
 	// If we are currently a candidate make sure we step down.
-	if n.state == Candidate {
+	if n.State() == Candidate {
 		n.stepdown.push(noLeader)
 	}
 
@@ -945,7 +943,7 @@ func (n *raft) SendSnapshot(data []byte) error {
 // entries that have been applied to the FSM but have not been applied to the raft state.
 func (n *raft) InstallSnapshot(data []byte) error {
 	n.Lock()
-	if n.state == Closed {
+	if n.State() == Closed {
 		n.Unlock()
 		return errNodeClosed
 	}
@@ -1164,7 +1162,7 @@ func (n *raft) Leader() bool {
 	if n == nil {
 		return false
 	}
-	return n.isLeader.Load()
+	return n.State() == Leader
 }
 
 func (n *raft) isCatchingUp() bool {
@@ -1178,7 +1176,7 @@ func (n *raft) isCatchingUp() bool {
 // Lock should be held.
 func (n *raft) isCurrent(includeForwardProgress bool) bool {
 	// Check if we are closed.
-	if n.state == Closed {
+	if n.State() == Closed {
 		n.debug("Not current, node is closed")
 		return false
 	}
@@ -1190,7 +1188,7 @@ func (n *raft) isCurrent(includeForwardProgress bool) bool {
 	}
 
 	// Make sure we are the leader or we know we have heard from the leader recently.
-	if n.state == Leader {
+	if n.State() == Leader {
 		return true
 	}
 
@@ -1300,7 +1298,7 @@ func (n *raft) StepDown(preferred ...string) error {
 		return errTooManyPrefs
 	}
 
-	if n.state != Leader {
+	if n.State() != Leader {
 		n.Unlock()
 		return errNotLeader
 	}
@@ -1394,7 +1392,7 @@ func randCampaignTimeout() time.Duration {
 // Lock should be held.
 func (n *raft) campaign() error {
 	n.debug("Starting campaign")
-	if n.state == Leader {
+	if n.State() == Leader {
 		return errAlreadyLeader
 	}
 	n.resetElect(randCampaignTimeout())
@@ -1405,7 +1403,7 @@ func (n *raft) campaign() error {
 // Lock should be held.
 func (n *raft) xferCampaign() error {
 	n.debug("Starting transfer campaign")
-	if n.state == Leader {
+	if n.State() == Leader {
 		n.lxfer = false
 		return errAlreadyLeader
 	}
@@ -1415,9 +1413,7 @@ func (n *raft) xferCampaign() error {
 
 // State returns the current state for this node.
 func (n *raft) State() RaftState {
-	n.RLock()
-	defer n.RUnlock()
-	return n.state
+	return RaftState(n.state.Load())
 }
 
 // Progress returns the current index, commit and applied values.
@@ -1478,7 +1474,7 @@ func (n *raft) UpdateKnownPeers(knownPeers []string) {
 	// Process like peer state update.
 	ps := &peerState{knownPeers, len(knownPeers), n.extSt}
 	n.processPeerState(ps)
-	isLeader := n.state == Leader
+	isLeader := n.State() == Leader
 	n.Unlock()
 
 	// If we are the leader send this update out as well.
@@ -1507,7 +1503,7 @@ func (n *raft) Delete() {
 
 func (n *raft) shutdown(shouldDelete bool) {
 	n.Lock()
-	if n.state == Closed {
+	if n.State() == Closed {
 		n.Unlock()
 		return
 	}
@@ -1525,7 +1521,7 @@ func (n *raft) shutdown(shouldDelete bool) {
 		}
 		c.closeConnection(InternalClient)
 	}
-	n.state = Closed
+	n.state.Store(int32(Closed))
 	s, g, wal := n.s, n.group, n.wal
 
 	// Delete our peer state and vote state and any snapshots.
@@ -1788,7 +1784,7 @@ func (n *raft) processAppendEntries() {
 }
 
 func (n *raft) runAsFollower() {
-	for {
+	for n.State() == Follower {
 		elect := n.electTimer()
 
 		select {
@@ -2157,7 +2153,7 @@ func (n *raft) handleForwardedProposal(sub *subscription, c *client, _ *Account,
 
 func (n *raft) runAsLeader() {
 	n.RLock()
-	if n.state == Closed {
+	if n.State() == Closed {
 		n.RUnlock()
 		return
 	}
@@ -2193,7 +2189,7 @@ func (n *raft) runAsLeader() {
 	lq := time.NewTicker(lostQuorumCheck)
 	defer lq.Stop()
 
-	for {
+	for n.State() == Leader {
 		select {
 		case <-n.s.quitCh:
 			n.shutdown(false)
@@ -2541,7 +2537,7 @@ func (n *raft) loadEntry(index uint64) (*appendEntry, error) {
 // applyCommit will update our commit index and apply the entry to the apply chan.
 // lock should be held.
 func (n *raft) applyCommit(index uint64) error {
-	if n.state == Closed {
+	if n.State() == Closed {
 		return errNodeClosed
 	}
 	if index <= n.commit {
@@ -2551,7 +2547,7 @@ func (n *raft) applyCommit(index uint64) error {
 	original := n.commit
 	n.commit = index
 
-	if n.state == Leader {
+	if n.State() == Leader {
 		delete(n.acks, index)
 	}
 
@@ -2568,7 +2564,7 @@ func (n *raft) applyCommit(index uint64) error {
 		if ae, err = n.loadEntry(index); err != nil {
 			if err != ErrStoreClosed && err != ErrStoreEOF {
 				n.warn("Got an error loading %d index: %v - will reset", index, err)
-				if n.state == Leader {
+				if n.State() == Leader {
 					n.stepdown.push(n.selectNextLeader())
 				}
 				// Reset and cancel any catchup.
@@ -2596,7 +2592,7 @@ func (n *raft) applyCommit(index uint64) error {
 		case EntrySnapshot:
 			committed = append(committed, e)
 		case EntryPeerState:
-			if n.state != Leader {
+			if n.State() != Leader {
 				if ps, err := decodePeerState(e.Data); err == nil {
 					n.processPeerState(ps)
 				}
@@ -2646,7 +2642,7 @@ func (n *raft) applyCommit(index uint64) error {
 			}
 
 			// If this is us and we are the leader we should attempt to stepdown.
-			if peer == n.id && n.state == Leader {
+			if peer == n.id && n.State() == Leader {
 				n.stepdown.push(n.selectNextLeader())
 			}
 
@@ -2675,7 +2671,7 @@ func (n *raft) applyCommit(index uint64) error {
 // Used to track a success response and apply entries.
 func (n *raft) trackResponse(ar *appendEntryResponse) {
 	n.Lock()
-	if n.state == Closed {
+	if n.State() == Closed {
 		n.Unlock()
 		return
 	}
@@ -2736,7 +2732,7 @@ func (n *raft) adjustClusterSizeAndQuorum() {
 		n.lsut = time.Now()
 	} else if ncsz < pcsz {
 		n.debug("Decreasing our clustersize: %d -> %d", pcsz, ncsz)
-		if n.state == Leader {
+		if n.State() == Leader {
 			go n.sendHeartbeat()
 		}
 	}
@@ -2749,7 +2745,7 @@ func (n *raft) trackPeer(peer string) error {
 	if n.removed != nil {
 		_, isRemoved = n.removed[peer]
 	}
-	if n.state == Leader {
+	if n.State() == Leader {
 		if lp, ok := n.peers[peer]; !ok || !lp.kp {
 			// Check if this peer had been removed previously.
 			needPeerAdd = !isRemoved
@@ -2780,7 +2776,7 @@ func (n *raft) runAsCandidate() {
 	// We vote for ourselves.
 	votes := 1
 
-	for {
+	for n.State() == Candidate {
 		elect := n.electTimer()
 		select {
 		case <-n.entry.ch:
@@ -2951,7 +2947,6 @@ func (n *raft) updateLeader(newLeader string) {
 	if !n.pleader && newLeader != noLeader {
 		n.pleader = true
 	}
-	n.isLeader.Store(newLeader == n.id)
 }
 
 // processAppendEntry will process an appendEntry.
@@ -2963,7 +2958,7 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 	}
 
 	// Just return if closed or we had previous write error.
-	if n.state == Closed || n.werr != nil {
+	if n.State() == Closed || n.werr != nil {
 		n.Unlock()
 		return
 	}
@@ -2973,7 +2968,7 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 	arbuf := scratch[:]
 
 	// Are we receiving from another leader.
-	if n.state == Leader {
+	if n.State() == Leader {
 		// If we are the same we should step down to break the tie.
 		if ae.term >= n.term {
 			n.term = ae.term
@@ -2994,7 +2989,7 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 	}
 
 	// If we received an append entry as a candidate we should convert to a follower.
-	if n.state == Candidate {
+	if n.State() == Candidate {
 		n.debug("Received append entry in candidate state from %q, converting to follower", ae.leader)
 		if n.term < ae.term {
 			n.term = ae.term
@@ -3060,13 +3055,13 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 		if isNew {
 			n.writeTermVote()
 		}
-		if n.state != Follower {
-			n.debug("Term higher than ours and we are not a follower: %v, stepping down to %q", n.state, ae.leader)
+		if n.State() != Follower {
+			n.debug("Term higher than ours and we are not a follower: %v, stepping down to %q", n.State(), ae.leader)
 			n.stepdown.push(ae.leader)
 		}
 	}
 
-	if isNew && n.leader != ae.leader && n.state == Follower {
+	if isNew && n.leader != ae.leader && n.State() == Follower {
 		n.debug("AppendEntry updating leader to %q", ae.leader)
 		n.updateLeader(ae.leader)
 		n.writeTermVote()
@@ -3334,7 +3329,7 @@ func (n *raft) storeToWAL(ae *appendEntry) error {
 	// Sanity checking for now.
 	if index := ae.pindex + 1; index != seq {
 		n.warn("Wrong index, ae is %+v, index stored was %d, n.pindex is %d, will reset", ae, seq, n.pindex)
-		if n.state == Leader {
+		if n.State() == Leader {
 			n.stepdown.push(n.selectNextLeader())
 		}
 		// Reset and cancel any catchup.
@@ -3565,7 +3560,7 @@ func (n *raft) readTermVote() (term uint64, voted string, err error) {
 // Lock should be held.
 func (n *raft) setWriteErrLocked(err error) {
 	// Check if we are closed already.
-	if n.state == Closed {
+	if n.State() == Closed {
 		return
 	}
 	// Ignore if already set.
@@ -3601,7 +3596,7 @@ func (n *raft) setWriteErrLocked(err error) {
 func (n *raft) isClosed() bool {
 	n.RLock()
 	defer n.RUnlock()
-	return n.state == Closed
+	return n.State() == Closed
 }
 
 // Capture our write error if any and hold.
@@ -3747,9 +3742,9 @@ func (n *raft) processVoteRequest(vr *voteRequest) error {
 
 	// If this is a higher term go ahead and stepdown.
 	if vr.term > n.term {
-		if n.state != Follower {
+		if n.State() != Follower {
 			n.debug("Stepping down from %s, detected higher term: %d vs %d",
-				strings.ToLower(n.state.String()), vr.term, n.term)
+				strings.ToLower(n.State().String()), vr.term, n.term)
 			n.stepdown.push(noLeader)
 			n.term = vr.term
 		}
@@ -3788,7 +3783,7 @@ func (n *raft) handleVoteRequest(sub *subscription, c *client, _ *Account, subje
 
 func (n *raft) requestVote() {
 	n.Lock()
-	if n.state != Candidate {
+	if n.State() != Candidate {
 		n.Unlock()
 		return
 	}
@@ -3830,9 +3825,6 @@ func (n *raft) quorumNeeded() int {
 
 // Lock should be held.
 func (n *raft) updateLeadChange(isLeader bool) {
-	// Update our atomic about being the leader.
-	n.isLeader.Store(isLeader)
-
 	// We don't care about values that have not been consumed (transitory states),
 	// so we dequeue any state that is pending and push the new one.
 	for {
@@ -3852,25 +3844,25 @@ func (n *raft) updateLeadChange(isLeader bool) {
 
 // Lock should be held.
 func (n *raft) switchState(state RaftState) {
-	if n.state == Closed {
+	if n.State() == Closed {
 		return
 	}
 
 	// Reset the election timer.
 	n.resetElectionTimeout()
 
-	if n.state == Leader && state != Leader {
+	if n.State() == Leader && state != Leader {
 		n.updateLeadChange(false)
 		// Drain the response queue.
 		n.resp.drain()
-	} else if state == Leader && n.state != Leader {
+	} else if state == Leader && n.State() != Leader {
 		if len(n.pae) > 0 {
 			n.pae = make(map[uint64]*appendEntry)
 		}
 		n.updateLeadChange(true)
 	}
 
-	n.state = state
+	n.state.Store(int32(state))
 	n.writeTermVote()
 }
 
@@ -3882,7 +3874,7 @@ const (
 func (n *raft) switchToFollower(leader string) {
 	n.Lock()
 	defer n.Unlock()
-	if n.state == Closed {
+	if n.State() == Closed {
 		return
 	}
 	n.debug("Switching to follower")
@@ -3895,7 +3887,7 @@ func (n *raft) switchToFollower(leader string) {
 func (n *raft) switchToCandidate() {
 	n.Lock()
 	defer n.Unlock()
-	if n.state == Closed {
+	if n.State() == Closed {
 		return
 	}
 	// If we are catching up or are in observer mode we can not switch.
@@ -3903,7 +3895,7 @@ func (n *raft) switchToCandidate() {
 		return
 	}
 
-	if n.state != Candidate {
+	if n.State() != Candidate {
 		n.debug("Switching to candidate")
 	} else {
 		if n.lostQuorumLocked() && time.Since(n.llqrt) > 20*time.Second {
@@ -3921,7 +3913,7 @@ func (n *raft) switchToCandidate() {
 
 func (n *raft) switchToLeader() {
 	n.Lock()
-	if n.state == Closed {
+	if n.State() == Closed {
 		n.Unlock()
 		return
 	}


### PR DESCRIPTION
This PR does the following:

1. Replaces `state` with an atomic, which can be accessed lock-free instead of needing to take the group mutex
2. Ensures that `runAsFollower`, `runAsLeader`, `runAsCandidate` can only continue running as long as the `state` is correct (they will stop looping and hand back to `run` if not)
3. Removes the `isLeader` atomic, as it is now unnecessary with the `state` atomic
4. Adds a unit test to prove that we can now recover from the situation of all nodes being forced into a leaderless follower state, which now passes with the above changes

Signed-off-by: Neil Twigg <neil@nats.io>