### PR TITLE
NRG (2.11): Remove stepdown channel, handle inline

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -198,15 +198,14 @@ type raft struct {
 	hcommit   uint64 // The commit at the time that applies were paused
 	pobserver bool   // Whether we were an observer at the time that applies were paused
 
-	prop     *ipQueue[*Entry]               // Proposals
-	entry    *ipQueue[*appendEntry]         // Append entries
-	resp     *ipQueue[*appendEntryResponse] // Append entries responses
-	apply    *ipQueue[*CommittedEntry]      // Apply queue (committed entries to be passed to upper layer)
-	reqs     *ipQueue[*voteRequest]         // Vote requests
-	votes    *ipQueue[*voteResponse]        // Vote responses
-	stepdown *ipQueue[string]               // Stepdown requests
-	leadc    chan bool                      // Leader changes
-	quit     chan struct{}                  // Raft group shutdown
+	prop  *ipQueue[*Entry]               // Proposals
+	entry *ipQueue[*appendEntry]         // Append entries
+	resp  *ipQueue[*appendEntryResponse] // Append entries responses
+	apply *ipQueue[*CommittedEntry]      // Apply queue (committed entries to be passed to upper layer)
+	reqs  *ipQueue[*voteRequest]         // Vote requests
+	votes *ipQueue[*voteResponse]        // Vote responses
+	leadc chan bool                      // Leader changes
+	quit  chan struct{}                  // Raft group shutdown
 }
 
 // cacthupState structure that holds our subscription, and catchup term and index
