### PR TITLE
[FIXED] Add total to JSZ and revert behavior

### DIFF
--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -4934,6 +4934,9 @@ func TestMonitorJsz(t *testing.T) {
 			if info.Limits.MaxHAAssets != 1000 {
 				t.Fatalf("expected max_ha_assets limit to be 1000 got %v", info.Limits)
 			}
+			if info.Total != 2 {
+				t.Fatalf("expected total to be 2 but got %d", info.Total)
+			}
 		}
 	})
 	t.Run("accounts", func(t *testing.T) {


### PR DESCRIPTION
In #6794, a limit default was enforced. However there was no indication of size in the response. The new behavior broke clients (Surveyor) that relied on getting everything in one request.

This change reverts the behavior to allow for everything to be returned in one request (fine for small deployments), but it adds a Total field on the response so clients can properly determine if subsequent requests are necessary.
