### PR TITLE
[FIXED] Consumer reset on stream snapshot failure

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -5665,7 +5665,7 @@ func (mset *stream) resetAndWaitOnConsumers() {
 	for _, o := range consumers {
 		if node := o.raftNode(); node != nil {
 			node.StepDown()
-			node.Delete()
+			node.Stop()
 		}
 		if o.isMonitorRunning() {
 			o.monitorWg.Wait()


### PR DESCRIPTION
When a stream follower requires a catchup from a leader but is unable to do so, `mset.resetClusteredState` is called. However, it would also result in the replicated consumer state to be deleted. Which isn't needed, as the node can just be restarted.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>