### PR TITLE
Run NRG & JWT server tests in separate test pipeline

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -255,6 +255,24 @@ jobs:
       - name: Run unit tests
         run: ./scripts/runTestsOnTravis.sh msgtrace_tests
 
+  server-pkg-non-js-2:
+    name: Test NRG & JWT Server Tests
+    needs: [build-latest, build-supported, lint]
+    runs-on: ${{ vars.GHA_WORKER_LARGE || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Run unit tests
+        run: ./scripts/runTestsOnTravis.sh srv_pkg_non_js_tests_2
+        timeout-minutes: 15
+
   server-pkg-non-js:
     name: Test Remaining Server Tests
     needs: [build-latest, build-supported, lint]

--- a/scripts/runTestsOnTravis.sh
+++ b/scripts/runTestsOnTravis.sh
@@ -97,9 +97,16 @@ elif [ "$1" = "srv_pkg_non_js_tests" ]; then
     # store tests by using the `skip_store_tests` build tag, the JS tests
     # by using `skip_js_tests`, MQTT tests by using `skip_mqtt_tests` and
     # message tracing tests by using `skip_msgtrace_tests`.
+    # Ignore JWT and NRG tests here as they are slow.
 
     # Also including the ldflag with the version since this includes the `TestVersionMatchesTag`.
-    go test $RACE -v -p=1 ./server/... -ldflags="-X=github.com/nats-io/nats-server/v2/server.serverVersion=$TRAVIS_TAG" -tags=skip_store_tests,skip_js_tests,skip_mqtt_tests,skip_msgtrace_tests,skip_no_race_tests -count=1 -vet=off -timeout=30m -failfast
+    go test $RACE -v -p=1 ./server/... -run="^Test(N[^R]|NR[^G]|J[^W]|JW[^T]|[^JN])" -ldflags="-X=github.com/nats-io/nats-server/v2/server.serverVersion=$TRAVIS_TAG" -tags=skip_store_tests,skip_js_tests,skip_mqtt_tests,skip_msgtrace_tests,skip_no_race_tests -count=1 -vet=off -timeout=30m -failfast
+
+elif [ "$1" = "srv_pkg_non_js_tests_2" ]; then
+
+    # Run the JWT and NRG tests that were ignored above in srv_pkg_non_js_tests.
+
+    go test $RACE -v -p=1 ./server/... -run="^Test(NRG|JWT)" -tags=skip_store_tests,skip_js_tests,skip_mqtt_tests,skip_msgtrace_tests,skip_no_race_tests -count=1 -vet=off -timeout=30m -failfast
 
 elif [ "$1" = "non_srv_pkg_tests" ]; then
 


### PR DESCRIPTION
These tests are taking up a considerable amount of time on the `Test Remaining Server Tests` pipeline, so shorten the runs by parallelising those.

Signed-off-by: Neil Twigg <neil@nats.io>