### PR TITLE
Added sampling for account's trace destination

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/klauspost/compress v1.17.6
 	github.com/minio/highwayhash v1.0.2
-	github.com/nats-io/jwt/v2 v2.5.4
+	github.com/nats-io/jwt/v2 v2.5.5
 	github.com/nats-io/nats.go v1.33.1
 	github.com/nats-io/nkeys v0.4.7
 	github.com/nats-io/nuid v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/klauspost/compress v1.17.6 h1:60eq2E/jlfwQXtvZEeBUYADs+BwKBWURIY+Gj2e
 github.com/klauspost/compress v1.17.6/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
 github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
-github.com/nats-io/jwt/v2 v2.5.4 h1:Bz+drKl2GbE30fxTOtb0NYl1BQ5RwZ+Zcqkg3mR5bbI=
-github.com/nats-io/jwt/v2 v2.5.4/go.mod h1:ZdWS1nZa6WMZfFwwgpEaqBV8EPGVgOTDHN/wTbz0Y5A=
+github.com/nats-io/jwt/v2 v2.5.5 h1:ROfXb50elFq5c9+1ztaUbdlrArNFl2+fQWP6B8HGEq4=
+github.com/nats-io/jwt/v2 v2.5.5/go.mod h1:ZdWS1nZa6WMZfFwwgpEaqBV8EPGVgOTDHN/wTbz0Y5A=
 github.com/nats-io/nats.go v1.33.1 h1:8TxLZZ/seeEfR97qV0/Bl939tpDnt2Z2fK3HkPypj70=
 github.com/nats-io/nats.go v1.33.1/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF0wkWclB8=
 github.com/nats-io/nkeys v0.4.7 h1:RwNJbbIdYCoClSDNY7QVKZlyb/wfT6ugvFCiKy6vDvI=

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -510,6 +510,7 @@ func TestAccountSimpleConfig(t *testing.T) {
 
 func TestAccountParseConfig(t *testing.T) {
 	traceDest := "my.trace.dest"
+	traceSampling := 50
 	confFileName := createConfFile(t, []byte(fmt.Sprintf(`
     accounts {
       synadia {
@@ -519,14 +520,14 @@ func TestAccountParseConfig(t *testing.T) {
         ]
       }
       nats.io {
-		trace_dest: %q
+		msg_trace: {dest: %q, sampling: %d%%}
         users = [
           {user: derek, password: foo}
           {user: ivan, password: bar}
         ]
       }
     }
-    `, traceDest)))
+    `, traceDest, traceSampling)))
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error processing config file: %v", err)
@@ -550,7 +551,9 @@ func TestAccountParseConfig(t *testing.T) {
 	if natsAcc == nil {
 		t.Fatalf("Error retrieving account for 'nats.io'")
 	}
-	require_Equal[string](t, natsAcc.getTraceDest(), traceDest)
+	td, tds := natsAcc.getTraceDestAndSampling()
+	require_Equal[string](t, td, traceDest)
+	require_Equal[int](t, tds, traceSampling)
 
 	for _, u := range opts.Users {
 		if u.Username == "derek" {

--- a/server/client.go
+++ b/server/client.go
@@ -4356,8 +4356,8 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 				// We also need to disable the message trace headers so that
 				// if the message is routed, it does not initialize tracing in the
 				// remote.
-				positions := mt.disableTraceHeaders(c, msg)
-				defer mt.enableTraceHeaders(c, msg, positions)
+				positions := disableTraceHeaders(c, msg)
+				defer enableTraceHeaders(c, msg, positions)
 			}
 		}
 	}

--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -920,7 +920,7 @@ func TestConfigCheck(t *testing.T) {
                   A { trace_dest: 123 }
                 }
 			`,
-			err:       errors.New(`interface conversion: interface {} is int64, not string`),
+			err:       errors.New(`Expected account message trace "trace_dest" to be a string or a map/struct, got int64`),
 			errorLine: 3,
 			errorPos:  23,
 		},
@@ -945,6 +945,94 @@ func TestConfigCheck(t *testing.T) {
 			err:       errors.New(`Trace destination "invalid.publish.*.subject" is not valid`),
 			errorLine: 3,
 			errorPos:  23,
+		},
+		{
+			name: "when account message trace dest is wrong type",
+			config: `
+                accounts {
+                  A { msg_trace: {dest: 123} }
+                }
+			`,
+			err:       errors.New(`Field "dest" should be a string, got int64`),
+			errorLine: 3,
+			errorPos:  35,
+		},
+		{
+			name: "when account message trace dest is invalid",
+			config: `
+                accounts {
+                  A { msg_trace: {dest: "invalid..dest"} }
+                }
+			`,
+			err:       errors.New(`Trace destination "invalid..dest" is not valid`),
+			errorLine: 3,
+			errorPos:  35,
+		},
+		{
+			name: "when account message trace sampling is wrong type",
+			config: `
+                accounts {
+                  A { msg_trace: {dest: "acc.dest", sampling: {wront: "type"}} }
+                }
+			`,
+			err:       errors.New(`Trace destination sampling field "sampling" should be an integer or a percentage, got map[string]interface {}`),
+			errorLine: 3,
+			errorPos:  53,
+		},
+		{
+			name: "when account message trace sampling is wrong string",
+			config: `
+                accounts {
+                  A { msg_trace: {dest: "acc.dest", sampling: abc%} }
+                }
+			`,
+			err:       errors.New(`Invalid trace destination sampling value "abc%"`),
+			errorLine: 3,
+			errorPos:  53,
+		},
+		{
+			name: "when account message trace sampling is negative",
+			config: `
+                accounts {
+                  A { msg_trace: {dest: "acc.dest", sampling: -1} }
+                }
+			`,
+			err:       errors.New(`Ttrace destination sampling value -1 is invalid, needs to be [1..100]`),
+			errorLine: 3,
+			errorPos:  53,
+		},
+		{
+			name: "when account message trace sampling is zero",
+			config: `
+                accounts {
+                  A { msg_trace: {dest: "acc.dest", sampling: 0} }
+                }
+			`,
+			err:       errors.New(`Ttrace destination sampling value 0 is invalid, needs to be [1..100]`),
+			errorLine: 3,
+			errorPos:  53,
+		},
+		{
+			name: "when account message trace sampling is more than 100",
+			config: `
+                accounts {
+                  A { msg_trace: {dest: "acc.dest", sampling: 101} }
+                }
+			`,
+			err:       errors.New(`Ttrace destination sampling value 101 is invalid, needs to be [1..100]`),
+			errorLine: 3,
+			errorPos:  53,
+		},
+		{
+			name: "when account message trace has unknown field",
+			config: `
+                accounts {
+                  A { msg_trace: {wrong: "field"} }
+                }
+			`,
+			err:       errors.New(`Unknown field "wrong" parsing account message trace map/struct "msg_trace"`),
+			errorLine: 3,
+			errorPos:  35,
 		},
 		{
 			name: "when user authorization config has both token and users",

--- a/server/msgtrace.go
+++ b/server/msgtrace.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -435,11 +436,19 @@ func (c *client) initMsgTrace() *msgTrace {
 	// If external, we need to have the account's trace destination set,
 	// otherwise, we are not enabling tracing.
 	if external {
+		var sampling int
 		if acc != nil {
-			dest = acc.getTraceDest()
+			dest, sampling = acc.getTraceDestAndSampling()
 		}
 		if dest == _EMPTY_ {
 			// No account destination, no tracing for external trace headers.
+			return nil
+		}
+		// Check sampling, but only from origin server.
+		if c.kind == CLIENT && !sample(sampling) {
+			// Need to desactivate the traceParentHdr so that if the message
+			// is routed, it does possibly trigger a trace there.
+			disableTraceHeaders(c, hdr)
 			return nil
 		}
 	}
@@ -470,6 +479,15 @@ func (c *client) initMsgTrace() *msgTrace {
 		tonly: traceOnly,
 	}
 	return c.pa.trace
+}
+
+func sample(sampling int) bool {
+	// Option parsing should ensure that sampling is [1..100], but consider
+	// any value outside of this range to be 100%.
+	if sampling <= 0 || sampling >= 100 {
+		return true
+	}
+	return rand.Int31n(100) <= int32(sampling)
 }
 
 // This function will return the header as a map (instead of http.Header because
@@ -637,7 +655,7 @@ func (t *msgTrace) setHopHeader(c *client, msg []byte) []byte {
 // Note that if `msg` can be either the header alone or the full message
 // (header and payload). This function will use c.pa.hdr to limit the
 // search to the header section alone.
-func (t *msgTrace) disableTraceHeaders(c *client, msg []byte) []int {
+func disableTraceHeaders(c *client, msg []byte) []int {
 	// Code largely copied from getHeader(), except that we don't need the value
 	if c.pa.hdr <= 0 {
 		return []int{-1, -1}
@@ -672,7 +690,7 @@ func (t *msgTrace) disableTraceHeaders(c *client, msg []byte) []int {
 
 // Changes back the character at the given position `pos` in the `msg`
 // byte slice to the first character of the MsgTraceSendTo header.
-func (t *msgTrace) enableTraceHeaders(c *client, msg []byte, positions []int) {
+func enableTraceHeaders(c *client, msg []byte, positions []int) {
 	firstChar := [2]byte{MsgTraceDest[0], traceParentHdr[0]}
 	for i, pos := range positions {
 		if pos == -1 {

--- a/server/msgtrace_test.go
+++ b/server/msgtrace_test.go
@@ -4898,3 +4898,216 @@ func TestMsgTraceStreamJWTUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestMsgTraceParseAccountDestWithSampling(t *testing.T) {
+	tmpl := `
+		port: -1
+		accounts {
+			A {
+				users: [{user: a, password: pwd}]
+				%s
+			}
+		}
+	`
+	for _, test := range []struct {
+		name        string
+		samplingStr string
+		want        int
+	}{
+		{"trace sampling no dest", `msg_trace: {sampling: 50}`, 0},
+		{"trace dest only", `msg_trace: {dest: foo}`, 100},
+		{"trace dest with number only", `msg_trace: {dest: foo, sampling: 20}`, 20},
+		{"trace dest with percentage", `msg_trace: {dest: foo, sampling: 50%}`, 50},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			conf := createConfFile(t, []byte(fmt.Sprintf(tmpl, test.samplingStr)))
+			o := LoadConfig(conf)
+			_, sampling := o.Accounts[0].getTraceDestAndSampling()
+			require_Equal[int](t, test.want, sampling)
+		})
+	}
+}
+
+func TestMsgTraceAccountDestWithSampling(t *testing.T) {
+	tmpl := `
+		port: -1
+		server_name: %s
+		accounts {
+			A {
+				users: [{user: a, password:pwd}]
+				msg_trace: {dest: "acc.dest"%s}
+			}
+		}
+		cluster {
+			port: -1
+			%s
+		}
+	`
+	conf1 := createConfFile(t, []byte(fmt.Sprintf(tmpl, "A", _EMPTY_, _EMPTY_)))
+	s1, o1 := RunServerWithConfig(conf1)
+	defer s1.Shutdown()
+
+	routes := fmt.Sprintf("routes: [\"nats://127.0.0.1:%d\"]", o1.Cluster.Port)
+	conf2 := createConfFile(t, []byte(fmt.Sprintf(tmpl, "B", _EMPTY_, routes)))
+	s2, _ := RunServerWithConfig(conf2)
+	defer s2.Shutdown()
+
+	checkClusterFormed(t, s1, s2)
+
+	nc2 := natsConnect(t, s2.ClientURL(), nats.UserInfo("a", "pwd"))
+	defer nc2.Close()
+	natsSub(t, nc2, "foo", func(_ *nats.Msg) {})
+	natsFlush(t, nc2)
+
+	nc1 := natsConnect(t, s1.ClientURL(), nats.UserInfo("a", "pwd"))
+	defer nc1.Close()
+	sub := natsSubSync(t, nc1, "acc.dest")
+	natsFlush(t, nc1)
+
+	checkSubInterest(t, s1, "A", "foo", time.Second)
+	checkSubInterest(t, s2, "A", "acc.dest", time.Second)
+
+	for iter, test := range []struct {
+		name        string
+		samplingStr string
+		sampling    int
+	}{
+		// Sampling is considered 100% if not specified or <=0 or >= 100.
+		// To disable sampling, the account destination should not be specified.
+		{"no sampling specified", _EMPTY_, 100},
+		{"sampling specified", ", sampling: \"25%\"", 25},
+		{"no sampling again", _EMPTY_, 100},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if iter > 0 {
+				reloadUpdateConfig(t, s1, conf1, fmt.Sprintf(tmpl, "A", test.samplingStr, _EMPTY_))
+				reloadUpdateConfig(t, s2, conf2, fmt.Sprintf(tmpl, "B", test.samplingStr, routes))
+			}
+			msg := nats.NewMsg("foo")
+			msg.Header.Set(traceParentHdr, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+			total := 400
+			for i := 0; i < total; i++ {
+				err := nc1.PublishMsg(msg)
+				require_NoError(t, err)
+			}
+			// Wait a bit to make sure that we received all traces that should
+			// have been received.
+			time.Sleep(500 * time.Millisecond)
+			n, _, err := sub.Pending()
+			require_NoError(t, err)
+			fromClient := 0
+			fromRoute := 0
+			for i := 0; i < n; i++ {
+				msg = natsNexMsg(t, sub, time.Second)
+				var e MsgTraceEvent
+				err = json.Unmarshal(msg.Data, &e)
+				require_NoError(t, err)
+				ingress := e.Ingress()
+				require_True(t, ingress != nil)
+				switch ingress.Kind {
+				case CLIENT:
+					fromClient++
+				case ROUTER:
+					fromRoute++
+				default:
+					t.Fatalf("Unexpected ingress: %+v", ingress)
+				}
+			}
+			// There should be as many messages coming from the origin server
+			// and the routed server. This checks that if sampling is not 100%
+			// then when a message is routed, the header is properly deactivated.
+			require_Equal[int](t, fromClient, fromRoute)
+			// Now check that if sampling was 100%, we have the total number
+			// of published messages.
+			if test.sampling == 100 {
+				require_Equal[int](t, fromClient, total)
+			} else {
+				// Otherwise, we should have no more (but let's be conservative)
+				// than the sampling number.
+				require_LessThan[int](t, fromClient, int(float64(test.sampling*total/100)*1.35))
+			}
+		})
+	}
+}
+
+func TestMsgTraceAccDestWithSamplingJWTUpdate(t *testing.T) {
+	// create system account
+	sysKp, _ := nkeys.CreateAccount()
+	sysPub, _ := sysKp.PublicKey()
+	sysCreds := newUser(t, sysKp)
+	// create account A
+	akp, _ := nkeys.CreateAccount()
+	aPub, _ := akp.PublicKey()
+	claim := jwt.NewAccountClaims(aPub)
+	claim.Trace = &jwt.MsgTrace{Destination: "acc.trace.dest"}
+	aJwt, err := claim.Encode(oKp)
+	require_NoError(t, err)
+
+	dir := t.TempDir()
+	conf := createConfFile(t, []byte(fmt.Sprintf(`
+			listen: -1
+			operator: %s
+			resolver: {
+				type: full
+				dir: '%s'
+			}
+			system_account: %s
+		`, ojwt, dir, sysPub)))
+	s, _ := RunServerWithConfig(conf)
+	defer s.Shutdown()
+	updateJwt(t, s.ClientURL(), sysCreds, aJwt, 1)
+
+	nc := natsConnect(t, s.ClientURL(), createUserCreds(t, nil, akp))
+	defer nc.Close()
+
+	sub := natsSubSync(t, nc, "acc.trace.dest")
+	natsFlush(t, nc)
+
+	for iter, test := range []struct {
+		name     string
+		sampling int
+	}{
+		{"no sampling specified", 100},
+		{"sampling", 25},
+		{"set back sampling to 0", 100},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if iter > 0 {
+				claim.Trace = &jwt.MsgTrace{Destination: "acc.trace.dest", Sampling: test.sampling}
+				aJwt, err = claim.Encode(oKp)
+				require_NoError(t, err)
+				updateJwt(t, s.ClientURL(), sysCreds, aJwt, 1)
+			}
+
+			msg := nats.NewMsg("foo")
+			msg.Header.Set(traceParentHdr, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+			msg.Data = []byte("hello")
+
+			total := 400
+			for i := 0; i < total; i++ {
+				err := nc.PublishMsg(msg)
+				require_NoError(t, err)
+			}
+			// Wait a bit to make sure that we received all traces that should
+			// have been received.
+			time.Sleep(500 * time.Millisecond)
+			n, _, err := sub.Pending()
+			require_NoError(t, err)
+			for i := 0; i < n; i++ {
+				msg = natsNexMsg(t, sub, time.Second)
+				var e MsgTraceEvent
+				err = json.Unmarshal(msg.Data, &e)
+				require_NoError(t, err)
+			}
+			// Now check that if sampling was 100%, we have the total number
+			// of published messages.
+			if test.sampling == 100 {
+				require_Equal[int](t, n, total)
+			} else {
+				// Otherwise, we should have no more (but let's be conservative)
+				// than the sampling number.
+				require_LessThan[int](t, n, int(float64(test.sampling*total/100)*1.35))
+			}
+		})
+	}
+}

--- a/server/stream.go
+++ b/server/stream.go
@@ -4224,7 +4224,7 @@ func (mset *stream) processInboundJetStreamMsg(_ *subscription, c *client, _ *Ac
 		// to prevent a trace event to be generated when a stored message
 		// is delivered to a consumer and routed.
 		if !traceOnly {
-			mt.disableTraceHeaders(c, hdr)
+			disableTraceHeaders(c, hdr)
 		}
 		// This will add the jetstream event while in the client read loop.
 		// Since the event will be updated in a different go routine, the


### PR DESCRIPTION
If an account has a trace destination and an incoming message has the `traceparent` header with the proper sampled flag, a trace message would be triggered. The `sampling` field allows to trace a certain percentage of the traffic.

The field `trace_dest` or now `msg_trace` can be a simple string representing the destination, and in this case sampling is 100% or it can be a structure with the `dest` and `sampling` fields. Sampling values that are negative or above 100 will trigger an error on configuration parsing. A value of 0 is converted to 100. If the sampling is specified without an account trace destination, it is set to 0 and a warning is issued when parsing configuration.

There is similar support for the property set in a JWT account claim.

Relates to #5014

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>