### PR TITLE
Deduplicate some `stree` functions

### DIFF
--- a/server/stree/node.go
+++ b/server/stree/node.go
@@ -36,3 +36,18 @@ type meta struct {
 	prefix []byte
 	size   uint16
 }
+
+func (n *meta) isLeaf() bool { return false }
+func (n *meta) base() *meta  { return n }
+
+func (n *meta) setPrefix(pre []byte) {
+	n.prefix = append([]byte(nil), pre...)
+}
+
+func (n *meta) numChildren() uint16 { return n.size }
+func (n *meta) path() []byte        { return n.prefix }
+
+// Will match parts against our prefix.
+func (n *meta) matchParts(parts [][]byte) ([][]byte, bool) {
+	return matchParts(parts, n.prefix)
+}

--- a/server/stree/node16.go
+++ b/server/stree/node16.go
@@ -26,13 +26,6 @@ func newNode16(prefix []byte) *node16 {
 	return nn
 }
 
-func (n *node16) isLeaf() bool { return false }
-func (n *node16) base() *meta  { return &n.meta }
-
-func (n *node16) setPrefix(pre []byte) {
-	n.prefix = append([]byte(nil), pre...)
-}
-
 // Currently we do not keep node16 sorted or use bitfields for traversal so just add to the end.
 // TODO(dlc) - We should revisit here with more detailed benchmarks.
 func (n *node16) addChild(c byte, nn node) {
@@ -43,9 +36,6 @@ func (n *node16) addChild(c byte, nn node) {
 	n.child[n.size] = nn
 	n.size++
 }
-
-func (n *node16) numChildren() uint16 { return n.size }
-func (n *node16) path() []byte        { return n.prefix }
 
 func (n *node16) findChild(c byte) *node {
 	for i := uint16(0); i < n.size; i++ {
@@ -96,11 +86,6 @@ func (n *node16) shrink() node {
 		nn.addChild(n.key[i], n.child[i])
 	}
 	return nn
-}
-
-// Will match parts against our prefix.no
-func (n *node16) matchParts(parts [][]byte) ([][]byte, bool) {
-	return matchParts(parts, n.prefix)
 }
 
 // Iterate over all children calling func f.

--- a/server/stree/node256.go
+++ b/server/stree/node256.go
@@ -25,20 +25,10 @@ func newNode256(prefix []byte) *node256 {
 	return nn
 }
 
-func (n *node256) isLeaf() bool { return false }
-func (n *node256) base() *meta  { return &n.meta }
-
-func (n *node256) setPrefix(pre []byte) {
-	n.prefix = append([]byte(nil), pre...)
-}
-
 func (n *node256) addChild(c byte, nn node) {
 	n.child[c] = nn
 	n.size++
 }
-
-func (n *node256) numChildren() uint16 { return n.size }
-func (n *node256) path() []byte        { return n.prefix }
 
 func (n *node256) findChild(c byte) *node {
 	if n.child[c] != nil {
@@ -70,11 +60,6 @@ func (n *node256) shrink() node {
 		}
 	}
 	return nn
-}
-
-// Will match parts against our prefix.
-func (n *node256) matchParts(parts [][]byte) ([][]byte, bool) {
-	return matchParts(parts, n.prefix)
 }
 
 // Iterate over all children calling func f.

--- a/server/stree/node4.go
+++ b/server/stree/node4.go
@@ -26,13 +26,6 @@ func newNode4(prefix []byte) *node4 {
 	return nn
 }
 
-func (n *node4) isLeaf() bool { return false }
-func (n *node4) base() *meta  { return &n.meta }
-
-func (n *node4) setPrefix(pre []byte) {
-	n.prefix = append([]byte(nil), pre...)
-}
-
 // Currently we do not need to keep sorted for traversal so just add to the end.
 func (n *node4) addChild(c byte, nn node) {
 	if n.size >= 4 {
@@ -42,9 +35,6 @@ func (n *node4) addChild(c byte, nn node) {
 	n.child[n.size] = nn
 	n.size++
 }
-
-func (n *node4) numChildren() uint16 { return n.size }
-func (n *node4) path() []byte        { return n.prefix }
 
 func (n *node4) findChild(c byte) *node {
 	for i := uint16(0); i < n.size; i++ {
@@ -91,11 +81,6 @@ func (n *node4) shrink() node {
 		return n.child[0]
 	}
 	return nil
-}
-
-// Will match parts against our prefix.
-func (n *node4) matchParts(parts [][]byte) ([][]byte, bool) {
-	return matchParts(parts, n.prefix)
 }
 
 // Iterate over all children calling func f.


### PR DESCRIPTION
The `isLeaf`, `base`, `setPrefix`, `numChildren`, `path` and `matchParts` functions all have the same implementation for each node type, so this cuts them down to a single copy.

The leaf type will continue to override these as normal with its own implementations.

Signed-off-by: Neil Twigg <neil@nats.io>