### PR TITLE
[IMPROVED] LoadNextMsg for wildcard consumers with millions of subjects

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -6542,7 +6542,10 @@ func (fs *fileStore) LoadNextMsg(filter string, wc bool, start uint64, sm *Store
 				// Nothing found in this block. We missed, if first block (bi) check psim.
 				// Similar to above if start <= first seq.
 				// TODO(dlc) - For v2 track these by filter subject since they will represent filtered consumers.
-				if i == bi {
+				// We should not do this at all if we are already on the last block.
+				// Also if we are a wildcard do not check if large subject space.
+				const wcMaxSizeToCheck = 64 * 1024
+				if i == bi && i < len(fs.blks)-1 && (!wc || fs.psim.Size() < wcMaxSizeToCheck) {
 					nbi, lbi := fs.checkSkipFirstBlock(filter, wc)
 					// Nothing available.
 					if nbi < 0 || lbi <= bi {


### PR DESCRIPTION
When LoadNextMsg misses, make sure to consult psim but conservatively.

We had a use case with millions of subjects and the last sequence checked being in the next to the last block. The consumer had a wildcard that matched lots of entries that were behind where we were. This would burn alot of cpu and when a stream had lots of consumers and they shift leadership this would introduce some instability due to all the cpu cycles.

Signed-off-by: Derek Collison <derek@nats.io>
