### PR TITLE
Standard exit code when shutdown via signal

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,8 @@ func main() {
 		fs.Usage,
 		server.PrintTLSHelpAndDie)
 	if err != nil {
-		server.PrintAndDie(fmt.Sprintf("%s: %s", exe, err))
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("%s: %s", exe, err))
+		os.Exit(1)
 	} else if opts.CheckConfig {
 		fmt.Fprintf(os.Stderr, "%s: configuration file %s is valid (%s)\n", exe, opts.ConfigFile, opts.ConfigDigest())
 		os.Exit(0)
@@ -117,7 +118,8 @@ func main() {
 	// Create the server with appropriate options.
 	s, err := server.NewServer(opts)
 	if err != nil {
-		server.PrintAndDie(fmt.Sprintf("%s: %s", exe, err))
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("%s: %s", exe, err))
+		os.Exit(1)
 	}
 
 	// Configure the logger based on the flags.
@@ -125,7 +127,7 @@ func main() {
 
 	// Start things up. Block here until done.
 	if err := server.Run(s); err != nil {
-		server.PrintAndDie(err.Error())
+		s.PrintAndDie(err.Error())
 	}
 
 	// Adjust MAXPROCS if running under linux/cgroups quotas.

--- a/server/signal_windows.go
+++ b/server/signal_windows.go
@@ -37,6 +37,7 @@ func (s *Server) handleSignals() {
 		for {
 			select {
 			case sig := <-c:
+				s.shutdownSignal.CompareAndSwap(0, int32(syscall.SIGTERM))
 				s.Debugf("Trapped %q signal", sig)
 				s.Shutdown()
 				os.Exit(0)


### PR DESCRIPTION
State:
 🟧 Code: POC for early feedback 
 🟥 Tests: missing

---

When receiving <signal>, exit with code 128+<signal>.

Pros:
 - Implement de-facto convention
 - Easier integration for any tool/script that expects this convention
 - Easier investigationof "why did server shutdown?" mystery scenarios

Cons:
 - May break some existing integration/tools/script (Hyrum's Law)

Sources:
 - https://tldp.org/LDP/abs/html/exitcodes.html
 - https://en.wikipedia.org/wiki/Exit_status#Shell_and_scripts
 - https://www.baeldung.com/linux/status-codes#fatal-error-signal

---

Behavior without this change:
 - Exit 1 in case of error
 - Exit 0 in case of signal

Target behavior:
 - Exit 1 in case of error
 - Exit 128+signal in case of signal and no shutdown errors
 - Exit 1 in error during shutdown as a result of signal

Signed-off-by: Marco Primi <marco@nats.io>
