### PR TITLE
(2.11) Internal: Small udpates to ipQueue

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2456,6 +2456,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 				} else {
 					// Our stream was closed out from underneath of us, simply return here.
 					if err == errStreamClosed {
+						aq.recycle(&ces)
 						return
 					}
 					s.Warnf("Error applying entries to '%s > %s': %v", accName, sa.Config.Name, err)
@@ -8472,6 +8473,7 @@ RETRY:
 					}
 				} else if isOutOfSpaceErr(err) {
 					notifyLeaderStopCatchup(mrec, err)
+					msgsQ.recycle(&mrecs)
 					return err
 				} else if err == NewJSInsufficientResourcesError() {
 					notifyLeaderStopCatchup(mrec, err)

--- a/server/stream.go
+++ b/server/stream.go
@@ -3278,6 +3278,7 @@ func (mset *stream) processAllSourceMsgs() {
 				if !mset.processInboundSourceMsg(im.si, im) {
 					// If we are no longer leader bail.
 					if !mset.IsLeader() {
+						msgs.recycle(&ims)
 						cleanUp()
 						return
 					}


### PR DESCRIPTION
Small updates to ipQueue:
- Document that caller must not reuse the slice after call to recycle().
- Reset size to 0 on pop() or last popOne() without need to call q.caclc().
- Added missing recycle() calls in some places.
- Added benchmarks to check perf impact on future changes.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
