### PR TITLE
Fix data race when updating leader

### DIFF
--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -3967,7 +3967,9 @@ func TestJetStreamClusterDesyncAfterErrorDuringCatchup(t *testing.T) {
 				for _, n := range server.raftNodes {
 					rn := n.(*raft)
 					if rn.accName == "$G" {
+						rn.Lock()
 						rn.updateLeader(noLeader)
+						rn.Unlock()
 					}
 				}
 


### PR DESCRIPTION
Should solve this data race, where `rn.updateLeader(noLeader)` was called without holding the lock.
```
==================
WARNING: DATA RACE
Write at 0x00c0011d6da8 by goroutine 238071:
  github.com/nats-io/nats-server/v2/server.(*raft).updateLeader()
      /home/travis/build/nats-io/nats-server/server/raft.go:3212 +0x1fa
  github.com/nats-io/nats-server/v2/server.TestJetStreamClusterDesyncAfterErrorDuringCatchup.func2()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster_4_test.go:3970 +0x1f2
  github.com/nats-io/nats-server/v2/server.TestJetStreamClusterDesyncAfterErrorDuringCatchup.func3()
      /home/travis/build/nats-io/nats-server/server/jetstream_cluster_4_test.go:4046 +0xc56
  testing.tRunner()
      /home/travis/sdk/go1.23.3/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /home/travis/sdk/go1.23.3/src/testing/testing.go:1743 +0x44
Previous read at 0x00c0011d6da8 by goroutine 238374:
  github.com/nats-io/nats-server/v2/server.(*raft).processAppendEntry()
      /home/travis/build/nats-io/nats-server/server/raft.go:3351 +0x124c
  github.com/nats-io/nats-server/v2/server.(*raft).processAppendEntries()
      /home/travis/build/nats-io/nats-server/server/raft.go:2029 +0x1f2
  github.com/nats-io/nats-server/v2/server.(*raft).runAsFollower()
      /home/travis/build/nats-io/nats-server/server/raft.go:2044 +0x446
  github.com/nats-io/nats-server/v2/server.(*raft).run()
      /home/travis/build/nats-io/nats-server/server/raft.go:1906 +0x557
  github.com/nats-io/nats-server/v2/server.(*raft).run-fm()
      <autogenerated>:1 +0x33
  github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
      /home/travis/build/nats-io/nats-server/server/server.go:3885 +0x59
```
Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
