### PR TITLE
Add support for subject delete markers by `MaxAge`

### DIFF
--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -5369,7 +5369,7 @@ func TestJetStreamClusterMessageTTLWhenSourcing(t *testing.T) {
 	})
 
 	hdr := nats.Header{}
-	hdr.Add("Nats-TTL", "1s")
+	hdr.Add(JSMessageTTL, "1s")
 
 	_, err := js.PublishMsg(&nats.Msg{
 		Subject: "test",
@@ -5436,7 +5436,7 @@ func TestJetStreamClusterMessageTTLWhenMirroring(t *testing.T) {
 	})
 
 	hdr := nats.Header{}
-	hdr.Add("Nats-TTL", "1s")
+	hdr.Add(JSMessageTTL, "1s")
 
 	_, err := js.PublishMsg(&nats.Msg{
 		Subject: "test",
@@ -5486,7 +5486,7 @@ func TestJetStreamClusterMessageTTLDisabled(t *testing.T) {
 		Header:  nats.Header{},
 	}
 
-	msg.Header.Set("Nats-TTL", "1s")
+	msg.Header.Set(JSMessageTTL, "1s")
 	_, err := js.PublishMsg(msg)
 	require_Error(t, err)
 

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -1265,7 +1265,7 @@ func jsClientConnectURL(t testing.TB, url string, opts ...nats.Option) (*nats.Co
 }
 
 // jsStreamCreate is for sending a stream create for fields that nats.go does not know about yet.
-func jsStreamCreate(t testing.TB, nc *nats.Conn, cfg *StreamConfig) *StreamConfig {
+func jsStreamCreate(t testing.TB, nc *nats.Conn, cfg *StreamConfig) (*StreamConfig, error) {
 	t.Helper()
 
 	j, err := json.Marshal(cfg)
@@ -1276,8 +1276,13 @@ func jsStreamCreate(t testing.TB, nc *nats.Conn, cfg *StreamConfig) *StreamConfi
 
 	var resp JSApiStreamUpdateResponse
 	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
 	require_NotNil(t, resp.StreamInfo)
-	return &resp.Config
+	return &resp.Config, nil
 }
 
 // jsStreamUpdate is for sending a stream create for fields that nats.go does not know about yet.

--- a/server/jetstream_versioning.go
+++ b/server/jetstream_versioning.go
@@ -45,7 +45,7 @@ func setStaticStreamMetadata(cfg *StreamConfig, _ *StreamConfig) {
 	}
 
 	// TTLs were added in v2.11 and require API level 1.
-	if cfg.AllowMsgTTL {
+	if cfg.AllowMsgTTL || cfg.SubjectDeleteMarkers {
 		requires(1)
 	}
 

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -36,6 +36,7 @@ type memStore struct {
 	dmap        avl.SequenceSet
 	maxp        int64
 	scb         StorageUpdateHandler
+	tcb         SubjectDeleteMarkerUpdateHandler
 	ageChk      *time.Timer
 	consumers   int
 	receivedAny bool
@@ -309,6 +310,13 @@ func (ms *memStore) SkipMsgs(seq uint64, num uint64) error {
 func (ms *memStore) RegisterStorageUpdates(cb StorageUpdateHandler) {
 	ms.mu.Lock()
 	ms.scb = cb
+	ms.mu.Unlock()
+}
+
+// RegisterSubjectDeleteMarkerUpdates registers a callback for updates to new subject delete markers.
+func (ms *memStore) RegisterSubjectDeleteMarkerUpdates(cb SubjectDeleteMarkerUpdateHandler) {
+	ms.mu.Lock()
+	ms.tcb = cb
 	ms.mu.Unlock()
 }
 

--- a/server/store.go
+++ b/server/store.go
@@ -83,6 +83,9 @@ type StoreMsg struct {
 // For the cases where its a single message we will also supply sequence number and subject.
 type StorageUpdateHandler func(msgs, bytes int64, seq uint64, subj string)
 
+// Used to call back into the upper layers to report on newly created subject delete markers.
+type SubjectDeleteMarkerUpdateHandler func(seq uint64, subj string)
+
 type StreamStore interface {
 	StoreMsg(subject string, hdr, msg []byte, ttl int64) (uint64, int64, error)
 	StoreRawMsg(subject string, hdr, msg []byte, seq uint64, ts int64, ttl int64) error
@@ -111,6 +114,7 @@ type StreamStore interface {
 	SyncDeleted(dbs DeleteBlocks)
 	Type() StorageType
 	RegisterStorageUpdates(StorageUpdateHandler)
+	RegisterSubjectDeleteMarkerUpdates(SubjectDeleteMarkerUpdateHandler)
 	UpdateConfig(cfg *StreamConfig) error
 	Delete() error
 	Stop() error


### PR DESCRIPTION
This PR adds the `LimitsTTL` functionality for system tombstones when a subject is removed via `MaxAge`. The tombstone will have the header `Nats-Applied-Limit` and the specified `LimitsTTL` value as the TTL.

Further limits and/or administrative actions to follow separately.

This also requires API version 1, cannot be set if TTLs are disabled and cannot be combined with a mirror configuration.

Signed-off-by: Neil Twigg <neil@nats.io>