### PR TITLE
[FIXED] check of the backoff and max delivery configs

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -623,7 +623,7 @@ func checkConsumerCfg(
 	}
 
 	// Check if we have a BackOff defined that MaxDeliver is within range etc.
-	if lbo := len(config.BackOff); lbo > 0 && config.MaxDeliver != -1 && config.MaxDeliver <= lbo {
+	if lbo := len(config.BackOff); lbo > 0 && config.MaxDeliver != -1 && lbo > config.MaxDeliver {
 		return NewJSConsumerMaxDeliverBackoffError()
 	}
 
@@ -2091,7 +2091,7 @@ func (acc *Account) checkNewConsumerConfig(cfg, ncfg *ConsumerConfig) error {
 	}
 
 	// Check if BackOff is defined, MaxDeliver is within range.
-	if lbo := len(ncfg.BackOff); lbo > 0 && ncfg.MaxDeliver != -1 && ncfg.MaxDeliver <= lbo {
+	if lbo := len(ncfg.BackOff); lbo > 0 && ncfg.MaxDeliver != -1 && lbo > ncfg.MaxDeliver {
 		return NewJSConsumerMaxDeliverBackoffError()
 	}
 


### PR DESCRIPTION
Match the check of the backoff and maxDeliver configs with the official documentation -> https://docs.nats.io/nats-concepts/jetstream/consumers#:~:text=The%20sequence%20length,MaxDelivery

Documentation, tell that `Backoff ` config **must** be **less than or equal** to `MaxDelivery`. But we were checking the opposite 

Signed-off-by: Luisao <luisgustavomacedo13@gmail.com>
