### PR TITLE
[FIXED] Monitoring: Issue with Connz filters "cid" and "state=all"

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -340,7 +340,17 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 
 	// Search by individual CID.
 	if cid > 0 {
-		if state == ConnClosed || state == ConnAll {
+		// Let's first check if user also selects on ConnOpen or ConnAll
+		// and look for opened connections.
+		if state == ConnOpen || state == ConnAll {
+			if client := s.clients[cid]; client != nil {
+				openClients = append(openClients, client)
+				closedClients = nil
+			}
+		}
+		// If we did not find, and the user selected for ConnClosed or ConnAll,
+		// look for closed connections.
+		if len(openClients) == 0 && (state == ConnClosed || state == ConnAll) {
 			copyClosed := closedClients
 			closedClients = nil
 			for _, cc := range copyClosed {
@@ -348,11 +358,6 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 					closedClients = []*closedClient{cc}
 					break
 				}
-			}
-		} else if state == ConnOpen || state == ConnAll {
-			client := s.clients[cid]
-			if client != nil {
-				openClients = append(openClients, client)
 			}
 		}
 	} else {

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1949,6 +1949,12 @@ func TestMonitorConnzWithStateForClosedConns(t *testing.T) {
 			if lc := len(c.Conns); lc != 1 {
 				return fmt.Errorf("Expected a connection in open array, got %d", lc)
 			}
+			// It should also work if we ask for "state=all"
+			c = pollConnz(t, s, mode, url+"connz?cid=2&state=all", &ConnzOptions{CID: 2, State: ConnAll})
+			if lc := len(c.Conns); lc != 1 {
+				return fmt.Errorf("Expected a connection in open array, got %d", lc)
+			}
+			// But not for "state=closed"
 			c = pollConnz(t, s, mode, url+"connz?cid=2&state=closed", &ConnzOptions{CID: 2, State: ConnClosed})
 			if lc := len(c.Conns); lc != 0 {
 				return fmt.Errorf("Expected no connections in closed array, got %d", lc)


### PR DESCRIPTION
When filtering on a given connection ID, if the user also filters on the state being "all" and the connection is opened, it would not be returned. It would be if the connection was closed.

Resolves #6839

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>