### PR TITLE
(2.12) Generate connect and disconnect events for global account clients

### DIFF
--- a/server/client_test.go
+++ b/server/client_test.go
@@ -1955,11 +1955,9 @@ func TestPingNotSentTooSoon(t *testing.T) {
 	if c.sendRTTPing() {
 		t.Fatalf("RTT ping should not have been sent")
 	}
-	// Speed up detection of time elapsed by moving the c.start to more than
-	// 2 secs in the past.
-	c.mu.Lock()
-	c.start = time.Unix(0, c.start.UnixNano()-int64(maxNoRTTPingBeforeFirstPong+time.Second))
-	c.mu.Unlock()
+	// Used to move c.start here but it is often causing race conditions,
+	// so we'll just wait instead.
+	time.Sleep(maxNoRTTPingBeforeFirstPong)
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/server/events.go
+++ b/server/events.go
@@ -2497,13 +2497,11 @@ func (s *Server) accountConnectEvent(c *client) {
 		s.mu.Unlock()
 		return
 	}
-	gacc := s.gacc
 	eid := s.nextEventID()
 	s.mu.Unlock()
 
 	c.mu.Lock()
-	// Ignore global account activity
-	if c.acc == nil || c.acc == gacc {
+	if c.acc == nil {
 		c.mu.Unlock()
 		return
 	}
@@ -2546,18 +2544,15 @@ func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string)
 		s.mu.Unlock()
 		return
 	}
-	gacc := s.gacc
 	eid := s.nextEventID()
 	s.mu.Unlock()
 
 	c.mu.Lock()
 
-	// Ignore global account activity
-	if c.acc == nil || c.acc == gacc {
+	if c.acc == nil {
 		c.mu.Unlock()
 		return
 	}
-
 	m := DisconnectEventMsg{
 		TypedEvent: TypedEvent{
 			Type: DisconnectEventMsgType,

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -583,10 +583,6 @@ func TestSystemAccountDisconnectBadLogin(t *testing.T) {
 	}
 	defer ncs.Close()
 
-	// We should never hear $G account events for bad logins.
-	sub, _ := ncs.SubscribeSync("$SYS.ACCOUNT.$G.*")
-	defer sub.Unsubscribe()
-
 	// Listen for auth error events though.
 	asub, _ := ncs.SubscribeSync("$SYS.SERVER.*.CLIENT.AUTH.ERR")
 	defer asub.Unsubscribe()
@@ -594,11 +590,6 @@ func TestSystemAccountDisconnectBadLogin(t *testing.T) {
 	ncs.Flush()
 
 	nats.Connect(url, nats.Name("TEST BAD LOGIN"))
-
-	// Should not hear these.
-	if _, err := sub.NextMsg(100 * time.Millisecond); err == nil {
-		t.Fatalf("Received a disconnect message from bad login, expected none")
-	}
 
 	m, err := asub.NextMsg(100 * time.Millisecond)
 	if err != nil {


### PR DESCRIPTION
Fixes #6543 SRV-13 by generating `$SYS.ACCOUNT.$G.CONNECT` and `$SYS.ACCOUNT.$G.DISCONNECT` events in the system account.

Signed-off-by: Neil Twigg <neil@nats.io>