### PR TITLE
[IMPROVED] Memory usage for large subject space streams

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4153,7 +4153,7 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 	}
 
 	// Pick correct "to" subject. If we matched on a wildcard use the literal publish subject.
-	to, subject := si.to, bytesToString(c.pa.subject)
+	to, subject := si.to, string(c.pa.subject)
 
 	if si.tr != nil {
 		// FIXME(dlc) - This could be slow, may want to look at adding cache to bare transforms?
@@ -5024,8 +5024,8 @@ func (c *client) processSubsOnConfigReload(awcsti map[string]struct{}) {
 	for _, sub := range c.subs {
 		// Just checking to rebuild mperms under the lock, will collect removed though here.
 		// Only collect under subs array of canSubscribe and checkAcc true.
-		canSub := c.canSubscribe(bytesToString(sub.subject))
-		canQSub := sub.queue != nil && c.canSubscribe(bytesToString(sub.subject), bytesToString(sub.queue))
+		canSub := c.canSubscribe(string(sub.subject))
+		canQSub := sub.queue != nil && c.canSubscribe(string(sub.subject), string(sub.queue))
 
 		if !canSub && !canQSub {
 			removed = append(removed, sub)
@@ -5238,7 +5238,7 @@ func (c *client) reconnect() {
 		rid := c.route.remoteID
 		rtype := c.route.routeType
 		rurl := c.route.url
-		accName := bytesToString(c.route.accName)
+		accName := string(c.route.accName)
 		checkRID := accName == _EMPTY_ && srv.getOpts().Cluster.PoolSize < 1 && rid != _EMPTY_
 		c.mu.Unlock()
 
@@ -5335,7 +5335,7 @@ func (c *client) getAccAndResultFromCache() (*Account, *SublistResult) {
 			acc = c.acc
 		} else {
 			// Match correct account and sublist.
-			if acc, _ = c.srv.LookupAccount(bytesToString(c.pa.account)); acc == nil {
+			if acc, _ = c.srv.LookupAccount(string(c.pa.account)); acc == nil {
 				return nil, nil
 			}
 		}

--- a/server/client.go
+++ b/server/client.go
@@ -1834,11 +1834,11 @@ func (c *client) traceOutOp(op string, arg []byte) {
 
 func (c *client) traceOp(format, op string, arg []byte) {
 	opa := []interface{}{}
-	if op != "" {
+	if op != _EMPTY_ {
 		opa = append(opa, op)
 	}
 	if arg != nil {
-		opa = append(opa, string(arg))
+		opa = append(opa, bytesToString(arg))
 	}
 	c.Tracef(format, opa)
 }
@@ -2531,7 +2531,7 @@ func (c *client) processHeaderPub(arg []byte) error {
 		c.maxPayloadViolation(c.pa.size, maxPayload)
 		return ErrMaxPayload
 	}
-	if c.opts.Pedantic && !IsValidLiteralSubject(string(c.pa.subject)) {
+	if c.opts.Pedantic && !IsValidLiteralSubject(bytesToString(c.pa.subject)) {
 		c.sendErr("Invalid Publish Subject")
 	}
 	return nil
@@ -2584,7 +2584,7 @@ func (c *client) processPub(arg []byte) error {
 		c.maxPayloadViolation(c.pa.size, maxPayload)
 		return ErrMaxPayload
 	}
-	if c.opts.Pedantic && !IsValidLiteralSubject(string(c.pa.subject)) {
+	if c.opts.Pedantic && !IsValidLiteralSubject(bytesToString(c.pa.subject)) {
 		c.sendErr("Invalid Publish Subject")
 	}
 	return nil
@@ -2660,7 +2660,7 @@ func (c *client) processSubEx(subject, queue, bsid []byte, cb msgHandler, noForw
 	acc := c.acc
 	srv := c.srv
 
-	sid := string(sub.sid)
+	sid := bytesToString(sub.sid)
 
 	// This check does not apply to SYSTEM or JETSTREAM or ACCOUNT clients (because they don't have a `nc`...)
 	if c.isClosed() && (kind != SYSTEM && kind != JETSTREAM && kind != ACCOUNT) {
@@ -2795,7 +2795,7 @@ func (c *client) addShadowSubscriptions(acc *Account, sub *subscription, enact b
 		acc.mu.RUnlock()
 		return nil
 	}
-	subj := string(sub.subject)
+	subj := bytesToString(sub.subject)
 	if len(acc.imports.streams) > 0 {
 		tokens = tokenizeSubjectIntoSlice(tsa[:0], subj)
 		for _, tk := range tokens {
@@ -2903,7 +2903,7 @@ func (c *client) addShadowSub(sub *subscription, ime *ime, enact bool) (*subscri
 		if im.rtr == nil {
 			im.rtr = im.tr.reverse()
 		}
-		s := string(nsub.subject)
+		s := bytesToString(nsub.subject)
 		if ime.overlapSubj != _EMPTY_ {
 			s = ime.overlapSubj
 		}
@@ -3000,7 +3000,7 @@ func queueMatches(queue string, qsubs [][]*subscription) bool {
 	}
 	for _, qsub := range qsubs {
 		qs := qsub[0]
-		qname := string(qs.queue)
+		qname := bytesToString(qs.queue)
 
 		// NOTE: '*' and '>' tokens can also be valid
 		// queue names so we first check against the
@@ -3020,9 +3020,7 @@ func (c *client) unsubscribe(acc *Account, sub *subscription, force, remove bool
 
 	c.mu.Lock()
 	if !force && sub.max > 0 && sub.nm < sub.max {
-		c.Debugf(
-			"Deferring actual UNSUB(%s): %d max, %d received",
-			string(sub.subject), sub.max, sub.nm)
+		c.Debugf("Deferring actual UNSUB(%s): %d max, %d received", sub.subject, sub.max, sub.nm)
 		c.mu.Unlock()
 		return
 	}
@@ -3034,7 +3032,7 @@ func (c *client) unsubscribe(acc *Account, sub *subscription, force, remove bool
 	// Remove accounting if requested. This will be false when we close a connection
 	// with open subscriptions.
 	if remove {
-		delete(c.subs, string(sub.sid))
+		delete(c.subs, bytesToString(sub.sid))
 		if acc != nil {
 			acc.sl.Remove(sub)
 		}
@@ -3194,7 +3192,7 @@ func (c *client) msgHeaderForRouteOrLeaf(subj, reply []byte, rt *routeTarget, ac
 		// Remap subject if its a shadow subscription, treat like a normal client.
 		if rt.sub.im != nil {
 			if rt.sub.im.tr != nil {
-				to := rt.sub.im.tr.TransformSubject(string(subj))
+				to := rt.sub.im.tr.TransformSubject(bytesToString(subj))
 				subj = []byte(to)
 			} else if !rt.sub.im.usePub {
 				subj = []byte(rt.sub.im.to)
@@ -3367,7 +3365,7 @@ func (c *client) deliverMsg(prodIsMQTT bool, sub *subscription, acc *Account, su
 			// still process the message in hand, otherwise
 			// unsubscribe and drop message on the floor.
 			if sub.nm == sub.max {
-				client.Debugf("Auto-unsubscribe limit of %d reached for sid '%s'", sub.max, string(sub.sid))
+				client.Debugf("Auto-unsubscribe limit of %d reached for sid '%s'", sub.max, sub.sid)
 				// Due to defer, reverse the code order so that execution
 				// is consistent with other cases where we unsubscribe.
 				if shouldForward {
@@ -3503,7 +3501,7 @@ func (c *client) deliverMsg(prodIsMQTT bool, sub *subscription, acc *Account, su
 	c.addToPCD(client)
 
 	if client.trace {
-		client.traceOutOp(string(mh[:len(mh)-LEN_CR_LF]), nil)
+		client.traceOutOp(bytesToString(mh[:len(mh)-LEN_CR_LF]), nil)
 	}
 
 	client.mu.Unlock()
@@ -3699,7 +3697,7 @@ func (c *client) pubAllowedFullCheck(subject string, fullCheck, hasLock bool) bo
 		}
 	} else {
 		// Update our cache here.
-		c.perms.pcache.Store(string(subject), allowed)
+		c.perms.pcache.Store(subject, allowed)
 		if n := atomic.AddInt32(&c.perms.pcsz, 1); n > maxPermCacheSize {
 			c.prunePubPermsCache()
 		}
@@ -3711,7 +3709,7 @@ func (c *client) pubAllowedFullCheck(subject string, fullCheck, hasLock bool) bo
 func isServiceReply(reply []byte) bool {
 	// This function is inlined and checking this way is actually faster
 	// than byte-by-byte comparison.
-	return len(reply) > 3 && string(reply[:4]) == replyPrefix
+	return len(reply) > 3 && bytesToString(reply[:4]) == replyPrefix
 }
 
 // Test whether a reply subject is a service import or a gateway routed reply.
@@ -3721,9 +3719,9 @@ func isReservedReply(reply []byte) bool {
 	}
 	rLen := len(reply)
 	// Faster to check with string([:]) than byte-by-byte
-	if rLen > jsAckPreLen && string(reply[:jsAckPreLen]) == jsAckPre {
+	if rLen > jsAckPreLen && bytesToString(reply[:jsAckPreLen]) == jsAckPre {
 		return true
-	} else if rLen > gwReplyPrefixLen && string(reply[:gwReplyPrefixLen]) == gwReplyPrefix {
+	} else if rLen > gwReplyPrefixLen && bytesToString(reply[:gwReplyPrefixLen]) == gwReplyPrefix {
 		return true
 	}
 	return false
@@ -3745,7 +3743,7 @@ func (c *client) processInboundMsg(msg []byte) {
 
 // selectMappedSubject will choose the mapped subject based on the client's inbound subject.
 func (c *client) selectMappedSubject() bool {
-	nsubj, changed := c.acc.selectMappedSubject(string(c.pa.subject))
+	nsubj, changed := c.acc.selectMappedSubject(bytesToString(c.pa.subject))
 	if changed {
 		c.pa.mapped = c.pa.subject
 		c.pa.subject = []byte(nsubj)
@@ -3821,7 +3819,7 @@ func (c *client) processInboundClientMsg(msg []byte) (bool, bool) {
 		c.mu.Lock()
 		rl := c.rrTracking.rmap[string(c.pa.subject)]
 		if rl != nil {
-			delete(c.rrTracking.rmap, string(c.pa.subject))
+			delete(c.rrTracking.rmap, bytesToString(c.pa.subject))
 		}
 		c.mu.Unlock()
 
@@ -3861,6 +3859,7 @@ func (c *client) processInboundClientMsg(msg []byte) (bool, bool) {
 
 	// Go back to the sublist data structure.
 	if !ok {
+		// Match may use the subject here to populate a cache, so can not use bytesToString here.
 		r = acc.sl.Match(string(c.pa.subject))
 		if len(r.psubs)+len(r.qsubs) > 0 {
 			c.in.results[string(c.pa.subject)] = r
@@ -4105,7 +4104,7 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 	var checkJS bool
 	shouldReturn := si.invalid || acc.sl == nil
 	if !shouldReturn && !isResponse && si.to == jsAllAPI {
-		subj := string(c.pa.subject)
+		subj := bytesToString(c.pa.subject)
 		if strings.HasPrefix(subj, jsRequestNextPre) || strings.HasPrefix(subj, jsDirectGetPre) {
 			checkJS = true
 		}
@@ -4154,7 +4153,7 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 	}
 
 	// Pick correct "to" subject. If we matched on a wildcard use the literal publish subject.
-	to, subject := si.to, string(c.pa.subject)
+	to, subject := si.to, bytesToString(c.pa.subject)
 
 	if si.tr != nil {
 		// FIXME(dlc) - This could be slow, may want to look at adding cache to bare transforms?
@@ -4215,7 +4214,7 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 		// Set clientInfo if present.
 		if ci != nil {
 			if b, _ := json.Marshal(ci); b != nil {
-				msg = c.setHeader(ClientInfoHdr, string(b), msg)
+				msg = c.setHeader(ClientInfoHdr, bytesToString(b), msg)
 			}
 		}
 	}
@@ -4447,7 +4446,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 				continue
 			}
 			if sub.im.tr != nil {
-				to := sub.im.tr.TransformSubject(string(subject))
+				to := sub.im.tr.TransformSubject(bytesToString(subject))
 				dsubj = append(_dsubj[:0], to...)
 			} else if sub.im.usePub {
 				dsubj = append(_dsubj[:0], subj...)
@@ -4600,7 +4599,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 					continue
 				}
 				if sub.im.tr != nil {
-					to := sub.im.tr.TransformSubject(string(subject))
+					to := sub.im.tr.TransformSubject(bytesToString(subject))
 					dsubj = append(_dsubj[:0], to...)
 				} else if sub.im.usePub {
 					dsubj = append(_dsubj[:0], subj...)
@@ -4677,7 +4676,7 @@ sendToRoutesOrLeafs:
 		if dc.kind == LEAF {
 			// Check two scenarios. One is inbound from a route (c.pa.origin)
 			if c.kind == ROUTER && len(c.pa.origin) > 0 {
-				if string(c.pa.origin) == dc.remoteCluster() {
+				if bytesToString(c.pa.origin) == dc.remoteCluster() {
 					continue
 				}
 			}
@@ -4737,7 +4736,7 @@ func (c *client) checkLeafClientInfoHeader(msg []byte) (dmsg []byte, setHdr bool
 			if ci.Account != remoteAcc {
 				ci.Account = remoteAcc
 				if b, _ := json.Marshal(ci); b != nil {
-					dmsg, setHdr = c.setHeader(ClientInfoHdr, string(b), msg), true
+					dmsg, setHdr = c.setHeader(ClientInfoHdr, bytesToString(b), msg), true
 				}
 			}
 		}
@@ -5025,8 +5024,8 @@ func (c *client) processSubsOnConfigReload(awcsti map[string]struct{}) {
 	for _, sub := range c.subs {
 		// Just checking to rebuild mperms under the lock, will collect removed though here.
 		// Only collect under subs array of canSubscribe and checkAcc true.
-		canSub := c.canSubscribe(string(sub.subject))
-		canQSub := sub.queue != nil && c.canSubscribe(string(sub.subject), string(sub.queue))
+		canSub := c.canSubscribe(bytesToString(sub.subject))
+		canQSub := sub.queue != nil && c.canSubscribe(bytesToString(sub.subject), bytesToString(sub.queue))
 
 		if !canSub && !canQSub {
 			removed = append(removed, sub)
@@ -5162,7 +5161,8 @@ func (c *client) closeConnection(reason ClosedState) {
 					if kind == LEAF {
 						num = sub.qw
 					}
-					key := string(sub.subject) + " " + string(sub.queue)
+					// TODO(dlc) - Better to use string builder?
+					key := bytesToString(sub.subject) + " " + bytesToString(sub.queue)
 					if esub, ok := qsubs[key]; ok {
 						esub.n += num
 					} else {
@@ -5238,7 +5238,7 @@ func (c *client) reconnect() {
 		rid := c.route.remoteID
 		rtype := c.route.routeType
 		rurl := c.route.url
-		accName := string(c.route.accName)
+		accName := bytesToString(c.route.accName)
 		checkRID := accName == _EMPTY_ && srv.getOpts().Cluster.PoolSize < 1 && rid != _EMPTY_
 		c.mu.Unlock()
 
@@ -5323,7 +5323,7 @@ func (c *client) getAccAndResultFromCache() (*Account, *SublistResult) {
 
 		if genid := atomic.LoadUint64(&sl.genid); genid != pac.genid {
 			ok = false
-			delete(c.in.pacache, string(c.pa.pacache))
+			delete(c.in.pacache, bytesToString(c.pa.pacache))
 		} else {
 			acc = pac.acc
 			r = pac.results
@@ -5335,7 +5335,7 @@ func (c *client) getAccAndResultFromCache() (*Account, *SublistResult) {
 			acc = c.acc
 		} else {
 			// Match correct account and sublist.
-			if acc, _ = c.srv.LookupAccount(string(c.pa.account)); acc == nil {
+			if acc, _ = c.srv.LookupAccount(bytesToString(c.pa.account)); acc == nil {
 				return nil, nil
 			}
 		}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -5681,7 +5681,7 @@ func TestFileStoreMsgBlockHolesAndIndexing(t *testing.T) {
 		sm, _, err := mb.fetchMsg(seq, nil)
 		require_NoError(t, err)
 		require_Equal(t, sm.subj, expectedSubj)
-		require_True(t, bytes.Equal(sm.buf, []byte(expectedSubj)))
+		require_True(t, bytes.Equal(sm.buf[:len(expectedSubj)], []byte(expectedSubj)))
 	}
 
 	writeMsg("A", 2)

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1963,7 +1963,7 @@ func (c *client) processGatewayRSub(arg []byte) error {
 	// If callUpdate is true, srv and sub will be not nil.
 	defer func() {
 		if callUpdate {
-			srv.updateInterestForAccountOnGateway(bytesToString(accName), sub, 1)
+			srv.updateInterestForAccountOnGateway(string(accName), sub, 1)
 		}
 	}()
 

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 The NATS Authors
+// Copyright 2018-2023 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -1225,22 +1225,22 @@ func (s *Server) forwardNewGatewayToLocalCluster(oinfo *Info) {
 // messages from the remote's outbound connection. This side is
 // the one sending the subscription interest.
 func (s *Server) sendQueueSubsToGateway(c *client) {
-	s.sendSubsToGateway(c, nil)
+	s.sendSubsToGateway(c, _EMPTY_)
 }
 
 // Sends all subscriptions for the given account to the remove gateway
 // This is sent from the inbound side, that is, the side that receives
 // messages from the remote's outbound connection. This side is
 // the one sending the subscription interest.
-func (s *Server) sendAccountSubsToGateway(c *client, accName []byte) {
+func (s *Server) sendAccountSubsToGateway(c *client, accName string) {
 	s.sendSubsToGateway(c, accName)
 }
 
-func gwBuildSubProto(buf *bytes.Buffer, accName []byte, acc map[string]*sitally, doQueues bool) {
+func gwBuildSubProto(buf *bytes.Buffer, accName string, acc map[string]*sitally, doQueues bool) {
 	for saq, si := range acc {
 		if doQueues && si.q || !doQueues && !si.q {
 			buf.Write(rSubBytes)
-			buf.Write(accName)
+			buf.WriteString(accName)
 			buf.WriteByte(' ')
 			// For queue subs (si.q is true), saq will be
 			// subject + ' ' + queue, for plain subs, this is
@@ -1255,7 +1255,7 @@ func gwBuildSubProto(buf *bytes.Buffer, accName []byte, acc map[string]*sitally,
 }
 
 // Sends subscriptions to remote gateway.
-func (s *Server) sendSubsToGateway(c *client, accountName []byte) {
+func (s *Server) sendSubsToGateway(c *client, accountName string) {
 	var (
 		bufa = [32 * 1024]byte{}
 		bbuf = bytes.NewBuffer(bufa[:0])
@@ -1268,22 +1268,22 @@ func (s *Server) sendSubsToGateway(c *client, accountName []byte) {
 	defer gw.pasi.Unlock()
 
 	// If account is specified...
-	if accountName != nil {
+	if accountName != _EMPTY_ {
 		// Simply send all plain subs (no queues) for this specific account
-		gwBuildSubProto(bbuf, accountName, gw.pasi.m[string(accountName)], false)
+		gwBuildSubProto(bbuf, accountName, gw.pasi.m[accountName], false)
 		// Instruct to send all subs (RS+/-) for this account from now on.
 		c.mu.Lock()
-		e := c.gw.insim[string(accountName)]
+		e := c.gw.insim[accountName]
 		if e == nil {
 			e = &insie{}
-			c.gw.insim[string(accountName)] = e
+			c.gw.insim[accountName] = e
 		}
 		e.mode = InterestOnly
 		c.mu.Unlock()
 	} else {
 		// Send queues for all accounts
 		for accName, acc := range gw.pasi.m {
-			gwBuildSubProto(bbuf, []byte(accName), acc, true)
+			gwBuildSubProto(bbuf, accName, acc, true)
 		}
 	}
 
@@ -1899,7 +1899,7 @@ func (c *client) processGatewayRUnsub(arg []byte) error {
 			return nil
 		}
 		if e.sl.Remove(sub) == nil {
-			delete(c.subs, string(key))
+			delete(c.subs, bytesToString(key))
 			if queue != nil {
 				e.qsubs--
 				atomic.AddInt64(&c.srv.gateway.totalQSubs, -1)
@@ -1963,7 +1963,7 @@ func (c *client) processGatewayRSub(arg []byte) error {
 	// If callUpdate is true, srv and sub will be not nil.
 	defer func() {
 		if callUpdate {
-			srv.updateInterestForAccountOnGateway(string(accName), sub, 1)
+			srv.updateInterestForAccountOnGateway(bytesToString(accName), sub, 1)
 		}
 	}()
 
@@ -1976,7 +1976,7 @@ func (c *client) processGatewayRSub(arg []byte) error {
 	}
 	defer c.mu.Unlock()
 
-	ei, _ := c.gw.outsim.Load(string(accName))
+	ei, _ := c.gw.outsim.Load(bytesToString(accName))
 	// We should always have an existing entry for plain subs because
 	// in optimistic mode we would have received RS- first, and
 	// in full knowledge, we are receiving RS+ for an account after
@@ -2038,7 +2038,7 @@ func (c *client) processGatewayRSub(arg []byte) error {
 		srv = c.srv
 		callUpdate = true
 	} else {
-		subj := string(subject)
+		subj := bytesToString(subject)
 		// If this is an RS+ for a wc subject, then
 		// remove from the no interest map all subjects
 		// that are a subset of this wc subject.
@@ -2149,8 +2149,8 @@ func (s *Server) maybeSendSubOrUnsubToGateways(accName string, sub *subscription
 		accProtoa [256]byte
 		accProto  []byte
 		proto     []byte
-		subject   = string(sub.subject)
-		hasWc     = subjectHasWildcard(subject)
+		subject   = bytesToString(sub.subject)
+		hasWC     = subjectHasWildcard(subject)
 	)
 	for _, c := range gws {
 		proto = nil
@@ -2165,7 +2165,7 @@ func (s *Server) maybeSendSubOrUnsubToGateways(accName string, sub *subscription
 				// For wildcard subjects, we will remove from our no-interest
 				// map, all subjects that are a subset of this wc subject, but we
 				// still send the wc subject and let the remote do its own cleanup.
-				if hasWc {
+				if hasWC {
 					for enis := range e.ni {
 						if subjectIsSubsetMatch(enis, subject) {
 							delete(e.ni, enis)
@@ -2337,7 +2337,7 @@ func (s *Server) gatewayUpdateSubInterest(accName string, sub *subscription, cha
 	} else {
 		entry.n += change
 		if entry.n <= 0 {
-			delete(st, string(key))
+			delete(st, bytesToString(key))
 			last = true
 			if len(st) == 0 {
 				delete(accMap, accName)
@@ -2381,7 +2381,7 @@ func (s *Server) gatewayUpdateSubInterest(accName string, sub *subscription, cha
 // that is, starts with $GNR and is long enough to contain cluster/server hash
 // and subject.
 func isGWRoutedReply(subj []byte) bool {
-	return len(subj) > gwSubjectOffset && string(subj[:gwReplyPrefixLen]) == gwReplyPrefix
+	return len(subj) > gwSubjectOffset && bytesToString(subj[:gwReplyPrefixLen]) == gwReplyPrefix
 }
 
 // Same than isGWRoutedReply but accepts the old prefix $GR and returns
@@ -2390,7 +2390,7 @@ func isGWRoutedSubjectAndIsOldPrefix(subj []byte) (bool, bool) {
 	if isGWRoutedReply(subj) {
 		return true, false
 	}
-	if len(subj) > oldGWReplyStart && string(subj[:oldGWReplyPrefixLen]) == oldGWReplyPrefix {
+	if len(subj) > oldGWReplyStart && bytesToString(subj[:oldGWReplyPrefixLen]) == oldGWReplyPrefix {
 		return true, true
 	}
 	return false, false
@@ -2399,7 +2399,7 @@ func isGWRoutedSubjectAndIsOldPrefix(subj []byte) (bool, bool) {
 // Returns true if subject starts with "$GNR.". This is to check that
 // clients can't publish on this subject.
 func hasGWRoutedReplyPrefix(subj []byte) bool {
-	return len(subj) > gwReplyPrefixLen && string(subj[:gwReplyPrefixLen]) == gwReplyPrefix
+	return len(subj) > gwReplyPrefixLen && bytesToString(subj[:gwReplyPrefixLen]) == gwReplyPrefix
 }
 
 // Evaluates if the given reply should be mapped or not.
@@ -2455,7 +2455,6 @@ func (c *client) sendMsgToGateways(acc *Account, msg, subject, reply []byte, qgr
 		return false
 	}
 	var (
-		subj       = string(subject)
 		queuesa    = [512]byte{}
 		queues     = queuesa[:0]
 		accName    = acc.Name
@@ -2499,7 +2498,7 @@ func (c *client) sendMsgToGateways(acc *Account, msg, subject, reply []byte, qgr
 			}
 		} else {
 			// Plain sub interest and queue sub results for this account/subject
-			psi, qr := gwc.gatewayInterest(accName, subj)
+			psi, qr := gwc.gatewayInterest(accName, string(subject))
 			if !psi && qr == nil {
 				continue
 			}
@@ -2760,11 +2759,11 @@ func (s *Server) removeRouteByHash(srvIDHash string) {
 // Returns the route with given hash or nil if not found.
 // This is for gateways only.
 func (s *Server) getRouteByHash(hash, accName []byte) (*client, bool) {
-	id := string(hash)
+	id := bytesToString(hash)
 	var perAccount bool
-	if v, ok := s.accRouteByHash.Load(string(accName)); ok {
+	if v, ok := s.accRouteByHash.Load(bytesToString(accName)); ok {
 		if v == nil {
-			id += string(accName)
+			id += bytesToString(accName)
 			perAccount = true
 		} else {
 			id += strconv.Itoa(v.(int))
@@ -2774,7 +2773,7 @@ func (s *Server) getRouteByHash(hash, accName []byte) (*client, bool) {
 		return v.(*client), perAccount
 	} else if !perAccount {
 		// Check if we have a "no pool" connection at index 0.
-		if v, ok := s.gateway.routesIDByHash.Load(string(hash) + "0"); ok {
+		if v, ok := s.gateway.routesIDByHash.Load(bytesToString(hash) + "0"); ok {
 			if r := v.(*client); r != nil {
 				r.mu.Lock()
 				noPool := r.route.noPool
@@ -3051,13 +3050,13 @@ func (c *client) gatewayAllSubsReceiveStart(info *Info) {
 // <Invoked from outbound connection's readLoop>
 func (c *client) gatewayAllSubsReceiveComplete(info *Info) {
 	account := getAccountFromGatewayCommand(c, info, "complete")
-	if account == "" {
+	if account == _EMPTY_ {
 		return
 	}
 	// Done receiving all subs from remote. Set the `ni`
 	// map to nil so that gatewayInterest() no longer
 	// uses it.
-	ei, _ := c.gw.outsim.Load(string(account))
+	ei, _ := c.gw.outsim.Load(account)
 	if ei != nil {
 		e := ei.(*outsie)
 		// Needs locking here since `ni` is checked by
@@ -3077,7 +3076,7 @@ func getAccountFromGatewayCommand(c *client, info *Info, cmd string) string {
 	if info.GatewayCmdPayload == nil {
 		c.sendErrAndErr(fmt.Sprintf("Account absent from receive-all-subscriptions-%s command", cmd))
 		c.closeConnection(ProtocolViolation)
-		return ""
+		return _EMPTY_
 	}
 	return string(info.GatewayCmdPayload)
 }
@@ -3113,7 +3112,7 @@ func (c *client) gatewaySwitchAccountToSendAllSubs(e *insie, accName string) {
 		info := Info{
 			Gateway:           s.gateway.name,
 			GatewayCmd:        cmd,
-			GatewayCmdPayload: []byte(accName),
+			GatewayCmdPayload: stringToBytes(accName),
 		}
 
 		b, _ := json.Marshal(&info)
@@ -3138,7 +3137,7 @@ func (c *client) gatewaySwitchAccountToSendAllSubs(e *insie, accName string) {
 	s.startGoRoutine(func() {
 		defer s.grWG.Done()
 
-		s.sendAccountSubsToGateway(c, []byte(accName))
+		s.sendAccountSubsToGateway(c, accName)
 		// Send the complete command. When the remote receives
 		// this, it will not send a message unless it has a
 		// matching sub from us.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7245,7 +7245,7 @@ func decodeStreamMsg(buf []byte) (subject, reply string, hdr, msg []byte, lseq u
 	if len(buf) < rl {
 		return _EMPTY_, _EMPTY_, nil, nil, 0, 0, errBadStreamMsg
 	}
-	reply = bytesToString(buf[:rl])
+	reply = string(buf[:rl])
 	buf = buf[rl:]
 	if len(buf) < 2 {
 		return _EMPTY_, _EMPTY_, nil, nil, 0, 0, errBadStreamMsg

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7235,7 +7235,7 @@ func decodeStreamMsg(buf []byte) (subject, reply string, hdr, msg []byte, lseq u
 	if len(buf) < sl {
 		return _EMPTY_, _EMPTY_, nil, nil, 0, 0, errBadStreamMsg
 	}
-	subject = bytesToString(buf[:sl])
+	subject = string(buf[:sl])
 	buf = buf[sl:]
 	if len(buf) < 2 {
 		return _EMPTY_, _EMPTY_, nil, nil, 0, 0, errBadStreamMsg

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7235,7 +7235,7 @@ func decodeStreamMsg(buf []byte) (subject, reply string, hdr, msg []byte, lseq u
 	if len(buf) < sl {
 		return _EMPTY_, _EMPTY_, nil, nil, 0, 0, errBadStreamMsg
 	}
-	subject = string(buf[:sl])
+	subject = bytesToString(buf[:sl])
 	buf = buf[sl:]
 	if len(buf) < 2 {
 		return _EMPTY_, _EMPTY_, nil, nil, 0, 0, errBadStreamMsg
@@ -7245,7 +7245,7 @@ func decodeStreamMsg(buf []byte) (subject, reply string, hdr, msg []byte, lseq u
 	if len(buf) < rl {
 		return _EMPTY_, _EMPTY_, nil, nil, 0, 0, errBadStreamMsg
 	}
-	reply = string(buf[:rl])
+	reply = bytesToString(buf[:rl])
 	buf = buf[rl:]
 	if len(buf) < 2 {
 		return _EMPTY_, _EMPTY_, nil, nil, 0, 0, errBadStreamMsg

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -158,7 +158,7 @@ func (s *Server) solicitLeafNodeRemotes(remotes []*RemoteLeafOpts) {
 				s.Errorf("LeafNode Remote Credentials file %q malformed", creds)
 			} else if _, err := nkeys.FromSeed(items[1][1]); err != nil {
 				s.Errorf("LeafNode Remote Credentials file %q has malformed seed", creds)
-			} else if uc, err := jwt.DecodeUserClaims(string(items[0][1])); err != nil {
+			} else if uc, err := jwt.DecodeUserClaims(bytesToString(items[0][1])); err != nil {
 				s.Errorf("LeafNode Remote Credentials file %q has malformed user jwt", creds)
 			} else if isSysAccRemote {
 				if !uc.Permissions.Pub.Empty() || !uc.Permissions.Sub.Empty() || uc.Permissions.Resp != nil {
@@ -828,7 +828,7 @@ func (c *client) sendLeafConnect(clusterName string, headers bool) error {
 
 		sigraw, _ := kp.Sign(c.nonce)
 		sig := base64.RawURLEncoding.EncodeToString(sigraw)
-		cinfo.JWT = string(tmp)
+		cinfo.JWT = bytesToString(tmp)
 		cinfo.Sig = sig
 	} else if userInfo := c.leaf.remote.curURL.User; userInfo != nil {
 		cinfo.User = userInfo.Username()
@@ -1039,7 +1039,7 @@ func (s *Server) createLeafNode(conn net.Conn, rURL *url.URL, remote *leafNodeCf
 		// Remember the nonce we sent here for signatures, etc.
 		c.nonce = make([]byte, nonceLen)
 		copy(c.nonce, nonce[:])
-		info.Nonce = string(c.nonce)
+		info.Nonce = bytesToString(c.nonce)
 		info.CID = c.cid
 		proto := generateInfoJSON(info)
 		if !opts.LeafNode.TLSHandshakeFirst {
@@ -1363,7 +1363,7 @@ func (s *Server) negotiateLeafCompression(c *client, didSolicit bool, infoCompre
 	cid := c.cid
 	var nonce string
 	if !didSolicit {
-		nonce = string(c.nonce)
+		nonce = bytesToString(c.nonce)
 	}
 	c.mu.Unlock()
 
@@ -1970,16 +1970,15 @@ func (s *Server) initLeafNodeSmapAndSendSubs(c *client) {
 	rc := c.leaf.remoteCluster
 	c.leaf.smap = make(map[string]int32)
 	for _, sub := range subs {
-		subj := string(sub.subject)
 		// Check perms regardless of role.
-		if !c.canSubscribe(subj) {
-			c.Debugf("Not permitted to subscribe to %q on behalf of %s%s", subj, accName, accNTag)
+		if !c.canSubscribe(bytesToString(sub.subject)) {
+			c.Debugf("Not permitted to subscribe to %q on behalf of %s%s", sub.subject, accName, accNTag)
 			continue
 		}
 		// We ignore ourselves here.
 		// Also don't add the subscription if it has a origin cluster and the
 		// cluster name matches the one of the client we are sending to.
-		if c != sub.client && (sub.origin == nil || (string(sub.origin) != rc)) {
+		if c != sub.client && (sub.origin == nil || (bytesToString(sub.origin) != rc)) {
 			count := int32(1)
 			if len(sub.queue) > 0 && sub.qw > 0 {
 				count = sub.qw
@@ -2069,7 +2068,7 @@ func (acc *Account) updateLeafNodes(sub *subscription, delta int32) {
 	// Capture the cluster even if its empty.
 	cluster := _EMPTY_
 	if sub.origin != nil {
-		cluster = string(sub.origin)
+		cluster = bytesToString(sub.origin)
 	}
 
 	// If we have an isolated cluster we can return early, as long as it is not a loop detection subject.
@@ -2087,7 +2086,7 @@ func (acc *Account) updateLeafNodes(sub *subscription, delta int32) {
 	defer acc.lmu.RUnlock()
 
 	// Do this once.
-	subject := string(sub.subject)
+	subject := bytesToString(sub.subject)
 
 	// Walk the connected leafnodes.
 	for _, ln := range acc.lleafs {
@@ -2196,19 +2195,15 @@ func (c *client) sendLeafNodeSubUpdate(key string, n int32) {
 
 // Helper function to build the key.
 func keyFromSub(sub *subscription) string {
-	var _rkey [1024]byte
-	var key []byte
-
+	var sb strings.Builder
+	sb.Grow(len(sub.subject) + len(sub.queue) + 1)
+	sb.Write(sub.subject)
 	if sub.queue != nil {
 		// Just make the key subject spc group, e.g. 'foo bar'
-		key = _rkey[:0]
-		key = append(key, sub.subject...)
-		key = append(key, byte(' '))
-		key = append(key, sub.queue...)
-	} else {
-		key = sub.subject
+		sb.WriteString(" ")
+		sb.Write(sub.queue)
 	}
-	return string(key)
+	return sb.String()
 }
 
 // Lock should be held.
@@ -2281,7 +2276,7 @@ func (c *client) processLeafSub(argo []byte) (err error) {
 	acc := c.acc
 	// Check if we have a loop.
 	ldsPrefix := bytes.HasPrefix(sub.subject, []byte(leafNodeLoopDetectionSubjectPrefix))
-	if ldsPrefix && string(sub.subject) == acc.getLDSubject() {
+	if ldsPrefix && bytesToString(sub.subject) == acc.getLDSubject() {
 		c.mu.Unlock()
 		c.handleLeafNodeLoop(true)
 		return nil
@@ -2298,11 +2293,14 @@ func (c *client) processLeafSub(argo []byte) (err error) {
 	}
 
 	// If we are a hub check that we can publish to this subject.
-	if checkPerms && subjectIsLiteral(string(sub.subject)) && !c.pubAllowedFullCheck(string(sub.subject), true, true) {
-		c.mu.Unlock()
-		c.leafSubPermViolation(sub.subject)
-		c.Debugf(fmt.Sprintf("Permissions Violation for Subscription to %q", sub.subject))
-		return nil
+	if checkPerms {
+		subj := bytesToString(sub.subject)
+		if subjectIsLiteral(subj) && !c.pubAllowedFullCheck(subj, true, true) {
+			c.mu.Unlock()
+			c.leafSubPermViolation(sub.subject)
+			c.Debugf(fmt.Sprintf("Permissions Violation for Subscription to %q", sub.subject))
+			return nil
+		}
 	}
 
 	// Check if we have a maximum on the number of subscriptions.
@@ -2324,7 +2322,7 @@ func (c *client) processLeafSub(argo []byte) (err error) {
 	} else {
 		sub.sid = arg
 	}
-	key := string(sub.sid)
+	key := bytesToString(sub.sid)
 	osub := c.subs[key]
 	updateGWs := false
 	delta := int32(1)

--- a/server/store.go
+++ b/server/store.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"strings"
 	"time"
+	"unsafe"
 
 	"github.com/nats-io/nats-server/v2/server/avl"
 )
@@ -713,4 +714,24 @@ func (sm *StoreMsg) clear() {
 	if len(sm.buf) > 0 {
 		sm.buf = sm.buf[:0]
 	}
+}
+
+// Note this will avoid a copy of the data used for the string, but it will also reference the existing slice's data pointer.
+// So this should be used sparingly when we know the encompassing byte slice's lifetime is the same.
+func bytesToString(b []byte) string {
+	if len(b) == 0 {
+		return _EMPTY_
+	}
+	p := unsafe.SliceData(b)
+	return unsafe.String(p, len(b))
+}
+
+// Same in reverse. Used less often.
+func stringToBytes(s string) []byte {
+	if len(s) == 0 {
+		return nil
+	}
+	p := unsafe.StringData(s)
+	b := unsafe.Slice(p, len(s))
+	return b
 }


### PR DESCRIPTION
Utilize non-allocating string casts to relieve pressure on GC subsystem and refactored subject handling for psim.

Signed-off-by: Derek Collison <derek@nats.io>

