### PR TITLE
[IMPROVED] When we are linear scanning for first message, check if start < mb.first.seq.

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -6509,7 +6509,6 @@ func TestFileStoreLargeFullStateMetaCleanup(t *testing.T) {
 		}
 		return nil
 	})
-
 }
 
 func TestFileStoreIndexDBExistsAfterShutdown(t *testing.T) {


### PR DESCRIPTION
In cases where msg blocks have msgs but many have been deleted from the front, this speeds that up significantly.

Signed-off-by: Derek Collison <derek@nats.io>