### PR TITLE
canary: changed uses of jwt.TagList.Contains() to jwt.TagList.ContainsEqualFold(), this relaxes matching to be case-insensitive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-tpm v0.9.0
 	github.com/klauspost/compress v1.17.10
 	github.com/minio/highwayhash v1.0.3
-	github.com/nats-io/jwt/v2 v2.6.0
+	github.com/nats-io/jwt/v2 v2.7.1-0.20241001190707-e5da71444547
 	github.com/nats-io/nats.go v1.36.0
 	github.com/nats-io/nkeys v0.4.7
 	github.com/nats-io/nuid v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-tpm v0.9.0
 	github.com/klauspost/compress v1.17.10
 	github.com/minio/highwayhash v1.0.3
-	github.com/nats-io/jwt/v2 v2.7.1-0.20241001190707-e5da71444547
+	github.com/nats-io/jwt/v2 v2.7.1-0.20241001214454-74c88303eeed
 	github.com/nats-io/nats.go v1.36.0
 	github.com/nats-io/nkeys v0.4.7
 	github.com/nats-io/nuid v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/klauspost/compress v1.17.10 h1:oXAz+Vh0PMUvJczoi+flxpnBEPxoER1IaAnU/N
 github.com/klauspost/compress v1.17.10/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/minio/highwayhash v1.0.3 h1:kbnuUMoHYyVl7szWjSxJnxw11k2U709jqFPPmIUyD6Q=
 github.com/minio/highwayhash v1.0.3/go.mod h1:GGYsuwP/fPD6Y9hMiXuapVvlIUEhFhMTh0rxU3ik1LQ=
-github.com/nats-io/jwt/v2 v2.7.1-0.20241001190707-e5da71444547 h1:tKUoWNfKHZJJ4kn+HUh1X0KBt4ziWaBeQHXVzBME4EI=
-github.com/nats-io/jwt/v2 v2.7.1-0.20241001190707-e5da71444547/go.mod h1:ZdWS1nZa6WMZfFwwgpEaqBV8EPGVgOTDHN/wTbz0Y5A=
+github.com/nats-io/jwt/v2 v2.7.1-0.20241001214454-74c88303eeed h1:IcCMjUKNR5otWsIE45fLPCaZ6sugAoM8QeTYOAJpqBE=
+github.com/nats-io/jwt/v2 v2.7.1-0.20241001214454-74c88303eeed/go.mod h1:ZdWS1nZa6WMZfFwwgpEaqBV8EPGVgOTDHN/wTbz0Y5A=
 github.com/nats-io/nats.go v1.36.0 h1:suEUPuWzTSse/XhESwqLxXGuj8vGRuPRoG7MoRN/qyU=
 github.com/nats-io/nats.go v1.36.0/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF0wkWclB8=
 github.com/nats-io/nkeys v0.4.7 h1:RwNJbbIdYCoClSDNY7QVKZlyb/wfT6ugvFCiKy6vDvI=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/klauspost/compress v1.17.10 h1:oXAz+Vh0PMUvJczoi+flxpnBEPxoER1IaAnU/N
 github.com/klauspost/compress v1.17.10/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/minio/highwayhash v1.0.3 h1:kbnuUMoHYyVl7szWjSxJnxw11k2U709jqFPPmIUyD6Q=
 github.com/minio/highwayhash v1.0.3/go.mod h1:GGYsuwP/fPD6Y9hMiXuapVvlIUEhFhMTh0rxU3ik1LQ=
