### PR TITLE
Fix workqueue overlap

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -612,7 +612,7 @@ func checkConsumerCfg(
 			return NewJSStreamInvalidConfigError(ErrBadSubject)
 		}
 		for inner, ssubject := range subjectFilters {
-			if inner != outer && subjectIsSubsetMatch(subject, ssubject) {
+			if inner != outer && SubjectsCollide(subject, ssubject) {
 				return NewJSConsumerOverlappingSubjectFiltersError()
 			}
 		}

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -898,6 +898,7 @@ func TestJetStreamConsumerWorkQueuePolicyOverlap(t *testing.T) {
 		AckPolicy:     nats.AckExplicitPolicy,
 	})
 	require_Error(t, err)
+	require_True(t, strings.Contains(err.Error(), "unique"))
 }
 
 func TestJetStreamConsumerIsEqualOrSubsetMatch(t *testing.T) {

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -871,6 +871,53 @@ func TestJetStreamConsumerIsFilteredMatch(t *testing.T) {
 	}
 }
 
+func TestJetStreamConsumerWorkQueuePolicy(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	tests := []struct {
+		name            string
+		streamFilter    []string
+		consumerAFilter []string
+		consumerBFilter []string
+		shouldFail      bool
+	}{
+		{
+			name:            "overlap_without_subset_match",
+			streamFilter:    []string{"foo.*.*"},
+			consumerAFilter: []string{"foo.*.bar"},
+			consumerBFilter: []string{"foo.bar.*"},
+			shouldFail:      true,
+		},
+	}
+
+	for _, test := range tests {
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:      test.name,
+			Subjects:  test.streamFilter,
+			Retention: nats.WorkQueuePolicy,
+		})
+		require_NoError(t, err)
+
+		_, err = js.AddConsumer(test.name, &nats.ConsumerConfig{
+			Durable:        "ConsumerA",
+			FilterSubjects: test.consumerAFilter,
+			AckPolicy:      nats.AckExplicitPolicy,
+		})
+		require_NoError(t, err)
+
+		_, err = js.AddConsumer(test.name, &nats.ConsumerConfig{
+			Durable:        "ConsumerB",
+			FilterSubjects: test.consumerBFilter,
+			AckPolicy:      nats.AckExplicitPolicy,
+		})
+		require_True(t, (err != nil) == test.shouldFail)
+	}
+}
+
 func TestJetStreamConsumerIsEqualOrSubsetMatch(t *testing.T) {
 	for _, test := range []struct {
 		name           string

--- a/server/stream.go
+++ b/server/stream.go
@@ -1287,7 +1287,7 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 				return StreamConfig{}, NewJSMirrorInvalidSubjectFilterError()
 			}
 			for inner, innertr := range cfg.Mirror.SubjectTransforms {
-				if inner != outer && subjectIsSubsetMatch(tr.Source, innertr.Source) {
+				if inner != outer && SubjectsCollide(tr.Source, innertr.Source) {
 					return StreamConfig{}, NewJSMirrorOverlappingSubjectFiltersError()
 				}
 			}

--- a/server/stream.go
+++ b/server/stream.go
@@ -5630,8 +5630,6 @@ func (mset *stream) Store() StreamStore {
 // Lock should be held.
 func (mset *stream) partitionUnique(name string, partitions []string) bool {
 	for _, partition := range partitions {
-		psa := [32]string{}
-		pts := tokenizeSubjectIntoSlice(psa[:0], partition)
 		for n, o := range mset.consumers {
 			// Skip the consumer being checked.
 			if n == name {
@@ -5641,8 +5639,7 @@ func (mset *stream) partitionUnique(name string, partitions []string) bool {
 				return false
 			}
 			for _, filter := range o.subjf {
-				if isSubsetMatchTokenized(pts, filter.tokenizedSubject) ||
-					isSubsetMatchTokenized(filter.tokenizedSubject, pts) {
+				if SubjectsCollide(partition, filter.subject) {
 					return false
 				}
 			}


### PR DESCRIPTION
Using subset match for overlap checks does not work in some cases, like:
```
foo.*.bar
foo.bar.*
```

This PR swaps to using `SubjectsCollide` that takes that scenario into account.
While working on that PR, I thought it is worth checking other places we use subsetMatch for overlap, and those were changed too.


Signed-off-by: Tomasz Pietrek tomasz@nats.io