### PR TITLE
Fix flapping in TestJetStreamMirrorBasics

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -11437,7 +11437,7 @@ func TestJetStreamMirrorBasics(t *testing.T) {
 	}
 
 	// Faster timeout since we loop below checking for condition.
-	js2, err := nc.JetStream(nats.MaxWait(250 * time.Millisecond))
+	js2, err := nc.JetStream(nats.MaxWait(500 * time.Millisecond))
 	require_NoError(t, err)
 
 	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
@@ -11605,25 +11605,25 @@ func TestJetStreamMirrorBasics(t *testing.T) {
 			si, err := js2.StreamInfo(streamName, &nats.StreamInfoRequest{SubjectsFilter: subject})
 			require_NoError(t, err)
 			if ss, ok := si.State.Subjects[subject]; !ok {
-				t.Logf("Expected messages with the transformed subject %s", subject)
+				return fmt.Errorf("expected messages with the transformed subject %s", subject)
 			} else {
-				if ss != subjectNumMsgs {
-					t.Fatalf("Expected %d messages on the transformed subject %s but got %d", subjectNumMsgs, subject, ss)
+				if ss > subjectNumMsgs || ss < subjectNumMsgs {
+					return fmt.Errorf("expected %d messages on the transformed subject %s but got %d", subjectNumMsgs, subject, ss)
 				}
 			}
 			if si.State.Msgs != streamNumMsg {
-				return fmt.Errorf("Expected %d stream messages, got state: %+v", streamNumMsg, si.State)
+				return fmt.Errorf("expected %d stream messages, got state: %+v", streamNumMsg, si.State)
 			}
 			if si.State.FirstSeq != firstSeq || si.State.LastSeq != lastSeq {
-				return fmt.Errorf("Expected first sequence=%d and last sequence=%d, but got state: %+v", firstSeq, lastSeq, si.State)
+				return fmt.Errorf("expected first sequence=%d and last sequence=%d, but got state: %+v", firstSeq, lastSeq, si.State)
 			}
 			return nil
 		}
 	}
 
-	checkFor(t, 10*time.Second, 100*time.Millisecond, f("M5", "foo2", 100, 100, 251, 350))
-	checkFor(t, 10*time.Second, 100*time.Millisecond, f("M6", "bar2", 50, 150, 101, 250))
-	checkFor(t, 10*time.Second, 100*time.Millisecond, f("M6", "baz2", 100, 150, 101, 250))
+	checkFor(t, 10*time.Second, 500*time.Millisecond, f("M5", "foo2", 100, 100, 251, 350))
+	checkFor(t, 10*time.Second, 500*time.Millisecond, f("M6", "bar2", 50, 150, 101, 250))
+	checkFor(t, 10*time.Second, 500*time.Millisecond, f("M6", "baz2", 100, 150, 101, 250))
 
 }
 

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -11607,7 +11607,7 @@ func TestJetStreamMirrorBasics(t *testing.T) {
 			if ss, ok := si.State.Subjects[subject]; !ok {
 				return fmt.Errorf("expected messages with the transformed subject %s", subject)
 			} else {
-				if ss > subjectNumMsgs || ss < subjectNumMsgs {
+				if ss != subjectNumMsgs {
 					return fmt.Errorf("expected %d messages on the transformed subject %s but got %d", subjectNumMsgs, subject, ss)
 				}
 			}


### PR DESCRIPTION
Fix test that could flap with the following kind  error in TestJetStreamMirrorBasics:
```
jetstream_test.go:11608: Expected messages with the transformed subject foo2
jetstream_test.go:11611: Expected 100 messageson  the transformed subject foo2 but got 13
```

Also saw a context timeout happening on a Stream Info in another part of the test, which could also flap sometimes as the timeout was pretty short at 250ms so relaxed it to 500ms and haven't seen that flap since.