### PR TITLE
Add logical name to accstatz endpoint

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -52,6 +52,7 @@ type Account struct {
 	stats
 	gwReplyMapping
 	Name         string
+	LogicalName  string
 	Nkey         string
 	Issuer       string
 	claimJWT     string
@@ -251,9 +252,10 @@ type importMap struct {
 // NewAccount creates a new unlimited account with the given name.
 func NewAccount(name string) *Account {
 	a := &Account{
-		Name:     name,
-		limits:   limits{-1, -1, -1, -1, false},
-		eventIds: nuid.New(),
+		Name:        name,
+		LogicalName: name,
+		limits:      limits{-1, -1, -1, -1, false},
+		eventIds:    nuid.New(),
 	}
 	return a
 }
@@ -3752,6 +3754,8 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 func (s *Server) buildInternalAccount(ac *jwt.AccountClaims) *Account {
 	acc := NewAccount(ac.Subject)
 	acc.Issuer = ac.Issuer
+	// Override subject with logical name.
+	acc.LogicalName = ac.Name
 	// Set this here since we are placing in s.tmpAccounts below and may be
 	// referenced by an route RS+, etc.
 	s.setAccountSublist(acc)

--- a/server/events.go
+++ b/server/events.go
@@ -206,7 +206,7 @@ type AccountNumConns struct {
 // AccountStat contains the data common between AccountNumConns and AccountStatz
 type AccountStat struct {
 	Account       string    `json:"acc"`
-	AccountName   string    `json:"acc_name"`
+	Name          string    `json:"name"`
 	Conns         int       `json:"conns"`
 	LeafNodes     int       `json:"leafnodes"`
 	TotalConns    int       `json:"total_conns"`
@@ -2105,12 +2105,12 @@ func (a *Account) statz() *AccountStat {
 	localConns := a.numLocalConnections()
 	leafConns := a.numLocalLeafNodes()
 	return &AccountStat{
-		Account:     a.Name,
-		AccountName: a.LogicalName,
-		Conns:       localConns,
-		LeafNodes:   leafConns,
-		TotalConns:  localConns + leafConns,
-		NumSubs:     a.sl.Count(),
+		Account:    a.Name,
+		Name:       a.LogicalName,
+		Conns:      localConns,
+		LeafNodes:  leafConns,
+		TotalConns: localConns + leafConns,
+		NumSubs:    a.sl.Count(),
 		Received: DataStats{
 			Msgs:  atomic.LoadInt64(&a.inMsgs),
 			Bytes: atomic.LoadInt64(&a.inBytes),

--- a/server/events.go
+++ b/server/events.go
@@ -206,6 +206,7 @@ type AccountNumConns struct {
 // AccountStat contains the data common between AccountNumConns and AccountStatz
 type AccountStat struct {
 	Account       string    `json:"acc"`
+	AccountName   string    `json:"acc_name"`
 	Conns         int       `json:"conns"`
 	LeafNodes     int       `json:"leafnodes"`
 	TotalConns    int       `json:"total_conns"`
@@ -2104,11 +2105,12 @@ func (a *Account) statz() *AccountStat {
 	localConns := a.numLocalConnections()
 	leafConns := a.numLocalLeafNodes()
 	return &AccountStat{
-		Account:    a.Name,
-		Conns:      localConns,
-		LeafNodes:  leafConns,
-		TotalConns: localConns + leafConns,
-		NumSubs:    a.sl.Count(),
+		Account:     a.Name,
+		AccountName: a.LogicalName,
+		Conns:       localConns,
+		LeafNodes:   leafConns,
+		TotalConns:  localConns + leafConns,
+		NumSubs:     a.sl.Count(),
 		Received: DataStats{
 			Msgs:  atomic.LoadInt64(&a.inMsgs),
 			Bytes: atomic.LoadInt64(&a.inBytes),

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -4050,9 +4050,78 @@ func TestMonitorAccountz(t *testing.T) {
 
 	body = string(readBody(t, fmt.Sprintf("http://127.0.0.1:%d%s?unused=1", s.MonitorAddr().Port, AccountStatzPath)))
 	require_Contains(t, body, `"acc": "$G"`)
-	require_Contains(t, body, `"acc_name": "$G"`)
+	require_Contains(t, body, `"name": "$G"`)
 	require_Contains(t, body, `"acc": "$SYS"`)
-	require_Contains(t, body, `"acc_name": "$SYS"`)
+	require_Contains(t, body, `"name": "$SYS"`)
+	require_Contains(t, body, `"sent": {`)
+	require_Contains(t, body, `"received": {`)
+	require_Contains(t, body, `"total_conns": 0,`)
+	require_Contains(t, body, `"leafnodes": 0,`)
+}
+
+func TestMonitorAccountzOperatorMode(t *testing.T) {
+	_, sysPub := createKey(t)
+	sysClaim := jwt.NewAccountClaims(sysPub)
+	sysClaim.Name = "SYS"
+	sysJwt := encodeClaim(t, sysClaim, sysPub)
+
+	accKp, accPub := createKey(t)
+	accClaim := jwt.NewAccountClaims(accPub)
+	accClaim.Name = "APP"
+	accJwt := encodeClaim(t, accClaim, accPub)
+
+	conf := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: 127.0.0.1:-1
+		http: 127.0.0.1:-1
+		operator = %s
+		resolver = MEMORY
+		system_account: %s
+		resolver_preload = {
+			%s : %s
+			%s : %s
+		}
+	`, ojwt, sysPub, accPub, accJwt, sysPub, sysJwt)))
+
+	s, _ := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	createUser := func() (string, string) {
+		ukp, _ := nkeys.CreateUser()
+		seed, _ := ukp.Seed()
+		upub, _ := ukp.PublicKey()
+		uclaim := newJWTTestUserClaims()
+		uclaim.Subject = upub
+		ujwt, err := uclaim.Encode(accKp)
+		require_NoError(t, err)
+		return upub, genCredsFile(t, ujwt, seed)
+	}
+
+	_, aCreds := createUser()
+
+	nc, err := nats.Connect(s.ClientURL(), nats.UserCredentials(aCreds))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	body := string(readBody(t, fmt.Sprintf("http://127.0.0.1:%d%s", s.MonitorAddr().Port, AccountzPath)))
+	require_Contains(t, body, accPub)
+	require_Contains(t, body, sysPub)
+	require_Contains(t, body, `"accounts": [`)
+	require_Contains(t, body, fmt.Sprintf(`"system_account": "%s"`, sysPub))
+
+	body = string(readBody(t, fmt.Sprintf("http://127.0.0.1:%d%s?acc=%s", s.MonitorAddr().Port, AccountzPath, sysPub)))
+	require_Contains(t, body, `"account_detail": {`)
+	require_Contains(t, body, fmt.Sprintf(`"account_name": "%s",`, sysPub))
+	require_Contains(t, body, `"subscriptions": 50,`)
+	require_Contains(t, body, `"is_system": true,`)
+	require_Contains(t, body, fmt.Sprintf(`"system_account": "%s"`, sysPub))
+
+	// TODO: understand why the APP account did not show up in the accountz detail
+	// even though unused is set. It required a connection to be made to show up.
+	body = string(readBody(t, fmt.Sprintf("http://127.0.0.1:%d%s?unused=1", s.MonitorAddr().Port, AccountStatzPath)))
+	require_Contains(t, body, fmt.Sprintf(`"acc": "%s"`, accPub))
+	require_Contains(t, body, fmt.Sprintf(`"name": "%s"`, accClaim.Name))
+	require_Contains(t, body, fmt.Sprintf(`"acc": "%s"`, sysPub))
+	require_Contains(t, body, fmt.Sprintf(`"name": "%s"`, sysClaim.Name))
 	require_Contains(t, body, `"sent": {`)
 	require_Contains(t, body, `"received": {`)
 	require_Contains(t, body, `"total_conns": 0,`)

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -4050,7 +4050,9 @@ func TestMonitorAccountz(t *testing.T) {
 
 	body = string(readBody(t, fmt.Sprintf("http://127.0.0.1:%d%s?unused=1", s.MonitorAddr().Port, AccountStatzPath)))
 	require_Contains(t, body, `"acc": "$G"`)
+	require_Contains(t, body, `"acc_name": "$G"`)
 	require_Contains(t, body, `"acc": "$SYS"`)
+	require_Contains(t, body, `"acc_name": "$SYS"`)
 	require_Contains(t, body, `"sent": {`)
 	require_Contains(t, body, `"received": {`)
 	require_Contains(t, body, `"total_conns": 0,`)


### PR DESCRIPTION
In operator mode, the `acc` is the public nkey which can be difficult to correlate in monitoring dashboards. The `acc_name` as been added which includes the logical name associated with that account claims.