### PR TITLE
Add filestore permutations to `BenchmarkJetStreamConsumeWithFilters`

### DIFF
--- a/server/jetstream_benchmark_test.go
+++ b/server/jetstream_benchmark_test.go
@@ -424,6 +424,8 @@ func BenchmarkJetStreamConsumeWithFilters(b *testing.B) {
 	}{
 		{1, 1, nats.MemoryStorage},
 		{3, 3, nats.MemoryStorage},
+		{1, 1, nats.FileStorage},
+		{3, 3, nats.FileStorage},
 	}
 
 	benchmarksCases := []struct {


### PR DESCRIPTION
The relevant code for multi-filtered consumers differs considerably between the two stores, so we need to be watching both.

Signed-off-by: Neil Twigg <neil@nats.io>