### PR TITLE
Pin third-party workflows in GitHub Actions

### DIFF
--- a/.github/actions/nightly-release/action.yaml
+++ b/.github/actions/nightly-release/action.yaml
@@ -31,7 +31,9 @@ runs:
         go-version: "${{ inputs.go }}"
 
     - name: goreleaser
-      uses: goreleaser/goreleaser-action@v5
+      # Use commit hash here to avoid a re-tagging attack, as this is a third-party action
+      # Commit 5742e2a039330cbb23ebf35f046f814d4c6ff811 = tag v5
+      uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811
       with:
         workdir: "${{ inputs.workdir }}"
         version: latest
@@ -49,9 +51,9 @@ runs:
       shell: bash
       run: |
         NDATE=$(date +%Y%m%d)
-    
+
         docker tag synadia/nats-server:nightly-${NDATE} synadia/nats-server:${{ inputs.label }}-${NDATE}
         docker tag synadia/nats-server:nightly-${NDATE} synadia/nats-server:${{ inputs.label }}
-    
+
         docker push synadia/nats-server:${{ inputs.label }}-${NDATE}
         docker push synadia/nats-server:${{ inputs.label }}

--- a/.github/workflows/cov.yaml
+++ b/.github/workflows/cov.yaml
@@ -33,13 +33,17 @@ jobs:
           set +e
 
       - name: Convert coverage.out to coverage.lcov
-        uses: jandelgado/gcov2lcov-action@v1.0.9
+        # Use commit hash here to avoid a re-tagging attack, as this is a third-party action
+        # Commit c680c0f7c7442485f1749eb2a13e54a686e76eb5 = tag v1.0.9
+        uses: jandelgado/gcov2lcov-action@c680c0f7c7442485f1749eb2a13e54a686e76eb5
         with:
           infile: acc.out
           working-directory: src/github.com/nats-io/nats-server
 
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        # Use commit hash here to avoid a re-tagging attack, as this is a third-party action
+        # Commit 3dfc5567390f6fa9267c0ee9c251e4c8c3f18949 = tag v2
+        uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949
         with:
           github-token: ${{ secrets.github_token }}
           file: src/github.com/nats-io/nats-server/coverage.lcov


### PR DESCRIPTION
Prevents potential re-tagging attacks on third-party workflows.

Reported-by: Trail of Bits <https://www.trailofbits.com>
Signed-off-by: Neil Twigg <neil@nats.io>