### PR TITLE
[FIXED] Don't `InstallSnapshot` during shutdown, would race with `monitorStream`/`monitorConsumer`

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -5700,12 +5700,6 @@ func (o *consumer) stopWithFlags(dflag, sdflag, doSignal, advisory bool) error {
 		if dflag {
 			n.Delete()
 		} else {
-			// Try to install snapshot on clean exit
-			if o.store != nil && (o.retention != LimitsPolicy || n.NeedSnapshot()) {
-				if snap, err := o.store.EncodedState(); err == nil {
-					n.InstallSnapshot(snap)
-				}
-			}
 			n.Stop()
 		}
 	}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2425,7 +2425,6 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 	// fully recovered from disk.
 	isRecovering := true
 
-	// Should only to be called from leader.
 	doSnapshot := func() {
 		if mset == nil || isRecovering || isRestore || time.Since(lastSnapTime) < minSnapDelta {
 			return

--- a/server/stream.go
+++ b/server/stream.go
@@ -5563,8 +5563,6 @@ func (mset *stream) stop(deleteFlag, advisory bool) error {
 			n.Delete()
 			sa = mset.sa
 		} else {
-			// Always attempt snapshot on clean exit.
-			n.InstallSnapshot(mset.stateSnapshotLocked())
 			n.Stop()
 		}
 	}


### PR DESCRIPTION
When stopping a stream or consumer, we would attempt to install a snapshot. However, this would race with what's happening in `monitorStream`/`monitorConsumer` at that time.

For example:
1. In `applyStreamEntries` we call into `mset.processJetStreamMsg` to persist one or multiple messages.
2. We call `mset.stop(..)` either before or during the above.
3. In `mset.stop(..)` we'd wait for `mset.processJetStreamMsg` to release the lock so we can enter  `mset.stateSnapshotLocked()`. **We create a snapshot with new state here!**
4. Now we call into `InstallSnapshot` to persist above snapshot, but `n.applied` does not contain the right value, the value will be lower.
5. Then `applyStreamEntries` finishes and we end with calling `n.Applied(..)`.

This would be a race condition depending on if 4 happened before or after 5.

It's essential that the snapshot we make is aligned with the `n.applied` value. If we don't that means we'll replay and need to increase `mset.clfs` which will snowball into stream desync due to this shift.

The only place where we can guarantee that the snapshot and applied are aligned is in `doSnapshot` of `monitorStream` and `monitorConsumer` (and `monitorCluster`), so we must not attempt installing snapshots outside of those.


Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
