### PR TITLE
Account for replicated msgs in user account.

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3552,7 +3552,8 @@ func (c *client) deliverMsg(prodIsMQTT bool, sub *subscription, acc *Account, su
 
 	// We do not update the outbound stats if we are doing trace only since
 	// this message will not be sent out.
-	if !traceOnly {
+	// Also do not update on internal callbacks.
+	if !traceOnly && sub.icb == nil {
 		// No atomic needed since accessed under client lock.
 		// Monitor is reading those also under client's lock.
 		client.outMsgs++

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8224,6 +8224,12 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	err := node.Propose(esm)
 	if err == nil {
 		mset.clseq++
+		// If we are using the system account for NRG, add in the extra sent msgs and bytes to our account
+		// so that the end user / account owner has visibility.
+		if node.IsSystemAccount() && mset.acc != nil && r > 1 {
+			atomic.AddInt64(&mset.acc.outMsgs, int64(r-1))
+			atomic.AddInt64(&mset.acc.outBytes, int64(len(esm)*(r-1)))
+		}
 	}
 
 	// Check to see if we are being overrun.

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -7532,6 +7532,61 @@ func TestJetStreamClusterStuckConsumerAfterLeaderChangeWithUnknownDeliveries(t *
 	require_Equal(t, ci.AckFloor.Stream, 3)
 }
 
+// This is for when we are still using $SYS for NRG replication but we want to make sure
+// we track this in something visible to the end user.
+func TestJetStreamClusterAccountStatsForReplicatedStreams(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R5S", 5)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 5,
+	})
+	require_NoError(t, err)
+
+	// Let's connect to stream leader to make sent messages predictable, otherwise we get those to come up based on routing to stream leader.
+	s := c.streamLeader(globalAccountName, "TEST")
+	require_True(t, s != nil)
+
+	nc, js = jsClientConnect(t, s)
+	defer nc.Close()
+
+	// NRG traffic can be compressed, so make this unique so we can check stats correctly.
+	msg := make([]byte, 1024*1024)
+	crand.Read(msg)
+
+	// Publish some messages into the stream.
+	for i := 0; i < 10; i++ {
+		_, err = js.Publish("foo", msg)
+		require_NoError(t, err)
+	}
+	time.Sleep(250 * time.Millisecond)
+
+	// Now grab the account stats for us and make sure we account for the replicated messages.
+
+	// Opts to grab our account.
+	opts := &AccountStatzOptions{
+		Accounts: []string{globalAccountName},
+	}
+	as, err := s.AccountStatz(opts)
+	require_NoError(t, err)
+	require_Equal(t, len(as.Accounts), 1)
+
+	accStats := as.Accounts[0]
+
+	// We need to account for possibility that the stream create was also on this server, hence the >= vs strict ==.
+	require_True(t, accStats.Received.Msgs >= 10)
+	require_True(t, accStats.Received.Bytes >= 1024*1204)
+	// For sent, we will have 10 pub acks, and then should have 40 extra messages that are sent and accounted for
+	// during the nrg propsal to the R5 peers.
+	require_True(t, accStats.Sent.Msgs >= 50)
+	require_True(t, accStats.Sent.Bytes >= accStats.Received.Bytes*4)
+}
+
 //
 // DO NOT ADD NEW TESTS IN THIS FILE (unless to balance test times)
 // Add at the end of jetstream_cluster_<n>_test.go, with <n> being the highest value.

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2303,7 +2303,7 @@ type AccountStatz struct {
 	Accounts []*AccountStat `json:"account_statz"`
 }
 
-// LeafzOptions are options passed to Leafz
+// AccountStatzOptions are options passed to account stats requests.
 type AccountStatzOptions struct {
 	Accounts      []string `json:"accounts"`
 	IncludeUnused bool     `json:"include_unused"`


### PR DESCRIPTION
When replicating messages over NRGs that still use the system account, make sure to add in to account stats the sent msgs and bytes to replicate.

Signed-off-by: Derek Collison <derek@nats.io>
