### PR TITLE
(2.12) Counter CRDT

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -35,6 +35,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"slices"
+
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/internal/fastrand"
@@ -4382,6 +4384,27 @@ func sliceHeader(key string, hdr []byte) []byte {
 		index++
 	}
 	return hdr[start:index:index]
+}
+
+func setHeader(key, val string, hdr []byte) []byte {
+	prefix := []byte(key + ": ")
+	start := bytes.Index(hdr, prefix)
+	if start >= 0 {
+		valStart := start + len(prefix)
+		valEnd := bytes.Index(hdr[valStart:], []byte("\r"))
+		if valEnd < 0 {
+			return hdr // malformed headers
+		}
+		valEnd += valStart
+		suffix := slices.Clone(hdr[valEnd:])
+		newHdr := append(hdr[:valStart], val...)
+		return append(newHdr, suffix...)
+	}
+	if len(hdr) > 0 && bytes.HasSuffix(hdr, []byte("\r\n")) {
+		hdr = hdr[:len(hdr)-2]
+		val += "\r\n"
+	}
+	return fmt.Appendf(hdr, "%s: %s\r\n", key, val)
 }
 
 // For bytes.HasPrefix below.

--- a/server/errors.json
+++ b/server/errors.json
@@ -1658,5 +1658,65 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSMessageIncrDisabledErr",
+    "code": 400,
+    "error_code": 10168,
+    "description": "message counters is disabled",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSMessageIncrMissingErr",
+    "code": 400,
+    "error_code": 10169,
+    "description": "message counter increment is missing",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSMessageIncrPayloadErr",
+    "code": 400,
+    "error_code": 10170,
+    "description": "message counter has payload",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSMessageIncrInvalidErr",
+    "code": 400,
+    "error_code": 10171,
+    "description": "message counter increment is invalid",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSMessageCounterBrokenErr",
+    "code": 400,
+    "error_code": 10172,
+    "description": "message counter is broken",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSMirrorWithCountersErr",
+    "code": 400,
+    "error_code": 10173,
+    "description": "stream mirrors can not also calculate counters",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -2999,6 +3000,21 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 					mset.clMu.Unlock()
 				}
 
+				// Update running total for counter.
+				if mset.clusteredCounterTotal != nil {
+					mset.clMu.Lock()
+					if counter, found := mset.clusteredCounterTotal[subject]; found {
+						// Decrement from pending operations. Once it reaches zero, it can be deleted.
+						if counter.ops > 0 {
+							counter.ops--
+						}
+						if counter.ops == 0 {
+							delete(mset.clusteredCounterTotal, subject)
+						}
+					}
+					mset.clMu.Unlock()
+				}
+
 				// Clear expected per subject state after processing.
 				if mset.expectedPerSubjectSequence != nil {
 					mset.clMu.Lock()
@@ -3256,6 +3272,8 @@ func (js *jetStream) processStreamLeaderChange(mset *stream, isLeader bool) {
 	mset.clMu.Lock()
 	// Clear inflight if we have it.
 	mset.inflight = nil
+	// Clear running counter totals.
+	mset.clusteredCounterTotal = nil
 	// Clear expected per subject state.
 	mset.expectedPerSubjectSequence = nil
 	mset.expectedPerSubjectInProcess = nil
@@ -7945,7 +7963,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	s, js, jsa, st, r, tierName, outq, node := mset.srv, mset.js, mset.jsa, mset.cfg.Storage, mset.cfg.Replicas, mset.tier, mset.outq, mset.node
 	maxMsgSize, lseq := int(mset.cfg.MaxMsgSize), mset.lseq
 	interestPolicy, discard, maxMsgs, maxBytes := mset.cfg.Retention != LimitsPolicy, mset.cfg.Discard, mset.cfg.MaxMsgs, mset.cfg.MaxBytes
-	isLeader, isSealed, allowTTL := mset.isLeader(), mset.cfg.Sealed, mset.cfg.AllowMsgTTL
+	isLeader, isSealed, allowTTL, allowMsgCounter := mset.isLeader(), mset.cfg.Sealed, mset.cfg.AllowMsgTTL, mset.cfg.AllowMsgCounter
 	mset.mu.RUnlock()
 
 	// This should not happen but possible now that we allow scale up, and scale down where this could trigger.
@@ -8025,6 +8043,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 
 	// Some header checks can be checked pre proposal. Most can not.
 	var msgId string
+	var incr *big.Int
 	if len(hdr) > 0 {
 		// Since we encode header len as u16 make sure we do not exceed.
 		// Again this works if it goes through but better to be pre-emptive.
@@ -8038,6 +8057,64 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 				outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
 			}
 			return err
+		}
+		// Counter increments.
+		// Only supported on counter streams, and payload must be empty (if not coming from a source).
+		var ok bool
+		if incr, ok = getMessageIncr(hdr); !ok {
+			apiErr := NewJSMessageIncrInvalidError()
+			if canRespond {
+				var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
+				resp.Error = apiErr
+				response, _ = json.Marshal(resp)
+				outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+			}
+			return apiErr
+		} else if incr != nil && !sourced {
+			// Only do checks if the message isn't sourced. Otherwise, we need to store verbatim.
+			if !allowMsgCounter {
+				apiErr := NewJSMessageIncrDisabledError()
+				if canRespond {
+					var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
+					resp.Error = apiErr
+					response, _ = json.Marshal(resp)
+					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+				}
+				return apiErr
+			} else if len(msg) > 0 {
+				apiErr := NewJSMessageIncrPayloadError()
+				if canRespond {
+					var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
+					resp.Error = apiErr
+					response, _ = json.Marshal(resp)
+					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+				}
+				return apiErr
+			} else {
+				// Check for incompatible headers.
+				var doErr bool
+				if getRollup(hdr) != _EMPTY_ ||
+					getExpectedStream(hdr) != _EMPTY_ ||
+					getExpectedLastMsgId(hdr) != _EMPTY_ ||
+					getExpectedLastSeqPerSubjectForSubject(hdr) != _EMPTY_ {
+					doErr = true
+				} else if _, ok := getExpectedLastSeq(hdr); ok {
+					doErr = true
+				} else if _, ok := getExpectedLastSeqPerSubject(hdr); ok {
+					doErr = true
+				}
+
+				if doErr {
+					apiErr := NewJSMessageIncrInvalidError()
+					if canRespond {
+						var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
+						resp.Error = apiErr
+						response, _ = json.Marshal(resp)
+						outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+					}
+					return apiErr
+				}
+			}
 		}
 		// Expected stream name can also be pre-checked.
 		if sname := getExpectedStream(hdr); sname != _EMPTY_ && sname != name {
@@ -8101,6 +8178,17 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 		}
 	}
 
