### PR TITLE
[FIXED] Cluster: loab balancing of queue groups from attached leaf nodes

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4790,12 +4790,18 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 			ql := _ql[:0]
 			for i := 0; i < len(qsubs); i++ {
 				sub = qsubs[i]
-				if sub.client.kind == LEAF || sub.client.kind == ROUTER {
-					// If we have assigned an rsub already, replace if the destination is a LEAF
-					// since we want to favor that compared to a ROUTER. We could make sure that
-					// we override only if previous was a ROUTE and not a LEAF, but we don't have to.
-					if rsub == nil || sub.client.kind == LEAF {
+				if dst := sub.client.kind; dst == LEAF || dst == ROUTER {
+					// If we have assigned an ROUTER rsub already, replace if
+					// the destination is a LEAF since we want to favor that.
+					if rsub == nil || (rsub.client.kind == ROUTER && dst == LEAF) {
 						rsub = sub
+					} else if dst == LEAF {
+						// We already have a LEAF and this is another one.
+						// Flip a coin to see if we swap it or not.
+						// See https://github.com/nats-io/nats-server/issues/6040
+						if fastrand.Uint32()%2 == 1 {
+							rsub = sub
+						}
 					}
 				} else {
 					ql = append(ql, sub)


### PR DESCRIPTION
When receiving a message from a route, if the queue interest is only routes and leaf connections, the server will always favor the leaf kind. However, if there were more than one leaf connections for the same queue group, the server will always pick the same (the last one). It would change if new leaf were to connect or disconnect/reconnect, but with a stable set, it would always be the same.

This PR makes this selection somewhat random.

Resolves #6040

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>