### PR TITLE
[IMPROVED] Do not fire the store's expire timer too soon or too often since.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4622,7 +4622,11 @@ func (fs *fileStore) resetAgeChk(delta int64) {
 
 	fireIn := fs.cfg.MaxAge
 	if delta > 0 && time.Duration(delta) < fireIn {
-		fireIn = time.Duration(delta)
+		if fireIn = time.Duration(delta); fireIn < time.Second {
+			// Only fire at most once a second.
+			// Excessive firing can effect ingest performance.
+			fireIn = time.Second
+		}
 	}
 	if fs.ageChk != nil {
 		fs.ageChk.Reset(fireIn)

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -599,7 +599,7 @@ func TestFileStoreBytesLimitWithDiscardNew(t *testing.T) {
 }
 
 func TestFileStoreAgeLimit(t *testing.T) {
-	maxAge := 250 * time.Millisecond
+	maxAge := 1 * time.Second
 
 	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
 		if fcfg.Compression != NoCompression {
@@ -658,7 +658,7 @@ func TestFileStoreAgeLimit(t *testing.T) {
 		// We will measure the time to make sure expires works with interior deletes.
 		start := time.Now()
 		checkExpired(t)
-		if elapsed := time.Since(start); elapsed > time.Second {
+		if elapsed := time.Since(start); elapsed > 5*time.Second {
 			t.Fatalf("Took too long to expire: %v", elapsed)
 		}
 	})
@@ -1158,7 +1158,7 @@ func TestFileStoreRemoveOutOfOrderRecovery(t *testing.T) {
 }
 
 func TestFileStoreAgeLimitRecovery(t *testing.T) {
-	maxAge := 10 * time.Millisecond
+	maxAge := 1 * time.Second
 
 	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
 		fcfg.CacheExpire = 1 * time.Millisecond
@@ -1180,6 +1180,8 @@ func TestFileStoreAgeLimitRecovery(t *testing.T) {
 			t.Fatalf("Expected %d msgs, got %d", toStore, state.Msgs)
 		}
 		fs.Stop()
+
+		time.Sleep(maxAge)
 
 		fcfg.CacheExpire = 0
 		fs, err = newFileStoreWithCreated(fcfg, cfg, created, prf(&fcfg), nil)
@@ -3468,7 +3470,7 @@ func TestFileStoreCompactReclaimHeadSpace(t *testing.T) {
 func TestFileStoreRememberLastMsgTime(t *testing.T) {
 	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
 		var fs *fileStore
-		cfg := StreamConfig{Name: "TEST", Storage: FileStorage, MaxAge: 500 * time.Millisecond}
+		cfg := StreamConfig{Name: "TEST", Storage: FileStorage, MaxAge: 1 * time.Second}
 
 		getFS := func() *fileStore {
 			t.Helper()
@@ -3527,7 +3529,7 @@ func TestFileStoreRememberLastMsgTime(t *testing.T) {
 		require_True(t, seq == 4)
 
 		// Wait til messages expire.
-		checkFor(t, time.Second, 250*time.Millisecond, func() error {
+		checkFor(t, 5*time.Second, time.Second, func() error {
 			state := fs.State()
 			if state.Msgs == 0 {
 				return nil
@@ -3671,7 +3673,7 @@ func TestFileStoreShortIndexWriteBug(t *testing.T) {
 			require_NoError(t, err)
 		}
 		// Wait til messages all go away.
-		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
 			if state := fs.State(); state.Msgs != 0 {
 				return fmt.Errorf("Expected no msgs, got %d", state.Msgs)
 			}
@@ -3728,7 +3730,7 @@ func TestFileStoreDoubleCompactWithWriteInBetweenEncryptedBug(t *testing.T) {
 // Happens when all messages expire and the are flushed and then subsequent writes occur.
 func TestFileStoreEncryptedKeepIndexNeedBekResetBug(t *testing.T) {
 	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
-		ttl := 250 * time.Millisecond
+		ttl := 1 * time.Second
 		cfg := StreamConfig{Name: "zzz", Storage: FileStorage, MaxAge: ttl}
 		fs, err := newFileStoreWithCreated(fcfg, cfg, time.Now(), prf(&fcfg), nil)
 		require_NoError(t, err)
@@ -3741,7 +3743,7 @@ func TestFileStoreEncryptedKeepIndexNeedBekResetBug(t *testing.T) {
 
 		// Want to go to 0.
 		// This will leave the marker.
-		checkFor(t, time.Second, ttl, func() error {
+		checkFor(t, 5*time.Second, ttl, func() error {
 			if state := fs.State(); state.Msgs != 0 {
 				return fmt.Errorf("Expected no msgs, got %d", state.Msgs)
 			}
@@ -4393,7 +4395,7 @@ func TestFileStoreBadFirstAndFailedExpireAfterRestart(t *testing.T) {
 		}
 
 		// Put two more after a delay.
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(1500 * time.Millisecond)
 		seq, _, err := fs.StoreMsg(subj, nil, msg)
 		require_NoError(t, err)
 		_, _, err = fs.StoreMsg(subj, nil, msg)
@@ -4414,7 +4416,7 @@ func TestFileStoreBadFirstAndFailedExpireAfterRestart(t *testing.T) {
 
 		// Stop the filstore and wait til first block expires.
 		fs.Stop()
-		time.Sleep(ttl - time.Since(start) + (10 * time.Millisecond))
+		time.Sleep(ttl - time.Since(start) + (time.Second))
 		fs, err = newFileStoreWithCreated(fcfg, cfg, time.Now(), prf(&fcfg), nil)
 		require_NoError(t, err)
 		defer fs.Stop()
@@ -4428,7 +4430,7 @@ func TestFileStoreBadFirstAndFailedExpireAfterRestart(t *testing.T) {
 		require_True(t, !state.FirstTime.IsZero())
 
 		// Wait and make sure expire timer is still working properly.
-		time.Sleep(ttl)
+		time.Sleep(2 * ttl)
 		fs.FastState(&state)
 		require_Equal(t, state.Msgs, 0)
 		require_Equal(t, state.FirstSeq, 10)

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -2919,7 +2919,7 @@ func TestJetStreamClusterStreamMaxAgeScaleUp(t *testing.T) {
 			require_True(t, info.State.Msgs == 10)
 
 			// Wait until MaxAge is reached.
-			time.Sleep(ttl - time.Since(start) + (10 * time.Millisecond))
+			time.Sleep(ttl - time.Since(start) + (1 * time.Second))
 
 			// Check if all messages are expired.
 			info, err = js.StreamInfo(test.stream)
@@ -3506,7 +3506,7 @@ func TestJetStreamClusterConsumerAckFloorDrift(t *testing.T) {
 		Name:     "TEST",
 		Subjects: []string{"*"},
 		Replicas: 3,
-		MaxAge:   200 * time.Millisecond,
+		MaxAge:   time.Second,
 		MaxMsgs:  10,
 	})
 	require_NoError(t, err)
@@ -3537,7 +3537,7 @@ func TestJetStreamClusterConsumerAckFloorDrift(t *testing.T) {
 	require_NotNil(t, state)
 
 	// Now let messages expire.
-	checkFor(t, time.Second, 100*time.Millisecond, func() error {
+	checkFor(t, 5*time.Second, time.Second, func() error {
 		si, err := js.StreamInfo("TEST")
 		require_NoError(t, err)
 		if si.State.Msgs == 0 {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -2403,7 +2403,7 @@ func TestJetStreamAckReplyStreamPending(t *testing.T) {
 		Name:      "MY_WQ",
 		Subjects:  []string{"foo.*"},
 		Storage:   MemoryStorage,
-		MaxAge:    250 * time.Millisecond,
+		MaxAge:    1 * time.Second,
 		Retention: WorkQueuePolicy,
 	}
 	fsc := msc
@@ -2498,7 +2498,7 @@ func TestJetStreamAckReplyStreamPending(t *testing.T) {
 			nc.Flush()
 
 			// Wait for expiration to kick in.
-			checkFor(t, time.Second, 10*time.Millisecond, func() error {
+			checkFor(t, 5*time.Second, time.Second, func() error {
 				if state := mset.state(); state.Msgs != 0 {
 					return fmt.Errorf("Stream still has messages")
 				}
@@ -8125,12 +8125,12 @@ func TestJetStreamUpdateStream(t *testing.T) {
 
 			// Now do age.
 			cfg = *c.mconfig
-			cfg.MaxAge = 100 * time.Millisecond
+			cfg.MaxAge = time.Second
 			if err := mset.update(&cfg); err != nil {
 				t.Fatalf("Unexpected error %v", err)
 			}
 			// Just wait a bit for expiration.
-			time.Sleep(200 * time.Millisecond)
+			time.Sleep(2 * time.Second)
 			if mset.config().MaxAge != cfg.MaxAge {
 				t.Fatalf("Expected the change to take effect, %d vs %d", mset.config().MaxAge, cfg.MaxAge)
 			}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -692,7 +692,11 @@ func (ms *memStore) resetAgeChk(delta int64) {
 
 	fireIn := ms.cfg.MaxAge
 	if delta > 0 && time.Duration(delta) < fireIn {
-		fireIn = time.Duration(delta)
+		if fireIn = time.Duration(delta); fireIn < time.Second {
+			// Only fire at most once a second.
+			// Excessive firing can effect ingest performance.
+			fireIn = time.Second
+		}
 	}
 	if ms.ageChk != nil {
 		ms.ageChk.Reset(fireIn)
@@ -703,19 +707,21 @@ func (ms *memStore) resetAgeChk(delta int64) {
 
 // Will expire msgs that are too old.
 func (ms *memStore) expireMsgs() {
-	ms.mu.Lock()
-	defer ms.mu.Unlock()
-
+	ms.mu.RLock()
 	now := time.Now().UnixNano()
 	minAge := now - int64(ms.cfg.MaxAge)
+	ms.mu.RUnlock()
+
 	for {
+		ms.mu.Lock()
 		if sm, ok := ms.msgs[ms.state.FirstSeq]; ok && sm.ts <= minAge {
 			ms.deleteFirstMsgOrPanic()
 			// Recalculate in case we are expiring a bunch.
 			now = time.Now().UnixNano()
 			minAge = now - int64(ms.cfg.MaxAge)
-
+			ms.mu.Unlock()
 		} else {
+			// We will exit here
 			if len(ms.msgs) == 0 {
 				if ms.ageChk != nil {
 					ms.ageChk.Stop()
@@ -734,7 +740,8 @@ func (ms *memStore) expireMsgs() {
 					ms.ageChk = time.AfterFunc(fireIn, ms.expireMsgs)
 				}
 			}
-			return
+			ms.mu.Unlock()
+			break
 		}
 	}
 }


### PR DESCRIPTION
Firing too often can effect ingest performance.

Resolves: #5136 

Signed-off-by: Derek Collison <derek@nats.io>
