### PR TITLE
De-flake TestNoRaceJetStreamClusterInterestPullConsumerStreamLimitBug

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -5119,15 +5119,17 @@ func TestNoRaceJetStreamClusterInterestPullConsumerStreamLimitBug(t *testing.T) 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for {
-			pt := time.NewTimer(time.Duration(rand.Intn(2)) * time.Millisecond)
+		for i := 0; ; i++ {
 			select {
-			case <-pt.C:
+			case <-qch:
+				return
+			default:
 				_, err := js.Publish("foo", []byte("BUG!"))
 				require_NoError(t, err)
-			case <-qch:
-				pt.Stop()
-				return
+				// Only sleep every so often.
+				if i % 100 == 0 {
+					time.Sleep(time.Millisecond)
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
The test could fail with the following error messages:
```
    norace_test.go:5181: Not hit limit yet
    norace_test.go:5163: Got a Fetch error: nats: Server Shutdown
    norace_test.go:5163: Got a Fetch error: nats: Server Shutdown
    norace_test.go:5163: Got a Fetch error: nats: Server Shutdown
    norace_test.go:5163: Got a Fetch error: nats: Server Shutdown
```

This was triggered by:
```go
if si.State.Msgs < limit {
	return fmt.Errorf("Not hit limit yet")
}
```

If we'd wait for 1 millisecond too often, you'd get this error.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>