### PR TITLE
Don't hold `clsMu` while purging stream consumers

### DIFF
--- a/locksordering.txt
+++ b/locksordering.txt
@@ -28,5 +28,9 @@ clearObserverState so that they cannot interleave which would leave Raft nodes i
 inconsistent observer states.
 
     jscmMu -> Account -> jsAccount
-    jscmMu -> stream.clsMu 
+    jscmMu -> stream.clsMu
     jscmMu -> RaftNode
+
+The "clsMu" lock protects the consumer list on a stream, used for signalling consumer activity.
+
+    stream -> clsMu


### PR DESCRIPTION
Otherwise this can potentially result in a deadlock if interleaving with certain other operations, i.e. stream purges, new consumer assignments.

Signed-off-by: Neil Twigg <neil@nats.io>