### PR TITLE
[FIXED] Adjust JSZ account filtering when asking for stream details

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2934,7 +2934,7 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 	if opts.Consumer {
 		opts.Streams = true
 	}
-	if opts.Streams {
+	if opts.Streams && opts.Account == _EMPTY_ {
 		opts.Accounts = true
 	}
 

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -4572,7 +4572,15 @@ func TestMonitorJsz(t *testing.T) {
 	})
 	t.Run("account-non-existing", func(t *testing.T) {
 		for _, url := range []string{monUrl1, monUrl2} {
-			info := readJsInfo(url + "?acc=DOES_NOT_EXIT")
+			info := readJsInfo(url + "?acc=DOES_NOT_EXIST")
+			if len(info.AccountDetails) != 0 {
+				t.Fatalf("expected no account to be returned by %s but got %v", url, info)
+			}
+		}
+	})
+	t.Run("account-non-existing-with-stream-details", func(t *testing.T) {
+		for _, url := range []string{monUrl1, monUrl2} {
+			info := readJsInfo(url + "?acc=DOES_NOT_EXIST&streams=true")
 			if len(info.AccountDetails) != 0 {
 				t.Fatalf("expected no account to be returned by %s but got %v", url, info)
 			}


### PR DESCRIPTION
When making a JSZ request with the following options:
```
{streams: true, account: "FOO"}
```

If a server is not aware of account FOO, then the server would send back *all known accounts* details.

(Example: the additional test case provided would fail because the server sends back 3 account details, rather than zero)

The new behavior is consistent with request handling when `streams` is false: return 1 account detail if there's a match and 0 if there is no match.


Signed-off-by: Marco Primi <marco@nats.io>
