### PR TITLE
Fix subpath used for ws leaf remote connect url

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -2784,14 +2785,14 @@ func (c *client) leafNodeSolicitWSConnection(opts *Options, rURL *url.URL, remot
 	// create a LEAF connection, not a CLIENT.
 	// In case we use the user's URL path in the future, make sure we append the user's
 	// path to our `/leafnode` path.
-	path := leafNodeWSPath
+	lpath := leafNodeWSPath
 	if curPath := rURL.EscapedPath(); curPath != _EMPTY_ {
 		if curPath[0] == '/' {
 			curPath = curPath[1:]
 		}
-		path += curPath
+		lpath = path.Join(lpath, curPath)
 	}
-	ustr := fmt.Sprintf("%s://%s%s", scheme, rURL.Host, path)
+	ustr := fmt.Sprintf("%s://%s%s", scheme, rURL.Host, lpath)
 	u, _ := url.Parse(ustr)
 	req := &http.Request{
 		Method:     "GET",

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"reflect"
 	"strings"
@@ -3007,6 +3009,48 @@ func TestLeafNodeWSNoMaskingRejected(t *testing.T) {
 
 	if !maskWrite {
 		t.Fatal("Leafnode remote connection should mask writes, it does not")
+	}
+}
+
+func TestLeafNodeWSSubPath(t *testing.T) {
+	o := testDefaultLeafNodeWSOptions()
+	s := RunServer(o)
+	defer s.Shutdown()
+
+	lo := testDefaultRemoteLeafNodeWSOptions(t, o, false)
+	ln := RunServer(lo)
+	defer ln.Shutdown()
+
+	// Confirm that it can connect using the subpath.
+	checkLeafNodeConnected(t, s)
+	checkLeafNodeConnected(t, ln)
+
+	// Add another leafnode that tries to connect to the subpath
+	// but intercept the attempt for the test.
+	o2 := testDefaultLeafNodeWSOptions()
+	lo2 := testDefaultRemoteLeafNodeWSOptions(t, o2, false)
+	attempts := make(chan string, 2)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts <- r.URL.String()
+	}))
+	u, _ := url.Parse(fmt.Sprintf("%v/some/path", ts.URL))
+	u.Scheme = "ws"
+	lo2.LeafNode.Remotes = []*RemoteLeafOpts{
+		{
+			URLs: []*url.URL{u},
+		},
+	}
+	ln2 := RunServer(lo2)
+	defer ln2.Shutdown()
+
+	expected := "/leafnode/some/path"
+	select {
+	case got := <-attempts:
+		if got != expected {
+			t.Fatalf("Expected: %v, got: %v", expected, got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for leaf ws connect attempt")
 	}
 }
 


### PR DESCRIPTION
This fixes the concatenated path used by remote leafnodes.

Fixes #4765


