### PR TITLE
Add support for "never expires" TTL

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5304,7 +5304,8 @@ func (fs *fileStore) expireMsgs() {
 	fs.mu.RUnlock()
 
 	if maxAge > 0 {
-		for sm, _ = fs.msgForSeq(0, &smv); sm != nil && sm.ts <= minAge; sm, _ = fs.msgForSeq(smv.seq+1, &smv) {
+		var seq uint64
+		for sm, seq, _ = fs.LoadNextMsg(fwcs, true, 0, &smv); sm != nil && sm.ts <= minAge; sm, seq, _ = fs.LoadNextMsg(fwcs, true, seq+1, &smv) {
 			if len(sm.hdr) > 0 {
 				if ttl, err := getMessageTTL(sm.hdr); err == nil && ttl < 0 {
 					// The message has a negative TTL, therefore it must "never expire".

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -25039,7 +25039,7 @@ func TestJetStreamMessageTTLNeverExpire(t *testing.T) {
 
 	// The first message we publish is set to "never expire", therefore it
 	// won't age out with the MaxAge policy.
-	msg.Header.Set("Nats-TTL", "-1")
+	msg.Header.Set("Nats-TTL", "never")
 	_, err := js.PublishMsg(msg)
 	require_NoError(t, err)
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -4220,6 +4220,7 @@ func getExpectedLastSeqPerSubjectForSubject(hdr []byte) string {
 // Fast lookup of the message TTL:
 // - Positive return value: duration in seconds.
 // - Zero return value: no TTL or parse error.
+// - Negative return value: never expires.
 func getMessageTTL(hdr []byte) (int64, error) {
 	ttl := getHeader(JSMessageTTL, hdr)
 	if len(ttl) == 0 {
@@ -4233,11 +4234,7 @@ func getMessageTTL(hdr []byte) (int64, error) {
 		}
 		return int64(dur.Seconds()), nil
 	}
-	t := parseInt64(ttl)
-	if t < 0 {
-		return 0, NewJSMessageTTLInvalidError()
-	}
-	return t, nil
+	return parseInt64(ttl), nil
 }
 
 // Signal if we are clustered. Will acquire rlock.


### PR DESCRIPTION
A message with `Nats-TTL: never` will never expire, even if the `MaxAge` policy is set.

Signed-off-by: Neil Twigg <neil@nats.io>