### PR TITLE
Optimise metalayer snapshots

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -133,6 +133,12 @@ const (
 	actionCreateOrUpdateJSONString = `""`
 )
 
+var (
+	actionUpdateJSONBytes         = []byte(actionUpdateJSONString)
+	actionCreateJSONBytes         = []byte(actionCreateJSONString)
+	actionCreateOrUpdateJSONBytes = []byte(actionCreateOrUpdateJSONString)
+)
+
 func (a ConsumerAction) String() string {
 	switch a {
 	case ActionCreateOrUpdate:
@@ -148,11 +154,11 @@ func (a ConsumerAction) String() string {
 func (a ConsumerAction) MarshalJSON() ([]byte, error) {
 	switch a {
 	case ActionCreate:
-		return []byte(actionCreateJSONString), nil
+		return actionCreateJSONBytes, nil
 	case ActionUpdate:
-		return []byte(actionUpdateJSONString), nil
+		return actionUpdateJSONBytes, nil
 	case ActionCreateOrUpdate:
-		return []byte(actionCreateOrUpdateJSONString), nil
+		return actionCreateOrUpdateJSONBytes, nil
 	default:
 		return nil, fmt.Errorf("can not marshal %v", a)
 	}

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -128,30 +128,31 @@ const (
 )
 
 const (
-	actionUpdateString         = "update"
-	actionCreateString         = "create"
-	actionCreateOrUpdateString = ""
+	actionUpdateJSONString         = `"update"`
+	actionCreateJSONString         = `"create"`
+	actionCreateOrUpdateJSONString = `""`
 )
 
 func (a ConsumerAction) String() string {
 	switch a {
 	case ActionCreateOrUpdate:
-		return actionCreateOrUpdateString
+		return actionCreateOrUpdateJSONString
 	case ActionCreate:
-		return actionCreateString
+		return actionCreateJSONString
 	case ActionUpdate:
-		return actionUpdateString
+		return actionUpdateJSONString
 	}
-	return actionCreateOrUpdateString
+	return actionCreateOrUpdateJSONString
 }
+
 func (a ConsumerAction) MarshalJSON() ([]byte, error) {
 	switch a {
 	case ActionCreate:
-		return json.Marshal(actionCreateString)
+		return []byte(actionCreateJSONString), nil
 	case ActionUpdate:
-		return json.Marshal(actionUpdateString)
+		return []byte(actionUpdateJSONString), nil
 	case ActionCreateOrUpdate:
-		return json.Marshal(actionCreateOrUpdateString)
+		return []byte(actionCreateOrUpdateJSONString), nil
 	default:
 		return nil, fmt.Errorf("can not marshal %v", a)
 	}
@@ -159,11 +160,11 @@ func (a ConsumerAction) MarshalJSON() ([]byte, error) {
 
 func (a *ConsumerAction) UnmarshalJSON(data []byte) error {
 	switch string(data) {
-	case jsonString("create"):
+	case actionCreateJSONString:
 		*a = ActionCreate
-	case jsonString("update"):
+	case actionUpdateJSONString:
 		*a = ActionUpdate
-	case jsonString(""):
+	case actionCreateOrUpdateJSONString:
 		*a = ActionCreateOrUpdate
 	default:
 		return fmt.Errorf("unknown consumer action: %v", string(data))
@@ -249,9 +250,9 @@ const (
 func (r ReplayPolicy) String() string {
 	switch r {
 	case ReplayInstant:
-		return "instant"
+		return replayInstantPolicyJSONString
 	default:
-		return "original"
+		return replayOriginalPolicyJSONString
 	}
 }
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1455,18 +1455,22 @@ func (js *jetStream) clusterStreamConfig(accName, streamName string) (StreamConf
 }
 
 func (js *jetStream) metaSnapshot() []byte {
-	var streams []writeableStreamAssignment
-
 	js.mu.RLock()
 	cc := js.cluster
+	nsa := 0
+	for _, asa := range cc.streams {
+		nsa += len(asa)
+	}
+	streams := make([]writeableStreamAssignment, 0, nsa)
 	for _, asa := range cc.streams {
 		for _, sa := range asa {
 			wsa := writeableStreamAssignment{
-				Client:  sa.Client,
-				Created: sa.Created,
-				Config:  sa.Config,
-				Group:   sa.Group,
-				Sync:    sa.Sync,
+				Client:    sa.Client,
+				Created:   sa.Created,
+				Config:    sa.Config,
+				Group:     sa.Group,
+				Sync:      sa.Sync,
+				Consumers: make([]*consumerAssignment, 0, len(sa.consumers)),
 			}
 			for _, ca := range sa.consumers {
 				wsa.Consumers = append(wsa.Consumers, ca)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3148,17 +3148,17 @@ func (t HealthZErrorType) MarshalJSON() ([]byte, error) {
 
 func (t *HealthZErrorType) UnmarshalJSON(data []byte) error {
 	switch string(data) {
-	case jsonString("CONNECTION"):
+	case `"CONNECTION"`:
 		*t = HealthzErrorConn
-	case jsonString("BAD_REQUEST"):
+	case `"BAD_REQUEST"`:
 		*t = HealthzErrorBadRequest
-	case jsonString("JETSTREAM"):
+	case `"JETSTREAM"`:
 		*t = HealthzErrorJetStream
-	case jsonString("ACCOUNT"):
+	case `"ACCOUNT"`:
 		*t = HealthzErrorAccount
-	case jsonString("STREAM"):
+	case `"STREAM"`:
 		*t = HealthzErrorStream
-	case jsonString("CONSUMER"):
+	case `"CONSUMER"`:
 		*t = HealthzErrorConsumer
 	default:
 		return fmt.Errorf("unknown healthz error type %q", data)

--- a/server/store.go
+++ b/server/store.go
@@ -15,7 +15,6 @@ package server
 
 import (
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -442,14 +441,10 @@ type TemplateStore interface {
 	Delete(*streamTemplate) error
 }
 
-func jsonString(s string) string {
-	return "\"" + s + "\""
-}
-
 const (
-	limitsPolicyString    = "limits"
-	interestPolicyString  = "interest"
-	workQueuePolicyString = "workqueue"
+	limitsPolicyJSONString    = `"limits"`
+	interestPolicyJSONString  = `"interest"`
+	workQueuePolicyJSONString = `"workqueue"`
 )
 
 func (rp RetentionPolicy) String() string {
@@ -468,11 +463,11 @@ func (rp RetentionPolicy) String() string {
 func (rp RetentionPolicy) MarshalJSON() ([]byte, error) {
 	switch rp {
 	case LimitsPolicy:
-		return json.Marshal(limitsPolicyString)
+		return []byte(limitsPolicyJSONString), nil
 	case InterestPolicy:
-		return json.Marshal(interestPolicyString)
+		return []byte(interestPolicyJSONString), nil
 	case WorkQueuePolicy:
-		return json.Marshal(workQueuePolicyString)
+		return []byte(workQueuePolicyJSONString), nil
 	default:
 		return nil, fmt.Errorf("can not marshal %v", rp)
 	}
@@ -480,11 +475,11 @@ func (rp RetentionPolicy) MarshalJSON() ([]byte, error) {
 
 func (rp *RetentionPolicy) UnmarshalJSON(data []byte) error {
 	switch string(data) {
-	case jsonString(limitsPolicyString):
+	case limitsPolicyJSONString:
 		*rp = LimitsPolicy
-	case jsonString(interestPolicyString):
+	case interestPolicyJSONString:
 		*rp = InterestPolicy
-	case jsonString(workQueuePolicyString):
+	case workQueuePolicyJSONString:
 		*rp = WorkQueuePolicy
 	default:
 		return fmt.Errorf("can not unmarshal %q", data)
@@ -506,9 +501,9 @@ func (dp DiscardPolicy) String() string {
 func (dp DiscardPolicy) MarshalJSON() ([]byte, error) {
 	switch dp {
 	case DiscardOld:
-		return json.Marshal("old")
+		return []byte(`"old"`), nil
 	case DiscardNew:
-		return json.Marshal("new")
+		return []byte(`"new"`), nil
 	default:
 		return nil, fmt.Errorf("can not marshal %v", dp)
 	}
@@ -516,9 +511,9 @@ func (dp DiscardPolicy) MarshalJSON() ([]byte, error) {
 
 func (dp *DiscardPolicy) UnmarshalJSON(data []byte) error {
 	switch strings.ToLower(string(data)) {
-	case jsonString("old"):
+	case `"old"`:
 		*dp = DiscardOld
-	case jsonString("new"):
+	case `"new"`:
 		*dp = DiscardNew
 	default:
 		return fmt.Errorf("can not unmarshal %q", data)
@@ -527,9 +522,9 @@ func (dp *DiscardPolicy) UnmarshalJSON(data []byte) error {
 }
 
 const (
-	memoryStorageString = "memory"
-	fileStorageString   = "file"
-	anyStorageString    = "any"
+	memoryStorageJSONString = `"memory"`
+	fileStorageJSONString   = `"file"`
+	anyStorageJSONString    = `"any"`
 )
 
 func (st StorageType) String() string {
@@ -548,11 +543,11 @@ func (st StorageType) String() string {
 func (st StorageType) MarshalJSON() ([]byte, error) {
 	switch st {
 	case MemoryStorage:
-		return json.Marshal(memoryStorageString)
+		return []byte(memoryStorageJSONString), nil
 	case FileStorage:
-		return json.Marshal(fileStorageString)
+		return []byte(fileStorageJSONString), nil
 	case AnyStorage:
-		return json.Marshal(anyStorageString)
+		return []byte(anyStorageJSONString), nil
 	default:
 		return nil, fmt.Errorf("can not marshal %v", st)
 	}
@@ -560,11 +555,11 @@ func (st StorageType) MarshalJSON() ([]byte, error) {
 
 func (st *StorageType) UnmarshalJSON(data []byte) error {
 	switch string(data) {
-	case jsonString(memoryStorageString):
+	case memoryStorageJSONString:
 		*st = MemoryStorage
-	case jsonString(fileStorageString):
+	case fileStorageJSONString:
 		*st = FileStorage
-	case jsonString(anyStorageString):
+	case anyStorageJSONString:
 		*st = AnyStorage
 	default:
 		return fmt.Errorf("can not unmarshal %q", data)
@@ -573,19 +568,19 @@ func (st *StorageType) UnmarshalJSON(data []byte) error {
 }
 
 const (
-	ackNonePolicyString     = "none"
-	ackAllPolicyString      = "all"
-	ackExplicitPolicyString = "explicit"
+	ackNonePolicyJSONString     = `"none"`
+	ackAllPolicyJSONString      = `"all"`
+	ackExplicitPolicyJSONString = `"explicit"`
 )
 
 func (ap AckPolicy) MarshalJSON() ([]byte, error) {
 	switch ap {
 	case AckNone:
-		return json.Marshal(ackNonePolicyString)
+		return []byte(ackNonePolicyJSONString), nil
 	case AckAll:
-		return json.Marshal(ackAllPolicyString)
+		return []byte(ackAllPolicyJSONString), nil
 	case AckExplicit:
-		return json.Marshal(ackExplicitPolicyString)
+		return []byte(ackExplicitPolicyJSONString), nil
 	default:
 		return nil, fmt.Errorf("can not marshal %v", ap)
 	}
@@ -593,11 +588,11 @@ func (ap AckPolicy) MarshalJSON() ([]byte, error) {
 
 func (ap *AckPolicy) UnmarshalJSON(data []byte) error {
 	switch string(data) {
-	case jsonString(ackNonePolicyString):
+	case ackNonePolicyJSONString:
 		*ap = AckNone
-	case jsonString(ackAllPolicyString):
+	case ackAllPolicyJSONString:
 		*ap = AckAll
-	case jsonString(ackExplicitPolicyString):
+	case ackExplicitPolicyJSONString:
 		*ap = AckExplicit
 	default:
 		return fmt.Errorf("can not unmarshal %q", data)
@@ -606,16 +601,16 @@ func (ap *AckPolicy) UnmarshalJSON(data []byte) error {
 }
 
 const (
-	replayInstantPolicyString  = "instant"
-	replayOriginalPolicyString = "original"
+	replayInstantPolicyJSONString  = `"instant"`
+	replayOriginalPolicyJSONString = `"original"`
 )
 
 func (rp ReplayPolicy) MarshalJSON() ([]byte, error) {
 	switch rp {
 	case ReplayInstant:
-		return json.Marshal(replayInstantPolicyString)
+		return []byte(replayInstantPolicyJSONString), nil
 	case ReplayOriginal:
-		return json.Marshal(replayOriginalPolicyString)
+		return []byte(replayOriginalPolicyJSONString), nil
 	default:
 		return nil, fmt.Errorf("can not marshal %v", rp)
 	}
@@ -623,9 +618,9 @@ func (rp ReplayPolicy) MarshalJSON() ([]byte, error) {
 
 func (rp *ReplayPolicy) UnmarshalJSON(data []byte) error {
 	switch string(data) {
-	case jsonString(replayInstantPolicyString):
+	case replayInstantPolicyJSONString:
 		*rp = ReplayInstant
-	case jsonString(replayOriginalPolicyString):
+	case replayOriginalPolicyJSONString:
 		*rp = ReplayOriginal
 	default:
 		return fmt.Errorf("can not unmarshal %q", data)
@@ -634,28 +629,28 @@ func (rp *ReplayPolicy) UnmarshalJSON(data []byte) error {
 }
 
 const (
-	deliverAllPolicyString       = "all"
-	deliverLastPolicyString      = "last"
-	deliverNewPolicyString       = "new"
-	deliverByStartSequenceString = "by_start_sequence"
-	deliverByStartTimeString     = "by_start_time"
-	deliverLastPerPolicyString   = "last_per_subject"
-	deliverUndefinedString       = "undefined"
+	deliverAllPolicyJSONString       = `"all"`
+	deliverLastPolicyJSONString      = `"last"`
+	deliverNewPolicyJSONString       = `"new"`
+	deliverByStartSequenceJSONString = `"by_start_sequence"`
+	deliverByStartTimeJSONString     = `"by_start_time"`
+	deliverLastPerPolicyJSONString   = `"last_per_subject"`
+	deliverUndefinedJSONString       = `"undefined"`
 )
 
 func (p *DeliverPolicy) UnmarshalJSON(data []byte) error {
 	switch string(data) {
-	case jsonString(deliverAllPolicyString), jsonString(deliverUndefinedString):
+	case deliverAllPolicyJSONString, deliverUndefinedJSONString:
 		*p = DeliverAll
-	case jsonString(deliverLastPolicyString):
+	case deliverLastPolicyJSONString:
 		*p = DeliverLast
-	case jsonString(deliverLastPerPolicyString):
+	case deliverLastPerPolicyJSONString:
 		*p = DeliverLastPerSubject
-	case jsonString(deliverNewPolicyString):
+	case deliverNewPolicyJSONString:
 		*p = DeliverNew
-	case jsonString(deliverByStartSequenceString):
+	case deliverByStartSequenceJSONString:
 		*p = DeliverByStartSequence
-	case jsonString(deliverByStartTimeString):
+	case deliverByStartTimeJSONString:
 		*p = DeliverByStartTime
 	default:
 		return fmt.Errorf("can not unmarshal %q", data)
@@ -667,19 +662,19 @@ func (p *DeliverPolicy) UnmarshalJSON(data []byte) error {
 func (p DeliverPolicy) MarshalJSON() ([]byte, error) {
 	switch p {
 	case DeliverAll:
-		return json.Marshal(deliverAllPolicyString)
+		return []byte(deliverAllPolicyJSONString), nil
 	case DeliverLast:
-		return json.Marshal(deliverLastPolicyString)
+		return []byte(deliverLastPolicyJSONString), nil
 	case DeliverLastPerSubject:
-		return json.Marshal(deliverLastPerPolicyString)
+		return []byte(deliverLastPerPolicyJSONString), nil
 	case DeliverNew:
-		return json.Marshal(deliverNewPolicyString)
+		return []byte(deliverNewPolicyJSONString), nil
 	case DeliverByStartSequence:
-		return json.Marshal(deliverByStartSequenceString)
+		return []byte(deliverByStartSequenceJSONString), nil
 	case DeliverByStartTime:
-		return json.Marshal(deliverByStartTimeString)
+		return []byte(deliverByStartTimeJSONString), nil
 	default:
-		return json.Marshal(deliverUndefinedString)
+		return []byte(deliverUndefinedJSONString), nil
 	}
 }
 

--- a/server/store.go
+++ b/server/store.go
@@ -447,6 +447,12 @@ const (
 	workQueuePolicyJSONString = `"workqueue"`
 )
 
+var (
+	limitsPolicyJSONBytes    = []byte(limitsPolicyJSONString)
+	interestPolicyJSONBytes  = []byte(interestPolicyJSONString)
+	workQueuePolicyJSONBytes = []byte(workQueuePolicyJSONString)
+)
+
 func (rp RetentionPolicy) String() string {
 	switch rp {
 	case LimitsPolicy:
@@ -463,11 +469,11 @@ func (rp RetentionPolicy) String() string {
 func (rp RetentionPolicy) MarshalJSON() ([]byte, error) {
 	switch rp {
 	case LimitsPolicy:
-		return []byte(limitsPolicyJSONString), nil
+		return limitsPolicyJSONBytes, nil
 	case InterestPolicy:
-		return []byte(interestPolicyJSONString), nil
+		return interestPolicyJSONBytes, nil
 	case WorkQueuePolicy:
-		return []byte(workQueuePolicyJSONString), nil
+		return workQueuePolicyJSONBytes, nil
 	default:
 		return nil, fmt.Errorf("can not marshal %v", rp)
 	}
@@ -527,6 +533,12 @@ const (
 	anyStorageJSONString    = `"any"`
 )
 
+var (
+	memoryStorageJSONBytes = []byte(memoryStorageJSONString)
+	fileStorageJSONBytes   = []byte(fileStorageJSONString)
+	anyStorageJSONBytes    = []byte(anyStorageJSONString)
+)
+
 func (st StorageType) String() string {
 	switch st {
 	case MemoryStorage:
@@ -543,11 +555,11 @@ func (st StorageType) String() string {
 func (st StorageType) MarshalJSON() ([]byte, error) {
 	switch st {
 	case MemoryStorage:
-		return []byte(memoryStorageJSONString), nil
+		return memoryStorageJSONBytes, nil
 	case FileStorage:
-		return []byte(fileStorageJSONString), nil
+		return fileStorageJSONBytes, nil
 	case AnyStorage:
-		return []byte(anyStorageJSONString), nil
+		return anyStorageJSONBytes, nil
 	default:
 		return nil, fmt.Errorf("can not marshal %v", st)
 	}
@@ -573,14 +585,20 @@ const (
 	ackExplicitPolicyJSONString = `"explicit"`
 )
 
+var (
+	ackNonePolicyJSONBytes     = []byte(ackNonePolicyJSONString)
+	ackAllPolicyJSONBytes      = []byte(ackAllPolicyJSONString)
+	ackExplicitPolicyJSONBytes = []byte(ackExplicitPolicyJSONString)
+)
+
 func (ap AckPolicy) MarshalJSON() ([]byte, error) {
 	switch ap {
 	case AckNone:
-		return []byte(ackNonePolicyJSONString), nil
+		return ackNonePolicyJSONBytes, nil
 	case AckAll:
-		return []byte(ackAllPolicyJSONString), nil
+		return ackAllPolicyJSONBytes, nil
 	case AckExplicit:
-		return []byte(ackExplicitPolicyJSONString), nil
+		return ackExplicitPolicyJSONBytes, nil
 	default:
 		return nil, fmt.Errorf("can not marshal %v", ap)
 	}
@@ -605,12 +623,17 @@ const (
 	replayOriginalPolicyJSONString = `"original"`
 )
 
+var (
+	replayInstantPolicyJSONBytes  = []byte(replayInstantPolicyJSONString)
+	replayOriginalPolicyJSONBytes = []byte(replayOriginalPolicyJSONString)
+)
+
 func (rp ReplayPolicy) MarshalJSON() ([]byte, error) {
 	switch rp {
 	case ReplayInstant:
-		return []byte(replayInstantPolicyJSONString), nil
+		return replayInstantPolicyJSONBytes, nil
 	case ReplayOriginal:
-		return []byte(replayOriginalPolicyJSONString), nil
+		return replayOriginalPolicyJSONBytes, nil
 	default:
 		return nil, fmt.Errorf("can not marshal %v", rp)
 	}
@@ -638,6 +661,16 @@ const (
 	deliverUndefinedJSONString       = `"undefined"`
 )
 
+var (
+	deliverAllPolicyJSONBytes       = []byte(deliverAllPolicyJSONString)
+	deliverLastPolicyJSONBytes      = []byte(deliverLastPolicyJSONString)
+	deliverNewPolicyJSONBytes       = []byte(deliverNewPolicyJSONString)
+	deliverByStartSequenceJSONBytes = []byte(deliverByStartSequenceJSONString)
+	deliverByStartTimeJSONBytes     = []byte(deliverByStartTimeJSONString)
+	deliverLastPerPolicyJSONBytes   = []byte(deliverLastPerPolicyJSONString)
+	deliverUndefinedJSONBytes       = []byte(deliverUndefinedJSONString)
+)
+
 func (p *DeliverPolicy) UnmarshalJSON(data []byte) error {
 	switch string(data) {
 	case deliverAllPolicyJSONString, deliverUndefinedJSONString:
@@ -662,19 +695,19 @@ func (p *DeliverPolicy) UnmarshalJSON(data []byte) error {
 func (p DeliverPolicy) MarshalJSON() ([]byte, error) {
 	switch p {
 	case DeliverAll:
-		return []byte(deliverAllPolicyJSONString), nil
+		return deliverAllPolicyJSONBytes, nil
 	case DeliverLast:
-		return []byte(deliverLastPolicyJSONString), nil
+		return deliverLastPolicyJSONBytes, nil
 	case DeliverLastPerSubject:
-		return []byte(deliverLastPerPolicyJSONString), nil
+		return deliverLastPerPolicyJSONBytes, nil
 	case DeliverNew:
-		return []byte(deliverNewPolicyJSONString), nil
+		return deliverNewPolicyJSONBytes, nil
 	case DeliverByStartSequence:
-		return []byte(deliverByStartSequenceJSONString), nil
+		return deliverByStartSequenceJSONBytes, nil
 	case DeliverByStartTime:
-		return []byte(deliverByStartTimeJSONString), nil
+		return deliverByStartTimeJSONBytes, nil
 	default:
-		return []byte(deliverUndefinedJSONString), nil
+		return deliverUndefinedJSONBytes, nil
 	}
 }
 


### PR DESCRIPTION
This PR optimises the marshalling of metalayer snapshots with a few techniques:

* Simplifies the custom marshalers for a number of types that appear often in the snapshotted config, as these were using reflection unnecessarily
* Simplifies the custom unmarshallers for the same types, as these were string-building more than necessary
* Attempts to reduce the number of reallocations that might happen in `metaSnapshot()` by preallocating slices

Signed-off-by: Neil Twigg <neil@nats.io>
