### PR TITLE
NRG: empty snapshots dir if memory WAL

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -424,18 +424,18 @@ func (s *Server) initRaftNode(accName string, cfg *RaftConfig, labels pprofLabel
 		n.vote = vote
 	}
 
-	// Make sure that the snapshots directory exists.
-	if err := os.MkdirAll(filepath.Join(n.sd, snapshotsDir), defaultDirPerms); err != nil {
-		return nil, fmt.Errorf("could not create snapshots directory - %v", err)
-	}
-
 	// Can't recover snapshots if memory based since wal will be reset.
 	// We will inherit from the current leader.
 	if _, ok := n.wal.(*memStore); ok {
-		os.Remove(filepath.Join(n.sd, snapshotsDir, "*"))
+		_ = os.RemoveAll(filepath.Join(n.sd, snapshotsDir))
 	} else {
 		// See if we have any snapshots and if so load and process on startup.
 		n.setupLastSnapshot()
+	}
+
+	// Make sure that the snapshots directory exists.
+	if err := os.MkdirAll(filepath.Join(n.sd, snapshotsDir), defaultDirPerms); err != nil {
+		return nil, fmt.Errorf("could not create snapshots directory - %v", err)
 	}
 
 	truncateAndErr := func(index uint64) {

--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -320,6 +320,15 @@ func newStateAdder(s *Server, cfg *RaftConfig, n RaftNode) stateMachine {
 
 func initSingleMemRaftNode(t *testing.T) (*raft, func()) {
 	t.Helper()
+	n, c := initSingleMemRaftNodeWithCluster(t)
+	cleanup := func() {
+		c.shutdown()
+	}
+	return n, cleanup
+}
+
+func initSingleMemRaftNodeWithCluster(t *testing.T) (*raft, *cluster) {
+	t.Helper()
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	s := c.servers[0] // RunBasicJetStreamServer not available
 
@@ -332,10 +341,7 @@ func initSingleMemRaftNode(t *testing.T) (*raft, func()) {
 	n, err := s.initRaftNode(globalAccountName, cfg, pprofLabels{})
 	require_NoError(t, err)
 
-	cleanup := func() {
-		c.shutdown()
-	}
-	return n, cleanup
+	return n, c
 }
 
 // Encode an AppendEntry.


### PR DESCRIPTION
`os.Remove(filepath.Join(n.sd, snapshotsDir, "*"))` doesn't remove all files in the snapshots directory. This PR ensures the snapshots dir is cleaned up for in-memory WALs.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
