### PR TITLE
NRG: Fix integer overflow on 32-bit platforms

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -88,8 +88,11 @@ jobs:
         with:
           go-version: stable
 
-      - name: Build NATS Server
-        run: go build
+      - name: Build NATS Server 64-bit
+        run: GOARCH=amd64 GOOS=linux go build
+
+      - name: Build NATS Server 32-bit
+        run: GOARCH=386 GOOS=linux go build
 
   build-supported:
     name: Build (Minimum Go)
@@ -103,8 +106,11 @@ jobs:
         with:
           go-version-file: "go.mod"
 
-      - name: Build NATS Server
-        run: go build
+      - name: Build NATS Server 64-bit
+        run: GOARCH=amd64 GOOS=linux go build
+
+      - name: Build NATS Server 32-bit
+        run: GOARCH=386 GOOS=linux go build
 
   # Using GitHub-supplied workers for Windows for now.
   # Note that the below testing steps depend on the Linux build


### PR DESCRIPTION
This PR fixes an integer overflow that would happen only on 32-bit architectures. It also improves the `elen` counting in the Raft code to do the right thing on both 32-bit and 64-bit architectures.

Also adds 32-bit build checks into CI so this kind of thing doesn't sneak in again.

Signed-off-by: Neil Twigg <neil@nats.io>