### PR TITLE
Fix url encoding for ocsp requests

### DIFF
--- a/server/certidp/ocsp_responder_test.go
+++ b/server/certidp/ocsp_responder_test.go
@@ -1,0 +1,29 @@
+package certidp
+
+import (
+	"encoding/base64"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestEncodeOCSPRequest(t *testing.T) {
+	data := []byte("test data for OCSP request")
+	encoded := encodeOCSPRequest(data)
+
+	if strings.ContainsAny(encoded, "+/=") {
+		t.Errorf("URL contains unescaped characters: %s", encoded)
+	}
+
+	decodedURL, err := url.QueryUnescape(encoded)
+	if err != nil {
+		t.Errorf("failed to url-decode request: %v", err)
+	}
+	decodedData, err := base64.StdEncoding.DecodeString(decodedURL)
+	if err != nil {
+		t.Errorf("failed to base64-decode request: %v", err)
+	}
+	if string(decodedData) != string(data) {
+		t.Errorf("Decoded data does not match original: got %s, want %s", decodedData, data)
+	}
+}


### PR DESCRIPTION
Like described in issue #7183 , this PR adds the encoding to the base64 encoded certificates.

Resolves #7183 

Signed-off-by: Alexander Zerbe <alex@aqube.de>
