### PR TITLE
[ADDED] Option that disables fast producer stalling (drops msg instead)

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -3586,6 +3586,11 @@ func (c *client) deliverMsg(prodIsMQTT bool, sub *subscription, acc *Account, su
 	// sending to is in a stalled state, go ahead and wait here
 	// with a limit.
 	if c.kind == CLIENT && client.out.stc != nil {
+		if srv.getOpts().NoFastProducerStall {
+			mt.addEgressEvent(client, sub, errMsgTraceFastProdNoStall)
+			client.mu.Unlock()
+			return false
+		}
 		client.stalledWait(c)
 	}
 

--- a/server/msgtrace.go
+++ b/server/msgtrace.go
@@ -244,6 +244,7 @@ const (
 	errMsgTraceSubClosed       = "Not delivered because subscription is closed"
 	errMsgTraceClientClosed    = "Not delivered because client is closed"
 	errMsgTraceAutoSubExceeded = "Not delivered because auto-unsubscribe exceeded"
+	errMsgTraceFastProdNoStall = "Not delivered because fast producer not stalled and consumer is slow"
 )
 
 type msgTrace struct {

--- a/server/opts.go
+++ b/server/opts.go
@@ -320,6 +320,7 @@ type Options struct {
 	MaxControlLine             int32         `json:"max_control_line"`
 	MaxPayload                 int32         `json:"max_payload"`
 	MaxPending                 int64         `json:"max_pending"`
+	NoFastProducerStall        bool          `json:"-"`
 	Cluster                    ClusterOpts   `json:"cluster,omitempty"`
 	Gateway                    GatewayOpts   `json:"gateway,omitempty"`
 	LeafNode                   LeafNodeOpts  `json:"leaf,omitempty"`
@@ -1674,6 +1675,8 @@ func (o *Options) processConfigFileLine(k string, v any, errors *[]error, warnin
 			*errors = append(*errors, err)
 			return
 		}
+	case "no_fast_producer_stall":
+		o.NoFastProducerStall = v.(bool)
 	default:
 		if au := atomic.LoadInt32(&allowUnknownTopLevelField); au == 0 && !tk.IsUsedVariable() {
 			err := &unknownConfigFieldErr{

--- a/server/reload.go
+++ b/server/reload.go
@@ -917,6 +917,19 @@ func (l *leafNodeOption) Apply(s *Server) {
 	}
 }
 
+type noFastProdStallReload struct {
+	noopOption
+	noStall bool
+}
+
+func (l *noFastProdStallReload) Apply(s *Server) {
+	var not string
+	if l.noStall {
+		not = "not "
+	}
+	s.Noticef("Reloaded: fast producers will %sbe stalled", not)
+}
+
 // Compares options and disconnects clients that are no longer listed in pinned certs. Lock must not be held.
 func (s *Server) recheckPinnedCerts(curOpts *Options, newOpts *Options) {
 	s.mu.Lock()
@@ -1638,6 +1651,8 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 			// skip changes in config digest, this is handled already while
 			// processing the config.
 			continue
+		case "nofastproducerstall":
+			diffOpts = append(diffOpts, &noFastProdStallReload{noStall: newValue.(bool)})
 		default:
 			// TODO(ik): Implement String() on those options to have a nice print.
 			// %v is difficult to figure what's what, %+v print private fields and


### PR DESCRIPTION
Normally, when a producer detects that one of the consumer of a message is falling behind, it will stall. Which means that if a message has 2 consumers and the first is "slow", then it will affect the timely delivery to the second consumer.

With the new option `no_fast_producer_stall=true`, the server will simply drop a message destined to a consumer that would have caused the producer to stall. The message is still delivered to consumers that are not falling behind.

The option can be config-reload'ed and if a message is dropped due to fast-producer/slow-consumer, and the message was traced (with deliver option), then the message trace egress event will have an error indicating the reason why the message was not delivered.

Resolves #6413

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
