### PR TITLE
(2.12) Support MaxMsgSize for Counter CRDTs

### DIFF
--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -915,7 +915,7 @@ func TestJetStreamAtomicBatchPublishStageAndCommit(t *testing.T) {
 						hdr = genHeader(hdr, key, value)
 					}
 				}
-				_, _, _, _, err = checkMsgHeadersPreClusteredProposal(diff, mset, m.subject, hdr, nil, false, "TEST", nil, test.allowTTL, test.allowMsgCounter, MemoryStorage, store, interestPolicy, discard, maxMsgs, maxBytes)
+				_, _, _, _, err = checkMsgHeadersPreClusteredProposal(diff, mset, m.subject, hdr, nil, false, "TEST", nil, test.allowTTL, test.allowMsgCounter, MemoryStorage, store, interestPolicy, discard, -1, maxMsgs, maxBytes)
 				if m.err != nil {
 					require_Error(t, err, m.err)
 				} else {


### PR DESCRIPTION
Counters already respected the server's `MaxPayload`, but did not yet respect the `MaxMsgSize` as configured on the stream. Also resolved cases where `len(hdr)+len(msg)` could potentially overflow.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>