### PR TITLE
Set CommitDate in goreleaser archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,8 +76,12 @@ archives:
       - goos: windows
         formats: ["zip"]
     files:
-      - README.md
-      - LICENSE
+      - src: README.md
+        info:
+          mtime: "{{ .CommitDate }}"
+      - src: LICENSE
+        info:
+          mtime: "{{ .CommitDate }}"
 
 checksum:
   name_template: "SHA256SUMS"


### PR DESCRIPTION
Follow up to https://github.com/nats-io/nats-server/pull/6299
The modification time of LICENSE and README.md in the archive is the one when the job https://github.com/nats-io/nats-server/actions/runs/13816873025/job/38652255585 checked out the code:
```
wget https://github.com/nats-io/nats-server/releases/download/v2.11.0-RC.3/nats-server-v2.11.0-RC.3-linux-amd64.tar.gz
tar -xvf nats-server-v2.11.0-RC.3-linux-amd64.tar.gz
ll nats-server-v2.11.0-RC.3-linux-amd64
total 16080
drwxr-xr-x  2 alex alex      100 Mar 12 12:58 .
drwxrwxrwt 48 root root     1280 Mar 12 12:57 ..
-rw-r--r--  1 alex alex    11357 Mar 12 09:54 LICENSE
-rwxr-xr-x  1 alex alex 16442017 Mar 12 09:43 nats-server
-rw-r--r--  1 alex alex     4404 Mar 12 09:54 README.md
```
And that works as designed: https://github.com/actions/checkout/issues/364#issuecomment-812618265

Those timestamps make archive not reproducible. Fix it by setting to commitDate.

## Test plan:
```
 touch LICENSE README.md
```
```
goreleaser  release --snapshot --clean -f .goreleaser.yml
```
Timestamp of all the files is the same(commit date), making archives reproducible:
```
tar -xvf dist/nats-server-v2.11.0-RC.3-linux-amd64.tar.gz
# ll nats-server-v2.11.0-RC.3-linux-amd64/
total 16088
drwxr-xr-x  2 alex alex     4096 Mar 12 12:53 .
drwxr-xr-x 16 alex alex     4096 Mar 12 12:53 ..
-rw-r--r--  1 alex alex    11357 Mar 12 09:43 LICENSE
-rwxr-xr-x  1 alex alex 16442017 Mar 12 09:43 nats-server
-rw-r--r--  1 alex alex     4404 Mar 12 09:43 README.md
```



Signed-off-by: Alex Bozhenko <alex@synadia.com>