### PR TITLE
Scope `getAccessTime` to server to avoid leaking goroutines

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2353,7 +2353,7 @@ func (mb *msgBlock) firstMatchingMulti(sl *Sublist, start uint64, sm *StoreMsg) 
 	var updateLLTS bool
 	defer func() {
 		if updateLLTS {
-			mb.llts = getAccessTime()
+			mb.llts = mb.fs.getAccessTime()
 		}
 		mb.mu.Unlock()
 	}()
@@ -2468,7 +2468,7 @@ func (mb *msgBlock) firstMatching(filter string, wc bool, start uint64, sm *Stor
 	var updateLLTS bool
 	defer func() {
 		if updateLLTS {
-			mb.llts = getAccessTime()
+			mb.llts = mb.fs.getAccessTime()
 		}
 		mb.mu.Unlock()
 	}()
@@ -2482,7 +2482,7 @@ func (mb *msgBlock) firstMatching(filter string, wc bool, start uint64, sm *Stor
 		didLoad = true
 	}
 	// Mark fss activity.
-	mb.lsts = getAccessTime()
+	mb.lsts = mb.fs.getAccessTime()
 
 	if filter == _EMPTY_ {
 		filter = fwcs
@@ -2996,7 +2996,7 @@ func (fs *fileStore) SubjectsState(subject string) map[string]SimpleState {
 			shouldExpire = true
 		}
 		// Mark fss activity.
-		mb.lsts = getAccessTime()
+		mb.lsts = fs.getAccessTime()
 		mb.fss.Match(stringToBytes(subject), func(bsubj []byte, ss *SimpleState) {
 			subj := string(bsubj)
 			if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
@@ -3351,7 +3351,7 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 			mb.tryForceExpireCacheLocked()
 		}
 		if updateLLTS {
-			mb.llts = getAccessTime()
+			mb.llts = fs.getAccessTime()
 		}
 		mb.mu.Unlock()
 		return total, validThrough
@@ -3377,7 +3377,7 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 				shouldExpire = true
 			}
 			// Mark fss activity.
-			mb.lsts = getAccessTime()
+			mb.lsts = fs.getAccessTime()
 
 			var t uint64
 			var havePartial bool
@@ -3477,7 +3477,7 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 					shouldExpire = true
 				}
 				// Mark fss activity.
-				mb.lsts = getAccessTime()
+				mb.lsts = fs.getAccessTime()
 
 				mb.fss.Match(stringToBytes(filter), func(bsubj []byte, ss *SimpleState) {
 					adjust += ss.Msgs
@@ -3517,7 +3517,7 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 			mb.tryForceExpireCacheLocked()
 		}
 		if updateLLTS {
-			mb.llts = getAccessTime()
+			mb.llts = fs.getAccessTime()
 		}
 		mb.mu.Unlock()
 	}
@@ -3660,7 +3660,7 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *Sublist, lastPerSubject bo
 			mb.tryForceExpireCacheLocked()
 		}
 		if updateLLTS {
-			mb.llts = getAccessTime()
+			mb.llts = fs.getAccessTime()
 		}
 		mb.mu.Unlock()
 		return total, validThrough
@@ -3685,7 +3685,7 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *Sublist, lastPerSubject bo
 				shouldExpire = true
 			}
 			// Mark fss activity.
-			mb.lsts = getAccessTime()
+			mb.lsts = fs.getAccessTime()
 
 			var t uint64
 			var havePartial bool
@@ -3738,7 +3738,7 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *Sublist, lastPerSubject bo
 				mb.tryForceExpireCacheLocked()
 			}
 			if updateLLTS {
-				mb.llts = getAccessTime()
+				mb.llts = fs.getAccessTime()
 			}
 			mb.mu.Unlock()
 			total += t
@@ -3798,7 +3798,7 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *Sublist, lastPerSubject bo
 					shouldExpire = true
 				}
 				// Mark fss activity.
-				mb.lsts = getAccessTime()
+				mb.lsts = fs.getAccessTime()
 				IntersectStree(mb.fss, sl, func(bsubj []byte, ss *SimpleState) {
 					adjust += ss.Msgs
 				})
@@ -3837,7 +3837,7 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *Sublist, lastPerSubject bo
 			mb.tryForceExpireCacheLocked()
 		}
 		if updateLLTS {
-			mb.llts = getAccessTime()
+			mb.llts = fs.getAccessTime()
 		}
 		mb.mu.Unlock()
 	}
