### PR TITLE
systemd example: reduce risk of naive breakage

### DIFF
--- a/util/nats-server-hardened.service
+++ b/util/nats-server-hardened.service
@@ -81,4 +81,6 @@ ReadWritePaths=/var/lib/nats
 
 [Install]
 WantedBy=multi-user.target
-Alias=nats.service
+# If you install this service as nats-server.service and want 'nats'
+# to work as an alias, then uncomment this next line:
+#Alias=nats.service


### PR DESCRIPTION
In commit c7887427 I made various updates to one of the example systemd service
scripts, but one change causes breakage if and only if the service file is
itself named `nats.service` when installed.

We now know that some folks are doing just that, automatically; it's bad to
have a config file which only works if it has certain names (and a little
surprising that systemd doesn't detect that the alias matches its current name
and filters).

So turn that directive into a commented-out suggestion.

Signed-off-by: Phil Pennock <pdp@nats.io>