### PR TITLE
[FIXED] DeleteRange deletes one message too much

### DIFF
--- a/server/store.go
+++ b/server/store.go
@@ -295,12 +295,16 @@ type DeleteRange struct {
 }
 
 func (dr *DeleteRange) State() (first, last, num uint64) {
-	return dr.First, dr.First + dr.Num, dr.Num
+	deletesAfterFirst := dr.Num
+	if deletesAfterFirst > 0 {
+		deletesAfterFirst--
+	}
+	return dr.First, dr.First + deletesAfterFirst, dr.Num
 }
 
 // Range will range over all the deleted sequences represented by this block.
 func (dr *DeleteRange) Range(f func(uint64) bool) {
-	for seq := dr.First; seq <= dr.First+dr.Num; seq++ {
+	for seq := dr.First; seq < dr.First+dr.Num; seq++ {
 		if !f(seq) {
 			return
 		}

--- a/server/store_test.go
+++ b/server/store_test.go
@@ -109,3 +109,35 @@ func TestStoreMsgLoadNextMsgMulti(t *testing.T) {
 		},
 	)
 }
+
+func TestStoreDeleteSlice(t *testing.T) {
+	ds := DeleteSlice{2}
+	var deletes []uint64
+	ds.Range(func(seq uint64) bool {
+		deletes = append(deletes, seq)
+		return true
+	})
+	require_Len(t, len(deletes), 1)
+	require_Equal(t, deletes[0], 2)
+
+	first, last, num := ds.State()
+	require_Equal(t, first, 2)
+	require_Equal(t, last, 2)
+	require_Equal(t, num, 1)
+}
+
+func TestStoreDeleteRange(t *testing.T) {
+	dr := DeleteRange{First: 2, Num: 1}
+	var deletes []uint64
+	dr.Range(func(seq uint64) bool {
+		deletes = append(deletes, seq)
+		return true
+	})
+	require_Len(t, len(deletes), 1)
+	require_Equal(t, deletes[0], 2)
+
+	first, last, num := dr.State()
+	require_Equal(t, first, 2)
+	require_Equal(t, last, 2)
+	require_Equal(t, num, 1)
+}


### PR DESCRIPTION
When a `DeleteRange` was used to mark deletes, when looping over it with `dr.Range(..)` it would delete one message too much.

Compared with a `DeleteSlice` the `DeleteRange` also didn't return the correct `last` for `dr.State()`. Also being +1 what it should be.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>