### PR TITLE
Extend the term advisory with a reason

### DIFF
--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -134,6 +134,7 @@ type JSConsumerDeliveryTerminatedAdvisory struct {
 	ConsumerSeq uint64 `json:"consumer_seq"`
 	StreamSeq   uint64 `json:"stream_seq"`
 	Deliveries  uint64 `json:"deliveries"`
+	Reason      string `json:"reason,omitempty"`
 	Domain      string `json:"domain,omitempty"`
 }
 

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -2935,7 +2935,7 @@ func TestJetStreamWorkQueueTerminateDelivery(t *testing.T) {
 			// We should get 1 back.
 			m := getMsg(1, 2)
 			// Now terminate
-			m.Respond(AckTerm)
+			m.Respond([]byte(fmt.Sprintf("%s with reason", string(AckTerm))))
 			time.Sleep(ackWait * 2)
 
 			// We should get 2 here, not 1 since we have indicated we wanted to terminate.
@@ -2962,6 +2962,9 @@ func TestJetStreamWorkQueueTerminateDelivery(t *testing.T) {
 			}
 			if adv.Deliveries != 2 {
 				t.Fatalf("Expected delivery count of %d, got %d", 2, adv.Deliveries)
+			}
+			if adv.Reason != "with reason" {
+				t.Fatalf("Advisory did not have a reason")
 			}
 		})
 	}


### PR DESCRIPTION
 * Support getting a reason from the client doing a term
 * Supply some reasons when terminating messages during limits processing

Signed-off-by: R.I.Pienaar <rip@devco.net>

