### PR TITLE
Only gather subject filters if we need them

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -812,8 +812,8 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 			return nil, NewJSConsumerWQRequiresExplicitAckError()
 		}
 
-		subjects := gatherSubjectFilters(config.FilterSubject, config.FilterSubjects)
 		if len(mset.consumers) > 0 {
+			subjects := gatherSubjectFilters(config.FilterSubject, config.FilterSubjects)
 			if len(subjects) == 0 {
 				mset.mu.Unlock()
 				return nil, NewJSConsumerWQMultipleUnfilteredError()


### PR DESCRIPTION
This Just moves an assignment inside the if branch where it is used.  It's a micro optimization that's probably not worth making at all, but I came across this when reading the code and thought I could as well change it.

Signed-off-by: Sven Neumann <sven.neumann@holoplot.com>
