### PR TITLE
Use `fastrand` instead of `prand`s

### DIFF
--- a/internal/fastrand/LICENSE
+++ b/internal/fastrand/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2011 The LevelDB-Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/internal/fastrand/fastrand.go
+++ b/internal/fastrand/fastrand.go
@@ -1,0 +1,23 @@
+// Copyright 2020-2023 The LevelDB-Go, Pebble and NATS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package fastrand
+
+import _ "unsafe" // required by go:linkname
+
+// Uint32 returns a lock free uint32 value.
+//
+//go:linkname Uint32 runtime.fastrand
+func Uint32() uint32
+
+// Uint32n returns a lock free uint32 value in the interval [0, n).
+//
+//go:linkname Uint32n runtime.fastrandn
+func Uint32n(n uint32) uint32
+
+// Uint32 returns a lock free uint64 value.
+func Uint64() uint64 {
+	v := uint64(Uint32())
+	return v<<32 | uint64(Uint32())
+}

--- a/internal/fastrand/fastrand_test.go
+++ b/internal/fastrand/fastrand_test.go
@@ -1,0 +1,72 @@
+// Copyright 2020-23 The LevelDB-Go, Pebble and NATS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package fastrand
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+type defaultRand struct {
+	mu  sync.Mutex
+	src rand.Source64
+}
+
+func newDefaultRand() *defaultRand {
+	r := &defaultRand{
+		src: rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+	return r
+}
+
+func (r *defaultRand) Uint32() uint32 {
+	r.mu.Lock()
+	i := uint32(r.src.Uint64())
+	r.mu.Unlock()
+	return i
+}
+
+func (r *defaultRand) Uint64() uint64 {
+	r.mu.Lock()
+	i := uint64(r.src.Uint64())
+	r.mu.Unlock()
+	return i
+}
+
+func BenchmarkFastRand32(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			Uint32()
+		}
+	})
+}
+
+func BenchmarkFastRand64(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			Uint64()
+		}
+	})
+}
+
+func BenchmarkDefaultRand32(b *testing.B) {
+	r := newDefaultRand()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r.Uint32()
+		}
+	})
+}
+
+func BenchmarkDefaultRand64(b *testing.B) {
+	r := newDefaultRand()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r.Uint64()
+		}
+	})
+}


### PR DESCRIPTION
In order to avoid top-level lock contention in the `math/rand` package, we were previously initialising our own `prand` sources in various structs. However these still needed to be protected by locks and they also just weren't that fast.

This PR removes those `prand`s and replaces those calls with calls to the Go runtime's `fastrand`, which is a couple hundred times faster and is, more importantly, lock-free:
```
goos: darwin
goarch: arm64
pkg: github.com/nats-io/nats-server/v2/server/fastrand
BenchmarkFastRand32
BenchmarkFastRand32-10          1000000000               0.2564 ns/op
BenchmarkFastRand64
BenchmarkFastRand64-10          1000000000               0.5019 ns/op
BenchmarkDefaultRand32
BenchmarkDefaultRand32-10       11997840               104.4 ns/op
BenchmarkDefaultRand64
BenchmarkDefaultRand64-10       11745747               105.8 ns/op
PASS
ok      github.com/nats-io/nats-server/v2/server/fastrand       3.768s
```

Signed-off-by: Neil Twigg <neil@nats.io>