### PR TITLE
Implement `(*Sublist).HasInterest()`

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2257,7 +2257,6 @@ func (mb *msgBlock) firstMatchingMulti(sl *Sublist, start uint64, sm *StoreMsg) 
 		sm = new(StoreMsg)
 	}
 
-	var result SublistResult
 	for seq := start; seq <= lseq; seq++ {
 		llseq := mb.llseq
 		fsm, err := mb.cacheLookup(seq, sm)
@@ -2266,7 +2265,7 @@ func (mb *msgBlock) firstMatchingMulti(sl *Sublist, start uint64, sm *StoreMsg) 
 		}
 		expireOk := seq == lseq && mb.llseq == seq
 
-		if r := sl.MatchWithResult(fsm.subj, &result); len(r.psubs) > 0 {
+		if sl.HasInterest(fsm.subj) {
 			return fsm, expireOk, nil
 		}
 		// If we are here we did not match, so put the llseq back.

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1055,13 +1055,12 @@ func (ms *memStore) LoadNextMsgMulti(sl *Sublist, start uint64, smp *StoreMsg) (
 	// Initial setup.
 	fseq, lseq := start, ms.state.LastSeq
 
-	var result SublistResult
 	for nseq := fseq; nseq <= lseq; nseq++ {
 		sm, ok := ms.msgs[nseq]
 		if !ok {
 			continue
 		}
-		if r := sl.MatchWithResult(sm.subj, &result); len(r.psubs) > 0 {
+		if sl.HasInterest(sm.subj) {
 			if smp == nil {
 				smp = new(StoreMsg)
 			}

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -1602,6 +1602,28 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func TestSublistHasInterest(t *testing.T) {
+	sl := NewSublistWithCache()
+	fooSub := newSub("foo")
+	sl.Insert(fooSub)
+
+	// Expect to find that "foo" matches but "bar" doesn't.
+	// At this point nothing should be in the cache.
+	require_True(t, sl.HasInterest("foo"))
+	require_False(t, sl.HasInterest("bar"))
+	require_Equal(t, sl.cacheHits, 0)
+
+	// Now call Match(), which will populate the cache.
+	sl.Match("foo")
+	require_Equal(t, sl.cacheHits, 0)
+
+	// Future calls to HasInterest() should hit the cache now.
+	for i := uint64(1); i <= 5; i++ {
+		require_True(t, sl.HasInterest("foo"))
+		require_Equal(t, sl.cacheHits, i)
+	}
+}
+
 func subsInit(pre string, toks []string) {
 	var sub string
 	for _, t := range toks {


### PR DESCRIPTION
This may end up being more efficient than `MatchWithResult()` in some cases as we will stop processing on the first match and not spend time building up a `*SublistResult`. May want to give more thought on the caching here — right now it checks the cache, but `HasInterest()` won't populate it, only `Match()` will.

/cc @kozlovic 

Signed-off-by: Neil Twigg <neil@nats.io>