### PR TITLE
Remove unused `Observer` const, add unit test to check observer applies

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -103,7 +103,6 @@ const (
 	Follower RaftState = iota
 	Leader
 	Candidate
-	Observer
 	Closed
 )
 
@@ -115,8 +114,6 @@ func (state RaftState) String() string {
 		return "CANDIDATE"
 	case Leader:
 		return "LEADER"
-	case Observer:
-		return "OBSERVER"
 	case Closed:
 		return "CLOSED"
 	}
@@ -1715,9 +1712,6 @@ func (n *raft) run() {
 			n.runAsCandidate()
 		case Leader:
 			n.runAsLeader()
-		case Observer:
-			// TODO(dlc) - fix.
-			n.runAsFollower()
 		case Closed:
 			return
 		}


### PR DESCRIPTION
The `Observer` raft state was actually unused and is a red herring. Instead, observer state is tracked using a separate bool.

This PR also adds a unit test that confirms that applies are still happening when followers are observers.

Signed-off-by: Neil Twigg <neil@synadia.com>
