### PR TITLE
Refactor duplicate `Nats-Msg-Id` tracking

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8135,7 +8135,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 			}
 			// FIXME(dlc) - locking conflict with accessing mset.clseq
 			// For now we stage with zero, and will update in processStreamMsg.
-			mset.storeMsgIdLocked(&ddentry{msgId, 0, time.Now().UnixNano()})
+			mset.storeMsgIdLocked(&ddentry{msgId, 0, time.Now().UnixNano(), nil, nil})
 			mset.mu.Unlock()
 		}
 	}
@@ -8763,7 +8763,7 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 				mset.rebuildDedupe()
 				mset.mu.Unlock()
 			}
-			mset.storeMsgId(&ddentry{msgId, seq, ts})
+			mset.storeMsgId(&ddentry{msgId, seq, ts, nil, nil})
 		}
 	}
 

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -24458,7 +24458,7 @@ func TestJetStreamStreamConfigClone(t *testing.T) {
 		Name:             "name",
 		Placement:        &Placement{Cluster: "placement", Tags: []string{"tag"}},
 		Mirror:           &StreamSource{Name: "mirror"},
-		Sources:          []*StreamSource{&StreamSource{Name: "source"}},
+		Sources:          []*StreamSource{{Name: "source"}},
 		SubjectTransform: &SubjectTransformConfig{Source: "source", Destination: "dest"},
 		RePublish:        &RePublish{Source: "source", Destination: "dest", HeadersOnly: false},
 		Metadata:         make(map[string]string),
@@ -24720,4 +24720,167 @@ func TestJetStreamMemoryPurgeClearsSubjectsState(t *testing.T) {
 	si, err = js.StreamInfo("TEST", &nats.StreamInfoRequest{SubjectsFilter: ">"})
 	require_NoError(t, err)
 	require_Len(t, len(si.State.Subjects), 0)
+}
+
+func TestJetStreamMsgIdDeduplication(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:       "TEST",
+		Subjects:   []string{"test"},
+		Duplicates: time.Second / 2,
+	})
+	require_NoError(t, err)
+
+	require_Publish := func(id string) {
+		t.Helper()
+		msg := &nats.Msg{
+			Subject: "test",
+			Header:  nats.Header{},
+		}
+		msg.Header.Set("Nats-Msg-Id", id)
+		_, err := js.PublishMsg(msg)
+		require_NoError(t, err)
+	}
+
+	require_Messages := func(msgs uint64) {
+		t.Helper()
+		si, err := js.StreamInfo("TEST")
+		require_NoError(t, err)
+		require_Equal(t, si.State.Msgs, msgs)
+	}
+
+	mset, err := s.GlobalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+
+	require_Stitched := func() {
+		t.Helper()
+		require_NotNil(t, mset.ddnext)
+		require_NotNil(t, mset.ddlast)
+		require_Equal(t, mset.ddnext.prev, nil)
+		require_Equal(t, mset.ddlast.next, nil)
+		for dde := mset.ddnext; dde != nil && dde != mset.ddlast; dde = dde.next {
+			if dde.next != nil {
+				require_Equal(t, dde.next.prev, dde)
+			}
+			if dde.prev != nil {
+				require_Equal(t, dde.prev.next, dde)
+			}
+		}
+	}
+
+	// At this point nothing has sent a message with a Nats-Msg-Id
+	// so there should be no state and no timer.
+	mset.mu.RLock()
+	require_Equal(t, mset.ddtmr, nil)
+	require_Equal(t, mset.ddnext, nil)
+	require_Equal(t, mset.ddlast, nil)
+	require_Equal(t, mset.ddtmr, nil)
+	mset.mu.RUnlock()
+
+	// Publish the first message with a Nats-Msg-Id. There should
+	// be exactly one message, which means it is both the next and
+	// the last.
+	require_Publish("one")
+	require_Messages(1)
+	mset.mu.RLock()
+	require_Equal(t, mset.ddmap.Size(), 1)
+	one, ok := mset.ddmap.Find(stringToBytes("one"))
+	require_True(t, ok)
+	require_Equal(t, mset.ddnext, *one)
+	require_Equal(t, mset.ddlast, *one)
+	require_Stitched()
+	require_NotNil(t, mset.ddtmr)
+	mset.mu.RUnlock()
+
+	// Now publish a duplicate. Nothing should change.
+	require_Publish("one")
+	require_Messages(1)
+	mset.mu.RLock()
+	require_Equal(t, mset.ddmap.Size(), 1)
+	require_Equal(t, mset.ddnext, *one)
+	require_Equal(t, mset.ddlast, *one)
+	require_Stitched()
+	require_NotNil(t, mset.ddtmr)
+	mset.mu.RUnlock()
+
+	// Publish a second message with a different Nats-Msg-Id.
+	// There will now be two messages and the ddentries for one
+	// and two should now be stitched together, with one being
+	// up front and two being last.
+	require_Publish("two")
+	require_Messages(2)
+	mset.mu.RLock()
+	require_Equal(t, mset.ddmap.Size(), 2)
+	two, ok := mset.ddmap.Find(stringToBytes("two"))
+	require_True(t, ok)
+	require_Equal(t, mset.ddnext, *one)
+	require_Equal(t, mset.ddlast, *two)
+	require_Stitched()
+	require_NotNil(t, mset.ddtmr)
+	mset.mu.RUnlock()
+
+	// Publish a third message with a different Nats-Msg-Id.
+	// There will now be three messages and the ddentries for
+	// all three should have been stitched together, with one
+	// still being up front and three now being last.
+	require_Publish("three")
+	require_Messages(3)
+	mset.mu.RLock()
+	require_Equal(t, mset.ddmap.Size(), 3)
+	three, ok := mset.ddmap.Find(stringToBytes("three"))
+	require_True(t, ok)
+	require_Equal(t, mset.ddnext, *one)
+	require_Equal(t, mset.ddlast, *three)
+	require_Stitched()
+	require_NotNil(t, mset.ddtmr)
+	mset.mu.RUnlock()
+
+	// Publish another duplicate for one, which is filtered
+	// out and ignored. Therefore all of the state should be
+	// unchanged from the previous publish.
+	require_Publish("one")
+	require_Messages(3)
+	mset.mu.RLock()
+	require_Equal(t, mset.ddmap.Size(), 3)
+	newone, ok := mset.ddmap.Find(stringToBytes("one"))
+	require_True(t, ok)
+	require_Equal(t, *one, *newone) // Entry not overwritten.
+	require_Equal(t, mset.ddnext, *one)
+	require_Equal(t, mset.ddlast, *three)
+	require_Stitched()
+	require_NotNil(t, mset.ddtmr)
+	mset.mu.RUnlock()
+
+	// Wait for the duplicate window to pass.
+	time.Sleep(time.Second)
+
+	// By this point the timer has fired and therefore the
+	// state for duplicates has been cleaned up by now.
+	mset.mu.RLock()
+	require_Equal(t, mset.ddmap.Size(), 0)
+	require_Equal(t, mset.ddtmr, nil)
+	require_Equal(t, mset.ddnext, nil)
+	require_Equal(t, mset.ddlast, nil)
+	mset.mu.RUnlock()
+
+	// This should now let us publish another message with
+	// a Nats-Msg-Id of one, which would have been a duplicate
+	// before but now isn't. Therefore there should now be 4
+	// messages in the stream.
+	require_Publish("one")
+	require_Messages(4)
+	mset.mu.RLock()
+	require_Equal(t, mset.ddmap.Size(), 1)
+	one, ok = mset.ddmap.Find(stringToBytes("one"))
+	require_True(t, ok)
+	require_Equal(t, mset.ddnext, *one)
+	require_Equal(t, mset.ddlast, *one)
+	require_Stitched()
+	require_NotNil(t, mset.ddtmr)
+	mset.mu.RUnlock()
 }


### PR DESCRIPTION
The current duplicate tracking has a couple of problems, namely that the `ddmap` capacity is potentially never reclaimed if it grows suddenly, and secondly that we have to constantly monitor `ddarr`'s capacity and copy it to stop the array from growing infinitely too.

This PR makes the following changes:

- `ddmap` is now using the stree, which means there is efficient in-place deduplication of message IDs and no infinitely growing backing capacity;
- `ddarr` and `ddindex` are now gone, replaced with linked-list references and `ddnext` and `ddlast` tracking, so we also don't need to watch the capacity and reallocate this either;
- `ddtmr` is now only scheduled when there is actually something to do.

Also added a unit test to prove the behaviour as well as the linked-list stitching.

Signed-off-by: Neil Twigg <neil@nats.io>
