### PR TITLE
Fix install stream snapshots on graceful shutdown

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3138,13 +3138,10 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				}
 			}
 
-			if !isRecovering && !mset.IsLeader() {
+			if isRecovering || !mset.IsLeader() {
 				if err := mset.processSnapshot(ss); err != nil {
 					return err
 				}
-			} else if isRecovering {
-				// On recovery, reset CLFS/FAILED.
-				mset.setCLFS(ss.Failed)
 			}
 		} else if e.Type == EntryRemovePeer {
 			js.mu.RLock()

--- a/server/stream.go
+++ b/server/stream.go
@@ -5340,6 +5340,10 @@ func (mset *stream) stop(deleteFlag, advisory bool) error {
 
 	// Kick monitor and collect consumers first.
 	mset.mu.Lock()
+
+	// Mark closed.
+	mset.closed.Store(true)
+
 	// Signal to the monitor loop.
 	// Can't use qch here.
 	if mset.mqch != nil {
@@ -5399,9 +5403,6 @@ func (mset *stream) stop(deleteFlag, advisory bool) error {
 	if deleteFlag && advisory {
 		mset.sendDeleteAdvisoryLocked()
 	}
-
-	// Mark closed.
-	mset.closed.Store(true)
 
 	// Quit channel, do this after sending the delete advisory
 	if mset.qch != nil {


### PR DESCRIPTION
Upon graceful shutdown, stream snapshots aren't installed:
stream.go
```go
} else {
	// Always attempt snapshot on clean exit.
	n.InstallSnapshot(mset.stateSnapshotLocked())
	n.Stop()
}
```

But raft.go exits immediately since it's in Closed state
```go
if n.State() == Closed {
        return errNodeClosed
}
```

This turns out to be because of calling either of `close(mset.mqch)` or `close(mset.qch)`. Which then calls the following upon leaving `monitorStream`:
```go
	// Make sure to stop the raft group on exit to prevent accidental memory bloat.
	// This should be below the checkInMonitor call though to avoid stopping it out
	// from underneath the one that is running since it will be the same raft node.
	defer n.Stop()
```

This PR proposes to skip running `n.Stop()` from `monitorStream` when we know we're closing / have called `mset.stop()`. Which will already take care of calling either `n.Stop()` or `n.Delete()` so there's no need in stopping from `monitorStream` in that case.

TLDR; this ensures stream snapshots are installed upon shutdown.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
