### PR TITLE
Goreleaser v2 config

### DIFF
--- a/.github/actions/nightly-release/action.yaml
+++ b/.github/actions/nightly-release/action.yaml
@@ -32,11 +32,11 @@ runs:
 
     - name: goreleaser
       # Use commit hash here to avoid a re-tagging attack, as this is a third-party action
-      # Commit 5742e2a039330cbb23ebf35f046f814d4c6ff811 = tag v5
-      uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811
+      # Commit 9ed2f89a662bf1735a48bc8557fd212fa902bebf = tag v6.1.0
+      uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf
       with:
         workdir: "${{ inputs.workdir }}"
-        version: latest
+        version: '~> v2'
         args: release --snapshot --config .goreleaser-nightly.yml
 
     - name: images

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -1,4 +1,5 @@
 project_name: nats-server
+version: 2
 
 builds:
   - main: .
@@ -32,4 +33,4 @@ checksum:
   algorithm: sha256
 
 snapshot:
-  name_template: '{{ if index .Env "IMAGE_NAME"  }}{{ .Env.IMAGE_NAME }}{{ else if not (eq .Branch "main" "dev" "") }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}'
+  version_template: '{{ if index .Env "IMAGE_NAME"  }}{{ .Env.IMAGE_NAME }}{{ else if not (eq .Branch "main" "dev" "") }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 project_name: nats-server
+version: 2
 
 release:
   github:
@@ -8,7 +9,7 @@ release:
   draft: true
 
 changelog:
-  skip: true
+  disable: true
 
 builds:
 - main: .

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script: ./scripts/runTestsOnTravis.sh $TEST_SUITE
 deploy:
   provider: script
   cleanup: true
-  script: curl -o /tmp/goreleaser.tar.gz -sLf https://github.com/goreleaser/goreleaser/releases/download/v1.26.2/goreleaser_Linux_x86_64.tar.gz && tar -xvf /tmp/goreleaser.tar.gz -C /tmp/ && /tmp/goreleaser
+  script: curl -o /tmp/goreleaser.tar.gz -sLf https://github.com/goreleaser/goreleaser/releases/download/v2.5.0/goreleaser_Linux_x86_64.tar.gz && tar -xvf /tmp/goreleaser.tar.gz -C /tmp/ && /tmp/goreleaser
   on:
     tags: true
     condition: ($TRAVIS_GO_VERSION =~ 1.23) && ($TEST_SUITE = "compile")


### PR DESCRIPTION
Switch to goreleaser v2, similar to:
https://github.com/nats-io/natscli/pull/1191

## Test plan:
```
[alex@omenlaptop:nats-server] [13:15:58] goreleaser_v2_config []   NGS-Default-CLI
# goreleaser check -f .goreleaser.yml
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!


[alex@omenlaptop:nats-server] [13:16:02] goreleaser_v2_config []   NGS-Default-CLI
# goreleaser check -f .goreleaser-nightly.yml
  • checking                                 path=.goreleaser-nightly.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```

```
# goreleaser release --snapshot --clean -f .goreleaser.yml
# goreleaser release --snapshot --clean -f .goreleaser-nightly.yml
```



Signed-off-by: Alex Bozhenko <alex@synadia.com>
