### PR TITLE
Check for sys being ready before calling sysRequest

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -6332,6 +6332,10 @@ func sysRequest[T any](s *Server, subjFormat string, args ...any) (*T, error) {
 	isubj := fmt.Sprintf(subjFormat, args...)
 
 	s.mu.Lock()
+	if s.sys == nil {
+		s.mu.Unlock()
+		return nil, ErrNoSysAccount
+	}
 	inbox := s.newRespInbox()
 	results := make(chan *T, 1)
 	s.sys.replies[inbox] = func(_ *subscription, _ *client, _ *Account, _, _ string, msg []byte) {


### PR DESCRIPTION
This should prevent the following from happening during shutdown:

```
[1] 2024/11/30 23:09:21.559476 [DBG] JETSTREAM - JetStream connection closed: Client Closed
[1] 2024/11/30 23:09:21.561754 [DBG] JETSTREAM - JetStream connection closed: Client Closed
fatal error: sync: Unlock of unlocked RWMutex
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xcde26b]
goroutine 623 [running]:
sync.fatal({0x12c1d0a?, 0xc040000000?})
	/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.linux-amd64/src/runtime/panic.go:1007 +0x18
sync.(*RWMutex).Unlock(0xc0000db7e4)
	/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.linux-amd64/src/sync/rwmutex.go:208 +0x7e
panic({0x11e5780?, 0x1b73560?})
	/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.linux-amd64/src/runtime/panic.go:770 +0x132
github.com/nats-io/nats-server/v2/server.(*Server).newRespInbox(0xc000225008)
	server/events.go:2742 +0x6b
github.com/nats-io/nats-server/v2/server.sysRequest[...](0xc000225008, {0x12af980, 0xd}, {0xc000665d30, 0x2, 0x2})
	server/jetstream_cluster.go:6335 +0xea
github.com/nats-io/nats-server/v2/server.(*Server).jsClusteredStreamUpdateRequest(0xc000225008, 0xc00068c000, 0xc00022a2c8, {0xc0007ad7a0, 0x21}, {0xc00052cfa8, 0x11}, {0xc000598840, 0x2ab, 0x2ab}, ...)
	server/jetstream_cluster.go:6545 +0x1505
created by github.com/nats-io/nats-server/v2/server.(*Server).jsStreamUpdateRequest in goroutine 149
	server/jetstream_api.go:1729 +0xdcb
goroutine 1 [chan receive, 1 minutes]:
github.com/nats-io/nats-server/v2/server.(*Server).WaitForShutdown(...)
	server/server.go:2694
```