### PR TITLE
Add account name tag to monitoring endpoints

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -452,7 +452,7 @@ func (a *Account) clearEventing() {
 // GetName will return the accounts name.
 func (a *Account) GetName() string {
 	if a == nil {
-		return ""
+		return "n/a"
 	}
 	a.mu.RLock()
 	name := a.Name
@@ -463,16 +463,15 @@ func (a *Account) GetName() string {
 // getNameTag will return the name tag or the account name if not set.
 func (a *Account) getNameTag() string {
 	if a == nil {
-		return ""
+		return _EMPTY_
 	}
 	a.mu.RLock()
 	nameTag := a.nameTag
-	name := a.Name
-	a.mu.RUnlock()
-	if nameTag != "" {
-		return nameTag
+	if nameTag == _EMPTY_ {
+		nameTag = a.Name
 	}
-	return name
+	a.mu.RUnlock()
+	return nameTag
 }
 
 // NumConnections returns active number of clients for this account for

--- a/server/events.go
+++ b/server/events.go
@@ -2337,9 +2337,14 @@ func (s *Server) sendAccConnsUpdate(a *Account, subj ...string) {
 func (a *Account) statz() *AccountStat {
 	localConns := a.numLocalConnections()
 	leafConns := a.numLocalLeafNodes()
+	// Do not use getNameTag() to avoid a deadlock with `registerWithAccount`.
+	nameTag := a.nameTag
+	if nameTag == _EMPTY_ {
+		nameTag = a.Name
+	}
 	return &AccountStat{
 		Account:    a.Name,
-		Name:       a.LogicalName,
+		Name:       nameTag,
 		Conns:      localConns,
 		LeafNodes:  leafConns,
 		TotalConns: localConns + leafConns,
@@ -2410,7 +2415,7 @@ func (s *Server) accountConnectEvent(c *client) {
 			Jwt:        c.opts.JWT,
 			IssuerKey:  issuerForClient(c),
 			Tags:       c.tags,
-			NameTag:    c.nameTag,
+			NameTag:    c.acc.getNameTag(),
 			Kind:       c.kindString(),
 			ClientType: c.clientTypeString(),
 			MQTTClient: c.getMQTTClientID(),
@@ -2462,7 +2467,7 @@ func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string)
 			Jwt:        c.opts.JWT,
 			IssuerKey:  issuerForClient(c),
 			Tags:       c.tags,
-			NameTag:    c.nameTag,
+			NameTag:    c.acc.getNameTag(),
 			Kind:       c.kindString(),
 			ClientType: c.clientTypeString(),
 			MQTTClient: c.getMQTTClientID(),
@@ -2516,7 +2521,7 @@ func (s *Server) sendAuthErrorEvent(c *client) {
 			Jwt:        c.opts.JWT,
 			IssuerKey:  issuerForClient(c),
 			Tags:       c.tags,
-			NameTag:    c.nameTag,
+			NameTag:    c.acc.getNameTag(),
 			Kind:       c.kindString(),
 			ClientType: c.clientTypeString(),
 			MQTTClient: c.getMQTTClientID(),
@@ -2574,7 +2579,7 @@ func (s *Server) sendAccountAuthErrorEvent(c *client, acc *Account, reason strin
 			Jwt:        c.opts.JWT,
 			IssuerKey:  issuerForClient(c),
 			Tags:       c.tags,
-			NameTag:    c.nameTag,
+			NameTag:    c.acc.getNameTag(),
 			Kind:       c.kindString(),
 			ClientType: c.clientTypeString(),
 			MQTTClient: c.getMQTTClientID(),

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -4598,7 +4598,7 @@ func TestJWTUserRevocation(t *testing.T) {
 			t.Fatalf("Expected connection to have failed")
 		}
 		m := <-ncChan
-		require_Len(t, strings.Count(string(m.Data), apub), 2)
+		require_Len(t, strings.Count(string(m.Data), apub), 3)
 		require_True(t, strings.Contains(string(m.Data), `"jwt":"eyJ0`))
 		// try again with old credentials. Expected to fail
 		if nc1, err := nats.Connect(srv.ClientURL(), nats.UserCredentials(aCreds1)); err == nil {

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -415,14 +415,11 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 		// Fill in user if auth requested.
 		if auth {
 			ci.AuthorizedUser = client.getRawAuthUser()
-			// Add in account iff not the global account.
-			if client.acc != nil && (client.acc.Name != globalAccountName) {
-				ci.Account = client.acc.Name
-			}
+			ci.Account = client.acc.GetName()
 			ci.JWT = client.opts.JWT
 			ci.IssuerKey = issuerForClient(client)
 			ci.Tags = client.tags
-			ci.NameTag = client.nameTag
+			ci.NameTag = client.acc.getNameTag()
 		}
 		client.mu.Unlock()
 		pconns[i] = ci
@@ -465,9 +462,11 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 		// Fill in user if auth requested.
 		if auth {
 			cc.AuthorizedUser = cc.user
-			// Add in account iff not the global account.
-			if cc.acc != _EMPTY_ && (cc.acc != globalAccountName) {
+			if cc.acc != _EMPTY_ {
 				cc.Account = cc.acc
+				if acc, err := s.LookupAccount(cc.acc); err == nil {
+					cc.NameTag = acc.getNameTag()
+				}
 			}
 		}
 		pconns[i] = &cc.ConnInfo
@@ -925,21 +924,21 @@ type SubszOptions struct {
 
 // SubDetail is for verbose information for subscriptions.
 type SubDetail struct {
-	Account string `json:"account,omitempty"`
-	Subject string `json:"subject"`
-	Queue   string `json:"qgroup,omitempty"`
-	Sid     string `json:"sid"`
-	Msgs    int64  `json:"msgs"`
-	Max     int64  `json:"max,omitempty"`
-	Cid     uint64 `json:"cid"`
+	Account    string `json:"account,omitempty"`
+	AccountTag string `json:"account_tag,omitempty"`
+	Subject    string `json:"subject"`
+	Queue      string `json:"qgroup,omitempty"`
+	Sid        string `json:"sid"`
+	Msgs       int64  `json:"msgs"`
+	Max        int64  `json:"max,omitempty"`
+	Cid        uint64 `json:"cid"`
 }
 
 // Subscription client should be locked and guaranteed to be present.
 func newSubDetail(sub *subscription) SubDetail {
 	sd := newClientSubDetail(sub)
-	if sub.client.acc != nil {
-		sd.Account = sub.client.acc.Name
-	}
+	sd.Account = sub.client.acc.GetName()
+	sd.AccountTag = sub.client.acc.getNameTag()
 	return sd
 }
 
@@ -2713,27 +2712,27 @@ func (s *Server) accountInfo(accName string) (*AccountInfo, error) {
 		mappings[src] = dests
 	}
 	return &AccountInfo{
-		accName,
-		a.updated.UTC(),
-		isSys,
-		a.expired.Load(),
-		!a.incomplete,
-		a.js != nil,
-		a.numLocalLeafNodes(),
-		a.numLocalConnections(),
-		a.sl.Count(),
-		mappings,
-		exports,
-		imports,
-		a.claimJWT,
-		a.Issuer,
-		a.nameTag,
-		a.tags,
-		claim,
-		vrIssues,
-		collectRevocations(a.usersRevoked),
-		a.sl.Stats(),
-		responses,
+		AccountName: accName,
+		LastUpdate:  a.updated.UTC(),
+		IsSystem:    isSys,
+		Expired:     a.expired.Load(),
+		Complete:    !a.incomplete,
+		JetStream:   a.js != nil,
+		LeafCnt:     a.numLocalLeafNodes(),
+		ClientCnt:   a.numLocalConnections(),
+		SubCnt:      a.sl.Count(),
+		Mappings:    mappings,
+		Exports:     exports,
+		Imports:     imports,
+		Jwt:         a.claimJWT,
+		IssuerKey:   a.Issuer,
+		NameTag:     a.getNameTag(),
+		Tags:        a.tags,
+		Claim:       claim,
+		Vr:          vrIssues,
+		RevokedUser: collectRevocations(a.usersRevoked),
+		Sublist:     a.sl.Stats(),
+		Responses:   responses,
 	}, nil
 }
 

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -415,7 +415,9 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 		// Fill in user if auth requested.
 		if auth {
 			ci.AuthorizedUser = client.getRawAuthUser()
-			ci.Account = client.acc.GetName()
+			if name := client.acc.GetName(); name != globalAccountName {
+				ci.Account = name
+			}
 			ci.JWT = client.opts.JWT
 			ci.IssuerKey = issuerForClient(client)
 			ci.Tags = client.tags
@@ -462,7 +464,7 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 		// Fill in user if auth requested.
 		if auth {
 			cc.AuthorizedUser = cc.user
-			if cc.acc != _EMPTY_ {
+			if cc.acc != _EMPTY_ && (cc.acc != globalAccountName) {
 				cc.Account = cc.acc
 				if acc, err := s.LookupAccount(cc.acc); err == nil {
 					cc.NameTag = acc.getNameTag()

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 package server
+
 import (
 	"bytes"
 	"crypto/tls"
@@ -37,9 +38,11 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"
 )
+
 const CLIENT_PORT = -1
 const MONITOR_PORT = -1
 const CLUSTER_PORT = -1
+
 func DefaultMonitorOptions() *Options {
 	return &Options{
 		Host:         "127.0.0.1",
@@ -152,6 +155,7 @@ func TestMyUptime(t *testing.T) {
 		t.Fatalf("Expected `22y32d4h4m22s`, go ``%s`", s)
 	}
 }
+
 // Make sure that we do not run the http server for monitoring unless asked.
 func TestMonitorNoPort(t *testing.T) {
 	s := runMonitorServerNoHTTPPort()
@@ -169,12 +173,14 @@ func TestMonitorNoPort(t *testing.T) {
 		t.Fatalf("Expected error: Got %+v\n", resp)
 	}
 }
+
 var (
 	appJSONContent = "application/json"
 	appJSContent   = "application/javascript"
 	textPlain      = "text/plain; charset=utf-8"
 	textHTML       = "text/html; charset=utf-8"
 )
+
 func readBodyEx(t *testing.T, url string, status int, content string) []byte {
 	t.Helper()
 	resp, err := http.Get(url)
@@ -234,6 +240,7 @@ func pollVarz(t *testing.T, s *Server, mode int, url string, opts *VarzOptions) 
 	}
 	return v
 }
+
 // https://github.com/nats-io/nats-server/issues/2170
 // Just the ever increasing subs part.
 func TestMonitorVarzSubscriptionsResetProperly(t *testing.T) {
@@ -581,6 +588,7 @@ func TestMonitorConnzWithCID(t *testing.T) {
 		}
 	}
 }
+
 // Helper to map to connection name
 func createConnMap(cz *Connz) map[string]*ConnInfo {
 	cm := make(map[string]*ConnInfo)
@@ -1262,6 +1270,7 @@ func TestMonitorConnzSortedByIdle(t *testing.T) {
 		testIdle(mode)
 	}
 }
+
 // getConnsIdleDurations returns a slice of parsed idle durations from a connection info slice.
 func getConnsIdleDurations(t *testing.T, conns []*ConnInfo) []time.Duration {
 	t.Helper()
@@ -1278,6 +1287,7 @@ func getConnsIdleDurations(t *testing.T, conns []*ConnInfo) []time.Duration {
 
 	return durations
 }
+
 // sortedDurationsDesc checks if a time.Duration slice is sorted in descending order.
 func sortedDurationsDesc(durations []time.Duration) bool {
 	return sort.SliceIsSorted(durations, func(i, j int) bool {
@@ -1345,6 +1355,7 @@ func TestMonitorConnzSortByIdleTime(t *testing.T) {
 		})
 	}
 }
+
 // getIdleDurations returns a slice of idle durations from a connection info list up until now time.
 func getIdleDurations(conns ConnInfos, now time.Time) []time.Duration {
 	durations := make([]time.Duration, 0, len(conns))
@@ -1355,6 +1366,7 @@ func getIdleDurations(conns ConnInfos, now time.Time) []time.Duration {
 
 	return durations
 }
+
 // sortedDurationsAsc checks if a time.Duration slice is sorted in ascending order.
 func sortedDurationsAsc(durations []time.Duration) bool {
 	return sort.SliceIsSorted(durations, func(i, j int) bool {
@@ -1802,6 +1814,7 @@ func TestMonitorSubszMultiAccountWithOffsetAndLimit(t *testing.T) {
 		}
 	}
 }
+
 // Tests handle root
 func TestMonitorHandleRoot(t *testing.T) {
 	s := runMonitorServer()
@@ -1944,6 +1957,7 @@ func TestMonitorConnzWithStateForClosedConns(t *testing.T) {
 		})
 	}
 }
+
 // Make sure options for ConnInfo like subs=1, authuser, etc do not cause a race.
 func TestMonitorConnzClosedConnsRace(t *testing.T) {
 	s := runMonitorServer()
@@ -1978,6 +1992,7 @@ func TestMonitorConnzClosedConnsRace(t *testing.T) {
 	go fn(urlWithoutSubs)
 	wg.Wait()
 }
+
 // Make sure a bad client that is disconnected right away has proper values.
 func TestMonitorConnzClosedConnsBadClient(t *testing.T) {
 	s := runMonitorServer()
@@ -2011,6 +2026,7 @@ func TestMonitorConnzClosedConnsBadClient(t *testing.T) {
 		t.Fatalf("LastActivity should not be Zero\n")
 	}
 }
+
 // Make sure a bad client that tries to connect plain to TLS has proper values.
 func TestMonitorConnzClosedConnsBadTLSClient(t *testing.T) {
 	resetPreviousHTTPConnections()
@@ -2060,6 +2076,7 @@ func TestMonitorConnzClosedConnsBadTLSClient(t *testing.T) {
 		t.Fatalf("LastActivity should not be Zero\n")
 	}
 }
+
 // Create a connection to test ConnInfo
 func createClientConnWithUserSubscribeAndPublish(t *testing.T, s *Server, user, pwd string) *nats.Conn {
 	natsURL := ""
@@ -2517,6 +2534,7 @@ func TestMonitorRoutezPermissions(t *testing.T) {
 		}
 	}
 }
+
 // Benchmark our Connz generation. Don't use HTTP here, just measure server endpoint.
 func Benchmark_Connz(b *testing.B) {
 	runtime.MemProfileRate = 0
@@ -4590,6 +4608,7 @@ func TestMonitorAuthorizedUsers(t *testing.T) {
 	// we should get the user's pubkey
 	checkAuthUser(upub)
 }
+
 // Helper function to check that a JS cluster is formed
 func checkForJSClusterUp(t *testing.T, servers ...*Server) {
 	t.Helper()
@@ -5588,6 +5607,7 @@ func TestMonitorConnzSortByRTT(t *testing.T) {
 		}
 	}
 }
+
 // https://github.com/nats-io/nats-server/issues/4144
 func TestMonitorAccountszMappingOrderReporting(t *testing.T) {
 	conf := createConfFile(t, []byte(`
@@ -5620,6 +5640,7 @@ func TestMonitorAccountszMappingOrderReporting(t *testing.T) {
 	}
 	require_True(t, found)
 }
+
 // createCallbackURL adds a callback query parameter for JSONP requests.
 func createCallbackURL(t *testing.T, endpoint string) string {
 	t.Helper()
@@ -5636,6 +5657,7 @@ func createCallbackURL(t *testing.T, endpoint string) string {
 
 	return u.String()
 }
+
 // stripCallback removes the JSONP callback function from the response.
 // Returns the JSON body without the wrapping callback function.
 // If there's no callback function, the data is returned as is.
@@ -5649,6 +5671,7 @@ func stripCallback(data []byte) []byte {
 
 	return data
 }
+
 // expectHealthStatus makes 1 regular and 1 JSONP request to the URL and checks the
 // HTTP status code, Content-Type header and health status string.
 func expectHealthStatus(t *testing.T, url string, statusCode int, wantStatus string) {
@@ -5663,6 +5686,7 @@ func expectHealthStatus(t *testing.T, url string, statusCode int, wantStatus str
 	jsonpBody := readBodyEx(t, jsonpURL, statusCode, appJSContent)
 	checkHealthStatus(t, stripCallback(jsonpBody), wantStatus)
 }
+
 // checkHealthStatus checks the health status from a JSON response.
 func checkHealthStatus(t *testing.T, body []byte, wantStatus string) {
 	t.Helper()
@@ -5677,6 +5701,7 @@ func checkHealthStatus(t *testing.T, body []byte, wantStatus string) {
 		t.Errorf("want health status %q, got %q", wantStatus, h.Status)
 	}
 }
+
 // checkHealthzEndpoint makes requests to the /healthz endpoint and checks the health status.
 func checkHealthzEndpoint(t *testing.T, address string, statusCode int, wantStatus string) {
 	t.Helper()
@@ -5773,6 +5798,7 @@ func TestMonitorHealthzStatusUnavailable(t *testing.T) {
 		})
 	}
 }
+
 // When we converted ipq to use generics we still were using sync.Map. Currently you can not convert
 // any or any to a generic parameterized type. So this stopped working and panics.
 // Copyright 2013-2024 The NATS Authors

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -56,6 +56,7 @@ func DefaultMonitorOptions() *Options {
 		Tags:         []string{"tag"},
 	}
 }
+
 func runMonitorJSServer(t *testing.T, clientPort int, monitorPort int, clusterPort int, routePort int) (*Server, *Options) {
 	resetPreviousHTTPConnections()
 	tmpDir := t.TempDir()
@@ -96,12 +97,14 @@ func runMonitorJSServer(t *testing.T, clientPort int, monitorPort int, clusterPo
 
 	return RunServerWithConfig(cf)
 }
+
 func runMonitorServer() *Server {
 	resetPreviousHTTPConnections()
 	opts := DefaultMonitorOptions()
 	opts.NoSystemAccount = true
 	return RunServer(opts)
 }
+
 func runMonitorServerWithAccounts() *Server {
 	resetPreviousHTTPConnections()
 	opts := DefaultMonitorOptions()
@@ -114,6 +117,7 @@ func runMonitorServerWithAccounts() *Server {
 		&User{Username: "b", Password: "b", Account: aB})
 	return RunServer(opts)
 }
+
 func runMonitorServerNoHTTPPort() *Server {
 	resetPreviousHTTPConnections()
 	opts := DefaultMonitorOptions()
@@ -121,9 +125,11 @@ func runMonitorServerNoHTTPPort() *Server {
 	opts.HTTPPort = 0
 	return RunServer(opts)
 }
+
 func resetPreviousHTTPConnections() {
 	http.DefaultTransport.(*http.Transport).CloseIdleConnections()
 }
+
 func TestMyUptime(t *testing.T) {
 	// Make sure we print this stuff right.
 	var d time.Duration
@@ -208,6 +214,7 @@ func readBodyEx(t *testing.T, url string, status int, content string) []byte {
 	}
 	return body
 }
+
 func TestMonitorHTTPBasePath(t *testing.T) {
 	resetPreviousHTTPConnections()
 	opts := DefaultMonitorOptions()
@@ -220,10 +227,12 @@ func TestMonitorHTTPBasePath(t *testing.T) {
 	url := fmt.Sprintf("http://127.0.0.1:%d/nats", s.MonitorAddr().Port)
 	readBodyEx(t, url, http.StatusOK, textHTML)
 }
+
 func readBody(t *testing.T, url string) []byte {
 	t.Helper()
 	return readBodyEx(t, url, http.StatusOK, appJSONContent)
 }
+
 func pollVarz(t *testing.T, s *Server, mode int, url string, opts *VarzOptions) *Varz {
 	t.Helper()
 	if mode == 0 {
@@ -260,6 +269,7 @@ func TestMonitorVarzSubscriptionsResetProperly(t *testing.T) {
 		t.Fatalf("Expected subs to stay the same, %d vs %d", osubs, v.Subscriptions)
 	}
 }
+
 func TestMonitorHandleVarz(t *testing.T) {
 	s, _ := runMonitorJSServer(t, -1, -1, 0, 0)
 	defer s.Shutdown()
@@ -334,6 +344,7 @@ func TestMonitorHandleVarz(t *testing.T) {
 	// Test JSONP
 	readBodyEx(t, url+"varz?callback=callback", http.StatusOK, appJSContent)
 }
+
 func pollConnz(t *testing.T, s *Server, mode int, url string, opts *ConnzOptions) *Connz {
 	t.Helper()
 	if mode == 0 {
@@ -350,6 +361,7 @@ func pollConnz(t *testing.T, s *Server, mode int, url string, opts *ConnzOptions
 	}
 	return c
 }
+
 func TestMonitorConnz(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -461,6 +473,7 @@ func TestMonitorConnz(t *testing.T) {
 	// Test JSONP
 	readBodyEx(t, url+"connz?callback=callback", http.StatusOK, appJSContent)
 }
+
 func TestMonitorConnzBadParams(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -472,6 +485,7 @@ func TestMonitorConnzBadParams(t *testing.T) {
 	readBodyEx(t, url+"limit=xxx", http.StatusBadRequest, textPlain)
 	readBodyEx(t, url+"state=xxx", http.StatusBadRequest, textPlain)
 }
+
 func TestMonitorConnzWithSubs(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -492,6 +506,7 @@ func TestMonitorConnzWithSubs(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzWithSubsDetail(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -512,6 +527,7 @@ func TestMonitorConnzWithSubsDetail(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorClosedConnzWithSubsDetail(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -541,6 +557,7 @@ func TestMonitorClosedConnzWithSubsDetail(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzWithCID(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -597,9 +614,11 @@ func createConnMap(cz *Connz) map[string]*ConnInfo {
 	}
 	return cm
 }
+
 func getFooAndBar(cm map[string]*ConnInfo) (*ConnInfo, *ConnInfo) {
 	return cm["foo"], cm["bar"]
 }
+
 func ensureServerActivityRecorded(t *testing.T, nc *nats.Conn) {
 	nc.Flush()
 	err := nc.Flush()
@@ -607,6 +626,7 @@ func ensureServerActivityRecorded(t *testing.T, nc *nats.Conn) {
 		t.Fatalf("Error flushing: %v\n", err)
 	}
 }
+
 func TestMonitorConnzRTT(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -661,6 +681,7 @@ func TestMonitorConnzRTT(t *testing.T) {
 		checkClientsCount(t, s, 0)
 	}
 }
+
 func TestMonitorConnzLastActivity(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -754,6 +775,7 @@ func TestMonitorConnzLastActivity(t *testing.T) {
 		testActivity(mode)
 	}
 }
+
 func TestMonitorConnzWithOffsetAndLimit(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -827,6 +849,7 @@ func TestMonitorConnzWithOffsetAndLimit(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzDefaultSorted(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -847,6 +870,7 @@ func TestMonitorConnzDefaultSorted(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzSortedByCid(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -868,6 +892,7 @@ func TestMonitorConnzSortedByCid(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzSortedByStart(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -889,6 +914,7 @@ func TestMonitorConnzSortedByStart(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzSortedByBytesAndMsgs(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -942,6 +968,7 @@ func TestMonitorConnzSortedByBytesAndMsgs(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzSortedByPending(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -966,6 +993,7 @@ func TestMonitorConnzSortedByPending(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzSortedBySubs(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -991,6 +1019,7 @@ func TestMonitorConnzSortedBySubs(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzSortedByLast(t *testing.T) {
 	resetPreviousHTTPConnections()
 	opts := DefaultMonitorOptions()
@@ -1021,6 +1050,7 @@ func TestMonitorConnzSortedByLast(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzSortedByUptime(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -1049,6 +1079,7 @@ func TestMonitorConnzSortedByUptime(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzSortedByUptimeClosedConn(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -1086,6 +1117,7 @@ func TestMonitorConnzSortedByUptimeClosedConn(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzSortedByStopOnOpen(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -1107,6 +1139,7 @@ func TestMonitorConnzSortedByStopOnOpen(t *testing.T) {
 		t.Fatalf("Expected err to be non-nil, got %+v\n", c)
 	}
 }
+
 func TestMonitorConnzSortedByStopTimeClosedConn(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -1151,6 +1184,7 @@ func TestMonitorConnzSortedByStopTimeClosedConn(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzSortedByReason(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -1189,6 +1223,7 @@ func TestMonitorConnzSortedByReason(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzSortedByReasonOnOpen(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -1210,6 +1245,7 @@ func TestMonitorConnzSortedByReasonOnOpen(t *testing.T) {
 		t.Fatalf("Expected err to be non-nil, got %+v\n", c)
 	}
 }
+
 func TestMonitorConnzSortedByIdle(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -1295,6 +1331,7 @@ func sortedDurationsDesc(durations []time.Duration) bool {
 		return durations[i] > durations[j]
 	})
 }
+
 func TestMonitorConnzSortByIdleTime(t *testing.T) {
 	now := time.Now().UTC()
 
@@ -1373,6 +1410,7 @@ func sortedDurationsAsc(durations []time.Duration) bool {
 		return durations[i] < durations[j]
 	})
 }
+
 func TestMonitorConnzSortBadRequest(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -1393,6 +1431,7 @@ func TestMonitorConnzSortBadRequest(t *testing.T) {
 		t.Fatal("Expected error, got none")
 	}
 }
+
 func pollRoutez(t *testing.T, s *Server, mode int, url string, opts *RoutezOptions) *Routez {
 	t.Helper()
 	if mode == 0 {
@@ -1409,6 +1448,7 @@ func pollRoutez(t *testing.T, s *Server, mode int, url string, opts *RoutezOptio
 	}
 	return rz
 }
+
 func TestMonitorConnzWithRoutes(t *testing.T) {
 	resetPreviousHTTPConnections()
 	opts := DefaultMonitorOptions()
@@ -1516,6 +1556,7 @@ func TestMonitorConnzWithRoutes(t *testing.T) {
 	// Test JSONP
 	readBodyEx(t, url+"routez?callback=callback", http.StatusOK, appJSContent)
 }
+
 func TestMonitorRoutezWithBadParams(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -1523,6 +1564,7 @@ func TestMonitorRoutezWithBadParams(t *testing.T) {
 	url := fmt.Sprintf("http://127.0.0.1:%d/routez?", s.MonitorAddr().Port)
 	readBodyEx(t, url+"subs=xxx", http.StatusBadRequest, textPlain)
 }
+
 func pollSubsz(t *testing.T, s *Server, mode int, url string, opts *SubszOptions) *Subsz {
 	t.Helper()
 	if mode == 0 {
@@ -1539,6 +1581,7 @@ func pollSubsz(t *testing.T, s *Server, mode int, url string, opts *SubszOptions
 	}
 	return sz
 }
+
 func TestSubsz(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -1642,6 +1685,7 @@ func TestMonitorSubszDetails(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorSubszWithOffsetAndLimit(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -1674,6 +1718,7 @@ func TestMonitorSubszWithOffsetAndLimit(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorSubszTestPubSubject(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -1707,6 +1752,7 @@ func TestMonitorSubszTestPubSubject(t *testing.T) {
 	readBodyEx(t, testUrl+"test=foo.>", http.StatusBadRequest, textPlain)
 	readBodyEx(t, testUrl+"test=foo..bar", http.StatusBadRequest, textPlain)
 }
+
 func TestMonitorSubszMultiAccount(t *testing.T) {
 	s := runMonitorServerWithAccounts()
 	defer s.Shutdown()
@@ -1774,6 +1820,7 @@ func TestMonitorSubszMultiAccount(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorSubszMultiAccountWithOffsetAndLimit(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -1847,6 +1894,7 @@ func TestMonitorHandleRoot(t *testing.T) {
 		t.Fatalf("Expected text/html response, got %s\n", ct)
 	}
 }
+
 func TestMonitorConnzWithNamedClient(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -1871,6 +1919,7 @@ func TestMonitorConnzWithNamedClient(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzWithStateForClosedConns(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -2106,9 +2155,11 @@ func createClientConnWithUserSubscribeAndPublish(t *testing.T, s *Server, user, 
 	nc.Flush()
 	return nc
 }
+
 func createClientConnSubscribeAndPublish(t *testing.T, s *Server) *nats.Conn {
 	return createClientConnWithUserSubscribeAndPublish(t, s, "", "")
 }
+
 func createClientConnWithName(t *testing.T, name string, s *Server) *nats.Conn {
 	natsURI := fmt.Sprintf("nats://127.0.0.1:%d", s.Addr().(*net.TCPAddr).Port)
 
@@ -2121,6 +2172,7 @@ func createClientConnWithName(t *testing.T, name string, s *Server) *nats.Conn {
 	}
 	return nc
 }
+
 func TestMonitorStacksz(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -2133,6 +2185,7 @@ func TestMonitorStacksz(t *testing.T) {
 		t.Fatalf("Result does not seem to contain server's stacks:\n%v", str)
 	}
 }
+
 func TestMonitorConcurrentMonitoring(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -2180,6 +2233,7 @@ func TestMonitorConcurrentMonitoring(t *testing.T) {
 	default:
 	}
 }
+
 func TestMonitorHandler(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -2193,6 +2247,7 @@ func TestMonitorHandler(t *testing.T) {
 		t.Fatal("HTTP Handler should be nil")
 	}
 }
+
 func TestMonitorRoutezRace(t *testing.T) {
 	resetPreviousHTTPConnections()
 	srvAOpts := DefaultMonitorOptions()
@@ -2232,6 +2287,7 @@ func TestMonitorRoutezRace(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzTLSInHandshake(t *testing.T) {
 	resetPreviousHTTPConnections()
 
@@ -2279,6 +2335,7 @@ func TestMonitorConnzTLSInHandshake(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzTLSCfg(t *testing.T) {
 	resetPreviousHTTPConnections()
 
@@ -2334,6 +2391,7 @@ func TestMonitorConnzTLSCfg(t *testing.T) {
 		check(varz.LeafNode.TLSVerify, varz.LeafNode.TLSRequired, varz.LeafNode.TLSTimeout)
 	}
 }
+
 func TestMonitorConnzTLSPeerCerts(t *testing.T) {
 	resetPreviousHTTPConnections()
 
@@ -2389,6 +2447,7 @@ func TestMonitorConnzTLSPeerCerts(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorServerIDs(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -2413,6 +2472,7 @@ func TestMonitorServerIDs(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorHttpStatsNoUpdatedWhenUsingServerFuncs(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -2433,6 +2493,7 @@ func TestMonitorHttpStatsNoUpdatedWhenUsingServerFuncs(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorClusterEmptyWhenNotDefined(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -2451,6 +2512,7 @@ func TestMonitorClusterEmptyWhenNotDefined(t *testing.T) {
 		t.Fatalf("Expected an empty cluster definition, instead got %+v\n", c)
 	}
 }
+
 func TestMonitorRoutezPermissions(t *testing.T) {
 	resetPreviousHTTPConnections()
 	opts := DefaultMonitorOptions()
@@ -2570,6 +2632,7 @@ func Benchmark_Connz(b *testing.B) {
 		}
 	}
 }
+
 func Benchmark_Varz(b *testing.B) {
 	runtime.MemProfileRate = 0
 
@@ -2586,6 +2649,7 @@ func Benchmark_Varz(b *testing.B) {
 		}
 	}
 }
+
 func Benchmark_VarzHttp(b *testing.B) {
 	runtime.MemProfileRate = 0
 
@@ -2614,6 +2678,7 @@ func Benchmark_VarzHttp(b *testing.B) {
 		resp.Body.Close()
 	}
 }
+
 func TestMonitorVarzRaces(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -2680,6 +2745,7 @@ func TestMonitorVarzRaces(t *testing.T) {
 	close(done)
 	wg.Wait()
 }
+
 func testMonitorStructPresent(t *testing.T, tag string) {
 	t.Helper()
 
@@ -2695,6 +2761,7 @@ func testMonitorStructPresent(t *testing.T, tag string) {
 		t.Fatalf("%s should be present and empty, got %s", tag, body)
 	}
 }
+
 func TestMonitorCluster(t *testing.T) {
 	testMonitorStructPresent(t, "cluster")
 
@@ -2747,6 +2814,7 @@ func TestMonitorCluster(t *testing.T) {
 		check(t, v)
 	}
 }
+
 func TestMonitorClusterURLs(t *testing.T) {
 	resetPreviousHTTPConnections()
 
@@ -2846,6 +2914,7 @@ func TestMonitorClusterURLs(t *testing.T) {
 		return nil
 	})
 }
+
 func TestMonitorGateway(t *testing.T) {
 	testMonitorStructPresent(t, "gateway")
 
@@ -2943,6 +3012,7 @@ func TestMonitorGateway(t *testing.T) {
 		check(t, v)
 	}
 }
+
 func TestMonitorGatewayURLsUpdated(t *testing.T) {
 	resetPreviousHTTPConnections()
 
@@ -3043,6 +3113,7 @@ func TestMonitorGatewayURLsUpdated(t *testing.T) {
 		return nil
 	})
 }
+
 func TestMonitorGatewayReportItsOwnURLs(t *testing.T) {
 	resetPreviousHTTPConnections()
 
@@ -3072,6 +3143,7 @@ func TestMonitorGatewayReportItsOwnURLs(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorLeafNode(t *testing.T) {
 	testMonitorStructPresent(t, "leaf")
 
@@ -3146,6 +3218,7 @@ func TestMonitorLeafNode(t *testing.T) {
 		check(t, v)
 	}
 }
+
 func pollGatewayz(t *testing.T, s *Server, mode int, url string, opts *GatewayzOptions) *Gatewayz {
 	t.Helper()
 	if mode == 0 {
@@ -3162,6 +3235,7 @@ func pollGatewayz(t *testing.T, s *Server, mode int, url string, opts *GatewayzO
 	}
 	return g
 }
+
 func TestMonitorGatewayz(t *testing.T) {
 	resetPreviousHTTPConnections()
 
@@ -3364,6 +3438,7 @@ func TestMonitorGatewayz(t *testing.T) {
 	checkGatewayB(t, gatewayzURL+"?gw_name=B", opts)
 	checkGatewayB(t, gatewayzURL, nil)
 }
+
 func TestMonitorGatewayzAccounts(t *testing.T) {
 	GatewayDoNotForceInterestOnlyMode(true)
 	defer GatewayDoNotForceInterestOnlyMode(false)
@@ -3729,6 +3804,7 @@ func TestMonitorGatewayzAccounts(t *testing.T) {
 		return nil
 	})
 }
+
 func TestMonitorRoutezRTT(t *testing.T) {
 	// Do not change default PingInterval and expect RTT to still be reported
 
@@ -3765,6 +3841,7 @@ func TestMonitorRoutezRTT(t *testing.T) {
 	checkRouteInfo(t, sa)
 	checkRouteInfo(t, sb)
 }
+
 func pollLeafz(t *testing.T, s *Server, mode int, url string, opts *LeafzOptions) *Leafz {
 	t.Helper()
 	if mode == 0 {
@@ -3781,6 +3858,7 @@ func pollLeafz(t *testing.T, s *Server, mode int, url string, opts *LeafzOptions
 	}
 	return l
 }
+
 func TestMonitorOpJWT(t *testing.T) {
 	content := `
 	listen: "127.0.0.1:-1"
@@ -3816,6 +3894,7 @@ func TestMonitorOpJWT(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorLeafz(t *testing.T) {
 	content := `
 	server_name: "hub"
@@ -4068,6 +4147,7 @@ func TestMonitorLeafz(t *testing.T) {
 		}
 	}
 }
+
 func pollAccountz(t *testing.T, s *Server, mode int, url string, opts *AccountzOptions) *Accountz {
 	t.Helper()
 	if mode == 0 {
@@ -4084,6 +4164,7 @@ func pollAccountz(t *testing.T, s *Server, mode int, url string, opts *AccountzO
 	}
 	return a
 }
+
 func pollAccountStatz(t *testing.T, s *Server, mode int, url string, opts *AccountStatzOptions) *AccountStatz {
 	t.Helper()
 	if mode == 0 {
@@ -4100,6 +4181,7 @@ func pollAccountStatz(t *testing.T, s *Server, mode int, url string, opts *Accou
 	}
 	return as
 }
+
 func TestMonitorAccountz(t *testing.T) {
 	s := RunServer(DefaultMonitorOptions())
 	defer s.Shutdown()
@@ -4129,6 +4211,7 @@ func TestMonitorAccountz(t *testing.T) {
 		require_Equal(t, a.SystemAccount, DEFAULT_SYSTEM_ACCOUNT)
 	}
 }
+
 func TestMonitorAccountStatz(t *testing.T) {
 	s := RunServer(DefaultMonitorOptions())
 	defer s.Shutdown()
@@ -4154,6 +4237,7 @@ func TestMonitorAccountStatz(t *testing.T) {
 		}
 	}
 }
+
 func runMonitorServerWithOperator(t *testing.T, sysName, accName string) ([]*Server, nkeys.KeyPair, nkeys.KeyPair) {
 	t.Helper()
 
@@ -4308,6 +4392,7 @@ func runMonitorServerWithOperator(t *testing.T, sysName, accName string) ([]*Ser
 
 	return servers, sysKp, accKp
 }
+
 func createUser(t *testing.T, accKp nkeys.KeyPair) (string, string) {
 	t.Helper()
 
@@ -4320,6 +4405,7 @@ func createUser(t *testing.T, accKp nkeys.KeyPair) (string, string) {
 	require_NoError(t, err)
 	return upub, genCredsFile(t, ujwt, seed)
 }
+
 func TestMonitorAccountzOperatorMode(t *testing.T) {
 	sysName := "SYS"
 	accName := "APP"
@@ -4365,6 +4451,7 @@ func TestMonitorAccountzOperatorMode(t *testing.T) {
 	}
 
 }
+
 func TestMonitorAccountStatzOperatorMode(t *testing.T) {
 	sysName := "SYS"
 	accName := "APP"
@@ -4408,6 +4495,7 @@ func TestMonitorAccountStatzOperatorMode(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorAccountzAccountIssuerUpdate(t *testing.T) {
 	// create an operator set of keys
 	okp, err := nkeys.CreateOperator()
@@ -4516,6 +4604,7 @@ func TestMonitorAccountzAccountIssuerUpdate(t *testing.T) {
 	require_NoError(t, json.Unmarshal(data, &ci))
 	require_Equal(t, ci.Account.IssuerKey, opk2)
 }
+
 func TestMonitorAuthorizedUsers(t *testing.T) {
 	kp, _ := nkeys.FromSeed(seed)
 	usrNKey, _ := kp.PublicKey()
@@ -4658,6 +4747,7 @@ func TestMonitorJszNonJszServer(t *testing.T) {
 		t.Fatalf("expected no jsi: %v", jsi)
 	}
 }
+
 func TestMonitorJsz(t *testing.T) {
 	readJsInfo := func(url string) *JSInfo {
 		t.Helper()
@@ -5143,6 +5233,7 @@ func TestMonitorReloadTLSConfig(t *testing.T) {
 		t.Fatalf("Error: %v", err)
 	}
 }
+
 func TestMonitorMQTT(t *testing.T) {
 	o := DefaultOptions()
 	o.HTTPHost = "127.0.0.1"
@@ -5187,6 +5278,7 @@ func TestMonitorMQTT(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorWebsocket(t *testing.T) {
 	o := DefaultOptions()
 	o.HTTPHost = "127.0.0.1"
@@ -5239,6 +5331,7 @@ func TestMonitorWebsocket(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorServerIDZRequest(t *testing.T) {
 	conf := createConfFile(t, []byte(`
 		listen: 127.0.0.1:-1
@@ -5266,6 +5359,7 @@ func TestMonitorServerIDZRequest(t *testing.T) {
 	require_True(t, sid.Name == "TEST22")
 	require_True(t, strings.HasPrefix(sid.ID, "N"))
 }
+
 func TestMonitorProfilez(t *testing.T) {
 	s := RunServer(DefaultOptions())
 	defer s.Shutdown()
@@ -5292,6 +5386,7 @@ func TestMonitorProfilez(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorRoutezPoolSize(t *testing.T) {
 	conf1 := createConfFile(t, []byte(`
 		port: -1
@@ -5384,6 +5479,7 @@ func TestMonitorRoutezPoolSize(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorRoutezPerAccount(t *testing.T) {
 	conf1 := createConfFile(t, []byte(`
 		port: -1
@@ -5465,6 +5561,7 @@ func TestMonitorRoutezPerAccount(t *testing.T) {
 		}
 	}
 }
+
 func TestMonitorConnzOperatorAccountNames(t *testing.T) {
 	sysName := "SYS"
 	accName := "APP"
@@ -5560,6 +5657,7 @@ func TestMonitorConnzOperatorModeFilterByUser(t *testing.T) {
 		require_True(t, ci.AuthorizedUser == aUser)
 	}
 }
+
 func TestMonitorConnzSortByRTT(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -5718,12 +5816,14 @@ func checkHealthzEndpoint(t *testing.T, address string, statusCode int, wantStat
 		})
 	}
 }
+
 func TestMonitorHealthzStatusOK(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
 
 	checkHealthzEndpoint(t, s.MonitorAddr().String(), http.StatusOK, "ok")
 }
+
 func TestMonitorHealthzStatusError(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
@@ -5742,6 +5842,7 @@ func TestMonitorHealthzStatusError(t *testing.T) {
 	s.listener = sl
 	s.mu.Unlock()
 }
+
 func TestMonitorHealthzStatusUnavailable(t *testing.T) {
 	opts := DefaultMonitorOptions()
 	opts.JetStream = true

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -6368,7 +6368,7 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 
 	url := fmt.Sprintf("http://127.0.0.1:%d/", s.MonitorAddr().Port)
 	for mode := 0; mode < 2; mode++ {
-		c := pollConz(t, s, mode, url+"connz", nil)
+		c := pollConnz(t, s, mode, url+"connz", nil)
 		if c.Conns == nil || len(c.Conns) != 3 {
 			t.Fatalf("Expected 3 connections in array, got %v", len(c.Conns))
 		}
@@ -6381,7 +6381,7 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 		}
 
 		// Check that we can select based on client ID:
-		c = pollConz(t, s, mode, url+"connz?mqtt_client=conn2", &ConnzOptions{MQTTClient: "conn2"})
+		c = pollConnz(t, s, mode, url+"connz?mqtt_client=conn2", &ConnzOptions{MQTTClient: "conn2"})
 		if c.Conns == nil || len(c.Conns) != 1 {
 			t.Fatalf("Expected 1 connection in array, got %v", len(c.Conns))
 		}
@@ -6390,7 +6390,7 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 		}
 
 		// Check that we have the closed ones
-		c = pollConz(t, s, mode, url+"connz?state=closed", &ConnzOptions{State: ConnClosed})
+		c = pollConnz(t, s, mode, url+"connz?state=closed", &ConnzOptions{State: ConnClosed})
 		if c.Conns == nil || len(c.Conns) != 2 {
 			t.Fatalf("Expected 2 connections in array, got %v", len(c.Conns))
 		}
@@ -6401,7 +6401,7 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 		}
 
 		// Check that we can select with client ID for closed state
-		c = pollConz(t, s, mode, url+"connz?state=closed&mqtt_client=conn3", &ConnzOptions{State: ConnClosed, MQTTClient: "conn3"})
+		c = pollConnz(t, s, mode, url+"connz?state=closed&mqtt_client=conn3", &ConnzOptions{State: ConnClosed, MQTTClient: "conn3"})
 		if c.Conns == nil || len(c.Conns) != 1 {
 			t.Fatalf("Expected 1 connection in array, got %v", len(c.Conns))
 		}
@@ -6409,7 +6409,7 @@ func TestMQTTConnectAndDisconnectEvent(t *testing.T) {
 			t.Fatalf("Unexpected client ID: %+v", c.Conns[0])
 		}
 		// Check that we can select with client ID for closed state (but in this case not found)
-		c = pollConz(t, s, mode, url+"connz?state=closed&mqtt_client=conn5", &ConnzOptions{State: ConnClosed, MQTTClient: "conn5"})
+		c = pollConnz(t, s, mode, url+"connz?state=closed&mqtt_client=conn5", &ConnzOptions{State: ConnClosed, MQTTClient: "conn5"})
 		if len(c.Conns) != 0 {
 			t.Fatalf("Expected 0 connection in array, got %v", len(c.Conns))
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -957,13 +957,13 @@ func TestLameDuckMode(t *testing.T) {
 	// of connections in the server A to be 0, the polling of connection closed may
 	// need a bit more time.
 	checkFor(t, time.Second, 15*time.Millisecond, func() error {
-		cz := pollConz(t, srvA, 1, "", &ConnzOptions{State: ConnClosed})
+		cz := pollConnz(t, srvA, 1, "", &ConnzOptions{State: ConnClosed})
 		if n := len(cz.Conns); n != total {
 			return fmt.Errorf("expected %v closed connections, got %v", total, n)
 		}
 		return nil
 	})
-	cz := pollConz(t, srvA, 1, "", &ConnzOptions{State: ConnClosed})
+	cz := pollConnz(t, srvA, 1, "", &ConnzOptions{State: ConnClosed})
 	if n := len(cz.Conns); n != total {
 		t.Fatalf("Expected %v closed connections, got %v", total, n)
 	}


### PR DESCRIPTION
This supersedes #5173 since it introduced a redundant field `LogicalName` on `Account` with the existing field `nameTag`.

The endpoints that are currently covered include:

- /accountz
- /accstatz
- /connz
- /subsz
- /jsz

The following endpoints also contain account metadata, but have not been implemented yet.

- /routez
- /gatewayz
- /leafz