### PR TITLE
(2.12) Initial atomic batch publish

### DIFF
--- a/locksordering.txt
+++ b/locksordering.txt
@@ -34,3 +34,9 @@ inconsistent observer states.
 The "clsMu" lock protects the consumer list on a stream, used for signalling consumer activity.
 
     stream -> clsMu
+
+The "clMu" and "ddMu" locks protect clustered and dedupe state respectively. The stream lock (`mset.mu`) is optional,
+but if holding "clMu" or "ddMu", locking the stream lock afterward would violate locking order.
+
+    stream -> clMu
+    stream -> ddMu

--- a/server/errors.json
+++ b/server/errors.json
@@ -1753,7 +1753,7 @@
     "constant": "JSAtomicPublishDuplicateErr",
     "code": 400,
     "error_code": 10177,
-    "description": "atomic publish batch contains duplicates",
+    "description": "atomic publish duplicates not allowed",
     "comment": "",
     "help": "",
     "url": "",

--- a/server/errors.json
+++ b/server/errors.json
@@ -1718,5 +1718,45 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSAtomicPublishDisabledErr",
+    "code": 400,
+    "error_code": 10174,
+    "description": "atomic publish is disabled",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSAtomicPublishMissingSeqErr",
+    "code": 400,
+    "error_code": 10175,
+    "description": "atomic publish sequence is missing",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSAtomicPublishIncompleteBatchErr",
+    "code": 400,
+    "error_code": 10176,
+    "description": "atomic publish batch is incomplete",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSAtomicPublishDuplicateErr",
+    "code": 400,
+    "error_code": 10177,
+    "description": "atomic publish batch contains duplicates",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7773,13 +7773,17 @@ func (fs *fileStore) Utilization() (total, reported uint64, err error) {
 	return total, reported, nil
 }
 
