### PR TITLE
(2.12) Delayed message scheduling

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -1838,5 +1838,75 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSMirrorWithMsgSchedulesErr",
+    "code": 400,
+    "error_code": 10186,
+    "description": "stream mirrors can not also schedule messages",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSSourceWithMsgSchedulesErr",
+    "code": 400,
+    "error_code": 10187,
+    "description": "stream source can not also schedule messages",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSMessageSchedulesDisabledErr",
+    "code": 400,
+    "error_code": 10188,
+    "description": "message schedules is disabled",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSMessageSchedulesPatternInvalidErr",
+    "code": 400,
+    "error_code": 10189,
+    "description": "message schedules pattern is invalid",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSMessageSchedulesTargetInvalidErr",
+    "code": 400,
+    "error_code": 10190,
+    "description": "message schedules target is invalid",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSMessageSchedulesTTLInvalidErr",
+    "code": 400,
+    "error_code": 10191,
+    "description": "message schedules invalid per-message TTL",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSMessageSchedulesRollupInvalidErr",
+    "code": 400,
+    "error_code": 10192,
+    "description": "message schedules invalid rollup",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8061,7 +8061,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	discard, discardNewPer, maxMsgs, maxMsgsPer, maxBytes := mset.cfg.Discard, mset.cfg.DiscardNewPer, mset.cfg.MaxMsgs, mset.cfg.MaxMsgsPer, mset.cfg.MaxBytes
 	s, js, jsa, st, r, tierName, outq, node := mset.srv, mset.js, mset.jsa, mset.cfg.Storage, mset.cfg.Replicas, mset.tier, mset.outq, mset.node
 	maxMsgSize, lseq := int(mset.cfg.MaxMsgSize), mset.lseq
-	isLeader, isSealed, allowRollup, denyPurge, allowTTL, allowMsgCounter := mset.isLeader(), mset.cfg.Sealed, mset.cfg.AllowRollup, mset.cfg.DenyPurge, mset.cfg.AllowMsgTTL, mset.cfg.AllowMsgCounter
+	isLeader, isSealed, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules := mset.isLeader(), mset.cfg.Sealed, mset.cfg.AllowRollup, mset.cfg.DenyPurge, mset.cfg.AllowMsgTTL, mset.cfg.AllowMsgCounter, mset.cfg.AllowMsgSchedules
 	mset.mu.RUnlock()
 
 	// This should not happen but possible now that we allow scale up, and scale down where this could trigger.
@@ -8157,7 +8157,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 		err    error
 	)
 	diff := &batchStagedDiff{}
