### PR TITLE
Add consumer Owner ID

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -730,6 +730,7 @@ type JSApiConsumerGetNextRequest struct {
 	MaxBytes  int           `json:"max_bytes,omitempty"`
 	NoWait    bool          `json:"no_wait,omitempty"`
 	Heartbeat time.Duration `json:"idle_heartbeat,omitempty"`
+	OwnerID   string        `json:"owner_id,omitempty"`
 }
 
 // JSApiStreamTemplateCreateResponse for creating templates.

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -639,7 +639,7 @@ func TestJetStreamConsumerMaxDeliveries(t *testing.T) {
 
 func TestJetStreamNextReqFromMsg(t *testing.T) {
 	bef := time.Now()
-	expires, _, _, _, _, _, err := nextReqFromMsg([]byte(`{"expires":5000000000}`)) // nanoseconds
+	expires, _, _, _, _, _, _, err := nextReqFromMsg([]byte(`{"expires":5000000000}`)) // nanoseconds
 	require_NoError(t, err)
 	now := time.Now()
 	if expires.Before(bef.Add(5*time.Second)) || expires.After(now.Add(5*time.Second)) {


### PR DESCRIPTION
This is an alternative approach to PR #5141 

It does not use metadata, but instead introduces lightweight "ownerID" string to consumer and request.

Needs more testing. Wanted to just show the idea.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>
