### PR TITLE
Only drop firstSeq under DiscardOld policy.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -3237,6 +3237,9 @@ func (fs *fileStore) firstSeqForSubj(subj string) (uint64, error) {
 // Will check the msg limit and drop firstSeq msg if needed.
 // Lock should be held.
 func (fs *fileStore) enforceMsgLimit() {
+	if fs.cfg.Discard != DiscardOld {
+		return
+	}
 	if fs.cfg.MaxMsgs <= 0 || fs.state.Msgs <= uint64(fs.cfg.MaxMsgs) {
 		return
 	}
@@ -3251,6 +3254,9 @@ func (fs *fileStore) enforceMsgLimit() {
 // Will check the bytes limit and drop msgs if needed.
 // Lock should be held.
 func (fs *fileStore) enforceBytesLimit() {
+	if fs.cfg.Discard != DiscardOld {
+		return
+	}
 	if fs.cfg.MaxBytes <= 0 || fs.state.Bytes <= uint64(fs.cfg.MaxBytes) {
 		return
 	}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -550,6 +550,9 @@ func (ms *memStore) enforcePerSubjectLimit(subj string, ss *SimpleState) {
 // Will check the msg limit and drop firstSeq msg if needed.
 // Lock should be held.
 func (ms *memStore) enforceMsgLimit() {
+	if ms.cfg.Discard != DiscardOld {
+		return
+	}
 	if ms.cfg.MaxMsgs <= 0 || ms.state.Msgs <= uint64(ms.cfg.MaxMsgs) {
 		return
 	}
@@ -561,6 +564,9 @@ func (ms *memStore) enforceMsgLimit() {
 // Will check the bytes limit and drop msgs if needed.
 // Lock should be held.
 func (ms *memStore) enforceBytesLimit() {
+	if ms.cfg.Discard != DiscardOld {
+		return
+	}
 	if ms.cfg.MaxBytes <= 0 || ms.state.Bytes <= uint64(ms.cfg.MaxBytes) {
 		return
 	}


### PR DESCRIPTION
No matter how a DiscardNew stream has gotten into a state where it is exceeding its configured limits, it it is never appropriate to fall back to DiscardOld behavior.  Applications rely on message durability after receiving delivery acknowledgement from a DiscardNew stream.

This patch adds a safety check to filestore's and memstore's limit reconciliation functions to prevent them from silently discarding a stream's first messages unless DiscardOld is configured.

Resolves #4775.  Silent data loss: enforceMsgLimit() and enforceBytesLimit() should never modify streams configured with DiscardPolicy.NEW

Related to #4771, where a nearby bug in message size calculation caused silent data loss.