### PR TITLE
Data race in configureAccounts

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1383,8 +1383,9 @@ func (s *Server) configureAccounts(reloading bool) (map[string]struct{}, error) 
 
 	// Add any required exports from system account.
 	if s.sys != nil {
+		sysAcc := s.sys.account
 		s.mu.Unlock()
-		s.addSystemAccountExports(s.sys.account)
+		s.addSystemAccountExports(sysAcc)
 		s.mu.Lock()
 	}
 


### PR DESCRIPTION
`s.sys = nil` is called in `shutdownEventing()` while holding the lock. But `configureAccounts` reads after unlocking.

```
=== RUN   TestConfigReloadNoPanicOnShutdown
==================
WARNING: DATA RACE
Write at 0x00c0000ca330 by goroutine 132061:
  github.com/nats-io/nats-server/v2/server.(*Server).shutdownEventing()
      /home/travis/build/nats-io/nats-server/server/events.go:1831 +0x1f0
Previous read at 0x00c0000ca330 by goroutine 131431:
  github.com/nats-io/nats-server/v2/server.(*Server).configureAccounts()
      /home/travis/build/nats-io/nats-server/server/server.go:1387 +0x1245
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
