### PR TITLE
ci: add loong64 to release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,7 @@ builds:
       - arm
       - arm64
       - 386
+      - loong64
       - mips64le
       - s390x
       - ppc64le


### PR DESCRIPTION
I need nats-server release to build container image for loong64. https://hub.docker.com/u/loongarch64\
[GoReleaser](https://github.com/goreleaser/goreleaser) has officially supported loong64 architecture. https://github.com/goreleaser/goreleaser/pull/3277

Signed-off-by: znley <shanjiantao@loongson.cn>
