### PR TITLE
Send the correct struct to the restore API

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -4258,6 +4258,7 @@ func TestJetStreamSnapshotsAPI(t *testing.T) {
 	state = mset.state()
 	mset.delete()
 
+	req, _ = json.Marshal(rreq)
 	rmsg, err = nc2.Request(strings.ReplaceAll(JSApiStreamRestoreT, JSApiPrefix, "$JS.domain.API"), req, time.Second)
 	if err != nil {
 		t.Fatalf("Unexpected error on snapshot request: %v", err)


### PR DESCRIPTION
While validating the ideas in ADR-44 the proposed improvements caught the fact that a snapshot request was being sent to a restore API call. Tests passed because there was enough overlap in the structs but strictly should have been a failure due to the invalid request

Signed-off-by: R.I.Pienaar <rip@devco.net>
