### PR TITLE
Fix test prefix to start with TestJetStreamCluster

### DIFF
--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -3904,7 +3904,7 @@ func TestJetStreamClusterAPILimitAdvisory(t *testing.T) {
 	require_Equal(t, advisory.Dropped, queueLimit) // Configured queue limit.
 }
 
-func TestJetStreamPendingRequestsInJsz(t *testing.T) {
+func TestJetStreamClusterPendingRequestsInJsz(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 
@@ -3962,7 +3962,7 @@ func TestJetStreamPendingRequestsInJsz(t *testing.T) {
 	require_NotEqual(t, m.Stats.JetStream.Meta.Pending, 0)
 }
 
-func TestJetStreamConsumerReplicasAfterScale(t *testing.T) {
+func TestJetStreamClusterConsumerReplicasAfterScale(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R5S", 5)
 	defer c.shutdown()
 


### PR DESCRIPTION
Noticed two tests in `jetstream_cluster_N_test.go` that weren't prefixed with `TestJetStreamCluster`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>