### PR TITLE
Direct get fixes

### DIFF
--- a/server/memstore.go
+++ b/server/memstore.go
@@ -369,7 +369,7 @@ func (ms *memStore) GetSeqFromTime(t time.Time) uint64 {
 		}
 	}
 	if lmsg == nil {
-		return ms.state.FirstSeq
+		return ms.state.LastSeq + 1
 	}
 
 	last := lmsg.ts


### PR DESCRIPTION
Fixes #6077 by ensuring that we can't select a sequence number from the timestamp that falls below the stream first sequence.

Fixes #6032 by ensuring that the memory store doesn't return the first sequence incorrectly when there are no matching messages.

Signed-off-by: Neil Twigg <neil@nats.io>