### PR TITLE
NRG: Fix writeErr lock usage in writePeerState

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3678,7 +3678,7 @@ func (n *raft) writePeerState(ps *peerState) {
 	// Stamp latest and write the peer state file.
 	n.wps = pse
 	if err := writePeerState(n.sd, ps); err != nil && !n.isClosed() {
-		n.setWriteErr(err)
+		n.setWriteErrLocked(err)
 		n.warn("Error writing peer state file for %q: %v", n.group, err)
 	}
 }
@@ -3807,7 +3807,7 @@ func (n *raft) writeTermVote() {
 	// Stamp latest and write the term & vote file.
 	n.wtv = b
 	if err := writeTermVote(n.sd, n.wtv); err != nil && !n.isClosed() {
-		n.setWriteErr(err)
+		n.setWriteErrLocked(err)
 		n.warn("Error writing term and vote file for %q: %v", n.group, err)
 	}
 }


### PR DESCRIPTION
Fixes:

```
goroutine 38 [sync.Mutex.Lock, 349 minutes]:
sync.runtime_SemacquireMutex(0x1400070c9c0?, 0xd0?, 0x140004630e0?)
	/opt/homebrew/Cellar/go/1.21.2/libexec/src/runtime/sema.go:77 +0x28
sync.(*Mutex).lockSlow(0x14000574300)
	/opt/homebrew/Cellar/go/1.21.2/libexec/src/sync/mutex.go:171 +0x174
sync.(*Mutex).Lock(...)
	/opt/homebrew/Cellar/go/1.21.2/libexec/src/sync/mutex.go:90
sync.(*RWMutex).Lock(0x14000574300)
	/opt/homebrew/Cellar/go/1.21.2/libexec/src/sync/rwmutex.go:147 +0x70
github.com/nats-io/nats-server/v2/server.(*raft).setWriteErr(0x14000574300, {0x101659208, 0x1400071bb00})
	/src/server/raft.go:3789 +0x34
github.com/nats-io/nats-server/v2/server.(*raft).writePeerState(0x14000574300, 0x140009043b0)
	/src/server/raft.go:3681 +0x20c
github.com/nats-io/nats-server/v2/server.(*raft).processPeerState(0x14000574300, 0x140009043b0)
	/src/server/raft.go:3429 +0x208
github.com/nats-io/nats-server/v2/server.(*raft).UpdateKnownPeers(0x14000574300, {0x14000296140, 0x3, 0x4})
	/src/server/raft.go:1585 +0x74
github.com/nats-io/nats-server/v2/server.(*stream).setStreamAssignment(0x14000592800, 0x140004b6090)
	/src/server/stream.go:779 +0x2bc
github.com/nats-io/nats-server/v2/server.(*Account).addStreamWithAssignment(0x140001ad900, 0x140002b0120, 0x0, 0x140004b6090)
	/src/server/stream.go:657 +0x147c
github.com/nats-io/nats-server/v2/server.(*jetStream).processClusterCreateStream(0x1400018c500, 0x140001ad900, 0x140004b6090)
	/src/server/jetstream_cluster.go:3717 +0x420
github.com/nats-io/nats-server/v2/server.(*jetStream).processStreamAssignment(0x1400018c500, 0x140004b6090)
	/src/server/jetstream_cluster.go:3355 +0x3a4
github.com/nats-io/nats-server/v2/server.(*jetStream).applyMetaEntries(0x1400018c500, {0x14000430020, 0x1, 0x0?}, 0x0)
	/src/server/jetstream_cluster.go:1898 +0x4dc
github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster(0x1400018c500)
	/src/server/jetstream_cluster.go:1363 +0x900
github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
	/src/server/server.go:3778 +0x3c
created by github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine in goroutine 1
	/src/server/server.go:3776 +0x154
```