### PR TITLE
refactor(raft): remove unused code

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -1029,9 +1029,6 @@ func (n *raft) InstallSnapshot(data []byte) error {
 		return errCatchupsRunning
 	}
 
-	var state StreamState
-	n.wal.FastState(&state)
-
 	if n.applied == 0 {
 		return errNoSnapAvailable
 	}


### PR DESCRIPTION
The `state` is not used here. 

Signed-off-by: Jay Chung <ken8203@gmail.com>