### PR TITLE
[FIXED] Consumer NumPending higher than total stream messages.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2975,6 +2975,10 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 		return 0, validThrough
 	}
 
+	// If sseq is less then our first set to first.
+	if sseq < fs.state.FirstSeq {
+		sseq = fs.state.FirstSeq
+	}
 	// Track starting for both block for the sseq and staring block that matches any subject.
 	var seqStart int
 	// See if we need to figure out starting block per sseq.


### PR DESCRIPTION
When we matched all and had no interior deletes we would short circuit num pending calculations but were not accounting for sseq < state.FirstSeq.

Signed-off-by: Derek Collison <derek@nats.io>
