### PR TITLE
Fix lock contention issue when reporting stream ingest warnings

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -4402,10 +4402,11 @@ func (mset *stream) queueInbound(ib *ipQueue[*inMsg], subj, rply string, hdr, ms
 	im.subj, im.rply, im.hdr, im.msg, im.si, im.mt = subj, rply, hdr, msg, si, mt
 	if _, err := ib.push(im); err != nil {
 		im.returnToPool()
-		mset.srv.RateLimitWarnf("Dropping messages due to excessive stream ingest rate on '%s' > '%s': %s", mset.acc.Name, mset.name(), err)
+		streamName := mset.cfg.Name
+		mset.srv.RateLimitWarnf("Dropping messages due to excessive stream ingest rate on '%s' > '%s': %s", mset.acc.Name, streamName, err)
 		if rply != _EMPTY_ {
 			hdr := []byte("NATS/1.0 429 Too Many Requests\r\n\r\n")
-			b, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: mset.cfg.Name}, Error: NewJSStreamTooManyRequestsError()})
+			b, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: streamName}, Error: NewJSStreamTooManyRequestsError()})
 			mset.outq.send(newJSPubMsg(rply, _EMPTY_, _EMPTY_, hdr, b, nil, 0))
 		}
 	}


### PR DESCRIPTION
Reporting the stream ingest warning on high load to publishers was causing lock contention issues trying to get the stream name:

```
goroutine 3570823 [sync.RWMutex.RLock, 6 minutes]:
sync.runtime_SemacquireRWMutexR(0x4906aa?, 0x20?, 0xc54f06ec80?)
        runtime/sema.go:100 +0x25
sync.(*RWMutex).RLock(...)
        sync/rwmutex.go:74
github.com/nats-io/nats-server/v2/server.(*stream).name(0xc0006b4408)
        github.com/nats-io/nats-server/v2/server/stream.go:5531 +0x4c
github.com/nats-io/nats-server/v2/server.(*stream).queueInbound(0xc0006b4408, 0xc0001a0000, {0xc1ece520b0, 0x10}, {0xc489410e40, 0x26}, {0x0, 0x0, 0x0}, {0xc237180c00, ...}, ...)
        github.com/nats-io/nats-server/v2/server/stream.go:4401 +0x1e6
github.com/nats-io/nats-server/v2/server.(*stream).processInboundJetStreamMsg(0xc0006b4408, 0xc54f06ee98?, 0xc478e00488, 0x45b0eb?, {0xc1ece520b0, 0x10}, {0xc489410e40, 0x26}, {0xc47af46041, 0x200, ...})
        github.com/nats-io/nats-server/v2/server/stream.go:4777 +0x22e
github.com/nats-io/nats-server/v2/server.(*client).deliverMsg(0xc478e00488, 0x0, 0xc000334840, 0xc00023c008, {0xc47af46004, 0x10, 0x3fc}, {0xc47af46015, 0x26, 0x3eb}, ...)
        github.com/nats-io/nats-server/v2/server/client.go:3791 +0xe7e
github.com/nats-io/nats-server/v2/server.(*client).processMsgResults(0xc478e00488, 0xc00023c008, 0xc036628db0, {0xc47af46041, 0x202, 0x3bf}, {0x0, 0x0, 0x1?}, {0xc47af46004, ...}, ...)
        github.com/nats-io/nats-server/v2/server/client.go:5003 +0xda7
github.com/nats-io/nats-server/v2/server.(*client).processInboundClientMsg(0xc478e00488, {0xc47af46041, 0x202, 0x3bf})
        github.com/nats-io/nats-server/v2/server/client.go:4304 +0xc8d
github.com/nats-io/nats-server/v2/server.(*client).processInboundMsg(0xc478e00488?, {0xc47af46041?, 0x3b?, 0x3fc?})
        github.com/nats-io/nats-server/v2/server/client.go:4130 +0x37
```

Signed-off-by: Waldemar Quevedo <wally@nats.io>
