### PR TITLE
Switch back to encoding/json from goccy/go-json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.22
 toolchain go1.22.8
 
 require (
-	github.com/goccy/go-json v0.10.3
 	github.com/google/go-tpm v0.9.0
 	github.com/klauspost/compress v1.17.11
 	github.com/minio/highwayhash v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
-github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/google/go-tpm v0.9.0 h1:sQF6YqWMi+SCXpsmS3fd21oPy/vSddwZry4JnmltHVk=
 github.com/google/go-tpm v0.9.0/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -24,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/auth_callout_test.go
+++ b/server/auth_callout_test.go
@@ -16,6 +16,7 @@ package server
 import (
 	"bytes"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -28,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -24,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 )

--- a/server/certidp/certidp.go
+++ b/server/certidp/certidp.go
@@ -17,12 +17,12 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
 	"time"
 
-	"github.com/goccy/go-json"
 	"golang.org/x/crypto/ocsp"
 )
 

--- a/server/client.go
+++ b/server/client.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -32,7 +33,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/internal/fastrand"

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -31,7 +32,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -16,6 +16,7 @@ package server
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -28,7 +29,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server/avl"
 	"github.com/nats-io/nuid"
 	"golang.org/x/time/rate"

--- a/server/events.go
+++ b/server/events.go
@@ -18,6 +18,7 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -29,7 +30,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/server/certidp"

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -16,6 +16,7 @@ package server
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -29,7 +30,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash"
@@ -39,7 +40,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/minio/highwayhash"
 	"github.com/nats-io/nats-server/v2/server/avl"

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -39,7 +40,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/nuid"
 )
@@ -1484,6 +1484,8 @@ func TestFileStoreMeta(t *testing.T) {
 	if err := json.Unmarshal(buf, &oconfig2); err != nil {
 		t.Fatalf("Error unmarshalling: %v", err)
 	}
+	// Since we set name we will get that back now.
+	oconfig.Name = oname
 	if !reflect.DeepEqual(oconfig2, oconfig) {
 		t.Fatalf("Consumer configs not equal, got %+v vs %+v", oconfig2, oconfig)
 	}

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -18,6 +18,7 @@ import (
 	"cmp"
 	"crypto/sha256"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -29,8 +30,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"github.com/goccy/go-json"
 )
 
 const (

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -30,7 +31,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/logger"
 	"github.com/nats-io/nats.go"
 	"golang.org/x/crypto/ocsp"

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -18,6 +18,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -29,7 +30,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/minio/highwayhash"
 	"github.com/nats-io/nats-server/v2/server/sysmem"
 	"github.com/nats-io/nats-server/v2/server/tpm"

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -16,6 +16,7 @@ package server
 import (
 	"bytes"
 	"cmp"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -30,7 +31,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nuid"
 )
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -18,6 +18,7 @@ import (
 	"cmp"
 	crand "crypto/rand"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -31,7 +32,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/minio/highwayhash"
 	"github.com/nats-io/nuid"

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	crand "crypto/rand"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -32,7 +33,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 )

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -22,6 +22,7 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -36,7 +37,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats.go"
 )
 

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -19,6 +19,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -32,7 +33,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 )

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -34,7 +35,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nuid"
 )

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -17,6 +17,7 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -28,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nuid"
 )

--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -14,9 +14,8 @@
 package server
 
 import (
+	"encoding/json"
 	"time"
-
-	"github.com/goccy/go-json"
 )
 
 func (s *Server) publishAdvisory(acc *Account, subject string, adv any) {

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -32,7 +33,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats.go"
 	"golang.org/x/time/rate"
 )

--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -17,6 +17,7 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -26,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"
 

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -17,6 +17,7 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -29,7 +30,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	crand "crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -41,7 +42,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/server/sysmem"
 	"github.com/nats-io/nats.go"

--- a/server/jetstream_versioning_test.go
+++ b/server/jetstream_versioning_test.go
@@ -19,13 +19,13 @@ package server
 import (
 	"archive/tar"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/nats.go"
 )

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -30,7 +31,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
@@ -35,7 +36,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"net"
@@ -36,7 +37,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/server/pse"
 )

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -16,6 +16,7 @@ package server
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -34,7 +35,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -18,6 +18,7 @@ import (
 	"cmp"
 	"crypto/tls"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -30,7 +31,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nuid"
 )
 

