### PR TITLE
v2.11: Disable skipping reload on no config changes

### DIFF
--- a/server/reload.go
+++ b/server/reload.go
@@ -1007,13 +1007,6 @@ func (s *Server) Reload() error {
 		// TODO: Dump previous good config to a .bak file?
 		return err
 	}
-
-	// Use the digest from the configuration to detect whether unnecessary to apply reload.
-	if s.getOpts().ConfigDigest() != "" && newOpts.ConfigDigest() == s.getOpts().ConfigDigest() {
-		s.Noticef("Config reload skipped. No changes detected.")
-		return nil
-	}
-
 	return s.ReloadOptions(newOpts)
 }
 

--- a/server/signal_test.go
+++ b/server/signal_test.go
@@ -92,10 +92,11 @@ func TestSignalToReloadConfig(t *testing.T) {
 
 	// Check that the reload time does not change when there are no changes.
 	loaded := s.ConfigTime()
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 	syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
-	if reloaded := s.ConfigTime(); reloaded.After(loaded) {
-		t.Fatalf("ConfigTime is incorrect.\nexpected no change: %s\ngot: %s", loaded, reloaded)
+	time.Sleep(250 * time.Millisecond)
+	if reloaded := s.ConfigTime(); reloaded.Equal(loaded) {
+		t.Fatalf("ConfigTime is incorrect.\nexpected reload time to change: %s\ngot: %s", loaded, reloaded)
 	}
 
 	// Repeat test to make sure that server services signals more than once...


### PR DESCRIPTION
Enabling this would require taking the digest of TLS certs among other extra state at the moment.  We could potentially re-enable in the future so that authorization with no changes is skipped since that would be safe to do.