### PR TITLE
[IMPROVED] Encoding for large meta snapshots

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 toolchain go1.22.8
 
 require (
+	github.com/goccy/go-json v0.10.3
 	github.com/google/go-tpm v0.9.0
 	github.com/klauspost/compress v1.17.11
 	github.com/minio/highwayhash v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
+github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/google/go-tpm v0.9.0 h1:sQF6YqWMi+SCXpsmS3fd21oPy/vSddwZry4JnmltHVk=
 github.com/google/go-tpm v0.9.0/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The NATS Authors
+// Copyright 2018-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,6 @@ package server
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -25,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/auth_callout_test.go
+++ b/server/auth_callout_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The NATS Authors
+// Copyright 2022-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,7 +16,6 @@ package server
 import (
 	"bytes"
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -29,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -15,7 +15,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -25,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 )

--- a/server/certidp/certidp.go
+++ b/server/certidp/certidp.go
@@ -17,12 +17,12 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
 	"time"
 
+	"github.com/goccy/go-json"
 	"golang.org/x/crypto/ocsp"
 )
 

--- a/server/client.go
+++ b/server/client.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -33,6 +32,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/internal/fastrand"

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2022 The NATS Authors
+// Copyright 2012-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,7 +16,7 @@ package server
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"math"
@@ -31,8 +31,7 @@ import (
 	"testing"
 	"time"
 
-	"crypto/tls"
-
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -16,7 +16,6 @@ package server
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -29,6 +28,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server/avl"
 	"github.com/nats-io/nuid"
 	"golang.org/x/time/rate"

--- a/server/events.go
+++ b/server/events.go
@@ -18,7 +18,6 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -30,8 +29,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
-
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/server/certidp"
 	"github.com/nats-io/nats-server/v2/server/pse"

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -16,7 +16,6 @@ package server
 import (
 	"bytes"
 	"crypto/sha256"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -30,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -22,7 +22,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"hash"
@@ -40,6 +39,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/minio/highwayhash"
 	"github.com/nats-io/nats-server/v2/server/avl"

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -24,7 +24,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -40,6 +39,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/nuid"
 )
@@ -1484,8 +1484,6 @@ func TestFileStoreMeta(t *testing.T) {
 	if err := json.Unmarshal(buf, &oconfig2); err != nil {
 		t.Fatalf("Error unmarshalling: %v", err)
 	}
-	// Since we set name we will get that back now.
-	oconfig.Name = oname
 	if !reflect.DeepEqual(oconfig2, oconfig) {
 		t.Fatalf("Consumer configs not equal, got %+v vs %+v", oconfig2, oconfig)
 	}

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -18,7 +18,6 @@ import (
 	"cmp"
 	"crypto/sha256"
 	"crypto/tls"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -30,6 +29,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 const (

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -31,10 +30,12 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/nats-io/nats-server/v2/internal/ocsp"
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/logger"
 	"github.com/nats-io/nats.go"
 	"golang.org/x/crypto/ocsp"
+
+	. "github.com/nats-io/nats-server/v2/internal/ocsp"
 )
 
 func init() {

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -18,7 +18,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -30,6 +29,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/minio/highwayhash"
 	"github.com/nats-io/nats-server/v2/server/sysmem"
 	"github.com/nats-io/nats-server/v2/server/tpm"

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 The NATS Authors
+// Copyright 2020-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,7 +16,6 @@ package server
 import (
 	"bytes"
 	"cmp"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -31,6 +30,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nuid"
 )
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -18,7 +18,6 @@ import (
 	"cmp"
 	crand "crypto/rand"
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -32,6 +31,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/minio/highwayhash"
 	"github.com/nats-io/nuid"
@@ -1572,7 +1572,7 @@ func (js *jetStream) metaSnapshot() []byte {
 	b, _ := json.Marshal(streams)
 	js.mu.RUnlock()
 
-	return s2.EncodeBetter(nil, b)
+	return s2.Encode(nil, b)
 }
 
 func (js *jetStream) applyMetaSnapshot(buf []byte, ru *recoveryUpdates, isRecovering bool) error {

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	crand "crypto/rand"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -33,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 )

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -22,7 +22,6 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -37,6 +36,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats.go"
 )
 

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -19,7 +19,6 @@ package server
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -33,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 )

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -19,7 +19,6 @@ package server
 import (
 	"context"
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -35,6 +34,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nuid"
 )

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The NATS Authors
+// Copyright 2022-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,7 +17,6 @@
 package server
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -29,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nuid"
 )

--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The NATS Authors
+// Copyright 2020-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,8 +14,9 @@
 package server
 
 import (
-	"encoding/json"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 func (s *Server) publishAdvisory(acc *Account, subject string, adv any) {

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -33,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats.go"
 	"golang.org/x/time/rate"
 )

--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 The NATS Authors
+// Copyright 2020-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,7 +17,6 @@
 package server
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -27,9 +26,11 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/nats-io/jwt/v2"
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"
+
+	jwt "github.com/nats-io/jwt/v2"
 )
 
 func TestJetStreamJWTLimits(t *testing.T) {

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -17,7 +17,6 @@
 package server
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -30,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	crand "crypto/rand"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -42,6 +41,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/server/sysmem"
 	"github.com/nats-io/nats.go"

--- a/server/jetstream_versioning_test.go
+++ b/server/jetstream_versioning_test.go
@@ -19,15 +19,14 @@ package server
 import (
 	"archive/tar"
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
-
 	"github.com/nats-io/nats.go"
 )
 

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 The NATS Authors
+// Copyright 2018-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -31,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
@@ -36,6 +35,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -20,7 +20,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
-	"encoding/json"
 	"expvar"
 	"fmt"
 	"net"
@@ -37,6 +36,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/server/pse"
 )

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2023 The NATS Authors
+// Copyright 2013-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,7 +16,6 @@ package server
 import (
 	"bytes"
 	"crypto/tls"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -35,6 +34,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 The NATS Authors
+// Copyright 2020-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -18,7 +18,6 @@ import (
 	"cmp"
 	"crypto/tls"
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -31,6 +30,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nuid"
 )
 

--- a/server/mqtt_ex_test_test.go
+++ b/server/mqtt_ex_test_test.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -27,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nuid"
 )
 

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 The NATS Authors
+// Copyright 2020-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/tls"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -33,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/msgtrace.go
+++ b/server/msgtrace.go
@@ -15,13 +15,14 @@ package server
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 const (

--- a/server/msgtrace_test.go
+++ b/server/msgtrace_test.go
@@ -19,7 +19,6 @@ package server
 import (
 	"bytes"
 	"compress/gzip"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -28,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"

--- a/server/nkey_test.go
+++ b/server/nkey_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The NATS Authors
+// Copyright 2018-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,15 +15,16 @@ package server
 
 import (
 	"bufio"
-	crand "crypto/rand"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	mrand "math/rand"
 	"strings"
 	"testing"
 	"time"
 
+	crand "crypto/rand"
+	mrand "math/rand"
+
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nkeys"
 )
 

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -22,7 +22,6 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -48,6 +47,7 @@ import (
 	crand "crypto/rand"
 	"crypto/sha256"
 
+	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/server/avl"
@@ -11181,4 +11181,58 @@ func TestNoRaceJetStreamClusterCheckInterestStatePerformanceInterest(t *testing.
 	start = time.Now()
 	mset.checkInterestState()
 	require_True(t, time.Since(start) < elapsed/100)
+}
+
+func TestNoRaceJetStreamClusterLargeMetaSnapshotTiming(t *testing.T) {
+	// This test was to show improvements in speed for marshaling the meta layer with lots of assets.
+	// Move to S2.Encode vs EncodeBetter which is 2x faster and actually better compression.
+	// Also moved to goccy json which is faster then the default and in my tests now always matches
+	// the default encoder byte for byte which last time I checked it did not.
+	t.Skip()
+
+	c := createJetStreamClusterExplicit(t, "R3F", 3)
+	defer c.shutdown()
+
+	// Create 200 streams, each with 500 consumers.
+	numStreams := 200
+	numConsumers := 500
+	wg := sync.WaitGroup{}
+	wg.Add(numStreams)
+	for i := 0; i < numStreams; i++ {
+		go func() {
+			defer wg.Done()
+			s := c.randomServer()
+			nc, js := jsClientConnect(t, s)
+			defer nc.Close()
+			sname := fmt.Sprintf("TEST-SNAPSHOT-%d", i)
+			subj := fmt.Sprintf("foo.%d", i)
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     sname,
+				Subjects: []string{subj},
+				Replicas: 3,
+			})
+			require_NoError(t, err)
+
+			// Now consumers.
+			for c := 0; c < numConsumers; c++ {
+				_, err = js.AddConsumer(sname, &nats.ConsumerConfig{
+					Durable:       fmt.Sprintf("C-%d", c),
+					FilterSubject: subj,
+					AckPolicy:     nats.AckExplicitPolicy,
+					Replicas:      1,
+				})
+				require_NoError(t, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	s := c.leader()
+	js := s.getJetStream()
+	n := js.getMetaGroup()
+	// Now let's see how long it takes to create a meta snapshot and how big it is.
+	start := time.Now()
+	snap := js.metaSnapshot()
+	require_NoError(t, n.InstallSnapshot(snap))
+	t.Logf("Took %v to snap meta with size of %v\n", time.Since(start), friendlyBytes(len(snap)))
 }

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -5371,7 +5371,7 @@ func TestNoRaceJetStreamClusterStreamNamesAndInfosMoreThanAPILimit(t *testing.T)
 		createStream(name)
 	}
 
-	// Not using the JS API here beacause we want to make sure that the
+	// Not using the JS API here because we want to make sure that the
 	// server returns the proper Total count, but also that it does not
 	// send more than when the API limit is in one go.
 	check := func(subj string, limit int) {
@@ -5379,19 +5379,35 @@ func TestNoRaceJetStreamClusterStreamNamesAndInfosMoreThanAPILimit(t *testing.T)
 
 		nreq := JSApiStreamNamesRequest{}
 		b, _ := json.Marshal(nreq)
+
 		msg, err := nc.Request(subj, b, 2*time.Second)
 		require_NoError(t, err)
 
-		nresp := JSApiStreamNamesResponse{}
-		json.Unmarshal(msg.Data, &nresp)
-		if n := nresp.ApiPaged.Total; n != max {
-			t.Fatalf("Expected total to be %v, got %v", max, n)
-		}
-		if n := nresp.ApiPaged.Limit; n != limit {
-			t.Fatalf("Expected limit to be %v, got %v", limit, n)
-		}
-		if n := len(nresp.Streams); n != limit {
-			t.Fatalf("Expected number of streams to be %v, got %v", limit, n)
+		switch subj {
+		case JSApiStreams:
+			nresp := JSApiStreamNamesResponse{}
+			json.Unmarshal(msg.Data, &nresp)
+			if n := nresp.ApiPaged.Total; n != max {
+				t.Fatalf("Expected total to be %v, got %v", max, n)
+			}
+			if n := nresp.ApiPaged.Limit; n != limit {
+				t.Fatalf("Expected limit to be %v, got %v", limit, n)
+			}
+			if n := len(nresp.Streams); n != limit {
+				t.Fatalf("Expected number of streams to be %v, got %v", limit, n)
+			}
+		case JSApiStreamList:
+			nresp := JSApiStreamListResponse{}
+			json.Unmarshal(msg.Data, &nresp)
+			if n := nresp.ApiPaged.Total; n != max {
+				t.Fatalf("Expected total to be %v, got %v", max, n)
+			}
+			if n := nresp.ApiPaged.Limit; n != limit {
+				t.Fatalf("Expected limit to be %v, got %v", limit, n)
+			}
+			if n := len(nresp.Streams); n != limit {
+				t.Fatalf("Expected number of streams to be %v, got %v", limit, n)
+			}
 		}
 	}
 

--- a/server/ocsp_responsecache.go
+++ b/server/ocsp_responsecache.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The NATS Authors
+// Copyright 2023-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,6 @@ package server
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -27,6 +26,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"golang.org/x/crypto/ocsp"
 

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2020 The NATS Authors
+// Copyright 2012-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,7 +16,6 @@ package server
 import (
 	"bytes"
 	"crypto/tls"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"net/url"
@@ -29,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 The NATS Authors
+// Copyright 2017-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/base64"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -35,6 +34,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/route.go
+++ b/server/route.go
@@ -16,7 +16,6 @@ package server
 import (
 	"bytes"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
@@ -28,6 +27,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 )
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2023 The NATS Authors
+// Copyright 2013-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
@@ -35,6 +34,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/server.go
+++ b/server/server.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -28,27 +27,27 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"regexp"
-	"runtime/pprof"
-
-	// Allow dynamic profiling.
-	_ "net/http/pprof"
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	// Allow dynamic profiling.
+	_ "net/http/pprof"
+
+	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
+	"github.com/nats-io/nats-server/v2/logger"
 	"github.com/nats-io/nkeys"
 	"github.com/nats-io/nuid"
-
-	"github.com/nats-io/nats-server/v2/logger"
 )
 
 const (

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -35,8 +34,10 @@ import (
 	"testing"
 	"time"
 
-	srvlog "github.com/nats-io/nats-server/v2/logger"
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats.go"
+
+	srvlog "github.com/nats-io/nats-server/v2/logger"
 )
 
 func checkForErr(totalWait, sleepDur time.Duration, f func() error) error {

--- a/server/stream.go
+++ b/server/stream.go
@@ -17,7 +17,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -32,6 +31,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/nuid"
 )

--- a/server/tpm/js_ek_tpm_windows.go
+++ b/server/tpm/js_ek_tpm_windows.go
@@ -17,12 +17,12 @@ package tpm
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
+	"github.com/goccy/go-json"
 	"github.com/google/go-tpm/legacy/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 	"github.com/nats-io/nkeys"

--- a/server/util.go
+++ b/server/util.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,7 +16,6 @@ package server
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -26,6 +25,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // This map is used to store URLs string as the key with a reference count as

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -19,7 +19,6 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -34,11 +33,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
+	"github.com/klauspost/compress/flate"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"
-
-	"github.com/klauspost/compress/flate"
 )
 
 type testReader struct {

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,12 +14,12 @@
 package test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 )
 

--- a/test/gateway_test.go
+++ b/test/gateway_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 The NATS Authors
+// Copyright 2018-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -25,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 )

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
@@ -30,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/logger"
 	"github.com/nats-io/nats-server/v2/server"

--- a/test/monitor_test.go
+++ b/test/monitor_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2020 The NATS Authors
+// Copyright 2012-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,7 +16,6 @@ package test
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -28,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 )

--- a/test/new_routes_test.go
+++ b/test/new_routes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2022 The NATS Authors
+// Copyright 2018-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,12 +14,12 @@
 package test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/logger"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"

--- a/test/norace_test.go
+++ b/test/norace_test.go
@@ -19,7 +19,6 @@ package test
 import (
 	"context"
 	crand "crypto/rand"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -31,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nuid"

--- a/test/ocsp_peer_test.go
+++ b/test/ocsp_peer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The NATS Authors
+// Copyright 2023-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,7 +17,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -27,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	. "github.com/nats-io/nats-server/v2/internal/ocsp"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
@@ -3013,12 +3013,12 @@ func TestOCSPMonitoringPort(t *testing.T) {
 				net: 127.0.0.1
 				port: -1
 				https: -1
-				ocsp { 
+				ocsp {
                                   mode = always
                                   url = http://127.0.0.1:18888
                                 }
                                 store_dir = %s
-                                
+
 				tls: {
 					cert_file: "configs/certs/ocsp_peer/mini-ca/server1/TestServer1_bundle.pem"
 					key_file: "configs/certs/ocsp_peer/mini-ca/server1/private/TestServer1_keypair.pem"

--- a/test/ports_test.go
+++ b/test/ports_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 The NATS Authors
+// Copyright 2018-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 package test
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -23,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 )
 

--- a/test/proto_test.go
+++ b/test/proto_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2020 The NATS Authors
+// Copyright 2012-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,10 +14,10 @@
 package test
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 )
 

--- a/test/route_discovery_test.go
+++ b/test/route_discovery_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 The NATS Authors
+// Copyright 2015-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -15,7 +15,6 @@ package test
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -26,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 )
 

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 package test
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -25,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/internal/testhelper"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"

--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The NATS Authors
+// Copyright 2019-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 package test
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -26,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"

--- a/test/test.go
+++ b/test/test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2019 The NATS Authors
+// Copyright 2012-2024 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,7 +16,6 @@ package test
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -28,8 +27,10 @@ import (
 	"testing"
 	"time"
 
-	srvlog "github.com/nats-io/nats-server/v2/logger"
+	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
+
+	srvlog "github.com/nats-io/nats-server/v2/logger"
 )
 
 // So we can pass tests and benchmarks..


### PR DESCRIPTION
Improve very large meta snapshots by moving to goccy json pkg and utilize s2.Encode vs EncodeBetter which is faster and compresses better on on our meta snapshots.

Signed-off-by: Derek Collison <derek@nats.io>