### PR TITLE
Tweak initial filestore sync timer

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -29,7 +29,7 @@ import (
 	"io"
 	"io/fs"
 	"math"
-	mrand "math/rand/v2"
+	mrand "math/rand"
 	"net"
 	"os"
 	"path/filepath"
@@ -8243,11 +8243,11 @@ func (fs *fileStore) setSyncTimer() {
 	if fs.syncTmr != nil {
 		fs.syncTmr.Reset(fs.fcfg.SyncInterval)
 	} else {
-		// First time this fires will be any time up to the fs.fcfg.SyncInterval,
+		// First time this fires will be between SyncInterval/2 and SyncInterval,
 		// so that different stores are spread out, rather than having many of
 		// them trying to all sync at once, causing blips and contending dios.
-		start := time.Duration(mrand.Int64N(int64(fs.fcfg.SyncInterval)))
-		fs.syncTmr = time.AfterFunc(min(start, time.Second), fs.syncBlocks)
+		start := (fs.fcfg.SyncInterval / 2) + (time.Duration(mrand.Int63n(int64(fs.fcfg.SyncInterval / 2))))
+		fs.syncTmr = time.AfterFunc(start, fs.syncBlocks)
 	}
 }
 

--- a/server/jetstream_benchmark_test.go
+++ b/server/jetstream_benchmark_test.go
@@ -1760,6 +1760,9 @@ func startJSClusterAndConnect(b *testing.B, clusterSize int) (c *cluster, s *Ser
 		shutdown = func() {
 			s.Shutdown()
 		}
+		s.optsMu.Lock()
+		s.opts.SyncInterval = 5 * time.Minute
+		s.optsMu.Unlock()
 	} else {
 		c = createJetStreamClusterExplicit(b, "BENCH_PUB", clusterSize)
 		c.waitOnClusterReadyWithNumPeers(clusterSize)
@@ -1767,6 +1770,11 @@ func startJSClusterAndConnect(b *testing.B, clusterSize int) (c *cluster, s *Ser
 		s = c.leader()
 		shutdown = func() {
 			c.shutdown()
+		}
+		for _, s := range c.servers {
+			s.optsMu.Lock()
+			s.opts.SyncInterval = 5 * time.Minute
+			s.optsMu.Unlock()
 		}
 	}
 


### PR DESCRIPTION
Previously this was always firing at the exact interval. Then #6041 changed this so that the first firing was anytime between 1s and the interval to spread out different stores. This tweaks it once more to anytime between interval/2 and interval. It will still spread things out a bit but hit the benchmarks a bit less badly.

Also go back to `math/rand` instead of `math/rand/v2` due to availability in Go versions that we still care about for 2.10.x.

Signed-off-by: Neil Twigg <neil@nats.io>
