### PR TITLE
[IMPROVED] Handling of sourcing into a WQ/Interest streamwith a limit and discard new

### DIFF
--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -241,7 +242,7 @@ func TestJetStreamClusterSourceWorkingQueueWithLimit(t *testing.T) {
 
 	sendBatch := func(subject string, n int) {
 		for i := 0; i < n; i++ {
-			_, err = js.Publish(subject, []byte("OK"))
+			_, err = js.Publish(subject, []byte(strconv.Itoa(i)))
 			require_NoError(t, err)
 		}
 	}
@@ -267,6 +268,9 @@ func TestJetStreamClusterSourceWorkingQueueWithLimit(t *testing.T) {
 		for i := 0; i < 300; i++ {
 			m, err := ss.Fetch(1, nats.MaxWait(3*time.Second))
 			require_NoError(t, err)
+			p, err := strconv.Atoi(string(m[0].Data))
+			require_NoError(t, err)
+			require_Equal(t, p, i)
 			time.Sleep(11 * time.Millisecond)
 			err = m[0].Ack()
 			require_NoError(t, err)


### PR DESCRIPTION
Small improvement to the handling of sourcing into a WQ/Interest stream with a limit and discard new.
 
 Avoids re-scanning the stream to find the consumer's starting sequence number for that source every time. Do not log a warning every time this happens as it becomes constant log spam for something that happens temporarily all the time.

Strengthen test TestJetStreamClusterSourceWorkingQueueWithLimit to also check the payload (to catch for example the same message being sourced more than once, or messages not getting sourced).