### PR TITLE
[FIXED] Memory growth from NRG create and delete operations 

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -5654,7 +5654,7 @@ func (c *client) getAccAndResultFromCache() (*Account, *SublistResult) {
 
 		if genid := atomic.LoadUint64(&sl.genid); genid != pac.genid {
 			ok = false
-			delete(c.in.pacache, bytesToString(c.pa.pacache))
+			c.in.pacache = make(map[string]*perAccountCache)
 		} else {
 			acc = pac.acc
 			r = pac.results

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4116,7 +4116,7 @@ func (js *jetStream) processConsumerAssignment(ca *consumerAssignment) {
 		sa.consumers = make(map[string]*consumerAssignment)
 	} else if oca := sa.consumers[ca.Name]; oca != nil {
 		wasExisting = true
-		// Copy over private existing state from former SA.
+		// Copy over private existing state from former CA.
 		if ca.Group != nil {
 			ca.Group.node = oca.Group.node
 		}
@@ -4238,6 +4238,7 @@ func (js *jetStream) processConsumerRemoval(ca *consumerAssignment) {
 			if ca.Group != nil && oca.Group != nil && ca.Group.Name == oca.Group.Name {
 				needDelete = true
 				oca.deleted = true
+				oca.Group.node = nil
 				delete(sa.consumers, ca.Name)
 			}
 		}


### PR DESCRIPTION
Fix for situations where GC struggled to clean up things.

This mostly stemmed from subscriptions being held in per connection caches (routers and gateways). These held references to both clients and any internal callbacks, which usually were closures so would also hold reference to the struct target as well.
 
Signed-off-by: Derek Collison <derek@nats.io>