### PR TITLE
(2.12) Elastic pointers in the filestore write-through cache

### DIFF
--- a/server/elastic/elastic.go
+++ b/server/elastic/elastic.go
@@ -1,0 +1,60 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elastic
+
+import (
+	"weak"
+)
+
+func Make[T any](ptr *T) *Pointer[T] {
+	return &Pointer[T]{
+		weak: weak.Make(ptr),
+	}
+}
+
+type Pointer[T any] struct {
+	weak   weak.Pointer[T]
+	strong *T
+}
+
+func (e *Pointer[T]) Set(ptr *T) {
+	e.weak = weak.Make(ptr)
+	if e.strong != nil {
+		e.strong = ptr
+	}
+}
+
+func (e *Pointer[T]) Strengthen() {
+	if e == nil || e.strong != nil {
+		return
+	}
+	e.strong = e.weak.Value()
+}
+
+func (e *Pointer[T]) Weaken() {
+	if e == nil || e.strong == nil {
+		return
+	}
+	e.strong = nil
+}
+
+func (e *Pointer[T]) Value() *T {
+	if e == nil {
+		return nil
+	}
+	if e.strong != nil {
+		return e.strong
+	}
+	return e.weak.Value()
+}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -7005,7 +7005,7 @@ func TestFileStoreFSSExpire(t *testing.T) {
 	mb := fs.blks[0]
 	fs.mu.RUnlock()
 	mb.mu.RLock()
-	cache, fss := mb.cache, mb.fss
+	cache, fss := mb.ecache.Value(), mb.fss
 	mb.mu.RUnlock()
 	require_True(t, fss != nil)
 	require_True(t, cache != nil)


### PR DESCRIPTION
This PR modifies the write-through cache in the filestore to use elastic pointers. Elastic pointers are weak by default and can be reclaimed by the GC under pressure, but can be strengthened when there are pending writes for a block. Once the flush has completed, we weaken the cache again.

There are now two cache references within each `msgBlock`:

- `mb.ecache`: The elastic pointer, populated when the cache is set up and only reset back to `nil` either by the GC or when `clearCache` is called
- `mb.cache`: Left as `nil` by default, populated with a strong reference from `mb.ecache` when we need to use the cache, and then reset back to `nil` after we're done with it

This PR replaces and therefore closes #7097.

Signed-off-by: Neil Twigg <neil@nats.io>