### PR TITLE
Correctly handle TTLs from upper-layer stream catchups

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8753,6 +8753,11 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 		return 0, NewJSInsufficientResourcesError()
 	}
 
+	// Find the message TTL if any.
+	// TODO(nat): If the TTL isn't valid by this stage then there isn't really a
+	// lot we can do about it, as we'd break the catchup if we reject the message.
+	ttl, _ := getMessageTTL(hdr)
+
 	// Put into our store
 	// Messages to be skipped have no subject or timestamp.
 	// TODO(dlc) - formalize with skipMsgOp
@@ -8760,7 +8765,7 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 		if lseq := mset.store.SkipMsg(); lseq != seq {
 			return 0, errCatchupWrongSeqForSkip
 		}
-	} else if err := mset.store.StoreRawMsg(subj, hdr, msg, seq, ts, 0); err != nil {
+	} else if err := mset.store.StoreRawMsg(subj, hdr, msg, seq, ts, ttl); err != nil {
 		return 0, err
 	}
 

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -83,15 +83,17 @@ func require_NoError(t testing.TB, err error) {
 	}
 }
 
-func require_NotNil[T any](t testing.TB, v T) {
+func require_NotNil[T any](t testing.TB, vs ...T) {
 	t.Helper()
-	r := reflect.ValueOf(v)
-	switch k := r.Kind(); k {
-	case reflect.Ptr, reflect.Interface, reflect.Slice,
-		reflect.Map, reflect.Chan, reflect.Func:
-		if r.IsNil() {
-			antithesis.AssertUnreachable(t, "Failed require_NotNil check", nil)
-			t.Fatalf("require not nil, but got nil")
+	for _, v := range vs {
+		r := reflect.ValueOf(v)
+		switch k := r.Kind(); k {
+		case reflect.Ptr, reflect.Interface, reflect.Slice,
+			reflect.Map, reflect.Chan, reflect.Func:
+			if r.IsNil() {
+				antithesis.AssertUnreachable(t, "Failed require_NotNil check", nil)
+				t.Fatalf("require not nil, but got nil")
+			}
 		}
 	}
 }


### PR DESCRIPTION
This ensures that messages received from an upper-layer catchup also have their TTLs added to the timed hash wheel correctly on the follower.

(Also updates `require_NotNil` to be variadic because it looks nicer in the test.)

Signed-off-by: Neil Twigg <neil@nats.io>