### PR TITLE
Correct test name

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -23417,7 +23417,7 @@ func TestJetStreamDirectGetMultiPaging(t *testing.T) {
 }
 
 // https://github.com/nats-io/nats-server/issues/4878
-func TestInterestConsumerFilterEdit(t *testing.T) {
+func TestJetStreamInterestStreamConsumerFilterEdit(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 


### PR DESCRIPTION
Test should've been prefixed with `TestJetStream`. As noted by @wallyqs: https://github.com/nats-io/nats-server/pull/5818#discussion_r1729264623

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
