### PR TITLE
NRG (2.11): Start catchup from `n.commit` & fix AppendEntry is stored at `seq=ae.pindex+1`

### DIFF
--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -784,8 +784,8 @@ func TestNRGTermDoesntRollBackToPtermOnCatchup(t *testing.T) {
 		require_Equal(t, rn.term, 2)
 
 		if !rn.Leader() {
-			rn.truncateWAL(1, 6) // This will overwrite rn.term, so...
-			rn.term = 2          // ... we'll set it back manually.
+			rn.truncateWAL(1, 6)
+			require_Equal(t, rn.term, 2) // rn.term must stay the same
 			require_Equal(t, rn.pterm, 1)
 			require_Equal(t, rn.pindex, 6)
 		}

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -1015,6 +1015,7 @@ func TestNRGWALEntryWithoutQuorumMustTruncate(t *testing.T) {
 					if len(expected) > 0 && int(state.LastSeq-state.FirstSeq+1) != len(expected) {
 						return fmt.Errorf("WAL is different: too many entries")
 					}
+					// Loop over all entries in the WAL, checking if the contents for all RAFT nodes are equal.
 					for index := state.FirstSeq; index <= state.LastSeq; index++ {
 						ae, err := an.loadEntry(index)
 						if err != nil {
@@ -1091,6 +1092,8 @@ func TestNRGCatchupDoesNotTruncateUncommittedEntriesWithQuorum(t *testing.T) {
 	n, err := s.initRaftNode(globalAccountName, cfg, pprofLabels{})
 	require_NoError(t, err)
 
+	// An AppendEntry is encoded into a buffer and that's stored into the WAL.
+	// This is a helper function to generate that buffer.
 	encode := func(ae *appendEntry) *appendEntry {
 		buf, err := ae.encode(nil)
 		require_NoError(t, err)

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -945,68 +945,93 @@ func TestNRGRemoveLeaderPeerDeadlockBug(t *testing.T) {
 }
 
 func TestNRGWALEntryWithoutQuorumMustTruncate(t *testing.T) {
-	c := createJetStreamClusterExplicit(t, "R3S", 3)
-	defer c.shutdown()
-
-	rg := c.createRaftGroup("TEST", 3, newStateAdder)
-	rg.waitOnLeader()
-
-	var err error
-	var scratch [1024]byte
-
-	// Simulate leader storing an AppendEntry in WAL but being hard killed before it can propose to its peers.
-	n := rg.leader().node().(*raft)
-	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
-	entries := []*Entry{newEntry(EntryNormal, esm)}
-	n.Lock()
-	ae := n.buildAppendEntry(entries)
-	ae.buf, err = ae.encode(scratch[:])
-	require_NoError(t, err)
-	err = n.storeToWAL(ae)
-	n.Unlock()
-	require_NoError(t, err)
-
-	// Stop the leader so it moves to another one.
-	n.shutdown(false)
-
-	// Wait for another leader to be picked
-	rg.waitOnLeader()
-
-	// Restart the previous leader that contains the stored AppendEntry without quorum.
-	for _, a := range rg {
-		if a.node().ID() == n.ID() {
-			sa := a.(*stateAdder)
-			sa.restart()
-			break
-		}
+	tests := []struct {
+		title  string
+		modify func(rg smGroup)
+	}{
+		{
+			// state equals, only need to remove the entry
+			title:  "equal",
+			modify: func(rg smGroup) {},
+		},
+		{
+			// state diverged, need to replace the entry
+			title: "diverged",
+			modify: func(rg smGroup) {
+				rg.leader().(*stateAdder).proposeDelta(11)
+			},
+		},
 	}
 
-	// The previous leader's WAL should truncate to remove the AppendEntry only it has.
-	// Eventually all WALs for all peers must match.
-	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
-		var expected [][]byte
-		for _, a := range rg {
-			an := a.node().(*raft)
-			var state StreamState
-			an.wal.FastState(&state)
-			if len(expected) > 0 && int(state.LastSeq-state.FirstSeq+1) != len(expected) {
-				return fmt.Errorf("WAL is different: too many entries")
-			}
-			for index := state.FirstSeq; index <= state.LastSeq; index++ {
-				ae, err := an.loadEntry(index)
-				if err != nil {
-					return err
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+
+			rg := c.createRaftGroup("TEST", 3, newStateAdder)
+			rg.waitOnLeader()
+
+			var err error
+			var scratch [1024]byte
+
+			// Simulate leader storing an AppendEntry in WAL but being hard killed before it can propose to its peers.
+			n := rg.leader().node().(*raft)
+			esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+			entries := []*Entry{newEntry(EntryNormal, esm)}
+			n.Lock()
+			ae := n.buildAppendEntry(entries)
+			ae.buf, err = ae.encode(scratch[:])
+			require_NoError(t, err)
+			err = n.storeToWAL(ae)
+			n.Unlock()
+			require_NoError(t, err)
+
+			// Stop the leader so it moves to another one.
+			n.shutdown(false)
+
+			// Wait for another leader to be picked
+			rg.waitOnLeader()
+
+			// Make a modification, specific to this test.
+			test.modify(rg)
+
+			// Restart the previous leader that contains the stored AppendEntry without quorum.
+			for _, a := range rg {
+				if a.node().ID() == n.ID() {
+					sa := a.(*stateAdder)
+					sa.restart()
+					break
 				}
-				seq := int(index)
-				if len(expected) < seq {
-					expected = append(expected, ae.buf)
-				} else if !bytes.Equal(expected[seq-1], ae.buf) {
-					return fmt.Errorf("WAL is different: stored bytes differ")
-				}
 			}
-		}
-		return nil
-	})
+
+			// The previous leader's WAL should truncate to remove the AppendEntry only it has.
+			// Eventually all WALs for all peers must match.
+			checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+				var expected [][]byte
+				for _, a := range rg {
+					an := a.node().(*raft)
+					var state StreamState
+					an.wal.FastState(&state)
+					if len(expected) > 0 && int(state.LastSeq-state.FirstSeq+1) != len(expected) {
+						return fmt.Errorf("WAL is different: too many entries")
+					}
+					for index := state.FirstSeq; index <= state.LastSeq; index++ {
+						ae, err := an.loadEntry(index)
+						if err != nil {
+							return err
+						}
+						seq := int(index)
+						if len(expected) < seq {
+							expected = append(expected, ae.buf)
+						} else if !bytes.Equal(expected[seq-1], ae.buf) {
+							return fmt.Errorf("WAL is different: stored bytes differ")
+						}
+					}
+				}
+				return nil
+			})
+		})
+	}
 }
 
 func TestNRGTermNoDecreaseAfterWALReset(t *testing.T) {


### PR DESCRIPTION
This PR makes three complementary fixes to the way how catchup and truncating is handled.
Specifically:
- when doing `n.loadEntry(index)` we need to pass where the AppendEntry is in terms of stream sequence, this is equal to `ae.pindex+1` since the `ae.pindex` is the value before it's stored in the stream.
- start catchup from `n.commit`, we could have messages past our commit that have been invalidated and need to be truncated since there was a switch between leaders
- because we catchup from `n.commit`, we check if our local AppendEntry matches terms with the incoming AppendEntry, we only need to truncate if the terms don't match

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>