### PR TITLE
stree: Reduce allocations in `matchParts`

### DIFF
--- a/server/stree/parts.go
+++ b/server/stree/parts.go
@@ -123,7 +123,10 @@ func matchParts(parts [][]byte, frag []byte) ([][]byte, bool) {
 		// but update the part to what was consumed. This allows upper layers to continue.
 		if end < si+lp {
 			if end >= lf {
-				parts = append([][]byte{}, parts...) // Create a copy before modifying.
+				// Create a copy before modifying. Reuse slice capacity available at the
+				// end of the parts slice, since this saves us additional allocations.
+				lp := len(parts)
+				parts = append(parts[lp:], parts[:lp]...)
 				parts[i] = parts[i][lf-si:]
 			} else {
 				i++


### PR DESCRIPTION
More often than not, if we need to copy when matching, we're potentially wasting free capacity at the end of the existing `parts` slice. Instead of allocating a whole new slice, attempt to reuse that capacity. If it overflows into a reallocation then that's not the end of the world, as there should now be more available capacity for the next iteration too.

This is safe to do as in the `match` function, `parts` is not modified at any point before the next call to `matchParts`, therefore unused capacity is not going to be overwritten.

Signed-off-by: Neil Twigg <neil@nats.io>
