### PR TITLE
Use stable go version in gh actions

### DIFF
--- a/.github/actions/nightly-release/action.yaml
+++ b/.github/actions/nightly-release/action.yaml
@@ -22,9 +22,9 @@ runs:
       run: docker login -u "${{ inputs.hub_username }}" -p "${{ inputs.hub_password }}"
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: "stable"
+        go-version: stable
 
     - name: Build and push Docker images
       # Use commit hash here to avoid a re-tagging attack, as this is a third-party action

--- a/.github/workflows/cov.yaml
+++ b/.github/workflows/cov.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: src/github.com/nats-io/nats-server/go.mod
+          go-version: stable
           cache-dependency-path: src/github.com/nats-io/nats-server/go.sum
 
       - name: Run code coverage

--- a/.github/workflows/long-tests.yaml
+++ b/.github/workflows/long-tests.yaml
@@ -24,10 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          # Use go version from go.mod
-          go-version-file: "go.mod"
-          # Use latest stable go version
-          # go-version: stable
+          go-version: stable
 
       - name: Run tests
         run: go test -race -v -run='^TestLong.*' ./server -tags=include_js_long_tests -count=1 -vet=off -timeout=60m -shuffle on -p 1 -failfast

--- a/.github/workflows/mqtt-test.yaml
+++ b/.github/workflows/mqtt-test.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: src/github.com/nats-io/nats-server/go.mod
+          go-version: stable
           cache-dependency-path: src/github.com/nats-io/nats-server/go.sum
 
       - name: Set up testing tools and environment


### PR DESCRIPTION
Setup-go has some non-straitforward tricks:
https://github.com/actions/setup-go?tab=readme-ov-file#getting-go-version-from-the-gomod-file
> The go directive in go.mod can specify a patch version or omit it altogether (e.g., go 1.22.0 or go 1.22).
If a patch version is specified, that specific patch version will be used.
If no patch version is specified, it will search for the latest available patch version in the cache, [versions-manifest.json](https://github.com/actions/go-versions/blob/main/versions-manifest.json), and the [official Go language website](https://golang.org/dl/?mode=json&include=all), in that order.

This is an invention of setup-go action authors. Go team [says](https://github.com/golang/go/issues/68971#issuecomment-2300236006) that release version (e.g. 1.22.0) should be specified 

That means, e.g. when [this commit](https://github.com/nats-io/nats-server/commit/8f465141c7baec6c2ebb4b7d1a58ec0e818412ca#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R3) updated go.mod from 1.22 to 1.22.0, the "Long JetStream tests" silently started to use 1.22.0, instead of 1.22.12.
"If nothing magically works, nothing magically breaks".

Since we update to the new toolchain version as soon as it is released, and we usually use the latest toolchain for the releases, we should run all tests using [go-version: stable](https://github.com/actions/setup-go?tab=readme-ov-file#using-stableoldstable-aliases)


Signed-off-by: Alex Bozhenko <alex@synadia.com>
