### PR TITLE
[FIXED] Stree match bug, filestore minor improvements.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2824,7 +2824,7 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 			} else {
 				// We need to adjust for all matches in this block.
 				// Make sure we have fss loaded. This loads whole block now.
-				if mb.cacheNotLoaded() {
+				if mb.fssNotLoaded() {
 					mb.loadMsgsWithLock()
 					shouldExpire = true
 				}

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2877,7 +2877,10 @@ func (fs *fileStore) SubjectsTotals(filter string) map[string]uint64 {
 	if fs.psim.Size() == 0 {
 		return nil
 	}
-
+	// Match all if no filter given.
+	if filter == _EMPTY_ {
+		filter = fwcs
+	}
 	fst := make(map[string]uint64)
 	fs.psim.Match(stringToBytes(filter), func(subj []byte, psi *psi) {
 		fst[string(subj)] = psi.total

--- a/server/stree/node.go
+++ b/server/stree/node.go
@@ -34,8 +34,7 @@ type node interface {
 
 // Maximum prefix len
 // We expect the most savings to come from long shared prefixes.
-// This also makes the meta base layer exactly 64 bytes, a normal L1 cache line.
-const maxPrefixLen = 60
+const maxPrefixLen = 24
 
 // 64 bytes total - an L1 cache line.
 type meta struct {

--- a/server/stree/parts.go
+++ b/server/stree/parts.go
@@ -99,10 +99,9 @@ func matchParts(parts [][]byte, frag []byte) ([][]byte, bool) {
 		}
 		end := min(si+lp, len(frag))
 		// If part is bigger then the fragment, adjust to a portion on the part.
-		partialPart := lp > end
-		if partialPart {
+		if partialPart := lp > end; partialPart {
 			// Frag is smaller then part itself.
-			part = part[:end]
+			part = part[:end-si]
 		}
 		if !bytes.Equal(part, frag[si:end]) {
 			return parts, false
@@ -117,7 +116,7 @@ func matchParts(parts [][]byte, frag []byte) ([][]byte, bool) {
 		if end < lp {
 			if end >= lf {
 				parts = append([][]byte{}, parts...) // Create a copy before modifying.
-				parts[i] = parts[i][lf:]
+				parts[i] = parts[i][lf-si:]
 			} else {
 				i++
 			}

--- a/server/stree/stree.go
+++ b/server/stree/stree.go
@@ -278,7 +278,7 @@ func (t *SubjectTree[T]) match(n node, parts [][]byte, pre []byte, cb func(subje
 		}
 		// We have matched here. If we are a leaf and have exhausted all parts or he have a FWC fire callback.
 		if n.isLeaf() {
-			if len(nparts) == 0 || hasFWC {
+			if len(nparts) == 0 || (hasFWC && len(nparts) == 1) {
 				ln := n.(*leaf[T])
 				cb(append(pre, ln.suffix...), &ln.value)
 			}

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -522,6 +522,17 @@ func TestSubjectTreeInsertSamePivotBug(t *testing.T) {
 	}
 }
 
+func TestSubjectTreeMatchTsepSecondThenPartialPartBug(t *testing.T) {
+	st := NewSubjectTree[int]()
+	st.Insert(b("foo.xxxxx.foo1234.zz"), 22)
+	st.Insert(b("foo.yyy.foo123.zz"), 22)
+	st.Insert(b("foo.yyybar789.zz"), 22)
+	st.Insert(b("foo.yyy.foo12345.zz"), 22)
+	st.Insert(b("foo.yyy.foo12345.yy"), 22)
+	st.Insert(b("foo.yyy.foo123456789.zz"), 22)
+	match(t, st, "foo.*.foo123456789.*", 1)
+}
+
 func TestSubjectTreeRandomTrackEntries(t *testing.T) {
 	st := NewSubjectTree[int]()
 	smap := make(map[string]struct{}, 1000)

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -577,7 +577,7 @@ func TestSubjectTreeRandomTrackEntries(t *testing.T) {
 
 func TestSubjectTreeMetaSize(t *testing.T) {
 	var base meta
-	require_Equal(t, unsafe.Sizeof(base), 64)
+	require_Equal(t, unsafe.Sizeof(base), 28)
 }
 
 func b(s string) []byte {

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -531,6 +531,7 @@ func TestSubjectTreeMatchTsepSecondThenPartialPartBug(t *testing.T) {
 	st.Insert(b("foo.yyy.foo12345.yy"), 22)
 	st.Insert(b("foo.yyy.foo123456789.zz"), 22)
 	match(t, st, "foo.*.foo123456789.*", 1)
+	match(t, st, "foo.*.*.zzz.foo.>", 0)
 }
 
 func TestSubjectTreeRandomTrackEntries(t *testing.T) {


### PR DESCRIPTION
When encountering partial frags or parts we were not properly offsetting by si. This would cause certain stree setups to fail to match properly against wildcarded subjects that had to deal with partial frags and partial parts.

Also lowered the prefix from 60 to 24.

Improved NumPending in filestore by check if fssLoaded vs whole cache.
