### PR TITLE
Fix data race in `TestJetStreamClusterMetaSnapshotMustNotIncludePendingConsumers`

### DIFF
--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -4422,11 +4422,13 @@ func TestJetStreamClusterMetaSnapshotMustNotIncludePendingConsumers(t *testing.T
 	// in ghost consumers if the meta proposal failed.
 	ml := c.leader()
 	mjs := ml.getJetStream()
+	mjs.mu.Lock()
 	cc := mjs.cluster
 	consumers := cc.streams[globalAccountName]["TEST"].consumers
 	sampleCa := *consumers["consumer"]
 	sampleCa.Name, sampleCa.pending = "pending-consumer", true
 	consumers[sampleCa.Name] = &sampleCa
+	mjs.mu.Unlock()
 
 	// Create snapshot, this should not contain pending consumers.
 	snap := mjs.metaSnapshot()


### PR DESCRIPTION
Signed-off-by: Neil Twigg <neil@nats.io>