### PR TITLE
Windows: Search for DLLs in system paths only

### DIFF
--- a/server/certstore/certstore_windows.go
+++ b/server/certstore/certstore_windows.go
@@ -124,18 +124,37 @@ var (
 	winAuthRootStore       = winWide("AuthRoot")
 
 	// These DLLs must be available on all Windows hosts
-	winCrypt32 = windows.MustLoadDLL("crypt32.dll")
-	winNCrypt  = windows.MustLoadDLL("ncrypt.dll")
+	winCrypt32 = windows.NewLazySystemDLL("crypt32.dll")
+	winNCrypt  = windows.NewLazySystemDLL("ncrypt.dll")
 
-	winCertFindCertificateInStore        = winCrypt32.MustFindProc("CertFindCertificateInStore")
-	winCryptAcquireCertificatePrivateKey = winCrypt32.MustFindProc("CryptAcquireCertificatePrivateKey")
-	winNCryptExportKey                   = winNCrypt.MustFindProc("NCryptExportKey")
-	winNCryptOpenStorageProvider         = winNCrypt.MustFindProc("NCryptOpenStorageProvider")
-	winNCryptGetProperty                 = winNCrypt.MustFindProc("NCryptGetProperty")
-	winNCryptSignHash                    = winNCrypt.MustFindProc("NCryptSignHash")
+	winCertFindCertificateInStore        = winCrypt32.NewProc("CertFindCertificateInStore")
+	winCryptAcquireCertificatePrivateKey = winCrypt32.NewProc("CryptAcquireCertificatePrivateKey")
+	winNCryptExportKey                   = winNCrypt.NewProc("NCryptExportKey")
+	winNCryptOpenStorageProvider         = winNCrypt.NewProc("NCryptOpenStorageProvider")
+	winNCryptGetProperty                 = winNCrypt.NewProc("NCryptGetProperty")
+	winNCryptSignHash                    = winNCrypt.NewProc("NCryptSignHash")
 
 	winFnGetProperty = winGetProperty
 )
+
+func init() {
+	for _, d := range []*windows.LazyDLL{
+		winCrypt32, winNCrypt,
+	} {
+		if err := d.Load(); err != nil {
+			panic(err)
+		}
+	}
+	for _, p := range []*windows.LazyProc{
+		winCertFindCertificateInStore, winCryptAcquireCertificatePrivateKey,
+		winNCryptExportKey, winNCryptOpenStorageProvider,
+		winNCryptGetProperty, winNCryptSignHash,
+	} {
+		if err := p.Find(); err != nil {
+			panic(err)
+		}
+	}
+}
 
 type winPKCS1PaddingInfo struct {
 	pszAlgID *uint16

--- a/server/pse/pse_windows.go
+++ b/server/pse/pse_windows.go
@@ -25,16 +25,32 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 var (
-	pdh                            = syscall.NewLazyDLL("pdh.dll")
+	pdh                            = windows.NewLazySystemDLL("pdh.dll")
 	winPdhOpenQuery                = pdh.NewProc("PdhOpenQuery")
 	winPdhAddCounter               = pdh.NewProc("PdhAddCounterW")
 	winPdhCollectQueryData         = pdh.NewProc("PdhCollectQueryData")
 	winPdhGetFormattedCounterValue = pdh.NewProc("PdhGetFormattedCounterValue")
 	winPdhGetFormattedCounterArray = pdh.NewProc("PdhGetFormattedCounterArrayW")
 )
+
+func init() {
+	if err := pdh.Load(); err != nil {
+		panic(err)
+	}
+	for _, p := range []*windows.LazyProc{
+		winPdhOpenQuery, winPdhAddCounter, winPdhCollectQueryData,
+		winPdhGetFormattedCounterValue, winPdhGetFormattedCounterArray,
+	} {
+		if err := p.Find(); err != nil {
+			panic(err)
+		}
+	}
+}
 
 // global performance counter query handle and counters
 var (


### PR DESCRIPTION
Otherwise DLLs can potentially be loaded in from the current working directory.

Tested on a Windows 11 ARM64 virtual machine.

Reported-by: Trail of Bits <https://www.trailofbits.com>
Signed-off-by: Neil Twigg <neil@nats.io>