+	if incr == nil && allowMsgCounter {
+		apiErr := NewJSMessageIncrMissingError()
+		if canRespond {
+			var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
+			resp.Error = apiErr
+			response, _ = json.Marshal(resp)
+			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+		}
+		return apiErr
+	}
+
 	// Proceed with proposing this message.
 
 	// We only use mset.clseq for clustering and in case we run ahead of actual commits.
@@ -8110,6 +8198,68 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 		// Re-capture
 		lseq = mset.lastSeq()
 		mset.clseq = lseq + mset.clfs
+	}
+
+	// Apply increment for counter.
+	// But only if it's allowed for this stream. This can happen when we store verbatim for a sourced stream.
+	if incr != nil && allowMsgCounter && store != nil {
+		// Store running totals for counters, we could have multiple counter increments proposed, but not applied yet.
+		if mset.clusteredCounterTotal == nil {
+			mset.clusteredCounterTotal = make(map[string]*msgCounterRunningTotal, 1)
+		}
+
+		// If we've got a running total, update that, since we have inflight proposals updating the same counter.
+		var ok bool
+		var counter *msgCounterRunningTotal
+		if counter, ok = mset.clusteredCounterTotal[subject]; ok {
+			counter.total.Add(counter.total, incr)
+			counter.ops++
+			msg = []byte(fmt.Sprintf("{%q:%q}", "val", counter.total.String()))
+		} else {
+			// Load last message, and store as inflight running total.
+			var smv StoreMsg
+			sm, err := store.LoadLastMsg(subject, &smv)
+			if err == nil && sm != nil {
+				var val CounterValue
+				var initial big.Int
+				// Return an error if the counter is broken somehow.
+				if json.Unmarshal(sm.msg, &val) != nil {
+					mset.clMu.Unlock()
+					apiErr := NewJSMessageCounterBrokenError()
+					if canRespond {
+						var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
+						resp.Error = apiErr
+						response, _ = json.Marshal(resp)
+						outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+					}
+					return apiErr
+				}
+				initial.SetString(val.Value, 10)
+				incr.Add(incr, &initial)
+			}
+			counter = &msgCounterRunningTotal{total: incr, ops: 1}
+			mset.clusteredCounterTotal[subject] = counter
+			msg = []byte(fmt.Sprintf("{%q:%q}", "val", counter.total.String()))
+		}
+
+		// Check to see if we are over the max msg size.
+		if int32(len(hdr)+len(msg)) > mset.srv.getOpts().MaxPayload {
+			// Undo staged counter changes.
+			counter.ops--
+			if counter.ops == 0 {
+				delete(mset.clusteredCounterTotal, subject)
+			} else {
+				counter.total.Sub(counter.total, incr)
+			}
+			mset.clMu.Unlock()
+			if canRespond {
+				var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
+				resp.Error = NewJSStreamMessageExceedsMaximumError()
+				response, _ = json.Marshal(resp)
+				outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+			}
+			return ErrMaxPayload
+		}
 	}
 
 	// Check if we have an interest policy and discard new with max msgs or bytes.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8203,6 +8203,8 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	// Apply increment for counter.
 	// But only if it's allowed for this stream. This can happen when we store verbatim for a sourced stream.
 	if incr != nil && allowMsgCounter && store != nil {
+		var initial big.Int
+		var sources CounterSources
 		// Store running totals for counters, we could have multiple counter increments proposed, but not applied yet.
 		if mset.clusteredCounterTotal == nil {
 			mset.clusteredCounterTotal = make(map[string]*msgCounterRunningTotal, 1)
@@ -8212,16 +8214,14 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 		var ok bool
 		var counter *msgCounterRunningTotal
 		if counter, ok = mset.clusteredCounterTotal[subject]; ok {
-			counter.total.Add(counter.total, incr)
-			counter.ops++
-			msg = []byte(fmt.Sprintf("{%q:%q}", "val", counter.total.String()))
+			initial = *counter.total
+			sources = counter.sources
 		} else {
 			// Load last message, and store as inflight running total.
 			var smv StoreMsg
 			sm, err := store.LoadLastMsg(subject, &smv)
 			if err == nil && sm != nil {
 				var val CounterValue
-				var initial big.Int
 				// Return an error if the counter is broken somehow.
 				if json.Unmarshal(sm.msg, &val) != nil {
 					mset.clMu.Unlock()
@@ -8234,13 +8234,90 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 					}
 					return apiErr
 				}
+				if ncs := getHeader(JSMessageCounterSources, sm.hdr); len(ncs) > 0 {
+					if err := json.Unmarshal(ncs, &sources); err != nil {
+						mset.clMu.Unlock()
+						apiErr := NewJSMessageCounterBrokenError()
+						if canRespond {
+							var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
+							resp.Error = apiErr
+							response, _ = json.Marshal(resp)
+							outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+						}
+						return apiErr
+					}
+				}
 				initial.SetString(val.Value, 10)
-				incr.Add(incr, &initial)
 			}
-			counter = &msgCounterRunningTotal{total: incr, ops: 1}
-			mset.clusteredCounterTotal[subject] = counter
-			msg = []byte(fmt.Sprintf("{%q:%q}", "val", counter.total.String()))
 		}
+		srchdr := sliceHeader(JSStreamSource, hdr)
+		if len(srchdr) > 0 {
+			// This is a sourced message, so we can't apply Nats-Incr but
+			// instead should just update the source count header.
+			fields := strings.Split(string(srchdr), " ")
+			origStream := fields[0]
+			origSubj := subject
+			if len(fields) >= 3 {
+				origSubj = fields[2]
+			}
+			var val CounterValue
+			if json.Unmarshal(msg, &val) != nil {
+				mset.clMu.Unlock()
+				apiErr := NewJSMessageCounterBrokenError()
+				if canRespond {
+					var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
+					resp.Error = apiErr
+					response, _ = json.Marshal(resp)
+					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+				}
+				return apiErr
+			}
+			var sourced big.Int
+			sourced.SetString(val.Value, 10)
+			if sources == nil {
+				sources = map[string]map[string]string{}
+			}
+			if _, ok := sources[origStream]; !ok {
+				sources[origStream] = map[string]string{}
+			}
+			prevVal := sources[origStream][origSubj]
+			sources[origStream][origSubj] = sourced.String()
+			// We will also replace the Nats-Incr header with the diff
+			// between our last value from this source and this one, so
+			// that the arithmetic is always correct.
+			var previous big.Int
+			previous.SetString(prevVal, 10)
+			incr.Sub(&sourced, &previous)
+			hdr = setHeader(JSMessageIncr, incr.String(), hdr)
+		}
+		// Now make the change.
+		initial.Add(&initial, incr)
+		// Generate the new payload.
+		msg = fmt.Appendf(nil, "{%q:%q}", "val", initial.String())
+		// Write the updated source count headers.
+		if len(sources) > 0 {
+			nhdr, err := json.Marshal(sources)
+			if err != nil {
+				mset.clMu.Unlock()
+				if canRespond {
+					var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
+					resp.Error = NewJSMessageCounterBrokenError()
+					response, _ = json.Marshal(resp)
+					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+				}
+				return err
+			}
+			hdr = setHeader(JSMessageCounterSources, string(nhdr), hdr)
+		}
+
+		// Keep the in-memory counters up-to-date.
+		if counter == nil {
+			counter = &msgCounterRunningTotal{}
+		}
+		counter.total = &initial
+		counter.sources = sources
+		counter.ops++
+		mset.clusteredCounterTotal[subject] = counter
 
 		// Check to see if we are over the max msg size.
 		if int32(len(hdr)+len(msg)) > mset.srv.getOpts().MaxPayload {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8234,7 +8234,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 					}
 					return apiErr
 				}
