### PR TITLE
Release v2.10.28-RC.1

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -55,7 +55,7 @@ func init() {
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.10.27"
+	VERSION = "2.10.28-RC.1"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original


### PR DESCRIPTION
Includes the following (already cherry-picked) PRs:

- https://github.com/nats-io/nats-server/pull/6587
- https://github.com/nats-io/nats-server/pull/6607
- https://github.com/nats-io/nats-server/pull/6612
- https://github.com/nats-io/nats-server/pull/6609
- https://github.com/nats-io/nats-server/pull/6620
- https://github.com/nats-io/nats-server/pull/6668
- https://github.com/nats-io/nats-server/pull/6674
- https://github.com/nats-io/nats-server/pull/6647
- https://github.com/nats-io/nats-server/pull/6684
- https://github.com/nats-io/nats-server/pull/6691
- https://github.com/nats-io/nats-server/pull/6697
- https://github.com/nats-io/nats-server/pull/6705
- https://github.com/nats-io/nats-server/pull/6706
- https://github.com/nats-io/nats-server/pull/6704
- https://github.com/nats-io/nats-server/pull/6714
- https://github.com/nats-io/nats-server/pull/6720
- https://github.com/nats-io/nats-server/pull/6727
- https://github.com/nats-io/nats-server/pull/6730
- https://github.com/nats-io/nats-server/pull/6726
- https://github.com/nats-io/nats-server/pull/6732
- https://github.com/nats-io/nats-server/pull/6759
- https://github.com/nats-io/nats-server/pull/6753
- https://github.com/nats-io/nats-server/pull/6685
- https://github.com/nats-io/nats-server/pull/6769
- https://github.com/nats-io/nats-server/pull/6777
- https://github.com/nats-io/nats-server/pull/6785
- https://github.com/nats-io/nats-server/pull/6786
- https://github.com/nats-io/nats-server/pull/6778
- https://github.com/nats-io/nats-server/pull/6790
- https://github.com/nats-io/nats-server/pull/6791
- https://github.com/nats-io/nats-server/pull/6798
- https://github.com/nats-io/nats-server/pull/6794
- https://github.com/nats-io/nats-server/pull/6801

Signed-off-by: Neil Twigg <neil@nats.io>