### PR TITLE
Fix select random qsub on 32-bit

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4736,7 +4736,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 		sindex := 0
 		lqs := len(qsubs)
 		if lqs > 1 {
-			sindex = int(fastrand.Uint32()) % lqs
+			sindex = int(fastrand.Uint32() % uint32(lqs))
 		}
 
 		// Find a subscription that is able to deliver this message starting at a random index.


### PR DESCRIPTION
Take modulus before casting fastrand result to int as it can end up negative.

Related: https://github.com/nats-io/nats-server/issues/5167
