### PR TITLE
Test: expected a fully formed cluster error

### DIFF
--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -1613,14 +1613,12 @@ func (c *cluster) waitOnClusterReadyWithNumPeers(numPeersExpected int) {
 	c.t.Helper()
 	var leader *Server
 	expires := time.Now().Add(40 * time.Second)
+	// Make sure we have all peers, and take into account the meta leader could still change.
 	for time.Now().Before(expires) {
-		if leader = c.leader(); leader != nil {
-			break
+		if leader = c.leader(); leader == nil {
+			time.Sleep(50 * time.Millisecond)
+			continue
 		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	// Now make sure we have all peers.
-	for leader != nil && time.Now().Before(expires) {
 		if len(leader.JetStreamClusterPeers()) == numPeersExpected {
 			time.Sleep(100 * time.Millisecond)
 			return


### PR DESCRIPTION
Cluster tests would sometimes fail with the following error message:
```
jetstream_helpers_test.go:774: Expected a fully formed cluster, only 0 of 3 peers seen
```

This was due to a logic error in the tests, where it was assumed that once a meta leader is chosen it will remain the same. That's not always true as the meta leader can still shift around. So, keep fetching the latest leader and check the peers on that.

Previously it would fail by selecting a meta leader, the meta leader would change, and the follower would then be used to request peers on. But because of the following lines in `JetStreamClusterPeers()`:
```go
	cc := js.cluster
	if !cc.isLeader() || cc.meta == nil {
		return nil
	}
```
You'd get no peers at all, leading into that error message.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>