### PR TITLE
[IMPROVED] Update nats.go dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nats-io/nats-server/v2
 
-go 1.22
+go 1.22.0
 
 toolchain go1.22.8
 
@@ -10,7 +10,7 @@ require (
 	github.com/klauspost/compress v1.17.11
 	github.com/minio/highwayhash v1.0.3
 	github.com/nats-io/jwt/v2 v2.7.3
-	github.com/nats-io/nats.go v1.36.0
+	github.com/nats-io/nats.go v1.39.0
 	github.com/nats-io/nkeys v0.4.9
 	github.com/nats-io/nuid v1.0.1
 	go.uber.org/automaxprocs v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/minio/highwayhash v1.0.3 h1:kbnuUMoHYyVl7szWjSxJnxw11k2U709jqFPPmIUyD
 github.com/minio/highwayhash v1.0.3/go.mod h1:GGYsuwP/fPD6Y9hMiXuapVvlIUEhFhMTh0rxU3ik1LQ=
 github.com/nats-io/jwt/v2 v2.7.3 h1:6bNPK+FXgBeAqdj4cYQ0F8ViHRbi7woQLq4W29nUAzE=
 github.com/nats-io/jwt/v2 v2.7.3/go.mod h1:GvkcbHhKquj3pkioy5put1wvPxs78UlZ7D/pY+BgZk4=
-github.com/nats-io/nats.go v1.36.0 h1:suEUPuWzTSse/XhESwqLxXGuj8vGRuPRoG7MoRN/qyU=
-github.com/nats-io/nats.go v1.36.0/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF0wkWclB8=
+github.com/nats-io/nats.go v1.39.0 h1:2/yg2JQjiYYKLwDuBzV0FbB2sIV+eFNkEevlRi4n9lI=
+github.com/nats-io/nats.go v1.39.0/go.mod h1:MgRb8oOdigA6cYpEPhXJuRVH6UE/V4jblJ2jQ27IXYM=
 github.com/nats-io/nkeys v0.4.9 h1:qe9Faq2Gxwi6RZnZMXfmGMZkg3afLLOtrU+gDZJ35b0=
 github.com/nats-io/nkeys v0.4.9/go.mod h1:jcMqs+FLG+W5YO36OX6wFIFcmpdAns+w1Wm6D3I/evE=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -3192,6 +3192,6 @@ func TestClientRejectsNRGSubjects(t *testing.T) {
 		require_NoError(t, nc.Publish("$NRG.foo", nil))
 		err = require_ChanRead(t, ech, time.Second)
 		require_Error(t, err)
-		require_True(t, strings.HasPrefix(err.Error(), "nats: Permissions Violation"))
+		require_True(t, strings.HasPrefix(err.Error(), "nats: permissions violation"))
 	})
 }

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -18697,7 +18697,7 @@ func TestJetStreamDirectGetBySubject(t *testing.T) {
 
 	select {
 	case e := <-errCh:
-		if !strings.HasPrefix(e.Error(), "nats: Permissions Violation") {
+		if !strings.HasPrefix(e.Error(), "nats: permissions violation") {
 			t.Fatalf("Expected a permissions violation but got %v", e)
 		}
 	case <-time.After(time.Second):

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -4281,7 +4281,7 @@ func TestJWTLimits(t *testing.T) {
 	t.Run("subs", func(t *testing.T) {
 		creds := createUserWithLimit(t, kp, doNotExpire, func(j *jwt.UserPermissionLimits) { j.Subs = 1 })
 		c := natsConnect(t, sA.ClientURL(), nats.UserCredentials(creds),
-			nats.DisconnectErrHandler(func(conn *nats.Conn, err error) {
+			nats.ErrorHandler(func(conn *nats.Conn, s *nats.Subscription, err error) {
 				if e := conn.LastError(); e != nil && strings.Contains(e.Error(), "maximum subscriptions exceeded") {
 					errChan <- struct{}{}
 				}
@@ -4466,7 +4466,7 @@ func TestJWTLimitsTemplate(t *testing.T) {
 	t.Run("fail", func(t *testing.T) {
 		c := natsConnect(t, sA.ClientURL(), nats.UserCredentials(creds),
 			nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
-				if strings.Contains(err.Error(), `nats: Permissions Violation for Publish to "foo.othername"`) {
+				if strings.Contains(err.Error(), `Permissions Violation for Publish to "foo.othername"`) {
 					errChan <- struct{}{}
 				}
 			}))

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -2085,7 +2085,7 @@ func createClientConnWithUserSubscribeAndPublish(t *testing.T, s *Server, user, 
 	} else {
 		natsURL = fmt.Sprintf("nats://%s:%s@127.0.0.1:%d", user, pwd, s.Addr().(*net.TCPAddr).Port)
 	}
-	client := nats.DefaultOptions
+	client := nats.GetDefaultOptions()
 	client.Servers = []string{natsURL}
 	nc, err := client.Connect()
 	if err != nil {
@@ -2114,7 +2114,7 @@ func createClientConnSubscribeAndPublish(t *testing.T, s *Server) *nats.Conn {
 func createClientConnWithName(t *testing.T, name string, s *Server) *nats.Conn {
 	natsURI := fmt.Sprintf("nats://127.0.0.1:%d", s.Addr().(*net.TCPAddr).Port)
 
-	client := nats.DefaultOptions
+	client := nats.GetDefaultOptions()
 	client.Servers = []string{natsURI}
 	client.Name = name
 	nc, err := client.Connect()

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -66,7 +66,7 @@ func TestTLSConnection(t *testing.T) {
 
 	nc.Publish(subj, []byte("We are Secure!"))
 	nc.Flush()
-	nmsgs, _ := sub.QueuedMsgs()
+	nmsgs, _, _ := sub.Pending()
 	if nmsgs != 1 {
 		t.Fatalf("Expected to receive a message over the TLS connection")
 	}
@@ -1100,7 +1100,7 @@ func TestTLSConnectionCurvePref(t *testing.T) {
 
 	nc.Publish(subj, []byte("We are Secure!"))
 	nc.Flush()
-	nmsgs, _ := sub.QueuedMsgs()
+	nmsgs, _, _ := sub.Pending()
 	if nmsgs != 1 {
 		t.Fatalf("Expected to receive a message over the TLS connection")
 	}


### PR DESCRIPTION
Updated nats.go to v1.39.0.

- https://github.com/nats-io/nats.go/pull/1674
- https://github.com/nats-io/nats.go/pull/1709
  Fixed the connection not being closed on exceeding subs, so using `nats.ErrorHandler` instead of `nats.DisconnectErrHandler`.
- https://github.com/nats-io/nats.go/pull/1728
  Changed `nats: Permissions Violation for ...` to `nats: permissions violation: Permissions Violation for ...`, so `strings.HasPrefix` checks (and others) have been updated.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
