### PR TITLE
Update to Go 1.23.3/1.22.9, use Go 1.23 for goreleaser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ language: go
 go:
   # This should be quoted or use .x, but should not be unquoted.
   # Remember that a YAML bare float drops trailing zeroes.
-  - "1.23.2"
-  - "1.22.8"
+  - "1.23.3"
+  - "1.22.9"
 
 go_import_path: github.com/nats-io/nats-server
 
@@ -58,4 +58,4 @@ deploy:
   script: curl -o /tmp/goreleaser.tar.gz -sLf https://github.com/goreleaser/goreleaser/releases/download/v1.26.2/goreleaser_Linux_x86_64.tar.gz && tar -xvf /tmp/goreleaser.tar.gz -C /tmp/ && /tmp/goreleaser
   on:
     tags: true
-    condition: ($TRAVIS_GO_VERSION =~ 1.22) && ($TEST_SUITE = "compile")
+    condition: ($TRAVIS_GO_VERSION =~ 1.23) && ($TEST_SUITE = "compile")


### PR DESCRIPTION
This updates the patch versions. It also updates the version that we use for goreleaser — all releases are currently built using Go 1.22, but there isn't really a good reason why we shouldn't build them with Go 1.23 instead, since there will be new compiler optimisations we can take advantage of.

Signed-off-by: Neil Twigg <neil@nats.io>