### PR TITLE
De-flake TestJetStreamClusterRespectConsumerStartSeq

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -7610,6 +7610,11 @@ func TestJetStreamClusterRespectConsumerStartSeq(t *testing.T) {
 	err = js.PurgeStream("TEST", &nats.StreamPurgeRequest{Sequence: 10})
 	require_NoError(t, err)
 
+	// Ensure all servers are up-to-date.
+	checkFor(t, 2*time.Second, 500*time.Millisecond, func() error {
+		return checkState(t, c, globalAccountName, "TEST")
+	})
+
 	ci, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
 		DeliverPolicy: nats.DeliverByStartSequencePolicy,
 		OptStartSeq:   20,


### PR DESCRIPTION
Stream is replicated, so `js.PurgeStream` could be performed too late on a follower where the consumer is created on, resulting in:
```
jetstream_cluster_1_test.go:7627: require uint64 equal, but got: 4 != 9
```
Since the purge hasn't happened yet on that follower, so the first seq isn't ahead yet.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>