### PR TITLE
[IMPROVED] Make num pending consistent

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -222,5 +222,5 @@ const (
 // For direct get batch requests.
 const (
 	dg  = "NATS/1.0\r\nNats-Stream: %s\r\nNats-Subject: %s\r\nNats-Sequence: %d\r\nNats-Time-Stamp: %s\r\n\r\n"
-	dgb = "NATS/1.0\r\nNats-Stream: %s\r\nNats-Subject: %s\r\nNats-Sequence: %d\r\nNats-Time-Stamp: %s\r\nNats-Pending-Messages: %d\r\nNats-Last-Sequence: %d\r\n\r\n"
+	dgb = "NATS/1.0\r\nNats-Stream: %s\r\nNats-Subject: %s\r\nNats-Sequence: %d\r\nNats-Time-Stamp: %s\r\nNats-Num-Pending: %d\r\nNats-Last-Sequence: %d\r\n\r\n"
 )

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -22164,11 +22164,11 @@ func TestJetStreamDirectGetBatch(t *testing.T) {
 			// If expected is _EMPTY_ that signals we expect a EOB marker.
 			if subj := expected[i]; subj != _EMPTY_ {
 				// Make sure subject is correct.
-				require_Equal(t, expected[i], msg.Header.Get("Nats-Subject"))
+				require_Equal(t, expected[i], msg.Header.Get(JSSubject))
 				// Should have Data field non-zero
 				require_True(t, len(msg.Data) > 0)
 				// Check we have NumPending and its correct.
-				require_Equal(t, strconv.Itoa(np), msg.Header.Get("Nats-Pending-Messages"))
+				require_Equal(t, strconv.Itoa(np), msg.Header.Get(JSNumPending))
 				np--
 
 			} else {
@@ -22180,7 +22180,7 @@ func TestJetStreamDirectGetBatch(t *testing.T) {
 				// Check description is EOB
 				require_Equal(t, msg.Header.Get("Description"), "EOB")
 				// Check we have NumPending and its correct.
-				require_Equal(t, strconv.Itoa(np), msg.Header.Get("Nats-Pending-Messages"))
+				require_Equal(t, strconv.Itoa(np), msg.Header.Get(JSNumPending))
 			}
 		}
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -4198,7 +4198,7 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 		if mset.lastSeq() > validThrough {
 			np, _ = store.NumPending(seq, req.NextFor, false)
 		}
-		hdr := []byte(fmt.Sprintf("NATS/1.0 204 EOB\r\nNats-Pending-Messages: %d\r\nNats-Last-Sequence: %d\r\n\r\n", np, lseq))
+		hdr := []byte(fmt.Sprintf("NATS/1.0 204 EOB\r\nNats-Num-Pending: %d\r\nNats-Last-Sequence: %d\r\n\r\n", np, lseq))
 		mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
 	}
 }


### PR DESCRIPTION
We were mixing between in batch messages and EOB. Make consistent and use the following always.
```go 
JSNumPending   = "Nats-Num-Pending"
```

Signed-off-by: Derek Collison <derek@nats.io>