### PR TITLE
Enhance JWT validation for scoped users

### DIFF
--- a/server/jwt.go
+++ b/server/jwt.go
@@ -80,7 +80,11 @@ func validateTrustedOperators(o *Options) error {
 		if err != nil {
 			return fmt.Errorf("default sentinel JWT not valid")
 		}
-		if !juc.BearerToken {
+
+		if !juc.BearerToken && juc.IssuerAccount != "" && juc.HasEmptyPermissions() {
+			// we cannot resolve the account yet - but this looks like a scoped user
+			// it will be rejected at runtime if not valid
+		} else if !juc.BearerToken {
 			return fmt.Errorf("default sentinel must be a bearer token")
 		}
 	}


### PR DESCRIPTION
Updated logic to allow scoped users with `IssuerAccount` and empty permissions to bypass immediate validation, with runtime rejection if invalid.

Fix #7137

Signed-off-by: Your Name alberto@synadia.io
