### PR TITLE
De-flake TestJetStreamConsumerMaxDeliveryAndServerRestart

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -3728,6 +3728,8 @@ func TestJetStreamConsumerMaxDeliveryAndServerRestart(t *testing.T) {
 	}
 
 	waitForClientReconnect := func() {
+		t.Helper()
+		require_NoError(t, nc.ForceReconnect())
 		checkFor(t, 2500*time.Millisecond, 5*time.Millisecond, func() error {
 			if !nc.IsConnected() {
 				return fmt.Errorf("Not connected")


### PR DESCRIPTION
The test could fail with the following error:
```
    jetstream_test.go:3749: No response for "order-3" (error: nats: timeout)
```

This was due to the server restarting, but the connection not yet recognizing the server was stopped when `sendStreamMsg(t, nc, mname, "order-3")` is called resulting in a timeout. Instead we can just force reconnect since we know we need to reconnect, and this test is about the MaxDelivery setting after restarts.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
