### PR TITLE
Report memory usage correctly on Linux with huge pages

### DIFF
--- a/server/pse/pse_linux.go
+++ b/server/pse/pse_linux.go
@@ -28,6 +28,7 @@ var (
 	lastTotal    int64
 	lastSeconds  int64
 	ipcpu        int64
+	pageSize     int64
 )
 
 const (
@@ -42,6 +43,7 @@ func init() {
 	// Avoiding to generate docker image without CGO
 	ticks = 100 // int64(C.sysconf(C._SC_CLK_TCK))
 	procStatFile = fmt.Sprintf("/proc/%d/stat", os.Getpid())
+	pageSize = int64(os.Getpagesize())
 	periodic()
 }
 
@@ -94,7 +96,7 @@ func ProcUsage(pcpu *float64, rss, vss *int64) error {
 	fields := bytes.Fields(contents)
 
 	// Memory
-	*rss = (parseInt64(fields[rssPos])) << 12
+	*rss = (parseInt64(fields[rssPos])) * pageSize
 	*vss = parseInt64(fields[vssPos])
 
 	// PCPU

--- a/server/pse/pse_test.go
+++ b/server/pse/pse_test.go
@@ -29,7 +29,7 @@ func TestPSEmulation(t *testing.T) {
 	var rss, vss, psRss, psVss int64
 	var pcpu, psPcpu float64
 
-	runtime.GC()
+	debug.FreeOSMemory()
 
 	// PS version first
 	pidStr := fmt.Sprintf("%d", os.Getpid())


### PR DESCRIPTION
4KB pages were assumed rather than asking the OS.

Signed-off-by: Neil Twigg <neil@nats.io>