### PR TITLE
Tweak consumer monitor logic to avoid potential race

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -5257,23 +5257,30 @@ func gatherSubjectFilters(filter string, filters []string) []string {
 	return filters
 }
 
-// Will check if we are running in the monitor already and if not set the appropriate flag.
-func (o *consumer) checkInMonitor() bool {
+// shouldStartMonitor will return true if we should start a monitor
+// goroutine or will return false if one is already running.
+func (o *consumer) shouldStartMonitor() bool {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
 	if o.inMonitor {
-		return true
+		return false
 	}
+	o.monitorWg.Add(1)
 	o.inMonitor = true
-	return false
+	return true
 }
 
-// Clear us being in the monitor routine.
+// Clear the monitor running state. The monitor goroutine should
+// call this in a defer to clean up on exit.
 func (o *consumer) clearMonitorRunning() {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	o.inMonitor = false
+
+	if o.inMonitor {
+		o.monitorWg.Done()
+		o.inMonitor = false
+	}
 }
 
 // Test whether we are in the monitor routine.


### PR DESCRIPTION
Beforehand the wait group was not adjusted until the goroutine had started, whereas the `inMonitor` state was adjusted before, so it may have been possible to race here. Moving these two things together should hopefully avoid this and I've also renamed a function for clarity.

This should hopefully also fix a potential panic on wait group reuse in some chaos scenarios.

Signed-off-by: Neil Twigg <neil@nats.io>