### PR TITLE
NRG: Tweak vote response handling

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -2919,7 +2919,9 @@ func (n *raft) runAsCandidate() {
 	n.requestVote()
 
 	// We vote for ourselves.
-	votes := 1
+	votes := map[string]struct{}{
+		n.ID(): {},
+	}
 
 	for n.State() == Candidate {
 		elect := n.electTimer()
@@ -2947,11 +2949,11 @@ func (n *raft) runAsCandidate() {
 			nterm := n.term
 			n.RUnlock()
 
-			if vresp.granted && nterm >= vresp.term {
+			if vresp.granted && nterm == vresp.term {
 				// only track peers that would be our followers
 				n.trackPeer(vresp.peer)
-				votes++
-				if n.wonElection(votes) {
+				votes[vresp.peer] = struct{}{}
+				if n.wonElection(len(votes)) {
 					// Become LEADER if we have won and gotten a quorum with everyone we should hear from.
 					n.switchToLeader()
 					return


### PR DESCRIPTION
This should ensure that duplicate vote responses from the same node can't be handled and that vote response terms can't be mixed during the handling.

Signed-off-by: Neil Twigg <neil@nats.io>