@@ -3922,7 +3922,7 @@ func (mb *msgBlock) setupWriteCache(buf []byte) {
 	if fi != nil {
 		mb.cache.off = int(fi.Size())
 	}
-	mb.llts = getAccessTime()
+	mb.llts = mb.fs.getAccessTime()
 	mb.startCacheExpireTimer()
 }
 
@@ -3953,7 +3953,7 @@ func (fs *fileStore) newMsgBlockForWrite() (*msgBlock, error) {
 	mb.fss = stree.NewSubjectTree[SimpleState]()
 
 	// Set cache time to creation time to start.
-	mb.llts, mb.lwts = 0, getAccessTime()
+	mb.llts, mb.lwts = 0, fs.getAccessTime()
 	// Remember our last sequence number.
 	atomic.StoreUint64(&mb.first.seq, fs.state.LastSeq+1)
 	atomic.StoreUint64(&mb.last.seq, fs.state.LastSeq)
@@ -4211,7 +4211,7 @@ func (mb *msgBlock) skipMsg(seq uint64, now time.Time) {
 		return
 	}
 	var needsRecord bool
-	nowts := getAccessTime()
+	nowts := mb.fs.getAccessTime()
 
 	mb.mu.Lock()
 	// If we are empty can just do meta.
@@ -4403,7 +4403,7 @@ func (fs *fileStore) firstSeqForSubj(subj string) (uint64, error) {
 			shouldExpire = true
 		}
 		// Mark fss activity.
-		mb.lsts = getAccessTime()
+		mb.lsts = fs.getAccessTime()
 
 		bsubj := stringToBytes(subj)
 		if ss, ok := mb.fss.Find(bsubj); ok && ss != nil {
@@ -4699,7 +4699,7 @@ func (fs *fileStore) removeMsg(seq uint64, secure, viaLimits, needFSLock bool) (
 	msz := fileStoreMsgSize(sm.subj, sm.hdr, sm.msg)
 
 	// Set cache timestamp for last remove.
-	mb.lrts = getAccessTime()
+	mb.lrts = fs.getAccessTime()
 
 	// Global stats
 	if fs.state.Msgs > 0 {
@@ -5489,7 +5489,7 @@ func (mb *msgBlock) expireCacheLocked() {
 	}
 
 	// Grab timestamp to compare.
-	tns := getAccessTime()
+	tns := mb.fs.getAccessTime()
 
 	// For the core buffer of messages, we care about reads and writes, but not removes.
 	bufts := mb.llts
@@ -5599,7 +5599,7 @@ func (fs *fileStore) expireMsgs() {
 
 	fs.mu.RLock()
 	maxAge := int64(fs.cfg.MaxAge)
-	minAge := getAccessTime() - maxAge
+	minAge := fs.getAccessTime() - maxAge
 	rmcb := fs.rmcb
 	sdmcb := fs.sdmcb
 	sdmTTL := int64(fs.cfg.SubjectDeleteMarkerTTL.Seconds())
@@ -5616,7 +5616,7 @@ func (fs *fileStore) expireMsgs() {
 			if len(sm.hdr) > 0 {
 				if ttl, err := getMessageTTL(sm.hdr); err == nil && ttl < 0 {
 					// The message has a negative TTL, therefore it must "never expire".
-					minAge = getAccessTime() - maxAge
+					minAge = fs.getAccessTime() - maxAge
 					continue
 				}
 			}
@@ -5633,7 +5633,7 @@ func (fs *fileStore) expireMsgs() {
 				fs.mu.Unlock()
 			}
 			// Recalculate in case we are expiring a bunch.
-			minAge = getAccessTime() - maxAge
+			minAge = fs.getAccessTime() - maxAge
 		}
 	}
 
@@ -5882,7 +5882,7 @@ func (mb *msgBlock) writeMsgRecordLocked(rl, seq uint64, subj string, mhdr, msg 
 			return err
 		}
 		// Mark fss activity.
-		mb.lsts = getAccessTime()
+		mb.lsts = mb.fs.getAccessTime()
 		if ss, ok := mb.fss.Find(stringToBytes(subj)); ok && ss != nil {
 			ss.Msgs++
 			ss.Last = seq
@@ -6560,7 +6560,7 @@ func (mb *msgBlock) indexCacheBuf(buf []byte) error {
 		popFss = true
 	}
 	// Mark fss activity.
-	mb.lsts = getAccessTime()
+	mb.lsts = mb.fs.getAccessTime()
 	mb.ttls = 0
 
 	lbuf := uint32(len(buf))
@@ -6786,7 +6786,7 @@ func (mb *msgBlock) flushPendingMsgsLocked() (*LostStreamData, error) {
 
 	// Decide what we want to do with the buffer in hand. If we have load interest
 	// we will hold onto the whole thing, otherwise empty the buffer, possibly reusing it.
-	if ts := getAccessTime(); ts < mb.llts || (ts-mb.llts) <= int64(mb.cexp) {
+	if ts := mb.fs.getAccessTime(); ts < mb.llts || (ts-mb.llts) <= int64(mb.cexp) {
 		mb.cache.wp += lob
 	} else {
 		if cap(mb.cache.buf) <= maxBufReuse {
@@ -6949,7 +6949,7 @@ checkCache:
 		return nil
 	}
 
-	mb.llts = getAccessTime()
+	mb.llts = mb.fs.getAccessTime()
 
 	// FIXME(dlc) - We could be smarter here.
 	if buf, _ := mb.bytesPending(); len(buf) > 0 {
@@ -7138,7 +7138,7 @@ func (mb *msgBlock) cacheLookupEx(seq uint64, sm *StoreMsg, doCopy bool) (*Store
 
 	// If we have a delete map check it.
 	if mb.dmap.Exists(seq) {
-		mb.llts = getAccessTime()
+		mb.llts = mb.fs.getAccessTime()
 		return nil, errDeletedMsg
 	}
 
@@ -7169,7 +7169,7 @@ func (mb *msgBlock) cacheLookupEx(seq uint64, sm *StoreMsg, doCopy bool) (*Store
 	}
 
 	// Update cache activity.
-	mb.llts = getAccessTime()
+	mb.llts = mb.fs.getAccessTime()
 
 	li := int(bi) - mb.cache.off
 	if li >= len(mb.cache.buf) {
@@ -7430,7 +7430,7 @@ func (fs *fileStore) loadLast(subj string, sm *StoreMsg) (lsm *StoreMsg, err err
 			return nil, err
 		}
 		// Mark fss activity.
-		mb.lsts = getAccessTime()
+		mb.lsts = mb.fs.getAccessTime()
 
 		var l uint64
 		// Optimize if subject is not a wildcard.
@@ -8975,7 +8975,7 @@ func (mb *msgBlock) generatePerSubjectInfo() error {
 
 	if mb.fss.Size() > 0 {
 		// Make sure we run the cache expire timer.
-		mb.llts = getAccessTime()
+		mb.llts = mb.fs.getAccessTime()
 		// Mark fss activity same as load time.
 		mb.lsts = mb.llts
 		mb.startCacheExpireTimer()
@@ -8989,7 +8989,7 @@ func (mb *msgBlock) ensurePerSubjectInfoLoaded() error {
 	if mb.fss != nil || mb.noTrack {
 		if mb.fss != nil {
 			// Mark fss activity.
-			mb.lsts = getAccessTime()
+			mb.lsts = mb.fs.getAccessTime()
 		}
 		return nil
 	}
@@ -11136,26 +11136,11 @@ func writeFileWithSync(name string, data []byte, perm fs.FileMode) error {
 	return f.Close()
 }
 
-// This is to offload UnixNano() processing from timestamp creation for cache management.
-var (
-	tsOnce     sync.Once
-	accessTime atomic.Int64
-)
-
-// Update every 100ms.
-const accessTimeTickInterval = 100 * time.Millisecond
-
-// Will load the access time from an atomic. We will also setup the Go routine
-// to update this in one place.
-func getAccessTime() int64 {
-	tsOnce.Do(func() {
-		accessTime.Store(time.Now().UnixNano())
-		go func() {
-			ticker := time.NewTicker(accessTimeTickInterval)
-			for range ticker.C {
-				accessTime.Store(time.Now().UnixNano())
-			}
-		}()
-	})
-	return accessTime.Load()
+// If possible, load the access time from an atomic that belongs to the server.
+// If not then we'll just get the time directly to satisfy unit tests.
+func (fs *fileStore) getAccessTime() int64 {
+	if fs.srv != nil {
+		return fs.srv.getAccessTime()
+	}
+	return time.Now().UnixNano() // Satisfy unit tests.
 }


### PR DESCRIPTION
This was picked up by the Go client tests checking for leaking goroutines.

Signed-off-by: Neil Twigg <neil@nats.io>