### PR TITLE
Include leaf node connections in `connz`

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"expvar"
 	"fmt"
+	"maps"
 	"math"
 	"net"
 	"net/http"
@@ -282,7 +283,9 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 	s.mu.RLock()
 	// Default to all client unless filled in above.
 	if clist == nil {
-		clist = s.clients
+		clist = make(map[uint64]*client, len(s.clients)+len(s.leafs))
+		maps.Copy(clist, s.clients)
+		maps.Copy(clist, s.leafs)
 	}
 
 	// copy the server id for monitoring


### PR DESCRIPTION
This worked if you used `nats server report connections` inside an account because we would automatically fill in `Account` in that case, and this worked if you specified `Account` because the account map included both clients and leafs, but the global `s.clients` map didn't so `/connz` or a system account request would omit `s.leafs`.

Fixes #6930.

Signed-off-by: Neil Twigg <neil@nats.io>