### PR TITLE
Improved batch direct get.

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2023 The NATS Authors
+// Copyright 2012-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -217,4 +217,10 @@ const (
 
 	// DEFAULT_FETCH_TIMEOUT is the default time that the system will wait for an account fetch to return.
 	DEFAULT_ACCOUNT_FETCH_TIMEOUT = 1900 * time.Millisecond
+)
+
+// For direct get batch requests.
+const (
+	dg  = "NATS/1.0\r\nNats-Stream: %s\r\nNats-Subject: %s\r\nNats-Sequence: %d\r\nNats-Time-Stamp: %s\r\n\r\n"
+	dgb = "NATS/1.0\r\nNats-Stream: %s\r\nNats-Subject: %s\r\nNats-Sequence: %d\r\nNats-Time-Stamp: %s\r\nNats-Pending-Messages: %d\r\nNats-Last-Sequence: %d\r\n\r\n"
 )

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -5958,6 +5958,8 @@ func TestJetStreamClusterStreamResetPreacks(t *testing.T) {
 	for _, msg := range msgs {
 		msg.AckSync()
 	}
+	// Let sync propagate.
+	time.Sleep(250 * time.Millisecond)
 
 	// Now grab a non-leader server.
 	// We will shut it down and remove the stream data.
@@ -5971,7 +5973,7 @@ func TestJetStreamClusterStreamResetPreacks(t *testing.T) {
 	c.waitOnConsumerLeader(globalAccountName, "TEST", "dlc")
 
 	// Now consume the remaining 10 and ack.
-	msgs, err = sub.Fetch(10, nats.MaxWait(time.Second))
+	msgs, err = sub.Fetch(10, nats.MaxWait(10*time.Second))
 	require_NoError(t, err)
 	require_Equal(t, len(msgs), 10)
 
@@ -5982,7 +5984,7 @@ func TestJetStreamClusterStreamResetPreacks(t *testing.T) {
 	// Now remove the stream manually.
 	require_NoError(t, os.RemoveAll(mdir))
 	nl = c.restartServer(nl)
-	c.waitOnServerCurrent(nl)
+	c.waitOnAllCurrent()
 
 	mset, err = nl.GlobalAccount().lookupStream("TEST")
 	require_NoError(t, err)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -22153,10 +22153,11 @@ func TestJetStreamDirectGetBatch(t *testing.T) {
 	}
 
 	// Batch sizes greater than 1 will have a nil message as the end marker.
-	checkResponses := func(sub *nats.Subscription, numPending int, expected ...string) {
+	checkResponses := func(sub *nats.Subscription, numPendingStart int, expected ...string) {
 		t.Helper()
 		defer sub.Unsubscribe()
 		checkSubsPending(t, sub, len(expected))
+		np := numPendingStart
 		for i := 0; i < len(expected); i++ {
 			msg, err := sub.NextMsg(10 * time.Millisecond)
 			require_NoError(t, err)
@@ -22166,6 +22167,10 @@ func TestJetStreamDirectGetBatch(t *testing.T) {
 				require_Equal(t, expected[i], msg.Header.Get("Nats-Subject"))
 				// Should have Data field non-zero
 				require_True(t, len(msg.Data) > 0)
+				// Check we have NumPending and its correct.
+				require_Equal(t, strconv.Itoa(np), msg.Header.Get("Nats-Pending-Messages"))
+				np--
+
 			} else {
 				// Check for properly formatted EOB marker.
 				// Should have no body.
@@ -22175,28 +22180,28 @@ func TestJetStreamDirectGetBatch(t *testing.T) {
 				// Check description is EOB
 				require_Equal(t, msg.Header.Get("Description"), "EOB")
 				// Check we have NumPending and its correct.
-				require_Equal(t, strconv.Itoa(numPending), msg.Header.Get("Nats-Pending-Messages"))
+				require_Equal(t, strconv.Itoa(np), msg.Header.Get("Nats-Pending-Messages"))
 			}
 		}
 	}
 
 	// Run some simple tests.
 	sub := sendRequest(&JSApiMsgGetRequest{Seq: 1, Batch: 2})
-	checkResponses(sub, 997, "foo.foo", "foo.bar", _EMPTY_)
+	checkResponses(sub, 999, "foo.foo", "foo.bar", _EMPTY_)
 
 	sub = sendRequest(&JSApiMsgGetRequest{Seq: 1, Batch: 3})
-	checkResponses(sub, 996, "foo.foo", "foo.bar", "foo.baz", _EMPTY_)
+	checkResponses(sub, 999, "foo.foo", "foo.bar", "foo.baz", _EMPTY_)
 
 	// Test NextFor works
 	sub = sendRequest(&JSApiMsgGetRequest{Seq: 1, Batch: 3, NextFor: "foo.*"})
-	checkResponses(sub, 996, "foo.foo", "foo.bar", "foo.baz", _EMPTY_)
+	checkResponses(sub, 999, "foo.foo", "foo.bar", "foo.baz", _EMPTY_)
 
 	sub = sendRequest(&JSApiMsgGetRequest{Seq: 1, Batch: 3, NextFor: "foo.baz"})
-	checkResponses(sub, 330, "foo.baz", "foo.baz", "foo.baz", _EMPTY_)
+	checkResponses(sub, 333, "foo.baz", "foo.baz", "foo.baz", _EMPTY_)
 
 	// Test stopping early by starting at 997 with only 3 messages.
 	sub = sendRequest(&JSApiMsgGetRequest{Seq: 997, Batch: 10, NextFor: "foo.*"})
-	checkResponses(sub, 0, "foo.foo", "foo.bar", "foo.baz", _EMPTY_)
+	checkResponses(sub, 3, "foo.foo", "foo.bar", "foo.baz", _EMPTY_)
 }
 
 func TestJetStreamDirectGetBatchMaxBytes(t *testing.T) {

--- a/server/stream.go
+++ b/server/stream.go
@@ -4104,10 +4104,18 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 
 	seq := req.Seq
 	wc := subjectHasWildcard(req.NextFor)
+	// For tracking num pending if we are batch.
+	var np, lseq uint64
+	var isBatchRequest bool
 	batch := req.Batch
 	if batch == 0 {
 		batch = 1
+	} else {
+		// This is a batch request, capture initial numPending.
+		isBatchRequest = true
+		np, _ = store.NumPending(seq, req.NextFor, false)
 	}
+
 	// Grab MaxBytes
 	mb := req.MaxBytes
 	if mb == 0 && s != nil {
@@ -4154,16 +4162,34 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 		hdr := sm.hdr
 		ts := time.Unix(0, sm.ts).UTC()
 
-		if len(hdr) == 0 {
-			const ht = "NATS/1.0\r\nNats-Stream: %s\r\nNats-Subject: %s\r\nNats-Sequence: %d\r\nNats-Time-Stamp: %s\r\n\r\n"
-			hdr = []byte(fmt.Sprintf(ht, name, sm.subj, sm.seq, ts.Format(time.RFC3339Nano)))
+		if isBatchRequest {
+			if len(hdr) == 0 {
+				hdr = []byte(fmt.Sprintf(dgb, name, sm.subj, sm.seq, ts.Format(time.RFC3339Nano), np, lseq))
+			} else {
+				hdr = copyBytes(hdr)
+				hdr = genHeader(hdr, JSStream, name)
+				hdr = genHeader(hdr, JSSubject, sm.subj)
+				hdr = genHeader(hdr, JSSequence, strconv.FormatUint(sm.seq, 10))
+				hdr = genHeader(hdr, JSTimeStamp, ts.Format(time.RFC3339Nano))
+				hdr = genHeader(hdr, JSNumPending, strconv.FormatUint(np, 10))
+				hdr = genHeader(hdr, JSLastSequence, strconv.FormatUint(lseq, 10))
+			}
+			// Decrement num pending. This is optimization and we do not continue to look it up for these operations.
+			np--
 		} else {
-			hdr = copyBytes(hdr)
-			hdr = genHeader(hdr, JSStream, name)
-			hdr = genHeader(hdr, JSSubject, sm.subj)
-			hdr = genHeader(hdr, JSSequence, strconv.FormatUint(sm.seq, 10))
-			hdr = genHeader(hdr, JSTimeStamp, ts.Format(time.RFC3339Nano))
+			if len(hdr) == 0 {
+				hdr = []byte(fmt.Sprintf(dg, name, sm.subj, sm.seq, ts.Format(time.RFC3339Nano)))
+			} else {
+				hdr = copyBytes(hdr)
+				hdr = genHeader(hdr, JSStream, name)
+				hdr = genHeader(hdr, JSSubject, sm.subj)
+				hdr = genHeader(hdr, JSSequence, strconv.FormatUint(sm.seq, 10))
+				hdr = genHeader(hdr, JSTimeStamp, ts.Format(time.RFC3339Nano))
+			}
 		}
+		// Track our lseq
+		lseq = sm.seq
+		// Send out our message.
 		mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, sm.msg, nil, 0))
 		// Check if we have exceeded max bytes.
 		sentBytes += len(sm.subj) + len(sm.hdr) + len(sm.msg)
@@ -4174,8 +4200,8 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 
 	// If batch was requested send EOB.
 	if batch > 1 {
-		np, _ := store.NumPending(seq, req.NextFor, false)
-		hdr := []byte(fmt.Sprintf("NATS/1.0 204 EOB\r\nNats-Pending-Messages: %d\r\n\r\n", np))
+		// TODO(dlc) - Should we recalculate num pending here to account for new messages?
+		hdr := []byte(fmt.Sprintf("NATS/1.0 204 EOB\r\nNats-Pending-Messages: %d\r\nNats-Last-Sequence: %d\r\n\r\n", np, lseq))
 		mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
 	}
 }


### PR DESCRIPTION
Updated direct get batch to always have num pending in headers. Also added in last sequence to detect any message loss to all messages and the EOB marker. Will also allow pipeline fills, to better set us up for using this as even lighter weight replacement for any consumer.

Signed-off-by: Derek Collison <derek@nats.io>
