### PR TITLE
[FIXED] Idempotent stream/consumer create after standalone server upgrade

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -922,8 +922,12 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 	if cName != _EMPTY_ {
 		if eo, ok := mset.consumers[cName]; ok {
 			mset.mu.Unlock()
-			if action == ActionCreate && !reflect.DeepEqual(*config, eo.config()) {
-				return nil, NewJSConsumerAlreadyExistsError()
+			if action == ActionCreate {
+				ocfg := eo.config()
+				copyConsumerMetadata(config, &ocfg)
+				if !reflect.DeepEqual(config, &ocfg) {
+					return nil, NewJSConsumerAlreadyExistsError()
+				}
 			}
 			// Check for overlapping subjects if we are a workqueue
 			if cfg.Retention == WorkQueuePolicy {


### PR DESCRIPTION
Relates to https://github.com/nats-io/nats-server/pull/6535

When upgrading from 2.10.x to 2.11.x, a standalone server would not allow what would otherwise be idempotent stream/consumer creates.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>