### PR TITLE
[FIXED] Route: Infinite retry cluster connection with invalid credentials

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -87,6 +87,17 @@ type route struct {
 	// Transient value used to set the Info.GossipMode when initiating
 	// an implicit route and sending to the remote.
 	gossipMode byte
+	// This will be set in case of pooling so that a route can trigger
+	// the creation of the next after receiving the first PONG, ensuring
+	// that authentication did not fail.
+	startNewRoute *routeInfo
+}
+
+// This contains the information required to create a new route.
+type routeInfo struct {
+	url        *url.URL
+	rtype      RouteType
+	gossipMode byte
 }
 
 // Do not change the values/order since they are exchanged between servers.
@@ -2380,20 +2391,18 @@ func (s *Server) addRoute(c *client, didSolicit, sendDelayedInfo bool, gossipMod
 		// Send the subscriptions interest.
 		s.sendSubsToRoute(c, idx, _EMPTY_)
 
-		// In pool mode, if we did not yet reach the cap, try to connect a new connection
+		// In pool mode, if we did not yet reach the cap, try to connect a new connection,
+		// but do so only after receiving the first PONG to our PING, which will ensure
+		// that we have proper authentication.
 		if pool && didSolicit && sz != effectivePoolSize {
-			s.startGoRoutine(func() {
-				select {
-				case <-time.After(time.Duration(rand.Intn(100)) * time.Millisecond):
-				case <-s.quitCh:
-					// Doing this here and not as a defer because connectToRoute is also
-					// calling s.grWG.Done() on exit, so we do this only if we don't
-					// invoke connectToRoute().
-					s.grWG.Done()
-					return
-				}
-				s.connectToRoute(url, rtype, true, gossipMode, _EMPTY_)
-			})
+			c.mu.Lock()
+			c.route.startNewRoute = &routeInfo{
+				url:        url,
+				rtype:      rtype,
+				gossipMode: gossipMode,
+			}
+			c.sendPing()
+			c.mu.Unlock()
 		}
 	}
 	s.mu.Unlock()


### PR DESCRIPTION
With route pooling, the server would create a connection to the remote and when receiving the INFO protocol, would start a new route if the amount of routes was below the effective pool size. But if the route failed due to authentication error, this would cause a rapid infinite attempt to recreate a route.

The approach here is to delay the creation of the new route after receiving the first PONG after sending a PING.

Resolves #7194

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>