### PR TITLE
(2.12) Atomic batch: limits & cleanup after timeout

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -1768,5 +1768,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSAtomicPublishInvalidBatchIDErr",
+    "code": 400,
+    "error_code": 10179,
+    "description": "atomic publish batch ID is invalid",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -14,6 +14,9 @@ const (
 	// JSAtomicPublishIncompleteBatchErr atomic publish batch is incomplete
 	JSAtomicPublishIncompleteBatchErr ErrorIdentifier = 10176
 
+	// JSAtomicPublishInvalidBatchIDErr atomic publish batch ID is invalid
+	JSAtomicPublishInvalidBatchIDErr ErrorIdentifier = 10179
+
 	// JSAtomicPublishMissingSeqErr atomic publish sequence is missing
 	JSAtomicPublishMissingSeqErr ErrorIdentifier = 10175
 
@@ -542,6 +545,7 @@ var (
 		JSAccountResourcesExceededErr:              {Code: 400, ErrCode: 10002, Description: "resource limits exceeded for account"},
 		JSAtomicPublishDisabledErr:                 {Code: 400, ErrCode: 10174, Description: "atomic publish is disabled"},
 		JSAtomicPublishIncompleteBatchErr:          {Code: 400, ErrCode: 10176, Description: "atomic publish batch is incomplete"},
+		JSAtomicPublishInvalidBatchIDErr:           {Code: 400, ErrCode: 10179, Description: "atomic publish batch ID is invalid"},
 		JSAtomicPublishMissingSeqErr:               {Code: 400, ErrCode: 10175, Description: "atomic publish sequence is missing"},
 		JSAtomicPublishUnsupportedHeaderBatchErr:   {Code: 400, ErrCode: 10177, Description: "atomic publish unsupported header used: {header}"},
 		JSBadRequestErr:                            {Code: 400, ErrCode: 10003, Description: "bad request"},
@@ -769,6 +773,16 @@ func NewJSAtomicPublishIncompleteBatchError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSAtomicPublishIncompleteBatchErr]
+}
+
+// NewJSAtomicPublishInvalidBatchIDError creates a new JSAtomicPublishInvalidBatchIDErr error: "atomic publish batch ID is invalid"
+func NewJSAtomicPublishInvalidBatchIDError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSAtomicPublishInvalidBatchIDErr]
 }
 
 // NewJSAtomicPublishMissingSeqError creates a new JSAtomicPublishMissingSeqErr error: "atomic publish sequence is missing"

--- a/server/stream.go
+++ b/server/stream.go
@@ -301,6 +301,21 @@ const (
 	streamDefaultMaxQueueBytes = 1024 * 1024 * 128
 )
 
+// For managing stream batches.
+const (
+	streamDefaultMaxBatchInflightPerStream = 50
+	streamDefaultMaxBatchInflightTotal     = 1000
+	streamDefaultMaxBatchSize              = 1000
+	streamDefaultMaxBatchTimeout           = 10 * time.Second
+)
+
+var (
+	streamMaxBatchInflightPerStream = streamDefaultMaxBatchInflightPerStream
+	streamMaxBatchInflightTotal     = streamDefaultMaxBatchInflightTotal
+	streamMaxBatchSize              = streamDefaultMaxBatchSize
+	streamMaxBatchTimeout           = streamDefaultMaxBatchTimeout
+)
+
 // Stream is a jetstream stream of messages. When we receive a message internally destined
 // for a Stream we will direct link from the client to this structure.
 type stream struct {


### PR DESCRIPTION
Limits for batches can now be configured with the following settings (listed values are the defaults):
```
jetstream {
    limits {
        batch {
            max_inflight_per_stream: 50
            max_inflight_total: 1000
            max_msgs: 1000
            timeout: 10s
        }
    }
}
```

Additional to the above listed limits, there's also a hard-coded limit of 64 characters for the `Nats-Batch-Id`. This protects the system and ensures very long IDs will not need to be stored in the batching map.

Resolves https://github.com/nats-io/nats-server/issues/6977

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>