-github.com/nats-io/jwt/v2 v2.6.0 h1:yXoBTdEotZw3NujMT+Nnu1UPNlFWdKQ3d0JJF/+pJag=
-github.com/nats-io/jwt/v2 v2.6.0/go.mod h1:ZdWS1nZa6WMZfFwwgpEaqBV8EPGVgOTDHN/wTbz0Y5A=
+github.com/nats-io/jwt/v2 v2.7.1-0.20241001190707-e5da71444547 h1:tKUoWNfKHZJJ4kn+HUh1X0KBt4ziWaBeQHXVzBME4EI=
+github.com/nats-io/jwt/v2 v2.7.1-0.20241001190707-e5da71444547/go.mod h1:ZdWS1nZa6WMZfFwwgpEaqBV8EPGVgOTDHN/wTbz0Y5A=
 github.com/nats-io/nats.go v1.36.0 h1:suEUPuWzTSse/XhESwqLxXGuj8vGRuPRoG7MoRN/qyU=
 github.com/nats-io/nats.go v1.36.0/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF0wkWclB8=
 github.com/nats-io/nkeys v0.4.7 h1:RwNJbbIdYCoClSDNY7QVKZlyb/wfT6ugvFCiKy6vDvI=

--- a/server/auth.go
+++ b/server/auth.go
@@ -506,13 +506,8 @@ func processUserPermissionsTemplate(lim jwt.UserPermissionLimits, ujwt *jwt.User
 								strings.TrimSuffix(strings.TrimPrefix(op, "tag("), ")")))
 						}
 
-						valueList := []string{}
-						for _, tag := range tags {
-							if strings.HasPrefix(tag, tagPrefix) {
-								tagValue := strings.TrimPrefix(tag, tagPrefix)
-								valueList = append(valueList, tagValue)
-							}
-						}
+						values := tags.GetValuesForTag(tagPrefix)
+						valueList := *values
 						if len(valueList) != 0 {
 							tagValues = append(tagValues, valueList)
 						}

--- a/server/events.go
+++ b/server/events.go
@@ -1965,7 +1965,7 @@ func (s *Server) filterRequest(fOpts *EventFilterOptions) bool {
 	if len(fOpts.Tags) > 0 {
 		opts := s.getOpts()
 		for _, t := range fOpts.Tags {
-			if !opts.Tags.Contains(t) {
+			if !opts.Tags.ContainsEqualsFold(t) {
 				return true
 			}
 		}

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2697,7 +2697,7 @@ func (s *Server) jsLeaderServerStreamCancelMoveRequest(sub *subscription, c *cli
 			}
 			nodeTags := si.(nodeInfo).tags
 			for _, tag := range cfg.Placement.Tags {
-				if !nodeTags.Contains(tag) {
+				if !nodeTags.ContainsEqualsFold(tag) {
 					// clear placement as tags don't match
 					cfg.Placement = nil
 					break FOR_TAGCHECK

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5858,7 +5858,7 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 			continue
 		}
 
-		if ni.tags.Contains(jsExcludePlacement) {
+		if ni.tags.ContainsEqualsFold(jsExcludePlacement) {
 			s.Debugf("Peer selection: discard %s@%s tags: %v reason: %s present",
 				ni.name, ni.cluster, ni.tags, jsExcludePlacement)
 			err.excludeTag = true
@@ -5868,7 +5868,7 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 		if len(tags) > 0 {
 			matched := true
 			for _, t := range tags {
-				if !ni.tags.Contains(t) {
+				if !ni.tags.ContainsEqualsFold(t) {
 					matched = false
 					s.Debugf("Peer selection: discard %s@%s tags: %v reason: mandatory tag %s not present",
 						ni.name, ni.cluster, ni.tags, t)

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -317,7 +317,7 @@ func TestHandleVarz(t *testing.T) {
 		if v.Name != "server_-1" {
 			t.Fatalf("Expected ServerName to be 'monitor_server' got %q", v.Name)
 		}
-		if !v.Tags.Contains("tag") {
+		if !v.Tags.ContainsEqualsFold("tag") {
 			t.Fatalf("Expected tags to be 'tag' got %v", v.Tags)
 		}
 		if v.JetStream.Config == nil {


### PR DESCRIPTION
This changes uses of jwt.Contains() to jwt.ContainsEqualsFold(), allowing case-insensitive matching in the jwt.TagList
Signed-off-by: Your Name <alberto@synadia.com>