-				if ncs := getHeader(JSMessageCounterSources, sm.hdr); len(ncs) > 0 {
+				if ncs := sliceHeader(JSMessageCounterSources, sm.hdr); len(ncs) > 0 {
 					if err := json.Unmarshal(ncs, &sources); err != nil {
 						mset.clMu.Unlock()
 						apiErr := NewJSMessageCounterBrokenError()
@@ -8293,7 +8293,8 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 		// Now make the change.
 		initial.Add(&initial, incr)
 		// Generate the new payload.
-		msg = fmt.Appendf(nil, "{%q:%q}", "val", initial.String())
+		var _msg [128]byte
+		msg = fmt.Appendf(_msg[:0], "{%q:%q}", "val", initial.String())
 		// Write the updated source count headers.
 		if len(sources) > 0 {
 			nhdr, err := json.Marshal(sources)

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -4813,7 +4813,9 @@ func TestJetStreamClusterMsgCounterRunningTotalConsistency(t *testing.T) {
 	rsm, err := js.GetLastMsg("TEST", "foo")
 	require_NoError(t, err)
 	require_Equal(t, rsm.Sequence, 1)
-	require_Equal(t, string(rsm.Data), "{\"val\":\"11\"}")
+	var count CounterValue
+	require_NoError(t, json.Unmarshal(rsm.Data, &count))
+	require_Equal(t, count.Value, "11")
 
 	// Confirm running total has properly been mutated.
 	total, ops := _EMPTY_, uint64(0)
@@ -4844,7 +4846,8 @@ func TestJetStreamClusterMsgCounterRunningTotalConsistency(t *testing.T) {
 	rsm, err = js.GetLastMsg("TEST", "foo")
 	require_NoError(t, err)
 	require_Equal(t, rsm.Sequence, 2)
-	require_Equal(t, string(rsm.Data), "{\"val\":\"12\"}")
+	require_NoError(t, json.Unmarshal(rsm.Data, &count))
+	require_Equal(t, count.Value, "12")
 
 	// Should be cleaned up after publish.
 	mset.clMu.Lock()

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"math/rand"
 	"os"
 	"path"
@@ -4772,6 +4773,83 @@ func TestJetStreamClusterExpectedPerSubjectConsistency(t *testing.T) {
 	defer mset.clMu.Unlock()
 	require_Len(t, len(mset.expectedPerSubjectSequence), 0)
 	require_Len(t, len(mset.expectedPerSubjectInProcess), 0)
+}
+
+func TestJetStreamClusterMsgCounterRunningTotalConsistency(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:            "TEST",
+		Subjects:        []string{"foo"},
+		Storage:         FileStorage,
+		Retention:       LimitsPolicy,
+		Replicas:        3,
+		AllowMsgCounter: true,
+	})
+	require_NoError(t, err)
+
+	s := c.streamLeader(globalAccountName, "TEST")
+	acc, err := s.lookupAccount(globalAccountName)
+	require_NoError(t, err)
+	mset, err := acc.lookupStream("TEST")
+	require_NoError(t, err)
+
+	// Running total should be kept up-to-date.
+	mset.clMu.Lock()
+	mset.clusteredCounterTotal = map[string]*msgCounterRunningTotal{
+		"foo": {total: big.NewInt(10), ops: 1},
+	}
+	mset.clMu.Unlock()
+	m := nats.NewMsg("foo")
+	m.Header.Set("Nats-Incr", "1")
+	pubAck, err := js.PublishMsg(m)
+	require_NoError(t, err)
+	require_Equal(t, pubAck.Sequence, 1)
+
+	rsm, err := js.GetLastMsg("TEST", "foo")
+	require_NoError(t, err)
+	require_Equal(t, rsm.Sequence, 1)
+	require_Equal(t, string(rsm.Data), "{\"val\":\"11\"}")
+
+	// Confirm running total has properly been mutated.
+	total, ops := _EMPTY_, uint64(0)
+	mset.clMu.Lock()
+	if l := len(mset.clusteredCounterTotal); l != 1 {
+		mset.clMu.Unlock()
+		require_Len(t, l, 1)
+	}
+	if counter, ok := mset.clusteredCounterTotal["foo"]; !ok {
+		mset.clMu.Unlock()
+		t.Fatal("counter not found")
+	} else {
+		total = counter.total.String()
+		ops = counter.ops
+	}
+	mset.clMu.Unlock()
+	require_Equal(t, total, "11")
+	require_Equal(t, ops, 1)
+
+	// Reset. Running totals should be removed once all inflight counter operations are applied.
+	mset.clMu.Lock()
+	mset.clusteredCounterTotal = nil
+	mset.clMu.Unlock()
+	pubAck, err = js.PublishMsg(m)
+	require_NoError(t, err)
+	require_Equal(t, pubAck.Sequence, 2)
+
+	rsm, err = js.GetLastMsg("TEST", "foo")
+	require_NoError(t, err)
+	require_Equal(t, rsm.Sequence, 2)
+	require_Equal(t, string(rsm.Data), "{\"val\":\"12\"}")
+
+	// Should be cleaned up after publish.
+	mset.clMu.Lock()
+	defer mset.clMu.Unlock()
+	require_Len(t, len(mset.clusteredCounterTotal), 0)
 }
 
 func TestJetStreamClusterConsistencyAfterLeaderChange(t *testing.T) {

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -242,6 +242,21 @@ const (
 	// JSMemoryResourcesExceededErr insufficient memory resources available
 	JSMemoryResourcesExceededErr ErrorIdentifier = 10028
 
+	// JSMessageCounterBrokenErr message counter is broken
+	JSMessageCounterBrokenErr ErrorIdentifier = 10172
+
+	// JSMessageIncrDisabledErr message counters is disabled
+	JSMessageIncrDisabledErr ErrorIdentifier = 10168
+
+	// JSMessageIncrInvalidErr message counter increment is invalid
+	JSMessageIncrInvalidErr ErrorIdentifier = 10171
+
+	// JSMessageIncrMissingErr message counter increment is missing
+	JSMessageIncrMissingErr ErrorIdentifier = 10169
+
+	// JSMessageIncrPayloadErr message counter has payload
+	JSMessageIncrPayloadErr ErrorIdentifier = 10170
+
 	// JSMessageTTLDisabledErr per-message TTL is disabled
 	JSMessageTTLDisabledErr ErrorIdentifier = 10166
 
@@ -268,6 +283,9 @@ const (
 
 	// JSMirrorOverlappingSubjectFilters mirror subject filters can not overlap
 	JSMirrorOverlappingSubjectFilters ErrorIdentifier = 10152
+
+	// JSMirrorWithCountersErr stream mirrors can not also calculate counters
+	JSMirrorWithCountersErr ErrorIdentifier = 10173
 
 	// JSMirrorWithFirstSeqErr stream mirrors can not have first sequence configured
 	JSMirrorWithFirstSeqErr ErrorIdentifier = 10143
@@ -585,6 +603,11 @@ var (
 		JSMaximumConsumersLimitErr:                 {Code: 400, ErrCode: 10026, Description: "maximum consumers limit reached"},
 		JSMaximumStreamsLimitErr:                   {Code: 400, ErrCode: 10027, Description: "maximum number of streams reached"},
 		JSMemoryResourcesExceededErr:               {Code: 500, ErrCode: 10028, Description: "insufficient memory resources available"},
+		JSMessageCounterBrokenErr:                  {Code: 400, ErrCode: 10172, Description: "message counter is broken"},
+		JSMessageIncrDisabledErr:                   {Code: 400, ErrCode: 10168, Description: "message counters is disabled"},
+		JSMessageIncrInvalidErr:                    {Code: 400, ErrCode: 10171, Description: "message counter increment is invalid"},
+		JSMessageIncrMissingErr:                    {Code: 400, ErrCode: 10169, Description: "message counter increment is missing"},
+		JSMessageIncrPayloadErr:                    {Code: 400, ErrCode: 10170, Description: "message counter has payload"},
 		JSMessageTTLDisabledErr:                    {Code: 400, ErrCode: 10166, Description: "per-message TTL is disabled"},
 		JSMessageTTLInvalidErr:                     {Code: 400, ErrCode: 10165, Description: "invalid per-message TTL"},
 		JSMirrorConsumerSetupFailedErrF:            {Code: 500, ErrCode: 10029, Description: "{err}"},
@@ -594,6 +617,7 @@ var (
 		JSMirrorMaxMessageSizeTooBigErr:            {Code: 400, ErrCode: 10030, Description: "stream mirror must have max message size >= source"},
 		JSMirrorMultipleFiltersNotAllowed:          {Code: 400, ErrCode: 10150, Description: "mirror with multiple subject transforms cannot also have a single subject filter"},
 		JSMirrorOverlappingSubjectFilters:          {Code: 400, ErrCode: 10152, Description: "mirror subject filters can not overlap"},
+		JSMirrorWithCountersErr:                    {Code: 400, ErrCode: 10173, Description: "stream mirrors can not also calculate counters"},
 		JSMirrorWithFirstSeqErr:                    {Code: 400, ErrCode: 10143, Description: "stream mirrors can not have first sequence configured"},
 		JSMirrorWithSourcesErr:                     {Code: 400, ErrCode: 10031, Description: "stream mirrors can not also contain other sources"},
 		JSMirrorWithStartSeqAndTimeErr:             {Code: 400, ErrCode: 10032, Description: "stream mirrors can not have both start seq and start time configured"},
@@ -1559,6 +1583,56 @@ func NewJSMemoryResourcesExceededError(opts ...ErrorOption) *ApiError {
 	return ApiErrors[JSMemoryResourcesExceededErr]
 }
 
+// NewJSMessageCounterBrokenError creates a new JSMessageCounterBrokenErr error: "message counter is broken"
+func NewJSMessageCounterBrokenError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMessageCounterBrokenErr]
+}
+
+// NewJSMessageIncrDisabledError creates a new JSMessageIncrDisabledErr error: "message counters is disabled"
+func NewJSMessageIncrDisabledError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMessageIncrDisabledErr]
+}
+
+// NewJSMessageIncrInvalidError creates a new JSMessageIncrInvalidErr error: "message counter increment is invalid"
+func NewJSMessageIncrInvalidError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMessageIncrInvalidErr]
+}
+
+// NewJSMessageIncrMissingError creates a new JSMessageIncrMissingErr error: "message counter increment is missing"
+func NewJSMessageIncrMissingError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMessageIncrMissingErr]
+}
+
+// NewJSMessageIncrPayloadError creates a new JSMessageIncrPayloadErr error: "message counter has payload"
+func NewJSMessageIncrPayloadError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMessageIncrPayloadErr]
+}
+
 // NewJSMessageTTLDisabledError creates a new JSMessageTTLDisabledErr error: "per-message TTL is disabled"
 func NewJSMessageTTLDisabledError(opts ...ErrorOption) *ApiError {
 	eopts := parseOpts(opts)
@@ -1665,6 +1739,16 @@ func NewJSMirrorOverlappingSubjectFiltersError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSMirrorOverlappingSubjectFilters]
+}
+
+// NewJSMirrorWithCountersError creates a new JSMirrorWithCountersErr error: "stream mirrors can not also calculate counters"
+func NewJSMirrorWithCountersError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMirrorWithCountersErr]
 }
 
 // NewJSMirrorWithFirstSeqError creates a new JSMirrorWithFirstSeqErr error: "stream mirrors can not have first sequence configured"

