### PR TITLE
[FIXED] Auth-Callout: Allow username-password/token in Leaf remote URL.

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -615,8 +615,8 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 		// Check config-mode. The global account is a condition since users that
 		// are not found in the config are implicitly bound to the global account.
 		// This means those users should be implicitly delegated to auth callout
-		// if configured.
-		if juc == nil && opts.AuthCallout != nil && c.acc.Name != globalAccountName {
+		// if configured. Exclude LEAF connections from this check.
+		if c.kind != LEAF && juc == nil && opts.AuthCallout != nil && c.acc.Name != globalAccountName {
 			// If no allowed accounts are defined, then all accounts are in scope.
 			// Otherwise see if the account is in the list.
 			delegated := len(opts.AuthCallout.AllowedAccounts) == 0


### PR DESCRIPTION
If a username and password is provided in a leaf remote URL, as such:
```
leafnodes {
   remotes [
     {url: "nats://leaf:pwd@hub_host:7422"
   ]
```
or a authorization token, as such:
```
leafnodes {
   remotes [
     {url: "nats://myToken@hub_host:7422"
   ]
```
and if the server uses authorization callout, it will be possible to authenticate such leafnode, in either server configuration or operator mode.

Resolves #6481

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
