### PR TITLE
Apply client write deadline to batches rather than total flushes

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1642,8 +1642,10 @@ func (c *client) flushOutbound() bool {
 		}
 		consumed := len(wnb)
 
-		// Actual write to the socket.
-		nc.SetWriteDeadline(start.Add(wdl))
+		// Actual write to the socket. The deadline applies to each batch
+		// rather than the total write, such that the configured deadline
+		// can be tuned to a known maximum quantity (64MB).
+		nc.SetWriteDeadline(time.Now().Add(wdl))
 		wn, err = wnb.WriteTo(nc)
 		nc.SetWriteDeadline(time.Time{})
 


### PR DESCRIPTION
By calculating the write deadline at the beginning of the flush operation, we could be hitting it early if there is a lot of data queued up. Instead this PR applies it to each `writev` batch of at most 1024 vectors, which means that the deadline applies to no more than 64MB in one go.

This makes it simpler to tune the write deadline as it can be thought of as "the maximum time taken to allow writing at most 64MB" instead.

Signed-off-by: Neil Twigg <neil@nats.io>