### PR TITLE
Optimise consumers with simple generic sublist, intersection in `NumPending`

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -45,6 +45,7 @@ import (
 
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/nats-server/v2/server/ats"
+	"github.com/nats-io/nats-server/v2/server/gsl"
 	"github.com/nats-io/nuid"
 )
 
@@ -8439,11 +8440,11 @@ func TestFileStoreNumPendingMulti(t *testing.T) {
 	}
 
 	// Now we want to do a calculate NumPendingMulti.
-	filters := NewSublistNoCache()
+	filters := gsl.NewSublist[struct{}]()
 	for filters.Count() < uint32(numFiltered) {
 		filter := subjects[rand.Intn(totalSubjects)]
 		if !filters.HasInterest(filter) {
-			filters.Insert(&subscription{subject: []byte(filter)})
+			filters.Insert(filter, struct{}{})
 		}
 	}
 
@@ -9709,8 +9710,8 @@ func TestFileStoreFirstMatchingMultiExpiry(t *testing.T) {
 		mb.expireCacheLocked()
 		fs.mu.RUnlock()
 
-		sl := NewSublistNoCache()
-		sl.Insert(&subscription{subject: []byte("foo.foo")})
+		sl := gsl.NewSublist[struct{}]()
+		sl.Insert("foo.foo", struct{}{})
 
 		_, didLoad, err := mb.firstMatchingMulti(sl, 1, nil)
 		require_NoError(t, err)

--- a/server/gsl/gsl.go
+++ b/server/gsl/gsl.go
@@ -45,6 +45,11 @@ var (
 	ErrAlreadyRegistered = errors.New("gsl: notification already registered")
 )
 
+// SimpleSublist is an alias type for GenericSublist that takes
+// empty values, useful for tracking interest only without any
+// unnecessary allocations.
+type SimpleSublist = GenericSublist[struct{}]
+
 // A GenericSublist stores and efficiently retrieves subscriptions.
 type GenericSublist[T comparable] struct {
 	sync.RWMutex

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/nats-io/nats-server/v2/server/avl"
+	"github.com/nats-io/nats-server/v2/server/gsl"
 	"github.com/nats-io/nats-server/v2/server/stree"
 	"github.com/nats-io/nats-server/v2/server/thw"
 )
@@ -782,7 +783,7 @@ func (ms *memStore) NumPending(sseq uint64, filter string, lastPerSubject bool) 
 }
 
 // NumPending will return the number of pending messages matching any subject in the sublist starting at sequence.
