### PR TITLE
Single configuration option for subject delete markers

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -8570,7 +8570,7 @@ func TestFileStoreSubjectDeleteMarkers(t *testing.T) {
 		StreamConfig{
 			Name: "zzz", Subjects: []string{"test"}, Storage: FileStorage,
 			MaxAge: time.Second, AllowMsgTTL: true,
-			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: time.Second,
+			SubjectDeleteMarkerTTL: time.Second,
 		},
 	)
 	require_NoError(t, err)
@@ -8614,7 +8614,7 @@ func TestFileStoreSubjectDeleteMarkersOnRestart(t *testing.T) {
 		StreamConfig{
 			Name: "zzz", Subjects: []string{"test"}, Storage: FileStorage,
 			MaxAge: time.Second, AllowMsgTTL: true,
-			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: time.Second,
+			SubjectDeleteMarkerTTL: time.Second,
 		},
 	)
 	require_NoError(t, err)
@@ -8637,7 +8637,7 @@ func TestFileStoreSubjectDeleteMarkersOnRestart(t *testing.T) {
 		StreamConfig{
 			Name: "zzz", Subjects: []string{"test"}, Storage: FileStorage,
 			MaxAge: time.Second, AllowMsgTTL: true,
-			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: time.Second,
+			SubjectDeleteMarkerTTL: time.Second,
 		},
 	)
 	require_NoError(t, err)
@@ -8662,7 +8662,7 @@ func TestFileStoreSubjectDeleteMarkersOnPurge(t *testing.T) {
 		StreamConfig{
 			Name: "zzz", Subjects: []string{"test.*"}, Storage: FileStorage,
 			MaxAge: time.Second, AllowMsgTTL: true,
-			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: time.Second,
+			SubjectDeleteMarkerTTL: time.Second,
 		},
 	)
 	require_NoError(t, err)
@@ -8692,7 +8692,7 @@ func TestFileStoreSubjectDeleteMarkersOnPurgeEx(t *testing.T) {
 		StreamConfig{
 			Name: "zzz", Subjects: []string{"test.*"}, Storage: FileStorage,
 			MaxAge: time.Second, AllowMsgTTL: true,
-			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: time.Second,
+			SubjectDeleteMarkerTTL: time.Second,
 		},
 	)
 	require_NoError(t, err)
@@ -8722,7 +8722,7 @@ func TestFileStoreSubjectDeleteMarkersOnCompact(t *testing.T) {
 		StreamConfig{
 			Name: "zzz", Subjects: []string{"test.*"}, Storage: FileStorage,
 			MaxAge: time.Second, AllowMsgTTL: true,
-			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: time.Second,
+			SubjectDeleteMarkerTTL: time.Second,
 		},
 	)
 	require_NoError(t, err)
@@ -8758,7 +8758,7 @@ func TestFileStoreSubjectDeleteMarkersOnRemoveMsg(t *testing.T) {
 		StreamConfig{
 			Name: "zzz", Subjects: []string{"test"}, Storage: FileStorage,
 			MaxAge: time.Second, AllowMsgTTL: true,
-			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: time.Second,
+			SubjectDeleteMarkerTTL: time.Second,
 		},
 	)
 	require_NoError(t, err)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -24202,70 +24202,6 @@ func TestJetStreamStreamCreatePedanticMode(t *testing.T) {
 			update:    true,
 			shouldErr: true,
 		},
-		{
-			name: "subject_delete_marker_specified",
-			cfg: StreamConfigRequest{
-				StreamConfig: StreamConfig{
-					Name:                   "SDM_TEST",
-					MaxAge:                 time.Minute,
-					Duplicates:             time.Minute,
-					Storage:                FileStorage,
-					AllowMsgTTL:            true,
-					SubjectDeleteMarkers:   true,
-					SubjectDeleteMarkerTTL: 10 * time.Minute,
-				},
-				Pedantic: true,
-			},
-			shouldErr: false,
-		},
-		{
-			name: "subject_delete_marker_not_specified",
-			cfg: StreamConfigRequest{
-				StreamConfig: StreamConfig{
-					Name:                 "SDM_TEST_2",
-					MaxAge:               time.Minute,
-					Duplicates:           time.Minute,
-					Storage:              FileStorage,
-					AllowMsgTTL:          true,
-					SubjectDeleteMarkers: true,
-				},
-				Pedantic: true,
-			},
-			shouldErr: true,
-		},
-		{
-			name: "update_subject_delete_marker_not_specified",
-			cfg: StreamConfigRequest{
-				StreamConfig: StreamConfig{
-					Name:                 "SDM_TEST",
-					MaxAge:               time.Minute,
-					Duplicates:           time.Minute,
-					Storage:              FileStorage,
-					AllowMsgTTL:          true,
-					SubjectDeleteMarkers: true,
-				},
-				Pedantic: true,
-			},
-			shouldErr: true,
-			update:    true,
-		},
-		{
-			name: "update_subject_delete_marker_specified",
-			cfg: StreamConfigRequest{
-				StreamConfig: StreamConfig{
-					Name:                   "SDM_TEST",
-					MaxAge:                 time.Minute,
-					Duplicates:             time.Minute,
-					Storage:                FileStorage,
-					AllowMsgTTL:            true,
-					SubjectDeleteMarkers:   true,
-					SubjectDeleteMarkerTTL: 11 * time.Minute,
-				},
-				Pedantic: true,
-			},
-			shouldErr: false,
-			update:    true,
-		},
 	}
 
 	for _, test := range tests {
@@ -25409,7 +25345,6 @@ func TestJetStreamSubjectDeleteMarkers(t *testing.T) {
 				Subjects:               []string{"test"},
 				MaxAge:                 time.Second,
 				AllowMsgTTL:            true,
-				SubjectDeleteMarkers:   true,
 				SubjectDeleteMarkerTTL: time.Second,
 			})
 
