### PR TITLE
[FIXED] LeafNode: possible delivery to several DQ members across Gateway

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4086,7 +4086,7 @@ func (c *client) processInboundClientMsg(msg []byte) (bool, bool) {
 			reply = append(reply, '@')
 			reply = append(reply, c.pa.deliver...)
 		}
-		didDeliver = c.sendMsgToGateways(acc, msg, c.pa.subject, reply, qnames) || didDeliver
+		didDeliver = c.sendMsgToGateways(acc, msg, c.pa.subject, reply, qnames, false) || didDeliver
 	}
 
 	// Check to see if we did not deliver to anyone and the client has a reply subject set
@@ -4133,7 +4133,7 @@ func (c *client) handleGWReplyMap(msg []byte) bool {
 			reply = append(reply, '@')
 			reply = append(reply, c.pa.deliver...)
 		}
-		c.sendMsgToGateways(c.acc, msg, c.pa.subject, reply, nil)
+		c.sendMsgToGateways(c.acc, msg, c.pa.subject, reply, nil, false)
 	}
 	return true
 }
@@ -4509,7 +4509,7 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 			flags |= pmrCollectQueueNames
 			var queues [][]byte
 			didDeliver, queues = c.processMsgResults(siAcc, rr, msg, c.pa.deliver, []byte(to), nrr, flags)
-			didDeliver = c.sendMsgToGateways(siAcc, msg, []byte(to), nrr, queues) || didDeliver
+			didDeliver = c.sendMsgToGateways(siAcc, msg, []byte(to), nrr, queues, false) || didDeliver
 		} else {
 			didDeliver, _ = c.processMsgResults(siAcc, rr, msg, c.pa.deliver, []byte(to), nrr, flags)
 		}

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2863,7 +2863,7 @@ func (c *client) processInboundLeafMsg(msg []byte) {
 
 	// Now deal with gateways
 	if c.srv.gateway.enabled {
-		c.sendMsgToGateways(acc, msg, c.pa.subject, c.pa.reply, qnames)
+		c.sendMsgToGateways(acc, msg, c.pa.subject, c.pa.reply, qnames, true)
 	}
 }
 


### PR DESCRIPTION
If the same queue group has members running on different leafnodes connected through a gateway, it was possible for a message to be delivered to several members running on different leaf nodes if there was an interest (either plain subscription or for other queue groups) that made the produce message travel through the gateway.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
