### PR TITLE
Add support for AsOfTime for get/direct msg requests

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -649,6 +649,8 @@ type JSApiMsgGetRequest struct {
 	// This will make sure we limit how much data we blast out. If not set we will
 	// inherit the slow consumer default max setting of the server. Default is MAX_PENDING_SIZE.
 	MaxBytes int `json:"max_bytes,omitempty"`
+	// Return messages as of this start time.
+	StartTime *time.Time `json:"start_time,omitempty"`
 
 	// Multiple response support. Will get the last msgs matching the subjects. These can include wildcards.
 	MultiLastFor []string `json:"multi_last,omitempty"`
@@ -656,8 +658,6 @@ type JSApiMsgGetRequest struct {
 	UpToSeq uint64 `json:"up_to_seq,omitempty"`
 	// Only return messages up to this time.
 	UpToTime *time.Time `json:"up_to_time,omitempty"`
-	// Return messages as of this start time.
-	StartTime *time.Time `json:"start_time,omitempty"`
 }
 
 type JSApiMsgGetResponse struct {

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -656,8 +656,8 @@ type JSApiMsgGetRequest struct {
 	UpToSeq uint64 `json:"up_to_seq,omitempty"`
 	// Only return messages up to this time.
 	UpToTime *time.Time `json:"up_to_time,omitempty"`
-	// Return messages as of this time.
-	AsOfTime *time.Time `json:"as_of_time,omitempty"`
+	// Return messages as of this start time.
+	StartTime *time.Time `json:"start_time,omitempty"`
 }
 
 type JSApiMsgGetResponse struct {
@@ -3145,9 +3145,9 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, _ *Account, subje
 	// Validate non-conflicting options. Seq, LastFor, and AsOfTime are mutually exclusive.
 	// NextFor can be paired with Seq or AsOfTime indicating a filter subject.
 	if (req.Seq > 0 && req.LastFor != _EMPTY_) ||
-		(req.Seq == 0 && req.LastFor == _EMPTY_ && req.NextFor == _EMPTY_ && req.AsOfTime == nil) ||
-		(req.Seq > 0 && req.AsOfTime != nil) ||
-		(req.AsOfTime != nil && req.LastFor != _EMPTY_) ||
+		(req.Seq == 0 && req.LastFor == _EMPTY_ && req.NextFor == _EMPTY_ && req.StartTime == nil) ||
+		(req.Seq > 0 && req.StartTime != nil) ||
+		(req.StartTime != nil && req.LastFor != _EMPTY_) ||
 		(req.LastFor != _EMPTY_ && req.NextFor != _EMPTY_) {
 		resp.Error = NewJSBadRequestError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -3166,8 +3166,8 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, _ *Account, subje
 
 	// If AsOfTime is set, perform this first to get the sequence.
 	var seq uint64
-	if req.AsOfTime != nil {
-		seq = mset.store.GetSeqFromTime(*req.AsOfTime)
+	if req.StartTime != nil {
+		seq = mset.store.GetSeqFromTime(*req.StartTime)
 	} else {
 		seq = req.Seq
 	}

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -22304,33 +22304,33 @@ func TestJetStreamMsgGetAsOfTime(t *testing.T) {
 	t0 := time.Now()
 
 	// Check for conflicting options.
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t0, LastFor: "foo.1"}, 0, NewJSBadRequestError())
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t0, Seq: 1}, 0, NewJSBadRequestError())
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t0, LastFor: "foo.1"}, 0, NewJSBadRequestError())
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t0, Seq: 1}, 0, NewJSBadRequestError())
 
 	// Nothing exists yet in the stream.
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t0}, 0, NewJSNoMessageFoundError())
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t0}, 0, NewJSNoMessageFoundError())
 
 	_, err = js.Publish("foo.1", nil)
 	require_NoError(t, err)
 
 	// Try again with t0 and now it will find the first message.
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t0}, 1, nil)
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t0}, 1, nil)
 
 	t1 := time.Now()
 	_, err = js.Publish("foo.2", nil)
 	require_NoError(t, err)
 
 	// At t0, first message will still be returned first.
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t0}, 1, nil)
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t0}, 1, nil)
 	// Unless we combine with NextFor...
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t0, NextFor: "foo.2"}, 2, nil)
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t0, NextFor: "foo.2"}, 2, nil)
 
 	// At t1 (after first message), the second message will be returned.
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t1}, 2, nil)
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t1}, 2, nil)
 
 	t2 := time.Now()
 	// t2 is later than the last message so nothing will be found.
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t2}, 0, NewJSNoMessageFoundError())
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t2}, 0, NewJSNoMessageFoundError())
 }
 
 func TestJetStreamMsgDirectGetAsOfTime(t *testing.T) {
@@ -22364,33 +22364,33 @@ func TestJetStreamMsgDirectGetAsOfTime(t *testing.T) {
 	t0 := time.Now()
 
 	// Check for conflicting options.
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t0, LastFor: "foo.1"}, 0, "Bad Request")
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t0, Seq: 1}, 0, "Bad Request")
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t0, LastFor: "foo.1"}, 0, "Bad Request")
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t0, Seq: 1}, 0, "Bad Request")
 
 	// Nothing exists yet in the stream.
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t0}, 0, "Message Not Found")
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t0}, 0, "Message Not Found")
 
 	_, err = js.Publish("foo.1", nil)
 	require_NoError(t, err)
 
 	// Try again with t0 and now it will find the first message.
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t0}, 1, "")
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t0}, 1, "")
 
 	t1 := time.Now()
 	_, err = js.Publish("foo.2", nil)
 	require_NoError(t, err)
 
 	// At t0, first message will still be returned first.
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t0}, 1, "")
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t0}, 1, "")
 	// Unless we combine with NextFor..
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t0, NextFor: "foo.2"}, 2, "")
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t0, NextFor: "foo.2"}, 2, "")
 
 	// At t1 (after first message), the second message will be returned.
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t1}, 2, "")
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t1}, 2, "")
 
 	t2 := time.Now()
 	// t2 is later than the last message so nothing will be found.
