### PR TITLE
[IMPROVED] Use match versus iter since more performant and less stressful on gc.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -3608,12 +3608,11 @@ func (fs *fileStore) enforceMsgPerSubjectLimit(fireCallback bool) {
 
 	// collect all that are not correct.
 	needAttention := make(map[string]*psi)
-	fs.psim.Iter(func(subj []byte, psi *psi) bool {
+	fs.psim.Match([]byte(fwcs), func(subj []byte, psi *psi) {
 		numMsgs += psi.total
 		if psi.total > maxMsgsPer {
 			needAttention[string(subj)] = psi
 		}
-		return true
 	})
 
 	// We had an issue with a use case where psim (and hence fss) were correct but idx was not and was not properly being caught.
@@ -3633,11 +3632,10 @@ func (fs *fileStore) enforceMsgPerSubjectLimit(fireCallback bool) {
 		fs.rebuildStateLocked(nil)
 		// Need to redo blocks that need attention.
 		needAttention = make(map[string]*psi)
-		fs.psim.Iter(func(subj []byte, psi *psi) bool {
+		fs.psim.Match([]byte(fwcs), func(subj []byte, psi *psi) {
 			if psi.total > maxMsgsPer {
 				needAttention[string(subj)] = psi
 			}
-			return true
 		})
 	}
 


### PR DESCRIPTION
We do not care about order so using Match() vs Iter() will be much more friendly to the GC. Especially for streams with lots of subjects, e.g. > 1M.

Signed-off-by: Derek Collison <derek@nats.io>
