### PR TITLE
Adds consumer metadata checking to next requests

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -725,11 +725,12 @@ const JSApiConsumerListResponseType = "io.nats.jetstream.api.v1.consumer_list_re
 
 // JSApiConsumerGetNextRequest is for getting next messages for pull based consumers.
 type JSApiConsumerGetNextRequest struct {
-	Expires   time.Duration `json:"expires,omitempty"`
-	Batch     int           `json:"batch,omitempty"`
-	MaxBytes  int           `json:"max_bytes,omitempty"`
-	NoWait    bool          `json:"no_wait,omitempty"`
-	Heartbeat time.Duration `json:"idle_heartbeat,omitempty"`
+	Expires   time.Duration     `json:"expires,omitempty"`
+	Batch     int               `json:"batch,omitempty"`
+	MaxBytes  int               `json:"max_bytes,omitempty"`
+	NoWait    bool              `json:"no_wait,omitempty"`
+	Heartbeat time.Duration     `json:"idle_heartbeat,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
 }
 
 // JSApiStreamTemplateCreateResponse for creating templates.


### PR DESCRIPTION
Adds a metadata field to consumer next requests
When processing the request the server will compare the request's metadata (if any) against the consumer's metadata (in the config) and reject the request with a status 409 if the two do not match (either a value is different or a key in the request is missing in the consumer).