### PR TITLE
[FIXED] JetStream: message not accepted after expired account is updated

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3148,7 +3148,9 @@ func (a *Account) expiredTimeout() {
 	// Collect the clients and expire them.
 	cs := a.getClients()
 	for _, c := range cs {
-		c.accountAuthExpired()
+		if !isInternalClient(c.kind) {
+			c.accountAuthExpired()
+		}
 	}
 }
 


### PR DESCRIPTION
After an account expires, it is expected that an existing or new connection for this account is closed/rejected. However, if the account's expiration time is updated, a new connection should be able to publish into a stream.

This was not the case because on account expiration, all its clients were closed, including internal ones, which would remove the subject interest for the stream.

Resolves #6806

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>