### PR TITLE
Disable subject delete markers on removes/purges

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4683,9 +4683,10 @@ func (fs *fileStore) removeMsg(seq uint64, secure, viaLimits, needFSLock bool) (
 	if wasLast && len(getHeader(JSMarkerReason, sm.hdr)) == 0 { // Not a marker.
 		if viaLimits {
 			sdmcb = fs.subjectDeleteMarkerIfNeeded(sm.subj, JSMarkerReasonMaxAge)
-		} else {
-			sdmcb = fs.subjectDeleteMarkerIfNeeded(sm.subj, JSMarkerReasonRemove)
-		}
+		} // else {
+		// TODO: Don't write markers on removes via the API yet, only via limits.
+		// sdmcb = fs.subjectDeleteMarkerIfNeeded(sm.subj, JSMarkerReasonRemove)
+		//}
 	}
 
 	// If we emptied the current message block and the seq was state.FirstSeq
@@ -7668,7 +7669,11 @@ func compareFn(subject string) func(string, string) bool {
 
 // PurgeEx will remove messages based on subject filters, sequence and number of messages to keep.
 // Will return the number of purged messages.
-func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64, noMarkers bool) (purged uint64, err error) {
+func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64, _ /* noMarkers */ bool) (purged uint64, err error) {
+	// TODO: Don't write markers on purge until we have solved performance
+	// issues with them.
+	noMarkers := true
+
 	if subject == _EMPTY_ || subject == fwcs {
 		if keep == 0 && sequence == 0 {
 			return fs.purge(0, noMarkers)
@@ -7821,7 +7826,11 @@ func (fs *fileStore) Purge() (uint64, error) {
 	return fs.purge(0, false)
 }
 
-func (fs *fileStore) purge(fseq uint64, noMarkers bool) (uint64, error) {
+func (fs *fileStore) purge(fseq uint64, _ /* noMarkers */ bool) (uint64, error) {
+	// TODO: Don't write markers on purge until we have solved performance
+	// issues with them.
+	noMarkers := true
+
 	fs.mu.Lock()
 	if fs.closed {
 		fs.mu.Unlock()
@@ -7934,7 +7943,11 @@ func (fs *fileStore) Compact(seq uint64) (uint64, error) {
 	return fs.compact(seq, false)
 }
 
-func (fs *fileStore) compact(seq uint64, noMarkers bool) (uint64, error) {
+func (fs *fileStore) compact(seq uint64, _ /* noMarkers */ bool) (uint64, error) {
+	// TODO: Don't write markers on compact until we have solved performance
+	// issues with them.
+	noMarkers := true
+
 	if seq == 0 {
 		return fs.purge(seq, noMarkers)
 	}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -8655,6 +8655,8 @@ func TestFileStoreSubjectDeleteMarkersOnRestart(t *testing.T) {
 }
 
 func TestFileStoreSubjectDeleteMarkersOnPurge(t *testing.T) {
+	t.SkipNow()
+
 	storeDir := t.TempDir()
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -8685,6 +8687,8 @@ func TestFileStoreSubjectDeleteMarkersOnPurge(t *testing.T) {
 }
 
 func TestFileStoreSubjectDeleteMarkersOnPurgeEx(t *testing.T) {
+	t.SkipNow()
+
 	storeDir := t.TempDir()
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -8715,6 +8719,8 @@ func TestFileStoreSubjectDeleteMarkersOnPurgeEx(t *testing.T) {
 }
 
 func TestFileStoreSubjectDeleteMarkersOnPurgeExNoMarkers(t *testing.T) {
+	t.SkipNow()
+
 	storeDir := t.TempDir()
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -8742,6 +8748,8 @@ func TestFileStoreSubjectDeleteMarkersOnPurgeExNoMarkers(t *testing.T) {
 }
 
 func TestFileStoreSubjectDeleteMarkersOnCompact(t *testing.T) {
+	t.SkipNow()
+
 	storeDir := t.TempDir()
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},
@@ -8778,6 +8786,8 @@ func TestFileStoreSubjectDeleteMarkersOnCompact(t *testing.T) {
 }
 
 func TestFileStoreSubjectDeleteMarkersOnRemoveMsg(t *testing.T) {
+	t.SkipNow()
+
 	storeDir := t.TempDir()
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: storeDir},

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -505,7 +505,7 @@ type JSApiStreamPurgeRequest struct {
 	Keep uint64 `json:"keep,omitempty"`
 	// NoMarkers ensures that subject delete markers will not be left. If subject delete markers
 	// are not enabled on the stream, then this flag is no-op.
-	NoMarkers bool `json:"no_markers,omitempty"`
+	// NoMarkers bool `json:"no_markers,omitempty"`
 }
 
 type JSApiStreamPurgeResponse struct {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -25430,6 +25430,8 @@ func TestJetStreamSubjectDeleteMarkersWithMirror(t *testing.T) {
 }
 
 func TestJetStreamSubjectDeleteMarkersAfterPurge(t *testing.T) {
+	t.SkipNow()
+
 	for _, storage := range []StorageType{FileStorage, MemoryStorage} {
 		t.Run(storage.String(), func(t *testing.T) {
 			s := RunBasicJetStreamServer(t)
@@ -25461,8 +25463,8 @@ func TestJetStreamSubjectDeleteMarkersAfterPurge(t *testing.T) {
 			}
 
 			body, err := json.Marshal(JSApiStreamPurgeRequest{
-				Sequence:  6,
-				NoMarkers: false,
+				Sequence: 6,
+				// NoMarkers: false,
 			})
 			require_NoError(t, err)
 
@@ -25488,6 +25490,8 @@ func TestJetStreamSubjectDeleteMarkersAfterPurge(t *testing.T) {
 }
 
 func TestJetStreamSubjectDeleteMarkersAfterPurgeNoMarkers(t *testing.T) {
+	t.SkipNow()
+
 	for _, storage := range []StorageType{FileStorage, MemoryStorage} {
 		t.Run(storage.String(), func(t *testing.T) {
 			s := RunBasicJetStreamServer(t)
@@ -25519,8 +25523,8 @@ func TestJetStreamSubjectDeleteMarkersAfterPurgeNoMarkers(t *testing.T) {
 			}
 
 			body, err := json.Marshal(JSApiStreamPurgeRequest{
-				Sequence:  6,
-				NoMarkers: true,
+				Sequence: 6,
+				// NoMarkers: true,
 			})
 			require_NoError(t, err)
 

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1089,7 +1089,11 @@ func (ms *memStore) expireMsgs() {
 
 // PurgeEx will remove messages based on subject filters, sequence and number of messages to keep.
 // Will return the number of purged messages.
-func (ms *memStore) PurgeEx(subject string, sequence, keep uint64, noMarkers bool) (purged uint64, err error) {
+func (ms *memStore) PurgeEx(subject string, sequence, keep uint64, _ /* noMarkers */ bool) (purged uint64, err error) {
+	// TODO: Don't write markers on purge until we have solved performance
+	// issues with them.
+	noMarkers := true
+
 	if subject == _EMPTY_ || subject == fwcs {
 		if keep == 0 && sequence == 0 {
 			return ms.purge(0, noMarkers)
@@ -1149,7 +1153,11 @@ func (ms *memStore) Purge() (uint64, error) {
 	return ms.purge(first, false)
 }
 
-func (ms *memStore) purge(fseq uint64, noMarkers bool) (uint64, error) {
+func (ms *memStore) purge(fseq uint64, _ /* noMarkers */ bool) (uint64, error) {
+	// TODO: Don't write markers on purge until we have solved performance
+	// issues with them.
+	noMarkers := true
+
 	ms.mu.Lock()
 	purged := uint64(len(ms.msgs))
 	cb := ms.scb
@@ -1192,7 +1200,11 @@ func (ms *memStore) Compact(seq uint64) (uint64, error) {
 	return ms.compact(seq, false)
 }
 
-func (ms *memStore) compact(seq uint64, noMarkers bool) (uint64, error) {
+func (ms *memStore) compact(seq uint64, _ /* noMarkers */ bool) (uint64, error) {
+	// TODO: Don't write markers on compact until we have solved performance
+	// issues with them.
+	noMarkers := true
+
 	if seq == 0 {
 		return ms.Purge()
 	}
@@ -1555,7 +1567,8 @@ func (ms *memStore) LoadPrevMsg(start uint64, smp *StoreMsg) (sm *StoreMsg, err 
 // Will return the number of bytes removed.
 func (ms *memStore) RemoveMsg(seq uint64) (bool, error) {
 	ms.mu.Lock()
-	removed := ms.removeMsg(seq, false, JSMarkerReasonRemove)
+	// TODO: Don't write markers on removes via the API yet, only via limits.
+	removed := ms.removeMsg(seq, false, _EMPTY_)
 	ms.mu.Unlock()
 	return removed, nil
 }
@@ -1563,7 +1576,8 @@ func (ms *memStore) RemoveMsg(seq uint64) (bool, error) {
 // EraseMsg will remove the message and rewrite its contents.
 func (ms *memStore) EraseMsg(seq uint64) (bool, error) {
 	ms.mu.Lock()
-	removed := ms.removeMsg(seq, true, JSMarkerReasonRemove)
+	// TODO: Don't write markers on removes via the API yet, only via limits.
+	removed := ms.removeMsg(seq, true, _EMPTY_)
 	ms.mu.Unlock()
 	return removed, nil
 }

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -1231,6 +1231,8 @@ func TestMemStoreSubjectDeleteMarkers(t *testing.T) {
 }
 
 func TestMemStoreSubjectDeleteMarkersOnPurge(t *testing.T) {
+	t.SkipNow()
+
 	ms, err := newMemStore(
 		&StreamConfig{
 			Name: "zzz", Subjects: []string{"test.*"}, Storage: MemoryStorage,
@@ -1259,6 +1261,8 @@ func TestMemStoreSubjectDeleteMarkersOnPurge(t *testing.T) {
 }
 
 func TestMemStoreSubjectDeleteMarkersOnPurgeEx(t *testing.T) {
+	t.SkipNow()
+
 	ms, err := newMemStore(
 		&StreamConfig{
 			Name: "zzz", Subjects: []string{"test.*"}, Storage: MemoryStorage,
@@ -1287,6 +1291,8 @@ func TestMemStoreSubjectDeleteMarkersOnPurgeEx(t *testing.T) {
 }
 
 func TestMemStoreSubjectDeleteMarkersOnPurgeExNoMarkers(t *testing.T) {
+	t.SkipNow()
+
 	ms, err := newMemStore(
 		&StreamConfig{
 			Name: "zzz", Subjects: []string{"test.*"}, Storage: MemoryStorage,
@@ -1312,6 +1318,8 @@ func TestMemStoreSubjectDeleteMarkersOnPurgeExNoMarkers(t *testing.T) {
 }
 
 func TestMemStoreSubjectDeleteMarkersOnCompact(t *testing.T) {
+	t.SkipNow()
+
 	ms, err := newMemStore(
 		&StreamConfig{
 			Name: "zzz", Subjects: []string{"test.*"}, Storage: MemoryStorage,
@@ -1346,6 +1354,8 @@ func TestMemStoreSubjectDeleteMarkersOnCompact(t *testing.T) {
 }
 
 func TestMemStoreSubjectDeleteMarkersOnRemoveMsg(t *testing.T) {
+	t.SkipNow()
+
 	ms, err := newMemStore(
 		&StreamConfig{
 			Name: "zzz", Subjects: []string{"test"}, Storage: MemoryStorage,

--- a/server/stream.go
+++ b/server/stream.go
@@ -2211,7 +2211,7 @@ func (mset *stream) purge(preq *JSApiStreamPurgeRequest) (purged uint64, err err
 	mset.mu.RUnlock()
 
 	if preq != nil {
-		purged, err = mset.store.PurgeEx(preq.Subject, preq.Sequence, preq.Keep, preq.NoMarkers)
+		purged, err = mset.store.PurgeEx(preq.Subject, preq.Sequence, preq.Keep, false /*preq.NoMarkers*/)
 	} else {
 		purged, err = mset.store.Purge()
 	}


### PR DESCRIPTION
This leaves the code mostly intact so that we can easily iterate on it further in a future patch release, but disables for now, so that only `MaxAge` leaves markers behind and not removes/purges.

Signed-off-by: Neil Twigg <neil@nats.io>