### PR TITLE
[FIXED] Reject parallel clustered stream create

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -75,6 +75,7 @@ type jetStreamCluster struct {
 type inflightInfo struct {
 	rg   *raftGroup
 	sync string
+	cfg  *StreamConfig
 }
 
 // Used to guide placement of streams and meta controllers in clustered JetStream.
@@ -6496,6 +6497,11 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 	if rg == nil {
 		// Check inflight before proposing in case we have an existing inflight proposal.
 		if existing, ok := streams[cfg.Name]; ok {
+			if !reflect.DeepEqual(existing.cfg, cfg) {
+				resp.Error = NewJSStreamNameExistError()
+				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+				return
+			}
 			// We have existing for same stream. Re-use same group and syncSubject.
 			rg, syncSubject = existing.rg, existing.sync
 		}
@@ -6523,7 +6529,7 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 		// on concurrent create requests while this stream assignment has
 		// possibly not been processed yet.
 		if streams, ok := cc.inflight[acc.Name]; ok && self == nil {
-			streams[cfg.Name] = &inflightInfo{rg, syncSubject}
+			streams[cfg.Name] = &inflightInfo{rg, syncSubject, cfg}
 		}
 	}
 }


### PR DESCRIPTION
In addition to https://github.com/nats-io/nats-server/pull/7202, this PR adds short-term protection for parallel stream creation if the to-be-created stream config doesn't equal what's inflight.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>