### PR TITLE
Optimize removeSeqPerSubject() for MaxMsgPerSubject == 1

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -8494,6 +8494,19 @@ func (mb *msgBlock) removeSeqPerSubject(subj string, seq uint64) {
 
 	ss.Msgs--
 
+	// Only one left.
+	if ss.Msgs == 1 {
+		if !ss.firstNeedsUpdate && seq == ss.First {
+			ss.First = ss.Last
+		}
+
+		if !ss.lastNeedsUpdate && seq == ss.Last {
+			ss.Last = ss.First
+		}
+
+		return
+	}
+
 	// We can lazily calculate the first/last sequence when needed.
 	ss.firstNeedsUpdate = seq == ss.First || ss.firstNeedsUpdate
 	ss.lastNeedsUpdate = seq == ss.Last || ss.lastNeedsUpdate

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1631,9 +1631,23 @@ func (ms *memStore) removeSeqPerSubject(subj string, seq uint64, marker bool) bo
 	}
 	ss.Msgs--
 
+	// Only one left
+	if ss.Msgs == 1 {
+		if !ss.firstNeedsUpdate && seq == ss.First {
+			ss.First = ss.Last
+		}
+
+		if !ss.lastNeedsUpdate && seq == ss.Last {
+			ss.Last = ss.First
+		}
+
+		return false
+	}
+
 	// We can lazily calculate the first/last sequence when needed.
 	ss.firstNeedsUpdate = seq == ss.First || ss.firstNeedsUpdate
 	ss.lastNeedsUpdate = seq == ss.Last || ss.lastNeedsUpdate
+
 	return false
 }
 


### PR DESCRIPTION
This brings back an optimization that was removed with commit 79b41b122511df.

Without this optimization the first sequence number is lost from the per-subject state whenever a message is added and the per subject limit is enforced. This is happening a lot on a stream with MaxMsgPerSubject set to 1. And it can lead to a dramatic slowdown when catching up on a stream with sequence numbers spread out wide.

Signed-off-by: Sven Neumann <sven.neumann@holoplot.com>