### PR TITLE
Fix matching by `thumbprint` in the Windows certificate store

### DIFF
--- a/server/certstore/certstore_windows.go
+++ b/server/certstore/certstore_windows.go
@@ -22,11 +22,9 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
-	"crypto/sha1"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"math/big"
@@ -406,14 +404,7 @@ func (w *winCertStore) certBySubject(subject string, storeType uint32, skipInval
 // current user's personal certs or local machine's personal certs using storeType.
 // See CERT_FIND_SUBJECT_STR description at https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certfindcertificateinstore
 func (w *winCertStore) certByThumbprint(hash string, storeType uint32, skipInvalid bool) (*x509.Certificate, *windows.CertContext, error) {
-	hb, err := hex.DecodeString(hash)
-	if err != nil {
-		return nil, nil, err
-	}
-	if len(hb) != sha1.Size {
-		return nil, nil, fmt.Errorf("incorrect thumbprint length %d", len(hb))
-	}
-	return w.certSearch(winFindHashStr, string(hb), winMyStore, storeType, skipInvalid)
+	return w.certSearch(winFindHashStr, hash, winMyStore, storeType, skipInvalid)
 }
 
 // caCertsBySubjectMatch matches and returns all matching certificates of the subject field.

--- a/server/certstore_windows_test.go
+++ b/server/certstore_windows_test.go
@@ -155,6 +155,7 @@ func TestLeafTLSWindowsCertStore(t *testing.T) {
 		{"WindowsCurrentUser", "Subject", "example.com", "\"NATS CA\"", 1},
 		{"WindowsCurrentUser", "Issuer", "NATS CA", "\"NATS CA\"", 1},
 		{"WindowsCurrentUser", "Issuer", "Frodo Baggins, Inc.", "\"NATS CA\"", 0},
+		{"WindowsCurrentUser", "Thumbprint", "7e44f478114a2e29b98b00beb1b3687d8dc0e481", "\"NATS CA\"", 0},
 		// Test CAs, NATS CA is valid, others are missing
 		{"WindowsCurrentUser", "Subject", "example.com", "[\"NATS CA\"]", 1},
 		{"WindowsCurrentUser", "Subject", "example.com", "[\"GlobalSign\"]", 0},


### PR DESCRIPTION
Fixes a bug in #6042 where the `thumbprint` would never match, as we were passing in a hex-decoded form instead of the actual string value.

Signed-off-by: Neil Twigg <neil@nats.io>