### PR TITLE
[ADDED] MQTT SparkplugB Aware support

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -4319,6 +4319,9 @@ func (c *client) mqttHandlePubRetain() {
 		// will use to save the retained message.
 		key = string(byteSubject)
 
+		// Store the retained message with the RETAIN flag set.
+		rm.Flags |= mqttPubFlagRetain
+
 		// Copy the payload out of pp since we will be sending the message
 		// asynchronously.
 		msg := make([]byte, pp.sz)

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -4266,8 +4266,8 @@ func (s *Server) mqttProcessPubRel(c *client, pi uint16, trace bool) error {
 func (c *client) mqttHandlePubRetain() {
 	pp := c.mqtt.pp
 	isRetained := mqttIsRetained(pp.flags)
-	isSparkBBirth, typ, groupID, nodeID, deviceID := sparkbIsBirth(pp.subject, sparkbNamespacePrefix)
-	if !isRetained && !isSparkBBirth {
+	isSparkbBirth, typ, groupID, nodeID, deviceID := sparkbIsBirth(pp.subject, sparkbNamespacePrefix)
+	if !isRetained && !isSparkbBirth {
 		return
 	}
 
@@ -4296,7 +4296,7 @@ func (c *client) mqttHandlePubRetain() {
 		}
 		return
 
-	case isSparkBBirth:
+	case isSparkbBirth:
 		// Spec [tck-id-conformance-mqtt-aware-nbirth-mqtt-topic]. A Sparkplug
 		// Aware MQTT Server MUST make NBIRTH messages available on a topic of
 		// the form:

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -191,15 +191,15 @@ const (
 )
 
 const (
-	sparkbNamespace    = "spBv1.0"
-	sparkbCertificates = "$sparkplug/certificates/spBv1.0"
-	sparkbNBIRTH       = "NBIRTH"
-	sparkbDBIRTH       = "DBIRTH"
+	sparkbNBIRTH = "NBIRTH"
+	sparkbDBIRTH = "DBIRTH"
+	sparkbNDEATH = "NDEATH"
+	sparkbDDEATH = "DDEATH"
 )
 
 var (
-	sparkbNamespacePrefix    = []byte("spBv1//0.")
-	sparkbCertificatesPrefix = []byte("$sparkplug.certificates.spBv1//0.")
+	sparkbNamespaceTopicPrefix    = []byte("spBv1.0/")
+	sparkbCertificatesTopicPrefix = []byte("$sparkplug/certificates/")
 )
 
 var (
@@ -4266,11 +4266,23 @@ func (s *Server) mqttProcessPubRel(c *client, pi uint16, trace bool) error {
 // Invoked from the MQTT publisher's readLoop. No client lock is held on entry.
 func (c *client) mqttHandlePubRetain() {
 	pp := c.mqtt.pp
-	isRetained := mqttIsRetained(pp.flags)
-	isSparkbBirth, typ, groupID, nodeID, deviceID := sparkbIsBirth(pp.subject, sparkbNamespacePrefix)
-	if !isRetained && !isSparkbBirth {
+	retainMQTT := mqttIsRetained(pp.flags)
+	isBirth, _, isCertificate := sparkbParseBirthDeathTopic(pp.topic)
+	retainSparkbBirth := isBirth && !isCertificate
+
+	// [tck-id-topics-nbirth-mqtt] NBIRTH messages MUST be published with MQTT
+	// QoS equal to 0 and retain equal to false.
+	//
+	// [tck-id-conformance-mqtt-aware-nbirth-mqtt-retain] A Sparkplug Aware MQTT
+	// Server MUST make NBIRTH messages available on the topic:
+	// $sparkplug/certificates/namespace/group_id/NBIRTH/edge_node_id with the
+	// MQTT retain flag set to true.
+	if retainMQTT == retainSparkbBirth {
+		// (retainSparkbBirth && retainMQTT) : not valid, so ignore altogether.
+		// (!retainSparkbBirth && !retainMQTT) : nothing to do.
 		return
 	}
+
 	asm := c.mqtt.asm
 	key := string(pp.subject)
 
@@ -4296,7 +4308,7 @@ func (c *client) mqttHandlePubRetain() {
 		Source: c.opts.Username,
 	}
 
-	if isSparkbBirth {
+	if retainSparkbBirth {
 		// [tck-id-conformance-mqtt-aware-store] A Sparkplug Aware MQTT Server
 		// MUST store NBIRTH and DBIRTH messages as they pass through the MQTT
 		// Server.
@@ -4309,14 +4321,13 @@ func (c *client) mqttHandlePubRetain() {
 		// MQTT Server MUST make DBIRTH messages available on a topic of the
 		// form:
 		// $sparkplug/certificates/namespace/group_id/DBIRTH/edge_node_id/device_id
-		rm.Topic = fmt.Sprintf(sparkbCertificates+"/%s/%s/%s", groupID, typ, nodeID)
-		if deviceID != _EMPTY_ {
-			rm.Topic += "/" + deviceID
-		}
-		byteSubject, _ := mqttTopicToNATSPubSubject([]byte(rm.Topic))
+		topic := append(sparkbCertificatesTopicPrefix, pp.topic...)
+		subject, _ := mqttTopicToNATSPubSubject(topic)
+		rm.Topic = string(topic)
+		rm.Subject = string(subject)
 
 		// will use to save the retained message.
-		key = string(byteSubject)
+		key = string(subject)
 
 		// Store the retained message with the RETAIN flag set.
 		rm.Flags |= mqttPubFlagRetain
@@ -4618,29 +4629,30 @@ func mqttIsRetained(flags byte) bool {
 	return flags&mqttPubFlagRetain != 0
 }
 
-// Checks if the subject is in the form of a Sparkplug BIRTH or DEATH message,
-// MQTT topic like spBv1.0/{group_id}/{message_type}/{edge_node_id}/{device_id}
-func sparkbIsBirth(natsSubject, prefix []byte) (is bool, typ, groupID, nodeID, deviceID string) {
-	if !bytes.HasPrefix(natsSubject, prefix) {
-		return false, _EMPTY_, _EMPTY_, _EMPTY_, _EMPTY_
+func sparkbParseBirthDeathTopic(topic []byte) (isBirth, isDeath, isCertificate bool) {
+	if bytes.HasPrefix(topic, sparkbCertificatesTopicPrefix) {
+		isCertificate = true
+		topic = topic[len(sparkbCertificatesTopicPrefix):]
 	}
-	natsSubject = natsSubject[len(prefix):]
-	parts := bytes.Split(natsSubject, []byte("."))
-	if len(parts) < 3 {
-		return false, _EMPTY_, _EMPTY_, _EMPTY_, _EMPTY_
+	if !bytes.HasPrefix(topic, sparkbNamespaceTopicPrefix) {
+		return false, false, false
 	}
-	typ = string(parts[1])
-	isDevice := (typ == sparkbDBIRTH)
-	if typ != sparkbNBIRTH && !isDevice {
-		return false, _EMPTY_, _EMPTY_, _EMPTY_, _EMPTY_
-	}
+	topic = topic[len(sparkbNamespaceTopicPrefix):]
 
-	groupID = string(natsSubjectToMQTTTopic(parts[0]))
-	nodeID = string(natsSubjectToMQTTTopic(parts[2]))
-	if isDevice && len(parts) > 3 {
-		deviceID = string(natsSubjectToMQTTTopic(parts[3]))
+	parts := bytes.Split(topic, []byte{'/'})
+	if len(parts) < 3 || len(parts) > 4 {
+		return false, false, false
 	}
-	return true, typ, groupID, nodeID, deviceID
+	typ := bytesToString(parts[1])
+	switch typ {
+	case sparkbNBIRTH, sparkbDBIRTH:
+		isBirth = true
+	case sparkbNDEATH, sparkbDDEATH:
+		isDeath = true
+	default:
+		return false, false, false
+	}
+	return isBirth, isDeath, isCertificate
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -4775,7 +4787,6 @@ func mqttDeliverMsgCbQoS0(sub *subscription, pc *client, _ *Account, subject, re
 		return
 	}
 
-	retain := false
 	hdr, msg := pc.msgParts(rmsg)
 	var topic []byte
 	if pc.isMqtt() {
@@ -4805,17 +4816,6 @@ func mqttDeliverMsgCbQoS0(sub *subscription, pc *client, _ *Account, subject, re
 			return
 		}
 
-		// [tck-id-conformance-mqtt-aware-nbirth-mqtt-retain] A Sparkplug Aware
-		// MQTT Server MUST make NBIRTH messages available on the topic:
-		// $sparkplug/certificates/namespace/group_id/NBIRTH/edge_node_id with
-		// the MQTT retain flag set to true
-		//
-		// [tck-id-conformance-mqtt-aware-dbirth-mqtt-retain] A Sparkplug Aware
-		// MQTT Server MUST make DBIRTH messages available on the topic:
-		// $sparkplug/certificates/namespace/group_id/DBIRTH/edge_node_id/device_id
-		// with the MQTT retain flag set to true
-		retain, _, _, _, _ = sparkbIsBirth(stringToBytes(subject), sparkbCertificatesPrefix)
-
 		// If size is more than what a MQTT client can handle, we should probably reject,
 		// for now just truncate.
 		if len(msg) > mqttMaxPayloadSize {
@@ -4825,7 +4825,7 @@ func mqttDeliverMsgCbQoS0(sub *subscription, pc *client, _ *Account, subject, re
 	}
 
 	// Message never has a packet identifier nor is marked as duplicate.
-	pc.mqttEnqueuePublishMsgTo(cc, sub, 0, 0, false, retain, topic, msg)
+	pc.mqttEnqueuePublishMsgTo(cc, sub, 0, 0, false, topic, msg)
 }
 
 // This is the callback attached to a JS durable subscription for a MQTT QoS 1+
@@ -4901,7 +4901,7 @@ func mqttDeliverMsgCbQoS12(sub *subscription, pc *client, _ *Account, subject, r
 	}
 
 	originalTopic := natsSubjectStrToMQTTTopic(strippedSubj)
-	pc.mqttEnqueuePublishMsgTo(cc, sub, pi, qos, dup, false, originalTopic, msg)
+	pc.mqttEnqueuePublishMsgTo(cc, sub, pi, qos, dup, originalTopic, msg)
 }
 
 func mqttDeliverPubRelCb(sub *subscription, pc *client, _ *Account, subject, reply string, rmsg []byte) {
@@ -4958,9 +4958,77 @@ func isMQTTReservedSubscription(subject string) bool {
 	return false
 }
 
+func sparkbReplaceDeathTimestamp(msg []byte) []byte {
+	const VARINT = 0
+	const TIMESTAMP = 1
+
+	orig := msg
+	buf := bytes.NewBuffer(make([]byte, 0, len(msg)+16)) // 16 bytes should be enough if we need to add a timestamp
+	writeDeathTimestamp := func() {
+		// [tck-id-conformance-mqtt-aware-ndeath-timestamp] A Sparkplug Aware
+		// MQTT Server MAY replace the timestamp of NDEATH messages. If it does,
+		// it MUST set the timestamp to the UTC time at which it attempts to
+		// deliver the NDEATH to subscribed clients
+		//
+		// sparkB spec: 6.4.1. Google Protocol Buffer Schema
+		//      optional uint64 timestamp = 1; // Timestamp at message sending time
+		//
+		// SparkplugB timestamps are milliseconds since epoch, represented as
+		// uint64 in go, transmitted as protobuf varint.
+		ts := uint64(time.Now().UnixMilli())
+		buf.Write(protoEncodeVarint(TIMESTAMP<<3 | VARINT))
+		buf.Write(protoEncodeVarint(ts))
+	}
+
+	for len(msg) > 0 {
+		fieldNumericID, fieldType, size, err := protoScanField(msg)
+		if err != nil {
+			return orig
+		}
+		if fieldType != VARINT || fieldNumericID != TIMESTAMP {
+			// Add the field as is
+			buf.Write(msg[:size])
+			msg = msg[size:]
+			continue
+		}
+
+		writeDeathTimestamp()
+
+		// Add the rest of the message as is, we are done
+		buf.Write(msg[size:])
+		return buf.Bytes()
+	}
+
+	// Add timestamp if we did not find one.
+	writeDeathTimestamp()
+
+	return buf.Bytes()
+}
+
 // Common function to mqtt delivery callbacks to serialize and send the message
 // to the `cc` client.
-func (c *client) mqttEnqueuePublishMsgTo(cc *client, sub *subscription, pi uint16, qos byte, dup, retain bool, topic, msg []byte) {
+func (c *client) mqttEnqueuePublishMsgTo(cc *client, sub *subscription, pi uint16, qos byte, dup bool, topic, msg []byte) {
+	// [tck-id-conformance-mqtt-aware-nbirth-mqtt-retain] A Sparkplug Aware
+	// MQTT Server MUST make NBIRTH messages available on the topic:
+	// $sparkplug/certificates/namespace/group_id/NBIRTH/edge_node_id with
+	// the MQTT retain flag set to true
+	//
+	// [tck-id-conformance-mqtt-aware-dbirth-mqtt-retain] A Sparkplug Aware
+	// MQTT Server MUST make DBIRTH messages available on the topic:
+	// $sparkplug/certificates/namespace/group_id/DBIRTH/edge_node_id/device_id
+	// with the MQTT retain flag set to true
+	//
+	// $sparkplug/certificates messages are sent as NATS messages, so we
+	// need to add the retain flag when sending them to MQTT ciients.
+
+	retain := false
+	isBirth, isDeath, isCertificate := sparkbParseBirthDeathTopic(topic)
+	if isBirth && qos == 0 {
+		retain = isCertificate
+	} else if isDeath && !isCertificate {
+		msg = sparkbReplaceDeathTimestamp(msg)
+	}
+
 	flags, headerBytes := mqttMakePublishHeader(pi, qos, dup, retain, topic, len(msg))
 
 	cc.mu.Lock()

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -191,14 +191,15 @@ const (
 )
 
 const (
-	sparkbNamespace = "spBv1.0"
-	sparkbNBIRTH    = "NBIRTH"
-	sparkbDBIRTH    = "DBIRTH"
+	sparkbNamespace    = "spBv1.0"
+	sparkbCertificates = "$sparkplug/certificates/spBv1.0"
+	sparkbNBIRTH       = "NBIRTH"
+	sparkbDBIRTH       = "DBIRTH"
 )
 
 var (
 	sparkbNamespacePrefix    = []byte("spBv1//0.")
-	sparkbCertificatesPrefix = []byte("$sparkplug.certificates.")
+	sparkbCertificatesPrefix = []byte("$sparkplug.certificates.spBv1//0.")
 )
 
 var (
@@ -4309,7 +4310,7 @@ func (c *client) mqttHandlePubRetain() {
 		// MQTT Server MUST make DBIRTH messages available on a topic of the
 		// form:
 		// $sparkplug/certificates/namespace/group_id/DBIRTH/edge_node_id/device_id
-		rm.Topic = fmt.Sprintf("$sparkplug/certificates/%s/%s/%s/%s", sparkbNamespace, groupID, typ, nodeID)
+		rm.Topic = fmt.Sprintf(sparkbCertificates+"/%s/%s/%s", groupID, typ, nodeID)
 		if deviceID != _EMPTY_ {
 			rm.Topic += "/" + deviceID
 		}
@@ -4621,7 +4622,7 @@ func sparkbIsBirth(natsSubject, prefix []byte) (is bool, typ, groupID, nodeID, d
 	if !bytes.HasPrefix(natsSubject, prefix) {
 		return false, "", "", "", ""
 	}
-	natsSubject = natsSubject[len(sparkbNamespacePrefix):]
+	natsSubject = natsSubject[len(prefix):]
 	parts := bytes.Split(natsSubject, []byte("."))
 	if len(parts) < 3 {
 		return false, "", "", "", ""

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -4297,10 +4297,18 @@ func (c *client) mqttHandlePubRetain() {
 		return
 
 	case isSparkbBirth:
-		// Spec [tck-id-conformance-mqtt-aware-nbirth-mqtt-topic]. A Sparkplug
-		// Aware MQTT Server MUST make NBIRTH messages available on a topic of
-		// the form:
-		// $sparkplug/certificates/namespace/group_id/NBIRTH/edge_node_id
+		// [tck-id-conformance-mqtt-aware-store] A Sparkplug Aware MQTT Server
+		// MUST store NBIRTH and DBIRTH messages as they pass through the MQTT
+		// Server.
+		//
+		// [tck-id-conformance-mqtt-aware-nbirth-mqtt-topic]. A Sparkplug Aware
+		// MQTT Server MUST make NBIRTH messages available on a topic of the
+		// form: $sparkplug/certificates/namespace/group_id/NBIRTH/edge_node_id
+		//
+		// [tck-id-conformance-mqtt-aware-dbirth-mqtt-topic] A Sparkplug Aware
+		// MQTT Server MUST make DBIRTH messages available on a topic of the
+		// form:
+		// $sparkplug/certificates/namespace/group_id/DBIRTH/edge_node_id/device_id
 		rm.Topic = fmt.Sprintf("$sparkplug/certificates/%s/%s/%s/%s", sparkbNamespace, groupID, typ, nodeID)
 		if deviceID != _EMPTY_ {
 			rm.Topic += "/" + deviceID
@@ -4794,8 +4802,15 @@ func mqttDeliverMsgCbQoS0(sub *subscription, pc *client, _ *Account, subject, re
 			return
 		}
 
-		// Messages on $sparkplug/certificates/... are to be published with the
-		// RETAIN flag on.
+		// [tck-id-conformance-mqtt-aware-nbirth-mqtt-retain] A Sparkplug Aware
+		// MQTT Server MUST make NBIRTH messages available on the topic:
+		// $sparkplug/certificates/namespace/group_id/NBIRTH/edge_node_id with
+		// the MQTT retain flag set to true
+		//
+		// [tck-id-conformance-mqtt-aware-dbirth-mqtt-retain] A Sparkplug Aware
+		// MQTT Server MUST make DBIRTH messages available on the topic:
+		// $sparkplug/certificates/namespace/group_id/DBIRTH/edge_node_id/device_id
+		// with the MQTT retain flag set to true
 		retain, _, _, _, _ = sparkbIsBirth(stringToBytes(subject), sparkbCertificatesPrefix)
 
 		// If size is more than what a MQTT client can handle, we should probably reject,

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -4622,17 +4622,17 @@ func mqttIsRetained(flags byte) bool {
 // MQTT topic like spBv1.0/{group_id}/{message_type}/{edge_node_id}/{device_id}
 func sparkbIsBirth(natsSubject, prefix []byte) (is bool, typ, groupID, nodeID, deviceID string) {
 	if !bytes.HasPrefix(natsSubject, prefix) {
-		return false, "", "", "", ""
+		return false, _EMPTY_, _EMPTY_, _EMPTY_, _EMPTY_
 	}
 	natsSubject = natsSubject[len(prefix):]
 	parts := bytes.Split(natsSubject, []byte("."))
 	if len(parts) < 3 {
-		return false, "", "", "", ""
+		return false, _EMPTY_, _EMPTY_, _EMPTY_, _EMPTY_
 	}
 	typ = string(parts[1])
 	isDevice := (typ == sparkbDBIRTH)
 	if typ != sparkbNBIRTH && !isDevice {
-		return false, "", "", "", ""
+		return false, _EMPTY_, _EMPTY_, _EMPTY_, _EMPTY_
 	}
 
 	groupID = string(natsSubjectToMQTTTopic(parts[0]))

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -7593,7 +7593,7 @@ func TestMQTTSparkbBirthHandling(t *testing.T) {
 			testMQTTCheckConnAck(t, test.r, mqttConnAckRCConnectionAccepted, false)
 
 			// Subscribne at QoS2 to make sure the messages are posted at QoS0 and
-			// not trucated to sub QoS.
+			// not truncated to sub QoS.
 			testMQTTSub(t, 0, test.mc, test.r, []*mqttFilter{{filter: test.topic, qos: 2}}, []byte{2})
 		}
 

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -1821,7 +1821,7 @@ func TestMQTTTopicAndSubjectConversion(t *testing.T) {
 				t.Fatalf("Expected subject %q got %q", test.natsSubject, toNATS)
 			}
 
-			res = natsSubjectToMQTTTopic(string(res))
+			res = natsSubjectToMQTTTopic(res)
 			backToMQTT := string(res)
 			if backToMQTT != test.mqttTopic {
 				t.Fatalf("Expected topic %q got %q (NATS conversion was %q)", test.mqttTopic, backToMQTT, toNATS)

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -7551,8 +7551,7 @@ func TestMQTTSparkbBirthHandling(t *testing.T) {
 	defer testMQTTShutdownServer(s)
 
 	// Publish an NBIRTH message. Make sure it is received as both the original
-	// subject, and as a $sparkplug/certificates one. Since BIRTH messages are
-	// QoS0, use a NATS client/subscriber to monitor.
+	// subject, and as a $sparkplug/certificates one.
 
 	const NBORN = "NODE BORN FAKE MESSAGE"
 	const DBORN = "DEVICE BORN FAKE MESSAGE"

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -7613,8 +7613,7 @@ func TestMQTTSparkbBirthHandling(t *testing.T) {
 	})
 
 	t.Run("$sparkplug messages retained", func(t *testing.T) {
-		// Connect/subscribe again, and m,ake sure that only retained messages are
-		// there.
+		// Connect/subscribe again, and make sure that only retained messages are there.
 		for i, test := range tests {
 			mc, r := testMQTTConnect(t, &mqttConnInfo{cleanSess: true, clientID: fmt.Sprintf("sub-%v", i+100)}, o.MQTT.Host, o.MQTT.Port)
 			defer mc.Close()

--- a/server/proto.go
+++ b/server/proto.go
@@ -1,0 +1,269 @@
+// Copyright 2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Inspired by https://github.com/protocolbuffers/protobuf-go/blob/master/encoding/protowire/wire.go
+
+package server
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+var errProtoInsufficient = errors.New("insufficient data to read a value")
+var errProtoOverflow = errors.New("too much data for a value")
+var errProtoInvalidFieldNumber = errors.New("invalid field number")
+
+func protoScanField(b []byte) (num, typ, size int, err error) {
+	num, typ, sizeTag, err := protoScanTag(b)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	b = b[sizeTag:]
+
+	sizeValue, err := protoScanFieldValue(typ, b)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return num, typ, sizeTag + sizeValue, nil
+}
+
+func protoScanTag(b []byte) (num, typ, size int, err error) {
+	tagint, size, err := protoScanVarint(b)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	// NOTE: MessageSet allows for larger field numbers than normal.
+	if (tagint >> 3) > uint64(math.MaxInt32) {
+		return 0, 0, 0, errProtoInvalidFieldNumber
+	}
+	num = int(tagint >> 3)
+	if num < 1 {
+		return 0, 0, 0, errProtoInvalidFieldNumber
+	}
+	typ = int(tagint & 7)
+
+	return num, typ, size, nil
+}
+
+func protoScanFieldValue(typ int, b []byte) (size int, err error) {
+	switch typ {
+	case 0:
+		_, size, err = protoScanVarint(b)
+	case 5: // fixed32
+		size = 4
+	case 1: // fixed64
+		size = 8
+	case 2: // length-delimited
+		size, err = protoScanBytes(b)
+	default:
+		return 0, fmt.Errorf("unsupported type: %d", typ)
+	}
+	return size, err
+}
+
+func protoScanVarint(b []byte) (v uint64, size int, err error) {
+	var y uint64
+	if len(b) <= 0 {
+		return 0, 0, errProtoInsufficient
+	}
+	v = uint64(b[0])
+	if v < 0x80 {
+		return v, 1, nil
+	}
+	v -= 0x80
+
+	if len(b) <= 1 {
+		return 0, 0, errProtoInsufficient
+	}
+	y = uint64(b[1])
+	v += y << 7
+	if y < 0x80 {
+		return v, 2, nil
+	}
+	v -= 0x80 << 7
+
+	if len(b) <= 2 {
+		return 0, 0, errProtoInsufficient
+	}
+	y = uint64(b[2])
+	v += y << 14
+	if y < 0x80 {
+		return v, 3, nil
+	}
+	v -= 0x80 << 14
+
+	if len(b) <= 3 {
+		return 0, 0, errProtoInsufficient
+	}
+	y = uint64(b[3])
+	v += y << 21
+	if y < 0x80 {
+		return v, 4, nil
+	}
+	v -= 0x80 << 21
+
+	if len(b) <= 4 {
+		return 0, 0, errProtoInsufficient
+	}
+	y = uint64(b[4])
+	v += y << 28
+	if y < 0x80 {
+		return v, 5, nil
+	}
+	v -= 0x80 << 28
+
+	if len(b) <= 5 {
+		return 0, 0, errProtoInsufficient
+	}
+	y = uint64(b[5])
+	v += y << 35
+	if y < 0x80 {
+		return v, 6, nil
+	}
+	v -= 0x80 << 35
+
+	if len(b) <= 6 {
+		return 0, 0, errProtoInsufficient
+	}
+	y = uint64(b[6])
+	v += y << 42
+	if y < 0x80 {
+		return v, 7, nil
+	}
+	v -= 0x80 << 42
+
+	if len(b) <= 7 {
+		return 0, 0, errProtoInsufficient
+	}
+	y = uint64(b[7])
+	v += y << 49
+	if y < 0x80 {
+		return v, 8, nil
+	}
+	v -= 0x80 << 49
+
+	if len(b) <= 8 {
+		return 0, 0, errProtoInsufficient
+	}
+	y = uint64(b[8])
+	v += y << 56
+	if y < 0x80 {
+		return v, 9, nil
+	}
+	v -= 0x80 << 56
+
+	if len(b) <= 9 {
+		return 0, 0, errProtoInsufficient
+	}
+	y = uint64(b[9])
+	v += y << 63
+	if y < 2 {
+		return v, 10, nil
+	}
+	return 0, 0, errProtoOverflow
+}
+
+func protoScanBytes(b []byte) (size int, err error) {
+	l, lenSize, err := protoScanVarint(b)
+	if err != nil {
+		return 0, err
+	}
+	if l > uint64(len(b[lenSize:])) {
+		return 0, errProtoInsufficient
+	}
+	return lenSize + int(l), nil
+}
+
+func protoEncodeVarint(v uint64) []byte {
+	b := make([]byte, 0, 10)
+	switch {
+	case v < 1<<7:
+		b = append(b, byte(v))
+	case v < 1<<14:
+		b = append(b,
+			byte((v>>0)&0x7f|0x80),
+			byte(v>>7))
+	case v < 1<<21:
+		b = append(b,
+			byte((v>>0)&0x7f|0x80),
+			byte((v>>7)&0x7f|0x80),
+			byte(v>>14))
+	case v < 1<<28:
+		b = append(b,
+			byte((v>>0)&0x7f|0x80),
+			byte((v>>7)&0x7f|0x80),
+			byte((v>>14)&0x7f|0x80),
+			byte(v>>21))
+	case v < 1<<35:
+		b = append(b,
+			byte((v>>0)&0x7f|0x80),
+			byte((v>>7)&0x7f|0x80),
+			byte((v>>14)&0x7f|0x80),
+			byte((v>>21)&0x7f|0x80),
+			byte(v>>28))
+	case v < 1<<42:
+		b = append(b,
+			byte((v>>0)&0x7f|0x80),
+			byte((v>>7)&0x7f|0x80),
+			byte((v>>14)&0x7f|0x80),
+			byte((v>>21)&0x7f|0x80),
+			byte((v>>28)&0x7f|0x80),
+			byte(v>>35))
+	case v < 1<<49:
+		b = append(b,
+			byte((v>>0)&0x7f|0x80),
+			byte((v>>7)&0x7f|0x80),
+			byte((v>>14)&0x7f|0x80),
+			byte((v>>21)&0x7f|0x80),
+			byte((v>>28)&0x7f|0x80),
+			byte((v>>35)&0x7f|0x80),
+			byte(v>>42))
+	case v < 1<<56:
+		b = append(b,
+			byte((v>>0)&0x7f|0x80),
+			byte((v>>7)&0x7f|0x80),
+			byte((v>>14)&0x7f|0x80),
+			byte((v>>21)&0x7f|0x80),
+			byte((v>>28)&0x7f|0x80),
+			byte((v>>35)&0x7f|0x80),
+			byte((v>>42)&0x7f|0x80),
+			byte(v>>49))
+	case v < 1<<63:
+		b = append(b,
+			byte((v>>0)&0x7f|0x80),
+			byte((v>>7)&0x7f|0x80),
+			byte((v>>14)&0x7f|0x80),
+			byte((v>>21)&0x7f|0x80),
+			byte((v>>28)&0x7f|0x80),
+			byte((v>>35)&0x7f|0x80),
+			byte((v>>42)&0x7f|0x80),
+			byte((v>>49)&0x7f|0x80),
+			byte(v>>56))
+	default:
+		b = append(b,
+			byte((v>>0)&0x7f|0x80),
+			byte((v>>7)&0x7f|0x80),
+			byte((v>>14)&0x7f|0x80),
+			byte((v>>21)&0x7f|0x80),
+			byte((v>>28)&0x7f|0x80),
+			byte((v>>35)&0x7f|0x80),
+			byte((v>>42)&0x7f|0x80),
+			byte((v>>49)&0x7f|0x80),
+			byte((v>>56)&0x7f|0x80),
+			1)
+	}
+	return b
+}


### PR DESCRIPTION
# SpakplugB-aware support. 

## TODO:
- [x] Add spec comments
- [x] Add go test
- [x] Resolve `[tck-id-conformance-mqtt-aware-nbirth-mqtt-retain]`, `[tck-id-conformance-mqtt-aware-dbirth-mqtt-retain]` issues
- [ ] Decide on a config option to enable SparkplugB awareness, get benchmark comparisons

## SPEC

[PDF](https://sparkplug.eclipse.org/specification/version/3.0/documents/sparkplug-specification-3.0.0.pdf)

#### 12.65. Sparkplug Compliant MQTT Server
- [x] [tck-id-conformance-mqtt-qos0] A Sparkplug conformant MQTT Server MUST support publish and
subscribe on QoS 0
- [x] [tck-id-conformance-mqtt-qos1] A Sparkplug conformant MQTT Server MUST support publish and
subscribe on QoS 1
- [x] [tck-id-conformance-mqtt-will-messages] A Sparkplug conformant MQTT Server MUST support all
133
aspects of Will Messages including use of the retain flag and QoS 1
- [x] [tck-id-conformance-mqtt-retained] A Sparkplug conformant MQTT Server MUST support all
aspects of the retain flag

#### 12.66. Sparkplug Aware MQTT Server
- [x] [tck-id-conformance-mqtt-aware-basic] A Sparkplug Aware MQTT Server MUST support all aspects
of a Sparkplug Compliant MQTT Server
- [x] [tck-id-conformance-mqtt-aware-store] A Sparkplug Aware MQTT Server MUST store NBIRTH and
DBIRTH messages as they pass through the MQTT Server
- [x] [tck-id-conformance-mqtt-aware-nbirth-mqtt-topic] A Sparkplug Aware MQTT Server MUST make
NBIRTH messages available on a topic of the form:
$sparkplug/certificates/namespace/group_id/NBIRTH/edge_node_id
- [x] [tck-id-conformance-mqtt-aware-nbirth-mqtt-retain] A Sparkplug Aware MQTT Server MUST make
NBIRTH messages available on the topic:
$sparkplug/certificates/namespace/group_id/NBIRTH/edge_node_id with the MQTT retain flag set to
true
- [x] [tck-id-conformance-mqtt-aware-dbirth-mqtt-topic] A Sparkplug Aware MQTT Server MUST make
DBIRTH messages available on a topic of the form:
$sparkplug/certificates/namespace/group_id/DBIRTH/edge_node_id/device_id
- [x] [tck-id-conformance-mqtt-aware-dbirth-mqtt-retain] A Sparkplug Aware MQTT Server MUST make
DBIRTH messages available on the topic:
$sparkplug/certificates/namespace/group_id/DBIRTH/edge_node_id/device_id with the MQTT retain
flag set to true
- [x] [tck-id-conformance-mqtt-aware-ndeath-timestamp] A Sparkplug Aware MQTT Server MAY replace
the timestmap of NDEATH messages. If it does, it MUST set the timestamp to the UTC time at which
it attempts to deliver the NDEATH to subscribed clients

## ISSUES:
- [x] `[tck-id-conformance-mqtt-aware-nbirth-mqtt-retain]`, `[tck-id-conformance-mqtt-aware-dbirth-mqtt-retain]` - not 100% clear from the spec if the messages should be published (only!) with the retained flag on, or should also be retained for future subscriptions (presently implemented). `[tck-id-conformance-mqtt-aware-store]` seems to suggest that they should indeed be stored as retained.
- [x] `[tck-id-conformance-mqtt-aware-ndeath-timestamp]` Not presently implemented. The spec says MAY, but TCK seems to require it. Adding re-writing the timestamp involves modifying protobuf payload, which would likely necessitate importing lots of go dependencies. Passed TCK (by faking the DEATH timestamp in the test node and device).
<img width="936" alt="image" src="https://github.com/nats-io/nats-server/assets/1187448/54f16873-705c-486b-90e6-5d55977757bb">
