### PR TITLE
make .tar.gz file metadata reproducible

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,12 +75,22 @@ archives:
     format_overrides:
       - goos: windows
         formats: ["zip"]
+    builds_info:
+      owner: root
+      group: root
+      mode: 0755
     files:
       - src: README.md
         info:
+          owner: root
+          group: root
+          mode: 0644
           mtime: "{{ .CommitDate }}"
       - src: LICENSE
         info:
+          owner: root
+          group: root
+          mode: 0644
           mtime: "{{ .CommitDate }}"
 
 checksum:


### PR DESCRIPTION
Make contents of the archive to be owned by root, so archives have same shasum, no matter which user runs the build.
https://www.gnu.org/software/tar/manual/html_node/Reproducibility.html

## Test plan
### Before
Built 2.11.0 tag locally with:
`# go clean -cache && goreleaser  release --skip=announce,publish,validate --clean -f .goreleaser.yml`
File permissions in the archive are different, reported by https://diffoscope.org/: 
```
# docker run --rm -t -w $(pwd) -v $(pwd):$(pwd):ro       registry.salsa.debian.org/reproducible-builds/diffoscope nats_server_gh_assets/2.11.0/nats-server-v2.11.0-linux-amd64.tar.gz nats-server/dist/nats-server-v2.11.0-linux-amd64.tar.gz
--- nats_server_gh_assets/2.11.0/nats-server-v2.11.0-linux-amd64.tar.gz
+++ nats-server/dist/nats-server-v2.11.0-linux-amd64.tar.gz
├── nats-server-v2.11.0-linux-amd64.tar
│ ├── file list
│ │ @@ -1,3 +1,3 @@
│ │ --rw-r--r--   0 runner    (1001) docker     (118)    11357 2025-03-19 15:28:05.000000 nats-server-v2.11.0-linux-amd64/LICENSE
│ │ --rw-r--r--   0 runner    (1001) docker     (118)     4404 2025-03-19 15:28:05.000000 nats-server-v2.11.0-linux-amd64/README.md
│ │ --rwxr-xr-x   0 runner    (1001) docker     (118) 16442017 2025-03-19 15:28:05.000000 nats-server-v2.11.0-linux-amd64/nats-server
│ │ +-rw-r--r--   0 alex      (1000) alex      (1000)    11357 2025-03-19 15:28:05.000000 nats-server-v2.11.0-linux-amd64/LICENSE
│ │ +-rw-r--r--   0 alex      (1000) alex      (1000)     4404 2025-03-19 15:28:05.000000 nats-server-v2.11.0-linux-amd64/README.md
│ │ +-rwxr-xr-x   0 alex      (1000) alex      (1000) 16442017 2025-03-19 15:28:05.000000 nats-server-v2.11.0-linux-amd64/nats-server
```
After:
Tar content owned by root:root 
![image](https://github.com/user-attachments/assets/da3b85f5-93aa-47e4-94af-c026ad54912f)


Signed-off-by: Alex Bozhenko <alex@synadia.com>