### PR TITLE
(2.12) Remove Read-after-Write for now

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -116,7 +116,7 @@ type ConsumerConfig struct {
 	// Force memory storage.
 	MemoryStorage bool `json:"mem_storage,omitempty"`
 	// Force the consumer to only deliver messages if the stream has at minimum this specified last sequence.
-	MinLastSeq uint64 `json:"min_last_seq,omitempty"`
+	MinLastSeq uint64 `json:"-"`
 
 	// Don't add to general clients.
 	Direct bool `json:"direct,omitempty"`

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -680,7 +680,7 @@ type JSApiMsgGetRequest struct {
 	NextFor string `json:"next_by_subj,omitempty"`
 
 	// Force the server to only deliver messages if the stream has at minimum this specified last sequence.
-	MinLastSeq uint64 `json:"min_last_seq,omitempty"`
+	MinLastSeq uint64 `json:"-"`
 
 	// Batch support. Used to request more than one msg at a time.
 	// Can be used with simple starting seq, but also NextFor with wildcards.

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -9230,6 +9230,9 @@ func TestJetStreamClusterAsyncFlushFileStoreFlushOnSnapshot(t *testing.T) {
 }
 
 func TestJetStreamClusterMsgGetReadAfterWrite(t *testing.T) {
+	// TODO(mvv): revisit for 2.14+
+	t.Skip()
+
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 
@@ -9270,6 +9273,9 @@ func TestJetStreamClusterMsgGetReadAfterWrite(t *testing.T) {
 }
 
 func TestJetStreamClusterMsgGetMonotonicRead(t *testing.T) {
+	// TODO(mvv): revisit for 2.14+
+	t.Skip()
+
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 
@@ -9306,6 +9312,9 @@ func TestJetStreamClusterMsgGetMonotonicRead(t *testing.T) {
 }
 
 func TestJetStreamClusterDirectGetReadAfterWrite(t *testing.T) {
+	// TODO(mvv): revisit for 2.14+
+	t.Skip()
+
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 
@@ -9367,6 +9376,9 @@ func TestJetStreamClusterDirectGetReadAfterWrite(t *testing.T) {
 }
 
 func TestJetStreamClusterMirrorDirectGetReadAfterWrite(t *testing.T) {
+	// TODO(mvv): revisit for 2.14+
+	t.Skip()
+
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 
@@ -9488,6 +9500,9 @@ func TestJetStreamClusterMirrorDirectGetReadAfterWrite(t *testing.T) {
 }
 
 func TestJetStreamClusterDirectGetReadAfterWriteOutdatedFollower(t *testing.T) {
+	// TODO(mvv): revisit for 2.14+
+	t.Skip()
+
 	test := func(t *testing.T, templ string, accName string, authenticated bool) {
 		c := createJetStreamClusterWithTemplate(t, templ, "R3S", 3)
 		defer c.shutdown()
@@ -9591,6 +9606,9 @@ func TestJetStreamClusterDirectGetReadAfterWriteOutdatedFollower(t *testing.T) {
 }
 
 func TestJetStreamClusterDirectGetMonotonicRead(t *testing.T) {
+	// TODO(mvv): revisit for 2.14+
+	t.Skip()
+
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 
@@ -9644,6 +9662,9 @@ func TestJetStreamClusterDirectGetMonotonicRead(t *testing.T) {
 }
 
 func TestJetStreamClusterDirectGetLastBySubjectReadAfterWrite(t *testing.T) {
+	// TODO(mvv): revisit for 2.14+
+	t.Skip()
+
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 
@@ -9705,6 +9726,9 @@ func TestJetStreamClusterDirectGetLastBySubjectReadAfterWrite(t *testing.T) {
 }
 
 func TestJetStreamClusterDirectGetLastBySubjectReadAfterWriteOutdatedFollower(t *testing.T) {
+	// TODO(mvv): revisit for 2.14+
+	t.Skip()
+
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 
@@ -9758,6 +9782,9 @@ func TestJetStreamClusterDirectGetLastBySubjectReadAfterWriteOutdatedFollower(t 
 }
 
 func TestJetStreamClusterDirectGetLastBySubjectMonotonicRead(t *testing.T) {
+	// TODO(mvv): revisit for 2.14+
+	t.Skip()
+
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 
@@ -9808,6 +9835,9 @@ func TestJetStreamClusterDirectGetLastBySubjectMonotonicRead(t *testing.T) {
 }
 
 func TestJetStreamClusterConsumerReadAfterWrite(t *testing.T) {
+	// TODO(mvv): revisit for 2.14+
+	t.Skip()
+
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 

--- a/server/jetstream_versioning.go
+++ b/server/jetstream_versioning.go
@@ -131,11 +131,6 @@ func setStaticConsumerMetadata(cfg *ConsumerConfig) {
 		requires(1)
 	}
 
-	// Added in 2.12, absent | zero is the feature is not used.
-	if cfg.MinLastSeq > 0 {
-		requires(2)
-	}
-
 	cfg.Metadata[JSRequiredLevelMetadataKey] = strconv.Itoa(requiredApiLevel)
 }
 

--- a/server/jetstream_versioning_test.go
+++ b/server/jetstream_versioning_test.go
@@ -229,11 +229,6 @@ func TestJetStreamSetStaticConsumerMetadata(t *testing.T) {
 			cfg:              &ConsumerConfig{PriorityPolicy: PriorityPinnedClient, PriorityGroups: []string{"a"}},
 			expectedMetadata: metadataAtLevel("1"),
 		},
-		{
-			desc:             "MinLastSeq",
-			cfg:              &ConsumerConfig{MinLastSeq: 1},
-			expectedMetadata: metadataAtLevel("2"),
-		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			setStaticConsumerMetadata(test.cfg)


### PR DESCRIPTION
Remove read-after-write/monotonic reads for 2.12.

> Although the design (read-after-write/monotonic reads/linearizable) gives a lot of control and flexibility, we'll need to decide whether this adds a bunch of complexity which would be (too) hard to understand by an end-user, in which case we might need to revisit this.
https://github.com/nats-io/nats-server/pull/7146#issuecomment-3160570465

The current design is very flexible, but adds a ton of complexity that needs to be handled on a per-request basis. We've discussed whether this should instead be on a per-stream basis. Where on a replicated stream/KV/ObjectStore the reads are serializable by default, but one can opt-in to linearizable for that whole stream. That would mean client code doesn't need to change at all to get this guarantee, only the stream setting would need to be updated.

We'll need to discuss this further, and likely introduce this early in the next 2.14 (skipping 2.13) release cycle.

Relates to https://github.com/nats-io/nats-server/issues/6557
Relates to PRs: https://github.com/nats-io/nats-server/pull/6970, https://github.com/nats-io/nats-server/pull/7146

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
