### PR TITLE
Add 'certs' option to TLS block for multi-certs support

### DIFF
--- a/server/configs/reload/tls_multi_cert_1.conf
+++ b/server/configs/reload/tls_multi_cert_1.conf
@@ -1,0 +1,13 @@
+# Simple TLS config file
+
+listen:   127.0.0.1:-1
+
+tls {
+  certs = [
+    {
+      cert_file: "../test/configs/certs/srva-cert.pem"
+      key_file:  "../test/configs/certs/srva-key.pem"
+    }
+  ]
+  timeout:    2
+}

--- a/server/configs/reload/tls_multi_cert_2.conf
+++ b/server/configs/reload/tls_multi_cert_2.conf
@@ -1,0 +1,19 @@
+# Simple TLS config file
+
+listen:   127.0.0.1:-1
+
+tls {
+  certs = [
+    {
+      cert_file: "../test/configs/certs/srva-cert.pem"
+      key_file:  "../test/configs/certs/srva-key.pem"
+    },
+    {
+      cert_file: "../test/configs/certs/srvb-cert.pem"
+      key_file:  "../test/configs/certs/srvb-key.pem"
+    }
+  ]
+  ca_file: "../test/configs/certs/ca.pem"
+  verify:  true
+  timeout: 2
+}

--- a/server/configs/reload/tls_multi_cert_3.conf
+++ b/server/configs/reload/tls_multi_cert_3.conf
@@ -1,0 +1,13 @@
+# Simple TLS config file
+
+listen:   127.0.0.1:-1
+
+tls {
+  certs = [
+    {
+      cert_file: "../test/configs/certs/srvb-cert.pem"
+      key_file:  "../test/configs/certs/srvb-key.pem"
+    }
+  ]
+  timeout: 2
+}

--- a/server/opts.go
+++ b/server/opts.go
@@ -4681,16 +4681,28 @@ func GenTLSConfig(tc *TLSConfigOpts) (*tls.Config, error) {
 	case tc.CertFile == _EMPTY_ && tc.KeyFile != _EMPTY_:
 		return nil, fmt.Errorf("missing 'cert_file' in TLS configuration")
 	case tc.CertFile != _EMPTY_ && tc.KeyFile != _EMPTY_:
-		// Now load in cert and private key
-		cert, err := tls.LoadX509KeyPair(tc.CertFile, tc.KeyFile)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing X509 certificate/key pair: %v", err)
+		// To support multiple certs (for SANs) without rearchitecting our
+		// configuration, we accept a list, separated by the platform list
+		// separator; both specs must contain the same count of entries.
+		// (So, colon-separated on Unix, semi-colon on Windows).
+		certFiles := strings.Split(tc.CertFile, string(os.PathListSeparator))
+		keyFiles := strings.Split(tc.KeyFile, string(os.PathListSeparator))
+		if len(certFiles) != len(keyFiles) {
+			return nil, fmt.Errorf("TLS configuration has %d entries in cert_file but %d in key_file", len(certFiles), len(keyFiles))
 		}
-		cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
-		if err != nil {
-			return nil, fmt.Errorf("error parsing certificate: %v", err)
+		config.Certificates = make([]tls.Certificate, len(certFiles))
+		// Now load in cert and private keys
+		for i := range certFiles {
+			cert, err := tls.LoadX509KeyPair(certFiles[i], keyFiles[i])
+			if err != nil {
+				return nil, fmt.Errorf("error parsing X509 certificate/key pair: %v", err)
+			}
+			cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
+			if err != nil {
+				return nil, fmt.Errorf("error parsing certificate: %v", err)
+			}
+			config.Certificates[i] = cert
 		}
-		config.Certificates = []tls.Certificate{cert}
 	case tc.CertStore != certstore.STOREEMPTY:
 		err := certstore.TLSConfig(tc.CertStore, tc.CertMatchBy, tc.CertMatch, &config)
 		if err != nil {

--- a/server/opts.go
+++ b/server/opts.go
@@ -669,6 +669,13 @@ type TLSConfigOpts struct {
 	CertMatchBy       certstore.MatchByType
 	CertMatch         string
 	OCSPPeerConfig    *certidp.OCSPPeerConfig
+	Certificates      []*TLSCertPairOpt
+}
+
+// TLSCertPairOpt are the paths to a certificate and private key.
+type TLSCertPairOpt struct {
+	CertFile string
+	KeyFile  string
 }
 
 // OCSPConfig represents the options of OCSP stapling options.
@@ -4180,7 +4187,7 @@ func parseTLS(v interface{}, isClientCtx bool) (t *TLSConfigOpts, retErr error) 
 	)
 	defer convertPanicToError(&lt, &retErr)
 
-	_, v = unwrapValue(v, &lt)
+	tk, v := unwrapValue(v, &lt)
 	tlsm = v.(map[string]interface{})
 	for mk, mv := range tlsm {
 		tk, mv := unwrapValue(mv, &lt)
@@ -4381,9 +4388,45 @@ func parseTLS(v interface{}, isClientCtx bool) (t *TLSConfigOpts, retErr error) 
 			default:
 				return nil, &configErr{tk, fmt.Sprintf("error parsing ocsp peer config: unsupported type %T", v)}
 			}
+		case "certs", "certificates":
+			certs, ok := mv.([]interface{})
+			if !ok {
+				return nil, &configErr{tk, fmt.Sprintf("error parsing certificates config: unsupported type %T", v)}
+			}
+			tc.Certificates = make([]*TLSCertPairOpt, len(certs))
+			for i, v := range certs {
+				tk, vv := unwrapValue(v, &lt)
+				pair, ok := vv.(map[string]interface{})
+				if !ok {
+					return nil, &configErr{tk, fmt.Sprintf("error parsing certificates config: unsupported type %T", vv)}
+				}
+				certPair := &TLSCertPairOpt{}
+				for k, v := range pair {
+					tk, vv = unwrapValue(v, &lt)
+					file, ok := vv.(string)
+					if !ok {
+						return nil, &configErr{tk, fmt.Sprintf("error parsing certificates config: unsupported type %T", vv)}
+					}
+					switch k {
+					case "cert_file":
+						certPair.CertFile = file
+					case "key_file":
+						certPair.KeyFile = file
+					default:
+						return nil, &configErr{tk, fmt.Sprintf("error parsing tls certs config, unknown field %q", k)}
+					}
+				}
+				if certPair.CertFile == _EMPTY_ || certPair.KeyFile == _EMPTY_ {
+					return nil, &configErr{tk, "error parsing certificates config: both 'cert_file' and 'cert_key' options are required"}
+				}
+				tc.Certificates[i] = certPair
+			}
 		default:
-			return nil, &configErr{tk, fmt.Sprintf("error parsing tls config, unknown field [%q]", mk)}
+			return nil, &configErr{tk, fmt.Sprintf("error parsing tls config, unknown field %q", mk)}
 		}
+	}
+	if len(tc.Certificates) > 0 && tc.CertFile != _EMPTY_ {
+		return nil, &configErr{tk, "error parsing tls config, cannot combine 'cert_file' option with 'certs' option"}
 	}
 
 	// If cipher suites were not specified then use the defaults
