### PR TITLE
[v2.11] Make RPMs and DEBs reproducible

### DIFF
--- a/.github/actions/nightly-release/action.yaml
+++ b/.github/actions/nightly-release/action.yaml
@@ -36,7 +36,7 @@ runs:
       uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf
       with:
         workdir: "${{ inputs.workdir }}"
-        version: '~> v2'
+        version: "~> v2"
         args: release --snapshot --config .goreleaser-nightly.yml
 
     - name: images

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,6 +58,7 @@ nfpms:
     formats:
       - deb
       - rpm
+    mtime: "{{ .CommitDate }}"
     contents:
       - src: /usr/bin/nats-server
         dst: /usr/local/bin/nats-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_deploy:
 deploy:
   provider: script
   cleanup: true
-  script: curl -o /tmp/goreleaser.tar.gz -sLf https://github.com/goreleaser/goreleaser/releases/download/v2.5.0/goreleaser_Linux_x86_64.tar.gz && tar -xvf /tmp/goreleaser.tar.gz -C /tmp/ && /tmp/goreleaser
+  script: curl -o /tmp/goreleaser.tar.gz -sLf https://github.com/goreleaser/goreleaser/releases/download/v2.6.1/goreleaser_Linux_x86_64.tar.gz && tar -xvf /tmp/goreleaser.tar.gz -C /tmp/ && /tmp/goreleaser
   on:
     tags: true
     condition: ($TRAVIS_GO_VERSION =~ 1.23) && ($TEST_SUITE = "compile")


### PR DESCRIPTION
Similar to https://github.com/nats-io/nats-server/pull/6299
Make packages set mtime to `commitdate`.

Upgrade goreleaser to the latest 2.6.1, which includes the feature used in this PR: https://github.com/goreleaser/goreleaser/pull/5392

```
go install github.com/goreleaser/goreleaser/v2@v2.6.1
goreleaser release --snapshot --clean -f .goreleaser.yml
mv dist/ ~/tmp/dist_before
goreleaser release --snapshot --clean -f .goreleaser.yml 

# now, all the artifacts of the two builds are exactly the same. Only sbom files are different(because those include timestamps)
vimdiff dist/SHA256SUMS ~/tmp/dist_before/SHA256SUMS
```
![image](https://github.com/user-attachments/assets/6ca9bc37-301a-4cda-b4ab-4d724762a31c)



Signed-off-by: Alex Bozhenko <alex@synadia.com>