### PR TITLE
NRG (2.11): Completeness/consistency after leader changes

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -358,7 +358,6 @@ type stream struct {
 	uch       chan struct{}     // The channel to signal updates to the monitor routine.
 	inMonitor bool              // True if the monitor routine has been started.
 
-	expectedPerSubjectReady     bool                // Initially blocks 'expected per subject' changes until leader is initially caught up with stored but not applied entries.
 	expectedPerSubjectSequence  map[uint64]string   // Inflight 'expected per subject' subjects per clseq.
 	expectedPerSubjectInProcess map[string]struct{} // Current 'expected per subject' subjects in process.
 


### PR DESCRIPTION
Previously https://github.com/nats-io/nats-server/pull/6194 implemented a way to wait for entries that are stored in the new leader's log but not yet applied, before allowing 'expected per subject' operations to go through. This protected against KV/stream desync.

That protection is now extended to the whole of (clustered) JetStream, and not specific to this one operation anymore. Meaning that if the new leader recognizes it has entries in its log that have not yet been applied, it waits for those to be applied before responding to any read/write operations. In essence it's the 'Leader Completeness Property' as described by the Raft paper. This also brings us closer to 'read-your-writes' when only requesting reads from the leader.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>