### PR TITLE
Don't run TTL state recovery if no messages

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1854,7 +1854,7 @@ func (fs *fileStore) recoverTTLState() error {
 	}
 
 	defer fs.resetAgeChk(0)
-	if fs.ttlseq <= fs.state.LastSeq {
+	if fs.state.Msgs > 0 && fs.ttlseq <= fs.state.LastSeq {
 		fs.warn("TTL state is outdated; attempting to recover using linear scan (seq %d to %d)", fs.ttlseq, fs.state.LastSeq)
 		var sm StoreMsg
 		mb := fs.selectMsgBlock(fs.ttlseq)


### PR DESCRIPTION
This avoids an unnecessary `TTL state is outdated` message in the log when there is nothing to do.

Signed-off-by: Neil Twigg <neil@nats.io>