### PR TITLE
Use IO gate when doing io.FullRead on block

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5553,7 +5553,9 @@ func (mb *msgBlock) loadBlock(buf []byte) ([]byte, error) {
 		buf = buf[:sz]
 	}
 
+	<-dios
 	n, err := io.ReadFull(f, buf)
+	dios <- struct{}{}
 	// On success capture raw bytes size.
 	if err == nil {
 		mb.rbytes = uint64(n)


### PR DESCRIPTION
While troubleshooting a cluster recovering a large stream, it was spotted that this read call was taking long to complete.
