### PR TITLE
JetStream pull over export service response type stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ _test
 dist
 
 # Configuration Files
-*.conf
 *.cfg
 
 # Architecture specific extensions/prefixes

--- a/server/client.go
+++ b/server/client.go
@@ -4334,7 +4334,7 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 		// For now we can't do $JS.ACK since that breaks pull consumers across accounts.
 		if !bytes.HasPrefix(c.pa.reply, []byte(jsAckPre)) {
 			// We need to know if this is a Jetstream message stream when deciding if we should remove the import
-			isJetstreamMsg = true
+			isJetstreamMsg = false
 			if rsi = c.setupResponseServiceImport(acc, si, tracking, headers); rsi != nil {
 				nrr = []byte(rsi.from)
 			}
@@ -4342,6 +4342,7 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 			// This only happens when we do a pull subscriber that trampolines through another account.
 			// Normally this code is not called.
 			nrr = c.pa.reply
+			isJetstreamMsg = true
 		}
 	} else if !isResponse && si.latency != nil && tracking {
 		// Check to see if this was a bad request with no reply and we were supposed to be tracking.

--- a/server/client.go
+++ b/server/client.go
@@ -4324,7 +4324,7 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 
 	var nrr []byte
 	var rsi *serviceImport
-	var isJetstreamMsg bool
+	var isJetstreamMsg = false
 
 	// Check if there is a reply present and set up a response.
 	tracking, headers := shouldSample(si.latency, c)
@@ -4334,7 +4334,6 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 		// For now we can't do $JS.ACK since that breaks pull consumers across accounts.
 		if !bytes.HasPrefix(c.pa.reply, []byte(jsAckPre)) {
 			// We need to know if this is a Jetstream message stream when deciding if we should remove the import
-			isJetstreamMsg = false
 			if rsi = c.setupResponseServiceImport(acc, si, tracking, headers); rsi != nil {
 				nrr = []byte(rsi.from)
 			}

--- a/server/client.go
+++ b/server/client.go
@@ -4333,7 +4333,6 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 		// TODO(dlc) - Formalize as a service import option for reply rewrite.
 		// For now we can't do $JS.ACK since that breaks pull consumers across accounts.
 		if !bytes.HasPrefix(c.pa.reply, []byte(jsAckPre)) {
-			// We need to know if this is a Jetstream message stream when deciding if we should remove the import
 			if rsi = c.setupResponseServiceImport(acc, si, tracking, headers); rsi != nil {
 				nrr = []byte(rsi.from)
 			}
@@ -4341,6 +4340,7 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 			// This only happens when we do a pull subscriber that trampolines through another account.
 			// Normally this code is not called.
 			nrr = c.pa.reply
+			// We need to know if this is a Jetstream message stream when deciding if we should remove the import
 			isJetstreamMsg = true
 		}
 	} else if !isResponse && si.latency != nil && tracking {

--- a/server/configs/multi_accounts_export_import.conf
+++ b/server/configs/multi_accounts_export_import.conf
@@ -1,0 +1,45 @@
+listen: 127.0.0.1:4043
+http: 127.0.0.1:8043
+
+password = "s3cr3t!"
+
+jetstream {
+  store_dir: "/tmp/nats-server/js-test"
+  max_memory_store: 1073741824
+  max_file_store: 10737418240
+}
+
+accounts: {
+   engineering: {
+      users = [
+        {user: alice, password: $password}
+        {user: bob,   password: $password}
+      ]
+    }
+
+    legal: {
+      jetstream: enabled
+      users = [
+        {user: john,  password: $password}
+        {user: mary,  password: $password}
+      ]
+      exports: [
+            { service: "$JS.API.>", accounts: [ "finance" ], response_type: "stream" }
+            { service: "foo.>", accounts: [ "finance" ], response_type: "stream" }
+        ]  
+    }
+
+    finance: {
+      jetstream: enabled
+      users = [
+        {user: peter, password: $password}
+        {user: paul,  password: $password}
+      ]
+      imports: [
+            { service: { account: legal, subject: "$JS.API.>" }, to: "$JS.legal.API.>" }
+            { service: { account: legal, subject: "foo.>"  } }  
+      ]
+    }
+}
+
+no_sys_acc: true

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -99,7 +99,7 @@ func RunBasicJetStreamServer(t testing.TB) *Server {
 }
 
 func RunServerWithExportImport(t *testing.T) *Server {
-	server, _ := RunServerWithConfig(".\\configs\\multi_accounts_export_import.conf")
+	server, _ := RunServerWithConfig("./configs/multi_accounts_export_import.conf")
 	return server
 }
 


### PR DESCRIPTION
Suggested fix - no unit tests provided yet

When doing a Jetstream fetch request to a stream across an account boundary we export:
`{ service: "$JS.API.>", accounts: [ "B" ], response_type: "stream" }`

When the reply stream contain a nil message (no body no headers) the import reply subject mapping is removed. This seems to be by design. To Jetstream this looks like a message loss and results in timeouts and retries. Note that not just the nil message is suppressed but all messages coming after the nil messages are not delivered either.

Adding a header to all messages (e.g. Nats-Msg-Id) prevents this effect.

The fix here make removeRespServiceImport() Jetstream aware. Not removing it for messages which which $JS.ACK set. This is a minor fix with no performance impact as the check for JS reply subjects is done anyway further up in the code.

Also see internal Zendesk ticket [986]

Signed-off-by:m Michael Roeschter <michael@synadia.com>
