### PR TITLE
Return error when trying to update a stream with a source with a bad subject transform

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -23760,5 +23760,6 @@ func TestJetStreamBadSubjectMappingStream(t *testing.T) {
 			},
 		},
 	})
-	require_NoError(t, err)
+
+	require_Error(t, err, NewJSStreamUpdateError(errors.New("unable to get subject transform for source: invalid mapping destination: too many arguments passed to the function in {{wildcard(1)}}{{split(3,1)}}")))
 }

--- a/server/stream.go
+++ b/server/stream.go
@@ -1846,7 +1846,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 							var err error
 							si.trs[i], err = NewSubjectTransform(s.SubjectTransforms[i].Source, s.SubjectTransforms[i].Destination)
 							if err != nil {
-								mset.srv.Errorf("Unable to get subject transform for source: %v", err)
+								return fmt.Errorf("unable to get subject transform for source: %v", err)
 							}
 						}
 					}


### PR DESCRIPTION
In some cases a bad subject transform could still pass the validation test that is part of the config check when updating a stream config, and no error would be returned. Now return an error when trying to update a stream config with a source that has a bad subject transform that is not caught by the subject transform destination check in the stream config check.

Improves #5571
