### PR TITLE
[FIXED] Allow compress after restart

### DIFF
--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -995,7 +995,7 @@ func TestNRGWALEntryWithoutQuorumMustTruncate(t *testing.T) {
 
 			// Simulate leader storing an AppendEntry in WAL but being hard killed before it can propose to its peers.
 			n := rg.leader().node().(*raft)
-			esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true, false)
+			esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
 			entries := []*Entry{newEntry(EntryNormal, esm)}
 			n.Lock()
 			ae := n.buildAppendEntry(entries)
@@ -1066,7 +1066,7 @@ func TestNRGTermNoDecreaseAfterWALReset(t *testing.T) {
 	l.term = 20
 	l.Unlock()
 
-	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true, false)
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 	l.Lock()
 	ae := l.buildAppendEntry(entries)
@@ -1102,7 +1102,7 @@ func TestNRGCatchupDoesNotTruncateUncommittedEntriesWithQuorum(t *testing.T) {
 	defer cleanup()
 
 	// Create a sample entry, the content doesn't matter, just that it's stored.
-	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true, false)
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 
 	nats0 := "S1Nunr6R" // "nats-0"
@@ -1183,7 +1183,7 @@ func TestNRGCatchupCanTruncateMultipleEntriesWithoutQuorum(t *testing.T) {
 	defer cleanup()
 
 	// Create a sample entry, the content doesn't matter, just that it's stored.
-	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true, false)
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 
 	nats0 := "S1Nunr6R" // "nats-0"
@@ -1282,7 +1282,7 @@ func TestNRGCatchupDoesNotTruncateCommittedEntriesDuringRedelivery(t *testing.T)
 	defer cleanup()
 
 	// Create a sample entry, the content doesn't matter, just that it's stored.
-	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true, false)
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 
 	nats0 := "S1Nunr6R" // "nats-0"
@@ -1333,7 +1333,7 @@ func TestNRGCatchupFromNewLeaderWithIncorrectPterm(t *testing.T) {
 	defer cleanup()
 
 	// Create a sample entry, the content doesn't matter, just that it's stored.
-	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true, false)
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 
 	nats0 := "S1Nunr6R" // "nats-0"
@@ -1379,7 +1379,7 @@ func TestNRGDontRemoveSnapshotIfTruncateToApplied(t *testing.T) {
 	defer cleanup()
 
 	// Create a sample entry, the content doesn't matter, just that it's stored.
-	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true, false)
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 
 	nats0 := "S1Nunr6R" // "nats-0"
@@ -1543,7 +1543,7 @@ func TestNRGCancelCatchupWhenDetectingHigherTermDuringVoteRequest(t *testing.T) 
 	defer cleanup()
 
 	// Create a sample entry, the content doesn't matter, just that it's stored.
-	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true, false)
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 
 	nats0 := "S1Nunr6R" // "nats-0"
@@ -1590,7 +1590,7 @@ func TestNRGTruncateDownToCommitted(t *testing.T) {
 	defer cleanup()
 
 	// Create a sample entry, the content doesn't matter, just that it's stored.
-	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true, false)
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 
 	nats0 := "S1Nunr6R" // "nats-0"
@@ -1651,7 +1651,7 @@ func TestNRGTruncateDownToCommittedWhenTruncateFails(t *testing.T) {
 	n.Unlock()
 
 	// Create a sample entry, the content doesn't matter, just that it's stored.
-	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true, false)
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 
 	nats0 := "S1Nunr6R" // "nats-0"
@@ -1716,7 +1716,7 @@ func TestNRGMemoryWALEmptiesSnapshotsDir(t *testing.T) {
 	defer c.shutdown()
 
 	// Create a sample entry, the content doesn't matter, just that it's stored.
-	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true, false)
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 
 	nats0 := "S1Nunr6R" // "nats-0"
@@ -1761,7 +1761,7 @@ func TestNRGHealthCheckWaitForCatchup(t *testing.T) {
 	defer cleanup()
 
 	// Create a sample entry, the content doesn't matter, just that it's stored.
-	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true, false)
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 
 	nats0 := "S1Nunr6R" // "nats-0"
