### PR TITLE
ocsp: make ocsp request with POST method

### DIFF
--- a/server/ocsp.go
+++ b/server/ocsp.go
@@ -14,12 +14,14 @@
 package server
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -161,16 +163,43 @@ func (oc *OCSPMonitor) getRemoteStatus() ([]byte, *ocsp.Response, error) {
 	if config := opts.OCSPConfig; config != nil {
 		overrideURLs = config.OverrideURLs
 	}
-	getRequestBytes := func(u string, hc *http.Client) ([]byte, error) {
+	getRequestBytes := func(u string, reqDER []byte, hc *http.Client) ([]byte, error) {
+		reqEnc := base64.StdEncoding.EncodeToString(reqDER)
+		u = fmt.Sprintf("%s/%s", u, reqEnc)
+		start := time.Now()
 		resp, err := hc.Get(u)
 		if err != nil {
 			return nil, err
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("non-ok http status: %d", resp.StatusCode)
-		}
 
+		oc.srv.Debugf("Received OCSP response (method=GET, status=%v, url=%s, duration=%.3fs)",
+			resp.StatusCode, u, time.Since(start).Seconds())
+		if resp.StatusCode > 299 {
+			return nil, fmt.Errorf("non-ok http status on GET request (reqlen=%d): %d", len(reqEnc), resp.StatusCode)
+		}
+		return io.ReadAll(resp.Body)
+	}
+	postRequestBytes := func(u string, body []byte, hc *http.Client) ([]byte, error) {
+		hreq, err := http.NewRequest("POST", u, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		hreq.Header.Add("Content-Type", "application/ocsp-request")
+		hreq.Header.Add("Accept", "application/ocsp-response")
+
+		start := time.Now()
+		resp, err := hc.Do(hreq)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		oc.srv.Debugf("Received OCSP response (method=POST, status=%v, url=%s, duration=%.3fs)",
+			resp.StatusCode, u, time.Since(start).Seconds())
+		if resp.StatusCode > 299 {
+			return nil, fmt.Errorf("non-ok http status on POST request (reqlen=%d): %d", len(body), resp.StatusCode)
+		}
 		return io.ReadAll(resp.Body)
 	}
 
@@ -181,8 +210,6 @@ func (oc *OCSPMonitor) getRemoteStatus() ([]byte, *ocsp.Response, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-
-	reqEnc := base64.StdEncoding.EncodeToString(reqDER)
 
 	responders := oc.Leaf.OCSPServer
 	if len(overrideURLs) > 0 {
@@ -195,18 +222,28 @@ func (oc *OCSPMonitor) getRemoteStatus() ([]byte, *ocsp.Response, error) {
 	oc.mu.Lock()
 	hc := oc.hc
 	oc.mu.Unlock()
+
 	var raw []byte
 	for _, u := range responders {
+		var postErr, getErr error
 		u = strings.TrimSuffix(u, "/")
-		raw, err = getRequestBytes(fmt.Sprintf("%s/%s", u, reqEnc), hc)
-		if err == nil {
+		// Prefer to make POST requests first.
+		raw, postErr = postRequestBytes(u, reqDER, hc)
+		if postErr == nil {
 			break
+		} else {
+			// Fallback to use a GET request.
+			raw, getErr = getRequestBytes(u, reqDER, hc)
+			if getErr == nil {
+				break
+			} else {
+				err = errors.Join(postErr, getErr)
+			}
 		}
 	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("exhausted ocsp servers: %w", err)
 	}
-
 	resp, err := ocsp.ParseResponse(raw, oc.Issuer)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get remote status: %w", err)

--- a/server/ocsp.go
+++ b/server/ocsp.go
@@ -230,11 +230,13 @@ func (oc *OCSPMonitor) getRemoteStatus() ([]byte, *ocsp.Response, error) {
 		// Prefer to make POST requests first.
 		raw, postErr = postRequestBytes(u, reqDER, hc)
 		if postErr == nil {
+			err = nil
 			break
 		} else {
 			// Fallback to use a GET request.
 			raw, getErr = getRequestBytes(u, reqDER, hc)
 			if getErr == nil {
+				err = nil
 				break
 			} else {
 				err = errors.Join(postErr, getErr)

--- a/test/ocsp_peer_test.go
+++ b/test/ocsp_peer_test.go
@@ -2821,7 +2821,7 @@ func TestOCSPPeerNextUpdateUnset(t *testing.T) {
 	respCertPEM := "configs/certs/ocsp_peer/mini-ca/ocsp1/ocsp1_bundle.pem"
 	respKeyPEM := "configs/certs/ocsp_peer/mini-ca/ocsp1/private/ocsp1_keypair.pem"
 	issuerCertPEM := "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem"
-	intermediateCA1Responder := newOCSPResponderBase(t, issuerCertPEM, respCertPEM, respKeyPEM, true, "127.0.0.1:18888", 0)
+	intermediateCA1Responder := newOCSPResponderBase(t, issuerCertPEM, respCertPEM, respKeyPEM, true, "127.0.0.1:18888", 0, "")
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
 	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)

--- a/test/ocsp_test.go
+++ b/test/ocsp_test.go
@@ -3091,20 +3091,25 @@ func TestOCSPCustomConfigReloadEnable(t *testing.T) {
 
 func newOCSPResponderCustomAddress(t *testing.T, issuerCertPEM, issuerKeyPEM string, addr string) *http.Server {
 	t.Helper()
-	return newOCSPResponderBase(t, issuerCertPEM, issuerCertPEM, issuerKeyPEM, false, addr, defaultResponseTTL)
+	return newOCSPResponderBase(t, issuerCertPEM, issuerCertPEM, issuerKeyPEM, false, addr, defaultResponseTTL, "")
 }
 
 func newOCSPResponder(t *testing.T, issuerCertPEM, issuerKeyPEM string) *http.Server {
 	t.Helper()
-	return newOCSPResponderBase(t, issuerCertPEM, issuerCertPEM, issuerKeyPEM, false, defaultAddress, defaultResponseTTL)
+	return newOCSPResponderBase(t, issuerCertPEM, issuerCertPEM, issuerKeyPEM, false, defaultAddress, defaultResponseTTL, "")
 }
 
 func newOCSPResponderDesignatedCustomAddress(t *testing.T, issuerCertPEM, respCertPEM, respKeyPEM string, addr string) *http.Server {
 	t.Helper()
-	return newOCSPResponderBase(t, issuerCertPEM, respCertPEM, respKeyPEM, true, addr, defaultResponseTTL)
+	return newOCSPResponderBase(t, issuerCertPEM, respCertPEM, respKeyPEM, true, addr, defaultResponseTTL, "")
 }
 
-func newOCSPResponderBase(t *testing.T, issuerCertPEM, respCertPEM, respKeyPEM string, embed bool, addr string, responseTTL time.Duration) *http.Server {
+func newOCSPResponderPreferringHTTPMethod(t *testing.T, issuerCertPEM, issuerKeyPEM, method string) *http.Server {
+	t.Helper()
+	return newOCSPResponderBase(t, issuerCertPEM, issuerCertPEM, issuerKeyPEM, false, defaultAddress, defaultResponseTTL, method)
+}
+
+func newOCSPResponderBase(t *testing.T, issuerCertPEM, respCertPEM, respKeyPEM string, embed bool, addr string, responseTTL time.Duration, method string) *http.Server {
 	t.Helper()
 	var mu sync.Mutex
 	status := make(map[string]int)
@@ -3157,12 +3162,26 @@ func newOCSPResponderBase(t *testing.T, issuerCertPEM, respCertPEM, respKeyPEM s
 	// OCSP status request and signs a response with a CA. Lightly based off:
 	// https://www.ietf.org/rfc/rfc2560.txt
 	mux.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
-		if r.Method != "GET" {
+		var reqData []byte
+		var err error
+
+		switch {
+		case r.Method == "GET":
+			if method != "" && r.Method != method {
+				http.Error(rw, "", http.StatusBadRequest)
+				return
+			}
+			reqData, err = base64.StdEncoding.DecodeString(r.URL.Path[1:])
+		case r.Method == "POST":
+			if method != "" && r.Method != method {
+				http.Error(rw, "", http.StatusBadRequest)
+				return
+			}
+			reqData, err = io.ReadAll(r.Body)
+		default:
 			http.Error(rw, "Method Not Allowed", http.StatusMethodNotAllowed)
 			return
 		}
-
-		reqData, err := base64.StdEncoding.DecodeString(r.URL.Path[1:])
 		if err != nil {
 			http.Error(rw, err.Error(), http.StatusBadRequest)
 			return
@@ -4196,5 +4215,148 @@ func TestMixedCAOCSPSuperCluster(t *testing.T) {
 	}
 	if lerr != nil {
 		t.Errorf("Unexpected error: %v", lerr)
+	}
+}
+
+func TestOCSPResponderHTTPMethods(t *testing.T) {
+	t.Run("prefer get", func(t *testing.T) {
+		testOCSPResponderHTTPMethods(t, "GET")
+	})
+	t.Run("prefer post", func(t *testing.T) {
+		testOCSPResponderHTTPMethods(t, "POST")
+	})
+	t.Run("all methods failing", func(t *testing.T) {
+		testOCSPResponderFailing(t, "TEST")
+	})
+}
+
+func testOCSPResponderHTTPMethods(t *testing.T, method string) {
+	const (
+		caCert     = "configs/certs/ocsp/ca-cert.pem"
+		caKey      = "configs/certs/ocsp/ca-key.pem"
+		serverCert = "configs/certs/ocsp/server-cert.pem"
+		serverKey  = "configs/certs/ocsp/server-key.pem"
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ocspr := newOCSPResponderPreferringHTTPMethod(t, caCert, caKey, method)
+	defer ocspr.Shutdown(ctx)
+	addr := fmt.Sprintf("http://%s", ocspr.Addr)
+	setOCSPStatus(t, addr, serverCert, ocsp.Good)
+
+	opts := server.Options{}
+	opts.Host = "127.0.0.1"
+	opts.NoLog = true
+	opts.NoSigs = true
+	opts.MaxControlLine = 4096
+	opts.Port = -1
+	opts.TLSCert = serverCert
+	opts.TLSKey = serverKey
+	opts.TLSCaCert = caCert
+	opts.TLSTimeout = 5
+	tcOpts := &server.TLSConfigOpts{
+		CertFile: opts.TLSCert,
+		KeyFile:  opts.TLSKey,
+		CaFile:   opts.TLSCaCert,
+		Timeout:  opts.TLSTimeout,
+	}
+
+	tlsConf, err := server.GenTLSConfig(tcOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts.TLSConfig = tlsConf
+
+	opts.OCSPConfig = &server.OCSPConfig{
+		Mode:         server.OCSPModeAlways,
+		OverrideURLs: []string{addr},
+	}
+	srv := RunServer(&opts)
+	defer srv.Shutdown()
+
+	nc, err := nats.Connect(fmt.Sprintf("tls://localhost:%d", opts.Port),
+		nats.Secure(&tls.Config{
+			VerifyConnection: func(s tls.ConnectionState) error {
+				resp, err := getOCSPStatus(s)
+				if err != nil {
+					return err
+				}
+				if resp.Status != ocsp.Good {
+					return fmt.Errorf("invalid staple")
+				}
+				return nil
+			},
+		}),
+		nats.RootCAs(caCert),
+		nats.ErrorHandler(noOpErrHandler),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nc.Close()
+	sub, err := nc.SubscribeSync("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nc.Publish("foo", []byte("hello world"))
+	nc.Flush()
+
+	_, err = sub.NextMsg(1 * time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nc.Close()
+}
+
+func testOCSPResponderFailing(t *testing.T, method string) {
+	const (
+		caCert     = "configs/certs/ocsp/ca-cert.pem"
+		caKey      = "configs/certs/ocsp/ca-key.pem"
+		serverCert = "configs/certs/ocsp/server-cert.pem"
+		serverKey  = "configs/certs/ocsp/server-key.pem"
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ocspr := newOCSPResponderPreferringHTTPMethod(t, caCert, caKey, method)
+	defer ocspr.Shutdown(ctx)
+	addr := fmt.Sprintf("http://%s", ocspr.Addr)
+	setOCSPStatus(t, addr, serverCert, ocsp.Good)
+
+	opts := server.Options{}
+	opts.Host = "127.0.0.1"
+	opts.NoLog = true
+	opts.NoSigs = true
+	opts.MaxControlLine = 4096
+	opts.Port = -1
+	opts.TLSCert = serverCert
+	opts.TLSKey = serverKey
+	opts.TLSCaCert = caCert
+	opts.TLSTimeout = 5
+	tcOpts := &server.TLSConfigOpts{
+		CertFile: opts.TLSCert,
+		KeyFile:  opts.TLSKey,
+		CaFile:   opts.TLSCaCert,
+		Timeout:  opts.TLSTimeout,
+	}
+
+	tlsConf, err := server.GenTLSConfig(tcOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts.TLSConfig = tlsConf
+
+	opts.OCSPConfig = &server.OCSPConfig{
+		Mode:         server.OCSPModeAlways,
+		OverrideURLs: []string{addr},
+	}
+	expected := "bad OCSP status update for certificate at 'configs/certs/ocsp/server-cert.pem': "
+	expected += "exhausted ocsp servers: non-ok http status on POST request (reqlen=68): 400\nnon-ok http status on GET request (reqlen=92): 400"
+	_, err = server.NewServer(&opts)
+	if err == nil {
+		t.Error("Unexpected success setting up server")
+	} else if err.Error() != expected {
+		t.Errorf("Expected %q, got: %q", expected, err.Error())
 	}
 }

--- a/test/ocsp_test.go
+++ b/test/ocsp_test.go
@@ -4245,6 +4245,11 @@ func testOCSPResponderHTTPMethods(t *testing.T, method string) {
 	addr := fmt.Sprintf("http://%s", ocspr.Addr)
 	setOCSPStatus(t, addr, serverCert, ocsp.Good)
 
+	// Add another responder that fails.
+	badaddr := "http://127.0.0.1:8889"
+	badocsp := newOCSPResponderCustomAddress(t, caCert, caKey, badaddr)
+	defer badocsp.Shutdown(ctx)
+
 	opts := server.Options{}
 	opts.Host = "127.0.0.1"
 	opts.NoLog = true
@@ -4270,7 +4275,7 @@ func testOCSPResponderHTTPMethods(t *testing.T, method string) {
 
 	opts.OCSPConfig = &server.OCSPConfig{
 		Mode:         server.OCSPModeAlways,
-		OverrideURLs: []string{addr},
+		OverrideURLs: []string{badaddr, addr},
 	}
 	srv := RunServer(&opts)
 	defer srv.Shutdown()


### PR DESCRIPTION
This makes the server send a POST request to the OCSP Server, then falling back to use GET as in previous versions.