### PR TITLE
[IMPROVED] Avoid stream locks for certain operations that could block routes/gateways.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The NATS Authors
+// Copyright 2019-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -707,15 +707,15 @@ func (mset *stream) addConsumer(config *ConsumerConfig) (*consumer, error) {
 }
 
 func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname string, ca *consumerAssignment, isRecovering bool, action ConsumerAction) (*consumer, error) {
-	mset.mu.RLock()
-	s, jsa, tierName, cfg, acc, closed := mset.srv, mset.jsa, mset.tier, mset.cfg, mset.acc, mset.closed
-	retention := cfg.Retention
-	mset.mu.RUnlock()
-
 	// Check if this stream has closed.
-	if closed {
+	if mset.closed.Load() {
 		return nil, NewJSStreamInvalidError()
 	}
+
+	mset.mu.RLock()
+	s, jsa, tierName, cfg, acc := mset.srv, mset.jsa, mset.tier, mset.cfg, mset.acc
+	retention := cfg.Retention
+	mset.mu.RUnlock()
 
 	// If we do not have the consumer currently assigned to us in cluster mode we will proceed but warn.
 	// This can happen on startup with restored state where on meta replay we still do not have

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The NATS Authors
+// Copyright 2019-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The NATS Authors
+// Copyright 2019-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -3717,7 +3717,7 @@ func (s *Server) streamSnapshot(ci *ClientInfo, acc *Account, mset *stream, sr *
 
 	// We will place sequence number and size of chunk sent in the reply.
 	ackSubj := fmt.Sprintf(jsSnapshotAckT, mset.name(), nuid.Next())
-	ackSub, _ := mset.subscribeInternalUnlocked(ackSubj+".>", func(_ *subscription, _ *client, _ *Account, subject, _ string, _ []byte) {
+	ackSub, _ := mset.subscribeInternal(ackSubj+".>", func(_ *subscription, _ *client, _ *Account, subject, _ string, _ []byte) {
 		cs, _ := strconv.Atoi(tokenAt(subject, 6))
 		// This is very crude and simple, but ok for now.
 		// This only matters when sending multiple chunks.

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -3728,7 +3728,7 @@ func (s *Server) streamSnapshot(ci *ClientInfo, acc *Account, mset *stream, sr *
 			}
 		}
 	})
-	defer mset.unsubscribeUnlocked(ackSub)
+	defer mset.unsubscribe(ackSub)
 
 	// TODO(dlc) - Add in NATS-Chunked-Sequence header
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7748,21 +7748,15 @@ func (mset *stream) hasCatchupPeers() bool {
 }
 
 func (mset *stream) setCatchingUp() {
-	mset.mu.Lock()
-	mset.catchup = true
-	mset.mu.Unlock()
+	mset.catchup.Store(true)
 }
 
 func (mset *stream) clearCatchingUp() {
-	mset.mu.Lock()
-	mset.catchup = false
-	mset.mu.Unlock()
+	mset.catchup.Store(false)
 }
 
 func (mset *stream) isCatchingUp() bool {
-	mset.mu.RLock()
-	defer mset.mu.RUnlock()
-	return mset.catchup
+	return mset.catchup.Load()
 }
 
 // Determine if a non-leader is current.
@@ -7771,7 +7765,7 @@ func (mset *stream) isCurrent() bool {
 	if mset.node == nil {
 		return true
 	}
-	return mset.node.Current() && !mset.catchup
+	return mset.node.Current() && !mset.catchup.Load()
 }
 
 // Maximum requests for the whole server that can be in flight at the same time.

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The NATS Authors
+// Copyright 2019-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The NATS Authors
+// Copyright 2018-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/server/store.go
+++ b/server/store.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The NATS Authors
+// Copyright 2019-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/server/stream.go
+++ b/server/stream.go
@@ -277,7 +277,7 @@ type stream struct {
 	// Clustered mode.
 	sa         *streamAssignment
 	node       RaftNode
-	catchup    bool
+	catchup    atomic.Bool
 	syncSub    *subscription
 	infoSub    *subscription
 	clMu       sync.Mutex

--- a/server/stream.go
+++ b/server/stream.go
@@ -2689,9 +2689,9 @@ func (mset *stream) setupMirrorConsumer() error {
 			}
 			mset.mu.Unlock()
 			ready.Wait()
-		case <-time.After(30 * time.Second):
+		case <-time.After(5 * time.Second):
 			mset.unsubscribe(crSub)
-			// We already waited 30 seconds, let's retry now.
+			// We already waited 5 seconds, let's retry now.
 			retry = true
 		}
 	}()
@@ -3043,9 +3043,9 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64, startTime time.T
 			}
 			mset.mu.Unlock()
 			ready.Wait()
-		case <-time.After(30 * time.Second):
+		case <-time.After(5 * time.Second):
 			mset.unsubscribe(crSub)
-			// We already waited 30 seconds, let's retry now.
+			// We already waited 5 seconds, let's retry now.
 			retry = true
 		}
 	}()

--- a/server/stream.go
+++ b/server/stream.go
@@ -2546,7 +2546,7 @@ func (mset *stream) setupMirrorConsumer() error {
 	respCh := make(chan *JSApiConsumerCreateResponse, 1)
 	reply := infoReplySubject()
 	crSub, err := mset.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-		mset.unsubscribeUnlocked(sub)
+		mset.unsubscribe(sub)
 		_, msg := c.msgParts(rmsg)
 
 		var ccr JSApiConsumerCreateResponse
@@ -2690,7 +2690,7 @@ func (mset *stream) setupMirrorConsumer() error {
 			mset.mu.Unlock()
 			ready.Wait()
 		case <-time.After(30 * time.Second):
-			mset.unsubscribeUnlocked(crSub)
+			mset.unsubscribe(crSub)
 			// We already waited 30 seconds, let's retry now.
 			retry = true
 		}
@@ -2908,7 +2908,7 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64, startTime time.T
 	respCh := make(chan *JSApiConsumerCreateResponse, 1)
 	reply := infoReplySubject()
 	crSub, err := mset.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-		mset.unsubscribeUnlocked(sub)
+		mset.unsubscribe(sub)
 		_, msg := c.msgParts(rmsg)
 		var ccr JSApiConsumerCreateResponse
 		if err := json.Unmarshal(msg, &ccr); err != nil {
@@ -3044,7 +3044,7 @@ func (mset *stream) setSourceConsumer(iname string, seq uint64, startTime time.T
 			mset.mu.Unlock()
 			ready.Wait()
 		case <-time.After(30 * time.Second):
-			mset.unsubscribeUnlocked(crSub)
+			mset.unsubscribe(crSub)
 			// We already waited 30 seconds, let's retry now.
 			retry = true
 		}
@@ -3732,12 +3732,6 @@ func (mset *stream) unsubscribe(sub *subscription) {
 		return
 	}
 	mset.client.processUnsub(sub.sid)
-}
-
-func (mset *stream) unsubscribeUnlocked(sub *subscription) {
-	mset.mu.Lock()
-	mset.unsubscribe(sub)
-	mset.mu.Unlock()
 }
 
 func (mset *stream) setupStore(fsCfg *FileStoreConfig) error {


### PR DESCRIPTION
Avoid needing the lock for mset subscriptions to avoid possibly blocking routes/gateways.
Also increase timeout for consumer creation for sources since might take a bit longer.

 Signed-off-by: Derek Collison <derek@nats.io>