### PR TITLE
[FIXED] Stream catchup would not sync after server crash and restart.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2831,6 +2831,11 @@ func (o *consumer) processAckMsg(sseq, dseq, dc uint64, doSample bool) {
 					}
 				}
 			}
+			// If nothing left set consumer to current delivered.
+			// Do not update stream.
+			if len(o.pending) == 0 {
+				o.adflr = o.dseq - 1
+			}
 		}
 		// We do these regardless.
 		delete(o.rdc, sseq)

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2831,10 +2831,6 @@ func (o *consumer) processAckMsg(sseq, dseq, dc uint64, doSample bool) {
 					}
 				}
 			}
-			// If nothing left set to current delivered.
-			if len(o.pending) == 0 {
-				o.adflr, o.asflr = o.dseq-1, o.sseq-1
-			}
 		}
 		// We do these regardless.
 		delete(o.rdc, sseq)
@@ -3793,9 +3789,12 @@ func (o *consumer) checkAckFloor() {
 	}
 
 	// If we are here, and this should be rare, we still are off with our ack floor.
+	// We will make sure we are not doing un-necessary work here if only off by a bit
+	// since this could be normal for a high activity wq or stream.
 	// We will set it explicitly to 1 behind our current lowest in pending, or if
 	// pending is empty, to our current delivered -1.
-	if o.asflr < ss.FirstSeq-1 {
+	const minOffThreshold = 50
+	if o.asflr < ss.FirstSeq-minOffThreshold {
 		var psseq, pdseq uint64
 		for seq, p := range o.pending {
 			if psseq == 0 || seq < psseq {
@@ -3807,7 +3806,7 @@ func (o *consumer) checkAckFloor() {
 			psseq, pdseq = o.sseq-1, o.dseq-1
 			// If still not adjusted.
 			if psseq < ss.FirstSeq-1 {
-				psseq, pdseq = ss.FirstSeq-1, ss.FirstSeq-1
+				psseq = ss.FirstSeq - 1
 			}
 		} else {
 			// Since this was set via the pending, we should not include

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7021,6 +7021,10 @@ SKIP:
 		purged = fs.state.Msgs
 	}
 	fs.state.Msgs -= purged
+	if fs.state.Msgs == 0 {
+		fs.state.FirstSeq = fs.state.LastSeq + 1
+		fs.state.FirstTime = time.Time{}
+	}
 
 	if bytes > fs.state.Bytes {
 		bytes = fs.state.Bytes

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8060,7 +8060,7 @@ func (mset *stream) isCurrent() bool {
 }
 
 // Maximum requests for the whole server that can be in flight at the same time.
-const maxConcurrentSyncRequests = 16
+const maxConcurrentSyncRequests = 32
 
 var (
 	errCatchupCorruptSnapshot = errors.New("corrupt stream snapshot detected")

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -19512,7 +19512,7 @@ func TestJetStreamConsumerMultipleSubjectsLast(t *testing.T) {
 	})
 	require_NoError(t, err)
 
-	sub, err := js.SubscribeSync("", nats.Bind("name", durable))
+	sub, err := js.SubscribeSync(_EMPTY_, nats.Bind("name", durable))
 	require_NoError(t, err)
 
 	msg, err := sub.NextMsg(time.Millisecond * 500)
@@ -19537,7 +19537,9 @@ func TestJetStreamConsumerMultipleSubjectsLast(t *testing.T) {
 	require_NoError(t, err)
 
 	require_True(t, info.NumAckPending == 0)
-	require_True(t, info.AckFloor.Stream == 8)
+	// Should be 6 since we do not pull "other". We used to jump ack floor ahead
+	// but no longer do that.
+	require_True(t, info.AckFloor.Stream == 6)
 	require_True(t, info.AckFloor.Consumer == 1)
 	require_True(t, info.NumPending == 0)
 }

--- a/server/store.go
+++ b/server/store.go
@@ -724,7 +724,7 @@ func isOutOfSpaceErr(err error) bool {
 var errFirstSequenceMismatch = errors.New("first sequence mismatch")
 
 func isClusterResetErr(err error) bool {
-	return err == errLastSeqMismatch || err == ErrStoreEOF || err == errFirstSequenceMismatch
+	return err == errLastSeqMismatch || err == ErrStoreEOF || err == errFirstSequenceMismatch || err == errCatchupTooManyRetries
 }
 
 // Copy all fields.


### PR DESCRIPTION
We had a bug that would overwrite the sync subject during parallel stream creation which would cause upper layer stream catchups to fail on server crash and subsequent restarts.
    
We also were reporting first sequence mismatch when we hit max retries to force a reset but this was misleading, so added in proper error for max retires limit.

Also on some extreme kill and restart cases our internal checks were being called before complete state was achieved, so delay the initial check and added in periodic checks to ensure replica consistency.

Signed-off-by: Derek Collison <derek@nats.io>