### PR TITLE
[FIXED]  Creating colliding workqueue consumers could sometimes succeed.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -604,7 +604,7 @@ func checkConsumerCfg(
 	}
 	subjectFilters := gatherSubjectFilters(config.FilterSubject, config.FilterSubjects)
 
-	// Check subject filters overlap.
+	// Check subject filters do not overlap.
 	for outer, subject := range subjectFilters {
 		if !IsValidSubject(subject) {
 			return NewJSStreamInvalidConfigError(ErrBadSubject)
@@ -788,7 +788,7 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 			if action == ActionCreate && !reflect.DeepEqual(*config, eo.config()) {
 				return nil, NewJSConsumerAlreadyExistsError()
 			}
-			// Check for overlapping subjects.
+			// Check for overlapping subjects if we are a workqueue
 			if mset.cfg.Retention == WorkQueuePolicy {
 				subjects := gatherSubjectFilters(config.FilterSubject, config.FilterSubjects)
 				if !mset.partitionUnique(cName, subjects) {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4283,7 +4283,7 @@ func (js *jetStream) processClusterCreateConsumer(ca *consumerAssignment, state 
 	var didCreate, isConfigUpdate, needsLocalResponse bool
 	if o == nil {
 		// Add in the consumer if needed.
-		if o, err = mset.addConsumerWithAssignment(ca.Config, ca.Name, ca, wasExisting, ActionCreateOrUpdate); err == nil {
+		if o, err = mset.addConsumerWithAssignment(ca.Config, ca.Name, ca, js.isMetaRecovering(), ActionCreateOrUpdate); err == nil {
 			didCreate = true
 		}
 	} else {
@@ -7071,7 +7071,7 @@ func (cc *jetStreamCluster) createGroupForConsumer(cfg *ConsumerConfig, sa *stre
 	return &raftGroup{Name: groupNameForConsumer(peers, storage), Storage: storage, Peers: peers}
 }
 
-// jsClusteredConsumerRequest is first point of entry to create a consumer with R > 1.
+// jsClusteredConsumerRequest is first point of entry to create a consumer in clustered mode.
 func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subject, reply string, rmsg []byte, stream string, cfg *ConsumerConfig, action ConsumerAction) {
 	js, cc := s.getJetStreamCluster()
 	if js == nil || cc == nil {
@@ -7246,6 +7246,40 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 				}
 			}
 		}
+
+		// Check if we are work queue policy.
+		// We will do pre-checks here to avoid thrashing meta layer.
+		if sa.Config.Retention == WorkQueuePolicy && !cfg.Direct {
+			if cfg.AckPolicy != AckExplicit {
+				resp.Error = NewJSConsumerWQRequiresExplicitAckError()
+				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+				return
+			}
+			subjects := gatherSubjectFilters(cfg.FilterSubject, cfg.FilterSubjects)
+			if len(subjects) == 0 && len(sa.consumers) > 0 {
+				resp.Error = NewJSConsumerWQMultipleUnfilteredError()
+				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+				return
+			}
+			// Check here to make sure we have not collided with another.
+			if len(sa.consumers) > 0 {
+				for _, oca := range sa.consumers {
+					if oca.Name == oname {
+						continue
+					}
+					for _, psubj := range gatherSubjectFilters(oca.Config.FilterSubject, oca.Config.FilterSubjects) {
+						for _, subj := range subjects {
+							if SubjectsCollide(subj, psubj) {
+								resp.Error = NewJSConsumerWQConsumerNotUniqueError()
+								s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+								return
+							}
+						}
+					}
+				}
+			}
+		}
+
 		ca = &consumerAssignment{
 			Group:   rg,
 			Stream:  stream,
@@ -7333,8 +7367,6 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 		ca = nca
 	}
 
-	eca := encodeAddConsumerAssignment(ca)
-
 	// Mark this as pending.
 	if sa.consumers == nil {
 		sa.consumers = make(map[string]*consumerAssignment)
@@ -7342,7 +7374,7 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 	sa.consumers[ca.Name] = ca
 
 	// Do formal proposal.
-	cc.meta.Propose(eca)
+	cc.meta.Propose(encodeAddConsumerAssignment(ca))
 }
 
 func encodeAddConsumerAssignment(ca *consumerAssignment) []byte {


### PR DESCRIPTION
When creating multiple workqueue consumers that collided, if the consumer landed on the meta-leader it would be created.

This was due to the fact that the meta-leader had the consumer assignment already and incorrectly passed wasExisting for isRecovering. On recovery we would allow from a previous bug in the 2.9 series and print a warning to the server log.

The fix is to not mark waExisting if the consumer assignment is not marked as recovering, and to pass the state of isRecovering from the js state itself.

Also added upper layer check to avoid thrashing the meta layer.

If the parent stream was an R1 the consumer would be created, on R>1 it would be created and then a non meta-leader server would fail and clean it up.

Resolves: #4957 

Signed-off-by: Derek Collison <derek@nats.io>
