### PR TITLE
Optimise `getAccAndResultFromCache` by reducing allocations

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3869,7 +3869,7 @@ func fetchAccount(res AccountResolver, name string) (string, error) {
 	if !nkeys.IsValidPublicAccountKey(name) {
 		return _EMPTY_, fmt.Errorf("will only fetch valid account keys")
 	}
-	return res.Fetch(name)
+	return res.Fetch(copyString(name))
 }
 
 // AccountResolver interface. This is to fetch Account JWTs by public nkeys

--- a/server/client.go
+++ b/server/client.go
@@ -5668,7 +5668,7 @@ func (c *client) getAccAndResultFromCache() (*Account, *SublistResult) {
 			}
 		} else {
 			// Match correct account and sublist.
-			if acc, _ = c.srv.LookupAccount(string(c.pa.account)); acc == nil {
+			if acc, _ = c.srv.LookupAccount(bytesToString(c.pa.account)); acc == nil {
 				return nil, nil
 			}
 		}


### PR DESCRIPTION
We'll still copy the string when asking the resolver, as we can't be sure whether a resolver will want to hold onto the string or not, but this should lead to improvements on the hot paths for routes and gateways when the cache doesn't contain the entries we want.

Signed-off-by: Neil Twigg <neil@nats.io>