### PR TITLE
Fix 0 expected last seq per subject for clustered stream

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7836,12 +7836,15 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 		}
 		// Expected last sequence per subject.
 		// We can check for last sequence per subject but only if the expected seq <= lseq.
-		if seq, exists := getExpectedLastSeqPerSubject(hdr); exists && store != nil && seq > 0 && seq <= lseq {
+		if seq, exists := getExpectedLastSeqPerSubject(hdr); exists && store != nil && seq <= lseq {
 			var smv StoreMsg
 			var fseq uint64
 			sm, err := store.LoadLastMsg(subject, &smv)
 			if sm != nil {
 				fseq = sm.seq
+			}
+			if err == ErrStoreMsgNotFound && seq == 0 {
+				fseq, err = 0, nil
 			}
 			if err != nil || fseq != seq {
 				if canRespond {

--- a/server/stream.go
+++ b/server/stream.go
@@ -4626,7 +4626,6 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		}
 
 		// Expected last sequence per subject.
-		// If we are clustered we have prechecked seq > 0.
 		if seq, exists := getExpectedLastSeqPerSubject(hdr); exists {
 			// TODO(dlc) - We could make a new store func that does this all in one.
 			var smv StoreMsg


### PR DESCRIPTION
The `getExpectedLastSeqPerSubject` check in `processJetStreamMsg` would take into account that we could get a create/seq=0 for last seq per subject.

However, the `processClusteredInboundMsg` would NOT take this into account. This would result in sending the message to all replicas. If any replica would store instead of reject the message, it would desync.

The reproducible example from below issue doesn't reproduce anymore after this fix.

Resolves https://github.com/nats-io/nats-server/issues/5644

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
