### PR TITLE
[BUMP] jwt to v2.7.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-tpm v0.9.0
 	github.com/klauspost/compress v1.17.10
 	github.com/minio/highwayhash v1.0.3
-	github.com/nats-io/jwt/v2 v2.6.0
+	github.com/nats-io/jwt/v2 v2.7.2
 	github.com/nats-io/nats.go v1.36.0
 	github.com/nats-io/nkeys v0.4.7
 	github.com/nats-io/nuid v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/klauspost/compress v1.17.10 h1:oXAz+Vh0PMUvJczoi+flxpnBEPxoER1IaAnU/N
 github.com/klauspost/compress v1.17.10/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/minio/highwayhash v1.0.3 h1:kbnuUMoHYyVl7szWjSxJnxw11k2U709jqFPPmIUyD6Q=
 github.com/minio/highwayhash v1.0.3/go.mod h1:GGYsuwP/fPD6Y9hMiXuapVvlIUEhFhMTh0rxU3ik1LQ=
-github.com/nats-io/jwt/v2 v2.6.0 h1:yXoBTdEotZw3NujMT+Nnu1UPNlFWdKQ3d0JJF/+pJag=
-github.com/nats-io/jwt/v2 v2.6.0/go.mod h1:ZdWS1nZa6WMZfFwwgpEaqBV8EPGVgOTDHN/wTbz0Y5A=
+github.com/nats-io/jwt/v2 v2.7.2 h1:SCRjfDLJ2q8naXp8YlGJJS5/yj3wGSODFYVi4nnwVMw=
+github.com/nats-io/jwt/v2 v2.7.2/go.mod h1:kB6QUmqHG6Wdrzj0KP2L+OX4xiTPBeV+NHVstFaATXU=
 github.com/nats-io/nats.go v1.36.0 h1:suEUPuWzTSse/XhESwqLxXGuj8vGRuPRoG7MoRN/qyU=
 github.com/nats-io/nats.go v1.36.0/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF0wkWclB8=
 github.com/nats-io/nkeys v0.4.7 h1:RwNJbbIdYCoClSDNY7QVKZlyb/wfT6ugvFCiKy6vDvI=

--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -1577,11 +1577,11 @@ func TestJetStreamJWTClusterAccountNRG(t *testing.T) {
 
 	// We'll try flipping the state a few times and then do some sanity
 	// checks to check that it took effect.
-	thirdAcc := fmt.Sprintf("account:%s", aExpPub2)
+	thirdAcc := jwt.ClusterTraffic(fmt.Sprintf("account:%s", aExpPub2))
 	// TODO: Not currently testing thirdAcc because we haven't enabled this
 	// functionality yet. If/when we do enable, this test is ready just by
 	// uncommenting the third state below.
-	for _, state := range []string{"system", "owner" /*, thirdAcc */} {
+	for _, state := range []jwt.ClusterTraffic{"system", "owner" /*, thirdAcc */} {
 		accClaim.ClusterTraffic = state
 		accJwt = encodeClaim(t, accClaim, aExpPub)
 


### PR DESCRIPTION
[BUMP] jwt to v2.7.2 - which retracts case-sensitive jwt.TagList
[FIX] jwt cluster test reference ClusterTraffic as a string

Signed-off-by: Alberto Ricart <alberto@synadia.com>
