### PR TITLE
[IMPROVED] Config Parsing consistency with authentication timeout option

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -2611,12 +2611,20 @@ func parseLeafAuthorization(v any, errors *[]error) (*authorization, error) {
 			}
 			auth.nkey = nk
 		case "timeout":
-			at := float64(1)
+			at := float64(0)
 			switch mv := mv.(type) {
 			case int64:
 				at = float64(mv)
 			case float64:
 				at = mv
+			case string:
+				d, err := time.ParseDuration(mv)
+				if err != nil {
+					return nil, &configErr{tk, fmt.Sprintf("error parsing leafnode authorization config, 'timeout' %s", err)}
+				}
+				at = d.Seconds()
+			default:
+				return nil, &configErr{tk, "error parsing leafnode authorization config, 'timeout' wrong type"}
 			}
 			auth.timeout = at
 		case "users":

--- a/server/opts.go
+++ b/server/opts.go
@@ -4131,12 +4131,20 @@ func parseAuthorization(v any, errors *[]error) (*authorization, error) {
 		case "token":
 			auth.token = mv.(string)
 		case "timeout":
-			at := float64(1)
+			at := float64(0)
 			switch mv := mv.(type) {
 			case int64:
 				at = float64(mv)
 			case float64:
 				at = mv
+			case string:
+				d, err := time.ParseDuration(mv)
+				if err != nil {
+					return nil, &configErr{tk, fmt.Sprintf("error parsing authorization config, 'timeout' %s", err)}
+				}
+				at = d.Seconds()
+			default:
+				return nil, &configErr{tk, "error parsing authorization config, 'timeout' wrong type"}
 			}
 			auth.timeout = at
 		case "users":

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -3478,10 +3478,11 @@ func TestProcessConfigString(t *testing.T) {
 
 func TestAuthorizationTimeoutConfigParsing(t *testing.T) {
 	type testCase struct {
-		name          string
-		config        string
-		expectParsed  float64
-		expectRunning float64
+		name                string
+		config              string
+		expectParsed        float64
+		expectRunning       float64
+		expectErrorContains string
 	}
 
 	for _, tc := range []testCase{{
@@ -3511,24 +3512,71 @@ func TestAuthorizationTimeoutConfigParsing(t *testing.T) {
 			authorization {
 				timeout: random_garbage
 			}`,
-		expectParsed:  1,
-		expectRunning: 1,
+		expectErrorContains: `invalid duration "random_garbage"`,
 	}, {
 		name: "human readable",
 		config: `
 			authorization {
 				timeout: 10s
 			}`,
-		expectParsed:  1,
-		expectRunning: 1,
+		expectParsed:  10,
+		expectRunning: 10,
+	}, {
+		name: "bare values could be parsed as integers",
+		config: `
+			authorization {
+				timeout: 1m
+			}`,
+		expectParsed:  1000000,
+		expectRunning: 1000000,
+	}, {
+		name: "but quoted values will be parsed as durations",
+		config: `
+			authorization {
+				timeout: "1m"
+			}`,
+		expectParsed:  60,
+		expectRunning: 60,
+	}, {
+		name: "human readable minutes quoted",
+		config: `
+			authorization {
+				timeout: "10m5s30ms"
+			}`,
+		expectParsed:  605.03,
+		expectRunning: 605.03,
+	}, {
+		name: "floats work",
+		config: `
+			authorization {
+				timeout: 0.091
+			}`,
+		expectParsed:  .091,
+		expectRunning: .091,
+	}, {
+		name: "but no leading digit fails",
+		config: `
+			authorization {
+				timeout: .091
+			}`,
+		expectErrorContains: "Floats must start with a digit",
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := &Options{}
-			if err := opts.ProcessConfigString(tc.config); err != nil {
-				t.Errorf("Error processing config: %v", err)
+			err := opts.ProcessConfigString(tc.config)
+			if tc.expectErrorContains != "" {
+				if !strings.Contains(err.Error(), tc.expectErrorContains) {
+					t.Errorf("Expected error like %q, got %v", tc.expectErrorContains, err)
+				}
+				return
+			} else {
+				if err != nil {
+					t.Errorf("Error processing config: %v", err)
+				}
 			}
+
 			if opts.AuthTimeout != tc.expectParsed {
-				t.Errorf("Expected Parsed AuthTimeout to be %v, got %v", tc.expectParsed, opts.AuthTimeout)
+				t.Errorf("Expected Parsed AuthTimeout to be %f, got %f", tc.expectParsed, opts.AuthTimeout)
 			}
 
 			s := RunServer(opts)
@@ -3536,7 +3584,7 @@ func TestAuthorizationTimeoutConfigParsing(t *testing.T) {
 
 			sopts := s.getOpts()
 			if sopts.AuthTimeout != tc.expectRunning {
-				t.Errorf("Expected Running AuthTimeout to be %v, got %v", tc.expectRunning, sopts.AuthTimeout)
+				t.Errorf("Expected Running AuthTimeout to be %f, got %f", tc.expectRunning, sopts.AuthTimeout)
 			}
 		})
 	}


### PR DESCRIPTION
Improve the config parsing to make `authorization` -> `timeout` parsing consistent with the `tls_timeout` option