### PR TITLE
[FIXED] LeafNode: Don't report cluster name in varz/banner when none defined

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1592,6 +1592,11 @@ func (s *Server) createVarz(pcpu float64, rss int64) *Varz {
 		TrustedOperatorsJwt:   opts.operatorJWT,
 		TrustedOperatorsClaim: opts.TrustedOperators,
 	}
+	// If this is a leaf without cluster, reset the cluster name (that is otherwise
+	// set to the server name).
+	if s.leafNoCluster {
+		varz.Cluster.Name = _EMPTY_
+	}
 	if len(opts.Routes) > 0 {
 		varz.Cluster.URLs = urlsToStrings(opts.Routes)
 	}

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -3138,6 +3138,14 @@ func TestMonitorLeafNode(t *testing.T) {
 	for mode := 0; mode < 2; mode++ {
 		check := func(t *testing.T, v *Varz) {
 			t.Helper()
+			// Issue 5913. When we have solicited leafnodes but no clustering
+			// and no clustername, we may need a stable clustername so we use
+			// the server name as cluster name. However, we should not expose
+			// it in /varz.
+			if v.Cluster.Name != _EMPTY_ {
+				t.Fatalf("mode=%v - unexpected cluster name: %s", mode, v.Cluster.Name)
+			}
+			// Check rest is as expected.
 			if !reflect.DeepEqual(v.LeafNode, expected) {
 				t.Fatalf("mode=%v - expected %+v, got %+v", mode, expected, v.LeafNode)
 			}


### PR DESCRIPTION
In situation where a Leaf server has no cluster specified, we internally use the server name as the cluster name. We may need it in the protocol so that the hub can suppress some messages to avoid duplicates.

We were however still reporting a cluster name in `/varz` and in the banner on startup. This PR fixes both.

Resolves #5913

Signed-off-by: Ivan Kozlovic ivan@synadia.com
