### PR TITLE
Fix correcting `clseq` drift on high `clfs`

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3154,6 +3154,14 @@ func (js *jetStream) processStreamLeaderChange(mset *stream, isLeader bool) {
 		if node := mset.raftNode(); node != nil && !node.Quorum() && time.Since(node.Created()) > 5*time.Second {
 			s.sendStreamLostQuorumAdvisory(mset)
 		}
+
+		// Clear clseq. If we become leader again, it will be fixed up
+		// automatically on the next processClusteredInboundMsg call.
+		mset.mu.Lock()
+		if mset.clseq > 0 {
+			mset.clseq = 0
+		}
+		mset.mu.Unlock()
 	}
 
 	// Tell stream to switch leader status.
@@ -7690,7 +7698,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	// We only use mset.clseq for clustering and in case we run ahead of actual commits.
 	// Check if we need to set initial value here
 	mset.clMu.Lock()
-	if mset.clseq == 0 || mset.clseq < lseq {
+	if mset.clseq == 0 || mset.clseq < lseq+clfs {
 		// Re-capture
 		lseq, clfs = mset.lseq, mset.clfs
 		mset.clseq = lseq + clfs


### PR DESCRIPTION
In a scenario where the `clfs` is high (i.e. with competing KV writes or a high number of duplicate messages) then the gap on the `clseq` fix-up condition was growing, probably to the point that it wasn't running when it should. This would cause a drift.

Signed-off-by: Neil Twigg <neil@nats.io>
