### PR TITLE
De-flake TestNoRaceJetStreamClusterGhostConsumers

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -1601,8 +1601,10 @@ func TestJetStreamClusterParallelConsumerCreation(t *testing.T) {
 
 func TestJetStreamClusterGhostEphemeralsAfterRestart(t *testing.T) {
 	consumerNotActiveStartInterval = time.Second
+	consumerNotActiveMaxInterval = time.Second
 	defer func() {
 		consumerNotActiveStartInterval = defaultConsumerNotActiveStartInterval
+		consumerNotActiveMaxInterval = defaultConsumerNotActiveMaxInterval
 	}()
 
 	c := createJetStreamClusterExplicit(t, "R3S", 3)


### PR DESCRIPTION
Consumer removal has exponential backoff starting from `startInterval` moving all the way up to max 5 minutes. This lowers that max for these tests.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>