### PR TITLE
[FIXED] JetStream would exceed limits calculation

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -2163,7 +2163,7 @@ func (js *jetStream) wouldExceedLimits(storeType StorageType, sz int) bool {
 	} else {
 		total, max = &js.storeUsed, js.config.MaxStore
 	}
-	return atomic.LoadInt64(total) > (max + int64(sz))
+	return (atomic.LoadInt64(total) + int64(sz)) > max
 }
 
 func (js *jetStream) limitsExceeded(storeType StorageType) bool {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -24721,3 +24721,19 @@ func TestJetStreamMemoryPurgeClearsSubjectsState(t *testing.T) {
 	require_NoError(t, err)
 	require_Len(t, len(si.State.Subjects), 0)
 }
+
+func TestJetStreamWouldExceedLimits(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	js := s.getJetStream()
+	require_NotNil(t, js)
+
+	// Storing exactly up to the limit should work.
+	require_False(t, js.wouldExceedLimits(MemoryStorage, int(js.config.MaxMemory)))
+	require_False(t, js.wouldExceedLimits(FileStorage, int(js.config.MaxStore)))
+
+	// Storing one more than the max should exceed limits.
+	require_True(t, js.wouldExceedLimits(MemoryStorage, int(js.config.MaxMemory)+1))
+	require_True(t, js.wouldExceedLimits(FileStorage, int(js.config.MaxStore)+1))
+}


### PR DESCRIPTION
The calculation should check if the current total plus what we want to store exceeds the max.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>