### PR TITLE
De-flake TestJetStreamClusterMirrorAndSourceExpiration

### DIFF
--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -1504,7 +1504,7 @@ func TestJetStreamClusterMirrorAndSourceExpiration(t *testing.T) {
 	sendBatch(100)
 	// Need to check both in parallel.
 	scheck, mcheck := uint64(0), uint64(0)
-	checkFor(t, 20*time.Second, 500*time.Millisecond, func() error {
+	checkFor(t, 20*time.Second, 100*time.Millisecond, func() error {
 		if scheck != 100 {
 			if si, _ := js.StreamInfo("S"); si != nil {
 				scheck = si.State.Msgs


### PR DESCRIPTION
`MaxAge` of source and mirror is just 500 milliseconds, so the interval must be faster than that.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
