### PR TITLE
Fixed test `TestJetStreamClusterMetaRecoveryLogic` causing data race

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -253,7 +253,10 @@ func TestJetStreamClusterMetaRecoveryLogic(t *testing.T) {
 				return errors.New("no meta leader")
 			}
 			sjs := ml.getJetStream()
-			if sjs.streamAssignment("$G", "TEST") != nil {
+			sjs.mu.RLock()
+			sa := sjs.streamAssignment("$G", "TEST")
+			sjs.mu.RUnlock()
+			if sa != nil {
 				return errors.New("stream exists still")
 			}
 			return nil


### PR DESCRIPTION
This was because it was calling `streamAssignment` without proper JS locking.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
