### PR TITLE
De-flake TestGatewayTLSMixedIPAndDNS

### DIFF
--- a/test/gateway_test.go
+++ b/test/gateway_test.go
@@ -621,6 +621,7 @@ func TestGatewayTLSMixedIPAndDNS(t *testing.T) {
 					ca_file:   "./configs/certs/ca.pem"
 					timeout: 2
 				}
+				connect_retries: 3
 			}
 			cluster {
 				listen: "127.0.0.1:-1"
@@ -640,6 +641,7 @@ func TestGatewayTLSMixedIPAndDNS(t *testing.T) {
 					ca_file:   "./configs/certs/ca.pem"
 					timeout: 2
 				}
+				connect_retries: 3
 			}
 			cluster {
 				listen: "127.0.0.1:-1"


### PR DESCRIPTION
The would flake (especially under CI) when the first gateway connection would fail. The reconnect would not be done because they are implicit gateway connections for this test, which don't retry unless configured. Configuring retries makes this test not flake anymore.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>