### PR TITLE
Remove obsolete build tags

### DIFF
--- a/conf/fuzz.go
+++ b/conf/fuzz.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build gofuzz
-// +build gofuzz
 
 package conf
 

--- a/logger/syslog.go
+++ b/logger/syslog.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package logger
 

--- a/logger/syslog_test.go
+++ b/logger/syslog_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package logger
 

--- a/logger/syslog_windows_test.go
+++ b/logger/syslog_windows_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package logger
 

--- a/server/avl/norace_test.go
+++ b/server/avl/norace_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !race && !skip_no_race_tests
-// +build !race,!skip_no_race_tests
 
 package avl
 

--- a/server/disk_avail.go
+++ b/server/disk_avail.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows && !openbsd && !netbsd && !wasm
-// +build !windows,!openbsd,!netbsd,!wasm
 
 package server
 

--- a/server/disk_avail_netbsd.go
+++ b/server/disk_avail_netbsd.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build netbsd
-// +build netbsd
 
 package server
 

--- a/server/disk_avail_openbsd.go
+++ b/server/disk_avail_openbsd.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build openbsd
-// +build openbsd
 
 package server
 

--- a/server/disk_avail_wasm.go
+++ b/server/disk_avail_wasm.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build wasm
-// +build wasm
 
 package server
 

--- a/server/disk_avail_windows.go
+++ b/server/disk_avail_windows.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package server
 

--- a/server/errors_gen.go
+++ b/server/errors_gen.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_store_tests
-// +build !skip_store_tests
 
 package server
 

--- a/server/fuzz.go
+++ b/server/fuzz.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build gofuzz
-// +build gofuzz
 
 package server
 

--- a/server/jetstream_benchmark_test.go
+++ b/server/jetstream_benchmark_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_js_tests && !skip_js_cluster_tests && !skip_js_cluster_tests_2
-// +build !skip_js_tests,!skip_js_cluster_tests,!skip_js_cluster_tests_2
 
 package server
 

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_js_tests && !skip_js_cluster_tests
-// +build !skip_js_tests,!skip_js_cluster_tests
 
 package server
 

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_js_tests && !skip_js_cluster_tests_2
-// +build !skip_js_tests,!skip_js_cluster_tests_2
 
 package server
 

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_js_tests && !skip_js_cluster_tests_3
-// +build !skip_js_tests,!skip_js_cluster_tests_3
 
 package server
 

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_js_tests && !skip_js_cluster_tests_4
-// +build !skip_js_tests,!skip_js_cluster_tests_4
 
 package server
 

--- a/server/jetstream_cluster_long_test.go
+++ b/server/jetstream_cluster_long_test.go
@@ -13,7 +13,6 @@
 
 // This test file is skipped by default to avoid accidentally running (e.g. `go test ./server`)
 //go:build !skip_js_tests && include_js_long_tests
-// +build !skip_js_tests,include_js_long_tests
 
 package server
 

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_js_tests
-// +build !skip_js_tests
 
 package server
 

--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_js_tests
-// +build !skip_js_tests
 
 package server
 

--- a/server/jetstream_leafnode_test.go
+++ b/server/jetstream_leafnode_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_js_tests
-// +build !skip_js_tests
 
 package server
 

--- a/server/jetstream_meta_benchmark_test.go
+++ b/server/jetstream_meta_benchmark_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_js_tests && !skip_js_cluster_tests && !skip_js_cluster_tests_2
-// +build !skip_js_tests,!skip_js_cluster_tests,!skip_js_cluster_tests_2
 
 package server
 

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_js_tests && !skip_js_cluster_tests && !skip_js_cluster_tests_2 && !skip_js_super_cluster_tests
-// +build !skip_js_tests,!skip_js_cluster_tests,!skip_js_cluster_tests_2,!skip_js_super_cluster_tests
 
 package server
 

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_js_tests
-// +build !skip_js_tests
 
 package server
 

--- a/server/jetstream_versioning_test.go
+++ b/server/jetstream_versioning_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_js_tests
-// +build !skip_js_tests
 
 package server
 

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_store_tests
-// +build !skip_store_tests
 
 package server
 

--- a/server/mqtt_ex_bench_test.go
+++ b/server/mqtt_ex_bench_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_mqtt_tests
-// +build !skip_mqtt_tests
 
 package server
 

--- a/server/mqtt_ex_test_test.go
+++ b/server/mqtt_ex_test_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_mqtt_tests
-// +build !skip_mqtt_tests
 
 package server
 

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_mqtt_tests
-// +build !skip_mqtt_tests
 
 package server
 

