### PR TITLE
(2.12) [FIXED] Pedantic stream/consumer config validation & max_ack_pending -1 default

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -554,32 +554,59 @@ const (
 // Helper function to set consumer config defaults from above.
 func setConsumerConfigDefaults(config *ConsumerConfig, streamCfg *StreamConfig, lim *JSLimitOpts, accLim *JetStreamAccountLimits, pedantic bool) *ApiError {
 	// Setup default of -1, meaning no limit for MaxDeliver.
-	if config.MaxDeliver <= 0 {
+	if config.MaxDeliver == 0 || config.MaxDeliver < -1 {
+		if pedantic {
+			return NewJSPedanticError(errors.New("max_deliver must be set to -1"))
+		}
 		config.MaxDeliver = -1
 	}
 	// Setup zero defaults.
 	if config.MaxWaiting < 0 {
+		if pedantic {
+			return NewJSPedanticError(errors.New("max_waiting must not be negative"))
+		}
 		config.MaxWaiting = 0
 	}
-	if config.MaxAckPending < 0 {
-		config.MaxAckPending = 0
+	if config.MaxAckPending < -1 {
+		if pedantic {
+			return NewJSPedanticError(errors.New("max_ack_pending must be set to -1"))
+		}
+		config.MaxAckPending = -1
 	}
 	if config.MaxRequestBatch < 0 {
+		if pedantic {
+			return NewJSPedanticError(errors.New("max_batch must not be negative"))
+		}
 		config.MaxRequestBatch = 0
 	}
 	if config.MaxRequestExpires < 0 {
+		if pedantic {
+			return NewJSPedanticError(errors.New("max_expires must not be negative"))
+		}
 		config.MaxRequestExpires = 0
 	}
 	if config.MaxRequestMaxBytes < 0 {
+		if pedantic {
+			return NewJSPedanticError(errors.New("max_bytes must not be negative"))
+		}
 		config.MaxRequestMaxBytes = 0
 	}
 	if config.Heartbeat < 0 {
+		if pedantic {
+			return NewJSPedanticError(errors.New("idle_heartbeat must not be negative"))
+		}
 		config.Heartbeat = 0
 	}
 	if config.InactiveThreshold < 0 {
+		if pedantic {
+			return NewJSPedanticError(errors.New("inactive_threshold must not be negative"))
+		}
 		config.InactiveThreshold = 0
 	}
 	if config.PinnedTTL < 0 {
+		if pedantic {
+			return NewJSPedanticError(errors.New("priority_timeout must not be negative"))
+		}
 		config.PinnedTTL = 0
 	}
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -1398,6 +1398,9 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 	}
 
 	if cfg.Replicas == 0 {
+		if pedantic {
+			return StreamConfig{}, NewJSPedanticError(fmt.Errorf("replicas must be set"))
+		}
 		cfg.Replicas = 1
 	}
 	if cfg.Replicas > StreamMaxReplicas {
@@ -1406,19 +1409,34 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 	if cfg.Replicas < 0 {
 		return cfg, NewJSReplicasCountCannotBeNegativeError()
 	}
-	if cfg.MaxMsgs <= 0 {
+	if cfg.MaxMsgs == 0 || cfg.MaxMsgs < -1 {
+		if pedantic {
+			return StreamConfig{}, NewJSPedanticError(fmt.Errorf("max_msgs must be set to -1"))
+		}
 		cfg.MaxMsgs = -1
 	}
-	if cfg.MaxMsgsPer <= 0 {
+	if cfg.MaxMsgsPer == 0 || cfg.MaxMsgsPer < -1 {
+		if pedantic {
+			return StreamConfig{}, NewJSPedanticError(fmt.Errorf("max_msgs_per_subject must be set to -1"))
+		}
 		cfg.MaxMsgsPer = -1
 	}
-	if cfg.MaxBytes <= 0 {
+	if cfg.MaxBytes == 0 || cfg.MaxBytes < -1 {
+		if pedantic {
+			return StreamConfig{}, NewJSPedanticError(fmt.Errorf("max_bytes must be set to -1"))
+		}
 		cfg.MaxBytes = -1
 	}
-	if cfg.MaxMsgSize <= 0 {
+	if cfg.MaxMsgSize == 0 || cfg.MaxMsgSize < -1 {
+		if pedantic {
+			return StreamConfig{}, NewJSPedanticError(fmt.Errorf("max_msg_size must be set to -1"))
+		}
 		cfg.MaxMsgSize = -1
 	}
-	if cfg.MaxConsumers <= 0 {
+	if cfg.MaxConsumers == 0 || cfg.MaxConsumers < -1 {
+		if pedantic {
+			return StreamConfig{}, NewJSPedanticError(fmt.Errorf("max_consumers must be set to -1"))
+		}
 		cfg.MaxConsumers = -1
 	}
 	if cfg.MaxAge != 0 && cfg.MaxAge < 100*time.Millisecond {
@@ -1428,13 +1446,13 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 		maxWindow := StreamDefaultDuplicatesWindow
 		if lim.Duplicates > 0 && maxWindow > lim.Duplicates {
 			if pedantic {
-				return StreamConfig{}, NewJSPedanticError(fmt.Errorf("pedantic mode: duplicate window limits are higher than current limits"))
+				return StreamConfig{}, NewJSPedanticError(fmt.Errorf("duplicate window limits are higher than current limits"))
 			}
 			maxWindow = lim.Duplicates
 		}
 		if cfg.MaxAge != 0 && cfg.MaxAge < maxWindow {
 			if pedantic {
-				return StreamConfig{}, NewJSPedanticError(fmt.Errorf("pedantic mode: duplicate window cannot be bigger than max age"))
+				return StreamConfig{}, NewJSPedanticError(fmt.Errorf("duplicate window cannot be bigger than max age"))
 			}
 			cfg.Duplicates = cfg.MaxAge
 		} else {
@@ -1828,7 +1846,7 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 		// Empty same as all.
 		if cfg.RePublish.Source == _EMPTY_ {
 			if pedantic {
-				return StreamConfig{}, NewJSPedanticError(fmt.Errorf("pedantic mode: republish source can not be empty"))
+				return StreamConfig{}, NewJSPedanticError(fmt.Errorf("republish source can not be empty"))
 			}
 			cfg.RePublish.Source = fwcs
 		}


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/7134 based on https://github.com/nats-io/nats-server/pull/7134#discussion_r2269737164 and https://github.com/nats-io/jsm.go/pull/693.

`max_ack_pending` should default to a minimum of -1. And add pedantic handling to all minimums.

Also removes the `pedantic mode:` prefix in the pedantic error, because it resulted in `pedantic mode: pedantic mode: {err}`, as the pedantic error already adds the prefix.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>