### PR TITLE
NRG: Only reset election timeout on vote request if granting

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3884,7 +3884,6 @@ func (n *raft) processVoteRequest(vr *voteRequest) error {
 	}
 
 	n.Lock()
-	n.resetElectionTimeout()
 
 	vresp := &voteResponse{n.term, n.id, false}
 	defer n.debug("Sending a voteResponse %+v -> %q", vresp, vr.reply)
@@ -3916,6 +3915,7 @@ func (n *raft) processVoteRequest(vr *voteRequest) error {
 		n.term = vr.term
 		n.vote = vr.candidate
 		n.writeTermVote()
+		n.resetElectionTimeout()
 	} else {
 		if vr.term >= n.term && n.vote == noVote {
 			n.term = vr.term

--- a/server/raft.go
+++ b/server/raft.go
@@ -150,6 +150,7 @@ type raft struct {
 	pae     map[uint64]*appendEntry        // Pending append entries
 
 	elect  *time.Timer // Election timer, normally accessed via electTimer
+	etlr   time.Time   // Election timer last reset time, for unit tests only
 	active time.Time   // Last activity time, i.e. for heartbeats
 	llqrt  time.Time   // Last quorum lost time
 	lsut   time.Time   // Last scale-up time
@@ -1766,6 +1767,7 @@ func (n *raft) resetElectionTimeoutWithLock() {
 
 // Lock should be held.
 func (n *raft) resetElect(et time.Duration) {
+	n.etlr = time.Now()
 	if n.elect == nil {
 		n.elect = time.NewTimer(et)
 	} else {


### PR DESCRIPTION
With the current behaviour, a node that is behind but running in the candidate state could cause nodes that are current to delay switching to the candidate state themselves because they keep resetting the election timer each time they receive a vote request.

Changing this to reset the election timeout only when granting means that we will allow other possibly more up-to-date nodes to transition to the candidate state faster.

This might explain why we've seen some unexpected delays in starting a new election after a leader has gone away.

Signed-off-by: Neil Twigg <neil@nats.io>