### PR TITLE
Optimize removeSeqPerSubject() for MaxMsgPerSubject == 1

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -8494,6 +8494,20 @@ func (mb *msgBlock) removeSeqPerSubject(subj string, seq uint64) {
 
 	ss.Msgs--
 
+	// Only one left.
+	if ss.Msgs == 1 {
+		if !ss.lastNeedsUpdate && seq != ss.Last {
+			ss.First = ss.Last
+			ss.firstNeedsUpdate = false
+			return
+		}
+		if !ss.firstNeedsUpdate && seq != ss.First {
+			ss.Last = ss.First
+			ss.lastNeedsUpdate = false
+			return
+		}
+	}
+
 	// We can lazily calculate the first/last sequence when needed.
 	ss.firstNeedsUpdate = seq == ss.First || ss.firstNeedsUpdate
 	ss.lastNeedsUpdate = seq == ss.Last || ss.lastNeedsUpdate

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1631,9 +1631,24 @@ func (ms *memStore) removeSeqPerSubject(subj string, seq uint64, marker bool) bo
 	}
 	ss.Msgs--
 
+	// Only one left
+	if ss.Msgs == 1 {
+		if !ss.lastNeedsUpdate && seq != ss.Last {
+			ss.First = ss.Last
+			ss.firstNeedsUpdate = false
+			return false
+		}
+		if !ss.firstNeedsUpdate && seq != ss.First {
+			ss.Last = ss.First
+			ss.lastNeedsUpdate = false
+			return false
+		}
+	}
+
 	// We can lazily calculate the first/last sequence when needed.
 	ss.firstNeedsUpdate = seq == ss.First || ss.firstNeedsUpdate
 	ss.lastNeedsUpdate = seq == ss.Last || ss.lastNeedsUpdate
+
 	return false
 }
 

--- a/server/store_test.go
+++ b/server/store_test.go
@@ -276,6 +276,97 @@ func TestStoreSubjectStateConsistency(t *testing.T) {
 	)
 }
 
+func TestStoreSubjectStateConsistencyOptimization(t *testing.T) {
+	testAllStoreAllPermutations(
+		t, false,
+		StreamConfig{Name: "TEST", Subjects: []string{"foo"}},
+		func(t *testing.T, fs StreamStore) {
+			fillMsgs := func(c int) {
+				t.Helper()
+				for i := 0; i < c; i++ {
+					_, _, err := fs.StoreMsg("foo", nil, nil, 0)
+					require_NoError(t, err)
+				}
+			}
+			removeMsgs := func(seqs ...uint64) {
+				t.Helper()
+				for _, seq := range seqs {
+					removed, err := fs.RemoveMsg(seq)
+					require_NoError(t, err)
+					require_True(t, removed)
+				}
+			}
+			getSubjectState := func() (ss *SimpleState) {
+				t.Helper()
+				if f, ok := fs.(*fileStore); ok {
+					ss, ok = f.lmb.fss.Find([]byte("foo"))
+					require_True(t, ok)
+				} else if ms, ok := fs.(*memStore); ok {
+					ss, ok = ms.fss.Find([]byte("foo"))
+					require_True(t, ok)
+				} else {
+					t.Fatal("Store not supported")
+				}
+				return ss
+			}
+			var smp StoreMsg
+			expectSeq := func(seq uint64) {
+				t.Helper()
+				sm, _, err := fs.LoadNextMsg("foo", false, 0, &smp)
+				require_NoError(t, err)
+				require_Equal(t, sm.seq, seq)
+				sm, err = fs.LoadLastMsg("foo", &smp)
+				require_NoError(t, err)
+				require_Equal(t, sm.seq, seq)
+			}
+
+			// results in ss.Last, ss.First is marked lazy (when we hit ss.Msgs-1==1).
+			fillMsgs(3)
+			removeMsgs(2, 1)
+			ss := getSubjectState()
+			require_Equal(t, ss.Msgs, 1)
+			require_Equal(t, ss.First, 3)
+			require_Equal(t, ss.Last, 3)
+			require_False(t, ss.firstNeedsUpdate)
+			require_False(t, ss.lastNeedsUpdate)
+			expectSeq(3)
+
+			// ss.First is marked lazy first, then ss.Last is marked lazy (when we hit ss.Msgs-1==1).
+			fillMsgs(2)
+			removeMsgs(3, 5)
+			ss = getSubjectState()
+			require_Equal(t, ss.Msgs, 1)
+			require_Equal(t, ss.First, 3)
+			require_Equal(t, ss.Last, 5)
+			require_True(t, ss.firstNeedsUpdate)
+			require_True(t, ss.lastNeedsUpdate)
+			expectSeq(4)
+
+			// ss.Last is marked lazy first, then ss.First is marked lazy (when we hit ss.Msgs-1==1).
+			fillMsgs(2)
+			removeMsgs(7, 4)
+			ss = getSubjectState()
+			require_Equal(t, ss.Msgs, 1)
+			require_Equal(t, ss.First, 4)
+			require_Equal(t, ss.Last, 7)
+			require_True(t, ss.firstNeedsUpdate)
+			require_True(t, ss.lastNeedsUpdate)
+			expectSeq(6)
+
+			// ss.Msgs=1, results in ss.First, ss.Last is marked lazy (when we hit ss.Msgs-1==1).
+			fillMsgs(2)
+			removeMsgs(9, 8)
+			ss = getSubjectState()
+			require_Equal(t, ss.Msgs, 1)
+			require_Equal(t, ss.First, 6)
+			require_Equal(t, ss.Last, 6)
+			require_False(t, ss.firstNeedsUpdate)
+			require_False(t, ss.lastNeedsUpdate)
+			expectSeq(6)
+		},
+	)
+}
+
 func TestStoreMaxMsgsPerUpdateBug(t *testing.T) {
 	config := func() StreamConfig {
 		return StreamConfig{Name: "TEST", Subjects: []string{"foo"}, MaxMsgsPer: 0}


### PR DESCRIPTION
The following PR builds on top of PR https://github.com/nats-io/nats-server/pull/6686 by @svenfoo:

> This brings back an optimization that was removed with commit 79b41b122511df.
>
> Without this optimization the first sequence number is lost from the per-subject state whenever a message is added and the per subject limit is enforced. This is happening a lot on a stream with MaxMsgPerSubject set to 1. And it can lead to a dramatic slowdown when catching up on a stream with sequence numbers spread out wide.

Resolves https://github.com/nats-io/nats-server/issues/6687

Signed-off-by: Sven Neumann <sven.neumann@holoplot.com>
Signed-off-by: Maurice van Veen <github@mauricevanveen.com>