### PR TITLE
Ensure Windows signal handler is stopped when shutting down via other means

### DIFF
--- a/server/signal_windows.go
+++ b/server/signal_windows.go
@@ -34,10 +34,15 @@ func (s *Server) handleSignals() {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
-		for sig := range c {
-			s.Debugf("Trapped %q signal", sig)
-			s.Shutdown()
-			os.Exit(0)
+		for {
+			select {
+			case sig := <-c:
+				s.Debugf("Trapped %q signal", sig)
+				s.Shutdown()
+				os.Exit(0)
+			case <-s.quitCh:
+				return
+			}
 		}
 	}()
 }


### PR DESCRIPTION
We weren't monitoring `quitCh` on Windows so we could leak goroutines if it wasn't a signal that caused us to shut down.

Signed-off-by: Neil Twigg <neil@nats.io>