### PR TITLE
[FIXED] Get header value with shared prefix

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4355,7 +4355,7 @@ func sliceHeader(key string, hdr []byte) []byte {
 	if len(hdr) == 0 {
 		return nil
 	}
-	index := bytes.Index(hdr, stringToBytes(key))
+	index := bytes.Index(hdr, stringToBytes(key+":"))
 	hdrLen := len(hdr)
 	// Check that we have enough characters, this will handle the -1 case of the key not
 	// being found and will also handle not having enough characters for trailing CRLF.

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -3038,6 +3038,26 @@ func TestSliceHeader(t *testing.T) {
 	require_True(t, bytes.Equal(sliced, copied))
 }
 
+func TestSliceHeaderOrdering(t *testing.T) {
+	hdr := []byte("NATS/1.0\r\n\r\n")
+
+	// These headers share the same prefix, the longer subject
+	// must not invalidate the existence of the shorter one.
+	hdr = genHeader(hdr, JSExpectedLastSubjSeqSubj, "foo")
+	hdr = genHeader(hdr, JSExpectedLastSubjSeq, "24")
+
+	sliced := sliceHeader(JSExpectedLastSubjSeq, hdr)
+	copied := getHeader(JSExpectedLastSubjSeq, hdr)
+
+	require_NotNil(t, sliced)
+	require_Equal(t, cap(sliced), 2)
+
+	require_NotNil(t, copied)
+	require_Equal(t, cap(copied), len(copied))
+
+	require_True(t, bytes.Equal(sliced, copied))
+}
+
 func TestInProcessAllowedConnectionType(t *testing.T) {
 	tmpl := `
 		listen: "127.0.0.1:-1"


### PR DESCRIPTION
`Nats-Expected-Last-Subject-Sequence-Subject` and `Nats-Expected-Last-Subject-Sequence` share a common prefix. We could not get the proper value for the latter header depending on the ordering in the headers.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>