### PR TITLE
Make goreleaser archives reproducible

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -14,6 +14,7 @@ builds:
       - linux
     goarch:
       - amd64
+    mod_timestamp: "{{ .CommitTimestamp }}"
 
 dockers:
   - goos: linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,6 +46,7 @@ builds:
       goarch: arm64
     - goos: freebsd
       goarch: 386
+  mod_timestamp: "{{ .CommitTimestamp }}"
 
 nfpms:
   - file_name_template: '{{.ProjectName}}-{{.Tag}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}'


### PR DESCRIPTION
Use commit time in mod_timestamp, as documented in:
https://goreleaser.com/customization/builds/#reproducible-builds
https://goreleaser.com/blog/reproducible-builds/
https://goreleaser.com/customization/templates/?h=templates#common-fields

## Test plan:
### Before.
Build two times:
```
goreleaser release --snapshot --clean -f .goreleaser.yml
mv dist/ ~/tmp/dist_before
goreleaser release --snapshot --clean -f .goreleaser.yml 
vimdiff dist/SHA256SUMS ~/tmp/dist_before/SHA256SUMS
```
Observe all the shasums are different:
![image](https://github.com/user-attachments/assets/ed0b932c-ab5b-46de-bf73-0516e223af8a)

### After:
Do the build two times, 
```
goreleaser release --snapshot --clean -f .goreleaser.yml
mv dist/ ~/tmp/dist_after
goreleaser release --snapshot --clean -f .goreleaser.yml 
vimdiff dist/SHA256SUMS ~/tmp/dist_after/SHA256SUMS
```
Observe that only rpm and deb packages are different
![image](https://github.com/user-attachments/assets/ad4e3786-5d2b-480b-9e66-c2824f379d57)

There was a feature added to goreleaser to make packages reproducible too, but I haven't figured out how to use it yet:
https://github.com/goreleaser/nfpm/pull/748
I asked in Discord. We can tackle that separately

Signed-off-by: Alex Bozhenko <alex@synadia.com>
