### PR TITLE
Adds testing for backwards compatibility of pre 2.10 existing stream sources

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -334,8 +334,8 @@ func generateJSMappingTable(domain string) map[string]string {
 // JSMaxDescription is the maximum description length for streams and consumers.
 const JSMaxDescriptionLen = 4 * 1024
 
-// JSMaxMetadataLen is the maximum length for streams an consumers metadata map.
-// It's calculated by summing length of all keys an values.
+// JSMaxMetadataLen is the maximum length for streams and consumers metadata map.
+// It's calculated by summing length of all keys and values.
 const JSMaxMetadataLen = 128 * 1024
 
 // JSMaxNameLen is the maximum name lengths for streams, consumers and templates.


### PR DESCRIPTION
Adds testing for backwards compatibility of pre 2.10 existing stream sources which used a previous message header format, the header is used to find the starting point of the source's consumer on leadership changes or stream config updates when sources are added.