### PR TITLE
Fix panic when subject transform has missing tokens

### DIFF
--- a/server/subject_transform.go
+++ b/server/subject_transform.go
@@ -459,7 +459,16 @@ func (tr *subjectTransform) TransformTokenizedSubject(tokens []string) string {
 				}
 				b.WriteString(tr.getHashPartition(keyForHashing, int(tr.dtokmfintargs[i])))
 			case Wildcard: // simple substitution
-				b.WriteString(tokens[tr.dtokmftokindexesargs[i][0]])
+				switch {
+				case len(tr.dtokmftokindexesargs) < i:
+					break
+				case len(tr.dtokmftokindexesargs[i]) < 1:
+					break
+				case len(tokens) <= tr.dtokmftokindexesargs[i][0]:
+					break
+				default:
+					b.WriteString(tokens[tr.dtokmftokindexesargs[i][0]])
+				}
 			case SplitFromLeft:
 				sourceToken := tokens[tr.dtokmftokindexesargs[i][0]]
 				sourceTokenLen := len(sourceToken)

--- a/server/subject_transform_test.go
+++ b/server/subject_transform_test.go
@@ -221,3 +221,14 @@ func TestSubjectTransforms(t *testing.T) {
 	shouldMatch("*", "{{left(1,3)}}", "1234", "123")
 	shouldMatch("*", "{{left(1,6)}}", "1234", "1234")
 }
+
+func TestSubjectTransformDoesntPanicTransformingMissingToken(t *testing.T) {
+	defer func() {
+		p := recover()
+		require_True(t, p == nil)
+	}()
+
+	tr, err := NewSubjectTransform("foo.*", "one.two.{{wildcard(1)}}")
+	require_NoError(t, err)
+	require_Equal(t, tr.TransformTokenizedSubject([]string{"foo"}), "one.two.")
+}


### PR DESCRIPTION
It is likely that this is to do with a faulty service import, and we'll almost certainly be able to do better validation there too, but in the meantime we can and should avoid a panic with more rigorous bounds checking.

Signed-off-by: Neil Twigg <neil@nats.io>