### PR TITLE
There is a useless memory allocation

### DIFF
--- a/server/parser.go
+++ b/server/parser.go
@@ -495,8 +495,10 @@ func (c *client) parse(buf []byte) error {
 			// Check for mappings.
 			if (c.kind == CLIENT || c.kind == LEAF) && c.in.flags.isSet(hasMappings) {
 				changed := c.selectMappedSubject()
-				if (trace || mt != nil) && changed {
-					c.traceInOp("MAPPING", []byte(fmt.Sprintf("%s -> %s", c.pa.mapped, c.pa.subject)))
+				if changed {
+					if trace {
+						c.traceInOp("MAPPING", []byte(fmt.Sprintf("%s -> %s", c.pa.mapped, c.pa.subject)))
+					}
 					// c.pa.subject is the subject the original is now mapped to.
 					mt.addSubjectMappingEvent(c.pa.subject)
 				}


### PR DESCRIPTION
When trace flags is closed and trace header is set, it leads to useless string memory allocation

Signed-off-by:  chenjpu <chenjpu@gmail.com>
