### PR TITLE
[FIXED] Removed stream is revived

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2817,6 +2817,14 @@ func (mset *stream) resetClusteredState(err error) bool {
 	stype, tierName, replicas := mset.cfg.Storage, mset.tier, mset.cfg.Replicas
 	mset.mu.RUnlock()
 
+	// The stream might already be deleted and not assigned to us anymore.
+	// In any case, don't revive the stream if it's already closed.
+	if mset.closed.Load() {
+		s.Warnf("Will not reset stream '%s > %s', stream is closed", acc, mset.name())
+		// Explicitly returning true here, we want the outside to break out of the monitoring loop as well.
+		return true
+	}
+
 	// Stepdown regardless if we are the leader here.
 	if node != nil {
 		node.StepDown()
@@ -2824,19 +2832,19 @@ func (mset *stream) resetClusteredState(err error) bool {
 
 	// If we detect we are shutting down just return.
 	if js != nil && js.isShuttingDown() {
-		s.Debugf("Will not reset stream, JetStream shutting down")
+		s.Debugf("Will not reset stream '%s > %s', JetStream shutting down", acc, mset.name())
 		return false
 	}
 
 	// Server
 	if js.limitsExceeded(stype) {
-		s.Warnf("Will not reset stream, server resources exceeded")
+		s.Warnf("Will not reset stream '%s > %s', server resources exceeded", acc, mset.name())
 		return false
 	}
 
 	// Account
 	if exceeded, _ := jsa.limitsExceeded(stype, tierName, replicas); exceeded {
-		s.Warnf("stream '%s > %s' errored, account resources exceeded", acc, mset.name())
+		s.Warnf("Stream '%s > %s' errored, account resources exceeded", acc, mset.name())
 		return false
 	}
 


### PR DESCRIPTION
A removed stream could be wrongfully revived. For example when quickly scaling up and down, the follower will not have caught up, eventually call `mset.resetClusteredState` and then the stream would be wrongfully recreated.

Note, there's still a race condition here. We're not holding any locks, and the revival is done (eventually) in a goroutine. There's not too much we can do to guard against the unfortunate scenario where all things align just right (at least for now). But we can easily guard against `mset.resetClusteredState` not resetting if we know the stream is already closed at that point.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>