### PR TITLE
[FIXED] No TTL outdated state after successful shutdown

### DIFF
--- a/server/thw/thw.go
+++ b/server/thw/thw.go
@@ -208,6 +208,11 @@ func (hw *HashWheel) GetNextExpiration(before int64) int64 {
 	return math.MaxInt64
 }
 
+// Count returns the amount of tasks in the THW.
+func (hw *HashWheel) Count() uint64 {
+	return hw.count
+}
+
 // AppendEncode writes out the contents of the THW into a binary snapshot
 // and returns it. The high seq number is included in the snapshot and will
 // be returned on decode.


### PR DESCRIPTION
If a server successfully shut down, upon recovery it would still (incorrectly) print the TTL state was outdated.

The sequence that's written into the TTL file should contain up to which sequence the TTLs were valid. So we don't have an off-by-one where the TTL state file contains `LastSeq` and we reload the last TTL because `ttlseq <= LastSeq`.

Also cleaned up `fs.ttlseq` as it was not really used.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>