### PR TITLE
Check for /leafnode suffix path on leaf ws connect

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2790,9 +2790,11 @@ func (c *client) leafNodeSolicitWSConnection(opts *Options, rURL *url.URL, remot
 		if curPath[0] == '/' {
 			curPath = curPath[1:]
 		}
-		lpath = path.Join(lpath, curPath)
+		lpath = path.Join(curPath, lpath)
+	} else {
+		lpath = lpath[1:]
 	}
-	ustr := fmt.Sprintf("%s://%s%s", scheme, rURL.Host, lpath)
+	ustr := fmt.Sprintf("%s://%s/%s", scheme, rURL.Host, lpath)
 	u, _ := url.Parse(ustr)
 	req := &http.Request{
 		Method:     "GET",

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -3043,7 +3043,7 @@ func TestLeafNodeWSSubPath(t *testing.T) {
 	ln2 := RunServer(lo2)
 	defer ln2.Shutdown()
 
-	expected := "/leafnode/some/path"
+	expected := "/some/path/leafnode"
 	select {
 	case got := <-attempts:
 		if got != expected {

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -693,9 +693,9 @@ func (s *Server) wsUpgrade(w http.ResponseWriter, r *http.Request) (*wsUpgradeRe
 	kind := CLIENT
 	if r.URL != nil {
 		ep := r.URL.EscapedPath()
-		if strings.HasPrefix(ep, leafNodeWSPath) {
+		if strings.HasSuffix(ep, leafNodeWSPath) {
 			kind = LEAF
-		} else if strings.HasPrefix(ep, mqttWSPath) {
+		} else if strings.HasSuffix(ep, mqttWSPath) {
 			kind = MQTT
 		}
 	}


### PR DESCRIPTION
This changes the`/leafnode` and `/mqtt` checks on a ws connection to detect that it is a leafnode connection over the websocket port.

This way given a remote like this:

```hcl
remotes = [
     {
       url: "ws://user:pass@127.0.0.1:8080/nats-leafnode",
       account: "ACC"
      }
 ]
```

Then the nginx LB configuration would match the same sub path as the configured remote leaf URL:

```hcl
upstream websocket {
        server 127.0.0.1:8888;
}
location /nats-leafnode/leafnode {
  proxy_pass http://websocket;
}
```