### PR TITLE
NRG: Don't send metaleader snapshot as normal entry on leader change

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1358,7 +1358,7 @@ func (js *jetStream) monitorCluster() {
 
 		case isLeader = <-lch:
 			// For meta layer synchronize everyone to our state on becoming leader.
-			if isLeader {
+			if isLeader && n.ApplyQ().len() == 0 {
 				n.SendSnapshot(js.metaSnapshot())
 			}
 			// Process the change.


### PR DESCRIPTION
Sending meta snapshots as normal entries on leader change might cause a snapshot to be generated before the apply queue has been processed fully.

Signed-off-by: Neil Twigg <neil@nats.io>
