### PR TITLE
[FIXED] Desync after quit during catchup

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2511,7 +2511,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 					ce.ReturnToPool()
 				} else {
 					// Our stream was closed out from underneath of us, simply return here.
-					if err == errStreamClosed {
+					if err == errStreamClosed || err == errCatchupStreamStopped || err == ErrServerNotRunning {
 						aq.recycle(&ces)
 						return
 					}


### PR DESCRIPTION
If a replica was catching up based on a stream snapshot and it would be incomplete due to the RAFT node/server quitting then there could be desync if there was at least one entry after it that got `n.Applied` and stored in a snapshot upon shutdown.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
