### PR TITLE
[FIXED] No redundant limit marker on KV purge

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5652,7 +5652,7 @@ func (fs *fileStore) expireMsgs() {
 			// if it was the last message of that particular subject that we just deleted.
 			if sdmEnabled {
 				if last, ok := fs.shouldProcessSdm(seq, sm.subj); ok {
-					sdm := last && len(getHeader(JSMarkerReason, sm.hdr)) == 0
+					sdm := last && isSubjectDeleteMarker(sm.hdr)
 					fs.handleRemovalOrSdm(seq, sm.subj, sdm, sdmTTL)
 				}
 			} else {
@@ -5685,7 +5685,7 @@ func (fs *fileStore) expireMsgs() {
 				if ttlSdm == nil {
 					ttlSdm = make(map[string][]SDMBySubj, 1)
 				}
-				ttlSdm[sm.subj] = append(ttlSdm[sm.subj], SDMBySubj{seq, len(getHeader(JSMarkerReason, sm.hdr)) != 0})
+				ttlSdm[sm.subj] = append(ttlSdm[sm.subj], SDMBySubj{seq, !isSubjectDeleteMarker(sm.hdr)})
 			} else {
 				// Collect sequences to remove. Don't remove messages inline here,
 				// as that releases the lock and THW is not thread-safe.

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1075,7 +1075,7 @@ func (ms *memStore) expireMsgs() {
 			}
 			if sdmEnabled {
 				if last, ok := ms.shouldProcessSdm(seq, sm.subj); ok {
-					sdm := last && len(getHeader(JSMarkerReason, sm.hdr)) == 0
+					sdm := last && isSubjectDeleteMarker(sm.hdr)
 					ms.handleRemovalOrSdm(seq, sm.subj, sdm, sdmTTL)
 				}
 			} else {
@@ -1105,7 +1105,7 @@ func (ms *memStore) expireMsgs() {
 					if ttlSdm == nil {
 						ttlSdm = make(map[string][]SDMBySubj, 1)
 					}
-					ttlSdm[sm.subj] = append(ttlSdm[sm.subj], SDMBySubj{seq, len(getHeader(JSMarkerReason, sm.hdr)) != 0})
+					ttlSdm[sm.subj] = append(ttlSdm[sm.subj], SDMBySubj{seq, !isSubjectDeleteMarker(sm.hdr)})
 					return false
 				}
 			} else {

--- a/server/sdm.go
+++ b/server/sdm.go
@@ -13,7 +13,10 @@
 
 package server
 
-import "time"
+import (
+	"bytes"
+	"time"
+)
 
 // SDMMeta holds pending/proposed data for subject delete markers or message removals.
 type SDMMeta struct {
@@ -38,6 +41,12 @@ func newSDMMeta() *SDMMeta {
 		totals:  make(map[string]uint64, 1),
 		pending: make(map[uint64]SDMBySeq, 1),
 	}
+}
+
+// isSubjectDeleteMarker returns whether the headers indicate this message is a subject delete marker.
+// Either it's a usual marker with JSMarkerReason, or it's a KV Purge marker as the KVOperation.
+func isSubjectDeleteMarker(hdr []byte) bool {
+	return len(sliceHeader(JSMarkerReason, hdr)) == 0 && !bytes.Equal(sliceHeader(KVOperation, hdr), KVOperationValuePurge)
 }
 
 // empty clears all data.

--- a/server/stream.go
+++ b/server/stream.go
@@ -468,6 +468,12 @@ const (
 	JSBatchCommit             = "Nats-Batch-Commit"
 )
 
+// Headers for published KV messages.
+var (
+	KVOperation           = "KV-Operation"
+	KVOperationValuePurge = []byte("PURGE")
+)
+
 // Headers for republished messages and direct gets.
 const (
 	JSStream       = "Nats-Stream"


### PR DESCRIPTION
When subject delete markers are enabled and you do a KV Purge with a TTL, you effectively get two subject delete markers. One of them is the explicit KV Purge operation, the other is the subject delete marker announcing (again) that the data is purged.

This PR is proposing to not have redundant limit markers, the KV Purge operation is in essence already a subject delete marker and should not trigger a "vanilla" subject delete marker duplicate.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>