### PR TITLE
Simplify Docker nightlies, fix on-demand custom builds

### DIFF
--- a/.github/actions/nightly-release/action.yaml
+++ b/.github/actions/nightly-release/action.yaml
@@ -2,14 +2,6 @@ name: Nightly Docker Releaser
 description: Builds nightly docker images
 
 inputs:
-  go:
-    description: The version of go to build with
-    required: true
-
-  label:
-    description: The label to use for built images
-    required: true
-
   hub_username:
     description: Docker hub username
     required: true
@@ -25,35 +17,20 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Log in to Docker Hub
+      shell: bash
+      run: docker login -u "${{ inputs.hub_username }}" -p "${{ inputs.hub_password }}"
+
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: "${{ inputs.go }}"
+        go-version: "stable"
 
-    - name: goreleaser
+    - name: Build and push Docker images
       # Use commit hash here to avoid a re-tagging attack, as this is a third-party action
       # Commit 9ed2f89a662bf1735a48bc8557fd212fa902bebf = tag v6.1.0
       uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf
       with:
         workdir: "${{ inputs.workdir }}"
-        version: "~> v2"
-        args: release --snapshot --config .goreleaser-nightly.yml
-
-    - name: images
-      shell: bash
-      run: docker images
-
-    - name: docker_login
-      shell: bash
-      run: docker login -u "${{ inputs.hub_username }}" -p "${{ inputs.hub_password }}"
-
-    - name: docker_push
-      shell: bash
-      run: |
-        NDATE=$(date +%Y%m%d)
-
-        docker tag synadia/nats-server:nightly-${NDATE} synadia/nats-server:${{ inputs.label }}-${NDATE}
-        docker tag synadia/nats-server:nightly-${NDATE} synadia/nats-server:${{ inputs.label }}
-
-        docker push synadia/nats-server:${{ inputs.label }}-${NDATE}
-        docker push synadia/nats-server:${{ inputs.label }}
+        version: ~> v2
+        args: release --skip=announce,validate --config .goreleaser-nightly.yml

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: "Override image branch (optional)"
+        description: "Override source branch (optional)"
         type: string
         required: false
 
@@ -19,11 +19,11 @@ jobs:
         with:
           path: src/github.com/nats-io/nats-server
           ref: ${{ inputs.target || 'main' }}
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: ./src/github.com/nats-io/nats-server/.github/actions/nightly-release
         with:
-          go: "1.23"
           workdir: src/github.com/nats-io/nats-server
-          label: nightly
           hub_username: "${{ secrets.DOCKER_USERNAME }}"
           hub_password: "${{ secrets.DOCKER_PASSWORD }}"

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -16,16 +16,19 @@ builds:
       - amd64
     mod_timestamp: "{{ .CommitTimestamp }}"
 
+release:
+  disable: true
+
 dockers:
   - goos: linux
     goarch: amd64
-    skip_push: true
     dockerfile: docker/Dockerfile.nightly
+    skip_push: false
     build_flag_templates:
-      - '--build-arg=VERSION={{ if index .Env "IMAGE_NAME"  }}{{ .Env.IMAGE_NAME }}{{ else if not (eq .Branch "main" "dev" "") }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}'
+      - '--build-arg=VERSION={{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}'
     image_templates:
-      - synadia/nats-server:{{.Version}}
-      - synadia/nats-server:{{ if index .Env "IMAGE_NAME"  }}{{ .Env.IMAGE_NAME }}{{ else if not (eq .Branch "main" "dev" "") }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}
+      - synadia/nats-server:{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}
+      - synadia/nats-server:{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}
     extra_files:
       - docker/nats-server.conf
 
@@ -34,4 +37,4 @@ checksum:
   algorithm: sha256
 
 snapshot:
-  version_template: '{{ if index .Env "IMAGE_NAME"  }}{{ .Env.IMAGE_NAME }}{{ else if not (eq .Branch "main" "dev" "") }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}'
+  version_template: '{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}'

--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:alpine AS builder
 
 ARG VERSION="nightly"
 


### PR DESCRIPTION
This simplifies the nightly Docker image pipeline, as well as always using the latest stable Go version for builds and fixing the ability to build on-demand images from custom branches. 

Signed-off-by: Neil Twigg <neil@nats.io>

[ci skip]
