### PR TITLE
Fix desync after errCatchupTooManyRetries

### DIFF
--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -4086,3 +4086,76 @@ func TestJetStreamConsumerReplicasAfterScale(t *testing.T) {
 	require_Equal(t, ci.Config.Replicas, 3)
 	require_Equal(t, len(ci.Cluster.Replicas), 2)
 }
+
+func TestJetStreamClusterDesyncAfterCatchupTooManyRetries(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	si, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	streamLeader := si.Cluster.Leader
+	streamLeaderServer := c.serverByName(streamLeader)
+	nc.Close()
+	nc, js = jsClientConnect(t, streamLeaderServer)
+	defer nc.Close()
+
+	servers := slices.DeleteFunc([]string{"S-1", "S-2", "S-3"}, func(s string) bool {
+		return s == streamLeader
+	})
+
+	// Publish 10 messages.
+	for i := 0; i < 10; i++ {
+		pubAck, err := js.Publish("foo", []byte("ok"))
+		require_NoError(t, err)
+		require_Equal(t, pubAck.Sequence, uint64(i+1))
+	}
+
+	outdatedServerName := servers[0]
+	clusterResetServerName := servers[1]
+
+	outdatedServer := c.serverByName(outdatedServerName)
+	outdatedServer.Shutdown()
+	outdatedServer.WaitForShutdown()
+
+	// Publish 10 more messages, one server will be behind.
+	for i := 0; i < 10; i++ {
+		pubAck, err := js.Publish("foo", []byte("ok"))
+		require_NoError(t, err)
+		require_Equal(t, pubAck.Sequence, uint64(i+11))
+	}
+
+	// We will not need the client anymore.
+	nc.Close()
+
+	// Shutdown stream leader so one server remains.
+	streamLeaderServer.Shutdown()
+	streamLeaderServer.WaitForShutdown()
+
+	clusterResetServer := c.serverByName(clusterResetServerName)
+	acc, err := clusterResetServer.lookupAccount(globalAccountName)
+	require_NoError(t, err)
+	mset, err := acc.lookupStream("TEST")
+	require_NoError(t, err)
+
+	// Too many retries while processing snapshot is considered a cluster reset.
+	// If a leader is temporarily unavailable we shouldn't blow away our state.
+	require_True(t, isClusterResetErr(errCatchupTooManyRetries))
+	mset.resetClusteredState(errCatchupTooManyRetries)
+
+	// Stream leader stays offline, we only start the server with missing stream data.
+	// We expect that the reset server must not allow the outdated server to become leader, as that would result in desync.
+	c.restartServer(outdatedServer)
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+
+	// Outdated server must NOT become the leader.
+	newStreamLeaderServer := c.streamLeader(globalAccountName, "TEST")
+	require_Equal(t, newStreamLeaderServer.Name(), clusterResetServerName)
+}


### PR DESCRIPTION
Looked into the issue reported in Antithesis of non-monotonic sequence / pub ack sequence moving back due to stream desync.

When looking at these logs:
```
[        48.508] [      service_nats-1] [inf] [1] 2024/09/27 09:29:29.624201 [WRN] Catchup for stream '$G > test-stream' stalled
[        48.508] [      service_nats-1] [inf] [1] 2024/09/27 09:29:29.624634 [DBG] RAFT [yrzKKRBu - S-R3F-gMW2rGjb] Resuming our apply channel
[        48.508] [      service_nats-1] [inf] [1] 2024/09/27 09:29:29.624796 [WRN] Error applying entries to '$G > test-stream': catchup failed, too many retries
[        48.510] [      service_nats-1] [inf] [1] 2024/09/27 09:29:29.626681 [DBG] SYSTEM - System connection closed: Internal Client
[        48.511] [      service_nats-1] [inf] [1] 2024/09/27 09:29:29.627700 [DBG] RAFT [yrzKKRBu - S-R3F-gMW2rGjb] Deleted
[        48.511] [      service_nats-1] [inf] [1] 2024/09/27 09:29:29.627853 [DBG] Exiting stream monitor for '$G > test-stream' [S-R3F-gMW2rGjb]
```

In `monitorStream` we call into `applyStreamEntries` which calls into `processSnapshot` when about a snapshot. If after reaching `maxRetries` catchup remains stalled, the RAFT data is deleted, which means `n.pindex=0`.

Then when a leader election comes around this server with missing RAFT data would allow an outdated server that misses data to become leader. This is reproduced in the test.

1. Start 3 servers, add a R3 stream.
2. Publish 10 messages into the stream.
3. One server will be shut down, so it misses data and will need to be caught up.
4. Publish 10 more messages, the 2 remaining servers will get this.
5. Stop the stream leader and don't start it anymore for this test.
6. Now simulate us processing a snapshot and failing, by calling `mset.resetClusteredState(errCatchupTooManyRetries)`
7. We now start the server from point 3 (which was missing data and should be caught up with the missing data)
8. Because of `n.pindex=0` on the reset server, it grants leader to the outdated server. Resulting in desync.

This PR proposes to not fully delete the RAFT state when we are not able to reach the leader during the processing of a snapshot. Which ensures the outdated server does NOT get selected as a leader and it gets correctly caught up to contain the data it missed.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