-	sendRequestAndCheck(&JSApiMsgGetRequest{AsOfTime: &t2}, 0, "Message Not Found")
+	sendRequestAndCheck(&JSApiMsgGetRequest{StartTime: &t2}, 0, "Message Not Found")
 }
 
 func TestJetStreamConsumerNakThenAckFloorMove(t *testing.T) {

--- a/server/stream.go
+++ b/server/stream.go
@@ -4028,7 +4028,7 @@ func (mset *stream) processDirectGetRequest(_ *subscription, c *client, _ *Accou
 		return
 	}
 	// Check if nothing set.
-	if req.Seq == 0 && req.LastFor == _EMPTY_ && req.NextFor == _EMPTY_ && len(req.MultiLastFor) == 0 && req.AsOfTime == nil {
+	if req.Seq == 0 && req.LastFor == _EMPTY_ && req.NextFor == _EMPTY_ && len(req.MultiLastFor) == 0 && req.StartTime == nil {
 		hdr := []byte("NATS/1.0 408 Empty Request\r\n\r\n")
 		mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
 		return
@@ -4036,8 +4036,8 @@ func (mset *stream) processDirectGetRequest(_ *subscription, c *client, _ *Accou
 	// Check we don't have conflicting options set.
 	// We do not allow batch mode for lastFor requests.
 	if (req.Seq > 0 && req.LastFor != _EMPTY_) ||
-		(req.Seq > 0 && req.AsOfTime != nil) ||
-		(req.AsOfTime != nil && req.LastFor != _EMPTY_) ||
+		(req.Seq > 0 && req.StartTime != nil) ||
+		(req.StartTime != nil && req.LastFor != _EMPTY_) ||
 		(req.LastFor != _EMPTY_ && req.NextFor != _EMPTY_) ||
 		(req.LastFor != _EMPTY_ && req.Batch > 0) ||
 		(req.LastFor != _EMPTY_ && len(req.MultiLastFor) > 0) ||
@@ -4228,8 +4228,8 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 
 	var seq uint64
 	// Lookup start seq if AsOfTime is set.
-	if req.AsOfTime != nil {
-		seq = store.GetSeqFromTime(*req.AsOfTime)
+	if req.StartTime != nil {
+		seq = store.GetSeqFromTime(*req.StartTime)
 	} else {
 		seq = req.Seq
 	}


### PR DESCRIPTION
The motivation for this feature is to enable stream message gets as of some starting time. This is to match the same behavior with setting a start time when creating a consumer.

What this enables, combined with batches, is to read messages from a stream without the need to use a consumer. This is not intended for high-throughput use, but for querying and stream inspection.

The main driving need for this is the ability to inspect workqueue streams that cannot otherwise be done do due to the overlapping subject constraint.