### PR TITLE
[FIXED] (2.11) Replicated consumer skipped redeliveries

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -5293,13 +5293,13 @@ func (o *consumer) selectStartingSeqNo() {
 			} else if o.cfg.DeliverPolicy == DeliverLast {
 				if o.subjf == nil {
 					o.sseq = state.LastSeq
-					return
-				}
-				// If we are partitioned here this will be properly set when we become leader.
-				for _, filter := range o.subjf {
-					ss := o.mset.store.FilteredState(1, filter.subject)
-					if ss.Last > o.sseq {
-						o.sseq = ss.Last
+				} else {
+					// If we are partitioned here this will be properly set when we become leader.
+					for _, filter := range o.subjf {
+						ss := o.mset.store.FilteredState(1, filter.subject)
+						if ss.Last > o.sseq {
+							o.sseq = ss.Last
+						}
 					}
 				}
 			} else if o.cfg.DeliverPolicy == DeliverLastPerSubject {

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -9884,9 +9884,30 @@ func (o *consumerFileStore) SetStarting(sseq uint64) error {
 	return o.writeState(buf)
 }
 
+// UpdateStarting updates our starting stream sequence.
+func (o *consumerFileStore) UpdateStarting(sseq uint64) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if sseq > o.state.Delivered.Stream {
+		o.state.Delivered.Stream = sseq
+		// For AckNone just update delivered and ackfloor at the same time.
+		if o.cfg.AckPolicy == AckNone {
+			o.state.AckFloor.Stream = sseq
+		}
+	}
+	// Make sure we flush to disk.
+	o.kickFlusher()
+}
+
 // HasState returns if this store has a recorded state.
 func (o *consumerFileStore) HasState() bool {
 	o.mu.Lock()
+	// We have a running state, or stored on disk but not yet initialized.
+	if o.state.Delivered.Consumer != 0 || o.state.Delivered.Stream != 0 {
+		o.mu.Unlock()
+		return true
+	}
 	_, err := os.Stat(o.ifn)
 	o.mu.Unlock()
 	return err == nil
@@ -9939,7 +9960,7 @@ func (o *consumerFileStore) UpdateDelivered(dseq, sseq, dc uint64, ts int64) err
 			if o.state.Redelivered == nil {
 				o.state.Redelivered = make(map[uint64]uint64)
 			}
-			// Only update if greater then what we already have.
+			// Only update if greater than what we already have.
 			if o.state.Redelivered[sseq] < dc-1 {
 				o.state.Redelivered[sseq] = dc - 1
 			}

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -9975,12 +9975,6 @@ func (o *consumerFileStore) UpdateAcks(dseq, sseq uint64) error {
 		return nil
 	}
 
-	// Match leader logic on checking if ack is ahead of delivered.
-	// This could happen on a cooperative takeover with high speed deliveries.
-	if sseq > o.state.Delivered.Stream {
-		o.state.Delivered.Stream = sseq + 1
-	}
-
 	if len(o.state.Pending) == 0 || o.state.Pending[sseq] == nil {
 		delete(o.state.Redelivered, sseq)
 		return ErrStoreMsgNotFound

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -7667,6 +7667,160 @@ func TestJetStreamClusterMessageTTLCatchup(t *testing.T) {
 	require_NotEqual(t, fs.(*fileStore).ttls.GetNextExpiration(math.MaxInt64), math.MaxInt64)
 }
 
+func TestJetStreamClusterConsumerRedeliveryAfterUnexpectedReplicatedAck(t *testing.T) {
+	for _, storage := range []nats.StorageType{nats.FileStorage, nats.MemoryStorage} {
+		t.Run(storage.String(), func(t *testing.T) {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+
+			nc, js := jsClientConnect(t, c.randomServer())
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     "TEST",
+				Subjects: []string{"foo"},
+				Replicas: 3,
+				Storage:  storage,
+			})
+			require_NoError(t, err)
+
+			for i := 0; i < 3; i++ {
+				_, err = js.Publish("foo", nil)
+				require_NoError(t, err)
+			}
+
+			sub, err := js.PullSubscribe("foo", "CONSUMER")
+			require_NoError(t, err)
+			defer sub.Unsubscribe()
+
+			getConsumerRaftNode := func(s *Server) *raft {
+				acc, err := s.lookupAccount(globalAccountName)
+				require_NoError(t, err)
+				mset, err := acc.lookupStream("TEST")
+				require_NoError(t, err)
+				o := mset.lookupConsumer("CONSUMER")
+				require_NotNil(t, o)
+				return o.raftNode().(*raft)
+			}
+
+			cl := c.consumerLeader(globalAccountName, "TEST", "CONSUMER")
+			rn := getConsumerRaftNode(cl)
+			rn.RLock()
+			bindex := rn.pindex
+			rn.RUnlock()
+
+			// Simulate sending replicated ack.
+			dseq, sseq := uint64(100), uint64(100)
+			var b [2*binary.MaxVarintLen64 + 1]byte
+			b[0] = byte(updateAcksOp)
+			n := 1
+			n += binary.PutUvarint(b[n:], dseq)
+			n += binary.PutUvarint(b[n:], sseq)
+			require_NoError(t, rn.Propose(b[:n]))
+
+			// Wait for ack to be applied.
+			checkFor(t, 2*time.Second, 500*time.Millisecond, func() error {
+				rn.RLock()
+				defer rn.RUnlock()
+				if rn.applied <= bindex {
+					return errors.New("proposal not applied yet")
+				}
+				return nil
+			})
+
+			// Ensure other servers can't become leader.
+			for _, s := range c.servers {
+				if s != cl {
+					cn := getConsumerRaftNode(s)
+					cn.Lock()
+					cn.paused = true
+					cn.Unlock()
+				}
+			}
+			// Step down and campaign, should re-elect the same leader.
+			require_NoError(t, rn.StepDown())
+			require_NoError(t, rn.Campaign())
+			c.waitOnConsumerLeader(globalAccountName, "TEST", "CONSUMER")
+
+			// Replicated ack would move starting sequence ahead, which made it so we skipped messages.
+			// It should have been ignored, and we should get the messages redelivered.
+			msgs, err := sub.Fetch(3, nats.MaxWait(2*time.Second))
+			require_NoError(t, err)
+			require_Len(t, len(msgs), 3)
+		})
+	}
+}
+
+func TestJetStreamClusterConsumerResetStartingSequenceToAgreedState(t *testing.T) {
+	for _, storage := range []nats.StorageType{nats.FileStorage, nats.MemoryStorage} {
+		t.Run(storage.String(), func(t *testing.T) {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+
+			nc, js := jsClientConnect(t, c.randomServer())
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     "TEST",
+				Subjects: []string{"foo"},
+				Replicas: 3,
+				Storage:  storage,
+			})
+			require_NoError(t, err)
+
+			for i := 0; i < 3; i++ {
+				_, err = js.Publish("foo", nil)
+				require_NoError(t, err)
+			}
+
+			sub, err := js.PullSubscribe("foo", "CONSUMER")
+			require_NoError(t, err)
+			defer sub.Unsubscribe()
+
+			cl := c.consumerLeader(globalAccountName, "TEST", "CONSUMER")
+
+			// Ensure other servers can't become leader.
+			for _, s := range c.servers {
+				if s != cl {
+					acc, err := s.lookupAccount(globalAccountName)
+					require_NoError(t, err)
+					mset, err := acc.lookupStream("TEST")
+					require_NoError(t, err)
+					o := mset.lookupConsumer("CONSUMER")
+					require_NotNil(t, o)
+					cn := o.raftNode().(*raft)
+					cn.Lock()
+					cn.paused = true
+					cn.Unlock()
+				}
+			}
+
+			acc, err := cl.lookupAccount(globalAccountName)
+			require_NoError(t, err)
+			mset, err := acc.lookupStream("TEST")
+			require_NoError(t, err)
+			o := mset.lookupConsumer("CONSUMER")
+			require_NotNil(t, o)
+			rn := o.raftNode().(*raft)
+
+			// Move consumer leader's state ahead to an unreasonable value.
+			// Its WAL does not contain entries for this, so reset back to agreed state.
+			o.mu.Lock()
+			o.sseq = 100
+			o.mu.Unlock()
+			// Step down and campaign, should re-elect the same leader.
+			require_NoError(t, rn.StepDown())
+			require_NoError(t, rn.Campaign())
+			c.waitOnConsumerLeader(globalAccountName, "TEST", "CONSUMER")
+
+			// Messages would not be redelivered if starting sequence was not reset back to agreed state.
+			msgs, err := sub.Fetch(3, nats.MaxWait(2*time.Second))
+			require_NoError(t, err)
+			require_Len(t, len(msgs), 3)
+		})
+	}
+}
+
 //
 // DO NOT ADD NEW TESTS IN THIS FILE  (unless to balance test times)
 // Add at the end of jetstream_cluster_<n>_test.go, with <n> being the highest value.

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -1390,7 +1390,7 @@ func TestJetStreamBasicDeliverSubject(t *testing.T) {
 			}
 			// Check that is the last msg we sent though.
 			if mseq, _ := strconv.Atoi(string(m.Data)); mseq != 200 {
-				t.Fatalf("Expected messag sequence to be 200, but got %d", mseq)
+				t.Fatalf("Expected message sequence to be 200, but got %d", mseq)
 			}
 
 			checkSubEmpty()

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -2069,12 +2069,6 @@ func (o *consumerMemStore) UpdateAcks(dseq, sseq uint64) error {
 		return nil
 	}
 
