### PR TITLE
NRG (2.11): Vote request cancels catchup, new leader could have rejected subsequent catchup messages

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -4063,6 +4063,7 @@ func (n *raft) processVoteRequest(vr *voteRequest) error {
 				strings.ToLower(n.State().String()), vr.term, n.term)
 			n.stepdownLocked(noLeader)
 		}
+		n.cancelCatchup()
 		n.term = vr.term
 		n.vote = noVote
 		n.writeTermVote()

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -1617,3 +1617,36 @@ func TestNRGRecoverPindexPtermOnlyIfLogNotEmpty(t *testing.T) {
 	require_Equal(t, rn.pterm, 0)
 	require_Equal(t, rn.pindex, 0)
 }
+
+func TestNRGCancelCatchupWhenDetectingHigherTermDuringVoteRequest(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// Create a sample entry, the content doesn't matter, just that it's stored.
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	// Timeline.
+	aeCatchupTrigger := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 1, entries: entries})
+	aeMsg1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+
+	// Truncate to simulate we missed one message and need to catchup.
+	n.processAppendEntry(aeCatchupTrigger, n.aesub)
+	require_True(t, n.catchup != nil)
+	require_Equal(t, n.catchup.pterm, 0)  // n.pterm
+	require_Equal(t, n.catchup.pindex, 0) // n.pindex
+
+	// Process first message as part of the catchup.
+	catchupSub := n.catchup.sub
+	n.processAppendEntry(aeMsg1, catchupSub)
+	require_True(t, n.catchup != nil)
+
+	// Receiving a vote request should cancel our catchup.
+	// Otherwise, we could receive catchup messages after this that provides the previous leader with quorum.
+	// If the new leader doesn't have these entries, the previous leader would desync since it would commit them.
+	err := n.processVoteRequest(&voteRequest{2, 1, 1, nats0, "reply"})
+	require_NoError(t, err)
+	require_True(t, n.catchup == nil)
+}


### PR DESCRIPTION
Antithesis triggered a case where:
- a follower (S0) is behind and triggers catchup from the leader (S2)
- another follower (S1) triggers leader election
- the follower (S0) allows follower (S1) to become leader
- the leader (S2) sends a new message, which new leader (S1) rejects because it's on a higher term
- the follower (S0) now receives above message that new leader (S1) rejected, providing previous leader (S2) with quorum
- the new leader (S1) rejected that message, so previous leader (S2) has now desynced since it applied the message

This is solved by canceling catchup once a leader election happens for a higher term. The new leader will then resume our catchup once it's elected.


Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
