### PR TITLE
NRG: Clarify debug log when clearing WAL

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3272,8 +3272,9 @@ func (n *raft) truncateWAL(term, index uint64) {
 	if err := n.wal.Truncate(index); err != nil {
 		// If we get an invalid sequence, reset our wal all together.
 		// We will not have holes, so this means we do not have this message stored anymore.
+		// This is normal when truncating back to applied/snapshot.
 		if err == ErrInvalidSequence {
-			n.debug("Resetting WAL")
+			n.debug("Clearing WAL")
 			n.wal.Truncate(0)
 			// If our index is non-zero use PurgeEx to set us to the correct next index.
 			if index > 0 {


### PR DESCRIPTION
Before this change there were two log statements: `WRN Resetting WAL state` and `DBG Resetting WAL`. Whenever a WAL needs to be reset, when looking at the WRN log, it means something went wrong and we can't properly replicate (which could result in desync). The DBG log however looks just as scary but actually is harmless. You'd see that log message when truncating the WAL back to applied/snapshot, which is normal and can happen.

Updating the wording in the DBG log to clearly differentiate between a (bad) reset and clearing/truncating the WAL which is normal in this case.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>