### PR TITLE
[FIXED] (2.11) Propose message delete for clustered interest stream

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -5977,6 +5977,7 @@ func (o *consumer) isMonitorRunning() bool {
 
 // If we detect that our ackfloor is higher than the stream's last sequence, return this error.
 var errAckFloorHigherThanLastSeq = errors.New("consumer ack floor is higher than streams last sequence")
+var errAckFloorInvalid = errors.New("consumer ack floor is invalid")
 
 // If we are a consumer of an interest or workqueue policy stream, process that state and make sure consistent.
 func (o *consumer) checkStateForInterestStream(ss *StreamState) error {
@@ -6006,7 +6007,7 @@ func (o *consumer) checkStateForInterestStream(ss *StreamState) error {
 	asflr := state.AckFloor.Stream
 	// Protect ourselves against rolling backwards.
 	if asflr&(1<<63) != 0 {
-		return nil
+		return errAckFloorInvalid
 	}
 
 	// Check if the underlying stream's last sequence is less than our floor.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2510,7 +2510,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 	var cist *time.Ticker
 	var cistc <-chan time.Time
 
-	checkInterestInterval := streamCheckInterestStateInterval + time.Duration(rand.Intn(streamCheckInterestStateJitterInSeconds))*time.Second
+	checkInterestInterval := checkInterestStateT + time.Duration(rand.Intn(checkInterestStateJ))*time.Second
 
 	if mset != nil && mset.isInterestRetention() {
 		// Wait on our consumers to be assigned and running before proceeding.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2510,8 +2510,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 	var cist *time.Ticker
 	var cistc <-chan time.Time
 
-	// 2 minutes plus up to 30s jitter.
-	checkInterestInterval := 2*time.Minute + time.Duration(rand.Intn(30))*time.Second
+	checkInterestInterval := streamCheckInterestStateInterval + time.Duration(rand.Intn(streamCheckInterestStateJitterInSeconds))*time.Second
 
 	if mset != nil && mset.isInterestRetention() {
 		// Wait on our consumers to be assigned and running before proceeding.

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -784,11 +784,11 @@ func TestJetStreamClusterConsumerPauseSurvivesRestart(t *testing.T) {
 }
 
 func TestJetStreamClusterStreamOrphanMsgsAndReplicasDrifting(t *testing.T) {
-	streamCheckInterestStateInterval = 4 * time.Second
-	streamCheckInterestStateJitterInSeconds = 1
+	checkInterestStateT = 4 * time.Second
+	checkInterestStateJ = 1
 	defer func() {
-		streamCheckInterestStateInterval = defaultStreamCheckInterestStateInterval
-		streamCheckInterestStateJitterInSeconds = defaultStreamCheckInterestStateJitterInSeconds
+		checkInterestStateT = defaultCheckInterestStateT
+		checkInterestStateJ = defaultCheckInterestStateJ
 	}()
 
 	type testParams struct {

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -784,6 +784,13 @@ func TestJetStreamClusterConsumerPauseSurvivesRestart(t *testing.T) {
 }
 
 func TestJetStreamClusterStreamOrphanMsgsAndReplicasDrifting(t *testing.T) {
+	streamCheckInterestStateInterval = 4 * time.Second
+	streamCheckInterestStateJitterInSeconds = 1
+	defer func() {
+		streamCheckInterestStateInterval = defaultStreamCheckInterestStateInterval
+		streamCheckInterestStateJitterInSeconds = defaultStreamCheckInterestStateJitterInSeconds
+	}()
+
 	type testParams struct {
 		restartAny       bool
 		restartLeader    bool

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -1225,13 +1225,21 @@ func TestJetStreamClusterStreamOrphanMsgsAndReplicasDrifting(t *testing.T) {
 				msets = append(msets, mset)
 			}
 			for seq := state.FirstSeq; seq <= state.LastSeq; seq++ {
+				var expectedErr error
 				var msgId string
 				var smv StoreMsg
 				for _, mset := range msets {
 					mset.mu.RLock()
 					sm, err := mset.store.LoadMsg(seq, &smv)
 					mset.mu.RUnlock()
-					require_NoError(t, err)
+					if err != nil || expectedErr != nil {
+						if expectedErr == nil {
+							expectedErr = err
+						} else {
+							require_Error(t, err, expectedErr)
+						}
+						continue
+					}
 					if msgId == _EMPTY_ {
 						msgId = string(sm.hdr)
 					} else if msgId != string(sm.hdr) {

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -9825,11 +9825,11 @@ func TestNoRaceJetStreamSnapshotsWithSlowAckDontSlowConsumer(t *testing.T) {
 }
 
 func TestNoRaceJetStreamWQSkippedMsgsOnScaleUp(t *testing.T) {
-	streamCheckInterestStateInterval = 4 * time.Second
-	streamCheckInterestStateJitterInSeconds = 1
+	checkInterestStateT = 4 * time.Second
+	checkInterestStateJ = 1
 	defer func() {
-		streamCheckInterestStateInterval = defaultStreamCheckInterestStateInterval
-		streamCheckInterestStateJitterInSeconds = defaultStreamCheckInterestStateJitterInSeconds
+		checkInterestStateT = defaultCheckInterestStateT
+		checkInterestStateJ = defaultCheckInterestStateJ
 	}()
 
 	c := createJetStreamClusterExplicit(t, "R3S", 3)

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -7271,17 +7271,25 @@ func TestNoRaceJetStreamInterestStreamCheckInterestRaceBug(t *testing.T) {
 		return nil
 	})
 
-	for _, s := range c.servers {
-		mset, err := s.GlobalAccount().lookupStream("TEST")
-		require_NoError(t, err)
+	checkFor(t, 5*time.Second, time.Second, func() error {
+		for _, s := range c.servers {
+			mset, err := s.GlobalAccount().lookupStream("TEST")
+			if err != nil {
+				return err
+			}
 
-		mset.mu.RLock()
-		defer mset.mu.RUnlock()
+			mset.mu.RLock()
+			defer mset.mu.RUnlock()
 
-		state := mset.state()
-		require_True(t, state.Msgs == 0)
-		require_True(t, state.FirstSeq == uint64(numToSend+1))
-	}
+			state := mset.state()
+			if state.Msgs != 0 {
+				return fmt.Errorf("too many messages: %d", state.Msgs)
+			} else if state.FirstSeq != uint64(numToSend+1) {
+				return fmt.Errorf("wrong FirstSeq: %d, expected: %d", state.FirstSeq, numToSend+1)
+			}
+		}
+		return nil
+	})
 }
 
 func TestNoRaceJetStreamClusterInterestStreamConsistencyAfterRollingRestart(t *testing.T) {
@@ -9817,6 +9825,13 @@ func TestNoRaceJetStreamSnapshotsWithSlowAckDontSlowConsumer(t *testing.T) {
 }
 
 func TestNoRaceJetStreamWQSkippedMsgsOnScaleUp(t *testing.T) {
+	streamCheckInterestStateInterval = 4 * time.Second
+	streamCheckInterestStateJitterInSeconds = 1
+	defer func() {
+		streamCheckInterestStateInterval = defaultStreamCheckInterestStateInterval
+		streamCheckInterestStateJitterInSeconds = defaultStreamCheckInterestStateJitterInSeconds
+	}()
+
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 
@@ -11189,7 +11204,7 @@ func TestNoRaceJetStreamClusterCheckInterestStatePerformanceInterest(t *testing.
 	}
 
 	require_Equal(t, checkFloor(mset.lookupConsumer("A")), 1)
-	require_Equal(t, checkFloor(mset.lookupConsumer("B")), 100_001)
+	require_Equal(t, checkFloor(mset.lookupConsumer("B")), 90_001)
 	require_Equal(t, checkFloor(mset.lookupConsumer("C")), 100_001)
 
 	// This checks the chkflr state. For this test this should be much faster,

--- a/server/stream.go
+++ b/server/stream.go
@@ -5679,13 +5679,13 @@ func (mset *stream) getPublicConsumers() []*consumer {
 
 // 2 minutes plus up to 30s jitter.
 const (
-	defaultStreamCheckInterestStateInterval        = 2 * time.Minute
-	defaultStreamCheckInterestStateJitterInSeconds = 30
+	defaultCheckInterestStateT = 2 * time.Minute
+	defaultCheckInterestStateJ = 30
 )
 
 var (
-	streamCheckInterestStateInterval        = defaultStreamCheckInterestStateInterval
-	streamCheckInterestStateJitterInSeconds = defaultStreamCheckInterestStateJitterInSeconds
+	checkInterestStateT = defaultCheckInterestStateT // Interval
+	checkInterestStateJ = defaultCheckInterestStateJ // Jitter (secs)
 )
 
 // Will check for interest retention and make sure messages

--- a/server/stream.go
+++ b/server/stream.go
@@ -6057,7 +6057,9 @@ func (mset *stream) ackMsg(o *consumer, seq uint64) bool {
 	if seq > state.LastSeq {
 		mset.registerPreAck(o, seq)
 		mset.mu.Unlock()
-		return false
+		// We have not removed the message, but should still signal so we could retry later
+		// since we potentially need to remove it then.
+		return true
 	}
 
 	// Always clear pre-ack if here.

--- a/server/stream.go
+++ b/server/stream.go
@@ -4993,13 +4993,11 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 	} else {
 		// Make sure to take into account any message assignments that we had to skip (clfs).
 		seq = lseq + 1 - clfs
-		// Check for preAcks and the need to skip vs store.
+		// Check for preAcks and the need to clear it.
 		if mset.hasAllPreAcks(seq, subject) {
 			mset.clearAllPreAcks(seq)
-			store.SkipMsg()
-		} else {
-			err = store.StoreRawMsg(subject, hdr, msg, seq, ts)
 		}
+		err = store.StoreRawMsg(subject, hdr, msg, seq, ts)
 	}
 
 	if err != nil {
@@ -5679,6 +5677,17 @@ func (mset *stream) getPublicConsumers() []*consumer {
 	return obs
 }
 
+// 2 minutes plus up to 30s jitter.
+const (
+	defaultStreamCheckInterestStateInterval        = 2 * time.Minute
+	defaultStreamCheckInterestStateJitterInSeconds = 30
+)
+
+var (
+	streamCheckInterestStateInterval        = defaultStreamCheckInterestStateInterval
+	streamCheckInterestStateJitterInSeconds = defaultStreamCheckInterestStateJitterInSeconds
+)
+
 // Will check for interest retention and make sure messages
 // that have been acked are processed and removed.
 // This will check the ack floors of all consumers, and adjust our first sequence accordingly.
@@ -6026,16 +6035,18 @@ func (mset *stream) clearPreAck(o *consumer, seq uint64) {
 }
 
 // ackMsg is called into from a consumer when we have a WorkQueue or Interest Retention Policy.
-func (mset *stream) ackMsg(o *consumer, seq uint64) {
+// Returns whether the message at seq was removed as a result of the ACK.
+// (Or should be removed in the case of clustered streams, since it requires a message delete proposal)
+func (mset *stream) ackMsg(o *consumer, seq uint64) bool {
 	if seq == 0 {
-		return
+		return false
 	}
 
 	// Don't make this RLock(). We need to have only 1 running at a time to gauge interest across all consumers.
 	mset.mu.Lock()
 	if mset.closed.Load() || mset.cfg.Retention == LimitsPolicy {
 		mset.mu.Unlock()
-		return
+		return false
 	}
 
 	store := mset.store
@@ -6046,7 +6057,7 @@ func (mset *stream) ackMsg(o *consumer, seq uint64) {
 	if seq > state.LastSeq {
 		mset.registerPreAck(o, seq)
 		mset.mu.Unlock()
-		return
+		return false
 	}
 
 	// Always clear pre-ack if here.
@@ -6055,7 +6066,7 @@ func (mset *stream) ackMsg(o *consumer, seq uint64) {
 	// Make sure this sequence is not below our first sequence.
 	if seq < state.FirstSeq {
 		mset.mu.Unlock()
-		return
+		return false
 	}
 
 	var shouldRemove bool
@@ -6067,18 +6078,35 @@ func (mset *stream) ackMsg(o *consumer, seq uint64) {
 	case InterestPolicy:
 		shouldRemove = mset.noInterest(seq, o)
 	}
-	mset.mu.Unlock()
 
 	// If nothing else to do.
 	if !shouldRemove {
-		return
+		mset.mu.Unlock()
+		return false
 	}
 
-	// If we are here we should attempt to remove.
-	if _, err := store.RemoveMsg(seq); err == ErrStoreEOF {
-		// This should not happen, but being pedantic.
-		mset.registerPreAckLock(o, seq)
+	if !mset.isClustered() {
+		mset.mu.Unlock()
+		// If we are here we should attempt to remove.
+		if _, err := store.RemoveMsg(seq); err == ErrStoreEOF {
+			// This should not happen, but being pedantic.
+			mset.registerPreAckLock(o, seq)
+		}
+		return true
 	}
+
+	// Only propose message deletion to the stream if we're consumer leader, otherwise all followers would also propose.
+	// We must be the consumer leader, since we know for sure we've stored the message and don't register as pre-ack.
+	if o != nil && !o.IsLeader() {
+		mset.mu.Unlock()
+		// Must still mark as removal if follower. If we become leader later, we must be able to retry the proposal.
+		return true
+	}
+
+	md := streamMsgDelete{Seq: seq, NoErase: true, Stream: mset.cfg.Name}
+	mset.node.ForwardProposal(encodeMsgDelete(&md))
+	mset.mu.Unlock()
+	return true
 }
 
 // Snapshot creates a snapshot for the stream and possibly consumers.


### PR DESCRIPTION
For an Interest or WorkQueue stream messages will be removed once all consumers that need to receive a message have acked it.

For a clustered stream each consumer would ack and remove a message by themselves. This can be problematic since that introduces different ordering between servers. For example when using DiscardOld with MaxMsgs, which could result in stream desync. Proposing the message removal ensures ordering between servers.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>