### PR TITLE
Purge requests with no subject delete markers

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -3302,7 +3302,7 @@ func TestFileStorePurgeExKeepOneBug(t *testing.T) {
 			t.Fatalf("Expected to find 2 `A` msgs, got %d", fss.Msgs)
 		}
 
-		n, err := fs.PurgeEx("A", 0, 1)
+		n, err := fs.PurgeEx("A", 0, 1, false)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -3671,7 +3671,7 @@ func TestFileStorePurgeExWithSubject(t *testing.T) {
 		require_NoError(t, err)
 
 		// This should purge all "foo.1"
-		p, err := fs.PurgeEx("foo.1", 1, 0)
+		p, err := fs.PurgeEx("foo.1", 1, 0, false)
 		require_NoError(t, err)
 		require_Equal(t, p, uint64(total))
 
@@ -5048,12 +5048,12 @@ func TestFileStoreKeepWithDeletedMsgsBug(t *testing.T) {
 		fs.StoreMsg("B", nil, msg, 0)
 	}
 
-	n, err := fs.PurgeEx("A", 0, 0)
+	n, err := fs.PurgeEx("A", 0, 0, false)
 	require_NoError(t, err)
 	require_True(t, n == 5)
 
 	// Purge with keep.
-	n, err = fs.PurgeEx(_EMPTY_, 0, 2)
+	n, err = fs.PurgeEx(_EMPTY_, 0, 2, false)
 	require_NoError(t, err)
 	require_True(t, n == 3)
 }
@@ -5445,7 +5445,7 @@ func TestFileStoreFullStatePurge(t *testing.T) {
 			fs.StoreMsg("C", nil, msg, 0)
 		}
 
-		n, err = fs.PurgeEx("B", 0, 0)
+		n, err = fs.PurgeEx("B", 0, 0, false)
 		require_NoError(t, err)
 		require_Equal(t, n, 5)
 
@@ -5462,7 +5462,7 @@ func TestFileStoreFullStatePurge(t *testing.T) {
 		}
 
 		// Purge with keep.
-		n, err = fs.PurgeEx(_EMPTY_, 0, 2)
+		n, err = fs.PurgeEx(_EMPTY_, 0, 2, false)
 		require_NoError(t, err)
 		require_Equal(t, n, 3)
 
@@ -6370,7 +6370,7 @@ func TestFileStorePurgeExBufPool(t *testing.T) {
 		fs.StoreMsg("foo.bar", nil, msg, 0)
 	}
 
-	p, err := fs.PurgeEx("foo.bar", 1, 0)
+	p, err := fs.PurgeEx("foo.bar", 1, 0, false)
 	require_NoError(t, err)
 	require_Equal(t, p, 1000)
 
