### PR TITLE
Skip trying to send system events just before shutdown

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -633,6 +633,11 @@ func (s *Server) sendInternalAccountMsgWithReply(a *Account, subject, reply stri
 	s.mu.RLock()
 	if s.sys == nil || s.sys.sendq == nil {
 		s.mu.RUnlock()
+		if s.isShuttingDown() {
+			// Skip in case this was called at the end phase during shut down
+			// to avoid too many entries in the logs.
+			return nil
+		}
 		return ErrNoSysAccount
 	}
 	c := s.sys.client


### PR DESCRIPTION
Avoids adding too many of these log entries while shutting down:
```
[S-2] | 2024/05/20 14:13:41.830762 [INF] JetStream cluster new consumer leader for 'js > test:13 > A:13:3'
[S-3] | 2024/05/20 14:13:41.868975 [INF] Initiating Shutdown...
[S-3] | 2024/05/20 14:13:41.868986 [INF] Initiating JetStream Shutdown...
[S-3] | 2024/05/20 14:13:41.869519 [WRN] Advisory could not be sent for account "js": system account not setup
[S-3] | 2024/05/20 14:13:41.869757 [WRN] Advisory could not be sent for account "js": system account not setup
[S-3] | 2024/05/20 14:13:41.870164 [WRN] Advisory could not be sent for account "js": system account not setup
[S-3] | 2024/05/20 14:13:41.870600 [WRN] Advisory could not be sent for account "js": system account not setup
[S-3] | 2024/05/20 14:13:41.870691 [WRN] Advisory could not be sent for account "js": system account not setup
[S-3] | 2024/05/20 14:13:41.870761 [WRN] Advisory could not be sent for account "js": system account not setup
[S-3] | 2024/05/20 14:13:41.870826 [WRN] Advisory could not be sent for account "js": system account not setup
[S-3] | 2024/05/20 14:13:41.870895 [WRN] Advisory could not be sent for account "js": system account not setup
[S-3] | 2024/05/20 14:13:41.870971 [WRN] Advisory could not be sent for account "js": system account not setup
...
```