### PR TITLE
Fixed nightly code coverage [ci skip]

### DIFF
--- a/.github/workflows/cov.yaml
+++ b/.github/workflows/cov.yaml
@@ -22,7 +22,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21.x"
+          go-version-file: src/github.com/nats-io/nats-server/go.mod
+          cache-dependency-path: src/github.com/nats-io/nats-server/go.sum
 
       - name: Run code coverage
         shell: bash --noprofile --norc -x -eo pipefail {0}

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -17,6 +17,12 @@ check_file () {
 export GO111MODULE="on"
 
 go install github.com/wadey/gocovmerge@latest
+# Fail fast by checking if we can run gocovmerge
+gocovmerge
+if [[ $? != 0 ]]; then
+    echo "Unable to run gocovmerge"
+    exit 1
+fi
 
 rm -rf ./cov
 mkdir cov


### PR DESCRIPTION
The code coverage GA was referencing 1.21.x which seem to prevent the install of gocovmerge.
Also added an early check to see if we can run gocovmerge before starting the test suite.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>