### PR TITLE
[FIXED] Server panic on bad subject and infinite recursion.

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1654,7 +1654,7 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 				subj := buf[bi : bi+lsubj]
 				// We had a bug that could cause memory corruption in the PSIM that could have gotten stored to disk.
 				// Only would affect subjects, so do quick check.
-				if !isValidSubject(string(subj), true) {
+				if !isValidSubject(bytesToString(subj), true) {
 					os.Remove(fn)
 					fs.warn("Stream state corrupt subject detected")
 					return errCorruptState

--- a/server/stree/stree.go
+++ b/server/stree/stree.go
@@ -55,6 +55,11 @@ func (t *SubjectTree[T]) Insert(subject []byte, value T) (*T, bool) {
 		return nil, false
 	}
 
+	// Make sure we never insert anything with a noPivot byte.
+	if bytes.IndexByte(subject, noPivot) >= 0 {
+		return nil, false
+	}
+
 	old, updated := t.insert(&t.root, subject, value, 0)
 	if !updated {
 		t.size++
@@ -151,7 +156,7 @@ func (t *SubjectTree[T]) insert(np *node, subject []byte, value T, si int) (*T, 
 		ln.setSuffix(ln.suffix[cpi:])
 		si += cpi
 		// Make sure we have different pivot, normally this will be the case unless we have overflowing prefixes.
-		if p := pivot(ln.suffix, 0); si < len(subject) && p == subject[si] {
+		if p := pivot(ln.suffix, 0); cpi > 0 && si < len(subject) && p == subject[si] {
 			// We need to split the original leaf. Recursively call into insert.
 			t.insert(np, subject, value, si)
 			// Now add the update version of *np as a child to the new node4.

--- a/server/stree/util.go
+++ b/server/stree/util.go
@@ -44,10 +44,14 @@ func copyBytes(src []byte) []byte {
 
 type position interface{ int | uint16 }
 
-// Can return 0 if we have all the subject as prefixes.
+// No pivot available.
+const noPivot = byte(127)
+
+// Can return 127 (DEL) if we have all the subject as prefixes.
+// We used to use 0, but when that was in the subject would cause infinite recursion in some situations.
 func pivot[N position](subject []byte, pos N) byte {
 	if int(pos) >= len(subject) {
-		return 0
+		return noPivot
 	}
 	return subject[pos]
 }

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -1204,6 +1204,10 @@ func isValidSubject(subject string, checkRunes bool) bool {
 		return false
 	}
 	if checkRunes {
+		// Check if we have embedded nulls.
+		if bytes.IndexByte(stringToBytes(subject), 0) >= 0 {
+			return false
+		}
 		// Since casting to a string will always produce valid UTF-8, we need to look for replacement runes.
 		// This signals something is off or corrupt.
 		for _, r := range subject {

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -634,6 +634,11 @@ func TestSublistValidSubjects(t *testing.T) {
 	checkBool(IsValidSubject("foo.>bar"), true, t)
 	checkBool(IsValidSubject("foo>.bar"), true, t)
 	checkBool(IsValidSubject(">bar"), true, t)
+
+	// Check for embedded nulls.
+	subj := []byte("foo.bar.baz.")
+	subj = append(subj, 0)
+	checkBool(isValidSubject(string(subj), true), false, t)
 }
 
 func TestSublistMatchLiterals(t *testing.T) {
@@ -697,7 +702,6 @@ func TestValidateDestinationSubject(t *testing.T) {
 	checkError(ValidateMapping("*", "foo.{{unknown(1)}}"), ErrInvalidMappingDestination, t)
 	checkError(ValidateMapping("foo", "foo..}"), ErrInvalidMappingDestination, t)
 	checkError(ValidateMapping("foo", "foo. bar}"), ErrInvalidMappingDestinationSubject, t)
-
 }
 
 func TestSubjectToken(t *testing.T) {


### PR DESCRIPTION
When a subject with embedded nulls was inserted into an stree followed by another one with more nulls we could recurse infinitely and panic the server.

We now changed the no pivot to 127(DEL) and enforce that you can not insert a subject with that byte. Also make sure we do not recursively call into insert with no cpi movement.

This condition was from an old server that had corrupted the PSIM data (known issue fixed), but we were not detecting it, so added test for this when checking runes under isValidSubject.

Signed-off-by: Derek Collison <derek@nats.io>

