### PR TITLE
[FIXED] Direct get subject delete marker

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5753,7 +5753,7 @@ func (fs *fileStore) handleRemovalOrSdm(seq uint64, subj string, sdm bool, sdmTT
 		var _hdr [128]byte
 		hdr := fmt.Appendf(
 			_hdr[:0],
-			"NATS/1.0\r\n%s: %s\r\n%s: %s\r\n%s: %s\r\n\r\n\r\n",
+			"NATS/1.0\r\n%s: %s\r\n%s: %s\r\n%s: %s\r\n\r\n",
 			JSMarkerReason, JSMarkerReasonMaxAge,
 			JSMessageTTL, time.Duration(sdmTTL)*time.Second,
 			JSMsgRollup, JSMsgRollupSubject,

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -19787,3 +19787,40 @@ func TestJetStreamRejectLargePublishes(t *testing.T) {
 	require_Error(t, err)
 	require_Contains(t, err.Error(), ErrMsgTooLarge.Error())
 }
+
+func TestJetStreamDirectGetSubjectDeleteMarker(t *testing.T) {
+	for _, storageType := range []nats.StorageType{nats.FileStorage, nats.MemoryStorage} {
+		t.Run(storageType.String(), func(t *testing.T) {
+			s := RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+
+			nc, js := jsClientConnect(t, s)
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:                   "TEST",
+				Subjects:               []string{"test"},
+				Storage:                storageType,
+				SubjectDeleteMarkerTTL: time.Second,
+				AllowMsgTTL:            true,
+				AllowDirect:            true,
+			})
+			require_NoError(t, err)
+
+			m := nats.NewMsg("test")
+			m.Header.Set(JSMessageTTL, "1s")
+			_, err = js.PublishMsg(m)
+			require_NoError(t, err)
+
+			first, err := js.GetLastMsg("TEST", "test", nats.DirectGet())
+			require_NoError(t, err)
+			require_Equal(t, first.Header.Get(JSSequence), "1")
+
+			time.Sleep(1500 * time.Millisecond)
+
+			second, err := js.GetLastMsg("TEST", "test", nats.DirectGet())
+			require_NoError(t, err)
+			require_Equal(t, second.Header.Get(JSSequence), "2")
+		})
+	}
+}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1193,7 +1193,7 @@ func (ms *memStore) handleRemovalOrSdm(seq uint64, subj string, sdm bool, sdmTTL
 		var _hdr [128]byte
 		hdr := fmt.Appendf(
 			_hdr[:0],
-			"NATS/1.0\r\n%s: %s\r\n%s: %s\r\n%s: %s\r\n\r\n\r\n",
+			"NATS/1.0\r\n%s: %s\r\n%s: %s\r\n%s: %s\r\n\r\n",
 			JSMarkerReason, JSMarkerReasonMaxAge,
 			JSMessageTTL, time.Duration(sdmTTL)*time.Second,
 			JSMsgRollup, JSMsgRollupSubject,


### PR DESCRIPTION
Direct gets on subject delete markers would fail to decode due to one too many CRLFs.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>