### PR TITLE
Fix consumer resume on empty/zero PauseUntil

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -4608,6 +4608,8 @@ func (s *Server) jsConsumerPauseRequest(sub *subscription, c *client, _ *Account
 	pauseUTC := req.PauseUntil.UTC()
 	if !pauseUTC.IsZero() {
 		ncfg.PauseUntil = &pauseUTC
+	} else {
+		ncfg.PauseUntil = nil
 	}
 
 	if err := obs.updateConfig(&ncfg); err != nil {


### PR DESCRIPTION
Fixes https://github.com/nats-io/nats-server/issues/5163, by setting the `PauseUntil` to `nil` if it was a zero-value.

This fixes the CLI `nats consumer resume` command, which is sending an empty/nil body to `$JS.API.CONSUMER.PAUSE.*.*`.

Allowing for both sending an empty/nil body as well as omitting `pause_until` (for example with just `{}`)

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
