### PR TITLE
Change Consumer Priority Group State info and fix pinned TTL

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -60,11 +60,12 @@ type ConsumerInfo struct {
 	Paused         bool            `json:"paused,omitempty"`
 	PauseRemaining time.Duration   `json:"pause_remaining,omitempty"`
 	// TimeStamp indicates when the info was gathered
-	TimeStamp      time.Time                     `json:"ts"`
-	PriorityGroups map[string]PriorityGroupState `json:"priority_groups,omitempty"`
+	TimeStamp      time.Time            `json:"ts"`
+	PriorityGroups []PriorityGroupState `json:"priority_groups,omitempty"`
 }
 
 type PriorityGroupState struct {
+	Group          string    `json:"group"`
 	PinnedClientID string    `json:"pinned_client_id,omitempty"`
 	PinnedTS       time.Time `json:"pinned_ts,omitempty"`
 }
@@ -2906,13 +2907,14 @@ func (o *consumer) infoWithSnapAndReply(snap bool, reply string) *ConsumerInfo {
 		rg = o.ca.Group
 	}
 
-	priorityGroups := make(map[string]PriorityGroupState)
+	priorityGroups := []PriorityGroupState{}
 	// TODO(jrm): when we introduce supporting many priority groups, we need to update assigning `o.currentNuid` for each group.
 	if len(o.cfg.PriorityGroups) > 0 {
-		priorityGroups[o.cfg.PriorityGroups[0]] = PriorityGroupState{
+		priorityGroups = append(priorityGroups, PriorityGroupState{
+			Group:          o.cfg.PriorityGroups[0],
 			PinnedClientID: o.currentPinId,
 			PinnedTS:       o.pinnedTS,
-		}
+		})
 	}
 
 	cfg := o.cfg

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3589,7 +3589,7 @@ func (o *consumer) nextWaiting(sz int) *waitingRequest {
 				if wr.priorityGroup.Id == _EMPTY_ {
 					o.currentPinId = nuid.Next()
 					wr.priorityGroup.Id = o.currentPinId
-					o.setPinnedTimer(&PriorityGroup{Group: priorityGroup, Id: o.currentPinId})
+					o.setPinnedTimer(priorityGroup)
 
 				} else {
 					// There is pin id set, but not a matching one. Send a notification to the client and remove the request.
@@ -3803,7 +3803,7 @@ func (o *consumer) processNextMsgRequest(reply string, msg []byte) {
 
 		if o.currentPinId != _EMPTY_ {
 			if priorityGroup.Id == o.currentPinId {
-				o.setPinnedTimer(priorityGroup)
+				o.setPinnedTimer(priorityGroup.Group)
 			} else if priorityGroup.Id != _EMPTY_ {
 				sendErr(423, "Nats-Pin-Id mismatch")
 				return


### PR DESCRIPTION
This PR introduces few changes & improvements to Pinned Consumers

**Fix pinned TTL timer when its assigned from existing waiting request**
Until now, we were resetting Pinned TTL only if pin was set on incoming
Pull Request, but not when we were pinning an existing waiting request.
It also simplifies some logic.

**Switch to slice of PriorityGroupState**
Previously, we were storing just the pinned IDs, but to be more
future-proof, this commit will switch approach to store a struct.
It also adds `PinnedTS` which can be useful for debugging pinned consumers.

cc @ripienaar @jnmoyne 

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>
