### PR TITLE
[IMPROVED] Interest based streams and consumers

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2830,10 +2830,10 @@ func (o *consumer) processAckMsg(sseq, dseq, dc uint64, doSample bool) {
 						break
 					}
 				}
-				// If nothing left set to current delivered.
-				if len(o.pending) == 0 {
-					o.adflr, o.asflr = o.dseq-1, o.sseq-1
-				}
+			}
+			// If nothing left set to current delivered.
+			if len(o.pending) == 0 {
+				o.adflr, o.asflr = o.dseq-1, o.sseq-1
 			}
 		}
 		// We do these regardless.
@@ -5458,7 +5458,7 @@ func (o *consumer) checkStateForInterestStream() error {
 	// See if we need to process this update if our parent stream is not a limits policy stream.
 	mset := o.mset
 	shouldProcessState := mset != nil && o.retention != LimitsPolicy
-	if o.closed || !shouldProcessState {
+	if o.closed || !shouldProcessState || o.store == nil {
 		o.mu.RUnlock()
 		return nil
 	}

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1947,16 +1947,7 @@ func (s *Server) jsStreamInfoRequest(sub *subscription, c *client, a *Account, s
 		}
 	}
 
-	mset.mu.RLock()
-	config := mset.cfg
-	checkAcks := config.Retention != LimitsPolicy && mset.hasLimitsSet()
-	mset.mu.RUnlock()
-
-	// Check if we are a clustered interest retention stream with limits.
-	// If so, check ack floors against our state.
-	if checkAcks {
-		mset.checkInterestState()
-	}
+	config := mset.config()
 
 	resp.StreamInfo = &StreamInfo{
 		Created:    mset.createdTime(),
@@ -4302,7 +4293,7 @@ func (s *Server) jsConsumerInfoRequest(sub *subscription, c *client, _ *Account,
 		return
 	}
 
-	// If we are in clustered mode we need to be the stream leader to proceed.
+	// If we are in clustered mode we need to be the consumer leader to proceed.
 	if s.JetStreamIsClustered() {
 		// Check to make sure the consumer is assigned.
 		js, cc := s.getJetStreamCluster()

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -7085,7 +7085,6 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 
 		nc, js := jsClientConnect(t, c.randomServer())
 		defer nc.Close()
-		t.Logf("Host: %v", nc.ConnectedUrl())
 
 		cnc, cjs := jsClientConnect(t, c.randomServer())
 		defer cnc.Close()
@@ -7153,7 +7152,6 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 						pjs.Publish(subject, payload, msgID, nats.AckWait(250*time.Millisecond))
 					}
 				}
-				t.Logf("Stopped publishing.")
 			}()
 		}
 
@@ -7195,7 +7193,7 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 				cpnc, cpjs := jsClientConnect(t, c.randomServer())
 				defer cpnc.Close()
 
