### PR TITLE
Fix returning `maximum consumers limit reached` on some consumer updates

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7227,7 +7227,7 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 
 	// See if we have an existing one already under same durable name or
 	// if name was set by the user.
-	if isDurableConsumer(cfg) || cfg.Name != _EMPTY_ {
+	if oname != _EMPTY_ {
 		if ca = sa.consumers[oname]; ca != nil && !ca.deleted {
 			if action == ActionCreate && !reflect.DeepEqual(cfg, ca.Config) {
 				resp.Error = NewJSConsumerAlreadyExistsError()


### PR DESCRIPTION
This will fix #5488 by doing two things:

1. Only enforcing the max consumer count on consumer create or create-or-update requests;
2. Not incorrectly counting a potentially existing matching consumer on create-or-update requests.

Note this only happens in clustered mode, on a single node system this does not happen.

Signed-off-by: Neil Twigg <neil@nats.io>