### PR TITLE
De-flake TestJetStreamAutoTuneFSConfig

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -324,9 +324,9 @@ func TestJetStreamAutoTuneFSConfig(t *testing.T) {
 
 	acc := s.GlobalAccount()
 
-	testBlkSize := func(subject string, maxMsgs, maxBytes int64, expectedBlkSize uint64) {
+	testBlkSize := func(name string, maxMsgs, maxBytes int64, expectedBlkSize uint64) {
 		t.Helper()
-		mset, err := acc.addStream(streamConfig(subject, maxMsgs, maxBytes))
+		mset, err := acc.addStream(streamConfig(name, maxMsgs, maxBytes))
 		if err != nil {
 			t.Fatalf("Unexpected error adding stream: %v", err)
 		}
@@ -339,6 +339,10 @@ func TestJetStreamAutoTuneFSConfig(t *testing.T) {
 			t.Fatalf("Expected auto tuned block size to be %d, got %d", expectedBlkSize, fsCfg.BlockSize)
 		}
 	}
+
+	// Create a dummy stream, to ensure removing stream/account directories don't race.
+	_, err := acc.addStream(streamConfig("dummy", 1, 0))
+	require_NoError(t, err)
 
 	testBlkSize("foo", 1, 0, FileStoreMinBlkSize)
 	testBlkSize("foo", 1, 512, FileStoreMinBlkSize)


### PR DESCRIPTION
Would race due to cleaning up streams/account directories in a goroutine.
```
=== RUN   TestJetStreamAutoTuneFSConfig
    jetstream_test.go:347: Unexpected error adding stream: could not create storage directory - mkdir /tmp/TestJetStreamAutoTuneFSConfig1851261231/002/jetstream/$G/streams/foo_bar_baz: no such file or directory (10077)
--- FAIL: TestJetStreamAutoTuneFSConfig (0.01s)
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>