### PR TITLE
[FIXED] `mset.noInterest` requires write lock

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -5787,12 +5787,14 @@ func (o *consumer) cleanupNoInterestMessages(mset *stream, ignoreInterest bool) 
 		return
 	}
 
+	mset.mu.RUnlock()
+	mset.mu.Lock()
 	for seq := start; seq <= stop; seq++ {
 		if mset.noInterest(seq, co) {
 			rmseqs = append(rmseqs, seq)
 		}
 	}
-	mset.mu.RUnlock()
+	mset.mu.Unlock()
 
 	// These can be removed.
 	for _, seq := range rmseqs {


### PR DESCRIPTION
`mset.noInterest(..)` mentions it requires a write lock to be held:
```go
// Check if there is no interest in this sequence number across our consumers.
// The consumer passed is optional if we are processing the ack for that consumer.
// Write lock should be held.
func (mset *stream) noInterest(seq uint64, obs *consumer) bool {
	return !mset.checkForInterest(seq, obs)
}
```

This wasn't done in `cleanupNoInterestMessages`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>