### PR TITLE
[FIXED] Freeze `n.Applied` for consumer when shutting down

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4949,7 +4949,11 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 						doSnapshot(true)
 					}
 				} else if err := js.applyConsumerEntries(o, ce, isLeader); err == nil {
-					ne, nb := n.Applied(ce.Index)
+					var ne, nb uint64
+					// We can't guarantee writes are flushed while we're shutting down. Just rely on replay during recovery.
+					if !js.isShuttingDown() {
+						ne, nb = n.Applied(ce.Index)
+					}
 					ce.ReturnToPool()
 					// If we have at least min entries to compact, go ahead and snapshot/compact.
 					if nb > 0 && ne >= compactNumMin || nb > compactSizeMin {


### PR DESCRIPTION
Similar to https://github.com/nats-io/nats-server/pull/6087, but for consumers. During shutdown we can't guarantee we'll still flush all that is needed. So don't touch `n.Applied` and rely on replay so those changes can be properly persisted.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
