### PR TITLE
[FIXED] Healthz "monitor goroutine not running" after stream restore

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2691,6 +2691,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 				if mset, err = acc.lookupStream(sa.Config.Name); mset != nil {
 					mset.monitorWg.Add(1)
 					defer mset.monitorWg.Done()
+					mset.checkInMonitor()
 					mset.setStreamAssignment(sa)
 					// Make sure to update our updateC which would have been nil.
 					uch = mset.updateC()


### PR DESCRIPTION
When restoring a replicated stream from a backup, healthz would report `JetStream stream '$G > test-stream' is not current: monitor goroutine not running`. This was due to not initializing we were already running that monitor goroutine.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>