-func fileStoreMsgSize(subj string, hdr, msg []byte) uint64 {
-	if len(hdr) == 0 {
+func fileStoreMsgSizeRaw(slen, hlen, mlen int) uint64 {
+	if hlen == 0 {
 		// length of the message record (4bytes) + seq(8) + ts(8) + subj_len(2) + subj + msg + hash(8)
-		return uint64(22 + len(subj) + len(msg) + 8)
+		return uint64(22 + slen + mlen + 8)
 	}
 	// length of the message record (4bytes) + seq(8) + ts(8) + subj_len(2) + subj + hdr_len(4) + hdr + msg + hash(8)
-	return uint64(22 + len(subj) + 4 + len(hdr) + len(msg) + 8)
+	return uint64(22 + slen + 4 + hlen + mlen + 8)
+}
+
+func fileStoreMsgSize(subj string, hdr, msg []byte) uint64 {
+	return fileStoreMsgSizeRaw(len(subj), len(hdr), len(msg))
 }
 
 func fileStoreMsgSizeEstimate(slen, maxPayload int) uint64 {

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -1,0 +1,312 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/big"
+	"strings"
+	"sync"
+	"time"
+)
+
+type batching struct {
+	mu    sync.Mutex
+	group map[string]*batchGroup
+}
+
+type batchGroup struct {
+	lseq  uint64
+	store StreamStore
+}
+
+// checkMsgHeadersPreClusteredProposal checks the message for expected/consistency headers.
+// mset.mu lock must NOT be held or used.
+// mset.clMu lock must be held.
+func checkMsgHeadersPreClusteredProposal(
+	mset *stream, subject string, hdr []byte, msg []byte, sourced bool, name string,
+	jsa *jsAccount, allowTTL bool, allowMsgCounter bool, stype StorageType, store StreamStore,
+	interestPolicy bool, discard DiscardPolicy, maxMsgs int64, maxBytes int64,
+) ([]byte, []byte, uint64, *ApiError, error) {
+	var incr *big.Int
+
+	// Some header checks must be checked pre proposal.
+	if len(hdr) > 0 {
+		// Since we encode header len as u16 make sure we do not exceed.
+		// Again this works if it goes through but better to be pre-emptive.
+		if len(hdr) > math.MaxUint16 {
+			err := fmt.Errorf("JetStream header size exceeds limits for '%s > %s'", jsa.acc().Name, mset.cfg.Name)
+			return hdr, msg, 0, NewJSStreamHeaderExceedsMaximumError(), err
+		}
+		// Counter increments.
+		// Only supported on counter streams, and payload must be empty (if not coming from a source).
+		var ok bool
+		if incr, ok = getMessageIncr(hdr); !ok {
+			apiErr := NewJSMessageIncrInvalidError()
+			return hdr, msg, 0, apiErr, apiErr
+		} else if incr != nil && !sourced {
+			// Only do checks if the message isn't sourced. Otherwise, we need to store verbatim.
+			if !allowMsgCounter {
+				apiErr := NewJSMessageIncrDisabledError()
+				return hdr, msg, 0, apiErr, apiErr
+			} else if len(msg) > 0 {
+				apiErr := NewJSMessageIncrPayloadError()
+				return hdr, msg, 0, apiErr, apiErr
+			} else {
+				// Check for incompatible headers.
+				var doErr bool
+				if getRollup(hdr) != _EMPTY_ ||
+					getExpectedStream(hdr) != _EMPTY_ ||
+					getExpectedLastMsgId(hdr) != _EMPTY_ ||
+					getExpectedLastSeqPerSubjectForSubject(hdr) != _EMPTY_ {
+					doErr = true
+				} else if _, ok := getExpectedLastSeq(hdr); ok {
+					doErr = true
+				} else if _, ok := getExpectedLastSeqPerSubject(hdr); ok {
+					doErr = true
+				}
+
+				if doErr {
+					apiErr := NewJSMessageIncrInvalidError()
+					return hdr, msg, 0, apiErr, apiErr
+				}
+			}
+		}
+		// Expected stream name can also be pre-checked.
+		if sname := getExpectedStream(hdr); sname != _EMPTY_ && sname != name {
+			return hdr, msg, 0, NewJSStreamNotMatchError(), errStreamMismatch
+		}
+		// TTL'd messages are rejected entirely if TTLs are not enabled on the stream, or if the TTL is invalid.
+		if ttl, err := getMessageTTL(hdr); !sourced && (ttl != 0 || err != nil) {
+			if !allowTTL {
+				return hdr, msg, 0, NewJSMessageTTLDisabledError(), errMsgTTLDisabled
+			} else if err != nil {
+				return hdr, msg, 0, NewJSMessageTTLInvalidError(), err
+			}
+		}
+		// Check for MsgIds here at the cluster level to avoid excessive CLFS accounting.
+		// Will help during restarts.
+		if msgId := getMsgId(hdr); msgId != _EMPTY_ {
+			mset.ddMu.Lock()
+			if dde := mset.checkMsgId(msgId); dde != nil {
+				seq := dde.seq
+				mset.ddMu.Unlock()
+				// Should not return an invalid sequence, in that case error.
+				if seq > 0 {
+					return hdr, msg, seq, nil, errMsgIdDuplicate
+				} else {
+					return hdr, msg, 0, NewJSStreamDuplicateMessageConflictError(), errMsgIdDuplicate
+				}
+			}
+			// We stage with zero, and will update in processJetStreamMsg once we know the sequence.
+			mset.storeMsgIdLocked(&ddentry{msgId, 0, time.Now().UnixNano()})
+			mset.ddMu.Unlock()
+		}
+	}
+
+	// Apply increment for counter.
+	// But only if it's allowed for this stream. This can happen when we store verbatim for a sourced stream.
+	if incr == nil && allowMsgCounter {
+		apiErr := NewJSMessageIncrMissingError()
+		return hdr, msg, 0, apiErr, apiErr
+	}
+	if incr != nil && allowMsgCounter && store != nil {
+		var initial big.Int
+		var sources CounterSources
+		// Store running totals for counters, we could have multiple counter increments proposed, but not applied yet.
+		if mset.clusteredCounterTotal == nil {
+			mset.clusteredCounterTotal = make(map[string]*msgCounterRunningTotal, 1)
+		}
+
+		// If we've got a running total, update that, since we have inflight proposals updating the same counter.
+		var ok bool
+		var counter *msgCounterRunningTotal
+		if counter, ok = mset.clusteredCounterTotal[subject]; ok {
+			initial = *counter.total
+			sources = counter.sources
+		} else {
+			// Load last message, and store as inflight running total.
+			var smv StoreMsg
+			sm, err := store.LoadLastMsg(subject, &smv)
+			if err == nil && sm != nil {
+				var val CounterValue
+				// Return an error if the counter is broken somehow.
+				if json.Unmarshal(sm.msg, &val) != nil {
+					apiErr := NewJSMessageCounterBrokenError()
+					return hdr, msg, 0, apiErr, apiErr
+				}
+				if ncs := sliceHeader(JSMessageCounterSources, sm.hdr); len(ncs) > 0 {
+					if err := json.Unmarshal(ncs, &sources); err != nil {
+						apiErr := NewJSMessageCounterBrokenError()
+						return hdr, msg, 0, apiErr, apiErr
+					}
+				}
+				initial.SetString(val.Value, 10)
+			}
+		}
+		srchdr := sliceHeader(JSStreamSource, hdr)
+		if len(srchdr) > 0 {
+			// This is a sourced message, so we can't apply Nats-Incr but
+			// instead should just update the source count header.
+			fields := strings.Split(string(srchdr), " ")
+			origStream := fields[0]
+			origSubj := subject
+			if len(fields) >= 3 {
+				origSubj = fields[2]
+			}
+			var val CounterValue
+			if json.Unmarshal(msg, &val) != nil {
+				apiErr := NewJSMessageCounterBrokenError()
+				return hdr, msg, 0, apiErr, apiErr
+			}
+			var sourced big.Int
+			sourced.SetString(val.Value, 10)
+			if sources == nil {
+				sources = map[string]map[string]string{}
+			}
+			if _, ok := sources[origStream]; !ok {
+				sources[origStream] = map[string]string{}
+			}
+			prevVal := sources[origStream][origSubj]
+			sources[origStream][origSubj] = sourced.String()
+			// We will also replace the Nats-Incr header with the diff
+			// between our last value from this source and this one, so
+			// that the arithmetic is always correct.
+			var previous big.Int
+			previous.SetString(prevVal, 10)
+			incr.Sub(&sourced, &previous)
+			hdr = setHeader(JSMessageIncr, incr.String(), hdr)
+		}
+		// Now make the change.
+		initial.Add(&initial, incr)
+		// Generate the new payload.
+		var _msg [128]byte
+		msg = fmt.Appendf(_msg[:0], "{%q:%q}", "val", initial.String())
+		// Write the updated source count headers.
+		if len(sources) > 0 {
+			nhdr, err := json.Marshal(sources)
+			if err != nil {
+				return hdr, msg, 0, NewJSMessageCounterBrokenError(), err
+			}
+			hdr = setHeader(JSMessageCounterSources, string(nhdr), hdr)
+		}
+
+		// Keep the in-memory counters up-to-date.
+		if counter == nil {
+			counter = &msgCounterRunningTotal{}
+		}
+		counter.total = &initial
+		counter.sources = sources
+		counter.ops++
+		mset.clusteredCounterTotal[subject] = counter
+
+		// Check to see if we are over the max msg size.
+		if int32(len(hdr)+len(msg)) > mset.srv.getOpts().MaxPayload {
+			// Undo staged counter changes.
+			counter.ops--
+			if counter.ops == 0 {
+				delete(mset.clusteredCounterTotal, subject)
+			} else {
+				counter.total.Sub(counter.total, incr)
+			}
+			return hdr, msg, 0, NewJSStreamMessageExceedsMaximumError(), ErrMaxPayload
+		}
+	}
+
+	// Check if we have an interest policy and discard new with max msgs or bytes.
+	// We need to deny here otherwise it could succeed on some peers and not others
+	// depending on consumer ack state. So we deny here, if we allow that means we know
+	// it would succeed on every peer.
+	if interestPolicy && discard == DiscardNew && (maxMsgs > 0 || maxBytes > 0) {
+		// Track inflight.
+		if mset.inflight == nil {
+			mset.inflight = make(map[uint64]uint64)
+		}
+		if stype == FileStorage {
+			mset.inflight[mset.clseq] = fileStoreMsgSizeRaw(len(subject), len(hdr), len(msg))
+		} else {
+			mset.inflight[mset.clseq] = memStoreMsgSizeRaw(len(subject), len(hdr), len(msg))
+		}
+
+		var state StreamState
+		mset.store.FastState(&state)
+
+		var err error
+		if maxMsgs > 0 && state.Msgs+uint64(len(mset.inflight)) > uint64(maxMsgs) {
+			err = ErrMaxMsgs
+		} else if maxBytes > 0 {
+			// TODO(dlc) - Could track this rollup independently.
+			var bytesPending uint64
+			for _, nb := range mset.inflight {
+				bytesPending += nb
+			}
+			if state.Bytes+bytesPending > uint64(maxBytes) {
+				err = ErrMaxBytes
+			}
+		}
+		if err != nil {
+			delete(mset.inflight, mset.clseq)
+			return hdr, msg, 0, NewJSStreamStoreFailedError(err, Unless(err)), err
+		}
+	}
+
+	if len(hdr) > 0 {
+		// Expected last sequence per subject.
+		if seq, exists := getExpectedLastSeqPerSubject(hdr); exists && store != nil {
+			// Allow override of the subject used for the check.
+			seqSubj := subject
+			if optSubj := getExpectedLastSeqPerSubjectForSubject(hdr); optSubj != _EMPTY_ {
+				seqSubj = optSubj
+			}
+
+			// If subject is already in process, block as otherwise we could have multiple messages inflight with same subject.
+			if _, found := mset.expectedPerSubjectInProcess[seqSubj]; found {
+				// Could have set inflight above, cleanup here.
+				delete(mset.inflight, mset.clseq)
+				err := fmt.Errorf("last sequence by subject mismatch")
+				return hdr, msg, 0, NewJSStreamWrongLastSequenceConstantError(), err
+			}
+
+			var smv StoreMsg
+			var fseq uint64
+			sm, err := store.LoadLastMsg(seqSubj, &smv)
+			if sm != nil {
+				fseq = sm.seq
+			}
+			if err == ErrStoreMsgNotFound && seq == 0 {
+				fseq, err = 0, nil
+			}
+			if err != nil || fseq != seq {
+				// Could have set inflight above, cleanup here.
+				delete(mset.inflight, mset.clseq)
+				err = fmt.Errorf("last sequence by subject mismatch: %d vs %d", seq, fseq)
+				return hdr, msg, 0, NewJSStreamWrongLastSequenceError(fseq), err
+			}
+
+			// Track sequence and subject.
+			if mset.expectedPerSubjectSequence == nil {
+				mset.expectedPerSubjectSequence = make(map[uint64]string)
+			}
+			if mset.expectedPerSubjectInProcess == nil {
+				mset.expectedPerSubjectInProcess = make(map[string]struct{})
+			}
+			mset.expectedPerSubjectSequence[mset.clseq] = seqSubj
+			mset.expectedPerSubjectInProcess[seqSubj] = struct{}{}
+		}
+	}
+
+	return hdr, msg, 0, nil, nil
+}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/big"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -3250,7 +3249,7 @@ func (js *jetStream) processStreamLeaderChange(mset *stream, isLeader bool) {
 	}
 
 	// Clear inflight dedupe IDs, where seq=0.
-	mset.mu.Lock()
+	mset.ddMu.Lock()
 	var removed int
 	for i := len(mset.ddarr) - 1; i >= mset.ddindex; i-- {
 		dde := mset.ddarr[i]
@@ -3269,7 +3268,7 @@ func (js *jetStream) processStreamLeaderChange(mset *stream, isLeader bool) {
 			mset.ddindex = 0
 		}
 	}
-	mset.mu.Unlock()
+	mset.ddMu.Unlock()
 
 	mset.clMu.Lock()
 	// Clear inflight if we have it.
@@ -7974,10 +7973,10 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	mset.mu.RLock()
 	canRespond := !mset.cfg.NoAck && len(reply) > 0
 	name, stype, store := mset.cfg.Name, mset.cfg.Storage, mset.store
+	interestPolicy, discard, maxMsgs, maxBytes := mset.cfg.Retention != LimitsPolicy, mset.cfg.Discard, mset.cfg.MaxMsgs, mset.cfg.MaxBytes
 	s, js, jsa, st, r, tierName, outq, node := mset.srv, mset.js, mset.jsa, mset.cfg.Storage, mset.cfg.Replicas, mset.tier, mset.outq, mset.node
 	maxMsgSize, lseq := int(mset.cfg.MaxMsgSize), mset.lseq
-	interestPolicy, discard, maxMsgs, maxBytes := mset.cfg.Retention != LimitsPolicy, mset.cfg.Discard, mset.cfg.MaxMsgs, mset.cfg.MaxBytes
-	isLeader, isSealed, allowTTL, allowMsgCounter := mset.isLeader(), mset.cfg.Sealed, mset.cfg.AllowMsgTTL, mset.cfg.AllowMsgCounter
+	isLeader, isSealed, allowTTL, allowMsgCounter, allowAtomicPublish := mset.isLeader(), mset.cfg.Sealed, mset.cfg.AllowMsgTTL, mset.cfg.AllowMsgCounter, mset.cfg.AllowAtomicPublish
 	mset.mu.RUnlock()
 
 	// This should not happen but possible now that we allow scale up, and scale down where this could trigger.
@@ -8055,152 +8054,188 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 		return err
 	}
 
