### PR TITLE
(2.12) Atomic batch: support isolated reads

### DIFF
--- a/locksordering.txt
+++ b/locksordering.txt
@@ -47,3 +47,8 @@ The "mset.batches.mu" lock protects the batching state without needing to hold t
 If "clMu" is used to commit a batch, it should only be acquired while already holding the batch lock.
 
     mset.batches.mu -> clMu
+
+The "mset.isolateMu" lock ensures atomic reads/writes over an arbitrary boundary.
+The stream lock (`mset.mu`) and consumer lock (`o.mu`) are optional.
+
+    mset.isolateMu -> stream -> consumer -> store

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -4416,9 +4416,6 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 		return pmsg, 1, err
 	}
 
-	// Hold onto this since we release the lock.
-	store := o.mset.store
-
 	var sseq uint64
 	var err error
 	var sm *StoreMsg
@@ -4428,13 +4425,13 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 	filters, subjf, fseq := o.filters, o.subjf, o.sseq
 	// Check if we are multi-filtered or not.
 	if filters != nil {
-		sm, sseq, err = store.LoadNextMsgMulti(filters, fseq, &pmsg.StoreMsg)
+		sm, sseq, err = o.mset.store.LoadNextMsgMulti(filters, fseq, &pmsg.StoreMsg)
 	} else if len(subjf) > 0 { // Means single filtered subject since o.filters means > 1.
 		filter, wc := subjf[0].subject, subjf[0].hasWildcard
-		sm, sseq, err = store.LoadNextMsg(filter, wc, fseq, &pmsg.StoreMsg)
+		sm, sseq, err = o.mset.store.LoadNextMsg(filter, wc, fseq, &pmsg.StoreMsg)
 	} else {
 		// No filter here.
-		sm, sseq, err = store.LoadNextMsg(_EMPTY_, false, fseq, &pmsg.StoreMsg)
+		sm, sseq, err = o.mset.store.LoadNextMsg(_EMPTY_, false, fseq, &pmsg.StoreMsg)
 	}
 	if sm == nil {
 		pmsg.returnToPool()
@@ -4798,11 +4795,14 @@ func (o *consumer) loopAndGatherMsgs(qch chan struct{}) {
 			wrn, wrb int
 		)
 
+		// Need to grab the isolation lock before the consumer lock.
+		mset.isolateMu.RLock()
 		o.mu.Lock()
 
 		// consumer is closed when mset is set to nil.
 		if o.closed || o.mset == nil {
 			o.mu.Unlock()
+			mset.isolateMu.RUnlock()
 			return
 		}
 
@@ -4813,21 +4813,25 @@ func (o *consumer) loopAndGatherMsgs(qch chan struct{}) {
 		if o.cfg.PauseUntil != nil && !o.cfg.PauseUntil.IsZero() && time.Now().Before(*o.cfg.PauseUntil) {
 			// If the consumer is paused and we haven't reached the deadline yet then
 			// go back to waiting.
+			mset.isolateMu.RUnlock()
 			goto waitForMsgs
 		}
 
 		// If we are in push mode and not active or under flowcontrol let's stop sending.
 		if o.isPushMode() {
 			if !o.active || (o.maxpb > 0 && o.pbytes > o.maxpb) {
+				o.mset.isolateMu.RUnlock()
 				goto waitForMsgs
 			}
 		} else if o.waiting.isEmpty() {
 			// If we are in pull mode and no one is waiting already break and wait.
+			mset.isolateMu.RUnlock()
 			goto waitForMsgs
 		}
 
 		// Grab our next msg.
 		pmsg, dc, err = o.getNextMsg()
+		mset.isolateMu.RUnlock()
 
 		// We can release the lock now under getNextMsg so need to check this condition again here.
 		if o.closed || o.mset == nil {

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1452,7 +1452,7 @@ func (a *Account) EnableJetStream(limits map[string]JetStreamAccountLimits) erro
 						mset.accName(), mset.name(), seq, err)
 					break
 				}
-				mset.processJetStreamMsg(sm.subj, _EMPTY_, sm.hdr, sm.msg, 0, 0, nil, false)
+				mset.processJetStreamMsg(sm.subj, _EMPTY_, sm.hdr, sm.msg, 0, 0, nil, false, false)
 			}
 			store.Delete(true)
 		SKIP:

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -3598,6 +3598,10 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, _ *Account, subje
 	var svp StoreMsg
 	var sm *StoreMsg
 
