### PR TITLE
Just testing to see if Pending is not actually used

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -784,7 +784,6 @@ type RouteInfo struct {
 	Idle         string             `json:"idle"`
 	Import       *SubjectPermission `json:"import,omitempty"`
 	Export       *SubjectPermission `json:"export,omitempty"`
-	Pending      int                `json:"pending_size"`
 	InMsgs       int64              `json:"in_msgs"`
 	OutMsgs      int64              `json:"out_msgs"`
 	InBytes      int64              `json:"in_bytes"`


### PR DESCRIPTION
Looks like `pending_size` is never set in `/routez`:
https://docs.nats.io/running-a-nats-service/nats_admin/monitoring#route-information-routez
I guess it would be used here:
https://github.com/nats-io/nats-server/blob/67aa107d750eec8c1344aed2c336d8373ed7c437/server/monitor.go#L823

But it is not...

Signed-off-by: Alex Bozhenko <alex@synadia.com>
