### PR TITLE
De-flake TestNRGTermDoesntRollBackToPtermOnCatchup

### DIFF
--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -216,16 +216,16 @@ func (a *stateAdder) waitGroup() *sync.WaitGroup {
 }
 
 func (a *stateAdder) propose(data []byte) {
-	a.Lock()
-	defer a.Unlock()
-	a.n.ForwardProposal(data)
+	// Don't hold state machine lock as we could deadlock if the node was locked as part of the test.
+	n := a.node()
+	n.ForwardProposal(data)
 }
 
 func (a *stateAdder) applyEntry(ce *CommittedEntry) {
 	a.Lock()
-	defer a.Unlock()
 	if ce == nil {
 		// This means initial state is done/replayed.
+		a.Unlock()
 		return
 	}
 	for _, e := range ce.Entries {
@@ -237,7 +237,10 @@ func (a *stateAdder) applyEntry(ce *CommittedEntry) {
 		}
 	}
 	// Update applied.
-	a.n.Applied(ce.Index)
+	// But don't hold state machine lock as we could deadlock if the node was locked as part of the test.
+	n := a.n
+	a.Unlock()
+	n.Applied(ce.Index)
 }
 
 func (a *stateAdder) leaderChange(isLeader bool) {
@@ -309,12 +312,16 @@ func (a *stateAdder) total() int64 {
 
 // Install a snapshot.
 func (a *stateAdder) snapshot(t *testing.T) {
+	// Don't hold state machine lock as we could deadlock if the node was locked as part of the test.
 	a.Lock()
-	defer a.Unlock()
+	sum := a.sum
+	rn := a.n
+	a.Unlock()
+
 	data := make([]byte, binary.MaxVarintLen64)
-	n := binary.PutVarint(data, a.sum)
+	n := binary.PutVarint(data, sum)
 	snap := data[:n]
-	require_NoError(t, a.n.InstallSnapshot(snap))
+	require_NoError(t, rn.InstallSnapshot(snap))
 }
 
 // Helper to wait for a certain state.

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -865,6 +865,11 @@ func TestNRGTermDoesntRollBackToPtermOnCatchup(t *testing.T) {
 	_, err := nc.ChanSubscribe(arInbox, arCh)
 	require_NoError(t, err)
 
+	// Ensure the subscription is known by the server we're connected to,
+	// but also by the other servers in the cluster.
+	require_NoError(t, nc.Flush())
+	time.Sleep(100 * time.Millisecond)
+
 	// In order to trip this condition, we need to send an append entry that
 	// will trick the followers into running a catchup. In the process they
 	// were setting the term back to pterm which is incorrect.


### PR DESCRIPTION
Various Raft tests could potentially deadlock if they'd make a call to `rg.lockAll()` which locks all Raft nodes while another part is also holding the state machine's lock and requires a Raft lock.

`TestNRGTermDoesntRollBackToPtermOnCatchup` could fail with the following error message due to interest propagation not being immediate.
```
raft_test.go:882: require read from channel within 5s but didn't get anything
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