@@ -391,7 +390,6 @@ func (s *Server) startRaftNode(accName string, cfg *RaftConfig, labels pprofLabe
 		entry:    newIPQueue[*appendEntry](s, qpfx+"appendEntry"),
 		resp:     newIPQueue[*appendEntryResponse](s, qpfx+"appendEntryResponse"),
 		apply:    newIPQueue[*CommittedEntry](s, qpfx+"committedEntry"),
-		stepdown: newIPQueue[string](s, qpfx+"stepdown"),
 		accName:  accName,
 		leadc:    make(chan bool, 32),
 		observer: cfg.Observer,
@@ -868,7 +866,7 @@ func (n *raft) PauseApply() error {
 
 	// If we are currently a candidate make sure we step down.
 	if n.State() == Candidate {
-		n.stepdown.push(noLeader)
+		n.stepdownLocked(noLeader)
 	}
 
 	n.debug("Pausing our apply channel")
@@ -1256,6 +1254,21 @@ func (n *raft) Leader() bool {
 	return n.State() == Leader
 }
 
+// stepdown immediately steps down the Raft node to the
+// follower state. This will take the lock itself.
+func (n *raft) stepdown(newLeader string) {
+	n.Lock()
+	defer n.Unlock()
+	n.stepdownLocked(newLeader)
+}
+
+// stepdownLocked immediately steps down the Raft node to the
+// follower state. This requires the lock is already held.
+func (n *raft) stepdownLocked(newLeader string) {
+	n.debug("Stepping down")
+	n.switchToFollowerLocked(newLeader)
+}
+
 // isCatchingUp returns true if a catchup is currently taking place.
 func (n *raft) isCatchingUp() bool {
 	n.RLock()
@@ -1463,8 +1476,6 @@ func (n *raft) StepDown(preferred ...string) error {
 	n.vote = noVote
 	n.writeTermVote()
 
-	stepdown := n.stepdown
-	prop := n.prop
 	n.Unlock()
 
 	if len(preferred) > 0 && maybeLeader == noLeader {
@@ -1472,14 +1483,17 @@ func (n *raft) StepDown(preferred ...string) error {
 	}
 
 	// If we have a new leader selected, transfer over to them.
+	// Send the append entry directly rather than via the proposals queue,
+	// as we will switch to follower state immediately and will blow away
+	// the contents of the proposal queue in the process.
 	if maybeLeader != noLeader {
-		n.debug("Selected %q for new leader", maybeLeader)
-		prop.push(newEntry(EntryLeaderTransfer, []byte(maybeLeader)))
-	} else {
-		// Force us to stepdown here.
-		n.debug("Stepping down")
-		stepdown.push(noLeader)
+		n.debug("Selected %q for new leader, stepping down due to leadership transfer", maybeLeader)
+		ae := newEntry(EntryLeaderTransfer, []byte(maybeLeader))
+		n.sendAppendEntry([]*Entry{ae})
 	}
+
+	// Force us to stepdown here.
+	n.stepdown(noLeader)
 
 	return nil
 }
@@ -1659,7 +1673,7 @@ func (n *raft) shutdown(shouldDelete bool) {
 	queues := []interface {
 		unregister()
 		drain()
-	}{n.reqs, n.votes, n.prop, n.entry, n.resp, n.apply, n.stepdown}
+	}{n.reqs, n.votes, n.prop, n.entry, n.resp, n.apply}
 	for _, q := range queues {
 		q.drain()
 		q.unregister()
@@ -1947,7 +1961,7 @@ func (n *raft) processAppendEntries() {
 // runAsFollower is called by run and will block for as long as the node is
 // running in the follower state.
 func (n *raft) runAsFollower() {
-	for {
+	for n.State() == Follower {
 		elect := n.electTimer()
 
 		select {
@@ -1999,13 +2013,6 @@ func (n *raft) runAsFollower() {
 			// Because of drain() it is possible that we get nil from popOne().
 			if voteReq, ok := n.reqs.popOne(); ok {
 				n.processVoteRequest(voteReq)
-			}
-		case <-n.stepdown.ch:
-			// We've received a stepdown request, start following the new leader if
-			// we can.
-			if newLeader, ok := n.stepdown.popOne(); ok {
-				n.switchToFollower(newLeader)
-				return
 			}
 		}
 	}
@@ -2342,7 +2349,7 @@ func (n *raft) runAsLeader() {
 	fsub, err := n.subscribe(psubj, n.handleForwardedProposal)
 	if err != nil {
 		n.warn("Error subscribing to forwarded proposals: %v", err)
-		n.stepdown.push(noLeader)
+		n.stepdownLocked(noLeader)
 		n.Unlock()
 		return
 	}
@@ -2350,7 +2357,7 @@ func (n *raft) runAsLeader() {
 	if err != nil {
 		n.warn("Error subscribing to forwarded remove peer proposals: %v", err)
 		n.unsubscribe(fsub)
-		n.stepdown.push(noLeader)
+		n.stepdownLocked(noLeader)
 		n.Unlock()
 		return
 	}
@@ -2397,15 +2404,6 @@ func (n *raft) runAsLeader() {
 					n.doRemovePeerAsLeader(string(b.Data))
 				}
 				entries = append(entries, b)
-				// If this is us sending out a leadership transfer stepdown inline here.
-				if b.Type == EntryLeaderTransfer {
-					// Send out what we have and switch to follower.
-					n.sendAppendEntry(entries)
-					n.prop.recycle(&es)
-					n.debug("Stepping down due to leadership transfer")
-					n.switchToFollower(noLeader)
-					return
-				}
 				// Increment size.
 				sz += len(b.Data) + 1
 				// If below thresholds go ahead and send.
@@ -2429,7 +2427,7 @@ func (n *raft) runAsLeader() {
 			}
 		case <-lq.C:
 			if n.lostQuorum() {
-				n.switchToFollower(noLeader)
+				n.stepdown(noLeader)
 				return
 			}
 		case <-n.votes.ch:
@@ -2439,7 +2437,7 @@ func (n *raft) runAsLeader() {
 				continue
 			}
 			if vresp.term > n.Term() {
-				n.switchToFollower(noLeader)
+				n.stepdown(noLeader)
 				return
 			}
 			n.trackPeer(vresp.peer)
@@ -2447,11 +2445,6 @@ func (n *raft) runAsLeader() {
 			// Because of drain() it is possible that we get nil from popOne().
 			if voteReq, ok := n.reqs.popOne(); ok {
 				n.processVoteRequest(voteReq)
-			}
-		case <-n.stepdown.ch:
-			if newLeader, ok := n.stepdown.popOne(); ok {
-				n.switchToFollower(newLeader)
-				return
 			}
 		case <-n.entry.ch:
 			n.processAppendEntries()
@@ -2623,7 +2616,7 @@ func (n *raft) sendSnapshotToFollower(subject string) (uint64, error) {
 	snap, err := n.loadLastSnapshot()
 	if err != nil {
 		// We need to stepdown here when this happens.
-		n.stepdown.push(noLeader)
+		n.stepdownLocked(noLeader)
 		// We need to reset our state here as well.
 		n.resetWAL()
 		return 0, err
@@ -2689,7 +2682,7 @@ func (n *raft) catchupFollower(ar *appendEntryResponse) {
 		n.warn("Request from follower for entry at index [%d] errored for state %+v - %v", start, state, err)
 		if err == ErrStoreEOF {
 			// If we are here we are seeing a request for an item beyond our state, meaning we should stepdown.
-			n.stepdown.push(noLeader)
+			n.stepdownLocked(noLeader)
 			n.Unlock()
 			arPool.Put(ar)
 			return
@@ -2701,7 +2694,7 @@ func (n *raft) catchupFollower(ar *appendEntryResponse) {
 		// If we are here we are seeing a request for an item we do not have, meaning we should stepdown.
 		// This is possible on a reset of our WAL but the other side has a snapshot already.
 		// If we do not stepdown this can cycle.
-		n.stepdown.push(noLeader)
+		n.stepdownLocked(noLeader)
 		n.Unlock()
 		arPool.Put(ar)
 		return
@@ -2754,7 +2747,7 @@ func (n *raft) applyCommit(index uint64) error {
 			if err != ErrStoreClosed && err != ErrStoreEOF {
 				n.warn("Got an error loading %d index: %v - will reset", index, err)
 				if n.State() == Leader {
-					n.stepdown.push(n.selectNextLeader())
+					n.stepdownLocked(n.selectNextLeader())
 				}
 				// Reset and cancel any catchup.
 				n.resetWAL()
@@ -2831,7 +2824,7 @@ func (n *raft) applyCommit(index uint64) error {
 
 			// If this is us and we are the leader we should attempt to stepdown.
 			if peer == n.id && n.State() == Leader {
-				n.stepdown.push(n.selectNextLeader())
+				n.stepdown(n.selectNextLeader())
 			}
 
 			// Remove from string intern map.
@@ -2962,7 +2955,7 @@ func (n *raft) runAsCandidate() {
 		n.ID(): {},
 	}
 
-	for {
+	for n.State() == Candidate {
 		elect := n.electTimer()
 		select {
 		case <-n.entry.ch:
@@ -3008,19 +3001,14 @@ func (n *raft) runAsCandidate() {
 				n.term = vresp.term
 				n.vote = noVote
 				n.writeTermVote()
-				n.stepdown.push(noLeader)
 				n.lxfer = false
+				n.stepdownLocked(noLeader)
 				n.Unlock()
 			}
 		case <-n.reqs.ch:
 			// Because of drain() it is possible that we get nil from popOne().
 			if voteReq, ok := n.reqs.popOne(); ok {
 				n.processVoteRequest(voteReq)
-			}
-		case <-n.stepdown.ch:
-			if newLeader, ok := n.stepdown.popOne(); ok {
-				n.switchToFollower(newLeader)
-				return
 			}
 		}
 	}
@@ -3182,7 +3170,7 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 				n.writeTermVote()
 			}
 			n.debug("Received append entry from another leader, stepping down to %q", ae.leader)
-			n.stepdown.push(ae.leader)
+			n.stepdownLocked(ae.leader)
 		} else {
 			// Let them know we are the leader.
 			ar := newAppendEntryResponse(n.term, n.pindex, n.id, false)
@@ -3211,7 +3199,7 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 				n.writeTermVote()
 			}
 			n.debug("Received append entry in candidate state from %q, converting to follower", ae.leader)
-			n.stepdown.push(ae.leader)
+			n.stepdownLocked(ae.leader)
 		}
 	}
 
@@ -3274,7 +3262,7 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 		}
 		if n.State() != Follower {
 			n.debug("Term higher than ours and we are not a follower: %v, stepping down to %q", n.State(), ae.leader)
-			n.stepdown.push(ae.leader)
+			n.stepdownLocked(ae.leader)
 		}
 	} else if ae.term < n.term && !catchingUp && isNew {
 		n.debug("Ignoring AppendEntry from a leader (%s) with term %d which is less than ours", ae.leader, ae.term)
@@ -3534,7 +3522,7 @@ func (n *raft) processAppendEntryResponse(ar *appendEntryResponse) {
 		n.vote = noVote
 		n.writeTermVote()
 		n.warn("Detected another leader with higher term, will stepdown and reset")
-		n.stepdown.push(noLeader)
+		n.stepdownLocked(noLeader)
 		n.resetWAL()
 		n.Unlock()
 		arPool.Put(ar)
@@ -3582,7 +3570,7 @@ func (n *raft) storeToWAL(ae *appendEntry) error {
 	if index := ae.pindex + 1; index != seq {
 		n.warn("Wrong index, ae is %+v, index stored was %d, n.pindex is %d, will reset", ae, seq, n.pindex)
 		if n.State() == Leader {
-			n.stepdown.push(n.selectNextLeader())
+			n.stepdownLocked(n.selectNextLeader())
 		}
 		// Reset and cancel any catchup.
 		n.resetWAL()
@@ -3982,7 +3970,7 @@ func (n *raft) processVoteRequest(vr *voteRequest) error {
 		if n.State() != Follower {
 			n.debug("Stepping down from %s, detected higher term: %d vs %d",
 				strings.ToLower(n.State().String()), vr.term, n.term)
-			n.stepdown.push(noLeader)
+			n.stepdownLocked(noLeader)
 		}
 		n.term = vr.term
 		n.vote = noVote
@@ -4117,12 +4105,16 @@ const (
 )
 
 func (n *raft) switchToFollower(leader string) {
+	n.Lock()
+	defer n.Unlock()
+
+	n.switchToFollowerLocked(leader)
+}
+
+func (n *raft) switchToFollowerLocked(leader string) {
 	if n.State() == Closed {
 		return
 	}
-
-	n.Lock()
-	defer n.Unlock()
 
 	n.debug("Switching to follower")
 

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -184,6 +184,21 @@ func TestNRGRecoverFromFollowingNoLeader(t *testing.T) {
 	require_NotEqual(t, rg.leader().node().Term(), term)
 }
 
+func TestNRGInlineStepdown(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	rg := c.createMemRaftGroup("TEST", 3, newStateAdder)
+	rg.waitOnLeader()
+
+	// When StepDown() completes, we should not be the leader. Before,
+	// this would not be guaranteed as the stepdown could be processed
+	// some time later.
+	n := rg.leader().node().(*raft)
+	require_NoError(t, n.StepDown())
+	require_NotEqual(t, n.State(), Leader)
+}
+
 func TestNRGObserverMode(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()


### PR DESCRIPTION
The stepdown channel interleaves with other channels such as the apply queue, leader change notifications etc in the `runAs` goroutines in an unpredictable order, so processing a stepdown request might be delayed behind other work. Doing this inline should be safer with stronger guarantees.

---

We originally raised this in #4990 (in v2.10.11) and then reverted it in #5200 (in v2.10.12) as it was slowing down some asset moves. This was also visible in the `TestJetStreamSuperClusterDoubleStreamMove` and `TestJetStreamSuperClusterMovingStreamAndMoveBack` unit tests.

We believe that the election timer being too eagerly reset was responsible for a slowdown in establishing a new leader and therefore think that the changes in #5315 will have helped here. Both unit tests don't show any particularly different variance in runtimes compared to `main`.

Signed-off-by: Neil Twigg <neil@nats.io>
