### PR TITLE
CI: Only run race detector on development branches

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  RACE: ${{ (github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && github.event_name != 'pull_request') && '-race' || '' }}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') }}

--- a/scripts/runTestsOnTravis.sh
+++ b/scripts/runTestsOnTravis.sh
@@ -1,20 +1,20 @@
 #!/bin/sh
 
-set -e
+set -ex
 
 if [ "$1" = "compile" ]; then
     # First check that NATS builds.
-    go build;
+    go build -v;
 
     # Now run the linters.
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.4;
     golangci-lint run;
     if [ "$TRAVIS_TAG" != "" ]; then
-        go test -race -v -run=TestVersionMatchesTag ./server -ldflags="-X=github.com/nats-io/nats-server/v2/server.serverVersion=$TRAVIS_TAG" -count=1 -vet=off
+        go test -v -run=TestVersionMatchesTag ./server -ldflags="-X=github.com/nats-io/nats-server/v2/server.serverVersion=$TRAVIS_TAG" -count=1 -vet=off
     fi
 
 elif [ "$1" = "build_only" ]; then
-    go build;
+    go build -v;
 
 elif [ "$1" = "no_race_tests" ]; then
 
@@ -28,9 +28,7 @@ elif [ "$1" = "store_tests" ]; then
     # Run store tests. By convention, all file store tests start with `TestFileStore`,
     # and memory store tests start with `TestMemStore`.
 
-    go test -race -v -run=TestMemStore ./server -count=1 -vet=off -timeout=30m -failfast
-    go test -race -v -run=TestFileStore ./server -count=1 -vet=off -timeout=30m -failfast
-    go test -race -v -run=TestStore ./server -count=1 -vet=off -timeout=30m -failfast
+    go test $RACE -v -p=1 -run=Test\(Store\|FileStore\|MemStore\) ./server -count=1 -vet=off -timeout=30m -failfast
 
 elif [ "$1" = "js_tests" ]; then
 
@@ -38,7 +36,7 @@ elif [ "$1" = "js_tests" ]; then
     # with `TestJetStream`. We exclude the clustered and super-clustered
     # tests by using the appropriate tags.
 
-    go test -race -v -run=TestJetStream ./server -tags=skip_js_cluster_tests,skip_js_cluster_tests_2,skip_js_cluster_tests_3,skip_js_cluster_tests_4,skip_js_super_cluster_tests -count=1 -vet=off -timeout=30m -failfast
+    go test $RACE -v -p=1 -run=TestJetStream ./server -tags=skip_js_cluster_tests,skip_js_cluster_tests_2,skip_js_cluster_tests_3,skip_js_cluster_tests_4,skip_js_super_cluster_tests -count=1 -vet=off -timeout=30m -failfast
 
 elif [ "$1" = "js_cluster_tests_1" ]; then
 
@@ -46,7 +44,7 @@ elif [ "$1" = "js_cluster_tests_1" ]; then
     # start with `TestJetStreamCluster`. Will run the first batch of tests,
     # excluding others with use of proper tags.
 
-    go test -race -v -run=TestJetStreamCluster ./server -tags=skip_js_cluster_tests_2,skip_js_cluster_tests_3,skip_js_cluster_tests_4 -count=1 -vet=off -timeout=30m -failfast
+    go test $RACE -v -p=1 -run=TestJetStreamCluster ./server -tags=skip_js_cluster_tests_2,skip_js_cluster_tests_3,skip_js_cluster_tests_4 -count=1 -vet=off -timeout=30m -failfast
 
 elif [ "$1" = "js_cluster_tests_2" ]; then
 
@@ -54,7 +52,7 @@ elif [ "$1" = "js_cluster_tests_2" ]; then
     # start with `TestJetStreamCluster`. Will run the second batch of tests,
     # excluding others with use of proper tags.
 
-    go test -race -v -run=TestJetStreamCluster ./server -tags=skip_js_cluster_tests,skip_js_cluster_tests_3,skip_js_cluster_tests_4 -count=1 -vet=off -timeout=30m -failfast
+    go test $RACE -v -p=1 -run=TestJetStreamCluster ./server -tags=skip_js_cluster_tests,skip_js_cluster_tests_3,skip_js_cluster_tests_4 -count=1 -vet=off -timeout=30m -failfast
 
 elif [ "$1" = "js_cluster_tests_3" ]; then
 
