### PR TITLE
Make jsz limits optional

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2795,7 +2795,7 @@ type JSInfo struct {
 	Now      time.Time       `json:"now"`
 	Disabled bool            `json:"disabled,omitempty"`
 	Config   JetStreamConfig `json:"config,omitempty"`
-	Limits   JSLimitOpts     `json:"limits"`
+	Limits   *JSLimitOpts    `json:"limits,omitempty"`
 	JetStreamStats
 	Streams   int              `json:"streams"`
 	Consumers int              `json:"consumers"`
@@ -2960,7 +2960,7 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 		return jsi, nil
 	}
 
-	jsi.Limits = s.getOpts().JetStreamLimits
+	jsi.Limits = &s.getOpts().JetStreamLimits
 
 	js.mu.RLock()
 	isLeader := js.cluster == nil || js.cluster.isLeader()


### PR DESCRIPTION
To create tooling and to be able to detect
when ran against old NATS Servers it would
be better if this was a pointer so the absense
of it would indicate unsupported servers rather
than ones that support this feature but have
no limits set

Signed-off-by: R.I.Pienaar <rip@devco.net>
