### PR TITLE
Fix `reflect.DeepEqual` both receiving pointers

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3799,7 +3799,8 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 			}
 			mset.setStreamAssignment(sa)
 			// Check if our config has really been updated.
-			if !reflect.DeepEqual(mset.config(), sa.Config) {
+			cfg := mset.config()
+			if !reflect.DeepEqual(&cfg, sa.Config) {
 				if err = mset.updateWithAdvisory(sa.Config, false, false); err != nil {
 					s.Warnf("JetStream cluster error updating stream %q for account %q: %v", sa.Config.Name, acc.Name, err)
 					if osa != nil {


### PR DESCRIPTION
In `processClusterCreateStream` there was a call to `reflect.DeepEqual` with different types making it always fail. `mset.config()` is the config itself, whereas `sa.Config` is a pointer to the config. So we need to pass `mset.config()` as a pointer instead.

In `processClusterCreateConsumer` this was done as well:
```go
cfg := o.config()
if isConfigUpdate = !reflect.DeepEqual(&cfg, ca.Config); isConfigUpdate {
```

<!-- Please make sure to read CONTRIBUTING.md, then delete this notice and replace it with your PR description. The below sign-off certifies that the contribution is your original work and that you license the work to the project under the Apache-2.0 license. We cannot accept contributions without it. -->

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