-	// Some header checks can be checked pre proposal. Most can not.
-	var msgId string
-	var incr *big.Int
-	if len(hdr) > 0 {
-		// Since we encode header len as u16 make sure we do not exceed.
-		// Again this works if it goes through but better to be pre-emptive.
-		if len(hdr) > math.MaxUint16 {
-			err := fmt.Errorf("JetStream header size exceeds limits for '%s > %s'", jsa.acc().Name, mset.cfg.Name)
-			s.RateLimitWarnf("%s", err.Error())
+	if batchId := getBatchId(hdr); batchId != _EMPTY_ {
+		if !allowAtomicPublish {
+			err := NewJSAtomicPublishDisabledError()
 			if canRespond {
-				var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-				resp.Error = NewJSStreamHeaderExceedsMaximumError()
-				response, _ = json.Marshal(resp)
-				outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+				b, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
+				outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, b, nil, 0))
 			}
 			return err
 		}
-		// Counter increments.
-		// Only supported on counter streams, and payload must be empty (if not coming from a source).
-		var ok bool
-		if incr, ok = getMessageIncr(hdr); !ok {
-			apiErr := NewJSMessageIncrInvalidError()
-			if canRespond {
-				var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-				resp.Error = apiErr
-				response, _ = json.Marshal(resp)
-				outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
-			}
-			return apiErr
-		} else if incr != nil && !sourced {
-			// Only do checks if the message isn't sourced. Otherwise, we need to store verbatim.
-			if !allowMsgCounter {
-				apiErr := NewJSMessageIncrDisabledError()
-				if canRespond {
-					var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-					resp.Error = apiErr
-					response, _ = json.Marshal(resp)
-					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
-				}
-				return apiErr
-			} else if len(msg) > 0 {
-				apiErr := NewJSMessageIncrPayloadError()
-				if canRespond {
-					var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-					resp.Error = apiErr
-					response, _ = json.Marshal(resp)
-					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
-				}
-				return apiErr
-			} else {
-				// Check for incompatible headers.
-				var doErr bool
-				if getRollup(hdr) != _EMPTY_ ||
-					getExpectedStream(hdr) != _EMPTY_ ||
-					getExpectedLastMsgId(hdr) != _EMPTY_ ||
-					getExpectedLastSeqPerSubjectForSubject(hdr) != _EMPTY_ {
-					doErr = true
-				} else if _, ok := getExpectedLastSeq(hdr); ok {
-					doErr = true
-				} else if _, ok := getExpectedLastSeqPerSubject(hdr); ok {
-					doErr = true
-				}
 
-				if doErr {
-					apiErr := NewJSMessageIncrInvalidError()
-					if canRespond {
-						var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-						resp.Error = apiErr
-						response, _ = json.Marshal(resp)
-						outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
-					}
-					return apiErr
-				}
-			}
-		}
-		// Expected stream name can also be pre-checked.
-		if sname := getExpectedStream(hdr); sname != _EMPTY_ && sname != name {
+		batchSeq, exists := getBatchSequence(hdr)
+		if !exists {
+			err := NewJSAtomicPublishMissingSeqError()
 			if canRespond {
-				var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-				resp.PubAck = &PubAck{Stream: name}
-				resp.Error = NewJSStreamNotMatchError()
-				b, _ := json.Marshal(resp)
-				outq.sendMsg(reply, b)
+				b, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
+				outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, b, nil, 0))
 			}
-			return errStreamMismatch
+			return err
 		}
-		// TTL'd messages are rejected entirely if TTLs are not enabled on the stream, or if the TTL is invalid.
-		if ttl, err := getMessageTTL(hdr); !sourced && (ttl != 0 || err != nil) {
-			if !allowTTL {
+		commit := len(sliceHeader(JSBatchCommit, hdr)) != 0
+
+		mset.mu.Lock()
+		if mset.batches == nil {
+			mset.batches = &batching{
+				group: make(map[string]*batchGroup, 1),
+			}
+		}
+		batches := mset.batches
+		mset.mu.Unlock()
+
+		// Get batch.
+		batches.mu.Lock()
+		b, ok := batches.group[batchId]
+		if !ok {
+			if batchSeq != 1 {
+				batches.mu.Unlock()
+				err := NewJSAtomicPublishIncompleteBatchError()
 				if canRespond {
-					var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-					resp.Error = NewJSMessageTTLDisabledError()
-					b, _ := json.Marshal(resp)
-					outq.sendMsg(reply, b)
-				}
-				return errMsgTTLDisabled
-			} else if err != nil {
-				if canRespond {
-					var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-					resp.Error = NewJSMessageTTLInvalidError()
-					b, _ := json.Marshal(resp)
-					outq.sendMsg(reply, b)
+					buf, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
+					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, buf, nil, 0))
 				}
 				return err
 			}
-		}
-		// Check for MsgIds here at the cluster level to avoid excessive CLFS accounting.
-		// Will help during restarts.
-		if msgId = getMsgId(hdr); msgId != _EMPTY_ {
-			mset.mu.Lock()
-			if dde := mset.checkMsgId(msgId); dde != nil {
-				var buf [256]byte
-				pubAck := append(buf[:0], mset.pubAck...)
-				seq := dde.seq
-				mset.mu.Unlock()
-				// Should not return an invalid sequence, in that case error.
-				if canRespond {
-					if seq > 0 {
-						response := append(pubAck, strconv.FormatUint(seq, 10)...)
-						response = append(response, ",\"duplicate\": true}"...)
-						outq.sendMsg(reply, response)
-					} else {
-						var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-						resp.Error = ApiErrors[JSStreamDuplicateMessageConflict]
-						b, _ := json.Marshal(resp)
-						outq.sendMsg(reply, b)
-					}
-				}
-				return errMsgIdDuplicate
-			}
-			// FIXME(dlc) - locking conflict with accessing mset.clseq
-			// For now we stage with zero, and will update in processStreamMsg.
-			mset.storeMsgIdLocked(&ddentry{msgId, 0, time.Now().UnixNano()})
-			mset.mu.Unlock()
-		}
-	}
 
