### PR TITLE
Benchmark JetStream consumer with filters

### DIFF
--- a/server/jetstream_benchmark_test.go
+++ b/server/jetstream_benchmark_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -397,6 +398,262 @@ func BenchmarkJetStreamConsume(b *testing.B) {
 						},
 					)
 				}
+			},
+		)
+	}
+}
+
+func BenchmarkJetStreamConsumeWithFilters(b *testing.B) {
+	const (
+		verbose          = false
+		streamName       = "S"
+		subjectPrefix    = "s"
+		seed             = 123456
+		messageSize      = 32
+		consumerReplicas = 1
+		domainNameLength = 36 // Length of domain portion of subject, must be an even number
+		publishBatchSize = 1000
+		publishTimeout   = 10 * time.Second
+	)
+
+	clusterSizeCases := []struct {
+		clusterSize int              // Single node or cluster
+		replicas    int              // Stream replicas
+		storage     nats.StorageType // Stream storage
+	}{
+		{1, 1, nats.MemoryStorage},
+		{3, 3, nats.MemoryStorage},
+	}
+
+	benchmarksCases := []struct {
+		domains             int // Number of distinct domains
+		subjectsPerDomain   int // Number of distinct subjects within each domain
+		filters             int // Number of filters (<prefix>.<domain>.>) per consumer
+		concurrentConsumers int // Number of consumer running
+
+	}{
+		{100, 10, 5, 12},
+		{1000, 10, 25, 12},
+		{10_000, 10, 50, 12},
+	}
+
+	for _, cs := range clusterSizeCases {
+		name := fmt.Sprintf(
+			"N=%d,R=%d,storage=%s",
+			cs.clusterSize,
+			cs.replicas,
+			cs.storage.String(),
+		)
+		b.Run(
+			name,
+			func(b *testing.B) {
+
+				for _, bc := range benchmarksCases {
+
+					name := fmt.Sprintf(
+						"D=%d,DS=%d,F=%d,C=%d",
+						bc.domains,
+						bc.subjectsPerDomain,
+						bc.filters,
+						bc.concurrentConsumers,
+					)
+
+					b.Run(
+						name,
+						func(b *testing.B) {
+
+							cl, s, shutdown, nc, js := startJSClusterAndConnect(b, cs.clusterSize)
+							defer shutdown()
+							defer nc.Close()
+
+							if verbose {
+								b.Logf("Creating stream with R=%d", cs.replicas)
+							}
+							streamConfig := &nats.StreamConfig{
+								Name:              streamName,
+								Subjects:          []string{subjectPrefix + ".>"},
+								Storage:           cs.storage,
+								Retention:         nats.LimitsPolicy,
+								MaxAge:            time.Hour,
+								Duplicates:        10 * time.Second,
+								Discard:           nats.DiscardOld,
+								NoAck:             false,
+								MaxMsgs:           -1,
+								MaxBytes:          -1,
+								MaxConsumers:      -1,
+								Replicas:          1,
+								MaxMsgsPerSubject: 1,
+							}
+							if _, err := js.AddStream(streamConfig); err != nil {
+								b.Fatalf("Error creating stream: %v", err)
+							}
+
+							// If replicated resource, connect to stream leader for lower variability
+							connectURL := s.ClientURL()
+							if cs.replicas > 1 {
+								connectURL = cl.streamLeader("$G", streamName).ClientURL()
+								nc.Close()
+								_, js = jsClientConnectURL(b, connectURL)
+							}
+
+							rng := rand.New(rand.NewSource(int64(seed)))
+							message := make([]byte, messageSize)
+							domain := make([]byte, domainNameLength/2)
+
+							domains := make([]string, 0, bc.domains*bc.subjectsPerDomain)
+
+							// Publish one message per subject for each domain
+							published := 0
+							totalMessages := bc.domains * bc.subjectsPerDomain
+							for d := 1; d <= bc.domains; d++ {
+								rng.Read(domain)
+								for s := 1; s <= bc.subjectsPerDomain; s++ {
+									rng.Read(message)
+									domainString := fmt.Sprintf("%X", domain)
+									domains = append(domains, domainString)
+									subject := fmt.Sprintf("%s.%s.%d", subjectPrefix, domainString, s)
+									_, err := js.PublishAsync(subject, message)
+									if err != nil {
+										b.Fatalf("failed to publish: %s", err)
+									}
+									published += 1
+
+									// Wait for all pending to be published before trying to publish the next batch
+									if published%publishBatchSize == 0 || published == totalMessages {
+										select {
+										case <-js.PublishAsyncComplete():
+											if verbose {
+												b.Logf("Published %d/%d messages", published, totalMessages)
+											}
+										case <-time.After(publishTimeout):
+											b.Fatalf("Publish timed out")
+										}
+									}
+
+								}
+							}
+
+							// Number of messages that each new consumer expects to consume
+							messagesPerIteration := bc.filters * bc.subjectsPerDomain
+
+							// Each call to 'subscribe_consume_unsubscribe' is one benchmark operation.
+							// i.e. subscribe_consume_unsubscribe will be called a total of b.N times (split among C threads)
+							// Each operation consists of:
+							// - Create filter
+							// - Create consumer / Subscribe
+							// - Consume expected number of messages
+							// - Unsubscribe
+							subscribeConsumeUnsubscribe := func(js nats.JetStreamContext, rng *rand.Rand) {
+
+								// Select F unique domains to create F non-overlapping filters
+								filterDomains := make(map[string]bool, bc.filters)
+								filters := make([]string, 0, bc.filters)
+								for len(filterDomains) < bc.filters {
+									domain := domains[rng.Intn(len(domains))]
+									filterDomains[domain] = true
+									filters = append(filters, fmt.Sprintf("%s.%s.>", subjectPrefix, domain))
+								}
+
+								if verbose {
+									b.Logf("Subscribe with filters: %+v", filters)
+								}
+
+								// Consumer callback
+								received := 0
+								consumeWg := sync.WaitGroup{}
+								consumeWg.Add(1)
+								cb := func(msg *nats.Msg) {
+									received += 1
+									if received == messagesPerIteration {
+										consumeWg.Done()
+										if verbose {
+											b.Logf("Received %d/%d messages", received, messagesPerIteration)
+										}
+									}
+								}
+
+								// Create consumer
+								subOpts := []nats.SubOpt{
+									nats.BindStream(streamName),
+									nats.OrderedConsumer(),
+									nats.ConsumerReplicas(consumerReplicas),
+									nats.ConsumerFilterSubjects(filters...),
+									nats.ConsumerMemoryStorage(),
+								}
+
+								var sub *nats.Subscription
+
+								sub, err := js.Subscribe("", cb, subOpts...)
+								if err != nil {
+									b.Fatalf("Failed to subscribe: %s", err)
+								}
+
+								defer func(sub *nats.Subscription) {
+									err := sub.Unsubscribe()
+									if err != nil {
+										b.Logf("Failed to unsubscribe: %s", err)
+									}
+								}(sub)
+
+								consumeWg.Wait()
+							}
+
+							// Wait for all consumer threads and main to be ready
+							wgReady := sync.WaitGroup{}
+							wgReady.Add(bc.concurrentConsumers + 1)
+							// Wait until all consumer threads have completed
+							wgCompleted := sync.WaitGroup{}
+							wgCompleted.Add(bc.concurrentConsumers)
+							// Operations left for consumer threads
+							opsCount := atomic.Int32{}
+							opsCount.Store(int32(b.N))
+
+							// Start a pool of C goroutines, each one with a dedicated connection.
+							for i := 1; i <= bc.concurrentConsumers; i++ {
+								go func(consumerId int) {
+
+									// Connect
+									nc, js := jsClientConnectURL(b, connectURL)
+									defer nc.Close()
+
+									// Signal completion of work
+									defer wgCompleted.Done()
+
+									rng := rand.New(rand.NewSource(int64(seed + consumerId)))
+
+									// Ready, wait for everyone else
+									wgReady.Done()
+									wgReady.Wait()
+
+									completed := 0
+									for opsCount.Add(-1) >= 0 {
+										subscribeConsumeUnsubscribe(js, rng)
+										completed += 1
+									}
+									if verbose {
+										b.Logf("Consumer thread %d completed %d of %d operations", consumerId, completed, b.N)
+									}
+								}(i)
+							}
+
+							// Wait for all consumers to be ready
+							wgReady.Done()
+							wgReady.Wait()
+
+							// Start measuring time
+							b.ResetTimer()
+
+							// Wait for consumers to have chewed through b.N operations
+							wgCompleted.Wait()
+							b.StopTimer()
+
+							// Throughput is not very important in this benchmark since each operation includes
+							// subscribe, unsubscribe and retrieves just a few bytes
+							//b.SetBytes(int64(messageSize * messagesPerIteration))
+						},
+					)
+				}
+
 			},
 		)
 	}


### PR DESCRIPTION
Creates a consumer with a number of filters pulling in order from a stream with high subject cardinality.
(Inspired by a similar [HoloPlot](https://github.com/holoplot) benchmark)


Signed-off-by: Marco Primi <marco@synadia.com>
