### PR TITLE
[FIXED] Make sure to not restart streams or consumers when they are deleted or creation time is too soon.

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -3786,7 +3786,7 @@ func TestJetStreamClusterHealthzCheckForStoppedAssets(t *testing.T) {
 	// Wait for exit.
 	time.Sleep(100 * time.Millisecond)
 
-	checkFor(t, 5*time.Second, 500*time.Millisecond, func() error {
+	checkFor(t, 15*time.Second, 500*time.Millisecond, func() error {
 		hs := s.healthz(nil)
 		if hs.Error != _EMPTY_ {
 			return errors.New(hs.Error)


### PR DESCRIPTION
Would lead to zombies, most common in consumers.

 Signed-off-by: Derek Collison <derek@nats.io>