### PR TITLE
Add js-meta-only healthz option

### DIFF
--- a/server/events_test.go
+++ b/server/events_test.go
@@ -2064,6 +2064,15 @@ func TestServerEventsHealthZSingleServer(t *testing.T) {
 			expected: HealthStatus{Status: "ok", StatusCode: 200},
 		},
 		{
+			name: "with js meta only",
+			req: &HealthzEventOptions{
+				HealthzOptions: HealthzOptions{
+					JSMetaOnly: true,
+				},
+			},
+			expected: HealthStatus{Status: "ok", StatusCode: 200},
+		},
+		{
 			name: "with account name",
 			req: &HealthzEventOptions{
 				HealthzOptions: HealthzOptions{
@@ -3046,6 +3055,7 @@ func TestServerEventsPingMonitorz(t *testing.T) {
 		{"HEALTHZ", nil, &JSzOptions{}, []string{"status"}},
 		{"HEALTHZ", &HealthzOptions{JSEnabledOnly: true}, &JSzOptions{}, []string{"status"}},
 		{"HEALTHZ", &HealthzOptions{JSServerOnly: true}, &JSzOptions{}, []string{"status"}},
+		{"HEALTHZ", &HealthzOptions{JSMetaOnly: true}, &JSzOptions{}, []string{"status"}},
 		{"EXPVARZ", nil, &ExpvarzStatus{}, []string{"memstats", "cmdline"}},
 	}
 

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -268,10 +268,30 @@ func TestJetStreamClusterMetaRecoveryLogic(t *testing.T) {
 
 	c.stopAll()
 	c.restartAll()
+	checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
+		s := c.leader()
+		hs := s.healthz(&HealthzOptions{
+			JSMetaOnly: true,
+		})
+		if hs.Error != _EMPTY_ {
+			return errors.New(hs.Error)
+		}
+		return nil
+	})
 	c.waitOnLeader()
 	c.waitOnStreamLeader("$G", "TEST")
 
 	s = c.randomNonLeader()
+	checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
+		hs := s.healthz(&HealthzOptions{
+			JSMetaOnly: true,
+		})
+		if hs.Error != _EMPTY_ {
+			return errors.New(hs.Error)
+		}
+		return nil
+	})
+
 	nc, js = jsClientConnect(t, s)
 	defer nc.Close()
 

--- a/server/norace_test.go
+++ b/server/norace_test.go
@@ -6564,8 +6564,7 @@ func TestNoRaceJetStreamKVAccountWithServerRestarts(t *testing.T) {
 			restarted := c.restartServer(server)
 			checkFor(t, time.Second, 200*time.Millisecond, func() error {
 				hs := restarted.healthz(&HealthzOptions{
-					JSEnabled:    true,
-					JSServerOnly: true,
+					JSMetaOnly: true,
 				})
 				if hs.Error != _EMPTY_ {
 					return errors.New(hs.Error)
@@ -6728,8 +6727,7 @@ func TestNoRaceJetStreamClusterGhostConsumers(t *testing.T) {
 		restarted := c.restartServer(server)
 		checkFor(t, time.Second, 200*time.Millisecond, func() error {
 			hs := restarted.healthz(&HealthzOptions{
-				JSEnabled:    true,
-				JSServerOnly: true,
+				JSMetaOnly: true,
 			})
 			if hs.Error != _EMPTY_ {
 				return errors.New(hs.Error)


### PR DESCRIPTION
This option checks the healthz state similar to js-server-only used to do on v2.10.X.
