### PR TITLE
CI: Check PR sign-offs with env variable

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,8 +51,10 @@ jobs:
 
       - name: Check PR description is signed off
         if: github.event_name == 'pull_request'
+        env:
+          PR_DESC: ${{ github.event.pull_request.body }}
         run: |
-          if ! echo "${{ github.event.pull_request.body }}" | grep -Pq '^Signed-off-by:\s*(?!Your Name|.*<your\.email@example\.com>)'; then
+          if ! echo "$PR_DESC" | grep -Pq '^Signed-off-by:\s*(?!Your Name|.*<your\.email@example\.com>)'; then
               echo "::error ::Pull request has not been signed off in the PR description with a \`Signed-off-by:\` line"
               exit 1
           fi


### PR DESCRIPTION
Capture `github.event.pull_request.body` in `"$PR_DESC"` as the PR description.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
