### PR TITLE
NRG (2.11): Heartbeat can establish quorum & reset acks during stepdown

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -4285,6 +4285,10 @@ func (n *raft) switchToFollowerLocked(leader string) {
 
 	n.aflr = 0
 	n.lxfer = false
+	// Reset acks, we can't assume acks from a previous term are still valid in another term.
+	if len(n.acks) > 0 {
+		n.acks = make(map[uint64]map[string]struct{})
+	}
 	n.updateLeader(leader)
 	n.switchState(Follower)
 }

--- a/server/raft.go
+++ b/server/raft.go
@@ -3020,18 +3020,23 @@ func (n *raft) trackResponse(ar *appendEntryResponse) {
 	// See if we have items to apply.
 	var sendHB bool
 
-	if results := n.acks[ar.index]; results != nil {
-		results[ar.peer] = struct{}{}
-		if nr := len(results); nr >= n.qn {
-			// We have a quorum.
-			for index := n.commit + 1; index <= ar.index; index++ {
-				if err := n.applyCommit(index); err != nil && err != errNodeClosed {
-					n.error("Got an error applying commit for %d: %v", index, err)
-					break
-				}
+	results := n.acks[ar.index]
+	if results == nil {
+		results = make(map[string]struct{})
+		n.acks[ar.index] = results
+	}
+	results[ar.peer] = struct{}{}
+
+	// We don't count ourselves to account for leader changes, so add 1.
+	if nr := len(results); nr+1 >= n.qn {
+		// We have a quorum.
+		for index := n.commit + 1; index <= ar.index; index++ {
+			if err := n.applyCommit(index); err != nil && err != errNodeClosed {
+				n.error("Got an error applying commit for %d: %v", index, err)
+				break
 			}
-			sendHB = n.prop.len() == 0
 		}
+		sendHB = n.prop.len() == 0
 	}
 	n.Unlock()
 
@@ -3765,8 +3770,6 @@ func (n *raft) sendAppendEntry(entries []*Entry) {
 		if err := n.storeToWAL(ae); err != nil {
 			return
 		}
-		// We count ourselves.
-		n.acks[n.pindex] = map[string]struct{}{n.id: {}}
 		n.active = time.Now()
 
 		// Save in memory for faster processing during applyCommit.


### PR DESCRIPTION
If the leader changed, a heartbeat would not be able to signal there's quorum on messages. This is because the leader only tracked quorum for entries it sent out itself AND were stored in its own log. Heartbeats are sent by the leader but are not stored in its log, which means they can't be used to track quorum.

To solve this we don't need to track the leader in `n.acks`, which would not get populated after a leader change. Instead we only track the replicas that signal success and we always count ourselves anyway. This ensures that heartbeats, although not stored, can still signal quorum properly.

Also, acks from previous terms would not be reset during stepdown. Which meant that successful acks from previous terms could be combined with acks from newer terms, making the leader believe it has quorum whereas it didn't properly check all of those acks came from the same term.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
