### PR TITLE
Place subject delete markers for TTL'd messages

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5593,7 +5593,7 @@ func (fs *fileStore) expireMsgs() {
 	nextTTL := int64(math.MaxInt64)
 	if fs.ttls != nil {
 		fs.ttls.ExpireTasks(func(seq uint64, ts int64) {
-			fs.removeMsg(seq, false, false, false)
+			fs.removeMsgViaLimits(seq)
 		})
 		if maxAge > 0 {
 			// Only check if we're expiring something in the next MaxAge interval, saves us a bit

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1067,7 +1067,7 @@ func (ms *memStore) expireMsgs() {
 	nextTTL := int64(math.MaxInt64)
 	if ms.ttls != nil {
 		ms.ttls.ExpireTasks(func(seq uint64, ts int64) {
-			ms.removeMsg(seq, false, _EMPTY_)
+			ms.removeMsg(seq, false, JSMarkerReasonMaxAge)
 		})
 		if maxAge > 0 {
 			// Only check if we're expiring something in the next MaxAge interval, saves us a bit

--- a/server/stream.go
+++ b/server/stream.go
@@ -5166,6 +5166,14 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		return err
 	}
 
+	// If subject delete markers are used, ensure message TTL is that at minimum.
+	// Otherwise, subject delete markers could be missed if one already exists for this subject.
+	if ttl > 0 && mset.cfg.SubjectDeleteMarkerTTL > 0 {
+		if minTtl := int64(mset.cfg.SubjectDeleteMarkerTTL.Seconds()); ttl < minTtl {
+			ttl = minTtl
+		}
+	}
+
 	// Store actual msg.
 	if lseq == 0 && ts == 0 {
 		seq, ts, err = store.StoreMsg(subject, hdr, msg, ttl)


### PR DESCRIPTION
Subject delete markers, if enabled, will now also be placed for TTL'd messages and not only messages expired by MaxAge.

However, there would be an issue if `SubjectDeleteMarkerTTL: 2h` and message `TTL: 5s` for example. If a subject delete marker for that subject already existed, then there wouldn't be a new subject delete marker if this message expired earlier than the previous subject delete marker. (Since subject delete markers don't place another marker once they expire)

To alleviate this, the TTL will always be made to be at minimum the `SubjectDeleteMarkerTTL`. This is not a hard error on publish, but will dynamically update the TTL based on the `SubjectDeleteMarkerTTL`. Since subject delete markers can be seen as a way to inform consumers about the removal of a subject, and the TTL signifies 'maximum time consumers would need to be informed'. It seems reasonable that the per-message TTL would need to have this minimum as well, at least for now. This ensures no subject delete markers would be missed.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>