### PR TITLE
[IMPROVED] Preserve source last seen

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -3485,7 +3485,6 @@ func (mset *stream) processAllSourceMsgs() {
 					defer mset.mu.Unlock()
 					for _, si := range stalled {
 						mset.setupSourceConsumer(si.iname, si.sseq+1, time.Time{})
-						si.last.Store(time.Now().UnixNano())
 					}
 				}()
 			}


### PR DESCRIPTION
When sourcing from a stream on a leaf node, it may be useful to know when it was last seen and how long ago that was. Before now that wasn't really possible because it would reset roughly every 10 seconds, even if the source consumer wasn't even established.

This makes the last seen value for sources a bit more valuable. Even though this value is not preserved after restarts, and will show last seen never in that case.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>