### PR TITLE
add sync.Pool for compression writers.

### DIFF
--- a/server/compress.go
+++ b/server/compress.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"compress/gzip"
+	"io"
+	"sync"
+
+	"github.com/klauspost/compress/s2"
+)
+
+var Gzip gzipPool
+var Snappy snappyPool
+
+type gzipPool struct {
+	writers sync.Pool
+}
+
+type snappyPool struct {
+	writers sync.Pool
+}
+
+func (pool *gzipPool) GetWriter(dst io.Writer) (writer *gzip.Writer) {
+	if w := pool.writers.Get(); w != nil {
+		writer = w.(*gzip.Writer)
+		writer.Reset(dst)
+	} else {
+		writer = gzip.NewWriter(dst)
+	}
+
+	return writer
+}
+
+func (pool *gzipPool) PutWriter(writer *gzip.Writer) {
+	writer.Close()
+	pool.writers.Put(writer)
+}
+
+func (pool *snappyPool) GetWriter(dst io.Writer) (writer *s2.Writer) {
+	if w := pool.writers.Get(); w != nil {
+		writer = w.(*s2.Writer)
+		writer.Reset(dst)
+	} else {
+		writer = s2.NewWriter(dst, s2.WriterSnappyCompat())
+	}
+
+	return writer
+}
+
+func (pool *snappyPool) PutWriter(writer *s2.Writer) {
+	writer.Close()
+	pool.writers.Put(writer)
+}

--- a/server/compress_test.go
+++ b/server/compress_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"testing"
+
+	"github.com/klauspost/compress/s2"
+)
+
+func TestGzipPool_CompressDecompress(t *testing.T) {
+	original := []byte("gzip compression pool test")
+	var buf bytes.Buffer
+
+	writer := Gzip.GetWriter(&buf)
+	if _, err := writer.Write(original); err != nil {
+		t.Fatalf("gzip write failed: %v", err)
+	}
+
+	Gzip.PutWriter(writer)
+
+	r, err := gzip.NewReader(&buf)
+	if err != nil {
+		t.Fatalf("gzip.NewReader failed: %v", err)
+	}
+	defer r.Close()
+
+	result, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading gzip decompressed data failed: %v", err)
+	}
+	if !bytes.Equal(original, result) {
+		t.Fatalf("decompressed gzip data does not match original.\nGot: %q\nWant: %q", result, original)
+	}
+}
+
+func TestSnappyPool_CompressDecompress(t *testing.T) {
+	original := []byte("snappy compression pool test")
+	var buf bytes.Buffer
+
+	writer := Snappy.GetWriter(&buf)
+	if _, err := writer.Write(original); err != nil {
+		t.Fatalf("snappy write failed: %v", err)
+	}
+
+	Snappy.PutWriter(writer)
+
+	result, err := s2.Decode(nil, buf.Bytes())
+	if err != nil {
+		t.Fatalf("snappy decode failed: %v", err)
+	}
+	if !bytes.Equal(original, result) {
+		t.Fatalf("decompressed snappy data does not match original.\nGot: %q\nWant: %q", result, original)
+	}
+}

--- a/server/events.go
+++ b/server/events.go
@@ -15,7 +15,6 @@ package server
 
 import (
 	"bytes"
-	"compress/gzip"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/json"
@@ -32,7 +31,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/server/certidp"
 	"github.com/nats-io/nats-server/v2/server/pse"
@@ -579,15 +577,15 @@ RESET:
 				if len(b) > 0 {
 					switch pm.oct {
 					case gzipCompression:
-						zw := gzip.NewWriter(&bb)
+						zw := Gzip.GetWriter(&bb)
 						zw.Write(b)
-						zw.Close()
+						Gzip.PutWriter(zw)
 						b = bb.Bytes()
 						contentHeader = "gzip"
 					case snappyCompression:
-						sw := s2.NewWriter(&bb, s2.WriterSnappyCompat())
+						sw := Snappy.GetWriter(&bb)
 						sw.Write(b)
-						sw.Close()
+						Snappy.PutWriter(sw)
 						b = bb.Bytes()
 						contentHeader = "snappy"
 					case unsupportedCompression:


### PR DESCRIPTION
Should greatly reduce CPU and memory when using compression.
should help resolve:
https://github.com/nats-io/nats-server/issues/7037

Signed-off-by: Aryeh Klein aryehlevklein@gmail.com
