### PR TITLE
[FIXED] Pull consumer AckWait signals still active

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -1425,7 +1425,7 @@ func TestJetStreamClusterPullConsumerAcksExtendInactivityThreshold(t *testing.T)
 	}
 
 	// Pull Consumer
-	sub, err := js.PullSubscribe("foo", "d", nats.InactiveThreshold(time.Second))
+	sub, err := js.PullSubscribe("foo", "d", nats.InactiveThreshold(time.Second), nats.AckWait(time.Second))
 	require_NoError(t, err)
 
 	fetchMsgs(t, sub, n/2, time.Second)
@@ -1453,7 +1453,7 @@ func TestJetStreamClusterPullConsumerAcksExtendInactivityThreshold(t *testing.T)
 	require_NoError(t, err)
 
 	// Make sure it gets cleaned up.
-	time.Sleep(2 * time.Second)
+	time.Sleep(3500 * time.Millisecond)
 	_, err = js.ConsumerInfo("TEST", "d")
 	require_Error(t, err, nats.ErrConsumerNotFound)
 }


### PR DESCRIPTION
For a pull consumer that has an `AckWait: 30s` and an `InactiveThreshold: 5s`, if it fetches a few messages and only acks all of them after 20 seconds, it will be removed due to inactivity.

Pending acks should count toward activity, even if we've not heard from the consumer in a while, we can safely assume they're processing the message if still within `AckWait` and must not mark it inactive early.

Resolves https://github.com/nats-io/nats.go/issues/1900

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>