### PR TITLE
Fixes for filestore FSS state

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -3084,6 +3084,10 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 
 			var havePartial bool
 			mb.fss.Match(stringToBytes(filter), func(bsubj []byte, ss *SimpleState) {
+				if havePartial {
+					// If we already found a partial then don't do anything else.
+					return
+				}
 				subj := bytesToString(bsubj)
 				if ss.firstNeedsUpdate {
 					mb.recalculateFirstForSubj(subj, ss.First, ss)

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2318,6 +2318,7 @@ func (mb *msgBlock) firstMatching(filter string, wc bool, start uint64, sm *Stor
 
 	if filter == _EMPTY_ {
 		filter = fwcs
+		wc = true
 	}
 
 	// If we only have 1 subject currently and it matches our filter we can also set isAll.
@@ -2461,6 +2462,7 @@ func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, sseq uint64) (
 
 	if filter == _EMPTY_ {
 		filter = fwcs
+		wc = true
 	}
 
 	update := func(ss *SimpleState) {

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2757,7 +2757,12 @@ func (fs *fileStore) SubjectsState(subject string) map[string]SimpleState {
 		if !ok {
 			return nil
 		}
-		start, stop = fs.bim[info.fblk], fs.bim[info.lblk]
+		if f := fs.bim[info.fblk]; f != nil {
+			start = f
+		}
+		if l := fs.bim[info.lblk]; l != nil {
+			stop = l
+		}
 	}
 
 	// Aggregate fss.

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2499,6 +2499,10 @@ func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, sseq uint64) (
 
 	var havePartial bool
 	mb.fss.Match(stringToBytes(filter), func(bsubj []byte, ss *SimpleState) {
+		if havePartial {
+			// If we already found a partial then don't do anything else.
+			return
+		}
 		if ss.firstNeedsUpdate {
 			mb.recalculateFirstForSubj(bytesToString(bsubj), ss.First, ss)
 		}

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -3826,11 +3826,12 @@ func (fs *fileStore) enforceMsgPerSubjectLimit(fireCallback bool) {
 
 	// collect all that are not correct.
 	needAttention := make(map[string]*psi)
-	fs.psim.Match([]byte(fwcs), func(subj []byte, psi *psi) {
+	fs.psim.Iter(func(subj []byte, psi *psi) bool {
 		numMsgs += psi.total
 		if psi.total > maxMsgsPer {
 			needAttention[string(subj)] = psi
 		}
+		return true
 	})
 
 	// We had an issue with a use case where psim (and hence fss) were correct but idx was not and was not properly being caught.
@@ -3850,10 +3851,11 @@ func (fs *fileStore) enforceMsgPerSubjectLimit(fireCallback bool) {
 		fs.rebuildStateLocked(nil)
 		// Need to redo blocks that need attention.
 		needAttention = make(map[string]*psi)
-		fs.psim.Match([]byte(fwcs), func(subj []byte, psi *psi) {
+		fs.psim.Iter(func(subj []byte, psi *psi) bool {
 			if psi.total > maxMsgsPer {
 				needAttention[string(subj)] = psi
 			}
+			return true
 		})
 	}
 

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -36,7 +36,10 @@ func TestSubjectTreeBasics(t *testing.T) {
 	require_True(t, old == nil)
 	require_False(t, updated)
 	require_Equal(t, st.Size(), 1)
-	// Find with single leaf.
+	// Find shouldn't work with a wildcard.
+	_, found := st.Find(b("foo.bar.*"))
+	require_False(t, found)
+	// But it should with a literal. Find with single leaf.
 	v, found := st.Find(b("foo.bar.baz"))
 	require_True(t, found)
 	require_Equal(t, *v, 22)


### PR DESCRIPTION
This PR contains some bug-fixes for the filestore FSS state.

First, if the filter provided is `_EMPTY_` then we need to overwrite it to `>` for the stree functions to work, but we failed to set `wc` when doing so. This could affect the decision on whether to linear-scan or not. We will now set `wc` too in this case.

Second, if the FSS only contains a single subject then we may not correctly set `isAll` if the filter contained a wildcard, as `Find` does not work with wildcards and therefore wouldn't match the single subject. Updated to use `Match` instead, so that it correctly uses wildcards.

Third, replaces `Match(>)` with `Iter` in `enforceMsgPerSubjectLimit`, not because it is behaviourally different, but because we need to walk the entire stree anyway and `Iter` saves CPU cycles by skipping the match step.

Fourth, updates the bounds checking on various functions that use `Find` so that the logic matches the `Match` equivalents. This also matters in particular in `SubjectsState` which could fail altogether when the filter was a subject literal rather than a wildcard and the `psim` was out-of-date/needing update.

Fifth, in `NumPending` and in `filteredPendingLocked` when matching the FSS state, if we find a partial, don't process any further matches after that. This bug was introduced in #5559 as there used to be a `break` there, whereas now the `Match` that replaces it can't be interrupted in the same way.

Signed-off-by: Neil Twigg <neil@nats.io>