### PR TITLE
Allow callout users to be revoked

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3688,8 +3688,8 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 		c.applyAccountLimits()
 		// if we have an nkey user we are a callout user - save
 		// the issuedAt, and nkey user id to honor revocations
-		nkeyUserID := ""
-		issuedAt := int64(0)
+		var nkeyUserID string
+		var issuedAt int64
 		if c.user != nil {
 			issuedAt = c.user.Issued
 			nkeyUserID = c.user.Nkey
@@ -3713,13 +3713,13 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 			}
 		}
 
-		// if we extracted nkeyUserID and issuedAt we are a callout user
-		// calloutIAT should only be set if we are in callout type scenario
+		// if we extracted nkeyUserID and issuedAt we are a callout type
+		// calloutIAT should only be set if we are in callout scenario as
 		// the user JWT is _NOT_ associated with the client for callouts,
 		// so we rely on the calloutIAT to know when the JWT was issued
 		// revocations simply state that JWT issued before or by that date
 		// are not valid
-		if ac.Revocations != nil && nkeyUserID != "" && issuedAt > 0 {
+		if ac.Revocations != nil && nkeyUserID != _EMPTY_ && issuedAt > 0 {
 			seconds, ok := ac.Revocations[jwt.All]
 			if ok && seconds >= issuedAt {
 				c.sendErrAndDebug("User Authentication Revoked")

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3686,6 +3686,14 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 		}
 		c.mu.Lock()
 		c.applyAccountLimits()
+		// if we have an nkey user we are a callout user - save
+		// the issuedAt, and nkey user id to honor revocations
+		nkeyUserID := ""
+		issuedAt := int64(0)
+		if c.user != nil {
+			issuedAt = c.user.Issued
+			nkeyUserID = c.user.Nkey
+		}
 		theJWT := c.opts.JWT
 		c.mu.Unlock()
 		// Check for being revoked here. We use ac one to avoid the account lock.
@@ -3699,6 +3707,27 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 				c.authViolation()
 				continue
 			} else if ok := ac.IsClaimRevoked(juc); ok {
+				c.sendErrAndDebug("User Authentication Revoked")
+				c.closeConnection(Revocation)
+				continue
+			}
+		}
+
+		// if we extracted nkeyUserID and issuedAt we are a callout user
+		// calloutIAT should only be set if we are in callout type scenario
+		// the user JWT is _NOT_ associated with the client for callouts,
+		// so we rely on the calloutIAT to know when the JWT was issued
+		// revocations simply state that JWT issued before or by that date
+		// are not valid
+		if ac.Revocations != nil && nkeyUserID != "" && issuedAt > 0 {
+			seconds, ok := ac.Revocations[jwt.All]
+			if ok && seconds >= issuedAt {
+				c.sendErrAndDebug("User Authentication Revoked")
+				c.closeConnection(Revocation)
+				continue
+			}
+			seconds, ok = ac.Revocations[nkeyUserID]
+			if ok && seconds >= issuedAt {
 				c.sendErrAndDebug("User Authentication Revoked")
 				c.closeConnection(Revocation)
 				continue
@@ -3814,7 +3843,7 @@ func buildPermissionsFromJwt(uc *jwt.Permissions) *Permissions {
 
 // Helper to build internal NKeyUser.
 func buildInternalNkeyUser(uc *jwt.UserClaims, acts map[string]struct{}, acc *Account) *NkeyUser {
-	nu := &NkeyUser{Nkey: uc.Subject, Account: acc, AllowedConnectionTypes: acts}
+	nu := &NkeyUser{Nkey: uc.Subject, Account: acc, AllowedConnectionTypes: acts, Issued: uc.IssuedAt}
 	if uc.IssuerAccount != _EMPTY_ {
 		nu.SigningKey = uc.Issuer
 	}

--- a/server/auth.go
+++ b/server/auth.go
@@ -59,9 +59,8 @@ type ClientAuthentication interface {
 
 // NkeyUser is for multiple nkey based users
 type NkeyUser struct {
-	Nkey string `json:"user"`
-	// this is a copy of the issued at (iat) field in the jwt
-	Issued                 int64               `json:"issued,omitempty"`
+	Nkey                   string              `json:"user"`
+	Issued                 int64               `json:"issued,omitempty"` // this is a copy of the issued at (iat) field in the jwt
 	Permissions            *Permissions        `json:"permissions,omitempty"`
 	Account                *Account            `json:"account,omitempty"`
 	SigningKey             string              `json:"signing_key,omitempty"`

--- a/server/auth.go
+++ b/server/auth.go
@@ -60,6 +60,7 @@ type ClientAuthentication interface {
 // NkeyUser is for multiple nkey based users
 type NkeyUser struct {
 	Nkey                   string              `json:"user"`
+	Issued                 int64               `json:"issued,omitempty"`
 	Permissions            *Permissions        `json:"permissions,omitempty"`
 	Account                *Account            `json:"account,omitempty"`
 	SigningKey             string              `json:"signing_key,omitempty"`

--- a/server/auth.go
+++ b/server/auth.go
@@ -59,7 +59,8 @@ type ClientAuthentication interface {
 
 // NkeyUser is for multiple nkey based users
 type NkeyUser struct {
-	Nkey                   string              `json:"user"`
+	Nkey string `json:"user"`
+	// this is a copy of the issued at (iat) field in the jwt
 	Issued                 int64               `json:"issued,omitempty"`
 	Permissions            *Permissions        `json:"permissions,omitempty"`
 	Account                *Account            `json:"account,omitempty"`

--- a/server/client.go
+++ b/server/client.go
@@ -261,6 +261,8 @@ type client struct {
 	msgb       [msgScratchSize]byte
 	last       time.Time
 	lastIn     time.Time
+	// this is a copy of the issued at (iat) field in the jwt
+	calloutIAT int64
 
 	headers bool
 

--- a/server/client.go
+++ b/server/client.go
@@ -261,8 +261,6 @@ type client struct {
 	msgb       [msgScratchSize]byte
 	last       time.Time
 	lastIn     time.Time
-	// this is a copy of the issued at (iat) field in the jwt
-	calloutIAT int64
 
 	headers bool
 


### PR DESCRIPTION
[FIX] added logic to enable users generated by a callout to be revoked - the callout is responsible to map the user ids for revocation purposes.

Fix #5477 


