### PR TITLE
WebSocket: Ensure full writes to compressor

### DIFF
--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1367,7 +1367,19 @@ func (c *client) wsCollapsePtoNB() (net.Buffers, int64) {
 		}
 		var csz int
 		for _, b := range nb {
-			cp.Write(b)
+			for len(b) > 0 {
+				n, err := cp.Write(b)
+				if err != nil {
+					if err == io.EOF {
+						break
+					}
+					c.Errorf("Error during compression: %v", err)
+					c.markConnAsClosed(WriteError)
+					nbPoolPut(b)
+					return nil, 0
+				}
+				b = b[n:]
+			}
 			nbPoolPut(b) // No longer needed as contents written to compressor.
 		}
 		if err := cp.Flush(); err != nil {


### PR DESCRIPTION
The `cp.Write()` call may have been partial and we would not have noticed.

Signed-off-by: Neil Twigg <neil@nats.io>