### PR TITLE
Fix `TestLongClusterWorkQueueMessagesNotSkipped`

### DIFF
--- a/server/jetstream_cluster_long_test.go
+++ b/server/jetstream_cluster_long_test.go
@@ -550,7 +550,7 @@ func TestLongClusterWorkQueueMessagesNotSkipped(t *testing.T) {
 				if errors.Is(err, nats.ErrTimeout) {
 					continue
 				}
-				if errors.Is(err, nats.ErrConnectionClosed) {
+				if errors.Is(err, nats.ErrConnectionClosed) || errors.Is(err, nats.ErrSubscriptionClosed) {
 					return // ... for when the test finishes
 				}
 				require_NoError(t, err)


### PR DESCRIPTION
We need to check for `ErrSubscriptionClosed` as the defer to close the client and shutdown the server will happen while the consumer goroutines are still running, so we need to detect that gracefully rather than accidentally failing the test.

[ci skip] as this test isn't run under Travis.

Signed-off-by: Neil Twigg <neil@nats.io>