### PR TITLE
Fix race condition in `checkInterestState` by taking write lock

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -5477,7 +5477,7 @@ func (mset *stream) checkInterestState() {
 			state, err := o.store.State()
 			if err != nil {
 				// On error we will not have enough information to process correctly so bail.
-				o.mu.RUnlock()
+				o.mu.Unlock()
 				return
 			}
 			// We need to account for consumers with ack floor of zero.

--- a/server/stream.go
+++ b/server/stream.go
@@ -5463,7 +5463,7 @@ func (mset *stream) checkInterestState() {
 	for _, o := range consumers {
 		o.checkStateForInterestStream()
 
-		o.mu.RLock()
+		o.mu.Lock()
 		if o.isLeader() {
 			// We need to account for consumers with ack floor of zero.
 			// We will collect them and see if we need to check pending below.
@@ -5491,7 +5491,7 @@ func (mset *stream) checkInterestState() {
 				o.applyState(state)
 			}
 		}
-		o.mu.RUnlock()
+		o.mu.Unlock()
 	}
 
 	// If nothing was set we can bail.


### PR DESCRIPTION
The call to `o.applyState()` assumes that a write lock is held, whereas we were only taking a read lock.

Signed-off-by: Neil Twigg <neil@nats.io>
