### PR TITLE
Fix go directive version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nats-io/nats-server/v2
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/google/go-tpm v0.9.1


### PR DESCRIPTION
According to [https://go.dev/issues/62278](https://github.com/golang/go/issues/62278) a concrete go version has to include
the patch number. The project declares the version as 1.21 which is invalid and
will result in an error:

	GOTOOLCHAIN="go1.20+auto" go1.21.5 mod tidy
	go: downloading go1.21 (linux/amd64)
	go: download go1.21 for linux/amd64: toolchain not available

Changed to 1.21.0 as this is the first actual release of go 1.21.