@@ -25451,36 +25386,13 @@ func TestJetStreamSubjectDeleteMarkersWithMirror(t *testing.T) {
 	require_NoError(t, err)
 
 	_, err = jsStreamCreate(t, nc, &StreamConfig{
-		Name:                 "Mirror",
-		Storage:              FileStorage,
-		AllowMsgTTL:          true,
-		SubjectDeleteMarkers: true,
+		Name:                   "Mirror",
+		Storage:                FileStorage,
+		AllowMsgTTL:            true,
+		SubjectDeleteMarkerTTL: time.Second,
 		Mirror: &StreamSource{
 			Name: "Origin",
 		},
 	})
 	require_Error(t, err)
-}
-
-func TestJetStreamSubjectDeleteMarkersDefaultTTL(t *testing.T) {
-	for _, storage := range []StorageType{FileStorage, MemoryStorage} {
-		t.Run(storage.String(), func(t *testing.T) {
-			s := RunBasicJetStreamServer(t)
-			defer s.Shutdown()
-
-			nc, _ := jsClientConnect(t, s)
-			defer nc.Close()
-
-			sc, err := jsStreamCreate(t, nc, &StreamConfig{
-				Name:                 "Origin",
-				Storage:              storage,
-				Subjects:             []string{"test"},
-				AllowMsgTTL:          true,
-				SubjectDeleteMarkers: true,
-			})
-			require_NoError(t, err)
-
-			require_Equal(t, sc.SubjectDeleteMarkerTTL, subjectDeleteMarkerDefaultTTL)
-		})
-	}
 }

--- a/server/jetstream_versioning.go
+++ b/server/jetstream_versioning.go
@@ -45,7 +45,7 @@ func setStaticStreamMetadata(cfg *StreamConfig, _ *StreamConfig) {
 	}
 
 	// TTLs were added in v2.11 and require API level 1.
-	if cfg.AllowMsgTTL || cfg.SubjectDeleteMarkers {
+	if cfg.AllowMsgTTL || cfg.SubjectDeleteMarkerTTL > 0 {
 		requires(1)
 	}
 

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -973,12 +973,12 @@ func (ms *memStore) cancelAgeChk() {
 // this function returns a callback func to call scb and sdmcb after
 // the lock has been released.
 func (ms *memStore) subjectDeleteMarkerIfNeeded(sm *StoreMsg, reason string) func() {
+	if ms.cfg.SubjectDeleteMarkerTTL <= 0 {
+		return nil
+	}
 	// If the deleted message was itself a delete marker then
 	// don't write out more of them or we'll churn endlessly.
 	if len(getHeader(JSMarkerReason, sm.hdr)) != 0 {
-		return nil
-	}
-	if !ms.cfg.SubjectDeleteMarkers {
 		return nil
 	}
 	if _, ok := ms.fss.Find(stringToBytes(sm.subj)); ok {

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -1194,7 +1194,7 @@ func TestMemStoreSubjectDeleteMarkers(t *testing.T) {
 		&StreamConfig{
 			Name: "zzz", Subjects: []string{"test"}, Storage: MemoryStorage,
 			MaxAge: time.Second, AllowMsgTTL: true,
-			SubjectDeleteMarkers: true, SubjectDeleteMarkerTTL: time.Second,
+			SubjectDeleteMarkerTTL: time.Second,
 		},
 	)
 	require_NoError(t, err)

--- a/server/store.go
+++ b/server/store.go
@@ -70,9 +70,6 @@ var (
 	ErrTooManyResults = errors.New("too many matching results for request")
 )
 
-// Default value for SubjectDeleteMarkerTTL if not specified.
-const subjectDeleteMarkerDefaultTTL = 15 * time.Minute
-
 // StoreMsg is the stored message format for messages that are retained by the Store layer.
 type StoreMsg struct {
 	subj string


### PR DESCRIPTION
Remove the boolean and the default value and preserve only the single TTL configuration option. We also no longer need the pedantic checks anymore either.

Signed-off-by: Neil Twigg <neil@nats.io>