### PR TITLE
Make ping/pong responses update last activity

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -2380,7 +2380,9 @@ func (c *client) processPing() {
 
 	// Record this to suppress us sending one if this
 	// is within a given time interval for activity.
-	c.lastIn = time.Now()
+	now := time.Now()
+	c.lastIn = now
+	c.last = now
 
 	// If not a CLIENT, we are done. Also the CONNECT should
 	// have been received, but make sure it is so before proceeding
@@ -2431,6 +2433,7 @@ func (c *client) processPong() {
 	c.mu.Lock()
 	c.ping.out = 0
 	c.rtt = computeRTT(c.rttStart)
+	c.last = time.Now()
 	srv := c.srv
 	reorderGWs := c.kind == GATEWAY && c.gw.outbound
 	// If compression is currently active for a route/leaf connection, if the

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -706,6 +706,14 @@ func TestConnzLastActivity(t *testing.T) {
 		if fooLA.Equal(nextLA) {
 			t.Fatalf("Message delivery should have triggered update to LastActivity\n")
 		}
+
+		// Ping also updates LastActivity.
+		prevLA := ciFoo.LastActivity
+		ncFoo.Flush()
+		ciFoo, _ = getFooAndBar(t, createConnMap(t, pollConz(t, s, mode, url, opts)))
+		if prevLA.Equal(ciFoo.LastActivity) {
+			t.Fatalf("Ping should have triggered update to LastActivity\n")
+		}
 	}
 
 	for mode := 0; mode < 2; mode++ {

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -133,6 +133,10 @@ func TestParsePong(t *testing.T) {
 	// Should be adjusting c.pout (Pings Outstanding): reset to 0
 	c.state = OP_START
 	c.ping.out = 10
+
+	// Snapshot to check that last activity is updated on pongs.
+	t0 := c.last
+
 	pong = []byte("PONG\r\n")
 	err = c.parse(pong)
 	if err != nil || c.state != OP_START {
@@ -140,6 +144,11 @@ func TestParsePong(t *testing.T) {
 	}
 	if c.ping.out != 0 {
 		t.Fatalf("Unexpected ping.out: %d vs 0\n", c.ping.out)
+	}
+
+	t1 := c.last
+	if t1.Equal(t0) {
+		t.Fatal("LastActivity should be updated when receiving pong.")
 	}
 }
 


### PR DESCRIPTION
Changes ping/pong interval to also make updates to LastActivity to better reflect possible stale connections via monitoring.
