### PR TITLE
Fix sending empty reply on gateway `RMSG`

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -2575,7 +2575,7 @@ func (c *client) sendMsgToGateways(acc *Account, msg, subject, reply []byte, qgr
 		mh = append(mh, subject...)
 		mh = append(mh, ' ')
 		if len(queues) > 0 {
-			if reply != nil {
+			if len(reply) > 0 {
 				mh = append(mh, "+ "...) // Signal that there is a reply.
 				mh = append(mh, mreply...)
 				mh = append(mh, ' ')

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -6909,27 +6909,25 @@ func TestGatewaySlowConsumer(t *testing.T) {
 
 // https://github.com/nats-io/nats-server/issues/5187
 func TestGatewayConnectEvents(t *testing.T) {
-	ca := createClusterEx(t, true, 5*time.Millisecond, true, "A", 2)
-	defer shutdownCluster(ca)
-
-	cb := createClusterEx(t, true, 5*time.Millisecond, true, "B", 2, ca)
-	defer shutdownCluster(cb)
-
 	checkEvents := func(t *testing.T, name string, queue bool) {
-		t.Helper()
-
 		t.Run(name, func(t *testing.T) {
+			ca := createClusterEx(t, true, 5*time.Millisecond, true, "A", 2)
+			defer shutdownCluster(ca)
+
+			cb := createClusterEx(t, true, 5*time.Millisecond, true, "B", 2, ca)
+			defer shutdownCluster(cb)
+
 			sysA, err := nats.Connect(ca.randomServer().ClientURL(), nats.UserInfo("sys", "pass"))
 			require_NoError(t, err)
 			defer sysA.Close()
 
 			var sub1 *nats.Subscription
 			if queue {
-				sub1, err = sysA.QueueSubscribeSync("$SYS.ACCOUNT.*.CONNECT", "myqueue")
+				sub1, err = sysA.QueueSubscribeSync("$SYS.ACCOUNT.FOO.CONNECT", "myqueue")
 			} else {
-				sub1, err = sysA.SubscribeSync("$SYS.ACCOUNT.*.CONNECT")
+				sub1, err = sysA.SubscribeSync("$SYS.ACCOUNT.FOO.CONNECT")
 			}
-			checkError(err, nil, t)
+			require_NoError(t, err)
 
 			cA, err := nats.Connect(ca.randomServer().ClientURL(), nats.UserInfo("foo", "pass"))
 			require_NoError(t, err)


### PR DESCRIPTION
This should fix #5187. The `nil` check was insufficient because the reply could still be non-nil but empty.

This meant that we sent `RMSG $SYS $SYS.ACCOUNT.FOO.CONNECT +  myqueue 502` instead of `RMSG $SYS $SYS.ACCOUNT.FOO.CONNECT | myqueue 502`.

Signed-off-by: Neil Twigg <neil@nats.io>
