### PR TITLE
Fix data race on mset.cfg

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1556,12 +1556,14 @@ func (a *Account) filteredStreams(filter string) []*stream {
 	var msets []*stream
 	for _, mset := range jsa.streams {
 		if filter != _EMPTY_ {
+			mset.cfgMu.RLock()
 			for _, subj := range mset.cfg.Subjects {
 				if SubjectsCollide(filter, subj) {
 					msets = append(msets, mset)
 					break
 				}
 			}
+			mset.cfgMu.RUnlock()
 		} else {
 			msets = append(msets, mset)
 		}


### PR DESCRIPTION
Using NATS in our unit tests with the Go data race detector turned on, we [sometimes see failures in `nats-server` like the following](https://github.com/mindersec/minder/actions/runs/13006404998/job/36274161639):

```
WARNING: DATA RACE
  Read at 0x00c0004ba0e8 by goroutine 41:
    github.com/nats-io/nats-server/v2/server.(*Account).filteredStreams()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/jetstream.go:1504 +0x3e4
    github.com/nats-io/nats-server/v2/server.(*Server).jsStreamNamesRequest()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/jetstream_api.go:1662 +0x516
    github.com/nats-io/nats-server/v2/server.(*Server).jsStreamNamesRequest-fm()
        <autogenerated>:1 +0xcb
    github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/jetstream_api.go:818 +0xb37
    github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch-fm()
        <autogenerated>:1 +0xcb
    github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:3473 +0xcfe
    github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:4565 +0x1206
    github.com/nats-io/nats-server/v2/server.(*client).processServiceImport()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:4350 +0x1e0e
    github.com/nats-io/nats-server/v2/server.(*Account).addServiceImportSub.func1()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/accounts.go:2024 +0x4d
    github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:3471 +0xdcf
    github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:4565 +0x1206
    github.com/nats-io/nats-server/v2/server.(*client).processInboundClientMsg()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:3952 +0x163d
    github.com/nats-io/nats-server/v2/server.(*client).processInboundMsg()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:3789 +0x88
    github.com/nats-io/nats-server/v2/server.(*client).parse()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/parser.go:497 +0x362d
    github.com/nats-io/nats-server/v2/server.(*client).readLoop()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:1393 +0x1b18
    github.com/nats-io/nats-server/v2/server.(*Server).createClientEx.func1()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/server.go:3295 +0x54
    github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/server.go:3795 +0x59
  
  Previous write at 0x00c0004ba0e8 by goroutine 54:
    github.com/nats-io/nats-server/v2/server.(*stream).updateWithAdvisory()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/stream.go:1963 +0x1b96
    github.com/nats-io/nats-server/v2/server.(*stream).update()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/stream.go:1726 +0xf2c
    github.com/nats-io/nats-server/v2/server.(*Server).jsStreamUpdateRequest()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/jetstream_api.go:1543 +0xf2d
    github.com/nats-io/nats-server/v2/server.(*Server).jsStreamUpdateRequest-fm()
        <autogenerated>:1 +0xcb
    github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/jetstream_api.go:818 +0xb37
    github.com/nats-io/nats-server/v2/server.(*jetStream).apiDispatch-fm()
        <autogenerated>:1 +0xcb
    github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:3473 +0xcfe
    github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:4565 +0x1206
    github.com/nats-io/nats-server/v2/server.(*client).processServiceImport()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:4350 +0x1e0e
    github.com/nats-io/nats-server/v2/server.(*Account).addServiceImportSub.func1()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/accounts.go:2024 +0x4d
    github.com/nats-io/nats-server/v2/server.(*client).deliverMsg()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:3471 +0xdcf
    github.com/nats-io/nats-server/v2/server.(*client).processMsgResults()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:4565 +0x1206
    github.com/nats-io/nats-server/v2/server.(*client).processInboundClientMsg()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:3952 +0x163d
    github.com/nats-io/nats-server/v2/server.(*client).processInboundMsg()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:3789 +0x88
    github.com/nats-io/nats-server/v2/server.(*client).parse()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/parser.go:497 +0x362d
    github.com/nats-io/nats-server/v2/server.(*client).readLoop()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/client.go:1393 +0x1b18
    github.com/nats-io/nats-server/v2/server.(*Server).createClientEx.func1()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/server.go:3295 +0x54
    github.com/nats-io/nats-server/v2/server.(*Server).startGoRoutine.func1()
        /home/runner/go/pkg/mod/github.com/nats-io/nats-server/v2@v2.10.25/server/server.go:3795 +0x59
```

Signed-off-by: Evan Anderson <evan@stacklok.com>
