### PR TITLE
Update go.mod to use Go v1.21 toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nats-io/nats-server/v2
 
-go 1.20
+go 1.21
 
 require (
 	github.com/google/go-tpm v0.9.0


### PR DESCRIPTION
Binary would be released with Go v1.22 but need to allow building with Go v1.21 as well, so updating to that version first.