### PR TITLE
[monitoring] Fix jsz offset bug

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3060,7 +3060,9 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 	js.mu.RLock()
 	jsi.Config = js.config
 	if opts.Account != "" {
-		accounts = append(accounts, js.accounts[opts.Account])
+		if acc, ok := js.accounts[opts.Account]; ok {
+			accounts = append(accounts, acc)
+		}
 	} else {
 		for _, info := range js.accounts {
 			accounts = append(accounts, info)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3059,13 +3059,13 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 
 	js.mu.RLock()
 	jsi.Config = js.config
-	if opts.Account != "" {
-		if acc, ok := js.accounts[opts.Account]; ok {
-			accounts = append(accounts, acc)
-		}
-	} else {
+	if opts.Accounts {
 		for _, info := range js.accounts {
 			accounts = append(accounts, info)
+		}
+	} else if opts.Account != "" {
+		if acc, ok := js.accounts[opts.Account]; ok {
+			accounts = append(accounts, acc)
 		}
 	}
 	js.mu.RUnlock()
@@ -3111,9 +3111,8 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 
 		limit := min(opts.Limit, len(accounts))
 		accounts = accounts[:limit]
-	} else if opts.Account == "" {
-		accounts = []*jsAccount{}
 	}
+
 	if len(accounts) > 0 {
 		jsi.AccountDetails = make([]*AccountDetail, 0, len(accounts))
 	}

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -5010,11 +5010,24 @@ func TestMonitorJsz(t *testing.T) {
 	})
 	t.Run("offset-stable", func(t *testing.T) {
 		for _, url := range []string{monUrl1, monUrl2} {
-			info1 := readJsInfo(url + "?accounts=true&offset=1&limit=1")
+			info1 := readJsInfo(url + "?accounts=true&offset=0&limit=1")
 			if len(info1.AccountDetails) != 1 {
 				t.Fatalf("expected one account to be returned by %s but got %v", url, info1)
 			}
-			info2 := readJsInfo(url + "?accounts=true&offset=1&limit=1")
+			info2 := readJsInfo(url + "?accounts=true&offset=0&limit=1")
+			if len(info2.AccountDetails) != 1 {
+				t.Fatalf("expected one account to be returned by %s but got %v", url, info2)
+			}
+			if info1.AccountDetails[0].Name != info2.AccountDetails[0].Name {
+				t.Fatalf("absent changes, same offset should result in same account but gut: %v %v",
+					info1.AccountDetails[0].Name, info2.AccountDetails[0].Name)
+			}
+
+			info1 = readJsInfo(url + "?accounts=true&offset=1&limit=1")
+			if len(info1.AccountDetails) != 1 {
+				t.Fatalf("expected one account to be returned by %s but got %v", url, info1)
+			}
+			info2 = readJsInfo(url + "?accounts=true&offset=1&limit=1")
 			if len(info2.AccountDetails) != 1 {
 				t.Fatalf("expected one account to be returned by %s but got %v", url, info2)
 			}

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -5019,7 +5019,7 @@ func TestMonitorJsz(t *testing.T) {
 				t.Fatalf("expected one account to be returned by %s but got %v", url, info2)
 			}
 			if info1.AccountDetails[0].Name != info2.AccountDetails[0].Name {
-				t.Fatalf("absent changes, same offset should result in same account but gut: %v %v",
+				t.Fatalf("absent changes, same offset should result in same account but got: %v %v",
 					info1.AccountDetails[0].Name, info2.AccountDetails[0].Name)
 			}
 


### PR DESCRIPTION
The core issue was that the account names were not being sorted unless offset was non-zero. However, the first page will always be an offset of zero and thus there is no determinism of the order.

Now the accounts are sorted and the logic is simplified to handle both single account and multiple account queries.