+	// Ensure this read request is isolated and doesn't interleave with writes.
+	mset.isolateMu.RLock()
+	defer mset.isolateMu.RUnlock()
+
 	// If AsOfTime is set, perform this first to get the sequence.
 	var seq uint64
 	if req.StartTime != nil {

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -1272,7 +1272,7 @@ func TestJetStreamAtomicBatchPublishSingleServerRecovery(t *testing.T) {
 	require_True(t, commitReady)
 
 	// Simulate the first message of the batch is committed.
-	err = mset.processJetStreamMsg("foo", _EMPTY_, hdr1, nil, 0, 0, nil, false)
+	err = mset.processJetStreamMsg("foo", _EMPTY_, hdr1, nil, 0, 0, nil, false, false)
 	require_NoError(t, err)
 
 	// Simulate a hard kill, upon recovery the rest of the batch should be applied.

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1717,4 +1718,129 @@ func TestJetStreamAtomicBatchPublishContinuousBatchesStillMoveAppliedUp(t *testi
 	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
 		return checkState(t, c, globalAccountName, "TEST")
 	})
+}
+
+func TestJetStreamRollupIsolatedRead(t *testing.T) {
+	const (
+		DirectBatchGet = iota
+		DirectMultiGet
+		Consumer
+	)
+
+	test := func(t *testing.T, mode int) {
+		c := createJetStreamClusterExplicit(t, "R3S", 3)
+		defer c.shutdown()
+
+		nc, js := jsClientConnect(t, c.randomServer())
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:        "TEST",
+			Subjects:    []string{"foo.*"},
+			AllowRollup: true,
+			Replicas:    3,
+		})
+		require_NoError(t, err)
+
+		rs := c.randomNonStreamLeader(globalAccountName, "TEST")
+		mset, err := rs.globalAccount().lookupStream("TEST")
+		require_NoError(t, err)
+
+		// Reconnect to the selected server.
+		nc.Close()
+		nc, js = jsClientConnect(t, rs)
+		defer nc.Close()
+
+		m := nats.NewMsg("foo.0")
+		pubAck, err := js.PublishMsg(m)
+		require_NoError(t, err)
+		require_Equal(t, pubAck.Sequence, 1)
+
+		// mset.processJetStreamMsg will first store the new message, then update dedupe state, and then do the rollup.
+		// We block the replica such that it can store the new message but can't do the rollup yet.
+		// A read should wait for the rollup to complete.
+		mset.ddMu.Lock()
+		m.Subject = "foo.1"
+		m.Header.Set(JSMsgRollup, JSMsgRollupAll)
+		m.Header.Set(JSMsgId, "msgId")
+		_, _ = js.PublishMsg(m)
+		err = checkForErr(2*time.Second, 200*time.Millisecond, func() error {
+			var state StreamState
+			mset.store.FastState(&state)
+			if state.LastSeq != 2 {
+				return fmt.Errorf("expected last seq 2, got: %d", state.LastSeq)
+			}
+			return nil
+		})
+		if err != nil {
+			mset.ddMu.Unlock()
+			require_NoError(t, err)
+		}
+
+		// We're now subscribing and going to do a request, while the write is still halfway.
+		sub, err := nc.SubscribeSync("reply")
+		if err != nil {
+			mset.ddMu.Unlock()
+			require_NoError(t, err)
+		}
+		defer sub.Drain()
+		if err = nc.Flush(); err != nil {
+			mset.ddMu.Unlock()
+			require_NoError(t, err)
+		}
+
+		// Run two goroutines, one will unblock the first write after a short sleep,
+		// the second will do the read/consumer request.
+		var (
+			ready   sync.WaitGroup
+			run     sync.WaitGroup
+			cleanup sync.WaitGroup
+		)
+		ready.Add(2)
+		run.Add(1)
+		cleanup.Add(1)
+		go func() {
+			ready.Done()
+			defer cleanup.Done()
+			run.Wait()
+			time.Sleep(250 * time.Millisecond)
+			mset.ddMu.Unlock()
+		}()
+		go func() {
+			ready.Done()
+			run.Wait()
+			switch mode {
+			case DirectBatchGet:
+				mset.getDirectRequest(&JSApiMsgGetRequest{NextFor: "foo.*", Batch: 2}, "reply")
+			case DirectMultiGet:
+				mset.getDirectRequest(&JSApiMsgGetRequest{MultiLastFor: []string{"foo.*"}, Batch: 2}, "reply")
+			case Consumer:
+				mset.addConsumer(&ConsumerConfig{DeliverSubject: "reply", Direct: true})
+			}
+		}()
+
+		// Wait for both to be ready, then run both of them.
+		ready.Wait()
+		run.Done()
+
+		msg, err := sub.NextMsg(time.Second)
+		// Make sure cleanup has happened before validating.
+		cleanup.Wait()
+		require_NoError(t, err)
+		if mode != Consumer {
+			require_Equal(t, msg.Header.Get(JSNumPending), "0")
+			require_Equal(t, msg.Header.Get(JSSequence), "2")
+		} else {
+			// $JS.ACK.<stream>.<consumer>.<delivered>.<sseq>.<cseq>.<tm>.<pending>
+			require_True(t, strings.HasPrefix(msg.Reply, jsAckPre))
+			tokens := strings.Split(msg.Reply, ".")
+			require_Len(t, len(tokens), 9)
+			require_Equal(t, tokens[8], "0") // pending
+			require_Equal(t, tokens[5], "2") // sseq
+		}
+	}
+
+	t.Run("BatchGet", func(t *testing.T) { test(t, DirectBatchGet) })
+	t.Run("MultiGet", func(t *testing.T) { test(t, DirectMultiGet) })
+	t.Run("Consumer", func(t *testing.T) { test(t, Consumer) })
 }

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3043,6 +3043,10 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 					continue
 				}
 
