### PR TITLE
(2.12) JetStream Strict by default

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -558,7 +558,7 @@ func (s *Server) restartJetStream() error {
 		MaxMemory:    opts.JetStreamMaxMemory,
 		MaxStore:     opts.JetStreamMaxStore,
 		Domain:       opts.JetStreamDomain,
-		Strict:       opts.JetStreamStrict,
+		Strict:       !opts.NoJetStreamStrict,
 	}
 	s.Noticef("Restarting JetStream")
 	err := s.EnableJetStream(&cfg)
@@ -2539,7 +2539,7 @@ func (s *Server) dynJetStreamConfig(storeDir string, maxStore, maxMem int64) *Je
 	opts := s.getOpts()
 
 	// Strict mode.
-	jsc.Strict = opts.JetStreamStrict
+	jsc.Strict = !opts.NoJetStreamStrict
 
 	// Sync options.
 	jsc.SyncInterval = opts.SyncInterval

--- a/server/opts.go
+++ b/server/opts.go
@@ -336,7 +336,7 @@ type Options struct {
 	Gateway                    GatewayOpts   `json:"gateway,omitempty"`
 	LeafNode                   LeafNodeOpts  `json:"leaf,omitempty"`
 	JetStream                  bool          `json:"jetstream"`
-	JetStreamStrict            bool          `json:"-"`
+	NoJetStreamStrict          bool          `json:"-"` // Strict by default.
 	JetStreamMaxMemory         int64         `json:"-"`
 	JetStreamMaxStore          int64         `json:"-"`
 	JetStreamDomain            string        `json:"-"`
@@ -2416,7 +2416,7 @@ func parseJetStream(v any, opts *Options, errors *[]error, warnings *[]error) er
 			switch strings.ToLower(mk) {
 			case "strict":
 				if v, ok := mv.(bool); ok {
-					opts.JetStreamStrict = v
+					opts.NoJetStreamStrict = !v
 				} else {
 					return &configErr{tk, fmt.Sprintf("Expected 'true' or 'false' for bool value, got '%s'", mv)}
 				}

--- a/server/server.go
+++ b/server/server.go
@@ -2378,7 +2378,7 @@ func (s *Server) Start() {
 			StoreDir:     opts.StoreDir,
 			SyncInterval: opts.SyncInterval,
 			SyncAlways:   opts.SyncAlways,
-			Strict:       opts.JetStreamStrict,
+			Strict:       !opts.NoJetStreamStrict,
 			MaxMemory:    opts.JetStreamMaxMemory,
 			MaxStore:     opts.JetStreamMaxStore,
 			Domain:       opts.JetStreamDomain,

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -35,7 +35,7 @@ var DefaultTestOptions = Options{
 	NoSigs:                true,
 	MaxControlLine:        4096,
 	DisableShortFirstPing: true,
-	JetStreamStrict:       true,
+	NoJetStreamStrict:     false,
 }
 
 func testDefaultClusterOptionsForLeafNodes() *Options {


### PR DESCRIPTION
Flipped to `opts.NoJetStreamStrict` so any empty `Options{}` will have JetStream be strict by default.

Resolves https://github.com/nats-io/nats-server/issues/6539

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