-	// Match leader logic on checking if ack is ahead of delivered.
-	// This could happen on a cooperative takeover with high speed deliveries.
-	if sseq > o.state.Delivered.Stream {
-		o.state.Delivered.Stream = sseq + 1
-	}
-
 	if len(o.state.Pending) == 0 || o.state.Pending[sseq] == nil {
 		delete(o.state.Redelivered, sseq)
 		return ErrStoreMsgNotFound

--- a/server/store.go
+++ b/server/store.go
@@ -350,6 +350,7 @@ func (dbs DeleteBlocks) NumDeleted() (total uint64) {
 // ConsumerStore stores state on consumers for streams.
 type ConsumerStore interface {
 	SetStarting(sseq uint64) error
+	UpdateStarting(sseq uint64)
 	HasState() bool
 	UpdateDelivered(dseq, sseq, dc uint64, ts int64) error
 	UpdateAcks(dseq, sseq uint64) error


### PR DESCRIPTION
Replicated consumers could skip redeliveries of non-acked messages when:
- A message was delivered to the client, but there was no quorum on updating delivered state across replicas. Then a replicated ack came in, which would up the starting sequence, skipping redelivery of messages below. The following code caused that issue:
```go
// Match leader logic on checking if ack is ahead of delivered.
// This could happen on a cooperative takeover with high speed deliveries.
if sseq > o.state.Delivered.Stream {
	o.state.Delivered.Stream = sseq + 1
}
```
- A message was delivered to the client, but there was no quorum on updating delivered state across replicas. Then the consumer leader steps down, and becomes leader again. It would not  reset `o.sseq` back down to agreed state, skipping redelivery of messages below. The following code caused that issue:
```go
// If o.sseq is greater don't update. Don't go backwards on o.sseq if leader.
if !o.isLeader() || o.sseq <= state.Delivered.Stream {
	o.sseq = state.Delivered.Stream + 1
}
```

Other included commits fix various code/tests that depended on above lines of code:
- `TestJetStreamSuperClusterConsumerDeliverNewBug` started flaking. It would never guarantee that all replicas agreed on the same consumer state.
  - The issue lied in `o.store.SetStarting(o.sseq - 1)` always being called, without being based on replicated state. Which meant that when the storage directory was purged, this state would not reliably come back. Now `o.updateSkipped(o.sseq)` is called for the very first time of becoming leader. Ensuring all replicas agree on the initial starting sequence, skipped ahead or not. It has also been changed to not only skip ahead `o.sseq`, but also reflect this in the underlying stored state.
  - The test has also been made stricter, not only checking the state on the consumer leader, but all replicas. And also checking both the in-memory state and the replicated state being exactly what they are supposed to be.
- `TestJetStreamBasicDeliverSubject` started failing due to a misplaced `return` in `o.selectStartingSeqNo()`. The return is now removed.
- `TestJetStreamClusterConsumerDeliveredSyncReporting` had a small correctness issue, as skipping ahead `o.sseq` would not be reflected in the underlying store. Now before the first fetch we expect stream/consumer sequence 0, after that fetch we expect stream/consumer sequence 1, and after the last fetch we expect a consumer sequence 1, and a skipped ahead stream sequence 11.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
