### PR TITLE
NRG: Only allow highest known term for catchup

### DIFF
--- a/server/norace_1_test.go
+++ b/server/norace_1_test.go
@@ -4998,7 +4998,7 @@ func TestNoRaceJetStreamAccountLimitsAndRestart(t *testing.T) {
 	c.waitOnLeader()
 	c.waitOnStreamLeader("$JS", "TEST")
 
-	checkFor(t, 2*time.Second, 500*time.Millisecond, func() error {
+	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
 		return checkState(t, c, "$JS", "TEST")
 	})
 	for _, cs := range c.servers {

--- a/server/raft.go
+++ b/server/raft.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2219,7 +2218,7 @@ type appendEntry struct {
 	pindex  uint64   // The previous commit index, for checking consistency.
 	entries []*Entry // Entries to process.
 	// Below fields are for internal use only:
-	lterm uint64        // The highest term, as the leader understands it. (If lterm=0, use term instead)
+	lterm uint64        // The highest term for catchups only, as the leader understands it. (If lterm=0, use term instead)
 	reply string        // Reply subject to respond to once committed.
 	sub   *subscription // The subscription that the append entry came in on.
 	buf   []byte
@@ -2313,34 +2312,40 @@ func (ae *appendEntry) encode(b []byte) ([]byte, error) {
 
 	var elen int
 	for _, e := range ae.entries {
+		if len(e.Data) > math.MaxUint32 {
+			return nil, errBadAppendEntry
+		}
 		elen += len(e.Data) + 1 + 4 // 1 is type, 4 is for size.
 	}
-	tlen := appendEntryBaseLen + elen + 1
+	// Uvarint for lterm can be a maximum 10 bytes for a uint64.
+	var _lterm [10]byte
+	lterm := _lterm[:binary.PutUvarint(_lterm[:], ae.lterm)]
+	tlen := appendEntryBaseLen + elen + len(lterm)
 
 	var buf []byte
 	if cap(b) >= tlen {
-		buf = b[:tlen]
+		buf = b[:idLen]
 	} else {
-		buf = make([]byte, tlen)
+		buf = make([]byte, idLen, tlen)
 	}
 
 	var le = binary.LittleEndian
 	copy(buf[:idLen], ae.leader)
-	le.PutUint64(buf[8:], ae.term)
-	le.PutUint64(buf[16:], ae.commit)
-	le.PutUint64(buf[24:], ae.pterm)
-	le.PutUint64(buf[32:], ae.pindex)
-	le.PutUint16(buf[40:], uint16(len(ae.entries)))
-	wi := 42
+	buf = le.AppendUint64(buf, ae.term)
+	buf = le.AppendUint64(buf, ae.commit)
+	buf = le.AppendUint64(buf, ae.pterm)
+	buf = le.AppendUint64(buf, ae.pindex)
+	buf = le.AppendUint16(buf, uint16(len(ae.entries)))
 	for _, e := range ae.entries {
-		le.PutUint32(buf[wi:], uint32(len(e.Data)+1))
-		wi += 4
-		buf[wi] = byte(e.Type)
-		wi++
-		copy(buf[wi:], e.Data)
-		wi += len(e.Data)
+		buf = le.AppendUint32(buf, uint32(1+len(e.Data)))
+		buf = append(buf, byte(e.Type))
+		buf = append(buf, e.Data...)
 	}
-	return buf[:wi], nil
+	// This is safe because old nodes will ignore bytes after the
+	// encoded messages. Nodes that are aware of this will decode
+	// it correctly.
+	buf = append(buf, lterm...)
+	return buf, nil
 }
 
 // This can not be used post the wire level callback since we do not copy.
@@ -2355,19 +2360,24 @@ func (n *raft) decodeAppendEntry(msg []byte, sub *subscription, reply string) (*
 	ae.reply, ae.sub = reply, sub
 
 	// Decode Entries.
-	ne, ri := int(le.Uint16(msg[40:])), 42
-	for i, max := 0, len(msg); i < ne; i++ {
+	ne, ri := int(le.Uint16(msg[40:])), uint64(42)
+	for i, max := 0, uint64(len(msg)); i < ne; i++ {
 		if ri >= max-1 {
 			return nil, errBadAppendEntry
 		}
-		le := int(le.Uint32(msg[ri:]))
+		ml := uint64(le.Uint32(msg[ri:]))
 		ri += 4
-		if le <= 0 || ri+le > max {
+		if ml <= 0 || ri+ml > max {
 			return nil, errBadAppendEntry
 		}
-		entry := newEntry(EntryType(msg[ri]), msg[ri+1:ri+le])
+		entry := newEntry(EntryType(msg[ri]), msg[ri+1:ri+ml])
 		ae.entries = append(ae.entries, entry)
-		ri += le
+		ri += ml
+	}
+	if len(msg[ri:]) > 0 {
+		if lterm, n := binary.Uvarint(msg[ri:]); n > 0 {
+			ae.lterm = lterm
+		}
 	}
 	ae.buf = msg
 	return ae, nil
@@ -2721,12 +2731,18 @@ func (n *raft) runCatchup(ar *appendEntryResponse, indexUpdatesQ *ipQueue[uint64
 				}
 				return true
 			}
+			// Re-encode with the lterm if needed
+			if ae.lterm != term {
+				ae.lterm = term
+				if ae.buf, err = ae.encode(ae.buf[:0]); err != nil {
+					n.warn("Got an error re-encoding append entry: %v", err)
+					return true
+				}
+			}
 			// Update our tracking total.
 			om[next] = len(ae.buf)
 			total += len(ae.buf)
-
-			hdr := generateCatchupHeader(term)
-			n.sendRPCWithHeader(subj, reply, hdr, ae.buf)
+			n.sendRPC(subj, reply, ae.buf)
 		}
 		return false
 	}
@@ -3200,18 +3216,9 @@ func (n *raft) runAsCandidate() {
 
 // handleAppendEntry handles an append entry from the wire. This function
 // is an internal callback from the "asubj" append entry subscription.
-func (n *raft) handleAppendEntry(sub *subscription, c *client, _ *Account, _, reply string, rmsg []byte) {
-	hdr, msg := c.msgParts(rmsg)
+func (n *raft) handleAppendEntry(sub *subscription, c *client, _ *Account, _, reply string, msg []byte) {
 	msg = copyBytes(msg)
 	if ae, err := n.decodeAppendEntry(msg, sub, reply); err == nil {
-		if hdr != nil {
-			if lterm := getHeader(raftLeaderTermHeader, hdr); lterm != nil {
-				if v, err := strconv.ParseUint(string(lterm), 10, 64); err == nil {
-					ae.lterm = v
-				}
-			}
-		}
-
 		// Push to the new entry channel. From here one of the worker
 		// goroutines (runAsLeader, runAsFollower, runAsCandidate) will
 		// pick it up.
@@ -3947,12 +3954,6 @@ func (n *raft) sendHeartbeat() {
 	n.sendAppendEntry(nil)
 }
 
-const raftLeaderTermHeader = "lterm"
-
-func generateCatchupHeader(term uint64) []byte {
-	return fmt.Appendf(nil, "NATS/1.0\r\n%s:%d\r\n\r\n", raftLeaderTermHeader, term)
-}
-
 type voteRequest struct {
 	term      uint64
 	lastTerm  uint64
@@ -4274,12 +4275,6 @@ func (n *raft) requestVote() {
 func (n *raft) sendRPC(subject, reply string, msg []byte) {
 	if n.sq != nil {
 		n.sq.send(subject, reply, nil, msg)
-	}
-}
-
-func (n *raft) sendRPCWithHeader(subject, reply string, hdr, msg []byte) {
-	if n.sq != nil {
-		n.sq.send(subject, reply, hdr, msg)
 	}
 }
 


### PR DESCRIPTION
Desync was observed in the Raft layer in the following scenario:
1. Server 1 is leader at `term=1` and proposes an entry but no server receives this entry.
2. Server 2, after some time, gets a heartbeat from Server 1 and starts catching up.
3. Server 2 receives the entry from Server 1 in its subscription buffer, but does not yet process this entry from `term=1`.
4. Server 3 tries to become leader for `term=2`, and Server 2 ups its term to `term=2` and votes for Server 3.
5. Server 2 now processes the catchup entry from the leader at `term=1` and (wrongfully) accepts it.

In this case, the catchup entry at step 5 from a leader at `term=1` should be rejected, because it knows the highest term is `term=2` at that point. We must only accept changes to the log if the leader tells us to. Because we upped to `term=2` and voted for a new leader, we knew `term=1` was not the leader anymore. Generally, during catchup we currently accept ANY entries from ANY term from ANY previous leader instead of rejecting.

During real-time proposals of entries we can rely on `ae.term`, because it will equal the current leader's `n.term`. However, during catchup `ae.term` will be the term of that entry at that point in time, whereas the leader that supplies a follower with that entry could already be at a higher term. During catchup, the leader's (highest) term is now also included in the append entry.

- An older 2.11 server already knows to ignore the new `ae.lterm` that the new version will include for append entries during catchup.
- A new version server, after an upgrade, will be caught up by an older version server. So it must handle the case where the `ae.lterm` is not provided. In this case it falls back to the current behavior of just accepting the catchup append entry.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>