### PR TITLE
(2.12) Source-aware counter CRDT

### DIFF
--- a/server/jetstream_benchmark_test.go
+++ b/server/jetstream_benchmark_test.go
@@ -16,6 +16,7 @@
 package server
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -900,6 +901,262 @@ func BenchmarkJetStreamPublish(b *testing.B) {
 				}
 			},
 		)
+	}
+}
+
+func BenchmarkJetStreamCounters(b *testing.B) {
+	const (
+		verbose    = false
+		seed       = 12345
+		streamName = "S"
+	)
+
+	// We don't actually create real sourcing streams, we just populate
+	// the Nats-Counter-Sources header to make it look like we have some,
+	// so that we can see how the code performs for bringing forward the
+	// latest headers each time.
+	generateSources := func(t testing.TB, count int) string {
+		t.Helper()
+		sources := CounterSources{}
+		for i := range count {
+			streamName := fmt.Sprintf("STREAM_%d", i%10)
+			subjectName := fmt.Sprintf("subject.%d", i)
+			if sources[streamName] == nil {
+				sources[streamName] = map[string]string{}
+			}
+			sources[streamName][subjectName] = "12345"
+		}
+		j, err := json.Marshal(sources)
+		require_NoError(t, err)
+		return string(j)
+	}
+
+	runSyncPublisher := func(b *testing.B, js nats.JetStreamContext, subjects []string, sources int) (int, int) {
+		published, errors := 0, 0
+		msg := &nats.Msg{
+			Header: nats.Header{},
+		}
+		msg.Header.Set(JSMessageIncr, "1")
+		if sources > 0 {
+			msg.Header.Set(JSMessageCounterSources, generateSources(b, sources))
+		}
+		b.ResetTimer()
+
+		for i := 1; i <= b.N; i++ {
+			msg.Subject = subjects[fastrand.Uint32n(uint32(len(subjects)))]
+			if _, pubErr := js.PublishMsg(msg); pubErr != nil {
+				errors++
+			} else {
+				published++
+			}
+
+			if verbose && i%1000 == 0 {
+				b.Logf("Published %d/%d, %d errors", i, b.N, errors)
+			}
+		}
+
+		b.StopTimer()
+		return published, errors
+	}
+
+	runAsyncPublisher := func(b *testing.B, js nats.JetStreamContext, subjects []string, sources int, asyncWindow int) (int, int) {
+		const publishCompleteMaxWait = 30 * time.Second
+		msg := &nats.Msg{
+			Header: nats.Header{},
+		}
+		msg.Header.Set(JSMessageIncr, "1")
+		if sources > 0 {
+			msg.Header.Set(JSMessageCounterSources, generateSources(b, sources))
+		}
+		published, errors := 0, 0
+		b.ResetTimer()
+
+		for published < b.N {
+			// Normally publish a full batch (of size `asyncWindow`)
+			publishBatchSize := min(b.N-published, asyncWindow)
+			pending := make([]nats.PubAckFuture, 0, publishBatchSize)
+
+			for range publishBatchSize {
+				msg.Subject = subjects[fastrand.Uint32n(uint32(len(subjects)))]
+				pubAckFuture, err := js.PublishMsgAsync(msg)
+				if err != nil {
+					errors++
+					continue
+				}
+				pending = append(pending, pubAckFuture)
+			}
+
+			// All in this batch published, wait for completed
+			select {
+			case <-js.PublishAsyncComplete():
+			case <-time.After(publishCompleteMaxWait):
+				b.Fatalf("Publish timed out")
+			}
+
+			// Verify one by one if they were published successfully
+			for _, pubAckFuture := range pending {
+				select {
+				case <-pubAckFuture.Ok():
+					published++
+				case <-pubAckFuture.Err():
+					errors++
+				default:
+					b.Fatalf("PubAck is still pending after publish completed")
+				}
+			}
+
+			if verbose {
+				b.Logf("Published %d/%d", published, b.N)
+			}
+		}
+
+		b.StopTimer()
+		return published, errors
+	}
+
+	type PublishType string
+	const (
+		Sync  PublishType = "Sync"
+		Async PublishType = "Async"
+	)
+
+	type benchmarksCase struct {
+		storageType StorageType
+		clusterSize int
+		replicas    int
+		numSubjects int
+		sources     int
+	}
+	var benchmarksCases []benchmarksCase
+	for _, storage := range []StorageType{FileStorage, MemoryStorage} {
+		for _, replicas := range []int{1, 3} {
+			for _, numSubjects := range []int{1, 1000} {
+				for _, sources := range []int{0, 10, 25, 250} {
+					benchmarksCases = append(benchmarksCases, benchmarksCase{
+						storageType: storage,
+						clusterSize: 3,
+						replicas:    replicas,
+						numSubjects: numSubjects,
+						sources:     sources,
+					})
+				}
+			}
+		}
+	}
+
+	// All the cases above are run with each of the publisher cases below
+	publisherCases := []struct {
+		pType       PublishType
+		asyncWindow int
+	}{
+		{Sync, -1},
+		{Async, 1000},
+		{Async, 4000},
+		{Async, 8000},
+	}
+
+	for _, bc := range benchmarksCases {
+		name := fmt.Sprintf(
+			"S=%s,N=%d,R=%d,Subjs=%d,Srcs=%d",
+			bc.storageType,
+			bc.clusterSize,
+			bc.replicas,
+			bc.numSubjects,
+			bc.sources,
+		)
+
+		b.Run(name, func(b *testing.B) {
+			for _, pc := range publisherCases {
+				name := fmt.Sprintf("%v", pc.pType)
+				if pc.pType == Async && pc.asyncWindow > 0 {
+					name = fmt.Sprintf("%s[W:%d]", name, pc.asyncWindow)
+				}
+
+				b.Run(name, func(b *testing.B) {
+					subjects := make([]string, bc.numSubjects)
+					for i := range bc.numSubjects {
+						subjects[i] = fmt.Sprintf("s-%d", i+1)
+					}
+
+					if verbose {
+						b.Logf("Running %s with %d ops", name, b.N)
+					}
+
+					if verbose {
+						b.Logf("Setting up %d nodes", bc.clusterSize)
+					}
+
+					cl, _, shutdown, nc, _ := startJSClusterAndConnect(b, bc.clusterSize)
+					defer shutdown()
+					defer nc.Close()
+
+					jsOpts := []nats.JSOpt{
+						nats.MaxWait(10 * time.Second),
+					}
+
+					if pc.asyncWindow > 0 && pc.pType == Async {
+						jsOpts = append(jsOpts, nats.PublishAsyncMaxPending(pc.asyncWindow))
+					}
+
+					js, err := nc.JetStream(jsOpts...)
+					if err != nil {
+						b.Fatalf("Unexpected error getting JetStream context: %v", err)
+					}
+
+					if verbose {
+						b.Logf("Creating stream with R=%d and %d input subjects", bc.replicas, bc.numSubjects)
+					}
+					if _, err := jsStreamCreate(b, nc, &StreamConfig{
+						Name:            streamName,
+						Storage:         bc.storageType,
+						Subjects:        subjects,
+						Replicas:        bc.replicas,
+						AllowMsgCounter: true,
+					}); err != nil {
+						b.Fatalf("Error creating stream: %v", err)
+					}
+
+					// If replicated resource, connect to stream leader for lower variability
+					if bc.replicas > 1 {
+						connectURL := cl.streamLeader("$G", streamName).ClientURL()
+						nc.Close()
+						nc, err = nats.Connect(connectURL)
+						if err != nil {
+							b.Fatalf("Failed to create client connection to stream leader: %v", err)
+						}
+						defer nc.Close()
+						js, err = nc.JetStream(jsOpts...)
+						if err != nil {
+							b.Fatalf("Unexpected error getting JetStream context for stream leader: %v", err)
+						}
+					}
+
+					if verbose {
+						b.Logf("Running %v publisher", pc.pType)
+					}
+
+					// Benchmark starts here
+					b.ResetTimer()
+
+					var published, errors int
+					switch pc.pType {
+					case Sync:
+						published, errors = runSyncPublisher(b, js, subjects, bc.sources)
+					case Async:
+						published, errors = runAsyncPublisher(b, js, subjects, bc.sources, pc.asyncWindow)
+					}
+
+					// Benchmark ends here
+					b.StopTimer()
+
+					if published+errors != b.N {
+						b.Fatalf("Something doesn't add up: %d + %d != %d", published, errors, b.N)
+					}
+
+					b.ReportMetric(float64(errors)*100/float64(b.N), "%error")
+				})
+			}
+		})
 	}
 }
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8226,7 +8226,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 					}
 					return apiErr
 				}