@@ -1820,7 +1820,7 @@ func TestNRGHealthCheckWaitForDoubleCatchup(t *testing.T) {
 	defer cleanup()
 
 	// Create a sample entry, the content doesn't matter, just that it's stored.
-	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true, false)
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 
 	nats0 := "S1Nunr6R" // "nats-0"
@@ -1902,7 +1902,7 @@ func TestNRGHealthCheckWaitForPendingCommitsWhenPaused(t *testing.T) {
 	defer cleanup()
 
 	// Create a sample entry, the content doesn't matter, just that it's stored.
-	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true, false)
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 
 	nats0 := "S1Nunr6R" // "nats-0"

--- a/server/stream.go
+++ b/server/stream.go
@@ -344,20 +344,19 @@ type stream struct {
 
 	// TODO(dlc) - Hide everything below behind two pointers.
 	// Clustered mode.
-	sa         *streamAssignment // What the meta controller uses to assign streams to peers.
-	node       RaftNode          // Our RAFT node for the stream's group.
-	catchup    atomic.Bool       // Used to signal we are in catchup mode.
-	catchups   map[string]uint64 // The number of messages that need to be caught per peer.
-	syncSub    *subscription     // Internal subscription for sync messages (on "$JSC.SYNC").
-	infoSub    *subscription     // Internal subscription for stream info requests.
-	clMu       sync.Mutex        // The mutex for clseq and clfs.
-	clseq      uint64            // The current last seq being proposed to the NRG layer.
-	clfs       uint64            // The count (offset) of the number of failed NRG sequences used to compute clseq.
-	inflight   map[uint64]uint64 // Inflight message sizes per clseq.
-	lqsent     time.Time         // The time at which the last lost quorum advisory was sent. Used to rate limit.
-	uch        chan struct{}     // The channel to signal updates to the monitor routine.
-	compressOK bool              // True if we can do message compression in RAFT and catchup logic
-	inMonitor  bool              // True if the monitor routine has been started.
+	sa        *streamAssignment // What the meta controller uses to assign streams to peers.
+	node      RaftNode          // Our RAFT node for the stream's group.
+	catchup   atomic.Bool       // Used to signal we are in catchup mode.
+	catchups  map[string]uint64 // The number of messages that need to be caught per peer.
+	syncSub   *subscription     // Internal subscription for sync messages (on "$JSC.SYNC").
+	infoSub   *subscription     // Internal subscription for stream info requests.
+	clMu      sync.Mutex        // The mutex for clseq and clfs.
+	clseq     uint64            // The current last seq being proposed to the NRG layer.
+	clfs      uint64            // The count (offset) of the number of failed NRG sequences used to compute clseq.
+	inflight  map[uint64]uint64 // Inflight message sizes per clseq.
+	lqsent    time.Time         // The time at which the last lost quorum advisory was sent. Used to rate limit.
+	uch       chan struct{}     // The channel to signal updates to the monitor routine.
+	inMonitor bool              // True if the monitor routine has been started.
 
 	expectedPerSubjectReady     bool                // Initially blocks 'expected per subject' changes until leader is initially caught up with stored but not applied entries.
 	expectedPerSubjectSequence  map[uint64]string   // Inflight 'expected per subject' subjects per clseq.


### PR DESCRIPTION
A replicated stream can compress the data in proposals/catchup if all servers support it. However, if a stream already exists and the servers restart then compression would not be enabled, even though all servers support it.

This was due to the `compressOK` flag only being set upon becoming leader, which meant that if a quorum of servers comes online and the leader is elected before the final server comes online, compression will not be enabled until there is another leader election.

We could re-calculate `compressOK` when a server comes online, but that could be expensive depending on the amount of servers and streams involved. Since compression has been added in v2.9.0 this means that all supported versions already support compression and there's no need to check. (Only 2.8.4 or earlier don't support it, but those are not supported versions anymore anyway and are ~3 years old at this point) So it's just simpler to clean it up and ensure compression can be used.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>