### PR TITLE
NRG: Truncate back to snapshot properly

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3570,6 +3570,10 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 						// Entry can't be found, this is normal because we have a snapshot at this index.
 						// Truncate back to where we've created the snapshot.
 						n.truncateWAL(snap.lastTerm, snap.lastIndex)
+						// Only continue if truncation was successful, and we ended up such that we can safely continue.
+						if ae.pterm == n.pterm && ae.pindex == n.pindex {
+							goto CONTINUE
+						}
 					} else {
 						// Otherwise, something has gone very wrong and we need to reset.
 						n.resetWAL()

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -2971,8 +2971,13 @@ func TestNRGReplayOnSnapshotDifferentTerm(t *testing.T) {
 	// Replay the append entry that matches our snapshot.
 	// This can happen as a repeated entry, or a delayed append entry after having already received it in a catchup.
 	// Should be recognized as truncating back to the installed snapshot, not reset the WAL fully.
+	// Since all is aligned after truncation, should also be able to apply the entry.
 	n.processAppendEntry(aeMsg2, n.aesub)
-	require_Equal(t, n.pindex, 1)
+	require_Equal(t, n.pindex, 2)
+
+	// Should now also be able to apply the third entry.
+	n.processAppendEntry(aeMsg3, n.aesub)
+	require_Equal(t, n.pindex, 3)
 }
 
 // This is a RaftChainOfBlocks test where a block is proposed and then we wait for all replicas to apply it before

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -2883,6 +2883,98 @@ func TestNRGInitializeAndScaleUp(t *testing.T) {
 	require_False(t, vr.empty)
 }
 
+func TestNRGReplayOnSnapshotSameTerm(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// Create a sample entry, the content doesn't matter, just that it's stored.
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	// Timeline
+	aeMsg1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 0, pindex: 0, entries: entries})
+	aeMsg2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 1, entries: entries})
+	aeMsg3 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 2, entries: entries})
+
+	// Process the first append entry.
+	n.processAppendEntry(aeMsg1, n.aesub)
+	require_Equal(t, n.pindex, 1)
+
+	// Commit and apply.
+	require_NoError(t, n.applyCommit(1))
+	require_Equal(t, n.commit, 1)
+	n.Applied(1)
+	require_Equal(t, n.applied, 1)
+
+	// Install snapshot.
+	require_NoError(t, n.InstallSnapshot(nil))
+	snap, err := n.loadLastSnapshot()
+	require_NoError(t, err)
+	require_Equal(t, snap.lastIndex, 1)
+
+	// Process other messages.
+	n.processAppendEntry(aeMsg2, n.aesub)
+	require_Equal(t, n.pindex, 2)
+	n.processAppendEntry(aeMsg3, n.aesub)
+	require_Equal(t, n.pindex, 3)
+
+	// Replay the append entry that matches our snapshot.
+	// This can happen as a repeated entry, or a delayed append entry after having already received it in a catchup.
+	// Should be recognized as a replay with the same term, marked as success, and not truncate.
+	n.processAppendEntry(aeMsg2, n.aesub)
+	require_Equal(t, n.pindex, 3)
+}
+
+func TestNRGReplayOnSnapshotDifferentTerm(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// Create a sample entry, the content doesn't matter, just that it's stored.
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	// Timeline
+	aeMsg1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 0, pindex: 0, entries: entries, lterm: 2})
+	aeMsg2 := encode(t, &appendEntry{leader: nats0, term: 2, commit: 1, pterm: 1, pindex: 1, entries: entries, lterm: 2})
+	aeMsg3 := encode(t, &appendEntry{leader: nats0, term: 2, commit: 1, pterm: 2, pindex: 2, entries: entries, lterm: 2})
+
+	// Process the first append entry.
+	n.processAppendEntry(aeMsg1, n.aesub)
+	require_Equal(t, n.pindex, 1)
+
+	// Commit and apply.
+	require_NoError(t, n.applyCommit(1))
+	require_Equal(t, n.commit, 1)
+	n.Applied(1)
+	require_Equal(t, n.applied, 1)
+
+	// Install snapshot.
+	require_NoError(t, n.InstallSnapshot(nil))
+	snap, err := n.loadLastSnapshot()
+	require_NoError(t, err)
+	require_Equal(t, snap.lastIndex, 1)
+
+	// Reset applied to simulate having received the snapshot from
+	// another leader, and we didn't apply yet since it's async.
+	n.applied = 0
+
+	// Process other messages.
+	n.processAppendEntry(aeMsg2, n.aesub)
+	require_Equal(t, n.pindex, 2)
+	n.processAppendEntry(aeMsg3, n.aesub)
+	require_Equal(t, n.pindex, 3)
+
+	// Replay the append entry that matches our snapshot.
+	// This can happen as a repeated entry, or a delayed append entry after having already received it in a catchup.
+	// Should be recognized as truncating back to the installed snapshot, not reset the WAL fully.
+	n.processAppendEntry(aeMsg2, n.aesub)
+	require_Equal(t, n.pindex, 1)
+}
+
 // This is a RaftChainOfBlocks test where a block is proposed and then we wait for all replicas to apply it before
 // proposing the next one.
 // The test may fail if:


### PR DESCRIPTION
We would not truncate back to a snapshot properly if `n.applied` was not caught up or moved further ahead.

For example:
- outdated server catches up and gets a snapshot at index 10 (`n.commit = 10`, but `n.applied = 0` still)
- server misses message at index 11
- server receives message at index 12 and catches up between indices 10-12
- server now receives message at index 11 with a delay (the `ae.pindex` will be 10, so it requires a consistency check on an append entry that doesn't exist because a snapshot is there)
- we now need to truncate the log back to the snapshot (we would reset the WAL fully, which is bad)

We now check if we can truncate back to the snapshot successfully, otherwise we still reset the WAL as before.

Also improved some logs to make debug lines more helpful when debugging issues.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>