### PR TITLE
Use the tag name for the version on release

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -5,7 +5,7 @@ builds:
     id: nats-server
     binary: nats-server
     ldflags:
-      - -w -X github.com/nats-io/nats-server/v2/server.gitCommit={{.ShortCommit}}
+      - -w -X github.com/nats-io/nats-server/v2/version.GitCommit={{.ShortCommit}} -X 'github.com/nats-io/nats-server/v2/version.Version={{.Summary}}'
     env:
       - GO111MODULE=on
       - CGO_ENABLED=0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
   flags:
   - -trimpath
   ldflags:
-    - -w -X github.com/nats-io/nats-server/v2/server.gitCommit={{.ShortCommit}}
+    - -w -X 'github.com/nats-io/nats-server/v2/server.gitCommit={{.ShortCommit}}' -X 'github.com/nats-io/nats-server/v2/server.serverVersion={{.CurrentTag}}' -X 'github.com/nats-io/nats-server/v2/version.Version={{.CurrentTag}}'
   env:
     - GO111MODULE=on
     - CGO_ENABLED=0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
   flags:
   - -trimpath
   ldflags:
-    - -w -X 'github.com/nats-io/nats-server/v2/server.gitCommit={{.ShortCommit}}' -X 'github.com/nats-io/nats-server/v2/server.serverVersion={{.CurrentTag}}' -X 'github.com/nats-io/nats-server/v2/version.Version={{.CurrentTag}}'
+    - -w -X 'github.com/nats-io/nats-server/v2/version.GitCommit={{.ShortCommit}}' -X 'github.com/nats-io/nats-server/v2/version.Version={{.CurrentTag}}'
   env:
     - GO111MODULE=on
     - CGO_ENABLED=0