--- a/server/jetstream_versioning.go
+++ b/server/jetstream_versioning.go
@@ -45,6 +45,11 @@ func setStaticStreamMetadata(cfg *StreamConfig) {
 		requires(1)
 	}
 
+	// Counter CRDTs were added in v2.12 and require API level 2.
+	if cfg.AllowMsgCounter {
+		requires(2)
+	}
+
 	cfg.Metadata[JSRequiredLevelMetadataKey] = strconv.Itoa(requiredApiLevel)
 }
 

--- a/server/jetstream_versioning_test.go
+++ b/server/jetstream_versioning_test.go
@@ -72,6 +72,11 @@ func TestJetStreamSetStaticStreamMetadata(t *testing.T) {
 			cfg:              &StreamConfig{SubjectDeleteMarkerTTL: time.Second},
 			expectedMetadata: metadataAtLevel("1"),
 		},
+		{
+			desc:             "AllowMsgCounter",
+			cfg:              &StreamConfig{AllowMsgCounter: true},
+			expectedMetadata: metadataAtLevel("2"),
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			setStaticStreamMetadata(test.cfg)

--- a/server/stream.go
+++ b/server/stream.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/big"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -109,6 +110,9 @@ type StreamConfig struct {
 	// subject delete markers.
 	SubjectDeleteMarkerTTL time.Duration `json:"subject_delete_marker_ttl,omitempty"`
 
+	// AllowMsgCounter allows a stream to use (only) counter CRDTs.
+	AllowMsgCounter bool `json:"allow_msg_counter"`
+
 	// Metadata is additional metadata for the Stream.
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
@@ -189,6 +193,13 @@ type PubAck struct {
 	Sequence  uint64 `json:"seq"`
 	Domain    string `json:"domain,omitempty"`
 	Duplicate bool   `json:"duplicate,omitempty"`
+	Value     string `json:"val,omitempty"`
+}
+
+// CounterValue is the body of a message when used as a counter.
+// e.g. {"val":"123"}
+type CounterValue struct {
+	Value string `json:"val"`
 }
 
 // StreamInfo shows config and current state for this stream.
@@ -367,14 +378,22 @@ type stream struct {
 	uch       chan struct{}     // The channel to signal updates to the monitor routine.
 	inMonitor bool              // True if the monitor routine has been started.
 
-	expectedPerSubjectSequence  map[uint64]string   // Inflight 'expected per subject' subjects per clseq.
-	expectedPerSubjectInProcess map[string]struct{} // Current 'expected per subject' subjects in process.
+	clusteredCounterTotal       map[string]*msgCounterRunningTotal // Inflight counter totals.
+	expectedPerSubjectSequence  map[uint64]string                  // Inflight 'expected per subject' subjects per clseq.
+	expectedPerSubjectInProcess map[string]struct{}                // Current 'expected per subject' subjects in process.
 
 	// Direct get subscription.
 	directSub *subscription
 	lastBySub *subscription
 
 	monitorWg sync.WaitGroup // Wait group for the monitor routine.
+}
+
+// msgCounterRunningTotal stores a running total and a number of inflight
+// but not yet applied clustered proposals/operations for this counter.
+type msgCounterRunningTotal struct {
+	total *big.Int // Running total.
+	ops   uint64   // Inflight operations. If this reaches zero, we can remove the running total.
 }
 
 type sourceInfo struct {
@@ -430,6 +449,7 @@ const (
 	JSResponseType            = "Nats-Response-Type"
 	JSMessageTTL              = "Nats-TTL"
 	JSMarkerReason            = "Nats-Marker-Reason"
+	JSMessageIncr             = "Nats-Incr"
 )
 
 // Headers for republished messages and direct gets.
@@ -1389,6 +1409,19 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 		return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("roll-ups require the purge permission"))
 	}
 
