### PR TITLE
Update default file and directory permissions

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -25,6 +25,9 @@ import (
 	"time"
 )
 
+// Default file permissions for log files.
+const defaultLogPerms = os.FileMode(0640)
+
 // Logger is the server logger
 type Logger struct {
 	sync.Mutex
@@ -142,7 +145,7 @@ type fileLogger struct {
 
 func newFileLogger(filename, pidPrefix string, time bool) (*fileLogger, error) {
 	fileflags := os.O_WRONLY | os.O_APPEND | os.O_CREATE
-	f, err := os.OpenFile(filename, fileflags, 0660)
+	f, err := os.OpenFile(filename, fileflags, defaultLogPerms)
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +263,7 @@ func (l *fileLogger) Write(b []byte) (int, error) {
 				now.Second(), now.Nanosecond())
 			os.Rename(fname, bak)
 			fileflags := os.O_WRONLY | os.O_APPEND | os.O_CREATE
-			f, err := os.OpenFile(fname, fileflags, 0660)
+			f, err := os.OpenFile(fname, fileflags, defaultLogPerms)
 			if err != nil {
 				l.Unlock()
 				panic(fmt.Sprintf("Unable to re-open the logfile %q after rotation: %v", fname, err))

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -154,8 +154,8 @@ type FileConsumerInfo struct {
 
 // Default file and directory permissions.
 const (
-	defaultDirPerms  = os.FileMode(0750)
-	defaultFilePerms = os.FileMode(0640)
+	defaultDirPerms  = os.FileMode(0700)
+	defaultFilePerms = os.FileMode(0600)
 )
 
 type psi struct {

--- a/server/raft.go
+++ b/server/raft.go
@@ -327,7 +327,7 @@ func (s *Server) bootstrapRaftNode(cfg *RaftConfig, knownPeers []string, allPeer
 
 	// Check the store directory. If we have a memory based WAL we need to make sure the directory is setup.
 	if stat, err := os.Stat(cfg.Store); os.IsNotExist(err) {
-		if err := os.MkdirAll(cfg.Store, 0750); err != nil {
+		if err := os.MkdirAll(cfg.Store, defaultDirPerms); err != nil {
 			return fmt.Errorf("raft: could not create storage directory - %v", err)
 		}
 	} else if stat == nil || !stat.IsDir() {
@@ -419,7 +419,7 @@ func (s *Server) startRaftNode(accName string, cfg *RaftConfig, labels pprofLabe
 	}
 
 	// Make sure that the snapshots directory exists.
-	if err := os.MkdirAll(filepath.Join(n.sd, snapshotsDir), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Join(n.sd, snapshotsDir), defaultDirPerms); err != nil {
 		return nil, fmt.Errorf("could not create snapshots directory - %v", err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -1603,7 +1603,7 @@ func (s *Server) isRunning() bool {
 
 func (s *Server) logPid() error {
 	pidStr := strconv.Itoa(os.Getpid())
-	return os.WriteFile(s.getOpts().PidFile, []byte(pidStr), 0660)
+	return os.WriteFile(s.getOpts().PidFile, []byte(pidStr), defaultFilePerms)
 }
 
 // numReservedAccounts will return the number of reserved accounts configured in the server.


### PR DESCRIPTION
Filestore-owned items don't need to be group-accessible and log files don't need to be group-writable.

Reported-by: Trail of Bits <https://www.trailofbits.com>
Signed-off-by: Neil Twigg <neil@nats.io>