### PR TITLE
[FIXED] Fixed bug that would return no msg found for loadLast.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -6279,6 +6279,8 @@ func (fs *fileStore) loadLast(subj string, sm *StoreMsg) (lsm *StoreMsg, err err
 		if stop == 0 {
 			return nil, ErrStoreMsgNotFound
 		}
+		// These need to be swapped.
+		start, stop = stop, start
 	} else if info, ok := fs.psim.Find(stringToBytes(subj)); ok {
 		start, stop = info.lblk, info.fblk
 	} else {

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -7039,6 +7039,25 @@ func TestFileStoreLoadLastWildcard(t *testing.T) {
 	require_Equal(t, cloads, 1)
 }
 
+func TestFileStoreLoadLastWildcardWithPresenceMultipleBlocks(t *testing.T) {
+	sd := t.TempDir()
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: sd, BlockSize: 64},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo.*.*"}, Storage: FileStorage})
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	// Make sure we have "foo.222.bar" in multiple blocks to show bug.
+	fs.StoreMsg("foo.22.bar", nil, []byte("hello"))
+	fs.StoreMsg("foo.22.baz", nil, []byte("ok"))
+	fs.StoreMsg("foo.22.baz", nil, []byte("ok"))
+	fs.StoreMsg("foo.22.bar", nil, []byte("hello22"))
+	require_True(t, fs.numMsgBlocks() > 1)
+	sm, err := fs.LoadLastMsg("foo.*.bar", nil)
+	require_NoError(t, err)
+	require_Equal(t, "hello22", string(sm.msg))
+}
+
 // We want to make sure that we update psim correctly on a miss.
 func TestFileStoreFilteredPendingPSIMFirstBlockUpdate(t *testing.T) {
 	sd := t.TempDir()


### PR DESCRIPTION
Bug was that new wildcard matching code would not reverse start and stop, which is needed since we walk backwards. Since they were not flipped as soon as start != stop, it would not enter the loop condition, e.g. start:1, stop:2 fails start >= stop.

Only existed in 2.10.17-RC4 and beyond, not in previous releases.

Signed-off-by: Derek Collison <derek@nats.io>