### PR TITLE
Avoid panic when reloading during LDM

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -1625,7 +1625,6 @@ func (s *Server) shutdownEventing() {
 	// internal send loop to exit.
 	s.sendShutdownEvent()
 	wg.Wait()
-	close(rc)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1637,6 +1636,9 @@ func (s *Server) shutdownEventing() {
 	})
 	// Turn everything off here.
 	s.sys = nil
+	// Make sure this is done after s.sys = nil, so that we don't
+	// get sends to closed channels on badly-timed config reloads.
+	close(rc)
 }
 
 // Request for our local connection count.


### PR DESCRIPTION
If a reload happened during the LDM grace period, it was possible for the `resetCh` to have been closed between the loader fetching the channel, releasing the lock and then sending to it. By making sure that closing the channel happens after `s.sys` is invalidated, we can avoid this panic.

Signed-off-by: Neil Twigg <neil@nats.io>