### PR TITLE
Empty `cluster_traffic` value should default to `"system"` in JWT

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3687,10 +3687,10 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 		a.mu.Lock()
 		previous := ajs.nrgAccount
 		switch tokens := strings.SplitN(ac.ClusterTraffic, ":", 2); tokens[0] {
-		case "system":
-			a.js.nrgAccount = _EMPTY_
+		case "system", _EMPTY_:
+			ajs.nrgAccount = _EMPTY_
 		case "owner":
-			a.js.nrgAccount = a.Name
+			ajs.nrgAccount = a.Name
 		default:
 			s.Errorf("Account claim for %q has invalid value %q for cluster traffic account", a.Name, ac.ClusterTraffic)
 		}

--- a/server/opts.go
+++ b/server/opts.go
@@ -2147,7 +2147,7 @@ func parseJetStreamForAccount(v any, acc *Account, errors *[]error) error {
 					return &configErr{tk, fmt.Sprintf("Expected either 'system' or 'account' string value for %q, got %v", mk, mv)}
 				}
 				switch tokens := strings.SplitN(vv, ":", 2); strings.ToLower(tokens[0]) {
-				case "system":
+				case "system", _EMPTY_:
 					acc.js.nrgAccount = _EMPTY_
 				case "owner":
 					acc.js.nrgAccount = acc.Name


### PR DESCRIPTION
Avoids unnecessary `has invalid value "" for cluster traffic account` error.

Signed-off-by: Neil Twigg <neil@nats.io>
