### PR TITLE
De-flake subject delete marker tests

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -8583,7 +8583,7 @@ func TestFileStoreSubjectDeleteMarkers(t *testing.T) {
 	}
 
 	// The last message should be gone after MaxAge has passed.
-	time.Sleep(time.Second * 2)
+	time.Sleep(time.Second + time.Millisecond*500)
 	sm, err := fs.LoadMsg(seq, nil)
 	require_Error(t, err)
 	require_Equal(t, sm, nil)

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -1207,7 +1207,7 @@ func TestMemStoreSubjectDeleteMarkers(t *testing.T) {
 	}
 
 	// The last message should be gone after MaxAge has passed.
-	time.Sleep(time.Second * 2)
+	time.Sleep(time.Second + time.Millisecond*500)
 	sm, err := fs.LoadMsg(seq, nil)
 	require_Error(t, err)
 	require_Equal(t, sm, nil)


### PR DESCRIPTION
These tests could flake because the 2 second pause was right on the boundary between the 1 second TTL and the 1 second max-age limit. Moving it by half a second resolves the flake.

Signed-off-by: Neil Twigg <neil@nats.io>