### PR TITLE
[FIXED] Corruption of subjects on recover of bad or missing index.db

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5093,9 +5093,7 @@ func (mb *msgBlock) indexCacheBuf(buf []byte) error {
 					ss.Msgs++
 					ss.Last = seq
 				} else {
-					// Note the fss cache and the underlying buffer cache are considered
-					// linked and exists and are removed at the same time.
-					mb.fss[bytesToString(bsubj)] = &SimpleState{
+					mb.fss[string(bsubj)] = &SimpleState{
 						Msgs:  1,
 						First: seq,
 						Last:  seq,


### PR DESCRIPTION
When populating the block's fss during a manual recovery, we could hoist the fss to the global PSIM.
This could lead to data corruption since we were not copying. This revert's that change with a test.

The corruption was all internal at the PSIM layer and was not reflected on disk, so a server upgrade will fix with no data corruption.

Resolves: #4842 

Signed-off-by: Derek Collison <derek@nats.io>