### PR TITLE
Add placeholder workflow for long-running server tests

### DIFF
--- a/.github/workflows/long-tests.yaml
+++ b/.github/workflows/long-tests.yaml
@@ -1,0 +1,18 @@
+name: NATS Server Long-Running Tests
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  # At most one of these workflow per ref running
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # New one cancels in-progress one
+  cancel-in-progress: true
+
+jobs:
+  placeholder:
+    name: Placeholder job
+    runs-on: ${{ vars.GHA_WORKER_SMALL }}
+    steps:
+      - name: Dummy step
+        run: echo "Hello World"


### PR DESCRIPTION
Create a dummy workflow, only triggered by manual user action.

The existence of this workflow on the main branch enables development  and testing of the same workflow in a different branch.

Signed-off-by: Your Name <marco@nats.io>
