### PR TITLE
[IMPROVED] NRG: remove StreamState usage in n.Applied and n.Size & async flush compacted tombstones 

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -8478,8 +8478,17 @@ SKIP:
 	smb.mu.Unlock()
 
 	// Write any tombstones as needed.
-	for _, tomb := range tombs {
-		fs.writeTombstone(tomb.seq, tomb.ts)
+	// When writing multiple tombstones we will flush at the end.
+	if len(tombs) > 0 {
+		for _, tomb := range tombs {
+			if err := fs.writeTombstoneNoFlush(tomb.seq, tomb.ts); err != nil {
+				return purged, err
+			}
+		}
+		// Flush any pending. If we change blocks the newMsgBlockForWrite() will flush any pending for us.
+		if lmb := fs.lmb; lmb != nil {
+			lmb.flushPendingMsgs()
+		}
 	}
 
 	if deleted > 0 {

--- a/server/raft.go
+++ b/server/raft.go
@@ -143,7 +143,6 @@ type raft struct {
 	wal   WAL         // WAL store (filestore or memstore)
 	wtype StorageType // WAL type, e.g. FileStorage or MemoryStorage
 	bytes uint64      // Total amount of bytes stored in the WAL. (Saves us from needing to call wal.FastState very often)
-	track bool        //
 	werr  error       // Last write error
 
 	state       atomic.Int32 // RaftState
@@ -176,25 +175,19 @@ type raft struct {
 
 	leader string // The ID of the leader
 	vote   string // Our current vote state
-	lxfer  bool   // Are we doing a leadership transfer?
-
-	hcbehind bool // Were we falling behind at the last health check? (see: isCurrent)
 
 	s  *Server    // Reference to top-level server
 	c  *client    // Internal client for subscriptions
 	js *jetStream // JetStream, if running, to see if we are out of resources
 
-	dflag       bool        // Debug flag
-	hasleader   atomic.Bool // Is there a group leader right now?
-	pleader     atomic.Bool // Has the group ever had a leader?
-	isSysAcc    atomic.Bool // Are we utilizing the system account?
-	maybeLeader bool        // The group had a preferred leader. And is maybe already acting as leader prior to scale up.
-
-	observer     bool // The node is observing, i.e. not able to become leader
-	initializing bool // The node is new, and "empty log" checks can be temporarily relaxed.
-	scaleUp      bool // The node is part of a scale up, puts us in observer mode until the log contains data.
+	hasleader atomic.Bool // Is there a group leader right now?
+	pleader   atomic.Bool // Has the group ever had a leader?
+	isSysAcc  atomic.Bool // Are we utilizing the system account?
 
 	extSt extensionState // Extension state
+
+	track bool // Whether out of resources checking is enabled.
+	dflag bool // Debug flag
 
 	psubj  string // Proposals subject
 	rpsubj string // Remove peers subject
@@ -212,7 +205,6 @@ type raft struct {
 	catchup  *catchupState               // For when we need to catch up as a follower.
 	progress map[string]*ipQueue[uint64] // For leader or server catching up a follower.
 
-	paused  bool   // Whether or not applies are paused
 	hcommit uint64 // The commit at the time that applies were paused
 
 	prop  *ipQueue[*proposedEntry]       // Proposals
@@ -223,6 +215,14 @@ type raft struct {
 	votes *ipQueue[*voteResponse]        // Vote responses
 	leadc chan bool                      // Leader changes
 	quit  chan struct{}                  // Raft group shutdown
+
+	lxfer        bool // Are we doing a leadership transfer?
+	hcbehind     bool // Were we falling behind at the last health check? (see: isCurrent)
+	maybeLeader  bool // The group had a preferred leader. And is maybe already acting as leader prior to scale up.
+	paused       bool // Whether or not applies are paused
+	observer     bool // The node is observing, i.e. not able to become leader
+	initializing bool // The node is new, and "empty log" checks can be temporarily relaxed.
+	scaleUp      bool // The node is part of a scale up, puts us in observer mode until the log contains data.
 }
 
 type proposedEntry struct {


### PR DESCRIPTION
Every call to `n.Applied` would result in calling `n.wal.FastState`, we can prevent this from happening by adding some additional tracking in the `raft` struct itself to not need to call out. The `raft` struct is now also aligned.

Any tombstones that need to be written as part of the `Compact` are now flushed async, similar to `PurgeEx`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>