### PR TITLE
[FIXED] TTL-ed message not removed after graceful restart

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -19740,6 +19740,13 @@ func TestJetStreamTHWExpireTasksRace(t *testing.T) {
 			// Wait for all goroutines to finish.
 			wg.Wait()
 
+			// Run once more to clean up for removed messages.
+			if fs, ok := mset.store.(*fileStore); ok {
+				fs.expireMsgs()
+			} else if ms, ok := mset.store.(*memStore); ok {
+				ms.expireMsgs()
+			}
+
 			// Count of entries in the THW should be exactly 0, and not underflow.
 			var hwCount uint64
 			if fs, ok := mset.store.(*fileStore); ok {


### PR DESCRIPTION
`fs.removeMsg` unlocks and relocks the filestore lock. We could be gracefully shutting down, write TTL state with the TTL-ed message expired, but have not yet removed the message because we shutdown too early. That would result in message not being removed by TTL after a restart.

For now we'll need to keep the message in the THW and check if the message is removed prior to removing it.

Later on we should make it so that `fs.removeMsg` doesn't unlock the filestore to do a callback. That would allow us to `fs.removeMsg` inline within THW's ExpireTasks and help fix the consumer pending race condition. But that will need more thinking/changes.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
