### PR TITLE
Move tls handshake errors to debug

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -5910,9 +5910,9 @@ func (c *client) doTLSHandshake(typ string, solicit bool, url *url.URL, tlsConfi
 
 	if err != nil {
 		if kind == CLIENT {
-			c.Errorf("TLS handshake error: %v", err)
+			c.Debugf("TLS handshake error: %v", err)
 		} else {
-			c.Errorf("TLS %s handshake error: %v", typ, err)
+			c.Debugf("TLS %s handshake error: %v", typ, err)
 		}
 		c.closeConnection(TLSHandshakeError)
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1806,8 +1806,10 @@ func TestRouteSaveTLSName(t *testing.T) {
 
 	// Set a logger to capture errors trying to connect after clearing
 	// the routeTLSName and causing a disconnect
-	l := &captureErrorLogger{errCh: make(chan string, 1)}
-	s2.SetLogger(l, false, false)
+	l := &captureErrorLogger{errCh: make(chan string, 1), filter: func(s string) bool {
+		return strings.Contains(s, "TLS route handshake error")
+	}}
+	s2.SetLogger(l, true, false)
 
 	var gotIt bool
 	for i := 0; !gotIt && i < 5; i++ {

--- a/test/cluster_tls_test.go
+++ b/test/cluster_tls_test.go
@@ -72,7 +72,7 @@ type captureTLSError struct {
 	ch chan struct{}
 }
 
-func (c *captureTLSError) Errorf(format string, v ...any) {
+func (c *captureTLSError) Debugf(format string, v ...any) {
 	msg := fmt.Sprintf(format, v...)
 	if strings.Contains(msg, "handshake error") {
 		select {
@@ -117,7 +117,7 @@ func TestClusterTLSInsecure(t *testing.T) {
 	defer srvA.Shutdown()
 
 	l := &captureTLSError{ch: make(chan struct{}, 1)}
-	srvA.SetLogger(l, false, false)
+	srvA.SetLogger(l, true, false)
 
 	bConfigTemplate := `
 		port: -1


### PR DESCRIPTION
This turned out to be a much bigger undertaking due to how the logs are used in tests

Signed-off-by: R.I.Pienaar <rip@devco.net>
