### PR TITLE
[FIXED] Gateway: Possible loss of queue sub interest on restart

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -2412,7 +2412,7 @@ func (s *Server) gatewayUpdateSubInterest(accName string, sub *subscription, cha
 		if change < 0 {
 			return
 		}
-		entry = &sitally{n: 1, q: sub.queue != nil}
+		entry = &sitally{n: change, q: sub.queue != nil}
 		st[string(key)] = entry
 		first = true
 	} else {


### PR DESCRIPTION
If a server has a connection from a route or a leaf and the remote has more than one member of the same queue group, when the connection is recreated (due to network issue or server restart), then count coming from the connection would be greater than 1 but the server would store the interest count for outbound gateways as 1.

When one of the remote queue subscriber unsubscribes, the count would go down to 0 and the server would incorrectly send a protocol to the gateway indicating that there is no longer interest for this queue group, which would stop the flow.

A new queue subscriber on that group would resume the flow.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
