### PR TITLE
(2.12) NRG: Empty log & partial catchup protection

### DIFF
--- a/server/raft_chain_of_blocks_helpers_test.go
+++ b/server/raft_chain_of_blocks_helpers_test.go
@@ -118,6 +118,7 @@ func (sm *RCOBStateMachine) applyEntry(ce *CommittedEntry) {
 		// A nil entry signals that the previous recovery backlog is over
 		sm.logDebug("Recovery complete")
 		sm.ready = true
+		sm.n.Recovered()
 		return
 	}
 	sm.logDebug("Apply entries #%d (%d entries)", ce.Index, len(ce.Entries))

--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -227,6 +227,7 @@ func (a *stateAdder) applyEntry(ce *CommittedEntry) {
 	a.Lock()
 	if ce == nil {
 		// This means initial state is done/replayed.
+		a.n.Recovered()
 		a.Unlock()
 		return
 	}
@@ -350,6 +351,7 @@ func newStateAdder(s *Server, cfg *RaftConfig, n RaftNode) stateMachine {
 func initSingleMemRaftNode(t *testing.T) (*raft, func()) {
 	t.Helper()
 	n, c := initSingleMemRaftNodeWithCluster(t)
+	n.Recovered()
 	cleanup := func() {
 		c.shutdown()
 	}


### PR DESCRIPTION
This PR solves two issues related to catchups and what happens after a disk is fully reset.

## Becoming leader when requiring catchup first

When an outdated follower requires JetStream-layer stream catchup, but the leader goes down, and the follower then restarts. Upon recovery it will retry the catchup, which will fail because there's no leader. If the outdated follower can get quorum and become leader: the catchup would be aborted, and the follower would continue with missing data.

This is solved by the introduction of `n.Recovered()`, which is a signaling mechanism that waits for the Raft recovery on startup to finish before allowing the server to start a leader election.

## Empty log protection

When a follower comes up with an entirely empty disk, it can vote for any server to become leader which could result in data loss. For example with a R3 stream. Server A is leader and has stored all JetStream messages. Server B was part of quorum, but didn't apply all JetStream messages yet. Server C has stored some JetStream messages, but it didn't get the messages that had quorum on Server A and Server B.

If we'd shutdown Server B and reset the disk, we would violate stable storage which Raft relies on. If Server A goes down now, Server B can't become leader because it's empty (which is good), but Server B can vote for Server C to become leader. That would be bad, because we'd have lost some writes, and Server A would then have desynced.

By extension, scaling up of streams can be dangerous. Scaling up a R1 stream to R3 will work most of the time, but technically there's a very short time frame where the stream can be assigned on the two other servers, and the previous R1 leader immediately dies right after. Now the remaining servers that got assigned to be part of the R3 stream can vote for each other to become leader, which will lose the full stream contents.

This PR proposes to add protection and special handling when a server's log is empty.
- The `Preferred` server value for who is meant to become the leader was a suggestion before. Now it's a hard requirement. No other server except the `Preferred` server can become leader. This ensures no data can be lost, as only the previous R1 server can become leader.
- When a server's disk is reset and comes up empty, we now protect against this server wanting to become leader as well as prevent it from voting in leader elections. This ensures only "non-empty" servers can participate in leadership, ensuring no data can be lost.

However, a caveat to this is that we can't prevent an empty server from becoming leader forever. Imagine a cluster of 5 nodes, and 3 servers hosting a R3 stream all get their disks fully reset. The data is gone then, no way to solve that (obviously), but the servers will prevent each other and themselves from becoming leader, because they recognize they're empty. So, there's a timeout after which the servers will remove the `Preferred` requirement and eventually allow an empty server to participate in voting again. This timeout is currently set to 5 minutes, which is aligned with the timeout for allowing a peer-removed server to come back. This allows the old leader containing all the data to come back within that time, and ensure the data is not lost in the case where the disk was reset of a server that was part of quorum.

Like I mentioned before, technically resetting a disk is already a violation of Raft, so we could call it a day there. But I feel like it's still a good thing to at least try to attempt to preserve the data, even in such a nightmarish scenario.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>