-	if incr == nil && allowMsgCounter {
-		apiErr := NewJSMessageIncrMissingError()
-		if canRespond {
-			var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-			resp.Error = apiErr
-			response, _ = json.Marshal(resp)
-			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+			ms, err := newMemStore(&StreamConfig{Name: _EMPTY_, Storage: MemoryStorage})
+			if err != nil {
+				batches.mu.Unlock()
+				err := NewJSAtomicPublishIncompleteBatchError()
+				if canRespond {
+					buf, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
+					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, buf, nil, 0))
+				}
+				return err
+			}
+
+			b = &batchGroup{store: ms}
+			batches.group[batchId] = b
 		}
-		return apiErr
+
+		cleanup := func() {
+			b.store.Delete()
+			delete(batches.group, batchId)
+		}
+
+		// Detect gaps.
+		b.lseq++
+		if b.lseq != batchSeq {
+			cleanup()
+			batches.mu.Unlock()
+			err := NewJSAtomicPublishIncompleteBatchError()
+			if canRespond {
+				buf, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
+				outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, buf, nil, 0))
+			}
+			return err
+		}
+
+		// Persist, but optimize if we're committing because we already know last.
+		if !commit {
+			seq, _, err := b.store.StoreMsg(subject, hdr, msg, 0)
+			if err != nil || seq != batchSeq {
+				cleanup()
+				batches.mu.Unlock()
+				err := NewJSAtomicPublishIncompleteBatchError()
+				if canRespond {
+					buf, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
+					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, buf, nil, 0))
+				}
+				return err
+			}
+			batches.mu.Unlock()
+			return nil
+		}
+
+		// Proceed with proposing the batch.
+
+		// We only use mset.clseq for clustering and in case we run ahead of actual commits.
+		// Check if we need to set initial value here
+		mset.clMu.Lock()
+		if mset.clseq == 0 || mset.clseq < lseq+mset.clfs {
+			// Re-capture
+			lseq = mset.lastSeq()
+			mset.clseq = lseq + mset.clfs
+		}
+
+		// TODO(mvv): support message tracing
+		ts := time.Now().UnixNano()
+		var entries []*Entry
+
+		var (
+			bsubj string
+			bhdr  []byte
+			bmsg  []byte
+			err   error
+			smv   StoreMsg
+			sm    *StoreMsg
+			sz    int
+		)
+		for seq := uint64(1); seq <= batchSeq; seq++ {
+			if seq == batchSeq {
+				bsubj, bhdr, bmsg = subject, hdr, msg
+			} else if sm, err = b.store.LoadMsg(seq, &smv); sm != nil && err == nil {
+				bsubj, bhdr, bmsg = sm.subj, sm.hdr, sm.msg
+			} else {
+				mset.clseq -= seq - 1
+				mset.clMu.Unlock()
+				cleanup()
+				batches.mu.Unlock()
+				apiErr := NewJSAtomicPublishIncompleteBatchError()
+				if canRespond {
+					buf, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: apiErr})
+					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, buf, nil, 0))
+				}
+				return apiErr
+			}
+
+			var apiErr *ApiError
+			if bhdr, bmsg, _, apiErr, err = checkMsgHeadersPreClusteredProposal(mset, subject, bhdr, bmsg, sourced, name, jsa, allowTTL, allowMsgCounter, stype, store, interestPolicy, discard, maxMsgs, maxBytes); err != nil {
+				// TODO(mvv): reset in-memory expected header maps
+				mset.clseq -= seq - 1
+				mset.clMu.Unlock()
+				cleanup()
+				batches.mu.Unlock()
+				if err == errMsgIdDuplicate && apiErr == nil {
+					apiErr = NewJSAtomicPublishDuplicateError()
+				}
+				if canRespond {
+					buf, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: apiErr})
+					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, buf, nil, 0))
+				}
+				return err
+			}
+
+			var _reply string
+			if seq == batchSeq {
+				_reply = reply
+			}
+			esm := encodeStreamMsgAllowCompress(bsubj, _reply, bhdr, bmsg, mset.clseq, ts, sourced)
+			entries = append(entries, newEntry(EntryNormal, esm))
+			mset.clseq++
+			sz += len(esm)
+		}
+
+		// Do proposal.
+		// TODO(mvv): replace with individual `node.Propose`?
+		if err := node.ProposeMulti(entries); err == nil {
+			mset.trackReplicationTraffic(node, sz, r)
+		} else {
+			// TODO(mvv): reset in-memory expected header maps
+			mset.clseq -= batchSeq
+		}
+
+		// Check to see if we are being overrun.
+		// TODO(dlc) - Make this a limit where we drop messages to protect ourselves, but allow to be configured.
+		if mset.clseq-(lseq+mset.clfs) > streamLagWarnThreshold {
+			lerr := fmt.Errorf("JetStream stream '%s > %s' has high message lag", jsa.acc().Name, name)
+			s.RateLimitWarnf("%s", lerr.Error())
+		}
+		mset.clMu.Unlock()
+		cleanup()
+		batches.mu.Unlock()
+		return nil
 	}
 
 	// Proceed with proposing this message.
@@ -8214,247 +8249,29 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 		mset.clseq = lseq + mset.clfs
 	}
 
