### PR TITLE
[FIXED]  Stree Find() would fail if delete caused a new prefix that was too large.

### DIFF
--- a/server/stree/dump.go
+++ b/server/stree/dump.go
@@ -38,7 +38,7 @@ func (t *SubjectTree[T]) dump(w io.Writer, n node, depth int) {
 	} else {
 		// We are a node type here, grab meta portion.
 		bn := n.base()
-		fmt.Fprintf(w, "%s %s Prefix: %q\n", dumpPre(depth), n.kind(), bn.prefix[:bn.prefixLen])
+		fmt.Fprintf(w, "%s %s Prefix: %q\n", dumpPre(depth), n.kind(), bn.prefix)
 		depth++
 		n.iter(func(n node) bool {
 			t.dump(w, n, depth)

--- a/server/stree/node.go
+++ b/server/stree/node.go
@@ -32,13 +32,7 @@ type node interface {
 	path() []byte
 }
 
-// Maximum prefix len
-// We expect the most savings to come from long shared prefixes.
-const maxPrefixLen = 24
-
-// 64 bytes total - an L1 cache line.
 type meta struct {
-	prefix    [maxPrefixLen]byte
-	prefixLen uint16
-	size      uint16
+	prefix []byte
+	size   uint16
 }

--- a/server/stree/node16.go
+++ b/server/stree/node16.go
@@ -30,10 +30,7 @@ func (n *node16) isLeaf() bool { return false }
 func (n *node16) base() *meta  { return &n.meta }
 
 func (n *node16) setPrefix(pre []byte) {
-	n.prefixLen = uint16(min(len(pre), maxPrefixLen))
-	for i := uint16(0); i < n.prefixLen; i++ {
-		n.prefix[i] = pre[i]
-	}
+	n.prefix = append([]byte(nil), pre...)
 }
 
 // Currently we do not keep node16 sorted or use bitfields for traversal so just add to the end.
@@ -48,7 +45,7 @@ func (n *node16) addChild(c byte, nn node) {
 }
 
 func (n *node16) numChildren() uint16 { return n.size }
-func (n *node16) path() []byte        { return n.prefix[:n.prefixLen] }
+func (n *node16) path() []byte        { return n.prefix }
 
 func (n *node16) findChild(c byte) *node {
 	for i := uint16(0); i < n.size; i++ {
@@ -62,7 +59,7 @@ func (n *node16) findChild(c byte) *node {
 func (n *node16) isFull() bool { return n.size >= 16 }
 
 func (n *node16) grow() node {
-	nn := newNode256(n.prefix[:n.prefixLen])
+	nn := newNode256(n.prefix)
 	for i := 0; i < 16; i++ {
 		nn.addChild(n.key[i], n.child[i])
 	}
@@ -103,7 +100,7 @@ func (n *node16) shrink() node {
 
 // Will match parts against our prefix.no
 func (n *node16) matchParts(parts [][]byte) ([][]byte, bool) {
-	return matchParts(parts, n.prefix[:n.prefixLen])
+	return matchParts(parts, n.prefix)
 }
 
 // Iterate over all children calling func f.

--- a/server/stree/node256.go
+++ b/server/stree/node256.go
@@ -29,10 +29,7 @@ func (n *node256) isLeaf() bool { return false }
 func (n *node256) base() *meta  { return &n.meta }
 
 func (n *node256) setPrefix(pre []byte) {
-	n.prefixLen = uint16(min(len(pre), maxPrefixLen))
-	for i := uint16(0); i < n.prefixLen; i++ {
-		n.prefix[i] = pre[i]
-	}
+	n.prefix = append([]byte(nil), pre...)
 }
 
 func (n *node256) addChild(c byte, nn node) {
@@ -41,7 +38,7 @@ func (n *node256) addChild(c byte, nn node) {
 }
 
 func (n *node256) numChildren() uint16 { return n.size }
-func (n *node256) path() []byte        { return n.prefix[:n.prefixLen] }
+func (n *node256) path() []byte        { return n.prefix }
 
 func (n *node256) findChild(c byte) *node {
 	if n.child[c] != nil {
@@ -77,7 +74,7 @@ func (n *node256) shrink() node {
 
 // Will match parts against our prefix.
 func (n *node256) matchParts(parts [][]byte) ([][]byte, bool) {
-	return matchParts(parts, n.prefix[:n.prefixLen])
+	return matchParts(parts, n.prefix)
 }
 
 // Iterate over all children calling func f.

--- a/server/stree/node4.go
+++ b/server/stree/node4.go
@@ -30,10 +30,7 @@ func (n *node4) isLeaf() bool { return false }
 func (n *node4) base() *meta  { return &n.meta }
 
 func (n *node4) setPrefix(pre []byte) {
-	n.prefixLen = uint16(min(len(pre), maxPrefixLen))
-	for i := uint16(0); i < n.prefixLen; i++ {
-		n.prefix[i] = pre[i]
-	}
+	n.prefix = append([]byte(nil), pre...)
 }
 
 // Currently we do not need to keep sorted for traversal so just add to the end.
@@ -47,7 +44,7 @@ func (n *node4) addChild(c byte, nn node) {
 }
 
 func (n *node4) numChildren() uint16 { return n.size }
-func (n *node4) path() []byte        { return n.prefix[:n.prefixLen] }
+func (n *node4) path() []byte        { return n.prefix }
 
 func (n *node4) findChild(c byte) *node {
 	for i := uint16(0); i < n.size; i++ {
@@ -61,7 +58,7 @@ func (n *node4) findChild(c byte) *node {
 func (n *node4) isFull() bool { return n.size >= 4 }
 
 func (n *node4) grow() node {
-	nn := newNode16(n.prefix[:n.prefixLen])
+	nn := newNode16(n.prefix)
 	for i := 0; i < 4; i++ {
 		nn.addChild(n.key[i], n.child[i])
 	}
@@ -98,7 +95,7 @@ func (n *node4) shrink() node {
 
 // Will match parts against our prefix.
 func (n *node4) matchParts(parts [][]byte) ([][]byte, bool) {
-	return matchParts(parts, n.prefix[:n.prefixLen])
+	return matchParts(parts, n.prefix)
 }
 
 // Iterate over all children calling func f.

--- a/server/stree/util.go
+++ b/server/stree/util.go
@@ -29,7 +29,7 @@ func commonPrefixLen(s1, s2 []byte) int {
 			break
 		}
 	}
-	return min(i, maxPrefixLen)
+	return i
 }
 
 // Helper to copy bytes.


### PR DESCRIPTION
With fixed prefixes this would cause the tree to be broken and find to not work and match would work but with shortened subjects. Could not fix up with fixed prefix arrays when delete caused a non-leaf node to merge a larger prefix.

Changed to normal []byte slice for meta node prefixes.

Signed-off-by: Derek Collison <derek@nats.io>
