### PR TITLE
[FIXED] Websocket: partial writes may lead to disconnect

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1340,6 +1340,7 @@ func (c *client) readLoop(pre []byte) {
 					c.Errorf("read error: %v", err)
 				}
 				c.closeConnection(closedStateForErr(err))
+				return
 			} else if bufs == nil {
 				continue
 			}
@@ -1496,15 +1497,6 @@ func (c *client) collapsePtoNB() (net.Buffers, int64) {
 		return c.wsCollapsePtoNB()
 	}
 	return c.out.nb, c.out.pb
-}
-
-// This will handle the fixup needed on a partial write.
-// Assume pending has been already calculated correctly.
-func (c *client) handlePartialWrite(pnb net.Buffers) {
-	if c.isWebsocket() {
-		c.ws.frames = append(pnb, c.ws.frames...)
-		return
-	}
 }
 
 // flushOutbound will flush outbound buffer to a client.
@@ -1675,12 +1667,6 @@ func (c *client) flushOutbound() bool {
 	c.out.pb -= n
 	if c.isWebsocket() {
 		c.ws.fs -= n
-	}
-
-	// Check for partial writes
-	// TODO(dlc) - zero write with no error will cause lost message and the writeloop to spin.
-	if n != attempted && n > 0 {
-		c.handlePartialWrite(c.out.nb)
 	}
 
 	// Check that if there is still data to send and writeLoop is in wait,


### PR DESCRIPTION
The application would disconnect due to garbage data.

This issue was introduced when refactoring flushOutbound with introduction of c.out.wnb. We no longer need to handle specifically for websocket (we were incorrectly adding c.out.nb to websocket frames...)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
