### PR TITLE
[FIXED] (2.11) Idempotent stream/consumer create after server upgrade

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1593,7 +1593,7 @@ func (s *Server) jsStreamCreateRequest(sub *subscription, c *client, _ *Account,
 	}
 
 	// Initialize asset version metadata.
-	setStaticStreamMetadata(&cfg.StreamConfig, nil)
+	setStaticStreamMetadata(&cfg.StreamConfig)
 
 	streamName := streamNameFromSubject(subject)
 	if streamName != cfg.Name {
@@ -1732,7 +1732,7 @@ func (s *Server) jsStreamUpdateRequest(sub *subscription, c *client, _ *Account,
 	}
 
 	// Update asset version metadata.
-	setStaticStreamMetadata(&cfg, &mset.cfg)
+	setStaticStreamMetadata(&cfg)
 
 	if err := mset.updatePedantic(&cfg, ncfg.Pedantic); err != nil {
 		resp.Error = NewJSStreamUpdateError(err, Unless(err))
@@ -4427,16 +4427,14 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 		return
 	}
 
-	var oldCfg *ConsumerConfig
 	if o := stream.lookupConsumer(consumerName); o != nil {
-		oldCfg = &o.cfg
 		// If the consumer already exists then don't allow updating the PauseUntil, just set
 		// it back to whatever the current configured value is.
 		req.Config.PauseUntil = o.cfg.PauseUntil
 	}
 
 	// Initialize/update asset version metadata.
-	setStaticConsumerMetadata(&req.Config, oldCfg)
+	setStaticConsumerMetadata(&req.Config)
 
 	o, err := stream.addConsumerWithAction(&req.Config, req.Action, req.Pedantic)
 
@@ -5010,7 +5008,7 @@ func (s *Server) jsConsumerPauseRequest(sub *subscription, c *client, _ *Account
 
 		// Update asset version metadata due to updating pause/resume.
 		// Only PauseUntil is updated above, so reuse config for both.
-		setStaticConsumerMetadata(nca.Config, nca.Config)
+		setStaticConsumerMetadata(nca.Config)
 
 		eca := encodeAddConsumerAssignment(&nca)
 		cc.meta.Propose(eca)
@@ -5046,8 +5044,7 @@ func (s *Server) jsConsumerPauseRequest(sub *subscription, c *client, _ *Account
 	}
 
 	// Update asset version metadata due to updating pause/resume.
-	// Only PauseUntil is updated above, so reuse config for both.
-	setStaticConsumerMetadata(&ncfg, &ncfg)
+	setStaticConsumerMetadata(&ncfg)
 
 	if err := obs.updateConfig(&ncfg); err != nil {
 		// The only type of error that should be returned here is from o.store,


### PR DESCRIPTION
If a stream or consumer was created prior to 2.11 there would be no versioning metadata. After the server upgrade sending an identical create request would fail with `stream already exists`. If a stream or consumer already exists without metadata, creates are now idempotent. Which also means that the new versioning metadata will only be set if creating a new stream/consumer, or when updating it.

Also, the signatures of `setStaticStreamMetadata` and `setStaticConsumerMetadata` were updated, since the second parameter is unused. Cleaned that up, along with duplicate test cases in `jetstream_versioning_test.go`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
