### PR TITLE
Remove the comment that durable_name is deprecated

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -76,7 +76,6 @@ type PriorityGroupState struct {
 }
 
 type ConsumerConfig struct {
-	// Durable is deprecated. All consumers should have names, picked by clients.
 	Durable         string          `json:"durable_name,omitempty"`
 	Name            string          `json:"name,omitempty"`
 	Description     string          `json:"description,omitempty"`


### PR DESCRIPTION
We intended to deprecate this but did not do so in the end and it is critical in current API clients

<!-- Please make sure to read CONTRIBUTING.md, then delete this notice and replace it with your PR description. The below sign-off certifies that the contribution is your original work and that you license the work to the project under the Apache-2.0 license. We cannot accept contributions without it. -->

Signed-off-by: R.I.Pienaar <rip@devco.net>
