### PR TITLE
[ADDED] Protocol: INFO in response to CONNECT contains account info.

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1991,12 +1991,16 @@ func (c *client) remoteCluster() string {
 // its permission settings for local enforcement.
 func (s *Server) sendPermsAndAccountInfo(c *client) {
 	// Copy
+	s.mu.Lock()
 	info := s.copyLeafNodeInfo()
+	s.mu.Unlock()
 	c.mu.Lock()
 	info.CID = c.cid
 	info.Import = c.opts.Import
 	info.Export = c.opts.Export
 	info.RemoteAccount = c.acc.Name
+	// s.SystemAccount() uses an atomic operation and does not get the server lock, so this is safe.
+	info.IsSystemAccount = c.acc == s.SystemAccount()
 	info.ConnectInfo = true
 	c.enqueueProto(generateInfoJSON(info))
 	c.mu.Unlock()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1147,6 +1147,8 @@ func TestLameDuckModeInfo(t *testing.T) {
 
 	getInfo(false)
 	c.Write([]byte("CONNECT {\"protocol\":1,\"verbose\":false}\r\nPING\r\n"))
+	// Consume both the first PONG and INFO in response to the Connect.
+	client.ReadString('\n')
 	client.ReadString('\n')
 
 	optsB := testWSOptions()

--- a/test/client_auth_test.go
+++ b/test/client_auth_test.go
@@ -17,7 +17,9 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 )
 
@@ -86,5 +88,71 @@ func TestTokenInConfig(t *testing.T) {
 	defer nc.Close()
 	if !nc.AuthRequired() {
 		t.Fatal("Expected auth to be required for the server")
+	}
+}
+
+func TestClientConnectInfo(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		sys      string
+		hasSys   bool
+		protocol int
+	}{
+		{"async info support with explicit system account", "system_account: SYS", true, server.ClientProtoInfo},
+		{"async info support without explicit system account", "", false, server.ClientProtoInfo},
+		{"no async info support with explicit system account", "system_account: SYS", true, server.ClientProtoZero},
+		{"no async info support without explicit system account", "", false, server.ClientProtoZero},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			conf := createConfFile(t, []byte(fmt.Sprintf(`
+				port: -1
+				%s
+				accounts {
+					SYS: { users: [{ user: sys, password: pwd}] }
+					A:   { users: [{ user: a, password: pwd}] }
+					B:   { users: [{ user: b, password: pwd}] }
+				}
+			`, test.sys)))
+			hub, oHub := RunServerWithConfig(conf)
+			defer hub.Shutdown()
+
+			checkInfoOnConnect := func(user, acc string, isSys bool) {
+				t.Helper()
+				cc := createClientConn(t, oHub.Host, oHub.Port)
+				defer cc.Close()
+
+				checkInfoMsg(t, cc)
+				sendProto(t, cc, fmt.Sprintf("CONNECT {\"user\":%q,\"pass\":\"pwd\",\"pedantic\":false,\"verbose\":false,\"protocol\":%d}\r\nPING\r\n", user, test.protocol))
+				// Since the PONG and INFO may be receive as a single TCP read,
+				// make sure we consume the pong alone here.
+				pongBuf := make([]byte, len("PONG\r\n"))
+				cc.SetReadDeadline(time.Now().Add(2 * time.Second))
+				n, err := cc.Read(pongBuf)
+				cc.SetReadDeadline(time.Time{})
+				if n <= 0 && err != nil {
+					t.Fatalf("Error reading from conn: %v\n", err)
+				}
+				if !pongRe.Match(pongBuf) {
+					t.Fatalf("Response did not match expected: \n\tReceived:'%q'\n\tExpected:'%s'\n", pongBuf, pongRe)
+				}
+				if test.protocol < server.ClientProtoInfo {
+					expectNothing(t, cc)
+				} else {
+					info := checkInfoMsg(t, cc)
+					if !info.ConnectInfo {
+						t.Fatal("Expected ConnectInfo to be true")
+					}
+					if an := info.RemoteAccount; an != acc {
+						t.Fatalf("Expected account %q, got %q", acc, info.RemoteAccount)
+					}
+					if ais := info.IsSystemAccount; ais != isSys {
+						t.Fatalf("Expected IsSystemAccount to be %v, got %v", isSys, ais)
+					}
+				}
+			}
+			checkInfoOnConnect("a", "A", false)
+			checkInfoOnConnect("sys", "SYS", test.hasSys)
+			checkInfoOnConnect("b", "B", false)
+		})
 	}
 }

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -586,11 +586,25 @@ func TestRouteSendAsyncINFOToClients(t *testing.T) {
 
 		newClientSend, newClientExpect := setupConnWithProto(t, newClient, clientProtoInfo)
 		newClientSend("PING\r\n")
-		newClientExpect(pongRe)
 
-		// Check that even a new client does not receive an async INFO at this point
-		// since there is no route created yet.
-		expectNothing(t, newClient)
+		// For new clients, the initial PING (after a CONNECT) will result in a
+		// PONG followed by an INFO, so make sure we receive them separately.
+		getPongAlone := func(c net.Conn) {
+			t.Helper()
+			pongBuf := make([]byte, len("PONG\r\n"))
+			c.SetReadDeadline(time.Now().Add(2 * time.Second))
+			n, err := c.Read(pongBuf)
+			c.SetReadDeadline(time.Time{})
+			if n <= 0 && err != nil {
+				t.Fatalf("Error reading from conn: %v\n", err)
+			}
+			if !pongRe.Match(pongBuf) {
+				t.Fatalf("Response did not match expected: \n\tReceived:'%q'\n\tExpected:'%s'\n", pongBuf, pongRe)
+			}
+		}
+		getPongAlone(newClient)
+		// The new client should receive an INFO with the ConnectInfo boolean set to true.
+		newClientExpect(infoRe)
 
 		routeID := "Server-B"
 
@@ -658,10 +672,16 @@ func TestRouteSendAsyncINFOToClients(t *testing.T) {
 			}
 		}
 
