### PR TITLE
[FIXED] MQTT race condition when subscribing to `#` with retained messages

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -1971,7 +1971,7 @@ func (a *Account) subscribeInternalEx(subject string, cb msgHandler, ri bool) (*
 		return nil, fmt.Errorf("no internal account client")
 	}
 
-	return c.processSubEx([]byte(subject), nil, []byte(sid), cb, false, false, ri)
+	return c.processSubEx([]byte(subject), nil, []byte(sid), cb, false, false, ri, nil)
 }
 
 // This will add an account subscription that matches the "from" from a service import entry.
@@ -1996,7 +1996,7 @@ func (a *Account) addServiceImportSub(si *serviceImport) error {
 	cb := func(sub *subscription, c *client, acc *Account, subject, reply string, msg []byte) {
 		c.processServiceImport(si, acc, msg)
 	}
-	sub, err := c.processSubEx([]byte(subject), nil, []byte(sid), cb, true, true, false)
+	sub, err := c.processSubEx([]byte(subject), nil, []byte(sid), cb, true, true, false, nil)
 	if err != nil {
 		return err
 	}

--- a/server/client.go
+++ b/server/client.go
@@ -2657,12 +2657,12 @@ func (c *client) parseSub(argo []byte, noForward bool) error {
 }
 
 func (c *client) processSub(subject, queue, bsid []byte, cb msgHandler, noForward bool) (*subscription, error) {
-	return c.processSubEx(subject, queue, bsid, cb, noForward, false, false)
+	return c.processSubEx(subject, queue, bsid, cb, noForward, false, false, nil)
 }
 
-func (c *client) processSubEx(subject, queue, bsid []byte, cb msgHandler, noForward, si, rsi bool) (*subscription, error) {
+func (c *client) processSubEx(subject, queue, bsid []byte, cb msgHandler, noForward, si, rsi bool, mqtt *mqttSub) (*subscription, error) {
 	// Create the subscription
-	sub := &subscription{client: c, subject: subject, queue: queue, sid: bsid, icb: cb, si: si, rsi: rsi}
+	sub := &subscription{client: c, subject: subject, queue: queue, sid: bsid, icb: cb, si: si, rsi: rsi, mqtt: mqtt}
 
 	c.mu.Lock()
 

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -331,7 +331,7 @@ type mqttRetainedMsgRef struct {
 }
 
 type mqttSub struct {
-	ready atomic.Value
+	ready atomic.Bool
 
 	qos byte
 	// Pending serialization of retained messages to be sent when subscription is registered
@@ -4184,7 +4184,7 @@ func mqttDeliverMsgCbQoS0(sub *subscription, pc *client, _ *Account, subject, re
 	}
 
 	// The subcription may still be initializing.
-	if ready := sub.mqtt.ready.Load(); ready == nil || !ready.(bool) {
+	if ready := sub.mqtt.ready.Load(); !ready {
 		return
 	}
 
@@ -4259,7 +4259,7 @@ func mqttDeliverMsgCbQoS12(sub *subscription, pc *client, _ *Account, subject, r
 	}
 
 	// The subcription may still be initializing.
-	if ready := sub.mqtt.ready.Load(); ready == nil || !ready.(bool) {
+	if ready := sub.mqtt.ready.Load(); !ready {
 		return
 	}
 

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -2187,8 +2187,7 @@ func (sess *mqttSession) setupSub(c *client, subject, sid, jsDur string, qos byt
 	sub.mqtt.qos = qos
 
 	if qos == 2 {
-		err = sess.ensurePubRelConsumerSubscription(c)
-		if err != nil {
+		if err = sess.ensurePubRelConsumerSubscription(c); err != nil {
 			return nil, err
 		}
 	}

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -2557,7 +2557,7 @@ func TestMQTTSubWithSpaces(t *testing.T) {
 	defer mcp.Close()
 	testMQTTCheckConnAck(t, mpr, mqttConnAckRCConnectionAccepted, false)
 
-	mc, r := testMQTTConnect(t, &mqttConnInfo{cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	mc, r := testMQTTConnect(t, &mqttConnInfo{user: "sub", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
 	defer mc.Close()
 	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
 


### PR DESCRIPTION
Attempting to subscribe to `#` was causing deadlocks when retained messages were present.

This PR takes a rather conservative approach, does not make locking any more granular than it was before, but eliminates deadlocks that were occurring between JSAPI and `mqttDeliverMsgCbQoS0`. The delivery callback (more recent) was getting invoked for the JSAPI subject, before passing the request to JS.

@derekcollison we can't easily pre-load the retained messages before `processSub` because we need `sub.shadow` which is set up there.

@neilalexander has a work-in-progress attempt to make the locking more granular for `mqttProcessSub`

@neilalexander @derekcollison: I have not yet looked into batch-fetching the retained message.