### PR TITLE
Data race and lock inversion on consumer delete (v2.10.12)

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -5069,8 +5069,6 @@ func (o *consumer) stopWithFlags(dflag, sdflag, doSignal, advisory bool) error {
 	}
 
 	o.mu.Lock()
-	js := o.js
-
 	if o.closed {
 		o.mu.Unlock()
 		return nil
@@ -5143,6 +5141,7 @@ func (o *consumer) stopWithFlags(dflag, sdflag, doSignal, advisory bool) error {
 		ca = o.ca
 	}
 	sigSubs := o.sigSubs
+	js := o.js
 	o.mu.Unlock()
 
 	if c != nil {


### PR DESCRIPTION
Includes: 
- https://github.com/nats-io/nats-server/pull/5146