+		var checkConnectInfo bool
 		checkINFOReceived := func(client net.Conn, clientExpect expectFun, expectedURLs []string) {
 			if opts.Cluster.NoAdvertise {
-				expectNothing(t, client)
-				return
+				if !checkConnectInfo {
+					expectNothing(t, client)
+					return
+				}
+				// Since it is no advertise, but we still get an INFO, the URLs
+				// should be empty.
+				expectedURLs = nil
 			}
 			buf := clientExpect(infoRe)
 			info := server.Info{}
@@ -669,6 +689,17 @@ func TestRouteSendAsyncINFOToClients(t *testing.T) {
 				stackFatalf(t, "Could not unmarshal route info: %v", err)
 			}
 			checkClientConnectURLS(info.ClientConnectURLs, expectedURLs)
+			if checkConnectInfo {
+				if !info.ConnectInfo {
+					stackFatalf(t, "ConnectInfo should have been true")
+				}
+				if info.RemoteAccount != "$G" {
+					stackFatalf(t, "RemoteAccount should be %q, got %q", "$G", info.RemoteAccount)
+				}
+				if info.IsSystemAccount {
+					stackFatalf(t, "IsSystemAccount should have been false")
+				}
+			}
 		}
 
 		// Create a route
@@ -751,36 +782,20 @@ func TestRouteSendAsyncINFOToClients(t *testing.T) {
 
 		// Now send the first PING
 		clientNoPingSend("PING\r\n")
-		// Should receive PONG followed by INFO
-		// Receive PONG only first
-		pongBuf := make([]byte, len("PONG\r\n"))
-		clientNoPing.SetReadDeadline(time.Now().Add(2 * time.Second))
-		n, err := clientNoPing.Read(pongBuf)
-		clientNoPing.SetReadDeadline(time.Time{})
-		if n <= 0 && err != nil {
-			t.Fatalf("Error reading from conn: %v\n", err)
-		}
-		if !pongRe.Match(pongBuf) {
-			t.Fatalf("Response did not match expected: \n\tReceived:'%q'\n\tExpected:'%s'\n", pongBuf, pongRe)
-		}
+		getPongAlone(clientNoPing)
+		// We should receive an INFO but with ConnectInfo==true, etc..
+		checkConnectInfo = true
 		checkINFOReceived(clientNoPing, clientNoPingExpect, expectedURLs)
+		checkConnectInfo = false
 
 		// Have the client that did not send the connect do it now
 		clientNoConnectSend, clientNoConnectExpect := setupConnWithProto(t, clientNoConnect, clientProtoInfo)
 		// Send the PING
 		clientNoConnectSend("PING\r\n")
-		// Should receive PONG followed by INFO
-		// Receive PONG only first
-		clientNoConnect.SetReadDeadline(time.Now().Add(2 * time.Second))
-		n, err = clientNoConnect.Read(pongBuf)
-		clientNoConnect.SetReadDeadline(time.Time{})
-		if n <= 0 && err != nil {
-			t.Fatalf("Error reading from conn: %v\n", err)
-		}
-		if !pongRe.Match(pongBuf) {
-			t.Fatalf("Response did not match expected: \n\tReceived:'%q'\n\tExpected:'%s'\n", pongBuf, pongRe)
-		}
+		getPongAlone(clientNoConnect)
+		checkConnectInfo = true
 		checkINFOReceived(clientNoConnect, clientNoConnectExpect, expectedURLs)
+		checkConnectInfo = false
 
 		// Create a client connection and verify content of initial INFO contains array
 		// (but empty if no advertise option is set)
@@ -789,7 +804,7 @@ func TestRouteSendAsyncINFOToClients(t *testing.T) {
 		buf := expectResult(t, cli, infoRe)
 		js := infoRe.FindAllSubmatch(buf, 1)[0][1]
 		var sinfo server.Info
-		err = json.Unmarshal(js, &sinfo)
+		err := json.Unmarshal(js, &sinfo)
 		if err != nil {
 			t.Fatalf("Could not unmarshal INFO json: %v\n", err)
 		}

--- a/test/test.go
+++ b/test/test.go
@@ -313,7 +313,7 @@ func setupConnWithAccount(t tLogger, s *server.Server, c net.Conn, account strin
 
 func setupConnWithUserPass(t tLogger, c net.Conn, username, password string) (sendFun, expectFun) {
 	checkInfoMsg(t, c)
-	cs := fmt.Sprintf("CONNECT {\"verbose\":%v,\"pedantic\":%v,\"tls_required\":%v,\"protocol\":1,\"user\":%q,\"pass\":%q}\r\n",
+	cs := fmt.Sprintf("CONNECT {\"verbose\":%v,\"pedantic\":%v,\"tls_required\":%v,\"user\":%q,\"pass\":%q}\r\n",
 		false, false, false, username, password)
 	sendProto(t, c, cs)
 	return sendCommand(t, c), expectLefMostCommand(t, c)


### PR DESCRIPTION
In response to a leafnode or client CONNECT protocol, the server responds
with an INFO that contains the name of the account it is bound to and if
this account is the system account.
    
For client connections, since most of our supported clients send the
CONNECT and a PING and expect a PONG *first*, the server will send
the "Connect Info" protocol only after receiving the first PING and
sending back the first PONG.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>