-	if hdr, msg, dseq, apiErr, err = checkMsgHeadersPreClusteredProposal(diff, mset, subject, hdr, msg, sourced, name, jsa, allowRollup, denyPurge, allowTTL, allowMsgCounter, discard, discardNewPer, maxMsgSize, maxMsgs, maxMsgsPer, maxBytes); err != nil {
+	if hdr, msg, dseq, apiErr, err = checkMsgHeadersPreClusteredProposal(diff, mset, subject, hdr, msg, sourced, name, jsa, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, discard, discardNewPer, maxMsgSize, maxMsgs, maxMsgsPer, maxBytes); err != nil {
 		// TODO(mvv): reset in-memory expected header maps
 		mset.clMu.Unlock()
 		if err == errMsgIdDuplicate && dseq > 0 {

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -287,6 +287,21 @@ const (
 	// JSMessageIncrPayloadErr message counter has payload
 	JSMessageIncrPayloadErr ErrorIdentifier = 10170
 
+	// JSMessageSchedulesDisabledErr message schedules is disabled
+	JSMessageSchedulesDisabledErr ErrorIdentifier = 10188
+
+	// JSMessageSchedulesPatternInvalidErr message schedules pattern is invalid
+	JSMessageSchedulesPatternInvalidErr ErrorIdentifier = 10189
+
+	// JSMessageSchedulesRollupInvalidErr message schedules invalid rollup
+	JSMessageSchedulesRollupInvalidErr ErrorIdentifier = 10192
+
+	// JSMessageSchedulesTTLInvalidErr message schedules invalid per-message TTL
+	JSMessageSchedulesTTLInvalidErr ErrorIdentifier = 10191
+
+	// JSMessageSchedulesTargetInvalidErr message schedules target is invalid
+	JSMessageSchedulesTargetInvalidErr ErrorIdentifier = 10190
+
 	// JSMessageTTLDisabledErr per-message TTL is disabled
 	JSMessageTTLDisabledErr ErrorIdentifier = 10166
 
@@ -319,6 +334,9 @@ const (
 
 	// JSMirrorWithFirstSeqErr stream mirrors can not have first sequence configured
 	JSMirrorWithFirstSeqErr ErrorIdentifier = 10143
+
+	// JSMirrorWithMsgSchedulesErr stream mirrors can not also schedule messages
+	JSMirrorWithMsgSchedulesErr ErrorIdentifier = 10186
 
 	// JSMirrorWithSourcesErr stream mirrors can not also contain other sources
 	JSMirrorWithSourcesErr ErrorIdentifier = 10031
@@ -397,6 +415,9 @@ const (
 
 	// JSSourceOverlappingSubjectFilters source filters can not overlap
 	JSSourceOverlappingSubjectFilters ErrorIdentifier = 10147
+
+	// JSSourceWithMsgSchedulesErr stream source can not also schedule messages
+	JSSourceWithMsgSchedulesErr ErrorIdentifier = 10187
 
 	// JSStorageResourcesExceededErr insufficient storage resources available
 	JSStorageResourcesExceededErr ErrorIdentifier = 10047
@@ -654,6 +675,11 @@ var (
 		JSMessageIncrInvalidErr:                    {Code: 400, ErrCode: 10171, Description: "message counter increment is invalid"},
 		JSMessageIncrMissingErr:                    {Code: 400, ErrCode: 10169, Description: "message counter increment is missing"},
 		JSMessageIncrPayloadErr:                    {Code: 400, ErrCode: 10170, Description: "message counter has payload"},
+		JSMessageSchedulesDisabledErr:              {Code: 400, ErrCode: 10188, Description: "message schedules is disabled"},
+		JSMessageSchedulesPatternInvalidErr:        {Code: 400, ErrCode: 10189, Description: "message schedules pattern is invalid"},
+		JSMessageSchedulesRollupInvalidErr:         {Code: 400, ErrCode: 10192, Description: "message schedules invalid rollup"},
+		JSMessageSchedulesTTLInvalidErr:            {Code: 400, ErrCode: 10191, Description: "message schedules invalid per-message TTL"},
+		JSMessageSchedulesTargetInvalidErr:         {Code: 400, ErrCode: 10190, Description: "message schedules target is invalid"},
 		JSMessageTTLDisabledErr:                    {Code: 400, ErrCode: 10166, Description: "per-message TTL is disabled"},
 		JSMessageTTLInvalidErr:                     {Code: 400, ErrCode: 10165, Description: "invalid per-message TTL"},
 		JSMirrorConsumerSetupFailedErrF:            {Code: 500, ErrCode: 10029, Description: "{err}"},
@@ -665,6 +691,7 @@ var (
 		JSMirrorOverlappingSubjectFilters:          {Code: 400, ErrCode: 10152, Description: "mirror subject filters can not overlap"},
 		JSMirrorWithCountersErr:                    {Code: 400, ErrCode: 10173, Description: "stream mirrors can not also calculate counters"},
 		JSMirrorWithFirstSeqErr:                    {Code: 400, ErrCode: 10143, Description: "stream mirrors can not have first sequence configured"},
+		JSMirrorWithMsgSchedulesErr:                {Code: 400, ErrCode: 10186, Description: "stream mirrors can not also schedule messages"},
 		JSMirrorWithSourcesErr:                     {Code: 400, ErrCode: 10031, Description: "stream mirrors can not also contain other sources"},
 		JSMirrorWithStartSeqAndTimeErr:             {Code: 400, ErrCode: 10032, Description: "stream mirrors can not have both start seq and start time configured"},
 		JSMirrorWithSubjectFiltersErr:              {Code: 400, ErrCode: 10033, Description: "stream mirrors can not contain filtered subjects"},
@@ -691,6 +718,7 @@ var (
 		JSSourceMaxMessageSizeTooBigErr:            {Code: 400, ErrCode: 10046, Description: "stream source must have max message size >= target"},
 		JSSourceMultipleFiltersNotAllowed:          {Code: 400, ErrCode: 10144, Description: "source with multiple subject transforms cannot also have a single subject filter"},
 		JSSourceOverlappingSubjectFilters:          {Code: 400, ErrCode: 10147, Description: "source filters can not overlap"},
+		JSSourceWithMsgSchedulesErr:                {Code: 400, ErrCode: 10187, Description: "stream source can not also schedule messages"},
 		JSStorageResourcesExceededErr:              {Code: 500, ErrCode: 10047, Description: "insufficient storage resources available"},
 		JSStreamAssignmentErrF:                     {Code: 500, ErrCode: 10048, Description: "{err}"},
 		JSStreamCreateErrF:                         {Code: 500, ErrCode: 10049, Description: "{err}"},
@@ -1787,6 +1815,56 @@ func NewJSMessageIncrPayloadError(opts ...ErrorOption) *ApiError {
 	return ApiErrors[JSMessageIncrPayloadErr]
 }
 
+// NewJSMessageSchedulesDisabledError creates a new JSMessageSchedulesDisabledErr error: "message schedules is disabled"
+func NewJSMessageSchedulesDisabledError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMessageSchedulesDisabledErr]
+}
+
+// NewJSMessageSchedulesPatternInvalidError creates a new JSMessageSchedulesPatternInvalidErr error: "message schedules pattern is invalid"
+func NewJSMessageSchedulesPatternInvalidError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMessageSchedulesPatternInvalidErr]
+}
+
+// NewJSMessageSchedulesRollupInvalidError creates a new JSMessageSchedulesRollupInvalidErr error: "message schedules invalid rollup"
+func NewJSMessageSchedulesRollupInvalidError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMessageSchedulesRollupInvalidErr]
+}
+
+// NewJSMessageSchedulesTTLInvalidError creates a new JSMessageSchedulesTTLInvalidErr error: "message schedules invalid per-message TTL"
+func NewJSMessageSchedulesTTLInvalidError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMessageSchedulesTTLInvalidErr]
+}
+
+// NewJSMessageSchedulesTargetInvalidError creates a new JSMessageSchedulesTargetInvalidErr error: "message schedules target is invalid"
+func NewJSMessageSchedulesTargetInvalidError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMessageSchedulesTargetInvalidErr]
+}
+
 // NewJSMessageTTLDisabledError creates a new JSMessageTTLDisabledErr error: "per-message TTL is disabled"
 func NewJSMessageTTLDisabledError(opts ...ErrorOption) *ApiError {
 	eopts := parseOpts(opts)
@@ -1913,6 +1991,16 @@ func NewJSMirrorWithFirstSeqError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSMirrorWithFirstSeqErr]
+}
+
+// NewJSMirrorWithMsgSchedulesError creates a new JSMirrorWithMsgSchedulesErr error: "stream mirrors can not also schedule messages"
+func NewJSMirrorWithMsgSchedulesError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMirrorWithMsgSchedulesErr]
 }
 
 // NewJSMirrorWithSourcesError creates a new JSMirrorWithSourcesErr error: "stream mirrors can not also contain other sources"
