### PR TITLE
[FIXED] LeafNode: connection may fail on slow link

### DIFF
--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -2009,6 +2009,23 @@ func TestConfigCheck(t *testing.T) {
 			errorPos:  9,
 		},
 		{
+			name: "invalid duration for remote leafnode first info timeout",
+			config: `
+				leafnodes {
+					port: -1
+					remotes [
+						{
+							url: "nats://127.0.0.1:123"
+							first_info_timeout: abc
+						}
+					]
+				}
+			`,
+			err:       fmt.Errorf("error parsing first_info_timeout: time: invalid duration %q", "abc"),
+			errorLine: 7,
+			errorPos:  8,
+		},
+		{
 			name:       "show warnings on empty configs without values",
 			config:     ``,
 			warningErr: errors.New(`config has no values or is empty`),

--- a/server/opts.go
+++ b/server/opts.go
@@ -205,6 +205,11 @@ type RemoteLeafOpts struct {
 	DenyImports       []string         `json:"-"`
 	DenyExports       []string         `json:"-"`
 
+	// FirstInfoTimeout is the amount of time the server will wait for the
+	// initial INFO protocol from the remote server before closing the
+	// connection.
+	FirstInfoTimeout time.Duration `json:"-"`
+
 	// Compression options for this remote. Each remote could have a different
 	// setting and also be different from the LeafNode options.
 	Compression CompressionOpts `json:"-"`
@@ -2668,6 +2673,8 @@ func parseRemoteLeafNodes(v any, errors *[]error, warnings *[]error) ([]*RemoteL
 					*errors = append(*errors, err)
 					continue
 				}
+			case "first_info_timeout":
+				remote.FirstInfoTimeout = parseDuration(k, tk, v, errors, warnings)
 			default:
 				if !tk.IsUsedVariable() {
 					err := &unknownConfigFieldErr{
@@ -5375,6 +5382,10 @@ func setBaselineOptions(opts *Options) {
 				} else {
 					c.Mode = CompressionS2Auto
 				}
+			}
+			// Set default first info timeout value if not set.
+			if r.FirstInfoTimeout <= 0 {
+				r.FirstInfoTimeout = DEFAULT_LEAFNODE_INFO_WAIT
 			}
 		}
 	}


### PR DESCRIPTION
Added the leafnode remote configuration parameter `first_info_timeout`
which is the amount of time that a server creating a leafnode
connection will wait for the initial INFO from the remote server.

Resolves #5417

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>