### PR TITLE
[FIXED] Too Many Requests error

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -1648,5 +1648,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSStreamTooManyRequests",
+    "code": 429,
+    "error_code": 10167,
+    "description": "too many requests",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -476,6 +476,9 @@ const (
 	// JSStreamTemplateNotFoundErr template not found
 	JSStreamTemplateNotFoundErr ErrorIdentifier = 10068
 
+	// JSStreamTooManyRequests too many requests
+	JSStreamTooManyRequests ErrorIdentifier = 10167
+
 	// JSStreamTransformInvalidDestination stream transform: {err}
 	JSStreamTransformInvalidDestination ErrorIdentifier = 10156
 
@@ -660,6 +663,7 @@ var (
 		JSStreamTemplateCreateErrF:                 {Code: 500, ErrCode: 10066, Description: "{err}"},
 		JSStreamTemplateDeleteErrF:                 {Code: 500, ErrCode: 10067, Description: "{err}"},
 		JSStreamTemplateNotFoundErr:                {Code: 404, ErrCode: 10068, Description: "template not found"},
+		JSStreamTooManyRequests:                    {Code: 429, ErrCode: 10167, Description: "too many requests"},
 		JSStreamTransformInvalidDestination:        {Code: 400, ErrCode: 10156, Description: "stream transform: {err}"},
 		JSStreamTransformInvalidSource:             {Code: 400, ErrCode: 10155, Description: "stream transform source: {err}"},
 		JSStreamUpdateErrF:                         {Code: 500, ErrCode: 10069, Description: "{err}"},
@@ -2501,6 +2505,16 @@ func NewJSStreamTemplateNotFoundError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSStreamTemplateNotFoundErr]
+}
+
+// NewJSStreamTooManyRequestsError creates a new JSStreamTooManyRequests error: "too many requests"
+func NewJSStreamTooManyRequestsError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSStreamTooManyRequests]
 }
 
 // NewJSStreamTransformInvalidDestinationError creates a new JSStreamTransformInvalidDestination error: "stream transform: {err}"

--- a/server/stream.go
+++ b/server/stream.go
@@ -4336,7 +4336,8 @@ func (mset *stream) queueInbound(ib *ipQueue[*inMsg], subj, rply string, hdr, ms
 		mset.srv.RateLimitWarnf("Dropping messages due to excessive stream ingest rate on '%s' > '%s': %s", mset.acc.Name, mset.name(), err)
 		if rply != _EMPTY_ {
 			hdr := []byte("NATS/1.0 429 Too Many Requests\r\n\r\n")
-			mset.outq.send(newJSPubMsg(rply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
+			b, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: mset.cfg.Name}, Error: NewJSStreamTooManyRequestsError()})
+			mset.outq.send(newJSPubMsg(rply, _EMPTY_, _EMPTY_, hdr, b, nil, 0))
 		}
 	}
 }


### PR DESCRIPTION
When sending too many requests into a stream it's rate-limited. However, that would result in the following error using the Go client (as part of a `nats bench`): `invalid jetstream publish response` due to `unexpected end of JSON input`, since the returned pub ack message is empty.

This PR introduces a specific error for 429 Too Many Requests so the clients can properly handle this without further changes.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
