### PR TITLE
Use interest-based intersection for `NumPendingMulti`

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -3332,11 +3332,11 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *Sublist, lastPerSubject bo
 
 			var t uint64
 			var havePartial bool
-			mb.fss.Iter(func(bsubj []byte, ss *SimpleState) bool {
+			IntersectStree[SimpleState](mb.fss, sl, func(bsubj []byte, ss *SimpleState) {
 				subj := bytesToString(bsubj)
-				if havePartial || !sl.HasInterest(subj) {
+				if havePartial {
 					// If we already found a partial then don't do anything else.
-					return !havePartial
+					return
 				}
 				if ss.firstNeedsUpdate {
 					mb.recalculateFirstForSubj(subj, ss.First, ss)
@@ -3347,7 +3347,6 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *Sublist, lastPerSubject bo
 					// We matched but its a partial.
 					havePartial = true
 				}
-				return !havePartial
 			})
 
 			// See if we need to scan msgs here.
@@ -3432,11 +3431,8 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *Sublist, lastPerSubject bo
 				}
 				// Mark fss activity.
 				mb.lsts = time.Now().UnixNano()
-				mb.fss.Iter(func(bsubj []byte, ss *SimpleState) bool {
-					if sl.HasInterest(bytesToString(bsubj)) {
-						adjust += ss.Msgs
-					}
-					return true
+				IntersectStree(mb.fss, sl, func(bsubj []byte, ss *SimpleState) {
+					adjust += ss.Msgs
 				})
 			}
 		} else {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -719,10 +719,7 @@ func (ms *memStore) NumPendingMulti(sseq uint64, sl *Sublist, lastPerSubject boo
 	var havePartial bool
 	var totalSkipped uint64
 	// We will track start and end sequences as we go.
-	ms.fss.Iter(func(subj []byte, fss *SimpleState) bool {
-		if !sl.HasInterest(bytesToString(subj)) {
-			return true
-		}
+	IntersectStree[SimpleState](ms.fss, sl, func(subj []byte, fss *SimpleState) {
 		if fss.firstNeedsUpdate {
 			ms.recalculateFirstForSubj(bytesToString(subj), fss.First, fss)
 		}
@@ -736,7 +733,6 @@ func (ms *memStore) NumPendingMulti(sseq uint64, sl *Sublist, lastPerSubject boo
 		} else {
 			totalSkipped += fss.Msgs
 		}
-		return true
 	})
 
 	// If we did not encounter any partials we can return here.

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"unicode/utf8"
+
+	"github.com/nats-io/nats-server/v2/server/stree"
 )
 
 // Sublist is a routing mechanism to handle subject distribution and
@@ -1733,5 +1735,46 @@ func getAllNodes(l *level, results *SublistResult) {
 	for _, n := range l.nodes {
 		addNodeToResults(n, results)
 		getAllNodes(n.next, results)
+	}
+}
+
+// IntersectStree will match all items in the given subject tree that
+// have interest expressed in the given sublist. The callback will only be called
+// once for each subject, regardless of overlapping subscriptions in the sublist.
+func IntersectStree[T any](st *stree.SubjectTree[T], sl *Sublist, cb func(subj []byte, entry *T)) {
+	var _subj [255]byte
+	intersectStree(st, sl.root, _subj[:0], cb)
+}
+
+func intersectStree[T any](st *stree.SubjectTree[T], r *level, subj []byte, cb func(subj []byte, entry *T)) {
+	if r.numNodes() == 0 {
+		st.Match(subj, cb)
+		return
+	}
+	nsubj := subj
+	if len(nsubj) > 0 {
+		nsubj = append(subj, '.')
+	}
+	switch {
+	case r.fwc != nil:
+		// We've reached a full wildcard, do a FWC match on the stree at this point
+		// and don't keep iterating downward.
+		nsubj := append(nsubj, '>')
+		st.Match(nsubj, cb)
+	case r.pwc != nil:
+		// We've found a partial wildcard. We'll keep iterating downwards, but first
+		// check whether there's interest at this level (without triggering dupes) and
+		// match if so.
+		nsubj := append(nsubj, '*')
+		if len(r.pwc.psubs)+len(r.pwc.qsubs) > 0 && r.pwc.next != nil && r.pwc.next.numNodes() > 0 {
+			st.Match(nsubj, cb)
+		}
+		intersectStree(st, r.pwc.next, nsubj, cb)
+	case r.numNodes() > 0:
+		// Normal node with subject literals, keep iterating.
+		for t, n := range r.nodes {
+			nsubj := append(nsubj, t...)
+			intersectStree(st, n.next, nsubj, cb)
+		}
 	}
 }


### PR DESCRIPTION
This optimises #6089 by ensuring that we don't over-walk either the sublist or the subject tree, instead only matching the subject tree on subjects for which the sublist expresses interest.

On my machine, in the `JetStreamConsumeWithFilters` benchmark with `-benchtime 1000x`, this reduces the CPU time taken by `NumPendingMulti` by 19.41 seconds, reducing it to only 0.06 seconds.

Signed-off-by: Neil Twigg <neil@nats.io>