### PR TITLE
Fix message being redelivered after successful ack on rollout restarts

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2232,22 +2232,18 @@ func (o *consumer) loopAndForwardProposals(qch chan struct{}) {
 
 // Lock should be held.
 func (o *consumer) propose(entry []byte) {
-	var notify bool
 	p := &proposal{data: entry}
 	if o.phead == nil {
 		o.phead = p
-		notify = true
 	} else {
 		o.ptail.next = p
 	}
 	o.ptail = p
 
-	// Kick our looper routine if needed.
-	if notify {
-		select {
-		case o.pch <- struct{}{}:
-		default:
-		}
+	// Kick our looper routine.
+	select {
+	case o.pch <- struct{}{}:
+	default:
 	}
 }
 
@@ -2832,6 +2828,12 @@ func (o *consumer) processAckMsg(sseq, dseq, dc uint64, reply string, doSample b
 	if o.closed {
 		o.mu.Unlock()
 		return
+	}
+
+	// Check if this ack is above the current pointer to our next to deliver.
+	// This could happen on a cooperative takeover with high speed deliveries.
+	if sseq >= o.sseq {
+		o.sseq = sseq + 1
 	}
 
 	mset := o.mset

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -1540,25 +1540,28 @@ func TestJetStreamClusterDoubleAckRedelivery(t *testing.T) {
 				}
 
 				msgID := msg.Header.Get(nats.MsgIdHdr)
-				if meta.NumDelivered > 1 {
-					if err, ok := errors[msgID]; ok {
-						t.Logf("Redelivery after failed Ack Sync: %+v - %+v - error: %v", msg.Reply, msg.Header, err)
-					} else {
-						t.Logf("Redelivery: %+v - %+v", msg.Reply, msg.Header)
-					}
-					if resp, ok := acked[msgID]; ok {
-						t.Errorf("Redelivery after successful Ack Sync: msgID:%v - redelivered:%v - original:%+v - ack:%+v",
-							msgID, msg.Reply, resp.original.Reply, resp.ack)
-						resp.redelivered = msg
-						extraRedeliveries++
-					}
+				if err, ok := errors[msgID]; ok {
+					t.Logf("Redelivery (num_delivered: %v) after failed Ack Sync: %+v - %+v - error: %v", meta.NumDelivered, msg.Reply, msg.Header, err)
+				}
+				if resp, ok := acked[msgID]; ok {
+					t.Errorf("Redelivery (num_delivered: %v) after successful Ack Sync: msgID:%v - redelivered:%v - original:%+v - ack:%+v",
+						meta.NumDelivered, msgID, msg.Reply, resp.original.Reply, resp.ack)
+					resp.redelivered = msg
+					extraRedeliveries++
 				}
 				received[msgID]++
-				resp, err := nc.Request(msg.Reply, []byte("+ACK"), 500*time.Millisecond)
-				if err != nil {
-					errors[msgID] = err
-				} else {
-					acked[msgID] = &ackResult{resp, msg, nil}
+
+				// Retry quickly a few times after there is a failed ack.
+			Retries:
+				for i := 0; i < 10; i++ {
+					resp, err := nc.Request(msg.Reply, []byte("+ACK"), 500*time.Millisecond)
+					if err != nil {
+						t.Logf("Error: %v %v", msgID, err)
+						errors[msgID] = err
+					} else {
+						acked[msgID] = &ackResult{resp, msg, nil}
+						break Retries
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Sometimes during rollout restarts, retrying quickly a previously failed ack could succeed but still the consumer would get the message being redelivered.  To prevent this it is now checked if an inbound ack on takeover is ahead of the consumer stream sequence.