### PR TITLE
[v2.11] Update goreleaser to build .tar.gz for linux, .zip for windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,15 +65,12 @@ nfpms:
 
 archives:
   - name_template: "{{.ProjectName}}-{{.Tag}}-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}"
-    wrap_in_directory: true
-    format: zip
-    files:
-      - README.md
-      - LICENSE
-  - name_template: "{{.ProjectName}}-{{.Tag}}-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}"
     id: targz-archives
     wrap_in_directory: true
     format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
     files:
       - README.md
       - LICENSE


### PR DESCRIPTION
There is no point in building .tar.gz. for windows and .zip for linux. 

When .tar.gz. was added in https://github.com/nats-io/nats-server/pull/1589
goreleaser did not have a feature to override the archive.
Now it does(found it in https://github.com/golangci/golangci-lint/blob/master/.golangci.yml)

## Test plan:
```
# goreleaser release --snapshot --clean -f .goreleaser.yml
# find dist/ -name '*.zip' -or -name '*.tar.gz' | sort
dist/nats-server-v2.11.0-dev-darwin-amd64.tar.gz
dist/nats-server-v2.11.0-dev-darwin-arm64.tar.gz
dist/nats-server-v2.11.0-dev-freebsd-amd64.tar.gz
dist/nats-server-v2.11.0-dev-linux-386.tar.gz
dist/nats-server-v2.11.0-dev-linux-amd64.tar.gz
dist/nats-server-v2.11.0-dev-linux-arm64.tar.gz
dist/nats-server-v2.11.0-dev-linux-arm6.tar.gz
dist/nats-server-v2.11.0-dev-linux-arm7.tar.gz
dist/nats-server-v2.11.0-dev-linux-mips64le.tar.gz
dist/nats-server-v2.11.0-dev-linux-ppc64le.tar.gz
dist/nats-server-v2.11.0-dev-linux-s390x.tar.gz
dist/nats-server-v2.11.0-dev-windows-386.zip
dist/nats-server-v2.11.0-dev-windows-amd64.zip
dist/nats-server-v2.11.0-dev-windows-arm64.zip
dist/nats-server-v2.11.0-dev-windows-arm6.zip
dist/nats-server-v2.11.0-dev-windows-arm7.zip
```

Signed-off-by: Alex Bozhenko <alex@synadia.com>
