### PR TITLE
(2.11) Internal: Intra-Process Queue fixes/improvements.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3958,12 +3958,12 @@ func (o *consumer) processInboundAcks(qch chan struct{}) {
 	for {
 		select {
 		case <-o.ackMsgs.ch:
-			acks := o.ackMsgs.pop()
+			acks, ql, qsz := o.ackMsgs.pop()
 			for _, ack := range acks {
 				o.processAck(ack.subject, ack.reply, ack.hdr, ack.msg)
 				ack.returnToPool()
 			}
-			o.ackMsgs.recycle(&acks)
+			o.ackMsgs.recycle(acks, ql, qsz)
 			// If we have an inactiveThreshold set, mark our activity.
 			if hasInactiveThresh {
 				o.suppressDeletion()
@@ -3988,12 +3988,12 @@ func (o *consumer) processInboundNextMsgReqs(qch chan struct{}) {
 	for {
 		select {
 		case <-o.nextMsgReqs.ch:
-			reqs := o.nextMsgReqs.pop()
+			reqs, ql, qsz := o.nextMsgReqs.pop()
 			for _, req := range reqs {
 				o.processNextMsgRequest(req.reply, req.msg)
 				req.returnToPool()
 			}
-			o.nextMsgReqs.recycle(&reqs)
+			o.nextMsgReqs.recycle(reqs, ql, qsz)
 		case <-qch:
 			return
 		case <-s.quitCh:

--- a/server/ipqueue.go
+++ b/server/ipqueue.go
@@ -115,7 +115,7 @@ func newIPQueue[T any](s *Server, name string, opts ...ipQueueOpt[T]) *ipQueue[T
 // If the queue has limits, this function checks against what is currently in
 // the queue in addition to the "in progress" elements (the ones that were
 // returned by `pop()`). It will return `errIPQLenLimitReached` or
-// `errIPQSizeLimitReached` if adding the element would have go over the length
+// `errIPQSizeLimitReached` if adding the element would have gone over the length
 // or size limit respectively.
 func (q *ipQueue[T]) push(e T) (int, uint64, error) {
 	var sz uint64
@@ -182,7 +182,7 @@ func (q *ipQueue[T]) pop() ([]T, int64, uint64) {
 	}
 	var elts []T
 	q.Lock()
-	if len(q.elts) == 0 {
+	if len(q.elts)-q.pos == 0 {
 		q.Unlock()
 		return nil, 0, 0
 	}
@@ -215,11 +215,6 @@ func (q *ipQueue[T]) pop() ([]T, int64, uint64) {
 // default empty value.
 func (q *ipQueue[T]) popOne() (T, bool) {
 	q.Lock()
-	if q.elts == nil {
-		q.Unlock()
-		var empty T
-		return empty, false
-	}
 	l := len(q.elts) - q.pos
 	if l == 0 {
 		q.Unlock()
@@ -300,9 +295,6 @@ func (q *ipQueue[T]) processed(e T, ql *int64, qsz *uint64) {
 func (q *ipQueue[T]) len() int {
 	q.Lock()
 	defer q.Unlock()
-	if q.elts == nil {
-		return 0
-	}
 	return len(q.elts) - q.pos
 }
 

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -2212,7 +2212,7 @@ func (as *mqttAccountSessionManager) sendJSAPIrequests(s *Server, c *client, acc
 	for {
 		select {
 		case <-sendq.ch:
-			pmis := sendq.pop()
+			pmis, ql, qsz := sendq.pop()
 			for _, r := range pmis {
 				var nsize int
 
@@ -2251,7 +2251,7 @@ func (as *mqttAccountSessionManager) sendJSAPIrequests(s *Server, c *client, acc
 				c.processInboundClientMsg(msg)
 				c.flushClients(0)
 			}
-			sendq.recycle(&pmis)
+			sendq.recycle(pmis, ql, qsz)
 
 		case <-closeCh:
 			return

--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -167,11 +167,11 @@ func smLoop(sm stateMachine) {
 		case <-qch:
 			return
 		case <-aq.ch:
-			ces := aq.pop()
+			ces, ql, qsz := aq.pop()
 			for _, ce := range ces {
 				sm.applyEntry(ce)
 			}
-			aq.recycle(&ces)
+			aq.recycle(ces, ql, qsz)
 
 		case isLeader := <-lch:
 			sm.leaderChange(isLeader)

--- a/server/sendq.go
+++ b/server/sendq.go
@@ -64,7 +64,7 @@ func (sq *sendq) internalLoop() {
 		case <-s.quitCh:
 			return
 		case <-q.ch:
-			pms := q.pop()
+			pms, ql, qsz := q.pop()
 			for _, pm := range pms {
 				c.pa.subject = append(subj[:0], pm.subj...)
 				c.pa.size = len(pm.msg) + len(pm.hdr)
@@ -91,7 +91,7 @@ func (sq *sendq) internalLoop() {
 			}
 			// TODO: should this be in the for-loop instead?
 			c.flushClients(0)
-			q.recycle(&pms)
+			q.recycle(pms, ql, qsz)
 		}
 	}
 }


### PR DESCRIPTION
Go says that when using pool we should use pointer to a slice, not the slice itself to save on copy when getting/putting things back.

That's what I tried to do, but I believe that the gain was defeated by the fact that I was storing it as a []T in the queue object, and more importantly, was returning the address of the local variable when putting back in the pool. The way it was used worked, but is dangerous if queues were to be use differently. For instance with implementation before this change, this in a loop would fail:
```
var elts []int
for i:=0;i<1000;i++{
    q.push(i+1)
    expected += i+1
    elts = q.pop()
    for _, v := range elts {
        sum += v
    }
    q.recycle(&elts)

    q.push(i+2)
    expected += i+2
    elts = q.pop()

    q.push(i+3)
    expected += i+3

    for _, v := range elts {
        sum += v
    }
    q.recycle(&elts)

    elts = q.pop()
    for _, v := range elts {
        sum += v
    }
    q.recycle(&elts)
}
if sum != expected {
   // ERROR!
}
```
If we use different variables, such as `elts1 := q.pop()`, etc.. then it works. And again, the way it was used before did not cause issues.

The changes here use a pointer to a `[]T` all the way.

I have tried dummy queue implementations of simply using `[]T` all the way, including when putting it back to the pool, and the perf and number of allocs etc... does not seem to change regardless of what I was using. However, with the real queue implementation, it somehow changes, so sticking with `*[T]` for now.

The other changes are to use the "in progress" count (and now size) when checking for the limits, which we were not. So after a `pop()`, since the queue is empty, the `push()` side would be able to store up to the limits while the receiver was processing the popped elements.

I have added APIs to indicate progress when processing elements in the "for-loop" that goes over the `pop()` result. I have modified code that uses a queue with limit (only 2 so far) so that they use the new API.

I have added benchmarks so we can evaluate future changes. Aside from the modifications to queue with limits, running the benchmark from original code to new shows a slight improvement. Of course, updating progress for each element popped() is slower than doing as a bulk, but it allows for fine-grained control on the queue limits. And when using with processing of JetStream messages, it is likely that the effect is not relevant.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
