### PR TITLE
[IMPROVED] Bypass meta-layer's API queue for non-existent consumers.

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -515,6 +515,8 @@ func (s *Server) enableJetStream(cfg JetStreamConfig) error {
 		if err := s.enableJetStreamClustering(); err != nil {
 			return err
 		}
+		// Set our atomic bool to clustered.
+		s.jsClustered.Store(true)
 	}
 
 	// Mark when we are up and running.
@@ -1020,6 +1022,8 @@ func (s *Server) shutdownJetStream() {
 			cc.c = nil
 		}
 		cc.meta = nil
+		// Set our atomic bool to false.
+		s.jsClustered.Store(false)
 	}
 	js.mu.Unlock()
 

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -159,8 +159,9 @@ const (
 
 	// JSApiConsumerInfo is for obtaining general information about a consumer.
 	// Will return JSON response.
-	JSApiConsumerInfo  = "$JS.API.CONSUMER.INFO.*.*"
-	JSApiConsumerInfoT = "$JS.API.CONSUMER.INFO.%s.%s"
+	JSApiConsumerInfoPre = "$JS.API.CONSUMER.INFO."
+	JSApiConsumerInfo    = "$JS.API.CONSUMER.INFO.*.*"
+	JSApiConsumerInfoT   = "$JS.API.CONSUMER.INFO.%s.%s"
 
 	// JSApiConsumerDelete is the endpoint to delete consumers.
 	// Will return JSON response.
@@ -1029,6 +1030,15 @@ func (s *Server) sendAPIErrResponse(ci *ClientInfo, acc *Account, subject, reply
 	acc.trackAPIErr()
 	if reply != _EMPTY_ {
 		s.sendInternalAccountMsg(nil, reply, response)
+	}
+	s.sendJetStreamAPIAuditAdvisory(ci, acc, subject, request, response)
+}
+
+// Use the account acc to send actual result from non-system account.
+func (s *Server) sendAPIErrResponseFromAccount(ci *ClientInfo, acc *Account, subject, reply, request, response string) {
+	acc.trackAPIErr()
+	if reply != _EMPTY_ {
+		s.sendInternalAccountMsg(acc, reply, response)
 	}
 	s.sendJetStreamAPIAuditAdvisory(ci, acc, subject, request, response)
 }
@@ -4589,6 +4599,55 @@ func (s *Server) jsConsumerListRequest(sub *subscription, c *client, _ *Account,
 	resp.Limit = JSApiListLimit
 	resp.Offset = offset
 	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+}
+
+// This will be a quick check on point of entry for a consumer that does
+// not exist. If that is the case we will return the response and return
+// true which will shortcut the service import to alleviate pressure on
+// the JS API queues.
+func (s *Server) jsConsumerProcessMissing(c *client, acc *Account) bool {
+	subject := bytesToString(c.pa.subject)
+	streamName, consumerName := streamNameFromSubject(subject), consumerNameFromSubject(subject)
+
+	// Check to make sure the consumer is assigned.
+	// All JS servers will have the meta information.
+	js, cc := s.getJetStreamCluster()
+	if js == nil || cc == nil {
+		return false
+	}
+	js.mu.RLock()
+	sa, ca := js.assignments(acc.Name, streamName, consumerName)
+	js.mu.RUnlock()
+
+	// If we have a consumer assignment return false here and let normally processing takeover.
+	if ca != nil {
+		return false
+	}
+
+	// We can't find the consumer, so mimic what would be the errors below.
+	var resp = JSApiConsumerInfoResponse{ApiResponse: ApiResponse{Type: JSApiConsumerInfoResponseType}}
+
+	// Need to make subject and reply real here for queued response processing.
+	subject = string(c.pa.subject)
+	reply := string(c.pa.reply)
+
+	ci := c.getClientInfo(true)
+
+	if hasJS, doErr := acc.checkJetStream(); !hasJS {
+		if doErr {
+			resp.Error = NewJSNotEnabledForAccountError()
+			s.sendAPIErrResponseFromAccount(ci, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+		}
+	} else if sa == nil {
+		resp.Error = NewJSStreamNotFoundError()
+		s.sendAPIErrResponseFromAccount(ci, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+	} else {
+		// If we are here the consumer is not present.
+		resp.Error = NewJSConsumerNotFoundError()
+		s.sendAPIErrResponseFromAccount(ci, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+	}
+
+	return true
 }
 
 // Request for information about an consumer.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4728,6 +4728,7 @@ func (js *jetStream) consumerAssignment(account, stream, consumer string) *consu
 }
 
 // Return both the stream and consumer assignments.
+// Lock should be held.
 func (js *jetStream) assignments(account, stream, consumer string) (*streamAssignment, *consumerAssignment) {
 	if sa := js.streamAssignment(account, stream); sa != nil {
 		return sa, sa.consumers[consumer]

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -224,11 +224,7 @@ func (s *Server) getJetStreamCluster() (*jetStream, *jetStreamCluster) {
 }
 
 func (s *Server) JetStreamIsClustered() bool {
-	js := s.getJetStream()
-	if js == nil {
-		return false
-	}
-	return js.isClustered()
+	return s.jsClustered.Load()
 }
 
 func (s *Server) JetStreamIsLeader() bool {
@@ -4729,6 +4725,14 @@ func (js *jetStream) consumerAssignment(account, stream, consumer string) *consu
 		return sa.consumers[consumer]
 	}
 	return nil
+}
+
+// Return both the stream and consumer assignments.
+func (js *jetStream) assignments(account, stream, consumer string) (*streamAssignment, *consumerAssignment) {
+	if sa := js.streamAssignment(account, stream); sa != nil {
+		return sa, sa.consumers[consumer]
+	}
+	return nil, nil
 }
 
 // consumerAssigned informs us if this server has this consumer assigned.

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -3412,7 +3412,6 @@ func TestJetStreamClusterExtendedAccountInfo(t *testing.T) {
 	// Go client will lag so use direct for now.
 	getAccountInfo := func() *nats.AccountInfo {
 		t.Helper()
-
 		info, err := js.AccountInfo()
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
@@ -3437,10 +3436,13 @@ func TestJetStreamClusterExtendedAccountInfo(t *testing.T) {
 	js.ConsumerInfo("TEST-2", "NO-CONSUMER")
 	js.ConsumerInfo("TEST-3", "NO-CONSUMER")
 
-	ai = getAccountInfo()
-	if ai.API.Errors != 4 {
-		t.Fatalf("Expected 4 API calls to be errors, got %d", ai.API.Errors)
-	}
+	checkFor(t, 2*time.Second, 250*time.Millisecond, func() error {
+		ai = getAccountInfo()
+		if ai.API.Errors != 4 {
+			return fmt.Errorf("Expected 4 API calls to be errors, got %d", ai.API.Errors)
+		}
+		return nil
+	})
 }
 
 func TestJetStreamClusterPeerRemovalAPI(t *testing.T) {
@@ -4319,7 +4321,8 @@ func TestJetStreamClusterNoQuorumStepdown(t *testing.T) {
 	if err := js.DeleteConsumer("NO-Q", "dlc"); !notAvailableErr(err) {
 		t.Fatalf("Expected an 'unavailable' error, got %v", err)
 	}
-	if _, err := js.ConsumerInfo("NO-Q", "dlc"); !notAvailableErr(err) {
+	// Since we did not create the consumer our bypass will respond from the local server.
+	if _, err := js.ConsumerInfo("NO-Q", "dlc"); err != nats.ErrConsumerNotFound {
 		t.Fatalf("Expected an 'unavailable' error, got %v", err)
 	}
 	// Listers

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -11252,3 +11252,60 @@ func TestNoRaceJetStreamClusterLargeMetaSnapshotTiming(t *testing.T) {
 	require_NoError(t, n.InstallSnapshot(snap))
 	t.Logf("Took %v to snap meta with size of %v\n", time.Since(start), friendlyBytes(len(snap)))
 }
+
+func TestNoRaceJetStreamClusterInfoOnMissingConsumers(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3F", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// Create a stream just so the consumer info processing misses on the consumer only.
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	done := make(chan bool)
+	pending := make(chan int, 1)
+
+	// Check to make sure we never have any pending on the API queue.
+	go func() {
+		ml := c.leader()
+		for {
+			select {
+			case <-done:
+				return
+			case <-time.After(100 * time.Millisecond):
+				qlen := ml.jsAPIRoutedReqs.len() + int(ml.jsAPIRoutedReqs.inProgress())
+				if qlen > 0 {
+					pending <- qlen
+					return
+				}
+			}
+		}
+	}()
+
+	wg := sync.WaitGroup{}
+	wg.Add(500)
+	for i := 0; i < 500; i++ {
+		go func() {
+			defer wg.Done()
+			s := c.randomServer()
+			nc, js := jsClientConnect(t, s)
+			defer nc.Close()
+			// Check for non-existent consumers.
+			for c := 0; c < 1000; c++ {
+				_, err := js.ConsumerInfo("TEST", fmt.Sprintf("C-%d", c))
+				require_Error(t, err)
+			}
+		}()
+	}
+	wg.Wait()
+	close(done)
+	if len(pending) > 0 {
+		t.Fatalf("Saw API pending of %d, expected always 0", <-pending)
+	}
+}


### PR DESCRIPTION
Processing a missing consumer was a heavier operation on the meta-layer and could lead to API queue buildup.
This processes that condition at point of entry to the system vs at the meta-layer.
If the consumer assignment does exist we process as normal for now.

Also moved jetstream clustered state and system account to atomics to avoid lock contention.
Add in lookup for both stream and consumer assignments at the same time.

Signed-off-by: Derek Collison <derek@nats.io>