### PR TITLE
v2.11: Disable max_buffered_msgs by default, bump max_buffered_size

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -264,8 +264,8 @@ type ExternalStream struct {
 
 // For managing stream ingest.
 const (
-	streamDefaultMaxQueueMsgs  = 10_000
-	streamDefaultMaxQueueBytes = 1024 * 1024 * 128
+	streamDefaultMaxQueueMsgs  = -1
+	streamDefaultMaxQueueBytes = 256 * 1024 * 1024
 )
 
 // Stream is a jetstream stream of messages. When we receive a message internally destined


### PR DESCRIPTION
- Bump max_buffered_size to 256MB by default
- Disable max_buffered_msgs and make it opt-in

This will avoid running into IPQ len on simple benchmarks or use cases that the server handles fine, the max_buffered_msgs is enough to protect the memory usage in most cases.