### PR TITLE
Remove statszRateLimit by setting to 0 just for tests to avoid flappers.

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -960,7 +960,7 @@ func (s *Server) sendStatsz(subj string) {
 	s.sendInternalMsg(subj, _EMPTY_, &m.Server, &m)
 }
 
-// Limit updates to the heartbeat interval, max one second.
+// Limit updates to the heartbeat interval, max one second by default.
 func (s *Server) limitStatsz(subj string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -44,7 +44,7 @@ func init() {
 	lostQuorumCheck = 4 * hbInterval
 
 	// For statz and jetstream placement speedups as well.
-	statszRateLimit = time.Millisecond * 100
+	statszRateLimit = 0
 }
 
 // Used to setup clusters of clusters for tests.


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>