### PR TITLE
RFC: Introduce subject package

### DIFF
--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats-server/v2/subject"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nuid"
 )
@@ -798,11 +799,8 @@ func TestJetStreamConsumerMultipleFiltersLastPerSubject(t *testing.T) {
 func consumerWithFilterSubjects(filterSubjects []string) *consumer {
 	c := consumer{}
 	for _, filter := range filterSubjects {
-		sub := &subjectFilter{
-			subject:          filter,
-			hasWildcard:      subjectHasWildcard(filter),
-			tokenizedSubject: tokenizeSubjectIntoSlice(nil, filter),
-		}
+		s, _ := subject.New(filter)
+		sub := &subjectFilter{subject: s}
 		c.subjf = append(c.subjf, sub)
 	}
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/klauspost/compress/s2"
+	"github.com/nats-io/nats-server/v2/subject"
 	"github.com/nats-io/nuid"
 )
 
@@ -5185,7 +5186,7 @@ func (mset *stream) removeConsumerAsLeader(o *consumer) {
 
 // swapSigSubs will update signal Subs for a new subject filter.
 // consumer lock should not be held.
-func (mset *stream) swapSigSubs(o *consumer, newFilters []string) {
+func (mset *stream) swapSigSubs(o *consumer, newFilters []*subject.Subject) {
 	mset.clsMu.Lock()
 	o.mu.Lock()
 
@@ -5215,7 +5216,7 @@ func (mset *stream) swapSigSubs(o *consumer, newFilters []string) {
 			// If there are filters, add their subjects to sublist.
 		} else {
 			for _, filter := range newFilters {
-				sub := &subscription{subject: []byte(filter), icb: o.processStreamSignal}
+				sub := &subscription{subject: []byte(filter.String()), icb: o.processStreamSignal}
 				mset.csl.Insert(sub)
 				o.sigSubs = append(o.sigSubs, sub)
 			}
@@ -5288,10 +5289,8 @@ func (mset *stream) Store() StreamStore {
 
 // Determines if the new proposed partition is unique amongst all consumers.
 // Lock should be held.
-func (mset *stream) partitionUnique(name string, partitions []string) bool {
+func (mset *stream) partitionUnique(name string, partitions []*subject.Subject) bool {
 	for _, partition := range partitions {
-		psa := [32]string{}
-		pts := tokenizeSubjectIntoSlice(psa[:0], partition)
 		for n, o := range mset.consumers {
 			// Skip the consumer being checked.
 			if n == name {
@@ -5301,8 +5300,8 @@ func (mset *stream) partitionUnique(name string, partitions []string) bool {
 				return false
 			}
 			for _, filter := range o.subjf {
-				if isSubsetMatchTokenized(pts, filter.tokenizedSubject) ||
-					isSubsetMatchTokenized(filter.tokenizedSubject, pts) {
+				if partition.IsSubsetMatch(filter.subject) ||
+					filter.subject.IsSubsetMatch(partition) {
 					return false
 				}
 			}

--- a/subject/subject.go
+++ b/subject/subject.go
@@ -1,0 +1,196 @@
+// Copyright 2019-2023 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subject
+
+import (
+	"errors"
+	"strings"
+)
+
+var (
+	ErrInvalid = errors.New("invalid subject")
+)
+
+// Common byte variables for wildcards and token separator.
+const (
+	_EMPTY_ = ""
+
+	pwc   = '*'
+	pwcs  = "*"
+	fwc   = '>'
+	fwcs  = ">"
+	tsep  = "."
+	btsep = '.'
+)
+
+type Subject struct {
+	subject   string
+	isLiteral bool
+	tokenized []string
+}
+
+var emptySubject = Subject{
+	subject:   _EMPTY_,
+	isLiteral: true,
+}
+
+func Empty() *Subject {
+	return &emptySubject
+}
+
+func New(subject string) (*Subject, error) {
+	if !isValidSubject(subject) {
+		return nil, ErrInvalid
+	}
+	s := &Subject{
+		subject:   subject,
+		isLiteral: isLiteralSubject(subject),
+		tokenized: tokenizeSubjectIntoSlice(nil, subject),
+	}
+	return s, nil
+}
+
+func Stack(subject string) (Subject, error) {
+	if !isValidSubject(subject) {
+		return Subject{}, ErrInvalid
+	}
+	tsa := [32]string{}
+	s := Subject{
+		subject:   subject,
+		isLiteral: isLiteralSubject(subject),
+		tokenized: tokenizeSubjectIntoSlice(tsa[:0], subject),
+	}
+	return s, nil
+}
+
+func (s *Subject) String() string {
+	return s.subject
+}
+
+func (s *Subject) IsEmpty() bool {
+	return s.subject == _EMPTY_
+}
+
+func (s *Subject) IsForwardWildcard() bool {
+	return s.subject == fwcs
+}
+
+func (s *Subject) IsLiteral() bool {
+	return s.isLiteral
+}
+
+func (s *Subject) HasWildcard() bool {
+	return !s.isLiteral
+}
+
+func (s *Subject) IsSubsetMatch(other *Subject) bool {
+	return isSubsetMatchTokenized(s.tokenized, other.tokenized)
+}
+
+func (s *Subject) EqualsLiteral(other string) bool {
+	return s.isLiteral && s.subject == other
+}
+
+func isLiteralSubject(subject string) bool {
+	for i, c := range subject {
+		if c == pwc || c == fwc {
+			if (i == 0 || subject[i-1] == btsep) &&
+				(i+1 == len(subject) || subject[i+1] == btsep) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isValidSubject(subject string) bool {
+	if subject == _EMPTY_ {
+		return false
+	}
+	sfwc := false
+	tokens := strings.Split(subject, tsep)
+	for _, t := range tokens {
+		length := len(t)
+		if length == 0 || sfwc {
+			return false
+		}
+		if length > 1 {
+			if strings.ContainsAny(t, "\t\n\f\r ") {
+				return false
+			}
+			continue
+		}
+		switch t[0] {
+		case fwc:
+			sfwc = true
+		case ' ', '\t', '\n', '\r', '\f':
+			return false
+		}
+	}
+	return true
+}
+
+// use similar to append. meaning, the updated slice will be returned
+func tokenizeSubjectIntoSlice(tts []string, subject string) []string {
+	start := 0
+	for i := 0; i < len(subject); i++ {
+		if subject[i] == btsep {
+			tts = append(tts, subject[start:i])
+			start = i + 1
+		}
+	}
+	tts = append(tts, subject[start:])
+	return tts
+}
+
+// This will test a subject as an array of tokens against a test subject (also encoded as array of tokens)
+// and determine if the tokens are matched. Both test subject and tokens
+// may contain wildcards. So foo.* is a subset match of [">", "*.*", "foo.*"],
+// but not of foo.bar, etc.
+func isSubsetMatchTokenized(tokens, test []string) bool {
+	// Walk the target tokens
+	for i, t2 := range test {
+		if i >= len(tokens) {
+			return false
+		}
+		l := len(t2)
+		if l == 0 {
+			return false
+		}
+		if t2[0] == fwc && l == 1 {
+			return true
+		}
+		t1 := tokens[i]
+
+		l = len(t1)
+		if l == 0 || t1[0] == fwc && l == 1 {
+			return false
+		}
+
+		if t1[0] == pwc && len(t1) == 1 {
+			m := t2[0] == pwc && len(t2) == 1
+			if !m {
+				return false
+			}
+			if i >= len(test) {
+				return true
+			}
+			continue
+		}
+		if t2[0] != pwc && strings.Compare(t1, t2) != 0 {
+			return false
+		}
+	}
+	return len(tokens) == len(test)
+}

--- a/subject/subject_test.go
+++ b/subject/subject_test.go
@@ -1,0 +1,236 @@
+// Copyright 2016-2023 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subject
+
+import (
+	"fmt"
+	"testing"
+)
+
+func checkBool(b, expected bool, t *testing.T) {
+	t.Helper()
+	if b != expected {
+		t.Fatalf("Expected %v, but got %v\n", expected, b)
+	}
+}
+
+func TestIsValidSubject(t *testing.T) {
+	t.Parallel()
+	checkBool(isValidSubject(""), false, t)
+	checkBool(isValidSubject("."), false, t)
+	checkBool(isValidSubject(".foo"), false, t)
+	checkBool(isValidSubject("foo."), false, t)
+	checkBool(isValidSubject("foo..bar"), false, t)
+	checkBool(isValidSubject(">.bar"), false, t)
+	checkBool(isValidSubject("foo.>.bar"), false, t)
+	checkBool(isValidSubject("foo"), true, t)
+	checkBool(isValidSubject("foo.bar.>"), true, t)
+	checkBool(isValidSubject("*"), true, t)
+	checkBool(isValidSubject(">"), true, t)
+	checkBool(isValidSubject("foo*"), true, t)
+	checkBool(isValidSubject("foo**"), true, t)
+	checkBool(isValidSubject("foo.**"), true, t)
+	checkBool(isValidSubject("foo*bar"), true, t)
+	checkBool(isValidSubject("foo.*bar"), true, t)
+	checkBool(isValidSubject("foo*.bar"), true, t)
+	checkBool(isValidSubject("*bar"), true, t)
+	checkBool(isValidSubject("foo>"), true, t)
+	checkBool(isValidSubject("foo.>>"), true, t)
+	checkBool(isValidSubject("foo>bar"), true, t)
+	checkBool(isValidSubject("foo.>bar"), true, t)
+	checkBool(isValidSubject("foo>.bar"), true, t)
+	checkBool(isValidSubject(">bar"), true, t)
+}
+
+func TestIsLiteralSubject(t *testing.T) {
+	t.Parallel()
+	checkBool(isLiteralSubject("foo"), true, t)
+	checkBool(isLiteralSubject("foo.bar"), true, t)
+	checkBool(isLiteralSubject("foo*.bar"), true, t)
+	checkBool(isLiteralSubject("*"), false, t)
+	checkBool(isLiteralSubject(">"), false, t)
+	checkBool(isLiteralSubject("foo.*"), false, t)
+	checkBool(isLiteralSubject("foo.>"), false, t)
+	checkBool(isLiteralSubject("foo.*.>"), false, t)
+	checkBool(isLiteralSubject("foo.*.bar"), false, t)
+	checkBool(isLiteralSubject("foo.bar.>"), false, t)
+}
+
+func TestSubjectNew(t *testing.T) {
+	for _, test := range []struct {
+		subject        string
+		expectsSuccess bool
+	}{
+		{"", false},
+		{"foo.bar", true},
+		{"foo..bar", false},
+		{"foo.*.bar", true},
+	} {
+		test := test
+		name := fmt.Sprintf("subject.New(\"%s\")", test.subject)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			s, err := New(test.subject)
+			if test.expectsSuccess {
+				if err != nil {
+					t.Fatalf("subject.New(\"%s\" failed: %v", test.subject, err)
+				}
+				if s == nil {
+					t.Fatalf("subject.New(\"%s\" returned nil", test.subject)
+				}
+				checkBool(s.IsEmpty(), false, t)
+			} else {
+				if s != nil || err == nil {
+					t.Fatalf("subject.New(\"%s\" should have failed", test.subject)
+				}
+			}
+		})
+	}
+}
+
+func TestSubjectIsSubsetMatch(t *testing.T) {
+	for _, test := range []struct {
+		subject string
+		other   string
+		result  bool
+	}{
+		{"foo.bar", "foo.bar", true},
+		{"foo.*", ">", true},
+		{"foo.*", "*.*", true},
+		{"foo.*", "foo.*", true},
+		{"foo.*", "foo.>", true},
+		{"foo.*", "foo.bar", false},
+		{"foo.>", ">", true},
+		{"foo.>", "*.>", true},
+		{"foo.>", "foo.>", true},
+		{"foo.>", "foo.bar", false},
+		{"foo.*.bar", "foo.>", true},
+		{"foo.*.bar", "foo.bar.>", false},
+		{"foo.bar.>", "foo.*.bar", false},
+	} {
+		test := test
+		var name string
+		if test.result {
+			name = fmt.Sprintf("\"%s\" is a subset match of \"%s\")", test.other, test.subject)
+		} else {
+			name = fmt.Sprintf("\"%s\" is not a subset match of \"%s\")", test.other, test.subject)
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			s, err := New(test.subject)
+			if err != nil {
+				t.Fatalf("subject.New(\"%s\" failed: %v", test.subject, err)
+			}
+			o, err := New(test.other)
+			if err != nil {
+				t.Fatalf("subject.New(\"%s\" failed: %v", test.other, err)
+			}
+			if res := s.IsSubsetMatch(o); res != test.result {
+				t.Fatalf("Subject %q is subset match of %q, should be %v, got %v",
+					test.other, test.subject, test.result, res)
+			}
+		})
+	}
+}
+
+func TestSubjectIsLiteral(t *testing.T) {
+	for _, test := range []struct {
+		subject string
+		result  bool
+	}{
+		{"foo", true},
+		{"foo.bar.*", false},
+		{"foo.bar.>", false},
+		{"*", false},
+		{">", false},
+		// The followings have widlcards characters but are not
+		// considered as such because they are not individual tokens.
+		{"foo*", true},
+		{"foo**", true},
+		{"foo.**", true},
+		{"foo*bar", true},
+		{"foo.*bar", true},
+		{"foo*.bar", true},
+		{"*bar", true},
+		{"foo>", true},
+		{"foo>>", true},
+		{"foo.>>", true},
+		{"foo>bar", true},
+		{"foo.>bar", true},
+		{"foo>.bar", true},
+		{">bar", true},
+	} {
+		test := test
+		name := fmt.Sprintf("Literal - \"%s\"", test.subject)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			s, err := New(test.subject)
+			if err != nil {
+				t.Fatalf("subject.New(\"%s\" failed: %v", test.subject, err)
+			}
+			if res := s.IsLiteral(); res != test.result {
+				t.Fatalf("IsLiteral() for subject \"%s\", should be %v, got %v", test.subject, test.result, res)
+			}
+			if res := s.HasWildcard(); res != !test.result {
+				t.Fatalf("HasWildcard() for subject \"%s\", should be %v, got %v", test.subject, !test.result, res)
+			}
+		})
+	}
+}
+
+func TestEmptySubject(t *testing.T) {
+	t.Parallel()
+	e := Empty()
+	checkBool(e.IsEmpty(), true, t)
+	checkBool(e.IsLiteral(), true, t)
+	checkBool(e.HasWildcard(), false, t)
+	s, _ := New("foo.bar")
+	checkBool(s.IsEmpty(), false, t)
+	checkBool(e.IsSubsetMatch(s), false, t)
+	checkBool(s.IsSubsetMatch(e), false, t)
+}
+
+func TestStackSubject(t *testing.T) {
+	t.Run("Stack - empty", func(t *testing.T) {
+		t.Parallel()
+		if _, err := Stack(""); err == nil {
+			t.Fatal("Expected Stack(\"\") to fail")
+		}
+	})
+	t.Run("Stack - literal", func(t *testing.T) {
+		t.Parallel()
+		s, err := Stack("foo.bar")
+		if err != nil {
+			t.Fatalf("Expected no err, got %v", err)
+		}
+		checkBool(s.IsEmpty(), false, t)
+		checkBool(s.IsLiteral(), true, t)
+		checkBool(s.HasWildcard(), false, t)
+	})
+	t.Run("Stack - wildcard", func(t *testing.T) {
+		t.Parallel()
+		s, err := Stack("foo.*.bar")
+		if err != nil {
+			t.Fatalf("Expected no err, got %v", err)
+		}
+		checkBool(s.IsEmpty(), false, t)
+		checkBool(s.IsLiteral(), false, t)
+		checkBool(s.HasWildcard(), true, t)
+		o, err := New("foo.>")
+		if err != nil {
+			t.Fatalf("Expected no err, got %v", err)
+		}
+		checkBool(s.IsSubsetMatch(o), true, t)
+	})
+}


### PR DESCRIPTION
_This is work in progress. It could potentially be merged already, but I am opening this PR mostly to get some comments on the approach taken here._

This introduces a new package `subject`, which holds code that is to a large extent copied from `server/sublist.go`.  Eventually the code this was copied from should not any longer be needed and can then be removed. The idea of using a separate package is that this allows to hide the internals from direct access. This will make it much easier to refactor these internals later.

The new package introduces the type `Subject` which holds the string representation of a subject together with its tokenized form. By using this type throughout the server code we can avoid tokenizing the same subject string over and over again. At least for some use cases this seems to be happening. I profiled the NATS server and I can show you profiles where `tokenizeSubjectIntoSlice()` is the function where most CPU cycles are spent.

The PR has two commits, the first introduces the new type, the second commit shows how it can be used. To really benefit from the new `Subject` type it would also have to be used in `sublist.go`,  `memstore,go` and `filestore,go`. Basically it should be used all over the place, everywhere a subject is used. This would become a large change and I would only want to invest time into it if the NATS developers agree with the approach and embrace it.

Please feel free to also point out bugs or problematic implementation details if you spot them. But most of all I am interested in hearing your opinion on the approach in general and whether you believe it is feasible and worthwhile.