### PR TITLE
ocsp: Fixes for gateway reconnecting and reloading

### DIFF
--- a/internal/ocsp/ocsp.go
+++ b/internal/ocsp/ocsp.go
@@ -1,0 +1,274 @@
+// Copyright 2019-2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testhelper
+
+import (
+	"crypto"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ocsp"
+)
+
+const (
+	defaultResponseTTL = 4 * time.Second
+	defaultAddress     = "127.0.0.1:8888"
+)
+
+func NewOCSPResponderCustomAddress(t *testing.T, issuerCertPEM, issuerKeyPEM string, addr string) *http.Server {
+	t.Helper()
+	return NewOCSPResponderBase(t, issuerCertPEM, issuerCertPEM, issuerKeyPEM, false, addr, defaultResponseTTL, "")
+}
+
+func NewOCSPResponder(t *testing.T, issuerCertPEM, issuerKeyPEM string) *http.Server {
+	t.Helper()
+	return NewOCSPResponderBase(t, issuerCertPEM, issuerCertPEM, issuerKeyPEM, false, defaultAddress, defaultResponseTTL, "")
+}
+
+func NewOCSPResponderDesignatedCustomAddress(t *testing.T, issuerCertPEM, respCertPEM, respKeyPEM string, addr string) *http.Server {
+	t.Helper()
+	return NewOCSPResponderBase(t, issuerCertPEM, respCertPEM, respKeyPEM, true, addr, defaultResponseTTL, "")
+}
+
+func NewOCSPResponderPreferringHTTPMethod(t *testing.T, issuerCertPEM, issuerKeyPEM, method string) *http.Server {
+	t.Helper()
+	return NewOCSPResponderBase(t, issuerCertPEM, issuerCertPEM, issuerKeyPEM, false, defaultAddress, defaultResponseTTL, method)
+}
+
+func NewOCSPResponderCustomTimeout(t *testing.T, issuerCertPEM, issuerKeyPEM string, responseTTL time.Duration) *http.Server {
+	t.Helper()
+	return NewOCSPResponderBase(t, issuerCertPEM, issuerCertPEM, issuerKeyPEM, false, defaultAddress, responseTTL, "")
+}
+
+func NewOCSPResponderBase(t *testing.T, issuerCertPEM, respCertPEM, respKeyPEM string, embed bool, addr string, responseTTL time.Duration, method string) *http.Server {
+	t.Helper()
+	var mu sync.Mutex
+	status := make(map[string]int)
+
+	issuerCert := parseCertPEM(t, issuerCertPEM)
+	respCert := parseCertPEM(t, respCertPEM)
+	respKey := parseKeyPEM(t, respKeyPEM)
+
+	mux := http.NewServeMux()
+	// The "/statuses/" endpoint is for directly setting a key-value pair in
+	// the CA's status database.
+	mux.HandleFunc("/statuses/", func(rw http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		key := r.URL.Path[len("/statuses/"):]
+		switch r.Method {
+		case "GET":
+			mu.Lock()
+			n, ok := status[key]
+			if !ok {
+				n = ocsp.Unknown
+			}
+			mu.Unlock()
+
+			fmt.Fprintf(rw, "%s %d", key, n)
+		case "POST":
+			data, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(rw, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			n, err := strconv.Atoi(string(data))
+			if err != nil {
+				http.Error(rw, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			mu.Lock()
+			status[key] = n
+			mu.Unlock()
+
+			fmt.Fprintf(rw, "%s %d", key, n)
+		default:
+			http.Error(rw, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+	})
+	// The "/" endpoint is for normal OCSP requests. This actually parses an
+	// OCSP status request and signs a response with a CA. Lightly based off:
+	// https://www.ietf.org/rfc/rfc2560.txt
+	mux.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+		var reqData []byte
+		var err error
+
+		switch {
+		case r.Method == "GET":
+			if method != "" && r.Method != method {
+				http.Error(rw, "", http.StatusBadRequest)
+				return
+			}
+			reqData, err = base64.StdEncoding.DecodeString(r.URL.Path[1:])
+		case r.Method == "POST":
+			if method != "" && r.Method != method {
+				http.Error(rw, "", http.StatusBadRequest)
+				return
+			}
+			reqData, err = io.ReadAll(r.Body)
+		default:
+			http.Error(rw, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		ocspReq, err := ocsp.ParseRequest(reqData)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		n, ok := status[ocspReq.SerialNumber.String()]
+		if !ok {
+			n = ocsp.Unknown
+		}
+		mu.Unlock()
+
+		tmpl := ocsp.Response{
+			Status:       n,
+			SerialNumber: ocspReq.SerialNumber,
+			ThisUpdate:   time.Now(),
+		}
+		if responseTTL != 0 {
+			tmpl.NextUpdate = tmpl.ThisUpdate.Add(responseTTL)
+		}
+		if embed {
+			tmpl.Certificate = respCert
+		}
+		respData, err := ocsp.CreateResponse(issuerCert, respCert, tmpl, respKey)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		rw.Header().Set("Content-Type", "application/ocsp-response")
+		rw.Header().Set("Content-Length", fmt.Sprint(len(respData)))
+
+		fmt.Fprint(rw, string(respData))
+	})
+
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+	go srv.ListenAndServe()
+	time.Sleep(1 * time.Second)
+	return srv
+}
+
+func parseCertPEM(t *testing.T, certPEM string) *x509.Certificate {
+	t.Helper()
+	block := parsePEM(t, certPEM)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse cert '%s': %s", certPEM, err)
+	}
+	return cert
+}
+
+func parseKeyPEM(t *testing.T, keyPEM string) crypto.Signer {
+	t.Helper()
+	block := parsePEM(t, keyPEM)
+
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		key, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			t.Fatalf("failed to parse ikey %s: %s", keyPEM, err)
+		}
+	}
+	keyc := key.(crypto.Signer)
+	return keyc
+}
+
+func parsePEM(t *testing.T, pemPath string) *pem.Block {
+	t.Helper()
+	data, err := os.ReadFile(pemPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		t.Fatalf("failed to decode PEM %s", pemPath)
+	}
+	return block
+}
+
+func GetOCSPStatus(s tls.ConnectionState) (*ocsp.Response, error) {
+	if len(s.VerifiedChains) == 0 {
+		return nil, fmt.Errorf("missing TLS verified chains")
+	}
+	chain := s.VerifiedChains[0]
+
+	if got, want := len(chain), 2; got < want {
+		return nil, fmt.Errorf("incomplete cert chain, got %d, want at least %d", got, want)
+	}
+	leaf, issuer := chain[0], chain[1]
+
+	resp, err := ocsp.ParseResponseForCert(s.OCSPResponse, leaf, issuer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse OCSP response: %w", err)
+	}
+	if err := resp.CheckSignatureFrom(issuer); err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+func SetOCSPStatus(t *testing.T, ocspURL, certPEM string, status int) {
+	t.Helper()
+
+	cert := parseCertPEM(t, certPEM)
+
+	hc := &http.Client{Timeout: 10 * time.Second}
+	resp, err := hc.Post(
+		fmt.Sprintf("%s/statuses/%s", ocspURL, cert.SerialNumber),
+		"",
+		strings.NewReader(fmt.Sprint(status)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read OCSP HTTP response body: %s", err)
+	}
+
+	if got, want := resp.Status, "200 OK"; got != want {
+		t.Error(strings.TrimSpace(string(data)))
+		t.Fatalf("unexpected OCSP HTTP set status, got %q, want %q", got, want)
+	}
+}

--- a/internal/ocsp/ocsp.go
+++ b/internal/ocsp/ocsp.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The NATS Authors
+// Copyright 2019-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -131,6 +131,7 @@ func NewOCSPResponderBase(t *testing.T, issuerCertPEM, respCertPEM, respKeyPEM s
 				return
 			}
 			reqData, err = io.ReadAll(r.Body)
+			r.Body.Close()
 		default:
 			http.Error(rw, "Method Not Allowed", http.StatusMethodNotAllowed)
 			return

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -432,6 +432,22 @@ func (g *srvGateway) updateRemotesTLSConfig(opts *Options) {
 			} else if opts.Gateway.TLSConfig != nil {
 				cfg.TLSConfig = opts.Gateway.TLSConfig.Clone()
 			}
+
+			// Ensure that OCSP callbacks are always setup after a reload if needed.
+			mustStaple := opts.OCSPConfig != nil && opts.OCSPConfig.Mode == OCSPModeAlways
+			if mustStaple && opts.Gateway.TLSConfig != nil {
+				clientCB := opts.Gateway.TLSConfig.GetClientCertificate
+				verifyCB := opts.Gateway.TLSConfig.VerifyConnection
+				if mustStaple && cfg.TLSConfig != nil {
+					if clientCB != nil && cfg.TLSConfig.GetClientCertificate == nil {
+						cfg.TLSConfig.GetClientCertificate = clientCB
+					}
+					if verifyCB != nil && cfg.TLSConfig.VerifyConnection == nil {
+						cfg.TLSConfig.VerifyConnection = verifyCB
+					}
+				}
+			}
+
 			cfg.Unlock()
 		}
 	}
@@ -811,10 +827,35 @@ func (s *Server) createGateway(cfg *gatewayCfg, url *url.URL, conn net.Conn) {
 		var timeout float64
 
 		if solicit {
+			var (
+				mustStaple = opts.OCSPConfig != nil && opts.OCSPConfig.Mode == OCSPModeAlways
+				clientCB   func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
+				verifyCB   func(tls.ConnectionState) error
+			)
+			// Snapshot callbacks for OCSP outside an ongoing reload which might be happening.
+			if mustStaple {
+				s.reloadMu.RLock()
+				s.optsMu.RLock()
+				clientCB = s.opts.Gateway.TLSConfig.GetClientCertificate
+				verifyCB = s.opts.Gateway.TLSConfig.VerifyConnection
+				s.optsMu.RUnlock()
+				s.reloadMu.RUnlock()
+			}
+
 			cfg.RLock()
 			tlsName = cfg.tlsName
 			tlsConfig = cfg.TLSConfig.Clone()
 			timeout = cfg.TLSTimeout
+
+			// Ensure that OCSP callbacks are always setup on gateway reconnect when OCSP policy is set to always.
+			if mustStaple {
+				if clientCB != nil && tlsConfig.GetClientCertificate == nil {
+					tlsConfig.GetClientCertificate = clientCB
+				}
+				if verifyCB != nil && tlsConfig.VerifyConnection == nil {
+					tlsConfig.VerifyConnection = verifyCB
+				}
+			}
 			cfg.RUnlock()
 		} else {
 			tlsConfig = opts.Gateway.TLSConfig
@@ -880,6 +921,7 @@ func (s *Server) createGateway(cfg *gatewayCfg, url *url.URL, conn net.Conn) {
 // Builds and sends the CONNECT protocol for a gateway.
 // Client lock held on entry.
 func (c *client) sendGatewayConnect(opts *Options) {
+	// FIXME: This can race with updateRemotesTLSConfig
 	tlsRequired := c.gw.cfg.TLSConfig != nil
 	url := c.gw.connectURL
 	c.gw.connectURL = nil

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -30,8 +31,10 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/nats-io/nats-server/v2/internal/ocsp"
 	"github.com/nats-io/nats-server/v2/logger"
 	"github.com/nats-io/nats.go"
+	"golang.org/x/crypto/ocsp"
 )
 
 func init() {
@@ -6949,4 +6952,395 @@ func TestGatewayConnectEvents(t *testing.T) {
 
 	checkEvents(t, "Unqueued", false)
 	checkEvents(t, "Queued", true)
+}
+
+func disconnectInboundGateways(s *Server) {
+	s.gateway.RLock()
+	in := s.gateway.in
+	s.gateway.RUnlock()
+
+	s.gateway.RLock()
+	for _, client := range in {
+		s.gateway.RUnlock()
+		client.closeConnection(ClientClosed)
+		s.gateway.RLock()
+	}
+	s.gateway.RUnlock()
+}
+
+type testMissingOCSPStapleLogger struct {
+	DummyLogger
+	ch chan string
+}
+
+func (l *testMissingOCSPStapleLogger) Errorf(format string, v ...interface{}) {
+	msg := fmt.Sprintf(format, v...)
+	if strings.Contains(msg, "peer missing OCSP Staple") {
+		select {
+		case l.ch <- msg:
+		default:
+		}
+	}
+}
+
+func TestOCSPGatewayMissingPeerStapleIssue(t *testing.T) {
+	const (
+		caCert = "../test/configs/certs/ocsp/ca-cert.pem"
+		caKey  = "../test/configs/certs/ocsp/ca-key.pem"
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ocspr := NewOCSPResponderCustomTimeout(t, caCert, caKey, 10*time.Minute)
+	defer ocspr.Shutdown(ctx)
+	addr := fmt.Sprintf("http://%s", ocspr.Addr)
+
+	// Node A
+	SetOCSPStatus(t, addr, "../test/configs/certs/ocsp/server-status-request-url-01-cert.pem", ocsp.Good)
+	SetOCSPStatus(t, addr, "../test/configs/certs/ocsp/server-status-request-url-02-cert.pem", ocsp.Good)
+
+	// Node B
+	SetOCSPStatus(t, addr, "../test/configs/certs/ocsp/server-status-request-url-03-cert.pem", ocsp.Good)
+	SetOCSPStatus(t, addr, "../test/configs/certs/ocsp/server-status-request-url-04-cert.pem", ocsp.Good)
+
+	// Node C
+	SetOCSPStatus(t, addr, "../test/configs/certs/ocsp/server-status-request-url-05-cert.pem", ocsp.Good)
+	SetOCSPStatus(t, addr, "../test/configs/certs/ocsp/server-status-request-url-06-cert.pem", ocsp.Good)
+
+	// Node A rotated certs
+	SetOCSPStatus(t, addr, "../test/configs/certs/ocsp/server-status-request-url-07-cert.pem", ocsp.Good)
+	SetOCSPStatus(t, addr, "../test/configs/certs/ocsp/server-status-request-url-08-cert.pem", ocsp.Good)
+
+	// Store Dirs
+	storeDirA := t.TempDir()
+	storeDirB := t.TempDir()
+	storeDirC := t.TempDir()
+
+	// Gateway server configuration
+	srvConfA := `
+		host: "127.0.0.1"
+		port: -1
+
+		server_name: "AAA"
+
+		ocsp { mode = always }
+
+                system_account = sys
+                accounts {
+                  sys   { users = [{ user: sys, pass: sys }]}
+                  guest { users = [{ user: guest, pass: guest }]}
+                }
+                no_auth_user = guest
+
+		store_dir: '%s'
+		gateway {
+			name: A
+			host: "127.0.0.1"
+			port: -1
+			advertise: "127.0.0.1"
+
+			tls {
+				cert_file: "../test/configs/certs/ocsp/server-status-request-url-02-cert.pem"
+				key_file: "../test/configs/certs/ocsp/server-status-request-url-02-key.pem"
+				ca_file: "../test/configs/certs/ocsp/ca-cert.pem"
+				timeout: 5
+			}
+		}
+	`
+	srvConfA = fmt.Sprintf(srvConfA, storeDirA)
+	sconfA := createConfFile(t, []byte(srvConfA))
+	srvA, optsA := RunServerWithConfig(sconfA)
+	defer srvA.Shutdown()
+
+	// Gateway B connects to Gateway A.
+	srvConfB := `
+		host: "127.0.0.1"
+		port: -1
+
+		server_name: "BBB"
+
+		ocsp { mode = always }
+
+                system_account = sys
+                accounts {
+                  sys   { users = [{ user: sys, pass: sys }]}
+                  guest { users = [{ user: guest, pass: guest }]}
+                }
+                no_auth_user = guest
+
+		store_dir: '%s'
+		gateway {
+			name: B
+			host: "127.0.0.1"
+			advertise: "127.0.0.1"
+			port: -1
+			gateways: [{
+				name: "A"
+				url: "nats://127.0.0.1:%d"
+			}]
+
+			tls {
+				cert_file: "../test/configs/certs/ocsp/server-status-request-url-04-cert.pem"
+				key_file: "../test/configs/certs/ocsp/server-status-request-url-04-key.pem"
+				ca_file: "../test/configs/certs/ocsp/ca-cert.pem"
+				timeout: 5
+			}
+		}
+	`
+	srvConfB = fmt.Sprintf(srvConfB, storeDirB, optsA.Gateway.Port)
+	conf := createConfFile(t, []byte(srvConfB))
+	srvB, optsB := RunServerWithConfig(conf)
+	defer srvB.Shutdown()
+
+	// Client connects to server A.
+	cA, err := nats.Connect(fmt.Sprintf("nats://127.0.0.1:%d", optsA.Port),
+		nats.ErrorHandler(noOpErrHandler),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cA.Close()
+
+	// Wait for connectivity between A and B.
+	waitForOutboundGateways(t, srvB, 1, 5*time.Second)
+
+	// Gateway C also connects to Gateway A.
+	srvConfC := `
+		host: "127.0.0.1"
+		port: -1
+
+		server_name: "CCC"
+
+		ocsp { mode = always }
+
+                system_account = sys
+                accounts {
+                  sys   { users = [{ user: sys, pass: sys }]}
+                  guest { users = [{ user: guest, pass: guest }]}
+                }
+                no_auth_user = guest
+
+		store_dir: '%s'
+		gateway {
+			name: C
+			host: "127.0.0.1"
+			advertise: "127.0.0.1"
+			port: -1
+			gateways: [{name: "A", url: "nats://127.0.0.1:%d" }]
+
+			tls {
+				cert_file: "../test/configs/certs/ocsp/server-status-request-url-06-cert.pem"
+				key_file: "../test/configs/certs/ocsp/server-status-request-url-06-key.pem"
+				ca_file: "../test/configs/certs/ocsp/ca-cert.pem"
+				timeout: 5
+			}
+		}
+	`
+	srvConfC = fmt.Sprintf(srvConfC, storeDirC, optsA.Gateway.Port)
+	conf = createConfFile(t, []byte(srvConfC))
+	srvC, optsC := RunServerWithConfig(conf)
+	defer srvC.Shutdown()
+
+	////////////////////////////////////////////////////////////////////////////
+	//                                                                        //
+	//  A and B are connected at this point and A is starting with certs that //
+	//  will be rotated.
+	//                                                                        //
+	////////////////////////////////////////////////////////////////////////////
+	cB, err := nats.Connect(fmt.Sprintf("nats://127.0.0.1:%d", optsB.Port),
+		nats.ErrorHandler(noOpErrHandler),
+	)
+	require_NoError(t, err)
+	defer cB.Close()
+
+	cC, err := nats.Connect(fmt.Sprintf("nats://127.0.0.1:%d", optsC.Port),
+		nats.ErrorHandler(noOpErrHandler),
+	)
+	require_NoError(t, err)
+	defer cC.Close()
+
+	_, err = cA.Subscribe("foo", func(m *nats.Msg) {
+		m.Respond(nil)
+	})
+	require_NoError(t, err)
+
+	cA.Flush()
+
+	_, err = cB.Subscribe("bar", func(m *nats.Msg) {
+		m.Respond(nil)
+	})
+	require_NoError(t, err)
+	cB.Flush()
+
+	waitForOutboundGateways(t, srvB, 1, 10*time.Second)
+	waitForOutboundGateways(t, srvC, 2, 10*time.Second)
+
+	/////////////////////////////////////////////////////////////////////////////////
+	//                                                                             //
+	//  Switch all the certs from server A, all OCSP monitors should be restarted  //
+	//  so it should have new staples.                                             //
+	//                                                                             //
+	/////////////////////////////////////////////////////////////////////////////////
+	srvConfA = `
+		host: "127.0.0.1"
+		port: -1
+
+		server_name: "AAA"
+
+		ocsp { mode = always }
+
+                system_account = sys
+                accounts {
+                  sys   { users = [{ user: sys, pass: sys }]}
+                  guest { users = [{ user: guest, pass: guest }]}
+                }
+                no_auth_user = guest
+
+		store_dir: '%s'
+		gateway {
+			name: A
+			host: "127.0.0.1"
+			port: -1
+			advertise: "127.0.0.1"
+
+			tls {
+				cert_file: "../test/configs/certs/ocsp/server-status-request-url-08-cert.pem"
+				key_file: "../test/configs/certs/ocsp/server-status-request-url-08-key.pem"
+				ca_file: "../test/configs/certs/ocsp/ca-cert.pem"
+				timeout: 5
+
+			}
+		}
+	`
+
+	srvConfA = fmt.Sprintf(srvConfA, storeDirA)
+	if err := os.WriteFile(sconfA, []byte(srvConfA), 0666); err != nil {
+		t.Fatalf("Error writing config: %v", err)
+	}
+	if err := srvA.Reload(); err != nil {
+		t.Fatal(err)
+	}
+	waitForOutboundGateways(t, srvA, 2, 5*time.Second)
+	waitForOutboundGateways(t, srvB, 2, 5*time.Second)
+	waitForOutboundGateways(t, srvC, 2, 5*time.Second)
+
+	// Now clients connect to C can communicate with B and A.
+	_, err = cC.Request("foo", nil, 2*time.Second)
+	require_NoError(t, err)
+
+	_, err = cC.Request("bar", nil, 2*time.Second)
+	require_NoError(t, err)
+
+	// Reload and disconnect very fast trying to produce the race.
+	ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Swap logger from server to capture the missing peer log.
+	lA := &testMissingOCSPStapleLogger{ch: make(chan string, 30)}
+	srvA.SetLogger(lA, false, false)
+
+	lB := &testMissingOCSPStapleLogger{ch: make(chan string, 30)}
+	srvB.SetLogger(lB, false, false)
+
+	lC := &testMissingOCSPStapleLogger{ch: make(chan string, 30)}
+	srvC.SetLogger(lC, false, false)
+
+	// Start with a reload from the last server that connected directly to A.
+	err = srvC.Reload()
+	require_NoError(t, err)
+
+	// Stress reconnections and reloading servers without getting
+	// missing OCSP peer staple errors.
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		for range time.NewTicker(500 * time.Millisecond).C {
+			select {
+			case <-ctx.Done():
+				wg.Done()
+				return
+			default:
+			}
+			disconnectInboundGateways(srvA)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		for range time.NewTicker(500 * time.Millisecond).C {
+			select {
+			case <-ctx.Done():
+				wg.Done()
+				return
+			default:
+			}
+			disconnectInboundGateways(srvB)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		for range time.NewTicker(500 * time.Millisecond).C {
+			select {
+			case <-ctx.Done():
+				wg.Done()
+				return
+			default:
+			}
+			disconnectInboundGateways(srvC)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		for range time.NewTicker(700 * time.Millisecond).C {
+			select {
+			case <-ctx.Done():
+				wg.Done()
+				return
+			default:
+			}
+			srvC.Reload()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		for range time.NewTicker(800 * time.Millisecond).C {
+			select {
+			case <-ctx.Done():
+				wg.Done()
+				return
+			default:
+			}
+			srvB.Reload()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		for range time.NewTicker(900 * time.Millisecond).C {
+			select {
+			case <-ctx.Done():
+				wg.Done()
+				return
+			default:
+			}
+			srvA.Reload()
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+	case msg := <-lA.ch:
+		t.Fatalf("Server A: Got OCSP Staple error: %v", msg)
+	case msg := <-lB.ch:
+		t.Fatalf("Server B: Got OCSP Staple error: %v", msg)
+	case msg := <-lC.ch:
+		t.Fatalf("Server C: Got OCSP Staple error: %v", msg)
+	}
+	waitForOutboundGateways(t, srvA, 2, 5*time.Second)
+	waitForOutboundGateways(t, srvB, 2, 5*time.Second)
+	waitForOutboundGateways(t, srvC, 2, 5*time.Second)
+	wg.Wait()
 }

--- a/server/ocsp.go
+++ b/server/ocsp.go
@@ -460,18 +460,18 @@ func (srv *Server) NewOCSPMonitor(config *tlsConfigKind) (*tls.Config, *OCSPMoni
 
 		// GetCertificate returns a certificate that's presented to a client.
 		tc.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			ccert := cert
 			raw, _, err := mon.getStatus()
 			if err != nil {
 				return nil, err
 			}
-
 			return &tls.Certificate{
 				OCSPStaple:                   raw,
-				Certificate:                  cert.Certificate,
-				PrivateKey:                   cert.PrivateKey,
-				SupportedSignatureAlgorithms: cert.SupportedSignatureAlgorithms,
-				SignedCertificateTimestamps:  cert.SignedCertificateTimestamps,
-				Leaf:                         cert.Leaf,
+				Certificate:                  ccert.Certificate,
+				PrivateKey:                   ccert.PrivateKey,
+				SupportedSignatureAlgorithms: ccert.SupportedSignatureAlgorithms,
+				SignedCertificateTimestamps:  ccert.SignedCertificateTimestamps,
+				Leaf:                         ccert.Leaf,
 			}, nil
 		}
 
@@ -532,13 +532,20 @@ func (srv *Server) NewOCSPMonitor(config *tlsConfigKind) (*tls.Config, *OCSPMoni
 
 			// When server makes a peer connection, need to also present an OCSP Staple.
 			tc.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				ccert := cert
 				raw, _, err := mon.getStatus()
 				if err != nil {
 					return nil, err
 				}
-				cert.OCSPStaple = raw
+				// NOTE: crypto/tls.sendClientCertificate internally also calls getClientCertificate
+				// so if for some reason these callbacks are triggered concurrently during a reconnect
+				// there can be a race. To avoid that, the OCSP monitor lock is used to serialize access
+				// to the staple which could also change inflight during an update.
+				mon.mu.Lock()
+				ccert.OCSPStaple = raw
+				mon.mu.Unlock()
 
-				return &cert, nil
+				return &ccert, nil
 			}
 		default:
 			// GetClientCertificate returns a certificate that's presented to a server.
@@ -546,7 +553,6 @@ func (srv *Server) NewOCSPMonitor(config *tlsConfigKind) (*tls.Config, *OCSPMoni
 				return &cert, nil
 			}
 		}
-
 	}
 	return tc, mon, nil
 }
@@ -761,8 +767,8 @@ func (s *Server) reloadOCSP() error {
 			if mon != nil {
 				ocspm = append(ocspm, mon)
 
-				// Apply latest TLS configuration.
-				config.apply(tc)
+				// Apply latest TLS configuration after OCSP monitors have started.
+				defer config.apply(tc)
 			}
 		}
 
@@ -774,7 +780,7 @@ func (s *Server) reloadOCSP() error {
 			}
 			if plugged && tc != nil {
 				s.ocspPeerVerify = true
-				config.apply(tc)
+				defer config.apply(tc)
 			}
 		}
 	}

--- a/test/ocsp_peer_test.go
+++ b/test/ocsp_peer_test.go
@@ -26,50 +26,50 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/crypto/ocsp"
-
+	. "github.com/nats-io/nats-server/v2/internal/ocsp"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
+	"golang.org/x/crypto/ocsp"
 )
 
-func newOCSPResponderRootCA(t *testing.T) *http.Server {
+func NewOCSPResponderRootCA(t *testing.T) *http.Server {
 	t.Helper()
 	respCertPEM := "configs/certs/ocsp_peer/mini-ca/caocsp/caocsp_cert.pem"
 	respKeyPEM := "configs/certs/ocsp_peer/mini-ca/caocsp/private/caocsp_keypair.pem"
 	issuerCertPEM := "configs/certs/ocsp_peer/mini-ca/root/root_cert.pem"
-	return newOCSPResponderDesignatedCustomAddress(t, issuerCertPEM, respCertPEM, respKeyPEM, "127.0.0.1:8888")
+	return NewOCSPResponderDesignatedCustomAddress(t, issuerCertPEM, respCertPEM, respKeyPEM, "127.0.0.1:8888")
 }
 
-func newOCSPResponderIntermediateCA1(t *testing.T) *http.Server {
+func NewOCSPResponderIntermediateCA1(t *testing.T) *http.Server {
 	t.Helper()
 	respCertPEM := "configs/certs/ocsp_peer/mini-ca/ocsp1/ocsp1_bundle.pem"
 	respKeyPEM := "configs/certs/ocsp_peer/mini-ca/ocsp1/private/ocsp1_keypair.pem"
 	issuerCertPEM := "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem"
-	return newOCSPResponderDesignatedCustomAddress(t, issuerCertPEM, respCertPEM, respKeyPEM, "127.0.0.1:18888")
+	return NewOCSPResponderDesignatedCustomAddress(t, issuerCertPEM, respCertPEM, respKeyPEM, "127.0.0.1:18888")
 }
 
-func newOCSPResponderIntermediateCA1Undelegated(t *testing.T) *http.Server {
+func NewOCSPResponderIntermediateCA1Undelegated(t *testing.T) *http.Server {
 	t.Helper()
 	issuerCertPEM := "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem"
 	issuerCertKey := "configs/certs/ocsp_peer/mini-ca/intermediate1/private/intermediate1_keypair.pem"
-	return newOCSPResponderCustomAddress(t, issuerCertPEM, issuerCertKey, "127.0.0.1:18888")
+	return NewOCSPResponderCustomAddress(t, issuerCertPEM, issuerCertKey, "127.0.0.1:18888")
 }
 
-func newOCSPResponderBadDelegateIntermediateCA1(t *testing.T) *http.Server {
+func NewOCSPResponderBadDelegateIntermediateCA1(t *testing.T) *http.Server {
 	t.Helper()
 	// UserA2 is a cert issued by intermediate1, but intermediate1 did not add OCSP signing extension
 	respCertPEM := "configs/certs/ocsp_peer/mini-ca/client1/UserA2_bundle.pem"
 	respKeyPEM := "configs/certs/ocsp_peer/mini-ca/client1/private/UserA2_keypair.pem"
 	issuerCertPEM := "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem"
-	return newOCSPResponderDesignatedCustomAddress(t, issuerCertPEM, respCertPEM, respKeyPEM, "127.0.0.1:18888")
+	return NewOCSPResponderDesignatedCustomAddress(t, issuerCertPEM, respCertPEM, respKeyPEM, "127.0.0.1:18888")
 }
 
-func newOCSPResponderIntermediateCA2(t *testing.T) *http.Server {
+func NewOCSPResponderIntermediateCA2(t *testing.T) *http.Server {
 	t.Helper()
 	respCertPEM := "configs/certs/ocsp_peer/mini-ca/ocsp2/ocsp2_bundle.pem"
 	respKeyPEM := "configs/certs/ocsp_peer/mini-ca/ocsp2/private/ocsp2_keypair.pem"
 	issuerCertPEM := "configs/certs/ocsp_peer/mini-ca/intermediate2/intermediate2_cert.pem"
-	return newOCSPResponderDesignatedCustomAddress(t, issuerCertPEM, respCertPEM, respKeyPEM, "127.0.0.1:28888")
+	return NewOCSPResponderDesignatedCustomAddress(t, issuerCertPEM, respCertPEM, respKeyPEM, "127.0.0.1:28888")
 }
 
 // TestOCSPPeerGoodClients is test of two NATS client (AIA enabled at leaf and cert) under good path (different intermediates)
@@ -78,21 +78,21 @@ func TestOCSPPeerGoodClients(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate2/intermediate2_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate2/intermediate2_cert.pem", ocsp.Good)
 
-	intermediateCA1Responder := newOCSPResponderIntermediateCA1(t)
+	intermediateCA1Responder := NewOCSPResponderIntermediateCA1(t)
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
 
-	intermediateCA2Responder := newOCSPResponderIntermediateCA2(t)
+	intermediateCA2Responder := NewOCSPResponderIntermediateCA2(t)
 	intermediateCA2ResponderURL := fmt.Sprintf("http://%s", intermediateCA2Responder.Addr)
 	defer intermediateCA2Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA2ResponderURL, "configs/certs/ocsp_peer/mini-ca/client2/UserB1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA2ResponderURL, "configs/certs/ocsp_peer/mini-ca/client2/UserB1_cert.pem", ocsp.Good)
 
 	for _, test := range []struct {
 		name      string
@@ -223,12 +223,12 @@ func TestOCSPPeerUnknownClient(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
 
-	intermediateCA1Responder := newOCSPResponderIntermediateCA1(t)
+	intermediateCA1Responder := NewOCSPResponderIntermediateCA1(t)
 	defer intermediateCA1Responder.Shutdown(ctx)
 
 	for _, test := range []struct {
@@ -295,15 +295,15 @@ func TestOCSPPeerRevokedClient(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
 
-	intermediateCA1Responder := newOCSPResponderIntermediateCA1(t)
+	intermediateCA1Responder := NewOCSPResponderIntermediateCA1(t)
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Revoked)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Revoked)
 
 	for _, test := range []struct {
 		name      string
@@ -439,21 +439,21 @@ func TestOCSPPeerUnknownAndRevokedIntermediate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Revoked)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Revoked)
 	// No test OCSP status set on intermediate2, so unknown
 
-	intermediateCA1Responder := newOCSPResponderIntermediateCA1(t)
+	intermediateCA1Responder := NewOCSPResponderIntermediateCA1(t)
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
 
-	intermediateCA2Responder := newOCSPResponderIntermediateCA2(t)
+	intermediateCA2Responder := NewOCSPResponderIntermediateCA2(t)
 	intermediateCA2ResponderURL := fmt.Sprintf("http://%s", intermediateCA2Responder.Addr)
 	defer intermediateCA2Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA2ResponderURL, "configs/certs/ocsp_peer/mini-ca/client2/UserB1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA2ResponderURL, "configs/certs/ocsp_peer/mini-ca/client2/UserB1_cert.pem", ocsp.Good)
 
 	for _, test := range []struct {
 		name      string
@@ -544,16 +544,16 @@ func TestOCSPPeerLeafGood(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
 
-	intermediateCA1Responder := newOCSPResponderIntermediateCA1(t)
+	intermediateCA1Responder := NewOCSPResponderIntermediateCA1(t)
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/server1/TestServer1_cert.pem", ocsp.Good)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/server1/TestServer2_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/server1/TestServer1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/server1/TestServer2_cert.pem", ocsp.Good)
 
 	for _, test := range []struct {
 		name        string
@@ -691,16 +691,16 @@ func TestOCSPPeerLeafReject(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
 
-	intermediateCA1Responder := newOCSPResponderIntermediateCA1(t)
+	intermediateCA1Responder := NewOCSPResponderIntermediateCA1(t)
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/server1/TestServer1_cert.pem", ocsp.Revoked)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/server1/TestServer2_cert.pem", ocsp.Revoked)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/server1/TestServer1_cert.pem", ocsp.Revoked)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/server1/TestServer2_cert.pem", ocsp.Revoked)
 
 	for _, test := range []struct {
 		name        string
@@ -849,21 +849,21 @@ func TestOCSPPeerGoodClientsNoneCache(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate2/intermediate2_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate2/intermediate2_cert.pem", ocsp.Good)
 
-	intermediateCA1Responder := newOCSPResponderIntermediateCA1(t)
+	intermediateCA1Responder := NewOCSPResponderIntermediateCA1(t)
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
 
-	intermediateCA2Responder := newOCSPResponderIntermediateCA2(t)
+	intermediateCA2Responder := NewOCSPResponderIntermediateCA2(t)
 	intermediateCA2ResponderURL := fmt.Sprintf("http://%s", intermediateCA2Responder.Addr)
 	defer intermediateCA2Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA2ResponderURL, "configs/certs/ocsp_peer/mini-ca/client2/UserB1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA2ResponderURL, "configs/certs/ocsp_peer/mini-ca/client2/UserB1_cert.pem", ocsp.Good)
 
 	deleteLocalStore(t, "")
 
@@ -975,21 +975,21 @@ func TestOCSPPeerGoodClientsLocalCache(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate2/intermediate2_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate2/intermediate2_cert.pem", ocsp.Good)
 
-	intermediateCA1Responder := newOCSPResponderIntermediateCA1(t)
+	intermediateCA1Responder := NewOCSPResponderIntermediateCA1(t)
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
 
-	intermediateCA2Responder := newOCSPResponderIntermediateCA2(t)
+	intermediateCA2Responder := NewOCSPResponderIntermediateCA2(t)
 	intermediateCA2ResponderURL := fmt.Sprintf("http://%s", intermediateCA2Responder.Addr)
 	defer intermediateCA2Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA2ResponderURL, "configs/certs/ocsp_peer/mini-ca/client2/UserB1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA2ResponderURL, "configs/certs/ocsp_peer/mini-ca/client2/UserB1_cert.pem", ocsp.Good)
 
 	for _, test := range []struct {
 		name      string
@@ -1603,10 +1603,10 @@ func TestOCSPPeerPreserveRevokedCacheItem(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
 
 	for _, test := range []struct {
 		name      string
@@ -1711,9 +1711,9 @@ func TestOCSPPeerPreserveRevokedCacheItem(t *testing.T) {
 					t.Fatal(err)
 				}
 			} else {
-				intermediateCA1Responder = newOCSPResponderIntermediateCA1(t)
+				intermediateCA1Responder = NewOCSPResponderIntermediateCA1(t)
 				intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
-				setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
+				SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
 				defer intermediateCA1Responder.Shutdown(ctx)
 			}
 			content := test.config
@@ -1755,15 +1755,15 @@ func TestOCSPStapleFeatureInterop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
 
-	intermediateCA1Responder := newOCSPResponderIntermediateCA1(t)
+	intermediateCA1Responder := NewOCSPResponderIntermediateCA1(t)
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/server1/TestServer1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/server1/TestServer1_cert.pem", ocsp.Good)
 
 	for _, test := range []struct {
 		name      string
@@ -1815,7 +1815,7 @@ func TestOCSPStapleFeatureInterop(t *testing.T) {
 			nil,
 			nil,
 			func() {
-				setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
+				SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
 			},
 		},
 		{
@@ -1860,7 +1860,7 @@ func TestOCSPStapleFeatureInterop(t *testing.T) {
 			fmt.Errorf("remote error: tls: bad certificate"),
 			nil,
 			func() {
-				setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Revoked)
+				SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Revoked)
 			},
 		},
 	} {
@@ -1904,15 +1904,15 @@ func TestOCSPPeerWarnOnlyOption(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
 
-	intermediateCA1Responder := newOCSPResponderIntermediateCA1(t)
+	intermediateCA1Responder := NewOCSPResponderIntermediateCA1(t)
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Revoked)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Revoked)
 
 	for _, test := range []struct {
 		name      string
@@ -2007,12 +2007,12 @@ func TestOCSPPeerUnknownIsGoodOption(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
 
-	intermediateCA1Responder := newOCSPResponderIntermediateCA1(t)
+	intermediateCA1Responder := NewOCSPResponderIntermediateCA1(t)
 	defer intermediateCA1Responder.Shutdown(ctx)
 
 	for _, test := range []struct {
@@ -2104,10 +2104,10 @@ func TestOCSPPeerAllowWhenCAUnreachableOption(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
 
 	for _, test := range []struct {
 		name           string
@@ -2310,10 +2310,10 @@ func TestOCSPResponseCacheLocalStoreOpt(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
 
 	for _, test := range []struct {
 		name           string
@@ -2446,21 +2446,21 @@ func TestOCSPPeerIncrementalSaveLocalCache(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate2/intermediate2_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate2/intermediate2_cert.pem", ocsp.Good)
 
-	intermediateCA1Responder := newOCSPResponderIntermediateCA1(t)
+	intermediateCA1Responder := NewOCSPResponderIntermediateCA1(t)
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
 
-	intermediateCA2Responder := newOCSPResponderIntermediateCA2(t)
+	intermediateCA2Responder := NewOCSPResponderIntermediateCA2(t)
 	intermediateCA2ResponderURL := fmt.Sprintf("http://%s", intermediateCA2Responder.Addr)
 	defer intermediateCA2Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA2ResponderURL, "configs/certs/ocsp_peer/mini-ca/client2/UserB1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA2ResponderURL, "configs/certs/ocsp_peer/mini-ca/client2/UserB1_cert.pem", ocsp.Good)
 
 	var fi os.FileInfo
 	var err error
@@ -2597,15 +2597,15 @@ func TestOCSPPeerUndelegatedCAResponseSigner(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
 
-	intermediateCA1Responder := newOCSPResponderIntermediateCA1Undelegated(t)
+	intermediateCA1Responder := NewOCSPResponderIntermediateCA1Undelegated(t)
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
 
 	for _, test := range []struct {
 		name      string
@@ -2669,15 +2669,15 @@ func TestOCSPPeerDelegatedCAResponseSigner(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
 
-	intermediateCA1Responder := newOCSPResponderIntermediateCA1(t)
+	intermediateCA1Responder := NewOCSPResponderIntermediateCA1(t)
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
 
 	for _, test := range []struct {
 		name      string
@@ -2741,15 +2741,15 @@ func TestOCSPPeerBadDelegatedCAResponseSigner(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
 
-	intermediateCA1Responder := newOCSPResponderBadDelegateIntermediateCA1(t)
+	intermediateCA1Responder := NewOCSPResponderBadDelegateIntermediateCA1(t)
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
 
 	for _, test := range []struct {
 		name      string
@@ -2813,18 +2813,18 @@ func TestOCSPPeerNextUpdateUnset(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rootCAResponder := newOCSPResponderRootCA(t)
+	rootCAResponder := NewOCSPResponderRootCA(t)
 	rootCAResponderURL := fmt.Sprintf("http://%s", rootCAResponder.Addr)
 	defer rootCAResponder.Shutdown(ctx)
-	setOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, rootCAResponderURL, "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem", ocsp.Good)
 
 	respCertPEM := "configs/certs/ocsp_peer/mini-ca/ocsp1/ocsp1_bundle.pem"
 	respKeyPEM := "configs/certs/ocsp_peer/mini-ca/ocsp1/private/ocsp1_keypair.pem"
 	issuerCertPEM := "configs/certs/ocsp_peer/mini-ca/intermediate1/intermediate1_cert.pem"
-	intermediateCA1Responder := newOCSPResponderBase(t, issuerCertPEM, respCertPEM, respKeyPEM, true, "127.0.0.1:18888", 0, "")
+	intermediateCA1Responder := NewOCSPResponderBase(t, issuerCertPEM, respCertPEM, respKeyPEM, true, "127.0.0.1:18888", 0, "")
 	intermediateCA1ResponderURL := fmt.Sprintf("http://%s", intermediateCA1Responder.Addr)
 	defer intermediateCA1Responder.Shutdown(ctx)
-	setOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
+	SetOCSPStatus(t, intermediateCA1ResponderURL, "configs/certs/ocsp_peer/mini-ca/client1/UserA1_cert.pem", ocsp.Good)
 
 	for _, test := range []struct {
 		name           string


### PR DESCRIPTION
Fixes some issues with gateways reconnections that had OCSP stapling enabled:
- Gateways that started without explicit remotes would not always have OCSP callbacks registered so had no staples ready for the remote connections, when this condition is detected they are now applied on the fly.
- Access to GetClientCertificate could be concurrent under some conditions and could also race with OCSP monitor updates.
- Reloading races with gateway reconnections also addressed.

Tests also cover conditions from #5207, this also moves the OCSP testing helpers to an internal package.