### PR TITLE
NRG (2.11): Send AE response when term is lower than ours

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3265,8 +3265,11 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 			n.stepdownLocked(ae.leader)
 		}
 	} else if ae.term < n.term && !catchingUp && isNew {
-		n.debug("Ignoring AppendEntry from a leader (%s) with term %d which is less than ours", ae.leader, ae.term)
+		n.debug("Rejected AppendEntry from a leader (%s) with term %d which is less than ours", ae.leader, ae.term)
+		ar := newAppendEntryResponse(n.term, n.pindex, n.id, false)
 		n.Unlock()
+		n.sendRPC(ae.reply, _EMPTY_, ar.encode(arbuf))
+		arPool.Put(ar)
 		return
 	}
 


### PR DESCRIPTION
Otherwise we may end up in a situation where we are dropping append entries from a leader that is obviously behind, but we cannot help to bring the cluster forward to make progress.

This resolves the flakiness in `TestJetStreamLeafNodeClusterExtensionWithSystemAccount` in local testing.

Signed-off-by: Neil Twigg <neil@nats.io>