### PR TITLE
[FIXED] Replicated NoWait/Expires request timeout

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5058,8 +5058,20 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 				o.ldt = time.Now()
 				// Need to send message to the client, since we have quorum to do so now.
 				if pmsg, ok := o.pendingDeliveries[sseq]; ok {
+					// Copy delivery subject and sequence first, as the send returns it to the pool and clears it.
+					dsubj, seq := pmsg.dsubj, pmsg.seq
 					o.outq.send(pmsg)
 					delete(o.pendingDeliveries, sseq)
+
+					// Might need to send a request timeout after sending the last replicated delivery.
+					if wd, ok := o.waitingDeliveries[dsubj]; ok && wd.seq == seq {
+						if wd.pn > 0 || wd.pb > 0 {
+							hdr := fmt.Appendf(nil, "NATS/1.0 408 Request Timeout\r\n%s: %d\r\n%s: %d\r\n\r\n", JSPullRequestPendingMsgs, wd.pn, JSPullRequestPendingBytes, wd.pb)
+							o.outq.send(newJSPubMsg(dsubj, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
+						}
+						wd.recycle()
+						delete(o.waitingDeliveries, dsubj)
+					}
 				}
 				o.mu.Unlock()
 				if err != nil {


### PR DESCRIPTION
Since https://github.com/nats-io/nats-server/pull/6792 we wait with delivering a message for a replicated consumer, until the delivery state is also replicated. However, that broke pull requests that use `NoWait` or `Expires`. A partial/quick fix was implemented in https://github.com/nats-io/nats-server/pull/6960 to not replicate deliveries for `NoWait`.

This PR solves the real issue, a Request Timeout now waits for replicated deliveries to finish or sends it immediately if there are no inflight replicated deliveries.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>