### PR TITLE
[IMPROVED] Several improvements to raft layer with limited or no state.

### DIFF
--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 The NATS Authors
+// Copyright 2020-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -2672,8 +2672,10 @@ func TestJetStreamClusterStreamCatchupNoState(t *testing.T) {
 	// For both make sure we have no raft snapshots.
 	snapDir := filepath.Join(lconfig.StoreDir, "$SYS", "_js_", gname, "snapshots")
 	os.RemoveAll(snapDir)
-	snapDir = filepath.Join(config.StoreDir, "$SYS", "_js_", gname, "snapshots")
-	os.RemoveAll(snapDir)
+	// Remove all our raft state, we do not want to hold onto our term and index which
+	// results in a coin toss for who becomes the leader.
+	raftDir := filepath.Join(config.StoreDir, "$SYS", "_js_", gname)
+	os.RemoveAll(raftDir)
 
 	// Now restart.
 	c.restartAll()


### PR DESCRIPTION
1. Pull term from tav.idx even with no voted peer on recovery.
2. If we have no pterm or pindex after recovery inherit from empty WAL and tav.idx.
3. Clear wtv if we fail to write the tav.idx file.

Also fixes flapper test with removing snapshots and block state.

Signed-off-by: Derek Collison <derek@nats.io>
