### PR TITLE
Prevent duplicate routes

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -3016,24 +3016,11 @@ func (s *Server) forEachRemote(f func(r *client)) {
 	}
 }
 
-func (s *Server) forEachRouteAndTempRoute(f func(r *client)) {
-	s.forEachRoute(f)
-	s.grMu.Lock()
-	defer s.grMu.Unlock()
-	for _, c := range s.grTmpClients {
-		if c != nil && c.kind == ROUTER {
-			f(c)
-		}
-	}
-}
-
 // Returns number of route connections for the host,
-// including not-yet-registered and unestablished connections.
+// including pending (not-yet-registered and unestablished) connections.
 func (s *Server) numRouteConns(host string, accName string) int {
 	nr := s.pendingRouteConns.Value(fmt.Sprintf("%s/%s", host, accName))
-	s.forEachRouteAndTempRoute(func(c *client) {
-		c.mu.Lock()
-		defer c.mu.Unlock()
+	s.forEachRoute(func(c *client) {
 		if c.route.url != nil &&
 			c.route.url.Host == host &&
 			accName == bytesToString(c.route.accName) {

--- a/server/route.go
+++ b/server/route.go
@@ -3032,6 +3032,8 @@ func (s *Server) forEachRouteAndTempRoute(f func(r *client)) {
 func (s *Server) numRouteConns(host string, accName string) int {
 	nr := s.pendingRouteConns.Value(fmt.Sprintf("%s/%s", host, accName))
 	s.forEachRouteAndTempRoute(func(c *client) {
+		c.mu.Lock()
+		defer c.mu.Unlock()
 		if c.route.url != nil &&
 			c.route.url.Host == host &&
 			accName == bytesToString(c.route.accName) {

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -4356,6 +4356,7 @@ func TestRouteNoRaceOnClusterNameNegotiation(t *testing.T) {
 
 func TestImplicitDuplicateRoutes(t *testing.T) {
 	c := createClusterWithName(t, "duplicateRoute", 10)
+	defer shutdownCluster(c)
 	duplicates := 0
 	for _, s := range c.servers {
 		logger := s.Logger().(*checkDuplicateRouteLogger)

--- a/server/server.go
+++ b/server/server.go
@@ -367,8 +367,8 @@ type CounterMap struct {
 }
 
 func (c *CounterMap) Add(key string, delta int64) {
-	val, _ := c.counters.LoadOrStore(key, new(int64))
-	if atomic.AddInt64(val.(*int64), delta) == 0 {
+	val, _ := c.counters.LoadOrStore(key, &atomic.Int64{})
+	if val.(*atomic.Int64).Add(delta) == 0 {
 		c.counters.CompareAndDelete(key, val)
 	}
 }
@@ -381,7 +381,7 @@ func (c *CounterMap) Value(key string) int64 {
 	if !ok {
 		return 0
 	}
-	return *(val.(*int64))
+	return val.(*atomic.Int64).Load()
 }
 
 // For tracking JS nodes.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -86,6 +86,9 @@ func RunServer(opts *Options) *Server {
 	if !opts.NoLog {
 		s.ConfigureLogger()
 	}
+	if opts.Gateway.Name == "duplicateRoute" {
+		s.SetLogger(&checkDuplicateRouteLogger{}, true, opts.Trace)
+	}
 
 	if ll := os.Getenv("NATS_LOGGING"); ll != "" {
 		log := srvlog.NewTestLogger(fmt.Sprintf("[%s] | ", s), true)


### PR DESCRIPTION
This PR attempts to prevent duplicate routes by checking the existing route-connection count before attempting to create a new connection.

Fixes #5483.

Before attempting a new connection, `connectToRoute` checks `s.numRouteConns` (the total sum of registered routes, unregistered routes, and pending route-connections), and skips the connection attempt if the server is already at its limit. This check prevents a pileup of pending connections (which will be eventually closed as duplicate routes) described in the linked issue #5483.

In order to track pending route-connections, this PR adds a counter map (`s.pendingRouteConns`) that is incremented on each route-connection attempt and decremented after the connection is established/aborted.

Signed-off-by: Your Name <will.jordan@gmail.com>