### PR TITLE
Don't panic if install snapshot failed in TestNRGChainOfBlocks

### DIFF
--- a/server/raft_chain_of_blocks_helpers_test.go
+++ b/server/raft_chain_of_blocks_helpers_test.go
@@ -315,7 +315,8 @@ func (sm *RCOBStateMachine) createSnapshot() {
 	// InstallSnapshot is actually "save the snapshot", which is an operation delegated to the node
 	err = sm.n.InstallSnapshot(snapshotData)
 	if err != nil {
-		panic(fmt.Sprintf("failed to snapshot: %s", err))
+		sm.logDebug("failed to snapshot: %s", err)
+		return
 	}
 
 	// Reset counter since last snapshot


### PR DESCRIPTION
```
FAIL: TestLongNRGChainOfBlocks (400.71s)
panic: failed to snapshot: raft: snapshot can not be installed while catchups running [recovered]
    panic: failed to snapshot: raft: snapshot can not be installed while catchups running
```

Installing snapshots can fail, for example if catchups are running. Don't need to panic if it fails.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
