### PR TITLE
[FIXED] When moving to direct addServiceImport, saw performance degradation.

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4089,6 +4089,12 @@ func getHeader(key string, hdr []byte) []byte {
 	return value
 }
 
+// For bytes.HasPrefix below.
+var (
+	jsRequestNextPreB = []byte(jsRequestNextPre)
+	jsDirectGetPreB   = []byte(jsDirectGetPre)
+)
+
 // processServiceImport is an internal callback when a subscription matches an imported service
 // from another account. This includes response mappings as well.
 func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byte) {
@@ -4110,8 +4116,7 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 	var checkJS bool
 	shouldReturn := si.invalid || acc.sl == nil
 	if !shouldReturn && !isResponse && si.to == jsAllAPI {
-		subj := bytesToString(c.pa.subject)
-		if strings.HasPrefix(subj, jsRequestNextPre) || strings.HasPrefix(subj, jsDirectGetPre) {
+		if bytes.HasPrefix(c.pa.subject, jsDirectGetPreB) || bytes.HasPrefix(c.pa.subject, jsRequestNextPreB) {
 			checkJS = true
 		}
 	}

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -654,7 +654,8 @@ func (a *Account) enableAllJetStreamServiceImportsAndMappings() error {
 
 	if !a.serviceImportExists(jsAllAPI) {
 		// Capture si so we can turn on implicit sharing with JetStream layer.
-		si, err := a.addServiceImport(s.SystemAccount(), jsAllAPI, _EMPTY_, nil)
+		// Make sure to set "to" otherwise will incur performance slow down.
+		si, err := a.addServiceImport(s.SystemAccount(), jsAllAPI, jsAllAPI, nil)
 		if err != nil {
 			return fmt.Errorf("Error setting up jetstream service imports for account: %v", err)
 		}


### PR DESCRIPTION
Needed to explicitly set "to" to avoid extra work.

Caused performance hit on KV Get performance tests. Never released, so internal.

Signed-off-by: Derek Collison <derek@nats.io>