### PR TITLE
stree: prevent matching invalid wildcards in subject

### DIFF
--- a/server/stree/parts.go
+++ b/server/stree/parts.go
@@ -45,6 +45,14 @@ func genParts(filter []byte, parts [][]byte) [][]byte {
 				start = i + 1
 			}
 		} else if filter[i] == pwc || filter[i] == fwc {
+			// Wildcard must be at the start or preceded by tsep.
+			if prev := i - 1; prev >= 0 && filter[prev] != tsep {
+				continue
+			}
+			// Wildcard must be at the end or followed by tsep.
+			if next := i + 1; next == e || next < e && filter[next] != tsep {
+				continue
+			}
 			// We start with a pwc or fwc.
 			parts = append(parts, filter[i:i+1])
 			if i+1 <= e {

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -541,6 +541,25 @@ func TestSubjectTreeMatchMultipleWildcardBasic(t *testing.T) {
 	match(t, st, "A.B.*.D.1.*.*.I.0", 1)
 }
 
+func TestSubjectTreeMatchInvalidWildcard(t *testing.T) {
+	st := NewSubjectTree[int]()
+	st.Insert(b("foo.123"), 22)
+	st.Insert(b("one.two.three.four.five"), 22)
+	st.Insert(b("'*.123"), 22)
+	match(t, st, "invalid.>", 0)
+	match(t, st, ">", 3)
+	match(t, st, `'*.*`, 1)
+	match(t, st, `'*.*.*'`, 0)
+	// None of these should match.
+	match(t, st, "`>`", 0)
+	match(t, st, `">"`, 0)
+	match(t, st, `'>'`, 0)
+	match(t, st, `'*.>'`, 0)
+	match(t, st, `'*.>.`, 0)
+	match(t, st, "`invalid.>`", 0)
+	match(t, st, `'*.*'`, 0)
+}
+
 func TestSubjectTreeRandomTrackEntries(t *testing.T) {
 	st := NewSubjectTree[int]()
 	smap := make(map[string]struct{}, 1000)


### PR DESCRIPTION
Partially addresses what is reported in https://github.com/nats-io/nats.go/issues/1608