-	// Apply increment for counter.
-	// But only if it's allowed for this stream. This can happen when we store verbatim for a sourced stream.
-	if incr != nil && allowMsgCounter && store != nil {
-		var initial big.Int
-		var sources CounterSources
-		// Store running totals for counters, we could have multiple counter increments proposed, but not applied yet.
-		if mset.clusteredCounterTotal == nil {
-			mset.clusteredCounterTotal = make(map[string]*msgCounterRunningTotal, 1)
-		}
-
-		// If we've got a running total, update that, since we have inflight proposals updating the same counter.
-		var ok bool
-		var counter *msgCounterRunningTotal
-		if counter, ok = mset.clusteredCounterTotal[subject]; ok {
-			initial = *counter.total
-			sources = counter.sources
-		} else {
-			// Load last message, and store as inflight running total.
-			var smv StoreMsg
-			sm, err := store.LoadLastMsg(subject, &smv)
-			if err == nil && sm != nil {
-				var val CounterValue
-				// Return an error if the counter is broken somehow.
-				if json.Unmarshal(sm.msg, &val) != nil {
-					mset.clMu.Unlock()
-					apiErr := NewJSMessageCounterBrokenError()
-					if canRespond {
-						var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-						resp.Error = apiErr
-						response, _ = json.Marshal(resp)
-						outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
-					}
-					return apiErr
-				}
-				if ncs := sliceHeader(JSMessageCounterSources, sm.hdr); len(ncs) > 0 {
-					if err := json.Unmarshal(ncs, &sources); err != nil {
-						mset.clMu.Unlock()
-						apiErr := NewJSMessageCounterBrokenError()
-						if canRespond {
-							var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-							resp.Error = apiErr
-							response, _ = json.Marshal(resp)
-							outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
-						}
-						return apiErr
-					}
-				}
-				initial.SetString(val.Value, 10)
-			}
-		}
-		srchdr := sliceHeader(JSStreamSource, hdr)
-		if len(srchdr) > 0 {
-			// This is a sourced message, so we can't apply Nats-Incr but
-			// instead should just update the source count header.
-			fields := strings.Split(string(srchdr), " ")
-			origStream := fields[0]
-			origSubj := subject
-			if len(fields) >= 3 {
-				origSubj = fields[2]
-			}
-			var val CounterValue
-			if json.Unmarshal(msg, &val) != nil {
-				mset.clMu.Unlock()
-				apiErr := NewJSMessageCounterBrokenError()
-				if canRespond {
-					var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-					resp.Error = apiErr
-					response, _ = json.Marshal(resp)
-					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
-				}
-				return apiErr
-			}
-			var sourced big.Int
-			sourced.SetString(val.Value, 10)
-			if sources == nil {
-				sources = map[string]map[string]string{}
-			}
-			if _, ok := sources[origStream]; !ok {
-				sources[origStream] = map[string]string{}
-			}
-			prevVal := sources[origStream][origSubj]
-			sources[origStream][origSubj] = sourced.String()
-			// We will also replace the Nats-Incr header with the diff
-			// between our last value from this source and this one, so
-			// that the arithmetic is always correct.
-			var previous big.Int
-			previous.SetString(prevVal, 10)
-			incr.Sub(&sourced, &previous)
-			hdr = setHeader(JSMessageIncr, incr.String(), hdr)
-		}
-		// Now make the change.
-		initial.Add(&initial, incr)
-		// Generate the new payload.
-		var _msg [128]byte
-		msg = fmt.Appendf(_msg[:0], "{%q:%q}", "val", initial.String())
-		// Write the updated source count headers.
-		if len(sources) > 0 {
-			nhdr, err := json.Marshal(sources)
-			if err != nil {
-				mset.clMu.Unlock()
-				if canRespond {
-					var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-					resp.Error = NewJSMessageCounterBrokenError()
-					response, _ = json.Marshal(resp)
-					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
-				}
-				return err
-			}
-			hdr = setHeader(JSMessageCounterSources, string(nhdr), hdr)
-		}
-
-		// Keep the in-memory counters up-to-date.
-		if counter == nil {
-			counter = &msgCounterRunningTotal{}
-		}
-		counter.total = &initial
-		counter.sources = sources
-		counter.ops++
-		mset.clusteredCounterTotal[subject] = counter
-
-		// Check to see if we are over the max msg size.
-		if int32(len(hdr)+len(msg)) > mset.srv.getOpts().MaxPayload {
-			// Undo staged counter changes.
-			counter.ops--
-			if counter.ops == 0 {
-				delete(mset.clusteredCounterTotal, subject)
-			} else {
-				counter.total.Sub(counter.total, incr)
-			}
-			mset.clMu.Unlock()
-			if canRespond {
-				var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-				resp.Error = NewJSStreamMessageExceedsMaximumError()
-				response, _ = json.Marshal(resp)
-				outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
-			}
-			return ErrMaxPayload
-		}
-	}
-
-	// Check if we have an interest policy and discard new with max msgs or bytes.
-	// We need to deny here otherwise it could succeed on some peers and not others
-	// depending on consumer ack state. So we deny here, if we allow that means we know
-	// it would succeed on every peer.
-	if interestPolicy && discard == DiscardNew && (maxMsgs > 0 || maxBytes > 0) {
-		// Track inflight.
-		if mset.inflight == nil {
-			mset.inflight = make(map[uint64]uint64)
-		}
-		if stype == FileStorage {
-			mset.inflight[mset.clseq] = fileStoreMsgSize(subject, hdr, msg)
-		} else {
-			mset.inflight[mset.clseq] = memStoreMsgSize(subject, hdr, msg)
-		}
-
-		var state StreamState
-		mset.store.FastState(&state)
-
-		var err error
-		if maxMsgs > 0 && state.Msgs+uint64(len(mset.inflight)) > uint64(maxMsgs) {
-			err = ErrMaxMsgs
-		} else if maxBytes > 0 {
-			// TODO(dlc) - Could track this rollup independently.
-			var bytesPending uint64
-			for _, nb := range mset.inflight {
-				bytesPending += nb
-			}
-			if state.Bytes+bytesPending > uint64(maxBytes) {
-				err = ErrMaxBytes
-			}
-		}
-		if err != nil {
-			delete(mset.inflight, mset.clseq)
-			mset.clMu.Unlock()
-			if canRespond {
-				var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-				resp.Error = NewJSStreamStoreFailedError(err, Unless(err))
-				response, _ = json.Marshal(resp)
-				outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
-			}
+	var (
+		dseq   uint64
+		apiErr *ApiError
+		err    error
+	)
+	if hdr, msg, dseq, apiErr, err = checkMsgHeadersPreClusteredProposal(mset, subject, hdr, msg, sourced, name, jsa, allowTTL, allowMsgCounter, stype, store, interestPolicy, discard, maxMsgs, maxBytes); err != nil {
+		// TODO(mvv): reset in-memory expected header maps
+		mset.clMu.Unlock()
+		if err == errMsgIdDuplicate && dseq > 0 {
+			var buf [256]byte
+			pubAck := append(buf[:0], mset.pubAck...)
+			response = append(pubAck, strconv.FormatUint(dseq, 10)...)
+			response = append(response, ",\"duplicate\": true}"...)
+			outq.sendMsg(reply, response)
 			return err
 		}
-	}
-
-	if len(hdr) > 0 {
-		// Expected last sequence per subject.
-		if seq, exists := getExpectedLastSeqPerSubject(hdr); exists && store != nil {
-			// Allow override of the subject used for the check.
-			seqSubj := subject
-			if optSubj := getExpectedLastSeqPerSubjectForSubject(hdr); optSubj != _EMPTY_ {
-				seqSubj = optSubj
-			}
-
-			// If subject is already in process, block as otherwise we could have multiple messages inflight with same subject.
-			if _, found := mset.expectedPerSubjectInProcess[seqSubj]; found {
-				// Could have set inflight above, cleanup here.
-				delete(mset.inflight, mset.clseq)
-				mset.clMu.Unlock()
-				if canRespond {
-					var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-					resp.PubAck = &PubAck{Stream: name}
-					resp.Error = NewJSStreamWrongLastSequenceConstantError()
-					b, _ := json.Marshal(resp)
-					outq.sendMsg(reply, b)
-				}
-				return fmt.Errorf("last sequence by subject mismatch")
-			}
-
-			var smv StoreMsg
-			var fseq uint64
-			sm, err := store.LoadLastMsg(seqSubj, &smv)
-			if sm != nil {
-				fseq = sm.seq
-			}
-			if err == ErrStoreMsgNotFound && seq == 0 {
-				fseq, err = 0, nil
-			}
-			if err != nil || fseq != seq {
-				// Could have set inflight above, cleanup here.
-				delete(mset.inflight, mset.clseq)
-				mset.clMu.Unlock()
-				if canRespond {
-					var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-					resp.PubAck = &PubAck{Stream: name}
-					resp.Error = NewJSStreamWrongLastSequenceError(fseq)
-					b, _ := json.Marshal(resp)
-					outq.sendMsg(reply, b)
-				}
-				return fmt.Errorf("last sequence by subject mismatch: %d vs %d", seq, fseq)
-			}
-
-			// Track sequence and subject.
-			if mset.expectedPerSubjectSequence == nil {
-				mset.expectedPerSubjectSequence = make(map[uint64]string)
-			}
-			if mset.expectedPerSubjectInProcess == nil {
-				mset.expectedPerSubjectInProcess = make(map[string]struct{})
-			}
-			mset.expectedPerSubjectSequence[mset.clseq] = seqSubj
-			mset.expectedPerSubjectInProcess[seqSubj] = struct{}{}
+		if canRespond {
+			var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
+			resp.Error = apiErr
+			response, _ = json.Marshal(resp)
+			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
 		}
+		return err
 	}
 
 	esm := encodeStreamMsgAllowCompress(subject, reply, hdr, msg, mset.clseq, time.Now().UnixNano(), sourced)
@@ -8468,22 +8285,11 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	}
 
 	// Do proposal.
-	err := node.Propose(esm)
+	err = node.Propose(esm)
+	// TODO(mvv): reset in-memory expected header maps, if err!=nil
 	if err == nil {
 		mset.clseq++
-		// If we are using the system account for NRG, add in the extra sent msgs and bytes to our account
-		// so that the end user / account owner has visibility.
-		if node.IsSystemAccount() && mset.acc != nil && r > 1 {
-			outMsgs := int64(r - 1)
-			outBytes := int64(len(esm) * (r - 1))
-
-			mset.acc.stats.Lock()
-			mset.acc.stats.outMsgs += outMsgs
-			mset.acc.stats.outBytes += outBytes
-			mset.acc.stats.rt.outMsgs += outMsgs
-			mset.acc.stats.rt.outBytes += outBytes
-			mset.acc.stats.Unlock()
-		}
+		mset.trackReplicationTraffic(node, len(esm), r)
 	}
 
 	// Check to see if we are being overrun.
@@ -9019,7 +8825,6 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 
 	mset.mu.Lock()
 	st := mset.cfg.Storage
-	ddloaded := mset.ddloaded
 	if mset.hasAllPreAcks(seq, subj) {
 		mset.clearAllPreAcks(seq)
 		// Mark this to be skipped
@@ -9056,10 +8861,9 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 	// Check for MsgId and if we have one here make sure to update our internal map.
 	if len(hdr) > 0 {
 		if msgId := getMsgId(hdr); msgId != _EMPTY_ {
-			if !ddloaded {
-				mset.rebuildDedupe()
-			}
+			mset.ddMu.Lock()
 			mset.storeMsgIdLocked(&ddentry{msgId, seq, ts})
+			mset.ddMu.Unlock()
 		}
 	}
 

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -2463,10 +2463,10 @@ func TestJetStreamClusterPubAckSequenceDupeResetAfterLeaderChange(t *testing.T) 
 	require_NoError(t, err)
 
 	// Store one msg ID that needs to be preserved, and another that should be removed during leader change.
-	mset.mu.Lock()
+	mset.ddMu.Lock()
 	mset.storeMsgIdLocked(&ddentry{"genuine", 1, time.Now().UnixNano()})
 	mset.storeMsgIdLocked(&ddentry{"msgId", 0, time.Now().UnixNano()})
-	mset.mu.Unlock()
+	mset.ddMu.Unlock()
 
 	// Simulates the msg ID being in process.
 	_, err = js.Publish("foo", nil, nats.MsgId("msgId"))
@@ -2492,9 +2492,9 @@ func TestJetStreamClusterPubAckSequenceDupeResetAfterLeaderChange(t *testing.T) 
 	nsl := c.streamLeader(globalAccountName, "TEST")
 	require_True(t, nsl == sl)
 
-	mset.mu.Lock()
+	mset.ddMu.Lock()
 	lenDdmap, lenDdarr := len(mset.ddmap), len(mset.ddarr)
-	mset.mu.Unlock()
+	mset.ddMu.Unlock()
 	require_Len(t, lenDdmap, 1)
 	require_Len(t, lenDdarr, 1)
 

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -11,7 +11,7 @@ const (
 	// JSAtomicPublishDisabledErr atomic publish is disabled
 	JSAtomicPublishDisabledErr ErrorIdentifier = 10174
 
-	// JSAtomicPublishDuplicateErr atomic publish batch contains duplicates
+	// JSAtomicPublishDuplicateErr atomic publish duplicates not allowed
 	JSAtomicPublishDuplicateErr ErrorIdentifier = 10177
 
 	// JSAtomicPublishIncompleteBatchErr atomic publish batch is incomplete
@@ -538,7 +538,7 @@ var (
 	ApiErrors = map[ErrorIdentifier]*ApiError{
 		JSAccountResourcesExceededErr:              {Code: 400, ErrCode: 10002, Description: "resource limits exceeded for account"},
 		JSAtomicPublishDisabledErr:                 {Code: 400, ErrCode: 10174, Description: "atomic publish is disabled"},
-		JSAtomicPublishDuplicateErr:                {Code: 400, ErrCode: 10177, Description: "atomic publish batch contains duplicates"},
+		JSAtomicPublishDuplicateErr:                {Code: 400, ErrCode: 10177, Description: "atomic publish duplicates not allowed"},
 		JSAtomicPublishIncompleteBatchErr:          {Code: 400, ErrCode: 10176, Description: "atomic publish batch is incomplete"},
 		JSAtomicPublishMissingSeqErr:               {Code: 400, ErrCode: 10175, Description: "atomic publish sequence is missing"},
 		JSBadRequestErr:                            {Code: 400, ErrCode: 10003, Description: "bad request"},
@@ -757,7 +757,7 @@ func NewJSAtomicPublishDisabledError(opts ...ErrorOption) *ApiError {
 	return ApiErrors[JSAtomicPublishDisabledErr]
 }
 
-// NewJSAtomicPublishDuplicateError creates a new JSAtomicPublishDuplicateErr error: "atomic publish batch contains duplicates"
+// NewJSAtomicPublishDuplicateError creates a new JSAtomicPublishDuplicateErr error: "atomic publish duplicates not allowed"
 func NewJSAtomicPublishDuplicateError(opts ...ErrorOption) *ApiError {
 	eopts := parseOpts(opts)
 	if ae, ok := eopts.err.(*ApiError); ok {

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -8,6 +8,18 @@ const (
 	// JSAccountResourcesExceededErr resource limits exceeded for account
 	JSAccountResourcesExceededErr ErrorIdentifier = 10002
 
+	// JSAtomicPublishDisabledErr atomic publish is disabled
+	JSAtomicPublishDisabledErr ErrorIdentifier = 10174
+
+	// JSAtomicPublishDuplicateErr atomic publish batch contains duplicates
+	JSAtomicPublishDuplicateErr ErrorIdentifier = 10177
+
+	// JSAtomicPublishIncompleteBatchErr atomic publish batch is incomplete
+	JSAtomicPublishIncompleteBatchErr ErrorIdentifier = 10176
+
+	// JSAtomicPublishMissingSeqErr atomic publish sequence is missing
+	JSAtomicPublishMissingSeqErr ErrorIdentifier = 10175
+
 	// JSBadRequestErr bad request
 	JSBadRequestErr ErrorIdentifier = 10003
 
@@ -525,6 +537,10 @@ const (
 var (
 	ApiErrors = map[ErrorIdentifier]*ApiError{
 		JSAccountResourcesExceededErr:              {Code: 400, ErrCode: 10002, Description: "resource limits exceeded for account"},
+		JSAtomicPublishDisabledErr:                 {Code: 400, ErrCode: 10174, Description: "atomic publish is disabled"},
+		JSAtomicPublishDuplicateErr:                {Code: 400, ErrCode: 10177, Description: "atomic publish batch contains duplicates"},
+		JSAtomicPublishIncompleteBatchErr:          {Code: 400, ErrCode: 10176, Description: "atomic publish batch is incomplete"},
+		JSAtomicPublishMissingSeqErr:               {Code: 400, ErrCode: 10175, Description: "atomic publish sequence is missing"},
 		JSBadRequestErr:                            {Code: 400, ErrCode: 10003, Description: "bad request"},
 		JSClusterIncompleteErr:                     {Code: 503, ErrCode: 10004, Description: "incomplete results"},
 		JSClusterNoPeersErrF:                       {Code: 400, ErrCode: 10005, Description: "{err}"},
@@ -729,6 +745,46 @@ func NewJSAccountResourcesExceededError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSAccountResourcesExceededErr]
+}
+
+// NewJSAtomicPublishDisabledError creates a new JSAtomicPublishDisabledErr error: "atomic publish is disabled"
+func NewJSAtomicPublishDisabledError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSAtomicPublishDisabledErr]
+}
+
+// NewJSAtomicPublishDuplicateError creates a new JSAtomicPublishDuplicateErr error: "atomic publish batch contains duplicates"
+func NewJSAtomicPublishDuplicateError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSAtomicPublishDuplicateErr]
+}
+
+// NewJSAtomicPublishIncompleteBatchError creates a new JSAtomicPublishIncompleteBatchErr error: "atomic publish batch is incomplete"
+func NewJSAtomicPublishIncompleteBatchError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSAtomicPublishIncompleteBatchErr]
+}
+
+// NewJSAtomicPublishMissingSeqError creates a new JSAtomicPublishMissingSeqErr error: "atomic publish sequence is missing"
+func NewJSAtomicPublishMissingSeqError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSAtomicPublishMissingSeqErr]
 }
 
 // NewJSBadRequestError creates a new JSBadRequestErr error: "bad request"

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -20430,7 +20430,7 @@ func TestJetStreamAllowMsgCounter(t *testing.T) {
 			s = RunBasicJetStreamServer(t)
 			servers = []*Server{s}
 			s.optsMu.Lock()
-			s.opts.MaxPayload = 400
+			s.opts.MaxPayload = 1024
 			s.optsMu.Unlock()
 			defer s.Shutdown()
 		} else {
@@ -20439,7 +20439,7 @@ func TestJetStreamAllowMsgCounter(t *testing.T) {
 			servers = c.servers
 			for _, cs := range c.servers {
 				cs.optsMu.Lock()
-				cs.opts.MaxPayload = 400
+				cs.opts.MaxPayload = 1024
 				cs.optsMu.Unlock()
 			}
 			s = c.randomServer()
@@ -20539,7 +20539,7 @@ func TestJetStreamAllowMsgCounter(t *testing.T) {
 		increment("1", 4, big.NewInt(1))
 
 		// Check payload exceeded, positive bound.
-		tooLargeIncrement := strings.Repeat("1", 300)
+		tooLargeIncrement := strings.Repeat("1", 500)
 		m = nats.NewMsg("foo")
 		m.Header.Set("Nats-Incr", tooLargeIncrement)
 		_, err = js.PublishMsg(m)
@@ -21049,4 +21049,196 @@ func TestJetStreamAllowMsgCounterSourceStartingAboveZero(t *testing.T) {
 
 	t.Run("R1", func(t *testing.T) { test(t, 1) })
 	t.Run("R3", func(t *testing.T) { test(t, 3) })
+}
+
+func TestJetStreamAtomicBatchPublish(t *testing.T) {
+	test := func(
+		t *testing.T,
+		nc *nats.Conn,
+		js nats.JetStreamContext,
+		storage StorageType,
+		retention RetentionPolicy,
+		replicas int,
+	) {
+		var pubAck JSPubAckResponse
+
+		cfg := &StreamConfig{
+			Name:      "TEST",
+			Subjects:  []string{"foo.*"},
+			Storage:   storage,
+			Retention: retention,
+			Replicas:  replicas,
+		}
+
+		_, err := jsStreamCreate(t, nc, cfg)
+		require_NoError(t, err)
+
+		m := nats.NewMsg("foo.0")
+		m.Data = []byte("foo.0")
+		m.Header.Set("Nats-Batch-Id", "uuid")
+
+		// Publish with atomic publish disabled.
+		rmsg, err := nc.RequestMsg(m, time.Second)
+		require_NoError(t, err)
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_NotNil(t, pubAck.Error)
+		require_Error(t, pubAck.Error, NewJSAtomicPublishDisabledError())
+
+		// Enable atomic publish.
+		cfg.AllowAtomicPublish = true
+		_, err = jsStreamUpdate(t, nc, cfg)
+		require_NoError(t, err)
+
+		// Publish without batch sequence errors.
+		rmsg, err = nc.RequestMsg(m, time.Second)
+		require_NoError(t, err)
+		pubAck = JSPubAckResponse{}
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_Error(t, pubAck.Error, NewJSAtomicPublishMissingSeqError())
+
+		// Publish a batch, misses start.
+		m.Header.Set("Nats-Batch-Id", "uuid")
+		m.Header.Set("Nats-Batch-Sequence", "2")
+		rmsg, err = nc.RequestMsg(m, time.Second)
+		require_NoError(t, err)
+		pubAck = JSPubAckResponse{}
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_Error(t, pubAck.Error, NewJSAtomicPublishIncompleteBatchError())
+
+		// Publish a "batch" which immediately commits.
+		m.Header.Set("Nats-Batch-Id", "uuid")
+		m.Header.Set("Nats-Batch-Sequence", "1")
+		m.Header.Set("Nats-Batch-Commit", "1")
+		rmsg, err = nc.RequestMsg(m, time.Second)
+		require_NoError(t, err)
+		pubAck = JSPubAckResponse{}
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_Equal(t, pubAck.Sequence, 1)
+		require_Equal(t, pubAck.BatchId, "uuid")
+		require_Equal(t, pubAck.BatchSize, 1)
+
+		// Reset commit.
+		m.Header.Del("Nats-Batch-Commit")
+
+		// Publish a "batch" which has gaps.
+		require_NoError(t, nc.PublishMsg(m))
+		m.Header.Set("Nats-Batch-Sequence", "3")
+		rmsg, err = nc.RequestMsg(m, time.Second)
+		require_NoError(t, err)
+		pubAck = JSPubAckResponse{}
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_Error(t, pubAck.Error, NewJSAtomicPublishIncompleteBatchError())
+
+		// Publish a batch of N messages.
+		m.Header.Del("Nats-Batch-Commit")
+		for seq, batch := uint64(1), uint64(5); seq <= batch; seq++ {
+			m.Subject = fmt.Sprintf("foo.%d", seq)
+			m.Data = []byte(m.Subject)
+			m.Header.Set("Nats-Batch-Sequence", strconv.FormatUint(seq, 10))
+			// If not commit.
+			if seq != batch {
+				require_NoError(t, nc.PublishMsg(m))
+				continue
+			}
+
+			m.Header.Set("Nats-Batch-Commit", "1")
+			rmsg, err = nc.RequestMsg(m, time.Second)
+			require_NoError(t, err)
+
+			pubAck = JSPubAckResponse{}
+			require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+			require_Equal(t, pubAck.Sequence, 6)
+			require_Equal(t, pubAck.BatchId, "uuid")
+			require_Equal(t, pubAck.BatchSize, 5)
+		}
+
+		// Validate stream contents.
+		if retention != InterestPolicy {
+			for i := 0; i < 6; i++ {
+				rsm, err := js.GetMsg("TEST", uint64(i+1))
+				require_NoError(t, err)
+				subj := fmt.Sprintf("foo.%d", i)
+				require_Equal(t, rsm.Subject, subj)
+				require_Equal(t, string(rsm.Data), subj)
+			}
+		}
+
+		// TODO(mvv): implement timeout
+	}
+
+	for _, storage := range []StorageType{FileStorage, MemoryStorage} {
+		for _, retention := range []RetentionPolicy{LimitsPolicy, InterestPolicy, WorkQueuePolicy} {
+			replicas := 3
+			t.Run(fmt.Sprintf("%s/%s/R%d", storage, retention, replicas), func(t *testing.T) {
+				c := createJetStreamClusterExplicit(t, "R3S", 3)
+				defer c.shutdown()
+
+				nc, js := jsClientConnect(t, c.randomServer())
+				defer nc.Close()
+
+				test(t, nc, js, storage, retention, replicas)
+			})
+		}
+	}
+}
+
+func TestJetStreamAtomicBatchPublishDedupe(t *testing.T) {
+	test := func(
+		t *testing.T,
+		nc *nats.Conn,
+		js nats.JetStreamContext,
+		storage StorageType,
+		retention RetentionPolicy,
+		replicas int,
+	) {
+		cfg := &StreamConfig{
+			Name:               "TEST",
+			Retention:          retention,
+			Subjects:           []string{"foo"},
+			Replicas:           3,
+			Storage:            FileStorage,
+			AllowAtomicPublish: true,
+		}
+
+		_, err := jsStreamCreate(t, nc, cfg)
+		require_NoError(t, err)
+
+		// Publish one duplicate.
+		_, err = js.Publish("foo", nil, nats.MsgId("pre-existing"))
+		require_NoError(t, err)
+
+		m := nats.NewMsg("foo")
+		m.Header.Set("Nats-Batch-Id", "uuid")
+		m.Header.Set("Nats-Batch-Sequence", "1")
+		m.Header.Set("Nats-Msg-Id", "msgId1")
+		require_NoError(t, nc.PublishMsg(m))
+		m.Header.Set("Nats-Batch-Sequence", "2")
+		m.Header.Set("Nats-Msg-Id", "pre-existing")
+		require_NoError(t, nc.PublishMsg(m))
+
+		var pubAck JSPubAckResponse
+		m.Header.Set("Nats-Batch-Sequence", "3")
+		m.Header.Set("Nats-Msg-Id", "msgId2")
+		m.Header.Set("Nats-Batch-Commit", "1")
+		rmsg, err := nc.RequestMsg(m, time.Second)
+		require_NoError(t, err)
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_NotNil(t, pubAck.Error)
+		require_Error(t, pubAck.Error, NewJSAtomicPublishDuplicateError())
+	}
+
+	for _, storage := range []StorageType{FileStorage, MemoryStorage} {
+		for _, retention := range []RetentionPolicy{LimitsPolicy, InterestPolicy, WorkQueuePolicy} {
+			replicas := 3
+			t.Run(fmt.Sprintf("%s/%s/R%d", storage, retention, replicas), func(t *testing.T) {
+				c := createJetStreamClusterExplicit(t, "R3S", 3)
+				defer c.shutdown()
+
+				nc, js := jsClientConnect(t, c.randomServer())
+				defer nc.Close()
+
+				test(t, nc, js, storage, retention, replicas)
+			})
+		}
+	}
 }

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -21182,7 +21182,7 @@ func TestJetStreamAtomicBatchPublish(t *testing.T) {
 	}
 }
 
-func TestJetStreamAtomicBatchPublishDedupe(t *testing.T) {
+func TestJetStreamAtomicBatchPublishDedupeNotAllowed(t *testing.T) {
 	test := func(
 		t *testing.T,
 		nc *nats.Conn,
@@ -21201,10 +21201,6 @@ func TestJetStreamAtomicBatchPublishDedupe(t *testing.T) {
 		}
 
 		_, err := jsStreamCreate(t, nc, cfg)
-		require_NoError(t, err)
-
-		// Publish one duplicate.
-		_, err = js.Publish("foo", nil, nats.MsgId("pre-existing"))
 		require_NoError(t, err)
 
 		m := nats.NewMsg("foo")

--- a/server/jetstream_versioning.go
+++ b/server/jetstream_versioning.go
@@ -50,6 +50,11 @@ func setStaticStreamMetadata(cfg *StreamConfig) {
 		requires(2)
 	}
 
+	// Atomic batch publishing was added in v2.12 and require API level 2.
+	if cfg.AllowAtomicPublish {
+		requires(2)
+	}
+
 	cfg.Metadata[JSRequiredLevelMetadataKey] = strconv.Itoa(requiredApiLevel)
 }
 

--- a/server/jetstream_versioning_test.go
+++ b/server/jetstream_versioning_test.go
@@ -77,6 +77,11 @@ func TestJetStreamSetStaticStreamMetadata(t *testing.T) {
 			cfg:              &StreamConfig{AllowMsgCounter: true},
 			expectedMetadata: metadataAtLevel("2"),
 		},
+		{
+			desc:             "AllowAtomicPublish",
+			cfg:              &StreamConfig{AllowAtomicPublish: true},
+			expectedMetadata: metadataAtLevel("2"),
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			setStaticStreamMetadata(test.cfg)

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1917,8 +1917,12 @@ func (ms *memStore) Utilization() (total, reported uint64, err error) {
 	return ms.state.Bytes, ms.state.Bytes, nil
 }
 
+func memStoreMsgSizeRaw(slen, hlen, mlen int) uint64 {
+	return uint64(slen + hlen + mlen + 16) // 8*2 for seq + age
+}
+
 func memStoreMsgSize(subj string, hdr, msg []byte) uint64 {
-	return uint64(len(subj) + len(hdr) + len(msg) + 16) // 8*2 for seq + age
+	return memStoreMsgSizeRaw(len(subj), len(hdr), len(msg))
 }
 
 // Delete is same as Stop for memory store.

--- a/server/norace_1_test.go
+++ b/server/norace_1_test.go
@@ -4646,10 +4646,11 @@ func TestNoRaceJetStreamRebuildDeDupeAndMemoryPerf(t *testing.T) {
 	require_NoError(t, err)
 
 	mset.mu.Lock()
-	mset.ddloaded = false
+	mset.ddMu.Lock()
 	start = time.Now()
 	mset.rebuildDedupe()
 	fmt.Printf("TOOK %v to rebuild dd\n", time.Since(start))
+	mset.ddMu.Unlock()
 	mset.mu.Unlock()
 
 	v, _ = s.Varz(nil)

--- a/server/raft.go
+++ b/server/raft.go
@@ -839,11 +839,11 @@ func (n *raft) Propose(data []byte) error {
 	return nil
 }
 
-// ProposeDirect will propose multiple entries at once.
+// ProposeMulti will propose multiple entries at once.
 // This should only be called on the leader.
 func (n *raft) ProposeMulti(entries []*Entry) error {
 	if state := n.State(); state != Leader {
-		n.debug("Direct proposal ignored, not leader (state: %v)", state)
+		n.debug("Multi proposal ignored, not leader (state: %v)", state)
 		return errNotLeader
 	}
 	n.Lock()


### PR DESCRIPTION
This PR implements an initial version for atomic/batch publishing, as described in [this ADR](https://github.com/nats-io/nats-architecture-and-design/pull/346).

In general:
- A client can now be implemented (given the current limitations listed below) to use the new batch API. For an example, see `TestJetStreamAtomicPublish`.
- The stream config field for `AllowAtomicPublish` is added, support for batch headers `Nats-Batch-Id, Nats-Batch-Sequence, Nats-Batch-Commit`, feature versioning, and support for batching as per the ADR.
- Dedupe state (`mset.ddmap, mset.ddarr, mset.ddindex`) is now guarded by a separate lock (`mset.ddMu`). This is required because we need to keep holding `mset.clMu` while accessing the dedupe state, and we can't use `mset.mu` as that would be a lock order violation. (Usage added to `locksordering.txt`)
- All clustered header checks (like `Nats-Expected-*` and `Nats-Msg-Id`) prior to proposal have been moved to `jetstream_batching.go`, such that they can be used to do checks for all messages in the batch prior to accepting it fully.

Implementation:
- Client publishes batches as per the ADR.
- Server receives these, and:
  - Stores each message in the batch into a `StreamStore`, currently `memstore` only.
  - Once `Nats-Batch-Commit`, we loop through all messages and do the required header checks prior to proposing.
- Server rejects the batch if gaps are detected, or any required header checks fail.
- Otherwise, Server proposes append entries consisting of the batched entries.
- Followers check they've received all proposed entries containing the batch, IFF the full batch is received they can simply apply all entries and don't need to do further header checks.

Atomic publish is not complete after this PR, importantly it has the following limitations that will need to be fixed in separate PRs:
- https://github.com/nats-io/nats-server/issues/6974
- https://github.com/nats-io/nats-server/issues/6975
- https://github.com/nats-io/nats-server/issues/6976
- https://github.com/nats-io/nats-server/issues/6977
- https://github.com/nats-io/nats-server/issues/6978
- https://github.com/nats-io/nats-server/issues/6979
- https://github.com/nats-io/nats-server/issues/6980
- etc.

Relates to https://github.com/nats-io/nats-server/issues/6549

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>