### PR TITLE
stree: Fix duplicate callbacks on full wildcard `Match`

### DIFF
--- a/server/stree/stree.go
+++ b/server/stree/stree.go
@@ -340,6 +340,7 @@ func (t *SubjectTree[T]) match(n node, parts [][]byte, pre []byte, cb func(subje
 					t.match(cn, nparts, pre, cb)
 				}
 			}
+			return
 		}
 		// Here we have normal traversal, so find the next child.
 		nn := n.findChild(p)

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -738,3 +738,26 @@ func TestSubjectTreeNode48(t *testing.T) {
 	require_True(t, gotB)
 	require_True(t, gotC)
 }
+
+func TestSubjectTreeMatchNoCallbackDupe(t *testing.T) {
+	st := NewSubjectTree[int]()
+	st.Insert(b("foo.bar.A"), 1)
+	st.Insert(b("foo.bar.B"), 1)
+	st.Insert(b("foo.bar.C"), 1)
+	st.Insert(b("foo.bar.>"), 1)
+
+	for _, f := range [][]byte{
+		[]byte(">"),
+		[]byte("foo.>"),
+		[]byte("foo.bar.>"),
+	} {
+		seen := map[string]struct{}{}
+		st.Match(f, func(bsubj []byte, _ *int) {
+			subj := string(bsubj)
+			if _, ok := seen[subj]; ok {
+				t.Logf("Match callback was called twice for %q", subj)
+			}
+			seen[subj] = struct{}{}
+		})
+	}
+}


### PR DESCRIPTION
On a full wildcard `Match`, we were iterating through children but then also falling through to a regular continuation instead of returning, which meant that the `Match` callback could fire twice for the same filter.

Fixes #5608.

Signed-off-by: Neil Twigg <neil@nats.io>
