### PR TITLE
[FIXED] Fix unsupported MQTT topic characters error message

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -217,7 +217,7 @@ var (
 	errMQTTEmptyUsername            = errors.New("empty user name not allowed")
 	errMQTTTopicIsEmpty             = errors.New("topic cannot be empty")
 	errMQTTPacketIdentifierIsZero   = errors.New("packet identifier cannot be 0")
-	errMQTTUnsupportedCharacters    = errors.New("characters ' ' and '.' not supported for MQTT topics")
+	errMQTTUnsupportedCharacters    = errors.New("character ' ' not supported for MQTT topics")
 	errMQTTInvalidSession           = errors.New("invalid MQTT session")
 )
 


### PR DESCRIPTION
Previously ' ' and '.' were not supported for MQTT topics until [#4243](https://github.com/nats-io/nats-server/pull/4243) brought in support for '.'. However the error message for unsupported characters appears to not have been updated. This simply updates the error message.

Had an example of a MQTT client trying to connect to `spBv1.0/Field Devices` and the error message indicated that both '.' and ' '  were unsupported which was misleading as only ' '  is unsupported.

Signed-off-by: Tom Hollingworth <tom.hollingworth@spruiktec.com>
