### PR TITLE
[FIXED] Stream/consumer limit reached edge conditions

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -2205,14 +2205,11 @@ func (jsa *jsAccount) selectLimits(replicas int) (JetStreamAccountLimits, string
 }
 
 // Lock should be held.
-func (jsa *jsAccount) countStreams(tier string, cfg *StreamConfig) int {
-	streams := len(jsa.streams)
-	if tier != _EMPTY_ {
-		streams = 0
-		for _, sa := range jsa.streams {
-			if isSameTier(&sa.cfg, cfg) {
-				streams++
-			}
+func (jsa *jsAccount) countStreams(tier string, cfg *StreamConfig) (streams int) {
+	for _, sa := range jsa.streams {
+		// Don't count the stream toward the limit if it already exists.
+		if (tier == _EMPTY_ || isSameTier(&sa.cfg, cfg)) && sa.cfg.Name != cfg.Name {
+			streams++
 		}
 	}
 	return streams

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -6052,15 +6052,16 @@ func groupName(prefix string, peers []string, storage StorageType) string {
 	return fmt.Sprintf("%s-R%d%s-%s", prefix, len(peers), storage.String()[:1], gns)
 }
 
-// returns stream count for this tier as well as applicable reservation size (not including reservations for cfg)
+// returns stream count for this tier as well as applicable reservation size (not including cfg)
 // jetStream read lock should be held
 func tieredStreamAndReservationCount(asa map[string]*streamAssignment, tier string, cfg *StreamConfig) (int, int64) {
 	var numStreams int
 	var reservation int64
 	for _, sa := range asa {
-		if tier == _EMPTY_ || isSameTier(sa.Config, cfg) {
+		// Don't count the stream toward the limit if it already exists.
+		if (tier == _EMPTY_ || isSameTier(sa.Config, cfg)) && sa.Config.Name != cfg.Name {
 			numStreams++
-			if sa.Config.MaxBytes > 0 && sa.Config.Storage == cfg.Storage && sa.Config.Name != cfg.Name {
+			if sa.Config.MaxBytes > 0 && sa.Config.Storage == cfg.Storage {
 				// If tier is empty, all storage is flat and we should adjust for replicas.
 				// Otherwise if tiered, storage replication already taken into consideration.
 				if tier == _EMPTY_ && cfg.Replicas > 1 {
@@ -7394,13 +7395,11 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 			// Don't count DIRECTS.
 			total := 0
 			for cn, ca := range sa.consumers {
-				if action == ActionCreateOrUpdate {
-					// If the consumer name is specified and we think it already exists, then
-					// we're likely updating an existing consumer, so don't count it. Otherwise
-					// we will incorrectly return NewJSMaximumConsumersLimitError for an update.
-					if oname != _EMPTY_ && cn == oname && sa.consumers[oname] != nil {
-						continue
-					}
+				// If the consumer name is specified and we think it already exists, then
+				// we're likely updating an existing consumer, so don't count it. Otherwise
+				// we will incorrectly return NewJSMaximumConsumersLimitError for an update.
+				if oname != _EMPTY_ && cn == oname && sa.consumers[oname] != nil {
+					continue
 				}
 				if ca.Config != nil && !ca.Config.Direct {
 					total++

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -3084,7 +3084,7 @@ func TestJetStreamClusterAccountInfoAndLimits(t *testing.T) {
 			MaxMemory:    1024,
 			MaxStore:     8000,
 			MaxStreams:   3,
-			MaxConsumers: 1,
+			MaxConsumers: 2,
 		},
 	})
 
@@ -3099,6 +3099,11 @@ func TestJetStreamClusterAccountInfoAndLimits(t *testing.T) {
 	if _, err := js.AddStream(&nats.StreamConfig{Name: "bar", Replicas: 2}); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+	if _, err := js.AddStream(&nats.StreamConfig{Name: "baz", Replicas: 3}); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Create with same config is idempotent, and must not exceed max streams as it already exists.
 	if _, err := js.AddStream(&nats.StreamConfig{Name: "baz", Replicas: 3}); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -3159,6 +3164,31 @@ func TestJetStreamClusterAccountInfoAndLimits(t *testing.T) {
 	_, err := js.AddConsumer("foo", &nats.ConsumerConfig{Durable: "dlc", AckPolicy: nats.AckExplicitPolicy})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Create (with explicit create API) for the same consumer must be idempotent, and not trigger limit.
+	obsReq := CreateConsumerRequest{
+		Stream: "foo",
+		Config: ConsumerConfig{Durable: "bar"},
+		Action: ActionCreate,
+	}
+	req, err := json.Marshal(obsReq)
+	require_NoError(t, err)
+
+	msg, err := nc.Request(fmt.Sprintf(JSApiDurableCreateT, "foo", "bar"), req, time.Second)
+	require_NoError(t, err)
+	var resp JSApiConsumerInfoResponse
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	if resp.Error != nil {
+		t.Fatalf("Unexpected error: %v", resp.Error)
+	}
+
+	msg, err = nc.Request(fmt.Sprintf(JSApiDurableCreateT, "foo", "bar"), req, time.Second)
+	require_NoError(t, err)
+	var resp2 JSApiConsumerInfoResponse
+	require_NoError(t, json.Unmarshal(msg.Data, &resp2))
+	if resp2.Error != nil {
+		t.Fatalf("Unexpected error: %v", resp2.Error)
 	}
 
 	// This should fail.

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -921,23 +921,54 @@ func TestJetStreamMaxConsumers(t *testing.T) {
 		Name:         "MAXC",
 		Storage:      nats.MemoryStorage,
 		Subjects:     []string{"in.maxc.>"},
-		MaxConsumers: 1,
+		MaxConsumers: 2,
 	}
 	if _, err := js.AddStream(cfg); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	si, err := js.StreamInfo("MAXC")
 	require_NoError(t, err)
-	if si.Config.MaxConsumers != 1 {
-		t.Fatalf("Expected max of 1, got %d", si.Config.MaxConsumers)
+	if si.Config.MaxConsumers != 2 {
+		t.Fatalf("Expected max of 2, got %d", si.Config.MaxConsumers)
 	}
 	// Make sure we get the right error.
 	// This should succeed.
-	if _, err := js.SubscribeSync("in.maxc.foo"); err != nil {
+	if _, err := js.PullSubscribe("in.maxc.foo", "maxc_foo"); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+	// Create for the same consumer must be idempotent, and not trigger limit.
+	if _, err := js.PullSubscribe("in.maxc.foo", "maxc_foo"); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Create (with explicit create API) for the same consumer must be idempotent, and not trigger limit.
+	obsReq := CreateConsumerRequest{
+		Stream: "MAXC",
+		Config: ConsumerConfig{Durable: "maxc_baz"},
+		Action: ActionCreate,
+	}
+	req, err := json.Marshal(obsReq)
+	require_NoError(t, err)
+
+	msg, err := nc.Request(fmt.Sprintf(JSApiDurableCreateT, "MAXC", "maxc_baz"), req, time.Second)
+	require_NoError(t, err)
+	var resp JSApiConsumerInfoResponse
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	if resp.Error != nil {
+		t.Fatalf("Unexpected error: %v", resp.Error)
+	}
+
+	msg, err = nc.Request(fmt.Sprintf(JSApiDurableCreateT, "MAXC", "maxc_baz"), req, time.Second)
+	require_NoError(t, err)
+	var resp2 JSApiConsumerInfoResponse
+	require_NoError(t, json.Unmarshal(msg.Data, &resp2))
+	if resp2.Error != nil {
+		t.Fatalf("Unexpected error: %v", resp2.Error)
+	}
+
+	// Exceeds limit.
 	if _, err := js.SubscribeSync("in.maxc.bar"); err == nil {
-		t.Fatalf("Eexpected error but got none")
+		t.Fatalf("Expected error but got none")
 	}
 }
 
@@ -6762,20 +6793,22 @@ func TestJetStreamStreamLimitUpdate(t *testing.T) {
 	defer nc.Close()
 
 	for _, storage := range []nats.StorageType{nats.MemoryStorage, nats.FileStorage} {
-		_, err = js.AddStream(&nats.StreamConfig{
+		cfg := &nats.StreamConfig{
 			Name:     "TEST",
 			Subjects: []string{"foo"},
 			Storage:  storage,
 			MaxBytes: 32,
-		})
+		}
+
+		_, err = js.AddStream(cfg)
 		require_NoError(t, err)
 
-		_, err = js.UpdateStream(&nats.StreamConfig{
-			Name:     "TEST",
-			Subjects: []string{"foo"},
-			Storage:  storage,
-			MaxBytes: 16,
-		})
+		// Create with same config is idempotent, and must not exceed max streams as it already exists.
+		_, err = js.AddStream(cfg)
+		require_NoError(t, err)
+
+		cfg.MaxBytes = 16
+		_, err = js.UpdateStream(cfg)
 		require_NoError(t, err)
 
 		require_NoError(t, js.DeleteStream("TEST"))


### PR DESCRIPTION
Using `MaxStreams` and `MaxConsumers` you can limit the amount of streams, and the amount of consumers on a specific stream.

There were some edge conditions where stream/consumer creates would fail with a "limit reached" error which have been fixed in this PR:
- non-clustered create of a stream that already exists when at limit
- clustered create of a stream that already exists when at limit
- clustered create of a consumer that already exists when at limit

In above cases the accounting would think an additional stream/consumer would be added which would exceed the limit, even though this was not the case and the request should have been successful.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
