### PR TITLE
Fix panic in JWT permissions template handling

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -525,7 +525,7 @@ func processUserPermissionsTemplate(lim jwt.UserPermissionLimits, ujwt *jwt.User
 				for _, valueList := range nArrayCartesianProduct(tagValues...) {
 					b := strings.Builder{}
 					for i, token := range newTokens {
-						if token == _EMPTY_ {
+						if token == _EMPTY_ && len(valueList) > 0 {
 							b.WriteString(valueList[0])
 							valueList = valueList[1:]
 						} else {

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -4362,6 +4362,27 @@ func TestJwtTemplates(t *testing.T) {
 	require_Contains(t, err.Error(), "generated invalid subject")
 }
 
+func TestJwtTemplateGoodTagAfterBadTag(t *testing.T) {
+	kp, _ := nkeys.CreateAccount()
+	aPub, _ := kp.PublicKey()
+	ukp, _ := nkeys.CreateUser()
+	upub, _ := ukp.PublicKey()
+	uclaim := newJWTTestUserClaims()
+	uclaim.Name = "myname"
+	uclaim.Subject = upub
+	uclaim.SetScoped(true)
+	uclaim.IssuerAccount = aPub
+	uclaim.Tags.Add("foo:foo1")
+
+	lim := jwt.UserPermissionLimits{}
+	lim.Pub.Deny.Add("{{tag(NOT_THERE)}}.{{tag(foo)}}")
+	acc := &Account{nameTag: "accname", tags: []string{"acc:acc1", "acc:acc2"}}
+
+	_, err := processUserPermissionsTemplate(lim, uclaim, acc)
+	require_Error(t, err)
+	require_Contains(t, err.Error(), "generated invalid subject")
+}
+
 func TestJWTLimitsTemplate(t *testing.T) {
 	kp, _ := nkeys.CreateAccount()
 	aPub, _ := kp.PublicKey()


### PR DESCRIPTION
If a tag that doesn't exist is followed by a tag that does, a panic can occur in the subject calculation. Added a test to prove that it no longer panics and instead just returns a `generated invalid subject` error.

Signed-off-by: Neil Twigg <neil@nats.io>