### PR TITLE
Fix sublist intersection regression

### DIFF
--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -9550,6 +9550,42 @@ func TestJetStreamConsumerDeliverAllOverlappingFilterSubjects(t *testing.T) {
 	}
 }
 
+// https://github.com/nats-io/nats-server/issues/6844
+func TestJetStreamConsumerDeliverAllNonOverlappingFilterSubjects(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnectNewAPI(t, s)
+	defer nc.Close()
+
+	ctx := context.Background()
+	_, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"stream.>"},
+	})
+	require_NoError(t, err)
+
+	publishMessageCount := 10
+	for i := 0; i < publishMessageCount; i++ {
+		_, err = js.Publish(ctx, "stream.subject", nil)
+		require_NoError(t, err)
+	}
+
+	// Create consumer
+	consumer, err := js.CreateOrUpdateConsumer(ctx, "TEST", jetstream.ConsumerConfig{
+		DeliverPolicy: jetstream.DeliverAllPolicy,
+		FilterSubjects: []string{
+			"stream.subject.A",
+			"stream.subject.A.>",
+		},
+	})
+	require_NoError(t, err)
+
+	i, err := consumer.Info(ctx)
+	require_NoError(t, err)
+	require_Equal(t, i.NumPending, 0)
+}
+
 func TestJetStreamConsumerStateAlwaysFromStore(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -1747,23 +1747,6 @@ func IntersectStree[T any](st *stree.SubjectTree[T], sl *Sublist, cb func(subj [
 }
 
 func intersectStree[T any](st *stree.SubjectTree[T], r *level, subj []byte, cb func(subj []byte, entry *T)) {
-	// This level could potentially match literals, despite being followed up by
-	// additional wildcards. For literals we can use Find since it is considerably
-	// faster. Then we can carry on checking for further matches in the usual way.
-	wc := subjectHasWildcard(bytesToString(subj))
-	if !wc {
-		if e, ok := st.Find(subj); ok {
-			cb(subj, e)
-		}
-	}
-	if r.numNodes() == 0 {
-		// No further recursions to be made at this point but there's still a wildcard
-		// to match, so let the subject tree work it out.
-		if wc {
-			st.Match(subj, cb)
-		}
-		return
-	}
 	nsubj := subj
 	if len(nsubj) > 0 {
 		nsubj = append(subj, '.')
@@ -1779,15 +1762,28 @@ func intersectStree[T any](st *stree.SubjectTree[T], r *level, subj []byte, cb f
 		// check whether there's interest at this level (without triggering dupes) and
 		// match if so.
 		nsubj := append(nsubj, '*')
-		if len(r.pwc.psubs)+len(r.pwc.qsubs) > 0 && r.pwc.next != nil && r.pwc.next.numNodes() > 0 {
+		if len(r.pwc.psubs)+len(r.pwc.qsubs) > 0 {
 			st.Match(nsubj, cb)
 		}
-		intersectStree(st, r.pwc.next, nsubj, cb)
-	case r.numNodes() > 0:
+		if r.pwc.next != nil && r.pwc.next.numNodes() > 0 {
+			intersectStree(st, r.pwc.next, nsubj, cb)
+		}
+	default:
 		// Normal node with subject literals, keep iterating.
 		for t, n := range r.nodes {
 			nsubj := append(nsubj, t...)
-			intersectStree(st, n.next, nsubj, cb)
+			if len(n.psubs)+len(n.qsubs) > 0 {
+				if subjectHasWildcard(bytesToString(nsubj)) {
+					st.Match(nsubj, cb)
+				} else {
+					if e, ok := st.Find(nsubj); ok {
+						cb(nsubj, e)
+					}
+				}
+			}
+			if n.next != nil && n.next.numNodes() > 0 {
+				intersectStree(st, n.next, nsubj, cb)
+			}
 		}
 	}
 }

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -2118,6 +2118,19 @@ func TestSublistInterestBasedIntersection(t *testing.T) {
 		})
 		require_Len(t, len(got), 0)
 	})
+
+	t.Run("NoMatchPartial", func(t *testing.T) {
+		got := map[string]int{}
+		sl := NewSublistNoCache()
+		sl.Insert(newSub("stream.A.not-child"))
+		sl.Insert(newSub("stream.A.child.>"))
+		IntersectStree(st, sl, func(subj []byte, entry *struct{}) {
+			fmt.Println("Matched", string(subj))
+			got[string(subj)]++
+		})
+		require_Len(t, len(got), 0)
+		require_NoDuplicates(t, got)
+	})
 }
 
 func subsInit(pre string, toks []string) {


### PR DESCRIPTION
A regression was introduced in #6827 which is now fixed, such that partials should not be incorrectly matched when the sublist doesn't have explicit interest for them. Also port the same fixes to the GSL.

Should fix #6844.

Signed-off-by: Neil Twigg <neil@nats.io>