### PR TITLE
[UPDATED] Add kick leafnode client functionality

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -2833,8 +2833,10 @@ func (s *Server) reloadConfig(sub *subscription, c *client, _ *Account, subject,
 	})
 }
 
+
 type KickClientReq struct {
 	CID uint64 `json:"cid"`
+	Kind string `json:"kind"`
 }
 
 type LDMClientReq struct {
@@ -2851,10 +2853,13 @@ func (s *Server) kickClient(_ *subscription, c *client, _ *Account, subject, rep
 		s.sys.client.Errorf("Error unmarshalling kick client request: %v", err)
 		return
 	}
+	if req.Kind == "" {
+		req.Kind = "Client"
+	}
 
 	optz := &EventFilterOptions{}
 	s.zReq(c, reply, hdr, msg, optz, optz, func() (any, error) {
-		return nil, s.DisconnectClientByID(req.CID)
+		return nil, s.DisconnectClientByID(req.CID, req.Kind)
 	})
 
 }

--- a/server/events.go
+++ b/server/events.go
@@ -2833,9 +2833,8 @@ func (s *Server) reloadConfig(sub *subscription, c *client, _ *Account, subject,
 	})
 }
 
-
 type KickClientReq struct {
-	CID uint64 `json:"cid"`
+	CID  uint64 `json:"cid"`
 	Kind string `json:"kind"`
 }
 

--- a/server/events.go
+++ b/server/events.go
@@ -2834,8 +2834,7 @@ func (s *Server) reloadConfig(sub *subscription, c *client, _ *Account, subject,
 }
 
 type KickClientReq struct {
-	CID  uint64 `json:"cid"`
-	Kind string `json:"kind"`
+	CID uint64 `json:"cid"`
 }
 
 type LDMClientReq struct {
@@ -2852,13 +2851,10 @@ func (s *Server) kickClient(_ *subscription, c *client, _ *Account, subject, rep
 		s.sys.client.Errorf("Error unmarshalling kick client request: %v", err)
 		return
 	}
-	if req.Kind == "" {
-		req.Kind = "Client"
-	}
 
 	optz := &EventFilterOptions{}
 	s.zReq(c, reply, hdr, msg, optz, optz, func() (any, error) {
-		return nil, s.DisconnectClientByID(req.CID, req.Kind)
+		return nil, s.DisconnectClientByID(req.CID)
 	})
 
 }

--- a/server/server.go
+++ b/server/server.go
@@ -4464,18 +4464,15 @@ func (s *Server) changeRateLimitLogInterval(d time.Duration) {
 }
 
 // DisconnectClientByID disconnects a client by connection ID
-func (s *Server) DisconnectClientByID(id uint64, kind string) error {
+func (s *Server) DisconnectClientByID(id uint64) error {
 	if s == nil {
 		return ErrServerNotRunning
 	}
-	var client *client
-	if kind == "Client" {
-		client = s.getClient(id)
+	if client := s.getClient(id); client != nil {
+		client.closeConnection(Kicked)
+		return nil
 	}
-	if kind == "Leafnode" {
-		client = s.GetLeafNode(id)
-	}
-	if client != nil {
+	if client := s.GetLeafNode(id); client != nil {
 		client.closeConnection(Kicked)
 		return nil
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -4464,11 +4464,18 @@ func (s *Server) changeRateLimitLogInterval(d time.Duration) {
 }
 
 // DisconnectClientByID disconnects a client by connection ID
-func (s *Server) DisconnectClientByID(id uint64) error {
+func (s *Server) DisconnectClientByID(id uint64, kind string) error {
 	if s == nil {
 		return ErrServerNotRunning
 	}
-	if client := s.getClient(id); client != nil {
+	var client *client
+	if kind == "Client" {
+		client = s.getClient(id)
+	}
+	if kind == "Leafnode" {
+		client = s.GetLeafNode(id)
+	}
+	if client != nil {
 		client.closeConnection(Kicked)
 		return nil
 	}


### PR DESCRIPTION
I was looking for a way to rebalance LeafNodes client connections (k8s loadbalancing) and found the original  #1556. I was informed at the slack that the KICK functionality in the API lacked the ability to kick leaf node connections. 

- Changed the KickClientReq struct to include client kind as per suggestion from slack. 
- Defaulted kind to "Client" to keep compability. 
- Added kind as an argument to server DisconnectClientByID
- Fetched client based on kind before closing connection. 

Tested functionality locally & ran tests without issues. Didn't get travis to work tho.

Signed-off-by: Niklas Holmstedt <n.holmstedt@gmail.com>
