### PR TITLE
Add `NATS_LOGGING` test helper

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -35,6 +35,7 @@ import (
 	"testing"
 	"time"
 
+	srvlog "github.com/nats-io/nats-server/v2/logger"
 	"github.com/nats-io/nats.go"
 )
 
@@ -84,6 +85,13 @@ func RunServer(opts *Options) *Server {
 
 	if !opts.NoLog {
 		s.ConfigureLogger()
+	}
+
+	if ll := os.Getenv("NATS_LOGGING"); ll != "" {
+		log := srvlog.NewTestLogger(fmt.Sprintf("[%s] | ", s), true)
+		debug := ll == "debug" || ll == "trace"
+		trace := ll == "trace"
+		s.SetLoggerV2(log, debug, trace, false)
 	}
 
 	// Run server in Go routine.

--- a/test/test.go
+++ b/test/test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	srvlog "github.com/nats-io/nats-server/v2/logger"
 	"github.com/nats-io/nats-server/v2/server"
 )
 
@@ -92,6 +93,13 @@ func RunServerCallback(opts *server.Options, callback func(*server.Server)) *ser
 
 	if doLog {
 		s.ConfigureLogger()
+	}
+
+	if ll := os.Getenv("NATS_LOGGING"); ll != "" {
+		log := srvlog.NewTestLogger(fmt.Sprintf("[%s] | ", s), true)
+		debug := ll == "debug" || ll == "trace"
+		trace := ll == "trace"
+		s.SetLoggerV2(log, debug, trace, false)
 	}
 
 	if callback != nil {


### PR DESCRIPTION
Setting this environment variable forces NATS Server instances running in the unit tests to log to stdout. Possible values are:

* `NATS_LOGGING=true go test ...` (or any other non-empty value)
* `NATS_LOGGING=debug go test ...`
* `NATS_LOGGING=trace go test ...`

Signed-off-by: Neil Twigg <neil@nats.io>