@@ -2215,6 +2303,16 @@ func NewJSSourceOverlappingSubjectFiltersError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSSourceOverlappingSubjectFilters]
+}
+
+// NewJSSourceWithMsgSchedulesError creates a new JSSourceWithMsgSchedulesErr error: "stream source can not also schedule messages"
+func NewJSSourceWithMsgSchedulesError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSSourceWithMsgSchedulesErr]
 }
 
 // NewJSStorageResourcesExceededError creates a new JSStorageResourcesExceededErr error: "insufficient storage resources available"

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -21748,3 +21748,27 @@ func TestJetStreamPromoteMirrorUpdatingOrigin(t *testing.T) {
 	t.Run("R1", func(t *testing.T) { test(t, 1) })
 	t.Run("R3", func(t *testing.T) { test(t, 3) })
 }
+
+func TestJetStreamScheduledMirrorOrSource(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc := clientConnectToServer(t, s)
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:              "TEST",
+		Storage:           FileStorage,
+		Mirror:            &StreamSource{Name: "M"},
+		AllowMsgSchedules: true,
+	})
+	require_Error(t, err, NewJSMirrorWithMsgSchedulesError())
+
+	_, err = jsStreamCreate(t, nc, &StreamConfig{
+		Name:              "TEST",
+		Storage:           FileStorage,
+		Sources:           []*StreamSource{{Name: "S"}},
+		AllowMsgSchedules: true,
+	})
+	require_Error(t, err, NewJSSourceWithMsgSchedulesError())
+}

