### PR TITLE
[FIXED] Return msg to pool if 429 Too Many Requests

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -4338,6 +4338,7 @@ func (mset *stream) queueInbound(ib *ipQueue[*inMsg], subj, rply string, hdr, ms
 	im := inMsgPool.Get().(*inMsg)
 	im.subj, im.rply, im.hdr, im.msg, im.si, im.mt = subj, rply, hdr, msg, si, mt
 	if _, err := ib.push(im); err != nil {
+		im.returnToPool()
 		mset.srv.RateLimitWarnf("Dropping messages due to excessive stream ingest rate on '%s' > '%s': %s", mset.acc.Name, mset.name(), err)
 		if rply != _EMPTY_ {
 			hdr := []byte("NATS/1.0 429 Too Many Requests\r\n\r\n")


### PR DESCRIPTION
Message was not returned to the pool if there was an error.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
