### PR TITLE
[IMPROVED] Services: Now possible to import same subject from diff accounts

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -2284,10 +2284,11 @@ func (s *Server) registerSystemImports(a *Account) {
 	if sacc == nil || sacc == a {
 		return
 	}
+	dstAccName := sacc.Name
 	// FIXME(dlc) - make a shared list between sys exports etc.
 
 	importSrvc := func(subj, mappedSubj string) {
-		if !a.serviceImportExists(subj) {
+		if !a.serviceImportExists(dstAccName, subj) {
 			if err := a.addServiceImportWithClaim(sacc, subj, mappedSubj, nil, true); err != nil {
 				s.Errorf("Error setting up system service import %s -> %s for account: %v",
 					subj, mappedSubj, err)
@@ -2824,8 +2825,6 @@ func (s *Server) remoteLatencyUpdate(sub *subscription, _ *client, _ *Account, s
 	si.rc = nil
 	acc.mu.Unlock()
 
-	// Make sure we remove the entry here.
-	acc.removeServiceImport(si.from)
 	// Send the metrics
 	s.sendInternalAccountMsg(acc, lsub, m1)
 }

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -715,7 +715,12 @@ func (a *Account) enableAllJetStreamServiceImportsAndMappings() error {
 		return fmt.Errorf("jetstream account not registered")
 	}
 
-	if !a.serviceImportExists(jsAllAPI) {
+	var dstAccName string
+	if sacc := s.SystemAccount(); sacc != nil {
+		dstAccName = sacc.Name
+	}
+
+	if !a.serviceImportExists(dstAccName, jsAllAPI) {
 		// Capture si so we can turn on implicit sharing with JetStream layer.
 		// Make sure to set "to" otherwise will incur performance slow down.
 		si, err := a.addServiceImport(s.SystemAccount(), jsAllAPI, jsAllAPI, nil)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2727,8 +2727,10 @@ func (s *Server) accountInfo(accName string) (*AccountInfo, error) {
 		}
 		imports = append(imports, imp)
 	}
-	for _, v := range a.imports.services {
-		imports = append(imports, newExtImport(v))
+	for _, sis := range a.imports.services {
+		for _, v := range sis {
+			imports = append(imports, newExtImport(v))
+		}
 	}
 	responses := map[string]ExtImport{}
 	for k, v := range a.exports.responses {

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -5809,8 +5809,14 @@ func TestMonitorAccountszMappingOrderReporting(t *testing.T) {
 		CLOUD {
 			exports [ { service: "downlink.>" } ]
 		}
+		CLOUD2 {
+			exports [ { service: "downlink.>" } ]
+		}
 		APP {
-			imports [ { service: { account: CLOUD, subject: "downlink.>"}, to: "event.>"} ]
+			imports [
+				{ service: { account: CLOUD, subject: "downlink.>"}, to: "event.>"}
+				{ service: { account: CLOUD2, subject: "downlink.>"}, to: "event.>"}
+			]
 		}
 	}`))
 
@@ -5823,14 +5829,18 @@ func TestMonitorAccountszMappingOrderReporting(t *testing.T) {
 	require_True(t, len(az.Account.Imports) > 0)
 
 	var found bool
+	m := map[string]struct{}{}
 	for _, si := range az.Account.Imports {
 		if si.Import.Subject == "downlink.>" {
 			found = true
 			require_True(t, si.Import.LocalSubject == "event.>")
-			break
+			m[si.Import.Account] = struct{}{}
 		}
 	}
 	require_True(t, found)
+	if len(m) != 2 {
+		t.Fatalf("Expected imports from CLOUD and CLOUD2, got %v", m)
+	}
 }
 
 // createCallbackURL adds a callback query parameter for JSONP requests.

--- a/server/opts.go
+++ b/server/opts.go
@@ -3593,8 +3593,9 @@ func parseAccountImports(v any, acc *Account, errors *[]error) ([]*importStream,
 
 	var services []*importService
 	var streams []*importStream
-	svcSubjects := map[string]*importService{}
+	svcSubjects := map[string][]*importService{}
 
+IMS_LOOP:
 	for _, v := range ims {
 		// Should have stream or service
 		stream, service, err := parseImportStreamOrService(v, errors)
@@ -3603,16 +3604,20 @@ func parseAccountImports(v any, acc *Account, errors *[]error) ([]*importStream,
 			continue
 		}
 		if service != nil {
-			if dup := svcSubjects[service.to]; dup != nil {
-				tk, _ := unwrapValue(v, &lt)
-				err := &configErr{tk,
-					fmt.Sprintf("Duplicate service import subject %q, previously used in import for account %q, subject %q",
-						service.to, dup.an, dup.sub)}
-				*errors = append(*errors, err)
-				continue
+			sisPerSubj := svcSubjects[service.to]
+			for _, dup := range sisPerSubj {
+				if dup.an == service.an {
+					tk, _ := unwrapValue(v, &lt)
+					err := &configErr{tk,
+						fmt.Sprintf("Duplicate service import subject %q, previously used in import for account %q, subject %q",
+							service.to, dup.an, dup.sub)}
+					*errors = append(*errors, err)
+					continue IMS_LOOP
+				}
 			}
-			svcSubjects[service.to] = service
 			service.acc = acc
+			sisPerSubj = append(sisPerSubj, service)
+			svcSubjects[service.to] = sisPerSubj
 			services = append(services, service)
 		}
 		if stream != nil {


### PR DESCRIPTION
Previously, if 2 accounts exported the same subject, another account would not be able to import the 2 accounts with the same subject. This would produce an error saying that there was a duplicate.

We are changing the internal structure to store the service imports which is now allowing such services import definition.

See test `TestAccountMultipleServiceImportsWithSameSubjectFromDifferentAccounts` for an example.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
