### PR TITLE
[FIXED] Last sequence stream reset on server restarts

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1869,7 +1869,7 @@ func (mb *msgBlock) lastChecksum() []byte {
 		mb.rbytes = uint64(fi.Size())
 	}
 	if mb.rbytes < checksumSize {
-		return nil
+		return lchk[:]
 	}
 	// Encrypted?
 	// Check for encryption, we do not load keys on startup anymore so might need to load them here.
@@ -3453,6 +3453,17 @@ func (mb *msgBlock) skipMsg(seq uint64, now time.Time) {
 		mb.last.ts = nowts
 		atomic.StoreUint64(&mb.first.seq, seq+1)
 		mb.first.ts = nowts
+		needsRecord = mb == mb.fs.lmb
+		if needsRecord && mb.rbytes > 0 {
+			// We wany to make sure since we have no messages
+			// that we write to the beginning since we only need last one.
+			mb.rbytes, mb.cache = 0, &cache{}
+			// If encrypted we need to reset counter since we just keep one.
+			if mb.bek != nil {
+				// Recreate to reset counter.
+				mb.bek, _ = genBlockEncryptionKey(mb.fs.fcfg.Cipher, mb.seed, mb.nonce)
+			}
+		}
 	} else {
 		needsRecord = true
 		mb.dmap.Insert(seq)

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -3455,7 +3455,7 @@ func (mb *msgBlock) skipMsg(seq uint64, now time.Time) {
 		mb.first.ts = nowts
 		needsRecord = mb == mb.fs.lmb
 		if needsRecord && mb.rbytes > 0 {
-			// We wany to make sure since we have no messages
+			// We want to make sure since we have no messages
 			// that we write to the beginning since we only need last one.
 			mb.rbytes, mb.cache = 0, &cache{}
 			// If encrypted we need to reset counter since we just keep one.

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -2216,3 +2216,68 @@ func TestJetStreamClusterSingleMaxConsumerUpdate(t *testing.T) {
 	})
 	require_NoError(t, err)
 }
+
+func TestJetStreamClusterStreamLastSequenceResetAfterStorageWipe(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// After bug was found, number of streams and wiping store directory really did not affect.
+	numStreams := 50
+	var wg sync.WaitGroup
+	wg.Add(numStreams)
+
+	for i := 1; i <= numStreams; i++ {
+		go func(n int) {
+			defer wg.Done()
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:      fmt.Sprintf("TEST:%d", n),
+				Retention: nats.InterestPolicy,
+				Subjects:  []string{fmt.Sprintf("foo.%d.*", n)},
+				Replicas:  3,
+			}, nats.MaxWait(30*time.Second))
+			require_NoError(t, err)
+			subj := fmt.Sprintf("foo.%d.bar", n)
+			for i := 0; i < 222; i++ {
+				js.Publish(subj, nil)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < 5; i++ {
+		// Walk the servers and shut each down, and wipe the storage directory.
+		for _, s := range c.servers {
+			sd := s.JetStreamConfig().StoreDir
+			s.Shutdown()
+			s.WaitForShutdown()
+			os.RemoveAll(sd)
+			s = c.restartServer(s)
+			checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
+				hs := s.healthz(nil)
+				if hs.Error != _EMPTY_ {
+					return errors.New(hs.Error)
+				}
+				return nil
+			})
+		}
+
+		for _, s := range c.servers {
+			for i := 1; i <= numStreams; i++ {
+				stream := fmt.Sprintf("TEST:%d", i)
+				mset, err := s.GlobalAccount().lookupStream(stream)
+				require_NoError(t, err)
+				var state StreamState
+				checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
+					mset.store.FastState(&state)
+					if state.LastSeq != 222 {
+						return fmt.Errorf("%v LAST SEQ WRONG %d for %q - STATE %+v", s, state.LastSeq, stream, state)
+					}
+					return nil
+				})
+			}
+		}
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -4276,6 +4276,7 @@ func (s *Server) lameDuckMode() {
 		}
 	}
 	s.Shutdown()
+	s.WaitForShutdown()
 }
 
 // Send an INFO update to routes with the indication that this server is in LDM mode.

--- a/server/signal.go
+++ b/server/signal.go
@@ -51,6 +51,7 @@ func (s *Server) handleSignals() {
 				switch sig {
 				case syscall.SIGINT:
 					s.Shutdown()
+					s.WaitForShutdown()
 					os.Exit(0)
 				case syscall.SIGTERM:
 					// Shutdown unless graceful shutdown already in progress.
@@ -60,6 +61,7 @@ func (s *Server) handleSignals() {
 
 					if !ldm {
 						s.Shutdown()
+						s.WaitForShutdown()
 						os.Exit(1)
 					}
 				case syscall.SIGUSR1:


### PR DESCRIPTION
 When we had skip msgs on the last msg block we were not writing proper tombstone markers if the block was empty.
 Also no checksum should match no recorded block checksum to pull in metadata from index.db.

Also we will now wait for all async processes to complete on shutdown from signal handlers and lameduck mode.
 
Signed-off-by: Derek Collison <derek@nats.io>