### PR TITLE
Add automemlimit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.6
 
 require (
+	github.com/KimMachineGun/automemlimit v0.7.0
 	github.com/antithesishq/antithesis-sdk-go v0.4.3-default-no-op
 	github.com/google/go-tpm v0.9.3
 	github.com/klauspost/compress v1.17.11
@@ -18,3 +19,5 @@ require (
 	golang.org/x/sys v0.30.0
 	golang.org/x/time v0.10.0
 )
+
+require github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/KimMachineGun/automemlimit v0.7.0 h1:7G06p/dMSf7G8E6oq+f2uOPuVncFyIlDI/pBWK49u88=
+github.com/KimMachineGun/automemlimit v0.7.0/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/antithesishq/antithesis-sdk-go v0.4.3-default-no-op h1:+OSa/t11TFhqfrX0EOSqQBDJ0YlpmK0rDSiB19dg9M0=
 github.com/antithesishq/antithesis-sdk-go v0.4.3-default-no-op/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl3v2yvUZjmKncl7U91fup7E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -16,6 +18,8 @@ github.com/nats-io/nkeys v0.4.10 h1:glmRrpCmYLHByYcePvnTBEAwawwapjCPMjy2huw20wc=
 github.com/nats-io/nkeys v0.4.10/go.mod h1:OjRrnIKnWBFl+s4YK5ChQfvHP2fxqZexrKJoVVyWB3U=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=

--- a/main.go
+++ b/main.go
@@ -18,8 +18,11 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
+	"runtime/debug"
 
+	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/nats-io/nats-server/v2/server"
 	"go.uber.org/automaxprocs/maxprocs"
 )
@@ -135,6 +138,11 @@ func main() {
 	} else {
 		defer undo()
 	}
+
+	// If GOMEMLIMIT is not set, adjust GOMEMLIMIT if running under linux/cgroups quotas.
+	memlimit.SetGoMemLimitWithOpts(memlimit.WithRatio(0.8), memlimit.WithLogger(slog.Default()))
+	currentMemLimit := debug.SetMemoryLimit(-1)
+	s.Noticef("Effective GOMEMLIMIT: %d bytes", currentMemLimit)
 
 	s.WaitForShutdown()
 }


### PR DESCRIPTION
## Summary
The problem:
![image](https://github.com/user-attachments/assets/1180de82-6661-454d-9415-ede570afb5fa)

A Guide to the Go Garbage Collector [suggests](https://go.dev/doc/gc-guide#:~:text=Do%20take%20advantage,is%20unaware%20of):

> Do take advantage of the memory limit when the execution environment of your Go program is entirely within your control, and the Go program is the only program with access to some set of resources (i.e. some kind of memory reservation, like a container memory limit).
> A good example is the deployment of a web service into containers with a fixed amount of available memory.
> In this case, a good rule of thumb is to leave an additional 5-10% of headroom to account for memory sources the Go runtime is unaware of.

When running in Kubernetes, the memory limit [set using cgroups]( https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#how-pods-with-resource-limits-are-run)

Let's use the [library](https://pkg.go.dev/github.com/KimMachineGun/automemlimit@v0.7.0/memlimit) that can automatically set the [GOMEMLIMIT](https://pkg.go.dev/runtime/debug#SetMemoryLimit) to a set percentage of memory limit of the cgroup

## Reproducibe test plan:
1. When no GOMEMLIMIT is set, the effective value is the default, math.MaxInt64 
```
# go build .

# ./nats-server 
...
[81117] 2025/02/20 12:59:21.150405 [INF] Server is ready
2025/02/20 12:59:21 INFO memory is not limited, skipping package=github.com/KimMachineGun/automemlimit/memlimit
[81117] 2025/02/20 12:59:21.151533 [INF] Effective GOMEMLIMIT: 9223372036854775807 bytes
```

2. When env var is set, its value is respected:
```
# GOMEMLIMIT=1000MiB ./nats-server 
[81345] 2025/02/20 13:00:50.034879 [INF] Server is ready
2025/02/20 13:00:50 INFO GOMEMLIMIT is already set, skipping package=github.com/KimMachineGun/automemlimit/memlimit GOMEMLIMIT=1000MiB
[81345] 2025/02/20 13:00:50.035615 [INF] Effective GOMEMLIMIT: 1048576000 bytes
```

Build a docker image for test: 
```
goreleaser release --snapshot --clean -f .goreleaser-nightly.yml 
```

3. When running in docker, by default no limit is set:
```
# docker run synadia/nats-server:add_automemlimit
...
[1] 2025/02/20 21:03:10.188627 [INF] Server is ready
[1] 2025/02/20 21:03:10.188685 [INF] Cluster name is 9QPBj9CtvlZlE9b8iyUn3a
[1] 2025/02/20 21:03:10.188829 [WRN] Cluster name was dynamically generated, consider setting one
[1] 2025/02/20 21:03:10.188923 [INF] Listening for route connections on 0.0.0.0:6222
2025/02/20 21:03:10 INFO memory is not limited, skipping package=github.com/KimMachineGun/automemlimit/memlimit
[1] 2025/02/20 21:03:10.189336 [INF] Effective GOMEMLIMIT: 9223372036854775807 bytes
```

4. When running in a container with a memory limit:
```
# docker run --cpus="4.0" --memory="2000m"  --name nats_container synadia/nats-server:add_automemlimit
[1] 2025/02/20 21:03:58.776768 [INF] Server is ready
[1] 2025/02/20 21:03:58.776869 [INF] Cluster name is ffq6b2J0D4cUuImY6PcyRA
[1] 2025/02/20 21:03:58.776899 [WRN] Cluster name was dynamically generated, consider setting one
[1] 2025/02/20 21:03:58.776986 [INF] Listening for route connections on 0.0.0.0:6222
2025/02/20 21:03:58 INFO GOMEMLIMIT is updated package=github.com/KimMachineGun/automemlimit/memlimit GOMEMLIMIT=1677721600 previous=9223372036854775807
[1] 2025/02/20 21:03:58.777953 [INF] Effective GOMEMLIMIT: 1677721600 bytes
```
The GOMEMLIMIT is set to 80% of the cgroup memory limit, as expected.
```
# cat  /sys/fs/cgroup/system.slice/docker-$(docker inspect --format="{{.Id}}" nats_container).scope/memory.max
2097152000
```

Signed-off-by: Alex Bozhenko <alex@synadia.com>
