### PR TITLE
De-flake TestJetStreamClusterMirrorAndSourceExpiration

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5317,7 +5317,7 @@ func (fs *fileStore) expireMsgs() {
 	defer fs.mu.Unlock()
 
 	// TODO: Not great that we're holding the lock here, but the timed hash wheel isn't thread-safe.
-	var nextTTL int64
+	nextTTL := int64(math.MaxInt64)
 	if fs.ttls != nil {
 		fs.ttls.ExpireTasks(func(seq uint64, ts int64) {
 			fs.removeMsgViaLimits(seq)
@@ -5331,7 +5331,7 @@ func (fs *fileStore) expireMsgs() {
 		}
 	}
 
-	// Onky cancel if no message left, not on potential lookup error that would result in sm == nil.
+	// Only cancel if no message left, not on potential lookup error that would result in sm == nil.
 	if fs.state.Msgs == 0 && nextTTL == math.MaxInt64 {
 		fs.cancelAgeChk()
 	} else {


### PR DESCRIPTION
`nextTTL` was not defaulted to `math.MaxInt64` so it would not cancel the age check in this condition: `if fs.state.Msgs == 0 && nextTTL == math.MaxInt64`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>