### PR TITLE
[FIXED] Ghost consumers after failed meta proposal

### DIFF
--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -2072,6 +2072,12 @@ func TestJetStreamClusterMaxConsumersMultipleConcurrentRequests(t *testing.T) {
 	if nc := len(names); nc > 1 {
 		t.Fatalf("Expected only 1 consumer, got %d", nc)
 	}
+
+	metaLeader := c.leader()
+	mjs := metaLeader.getJetStream()
+	sa := mjs.streamAssignment(globalAccountName, "MAXCC")
+	require_NotNil(t, sa)
+	require_True(t, sa.pendingConsumers == nil)
 }
 
 func TestJetStreamClusterAccountMaxStreamsAndConsumersMultipleConcurrentRequests(t *testing.T) {


### PR DESCRIPTION
If the `cc.meta.Propose` fails, for example due to restarts, the `sa.consumers[ca.Name] = ca` would have staged a consumer that will never be successfully added. That consumer would then become part of the next snapshot (for example during shutdown), which meant that that server had a ghost consumer it was unable to clean up.

This does not fully solve the ghost consumers issue, but this should contribute to the final solution.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>