### PR TITLE
Move helper subjectInfo() to the file where it's used

### DIFF
--- a/server/subject_transform.go
+++ b/server/subject_transform.go
@@ -561,3 +561,29 @@ func (tr *subjectTransform) reverse() *subjectTransform {
 	rtr, _ := NewSubjectTransformStrict(nsrc, ndest)
 	return rtr
 }
+
+// Will share relevant info regarding the subject.
+// Returns valid, tokens, num pwcs, has fwc.
+func subjectInfo(subject string) (bool, []string, int, bool) {
+	if subject == "" {
+		return false, nil, 0, false
+	}
+	npwcs := 0
+	sfwc := false
+	tokens := strings.Split(subject, tsep)
+	for _, t := range tokens {
+		if len(t) == 0 || sfwc {
+			return false, nil, 0, false
+		}
+		if len(t) > 1 {
+			continue
+		}
+		switch t[0] {
+		case fwc:
+			sfwc = true
+		case pwc:
+			npwcs++
+		}
+	}
+	return true, tokens, npwcs, sfwc
+}

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -1101,32 +1101,6 @@ func IsValidSubject(subject string) bool {
 	return true
 }
 
-// Will share relevant info regarding the subject.
-// Returns valid, tokens, num pwcs, has fwc.
-func subjectInfo(subject string) (bool, []string, int, bool) {
-	if subject == "" {
-		return false, nil, 0, false
-	}
-	npwcs := 0
-	sfwc := false
-	tokens := strings.Split(subject, tsep)
-	for _, t := range tokens {
-		if len(t) == 0 || sfwc {
-			return false, nil, 0, false
-		}
-		if len(t) > 1 {
-			continue
-		}
-		switch t[0] {
-		case fwc:
-			sfwc = true
-		case pwc:
-			npwcs++
-		}
-	}
-	return true, tokens, npwcs, sfwc
-}
-
 // IsValidLiteralSubject returns true if a subject is valid and literal (no wildcards), false otherwise
 func IsValidLiteralSubject(subject string) bool {
 	return isValidLiteralSubject(strings.Split(subject, tsep))


### PR DESCRIPTION
This method is only used from `subject_transform.go`, should it then live there as well?

Signed-off-by: Sven Neumann <sven.neumann@holoplot.com>