+	// Counter is not compatible with some settings.
+	if cfg.AllowMsgCounter {
+		if cfg.Discard == DiscardNew {
+			return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("counter stream cannot use discard new"))
+		}
+		if cfg.AllowMsgTTL {
+			return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("counter stream cannot use message TTLs"))
+		}
+		if cfg.Retention != LimitsPolicy {
+			return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("counter stream can only use limits retention"))
+		}
+	}
+
 	// Check for new discard new per subject, we require the discard policy to also be new.
 	if cfg.DiscardNewPer {
 		if cfg.Discard != DiscardNew {
@@ -1457,6 +1490,9 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 		}
 		if len(cfg.Sources) > 0 {
 			return StreamConfig{}, NewJSMirrorWithSourcesError()
+		}
+		if cfg.AllowMsgCounter {
+			return StreamConfig{}, NewJSMirrorWithCountersError()
 		}
 		if cfg.Mirror.FilterSubject != _EMPTY_ && len(cfg.Mirror.SubjectTransforms) != 0 {
 			return StreamConfig{}, NewJSMirrorMultipleFiltersNotAllowedError()
@@ -1859,6 +1895,11 @@ func (jsa *jsAccount) configUpdateCheck(old, new *StreamConfig, s *Server, pedan
 	// Check on the allowed message TTL status.
 	if old.AllowMsgTTL && !cfg.AllowMsgTTL {
 		return nil, NewJSStreamInvalidConfigError(fmt.Errorf("message TTL status can not be disabled"))
+	}
+
+	// Can't change counter setting.
+	if cfg.AllowMsgCounter != old.AllowMsgCounter {
+		return nil, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration update can not change message counter setting"))
 	}
 
 	// Do some adjustments for being sealed.
@@ -4414,6 +4455,17 @@ func parseMessageTTL(ttl string) (int64, error) {
 	return t, nil
 }
 
+// Fast lookup of the message Incr from headers.
+// Return includes the value or nil, and success.
+func getMessageIncr(hdr []byte) (*big.Int, bool) {
+	incr := getHeader(JSMessageIncr, hdr)
+	if len(incr) == 0 {
+		return nil, true
+	}
+	var v big.Int
+	return v.SetString(bytesToString(incr), 10)
+}
+
 // Signal if we are clustered. Will acquire rlock.
 func (mset *stream) IsClustered() bool {
 	mset.mu.RLock()
@@ -4888,15 +4940,16 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 	maxMsgSize := int(mset.cfg.MaxMsgSize)
 	numConsumers := len(mset.consumers)
 	interestRetention := mset.cfg.Retention == InterestPolicy
+	allowMsgCounter := mset.cfg.AllowMsgCounter
 	// Snapshot if we are the leader and if we can respond.
 	isLeader, isSealed := mset.isLeaderNodeState(), mset.cfg.Sealed
 	canRespond := doAck && len(reply) > 0 && isLeader
+	outq := mset.outq
 
 	var resp = &JSPubAckResponse{}
 
 	// Bail here if sealed.
 	if isSealed {
-		outq := mset.outq
 		mset.mu.Unlock()
 		bumpCLFS()
 		if canRespond && outq != nil {
@@ -4936,7 +4989,6 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 			}
 			// Really is a mismatch.
 			if isMisMatch {
-				outq := mset.outq
 				mset.mu.Unlock()
 				if canRespond && outq != nil {
 					resp.PubAck = &PubAck{Stream: name}
@@ -4957,16 +5009,83 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 
 	// Process additional msg headers if still present.
 	var msgId string
+	var incr *big.Int
 	var rollupSub, rollupAll bool
 	isClustered := mset.isClustered()
 
 	if len(hdr) > 0 {
-		outq := mset.outq
 
 		// Certain checks have already been performed if in clustered mode, so only check if not.
 		// Note, for cluster mode but with message tracing (without message delivery), we need
 		// to do this check here since it was not done in processClusteredInboundMsg().
 		if !isClustered || traceOnly {
+			// Counter increments.
+			// Only supported on counter streams, and payload must be empty (if not coming from a source).
+			var ok bool
+			if incr, ok = getMessageIncr(hdr); !ok {
+				mset.mu.Unlock()
+				bumpCLFS()
+				apiErr := NewJSMessageIncrInvalidError()
+				if canRespond {
+					resp.PubAck = &PubAck{Stream: name}
+					resp.Error = apiErr
+					b, _ := json.Marshal(resp)
+					outq.sendMsg(reply, b)
+				}
+				return apiErr
+			} else if incr != nil && !sourced {
+				// Only do checks if the message isn't sourced. Otherwise, we need to store verbatim.
+				if !allowMsgCounter {
+					mset.mu.Unlock()
+					bumpCLFS()
+					apiErr := NewJSMessageIncrDisabledError()
+					if canRespond {
+						resp.PubAck = &PubAck{Stream: name}
+						resp.Error = apiErr
+						b, _ := json.Marshal(resp)
+						outq.sendMsg(reply, b)
+					}
+					return apiErr
+				} else if len(msg) > 0 {
+					mset.mu.Unlock()
+					bumpCLFS()
+					apiErr := NewJSMessageIncrPayloadError()
+					if canRespond {
+						resp.PubAck = &PubAck{Stream: name}
+						resp.Error = apiErr
+						b, _ := json.Marshal(resp)
+						outq.sendMsg(reply, b)
+					}
+					return apiErr
+				} else {
+					// Check for incompatible headers.
+					var doErr bool
+					if getRollup(hdr) != _EMPTY_ ||
+						getExpectedStream(hdr) != _EMPTY_ ||
+						getExpectedLastMsgId(hdr) != _EMPTY_ ||
+						getExpectedLastSeqPerSubjectForSubject(hdr) != _EMPTY_ {
+						doErr = true
+					} else if _, ok := getExpectedLastSeq(hdr); ok {
+						doErr = true
+					} else if _, ok := getExpectedLastSeqPerSubject(hdr); ok {
+						doErr = true
+					}
+
+					if doErr {
+						mset.mu.Unlock()
+						bumpCLFS()
+						apiErr := NewJSMessageIncrInvalidError()
+						if canRespond {
+							resp.PubAck = &PubAck{Stream: name}
+							resp.Error = apiErr
+							b, _ := json.Marshal(resp)
+							outq.sendMsg(reply, b)
+						}
+						return apiErr
+					}
+				}
+			}
+
 			// Expected stream.
 			if sname := getExpectedStream(hdr); sname != _EMPTY_ && sname != name {
 				mset.mu.Unlock()
@@ -5118,12 +5237,66 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		}
 	}
 
+	if !isClustered && incr == nil && allowMsgCounter {
+		mset.mu.Unlock()
+		// FIXME(mvv): we're not clustered, does bumping CLFS result in issues?
+		bumpCLFS()
+		apiErr := NewJSMessageIncrMissingError()
+		if canRespond {
+			resp.PubAck = &PubAck{Stream: name}
+			resp.Error = apiErr
+			b, _ := json.Marshal(resp)
+			outq.sendMsg(reply, b)
+		}
+		return apiErr
+	}
+
 	// Response Ack.
 	var (
 		response []byte
 		seq      uint64
 		err      error
 	)
+
+	// Apply increment for counter.
+	// But only if it's allowed for this stream. This can happen when we store verbatim for a sourced stream.
+	if !isClustered && incr != nil && allowMsgCounter {
+		var smv StoreMsg
+		sm, err := store.LoadLastMsg(subject, &smv)
+		if err == nil && sm != nil {
+			var val CounterValue
+			// Return an error if the counter is broken somehow.
+			if json.Unmarshal(sm.msg, &val) != nil {
+				mset.mu.Unlock()
+				bumpCLFS()
+				apiErr := NewJSMessageCounterBrokenError()
+				if canRespond {
+					resp.PubAck = &PubAck{Stream: name}
+					resp.Error = apiErr
+					b, _ := json.Marshal(resp)
+					outq.sendMsg(reply, b)
+				}
+				return apiErr
+			}
+			var initial big.Int
+			initial.SetString(val.Value, 10)
+			incr.Add(incr, &initial)
+		}
+		msg = []byte(fmt.Sprintf("{%q:%q}", "val", incr.String()))
+
+		// Check to see if we are over the max msg size.
+		if int32(len(hdr)+len(msg)) > mset.srv.getOpts().MaxPayload {
+			mset.mu.Unlock()
+			bumpCLFS()
+			if canRespond {
+				resp.PubAck = &PubAck{Stream: name}
+				resp.Error = NewJSStreamMessageExceedsMaximumError()
+				response, _ = json.Marshal(resp)
+				outq.sendMsg(reply, response)
+			}
+			return ErrMaxPayload
+		}
+	}
 
 	// Check to see if we are over the max msg size.
 	if maxMsgSize >= 0 && (len(hdr)+len(msg)) > maxMsgSize {
@@ -5133,7 +5306,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 			resp.PubAck = &PubAck{Stream: name}
 			resp.Error = NewJSStreamMessageExceedsMaximumError()
 			response, _ = json.Marshal(resp)
-			mset.outq.sendMsg(reply, response)
+			outq.sendMsg(reply, response)
 		}
 		return ErrMaxPayload
 	}
@@ -5145,7 +5318,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 			resp.PubAck = &PubAck{Stream: name}
 			resp.Error = NewJSStreamHeaderExceedsMaximumError()
 			response, _ = json.Marshal(resp)
-			mset.outq.sendMsg(reply, response)
+			outq.sendMsg(reply, response)
 		}
 		return ErrMaxPayload
 	}
@@ -5159,7 +5332,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 			resp.PubAck = &PubAck{Stream: name}
 			resp.Error = NewJSInsufficientResourcesError()
 			response, _ = json.Marshal(resp)
-			mset.outq.sendMsg(reply, response)
+			outq.sendMsg(reply, response)
 		}
 		// Stepdown regardless.
 		if node := mset.raftNode(); node != nil {
@@ -5199,7 +5372,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		if canRespond {
 			response = append(pubAck, strconv.FormatUint(mset.lseq, 10)...)
 			response = append(response, '}')
-			mset.outq.sendMsg(reply, response)
+			outq.sendMsg(reply, response)
 		}
 		mset.mu.Unlock()
 		return nil
@@ -5243,7 +5416,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 				resp.PubAck = &PubAck{Stream: name}
 				resp.Error = err
 				response, _ = json.Marshal(resp)
-				mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+				outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
 			}
 			mset.mu.Unlock()
 			return err
@@ -5257,7 +5430,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 			resp.PubAck = &PubAck{Stream: name}
 			resp.Error = NewJSMessageTTLInvalidError()
 			response, _ = json.Marshal(resp)
-			mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
 		}
 		mset.mu.Unlock()
 		return err
@@ -5314,7 +5487,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 			resp.PubAck = &PubAck{Stream: name}
 			resp.Error = NewJSStreamStoreFailedError(err, Unless(err))
 			response, _ = json.Marshal(resp)
-			mset.outq.sendMsg(reply, response)
+			outq.sendMsg(reply, response)
 		}
 		return err
 	}
@@ -5370,14 +5543,19 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 				hdr = fmt.Appendf(hdr[:end:end], htho[hoff:], name, subject, seq, tsStr, tlseq, len(msg))
 			}
 		}
