### PR TITLE
Use correct sequence on duplicate message with no interest

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -23468,7 +23468,7 @@ func TestInterestConsumerFilterEdit(t *testing.T) {
 }
 
 // https://github.com/nats-io/nats-server/issues/5383
-func TestInterestStreamWithFilterSubjectsConsumer(t *testing.T) {
+func TestJetStreamInterestStreamWithFilterSubjectsConsumer(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
@@ -23926,7 +23926,7 @@ func TestJetStreamConsumerStartSequenceNotInStream(t *testing.T) {
 	}()
 }
 
-func TestInterestStreamWithDuplicateMessages(t *testing.T) {
+func TestJetStreamInterestStreamWithDuplicateMessages(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -4793,7 +4793,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		mset.lmsgId = msgId
 		// If we have a msgId make sure to save.
 		if msgId != _EMPTY_ {
-			mset.storeMsgIdLocked(&ddentry{msgId, seq, ts})
+			mset.storeMsgIdLocked(&ddentry{msgId, mset.lseq, ts})
 		}
 		if canRespond {
 			response = append(pubAck, strconv.FormatUint(mset.lseq, 10)...)


### PR DESCRIPTION
A duplicate message inserted into an Interest-based stream with no interest would return 0 as sequence instead of the sequence of the initial message.

```sh
$ nats req interest '' -H 'Nats-Msg-Id: dedupe'
20:31:43 Sending request on "interest"
20:31:43 Received with rtt 187.55µs
{"stream":"INTEREST", "seq":6}

$ nats req interest '' -H 'Nats-Msg-Id: dedupe'
20:31:43 Sending request on "interest"
20:31:43 Received with rtt 101.95µs
{"stream":"INTEREST", "seq":0,"duplicate": true}
# ---- seq should be 6 -----^
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
