### PR TITLE
Improve stream backup error reporting

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -8183,7 +8183,7 @@ func (fs *fileStore) stop(delete, writeState bool) error {
 const errFile = "errors.txt"
 
 // Stream our snapshot through S2 compression and tar.
-func (fs *fileStore) streamSnapshot(w io.WriteCloser, includeConsumers bool) {
+func (fs *fileStore) streamSnapshot(w io.WriteCloser, includeConsumers bool, errCh chan string) {
 	defer w.Close()
 
 	enc := s2.NewWriter(w)
@@ -8221,6 +8221,7 @@ func (fs *fileStore) streamSnapshot(w io.WriteCloser, includeConsumers bool) {
 
 	writeErr := func(err string) {
 		writeFile(errFile, []byte(err))
+		errCh <- err
 	}
 
 	fs.mu.Lock()
@@ -8396,9 +8397,10 @@ func (fs *fileStore) Snapshot(deadline time.Duration, checkMsgs, includeConsumer
 	fs.FastState(&state)
 
 	// Stream in separate Go routine.
-	go fs.streamSnapshot(pw, includeConsumers)
+	errCh := make(chan string, 1)
+	go fs.streamSnapshot(pw, includeConsumers, errCh)
 
-	return &SnapshotResult{pr, state}, nil
+	return &SnapshotResult{pr, state, errCh}, nil
 }
 
 // Helper to return the config.

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -8184,6 +8184,7 @@ const errFile = "errors.txt"
 
 // Stream our snapshot through S2 compression and tar.
 func (fs *fileStore) streamSnapshot(w io.WriteCloser, includeConsumers bool, errCh chan string) {
+	defer close(errCh)
 	defer w.Close()
 
 	enc := s2.NewWriter(w)

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -3838,6 +3838,14 @@ func (s *Server) streamSnapshot(acc *Account, mset *stream, sr *SnapshotResult, 
 		atomic.AddInt32(&out, int32(len(chunk)))
 	}
 done:
+	select {
+	case err, ok := <-sr.errCh:
+		if ok {
+			hdr = []byte(fmt.Sprintf("NATS/1.0 500 %s\r\n\r\n", err))
+		}
+	default:
+	}
+
 	// Send last EOF
 	// TODO(dlc) - place hash in header
 	mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -3838,12 +3838,8 @@ func (s *Server) streamSnapshot(acc *Account, mset *stream, sr *SnapshotResult, 
 		atomic.AddInt32(&out, int32(len(chunk)))
 	}
 done:
-	select {
-	case err, ok := <-sr.errCh:
-		if ok {
-			hdr = []byte(fmt.Sprintf("NATS/1.0 500 %s\r\n\r\n", err))
-		}
-	default:
+	if err := <-sr.errCh; err != _EMPTY_ {
+		hdr = []byte(fmt.Sprintf("NATS/1.0 500 %s\r\n\r\n", err))
 	}
 
 	// Send last EOF

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -3837,11 +3837,12 @@ func (s *Server) streamSnapshot(acc *Account, mset *stream, sr *SnapshotResult, 
 		mset.outq.send(newJSPubMsg(reply, _EMPTY_, ackReply, nil, chunk, nil, 0))
 		atomic.AddInt32(&out, int32(len(chunk)))
 	}
-done:
+
 	if err := <-sr.errCh; err != _EMPTY_ {
 		hdr = []byte(fmt.Sprintf("NATS/1.0 500 %s\r\n\r\n", err))
 	}
 
+done:
 	// Send last EOF
 	// TODO(dlc) - place hash in header
 	mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))

--- a/server/store.go
+++ b/server/store.go
@@ -180,6 +180,7 @@ type LostStreamData struct {
 type SnapshotResult struct {
 	Reader io.ReadCloser
 	State  StreamState
+	errCh  chan string
 }
 
 const (


### PR DESCRIPTION
Currently it's possible for errors to occur during the creation of a stream backup, but they are not properly reported to the user. Making it look like the backup was successful.

During stream backup, errors are reported through calling `writeErr`, which in turn writes an `errors.txt` file containing the error message:
https://github.com/nats-io/nats-server/blob/a07bde9fa7d499c7039f74cac9d11f4c046b9250/server/filestore.go#L8285-L8286

When performing a backup, for example through the CLI, even when this error is hit it reports as successful:
```
$ nats str backup stream stream-backup/
Starting backup of Stream "stream" with 10 MiB

386 KiB/s [=>--------------------------------------------]   4%

Received 386 KiB compressed data in 18 chunks for stream "stream" in 38ms, 13 MiB uncompressed
```

Because the error is only reported through `errors.txt` it's not easy to know if an error occurred, unless you take the tar+s2-ed output, undo those, and then read the contents.

There is also another way of reporting errors, namely in the EOF message which could contain an error like:
https://github.com/nats-io/nats-server/blob/a07bde9fa7d499c7039f74cac9d11f4c046b9250/server/jetstream_api.go#L3826

This is handled properly by the CLI/jsm.go. So I'd propose to keep the `errors.txt`, but also include the error message in EOF so it's easier to handle any errors.

Then the output of the CLI would look like:
```
$ nats str backup stream stream-backup/
Starting backup of Stream "stream" with 10 MiB

0 B/s [--------]   0%
error: snapshot failed: 500 Could not read message block [401]: message block data missing
```

Informing us the backup failed and it can't be used.


Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
