### PR TITLE
[IMPROVED] Detect corrupt psim subjects during recovery of index.db.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1590,6 +1590,13 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 				// We could reference the underlying buffer, but we could guess wrong if
 				// number of blocks is large and subjects is low, since we would reference buf.
 				subj := string(buf[bi : bi+lsubj])
+				// We had a bug that could cause memory corruption in the PSIM that could have gotten stored to disk.
+				// Only would affect subjects, so do quick check.
+				if !isValidSubject(subj, true) {
+					os.Remove(fn)
+					fs.warn("Stream state corrupt subject detected")
+					return errCorruptState
+				}
 				bi += lsubj
 				psi := &psi{total: readU64(), fblk: uint32(readU64())}
 				if psi.total > 1 {

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"unicode/utf8"
 )
 
 // Sublist is a routing mechanism to handle subject distribution and
@@ -1075,8 +1076,21 @@ func IsValidPublishSubject(subject string) bool {
 
 // IsValidSubject returns true if a subject is valid, false otherwise
 func IsValidSubject(subject string) bool {
+	return isValidSubject(subject, false)
+}
+
+func isValidSubject(subject string, checkRunes bool) bool {
 	if subject == _EMPTY_ {
 		return false
+	}
+	if checkRunes {
+		// Since casting to a string will always produce valid UTF-8, we need to look for replacement runes.
+		// This signals something is off or corrupt.
+		for _, r := range subject {
+			if r == utf8.RuneError {
+				return false
+			}
+		}
 	}
 	sfwc := false
 	tokens := strings.Split(subject, tsep)


### PR DESCRIPTION
We had a bug that could cause internal memory corruption of psim subjects/keys in filestore. This could make it to disk via index.db. This checks subjects for corruption on reading in index.db.

Signed-off-by: Derek Collison <derek@nats.io
