### PR TITLE
(2.12) [FIXED] Leaf node without auth doesn't default to global account

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -697,6 +697,11 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 	if !authRequired {
 		// TODO(dlc) - If they send us credentials should we fail?
 		s.mu.Unlock()
+		if c.kind == LEAF {
+			// Auth is not required, register the leaf node with the selected account.
+			// Otherwise, auth needs to match client auth.
+			return s.registerLeafWithAccount(c, opts.LeafNode.Account)
+		}
 		return true
 	}
 	var (
@@ -1094,12 +1099,6 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 			}
 			return comparePasswords(password, c.opts.Password)
 		}
-	} else if c.kind == LEAF {
-		// There is no required username/password to connect and
-		// there was no u/p in the CONNECT or none that matches the
-		// know users. Register the leaf connection with global account
-		// or the one specified in config (if provided).
-		return s.registerLeafWithAccount(c, opts.LeafNode.Account)
 	}
 	return false
 }

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -630,9 +630,9 @@ func TestLeafNodeBasicAuthSingleton(t *testing.T) {
 		lnURLCreds string
 		shouldFail bool
 	}{
-		{"no user creds required and no user so binds to ACC1", "", "", false},
-		{"no user creds required and pick user2 associated to ACC2", "", "user2:user2@", false},
-		{"no user creds required and unknown user should fail", "", "unknown:user@", true},
+		{"user creds required and no user so fails", "", "", true},
+		{"user creds required and pick user2 associated to ACC2", "", "user2:user2@", false},
+		{"user creds required and unknown user should fail", "", "unknown:user@", true},
 		{"user creds required so binds to ACC1", "user: \"ln\"\npass: \"pwd\"", "ln:pwd@", false},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/test/leafnode_test.go
+++ b/test/leafnode_test.go
@@ -2755,7 +2755,7 @@ func TestLeafNodeServiceImportLikeNGS(t *testing.T) {
 
 	// Now create a leafnode server on B.
 	opts = cb.opts[1]
-	sl, slOpts := runSolicitLeafServer(opts)
+	sl, slOpts := runSolicitLeafServerToURL(fmt.Sprintf("nats-leaf://dlc:pass@%s:%d", opts.LeafNode.Host, opts.LeafNode.Port))
 	defer sl.Shutdown()
 
 	checkLeafNodeConnected(t, sl)
@@ -2952,7 +2952,8 @@ func TestLeafNodeDistributedQueueAcrossGWs(t *testing.T) {
 	createLNS := func(c *cluster) (*server.Server, *server.Options) {
 		t.Helper()
 		// Pick one at random.
-		s, opts := runSolicitLeafServer(c.opts[rand.Intn(len(c.servers))])
+		copts := c.opts[rand.Intn(len(c.servers))]
+		s, opts := runSolicitLeafServerToURL(fmt.Sprintf("nats-leaf://dlc:pass@%s:%d", copts.LeafNode.Host, copts.LeafNode.Port))
 		checkLeafNodeConnected(t, s)
 		return s, opts
 	}
@@ -3032,7 +3033,7 @@ func TestLeafNodeDistributedQueueEvenly(t *testing.T) {
 		t.Helper()
 		// Pick one at random.
 		copts := c.opts[rand.Intn(len(c.servers))]
-		s, opts := runSolicitLeafServer(copts)
+		s, opts := runSolicitLeafServerToURL(fmt.Sprintf("nats-leaf://dlc:pass@%s:%d", copts.LeafNode.Host, copts.LeafNode.Port))
 		checkLeafNodeConnected(t, s)
 		return s, opts
 	}
@@ -3753,7 +3754,11 @@ func TestServiceExportWithLeafnodeRestart(t *testing.T) {
 		listen: 127.0.0.1:-1
 		leafnodes {
 			listen: "127.0.0.1:-1"
-			authorization { account:"EXTERNAL" }
+			authorization {
+				account:"EXTERNAL"
+				user: ln
+				password: pass
+			}
 		}
 
 		accounts: {
@@ -3798,7 +3803,7 @@ func TestServiceExportWithLeafnodeRestart(t *testing.T) {
 			listen: "127.0.0.1:-1"
 			remotes = [
 			{
-				url:"nats://127.0.0.1:%d"
+				url:"nats://ln:pass@127.0.0.1:%d"
 				account:"EXTERNAL_GOOD"
 			}
 			]


### PR DESCRIPTION
A leafnode could connect to a server without any credentials and be assigned to the global account. Even if the server we're connecting to requires auth, the leafnode connection would bypass that and connect it to the global account, even if a global account is not configured and nobody is listening in that account.

This is not an issue for decentralized auth or when using auth callout, as they will reject if respectively no valid JWT or credentials are passed. In other setups we need to also respect authentication and require the leafnode to have the proper credentials. This resolves confusing situations where accounts and authentication is defined, but a leafnode is able to connect without creds, connects to the global account, and proceeds to not be usable at all.

Either the leafnode requires proper credentials to be passed when connecting, or `no_auth_user` can be used to allow the leafnode to not specify credentials.

Resolves https://github.com/nats-io/nats-server/issues/6972

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
