### PR TITLE
New benchmarks: filtered subscription, resource creation

### DIFF
--- a/server/jetstream_benchmark_test.go
+++ b/server/jetstream_benchmark_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -395,6 +396,265 @@ func BenchmarkJetStreamConsume(b *testing.B) {
 
 							b.ReportMetric(float64(duplicates)*100/float64(b.N), "%dupe")
 							b.ReportMetric(float64(errors)*100/float64(b.N), "%error")
+						},
+					)
+				}
+			},
+		)
+	}
+}
+
+func BenchmarkJetStreamConsumeWithFilters(b *testing.B) {
+	const (
+		verbose          = false
+		streamName       = "S"
+		subjectPrefix    = "s"
+		seed             = 123456
+		messageSize      = 32
+		consumerReplicas = 1
+		domainNameLength = 36 // Length of domain portion of subject, must be an even number
+		publishBatchSize = 1000
+		publishTimeout   = 10 * time.Second
+	)
+
+	clusterSizeCases := []struct {
+		clusterSize int              // Single node or cluster
+		replicas    int              // Stream replicas
+		storage     nats.StorageType // Stream storage
+	}{
+		{1, 1, nats.MemoryStorage},
+		{3, 3, nats.MemoryStorage},
+	}
+
+	benchmarksCases := []struct {
+		domains             int // Number of distinct domains
+		subjectsPerDomain   int // Number of distinct subjects within each domain
+		filters             int // Number of filters (<prefix>.<domain>.>) per consumer
+		concurrentConsumers int // Number of consumer running
+
+	}{
+		{100, 10, 5, 12},
+		{1000, 10, 25, 12},
+		{10_000, 10, 50, 12},
+	}
+
+	for _, cs := range clusterSizeCases {
+		name := fmt.Sprintf(
+			"N=%d,R=%d,storage=%s",
+			cs.clusterSize,
+			cs.replicas,
+			cs.storage.String(),
+		)
+		b.Run(
+			name,
+			func(b *testing.B) {
+
+				for _, bc := range benchmarksCases {
+
+					name := fmt.Sprintf(
+						"D=%d,DS=%d,F=%d,C=%d",
+						bc.domains,
+						bc.subjectsPerDomain,
+						bc.filters,
+						bc.concurrentConsumers,
+					)
+
+					b.Run(
+						name,
+						func(b *testing.B) {
+
+							cl, s, shutdown, nc, js := startJSClusterAndConnect(b, cs.clusterSize)
+							defer shutdown()
+							defer nc.Close()
+
+							if verbose {
+								b.Logf("Creating stream with R=%d", cs.replicas)
+							}
+							streamConfig := &nats.StreamConfig{
+								Name:              streamName,
+								Subjects:          []string{subjectPrefix + ".>"},
+								Storage:           cs.storage,
+								Retention:         nats.LimitsPolicy,
+								MaxAge:            time.Hour,
+								Duplicates:        10 * time.Second,
+								Discard:           nats.DiscardOld,
+								NoAck:             false,
+								MaxMsgs:           -1,
+								MaxBytes:          -1,
+								MaxConsumers:      -1,
+								Replicas:          1,
+								MaxMsgsPerSubject: 1,
+							}
+							if _, err := js.AddStream(streamConfig); err != nil {
+								b.Fatalf("Error creating stream: %v", err)
+							}
+
+							// If replicated resource, connect to stream leader for lower variability
+							connectURL := s.ClientURL()
+							if cs.replicas > 1 {
+								connectURL = cl.streamLeader("$G", streamName).ClientURL()
+								nc.Close()
+								_, js = jsClientConnectURL(b, connectURL)
+							}
+
+							rng := rand.New(rand.NewSource(int64(seed)))
+							message := make([]byte, messageSize)
+							domain := make([]byte, domainNameLength/2)
+
+							domains := make([]string, 0, bc.domains*bc.subjectsPerDomain)
+
+							// Publish one message per subject for each domain
+							published := 0
+							totalMessages := bc.domains * bc.subjectsPerDomain
+							for d := 1; d <= bc.domains; d++ {
+								rng.Read(domain)
+								for s := 1; s <= bc.subjectsPerDomain; s++ {
+									rng.Read(message)
+									domainString := fmt.Sprintf("%X", domain)
+									domains = append(domains, domainString)
+									subject := fmt.Sprintf("%s.%s.%d", subjectPrefix, domainString, s)
+									_, err := js.PublishAsync(subject, message)
+									if err != nil {
+										b.Fatalf("failed to publish: %s", err)
+									}
+									published += 1
+
+									// Wait for all pending to be published before trying to publish the next batch
+									if published%publishBatchSize == 0 || published == totalMessages {
+										select {
+										case <-js.PublishAsyncComplete():
+											if verbose {
+												b.Logf("Published %d/%d messages", published, totalMessages)
+											}
+										case <-time.After(publishTimeout):
+											b.Fatalf("Publish timed out")
+										}
+									}
+
+								}
+							}
+
+							// Number of messages that each new consumer expects to consume
+							messagesPerIteration := bc.filters * bc.subjectsPerDomain
+
+							// Each call to 'subscribe_consume_unsubscribe' is one benchmark operation.
+							// i.e. subscribe_consume_unsubscribe will be called a total of b.N times (split among C threads)
+							// Each operation consists of:
+							// - Create filter
+							// - Create consumer / Subscribe
+							// - Consume expected number of messages
+							// - Unsubscribe
+							subscribeConsumeUnsubscribe := func(js nats.JetStreamContext, rng *rand.Rand) {
+
+								// Select F unique domains to create F non-overlapping filters
+								filterDomains := make(map[string]bool, bc.filters)
+								filters := make([]string, 0, bc.filters)
+								for len(filterDomains) < bc.filters {
+									domain := domains[rng.Intn(len(domains))]
+									if _, found := filterDomains[domain]; found {
+										// Collision with existing filter, try again
+										continue
+									}
+									filterDomains[domain] = true
+									filters = append(filters, fmt.Sprintf("%s.%s.>", subjectPrefix, domain))
+								}
+
+								if verbose {
+									b.Logf("Subscribe with filters: %+v", filters)
+								}
+
+								// Consumer callback
+								received := 0
+								consumeWg := sync.WaitGroup{}
+								consumeWg.Add(1)
+								cb := func(msg *nats.Msg) {
+									received += 1
+									if received == messagesPerIteration {
+										consumeWg.Done()
+										if verbose {
+											b.Logf("Received %d/%d messages", received, messagesPerIteration)
+										}
+									}
+								}
+
+								// Create consumer
+								subOpts := []nats.SubOpt{
+									nats.BindStream(streamName),
+									nats.OrderedConsumer(),
+									nats.ConsumerReplicas(consumerReplicas),
+									nats.ConsumerFilterSubjects(filters...),
+									nats.ConsumerMemoryStorage(),
+								}
+
+								var sub *nats.Subscription
+
+								sub, err := js.Subscribe("", cb, subOpts...)
+								if err != nil {
+									b.Fatalf("Failed to subscribe: %s", err)
+								}
+
+								defer func(sub *nats.Subscription) {
+									err := sub.Unsubscribe()
+									if err != nil {
+										b.Logf("Failed to unsubscribe: %s", err)
+									}
+								}(sub)
+
+								consumeWg.Wait()
+							}
+
+							// Wait for all consumer threads and main to be ready
+							wgReady := sync.WaitGroup{}
+							wgReady.Add(bc.concurrentConsumers + 1)
+							// Wait until all consumer threads have completed
+							wgCompleted := sync.WaitGroup{}
+							wgCompleted.Add(bc.concurrentConsumers)
+							// Operations left for consumer threads
+							opsCount := atomic.Int32{}
+							opsCount.Store(int32(b.N))
+
+							// Start a pool of C goroutines, each one with a dedicated connection.
+							for i := 1; i <= bc.concurrentConsumers; i++ {
+								go func(consumerId int) {
+
+									// Connect
+									nc, js := jsClientConnectURL(b, connectURL)
+									defer nc.Close()
+
+									// Signal completion of work
+									defer wgCompleted.Done()
+
+									rng := rand.New(rand.NewSource(int64(seed + consumerId)))
+
+									// Ready, wait for everyone else
+									wgReady.Done()
+									wgReady.Wait()
+
+									completed := 0
+									for opsCount.Add(-1) >= 0 {
+										subscribeConsumeUnsubscribe(js, rng)
+										completed += 1
+									}
+									if verbose {
+										b.Logf("Consumer thread %d completed %d of %d operations", consumerId, completed, b.N)
+									}
+								}(i)
+							}
+
+							// Wait for all consumers to be ready
+							wgReady.Done()
+							wgReady.Wait()
+
+							// Start measuring time
+							b.ResetTimer()
+
+							// Wait for consumers to have chewed through b.N operations
+							wgCompleted.Wait()
+							b.StopTimer()
+
+							// Throughput is not very important in this benchmark since each operation includes
+							// subscribe, unsubscribe and retrieves just a few bytes
+							//b.SetBytes(int64(messageSize * messagesPerIteration))
 						},
 					)
 				}

--- a/server/jetstream_benchmark_test.go
+++ b/server/jetstream_benchmark_test.go
@@ -1560,7 +1560,7 @@ func BenchmarkJetStreamObjStore(b *testing.B) {
 	}
 }
 
-func BenchmarkJetStreamMultiProducer(b *testing.B) {
+func BenchmarkJetStreamPublishConcurrent(b *testing.B) {
 	const (
 		subject    = "test-subject"
 		streamName = "test-stream"
@@ -1580,15 +1580,12 @@ func BenchmarkJetStreamMultiProducer(b *testing.B) {
 	}
 
 	messageSizeCases := []int64{
-		100,        // 100B
-		1024,       // 1KiB
-		10240,      // 10KiB
-		512 * 1024, // 512KiB
+		10,     // 10B
+		1024,   // 1KiB
+		102400, // 100KiB
 	}
 	numPubsCases := []int{
-		3,
-		5,
-		10,
+		12,
 	}
 
 	replicasCases := []struct {

--- a/server/jetstream_meta_benchmark_test.go
+++ b/server/jetstream_meta_benchmark_test.go
@@ -1,0 +1,351 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !skip_js_tests && !skip_js_cluster_tests && !skip_js_cluster_tests_2
+// +build !skip_js_tests,!skip_js_cluster_tests,!skip_js_cluster_tests_2
+
+package server
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+)
+
+func BenchmarkJetStreamCreate(b *testing.B) {
+
+	const (
+		verbose        = false
+		resourcePrefix = "S"
+		concurrency    = 12
+	)
+
+	// Types of resource that this benchmark creates
+	type ResourceType string
+	const (
+		Stream      ResourceType = "Stream"
+		KVBucket    ResourceType = "KVBucket"
+		ObjectStore ResourceType = "ObjStore"
+	)
+
+	resourceTypeCases := []ResourceType{
+		Stream,
+		KVBucket,
+		ObjectStore,
+	}
+
+	benchmarksCases := []struct {
+		clusterSize int
+		replicas    int
+		storage     nats.StorageType
+	}{
+		{1, 1, nats.MemoryStorage},
+		{3, 3, nats.MemoryStorage},
+		{3, 3, nats.FileStorage},
+	}
+
+	for _, bc := range benchmarksCases {
+		bName := fmt.Sprintf(
+			"N=%d,R=%d,storage=%s,C=%d",
+			bc.clusterSize,
+			bc.replicas,
+			bc.storage.String(),
+			concurrency,
+		)
+
+		b.Run(
+			bName,
+			func(b *testing.B) {
+				for _, rt := range resourceTypeCases {
+					//for _, bc := range benchmarksCases {
+					rName := fmt.Sprintf("resource=%s", rt)
+					b.Run(
+						rName,
+						func(b *testing.B) {
+
+							if verbose {
+								b.Logf(
+									"Creating %d %s resources in cluster with %d nodes, R=%d, %s storage",
+									b.N,
+									string(rt),
+									bc.clusterSize,
+									bc.replicas,
+									bc.storage,
+								)
+							}
+
+							// Setup server or cluster
+							_, leaderServer, shutdown, nc, _ := startJSClusterAndConnect(b, bc.clusterSize)
+							defer shutdown()
+							defer nc.Close()
+
+							// All clients connect to cluster (meta) leader for lower variability
+							connectURL := leaderServer.ClientURL()
+
+							// Wait for all clients and main routine to be ready
+							wgReady := sync.WaitGroup{}
+							wgReady.Add(concurrency + 1)
+							// Wait for all routines to complete
+							wgComplete := sync.WaitGroup{}
+							wgComplete.Add(concurrency)
+
+							// Number of operations (divided amongst clients)
+							opsLeft := atomic.Int64{}
+							opsLeft.Store(int64(b.N))
+							totalErrors := atomic.Int64{}
+
+							// Pre-create connections and JS contexts
+							for i := 1; i <= concurrency; i++ {
+								nc, js := jsClientConnectURL(b, connectURL)
+								defer nc.Close()
+								go func(clientId int, nc *nats.Conn, js nats.JetStreamContext) {
+									defer wgComplete.Done()
+
+									// Config struct (reused and modified in place for each call)
+									streamConfig := nats.StreamConfig{
+										Name:     "?",
+										Storage:  bc.storage,
+										Replicas: bc.replicas,
+									}
+									kvConfig := nats.KeyValueConfig{
+										Bucket:   "?",
+										Storage:  bc.storage,
+										Replicas: bc.replicas,
+									}
+									objConfig := nats.ObjectStoreConfig{
+										Bucket:   "?",
+										Storage:  bc.storage,
+										Replicas: bc.replicas,
+									}
+
+									// Block until everyone is ready
+									wgReady.Done()
+									wgReady.Wait()
+
+									errCount := int64(0)
+									defer func() {
+										// Roll up error count on completion
+										totalErrors.Add(errCount)
+									}()
+
+									// Track per-client opCount (just for logging/debugging)
+									opCount := 0
+									for opsLeft.Add(-1) >= 0 {
+										var err error
+										// Create unique resource name
+										resourceName := fmt.Sprintf("%s_%d_%d", resourcePrefix, clientId, opCount)
+										switch rt {
+										case Stream:
+											streamConfig.Name = resourceName
+											_, err = js.AddStream(&streamConfig)
+										case KVBucket:
+											kvConfig.Bucket = resourceName
+											_, err = js.CreateKeyValue(&kvConfig)
+										case ObjectStore:
+											objConfig.Bucket = resourceName
+											_, err = js.CreateObjectStore(&objConfig)
+										}
+										opCount += 1
+										if err != nil {
+											b.Logf("Error creating %s (%s): %s", rt, resourceName, err)
+											errCount += 1
+										}
+									}
+
+									if verbose {
+										b.Logf("Client %d completed %d operations", clientId, opCount)
+									}
+
+								}(i, nc, js)
+							}
+
+							// Wait for all clients to be ready
+							wgReady.Done()
+							wgReady.Wait()
+
+							// Start benchmark clock
+							b.ResetTimer()
+
+							wgComplete.Wait()
+							b.StopTimer()
+
+							b.ReportMetric(float64(100*(totalErrors.Load()))/float64(b.N), "%error")
+						},
+					)
+				}
+			},
+		)
+	}
+}
+
+func BenchmarkJetStreamCreateConsumers(b *testing.B) {
+
+	const (
+		verbose        = false
+		streamName     = "S"
+		consumerPrefix = "C"
+		concurrency    = 12
+	)
+
+	benchmarksCases := []struct {
+		clusterSize      int
+		consumerReplicas int
+		consumerStorage  nats.StorageType
+	}{
+		{1, 1, nats.MemoryStorage},
+		{3, 3, nats.MemoryStorage},
+		{3, 3, nats.FileStorage},
+	}
+
+	type ConsumerType string
+	const (
+		Ephemeral ConsumerType = "Ephemeral"
+		Durable   ConsumerType = "Durable"
+	)
+
+	consumerTypeCases := []ConsumerType{
+		Ephemeral,
+		Durable,
+	}
+
+	for _, bc := range benchmarksCases {
+
+		bName := fmt.Sprintf(
+			"N=%d,R=%d,storage=%s,C=%d",
+			bc.clusterSize,
+			bc.consumerReplicas,
+			bc.consumerStorage.String(),
+			concurrency,
+		)
+
+		b.Run(
+			bName,
+			func(b *testing.B) {
+
+				for _, ct := range consumerTypeCases {
+
+					cName := fmt.Sprintf("Consumer=%s", ct)
+
+					b.Run(
+						cName,
+						func(b *testing.B) {
+							if verbose {
+								b.Logf(
+									"Creating %d consumers in cluster with %d nodes, R=%d, %s storage",
+									b.N,
+									bc.clusterSize,
+									bc.consumerReplicas,
+									bc.consumerStorage,
+								)
+							}
+
+							// Setup server or cluster
+							_, leaderServer, shutdown, nc, js := startJSClusterAndConnect(b, bc.clusterSize)
+							defer shutdown()
+							defer nc.Close()
+
+							// All clients connect to cluster (meta) leader for lower variability
+							connectURL := leaderServer.ClientURL()
+
+							// Create stream
+							streamConfig := nats.StreamConfig{
+								Name:     streamName,
+								Storage:  nats.FileStorage,
+								Replicas: bc.clusterSize,
+							}
+
+							_, err := js.AddStream(&streamConfig)
+							if err != nil {
+								b.Fatalf("Failed to create stream: %s", err)
+							}
+
+							// Wait for all clients and main routine to be ready
+							wgReady := sync.WaitGroup{}
+							wgReady.Add(concurrency + 1)
+							// Wait for all routines to complete
+							wgComplete := sync.WaitGroup{}
+							wgComplete.Add(concurrency)
+
+							// Number of operations (divided amongst clients)
+							opsLeft := atomic.Int64{}
+							opsLeft.Store(int64(b.N))
+							// Total number of errors
+							totalErrors := atomic.Int64{}
+
+							// Pre-create connections and JS contexts
+							for i := 1; i <= concurrency; i++ {
+								nc, js := jsClientConnectURL(b, connectURL)
+								defer nc.Close()
+
+								go func(clientId int, nc *nats.Conn, js nats.JetStreamContext) {
+									defer wgComplete.Done()
+
+									// Config struct (reused and modified in place for each call)
+									cfg := nats.ConsumerConfig{
+										Durable:       "",
+										Name:          "",
+										Replicas:      bc.consumerReplicas,
+										MemoryStorage: bc.consumerStorage == nats.MemoryStorage,
+									}
+
+									// Block until everyone is ready
+									wgReady.Done()
+									wgReady.Wait()
+
+									errCount := int64(0)
+									opCount := 0
+									for opsLeft.Add(-1) >= 0 {
+										var err error
+										// Set unique consumer name
+										cfg.Name = fmt.Sprintf("%s_%d_%d", consumerPrefix, clientId, opCount)
+										if ct == Durable {
+											cfg.Durable = cfg.Name
+										}
+										_, err = js.AddConsumer(streamName, &cfg)
+										if err != nil {
+											b.Logf("Failed to add consumer: %s", err)
+											errCount += 1
+										}
+										opCount += 1
+									}
+
+									if verbose {
+										b.Logf("Client %d completed %d operations", clientId, opCount)
+									}
+
+									totalErrors.Add(errCount)
+
+								}(i, nc, js)
+							}
+
+							// Wait for all clients to be ready
+							wgReady.Done()
+							wgReady.Wait()
+
+							// Start benchmark clock
+							b.ResetTimer()
+
+							wgComplete.Wait()
+							b.StopTimer()
+
+							b.ReportMetric(float64(100*(totalErrors.Load()))/float64(b.N), "%error")
+						},
+					)
+				}
+			},
+		)
+	}
+}


### PR DESCRIPTION
New benchmarks:
 - Jetstream subscription with filters over high cardinality subjects stream
 - Create throughput for Stream, KV Store, Object store 
 - Create throughput for JetStream consumers 

Signed-off-by: Marco Primi <marco@nats.io>
