### PR TITLE
Clarify that Heartbeat field in ConsumerConfig only applies to push consumer

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -94,7 +94,6 @@ type ConsumerConfig struct {
 	SampleFrequency string          `json:"sample_freq,omitempty"`
 	MaxWaiting      int             `json:"max_waiting,omitempty"`
 	MaxAckPending   int             `json:"max_ack_pending,omitempty"`
-	Heartbeat       time.Duration   `json:"idle_heartbeat,omitempty"`
 	FlowControl     bool            `json:"flow_control,omitempty"`
 	HeadersOnly     bool            `json:"headers_only,omitempty"`
 
@@ -104,8 +103,9 @@ type ConsumerConfig struct {
 	MaxRequestMaxBytes int           `json:"max_bytes,omitempty"`
 
 	// Push based consumers.
-	DeliverSubject string `json:"deliver_subject,omitempty"`
-	DeliverGroup   string `json:"deliver_group,omitempty"`
+	DeliverSubject string        `json:"deliver_subject,omitempty"`
+	DeliverGroup   string        `json:"deliver_group,omitempty"`
+	Heartbeat      time.Duration `json:"idle_heartbeat,omitempty"`
 
 	// Ephemeral inactivity threshold.
 	InactiveThreshold time.Duration `json:"inactive_threshold,omitempty"`


### PR DESCRIPTION
Idle heartbeats for push consumers were added in https://github.com/nats-io/nats-server/pull/1965

But for pull consumers, it is a field in `JS.API.CONSUMER.MSG.NEXT`
https://github.com/nats-io/nats-server/pull/2865/files#diff-9c075c47b0690a821ad35caa26308b69adeb132042f062eef75513db2a26638aR580
https://beta-docs.nats.io/ref/protocols/jetstream#pull-next-messages

Clarify that by moving the field close to other push-based consumer fields

See also
https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-9.md



Signed-off-by: Alex Bozhenko <alex@synadia.com>
