### PR TITLE
[FIXED] (2.11) Clear inflight dedupe IDs on leader change

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -265,7 +265,6 @@ const (
 	JetStreamEnabled     ServerCapability = 1 << iota // Server had JetStream enabled.
 	BinaryStreamSnapshot                              // New stream snapshot capability.
 	AccountNRG                                        // Move NRG traffic out of system account.
-	DeferClusteredDedupe                              // Defer de-duplication to replicas under certain conditions.
 )
 
 // Set JetStream capability.
@@ -300,17 +299,6 @@ func (si *ServerInfo) SetAccountNRG() {
 // system account and into the asset account.
 func (si *ServerInfo) AccountNRG() bool {
 	return si.Flags&AccountNRG != 0
-}
-
-// Set deferred clustered dedupe capability.
-func (si *ServerInfo) SetDeferClusteredDedupe() {
-	si.Flags |= DeferClusteredDedupe
-}
-
-// DeferClusteredDedupe indicates whether we support deferring de-duplication
-// of multiple inflight messages with the same ID to replicas.
-func (si *ServerInfo) DeferClusteredDedupe() bool {
-	return si.Flags&DeferClusteredDedupe != 0
 }
 
 // ClientInfo is detailed information about the client forming a connection.
@@ -539,7 +527,6 @@ RESET:
 						if s.accountNRGAllowed.Load() {
 							si.SetAccountNRG()
 						}
-						si.SetDeferClusteredDedupe()
 					}
 				}
 				var b []byte
@@ -1712,7 +1699,6 @@ func (s *Server) remoteServerUpdate(sub *subscription, c *client, _ *Account, su
 		si.JetStreamEnabled(),
 		si.BinaryStreamSnapshot(),
 		accountNRG,
-		si.DeferClusteredDedupe(),
 	})
 	if oldInfo == nil || accountNRG != oldInfo.(nodeInfo).accountNRG {
 		// One of the servers we received statsz from changed its mind about
@@ -1767,7 +1753,6 @@ func (s *Server) processNewServer(si *ServerInfo) {
 				si.JetStreamEnabled(),
 				si.BinaryStreamSnapshot(),
 				si.AccountNRG(),
-				si.DeferClusteredDedupe(),
 			})
 		}
 	}

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -3200,7 +3200,9 @@ func TestJetStreamClusterPubAckSequenceDupe(t *testing.T) {
 		require_NoError(t, err)
 		require_Equal(t, seq, pubAck2.Sequence)
 		require_True(t, pubAck2.Duplicate)
+
 	}
