### PR TITLE
[FIXED] Health check only does reporting

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -482,8 +482,6 @@ func (js *jetStream) isStreamHealthy(acc *Account, sa *streamAssignment) error {
 
 	case node != msetNode:
 		s.Warnf("Detected stream cluster node skew '%s > %s'", acc.GetName(), streamName)
-		node.Delete()
-		mset.resetClusteredState(nil)
 		return errors.New("cluster node skew detected")
 
 	case !mset.isMonitorRunning():
@@ -544,14 +542,6 @@ func (js *jetStream) isConsumerHealthy(mset *stream, consumer string, ca *consum
 		accName, streamName := mset.acc.GetName(), mset.cfg.Name
 		mset.mu.RUnlock()
 		s.Warnf("Detected consumer cluster node skew '%s > %s > %s'", accName, streamName, consumer)
-		node.Delete()
-		o.deleteWithoutAdvisory()
-
-		// When we try to restart we nil out the node and reprocess the consumer assignment.
-		js.mu.Lock()
-		ca.Group.node = nil
-		js.mu.Unlock()
-		js.processConsumerAssignment(ca)
 		return errors.New("cluster node skew detected")
 
 	case !o.isMonitorRunning():


### PR DESCRIPTION
The health check could still reset/restart stream and consumer Raft nodes. However, if a new Raft node instance is assigned to the stream/consumer assignment, but this is not yet reflected in the stream/consumer, then the new Raft node's state would be fully deleted. This is possible because the assignment's Raft node is updated under the JS lock, but the stream/consumer nodes aren't, resulting in many potential race conditions for the health check to do the wrong thing.

The health check must only do reporting and not try to fix anything, it simply can't guarantee both the assignment and stream/consumer nodes are not stale.

When the logs show `Detected stream/consumer cluster node skew` once, there's nothing to worry about. It was simply a temporary condition that resolved itself. If it's logged for every health check, something went wrong. The health check must not attempt to fix this, we should fix the underlying bug if this is observed.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>