### PR TITLE
Subject delete markers on purges and removes for filestore

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -25429,7 +25429,7 @@ func TestJetStreamSubjectDeleteMarkers(t *testing.T) {
 
 			msg, err := sub.NextMsg(time.Second * 10)
 			require_NoError(t, err)
-			require_Equal(t, msg.Header.Get(JSAppliedLimit), "MaxAge")
+			require_Equal(t, msg.Header.Get(JSMarkerReason), "MaxAge")
 			require_Equal(t, msg.Header.Get(JSMessageTTL), "1s")
 		})
 	}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -975,7 +975,7 @@ func (ms *memStore) cancelAgeChk() {
 func (ms *memStore) subjectDeleteMarkerIfNeeded(sm *StoreMsg, reason string) func() {
 	// If the deleted message was itself a delete marker then
 	// don't write out more of them or we'll churn endlessly.
-	if len(getHeader(JSAppliedLimit, sm.hdr)) != 0 {
+	if len(getHeader(JSMarkerReason, sm.hdr)) != 0 {
 		return nil
 	}
 	if !ms.cfg.SubjectDeleteMarkers {
@@ -995,7 +995,7 @@ func (ms *memStore) subjectDeleteMarkerIfNeeded(sm *StoreMsg, reason string) fun
 		return nil
 	}
 	var _hdr [128]byte
-	hdr := fmt.Appendf(_hdr[:0], "NATS/1.0\r\n%s: %s\r\n%s: %s\r\n\r\n", JSAppliedLimit, reason, JSMessageTTL, time.Duration(ttl)*time.Second)
+	hdr := fmt.Appendf(_hdr[:0], "NATS/1.0\r\n%s: %s\r\n%s: %s\r\n\r\n", JSMarkerReason, reason, JSMessageTTL, time.Duration(ttl)*time.Second)
 	seq, ts := ms.state.LastSeq+1, time.Now().UnixNano()
 	// Store it in the stream and then prepare the callbacks
 	// to return to the caller.
@@ -1034,7 +1034,7 @@ func (ms *memStore) expireMsgs() {
 			}
 			ms.mu.Lock()
 			ms.removeMsg(seq, false)
-			cbs := ms.subjectDeleteMarkerIfNeeded(sm, JSAppliedLimitMaxAge)
+			cbs := ms.subjectDeleteMarkerIfNeeded(sm, JSMarkerReasonMaxAge)
 			ms.mu.Unlock()
 			if cbs != nil {
 				cbs()

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -1216,7 +1216,7 @@ func TestMemStoreSubjectDeleteMarkers(t *testing.T) {
 	// We should have replaced it with a tombstone.
 	sm, err = fs.LoadMsg(seq+1, nil)
 	require_NoError(t, err)
-	require_Equal(t, bytesToString(getHeader(JSAppliedLimit, sm.hdr)), JSAppliedLimitMaxAge)
+	require_Equal(t, bytesToString(getHeader(JSMarkerReason, sm.hdr)), JSMarkerReasonMaxAge)
 	require_Equal(t, bytesToString(getHeader(JSMessageTTL, sm.hdr)), "1s")
 
 	time.Sleep(time.Second * 2)

--- a/server/stream.go
+++ b/server/stream.go
@@ -426,7 +426,7 @@ const (
 	JSMsgSize                 = "Nats-Msg-Size"
 	JSResponseType            = "Nats-Response-Type"
 	JSMessageTTL              = "Nats-TTL"
-	JSAppliedLimit            = "Nats-Applied-Limit"
+	JSMarkerReason            = "Nats-Marker-Reason"
 )
 
 // Headers for republished messages and direct gets.
@@ -448,7 +448,9 @@ const (
 
 // Applied limits in the Nats-Applied-Limit header.
 const (
-	JSAppliedLimitMaxAge = "MaxAge"
+	JSMarkerReasonMaxAge = "MaxAge"
+	JSMarkerReasonPurge  = "Purge"
+	JSMarkerReasonRemove = "Remove"
 )
 
 const (


### PR DESCRIPTION
This PR adds subject delete markers when doing purge/compact/remove operations for the filestore.

Memstore will be a separate PR but expect it to look a lot like this one.

Remaining questions before I mark for review:

- [ ] Are we happy with the approach?
- [ ] Does the name `Nats-Applied-Limit` make sense or do we want a more generic name like `Nats-Marker-Reason`?
- [ ] ... or do we want a separate header for administrative reasons like `Purge` and `Remove`?

Signed-off-by: Neil Twigg <neil@nats.io>