### PR TITLE
[FIXED] Write tombstone for TTL'd messages

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5572,7 +5572,7 @@ func (fs *fileStore) expireMsgs() {
 					return false
 				}
 			} else {
-				fs.removeMsgViaLimits(seq)
+				fs.removeMsg(seq, false, false, false)
 			}
 			return true
 		})


### PR DESCRIPTION
A tombstone must be written for TTL'd messages, so that if `index.db` is invalid upon recovery. We still know to remove the TTL'd message, even if the TTL file was valid.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>