### PR TITLE
[IMPROVED] Consumer with AckAll performance of first ack with large first stream sequence.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2886,7 +2886,7 @@ func (o *consumer) processAckMsg(sseq, dseq, dc uint64, reply string, doSample b
 		}
 		sagap = sseq - o.asflr
 		o.adflr, o.asflr = dseq, sseq
-		for seq := sseq; seq > sseq-sagap; seq-- {
+		for seq := sseq; seq > sseq-sagap && len(o.pending) > 0; seq-- {
 			delete(o.pending, seq)
 			delete(o.rdc, seq)
 			o.removeFromRedeliverQueue(seq)

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -8729,7 +8729,7 @@ func (o *consumerFileStore) UpdateAcks(dseq, sseq uint64) error {
 		sgap := sseq - o.state.AckFloor.Stream
 		o.state.AckFloor.Consumer = dseq
 		o.state.AckFloor.Stream = sseq
-		for seq := sseq; seq > sseq-sgap; seq-- {
+		for seq := sseq; seq > sseq-sgap && len(o.state.Pending) > 0; seq-- {
 			delete(o.state.Pending, seq)
 			if len(o.state.Redelivered) > 0 {
 				delete(o.state.Redelivered, seq)


### PR DESCRIPTION
When the first ack was called on an AckAll consumer attached to a stream with a very high first sequence, the server would become unresponsive for that consumer and potentially the stream due to looping down to the existing ackfloor which in this case would be zero.

Signed-off-by: Derek Collison <derek@nats.io>

