### PR TITLE
Fix some missing mutex unlocks in filestore and streams

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -5611,6 +5611,7 @@ func (mset *stream) swapSigSubs(o *consumer, newFilters []string) {
 
 	if o.closed || o.mset == nil {
 		o.mu.Unlock()
+		mset.clsMu.Unlock()
 		return
 	}
 


### PR DESCRIPTION
These error conditions didn't release held locks.

Reported-by: Trail of Bits <https://www.trailofbits.com>
Signed-off-by: Neil Twigg <neil@nats.io>