### PR TITLE
NRG: Fix leaving observer state when applies are paused

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -1886,6 +1886,14 @@ func (n *raft) setObserver(isObserver bool, extSt extensionState) {
 	n.Lock()
 	defer n.Unlock()
 
+	if n.paused {
+		// Applies are paused so we're already in observer state.
+		// Resuming the applies will set the state back to whatever
+		// is in "pobserver", so update that instead.
+		n.pobserver = isObserver
+		return
+	}
+
 	wasObserver := n.observer
 	n.observer = isObserver
 	n.extSt = extSt


### PR DESCRIPTION
Previously, if the applies were paused (i.e. due to an on-going catchup) then calls to `SetObserver(...)` from other places, i.e. `jetstream_cluster_migrate`, would not leave observer mode after applies were resumed. This could result in assets getting stuck in observer mode.

Signed-off-by: Neil Twigg <neil@nats.io>