### PR TITLE
[FIXED] Protect against corrupt msgBlock first or last sequence when doing indexing

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5343,6 +5343,12 @@ func (mb *msgBlock) indexCacheBuf(buf []byte) error {
 	mbFirstSeq := atomic.LoadUint64(&mb.first.seq)
 	mbLastSeq := atomic.LoadUint64(&mb.last.seq)
 
+	// Sanity check here since we calculate size to allocate based on this.
+	if mbFirstSeq > (mbLastSeq + 1) { // Purged state first == last + 1
+		// This would cause idxSz to wrap.
+		return errCorruptState
+	}
+
 	// Capture beginning size of dmap.
 	dms := uint64(mb.dmap.Size())
 	idxSz := mbLastSeq - mbFirstSeq + 1

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -31,6 +31,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -6718,6 +6719,39 @@ func TestFileStoreMultiLastSeqsMaxAllowed(t *testing.T) {
 	seqs, err := fs.MultiLastSeqs([]string{"foo.*"}, 0, 10)
 	require_True(t, seqs == nil)
 	require_Error(t, err, ErrTooManyResults)
+}
+
+// https://github.com/nats-io/nats-server/issues/5236
+// Unclear how the sequences get off here, this is just forcing the situation reported.
+func TestFileStoreMsgBlockFirstAndLastSeqCorrupt(t *testing.T) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir()},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo.*"}, Storage: FileStorage})
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	msg := []byte("abc")
+	for i := 1; i <= 10; i++ {
+		fs.StoreMsg(fmt.Sprintf("foo.%d", i), nil, msg)
+	}
+	fs.Purge()
+
+	fs.mu.RLock()
+	mb := fs.blks[0]
+	fs.mu.RUnlock()
+
+	mb.mu.Lock()
+	mb.tryForceExpireCacheLocked()
+	atomic.StoreUint64(&mb.last.seq, 9)
+	mb.mu.Unlock()
+
+	// We should rebuild here and return no error.
+	require_NoError(t, mb.loadMsgs())
+	mb.mu.RLock()
+	fseq, lseq := atomic.LoadUint64(&mb.first.seq), atomic.LoadUint64(&mb.last.seq)
+	mb.mu.RUnlock()
+	require_Equal(t, fseq, 11)
+	require_Equal(t, lseq, 10)
 }
 
 ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Resolves: #5236 

Although unclear how the sequences got corrupted in the first place.

Signed-off-by: Derek Collison <derek@nats.io>