### PR TITLE
Update `golangci-lint` to v1.59.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,14 @@
 # Config file for golangci-lint
 run:
   concurrency: 4
-  deadline: 1m
   issues-exit-code: 1
   tests: true
-  skip-dirs:
-    - .github
-    - doc
-    - docker
-    - logos
-    - scripts
-    - util
   modules-download-mode: readonly
 
 output:
-  format: colored-line-number
+  formats:
+    - format: colored-line-number
+      path: stdout
   print-issued-lines: true
   print-linter-name: true
 
@@ -23,13 +17,11 @@ linters:
   enable:
     # - errcheck
     - forbidigo
-    - gofmt
-    # - goimports
+    - goimports
     - gosimple
     - govet
     - ineffassign
     # - maligned
-    - megacheck
     - misspell
     # - prealloc
     - staticcheck
@@ -44,7 +36,6 @@ linters-settings:
     forbid:
       - ^fmt\.Print(f|ln)?$
   govet:
-    check-shadowing: false
     settings:
       printf:
         funcs:
@@ -52,8 +43,6 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-  gofmt:
-    simple: true
   misspell:
     locale: US
   unparam:
@@ -64,6 +53,13 @@ linters-settings:
     for-loops: true
 
 issues:
+  exclude-dirs:
+    - .github
+    - doc
+    - docker
+    - logos
+    - scripts
+    - util
   exclude-rules:
     - path: "main.go" # Excludes main usage
       linters: [forbidigo]

--- a/scripts/runTestsOnTravis.sh
+++ b/scripts/runTestsOnTravis.sh
@@ -7,7 +7,7 @@ if [ "$1" = "compile" ]; then
     go build;
 
     # Now run the linters.
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.1;
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1;
     golangci-lint run;
     if [ "$TRAVIS_TAG" != "" ]; then
         go test -race -v -run=TestVersionMatchesTag ./server -ldflags="-X=github.com/nats-io/nats-server/v2/server.serverVersion=$TRAVIS_TAG" -count=1 -vet=off

--- a/server/jetstream_sourcing_scaling_test.go
+++ b/server/jetstream_sourcing_scaling_test.go
@@ -15,10 +15,11 @@ package server
 
 import (
 	"fmt"
-	"github.com/nats-io/nats.go"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/nats-io/nats.go"
 )
 
 var serverConfig1 = `


### PR DESCRIPTION
Also fixes the configuration file to remove deprecated options and/or to use new format.

Finally, run `goimports` on `jetstream_sourcing_scaling_test.go` to satisfy the linter.

Signed-off-by: Neil Twigg <neil@nats.io>