### PR TITLE
Proposed subject delete markers

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -25436,7 +25436,7 @@ func TestJetStreamSubjectDeleteMarkersAfterRestart(t *testing.T) {
 	nc, js := jsClientConnect(t, s)
 	defer nc.Close()
 
-	jsStreamCreate(t, nc, &StreamConfig{
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
 		Name:                   "TEST",
 		Storage:                FileStorage,
 		Subjects:               []string{"test"},
@@ -25444,11 +25444,13 @@ func TestJetStreamSubjectDeleteMarkersAfterRestart(t *testing.T) {
 		AllowMsgTTL:            true,
 		SubjectDeleteMarkerTTL: time.Second,
 	})
+	require_NoError(t, err)
 
-	_, err := js.AddConsumer("TEST", &nats.ConsumerConfig{
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
 		Name:      "test_consumer",
 		AckPolicy: nats.AckExplicitPolicy,
 	})
+	require_NoError(t, err)
 
 	for i := 0; i < 3; i++ {
 		_, err = js.Publish("test", nil)

--- a/server/store.go
+++ b/server/store.go
@@ -85,7 +85,7 @@ type StoreMsg struct {
 type StorageUpdateHandler func(msgs, bytes int64, seq uint64, subj string)
 
 // Used to call back into the upper layers to report on newly created subject delete markers.
-type SubjectDeleteMarkerUpdateHandler func(seq uint64, subj string)
+type SubjectDeleteMarkerUpdateHandler func(*inMsg)
 
 type StreamStore interface {
 	StoreMsg(subject string, hdr, msg []byte, ttl int64) (uint64, int64, error)


### PR DESCRIPTION
This PR proposes subject delete markers through the stream, avoiding a last sequence mismatch between the stream layer and the store, and ensuring that in clustered mode, all replicas are inserting the markers in a consistent order.

Signed-off-by: Neil Twigg <neil@nats.io>
Co-authored-by: Maurice van Veen <github@mauricevanveen.com>