### PR TITLE
De-flake TestNoRaceProducerStallLimits

### DIFF
--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -11564,9 +11564,9 @@ func TestNoRaceProducerStallLimits(t *testing.T) {
 	elapsed := time.Since(start)
 	require_NoError(t, err)
 
-	// This should have not cleared on its own but should have bettwen min and max pause.
+	// This should have not cleared on its own but should have between min and max pause.
 	require_True(t, elapsed >= stallClientMinDuration)
-	require_True(t, elapsed < stallClientMaxDuration)
+	require_LessThan(t, elapsed, stallClientMaxDuration)
 
 	// Now test total maximum by loading up a bunch of requests and measuring the last one.
 	// Artificially set a stall channel again on the subscriber.
@@ -11586,7 +11586,7 @@ func TestNoRaceProducerStallLimits(t *testing.T) {
 	require_NoError(t, err)
 
 	require_True(t, elapsed >= stallTotalAllowed)
-	// Should always be close to totalAllowed (e.g. 10ms), but if you run alot of them in one go can bump up
+	// Should always be close to totalAllowed (e.g. 10ms), but if you run a lot of them in one go can bump up
 	// just past 12ms, hence the Max setting below to avoid a flapper.
-	require_True(t, elapsed < stallTotalAllowed+stallClientMaxDuration)
+	require_LessThan(t, elapsed, stallTotalAllowed+stallClientMaxDuration*2)
 }


### PR DESCRIPTION
Allow for some more time for a stalled request to return, and make error message more informative.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
