### PR TITLE
Fix subsz total subs count

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1018,7 +1018,7 @@ func (s *Server) Subsz(opts *SubszOptions) (*Subsz, error) {
 			return true
 		})
 
-		details := make([]SubDetail, len(subs))
+		details := make([]SubDetail, 0, len(subs))
 		i := 0
 		// TODO(dlc) - may be inefficient and could just do normal match when total subs is large and filtering.
 		for _, sub := range subs {
@@ -1030,7 +1030,7 @@ func (s *Server) Subsz(opts *SubszOptions) (*Subsz, error) {
 				continue
 			}
 			sub.client.mu.Lock()
-			details[i] = newSubDetail(sub)
+			details = append(details, newSubDetail(sub))
 			sub.client.mu.Unlock()
 			i++
 		}
@@ -1047,7 +1047,7 @@ func (s *Server) Subsz(opts *SubszOptions) (*Subsz, error) {
 			maxoff = maxIndex
 		}
 		sz.Subs = details[minoff:maxoff]
-		sz.Total = len(sz.Subs)
+		sz.Total = len(details)
 	} else {
 		s.accounts.Range(func(k, v any) bool {
 			acc := v.(*Account)

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1656,8 +1656,8 @@ func TestMonitorSubszWithOffsetAndLimit(t *testing.T) {
 		if sl.NumSubs != 200 {
 			t.Fatalf("Expected NumSubs of 200, got %d\n", sl.NumSubs)
 		}
-		if sl.Total != 100 {
-			t.Fatalf("Expected Total of 100, got %d\n", sl.Total)
+		if sl.Total != 200 {
+			t.Fatalf("Expected Total of 200, got %d\n", sl.Total)
 		}
 		if sl.Offset != 10 {
 			t.Fatalf("Expected Offset of 10, got %d\n", sl.Offset)
@@ -1799,8 +1799,8 @@ func TestMonitorSubszMultiAccountWithOffsetAndLimit(t *testing.T) {
 		if sl.NumSubs != 400 {
 			t.Fatalf("Expected NumSubs of 200, got %d\n", sl.NumSubs)
 		}
-		if sl.Total != 100 {
-			t.Fatalf("Expected Total of 100, got %d\n", sl.Total)
+		if sl.Total != 400 {
+			t.Fatalf("Expected Total of 400, got %d\n", sl.Total)
 		}
 		if sl.Offset != 10 {
 			t.Fatalf("Expected Offset of 10, got %d\n", sl.Offset)


### PR DESCRIPTION
Previously `SUBSZ` reported the number of returned `SubDetails` in `Subsz.Total`, which means that when using pagination if the total number of subs exceeds `Limit` it will cap at that). That does not align with how `Total` is used when using pagination in other endpoints (e.g. in `CONNZ` `Total` contains the full number of connections).

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)
