### PR TITLE
[IMPROVED] Lower minimum threshold for expire timers to 250ms.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4622,8 +4622,8 @@ func (fs *fileStore) resetAgeChk(delta int64) {
 
 	fireIn := fs.cfg.MaxAge
 	if delta > 0 && time.Duration(delta) < fireIn {
-		if fireIn = time.Duration(delta); fireIn < time.Second {
-			// Only fire at most once a second.
+		if fireIn = time.Duration(delta); fireIn < 250*time.Millisecond {
+			// Only fire at most once every 250ms.
 			// Excessive firing can effect ingest performance.
 			fireIn = time.Second
 		}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -692,8 +692,8 @@ func (ms *memStore) resetAgeChk(delta int64) {
 
 	fireIn := ms.cfg.MaxAge
 	if delta > 0 && time.Duration(delta) < fireIn {
-		if fireIn = time.Duration(delta); fireIn < time.Second {
-			// Only fire at most once a second.
+		if fireIn = time.Duration(delta); fireIn < 250*time.Millisecond {
+			// Only fire at most once every 250ms.
 			// Excessive firing can effect ingest performance.
 			fireIn = time.Second
 		}


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>
