### PR TITLE
[FIXED] On failed snapshot restore make sure healthz is clean.

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -6106,6 +6106,8 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 	}
 	mset, err := a.addStream(&cfg)
 	if err != nil {
+		// Make sure to clean up after ourselves here.
+		os.RemoveAll(ndir)
 		return nil, err
 	}
 	if !fcfg.Created.IsZero() {


### PR DESCRIPTION
On a bad snapshot restore, e.g. R3 on single server, make sure to remove the restored stream since otherwise it would cause bad healthz reports.

Signed-off-by: Derek Collison <derek@nats.io>
