### PR TITLE
FreeBSD: PSE non-CGO for arm64 too

### DIFF
--- a/server/pse/pse_freebsd_cgo.go
+++ b/server/pse/pse_freebsd_cgo.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !amd64
+//go:build cgo && freebsd
 
 package pse
 


### PR DESCRIPTION
For the pse support for FreeBSD:
 * switch the CGO implementation to require the cgo build tag, rather than per-architecture exemptions
 * rather than have N files, 1 for each arch, to set the constants for that one arch, switch the existing non-CGO file:
   + Be named without an arch constraint (use `_sysctl` instead)
   + Use arch build tags
   + Use an init-time runtime.GOARCH dispatch to set the variables needed.

Signed-off-by: Phil Pennock <pdp@nats.io>