### PR TITLE
Explicitly set go toolchain in goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,7 @@ builds:
     ldflags:
       - -w -X 'github.com/nats-io/nats-server/v2/server.gitCommit={{.ShortCommit}}' -X 'github.com/nats-io/nats-server/v2/server.serverVersion={{.Tag}}'
     env:
+      - GOTOOLCHAIN={{ envOrDefault "GORELEASER_TOOLCHAIN" "go1.23.5" }}
       - GO111MODULE=on
       - CGO_ENABLED=0
     goos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,9 @@ builds:
     ldflags:
       - -w -X 'github.com/nats-io/nats-server/v2/server.gitCommit={{.ShortCommit}}' -X 'github.com/nats-io/nats-server/v2/server.serverVersion={{.Tag}}'
     env:
-      - GOTOOLCHAIN={{ envOrDefault "GORELEASER_TOOLCHAIN" "go1.23.5" }}
+      # This is the toolchain version we use for releases. To override, set the env var, e.g.:
+      # GORELEASER_TOOLCHAIN="go1.22.8" TARGET='linux_amd64' goreleaser build --snapshot --clean --single-target
+      - GOTOOLCHAIN={{ envOrDefault "GORELEASER_TOOLCHAIN" "go1.24.0" }}
       - GO111MODULE=on
       - CGO_ENABLED=0
     goos:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ language: go
 go:
   # This should be quoted or use .x, but should not be unquoted.
   # Remember that a YAML bare float drops trailing zeroes.
+  # These toolchain versions define the test environment.
+  # When updating, also update the GOTOOLCHAIN value in .goreleaser.yml.
   - "1.24.0"
   - "1.23.6"
 


### PR DESCRIPTION
## Details
We have reproducible binaries, [rpms/debs](https://github.com/nats-io/nats-server/pull/6359) and [archives](https://github.com/nats-io/nats-server/pull/6299).
And `goreleaser.yml` holds [all the knobs](https://goreleaser.com/customization/builds/go/) that can be tuned to build the binary. 

The only thing that affects the build and is not defined in the goreleaser config is the go toolchain version. 
Currently, we set the version of the go toolchain that is used for releases in Travis:
<https://github.com/nats-io/nats-server/blob/5e6017135b4b1d333b435ff55b720275a39bb7af/.travis.yml#L11-L12>
<https://github.com/nats-io/nats-server/blob/5e6017135b4b1d333b435ff55b720275a39bb7af/.travis.yml#L67>

I spent some time [trying to understand the behavior of go and toolchain directives](https://alexbozhenko.github.io/posts/2024-12-19-understand-go-toolchain-directive-or-your-money-back/). I think setting the toolchain used for releases in .goreleser.yml would make it more explicit and future-proof.


With this change, any human or script who has `go>1.21.0` and goreleaser installed can checkout the repo at any commit, run one command, and get binaries that will be _exactly_ as if we were cutting a release on that commit.

```
goreleaser build --snapshot --clean --single-target
```

Several places would benefit from not having to worry about keeping toolchain and all the go build flags in sync:

* get-nats.io(already uses gorelaser, but toolchain used to build depends on the build host):
<https://github.com/ConnectEverything/client-tools/blob/eba999ac9a1e107205fbf89ba230df3f80458028/build-nightlies.sh#L184-L188>
* <redacted> number of private repos

If we land this, we can update the above places to use `goreleaser build`, thus making sure we use _exactly the same_ binary everywhere, and forever forget about managing/updating go versions in other places that need to build the binary

## Reproducible test plan

### Before

Behavior is not hermetic. We depend on toolchain that happens to be installed on the build host.

1.
    <details>
    <summary>Local go(`1.21.0`) < one that is specified in go.mod. Go will download and use toolchain from go.mod:</summary>

        ```
        # go version
        go version go1.21.0 linux/amd64

        # TARGET='linux_amd64' goreleaser build --snapshot --clean --single-target
        # go version -m  dist/nats-server_linux_amd64_v1/nats-server | grep go1
        dist/nats-server_linux_amd64_v1/nats-server: go1.22.8
        ```
    </details>

2.
    <details>
    <summary>Local go(`1.23.3`) > one that is specified in go.mod. Local toolchain will be used:</summary>

    ```
    # wget https://go.dev/dl/go1.23.3.linux-amd64.tar.gz
    # sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.23.3.linux-amd64.tar.gz
    # go version
    go version go1.23.3 linux/amd64
    
    # TARGET='linux_amd64' goreleaser build --snapshot --clean --single-target
    # go version -m  dist/nats-server_linux_amd64_v1/nats-server | grep go1
    dist/nats-server_linux_amd64_v1/nats-server: go1.23.3
    ```

    </details>

### After

1.
    <details>
    <summary>Local go version (1.23.4) did not affect what was used for the binary</summary>

    It will download (just like it [downloads all the modules](https://youtu.be/KqTySYYhPUE?feature=shared&t=229))
    the version of the toolchain specified in goreleaer config, and use it for building the binary.

    ```

    # go version
    go version go1.23.4 linux/amd64

    # TARGET='linux_amd64' goreleaser build --snapshot --clean --single-target
    # go version -m  dist/nats-server_linux_amd64_v1/nats-server | grep go1
    dist/nats-server_linux_amd64_v1/nats-server: go1.23.5

    # sha256sum  dist/nats-server_linux_amd64_v1/nats-server
    95d52ed8656f74abd0c0576d8d9be50fcc00562c8e18215d1f1f04b8c0b6fc3d  dist/nats-server_linux_amd64_v1/nats-server
    ```

    </details>

2.
    <details>
    <summary>Any  go >= go1.21.0 (released 2023-08-08)  will build exactly the same binary:</summary>

    ```
    # wget <https://go.dev/dl/go1.21.0.linux-amd64.tar.gz>
    # sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.21.0.linux-amd64.tar.gz
    # go version
    go version go1.21.0 linux/amd64

    # TARGET='linux_amd64' goreleaser build --snapshot --clean --single-target
    # go version -m  dist/nats-server_linux_amd64_v1/nats-server | grep go1
    dist/nats-server_linux_amd64_v1/nats-server: go1.23.5

    # sha256sum  dist/nats-server_linux_amd64_v1/nats-server
    95d52ed8656f74abd0c0576d8d9be50fcc00562c8e18215d1f1f04b8c0b6fc3d  dist/nats-server_linux_amd64_v1/nats-server
    ```

    </details>

3. To build using specific toolchain one would set the `GORELEASER_TOOLCHAIN` env variable:

    ```
    # GORELEASER_TOOLCHAIN="go1.22.8" TARGET='linux_amd64' goreleaser build --snapshot --clean --single-target
    # go version -m  dist/nats-server_linux_amd64_v1/nats-server | grep go1
    dist/nats-server_linux_amd64_v1/nats-server: go1.22.8
    ```


Note that starting from go1.24.0 we can use the [tool directive](https://tip.golang.org/doc/modules/managing-dependencies#tools
) in go.mod, and even version goreleaser itself. It will look something like this:

```
go tool goreleaser build --snapshot --clean --single-target
```

