### PR TITLE
[FIXED] PurgeEx with zero seq equals Purge

### DIFF
--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1150,10 +1150,7 @@ func (ms *memStore) PurgeEx(subject string, sequence, keep uint64, _ /* noMarker
 // Purge will remove all messages from this store.
 // Will return the number of purged messages.
 func (ms *memStore) Purge() (uint64, error) {
-	ms.mu.RLock()
-	first := ms.state.LastSeq + 1
-	ms.mu.RUnlock()
-	return ms.purge(first, false)
+	return ms.purge(0, false)
 }
 
 func (ms *memStore) purge(fseq uint64, _ /* noMarkers */ bool) (uint64, error) {
@@ -1165,7 +1162,9 @@ func (ms *memStore) purge(fseq uint64, _ /* noMarkers */ bool) (uint64, error) {
 	purged := uint64(len(ms.msgs))
 	cb := ms.scb
 	bytes := int64(ms.state.Bytes)
-	if fseq < ms.state.LastSeq {
+	if fseq == 0 {
+		fseq = ms.state.LastSeq + 1
+	} else if fseq < ms.state.LastSeq {
 		ms.mu.Unlock()
 		return 0, fmt.Errorf("partial purges not supported on memory store")
 	}

--- a/server/store_test.go
+++ b/server/store_test.go
@@ -512,3 +512,26 @@ func TestStoreTruncateCleansUpDmap(t *testing.T) {
 		})
 	}
 }
+
+// https://github.com/nats-io/nats-server/issues/6709
+func TestStorePurgeExZero(t *testing.T) {
+	testAllStoreAllPermutations(
+		t, false,
+		StreamConfig{Name: "TEST", Subjects: []string{"foo"}},
+		func(t *testing.T, fs StreamStore) {
+			// Simple purge all.
+			_, err := fs.Purge()
+			require_NoError(t, err)
+			ss := fs.State()
+			require_Equal(t, ss.FirstSeq, 1)
+			require_Equal(t, ss.LastSeq, 0)
+
+			// PurgeEx(seq=0) must be equal.
+			_, err = fs.PurgeEx(_EMPTY_, 0, 0, false)
+			require_NoError(t, err)
+			ss = fs.State()
+			require_Equal(t, ss.FirstSeq, 1)
+			require_Equal(t, ss.LastSeq, 0)
+		},
+	)
+}


### PR DESCRIPTION
The change from `ms.Purge()` to `ms.purge(0, false)` in https://github.com/nats-io/nats-server/commit/0208ab26237a9b347e8561b187ebc622958a2bb3, introduced a regression in 2.11.0 where it would set the `FirstSeq=0` and the `LastSeq` be max of `uint64`, making the in-memory stream unusable after.

This change makes the memstore a bit more aligned with the filestore, where `fs.purge(0, false)` equals a full purge as well.

Resolves https://github.com/nats-io/nats-server/issues/6709

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>