### PR TITLE
Fix possible panic on monitorStream when shutting down

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2262,7 +2262,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 	// from underneath the one that is running since it will be the same raft node.
 	defer func() {
 		// We might be closing during shutdown, don't pre-emptively stop here since we'll still want to install snapshots.
-		if !mset.closed.Load() {
+		if mset != nil && !mset.closed.Load() {
 			n.Stop()
 		}
 	}()


### PR DESCRIPTION
Spotted the following in a test run:
```
=== RUN   TestJetStreamClusterUserSnapshotAndRestoreConfigChanges
    jetstream_cluster_1_test.go:3029: Unexpected error: nats: no responders available for request
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x25c pc=0x939f79]
goroutine 22770 [running]:
github.com/nats-io/nats-server/v2/server.(*jetStream).monitorStream.func1()
	./server/jetstream_cluster.go:2269 +0x19
github.com/nats-io/nats-server/v2/server.(*jetStream).monitorStream(0xc00070aa00, 0x0, 0xc000ac2900, 0x0)
	./server/jetstream_cluster.go:2428 +0x2333
github.com/nats-io/nats-server/v2/server.(*jetStream).processClusterCreateStream.func1()
	./server/jetstream_cluster.go:3876 +0x25
github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
	./server/server.go:3794 +0x32
created by github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine in goroutine 22569
	./server/server.go:3792 +0x145
FAIL	github.com/nats-io/nats-server/v2/server	88.009s
```