### PR TITLE
Improve pinning/unpinning in Priority Groups

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3532,7 +3532,7 @@ func (o *consumer) setPinnedTimer(priorityGroup string) {
 	} else {
 		o.pinnedTtl = time.AfterFunc(o.cfg.PinnedTTL, func() {
 			o.mu.Lock()
-			o.pinnedTS = time.Now().Add(o.cfg.PinnedTTL)
+			o.pinnedTS = time.Now()
 			o.currentPinId = _EMPTY_
 			o.sendUnpinnedAdvisoryLocked(priorityGroup, "timeout")
 			o.mu.Unlock()

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1626,7 +1626,7 @@ func (o *consumer) sendPinnedAdvisoryLocked(group string) {
 func (o *consumer) sendUnpinnedAdvisoryLocked(group string, reason string) {
 	e := JSConsumerGroupUnPinnedAdvisory{
 		TypedEvent: TypedEvent{
-			Type: JSConsumerGroupPinnedAdvisoryType,
+			Type: JSStreamGroupUnPinnedAdvisoryType,
 			ID:   nuid.Next(),
 			Time: time.Now().UTC(),
 		},

--- a/server/errors.json
+++ b/server/errors.json
@@ -1598,5 +1598,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerInvalidGroupNameErr",
+    "code": 400,
+    "error_code": 10162,
+    "description": "Valid name must match A-Z, a-z, 0-9, -_/=)+ and may not exceed 16 characters",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -3424,6 +3424,11 @@ func (s *Server) jsConsumerUnpinRequest(sub *subscription, c *client, _ *Account
 		return
 	}
 
+	if !validGroupName.MatchString(req.Group) {
+		resp.Error = NewJSConsumerInvalidGroupNameError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
 	if s.JetStreamIsClustered() {
 		// Check to make sure the stream is assigned.
 		js, cc := s.getJetStreamCluster()

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -122,6 +122,9 @@ const (
 	// JSConsumerInvalidDeliverSubject invalid push consumer deliver subject
 	JSConsumerInvalidDeliverSubject ErrorIdentifier = 10112
 
+	// JSConsumerInvalidGroupNameErr Valid name must match A-Z, a-z, 0-9, -_/=)+ and may not exceed 16 characters
+	JSConsumerInvalidGroupNameErr ErrorIdentifier = 10162
+
 	// JSConsumerInvalidPolicyErrF Generic delivery policy error ({err})
 	JSConsumerInvalidPolicyErrF ErrorIdentifier = 10094
 
@@ -527,6 +530,7 @@ var (
 		JSConsumerHBRequiresPushErr:                {Code: 400, ErrCode: 10088, Description: "consumer idle heartbeat requires a push based consumer"},
 		JSConsumerInactiveThresholdExcess:          {Code: 400, ErrCode: 10153, Description: "consumer inactive threshold exceeds system limit of {limit}"},
 		JSConsumerInvalidDeliverSubject:            {Code: 400, ErrCode: 10112, Description: "invalid push consumer deliver subject"},
+		JSConsumerInvalidGroupNameErr:              {Code: 400, ErrCode: 10162, Description: "Valid name must match A-Z, a-z, 0-9, -_/=)+ and may not exceed 16 characters"},
 		JSConsumerInvalidPolicyErrF:                {Code: 400, ErrCode: 10094, Description: "{err}"},
 		JSConsumerInvalidPriorityGroupErr:          {Code: 400, ErrCode: 10160, Description: "Provided priority group does not exist for this consumer"},
 		JSConsumerInvalidSamplingErrF:              {Code: 400, ErrCode: 10095, Description: "failed to parse consumer sampling configuration: {err}"},
@@ -1085,6 +1089,16 @@ func NewJSConsumerInvalidDeliverSubjectError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSConsumerInvalidDeliverSubject]
+}
+
+// NewJSConsumerInvalidGroupNameError creates a new JSConsumerInvalidGroupNameErr error: "Valid name must match A-Z, a-z, 0-9, -_/=)+ and may not exceed 16 characters"
+func NewJSConsumerInvalidGroupNameError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSConsumerInvalidGroupNameErr]
 }
 
 // NewJSConsumerInvalidPolicyError creates a new JSConsumerInvalidPolicyErrF error: "{err}"

--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -284,10 +284,10 @@ type JSConsumerGroupPinnedAdvisory struct {
 	PinnedClientId string `json:"pinned_id"`
 }
 
-const JSStreamGroupUnPinnedAdvisoryType = "io.nats.jetstream.advisory.v1.consumer_group_unpinned"
+const JSConsumerGroupUnpinnedAdvisoryType = "io.nats.jetstream.advisory.v1.consumer_group_unpinned"
 
-// JSConsumerGroupUnPinnedAdvisory indicates that a pin was lost
-type JSConsumerGroupUnPinnedAdvisory struct {
+// JSConsumerGroupUnpinnedAdvisory indicates that a pin was lost
+type JSConsumerGroupUnpinnedAdvisory struct {
 	TypedEvent
 	Account  string `json:"account,omitempty"`
 	Stream   string `json:"stream"`


### PR DESCRIPTION
After round of feedback, few changes were requested:

**Fix unpin advisory name**

Copy-paste mistake was made in unpin advisory name.

**Fix PinnedTS**

It was meant to return time when pinned happened, not the daedline.

**Add check for group name**

As the ADR for Priority Groups was [also updated](https://github.com/nats-io/nats-architecture-and-design/pull/311) after feedbach, this PR implements that.

cc @ripienaar @jnmoyne 

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>