### PR TITLE
Fix desync after errCatchupAbortedNoLeader

### DIFF
--- a/server/store.go
+++ b/server/store.go
@@ -724,7 +724,7 @@ func isOutOfSpaceErr(err error) bool {
 var errFirstSequenceMismatch = errors.New("first sequence mismatch")
 
 func isClusterResetErr(err error) bool {
-	return err == errLastSeqMismatch || err == ErrStoreEOF || err == errFirstSequenceMismatch || err == errCatchupTooManyRetries
+	return err == errLastSeqMismatch || err == ErrStoreEOF || err == errFirstSequenceMismatch || errors.Is(err, errCatchupAbortedNoLeader) || err == errCatchupTooManyRetries
 }
 
 // Copy all fields.


### PR DESCRIPTION
Previously a related case of RAFT state being deleted was fixed, when running into `errCatchupTooManyRetries`: https://github.com/nats-io/nats-server/pull/5939

After hitting this we shutdown and retry.. but if we have not elected a leader yet we'd hit `"catchup for stream '%s > %s' aborted, no leader"`, which then would again throw away RAFT state. This PR proposes a fix for that case.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
