### PR TITLE
De-flake TestNoRaceJetStreamClusterConsumerInfoSpeed

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -6431,7 +6431,7 @@ func TestNoRaceJetStreamClusterConsumerInfoSpeed(t *testing.T) {
 		ci, err := js.ConsumerInfo("TEST", "DLC")
 		require_NoError(t, err)
 		// Make sure these are fast now.
-		if elapsed := time.Since(start); elapsed > 5*time.Millisecond {
+		if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
 			t.Fatalf("ConsumerInfo took too long: %v", elapsed)
 		}
 		// Make sure pending == expected.


### PR DESCRIPTION
The test can fail for any consumer info call that takes longer than 5ms. On CI, and for replicated streams/consumers this seems to be too short. Failing with for example:
```
norace_test.go:6441: ConsumerInfo took too long: 6.324631ms
norace_test.go:6457: ConsumerInfo took too long: 10.305282ms
```

Changed to 50ms to be aligned with other performance related tests like `TestJetStreamClusterConsumerDeleteInterestPolicyPerf`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
