### PR TITLE
[FIXED] Reject parallel clustered stream create

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -6495,9 +6495,10 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 	// Raft group selection and placement.
 	if rg == nil {
 		// Check inflight before proposing in case we have an existing inflight proposal.
-		if existing, ok := streams[cfg.Name]; ok {
-			// We have existing for same stream. Re-use same group and syncSubject.
-			rg, syncSubject = existing.rg, existing.sync
+		if _, ok = streams[cfg.Name]; ok {
+			resp.Error = NewJSStreamNameExistError()
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+			return
 		}
 	}
 	// Create a new one here if needed.


### PR DESCRIPTION
In addition to https://github.com/nats-io/nats-server/pull/7202, this PR adds short-term protection for parallel stream creation.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>