+
 }
 
 func TestJetStreamClusterPubAckSequenceDupeAsync(t *testing.T) {
@@ -3224,6 +3226,7 @@ func TestJetStreamClusterPubAckSequenceDupeAsync(t *testing.T) {
 
 		msgSubject := "TEST_SUBJECT"
 		msgIdOpt := nats.MsgId(nuid.Next())
+		conflictErr := &nats.APIError{ErrorCode: nats.ErrorCode(JSStreamDuplicateMessageConflict)}
 
 		wg := sync.WaitGroup{}
 		wg.Add(2)
@@ -3238,6 +3241,11 @@ func TestJetStreamClusterPubAckSequenceDupeAsync(t *testing.T) {
 				defer wg.Done()
 				var err error
 				pubAcks[i], err = js.Publish(msgSubject, msgData, msgIdOpt)
+				// Conflict on duplicate message, wait a bit before retrying to get the proper pubAck.
+				if errors.Is(err, conflictErr) {
+					time.Sleep(time.Millisecond * 500)
+					pubAcks[i], err = js.Publish(msgSubject, msgData, msgIdOpt)
+				}
 				require_NoError(t, err)
 			}(i)
 		}
@@ -3249,55 +3257,6 @@ func TestJetStreamClusterPubAckSequenceDupeAsync(t *testing.T) {
 		// Exactly one of the pubAck should be marked dupe
 		require_True(t, (pubAcks[0].Duplicate || pubAcks[1].Duplicate) && (pubAcks[0].Duplicate != pubAcks[1].Duplicate))
 	}
-}
-
-func TestJetStreamClusterPubAckSequenceDupeDeterministic(t *testing.T) {
-	c := createJetStreamClusterExplicit(t, "R3S", 3)
-	defer c.shutdown()
-
-	nc, js := jsClientConnect(t, c.randomServer())
-	defer nc.Close()
-
-	duplicates := 2 * time.Minute
-	_, err := js.AddStream(&nats.StreamConfig{
-		Name:       "TEST",
-		Subjects:   []string{"foo"},
-		Replicas:   3,
-		Duplicates: duplicates,
-	})
-	require_NoError(t, err)
-
-	sl := c.streamLeader(globalAccountName, "TEST")
-	acc, err := sl.lookupAccount(globalAccountName)
-	require_NoError(t, err)
-	mset, err := acc.lookupStream("TEST")
-	require_NoError(t, err)
-
-	baseTs := time.Now().Add(-time.Hour)
-	ts := baseTs.UnixNano()
-	hdr := []byte("NATS/1.0\r\nNats-Msg-Id: msgId\r\n\r\n")
-
-	// First message is stored.
-	err = mset.processJetStreamMsg("foo", _EMPTY_, hdr, nil, 0, ts, nil, false)
-	require_NoError(t, err)
-
-	// Second message sent at the same time is de-duped.
-	err = mset.processJetStreamMsg("foo", _EMPTY_, hdr, nil, 1, ts, nil, false)
-	require_Error(t, err, errMsgIdDuplicate)
-
-	// Third message is also de-duped.
-	ts = baseTs.Add(duplicates).Add(-time.Nanosecond).UnixNano()
-	err = mset.processJetStreamMsg("foo", _EMPTY_, hdr, nil, 2, ts, nil, false)
-	require_Error(t, err, errMsgIdDuplicate)
-
-	// Fourth message is exactly at the dupe window, must be accepted.
-	ts = baseTs.Add(duplicates).UnixNano()
-	err = mset.processJetStreamMsg("foo", _EMPTY_, hdr, nil, 3, ts, nil, false)
-	require_NoError(t, err)
-
-	// Also confirm the leader can allow a message to go through, even if the purging timer hasn't cleaned it up yet.
-	err = mset.processClusteredInboundMsg("foo", _EMPTY_, hdr, nil, nil, false)
-	require_NoError(t, err)
 }
 
 func TestJetStreamClusterConsumeWithStartSequence(t *testing.T) {

--- a/server/route.go
+++ b/server/route.go
@@ -2272,7 +2272,7 @@ func (s *Server) addRoute(c *client, didSolicit, sendDelayedInfo bool, gossipMod
 			// check to be consistent and future proof. but will be same domain
 			if s.sameDomain(info.Domain) {
 				s.nodeToInfo.Store(rHash,
-					nodeInfo{rn, s.info.Version, s.info.Cluster, info.Domain, id, nil, nil, nil, false, info.JetStream, false, false, false})
+					nodeInfo{rn, s.info.Version, s.info.Cluster, info.Domain, id, nil, nil, nil, false, info.JetStream, false, false})
 			}
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -387,7 +387,6 @@ type nodeInfo struct {
 	js              bool
 	binarySnapshots bool
 	accountNRG      bool
-	deferDedupe     bool
 }
 
 // Make sure all are 64bits for atomic use
@@ -788,7 +787,7 @@ func NewServer(opts *Options) (*Server, error) {
 			opts.Tags,
 			&JetStreamConfig{MaxMemory: opts.JetStreamMaxMemory, MaxStore: opts.JetStreamMaxStore, CompressOK: true},
 			nil,
-			false, true, true, true, true,
+			false, true, true, true,
 		})
 	}
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -4897,7 +4897,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 			if isClustered {
 				mset.purgeMsgIdsAtLocked(ts)
 			}
