### PR TITLE
[IMPROVED] Do not allow large memory buildup in the apply queue for NRGs during startup.

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -2774,7 +2774,7 @@ func TestJetStreamClusterUserSnapshotAndRestore(t *testing.T) {
 	req, _ = json.Marshal(rreq)
 
 	// Make sure a restore to an existing stream fails.
-	rmsg, err = nc.Request(fmt.Sprintf(JSApiStreamRestoreT, "TEST"), req, time.Second)
+	rmsg, err = nc.Request(fmt.Sprintf(JSApiStreamRestoreT, "TEST"), req, 2*time.Second)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2807,7 +2807,9 @@ func TestJetStreamClusterUserSnapshotAndRestore(t *testing.T) {
 	if rresp.Error != nil {
 		t.Fatalf("Got an unexpected error response: %+v", rresp.Error)
 	}
-
+	if rresp.DeliverSubject == _EMPTY_ {
+		t.Fatalf("No deliver subject set on response: %+v", rresp)
+	}
 	// Send our snapshot back in to restore the stream.
 	// Can be any size message.
 	var chunk [1024]byte
@@ -2818,7 +2820,7 @@ func TestJetStreamClusterUserSnapshotAndRestore(t *testing.T) {
 		}
 		nc.Request(rresp.DeliverSubject, chunk[:n], time.Second)
 	}
-	rmsg, err = nc.Request(rresp.DeliverSubject, nil, time.Second)
+	rmsg, err = nc.Request(rresp.DeliverSubject, nil, 2*time.Second)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -3008,6 +3010,9 @@ func TestJetStreamClusterUserSnapshotAndRestoreConfigChanges(t *testing.T) {
 		if rresp.Error != nil {
 			t.Fatalf("Got an unexpected error response: %+v", rresp.Error)
 		}
+		if rresp.DeliverSubject == _EMPTY_ {
+			t.Fatalf("No deliver subject set on response: %+v", rresp)
+		}
 		// Send our snapshot back in to restore the stream.
 		// Can be any size message.
 		var chunk [1024]byte
@@ -3018,7 +3023,7 @@ func TestJetStreamClusterUserSnapshotAndRestoreConfigChanges(t *testing.T) {
 			}
 			nc.Request(rresp.DeliverSubject, chunk[:n], time.Second)
 		}
-		rmsg, err = nc.Request(rresp.DeliverSubject, nil, time.Second)
+		rmsg, err = nc.Request(rresp.DeliverSubject, nil, 2*time.Second)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -1622,7 +1622,7 @@ func addStreamWithError(t *testing.T, nc *nats.Conn, cfg *StreamConfig) (*Stream
 	t.Helper()
 	req, err := json.Marshal(cfg)
 	require_NoError(t, err)
-	rmsg, err := nc.Request(fmt.Sprintf(JSApiStreamCreateT, cfg.Name), req, time.Second)
+	rmsg, err := nc.Request(fmt.Sprintf(JSApiStreamCreateT, cfg.Name), req, 5*time.Second)
 	require_NoError(t, err)
 	var resp JSApiStreamCreateResponse
 	err = json.Unmarshal(rmsg.Data, &resp)

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/nats-io/nuid"
 )
 
-var testMQTTTimeout = 5 * time.Second
+var testMQTTTimeout = 10 * time.Second
 
 var jsClusterTemplWithLeafAndMQTT = `
 	listen: 127.0.0.1:-1


### PR DESCRIPTION
Previously we processed this inline with startRaftNode. Normally this was fine, however if the existing WAL entries were very large, this would consume lots of memory since the upper state machine will not be running. 

Now we will track how much memory we have been building up in the apply queue, and if it exceeds our threshold we will pause the apply queue and resume from the run() go routine.

Signed-off-by: Derek Collison <derek@nats.io>
