### PR TITLE
Improve TestLongNRGChainOfBlocks

### DIFF
--- a/server/raft_chain_of_blocks_helpers_test.go
+++ b/server/raft_chain_of_blocks_helpers_test.go
@@ -151,9 +151,10 @@ func (sm *RCOBStateMachine) leaderChange(isLeader bool) {
 }
 
 func (sm *RCOBStateMachine) stop() {
-	sm.node().Stop()
-	sm.node().WaitForStop()
-	sm.waitGroup().Wait()
+	n, wg := sm.node(), sm.waitGroup()
+	n.Stop()
+	n.WaitForStop()
+	wg.Wait()
 
 	// Clear state, on restart it will be recovered from snapshot or peers
 	sm.Lock()


### PR DESCRIPTION
Set a cooldown on `StopOne` and `StopAll`, otherwise they could be essentially spammed resulting in not being able to make any progress due to no leader being elected/a majority to be established.

And make `RCOBStateMachine.stop()` consistent with `stateAdder.stop()`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>