### PR TITLE
Added Left and Right Mapping Operations

### DIFF
--- a/server/subject_transform.go
+++ b/server/subject_transform.go
@@ -536,7 +536,7 @@ func (tr *subjectTransform) TransformTokenizedSubject(tokens []string) string {
 				sourceTokenLen := len(sourceToken)
 				sliceSize := int(tr.dtokmfintargs[i])
 				if sliceSize > 0 && sliceSize < sourceTokenLen {
-					b.WriteString(sourceToken[0:2])
+					b.WriteString(sourceToken[0:sliceSize])
 				} else { // too small to slice at the requested size: don't slice
 					b.WriteString(sourceToken)
 				}

--- a/server/subject_transform.go
+++ b/server/subject_transform.go
@@ -545,7 +545,7 @@ func (tr *subjectTransform) TransformTokenizedSubject(tokens []string) string {
 				sourceTokenLen := len(sourceToken)
 				sliceSize := int(tr.dtokmfintargs[i])
 				if sliceSize > 0 && sliceSize < sourceTokenLen {
-					b.WriteString(sourceToken[sourceTokenLen-2 : sourceTokenLen])
+					b.WriteString(sourceToken[sourceTokenLen-sliceSize : sourceTokenLen])
 				} else { // too small to slice at the requested size: don't slice
 					b.WriteString(sourceToken)
 				}

--- a/server/subject_transform.go
+++ b/server/subject_transform.go
@@ -31,6 +31,8 @@ var (
 	sliceFromLeftMappingFunctionRegEx  = regexp.MustCompile(`{{\s*[sS]lice[fF]rom[lL]eft\s*\((.*)\)\s*}}`)
 	sliceFromRightMappingFunctionRegEx = regexp.MustCompile(`{{\s*[sS]lice[fF]rom[rR]ight\s*\((.*)\)\s*}}`)
 	splitMappingFunctionRegEx          = regexp.MustCompile(`{{\s*[sS]plit\s*\((.*)\)\s*}}`)
+	leftMappingFunctionRegEx           = regexp.MustCompile(`{{\s*[lL]eft\s*\((.*)\)\s*}}`)
+	rightMappingFunctionRegEx          = regexp.MustCompile(`{{\s*[rR]ight\s*\((.*)\)\s*}}`)
 )
 
 // Enum for the subject mapping subjectTransform function types
@@ -44,6 +46,8 @@ const (
 	SliceFromLeft
 	SliceFromRight
 	Split
+	Left
+	Right
 )
 
 // Transforms for arbitrarily mapping subjects from one to another for maps, tees and filters.
@@ -297,6 +301,18 @@ func indexPlaceHolders(token string) (int16, []int, int32, string, error) {
 				return transformIndexIntArgsHelper(token, args, SliceFromRight)
 			}
 
+			// Right(token, length)
+			args = getMappingFunctionArgs(rightMappingFunctionRegEx, token)
+			if args != nil {
+				return transformIndexIntArgsHelper(token, args, Right)
+			}
+
+			// Left(token, length)
+			args = getMappingFunctionArgs(leftMappingFunctionRegEx, token)
+			if args != nil {
+				return transformIndexIntArgsHelper(token, args, Left)
+			}
+
 			// split(token, deliminator)
 			args = getMappingFunctionArgs(splitMappingFunctionRegEx, token)
 			if args != nil {
@@ -514,6 +530,24 @@ func (tr *subjectTransform) TransformTokenizedSubject(tokens []string) string {
 					if j < len(splits)-1 && splits[j+1] != _EMPTY_ && !(j == 0 && split == _EMPTY_) {
 						b.WriteString(tsep)
 					}
+				}
+			case Left:
+				sourceToken := tokens[tr.dtokmftokindexesargs[i][0]]
+				sourceTokenLen := len(sourceToken)
+				sliceSize := int(tr.dtokmfintargs[i])
+				if sliceSize > 0 && sliceSize < sourceTokenLen {
+					b.WriteString(sourceToken[0:2])
+				} else { // too small to slice at the requested size: don't slice
+					b.WriteString(sourceToken)
+				}
+			case Right:
+				sourceToken := tokens[tr.dtokmftokindexesargs[i][0]]
+				sourceTokenLen := len(sourceToken)
+				sliceSize := int(tr.dtokmfintargs[i])
+				if sliceSize > 0 && sliceSize < sourceTokenLen {
+					b.WriteString(sourceToken[sourceTokenLen-2 : sourceTokenLen])
+				} else { // too small to slice at the requested size: don't slice
+					b.WriteString(sourceToken)
 				}
 			}
 		}

--- a/server/subject_transform_test.go
+++ b/server/subject_transform_test.go
@@ -214,8 +214,10 @@ func TestSubjectTransforms(t *testing.T) {
 	shouldMatch("*", "{{split(1,-)}}", "-abc-def--ghi-", "abc.def.ghi")
 	shouldMatch("*", "{{split(1,-)}}", "abc-def--ghi-", "abc.def.ghi")
 	shouldMatch("*.*", "{{split(2,-)}}.{{splitfromleft(1,2)}}", "foo.-abc-def--ghij-", "abc.def.ghij.fo.o") // combo + checks split for multiple instance of deliminator and deliminator being at the start or end
-	shouldMatch("*", "{{right(1,2)}}", "1234", "34")
+	shouldMatch("*", "{{right(1,1)}}", "1234", "4")
+	shouldMatch("*", "{{right(1,3)}}", "1234", "234")
 	shouldMatch("*", "{{right(1,6)}}", "1234", "1234")
-	shouldMatch("*", "{{left(1,2)}}", "1234", "12")
+	shouldMatch("*", "{{left(1,1)}}", "1234", "1")
+	shouldMatch("*", "{{left(1,3)}}", "1234", "123")
 	shouldMatch("*", "{{left(1,6)}}", "1234", "1234")
 }

--- a/server/subject_transform_test.go
+++ b/server/subject_transform_test.go
@@ -71,6 +71,20 @@ func TestPlaceHolderIndex(t *testing.T) {
 	if err != nil || transformType != SliceFromLeft || len(indexes) != 1 || indexes[0] != 2 || sliceSize != 2 {
 		t.Fatalf("Error parsing %s", testString)
 	}
+
+	testString = "{{Left(3,2)}}"
+	transformType, indexes, position, _, err = indexPlaceHolders(testString)
+
+	if err != nil || transformType != Left || len(indexes) != 1 || indexes[0] != 3 || position != 2 {
+		t.Fatalf("Error parsing %s", testString)
+	}
+
+	testString = "{{Right(3,2)}}"
+	transformType, indexes, position, _, err = indexPlaceHolders(testString)
+
+	if err != nil || transformType != Right || len(indexes) != 1 || indexes[0] != 3 || position != 2 {
+		t.Fatalf("Error parsing %s", testString)
+	}
 }
 
 func TestSubjectTransformHelpers(t *testing.T) {
@@ -200,4 +214,8 @@ func TestSubjectTransforms(t *testing.T) {
 	shouldMatch("*", "{{split(1,-)}}", "-abc-def--ghi-", "abc.def.ghi")
 	shouldMatch("*", "{{split(1,-)}}", "abc-def--ghi-", "abc.def.ghi")
 	shouldMatch("*.*", "{{split(2,-)}}.{{splitfromleft(1,2)}}", "foo.-abc-def--ghij-", "abc.def.ghij.fo.o") // combo + checks split for multiple instance of deliminator and deliminator being at the start or end
+	shouldMatch("*", "{{right(1,2)}}", "1234", "34")
+	shouldMatch("*", "{{right(1,6)}}", "1234", "1234")
+	shouldMatch("*", "{{left(1,2)}}", "1234", "12")
+	shouldMatch("*", "{{left(1,6)}}", "1234", "1234")
 }


### PR DESCRIPTION
<!-- Please make sure to read CONTRIBUTING.md, then delete this notice and replace it with your PR description. The below sign-off certifies that the contribution is your original work and that you license the work to the project under the Apache-2.0 license. We cannot accept contributions without it. -->
Adding Left and Right operations to Mappings enabling the ability to group by token beginnings and endings.  

Example: 
foo.*: foo.{{Right(1,2)}} -> foo.1234 -> foo.34
foo.*:foo.{{Left(1,2)}} -> foo.1234:  -> foo.12

Signed-off-by: Stephen Spates <sspates@starbucks.com>
