### PR TITLE
[IMPROVED] Resiliency when doing lots of conditional updates to a KV and restarting servers.

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2349,19 +2349,16 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 
 		case isLeader = <-lch:
 			if isLeader {
-				if mset != nil && n != nil {
-					// Send a snapshot if being asked or if we are tracking
-					// a failed state so that followers sync.
-					if clfs := mset.clearCLFS(); clfs > 0 || sendSnapshot {
-						n.SendSnapshot(mset.stateSnapshot())
-						sendSnapshot = false
-					}
+				if mset != nil && n != nil && sendSnapshot {
+					n.SendSnapshot(mset.stateSnapshot())
+					sendSnapshot = false
+
 				}
 				if isRestore {
 					acc, _ := s.LookupAccount(sa.Client.serviceAccount())
 					restoreDoneCh = s.processStreamRestore(sa.Client, acc, sa.Config, _EMPTY_, sa.Reply, _EMPTY_)
 					continue
-				} else if n.NeedSnapshot() {
+				} else if n != nil && n.NeedSnapshot() {
 					doSnapshot()
 				}
 				// Always cancel if this was running.

--- a/server/stream.go
+++ b/server/stream.go
@@ -985,14 +985,6 @@ func (mset *stream) lastSeqAndCLFS() (uint64, uint64) {
 	return mset.lseq, mset.getCLFS()
 }
 
-func (mset *stream) clearCLFS() uint64 {
-	mset.clMu.Lock()
-	defer mset.clMu.Unlock()
-	clfs := mset.clfs
-	mset.clfs, mset.clseq = 0, 0
-	return clfs
-}
-
 func (mset *stream) getCLFS() uint64 {
 	mset.clMu.Lock()
 	defer mset.clMu.Unlock()


### PR DESCRIPTION
We would attempt to sync with stream state and reset our CLFS tracking which would cause issues, so we do not reset CLFS or send snapshots upon being elected leader.

There is still a bug that I can see that I am chasing, but this solves many of the issues we would see in other tests.

Signed-off-by: Derek Collison <derek@nats.io>
