### PR TITLE
Improve metalayer snapshot on shutdown

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1355,6 +1355,8 @@ func (js *jetStream) monitorCluster() {
 	for {
 		select {
 		case <-s.quitCh:
+			// Server shutting down, but we might receive this before qch, so try to snapshot.
+			doSnapshot()
 			return
 		case <-rqch:
 			return


### PR DESCRIPTION
We can't know whether `s.quitCh` or `qch` will fire first, since the `select` order is indeterminate. Try to snapshot either way.

Signed-off-by: Neil Twigg <neil@nats.io>