### PR TITLE
(2.12) [ADD] no responders return the original subject

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4211,7 +4211,8 @@ func (c *client) processInboundClientMsg(msg []byte) (bool, bool) {
 		c.mu.Lock()
 		if c.opts.NoResponders {
 			if sub := c.subForReply(c.pa.reply); sub != nil {
-				proto := fmt.Sprintf("HMSG %s %s 16 16\r\nNATS/1.0 503\r\n\r\n\r\n", c.pa.reply, sub.sid)
+				hdrLen := 32 /* header without the subject */ + len(c.pa.subject)
+				proto := fmt.Sprintf("HMSG %s %s %d %d\r\nNATS/1.0 503\r\nNats-Subject: %s\r\n\r\n\r\n", c.pa.reply, sub.sid, hdrLen, hdrLen, c.pa.subject)
 				c.queueOutbound([]byte(proto))
 				c.addToPCD(c)
 			}

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -251,7 +251,7 @@ func TestClientNoResponderSupport(t *testing.T) {
 	if len(am) == 0 {
 		t.Fatalf("Did not get a match for %q", l)
 	}
-	checkPayload(cr, []byte("NATS/1.0 503\r\n\r\n"), t)
+	checkPayload(cr, []byte("NATS/1.0 503\r\nNats-Subject: foo\r\n\r\n\r\n"), t)
 }
 
 func TestServerHeaderSupport(t *testing.T) {


### PR DESCRIPTION
<!-- Please make sure to read CONTRIBUTING.md, then delete this notice and replace it with your PR description. The below sign-off certifies that the contribution is your original work and that you license the work to the project under the Apache-2.0 license. We cannot accept contributions without it. -->

Using [Request-Reply](https://docs.nats.io/nats-concepts/core-nats/reqreply) is very useful.

When using Request with multiple replays, it is difficult to know when the requester loses interest in the replays.
Today, Nats returns an error 503 to the replay subject without any extra information.


Signed-off-by: Ramon Berrutti <ramonberrutti@gmail.com>
