### PR TITLE
[FIXED] AckAll R1 consumer use correct floor

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3159,7 +3159,7 @@ func (o *consumer) processAckMsg(sseq, dseq, dc uint64, reply string, doSample b
 			needSignal = true
 		}
 		sgap = sseq - o.asflr
-		floor = sgap // start at same and set lower as we go.
+		floor = sseq // start at same and set lower as we go.
 		o.adflr, o.asflr = dseq, sseq
 
 		remove := func(seq uint64) {


### PR DESCRIPTION
For R1 AckAll consumers with Interest/WorkQueue retention would set the `floor` to `sgap`, which is the amount of messages that need to be deleted. However, that's incorrect, for example with:
```go
o.asflr = 2500
sseq = 2550
sgap = 50
```
We would scan from 2550 to 50, instead of from 2550 to 2501. If the `FirstSeq` of the stream was already at 2501, then we'd be doing over 2k additional iterations of `mset.ackMsg`.

```go
for seq := sseq; seq >= floor; seq-- {
	mset.ackMsg(o, seq)
}
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>