### PR TITLE
[ADD] WebSocket custom response headers

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -133,7 +133,8 @@ type srvWebsocket struct {
 	sameOrigin     bool
 	connectURLs    []string
 	connectURLsMap refCountedUrlSet
-	authOverride   bool // indicate if there is auth override in websocket config
+	authOverride   bool   // indicate if there is auth override in websocket config
+	rawHeaders     string // raw headers to be used in the upgrade response.
 }
 
 type allowedOrigin struct {
@@ -777,6 +778,9 @@ func (s *Server) wsUpgrade(w http.ResponseWriter, r *http.Request) (*wsUpgradeRe
 	if kind == MQTT {
 		p = append(p, wsMQTTSecProto...)
 	}
+	if s.websocket.rawHeaders != _EMPTY_ {
+		p = append(p, s.websocket.rawHeaders...)
+	}
 	p = append(p, _CRLF_...)
 
 	if _, err = conn.Write(p); err != nil {
@@ -1019,6 +1023,24 @@ func validateWebsocketOptions(o *Options) error {
 	if err := validatePinnedCerts(wo.TLSPinnedCerts); err != nil {
 		return fmt.Errorf("websocket: %v", err)
 	}
+
+	// Check for invalid headers here.
+	for key := range wo.Headers {
+		k := strings.ToLower(key)
+		switch k {
+		case "host",
+			"content-length",
+			"connection",
+			"upgrade",
+			"nats-no-masking":
+			return fmt.Errorf("websocket: invalid header %q not allowed", key)
+		}
+
+		if strings.HasPrefix(k, "sec-websocket-") {
+			return fmt.Errorf("websocket: invalid header %q, \"Sec-WebSocket-\" prefix no allowed", key)
+		}
+	}
+
 	return nil
 }
 
@@ -1050,6 +1072,21 @@ func (s *Server) wsSetOriginOptions(o *WebsocketOpts) {
 	}
 }
 
+// Calculate the raw headers for websocket upgrade response.
+func (s *Server) wsSetHeadersOptions(o *WebsocketOpts) {
+	var sb strings.Builder
+	for k, v := range o.Headers {
+		sb.WriteString(k)
+		sb.WriteString(": ")
+		sb.WriteString(v)
+		sb.WriteString(_CRLF_)
+	}
+	ws := &s.websocket
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	ws.rawHeaders = sb.String()
+}
+
 // Given the websocket options, we check if any auth configuration
 // has been provided. If so, possibly create users/nkey users and
 // store them in s.websocket.users/nkeys.
@@ -1071,6 +1108,7 @@ func (s *Server) startWebsocketServer() {
 	o := &sopts.Websocket
 
 	s.wsSetOriginOptions(o)
+	s.wsSetHeadersOptions(o)
 
 	var hl net.Listener
 	var proto string

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1037,7 +1037,7 @@ func validateWebsocketOptions(o *Options) error {
 		}
 
 		if strings.HasPrefix(k, "sec-websocket-") {
-			return fmt.Errorf("websocket: invalid header %q, \"Sec-WebSocket-\" prefix no allowed", key)
+			return fmt.Errorf("websocket: invalid header %q, \"Sec-WebSocket-\" prefix not allowed", key)
 		}
 	}
 

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -1746,7 +1746,7 @@ func TestWSValidateOptions(t *testing.T) {
 			o := wso.Clone()
 			o.Websocket.Headers = map[string]string{"Sec-WebSocket-Key": "123"}
 			return o
-		}, `invalid header "Sec-WebSocket-Key", "Sec-WebSocket-" prefix no allowed`},
+		}, `invalid header "Sec-WebSocket-Key", "Sec-WebSocket-" prefix not allowed`},
 		{"header with host", func() *Options {
 			o := wso.Clone()
 			o.Websocket.Headers = map[string]string{"Host": "http://localhost:8080"}


### PR DESCRIPTION
<!-- Please make sure to read CONTRIBUTING.md, then delete this notice and replace it with your PR description. The below sign-off certifies that the contribution is your original work and that you license the work to the project under the Apache-2.0 license. We cannot accept contributions without it. -->

Allow to configure extra headers for the WebSocket Upgrade Response:

For Example:
```
websocket {
    port: 8080
    no_tls: true
    headers {
        Strict-Transport-Security: "max-age=15768000 ; includeSubDomains"
        X-Frame-Options: "DENY"
    }
}
```


Related Issue: https://github.com/nats-io/nats-server/issues/5226

Signed-off-by: Ramon Berrutti <ramonberrutti@gmail.com>