--- a/server/jetstream_versioning.go
+++ b/server/jetstream_versioning.go
@@ -55,6 +55,11 @@ func setStaticStreamMetadata(cfg *StreamConfig) {
 		requires(2)
 	}
 
+	// Message scheduling was added in v2.12 and require API level 2.
+	if cfg.AllowMsgSchedules {
+		requires(2)
+	}
+
 	cfg.Metadata[JSRequiredLevelMetadataKey] = strconv.Itoa(requiredApiLevel)
 }
 

--- a/server/jetstream_versioning_test.go
+++ b/server/jetstream_versioning_test.go
@@ -83,6 +83,11 @@ func TestJetStreamSetStaticStreamMetadata(t *testing.T) {
 			cfg:              &StreamConfig{AllowAtomicPublish: true},
 			expectedMetadata: metadataAtLevel("2"),
 		},
+		{
+			desc:             "AllowMsgSchedules",
+			cfg:              &StreamConfig{AllowMsgSchedules: true},
+			expectedMetadata: metadataAtLevel("2"),
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			setStaticStreamMetadata(test.cfg)

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -1,0 +1,239 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"math"
+	"slices"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server/thw"
+)
+
+// Error for when we try to decode a binary-encoded message schedule with an unknown version number.
+var ErrMsgScheduleInvalidVersion = errors.New("msg scheduling: encoded version not known")
+
+const (
+	headerLen = 17 // 1 byte magic + 2x uint64s
+)
+
+type MsgScheduling struct {
+	run       func()
+	ttls      *thw.HashWheel
+	timer     *time.Timer
+	schedules map[string]*MsgSchedule
+	seqToSubj map[uint64]string
+	inflight  map[string]struct{}
+}
+
+type MsgSchedule struct {
+	seq uint64
+	ts  int64
+}
+
+func newMsgScheduling(run func()) *MsgScheduling {
+	return &MsgScheduling{
+		run:       run,
+		ttls:      thw.NewHashWheel(),
+		schedules: make(map[string]*MsgSchedule),
+		seqToSubj: make(map[uint64]string),
+		inflight:  make(map[string]struct{}),
+	}
+}
+
+func (ms *MsgScheduling) add(seq uint64, subj string, ts int64) {
+	ms.init(seq, subj, ts)
+	ms.resetTimer()
+}
+
+func (ms *MsgScheduling) init(seq uint64, subj string, ts int64) {
+	if sched, ok := ms.schedules[subj]; ok {
+		delete(ms.seqToSubj, sched.seq)
+		// Remove and add separately, since they'll have different sequences.
+		ms.ttls.Remove(sched.seq, sched.ts)
+		ms.ttls.Add(seq, ts)
+		sched.ts, sched.seq = ts, seq
+	} else {
+		ms.ttls.Add(seq, ts)
+		ms.schedules[subj] = &MsgSchedule{seq: seq, ts: ts}
+	}
+	ms.seqToSubj[seq] = subj
+	delete(ms.inflight, subj)
+}
+
+func (ms *MsgScheduling) markInflight(subj string) {
+	if _, ok := ms.schedules[subj]; ok {
+		ms.inflight[subj] = struct{}{}
+	}
+}
+
+func (ms *MsgScheduling) isInflight(subj string) bool {
+	_, ok := ms.inflight[subj]
+	return ok
+}
+
+func (ms *MsgScheduling) remove(seq uint64) {
+	if subj, ok := ms.seqToSubj[seq]; ok {
+		delete(ms.seqToSubj, seq)
+		delete(ms.schedules, subj)
+	}
+}
+
+func (ms *MsgScheduling) clearInflight() {
+	ms.inflight = make(map[string]struct{})
+}
+
+func (ms *MsgScheduling) resetTimer() {
+	next := ms.ttls.GetNextExpiration(math.MaxInt64)
+	if next == math.MaxInt64 {
+		clearTimer(&ms.timer)
+		return
+	}
+	fireIn := time.Until(time.Unix(0, next))
+
+	// Make sure we aren't firing too often either way, otherwise we can
+	// negatively impact stream ingest performance.
+	if fireIn < 250*time.Millisecond {
+		fireIn = 250 * time.Millisecond
+	}
+
+	if ms.timer != nil {
+		ms.timer.Reset(fireIn)
+	} else {
+		ms.timer = time.AfterFunc(fireIn, ms.run)
+	}
+}
+
+func (ms *MsgScheduling) getScheduledMessages(loadMsg func(seq uint64, smv *StoreMsg) *StoreMsg) []*inMsg {
+	var (
+		smv  StoreMsg
+		sm   *StoreMsg
+		msgs []*inMsg
+	)
+	ms.ttls.ExpireTasks(func(seq uint64, ts int64) bool {
+		// Need to grab the message for the specified sequence, and check
+		// if it hasn't been removed in the meantime.
+		sm = loadMsg(seq, &smv)
+		if sm != nil {
+			// If already inflight, don't duplicate a scheduled message. The stream could
+			// be replicated and the scheduled message could take some time to propagate.
+			if ms.isInflight(sm.subj) {
+				return false
+			}
+			// Validate the contents are correct if not, we just remove it from THW.
+			ttl, ok := getMessageScheduleTTL(sm.hdr)
+			if !ok {
+				ms.remove(seq)
+				return true
+			}
+			target := getMessageScheduleTarget(sm.hdr)
+			if target == _EMPTY_ {
+				ms.remove(seq)
+				return true
+			}
+
+			// Copy, as this is retrieved directly from storage, and we'll need to keep hold of this for some time.
+			// And in the case of headers, we'll copy all of them, but make changes.
+			hdr, msg := copyBytes(sm.hdr), copyBytes(sm.msg)
+
+			// Strip headers specific to the schedule.
+			hdr = removeHeaderIfPresent(hdr, JSSchedulePattern)
+			hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Schedule-")
+			hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Expected-")
+			hdr = removeHeaderIfPresent(hdr, JSMsgId)
+			hdr = removeHeaderIfPresent(hdr, JSMessageTTL)
+			hdr = removeHeaderIfPresent(hdr, JSMsgRollup)
+
+			// Add headers for the scheduled message.
+			hdr = genHeader(hdr, JSScheduler, sm.subj)
+			hdr = genHeader(hdr, JSScheduleNext, JSScheduleNextPurge) // Purge the schedule message itself.
+			if ttl != _EMPTY_ {
+				hdr = genHeader(hdr, JSMessageTTL, ttl)
+			}
+			msgs = append(msgs, &inMsg{seq: seq, subj: target, hdr: hdr, msg: msg})
+			ms.markInflight(sm.subj)
+			return false
+		}
+		ms.remove(seq)
+		return true
+	})
+	// THW is unordered, so must sort by sequence.
+	slices.SortFunc(msgs, func(a, b *inMsg) int {
+		if a.seq == b.seq {
+			return 0
+		} else if a.seq < b.seq {
+			return -1
+		} else {
+			return 1
+		}
+	})
+	return msgs
+}
+
+// encode writes out the contents of the schedule into a binary snapshot
+// and returns it. The high seq number is included in the snapshot and will
+// be returned on decode.
+func (ms *MsgScheduling) encode(highSeq uint64) []byte {
+	count := uint64(len(ms.schedules))
+	b := make([]byte, 0, headerLen+(count*(2*binary.MaxVarintLen64)))
+	b = append(b, 1)                                 // Magic version
+	b = binary.LittleEndian.AppendUint64(b, count)   // Entry count
+	b = binary.LittleEndian.AppendUint64(b, highSeq) // Stamp
+	for subj, sched := range ms.schedules {
+		slen := min(uint64(len(subj)), math.MaxUint16)
+		b = binary.LittleEndian.AppendUint16(b, uint16(slen))
+		b = append(b, subj[:slen]...)
+		b = binary.AppendVarint(b, sched.ts)
+		b = binary.AppendUvarint(b, sched.seq)
+	}
+	return b
+}
+
+// decode snapshots a binary-encoded schedule and replaces the contents of this
+// schedule with them. Returns the high seq number from the snapshot.
+func (ms *MsgScheduling) decode(b []byte) (uint64, error) {
+	if len(b) < headerLen {
+		return 0, io.ErrShortBuffer
+	}
+	if b[0] != 1 {
+		return 0, ErrMsgScheduleInvalidVersion
+	}
+
+	count := binary.LittleEndian.Uint64(b[1:])
+	stamp := binary.LittleEndian.Uint64(b[9:])
+	b = b[headerLen:]
+	for i := uint64(0); i < count; i++ {
+		sl := int(binary.LittleEndian.Uint16(b))
+		b = b[2:]
+		if len(b) < sl {
+			return 0, io.ErrUnexpectedEOF
+		}
+		subj := string(b[:sl])
+		b = b[sl:]
+		ts, tn := binary.Varint(b)
+		if tn < 0 {
+			return 0, io.ErrUnexpectedEOF
+		}
+		seq, vn := binary.Uvarint(b[tn:])
+		if vn < 0 {
+			return 0, io.ErrUnexpectedEOF
+		}
+		ms.init(seq, subj, ts)
+		b = b[tn+vn:]
+	}
+	return stamp, nil
+}

