### PR TITLE
Fix race condition in `TestNRGUnsuccessfulVoteRequestDoesntResetElectionTimer`

### DIFF
--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -83,6 +83,20 @@ func (sg smGroup) nonLeader() stateMachine {
 	return nil
 }
 
+// Take out the lock on all nodes.
+func (sg smGroup) lockAll() {
+	for _, sm := range sg {
+		sm.node().(*raft).Lock()
+	}
+}
+
+// Release the lock on all nodes.
+func (sg smGroup) unlockAll() {
+	for _, sm := range sg {
+		sm.node().(*raft).Unlock()
+	}
+}
+
 // Create a raft group and place on numMembers servers at random.
 func (c *cluster) createRaftGroup(name string, numMembers int, smf smFactory) smGroup {
 	c.t.Helper()


### PR DESCRIPTION
Fixes a race that was picked up by the race detector.

Signed-off-by: Neil Twigg <neil@nats.io>