### PR TITLE
[IMPROVED] SubjectDeleteMarkerTTL not used as minimum TTL when MaxMsgsPer=1 is set

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -5200,7 +5200,8 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 
 	// If subject delete markers are used, ensure message TTL is that at minimum.
 	// Otherwise, subject delete markers could be missed if one already exists for this subject.
-	if ttl > 0 && mset.cfg.SubjectDeleteMarkerTTL > 0 {
+	// MaxMsgsPer=1 is an exception, because we'll only ever have one message.
+	if ttl > 0 && mset.cfg.SubjectDeleteMarkerTTL > 0 && mset.cfg.MaxMsgsPer != 1 {
 		if minTtl := int64(mset.cfg.SubjectDeleteMarkerTTL.Seconds()); ttl < minTtl {
 			ttl = minTtl
 		}


### PR DESCRIPTION
In https://github.com/nats-io/nats-server/pull/6741 if `SubjectDeleteMarkerTTL` is used it will require that any per-message TTL is either the same or higher than the configured `SubjectDeleteMarkerTTL`. This limitation was added to ensure a subject delete marker is not missed when there's already a subject delete marker for a given subject, and a new message with a lower TTL expires earlier.

This limitation doesn't need to apply when `MaxMsgsPer=1` is set, because then the subject delete marker will be removed automatically for the new published message. This allows you to have a high `SubjectDeleteMarkerTTL`, but use lower per-message TTLs, if the use case matches with `MaxMsgsPer=1`.

Resolves https://github.com/nats-io/nats-server/issues/6814

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>