### PR TITLE
[CHANGED] Make monitoring overview page aesthetically more pleasant

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1437,7 +1437,8 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 		a.last { padding-bottom: 16px }
 		a.version { font-size: 14; font-weight: 400; width: 312px; text-align: right; margin-top: -2rem }
 		a.version:hover { color: rgb(22 22 32) }
-		.endpoint { font-size: 12px; color: #999; font-family: monospace }
+		.endpoint { font-size: 12px; color: #999; font-family: monospace; display: none }
+		a:hover .endpoint { display: inline }
 
 	</style>
 	</head>


### PR DESCRIPTION
Follow-up to https://github.com/nats-io/nats-server/pull/7066

Still simplifies life of dummies who do not remember all the endpoints by heart, but also makes UI not cluttered by showing endpoint only on hover
<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/1668b499-5565-4150-a05d-fd1ff4f2749d" />



Signed-off-by: Alex Bozhenko <alexbozhenko@gmail.com>