--- a/server/mqtt_ex_test_test.go
+++ b/server/mqtt_ex_test_test.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -26,7 +27,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nuid"
 )
 

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -32,7 +33,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/msgtrace.go
+++ b/server/msgtrace.go
@@ -15,14 +15,13 @@ package server
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
-
-	"github.com/goccy/go-json"
 )
 
 const (

--- a/server/msgtrace_test.go
+++ b/server/msgtrace_test.go
@@ -19,6 +19,7 @@ package server
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -27,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"

--- a/server/nkey_test.go
+++ b/server/nkey_test.go
@@ -16,6 +16,7 @@ package server
 import (
 	"bufio"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -24,7 +25,6 @@ import (
 	crand "crypto/rand"
 	mrand "math/rand"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nkeys"
 )
 

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -22,6 +22,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -47,7 +48,6 @@ import (
 	crand "crypto/rand"
 	"crypto/sha256"
 
-	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/server/avl"

--- a/server/ocsp_responsecache.go
+++ b/server/ocsp_responsecache.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -26,7 +27,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"golang.org/x/crypto/ocsp"
 

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -16,6 +16,7 @@ package server
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net/url"
@@ -28,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/base64"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -34,7 +35,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/route.go
+++ b/server/route.go
@@ -16,6 +16,7 @@ package server
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
@@ -27,7 +28,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 )
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
@@ -34,7 +35,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"

--- a/server/server.go
+++ b/server/server.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -42,7 +43,6 @@ import (
 	// Allow dynamic profiling.
 	_ "net/http/pprof"
 
-	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/logger"

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -34,7 +35,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats.go"
 
 	srvlog "github.com/nats-io/nats-server/v2/logger"

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2334,3 +2334,26 @@ func TestServerClientURL(t *testing.T) {
 		require_Equal(t, s.ClientURL(), expected)
 	}
 }
+
+// This is a test that guards against using goccy/go-json.
+// At least until it's fully compatible with std encoding/json, and we've thoroughly tested it.
+// This is just one bug (at the time of writing) that results in a panic.
+// https://github.com/goccy/go-json/issues/519
+func TestServerJsonMarshalNestedStructsPanic(t *testing.T) {
+	type Item struct {
+		A string `json:"a"`
+		B string `json:"b,omitempty"`
+	}
+
+	type Detail struct {
+		I Item `json:"i"`
+	}
+
+	type Body struct {
+		Payload *Detail `json:"p,omitempty"`
+	}
+
+	b, err := json.Marshal(Body{Payload: &Detail{I: Item{A: "a", B: "b"}}})
+	require_NoError(t, err)
+	require_Equal(t, string(b), "{\"p\":{\"i\":{\"a\":\"a\",\"b\":\"b\"}}}")
+}

--- a/server/stream.go
+++ b/server/stream.go
@@ -17,6 +17,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -31,7 +32,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/nuid"
 )

--- a/server/tpm/js_ek_tpm_windows.go
+++ b/server/tpm/js_ek_tpm_windows.go
@@ -17,12 +17,12 @@ package tpm
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
-	"github.com/goccy/go-json"
 	"github.com/google/go-tpm/legacy/tpm2"
 	"github.com/google/go-tpm/tpmutil"
 	"github.com/nats-io/nkeys"

--- a/server/util.go
+++ b/server/util.go
@@ -16,6 +16,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -25,8 +26,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/goccy/go-json"
 )
 
 // This map is used to store URLs string as the key with a reference count as

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -33,7 +34,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/klauspost/compress/flate"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -14,12 +14,12 @@
 package test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 )
 

--- a/test/gateway_test.go
+++ b/test/gateway_test.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -24,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 )

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
@@ -29,7 +30,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/logger"
 	"github.com/nats-io/nats-server/v2/server"

--- a/test/monitor_test.go
+++ b/test/monitor_test.go
@@ -16,6 +16,7 @@ package test
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -27,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 )

--- a/test/new_routes_test.go
+++ b/test/new_routes_test.go
@@ -14,12 +14,12 @@
 package test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/logger"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"

--- a/test/norace_test.go
+++ b/test/norace_test.go
@@ -19,6 +19,7 @@ package test
 import (
 	"context"
 	crand "crypto/rand"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -30,7 +31,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nuid"

--- a/test/ocsp_peer_test.go
+++ b/test/ocsp_peer_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -26,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	. "github.com/nats-io/nats-server/v2/internal/ocsp"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"

--- a/test/ports_test.go
+++ b/test/ports_test.go
@@ -14,6 +14,7 @@
 package test
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -22,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 )
 

--- a/test/proto_test.go
+++ b/test/proto_test.go
@@ -14,10 +14,10 @@
 package test
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 )
 

--- a/test/route_discovery_test.go
+++ b/test/route_discovery_test.go
@@ -15,6 +15,7 @@ package test
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -25,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 )
 

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -14,6 +14,7 @@
 package test
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -24,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/internal/testhelper"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"

--- a/test/service_latency_test.go
+++ b/test/service_latency_test.go
@@ -14,6 +14,7 @@
 package test
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -25,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"

--- a/test/test.go
+++ b/test/test.go
@@ -16,6 +16,7 @@ package test
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -27,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goccy/go-json"
 	"github.com/nats-io/nats-server/v2/server"
 
 	srvlog "github.com/nats-io/nats-server/v2/logger"


### PR DESCRIPTION
Despite go-json having less allocations, it seems it has quite few unresolved issues which might be hitting us, causing panics.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>
