### PR TITLE
Reduce allocations in consumers

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3547,6 +3547,7 @@ func (o *consumer) processNextMsgRequest(reply string, msg []byte) {
 
 	if err := o.waiting.add(wr); err != nil {
 		sendErr(409, "Exceeded MaxWaiting")
+		wr.recycle()
 		return
 	}
 	o.signalNewMessages()

--- a/server/stream.go
+++ b/server/stream.go
@@ -5199,6 +5199,9 @@ func newJSPubMsg(dsubj, subj, reply string, hdr, msg []byte, o *consumer, seq ui
 	if pm != nil {
 		m = pm.(*jsPubMsg)
 		buf = m.buf[:0]
+		if hdr != nil {
+			hdr = append(m.hdr[:0], hdr...)
+		}
 	} else {
 		m = new(jsPubMsg)
 	}
@@ -5226,6 +5229,9 @@ func (pm *jsPubMsg) returnToPool() {
 	pm.subj, pm.dsubj, pm.reply, pm.hdr, pm.msg, pm.o = _EMPTY_, _EMPTY_, _EMPTY_, nil, nil, nil
 	if len(pm.buf) > 0 {
 		pm.buf = pm.buf[:0]
+	}
+	if len(pm.hdr) > 0 {
+		pm.hdr = pm.hdr[:0]
 	}
 	jsPubMsgPool.Put(pm)
 }


### PR DESCRIPTION
This PR makes the following changes that should reduce allocations in consumers:

* `JSApiConsumerGetNextRequest` structs are now pooled, as they were unavoidably escaping to the heap;
* `waitingRequest` structs are now returned to the pool correctly if hitting `MaxWaiting`;
* Reuse the `hdr` buffer from pooled `jsPubMsg` when returning consumer errors to the client.

Signed-off-by: Neil Twigg <neil@nats.io>