### PR TITLE
Benchmark performance of MaxMsgsPer=1 subject state optimization

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -8186,6 +8186,36 @@ func Benchmark_FileStoreCreateConsumerStores(b *testing.B) {
 	}
 }
 
+func Benchmark_FileStoreSubjectStateConsistencyOptimizationPerf(b *testing.B) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: b.TempDir()},
+		StreamConfig{Name: "TEST", Subjects: []string{"foo.*"}, Storage: FileStorage, MaxMsgsPer: 1},
+	)
+	require_NoError(b, err)
+	defer fs.Stop()
+
+	// Do R rounds of storing N messages.
+	// MaxMsgsPer=1, so every unique subject that's placed only exists in the stream once.
+	// If R=2, N=3 that means we'd place foo.0, foo.1, foo.2 in the first round, and the second
+	// round we'd place foo.2, foo.1, foo.0, etc. This is intentional so that without any
+	// optimizations we'd need to scan either 1 in the optimal case or N in the worst case.
+	// Which is way more expensive than always knowing what the sequences are and it being O(1).
+	r := max(2, b.N)
+	n := 40_000
+	b.ResetTimer()
+	for i := 0; i < r; i++ {
+		for j := 0; j < n; j++ {
+			d := j
+			if i%2 == 0 {
+				d = n - j - 1
+			}
+			subject := fmt.Sprintf("foo.%d", d)
+			_, _, err = fs.StoreMsg(subject, nil, nil, 0)
+			require_NoError(b, err)
+		}
+	}
+}
+
 func TestFileStoreWriteFullStateDetectCorruptState(t *testing.T) {
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: t.TempDir()},

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -1437,3 +1437,31 @@ func Benchmark_MemStoreNumPendingWithLargeInteriorDeletesExclude(b *testing.B) {
 		}
 	}
 }
+
+func Benchmark_MemStoreSubjectStateConsistencyOptimizationPerf(b *testing.B) {
+	cfg := &StreamConfig{Name: "TEST", Subjects: []string{"foo.*"}, Storage: MemoryStorage, MaxMsgsPer: 1}
+	ms, err := newMemStore(cfg)
+	require_NoError(b, err)
+	defer ms.Stop()
+
+	// Do R rounds of storing N messages.
+	// MaxMsgsPer=1, so every unique subject that's placed only exists in the stream once.
+	// If R=2, N=3 that means we'd place foo.0, foo.1, foo.2 in the first round, and the second
+	// round we'd place foo.2, foo.1, foo.0, etc. This is intentional so that without any
+	// optimizations we'd need to scan either 1 in the optimal case or N in the worst case.
+	// Which is way more expensive than always knowing what the sequences are and it being O(1).
+	r := max(2, b.N)
+	n := 40_000
+	b.ResetTimer()
+	for i := 0; i < r; i++ {
+		for j := 0; j < n; j++ {
+			d := j
+			if i%2 == 0 {
+				d = n - j - 1
+			}
+			subject := fmt.Sprintf("foo.%d", d)
+			_, _, err = ms.StoreMsg(subject, nil, nil, 0)
+			require_NoError(b, err)
+		}
+	}
+}


### PR DESCRIPTION
A performance regression with subject state performance was fixed in https://github.com/nats-io/nats-server/pull/6688.
This performance regression existed in v2.10.25 and v2.10.26. Prior to v2.10.25 (v2.10.24 and lower) there was no performance regression, but there were some cases where the subject state would not be kept up-to-date correctly (although this did not apply to `MaxMsgsPer=1`).

The added benchmark confirms the performance optimization put into place is kept, as it's exponentially expensive to recalculate the next subject sequence otherwise.

Measuring the time taken to execute this benchmark (locally) before and after fixing the regression:
- Memory, before: 2m32s, after: 300ms
- File, before: 31s, after: 1s

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>