### PR TITLE
Fix consumer deleted message in non-clustered mode

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2339,12 +2339,12 @@ func (o *consumer) checkPendingRequests() {
 // This will release any pending pull requests if applicable.
 // Should be called only by the leader being deleted or stopped.
 // Lock should be held.
-func (o *consumer) releaseAnyPendingRequests(isConsumerAssigned bool) {
+func (o *consumer) releaseAnyPendingRequests(isAssigned bool) {
 	if o.mset == nil || o.outq == nil || o.waiting.len() == 0 {
 		return
 	}
 	var hdr []byte
-	if !isConsumerAssigned {
+	if !isAssigned {
 		hdr = []byte("NATS/1.0 409 Consumer Deleted\r\n\r\n")
 	}
 	wq := o.waiting
@@ -5148,21 +5148,24 @@ func (o *consumer) isClosed() bool {
 
 func (o *consumer) stopWithFlags(dflag, sdflag, doSignal, advisory bool) error {
 	// If dflag is true determine if we are still assigned.
-	var isConsumerAssigned bool
+	var isAssigned bool
 	if dflag {
 		o.mu.RLock()
 		acc, stream, consumer := o.acc, o.stream, o.name
+		isClustered := o.js != nil && o.js.isClustered()
 		o.mu.RUnlock()
-		// Grab jsa to check assignment.
-		var jsa *jsAccount
-		if acc != nil {
-			// Need lock here to avoid data race.
-			acc.mu.RLock()
-			jsa = acc.js
-			acc.mu.RUnlock()
-		}
-		if jsa != nil {
-			isConsumerAssigned = jsa.consumerAssigned(stream, consumer)
+		if isClustered {
+			// Grab jsa to check assignment.
+			var jsa *jsAccount
+			if acc != nil {
+				// Need lock here to avoid data race.
+				acc.mu.RLock()
+				jsa = acc.js
+				acc.mu.RUnlock()
+			}
+			if jsa != nil {
+				isAssigned = jsa.consumerAssigned(stream, consumer)
+			}
 		}
 	}
 
@@ -5182,13 +5185,14 @@ func (o *consumer) stopWithFlags(dflag, sdflag, doSignal, advisory bool) error {
 
 		// dflag does not necessarily mean that the consumer is being deleted,
 		// just that the consumer node is being removed from this peer, so we
-		// send delete advisories only if we are no longer assigned at the meta layer.
-		if !isConsumerAssigned && advisory {
+		// send delete advisories only if we are no longer assigned at the meta layer,
+		// or we are not clustered.
+		if !isAssigned && advisory {
 			o.sendDeleteAdvisoryLocked()
 		}
 		if o.isPullMode() {
 			// Release any pending.
-			o.releaseAnyPendingRequests(isConsumerAssigned)
+			o.releaseAnyPendingRequests(isAssigned)
 		}
 	}
 


### PR DESCRIPTION
In PR #5111 we decided to send or not the `Consumer Deleted`  message based on the fact if consumer is or is not assigned. However, in non-clustered mode, consumer will not have assignment, which would result in not sending the `Consumer Deleted` message.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>
