### PR TITLE
Tweak GHA, don't run on push

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,7 @@
 name: NATS Server Tests
 
 on:
-  push:
+  # push:
   # pull_request:
   schedule:
     - cron: "15 * * * *" # Hourly, 15 mins past the hour
@@ -227,6 +227,7 @@ jobs:
 
       - name: Run unit tests
         run: go test -race -v -p=1 ./server/... -tags=skip_js_tests,skip_mqtt_tests -count=1 -vet=off -timeout=30m -failfast
+        timeout-minutes: 15
 
   non-server-pkg:
     name: Tests from all other packages


### PR DESCRIPTION
This should stop the status on `main` for now.

Signed-off-by: Neil Twigg <neil@nats.io>