### PR TITLE
[IMPROVED] Pre-acks handling, detecting ack for out of bounds sequence.

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3062,16 +3062,28 @@ func (o *consumer) processAckMsg(sseq, dseq, dc uint64, reply string, doSample b
 		return false
 	}
 
-	// Check if this ack is above the current pointer to our next to deliver.
-	// This could happen on a cooperative takeover with high speed deliveries.
-	if sseq >= o.sseq {
-		o.sseq = sseq + 1
-	}
-
 	mset := o.mset
 	if mset == nil || mset.closed.Load() {
 		o.mu.Unlock()
 		return false
+	}
+
+	// Check if this ack is above the current pointer to our next to deliver.
+	// This could happen on a cooperative takeover with high speed deliveries.
+	if sseq >= o.sseq {
+		// Let's make sure this is valid.
+		// This is only received on the consumer leader, so should never be higher
+		// than the last stream sequence.
+		var ss StreamState
+		mset.store.FastState(&ss)
+		if sseq > ss.LastSeq {
+			o.srv.Warnf("JetStream consumer '%s > %s > %s' ACK sequence %d past last stream sequence of %d",
+				o.acc.Name, o.stream, o.name, sseq, ss.LastSeq)
+			// FIXME(dlc) - For 2.11 onwards should we return an error here to the caller?
+			o.mu.Unlock()
+			return false
+		}
+		o.sseq = sseq + 1
 	}
 
 	// Let the owning stream know if we are interest or workqueue retention based.

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -6703,7 +6703,7 @@ func TestNoRaceJetStreamClusterGhostConsumers(t *testing.T) {
 			cc := sjs.cluster
 			sa := cc.streams[globalAccountName]["TEST"]
 			var consumers []string
-			for cName, _ := range sa.consumers {
+			for cName := range sa.consumers {
 				consumers = append(consumers, cName)
 			}
 			sjs.mu.Unlock()

--- a/server/stream.go
+++ b/server/stream.go
@@ -1692,8 +1692,8 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 
 // Config returns the stream's configuration.
 func (mset *stream) config() StreamConfig {
-	mset.mu.RLock()
-	defer mset.mu.RUnlock()
+	mset.cfgMu.RLock()
+	defer mset.cfgMu.RUnlock()
 	return mset.cfg
 }
 
@@ -3654,7 +3654,6 @@ func (mset *stream) resetSourceInfo() {
 	}
 }
 
-// Lock should be held.
 // This will do a reverse scan on startup or leader election
 // searching for the starting sequence number.
 // This can be slow in degenerative cases.


### PR DESCRIPTION
Detect if we receive an ack past our last stream sequence.

We also no longer register pre-acks when we detect this from a consumer snapshot since we properly handle this now and this could lead to excessive memory usage.

Signed-off-by: Derek Collison <derek@nats.io>