### PR TITLE
[IMPROVED] Do not load blocks when calling LoadNextMsg for the first time after restart or long inactivity

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5960,6 +5960,16 @@ func (fs *fileStore) LoadNextMsg(filter string, wc bool, start uint64, sm *Store
 		start = fs.state.FirstSeq
 	}
 
+	// If start is less than or equal to beginning of our stream, meaning our first call,
+	// let's check the psim to see if we can skip ahead.
+	if start <= fs.state.FirstSeq {
+		var ss SimpleState
+		fs.numFilteredPending(filter, &ss)
+		if ss.First > start {
+			start = ss.First
+		}
+	}
+
 	if bi, _ := fs.selectMsgBlockWithIndex(start); bi >= 0 {
 		for i := bi; i < len(fs.blks); i++ {
 			mb := fs.blks[i]


### PR DESCRIPTION
If LoadNextMsg was called with start sequence == FirstSeq, we would walk all blocks, which if fss was loaded we could skip fairly quickly. However on a restart or no activity past a sync interval this could cause memory blocks to be loaded in just to be skipped.

https://github.com/nats-io/nats-server/discussions/4906

Signed-off-by: Derek Collison <derek@nats.io>