### PR TITLE
Increase disk I/O semaphore on systems with more CPU cores

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -33,6 +33,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -9504,8 +9505,9 @@ var dios chan struct{}
 // Used to setup our simplistic counting semaphore using buffered channels.
 // golang.org's semaphore seemed a bit heavy.
 func init() {
-	// Limit ourselves to a max of 4 blocking IO calls.
-	const nIO = 4
+	// Limit ourselves to a sensible number of blocking I/O calls. Range between
+	// 4-16 concurrent disk I/Os based on the number of CPU cores available.
+	nIO := min(16, max(4, runtime.GOMAXPROCS(-1)))
 	dios = make(chan struct{}, nIO)
 	// Fill it up to start.
 	for i := 0; i < nIO; i++ {


### PR DESCRIPTION
This should provide less contention on systems where we have plenty of headroom for more I/O-blocked threads.

Signed-off-by: Neil Twigg <neil@nats.io>
