### PR TITLE
NRG: Partial catchup protection

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -1314,8 +1314,9 @@ func (n *raft) setupLastSnapshot() {
 	// Compact the WAL when we're done if needed.
 	n.pindex = snap.lastIndex
 	n.pterm = snap.lastTerm
+	// Explicitly only set commit, and not applied.
+	// Applied will move up when the snapshot is actually applied.
 	n.commit = snap.lastIndex
-	n.applied = snap.lastIndex
 	n.apply.push(newCommittedEntry(n.commit, []*Entry{{EntrySnapshot, snap.data}}))
 	if _, err := n.wal.Compact(snap.lastIndex + 1); err != nil {
 		n.setWriteErrLocked(err)


### PR DESCRIPTION
When an outdated follower requires JetStream-layer stream catchup, but the leader goes down, and the follower then restarts. Upon recovery it will retry the catchup, which will fail because there's no leader. If the outdated follower can get quorum and become leader: the catchup would be aborted, and the follower would continue with missing data.

This is solved by not upping `n.applied` on recovery, because a server can only become leader if all commits are applied (so `n.commit==n.applied`). This requires the Raft recovery and snapshot processing on startup to finish before allowing the server to start a leader election.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>