### PR TITLE
Fix message parsing in nats resolver account deletion handling

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -4360,7 +4360,8 @@ func (dr *DirAccResolver) Start(s *Server) error {
 	}); err != nil {
 		return fmt.Errorf("error setting up list request handling: %v", err)
 	}
-	if _, err := s.sysSubscribe(accDeleteReqSubj, func(_ *subscription, _ *client, _ *Account, _, reply string, msg []byte) {
+	if _, err := s.sysSubscribe(accDeleteReqSubj, func(_ *subscription, c *client, _ *Account, _, reply string, msg []byte) {
+		_, msg = c.msgParts(msg)
 		handleDeleteRequest(dr.DirJWTStore, s, msg, reply)
 	}); err != nil {
 		return fmt.Errorf("error setting up delete request handling: %v", err)
@@ -4627,7 +4628,8 @@ func (dr *CacheDirAccResolver) Start(s *Server) error {
 	}); err != nil {
 		return fmt.Errorf("error setting up list request handling: %v", err)
 	}
-	if _, err := s.sysSubscribe(accDeleteReqSubj, func(_ *subscription, _ *client, _ *Account, _, reply string, msg []byte) {
+	if _, err := s.sysSubscribe(accDeleteReqSubj, func(_ *subscription, c *client, _ *Account, _, reply string, msg []byte) {
+		_, msg = c.msgParts(msg)
 		handleDeleteRequest(dr.DirJWTStore, s, msg, reply)
 	}); err != nil {
 		return fmt.Errorf("error setting up list request handling: %v", err)


### PR DESCRIPTION
Added a call to `c.msgParts` for proper parsing of message contents in the account deletion request handler. Tests pass without this change, but an actual call of the API will always fail to parse the request JWT because the delete function only expects the JWT portion:

```
NATS/1.0
Nats-Request-Info: {"acc":"AA3SRJHT6PP52IJG26AXNSA7DYOCOZCWZARDOPVLMPGV45QBKRLGEVNW","rtt":899875,"server":"NBK7H52ED2O6XYMB5E6YTQIZPVKCF6BQN4G7XDEZ3GPGJU25K3DDTEQN"}

eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NT......
```
Note that since this feature doesn't currently work, it means that it is not use, and I am not sure what the wisdom is on deleting accounts from the resolver, so possibly OK to leave as is.



Signed-off-by: alberto <alberto@synadia.com>
