### PR TITLE
Update example systemd unit files to use Lame Duck Mode

### DIFF
--- a/util/nats-server-hardened.service
+++ b/util/nats-server-hardened.service
@@ -11,16 +11,20 @@ Type=simple
 EnvironmentFile=-/etc/default/nats-server
 ExecStart=/usr/sbin/nats-server -c /etc/nats-server.conf
 ExecReload=/bin/kill -s HUP $MAINPID
-ExecStop=/bin/kill -s SIGINT $MAINPID
+
+# The nats-server uses SIGUSR2 to trigger Lame Duck Mode (LDM) shutdown
+# https://docs.nats.io/running-a-nats-service/nats_admin/lame_duck_mode
+ExecStop=/bin/kill -s SIGUSR2  $MAINPID
 
 User=nats
 Group=nats
 
 Restart=always
 RestartSec=5
-# The nats-server uses SIGUSR2 to trigger using Lame Duck Mode (LDM) shutdown
-KillSignal=SIGUSR2
-# You might want to adjust TimeoutStopSec too.
+
+# This should be `lame_duck_duration` + some buffer to finish the shutdown.
+# By default, `lame_duck_duration` is 2 mins.
+TimeoutStopSec=150
 
 # Capacity Limits
 # JetStream requires 2 FDs open per stream.

--- a/util/nats-server.service
+++ b/util/nats-server.service
@@ -7,12 +7,17 @@ PrivateTmp=true
 Type=simple
 ExecStart=/usr/sbin/nats-server -c /etc/nats-server.conf
 ExecReload=/bin/kill -s HUP $MAINPID
-ExecStop=/bin/kill -s SIGINT $MAINPID
+
+# The nats-server uses SIGUSR2 to trigger Lame Duck Mode (LDM) shutdown
+# https://docs.nats.io/running-a-nats-service/nats_admin/lame_duck_mode
+ExecStop=/bin/kill -s SIGUSR2  $MAINPID
+
+# This should be `lame_duck_duration` + some buffer to finish the shutdown.
+# By default, `lame_duck_duration` is 2 mins.
+TimeoutStopSec=150
+
 User=nats
 Group=nats
-# The nats-server uses SIGUSR2 to trigger using Lame Duck Mode (LDM) shutdown
-KillSignal=SIGUSR2
-# You might want to adjust TimeoutStopSec too.
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Based on description the following directives:
* [ExecStop](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#ExecStop=)
* [TimeoutStopSec](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#TimeoutStopSec=)
* [KillSignal](https://www.freedesktop.org/software/systemd/man/latest/systemd.kill.html#KillSignal=)

This is what happens when one executes `systemctl stop nats-server` (or shuts down/reboots the host):
1. The timer for `TimeoutStopSec` is started.
2. `ExecStop` is executed
3. Immediately after `ExecStop` returns, `SIGTERM` is sent to the process.
4. After `TimeoutStopSec` seconds passed, if the service is still running, it is killed with `SIGKILL`

When we handle `SIGTERM`, [we do nothing if LDM is already in progress](https://github.com/nats-io/nats-server/blob/v2.11.1/server/signal.go#L55-L65).

And when LDM has gracefully evicted the clients, [it will proceed with shutdown](https://github.com/nats-io/nats-server/blob/v2.11.1/server/server.go#L4365)

That means we can put the server to LDM in the `ExecStop` command. Even though that kill command is not synchronous, SIGTERM sent immediately after that will do nothing, and server will continue with the LDM followed by a shutdown.
This is similar how we do it in [helm chart](https://github.com/nats-io/k8s/issues/994)

## Test plan:
Executed `systemctl stop nats-server`. 
See how after SIGUSR2 we almost immediately trap `SIGTERM`, and then proceed with lame duck mode(which can bee seen as 10s `lame_duck_grace_period` delay in the log)
```
[428721] 2025/04/18 15:09:54.890605 [INF] Trapped "user defined signal 2" signal    
[428721] 2025/04/18 15:09:54.890761 [INF] Entering lame duck mode, stop accepting new clients                                                                           
[428721] 2025/04/18 15:09:54.890836 [INF] Initiating JetStream Shutdown...          
[428721] 2025/04/18 15:09:54.890876 [INF] JetStream Shutdown           
[428721] 2025/04/18 15:09:54.892268 [INF] Trapped "terminated" signal
[428721] 2025/04/18 15:10:04.891993 [INF] Closing existing clients                                                                                                      
[428721] 2025/04/18 15:10:04.892140 [INF] Initiating Shutdown...                    
[428721] 2025/04/18 15:10:04.892358 [INF] Server Exiting.. 
```

To test the killing, I set `TimeoutStopSec` to 5 secs, and observed the following:
```
15:13:18 omenlaptop nats-server[433370]: [433370] 2025/04/18 15:13:18.296945 [INF] Trapped "user defined signal 2" signal
15:13:18 omenlaptop nats-server[433370]: [433370] 2025/04/18 15:13:18.297076 [INF] Entering lame duck mode, stop accepting new clients
15:13:18 omenlaptop nats-server[433370]: [433370] 2025/04/18 15:13:18.297194 [INF] Initiating JetStream Shutdown...
15:13:18 omenlaptop nats-server[433370]: [433370] 2025/04/18 15:13:18.297258 [INF] JetStream Shutdown
15:13:18 omenlaptop nats-server[433370]: [433370] 2025/04/18 15:13:18.298560 [INF] Trapped "terminated" signal
15:13:23 omenlaptop systemd[1]: nats.service: State 'stop-sigterm' timed out. Killing.
15:13:23 omenlaptop systemd[1]: nats.service: Killing process 433370 (nats-server) with signal SIGKILL.
15:13:23 omenlaptop systemd[1]: nats.service: Killing process 433374 (nats-server) with signal SIGKILL.
15:13:23 omenlaptop systemd[1]: nats.service: Main process exited, code=killed, status=9/KILL
15:13:23 omenlaptop systemd[1]: nats.service: Failed with result 'timeout'.
15:13:23 omenlaptop systemd[1]: Stopped NATS Server.
```


Fixes: https://github.com/nats-io/nats-server/issues/6802

Signed-off-by: Alex Bozhenko <alex@synadia.com>