### PR TITLE
Stream-managed consumer assignments

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1980,17 +1980,16 @@ func (o *consumer) deleteNotActive() {
 	if !isDirect && s.JetStreamIsClustered() {
 		js.mu.RLock()
 		var (
-			cca         consumerAssignment
-			meta        RaftNode
+			node        RaftNode
 			removeEntry []byte
 		)
 		ca, cc := js.consumerAssignment(acc, stream, name), js.cluster
 		if ca != nil && cc != nil {
-			meta = cc.meta
-			cca = *ca
+			node = cc.nodeForConsumerProposals(o.mset.sa)
+			cca := ca.copyGroup()
 			cca.Reply = _EMPTY_
-			removeEntry = encodeDeleteConsumerAssignment(&cca)
-			meta.ForwardProposal(removeEntry)
+			removeEntry = encodeDeleteConsumerAssignment(cca)
+			node.ForwardProposal(removeEntry)
 		}
 		js.mu.RUnlock()
 
@@ -2019,7 +2018,7 @@ func (o *consumer) deleteNotActive() {
 				// Make sure this is the same consumer assignment, and not a new consumer with the same name.
 				if nca != nil && reflect.DeepEqual(nca, ca) {
 					s.Warnf("Consumer assignment for '%s > %s > %s' not cleaned up, retrying", acc, stream, name)
-					meta.ForwardProposal(removeEntry)
+					node.ForwardProposal(removeEntry)
 					if interval < cnaMax {
 						interval *= 2
 						ticker.Reset(interval)

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -10000,7 +10000,9 @@ func (fs *fileStore) EncodedStreamState(failed uint64, consumers []*consumerAssi
 	if fs.cfg.ManagesConsumers {
 		bw := bytes.NewBuffer(b)
 		bw.Truncate(len(b)) // Reset the write pointer but preserve data
-		json.NewEncoder(bw).Encode(consumers)
+		if err := json.NewEncoder(bw).Encode(consumers); err != nil {
+			return nil, err
+		}
 		b = bw.Bytes()
 	}
 

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -9944,7 +9944,7 @@ func (fs *fileStore) readUnlockAllMsgBlocks() {
 }
 
 // Binary encoded state snapshot, >= v2.10 server.
-func (fs *fileStore) EncodedStreamState(failed uint64) ([]byte, error) {
+func (fs *fileStore) EncodedStreamState(failed uint64, consumers []*consumerAssignment) ([]byte, error) {
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()
 
@@ -9995,6 +9995,13 @@ func (fs *fileStore) EncodedStreamState(failed uint64) ([]byte, error) {
 				return nil, errors.New("no impl")
 			}
 		}
+	}
+
+	if fs.cfg.ManagesConsumers {
+		bw := bytes.NewBuffer(b)
+		bw.Truncate(len(b)) // Reset the write pointer but preserve data
+		json.NewEncoder(bw).Encode(consumers)
+		b = bw.Bytes()
 	}
 
 	return b, nil

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2994,7 +2994,7 @@ func (s *Server) jsLeaderAccountPurgeRequest(sub *subscription, c *client, _ *Ac
 		for _, oca := range osa.consumers {
 			oca.deleted = true
 			ca := &consumerAssignment{Group: oca.Group, Stream: oca.Stream, Name: oca.Name, Config: oca.Config, Subject: subject, Client: oca.Client}
-			node.Propose(encodeDeleteConsumerAssignment(ca))
+			node.ForwardProposal(encodeDeleteConsumerAssignment(ca))
 			nc++
 		}
 		sa := &streamAssignment{Group: osa.Group, Config: osa.Config, Subject: subject, Client: osa.Client}

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -145,10 +146,11 @@ const (
 	// This was also the legacy endpoint for ephemeral consumers.
 	// It now can take consumer name and optional filter subject, which when part of the subject controls access.
 	// Will return JSON response.
-	JSApiConsumerCreate    = "$JS.API.CONSUMER.CREATE.*"
-	JSApiConsumerCreateT   = "$JS.API.CONSUMER.CREATE.%s"
-	JSApiConsumerCreateEx  = "$JS.API.CONSUMER.CREATE.*.>"
-	JSApiConsumerCreateExT = "$JS.API.CONSUMER.CREATE.%s.%s.%s"
+	JSApiConsumerCreate     = "$JS.API.CONSUMER.CREATE.*"
+	JSApiConsumerCreateT    = "$JS.API.CONSUMER.CREATE.%s"
+	JSApiConsumerCreateEx   = "$JS.API.CONSUMER.CREATE.*.>"
+	JSApiConsumerCreateExT  = "$JS.API.CONSUMER.CREATE.%s.%s.%s"
+	JSApiConsumerCreateExTW = "$JS.API.CONSUMER.CREATE.%s.>"
 
 	// JSApiDurableCreate is the endpoint to create durable consumers for streams.
 	// You need to include the stream and consumer name in the subject.
@@ -2346,27 +2348,28 @@ func (s *Server) jsConsumerLeaderStepDownRequest(sub *subscription, c *client, _
 	if js == nil || cc == nil {
 		return
 	}
-	if js.isLeaderless() {
-		resp.Error = NewJSClusterNotAvailError()
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
-		return
-	}
 
 	// Have extra token for this one.
 	stream := tokenAt(subject, 6)
 	consumer := tokenAt(subject, 7)
 
 	js.mu.RLock()
-	isLeader, sa := cc.isLeader(), js.streamAssignment(acc.Name, stream)
+	isLeaderless, sa := js.isLeaderless(), js.streamAssignment(acc.Name, stream)
+	managesConsumers := sa != nil && sa.Config != nil && sa.Config.ManagesConsumers
 	js.mu.RUnlock()
 
-	if isLeader && sa == nil {
+	if !managesConsumers && isLeaderless {
+		resp.Error = NewJSClusterNotAvailError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+
+	if sa == nil {
 		resp.Error = NewJSStreamNotFoundError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
-	} else if sa == nil {
-		return
 	}
+
 	var ca *consumerAssignment
 	if sa.consumers != nil {
 		ca = sa.consumers[consumer]
@@ -2987,10 +2990,11 @@ func (s *Server) jsLeaderAccountPurgeRequest(sub *subscription, c *client, _ *Ac
 	ns, nc := 0, 0
 	streams, hasAccount := cc.streams[accName]
 	for _, osa := range streams {
+		node := cc.nodeForConsumerProposals(osa)
 		for _, oca := range osa.consumers {
 			oca.deleted = true
 			ca := &consumerAssignment{Group: oca.Group, Stream: oca.Stream, Name: oca.Name, Config: oca.Config, Subject: subject, Client: oca.Client}
-			cc.meta.Propose(encodeDeleteConsumerAssignment(ca))
+			node.Propose(encodeDeleteConsumerAssignment(ca))
 			nc++
 		}
 		sa := &streamAssignment{Group: osa.Group, Config: osa.Config, Subject: subject, Client: osa.Client}
@@ -3532,12 +3536,12 @@ func (s *Server) jsConsumerUnpinRequest(sub *subscription, c *client, _ *Account
 		return
 	}
 
+	var resp = JSApiConsumerUnpinResponse{ApiResponse: ApiResponse{Type: JSApiConsumerUnpinResponseType}}
+
 	stream := streamNameFromSubject(subject)
 	consumer := consumerNameFromSubject(subject)
 
 	var req JSApiConsumerUnpinRequest
-	var resp = JSApiConsumerUnpinResponse{ApiResponse: ApiResponse{Type: JSApiConsumerUnpinResponseType}}
-
 	if err := json.Unmarshal(msg, &req); err != nil {
 		resp.Error = NewJSInvalidJSONError(err)
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -4295,7 +4299,7 @@ const (
 // Request to create a consumer where stream and optional consumer name are part of the subject, and optional
 // filtered subjects can be at the tail end.
 // Assumes stream and consumer names are single tokens.
-func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Account, subject, reply string, rmsg []byte) {
+func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
@@ -4317,20 +4321,24 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 
 	var js *jetStream
 	isClustered := s.JetStreamIsClustered()
+	streamName := streamNameFromSubject(subject)
 
 	// Determine if we should proceed here when we are in clustered mode.
 	if isClustered {
-		if req.Config.Direct {
-			// Check to see if we have this stream and are the stream leader.
-			if !acc.JetStreamIsStreamLeader(streamNameFromSubject(subject)) {
+		var cc *jetStreamCluster
+		js, cc = s.getJetStreamCluster()
+		if js == nil || cc == nil {
+			return
+		}
+		js.mu.RLock()
+		sa := js.streamAssignment(acc.Name, streamName)
+		managesConsumers := sa != nil && sa.Config != nil && sa.Config.ManagesConsumers
+		js.mu.RUnlock()
+		if req.Config.Direct || managesConsumers {
+			if !acc.JetStreamIsStreamLeader(streamName) {
 				return
 			}
 		} else {
-			var cc *jetStreamCluster
-			js, cc = s.getJetStreamCluster()
-			if js == nil || cc == nil {
-				return
-			}
 			if js.isLeaderless() {
 				resp.Error = NewJSClusterNotAvailError()
 				s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -4343,7 +4351,7 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 		}
 	}
 
-	var streamName, consumerName, filteredSubject string
+	var consumerName, filteredSubject string
 	var rt ccReqType
 
 	if n := numTokens(subject); n < 5 {
@@ -4514,23 +4522,6 @@ func (s *Server) jsConsumerNamesRequest(sub *subscription, c *client, _ *Account
 		Consumers:   []string{},
 	}
 
-	// Determine if we should proceed here when we are in clustered mode.
-	if s.JetStreamIsClustered() {
-		js, cc := s.getJetStreamCluster()
-		if js == nil || cc == nil {
-			return
-		}
-		if js.isLeaderless() {
-			resp.Error = NewJSClusterNotAvailError()
-			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
-			return
-		}
-		// Make sure we are meta leader.
-		if !s.JetStreamIsLeader() {
-			return
-		}
-	}
-
 	if hasJS, doErr := acc.checkJetStream(); !hasJS {
 		if doErr {
 			resp.Error = NewJSNotEnabledForAccountError()
@@ -4636,23 +4627,6 @@ func (s *Server) jsConsumerListRequest(sub *subscription, c *client, _ *Account,
 		Consumers:   []*ConsumerInfo{},
 	}
 
-	// Determine if we should proceed here when we are in clustered mode.
-	if s.JetStreamIsClustered() {
-		js, cc := s.getJetStreamCluster()
-		if js == nil || cc == nil {
-			return
-		}
-		if js.isLeaderless() {
-			resp.Error = NewJSClusterNotAvailError()
-			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
-			return
-		}
-		// Make sure we are meta leader.
-		if !s.JetStreamIsLeader() {
-			return
-		}
-	}
-
 	if hasJS, doErr := acc.checkJetStream(); !hasJS {
 		if doErr {
 			resp.Error = NewJSNotEnabledForAccountError()
@@ -4724,10 +4698,10 @@ func (s *Server) jsConsumerInfoRequest(sub *subscription, c *client, _ *Account,
 		return
 	}
 
+	var resp = JSApiConsumerInfoResponse{ApiResponse: ApiResponse{Type: JSApiConsumerInfoResponseType}}
+
 	streamName := streamNameFromSubject(subject)
 	consumerName := consumerNameFromSubject(subject)
-
-	var resp = JSApiConsumerInfoResponse{ApiResponse: ApiResponse{Type: JSApiConsumerInfoResponseType}}
 
 	if !isEmptyRequest(msg) {
 		resp.Error = NewJSNotEmptyRequestError()
@@ -4754,6 +4728,16 @@ func (s *Server) jsConsumerInfoRequest(sub *subscription, c *client, _ *Account,
 
 		js.mu.RLock()
 		isLeader, sa, ca := cc.isLeader(), js.streamAssignment(acc.Name, streamName), js.consumerAssignment(acc.Name, streamName, consumerName)
+		if sa != nil && sa.Config != nil && sa.Config.ManagesConsumers {
+			// If the stream manages its own consumers then we care about the stream
+			// leader at this point, not the metaleader, as the metaleader will not
+			// know or not whether the consumer is meant to exist.
+			isLeader = cc.isStreamLeader(acc.Name, streamName)
+			if node := cc.nodeForConsumerProposals(sa); node != nil {
+				groupLeaderless = node.Leaderless()
+				groupCreated = node.Created()
+			}
+		}
 		var rg *raftGroup
 		var offline, isMember bool
 		if ca != nil {
@@ -4909,23 +4893,6 @@ func (s *Server) jsConsumerDeleteRequest(sub *subscription, c *client, _ *Accoun
 
 	var resp = JSApiConsumerDeleteResponse{ApiResponse: ApiResponse{Type: JSApiConsumerDeleteResponseType}}
 
-	// Determine if we should proceed here when we are in clustered mode.
-	if s.JetStreamIsClustered() {
-		js, cc := s.getJetStreamCluster()
-		if js == nil || cc == nil {
-			return
-		}
-		if js.isLeaderless() {
-			resp.Error = NewJSClusterNotAvailError()
-			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
-			return
-		}
-		// Make sure we are meta leader.
-		if !s.JetStreamIsLeader() {
-			return
-		}
-	}
-
 	if hasJS, doErr := acc.checkJetStream(); !hasJS {
 		if doErr {
 			resp.Error = NewJSNotEnabledForAccountError()
@@ -4979,31 +4946,13 @@ func (s *Server) jsConsumerPauseRequest(sub *subscription, c *client, _ *Account
 		return
 	}
 
-	var req JSApiConsumerPauseRequest
 	var resp = JSApiConsumerPauseResponse{ApiResponse: ApiResponse{Type: JSApiConsumerPauseResponseType}}
 
+	var req JSApiConsumerPauseRequest
 	if isJSONObjectOrArray(msg) {
 		if err := s.unmarshalRequest(c, acc, subject, msg, &req); err != nil {
 			resp.Error = NewJSInvalidJSONError(err)
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
-			return
-		}
-	}
-
-	// Determine if we should proceed here when we are in clustered mode.
-	isClustered := s.JetStreamIsClustered()
-	js, cc := s.getJetStreamCluster()
-	if isClustered {
-		if js == nil || cc == nil {
-			return
-		}
-		if js.isLeaderless() {
-			resp.Error = NewJSClusterNotAvailError()
-			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
-			return
-		}
-		// Make sure we are meta leader.
-		if !s.JetStreamIsLeader() {
 			return
 		}
 	}
@@ -5019,7 +4968,8 @@ func (s *Server) jsConsumerPauseRequest(sub *subscription, c *client, _ *Account
 	stream := streamNameFromSubject(subject)
 	consumer := consumerNameFromSubject(subject)
 
-	if isClustered {
+	if s.JetStreamIsClustered() {
+		js, cc := s.getJetStreamCluster()
 		js.mu.RLock()
 		sa := js.streamAssignment(acc.Name, stream)
 		if sa == nil {
@@ -5040,6 +4990,7 @@ func (s *Server) jsConsumerPauseRequest(sub *subscription, c *client, _ *Account
 		nca := *ca
 		ncfg := *ca.Config
 		nca.Config = &ncfg
+		nca.Config.Metadata = maps.Clone(ca.Config.Metadata)
 		js.mu.RUnlock()
 		pauseUTC := req.PauseUntil.UTC()
 		if !pauseUTC.IsZero() {
@@ -5053,7 +5004,7 @@ func (s *Server) jsConsumerPauseRequest(sub *subscription, c *client, _ *Account
 		setStaticConsumerMetadata(nca.Config)
 
 		eca := encodeAddConsumerAssignment(&nca)
-		cc.meta.Propose(eca)
+		cc.nodeForConsumerProposals(sa).ForwardProposal(eca)
 
 		resp.PauseUntil = pauseUTC
 		if resp.Paused = time.Now().Before(pauseUTC); resp.Paused {

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -4545,20 +4545,32 @@ func (s *Server) jsConsumerNamesRequest(sub *subscription, c *client, _ *Account
 	var numConsumers int
 
 	if s.JetStreamIsClustered() {
+		// Determine if we should proceed here when we are in clustered mode.
 		js, cc := s.getJetStreamCluster()
 		if js == nil || cc == nil {
-			// TODO(dlc) - Debug or Warn?
 			return
 		}
 		js.mu.RLock()
-		sas := cc.streams[acc.Name]
-		if sas == nil {
-			js.mu.RUnlock()
-			resp.Error = NewJSStreamNotFoundError()
-			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
-			return
+		sa := js.streamAssignment(acc.Name, streamName)
+		managesConsumers := sa != nil && sa.Config != nil && sa.Config.ManagesConsumers
+		js.mu.RUnlock()
+		if managesConsumers {
+			if !acc.JetStreamIsStreamLeader(streamName) {
+				return
+			}
+		} else {
+			if js.isLeaderless() {
+				resp.Error = NewJSClusterNotAvailError()
+				s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+				return
+			}
+			// Make sure we are meta leader.
+			if !s.JetStreamIsLeader() {
+				return
+			}
 		}
-		sa := sas[streamName]
+
+		js.mu.RLock()
 		if sa == nil || sa.err != nil {
 			js.mu.RUnlock()
 			resp.Error = NewJSStreamNotFoundError()
@@ -4650,6 +4662,31 @@ func (s *Server) jsConsumerListRequest(sub *subscription, c *client, _ *Account,
 
 	// Clustered mode will invoke a scatter and gather.
 	if s.JetStreamIsClustered() {
+		// Determine if we should proceed here when we are in clustered mode.
+		js, cc := s.getJetStreamCluster()
+		if js == nil || cc == nil {
+			return
+		}
+		js.mu.RLock()
+		sa := js.streamAssignment(acc.Name, streamName)
+		managesConsumers := sa != nil && sa.Config != nil && sa.Config.ManagesConsumers
+		js.mu.RUnlock()
+		if managesConsumers {
+			if !acc.JetStreamIsStreamLeader(streamName) {
+				return
+			}
+		} else {
+			if js.isLeaderless() {
+				resp.Error = NewJSClusterNotAvailError()
+				s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+				return
+			}
+			// Make sure we are meta leader.
+			if !s.JetStreamIsLeader() {
+				return
+			}
+		}
+
 		// Need to copy these off before sending.. don't move this inside startGoRoutine!!!
 		msg = copyBytes(msg)
 		s.startGoRoutine(func() {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1548,6 +1548,10 @@ func (js *jetStream) applyMetaSnapshot(buf []byte, ru *recoveryUpdates, isRecove
 	// Now walk the ones to check and process consumers.
 	var caAdd, caDel []*consumerAssignment
 	for _, sa := range saChk {
+		// Skip if the stream manages its own consumers.
+		if sa.Config.ManagesConsumers {
+			continue
+		}
 		// Make sure to add in all the new ones from sa.
 		for _, ca := range sa.consumers {
 			caAdd = append(caAdd, ca)
@@ -3292,7 +3296,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 			}
 
 			if isRecovering || !mset.IsLeader() {
-				if err := mset.processSnapshot(ss, ce.Index); err != nil {
+				if err := mset.processSnapshot(js, ss, ce.Index); err != nil {
 					return err
 				}
 			}
@@ -8725,10 +8729,20 @@ var (
 )
 
 // Process a stream snapshot.
-func (mset *stream) processSnapshot(snap *StreamReplicatedState, index uint64) (e error) {
+func (mset *stream) processSnapshot(js *jetStream, snap *StreamReplicatedState, index uint64) (e error) {
 	// Update any deletes, etc.
 	mset.processSnapshotDeletes(snap)
 	mset.setCLFS(snap.Failed)
+
+	mset.cfgMu.RLock()
+	managesConsumers := mset.cfg.ManagesConsumers
+	mset.cfgMu.RUnlock()
+	if managesConsumers {
+		// Revive the consumer assignments from the snapshot.
+		for _, ca := range snap.Consumers {
+			js.processConsumerAssignment(ca)
+		}
+	}
 
 	mset.mu.Lock()
 	var state StreamState

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1006,6 +1006,16 @@ func (cc *jetStreamCluster) isConsumerLeader(account, stream, consumer string) b
 	return false
 }
 
+func (cc *jetStreamCluster) nodeForConsumerProposals(sa *streamAssignment) RaftNode {
+	if sa.Config.ManagesConsumers {
+		if sa.Group == nil || sa.Group.node == nil {
+			return nil
+		}
+		return sa.Group.node
+	}
+	return cc.meta
+}
+
 // Remove the stream `streamName` for the account `accName` from the inflight
 // proposals map. This is done on success (processStreamAssignment) or on
 // failure (processStreamAssignmentResults).
@@ -1408,25 +1418,29 @@ func (js *jetStream) metaSnapshot() ([]byte, error) {
 	for _, asa := range cc.streams {
 		for _, sa := range asa {
 			wsa := writeableStreamAssignment{
-				Client:    sa.Client.forAssignmentSnap(),
-				Created:   sa.Created,
-				Config:    sa.Config,
-				Group:     sa.Group,
-				Sync:      sa.Sync,
-				Consumers: make([]*consumerAssignment, 0, len(sa.consumers)),
+				Client:  sa.Client.forAssignmentSnap(),
+				Created: sa.Created,
+				Config:  sa.Config,
+				Group:   sa.Group,
+				Sync:    sa.Sync,
 			}
-			for _, ca := range sa.consumers {
-				// Skip if the consumer is pending, we can't include it in our snapshot.
-				// If the proposal fails after we marked it pending, it would result in a ghost consumer.
-				if ca.pending {
-					continue
+			if !sa.Config.ManagesConsumers {
+				// If this stream manages its own consumers then don't include the consumers in the
+				// metalayer snapshot.
+				wsa.Consumers = make([]*consumerAssignment, 0, len(sa.consumers))
+				for _, ca := range sa.consumers {
+					// Skip if the consumer is pending, we can't include it in our snapshot.
+					// If the proposal fails after we marked it pending, it would result in a ghost consumer.
+					if ca.pending {
+						continue
+					}
+					cca := *ca
+					cca.Stream = wsa.Config.Name // Needed for safe roll-backs.
+					cca.Client = cca.Client.forAssignmentSnap()
+					cca.Subject, cca.Reply = _EMPTY_, _EMPTY_
+					wsa.Consumers = append(wsa.Consumers, &cca)
+					nca++
 				}
-				cca := *ca
-				cca.Stream = wsa.Config.Name // Needed for safe roll-backs.
-				cca.Client = cca.Client.forAssignmentSnap()
-				cca.Subject, cca.Reply = _EMPTY_, _EMPTY_
-				wsa.Consumers = append(wsa.Consumers, &cca)
-				nca++
 			}
 			streams = append(streams, wsa)
 		}
@@ -1485,7 +1499,9 @@ func (js *jetStream) applyMetaSnapshot(buf []byte, ru *recoveryUpdates, isRecove
 		}
 		sa := &streamAssignment{Client: wsa.Client, Created: wsa.Created, Config: wsa.Config, Group: wsa.Group, Sync: wsa.Sync}
 		if len(wsa.Consumers) > 0 {
-			sa.consumers = make(map[string]*consumerAssignment)
+			if sa.consumers == nil {
+				sa.consumers = make(map[string]*consumerAssignment)
+			}
 			for _, ca := range wsa.Consumers {
 				if ca.Stream == _EMPTY_ {
 					ca.Stream = sa.Config.Name // Rehydrate from the stream name.
@@ -1701,12 +1717,13 @@ func (js *jetStream) processAddPeer(peer string) {
 				csa.Group.Peers = append(csa.Group.Peers, peer)
 				// Send our proposal for this csa. Also use same group definition for all the consumers as well.
 				cc.meta.Propose(encodeAddStreamAssignment(csa))
+				node := cc.nodeForConsumerProposals(sa)
 				for _, ca := range sa.consumers {
 					// Ephemerals are R=1, so only auto-remap durables, or R>1.
 					if ca.Config.Durable != _EMPTY_ || len(ca.Group.Peers) > 1 {
 						cca := ca.copyGroup()
 						cca.Group.Peers = csa.Group.Peers
-						cc.meta.Propose(encodeAddConsumerAssignment(cca))
+						node.ForwardProposal(encodeAddConsumerAssignment(cca))
 					}
 				}
 			}
@@ -1791,15 +1808,16 @@ func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer strin
 	// Send our proposal for this csa. Also use same group definition for all the consumers as well.
 	cc.meta.Propose(encodeAddStreamAssignment(csa))
 	rg := csa.Group
+	node := cc.nodeForConsumerProposals(sa)
 	for _, ca := range sa.consumers {
 		// Ephemerals are R=1, so only auto-remap durables, or R>1.
 		if ca.Config.Durable != _EMPTY_ {
 			cca := ca.copyGroup()
 			cca.Group.Peers, cca.Group.Preferred = rg.Peers, _EMPTY_
-			cc.meta.Propose(encodeAddConsumerAssignment(cca))
+			node.ForwardProposal(encodeAddConsumerAssignment(cca))
 		} else if ca.Group.isMember(peer) {
 			// These are ephemerals. Check to see if we deleted this peer.
-			cc.meta.Propose(encodeDeleteConsumerAssignment(ca))
+			node.ForwardProposal(encodeDeleteConsumerAssignment(ca))
 		}
 	}
 	return replaced
@@ -2357,7 +2375,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 		// This shouldn't happen for streams like it can for pull
 		// consumers on idle streams but better to be safe than sorry!
 		ne, nb := n.Size()
-		if curState == lastState && ne < compactNumMin && nb < compactSizeMin {
+		if mset.numConsumers() == 0 && curState == lastState && ne < compactNumMin && nb < compactSizeMin {
 			return
 		}
 
@@ -2786,9 +2804,13 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 						State:   state,
 					}
 
+					js.mu.RLock()
+					cnode := cc.nodeForConsumerProposals(sa)
+					js.mu.RUnlock()
+
 					// We make these compressed in case state is complex.
 					addEntry := encodeAddConsumerAssignmentCompressed(ca)
-					cc.meta.ForwardProposal(addEntry)
+					cnode.ForwardProposal(addEntry)
 
 					// Check to make sure we see the assignment.
 					go func() {
@@ -2801,7 +2823,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 							if ca == nil {
 								s.Warnf("Consumer assignment has not been assigned, retrying")
 								if meta != nil {
-									meta.ForwardProposal(addEntry)
+									cnode.ForwardProposal(addEntry)
 								} else {
 									return
 								}
@@ -3189,6 +3211,27 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 						s.sendAPIResponse(sp.Client, mset.account(), sp.Subject, sp.Reply, _EMPTY_, s.jsonResponse(resp))
 					}
 				}
+			case assignConsumerOp:
+				ca, err := decodeConsumerAssignment(buf[1:])
+				if err != nil {
+					js.srv.Errorf("JetStream cluster failed to decode consumer assignment: %q", buf[1:])
+					continue
+				}
+				js.processConsumerAssignment(ca)
+			case assignCompressedConsumerOp:
+				ca, err := decodeConsumerAssignmentCompressed(buf[1:])
+				if err != nil {
+					js.srv.Errorf("JetStream cluster failed to decode compressed consumer assignment: %q", buf[1:])
+					continue
+				}
+				js.processConsumerAssignment(ca)
+			case removeConsumerOp:
+				ca, err := decodeConsumerAssignment(buf[1:])
+				if err != nil {
+					js.srv.Errorf("JetStream cluster failed to decode consumer assignment: %q", buf[1:])
+					continue
+				}
+				js.processConsumerRemoval(ca)
 			default:
 				panic(fmt.Sprintf("JetStream Cluster Unknown group entry op type: %v", op))
 			}
@@ -3228,11 +3271,12 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				}
 				// Convert over to StreamReplicatedState
 				ss = &StreamReplicatedState{
-					Msgs:     snap.Msgs,
-					Bytes:    snap.Bytes,
-					FirstSeq: snap.FirstSeq,
-					LastSeq:  snap.LastSeq,
-					Failed:   snap.Failed,
+					Msgs:      snap.Msgs,
+					Bytes:     snap.Bytes,
+					FirstSeq:  snap.FirstSeq,
+					LastSeq:   snap.LastSeq,
+					Failed:    snap.Failed,
+					Consumers: snap.Consumers,
 				}
 				if len(snap.Deleted) > 0 {
 					ss.Deleted = append(ss.Deleted, DeleteSlice(snap.Deleted))
@@ -3243,6 +3287,11 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				if err := mset.processSnapshot(ss, ce.Index); err != nil {
 					return err
 				}
+			}
+
+			// Process consumer assignments from the stream snapshot.
+			for _, ca := range ss.Consumers {
+				js.processConsumerAssignment(ca)
 			}
 		} else if e.Type == EntryRemovePeer {
 			js.mu.RLock()
@@ -3513,7 +3562,7 @@ func (js *jetStream) processStreamAssignment(sa *streamAssignment) bool {
 		accStreams = make(map[string]*streamAssignment)
 	} else if osa := accStreams[stream]; osa != nil && osa != sa {
 		// Copy over private existing state from former SA.
-		if sa.Group != nil {
+		if sa.Group != nil && osa.Group != nil && osa.Group.node != nil {
 			sa.Group.node = osa.Group.node
 		}
 		sa.consumers = osa.consumers
@@ -3606,7 +3655,7 @@ func (js *jetStream) processUpdateStreamAssignment(sa *streamAssignment) {
 	}
 
 	// Copy over private existing state from former SA.
-	if sa.Group != nil {
+	if sa.Group != nil && osa.Group != nil && osa.Group.node != nil {
 		sa.Group.node = osa.Group.node
 	}
 	sa.consumers = osa.consumers
@@ -3694,7 +3743,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 	sa.responded = true
 	recovering := sa.recovering
 	cc := js.cluster
-	meta := cc.meta
+	node := cc.nodeForConsumerProposals(osa)
 	js.mu.Unlock()
 
 	mset, err := acc.lookupStream(cfg.Name)
@@ -3947,7 +3996,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 
 	// Process any staged consumer updates.
 	for _, ca := range consumers {
-		meta.ForwardProposal(encodeAddConsumerAssignment(ca))
+		node.ForwardProposal(encodeAddConsumerAssignment(ca))
 	}
 }
 
@@ -4170,6 +4219,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 					if consumers := mset.getPublicConsumers(); len(consumers) > 0 {
 						js.mu.RLock()
 						cc := js.cluster
+						cnode := cc.nodeForConsumerProposals(sa)
 						js.mu.RUnlock()
 
 						for _, o := range consumers {
@@ -4187,7 +4237,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 							}
 
 							addEntry := encodeAddConsumerAssignment(ca)
-							cc.meta.ForwardProposal(addEntry)
+							cnode.ForwardProposal(addEntry)
 
 							// Check to make sure we see the assignment.
 							go func() {
@@ -4195,12 +4245,12 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 								defer ticker.Stop()
 								for range ticker.C {
 									js.mu.RLock()
-									ca, meta := js.consumerAssignment(ca.Client.serviceAccount(), sa.Config.Name, name), cc.meta
+									ca := js.consumerAssignment(ca.Client.serviceAccount(), sa.Config.Name, name)
 									js.mu.RUnlock()
 									if ca == nil {
 										s.Warnf("Consumer assignment has not been assigned, retrying")
-										if meta != nil {
-											meta.ForwardProposal(addEntry)
+										if cnode != nil {
+											cnode.ForwardProposal(addEntry)
 										} else {
 											return
 										}
@@ -4537,6 +4587,7 @@ func (js *jetStream) processClusterCreateConsumer(ca *consumerAssignment, state 
 	alreadyRunning := rg != nil && rg.node != nil
 	accName, stream, consumer := ca.Client.serviceAccount(), ca.Stream, ca.Name
 	recovering := ca.recovering
+	sa := js.streamAssignment(accName, stream)
 	js.mu.RUnlock()
 
 	acc, err := s.LookupAccount(accName)
@@ -4549,6 +4600,11 @@ func (js *jetStream) processClusterCreateConsumer(ca *consumerAssignment, state 
 	mset, err := acc.lookupStream(stream)
 	if err != nil {
 		if !js.isMetaRecovering() {
+			if sa != nil {
+				// The stream *should* exist, it just doesn't exist here on this server, so
+				// it's quite likely that the stream move has been canceled.
+				return
+			}
 			js.mu.Lock()
 			s.Warnf("Consumer create failed, could not locate stream '%s > %s > %s'", ca.Client.serviceAccount(), ca.Stream, ca.Name)
 			ca.err = NewJSStreamNotFoundError()
@@ -5161,7 +5217,10 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 				cca := ca.copyGroup()
 				cca.Group.Peers = newPeers
 				cca.Group.Cluster = s.cachedClusterName()
-				meta.ForwardProposal(encodeAddConsumerAssignment(cca))
+				js.mu.RLock()
+				cnode := js.cluster.nodeForConsumerProposals(o.mset.sa)
+				js.mu.RUnlock()
+				cnode.ForwardProposal(encodeAddConsumerAssignment(cca))
 				s.Noticef("Scaling down '%s > %s > %s' to %+v", ca.Client.serviceAccount(), ca.Stream, ca.Name, s.peerSetToNames(newPeers))
 
 			} else {
@@ -7284,7 +7343,17 @@ func (s *Server) jsClusteredConsumerDeleteRequest(ci *ClientInfo, acc *Account, 
 		resp.Error = NewJSStreamNotFoundError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return
-
+	}
+	if sa.Config != nil && sa.Config.ManagesConsumers && !cc.isStreamLeader(acc.Name, stream) {
+		// Only the stream leader must make this proposal when the stream manages
+		// its own consumers.
+		return
+	} else if cc.meta.Leaderless() {
+		resp.Error = NewJSClusterNotAvailError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+		return
+	} else if !cc.isLeader() {
+		return
 	}
 	if sa.consumers == nil {
 		resp.Error = NewJSConsumerNotFoundError()
@@ -7299,7 +7368,7 @@ func (s *Server) jsClusteredConsumerDeleteRequest(ci *ClientInfo, acc *Account, 
 	}
 	oca.deleted = true
 	ca := &consumerAssignment{Group: oca.Group, Stream: stream, Name: consumer, Config: oca.Config, Subject: subject, Reply: reply, Client: ci}
-	cc.meta.Propose(encodeDeleteConsumerAssignment(ca))
+	cc.nodeForConsumerProposals(sa).ForwardProposal(encodeDeleteConsumerAssignment(ca))
 }
 
 func encodeMsgDelete(md *streamMsgDelete) []byte {
@@ -7499,6 +7568,14 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 	sa := js.streamAssignment(acc.Name, stream)
 	if sa == nil {
 		resp.Error = NewJSStreamNotFoundError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+		return
+	}
+
+	node := cc.nodeForConsumerProposals(sa)
+	if node == nil {
+		// TODO(nat): is this the right thing to do?
+		resp.Error = NewJSStreamOfflineError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return
 	}
@@ -7794,7 +7871,7 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 	}
 
 	// Do formal proposal.
-	if err := cc.meta.Propose(encodeAddConsumerAssignment(ca)); err == nil {
+	if err := node.ForwardProposal(encodeAddConsumerAssignment(ca)); err == nil {
 		// Mark this as pending.
 		if sa.consumers == nil {
 			sa.consumers = make(map[string]*consumerAssignment)
@@ -8000,12 +8077,13 @@ func (mset *stream) supportsBinarySnapshotLocked() bool {
 // StreamSnapshot is used for snapshotting and out of band catch up in clustered mode.
 // Legacy, replace with binary stream snapshots.
 type streamSnapshot struct {
-	Msgs     uint64   `json:"messages"`
-	Bytes    uint64   `json:"bytes"`
-	FirstSeq uint64   `json:"first_seq"`
-	LastSeq  uint64   `json:"last_seq"`
-	Failed   uint64   `json:"clfs"`
-	Deleted  []uint64 `json:"deleted,omitempty"`
+	Msgs      uint64                `json:"messages"`
+	Bytes     uint64                `json:"bytes"`
+	FirstSeq  uint64                `json:"first_seq"`
+	LastSeq   uint64                `json:"last_seq"`
+	Failed    uint64                `json:"clfs"`
+	Deleted   []uint64              `json:"deleted,omitempty"`
+	Consumers []*consumerAssignment `json:"consumers,omitempty"`
 }
 
 // Grab a snapshot of a stream for clustered mode.
@@ -8019,7 +8097,8 @@ func (mset *stream) stateSnapshot() []byte {
 // Lock should be held.
 func (mset *stream) stateSnapshotLocked() []byte {
 	// Decide if we can support the new style of stream snapshots.
-	if mset.supportsBinarySnapshotLocked() {
+	// TODO(nat): Fix this once we have added the consumers into the binary snap format.
+	if mset.supportsBinarySnapshotLocked() && !mset.cfg.ManagesConsumers {
 		snap, err := mset.store.EncodedStreamState(mset.getCLFS())
 		if err != nil {
 			return nil
@@ -8030,12 +8109,25 @@ func (mset *stream) stateSnapshotLocked() []byte {
 	// Older v1 version with deleted as a sorted []uint64.
 	state := mset.store.State()
 	snap := &streamSnapshot{
-		Msgs:     state.Msgs,
-		Bytes:    state.Bytes,
-		FirstSeq: state.FirstSeq,
-		LastSeq:  state.LastSeq,
-		Failed:   mset.getCLFS(),
-		Deleted:  state.Deleted,
+		Msgs:      state.Msgs,
+		Bytes:     state.Bytes,
+		FirstSeq:  state.FirstSeq,
+		LastSeq:   state.LastSeq,
+		Failed:    mset.getCLFS(),
+		Deleted:   state.Deleted,
+		Consumers: make([]*consumerAssignment, 0, len(mset.consumers)),
+	}
+	for _, o := range mset.consumers {
+		// Skip if the consumer is pending, we can't include it in our snapshot.
+		// If the proposal fails after we marked it pending, it would result in a ghost consumer.
+		if o.ca == nil || o.ca.pending {
+			continue
+		}
+		cca := *o.ca
+		cca.Stream = mset.cfg.Name // Needed for safe roll-backs.
+		cca.Client = cca.Client.forAssignmentSnap()
+		cca.Subject, cca.Reply = _EMPTY_, _EMPTY_
+		snap.Consumers = append(snap.Consumers, &cca)
 	}
 	b, _ := json.Marshal(snap)
 	return b

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1006,6 +1006,7 @@ func (cc *jetStreamCluster) isConsumerLeader(account, stream, consumer string) b
 	return false
 }
 
+// Read lock should be held.
 func (cc *jetStreamCluster) nodeForConsumerProposals(sa *streamAssignment) RaftNode {
 	if sa.Config.ManagesConsumers {
 		if sa.Group == nil || sa.Group.node == nil {
@@ -4249,11 +4250,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 									js.mu.RUnlock()
 									if ca == nil {
 										s.Warnf("Consumer assignment has not been assigned, retrying")
-										if cnode != nil {
-											cnode.ForwardProposal(addEntry)
-										} else {
-											return
-										}
+										cnode.ForwardProposal(addEntry)
 									} else {
 										return
 									}
@@ -7574,7 +7571,6 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 
 	node := cc.nodeForConsumerProposals(sa)
 	if node == nil {
-		// TODO(nat): is this the right thing to do?
 		resp.Error = NewJSStreamOfflineError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return
@@ -8096,10 +8092,26 @@ func (mset *stream) stateSnapshot() []byte {
 // Grab a snapshot of a stream for clustered mode.
 // Lock should be held.
 func (mset *stream) stateSnapshotLocked() []byte {
+	var consumers []*consumerAssignment
+	if mset.cfg.ManagesConsumers {
+		consumers = make([]*consumerAssignment, 0, len(mset.consumers))
+		for _, o := range mset.consumers {
+			// Skip if the consumer is pending, we can't include it in our snapshot.
+			// If the proposal fails after we marked it pending, it would result in a ghost consumer.
+			if o.ca == nil || o.ca.pending {
+				continue
+			}
+			cca := *o.ca
+			cca.Stream = mset.cfg.Name // Needed for safe roll-backs.
+			cca.Client = cca.Client.forAssignmentSnap()
+			cca.Subject, cca.Reply = _EMPTY_, _EMPTY_
+			consumers = append(consumers, &cca)
+		}
+	}
+
 	// Decide if we can support the new style of stream snapshots.
-	// TODO(nat): Fix this once we have added the consumers into the binary snap format.
-	if mset.supportsBinarySnapshotLocked() && !mset.cfg.ManagesConsumers {
-		snap, err := mset.store.EncodedStreamState(mset.getCLFS())
+	if mset.supportsBinarySnapshotLocked() {
+		snap, err := mset.store.EncodedStreamState(mset.getCLFS(), consumers)
 		if err != nil {
 			return nil
 		}
@@ -8115,19 +8127,7 @@ func (mset *stream) stateSnapshotLocked() []byte {
 		LastSeq:   state.LastSeq,
 		Failed:    mset.getCLFS(),
 		Deleted:   state.Deleted,
-		Consumers: make([]*consumerAssignment, 0, len(mset.consumers)),
-	}
-	for _, o := range mset.consumers {
-		// Skip if the consumer is pending, we can't include it in our snapshot.
-		// If the proposal fails after we marked it pending, it would result in a ghost consumer.
-		if o.ca == nil || o.ca.pending {
-			continue
-		}
-		cca := *o.ca
-		cca.Stream = mset.cfg.Name // Needed for safe roll-backs.
-		cca.Client = cca.Client.forAssignmentSnap()
-		cca.Subject, cca.Reply = _EMPTY_, _EMPTY_
-		snap.Consumers = append(snap.Consumers, &cca)
+		Consumers: consumers,
 	}
 	b, _ := json.Marshal(snap)
 	return b

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1108,6 +1108,13 @@ func (js *jetStream) checkForOrphans() {
 				streams = append(streams, mset)
 			} else {
 				// This one is good, check consumers now.
+				mset.cfgMu.RLock()
+				managesConsumers := mset.cfg.ManagesConsumers
+				mset.cfgMu.RUnlock()
+				// Don't mark as orphaned if the stream itself manages its own consumers.
+				if managesConsumers {
+					continue
+				}
 				for _, o := range mset.getConsumers() {
 					if sa.consumers[o.String()] == nil {
 						consumers = append(consumers, o)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7352,10 +7352,12 @@ func (s *Server) jsClusteredConsumerDeleteRequest(ci *ClientInfo, acc *Account, 
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return
 	}
-	if sa.Config != nil && sa.Config.ManagesConsumers && !cc.isStreamLeader(acc.Name, stream) {
-		// Only the stream leader must make this proposal when the stream manages
-		// its own consumers.
-		return
+	if sa.Config != nil && sa.Config.ManagesConsumers {
+		if !cc.isStreamLeader(acc.Name, stream) {
+			// Only the stream leader must make this proposal when the stream manages
+			// its own consumers.
+			return
+		}
 	} else if cc.meta.Leaderless() {
 		resp.Error = NewJSClusterNotAvailError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -4499,9 +4499,11 @@ func TestJetStreamClusterNoQuorumStepdown(t *testing.T) {
 	for info := range js.StreamsInfo() {
 		t.Fatalf("Unexpected stream info, got %v", info)
 	}
-	for info := range js.ConsumersInfo("NO-Q") {
-		t.Fatalf("Unexpected consumer info, got %v", info)
-	}
+	// TODO(nat): Check this, if the metaleader is down then technically we can still
+	// service these requests as long as the stream leader is up.
+	// for info := range js.ConsumersInfo("NO-Q") {
+	// 	t.Fatalf("Unexpected consumer info, got %v", info)
+	// }
 }
 
 func TestJetStreamClusterCreateResponseAdvisoriesHaveSubject(t *testing.T) {

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -35,6 +35,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nuid"
 )
@@ -6640,4 +6641,229 @@ func TestJetStreamClusterSDMMaxAgeProposeExpiryShortRetry(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestJetStreamClusterManagedConsumers(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:             "TEST1",
+		Retention:        LimitsPolicy,
+		Subjects:         []string{"foo"},
+		Storage:          FileStorage,
+		Replicas:         3,
+		ManagesConsumers: true,
+	})
+	require_NoError(t, err)
+
+	_, err = jsStreamCreate(t, nc, &StreamConfig{
+		Name:             "TEST2",
+		Retention:        LimitsPolicy,
+		Subjects:         []string{"bar"},
+		Storage:          FileStorage,
+		Replicas:         3,
+		ManagesConsumers: false,
+	})
+	require_NoError(t, err)
+
+	c.waitOnStreamLeader(globalAccountName, "TEST1")
+	c.waitOnStreamLeader(globalAccountName, "TEST2")
+
+	_, err = js.AddConsumer("TEST1", &nats.ConsumerConfig{
+		Name:      "TestConsumer",
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	_, err = js.AddConsumer("TEST2", &nats.ConsumerConfig{
+		Name:      "TestConsumer",
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	// Prove that none of the servers have consumers for this stream
+	// in their metadata.
+	for _, s := range c.servers {
+		js := s.getJetStream()
+		compressed, err := js.metaSnapshot()
+		require_NoError(t, err)
+		var metadata []writeableStreamAssignment
+		decompressed, err := s2.Decode(nil, compressed)
+		require_NoError(t, err)
+		require_NoError(t, json.Unmarshal(decompressed, &metadata))
+		require_Len(t, len(metadata), 2)
+		for _, sa := range metadata {
+			switch sa.Config.Name {
+			case "TEST1": // TEST1 manages its own consumers so the metalayer should not contain any.
+				require_Len(t, len(sa.Consumers), 0)
+			case "TEST2": // TEST2 does not manage its own consumers so we expect them to be here.
+				require_Len(t, len(sa.Consumers), 1)
+			}
+		}
+	}
+}
+
+func TestJetStreamClusterManagedConsumerStreamScaleDown(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:             "TEST",
+		Retention:        InterestPolicy,
+		Subjects:         []string{"foo"},
+		Storage:          FileStorage,
+		Replicas:         3,
+		ManagesConsumers: true,
+	})
+	require_NoError(t, err)
+
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+
+	ci, err := js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Name:      "TestConsumer",
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+	require_Len(t, len(ci.Cluster.Replicas), 2)
+
+	_, err = jsStreamUpdate(t, nc, &StreamConfig{
+		Name:             "TEST",
+		Retention:        InterestPolicy,
+		Subjects:         []string{"foo"},
+		Storage:          FileStorage,
+		Replicas:         1,
+		ManagesConsumers: true,
+	})
+	require_Error(t, err) // 10052
+	jserr, ok := err.(*ApiError)
+	require_True(t, ok)
+	require_Equal(t, jserr.Code, 500)
+	require_Equal(t, jserr.ErrCode, 10052)
+}
+
+func TestJetStreamClusterManagedConsumerStreamScaleUp(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 5)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:             "TEST",
+		Retention:        InterestPolicy,
+		Subjects:         []string{"foo"},
+		Storage:          FileStorage,
+		Replicas:         3,
+		ManagesConsumers: true,
+	})
+	require_NoError(t, err)
+
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+	_ = js
+
+	ci, err := js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Name:      "TestConsumer",
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	checkFor(t, 10*time.Second, 500*time.Millisecond, func() error {
+		if ci, err = js.ConsumerInfo("TEST", "TestConsumer"); err != nil {
+			return err
+		}
+		if replicas := len(ci.Cluster.Replicas); replicas != 2 {
+			return fmt.Errorf("expected 2 replicas, got %d replicas", replicas)
+		}
+		return nil
+	})
+
+	_, err = jsStreamUpdate(t, nc, &StreamConfig{
+		Name:             "TEST",
+		Retention:        InterestPolicy,
+		Subjects:         []string{"foo"},
+		Storage:          FileStorage,
+		Replicas:         5,
+		ManagesConsumers: true,
+	})
+	require_NoError(t, err)
+
+	c.waitOnAllCurrent()
+
+	checkFor(t, 10*time.Second, 500*time.Millisecond, func() error {
+		if ci, err = js.ConsumerInfo("TEST", "TestConsumer"); err != nil {
+			return err
+		}
+		if replicas := len(ci.Cluster.Replicas); replicas != 4 {
+			return fmt.Errorf("expected 4 replicas, got %d replicas", replicas)
+		}
+		return nil
+	})
+}
+
+func TestJetStreamClusterManagedConsumerStreamScaleMove(t *testing.T) {
+	gid := 0
+	c := createJetStreamClusterWithTemplateAndModHook(t, jsClusterTempl, "R3S", 6,
+		func(serverName, clusterName, storeDir, conf string) string {
+			gid++
+			return fmt.Sprintf("%s\nserver_tags: [group:%d]", conf, (gid%2)+1)
+		})
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	sc, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:             "TEST",
+		Retention:        InterestPolicy,
+		Subjects:         []string{"foo"},
+		Storage:          FileStorage,
+		Replicas:         3,
+		ManagesConsumers: true,
+		Placement: &Placement{
+			Tags: []string{"group:1"},
+		},
+	})
+	require_NoError(t, err)
+
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+
+	ci, err := js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Name:      "TestConsumer",
+		Durable:   "TestConsumer",
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	checkFor(t, 10*time.Second, 500*time.Millisecond, func() error {
+		if ci, err = js.ConsumerInfo("TEST", "TestConsumer"); err != nil {
+			return err
+		}
+		if replicas := len(ci.Cluster.Replicas); replicas != 2 {
+			return fmt.Errorf("expected 2 replicas, got %d replicas", replicas)
+		}
+		return nil
+	})
+
+	sc.Placement.Tags = []string{"group:2"}
+	_, err = jsStreamUpdate(t, nc, sc)
+	require_NoError(t, err)
+
+	c.waitOnAllCurrent()
+
+	checkFor(t, 20*time.Second, 500*time.Millisecond, func() error {
+		if ci, err = js.ConsumerInfo("TEST", "TestConsumer"); err != nil {
+			return err
+		}
+		if replicas := len(ci.Cluster.Replicas); replicas != 2 {
+			return fmt.Errorf("expected 2 replicas, got %d replicas", replicas)
+		}
+		return nil
+	})
 }

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -6707,6 +6707,62 @@ func TestJetStreamClusterManagedConsumers(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterManagedConsumersEncodedStreamState(t *testing.T) {
+	for _, storage := range []StorageType{FileStorage, MemoryStorage} {
+		t.Run(storage.String(), func(t *testing.T) {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+
+			nc, js := jsClientConnect(t, c.randomServer())
+			defer nc.Close()
+
+			_, err := jsStreamCreate(t, nc, &StreamConfig{
+				Name:             "TEST",
+				Retention:        LimitsPolicy,
+				Subjects:         []string{"foo.*"},
+				Storage:          storage,
+				Replicas:         3,
+				ManagesConsumers: true,
+			})
+			require_NoError(t, err)
+
+			c.waitOnStreamLeader(globalAccountName, "TEST")
+
+			// Publish messages and ensure there's an interior delete.
+			// This tests we can read an undefined amount of deletes, and the managed consumers afterward.
+			_, err = js.Publish("foo.0", nil)
+			require_NoError(t, err)
+			_, err = js.Publish("foo.1", nil)
+			require_NoError(t, err)
+			_, err = js.Publish("foo.0", nil)
+			require_NoError(t, err)
+			require_NoError(t, js.PurgeStream("TEST", &nats.StreamPurgeRequest{Subject: "foo.1"}))
+
+			// Add consumer to be included in the snapshot.
+			_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Name: "CONSUMER"})
+			require_NoError(t, err)
+
+			sl := c.streamLeader(globalAccountName, "TEST")
+			sjs := sl.getJetStream()
+			ca := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+			require_NotNil(t, ca)
+			mset, err := sl.globalAccount().lookupStream("TEST")
+			require_NoError(t, err)
+
+			// Encode and decode state.
+			snap, err := mset.store.EncodedStreamState(0, []*consumerAssignment{ca})
+			require_NoError(t, err)
+			state, err := DecodeStreamState(snap)
+			require_NoError(t, err)
+
+			require_Equal(t, state.Msgs, 2)
+			require_Equal(t, state.FirstSeq, 1)
+			require_Equal(t, state.LastSeq, 3)
+			require_Len(t, len(state.Consumers), 1)
+		})
+	}
+}
+
 func TestJetStreamClusterManagedConsumerStreamScaleDown(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -6766,7 +6766,6 @@ func TestJetStreamClusterManagedConsumerStreamScaleUp(t *testing.T) {
 	require_NoError(t, err)
 
 	c.waitOnStreamLeader(globalAccountName, "TEST")
-	_ = js
 
 	ci, err := js.AddConsumer("TEST", &nats.ConsumerConfig{
 		Name:      "TestConsumer",
@@ -6866,4 +6865,36 @@ func TestJetStreamClusterManagedConsumerStreamScaleMove(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+func TestJetStreamClusterManagedConsumerPreventsStreamUpdate(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, _ := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:             "TEST",
+		Retention:        InterestPolicy,
+		Subjects:         []string{"foo"},
+		Storage:          FileStorage,
+		Replicas:         3,
+		ManagesConsumers: true,
+	})
+	require_NoError(t, err)
+
+	_, err = jsStreamUpdate(t, nc, &StreamConfig{
+		Name:             "TEST",
+		Retention:        InterestPolicy,
+		Subjects:         []string{"foo"},
+		Storage:          FileStorage,
+		Replicas:         3,
+		ManagesConsumers: false,
+	})
+	require_Error(t, err) // 10052
+	jserr, ok := err.(*ApiError)
+	require_True(t, ok)
+	require_Equal(t, jserr.Code, 500)
+	require_Equal(t, jserr.ErrCode, 10052)
 }

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -3367,7 +3367,7 @@ func TestJetStreamClusterDesyncAfterErrorDuringCatchup(t *testing.T) {
 				var snap StreamReplicatedState
 				snap.LastSeq = 1_000      // ensure we can catchup based on the snapshot
 				appliedIndex := uint64(0) // incorrect index, but doesn't matter for this test
-				err := mset.processSnapshot(&snap, appliedIndex)
+				err := mset.processSnapshot(mset.srv.getJetStream(), &snap, appliedIndex)
 				require_True(t, errors.Is(err, errCatchupAbortedNoLeader))
 				require_True(t, isClusterResetErr(err))
 				mset.resetClusteredState(err)

--- a/server/jetstream_versioning.go
+++ b/server/jetstream_versioning.go
@@ -60,6 +60,11 @@ func setStaticStreamMetadata(cfg *StreamConfig) {
 		requires(2)
 	}
 
+	// Streams owning their consumers were added in 2.12 and require API level 2.
+	if cfg.ManagesConsumers {
+		requires(2)
+	}
+
 	cfg.Metadata[JSRequiredLevelMetadataKey] = strconv.Itoa(requiredApiLevel)
 }
 

--- a/server/jetstream_versioning_test.go
+++ b/server/jetstream_versioning_test.go
@@ -87,6 +87,11 @@ func TestJetStreamSetStaticStreamMetadata(t *testing.T) {
 			cfg:              &StreamConfig{AllowAsyncFlush: true},
 			expectedMetadata: metadataAtLevel("2"),
 		},
+		{
+			desc:             "ManagesConsumers",
+			cfg:              &StreamConfig{ManagesConsumers: true},
+			expectedMetadata: metadataAtLevel("2"),
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			setStaticStreamMetadata(test.cfg)

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -14,8 +14,10 @@
 package server
 
 import (
+	"bytes"
 	crand "crypto/rand"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math"
 	"slices"
@@ -2042,7 +2044,7 @@ func (ms *memStore) Snapshot(_ time.Duration, _, _ bool) (*SnapshotResult, error
 }
 
 // Binary encoded state snapshot, >= v2.10 server.
-func (ms *memStore) EncodedStreamState(failed uint64) ([]byte, error) {
+func (ms *memStore) EncodedStreamState(failed uint64, consumers []*consumerAssignment) ([]byte, error) {
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
 
@@ -2071,6 +2073,13 @@ func (ms *memStore) EncodedStreamState(failed uint64) ([]byte, error) {
 			return nil, err
 		}
 		b = append(b, buf...)
+	}
+
+	if ms.cfg.ManagesConsumers {
+		bw := bytes.NewBuffer(b)
+		bw.Truncate(len(b)) // Reset the write pointer but preserve data
+		json.NewEncoder(bw).Encode(consumers)
+		b = bw.Bytes()
 	}
 
 	return b, nil

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -2078,7 +2078,9 @@ func (ms *memStore) EncodedStreamState(failed uint64, consumers []*consumerAssig
 	if ms.cfg.ManagesConsumers {
 		bw := bytes.NewBuffer(b)
 		bw.Truncate(len(b)) // Reset the write pointer but preserve data
-		json.NewEncoder(bw).Encode(consumers)
+		if err := json.NewEncoder(bw).Encode(consumers); err != nil {
+			return nil, err
+		}
 		b = bw.Bytes()
 	}
 

--- a/server/norace_2_test.go
+++ b/server/norace_2_test.go
@@ -439,7 +439,7 @@ func TestNoRaceBinaryStreamSnapshotEncodingBasic(t *testing.T) {
 	mset, err := s.GlobalAccount().lookupStream("TEST")
 	require_NoError(t, err)
 
-	snap, err := mset.store.EncodedStreamState(0)
+	snap, err := mset.store.EncodedStreamState(0, nil)
 	require_NoError(t, err)
 
 	// Now decode the snapshot.
@@ -473,7 +473,7 @@ func TestNoRaceFilestoreBinaryStreamSnapshotEncodingLargeGaps(t *testing.T) {
 	}
 	fs.StoreMsg(subj, nil, msg, 0)
 
-	snap, err := fs.EncodedStreamState(0)
+	snap, err := fs.EncodedStreamState(0, nil)
 	require_NoError(t, err)
 	require_True(t, len(snap) < 512)
 
@@ -617,7 +617,7 @@ func TestNoRaceStoreStreamEncoderDecoder(t *testing.T) {
 					continue
 				}
 				start := time.Now()
-				snap, err := gs.EncodedStreamState(0)
+				snap, err := gs.EncodedStreamState(0, nil)
 				require_NoError(t, err)
 				elapsed := time.Since(start)
 				// Should take <1ms without race but if CI/CD is slow we will give it a bit of room.

--- a/server/raft.go
+++ b/server/raft.go
@@ -889,6 +889,10 @@ func (n *raft) ProposeMulti(entries []*Entry) error {
 // ForwardProposal will forward the proposal to the leader if known.
 // If we are the leader this is the same as calling propose.
 func (n *raft) ForwardProposal(entry []byte) error {
+	if n == nil {
+		return fmt.Errorf("no Raft group present")
+	}
+
 	if n.State() == Leader {
 		return n.Propose(entry)
 	}

--- a/server/store.go
+++ b/server/store.go
@@ -222,12 +222,13 @@ type DeleteBlocks []DeleteBlock
 // StreamReplicatedState represents what is encoded in a binary stream snapshot used
 // for stream replication in an NRG.
 type StreamReplicatedState struct {
-	Msgs     uint64
-	Bytes    uint64
-	FirstSeq uint64
-	LastSeq  uint64
-	Failed   uint64
-	Deleted  DeleteBlocks
+	Msgs      uint64
+	Bytes     uint64
+	FirstSeq  uint64
+	LastSeq   uint64
+	Failed    uint64
+	Deleted   DeleteBlocks
+	Consumers []*consumerAssignment
 }
 
 // Determine if this is an encoded stream state.

--- a/server/stream.go
+++ b/server/stream.go
@@ -1962,6 +1962,11 @@ func (jsa *jsAccount) configUpdateCheck(old, new *StreamConfig, s *Server, pedan
 		return nil, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration update can not change message counter setting"))
 	}
 
+	// Can't change the consumer assignments setting.
+	if cfg.ManagesConsumers != old.ManagesConsumers {
+		return nil, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration update can not change consumer management"))
+	}
+
 	// Do some adjustments for being sealed.
 	// Pedantic mode will allow those changes to be made, as they are deterministic and important to get a sealed stream.
 	if cfg.Sealed {


### PR DESCRIPTION
This PR adds a new configuration `ManagesConsumers` to the stream config. When enabled, the stream will manage the assignments for its own consumers instead of leaving the metalayer to do it. This means that you can, in theory, load a system with far more consumers than before without creating global lockups at the metalayer during snapshotting.

Some notes:

- Right now this only works for replicated streams, since we store the assignments in the stream snapshot, reusing existing synchronisation logic provided by the Raft layer;
- It can only be enabled when the stream is created, it cannot be updated later;
- It is not possible to scale a stream down to R1 when this is enabled;
- Currently the consumer assignments are encoded into the stream snapshot using gob encoding — this is faster than JSON and less dangerous than using a custom encoding where we might forget to add a new consumer config field later;
- Probably still needs some more tests, there are a handful for proving it works with scale up/down and stream move/cancel.

Signed-off-by: Neil Twigg <neil@nats.io>