### PR TITLE
[IMPROVED] Streams ingest performance with many stream sources.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -429,8 +429,7 @@ const (
 	// JsDeleteWaitTimeDefault is the default amount of time we will wait for non-durable
 	// consumers to be in an inactive state before deleting them.
 	JsDeleteWaitTimeDefault = 5 * time.Second
-	// JsFlowControlMaxPending specifies default pending bytes during flow control that can be
-	// outstanding.
+	// JsFlowControlMaxPending specifies default pending bytes during flow control that can be outstanding.
 	JsFlowControlMaxPending = 32 * 1024 * 1024
 	// JsDefaultMaxAckPending is set for consumers with explicit ack that do not set the max ack pending.
 	JsDefaultMaxAckPending = 1000
@@ -1177,17 +1176,12 @@ func (o *consumer) clearNode() {
 
 // IsLeader will return if we are the current leader.
 func (o *consumer) IsLeader() bool {
-	o.mu.RLock()
-	defer o.mu.RUnlock()
 	return o.isLeader()
 }
 
 // Lock should be held.
 func (o *consumer) isLeader() bool {
-	if o.node != nil {
-		return o.node.Leader()
-	}
-	return true
+	return o.leader.Load()
 }
 
 func (o *consumer) setLeader(isLeader bool) {
@@ -1536,15 +1530,15 @@ func (o *consumer) setCreatedTime(created time.Time) {
 // that, but in the absence of local interest and presence of gateways or service imports we need
 // to check those as well.
 func (o *consumer) hasDeliveryInterest(localInterest bool) bool {
-	o.mu.Lock()
+	o.mu.RLock()
 	mset := o.mset
 	if mset == nil {
-		o.mu.Unlock()
+		o.mu.RUnlock()
 		return false
 	}
 	acc := o.acc
 	deliver := o.cfg.DeliverSubject
-	o.mu.Unlock()
+	o.mu.RUnlock()
 
 	if localInterest {
 		return true
@@ -4103,7 +4097,8 @@ func (o *consumer) loopAndGatherMsgs(qch chan struct{}) {
 
 		// If given request fulfilled batch size, but there are still pending bytes, send information about it.
 		if wrn <= 0 && wrb > 0 {
-			o.outq.send(newJSPubMsg(dsubj, _EMPTY_, _EMPTY_, fmt.Appendf(nil, JsPullRequestRemainingBytesT, JSPullRequestPendingMsgs, wrn, JSPullRequestPendingBytes, wrb), nil, nil, 0))
+			msg := fmt.Appendf(nil, JsPullRequestRemainingBytesT, JSPullRequestPendingMsgs, wrn, JSPullRequestPendingBytes, wrb)
+			o.outq.send(newJSPubMsg(dsubj, _EMPTY_, _EMPTY_, msg, nil, nil, 0))
 		}
 		// Reset our idle heartbeat timer if set.
 		if hb != nil {

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5859,7 +5859,7 @@ checkCache:
 	// We want to hold the mb lock here to avoid any changes to state.
 	buf, err := mb.loadBlock(nil)
 	if err != nil {
-		mb.fs.warn("loadBlock error: ", err)
+		mb.fs.warn("loadBlock error: %v", err)
 		if err == errNoBlkData {
 			if ld, _, err := mb.rebuildStateLocked(); err != nil && ld != nil {
 				// Rebuild fs state too.

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -6286,7 +6286,7 @@ func (fs *fileStore) LoadNextMsgMulti(sl *Sublist, start uint64, smp *StoreMsg) 
 	if fs.closed {
 		return nil, 0, ErrStoreClosed
 	}
-	if fs.state.Msgs == 0 {
+	if fs.state.Msgs == 0 || start > fs.state.LastSeq {
 		return nil, fs.state.LastSeq, ErrStoreEOF
 	}
 	if start < fs.state.FirstSeq {
@@ -6320,7 +6320,7 @@ func (fs *fileStore) LoadNextMsg(filter string, wc bool, start uint64, sm *Store
 	if fs.closed {
 		return nil, 0, ErrStoreClosed
 	}
-	if fs.state.Msgs == 0 {
+	if fs.state.Msgs == 0 || start > fs.state.LastSeq {
 		return nil, fs.state.LastSeq, ErrStoreEOF
 	}
 	if start < fs.state.FirstSeq {

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -6371,7 +6371,7 @@ func TestFileStoreFSSMeta(t *testing.T) {
 	require_False(t, stillHasCache)
 
 	// Let fss expire via SubjectStateExpire.
-	time.Sleep(time.Second)
+	time.Sleep(1500 * time.Millisecond)
 
 	var noFSS bool
 	fs.mu.RLock()

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -1481,6 +1481,9 @@ func TestJetStreamClusterMirrorAndSourceExpiration(t *testing.T) {
 		}
 	}
 
+	// Allow direct sync consumers to connect.
+	time.Sleep(1500 * time.Millisecond)
+
 	sendBatch(100)
 	checkTest(100)
 	checkMirror(100)

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 The NATS Authors
+// Copyright 2020-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -40,7 +40,7 @@ func init() {
 	hbInterval = 50 * time.Millisecond
 	minElectionTimeout = 750 * time.Millisecond
 	maxElectionTimeout = 2500 * time.Millisecond
-	lostQuorumInterval = 500 * time.Millisecond
+	lostQuorumInterval = 1 * time.Second
 	lostQuorumCheck = 4 * hbInterval
 }
 

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 The NATS Authors
+// Copyright 2020-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -1996,7 +1996,7 @@ func TestJetStreamSuperClusterMovingStreamsWithMirror(t *testing.T) {
 	}()
 
 	// Let it get going.
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(1500 * time.Millisecond)
 
 	// Now move the source to a new cluster.
 	_, err = js.UpdateStream(&nats.StreamConfig{
@@ -2531,7 +2531,7 @@ func TestJetStreamSuperClusterStateOnRestartPreventsConsumerRecovery(t *testing.
 		require_NoError(t, err)
 	}
 	sub := natsSubSync(t, nc, "d")
-	natsNexMsg(t, sub, time.Second)
+	natsNexMsg(t, sub, 5*time.Second)
 
 	c := sc.clusterForName("C2")
 	cl := c.consumerLeader("$G", "DS", "dlc")

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -11994,7 +11994,7 @@ func TestJetStreamStreamSourceFromKV(t *testing.T) {
 	rev1, err := kv.Create("key", []byte("value1"))
 	require_NoError(t, err)
 
-	m, err := ss.Fetch(1, nats.MaxWait(500*time.Millisecond))
+	m, err := ss.Fetch(1, nats.MaxWait(2*time.Second))
 	require_NoError(t, err)
 	require_NoError(t, m[0].Ack())
 	if string(m[0].Data) != "value1" {
@@ -21723,6 +21723,7 @@ func TestJetStreamLimitsToInterestPolicy(t *testing.T) {
 	// another consumer info just to be sure.
 	// require_NoError(t, err)
 	c.waitOnAllCurrent()
+	c.waitOnConsumerLeader(globalAccountName, "TEST", cname)
 	cinfo, err = js.ConsumerInfo("TEST", cname)
 	require_NoError(t, err)
 	require_Equal(t, cinfo.Config.Replicas, streamCfg.Replicas)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -16808,7 +16808,7 @@ func TestJetStreamWorkQueueSourceRestart(t *testing.T) {
 	sub, err := js.PullSubscribe("foo", "dur", nats.BindStream("TEST"))
 	require_NoError(t, err)
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 
 	ci, err := js.ConsumerInfo("TEST", "dur")
 	require_NoError(t, err)

--- a/server/stream.go
+++ b/server/stream.go
@@ -257,6 +257,7 @@ type stream struct {
 	sources              map[string]*sourceInfo
 	sourceSetupSchedules map[string]*time.Timer
 	sourcesConsumerSetup *time.Timer
+	smsgs                *ipQueue[*inMsg] // Intra-process queue for all incoming sourced messages.
 
 	// Indicates we have direct consumers.
 	directs int
@@ -294,7 +295,6 @@ type stream struct {
 	clseq      uint64            // The current last seq being proposed to the NRG layer.
 	clfs       uint64            // The count (offset) of the number of failed NRG sequences used to compute clseq.
 	inflight   map[uint64]uint64 // Inflight message sizes per clseq.
-	leader     string            // The current leader for the RAFT group.
 	lqsent     time.Time         // The time at which the last lost quorum advisory was sent. Used to rate limit.
 	uch        chan struct{}     // The channel to signal updates to the monitor routine.
 	compressOK bool              // True if we can do message compression in RAFT and catchup logic
@@ -324,11 +324,10 @@ type sourceInfo struct {
 	msgs  *ipQueue[*inMsg]    // Intra-process queue for incoming messages.
 	sseq  uint64              // Last stream message sequence number seen from the source.
 	dseq  uint64              // Last delivery (i.e. consumer's) sequence number.
-	start time.Time           // The time of the last message recorded in the stream doing the sourcing.
 	lag   uint64              // 0 or number of messages pending (as last reported by the consumer) - 1.
 	err   *ApiError           // The API error that caused the last consumer setup to fail.
 	fails int                 // The number of times trying to setup the consumer failed.
-	last  time.Time           // Time the consumer was created or of last message it received.
+	last  atomic.Int64        // Time the consumer was created or of last message it received.
 	lreq  time.Time           // The last time setupMirrorConsumer/setupSourceConsumer was called.
 	qch   chan struct{}       // Quit channel.
 	sip   bool                // Setup in progress.
@@ -850,6 +849,10 @@ func (mset *stream) setLeader(isLeader bool) error {
 		mset.startClusterSubs()
 		// Setup subscriptions
 		if err := mset.subscribeToStream(); err != nil {
+			if isLeader && mset.isClustered() {
+				// Stepdown since we have an error.
+				mset.node.StepDown()
+			}
 			mset.mu.Unlock()
 			return err
 		}
@@ -865,12 +868,6 @@ func (mset *stream) setLeader(isLeader bool) error {
 		mset.unsubscribeToStream(false)
 		// Clear catchup state
 		mset.clearAllCatchupPeers()
-	}
-	// Track group leader.
-	if mset.isClustered() {
-		mset.leader = mset.node.GroupLeader()
-	} else {
-		mset.leader = _EMPTY_
 	}
 	mset.mu.Unlock()
 
@@ -2110,10 +2107,10 @@ func (mset *stream) sourceInfo(si *sourceInfo) *StreamSourceInfo {
 	ssi.SubjectTransforms = trConfigs
 
 	// If we have not heard from the source, set Active to -1.
-	if si.last.IsZero() {
+	if last := si.last.Load(); last == 0 {
 		ssi.Active = -1
 	} else {
-		ssi.Active = time.Since(si.last)
+		ssi.Active = time.Since(time.Unix(0, last))
 	}
 
 	var ext *ExternalStream
@@ -2138,7 +2135,12 @@ func (mset *stream) mirrorInfo() *StreamSourceInfo {
 	return mset.sourceInfo(mset.mirror)
 }
 
-const sourceHealthCheckInterval = 5 * time.Second
+const (
+	// Our consumer HB interval.
+	sourceHealthHB = 1 * time.Second
+	// How often we check and our stalled interval.
+	sourceHealthCheckInterval = 10 * time.Second
+)
 
 // Will run as a Go routine to process mirror consumer messages.
 func (mset *stream) processMirrorMsgs(mirror *sourceInfo, ready *sync.WaitGroup) {
@@ -2152,7 +2154,7 @@ func (mset *stream) processMirrorMsgs(mirror *sourceInfo, ready *sync.WaitGroup)
 	mset.mu.Lock()
 	msgs, qch, siqch := mirror.msgs, mset.qch, mirror.qch
 	// Set the last seen as now so that we don't fail at the first check.
-	mirror.last = time.Now()
+	mirror.last.Store(time.Now().UnixNano())
 	mset.mu.Unlock()
 
 	// Signal the caller that we have captured the above fields.
@@ -2183,12 +2185,14 @@ func (mset *stream) processMirrorMsgs(mirror *sourceInfo, ready *sync.WaitGroup)
 				if !mset.processInboundMirrorMsg(im) {
 					break
 				}
+				im.returnToPool()
 			}
 			msgs.recycle(&ims)
 		case <-t.C:
 			mset.mu.RLock()
 			isLeader := mset.isLeader()
-			stalled := mset.mirror != nil && time.Since(mset.mirror.last) > 3*sourceHealthCheckInterval
+			last := time.Unix(0, mset.mirror.last.Load())
+			stalled := mset.mirror != nil && time.Since(last) > sourceHealthCheckInterval
 			mset.mu.RUnlock()
 			// No longer leader.
 			if !isLeader {
@@ -2232,9 +2236,6 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 		mset.mu.Unlock()
 		return false
 	}
-
-	mset.mirror.last = time.Now()
-	node := mset.node
 
 	// Check for heartbeats and flow control messages.
 	if isControl {
@@ -2306,20 +2307,22 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 	}
 
 	// Do the subject transform if there's one
-
-	for _, tr := range mset.mirror.trs {
-		if tr == nil {
-			continue
-		} else {
-			tsubj, err := tr.Match(m.subj)
-			if err == nil {
-				m.subj = tsubj
-				break
+	if len(mset.mirror.trs) > 0 {
+		for _, tr := range mset.mirror.trs {
+			if tr == nil {
+				continue
+			} else {
+				tsubj, err := tr.Match(m.subj)
+				if err == nil {
+					m.subj = tsubj
+					break
+				}
 			}
 		}
 	}
 
 	s, js, stype := mset.srv, mset.js, mset.cfg.Storage
+	node := mset.node
 	mset.mu.Unlock()
 
 	var err error
@@ -2533,15 +2536,16 @@ func (mset *stream) setupMirrorConsumer() error {
 	req := &CreateConsumerRequest{
 		Stream: mset.cfg.Mirror.Name,
 		Config: ConsumerConfig{
-			DeliverSubject: deliverSubject,
-			DeliverPolicy:  DeliverByStartSequence,
-			OptStartSeq:    state.LastSeq + 1,
-			AckPolicy:      AckNone,
-			AckWait:        22 * time.Hour,
-			MaxDeliver:     1,
-			Heartbeat:      sourceHealthCheckInterval,
-			FlowControl:    true,
-			Direct:         true,
+			DeliverSubject:    deliverSubject,
+			DeliverPolicy:     DeliverByStartSequence,
+			OptStartSeq:       state.LastSeq + 1,
+			AckPolicy:         AckNone,
+			AckWait:           22 * time.Hour,
+			MaxDeliver:        1,
+			Heartbeat:         sourceHealthHB,
+			FlowControl:       true,
+			Direct:            true,
+			InactiveThreshold: sourceHealthCheckInterval,
 		},
 	}
 
@@ -2681,7 +2685,8 @@ func (mset *stream) setupMirrorConsumer() error {
 				msgs := mirror.msgs
 				sub, err := mset.subscribeInternal(deliverSubject, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
 					hdr, msg := c.msgParts(copyBytes(rmsg)) // Need to copy.
-					mset.queueInbound(msgs, subject, reply, hdr, msg, nil)
+					mset.queueInbound(msgs, subject, reply, hdr, msg, nil, nil)
+					mirror.last.Store(time.Now().UnixNano())
 				})
 				if err != nil {
 					mirror.err = NewJSMirrorConsumerSetupFailedError(err, Unless(err))
@@ -2796,7 +2801,7 @@ func (mset *stream) cancelSourceInfo(si *sourceInfo) {
 
 const sourceConsumerRetryThreshold = 2 * time.Second
 
-// This is the main function to call when needing to setup a new consumer for the source
+// This is the main function to call when needing to setup a new consumer for the source.
 // It actually only does the scheduling of the execution of trySetupSourceConsumer in order to implement retry backoff
 // and throttle the number of requests.
 // Lock should be held.
@@ -2830,7 +2835,7 @@ func (mset *stream) setupSourceConsumer(iname string, seq uint64, startTime time
 	}
 
 	// Always add some jitter
-	scheduleDelay += time.Duration(rand.Intn(int(10*time.Millisecond))) + 10*time.Millisecond
+	scheduleDelay += time.Duration(rand.Intn(int(100*time.Millisecond))) + 100*time.Millisecond
 
 	// Schedule the call to trySetupSourceConsumer
 	mset.sourceSetupSchedules[iname] = time.AfterFunc(scheduleDelay, func() {
@@ -2845,8 +2850,8 @@ func (mset *stream) setupSourceConsumer(iname string, seq uint64, startTime time
 // This is where we will actually try to create a new consumer for the source
 // Lock should be held.
 func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime time.Time) {
-	// Ignore if closed.
-	if mset.closed.Load() {
+	// Ignore if closed or not leader.
+	if mset.closed.Load() || !mset.isLeader() {
 		return
 	}
 
@@ -2854,6 +2859,7 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 	if si == nil {
 		return
 	}
+
 	// Cancel previous instance if applicable
 	mset.cancelSourceInfo(si)
 
@@ -2877,13 +2883,14 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 	req := &CreateConsumerRequest{
 		Stream: si.name,
 		Config: ConsumerConfig{
-			DeliverSubject: deliverSubject,
-			AckPolicy:      AckNone,
-			AckWait:        22 * time.Hour,
-			MaxDeliver:     1,
-			Heartbeat:      sourceHealthCheckInterval,
-			FlowControl:    true,
-			Direct:         true,
+			DeliverSubject:    deliverSubject,
+			AckPolicy:         AckNone,
+			AckWait:           22 * time.Hour,
+			MaxDeliver:        1,
+			Heartbeat:         sourceHealthHB,
+			FlowControl:       true,
+			Direct:            true,
+			InactiveThreshold: sourceHealthCheckInterval,
 		},
 	}
 
@@ -2895,20 +2902,22 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 		if ssi.OptStartSeq > 0 {
 			req.Config.OptStartSeq = ssi.OptStartSeq
 			req.Config.DeliverPolicy = DeliverByStartSequence
-		} else if ssi.OptStartTime != nil {
-			// Check to see if our configured start is before what we remember.
-			// Applicable on restart similar to below.
-			if ssi.OptStartTime.Before(si.start) {
-				req.Config.OptStartTime = &si.start
-			} else {
-				req.Config.OptStartTime = ssi.OptStartTime
+		} else {
+			// We have not recovered state so check that configured time is less that our first seq time.
+			var state StreamState
+			mset.store.FastState(&state)
+			if ssi.OptStartTime != nil {
+				if !state.LastTime.IsZero() && ssi.OptStartTime.Before(state.LastTime) {
+					req.Config.OptStartTime = &state.LastTime
+				} else {
+					req.Config.OptStartTime = ssi.OptStartTime
+				}
+				req.Config.DeliverPolicy = DeliverByStartTime
+			} else if state.FirstSeq > 1 && !state.LastTime.IsZero() {
+				req.Config.OptStartTime = &state.LastTime
 			}
-			req.Config.DeliverPolicy = DeliverByStartTime
-		} else if !si.start.IsZero() {
-			// We are falling back to time based startup on a recover, but our messages are gone. e.g. purge, expired, retention policy.
-			req.Config.OptStartTime = &si.start
-			req.Config.DeliverPolicy = DeliverByStartTime
 		}
+
 	} else {
 		req.Config.OptStartSeq = seq
 		req.Config.DeliverPolicy = DeliverByStartSequence
@@ -2997,13 +3006,9 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 			mset.mu.Unlock()
 		}()
 
-		// Wait for previous processSourceMsgs go routine to be completely done.
-		// If none is running, this will not block.
-		si.wg.Wait()
-
 		select {
 		case ccr := <-respCh:
-			ready := sync.WaitGroup{}
+			//			ready := sync.WaitGroup{}
 			mset.mu.Lock()
 			// Check that it has not been removed or canceled (si.sub would be nil)
 			if si := mset.sources[iname]; si != nil {
@@ -3019,14 +3024,37 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 					mset.mu.Unlock()
 					return
 				} else {
+					// Check if our shared msg queue and go routine is running or not.
+					if mset.smsgs == nil {
+						qname := fmt.Sprintf("[ACC:%s] stream sources '%s' msgs", mset.acc.Name, mset.cfg.Name)
+						mset.smsgs = newIPQueue[*inMsg](mset.srv, qname)
+						mset.srv.startGoRoutine(func() { mset.processAllSourceMsgs() },
+							pprofLabels{
+								"type":    "source",
+								"account": mset.acc.Name,
+								"stream":  mset.cfg.Name,
+							},
+						)
+					}
+
 					// Setup actual subscription to process messages from our source.
-					qname := fmt.Sprintf("[ACC:%s] stream source '%s' from '%s' msgs", mset.acc.Name, mset.cfg.Name, si.name)
-					// Create a new queue each time
-					si.msgs = newIPQueue[*inMsg](mset.srv, qname)
-					msgs := si.msgs
+					if si.sseq != ccr.ConsumerInfo.Delivered.Stream {
+						si.sseq = ccr.ConsumerInfo.Delivered.Stream + 1
+					}
+					// Capture consumer name.
+					si.cname = ccr.ConsumerInfo.Name
+
+					// Do not set si.sseq to seq here. si.sseq will be set in processInboundSourceMsg
+					si.dseq = 0
+					si.qch = make(chan struct{})
+					// Set the last seen as now so that we don't fail at the first check.
+					si.last.Store(time.Now().UnixNano())
+
+					msgs := mset.smsgs
 					sub, err := mset.subscribeInternal(deliverSubject, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
 						hdr, msg := c.msgParts(copyBytes(rmsg)) // Need to copy.
-						mset.queueInbound(msgs, subject, reply, hdr, msg, nil)
+						mset.queueInbound(msgs, subject, reply, hdr, msg, si, nil)
+						si.last.Store(time.Now().UnixNano())
 					})
 					if err != nil {
 						si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
@@ -3036,32 +3064,10 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 					}
 					// Save our sub.
 					si.sub = sub
-
-					if si.sseq != ccr.ConsumerInfo.Delivered.Stream {
-						si.sseq = ccr.ConsumerInfo.Delivered.Stream + 1
-					}
-					// Capture consumer name.
-					si.cname = ccr.ConsumerInfo.Name
-					// Do not set si.sseq to seq here. si.sseq will be set in processInboundSourceMsg
-					si.dseq = 0
-					si.qch = make(chan struct{})
-					si.wg.Add(1)
-					ready.Add(1)
-					if !mset.srv.startGoRoutine(
-						func() { mset.processSourceMsgs(si, &ready) },
-						pprofLabels{
-							"type":     "source",
-							"account":  mset.acc.Name,
-							"stream":   mset.cfg.Name,
-							"consumer": si.cname,
-						},
-					) {
-						ready.Done()
-					}
 				}
 			}
 			mset.mu.Unlock()
-			ready.Wait()
+			//ready.Wait()
 		case <-time.After(srcConsumerWaitTime):
 			mset.unsubscribe(crSub)
 			// We already waited 30 seconds, let's retry now.
@@ -3070,25 +3076,32 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 	}()
 }
 
-func (mset *stream) processSourceMsgs(si *sourceInfo, ready *sync.WaitGroup) {
+// This will process all inbound source msgs.
+// We mux them into one go routine to avoid lock contention and high cpu and thread thrashing.
+// TODO(dlc) make this more then one and pin sources to one of a group.
+func (mset *stream) processAllSourceMsgs() {
 	s := mset.srv
-	defer func() {
-		si.wg.Done()
-		s.grWG.Done()
-	}()
+	defer s.grWG.Done()
 
-	// Grab some stream and sourceInfo values now...
-	mset.mu.Lock()
-	msgs, qch, siqch, iname := si.msgs, mset.qch, si.qch, si.iname
-	// Set the last seen as now so that we don't fail at the first check.
-	si.last = time.Now()
-	mset.mu.Unlock()
-
-	// Signal the caller that we have captured the above fields.
-	ready.Done()
+	mset.mu.RLock()
+	msgs, qch := mset.smsgs, mset.qch
+	mset.mu.RUnlock()
 
 	t := time.NewTicker(sourceHealthCheckInterval)
 	defer t.Stop()
+
+	// When we detect we are no longer leader, we will cleanup.
+	// Should always return right after this is called.
+	cleanUp := func() {
+		mset.mu.Lock()
+		defer mset.mu.Unlock()
+		for _, si := range mset.sources {
+			mset.cancelSourceConsumer(si.iname)
+		}
+		mset.smsgs.drain()
+		mset.smsgs.unregister()
+		mset.smsgs = nil
+	}
 
 	for {
 		select {
@@ -3096,38 +3109,54 @@ func (mset *stream) processSourceMsgs(si *sourceInfo, ready *sync.WaitGroup) {
 			return
 		case <-qch:
 			return
-		case <-siqch:
-			return
 		case <-msgs.ch:
 			ims := msgs.pop()
 			for _, im := range ims {
-				if !mset.processInboundSourceMsg(si, im) {
+				if !mset.processInboundSourceMsg(im.si, im) {
+					// If we are no longer leader bail.
+					if !mset.isLeader() {
+						cleanUp()
+						return
+					}
 					break
 				}
+				im.returnToPool()
 			}
 			msgs.recycle(&ims)
 		case <-t.C:
-			mset.mu.RLock()
-			isLeader := mset.isLeader()
-			stalled := time.Since(si.last) > 3*sourceHealthCheckInterval
-			mset.mu.RUnlock()
-
-			// No longer leader.
-			if !isLeader {
-				mset.mu.Lock()
-				mset.cancelSourceConsumer(iname)
-				mset.mu.Unlock()
+			// If we are no longer leader bail.
+			if !mset.isLeader() {
+				cleanUp()
 				return
 			}
 
-			// We are stalled.
-			if stalled {
-				mset.mu.Lock()
-				// We don't need to schedule here, we are going to simply
-				// call setupSourceConsumer with the current state+1.
-				mset.setupSourceConsumer(iname, si.sseq+1, time.Time{})
-				si.last = time.Now()
-				mset.mu.Unlock()
+			// Check health of all sources.
+			var stalled []*sourceInfo
+			mset.mu.RLock()
+			for _, si := range mset.sources {
+				if time.Since(time.Unix(0, si.last.Load())) > sourceHealthCheckInterval {
+					stalled = append(stalled, si)
+				}
+			}
+			numSources := len(mset.sources)
+			mset.mu.RUnlock()
+
+			// This can happen on an update when no longer have sources.
+			if numSources == 0 {
+				cleanUp()
+				return
+			}
+
+			// We do not want to block here so do in separate Go routine.
+			if len(stalled) > 0 {
+				go func() {
+					mset.mu.Lock()
+					defer mset.mu.Unlock()
+					for _, si := range stalled {
+						mset.setupSourceConsumer(si.iname, si.sseq+1, time.Time{})
+						si.last.Store(time.Now().UnixNano())
+					}
+				}()
 			}
 		}
 	}
@@ -3160,15 +3189,15 @@ func (mset *stream) handleFlowControl(m *inMsg) {
 
 // processInboundSourceMsg handles processing other stream messages bound for this stream.
 func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
-	mset.mu.Lock()
-
 	// If we are no longer the leader cancel this subscriber.
 	if !mset.isLeader() {
+		mset.mu.Lock()
 		mset.cancelSourceConsumer(si.iname)
 		mset.mu.Unlock()
 		return false
 	}
 
+	mset.mu.Lock()
 	isControl := m.isControlMsg()
 
 	// Ignore from old subscriptions.
@@ -3176,9 +3205,6 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 		mset.mu.Unlock()
 		return false
 	}
-
-	si.last = time.Now()
-	node := mset.node
 
 	// Check for heartbeats and flow control messages.
 	if isControl {
@@ -3230,6 +3256,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 	} else {
 		si.lag = pending - 1
 	}
+	node := mset.node
 	mset.mu.Unlock()
 
 	hdr, msg := m.hdr, m.msg
@@ -3237,7 +3264,6 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 	// If we are daisy chained here make sure to remove the original one.
 	if len(hdr) > 0 {
 		hdr = removeHeaderIfPresent(hdr, JSStreamSource)
-
 		// Remove any Nats-Expected- headers as we don't want to validate them.
 		hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Expected-")
 	}
@@ -3245,15 +3271,16 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 	hdr = genHeader(hdr, JSStreamSource, si.genSourceHeader(m.rply))
 
 	// Do the subject transform for the source if there's one
-
-	for _, tr := range si.trs {
-		if tr == nil {
-			continue
-		} else {
-			tsubj, err := tr.Match(m.subj)
-			if err == nil {
-				m.subj = tsubj
-				break
+	if len(si.trs) > 0 {
+		for _, tr := range si.trs {
+			if tr == nil {
+				continue
+			} else {
+				tsubj, err := tr.Match(m.subj)
+				if err == nil {
+					m.subj = tsubj
+					break
+				}
 			}
 		}
 	}
@@ -3291,16 +3318,16 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 					s.RateLimitWarnf("Error processing inbound source %q for '%s' > '%s': %v",
 						iName, accName, sname, err)
 				}
-				// Retry in all type of errors.
-				// This will make sure the source is still in mset.sources map,
-				// find the last sequence and then call setupSourceConsumer.
-				iNameMap := map[string]struct{}{
-					iName: {},
+				// Retry in all type of errors if we are still leader.
+				if mset.isLeader() {
+					// This will make sure the source is still in mset.sources map,
+					// find the last sequence and then call setupSourceConsumer.
+					iNameMap := map[string]struct{}{iName: {}}
+					mset.setStartingSequenceForSources(iNameMap)
+					mset.mu.Lock()
+					mset.retrySourceConsumerAtSeq(iName, si.sseq+1)
+					mset.mu.Unlock()
 				}
-				mset.setStartingSequenceForSources(iNameMap)
-				mset.mu.Lock()
-				mset.retrySourceConsumerAtSeq(iName, si.sseq+1)
-				mset.mu.Unlock()
 			}
 		}
 		return false
@@ -3476,13 +3503,6 @@ func (mset *stream) startingSequenceForSources() {
 	var state StreamState
 	mset.store.FastState(&state)
 
-	// If the last time has been stamped remember in case we need to fall back to this for any given upstream source.
-	// TODO(dlc) - This will be ok, but should formalize with new approach and more formal and durable state.
-	if !state.LastTime.IsZero() {
-		for _, si := range mset.sources {
-			si.start = state.LastTime
-		}
-	}
 	// Bail if no messages, meaning no context.
 	if state.Msgs == 0 {
 		return
@@ -3526,15 +3546,15 @@ func (mset *stream) startingSequenceForSources() {
 			}
 		}
 
-		streamName, iName, sSeq := streamAndSeq(string(ss))
+		streamName, iName, sseq := streamAndSeq(string(ss))
 		if iName == _EMPTY_ { // Pre-2.10 message header means it's a match for any source using that stream name
 			for _, ssi := range mset.cfg.Sources {
 				if streamName == ssi.Name || (ssi.External != nil && streamName == ssi.Name+":"+getHash(ssi.External.ApiPrefix)) {
-					update(ssi.iname, sSeq)
+					update(ssi.iname, sseq)
 				}
 			}
 		} else {
-			update(iName, sSeq)
+			update(iName, sseq)
 		}
 		if len(seqs) == expected {
 			return
@@ -3608,8 +3628,7 @@ func (mset *stream) subscribeToStream() error {
 		// Setup the initial source infos for the sources
 		mset.resetSourceInfo()
 		// Delay the actual source consumer(s) creation(s) for after a delay
-
-		mset.sourcesConsumerSetup = time.AfterFunc(time.Duration(rand.Intn(int(10*time.Millisecond)))+10*time.Millisecond, func() {
+		mset.sourcesConsumerSetup = time.AfterFunc(time.Duration(rand.Intn(int(500*time.Millisecond)))+100*time.Millisecond, func() {
 			mset.mu.Lock()
 			mset.setupSourceConsumers()
 			mset.mu.Unlock()
@@ -4008,11 +4027,25 @@ type inMsg struct {
 	rply string
 	hdr  []byte
 	msg  []byte
+	si   *sourceInfo
 	mt   *msgTrace
 }
 
-func (mset *stream) queueInbound(ib *ipQueue[*inMsg], subj, rply string, hdr, msg []byte, mt *msgTrace) {
-	ib.push(&inMsg{subj, rply, hdr, msg, mt})
+var inMsgPool = sync.Pool{
+	New: func() any {
+		return &inMsg{}
+	},
+}
+
+func (im *inMsg) returnToPool() {
+	im.subj, im.rply, im.hdr, im.msg, im.si, im.mt = _EMPTY_, _EMPTY_, nil, nil, nil, nil
+	inMsgPool.Put(im)
+}
+
+func (mset *stream) queueInbound(ib *ipQueue[*inMsg], subj, rply string, hdr, msg []byte, si *sourceInfo, mt *msgTrace) {
+	im := inMsgPool.Get().(*inMsg)
+	im.subj, im.rply, im.hdr, im.msg, im.si, im.mt = subj, rply, hdr, msg, si, mt
+	ib.push(im)
 }
 
 var dgPool = sync.Pool{
@@ -4361,14 +4394,7 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 
 // processInboundJetStreamMsg handles processing messages bound for a stream.
 func (mset *stream) processInboundJetStreamMsg(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-	hdr, msg := c.msgParts(rmsg)
-	// Copy these.
-	if len(hdr) > 0 {
-		hdr = copyBytes(hdr)
-	}
-	if len(msg) > 0 {
-		msg = copyBytes(msg)
-	}
+	hdr, msg := c.msgParts(copyBytes(rmsg)) // Need to copy.
 	if mt, traceOnly := c.isMsgTraceEnabled(); mt != nil {
 		// If message is delivered, we need to disable the message trace headers
 		// to prevent a trace event to be generated when a stored message
@@ -4382,7 +4408,7 @@ func (mset *stream) processInboundJetStreamMsg(_ *subscription, c *client, _ *Ac
 		// object.
 		mt.addJetStreamEvent(mset.name())
 	}
-	mset.queueInbound(mset.msgs, subject, reply, hdr, msg, c.pa.trace)
+	mset.queueInbound(mset.msgs, subject, reply, hdr, msg, nil, c.pa.trace)
 }
 
 var (
@@ -5184,6 +5210,7 @@ func (mset *stream) internalLoop() {
 				} else {
 					mset.processJetStreamMsg(im.subj, im.rply, im.hdr, im.msg, 0, 0, im.mt)
 				}
+				im.returnToPool()
 			}
 			msgs.recycle(&ims)
 		case <-gets.ch:
@@ -5357,6 +5384,7 @@ func (mset *stream) stop(deleteFlag, advisory bool) error {
 		mset.ackq.unregister()
 		mset.outq.unregister()
 		mset.sigq.unregister()
+		mset.smsgs.unregister()
 	}
 
 	// Snapshot store.

--- a/server/stream.go
+++ b/server/stream.go
@@ -3067,7 +3067,6 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 				}
 			}
 			mset.mu.Unlock()
-			//ready.Wait()
 		case <-time.After(srcConsumerWaitTime):
 			mset.unsubscribe(crSub)
 			// We already waited 30 seconds, let's retry now.


### PR DESCRIPTION
We were struggling with inbound performance from a large number of streams, and were not properly getting all messages when our stream had a leader change.

The general issue with performance was that we had a go routine per source pulling from individual internal message queues. If we were behind and catching up, or if all sources were receiving messages in a quick fashion, we would be very slow. This was due to us lighting up all the go routines and hence kernel threads only to contend on locks and then IO. So were were thrashing.

We now mux all sources into a single processing go routine with a shared internal message queue.

During testing there were other optimizations that were realized as well.

@jnmoyne also did some restructuring of the sourcing code to make it more understandable and easier to approach and improve.

Thanks for @jnmoyne and @wallyqs for the testing!

Signed-off-by: Derek Collison <derek@nats.io>
