### PR TITLE
Constant-time evaluation of non-bcrypt passwords

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"crypto/sha256"
+	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -1418,8 +1419,14 @@ func comparePasswords(serverPassword, clientPassword string) bool {
 		if err := bcrypt.CompareHashAndPassword([]byte(serverPassword), []byte(clientPassword)); err != nil {
 			return false
 		}
-	} else if serverPassword != clientPassword {
-		return false
+	} else {
+		// stringToBytes should be constant-time near enough compared to
+		// turning a string into []byte normally.
+		spass := stringToBytes(serverPassword)
+		cpass := stringToBytes(clientPassword)
+		if subtle.ConstantTimeCompare(spass, cpass) == 0 {
+			return false
+		}
 	}
 	return true
 }


### PR DESCRIPTION
This ensures that comparison of non-bcrypted passwords is done in constant time, whereas otherwise timing information may be apparent on a network with next to no jitter.

Reported-by: Trail of Bits <https://www.trailofbits.com>
Signed-off-by: Neil Twigg <neil@nats.io>
