### PR TITLE
Fix sending `Consumer Deleted` on peer remove

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -5060,11 +5060,12 @@ func (o *consumer) stopWithFlags(dflag, sdflag, doSignal, advisory bool) error {
 		// just that the consumer node is being removed, so we send delete
 		// advisories only if the consumer assignment is gone, which means
 		// actual consumer removal happened.
-		isConsumerAssigned := o.js.cluster.isConsumerAssigned(o.acc, o.stream, o.name)
-		if !isConsumerAssigned {
-			if advisory {
-				o.sendDeleteAdvisoryLocked()
-			}
+		isConsumerAssigned := true
+		if o.acc == nil || o.acc.js == nil || !o.acc.js.consumerAssigned(o.stream, o.name) {
+			isConsumerAssigned = false
+		}
+		if !isConsumerAssigned && advisory {
+			o.sendDeleteAdvisoryLocked()
 		}
 		if o.isPullMode() {
 			// Release any pending.


### PR DESCRIPTION
There was a bug that caused sending `Consumer Deleted` sending to pull consumers whenever a Peer was removed.

This is a draft solution, as I don't like how the code looks right now:
When peer is removed, the `delete flag` is set to `true`, and thats fine. After all we need to remove the stream from the peer.
However, we do not differentiate in any way if we are removing the RAFT asset as a whole, or just it from the given peer.
That's why I added additional flag, which allows more informed choices by the codepaths for stopping streams and consumers.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>
