### PR TITLE
[FIXED] When calculating limits exceeded, treat replicated tier limits as flat

### DIFF
--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -422,7 +422,7 @@ func TestJetStreamJWTClusteredTiers(t *testing.T) {
 	accClaim.Limits.JetStreamTieredLimits["R1"] = jwt.JetStreamLimits{
 		DiskStorage: 1100, Consumer: 2, Streams: 2}
 	accClaim.Limits.JetStreamTieredLimits["R3"] = jwt.JetStreamLimits{
-		DiskStorage: 3300, Consumer: 1, Streams: 1}
+		DiskStorage: 1100, Consumer: 1, Streams: 1}
 	accJwt := encodeClaim(t, accClaim, aExpPub)
 	accCreds := newUser(t, accKp)
 	tmlp := `
@@ -555,7 +555,7 @@ func TestJetStreamJWTClusteredTiers(t *testing.T) {
 	require_True(t, r3.Memory == 0)
 	require_True(t, r3.Limits == JetStreamAccountLimits{
 		MaxMemory:            0,
-		MaxStore:             3300,
+		MaxStore:             1100,
 		MaxStreams:           1,
 		MaxConsumers:         1,
 		MaxAckPending:        -1,
@@ -1263,4 +1263,102 @@ func TestJetStreamJWTDeletedAccountIsReEnabled(t *testing.T) {
 		t.Error("Unexpected message")
 	}
 	ncA.Close()
+}
+
+// Make sure 100MB HA means 100MB of R3, not 33.3MB.
+func TestJetStreamJWTHAStorageLimitsAndAccounting(t *testing.T) {
+	sysKp, syspub := createKey(t)
+	sysJwt := encodeClaim(t, jwt.NewAccountClaims(syspub), syspub)
+	newUser(t, sysKp)
+
+	maxFileStorage := int64(100 * 1024 * 1024)
+	maxMemStorage := int64(2 * 1024 * 1024)
+
+	accKp, aExpPub := createKey(t)
+	accClaim := jwt.NewAccountClaims(aExpPub)
+	accClaim.Name = "acc"
+	accClaim.Limits.JetStreamTieredLimits["R3"] = jwt.JetStreamLimits{DiskStorage: maxFileStorage, MemoryStorage: maxMemStorage}
+	accJwt := encodeClaim(t, accClaim, aExpPub)
+	accCreds := newUser(t, accKp)
+	tmlp := `
+		listen: 127.0.0.1:-1
+		server_name: %s
+		jetstream: {max_mem_store: 256MB, max_file_store: 2GB, store_dir: '%s'}
+		leaf { listen: 127.0.0.1:-1 }
+		cluster {
+			name: %s
+			listen: 127.0.0.1:%d
+			routes = [%s]
+		}
+	` + fmt.Sprintf(`
+		operator: %s
+		system_account: %s
+		resolver = MEMORY
+		resolver_preload = {
+			%s : %s
+			%s : %s
+		}
+	`, ojwt, syspub, syspub, sysJwt, aExpPub, accJwt)
+
+	c := createJetStreamClusterWithTemplate(t, tmlp, "cluster", 3)
+	defer c.shutdown()
+
+	nc := natsConnect(t, c.randomServer().ClientURL(), nats.UserCredentials(accCreds))
+	defer nc.Close()
+
+	js, err := nc.JetStream()
+	require_NoError(t, err)
+
+	// Test max bytes first.
+	_, err = js.AddStream(&nats.StreamConfig{Name: "TEST", Replicas: 3, MaxBytes: maxFileStorage, Subjects: []string{"foo"}})
+	require_NoError(t, err)
+
+	require_NoError(t, js.DeleteStream("TEST"))
+
+	_, err = js.AddStream(&nats.StreamConfig{Name: "TEST", Replicas: 3, Subjects: []string{"foo"}})
+	require_NoError(t, err)
+
+	// Now test actual usage.
+	// We should be able to send just over 200 of these.
+	msg := [500 * 1024]byte{}
+	for i := 0; i < 250; i++ {
+		if _, err := js.Publish("foo", msg[:]); err != nil {
+			require_Error(t, err, NewJSAccountResourcesExceededError())
+			require_True(t, i > 200)
+			break
+		}
+	}
+
+	si, err := js.StreamInfo("TEST")
+	require_NoError(t, err)
+	// Make sure we are no more then 1 msg below our max in terms of size.
+	delta := maxFileStorage - int64(si.State.Bytes)
+	require_True(t, int(delta) < len(msg))
+
+	// Now memory as well.
+	require_NoError(t, js.DeleteStream("TEST"))
+
+	// Test max bytes first.
+	_, err = js.AddStream(&nats.StreamConfig{Name: "TEST", Replicas: 3, MaxBytes: maxMemStorage, Storage: nats.MemoryStorage, Subjects: []string{"foo"}})
+	require_NoError(t, err)
+
+	require_NoError(t, js.DeleteStream("TEST"))
+
+	_, err = js.AddStream(&nats.StreamConfig{Name: "TEST", Replicas: 3, Storage: nats.MemoryStorage, Subjects: []string{"foo"}})
+	require_NoError(t, err)
+
+	// This is much smaller, so should only be able to send 4.
+	for i := 0; i < 5; i++ {
+		if _, err := js.Publish("foo", msg[:]); err != nil {
+			require_Error(t, err, NewJSAccountResourcesExceededError())
+			require_Equal(t, i, 4)
+			break
+		}
+	}
+
+	si, err = js.StreamInfo("TEST")
+	require_NoError(t, err)
+	// Make sure we are no more then 1 msg below our max in terms of size.
+	delta = maxMemStorage - int64(si.State.Bytes)
+	require_True(t, int(delta) < len(msg))
 }

--- a/server/stream.go
+++ b/server/stream.go
@@ -4453,7 +4453,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		return err
 	}
 
-	if exceeded, apiErr := jsa.limitsExceeded(stype, tierName); exceeded {
+	if exceeded, apiErr := jsa.limitsExceeded(stype, tierName, mset.cfg.Replicas); exceeded {
 		s.RateLimitWarnf("JetStream resource limits exceeded for account: %q", accName)
 		if canRespond {
 			resp.PubAck = &PubAck{Stream: name}


### PR DESCRIPTION
We had an issue with tiered accounts, where limits are flat based on type of storage. Meaning 100GB on R3 means 100GB of R3 storage, or 300GB in total. If we have limits only on an empty string tier, then consider limit as absolute, otherwise scale by tier replication.

Resolves issues with NGS account for HA / R3 limits.

Signed-off-by: Derek Collison <derek@nats.io>

