### PR TITLE
De-flake TestJetStreamClusterInterestStreamConsumer

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -1262,6 +1262,13 @@ func TestJetStreamClusterHAssetsEnforcement(t *testing.T) {
 }
 
 func TestJetStreamClusterInterestStreamConsumer(t *testing.T) {
+	checkInterestStateT = 4 * time.Second
+	checkInterestStateJ = 1
+	defer func() {
+		checkInterestStateT = defaultCheckInterestStateT
+		checkInterestStateJ = defaultCheckInterestStateJ
+	}()
+
 	c := createJetStreamClusterExplicit(t, "R5S", 5)
 	defer c.shutdown()
 
@@ -1309,7 +1316,7 @@ func TestJetStreamClusterInterestStreamConsumer(t *testing.T) {
 	}
 
 	// Make sure replicated acks are processed.
-	checkFor(t, time.Second, 250*time.Millisecond, func() error {
+	checkFor(t, 20*time.Second, 250*time.Millisecond, func() error {
 		si, err := js.StreamInfo("TEST")
 		if err != nil {
 			return err


### PR DESCRIPTION
Since replicated interest/workqueue streams now do message removals through proposals sent by the consumer leader, there could be a scenario where one consumer leader is on one server, and another leader on another. Both leaders process acks first, and both decide to not remove the message, then the followers process acks (and they aren't allowed to propose message removals). Due to this ordering the messages would not be removed early, and `checkInterestState` needs to run to clear them up.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>