### PR TITLE
Fix `DeliverLastPerSubject` consumer policy with interior deletes

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -4105,6 +4105,7 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 			o.updateSkipped(o.sseq)
 		} else {
 			o.lss.seqs = o.lss.seqs[1:]
+			o.sseq = seq
 		}
 		pmsg := getJSPubMsgFromPool()
 		sm, err := o.mset.store.LoadMsg(seq, &pmsg.StoreMsg)
@@ -5353,7 +5354,7 @@ func (o *consumer) selectStartingSeqNo() {
 				if mmp == 1 {
 					o.sseq = state.FirstSeq
 				} else {
-					var filters []string
+					filters := make([]string, 0, len(o.subjf))
 					if o.subjf == nil {
 						filters = append(filters, o.cfg.FilterSubject)
 					} else {


### PR DESCRIPTION
When the consumer was trying to find the next message from a skiplist, we were not correctly moving `o.sseq` up to the next skiplist sequence, which would result in missed messages and some acks being ignored. This is particularly evident with interior deletes, such as those created by the `MaxMsgsPerSubject` limit which the unit test uses.

Signed-off-by: Neil Twigg <neil@nats.io>