### PR TITLE
[FIXED] update consumer config fails to check OptStartTime properly

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1758,7 +1758,13 @@ func (acc *Account) checkNewConsumerConfig(cfg, ncfg *ConsumerConfig) error {
 	if cfg.OptStartSeq != ncfg.OptStartSeq {
 		return errors.New("start sequence can not be updated")
 	}
-	if cfg.OptStartTime != ncfg.OptStartTime {
+	if cfg.OptStartTime != nil && ncfg.OptStartTime != nil {
+		// Both have start times set, compare them directly:
+		if !cfg.OptStartTime.Equal(*ncfg.OptStartTime) {
+			return errors.New("start time can not be updated")
+		}
+	} else if cfg.OptStartTime != nil || ncfg.OptStartTime != nil {
+		// At least one start time is set and the other is not
 		return errors.New("start time can not be updated")
 	}
 	if cfg.AckPolicy != ncfg.AckPolicy {


### PR DESCRIPTION
while working on a pull request for the nats rust client, implementing the update_consumer method (which updates a consumer with a new config), i ran into a weird issue.
consumers that had the "by_start_time" delivery_policy could not be updated - they would throw the error "start time can not be updated" even though the OptStartTime would be set to the same value.

reading through the server/consumer.go code it seems like even though OptStartTime is a pointer to a time, the comparison in checkNewConsumerConfig does not take that into account and just checks for equality. therefore - if both the old config had their OptStartTime set and the new config has the same time.Time - they would be different, as they are different pointers.

this is my attempt at fixing the issue following the logic that the values should only be compared if both are not nil, and if that is not true, if any of them are not nil - it means they are also different values (one being nil and the other is not).

i manually tested this using my rust client test suite and it seems to work fine for all cases.

Signed-off-by: Tom Keidar
