### PR TITLE
[FIXED] Make access to mb's first and last sequence to consistently use atomics.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1093,11 +1093,12 @@ func (fs *fileStore) rebuildStateLocked(ld *LostStreamData) {
 		mb.mu.RLock()
 		fs.state.Msgs += mb.msgs
 		fs.state.Bytes += mb.bytes
-		if fs.state.FirstSeq == 0 || mb.first.seq < fs.state.FirstSeq {
-			fs.state.FirstSeq = mb.first.seq
+		fseq := atomic.LoadUint64(&mb.first.seq)
+		if fs.state.FirstSeq == 0 || fseq < fs.state.FirstSeq {
+			fs.state.FirstSeq = fseq
 			fs.state.FirstTime = time.Unix(0, mb.first.ts).UTC()
 		}
-		fs.state.LastSeq = mb.last.seq
+		fs.state.LastSeq = atomic.LoadUint64(&mb.last.seq)
 		fs.state.LastTime = time.Unix(0, mb.last.ts).UTC()
 		mb.mu.RUnlock()
 	}
@@ -1218,7 +1219,7 @@ func (mb *msgBlock) rebuildState() (*LostStreamData, []uint64, error) {
 // Rebuild the state of the blk based on what we have on disk in the N.blk file.
 // Lock should be held.
 func (mb *msgBlock) rebuildStateLocked() (*LostStreamData, []uint64, error) {
-	startLastSeq := mb.last.seq
+	startLastSeq := atomic.LoadUint64(&mb.last.seq)
 
 	// Remove the .fss file and clear any cache we have set.
 	mb.clearCacheAndOffset()
@@ -1232,7 +1233,8 @@ func (mb *msgBlock) rebuildStateLocked() (*LostStreamData, []uint64, error) {
 		if mb.msgs > 0 {
 			// We need to declare lost data here.
 			ld = &LostStreamData{Msgs: make([]uint64, 0, mb.msgs), Bytes: mb.bytes}
-			for seq := mb.first.seq; seq <= mb.last.seq; seq++ {
+			firstSeq, lastSeq := atomic.LoadUint64(&mb.first.seq), atomic.LoadUint64(&mb.last.seq)
+			for seq := firstSeq; seq <= lastSeq; seq++ {
 				if !mb.dmap.Exists(seq) {
 					ld.Msgs = append(ld.Msgs, seq)
 				}
@@ -1240,14 +1242,15 @@ func (mb *msgBlock) rebuildStateLocked() (*LostStreamData, []uint64, error) {
 			// Clear invalid state. We will let this blk be added in here.
 			mb.msgs, mb.bytes, mb.rbytes, mb.fss = 0, 0, 0, nil
 			mb.dmap.Empty()
-			mb.first.seq = mb.last.seq + 1
+			atomic.StoreUint64(&mb.first.seq, atomic.LoadUint64(&mb.last.seq)+1)
 		}
 		return ld, nil, err
 	}
 
 	// Clear state we need to rebuild.
 	mb.msgs, mb.bytes, mb.rbytes, mb.fss = 0, 0, 0, nil
-	mb.last.seq, mb.last.ts = 0, 0
+	atomic.StoreUint64(&mb.last.seq, 0)
+	mb.last.ts = 0
 	firstNeedsSet := true
 
 	// Check if we need to decrypt.
@@ -1302,7 +1305,7 @@ func (mb *msgBlock) rebuildStateLocked() (*LostStreamData, []uint64, error) {
 
 	gatherLost := func(lb uint32) *LostStreamData {
 		var ld LostStreamData
-		for seq := mb.last.seq + 1; seq <= startLastSeq; seq++ {
+		for seq := atomic.LoadUint64(&mb.last.seq) + 1; seq <= startLastSeq; seq++ {
 			ld.Msgs = append(ld.Msgs, seq)
 		}
 		ld.Bytes = uint64(lb)
@@ -1370,18 +1373,20 @@ func (mb *msgBlock) rebuildStateLocked() (*LostStreamData, []uint64, error) {
 			continue
 		}
 
+		fseq := atomic.LoadUint64(&mb.first.seq)
 		// This is an old erased message, or a new one that we can track.
-		if seq == 0 || seq&ebit != 0 || seq < mb.first.seq {
+		if seq == 0 || seq&ebit != 0 || seq < fseq {
 			seq = seq &^ ebit
-			if seq >= mb.first.seq {
+			if seq >= fseq {
 				// Only add to dmap if past recorded first seq and non-zero.
 				if seq != 0 {
 					addToDmap(seq)
 				}
-				mb.last.seq = seq
+				atomic.StoreUint64(&mb.last.seq, seq)
 				mb.last.ts = ts
 				if mb.msgs == 0 {
-					mb.first.seq, mb.first.ts = seq+1, 0
+					atomic.StoreUint64(&mb.first.seq, seq+1)
+					mb.first.ts = 0
 				}
 			}
 			index += rl
@@ -1391,8 +1396,9 @@ func (mb *msgBlock) rebuildStateLocked() (*LostStreamData, []uint64, error) {
 		// This is for when we have index info that adjusts for deleted messages
 		// at the head. So the first.seq will be already set here. If this is larger
 		// replace what we have with this seq.
-		if firstNeedsSet && seq >= mb.first.seq {
-			firstNeedsSet, mb.first.seq, mb.first.ts = false, seq, ts
+		if firstNeedsSet && seq >= fseq {
+			atomic.StoreUint64(&mb.first.seq, seq)
+			firstNeedsSet, mb.first.ts = false, ts
 		}
 
 		if !mb.dmap.Exists(seq) {
@@ -1418,7 +1424,7 @@ func (mb *msgBlock) rebuildStateLocked() (*LostStreamData, []uint64, error) {
 		}
 
 		// Always set last
-		mb.last.seq = seq
+		atomic.StoreUint64(&mb.last.seq, seq)
 		mb.last.ts = ts
 
 		// Advance to next record.
@@ -1429,12 +1435,15 @@ func (mb *msgBlock) rebuildStateLocked() (*LostStreamData, []uint64, error) {
 	// Or if we seem to have no messages but had a tombstone, which we use to remember
 	// sequences and timestamps now, use that to properly setup the first and last.
 	if mb.msgs == 0 {
-		if mb.first.seq > 0 {
-			mb.last.seq = mb.first.seq - 1
-		} else if mb.first.seq == 0 && minTombstoneSeq > 0 {
-			mb.first.seq, mb.first.ts = minTombstoneSeq+1, 0
+		fseq := atomic.LoadUint64(&mb.first.seq)
+		if fseq > 0 {
+			atomic.StoreUint64(&mb.last.seq, fseq-1)
+		} else if fseq == 0 && minTombstoneSeq > 0 {
+			atomic.StoreUint64(&mb.first.seq, minTombstoneSeq+1)
+			mb.first.ts = 0
 			if mb.last.seq == 0 {
-				mb.last.seq, mb.last.ts = minTombstoneSeq, minTombstoneTs
+				atomic.StoreUint64(&mb.last.seq, minTombstoneSeq)
+				mb.last.ts = minTombstoneTs
 			}
 		}
 	}
@@ -1592,7 +1601,9 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 				break
 			}
 			mb := fs.initMsgBlock(index)
-			mb.first.seq, mb.last.seq, mb.msgs, mb.bytes = fseq, lseq, lseq-fseq+1, nbytes
+			atomic.StoreUint64(&mb.first.seq, fseq)
+			atomic.StoreUint64(&mb.last.seq, lseq)
+			mb.msgs, mb.bytes = lseq-fseq+1, nbytes
 			mb.first.ts, mb.last.ts = fts+baseTime, lts+baseTime
 			if numDeleted > 0 {
 				dmap, n, err := avl.Decode(buf[bi:])
@@ -1677,13 +1688,13 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 			return err
 		}
 		if nmb != nil {
-			// Update top level accounting.
-			if fs.state.FirstSeq == 0 || nmb.first.seq < fs.state.FirstSeq {
-				fs.state.FirstSeq = nmb.first.seq
+			// Update top level accounting
+			if fseq := atomic.LoadUint64(&nmb.first.seq); fs.state.FirstSeq == 0 || fseq < fs.state.FirstSeq {
+				fs.state.FirstSeq = fseq
 				fs.state.FirstTime = time.Unix(0, nmb.first.ts).UTC()
 			}
-			if nmb.last.seq > fs.state.LastSeq {
-				fs.state.LastSeq = nmb.last.seq
+			if lseq := atomic.LoadUint64(&nmb.last.seq); lseq > fs.state.LastSeq {
+				fs.state.LastSeq = lseq
 				fs.state.LastTime = time.Unix(0, nmb.last.ts).UTC()
 			}
 			fs.state.Msgs += nmb.msgs
@@ -1709,7 +1720,7 @@ func (fs *fileStore) adjustAccounting(mb, nmb *msgBlock) {
 	// triggered limits exceeded will be handled after the recovery and prior to the stream
 	// being available to the system.
 	var smv StoreMsg
-	for seq := mb.last.seq + 1; seq <= nmb.last.seq; seq++ {
+	for seq, lseq := atomic.LoadUint64(&mb.last.seq)+1, atomic.LoadUint64(&nmb.last.seq); seq <= lseq; seq++ {
 		// Lookup the message. If an error will be deleted, so can skip.
 		sm, err := nmb.cacheLookup(seq, &smv)
 		if err != nil {
@@ -1732,18 +1743,18 @@ func (fs *fileStore) adjustAccounting(mb, nmb *msgBlock) {
 	}
 
 	// Now check to see if we had a higher first for the recovered state mb vs nmb.
-	if nmb.first.seq < mb.first.seq {
+	if atomic.LoadUint64(&nmb.first.seq) < atomic.LoadUint64(&mb.first.seq) {
 		// Now set first for nmb.
-		nmb.first = mb.first
+		atomic.StoreUint64(&nmb.first.seq, atomic.LoadUint64(&mb.first.seq))
 	}
 
 	// Update top level accounting.
-	if fs.state.FirstSeq == 0 || nmb.first.seq < fs.state.FirstSeq {
-		fs.state.FirstSeq = nmb.first.seq
+	if fseq := atomic.LoadUint64(&nmb.first.seq); fs.state.FirstSeq == 0 || fseq < fs.state.FirstSeq {
+		fs.state.FirstSeq = fseq
 		fs.state.FirstTime = time.Unix(0, nmb.first.ts).UTC()
 	}
-	if nmb.last.seq > fs.state.LastSeq {
-		fs.state.LastSeq = nmb.last.seq
+	if lseq := atomic.LoadUint64(&nmb.last.seq); lseq > fs.state.LastSeq {
+		fs.state.LastSeq = lseq
 		fs.state.LastTime = time.Unix(0, nmb.last.ts).UTC()
 	}
 }
@@ -1857,17 +1868,21 @@ func (fs *fileStore) recoverMsgs() error {
 				fs.removeMsgBlockFromList(mb)
 				continue
 			}
-			if fs.state.FirstSeq == 0 || mb.first.seq < fs.state.FirstSeq {
-				fs.state.FirstSeq = mb.first.seq
+			if fseq := atomic.LoadUint64(&mb.first.seq); fs.state.FirstSeq == 0 || fseq < fs.state.FirstSeq {
+				fs.state.FirstSeq = fseq
 				if mb.first.ts == 0 {
 					fs.state.FirstTime = time.Time{}
 				} else {
 					fs.state.FirstTime = time.Unix(0, mb.first.ts).UTC()
 				}
 			}
-			if mb.last.seq > fs.state.LastSeq {
-				fs.state.LastSeq = mb.last.seq
-				fs.state.LastTime = time.Unix(0, mb.last.ts).UTC()
+			if lseq := atomic.LoadUint64(&mb.last.seq); lseq > fs.state.LastSeq {
+				fs.state.LastSeq = lseq
+				if mb.last.ts == 0 {
+					fs.state.LastTime = time.Time{}
+				} else {
+					fs.state.LastTime = time.Unix(0, mb.last.ts).UTC()
+				}
 			}
 			fs.state.Msgs += mb.msgs
 			fs.state.Bytes += mb.bytes
@@ -1945,7 +1960,8 @@ func (fs *fileStore) expireMsgsOnRecover() {
 		// If we are the last keep state to remember first/last sequence.
 		// Do this part by hand since not deleting one by one.
 		if mb == fs.lmb {
-			last = mb.last
+			last.seq = atomic.LoadUint64(&mb.last.seq)
+			last.ts = mb.last.ts
 		}
 		// Make sure we do subject cleanup as well.
 		mb.ensurePerSubjectInfoLoaded()
@@ -1985,7 +2001,8 @@ func (fs *fileStore) expireMsgsOnRecover() {
 
 		// Walk messages and remove if expired.
 		mb.ensurePerSubjectInfoLoaded()
-		for seq := mb.first.seq; seq <= mb.last.seq; seq++ {
+		fseq, lseq := atomic.LoadUint64(&mb.first.seq), atomic.LoadUint64(&mb.last.seq)
+		for seq := fseq; seq <= lseq; seq++ {
 			sm, err := mb.cacheLookup(seq, &smv)
 			// Process interior deleted msgs.
 			if err == errDeletedMsg {
@@ -1994,12 +2011,14 @@ func (fs *fileStore) expireMsgsOnRecover() {
 					mb.dmap.Delete(seq)
 				}
 				// Keep this updated just in case since we are removing dmap entries.
-				mb.first.seq, needNextFirst = seq, true
+				atomic.StoreUint64(&mb.first.seq, seq)
+				needNextFirst = true
 				continue
 			}
 			// Break on other errors.
 			if err != nil || sm == nil {
-				mb.first.seq, needNextFirst = seq, true
+				atomic.StoreUint64(&mb.first.seq, seq)
+				needNextFirst = true
 				break
 			}
 
@@ -2007,16 +2026,17 @@ func (fs *fileStore) expireMsgsOnRecover() {
 
 			// Check for done.
 			if minAge < sm.ts {
-				mb.first.seq, needNextFirst = sm.seq, false
-				mb.first.seq = sm.seq
+				atomic.StoreUint64(&mb.first.seq, sm.seq)
 				mb.first.ts = sm.ts
+				needNextFirst = false
 				nts = sm.ts
 				break
 			}
 
 			// Delete the message here.
 			if mb.msgs > 0 {
-				mb.first.seq, needNextFirst = seq, true
+				atomic.StoreUint64(&mb.first.seq, seq)
+				needNextFirst = true
 				sz := fileStoreMsgSize(sm.subj, sm.hdr, sm.msg)
 				if sz > mb.bytes {
 					sz = mb.bytes
@@ -2120,10 +2140,8 @@ func (fs *fileStore) GetSeqFromTime(t time.Time) uint64 {
 		return lastSeq + 1
 	}
 
-	mb.mu.RLock()
-	fseq := mb.first.seq
-	lseq := mb.last.seq
-	mb.mu.RUnlock()
+	fseq := atomic.LoadUint64(&mb.first.seq)
+	lseq := atomic.LoadUint64(&mb.last.seq)
 
 	var smv StoreMsg
 
@@ -2161,7 +2179,8 @@ func (mb *msgBlock) firstMatching(filter string, wc bool, start uint64, sm *Stor
 	// Skip scan of mb.fss if number of messages in the block are less than
 	// 1/2 the number of subjects in mb.fss. Or we have a wc and lots of fss entries.
 	const linearScanMaxFSS = 32
-	doLinearScan := isAll || 2*int(mb.last.seq-start) < len(mb.fss) || (wc && len(mb.fss) > linearScanMaxFSS)
+	lseq := atomic.LoadUint64(&mb.last.seq)
+	doLinearScan := isAll || 2*int(lseq-start) < len(mb.fss) || (wc && len(mb.fss) > linearScanMaxFSS)
 
 	if !doLinearScan {
 		// If we have a wildcard match against all tracked subjects we know about.
@@ -2173,7 +2192,7 @@ func (mb *msgBlock) firstMatching(filter string, wc bool, start uint64, sm *Stor
 				}
 			}
 		}
-		fseq = mb.last.seq + 1
+		fseq = lseq + 1
 		for _, subj := range subs {
 			ss := mb.fss[subj]
 			if ss != nil && ss.firstNeedsUpdate {
@@ -2190,7 +2209,7 @@ func (mb *msgBlock) firstMatching(filter string, wc bool, start uint64, sm *Stor
 		}
 	}
 
-	if fseq > mb.last.seq {
+	if fseq > lseq {
 		return nil, false, ErrStoreMsgNotFound
 	}
 
@@ -2198,13 +2217,13 @@ func (mb *msgBlock) firstMatching(filter string, wc bool, start uint64, sm *Stor
 		sm = new(StoreMsg)
 	}
 
-	for seq := fseq; seq <= mb.last.seq; seq++ {
+	for seq := fseq; seq <= lseq; seq++ {
 		llseq := mb.llseq
 		fsm, err := mb.cacheLookup(seq, sm)
 		if err != nil {
 			continue
 		}
-		expireOk := seq == mb.last.seq && mb.llseq == seq
+		expireOk := seq == lseq && mb.llseq == seq
 		if isAll {
 			return fsm, expireOk, nil
 		}
@@ -2242,8 +2261,10 @@ func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, sseq uint64) (
 
 	// First check if we can optimize this part.
 	// This means we want all and the starting sequence was before this block.
-	if isAll && sseq <= mb.first.seq {
-		return mb.msgs, mb.first.seq, mb.last.seq
+	if isAll {
+		if fseq := atomic.LoadUint64(&mb.first.seq); sseq <= fseq {
+			return mb.msgs, fseq, atomic.LoadUint64(&mb.last.seq)
+		}
 	}
 
 	update := func(ss *SimpleState) {
@@ -2308,7 +2329,7 @@ func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, sseq uint64) (
 	}
 
 	var smv StoreMsg
-	for seq := sseq; seq <= mb.last.seq; seq++ {
+	for seq, lseq := sseq, atomic.LoadUint64(&mb.last.seq); seq <= lseq; seq++ {
 		sm, _ := mb.cacheLookup(seq, &smv)
 		if sm == nil {
 			continue
@@ -2575,7 +2596,7 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 			mb := fs.blks[i]
 			mb.mu.Lock()
 			var t uint64
-			if isAll && sseq <= mb.first.seq {
+			if isAll && sseq <= atomic.LoadUint64(&mb.first.seq) {
 				if lastPerSubject {
 					mb.ensurePerSubjectInfoLoaded()
 					for subj := range mb.fss {
@@ -2628,7 +2649,7 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 					shouldExpire = true
 				}
 				var smv StoreMsg
-				for seq := sseq; seq <= mb.last.seq; seq++ {
+				for seq, lseq := sseq, atomic.LoadUint64(&mb.last.seq); seq <= lseq; seq++ {
 					if sm, _ := mb.cacheLookup(seq, &smv); sm != nil && (isAll || isMatch(sm.subj)) {
 						t++
 					}
@@ -2700,7 +2721,7 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 		var shouldExpire bool
 		mb.mu.Lock()
 		// Check if we should include all of this block in adjusting. If so work with metadata.
-		if sseq > mb.last.seq {
+		if sseq > atomic.LoadUint64(&mb.last.seq) {
 			if isAll && !lastPerSubject {
 				adjust += mb.msgs
 			} else {
@@ -2728,11 +2749,11 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 				shouldExpire = true
 			}
 
-			var last = mb.last.seq
+			var last = atomic.LoadUint64(&mb.last.seq)
 			if sseq < last {
 				last = sseq
 			}
-			for seq := mb.first.seq; seq < last; seq++ {
+			for seq := atomic.LoadUint64(&mb.first.seq); seq < last; seq++ {
 				sm, _ := mb.cacheLookup(seq, &smv)
 				if sm == nil {
 					continue
@@ -2860,8 +2881,8 @@ func (fs *fileStore) newMsgBlockForWrite() (*msgBlock, error) {
 	ts := time.Now().UnixNano()
 	mb.llts, mb.lwts = 0, ts
 	// Remember our last sequence number.
-	mb.first.seq = fs.state.LastSeq + 1
-	mb.last.seq = fs.state.LastSeq
+	atomic.StoreUint64(&mb.first.seq, fs.state.LastSeq+1)
+	atomic.StoreUint64(&mb.last.seq, fs.state.LastSeq)
 	mb.mu.Unlock()
 
 	// Now do local hash.
@@ -3104,9 +3125,9 @@ func (mb *msgBlock) skipMsg(seq uint64, now time.Time) {
 	mb.mu.Lock()
 	// If we are empty can just do meta.
 	if mb.msgs == 0 {
-		mb.last.seq = seq
+		atomic.StoreUint64(&mb.last.seq, seq)
 		mb.last.ts = nowts
-		mb.first.seq = seq + 1
+		atomic.StoreUint64(&mb.first.seq, seq+1)
 		mb.first.ts = nowts
 	} else {
 		needsRecord = true
@@ -3432,7 +3453,7 @@ func (fs *fileStore) removeMsg(seq uint64, secure, viaLimits, needFSLock bool) (
 	mb.mu.Lock()
 
 	// See if we are closed or the sequence number is still relevant.
-	if mb.closed || seq < mb.first.seq {
+	if mb.closed || seq < atomic.LoadUint64(&mb.first.seq) {
 		mb.mu.Unlock()
 		fsUnlock()
 		return false, nil
@@ -3464,7 +3485,7 @@ func (fs *fileStore) removeMsg(seq uint64, secure, viaLimits, needFSLock bool) (
 			return false, ErrStoreClosed
 		}
 		mb.mu.Lock()
-		if mb.closed || seq < mb.first.seq {
+		if mb.closed || seq < atomic.LoadUint64(&mb.first.seq) {
 			mb.mu.Unlock()
 			fsUnlock()
 			return false, nil
@@ -3525,7 +3546,7 @@ func (fs *fileStore) removeMsg(seq uint64, secure, viaLimits, needFSLock bool) (
 		mb.eraseMsg(seq, int(ri), int(rl))
 	}
 
-	fifo := seq == mb.first.seq
+	fifo := seq == atomic.LoadUint64(&mb.first.seq)
 	isLastBlock := mb == fs.lmb
 	isEmpty := mb.msgs == 0
 
@@ -3534,7 +3555,7 @@ func (fs *fileStore) removeMsg(seq uint64, secure, viaLimits, needFSLock bool) (
 		if !isEmpty {
 			// Can update this one in place.
 			if seq == fs.state.FirstSeq {
-				fs.state.FirstSeq = mb.first.seq // new one.
+				fs.state.FirstSeq = atomic.LoadUint64(&mb.first.seq) // new one.
 				if mb.first.ts == 0 {
 					fs.state.FirstTime = time.Time{}
 				} else {
@@ -3632,8 +3653,9 @@ func (mb *msgBlock) compact() {
 	var le = binary.LittleEndian
 	var firstSet bool
 
+	fseq := atomic.LoadUint64(&mb.first.seq)
 	isDeleted := func(seq uint64) bool {
-		return seq == 0 || seq&ebit != 0 || seq < mb.first.seq || mb.dmap.Exists(seq)
+		return seq == 0 || seq&ebit != 0 || mb.dmap.Exists(seq) || seq < fseq
 	}
 
 	for index, lbuf := uint32(0), uint32(len(buf)); index < lbuf; {
@@ -3656,21 +3678,21 @@ func (mb *msgBlock) compact() {
 			// Check for tombstones.
 			if seq&tbit != 0 {
 				// If we are last mb we should consider to keep these unless the tombstone reflects a seq in this mb.
-				if mb == mb.fs.lmb && seq < mb.first.seq {
+				if mb == mb.fs.lmb && seq < fseq {
 					nbuf = append(nbuf, buf[index:index+rl]...)
 				}
 			} else {
 				// Normal message here.
 				nbuf = append(nbuf, buf[index:index+rl]...)
 				if !firstSet {
-					firstSet = true
-					mb.first.seq = seq
+					firstSet, fseq = true, seq
+					atomic.StoreUint64(&mb.first.seq, seq)
 				}
 			}
 		}
 		// Always set last as long as not a tombstone.
 		if seq&tbit == 0 {
-			mb.last.seq = seq &^ ebit
+			atomic.StoreUint64(&mb.last.seq, seq&^ebit)
 		}
 		// Advance to next record.
 		index += rl
@@ -3926,7 +3948,7 @@ func (mb *msgBlock) truncate(sm *StoreMsg) (nmsgs, nbytes uint64, err error) {
 	checkDmap := mb.dmap.Size() > 0
 	var smv StoreMsg
 
-	for seq := mb.last.seq; seq > sm.seq; seq-- {
+	for seq := atomic.LoadUint64(&mb.last.seq); seq > sm.seq; seq-- {
 		if checkDmap {
 			if mb.dmap.Exists(seq) {
 				// Delete and skip to next.
@@ -4013,7 +4035,7 @@ func (mb *msgBlock) truncate(sm *StoreMsg) (nmsgs, nbytes uint64, err error) {
 	}
 
 	// Update our last msg.
-	mb.last.seq = sm.seq
+	atomic.StoreUint64(&mb.last.seq, sm.seq)
 	mb.last.ts = sm.ts
 
 	// Clear our cache.
@@ -4030,15 +4052,16 @@ func (mb *msgBlock) truncate(sm *StoreMsg) (nmsgs, nbytes uint64, err error) {
 	return purged, bytes, nil
 }
 
-// Lock should be held.
+// Helper to determine if the mb is empty.
 func (mb *msgBlock) isEmpty() bool {
-	return mb.first.seq > mb.last.seq
+	return atomic.LoadUint64(&mb.first.seq) > atomic.LoadUint64(&mb.last.seq)
 }
 
 // Lock should be held.
 func (mb *msgBlock) selectNextFirst() {
 	var seq uint64
-	for seq = mb.first.seq + 1; seq <= mb.last.seq; seq++ {
+	fseq, lseq := atomic.LoadUint64(&mb.first.seq), atomic.LoadUint64(&mb.last.seq)
+	for seq = fseq + 1; seq <= lseq; seq++ {
 		if mb.dmap.Exists(seq) {
 			// We will move past this so we can delete the entry.
 			mb.dmap.Delete(seq)
@@ -4047,10 +4070,10 @@ func (mb *msgBlock) selectNextFirst() {
 		}
 	}
 	// Set new first sequence.
-	mb.first.seq = seq
+	atomic.StoreUint64(&mb.first.seq, seq)
 
 	// Check if we are empty..
-	if mb.isEmpty() {
+	if seq > lseq {
 		mb.first.ts = 0
 		return
 	}
@@ -4078,7 +4101,7 @@ func (fs *fileStore) selectNextFirst() {
 	if len(fs.blks) > 0 {
 		mb := fs.blks[0]
 		mb.mu.RLock()
-		fs.state.FirstSeq = mb.first.seq
+		fs.state.FirstSeq = atomic.LoadUint64(&mb.first.seq)
 		fs.state.FirstTime = time.Unix(0, mb.first.ts).UTC()
 		mb.mu.RUnlock()
 	} else {
@@ -4566,8 +4589,9 @@ func (mb *msgBlock) updateAccounting(seq uint64, ts int64, rl uint64) {
 		seq = seq &^ ebit
 	}
 
-	if (mb.first.seq == 0 || mb.first.ts == 0) && seq >= mb.first.seq {
-		mb.first.seq = seq
+	fseq := atomic.LoadUint64(&mb.first.seq)
+	if (fseq == 0 || mb.first.ts == 0) && seq >= fseq {
+		atomic.StoreUint64(&mb.first.seq, seq)
 		mb.first.ts = ts
 	}
 	// Need atomics here for selectMsgBlock speed.
@@ -4932,9 +4956,11 @@ func (mb *msgBlock) indexCacheBuf(buf []byte) error {
 	var idx []uint32
 	var index uint32
 
+	mbFirstSeq := atomic.LoadUint64(&mb.first.seq)
+
 	if mb.cache == nil {
 		// Approximation, may adjust below.
-		fseq = mb.first.seq
+		fseq = mbFirstSeq
 		idx = make([]uint32, 0, mb.msgs)
 		mb.cache = &cache{}
 	} else {
@@ -4983,11 +5009,11 @@ func (mb *msgBlock) indexCacheBuf(buf []byte) error {
 
 		// We defer checksum checks to individual msg cache lookups to amortorize costs and
 		// not introduce latency for first message from a newly loaded block.
-		if seq >= mb.first.seq {
+		if seq >= mbFirstSeq {
 			// Track that we do not have holes.
-			if slot := int(seq - mb.first.seq); slot != len(idx) {
+			if slot := int(seq - mbFirstSeq); slot != len(idx) {
 				// If we have a hole fill it.
-				for dseq := mb.first.seq + uint64(len(idx)); dseq < seq; dseq++ {
+				for dseq := mbFirstSeq + uint64(len(idx)); dseq < seq; dseq++ {
 					idx = append(idx, dbit)
 					mb.dmap.Insert(dseq)
 				}
@@ -5012,8 +5038,7 @@ func (mb *msgBlock) indexCacheBuf(buf []byte) error {
 					ss.Msgs++
 					ss.Last = seq
 				} else {
-					subj := mb.subjString(bsubj)
-					mb.fss[subj] = &SimpleState{Msgs: 1, First: seq, Last: seq}
+					mb.fss[mb.subjString(bsubj)] = &SimpleState{Msgs: 1, First: seq, Last: seq}
 				}
 			}
 		}
@@ -5184,7 +5209,7 @@ func (mb *msgBlock) cacheAlreadyLoaded() bool {
 	if mb.cache == nil || mb.cache.off != 0 || mb.cache.fseq == 0 || len(mb.cache.buf) == 0 {
 		return false
 	}
-	numEntries := mb.msgs + uint64(mb.dmap.Size()) + (mb.first.seq - mb.cache.fseq)
+	numEntries := mb.msgs + uint64(mb.dmap.Size()) + (atomic.LoadUint64(&mb.first.seq) - mb.cache.fseq)
 	return numEntries == uint64(len(mb.cache.idx))
 }
 
@@ -5355,7 +5380,7 @@ func (mb *msgBlock) fetchMsg(seq uint64, sm *StoreMsg) (*StoreMsg, bool, error) 
 	if err != nil {
 		return nil, false, err
 	}
-	expireOk := seq == mb.last.seq && mb.llseq == seq
+	expireOk := seq == atomic.LoadUint64(&mb.last.seq) && mb.llseq == seq
 	return fsm, expireOk, err
 }
 
@@ -5393,7 +5418,7 @@ const (
 // Will do a lookup from cache.
 // Lock should be held.
 func (mb *msgBlock) cacheLookup(seq uint64, sm *StoreMsg) (*StoreMsg, error) {
-	if seq < mb.first.seq || seq > mb.last.seq {
+	if seq < atomic.LoadUint64(&mb.first.seq) || seq > atomic.LoadUint64(&mb.last.seq) {
 		return nil, ErrStoreMsgNotFound
 	}
 
@@ -5688,7 +5713,7 @@ func (fs *fileStore) loadLast(subj string, sm *StoreMsg) (lsm *StoreMsg, err err
 			}
 		}
 		if l == 0 {
-			_, _, l = mb.filteredPendingLocked(subj, wc, mb.first.seq)
+			_, _, l = mb.filteredPendingLocked(subj, wc, atomic.LoadUint64(&mb.first.seq))
 		}
 		if l > 0 {
 			if mb.cacheNotLoaded() {
@@ -5795,14 +5820,14 @@ func (fs *fileStore) State() StreamState {
 
 		for _, mb := range fs.blks {
 			mb.mu.Lock()
-			fseq := mb.first.seq
+			fseq := atomic.LoadUint64(&mb.first.seq)
 			// Account for messages missing from the head.
 			if fseq > cur {
 				for seq := cur; seq < fseq; seq++ {
 					state.Deleted = append(state.Deleted, seq)
 				}
 			}
-			cur = mb.last.seq + 1 // Expected next first.
+			cur = atomic.LoadUint64(&mb.last.seq) + 1 // Expected next first.
 
 			mb.dmap.Range(func(seq uint64) bool {
 				if seq < fseq {
@@ -5931,9 +5956,9 @@ func (mb *msgBlock) readIndexInfo() error {
 	}
 	mb.msgs = readCount()
 	mb.bytes = readCount()
-	mb.first.seq = readSeq()
+	atomic.StoreUint64(&mb.first.seq, readSeq())
 	mb.first.ts = readTimeStamp()
-	mb.last.seq = readSeq()
+	atomic.StoreUint64(&mb.last.seq, readSeq())
 	mb.last.ts = readTimeStamp()
 	dmapLen := readCount()
 
@@ -5944,7 +5969,7 @@ func (mb *msgBlock) readIndexInfo() error {
 	}
 
 	// Check for consistency if accounting. If something is off bail and we will rebuild.
-	if mb.msgs != (mb.last.seq-mb.first.seq+1)-dmapLen {
+	if mb.msgs != (atomic.LoadUint64(&mb.last.seq)-atomic.LoadUint64(&mb.first.seq)+1)-dmapLen {
 		os.Remove(ifn)
 		return fmt.Errorf("accounting inconsistent")
 	}
@@ -5964,12 +5989,12 @@ func (mb *msgBlock) readIndexInfo() error {
 			mb.dmap = *dmap
 		} else {
 			// This is the old version.
-			for i := 0; i < int(dmapLen); i++ {
+			for i, fseq := 0, atomic.LoadUint64(&mb.first.seq); i < int(dmapLen); i++ {
 				seq := readSeq()
 				if seq == 0 {
 					break
 				}
-				mb.dmap.Insert(seq + mb.first.seq)
+				mb.dmap.Insert(seq + fseq)
 			}
 		}
 	}
@@ -6071,7 +6096,7 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 			mb.mu.Unlock()
 			continue
 		}
-		t, f, l := mb.filteredPendingLocked(subject, wc, mb.first.seq)
+		t, f, l := mb.filteredPendingLocked(subject, wc, atomic.LoadUint64(&mb.first.seq))
 		if t == 0 {
 			mb.mu.Unlock()
 			continue
@@ -6113,7 +6138,7 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 				fs.removePerSubject(sm.subj)
 
 				// Check for first message.
-				if seq == mb.first.seq {
+				if seq == atomic.LoadUint64(&mb.first.seq) {
 					mb.selectNextFirst()
 					if mb.isEmpty() {
 						fs.removeMsgBlock(mb)
@@ -6121,7 +6146,7 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 						// keep flag set, if set previously
 						firstSeqNeedsUpdate = firstSeqNeedsUpdate || seq == fs.state.FirstSeq
 					} else if seq == fs.state.FirstSeq {
-						fs.state.FirstSeq = mb.first.seq // new one.
+						fs.state.FirstSeq = atomic.LoadUint64(&mb.first.seq) // new one.
 						fs.state.FirstTime = time.Unix(0, mb.first.ts).UTC()
 					}
 				} else {
@@ -6226,14 +6251,14 @@ func (fs *fileStore) purge(fseq uint64) (uint64, error) {
 	}
 
 	lmb := fs.lmb
-	lmb.first.seq = fs.state.FirstSeq
-	lmb.last.seq = fs.state.LastSeq
+	atomic.StoreUint64(&lmb.first.seq, fs.state.FirstSeq)
+	atomic.StoreUint64(&lmb.last.seq, fs.state.LastSeq)
 	lmb.last.ts = fs.state.LastTime.UnixNano()
 
-	if fs.lmb.last.seq > 1 {
+	if lseq := atomic.LoadUint64(&lmb.last.seq); lseq > 1 {
 		// Leave a tombstone so we can remember our starting sequence in case
 		// full state becomes corrupted.
-		lmb.writeTombstone(fs.lmb.last.seq, fs.lmb.last.ts)
+		lmb.writeTombstone(lseq, lmb.last.ts)
 	}
 
 	cb := fs.scb
@@ -6296,7 +6321,7 @@ func (fs *fileStore) Compact(seq uint64) (uint64, error) {
 	var isEmpty bool
 
 	smb.mu.Lock()
-	if smb.first.seq == seq {
+	if atomic.LoadUint64(&smb.first.seq) == seq {
 		goto SKIP
 	}
 
@@ -6306,7 +6331,7 @@ func (fs *fileStore) Compact(seq uint64) (uint64, error) {
 			goto SKIP
 		}
 	}
-	for mseq := smb.first.seq; mseq < seq; mseq++ {
+	for mseq := atomic.LoadUint64(&smb.first.seq); mseq < seq; mseq++ {
 		sm, err := smb.cacheLookup(mseq, &smv)
 		if err == errDeletedMsg {
 			// Update dmap.
@@ -6335,24 +6360,24 @@ func (fs *fileStore) Compact(seq uint64) (uint64, error) {
 	if isEmpty {
 		smb.dirtyCloseWithRemove(true)
 		// Update fs first here as well.
-		fs.state.FirstSeq = smb.last.seq + 1
+		fs.state.FirstSeq = atomic.LoadUint64(&smb.last.seq) + 1
 		fs.state.FirstTime = time.Time{}
 		deleted++
 	} else {
 		// Make sure to sync changes.
 		smb.needSync = true
 		// Update fs first seq and time.
-		smb.first.seq = seq - 1 // Just for start condition for selectNextFirst.
+		atomic.StoreUint64(&smb.first.seq, seq-1) // Just for start condition for selectNextFirst.
 		smb.selectNextFirst()
 
-		fs.state.FirstSeq = smb.first.seq
+		fs.state.FirstSeq = atomic.LoadUint64(&smb.first.seq)
 		fs.state.FirstTime = time.Unix(0, smb.first.ts).UTC()
 
 		// Check if we should reclaim the head space from this block.
 		// This will be optimistic only, so don't continue if we encounter any errors here.
 		if smb.rbytes > compactMinimum && smb.bytes*2 < smb.rbytes {
 			var moff uint32
-			moff, _, _, err = smb.slotInfo(int(smb.first.seq - smb.cache.fseq))
+			moff, _, _, err = smb.slotInfo(int(atomic.LoadUint64(&smb.first.seq) - smb.cache.fseq))
 			if err != nil || moff >= uint32(len(smb.cache.buf)) {
 				goto SKIP
 			}
@@ -6616,12 +6641,12 @@ func (fs *fileStore) removeMsgBlock(mb *msgBlock) {
 	fs.removeMsgBlockFromList(mb)
 	// Check for us being last message block
 	if mb == fs.lmb {
-		last := mb.last
+		lseq, lts := atomic.LoadUint64(&mb.last.seq), mb.last.ts
 		// Creating a new message write block requires that the lmb lock is not held.
 		mb.mu.Unlock()
 		// Write the tombstone to remember since this was last block.
 		if lmb, _ := fs.newMsgBlockForWrite(); lmb != nil {
-			lmb.writeTombstone(last.seq, last.ts)
+			lmb.writeTombstone(lseq, lts)
 		}
 		mb.mu.Lock()
 	}
@@ -6725,7 +6750,7 @@ func (mb *msgBlock) recalculateFirstForSubj(subj string, startSeq uint64, ss *Si
 	}
 
 	var le = binary.LittleEndian
-	for slot := startSlot; slot < len(mb.cache.idx); slot++ {
+	for slot, fseq := startSlot, atomic.LoadUint64(&mb.first.seq); slot < len(mb.cache.idx); slot++ {
 		bi := mb.cache.idx[slot] &^ hbit
 		if bi == dbit {
 			// delete marker so skip.
@@ -6741,7 +6766,7 @@ func (mb *msgBlock) recalculateFirstForSubj(subj string, startSeq uint64, ss *Si
 		slen := int(le.Uint16(hdr[20:]))
 		if subj == string(buf[msgHdrSize:msgHdrSize+slen]) {
 			seq := le.Uint64(hdr[4:])
-			if seq < mb.first.seq || seq&ebit != 0 || mb.dmap.Exists(seq) {
+			if seq < fseq || seq&ebit != 0 || mb.dmap.Exists(seq) {
 				continue
 			}
 			ss.First = seq
@@ -6787,7 +6812,7 @@ func (mb *msgBlock) generatePerSubjectInfo() error {
 	mb.fss = make(map[string]*SimpleState)
 
 	var smv StoreMsg
-	fseq, lseq := mb.first.seq, mb.last.seq
+	fseq, lseq := atomic.LoadUint64(&mb.first.seq), atomic.LoadUint64(&mb.last.seq)
 	for seq := fseq; seq <= lseq; seq++ {
 		sm, err := mb.cacheLookup(seq, &smv)
 		if err != nil {
@@ -7096,9 +7121,9 @@ func (fs *fileStore) writeFullState() error {
 		mb.mu.RLock()
 		buf = binary.AppendUvarint(buf, uint64(mb.index))
 		buf = binary.AppendUvarint(buf, mb.bytes)
-		buf = binary.AppendUvarint(buf, mb.first.seq)
+		buf = binary.AppendUvarint(buf, atomic.LoadUint64(&mb.first.seq))
 		buf = binary.AppendVarint(buf, mb.first.ts-baseTime)
-		buf = binary.AppendUvarint(buf, mb.last.seq)
+		buf = binary.AppendUvarint(buf, atomic.LoadUint64(&mb.last.seq))
 		buf = binary.AppendVarint(buf, mb.last.ts-baseTime)
 
 		numDeleted := mb.dmap.Size()
@@ -7538,14 +7563,14 @@ func (fs *fileStore) deleteBlocks() DeleteBlocks {
 
 	for _, mb := range fs.blks {
 		// Detect if we have a gap between these blocks.
-		if prevLast > 0 && prevLast+1 != mb.first.seq {
-			gap := mb.first.seq - prevLast - 1
-			dbs = append(dbs, &DeleteRange{First: prevLast + 1, Num: gap})
+		fseq := atomic.LoadUint64(&mb.first.seq)
+		if prevLast > 0 && prevLast+1 != fseq {
+			dbs = append(dbs, &DeleteRange{First: prevLast + 1, Num: fseq - prevLast - 1})
 		}
 		if mb.dmap.Size() > 0 {
 			dbs = append(dbs, &mb.dmap)
 		}
-		prevLast = mb.last.seq
+		prevLast = atomic.LoadUint64(&mb.last.seq)
 	}
 	return dbs
 }


### PR DESCRIPTION
Fixes data races.

Signed-off-by: Derek Collison <derek@nats.io>