--- a/server/store.go
+++ b/server/store.go
@@ -84,8 +84,9 @@ type StorageUpdateHandler func(msgs, bytes int64, seq uint64, subj string)
 // Used to call back into the upper layers to remove a message.
 type StorageRemoveMsgHandler func(seq uint64)
 
-// Used to call back into the upper layers to report on newly created subject delete markers.
-type SubjectDeleteMarkerUpdateHandler func(*inMsg)
+// Used to call back into the upper layers to process a JetStream message.
+// Will propose the message if the stream is replicated.
+type ProcessJetStreamMsgHandler func(*inMsg)
 
 type StreamStore interface {
 	StoreMsg(subject string, hdr, msg []byte, ttl int64) (uint64, int64, error)
@@ -120,7 +121,7 @@ type StreamStore interface {
 	Type() StorageType
 	RegisterStorageUpdates(StorageUpdateHandler)
 	RegisterStorageRemoveMsg(StorageRemoveMsgHandler)
-	RegisterSubjectDeleteMarkerUpdates(SubjectDeleteMarkerUpdateHandler)
+	RegisterProcessJetStreamMsg(ProcessJetStreamMsgHandler)
 	UpdateConfig(cfg *StreamConfig) error
 	Delete(inline bool) error
 	Stop() error
@@ -129,6 +130,7 @@ type StreamStore interface {
 	RemoveConsumer(o ConsumerStore) error
 	Snapshot(deadline time.Duration, includeConsumers, checkMsgs bool) (*SnapshotResult, error)
 	Utilization() (total, reported uint64, err error)
+	ResetState()
 }
 
 // RetentionPolicy determines how messages in a set are retained.

--- a/server/thw/thw.go
+++ b/server/thw/thw.go
@@ -211,7 +211,7 @@ func (hw *HashWheel) Count() uint64 {
 	return hw.count
 }
 
-// AppendEncode writes out the contents of the THW into a binary snapshot
+// Encode writes out the contents of the THW into a binary snapshot
 // and returns it. The high seq number is included in the snapshot and will
 // be returned on decode.
 func (hw *HashWheel) Encode(highSeq uint64) []byte {


### PR DESCRIPTION
This PR implements [Single scheduled message from ADR-51](https://github.com/nats-io/nats-architecture-and-design/pull/350). Adding support for the `Nats-Schedule: @at 2009-11-10T23:00:00Z`, `Nats-Schedule-TTL: 5m` and `Nats-Schedule-Target: $SCHED.trigger.update_orders` headers.

Specifically for single non-repeating scheduled/delayed messages, the `Nats-Schedule-Next` header will hold a value of `purge`. This will purge the schedule automatically so the delayed message can't be duplicated in any way. For Cron-like schedules the `Nats-Schedule-Next` will instead hold the next time the schedule will run.

Importantly, this PR only implements Single scheduled messages, not the Cron-like schedules.

Relates to https://github.com/nats-io/nats-server/issues/6884

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>