### PR TITLE
Report cluster traffic account in `jsz`

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8827,6 +8827,8 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 		Name:        s.cachedClusterName(),
 		Leader:      s.serverNameForNode(n.GroupLeader()),
 		LeaderSince: n.LeaderSince(),
+		SystemAcc:   n.IsSystemAccount(),
+		TrafficAcc:  n.GetTrafficAccountName(),
 		RaftGroup:   rg.Name,
 	}
 

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -5354,6 +5354,8 @@ func TestMonitorJsz(t *testing.T) {
 			if len(crgroup.RaftGroup) == 0 {
 				t.Fatal("expected consumer raft group info to be included")
 			}
+			require_True(t, si.Cluster.SystemAcc)
+			require_Equal(t, si.Cluster.TrafficAcc, "SYS")
 		}
 	})
 	t.Run("js-api-level", func(t *testing.T) {

--- a/server/raft.go
+++ b/server/raft.go
@@ -82,6 +82,7 @@ type RaftNode interface {
 	Delete()
 	RecreateInternalSubs() error
 	IsSystemAccount() bool
+	GetTrafficAccountName() string
 }
 
 type WAL interface {
@@ -601,6 +602,13 @@ func (n *raft) checkAccountNRGStatus() bool {
 // Whether we are using the system account or not.
 func (n *raft) IsSystemAccount() bool {
 	return n.isSysAcc.Load()
+}
+
+// GetTrafficAccountName returns the account name of the account used for replication traffic.
+func (n *raft) GetTrafficAccountName() string {
+	n.RLock()
+	defer n.RUnlock()
+	return n.acc.GetName()
 }
 
 func (n *raft) RecreateInternalSubs() error {

--- a/server/stream.go
+++ b/server/stream.go
@@ -241,6 +241,8 @@ type ClusterInfo struct {
 	RaftGroup   string      `json:"raft_group,omitempty"`
 	Leader      string      `json:"leader,omitempty"`
 	LeaderSince *time.Time  `json:"leader_since,omitempty"`
+	SystemAcc   bool        `json:"system_account,omitempty"`
+	TrafficAcc  string      `json:"traffic_account,omitempty"`
 	Replicas    []*PeerInfo `json:"replicas,omitempty"`
 }
 


### PR DESCRIPTION
Similar to https://github.com/nats-io/nats-server/pull/7186, but implementing it for `/jsz`. Due to it being added in `ClusterInfo`, this means a `nats stream info` will also include these details.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>