-				if ncs := getHeader(JSMessageCounterSources, sm.hdr); len(ncs) > 0 {
+				if ncs := sliceHeader(JSMessageCounterSources, sm.hdr); len(ncs) > 0 {
 					if err := json.Unmarshal(ncs, &sources); err != nil {
 						mset.clMu.Unlock()
 						apiErr := NewJSMessageCounterBrokenError()
@@ -8285,7 +8285,8 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 		// Now make the change.
 		initial.Add(&initial, incr)
 		// Generate the new payload.
-		msg = fmt.Appendf(nil, "{%q:%q}", "val", initial.String())
+		var _msg [128]byte
+		msg = fmt.Appendf(_msg[:0], "{%q:%q}", "val", initial.String())
 		// Write the updated source count headers.
 		if len(sources) > 0 {
 			nhdr, err := json.Marshal(sources)

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -4813,7 +4813,9 @@ func TestJetStreamClusterMsgCounterRunningTotalConsistency(t *testing.T) {
 	rsm, err := js.GetLastMsg("TEST", "foo")
 	require_NoError(t, err)
 	require_Equal(t, rsm.Sequence, 1)
-	require_Equal(t, string(rsm.Data), "{\"val\":\"11\"}")
+	var count CounterValue
+	require_NoError(t, json.Unmarshal(rsm.Data, &count))
+	require_Equal(t, count.Value, "11")
 
 	// Confirm running total has properly been mutated.
 	total, ops := _EMPTY_, uint64(0)
@@ -4844,7 +4846,8 @@ func TestJetStreamClusterMsgCounterRunningTotalConsistency(t *testing.T) {
 	rsm, err = js.GetLastMsg("TEST", "foo")
 	require_NoError(t, err)
 	require_Equal(t, rsm.Sequence, 2)
-	require_Equal(t, string(rsm.Data), "{\"val\":\"12\"}")
+	require_NoError(t, json.Unmarshal(rsm.Data, &count))
+	require_Equal(t, count.Value, "12")
 
 	// Should be cleaned up after publish.
 	mset.clMu.Lock()

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -20446,7 +20446,10 @@ func TestJetStreamAllowMsgCounterMirror(t *testing.T) {
 			if incr := rsm.Header.Get("Nats-Incr"); incr != "1" {
 				return fmt.Errorf("incorrect increment: %q", incr)
 			}
-			if string(rsm.Data) != "{\"val\":\"1\"}" {
+			var count CounterValue
+			if err := json.Unmarshal(rsm.Data, &count); err != nil {
+				return fmt.Errorf("JSON error: %w", err)
+			} else if count.Value != "1" {
 				return fmt.Errorf("unexpected value: %s", rsm.Data)
 			}
 			return nil
@@ -20528,7 +20531,10 @@ func TestJetStreamAllowMsgCounterSourceAggregates(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			if string(rsm.Data) != "{\"val\":\"3\"}" {
+			var count CounterValue
+			if err := json.Unmarshal(rsm.Data, &count); err != nil {
+				return fmt.Errorf("JSON error: %w", err)
+			} else if count.Value != "3" {
 				return fmt.Errorf("unexpected value: %s", rsm.Data)
 			}
 			return nil
@@ -20604,8 +20610,11 @@ func TestJetStreamAllowMsgCounterSourceVerbatim(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			if string(rsm.Data) != "{\"val\":\"1\"}" {
-				return fmt.Errorf("unexpected value #1: %s", rsm.Data)
+			var count CounterValue
+			if err := json.Unmarshal(rsm.Data, &count); err != nil {
+				return fmt.Errorf("JSON error: %w", err)
+			} else if count.Value != "1" {
+				return fmt.Errorf("unexpected value: %s", rsm.Data)
 			}
 			return nil
 		})
@@ -20622,11 +20631,164 @@ func TestJetStreamAllowMsgCounterSourceVerbatim(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			if string(rsm.Data) != "{\"val\":\"2\"}" {
-				return fmt.Errorf("unexpected value #2: %s", rsm.Data)
+			var count CounterValue
+			if err := json.Unmarshal(rsm.Data, &count); err != nil {
+				return fmt.Errorf("JSON error: %w", err)
+			} else if count.Value != "2" {
+				return fmt.Errorf("unexpected value: %s", rsm.Data)
 			}
 			return nil
 		})
+	}
+
+	t.Run("R1", func(t *testing.T) { test(t, 1) })
+	t.Run("R3", func(t *testing.T) { test(t, 3) })
+}
+
+func TestJetStreamAllowMsgCounterSourceStartingAboveZero(t *testing.T) {
+	test := func(t *testing.T, replicas int) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := jsStreamCreate(t, nc, &StreamConfig{
+			Name:            "O1",
+			Subjects:        []string{"foo.1"},
+			Storage:         FileStorage,
+			AllowMsgCounter: true,
+			Replicas:        replicas,
+			MaxMsgsPer:      1,
+		})
+		require_NoError(t, err)
+
+		_, err = jsStreamCreate(t, nc, &StreamConfig{
+			Name:            "O2",
+			Subjects:        []string{"foo.2"},
+			Storage:         FileStorage,
+			AllowMsgCounter: true,
+			Replicas:        replicas,
+			MaxMsgsPer:      1,
+		})
+		require_NoError(t, err)
+
+		for i := range uint64(5) {
+			m := nats.NewMsg("foo.1")
+			m.Header.Set("Nats-Incr", "1")
+			pubAck, err := js.PublishMsg(m)
+			require_NoError(t, err)
+			require_Equal(t, pubAck.Sequence, i+1)
+
+			m = nats.NewMsg("foo.2")
+			m.Header.Set("Nats-Incr", "2")
+			pubAck, err = js.PublishMsg(m)
+			require_NoError(t, err)
+			require_Equal(t, pubAck.Sequence, i+1)
+		}
+
+		// Source will only work if counters are enabled on both streams.
+		_, err = jsStreamCreate(t, nc, &StreamConfig{
+			Name:            "M",
+			Subjects:        []string{"foo"},
+			Storage:         FileStorage,
+			AllowMsgCounter: true,
+			Replicas:        replicas,
+		})
+		require_NoError(t, err)
+
+		// Now make an addition locally on this stream too.
+		m := nats.NewMsg("foo")
+		m.Header.Set("Nats-Incr", "1")
+		pubAck, err := js.PublishMsg(m)
+		require_NoError(t, err)
+		require_Equal(t, pubAck.Sequence, 1)
+
+		// Source will only work if counters are enabled on both streams.
+		_, err = jsStreamUpdate(t, nc, &StreamConfig{
+			Name:     "M",
+			Subjects: []string{"foo"},
+			Sources: []*StreamSource{
+				{
+					Name:              "O1",
+					SubjectTransforms: []SubjectTransformConfig{{Source: "foo.1", Destination: "foo"}},
+				},
+				{
+					Name:              "O2",
+					SubjectTransforms: []SubjectTransformConfig{{Source: "foo.2", Destination: "foo"}},
+				},
+			},
+			Storage:         FileStorage,
+			AllowMsgCounter: true,
+			Replicas:        replicas,
+		})
+		require_NoError(t, err)
+
+		// Source should aggregate.
+		var first, second, third, fourth *nats.RawStreamMsg
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			first, err = js.GetMsg("M", 1)
+			if err != nil {
+				return err
+			}
+			second, err = js.GetMsg("M", 2)
+			if err != nil {
+				return err
+			}
+			third, err = js.GetMsg("M", 3)
+			return err
+		})
+
+		// Now make an addition locally on this stream too.
+		m = nats.NewMsg("foo")
+		m.Header.Set("Nats-Incr", "1")
+		pubAck, err = js.PublishMsg(m)
+		require_NoError(t, err)
+		require_Equal(t, pubAck.Sequence, 4)
+
+		// Fetch it back out of the stream.
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			fourth, err = js.GetMsg("M", 4)
+			return err
+		})
+
+		// There are no local additions to this counter, but the total
+		// comprises changes from the sources.
+		var count CounterValue
+		require_NoError(t, json.Unmarshal(fourth.Data, &count))
+		require_Equal(t, count.Value, "17")
+
+		// The most recent message should contain information about both
+		// sources, so let's check.
+		var sources CounterSources
+		require_NoError(t, json.Unmarshal([]byte(fourth.Header.Get(JSMessageCounterSources)), &sources))
+		require_NotNil(t, sources["O1"])
+		require_NotNil(t, sources["O2"])
+		require_Equal(t, sources["O1"]["foo.1"], "5")
+		require_Equal(t, sources["O2"]["foo.2"], "10")
+
+		// Since this is the first time we've seen a message from these
+		// sources, the Nats-Incr header should have been updated to reflect
+		// the correct delta.
+		for _, rsm := range []*nats.RawStreamMsg{first, second, third, fourth} {
+			require_Equal(t, rsm.Subject, "foo") // Subject transform'd
+			switch rsm {
+			case first:
+				require_Equal(t, rsm.Header.Get(JSMessageIncr), "1")
+			case second, third: // We can't know which order they got sourced in
+				incr := rsm.Header.Get(JSMessageIncr)
+				require_True(t, incr == "5" || incr == "10")
+			case fourth:
+				require_Equal(t, rsm.Header.Get(JSMessageIncr), "1")
+			}
+		}
 	}
 
 	t.Run("R1", func(t *testing.T) { test(t, 1) })

--- a/server/stream.go
+++ b/server/stream.go
@@ -4465,7 +4465,7 @@ func parseMessageTTL(ttl string) (int64, error) {
 // Fast lookup of the message Incr from headers.
 // Return includes the value or nil, and success.
 func getMessageIncr(hdr []byte) (*big.Int, bool) {
-	incr := getHeader(JSMessageIncr, hdr)
+	incr := sliceHeader(JSMessageIncr, hdr)
 	if len(incr) == 0 {
 		return nil, true
 	}
@@ -5287,7 +5287,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 				}
 				return apiErr
 			}
-			if ncs := getHeader(JSMessageCounterSources, sm.hdr); len(ncs) > 0 {
+			if ncs := sliceHeader(JSMessageCounterSources, sm.hdr); len(ncs) > 0 {
 				if err := json.Unmarshal(ncs, &sources); err != nil {
 					mset.mu.Unlock()
 					bumpCLFS()
@@ -5347,7 +5347,8 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		// Now make the change.
 		initial.Add(&initial, incr)
 		// Generate the new payload.
-		msg = fmt.Appendf(nil, "{%q:%q}", "val", initial.String())
+		var _msg [128]byte
+		msg = fmt.Appendf(_msg[:0], "{%q:%q}", "val", initial.String())
 		// Write the updated source count headers.
 		if len(sources) > 0 {
 			nhdr, err := json.Marshal(sources)

--- a/server/stream.go
+++ b/server/stream.go
@@ -202,6 +202,10 @@ type CounterValue struct {
 	Value string `json:"val"`
 }
 
+// CounterSources is the body of the Nats-Counter-Sources header.
+// e.g. {"stream":{"subject":"123"}}
+type CounterSources map[string]map[string]string
+
 // StreamInfo shows config and current state for this stream.
 type StreamInfo struct {
 	Config     StreamConfig        `json:"config"`
@@ -392,8 +396,9 @@ type stream struct {
 // msgCounterRunningTotal stores a running total and a number of inflight
 // but not yet applied clustered proposals/operations for this counter.
 type msgCounterRunningTotal struct {
-	total *big.Int // Running total.
-	ops   uint64   // Inflight operations. If this reaches zero, we can remove the running total.
+	total   *big.Int       // Running total.
+	sources CounterSources // Last seen counter sources.
+	ops     uint64         // Inflight operations. If this reaches zero, we can remove the running total.
 }
 
 type sourceInfo struct {
@@ -450,6 +455,7 @@ const (
 	JSMessageTTL              = "Nats-TTL"
 	JSMarkerReason            = "Nats-Marker-Reason"
 	JSMessageIncr             = "Nats-Incr"
+	JSMessageCounterSources   = "Nats-Counter-Sources"
 )
 
 // Headers for republished messages and direct gets.
@@ -5262,6 +5268,8 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 	// Apply increment for counter.
 	// But only if it's allowed for this stream. This can happen when we store verbatim for a sourced stream.
 	if !isClustered && incr != nil && allowMsgCounter {
+		var initial big.Int
+		var sources CounterSources
 		var smv StoreMsg
 		sm, err := store.LoadLastMsg(subject, &smv)
 		if err == nil && sm != nil {
@@ -5279,11 +5287,83 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 				}
 				return apiErr
 			}
-			var initial big.Int
+			if ncs := getHeader(JSMessageCounterSources, sm.hdr); len(ncs) > 0 {
+				if err := json.Unmarshal(ncs, &sources); err != nil {
+					mset.mu.Unlock()
+					bumpCLFS()
+					apiErr := NewJSMessageCounterBrokenError()
+					if canRespond {
+						resp.PubAck = &PubAck{Stream: name}
+						resp.Error = apiErr
+						b, _ := json.Marshal(resp)
+						outq.sendMsg(reply, b)
+					}
+					return apiErr
+				}
+			}
 			initial.SetString(val.Value, 10)
-			incr.Add(incr, &initial)
 		}
-		msg = []byte(fmt.Sprintf("{%q:%q}", "val", incr.String()))
+		srchdr := sliceHeader(JSStreamSource, hdr)
+		if len(srchdr) > 0 {
+			// This is a sourced message, so we can't apply Nats-Incr but
+			// instead should just update the source count header.
+			fields := strings.Split(string(srchdr), " ")
+			origStream := fields[0]
+			origSubj := subject
+			if len(fields) >= 3 {
+				origSubj = fields[2]
+			}
+			var val CounterValue
+			if json.Unmarshal(msg, &val) != nil {
+				mset.mu.Unlock()
+				bumpCLFS()
+				apiErr := NewJSMessageCounterBrokenError()
+				if canRespond {
+					resp.PubAck = &PubAck{Stream: name}
+					resp.Error = apiErr
+					b, _ := json.Marshal(resp)
+					outq.sendMsg(reply, b)
+				}
+				return apiErr
+			}
+			var sourced big.Int
+			sourced.SetString(val.Value, 10)
+			if sources == nil {
+				sources = map[string]map[string]string{}
+			}
+			if _, ok := sources[origStream]; !ok {
+				sources[origStream] = map[string]string{}
+			}
+			prevVal := sources[origStream][origSubj]
+			sources[origStream][origSubj] = sourced.String()
+			// We will also replace the Nats-Incr header with the diff
+			// between our last value from this source and this one, so
+			// that the arithmetic is always correct.
+			var previous big.Int
+			previous.SetString(prevVal, 10)
+			incr.Sub(&sourced, &previous)
+			hdr = setHeader(JSMessageIncr, incr.String(), hdr)
+		}
+		// Now make the change.
+		initial.Add(&initial, incr)
+		// Generate the new payload.
+		msg = fmt.Appendf(nil, "{%q:%q}", "val", initial.String())
+		// Write the updated source count headers.
+		if len(sources) > 0 {
+			nhdr, err := json.Marshal(sources)
+			if err != nil {
+				mset.mu.Unlock()
+				bumpCLFS()
+				if canRespond {
+					resp.PubAck = &PubAck{Stream: name}
+					resp.Error = NewJSMessageCounterBrokenError()
+					response, _ = json.Marshal(resp)
+					outq.sendMsg(reply, response)
+				}
+				return err
+			}
+			hdr = setHeader(JSMessageCounterSources, string(nhdr), hdr)
+		}
 
 		// Check to see if we are over the max msg size.
 		if int32(len(hdr)+len(msg)) > mset.srv.getOpts().MaxPayload {


### PR DESCRIPTION
This extends Maurice's work in #6973 by adding source tracking in the `Nats-Counter-Sources` header. This allows us to correctly rewrite `Nats-Incr` when a source counter that's non-zero is added, as well as correctly identifying and reconciling gaps due to the source being removed or unavailable, or when there are lost messages etc, providing eventual consistency with sourced counters.

The additional unit test proves the functionality even with source streams that have `MaxMsgsPerSubject` of 1, as well as a combination of stream-local and sourced increments, with full header checking.

Signed-off-by: Neil Twigg <neil@nats.io>