### PR TITLE
Don't return `seq=0, duplicate=true` when processing duplicate messages asynchronously

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -1558,5 +1558,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSStreamDuplicateMessageConflict",
+    "code": 409,
+    "error_code": 10158,
+    "description": "duplicate message id is in process",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7893,7 +7893,8 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 				pubAck := append(buf[:0], mset.pubAck...)
 				seq := dde.seq
 				mset.mu.Unlock()
-				if canRespond {
+				// Should not return an invalid sequence, in that case timeout.
+				if canRespond && seq > 0 {
 					response := append(pubAck, strconv.FormatUint(seq, 10)...)
 					response = append(response, ",\"duplicate\": true}"...)
 					outq.sendMsg(reply, response)

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -3125,7 +3125,7 @@ func TestJetStreamClusterPubAckSequenceDupe(t *testing.T) {
 
 }
 
-func TestJetStreamClusterPubAckSequenceDupe2(t *testing.T) {
+func TestJetStreamClusterPubAckSequenceDupeAsync(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "TEST_CLUSTER", 3)
 	defer c.shutdown()
 
@@ -3146,6 +3146,7 @@ func TestJetStreamClusterPubAckSequenceDupe2(t *testing.T) {
 
 		msgSubject := "TEST_SUBJECT"
 		msgIdOpt := nats.MsgId(nuid.Next())
+		ackWait := time.Millisecond * 500
 
 		wg := sync.WaitGroup{}
 		wg.Add(2)
@@ -3159,7 +3160,10 @@ func TestJetStreamClusterPubAckSequenceDupe2(t *testing.T) {
 			go func(i int) {
 				defer wg.Done()
 				var err error
-				pubAcks[i], err = js.Publish(msgSubject, msgData, msgIdOpt)
+				pubAcks[i], err = js.Publish(msgSubject, msgData, msgIdOpt, nats.AckWait(ackWait))
+				if err != nil {
+					pubAcks[i], err = js.Publish(msgSubject, msgData, msgIdOpt, nats.AckWait(ackWait))
+				}
 				require_NoError(t, err)
 			}(i)
 		}

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -3146,6 +3146,7 @@ func TestJetStreamClusterPubAckSequenceDupeAsync(t *testing.T) {
 
 		msgSubject := "TEST_SUBJECT"
 		msgIdOpt := nats.MsgId(nuid.Next())
+		conflictErr := &nats.APIError{ErrorCode: nats.ErrorCode(JSStreamDuplicateMessageConflict)}
 
 		wg := sync.WaitGroup{}
 		wg.Add(2)
@@ -3161,7 +3162,7 @@ func TestJetStreamClusterPubAckSequenceDupeAsync(t *testing.T) {
 				var err error
 				pubAcks[i], err = js.Publish(msgSubject, msgData, msgIdOpt)
 				// Conflict on duplicate message, wait a bit before retrying to get the proper pubAck.
-				if err != nil {
+				if errors.Is(err, conflictErr) {
 					time.Sleep(time.Millisecond * 500)
 					pubAcks[i], err = js.Publish(msgSubject, msgData, msgIdOpt)
 				}

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -341,6 +341,9 @@ const (
 	// JSStreamDeleteErrF General stream deletion error string ({err})
 	JSStreamDeleteErrF ErrorIdentifier = 10050
 
+	// JSStreamDuplicateMessageConflict duplicate message id is in process
+	JSStreamDuplicateMessageConflict ErrorIdentifier = 10158
+
 	// JSStreamExternalApiOverlapErrF stream external api prefix {prefix} must not overlap with {subject}
 	JSStreamExternalApiOverlapErrF ErrorIdentifier = 10021
 
@@ -588,6 +591,7 @@ var (
 		JSStreamAssignmentErrF:                     {Code: 500, ErrCode: 10048, Description: "{err}"},
 		JSStreamCreateErrF:                         {Code: 500, ErrCode: 10049, Description: "{err}"},
 		JSStreamDeleteErrF:                         {Code: 500, ErrCode: 10050, Description: "{err}"},
+		JSStreamDuplicateMessageConflict:           {Code: 409, ErrCode: 10158, Description: "duplicate message id is in process"},
 		JSStreamExternalApiOverlapErrF:             {Code: 400, ErrCode: 10021, Description: "stream external api prefix {prefix} must not overlap with {subject}"},
 		JSStreamExternalDelPrefixOverlapsErrF:      {Code: 400, ErrCode: 10022, Description: "stream external delivery prefix {prefix} overlaps with stream subject {subject}"},
 		JSStreamGeneralErrorF:                      {Code: 500, ErrCode: 10051, Description: "{err}"},
@@ -1919,6 +1923,16 @@ func NewJSStreamDeleteError(err error, opts ...ErrorOption) *ApiError {
 		ErrCode:     e.ErrCode,
 		Description: strings.NewReplacer(args...).Replace(e.Description),
 	}
+}
+
+// NewJSStreamDuplicateMessageConflictError creates a new JSStreamDuplicateMessageConflict error: "duplicate message id is in process"
+func NewJSStreamDuplicateMessageConflictError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSStreamDuplicateMessageConflict]
 }
 
 // NewJSStreamExternalApiOverlapError creates a new JSStreamExternalApiOverlapErrF error: "stream external api prefix {prefix} must not overlap with {subject}"


### PR DESCRIPTION
This issue was reported by Marco and Antithesis.

`seq=0, duplicate=true` would be returned if two duplicate messages would be processed at the same time. The first will propagate, which will take some time for a clustered stream, but then the second message gets processed and rejected with `seq=0, duplicate=true` (without `error`) which would be invalid.

One option to fix this is timing out the second publish and wait for the original message to finish processing.
That fixes this issue, and the user would just retry the request and get the valid sequence once the other message has gone through.

However, it could decrease message throughput when this is hit. An alternative could be to throw an error, but if the user would always retry if `err != nil` then they'd be "spamming" the same request until the original message is fully propagated.

Would like to hear your thoughts :) 
Maybe this would be more suitable for 2.11.x as well?

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
