### PR TITLE
Test: fix panic for non-existent RAFT node/group

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -7787,7 +7787,11 @@ func TestJetStreamClusterRecreateConsumerFromMetaSnapshot(t *testing.T) {
 				return err
 			} else if o := mset.lookupConsumer("CONSUMER"); o == nil {
 				return errors.New("consumer doesn't exist")
-			} else if ccrg := o.raftNode().Group(); consumerRg == _EMPTY_ {
+			} else if rn := o.raftNode(); rn == nil {
+				return errors.New("consumer raft node doesn't exist")
+			} else if ccrg := rn.Group(); ccrg == _EMPTY_ {
+				return errors.New("consumer raft group doesn't exist")
+			} else if consumerRg == _EMPTY_ {
 				consumerRg = ccrg
 			} else if consumerRg != ccrg {
 				return errors.New("consumer raft groups don't match")


### PR DESCRIPTION
Fixes the following test panic:
```
=== FAIL: server TestJetStreamClusterRecreateConsumerFromMetaSnapshot (4.18s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x68 pc=0xc4a8b3]
goroutine 68737 [running]:
testing.tRunner.func1.2({0x134cb80, 0x20093e0})
    /usr/local/go/src/testing/testing.go:1734 +0x21c
testing.tRunner.func1()
    /usr/local/go/src/testing/testing.go:1737 +0x35e
panic({0x134cb80?, 0x20093e0?})
    /usr/local/go/src/runtime/panic.go:787 +0x132
github.com/nats-io/nats-server/v2/server.TestJetStreamClusterRecreateConsumerFromMetaSnapshot.func3()
    /workspace/build/buildkite/synadia/nats-server-dev/server/jetstream_cluster_1_test.go:7790 +0xd3
github.com/nats-io/nats-server/v2/server.checkForErr(0x77359400, 0x1dcd6500, 0xc0011d5ed0)
    /workspace/build/buildkite/synadia/nats-server-dev/server/server_test.go:48 +0x94
github.com/nats-io/nats-server/v2/server.checkFor({0x1749f00, 0xc00037c700}, 0x77359400, 0x1dcd6500, 0xc0011d5ed0)
    /workspace/build/buildkite/synadia/nats-server-dev/server/server_test.go:59 +0x48
github.com/nats-io/nats-server/v2/server.TestJetStreamClusterRecreateConsumerFromMetaSnapshot(0xc00037c700)
    /workspace/build/buildkite/synadia/nats-server-dev/server/jetstream_cluster_1_test.go:7781 +0x6db
testing.tRunner(0xc00037c700, 0x15530e8)
    /usr/local/go/src/testing/testing.go:1792 +0xf4
created by testing.(*T).Run in goroutine 1
    /usr/local/go/src/testing/testing.go:1851 +0x413
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>