### PR TITLE
Add missing marshaling case for PriorityPolicy

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -249,6 +249,8 @@ func (pp PriorityPolicy) MarshalJSON() ([]byte, error) {
 		return PriorityOverflowJSONBytes, nil
 	case PriorityPinnedClient:
 		return PriorityPinnedClientJSONBytes, nil
+	case PriorityNone:
+		return PriorityNoneJSONBytes, nil
 	default:
 		return nil, fmt.Errorf("unknown priority policy: %v", pp)
 	}

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -2102,6 +2102,7 @@ func TestJetStreamConsumerWithPriorityGroups(t *testing.T) {
 		{"Pinned Consumer with empty Priority Group, clustered", cnc, "TEST", "PINNED_NO_GROUP", []string{""}, PriorityPinnedClient, &ApiError{ErrCode: uint16(JSConsumerEmptyGroupName)}},
 		{"Pinned Consumer with empty Priority Group", nc, "TEST", "PINNED_NO_GROUP", []string{""}, PriorityOverflow, &ApiError{ErrCode: uint16(JSConsumerEmptyGroupName)}},
 		{"Pinned Consumer with empty Priority Group, clustered", cnc, "TEST", "PINNED_NO_GROUP", []string{""}, PriorityOverflow, &ApiError{ErrCode: uint16(JSConsumerEmptyGroupName)}},
+		{"Consumer with `none` policy priority", nc, "TEST", "NONE", []string{"A"}, PriorityNone, nil},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 


### PR DESCRIPTION
This was not seen in tests, as `ConsumerConfig.PriorityPolicy` is `omitempty` and `PolicyNone` is 0, but could still fail in other structs.

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>