@@ -4681,32 +4724,34 @@ func GenTLSConfig(tc *TLSConfigOpts) (*tls.Config, error) {
 	case tc.CertFile == _EMPTY_ && tc.KeyFile != _EMPTY_:
 		return nil, fmt.Errorf("missing 'cert_file' in TLS configuration")
 	case tc.CertFile != _EMPTY_ && tc.KeyFile != _EMPTY_:
-		// To support multiple certs (for SANs) without rearchitecting our
-		// configuration, we accept a list, separated by the platform list
-		// separator; both specs must contain the same count of entries.
-		// (So, colon-separated on Unix, semi-colon on Windows).
-		certFiles := strings.Split(tc.CertFile, string(os.PathListSeparator))
-		keyFiles := strings.Split(tc.KeyFile, string(os.PathListSeparator))
-		if len(certFiles) != len(keyFiles) {
-			return nil, fmt.Errorf("TLS configuration has %d entries in cert_file but %d in key_file", len(certFiles), len(keyFiles))
+		// Now load in cert and private key
+		cert, err := tls.LoadX509KeyPair(tc.CertFile, tc.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing X509 certificate/key pair: %v", err)
 		}
-		config.Certificates = make([]tls.Certificate, len(certFiles))
-		// Now load in cert and private keys
-		for i := range certFiles {
-			cert, err := tls.LoadX509KeyPair(certFiles[i], keyFiles[i])
-			if err != nil {
-				return nil, fmt.Errorf("error parsing X509 certificate/key pair: %v", err)
-			}
-			cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
-			if err != nil {
-				return nil, fmt.Errorf("error parsing certificate: %v", err)
-			}
-			config.Certificates[i] = cert
+		cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing certificate: %v", err)
 		}
+		config.Certificates = []tls.Certificate{cert}
 	case tc.CertStore != certstore.STOREEMPTY:
 		err := certstore.TLSConfig(tc.CertStore, tc.CertMatchBy, tc.CertMatch, &config)
 		if err != nil {
 			return nil, err
+		}
+	case tc.Certificates != nil:
+		// Multiple certificate support.
+		config.Certificates = make([]tls.Certificate, len(tc.Certificates))
+		for i, certPair := range tc.Certificates {
+			cert, err := tls.LoadX509KeyPair(certPair.CertFile, certPair.KeyFile)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing X509 certificate/key pair %d/%d: %v", i+1, len(tc.Certificates), err)
+			}
+			cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
+			if err != nil {
+				return nil, fmt.Errorf("error parsing certificate %d/%d: %v", i+1, len(tc.Certificates), err)
+			}
+			config.Certificates[i] = cert
 		}
 	}
 


### PR DESCRIPTION
This adds a `certs` option to the `tls` block to support loading multiple certs:
    
```hcl
    tls {
      certs = [
        {
          cert_file: "./configs/certs/srva-cert.pem"
          key_file:  "./configs/certs/srva-key.pem"
        },
        {
          cert_file: "./configs/certs/srvb-cert.pem"
          key_file:  "./configs/certs/srvb-key.pem"
        }
      ]
      ca_file: "./configs/certs/ca.pem"
      verify:  true
      timeout: 2
    }
```

Follow up from https://github.com/nats-io/nats-server/pull/2029