### PR TITLE
[FIXED] Filestore PurgeEx by sequence with interior delete gap

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -8332,8 +8332,13 @@ func (fs *fileStore) compact(seq uint64) (uint64, error) {
 	} else {
 		// Make sure to sync changes.
 		smb.needSync = true
-		// Update fs first seq and time.
-		atomic.StoreUint64(&smb.first.seq, seq-1) // Just for start condition for selectNextFirst.
+		// Just for start condition for selectNextFirst.
+		if smb.first.seq < seq {
+			atomic.StoreUint64(&smb.first.seq, seq-1)
+		} else {
+			// selectNextFirst always adds 1, so need to subtract 1 here.
+			atomic.StoreUint64(&smb.first.seq, smb.first.seq-1)
+		}
 		smb.selectNextFirst()
 
 		fs.state.FirstSeq = atomic.LoadUint64(&smb.first.seq)


### PR DESCRIPTION
Filestore would incorrectly set `mb.first.seq` after a `PurgeEx` using a sequence within an interior delete gap. It would set the first sequence to whatever is provided as the purge sequence, instead of properly moving the first sequence up and taking deletes into account.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>