### PR TITLE
NRG: Reduce sendq allocations

### DIFF
--- a/server/sendq.go
+++ b/server/sendq.go
@@ -78,12 +78,14 @@ func (sq *sendq) internalLoop() {
 				if len(pm.hdr) > 0 {
 					c.pa.hdr = len(pm.hdr)
 					c.pa.hdb = append(hdb[:0], strconv.Itoa(c.pa.hdr)...)
-					msg = append(pm.hdr, pm.msg...)
+					msg = append(msg, pm.hdr...)
+					msg = append(msg, pm.msg...)
 					msg = append(msg, _CRLF_...)
 				} else {
 					c.pa.hdr = -1
 					c.pa.hdb = nil
-					msg = append(pm.msg, _CRLF_...)
+					msg = append(msg, pm.msg...)
+					msg = append(msg, _CRLF_...)
 				}
 				c.processInboundClientMsg(msg)
 				c.pa.szb = nil
@@ -108,16 +110,7 @@ func (sq *sendq) send(subj, rply string, hdr, msg []byte) {
 	}
 	out := outMsgPool.Get().(*outMsg)
 	out.subj, out.rply = subj, rply
-	out.hdr, out.msg = nil, nil
-
-	// We will copy these for now.
-	if len(hdr) > 0 {
-		hdr = copyBytes(hdr)
-		out.hdr = hdr
-	}
-	if len(msg) > 0 {
-		msg = copyBytes(msg)
-		out.msg = msg
-	}
+	out.hdr = append(out.hdr[:0], hdr...)
+	out.msg = append(out.msg[:0], msg...)
 	sq.q.push(out)
 }

--- a/server/sendq.go
+++ b/server/sendq.go
@@ -57,6 +57,8 @@ func (sq *sendq) internalLoop() {
 		rply [256]byte
 		szb  [10]byte
 		hdb  [10]byte
+		_msg [4096]byte
+		msg  = _msg[:0]
 	)
 
 	for s.isRunning() {
@@ -74,7 +76,7 @@ func (sq *sendq) internalLoop() {
 				} else {
 					c.pa.reply = nil
 				}
-				var msg []byte
+				msg = msg[:0]
 				if len(pm.hdr) > 0 {
 					c.pa.hdr = len(pm.hdr)
 					c.pa.hdb = append(hdb[:0], strconv.Itoa(c.pa.hdr)...)


### PR DESCRIPTION
This reduces allocations in the NRG `sendRPC` and `sendReply` functions by promoting buffer reuse.

Signed-off-by: Neil Twigg <neil@nats.io>