### PR TITLE
De-flake by waiting for account fetch in (super) cluster

### DIFF
--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -559,6 +559,27 @@ func (sc *supercluster) waitOnLeader() {
 	sc.t.Fatalf("Expected a cluster leader, got none")
 }
 
+func (sc *supercluster) waitOnAccount(account string) {
+	sc.t.Helper()
+	expires := time.Now().Add(40 * time.Second)
+	for time.Now().Before(expires) {
+		found := true
+		for _, c := range sc.clusters {
+			for _, s := range c.servers {
+				acc, err := s.fetchAccount(account)
+				found = found && err == nil && acc != nil
+			}
+		}
+		if found {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+		continue
+	}
+
+	sc.t.Fatalf("Expected account %q to exist but didn't", account)
+}
+
 func (sc *supercluster) waitOnAllCurrent() {
 	sc.t.Helper()
 	for _, c := range sc.clusters {

--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -326,6 +326,8 @@ func TestJetStreamJWTMove(t *testing.T) {
 		require_False(t, s.JetStreamEnabled())
 		updateJwt(t, s.ClientURL(), sysCreds, accJwt, 10)
 
+		sc.waitOnAccount(aExpPub)
+
 		s = sc.serverByName("C2-S1")
 		require_False(t, s.JetStreamEnabled())
 
@@ -609,6 +611,8 @@ func TestJetStreamJWTClusteredTiersChange(t *testing.T) {
 	updateJwt(t, c.randomServer().ClientURL(), sysCreds, sysJwt, 3)
 	updateJwt(t, c.randomServer().ClientURL(), sysCreds, accJwt1, 3)
 
+	c.waitOnAccount(aExpPub)
+
 	nc := natsConnect(t, c.randomServer().ClientURL(), nats.UserCredentials(accCreds))
 	defer nc.Close()
 
@@ -692,6 +696,8 @@ func TestJetStreamJWTClusteredDeleteTierWithStreamAndMove(t *testing.T) {
 
 	updateJwt(t, c.randomServer().ClientURL(), sysCreds, sysJwt, 3)
 	updateJwt(t, c.randomServer().ClientURL(), sysCreds, accJwt1, 3)
+
+	c.waitOnAccount(aExpPub)
 
 	nc := natsConnect(t, c.randomServer().ClientURL(), nats.UserCredentials(accCreds))
 	defer nc.Close()


### PR DESCRIPTION
Similar fix to https://github.com/nats-io/nats-server/pull/4533, but extending to some other clustered tests, as well as one super cluster test. Should prevent these tests from failing with `JetStream not enabled for account`. 

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
