### PR TITLE
Fix readme build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you are interested in contributing to NATS, read about our...
 [Fossa-Url]: https://app.fossa.io/projects/git%2Bgithub.com%2Fnats-io%2Fnats-server?ref=badge_shield
 [Fossa-Image]: https://app.fossa.io/api/projects/git%2Bgithub.com%2Fnats-io%2Fnats-server.svg?type=shield
 [Build-Status-Url]: https://travis-ci.com/github/nats-io/nats-server
-[Build-Status-Image]: https://travis-ci.com/nats-io/nats-server.svg?branch=main
+[Build-Status-Image]: https://travis-ci.org/nats-io/nats-server.svg?branch=main
 [Release-Url]: https://github.com/nats-io/nats-server/releases/latest
 [Release-image]: https://img.shields.io/github/v/release/nats-io/nats-server
 [Coverage-Url]: https://coveralls.io/r/nats-io/nats-server?branch=main


### PR DESCRIPTION
Currently build badge on readme is broken (at least for me)

For some reason when image is on 'org' domain it works.

![Build](https://travis-ci.com/nats-io/nats-server.svg?branch=main)
vs.
![Build](https://travis-ci.org/nats-io/nats-server.svg?branch=main)

see also build tag on travis' own readme https://github.com/travis-ci/travis-web/blob/master/README.md

Signed-off-by: Ziya Suzen <ziya@synadia.com>
