### PR TITLE
(2.12) Filestore async flush

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5134,16 +5134,19 @@ func (mb *msgBlock) flushLoop(fch, qch chan struct{}) {
 					waiting = newWaiting
 					ts *= 2
 				}
+
 				mb.flushPendingMsgs()
-				// Check if we are no longer the last message block. If we are
-				// not we can close FDs and exit.
-				mb.fs.mu.RLock()
-				notLast := mb != mb.fs.lmb
-				mb.fs.mu.RUnlock()
-				if notLast {
-					if err := mb.closeFDs(); err == nil {
-						return
-					}
+			}
+
+			// Check if we are no longer the last message block. If we are
+			// not we can close FDs and exit.
+			mb.fs.mu.RLock()
+			notLast := mb != mb.fs.lmb
+			mb.fs.mu.RUnlock()
+
+			if notLast {
+				if err := mb.closeFDs(); err == nil {
+					return
 				}
 			}
 		case <-qch:

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -888,7 +888,7 @@ func TestFileStoreCompactLastPlusOne(t *testing.T) {
 		// The performance of this test is quite terrible with compression
 		// if we have AsyncFlush = false, so we'll batch flushes instead.
 		fs.mu.Lock()
-		fs.checkAndFlushAllBlocks()
+		fs.checkAndFlushLastBlock()
 		fs.mu.Unlock()
 
 		if state := fs.State(); state.Msgs != 10_000 {
@@ -1327,7 +1327,7 @@ func TestFileStoreEraseMsg(t *testing.T) {
 	if sm2, _ := fs.msgForSeq(1, nil); sm2 != nil {
 		t.Fatalf("Expected msg to be erased")
 	}
-	fs.checkAndFlushAllBlocks()
+	fs.checkAndFlushLastBlock()
 
 	// Now look on disk as well.
 	rl := fileStoreMsgSize(subj, nil, msg)

--- a/server/jetstream_benchmark_test.go
+++ b/server/jetstream_benchmark_test.go
@@ -858,12 +858,14 @@ func BenchmarkJetStreamPublish(b *testing.B) {
 		replicas    int
 		messageSize int
 		numSubjects int
-		minMessages int
+		asyncFlush  bool
 	}{
-		{1, 1, 10, 1, 100_000}, // Single node, 10B messages, ~1MB minimum
-		{1, 1, 1024, 1, 1_000}, // Single node, 1KB messages, ~1MB minimum
-		{3, 3, 10, 1, 100_000}, // 3-nodes cluster, R=3, 10B messages, ~1MB minimum
-		{3, 3, 1024, 1, 1_000}, // 3-nodes cluster, R=3, 10B messages, ~1MB minimum
+		{1, 1, 10, 1, false},   // Single node, 10B messages
+		{1, 1, 1024, 1, false}, // Single node, 1KB messages
+		{3, 3, 10, 1, false},   // 3-nodes cluster, R=3, 10B messages
+		{3, 3, 1024, 1, false}, // 3-nodes cluster, R=3, 1KB messages
+		{3, 3, 10, 1, true},    // 3-nodes cluster, R=3, 10B messages (async flush)
+		{3, 3, 1024, 1, true},  // 3-nodes cluster, R=3, 1KB messages (async flush)
 	}
 
 	// All the cases above are run with each of the publisher cases below
@@ -885,6 +887,9 @@ func BenchmarkJetStreamPublish(b *testing.B) {
 			bc.messageSize,
 			bc.numSubjects,
 		)
+		if bc.asyncFlush {
+			name += ",AsyncFlush"
+		}
 
 		b.Run(
 			name,
@@ -933,12 +938,14 @@ func BenchmarkJetStreamPublish(b *testing.B) {
 							if verbose {
 								b.Logf("Creating stream with R=%d and %d input subjects", bc.replicas, bc.numSubjects)
 							}
-							streamConfig := &nats.StreamConfig{
-								Name:     streamName,
-								Subjects: subjects,
-								Replicas: bc.replicas,
-							}
-							if _, err := js.AddStream(streamConfig); err != nil {
+							_, err = jsStreamCreate(b, nc, &StreamConfig{
+								Name:            streamName,
+								Subjects:        subjects,
+								Replicas:        bc.replicas,
+								Storage:         FileStorage,
+								AllowAsyncFlush: bc.asyncFlush,
+							})
+							if err != nil {
 								b.Fatalf("Error creating stream: %v", err)
 							}
 
@@ -1935,9 +1942,11 @@ func BenchmarkJetStreamPublishConcurrent(b *testing.B) {
 	replicasCases := []struct {
 		clusterSize int
 		replicas    int
+		asyncFlush  bool
 	}{
-		{1, 1},
-		{3, 3},
+		{1, 1, false},
+		{3, 3, false},
+		{3, 3, true},
 	}
 
 	workload := func(b *testing.B, numPubs int, messageSize int64, clientUrl string) {
@@ -2046,8 +2055,12 @@ func BenchmarkJetStreamPublishConcurrent(b *testing.B) {
 
 	// benchmark case matrix
 	for _, replicasCase := range replicasCases {
+		title := fmt.Sprintf("N=%d,R=%d", replicasCase.clusterSize, replicasCase.replicas)
+		if replicasCase.asyncFlush {
+			title += ",AsyncFlush"
+		}
 		b.Run(
-			fmt.Sprintf("N=%d,R=%d", replicasCase.clusterSize, replicasCase.replicas),
+			title,
 			func(b *testing.B) {
 				for _, messageSize := range messageSizeCases {
 					b.Run(
@@ -2065,10 +2078,12 @@ func BenchmarkJetStreamPublishConcurrent(b *testing.B) {
 										clientUrl := ls.ClientURL()
 
 										// create stream
-										_, err := js.AddStream(&nats.StreamConfig{
-											Name:     streamName,
-											Subjects: []string{subject},
-											Replicas: replicasCase.replicas,
+										_, err := jsStreamCreate(b, nc, &StreamConfig{
+											Name:            streamName,
+											Subjects:        []string{subject},
+											Replicas:        replicasCase.replicas,
+											Storage:         FileStorage,
+											AllowAsyncFlush: replicasCase.asyncFlush,
 										})
 										if err != nil {
 											b.Fatal(err)

--- a/server/jetstream_versioning.go
+++ b/server/jetstream_versioning.go
@@ -55,6 +55,11 @@ func setStaticStreamMetadata(cfg *StreamConfig) {
 		requires(2)
 	}
 
+	// Async flush was added in v2.12 and require API level 2.
+	if cfg.AllowAsyncFlush {
+		requires(2)
+	}
+
 	cfg.Metadata[JSRequiredLevelMetadataKey] = strconv.Itoa(requiredApiLevel)
 }
 

--- a/server/jetstream_versioning_test.go
+++ b/server/jetstream_versioning_test.go
@@ -82,6 +82,11 @@ func TestJetStreamSetStaticStreamMetadata(t *testing.T) {
 			cfg:              &StreamConfig{AllowAtomicPublish: true},
 			expectedMetadata: metadataAtLevel("2"),
 		},
+		{
+			desc:             "AllowAsyncFlush",
+			cfg:              &StreamConfig{AllowAsyncFlush: true},
+			expectedMetadata: metadataAtLevel("2"),
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			setStaticStreamMetadata(test.cfg)

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -331,6 +331,11 @@ func (ms *memStore) SkipMsgs(seq uint64, num uint64) error {
 	return nil
 }
 
+// FlushAllPending flushes all data that was still pending to be written.
+func (ms *memStore) FlushAllPending() {
+	// Noop, in-memory store doesn't use async applying.
+}
+
 // RegisterStorageUpdates registers a callback for updates to storage changes.
 // It will present number of messages and bytes as a signed integer and an
 // optional sequence number of the message if a single.

--- a/server/store.go
+++ b/server/store.go
@@ -96,6 +96,7 @@ type StreamStore interface {
 	StoreRawMsg(subject string, hdr, msg []byte, seq uint64, ts int64, ttl int64) error
 	SkipMsg() uint64
 	SkipMsgs(seq uint64, num uint64) error
+	FlushAllPending()
 	LoadMsg(seq uint64, sm *StoreMsg) (*StoreMsg, error)
 	LoadNextMsg(filter string, wc bool, start uint64, smp *StoreMsg) (sm *StoreMsg, skip uint64, err error)
 	LoadNextMsgMulti(sl *gsl.SimpleSublist, start uint64, smp *StoreMsg) (sm *StoreMsg, skip uint64, err error)
@@ -122,7 +123,7 @@ type StreamStore interface {
 	SyncDeleted(dbs DeleteBlocks)
 	Type() StorageType
 	RegisterStorageUpdates(StorageUpdateHandler)
-	RegisterStorageRemoveMsg(handler StorageRemoveMsgHandler)
+	RegisterStorageRemoveMsg(StorageRemoveMsgHandler)
 	RegisterSubjectDeleteMarkerUpdates(SubjectDeleteMarkerUpdateHandler)
 	UpdateConfig(cfg *StreamConfig) error
 	Delete() error

--- a/server/stream.go
+++ b/server/stream.go
@@ -116,6 +116,10 @@ type StreamConfig struct {
 	// AllowAtomicPublish allows atomic batch publishing into the stream.
 	AllowAtomicPublish bool `json:"allow_atomic"`
 
+	// AllowAsyncFlush allows replicated streams to asynchronously flush
+	// to the stream, improving throughput.
+	AllowAsyncFlush bool `json:"allow_async_flush"`
+
 	// Metadata is additional metadata for the Stream.
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
@@ -778,7 +782,8 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 		}
 	}
 	fsCfg.StoreDir = storeDir
-	fsCfg.AsyncFlush = false
+	// Async flushing is only allowed if the stream has a sync log backing it.
+	fsCfg.AsyncFlush = config.AllowAsyncFlush && config.Replicas > 1
 	// Grab configured sync interval.
 	fsCfg.SyncInterval = s.getOpts().SyncInterval
 	fsCfg.SyncAlways = s.getOpts().SyncAlways


### PR DESCRIPTION
The filestore's `AsyncFlush` setting can now be enabled for a JetStream stream using the `AllowAsyncFlush` field. Some initial benchmarks showed a 10-15% performance increase when using a R3 stream (3-node cluster with each node in a different availability zone).

Only enabling the filestore's `AsyncFlush` setting without additional code would be unsafe. That's why this PR introduces some new mechanisms to make it safe. This makes the performance improvement essentially "free", with no negative consequences for data safety/consistency.
- Before `n.InstallSnapshot(..)` we now do a `mset.flushAllPending()` to ensure all state represented in the snapshot, actually all made it to disk.
- The previous `fs.lmb` would only be sometimes be flushed, for example in `fs.checkLastBlock` but not when creating a new `fs.lmb` in `fs.newMsgBlockForWrite`. Instead, always flush and close `fs.lmb` when creating a new block in `fs.newMsgBlockForWrite`. This resolves non-monotonic sequence issues that could be reproduced by Antithesis.
- The `AllowAsyncFlush` stream setting can be freely/safely enabled and disabled. It will only be effective when using file storage, and only when the stream is backed by a Raft log, i.e. it's replicated.

Relates to https://github.com/nats-io/nats-server/issues/6784

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>