### PR TITLE
stree: Reduce allocations in `iter` and `match`

### DIFF
--- a/server/stree/parts.go
+++ b/server/stree/parts.go
@@ -116,6 +116,7 @@ func matchParts(parts [][]byte, frag []byte) ([][]byte, bool) {
 		// but update the part to what was consumed. This allows upper layers to continue.
 		if end < lp {
 			if end >= lf {
+				parts = append([][]byte{}, parts...) // Create a copy before modifying.
 				parts[i] = parts[i][lf:]
 			} else {
 				i++


### PR DESCRIPTION
The `_pre` and `cparts` copies are more often than not unnecessary and result in potentially gigabytes of allocations which can slow down functions like `NumPending`.

Passing `pre` and `nparts` down recursively without copies is usually safe, even where there are appends in those, because there is no concurrency and those appends will not modify the slice length back at the callsite. Instead we'll only reallocate either when `append` does so naturally (we've ran out of capacity) or when we know specifically that we're modifying something in-place (like in `matchParts`).

This improves performance of things like `NumPending` with high subject cardinality.

Signed-off-by: Neil Twigg <neil@nats.io>
