### PR TITLE
Fix clustered consumer resume on empty/zero PauseUntil

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -4586,6 +4586,8 @@ func (s *Server) jsConsumerPauseRequest(sub *subscription, c *client, _ *Account
 		pauseUTC := req.PauseUntil.UTC()
 		if !pauseUTC.IsZero() {
 			nca.Config.PauseUntil = &pauseUTC
+		} else {
+			nca.Config.PauseUntil = nil
 		}
 		eca := encodeAddConsumerAssignment(&nca)
 		cc.meta.Propose(eca)


### PR DESCRIPTION
Follow-up of: https://github.com/nats-io/nats-server/pull/5164

When sending a consumer resume request it would be handled for single-replica per above PR, but not for the clustered case. This PR ensures clustered consumers can also be resumed.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
