### PR TITLE
Support building for linux/ppc64le arch

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,6 +32,7 @@ builds:
   - 386
   - mips64le
   - s390x
+  - ppc64le
   goarm:
   - 6
   - 7


### PR DESCRIPTION
This request was raised in #555 (2017) and more recently in the nats-docker repo here: https://github.com/nats-io/nats-docker/issues/117.

Although @kozlovic noted in #555 that we don't have hardware readily available to test against if a platform-specific bug is raised, we are already building for other architectures that fall into this category: `mips64le` and `s390x`. If such an issue arises, we would rely on the community who are using those platforms to facilitate debugging.
