### PR TITLE
[FIXED] Don't report redeliveries for consumer with MaxDeliver 1

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2976,6 +2976,11 @@ func (o *consumer) infoWithSnapAndReply(snap bool, reply string) *ConsumerInfo {
 		TimeStamp:      time.Now().UTC(),
 		PriorityGroups: priorityGroups,
 	}
+	// Reset redelivered for MaxDeliver 1. Redeliveries are disabled so must not report it (is confusing otherwise).
+	// The state does still keep track of these messages.
+	if o.cfg.MaxDeliver == 1 {
+		info.NumRedelivered = 0
+	}
 	if o.cfg.PauseUntil != nil {
 		p := *o.cfg.PauseUntil
 		if info.Paused = time.Now().Before(p); info.Paused {

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -6599,7 +6599,7 @@ func TestJetStreamClusterMaxDeliveriesOnInterestStreams(t *testing.T) {
 		require_Equal(t, ci.AckFloor.Consumer, 0)
 		require_Equal(t, ci.AckFloor.Stream, 0)
 		require_Equal(t, ci.NumAckPending, 0)
-		require_Equal(t, ci.NumRedelivered, 1)
+		require_Equal(t, ci.NumRedelivered, 0)
 		require_Equal(t, ci.NumPending, 0)
 	}
 }

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -5478,7 +5478,7 @@ func TestJetStreamClusterConsumerMaxDeliveryNumAckPendingBug(t *testing.T) {
 		require_Equal(t, a.AckFloor.Consumer, 0)
 		require_Equal(t, a.AckFloor.Stream, 0)
 		require_Equal(t, a.NumPending, 40)
-		require_Equal(t, a.NumRedelivered, 10)
+		require_Equal(t, a.NumRedelivered, 0)
 		a.Cluster, b.Cluster = nil, nil
 		a.Delivered.Last, b.Delivered.Last = nil, nil
 		if !reflect.DeepEqual(a, b) {


### PR DESCRIPTION
A consumer with `MaxDeliver: 1` reports non-acked messages as `Redelivered Messages`, although no redeliveries have happened. The state is still preserved, otherwise unacked messages in an Interest stream can be lost if used for DLQ (https://github.com/nats-io/nats-server/issues/6538). But we don't report redeliveries anymore for this case.

Resolves https://github.com/nats-io/nats-server/issues/6874

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>