### PR TITLE
(2.12) Improved partitioning in subject transforms

### DIFF
--- a/server/subject_transform.go
+++ b/server/subject_transform.go
@@ -16,6 +16,7 @@ package server
 import (
 	"fmt"
 	"hash/fnv"
+	"math"
 	"math/rand"
 	"regexp"
 	"strconv"
@@ -263,14 +264,14 @@ func indexPlaceHolders(token string) (int16, []int, int32, string, error) {
 				}
 				if len(args) == 1 {
 					mappingFunctionIntArg, err := strconv.Atoi(strings.Trim(args[0], " "))
-					if err != nil {
+					if err != nil || mappingFunctionIntArg > math.MaxInt32 {
 						return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrMappingDestinationInvalidArg}
 					}
 					return Partition, []int{}, int32(mappingFunctionIntArg), _EMPTY_, nil
 				}
 				if len(args) >= 2 {
 					mappingFunctionIntArg, err := strconv.Atoi(strings.Trim(args[0], " "))
-					if err != nil {
+					if err != nil || mappingFunctionIntArg > math.MaxInt32 {
 						return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrMappingDestinationInvalidArg}
 					}
 					var numPositions = len(args[1:])
@@ -350,7 +351,7 @@ func indexPlaceHolders(token string) (int16, []int, int32, string, error) {
 					return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrMappingDestinationNotEnoughArgs}
 				}
 				mappingFunctionIntArg, err := strconv.Atoi(strings.Trim(args[0], " "))
-				if err != nil {
+				if err != nil || mappingFunctionIntArg > math.MaxInt32 {
 					return BadTransform, []int{}, -1, _EMPTY_, &mappingDestinationErr{token, ErrMappingDestinationInvalidArg}
 				}
 				return Random, []int{}, int32(mappingFunctionIntArg), _EMPTY_, nil

--- a/server/subject_transform.go
+++ b/server/subject_transform.go
@@ -127,16 +127,15 @@ func NewSubjectTransformWithStrict(src, dest string, strict bool) (*subjectTrans
 				}
 			}
 
-			if npwcs == 0 {
-				if tranformType != NoTransform {
-					return nil, &mappingDestinationErr{token, ErrMappingDestinationIndexOutOfRange}
-				}
-			}
-
 			if tranformType == NoTransform {
 				dtokMappingFunctionTypes = append(dtokMappingFunctionTypes, NoTransform)
 				dtokMappingFunctionTokenIndexes = append(dtokMappingFunctionTokenIndexes, []int{-1})
 				dtokMappingFunctionIntArgs = append(dtokMappingFunctionIntArgs, -1)
+				dtokMappingFunctionStringArgs = append(dtokMappingFunctionStringArgs, _EMPTY_)
+			} else if tranformType == Random {
+				dtokMappingFunctionTypes = append(dtokMappingFunctionTypes, Random)
+				dtokMappingFunctionTokenIndexes = append(dtokMappingFunctionTokenIndexes, []int{})
+				dtokMappingFunctionIntArgs = append(dtokMappingFunctionIntArgs, transfomArgInt)
 				dtokMappingFunctionStringArgs = append(dtokMappingFunctionStringArgs, _EMPTY_)
 			} else {
 				nphs += len(transformArgWildcardIndexes)
@@ -162,12 +161,22 @@ func NewSubjectTransformWithStrict(src, dest string, strict bool) (*subjectTrans
 	} else {
 		// no wildcards used in the source: check that no transform functions are used in the destination
 		for _, token := range dtokens {
-			tranformType, _, _, _, err := indexPlaceHolders(token)
+			tranformType, _, transfomArgInt, _, err := indexPlaceHolders(token)
 			if err != nil {
 				return nil, err
 			}
 
-			if tranformType != NoTransform {
+			if tranformType == NoTransform {
+				dtokMappingFunctionTypes = append(dtokMappingFunctionTypes, NoTransform)
+				dtokMappingFunctionTokenIndexes = append(dtokMappingFunctionTokenIndexes, []int{-1})
+				dtokMappingFunctionIntArgs = append(dtokMappingFunctionIntArgs, -1)
+				dtokMappingFunctionStringArgs = append(dtokMappingFunctionStringArgs, _EMPTY_)
+			} else if tranformType == Random || tranformType == Partition {
+				dtokMappingFunctionTypes = append(dtokMappingFunctionTypes, tranformType)
+				dtokMappingFunctionTokenIndexes = append(dtokMappingFunctionTokenIndexes, []int{})
+				dtokMappingFunctionIntArgs = append(dtokMappingFunctionIntArgs, transfomArgInt)
+				dtokMappingFunctionStringArgs = append(dtokMappingFunctionStringArgs, _EMPTY_)
+			} else {
 				return nil, &mappingDestinationErr{token, ErrMappingDestinationIndexOutOfRange}
 			}
 		}

--- a/server/subject_transform_test.go
+++ b/server/subject_transform_test.go
@@ -196,6 +196,7 @@ func TestSubjectTransforms(t *testing.T) {
 
 	shouldBeOK("foo.*", fmt.Sprintf("foo.{{partition(%d)}}", math.MaxInt32), false) // Exactly int32
 	shouldBeOK("foo.*", fmt.Sprintf("foo.{{random(%d)}}", math.MaxInt32), false)    // Exactly int32
+	shouldBeOK("foo.bar", fmt.Sprintf("foo.{{random(%d)}}", math.MaxInt32), false)  // Exactly int32
 
 	shouldMatch := func(src, dest, sample string, expected ...string) {
 		t.Helper()
@@ -242,6 +243,10 @@ func TestSubjectTransforms(t *testing.T) {
 	for range 100 {
 		shouldMatch("*", "bar.{{random(6)}}", "qux", "bar.0", "bar.1", "bar.2", "bar.3", "bar.4", "bar.5")
 	}
+	shouldBeOK("foo.bar", "baz.{{partition(10)}}", false)
+	shouldMatch("foo.bar", "baz.{{partition(10)}}", "foo.bar", "baz.6")
+	shouldMatch("foo.baz", "qux.{{partition(10)}}", "foo.baz", "qux.4")
+	shouldMatch("test.subject", "result.{{partition(5)}}", "test.subject", "result.0")
 }
 
 func TestSubjectTransformDoesntPanicTransformingMissingToken(t *testing.T) {

--- a/server/subject_transform_test.go
+++ b/server/subject_transform_test.go
@@ -156,7 +156,7 @@ func TestSubjectTransforms(t *testing.T) {
 	shouldErr("foo.*", "bar.{{Partition(2,1)}}", true)    // can only use Wildcard function (and old-style $x) in import transform
 	shouldErr("foo.*", "foo.{{wildcard(2)}}", false)      // Mapping function being passed an out of range wildcard index
 	shouldErr("foo.*", "foo.{{unimplemented(1)}}", false) // Mapping trying to use an unknown mapping function
-	shouldErr("foo.*", "foo.{{partition(10)}}", false)    // Not enough arguments passed to the mapping function
+	shouldErr("foo.*", "foo.{{partition()}}", false)      // Not enough arguments passed to the mapping function
 	shouldErr("foo.*", "foo.{{wildcard(foo)}}", false)    // Invalid argument passed to the mapping function
 	shouldErr("foo.*", "foo.{{wildcard()}}", false)       // Not enough arguments passed to the mapping function
 	shouldErr("foo.*", "foo.{{wildcard(1,2)}}", false)    // Too many arguments passed to the mapping function
@@ -177,6 +177,7 @@ func TestSubjectTransforms(t *testing.T) {
 
 	shouldBeOK("foo.*.*", "bar.$2", false)              // don't have to use all pwcs.
 	shouldBeOK("foo.*.*", "bar.{{wildcard(1)}}", false) // don't have to use all pwcs.
+	shouldBeOK("foo.*.*", "bar.{{partition(1)}}", false)
 	shouldBeOK("foo", "bar", false)
 	shouldBeOK("foo.*.bar.*.baz", "req.$2.$1", false)
 	shouldBeOK("baz.>", "mybaz.>", false)
@@ -220,6 +221,12 @@ func TestSubjectTransforms(t *testing.T) {
 	shouldMatch("*", "{{left(1,1)}}", "1234", "1")
 	shouldMatch("*", "{{left(1,3)}}", "1234", "123")
 	shouldMatch("*", "{{left(1,6)}}", "1234", "1234")
+	shouldMatch("*", "bar.{{partition(0)}}", "baz", "bar.0")
+	shouldMatch("*", "bar.{{partition(10, 0)}}", "foo", "bar.3")
+	shouldMatch("*.*", "bar.{{partition(10)}}", "foo.bar", "bar.6")
+	shouldMatch("*", "bar.{{partition(10)}}", "foo", "bar.3")
+	shouldMatch("*", "bar.{{partition(10)}}", "baz", "bar.0")
+	shouldMatch("*", "bar.{{partition(10)}}", "qux", "bar.9")
 }
 
 func TestSubjectTransformDoesntPanicTransformingMissingToken(t *testing.T) {

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -1292,7 +1292,8 @@ func ValidateMapping(src string, dest string) error {
 				!splitFromRightMappingFunctionRegEx.MatchString(t) &&
 				!sliceFromLeftMappingFunctionRegEx.MatchString(t) &&
 				!sliceFromRightMappingFunctionRegEx.MatchString(t) &&
-				!splitMappingFunctionRegEx.MatchString(t) {
+				!splitMappingFunctionRegEx.MatchString(t) &&
+				!randomMappingFunctionRegEx.MatchString(t) {
 				return &mappingDestinationErr{t, ErrUnknownMappingDestinationFunction}
 			} else {
 				continue


### PR DESCRIPTION
This adds support for two new subject transforms:

* `partition(n)`, in addition to `partition(n, ...)`, which provides a deterministic partition number based on the hash of the entire subject, up to `n`;
* `random(n)`, which provides a non-deterministic and entirely random partition number, up to `n`.

Signed-off-by: Neil Twigg <neil@nats.io>