### PR TITLE
Change js-server-only healthcheck to not check JS state

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3289,6 +3289,11 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 		return health
 	}
 
+	// If JSServerOnly is true, then do not check further accounts, streams and consumers.
+	if opts.JSServerOnly {
+		return health
+	}
+
 	sopts := s.getOpts()
 
 	// If JS is not enabled in the config, we stop.
@@ -3480,11 +3485,6 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 				},
 			}
 		}
-		return health
-	}
-
-	// If JSServerOnly is true, then do not check further accounts, streams and consumers.
-	if opts.JSServerOnly {
 		return health
 	}
 


### PR DESCRIPTION
Currently the js-server-only check which is often used for readiness probe in k8s (so used to determines whether a service should be available in the load balancer or a kubernetes DNS entry) also checks some of the state from JS so during meta leader, this means that during restarts it could make it appear that temporarily nodes are unhealthy.
This changes the js-server-only check to report once ports are ready instead.