### PR TITLE
[FIXED] Consumer/JS deadlock

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1866,10 +1866,10 @@ func (o *consumer) deleteNotActive() {
 	if o.srv != nil {
 		qch = o.srv.quitCh
 	}
-	if o.js != nil {
-		cqch = o.js.clusterQuitC()
-	}
 	o.mu.Unlock()
+	if js != nil {
+		cqch = js.clusterQuitC()
+	}
 
 	// Useful for pprof.
 	setGoRoutineLabels(pprofLabels{


### PR DESCRIPTION
Lock ordering was violated resulting in a deadlock. Must not hold consumer lock while trying to grab JS lock.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
