### PR TITLE
NRG: Drop append entries when upper layer is overloaded

### DIFF
--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -97,6 +97,27 @@ func (sg smGroup) unlockAll() {
 	}
 }
 
+// Causes the upper layer to purposefully block on receipt of
+// append entries until unwedge is called, simulating the scenario
+// that the upper layer is stuck on processing something.
+// Note that this is different from PauseApply, which stops the
+// Raft layer from sending applies to the upper layer at all.
+func (sg smGroup) wedge() {
+	for _, n := range sg {
+		n.(*stateAdder).wedge.Lock()
+	}
+}
+
+// Unwedges the upper layer. Any append entries that have built
+// up in the apply queue will start to apply.
+// Note that this is different from ResumeApply, which starts the
+// Raft layer sending applies to the upper layer again.
+func (sg smGroup) unwedge() {
+	for _, n := range sg {
+		n.(*stateAdder).wedge.Unlock()
+	}
+}
+
 // Create a raft group and place on numMembers servers at random.
 // Filestore based.
 func (c *cluster) createRaftGroup(name string, numMembers int, smf smFactory) smGroup {
@@ -183,11 +204,12 @@ func smLoop(sm stateMachine) {
 // The adder state just sums up int64 values.
 type stateAdder struct {
 	sync.Mutex
-	s   *Server
-	n   RaftNode
-	cfg *RaftConfig
-	sum int64
-	lch chan bool
+	s     *Server
+	n     RaftNode
+	cfg   *RaftConfig
+	sum   int64
+	lch   chan bool
+	wedge sync.Mutex
 }
 
 // Simple getters for server and the raft node.
@@ -209,6 +231,8 @@ func (a *stateAdder) propose(data []byte) {
 }
 
 func (a *stateAdder) applyEntry(ce *CommittedEntry) {
+	a.wedge.Lock()
+	defer a.wedge.Unlock()
 	a.Lock()
 	defer a.Unlock()
 	if ce == nil {


### PR DESCRIPTION
This adds a mechanism for the Raft layer to detect when the upper layer isn't keeping up with applies. When the overloaded condition is detected, we'll start dropping newly incoming append entries instead so that the apply queue doesn't build up endlessly.

Still need to figure out what threshold makes sense here, or how it makes sense to configure it.

Signed-off-by: Neil Twigg <neil@nats.io>
