### PR TITLE
De-flake TestNoRaceJetStreamClusterCheckInterestStatePerformanceWQ

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -11063,7 +11063,7 @@ func TestNoRaceJetStreamClusterCheckInterestStatePerformanceWQ(t *testing.T) {
 	elapsed := time.Since(start)
 	// This is actually ~300 microseconds but due to travis and race flags etc.
 	// Was > 30 ms before fix for comparison, M2 macbook air.
-	require_True(t, elapsed < 5*time.Millisecond)
+	require_LessThan(t, elapsed, 5*time.Millisecond)
 
 	// Make sure we set the chkflr correctly.
 	checkFloor := func(o *consumer) uint64 {
@@ -11083,7 +11083,8 @@ func TestNoRaceJetStreamClusterCheckInterestStatePerformanceWQ(t *testing.T) {
 	// This checks the chkflr state.
 	start = time.Now()
 	mset.checkInterestState()
-	require_True(t, time.Since(start) < elapsed)
+	elapsed = time.Since(start)
+	require_LessThan(t, elapsed, 5*time.Millisecond)
 }
 
 func TestNoRaceJetStreamClusterCheckInterestStatePerformanceInterest(t *testing.T) {


### PR DESCRIPTION
The test failed on CI, but also sometimes locally. Had this fail locally just now with:
```
norace_test.go:11087: require 74.138µs to be less than 46.426µs
```

Improved the require to also report the time spent, as well as be <5ms.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>