### PR TITLE
Improve stream sourcing consumers stall handling

### DIFF
--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -1501,7 +1501,7 @@ func TestJetStreamClusterMirrorAndSourceExpiration(t *testing.T) {
 	sendBatch(100)
 	// Need to check both in parallel.
 	scheck, mcheck := uint64(0), uint64(0)
-	checkFor(t, 10*time.Second, 50*time.Millisecond, func() error {
+	checkFor(t, 40*time.Second, 500*time.Millisecond, func() error {
 		if scheck != 100 {
 			if si, _ := js.StreamInfo("S"); si != nil {
 				scheck = si.State.Msgs

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -1501,7 +1501,7 @@ func TestJetStreamClusterMirrorAndSourceExpiration(t *testing.T) {
 	sendBatch(100)
 	// Need to check both in parallel.
 	scheck, mcheck := uint64(0), uint64(0)
-	checkFor(t, 40*time.Second, 500*time.Millisecond, func() error {
+	checkFor(t, 20*time.Second, 500*time.Millisecond, func() error {
 		if scheck != 100 {
 			if si, _ := js.StreamInfo("S"); si != nil {
 				scheck = si.State.Msgs

--- a/server/jetstream_sourcing_scaling_test.go
+++ b/server/jetstream_sourcing_scaling_test.go
@@ -1,0 +1,118 @@
+// Copyright 2019-2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/nats-io/nats.go"
+	"testing"
+	"time"
+)
+
+func TestStreamSourcingScalingManySourcing(t *testing.T) {
+	var numSourcing = 10000
+	var numMessages = uint64(1000)
+
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+	s := c.randomServer()
+	urls := s.clientConnectURLs
+	fmt.Printf("Connected to server %+v\n", urls)
+
+	nc, js := jsClientConnect(t, s, nats.Timeout(20*time.Second))
+	defer nc.Close()
+
+	// create a stream to source from
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:                 "source",
+		Subjects:             []string{"foo.>"},
+		Retention:            nats.LimitsPolicy,
+		Storage:              nats.FileStorage,
+		Discard:              nats.DiscardOld,
+		Replicas:             3,
+		AllowDirect:          true,
+		MirrorDirect:         false,
+		DiscardNewPerSubject: false,
+		MaxAge:               time.Duration(60 * time.Minute),
+	})
+	require_NoError(t, err)
+
+	// create n streams that source from it
+	for i := 0; i < numSourcing; i++ {
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:                 fmt.Sprintf("sourcing-%d", i),
+			Sources:              []*nats.StreamSource{{Name: "source", FilterSubject: fmt.Sprintf("foo.%d", i)}},
+			Retention:            nats.LimitsPolicy,
+			Storage:              nats.FileStorage,
+			Discard:              nats.DiscardOld,
+			Replicas:             1,
+			AllowDirect:          true,
+			MirrorDirect:         false,
+			DiscardNewPerSubject: false,
+			MaxAge:               time.Duration(60 * time.Minute),
+		})
+		require_NoError(t, err)
+	}
+
+	fmt.Printf("Streams created\n")
+
+	// publish n messages for each sourcer in the source stream
+	for j := uint64(0); j < numMessages; j++ {
+		start := time.Now()
+		for i := 0; i < numSourcing; i++ {
+			_, err = js.Publish(fmt.Sprintf("foo.%d", i), []byte("hello"))
+			require_NoError(t, err)
+		}
+		end := time.Now()
+		fmt.Printf("Published round %d, avg pub latency %v\n", j, end.Sub(start)/time.Duration(numSourcing))
+	}
+
+	fmt.Printf("Messages published\n")
+	time.Sleep(100 * time.Millisecond)
+
+	// cause a leader stepdown
+	resp, err := nc.Request(fmt.Sprintf(JSApiStreamLeaderStepDownT, "source"), nil, time.Second)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	var sdResp JSApiStreamLeaderStepDownResponse
+	if err := json.Unmarshal(resp.Data, &sdResp); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if sdResp.Error != nil {
+		t.Fatalf("Unexpected error: %+v", sdResp.Error)
+	}
+
+	fmt.Printf("Leader stepdown done\n")
+
+	for i := 0; i < numSourcing; i++ {
+		// publish one message for each sourcer into the source stream
+		_, err = js.Publish(fmt.Sprintf("foo.%d", i), []byte("hello"))
+		require_NoError(t, err)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	for i := 0; i < numSourcing; i++ {
+		// check that each sourcer has the message
+		state, err := js.StreamInfo(fmt.Sprintf("sourcing-%d", i))
+		require_NoError(t, err)
+		if state.State.Msgs != numMessages+1 {
+			t.Fatalf("Expected %d messages, got %d", numMessages, state.State.Msgs)
+		}
+		fmt.Printf("Stream sourcing-%d has %d messages\n", i, state.State.Msgs)
+	}
+
+}

--- a/server/jetstream_sourcing_scaling_test.go
+++ b/server/jetstream_sourcing_scaling_test.go
@@ -41,7 +41,7 @@ func TestStreamSourcingScalingManySourcing(t *testing.T) {
 		Retention:            nats.LimitsPolicy,
 		Storage:              nats.FileStorage,
 		Discard:              nats.DiscardOld,
-		Replicas:             3,
+		Replicas:             1,
 		AllowDirect:          true,
 		MirrorDirect:         false,
 		DiscardNewPerSubject: false,

--- a/server/jetstream_sourcing_scaling_test.go
+++ b/server/jetstream_sourcing_scaling_test.go
@@ -120,7 +120,7 @@ func TestStreamSourcingScalingManySourcing(t *testing.T) {
 }
 
 func TestStreamSourcingScalingSourcingMany(t *testing.T) {
-	//t.Skip()
+	t.Skip()
 
 	var numSourced = 10000
 	var numMsgPerSource = uint64(1000)

--- a/server/jetstream_sourcing_scaling_test.go
+++ b/server/jetstream_sourcing_scaling_test.go
@@ -120,7 +120,7 @@ func TestStreamSourcingScalingManySourcing(t *testing.T) {
 }
 
 func TestStreamSourcingScalingSourcingMany(t *testing.T) {
-	t.Skip()
+	//t.Skip()
 
 	var numSourced = 10000
 	var numMsgPerSource = uint64(1000)
@@ -203,7 +203,7 @@ func TestStreamSourcingScalingSourcingMany(t *testing.T) {
 
 		for i := 0; i < numSourced; i++ {
 			select {
-			case _ = <-pafs[i].Ok():
+			case <-pafs[i].Ok():
 			case psae := <-pafs[i].Err():
 				fmt.Printf("Error on PubAckFuture: %v, retrying sync...\n", psae)
 				retries++

--- a/server/jetstream_sourcing_scaling_test.go
+++ b/server/jetstream_sourcing_scaling_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 )
 
+// This test is being skipped by CI as it takes too long to run and is meant to test the scalability of sourcing
+// rather than being a unit test.
 func TestStreamSourcingScalingManySourcing(t *testing.T) {
 	t.Skip()
 
@@ -119,6 +121,8 @@ func TestStreamSourcingScalingManySourcing(t *testing.T) {
 
 }
 
+// This test is being skipped by CI as it takes too long to run and is meant to test the scalability of sourcing
+// rather than being a unit test.
 func TestStreamSourcingScalingSourcingMany(t *testing.T) {
 	t.Skip()
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -2125,7 +2125,7 @@ func (mset *stream) mirrorInfo() *StreamSourceInfo {
 	return mset.sourceInfo(mset.mirror)
 }
 
-const sourceHealthCheckInterval = 20 * time.Second
+const sourceHealthCheckInterval = 10 * time.Second
 
 // Will run as a Go routine to process mirror consumer messages.
 func (mset *stream) processMirrorMsgs(mirror *sourceInfo, ready *sync.WaitGroup) {

--- a/server/stream.go
+++ b/server/stream.go
@@ -2125,7 +2125,7 @@ func (mset *stream) mirrorInfo() *StreamSourceInfo {
 	return mset.sourceInfo(mset.mirror)
 }
 
-const sourceHealthCheckInterval = 10 * time.Second
+const sourceHealthCheckInterval = 5 * time.Second
 
 // Will run as a Go routine to process mirror consumer messages.
 func (mset *stream) processMirrorMsgs(mirror *sourceInfo, ready *sync.WaitGroup) {


### PR DESCRIPTION
- Resets the stalling detection timestamp upon re-creating the consumer
- Adjust the idle heart beat for source/mirror consumers from 1s to 5s