### PR TITLE
[IMPROVED] Replicated asset creation performance

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2108,7 +2108,7 @@ retry:
 	rg.node = n
 	// See if we are preferred and should start campaign immediately.
 	if n.ID() == rg.Preferred && n.Term() == 0 {
-		n.Campaign()
+		n.CampaignImmediately()
 	}
 	js.mu.Unlock()
 	return nil

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -5032,3 +5032,26 @@ func TestJetStreamClusterMessageTTLDisabled(t *testing.T) {
 		require_Equal(t, stream.getCLFS(), 0)
 	}
 }
+
+func TestJetStreamClusterCreateStreamPerf(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	for i := 0; i < 10; i++ {
+		// Check that creating a replicated asset doesn't take too long.
+		start := time.Now()
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:      fmt.Sprintf("TEST-%d", i),
+			Retention: nats.LimitsPolicy,
+			Subjects:  []string{fmt.Sprintf("foo.%d", i)},
+			Replicas:  3,
+		})
+		require_NoError(t, err)
+		if elapsed := time.Since(start); elapsed > 150*time.Millisecond {
+			t.Fatalf("Took too long to create a R3 stream: %v", elapsed)
+		}
+	}
+}

--- a/server/raft.go
+++ b/server/raft.go
@@ -59,6 +59,7 @@ type RaftNode interface {
 	SetObserver(isObserver bool)
 	IsObserver() bool
 	Campaign() error
+	CampaignImmediately() error
 	ID() string
 	Group() string
 	Peers() []*Peer
@@ -1639,7 +1640,14 @@ func (n *raft) StepDown(preferred ...string) error {
 func (n *raft) Campaign() error {
 	n.Lock()
 	defer n.Unlock()
-	return n.campaign()
+	return n.campaign(randCampaignTimeout())
+}
+
+// CampaignImmediately will have our node start a leadership vote after minimal delay.
+func (n *raft) CampaignImmediately() error {
+	n.Lock()
+	defer n.Unlock()
+	return n.campaign(minCampaignTimeout / 2)
 }
 
 func randCampaignTimeout() time.Duration {
@@ -1649,12 +1657,12 @@ func randCampaignTimeout() time.Duration {
 
 // Campaign will have our node start a leadership vote.
 // Lock should be held.
-func (n *raft) campaign() error {
+func (n *raft) campaign(et time.Duration) error {
 	n.debug("Starting campaign")
 	if n.State() == Leader {
 		return errAlreadyLeader
 	}
-	n.resetElect(randCampaignTimeout())
+	n.resetElect(et)
 	return nil
 }
 


### PR DESCRIPTION
When creating a replicated stream/consumer a preferred leader is selected, which will start campaigning earlier than the normal election timer. This is to speed up leader election so we can respond quickly to the create request.

However, campaigning uses a random delay between 100-800ms which can delay any replicated create request by at least that delay, averaging around ~470ms to create. Versus ~20ms for non-replicated assets.

Since it's the initial creation/campaign, we could speed it up further to not have an as long delay. With this PR the average create time would be ~60ms instead, significantly speeding up replicated asset creation.

This change also significantly speeds up server test times that rely on a setup containing replicated stream/consumer creation.

Resolves https://github.com/nats-io/nats-server/issues/6696

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>