-		mset.outq.send(newJSPubMsg(tsubj, _EMPTY_, _EMPTY_, hdr, rpMsg, nil, seq))
+		outq.send(newJSPubMsg(tsubj, _EMPTY_, _EMPTY_, hdr, rpMsg, nil, seq))
 	}
 
 	// Send response here.
 	if canRespond {
 		response = append(pubAck, strconv.FormatUint(seq, 10)...)
+		if allowMsgCounter {
+			var counter CounterValue
+			json.Unmarshal(msg, &counter)
+			response = append(response, fmt.Sprintf(",\"val\":%q", counter.Value)...)
+		}
 		response = append(response, '}')
-		mset.outq.sendMsg(reply, response)
+		outq.sendMsg(reply, response)
 	}
 
 	// Signal consumers for new messages.

--- a/server/stream.go
+++ b/server/stream.go
@@ -4464,7 +4464,7 @@ func parseMessageTTL(ttl string) (int64, error) {
 // Fast lookup of the message Incr from headers.
 // Return includes the value or nil, and success.
 func getMessageIncr(hdr []byte) (*big.Int, bool) {
-	incr := getHeader(JSMessageIncr, hdr)
+	incr := sliceHeader(JSMessageIncr, hdr)
 	if len(incr) == 0 {
 		return nil, true
 	}
@@ -5286,7 +5286,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 				}
 				return apiErr
 			}
