### PR TITLE
Avoid filestore corruption by rejecting large publishes into JetStream

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5976,7 +5976,7 @@ func (fs *fileStore) writeMsgRecord(seq uint64, ts int64, subj string, hdr, msg 
 
 	// Get size for this message.
 	rl := fileStoreMsgSize(subj, hdr, msg)
-	if rl&hbit != 0 {
+	if rl&hbit != 0 || rl > rlBadThresh {
 		return 0, ErrMsgTooLarge
 	}
 	// Grab our current last message block.


### PR DESCRIPTION
We have an effective and seemingly undocumented limit of 32MB for messages published into JetStream as `indexCacheBuf` in the filestore rejects any records that exceed this length. We did not catch this on publish however, and then `indexCacheBuf` would later error when consuming etc.

Related: #6797
Signed-off-by: Neil Twigg <neil@nats.io>