### PR TITLE
Fix panic in `fileStore.Stop()`

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7212,6 +7212,10 @@ func (fs *fileStore) Stop() error {
 		return ErrStoreClosed
 	}
 
+	// Mark as closed. Do before releasing the lock to writeFullState
+	// so we don't end up with this function running more than once.
+	fs.closed = true
+
 	fs.checkAndFlushAllBlocks()
 	fs.closeAllMsgBlocks(false)
 
@@ -7229,8 +7233,7 @@ func (fs *fileStore) Stop() error {
 	fs.writeFullState()
 	fs.mu.Lock()
 
-	// Mark as closed.
-	fs.closed = true
+	// Needs to be cleared after writeFullState has completed.
 	fs.lmb = nil
 
 	// We should update the upper usage layer on a stop.

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -187,6 +187,7 @@ type fileStore struct {
 	cfs         []ConsumerStore
 	sips        int
 	dirty       int
+	closing     bool
 	closed      bool
 	fip         bool
 	receivedAny bool
@@ -7207,14 +7208,14 @@ func (fs *fileStore) writeFullState() error {
 // Stop the current filestore.
 func (fs *fileStore) Stop() error {
 	fs.mu.Lock()
-	if fs.closed {
+	if fs.closed || fs.closing {
 		fs.mu.Unlock()
 		return ErrStoreClosed
 	}
 
-	// Mark as closed. Do before releasing the lock to writeFullState
+	// Mark as closing. Do before releasing the lock to writeFullState
 	// so we don't end up with this function running more than once.
-	fs.closed = true
+	fs.closing = true
 
 	fs.checkAndFlushAllBlocks()
 	fs.closeAllMsgBlocks(false)
@@ -7223,7 +7224,10 @@ func (fs *fileStore) Stop() error {
 	fs.cancelAgeChk()
 
 	// Release the state flusher loop.
-	close(fs.qch)
+	if fs.qch != nil {
+		close(fs.qch)
+		fs.qch = nil
+	}
 
 	// Wait for the state flush loop to exit.
 	fsld := fs.fsld
@@ -7233,7 +7237,9 @@ func (fs *fileStore) Stop() error {
 	fs.writeFullState()
 	fs.mu.Lock()
 
-	// Needs to be cleared after writeFullState has completed.
+	// Mark as closed. Last message block needs to be cleared after
+	// writeFullState has completed.
+	fs.closed = true
 	fs.lmb = nil
 
 	// We should update the upper usage layer on a stop.

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -6512,6 +6512,37 @@ func TestFileStoreLargeFullStateMetaCleanup(t *testing.T) {
 
 }
 
+func TestFileStoreIndexDBExistsAfterShutdown(t *testing.T) {
+	sd := t.TempDir()
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: sd},
+		StreamConfig{Name: "zzz", Subjects: []string{">"}, Storage: FileStorage})
+	require_NoError(t, err)
+
+	subj, _ := "foo.bar.baz", bytes.Repeat([]byte("ABC"), 33) // ~100bytes
+	for i := 0; i < 1000; i++ {
+		fs.StoreMsg(subj, nil, nil)
+	}
+
+	idxFile := filepath.Join(sd, msgDir, streamStreamStateFile)
+
+	fs.mu.Lock()
+	fs.dirty = 1
+	if err := os.Remove(idxFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Fatal(err)
+	}
+	fs.mu.Unlock()
+
+	fs.Stop()
+
+	checkFor(t, time.Second, 50*time.Millisecond, func() error {
+		if _, err := os.Stat(idxFile); err != nil {
+			return fmt.Errorf("%q doesn't exist", idxFile)
+		}
+		return nil
+	})
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // Benchmarks
 ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The lock was briefly released to run `writeFullState`, but `fs.closed` wasn't set by that point, so another `Stop()` call could run and panic on closing the `qch` which was already closed.

Signed-off-by: Neil Twigg <neil@nats.io>