### PR TITLE
[FIXED] JWT max connections update closes internal clients

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1837,9 +1837,9 @@ func (s *Server) createInternalAccountClient() *client {
 	return s.createInternalClient(ACCOUNT)
 }
 
-// Internal clients. kind should be SYSTEM or JETSTREAM
+// Internal clients. kind should be SYSTEM, JETSTREAM or ACCOUNT
 func (s *Server) createInternalClient(kind int) *client {
-	if kind != SYSTEM && kind != JETSTREAM && kind != ACCOUNT {
+	if !isInternalClient(kind) {
 		return nil
 	}
 	now := time.Now()


### PR DESCRIPTION
If the max connections on the JWT for an account is updated, connections over the limit will be closed. However, it would also close internal clients, like `SYSTEM`, `JETSTREAM`, and `ACCOUNT`. This would result in publishing into the stream to fail (as well as any interactions with any other internal clients).

Only close non-internal clients when the JWT's max connections is updated.

Resolves https://github.com/nats-io/nats-server/issues/6766

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
