### PR TITLE
[FIXED] JetStream: data race between consumer and stream when updated

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -717,7 +717,7 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 	}
 
 	mset.mu.RLock()
-	s, jsa, cfg, acc := mset.srv, mset.jsa, mset.getCfg(), mset.acc
+	s, jsa, cfg, acc := mset.srv, mset.jsa, mset.cfg, mset.acc
 	mset.mu.RUnlock()
 
 	// If we do not have the consumer currently assigned to us in cluster mode we will proceed but warn.

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -3607,7 +3607,7 @@ func TestClusterSetupMsgs(t *testing.T) {
 
 	var totalOut int
 	for _, server := range c.servers {
-		totalOut += int(server.outMsgs)
+		totalOut += int(atomic.LoadInt64(&server.outMsgs))
 	}
 	totalExpected := numServers * numServers
 	if totalOut >= totalExpected {

--- a/server/stream.go
+++ b/server/stream.go
@@ -1979,7 +1979,14 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 	}
 
 	// Now update config and store's version of our config.
-	mset.setCfg(cfg)
+	// Although we are under the stream write lock, we will also assign the new
+	// configuration under mset.cfgMu lock. This is so that in places where
+	// mset.mu cannot be acquired (like many cases in consumer.go where code
+	// is under the consumer's lock), and the stream's configuration needs to
+	// be inspected, one can use mset.cfgMu's read lock to do that safely.
+	mset.cfgMu.Lock()
+	mset.cfg = *cfg
+	mset.cfgMu.Unlock()
 
 	// If we're changing retention and haven't errored because of consumer
 	// replicas by now, whip through and update the consumer retention.
@@ -2028,30 +2035,6 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 	mset.store.UpdateConfig(cfg)
 
 	return nil
-}
-
-// Sets the configuration for this stream.
-// This is called under mset.mu.Lock(), but this function will also acquire
-// mset.cfgMu lock. This is so that in places where mset.mu cannot be acquired
-// (like many cases in consumer.go where code is under the consumer's lock),
-// but the stream's configuration needs to be inspected, the caller can call
-// mset.getCfg() to get (safely) a copy of the stream's configuration.
-func (mset *stream) setCfg(cfg *StreamConfig) {
-	mset.cfgMu.Lock()
-	mset.cfg = *cfg
-	mset.cfgMu.Unlock()
-}
-
-// The stream configuration is a structure. Normally, code that would do
-// something like cfg := mset.cfg would get a copy of that structure. However,
-// this would race with code that assigns a new congiguration to the stream
-// (think stream update). The update will be done using setCfg(), and therefore,
-// to avoid races, callers that need the stream's congiguration should call
-// this function, or protect using mset.cfgMu read lock.
-func (mset *stream) getCfg() StreamConfig {
-	mset.cfgMu.RLock()
-	defer mset.cfgMu.RUnlock()
-	return mset.cfg
 }
 
 // Small helper to return the Name field from mset.cfg, protected by

--- a/server/stream.go
+++ b/server/stream.go
@@ -236,6 +236,7 @@ type stream struct {
 	consumers map[string]*consumer    // The consumers for this stream.
 	numFilter int                     // The number of filtered consumers.
 	cfg       StreamConfig            // The stream's config.
+	cfgMu     sync.RWMutex            // Config mutex used to solve some races with consumer code
 	created   time.Time               // Time the stream was created.
 	stype     StorageType             // The storage type.
 	tier      string                  // The tier is the number of replicas for the stream (e.g. "R1" or "R3").
@@ -1978,7 +1979,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 	}
 
 	// Now update config and store's version of our config.
-	mset.cfg = *cfg
+	mset.setCfg(cfg)
 
 	// If we're changing retention and haven't errored because of consumer
 	// replicas by now, whip through and update the consumer retention.
@@ -2027,6 +2028,39 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool) 
 	mset.store.UpdateConfig(cfg)
 
 	return nil
+}
+
+// Sets the configuration for this stream.
+// This is called under mset.mu.Lock(), but this function will also acquire
+// mset.cfgMu lock. This is so that in places where mset.mu cannot be acquired
+// (like many cases in consumer.go where code is under the consumer's lock),
+// but the stream's configuration needs to be inspected, the caller can call
+// mset.getCfg() to get (safely) a copy of the stream's configuration.
+func (mset *stream) setCfg(cfg *StreamConfig) {
+	mset.cfgMu.Lock()
+	mset.cfg = *cfg
+	mset.cfgMu.Unlock()
+}
+
+// The stream configuration is a structure. Normally, code that would do
+// something like cfg := mset.cfg would get a copy of that structure. However,
+// this would race with code that assigns a new congiguration to the stream
+// (think stream update). The update will be done using setCfg(), and therefore,
+// to avoid races, callers that need the stream's congiguration should call
+// this function, or protect using mset.cfgMu read lock.
+func (mset *stream) getCfg() StreamConfig {
+	mset.cfgMu.RLock()
+	defer mset.cfgMu.RUnlock()
+	return mset.cfg
+}
+
+// Small helper to return the Name field from mset.cfg, protected by
+// the mset.cfgMu mutex. This is simply because we have several places
+// in consumer.go where we need it.
+func (mset *stream) getCfgName() string {
+	mset.cfgMu.RLock()
+	defer mset.cfgMu.RUnlock()
+	return mset.cfg.Name
 }
 
 // Purge will remove all messages from the stream and underlying store based on the request.


### PR DESCRIPTION
Some tests were showing often a race between updateWithAdvisory() and isFiltered().

There may be other data races in other files that read the mset's configuration without proper locking, but this PR addresses specifically issues between consumer (consumer.go) and stream.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>