### PR TITLE
Fix TestServerEventsConnectDisconnectForGlobalAcc flaking 

### DIFF
--- a/server/events_test.go
+++ b/server/events_test.go
@@ -3882,10 +3882,13 @@ func TestServerEventsConnectDisconnectForGlobalAcc(t *testing.T) {
 	require_NoError(t, err)
 	defer ncs.Close()
 
-	s1, err := ncs.SubscribeSync(fmt.Sprintf(connectEventSubj, "*"))
+	s1, err := ncs.SubscribeSync(fmt.Sprintf(connectEventSubj, globalAccountName))
 	require_NoError(t, err)
-	s2, err := ncs.SubscribeSync(fmt.Sprintf(disconnectEventSubj, "*"))
+	s2, err := ncs.SubscribeSync(fmt.Sprintf(disconnectEventSubj, globalAccountName))
 	require_NoError(t, err)
+
+	// Flush to make sure subscriptions are established
+	require_NoError(t, ncs.Flush())
 
 	// Connect to global account
 	ncg, err := nats.Connect(url, nats.UserInfo("", ""))

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -3213,7 +3213,7 @@ func TestJetStreamClusterConsumerReplicasAfterScale(t *testing.T) {
 				return fmt.Errorf("cluster nil")
 			}
 			if len(ci.Cluster.Replicas) != clr {
-				return fmt.Errorf("cluster replicas %d != %d", len(ci.Cluster.Replicas), cor)
+				return fmt.Errorf("cluster replica peers %d != %d", len(ci.Cluster.Replicas), clr)
 			}
 			return nil
 		})


### PR DESCRIPTION
Also fix reported error from `TestJetStreamClusterConsumerReplicasAfterScale`

Signed-off-by: Waldemar Quevedo <wally@nats.io>
