### PR TITLE
De-flake TestJetStreamClusterStreamPublishWithActiveConsumers

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -1180,10 +1180,17 @@ func TestJetStreamClusterStreamPublishWithActiveConsumers(t *testing.T) {
 		}
 	}
 
-	ci, err := sub.ConsumerInfo()
-	if err != nil {
-		t.Fatalf("Unexpected error getting consumer info: %v", err)
-	}
+	var ci *nats.ConsumerInfo
+	checkFor(t, time.Second, 100*time.Millisecond, func() error {
+		ci, err = sub.ConsumerInfo()
+		if err != nil {
+			return fmt.Errorf("Unexpected error getting consumer info: %v", err)
+		}
+		if ci.Delivered.Stream != 11 {
+			return fmt.Errorf("expected delivered stream sequence to be %d, got %d", 11, ci.Delivered.Stream)
+		}
+		return nil
+	})
 
 	c.consumerLeader("$G", "foo", "dlc").Shutdown()
 	c.waitOnConsumerLeader("$G", "foo", "dlc")


### PR DESCRIPTION
Test would fail with:
```
    jetstream_cluster_1_test.go:1203: Consumer info did not match: &{Stream:foo ... Delivered:{Consumer:10 Stream:10 Last:<nil>} ...} vs &{Stream:foo ... Delivered:{Consumer:11 Stream:11 Last:<nil>} ...}
```

Delivered state is proposed asynchronously compared with a call to `sub.NextMsg`, so it can't be guaranteed to be up-to-date immediately after receiving a message. Need to wait for the state to be what we expect.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
