### PR TITLE
[FIXED] Make sure to send consumer create advisory regardless of node presence.

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5200,9 +5200,7 @@ func (js *jetStream) processConsumerLeaderChange(o *consumer, isLeader bool) err
 	} else {
 		resp.ConsumerInfo = o.initialInfo()
 		s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
-		if node := o.raftNode(); node != nil {
-			o.sendCreateAdvisory()
-		}
+		o.sendCreateAdvisory()
 	}
 
 	// Only send a pause advisory on consumer create if we're


### PR DESCRIPTION
For R1 consumers we used to have the leader set as we called add so was handled there similar to standalone server mode. Now process in same place as R>1 for clustered usage.

Signed-off-by: Derek Collison <derek@nats.io>