### PR TITLE
systemd: switch to Restart=on-failure

### DIFF
--- a/util/nats-server-hardened.service
+++ b/util/nats-server-hardened.service
@@ -19,7 +19,7 @@ ExecStop=/bin/kill -s SIGUSR2  $MAINPID
 User=nats
 Group=nats
 
-Restart=always
+Restart=on-failure
 RestartSec=5
 
 # This should be `lame_duck_duration` + some buffer to finish the shutdown.

--- a/util/nats-server.service
+++ b/util/nats-server.service
@@ -16,6 +16,8 @@ ExecStop=/bin/kill -s SIGUSR2  $MAINPID
 # By default, `lame_duck_duration` is 2 mins.
 TimeoutStopSec=150
 
+Restart=on-failure
+
 User=nats
 Group=nats
 


### PR DESCRIPTION
I switched the hardened example config file to use `Restart=always` in c78874276 just over a year ago.  That was a mistake.

If the nats-server is asked to shut down, and shuts down cleanly, then the service manager should not restart it.  The server should be restarted if it exits on failure.

https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Restart=

Signed-off-by: Phil Pennock <pdp@nats.io>
