### PR TITLE
NRG (2.11): Don't revert `term` to `pterm` on AE mismatch

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3387,8 +3387,6 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 
 		} else {
 			n.debug("AppendEntry did not match %d %d with %d %d", ae.pterm, ae.pindex, n.pterm, n.pindex)
-			// Reset our term.
-			n.term = n.pterm
 			if ae.pindex > n.pindex {
 				// Setup our state for catching up.
 				inbox := n.createCatchup(ae)


### PR DESCRIPTION
Beforehand when we were trying to run a catchup, we were reverting the `term` back to `pterm`. We can't ever move the term backwards safely and the catchup itself does not rely on this behaviour in order to work (as the catchup entries are matched only on `pterm`/`pindex`), so don't revert it.

We saw this behaviour in Antithesis where a catchup could take us back a term. 

Signed-off-by: Neil Twigg <neil@nats.io>