### PR TITLE
[FIXED] 'cluster_traffic: owner' is forgotten after restart

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3784,6 +3784,11 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 			// Absent reload of js server cfg, this is going to be broken until js is disabled
 			a.incomplete = true
 			a.mu.Unlock()
+		} else {
+			a.mu.Lock()
+			// Refresh reference, we've just enabled JetStream, so it would have been nil before.
+			ajs = a.js
+			a.mu.Unlock()
 		}
 	} else if a.jsLimits != nil {
 		// We do not have JS enabled for this server, but the account has it enabled so setup


### PR DESCRIPTION
`cluster_traffic: owner` can be used to have replication traffic go over the account "owning" the stream, versus this traffic going over the system account (`cluster_traffic: system`/default).

When pushing an updated JWT to all servers, all these servers would correctly update their `cluster_traffic` setting.

However, if a server was restarted it would "forget" `cluster_traffic: owner` was set, and revert back to `cluster_traffic: system`. This would put this single server to be unable to communicate with the remainder of the cluster. Restarting the rest of the cluster would have them also revert back to `cluster_traffic: system`, which would allow them to communicate again. But, without respecting the `cluster_traffic: owner` setting on the account.

This PR fixes that by ensuring `cluster_traffic` can be updated at the same time as that JetStream is enabled for that particular account upon startup.

Due to this issue, if a server with this fix is deployed, it will not be able to communicate with the other servers that had reverted back to `cluster_traffic: system`. A clean upgrade path for this would be:
- Temporarily update the account to have `cluster_traffic: system`. If all servers were restarted they were already on this setting. Any servers that were not yet restarted will now agree on this setting.
- Upgrade all servers to the new server version with this fix.
- Update the account to have `cluster_traffic: owner` again. It should now be remembered even after a server restart.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>