### PR TITLE
Test panic with nil super cluster meta leader

### DIFF
--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -361,7 +361,9 @@ func createJetStreamTaggedSuperClusterWithGWProxy(t *testing.T, gwm gwProxyMap) 
 		reset(s)
 	}
 
+	sc.waitOnLeader()
 	ml := sc.leader()
+	require_True(t, ml != nil)
 	js := ml.getJetStream()
 	require_True(t, js != nil)
 	js.mu.RLock()


### PR DESCRIPTION
Tests like `TestJetStreamSuperClusterMetaStepDown` could fail if the meta leader was not yet available. It would panic on the `.getJetStream()` call. Wait for a leader and ensure the test doesn't panic/indicates no meta leader being available.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>