### PR TITLE
Limit statsz updates

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -134,6 +134,7 @@ type internal struct {
 	shash          string
 	inboxPre       string
 	remoteStatsSub *subscription
+	lastStatsz     time.Time
 }
 
 // ServerStatsMsg is sent periodically with stats updates.
@@ -815,6 +816,20 @@ func (s *Server) sendStatsz(subj string) {
 	if s.sys == nil || s.sys.account == nil {
 		return
 	}
+
+	// Limit updates to the heartbeat interval, max one second.
+	statzInterval := time.Second
+	if s.sys.cstatsz < statzInterval {
+		statzInterval = s.sys.cstatsz
+	}
+	if time.Since(s.sys.lastStatsz) < statzInterval {
+		// Reschedule heartbeat for the next interval.
+		if s.sys.stmr != nil {
+			s.sys.stmr.Reset(time.Until(s.sys.lastStatsz.Add(statzInterval)))
+		}
+		return
+	}
+	s.sys.lastStatsz = time.Now()
 
 	shouldCheckInterest := func() bool {
 		opts := s.getOpts()

--- a/server/events.go
+++ b/server/events.go
@@ -98,6 +98,8 @@ const (
 // FIXME(dlc) - make configurable.
 var eventsHBInterval = 30 * time.Second
 
+const statszRateLimit = 1 * time.Second
+
 type sysMsgHandler func(sub *subscription, client *client, acc *Account, subject, reply string, hdr, msg []byte)
 
 // Used if we have to queue things internally to avoid the route/gw path.
@@ -968,7 +970,7 @@ func (s *Server) limitStatsz(subj string) bool {
 		return false
 	}
 
-	interval := time.Second
+	interval := statszRateLimit
 	if s.sys.cstatsz < interval {
 		interval = s.sys.cstatsz
 	}

--- a/server/events.go
+++ b/server/events.go
@@ -98,7 +98,7 @@ const (
 // FIXME(dlc) - make configurable.
 var eventsHBInterval = 30 * time.Second
 
-const statszRateLimit = 1 * time.Second
+var statszRateLimit = 1 * time.Second
 
 type sysMsgHandler func(sub *subscription, client *client, acc *Account, subject, reply string, hdr, msg []byte)
 

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -3538,3 +3538,17 @@ func Benchmark_GetHash(b *testing.B) {
 	default:
 	}
 }
+
+func TestClusterSetupMsgs(t *testing.T) {
+	numServers := 10
+	c := createClusterEx(t, false, 0, false, "cluster", numServers)
+	var totalOut int
+
+	for _, server := range c.servers {
+		totalOut += int(server.outMsgs)
+	}
+	totalExpected := numServers * numServers
+	if totalOut >= totalExpected {
+		t.Fatalf("Total outMsgs is %d, expected < %d\n", totalOut, totalExpected)
+	}
+}

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -1355,6 +1355,10 @@ func TestJetStreamSuperClusterPushConsumerInterest(t *testing.T) {
 }
 
 func TestJetStreamSuperClusterOverflowPlacement(t *testing.T) {
+	orgStatszRateLimit := statszRateLimit
+	statszRateLimit = time.Millisecond * 100
+	defer func() { statszRateLimit = orgStatszRateLimit }()
+
 	sc := createJetStreamSuperClusterWithTemplate(t, jsClusterMaxBytesTempl, 3, 3)
 	defer sc.shutdown()
 


### PR DESCRIPTION
This PR adds a filter to `sendStatsz` that limits statsz updates to the current heartbeat interval (max once per second), adding a `time.Time` field to track the time the last statsz update was sent. This limit should reduce overall `STATSZ` system event load in large clusters while still allowing initial statsz update to quickly reach newly-discovered nodes.

Fixes #5469.

Signed-off-by: Will Jordan <will.jordan@gmail.com>
