### PR TITLE
Enable stale issue/PR workflow

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
-          debug-only: true # Set until the behavior is tuned.
+          stale-issue-label: stale
+          stale-pr-label: stale
           days-before-stale: 56 # Mark stale after 8 weeks (56 days) of inactivity
           days-before-close: -1 # Disable auto-closing
           exempt-all-milestones: true # Any issue/PR within a milestone will be omitted
-          #exempt-assigness: "foo,bar"  # Exempt issues/PRs assigned to particular users


### PR DESCRIPTION
This will mark an issue/PR as stale after 8 weeks
of complete inactivity (including comments). If/when new activity occurs, the stale label will be removed.

The purpose of this is to make it simplier for triagers to filter on stale issues to follow-up on.
