### PR TITLE
(2.12) Add `"leader_since"` to stream and consumer info response

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8824,9 +8824,10 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 
 	n := rg.node
 	ci := &ClusterInfo{
-		Name:      s.cachedClusterName(),
-		Leader:    s.serverNameForNode(n.GroupLeader()),
-		RaftGroup: rg.Name,
+		Name:        s.cachedClusterName(),
+		Leader:      s.serverNameForNode(n.GroupLeader()),
+		LeaderSince: n.LeaderSince(),
+		RaftGroup:   rg.Name,
 	}
 
 	now := time.Now()

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -5795,6 +5795,7 @@ func TestJetStreamClusterParallelCreateRaftGroup(t *testing.T) {
 
 	// Do second half of Stop while goroutines are in createRaftGroup.
 	rn.leaderState.Store(false)
+	rn.leaderSince.Store(nil)
 	close(rn.quit)
 
 	// Wait for node and goroutines to stop.

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3959,6 +3959,7 @@ type RaftzGroup struct {
 	Applied       uint64                    `json:"applied"`
 	CatchingUp    bool                      `json:"catching_up,omitempty"`
 	Leader        string                    `json:"leader,omitempty"`
+	LeaderSince   *time.Time                `json:"leader_since,omitempty"`
 	EverHadLeader bool                      `json:"ever_had_leader"`
 	Term          uint64                    `json:"term"`
 	Vote          string                    `json:"voted_for,omitempty"`
@@ -4066,6 +4067,7 @@ func (s *Server) Raftz(opts *RaftzOptions) *RaftzStatus {
 			Applied:       n.applied,
 			CatchingUp:    n.catchup != nil,
 			Leader:        n.leader,
+			LeaderSince:   n.leaderSince.Load(),
 			EverHadLeader: n.pleader.Load(),
 			Term:          n.term,
 			Vote:          n.vote,

--- a/server/raft.go
+++ b/server/raft.go
@@ -48,6 +48,7 @@ type RaftNode interface {
 	Size() (entries, bytes uint64)
 	Progress() (index, commit, applied uint64)
 	Leader() bool
+	LeaderSince() *time.Time
 	Quorum() bool
 	Current() bool
 	Healthy() bool
@@ -145,10 +146,11 @@ type raft struct {
 	bytes uint64      // Total amount of bytes stored in the WAL. (Saves us from needing to call wal.FastState very often)
 	werr  error       // Last write error
 
-	state       atomic.Int32 // RaftState
-	leaderState atomic.Bool  // Is in (complete) leader state.
-	hh          hash.Hash64  // Highwayhash, used for snapshots
-	snapfile    string       // Snapshot filename
+	state       atomic.Int32              // RaftState
+	leaderState atomic.Bool               // Is in (complete) leader state.
+	leaderSince atomic.Pointer[time.Time] // How long since becoming leader.
+	hh          hash.Hash64               // Highwayhash, used for snapshots
+	snapfile    string                    // Snapshot filename
 
 	csz   int             // Cluster size
 	qn    int             // Number of nodes needed to establish quorum
@@ -1112,7 +1114,11 @@ func (n *raft) Applied(index uint64) (entries uint64, bytes uint64) {
 		// Quick sanity-check to confirm we're still leader.
 		// In which case we must signal, since switchToLeader would not have done so already.
 		if n.State() == Leader {
-			n.leaderState.Store(true)
+			if !n.leaderState.Swap(true) {
+				// Only update timestamp if leader state actually changed.
+				nowts := time.Now().UTC()
+				n.leaderSince.Store(&nowts)
+			}
 			n.updateLeadChange(true)
 		}
 	}
@@ -1417,6 +1423,15 @@ func (n *raft) Leader() bool {
 		return false
 	}
 	return n.leaderState.Load()
+}
+
+// LeaderSince returns how long we have been leader for,
+// if applicable.
+func (n *raft) LeaderSince() *time.Time {
+	if n == nil {
+		return nil
+	}
+	return n.leaderSince.Load()
 }
 
 // stepdown immediately steps down the Raft node to the
@@ -1834,6 +1849,7 @@ func (n *raft) shutdown() {
 	// to notify the runAs goroutines to stop what they're doing.
 	if n.state.Swap(int32(Closed)) != int32(Closed) {
 		n.leaderState.Store(false)
+		n.leaderSince.Store(nil)
 		close(n.quit)
 	}
 }
@@ -4446,6 +4462,7 @@ func (n *raft) switchToFollowerLocked(leader string) {
 
 	n.aflr = 0
 	n.leaderState.Store(false)
+	n.leaderSince.Store(nil)
 	n.lxfer = false
 	// Reset acks, we can't assume acks from a previous term are still valid in another term.
 	if len(n.acks) > 0 {
@@ -4512,7 +4529,11 @@ func (n *raft) switchToLeader() {
 			// We know we have applied all entries in our log and can signal immediately.
 			// For sanity reset applied floor back down to 0, so we aren't able to signal twice.
 			n.aflr = 0
-			n.leaderState.Store(true)
+			if !n.leaderState.Swap(true) {
+				// Only update timestamp if leader state actually changed.
+				nowts := time.Now().UTC()
+				n.leaderSince.Store(&nowts)
+			}
 			n.updateLeadChange(true)
 		}
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -237,10 +237,11 @@ type StreamAlternate struct {
 // ClusterInfo shows information about the underlying set of servers
 // that make up the stream or consumer.
 type ClusterInfo struct {
-	Name      string      `json:"name,omitempty"`
-	RaftGroup string      `json:"raft_group,omitempty"`
-	Leader    string      `json:"leader,omitempty"`
-	Replicas  []*PeerInfo `json:"replicas,omitempty"`
+	Name        string      `json:"name,omitempty"`
+	RaftGroup   string      `json:"raft_group,omitempty"`
+	Leader      string      `json:"leader,omitempty"`
+	LeaderSince *time.Time  `json:"leader_since,omitempty"`
+	Replicas    []*PeerInfo `json:"replicas,omitempty"`
 }
 
 // PeerInfo shows information about all the peers in the cluster that


### PR DESCRIPTION
This reports how long the leader believes it has been leader in stream & consumer info responses, as well as raftz.

Signed-off-by: Neil Twigg <neil@nats.io>