### PR TITLE
Fix return value in func

### DIFF
--- a/server/certidp/certidp.go
+++ b/server/certidp/certidp.go
@@ -53,7 +53,13 @@ var (
 )
 
 func GetStatusAssertionStr(sa int) string {
-	return StatusAssertionValToStr[StatusAssertionIntToVal[sa]]
+	v, ok := StatusAssertionIntToVal[sa]
+	if !ok {
+		// set unknown as fallback
+		v = ocsp.Unknown
+	}
+
+	return StatusAssertionValToStr[v]
 }
 
 func (sa StatusAssertion) MarshalJSON() ([]byte, error) {

--- a/server/certidp/certidp.go
+++ b/server/certidp/certidp.go
@@ -54,12 +54,10 @@ var (
 
 // GetStatusAssertionStr returns the corresponding string representation of the StatusAssertion.
 func GetStatusAssertionStr(sa int) string {
-	/*
-	 If the provided status assertion value is not found in the map (StatusAssertionIntToVal),
-	 the function defaults to "unknown" to avoid defaulting to "good," which is the default iota value
-	 for the ocsp.StatusAssertion enumeration (https://pkg.go.dev/golang.org/x/crypto/ocsp#pkg-constants).
-	 This ensures that we don't unintentionally default to "good" when there's no map entry.
-	*/
+	// If the provided status assertion value is not found in the map (StatusAssertionIntToVal),
+	// the function defaults to "unknown" to avoid defaulting to "good," which is the default iota value
+	// for the ocsp.StatusAssertion enumeration (https://pkg.go.dev/golang.org/x/crypto/ocsp#pkg-constants).
+	// This ensures that we don't unintentionally default to "good" when there's no map entry.
 	v, ok := StatusAssertionIntToVal[sa]
 	if !ok {
 		// set unknown as fallback

--- a/server/certidp/certidp.go
+++ b/server/certidp/certidp.go
@@ -52,7 +52,14 @@ var (
 	}
 )
 
+// GetStatusAssertionStr returns the corresponding string representation of the StatusAssertion.
 func GetStatusAssertionStr(sa int) string {
+	/*
+	 If the provided status assertion value is not found in the map (StatusAssertionIntToVal),
+	 the function defaults to "unknown" to avoid defaulting to "good," which is the default iota value
+	 for the ocsp.StatusAssertion enumeration (https://pkg.go.dev/golang.org/x/crypto/ocsp#pkg-constants).
+	 This ensures that we don't unintentionally default to "good" when there's no map entry.
+	*/
 	v, ok := StatusAssertionIntToVal[sa]
 	if !ok {
 		// set unknown as fallback
@@ -63,6 +70,8 @@ func GetStatusAssertionStr(sa int) string {
 }
 
 func (sa StatusAssertion) MarshalJSON() ([]byte, error) {
+	// This ensures that we don't unintentionally default to "good" when there's no map entry.
+	// (see more details in the GetStatusAssertionStr() comment)
 	str, ok := StatusAssertionValToStr[sa]
 	if !ok {
 		// set unknown as fallback
@@ -72,6 +81,8 @@ func (sa StatusAssertion) MarshalJSON() ([]byte, error) {
 }
 
 func (sa *StatusAssertion) UnmarshalJSON(in []byte) error {
+	// This ensures that we don't unintentionally default to "good" when there's no map entry.
+	// (see more details in the GetStatusAssertionStr() comment)
 	v, ok := StatusAssertionStrToVal[strings.ReplaceAll(string(in), "\"", "")]
 	if !ok {
 		// set unknown as fallback

--- a/server/certidp/certidp_test.go
+++ b/server/certidp/certidp_test.go
@@ -1,0 +1,56 @@
+// Copyright 2023 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certidp
+
+import "testing"
+
+// Checks the return values of the function GetStatusAssertionStr
+func TestGetStatusAssertionStr(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    int
+		expected string
+	}{
+		{
+			name:     "GoodStatus",
+			input:    0,
+			expected: "good",
+		},
+		{
+			name:     "RevokedStatus",
+			input:    1,
+			expected: "revoked",
+		},
+		{
+			name:     "UnknownStatus",
+			input:    2,
+			expected: "unknown",
+		},
+		// Invalid status assertion value.
+		{
+			name:     "InvalidStatus",
+			input:    42,
+			expected: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetStatusAssertionStr(tt.input)
+			if got != tt.expected {
+				t.Errorf("Expected GetStatusAssertionStr: %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Changes Proposed**
This pull request introduces a modification to the GetStatusAssertionStr

This change ensures that if no suitable value is found in the mapping (StatusAssertionIntToVal), the function will now default to returning "unknown" (from ocsp.Unknown).

**Motivation**
The motivation behind this change is to enhance the robustness of the GetStatus Assertion Str function. Previously, if the provided status assertion value did not exist in the map, the function return ocsp.Good.

**Unit Tests**
Unit tests have been added to cover various scenarios, including valid status assertion values for "good," "revoked," and "unknown," as well as an invalid status assertion value.

Please review this pull request 

Signed-off-by: Denis Korovin @korovindenis
