### PR TITLE
fix TestJetStreamJWTMove flapper

### DIFF
--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -345,10 +345,9 @@ func TestJetStreamJWTMove(t *testing.T) {
 		require_NoError(t, err)
 
 		// Perform actual move
-		ci, err = js.UpdateStream(&nats.StreamConfig{Name: "MOVE-ME", Replicas: replicas,
+		_, err = js.UpdateStream(&nats.StreamConfig{Name: "MOVE-ME", Replicas: replicas,
 			Placement: &nats.Placement{Tags: []string{"cloud:C2-tag"}}})
 		require_NoError(t, err)
-		require_Equal(t, ci.Cluster.Name, "C1")
 
 		sc.clusterForName("C2").waitOnStreamLeader(aExpPub, "MOVE-ME")
 


### PR DESCRIPTION
test(flapper): fix TestJetStreamJWTMove - by removing a check on stream update for the configuration, likely the server was able to accomplish the move, right after, the test will assert that C2 is the stream was placed in the correct cluster



Signed-off-by: Alberto Ricart <alberto@synadia.com>
