### PR TITLE
Add missed angle bracket to the help output

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ Server Options:
     -c, --config <file>              Configuration file
     -t                               Test configuration and exit
     -sl,--signal <signal>[=<pid>]    Send signal to nats-server process (ldm, stop, quit, term, reopen, reload)
-                                     pid> can be either a PID (e.g. 1) or the path to a PID file (e.g. /var/run/nats-server.pid)
+                                     <pid> can be either a PID (e.g. 1) or the path to a PID file (e.g. /var/run/nats-server.pid)
         --client_advertise <string>  Client URL to advertise to other servers
         --ports_file_dir <dir>       Creates a ports file in the specified directory (<executable_name>_<pid>.ports).
 


### PR DESCRIPTION
As one was lost in the https://github.com/nats-io/nats-server/pull/3536

Signed-off-by: Alexander Kuleshov <kuleshovmail@gmail.com>
