### PR TITLE
Fix inconsistent atomic accesses of client `mpay`, `msubs`, `mcl`

### DIFF
--- a/server/client_test.go
+++ b/server/client_test.go
@@ -2423,11 +2423,11 @@ func TestClientLimits(t *testing.T) {
 				t.Fatalf("Error encoding jwt: %v", err)
 			}
 			c.applyAccountLimits()
-			if c.mpay != test.expect {
-				t.Fatalf("payload %d not as expected %d", c.mpay, test.expect)
+			if mpay := c.mpay.Load(); mpay != test.expect {
+				t.Fatalf("payload %d not as expected %d", mpay, test.expect)
 			}
-			if c.msubs != test.expect {
-				t.Fatalf("subscriber %d not as expected %d", c.msubs, test.expect)
+			if msubs := c.msubs.Load(); msubs != test.expect {
+				t.Fatalf("subscriber %d not as expected %d", msubs, test.expect)
 			}
 		})
 	}

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -1113,9 +1113,9 @@ func TestJWTAccountLimitsSubs(t *testing.T) {
 	fooAcc.mu.RUnlock()
 	// Now test that the client has limits too.
 	c.mu.Lock()
-	if c.msubs != 10 {
+	if msubs := c.msubs.Load(); msubs != 10 {
 		c.mu.Unlock()
-		t.Fatalf("Expected client msubs to be 10, got %d", c.msubs)
+		t.Fatalf("Expected client msubs to be 10, got %d", msubs)
 	}
 	c.mu.Unlock()
 
@@ -1229,9 +1229,9 @@ func TestJWTAccountLimitsMaxPayload(t *testing.T) {
 	fooAcc.mu.RUnlock()
 	// Now test that the client has limits too.
 	c.mu.Lock()
-	if c.mpay != 8 {
+	if mpay := c.mpay.Load(); mpay != 8 {
 		c.mu.Unlock()
-		t.Fatalf("Expected client to have mpay of 10, got %d", c.mpay)
+		t.Fatalf("Expected client to have mpay of 10, got %d", mpay)
 	}
 	c.mu.Unlock()
 

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -945,7 +945,9 @@ func (s *Server) createLeafNode(conn net.Conn, rURL *url.URL, remote *leafNodeCf
 	}
 	now := time.Now().UTC()
 
-	c := &client{srv: s, nc: conn, kind: LEAF, opts: defaultOpts, mpay: maxPay, msubs: maxSubs, start: now, last: now}
+	c := &client{srv: s, nc: conn, kind: LEAF, opts: defaultOpts, start: now, last: now}
+	c.mpay.Store(maxPay)
+	c.msubs.Store(maxSubs)
 	// Do not update the smap here, we need to do it in initLeafNodeSmapAndSendSubs
 	c.leaf = &leaf{}
 

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -548,7 +548,9 @@ func (s *Server) createMQTTClient(conn net.Conn, ws *websocket) *client {
 		rejectQoS2Pub:    opts.MQTT.rejectQoS2Pub,
 		downgradeQoS2Sub: opts.MQTT.downgradeQoS2Sub,
 	}
-	c := &client{srv: s, nc: conn, mpay: maxPay, msubs: maxSubs, start: now, last: now, mqtt: mqtt, ws: ws}
+	c := &client{srv: s, nc: conn, start: now, last: now, mqtt: mqtt, ws: ws}
+	c.mpay.Store(maxPay)
+	c.msubs.Store(maxSubs)
 	c.headers = true
 	c.mqtt.pp = &mqttPublish{}
 	// MQTT clients don't send NATS CONNECT protocols. So make it an "echo"

--- a/server/parser.go
+++ b/server/parser.go
@@ -148,7 +148,7 @@ func (c *client) parse(buf []byte) error {
 	// proper CONNECT if needed.
 	authSet := c.awaitingAuth()
 	// Snapshot max control line as well.
-	s, mcl, trace := c.srv, c.mcl, c.trace
+	s, mcl, trace := c.srv, c.mcl.Load(), c.trace
 	c.mu.Unlock()
 
 	// Move to loop instead of range syntax to allow jumping of i

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -19,7 +19,11 @@ import (
 )
 
 func dummyClient() *client {
-	return &client{srv: New(&defaultServerOptions), msubs: -1, mpay: -1, mcl: MAX_CONTROL_LINE_SIZE}
+	c := &client{srv: New(&defaultServerOptions)}
+	c.mpay.Store(-1)
+	c.msubs.Store(-1)
+	c.mcl.Store(MAX_CONTROL_LINE_SIZE)
+	return c
 }
 
 func dummyRouteClient() *client {
@@ -301,7 +305,7 @@ func TestParsePubArg(t *testing.T) {
 func TestParsePubBadSize(t *testing.T) {
 	c := dummyClient()
 	// Setup localized max payload
-	c.mpay = 32768
+	c.mpay.Store(32768)
 	if err := c.processPub([]byte("foo 2222222222222222")); err == nil {
 		t.Fatalf("Expected parse error for size too large")
 	}
@@ -837,7 +841,7 @@ func TestMaxControlLine(t *testing.T) {
 				case GATEWAY:
 					c.gw = &gateway{outbound: false, connected: true, insim: make(map[string]*insie)}
 				}
-				c.mcl = 8
+				c.mcl.Store(8)
 				return c
 			}
 

--- a/server/reload.go
+++ b/server/reload.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"sort"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/klauspost/compress/s2"
@@ -610,7 +609,7 @@ func (m *maxControlLineOption) Apply(server *Server) {
 	mcl := int32(m.newValue)
 	server.mu.Lock()
 	for _, client := range server.clients {
-		atomic.StoreInt32(&client.mcl, mcl)
+		client.mcl.Store(mcl)
 	}
 	server.mu.Unlock()
 	server.Noticef("Reloaded: max_control_line = %d", mcl)
@@ -628,7 +627,7 @@ func (m *maxPayloadOption) Apply(server *Server) {
 	server.mu.Lock()
 	server.info.MaxPayload = m.newValue
 	for _, client := range server.clients {
-		atomic.StoreInt32(&client.mpay, int32(m.newValue))
+		client.mpay.Store(int32(m.newValue))
 	}
 	server.mu.Unlock()
 	server.Noticef("Reloaded: max_payload = %d", m.newValue)

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -3859,7 +3859,7 @@ func TestConfigReloadMaxControlLineWithClients(t *testing.T) {
 	getMcl := func(c *client) int32 {
 		c.mu.Lock()
 		defer c.mu.Unlock()
-		return c.mcl
+		return c.mcl.Load()
 	}
 	if mcl := getMcl(c); mcl != opts.MaxControlLine {
 		t.Fatalf("Expected snapshot in client for mcl to be same as opts.MaxControlLine, got %d vs %d",

--- a/server/route.go
+++ b/server/route.go
@@ -1692,7 +1692,9 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL, accName string) *clie
 		}
 	}
 
-	c := &client{srv: s, nc: conn, opts: ClientOpts{}, kind: ROUTER, msubs: -1, mpay: -1, route: r, start: time.Now()}
+	c := &client{srv: s, nc: conn, opts: ClientOpts{}, kind: ROUTER, route: r, start: time.Now()}
+	c.mpay.Store(-1)
+	c.msubs.Store(-1)
 
 	// Is the server configured for compression?
 	compressionConfigured := needsCompression(opts.Cluster.Compression.Mode)

--- a/server/server.go
+++ b/server/server.go
@@ -1804,7 +1804,9 @@ func (s *Server) createInternalClient(kind int) *client {
 		return nil
 	}
 	now := time.Now()
-	c := &client{srv: s, kind: kind, opts: internalOpts, msubs: -1, mpay: -1, start: now, last: now}
+	c := &client{srv: s, kind: kind, opts: internalOpts, start: now, last: now}
+	c.msubs.Store(-1)
+	c.mpay.Store(-1)
 	c.initClient()
 	c.echo = false
 	c.headers = true
@@ -3106,12 +3108,12 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 		srv:   s,
 		nc:    conn,
 		opts:  defaultOpts,
-		mpay:  maxPay,
-		msubs: maxSubs,
 		start: now,
 		last:  now,
 		iproc: inProcess,
 	}
+	c.mpay.Store(maxPay)
+	c.msubs.Store(maxSubs)
 
 	c.registerWithAccount(s.globalAccount())
 

--- a/server/split_test.go
+++ b/server/split_test.go
@@ -29,7 +29,10 @@ func TestSplitBufferSubOp(t *testing.T) {
 		t.Fatalf("Error creating gateways: %v", err)
 	}
 	s.registerAccount(s.gacc)
-	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription), nc: cli}
+	c := &client{srv: s, acc: s.gacc, subs: make(map[string]*subscription), nc: cli}
+	c.msubs.Store(-1)
+	c.mpay.Store(-1)
+	c.mcl.Store(1024)
 
 	subop := []byte("SUB foo 1\r\n")
 	subop1 := subop[:6]
@@ -66,7 +69,10 @@ func TestSplitBufferSubOp(t *testing.T) {
 func TestSplitBufferUnsubOp(t *testing.T) {
 	s := &Server{gacc: NewAccount(globalAccountName), gateway: &srvGateway{}}
 	s.registerAccount(s.gacc)
-	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
+	c := &client{srv: s, acc: s.gacc, subs: make(map[string]*subscription)}
+	c.msubs.Store(-1)
+	c.mpay.Store(-1)
+	c.mcl.Store(1024)
 
 	subop := []byte("SUB foo 1024\r\n")
 	if err := c.parse(subop); err != nil {
@@ -99,7 +105,10 @@ func TestSplitBufferUnsubOp(t *testing.T) {
 }
 
 func TestSplitBufferPubOp(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
+	c := &client{subs: make(map[string]*subscription)}
+	c.msubs.Store(-1)
+	c.mpay.Store(-1)
+	c.mcl.Store(1024)
 	pub := []byte("PUB foo.bar INBOX.22 11\r\nhello world\r")
 	pub1 := pub[:2]
 	pub2 := pub[2:9]
@@ -165,7 +174,10 @@ func TestSplitBufferPubOp(t *testing.T) {
 }
 
 func TestSplitBufferPubOp2(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
+	c := &client{subs: make(map[string]*subscription)}
+	c.msubs.Store(-1)
+	c.mpay.Store(-1)
+	c.mcl.Store(1024)
 	pub := []byte("PUB foo.bar INBOX.22 11\r\nhello world\r\n")
 	pub1 := pub[:30]
 	pub2 := pub[30:]
@@ -185,7 +197,10 @@ func TestSplitBufferPubOp2(t *testing.T) {
 }
 
 func TestSplitBufferPubOp3(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
+	c := &client{subs: make(map[string]*subscription)}
+	c.msubs.Store(-1)
+	c.mpay.Store(-1)
+	c.mcl.Store(1024)
 	pubAll := []byte("PUB foo bar 11\r\nhello world\r\n")
 	pub := pubAll[:16]
 
@@ -211,7 +226,10 @@ func TestSplitBufferPubOp3(t *testing.T) {
 }
 
 func TestSplitBufferPubOp4(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
+	c := &client{subs: make(map[string]*subscription)}
+	c.msubs.Store(-1)
+	c.mpay.Store(-1)
+	c.mcl.Store(1024)
 	pubAll := []byte("PUB foo 11\r\nhello world\r\n")
 	pub := pubAll[:12]
 
@@ -237,7 +255,10 @@ func TestSplitBufferPubOp4(t *testing.T) {
 }
 
 func TestSplitBufferPubOp5(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
+	c := &client{subs: make(map[string]*subscription)}
+	c.msubs.Store(-1)
+	c.mpay.Store(-1)
+	c.mcl.Store(1024)
 	pubAll := []byte("PUB foo 11\r\nhello world\r\n")
 
 	// Splits need to be on MSG_END_R now too, so make sure we check that.
@@ -256,7 +277,10 @@ func TestSplitBufferPubOp5(t *testing.T) {
 }
 
 func TestSplitConnectArg(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
+	c := &client{subs: make(map[string]*subscription)}
+	c.msubs.Store(-1)
+	c.mpay.Store(-1)
+	c.mcl.Store(1024)
 	connectAll := []byte("CONNECT {\"verbose\":false,\"tls_required\":false," +
 		"\"user\":\"test\",\"pedantic\":true,\"pass\":\"pass\"}\r\n")
 
@@ -305,7 +329,10 @@ func TestSplitConnectArg(t *testing.T) {
 
 func TestSplitDanglingArgBuf(t *testing.T) {
 	s := New(&defaultServerOptions)
-	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
+	c := &client{srv: s, acc: s.gacc, subs: make(map[string]*subscription)}
+	c.msubs.Store(-1)
+	c.mpay.Store(-1)
+	c.mcl.Store(1024)
 
 	// We test to make sure we do not dangle any argBufs after processing
 	// since that could lead to performance issues.
@@ -364,7 +391,9 @@ func TestSplitDanglingArgBuf(t *testing.T) {
 	}
 
 	// MSG (the client has to be a ROUTE)
-	c = &client{msubs: -1, mpay: -1, subs: make(map[string]*subscription), kind: ROUTER, route: &route{}}
+	c = &client{subs: make(map[string]*subscription), kind: ROUTER, route: &route{}}
+	c.msubs.Store(-1)
+	c.mpay.Store(-1)
 	msgop := []byte("RMSG $foo foo 5\r\nhello\r\n")
 	c.parse(msgop[:5])
 	c.parse(msgop[5:10])
@@ -446,7 +475,10 @@ func TestSplitRoutedMsgArg(t *testing.T) {
 }
 
 func TestSplitBufferMsgOp(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription), kind: ROUTER, route: &route{}}
+	c := &client{subs: make(map[string]*subscription), kind: ROUTER, route: &route{}}
+	c.msubs.Store(-1)
+	c.mpay.Store(-1)
+	c.mcl.Store(1024)
 	msg := []byte("RMSG $G foo.bar _INBOX.22 11\r\nhello world\r")
 	msg1 := msg[:2]
 	msg2 := msg[2:9]
@@ -519,7 +551,10 @@ func TestSplitBufferMsgOp(t *testing.T) {
 }
 
 func TestSplitBufferLeafMsgArg(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription), kind: LEAF}
+	c := &client{subs: make(map[string]*subscription), kind: LEAF}
+	c.msubs.Store(-1)
+	c.mpay.Store(-1)
+	c.mcl.Store(1024)
 	msg := []byte("LMSG foo + bar baz 11\r\n")
 	if err := c.parse(msg); err != nil {
 		t.Fatalf("Unexpected parse error: %v\n", err)

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1247,7 +1247,9 @@ func (s *Server) createWSClient(conn net.Conn, ws *websocket) *client {
 	}
 	now := time.Now().UTC()
 
-	c := &client{srv: s, nc: conn, opts: defaultOpts, mpay: maxPay, msubs: maxSubs, start: now, last: now, ws: ws}
+	c := &client{srv: s, nc: conn, opts: defaultOpts, start: now, last: now, ws: ws}
+	c.mpay.Store(maxPay)
+	c.msubs.Store(maxSubs)
 
 	c.registerWithAccount(s.globalAccount())
 


### PR DESCRIPTION
This fixes data races reported by the race detector. By switching to `atomic.Int32` type, we can guarantee that the accesses are atomic across the board, whereas before there were some instances of plain reads/writes mixed with other cases of `atomic.StoreInt32`/`atomic.LoadInt32`. 

Signed-off-by: Neil Twigg <neil@nats.io>