@@ -6409,7 +6409,7 @@ func TestFileStoreFSSMeta(t *testing.T) {
 	// Let cache's expire before PurgeEx which will load them back in.
 	time.Sleep(250 * time.Millisecond)
 
-	p, err := fs.PurgeEx("A", 1, 0)
+	p, err := fs.PurgeEx("A", 1, 0, false)
 	require_NoError(t, err)
 	require_Equal(t, p, 2)
 
@@ -6827,7 +6827,7 @@ func TestFileStoreWriteFullStateAfterPurgeEx(t *testing.T) {
 	fs.RemoveMsg(9)
 	fs.RemoveMsg(10)
 
-	n, err := fs.PurgeEx(">", 8, 0)
+	n, err := fs.PurgeEx(">", 8, 0, false)
 	require_NoError(t, err)
 	require_Equal(t, n, 7)
 
@@ -7767,7 +7767,7 @@ func TestFileStoreRestoreDeleteTombstonesExceedingMaxBlkSize(t *testing.T) {
 		require_NoError(t, err)
 		defer fs.Stop()
 
-		n, err := fs.PurgeEx(_EMPTY_, 1_000_000_000, 0)
+		n, err := fs.PurgeEx(_EMPTY_, 1_000_000_000, 0, false)
 		require_NoError(t, err)
 		require_Equal(t, n, 0)
 
@@ -8703,7 +8703,7 @@ func TestFileStoreSubjectDeleteMarkersOnPurgeEx(t *testing.T) {
 		require_NoError(t, err)
 	}
 
-	_, err = fs.PurgeEx("test.*", 1, 0)
+	_, err = fs.PurgeEx("test.*", 1, 0, false)
 	require_NoError(t, err)
 
 	for i := uint64(0); i < 10; i++ {

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -503,6 +503,9 @@ type JSApiStreamPurgeRequest struct {
 	Subject string `json:"filter,omitempty"`
 	// Number of messages to keep.
 	Keep uint64 `json:"keep,omitempty"`
+	// NoMarkers ensures that subject delete markers will not be left. If subject delete markers
+	// are not enabled on the stream, then this flag is no-op.
+	NoMarkers bool `json:"no_markers,omitempty"`
 }
 
 type JSApiStreamPurgeResponse struct {

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -449,7 +449,7 @@ func TestMemStorePurgeExWithSubject(t *testing.T) {
 	}
 
 	// This should purge all.
-	ms.PurgeEx("foo", 1, 0)
+	ms.PurgeEx("foo", 1, 0, false)
 	require_True(t, ms.State().Msgs == 0)
 }
 
@@ -1043,7 +1043,7 @@ func TestMemStorePurgeExWithDeletedMsgs(t *testing.T) {
 	ms.RemoveMsg(2)
 	ms.RemoveMsg(9) // This was the bug
 
-	n, err := ms.PurgeEx(_EMPTY_, 9, 0)
+	n, err := ms.PurgeEx(_EMPTY_, 9, 0, true)
 	require_NoError(t, err)
 	require_Equal(t, n, 7)
 
@@ -1275,7 +1275,7 @@ func TestMemStoreSubjectDeleteMarkersOnPurgeEx(t *testing.T) {
 		require_NoError(t, err)
 	}
 
-	_, err = ms.PurgeEx("test.*", 1, 0)
+	_, err = ms.PurgeEx("test.*", 1, 0, false)
 	require_NoError(t, err)
 
 	for i := uint64(0); i < 10; i++ {

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -11326,7 +11326,7 @@ func TestNoRaceStoreReverseWalkWithDeletesPerf(t *testing.T) {
 		require_Equal(t, ss.Msgs, 1_000_002)
 
 		// Create a bunch of interior deletes.
-		p, err := store.PurgeEx("foo.B", 1, 0)
+		p, err := store.PurgeEx("foo.B", 1, 0, true)
 		require_NoError(t, err)
 		require_Equal(t, p, 1_000_000)
 

--- a/server/raft.go
+++ b/server/raft.go
@@ -89,7 +89,7 @@ type WAL interface {
 	RemoveMsg(index uint64) (bool, error)
 	Compact(index uint64) (uint64, error)
 	Purge() (uint64, error)
-	PurgeEx(subject string, seq, keep uint64) (uint64, error)
+	PurgeEx(subject string, seq, keep uint64, noMarkers bool) (uint64, error)
 	Truncate(seq uint64) error
 	State() StreamState
 	FastState(*StreamState)
@@ -3253,7 +3253,7 @@ func (n *raft) truncateWAL(term, index uint64) {
 			n.wal.Truncate(0)
 			// If our index is non-zero use PurgeEx to set us to the correct next index.
 			if index > 0 {
-				n.wal.PurgeEx(fwcs, index+1, 0)
+				n.wal.PurgeEx(fwcs, index+1, 0, true)
 			}
 		} else {
 			n.warn("Error truncating WAL: %v", err)

--- a/server/store.go
+++ b/server/store.go
@@ -100,7 +100,7 @@ type StreamStore interface {
 	RemoveMsg(seq uint64) (bool, error)
 	EraseMsg(seq uint64) (bool, error)
 	Purge() (uint64, error)
-	PurgeEx(subject string, seq, keep uint64) (uint64, error)
+	PurgeEx(subject string, seq, keep uint64, noMarkers bool) (uint64, error)
 	Compact(seq uint64) (uint64, error)
 	Truncate(seq uint64) error
 	GetSeqFromTime(t time.Time) uint64

--- a/server/stream.go
+++ b/server/stream.go
@@ -2212,7 +2212,7 @@ func (mset *stream) purge(preq *JSApiStreamPurgeRequest) (purged uint64, err err
 	mset.mu.RUnlock()
 
 	if preq != nil {
-		purged, err = mset.store.PurgeEx(preq.Subject, preq.Sequence, preq.Keep)
+		purged, err = mset.store.PurgeEx(preq.Subject, preq.Sequence, preq.Keep, preq.NoMarkers)
 	} else {
 		purged, err = mset.store.Purge()
 	}
@@ -2944,7 +2944,7 @@ func (mset *stream) setupMirrorConsumer() error {
 					// Check to see if delivered is past our last and we have no msgs. This will help the
 					// case when mirroring a stream that has a very high starting sequence number.
 					if state.Msgs == 0 && ccr.ConsumerInfo.Delivered.Stream > state.LastSeq {
-						mset.store.PurgeEx(_EMPTY_, ccr.ConsumerInfo.Delivered.Stream+1, 0)
+						mset.store.PurgeEx(_EMPTY_, ccr.ConsumerInfo.Delivered.Stream+1, 0, true)
 						mset.lseq = ccr.ConsumerInfo.Delivered.Stream
 					} else {
 						mset.skipMsgs(state.LastSeq+1, ccr.ConsumerInfo.Delivered.Stream)


### PR DESCRIPTION
As per [the ADR](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-43.md#purge-api-call-marker), this adds the `no_markers` flag to the JS API stream purge request, such that a stream can be purged without leaving behind any subject delete markers, if they are enabled.

This helps to avoid the "poison pill" problem if there are subjects for example that are causing problems with a consuming application.

Individual message deletes are less of a concern here because a single message delete will leave behind at most one marker, which can be deleted too (and would not be replaced in that case), but a purge can potentially leave behind lots of markers for lots of subjects, which could be difficult to sort through by hand otherwise.

Signed-off-by: Neil Twigg <neil@nats.io>
