### PR TITLE
Add support to customize cluster ping_interval

### DIFF
--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -1580,7 +1580,7 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  6,
 		},
 		{
-			name: "wrong type for cluter pool size",
+			name: "wrong type for cluster pool size",
 			config: `
 				cluster {
 					port: -1
@@ -1592,7 +1592,7 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  6,
 		},
 		{
-			name: "wrong type for cluter accounts",
+			name: "wrong type for cluster accounts",
 			config: `
 				cluster {
 					port: -1
@@ -1604,7 +1604,7 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  6,
 		},
 		{
-			name: "wrong type for cluter compression",
+			name: "wrong type for cluster compression",
 			config: `
 				cluster {
 					port: -1
@@ -1616,7 +1616,7 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  6,
 		},
 		{
-			name: "wrong type for cluter compression mode",
+			name: "wrong type for cluster compression mode",
 			config: `
 				cluster {
 					port: -1
@@ -1630,7 +1630,7 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  7,
 		},
 		{
-			name: "wrong type for cluter compression rtt thresholds",
+			name: "wrong type for cluster compression rtt thresholds",
 			config: `
 				cluster {
 					port: -1
@@ -1645,7 +1645,7 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  7,
 		},
 		{
-			name: "invalid durations for cluter compression rtt thresholds",
+			name: "invalid durations for cluster compression rtt thresholds",
 			config: `
 				cluster {
 					port: -1
@@ -1658,6 +1658,32 @@ func TestConfigCheck(t *testing.T) {
 			err:       fmt.Errorf("time: invalid duration %q", "abc"),
 			errorLine: 6,
 			errorPos:  7,
+		},
+		{
+			name: "invalid durations for cluster ping interval",
+			config: `
+				cluster {
+					port: -1
+					ping_interval: -1
+					ping_max: 6
+				}
+			`,
+			err:       fmt.Errorf(`invalid use of field "ping_interval": ping_interval should be converted to a duration`),
+			errorLine: 4,
+			errorPos:  6,
+		},
+		{
+			name: "invalid durations for cluster ping interval",
+			config: `
+				cluster {
+					port: -1
+					ping_interval: '2m'
+					ping_max: 6
+				}
+			`,
+			warningErr: fmt.Errorf(`Cluster 'ping_interval' will reset to 30s which is the max for routes`),
+			errorLine:  4,
+			errorPos:   6,
 		},
 		{
 			name: "wrong type for leafnodes compression",

--- a/server/configs/reload/reload.conf
+++ b/server/configs/reload/reload.conf
@@ -35,4 +35,6 @@ cluster {
     listen:       127.0.0.1:-1
     name: "abc"
     no_advertise: true # enable on reload
+    ping_interval: '20s'
+    ping_max: 8
 }

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -348,6 +348,12 @@ func TestConfigReload(t *testing.T) {
 	if !updated.Cluster.NoAdvertise {
 		t.Fatal("Expected NoAdvertise to be true")
 	}
+	if updated.Cluster.PingInterval != 20*time.Second {
+		t.Fatalf("Cluster PingInterval is incorrect.\nexpected: 20s\ngot: %v", updated.Cluster.PingInterval)
+	}
+	if updated.Cluster.MaxPingsOut != 8 {
+		t.Fatalf("Cluster MaxPingsOut is incorrect.\nexpected: 6\ngot: %v", updated.Cluster.MaxPingsOut)
+	}
 	if updated.PidFile != "nats-server.pid" {
 		t.Fatalf("PidFile is incorrect.\nexpected: nats-server.pid\ngot: %s", updated.PidFile)
 	}

--- a/server/route.go
+++ b/server/route.go
@@ -1780,7 +1780,15 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL, accName string) *clie
 	// the connection as stale based on the ping interval and max out values,
 	// but without actually sending pings.
 	if compressionConfigured {
-		c.ping.tmr = time.AfterFunc(opts.PingInterval*time.Duration(opts.MaxPingsOut+1), func() {
+		pingInterval := opts.PingInterval
+		pingMax := opts.MaxPingsOut
+		if opts.Cluster.PingInterval > 0 {
+			pingInterval = opts.Cluster.PingInterval
+		}
+		if opts.Cluster.MaxPingsOut > 0 {
+			pingMax = opts.MaxPingsOut
+		}
+		c.ping.tmr = time.AfterFunc(pingInterval*time.Duration(pingMax+1), func() {
 			c.mu.Lock()
 			c.Debugf("Stale Client Connection - Closing")
 			c.enqueueProto([]byte(fmt.Sprintf(errProto, "Stale Connection")))


### PR DESCRIPTION
Adds support to customize the `ping_interval` for routes to be different from `ping_interval` from clients:

```hcl
port = 4222
http = 8222

server_name = 'A'

cluster {
  name = 'ABC'
  port = 6222
  routes = [
    nats://localhost:6222
    nats://localhost:6223
    nats://localhost:6224
  ]
  ping_interval = '5s'
  ping_max = 6
}

ping_interval = '30s'
```