-func (ms *memStore) NumPendingMulti(sseq uint64, sl *Sublist, lastPerSubject bool) (total, validThrough uint64) {
+func (ms *memStore) NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPerSubject bool) (total, validThrough uint64) {
 	if sl == nil {
 		return ms.NumPending(sseq, fwcs, lastPerSubject)
 	}
@@ -817,7 +818,7 @@ func (ms *memStore) NumPendingMulti(sseq uint64, sl *Sublist, lastPerSubject boo
 	var havePartial bool
 	var totalSkipped uint64
 	// We will track start and end sequences as we go.
-	IntersectStree[SimpleState](ms.fss, sl, func(subj []byte, fss *SimpleState) {
+	gsl.IntersectStree[SimpleState](ms.fss, sl, func(subj []byte, fss *SimpleState) {
 		if fss.firstNeedsUpdate || fss.lastNeedsUpdate {
 			ms.recalculateForSubj(bytesToString(subj), fss)
 		}
@@ -1546,7 +1547,7 @@ func (ms *memStore) LoadLastMsg(subject string, smp *StoreMsg) (*StoreMsg, error
 }
 
 // LoadNextMsgMulti will find the next message matching any entry in the sublist.
-func (ms *memStore) LoadNextMsgMulti(sl *Sublist, start uint64, smp *StoreMsg) (sm *StoreMsg, skip uint64, err error) {
+func (ms *memStore) LoadNextMsgMulti(sl *gsl.SimpleSublist, start uint64, smp *StoreMsg) (sm *StoreMsg, skip uint64, err error) {
 	// TODO(dlc) - for now simple linear walk to get started.
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats-server/v2/server/gsl"
 	"github.com/nats-io/nuid"
 )
 
@@ -1107,11 +1108,11 @@ func TestMemStoreNumPendingMulti(t *testing.T) {
 	}
 
 	// Now we want to do a calculate NumPendingMulti.
-	filters := NewSublistNoCache()
+	filters := gsl.NewSublist[struct{}]()
 	for filters.Count() < uint32(numFiltered) {
 		filter := subjects[rand.Intn(totalSubjects)]
 		if !filters.HasInterest(filter) {
-			filters.Insert(&subscription{subject: []byte(filter)})
+			filters.Insert(filter, struct{}{})
 		}
 	}
 

--- a/server/norace_2_test.go
+++ b/server/norace_2_test.go
@@ -37,6 +37,7 @@ import (
 
 	crand "crypto/rand"
 
+	"github.com/nats-io/nats-server/v2/server/gsl"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nuid"
 )
@@ -1855,8 +1856,8 @@ func TestNoRaceFileStoreMsgLoadNextMsgMultiPerf(t *testing.T) {
 	require_LessThan(t, elapsed, 2*baseline)
 
 	// Now do multi load next with 1 wc entry.
-	sl := NewSublistWithCache()
-	require_NoError(t, sl.Insert(&subscription{subject: []byte("foo.>")}))
+	sl := gsl.NewSublist[struct{}]()
+	require_NoError(t, sl.Insert("foo.>", struct{}{}))
 	start = time.Now()
 	for i, seq := 0, uint64(1); i < 1000; i++ {
 		sm, nseq, err := fs.LoadNextMsgMulti(sl, seq, &smv)
@@ -1870,10 +1871,10 @@ func TestNoRaceFileStoreMsgLoadNextMsgMultiPerf(t *testing.T) {
 	require_LessThan(t, elapsed, 2*baseline)
 
 	// Now do multi load next with 1000 literal subjects.
-	sl = NewSublistWithCache()
+	sl = gsl.NewSublist[struct{}]()
 	for i := 0; i < 1000; i++ {
 		subj := fmt.Sprintf("foo.%d", i)
-		require_NoError(t, sl.Insert(&subscription{subject: []byte(subj)}))
+		require_NoError(t, sl.Insert(subj, struct{}{}))
 	}
 	start = time.Now()
 	for i, seq := 0, uint64(1); i < 1000; i++ {

--- a/server/store.go
+++ b/server/store.go
@@ -24,6 +24,7 @@ import (
 	"unsafe"
 
 	"github.com/nats-io/nats-server/v2/server/avl"
+	"github.com/nats-io/nats-server/v2/server/gsl"
 )
 
 // StorageType determines how messages are stored for retention.
@@ -97,7 +98,7 @@ type StreamStore interface {
 	SkipMsgs(seq uint64, num uint64) error
 	LoadMsg(seq uint64, sm *StoreMsg) (*StoreMsg, error)
 	LoadNextMsg(filter string, wc bool, start uint64, smp *StoreMsg) (sm *StoreMsg, skip uint64, err error)
-	LoadNextMsgMulti(sl *Sublist, start uint64, smp *StoreMsg) (sm *StoreMsg, skip uint64, err error)
+	LoadNextMsgMulti(sl *gsl.SimpleSublist, start uint64, smp *StoreMsg) (sm *StoreMsg, skip uint64, err error)
 	LoadLastMsg(subject string, sm *StoreMsg) (*StoreMsg, error)
 	LoadPrevMsg(start uint64, smp *StoreMsg) (sm *StoreMsg, err error)
 	RemoveMsg(seq uint64) (bool, error)
@@ -114,7 +115,7 @@ type StreamStore interface {
 	MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed int) ([]uint64, error)
 	SubjectForSeq(seq uint64) (string, error)
 	NumPending(sseq uint64, filter string, lastPerSubject bool) (total, validThrough uint64)
-	NumPendingMulti(sseq uint64, sl *Sublist, lastPerSubject bool) (total, validThrough uint64)
+	NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPerSubject bool) (total, validThrough uint64)
 	State() StreamState
 	FastState(*StreamState)
 	EncodedStreamState(failed uint64) (enc []byte, err error)

--- a/server/store_test.go
+++ b/server/store_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/nats-io/nats-server/v2/server/gsl"
 )
 
 func testAllStoreAllPermutations(t *testing.T, compressionAndEncryption bool, cfg StreamConfig, fn func(t *testing.T, fs StreamStore)) {
@@ -62,8 +64,8 @@ func TestStoreMsgLoadNextMsgMulti(t *testing.T) {
 
 			var smv StoreMsg
 			// Do multi load next with 1 wc entry.
-			sl := NewSublistWithCache()
-			sl.Insert(&subscription{subject: []byte("foo.>")})
+			sl := gsl.NewSublist[struct{}]()
+			sl.Insert("foo.>", struct{}{})
 			for i, seq := 0, uint64(1); i < 1000; i++ {
 				sm, nseq, err := fs.LoadNextMsgMulti(sl, seq, &smv)
 				require_NoError(t, err)
@@ -73,10 +75,10 @@ func TestStoreMsgLoadNextMsgMulti(t *testing.T) {
 			}
 
 			// Now do multi load next with 1000 literal subjects.
-			sl = NewSublistWithCache()
+			sl = gsl.NewSublist[struct{}]()
 			for i := 0; i < 1000; i++ {
 				subj := fmt.Sprintf("foo.%d", i)
-				sl.Insert(&subscription{subject: []byte(subj)})
+				sl.Insert(subj, struct{}{})
 			}
 			for i, seq := 0, uint64(1); i < 1000; i++ {
 				sm, nseq, err := fs.LoadNextMsgMulti(sl, seq, &smv)
@@ -87,10 +89,10 @@ func TestStoreMsgLoadNextMsgMulti(t *testing.T) {
 			}
 
 			// Check that we can pull out 3 individuals.
-			sl = NewSublistWithCache()
-			sl.Insert(&subscription{subject: []byte("foo.2")})
-			sl.Insert(&subscription{subject: []byte("foo.222")})
-			sl.Insert(&subscription{subject: []byte("foo.999")})
+			sl = gsl.NewSublist[struct{}]()
+			sl.Insert("foo.2", struct{}{})
+			sl.Insert("foo.222", struct{}{})
+			sl.Insert("foo.999", struct{}{})
 			sm, seq, err := fs.LoadNextMsgMulti(sl, 1, &smv)
 			require_NoError(t, err)
 			require_Equal(t, sm.subj, "foo.2")


### PR DESCRIPTION
The generic sublist is cheaper in allocations than the regular sublist, so switch consumer filtering to use those instead.

Also updates the `NumPendingMulti` to use intersection instead of collecting all subs and then calling `Match`, as this further reduces allocations and avoids misses on the sublist.

Signed-off-by: Neil Twigg <neil@nats.io>