### PR TITLE
[IMPROVED] CPU spike during recalc of first msg in memstore.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -4255,7 +4255,8 @@ func (o *consumer) checkNumPending() uint64 {
 	if o.mset != nil {
 		var state StreamState
 		o.mset.store.FastState(&state)
-		if o.sseq > state.LastSeq && o.npc != 0 || o.npc > int64(state.Msgs) {
+		npc := o.numPending()
+		if o.sseq > state.LastSeq && npc > 0 || npc > state.Msgs {
 			// Re-calculate.
 			o.streamNumPending()
 		}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -426,9 +426,8 @@ func (ms *memStore) filteredStateLocked(sseq uint64, filter string, lastPerSubje
 	var havePartial bool
 	// We will track start and end sequences as we go.
 	ms.fss.Match(stringToBytes(filter), func(subj []byte, fss *SimpleState) {
-		subjs := bytesToString(subj)
 		if fss.firstNeedsUpdate {
-			ms.recalculateFirstForSubj(subjs, fss.First, fss)
+			ms.recalculateFirstForSubj(bytesToString(subj), fss.First, fss)
 		}
 		if sseq <= fss.First {
 			update(fss)
@@ -1267,7 +1266,11 @@ func (ms *memStore) removeSeqPerSubject(subj string, seq uint64) {
 // Will recalculate the first sequence for this subject in this block.
 // Lock should be held.
 func (ms *memStore) recalculateFirstForSubj(subj string, startSeq uint64, ss *SimpleState) {
-	for tseq := startSeq + 1; tseq <= ss.Last; tseq++ {
+	tseq := startSeq + 1
+	if tseq < ms.state.FirstSeq {
+		tseq = ms.state.FirstSeq
+	}
+	for ; tseq <= ss.Last; tseq++ {
 		if sm := ms.msgs[tseq]; sm != nil && sm.subj == subj {
 			ss.First = tseq
 			ss.firstNeedsUpdate = false


### PR DESCRIPTION
When recalculating for the first, make sure not to trip accidentally with a negative npc, and make sure to floor against first sequence as needed.

Resolves: #5621 5621

Signed-off-by: Derek Collison <derek@nats.io>
