### PR TITLE
stree: Split `Iter` into `IterFast` and `IterOrdered`

### DIFF
--- a/server/memstore.go
+++ b/server/memstore.go
@@ -102,7 +102,7 @@ func (ms *memStore) UpdateConfig(cfg *StreamConfig) error {
 	// If the value is smaller, or was unset before, we need to enforce that.
 	if ms.maxp > 0 && (maxp == 0 || ms.maxp < maxp) {
 		lm := uint64(ms.maxp)
-		ms.fss.Iter(func(subj []byte, ss *SimpleState) bool {
+		ms.fss.IterFast(func(subj []byte, ss *SimpleState) bool {
 			if ss.Msgs > lm {
 				ms.enforcePerSubjectLimit(bytesToString(subj), ss)
 			}
@@ -1161,7 +1161,7 @@ func (ms *memStore) purge(fseq uint64) (uint64, error) {
 	ms.msgs = make(map[uint64]*StoreMsg)
 	// Subject delete markers if needed.
 	if ms.cfg.SubjectDeleteMarkerTTL > 0 {
-		ms.fss.Iter(func(bsubj []byte, ss *SimpleState) bool {
+		ms.fss.IterOrdered(func(bsubj []byte, ss *SimpleState) bool {
 			ms.markers = append(ms.markers, string(bsubj))
 			return true
 		})
@@ -1231,7 +1231,7 @@ func (ms *memStore) Compact(seq uint64) (uint64, error) {
 		ms.state.LastSeq = seq - 1
 		// Subject delete markers if needed.
 		if ms.cfg.SubjectDeleteMarkerTTL > 0 {
-			ms.fss.Iter(func(bsubj []byte, ss *SimpleState) bool {
+			ms.fss.IterOrdered(func(bsubj []byte, ss *SimpleState) bool {
 				ms.markers = append(ms.markers, string(bsubj))
 				return true
 			})

--- a/server/stree/util.go
+++ b/server/stree/util.go
@@ -55,11 +55,3 @@ func pivot[N position](subject []byte, pos N) byte {
 	}
 	return subject[pos]
 }
-
-// TODO(dlc) - Can be removed with Go 1.21 once server is on Go 1.22.
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
Not all of the `Iter()` call-sites required ordering, and ordering would slow down the process quite a bit, so replace with two new `IterFast()` and `IterOrdered()` functions instead.

This should speed up populating the per-subject infos, multi-filter num pending and enforcing the per-subject limits.

Signed-off-by: Neil Twigg <neil@nats.io>