### PR TITLE
De-flake TestNoRaceJetStreamAccountLimitsAndRestart

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8647,9 +8647,6 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 	mset.mu.Lock()
 	st := mset.cfg.Storage
 	ddloaded := mset.ddloaded
-	tierName := mset.tier
-	replicas := mset.cfg.Replicas
-
 	if mset.hasAllPreAcks(seq, subj) {
 		mset.clearAllPreAcks(seq)
 		// Mark this to be skipped
@@ -8657,11 +8654,8 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 	}
 	mset.mu.Unlock()
 
+	// Since we're clustered we do not want to check limits based on tier here and possibly introduce skew.
 	if mset.js.limitsExceeded(st) {
-		return 0, NewJSInsufficientResourcesError()
-	} else if exceeded, apiErr := mset.jsa.limitsExceeded(st, tierName, replicas); apiErr != nil {
-		return 0, apiErr
-	} else if exceeded {
 		return 0, NewJSInsufficientResourcesError()
 	}
 

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -2111,6 +2111,10 @@ func checkState(t *testing.T, c *cluster, accountName, streamName string) error 
 			// Skip self
 			continue
 		}
+		if srv.isShuttingDown() {
+			// Skip if shutdown.
+			continue
+		}
 		acc, err := srv.LookupAccount(accountName)
 		require_NoError(t, err)
 		stream, err := acc.lookupStream(streamName)


### PR DESCRIPTION
The test could flake if the stream leader makes a snapshot which requires the shutdown follower to catchup based on that snapshot. The follower would then get these errors during startup:
```
[WRN] Catchup for stream '$JS > TEST' errored, account resources exceeded: insufficient resources (10023)
[WRN] Error applying entries to '$JS > TEST': insufficient resources (10023)
```

This was because tier-based limits would be checked during catchup, but we should not do so. The same reasoning mentioned in `processJetStreamMsg` applies here as well:
```go
// If clustered this was already checked and we do not want to check here and possibly introduce skew.
if !isClustered {
	if exceeded, err := jsa.wouldExceedLimits(stype, tierName, mset.cfg.Replicas, subject, hdr, msg); exceeded {
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>