--- a/server/msgtrace_test.go
+++ b/server/msgtrace_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_msgtrace_tests
-// +build !skip_msgtrace_tests
 
 package server
 

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !race && !skip_no_race_tests
-// +build !race,!skip_no_race_tests
 
 package server
 

--- a/server/pse/pse_freebsd.go
+++ b/server/pse/pse_freebsd.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !amd64
-// +build !amd64
 
 package pse
 

--- a/server/pse/pse_rumprun.go
+++ b/server/pse/pse_rumprun.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build rumprun
-// +build rumprun
 
 package pse
 

--- a/server/pse/pse_wasm.go
+++ b/server/pse/pse_wasm.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build wasm
-// +build wasm
 
 package pse
 

--- a/server/pse/pse_windows.go
+++ b/server/pse/pse_windows.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package pse
 

--- a/server/pse/pse_windows_test.go
+++ b/server/pse/pse_windows_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package pse
 

--- a/server/pse/pse_zos.go
+++ b/server/pse/pse_zos.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build zos
-// +build zos
 
 package pse
 

--- a/server/service.go
+++ b/server/service.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package server
 

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package server
 

--- a/server/signal.go
+++ b/server/signal.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows && !wasm
-// +build !windows,!wasm
 
 package server
 

--- a/server/signal_test.go
+++ b/server/signal_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package server
 

--- a/server/signal_wasm.go
+++ b/server/signal_wasm.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build wasm
-// +build wasm
 
 package server
 

--- a/server/store_test.go
+++ b/server/store_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !skip_store_tests
-// +build !skip_store_tests
 
 package server
 

--- a/server/sysmem/mem_bsd.go
+++ b/server/sysmem/mem_bsd.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build freebsd || openbsd || dragonfly || netbsd
-// +build freebsd openbsd dragonfly netbsd
 
 package sysmem
 

--- a/server/sysmem/mem_darwin.go
+++ b/server/sysmem/mem_darwin.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build darwin
-// +build darwin
 
 package sysmem
 

--- a/server/sysmem/mem_linux.go
+++ b/server/sysmem/mem_linux.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build linux
-// +build linux
 
 package sysmem
 

--- a/server/sysmem/mem_wasm.go
+++ b/server/sysmem/mem_wasm.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build wasm
-// +build wasm
 
 package sysmem
 

--- a/server/sysmem/mem_windows.go
+++ b/server/sysmem/mem_windows.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package sysmem
 

--- a/server/sysmem/mem_zos.go
+++ b/server/sysmem/mem_zos.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build zos
-// +build zos
 
 package sysmem
 

--- a/server/sysmem/sysctl.go
+++ b/server/sysmem/sysctl.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build darwin || freebsd || openbsd || dragonfly || netbsd
-// +build darwin freebsd openbsd dragonfly netbsd
 
 package sysmem
 

--- a/test/fanout_test.go
+++ b/test/fanout_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !race && !skipnoracetests
-// +build !race,!skipnoracetests
 
 package test
 

--- a/test/norace_test.go
+++ b/test/norace_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !race && !skip_no_race_tests
-// +build !race,!skip_no_race_tests
 
 package test
 


### PR DESCRIPTION
Run:
`# go fix ./...`

It removed obsolete `// +build lines`: https://tip.golang.org/doc/go1.18#go-build-lines
Current build tag syntax: https://pkg.go.dev/cmd/go#hdr-Build_constraints

Since new fixes are rarely introduced, we shouldn't bother with running this automatically:
https://go.dev/blog/introducing-gofix
https://pkg.go.dev/cmd/fix@go1.23.5

```
go tool fix -h
Available rewrites are:

buildtag
        Remove +build comments from modules using Go 1.18 or later

cftype
        Fixes initializers and casts of C.*Ref and JNI types

context
        Change imports of golang.org/x/net/context to context

egl
        Fixes initializers of EGLDisplay

eglconf
        Fixes initializers of EGLConfig

gotypes
        Change imports of golang.org/x/tools/go/{exact,types} to go/{constant,types}

jni
        Fixes initializers of JNI's jobject and subtypes

netipv6zone
        Adapt element key to IPAddr, UDPAddr or TCPAddr composite literals.

        https://codereview.appspot.com/6849045/

printerconfig
        Add element keys to Config composite literals.
```

Signed-off-by: Alex Bozhenko <alex@synadia.com>
