### PR TITLE
NRG: Don't compact on catchup until snapshot written

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3595,12 +3595,6 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 			n.pterm = ae.pterm
 			n.commit = ae.pindex
 
-			if _, err := n.wal.Compact(n.pindex + 1); err != nil {
-				n.setWriteErrLocked(err)
-				n.Unlock()
-				return
-			}
-
 			snap := &snapshot{
 				lastTerm:  n.pterm,
 				lastIndex: n.pindex,


### PR DESCRIPTION
The `n.wal.Compact()` call before `n.installSnapshot()` is potentially dangerous in a crash scenario as we could blow away the log without having written the snapshot to disk yet. Once the snapshot is written, `n.installSnapshot()` will compact the log itself to the same index (as `lastIndex == n.pindex`).

Signed-off-by: Neil Twigg <neil@nats.io>