### PR TITLE
[IMPROVED] Routing: reduce account lookup for pinned accounts

### DIFF
--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -831,7 +831,10 @@ func TestMaxControlLine(t *testing.T) {
 				c.setNoReconnect()
 				c.flags.set(connectReceived)
 				c.kind = test.kind
-				if test.kind == GATEWAY {
+				switch test.kind {
+				case ROUTER:
+					c.route = &route{}
+				case GATEWAY:
 					c.gw = &gateway{outbound: false, connected: true, insim: make(map[string]*insie)}
 				}
 				c.mcl = 8

--- a/server/route.go
+++ b/server/route.go
@@ -1860,6 +1860,17 @@ const (
 func (s *Server) addRoute(c *client, didSolicit bool, info *Info, accName string) bool {
 	id := info.ID
 
+	var acc *Account
+	if accName != _EMPTY_ {
+		var err error
+		acc, err = s.LookupAccount(accName)
+		if err != nil {
+			c.sendErrAndErr(fmt.Sprintf("Unable to lookup account %q: %v", accName, err))
+			c.closeConnection(MissingAccount)
+			return false
+		}
+	}
+
 	s.mu.Lock()
 	if !s.isRunning() || s.routesReject {
 		s.mu.Unlock()
@@ -1934,6 +1945,9 @@ func (s *Server) addRoute(c *client, didSolicit bool, info *Info, accName string
 			cid := c.cid
 			if c.last.IsZero() {
 				c.last = time.Now()
+			}
+			if acc != nil {
+				c.acc = acc
 			}
 			c.mu.Unlock()
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1858,6 +1858,10 @@ func TestRoutePoolAndPerAccountErrors(t *testing.T) {
 
 	conf1 := createConfFile(t, []byte(`
 		port: -1
+		accounts {
+			abc { users: [{user:abc, password: pwd}] }
+			def { users: [{user:def, password: pwd}] }
+		}
 		cluster {
 			port: -1
 			name: "local"
@@ -1872,6 +1876,10 @@ func TestRoutePoolAndPerAccountErrors(t *testing.T) {
 
 	conf2 := createConfFile(t, []byte(fmt.Sprintf(`
 		port: -1
+		accounts {
+			abc { users: [{user:abc, password: pwd}] }
+			def { users: [{user:def, password: pwd}] }
+		}
 		cluster {
 			port: -1
 			name: "local"


### PR DESCRIPTION
Small optimization that bypass lookup of account for a pinned account's route since the account is known for this route. The lookup would occur for every inbound message whose exact destination was not found in the cache.
Also, since configuration reload no long swaps account's sublist, we can do without the account's locking to get the sublist pointer.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>