+				// Ensure the whole batch is fully isolated, and reads
+				// can only happen after the full batch is committed.
+				mset.isolateMu.Lock()
+
 				// Process any entries that are part of this batch but prior to the current one.
 				for j, bce := range batch.entries {
 					if j == 0 {
@@ -3055,10 +3059,12 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 					for _, entry := range entries {
 						_, _, op, buf, err = decodeBatchMsg(entry.Data[1:])
 						if err != nil {
+							mset.isolateMu.Unlock()
 							batch.mu.Unlock()
 							panic(err.Error())
 						}
-						if err = js.applyStreamMsgOp(mset, op, buf, isRecovering); err != nil {
+						if err = js.applyStreamMsgOp(mset, op, buf, isRecovering, false); err != nil {
+							mset.isolateMu.Unlock()
 							batch.mu.Unlock()
 							// Make sure to return remaining entries to the pool on an error.
 							for _, nce := range batch.entries[j:] {
@@ -3081,15 +3087,18 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				for _, entry := range entries {
 					_, _, op, buf, err = decodeBatchMsg(entry.Data[1:])
 					if err != nil {
+						mset.isolateMu.Unlock()
 						batch.mu.Unlock()
 						panic(err.Error())
 					}
-					if err = js.applyStreamMsgOp(mset, op, buf, isRecovering); err != nil {
+					if err = js.applyStreamMsgOp(mset, op, buf, isRecovering, false); err != nil {
+						mset.isolateMu.Unlock()
 						batch.mu.Unlock()
 						return 0, err
 					}
 				}
 				// Clear state, batch was successful.
+				mset.isolateMu.Unlock()
 				batch.clearBatchStateLocked()
 				batch.mu.Unlock()
 				continue
@@ -3101,7 +3110,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 			switch op {
 			case streamMsgOp, compressedStreamMsgOp:
 				mbuf := buf[1:]
-				if err := js.applyStreamMsgOp(mset, op, mbuf, isRecovering); err != nil {
+				if err := js.applyStreamMsgOp(mset, op, mbuf, isRecovering, true); err != nil {
 					return 0, err
 				}
 
@@ -3284,7 +3293,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 	return 0, nil
 }
 
-func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isRecovering bool) error {
+func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isRecovering bool, needIsolation bool) error {
 	s := js.srv
 
 	if op == compressedStreamMsgOp {
@@ -3352,7 +3361,7 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 		mt = mset.getAndDeleteMsgTrace(lseq)
 	}
 	// Process the actual message here.
-	err = mset.processJetStreamMsg(subject, reply, hdr, msg, lseq, ts, mt, sourced)
+	err = mset.processJetStreamMsg(subject, reply, hdr, msg, lseq, ts, mt, sourced, needIsolation)
 
 	// If we have inflight make sure to clear after processing.
 	// TODO(dlc) - technically check on inflight != nil could cause datarace.
@@ -3419,7 +3428,7 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 			if state.Msgs == 0 {
 				mset.store.Compact(lseq + 1)
 				// Retry
-				err = mset.processJetStreamMsg(subject, reply, hdr, msg, lseq, ts, mt, sourced)
+				err = mset.processJetStreamMsg(subject, reply, hdr, msg, lseq, ts, mt, sourced, needIsolation)
 			}
 			// FIXME(dlc) - We could just run a catchup with a request defining the span between what we expected
 			// and what we got.
@@ -8273,7 +8282,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	// We also invoke this in clustering mode for message tracing when not
 	// performing message delivery.
 	if node == nil || mt.traceOnly() {
-		return mset.processJetStreamMsg(subject, reply, hdr, msg, 0, 0, mt, sourced)
+		return mset.processJetStreamMsg(subject, reply, hdr, msg, 0, 0, mt, sourced, true)
 	}
 
 	// If message tracing (with message delivery), we will need to send the

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -4308,7 +4308,7 @@ func TestJetStreamClusterDontInstallSnapshotWhenStoppingStream(t *testing.T) {
 	validateStreamState(snap)
 
 	// Simulate a message being stored, but not calling Applied yet.
-	err = mset.processJetStreamMsg("foo", _EMPTY_, nil, nil, 1, time.Now().UnixNano(), nil, false)
+	err = mset.processJetStreamMsg("foo", _EMPTY_, nil, nil, 1, time.Now().UnixNano(), nil, false, true)
 	require_NoError(t, err)
 
 	// Simulate the stream being stopped before we're able to call Applied.

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -16854,9 +16854,11 @@ func TestJetStreamDirectGetBatch(t *testing.T) {
 				require_Equal(t, expected[i], msg.Header.Get(JSSubject))
 				// Should have Data field non-zero
 				require_True(t, len(msg.Data) > 0)
-				// Check we have NumPending and its correct.
+				// Check we have NumPending and it's correct.
+				if np > 0 {
+					np--
+				}
 				require_Equal(t, strconv.Itoa(np), msg.Header.Get(JSNumPending))
-				np--
 
 			} else {
 				// Check for properly formatted EOB marker.
@@ -16866,7 +16868,7 @@ func TestJetStreamDirectGetBatch(t *testing.T) {
 				require_Equal(t, msg.Header.Get("Status"), "204")
 				// Check description is EOB
 				require_Equal(t, msg.Header.Get("Description"), "EOB")
-				// Check we have NumPending and its correct.
+				// Check we have NumPending and it's correct.
 				require_Equal(t, strconv.Itoa(np), msg.Header.Get(JSNumPending))
 			}
 		}
@@ -17244,11 +17246,11 @@ func TestJetStreamDirectGetMulti(t *testing.T) {
 						require_Equal(t, strconv.Itoa(expected[i].seq), msg.Header.Get(JSSequence))
 						// Should have Data field non-zero
 						require_True(t, len(msg.Data) > 0)
-						// Check we have NumPending and its correct.
-						require_Equal(t, strconv.Itoa(np), msg.Header.Get(JSNumPending))
+						// Check we have NumPending and it's correct.
 						if np > 0 {
 							np--
 						}
+						require_Equal(t, strconv.Itoa(np), msg.Header.Get(JSNumPending))
 					} else {
 						// Check for properly formatted EOB marker.
 						// Should have no body.
@@ -17257,17 +17259,17 @@ func TestJetStreamDirectGetMulti(t *testing.T) {
 						require_Equal(t, msg.Header.Get("Status"), "204")
 						// Check description is EOB
 						require_Equal(t, msg.Header.Get("Description"), "EOB")
-						// Check we have NumPending and its correct.
+						// Check we have NumPending and it's correct.
 						require_Equal(t, strconv.Itoa(np), msg.Header.Get(JSNumPending))
 					}
 				}
 			}
 
 			sub := sendRequest(&JSApiMsgGetRequest{MultiLastFor: []string{"foo.*"}})
-			checkResponses(sub, 2, p{"foo.foo", 97}, p{"foo.bar", 98}, p{"foo.baz", 99}, eob)
+			checkResponses(sub, 3, p{"foo.foo", 97}, p{"foo.bar", 98}, p{"foo.baz", 99}, eob)
 			// Check with UpToSeq
 			sub = sendRequest(&JSApiMsgGetRequest{MultiLastFor: []string{"foo.*"}, UpToSeq: 3})
-			checkResponses(sub, 2, p{"foo.foo", 1}, p{"foo.bar", 2}, p{"foo.baz", 3}, eob)
+			checkResponses(sub, 3, p{"foo.foo", 1}, p{"foo.bar", 2}, p{"foo.baz", 3}, eob)
 
 			// Test No Results.
 			sub = sendRequest(&JSApiMsgGetRequest{MultiLastFor: []string{"bar.*"}})
@@ -17453,7 +17455,7 @@ func TestJetStreamDirectGetMultiPaging(t *testing.T) {
 	}
 
 	// Setup variables that control procesPartial
-	start, seq, np, b, bsz := 1, 1, sent-1, 0, 128
+	start, seq, np, b, bsz := 1, 1, sent, 0, 128
 
 	processPartial := func(expected int) {
 		t.Helper()
@@ -17466,11 +17468,11 @@ func TestJetStreamDirectGetMultiPaging(t *testing.T) {
 			require_NoError(t, err)
 			// Make sure sequence is correct.
 			require_Equal(t, strconv.Itoa(int(seq)), msg.Header.Get(JSSequence))
-			// Check we have NumPending and its correct.
-			require_Equal(t, strconv.Itoa(int(np)), msg.Header.Get(JSNumPending))
+			// Check we have NumPending and it's correct.
 			if np > 0 {
 				np--
 			}
+			require_Equal(t, strconv.Itoa(np), msg.Header.Get(JSNumPending))
 		}
 		// Now check EOB
 		msg, err := sub.NextMsg(10 * time.Millisecond)
@@ -17479,11 +17481,11 @@ func TestJetStreamDirectGetMultiPaging(t *testing.T) {
 		require_Equal(t, msg.Header.Get("Status"), "204")
 		// Check description is EOB
 		require_Equal(t, msg.Header.Get("Description"), "EOB")
-		// Check we have NumPending and its correct.
+		// Check we have NumPending and it's correct.
 		require_Equal(t, strconv.Itoa(np), msg.Header.Get(JSNumPending))
-		// Check we have LastSequence and its correct.
+		// Check we have LastSequence and it's correct.
 		require_Equal(t, strconv.Itoa(seq-1), msg.Header.Get(JSLastSequence))
-		// Check we have UpToSequence and its correct.
+		// Check we have UpToSequence and it's correct.
 		require_Equal(t, strconv.Itoa(sent), msg.Header.Get(JSUpToSequence))
 		// Update start
 		start = seq
@@ -17496,7 +17498,7 @@ func TestJetStreamDirectGetMultiPaging(t *testing.T) {
 	processPartial(116 + 1)
 
 	// Now reset and test that batch is honored as well.
-	start, seq, np, b = 1, 1, sent-1, 100
+	start, seq, np, b = 1, 1, sent, 100
 	for i := 0; i < 5; i++ {
 		processPartial(b + 1) // 100 + EOB
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -2771,7 +2771,7 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 			err = node.Propose(encodeStreamMsg(m.subj, _EMPTY_, m.hdr, m.msg, sseq-1, ts, true))
 		}
 	} else {
-		err = mset.processJetStreamMsg(m.subj, _EMPTY_, m.hdr, m.msg, sseq-1, ts, nil, true)
+		err = mset.processJetStreamMsg(m.subj, _EMPTY_, m.hdr, m.msg, sseq-1, ts, nil, true, true)
 	}
 	if err != nil {
 		if strings.Contains(err.Error(), "no space left") {
@@ -3742,7 +3742,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 	if node != nil {
 		err = mset.processClusteredInboundMsg(m.subj, _EMPTY_, hdr, msg, nil, true)
 	} else {
-		err = mset.processJetStreamMsg(m.subj, _EMPTY_, hdr, msg, 0, 0, nil, true)
+		err = mset.processJetStreamMsg(m.subj, _EMPTY_, hdr, msg, 0, 0, nil, true, true)
 	}
 
 	if err != nil {
@@ -4393,7 +4393,7 @@ func (mset *stream) setupStore(fsCfg *FileStoreConfig) error {
 				mset.processClusteredInboundMsg(im.subj, im.rply, im.hdr, im.msg, im.mt, false)
 			}
 		} else {
-			mset.processJetStreamMsg(im.subj, im.rply, im.hdr, im.msg, 0, 0, im.mt, false)
+			mset.processJetStreamMsg(im.subj, im.rply, im.hdr, im.msg, 0, 0, im.mt, false, true)
 		}
 	})
 	mset.mu.Unlock()
@@ -5132,7 +5132,7 @@ var (
 )
 
 // processJetStreamMsg is where we try to actually process the stream msg.
-func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, lseq uint64, ts int64, mt *msgTrace, sourced bool) (retErr error) {
+func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, lseq uint64, ts int64, mt *msgTrace, sourced bool, needIsolation bool) (retErr error) {
 	if mt != nil {
 		// Only the leader/standalone will have mt!=nil. On exit, send the
 		// message trace event.
@@ -5145,9 +5145,12 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		return errStreamClosed
 	}
 
-	// Hold isolation lock while storing message, and potentially purging as part of a rollup.
-	mset.isolateMu.Lock()
-	defer mset.isolateMu.Unlock()
+	// Hold isolation lock while storing the message, and potentially purging as part of a rollup.
+	// If we're writing an atomic batch of multiple messages, the isolation lock is already held.
+	if needIsolation {
+		mset.isolateMu.Lock()
+		defer mset.isolateMu.Unlock()
+	}
 
 	mset.mu.Lock()
 	s, store := mset.srv, mset.store
@@ -6214,6 +6217,11 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 
 	// Commit batch.
 	if !isClustered {
+		mset.clMu.Unlock()
+
+		// Ensure the whole batch is fully isolated, and reads
+		// can only happen after the full batch is committed.
+		mset.isolateMu.Lock()
 		for seq := uint64(1); seq <= batchSeq; seq++ {
 			if seq == batchSeq && b.store.Type() != FileStorage {
 				bsubj, bhdr, bmsg = subject, hdr, msg
@@ -6229,8 +6237,9 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 			if seq == batchSeq {
 				_reply = reply
 			}
-			mset.processJetStreamMsg(bsubj, _reply, bhdr, bmsg, 0, 0, mt, false)
+			mset.processJetStreamMsg(bsubj, _reply, bhdr, bmsg, 0, 0, mt, false, false)
 		}
+		mset.isolateMu.Unlock()
 	} else {
 		// Do a single multi proposal. This ensures we get to push all entries to the proposal queue in-order
 		// and not interleaved with other proposals.
@@ -6248,8 +6257,8 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 			lerr := fmt.Errorf("JetStream stream '%s > %s' has high message lag", jsa.acc().Name, name)
 			s.RateLimitWarnf("%s", lerr.Error())
 		}
+		mset.clMu.Unlock()
 	}
-	mset.clMu.Unlock()
 	b.cleanupLocked(batchId, batches)
 	batches.mu.Unlock()
 	return nil
@@ -6557,7 +6566,7 @@ func (mset *stream) internalLoop() {
 				} else if isClustered {
 					mset.processClusteredInboundMsg(im.subj, im.rply, im.hdr, im.msg, im.mt, false)
 				} else {
-					mset.processJetStreamMsg(im.subj, im.rply, im.hdr, im.msg, 0, 0, im.mt, false)
+					mset.processJetStreamMsg(im.subj, im.rply, im.hdr, im.msg, 0, 0, im.mt, false, true)
 				}
 				im.returnToPool()
 			}

--- a/server/stream.go
+++ b/server/stream.go
@@ -323,6 +323,8 @@ type stream struct {
 	client *client      // The internal JetStream client.
 	sysc   *client      // The internal JetStream system client.
 
+	isolateMu sync.RWMutex // Read/write isolation lock for the stream. Used to guarantee atomic reads.
+
 	// The current last subscription ID for the subscriptions through `client`.
 	// Those subscriptions are for the subjects filters being listened to and captured by the stream.
 	sid atomic.Uint64
@@ -4857,11 +4859,14 @@ func (mset *stream) getDirectMulti(req *JSApiMsgGetRequest, reply string) {
 	// TODO(dlc) - Make configurable?
 	const maxAllowedResponses = 1024
 
-	// We hold the lock here to try to avoid changes out from underneath of us.
-	mset.mu.RLock()
-	defer mset.mu.RUnlock()
+	// We hold the lock here to avoid changes out from underneath of us.
+	mset.isolateMu.RLock()
+	defer mset.isolateMu.RUnlock()
+
 	// Grab store and name.
+	mset.mu.RLock()
 	store, name, s := mset.store, mset.cfg.Name, mset.srv
+	mset.mu.RUnlock()
 
 	// Grab MaxBytes
 	mb := req.MaxBytes
@@ -4909,7 +4914,7 @@ func (mset *stream) getDirectMulti(req *JSApiMsgGetRequest, reply string) {
 		return
 	}
 
-	np, lseq, sentBytes, sent := uint64(len(seqs)-1), uint64(0), 0, 0
+	np, lseq, sentBytes, sent := uint64(len(seqs)), uint64(0), 0, 0
 	for _, seq := range seqs {
 		if seq < req.Seq {
 			if np > 0 {
@@ -4928,6 +4933,10 @@ func (mset *stream) getDirectMulti(req *JSApiMsgGetRequest, reply string) {
 		hdr := sm.hdr
 		ts := time.Unix(0, sm.ts).UTC()
 
+		// Decrement num pending. This is optimization and we do not continue to look it up for these operations.
+		if np > 0 {
+			np--
+		}
 		if len(hdr) == 0 {
 			hdr = fmt.Appendf(nil, dgb, name, sm.subj, sm.seq, ts.Format(time.RFC3339Nano), np, lseq)
 		} else {
@@ -4938,10 +4947,6 @@ func (mset *stream) getDirectMulti(req *JSApiMsgGetRequest, reply string) {
 			hdr = genHeader(hdr, JSTimeStamp, ts.Format(time.RFC3339Nano))
 			hdr = genHeader(hdr, JSNumPending, strconv.FormatUint(np, 10))
 			hdr = genHeader(hdr, JSLastSequence, strconv.FormatUint(lseq, 10))
-		}
-		// Decrement num pending. This is optimization and we do not continue to look it up for these operations.
-		if np > 0 {
-			np--
 		}
 		// Track our lseq
 		lseq = sm.seq
@@ -4975,6 +4980,10 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 	mset.mu.RLock()
 	store, name, s := mset.store, mset.cfg.Name, mset.srv
 	mset.mu.RUnlock()
+
+	// Ensure this read request is isolated and doesn't interleave with writes.
+	mset.isolateMu.RLock()
+	defer mset.isolateMu.RUnlock()
 
 	var seq uint64
 	// Lookup start seq if AsOfTime is set.
@@ -5045,6 +5054,10 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 		if !req.NoHeaders {
 			hdr = sm.hdr
 			if isBatchRequest {
+				// Decrement num pending. This is optimization and we do not continue to look it up for these operations.
+				if np > 0 {
+					np--
+				}
 				if len(hdr) == 0 {
 					hdr = fmt.Appendf(nil, dgb, name, sm.subj, sm.seq, ts.Format(time.RFC3339Nano), np, lseq)
 				} else {
@@ -5056,8 +5069,6 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 					hdr = genHeader(hdr, JSNumPending, strconv.FormatUint(np, 10))
 					hdr = genHeader(hdr, JSLastSequence, strconv.FormatUint(lseq, 10))
 				}
-				// Decrement num pending. This is optimization and we do not continue to look it up for these operations.
-				np--
 			} else {
 				if len(hdr) == 0 {
 					hdr = fmt.Appendf(nil, dg, name, sm.subj, sm.seq, ts.Format(time.RFC3339Nano))
@@ -5133,6 +5144,10 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 	if mset.closed.Load() {
 		return errStreamClosed
 	}
+
+	// Hold isolation lock while storing message, and potentially purging as part of a rollup.
+	mset.isolateMu.Lock()
+	defer mset.isolateMu.Unlock()
 
 	mset.mu.Lock()
 	s, store := mset.srv, mset.store


### PR DESCRIPTION
A new `mset.isolateMu` lock has been introduced that's held while applying a batch, any reads through message get requests or consumers need to wait for this lock to be released. This ensures a batch writing N messages will be atomically observed by any reads, instead of them observing only part of the batch.

This PR also resolves an issue with rollups as the `mset.mu` lock was previously used for that, and `processJetStreamMsg` lets go of the `mset.mu` to then re-acquire it to perform the rollup. This allowed for an inconsistent/non-isolated read when rollups are used, where the new message could be observed but the rollup was not applied yet. This would probably be less of an obvious issue than reading only part of a batch with the new atomic batch support though.

This PR also resolves off-by-one inconsistencies in the num pending count that was returned as part of direct batch get and direct multi get. The num pending that's reported using those reads now matches exactly what would have been reported if a consumer was used instead.

Resolves https://github.com/nats-io/nats-server/issues/7128

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>