### PR TITLE
[FIXED] Gateway: Outbound may fail to detect stale connection

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -5135,6 +5135,23 @@ func adjustPingInterval(kind int, d time.Duration) time.Duration {
 	return d
 }
 
+// This is used when a connection cannot yet start to send PINGs because
+// the remote would not be able to handle them (case of compression,
+// or outbound gateway, etc...), but we still want to close the connection
+// if the timer has not been reset by the time we reach the time equivalent
+// to have sent the max number of pings.
+//
+// Lock should be held
+func (c *client) watchForStaleConnection(pingInterval time.Duration, pingMax int) {
+	c.ping.tmr = time.AfterFunc(pingInterval*time.Duration(pingMax+1), func() {
+		c.mu.Lock()
+		c.Debugf("Stale Client Connection - Closing")
+		c.enqueueProto([]byte(fmt.Sprintf(errProto, "Stale Connection")))
+		c.mu.Unlock()
+		c.closeConnection(StaleConnection)
+	})
+}
+
 // Lock should be held
 func (c *client) setPingTimer() {
 	if c.srv == nil {

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -910,6 +910,15 @@ func (s *Server) createGateway(cfg *gatewayCfg, url *url.URL, conn net.Conn) {
 		c.Debugf("TLS version %s, cipher suite %s", tlsVersion(cs.Version), tlsCipher(cs.CipherSuite))
 	}
 
+	// For outbound, we can't set the normal ping timer yet since the other
+	// side would fail with a parse error should it receive anything but the
+	// CONNECT protocol as the first protocol. We still want to make sure
+	// that the connection is not stale until the first INFO from the remote
+	// is received.
+	if solicit {
+		c.watchForStaleConnection(adjustPingInterval(GATEWAY, opts.PingInterval), opts.MaxPingsOut)
+	}
+
 	c.mu.Unlock()
 
 	// Announce ourselves again to new connections.

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -6490,15 +6490,15 @@ func TestGatewayAuthDiscovered(t *testing.T) {
 	waitForOutboundGateways(t, srvB, 1, time.Second)
 }
 
-func TestTLSGatewaysCertificateImplicitAllowPass(t *testing.T) {
-	testTLSGatewaysCertificateImplicitAllow(t, true)
+func TestGatewayTLSCertificateImplicitAllowPass(t *testing.T) {
+	testGatewayTLSCertificateImplicitAllow(t, true)
 }
 
-func TestTLSGatewaysCertificateImplicitAllowFail(t *testing.T) {
-	testTLSGatewaysCertificateImplicitAllow(t, false)
+func TestGatewayTLSCertificateImplicitAllowFail(t *testing.T) {
+	testGatewayTLSCertificateImplicitAllow(t, false)
 }
 
-func testTLSGatewaysCertificateImplicitAllow(t *testing.T, pass bool) {
+func testGatewayTLSCertificateImplicitAllow(t *testing.T, pass bool) {
 	// Base config for the servers
 	cfg := createTempFile(t, "cfg")
 	cfg.WriteString(fmt.Sprintf(`
@@ -6988,7 +6988,7 @@ func (l *testMissingOCSPStapleLogger) Errorf(format string, v ...any) {
 	}
 }
 
-func TestOCSPGatewayMissingPeerStapleIssue(t *testing.T) {
+func TestGatewayOCSPMissingPeerStapleIssue(t *testing.T) {
 	const (
 		caCert = "../test/configs/certs/ocsp/ca-cert.pem"
 		caKey  = "../test/configs/certs/ocsp/ca-key.pem"
@@ -7348,4 +7348,64 @@ func TestOCSPGatewayMissingPeerStapleIssue(t *testing.T) {
 	waitForOutboundGateways(t, srvB, 2, 5*time.Second)
 	waitForOutboundGateways(t, srvC, 2, 5*time.Second)
 	wg.Wait()
+}
+
+func TestGatewayOutboundDetectsStaleConnectionIfNoInfo(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require_NoError(t, err)
+	defer l.Close()
+
+	ch := make(chan struct{})
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c, err := l.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		<-ch
+	}()
+
+	url := fmt.Sprintf("nats://%s", l.Addr())
+	o := testGatewayOptionsFromToWithURLs(t, "A", "B", []string{url})
+	o.gatewaysSolicitDelay = time.Millisecond
+	o.DisableShortFirstPing = false
+	o.PingInterval = 50 * time.Millisecond
+	o.MaxPingsOut = 3
+	o.NoLog = false
+	s, err := NewServer(o)
+	require_NoError(t, err)
+	defer s.Shutdown()
+
+	log := &captureDebugLogger{dbgCh: make(chan string, 100)}
+	s.SetLogger(log, true, false)
+	s.Start()
+
+	timeout := time.NewTimer(time.Second)
+	defer timeout.Stop()
+	for done := false; !done; {
+		select {
+		case dbg := <-log.dbgCh:
+			// The server should not send PING because the accept side expects
+			// the CONNECT as the first protocol (otherwise it would be a parse
+			// error if that were to happen).
+			if strings.Contains(dbg, "Ping Timer") {
+				t.Fatalf("The server should not have sent a ping, got %q", dbg)
+			}
+			// However, it should detect at one point that the connection is
+			// stale and close it.
+			if strings.Contains(dbg, "Stale") {
+				done = true
+			}
+		case <-timeout.C:
+			t.Fatalf("Did not capture the stale connection condition")
+		}
+	}
+
+	s.Shutdown()
+	close(ch)
+	wg.Wait()
+	s.WaitForShutdown()
 }

--- a/server/route.go
+++ b/server/route.go
@@ -1773,13 +1773,7 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL, accName string) *clie
 		if opts.Cluster.MaxPingsOut > 0 {
 			pingMax = opts.MaxPingsOut
 		}
-		c.ping.tmr = time.AfterFunc(pingInterval*time.Duration(pingMax+1), func() {
-			c.mu.Lock()
-			c.Debugf("Stale Client Connection - Closing")
-			c.enqueueProto([]byte(fmt.Sprintf(errProto, "Stale Connection")))
-			c.mu.Unlock()
-			c.closeConnection(StaleConnection)
-		})
+		c.watchForStaleConnection(adjustPingInterval(ROUTER, pingInterval), pingMax)
 	} else {
 		// Set the Ping timer
 		c.setFirstPingTimer()


### PR DESCRIPTION
If the first INFO never makes it back and for some reasons the remote also does not close the connection, or connection is half closed, the outbound would not have detected that the connection is stale.

The outbound connection cannot send PING before it receives the INFO from the remote because that is only when the outbound sends the CONNECT. But the remote will fail if the first protocol from an outbound is not CONNECT.

Using the same principle that we used for routes with compression enabled, where PINGs cannot be sent until a certain time in the handshake, we will use the ping timer to simply close the connection as stale if the ping timer has not been reset before the time needed to send the max number of pings.

Resolves #5349

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>