### PR TITLE
NRG: Don't mark current/healthy while paused with pending commits

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -1437,6 +1437,12 @@ func (n *raft) isCurrent(includeForwardProgress bool) bool {
 		return false
 	}
 
+	if n.paused && n.hcommit > n.commit {
+		// We're currently paused, waiting to be resumed to apply pending commits.
+		n.debug("Not current, waiting to resume applies commit=%d, hcommit=%d", n.commit, n.hcommit)
+		return false
+	}
+
 	if n.commit == n.applied {
 		// At this point if we are current, we can return saying so.
 		clearBehindState()


### PR DESCRIPTION
There could be a call to `n.PauseApply()`, for example during recovery if a max size is reached or when doing a stream catchup. This pauses the commits but was not reflected by the health check. Should only report current/healthy if we're paused but still up-to-date, with pending commits we should wait for `n.ResumeApply()` to be called and applies to be current.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>