### PR TITLE
NRG (2.11): Do not revert term on truncate WAL

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3215,7 +3215,7 @@ func (n *raft) truncateWAL(term, index uint64) {
 		}
 	}
 	// Set after we know we have truncated properly.
-	n.term, n.pterm, n.pindex = term, term, index
+	n.pterm, n.pindex = term, index
 }
 
 // Reset our WAL. This is equivalent to truncating all data from the log.


### PR DESCRIPTION
It is never safe for the term number to go backwards for any reason, even in a truncate scenario, as this breaks the consistency guarantees and could cause us to vote again in what should be past elections if more than one node has to truncate back at the same time.

All calls to `truncateWAL(...)` are after the AE has bumped the term number up if needed, so this is safe for making forward progress.

Signed-off-by: Neil Twigg <neil@nats.io>