### PR TITLE
NRG: Don't delete on-disk state if failing to create internal subs

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -497,7 +497,7 @@ func (s *Server) startRaftNode(accName string, cfg *RaftConfig, labels pprofLabe
 	// If we fail to do this for some reason then this is fatal — we cannot
 	// continue setting up or the Raft node may be partially/totally isolated.
 	if err := n.createInternalSubs(); err != nil {
-		n.shutdown(true)
+		n.shutdown(false)
 		return nil, err
 	}
 


### PR DESCRIPTION
If we failed to start the Raft group subscriptions then we were calling `shutdown` with the `shouldDelete` flag set, which would nuke the state on disk, blowing away the WAL, the term and vote etc.

However, this could happen if a Raft group tried to be started while the server was shutting down. When this happened, we would see a log entry saying `Error creating raft group: system account not setup` and then the Raft state would get deleted, so after a restart, all state was lost.

This PR changes `shouldDelete` to false so that we preserve the state on disk for the next startup.

Signed-off-by: Neil Twigg <neil@nats.io>