### PR TITLE
NRG: Stepping down from preferred candidate

### DIFF
--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -2302,6 +2302,67 @@ func TestNRGRevalidateQuorumAfterLeaderChange(t *testing.T) {
 	require_Len(t, len(n.acks), 1)
 }
 
+func TestNRGSignalLeadChangeFalseIfCampaignImmediately(t *testing.T) {
+	tests := []struct {
+		title      string
+		switchNode func(n *raft)
+	}{
+		{
+			title: "Follower",
+		},
+		{
+			title: "Candidate",
+			switchNode: func(n *raft) {
+				n.switchToCandidate()
+			},
+		},
+		{
+			title: "Leader",
+			switchNode: func(n *raft) {
+				n.switchToCandidate()
+				n.switchToLeader()
+				select {
+				case isLeader := <-n.LeadChangeC():
+					require_True(t, isLeader)
+				default:
+					t.Error("Expected leadChange signal")
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			n, cleanup := initSingleMemRaftNode(t)
+			defer cleanup()
+
+			// Create a sample entry, the content doesn't matter, just that it's stored.
+			esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+			entries := []*Entry{newEntry(EntryNormal, esm)}
+
+			nats0 := "S1Nunr6R" // "nats-0"
+			aeMsg1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+
+			// Campaigning immediately signals we're the preferred leader.
+			require_NoError(t, n.CampaignImmediately())
+			if test.switchNode != nil {
+				test.switchNode(n)
+			}
+
+			n.processAppendEntry(aeMsg1, n.aesub)
+
+			select {
+			case isLeader := <-n.LeadChangeC():
+				require_False(t, isLeader)
+			default:
+				t.Error("Expected leadChange signal")
+			}
+			require_Equal(t, n.State(), Follower)
+			require_Equal(t, n.leader, nats0)
+			require_Equal(t, n.term, 1)
+		})
+	}
+}
+
 // This is a RaftChainOfBlocks test where a block is proposed and then we wait for all replicas to apply it before
 // proposing the next one.
 // The test may fail if:


### PR DESCRIPTION
A stream/consumer is already leader when it's R1. When it's scaled up, it remains leader and is preferred to be the leader of the Raft group. However, if it's in candidate state and doesn't get elected, it would not signal back to JetStream that it's not leader anymore once a new leader comes up.

This resulted in various weird situations where:
- Two leaders could be responding to requests; the new (real) leader, and the old (R1) leader.
- Various stream/consumer reporting would stop functioning properly, although they'd still be functional.

This is hard to reproduce normally, because the preferred leader nearly always gets elected.

Resolves https://github.com/nats-io/nats-server/issues/6838

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>