### PR TITLE
[FIXED] A request through a service import with no interest should return no reponders.

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -2086,7 +2086,7 @@ func (a *Account) addServiceImportSub(si *serviceImport) error {
 	a.mu.Unlock()
 
 	cb := func(sub *subscription, c *client, acc *Account, subject, reply string, msg []byte) {
-		c.processServiceImport(si, acc, msg)
+		c.pa.delivered = c.processServiceImport(si, acc, msg)
 	}
 	sub, err := c.processSubEx([]byte(subject), nil, []byte(sid), cb, true, true, false)
 	if err != nil {

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -7132,7 +7132,7 @@ func TestJetStreamClusterStreamDirectGetNotTooSoon(t *testing.T) {
 	defer nc.Close()
 
 	_, err = nc.Request(getSubj, nil, time.Second)
-	require_Error(t, err, nats.ErrTimeout)
+	require_Error(t, err, nats.ErrNoResponders)
 
 	// Now start all and make sure they all eventually have subs for direct access.
 	c.restartAll()

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -6219,8 +6219,7 @@ func TestJWTAccountProtectedImport(t *testing.T) {
 
 		// ensure service fails
 		_, err = ncImp.Request(srvcSub, []byte("hello"), time.Second)
-		require_Error(t, err)
-		require_Contains(t, err.Error(), "timeout")
+		require_Error(t, err, nats.ErrNoResponders)
 		s.AccountResolver().Store(exportPub, exportJWTOn)
 		// ensure stream fails
 		err = ncExp.Publish(strmSub, []byte("hello"))

--- a/server/msgtrace_test.go
+++ b/server/msgtrace_test.go
@@ -1799,7 +1799,7 @@ func TestMsgTraceServiceImport(t *testing.T) {
 						}
 					}
 					// Check that no (more) messages are received.
-					if msg, err := sub.NextMsg(100 * time.Millisecond); msg != nil || err != nats.ErrTimeout {
+					if msg, err := sub.NextMsg(100 * time.Millisecond); msg != nil || (err != nats.ErrTimeout && err != nats.ErrNoResponders) {
 						t.Fatalf("Did not expect application message, got msg=%v err=%v", msg, err)
 					}
 					if !test.deliverMsg {
@@ -2072,7 +2072,7 @@ func TestMsgTraceServiceImportWithSuperCluster(t *testing.T) {
 						}
 					}
 					// Check that no (more) messages are received.
-					if msg, err := sub.NextMsg(100 * time.Millisecond); msg != nil || err != nats.ErrTimeout {
+					if msg, err := sub.NextMsg(100 * time.Millisecond); msg != nil || (err != nats.ErrTimeout && err != nats.ErrNoResponders) {
 						t.Fatalf("Did not expect application message, got msg=%v err=%v", msg, err)
 					}
 					if !test.deliverMsg {
@@ -2523,7 +2523,7 @@ func TestMsgTraceServiceImportWithLeafNodeLeaf(t *testing.T) {
 				require_Equal[string](t, string(appMsg.Data), "request2")
 			}
 			// Check that no (more) messages are received.
-			if msg, err := sub.NextMsg(100 * time.Millisecond); msg != nil || err != nats.ErrTimeout {
+			if msg, err := sub.NextMsg(100 * time.Millisecond); msg != nil || (err != nats.ErrTimeout && err != nats.ErrNoResponders) {
 				t.Fatalf("Did not expect application message, got msg=%v err=%v", msg, err)
 			}
 			if !test.deliverMsg {

--- a/server/parser.go
+++ b/server/parser.go
@@ -35,21 +35,22 @@ type parseState struct {
 }
 
 type pubArg struct {
-	arg     []byte
-	pacache []byte
-	origin  []byte
-	account []byte
-	subject []byte
-	deliver []byte
-	mapped  []byte
-	reply   []byte
-	szb     []byte
-	hdb     []byte
-	queues  [][]byte
-	size    int
-	hdr     int
-	psi     []*serviceImport
-	trace   *msgTrace
+	arg       []byte
+	pacache   []byte
+	origin    []byte
+	account   []byte
+	subject   []byte
+	deliver   []byte
+	mapped    []byte
+	reply     []byte
+	szb       []byte
+	hdb       []byte
+	queues    [][]byte
+	size      int
+	hdr       int
+	psi       []*serviceImport
+	trace     *msgTrace
+	delivered bool // Only used for service imports
 }
 
 // Parser constants
@@ -516,6 +517,7 @@ func (c *client) parse(buf []byte) error {
 			c.pa.arg, c.pa.pacache, c.pa.origin, c.pa.account, c.pa.subject, c.pa.mapped = nil, nil, nil, nil, nil, nil
 			c.pa.reply, c.pa.hdr, c.pa.size, c.pa.szb, c.pa.hdb, c.pa.queues = nil, -1, 0, nil, nil, nil
 			c.pa.trace = nil
+			c.pa.delivered = false
 			lmsg = false
 		case OP_A:
 			switch b {


### PR DESCRIPTION
Since service imports are internal callbacks with no signaling for delivered status, when sending through a service import with no interest in the exporting account, the requestor would simply timeout. 

Signed-off-by: Derek Collison <derek@nats.io>