### PR TITLE
Use GitHub Actions for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+name: NATS Server Releases
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  run:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Check version matches tag
+        env:
+          TRAVIS_TAG: ${{ github.ref_name }}
+        run: |
+          go test -race -v -run=TestVersionMatchesTag ./server -ldflags="-X=github.com/nats-io/nats-server/v2/server.serverVersion=$TRAVIS_TAG" -count=1 -vet=off
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.7.0
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0.18.0
+        with:
+          syft-version: "v1.20.0"
+
+      - name: Create release
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ version: 2
 
 release:
   github:
-    owner: nats-io
+    owner: '{{ envOrDefault "GITHUB_REPOSITORY_OWNER" "nats-io" }}'
     name: nats-server
   name_template: "Release {{.Tag}}"
   draft: true
@@ -71,10 +71,10 @@ archives:
   - name_template: "{{.ProjectName}}-{{.Tag}}-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}"
     id: targz-archives
     wrap_in_directory: true
-    format: tar.gz
+    formats: ["tar.gz"]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]
     files:
       - README.md
       - LICENSE

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,17 +53,3 @@ jobs:
       env: TEST_SUITE=build_only
 
 script: ./scripts/runTestsOnTravis.sh $TEST_SUITE
-
-# Install Syft which is used by GoReleaser in the deploy step.
-# Cosign is an optional dependency to verify the Syft binary.
-before_deploy:
-  - curl -o /usr/local/bin/cosign -L https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 && chmod +x /usr/local/bin/cosign
-  - curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | COSIGN_BINARY=/usr/local/bin/cosign sh -s -- -v -b /usr/local/bin v1.18.1
-
-deploy:
-  provider: script
-  cleanup: true
-  script: curl -o /tmp/goreleaser.tar.gz -sLf https://github.com/goreleaser/goreleaser/releases/download/v2.6.1/goreleaser_Linux_x86_64.tar.gz && tar -xvf /tmp/goreleaser.tar.gz -C /tmp/ && /tmp/goreleaser
-  on:
-    tags: true
-    condition: ($TRAVIS_GO_VERSION =~ 1.24) && ($TEST_SUITE = "compile")

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -5127,7 +5127,7 @@ func TestNoRaceJetStreamClusterInterestPullConsumerStreamLimitBug(t *testing.T) 
 				_, err := js.Publish("foo", []byte("BUG!"))
 				require_NoError(t, err)
 				// Only sleep every so often.
-				if i % 100 == 0 {
+				if i%100 == 0 {
 					time.Sleep(time.Millisecond)
 				}
 			}


### PR DESCRIPTION
This switches the release process to use GitHub Actions instead of Travis CI.

Tested on a forked repository:
- Successful run: https://github.com/neilalexander/nats-server/actions/runs/13546082159/job/37857914525
- Created release: https://github.com/neilalexander/nats-server/releases/tag/v2.11.0-RC.4

Signed-off-by: Neil Twigg <neil@nats.io>