### PR TITLE
On stream snapshot with CheckMsgs also forceWriteFullState

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -8382,7 +8382,13 @@ func (fs *fileStore) Snapshot(deadline time.Duration, checkMsgs, includeConsumer
 	}
 
 	// Write out full state as well before proceeding.
-	fs.writeFullState()
+	if checkMsgs {
+		// If we're checking for messages also force writing full meta state.
+		// Otherwise, state could be outdated due to it being skipped before.
+		fs.forceWriteFullState()
+	} else {
+		fs.writeFullState()
+	}
 
 	pr, pw := net.Pipe()
 

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -525,7 +525,7 @@ type JSApiStreamSnapshotRequest struct {
 	// Optional chunk size preference.
 	// Best to just let server select.
 	ChunkSize int `json:"chunk_size,omitempty"`
-	// Check all message's checksums prior to snapshot.
+	// Check all message's checksums prior to snapshot, and force full state to be written.
 	CheckMsgs bool `json:"jsck,omitempty"`
 }
 


### PR DESCRIPTION
Normally full state is written on an interval, but this is skipped if there are many (>1M) unique subjects or interior deletes.

https://github.com/nats-io/nats-server/blob/a07bde9fa7d499c7039f74cac9d11f4c046b9250/server/filestore.go#L7936-L7951

When making a backup there is no way to force this full state to be written, which means `index.db` could be stale under these conditions.

This PR proposes forcing the `index.db` to be written when a flag is set. Ensuring `index.db` can be updated even under above conditions.

Currently reusing `CheckMsgs` as that flag, to both check messages and force full state to be written. Looking at the CLI description that seems to be okay as it technically improves the "health" of `index.db`:
```
  --check           Checks the Stream for health prior to backup
```
Could also introduce another flag that decouples it, but that would mean the CLI would also need to be updated to include this option. Which method would be preferred?


Signed-off-by: Maurice van Veen <github@mauricevanveen.com>