### PR TITLE
[auth-callout] Support opt-in list of accounts to be delegated in config-mode

### DIFF
--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -3292,6 +3292,24 @@ func TestAuthorizationAndAccountsMisconfigurations(t *testing.T) {
 			`,
 			"Can not have a token",
 		},
+		{
+			"auth callout allowed accounts",
+			`
+			accounts {
+				AUTH { users = [ {user: "auth", password: "auth"} ] }
+				FOO {}
+			}
+			authorization {
+				auth_callout {
+					issuer: "ABJHLOVMPA4CI6R5KLNGOB4GSLNIY7IOUPAJC4YFNDLQVIOBYQGUWVLA"
+					account: AUTH
+					auth_users: [ auth ]
+					allowed_accounts: [ BAR ]
+				}
+			}
+			`,
+			"auth_callout allowed account \"BAR\" not found in configured accounts",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			conf := createConfFile(t, []byte(test.config))


### PR DESCRIPTION
This introduces a new `auth_callout` field `allowed_accounts` which enables explicitly listing which accounts in the server config should be delegated to the auth callout service.

This improves the current behavior which is an all-or-nothing switch over from config auth to auth callout.

The primary motivation for this change is to enable the system account to authenticate against the server rather than being dependent on the availability of the auth callout service.

(For reference the name `allowed_accounts` [matches what exists in nsc](https://github.com/nats-io/nsc/blob/main/cmd/editauthorization.go#L33))