### PR TITLE
Fixed `(*Sublist).HasInterest()`

### DIFF
--- a/server/sublist.go
+++ b/server/sublist.go
@@ -621,7 +621,9 @@ func (s *Sublist) hasInterest(subject string, doLock bool) bool {
 	}
 	var matched bool
 	if s.cache != nil {
-		_, matched = s.cache[subject]
+		if r, ok := s.cache[subject]; ok {
+			matched = len(r.psubs)+len(r.qsubs) > 0
+		}
 	}
 	if doLock {
 		s.RUnlock()
@@ -789,7 +791,7 @@ func matchLevelForAny(l *level, toks []string) bool {
 		}
 	}
 	if n != nil {
-		return true
+		return len(n.plist) > 0 || len(n.psubs) > 0 || len(n.qsubs) > 0
 	}
 	if pwc != nil {
 		return true

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -794,7 +794,7 @@ func matchLevelForAny(l *level, toks []string) bool {
 		return len(n.plist) > 0 || len(n.psubs) > 0 || len(n.qsubs) > 0
 	}
 	if pwc != nil {
-		return true
+		return len(pwc.plist) > 0 || len(pwc.psubs) > 0 || len(pwc.qsubs) > 0
 	}
 	return false
 }

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -1655,6 +1655,26 @@ func TestSublistHasInterest(t *testing.T) {
 	require_False(t, sl.HasInterest("foo.bar"))
 	require_False(t, sl.HasInterest("foo.bar.baz"))
 
+	sub = newSub("*.>")
+	sl.Insert(sub)
+	require_False(t, sl.HasInterest("foo"))
+	require_True(t, sl.HasInterest("foo.bar"))
+	require_True(t, sl.HasInterest("foo.baz"))
+	sl.Remove(sub)
+
+	sub = newSub("*.bar")
+	sl.Insert(sub)
+	require_False(t, sl.HasInterest("foo"))
+	require_True(t, sl.HasInterest("foo.bar"))
+	require_False(t, sl.HasInterest("foo.baz"))
+	sl.Remove(sub)
+
+	sub = newSub("*")
+	sl.Insert(sub)
+	require_True(t, sl.HasInterest("foo"))
+	require_False(t, sl.HasInterest("foo.bar"))
+	sl.Remove(sub)
+
 	// Try with queues now.
 	qsub := newQSub("foo", "bar")
 	sl.Insert(qsub)
@@ -1727,6 +1747,25 @@ func TestSublistHasInterest(t *testing.T) {
 	require_False(t, sl.HasInterest("foo.bar"))
 	require_False(t, sl.HasInterest("foo.bar.baz"))
 
+	qsub = newQSub("*.>", "bar")
+	sl.Insert(qsub)
+	require_False(t, sl.HasInterest("foo"))
+	require_True(t, sl.HasInterest("foo.bar"))
+	require_True(t, sl.HasInterest("foo.baz"))
+	sl.Remove(qsub)
+
+	qsub = newQSub("*.bar", "bar")
+	sl.Insert(qsub)
+	require_False(t, sl.HasInterest("foo"))
+	require_True(t, sl.HasInterest("foo.bar"))
+	require_False(t, sl.HasInterest("foo.baz"))
+	sl.Remove(qsub)
+
+	qsub = newQSub("*", "bar")
+	sl.Insert(qsub)
+	require_True(t, sl.HasInterest("foo"))
+	require_False(t, sl.HasInterest("foo.bar"))
+	sl.Remove(qsub)
 }
 
 func subsInit(pre string, toks []string) {

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -1622,6 +1622,111 @@ func TestSublistHasInterest(t *testing.T) {
 		require_True(t, sl.HasInterest("foo"))
 		require_Equal(t, sl.cacheHits, i)
 	}
+
+	// Call Match on a subject we know there is no match.
+	sl.Match("bar")
+	require_False(t, sl.HasInterest("bar"))
+
+	// Remove fooSub and check interest again
+	sl.Remove(fooSub)
+	require_False(t, sl.HasInterest("foo"))
+
+	// Try with some wildcards
+	sub := newSub("foo.*")
+	sl.Insert(sub)
+	require_False(t, sl.HasInterest("foo"))
+	require_True(t, sl.HasInterest("foo.bar"))
+	require_False(t, sl.HasInterest("foo.bar.baz"))
+
+	// Remove sub, there should be no interest
+	sl.Remove(sub)
+	require_False(t, sl.HasInterest("foo"))
+	require_False(t, sl.HasInterest("foo.bar"))
+	require_False(t, sl.HasInterest("foo.bar.baz"))
+
+	sub = newSub("foo.>")
+	sl.Insert(sub)
+	require_False(t, sl.HasInterest("foo"))
+	require_True(t, sl.HasInterest("foo.bar"))
+	require_True(t, sl.HasInterest("foo.bar.baz"))
+
+	sl.Remove(sub)
+	require_False(t, sl.HasInterest("foo"))
+	require_False(t, sl.HasInterest("foo.bar"))
+	require_False(t, sl.HasInterest("foo.bar.baz"))
+
+	// Try with queues now.
+	qsub := newQSub("foo", "bar")
+	sl.Insert(qsub)
+	require_True(t, sl.HasInterest("foo"))
+	require_False(t, sl.HasInterest("foo.bar"))
+
+	qsub2 := newQSub("foo", "baz")
+	sl.Insert(qsub2)
+	require_True(t, sl.HasInterest("foo"))
+	require_False(t, sl.HasInterest("foo.bar"))
+
+	// Remove first queue
+	sl.Remove(qsub)
+	require_True(t, sl.HasInterest("foo"))
+	require_False(t, sl.HasInterest("foo.bar"))
+
+	// Remove last.
+	sl.Remove(qsub2)
+	require_False(t, sl.HasInterest("foo"))
+	require_False(t, sl.HasInterest("foo.bar"))
+
+	// With wildcards now
+	qsub = newQSub("foo.*", "bar")
+	sl.Insert(qsub)
+	require_False(t, sl.HasInterest("foo"))
+	require_True(t, sl.HasInterest("foo.bar"))
+	require_False(t, sl.HasInterest("foo.bar.baz"))
+
+	// Add another queue to the group
+	qsub2 = newQSub("foo.*", "baz")
+	sl.Insert(qsub2)
+	require_False(t, sl.HasInterest("foo"))
+	require_True(t, sl.HasInterest("foo.bar"))
+	require_False(t, sl.HasInterest("foo.bar.baz"))
+
+	// Remove first queue
+	sl.Remove(qsub)
+	require_False(t, sl.HasInterest("foo"))
+	require_True(t, sl.HasInterest("foo.bar"))
+	require_False(t, sl.HasInterest("foo.bar.baz"))
+
+	// Remove last
+	sl.Remove(qsub2)
+	require_False(t, sl.HasInterest("foo"))
+	require_False(t, sl.HasInterest("foo.bar"))
+	require_False(t, sl.HasInterest("foo.bar.baz"))
+
+	qsub = newQSub("foo.>", "bar")
+	sl.Insert(qsub)
+	require_False(t, sl.HasInterest("foo"))
+	require_True(t, sl.HasInterest("foo.bar"))
+	require_True(t, sl.HasInterest("foo.bar.baz"))
+
+	// Add another queue to the group
+	qsub2 = newQSub("foo.>", "baz")
+	sl.Insert(qsub2)
+	require_False(t, sl.HasInterest("foo"))
+	require_True(t, sl.HasInterest("foo.bar"))
+	require_True(t, sl.HasInterest("foo.bar.baz"))
+
+	// Remove first queue
+	sl.Remove(qsub)
+	require_False(t, sl.HasInterest("foo"))
+	require_True(t, sl.HasInterest("foo.bar"))
+	require_True(t, sl.HasInterest("foo.bar.baz"))
+
+	// Remove last
+	sl.Remove(qsub2)
+	require_False(t, sl.HasInterest("foo"))
+	require_False(t, sl.HasInterest("foo.bar"))
+	require_False(t, sl.HasInterest("foo.bar.baz"))
+
 }
 
 func subsInit(pre string, toks []string) {


### PR DESCRIPTION
I made an incorrect comment previously about not needing to check the cache's result to know if there is a match. I added a test for that, but also discovered that there was an issue where `HasInterest()` would incorrectly return true if checking for `foo` when there is only a subscription on `foo.*`. Added more tests.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
