### PR TITLE
Fix cleanup of messages that lost interest after consumer FilterSubject update

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -5274,9 +5274,9 @@ func (o *consumer) stopWithFlags(dflag, sdflag, doSignal, advisory bool) error {
 // We need to optionally remove all messages since we are interest based retention.
 // We will do this consistently on all replicas. Note that if in clustered mode the non-leader
 // consumers will need to restore state first.
-// delete marks whether the consumer is being deleted, and should not be counted against interest.
+// ignoreInterest marks whether the consumer should be ignored when determining interest.
 // No lock held on entry.
-func (o *consumer) cleanupNoInterestMessages(mset *stream, delete bool) {
+func (o *consumer) cleanupNoInterestMessages(mset *stream, ignoreInterest bool) {
 	state := mset.state()
 	stop := state.LastSeq
 	o.mu.Lock()
@@ -5290,9 +5290,9 @@ func (o *consumer) cleanupNoInterestMessages(mset *stream, delete bool) {
 		start = state.FirstSeq
 	}
 
-	// Ignore consumer if deleting, don't ignore if updating.
+	// Consumer's interests are ignored by default. If we should not ignore interest, unset.
 	co := o
-	if !delete {
+	if !ignoreInterest {
 		co = nil
 	}
 

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -23415,3 +23415,54 @@ func TestJetStreamDirectGetMultiPaging(t *testing.T) {
 		processPartial(b + 1) // 100 + EOB
 	}
 }
+
+// https://github.com/nats-io/nats-server/issues/4878
+func TestInterestConsumerFilterEdit(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "INTEREST",
+		Retention: nats.InterestPolicy,
+		Subjects:  []string{"interest.>"},
+	})
+	require_NoError(t, err)
+
+	_, err = js.AddConsumer("INTEREST", &nats.ConsumerConfig{
+		Durable:       "C0",
+		FilterSubject: "interest.>",
+		AckPolicy:     nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		_, err = js.Publish(fmt.Sprintf("interest.%d", i), []byte(strconv.Itoa(i)))
+		require_NoError(t, err)
+	}
+
+	// we check we got 10 messages
+	nfo, err := js.StreamInfo("INTEREST")
+	require_NoError(t, err)
+	if nfo.State.Msgs != 10 {
+		t.Fatalf("expected 10 messages got %d", nfo.State.Msgs)
+	}
+
+	// now we lower the consumer interest from all subjects to 1,
+	// then check the stream state and check if interest behavior still works
+	_, err = js.UpdateConsumer("INTEREST", &nats.ConsumerConfig{
+		Durable:       "C0",
+		FilterSubject: "interest.1",
+		AckPolicy:     nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	// we should now have only one message left
+	nfo, err = js.StreamInfo("INTEREST")
+	require_NoError(t, err)
+	if nfo.State.Msgs != 1 {
+		t.Fatalf("expected 1 message got %d", nfo.State.Msgs)
+	}
+}


### PR DESCRIPTION
When deleting a consumer, messages that lost interest would be deleted from the stream.
The same would not happen for messages that lost interest due to a consumer `FilterSubject` update.

This PR fixes that by extracting the cleanup logic that happened on delete and reuse it on update.

The tests are trimmed down versions of the unit test described here: https://github.com/nats-io/nats-server/issues/4878#issuecomment-2025831232.
These are duplicates of each other, apart from the `Replicas: 3` for the clustered setup (and of course in `jetstream_test.go` vs `jetstream_cluster_4_test.go`).  Please let me know if and how those should be deduped if you'd prefer them to be. :slightly_smiling_face: 

Resolves https://github.com/nats-io/nats-server/issues/4878

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>