### PR TITLE
Variable-length prefix slices in `stree`

### DIFF
--- a/server/stree/dump.go
+++ b/server/stree/dump.go
@@ -38,7 +38,7 @@ func (t *SubjectTree[T]) dump(w io.Writer, n node, depth int) {
 	} else {
 		// We are a node type here, grab meta portion.
 		bn := n.base()
-		fmt.Fprintf(w, "%s %s Prefix: %q\n", dumpPre(depth), n.kind(), bn.prefix[:bn.prefixLen])
+		fmt.Fprintf(w, "%s %s Prefix: %q\n", dumpPre(depth), n.kind(), bn.prefix)
 		depth++
 		n.iter(func(n node) bool {
 			t.dump(w, n, depth)

--- a/server/stree/node.go
+++ b/server/stree/node.go
@@ -37,9 +37,15 @@ type node interface {
 // This also makes the meta base layer exactly 64 bytes, a normal L1 cache line.
 const maxPrefixLen = 60
 
-// 64 bytes total - an L1 cache line.
 type meta struct {
-	prefix    [maxPrefixLen]byte
-	prefixLen uint16
-	size      uint16
+	prefix []byte
+	size   uint16
 }
+
+func (m *meta) setPrefix(pre []byte) {
+	max := min(len(pre), maxPrefixLen)
+	m.prefix = append(m.prefix[:0], pre[:max]...)
+}
+
+func (m *meta) numChildren() uint16 { return m.size }
+func (m *meta) path() []byte        { return m.prefix }

--- a/server/stree/node16.go
+++ b/server/stree/node16.go
@@ -29,13 +29,6 @@ func newNode16(prefix []byte) *node16 {
 func (n *node16) isLeaf() bool { return false }
 func (n *node16) base() *meta  { return &n.meta }
 
-func (n *node16) setPrefix(pre []byte) {
-	n.prefixLen = uint16(min(len(pre), maxPrefixLen))
-	for i := uint16(0); i < n.prefixLen; i++ {
-		n.prefix[i] = pre[i]
-	}
-}
-
 // Currently we do not keep node16 sorted or use bitfields for traversal so just add to the end.
 // TODO(dlc) - We should revisit here with more detailed benchmarks.
 func (n *node16) addChild(c byte, nn node) {
@@ -46,9 +39,6 @@ func (n *node16) addChild(c byte, nn node) {
 	n.child[n.size] = nn
 	n.size++
 }
-
-func (n *node16) numChildren() uint16 { return n.size }
-func (n *node16) path() []byte        { return n.prefix[:n.prefixLen] }
 
 func (n *node16) findChild(c byte) *node {
 	for i := uint16(0); i < n.size; i++ {
@@ -62,7 +52,7 @@ func (n *node16) findChild(c byte) *node {
 func (n *node16) isFull() bool { return n.size >= 16 }
 
 func (n *node16) grow() node {
-	nn := newNode256(n.prefix[:n.prefixLen])
+	nn := newNode256(n.prefix)
 	for i := 0; i < 16; i++ {
 		nn.addChild(n.key[i], n.child[i])
 	}
@@ -103,7 +93,7 @@ func (n *node16) shrink() node {
 
 // Will match parts against our prefix.no
 func (n *node16) matchParts(parts [][]byte) ([][]byte, bool) {
-	return matchParts(parts, n.prefix[:n.prefixLen])
+	return matchParts(parts, n.prefix)
 }
 
 // Iterate over all children calling func f.

--- a/server/stree/node256.go
+++ b/server/stree/node256.go
@@ -28,20 +28,10 @@ func newNode256(prefix []byte) *node256 {
 func (n *node256) isLeaf() bool { return false }
 func (n *node256) base() *meta  { return &n.meta }
 
-func (n *node256) setPrefix(pre []byte) {
-	n.prefixLen = uint16(min(len(pre), maxPrefixLen))
-	for i := uint16(0); i < n.prefixLen; i++ {
-		n.prefix[i] = pre[i]
-	}
-}
-
 func (n *node256) addChild(c byte, nn node) {
 	n.child[c] = nn
 	n.size++
 }
-
-func (n *node256) numChildren() uint16 { return n.size }
-func (n *node256) path() []byte        { return n.prefix[:n.prefixLen] }
 
 func (n *node256) findChild(c byte) *node {
 	if n.child[c] != nil {
@@ -77,7 +67,7 @@ func (n *node256) shrink() node {
 
 // Will match parts against our prefix.
 func (n *node256) matchParts(parts [][]byte) ([][]byte, bool) {
-	return matchParts(parts, n.prefix[:n.prefixLen])
+	return matchParts(parts, n.prefix)
 }
 
 // Iterate over all children calling func f.

--- a/server/stree/node4.go
+++ b/server/stree/node4.go
@@ -29,13 +29,6 @@ func newNode4(prefix []byte) *node4 {
 func (n *node4) isLeaf() bool { return false }
 func (n *node4) base() *meta  { return &n.meta }
 
-func (n *node4) setPrefix(pre []byte) {
-	n.prefixLen = uint16(min(len(pre), maxPrefixLen))
-	for i := uint16(0); i < n.prefixLen; i++ {
-		n.prefix[i] = pre[i]
-	}
-}
-
 // Currently we do not need to keep sorted for traversal so just add to the end.
 func (n *node4) addChild(c byte, nn node) {
 	if n.size >= 4 {
@@ -45,9 +38,6 @@ func (n *node4) addChild(c byte, nn node) {
 	n.child[n.size] = nn
 	n.size++
 }
-
-func (n *node4) numChildren() uint16 { return n.size }
-func (n *node4) path() []byte        { return n.prefix[:n.prefixLen] }
 
 func (n *node4) findChild(c byte) *node {
 	for i := uint16(0); i < n.size; i++ {
@@ -61,7 +51,7 @@ func (n *node4) findChild(c byte) *node {
 func (n *node4) isFull() bool { return n.size >= 4 }
 
 func (n *node4) grow() node {
-	nn := newNode16(n.prefix[:n.prefixLen])
+	nn := newNode16(n.prefix)
 	for i := 0; i < 4; i++ {
 		nn.addChild(n.key[i], n.child[i])
 	}
@@ -98,7 +88,7 @@ func (n *node4) shrink() node {
 
 // Will match parts against our prefix.
 func (n *node4) matchParts(parts [][]byte) ([][]byte, bool) {
-	return matchParts(parts, n.prefix[:n.prefixLen])
+	return matchParts(parts, n.prefix)
 }
 
 // Iterate over all children calling func f.

--- a/server/stree/stree.go
+++ b/server/stree/stree.go
@@ -69,13 +69,14 @@ func (t *SubjectTree[T]) Find(subject []byte) (*T, bool) {
 			return nil, false
 		}
 		// We are a node type here, grab meta portion.
-		if bn := n.base(); bn.prefixLen > 0 {
-			end := min(int(si+bn.prefixLen), len(subject))
-			if !bytes.Equal(subject[si:end], bn.prefix[:bn.prefixLen]) {
+		if bn := n.base(); len(bn.prefix) > 0 {
+			pl := uint16(len(bn.prefix))
+			end := min(int(si+pl), len(subject))
+			if !bytes.Equal(subject[si:end], bn.prefix) {
 				return nil, false
 			}
 			// Increment our subject index.
-			si += bn.prefixLen
+			si += pl
 		}
 		if an := n.findChild(pivot(subject, si)); an != nil {
 			n = *an
@@ -157,12 +158,12 @@ func (t *SubjectTree[T]) insert(np *node, subject []byte, value T, si int) (*T, 
 
 	// Non-leaf nodes.
 	bn := n.base()
-	if bn.prefixLen > 0 {
-		cpi := commonPrefixLen(bn.prefix[:bn.prefixLen], subject[si:])
-		if pli := int(bn.prefixLen); cpi >= pli {
+	if pl := len(bn.prefix); pl > 0 {
+		cpi := commonPrefixLen(bn.prefix, subject[si:])
+		if cpi >= pl {
 			// Move past this node. We look for an existing child node to recurse into.
 			// If one does not exist we can create a new leaf node.
-			si += pli
+			si += pl
 			if nn := n.findChild(pivot(subject, si)); nn != nil {
 				return t.insert(nn, subject, value, si)
 			}
@@ -180,7 +181,7 @@ func (t *SubjectTree[T]) insert(np *node, subject []byte, value T, si int) (*T, 
 			// We will insert a new node4 and attach our current node below after adjusting prefix.
 			nn := newNode4(prefix)
 			// Shift the prefix for our original node.
-			n.setPrefix(bn.prefix[cpi:bn.prefixLen])
+			n.setPrefix(bn.prefix[cpi:pl])
 			nn.addChild(pivot(bn.prefix[:], 0), n)
 			// Add in our new leaf.
 			nn.addChild(pivot(subject[si:], 0), newLeaf(subject[si:], value))
@@ -217,12 +218,13 @@ func (t *SubjectTree[T]) delete(np *node, subject []byte, si uint16) (*T, bool) 
 		return nil, false
 	}
 	// Not a leaf node.
-	if bn := n.base(); bn.prefixLen > 0 {
-		if !bytes.Equal(subject[si:si+bn.prefixLen], bn.prefix[:bn.prefixLen]) {
+	if bn := n.base(); len(bn.prefix) > 0 {
+		pl := uint16(len(bn.prefix))
+		if !bytes.Equal(subject[si:si+pl], bn.prefix) {
 			return nil, false
 		}
 		// Increment our subject index.
-		si += bn.prefixLen
+		si += pl
 	}
 	p := pivot(subject, si)
 	nna := n.findChild(p)
@@ -237,8 +239,9 @@ func (t *SubjectTree[T]) delete(np *node, subject []byte, si uint16) (*T, bool) 
 
 			if sn := n.shrink(); sn != nil {
 				bn := n.base()
+				pl := len(bn.prefix)
 				// Make sure to set cap so we force an append to copy below.
-				pre := bn.prefix[:bn.prefixLen:bn.prefixLen]
+				pre := bn.prefix[:pl:pl]
 				// Need to fix up prefixes/suffixes.
 				if sn.isLeaf() {
 					ln := sn.(*leaf[T])
@@ -248,7 +251,7 @@ func (t *SubjectTree[T]) delete(np *node, subject []byte, si uint16) (*T, bool) 
 					// We are a node here, we need to add in the old prefix.
 					if len(pre) > 0 {
 						bsn := sn.base()
-						sn.setPrefix(append(pre, bsn.prefix[:bsn.prefixLen]...))
+						sn.setPrefix(append(pre, bsn.prefix[:len(bsn.prefix)]...))
 					}
 				}
 				*np = sn
@@ -287,9 +290,9 @@ func (t *SubjectTree[T]) match(n node, parts [][]byte, pre []byte, cb func(subje
 		// We have normal nodes here.
 		// We need to append our prefix
 		bn := n.base()
-		if bn.prefixLen > 0 {
+		if pl := len(bn.prefix); pl > 0 {
 			// Note that this append may reallocate, but it doesn't modify "pre" at the "match" callsite.
-			pre = append(pre, bn.prefix[:bn.prefixLen]...)
+			pre = append(pre, bn.prefix...)
 		}
 
 		// Check our remaining parts.
@@ -359,7 +362,7 @@ func (t *SubjectTree[T]) iter(n node, pre []byte, cb func(subject []byte, val *T
 	// We are normal node here.
 	bn := n.base()
 	// Note that this append may reallocate, but it doesn't modify "pre" at the "iter" callsite.
-	pre = append(pre, bn.prefix[:bn.prefixLen]...)
+	pre = append(pre, bn.prefix...)
 	// Collect nodes since unsorted.
 	var _nodes [256]node
 	nodes := _nodes[:0]

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -566,7 +566,7 @@ func TestSubjectTreeRandomTrackEntries(t *testing.T) {
 
 func TestSubjectTreeMetaSize(t *testing.T) {
 	var base meta
-	require_Equal(t, unsafe.Sizeof(base), 64)
+	require_Equal(t, unsafe.Sizeof(base), 32)
 }
 
 func b(s string) []byte {


### PR DESCRIPTION
This replaces the fixed-size prefix arrays in the node meta struct with variable-length slices.

Beforehand, every single node in the tree had a 60-byte prefix array embedded in the node meta struct, regardless of whether the prefix was anywhere near that long, which will be a contributing factor to why `stree` is so prominent in the in-use heap memory on systems where subject cardinality is very high.

This does add a few allocations during the insert phase, however it removes various others from many other paths as we no longer need to create new slice headers from the `prefixLen` on each call to `path`, `newNode4`, `newNode16`, `newNode256` or `matchParts`.

As a result, as well as saving memory, there's actually a slight performance improvement in most cases.

On `main` with 100 million subjects:
```
=== RUN   TestSubjectTreeMatchAllPerf
    stree_test.go:602: Match ">" took 12.530168458s and matched 100000000 entries
    stree_test.go:602: Match "subj.>" took 12.511737208s and matched 100000000 entries
    stree_test.go:602: Match "subj.*.*" took 11.492906792s and matched 100000000 entries
    stree_test.go:602: Match "*.*.*" took 11.461866875s and matched 100000000 entries
    stree_test.go:602: Match "subj.1.*" took 115.148375ms and matched 999408 entries
    stree_test.go:602: Match "subj.1.>" took 125.542584ms and matched 999408 entries
    stree_test.go:602: Match "subj.*.1" took 14.5µs and matched 1 entries
    stree_test.go:602: Match "*.*.1" took 6.167µs and matched 1 entries
--- PASS: TestSubjectTreeMatchAllPerf (78.29s)
```

On this branch, also with 100 million subjects:
```
=== RUN   TestSubjectTreeMatchAllPerf
    stree_test.go:602: Match ">" took 11.358998084s and matched 100000000 entries
    stree_test.go:602: Match "subj.>" took 11.398956958s and matched 100000000 entries
    stree_test.go:602: Match "subj.*.*" took 10.474617958s and matched 100000000 entries
    stree_test.go:602: Match "*.*.*" took 10.43056825s and matched 100000000 entries
    stree_test.go:602: Match "subj.1.*" took 105.615875ms and matched 1002026 entries
    stree_test.go:602: Match "subj.1.>" took 115.68ms and matched 1002026 entries
    stree_test.go:602: Match "subj.*.1" took 22.083µs and matched 1 entries
    stree_test.go:602: Match "*.*.1" took 6.25µs and matched 1 entries
--- PASS: TestSubjectTreeMatchAllPerf (75.10s)
```

Signed-off-by: Neil Twigg <neil@nats.io>