### PR TITLE
Prevent interleaving of setting/unsetting observer states with `jetstream_cluster_migrate`

### DIFF
--- a/locksordering.txt
+++ b/locksordering.txt
@@ -22,3 +22,11 @@ This must be taken out as soon as a reload is about to happen before any other l
 
     reloadMu -> Server
     reloadMu -> optsMu
+
+The "jscmMu" lock in the Account is used to serialise calls to checkJetStreamMigrate and
+clearObserverState so that they cannot interleave which would leave Raft nodes in
+inconsistent observer states.
+
+    jscmMu -> Account -> jsAccount
+    jscmMu -> stream.clsMu 
+    jscmMu -> RaftNode

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -103,6 +103,9 @@ type Account struct {
 	// and if it falls between 0 and that value, message tracing will be triggered.
 	traceDest         string
 	traceDestSampling int
+	// Guarantee that only one goroutine can be running either checkJetStreamMigrate
+	// or clearObserverState at a given time for this account to prevent interleaving.
+	jscmMu sync.Mutex
 }
 
 const (

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -584,6 +584,9 @@ func (s *Server) clearObserverState(remote *leafNodeCfg) {
 		return
 	}
 
+	acc.jscmMu.Lock()
+	defer acc.jscmMu.Unlock()
+
 	// Walk all streams looking for any clustered stream, skip otherwise.
 	for _, mset := range acc.streams() {
 		node := mset.raftNode()
@@ -618,6 +621,9 @@ func (s *Server) checkJetStreamMigrate(remote *leafNodeCfg) {
 		s.Warnf("Error looking up account [%s] checking for JetStream migration on a leafnode", accName)
 		return
 	}
+
+	acc.jscmMu.Lock()
+	defer acc.jscmMu.Unlock()
 
 	// Walk all streams looking for any clustered stream, skip otherwise.
 	// If we are the leader force stepdown.


### PR DESCRIPTION
There is a possibility this might happen if `reConnectToRemoteLeafNode` from a connection drop and `connectToRemoteLeafNode` from solicitation are running in separate goroutines for the same remotes.

Signed-off-by: Neil Twigg <neil@nats.io>