### PR TITLE
Skip JS cluster 4 tests when running JS no cluster tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -114,7 +114,7 @@ jobs:
           go-version: stable
 
       - name: Run unit tests
-        run: go test -race -v -run=TestJetStream ./server/... -tags=skip_js_cluster_tests,skip_js_cluster_tests_2,skip_js_cluster_tests_3,skip_js_super_cluster_tests -count=1 -vet=off -timeout=30m -failfast
+        run: go test -race -v -run=TestJetStream ./server/... -tags=skip_js_cluster_tests,skip_js_cluster_tests_2,skip_js_cluster_tests_3,skip_js_cluster_tests_4,skip_js_super_cluster_tests -count=1 -vet=off -timeout=30m -failfast
 
   js-cluster-1:
     name: JetStream Cluster tests (1)


### PR DESCRIPTION
When running in GitHub actions JS cluster 4 tests would not be skipped when running JS no cluster tests.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
