### PR TITLE
[FIXED] Replicated consumer's messages are returned after NoWait's request timeout

### DIFF
--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -9674,14 +9674,13 @@ func TestJetStreamConsumerPullNoWaitBatchLargerThanPending(t *testing.T) {
 	sub := sendRequest(t, nc, "rply", req)
 	defer sub.Unsubscribe()
 
-	// we should get all 5 messages
-	// this fails on nats-server >= v2.11.2
+	// Should get all 5 messages.
+	// TODO(mvv): Currently bypassing replicating first, need to figure out
+	//  how to send NoWait's request timeout after replication.
 	for range 5 {
 		msg, err := sub.NextMsg(time.Second)
 		require_NoError(t, err)
 		if len(msg.Data) == 0 && msg.Header != nil {
-			fmt.Printf("Header: %+v\n", msg.Header)
-			time.Sleep(100 * time.Millisecond)
 			t.Fatalf("Expected data, got: %s", msg.Header.Get("Description"))
 		}
 	}


### PR DESCRIPTION
Since consumer messages are now replicated fully prior to delivery, this broke `NoWait` pull requests. `NoWait`'s request timeout would be sent earlier than the replication could complete. For a 2.11 patch version we now bypass replicating first, and send the messages to the client immediately without waiting for replication (just like we do for flow-controlled consumers, AckNone, etc.).

We might need to look into replicating first and sending `NoWait`'s request timeout after the replicated messages are sent for 2.12 or later.

Introduced by https://github.com/nats-io/nats-server/pull/6792

Resolves https://github.com/nats-io/nats-server/issues/6952

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
Co-authored-by: Piotr Piotrowski <piotr@synadia.com>
