### PR TITLE
De-flake TestJetStreamClusterParallelStreamCreation & improve logging when `len(errCh) > 0 `

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -1415,7 +1415,7 @@ func TestJetStreamClusterParallelStreamCreation(t *testing.T) {
 	wg.Wait()
 
 	if len(errCh) > 0 {
-		t.Fatalf("Expected no errors, got %d", len(errCh))
+		t.Fatalf("Expected no errors, got %d: %v", len(errCh), <-errCh)
 	}
 
 	// We had a bug during parallel stream creation as well that would overwrite the sync subject used for catchups, etc.
@@ -1579,7 +1579,7 @@ func TestJetStreamClusterParallelConsumerCreation(t *testing.T) {
 	wg.Wait()
 
 	if len(errCh) > 0 {
-		t.Fatalf("Expected no errors, got %d", len(errCh))
+		t.Fatalf("Expected no errors, got %d: %v", len(errCh), <-errCh)
 	}
 
 	// Make sure we only have 3 unique raft groups for all servers.
@@ -5220,7 +5220,7 @@ func TestJetStreamClusterStreamFailTracking(t *testing.T) {
 
 	wg.Wait()
 	if len(errCh) > 0 {
-		t.Fatalf("Expected no errors, got %d", len(errCh))
+		t.Fatalf("Expected no errors, got %d: %v", len(errCh), <-errCh)
 	}
 }
 
@@ -5318,7 +5318,7 @@ func TestJetStreamClusterStreamFailTrackingSnapshots(t *testing.T) {
 
 	wg.Wait()
 	if len(errCh) > 0 {
-		t.Fatalf("Expected no errors, got %d", len(errCh))
+		t.Fatalf("Expected no errors, got %d: %v", len(errCh), <-errCh)
 	}
 }
 

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -1445,7 +1445,7 @@ func TestJetStreamClusterParallelStreamCreation(t *testing.T) {
 	node.InstallSnapshot(mset.stateSnapshot())
 
 	nl = c.restartServer(nl)
-	c.waitOnServerCurrent(nl)
+	c.waitOnStreamCurrent(nl, globalAccountName, "TEST")
 
 	mset, err = nl.GlobalAccount().lookupStream("TEST")
 	require_NoError(t, err)

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -7916,7 +7916,7 @@ func TestNoRaceParallelStreamAndConsumerCreation(t *testing.T) {
 
 	// Check for no errors.
 	if len(errCh) > 0 {
-		t.Fatalf("Expected no errors, got %d", len(errCh))
+		t.Fatalf("Expected no errors, got %d: %v", len(errCh), <-errCh)
 	}
 
 	// Now make sure we really only created one stream.
@@ -7979,7 +7979,7 @@ func TestNoRaceParallelStreamAndConsumerCreation(t *testing.T) {
 
 	// Check for no errors.
 	if len(errCh) > 0 {
-		t.Fatalf("Expected no errors, got %d", len(errCh))
+		t.Fatalf("Expected no errors, got %d: %v", len(errCh), <-errCh)
 	}
 
 	// Now make sure we really only created one stream.
@@ -9296,7 +9296,7 @@ func TestNoRaceJetStreamAPIDispatchQueuePending(t *testing.T) {
 	wg.Wait()
 
 	if len(errCh) > 0 {
-		t.Fatalf("Expected no errors, got %d", len(errCh))
+		t.Fatalf("Expected no errors, got %d: %v", len(errCh), <-errCh)
 	}
 }
 


### PR DESCRIPTION
`TestJetStreamClusterParallelStreamCreation` called `c.waitOnServerCurrent(nl)` whereas it should've called `c.waitOnStreamCurrent(nl, globalAccountName, "TEST")`. So it waits for the stream to be current, and not just the meta layer.

Also slightly extended logging where we'd only print `"Expected no errors, got 1"`. Now also logging the first received error to give more context what went wrong.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>