### PR TITLE
[FIXED] Subscription interest could remain after slow consumer error

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1827,20 +1827,11 @@ func (c *client) markConnAsClosed(reason ClosedState) {
 	// Save off the connection if its a client or leafnode.
 	if c.kind == CLIENT || c.kind == LEAF {
 		if nc := c.nc; nc != nil && c.srv != nil {
-			// Capture the subs and pass them to the go routine. We don't
-			// know for sure if the go routine will execute before or
-			// after closeConnection is done, so we can't have the go
-			// routine set c.subs to nil (to release the connection).
-			var subs []*subscription
-			if len(c.subs) > 0 {
-				subs = make([]*subscription, 0, len(c.subs))
-				for _, sub := range c.subs {
-					subs = append(subs, sub)
-				}
-			}
 			// TODO: May want to send events to single go routine instead
 			// of creating a new go routine for each save.
-			go c.srv.saveClosedClient(c, nc, subs, reason)
+			// Pass the c.subs as a reference. It may be set to nil in
+			// closeConnection.
+			go c.srv.saveClosedClient(c, nc, c.subs, reason)
 		}
 	}
 	// If writeLoop exists, let it do the final flush, close and teardown.

--- a/server/client.go
+++ b/server/client.go
@@ -1827,9 +1827,20 @@ func (c *client) markConnAsClosed(reason ClosedState) {
 	// Save off the connection if its a client or leafnode.
 	if c.kind == CLIENT || c.kind == LEAF {
 		if nc := c.nc; nc != nil && c.srv != nil {
+			// Capture the subs and pass them to the go routine. We don't
+			// know for sure if the go routine will execute before or
+			// after closeConnection is done, so we can't have the go
+			// routine set c.subs to nil (to release the connection).
+			var subs []*subscription
+			if len(c.subs) > 0 {
+				subs = make([]*subscription, 0, len(c.subs))
+				for _, sub := range c.subs {
+					subs = append(subs, sub)
+				}
+			}
 			// TODO: May want to send events to single go routine instead
 			// of creating a new go routine for each save.
-			go c.srv.saveClosedClient(c, nc, reason)
+			go c.srv.saveClosedClient(c, nc, subs, reason)
 		}
 	}
 	// If writeLoop exists, let it do the final flush, close and teardown.
@@ -5509,6 +5520,14 @@ func (c *client) closeConnection(reason ClosedState) {
 				srv.decActiveAccounts()
 			}
 		}
+	}
+
+	// Now that we are done with subscriptions, clear the field so that the
+	// connection can be released and gc'ed.
+	if kind == CLIENT || kind == LEAF {
+		c.mu.Lock()
+		c.subs = nil
+		c.mu.Unlock()
 	}
 
 	// Don't reconnect connections that have been marked with

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -10029,6 +10029,7 @@ func TestNoRaceConnectionObjectReleased(t *testing.T) {
 	cid, err := nc.GetClientID()
 	require_NoError(t, err)
 	natsSubSync(t, nc, "foo")
+	natsFlush(t, nc)
 
 	ncWS := natsConnect(t, fmt.Sprintf("ws://a:pwd@127.0.0.1:%d", oa.Websocket.Port))
 	defer ncWS.Close()

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -10016,6 +10016,7 @@ func TestNoRaceConnectionObjectReleased(t *testing.T) {
 
 	// Start an independent MQTT server to check MQTT client connection.
 	mo := testMQTTDefaultOptions()
+	mo.ServerName = "MQTTServer"
 	sm := testMQTTRunServer(t, mo)
 	defer testMQTTShutdownServer(sm)
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -4159,6 +4159,110 @@ func TestRouteNoLeakOnSlowConsumer(t *testing.T) {
 	}
 }
 
+func TestRouteNoAppSubLeakOnSlowConsumer(t *testing.T) {
+	o1 := DefaultOptions()
+	o1.MaxPending = 1024
+	o1.MaxPayload = int32(o1.MaxPending)
+	s1 := RunServer(o1)
+	defer s1.Shutdown()
+
+	o2 := DefaultOptions()
+	o2.MaxPending = 1024
+	o2.MaxPayload = int32(o2.MaxPending)
+	o2.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", o1.Cluster.Port))
+	s2 := RunServer(o2)
+	defer s2.Shutdown()
+
+	checkClusterFormed(t, s1, s2)
+
+	checkSub := func(expected bool) {
+		t.Helper()
+		checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+			subsz, err := s1.Subsz(&SubszOptions{Subscriptions: true, Account: globalAccountName})
+			require_NoError(t, err)
+			for _, sub := range subsz.Subs {
+				if sub.Subject == "foo" {
+					if expected {
+						return nil
+					}
+					return fmt.Errorf("Subscription should not have been found: %+v", sub)
+				}
+			}
+			if expected {
+				return fmt.Errorf("Subscription on `foo` not found")
+			}
+			return nil
+		})
+	}
+
+	checkRoutedSub := func(expected bool) {
+		t.Helper()
+		checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+			routez, err := s2.Routez(&RoutezOptions{Subscriptions: true})
+			require_NoError(t, err)
+			for _, route := range routez.Routes {
+				if route.Account != _EMPTY_ {
+					continue
+				}
+				if len(route.Subs) == 1 && route.Subs[0] == "foo" {
+					if expected {
+						return nil
+					}
+					return fmt.Errorf("Subscription should not have been found: %+v", route.Subs)
+				}
+			}
+			if expected {
+				return fmt.Errorf("Did not find `foo` subscription")
+			}
+			return nil
+		})
+	}
+
+	checkClosed := func(cid uint64) {
+		t.Helper()
+		checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+			connz, err := s1.Connz(&ConnzOptions{State: ConnClosed, CID: cid, Subscriptions: true})
+			if err != nil {
+				return err
+			}
+			require_Len(t, len(connz.Conns), 1)
+			conn := connz.Conns[0]
+			require_Equal(t, conn.Reason, SlowConsumerPendingBytes.String())
+			subs := conn.Subs
+			require_Len(t, len(subs), 1)
+			require_Equal[string](t, subs[0], "foo")
+			return nil
+		})
+	}
+
+	for i := 0; i < 5; i++ {
+		nc := natsConnect(t, s1.ClientURL())
+		defer nc.Close()
+
+		natsSubSync(t, nc, "foo")
+		natsFlush(t, nc)
+
+		checkSub(true)
+		checkRoutedSub(true)
+
+		cid, err := nc.GetClientID()
+		require_NoError(t, err)
+		c := s1.getClient(cid)
+		payload := make([]byte, 2048)
+		c.mu.Lock()
+		c.queueOutbound([]byte(fmt.Sprintf("MSG foo 1 2048\r\n%s\r\n", payload)))
+		closed := c.isClosed()
+		c.mu.Unlock()
+
+		require_True(t, closed)
+		checkSub(false)
+		checkRoutedSub(false)
+		checkClosed(cid)
+
+		nc.Close()
+	}
+}
+
 func TestRouteSlowConsumerRecover(t *testing.T) {
 	o1 := DefaultOptions()
 	o1.Cluster.PoolSize = -1

--- a/server/server.go
+++ b/server/server.go
@@ -3357,7 +3357,7 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 
 // This will save off a closed client in a ring buffer such that
 // /connz can inspect. Useful for debugging, etc.
-func (s *Server) saveClosedClient(c *client, nc net.Conn, subs []*subscription, reason ClosedState) {
+func (s *Server) saveClosedClient(c *client, nc net.Conn, subs map[string]*subscription, reason ClosedState) {
 	now := time.Now()
 
 	s.accountDisconnectEvent(c, now, reason.String())
@@ -3366,7 +3366,8 @@ func (s *Server) saveClosedClient(c *client, nc net.Conn, subs []*subscription, 
 
 	cc := &closedClient{}
 	cc.fill(c, nc, now, false)
-	// Note that cc.fill is using len(c.subs), so replace cc.NumSubs with len(subs).
+	// Note that cc.fill is using len(c.subs), which may have been set to nil by now,
+	// so replace cc.NumSubs with len(subs).
 	cc.NumSubs = uint32(len(subs))
 	cc.Stop = &now
 	cc.Reason = reason.String()

--- a/server/server.go
+++ b/server/server.go
@@ -3357,7 +3357,7 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 
 // This will save off a closed client in a ring buffer such that
 // /connz can inspect. Useful for debugging, etc.
-func (s *Server) saveClosedClient(c *client, nc net.Conn, reason ClosedState) {
+func (s *Server) saveClosedClient(c *client, nc net.Conn, subs []*subscription, reason ClosedState) {
 	now := time.Now()
 
 	s.accountDisconnectEvent(c, now, reason.String())
@@ -3366,17 +3366,17 @@ func (s *Server) saveClosedClient(c *client, nc net.Conn, reason ClosedState) {
 
 	cc := &closedClient{}
 	cc.fill(c, nc, now, false)
+	// Note that cc.fill is using len(c.subs), so replace cc.NumSubs with len(subs).
+	cc.NumSubs = uint32(len(subs))
 	cc.Stop = &now
 	cc.Reason = reason.String()
 
 	// Do subs, do not place by default in main ConnInfo
-	if len(c.subs) > 0 {
-		cc.subs = make([]SubDetail, 0, len(c.subs))
-		for _, sub := range c.subs {
+	if len(subs) > 0 {
+		cc.subs = make([]SubDetail, 0, len(subs))
+		for _, sub := range subs {
 			cc.subs = append(cc.subs, newSubDetail(sub))
 		}
-		// Now set this to nil to allow connection to be released.
-		c.subs = nil
 	}
 	// Hold user as well.
 	cc.user = c.getRawAuthUser()


### PR DESCRIPTION
When a slow consumer error is detected, the server will close the connection. In some race situations, it could be that the subscription interest is left intact, which would cause routed servers to continue routing messages although the interest should have been gone.

The subscription could still be seen in the monitoring subscriptions list (when displaying with details), referencing a client connection that would be in the closed connection state.
The monitoring route page of the other servers would still indicate that there is interest for this subject on the origin server.

Resolves #5539

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
