### PR TITLE
badges: add ArtifactHub; normalize CIIBestPractices

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [NATS](https://nats.io) is a simple, secure and performant communications system for digital systems, services and devices. NATS is part of the Cloud Native Computing Foundation ([CNCF](https://cncf.io)). NATS has over [40 client language implementations](https://nats.io/download/), and its server can run on-premise, in the cloud, at the edge, and even on a Raspberry Pi. NATS can secure and simplify design and operation of modern distributed systems.
 
-[![License][License-Image]][License-Url] [![Build][Build-Status-Image]][Build-Status-Url] [![Release][Release-Image]][Release-Url] [![Slack][Slack-Image]][Slack-Url] [![Coverage][Coverage-Image]][Coverage-Url] [![Docker Downloads][Docker-Image]][Docker-Url] [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1895/badge)](https://bestpractices.coreinfrastructure.org/projects/1895)
+[![License][License-Image]][License-Url] [![Build][Build-Status-Image]][Build-Status-Url] [![Release][Release-Image]][Release-Url] [![Slack][Slack-Image]][Slack-Url] [![Coverage][Coverage-Image]][Coverage-Url] [![Docker Downloads][Docker-Image]][Docker-Url] [![CII Best Practices][CIIBestPractices-Image]][CIIBestPractices-Url] [![Artifact Hub][ArtifactHub-Image]][ArtifactHub-Url]
 
 ## Documentation
 
@@ -43,6 +43,10 @@ If you are interested in contributing to NATS, read about our...
 [Coverage-image]: https://coveralls.io/repos/github/nats-io/nats-server/badge.svg?branch=main
 [ReportCard-Url]: https://goreportcard.com/report/nats-io/nats-server
 [ReportCard-Image]: https://goreportcard.com/badge/github.com/nats-io/nats-server
+[CIIBestPractices-Url]: https://bestpractices.coreinfrastructure.org/projects/1895
+[CIIBestPractices-Image]: https://bestpractices.coreinfrastructure.org/projects/1895/badge
+[ArtifactHub-Url]: https://artifacthub.io/packages/helm/nats/nats
+[ArtifactHub-Image]: https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/nats
 [github-release]: https://github.com/nats-io/nats-server/releases/
 
 ## Roadmap


### PR DESCRIPTION
We have an existing Artifacts Hub repository, based on the nats-io/k8s repo.

Including a badge which links to that repository should resolve the "Artifact Hub badge" item in the CLOMonitor report on nats.

While there, normalise the "CII Best Practices" badge to use markdown reference links, the same as all the other badges.

Signed-off-by: Phil Pennock <pdp@nats.io>