### PR TITLE
Change `SubjectDeleteMarkerTTL` stream config field to duration

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5356,7 +5356,7 @@ func (fs *fileStore) subjectDeleteMarkerIfNeeded(sm *StoreMsg, reason string) fu
 	// we'll default to 15 minutes — by that time every possible condition
 	// should have cleared (i.e. ordered consumer timeout, client timeouts,
 	// route/gateway interruptions, even device/client restarts etc).
-	ttl, _ := parseMessageTTL(fs.cfg.SubjectDeleteMarkerTTL)
+	ttl := int64(fs.cfg.SubjectDeleteMarkerTTL.Seconds())
 	if ttl <= 0 {
 		return nil
 	}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -8570,7 +8570,7 @@ func TestFileStoreSubjectDeleteMarkers(t *testing.T) {
 		StreamConfig{
 			Name: "zzz", Subjects: []string{"test"}, Storage: FileStorage,
 			MaxAge: time.Second, AllowMsgTTL: true,
-			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: "1s",
+			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: time.Second,
 		},
 	)
 	require_NoError(t, err)
@@ -8614,7 +8614,7 @@ func TestFileStoreSubjectDeleteMarkersOnRestart(t *testing.T) {
 		StreamConfig{
 			Name: "zzz", Subjects: []string{"test"}, Storage: FileStorage,
 			MaxAge: time.Second, AllowMsgTTL: true,
-			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: "1s",
+			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: time.Second,
 		},
 	)
 	require_NoError(t, err)
@@ -8637,7 +8637,7 @@ func TestFileStoreSubjectDeleteMarkersOnRestart(t *testing.T) {
 		StreamConfig{
 			Name: "zzz", Subjects: []string{"test"}, Storage: FileStorage,
 			MaxAge: time.Second, AllowMsgTTL: true,
-			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: "1s",
+			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: time.Second,
 		},
 	)
 	require_NoError(t, err)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -24171,7 +24171,7 @@ func TestJetStreamStreamCreatePedanticMode(t *testing.T) {
 					Storage:                FileStorage,
 					AllowMsgTTL:            true,
 					SubjectDeleteMarkers:   true,
-					SubjectDeleteMarkerTTL: "10m",
+					SubjectDeleteMarkerTTL: 10 * time.Minute,
 				},
 				Pedantic: true,
 			},
@@ -24218,7 +24218,7 @@ func TestJetStreamStreamCreatePedanticMode(t *testing.T) {
 					Storage:                FileStorage,
 					AllowMsgTTL:            true,
 					SubjectDeleteMarkers:   true,
-					SubjectDeleteMarkerTTL: "11m",
+					SubjectDeleteMarkerTTL: 11 * time.Minute,
 				},
 				Pedantic: true,
 			},
@@ -25369,7 +25369,7 @@ func TestJetStreamSubjectDeleteMarkers(t *testing.T) {
 				MaxAge:                 time.Second,
 				AllowMsgTTL:            true,
 				SubjectDeleteMarkers:   true,
-				SubjectDeleteMarkerTTL: "1s",
+				SubjectDeleteMarkerTTL: time.Second,
 			})
 
 			sub, err := js.SubscribeSync("test")

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -990,7 +990,7 @@ func (ms *memStore) subjectDeleteMarkerIfNeeded(sm *StoreMsg, reason string) fun
 	// we'll default to 15 minutes — by that time every possible condition
 	// should have cleared (i.e. ordered consumer timeout, client timeouts,
 	// route/gateway interruptions, even device/client restarts etc).
-	ttl, _ := parseMessageTTL(ms.cfg.SubjectDeleteMarkerTTL)
+	ttl := int64(ms.cfg.SubjectDeleteMarkerTTL.Seconds())
 	if ttl <= 0 {
 		return nil
 	}

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -1194,7 +1194,7 @@ func TestMemStoreSubjectDeleteMarkers(t *testing.T) {
 		&StreamConfig{
 			Name: "zzz", Subjects: []string{"test"}, Storage: MemoryStorage,
 			MaxAge: time.Second, AllowMsgTTL: true,
-			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: "1s",
+			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: time.Second,
 		},
 	)
 	require_NoError(t, err)

--- a/server/store.go
+++ b/server/store.go
@@ -71,7 +71,7 @@ var (
 )
 
 // Default value for SubjectDeleteMarkerTTL if not specified.
-const subjectDeleteMarkerDefaultTTL = "15m"
+const subjectDeleteMarkerDefaultTTL = 15 * time.Minute
 
 // StoreMsg is the stored message format for messages that are retained by the Store layer.
 type StoreMsg struct {


### PR DESCRIPTION
After experimenting with this, it feels strange to have `MaxAge` etc typed as `time.Duration` but then have `SubjectDeleteMarkerTTL` typed as a maybe-string-integer maybe-string-duration. This PR instead standardises on `time.Duration`.

This does not change the behaviour of the `Nats-TTL` header.

Signed-off-by: Neil Twigg <neil@nats.io>