### PR TITLE
[FIXED] Remove expected headers when mirroring

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -2960,6 +2960,10 @@ func (mset *stream) setupMirrorConsumer() error {
 				msgs := mirror.msgs
 				sub, err := mset.subscribeInternal(deliverSubject, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
 					hdr, msg := c.msgParts(copyBytes(rmsg)) // Need to copy.
+					if len(hdr) > 0 {
+						// Remove any Nats-Expected- headers as we don't want to validate them.
+						hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Expected-")
+					}
 					mset.queueInbound(msgs, subject, reply, hdr, msg, nil, nil)
 					mirror.last.Store(time.Now().UnixNano())
 				})


### PR DESCRIPTION
When publishing a message into a stream with an `Nats-Expected-Stream` (or other) header, it prevents this message from being stored by a mirror. Previously this was also prevented when sourcing, but that was fixed since 2.10.14 in https://github.com/nats-io/nats-server/pull/5256.

Resolves https://github.com/nats-io/nats-server/issues/5865

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>