### PR TITLE
Bump Go version to 1.21.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ language: go
 go:
   # This should be quoted or use .x, but should not be unquoted.
   # Remember that a YAML bare float drops trailing zeroes.
-  - "1.21.5"
-  - "1.20.12"
+  - "1.21.6"
+  - "1.20.13"
 
 go_import_path: github.com/nats-io/nats-server
 


### PR DESCRIPTION
Test versions are now:
 - 1.21.6
 - 1.20.13