### PR TITLE
fix(leafnode): credentials parsing for leafnode connections doesn't handle CRLFs correctly

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -796,7 +796,7 @@ func (s *Server) startLeafNodeAcceptLoop() {
 }
 
 // RegEx to match a creds file with user JWT and Seed.
-var credsRe = regexp.MustCompile(`\s*(?:(?:[-]{3,}[^\n]*[-]{3,}\n)(.+)(?:\n\s*[-]{3,}[^\n]*[-]{3,}\n))`)
+var credsRe = regexp.MustCompile(`\s*(?:(?:[-]{3,}.*[-]{3,}\r?\n)([\w\-.=]+)(?:\r?\n[-]{3,}.*[-]{3,}(\r?\n|\z)))`)
 
 // clusterName is provided as argument to avoid lock ordering issues with the locked client c
 // Lock should be held entering here.

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -9102,6 +9102,7 @@ func TestLeafCredFormatting(t *testing.T) {
 	aKP, err := nkeys.CreateAccount()
 	require_NoError(t, err)
 	aPK, err := aKP.PublicKey()
+	require_NoError(t, err)
 
 	ac := jwt.NewAccountClaims(aPK)
 	ac.Name = "A"


### PR DESCRIPTION
Leaf node credential parsing was using a regular expression that didn't handle CRLFs correctly

Fix #6167

Signed-off-by: Your Name <alberto@synadia.com>
