### PR TITLE
Change Account.TraceDest to private and add getter/setter

### DIFF
--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -550,7 +550,7 @@ func TestAccountParseConfig(t *testing.T) {
 	if natsAcc == nil {
 		t.Fatalf("Error retrieving account for 'nats.io'")
 	}
-	require_Equal[string](t, natsAcc.TraceDest, traceDest)
+	require_Equal[string](t, natsAcc.getTraceDest(), traceDest)
 
 	for _, u := range opts.Users {
 		if u.Username == "derek" {

--- a/server/msgtrace.go
+++ b/server/msgtrace.go
@@ -436,9 +436,7 @@ func (c *client) initMsgTrace() *msgTrace {
 	// otherwise, we are not enabling tracing.
 	if external {
 		if acc != nil {
-			acc.mu.RLock()
-			dest = acc.TraceDest
-			acc.mu.RUnlock()
+			dest = acc.getTraceDest()
 		}
 		if dest == _EMPTY_ {
 			// No account destination, no tracing for external trace headers.

--- a/server/opts.go
+++ b/server/opts.go
@@ -3032,7 +3032,7 @@ func parseAccounts(v interface{}, opts *Options, errors *[]error, warnings *[]er
 						*errors = append(*errors, err)
 						continue
 					}
-					acc.TraceDest = td
+					acc.traceDest = td
 				default:
 					if !tk.IsUsedVariable() {
 						err := &unknownConfigFieldErr{

--- a/server/server.go
+++ b/server/server.go
@@ -1046,15 +1046,6 @@ func validateOptions(o *Options) error {
 		return fmt.Errorf("max_payload (%v) cannot be higher than max_pending (%v)",
 			o.MaxPayload, o.MaxPending)
 	}
-	// Check that account's trace_dest is a valid subject.
-	for _, acc := range o.Accounts {
-		if acc.TraceDest == _EMPTY_ {
-			continue
-		}
-		if !IsValidPublishSubject(acc.TraceDest) {
-			return fmt.Errorf("trace_dest %q of account %q is not valid", acc.TraceDest, acc.Name)
-		}
-	}
 	// Check that the trust configuration is correct.
 	if err := validateTrustedOperators(o); err != nil {
 		return err


### PR DESCRIPTION
Update the tests accordingly.

This change is ok since the message tracing feature is targeted for v2.11.0 which has not been released yet.

Related to #5057

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>