### PR TITLE
NRG (2.11): Mark n.Leader() when complete with applied floor

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -5621,7 +5621,7 @@ func (o *consumer) stopWithFlags(dflag, sdflag, doSignal, advisory bool) error {
 	// Check if we are the leader and are being deleted (as a node).
 	if dflag && o.isLeader() {
 		// If we are clustered and node leader (probable from above), stepdown.
-		if node := o.node; node != nil && node.Leader() {
+		if node := o.node; node != nil {
 			node.StepDown()
 		}
 

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1922,8 +1922,8 @@ func (o *consumer) deleteNotActive() {
 				}
 				nca := js.consumerAssignment(acc, stream, name)
 				js.mu.RUnlock()
-				// Make sure this is not a new consumer with the same name.
-				if nca != nil && nca == ca {
+				// Make sure this is the same consumer assignment, and not a new consumer with the same name.
+				if nca != nil && reflect.DeepEqual(nca, ca) {
 					s.Warnf("Consumer assignment for '%s > %s > %s' not cleaned up, retrying", acc, stream, name)
 					meta.ForwardProposal(removeEntry)
 					if interval < cnaMax {

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2431,7 +2431,7 @@ func (o *consumer) loopAndForwardProposals(qch chan struct{}) {
 
 	forwardProposals := func() error {
 		o.mu.Lock()
-		if o.node == nil || o.node.State() != Leader {
+		if o.node == nil || !o.node.Leader() {
 			o.mu.Unlock()
 			return errors.New("no longer leader")
 		}

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -2931,11 +2931,11 @@ func (s *Server) resourcesExceededError() {
 	}
 	s.rerrMu.Unlock()
 
-	// If we are meta leader we should relinguish that here.
+	// If we are meta leader we should relinquish that here.
 	if didAlert {
 		if js := s.getJetStream(); js != nil {
 			js.mu.RLock()
-			if cc := js.cluster; cc != nil && cc.isLeader() {
+			if cc := js.cluster; cc != nil && cc.meta != nil {
 				cc.meta.StepDown()
 			}
 			js.mu.RUnlock()

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2288,16 +2288,14 @@ func (s *Server) jsStreamLeaderStepDownRequest(sub *subscription, c *client, _ *
 		}
 	}
 
-	// Call actual stepdown. Do this in a Go routine.
-	go func() {
-		mset.setLeader(false)
-		// TODO (mh) eventually make sure all go routines exited and all channels are cleared
-		time.Sleep(250 * time.Millisecond)
-		node.StepDown(preferredLeader)
-
+	// Call actual stepdown.
+	err = node.StepDown(preferredLeader)
+	if err != nil {
+		resp.Error = NewJSRaftGeneralError(err, Unless(err))
+	} else {
 		resp.Success = true
-		s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
-	}()
+	}
+	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 }
 
 // Request to have a consumer leader stepdown.
@@ -2408,16 +2406,14 @@ func (s *Server) jsConsumerLeaderStepDownRequest(sub *subscription, c *client, _
 		}
 	}
 
-	// Call actual stepdown. Do this in a Go routine.
-	go func() {
-		o.setLeader(false)
-		// TODO (mh) eventually make sure all go routines exited and all channels are cleared
-		time.Sleep(250 * time.Millisecond)
-		n.StepDown(preferredLeader)
-
+	// Call actual stepdown.
+	err = n.StepDown(preferredLeader)
+	if err != nil {
+		resp.Error = NewJSRaftGeneralError(err, Unless(err))
+	} else {
 		resp.Success = true
-		s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
-	}()
+	}
+	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 }
 
 // Request to remove a peer from a clustered stream.

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -659,17 +659,13 @@ func (s *Server) checkJetStreamMigrate(remote *leafNodeCfg) {
 		// Collect any consumers
 		for _, o := range mset.getConsumers() {
 			if n := o.raftNode(); n != nil {
-				if n.Leader() {
-					n.StepDown()
-				}
+				n.StepDown()
 				// Ensure we can not become a leader while in this state.
 				n.SetObserver(true)
 			}
 		}
 		// Stepdown if this stream was leader.
-		if node.Leader() {
-			node.StepDown()
-		}
+		node.StepDown()
 		// Ensure we can not become a leader while in this state.
 		node.SetObserver(true)
 	}

--- a/server/raft.go
+++ b/server/raft.go
@@ -1671,6 +1671,7 @@ func (n *raft) xferCampaign() error {
 }
 
 // State returns the current state for this node.
+// Upper layers should not check State to check if we're Leader, use n.Leader() instead.
 func (n *raft) State() RaftState {
 	return RaftState(n.state.Load())
 }

--- a/server/raft.go
+++ b/server/raft.go
@@ -1788,6 +1788,7 @@ func (n *raft) shutdown() {
 	// First call to Stop or Delete should close the quit chan
 	// to notify the runAs goroutines to stop what they're doing.
 	if n.state.Swap(int32(Closed)) != int32(Closed) {
+		n.leaderState.Store(false)
 		close(n.quit)
 	}
 }

--- a/server/stream.go
+++ b/server/stream.go
@@ -2737,12 +2737,13 @@ func (mset *stream) setupMirrorConsumer() error {
 	} else {
 		mset.cancelSourceInfo(mset.mirror)
 		mset.mirror.sseq = mset.lseq
-
-		// If we are no longer the leader stop trying.
-		if !mset.isLeader() {
-			return nil
-		}
 	}
+
+	// If we are no longer the leader stop trying.
+	if !mset.isLeader() {
+		return nil
+	}
+
 	mirror := mset.mirror
 
 	// We want to throttle here in terms of how fast we request new consumers,

--- a/server/stream.go
+++ b/server/stream.go
@@ -5603,9 +5603,7 @@ func (mset *stream) resetAndWaitOnConsumers() {
 
 	for _, o := range consumers {
 		if node := o.raftNode(); node != nil {
-			if o.IsLeader() {
-				node.StepDown()
-			}
+			node.StepDown()
 			node.Delete()
 		}
 		if o.isMonitorRunning() {


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/6485

After above PR the RAFT state would become `Leader` as normal, but a call to `updateLeadChange` would be delayed until the server is up-to-date with all stored but unapplied entries from its log. The intention of this is to not respond to read/write requests for meta/stream/consumer until the leader is in a complete state, which ensures consistent handling of requests after leader changes.

However, calls like `isLeader`, `isStreamLeader`, and `isConsumerLeader` would request `n.Leader()` which returns whether the RAFT node is leader. And it would not use the signal sent to `updateLeadChange`.

To achieve this level of consistency with minimal code changes:
- `n.Leader()` only returns true once the RAFT node is both a leader, and all initial entries from its log were applied.
- Calls to `n.StepDown()` would be preceded by `n.Leader()`, however with it being changed to not just return whether the RAFT node is leader this is not possible anymore. Instead we can always just call `n.StepDown()` without checking for being leader. As the RAFT code itself already checks for this as well.

Some test de-flakes are included as well.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>