### PR TITLE
[FIXED] Make sure jsz reporting of filtered consumers delivered stream sequence is consistent.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -8758,6 +8758,12 @@ func (o *consumerFileStore) UpdateAcks(dseq, sseq uint64) error {
 		return nil
 	}
 
+	// Match leader logic on checking if ack is ahead of delivered.
+	// This could happen on a cooperative takeover with high speed deliveries.
+	if sseq > o.state.Delivered.Stream {
+		o.state.Delivered.Stream = sseq + 1
+	}
+
 	if len(o.state.Pending) == 0 || o.state.Pending[sseq] == nil {
 		return ErrStoreMsgNotFound
 	}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1658,6 +1658,12 @@ func (o *consumerMemStore) UpdateAcks(dseq, sseq uint64) error {
 		return nil
 	}
 
+	// Match leader logic on checking if ack is ahead of delivered.
+	// This could happen on a cooperative takeover with high speed deliveries.
+	if sseq > o.state.Delivered.Stream {
+		o.state.Delivered.Stream = sseq + 1
+	}
+
 	// Check for AckAll here.
 	if o.cfg.AckPolicy == AckAll {
 		sgap := sseq - o.state.AckFloor.Stream


### PR DESCRIPTION
For a leader, it will skip msgs at the end to eof and remember o.sseq for the next getNextMsg call.
But this will report stream delivered different for the leader vs the followers.

Also if a consumer leader processed an ack ahead of delivered it would sync, but followers would not.
This makes the behavior consistent between leaders and followers.

Signed-off-by: Derek Collison <derek@nats.io>