### PR TITLE
(2.12) Allow promoting mirrors

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -6633,7 +6633,8 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		return
 	}
 	// Check for mirror changes which are not allowed.
-	if !reflect.DeepEqual(newCfg.Mirror, osa.Config.Mirror) {
+	// We will allow removing the mirror config to "promote" the mirror to a normal stream.
+	if newCfg.Mirror != nil && !reflect.DeepEqual(newCfg.Mirror, osa.Config.Mirror) {
 		resp.Error = NewJSStreamMirrorNotUpdatableError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return


### PR DESCRIPTION
This allows promoting mirrors by removing the mirror configuration in a stream update.

Signed-off-by: Neil Twigg <neil@nats.io>
