### PR TITLE
[FIXED] Multiple deliveries of messages with delivery count going backwards.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -4048,9 +4048,9 @@ func (o *consumer) loopAndGatherMsgs(qch chan struct{}) {
 				wr.hbt = time.Now().Add(wr.hb)
 			}
 		} else {
-			// We will redo this one.
-			o.sseq--
+			// We will redo this one as long as this is not a redelivery.
 			if dc == 1 {
+				o.sseq--
 				o.npc++
 			}
 			pmsg.returnToPool()
@@ -4492,7 +4492,7 @@ func (o *consumer) didNotDeliver(seq uint64, subj string) {
 		if _, ok := o.pending[seq]; ok {
 			// We found this messsage on pending, we need
 			// to queue it up for immediate redelivery since
-			// we know it was not delivered.
+			// we know it was not delivered
 			if !o.onRedeliverQueue(seq) {
 				o.addToRedeliverQueue(seq)
 				o.signalNewMessages()

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -1089,8 +1089,9 @@ func TestFetchWithDrain(t *testing.T) {
 		metadata, err := msg.Metadata()
 		require_NoError(t, err)
 		err = msg.Ack()
+		require_NoError(t, err)
 
-		fmt.Printf("DELIVERY seq: %v STREAM seq: %v\n", metadata.NumDelivered, metadata.Sequence.Stream)
+		fmt.Printf("DELIVERY seq: %v STREAM seq: %v CONSUMER seq: %v\n", metadata.NumDelivered, metadata.Sequence.Stream, metadata.Sequence.Consumer)
 
 		_, ok := msgs[int(metadata.Sequence.Stream)]
 		if _, ok := msgs[int(metadata.Sequence.Stream-1)]; !ok && len(msgs) > 0 {


### PR DESCRIPTION
When we fail to deliver a message, we were not checking if this was a redelivery already and would decrement o.sseq, meaning we would pick up the same message after the next redelivery and would have a delivered count of 1.

This could lead to a message being delivered from the redelivery queue, but that could fail, then you would see same message twice, first with dc of 2, then 1.

Now app only gets one copy with delivery count of 2.

Signed-off-by: Derek Collison <derek@nats.io>