### PR TITLE
Reduce size of meta snapshots further

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -134,8 +134,8 @@ type streamAssignment struct {
 	Config  *StreamConfig `json:"stream"`
 	Group   *raftGroup    `json:"group"`
 	Sync    string        `json:"sync"`
-	Subject string        `json:"subject"`
-	Reply   string        `json:"reply"`
+	Subject string        `json:"subject,omitempty"`
+	Reply   string        `json:"reply,omitempty"`
 	Restore *StreamState  `json:"restore_state,omitempty"`
 	// Internal
 	consumers   map[string]*consumerAssignment
@@ -153,8 +153,8 @@ type consumerAssignment struct {
 	Stream  string          `json:"stream"`
 	Config  *ConsumerConfig `json:"consumer"`
 	Group   *raftGroup      `json:"group"`
-	Subject string          `json:"subject"`
-	Reply   string          `json:"reply"`
+	Subject string          `json:"subject,omitempty"`
+	Reply   string          `json:"reply,omitempty"`
 	State   *ConsumerState  `json:"state,omitempty"`
 	// Internal
 	responded  bool
@@ -1557,6 +1557,7 @@ func (js *jetStream) metaSnapshot() []byte {
 				}
 				cca := *ca
 				cca.Client = cca.Client.forAssignmentSnap()
+				cca.Subject, cca.Reply = _EMPTY_, _EMPTY_
 				wsa.Consumers = append(wsa.Consumers, &cca)
 				nca++
 			}


### PR DESCRIPTION
We would not expect to respond to a consumer assignment after, e.g. a restart, and we don't store these for stream assignments already, therefore the `subject` and `reply` fields do not need to be encoded for consumer assignments either.

Similarly, the `stream` name doesn't need to be repeated for each consumer assignment either, as we can just pull that out of the parent stream assignment when decoding, so don't encode that either.

This should further reduce the size of meta snapshots and, with it, reduce their encoding/decoding time.

Signed-off-by: Neil Twigg <neil@nats.io>