### PR TITLE
Upgrade sort.Slice with slices.sort

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -387,7 +387,7 @@ func (a *Account) updateRemoteServer(m *AccountNumConns) []*client {
 	var clients []*client
 	if mtce {
 		clients = a.getClientsLocked()
-		slices.SortFunc(clients, func(i, j *client) int { return -i.start.Compare(j.start) }) // reserve order
+		slices.SortFunc(clients, func(i, j *client) int { return -i.start.Compare(j.start) }) // reserve
 		over := (len(a.clients) - int(a.sysclients) + int(a.nrclients)) - int(a.mconns)
 		if over < len(clients) {
 			clients = clients[:over]

--- a/server/auth_callout_test.go
+++ b/server/auth_callout_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -791,9 +791,9 @@ func TestAuthCalloutOperatorModeBasics(t *testing.T) {
 		t.Fatalf("Expected to be switched to %q, but got %q", tpub, userInfo.Account)
 	}
 	require_True(t, len(userInfo.Permissions.Publish.Allow) == 2)
-	sort.Strings(userInfo.Permissions.Publish.Allow)
+	slices.Sort(userInfo.Permissions.Publish.Allow)
 	require_Equal(t, "foo.>", userInfo.Permissions.Publish.Allow[1])
-	sort.Strings(userInfo.Permissions.Subscribe.Allow)
+	slices.Sort(userInfo.Permissions.Subscribe.Allow)
 	require_True(t, len(userInfo.Permissions.Subscribe.Allow) == 2)
 	require_Equal(t, "foo.>", userInfo.Permissions.Subscribe.Allow[1])
 }
@@ -916,9 +916,9 @@ func testAuthCalloutScopedUser(t *testing.T, allowAnyAccount bool) {
 		t.Fatalf("Expected to be switched to %q, but got %q", tpub, userInfo.Account)
 	}
 	require_True(t, len(userInfo.Permissions.Publish.Allow) == 2)
-	sort.Strings(userInfo.Permissions.Publish.Allow)
+	slices.Sort(userInfo.Permissions.Publish.Allow)
 	require_Equal(t, "foo.>", userInfo.Permissions.Publish.Allow[1])
-	sort.Strings(userInfo.Permissions.Subscribe.Allow)
+	slices.Sort(userInfo.Permissions.Subscribe.Allow)
 	require_True(t, len(userInfo.Permissions.Subscribe.Allow) == 2)
 	require_Equal(t, "foo.>", userInfo.Permissions.Subscribe.Allow[1])
 

--- a/server/avl/seqset.go
+++ b/server/avl/seqset.go
@@ -14,10 +14,11 @@
 package avl
 
 import (
+	"cmp"
 	"encoding/binary"
 	"errors"
 	"math/bits"
-	"sort"
+	"slices"
 )
 
 // SequenceSet is a memory and encoding optimized set for storing unsigned ints.
@@ -209,7 +210,7 @@ func Union(ssa ...*SequenceSet) *SequenceSet {
 		return nil
 	}
 	// Sort so we can clone largest.
-	sort.Slice(ssa, func(i, j int) bool { return ssa[i].Size() > ssa[j].Size() })
+	slices.SortFunc(ssa, func(i, j *SequenceSet) int { return -cmp.Compare(i.Size(), j.Size()) }) // reverse order
 	ss := ssa[0].Clone()
 
 	// Insert the rest through range call.

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1761,7 +1761,7 @@ func (o *consumer) forceExpirePending() {
 		}
 	}
 	if len(expired) > 0 {
-		sort.Slice(expired, func(i, j int) bool { return expired[i] < expired[j] })
+		slices.Sort(expired)
 		o.addToRedeliverQueue(expired...)
 		// Now we should update the timestamp here since we are redelivering.
 		// We will use an incrementing time to preserve order for any other redelivery.
@@ -4757,7 +4757,7 @@ func (o *consumer) checkPending() {
 
 	if len(expired) > 0 {
 		// We need to sort.
-		sort.Slice(expired, func(i, j int) bool { return expired[i] < expired[j] })
+		slices.Sort(expired)
 		o.addToRedeliverQueue(expired...)
 		// Now we should update the timestamp here since we are redelivering.
 		// We will use an incrementing time to preserve order for any other redelivery.
@@ -4942,9 +4942,7 @@ func (o *consumer) selectStartingSeqNo() {
 					}
 					// Sort the skip list if needed.
 					if len(lss.seqs) > 1 {
-						sort.Slice(lss.seqs, func(i, j int) bool {
-							return lss.seqs[j] > lss.seqs[i]
-						})
+						slices.Sort(lss.seqs)
 					}
 					if len(lss.seqs) == 0 {
 						o.sseq = state.LastSeq

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -32,6 +32,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -1069,7 +1070,7 @@ func (fs *fileStore) addLostData(ld *LostStreamData) {
 		}
 		if added {
 			msgs := fs.ld.Msgs
-			sort.Slice(msgs, func(i, j int) bool { return msgs[i] < msgs[j] })
+			slices.Sort(msgs)
 			fs.ld.Bytes += ld.Bytes
 		}
 	} else {
@@ -1079,17 +1080,14 @@ func (fs *fileStore) addLostData(ld *LostStreamData) {
 
 // Helper to see if we already have this sequence reported in our lost data.
 func (ld *LostStreamData) exists(seq uint64) (int, bool) {
-	i, found := sort.Find(len(ld.Msgs), func(i int) int {
-		tseq := ld.Msgs[i]
-		if tseq < seq {
-			return -1
-		}
-		if tseq > seq {
-			return +1
-		}
-		return 0
+	i := slices.IndexFunc(ld.Msgs, func(i uint64) bool {
+		return i == seq
 	})
-	return i, found
+	if i == -1 {
+		return -1, false
+	} else {
+		return i, true
+	}
 }
 
 func (fs *fileStore) removeFromLostData(seq uint64) {
@@ -2956,7 +2954,7 @@ func (fs *fileStore) MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed i
 	if len(seqs) == 0 {
 		return nil, nil
 	}
-	sort.Slice(seqs, func(i, j int) bool { return seqs[i] < seqs[j] })
+	slices.Sort(seqs)
 	return seqs, nil
 }
 
@@ -6659,9 +6657,7 @@ func (fs *fileStore) State() StreamState {
 
 	// Can not be guaranteed to be sorted.
 	if len(state.Deleted) > 0 {
-		sort.Slice(state.Deleted, func(i, j int) bool {
-			return state.Deleted[i] < state.Deleted[j]
-		})
+		slices.Sort(state.Deleted)
 		state.NumDeleted = len(state.Deleted)
 	}
 	return state

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1083,11 +1083,7 @@ func (ld *LostStreamData) exists(seq uint64) (int, bool) {
 	i := slices.IndexFunc(ld.Msgs, func(i uint64) bool {
 		return i == seq
 	})
-	if i == -1 {
-		return -1, false
-	} else {
-		return i, true
-	}
+	return i, i > -1
 }
 
 func (fs *fileStore) removeFromLostData(seq uint64) {

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"bytes"
+	"cmp"
 	"crypto/sha256"
 	"crypto/tls"
 	"encoding/json"
@@ -23,7 +24,7 @@ import (
 	"math/rand"
 	"net"
 	"net/url"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1742,9 +1743,7 @@ func (s *Server) getOutboundGatewayConnections(a *[]*client) {
 // Gateway write lock is held on entry
 func (g *srvGateway) orderOutboundConnectionsLocked() {
 	// Order the gateways by lowest RTT
-	sort.Slice(g.outo, func(i, j int) bool {
-		return g.outo[i].getRTTValue() < g.outo[j].getRTTValue()
-	})
+	slices.SortFunc(g.outo, func(i, j *client) int { return cmp.Compare(i.getRTTValue(), j.getRTTValue()) })
 }
 
 // Orders the array of outbound connections.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5919,7 +5919,7 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 		if i.avail == j.avail {
 			return cmp.Compare(i.ns, j.ns)
 		}
-		return cmp.Compare(i.avail, j.avail)
+		return -cmp.Compare(i.avail, j.avail) // reverse
 	})
 	// If we are placing a replicated stream, let's sort based on HAAssets, as that is more important to balance.
 	if cfg.Replicas > 1 {

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -162,9 +162,7 @@ func TestJetStreamConsumerMultipleFiltersRace(t *testing.T) {
 		if len(seqs) != 3*total {
 			return fmt.Errorf("found %d messages instead of %d", len(seqs), 3*total)
 		}
-		sort.Slice(seqs, func(i, j int) bool {
-			return seqs[i] < seqs[j]
-		})
+		slices.Sort(seqs)
 		for i := 1; i < len(seqs); i++ {
 			if seqs[i] != seqs[i-1]+1 {
 				fmt.Printf("seqs: %+v\n", seqs)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -34,7 +34,7 @@ import (
 	"reflect"
 	"runtime"
 	"runtime/debug"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -7872,7 +7872,7 @@ func TestJetStreamRequestAPI(t *testing.T) {
 	if len(tListResp.Templates) != 2 {
 		t.Fatalf("Expected 2 templates but got %d", len(tListResp.Templates))
 	}
-	sort.Strings(tListResp.Templates)
+	slices.Sort(tListResp.Templates)
 	if tListResp.Templates[0] != "kv" {
 		t.Fatalf("Expected to get %q, but got %q", "kv", tListResp.Templates[0])
 	}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -17,6 +17,7 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"fmt"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -636,7 +637,7 @@ func (ms *memStore) MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed in
 			return nil, ErrTooManyResults
 		}
 	}
-	sort.Slice(seqs, func(i, j int) bool { return seqs[i] < seqs[j] })
+	slices.Sort(seqs)
 	return seqs, nil
 }
 

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"bytes"
+	"cmp"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
@@ -29,6 +30,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/pprof"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -3024,9 +3026,7 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 		accounts = []*jsAccount{accounts[filterIdx]}
 	} else if opts.Accounts {
 		if opts.Offset != 0 {
-			sort.Slice(accounts, func(i, j int) bool {
-				return strings.Compare(accounts[i].acc().Name, accounts[j].acc().Name) < 0
-			})
+			slices.SortFunc(accounts, func(i, j *jsAccount) int { return cmp.Compare(i.acc().Name, j.acc().Name) })
 			if opts.Offset > len(accounts) {
 				accounts = []*jsAccount{}
 			} else {

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"bytes"
+	"cmp"
 	"crypto/tls"
 	"encoding/binary"
 	"encoding/json"
@@ -23,7 +24,7 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -4431,9 +4432,7 @@ func (s *Server) mqttCheckPubRetainedPerms() {
 			})
 		}
 		asm.mu.RUnlock()
-		sort.Slice(rms, func(i, j int) bool {
-			return rms[i].rmsg.sseq < rms[j].rmsg.sseq
-		})
+		slices.SortFunc(rms, func(i, j retainedMsg) int { return cmp.Compare(i.rmsg.sseq, j.rmsg.sseq) })
 
 		perms := map[string]*perm{}
 		deletes := map[string]uint64{}

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -36,7 +36,7 @@ import (
 	"reflect"
 	"runtime"
 	"runtime/debug"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -10124,7 +10124,7 @@ func TestNoRaceConnectionObjectReleased(t *testing.T) {
 			// Don't fail the test since there is no guarantee that
 			// finalizers are invoked.
 			t.Logf("Got %v out of %v finalizers", len(clients), total)
-			sort.Strings(clients)
+			slices.Sort(clients)
 			for _, cs := range clients {
 				t.Logf("  => %s", cs)
 			}
@@ -10273,7 +10273,7 @@ func TestNoRaceWQAndMultiSubjectFilters(t *testing.T) {
 		}
 	}
 
-	sort.Slice(received, func(i, j int) bool { return received[i] < received[j] })
+	slices.Sort(received)
 
 	var pseq, gaps uint64
 	for _, seq := range received {

--- a/server/reload.go
+++ b/server/reload.go
@@ -14,12 +14,13 @@
 package server
 
 import (
+	"cmp"
 	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -1131,38 +1132,24 @@ func (s *Server) reloadOptions(curOpts, newOpts *Options) error {
 func imposeOrder(value any) error {
 	switch value := value.(type) {
 	case []*Account:
-		sort.Slice(value, func(i, j int) bool {
-			return value[i].Name < value[j].Name
-		})
+		slices.SortFunc(value, func(i, j *Account) int { return cmp.Compare(i.Name, j.Name) })
 		for _, a := range value {
-			sort.Slice(a.imports.streams, func(i, j int) bool {
-				return a.imports.streams[i].acc.Name < a.imports.streams[j].acc.Name
-			})
+			slices.SortFunc(a.imports.streams, func(i, j *streamImport) int { return cmp.Compare(i.acc.Name, j.acc.Name) })
 		}
 	case []*User:
-		sort.Slice(value, func(i, j int) bool {
-			return value[i].Username < value[j].Username
-		})
+		slices.SortFunc(value, func(i, j *User) int { return cmp.Compare(i.Username, j.Username) })
 	case []*NkeyUser:
-		sort.Slice(value, func(i, j int) bool {
-			return value[i].Nkey < value[j].Nkey
-		})
+		slices.SortFunc(value, func(i, j *NkeyUser) int { return cmp.Compare(i.Nkey, j.Nkey) })
 	case []*url.URL:
-		sort.Slice(value, func(i, j int) bool {
-			return value[i].String() < value[j].String()
-		})
+		slices.SortFunc(value, func(i, j *url.URL) int { return cmp.Compare(i.String(), j.String()) })
 	case []string:
-		sort.Strings(value)
+		slices.Sort(value)
 	case []*jwt.OperatorClaims:
-		sort.Slice(value, func(i, j int) bool {
-			return value[i].Issuer < value[j].Issuer
-		})
+		slices.SortFunc(value, func(i, j *jwt.OperatorClaims) int { return cmp.Compare(i.Issuer, j.Issuer) })
 	case GatewayOpts:
-		sort.Slice(value.Gateways, func(i, j int) bool {
-			return value.Gateways[i].Name < value.Gateways[j].Name
-		})
+		slices.SortFunc(value.Gateways, func(i, j *RemoteGatewayOpts) int { return cmp.Compare(i.Name, j.Name) })
 	case WebsocketOpts:
-		sort.Strings(value.AllowedOrigins)
+		slices.Sort(value.AllowedOrigins)
 	case string, bool, uint8, int, int32, int64, time.Duration, float64, nil, LeafNodeOpts, ClusterOpts, *tls.Config, PinnedCertSet,
 		*URLAccResolver, *MemAccResolver, *DirAccResolver, *CacheDirAccResolver, Authentication, MQTTOpts, jwt.TagList,
 		*OCSPConfig, map[string]string, JSLimitOpts, StoreCipher, *OCSPResponseCacheConfig:

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -28,7 +28,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1060,9 +1060,9 @@ func TestLameDuckModeInfo(t *testing.T) {
 		t.Helper()
 		var si *serverInfo
 		for i, ws := range []bool{false, true} {
-			sort.Strings(expected[i])
+			slices.Sort(expected[i])
 			si = getInfo(ws)
-			sort.Strings(si.ConnectURLs)
+			slices.Sort(si.ConnectURLs)
 			if !reflect.DeepEqual(expected[i], si.ConnectURLs) {
 				t.Fatalf("Expected %q, got %q", expected, si.ConnectURLs)
 			}


### PR DESCRIPTION
Replace usage of the new sort package with the slices package (Go 1.21) where it is faster (i.e. when it has to do a conversion from `interface{}`).
Use the new (Go 1.21) cmp.Compare in the sort functions.
Also fixes a variable shadowing that somehow wasn't being detected when using `sort.Slices` on that shadowing variable.