### PR TITLE
Per-message TTLs set metadata API level to `1`

### DIFF
--- a/server/jetstream_versioning_test.go
+++ b/server/jetstream_versioning_test.go
@@ -79,6 +79,12 @@ func TestJetStreamSetStaticStreamMetadata(t *testing.T) {
 			prev:             &StreamConfig{},
 			expectedMetadata: metadataAtLevel("0"),
 		},
+		{
+			desc:             "create/AllowMsgTTL",
+			cfg:              &StreamConfig{AllowMsgTTL: true},
+			prev:             nil,
+			expectedMetadata: metadataAtLevel("1"),
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			setStaticStreamMetadata(test.cfg, test.prev)


### PR DESCRIPTION
As per the ADR:

> When either these settings are set the Stream should require API level `1`.

Signed-off-by: Neil Twigg <neil@nats.io>