### PR TITLE
[FIXED] Stream interest leaving messages

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2357,6 +2357,9 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 				// No special processing needed for when we are caught up on restart.
 				if ce == nil {
 					isRecovering = false
+					// If we are interest based make sure to check consumers if interest retention policy.
+					// This is to make sure we process any outstanding acks.
+					mset.checkInterestState()
 					// Make sure we create a new snapshot in case things have changed such that any existing
 					// snapshot may no longer be valid.
 					doSnapshot()
@@ -2895,6 +2898,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 					if err == errLastSeqMismatch {
 						var state StreamState
 						mset.store.FastState(&state)
+
 						// If we have no msgs and the other side is delivering us a sequence past where we
 						// should be reset. This is possible if the other side has a stale snapshot and no longer
 						// has those messages. So compact and retry to reset.
@@ -4721,7 +4725,7 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 					if nb > 0 && ne >= compactNumMin || nb > compactSizeMin {
 						doSnapshot(false)
 					}
-				} else {
+				} else if err != errConsumerClosed {
 					s.Warnf("Error applying consumer entries to '%s > %s'", ca.Client.serviceAccount(), ca.Name)
 				}
 			}
@@ -4910,7 +4914,9 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 					}
 					panic(err.Error())
 				}
-				o.processReplicatedAck(dseq, sseq)
+				if err := o.processReplicatedAck(dseq, sseq); err == errConsumerClosed {
+					return err
+				}
 			case updateSkipOp:
 				o.mu.Lock()
 				if !o.isLeader() {
@@ -4945,13 +4951,14 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 	return nil
 }
 
-func (o *consumer) processReplicatedAck(dseq, sseq uint64) {
-	o.mu.Lock()
+var errConsumerClosed = errors.New("consumer closed")
 
+func (o *consumer) processReplicatedAck(dseq, sseq uint64) error {
+	o.mu.Lock()
 	mset := o.mset
 	if o.closed || mset == nil {
 		o.mu.Unlock()
-		return
+		return errConsumerClosed
 	}
 
 	// Update activity.
@@ -4962,7 +4969,7 @@ func (o *consumer) processReplicatedAck(dseq, sseq uint64) {
 
 	if o.retention == LimitsPolicy {
 		o.mu.Unlock()
-		return
+		return nil
 	}
 
 	var sagap uint64
@@ -4974,7 +4981,7 @@ func (o *consumer) processReplicatedAck(dseq, sseq uint64) {
 			state, err := o.store.State()
 			if err != nil {
 				o.mu.Unlock()
-				return
+				return err
 			}
 			sagap = sseq - state.AckFloor.Stream
 		}
@@ -4989,6 +4996,7 @@ func (o *consumer) processReplicatedAck(dseq, sseq uint64) {
 	} else {
 		mset.ackMsg(o, sseq)
 	}
+	return nil
 }
 
 var errBadAckUpdate = errors.New("jetstream cluster bad replicated ack update")
@@ -8030,24 +8038,6 @@ func (mset *stream) processSnapshot(snap *StreamReplicatedState) (e error) {
 	// On exit, we will release our semaphore if we acquired it.
 	defer releaseSyncOutSem()
 
-	// Check our final state when we exit cleanly.
-	// This will make sure we have interest consumers updated.
-	checkFinalState := func() {
-		// Bail if no stream.
-		if mset == nil {
-			return
-		}
-		mset.mu.RLock()
-		consumers := make([]*consumer, 0, len(mset.consumers))
-		for _, o := range mset.consumers {
-			consumers = append(consumers, o)
-		}
-		mset.mu.RUnlock()
-		for _, o := range consumers {
-			o.checkStateForInterestStream()
-		}
-	}
-
 	// Do not let this go on forever.
 	const maxRetries = 3
 	var numRetries int
@@ -8152,7 +8142,7 @@ RETRY:
 				// Check for eof signaling.
 				if len(msg) == 0 {
 					msgsQ.recycle(&mrecs)
-					checkFinalState()
+					mset.checkInterestState()
 					return nil
 				}
 				if _, err := mset.processCatchupMsg(msg); err == nil {

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -5958,8 +5958,6 @@ func TestJetStreamClusterStreamResetPreacks(t *testing.T) {
 	for _, msg := range msgs {
 		msg.AckSync()
 	}
-	// Let sync propagate.
-	time.Sleep(250 * time.Millisecond)
 
 	// Now grab a non-leader server.
 	// We will shut it down and remove the stream data.

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -5501,7 +5501,7 @@ func TestNoRaceJetStreamFileStoreLargeKVAccessTiming(t *testing.T) {
 	require_NoError(t, err)
 	slow := time.Since(start)
 
-	if slow > 4*base || slow > time.Millisecond {
+	if base > 100*time.Microsecond || slow > 200*time.Microsecond {
 		t.Fatalf("Took too long to look up first key vs last: %v vs %v", base, slow)
 	}
 
@@ -5516,7 +5516,7 @@ func TestNoRaceJetStreamFileStoreLargeKVAccessTiming(t *testing.T) {
 	slow = time.Since(start)
 	fs.mu.RUnlock()
 
-	if slow > 4*base || slow > time.Millisecond {
+	if base > 100*time.Microsecond || slow > 200*time.Microsecond {
 		t.Fatalf("Took too long to look up last key by subject vs first: %v vs %v", base, slow)
 	}
 }

--- a/server/stream.go
+++ b/server/stream.go
@@ -5421,6 +5421,28 @@ func (mset *stream) getPublicConsumers() []*consumer {
 	return obs
 }
 
+// Will check for interest retention and make sure messages
+// that have been acked are processed.
+func (mset *stream) checkInterestState() {
+	if mset == nil {
+		return
+	}
+	mset.mu.RLock()
+	// If we are limits based nothing to do.
+	if mset.cfg.Retention == LimitsPolicy {
+		mset.mu.RUnlock()
+		return
+	}
+	consumers := make([]*consumer, 0, len(mset.consumers))
+	for _, o := range mset.consumers {
+		consumers = append(consumers, o)
+	}
+	mset.mu.RUnlock()
+	for _, o := range consumers {
+		o.checkStateForInterestStream()
+	}
+}
+
 func (mset *stream) isInterestRetention() bool {
 	mset.mu.RLock()
 	defer mset.mu.RUnlock()


### PR DESCRIPTION
Several fixes to consumers and interest based streams.

1. Make sure to not commit a replicated ack if we bail due to a closed consumer.
2. Check the stream state once recovery is complete. This checks NRG, we already were checking on upper state catchups.

Signed-off-by: Derek Collison <derek@nats.io>