-				psub, err := cpjs.PullSubscribe(subject, consumer, mp)
+				psub, err := cpjs.PullSubscribe(subject, consumer, mp, mw, aw)
 				require_NoError(t, err)
 
 				time.AfterFunc(15*time.Second, func() {
@@ -7250,7 +7248,7 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 				cpnc, cpjs := jsClientConnect(t, c.randomServer())
 				defer cpnc.Close()
 
-				psub, err := cpjs.PullSubscribe(subject, consumer, mp)
+				psub, err := cpjs.PullSubscribe(subject, consumer, mp, mw, aw)
 				if err != nil {
 					t.Logf("ERROR: %v", err)
 					continue
@@ -7312,9 +7310,7 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 					t.Logf("Disconnecting routes from %v", s.Name())
 					s.mu.Lock()
 					for _, conns := range s.routes {
-						for _, r := range conns {
-							routes = append(routes, r)
-						}
+						routes = append(routes, conns...)
 					}
 					s.mu.Unlock()
 					for _, r := range routes {
@@ -7341,7 +7337,6 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 						return
 					default:
 					}
-
 					// Force reconnect clients from one of the servers.
 					s := c.servers[rand.Intn(len(c.servers))]
 					reconnectClients(s)
@@ -7419,8 +7414,7 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 			jsz, err := srv.Jsz(&JSzOptions{Accounts: true, Streams: true, Consumer: true})
 			require_NoError(t, err)
 			if len(jsz.AccountDetails) > 0 && len(jsz.AccountDetails[0].Streams) > 0 {
-				details := jsz.AccountDetails[0]
-				stream := details.Streams[0]
+				stream := jsz.AccountDetails[0].Streams[0]
 				return &stream
 			}
 			t.Error("Could not find account details")
@@ -7435,7 +7429,7 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 				return fmt.Errorf("no leader found for stream")
 			}
 			streamLeader := getStreamDetails(t, leaderSrv)
-			errs := make([]error, 0)
+			var errs []error
 			for _, srv := range c.servers {
 				if srv == leaderSrv {
 					// Skip self
@@ -7445,24 +7439,25 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 				if stream == nil {
 					return fmt.Errorf("stream not found")
 				}
+
 				if stream.State.Msgs != streamLeader.State.Msgs {
 					err := fmt.Errorf("Leader %v has %d messages, Follower %v has %d messages",
 						stream.Cluster.Leader, streamLeader.State.Msgs,
-						srv.Name(), stream.State.Msgs,
+						srv, stream.State.Msgs,
 					)
 					errs = append(errs, err)
 				}
 				if stream.State.FirstSeq != streamLeader.State.FirstSeq {
 					err := fmt.Errorf("Leader %v FirstSeq is %d, Follower %v is at %d",
 						stream.Cluster.Leader, streamLeader.State.FirstSeq,
-						srv.Name(), stream.State.FirstSeq,
+						srv, stream.State.FirstSeq,
 					)
 					errs = append(errs, err)
 				}
 				if stream.State.LastSeq != streamLeader.State.LastSeq {
 					err := fmt.Errorf("Leader %v LastSeq is %d, Follower %v is at %d",
 						stream.Cluster.Leader, streamLeader.State.LastSeq,
-						srv.Name(), stream.State.LastSeq,
+						srv, stream.State.LastSeq,
 					)
 					errs = append(errs, err)
 				}
@@ -7471,6 +7466,35 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 				return errors.Join(errs...)
 			}
 			return nil
+		}
+
+		checkMsgsEqual := func(t *testing.T) {
+			// These have already been checked to be the same for all streams.
+			state := getStreamDetails(t, c.streamLeader("js", sc.Name)).State
+			// Gather all the streams.
+			var msets []*stream
+			for _, s := range c.servers {
+				acc, err := s.LookupAccount("js")
+				require_NoError(t, err)
+				mset, err := acc.lookupStream(sc.Name)
+				require_NoError(t, err)
+				msets = append(msets, mset)
+			}
+			for seq := state.FirstSeq; seq <= state.LastSeq; seq++ {
+				var msgId string
+				var smv StoreMsg
+				for _, mset := range msets {
+					mset.mu.RLock()
+					sm, err := mset.store.LoadMsg(seq, &smv)
+					mset.mu.RUnlock()
+					require_NoError(t, err)
+					if msgId == _EMPTY_ {
+						msgId = string(sm.hdr)
+					} else if msgId != string(sm.hdr) {
+						t.Fatalf("MsgIds do not match for seq %d: %q vs %q", seq, msgId, sm.hdr)
+					}
+				}
+			}
 		}
 
 		// Check state of streams and consumers.
@@ -7487,9 +7511,14 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 
 		// If clustered, check whether leader and followers have drifted.
 		if sc.Replicas > 1 {
-			checkFor(t, 3*time.Minute, 100*time.Millisecond, func() error {
+			// If we have drifted do not have to wait too long, usually its stuck for good.
+			checkFor(t, time.Minute, time.Second, func() error {
 				return checkState(t)
 			})
+			// If we succeeded now let's check that all messages are also the same.
+			// We may have no messages but for tests that do we make sure each msg is the same
+			// across all replicas.
+			checkMsgsEqual(t)
 		}
 
 		wg.Wait()

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -7040,8 +7040,409 @@ func TestJetStreamClusterConsumerPauseSurvivesRestart(t *testing.T) {
 }
 
 func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
+	type testParams struct {
+		restartAny     bool
+		restartLeader  bool
+		rolloutRestart bool
+		ldmRestart     bool
+		restarts       int
+		checkHealthz   bool
+	}
+	test := func(t *testing.T, params *testParams, sc *nats.StreamConfig) {
+		conf := `
+		listen: 127.0.0.1:-1
+		server_name: %s
+		jetstream: {
+			store_dir: '%s',
+		}
+		cluster {
+			name: %s
+			listen: 127.0.0.1:%d
+			routes = [%s]
+		}
+		server_tags: ["test"]
+		system_account: sys
+		no_auth_user: js
+		accounts {
+			sys { users = [ { user: sys, pass: sys } ] }
+			js {
+				jetstream = enabled
+				users = [ { user: js, pass: js } ]
+		    }
+		}`
+		c := createJetStreamClusterWithTemplate(t, conf, sc.Name, 3)
+		defer c.shutdown()
+
+		// Update lame duck duration for all servers.
+		for _, s := range c.servers {
+			s.optsMu.Lock()
+			s.opts.LameDuckDuration = 5 * time.Second
+			s.opts.LameDuckGracePeriod = -5 * time.Second
+			s.optsMu.Unlock()
+		}
+
+		nc, js := jsClientConnect(t, c.randomServer())
+		defer nc.Close()
+		t.Logf("Host: %v", nc.ConnectedUrl())
+
+		cnc, cjs := jsClientConnect(t, c.randomServer())
+		defer cnc.Close()
+
+		_, err := js.AddStream(sc)
+		require_NoError(t, err)
+
+		pctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Start producers
+		var wg sync.WaitGroup
+
+		// First call is just to create the pull subscribers.
+		mp := nats.MaxAckPending(10000)
+		mw := nats.PullMaxWaiting(1000)
+		aw := nats.AckWait(5 * time.Second)
+
+		for i := 0; i < 10; i++ {
+			for _, partition := range []string{"EEEEE"} {
+				subject := fmt.Sprintf("MSGS.%s.*.H.100XY.*.*.WQ.00000000000%d", partition, i)
+				consumer := fmt.Sprintf("consumer:%s:%d", partition, i)
+				_, err := cjs.PullSubscribe(subject, consumer, mp, mw, aw)
+				require_NoError(t, err)
+			}
+		}
+
+		// Create a single consumer that does no activity.
+		// Make sure we still calculate low ack properly and cleanup etc.
+		_, err = cjs.PullSubscribe("MSGS.ZZ.>", "consumer:ZZ:0", mp, mw, aw)
+		require_NoError(t, err)
+
+		subjects := []string{
+			"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000000",
+			"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000001",
+			"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000002",
+			"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000003",
+			"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000004",
+			"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000005",
+			"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000006",
+			"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000007",
+			"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000008",
+			"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000009",
+		}
+		payload := []byte(strings.Repeat("A", 1024))
+
+		for i := 0; i < 50; i++ {
+			wg.Add(1)
+			go func() {
+				pnc, pjs := jsClientConnect(t, c.randomServer())
+				defer pnc.Close()
+
+				for i := 1; i < 200_000; i++ {
+					select {
+					case <-pctx.Done():
+						wg.Done()
+						return
+					default:
+					}
+					for _, subject := range subjects {
+						// Send each message a few times.
+						msgID := nats.MsgId(nuid.Next())
+						pjs.PublishAsync(subject, payload, msgID)
+						pjs.Publish(subject, payload, msgID, nats.AckWait(250*time.Millisecond))
+						pjs.Publish(subject, payload, msgID, nats.AckWait(250*time.Millisecond))
+					}
+				}
+				t.Logf("Stopped publishing.")
+			}()
+		}
+
+		// Rogue publisher that sends the same msg ID everytime.
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				pnc, pjs := jsClientConnect(t, c.randomServer())
+				defer pnc.Close()
+
+				msgID := nats.MsgId("1234567890")
+				for i := 1; ; i++ {
+					select {
+					case <-pctx.Done():
+						wg.Done()
+						return
+					default:
+					}
+					for _, subject := range subjects {
+						// Send each message a few times.
+						pjs.PublishAsync(subject, payload, msgID, nats.RetryAttempts(0), nats.RetryWait(0))
+						pjs.Publish(subject, payload, msgID, nats.AckWait(1*time.Millisecond), nats.RetryAttempts(0), nats.RetryWait(0))
+						pjs.Publish(subject, payload, msgID, nats.AckWait(1*time.Millisecond), nats.RetryAttempts(0), nats.RetryWait(0))
+					}
+				}
+			}()
+		}
+
+		// Let enough messages into the stream then start consumers.
+		time.Sleep(15 * time.Second)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		defer cancel()
+
+		for i := 0; i < 10; i++ {
+			subject := fmt.Sprintf("MSGS.EEEEE.*.H.100XY.*.*.WQ.00000000000%d", i)
+			consumer := fmt.Sprintf("consumer:EEEEE:%d", i)
+			for n := 0; n < 5; n++ {
+				cpnc, cpjs := jsClientConnect(t, c.randomServer())
+				defer cpnc.Close()
+
+				psub, err := cpjs.PullSubscribe(subject, consumer, mp)
+				require_NoError(t, err)
+
+				time.AfterFunc(15*time.Second, func() {
+					cpnc.Close()
+				})
+
+				wg.Add(1)
+				go func() {
+					tick := time.NewTicker(1 * time.Millisecond)
+					for {
+						if cpnc.IsClosed() {
+							wg.Done()
+							return
+						}
+						select {
+						case <-ctx.Done():
+							wg.Done()
+							return
+						case <-tick.C:
+							// Fetch 1 first, then if no errors Fetch 100.
+							msgs, err := psub.Fetch(1, nats.MaxWait(200*time.Millisecond))
+							if err != nil {
+								continue
+							}
+							for _, msg := range msgs {
+								msg.Ack()
+							}
+							msgs, err = psub.Fetch(100, nats.MaxWait(200*time.Millisecond))
+							if err != nil {
+								continue
+							}
+							for _, msg := range msgs {
+								msg.Ack()
+							}
+							msgs, err = psub.Fetch(1000, nats.MaxWait(200*time.Millisecond))
+							if err != nil {
+								continue
+							}
+							for _, msg := range msgs {
+								msg.Ack()
+							}
+						}
+					}
+				}()
+			}
+		}
+
+		for i := 0; i < 10; i++ {
+			subject := fmt.Sprintf("MSGS.EEEEE.*.H.100XY.*.*.WQ.00000000000%d", i)
+			consumer := fmt.Sprintf("consumer:EEEEE:%d", i)
+			for n := 0; n < 10; n++ {
+				cpnc, cpjs := jsClientConnect(t, c.randomServer())
+				defer cpnc.Close()
+
+				psub, err := cpjs.PullSubscribe(subject, consumer, mp)
+				if err != nil {
+					t.Logf("ERROR: %v", err)
+					continue
+				}
+
+				wg.Add(1)
+				go func() {
+					tick := time.NewTicker(1 * time.Millisecond)
+					for {
+						select {
+						case <-ctx.Done():
+							wg.Done()
+							return
+						case <-tick.C:
+							// Fetch 1 first, then if no errors Fetch 100.
+							msgs, err := psub.Fetch(1, nats.MaxWait(200*time.Millisecond))
+							if err != nil {
+								continue
+							}
+							for _, msg := range msgs {
+								msg.Ack()
+							}
+							msgs, err = psub.Fetch(100, nats.MaxWait(200*time.Millisecond))
+							if err != nil {
+								continue
+							}
+							for _, msg := range msgs {
+								msg.Ack()
+							}
+
+							msgs, err = psub.Fetch(1000, nats.MaxWait(200*time.Millisecond))
+							if err != nil {
+								continue
+							}
+							for _, msg := range msgs {
+								msg.Ack()
+							}
+						}
+					}
+				}()
+			}
+		}
+
+		time.AfterFunc(10*time.Second, func() {
+			for i := 0; i < params.restarts; i++ {
+				switch {
+				case params.restartLeader:
+					// Find server leader of the stream and restart it.
+					s := c.streamLeader("js", sc.Name)
+					if params.ldmRestart {
+						s.lameDuckMode()
+					} else {
+						s.Shutdown()
+					}
+					s.WaitForShutdown()
+					c.restartServer(s)
+				case params.restartAny:
+					s := c.servers[rand.Intn(len(c.servers))]
+					if params.ldmRestart {
+						s.lameDuckMode()
+					} else {
+						s.Shutdown()
+					}
+					s.WaitForShutdown()
+					c.restartServer(s)
+				case params.rolloutRestart:
+					for _, s := range c.servers {
+						if params.ldmRestart {
+							s.lameDuckMode()
+						} else {
+							s.Shutdown()
+						}
+						s.WaitForShutdown()
+						c.restartServer(s)
+
+						if params.checkHealthz {
+							hctx, hcancel := context.WithTimeout(ctx, 15*time.Second)
+							defer hcancel()
+
+							for range time.NewTicker(2 * time.Second).C {
+								select {
+								case <-hctx.Done():
+								default:
+								}
+
+								status := s.healthz(nil)
+								if status.StatusCode == 200 {
+									break
+								}
+							}
+						}
+					}
+				}
+				c.waitOnClusterReady()
+			}
+		})
+
+		// Wait until context is done then check state.
+		<-ctx.Done()
+
+		var consumerPending int
+		for i := 0; i < 10; i++ {
+			ci, err := js.ConsumerInfo(sc.Name, fmt.Sprintf("consumer:EEEEE:%d", i))
+			require_NoError(t, err)
+			consumerPending += int(ci.NumPending)
+		}
+
+		getStreamDetails := func(t *testing.T, srv *Server) *StreamDetail {
+			t.Helper()
+			jsz, err := srv.Jsz(&JSzOptions{Accounts: true, Streams: true, Consumer: true})
+			require_NoError(t, err)
+			if len(jsz.AccountDetails) > 0 && len(jsz.AccountDetails[0].Streams) > 0 {
+				details := jsz.AccountDetails[0]
+				stream := details.Streams[0]
+				return &stream
+			}
+			t.Error("Could not find account details")
+			return nil
+		}
+
+		checkState := func(t *testing.T) error {
+			t.Helper()
+
+			leaderSrv := c.streamLeader("js", sc.Name)
+			if leaderSrv == nil {
+				return fmt.Errorf("no leader found for stream")
+			}
+			streamLeader := getStreamDetails(t, leaderSrv)
+			errs := make([]error, 0)
+			for _, srv := range c.servers {
+				if srv == leaderSrv {
+					// Skip self
+					continue
+				}
+				stream := getStreamDetails(t, srv)
+				if stream == nil {
+					return fmt.Errorf("stream not found")
+				}
+				if stream.State.Msgs != streamLeader.State.Msgs {
+					err := fmt.Errorf("Leader %v has %d messages, Follower %v has %d messages",
+						stream.Cluster.Leader, streamLeader.State.Msgs,
+						srv.Name(), stream.State.Msgs,
+					)
+					errs = append(errs, err)
+				}
+				if stream.State.FirstSeq != streamLeader.State.FirstSeq {
+					err := fmt.Errorf("Leader %v FirstSeq is %d, Follower %v is at %d",
+						stream.Cluster.Leader, streamLeader.State.FirstSeq,
+						srv.Name(), stream.State.FirstSeq,
+					)
+					errs = append(errs, err)
+				}
+				if stream.State.LastSeq != streamLeader.State.LastSeq {
+					err := fmt.Errorf("Leader %v LastSeq is %d, Follower %v is at %d",
+						stream.Cluster.Leader, streamLeader.State.LastSeq,
+						srv.Name(), stream.State.LastSeq,
+					)
+					errs = append(errs, err)
+				}
+			}
+			if len(errs) > 0 {
+				return errors.Join(errs...)
+			}
+			return nil
+		}
+
+		// Check state of streams and consumers.
+		si, err := js.StreamInfo(sc.Name)
+		require_NoError(t, err)
+
+		streamPending := int(si.State.Msgs)
+		if streamPending != consumerPending {
+			t.Errorf("Unexpected number of pending messages, stream=%d, consumers=%d", streamPending, consumerPending)
+		}
+
+		// If clustered, check whether leader and followers have drifted.
+		if sc.Replicas > 1 {
+			checkFor(t, 3*time.Minute, 100*time.Millisecond, func() error {
+				return checkState(t)
+			})
+		}
+	}
+
+	// Setting up test variations below:
+	//
+	// File based with single replica and discard old policy.
 	t.Run("R1F", func(t *testing.T) {
-		testJetStreamClusterWorkQueueStreamOrphanIssue(t, &nats.StreamConfig{
+		params := &testParams{
+			restartAny:     true,
+			ldmRestart:     false,
+			rolloutRestart: false,
+			restarts:       1,
+		}
+		test(t, params, &nats.StreamConfig{
 			Name:        "OWQTEST_R1F",
 			Subjects:    []string{"MSGS.>"},
 			Replicas:    1,
@@ -7055,8 +7456,17 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 			},
 		})
 	})
+
+	// Clustered memory based with discard new policy and max msgs limit.
 	t.Run("R3M", func(t *testing.T) {
-		testJetStreamClusterWorkQueueStreamOrphanIssue(t, &nats.StreamConfig{
+		params := &testParams{
+			restartAny:     true,
+			ldmRestart:     true,
+			rolloutRestart: false,
+			restarts:       1,
+			checkHealthz:   false,
+		}
+		test(t, params, &nats.StreamConfig{
 			Name:        "OWQTEST_R3M",
 			Subjects:    []string{"MSGS.>"},
 			Replicas:    3,
@@ -7072,8 +7482,16 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 			},
 		})
 	})
+
+	// Clustered file based with discard new policy and max msgs limit.
 	t.Run("R3F_DN", func(t *testing.T) {
-		testJetStreamClusterWorkQueueStreamOrphanIssue(t, &nats.StreamConfig{
+		params := &testParams{
+			restartAny:     true,
+			ldmRestart:     true,
+			rolloutRestart: false,
+			restarts:       1,
+		}
+		test(t, params, &nats.StreamConfig{
 			Name:        "OWQTEST_R3F_DN",
 			Subjects:    []string{"MSGS.>"},
 			Replicas:    3,
@@ -7088,8 +7506,16 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 			},
 		})
 	})
+
+	// Clustered file based with discard old policy and max msgs limit.
 	t.Run("R3F_DO", func(t *testing.T) {
-		testJetStreamClusterWorkQueueStreamOrphanIssue(t, &nats.StreamConfig{
+		params := &testParams{
+			restartAny:     true,
+			ldmRestart:     true,
+			rolloutRestart: false,
+			restarts:       1,
+		}
+		test(t, params, &nats.StreamConfig{
 			Name:        "OWQTEST_R3F_DO",
 			Subjects:    []string{"MSGS.>"},
 			Replicas:    3,
@@ -7104,281 +7530,4 @@ func TestJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T) {
 			},
 		})
 	})
-}
-
-func testJetStreamClusterWorkQueueStreamOrphanIssue(t *testing.T, sc *nats.StreamConfig) {
-	conf := `
-	listen: 127.0.0.1:-1
-	server_name: %s
-	jetstream: {
-		store_dir: '%s',
-	}
-	cluster {
-		name: %s
-		listen: 127.0.0.1:%d
-		routes = [%s]
-	}
-	server_tags: ["test"]
-	system_account: sys
-	no_auth_user: js
-	accounts {
-		sys { users = [ { user: sys, pass: sys } ] }
-		js {
-			jetstream = enabled
-			users = [ { user: js, pass: js } ]
-	    }
-	}`
-	c := createJetStreamClusterWithTemplate(t, conf, sc.Name, 3)
-	defer c.shutdown()
-
-	nc, js := jsClientConnect(t, c.randomServer())
-	defer nc.Close()
-
-	cnc, cjs := jsClientConnect(t, c.randomServer())
-	defer cnc.Close()
-
-	_, err := js.AddStream(sc)
-	require_NoError(t, err)
-
-	pctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Start producers
-	var wg sync.WaitGroup
-
-	// First call is just to create the pull subscribers.
-	mp := nats.MaxAckPending(10000)
-	mw := nats.PullMaxWaiting(1000)
-	aw := nats.AckWait(5 * time.Second)
-
-	for i := 0; i < 10; i++ {
-		for _, partition := range []string{"EEEEE"} {
-			subject := fmt.Sprintf("MSGS.%s.*.H.100XY.*.*.WQ.00000000000%d", partition, i)
-			consumer := fmt.Sprintf("consumer:%s:%d", partition, i)
-			_, err := cjs.PullSubscribe(subject, consumer, mp, mw, aw)
-			require_NoError(t, err)
-		}
-	}
-
-	// Create a single consumer that does no activity.
-	// Make sure we still calculate low ack properly and cleanup etc.
-	_, err = cjs.PullSubscribe("MSGS.ZZ.>", "consumer:ZZ:0", mp, mw, aw)
-	require_NoError(t, err)
-
-	subjects := []string{
-		"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000000",
-		"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000001",
-		"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000002",
-		"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000003",
-		"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000004",
-		"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000005",
-		"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000006",
-		"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000007",
-		"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000008",
-		"MSGS.EEEEE.P.H.100XY.1.100Z.WQ.000000000009",
-	}
-	payload := []byte(strings.Repeat("A", 1024))
-
-	for i := 0; i < 50; i++ {
-		wg.Add(1)
-		go func() {
-			pnc, pjs := jsClientConnect(t, c.randomServer())
-			defer pnc.Close()
-
-			for i := 1; i < 200_000; i++ {
-				select {
-				case <-pctx.Done():
-					wg.Done()
-					return
-				default:
-				}
-				for _, subject := range subjects {
-					// Send each message a few times.
-					msgID := nats.MsgId(nuid.Next())
-					pjs.PublishAsync(subject, payload, msgID)
-					pjs.Publish(subject, payload, msgID, nats.AckWait(250*time.Millisecond))
-					pjs.Publish(subject, payload, msgID, nats.AckWait(250*time.Millisecond))
-				}
-			}
-			t.Logf("Stopped publishing.")
-		}()
-	}
-
-	// Rogue publisher that sends the same msg ID everytime.
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			pnc, pjs := jsClientConnect(t, c.randomServer())
-			defer pnc.Close()
-
-			msgID := nats.MsgId("1234567890")
-			for i := 1; ; i++ {
-				select {
-				case <-pctx.Done():
-					wg.Done()
-					return
-				default:
-				}
-				for _, subject := range subjects {
-					// Send each message a few times.
-					pjs.PublishAsync(subject, payload, msgID, nats.RetryAttempts(0), nats.RetryWait(0))
-					pjs.Publish(subject, payload, msgID, nats.AckWait(1*time.Millisecond), nats.RetryAttempts(0), nats.RetryWait(0))
-					pjs.Publish(subject, payload, msgID, nats.AckWait(1*time.Millisecond), nats.RetryAttempts(0), nats.RetryWait(0))
-				}
-			}
-		}()
-	}
-
-	// Let enough messages into the stream then start consumers.
-	time.Sleep(15 * time.Second)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
-	defer cancel()
-
-	for i := 0; i < 10; i++ {
-		subject := fmt.Sprintf("MSGS.EEEEE.*.H.100XY.*.*.WQ.00000000000%d", i)
-		consumer := fmt.Sprintf("consumer:EEEEE:%d", i)
-		for n := 0; n < 5; n++ {
-			cpnc, cpjs := jsClientConnect(t, c.randomServer())
-			defer cpnc.Close()
-
-			psub, err := cpjs.PullSubscribe(subject, consumer, mp)
-			require_NoError(t, err)
-
-			time.AfterFunc(15*time.Second, func() {
-				cpnc.Close()
-			})
-
-			wg.Add(1)
-			go func() {
-				tick := time.NewTicker(1 * time.Millisecond)
-				for {
-					if cpnc.IsClosed() {
-						wg.Done()
-						return
-					}
-					select {
-					case <-ctx.Done():
-						wg.Done()
-						return
-					case <-tick.C:
-						// Fetch 1 first, then if no errors Fetch 100.
-						msgs, err := psub.Fetch(1, nats.MaxWait(200*time.Millisecond))
-						if err != nil {
-							continue
-						}
-						for _, msg := range msgs {
-							msg.Ack()
-						}
-						msgs, err = psub.Fetch(100, nats.MaxWait(200*time.Millisecond))
-						if err != nil {
-							continue
-						}
-						for _, msg := range msgs {
-							msg.Ack()
-						}
-						msgs, err = psub.Fetch(1000, nats.MaxWait(200*time.Millisecond))
-						if err != nil {
-							continue
-						}
-						for _, msg := range msgs {
-							msg.Ack()
-						}
-					}
-				}
-			}()
-		}
-	}
-
-	for i := 0; i < 10; i++ {
-		subject := fmt.Sprintf("MSGS.EEEEE.*.H.100XY.*.*.WQ.00000000000%d", i)
-		consumer := fmt.Sprintf("consumer:EEEEE:%d", i)
-		for n := 0; n < 10; n++ {
-			cpnc, cpjs := jsClientConnect(t, c.randomServer())
-			defer cpnc.Close()
-
-			psub, err := cpjs.PullSubscribe(subject, consumer, mp)
-			if err != nil {
-				t.Logf("ERROR: %v", err)
-				continue
-			}
-
-			wg.Add(1)
-			go func() {
-				tick := time.NewTicker(1 * time.Millisecond)
-				for {
-					select {
-					case <-ctx.Done():
-						wg.Done()
-						return
-					case <-tick.C:
-						// Fetch 1 first, then if no errors Fetch 100.
-						msgs, err := psub.Fetch(1, nats.MaxWait(200*time.Millisecond))
-						if err != nil {
-							continue
-						}
-						for _, msg := range msgs {
-							msg.Ack()
-						}
-						msgs, err = psub.Fetch(100, nats.MaxWait(200*time.Millisecond))
-						if err != nil {
-							continue
-						}
-						for _, msg := range msgs {
-							msg.Ack()
-						}
-
-						msgs, err = psub.Fetch(1000, nats.MaxWait(200*time.Millisecond))
-						if err != nil {
-							continue
-						}
-						for _, msg := range msgs {
-							msg.Ack()
-						}
-					}
-				}
-			}()
-		}
-	}
-
-	time.AfterFunc(10*time.Second, func() {
-		if sc.Replicas == 1 {
-			// Find server leader of the stream and restart it.
-			leaderSrv := c.streamLeader("js", sc.Name)
-			leaderSrv.Shutdown()
-			leaderSrv.WaitForShutdown()
-			c.restartServer(leaderSrv)
-		} else {
-			// NOTE (wq): For R=3, not sure which server causes the issue here
-			// so this may be have flaky behavior.
-			s := c.servers[0]
-			s.optsMu.Lock()
-			s.opts.LameDuckDuration = 5 * time.Second
-			s.opts.LameDuckGracePeriod = -5 * time.Second
-			s.optsMu.Unlock()
-			s.lameDuckMode()
-			s.WaitForShutdown()
-			c.restartServer(s)
-			c.waitOnClusterReady()
-		}
-	})
-
-	// Wait until context is done then check state.
-	<-ctx.Done()
-
-	var consumerPending int
-	for i := 0; i < 10; i++ {
-		ci, err := js.ConsumerInfo(sc.Name, fmt.Sprintf("consumer:EEEEE:%d", i))
-		require_NoError(t, err)
-		consumerPending += int(ci.NumPending)
-	}
-
-	// Check state of streams and consumers.
-	si, err := js.StreamInfo(sc.Name)
-	require_NoError(t, err)
-
-	streamPending := int(si.State.Msgs)
-	if streamPending != consumerPending {
-		t.Fatalf("Unexpected number of pending messages, stream=%d, consumers=%d", streamPending, consumerPending)
-	}
 }

--- a/server/stream.go
+++ b/server/stream.go
@@ -861,11 +861,10 @@ func (mset *stream) setLeader(isLeader bool) error {
 	}
 	mset.mu.Unlock()
 
-	if mset.isInterestRetention() {
-		// If we are interest based make sure to check consumers.
-		// This is to make sure we process any outstanding acks.
-		mset.checkInterestState()
-	}
+	// If we are interest based make sure to check consumers.
+	// This is to make sure we process any outstanding acks.
+	mset.checkInterestState()
+
 	return nil
 }
 
@@ -3990,12 +3989,6 @@ func (mset *stream) isClustered() bool {
 	return mset.node != nil
 }
 
-// Return if any limits are set.
-// Lock should be held.
-func (mset *stream) hasLimitsSet() bool {
-	return mset.cfg.MaxMsgs > 0 || mset.cfg.MaxBytes > 0 || mset.cfg.MaxMsgsPer > 0 || mset.cfg.MaxAge > 0
-}
-
 // Used if we have to queue things internally to avoid the route/gw path.
 type inMsg struct {
 	subj string
@@ -4384,6 +4377,7 @@ var (
 	errMsgIdDuplicate    = errors.New("msgid is duplicate")
 	errStreamClosed      = errors.New("stream closed")
 	errInvalidMsgHandler = errors.New("undefined message handler")
+	errStreamMismatch    = errors.New("expected stream does not match")
 )
 
 // processJetStreamMsg is where we try to actually process the stream msg.
@@ -4518,23 +4512,28 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 					b, _ := json.Marshal(resp)
 					outq.sendMsg(reply, b)
 				}
-				return errors.New("expected stream does not match")
+				return errStreamMismatch
 			}
 		}
 
