### PR TITLE
(2.11) Include original subject in `Nats-Stream-Source`, use in counter sourcing map

### DIFF
--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -164,8 +164,8 @@ func checkMsgHeadersPreClusteredProposal(
 			fields := strings.Split(string(srchdr), " ")
 			origStream := fields[0]
 			origSubj := subject
-			if len(fields) >= 3 {
-				origSubj = fields[2]
+			if len(fields) >= 5 {
+				origSubj = fields[4]
 			}
 			var val CounterValue
 			if json.Unmarshal(msg, &val) != nil {

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -292,12 +292,12 @@ func TestJetStreamAtomicBatchPublishSourceAndMirror(t *testing.T) {
 		rsm, err = js.GetMsg("S", 1)
 		require_NoError(t, err)
 		require_Len(t, len(rsm.Header), 1)
-		require_Equal(t, rsm.Header.Get(JSStreamSource), "TEST 1 > >")
+		require_Equal(t, rsm.Header.Get(JSStreamSource), "TEST 1 > > foo")
 
 		rsm, err = js.GetMsg("S", 2)
 		require_NoError(t, err)
 		require_Len(t, len(rsm.Header), 1)
-		require_Equal(t, rsm.Header.Get(JSStreamSource), "TEST 3 > >")
+		require_Equal(t, rsm.Header.Get(JSStreamSource), "TEST 3 > > foo")
 	}
 
 	t.Run("R1", func(t *testing.T) { test(t, 1) })

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -20755,11 +20755,11 @@ func TestJetStreamAllowMsgCounterSourceAggregates(t *testing.T) {
 			Sources: []*StreamSource{
 				{
 					Name:              "O1",
-					SubjectTransforms: []SubjectTransformConfig{{Source: "foo.1", Destination: "foo"}},
+					SubjectTransforms: []SubjectTransformConfig{{Source: "foo.*", Destination: "foo"}},
 				},
 				{
 					Name:              "O2",
-					SubjectTransforms: []SubjectTransformConfig{{Source: "foo.2", Destination: "foo"}},
+					SubjectTransforms: []SubjectTransformConfig{{Source: "foo.*", Destination: "foo"}},
 				},
 			},
 			Storage:         FileStorage,
@@ -20840,11 +20840,11 @@ func TestJetStreamAllowMsgCounterSourceVerbatim(t *testing.T) {
 			Sources: []*StreamSource{
 				{
 					Name:              "O1",
-					SubjectTransforms: []SubjectTransformConfig{{Source: "foo.1", Destination: "foo"}},
+					SubjectTransforms: []SubjectTransformConfig{{Source: "foo.*", Destination: "foo"}},
 				},
 				{
 					Name:              "O2",
-					SubjectTransforms: []SubjectTransformConfig{{Source: "foo.2", Destination: "foo"}},
+					SubjectTransforms: []SubjectTransformConfig{{Source: "foo.*", Destination: "foo"}},
 				},
 			},
 			Storage:         FileStorage,
@@ -20974,11 +20974,11 @@ func TestJetStreamAllowMsgCounterSourceStartingAboveZero(t *testing.T) {
 			Sources: []*StreamSource{
 				{
 					Name:              "O1",
-					SubjectTransforms: []SubjectTransformConfig{{Source: "foo.1", Destination: "foo"}},
+					SubjectTransforms: []SubjectTransformConfig{{Source: "foo.*", Destination: "foo"}},
 				},
 				{
 					Name:              "O2",
-					SubjectTransforms: []SubjectTransformConfig{{Source: "foo.2", Destination: "foo"}},
+					SubjectTransforms: []SubjectTransformConfig{{Source: "foo.*", Destination: "foo"}},
 				},
 			},
 			Storage:         FileStorage,


### PR DESCRIPTION
This fixes a potential footgun with counter sourcing whereby you may have a subject transform from a single stream with a wildcard source but a non-wildcard destination, i.e. `foo.>` into `bar`. Without this, we would not correctly track `foo.baz` and `foo.qux` separately, causing a consistency error.

Signed-off-by: Neil Twigg <neil@nats.io>