### PR TITLE
[FIXED] MQTT: deadlock between JS API and mqttDeliverMsgCbQoS0

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2349,7 +2349,7 @@ func (c *client) processLeafSub(argo []byte) (err error) {
 
 	// Only add in shadow subs if a new sub or qsub.
 	if osub == nil {
-		if err := c.addShadowSubscriptions(acc, sub); err != nil {
+		if err := c.addShadowSubscriptions(acc, sub, true); err != nil {
 			c.Errorf(err.Error())
 		}
 	}

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -4584,6 +4584,7 @@ func (sess *mqttSession) ensurePubRelConsumerSubscription(c *client) error {
 	pubRelConsumer := sess.pubRelConsumer
 	tmaxack := sess.tmaxack
 	idHash := sess.idHash
+	id := sess.id
 	sess.mu.Unlock()
 
 	// Subscribe before the consumer is created so we don't loose any messages.
@@ -4622,7 +4623,7 @@ func (sess *mqttSession) ensurePubRelConsumerSubscription(c *client) error {
 			ccr.Config.InactiveThreshold = opts.MQTT.ConsumerInactiveThreshold
 		}
 		if _, err := sess.jsa.createConsumer(ccr); err != nil {
-			c.Errorf("Unable to add JetStream consumer for PUBREL for client %q: err=%v", sess.id, err)
+			c.Errorf("Unable to add JetStream consumer for PUBREL for client %q: err=%v", id, err)
 			return err
 		}
 		pubRelConsumer = &ccr.Config

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -4322,13 +4322,6 @@ func mqttDeliverMsgCbQoS0(sub *subscription, pc *client, _ *Account, subject, re
 // the message contains a NATS/MQTT header that indicates that this is a
 // published QoS1+ message.
 func mqttDeliverMsgCbQoS12(sub *subscription, pc *client, _ *Account, subject, reply string, rmsg []byte) {
-	// This is for consistency with mqttDeliverMsgCbQoS0. This callback does not
-	// present the risk of deadlocking with JS API calls since it is filtering
-	// on the header.
-	// if mqttDoNotDeliverSubject(subject) {
-	// 	return
-	// }
-
 	// Message on foo.bar is stored under $MQTT.msgs.foo.bar, so the subject has to be
 	// at least as long as the stream subject prefix "$MQTT.msgs.", and after removing
 	// the prefix, has to be at least 1 character long.

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -2225,7 +2225,10 @@ func (as *mqttAccountSessionManager) processSubs(sess *mqttSession, c *client,
 			subject: subject,
 			sid:     subject,
 		}
-		if err := c.addShadowSubscriptions(c.acc, sub, false); err != nil {
+		c.mu.Lock()
+		acc := c.acc
+		c.mu.Unlock()
+		if err := c.addShadowSubscriptions(acc, sub, false); err != nil {
 			return err
 		}
 		// Best-effort loading the messages, logs on errors (to c.srv), loads

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -2166,7 +2166,7 @@ func (as *mqttAccountSessionManager) removeSession(sess *mqttSession, lock bool)
 
 // Helpers that sets the sub's mqtt fields and possibly serialize
 // (pre-loaded) retained messages.
-// Account manager and session lock held.
+// Session lock held on entry.
 func (sess *mqttSession) processSub(c *client, subject, sid []byte, isReserved bool, qos byte, jsDurName string, h msgHandler, initShadow bool) (*subscription, error) {
 	sub, err := c.processSub(subject, nil, sid, h, false)
 	if err != nil {

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -2473,6 +2473,7 @@ func (as *mqttAccountSessionManager) loadRetainedMessagesForSubject(rms map[stri
 		var rm mqttRetainedMsg
 		if err := json.Unmarshal(jsm.Data, &rm); err != nil {
 			log.Warnf("failed to decode retained message for subject %q: %v", loadSubject, err)
+			continue
 		}
 		rms[subject] = &rm
 	}

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -4729,7 +4729,6 @@ func (sess *mqttSession) processJSConsumer(c *client, subject, sid string,
 			ccr.Config.InactiveThreshold = opts.MQTT.ConsumerInactiveThreshold
 		}
 		if _, err := sess.jsa.createConsumer(ccr); err != nil {
-			// <>/<> FIXME handle already exists error
 			c.Errorf("Unable to add JetStream consumer for subscription on %q: err=%v", subject, err)
 			return nil, nil, err
 		}

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -2297,6 +2297,14 @@ func (as *mqttAccountSessionManager) processSubs(sess *mqttSession, c *client,
 		sess.cons[sid] = cc
 	}
 
+	serializeRMS := func(sub *subscription) {
+		if fromSubProto {
+			for _, ss := range append([]*subscription{sub}, sub.shadow...) {
+				as.serializeRetainedMsgsForSub(rms, sess, c, ss, trace)
+			}
+		}
+	}
+
 	var err error
 	subs := make([]*subscription, 0, len(filters))
 	for _, f := range filters {
@@ -2320,7 +2328,7 @@ func (as *mqttAccountSessionManager) processSubs(sess *mqttSession, c *client,
 		sub, err := sess.processSub(c, bsubject, bsid,
 			isMQTTReservedSubscription(subject), f.qos, _EMPTY_, mqttDeliverMsgCbQoS0, true)
 		if err == nil {
-			as.serializeRetainedMsgsForSub(rms, sess, c, sub, trace)
+			serializeRMS(sub)
 		}
 		sess.mu.Unlock()
 		as.mu.Unlock()
@@ -2353,7 +2361,7 @@ func (as *mqttAccountSessionManager) processSubs(sess *mqttSession, c *client,
 			fwcsub, err = sess.processSub(c, []byte(fwcsubject), []byte(fwcsid),
 				isMQTTReservedSubscription(subject), f.qos, _EMPTY_, mqttDeliverMsgCbQoS0, true)
 			if err == nil {
-				as.serializeRetainedMsgsForSub(rms, sess, c, fwcsub, trace)
+				serializeRMS(fwcsub)
 			}
 			sess.mu.Unlock()
 			as.mu.Unlock()

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -4733,7 +4733,6 @@ func (sess *mqttSession) processJSConsumer(c *client, subject, sid string,
 			return nil, nil, err
 		}
 		cc = &ccr.Config
-
 		tmaxack += maxAckPending
 	}
 

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -2298,10 +2298,8 @@ func (as *mqttAccountSessionManager) processSubs(sess *mqttSession, c *client,
 	}
 
 	serializeRMS := func(sub *subscription) {
-		if fromSubProto {
-			for _, ss := range append([]*subscription{sub}, sub.shadow...) {
-				as.serializeRetainedMsgsForSub(rms, sess, c, ss, trace)
-			}
+		for _, ss := range append([]*subscription{sub}, sub.shadow...) {
+			as.serializeRetainedMsgsForSub(rms, sess, c, ss, trace)
 		}
 	}
 
@@ -2327,7 +2325,7 @@ func (as *mqttAccountSessionManager) processSubs(sess *mqttSession, c *client,
 		sess.mu.Lock()
 		sub, err := sess.processSub(c, bsubject, bsid,
 			isMQTTReservedSubscription(subject), f.qos, _EMPTY_, mqttDeliverMsgCbQoS0, true)
-		if err == nil {
+		if err == nil && fromSubProto {
 			serializeRMS(sub)
 		}
 		sess.mu.Unlock()
@@ -2360,7 +2358,7 @@ func (as *mqttAccountSessionManager) processSubs(sess *mqttSession, c *client,
 			sess.mu.Lock()
 			fwcsub, err = sess.processSub(c, []byte(fwcsubject), []byte(fwcsid),
 				isMQTTReservedSubscription(subject), f.qos, _EMPTY_, mqttDeliverMsgCbQoS0, true)
-			if err == nil {
+			if err == nil && fromSubProto {
 				serializeRMS(fwcsub)
 			}
 			sess.mu.Unlock()


### PR DESCRIPTION
Re-ordered the interactions with JetStream outside the locks.

2 specific use-cases covered in the tests
- Attempt to subscribe to `#` was causing deadlocks when retained messages were present.
- Attempt to subscribe to anything with relevant retained messages if a `#` (or any other subscription matching internal subjects, say `+/+/.../+`) was already set up.