### PR TITLE
Add assert.Unreachable when losing commits

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -31,6 +31,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/nats-io/nats-server/v2/internal/fastrand"
 
 	"github.com/minio/highwayhash"
@@ -3352,6 +3353,14 @@ func (n *raft) truncateWAL(term, index uint64) {
 		} else {
 			n.debug("Clearing WAL state (no commits)")
 		}
+	}
+	if index < n.commit {
+		assert.Unreachable("WAL truncate lost commits", map[string]any{
+			"term":    term,
+			"index":   index,
+			"commit":  n.commit,
+			"applied": n.applied,
+		})
 	}
 
 	defer func() {


### PR DESCRIPTION
To support our testing in Antithesis, add an explicit assert when truncating data that was meant to be committed. Before we'd only be notified based on logging `Resetting WAL state`, but even if the WAL is not reset entirely losing just a single committed message already violates correctness.

This assert is purely added to make it easier to spot any issues in Antithesis, and given our effort in fixing replication bugs I don't expect this assert to fail. It will just be there being a more strict guard for safety.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>