### PR TITLE
Fix setting first Pinned TS and use UTC

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3530,7 +3530,6 @@ func (o *consumer) setPinnedTimer(priorityGroup string) {
 	} else {
 		o.pinnedTtl = time.AfterFunc(o.cfg.PinnedTTL, func() {
 			o.mu.Lock()
-			o.pinnedTS = time.Now()
 			o.currentPinId = _EMPTY_
 			o.sendUnpinnedAdvisoryLocked(priorityGroup, "timeout")
 			o.mu.Unlock()
@@ -3588,6 +3587,7 @@ func (o *consumer) nextWaiting(sz int) *waitingRequest {
 			if needNewPin {
 				if wr.priorityGroup.Id == _EMPTY_ {
 					o.currentPinId = nuid.Next()
+					o.pinnedTS = time.Now().UTC()
 					wr.priorityGroup.Id = o.currentPinId
 					o.setPinnedTimer(priorityGroup)
 


### PR DESCRIPTION
Pinned timestamp was set when the timer was triggered, instead when the new ID was set.
Additionally, this PR make the timestamp format consistent with other timestampts by setting it to UTC.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>
