### PR TITLE
Remove regression note on TestAccountMaxConnectionsDisconnectsNewestFirst

### DIFF
--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -3537,7 +3537,6 @@ func TestAccountLimitsServerConfig(t *testing.T) {
 	require_Error(t, err)
 }
 
-// Regression test for issue introduced in: https://github.com/nats-io/nats-server/pull/5757
 // Connections being closed should be the newer ones in case of JWT limits.
 func TestAccountMaxConnectionsDisconnectsNewestFirst(t *testing.T) {
 	cf := createConfFile(t, []byte(`


### PR DESCRIPTION
https://github.com/nats-io/nats-server/pull/7181 mentioned https://github.com/nats-io/nats-server/pull/5757 introduced a regression as observed by `TestAccountMaxConnectionsDisconnectsNewestFirst`.

However, that bug has been in there since 2.9.0 or earlier, so it can't be attributed to that PR. Both tests are failing all the way to that version. `TestAccountUpdateRemoteServerDisconnectsNewestFirst` was actually fixed since https://github.com/nats-io/nats-server/pull/5757.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>