### PR TITLE
Get last sequence with read lock in processClusteredInboundMsg

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7700,7 +7700,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	mset.clMu.Lock()
 	if mset.clseq == 0 || mset.clseq < lseq+clfs {
 		// Re-capture
-		lseq, clfs = mset.lseq, mset.clfs
+		lseq, clfs = mset.lastSeq(), mset.clfs
 		mset.clseq = lseq + clfs
 	}
 


### PR DESCRIPTION
Avoid potential data race when re-capturing last seq:

```
==================
WARNING: DATA RACE
Write at 0x00c00881bc98 by goroutine 9941:
  github.com/nats-io/nats-server/v2/server.(*stream).processJetStreamMsg()
      /nats-dev/src/github.com/nats-io/nats-server-gp/server/stream.go:4716 +0x2850
  github.com/nats-io/nats-server/v2/server.(*jetStream).applyStreamEntries()
      /nats-dev/src/github.com/nats-io/nats-server-gp/server/jetstream_cluster.go:2883 +0xb94
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorStream()
      /nats-dev/src/github.com/nats-io/nats-server-gp/server/jetstream_cluster.go:2372 +0x2f00
  github.com/nats-io/nats-server/v2/server.(*jetStream).processClusterCreateStream.func1()
      /nats-dev/src/github.com/nats-io/nats-server-gp/server/jetstream_cluster.go:3781 +0x54
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
      /nats-dev/src/github.com/nats-io/nats-server-gp/server/server.go:3778 +0x58
Previous read at 0x00c00881bc98 by goroutine 9939:
  github.com/nats-io/nats-server/v2/server.(*stream).processClusteredInboundMsg()
      /nats-dev/src/github.com/nats-io/nats-server-gp/server/jetstream_cluster.go:7703 +0xf78
  github.com/nats-io/nats-server/v2/server.(*stream).internalLoop()
      /nats-dev/src/github.com/nats-io/nats-server-gp/server/stream.go:5157 +0x1270
  github.com/nats-io/nats-server/v2/server.(*stream).setupSendCapabilities.func2()
      /nats-dev/src/github.com/nats-io/nats-server-gp/server/stream.go:5038 +0x34

```
