### PR TITLE
Use `permissions` key in GHA release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,9 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: write
+
 jobs:
   run:
     name: GitHub Release


### PR DESCRIPTION
Signed-off-by: Neil Twigg <neil@nats.io>
