### PR TITLE
chore: Update GitHub actions

### DIFF
--- a/.github/actions/nightly-release/action.yaml
+++ b/.github/actions/nightly-release/action.yaml
@@ -31,7 +31,7 @@ runs:
         go-version: "${{ inputs.go }}"
 
     - name: goreleaser
-      uses: goreleaser/goreleaser-action@v3
+      uses: goreleaser/goreleaser-action@v5
       with:
         workdir: "${{ inputs.workdir }}"
         version: latest

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/MQTT_test.yaml
+++ b/.github/workflows/MQTT_test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: src/github.com/nats-io/nats-server
 

--- a/.github/workflows/cov.yaml
+++ b/.github/workflows/cov.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: src/github.com/nats-io/nats-server
 

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: src/github.com/nats-io/nats-server
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: src/github.com/nats-io/nats-server
           ref: ${{ inputs.target || 'main' }}

--- a/.github/workflows/rc_nightly.yaml
+++ b/.github/workflows/rc_nightly.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: src/github.com/nats-io/nats-server
-          ref: ${{ inputs.target || 'v2.9.22' }}
+          ref: ${{ inputs.target || 'v2.10.4' }}
 
       - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:


### PR DESCRIPTION
* goreleaser/goreleaser-action 3 -> 5
* actions/checkout 3 -> 4

Also bumped default tag for nightly.

Signed-off-by: Rene Leonhardt <65483435+reneleonhardt@users.noreply.github.com>
