### PR TITLE
[IMPROVED] Move the access time service to its own package and ensure go routine cleanup.

### DIFF
--- a/server/ats/ats.go
+++ b/server/ats/ats.go
@@ -1,0 +1,83 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ats controls the go routines for the access time service.
+// This allows more efficient unixnano operations for cache access times.
+// We will have one per binary (usually per server).
+package ats
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// Update every 100ms for gathering access time in unix nano.
+const TickInterval = 100 * time.Millisecond
+
+var (
+	// Our unix nano time.
+	utime atomic.Int64
+	// How may registered users do we have, controls lifetime of Go routine.
+	refs atomic.Int64
+	// To signal the shutdown of the Go routine.
+	done chan struct{}
+)
+
+func init() {
+	// Initialize our done chan.
+	done = make(chan struct{}, 1)
+}
+
+// Register usage. This will happen on filestore creation.
+func Register() {
+	if v := refs.Add(1); v == 1 {
+		// This is the first to register (could also go up and down),
+		// so spin up Go routine and grab initial time.
+		utime.Store(time.Now().UnixNano())
+
+		go func() {
+			ticker := time.NewTicker(TickInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					utime.Store(time.Now().UnixNano())
+				case <-done:
+					return
+				}
+			}
+		}()
+	}
+}
+
+// Unregister usage. We will shutdown the go routine if no more registered users.
+func Unregister() {
+	if v := refs.Add(-1); v == 0 {
+		done <- struct{}{}
+	} else if v < 0 {
+		refs.Store(0)
+		panic("unbalanced unregister for access time state")
+	}
+}
+
+// Will load the access time from an atomic.
+// If no one has registered this will return 0 or stale data.
+// It is the responsibility of the user to properly register and unregister.
+func AccessTime() int64 {
+	// Return last updated time.
+	v := utime.Load()
+	if v == 0 {
+		panic("access time service not running")
+	}
+	return v
+}

--- a/server/ats/ats_test.go
+++ b/server/ats/ats_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ats
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestNotRunningPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected function to panic, but it did not")
+		}
+	}()
+	// Set back to zero in case this test gets run multiple times via --count.
+	utime.Store(0)
+	_ = AccessTime()
+}
+
+func TestRegisterAndUnregister(t *testing.T) {
+	ngrp := runtime.NumGoroutine()
+
+	Register()
+	if r := refs.Load(); r != 1 {
+		t.Fatalf("Expected refs to be 1, got %d", r)
+	}
+	// Make sure we have a non-zero time.
+	at := AccessTime()
+	if at == 0 {
+		t.Fatal("Expected non-zero access time")
+	}
+	// Make sure we are updating access time.
+	time.Sleep(2 * TickInterval)
+	atn := AccessTime()
+	if atn == at {
+		t.Fatal("Expected access time to be updated but it was not")
+	}
+
+	// Now unregister.
+	Unregister()
+	if r := refs.Load(); r != 0 {
+		t.Fatalf("Expected refs to be 0, got %d", r)
+	}
+	time.Sleep(TickInterval)
+
+	at = AccessTime()
+	time.Sleep(2 * TickInterval)
+	atn = AccessTime()
+	if atn != at {
+		t.Fatal("Did not expect updates to access time")
+	}
+
+	// Check that we have no additional go routines running.
+	ngra := runtime.NumGoroutine()
+	if ngra != ngrp {
+		t.Fatalf("Expected same number of go routines after removing all registered: %d vs %d", ngrp, ngra)
+	}
+
+	// Check that we spin back up on going from zero to one registered after spinning down.
+	Register()
+	defer Unregister()
+
+	at = AccessTime()
+	time.Sleep(2 * TickInterval)
+	atn = AccessTime()
+	if atn == at {
+		t.Fatal("Expected access time to be updated but it was not")
+	}
+	ngra = runtime.NumGoroutine()
+	if ngra != ngrp+1 {
+		t.Fatalf("Expected to see additional go routine: %d vs %d", ngrp, ngra)
+	}
+}
+
+func TestUnbalancedUnregister(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected function to panic, but it did not")
+		}
+	}()
+	Unregister()
+}

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -233,7 +233,6 @@ func (s *Server) EnableJetStream(config *JetStreamConfig) error {
 type keyGen func(context []byte) ([]byte, error)
 
 // Return a key generation function or nil if encryption not enabled.
-// keyGen defined in filestore.go - keyGen func(iv, context []byte) []byte
 func (s *Server) jsKeyGen(jsKey, info string) keyGen {
 	if ek := jsKey; ek != _EMPTY_ {
 		return func(context []byte) ([]byte, error) {


### PR DESCRIPTION
Signed-off-by: Derek Collison <derek@nats.io>