### PR TITLE
NRG: Don't step down for old terms in AEs

### DIFF
--- a/server/test_test.go
+++ b/server/test_test.go
@@ -122,7 +122,7 @@ func require_Equal[T comparable](t *testing.T, a, b T) {
 func require_NotEqual[T comparable](t *testing.T, a, b T) {
 	t.Helper()
 	if a == b {
-		t.Fatalf("require %T not equal, but got: %v != %v", a, a, b)
+		t.Fatalf("require %T not equal, but got: %v == %v", a, a, b)
 	}
 }
 


### PR DESCRIPTION
We shouldn't step down if the append entry contains old terms, it may just be still in-flight from a distant node that is still behind. We also shouldn't clear the vote when leader unless we've definitely seen a newer term and not just the existing term, otherwise we could cast multiple votes.

Signed-off-by: Neil Twigg <neil@nats.io>