### PR TITLE
Add serverVersion var set via ldflags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
   flags:
   - -trimpath
   ldflags:
-    - -w -X github.com/nats-io/nats-server/v2/server.gitCommit={{.ShortCommit}}
+    - -w -X 'github.com/nats-io/nats-server/v2/server.gitCommit={{.ShortCommit}}' -X 'github.com/nats-io/nats-server/v2/server.serverVersion={{.Tag}}'
   env:
     - GO111MODULE=on
     - CGO_ENABLED=0

--- a/scripts/runTestsOnTravis.sh
+++ b/scripts/runTestsOnTravis.sh
@@ -10,7 +10,7 @@ if [ "$1" = "compile" ]; then
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.1;
     golangci-lint run;
     if [ "$TRAVIS_TAG" != "" ]; then
-        go test -race -v -run=TestVersionMatchesTag ./server -count=1 -vet=off
+        go test -race -v -run=TestVersionMatchesTag ./server -ldflags="-X=github.com/nats-io/nats-server/v2/server.serverVersion=$TRAVIS_TAG" -count=1 -vet=off
     fi
 
 elif [ "$1" = "build_only" ]; then

--- a/server/const.go
+++ b/server/const.go
@@ -34,8 +34,8 @@ const (
 )
 
 var (
-	// gitCommit injected at build
-	gitCommit string
+	// gitCommit and serverVersion injected at build.
+	gitCommit, serverVersion string
 	// trustedKeys is a whitespace separated array of trusted operator's public nkeys.
 	trustedKeys string
 	// SemVer regexp to validate the VERSION.

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1387,6 +1387,8 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 	var srcUrl string
 	if gitCommit == _EMPTY_ {
 		srcUrl = "https://github.com/nats-io/nats-server"
+	} else if serverVersion != _EMPTY_ {
+		srcUrl = fmt.Sprintf("https://github.com/nats-io/nats-server/tree/%s", serverVersion)
 	} else {
 		srcUrl = fmt.Sprintf("https://github.com/nats-io/nats-server/tree/%s", gitCommit)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -143,6 +143,17 @@ func TestVersionMatchesTag(t *testing.T) {
 	if VERSION != tag[1:] {
 		t.Fatalf("Version (%s) does not match tag (%s)", VERSION, tag[1:])
 	}
+	// Check that the version dynamically set via ldflags matches the version
+	// from the server previous to releasing.
+	if serverVersion == _EMPTY_ {
+		t.Fatal("Version missing in ldflags")
+	}
+	// Unlike VERSION constant, serverVersion is prefixed with a 'v'
+	// since it should be the same as the git tag.
+	expected := "v" + VERSION
+	if serverVersion != _EMPTY_ && expected != serverVersion {
+		t.Fatalf("Version (%s) does not match ldflags version (%s)", expected, serverVersion)
+	}
 }
 
 func TestStartProfiler(t *testing.T) {


### PR DESCRIPTION
Setting a `serverVersion` variable which is set via ldflags to help security scanners like `syft` detect the version when inspecting the binary.  Goreleaser is modified to set this ldflag and a test is added to make sure that the `VERSION` constant matches the tag from the release.

Result:

```sh
$ export TRAVIS_TAG=v2.10.18

$ go test -race -v -run=TestVersionMatchesTag ./server --trimpath -ldflags="-X=github.com/nats-io/nats-server/v2/server.serverVersion=$TRAVIS_TAG" -count=1 -vet=off

# Example failure
=== RUN   TestVersionMatchesTag
    server_test.go:144: Version (2.11.0-dev) does not match tag (2.10.18)
--- FAIL: TestVersionMatchesTag (0.00s)

$ go build --trimpath -ldflags="-X 'github.com/nats-io/nats-server/v2/server.serverVersion=$TRAVIS_TAG'" .

$ syft ./nats-server
NAME                               VERSION   TYPE     
...   
github.com/nats-io/nats-server/v2  v2.10.18  go-module    
...
```
