### PR TITLE
De-flakes for v2.10.28

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5382,7 +5382,7 @@ func (fs *fileStore) resetAgeChk(delta int64) {
 		if fireIn = time.Duration(delta); fireIn < 250*time.Millisecond {
 			// Only fire at most once every 250ms.
 			// Excessive firing can effect ingest performance.
-			fireIn = time.Second
+			fireIn = 250 * time.Millisecond
 		}
 	}
 	if fs.ageChk != nil {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -941,7 +941,7 @@ func (ms *memStore) resetAgeChk(delta int64) {
 		if fireIn = time.Duration(delta); fireIn < 250*time.Millisecond {
 			// Only fire at most once every 250ms.
 			// Excessive firing can effect ingest performance.
-			fireIn = time.Second
+			fireIn = 250 * time.Millisecond
 		}
 	}
 	if ms.ageChk != nil {

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -1552,14 +1552,8 @@ func TestNRGSnapshotAndTruncateToApplied(t *testing.T) {
 	// Simulate upper layer calling down to apply.
 	n.Applied(1)
 
-	// Send heartbeat, which commits the second message.
-	n.processAppendEntryResponse(&appendEntryResponse{
-		term:    aeHeartbeat1.term,
-		index:   aeHeartbeat1.pindex,
-		peer:    nats1,
-		reply:   _EMPTY_,
-		success: true,
-	})
+	// Receive heartbeat, which commits the second message.
+	n.processAppendEntry(aeHeartbeat1, n.aesub)
 	require_Equal(t, n.commit, 2)
 
 	// Simulate upper layer calling down to apply.


### PR DESCRIPTION
De-flakes `TestJetStreamUpdateStream`, `TestJetStreamLargeExpiresAndServerRestart`, and `TestNRGSnapshotAndTruncateToApplied`.

Actually use 250ms as minimal expiry, and don't rely on v2.11.x behavior for test.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>