### PR TITLE
(2.12) [IMPROVED] Always handle JS API requests from pool

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -802,8 +802,7 @@ type JSApiStreamTemplateNamesResponse struct {
 const JSApiStreamTemplateNamesResponseType = "io.nats.jetstream.api.v1.stream_template_names_response"
 
 // Structure that holds state for a JetStream API request that is processed
-// in a separate long-lived go routine. This is to avoid possibly blocking
-// ROUTE and GATEWAY connections.
+// in a separate long-lived go routine. This is to avoid blocking connections.
 type jsAPIRoutedReq struct {
 	jsub    *subscription
 	sub     *subscription
@@ -872,17 +871,6 @@ func (js *jetStream) apiDispatch(sub *subscription, c *client, acc *Account, sub
 	}
 	jsub := rr.psubs[0]
 
-	// If this is directly from a client connection ok to do in place.
-	if c.kind != ROUTER && c.kind != GATEWAY && c.kind != LEAF {
-		start := time.Now()
-		jsub.icb(sub, c, acc, subject, reply, rmsg)
-		if dur := time.Since(start); dur >= readLoopReportThreshold {
-			s.Warnf("Internal subscription on %q took too long: %v", subject, dur)
-		}
-		return
-	}
-
-	// If we are here we have received this request over a non-client connection.
 	// We need to make sure not to block. We will send the request to a long-lived
 	// pool of go routines.
 
@@ -1718,8 +1706,7 @@ func (s *Server) jsStreamUpdateRequest(sub *subscription, c *client, _ *Account,
 
 	// Handle clustered version here.
 	if s.JetStreamIsClustered() {
-		// Always do in separate Go routine.
-		go s.jsClusteredStreamUpdateRequest(ci, acc, subject, reply, copyBytes(rmsg), &cfg, nil, ncfg.Pedantic)
+		s.jsClusteredStreamUpdateRequest(ci, acc, subject, reply, copyBytes(rmsg), &cfg, nil, ncfg.Pedantic)
 		return
 	}
 
@@ -4417,14 +4404,7 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 	}
 
 	if isClustered && !req.Config.Direct {
-		// If we are inline with client, we still may need to do a callout for consumer info
-		// during this call, so place in Go routine to not block client.
-		// Router and Gateway API calls already in separate context.
-		if c.kind != ROUTER && c.kind != GATEWAY {
-			go s.jsClusteredConsumerRequest(ci, acc, subject, reply, rmsg, req.Stream, &req.Config, req.Action, req.Pedantic)
-		} else {
-			s.jsClusteredConsumerRequest(ci, acc, subject, reply, rmsg, req.Stream, &req.Config, req.Action, req.Pedantic)
-		}
+		s.jsClusteredConsumerRequest(ci, acc, subject, reply, rmsg, req.Stream, &req.Config, req.Action, req.Pedantic)
 		return
 	}
 


### PR DESCRIPTION
Consumer creates/updates and stream updates would spin up multiple (redundant) goroutines, potentially allowing the system to become overloaded.

`if c.kind != ROUTER && c.kind != GATEWAY` we're already running a goroutine because it will be done by the JS API pool, that uses a `JETSTREAM` client, so it would then open yet another goroutine. Due to this other goroutine we also lose visibility on requests that take a long time, because the `Internal subscription on %q took too long: %v` only gets logged if taking a long time AND we've not spun up a different goroutine to do the actual work that could take time, making this logging ineffective. These additional goroutines could also result in being able to quickly overwhelm the API. Client connections would block and handle these inline (sometimes), but routers/gateways would spin up additional goroutines and could quickly zip through all requests and spin up many many goroutines all waiting for the same locks.

This PR makes JS API handling consistent by always having API requests go through the pool. This ensures we're never blocking the requests for any connection, we're consistent in the amount of goroutines that can run (will always equal the pool size, except when listing streams/consumers since they run in a separate goroutine), we're consistent in dropping API requests when required, and we can effectively log when processing takes too long.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>