### PR TITLE
[FIXED] Potential panic if subject to delete shorter then interior node index and prefix.

### DIFF
--- a/server/stree/stree.go
+++ b/server/stree/stree.go
@@ -124,7 +124,7 @@ func (t *SubjectTree[T]) Match(filter []byte, cb func(subject []byte, val *T)) {
 	t.match(t.root, parts, _pre[:0], cb)
 }
 
-// IterOrdered will walk all entries in the SubjectTree lexographically. The callback can return false to terminate the walk.
+// IterOrdered will walk all entries in the SubjectTree lexicographically. The callback can return false to terminate the walk.
 func (t *SubjectTree[T]) IterOrdered(cb func(subject []byte, val *T) bool) {
 	if t == nil || t.root == nil {
 		return
@@ -244,6 +244,10 @@ func (t *SubjectTree[T]) delete(np *node, subject []byte, si int) (*T, bool) {
 	}
 	// Not a leaf node.
 	if bn := n.base(); len(bn.prefix) > 0 {
+		// subject could be shorter and would panic on bad index into subject slice.
+		if len(subject) < si+len(bn.prefix) {
+			return nil, false
+		}
 		if !bytes.Equal(subject[si:si+len(bn.prefix)], bn.prefix) {
 			return nil, false
 		}
@@ -377,7 +381,7 @@ func (t *SubjectTree[T]) match(n node, parts [][]byte, pre []byte, cb func(subje
 	}
 }
 
-// Interal iter function to walk nodes in lexigraphical order.
+// Internal iter function to walk nodes in lexicographical order.
 func (t *SubjectTree[T]) iter(n node, pre []byte, ordered bool, cb func(subject []byte, val *T) bool) bool {
 	if n.isLeaf() {
 		ln := n.(*leaf[T])

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -956,3 +956,25 @@ func TestSubjectTreeLazyIntersect(t *testing.T) {
 	require_Equal(t, intersected["foo.bar"], 1)
 	require_Equal(t, intersected["foo.bar.baz.qux"], 1)
 }
+
+func TestSubjectTreeDeleteShortSubjectNoPanic(t *testing.T) {
+	defer func() {
+		p := recover()
+		require_True(t, p == nil)
+	}()
+
+	st := NewSubjectTree[int]()
+
+	st.Insert(b("foo.bar.baz"), 1)
+	st.Insert(b("foo.bar.qux"), 2)
+
+	v, found := st.Delete(b("foo.bar"))
+	require_False(t, found)
+	require_Equal(t, v, nil)
+	v, found = st.Find(b("foo.bar.baz"))
+	require_True(t, found)
+	require_Equal(t, *v, 1)
+	v, found = st.Find(b("foo.bar.qux"))
+	require_True(t, found)
+	require_Equal(t, *v, 2)
+}


### PR DESCRIPTION
Fix a bug that could cause a panic if subject to delete was shorter then index and prefix.

Also fixed some spelling.

Signed-off-by: Derek Collison <derek@nats.io>
