### PR TITLE
[FIXED] Healthz with details returns 200 OK even with errors

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3241,10 +3241,11 @@ func (s *Server) HandleHealthz(w http.ResponseWriter, r *http.Request) {
 		Details:       includeDetails,
 	})
 
-	code := http.StatusOK
+	code := hs.StatusCode
 	if hs.Error != _EMPTY_ {
 		s.Warnf("Healthcheck failed: %q", hs.Error)
-		code = hs.StatusCode
+	} else if len(hs.Errors) != 0 {
+		s.Warnf("Healthcheck failed: %d errors", len(hs.Errors))
 	}
 	// Remove StatusCode from JSON representation when responding via HTTP
 	// since this is already in the response.

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -5492,7 +5492,7 @@ func TestHealthzStatusUnavailable(t *testing.T) {
 	}{
 		{
 			"healthz",
-			fmt.Sprintf("http://%s/healthz", s.MonitorAddr().String()),
+			fmt.Sprintf("http://%s/healthz?", s.MonitorAddr().String()),
 			http.StatusServiceUnavailable,
 			"unavailable",
 		},
@@ -5510,7 +5510,16 @@ func TestHealthzStatusUnavailable(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			expectHealthStatus(t, test.url, test.statusCode, test.wantStatus)
+			t.Run("no-details", func(t *testing.T) {
+				expectHealthStatus(t, test.url, test.statusCode, test.wantStatus)
+			})
+			t.Run("with-details", func(t *testing.T) {
+				detailsUrl := fmt.Sprintf("%s&details=true", test.url)
+				if test.wantStatus != "ok" {
+					test.wantStatus = "error"
+				}
+				expectHealthStatus(t, detailsUrl, test.statusCode, test.wantStatus)
+			})
 		})
 	}
 }


### PR DESCRIPTION
Return non-200 status codes if there are errors, also log (just the count, otherwise the log statement could explode in size).

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
