### PR TITLE
[FIXED] Cleanup dmap on Compact/Truncate

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -8002,7 +8002,7 @@ func (fs *fileStore) compact(seq uint64, noMarkers bool) (uint64, error) {
 		if err == errDeletedMsg {
 			// Update dmap.
 			if !smb.dmap.IsEmpty() {
-				smb.dmap.Delete(seq)
+				smb.dmap.Delete(mseq)
 			}
 		} else if sm != nil {
 			sz := fileStoreMsgSize(sm.subj, sm.hdr, sm.msg)


### PR DESCRIPTION
In `Compact` and `Truncate` the interior delete map would not always be cleaned up properly. This could result in memory leaks. Also, if the filestore would restore based on `index.db` it would invalidate it due to having too many deletes and not being able to reconstruct the state.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>