### PR TITLE
[FIXED] Possible memory leak due to connections not being released

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -895,24 +895,26 @@ func (a *Account) addClient(c *client) int {
 	if a.clients != nil {
 		a.clients[c] = struct{}{}
 	}
-	added := n != len(a.clients)
-	if added {
-		if c.kind != CLIENT && c.kind != LEAF {
-			a.sysclients++
-		} else if c.kind == LEAF {
-			a.nleafs++
-		}
+	// If we did not add it, we are done
+	if n == len(a.clients) {
+		a.mu.Unlock()
+		return n
+	}
+	if c.kind != CLIENT && c.kind != LEAF {
+		a.sysclients++
+	} else if c.kind == LEAF {
+		a.nleafs++
 	}
 	a.mu.Unlock()
 
 	// If we added a new leaf use the list lock and add it to the list.
-	if added && c.kind == LEAF {
+	if c.kind == LEAF {
 		a.lmu.Lock()
 		a.lleafs = append(a.lleafs, c)
 		a.lmu.Unlock()
 	}
 
-	if c != nil && c.srv != nil && added {
+	if c != nil && c.srv != nil {
 		c.srv.accConnsUpdate(a)
 	}
 
@@ -977,31 +979,33 @@ func (a *Account) removeClient(c *client) int {
 	a.mu.Lock()
 	n := len(a.clients)
 	delete(a.clients, c)
-	removed := n != len(a.clients)
-	if removed {
-		if c.kind != CLIENT && c.kind != LEAF {
-			a.sysclients--
-		} else if c.kind == LEAF {
-			a.nleafs--
-			// Need to do cluster accounting here.
-			// Do cluster accounting if we are a hub.
-			if c.isHubLeafNode() {
-				cluster := c.remoteCluster()
-				if count := a.leafClusters[cluster]; count > 1 {
-					a.leafClusters[cluster]--
-				} else if count == 1 {
-					delete(a.leafClusters, cluster)
-				}
+	// If we did not actually remove it, we are done.
+	if n == len(a.clients) {
+		a.mu.Unlock()
+		return n
+	}
+	if c.kind != CLIENT && c.kind != LEAF {
+		a.sysclients--
+	} else if c.kind == LEAF {
+		a.nleafs--
+		// Need to do cluster accounting here.
+		// Do cluster accounting if we are a hub.
+		if c.isHubLeafNode() {
+			cluster := c.remoteCluster()
+			if count := a.leafClusters[cluster]; count > 1 {
+				a.leafClusters[cluster]--
+			} else if count == 1 {
+				delete(a.leafClusters, cluster)
 			}
 		}
 	}
 	a.mu.Unlock()
 
-	if removed && c.kind == LEAF {
+	if c.kind == LEAF {
 		a.removeLeafNode(c)
 	}
 
-	if c != nil && c.srv != nil && removed {
+	if c != nil && c.srv != nil {
 		c.srv.accConnsUpdate(a)
 	}
 

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1888,8 +1888,8 @@ func TestServerEventsStatsZ(t *testing.T) {
 	if m.Stats.Connections != 1 {
 		t.Fatalf("Did not match connections of 1, got %d", m.Stats.Connections)
 	}
-	if m.Stats.ActiveAccounts != 2 {
-		t.Fatalf("Did not match active accounts of 2, got %d", m.Stats.ActiveAccounts)
+	if m.Stats.ActiveAccounts != 1 {
+		t.Fatalf("Did not match active accounts of 1, got %d", m.Stats.ActiveAccounts)
 	}
 	if m.Stats.Sent.Msgs < 1 {
 		t.Fatalf("Did not match sent msgs of >=1, got %d", m.Stats.Sent.Msgs)
@@ -1919,8 +1919,8 @@ func TestServerEventsStatsZ(t *testing.T) {
 	if m2.Stats.Connections != 1 {
 		t.Fatalf("Did not match connections of 1, got %d", m2.Stats.Connections)
 	}
-	if m2.Stats.ActiveAccounts != 2 {
-		t.Fatalf("Did not match active accounts of 2, got %d", m2.Stats.ActiveAccounts)
+	if m2.Stats.ActiveAccounts != 1 {
+		t.Fatalf("Did not match active accounts of 1, got %d", m2.Stats.ActiveAccounts)
 	}
 	if m2.Stats.Sent.Msgs < 3 {
 		t.Fatalf("Did not match sent msgs of >= 3, got %d", m2.Stats.Sent.Msgs)
@@ -1946,8 +1946,8 @@ func TestServerEventsStatsZ(t *testing.T) {
 	if m3.Stats.Connections != 1 {
 		t.Fatalf("Did not match connections of 1, got %d", m3.Stats.Connections)
 	}
-	if m3.Stats.ActiveAccounts != 2 {
-		t.Fatalf("Did not match active accounts of 2, got %d", m3.Stats.ActiveAccounts)
+	if m3.Stats.ActiveAccounts != 1 {
+		t.Fatalf("Did not match active accounts of 1, got %d", m3.Stats.ActiveAccounts)
 	}
 	if m3.Stats.Sent.Msgs < 4 {
 		t.Fatalf("Did not match sent msgs of >= 4, got %d", m3.Stats.Sent.Msgs)

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1757,6 +1757,15 @@ func (s *Server) removeRemoteGatewayConnection(c *client) {
 	cid := c.cid
 	isOutbound := c.gw.outbound
 	gwName := c.gw.name
+	if isOutbound && c.gw.outsim != nil {
+		// We do this to allow the GC to release this connection.
+		// Since the map is used by the rest of the code without client lock,
+		// we can't simply set it to nil, instead, just make sure we empty it.
+		c.gw.outsim.Range(func(k, _ any) bool {
+			c.gw.outsim.Delete(k)
+			return true
+		})
+	}
 	c.mu.Unlock()
 
 	gw := s.gateway
@@ -1793,6 +1802,7 @@ func (s *Server) removeRemoteGatewayConnection(c *client) {
 				qSubsRemoved++
 			}
 		}
+		c.subs = nil
 		c.mu.Unlock()
 		// Update total count of qsubs in remote gateways.
 		atomic.AddInt64(&c.srv.gateway.totalQSubs, -qSubsRemoved)
@@ -1807,6 +1817,7 @@ func (s *Server) removeRemoteGatewayConnection(c *client) {
 		for _, sub := range c.subs {
 			subs = append(subs, sub)
 		}
+		c.subs = nil
 		c.mu.Unlock()
 		for _, sub := range subs {
 			c.removeReplySub(sub)
@@ -1918,6 +1929,10 @@ func (c *client) processGatewayRUnsub(arg []byte) error {
 		return nil
 	}
 	defer c.mu.Unlock()
+	// If closed, c.subs map will be nil, so bail out.
+	if c.isClosed() {
+		return nil
+	}
 
 	ei, _ := c.gw.outsim.Load(accName)
 	if ei != nil {
@@ -2024,6 +2039,10 @@ func (c *client) processGatewayRSub(arg []byte) error {
 		return nil
 	}
 	defer c.mu.Unlock()
+	// If closed, c.subs map will be nil, so bail out.
+	if c.isClosed() {
+		return nil
+	}
 
 	ei, _ := c.gw.outsim.Load(bytesToString(accName))
 	// We should always have an existing entry for plain subs because
@@ -2678,6 +2697,8 @@ func (c *client) sendMsgToGateways(acc *Account, msg, subject, reply []byte, qgr
 	}
 	// Done with subscription, put back to pool. We don't need
 	// to reset content since we explicitly set when using it.
+	// However, make sure to not hold a reference to a connection.
+	sub.client = nil
 	subPool.Put(sub)
 	return didDeliver
 }

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -96,6 +96,8 @@ type leaf struct {
 	tsubt *time.Timer
 	// Selected compression mode, which may be different from the server configured mode.
 	compression string
+	// This is for GW map replies.
+	gwSub *subscription
 }
 
 // Used for remote (solicited) leafnodes.
@@ -1695,9 +1697,16 @@ func (s *Server) addLeafNodeConnection(c *client, srvName, clusterName string, c
 func (s *Server) removeLeafNodeConnection(c *client) {
 	c.mu.Lock()
 	cid := c.cid
-	if c.leaf != nil && c.leaf.tsubt != nil {
-		c.leaf.tsubt.Stop()
-		c.leaf.tsubt = nil
+	if c.leaf != nil {
+		if c.leaf.tsubt != nil {
+			c.leaf.tsubt.Stop()
+			c.leaf.tsubt = nil
+		}
+		if c.leaf.gwSub != nil {
+			s.gwLeafSubs.Remove(c.leaf.gwSub)
+			// We need to set this to nil for GC to release the connection
+			c.leaf.gwSub = nil
+		}
 	}
 	c.mu.Unlock()
 	s.mu.Lock()
@@ -1993,7 +2002,10 @@ func (s *Server) initLeafNodeSmapAndSendSubs(c *client) {
 	if c.isSpokeLeafNode() {
 		// Add a fake subscription for this solicited leafnode connection
 		// so that we can send back directly for mapped GW replies.
-		c.srv.gwLeafSubs.Insert(&subscription{client: c, subject: []byte(gwReplyPrefix + ">")})
+		// We need to keep track of this subscription so it can be removed
+		// when the connection is closed so that the GC can release it.
+		c.leaf.gwSub = &subscription{client: c, subject: []byte(gwReplyPrefix + ">")}
+		c.srv.gwLeafSubs.Insert(c.leaf.gwSub)
 	}
 
 	// Now walk the results and add them to our smap

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -5067,7 +5067,9 @@ func (sess *mqttSession) processJSConsumer(c *client, subject, sid string,
 			// The JS durable consumer's delivery subject is on a NUID of
 			// the form: mqttSubPrefix + <nuid>. It is also used as the sid
 			// for the NATS subscription, so use that for the lookup.
+			c.mu.Lock()
 			sub := c.subs[cc.DeliverSubject]
+			c.mu.Unlock()
 
 			sess.mu.Lock()
 			delete(sess.cons, sid)

--- a/server/route.go
+++ b/server/route.go
@@ -1162,7 +1162,7 @@ func (c *client) removeRemoteSubs() {
 	c.mu.Lock()
 	srv := c.srv
 	subs := c.subs
-	c.subs = make(map[string]*subscription)
+	c.subs = nil
 	c.mu.Unlock()
 
 	for key, sub := range subs {

--- a/server/server.go
+++ b/server/server.go
@@ -3331,6 +3331,8 @@ func (s *Server) saveClosedClient(c *client, nc net.Conn, reason ClosedState) {
 		for _, sub := range c.subs {
 			cc.subs = append(cc.subs, newSubDetail(sub))
 		}
+		// Now set this to nil to allow connection to be released.
+		c.subs = nil
 	}
 	// Hold user as well.
 	cc.user = c.getRawAuthUser()


### PR DESCRIPTION
The main issue for router/gateway connections were that they would be registered with the global account but never removed from there, which would cause the connection to be retained. The memory leak was apparent in one user setup with large amount of subscriptions that were transfered to a slow gateway, causing accumulation of partial buffers before the connection was dropped.

For gateway connections, we also needed to clean the outbound's map since it can contain sublist referencing its own connection. Same for subscriptions in c.subs.

Another found cause for retained connection is with leafnode where we are using a subscription referencing the leafnode connection that was globally registered in a global sublist but never removed.

Also the connection's c.out.sg (a `*Cond`) needed to be set to `nil` when the connection is closed. Without that, it seems that the connection would not be released (at least based on experimentation). We now make sure that c.out.sg is not nil before sending a signal.

The bottom line is that it looks like having an object referencing itself in some way, prevents the GC from releasing the object, even if the "top level" object is no longer reachable. For instance, suppose `obj.someField = obj` seem to prevent the GC from releasing `obj`, even if `obj` itself is no longer referenced.

The original issue/PR (#5212) was simply cleaning the c.out.wnb, but the way it was done was racy since c.out.wnb is used without lock in flushOutbound. Once the retain/release issue is fixed, cleaning this buffer is not really required (but good practice especially if not running with GOMEMLIMIT), so we take care of cleaning this up, but under the protection of the flushOutbound flag. If set, flushAndClose() will not do the cleaning, flushOutbound will do it.

Relates to #5212

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
