### PR TITLE
(2.11) Add ability for IP queues to track total size

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -863,7 +863,7 @@ func (js *jetStream) apiDispatch(sub *subscription, c *client, acc *Account, sub
 	// header from the msg body. No other references are needed.
 	// Check pending and warn if getting backed up.
 	const warnThresh = 128
-	pending := s.jsAPIRoutedReqs.push(&jsAPIRoutedReq{jsub, sub, acc, subject, reply, copyBytes(rmsg), c.pa})
+	pending, _ := s.jsAPIRoutedReqs.push(&jsAPIRoutedReq{jsub, sub, acc, subject, reply, copyBytes(rmsg), c.pa})
 	if pending >= warnThresh {
 		s.rateLimitFormatWarnf("JetStream request queue has high pending count: %d", pending)
 	}


### PR DESCRIPTION
You can optionally pass in an `ipQueue_SizeCalculation` function to an IP queue that fires each time an item is pushed or popped so that the total size can be tracked.

There is a slight performance impact but mostly it will depend on the complexity of the calculation function:
```
go test -v ./server -run=XXX -bench=IPQueueSizeCalculation -benchtime=10s
goos: darwin
goarch: arm64
pkg: github.com/nats-io/nats-server/v2/server
BenchmarkIPQueueSizeCalculation
BenchmarkIPQueueSizeCalculation/WithoutCalc
BenchmarkIPQueueSizeCalculation/WithoutCalc-24          396342910               30.75 ns/op      520.35 MB/s
BenchmarkIPQueueSizeCalculation/WithEmptyCalc
BenchmarkIPQueueSizeCalculation/WithEmptyCalc-24        377004524               33.91 ns/op      471.80 MB/s
BenchmarkIPQueueSizeCalculation/WithLenCalc
BenchmarkIPQueueSizeCalculation/WithLenCalc-24          375148896               33.76 ns/op      473.99 MB/s
PASS
ok      github.com/nats-io/nats-server/v2/server        48.150s
```

Signed-off-by: Neil Twigg <neil@nats.io>