### PR TITLE
[FIXED] Processes config file during embeded server initialization.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -685,6 +685,9 @@ func New(opts *Options) *Server {
 // The provided Options type should not be re-used afterwards.
 // Either use Options.Clone() to pass a copy, or make a new one.
 func NewServer(opts *Options) (*Server, error) {
+	if opts.ConfigFile != _EMPTY_ {
+		opts.ProcessConfigFile(opts.ConfigFile)
+	}
 	setBaselineOptions(opts)
 
 	// Process TLS options, including whether we require client certificates.


### PR DESCRIPTION
Resolves #7092
Edited the  NewServer function in the server package , server.go file. Using the ProcessConfigFile method of the Options type, to enable the embeded nats-server to read the config file
Signed-off-by: orician <lzjzxOYX201905@gmail.com>