-			if dde := mset.checkMsgId(msgId); dde != nil && dde.seq > 0 {
+			if dde := mset.checkMsgId(msgId); dde != nil {
 				mset.mu.Unlock()
 				bumpCLFS()
 				if canRespond {
@@ -5208,11 +5208,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 
 	// If we have a msgId make sure to save.
 	if msgId != _EMPTY_ {
-		if dde := mset.ddmap[msgId]; dde != nil {
-			dde.seq, dde.ts = seq, ts
-		} else {
-			mset.storeMsgIdLocked(&ddentry{msgId, seq, ts})
-		}
+		mset.storeMsgIdLocked(&ddentry{msgId, seq, ts})
 	}
 
 	// If here we succeeded in storing the message.

--- a/server/stream.go
+++ b/server/stream.go
@@ -4166,17 +4166,24 @@ func (mset *stream) purgeMsgIds() {
 	mset.mu.Lock()
 	defer mset.mu.Unlock()
 
-	now := time.Now()
-	// If clustered we must ensure all servers agree on which message is marked as a duplicate.
-	// But, since the de-dupe map is time-dependent we must take into account clock skew/ordering guarantees.
-	// For example a replica clearing the de-dupe map earlier than the leader would, could result in desync,
-	// so deliberately delay replicas from cleaning up before the leader is likely to.
-	// processJetStreamMsg/processClusteredInboundMsg are both aware of this timer, and they clean up inline if necessary.
-	if mset.isClustered() {
-		now = now.Add(-5 * time.Second)
-	}
-	tmrNext := mset.purgeMsgIdsAtLocked(now.UnixNano())
+	now := time.Now().UnixNano()
+	tmrNext := mset.cfg.Duplicates
+	window := int64(tmrNext)
 
+	for i, dde := range mset.ddarr[mset.ddindex:] {
+		if now-dde.ts >= window {
+			delete(mset.ddmap, dde.id)
+		} else {
+			mset.ddindex += i
+			// Check if we should garbage collect here if we are 1/3 total size.
+			if cap(mset.ddarr) > 3*(len(mset.ddarr)-mset.ddindex) {
+				mset.ddarr = append([]*ddentry(nil), mset.ddarr[mset.ddindex:]...)
+				mset.ddindex = 0
+			}
+			tmrNext = time.Duration(window - (now - dde.ts))
+			break
+		}
+	}
 	if len(mset.ddmap) > 0 {
 		// Make sure to not fire too quick
 		const minFire = 50 * time.Millisecond
@@ -4197,29 +4204,6 @@ func (mset *stream) purgeMsgIds() {
 		mset.ddarr = nil
 		mset.ddindex = 0
 	}
-}
-
-// Will purge the entries that are past the window given a specific ts.
-// Lock should be held.
-func (mset *stream) purgeMsgIdsAtLocked(ts int64) time.Duration {
-	tmrNext := mset.cfg.Duplicates
-	window := int64(tmrNext)
-
-	for i, dde := range mset.ddarr[mset.ddindex:] {
-		if ts-dde.ts >= window {
-			delete(mset.ddmap, dde.id)
-		} else {
-			mset.ddindex += i
-			// Check if we should garbage collect here if we are 1/3 total size.
-			if cap(mset.ddarr) > 3*(len(mset.ddarr)-mset.ddindex) {
-				mset.ddarr = append([]*ddentry(nil), mset.ddarr[mset.ddindex:]...)
-				mset.ddindex = 0
-			}
-			tmrNext = time.Duration(window - (ts - dde.ts))
-			break
-		}
-	}
-	return tmrNext
 }
 
 // storeMsgIdLocked will store the message id for duplicate detection.
@@ -4889,23 +4873,21 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 			return errMsgTTLDisabled
 		}
 
-		// Dedupe detection. This is done at the cluster level for dedupe detection above the
-		// lower layers. But not while the message is not applied yet, so we need to still check if
-		// multiple messages with the same ID are proposed at the same time and block here.
+		// Dedupe detection. This is done at the cluster level for dedupe detectiom above the
+		// lower layers. But we still need to pull out the msgId.
 		if msgId = getMsgId(hdr); msgId != _EMPTY_ {
-			// If clustered we know the timestamp, so deterministically try to purge.
-			if isClustered {
-				mset.purgeMsgIdsAtLocked(ts)
-			}
-			if dde := mset.checkMsgId(msgId); dde != nil {
-				mset.mu.Unlock()
-				bumpCLFS()
-				if canRespond {
-					response := append(pubAck, strconv.FormatUint(dde.seq, 10)...)
-					response = append(response, ",\"duplicate\": true}"...)
-					outq.sendMsg(reply, response)
+			// Do real check only if not clustered or traceOnly flag is set.
+			if !isClustered || traceOnly {
+				if dde := mset.checkMsgId(msgId); dde != nil {
+					mset.mu.Unlock()
+					bumpCLFS()
+					if canRespond {
+						response := append(pubAck, strconv.FormatUint(dde.seq, 10)...)
+						response = append(response, ",\"duplicate\": true}"...)
+						outq.sendMsg(reply, response)
+					}
+					return errMsgIdDuplicate
 				}
-				return errMsgIdDuplicate
 			}
 		}
 
@@ -5207,8 +5189,18 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 	}
 
 	// If we have a msgId make sure to save.
+	// This will replace our estimate from the cluster layer if we are clustered.
 	if msgId != _EMPTY_ {
-		mset.storeMsgIdLocked(&ddentry{msgId, seq, ts})
+		if isClustered && isLeader && mset.ddmap != nil {
+			if dde := mset.ddmap[msgId]; dde != nil {
+				dde.seq, dde.ts = seq, ts
+			} else {
+				mset.storeMsgIdLocked(&ddentry{msgId, seq, ts})
+			}
+		} else {
+			// R1 or not leader..
+			mset.storeMsgIdLocked(&ddentry{msgId, seq, ts})
+		}
 	}
 
 	// If here we succeeded in storing the message.


### PR DESCRIPTION
Reverts https://github.com/nats-io/nats-server/pull/6415 and https://github.com/nats-io/nats-server/pull/6426. If duplication would be deferred to be done by a replica, and that replica was down for at least 'dupe window+5s', and it would clean up the dedupe map. A message that was meant to be duplicate could be passed as a genuine message, resulting in stream desync.

Instead, the dedupe map should be cleared of any staged zero-sequences. However, that was not possible before as a new leader would not always be fully up-to-date when it starts responding to new write requests, which could result in duplicate messages as well.

However, relying on the 'Leader Completeness Property' implemented here: https://github.com/nats-io/nats-server/pull/6485, we can confidently clear the dedupe map now of any staged zero-sequences (knowing they were not proposed). Ensuring both there's no desync, and a failed proposal for a message would not block subsequent messages with the same dedupe ID.

Have left the commits as separate, to ease reviewing.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>