### PR TITLE
Allow for audit exception for `$JS.EVENT.>` and `$SYS.ACCOUNT.>` which may already exist.

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -23679,17 +23679,30 @@ func TestJetStreamAuditStreams(t *testing.T) {
 	// Since prior behavior did allow $JS.EVENT to be captured without no-ack, these might break
 	// on a server upgrade so make sure they still work ok without --no-ack.
 
-	// Do avoid overlap.
+	// To avoid overlap error.
 	err = js.DeleteStream("TEST1")
 	require_NoError(t, err)
 
 	_, err = js.AddStream(&nats.StreamConfig{
 		Name:     "TEST4",
 		Subjects: []string{"$JS.EVENT.>"},
-		NoAck:    true,
 	})
 	require_NoError(t, err)
 
+	// Also allow $SYS.ACCOUNT to be captured without no-ack, these also might break
+	// on a server upgrade so make sure they still work ok without --no-ack.
+
+	// To avoid overlap error.
+	err = js.DeleteStream("TEST3")
+	require_NoError(t, err)
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "TEST5",
+		Subjects: []string{"$SYS.ACCOUNT.>"},
+	})
+	require_NoError(t, err)
+
+	// We will test handling of ">" on a cluster here.
 	// Specific test for capturing everything which will require both no-ack and replicas of 1.
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -984,7 +984,7 @@ func TestJetStreamAddStreamOverlapWithJSAPISubjects(t *testing.T) {
 
 	expectErr := func(_ *stream, err error) {
 		t.Helper()
-		if err == nil || !strings.Contains(err.Error(), "subjects overlap") {
+		if err == nil || !strings.Contains(err.Error(), "subjects that overlap with jetstream api") {
 			t.Fatalf("Expected error but got none")
 		}
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -1504,11 +1504,14 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 			}
 			// Also check to make sure we do not overlap with our $JS API subjects.
 			if !cfg.NoAck && (subjectIsSubsetMatch(subj, "$JS.>") || subjectIsSubsetMatch(subj, "$JSC.>")) {
-				return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("subjects overlap with jetstream api"))
+				// We allow an exception for $JS.EVENT.> since these could have been created in the past.
+				if !subjectIsSubsetMatch(subj, "$JS.EVENT.>") {
+					return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("subjects that overlap with jetstream api require no-ack to be true"))
+				}
 			}
 			// And the $SYS subjects.
 			if !cfg.NoAck && subjectIsSubsetMatch(subj, "$SYS.>") {
-				return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("subjects overlap with system api"))
+				return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("subjects that overlap with system api require no-ack to be true"))
 			}
 			// Mark for duplicate check.
 			dset[subj] = struct{}{}

--- a/server/stream.go
+++ b/server/stream.go
@@ -1521,7 +1521,9 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account) (StreamConfi
 			}
 			// And the $SYS subjects.
 			if !cfg.NoAck && subjectIsSubsetMatch(subj, "$SYS.>") {
-				return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("subjects that overlap with system api require no-ack to be true"))
+				if !subjectIsSubsetMatch(subj, "$SYS.ACCOUNT.>") {
+					return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("subjects that overlap with system api require no-ack to be true"))
+				}
 			}
 			// Mark for duplicate check.
 			dset[subj] = struct{}{}


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>
