### PR TITLE
Update to Go 1.22.4, 1.21.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ language: go
 go:
   # This should be quoted or use .x, but should not be unquoted.
   # Remember that a YAML bare float drops trailing zeroes.
-  - "1.22.3"
-  - "1.21.10"
+  - "1.22.4"
+  - "1.21.11"
 
 go_import_path: github.com/nats-io/nats-server
 


### PR DESCRIPTION
This updates the `goreleaser` Go versions.

Signed-off-by: Neil Twigg <neil@nats.io>