### PR TITLE
Update to Go 1.24.0/1.23.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ language: go
 go:
   # This should be quoted or use .x, but should not be unquoted.
   # Remember that a YAML bare float drops trailing zeroes.
+  - "1.24.0"
   - "1.23.6"
-  - "1.22.12"
 
 go_import_path: github.com/nats-io/nats-server
 
@@ -47,7 +47,7 @@ jobs:
     - name: "Run all tests from all other packages"
       env: TEST_SUITE=non_srv_pkg_tests
     - name: "Compile with older Go release"
-      go: "1.22.x"
+      go: "1.23.x"
       env: TEST_SUITE=build_only
 
 script: ./scripts/runTestsOnTravis.sh $TEST_SUITE
@@ -64,4 +64,4 @@ deploy:
   script: curl -o /tmp/goreleaser.tar.gz -sLf https://github.com/goreleaser/goreleaser/releases/download/v2.6.1/goreleaser_Linux_x86_64.tar.gz && tar -xvf /tmp/goreleaser.tar.gz -C /tmp/ && /tmp/goreleaser
   on:
     tags: true
-    condition: ($TRAVIS_GO_VERSION =~ 1.23) && ($TEST_SUITE = "compile")
+    condition: ($TRAVIS_GO_VERSION =~ 1.24) && ($TEST_SUITE = "compile")

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/nats-io/nats-server/v2
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.8
+toolchain go1.23.6
 
 require (
 	github.com/antithesishq/antithesis-sdk-go v0.4.3-default-no-op

--- a/scripts/runTestsOnTravis.sh
+++ b/scripts/runTestsOnTravis.sh
@@ -7,7 +7,7 @@ if [ "$1" = "compile" ]; then
     go build;
 
     # Now run the linters.
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0;
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.4;
     golangci-lint run;
     if [ "$TRAVIS_TAG" != "" ]; then
         go test -race -v -run=TestVersionMatchesTag ./server -ldflags="-X=github.com/nats-io/nats-server/v2/server.serverVersion=$TRAVIS_TAG" -count=1 -vet=off

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7504,7 +7504,7 @@ func (mb *msgBlock) sinceLastWriteActivity() time.Duration {
 }
 
 func checkNewHeader(hdr []byte) error {
-	if hdr == nil || len(hdr) < 2 || hdr[0] != magic ||
+	if len(hdr) < 2 || hdr[0] != magic ||
 		(hdr[1] != version && hdr[1] != newVersion) {
 		return errCorruptState
 	}
@@ -10247,7 +10247,7 @@ func (cfs *consumerFileStore) writeConsumerMeta() error {
 
 // Consumer version.
 func checkConsumerHeader(hdr []byte) (uint8, error) {
-	if hdr == nil || len(hdr) < 2 || hdr[0] != magic {
+	if len(hdr) < 2 || hdr[0] != magic {
 		return 0, errCorruptState
 	}
 	version := hdr[1]


### PR DESCRIPTION
Updates `go.mod` to require Go 1.23, update Travis CI to use Go 1.24.

Also update golangci-lint and fix a couple new things that it highlighted.

Signed-off-by: Neil Twigg <neil@nats.io>