### PR TITLE
NRG: Do not set `pterm`/`pindex` if no snapshots and/or log entries

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -480,11 +480,6 @@ func (s *Server) initRaftNode(accName string, cfg *RaftConfig, labels pprofLabel
 				}
 			}
 		}
-	} else if n.pterm == 0 && n.pindex == 0 {
-		// We have recovered no state, either through our WAL or snapshots,
-		// so inherit from term from our tav.idx file and pindex from our last sequence.
-		n.pterm = n.term
-		n.pindex = state.LastSeq
 	}
 
 	// Make sure to track ourselves.


### PR DESCRIPTION
If we haven't recovered the `pterm`/`pindex` from a snapshot, and the WAL is empty, then we shouldn't tell other nodes that we have a log that we don't have (i.e. by vote request). Instead leave both `pterm` and `pindex` as zero to correctly signal that we don't know anything about the state of the log.

Signed-off-by: Neil Twigg <neil@nats.io>