### PR TITLE
[ADDED] Delay option to js_cluster_migrate

### DIFF
--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -1135,6 +1135,16 @@ func (s *Server) setJetStreamMigrateOnRemoteLeaf() {
 	s.mu.Unlock()
 }
 
+// Helper to set the remote migrate feature.
+func (s *Server) setJetStreamMigrateOnRemoteLeafWithDelay(delay time.Duration) {
+	s.mu.Lock()
+	for _, cfg := range s.leafRemoteCfgs {
+		cfg.JetStreamClusterMigrate = true
+		cfg.JetStreamClusterMigrateDelay = delay
+	}
+	s.mu.Unlock()
+}
+
 // Will add in the mapping for the account to each server.
 func (c *cluster) addSubjectMapping(account, src, dest string) {
 	c.t.Helper()

--- a/server/jetstream_leafnode_test.go
+++ b/server/jetstream_leafnode_test.go
@@ -1324,3 +1324,106 @@ func TestJetStreamLeafNodeJSClusterMigrateRecovery(t *testing.T) {
 	// long election timer. Now this should work reliably.
 	lnc.waitOnStreamLeader(globalAccountName, "TEST")
 }
+
+func TestJetStreamLeafNodeJSClusterMigrateRecoveryWithDelay(t *testing.T) {
+	tmpl := strings.Replace(jsClusterAccountsTempl, "store_dir:", "domain: hub, store_dir:", 1)
+	c := createJetStreamCluster(t, tmpl, "hub", _EMPTY_, 3, 12232, true)
+	defer c.shutdown()
+
+	tmpl = strings.Replace(jsClusterTemplWithLeafNode, "store_dir:", "domain: leaf, store_dir:", 1)
+	lnc := c.createLeafNodesWithTemplateAndStartPort(tmpl, "leaf", 3, 23913)
+	defer lnc.shutdown()
+
+	lnc.waitOnClusterReady()
+	delay := 5 * time.Second
+	for _, s := range lnc.servers {
+		s.setJetStreamMigrateOnRemoteLeafWithDelay(delay)
+	}
+
+	nc, _ := jsClientConnect(t, lnc.randomServer())
+	defer nc.Close()
+
+	ljs, err := nc.JetStream(nats.Domain("leaf"))
+	require_NoError(t, err)
+
+	// Create an asset in the leafnode cluster.
+	si, err := ljs.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+	require_Equal(t, si.Cluster.Name, "leaf")
+	require_NotEqual(t, si.Cluster.Leader, noLeader)
+	require_Equal(t, len(si.Cluster.Replicas), 2)
+
+	// Count how many remotes each server in the leafnode cluster is
+	// supposed to have and then take them down.
+	remotes := map[*Server]int{}
+	for _, s := range lnc.servers {
+		remotes[s] += len(s.leafRemoteCfgs)
+		s.closeAndDisableLeafnodes()
+		checkLeafNodeConnectedCount(t, s, 0)
+	}
+
+	// The Raft nodes in the leafnode cluster now need some time to
+	// notice that they're no longer receiving AEs from a leader, as
+	// they should have been forced into observer mode. Check that
+	// this is the case.
+	// We expect the nodes to become observers after the delay time.
+	now := time.Now()
+	timeout := maxElectionTimeout + delay
+	success := false
+	for time.Since(now) <= timeout {
+		allObservers := true
+		for _, s := range lnc.servers {
+			s.rnMu.RLock()
+			for name, n := range s.raftNodes {
+				if name == defaultMetaGroupName {
+					require_False(t, n.IsObserver())
+				} else if n.IsObserver() {
+					// Make sure the migration delay is respected.
+					require_True(t, time.Since(now) > time.Duration(float64(delay)*0.7))
+				} else {
+					allObservers = false
+				}
+			}
+			s.rnMu.RUnlock()
+		}
+		if allObservers {
+			success = true
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	require_True(t, success)
+
+	// Bring the leafnode connections back up.
+	for _, s := range lnc.servers {
+		s.reEnableLeafnodes()
+		checkLeafNodeConnectedCount(t, s, remotes[s])
+	}
+
+	// Wait for nodes to notice they are no longer in observer mode
+	// and to leave observer mode.
+	time.Sleep(maxElectionTimeout)
+	for _, s := range lnc.servers {
+		s.rnMu.RLock()
+		for _, n := range s.raftNodes {
+			require_False(t, n.IsObserver())
+		}
+		s.rnMu.RUnlock()
+	}
+
+	// Make sure all delay timers in remotes are disabled
+	for _, s := range lnc.servers {
+		for _, r := range s.leafRemoteCfgs {
+			require_True(t, r.jsMigrateTimer == nil)
+		}
+	}
+
+	// Previously nodes would have left observer mode but then would
+	// have failed to elect a stream leader as they were stuck on a
+	// long election timer. Now this should work reliably.
+	lnc.waitOnStreamLeader(globalAccountName, "TEST")
+}

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -494,7 +494,7 @@ func (s *Server) connectToRemoteLeafNode(remote *leafNodeCfg, firstConnect bool)
 
 	opts := s.getOpts()
 	reconnectDelay := opts.LeafNode.ReconnectInterval
-	s.mu.Lock()
+	s.mu.RLock()
 	dialTimeout := s.leafNodeOpts.dialTimeout
 	resolver := s.leafNodeOpts.resolver
 	var isSysAcc bool
@@ -502,7 +502,7 @@ func (s *Server) connectToRemoteLeafNode(remote *leafNodeCfg, firstConnect bool)
 		isSysAcc = remote.LocalAccount == s.sys.account.Name
 	}
 	jetstreamMigrateDelay := remote.JetStreamClusterMigrateDelay
-	s.mu.Unlock()
+	s.mu.RUnlock()
 
 	// If we are sharing a system account and we are not standalone delay to gather some info prior.
 	if firstConnect && isSysAcc && !s.standAloneMode() {

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -591,10 +591,7 @@ func (s *Server) connectToRemoteLeafNode(remote *leafNodeCfg, firstConnect bool)
 
 func (cfg *leafNodeCfg) cancelMigrateTimer() {
 	cfg.Lock()
-	if cfg.jsMigrateTimer != nil {
-		cfg.jsMigrateTimer.Stop()
-		cfg.jsMigrateTimer = nil
-	}
+	stopAndClearTimer(&cfg.jsMigrateTimer)
 	cfg.Unlock()
 }
 

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -2540,6 +2540,57 @@ func TestParsingLeafNodeRemotes(t *testing.T) {
 			t.Fatal("Expected urls to be random")
 		}
 	})
+
+	t.Run("parse config file js_cluster_migrate", func(t *testing.T) {
+		content := `
+		leafnodes {
+			remotes = [
+				{
+					url: nats-leaf://127.0.0.1:2222
+					account: foo // Local Account to bind to..
+					credentials: "./my.creds"
+					js_cluster_migrate: true
+				},
+				{
+					url: nats-leaf://127.0.0.1:2222
+					account: bar // Local Account to bind to..
+					credentials: "./my.creds"
+					js_cluster_migrate: {
+						delay: 30s
+					}
+				}
+			]
+		}
+		`
+		conf := createConfFile(t, []byte(content))
+		opts, err := ProcessConfigFile(conf)
+		if err != nil {
+			t.Fatalf("Error processing file: %v", err)
+		}
+		if len(opts.LeafNode.Remotes) != 2 {
+			t.Fatalf("Expected 2 remote, got %d", len(opts.LeafNode.Remotes))
+		}
+		u, _ := url.Parse("nats-leaf://127.0.0.1:2222")
+		expected := []*RemoteLeafOpts{
+			{
+				URLs:                    []*url.URL{u},
+				LocalAccount:            "foo",
+				Credentials:             "./my.creds",
+				JetStreamClusterMigrate: true,
+			},
+			{
+				URLs:                         []*url.URL{u},
+				LocalAccount:                 "bar",
+				Credentials:                  "./my.creds",
+				JetStreamClusterMigrate:      true,
+				JetStreamClusterMigrateDelay: 30 * time.Second,
+			},
+		}
+		if !reflect.DeepEqual(opts.LeafNode.Remotes, expected) {
+			t.Fatalf("Expected %v, got %v", expected, opts.LeafNode.Remotes)
+		}
+	})
+
 }
 
 func TestLargeMaxControlLine(t *testing.T) {

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -2556,8 +2556,14 @@ func TestParsingLeafNodeRemotes(t *testing.T) {
 					account: bar // Local Account to bind to..
 					credentials: "./my.creds"
 					js_cluster_migrate: {
-						delay: 30s
+						leader_migrate_delay: 30s
 					}
+				},
+				{
+					url: nats-leaf://127.0.0.1:2222
+					account: baz // Local Account to bind to..
+					credentials: "./my.creds"
+					js_cluster_migrate: false
 				}
 			]
 		}
@@ -2567,7 +2573,7 @@ func TestParsingLeafNodeRemotes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error processing file: %v", err)
 		}
-		if len(opts.LeafNode.Remotes) != 2 {
+		if len(opts.LeafNode.Remotes) != 3 {
 			t.Fatalf("Expected 2 remote, got %d", len(opts.LeafNode.Remotes))
 		}
 		u, _ := url.Parse("nats-leaf://127.0.0.1:2222")
@@ -2584,6 +2590,12 @@ func TestParsingLeafNodeRemotes(t *testing.T) {
 				Credentials:                  "./my.creds",
 				JetStreamClusterMigrate:      true,
 				JetStreamClusterMigrateDelay: 30 * time.Second,
+			},
+			{
+				URLs:                    []*url.URL{u},
+				LocalAccount:            "baz",
+				Credentials:             "./my.creds",
+				JetStreamClusterMigrate: false,
 			},
 		}
 		if !reflect.DeepEqual(opts.LeafNode.Remotes, expected) {


### PR DESCRIPTION
This adds a `delay` option to `js_cluster_migrate` as an option in nested object. The assets assets will only be migrated after the specified delay (rather than immediately, which is the default).

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)
