### PR TITLE
(2.12) Exponential backoff on route/gateway reconnection attempts

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -138,7 +138,10 @@ const (
 	// DEFAULT_ROUTE_CONNECT Route solicitation intervals.
 	DEFAULT_ROUTE_CONNECT = 1 * time.Second
 
-	// DEFAULT_ROUTE_RECONNECT Route reconnect intervals.
+	// DEFAULT_ROUTE_CONNECT_MAX Route solicitation intervals (max).
+	DEFAULT_ROUTE_CONNECT_MAX = 30 * time.Second
+
+	// DEFAULT_ROUTE_RECONNECT Route reconnect delay.
 	DEFAULT_ROUTE_RECONNECT = 1 * time.Second
 
 	// DEFAULT_ROUTE_DIAL Route dial timeout.

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -35,6 +35,7 @@ import (
 const (
 	defaultSolicitGatewaysDelay         = time.Second
 	defaultGatewayConnectDelay          = time.Second
+	defaultGatewayConnectMaxDelay       = 30 * time.Second
 	defaultGatewayReconnectDelay        = time.Second
 	defaultGatewayRecentSubExpiration   = 2 * time.Second
 	defaultGatewayMaxRUnsubBeforeSwitch = 1000
@@ -59,6 +60,7 @@ const (
 
 var (
 	gatewayConnectDelay          = defaultGatewayConnectDelay
+	gatewayConnectMaxDelay       = defaultGatewayConnectMaxDelay
 	gatewayReconnectDelay        = defaultGatewayReconnectDelay
 	gatewayMaxRUnsubBeforeSwitch = defaultGatewayMaxRUnsubBeforeSwitch
 	gatewaySolicitDelay          = int64(defaultSolicitGatewaysDelay)
@@ -703,10 +705,11 @@ func (s *Server) reconnectGateway(cfg *gatewayCfg) {
 // to the given Gateway. It will return once a connection has been created.
 func (s *Server) solicitGateway(cfg *gatewayCfg, firstConnect bool) {
 	var (
-		opts       = s.getOpts()
-		isImplicit = cfg.isImplicit()
-		attempts   int
-		typeStr    string
+		opts         = s.getOpts()
+		isImplicit   = cfg.isImplicit()
+		attemptDelay = gatewayConnectDelay
+		attempts     int
+		typeStr      string
 	)
 	if isImplicit {
 		typeStr = "implicit"
@@ -769,7 +772,12 @@ func (s *Server) solicitGateway(cfg *gatewayCfg, firstConnect bool) {
 		select {
 		case <-s.quitCh:
 			return
-		case <-time.After(gatewayConnectDelay):
+		case <-time.After(attemptDelay):
+			// Use exponential backoff for connection attempts.
+			attemptDelay *= 2
+			if attemptDelay > gatewayConnectMaxDelay {
+				attemptDelay = gatewayConnectMaxDelay
+			}
 			continue
 		}
 	}


### PR DESCRIPTION
Implement exponential backoff for route/gateway reconnection attempts, which reduces log entries, DNS lookups etc. after network issues or outages. When the to-be-connected-to server comes back, it will immediately try to create connections to explicit routes (and setup any implicit), which makes the reduction in reconnection speed not really be an issue.

Leaf nodes can also often log and attempt reconnection, but those can already be configured to happen less often (default is 1s):
```
leafnodes {
    reconnect_interval: 30s
}
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>