### PR TITLE
[FIXED] Consistent filtered consumer state reporting

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2983,13 +2983,14 @@ func (o *consumer) infoWithSnapAndReply(snap bool, reply string) *ConsumerInfo {
 		}
 	}
 
-	// If we are replicated, we need to pull certain data from our store.
-	if rg != nil && rg.node != nil && o.store != nil {
+	// We always need to pull certain data from our store.
+	if o.store != nil {
 		state, err := o.store.BorrowState()
 		if err != nil {
 			o.mu.Unlock()
 			return nil
 		}
+
 		// If we are the leader we could have o.sseq that is skipped ahead.
 		// To maintain consistency in reporting (e.g. jsz) we always take the state for our delivered/ackfloor stream sequence.
 		// Only use skipped ahead o.sseq if we're a new consumer and have not yet replicated this state yet.

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -6566,7 +6566,8 @@ func TestJetStreamClusterMaxDeliveriesOnInterestStreams(t *testing.T) {
 	sub2, err := js.PullSubscribe("foo.*", "c2", nats.AckWait(10*time.Millisecond), nats.MaxDeliver(1))
 	require_NoError(t, err)
 
-	js.Publish("foo.bar", []byte("HELLO"))
+	_, err = js.Publish("foo.bar", []byte("HELLO"))
+	require_NoError(t, err)
 
 	si, err := js.StreamInfo("TEST")
 	require_NoError(t, err)
@@ -6595,8 +6596,8 @@ func TestJetStreamClusterMaxDeliveriesOnInterestStreams(t *testing.T) {
 		require_NoError(t, err)
 		require_Equal(t, ci.Delivered.Consumer, 1)
 		require_Equal(t, ci.Delivered.Stream, 1)
-		require_Equal(t, ci.AckFloor.Consumer, 1)
-		require_Equal(t, ci.AckFloor.Stream, 1)
+		require_Equal(t, ci.AckFloor.Consumer, 0)
+		require_Equal(t, ci.AckFloor.Stream, 0)
 		require_Equal(t, ci.NumAckPending, 0)
 		require_Equal(t, ci.NumRedelivered, 1)
 		require_Equal(t, ci.NumPending, 0)

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -5474,14 +5474,9 @@ func TestJetStreamClusterConsumerMaxDeliveryNumAckPendingBug(t *testing.T) {
 		t.Helper()
 		require_Equal(t, a.Delivered.Consumer, 10)
 		require_Equal(t, a.Delivered.Stream, 10)
-		// If replicated, agreed upon state is used. Otherwise, o.asflr and o.adflr would be skipped ahead for R1.
-		if replicated {
-			require_Equal(t, a.AckFloor.Consumer, 0)
-			require_Equal(t, a.AckFloor.Stream, 0)
-		} else {
-			require_Equal(t, a.AckFloor.Consumer, 10)
-			require_Equal(t, a.AckFloor.Stream, 10)
-		}
+		// Agreed upon state is always used. Otherwise, o.asflr and o.adflr would be skipped ahead.
+		require_Equal(t, a.AckFloor.Consumer, 0)
+		require_Equal(t, a.AckFloor.Stream, 0)
 		require_Equal(t, a.NumPending, 40)
 		require_Equal(t, a.NumRedelivered, 10)
 		a.Cluster, b.Cluster = nil, nil


### PR DESCRIPTION
Consumer state reporting would be incorrect for filtered consumers. For example:
- 2 messages in the stream, one matches your filter subject
- you fetch 2 messages, but only get one because that matches your filter
- you now ack that message at sequence 1
- after acking, your delivered and ack floor state should mention sequence 1

However, currently this is incorrect and reports sequence 2 for both.

We must always use our stored state, even if not replicated. The leader uses a running total, and although that can be relied upon for delivering new messages, it does not always report correct data when used for info requests.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>