### PR TITLE
[FIXED] Duplicate Raft nodes during restart

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -7552,7 +7552,7 @@ func TestJetStreamClusterConsumerHealthCheckMustNotRecreate(t *testing.T) {
 	checkNodeIsClosed(ca)
 
 	// We create a new RAFT group, the health check should detect this skew and restart.
-	err = sjs.createRaftGroup(globalAccountName, ca.Group, MemoryStorage, pprofLabels{})
+	_, err = sjs.createRaftGroup(globalAccountName, ca.Group, MemoryStorage, pprofLabels{})
 	require_NoError(t, err)
 	sjs.mu.Lock()
 	// We set creating to now, since previously it would delete all data but NOT restart if created within <10s.


### PR DESCRIPTION
Antithesis triggered duplicate Raft nodes with the following scenario:
- follower needs to catchup based on snapshot, but is leaderless, so results in: `catchup aborted, no leader`
  - call to `mset.resetClusteredState(..)` attempts to restart Raft node
  - `mset.stop(..)` call resets `sa.Group.node = nil`
  - goes into `js.createRaftGroup(..)` and waits for Raft node to stop
- in the meantime this folllower gets a snapshot from the meta layer, which updates/checks the stream assignment
  - update notices `sa.Group.node == nil`
  - does another call to `js.createRaftGroup(..)`, and also waits for Raft node to stop
- now Raft node stops and both `js.createRaftGroup(..)` calls duplicate the Raft node
- health check now notices `Detected stream cluster node skew`, deletes node and resets

This fix ensures we can't create duplicate Raft nodes for the same group.

It's unlikely to hit this normally due to requiring exact timing and leaderless condition on the stream while having a leader for the meta layer. But was easily reproducible in a test by just calling `js.createRaftGroup` in parallel.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>