### PR TITLE
Fix js-server-only health check on v2.10.17

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3485,6 +3485,11 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 		return health
 	}
 
+	// If JSServerOnly is true, then do not check further accounts, streams and consumers.
+	if opts.JSServerOnly {
+		return health
+	}
+
 	// Are we still recovering meta layer?
 	if js.isMetaRecovering() {
 		if !details {


### PR DESCRIPTION
Got removed while applying last cherry pick so adding it back with the expected behavior for v2.10.X.