### PR TITLE
stree: Make `Iter` faster by using generic sorting function

### DIFF
--- a/server/stree/stree.go
+++ b/server/stree/stree.go
@@ -15,7 +15,7 @@ package stree
 
 import (
 	"bytes"
-	"sort"
+	"slices"
 )
 
 // SubjectTree is an adaptive radix trie (ART) for storing subject information on literal subjects.
@@ -382,7 +382,7 @@ func (t *SubjectTree[T]) iter(n node, pre []byte, cb func(subject []byte, val *T
 		}
 	}
 	// Now sort.
-	sort.SliceStable(nodes, func(i, j int) bool { return bytes.Compare(nodes[i].path(), nodes[j].path()) < 0 })
+	slices.SortStableFunc(nodes, func(a, b node) int { return bytes.Compare(a.path(), b.path()) })
 	// Now walk the nodes in order and call into next iter.
 	for i := range nodes {
 		if !t.iter(nodes[i], pre, cb) {

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -669,6 +669,26 @@ func TestSubjectTreeMatchAllPerf(t *testing.T) {
 	}
 }
 
+func TestSubjectTreeIterPerf(t *testing.T) {
+	if !*runResults {
+		t.Skip()
+	}
+	st := NewSubjectTree[int]()
+
+	for i := 0; i < 1_000_000; i++ {
+		subj := fmt.Sprintf("subj.%d.%d", rand.Intn(100)+1, i)
+		st.Insert(b(subj), 22)
+	}
+
+	start := time.Now()
+	count := 0
+	st.Iter(func(_ []byte, _ *int) bool {
+		count++
+		return true
+	})
+	t.Logf("Iter took %s and matched %d entries", time.Since(start), count)
+}
+
 func TestSubjectTreeNode48(t *testing.T) {
 	var a, b, c leaf[int]
 	var n node48


### PR DESCRIPTION
This is roughly 4x faster since there are no interface conversions and reduces allocations.

Signed-off-by: Neil Twigg <neil@nats.io>