### PR TITLE
[FIXED] Config Reload: Possible panic when adding dedicated route

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -572,6 +572,12 @@ func (c *client) processRouteInfo(info *Info) {
 					return
 				}
 				s.mu.Lock()
+				// If running without system account and adding a dedicated
+				// route for an account for the first time, it could be that
+				// the map is nil. If so, create it.
+				if s.accRoutes == nil {
+					s.accRoutes = make(map[string]map[string]*client)
+				}
 				if _, ok := s.accRoutes[an]; !ok {
 					s.accRoutes[an] = make(map[string]*client)
 				}


### PR DESCRIPTION
When the cluster is configured without any pinned account and the system account is disabled, the first time an account would be added to the `accounts` lister in the `cluster{}` block and the configuration would be reloaded, the remote server would panic.

This would not happen if the system account was not disabled.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>