### PR TITLE
De-flake TestNRGSimple

### DIFF
--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -36,11 +36,11 @@ func TestNRGSimple(t *testing.T) {
 	rg := c.createRaftGroup("TEST", 3, newStateAdder)
 	rg.waitOnLeader()
 	// Do several state transitions.
-	rg.randomMember().(*stateAdder).proposeDelta(11)
-	rg.randomMember().(*stateAdder).proposeDelta(11)
-	rg.randomMember().(*stateAdder).proposeDelta(-22)
+	rg.randomMember().(*stateAdder).proposeDelta(22)
+	rg.randomMember().(*stateAdder).proposeDelta(-11)
+	rg.randomMember().(*stateAdder).proposeDelta(-10)
 	// Wait for all members to have the correct state.
-	rg.waitOnTotal(t, 0)
+	rg.waitOnTotal(t, 1)
 }
 
 func TestNRGSnapshotAndRestart(t *testing.T) {


### PR DESCRIPTION
`TestNRGSimple` was not actually testing anything, as `proposeDelta` asynchronously proposes the changes so the `waitOnTotal` would immediately pass even if none of the proposals went through (or even if `proposeDelta` was commented out).

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>