### PR TITLE
[FIXED] Improvements to dealing with old or non-existant index.db

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1051,6 +1051,19 @@ func TestFileStoreStreamTruncate(t *testing.T) {
 		mb := fs.getFirstBlock()
 		require_True(t, mb != nil)
 		require_NoError(t, mb.loadMsgs())
+
+		// Also make sure we can recover properly with no index.db present.
+		// We want to make sure we preserve tombstones from any blocks being deleted.
+		fs.Stop()
+		os.Remove(filepath.Join(fs.fcfg.StoreDir, msgDir, streamStreamStateFile))
+
+		fs, err = newFileStoreWithCreated(fcfg, cfg, created, prf(&fcfg), nil)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		if state := fs.State(); !reflect.DeepEqual(state, before) {
+			t.Fatalf("Expected state of %+v, got %+v without index.db state", before, state)
+		}
 	})
 }
 
@@ -3635,11 +3648,16 @@ func TestFileStorePurgeExWithSubject(t *testing.T) {
 	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
 		fcfg.BlockSize = 1000
 		cfg := StreamConfig{Name: "TEST", Subjects: []string{"foo.>"}, Storage: FileStorage}
-		fs, err := newFileStoreWithCreated(fcfg, cfg, time.Now(), prf(&fcfg), nil)
+		created := time.Now()
+		fs, err := newFileStoreWithCreated(fcfg, cfg, created, prf(&fcfg), nil)
 		require_NoError(t, err)
 		defer fs.Stop()
 
 		payload := make([]byte, 20)
+
+		_, _, err = fs.StoreMsg("foo.0", nil, payload)
+		require_NoError(t, err)
+
 		total := 200
 		for i := 0; i < total; i++ {
 			_, _, err = fs.StoreMsg("foo.1", nil, payload)
@@ -3648,13 +3666,38 @@ func TestFileStorePurgeExWithSubject(t *testing.T) {
 		_, _, err = fs.StoreMsg("foo.2", nil, []byte("xxxxxx"))
 		require_NoError(t, err)
 
-		// This should purge all.
+		// This should purge all "foo.1"
 		p, err := fs.PurgeEx("foo.1", 1, 0)
 		require_NoError(t, err)
-		require_True(t, int(p) == total)
-		require_True(t, int(p) == total)
-		require_True(t, fs.State().Msgs == 1)
-		require_True(t, fs.State().FirstSeq == 201)
+		require_Equal(t, p, uint64(total))
+
+		state := fs.State()
+		require_Equal(t, state.Msgs, 2)
+		require_Equal(t, state.FirstSeq, 1)
+
+		// Make sure we can recover same state.
+		fs.Stop()
+		fs, err = newFileStoreWithCreated(fcfg, cfg, created, prf(&fcfg), nil)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		before := state
+		if state := fs.State(); !reflect.DeepEqual(state, before) {
+			t.Fatalf("Expected state of %+v, got %+v", before, state)
+		}
+
+		// Also make sure we can recover properly with no index.db present.
+		// We want to make sure we preserve any tombstones from the subject based purge.
+		fs.Stop()
+		os.Remove(filepath.Join(fs.fcfg.StoreDir, msgDir, streamStreamStateFile))
+
+		fs, err = newFileStoreWithCreated(fcfg, cfg, created, prf(&fcfg), nil)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		if state := fs.State(); !reflect.DeepEqual(state, before) {
+			t.Fatalf("Expected state of %+v, got %+v without index.db state", before, state)
+		}
 	})
 }
 
