### PR TITLE
[FIXED] Correct Nats-TTL header if SDM TTL overrides it

### DIFF
--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -5837,8 +5837,9 @@ func TestJetStreamClusterSubjectDeleteMarkersMinimumTTL(t *testing.T) {
 
 				// After the TTL expires it should still be there, because SubjectDeleteMarkerTTL is the minimum.
 				time.Sleep(1500 * time.Millisecond)
-				_, err = js.GetMsg("TEST", 1)
+				rsm, err := js.GetMsg("TEST", 1)
 				require_NoError(t, err)
+				require_Equal(t, rsm.Header.Get(JSMessageTTL), "3") // 3s from the SDM TTL.
 
 				// Need to wait for the subject delete marker to be placed.
 				time.Sleep(2 * time.Second)

--- a/server/stream.go
+++ b/server/stream.go
@@ -5726,6 +5726,8 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 	if ttl > 0 && mset.cfg.SubjectDeleteMarkerTTL > 0 && mset.cfg.MaxMsgsPer != 1 {
 		if minTtl := int64(mset.cfg.SubjectDeleteMarkerTTL.Seconds()); ttl < minTtl {
 			ttl = minTtl
+			hdr = removeHeaderIfPresent(hdr, JSMessageTTL)
+			hdr = genHeader(hdr, JSMessageTTL, strconv.FormatInt(ttl, 10))
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a bug where the `Nats-TTL` header would not be corrected if the TTL got changed based on the `SubjectDeleteMarkerTTL` and `MaxMsgsPer`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>