### PR TITLE
[FIXED] (2.11) Race when checking for orphaned NRG

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1138,65 +1138,6 @@ func (js *jetStream) checkForOrphans() {
 	}
 }
 
-// Check and delete any orphans we may come across.
-func (s *Server) checkForNRGOrphans() {
-	js, cc := s.getJetStreamCluster()
-	if js == nil || cc == nil || js.isMetaRecovering() {
-		// No cluster means no NRGs. Also return if still recovering.
-		return
-	}
-
-	// Track which assets R>1 should be on this server.
-	nrgMap := make(map[string]struct{})
-	trackGroup := func(rg *raftGroup) {
-		// If R>1 track this as a legit NRG.
-		if rg.node != nil {
-			nrgMap[rg.Name] = struct{}{}
-		}
-	}
-	// Register our meta.
-	js.mu.RLock()
-	meta := cc.meta
-	if meta == nil {
-		js.mu.RUnlock()
-		// Bail with no meta node.
-		return
-	}
-
-	ourID := meta.ID()
-	nrgMap[meta.Group()] = struct{}{}
-
-	// Collect all valid groups from our assignments.
-	for _, asa := range cc.streams {
-		for _, sa := range asa {
-			if sa.Group.isMember(ourID) && sa.Restore == nil {
-				trackGroup(sa.Group)
-				for _, ca := range sa.consumers {
-					if ca.Group.isMember(ourID) {
-						trackGroup(ca.Group)
-					}
-				}
-			}
-		}
-	}
-	js.mu.RUnlock()
-
-	// Check NRGs that are running.
-	var needDelete []RaftNode
-	s.rnMu.RLock()
-	for name, n := range s.raftNodes {
-		if _, ok := nrgMap[name]; !ok {
-			needDelete = append(needDelete, n)
-		}
-	}
-	s.rnMu.RUnlock()
-
-	for _, n := range needDelete {
-		s.Warnf("Detected orphaned NRG %q, will cleanup", n.Group())
-		n.Delete()
-	}
-}
-
 func (js *jetStream) monitorCluster() {
 	s, n := js.server(), js.getMetaGroup()
 	qch, rqch, lch, aq := js.clusterQuitC(), n.QuitC(), n.LeadChangeC(), n.ApplyQ()
@@ -1229,8 +1170,6 @@ func (js *jetStream) monitorCluster() {
 		if hs := s.healthz(nil); hs.Error != _EMPTY_ {
 			s.Warnf("%v", hs.Error)
 		}
-		// Also check for orphaned NRGs.
-		s.checkForNRGOrphans()
 	}
 
 	var (
@@ -2202,15 +2141,6 @@ func (mset *stream) removeNode() {
 		n.Delete()
 		mset.node = nil
 	}
-}
-
-func (mset *stream) clearRaftNode() {
-	if mset == nil {
-		return
-	}
-	mset.mu.Lock()
-	defer mset.mu.Unlock()
-	mset.node = nil
 }
 
 // Helper function to generate peer info.


### PR DESCRIPTION
There was a race condition (reproduced by Antithesis) where a server restarts and needs to catchup with a stream leader, but no stream leader could be elected for that stream temporarily. The RAFT node would then be stopped and restarted after some time, allowing for a stream leader to be elected, after which we can request catchup again.

However, since `resetClusteredState` is called, which resets `sa.Group.node = nil` and recreates it after. `checkForNRGOrphans` does not track the stream assignment while collecting RAFT nodes, and then sees the RAFT node is still registered on the server (because `n.Stop()` runs in parallel and didn't get to cleaning this up yet), and then deletes the RAFT node.

If the intend was to restart the RAFT node and all RAFT state is nuked due to this check running, that means after the RAFT node is restarted we've lost the whole data directory, potentially losing entries that were part of quorum, running into other issues while the restarted RAFT node expects the directory to be there, etc. etc.

It's unsafe to cleanup RAFT nodes like this. And since it only runs on startup or every hour, it likely doesn't need to be there anymore, knowing this race condition can happen and also knowing there have been many RAFT-related fixes the past months.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
