### PR TITLE
[IMPROVED] Waiting queue for pull consumers

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -370,6 +370,7 @@ type consumer struct {
 	created           time.Time
 	ldt               time.Time
 	lat               time.Time
+	lwqic             time.Time
 	closed            bool
 
 	// Clustered.
@@ -3341,7 +3342,10 @@ func (o *consumer) processNextMsgRequest(reply string, msg []byte) {
 	// If we have the max number of requests already pending try to expire.
 	if o.waiting.isFull() {
 		// Try to expire some of the requests.
-		o.processWaiting(false)
+		// We do not want to push too hard here so at maximum process once per sec.
+		if time.Since(o.lwqic) > time.Second {
+			o.processWaiting(false)
+		}
 	}
 
 	// If the request is for noWait and we have pending requests already, check if we have room.
@@ -3674,6 +3678,8 @@ func (o *consumer) processWaiting(eos bool) (int, int, int, time.Time) {
 	if o.srv == nil || o.waiting.isEmpty() {
 		return 0, 0, 0, fexp
 	}
+	// Mark our last check time.
+	o.lwqic = time.Now()
 
 	var expired, brp int
 	s, now := o.srv, time.Now()
@@ -3711,7 +3717,6 @@ func (o *consumer) processWaiting(eos bool) (int, int, int, time.Time) {
 				interest = true
 			}
 		}
-
 		// Check if we have interest.
 		if !interest {
 			// No more interest here so go ahead and remove this one from our list.


### PR DESCRIPTION
Moved waiting queue for pull requests to linked-list. We had issues with very large MaxWaiting configured and causing memory and GC issues, especially if compaction kicked in.

Also when new requests for msgs are received and we are full, only check waiting queue at most once per second to avoid CPU pressure when application is continually sending new requests when the queue is full.

Signed-off-by: Derek Collison <derek@nats.io>