### PR TITLE
Stop stream when stream state inconsistency is detected during flush

### DIFF
--- a/server/memstore.go
+++ b/server/memstore.go
@@ -36,6 +36,7 @@ type memStore struct {
 	dmap        avl.SequenceSet
 	maxp        int64
 	scb         StorageUpdateHandler
+	sscb        StreamStateCorruptionHandler
 	ageChk      *time.Timer
 	consumers   int
 	receivedAny bool
@@ -306,6 +307,13 @@ func (ms *memStore) SkipMsgs(seq uint64, num uint64) error {
 func (ms *memStore) RegisterStorageUpdates(cb StorageUpdateHandler) {
 	ms.mu.Lock()
 	ms.scb = cb
+	ms.mu.Unlock()
+}
+
+// RegisterStreamStateCorruptionCB registers a callback for stream state corruption
+func (ms *memStore) RegisterStreamStateCorruptionCB(cb StreamStateCorruptionHandler) {
+	ms.mu.Lock()
+	ms.sscb = cb
 	ms.mu.Unlock()
 }
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -339,6 +339,7 @@ type Options struct {
 	JetStreamRequestQueueLimit int64
 	StreamMaxBufferedMsgs      int               `json:"-"`
 	StreamMaxBufferedSize      int64             `json:"-"`
+	StreamStopOnCorruption     bool              `json:"-"`
 	StoreDir                   string            `json:"-"`
 	SyncInterval               time.Duration     `json:"-"`
 	SyncAlways                 bool              `json:"-"`
@@ -2433,6 +2434,10 @@ func parseJetStream(v any, opts *Options, errors *[]error, warnings *[]error) er
 					return &configErr{tk, fmt.Sprintf("%s %s", strings.ToLower(mk), err)}
 				}
 				opts.StreamMaxBufferedSize = s
+			case "stream_stop_on_corruption":
+				if v, ok := mv.(bool); ok {
+					opts.StreamStopOnCorruption = v
+				}
 			case "max_buffered_msgs":
 				mlen, ok := mv.(int64)
 				if !ok {

--- a/server/store.go
+++ b/server/store.go
@@ -83,6 +83,9 @@ type StoreMsg struct {
 // For the cases where its a single message we will also supply sequence number and subject.
 type StorageUpdateHandler func(msgs, bytes int64, seq uint64, subj string)
 
+// Callback to stop stream when stream state is corrupted
+type StreamStateCorruptionHandler func()
+
 type StreamStore interface {
 	StoreMsg(subject string, hdr, msg []byte) (uint64, int64, error)
 	StoreRawMsg(subject string, hdr, msg []byte, seq uint64, ts int64) error
@@ -111,6 +114,7 @@ type StreamStore interface {
 	SyncDeleted(dbs DeleteBlocks)
 	Type() StorageType
 	RegisterStorageUpdates(StorageUpdateHandler)
+	RegisterStreamStateCorruptionCB(StreamStateCorruptionHandler)
 	UpdateConfig(cfg *StreamConfig) error
 	Delete() error
 	Stop() error


### PR DESCRIPTION
This PR is intended to handle the stream state reset observed when filesystem enters read-only mode.(for reference: https://github.com/nats-io/nats-server/issues/6211)

This PR introduces the following:

1. A new server configuration `stream_stop_on_corruption` for jetstream to stop stream when filestore corruption is observed.
        a. When filesystem enters read-only mode, filestore detects stream state corruption which resets the in-memory state of stream to zero and future publish fails even if filesystem recovers until nats server restarts and restores stream state on server startup
        b. We have also seen scenarios when steam state was reset and publish resumed without needing a restart. This caused the consumers to stop consuming new msgs from stream since consumer stream seq was way ahead of stream seq
        c. Hence, to avoid these situations, we introduce a new server configuration to stop stream as soon as stream state corruption is detected during writing stream state onto disk.
2. Mark stream’s filestore is corrupt when the server is configured to stop stream on state corruption. 
        a. This change allows to ensure that inconsistent state is not flushed onto disk before stream is stopped
