### PR TITLE
Print "Trapped %q signal" as Notice level message

### DIFF
--- a/server/signal.go
+++ b/server/signal.go
@@ -46,7 +46,7 @@ func (s *Server) handleSignals() {
 		for {
 			select {
 			case sig := <-c:
-				s.Debugf("Trapped %q signal", sig)
+				s.Noticef("Trapped %q signal", sig)
 				switch sig {
 				case syscall.SIGINT:
 					s.Shutdown()


### PR DESCRIPTION
It would be useful to figure out what led to a change in the server state post-factum.   

## Test plan:
`nats-server --signal term`
and observer in the console:
```
[390785] 2025/04/16 16:19:23.666627 [INF] Server is ready
[390785] 2025/04/16 16:19:54.341025 [INF] Trapped "terminated" signal
[390785] 2025/04/16 16:19:54.341190 [INF] Initiating Shutdown...
[390785] 2025/04/16 16:19:54.341316 [INF] Server Exiting..       
```

There is https://pkg.go.dev/golang.org/x/sys/unix#SignalName, that we could use to print names like SIGTERM here, but I guess we do not add the dependency just for that.

Signed-off-by: Alex Bozhenko <alex@synadia.com>
