### PR TITLE
Compact JetStream asset versioning

### DIFF
--- a/server/jetstream_versioning.go
+++ b/server/jetstream_versioning.go
@@ -19,17 +19,15 @@ const (
 	// JSApiLevel is the maximum supported JetStream API level for this server.
 	JSApiLevel int = 1
 
-	JSCreatedVersionMetadataKey = "_nats.created.server.version"
-	JSCreatedLevelMetadataKey   = "_nats.created.server.api_level"
-	JSRequiredLevelMetadataKey  = "_nats.server.require.api_level"
-	JSServerVersionMetadataKey  = "_nats.server.version"
-	JSServerLevelMetadataKey    = "_nats.server.api_level"
+	JSRequiredLevelMetadataKey = "_nats.req.level"
+	JSServerVersionMetadataKey = "_nats.ver"
+	JSServerLevelMetadataKey   = "_nats.level"
 )
 
 // setStaticStreamMetadata sets JetStream stream metadata, like the server version and API level.
 // Given:
-//   - cfg!=nil, prevCfg==nil		add stream: adds created and required metadata
-//   - cfg!=nil, prevCfg!=nil		update stream: created metadata is preserved, required metadata is updated
+//   - cfg!=nil, prevCfg==nil		add stream: adds required metadata
+//   - cfg!=nil, prevCfg!=nil		update stream: required metadata is updated
 //
 // Any dynamic metadata is removed, it must not be stored and only be added for responses.
 func setStaticStreamMetadata(cfg *StreamConfig, prevCfg *StreamConfig) {
@@ -38,16 +36,6 @@ func setStaticStreamMetadata(cfg *StreamConfig, prevCfg *StreamConfig) {
 	} else {
 		deleteDynamicMetadata(cfg.Metadata)
 	}
-
-	var prevMetadata map[string]string
-	if prevCfg != nil {
-		prevMetadata = prevCfg.Metadata
-		if prevMetadata == nil {
-			// Initialize to empty to indicate we had a previous config but metadata was missing.
-			prevMetadata = make(map[string]string)
-		}
-	}
-	preserveCreatedMetadata(cfg.Metadata, prevMetadata)
 
 	var requiredApiLevel int
 	cfg.Metadata[JSRequiredLevelMetadataKey] = strconv.Itoa(requiredApiLevel)
@@ -67,8 +55,8 @@ func setDynamicStreamMetadata(cfg *StreamConfig) *StreamConfig {
 
 // setStaticConsumerMetadata sets JetStream consumer metadata, like the server version and API level.
 // Given:
-//   - cfg!=nil, prevCfg==nil		add consumer: adds created and required metadata
-//   - cfg!=nil, prevCfg!=nil		update consumer: created metadata is preserved, required metadata is updated
+//   - cfg!=nil, prevCfg==nil		add consumer: adds required metadata
+//   - cfg!=nil, prevCfg!=nil		update consumer: required metadata is updated
 //
 // Any dynamic metadata is removed, it must not be stored and only be added for responses.
 func setStaticConsumerMetadata(cfg *ConsumerConfig, prevCfg *ConsumerConfig) {
@@ -77,16 +65,6 @@ func setStaticConsumerMetadata(cfg *ConsumerConfig, prevCfg *ConsumerConfig) {
 	} else {
 		deleteDynamicMetadata(cfg.Metadata)
 	}
-
-	var prevMetadata map[string]string
-	if prevCfg != nil {
-		prevMetadata = prevCfg.Metadata
-		if prevMetadata == nil {
-			// Initialize to empty to indicate we had a previous config but metadata was missing.
-			prevMetadata = make(map[string]string)
-		}
-	}
-	preserveCreatedMetadata(cfg.Metadata, prevMetadata)
 
 	var requiredApiLevel int
 
@@ -142,8 +120,6 @@ func copyConsumerMetadata(cfg *ConsumerConfig, prevCfg *ConsumerConfig) {
 	// Remove fields when no previous metadata.
 	if prevCfg == nil || prevCfg.Metadata == nil {
 		if cfg.Metadata != nil {
-			delete(cfg.Metadata, JSCreatedVersionMetadataKey)
-			delete(cfg.Metadata, JSCreatedLevelMetadataKey)
 			delete(cfg.Metadata, JSRequiredLevelMetadataKey)
 			if len(cfg.Metadata) == 0 {
 				cfg.Metadata = nil
@@ -153,8 +129,6 @@ func copyConsumerMetadata(cfg *ConsumerConfig, prevCfg *ConsumerConfig) {
 	}
 
 	// Set if exists, delete otherwise.
-	setOrDeleteInMetadata(cfg, prevCfg, JSCreatedVersionMetadataKey)
-	setOrDeleteInMetadata(cfg, prevCfg, JSCreatedLevelMetadataKey)
 	setOrDeleteInMetadata(cfg, prevCfg, JSRequiredLevelMetadataKey)
 }
 
@@ -167,28 +141,6 @@ func setOrDeleteInMetadata(cfg *ConsumerConfig, prevCfg *ConsumerConfig, key str
 		cfg.Metadata[key] = value
 	} else {
 		delete(cfg.Metadata, key)
-	}
-}
-
-// preserveCreatedMetadata sets metadata to contain which version and API level the asset was created on.
-// Preserves previous metadata, if not set it initializes versions for the metadata.
-func preserveCreatedMetadata(metadata, prevMetadata map[string]string) {
-	if prevMetadata == nil {
-		metadata[JSCreatedVersionMetadataKey] = VERSION
-		metadata[JSCreatedLevelMetadataKey] = strconv.Itoa(JSApiLevel)
-		return
-	}
-
-	// Preserve previous metadata if it was set, but delete if not since it could be user-provided.
-	if v := prevMetadata[JSCreatedVersionMetadataKey]; v != _EMPTY_ {
-		metadata[JSCreatedVersionMetadataKey] = v
-	} else {
-		delete(metadata, JSCreatedVersionMetadataKey)
-	}
-	if v := prevMetadata[JSCreatedLevelMetadataKey]; v != _EMPTY_ {
-		metadata[JSCreatedLevelMetadataKey] = v
-	} else {
-		delete(metadata, JSCreatedLevelMetadataKey)
 	}
 }
 


### PR DESCRIPTION
Based on https://github.com/nats-io/nats-architecture-and-design/pull/309

Compact the keys and remove the 'created' keys.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>