### PR TITLE
[FIXED] LeafNodes: Queue interest may be lost in super cluster

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -1394,8 +1394,6 @@ func (c *client) processRemoteUnsub(arg []byte, leafUnsub bool) (err error) {
 		return nil
 	}
 
-	updateGWs := false
-
 	_keya := [128]byte{}
 	_key := _keya[:0]
 
@@ -1419,19 +1417,21 @@ func (c *client) processRemoteUnsub(arg []byte, leafUnsub bool) (err error) {
 	if ok {
 		delete(c.subs, key)
 		acc.sl.Remove(sub)
-		updateGWs = srv.gateway.enabled
 		if len(sub.queue) > 0 {
 			delta = sub.qw
 		}
 	}
 	c.mu.Unlock()
 
-	if updateGWs {
-		srv.gatewayUpdateSubInterest(accountName, sub, -delta)
-	}
+	// Update gateways and leaf nodes only if the subscription was found.
+	if ok {
+		if srv.gateway.enabled {
+			srv.gatewayUpdateSubInterest(accountName, sub, -delta)
+		}
 
-	// Now check on leafnode updates.
-	acc.updateLeafNodes(sub, -delta)
+		// Now check on leafnode updates.
+		acc.updateLeafNodes(sub, -delta)
+	}
 
 	if c.opts.Verbose {
 		c.sendOK()
@@ -1646,7 +1646,6 @@ func (c *client) processRemoteSub(argo []byte, hasOrigin bool) (err error) {
 	// We use the sub.sid for the key of the c.subs map.
 	key := bytesToString(sub.sid)
 	osub := c.subs[key]
-	updateGWs := false
 	if osub == nil {
 		c.subs[key] = sub
 		// Now place into the account sl.
@@ -1657,7 +1656,6 @@ func (c *client) processRemoteSub(argo []byte, hasOrigin bool) (err error) {
 			c.sendErr("Invalid Subscription")
 			return nil
 		}
-		updateGWs = srv.gateway.enabled
 	} else if sub.queue != nil {
 		// For a queue we need to update the weight.
 		delta = sub.qw - atomic.LoadInt32(&osub.qw)
@@ -1666,7 +1664,7 @@ func (c *client) processRemoteSub(argo []byte, hasOrigin bool) (err error) {
 	}
 	c.mu.Unlock()
 
-	if updateGWs {
+	if srv.gateway.enabled {
 		srv.gatewayUpdateSubInterest(acc.Name, sub, delta)
 	}
 


### PR DESCRIPTION
If a cluster has leafnode connections and each have the same queue group, the loss of a leafnode connection could cause the server in the "hub" cluster to drop interest across a gateway for this queue group.

The issue is fixed by properly accounting for all queue sub and unsub in the server gateway interest map.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>