### PR TITLE
De-flake TestJetStreamClusterConsumerInfoAfterCreate

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -7032,6 +7032,9 @@ func TestJetStreamClusterConsumerInfoAfterCreate(t *testing.T) {
 		require_NoError(t, json.Unmarshal(resp.Data, &sdr))
 	}
 
+	// Wait some time for the leader to settle.
+	time.Sleep(500 * time.Millisecond)
+
 	// Scale down to ensure the consumer gets created on this server.
 	cfg.Replicas = 1
 	si, err = js.UpdateStream(cfg)


### PR DESCRIPTION
Wait some time for the leader to be stable, scaling down the stream requires the meta leader to ask who the current stream leader is. If that fails, the meta leader might remove the wrong peers.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
