### PR TITLE
Use ReadBuildInfo if available to detect gitCommit

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"regexp"
+	"runtime/debug"
 	"time"
 )
 
@@ -41,6 +42,19 @@ var (
 	// SemVer regexp to validate the VERSION.
 	semVerRe = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 )
+
+func init() {
+	// Use build info if present, it would be if building using 'go build .'
+	// or when using a release.
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				gitCommit = setting.Value[:7]
+			}
+		}
+	}
+}
 
 const (
 	// VERSION is the current version for the server.


### PR DESCRIPTION
Currently we use an `ldflag` to add the git commit from a server version, but this information is already present in many cases such as when building the package or using `go install`.

```
$ go build .
$  ./nats-server 
[90016] 2024/07/15 17:01:31.280879 [INF] Starting nats-server
[90016] 2024/07/15 17:01:31.281050 [INF]   Version:  2.11.0-dev
[90016] 2024/07/15 17:01:31.281054 [INF]   Git:      [dcd20c0]
```

When calling `go run` or `go build main.go` it would be still left unset:

```
go run main.go 
[90162] 2024/07/15 17:02:13.081669 [INF] Starting nats-server
[90162] 2024/07/15 17:02:13.081845 [INF]   Version:  2.11.0-dev
[90162] 2024/07/15 17:02:13.081849 [INF]   Git:      [not set]
```