### PR TITLE
Fix JS API in-flight metric

### DIFF
--- a/server/ipqueue.go
+++ b/server/ipqueue.go
@@ -246,14 +246,16 @@ func (q *ipQueue[T]) size() uint64 {
 }
 
 // Empty the queue and consumes the notification signal if present.
+// Returns the number of items that were drained from the queue.
 // Note that this could cause a reader go routine that has been
 // notified that there is something in the queue (reading from queue's `ch`)
 // may then get nothing if `drain()` is invoked before the `pop()` or `popOne()`.
-func (q *ipQueue[T]) drain() {
+func (q *ipQueue[T]) drain() int {
 	if q == nil {
-		return
+		return 0
 	}
 	q.Lock()
+	olen := len(q.elts) - q.pos
 	q.elts, q.pos, q.sz = nil, 0, 0
 	// Consume the signal if it was present to reduce the chance of a reader
 	// routine to be think that there is something in the queue...
@@ -262,6 +264,7 @@ func (q *ipQueue[T]) drain() {
 	default:
 	}
 	q.Unlock()
+	return olen
 }
 
 // Since the length of the queue goes to 0 after a pop(), it is good to

--- a/server/raft.go
+++ b/server/raft.go
@@ -1962,7 +1962,7 @@ runner:
 	// just will remove them from the central monitoring map
 	queues := []interface {
 		unregister()
-		drain()
+		drain() int
 	}{n.reqs, n.votes, n.prop, n.entry, n.resp, n.apply}
 	for _, q := range queues {
 		q.drain()


### PR DESCRIPTION
After a drain this would have been misreporting, as we did not remove drained entries from the `apiInflight` count.

Signed-off-by: Neil Twigg <neil@nats.io>