### PR TITLE
(2.12) Don't propose deletion of failed consumer assignment

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5679,13 +5679,10 @@ func (js *jetStream) processConsumerAssignmentResults(sub *subscription, c *clie
 
 			// Check if this failed.
 			// TODO(dlc) - Could have mixed results, should track per peer.
-			// Make sure this is recent response, do not delete existing consumers.
+			// Make sure this is recent response.
 			if result.Response.Error != nil && result.Response.Error != NewJSConsumerNameExistError() && time.Since(ca.Created) < 2*time.Second {
-				// So while we are deleting we will not respond to list/names requests.
+				// Do not list in consumer names/lists.
 				ca.err = NewJSClusterNotAssignedError()
-				cc.meta.Propose(encodeDeleteConsumerAssignment(ca))
-				s.Warnf("Proposing to delete consumer `%s > %s > %s' due to assignment response error: %v",
-					result.Account, result.Stream, result.Consumer, result.Response.Error)
 			}
 		}
 	}


### PR DESCRIPTION
The way that consumer assignments were proposed was changed in #7071 so that the stream leader is responsible for those updates instead of the metaleader. This subtly changes the timing involved in stream moves and cancels, as it is now not a given that the consumer assignments are always serialised with stream assignments in the same order. If a consumer assignment fails due to a cancelled stream move for example, we should not propose deleting the consumer, as the new stream leader will shortly come along and update the assignment correctly for the new placement.

Signed-off-by: Neil Twigg <neil@nats.io>