### PR TITLE
Reuse pre-existing sys account reference

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -854,7 +854,6 @@ func (js *jetStream) setupMetaGroup() error {
 	}
 
 	c := s.createInternalJetStreamClient()
-	sacc := s.SystemAccount()
 
 	js.mu.Lock()
 	defer js.mu.Unlock()
@@ -866,7 +865,7 @@ func (js *jetStream) setupMetaGroup() error {
 		qch:     make(chan struct{}),
 	}
 	atomic.StoreInt32(&js.clustered, 1)
-	c.registerWithAccount(sacc)
+	c.registerWithAccount(sysAcc)
 
 	// Set to true before we start.
 	js.metaRecovering = true
@@ -874,7 +873,7 @@ func (js *jetStream) setupMetaGroup() error {
 		js.monitorCluster,
 		pprofLabels{
 			"type":    "metaleader",
-			"account": sacc.Name,
+			"account": sysAcc.Name,
 		},
 	)
 	return nil


### PR DESCRIPTION
Fixes the following panic:
```
[inf] panic: runtime error: invalid memory address or nil pointer dereference
[inf] [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc0a90d]
[inf]
[inf] goroutine 1 [running]:
[inf] github.com/nats-io/nats-server/v2/server.(*jetStream).setupMetaGroup(0xc0002c2200)
[inf] server/jetstream_cluster.go:877 +0x12ed
[inf] github.com/nats-io/nats-server/v2/server.(*Server).enableJetStreamClustering(0xc00023e008)
[inf] server/jetstream_cluster.go:759 +0x1af
[inf] github.com/nats-io/nats-server/v2/server.(*Server).enableJetStream(0xc00023e008, {0x40000000, 0x280000000, {0xc00002a3f0, 0x15}, 0x1bf08eb000, 0x0, {0x0, 0x0}, 0x1, ...})
[inf] server/jetstream.go:508 +0x11fc
[inf] github.com/nats-io/nats-server/v2/server.(*Server).EnableJetStream(0xc00023e008, 0xc000033d18)
[inf] server/jetstream.go:230 +0x945
[inf] github.com/nats-io/nats-server/v2/server.(*Server).Start(0xc00023e008)
[inf] server/server.go:2347 +0x2005
[inf] github.com/nats-io/nats-server/v2/server.Run(0xc00023e008)
[inf] server/service.go:22 +0x32
[inf] main.main()
[inf] main.go:127 +0x62c
```


The panic would occur if we were starting up and were in `setupMetaGroup`, but while we're there we get shutdown.
```
[inf] [1] 2024/09/24 23:18:56.478586 [INF] Starting JetStream cluster
[inf] [1] 2024/09/24 23:18:56.478739 [DBG] JetStream cluster checking for stable cluster name and peers
[inf] [1] 2024/09/24 23:18:56.480463 [INF] Creating JetStream metadata controller
[inf] [1] 2024/09/24 23:18:56.501280 [INF] JetStream cluster recovering state
[inf] [1] 2024/09/24 23:18:56.554002 [DBG] Trapped "terminated" signal
[inf] [1] 2024/09/24 23:18:56.565929 [INF] Initiating Shutdown...
[inf] [1] 2024/09/24 23:18:56.568012 [INF] Initiating JetStream Shutdown...
[inf] [1] 2024/09/24 23:18:56.585020 [DBG] JETSTREAM - JetStream connection closed: Client Closed
[inf] [1] 2024/09/24 23:18:56.585908 [DBG] JETSTREAM - JetStream connection closed: Client Closed
[inf] [1] 2024/09/24 23:18:56.595023 [DBG] JETSTREAM - JetStream connection closed: Client Closed
[inf] [1] 2024/09/24 23:18:56.598251 [DBG] RAFT [yrzKKRBu - _meta_] Started
[inf] [1] 2024/09/24 23:18:56.601805 [INF] Server is ready
```

Upon shutting down `s.sys` gets reset:
https://github.com/nats-io/nats-server/blob/74ef475025ce4baaaf8724412ae08b20e54be8d2/server/events.go#L1793

So if we would then request the system account here, it could be `nil`:
https://github.com/nats-io/nats-server/blob/74ef475025ce4baaaf8724412ae08b20e54be8d2/server/jetstream_cluster.go#L857

Then panic/nil dereference happening here:
https://github.com/nats-io/nats-server/blob/74ef475025ce4baaaf8724412ae08b20e54be8d2/server/jetstream_cluster.go#L877

This PR proposes to just reuse the `sysAcc` variable that was already available:
https://github.com/nats-io/nats-server/blob/74ef475025ce4baaaf8724412ae08b20e54be8d2/server/jetstream_cluster.go#L782

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
