### PR TITLE
[FIXED] Also recover on old index.db when not using MaxMsgsPer

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -10842,67 +10842,111 @@ func TestNoRaceJetStreamStandaloneDontReplyToAckBeforeProcessingIt(t *testing.T)
 	}
 }
 
-// Under certain scenarios an old index.db with a stream that has max msgs per set will not restore properly
-// due to and old index.db and compaction after the index.db took place which could lose per subject information.
-func TestNoRaceFileStoreMaxMsgsPerSubjectAndOldRecoverState(t *testing.T) {
-	sd := t.TempDir()
-	fs, err := newFileStore(
-		FileStoreConfig{StoreDir: sd},
-		StreamConfig{Name: "zzz", Subjects: []string{"foo.*"}, Storage: FileStorage, MaxMsgsPer: 1})
-	require_NoError(t, err)
-	defer fs.Stop()
+// Under certain scenarios an old index.db with a stream that has msg limits set will not restore properly
+// due to an old index.db and compaction after the index.db took place which could lose per subject information.
+func TestNoRaceFileStoreMsgLimitsAndOldRecoverState(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		expectedFirstSeq uint64
+		expectedLastSeq  uint64
+		expectedMsgs     uint64
+		transform        func(StreamConfig) StreamConfig
+	}{
+		{
+			name:             "MaxMsgsPer",
+			expectedFirstSeq: 10_001,
+			expectedLastSeq:  1_010_001,
+			expectedMsgs:     1_000_001,
+			transform: func(config StreamConfig) StreamConfig {
+				config.MaxMsgsPer = 1
+				return config
+			},
+		},
+		{
+			name:             "MaxMsgs",
+			expectedFirstSeq: 10_001,
+			expectedLastSeq:  1_010_001,
+			expectedMsgs:     1_000_001,
+			transform: func(config StreamConfig) StreamConfig {
+				config.MaxMsgs = 1_000_001
+				return config
+			},
+		},
+		{
+			name:             "MaxBytes",
+			expectedFirstSeq: 8_624,
+			expectedLastSeq:  1_010_001,
+			expectedMsgs:     1_001_378,
+			transform: func(config StreamConfig) StreamConfig {
+				config.MaxBytes = 1_065_353_216
+				return config
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			sd := t.TempDir()
+			fs, err := newFileStore(
+				FileStoreConfig{StoreDir: sd},
+				test.transform(StreamConfig{Name: "zzz", Subjects: []string{"foo.*"}, Storage: FileStorage}),
+			)
+			require_NoError(t, err)
+			defer fs.Stop()
 
-	msg := make([]byte, 1024)
+			msg := make([]byte, 1024)
 
-	for i := 0; i < 10_000; i++ {
-		subj := fmt.Sprintf("foo.%d", i)
-		fs.StoreMsg(subj, nil, msg)
+			for i := 0; i < 10_000; i++ {
+				subj := fmt.Sprintf("foo.%d", i)
+				fs.StoreMsg(subj, nil, msg)
+			}
+
+			// This will write the index.db file. We will capture this and use it to replace a new one.
+			sfile := filepath.Join(fs.fcfg.StoreDir, msgDir, streamStreamStateFile)
+			fs.Stop()
+			_, err = os.Stat(sfile)
+			require_NoError(t, err)
+
+			// Read it in and make sure len > 0.
+			buf, err := os.ReadFile(sfile)
+			require_NoError(t, err)
+			require_True(t, len(buf) > 0)
+
+			// Restart
+			fs, err = newFileStore(
+				FileStoreConfig{StoreDir: sd},
+				test.transform(StreamConfig{Name: "zzz", Subjects: []string{"foo.*"}, Storage: FileStorage}),
+			)
+			require_NoError(t, err)
+			defer fs.Stop()
+
+			// Put in more messages with wider range. This will compact a bunch of the previous blocks.
+			for i := 0; i < 1_000_001; i++ {
+				subj := fmt.Sprintf("foo.%d", i)
+				fs.StoreMsg(subj, nil, msg)
+			}
+
+			var ss StreamState
+			fs.FastState(&ss)
+			require_Equal(t, ss.FirstSeq, test.expectedFirstSeq)
+			require_Equal(t, ss.LastSeq, test.expectedLastSeq)
+			require_Equal(t, ss.Msgs, test.expectedMsgs)
+
+			// Now stop again, but replace index.db with old one.
+			fs.Stop()
+			// Put back old stream state.
+			require_NoError(t, os.WriteFile(sfile, buf, defaultFilePerms))
+
+			// Restart
+			fs, err = newFileStore(
+				FileStoreConfig{StoreDir: sd},
+				test.transform(StreamConfig{Name: "zzz", Subjects: []string{"foo.*"}, Storage: FileStorage}),
+			)
+			require_NoError(t, err)
+			defer fs.Stop()
+
+			fs.FastState(&ss)
+			require_Equal(t, ss.FirstSeq, test.expectedFirstSeq)
+			require_Equal(t, ss.LastSeq, test.expectedLastSeq)
+			require_Equal(t, ss.Msgs, test.expectedMsgs)
+		})
 	}
-
-	// This will write the index.db file. We will capture this and use it to replace a new one.
-	sfile := filepath.Join(fs.fcfg.StoreDir, msgDir, streamStreamStateFile)
-	fs.Stop()
-	_, err = os.Stat(sfile)
-	require_NoError(t, err)
-
-	// Read it in and make sure len > 0.
-	buf, err := os.ReadFile(sfile)
-	require_NoError(t, err)
-	require_True(t, len(buf) > 0)
-
-	// Restart
-	fs, err = newFileStore(
-		FileStoreConfig{StoreDir: sd},
-		StreamConfig{Name: "zzz", Subjects: []string{"foo.*"}, Storage: FileStorage, MaxMsgsPer: 1})
-	require_NoError(t, err)
-	defer fs.Stop()
-
-	// Put in more messages with wider range. This will compact a bunch of the previous blocks.
-	for i := 0; i < 1_000_001; i++ {
-		subj := fmt.Sprintf("foo.%d", i)
-		fs.StoreMsg(subj, nil, msg)
-	}
-
-	var ss StreamState
-	fs.FastState(&ss)
-	require_Equal(t, ss.FirstSeq, 10_001)
-	require_Equal(t, ss.LastSeq, 1_010_001)
-	require_Equal(t, ss.Msgs, 1_000_001)
-
-	// Now stop again, but replace index.db with old one.
-	fs.Stop()
-	// Put back old stream state.
-	require_NoError(t, os.WriteFile(sfile, buf, defaultFilePerms))
-
-	// Restart
-	fs, err = newFileStore(
-		FileStoreConfig{StoreDir: sd},
-		StreamConfig{Name: "zzz", Subjects: []string{"foo.*"}, Storage: FileStorage, MaxMsgsPer: 1})
-	require_NoError(t, err)
-	defer fs.Stop()
-
-	fs.FastState(&ss)
-	require_Equal(t, ss.FirstSeq, 10_001)
-	require_Equal(t, ss.LastSeq, 1_010_001)
-	require_Equal(t, ss.Msgs, 1_000_001)
 }


### PR DESCRIPTION
Extension to https://github.com/nats-io/nats-server/pull/5893

If we can't update the index.db upon shutdown, for example during a hard kill, we'd enter into this condition if `MaxMsgsPer` was set.
https://github.com/nats-io/nats-server/pull/5893/files#diff-384c189826934c9a6fc3554dafc63dab2076245010e3d6fce5c71a93e15e9877R1752

However, all limits-based fields have this issue not just `MaxMsgsPer`.
Running similar tests where `nats str info` before hard kill should equal its output after hard kill:
- `MaxMsgsPer`: −7,877 diff (fixed with addition of above condition/PR)
- `MaxMsgs`: +2,123 diff
- `MaxAge`: no diff (correct messages, but still `[WRN] Filestore [stream] loadBlock error: message block data missing`)
- `MaxBytes`: +3,567 diff (had a MaxBytes set of 1016 MiB, but after restart the state has more messages and Bytes: 1020 MiB)

I think we shouldn't only target `MaxMsgsPer`, since other fields can also trigger this and making it specific to also include these other fields would come back to bite if we add other limits-based fields in the future and forget to add it in this condition.
We need to detect index.db was not written during shutdown or there is a difference between index.db and our msg blocks. If we detect this we can't rely on it being correct still, so I'd propose to simplify and upon detecting defer to rebuilding.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
