### PR TITLE
[FIXED] NRG: Fix server shutdown race condition

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1225,6 +1225,8 @@ func (js *jetStream) monitorCluster() {
 			doSnapshot()
 			return
 		case <-rqch:
+			// Clean signal from shutdown routine so do best effort attempt to snapshot meta layer.
+			doSnapshot()
 			return
 		case <-qch:
 			// Clean signal from shutdown routine so do best effort attempt to snapshot meta layer.

--- a/server/raft.go
+++ b/server/raft.go
@@ -1958,7 +1958,7 @@ func (n *raft) run() {
 	n.apply.push(nil)
 
 runner:
-	for s.isRunning() {
+	for {
 		switch n.State() {
 		case Follower:
 			n.runAsFollower()


### PR DESCRIPTION
The `for s.isRunning() {..}` makes sure the Raft run loop keeps running while the server is running and stops when it's done. Although this sounds sane, this actually results in a race condition. If the `n.State()` changes, for example if you're leader and do a leader transfer as part of shutting down, then this race condition could hit where `s.isRunning()` breaks us out of the loop, and then the `monitorCluster/Stream/Consumer` can't install a snapshot on shutdown.

The run loop can simply be a `for {..}`, because the last part of shutting down the server is `s.shutdownRaftNodes()` which stops any nodes that weren't stopped already. Which would properly break the loop.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>