### PR TITLE
Fixed incorrect mqtt-test reference (mqttex tests failure)

### DIFF
--- a/.github/workflows/MQTT_test.yaml
+++ b/.github/workflows/MQTT_test.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           wget https://github.com/hivemq/mqtt-cli/releases/download/v4.20.0/mqtt-cli-4.20.0.deb
           sudo apt install ./mqtt-cli-4.20.0.deb
-          go install github.com/ConnectEverything/mqtt-test@latest
+          go install github.com/ConnectEverything/mqtt-test@4dd571c31318dcfebe5443242f53f262403ceafb
 
       # - name: Download benchmark result for ${{ github.base_ref || github.ref_name }}
       #   uses: dawidd6/action-download-artifact@v2


### PR DESCRIPTION
https://github.com/nats-io/nats-server/pull/5082 was supposed to fix this, but it is not reviewed yet.

`mqtt-test` got updated; and the `@latest` reference is causing the new, incompatible, version to be used. This PR will fix it, until #5082 is merged.