### PR TITLE
[FIXED] Consumer skips some messages

### DIFF
--- a/server/memstore.go
+++ b/server/memstore.go
@@ -206,6 +206,7 @@ func (ms *memStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, tt
 		if ss != nil {
 			ss.Msgs++
 			ss.Last = seq
+			ss.lastNeedsUpdate = false
 			// Check per subject limits.
 			if ms.maxp > 0 && ss.Msgs > uint64(ms.maxp) {
 				ms.enforcePerSubjectLimit(subj, ss)

--- a/server/store_test.go
+++ b/server/store_test.go
@@ -254,6 +254,24 @@ func TestStoreSubjectStateConsistency(t *testing.T) {
 			expectFirstSeq(6)
 			require_Equal(t, ss.Last, 6)
 			expectLastSeq(6)
+
+			// We store a new message for ss.Last and remove it after, which marks it to be recalculated.
+			_, _, err = fs.StoreMsg("foo", nil, nil, 0)
+			require_NoError(t, err)
+			removed, err = fs.RemoveMsg(8)
+			require_NoError(t, err)
+			require_True(t, removed)
+			// This will be the new ss.Last message, so reset ss.lastNeedsUpdate
+			_, _, err = fs.StoreMsg("foo", nil, nil, 0)
+			require_NoError(t, err)
+
+			// ss.First should remain the same, but ss.Last should equal the last message.
+			ss = getSubjectState()
+			require_Equal(t, ss.Msgs, 2)
+			require_Equal(t, ss.First, 6)
+			expectFirstSeq(6)
+			require_Equal(t, ss.Last, 9)
+			expectLastSeq(9)
 		},
 	)
 }


### PR DESCRIPTION
Consumers could occasionally skip messages given specific message removal patterns. This was most prevalent for WorkQueue and Interest-based streams.

The issue lies in both `ss.First` and `ss.Last` being lazy and needing to be recalculated once they are needed. `ss.Last` was not recalculated before, but it is since https://github.com/nats-io/nats-server/pull/6235 ensuring the subject state remains correct.

However, if `ss.Last` was overwritten after a new message was ingested into the stream, the `ss.lastNeedsUpdate` flag was not updated. Which resulted in `ss.Last` being recalculated to a lower value, skipping over the message with the sequence that was previously `ss.Last`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