@@ -63,7 +61,7 @@ elif [ "$1" = "js_cluster_tests_3" ]; then
     # excluding others with use of proper tags.
     #
 
-    go test -race -v -run=TestJetStreamCluster ./server -tags=skip_js_cluster_tests,skip_js_cluster_tests_2,skip_js_cluster_tests_4 -count=1 -vet=off -timeout=30m -failfast
+    go test $RACE -v -p=1 -run=TestJetStreamCluster ./server -tags=skip_js_cluster_tests,skip_js_cluster_tests_2,skip_js_cluster_tests_4 -count=1 -vet=off -timeout=30m -failfast
 
 elif [ "$1" = "js_cluster_tests_4" ]; then
 
@@ -72,26 +70,26 @@ elif [ "$1" = "js_cluster_tests_4" ]; then
     # excluding others with use of proper tags.
     #
 
-    go test -race -v -run=TestJetStreamCluster ./server -tags=skip_js_cluster_tests,skip_js_cluster_tests_2,skip_js_cluster_tests_3 -count=1 -vet=off -timeout=30m -failfast
+    go test $RACE -v -p=1 -run=TestJetStreamCluster ./server -tags=skip_js_cluster_tests,skip_js_cluster_tests_2,skip_js_cluster_tests_3 -count=1 -vet=off -timeout=30m -failfast
 
 elif [ "$1" = "js_super_cluster_tests" ]; then
 
     # Run JetStream super clustered tests. By convention, all JS super cluster
     # tests start with `TestJetStreamSuperCluster`.
 
-    go test -race -v -run=TestJetStreamSuperCluster ./server -count=1 -vet=off -timeout=30m -failfast
+    go test $RACE -v -p=1 -run=TestJetStreamSuperCluster ./server -count=1 -vet=off -timeout=30m -failfast
 
 elif [ "$1" = "mqtt_tests" ]; then
 
     # Run MQTT tests. By convention, all MQTT tests start with `TestMQTT`.
 
-    go test -race -v -run=TestMQTT ./server -count=1 -vet=off -timeout=30m -failfast
+    go test $RACE -v -p=1 -run=TestMQTT ./server -count=1 -vet=off -timeout=30m -failfast
 
 elif [ "$1" = "msgtrace_tests" ]; then
 
     # Run Message Tracing tests. By convention, all message tracing tests start with `TestMsgTrace`.
 
-    go test -race -v -run=TestMsgTrace ./server -count=1 -vet=off -timeout=30m -failfast
+    go test $RACE -v -p=1 -run=TestMsgTrace ./server -count=1 -vet=off -timeout=30m -failfast
 
 elif [ "$1" = "srv_pkg_non_js_tests" ]; then
 
@@ -101,12 +99,12 @@ elif [ "$1" = "srv_pkg_non_js_tests" ]; then
     # message tracing tests by using `skip_msgtrace_tests`.
 
     # Also including the ldflag with the version since this includes the `TestVersionMatchesTag`.
-    go test -race -v -p=1 ./server/... -ldflags="-X=github.com/nats-io/nats-server/v2/server.serverVersion=$TRAVIS_TAG" -tags=skip_store_tests,skip_js_tests,skip_mqtt_tests,skip_msgtrace_tests -count=1 -vet=off -timeout=30m -failfast
+    go test $RACE -v -p=1 ./server/... -ldflags="-X=github.com/nats-io/nats-server/v2/server.serverVersion=$TRAVIS_TAG" -tags=skip_store_tests,skip_js_tests,skip_mqtt_tests,skip_msgtrace_tests,skip_no_race_tests -count=1 -vet=off -timeout=30m -failfast
 
 elif [ "$1" = "non_srv_pkg_tests" ]; then
 
     # Run all tests of all non server package.
 
-    go test -race -v -p=1 $(go list ./... | grep -v "/server") -count=1 -vet=off -timeout=30m -failfast
+    go test $RACE -v -p=1 $(go list ./... | grep -v "/server") -count=1 -vet=off -timeout=30m -failfast
 
 fi


### PR DESCRIPTION
This will keep the race detector runs on development branches, but it will no longer run on `main`, release branches or `pull_request` runs.

Signed-off-by: Neil Twigg <neil@nats.io>