### PR TITLE
Re-order struct fields in `stree` for improved memory alignment

### DIFF
--- a/server/stree/leaf.go
+++ b/server/stree/leaf.go
@@ -18,16 +18,17 @@ import (
 )
 
 // Leaf node
+// Order of struct fields for best memory alignment (as per govet/fieldalignment)
 type leaf[T any] struct {
+	value T
 	// This could be the whole subject, but most likely just the suffix portion.
 	// We will only store the suffix here and assume all prior prefix paths have
 	// been checked once we arrive at this leafnode.
 	suffix []byte
-	value  T
 }
 
 func newLeaf[T any](suffix []byte, value T) *leaf[T] {
-	return &leaf[T]{copyBytes(suffix), value}
+	return &leaf[T]{value, copyBytes(suffix)}
 }
 
 func (n *leaf[T]) isLeaf() bool                               { return true }

--- a/server/stree/node16.go
+++ b/server/stree/node16.go
@@ -14,10 +14,11 @@
 package stree
 
 // Node with 16 children
+// Order of struct fields for best memory alignment (as per govet/fieldalignment)
 type node16 struct {
-	meta
 	child [16]node
-	key   [16]byte
+	meta
+	key [16]byte
 }
 
 func newNode16(prefix []byte) *node16 {

--- a/server/stree/node256.go
+++ b/server/stree/node256.go
@@ -14,9 +14,10 @@
 package stree
 
 // Node with 256 children
+// Order of struct fields for best memory alignment (as per govet/fieldalignment)
 type node256 struct {
-	meta
 	child [256]node
+	meta
 }
 
 func newNode256(prefix []byte) *node256 {

--- a/server/stree/node4.go
+++ b/server/stree/node4.go
@@ -14,10 +14,11 @@
 package stree
 
 // Node with 4 children
+// Order of struct fields for best memory alignment (as per govet/fieldalignment)
 type node4 struct {
-	meta
 	child [4]node
-	key   [4]byte
+	meta
+	key [4]byte
 }
 
 func newNode4(prefix []byte) *node4 {


### PR DESCRIPTION
Saves:
* 16 bytes per `leaf`
* 24 bytes per `node4`, `node16` and `node256`

Signed-off-by: Neil Twigg <neil@nats.io>