### PR TITLE
De-flake TestJetStreamClusterConsumerAckSyncReporting

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -6167,6 +6167,11 @@ func TestJetStreamClusterConsumerAckSyncReporting(t *testing.T) {
 		require_NoError(t, err)
 	}
 
+	// Wait for all servers to converge on the same state. Stream and consumer leader could be different.
+	checkFor(t, time.Second, 100*time.Millisecond, func() error {
+		return checkState(t, c, globalAccountName, "TEST")
+	})
+
 	msgs, err := sub.Fetch(10)
 	require_NoError(t, err)
 	require_Equal(t, len(msgs), 10)


### PR DESCRIPTION
Test could fail with:
```
jetstream_cluster_1_test.go:6169: require int equal, but got: 9 != 10
```
If the stream leader and consumer leader are not on the same server.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>