### PR TITLE
[FIXED] Consumer stuck/slowdown during leader changes or redeliveries

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -4021,17 +4021,21 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 				}
 				continue
 			}
-			if seq > 0 {
-				pmsg := getJSPubMsgFromPool()
-				sm, err := o.mset.store.LoadMsg(seq, &pmsg.StoreMsg)
-				if sm == nil || err != nil {
-					pmsg.returnToPool()
-					pmsg, dc = nil, 0
-					// Adjust back deliver count.
-					o.decDeliveryCount(seq)
-				}
-				return pmsg, dc, err
+			pmsg := getJSPubMsgFromPool()
+			sm, err := o.mset.store.LoadMsg(seq, &pmsg.StoreMsg)
+			if sm == nil || err != nil {
+				pmsg.returnToPool()
+				pmsg, dc = nil, 0
+				// Adjust back deliver count.
+				o.decDeliveryCount(seq)
 			}
+			// Message was scheduled for redelivery but was removed in the meantime.
+			if err == ErrStoreMsgNotFound || err == errDeletedMsg {
+				delete(o.pending, seq)
+				delete(o.rdc, seq)
+				continue
+			}
+			return pmsg, dc, err
 		}
 	}
 

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1548,6 +1548,8 @@ func (o *consumer) setLeader(isLeader bool) {
 		// If we were the leader make sure to drain queued up acks.
 		if wasLeader {
 			o.ackMsgs.drain()
+			// Reset amount of acks that need to be processed.
+			atomic.StoreInt64(&o.awl, 0)
 			// Also remove any pending replies since we should not be the one to respond at this point.
 			o.replies = nil
 		}

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -2627,3 +2627,66 @@ func TestJetStreamConsumerSwitchLeaderDuringInflightAck(t *testing.T) {
 	require_NoError(t, err)
 	require_Len(t, len(msgs), 1)
 }
+
+func TestJetStreamConsumerMessageDeletedDuringRedelivery(t *testing.T) {
+	storageTypes := []nats.StorageType{nats.MemoryStorage, nats.FileStorage}
+	for _, storageType := range storageTypes {
+		t.Run(storageType.String(), func(t *testing.T) {
+			s := RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+
+			nc, js := jsClientConnect(t, s)
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     "TEST",
+				Subjects: []string{"foo"},
+				Storage:  storageType,
+			})
+			require_NoError(t, err)
+
+			for i := 0; i < 3; i++ {
+				_, err = js.Publish("foo", nil)
+				require_NoError(t, err)
+			}
+
+			sub, err := js.PullSubscribe(
+				"foo",
+				"CONSUMER",
+				nats.ManualAck(),
+				nats.AckExplicit(),
+				nats.AckWait(time.Second),
+			)
+			require_NoError(t, err)
+
+			acc, err := s.lookupAccount(globalAccountName)
+			require_NoError(t, err)
+			mset, err := acc.lookupStream("TEST")
+			require_NoError(t, err)
+			o := mset.lookupConsumer("CONSUMER")
+			require_NotNil(t, o)
+
+			msgs, err := sub.Fetch(3)
+			require_NoError(t, err)
+			require_Len(t, len(msgs), 3)
+
+			err = js.DeleteMsg("TEST", 2)
+			require_NoError(t, err)
+
+			o.mu.Lock()
+			defer o.mu.Unlock()
+			for seq := range o.rdc {
+				o.removeFromRedeliverQueue(seq)
+			}
+
+			o.pending = make(map[uint64]*Pending)
+			o.pending[2] = &Pending{}
+			o.addToRedeliverQueue(2)
+
+			_, _, err = o.getNextMsg()
+			require_Error(t, err, ErrStoreEOF)
+			require_Len(t, len(o.pending), 0)
+			require_Len(t, len(o.rdc), 0)
+		})
+	}
+}


### PR DESCRIPTION
Contains two fixes:
1. If a message is Acked, `o.awl` is incremented and the message is pushed into `o.ackMsgs`. However, if the consumer leader steps down (with `o.setLeader(false)`), `o.ackMsgs.drain()` is called, but `o.awl` is not reset. This results in a stuck consumer that can't redeliver messages due to `o.checkPending` short-circuiting on `o.awl` being set.
2. If a message is scheduled for redelivery but a race condition is hit where the message has been removed in the meantime. We would not catch this, keep the message around for redelivery, and as a result slowdown a lot. Instead the message should be removed since it can not be delivered anymore.

Resolves https://github.com/nats-io/nats-server/issues/6374

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>