### PR TITLE
wip safe config load and no reload

### DIFF
--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -1370,6 +1370,15 @@ func TestPingIntervalNew(t *testing.T) {
 	}
 }
 
+func TestOptions_ProcessConfigFileSafely(t *testing.T) {
+	opts := &Options{NoIncludes: true}
+
+	err := opts.ProcessConfigFile("./configs/include_conf_check_a.conf")
+	if err == nil || err.Error() != "file includes are not allowed in safe mode, but got 'include_conf_check_b.conf' on line 4" {
+		t.Fatalf("Expected includes not to be allowed, got %v", err)
+	}
+}
+
 func TestOptionsProcessConfigFile(t *testing.T) {
 	// Create options with default values of Debug and Trace
 	// that are the opposite of what is in the config file.

--- a/server/reload.go
+++ b/server/reload.go
@@ -1015,6 +1015,10 @@ func (s *Server) recheckPinnedCerts(curOpts *Options, newOpts *Options) {
 // to apply the changes. This returns an error if the server was not started
 // with a config file or an option which doesn't support hot-swapping was changed.
 func (s *Server) Reload() error {
+	if s.getOpts().NoReload {
+		return errors.New("can not reload config when NoReload is set")
+	}
+
 	s.mu.Lock()
 	configFile := s.configFile
 	s.mu.Unlock()

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -124,6 +124,14 @@ func TestConfigReloadNoConfigFile(t *testing.T) {
 	}
 }
 
+func TestConfigReloadDisabled(t *testing.T) {
+	server := New(&Options{NoSigs: true, NoReload: true})
+	err := server.Reload()
+	if err == nil || err.Error() != "can not reload config when NoReload is set" {
+		t.Fatalf("Expected error to be 'can not reload config when NoReload is set', got: %v", err)
+	}
+}
+
 // Ensure Reload returns an error when attempting to change an option which
 // does not support reloading.
 func TestConfigReloadUnsupported(t *testing.T) {


### PR DESCRIPTION
Adds an options parsing mode that disables `include` and variables.  Additionally allow reloads to be disabled.

Primarily to enable embedded uses where the configuration file might include file integrity checks etc

Signed-off-by: R.I.Pienaar <rip@devco.net>
