### PR TITLE
Place default subject delete marker TTL into stream config

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5342,9 +5342,9 @@ func (fs *fileStore) subjectDeleteMarkerIfNeeded(sm *StoreMsg, reason string) fu
 	// we'll default to 15 minutes — by that time every possible condition
 	// should have cleared (i.e. ordered consumer timeout, client timeouts,
 	// route/gateway interruptions, even device/client restarts etc).
-	var ttl int64 = 60 * 15
-	if fs.cfg.SubjectDeleteMarkerTTL != _EMPTY_ {
-		ttl, _ = parseMessageTTL(fs.cfg.SubjectDeleteMarkerTTL)
+	ttl, _ := parseMessageTTL(fs.cfg.SubjectDeleteMarkerTTL)
+	if ttl <= 0 {
+		return nil
 	}
 	var _hdr [128]byte
 	hdr := fmt.Appendf(_hdr[:0], "NATS/1.0\r\n%s: %s\r\n%s: %s\r\n\r\n", JSAppliedLimit, reason, JSMessageTTL, time.Duration(ttl)*time.Second)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -24161,6 +24161,70 @@ func TestJetStreamStreamCreatePedanticMode(t *testing.T) {
 			update:    true,
 			shouldErr: true,
 		},
+		{
+			name: "subject_delete_marker_specified",
+			cfg: StreamConfigRequest{
+				StreamConfig: StreamConfig{
+					Name:                   "SDM_TEST",
+					MaxAge:                 time.Minute,
+					Duplicates:             time.Minute,
+					Storage:                FileStorage,
+					AllowMsgTTL:            true,
+					SubjectDeleteMarkers:   true,
+					SubjectDeleteMarkerTTL: "10m",
+				},
+				Pedantic: true,
+			},
+			shouldErr: false,
+		},
+		{
+			name: "subject_delete_marker_not_specified",
+			cfg: StreamConfigRequest{
+				StreamConfig: StreamConfig{
+					Name:                 "SDM_TEST_2",
+					MaxAge:               time.Minute,
+					Duplicates:           time.Minute,
+					Storage:              FileStorage,
+					AllowMsgTTL:          true,
+					SubjectDeleteMarkers: true,
+				},
+				Pedantic: true,
+			},
+			shouldErr: true,
+		},
+		{
+			name: "update_subject_delete_marker_not_specified",
+			cfg: StreamConfigRequest{
+				StreamConfig: StreamConfig{
+					Name:                 "SDM_TEST",
+					MaxAge:               time.Minute,
+					Duplicates:           time.Minute,
+					Storage:              FileStorage,
+					AllowMsgTTL:          true,
+					SubjectDeleteMarkers: true,
+				},
+				Pedantic: true,
+			},
+			shouldErr: true,
+			update:    true,
+		},
+		{
+			name: "update_subject_delete_marker_specified",
+			cfg: StreamConfigRequest{
+				StreamConfig: StreamConfig{
+					Name:                   "SDM_TEST",
+					MaxAge:                 time.Minute,
+					Duplicates:             time.Minute,
+					Storage:                FileStorage,
+					AllowMsgTTL:            true,
+					SubjectDeleteMarkers:   true,
+					SubjectDeleteMarkerTTL: "11m",
+				},
+				Pedantic: true,
+			},
+			shouldErr: false,
+			update:    true,
+		},
 	}
 
 	for _, test := range tests {
@@ -25335,4 +25399,23 @@ func TestJetStreamSubjectDeleteMarkersWithMirror(t *testing.T) {
 		},
 	})
 	require_Error(t, err)
+}
+
+func TestJetStreamSubjectDeleteMarkersDefaultTTL(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, _ := jsClientConnect(t, s)
+	defer nc.Close()
+
+	sc, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:                 "Origin",
+		Storage:              FileStorage,
+		Subjects:             []string{"test"},
+		AllowMsgTTL:          true,
+		SubjectDeleteMarkers: true,
+	})
+	require_NoError(t, err)
+
+	require_Equal(t, sc.SubjectDeleteMarkerTTL, subjectDeleteMarkerDefaultTTL)
 }

--- a/server/store.go
+++ b/server/store.go
@@ -69,6 +69,9 @@ var (
 	ErrTooManyResults = errors.New("too many matching results for request")
 )
 
+// Default value for SubjectDeleteMarkerTTL if not specified.
+const subjectDeleteMarkerDefaultTTL = "15m"
+
 // StoreMsg is the stored message format for messages that are retained by the Store layer.
 type StoreMsg struct {
 	subj string

--- a/server/stream.go
+++ b/server/stream.go
@@ -1370,6 +1370,9 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 		if !cfg.AllowMsgTTL {
 			return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("subject marker delete cannot be set if message TTLs are disabled"))
 		}
+		if pedantic && cfg.SubjectDeleteMarkerTTL == _EMPTY_ {
+			return StreamConfig{}, NewJSPedanticError(fmt.Errorf("pedantic mode: subject marker delete TTL can not be empty"))
+		}
 		if cfg.SubjectDeleteMarkerTTL != _EMPTY_ {
 			ttl, err := parseMessageTTL(cfg.SubjectDeleteMarkerTTL)
 			if err != nil {
@@ -1378,6 +1381,8 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 			if ttl < 1 {
 				return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("subject marker delete TTL must be at least 1 second"))
 			}
+		} else {
+			cfg.SubjectDeleteMarkerTTL = subjectDeleteMarkerDefaultTTL
 		}
 	} else {
 		if cfg.SubjectDeleteMarkerTTL != _EMPTY_ {


### PR DESCRIPTION
This avoids problems where we have "hidden" defaults. This also replaces a test from the filestore with one in JetStream, and ensures pedantic mode also does the right thing.

Signed-off-by: Neil Twigg <neil@nats.io>