### PR TITLE
Set `ReadTimeout` on profiling, monitoring and OCSP HTTP servers

### DIFF
--- a/internal/ocsp/ocsp.go
+++ b/internal/ocsp/ocsp.go
@@ -178,8 +178,9 @@ func NewOCSPResponderBase(t *testing.T, issuerCertPEM, respCertPEM, respKeyPEM s
 	})
 
 	srv := &http.Server{
-		Addr:    addr,
-		Handler: mux,
+		Addr:        addr,
+		Handler:     mux,
+		ReadTimeout: time.Second * 5,
 	}
 	go srv.ListenAndServe()
 	time.Sleep(1 * time.Second)

--- a/server/server.go
+++ b/server/server.go
@@ -2826,6 +2826,7 @@ func (s *Server) StartProfiler() {
 		Addr:           hp,
 		Handler:        http.DefaultServeMux,
 		MaxHeaderBytes: 1 << 20,
+		ReadTimeout:    time.Second * 5,
 	}
 	s.profiler = l
 	s.profilingServer = srv
@@ -3025,10 +3026,11 @@ func (s *Server) startMonitoring(secure bool) error {
 	// to return empty response or unable to display page if the
 	// server needs more time to build the response.
 	srv := &http.Server{
-		Addr:           hp,
-		Handler:        mux,
-		MaxHeaderBytes: 1 << 20,
-		ErrorLog:       log.New(&captureHTTPServerLog{s, "monitoring: "}, _EMPTY_, 0),
+		Addr:              hp,
+		Handler:           mux,
+		MaxHeaderBytes:    1 << 20,
+		ErrorLog:          log.New(&captureHTTPServerLog{s, "monitoring: "}, _EMPTY_, 0),
+		ReadHeaderTimeout: time.Second * 5,
 	}
 	s.mu.Lock()
 	s.http = httpListener

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -761,7 +761,7 @@ func TestProfilingNoTimeout(t *testing.T) {
 	if srv == nil {
 		t.Fatalf("Profiling server not set")
 	}
-	if srv.ReadTimeout != 0 {
+	if srv.ReadTimeout != time.Second*5 {
 		t.Fatalf("ReadTimeout should not be set, was set to %v", srv.ReadTimeout)
 	}
 	if srv.WriteTimeout != 0 {


### PR DESCRIPTION
Reported-by: Trail of Bits <https://www.trailofbits.com>
Signed-off-by: Neil Twigg <neil@nats.io>