### PR TITLE
Fix consumer starting sequence with start time and multiple filters

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -5331,7 +5331,7 @@ func (o *consumer) selectStartingSeqNo() {
 					for _, filter := range o.subjf {
 						// Use first sequence since this is more optimized atm.
 						ss := o.mset.store.FilteredState(state.FirstSeq, filter.subject)
-						if ss.First > o.sseq && ss.First < nseq {
+						if ss.First >= o.sseq && ss.First < nseq {
 							nseq = ss.First
 						}
 					}


### PR DESCRIPTION
fixes #6076 

When starting by time option was used , a different codepath was taken when calculating starting sequence for the consumer. That codepath had off by one bug.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>