### PR TITLE
Fix timing inconsistency between `Nats-TTL` and `MaxAge` timers

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4045,10 +4045,10 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 
 	// Check if we have and need the age expiration timer running.
 	switch {
+	case fs.ttls != nil && ttl > 0:
+		fs.resetAgeChk(0)
 	case fs.ageChk == nil && (fs.cfg.MaxAge > 0 || fs.ttls != nil):
 		fs.startAgeChk()
-	case fs.ageChk != nil && fs.ttls != nil && ttl > 0:
-		fs.resetAgeChk(0)
 	}
 
 	return nil

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -228,11 +228,12 @@ func (ms *memStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, tt
 
 	// Check if we have and need the age expiration timer running.
 	switch {
+	case ms.ttls != nil && ttl > 0:
+		ms.resetAgeChk(0)
 	case ms.ageChk == nil && (ms.cfg.MaxAge > 0 || ms.ttls != nil):
 		ms.startAgeChk()
-	case ms.ageChk != nil && ms.ttls != nil && ttl > 0:
-		ms.resetAgeChk(0)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
We would only reset the timer based on the newly submitted TTL value if the timer was already running, but that could have been set to `MaxAge` based on no messages being left in the stream if it was configured, delaying the next clean-up. Instead just kick the timer anyway with each new TTL message.

Signed-off-by: Neil Twigg <neil@nats.io>