### PR TITLE
[TEST ONLY] Deflake TestMQTTSubRetainedRace by restarting the server

### DIFF
--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -7089,8 +7089,6 @@ func TestMQTTSubjectMappingWithImportExport(t *testing.T) {
 
 func TestMQTTSubRetainedRace(t *testing.T) {
 	o := testMQTTDefaultOptions()
-	s := testMQTTRunServer(t, o)
-	defer testMQTTShutdownServer(s)
 
 	useCases := []struct {
 		name string
@@ -7108,6 +7106,9 @@ func TestMQTTSubRetainedRace(t *testing.T) {
 				t.Run(subTopic, func(t *testing.T) {
 					for _, qos := range QOS {
 						t.Run(fmt.Sprintf("QOS%d", qos), func(t *testing.T) {
+							s := testMQTTRunServer(t, o)
+							defer testMQTTShutdownServer(s)
+
 							tc.f(t, o, subTopic, pubTopic, qos)
 						})
 					}


### PR DESCRIPTION
https://buildkite.com/synadia/nats-server-dev/builds/777#01938f20-ead7-4c99-8718-52440ac1b802 likely failed because of the prior message redelivery. The test client code is very sensitive to it. Hopefully restarting the server on every run will fix it - I have not been able to reproduce.

Signed-off-by: Lev Brouk <lev@synadia.com>
