### PR TITLE
Error handling in `metaSnapshot`

### DIFF
--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -4472,7 +4472,8 @@ func TestJetStreamClusterMetaSnapshotMustNotIncludePendingConsumers(t *testing.T
 	mjs.mu.Unlock()
 
 	// Create snapshot, this should not contain pending consumers.
-	snap := mjs.metaSnapshot()
+	snap, err := mjs.metaSnapshot()
+	require_NoError(t, err)
 
 	ru := &recoveryUpdates{
 		removeStreams:   make(map[string]*streamAssignment),

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -11293,7 +11293,8 @@ func TestNoRaceJetStreamClusterLargeMetaSnapshotTiming(t *testing.T) {
 	n := js.getMetaGroup()
 	// Now let's see how long it takes to create a meta snapshot and how big it is.
 	start := time.Now()
-	snap := js.metaSnapshot()
+	snap, err := js.metaSnapshot()
+	require_NoError(t, err)
 	require_NoError(t, n.InstallSnapshot(snap))
 	t.Logf("Took %v to snap meta with size of %v\n", time.Since(start), friendlyBytes(len(snap)))
 }


### PR DESCRIPTION
Since we use `MarshalJSON()` on some types, we must be careful that a JSON marshalling error cannot be dropped.

Signed-off-by: Neil Twigg <neil@nats.io>