### PR TITLE
[ADDED] MQTT: allow custom timeout for JS API calls

### DIFF
--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -469,6 +469,11 @@ func TestMQTTValidateOptions(t *testing.T) {
 			o.MQTT.AckWait = -10 * time.Second
 			return o
 		}, errMQTTAckWaitMustBePositive},
+		{"js api timeout should be >=0", func() *Options {
+			o := mqtto.Clone()
+			o.MQTT.JSAPITimeout = -10 * time.Second
+			return o
+		}, errMQTTJSAPITimeoutMustBePositive},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := validateMQTTOptions(test.getOpts())
@@ -498,6 +503,7 @@ func TestMQTTParseOptions(t *testing.T) {
 		{"ack wait", `mqtt: {ack_wait: abc}`, nil, "invalid duration"},
 		{"max ack pending", `mqtt: {max_ack_pending: abc}`, nil, "not int64"},
 		{"max ack pending too high", `mqtt: {max_ack_pending: 12345678}`, nil, "invalid value"},
+		{"js_api_timeout bad duration", `mqtt: {js_api_timeout: abc}`, nil, "invalid duration"},
 		// Positive tests
 		{"tls gen fails", `
 			mqtt {
@@ -624,6 +630,17 @@ func TestMQTTParseOptions(t *testing.T) {
 			`, func(o *MQTTOpts) error {
 				if !o.downgradeQoS2Sub {
 					return fmt.Errorf("Invalid: expected downgradeQoS2Sub to be set")
+				}
+				return nil
+			}, ""},
+		{"js_api_timeout",
+			`
+			mqtt {
+				js_api_timeout: "60s"
+			}
+			`, func(o *MQTTOpts) error {
+				if o.JSAPITimeout != 60*time.Second {
+					return fmt.Errorf("Invalid JS API timeout: %v", o.JSAPITimeout)
 				}
 				return nil
 			}, ""},

--- a/server/opts.go
+++ b/server/opts.go
@@ -616,6 +616,9 @@ type MQTTOpts struct {
 	// PubRels).
 	AckWait time.Duration
 
+	// JSAPITimeout defines timeout for JetStream api calls (default is 5 seconds)
+	JSAPITimeout time.Duration
+
 	// MaxAckPending is the amount of QoS 1 and 2 messages (combined) the server
 	// can send to a subscription without receiving any PUBACK for those
 	// messages. The valid range is [0..65535].
@@ -5205,6 +5208,8 @@ func parseMQTT(v any, o *Options, errors *[]error, warnings *[]error) error {
 			o.MQTT.NoAuthUser = mv.(string)
 		case "ack_wait", "ackwait":
 			o.MQTT.AckWait = parseDuration("ack_wait", tk, mv, errors, warnings)
+		case "js_api_timeout", "api_timeout":
+			o.MQTT.JSAPITimeout = parseDuration("js_api_timeout", tk, mv, errors, warnings)
 		case "max_ack_pending", "max_pending", "max_inflight":
 			tmp := int(mv.(int64))
 			if tmp < 0 || tmp > 0xFFFF {


### PR DESCRIPTION
There was a hard-coded timeout of 4s for making JS API calls (`mqttJSAPITimeout`).

Added an MQTT config option to configure this timeout.

Partially fixes https://github.com/nats-io/nats-server/issues/6191 

I think the proper fix would require sending an error to the mqtt client that we could not create a subscription. But this helps to at least bump the limit.

Signed-off-by: Ondrej Belusky <zlymeda@gmail.com>


