### PR TITLE
Add `node10` to stree

### DIFF
--- a/server/stree/dump.go
+++ b/server/stree/dump.go
@@ -50,6 +50,7 @@ func (t *SubjectTree[T]) dump(w io.Writer, n node, depth int) {
 // For individual node/leaf dumps.
 func (n *leaf[T]) kind() string { return "LEAF" }
 func (n *node4) kind() string   { return "NODE4" }
+func (n *node10) kind() string  { return "NODE10" }
 func (n *node16) kind() string  { return "NODE16" }
 func (n *node48) kind() string  { return "NODE48" }
 func (n *node256) kind() string { return "NODE256" }

--- a/server/stree/node16.go
+++ b/server/stree/node16.go
@@ -79,10 +79,10 @@ func (n *node16) deleteChild(c byte) {
 
 // Shrink if needed and return new node, otherwise return nil.
 func (n *node16) shrink() node {
-	if n.size > 4 {
+	if n.size > 10 {
 		return nil
 	}
-	nn := newNode4(nil)
+	nn := newNode10(nil)
 	for i := uint16(0); i < n.size; i++ {
 		nn.addChild(n.key[i], n.child[i])
 	}

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -79,9 +79,22 @@ func TestSubjectTreeNodeGrow(t *testing.T) {
 	old, updated := st.Insert(b("foo.bar.E"), 22)
 	require_True(t, old == nil)
 	require_False(t, updated)
+	_, ok = st.root.(*node10)
+	require_True(t, ok)
+	for i := 5; i < 10; i++ {
+		subj := b(fmt.Sprintf("foo.bar.%c", 'A'+i))
+		old, updated := st.Insert(subj, 22)
+		require_True(t, old == nil)
+		require_False(t, updated)
+	}
+	// This one will trigger us to grow.
+	old, updated = st.Insert(b("foo.bar.K"), 22)
+	require_True(t, old == nil)
+	require_False(t, updated)
+	// We have filled a node10.
 	_, ok = st.root.(*node16)
 	require_True(t, ok)
-	for i := 5; i < 16; i++ {
+	for i := 11; i < 16; i++ {
 		subj := b(fmt.Sprintf("foo.bar.%c", 'A'+i))
 		old, updated := st.Insert(subj, 22)
 		require_True(t, old == nil)
@@ -164,18 +177,33 @@ func TestSubjectTreeNodeDelete(t *testing.T) {
 	require_True(t, found)
 	require_Equal(t, *v, 11)
 	require_Equal(t, st.root, nil)
-	// Now pop up to a node16 and make sure we can shrink back down.
+	// Now pop up to a node10 and make sure we can shrink back down.
 	for i := 0; i < 5; i++ {
 		subj := fmt.Sprintf("foo.bar.%c", 'A'+i)
 		st.Insert(b(subj), 22)
 	}
-	_, ok := st.root.(*node16)
+	_, ok := st.root.(*node10)
 	require_True(t, ok)
 	v, found = st.Delete(b("foo.bar.A"))
 	require_True(t, found)
 	require_Equal(t, *v, 22)
 	_, ok = st.root.(*node4)
 	require_True(t, ok)
+	// Now pop up to node16
+	for i := 0; i < 11; i++ {
+		subj := fmt.Sprintf("foo.bar.%c", 'A'+i)
+		st.Insert(b(subj), 22)
+	}
+	_, ok = st.root.(*node16)
+	require_True(t, ok)
+	v, found = st.Delete(b("foo.bar.A"))
+	require_True(t, found)
+	require_Equal(t, *v, 22)
+	_, ok = st.root.(*node10)
+	require_True(t, ok)
+	v, found = st.Find(b("foo.bar.B"))
+	require_True(t, found)
+	require_Equal(t, *v, 22)
 	// Now pop up to node48
 	st = NewSubjectTree[int]()
 	for i := 0; i < 17; i++ {


### PR DESCRIPTION
Although we probably don't want too many different node sizes here, the `node10` case is particularly interesting because it perfectly fits the full 0-9 numeric range without wasting bytes. In fact it saves 96 bytes (208 bytes instead of 304) compared to using `node16` for the same purpose.

This means memory savings for tracking subjects which are either mostly numerical throughout, or have tokens that are primarily numerical.

For a subject space that is mostly numerical, this can be several GBs less at the half-billion subjects mark and the saving can grow above that.

Signed-off-by: Neil Twigg <neil@nats.io>