### PR TITLE
[FIXED] Don't timeout for retried AckAll

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3134,7 +3134,8 @@ func (o *consumer) processAckMsg(sseq, dseq, dc uint64, reply string, doSample b
 		// no-op
 		if dseq <= o.adflr || sseq <= o.asflr {
 			o.mu.Unlock()
-			return ackInPlace
+			// Return true to let caller respond back to the client.
+			return true
 		}
 		if o.maxp > 0 && len(o.pending) >= o.maxp {
 			needSignal = true


### PR DESCRIPTION
During server restarts (for example) a response to an `AckSync` could be lost which leads into a timeout. If the client would then retry the `AckSync` it should eventually come back successful.

This was true for `AckExplicit`, but for `AckAll` the retried `AckSync` would always timeout. In this case the server would not respond to the client at all, making it impossible for the client to know if the ack for that message went through.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>