### PR TITLE
[IMPROVED] Routing: upgrade non solicited routes if present in config

### DIFF
--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -2127,6 +2127,20 @@ func TestRoutePoolConnectRace(t *testing.T) {
 		}
 	}
 
+	// Also, check that they all report as solicited and configured in monitoring.
+	for _, s := range servers {
+		routes, err := s.Routez(nil)
+		require_NoError(t, err)
+		for _, r := range routes.Routes {
+			if !r.DidSolicit {
+				t.Fatalf("All routes should have been marked as solicited, this one was not: %+v", r)
+			}
+			if !r.IsConfigured {
+				t.Fatalf("All routes should have been marked as configured, this one was not: %+v", r)
+			}
+		}
+	}
+
 	for _, s := range servers {
 		s.Shutdown()
 		s.WaitForShutdown()
@@ -2529,6 +2543,20 @@ func TestRoutePerAccountConnectRace(t *testing.T) {
 		case <-time.After(DEFAULT_ROUTE_RECONNECT + 250*time.Millisecond):
 			// More than reconnect and some, and no reconnect, so we are good.
 			done = true
+		}
+	}
+
+	// Also, check that they all report as solicited and configured in monitoring.
+	for _, s := range servers {
+		routes, err := s.Routez(nil)
+		require_NoError(t, err)
+		for _, r := range routes.Routes {
+			if !r.DidSolicit {
+				t.Fatalf("All routes should have been marked as solicited, this one was not: %+v", r)
+			}
+			if !r.IsConfigured {
+				t.Fatalf("All routes should have been marked as configured, this one was not: %+v", r)
+			}
 		}
 	}
 


### PR DESCRIPTION
When a server accepts a route, that route would not be marked as solicited or configured while it should if it was present in the configuration.

Prior to pooling, if server A pointed to server B and vice-versa, one of the server will have the route as solicited and the server that accepted the route would have upgraded it as solicited. With pooling code, this was not always happening.

Maybe related to #4681 

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>