### PR TITLE
De-flake TestJetStreamNextMsgNoInterest

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -8540,10 +8540,14 @@ func TestJetStreamNextMsgNoInterest(t *testing.T) {
 				}
 			}
 			nc.Flush()
-			ostate := o.info()
-			if ostate.AckFloor.Stream != 11 || ostate.NumAckPending > 0 {
-				t.Fatalf("Inconsistent ack state: %+v", ostate)
-			}
+
+			checkFor(t, time.Second, 10*time.Millisecond, func() error {
+				ostate := o.info()
+				if ostate.AckFloor.Stream != 11 || ostate.NumAckPending > 0 {
+					return fmt.Errorf("Inconsistent ack state: %+v", ostate)
+				}
+				return nil
+			})
 		})
 	}
 }


### PR DESCRIPTION
Ack state could take some time to propagate, since the sent acks are not synchronous.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
