### PR TITLE
[IMPROVED] Log rate limited warnings

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -6089,6 +6089,14 @@ func (c *client) Warnf(format string, v ...any) {
 	c.srv.Warnf(format, v...)
 }
 
+func (c *client) rateLimitFormatWarnf(format string, v ...any) {
+	if _, loaded := c.srv.rateLimitLogging.LoadOrStore(format, time.Now()); loaded {
+		return
+	}
+	statement := fmt.Sprintf(format, v...)
+	c.Warnf("%s", statement)
+}
+
 func (c *client) RateLimitWarnf(format string, v ...any) {
 	// Do the check before adding the client info to the format...
 	statement := fmt.Sprintf(format, v...)

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -862,10 +862,10 @@ func (js *jetStream) apiDispatch(sub *subscription, c *client, acc *Account, sub
 	// Copy the state. Note the JSAPI only uses the hdr index to piece apart the
 	// header from the msg body. No other references are needed.
 	// Check pending and warn if getting backed up.
-	const warnThresh = 32
+	const warnThresh = 128
 	pending := s.jsAPIRoutedReqs.push(&jsAPIRoutedReq{jsub, sub, acc, subject, reply, copyBytes(rmsg), c.pa})
-	if pending > warnThresh {
-		s.RateLimitWarnf("JetStream request queue has high pending count: %d", pending)
+	if pending >= warnThresh {
+		s.rateLimitFormatWarnf("JetStream request queue has high pending count: %d", pending)
 	}
 }
 

--- a/server/log.go
+++ b/server/log.go
@@ -219,6 +219,14 @@ func (s *Server) Warnf(format string, v ...any) {
 	}, format, v...)
 }
 
+func (s *Server) rateLimitFormatWarnf(format string, v ...any) {
+	if _, loaded := s.rateLimitLogging.LoadOrStore(format, time.Now()); loaded {
+		return
+	}
+	statement := fmt.Sprintf(format, v...)
+	s.Warnf("%s", statement)
+}
+
 func (s *Server) RateLimitWarnf(format string, v ...any) {
 	statement := fmt.Sprintf(format, v...)
 	if _, loaded := s.rateLimitLogging.LoadOrStore(statement, time.Now()); loaded {


### PR DESCRIPTION
RateLimitWarnf does actually rate limit when the error message changes every time (i.e. if it includes something like a count or a number that changes with every log line)

Added rateLimitFormatWarnf that does the rate limiting for all log messages according to the format (rather than the statement).

This also updates the default warning threshold for pending JS requests from 32 to 128.