@@ -7555,6 +7598,47 @@ func TestFileStoreSyncCompressOnlyIfDirty(t *testing.T) {
 	fs.mu.Unlock()
 	// Verify that since we deleted a message we should be considered for compaction again in syncBlocks().
 	require_False(t, noCompact)
+}
+
+// This test is for deleted interior message tracking after compaction from limits based deletes, meaning no tombstones.
+// Bug was that dmap would not be properly be hydrated after the compact from rebuild. But we did so in populateGlobalInfo.
+// So this is just to fix a bug in rebuildState tracking gaps after a compact.
+func TestFileStoreDmapBlockRecoverAfterCompact(t *testing.T) {
+	sd := t.TempDir()
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: sd, BlockSize: 256},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo.*"}, Storage: FileStorage, MaxMsgsPer: 1})
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	msg := []byte("hello")
+
+	// 6 msgs per block.
+	// Fill the first block.
+	for i := 1; i <= 6; i++ {
+		fs.StoreMsg(fmt.Sprintf("foo.%d", i), nil, msg)
+	}
+	require_Equal(t, fs.numMsgBlocks(), 1)
+
+	// Now create holes in the first block via the max msgs per subject of 1.
+	for i := 2; i < 6; i++ {
+		fs.StoreMsg(fmt.Sprintf("foo.%d", i), nil, msg)
+	}
+	require_Equal(t, fs.numMsgBlocks(), 2)
+	// Compact and rebuild the first blk. Do not have it call indexCacheBuf which will fix it up.
+	mb := fs.getFirstBlock()
+	mb.mu.Lock()
+	mb.compact()
+	// Empty out dmap state.
+	mb.dmap.Empty()
+	ld, tombs, err := mb.rebuildStateLocked()
+	dmap := mb.dmap.Clone()
+	mb.mu.Unlock()
+
+	require_NoError(t, err)
+	require_Equal(t, ld, nil)
+	require_Equal(t, len(tombs), 0)
+	require_Equal(t, dmap.Size(), 4)
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -10838,3 +10838,68 @@ func TestNoRaceJetStreamStandaloneDontReplyToAckBeforeProcessingIt(t *testing.T)
 		}
 	}
 }
+
+// Under certain scenarios an old index.db with a stream that has max msgs per set will not restore properly
+// due to and old index.db and compaction after the index.db took place which could lose per subject information.
+func TestNoRaceFileStoreMaxMsgsPerSubjectAndOldRecoverState(t *testing.T) {
+	sd := t.TempDir()
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: sd},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo.*"}, Storage: FileStorage, MaxMsgsPer: 1})
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	msg := make([]byte, 1024)
+
+	for i := 0; i < 10_000; i++ {
+		subj := fmt.Sprintf("foo.%d", i)
+		fs.StoreMsg(subj, nil, msg)
+	}
+
+	// This will write the index.db file. We will capture this and use it to replace a new one.
+	sfile := filepath.Join(fs.fcfg.StoreDir, msgDir, streamStreamStateFile)
+	fs.Stop()
+	_, err = os.Stat(sfile)
+	require_NoError(t, err)
+
+	// Read it in and make sure len > 0.
+	buf, err := os.ReadFile(sfile)
+	require_NoError(t, err)
+	require_True(t, len(buf) > 0)
+
+	// Restart
+	fs, err = newFileStore(
+		FileStoreConfig{StoreDir: sd},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo.*"}, Storage: FileStorage, MaxMsgsPer: 1})
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	// Put in more messages with wider range. This will compact a bunch of the previous blocks.
+	for i := 0; i < 1_000_001; i++ {
+		subj := fmt.Sprintf("foo.%d", i)
+		fs.StoreMsg(subj, nil, msg)
+	}
+
+	var ss StreamState
+	fs.FastState(&ss)
+	require_Equal(t, ss.FirstSeq, 10_001)
+	require_Equal(t, ss.LastSeq, 1_010_001)
+	require_Equal(t, ss.Msgs, 1_000_001)
+
+	// Now stop again, but replace index.db with old one.
+	fs.Stop()
+	// Put back old stream state.
+	require_NoError(t, os.WriteFile(sfile, buf, defaultFilePerms))
+
+	// Restart
+	fs, err = newFileStore(
+		FileStoreConfig{StoreDir: sd},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo.*"}, Storage: FileStorage, MaxMsgsPer: 1})
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	fs.FastState(&ss)
+	require_Equal(t, ss.FirstSeq, 10_001)
+	require_Equal(t, ss.LastSeq, 1_010_001)
+	require_Equal(t, ss.Msgs, 1_000_001)
+}


### PR DESCRIPTION
We had a condition where an old index.db was not able to properly restore a stream due to max msgs per subject being set and certain blocks being compacted away and removing subject info for those sequences. In addition we fixed recovery after Truncate and PurgeEx by subject when the index.db was corrupt or not available.

This change also moves generating the index.db file to after writing the blocks during a snapshot and we do a force call to make sure it is written even when complex.

Signed-off-by: Derek Collison <derek@nats.io>

