### PR TITLE
[FIXED] Preserve redelivered state with lagging stream

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -6414,7 +6414,6 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 	if !fcfg.Created.IsZero() {
 		mset.setCreatedTime(fcfg.Created)
 	}
-	lseq := mset.lastSeq()
 
 	// Make sure we do an update if the configs have changed.
 	if !reflect.DeepEqual(fcfg.StreamConfig, cfg) {
@@ -6465,7 +6464,7 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 			obs.setCreatedTime(cfg.Created)
 		}
 		obs.mu.Lock()
-		err = obs.readStoredState(lseq)
+		err = obs.readStoredState()
 		obs.mu.Unlock()
 		if err != nil {
 			mset.stop(true, false)


### PR DESCRIPTION
`o.checkRedelivered` would throw away delivered counters for messages if the server that became consumer leader was a lagging-behind stream follower. Should preserve this data to ensure the counters stay correct and the client gets the right data once the stream becomes up-to-date again.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>