--- a/server/const.go
+++ b/server/const.go
@@ -34,6 +34,7 @@ const (
 )
 
 var (
+	serverVersion string
 	// gitCommit injected at build
 	gitCommit string
 	// trustedKeys is a whitespace separated array of trusted operator's public nkeys.

--- a/server/const.go
+++ b/server/const.go
@@ -34,9 +34,6 @@ const (
 )
 
 var (
-	serverVersion string
-	// gitCommit injected at build
-	gitCommit string
 	// trustedKeys is a whitespace separated array of trusted operator's public nkeys.
 	trustedKeys string
 	// SemVer regexp to validate the VERSION.
@@ -44,9 +41,6 @@ var (
 )
 
 const (
-	// VERSION is the current version for the server.
-	VERSION = "2.11.0-dev"
-
 	// PROTO is the currently supported protocol.
 	// 0 was the original
 	// 1 maintains proto 0, adds echo abilities for CONNECT from the client. Clients

--- a/server/events.go
+++ b/server/events.go
@@ -35,6 +35,7 @@ import (
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/server/certidp"
 	"github.com/nats-io/nats-server/v2/server/pse"
+	serverVersion "github.com/nats-io/nats-server/v2/version"
 )
 
 const (
@@ -479,7 +480,7 @@ RESET:
 					si.Cluster = cluster
 					si.ID = id
 					si.Seq = atomic.AddUint64(seqp, 1)
-					si.Version = VERSION
+					si.Version = serverVersion.Version
 					si.Time = time.Now().UTC()
 					si.Tags = tags
 					if js {

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/nats-io/jwt/v2"
+	serverVersion "github.com/nats-io/nats-server/v2/version"
 	"github.com/nats-io/nkeys"
 )
 
@@ -107,7 +108,7 @@ func validateTrustedOperators(o *Options) error {
 		}
 	}
 
-	srvMajor, srvMinor, srvUpdate, _ := versionComponents(VERSION)
+	srvMajor, srvMinor, srvUpdate, _ := versionComponents(serverVersion.Version)
 	for _, opc := range o.TrustedOperators {
 		if major, minor, update, err := jwt.ParseServerVersion(opc.AssertServerVersion); err != nil {
 			return fmt.Errorf("operator %s expects version %s got error instead: %s",

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
+	serverVersion "github.com/nats-io/nats-server/v2/version"
 	"github.com/nats-io/nkeys"
 	"github.com/nats-io/nuid"
 )
@@ -718,7 +719,7 @@ func (s *Server) startLeafNodeAcceptLoop() {
 		ID:            s.info.ID,
 		Name:          s.info.Name,
 		Version:       s.info.Version,
-		GitCommit:     gitCommit,
+		GitCommit:     serverVersion.GitCommit,
 		GoVersion:     runtime.Version(),
 		AuthRequired:  true,
 		TLSRequired:   tlsRequired,
@@ -780,7 +781,7 @@ var credsRe = regexp.MustCompile(`\s*(?:(?:[-]{3,}[^\n]*[-]{3,}\n)(.+)(?:\n\s*[-
 func (c *client) sendLeafConnect(clusterName string, headers bool) error {
 	// We support basic user/pass and operator based user JWT with signatures.
 	cinfo := leafConnectInfo{
-		Version:       VERSION,
+		Version:       serverVersion.Version,
 		ID:            c.srv.info.ID,
 		Domain:        c.srv.info.Domain,
 		Name:          c.srv.info.Name,

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/server/pse"
+	serverVersion "github.com/nats-io/nats-server/v2/version"
 )
 
 // Connz represents detailed information on current client connections.
@@ -1385,10 +1386,10 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 
 	// Calculate source url. If git set go directly to that tag, otherwise just main.
 	var srcUrl string
-	if gitCommit == _EMPTY_ {
+	if serverVersion.GitCommit == _EMPTY_ {
 		srcUrl = "https://github.com/nats-io/nats-server"
 	} else {
-		srcUrl = fmt.Sprintf("https://github.com/nats-io/nats-server/tree/%s", gitCommit)
+		srcUrl = fmt.Sprintf("https://github.com/nats-io/nats-server/tree/%s", serverVersion.GitCommit)
 	}
 
 	fmt.Fprintf(w, `<html lang="en">
@@ -1427,7 +1428,7 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
   </body>
 </html>`,
 		srcUrl,
-		VERSION,
+		serverVersion.Version,
 		s.basePath(VarzPath),
 		s.basePath(JszPath),
 		s.basePath(ConnzPath),

--- a/server/server.go
+++ b/server/server.go
@@ -48,6 +48,7 @@ import (
 	"github.com/nats-io/nuid"
 
 	"github.com/nats-io/nats-server/v2/logger"
+	serverVersion "github.com/nats-io/nats-server/v2/version"
 )
 
 const (
@@ -648,10 +649,6 @@ func New(opts *Options) *Server {
 func NewServer(opts *Options) (*Server, error) {
 	setBaselineOptions(opts)
 
-	if serverVersion == _EMPTY_ {
-		serverVersion = VERSION
-	}
-
 	// Process TLS options, including whether we require client certificates.
 	tlsReq := opts.TLSConfig != nil
 	verify := (tlsReq && opts.TLSConfig.ClientAuth == tls.RequireAndVerifyClientCert)
@@ -682,9 +679,9 @@ func NewServer(opts *Options) (*Server, error) {
 	info := Info{
 		ID:           pub,
 		XKey:         xpub,
-		Version:      serverVersion,
+		Version:      serverVersion.Version,
 		Proto:        PROTO,
-		GitCommit:    gitCommit,
+		GitCommit:    serverVersion.GitCommit,
 		GoVersion:    runtime.Version(),
 		Name:         serverName,
 		Host:         opts.Host,
@@ -761,7 +758,7 @@ func NewServer(opts *Options) (*Server, error) {
 		ourNode := getHash(serverName)
 		s.nodeToInfo.Store(ourNode, nodeInfo{
 			serverName,
-			VERSION,
+			serverVersion.Version,
 			opts.Cluster.Name,
 			opts.JetStreamDomain,
 			info.ID,
@@ -1550,7 +1547,7 @@ func PrintAndDie(msg string) {
 
 // PrintServerAndExit will print our version and exit.
 func PrintServerAndExit() {
-	fmt.Printf("nats-server: v%s\n", serverVersion)
+	fmt.Printf("nats-server: v%s\n", serverVersion.Version)
 	os.Exit(0)
 }
 
@@ -2151,7 +2148,7 @@ func (s *Server) fetchAccount(name string) (*Account, error) {
 func (s *Server) Start() {
 	s.Noticef("Starting nats-server")
 
-	gc := gitCommit
+	gc := serverVersion.GitCommit
 	if gc == _EMPTY_ {
 		gc = "not set"
 	}
@@ -2160,7 +2157,7 @@ func (s *Server) Start() {
 	opts := s.getOpts()
 	clusterName := s.ClusterName()
 
-	s.Noticef("  Version:  %s", VERSION)
+	s.Noticef("  Version:  %s", serverVersion.Version)
 	s.Noticef("  Git:      [%s]", gc)
 	s.Debugf("  Go build: %s", s.info.GoVersion)
 	if clusterName != _EMPTY_ {

--- a/server/server.go
+++ b/server/server.go
@@ -648,6 +648,10 @@ func New(opts *Options) *Server {
 func NewServer(opts *Options) (*Server, error) {
 	setBaselineOptions(opts)
 
+	if serverVersion == _EMPTY_ {
+		serverVersion = VERSION
+	}
+
 	// Process TLS options, including whether we require client certificates.
 	tlsReq := opts.TLSConfig != nil
 	verify := (tlsReq && opts.TLSConfig.ClientAuth == tls.RequireAndVerifyClientCert)
@@ -678,7 +682,7 @@ func NewServer(opts *Options) (*Server, error) {
 	info := Info{
 		ID:           pub,
 		XKey:         xpub,
-		Version:      VERSION,
+		Version:      serverVersion,
 		Proto:        PROTO,
 		GitCommit:    gitCommit,
 		GoVersion:    runtime.Version(),
@@ -1546,7 +1550,7 @@ func PrintAndDie(msg string) {
 
 // PrintServerAndExit will print our version and exit.
 func PrintServerAndExit() {
-	fmt.Printf("nats-server: v%s\n", VERSION)
+	fmt.Printf("nats-server: v%s\n", serverVersion)
 	os.Exit(0)
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+var Version string
+
+// gitCommit injected at build
+var GitCommit string


### PR DESCRIPTION
Use the tag name for the version on release. This also makes the version easier to detect in scanners such as Syft. Otherwise the version that gets detected is listed as `(devel)`.

Signed-off-by: Laurent Goderre <laurent.goderre@docker.com>