-		// Dedupe detection.
+		// Dedupe detection. This is done at the cluster level for dedupe detectiom above the
+		// lower layers. But we still need to pull out the msgId.
 		if msgId = getMsgId(hdr); msgId != _EMPTY_ {
-			if dde := mset.checkMsgId(msgId); dde != nil {
-				mset.mu.Unlock()
-				bumpCLFS()
-				if canRespond {
-					response := append(pubAck, strconv.FormatUint(dde.seq, 10)...)
-					response = append(response, ",\"duplicate\": true}"...)
-					outq.sendMsg(reply, response)
+			// Do real check only if not clustered or traceOnly flag is set.
+			if !isClustered || traceOnly {
+				if dde := mset.checkMsgId(msgId); dde != nil {
+					mset.mu.Unlock()
+					bumpCLFS()
+					if canRespond {
+						response := append(pubAck, strconv.FormatUint(dde.seq, 10)...)
+						response = append(response, ",\"duplicate\": true}"...)
+						outq.sendMsg(reply, response)
+					}
+					return errMsgIdDuplicate
 				}
-				return errMsgIdDuplicate
 			}
 		}
+
 		// Expected last sequence per subject.
 		// If we are clustered we have prechecked seq > 0.
 		if seq, exists := getExpectedLastSeqPerSubject(hdr); exists {
@@ -4809,8 +4808,18 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 	}
 
 	// If we have a msgId make sure to save.
+	// This will replace our estimate from the cluster layer if we are clustered.
 	if msgId != _EMPTY_ {
-		mset.storeMsgIdLocked(&ddentry{msgId, seq, ts})
+		if isClustered && isLeader && mset.ddmap != nil {
+			if dde := mset.ddmap[msgId]; dde != nil {
+				dde.seq, dde.ts = seq, ts
+			} else {
+				mset.storeMsgIdLocked(&ddentry{msgId, seq, ts})
+			}
+		} else {
+			// R1 or not leader..
+			mset.storeMsgIdLocked(&ddentry{msgId, seq, ts})
+		}
 	}
 
 	// If here we succeeded in storing the message.
@@ -5442,18 +5451,18 @@ func (mset *stream) getPublicConsumers() []*consumer {
 // that have been acked are processed and removed.
 // This will check the ack floors of all consumers, and adjust our first sequence accordingly.
 func (mset *stream) checkInterestState() {
-	if mset == nil {
-		return
-	}
-	if !mset.isInterestRetention() {
+	if mset == nil || !mset.isInterestRetention() {
 		// If we are limits based nothing to do.
 		return
 	}
 
-	mset.clsMu.RLock()
 	var zeroAcks []*consumer
 	var lowAckFloor uint64 = math.MaxUint64
-	for _, o := range mset.cList {
+	consumers := mset.getConsumers()
+
+	for _, o := range consumers {
+		o.checkStateForInterestStream()
+
 		o.mu.RLock()
 		if o.isLeader() {
 			// We need to account for consumers with ack floor of zero.
@@ -5469,7 +5478,6 @@ func (mset *stream) checkInterestState() {
 			if err != nil {
 				// On error we will not have enough information to process correctly so bail.
 				o.mu.RUnlock()
-				mset.clsMu.RUnlock()
 				return
 			}
 			// We need to account for consumers with ack floor of zero.
@@ -5485,7 +5493,6 @@ func (mset *stream) checkInterestState() {
 		}
 		o.mu.RUnlock()
 	}
-	mset.clsMu.RUnlock()
 
 	// If nothing was set we can bail.
 	if lowAckFloor == math.MaxUint64 {
@@ -5500,7 +5507,7 @@ func (mset *stream) checkInterestState() {
 	var state StreamState
 	mset.store.FastState(&state)
 
-	if lowAckFloor < math.MaxUint64 && lowAckFloor > state.FirstSeq {
+	if lowAckFloor < math.MaxUint64 && lowAckFloor > state.FirstSeq && lowAckFloor <= state.LastSeq {
 		// Check if we had any zeroAcks, we will need to check them.
 		for _, o := range zeroAcks {
 			var np uint64
@@ -5518,9 +5525,12 @@ func (mset *stream) checkInterestState() {
 		}
 		// Purge the stream to lowest ack floor + 1
 		mset.store.PurgeEx(_EMPTY_, lowAckFloor+1, 0)
-		// Also make sure we clear any pending acks.
-		mset.clearAllPreAcksBelowFloor(lowAckFloor + 1)
 	}
+	// Make sure to reset our local lseq.
+	mset.store.FastState(&state)
+	mset.lseq = state.LastSeq
+	// Also make sure we clear any pending acks.
+	mset.clearAllPreAcksBelowFloor(state.FirstSeq)
 }
 
 func (mset *stream) isInterestRetention() bool {


### PR DESCRIPTION
Updates and improvements to consistency of stream peers with interest retention and limits.
We moved msgId de-dupe processing to upper layer if clustered. 
Fixed interest state checks for streams and consumers.

For both filestore and memstore, if we are discard new and interest based retention we should not enforce at the store level.
This could lead to replica drift and sequences being assigned differently during server restarts, network hiccups.

Fixed bug in filestore that would not leave a tombstone during PurgeEx or Compact leading to recovery of a zero state.

Signed-off-by: Derek Collison <derek@nats.io>