### PR TITLE
Fix `TestJetStreamClusterConsumerAckOutOfBounds` not run in CI

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -6670,7 +6670,7 @@ func TestJetStreamClusterMetaRecoveryConsumerCreateAndRemove(t *testing.T) {
 
 // Make sure if we received acks that are out of bounds, meaning past our
 // last sequence or before our first that they are ignored and errored if applicable.
-func TestJetStreamConsumerAckOutOfBounds(t *testing.T) {
+func TestJetStreamClusterConsumerAckOutOfBounds(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 


### PR DESCRIPTION
Signed-off-by: Maurice van Veen <github@mauricevanveen.com>