### PR TITLE
[FIXED] Deadlock on getting account name tag

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -466,11 +466,20 @@ func (a *Account) getNameTag() string {
 		return _EMPTY_
 	}
 	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.getNameTagLocked()
+}
+
+// getNameTagLocked will return the name tag or the account name if not set.
+// Lock should be held.
+func (a *Account) getNameTagLocked() string {
+	if a == nil {
+		return _EMPTY_
+	}
 	nameTag := a.nameTag
 	if nameTag == _EMPTY_ {
 		nameTag = a.Name
 	}
-	a.mu.RUnlock()
 	return nameTag
 }
 

--- a/server/events.go
+++ b/server/events.go
@@ -2393,14 +2393,9 @@ func (s *Server) sendAccConnsUpdate(a *Account, subj ...string) {
 func (a *Account) statz() *AccountStat {
 	localConns := a.numLocalConnections()
 	leafConns := a.numLocalLeafNodes()
-	// Do not use getNameTag() to avoid a deadlock with `registerWithAccount`.
-	nameTag := a.nameTag
-	if nameTag == _EMPTY_ {
-		nameTag = a.Name
-	}
 	return &AccountStat{
 		Account:    a.Name,
-		Name:       nameTag,
+		Name:       a.getNameTagLocked(),
 		Conns:      localConns,
 		LeafNodes:  leafConns,
 		TotalConns: localConns + leafConns,

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2772,7 +2772,7 @@ func (s *Server) accountInfo(accName string) (*AccountInfo, error) {
 		Imports:     imports,
 		Jwt:         a.claimJWT,
 		IssuerKey:   a.Issuer,
-		NameTag:     a.getNameTag(),
+		NameTag:     a.getNameTagLocked(),
 		Tags:        a.tags,
 		Claim:       claim,
 		Vr:          vrIssues,


### PR DESCRIPTION
There was a deadlock introduced in https://github.com/nats-io/nats-server/pull/6310. In `s.accountInfo(accName)` we get the read lock on the account, but when going into `a.getNameTag()` we get the read lock again. If at any point the write lock would be taken from somewhere else, we'd be deadlocked. Since we're already holding the lock we don't need to get it again.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
