### PR TITLE
Warn if using temp storage for JetStream

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -219,6 +219,7 @@ func (s *Server) EnableJetStream(config *JetStreamConfig) error {
 	cfg := *config
 	if cfg.StoreDir == _EMPTY_ {
 		cfg.StoreDir = filepath.Join(os.TempDir(), JetStreamStoreDir)
+		s.Warnf("Temporary storage directory used, data could be lost on system reboot")
 	}
 
 	// We will consistently place the 'jetstream' directory under the storedir that was handed to us. Prior to 2.2.3 though
@@ -2521,6 +2522,7 @@ func (s *Server) dynJetStreamConfig(storeDir string, maxStore, maxMem int64) *Je
 	} else {
 		// Create one in tmp directory, but make it consistent for restarts.
 		jsc.StoreDir = filepath.Join(os.TempDir(), "nats", JetStreamStoreDir)
+		s.Warnf("Temporary storage directory used, data could be lost on system reboot")
 	}
 
 	opts := s.getOpts()


### PR DESCRIPTION
Based on [a discussion on Community NATS Slack](https://natsio.slack.com/archives/CM3T6T7JQ/p1727353138572209?thread_ts=1727312314.349369&cid=CM3T6T7JQ).

When just running `nats-server -js` or with Docker using `docker run --network host nats -js`, a temporary storage directory will be used since `-sd`/`jetstream.store_dir` is not specified.

There have been some times where people lost data, because they were not aware of the temp storage being used.
A user commented if a warning could be shown for this, therefore proposing this small fix to try and make it more obvious.

@bruth, tagging as you commented in the thread as well.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
