### PR TITLE
NRG: Stepdown candidate when AE ahead of last log term

### DIFF
--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -14,6 +14,7 @@
 package server
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
 	"os"
@@ -427,4 +428,43 @@ func TestNRGInvalidTAVDoesntPanic(t *testing.T) {
 
 	// Before the fix, a crash would have happened before this point.
 	c.waitOnAllCurrent()
+}
+
+func TestNRGCandidateStepsDownAfterAE(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+	c.waitOnLeader()
+
+	nc, _ := jsClientConnect(t, c.leader(), nats.UserInfo("admin", "s3cr3t!"))
+	defer nc.Close()
+
+	rg := c.createRaftGroup("TEST", 3, newStateAdder)
+	rg.waitOnLeader()
+
+	// Pick a random follower node. Bump the term up by a considerable
+	// amount and force it into the candidate state. This is what happens
+	// after a period of time in isolation.
+	n := rg.nonLeader().node().(*raft)
+	n.Lock()
+	n.term += 100
+	n.switchState(Candidate)
+	n.Unlock()
+
+	// Have the leader push through something on the current term just
+	// for good measure, although the heartbeats probably work too.
+	rg.leader().(*stateAdder).proposeDelta(1)
+
+	// Wait for the leader to receive the next append entry from the
+	// current leader. What should happen is that the node steps down
+	// and starts following the leader, as nothing in the log of the
+	// follower is newer than the term of the leader.
+	checkFor(t, time.Second, 50*time.Millisecond, func() error {
+		if n.State() == Candidate {
+			return fmt.Errorf("shouldn't still be candidate state")
+		}
+		if nterm, lterm := n.Term(), rg.leader().node().Term(); nterm != lterm {
+			return fmt.Errorf("follower term %d should match leader term %d", nterm, lterm)
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
A node that has been isolated in the candidate state for a considerable amount of time might have bumped its vote term up considerably due to a number of failed election attempts, so when the network recovers, new AEs would not trigger a stepdown. Instead, check the `pterm`, which is the term of the last entry in our log, as this will not have ratcheted up during the period of isolation.

Signed-off-by: Neil Twigg <neil@nats.io>