### PR TITLE
Enable SBOM config for GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,72 +5,72 @@ release:
   github:
     owner: nats-io
     name: nats-server
-  name_template: 'Release {{.Tag}}'
+  name_template: "Release {{.Tag}}"
   draft: true
 
 changelog:
   disable: true
 
 builds:
-- main: .
-  binary: nats-server
-  flags:
-  - -trimpath
-  ldflags:
-    - -w -X 'github.com/nats-io/nats-server/v2/server.gitCommit={{.ShortCommit}}' -X 'github.com/nats-io/nats-server/v2/server.serverVersion={{.Tag}}'
-  env:
-    - GO111MODULE=on
-    - CGO_ENABLED=0
-  goos:
-  - darwin
-  - linux
-  - windows
-  - freebsd
-  goarch:
-  - amd64
-  - arm
-  - arm64
-  - 386
-  - mips64le
-  - s390x
-  - ppc64le
-  goarm:
-  - 6
-  - 7
-  ignore:
-    - goos: darwin
-      goarch: 386
-    - goos: freebsd
-      goarch: arm
-    - goos: freebsd
-      goarch: arm64
-    - goos: freebsd
-      goarch: 386
-  mod_timestamp: "{{ .CommitTimestamp }}"
+  - main: .
+    binary: nats-server
+    flags:
+      - -trimpath
+    ldflags:
+      - -w -X 'github.com/nats-io/nats-server/v2/server.gitCommit={{.ShortCommit}}' -X 'github.com/nats-io/nats-server/v2/server.serverVersion={{.Tag}}'
+    env:
+      - GO111MODULE=on
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+      - freebsd
+    goarch:
+      - amd64
+      - arm
+      - arm64
+      - 386
+      - mips64le
+      - s390x
+      - ppc64le
+    goarm:
+      - 6
+      - 7
+    ignore:
+      - goos: darwin
+        goarch: 386
+      - goos: freebsd
+        goarch: arm
+      - goos: freebsd
+        goarch: arm64
+      - goos: freebsd
+        goarch: 386
+    mod_timestamp: "{{ .CommitTimestamp }}"
 
 nfpms:
-  - file_name_template: '{{.ProjectName}}-{{.Tag}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}'
-    homepage:  https://nats.io
+  - file_name_template: "{{.ProjectName}}-{{.Tag}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}"
+    homepage: https://nats.io
     description: High-Performance server for NATS, the cloud native messaging system.
     maintainer: Ivan Kozlovic <ivan@synadia.com>
     license: Apache 2.0
     vendor: Synadia Inc.
     formats:
-    - deb
-    - rpm
+      - deb
+      - rpm
     contents:
-    - src: /usr/bin/nats-server
-      dst: /usr/local/bin/nats-server
-      type: "symlink"
+      - src: /usr/bin/nats-server
+        dst: /usr/local/bin/nats-server
+        type: "symlink"
 
 archives:
-  - name_template: '{{.ProjectName}}-{{.Tag}}-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}'
+  - name_template: "{{.ProjectName}}-{{.Tag}}-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}"
     wrap_in_directory: true
     format: zip
     files:
       - README.md
       - LICENSE
-  - name_template: '{{.ProjectName}}-{{.Tag}}-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}'
+  - name_template: "{{.ProjectName}}-{{.Tag}}-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}"
     id: targz-archives
     wrap_in_directory: true
     format: tar.gz
@@ -79,5 +79,12 @@ archives:
       - LICENSE
 
 checksum:
-  name_template: 'SHA256SUMS'
+  name_template: "SHA256SUMS"
   algorithm: sha256
+
+sboms:
+  - artifacts: binary
+    documents:
+      [
+        "{{.ProjectName}}-{{.Tag}}-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}.sbom.spdx.json",
+      ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,9 @@ jobs:
 
 script: ./scripts/runTestsOnTravis.sh $TEST_SUITE
 
+before_deploy:
+  - curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
 deploy:
   provider: script
   cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,11 @@ jobs:
 
 script: ./scripts/runTestsOnTravis.sh $TEST_SUITE
 
+# Install Syft which is used by GoReleaser in the deploy step.
+# Cosign is an optional dependency to verify the Syft binary.
 before_deploy:
-  - curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+  - curl -o /usr/local/bin/cosign -L https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 && chmod +x /usr/local/bin/cosign
+  - curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | COSIGN_BINARY=/usr/local/bin/cosign sh -s -- -v -b /usr/local/bin
 
 deploy:
   provider: script


### PR DESCRIPTION
This will generate a new set of SPDX-formatted SBOM files on a release using the the GoReleaser + Syft toolchain.

Travis currenly invocates GoReleaser so the Syft dependency needs to be installed ahead of the `deploy` action.
