### PR TITLE
Add goroutine annotation for stream internal loop

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -5121,6 +5121,10 @@ func (mset *stream) name() string {
 
 func (mset *stream) internalLoop() {
 	mset.mu.RLock()
+	setGoRoutineLabels(pprofLabels{
+		"account": mset.acc.Name,
+		"stream":  mset.cfg.Name,
+	})
 	s := mset.srv
 	c := s.createInternalJetStreamClient()
 	c.registerWithAccount(mset.acc)


### PR DESCRIPTION
This will improve observability on the `mset.internalLoop()` in profiles.

Signed-off-by: Neil Twigg <neil@nats.io>