### PR TITLE
De-flake TestNoRaceJetStreamClusterGhostConsumers

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -1600,7 +1600,7 @@ func TestJetStreamClusterParallelConsumerCreation(t *testing.T) {
 }
 
 func TestJetStreamClusterGhostEphemeralsAfterRestart(t *testing.T) {
-	consumerNotActiveStartInterval = time.Second * 5
+	consumerNotActiveStartInterval = time.Second
 	defer func() {
 		consumerNotActiveStartInterval = defaultConsumerNotActiveStartInterval
 	}()

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -6577,7 +6577,7 @@ func TestNoRaceJetStreamConsumerCreateTimeNumPending(t *testing.T) {
 }
 
 func TestNoRaceJetStreamClusterGhostConsumers(t *testing.T) {
-	consumerNotActiveStartInterval = time.Second * 5
+	consumerNotActiveStartInterval = time.Second
 	defer func() {
 		consumerNotActiveStartInterval = defaultConsumerNotActiveStartInterval
 	}()


### PR DESCRIPTION
Both tests became a bit flaky. If they would not be able to retry within the first 5s, the test would fail. So having CI be a bit slow could make this flake.

Lowering the  `startInterval` for these tests to more often try to run the consumer cleanup.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
