### PR TITLE
[FIXED] (2.11) Successful exit code for SIGTERM

### DIFF
--- a/server/signal.go
+++ b/server/signal.go
@@ -62,7 +62,7 @@ func (s *Server) handleSignals() {
 					if !ldm {
 						s.Shutdown()
 						s.WaitForShutdown()
-						os.Exit(1)
+						os.Exit(0)
 					}
 				case syscall.SIGUSR1:
 					// File log re-open for rotating file logs.

--- a/server/signal_test.go
+++ b/server/signal_test.go
@@ -483,3 +483,33 @@ func TestProcessSignalTermDuringLameDuckMode(t *testing.T) {
 		}
 	}
 }
+
+func TestSignalInterruptHasSuccessfulExit(t *testing.T) {
+	if os.Getenv("IN_TEST") == "1" {
+		s := RunServer(&Options{})
+		defer s.Shutdown()
+		require_NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGINT))
+		s.WaitForShutdown()
+		return
+	}
+	// To check for successful/0 exit code, need execute as separate process.
+	cmd := exec.Command(os.Args[0], "-test.run=TestSignalInterruptHasSuccessfulExit")
+	cmd.Env = append(os.Environ(), "IN_TEST=1")
+	err := cmd.Run()
+	require_NoError(t, err)
+}
+
+func TestSignalTermHasSuccessfulExit(t *testing.T) {
+	if os.Getenv("IN_TEST") == "1" {
+		s := RunServer(&Options{})
+		defer s.Shutdown()
+		require_NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGTERM))
+		s.WaitForShutdown()
+		return
+	}
+	// To check for successful/0 exit code, need execute as separate process.
+	cmd := exec.Command(os.Args[0], "-test.run=TestSignalTermHasSuccessfulExit")
+	cmd.Env = append(os.Environ(), "IN_TEST=1")
+	err := cmd.Run()
+	require_NoError(t, err)
+}


### PR DESCRIPTION
Upon receiving `SIGTERM` we would exit with exit code 1, even though we successfully/gracefully shutdown.

This was also flagged by Antithesis as a correctness issue:
> Containers that exit normally (exit code 0) will not trip this property. Nor will containers exiting with codes 137 and 143, which correspond to SIGKILL and SIGTERM on the container process. This is because attempts to shut down containers with standard tools may generate these codes.
>
> To avoid false positives, please ensure that the main process running within each of your containers exits with code 0 when terminating without error.

We should return a successful/0 exit code when we were able to gracefully shutdown, just like when receiving `SIGINT`.

Have added 2.11 in the title, as we might want to put this into a minor rather than a patch version?

Resolves https://github.com/nats-io/nats-server/issues/6083

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
