### PR TITLE
NRG: Fix data race in `processAppendEntry`

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3547,13 +3547,17 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 		}
 	}
 
+	// Make a copy of these values, as the AppendEntry might be cached and returned to the pool in applyCommit.
+	aeCommit := ae.commit
+	aeReply := ae.reply
+
 	// Apply anything we need here.
-	if ae.commit > n.commit {
+	if aeCommit > n.commit {
 		if n.paused {
-			n.hcommit = ae.commit
-			n.debug("Paused, not applying %d", ae.commit)
+			n.hcommit = aeCommit
+			n.debug("Paused, not applying %d", aeCommit)
 		} else {
-			for index := n.commit + 1; index <= ae.commit; index++ {
+			for index := n.commit + 1; index <= aeCommit; index++ {
 				if err := n.applyCommit(index); err != nil {
 					break
 				}
@@ -3569,7 +3573,7 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 
 	// Success. Send our response.
 	if ar != nil {
-		n.sendRPC(ae.reply, _EMPTY_, ar.encode(arbuf))
+		n.sendRPC(aeReply, _EMPTY_, ar.encode(arbuf))
 		arPool.Put(ar)
 	}
 }


### PR DESCRIPTION
Fix a data race in `processAppendEntry`. Since the `ae` could be cached and returned to the pool in `applyCommit`, need to make sure we make a copy for ourselves here.

```
WARNING: DATA RACE
Write at 0x00c0157328c8 by goroutine 160360:
  github.com/nats-io/nats-server/v2/server.(*appendEntry).returnToPool()
      /home/travis/build/nats-io/nats-server/server/raft.go:2194 +0x17a4
  github.com/nats-io/nats-server/v2/server.(*raft).applyCommit()
      /home/travis/build/nats-io/nats-server/server/raft.go:2935 +0x16e8
  github.com/nats-io/nats-server/v2/server.(*raft).ResumeApply()
      /home/travis/build/nats-io/nats-server/server/raft.go:1001 +0x2c4
  github.com/nats-io/nats-server/v2/server.(*stream).processSnapshot.func1()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:8307 +0x167
  runtime.deferreturn()
      /home/travis/sdk/go1.23.0/src/runtime/panic.go:605 +0x5d
  github.com/nats-io/nats-server/v2/server.(*jetStream).applyStreamEntries()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:3157 +0x2b57
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorStream()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:2448 +0x4492
  github.com/nats-io/nats-server/v2/server.(*jetStream).processClusterCreateStream.func1()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:3888 +0x55
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
      /home/travis/build/nats-io/nats-server/server/server.go:3871 +0x59
Previous read at 0x00c0157328c8 by goroutine 160359:
  github.com/nats-io/nats-server/v2/server.(*raft).processAppendEntry()
      /home/travis/build/nats-io/nats-server/server/raft.go:3577 +0x55c4
  github.com/nats-io/nats-server/v2/server.(*raft).processAppendEntries()
      /home/travis/build/nats-io/nats-server/server/raft.go:2046 +0x1f2
  github.com/nats-io/nats-server/v2/server.(*raft).runAsFollower()
      /home/travis/build/nats-io/nats-server/server/raft.go:2061 +0x446
  github.com/nats-io/nats-server/v2/server.(*raft).run()
      /home/travis/build/nats-io/nats-server/server/raft.go:1961 +0x4c9
  github.com/nats-io/nats-server/v2/server.(*raft).run-fm()
      <autogenerated>:1 +0x33
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
      /home/travis/build/nats-io/nats-server/server/server.go:3871 +0x59
Goroutine 160360 (running) created at:
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine()
      /home/travis/build/nats-io/nats-server/server/server.go:3869 +0x1ba
  github.com/nats-io/nats-server/v2/server.(*jetStream).processClusterCreateStream()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:3887 +0x1ff8
  github.com/nats-io/nats-server/v2/server.newFileStoreWithCreated()
      /home/travis/build/nats-io/nats-server/server/filestore.go:437 +0x10d5
  github.com/nats-io/nats-server/v2/server.(*jetStream).createRaftGroup()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:2081 +0xbfd
  github.com/nats-io/nats-server/v2/server.(*jetStream).processClusterCreateStream()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:3743 +0x3ae
  github.com/nats-io/nats-server/v2/server.(*jetStream).processStreamAssignment()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:3461 +0x88e
  github.com/nats-io/nats-server/v2/server.(*jetStream).applyMetaSnapshot()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:1637 +0x13a5
  github.com/nats-io/nats-server/v2/server.(*jetStream).applyMetaEntries()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:1901 +0x124
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:1392 +0x10d0
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster-fm()
      <autogenerated>:1 +0x33
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
      /home/travis/build/nats-io/nats-server/server/server.go:3871 +0x59
Goroutine 160359 (running) created at:
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine()
      /home/travis/build/nats-io/nats-server/server/server.go:3869 +0x1ba
  github.com/nats-io/nats-server/v2/server.(*Server).startRaftNode()
      /home/travis/build/nats-io/nats-server/server/raft.go:524 +0x1f58
  github.com/nats-io/nats-server/v2/server.(*jetStream).createRaftGroup()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:2108 +0x1331
  fmt.Sscanf()
      /home/travis/sdk/go1.23.0/src/fmt/scan.go:114 +0x238f
  github.com/nats-io/nats-server/v2/server.(*fileStore).recoverFullState()
      /home/travis/build/nats-io/nats-server/server/filestore.go:1769 +0x224b
  github.com/nats-io/nats-server/v2/server.newFileStoreWithCreated()
      /home/travis/build/nats-io/nats-server/server/filestore.go:437 +0x10d5
  github.com/nats-io/nats-server/v2/server.(*jetStream).createRaftGroup()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:2081 +0xbfd
  github.com/nats-io/nats-server/v2/server.(*jetStream).processClusterCreateStream()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:3743 +0x3ae
  github.com/nats-io/nats-server/v2/server.(*jetStream).processStreamAssignment()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:3461 +0x88e
  github.com/nats-io/nats-server/v2/server.(*jetStream).applyMetaSnapshot()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:1637 +0x13a5
  github.com/nats-io/nats-server/v2/server.(*jetStream).applyMetaEntries()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:1901 +0x124
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster.go:1392 +0x10d0
  github.com/nats-io/nats-server/v2/server.(*jetStream).monitorCluster-fm()
      <autogenerated>:1 +0x33
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
      /home/travis/build/nats-io/nats-server/server/server.go:3871 +0x59
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
