### PR TITLE
Add support for placement tags and `preferred` to metaleader stepdown request

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -829,6 +829,12 @@ func checkConsumerCfg(
 			}
 		}
 	}
+
+	// For now don't allow preferred server in placement.
+	if cfg.Placement != nil && cfg.Placement.Preferred != _EMPTY_ {
+		return NewJSStreamInvalidConfigError(fmt.Errorf("preferred server not permitted in placement"))
+	}
+
 	return nil
 }
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -79,8 +79,9 @@ type inflightInfo struct {
 
 // Used to guide placement of streams and meta controllers in clustered JetStream.
 type Placement struct {
-	Cluster string   `json:"cluster,omitempty"`
-	Tags    []string `json:"tags,omitempty"`
+	Cluster   string   `json:"cluster,omitempty"`
+	Tags      []string `json:"tags,omitempty"`
+	Preferred string   `json:"preferred,omitempty"`
 }
 
 // Define types of the entry.

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -326,26 +326,29 @@ func createJetStreamTaggedSuperClusterWithGWProxy(t *testing.T, gwm gwProxyMap) 
 	}
 
 	// Make first cluster AWS, US country code.
-	for _, s := range sc.clusterForName("C1").servers {
+	for i, s := range sc.clusterForName("C1").servers {
 		s.optsMu.Lock()
 		s.opts.Tags.Add("cloud:aws")
 		s.opts.Tags.Add("country:us")
+		s.opts.Tags.Add(fmt.Sprintf("node:%d", i+1))
 		s.optsMu.Unlock()
 		reset(s)
 	}
 	// Make second cluster GCP, UK country code.
-	for _, s := range sc.clusterForName("C2").servers {
+	for i, s := range sc.clusterForName("C2").servers {
 		s.optsMu.Lock()
 		s.opts.Tags.Add("cloud:gcp")
 		s.opts.Tags.Add("country:uk")
+		s.opts.Tags.Add(fmt.Sprintf("node:%d", i+1))
 		s.optsMu.Unlock()
 		reset(s)
 	}
 	// Make third cluster AZ, JP country code.
-	for _, s := range sc.clusterForName("C3").servers {
+	for i, s := range sc.clusterForName("C3").servers {
 		s.optsMu.Lock()
 		s.opts.Tags.Add("cloud:az")
 		s.opts.Tags.Add("country:jp")
+		s.opts.Tags.Add(fmt.Sprintf("node:%d", i+1))
 		s.optsMu.Unlock()
 		reset(s)
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -1691,6 +1691,11 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 		}
 	}
 
+	// For now don't allow preferred server in placement.
+	if cfg.Placement != nil && cfg.Placement.Preferred != _EMPTY_ {
+		return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("preferred server not permitted in placement"))
+	}
+
 	return cfg, nil
 }
 


### PR DESCRIPTION
This makes it possible to nominate a JetStream metaleader transfer to servers matching specific placement tags in addition to cluster names, or optionally, to a specific named server.

* If `preferred_server` is specified then placement will select that server only.
* Otherwise, either `cluster` or `tags` can be supplied for placement. If both the `cluster` and `tags` are supplied then the placement will select a server that matches both.
* If multiple `tags` are specified, the placement will select servers only if they match all supplied tags.

Also factors out some of the logic for making the preferred leader decision so that it could be reused for stream & consumer stepdowns.

Signed-off-by: Neil Twigg <neil@nats.io>
