### PR TITLE
Don't unconditionally send consumer snapshot when becoming leader

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4660,16 +4660,6 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 				js.setConsumerAssignmentRecovering(ca)
 			}
 
-			// Synchronize everyone to our state.
-			if isLeader && n != nil {
-				// Only send out if we have state.
-				if _, _, applied := n.Progress(); applied > 0 {
-					if snap, err := o.store.EncodedState(); err == nil {
-						n.SendSnapshot(snap)
-					}
-				}
-			}
-
 			// Process the change.
 			if err := js.processConsumerLeaderChange(o, isLeader); err == nil && isLeader {
 				doSnapshot(true)


### PR DESCRIPTION
Feasibly a Raft node that is keeping up with its peers can become a leader regardless of whether or not the upper layer is caught up with its applies. Since the leader change notification to the upper state machine could interleave with the apply queue, then unconditionally sending a snapshot as a new append entry on consumer leader transitions could cause the rest of the group to revert to an earlier consumer state.

Signed-off-by: Neil Twigg <neil@nats.io>