### PR TITLE
NRG: Success signaling & stepdown during catchup 

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3405,14 +3405,22 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 	var scratch [appendEntryResponseLen]byte
 	arbuf := scratch[:]
 
+	// Grab term from append entry. But if leader explicitly defined its term, use that instead.
+	// This is required during catchup if the leader catches us up on older items from previous terms.
+	// While still allowing us to confirm they're matching our highest known term.
+	lterm := ae.term
+	if ae.lterm != 0 {
+		lterm = ae.lterm
+	}
+
 	// Are we receiving from another leader.
 	if n.State() == Leader {
 		// If we are the same we should step down to break the tie.
-		if ae.term >= n.term {
+		if lterm >= n.term {
 			// If the append entry term is newer than the current term, erase our
 			// vote.
-			if ae.term > n.term {
-				n.term = ae.term
+			if lterm > n.term {
+				n.term = lterm
 				n.vote = noVote
 				n.writeTermVote()
 			}
@@ -3424,10 +3432,9 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 			n.debug("AppendEntry ignoring old term from another leader")
 			n.sendRPC(ae.reply, _EMPTY_, ar.encode(arbuf))
 			arPool.Put(ar)
+			n.Unlock()
+			return
 		}
-		// Always return here from processing.
-		n.Unlock()
-		return
 	}
 
 	// If we received an append entry as a candidate then it would appear that
@@ -3436,11 +3443,11 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 	if n.State() == Candidate {
 		// If we have a leader in the current term or higher, we should stepdown,
 		// write the term and vote if the term of the request is higher.
-		if ae.term >= n.term {
+		if lterm >= n.term {
 			// If the append entry term is newer than the current term, erase our
 			// vote.
-			if ae.term > n.term {
-				n.term = ae.term
+			if lterm > n.term {
+				n.term = lterm
 				n.vote = noVote
 				n.writeTermVote()
 			}
@@ -3497,14 +3504,6 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 			// Ignore new while catching up or replaying.
 			return
 		}
-	}
-
-	// Grab term from append entry. But if leader explicitly defined its term, use that instead.
-	// This is required during catchup if the leader catches us up on older items from previous terms.
-	// While still allowing us to confirm they're matching our highest known term.
-	lterm := ae.term
-	if ae.lterm != 0 {
-		lterm = ae.lterm
 	}
 
 	// If this term is greater than ours.

--- a/server/raft.go
+++ b/server/raft.go
@@ -1120,8 +1120,8 @@ func (n *raft) Applied(index uint64) (entries uint64, bytes uint64) {
 	if n.applied > n.papplied {
 		entries = n.applied - n.papplied
 	}
-	if n.bytes > 0 {
-		bytes = entries * n.bytes / (n.pindex - n.papplied)
+	if msgs := n.pindex - n.papplied; msgs > 0 {
+		bytes = entries * n.bytes / msgs
 	}
 	return entries, bytes
 }
@@ -3345,6 +3345,10 @@ func (n *raft) truncateWAL(term, index uint64) {
 		if n.papplied > n.applied {
 			n.papplied = n.applied
 		}
+		// Refresh bytes count after truncate.
+		var state StreamState
+		n.wal.FastState(&state)
+		n.bytes = state.Bytes
 	}()
 
 	if err := n.wal.Truncate(index); err != nil {
@@ -3460,9 +3464,9 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 		}
 	}
 
-	// If we are catching up ignore old catchup subs.
+	// If we are/were catching up ignore old catchup subs.
 	// This could happen when we stall or cancel a catchup.
-	if !isNew && catchingUp && sub != n.catchup.sub {
+	if !isNew && sub != nil && (!catchingUp || sub != n.catchup.sub) {
 		n.Unlock()
 		n.debug("AppendEntry ignoring old entry from previous catchup")
 		return
@@ -3543,7 +3547,6 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 		// Check if this is a lower or equal index than what we were expecting.
 		if ae.pindex <= n.pindex {
 			n.debug("AppendEntry detected pindex less than/equal to ours: [%d:%d] vs [%d:%d]", ae.pterm, ae.pindex, n.pterm, n.pindex)
-			var ar *appendEntryResponse
 			var success bool
 
 			if ae.pindex < n.commit {
@@ -3552,10 +3555,10 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 				n.debug("AppendEntry pindex %d below commit %d, marking success", ae.pindex, n.commit)
 			} else if eae, _ := n.loadEntry(ae.pindex); eae == nil {
 				// If terms are equal, and we are not catching up, we have simply already processed this message.
-				// So we will ACK back to the leader. This can happen on server restarts based on timings of snapshots.
-				if ae.pterm == n.pterm && !catchingUp {
+				// This can happen on server restarts based on timings of snapshots.
+				if ae.pterm == n.pterm && isNew {
 					success = true
-					n.debug("AppendEntry pindex %d already processed, marking success", ae.pindex, n.commit)
+					n.debug("AppendEntry pindex %d already processed, marking success", ae.pindex)
 				} else if ae.pindex == n.pindex {
 					// Check if only our terms do not match here.
 					// Make sure pterms match and we take on the leader's.
@@ -3593,12 +3596,12 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 			if !success {
 				n.cancelCatchup()
 			}
-
-			// Create response.
-			ar = newAppendEntryResponse(ae.pterm, ae.pindex, n.id, success)
+			// Intentionally not responding. Otherwise, we could erroneously report "success". Reporting
+			// non-success is not needed either, and would only be wasting messages.
+			// For example, if we got partial catchup, and then the "real-time" messages came in very delayed.
+			// If we reported "success" on those "real-time" messages, we'd wrongfully be providing
+			// quorum while not having an up-to-date log.
 			n.Unlock()
-			n.sendRPC(ae.reply, _EMPTY_, ar.encode(arbuf))
-			arPool.Put(ar)
 			return
 		}
 
@@ -3753,6 +3756,7 @@ CONTINUE:
 
 	// Only ever respond to new entries.
 	// Never respond to catchup messages, because providing quorum based on this is unsafe.
+	// The only way for the leader to receive "success" MUST be through this path.
 	var ar *appendEntryResponse
 	if sub != nil && isNew {
 		ar = newAppendEntryResponse(n.pterm, n.pindex, n.id, true)


### PR DESCRIPTION
This PR fixes some potential issues with our Raft replication:
- Could technically do a divide by zero in `n.Applied(index)`, now guarding against that. As well as recalculating `n.bytes` after `n.truncateWAL(term, index)`.
- Grab `ae.lterm` from the append entry earlier, and stepdown from leader or candidate if a higher term is detected during catchup.
- Handle case where catchup is canceled but we still receive an entry from a previous catchup, in which case we ignore that entry.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>