### PR TITLE
Add `node48` to stree

### DIFF
--- a/server/stree/dump.go
+++ b/server/stree/dump.go
@@ -51,6 +51,7 @@ func (t *SubjectTree[T]) dump(w io.Writer, n node, depth int) {
 func (n *leaf[T]) kind() string { return "LEAF" }
 func (n *node4) kind() string   { return "NODE4" }
 func (n *node16) kind() string  { return "NODE16" }
+func (n *node48) kind() string  { return "NODE48" }
 func (n *node256) kind() string { return "NODE256" }
 
 // Calculates the indendation, etc.

--- a/server/stree/node16.go
+++ b/server/stree/node16.go
@@ -50,7 +50,7 @@ func (n *node16) findChild(c byte) *node {
 func (n *node16) isFull() bool { return n.size >= 16 }
 
 func (n *node16) grow() node {
-	nn := newNode256(n.prefix)
+	nn := newNode48(n.prefix)
 	for i := 0; i < 16; i++ {
 		nn.addChild(n.key[i], n.child[i])
 	}

--- a/server/stree/node256.go
+++ b/server/stree/node256.go
@@ -51,10 +51,10 @@ func (n *node256) deleteChild(c byte) {
 
 // Shrink if needed and return new node, otherwise return nil.
 func (n *node256) shrink() node {
-	if n.size > 16 {
+	if n.size > 48 {
 		return nil
 	}
-	nn := newNode16(nil)
+	nn := newNode48(nil)
 	for c, child := range n.child {
 		if child != nil {
 			nn.addChild(byte(c), n.child[c])

--- a/server/stree/node48.go
+++ b/server/stree/node48.go
@@ -1,0 +1,110 @@
+// Copyright 2023-2024 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stree
+
+// Node with 48 children
+// Memory saving vs node256 comes from the fact that the child array is 16 bytes
+// per `node` entry, so node256's 256*16=4096 vs node48's 256+(48*16)=1024
+// Note that `key` is effectively 1-indexed, as 0 means no entry, so offset by 1
+// Order of struct fields for best memory alignment (as per govet/fieldalignment)
+type node48 struct {
+	child [48]node
+	meta
+	key [256]byte
+}
+
+func newNode48(prefix []byte) *node48 {
+	nn := &node48{}
+	nn.setPrefix(prefix)
+	return nn
+}
+
+func (n *node48) addChild(c byte, nn node) {
+	if n.size >= 48 {
+		panic("node48 full!")
+	}
+	n.child[n.size] = nn
+	n.key[c] = byte(n.size + 1) // 1-indexed
+	n.size++
+}
+
+func (n *node48) findChild(c byte) *node {
+	i := n.key[c]
+	if i == 0 {
+		return nil
+	}
+	return &n.child[i-1]
+}
+
+func (n *node48) isFull() bool { return n.size >= 48 }
+
+func (n *node48) grow() node {
+	nn := newNode256(n.prefix)
+	for c := byte(0); c < 255; c++ {
+		if i := n.key[c]; i > 0 {
+			nn.addChild(c, n.child[i-1])
+		}
+	}
+	return nn
+}
+
+// Deletes a child from the node.
+func (n *node48) deleteChild(c byte) {
+	i := n.key[c]
+	if i == 0 {
+		return
+	}
+	i-- // Adjust for 1-indexing
+	last := byte(n.size - 1)
+	if i < last {
+		n.child[i] = n.child[last]
+		for c := byte(0); c <= 255; c++ {
+			if n.key[c] == last+1 {
+				n.key[c] = i + 1
+				break
+			}
+		}
+	}
+	n.child[last] = nil
+	n.key[c] = 0
+	n.size--
+}
+
+// Shrink if needed and return new node, otherwise return nil.
+func (n *node48) shrink() node {
+	if n.size > 16 {
+		return nil
+	}
+	nn := newNode16(nil)
+	for c := byte(0); c < 255; c++ {
+		if i := n.key[c]; i > 0 {
+			nn.addChild(c, n.child[i-1])
+		}
+	}
+	return nn
+}
+
+// Iterate over all children calling func f.
+func (n *node48) iter(f func(node) bool) {
+	for _, c := range n.child {
+		if c != nil && !f(c) {
+			return
+		}
+	}
+}
+
+// Return our children as a slice.
+func (n *node48) children() []node {
+	return n.child[:n.size]
+}


### PR DESCRIPTION
A `node256` is nearly 4KB in memory whereas a `node48` is closer to 1KB, so there is a potential for anywhere up to 75% memory savings in some subject spaces.

Implemented as per the ART paper, although with the caveat that our pointers are actually 16 bytes (as `interface{}`s) rather than 8 bytes as the paper assumes:

> Node48: As the number of entries in a node increases, searching the key array becomes expensive. Therefore, nodes with more than 16 pointers do not store the keys explicitly. Instead, a 256-element array is used, which can be indexed with key bytes directly. If a node has between 17 and 48 child pointers, this array stores indexes into a second array which contains up to 48 pointers. This indirection saves space in comparison to 256 pointers of 8 bytes, because the indexes only require 6 bits (we use 1 byte for simplicity).

Signed-off-by: Neil Twigg <neil@nats.io>
