### PR TITLE
NRG: Don't switch to candidate when waiting for pending applies

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -4228,7 +4228,9 @@ func (n *raft) switchToCandidate() {
 	defer n.Unlock()
 
 	// If we are catching up or are in observer mode we can not switch.
-	if n.observer || n.paused {
+	// Avoid petitioning to become leader if we're behind on applies.
+	if n.observer || n.paused || n.applied < n.commit {
+		n.resetElect(minElectionTimeout / 4)
 		return
 	}
 


### PR DESCRIPTION
A follower could become candidate/leader before processing a snapshot. Based on timing the snapshot could enter into the apply queue, and before `n.PauseApply()` is called the follower could freely become leader and then fail processing the snapshot.

When a snapshot is not successfully applied yet, block the follower from becoming candidate until the snapshot is processed.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
