### PR TITLE
[IMPROVED] Recover TTL when enabled

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -652,7 +652,7 @@ func (fs *fileStore) UpdateConfig(cfg *StreamConfig) error {
 
 	// Create or delete the THW if needed.
 	if cfg.AllowMsgTTL && fs.ttls == nil {
-		fs.ttls = thw.NewHashWheel()
+		fs.recoverTTLState()
 	} else if !cfg.AllowMsgTTL && fs.ttls != nil {
 		fs.ttls = nil
 	}
@@ -1913,6 +1913,7 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 	return nil
 }
 
+// Lock should be held.
 func (fs *fileStore) recoverTTLState() error {
 	// See if we have a timed hash wheel for TTLs.
 	<-dios

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -18818,128 +18818,163 @@ func TestJetStreamMessageTTLDisabled(t *testing.T) {
 }
 
 func TestJetStreamMessageTTLWhenSourcing(t *testing.T) {
-	s := RunBasicJetStreamServer(t)
-	defer s.Shutdown()
+	for _, storage := range []StorageType{FileStorage, MemoryStorage} {
+		t.Run(storage.String(), func(t *testing.T) {
+			s := RunBasicJetStreamServer(t)
+			defer s.Shutdown()
 
-	nc, js := jsClientConnect(t, s)
-	defer nc.Close()
+			nc, js := jsClientConnect(t, s)
+			defer nc.Close()
 
-	jsStreamCreate(t, nc, &StreamConfig{
-		Name:        "Origin",
-		Storage:     FileStorage,
-		Subjects:    []string{"test"},
-		AllowMsgTTL: true,
-	})
-
-	jsStreamCreate(t, nc, &StreamConfig{
-		Name:    "TTLEnabled",
-		Storage: FileStorage,
-		Sources: []*StreamSource{
-			{Name: "Origin"},
-		},
-		AllowMsgTTL: true,
-	})
-
-	jsStreamCreate(t, nc, &StreamConfig{
-		Name:    "TTLDisabled",
-		Storage: FileStorage,
-		Sources: []*StreamSource{
-			{Name: "Origin"},
-		},
-		AllowMsgTTL: false,
-	})
-
-	hdr := nats.Header{}
-	hdr.Add(JSMessageTTL, "1s")
-
-	_, err := js.PublishMsg(&nats.Msg{
-		Subject: "test",
-		Header:  hdr,
-	})
-	require_NoError(t, err)
-
-	for _, stream := range []string{"TTLEnabled", "TTLDisabled"} {
-		t.Run(stream, func(t *testing.T) {
-			sc, err := js.PullSubscribe("test", "consumer", nats.BindStream(stream))
+			_, err := jsStreamCreate(t, nc, &StreamConfig{
+				Name:        "Origin",
+				Storage:     storage,
+				Subjects:    []string{"test"},
+				AllowMsgTTL: true,
+			})
 			require_NoError(t, err)
 
-			msgs, err := sc.Fetch(1)
+			_, err = jsStreamCreate(t, nc, &StreamConfig{
+				Name:    "TTLEnabled",
+				Storage: storage,
+				Sources: []*StreamSource{
+					{Name: "Origin"},
+				},
+				AllowMsgTTL: true,
+			})
 			require_NoError(t, err)
-			require_Len(t, len(msgs), 1)
-			require_Equal(t, msgs[0].Header.Get(JSMessageTTL), "1s")
 
-			time.Sleep(time.Second)
-
-			si, err := js.StreamInfo(stream)
+			ttlDisabledConfig := &StreamConfig{
+				Name:    "TTLDisabled",
+				Storage: storage,
+				Sources: []*StreamSource{
+					{Name: "Origin"},
+				},
+				AllowMsgTTL: false,
+			}
+			_, err = jsStreamCreate(t, nc, ttlDisabledConfig)
 			require_NoError(t, err)
-			if stream == "TTLDisabled" {
-				require_Equal(t, si.State.Msgs, 1)
-			} else {
-				require_Equal(t, si.State.Msgs, 0)
+
+			hdr := nats.Header{}
+			hdr.Add(JSMessageTTL, "1s")
+
+			_, err = js.PublishMsg(&nats.Msg{
+				Subject: "test",
+				Header:  hdr,
+			})
+			require_NoError(t, err)
+
+			for _, stream := range []string{"TTLEnabled", "TTLDisabled"} {
+				t.Run(stream, func(t *testing.T) {
+					sc, err := js.PullSubscribe("test", "consumer", nats.BindStream(stream))
+					require_NoError(t, err)
+
+					msgs, err := sc.Fetch(1)
+					require_NoError(t, err)
+					require_Len(t, len(msgs), 1)
+					require_Equal(t, msgs[0].Header.Get(JSMessageTTL), "1s")
+
+					time.Sleep(time.Second)
+
+					si, err := js.StreamInfo(stream)
+					require_NoError(t, err)
+
+					if stream != "TTLDisabled" {
+						require_Equal(t, si.State.Msgs, 0)
+						return
+					}
+
+					require_Equal(t, si.State.Msgs, 1)
+
+					ttlDisabledConfig.AllowMsgTTL = true
+					_, err = jsStreamUpdate(t, nc, ttlDisabledConfig)
+					require_NoError(t, err)
+
+					si, err = js.StreamInfo(stream)
+					require_NoError(t, err)
+					require_Equal(t, si.State.Msgs, 0)
+				})
 			}
 		})
 	}
 }
 
 func TestJetStreamMessageTTLWhenMirroring(t *testing.T) {
-	s := RunBasicJetStreamServer(t)
-	defer s.Shutdown()
+	for _, storage := range []StorageType{FileStorage, MemoryStorage} {
+		t.Run(storage.String(), func(t *testing.T) {
+			s := RunBasicJetStreamServer(t)
+			defer s.Shutdown()
 
-	nc, js := jsClientConnect(t, s)
-	defer nc.Close()
+			nc, js := jsClientConnect(t, s)
+			defer nc.Close()
 
-	jsStreamCreate(t, nc, &StreamConfig{
-		Name:        "Origin",
-		Storage:     FileStorage,
-		Subjects:    []string{"test"},
-		AllowMsgTTL: true,
-	})
-
-	jsStreamCreate(t, nc, &StreamConfig{
-		Name:    "TTLEnabled",
-		Storage: FileStorage,
-		Mirror: &StreamSource{
-			Name: "Origin",
-		},
-		AllowMsgTTL: true,
-	})
-
-	jsStreamCreate(t, nc, &StreamConfig{
-		Name:    "TTLDisabled",
-		Storage: FileStorage,
-		Mirror: &StreamSource{
-			Name: "Origin",
-		},
-		AllowMsgTTL: false,
-	})
-
-	hdr := nats.Header{}
-	hdr.Add(JSMessageTTL, "1s")
-
-	_, err := js.PublishMsg(&nats.Msg{
-		Subject: "test",
-		Header:  hdr,
-	})
-	require_NoError(t, err)
-
-	for _, stream := range []string{"TTLEnabled", "TTLDisabled"} {
-		t.Run(stream, func(t *testing.T) {
-			sc, err := js.PullSubscribe("test", "consumer", nats.BindStream(stream))
+			_, err := jsStreamCreate(t, nc, &StreamConfig{
+				Name:        "Origin",
+				Storage:     storage,
+				Subjects:    []string{"test"},
+				AllowMsgTTL: true,
+			})
 			require_NoError(t, err)
 
-			msgs, err := sc.Fetch(1)
+			_, err = jsStreamCreate(t, nc, &StreamConfig{
+				Name:    "TTLEnabled",
+				Storage: storage,
+				Mirror: &StreamSource{
+					Name: "Origin",
+				},
+				AllowMsgTTL: true,
+			})
 			require_NoError(t, err)
-			require_Len(t, len(msgs), 1)
-			require_Equal(t, msgs[0].Header.Get(JSMessageTTL), "1s")
 
-			time.Sleep(time.Second)
-
-			si, err := js.StreamInfo(stream)
+			ttlDisabledConfig := &StreamConfig{
+				Name:    "TTLDisabled",
+				Storage: storage,
+				Mirror: &StreamSource{
+					Name: "Origin",
+				},
+				AllowMsgTTL: false,
+			}
+			_, err = jsStreamCreate(t, nc, ttlDisabledConfig)
 			require_NoError(t, err)
-			if stream == "TTLDisabled" {
-				require_Equal(t, si.State.Msgs, 1)
-			} else {
-				require_Equal(t, si.State.Msgs, 0)
+
+			hdr := nats.Header{}
+			hdr.Add(JSMessageTTL, "1s")
+
+			_, err = js.PublishMsg(&nats.Msg{
+				Subject: "test",
+				Header:  hdr,
+			})
+			require_NoError(t, err)
+
+			for _, stream := range []string{"TTLEnabled", "TTLDisabled"} {
+				t.Run(stream, func(t *testing.T) {
+					sc, err := js.PullSubscribe("test", "consumer", nats.BindStream(stream))
+					require_NoError(t, err)
+
+					msgs, err := sc.Fetch(1)
+					require_NoError(t, err)
+					require_Len(t, len(msgs), 1)
+					require_Equal(t, msgs[0].Header.Get(JSMessageTTL), "1s")
+
+					time.Sleep(time.Second)
+
+					si, err := js.StreamInfo(stream)
+					require_NoError(t, err)
+					if stream != "TTLDisabled" {
+						require_Equal(t, si.State.Msgs, 0)
+						return
+					}
+
+					require_Equal(t, si.State.Msgs, 1)
+
+					ttlDisabledConfig.AllowMsgTTL = true
+					_, err = jsStreamUpdate(t, nc, ttlDisabledConfig)
+					require_NoError(t, err)
+
+					si, err = js.StreamInfo(stream)
+					require_NoError(t, err)
+					require_Equal(t, si.State.Msgs, 0)
+				})
 			}
 		})
 	}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -91,7 +91,7 @@ func (ms *memStore) UpdateConfig(cfg *StreamConfig) error {
 	ms.cfg = *cfg
 	// Create or delete the THW if needed.
 	if cfg.AllowMsgTTL && ms.ttls == nil {
-		ms.ttls = thw.NewHashWheel()
+		ms.recoverTTLState()
 	} else if !cfg.AllowMsgTTL && ms.ttls != nil {
 		ms.ttls = nil
 	}
@@ -128,6 +128,30 @@ func (ms *memStore) UpdateConfig(cfg *StreamConfig) error {
 		ms.expireMsgs()
 	}
 	return nil
+}
+
+// Lock should be held.
+func (ms *memStore) recoverTTLState() {
+	ms.ttls = thw.NewHashWheel()
+	if ms.state.Msgs == 0 {
+		return
+	}
+
+	var (
+		seq uint64
+		smv StoreMsg
+		sm  *StoreMsg
+	)
+	defer ms.resetAgeChk(0)
+	for sm, seq, _ = ms.loadNextMsgLocked(fwcs, true, 0, &smv); sm != nil; sm, seq, _ = ms.loadNextMsgLocked(fwcs, true, seq+1, &smv) {
+		if len(sm.hdr) == 0 {
+			continue
+		}
+		if ttl, _ := getMessageTTL(sm.hdr); ttl > 0 {
+			expires := time.Duration(sm.ts) + (time.Second * time.Duration(ttl))
+			ms.ttls.Add(seq, int64(expires))
+		}
+	}
 }
 
 // Stores a raw message with expected sequence number and timestamp.
@@ -1597,7 +1621,11 @@ func (ms *memStore) LoadNextMsgMulti(sl *gsl.SimpleSublist, start uint64, smp *S
 func (ms *memStore) LoadNextMsg(filter string, wc bool, start uint64, smp *StoreMsg) (*StoreMsg, uint64, error) {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
+	return ms.loadNextMsgLocked(filter, wc, start, smp)
+}
 
+// Lock should be held.
+func (ms *memStore) loadNextMsgLocked(filter string, wc bool, start uint64, smp *StoreMsg) (*StoreMsg, uint64, error) {
 	if start < ms.state.FirstSeq {
 		start = ms.state.FirstSeq
 	}


### PR DESCRIPTION
Enabling TTLs on a stream/source/mirror would not recover previous TTLs. TTLs can be enabled but not disabled, so it must be a conscious decision to enable it. Depending on the stream size, it might take a long time to recover but it will ensure all TTLs are respected.

This is important for a KV that's mirrored, because a mirrored KV might not have TTLs enabled yet, but the origin stream has. If you want the TTLs to be respected on the mirror as well, it needs to respect both new messages with TTLs as messages that it received prior.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
