### PR TITLE
Added OpenTelemetry support

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -54,6 +54,7 @@ type Account struct {
 	Name         string
 	Nkey         string
 	Issuer       string
+	TraceDest    string
 	claimJWT     string
 	updated      time.Time
 	mu           sync.RWMutex
@@ -260,6 +261,7 @@ func (a *Account) String() string {
 func (a *Account) shallowCopy(na *Account) {
 	na.Nkey = a.Nkey
 	na.Issuer = a.Issuer
+	na.TraceDest = a.TraceDest
 
 	if a.imports.streams != nil {
 		na.imports.streams = make([]*streamImport, 0, len(a.imports.streams))

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2164,9 +2164,15 @@ func shouldSample(l *serviceLatency, c *client) (bool, http.Header) {
 		}
 		return true, http.Header{trcB3: b3} // sampling allowed or left to recipient of header
 	} else if tId := h[trcCtx]; len(tId) != 0 {
+		var sample bool
 		// sample 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
 		tk := strings.Split(tId[0], "-")
-		if len(tk) == 4 && len([]byte(tk[3])) == 2 && tk[3] == "01" {
+		if len(tk) == 4 && len([]byte(tk[3])) == 2 {
+			if hexVal, err := strconv.ParseInt(tk[3], 16, 8); err == nil {
+				sample = hexVal&0x1 == 0x1
+			}
+		}
+		if sample {
 			return true, newTraceCtxHeader(h, tId)
 		} else {
 			return false, nil

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -509,7 +509,8 @@ func TestAccountSimpleConfig(t *testing.T) {
 }
 
 func TestAccountParseConfig(t *testing.T) {
-	confFileName := createConfFile(t, []byte(`
+	traceDest := "my.trace.dest"
+	confFileName := createConfFile(t, []byte(fmt.Sprintf(`
     accounts {
       synadia {
         users = [
@@ -518,13 +519,14 @@ func TestAccountParseConfig(t *testing.T) {
         ]
       }
       nats.io {
+		trace_dest: %q
         users = [
           {user: derek, password: foo}
           {user: ivan, password: bar}
         ]
       }
     }
-    `))
+    `, traceDest)))
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error processing config file: %v", err)
@@ -548,6 +550,7 @@ func TestAccountParseConfig(t *testing.T) {
 	if natsAcc == nil {
 		t.Fatalf("Error retrieving account for 'nats.io'")
 	}
+	require_Equal[string](t, natsAcc.TraceDest, traceDest)
 
 	for _, u := range opts.Users {
 		if u.Username == "derek" {

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -3218,7 +3218,9 @@ func TestSamplingHeader(t *testing.T) {
 	test(false, http.Header{"B3": []string{"80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-0-05e3ac9a4f6e3b90"}})
 
 	test(true, http.Header{"traceparent": []string{"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}})
+	test(true, http.Header{"traceparent": []string{"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-27"}})
 	test(false, http.Header{"traceparent": []string{"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"}})
+	test(false, http.Header{"traceparent": []string{"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-22"}})
 }
 
 func TestAccountSystemPermsWithGlobalAccess(t *testing.T) {

--- a/server/client.go
+++ b/server/client.go
@@ -4349,11 +4349,11 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 				// We do so by setting the c.pa.trace to nil (it will be restored
 				// with c.pa = pacopy).
 				c.pa.trace = nil
-				// We also need to disable the trace destination header so that
-				// if message is routed, it does not initialize tracing in the
+				// We also need to disable the message trace headers so that
+				// if the message is routed, it does not initialize tracing in the
 				// remote.
-				pos := mt.disableTraceHeader(c, msg)
-				defer mt.enableTraceHeader(c, msg, pos)
+				positions := mt.disableTraceHeaders(c, msg)
+				defer mt.enableTraceHeaders(c, msg, positions)
 			}
 		}
 	}

--- a/server/client.go
+++ b/server/client.go
@@ -2540,7 +2540,7 @@ func (c *client) processHeaderPub(arg, remaining []byte) error {
 		// trace event with the max payload ingress error.
 		// Do this only for CLIENT connections.
 		if c.kind == CLIENT && len(remaining) > 0 {
-			if td := getHeader(MsgTraceSendTo, remaining); len(td) > 0 {
+			if td := getHeader(MsgTraceDest, remaining); len(td) > 0 {
 				c.initAndSendIngressErrEvent(remaining, string(td), ErrMaxPayload)
 			}
 		}

--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -914,6 +914,28 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  25,
 		},
 		{
+			name: "when account trace destination is of the wrong type",
+			config: `
+                accounts {
+                  A { trace_dest: 123 }
+                }
+			`,
+			err:       errors.New(`interface conversion: interface {} is int64, not string`),
+			errorLine: 3,
+			errorPos:  23,
+		},
+		{
+			name: "when account trace destination is not a valid destination",
+			config: `
+                accounts {
+                  A { trace_dest: "invalid..dest" }
+                }
+			`,
+			err:       errors.New(`Trace destination "invalid..dest" is not valid`),
+			errorLine: 3,
+			errorPos:  23,
+		},
+		{
 			name: "when user authorization config has both token and users",
 			config: `
 		authorization = {

--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -936,6 +936,17 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  23,
 		},
 		{
+			name: "when account trace destination is not a valid publish subject",
+			config: `
+                accounts {
+                  A { trace_dest: "invalid.publish.*.subject" }
+                }
+			`,
+			err:       errors.New(`Trace destination "invalid.publish.*.subject" is not valid`),
+			errorLine: 3,
+			errorPos:  23,
+		},
+		{
 			name: "when user authorization config has both token and users",
 			config: `
 		authorization = {

--- a/server/msgtrace.go
+++ b/server/msgtrace.go
@@ -575,12 +575,12 @@ func (t *msgTrace) disableTraceHeaders(c *client, msg []byte) []int {
 // Changes back the character at the given position `pos` in the `msg`
 // byte slice to the first character of the MsgTraceSendTo header.
 func (t *msgTrace) enableTraceHeaders(c *client, msg []byte, positions []int) {
-	headers := [2]string{MsgTraceSendTo, trcCtx}
+	firstChar := [2]byte{MsgTraceSendTo[0], trcCtx[0]}
 	for i, pos := range positions {
 		if pos == -1 {
 			continue
 		}
-		msg[pos] = headers[i][0]
+		msg[pos] = firstChar[i]
 	}
 }
 

--- a/server/msgtrace.go
+++ b/server/msgtrace.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -28,6 +28,12 @@ const (
 	MsgTraceHop           = "Nats-Trace-Hop"
 	MsgTraceOriginAccount = "Nats-Trace-Origin-Account"
 	MsgTraceOnly          = "Nats-Trace-Only"
+
+	// External trace header. Note that this header is normally in lower
+	// case (https://www.w3.org/TR/trace-context/#header-name). Vendors
+	// MUST expect the header in any case (upper, lower, mixed), and
+	// SHOULD send the header name in lowercase.
+	traceParentHdr = "traceparent"
 )
 
 type MsgTraceType string
@@ -51,8 +57,9 @@ type MsgTraceEvent struct {
 }
 
 type MsgTraceRequest struct {
-	Header  http.Header `json:"header,omitempty"`
-	MsgSize int         `json:"msgsize,omitempty"`
+	// We are not making this an http.Header so that header name case is preserved.
+	Header  map[string][]string `json:"header,omitempty"`
+	MsgSize int                 `json:"msgsize,omitempty"`
 }
 
 type MsgTraceEvents []MsgTrace
@@ -330,38 +337,24 @@ func (c *client) initMsgTrace() *msgTrace {
 		return nil
 	}
 	hdr := c.msgBuf[:c.pa.hdr]
-	var external bool
-	// Do not call c.parseState.getHeader() yet for performance reasons.
-	// We first do a "manual" search of the "send-to" destination's header.
-	// If not present, no need to lift the message headers.
-	td := getHeader(MsgTraceSendTo, hdr)
-	if len(td) <= 0 {
-		// If the NATS trace destination header is not present, look for
-		// the external trace header.
-		trcCtxHdrVal := getHeader(trcCtx, hdr)
-		if len(trcCtxHdrVal) <= 0 {
-			return nil
-		}
-		// See if we need to trigger the race based on the last token
-		// that should be set to "01".
-		tk := bytes.Split(trcCtxHdrVal, stringToBytes("-"))
-		if len(tk) != 4 || len([]byte(tk[3])) != 2 || !bytes.Equal(tk[3], stringToBytes("01")) {
-			return nil
-		}
-		external = true
-	}
-	// Now we know that this is a message that requested tracing, we
-	// will lift the headers since we also need to transfer them to
-	// the produced trace message.
-	headers := c.parseState.getHeader()
-	if headers == nil {
+	headers, external := genHeaderMapIfTraceHeadersPresent(hdr)
+	if len(headers) == 0 {
 		return nil
 	}
-	ct := getCompressionType(headers.Get(acceptEncodingHeader))
+	// Little helper to give us the first value of a given header, or _EMPTY_
+	// if key is not present.
+	getHdrVal := func(key string) string {
+		vv, ok := headers[key]
+		if !ok {
+			return _EMPTY_
+		}
+		return vv[0]
+	}
+	ct := getCompressionType(getHdrVal(acceptEncodingHeader))
 	var traceOnly bool
 	// Check for traceOnly only if not external.
 	if !external {
-		if to := headers.Get(MsgTraceOnly); to != _EMPTY_ {
+		if to := getHdrVal(MsgTraceOnly); to != _EMPTY_ {
 			tos := strings.ToLower(to)
 			switch tos {
 			case "1", "true", "on":
@@ -389,7 +382,7 @@ func (c *client) initMsgTrace() *msgTrace {
 		}
 		// The remote will have set the origin account header only if the
 		// message changed account (think of service imports).
-		oan = headers.Get(MsgTraceOriginAccount)
+		oan = getHdrVal(MsgTraceOriginAccount)
 		if oan == _EMPTY_ {
 			// For LEAF or ROUTER with pinned-account, we can use the c.acc.
 			if c.kind == LEAF || (c.kind == ROUTER && len(c.route.accName) > 0) {
@@ -414,7 +407,7 @@ func (c *client) initMsgTrace() *msgTrace {
 			}
 		}
 		// Check the hop header
-		hop = headers.Get(MsgTraceHop)
+		hop = getHdrVal(MsgTraceHop)
 	} else {
 		acc = c.acc
 		ian = acc.GetName()
@@ -432,7 +425,7 @@ func (c *client) initMsgTrace() *msgTrace {
 			return nil
 		}
 	} else {
-		dest = string(td)
+		dest = getHdrVal(MsgTraceSendTo)
 	}
 	c.pa.trace = &msgTrace{
 		srv:  c.srv,
@@ -461,6 +454,99 @@ func (c *client) initMsgTrace() *msgTrace {
 		tonly: traceOnly,
 	}
 	return c.pa.trace
+}
+
+// This function will return the header as a map (instead of http.Header because
+// we want to preserve the header names' case) and a boolean that indicates if
+// the headers have been lifted due to the presence of the external trace header
+// only.
+// Note that because of the traceParentHdr, the search is done in a case
+// insensitive way, but if the header is found, it is rewritten in lower case
+// as suggested by the spec, but also to make it easier to disable the header
+// when needed.
+func genHeaderMapIfTraceHeadersPresent(hdr []byte) (map[string][]string, bool) {
+
+	var (
+		_keys               = [64][]byte{}
+		_vals               = [64][]byte{}
+		m                   map[string][]string
+		traceDestHdrFound   bool
+		traceParentHdrFound bool
+	)
+	// Skip the hdrLine
+	if !bytes.HasPrefix(hdr, stringToBytes(hdrLine)) {
+		return nil, false
+	}
+
+	traceDestHdrAsBytes := stringToBytes(MsgTraceSendTo)
+	traceParentHdrAsBytes := stringToBytes(traceParentHdr)
+	crLFAsBytes := stringToBytes(CR_LF)
+	dashAsBytes := stringToBytes("-")
+
+	keys := _keys[:0]
+	vals := _vals[:0]
+
+	for i := len(hdrLine); i < len(hdr); {
+		// Search for key/val delimiter
+		del := bytes.IndexByte(hdr[i:], ':')
+		if del < 0 {
+			break
+		}
+		keyStart := i
+		key := hdr[keyStart : keyStart+del]
+		i += del + 1
+		valStart := i
+		nl := bytes.Index(hdr[valStart:], crLFAsBytes)
+		if nl < 0 {
+			break
+		}
+		if len(key) > 0 {
+			val := bytes.Trim(hdr[valStart:valStart+nl], " \t")
+			vals = append(vals, val)
+
+			// Check for the external trace header.
+			if bytes.EqualFold(key, traceParentHdrAsBytes) {
+				// Rewrite the header using lower case if needed.
+				if !bytes.Equal(key, traceParentHdrAsBytes) {
+					copy(hdr[keyStart:], traceParentHdrAsBytes)
+				}
+				// We will now check if the value has sampling or not.
+				// TODO(ik): Not sure if this header can have multiple values
+				// or not, and if so, what would be the rule to check for
+				// sampling. What is done here is to check them all until we
+				// found one with sampling.
+				if !traceParentHdrFound {
+					tk := bytes.Split(val, dashAsBytes)
+					if len(tk) == 4 && len([]byte(tk[3])) == 2 {
+						if hexVal, err := strconv.ParseInt(bytesToString(tk[3]), 16, 8); err == nil {
+							if hexVal&0x1 == 0x1 {
+								traceParentHdrFound = true
+							}
+						}
+					}
+				}
+				// Add to the keys with the external trace header in lower case.
+				keys = append(keys, traceParentHdrAsBytes)
+			} else {
+				// Is the key the Nats-Trace-Dest header?
+				if bytes.EqualFold(key, traceDestHdrAsBytes) {
+					traceDestHdrFound = true
+				}
+				// Add to the keys and preserve the key's case
+				keys = append(keys, key)
+			}
+		}
+		i += nl + 2
+	}
+	if !traceDestHdrFound && !traceParentHdrFound {
+		return nil, false
+	}
+	m = make(map[string][]string, len(keys))
+	for i, k := range keys {
+		hname := string(k)
+		m[hname] = append(m[hname], string(vals[i]))
+	}
+	return m, !traceDestHdrFound && traceParentHdrFound
 }
 
 // Special case where we create a trace event before parsing the message.
@@ -527,7 +613,7 @@ func (t *msgTrace) setHopHeader(c *client, msg []byte) []byte {
 	return c.setHeader(MsgTraceHop, t.nhop, msg)
 }
 
-// Will look for the MsgTraceSendTo and trcCtx headers and change the first
+// Will look for the MsgTraceSendTo and traceParentHdr headers and change the first
 // character to an 'X' so that if this message is sent to a remote, the remote
 // will not initialize tracing since it won't find the actual trace headers.
 // The function returns the position of the headers so it can efficiently be
@@ -541,27 +627,23 @@ func (t *msgTrace) disableTraceHeaders(c *client, msg []byte) []int {
 		return []int{-1, -1}
 	}
 	hdr := msg[:c.pa.hdr]
-	headers := [2]string{MsgTraceSendTo, trcCtx}
-	positions := [2]int{}
+	headers := [2]string{MsgTraceSendTo, traceParentHdr}
+	positions := [2]int{-1, -1}
 	for i := 0; i < 2; i++ {
 		key := stringToBytes(headers[i])
 		pos := bytes.Index(hdr, key)
 		if pos < 0 {
-			positions[i] = -1
 			continue
 		}
 		// Make sure this key does not have additional prefix.
 		if pos < 2 || hdr[pos-1] != '\n' || hdr[pos-2] != '\r' {
-			positions[i] = -1
 			continue
 		}
 		index := pos + len(key)
 		if index >= len(hdr) {
-			positions[i] = -1
 			continue
 		}
 		if hdr[index] != ':' {
-			positions[i] = -1
 			continue
 		}
 		// Disable the trace by altering the first character of the header
@@ -575,7 +657,7 @@ func (t *msgTrace) disableTraceHeaders(c *client, msg []byte) []int {
 // Changes back the character at the given position `pos` in the `msg`
 // byte slice to the first character of the MsgTraceSendTo header.
 func (t *msgTrace) enableTraceHeaders(c *client, msg []byte, positions []int) {
-	firstChar := [2]byte{MsgTraceSendTo[0], trcCtx[0]}
+	firstChar := [2]byte{MsgTraceSendTo[0], traceParentHdr[0]}
 	for i, pos := range positions {
 		if pos == -1 {
 			continue
@@ -696,6 +778,9 @@ func (t *msgTrace) updateJetStreamEvent(subject string, noInterest bool) {
 	}
 	t.js.Subject = subject
 	t.js.NoInterest = noInterest
+	// Update the timestamp since this is more accurate than when it
+	// was first added in addJetStreamEvent().
+	t.js.Timestamp = time.Now()
 }
 
 func (t *msgTrace) sendEventFromJetStream(err error) {

--- a/server/msgtrace_test.go
+++ b/server/msgtrace_test.go
@@ -82,28 +82,28 @@ func TestMsgTraceGenHeaderMap(t *testing.T) {
 	}{
 		{"missing header line", []byte("Nats-Trace-Dest: val\r\n"), nil, false},
 		{"no trace header present", []byte(hdrLine + "Header1: val1\r\nHeader2: val2\r\n"), nil, false},
-		{"trace header with some prefix", []byte(hdrLine + "Some-Prefix-" + MsgTraceSendTo + ": some value\r\n"), nil, false},
-		{"trace header with some suffix", []byte(hdrLine + MsgTraceSendTo + "-Some-Suffix: some value\r\n"), nil, false},
-		{"trace header with space before colon", []byte(hdrLine + MsgTraceSendTo + " : some value\r\n"), nil, false},
-		{"trace header with missing cr_lf for value", []byte(hdrLine + MsgTraceSendTo + " : bogus"), nil, false},
+		{"trace header with some prefix", []byte(hdrLine + "Some-Prefix-" + MsgTraceDest + ": some value\r\n"), nil, false},
+		{"trace header with some suffix", []byte(hdrLine + MsgTraceDest + "-Some-Suffix: some value\r\n"), nil, false},
+		{"trace header with space before colon", []byte(hdrLine + MsgTraceDest + " : some value\r\n"), nil, false},
+		{"trace header with missing cr_lf for value", []byte(hdrLine + MsgTraceDest + " : bogus"), nil, false},
 		{"external trace header with some prefix", []byte(hdrLine + "Some-Prefix-" + traceParentHdr + ": 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01\r\n"), nil, false},
 		{"external trace header with some suffix", []byte(hdrLine + traceParentHdr + "-Some-Suffix: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01\r\n"), nil, false},
 		{"external header with space before colon", []byte(hdrLine + traceParentHdr + " : 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01\r\n"), nil, false},
 		{"external header with missing cr_lf for value", []byte(hdrLine + traceParentHdr + " : 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"), nil, false},
-		{"trace header first", []byte(hdrLine + MsgTraceSendTo + ": some.dest\r\nSome-Header: some value\r\n"),
-			map[string][]string{"Some-Header": {"some value"}, MsgTraceSendTo: {"some.dest"}}, false},
-		{"trace header last", []byte(hdrLine + "Some-Header: some value\r\n" + MsgTraceSendTo + ": some.dest\r\n"),
-			map[string][]string{"Some-Header": {"some value"}, MsgTraceSendTo: {"some.dest"}}, false},
-		{"trace header multiple values", []byte(hdrLine + MsgTraceSendTo + ": some.dest\r\nSome-Header: some value\r\n" + MsgTraceSendTo + ": some.dest.2"),
-			map[string][]string{"Some-Header": {"some value"}, MsgTraceSendTo: {"some.dest", "some.dest.2"}}, false},
-		{"trace header and some empty key", []byte(hdrLine + MsgTraceSendTo + ": some.dest\r\n: bogus\r\nSome-Header: some value\r\n"),
-			map[string][]string{"Some-Header": {"some value"}, MsgTraceSendTo: {"some.dest"}}, false},
-		{"trace header and some header missing cr_lf for value", []byte(hdrLine + MsgTraceSendTo + ": some.dest\r\nSome-Header: bogus"),
-			map[string][]string{MsgTraceSendTo: {"some.dest"}}, false},
-		{"trace header and external after", []byte(hdrLine + MsgTraceSendTo + ": some.dest\r\n" + traceParentHdr + ": 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01\r\nSome-Header: some value\r\n"),
-			map[string][]string{"Some-Header": {"some value"}, MsgTraceSendTo: {"some.dest"}, traceParentHdr: {"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}}, false},
-		{"trace header and external before", []byte(hdrLine + traceParentHdr + ": 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01\r\n" + MsgTraceSendTo + ": some.dest\r\nSome-Header: some value\r\n"),
-			map[string][]string{"Some-Header": {"some value"}, MsgTraceSendTo: {"some.dest"}, traceParentHdr: {"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}}, false},
+		{"trace header first", []byte(hdrLine + MsgTraceDest + ": some.dest\r\nSome-Header: some value\r\n"),
+			map[string][]string{"Some-Header": {"some value"}, MsgTraceDest: {"some.dest"}}, false},
+		{"trace header last", []byte(hdrLine + "Some-Header: some value\r\n" + MsgTraceDest + ": some.dest\r\n"),
+			map[string][]string{"Some-Header": {"some value"}, MsgTraceDest: {"some.dest"}}, false},
+		{"trace header multiple values", []byte(hdrLine + MsgTraceDest + ": some.dest\r\nSome-Header: some value\r\n" + MsgTraceDest + ": some.dest.2"),
+			map[string][]string{"Some-Header": {"some value"}, MsgTraceDest: {"some.dest", "some.dest.2"}}, false},
+		{"trace header and some empty key", []byte(hdrLine + MsgTraceDest + ": some.dest\r\n: bogus\r\nSome-Header: some value\r\n"),
+			map[string][]string{"Some-Header": {"some value"}, MsgTraceDest: {"some.dest"}}, false},
+		{"trace header and some header missing cr_lf for value", []byte(hdrLine + MsgTraceDest + ": some.dest\r\nSome-Header: bogus"),
+			map[string][]string{MsgTraceDest: {"some.dest"}}, false},
+		{"trace header and external after", []byte(hdrLine + MsgTraceDest + ": some.dest\r\n" + traceParentHdr + ": 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01\r\nSome-Header: some value\r\n"),
+			map[string][]string{"Some-Header": {"some value"}, MsgTraceDest: {"some.dest"}, traceParentHdr: {"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}}, false},
+		{"trace header and external before", []byte(hdrLine + traceParentHdr + ": 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01\r\n" + MsgTraceDest + ": some.dest\r\nSome-Header: some value\r\n"),
+			map[string][]string{"Some-Header": {"some value"}, MsgTraceDest: {"some.dest"}, traceParentHdr: {"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}}, false},
 		{"external malformed", []byte(hdrLine + traceParentHdr + ": 00-4bf92f3577b34da6a3ce929d0e0e4736-01\r\n"), nil, false},
 		{"external first and sampling", []byte(hdrLine + traceParentHdr + ": 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01\r\nSome-Header: some value\r\n"),
 			map[string][]string{"Some-Header": {"some value"}, traceParentHdr: {"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}}, true},
@@ -174,7 +174,7 @@ func TestMsgTraceBasic(t *testing.T) {
 	// Send trace message to a dummy subject to check that resulting trace's
 	// SubjectMapping and Egress are nil.
 	msg := nats.NewMsg("dummy")
-	msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+	msg.Header.Set(MsgTraceDest, traceSub.Subject)
 	msg.Header.Set(MsgTraceOnly, "true")
 	msg.Data = []byte("hello!")
 	err = nc.PublishMsg(msg)
@@ -228,7 +228,7 @@ func TestMsgTraceBasic(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			msg = nats.NewMsg("foo")
 			msg.Header.Set("Some-App-Header", "some value")
-			msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+			msg.Header.Set(MsgTraceDest, traceSub.Subject)
 			if !test.deliverMsg {
 				msg.Header.Set(MsgTraceOnly, "true")
 			}
@@ -244,7 +244,7 @@ func TestMsgTraceBasic(t *testing.T) {
 					// 2 headers (the app + trace destination)
 					require_True(t, len(appMsg.Header) == 2)
 					require_Equal[string](t, appMsg.Header.Get("Some-App-Header"), "some value")
-					require_Equal[string](t, appMsg.Header.Get(MsgTraceSendTo), traceSub.Subject)
+					require_Equal[string](t, appMsg.Header.Get(MsgTraceDest), traceSub.Subject)
 				}
 				// Check that no (more) messages are received.
 				if msg, err := sub.NextMsg(100 * time.Millisecond); err != nats.ErrTimeout {
@@ -335,7 +335,7 @@ func TestMsgTraceIngressMaxPayloadError(t *testing.T) {
 			if !test.deliverMsg {
 				traceOnlyHdr = fmt.Sprintf("%s:true\r\n", MsgTraceOnly)
 			}
-			hdr := fmt.Sprintf("%s%s:%s\r\n%s\r\n", hdrLine, MsgTraceSendTo, traceSub.Subject, traceOnlyHdr)
+			hdr := fmt.Sprintf("%s%s:%s\r\n%s\r\n", hdrLine, MsgTraceDest, traceSub.Subject, traceOnlyHdr)
 			hPub := fmt.Sprintf("HPUB foo %d 2048\r\n%sAAAAAAAAAAAAAAAAAA...", len(hdr), hdr)
 			nc2.Write([]byte(hPub))
 
@@ -395,7 +395,7 @@ func TestMsgTraceIngressErrors(t *testing.T) {
 
 			sendMsg := func(subj, reply, errTxt string) {
 				msg := nats.NewMsg(subj)
-				msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+				msg.Header.Set(MsgTraceDest, traceSub.Subject)
 				if !test.deliverMsg {
 					msg.Header.Set(MsgTraceOnly, "true")
 				}
@@ -469,7 +469,7 @@ func TestMsgTraceEgressErrors(t *testing.T) {
 				t.Helper()
 
 				msg := nats.NewMsg(subj)
-				msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+				msg.Header.Set(MsgTraceDest, traceSub.Subject)
 				if !test.deliverMsg {
 					msg.Header.Set(MsgTraceOnly, "true")
 				}
@@ -554,7 +554,7 @@ func TestMsgTraceEgressErrors(t *testing.T) {
 				c.out.stc = make(chan struct{})
 				c.mu.Unlock()
 				msg := nats.NewMsg("bar.bar")
-				msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+				msg.Header.Set(MsgTraceDest, traceSub.Subject)
 				if !test.deliverMsg {
 					msg.Header.Set(MsgTraceOnly, "true")
 				}
@@ -615,7 +615,7 @@ func TestMsgTraceWithQueueSub(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			msg := nats.NewMsg("foo")
-			msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+			msg.Header.Set(MsgTraceDest, traceSub.Subject)
 			if !test.deliverMsg {
 				msg.Header.Set(MsgTraceOnly, "true")
 			}
@@ -715,7 +715,7 @@ func TestMsgTraceWithRoutes(t *testing.T) {
 		// Send trace message to a dummy subject to check that resulting trace
 		// is as expected.
 		msg := nats.NewMsg("dummy")
-		msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+		msg.Header.Set(MsgTraceDest, traceSub.Subject)
 		msg.Header.Set(MsgTraceOnly, "true")
 		msg.Data = []byte("hello!")
 		err := nc.PublishMsg(msg)
@@ -779,7 +779,7 @@ func TestMsgTraceWithRoutes(t *testing.T) {
 			} {
 				t.Run(test.name, func(t *testing.T) {
 					msg := nats.NewMsg("foo.bar")
-					msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+					msg.Header.Set(MsgTraceDest, traceSub.Subject)
 					if !test.deliverMsg {
 						msg.Header.Set(MsgTraceOnly, "true")
 					}
@@ -916,7 +916,7 @@ func TestMsgTraceWithRouteToOldServer(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			msg := nats.NewMsg("foo")
-			msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+			msg.Header.Set(MsgTraceDest, traceSub.Subject)
 			if !test.deliverMsg {
 				msg.Header.Set(MsgTraceOnly, "true")
 			}
@@ -1089,7 +1089,7 @@ func TestMsgTraceWithLeafNode(t *testing.T) {
 			} {
 				t.Run(test.name, func(t *testing.T) {
 					msg := nats.NewMsg("foo")
-					msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+					msg.Header.Set(MsgTraceDest, traceSub.Subject)
 					if !test.deliverMsg {
 						msg.Header.Set(MsgTraceOnly, "true")
 					}
@@ -1233,7 +1233,7 @@ func TestMsgTraceWithLeafNodeToOldServer(t *testing.T) {
 			} {
 				t.Run(test.name, func(t *testing.T) {
 					msg := nats.NewMsg("foo")
-					msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+					msg.Header.Set(MsgTraceDest, traceSub.Subject)
 					if !test.deliverMsg {
 						msg.Header.Set(MsgTraceOnly, "true")
 					}
@@ -1370,7 +1370,7 @@ func TestMsgTraceWithLeafNodeDaisyChain(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			msg := nats.NewMsg("foo.bar")
-			msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+			msg.Header.Set(MsgTraceDest, traceSub.Subject)
 			if !test.deliverMsg {
 				msg.Header.Set(MsgTraceOnly, "true")
 			}
@@ -1504,7 +1504,7 @@ func TestMsgTraceWithGateways(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			msg := nats.NewMsg("foo.bar")
-			msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+			msg.Header.Set(MsgTraceDest, traceSub.Subject)
 			if !test.deliverMsg {
 				msg.Header.Set(MsgTraceOnly, "true")
 			}
@@ -1636,7 +1636,7 @@ func TestMsgTraceWithGatewayToOldServer(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			msg := nats.NewMsg("foo")
-			msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+			msg.Header.Set(MsgTraceDest, traceSub.Subject)
 			if !test.deliverMsg {
 				msg.Header.Set(MsgTraceOnly, "true")
 			}
@@ -1771,7 +1771,7 @@ func TestMsgTraceServiceImport(t *testing.T) {
 			} {
 				t.Run(test.name, func(t *testing.T) {
 					msg := nats.NewMsg("bat")
-					msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+					msg.Header.Set(MsgTraceDest, traceSub.Subject)
 					if !test.deliverMsg {
 						msg.Header.Set(MsgTraceOnly, "true")
 					}
@@ -1988,7 +1988,7 @@ func TestMsgTraceServiceImportWithSuperCluster(t *testing.T) {
 			} {
 				t.Run(test.name, func(t *testing.T) {
 					msg := nats.NewMsg("bat")
-					msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+					msg.Header.Set(MsgTraceDest, traceSub.Subject)
 					if !test.deliverMsg {
 						msg.Header.Set(MsgTraceOnly, "true")
 					}
@@ -2019,14 +2019,14 @@ func TestMsgTraceServiceImportWithSuperCluster(t *testing.T) {
 							// trace would not reach the origin server because
 							// the origin account header will not be present.
 							if mainTest.allow {
-								if hv := appMsg.Header.Get(MsgTraceSendTo); hv != traceSub.Subject {
+								if hv := appMsg.Header.Get(MsgTraceDest); hv != traceSub.Subject {
 									t.Fatalf("Expecting header with %q, but got %q", traceSub.Subject, hv)
 								}
 								if hv := appMsg.Header.Get(traceParentHdr); hv != traceParentHdrVal {
 									t.Fatalf("Expecting header with %q, but got %q", traceParentHdrVal, hv)
 								}
 							} else {
-								if hv := appMsg.Header.Get(MsgTraceSendTo); hv != _EMPTY_ {
+								if hv := appMsg.Header.Get(MsgTraceDest); hv != _EMPTY_ {
 									t.Fatalf("Expecting no header, but header was present with value: %q", hv)
 								}
 								if hv := appMsg.Header.Get(traceParentHdr); hv != _EMPTY_ {
@@ -2035,7 +2035,7 @@ func TestMsgTraceServiceImportWithSuperCluster(t *testing.T) {
 								// We don't really need to check that, but we
 								// should see the header with the first letter
 								// being an `X`.
-								hnb := []byte(MsgTraceSendTo)
+								hnb := []byte(MsgTraceDest)
 								hnb[0] = 'X'
 								hn := string(hnb)
 								if hv := appMsg.Header.Get(hn); hv != traceSub.Subject {
@@ -2285,7 +2285,7 @@ func TestMsgTraceServiceImportWithLeafNodeHub(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			msg := nats.NewMsg("bat")
-			msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+			msg.Header.Set(MsgTraceDest, traceSub.Subject)
 			if !test.deliverMsg {
 				msg.Header.Set(MsgTraceOnly, "true")
 			}
@@ -2491,7 +2491,7 @@ func TestMsgTraceServiceImportWithLeafNodeLeaf(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			msg := nats.NewMsg("baz")
-			msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+			msg.Header.Set(MsgTraceDest, traceSub.Subject)
 			if !test.deliverMsg {
 				msg.Header.Set(MsgTraceOnly, "true")
 			}
@@ -2649,7 +2649,7 @@ func TestMsgTraceStreamExport(t *testing.T) {
 			} {
 				t.Run(test.name, func(t *testing.T) {
 					msg := nats.NewMsg("info.11.22.bar")
-					msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+					msg.Header.Set(MsgTraceDest, traceSub.Subject)
 					if !test.deliverMsg {
 						msg.Header.Set(MsgTraceOnly, "true")
 					}
@@ -2797,7 +2797,7 @@ func TestMsgTraceStreamExportWithSuperCluster(t *testing.T) {
 			} {
 				t.Run(test.name, func(t *testing.T) {
 					msg := nats.NewMsg("info.11.22.bar")
-					msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+					msg.Header.Set(MsgTraceDest, traceSub.Subject)
 					if !test.deliverMsg {
 						msg.Header.Set(MsgTraceOnly, "true")
 					}
@@ -3004,7 +3004,7 @@ func TestMsgTraceStreamExportWithLeafNode_Hub(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			msg := nats.NewMsg("info.11.22.bar")
-			msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+			msg.Header.Set(MsgTraceDest, traceSub.Subject)
 			if !test.deliverMsg {
 				msg.Header.Set(MsgTraceOnly, "true")
 			}
@@ -3191,7 +3191,7 @@ func TestMsgTraceStreamExportWithLeafNode_Leaf(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			msg := nats.NewMsg("info.11.22.bar")
-			msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+			msg.Header.Set(MsgTraceDest, traceSub.Subject)
 			if !test.deliverMsg {
 				msg.Header.Set(MsgTraceOnly, "true")
 			}
@@ -3351,7 +3351,7 @@ func TestMsgTraceJetStream(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			msg := nats.NewMsg("foo")
-			msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+			msg.Header.Set(MsgTraceDest, traceSub.Subject)
 			if !test.deliverMsg {
 				msg.Header.Set(MsgTraceOnly, "true")
 			}
@@ -3397,7 +3397,7 @@ func TestMsgTraceJetStream(t *testing.T) {
 	// increased, and that the JS trace shows the error.
 	newMsg := func() *nats.Msg {
 		msg = nats.NewMsg("foo")
-		msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+		msg.Header.Set(MsgTraceDest, traceSub.Subject)
 		msg.Header.Set(MsgTraceOnly, "true")
 		msg.Data = []byte("hello")
 		return msg
@@ -3489,7 +3489,7 @@ func TestMsgTraceJetStream(t *testing.T) {
 	})
 	require_NoError(t, err)
 	msg = nats.NewMsg("baz")
-	msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+	msg.Header.Set(MsgTraceDest, traceSub.Subject)
 	msg.Header.Set(MsgTraceOnly, "true")
 	msg.Data = []byte("hello")
 	err = nct.PublishMsg(msg)
@@ -3610,7 +3610,7 @@ func TestMsgTraceJetStreamWithSuperCluster(t *testing.T) {
 			} {
 				t.Run(test.name, func(t *testing.T) {
 					msg := nats.NewMsg(mainTest.stream)
-					msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+					msg.Header.Set(MsgTraceDest, traceSub.Subject)
 					if !test.deliverMsg {
 						msg.Header.Set(MsgTraceOnly, "true")
 					}
@@ -3726,7 +3726,7 @@ func TestMsgTraceJetStreamWithSuperCluster(t *testing.T) {
 
 			newMsg := func() *nats.Msg {
 				msg := nats.NewMsg(mainTest.stream)
-				msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+				msg.Header.Set(MsgTraceDest, traceSub.Subject)
 				msg.Header.Set(MsgTraceOnly, "true")
 				msg.Header.Set(traceParentHdr, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
 				msg.Data = []byte("hello")
@@ -3873,7 +3873,7 @@ func TestMsgTraceJetStreamWithSuperCluster(t *testing.T) {
 	for i := 0; i < 7; i++ {
 		jmsg, err := sub.NextMsg(time.Second)
 		require_NoError(t, err)
-		require_Equal[string](t, jmsg.Header.Get(MsgTraceSendTo), _EMPTY_)
+		require_Equal[string](t, jmsg.Header.Get(MsgTraceDest), _EMPTY_)
 	}
 
 	msg, err := traceSub.NextMsg(250 * time.Millisecond)
@@ -3908,7 +3908,7 @@ func TestMsgTraceWithCompression(t *testing.T) {
 	} {
 		t.Run(test.compressAlgo, func(t *testing.T) {
 			msg := nats.NewMsg("foo")
-			msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+			msg.Header.Set(MsgTraceDest, traceSub.Subject)
 			msg.Header.Set(acceptEncodingHeader, test.compressAlgo)
 			msg.Data = []byte("hello!")
 			err := nc.PublishMsg(msg)
@@ -4143,7 +4143,7 @@ func TestMsgTraceHops(t *testing.T) {
 
 	// Now send a trace message from c1s1
 	msg := nats.NewMsg("foo")
-	msg.Header.Set(MsgTraceSendTo, traceSub.Subject)
+	msg.Header.Set(MsgTraceDest, traceSub.Subject)
 	msg.Data = []byte("hello!")
 	err := nct.PublishMsg(msg)
 	require_NoError(t, err)
@@ -4454,7 +4454,7 @@ func TestMsgTraceTriggeredByExternalHeader(t *testing.T) {
 		// always deliver to the Nats-Trace-Dest, not the account.
 		{"trace dest and external header sampling",
 			func(h nats.Header) {
-				h.Set(MsgTraceSendTo, traceSub.Subject)
+				h.Set(MsgTraceDest, traceSub.Subject)
 				h.Set(traceParentHdr, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
 			},
 			true,
@@ -4462,7 +4462,7 @@ func TestMsgTraceTriggeredByExternalHeader(t *testing.T) {
 			false},
 		{"trace dest and external header no sampling",
 			func(h nats.Header) {
-				h.Set(MsgTraceSendTo, traceSub.Subject)
+				h.Set(MsgTraceDest, traceSub.Subject)
 				h.Set(traceParentHdr, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00")
 			},
 			true,
@@ -4470,7 +4470,7 @@ func TestMsgTraceTriggeredByExternalHeader(t *testing.T) {
 			false},
 		{"trace dest with trace only and external header sampling",
 			func(h nats.Header) {
-				h.Set(MsgTraceSendTo, traceSub.Subject)
+				h.Set(MsgTraceDest, traceSub.Subject)
 				h.Set(MsgTraceOnly, "true")
 				h.Set(traceParentHdr, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
 			},
@@ -4479,7 +4479,7 @@ func TestMsgTraceTriggeredByExternalHeader(t *testing.T) {
 			false},
 		{"trace dest with trace only and external header no sampling",
 			func(h nats.Header) {
-				h.Set(MsgTraceSendTo, traceSub.Subject)
+				h.Set(MsgTraceDest, traceSub.Subject)
 				h.Set(MsgTraceOnly, "true")
 				h.Set(traceParentHdr, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00")
 			},

--- a/server/msgtrace_test.go
+++ b/server/msgtrace_test.go
@@ -4502,18 +4502,25 @@ func TestMsgTraceTriggeredByExternalHeader(t *testing.T) {
 	s1.Shutdown()
 	s1 = nil
 
-	t.Run("check account trace destination valid when specified programmatically", func(t *testing.T) {
-		o1.Accounts[0].TraceDest = "invalid..dest"
-		o1.Accounts = o1.Accounts[:1]
-		accName := o1.Accounts[0].Name
-		o1.Port, o1.Cluster.Port = -1, -1
-		s1, err := NewServer(o1)
-		if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("trace_dest %q of account %q is not valid", "invalid..dest", accName)) {
-			if s1 != nil {
-				s1.Shutdown()
-			}
+	o1.Accounts = o1.Accounts[:1]
+	accName := o1.Accounts[0].Name
+	o1.Port, o1.Cluster.Port = -1, -1
 
-		}
-		s1.Shutdown()
-	})
+	for _, test := range []struct {
+		name      string
+		traceDest string
+	}{
+		{"account trace invalid subject", "invalid..subject"},
+		{"account trace invalid publish subject", "invalid.publish.*.subject"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			o1.Accounts[0].TraceDest = test.traceDest
+			s1, err := NewServer(o1)
+			if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("trace_dest %q of account %q is not valid", test.traceDest, accName)) {
+				if s1 != nil {
+					s1.Shutdown()
+				}
+			}
+		})
+	}
 }

--- a/server/opts.go
+++ b/server/opts.go
@@ -3025,6 +3025,14 @@ func parseAccounts(v interface{}, opts *Options, errors *[]error, warnings *[]er
 						*errors = append(*errors, err)
 						continue
 					}
+				case "trace_dest", "trace_destination", "trace_subject":
+					td := mv.(string)
+					if !IsValidSubject(td) {
+						err := &configErr{tk, fmt.Sprintf("Trace destination %q is not valid", mv)}
+						*errors = append(*errors, err)
+						continue
+					}
+					acc.TraceDest = td
 				default:
 					if !tk.IsUsedVariable() {
 						err := &unknownConfigFieldErr{

--- a/server/opts.go
+++ b/server/opts.go
@@ -3027,7 +3027,7 @@ func parseAccounts(v interface{}, opts *Options, errors *[]error, warnings *[]er
 					}
 				case "trace_dest", "trace_destination", "trace_subject":
 					td := mv.(string)
-					if !IsValidSubject(td) {
+					if !IsValidPublishSubject(td) {
 						err := &configErr{tk, fmt.Sprintf("Trace destination %q is not valid", mv)}
 						*errors = append(*errors, err)
 						continue

--- a/server/server.go
+++ b/server/server.go
@@ -1046,6 +1046,15 @@ func validateOptions(o *Options) error {
 		return fmt.Errorf("max_payload (%v) cannot be higher than max_pending (%v)",
 			o.MaxPayload, o.MaxPending)
 	}
+	// Check that account's trace_dest is a valid subject.
+	for _, acc := range o.Accounts {
+		if acc.TraceDest == _EMPTY_ {
+			continue
+		}
+		if !IsValidSubject(acc.TraceDest) {
+			return fmt.Errorf("trace_dest %q of account %q is not valid", acc.TraceDest, acc.Name)
+		}
+	}
 	// Check that the trust configuration is correct.
 	if err := validateTrustedOperators(o); err != nil {
 		return err

--- a/server/server.go
+++ b/server/server.go
@@ -1051,7 +1051,7 @@ func validateOptions(o *Options) error {
 		if acc.TraceDest == _EMPTY_ {
 			continue
 		}
-		if !IsValidSubject(acc.TraceDest) {
+		if !IsValidPublishSubject(acc.TraceDest) {
 			return fmt.Errorf("trace_dest %q of account %q is not valid", acc.TraceDest, acc.Name)
 		}
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -4213,11 +4213,11 @@ func (mset *stream) processInboundJetStreamMsg(_ *subscription, c *client, _ *Ac
 		msg = copyBytes(msg)
 	}
 	if mt, traceOnly := c.isMsgTraceEnabled(); mt != nil {
-		// If message is delivered, we need to disable the message trace destination
-		// header to prevent a trace event to be generated when a stored message
+		// If message is delivered, we need to disable the message trace headers
+		// to prevent a trace event to be generated when a stored message
 		// is delivered to a consumer and routed.
 		if !traceOnly {
-			mt.disableTraceHeader(c, hdr)
+			mt.disableTraceHeaders(c, hdr)
 		}
 		// This will add the jetstream event while in the client read loop.
 		// Since the event will be updated in a different go routine, the


### PR DESCRIPTION
If the `Nats-Trace-Dest` header is not present, but `Traceparent` is and its last token is `01`, then message tracing is triggered. This also requires that the account be defined with a `trace_dest` subject so that traces can be sent there.
Note that `Nats-Trace-Only` is not applicable for `Traceparent`.

Addition to PR #5014
Resolves #5052

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>