### PR TITLE
NRG: Wait for upper layer to update applied on inline CE updates

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -2798,16 +2798,15 @@ func (n *raft) applyCommit(index uint64) error {
 			committed = append(committed, e)
 		}
 	}
-	// Pass to the upper layers if we have normal entries.
-	if len(committed) > 0 {
-		if fpae {
-			delete(n.pae, index)
-		}
-		n.apply.push(newCommittedEntry(index, committed))
-	} else {
-		// If we processed inline update our applied index.
-		n.applied = index
+	if fpae {
+		delete(n.pae, index)
 	}
+	// Pass to the upper layers if we have normal entries. It is
+	// entirely possible that 'committed' might be an empty slice here,
+	// which will happen if we've processed updates inline (like peer
+	// states). In which case the upper layer will just call down with
+	// Applied() with no further action.
+	n.apply.push(newCommittedEntry(index, committed))
 	// Place back in the pool.
 	ae.returnToPool()
 	return nil


### PR DESCRIPTION
In particular peer state entries don't produce committed entries, but bumping `applied` inline means that we can potentially move the Raft state ahead of the real applied state. Instead just send up a CE with no entries and wait for the upper layer to update `applied` instead, so that there is better consistency between the layers.

Signed-off-by: Neil Twigg <neil@nats.io>