### PR TITLE
Propagate stream interest policy changes to consumers in all cases

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -2177,7 +2177,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 
 	// If we're changing retention and haven't errored because of consumer
 	// replicas by now, whip through and update the consumer retention.
-	if ocfg.Retention != cfg.Retention && cfg.Retention == InterestPolicy {
+	if ocfg.Retention != cfg.Retention {
 		toUpdate := make([]*consumer, 0, len(mset.consumers))
 		for _, c := range mset.consumers {
 			toUpdate = append(toUpdate, c)


### PR DESCRIPTION
When switching from limits to interest, we were propagating this update to consumers, but we weren't doing so when switching from interest to limits. This would leave consumers running with `o.retention` set to `InterestPolicy`, continuing to run `checkStateForInterestStream` etc even after the stream itself had moved back to the `LimitsPolicy`.

Signed-off-by: Neil Twigg <neil@nats.io>
