### PR TITLE
[IMPROVED] Use GOMEMLIMIT if set to calculate dynamic memory limits for JetStream

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -854,8 +854,12 @@ func (c *client) applyAccountLimits() {
 			}
 		}
 	}
+
+	c.acc.mu.RLock()
 	minLimit(&c.mpay, c.acc.mpay)
 	minLimit(&c.msubs, c.acc.msubs)
+	c.acc.mu.RUnlock()
+
 	s := c.srv
 	opts := s.getOpts()
 	mPay := opts.MaxPayload

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7923,7 +7923,7 @@ func (mset *stream) processSnapshot(snap *StreamReplicatedState) (e error) {
 	mset.setCLFS(snap.Failed)
 	sreq := mset.calculateSyncRequest(&state, snap)
 
-	s, js, subject, n := mset.srv, mset.js, mset.sa.Sync, mset.node
+	s, js, subject, n, st := mset.srv, mset.js, mset.sa.Sync, mset.node, mset.cfg.Storage
 	qname := fmt.Sprintf("[ACC:%s] stream '%s' snapshot", mset.acc.Name, mset.cfg.Name)
 	mset.mu.Unlock()
 
@@ -7933,7 +7933,7 @@ func (mset *stream) processSnapshot(snap *StreamReplicatedState) (e error) {
 	}
 
 	// Just return if up to date or already exceeded limits.
-	if sreq == nil || js.limitsExceeded(mset.cfg.Storage) {
+	if sreq == nil || js.limitsExceeded(st) {
 		return nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>