### PR TITLE
[IMPROVED] NRG: Clarify log when resetting WAL

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3259,7 +3259,11 @@ func (n *raft) truncateWAL(term, index uint64) {
 	n.debug("Truncating and repairing WAL to Term %d Index %d", term, index)
 
 	if term == 0 && index == 0 {
-		n.warn("Resetting WAL state")
+		if n.commit > 0 {
+			n.warn("Resetting WAL state")
+		} else {
+			n.debug("Clearing WAL state (no commits)")
+		}
 	}
 
 	defer func() {


### PR DESCRIPTION
Usually `Resetting WAL state` is a prime indicator something went horribly wrong with replication, and resetting is our last effort at fixing things. Antithesis reports on this being logged so we can look into it and fix the condition.

However, this also triggers if the WAL is empty, a leader gets elected and stores a message that doesn't get quorum. Once a new leader is elected and this entry without quorum gets removed, we'd also log `Resetting WAL state` even though this is a normal condition. If we have made no commits, it's safe to reset/clear the WAL. This PR changes the log line to clarify this.

Relates to https://github.com/nats-io/nats-server/pull/6705

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
