### PR TITLE
Change AccountResolver() to use RLock

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3144,9 +3144,9 @@ func (s *Server) SetAccountResolver(ar AccountResolver) {
 
 // AccountResolver returns the registered account resolver.
 func (s *Server) AccountResolver() AccountResolver {
-	s.mu.Lock()
+	s.mu.RLock()
 	ar := s.accResolver
-	s.mu.Unlock()
+	s.mu.RUnlock()
 	return ar
 }
 


### PR DESCRIPTION
`Readloop processing time` on routes would appear sporadically waiting to get the server lock via `AccountResolver()` even if one is not setup.

```
[32554] 2024/04/24 21:10:23.683892 [WRN] 127.0.0.1:6222 - rid:2631 - Readloop processing time: 2.95526175s
ACCOUNT RESOLVER LOCK TOOK 1.830271834s
[32554] 2024/04/24 21:10:23.719838 [DBG] RAFT [sAhlEnh5 - S-R3F-qADugAfB] Not switching to candidate, observer only
goroutine 32490 [running]:
runtime/debug.Stack()
...
github.com/nats-io/nats-server/v2/server.(*Server).AccountResolver(0x140001a6d80)
	github.com/nats-io/nats-server/server/accounts.go:3152 +0xc0
github.com/nats-io/nats-server/v2/server.(*client).processRemoteSub(0x1411e713300, {0x142afef46c4, 0x22, 0x104c59a5c?}, 0x0)
	github.com/nats-io/nats-server/server/route.go:1362 +0x5ac
github.com/nats-io/nats-server/v2/server.(*client).parse(0x1411e713300, {0x142afef46c0, 0x28, 0x40})
	github.com/nats-io/nats-server/server/parser.go:669 +0x2240
github.com/nats-io/nats-server/v2/server.(*client).readLoop(0x1411e713300, {0x0, 0x0, 0x0})
	github.com/nats-io/nats-server/server/client.go:1396 +0x1024
github.com/nats-io/nats-server/v2/server.(*Server).createRoute.func2()
	github.com/nats-io/nats-server/server/route.go:1821 +0x2c
github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
	github.com/nats-io/nats-server/server/server.go:3787 +0x3c
created by github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine in goroutine 32506
	github.com/nats-io/nats-server/server/server.go:3785 +0x154
ACCOUNT RESOLVER LOCK TOOK 1.110604417s
goroutine 32525 [running]:
runtime/debug.Stack()
...
github.com/nats-io/nats-server/v2/server.(*Server).AccountResolver(0x140001a6d80)
	github.com/nats-io/nats-server/server/accounts.go:3152 +0xc0
github.com/nats-io/nats-server/v2/server.(*client).processRemoteSub(0x1438ea69300, {0x1400757405a, 0x26, 0x104c59a5c?}, 0x0)
	github.com/nats-io/nats-server/server/route.go:1362 +0x5ac
github.com/nats-io/nats-server/v2/server.(*client).parse(0x1438ea69300, {0x14007574000, 0xf7, 0x400})
	github.com/nats-io/nats-server/server/parser.go:669 +0x2240
github.com/nats-io/nats-server/v2/server.(*client).readLoop(0x1438ea69300, {0x0, 0x0, 0x0})
	github.com/nats-io/nats-server/server/client.go:1396 +0x1024
github.com/nats-io/nats-server/v2/server.(*Server).createRoute.func2()
	github.com/nats-io/nats-server/server/route.go:1821 +0x2c
github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
	github.com/nats-io/nats-server/server/server.go:3787 +0x3c
created by github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine in goroutine 32413
	github.com/nats-io/nats-server/server/server.go:3785 +0x154
```