### PR TITLE
[FIXED] LeafNode: queue interest on leaf not propagated with permissions on hub

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2329,8 +2329,16 @@ func (c *client) sendLeafNodeSubUpdate(key string, n int32) {
 				checkPerms = false
 			}
 		}
-		if checkPerms && !c.canSubscribe(key) {
-			return
+		if checkPerms {
+			var subject string
+			if sep := strings.IndexByte(key, ' '); sep != -1 {
+				subject = key[:sep]
+			} else {
+				subject = key
+			}
+			if !c.canSubscribe(subject) {
+				return
+			}
 		}
 	}
 	// If we are here we can send over to the other side.


### PR DESCRIPTION
If the hub has a user with subscribe permissions on a literal subject that the leaf is trying to create a queue subscription on, the interest may not be propagated.

The issue was caused by the fact that we were checking the permissions on the key (that includes subject and queue name) instead of the subject itself.

Resolves #6281

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>