### PR TITLE
[FIXED] Protect against bad consumer state with rollback.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -8512,6 +8512,12 @@ func decodeConsumerState(buf []byte) (*ConsumerState, error) {
 		}
 	}
 
+	// Protect ourselves against rolling backwards.
+	const hbit = 1 << 63
+	if state.AckFloor.Stream&hbit != 0 || state.Delivered.Stream&hbit != 0 {
+		return nil, errCorruptState
+	}
+
 	// We have additional stuff.
 	if numPending := readLen(); numPending > 0 {
 		mints := readTimeStamp()


### PR DESCRIPTION
If we had a rollback this could consume lots of memory during checkStateForInterestStream for followers since it will create pre-register acks incorrectly.

Signed-off-by: Derek Collison <derek@nats.io>
