### PR TITLE
Watch for file changes using fsnotify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,5 @@ require (
 	golang.org/x/sys v0.22.0
 	golang.org/x/time v0.5.0
 )
+
+require github.com/fsnotify/fsnotify v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/google/go-tpm v0.9.0 h1:sQF6YqWMi+SCXpsmS3fd21oPy/vSddwZry4JnmltHVk=
 github.com/google/go-tpm v0.9.0/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ Server Options:
                                      pid> can be either a PID (e.g. 1) or the path to a PID file (e.g. /var/run/nats-server.pid)
         --client_advertise <string>  Client URL to advertise to other servers
         --ports_file_dir <dir>       Creates a ports file in the specified directory (<executable_name>_<pid>.ports).
+        --watch-conf                 Watch for config files changes and reload
 
 Logging Options:
     -l, --log <file>                 File to redirect log output

--- a/server/debounce/debounce.go
+++ b/server/debounce/debounce.go
@@ -1,0 +1,38 @@
+package debounce
+
+import (
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Debouncer will debounce fsnotify events
+type Debouncer struct {
+	duration time.Duration
+	mu       sync.Mutex
+	timers   map[string]*time.Timer
+}
+
+func NewDebouncer(duration time.Duration) *Debouncer {
+	return &Debouncer{
+		duration: duration,
+		timers:   make(map[string]*time.Timer),
+	}
+}
+
+func (d *Debouncer) Debounce(event fsnotify.Event, callback func(fsnotify.Event)) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if timer, exists := d.timers[event.Name]; exists {
+		timer.Stop()
+	}
+
+	d.timers[event.Name] = time.AfterFunc(d.duration, func() {
+		d.mu.Lock()
+		delete(d.timers, event.Name)
+		d.mu.Unlock()
+		callback(event)
+	})
+}

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -507,10 +507,8 @@ func (s *Server) enableJetStream(cfg JetStreamConfig) error {
 	return nil
 }
 
-const (
-	jsNoExtend   = "no_extend"
-	jsWillExtend = "will_extend"
-)
+const jsNoExtend = "no_extend"
+const jsWillExtend = "will_extend"
 
 // This will check if we have a solicited leafnode that shares the system account
 // and extension is not manually disabled
@@ -1901,7 +1899,7 @@ func (jsa *jsAccount) remoteUpdateUsage(sub *subscription, c *client, _ *Account
 		total.total.store += storeUsed
 	}
 
-	le := binary.LittleEndian
+	var le = binary.LittleEndian
 	apiTotal, apiErrors := le.Uint64(msg[16:]), le.Uint64(msg[24:])
 	memUsed, storeUsed := int64(le.Uint64(msg[0:])), int64(le.Uint64(msg[8:]))
 
@@ -2113,7 +2111,7 @@ func (jsa *jsAccount) sendClusterUsageUpdate() {
 	}
 
 	var i int
-	le := binary.LittleEndian
+	var le = binary.LittleEndian
 	for tier, usage := range jsa.usage {
 		le.PutUint64(b[i+0:], uint64(usage.local.mem))
 		le.PutUint64(b[i+8:], uint64(usage.local.store))

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -507,8 +507,10 @@ func (s *Server) enableJetStream(cfg JetStreamConfig) error {
 	return nil
 }
 
-const jsNoExtend = "no_extend"
-const jsWillExtend = "will_extend"
+const (
+	jsNoExtend   = "no_extend"
+	jsWillExtend = "will_extend"
+)
 
 // This will check if we have a solicited leafnode that shares the system account
 // and extension is not manually disabled
@@ -1899,7 +1901,7 @@ func (jsa *jsAccount) remoteUpdateUsage(sub *subscription, c *client, _ *Account
 		total.total.store += storeUsed
 	}
 
-	var le = binary.LittleEndian
+	le := binary.LittleEndian
 	apiTotal, apiErrors := le.Uint64(msg[16:]), le.Uint64(msg[24:])
 	memUsed, storeUsed := int64(le.Uint64(msg[0:])), int64(le.Uint64(msg[8:]))
 
@@ -2111,7 +2113,7 @@ func (jsa *jsAccount) sendClusterUsageUpdate() {
 	}
 
 	var i int
-	var le = binary.LittleEndian
+	le := binary.LittleEndian
 	for tier, usage := range jsa.usage {
 		le.PutUint64(b[i+0:], uint64(usage.local.mem))
 		le.PutUint64(b[i+8:], uint64(usage.local.store))

--- a/server/server.go
+++ b/server/server.go
@@ -1429,7 +1429,6 @@ func (s *Server) startWatchConf() error {
 				select {
 				case <-s.quitCh:
 					s.configWatcher.Close()
-					s.Noticef("Ended watching config file")
 					return
 
 				case event, ok := <-s.configWatcher.Events:


### PR DESCRIPTION
Add an option:
```
        --watch-conf                 Watch for config files changes and reload
```
As well as `watch_conf` syntax in configuration file.
Supports reload on and off.

This could open the door to get rid of the `nats-server-config-reloader` container in Kubernetes configurations.

If you are interested in this PR I'll continue the work and add tests.

