### PR TITLE
[FIXED] Fix data race when moving a stream

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2659,7 +2659,7 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 	if ok {
 		sa, ok := streams[streamName]
 		if ok {
-			cfg = *sa.Config
+			cfg = *sa.Config.clone()
 			streamFound = true
 			currPeers = sa.Group.Peers
 			currCluster = sa.Group.Cluster
@@ -2801,7 +2801,7 @@ func (s *Server) jsLeaderServerStreamCancelMoveRequest(sub *subscription, c *cli
 	if ok {
 		sa, ok := streams[streamName]
 		if ok {
-			cfg = *sa.Config
+			cfg = *sa.Config.clone()
 			streamFound = true
 			currPeers = sa.Group.Peers
 		}

--- a/server/stream.go
+++ b/server/stream.go
@@ -1350,7 +1350,7 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 			if js, _ := s.getJetStreamCluster(); js != nil {
 				js.mu.RLock()
 				if sa := js.streamAssignment(acc.Name, streamName); sa != nil {
-					cfg = *sa.Config
+					cfg = *sa.Config.clone()
 					exists = true
 				}
 				js.mu.RUnlock()


### PR DESCRIPTION
The same data race was fixed before in https://github.com/nats-io/nats-server/pull/5880, but was re-introduced in https://github.com/nats-io/nats-server/pull/5858/files#diff-9c075c47b0690a821ad35caa26308b69adeb132042f062eef75513db2a26638aL2515

This PR re-introduces the calls to `.clone()`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
