### PR TITLE
Don't include unnecessary `ClientInfo` fields in metalayer snapshots

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -327,6 +327,15 @@ type ClientInfo struct {
 	Nonce      string        `json:"nonce,omitempty"`
 }
 
+// forAssignmentSnap returns the minimum amount of ClientInfo we need for assignment snapshots.
+func (ci *ClientInfo) forAssignmentSnap() *ClientInfo {
+	return &ClientInfo{
+		Account: ci.Account,
+		Service: ci.Service,
+		Cluster: ci.Cluster,
+	}
+}
+
 // ServerStats hold various statistics that we will periodically send out.
 type ServerStats struct {
 	Start              time.Time           `json:"start"`

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1542,7 +1542,7 @@ func (js *jetStream) metaSnapshot() []byte {
 	for _, asa := range cc.streams {
 		for _, sa := range asa {
 			wsa := writeableStreamAssignment{
-				Client:    sa.Client,
+				Client:    sa.Client.forAssignmentSnap(),
 				Created:   sa.Created,
 				Config:    sa.Config,
 				Group:     sa.Group,
@@ -1555,7 +1555,9 @@ func (js *jetStream) metaSnapshot() []byte {
 				if ca.pending {
 					continue
 				}
-				wsa.Consumers = append(wsa.Consumers, ca)
+				cca := *ca
+				cca.Client = cca.Client.forAssignmentSnap()
+				wsa.Consumers = append(wsa.Consumers, &cca)
 				nca++
 			}
 			streams = append(streams, wsa)


### PR DESCRIPTION
This should reduce the size of metalayer snapshots quite significantly by only including the `Account`, `Service` and `Cluster` fields from the `ClientInfo`, as those are the only ones that are relevant from a snapshot.

Signed-off-by: Neil Twigg <neil@nats.io>