### PR TITLE
[FIXED] Data race on copy stream metadata

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -543,8 +543,12 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 			s.setIndexName()
 		}
 
+		// Hold lock, because we'll be reading from and writing to a shared object.
+		js.mu.Lock()
 		copyStreamMetadata(cfg, &ocfg)
-		if reflect.DeepEqual(cfg, &ocfg) {
+		deepEqual := reflect.DeepEqual(cfg, &ocfg)
+		js.mu.Unlock()
+		if deepEqual {
 			if sa != nil {
 				mset.setStreamAssignment(sa)
 			}


### PR DESCRIPTION
There was a data race between writing stream metadata in `copyStreamMetadata` and the reading using `reflect.DeepEqual`.

```
WARNING: DATA RACE
Write at 0x00c0002a0c30 by goroutine 227:
  runtime.mapdelete_faststr()
      /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.7.linux-amd64/src/runtime/map_faststr.go:321 +0x0
  github.com/nats-io/nats-server/v2/server.deleteDynamicMetadata()
      server/jetstream_versioning.go:177 +0xa8
  github.com/nats-io/nats-server/v2/server.copyStreamMetadata()
      server/jetstream_versioning.go:70 +0x66
  github.com/nats-io/nats-server/v2/server.(*Account).addStreamWithAssignment()
      server/stream.go:537 +0x46e9
  github.com/nats-io/nats-server/v2/server.(*jetStream).processClusterCreateStream()
      server/jetstream_cluster.go:3842 +0x1b24
  github.com/nats-io/nats-server/v2/server.(*stream).resetClusteredState.func3()
      server/jetstream_cluster.go:2887 +0x4a4

Previous write at 0x00c0002a0c30 by goroutine 230:
  runtime.mapassign_faststr()
      /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.7.linux-amd64/src/runtime/map_faststr.go:223 +0x0
  github.com/nats-io/nats-server/v2/server.setOrDeleteInStreamMetadata()
      server/jetstream_versioning.go:82 +0x1d3
  github.com/nats-io/nats-server/v2/server.copyStreamMetadata()
      server/jetstream_versioning.go:72 +0xf7
  github.com/nats-io/nats-server/v2/server.(*Account).addStreamWithAssignment()
      server/stream.go:537 +0x46e9
  github.com/nats-io/nats-server/v2/server.(*jetStream).processClusterCreateStream()
      server/jetstream_cluster.go:3842 +0x1b24
  github.com/nats-io/nats-server/v2/server.(*stream).resetClusteredState.func3()
      server/jetstream_cluster.go:2887 +0x4a4
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
