### PR TITLE
[FIXED] Clustering: fixed data race when negotiating cluster name

### DIFF
--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -4318,3 +4318,36 @@ func TestRouteNoLeakOnAuthTimeout(t *testing.T) {
 		t.Fatalf("Server should have no route connections, got %v", nc)
 	}
 }
+
+func TestRouteNoRaceOnClusterNameNegotiation(t *testing.T) {
+	// Running the test 5 times was consistently producing the race.
+	for i := 0; i < 5; i++ {
+		o1 := DefaultOptions()
+		// Set this cluster name as dynamic
+		o1.Cluster.Name = _EMPTY_
+		// Increase number of routes and pinned accounts to increase
+		// the number of processRouteConnect() happening in parallel
+		// to produce the race.
+		o1.Cluster.PoolSize = 5
+		o1.Cluster.PinnedAccounts = []string{"A", "B", "C", "D"}
+		o1.Accounts = []*Account{NewAccount("A"), NewAccount("B"), NewAccount("C"), NewAccount("D")}
+		s1 := RunServer(o1)
+		defer s1.Shutdown()
+
+		route := RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", o1.Cluster.Port))
+
+		o2 := DefaultOptions()
+		// Set this one as explicit. Use name that is likely to be "higher"
+		// than the dynamic one.
+		o2.Cluster.Name = "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+		o2.Cluster.PoolSize = 5
+		o2.Cluster.PinnedAccounts = []string{"A", "B", "C", "D"}
+		o2.Accounts = []*Account{NewAccount("A"), NewAccount("B"), NewAccount("C"), NewAccount("D")}
+		o2.Routes = route
+		s2 := RunServer(o2)
+		defer s2.Shutdown()
+		checkClusterFormed(t, s1, s2)
+		s2.Shutdown()
+		s1.Shutdown()
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -975,7 +975,13 @@ func (s *Server) setClusterName(name string) {
 
 // Return whether the cluster name is dynamic.
 func (s *Server) isClusterNameDynamic() bool {
-	return s.getOpts().Cluster.Name == _EMPTY_
+	// We need to lock the whole "Cluster.Name" check and not use s.getOpts()
+	// because otherwise this could cause a data race with setting the name in
+	// route.go's processRouteConnect().
+	s.optsMu.RLock()
+	dynamic := s.opts.Cluster.Name == _EMPTY_
+	s.optsMu.RUnlock()
+	return dynamic
 }
 
 // Returns our configured serverName.


### PR DESCRIPTION
Added a test that demonstrated the following data race:
```
==================
WARNING: DATA RACE
Write at 0x00c00030cbf8 by goroutine 206:
  github.com/nats-io/nats-server/v2/server.(*client).processRouteConnect()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/route.go:2747 +0x2ac
  github.com/nats-io/nats-server/v2/server.(*client).processConnect()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/client.go:2147 +0xdec
  github.com/nats-io/nats-server/v2/server.(*client).parse()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/parser.go:942 +0xe90
  github.com/nats-io/nats-server/v2/server.(*client).readLoop()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/client.go:1389 +0x13a4
  github.com/nats-io/nats-server/v2/server.(*Server).createRoute.func1()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/route.go:1803 +0x38
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/server.go:3805 +0x58

Previous read at 0x00c00030cbf8 by goroutine 199:
  github.com/nats-io/nats-server/v2/server.(*Server).isClusterNameDynamic()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/server.go:978 +0x164
  github.com/nats-io/nats-server/v2/server.(*client).processRouteConnect()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/route.go:2741 +0x170
  github.com/nats-io/nats-server/v2/server.(*client).processConnect()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/client.go:2147 +0xdec
  github.com/nats-io/nats-server/v2/server.(*client).parse()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/parser.go:942 +0xe90
  github.com/nats-io/nats-server/v2/server.(*client).readLoop()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/client.go:1389 +0x13a4
  github.com/nats-io/nats-server/v2/server.(*Server).createRoute.func1()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/route.go:1803 +0x38
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/server.go:3805 +0x58

Goroutine 206 (running) created at:
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/server.go:3803 +0x160
  github.com/nats-io/nats-server/v2/server.(*Server).createRoute()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/route.go:1803 +0xa38
  github.com/nats-io/nats-server/v2/server.(*Server).startRouteAcceptLoop.func1()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/route.go:2527 +0x48
  github.com/nats-io/nats-server/v2/server.(*Server).acceptConnections.func1()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/server.go:2745 +0x70
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/server.go:3805 +0x58

Goroutine 199 (running) created at:
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/server.go:3803 +0x160
  github.com/nats-io/nats-server/v2/server.(*Server).createRoute()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/route.go:1803 +0xa38
  github.com/nats-io/nats-server/v2/server.(*Server).startRouteAcceptLoop.func1()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/route.go:2527 +0x48
  github.com/nats-io/nats-server/v2/server.(*Server).acceptConnections.func1()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/server.go:2745 +0x70
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
      /Users/ik/dev/go/src/github.com/nats-io/nats-server/server/server.go:3805 +0x58
==================
```

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