-			if ncs := getHeader(JSMessageCounterSources, sm.hdr); len(ncs) > 0 {
+			if ncs := sliceHeader(JSMessageCounterSources, sm.hdr); len(ncs) > 0 {
 				if err := json.Unmarshal(ncs, &sources); err != nil {
 					mset.mu.Unlock()
 					bumpCLFS()
@@ -5346,7 +5346,8 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		// Now make the change.
 		initial.Add(&initial, incr)
 		// Generate the new payload.
-		msg = fmt.Appendf(nil, "{%q:%q}", "val", initial.String())
+		var _msg [128]byte
+		msg = fmt.Appendf(_msg[:0], "{%q:%q}", "val", initial.String())
 		// Write the updated source count headers.
 		if len(sources) > 0 {
 			nhdr, err := json.Marshal(sources)


### PR DESCRIPTION
Implement a counter CRDT based on [ADR 49](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-49.md).

R1 is pretty straightforward, enable `AllowMsgCounter`, and publish using `Nats-Incr` headers. R3 is also straightforward from the user's perspective, it works exactly the same, but in terms of replication we need to keep a running count if a single counter is rapidly updated by multiple processes such that there are multiple but not yet applied proposals and can continue counting without needing to block or error.

Additionally, Mirrors can do verbatim copies. Sources can do verbatim copies if `AllowMsgCounter` is disabled. Sources can aggregate counters if `AllowMsgCounter` is enabled.

Resolves https://github.com/nats-io/nats-server/issues/6560

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>