### PR TITLE
[IMPROVED] Routing: reduce chances of duplicate implicit routes

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -82,6 +82,9 @@ type route struct {
 	// Selected compression mode, which may be different from the
 	// server configured mode.
 	compression string
+	// Transient value used to set the Info.NoGossip when initiating
+	// an implicit route and sending to the remote.
+	noGossip bool
 }
 
 type connectInfo struct {
@@ -684,12 +687,15 @@ func (c *client) processRouteInfo(info *Info) {
 		return
 	}
 
+	var sendDelayedInfo bool
+
 	// First INFO, check if this server is configured for compression because
 	// if that is the case, we need to negotiate it with the remote server.
 	if needsCompression(opts.Cluster.Compression.Mode) {
 		accName := bytesToString(c.route.accName)
 		// If we did not yet negotiate...
-		if !c.flags.isSet(compressionNegotiated) {
+		compNeg := c.flags.isSet(compressionNegotiated)
+		if !compNeg {
 			// Prevent from getting back here.
 			c.flags.set(compressionNegotiated)
 			// Release client lock since following function will need server lock.
@@ -706,24 +712,21 @@ func (c *client) processRouteInfo(info *Info) {
 			}
 			// No compression because one side does not want/can't, so proceed.
 			c.mu.Lock()
-		} else if didSolicit {
-			// The other side has switched to compression, so we can now set
-			// the first ping timer and send the delayed INFO for situations
-			// where it was not already sent.
-			c.setFirstPingTimer()
-			if !routeShouldDelayInfo(accName, opts) {
-				cm := compressionModeForInfoProtocol(&opts.Cluster.Compression, c.route.compression)
-				// Need to release and then reacquire...
+			// Check that the connection did not close if the lock was released.
+			if c.isClosed() {
 				c.mu.Unlock()
-				s.sendDelayedRouteInfo(c, accName, cm)
-				c.mu.Lock()
+				return
 			}
 		}
-		// Check that the connection did not close if the lock was released.
-		if c.isClosed() {
-			c.mu.Unlock()
-			return
+		// We can set the ping timer after we just negotiated compression above,
+		// or for solicited routes if we already negotiated.
+		if !compNeg || didSolicit {
+			c.setFirstPingTimer()
 		}
+		// When compression is configured, we delay the initial INFO for any
+		// solicited route. So we need to send the delayed INFO simply based
+		// on the didSolicit boolean.
+		sendDelayedInfo = didSolicit
 	} else {
 		// Coming from an old server, the Compression field would be the empty
 		// string. For servers that are configured with CompressionNotSupported,
@@ -733,6 +736,10 @@ func (c *client) processRouteInfo(info *Info) {
 		} else {
 			c.route.compression = CompressionOff
 		}
+		// When compression is not configured, we delay the initial INFO only
+		// for solicited pooled routes, so use the same check that we did when
+		// we decided to delay in createRoute().
+		sendDelayedInfo = didSolicit && routeShouldDelayInfo(bytesToString(c.route.accName), opts)
 	}
 
 	// Mark that the INFO protocol has been received, so we can detect updates.
@@ -810,11 +817,15 @@ func (c *client) processRouteInfo(info *Info) {
 	}
 	accName := string(c.route.accName)
 
+	// Capture the noGossip value and reset it here.
+	noGossip := c.route.noGossip
+	c.route.noGossip = false
+
 	// Check to see if we have this remote already registered.
 	// This can happen when both servers have routes to each other.
 	c.mu.Unlock()
 
-	if added := s.addRoute(c, didSolicit, info, accName); added {
+	if added := s.addRoute(c, didSolicit, sendDelayedInfo, noGossip, info, accName); added {
 		if accName != _EMPTY_ {
 			c.Debugf("Registering remote route %q for account %q", info.ID, accName)
 		} else {
@@ -848,7 +859,7 @@ func (s *Server) negotiateRouteCompression(c *client, didSolicit bool, accName, 
 	if needsCompression(cm) {
 		// Generate an INFO with the chosen compression mode.
 		s.mu.Lock()
-		infoProto := s.generateRouteInitialInfoJSON(accName, cm, 0)
+		infoProto := s.generateRouteInitialInfoJSON(accName, cm, 0, false)
 		s.mu.Unlock()
 
 		// If we solicited, then send this INFO protocol BEFORE switching
@@ -877,27 +888,7 @@ func (s *Server) negotiateRouteCompression(c *client, didSolicit bool, accName, 
 		c.mu.Unlock()
 		return true, nil
 	}
-	// We are not using compression, set the ping timer.
-	c.mu.Lock()
-	c.setFirstPingTimer()
-	c.mu.Unlock()
-	// If this is a solicited route, we need to send the INFO if it was not
-	// done during createRoute() and will not be done in addRoute().
-	if didSolicit && !routeShouldDelayInfo(accName, opts) {
-		cm = compressionModeForInfoProtocol(&opts.Cluster.Compression, cm)
-		s.sendDelayedRouteInfo(c, accName, cm)
-	}
 	return false, nil
-}
-
-func (s *Server) sendDelayedRouteInfo(c *client, accName, cm string) {
-	s.mu.Lock()
-	infoProto := s.generateRouteInitialInfoJSON(accName, cm, 0)
-	s.mu.Unlock()
-
-	c.mu.Lock()
-	c.enqueueProto(infoProto)
-	c.mu.Unlock()
 }
 
 // Possibly sends local subscriptions interest to this route
@@ -1035,7 +1026,7 @@ func (s *Server) processImplicitRoute(info *Info, routeNoPool bool) {
 	if info.AuthRequired {
 		r.User = url.UserPassword(opts.Cluster.Username, opts.Cluster.Password)
 	}
-	s.startGoRoutine(func() { s.connectToRoute(r, false, true, info.RouteAccount) })
+	s.startGoRoutine(func() { s.connectToRoute(r, Implicit, true, info.NoGossip, info.RouteAccount) })
 	// If we are processing an implicit route from a route that does not
 	// support pooling/pinned-accounts, we won't receive an INFO for each of
 	// the pinned-accounts that we would normally receive. In that case, just
@@ -1045,7 +1036,7 @@ func (s *Server) processImplicitRoute(info *Info, routeNoPool bool) {
 		rURL := r
 		for _, an := range opts.Cluster.PinnedAccounts {
 			accName := an
-			s.startGoRoutine(func() { s.connectToRoute(rURL, false, true, accName) })
+			s.startGoRoutine(func() { s.connectToRoute(rURL, Implicit, true, info.NoGossip, accName) })
 		}
 	}
 }
@@ -1097,11 +1088,39 @@ func (s *Server) forwardNewRouteInfoToKnownServers(info *Info) {
 	b, _ := json.Marshal(info)
 	infoJSON := []byte(fmt.Sprintf(InfoProto, b))
 
+	// If this is for a pinned account, we will try to send the gossip
+	// through our pinned account routes, but fall back to the other
+	// routes in case we don't have one for a given remote.
+	accRemotes := map[string]struct{}{}
+	if info.RouteAccount != _EMPTY_ {
+		if remotes, ok := s.accRoutes[info.RouteAccount]; ok {
+			for remoteID, r := range remotes {
+				if r == nil {
+					continue
+				}
+				accRemotes[remoteID] = struct{}{}
+				r.mu.Lock()
+				// Do not send to a remote that does not support pooling/pinned-accounts.
+				if remoteID != info.ID && !r.route.noPool {
+					r.enqueueProto(infoJSON)
+				}
+				r.mu.Unlock()
+			}
+		}
+	}
+
 	s.forEachRemote(func(r *client) {
 		r.mu.Lock()
+		remoteID := r.route.remoteID
+		if info.RouteAccount != _EMPTY_ {
+			if _, processed := accRemotes[remoteID]; processed {
+				r.mu.Unlock()
+				return
+			}
+		}
 		// If this is a new route for a given account, do not send to a server
 		// that does not support pooling/pinned-accounts.
-		if r.route.remoteID != info.ID &&
+		if remoteID != info.ID &&
 			(info.RouteAccount == _EMPTY_ || (info.RouteAccount != _EMPTY_ && !r.route.noPool)) {
 			r.enqueueProto(infoJSON)
 		}
@@ -1680,17 +1699,12 @@ func (c *client) sendRouteSubOrUnSubProtos(subs []*subscription, isSubProto, tra
 	c.enqueueProto(buf)
 }
 
-func (s *Server) createRoute(conn net.Conn, rURL *url.URL, accName string) *client {
+func (s *Server) createRoute(conn net.Conn, rURL *url.URL, rtype RouteType, noGossip bool, accName string) *client {
 	// Snapshot server options.
 	opts := s.getOpts()
 
 	didSolicit := rURL != nil
-	r := &route{didSolicit: didSolicit, poolIdx: -1}
-	for _, route := range opts.Routes {
-		if rURL != nil && (strings.EqualFold(rURL.Host, route.Host)) {
-			r.routeType = Explicit
-		}
-	}
+	r := &route{routeType: rtype, didSolicit: didSolicit, poolIdx: -1, noGossip: noGossip}
 
 	c := &client{srv: s, nc: conn, opts: ClientOpts{}, kind: ROUTER, msubs: -1, mpay: -1, route: r, start: time.Now()}
 
@@ -1707,7 +1721,7 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL, accName string) *clie
 	// the incoming INFO from the remote. Also delay if configured for compression.
 	delayInfo := didSolicit && (compressionConfigured || routeShouldDelayInfo(accName, opts))
 	if !delayInfo {
-		infoJSON = s.generateRouteInitialInfoJSON(accName, opts.Cluster.Compression.Mode, 0)
+		infoJSON = s.generateRouteInitialInfoJSON(accName, opts.Cluster.Compression.Mode, 0, noGossip)
 	}
 	authRequired := s.routeInfo.AuthRequired
 	tlsRequired := s.routeInfo.TLSRequired
@@ -1840,7 +1854,7 @@ func routeShouldDelayInfo(accName string, opts *Options) bool {
 // To be used only when a route is created (to send the initial INFO protocol).
 //
 // Server lock held on entry.
-func (s *Server) generateRouteInitialInfoJSON(accName, compression string, poolIdx int) []byte {
+func (s *Server) generateRouteInitialInfoJSON(accName, compression string, poolIdx int, noGossip bool) []byte {
 	// New proto wants a nonce (although not used in routes, that is, not signed in CONNECT)
 	var raw [nonceLen]byte
 	nonce := raw[:]
@@ -1850,11 +1864,11 @@ func (s *Server) generateRouteInitialInfoJSON(accName, compression string, poolI
 	if s.getOpts().Cluster.Compression.Mode == CompressionS2Auto {
 		compression = CompressionS2Auto
 	}
-	ri.Nonce, ri.RouteAccount, ri.RoutePoolIdx, ri.Compression = string(nonce), accName, poolIdx, compression
+	ri.Nonce, ri.RouteAccount, ri.RoutePoolIdx, ri.Compression, ri.NoGossip = string(nonce), accName, poolIdx, compression, noGossip
 	infoJSON := generateInfoJSON(&s.routeInfo)
 	// Clear now that it has been serialized. Will prevent nonce to be included in async INFO that we may send.
 	// Same for some other fields.
-	ri.Nonce, ri.RouteAccount, ri.RoutePoolIdx, ri.Compression = _EMPTY_, _EMPTY_, 0, _EMPTY_
+	ri.Nonce, ri.RouteAccount, ri.RoutePoolIdx, ri.Compression, ri.NoGossip = _EMPTY_, _EMPTY_, 0, _EMPTY_, false
 	return infoJSON
 }
 
@@ -1863,7 +1877,7 @@ const (
 	_EMPTY_ = ""
 )
 
-func (s *Server) addRoute(c *client, didSolicit bool, info *Info, accName string) bool {
+func (s *Server) addRoute(c *client, didSolicit, sendDelayedInfo, noGossip bool, info *Info, accName string) bool {
 	id := info.ID
 
 	var acc *Account
@@ -1949,12 +1963,19 @@ func (s *Server) addRoute(c *client, didSolicit bool, info *Info, accName string
 			c.mu.Lock()
 			idHash := c.route.idHash
 			cid := c.cid
+			if sendDelayedInfo {
+				cm := compressionModeForInfoProtocol(&opts.Cluster.Compression, c.route.compression)
+				c.enqueueProto(s.generateRouteInitialInfoJSON(accName, cm, 0, noGossip))
+			}
 			if c.last.IsZero() {
 				c.last = time.Now()
 			}
 			if acc != nil {
 				c.acc = acc
 			}
+			// This will be true if this is a route that was initiated from the
+			// gossip protocol (basically invoked from processImplicitRoute).
+			fromGossip := didSolicit && c.route.routeType == Implicit
 			c.mu.Unlock()
 
 			// Store this route with key being the route id hash + account name
@@ -1963,8 +1984,20 @@ func (s *Server) addRoute(c *client, didSolicit bool, info *Info, accName string
 			// Now that we have registered the route, we can remove from the temp map.
 			s.removeFromTempClients(cid)
 
-			// Notify other routes about this new route
-			s.forwardNewRouteInfoToKnownServers(info)
+			// We will not gossip if we are an implicit route created due to
+			// gossip, or if the remote instructed us not to gossip.
+			if !fromGossip && !info.NoGossip {
+				if !didSolicit {
+					// If the connection was accepted, instruct the neighbors to
+					// set Info.NoGossip to true also when sending their own INFO
+					// protocol. In normal situations, any implicit route would
+					// set their Info.NoGossip to true, but we do this to solve
+					// a very specific situation. For some background, see test
+					// TestRouteImplicitJoinsSeparateGroups.
+					info.NoGossip = true
+				}
+				s.forwardNewRouteInfoToKnownServers(info)
+			}
 
 			// Send subscription interest
 			s.sendSubsToRoute(c, -1, accName)
@@ -2045,9 +2078,9 @@ func (s *Server) addRoute(c *client, didSolicit bool, info *Info, accName string
 		rHash := c.route.hash
 		rn := c.route.remoteName
 		url := c.route.url
-		// For solicited routes, we need now to send the INFO protocol.
-		if didSolicit {
-			c.enqueueProto(s.generateRouteInitialInfoJSON(_EMPTY_, c.route.compression, idx))
+		if sendDelayedInfo {
+			cm := compressionModeForInfoProtocol(&opts.Cluster.Compression, c.route.compression)
+			c.enqueueProto(s.generateRouteInitialInfoJSON(_EMPTY_, cm, idx, noGossip))
 		}
 		if c.last.IsZero() {
 			c.last = time.Now()
@@ -2085,8 +2118,13 @@ func (s *Server) addRoute(c *client, didSolicit bool, info *Info, accName string
 			}
 
 			// we don't need to send if the only route is the one we just accepted.
-			if len(s.routes) > 1 {
-				// Now let the known servers know about this new route
+			// For other checks, see other call to forwardNewRouteInfoToKnownServers
+			// in the handling of pinned account above.
+			fromGossip := didSolicit && rtype == Implicit
+			if len(s.routes) > 1 && !fromGossip && !info.NoGossip {
+				if !didSolicit {
+					info.NoGossip = true
+				}
 				s.forwardNewRouteInfoToKnownServers(info)
 			}
 
@@ -2122,7 +2160,7 @@ func (s *Server) addRoute(c *client, didSolicit bool, info *Info, accName string
 					s.grWG.Done()
 					return
 				}
-				s.connectToRoute(url, rtype == Explicit, true, _EMPTY_)
+				s.connectToRoute(url, rtype, true, noGossip, _EMPTY_)
 			})
 		}
 	}
@@ -2524,7 +2562,7 @@ func (s *Server) startRouteAcceptLoop() {
 	}
 
 	// Start the accept loop in a different go routine.
-	go s.acceptConnections(l, "Route", func(conn net.Conn) { s.createRoute(conn, nil, _EMPTY_) }, nil)
+	go s.acceptConnections(l, "Route", func(conn net.Conn) { s.createRoute(conn, nil, Implicit, false, _EMPTY_) }, nil)
 
 	// Solicit Routes if applicable. This will not block.
 	s.solicitRoutes(opts.Routes, opts.Cluster.PinnedAccounts)
@@ -2566,14 +2604,13 @@ func (s *Server) StartRouting(clientListenReady chan struct{}) {
 }
 
 func (s *Server) reConnectToRoute(rURL *url.URL, rtype RouteType, accName string) {
-	tryForEver := rtype == Explicit
 	// If A connects to B, and B to A (regardless if explicit or
 	// implicit - due to auto-discovery), and if each server first
 	// registers the route on the opposite TCP connection, the
 	// two connections will end-up being closed.
 	// Add some random delay to reduce risk of repeated failures.
 	delay := time.Duration(rand.Intn(100)) * time.Millisecond
-	if tryForEver {
+	if rtype == Explicit {
 		delay += DEFAULT_ROUTE_RECONNECT
 	}
 	select {
@@ -2582,7 +2619,7 @@ func (s *Server) reConnectToRoute(rURL *url.URL, rtype RouteType, accName string
 		s.grWG.Done()
 		return
 	}
-	s.connectToRoute(rURL, tryForEver, false, accName)
+	s.connectToRoute(rURL, rtype, false, false, accName)
 }
 
 // Checks to make sure the route is still valid.
@@ -2595,21 +2632,26 @@ func (s *Server) routeStillValid(rURL *url.URL) bool {
 	return false
 }
 
-func (s *Server) connectToRoute(rURL *url.URL, tryForEver, firstConnect bool, accName string) {
+func (s *Server) connectToRoute(rURL *url.URL, rtype RouteType, firstConnect, noGossip bool, accName string) {
+	defer s.grWG.Done()
+	if rURL == nil {
+		return
+	}
+	// For explicit routes, we will try to connect until we succeed. For implicit
+	// we will try only based on the number of ConnectRetries optin.
+	tryForEver := rtype == Explicit
+
 	// Snapshot server options.
 	opts := s.getOpts()
 
-	defer s.grWG.Done()
-
 	const connErrFmt = "Error trying to connect to route (attempt %v): %v"
 
-	s.mu.Lock()
+	s.mu.RLock()
 	resolver := s.routeResolver
 	excludedAddresses := s.routesToSelf
-	s.mu.Unlock()
+	s.mu.RUnlock()
 
-	attempts := 0
-	for s.isRunning() && rURL != nil {
+	for attempts := 0; s.isRunning(); {
 		if tryForEver {
 			if !s.routeStillValid(rURL) {
 				return
@@ -2663,7 +2705,7 @@ func (s *Server) connectToRoute(rURL *url.URL, tryForEver, firstConnect bool, ac
 
 		// We have a route connection here.
 		// Go ahead and create it and exit this func.
-		s.createRoute(conn, rURL, accName)
+		s.createRoute(conn, rURL, rtype, noGossip, accName)
 		return
 	}
 }
@@ -2692,13 +2734,13 @@ func (s *Server) solicitRoutes(routes []*url.URL, accounts []string) {
 	s.saveRouteTLSName(routes)
 	for _, r := range routes {
 		route := r
-		s.startGoRoutine(func() { s.connectToRoute(route, true, true, _EMPTY_) })
+		s.startGoRoutine(func() { s.connectToRoute(route, Explicit, true, false, _EMPTY_) })
 	}
 	// Now go over possible per-account routes and create them.
 	for _, an := range accounts {
 		for _, r := range routes {
 			route, accName := r, an
-			s.startGoRoutine(func() { s.connectToRoute(route, true, true, accName) })
+			s.startGoRoutine(func() { s.connectToRoute(route, Explicit, true, false, accName) })
 		}
 	}
 }
@@ -2820,7 +2862,7 @@ func (s *Server) removeRoute(c *client) {
 		opts          = s.getOpts()
 		rURL          *url.URL
 		noPool        bool
-		didSolicit    bool
+		rtype         RouteType
 	)
 	c.mu.Lock()
 	cid := c.cid
@@ -2839,7 +2881,7 @@ func (s *Server) removeRoute(c *client) {
 		connectURLs = r.connectURLs
 		wsConnectURLs = r.wsConnURLs
 		rURL = r.url
-		didSolicit = r.didSolicit
+		rtype = r.routeType
 	}
 	c.mu.Unlock()
 	if accName != _EMPTY_ {
@@ -2902,12 +2944,12 @@ func (s *Server) removeRoute(c *client) {
 			// this remote was a "no pool" route, attempt to reconnect.
 			if noPool {
 				if s.routesPoolSize > 1 {
-					s.startGoRoutine(func() { s.connectToRoute(rURL, didSolicit, true, _EMPTY_) })
+					s.startGoRoutine(func() { s.connectToRoute(rURL, rtype, true, false, _EMPTY_) })
 				}
 				if len(opts.Cluster.PinnedAccounts) > 0 {
 					for _, an := range opts.Cluster.PinnedAccounts {
 						accName := an
-						s.startGoRoutine(func() { s.connectToRoute(rURL, didSolicit, true, accName) })
+						s.startGoRoutine(func() { s.connectToRoute(rURL, rtype, true, false, accName) })
 					}
 				}
 			}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -738,15 +738,10 @@ func TestClientConnectToRoutePort(t *testing.T) {
 }
 
 type checkDuplicateRouteLogger struct {
-	sync.Mutex
+	DummyLogger
 	gotDuplicate bool
 }
 
-func (l *checkDuplicateRouteLogger) Noticef(format string, v ...any) {}
-func (l *checkDuplicateRouteLogger) Errorf(format string, v ...any)  {}
-func (l *checkDuplicateRouteLogger) Warnf(format string, v ...any)   {}
-func (l *checkDuplicateRouteLogger) Fatalf(format string, v ...any)  {}
-func (l *checkDuplicateRouteLogger) Tracef(format string, v ...any)  {}
 func (l *checkDuplicateRouteLogger) Debugf(format string, v ...any) {
 	l.Lock()
 	defer l.Unlock()
@@ -3357,7 +3352,8 @@ func TestRoutePoolAndPerAccountWithOlderServer(t *testing.T) {
 
 type testDuplicateRouteLogger struct {
 	DummyLogger
-	ch chan struct{}
+	ch    chan struct{}
+	count int
 }
 
 func (l *testDuplicateRouteLogger) Noticef(format string, args ...any) {
@@ -3369,6 +3365,9 @@ func (l *testDuplicateRouteLogger) Noticef(format string, args ...any) {
 	case l.ch <- struct{}{}:
 	default:
 	}
+	l.Mutex.Lock()
+	l.count++
+	l.Mutex.Unlock()
 }
 
 // This test will make sure that a server with pooling does not
@@ -4349,5 +4348,178 @@ func TestRouteNoRaceOnClusterNameNegotiation(t *testing.T) {
 		checkClusterFormed(t, s1, s2)
 		s2.Shutdown()
 		s1.Shutdown()
+	}
+}
+
+func TestRouteImplicitNotTooManyDuplicates(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		pooling     bool
+		compression bool
+	}{
+		{"no pooling-no compression", false, false},
+		{"no pooling-compression", false, true},
+		{"pooling-no compression", true, false},
+		{"pooling-compression", true, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			o := DefaultOptions()
+			o.ServerName = "SEED"
+			if !test.pooling {
+				o.Cluster.PoolSize = -1
+			}
+			if !test.compression {
+				o.Cluster.Compression.Mode = CompressionOff
+			}
+			seed := RunServer(o)
+			defer seed.Shutdown()
+
+			dl := &testDuplicateRouteLogger{}
+
+			servers := make([]*Server, 0, 10)
+			for i := 0; i < cap(servers); i++ {
+				io := DefaultOptions()
+				io.ServerName = fmt.Sprintf("IMPLICIT_%d", i+1)
+				io.NoLog = false
+				io.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", o.Cluster.Port))
+				if !test.pooling {
+					io.Cluster.PoolSize = -1
+				}
+				if !test.compression {
+					io.Cluster.Compression.Mode = CompressionOff
+				}
+				is, err := NewServer(io)
+				require_NoError(t, err)
+				// Will do defer of shutdown later.
+				is.SetLogger(dl, true, false)
+				is.Start()
+				servers = append(servers, is)
+			}
+
+			allServers := make([]*Server, 0, len(servers)+1)
+			allServers = append(allServers, seed)
+			allServers = append(allServers, servers...)
+
+			// Let's make sure that we wait for each server to be ready.
+			for _, s := range allServers {
+				if !s.ReadyForConnections(2 * time.Second) {
+					t.Fatalf("Server %q is not ready for connections", s)
+				}
+			}
+
+			// Do the defer of shutdown of all servers this way instead of individual
+			// defers when starting them. It takes less time for the servers to shutdown
+			// this way.
+			defer func() {
+				for _, s := range allServers {
+					s.Shutdown()
+				}
+			}()
+			checkClusterFormed(t, allServers...)
+
+			dl.Mutex.Lock()
+			count := dl.count
+			dl.Mutex.Unlock()
+			// Getting duplicates should not be considered fatal, it is an optimization
+			// to reduce the occurrences of those. But to make sure we don't have a
+			// regression, we will fail the test if we get say more than 20 or so (
+			// without the code change, we would get more than 500 of duplicates).
+			if count > 20 {
+				t.Fatalf("Got more duplicates than anticipated: %v", count)
+			}
+		})
+	}
+}
+
+func TestRouteImplicitJoinsSeparateGroups(t *testing.T) {
+	// The test TestRouteImplicitNotTooManyDuplicates makes sure that we do
+	// not have too many duplicate routes cases when processing implicit routes.
+	// This test is to ensure that the code changes to reduce the number
+	// of duplicate routes does not prevent the formation of the cluster
+	// with the given setup (which is admittedly not good since a disconnect
+	// between some routes would not result in a reconnect leading to a full mesh).
+	// Still, original code was able to create the original full mesh, so we want
+	// to make sure that this is still possible.
+	for _, test := range []struct {
+		name        string
+		pooling     bool
+		compression bool
+	}{
+		{"no pooling-no compression", false, false},
+		{"no pooling-compression", false, true},
+		{"pooling-no compression", true, false},
+		{"pooling-compression", true, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			setOpts := func(o *Options) {
+				if !test.pooling {
+					o.Cluster.PoolSize = -1
+				}
+				if !test.compression {
+					o.Cluster.Compression.Mode = CompressionOff
+				}
+			}
+
+			// Create a cluster s1/s2/s3
+			o1 := DefaultOptions()
+			o1.ServerName = "S1"
+			setOpts(o1)
+			s1 := RunServer(o1)
+			defer s1.Shutdown()
+
+			o2 := DefaultOptions()
+			o2.ServerName = "S2"
+			setOpts(o2)
+			o2.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", o1.Cluster.Port))
+			s2 := RunServer(o2)
+			defer s2.Shutdown()
+
+			tmpl := `
+				server_name: "S3"
+				listen: "127.0.0.1:-1"
+				cluster {
+					name: "abc"
+					listen: "127.0.0.1:-1"
+					%s
+					%s
+					routes: ["nats://127.0.0.1:%d"%s]
+				}
+			`
+			var poolCfg string
+			var compressionCfg string
+			if !test.pooling {
+				poolCfg = "pool_size: -1"
+			}
+			if !test.compression {
+				compressionCfg = "compression: off"
+			}
+			conf := createConfFile(t, []byte(fmt.Sprintf(tmpl, poolCfg, compressionCfg, o1.Cluster.Port, _EMPTY_)))
+			s3, _ := RunServerWithConfig(conf)
+			defer s3.Shutdown()
+
+			checkClusterFormed(t, s1, s2, s3)
+
+			// Now s4 and s5 connected to each other, but not linked to s1/s2/s3
+			o4 := DefaultOptions()
+			o4.ServerName = "S4"
+			setOpts(o4)
+			s4 := RunServer(o4)
+			defer s4.Shutdown()
+
+			o5 := DefaultOptions()
+			o5.ServerName = "S5"
+			setOpts(o5)
+			o5.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", o4.Cluster.Port))
+			s5 := RunServer(o5)
+			defer s5.Shutdown()
+
+			checkClusterFormed(t, s4, s5)
+
+			// Now add a route from s3 to s4 and make sure that we have a full mesh.
+			routeToS4 := fmt.Sprintf(`, "nats://127.0.0.1:%d"`, o4.Cluster.Port)
+			reloadUpdateConfig(t, s3, conf, fmt.Sprintf(tmpl, poolCfg, compressionCfg, o1.Cluster.Port, routeToS4))
+
+			checkClusterFormed(t, s1, s2, s3, s4, s5)
+		})
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -141,6 +141,7 @@ type Info struct {
 	RoutePoolIdx  int                `json:"route_pool_idx,omitempty"`
 	RouteAccount  string             `json:"route_account,omitempty"`
 	RouteAccReqID string             `json:"route_acc_add_reqid,omitempty"`
+	NoGossip      bool               `json:"no_gossip,omitempty"`
 
 	// Gateways Specific
 	Gateway           string   `json:"gateway,omitempty"`             // Name of the origin Gateway (sent by gateway's INFO)


### PR DESCRIPTION
This is an alternate approach to the PR #5484 from @wjordan.

Using the code in that PR with the test added in this PR, I could still see duplicate routes (up to 125 in one of the matrix), and still had a data race (that could have easily be fixed). The main issue is that the increment happens in connectToRoute, which is running from a go routine, so there were still chances for duplicates.

Instead, I took the approach that those duplicates were the result of way too many gossip protocols. Suppose that you have servers A and B already connected. C connects to A. A gossips to B that it should connect to C. When that happened, B would gossip to A the server C and C would gossip to A the server B, which all that was unnecessary. It would grow quite fast with the size of the cluster (that is, several thousands for a cluster size of 15 or so).

Resolves #5483

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>