### PR TITLE
[FIXED] Empty placement triggers move request

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7167,7 +7167,7 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 			// try to pick one. This could happen with older streams that were assigned by
 			// previous servers.
 			if rg.Cluster == _EMPTY_ {
-				// Prefer placement directrives if we have them.
+				// Prefer placement directives if we have them.
 				if newCfg.Placement != nil && newCfg.Placement.Cluster != _EMPTY_ {
 					rg.Cluster = newCfg.Placement.Cluster
 				} else {

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -10796,6 +10796,40 @@ func TestJetStreamClusterConsumerMonitorShutdownWithoutRaftNode(t *testing.T) {
 	})
 }
 
+func TestJetStreamClusterUnsetEmptyPlacement(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Placement: &nats.Placement{},
+	}
+	si, err := js.AddStream(cfg)
+	require_NoError(t, err)
+	require_True(t, si.Config.Placement == nil)
+
+	si, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+	require_True(t, si.Config.Placement == nil)
+
+	// Set a placement level
+	cfg.Placement = &nats.Placement{Cluster: "R3S"}
+	si, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+	require_True(t, si.Config.Placement != nil)
+	require_Equal(t, si.Config.Placement.Cluster, "R3S")
+
+	// And ensure it can be reset.
+	cfg.Placement = &nats.Placement{}
+	si, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+	require_True(t, si.Config.Placement == nil)
+}
+
 //
 // DO NOT ADD NEW TESTS IN THIS FILE (unless to balance test times)
 // Add at the end of jetstream_cluster_<n>_test.go, with <n> being the highest value.

--- a/server/stream.go
+++ b/server/stream.go
@@ -1940,6 +1940,10 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 		}
 	}
 
+	// Remove placement if it's an empty object.
+	if cfg.Placement != nil && reflect.DeepEqual(cfg.Placement, &Placement{}) {
+		cfg.Placement = nil
+	}
 	// For now don't allow preferred server in placement.
 	if cfg.Placement != nil && cfg.Placement.Preferred != _EMPTY_ {
 		return StreamConfig{}, NewJSStreamInvalidConfigError(fmt.Errorf("preferred server not permitted in placement"))


### PR DESCRIPTION
If a stream was created with `Placement: nil`, but a stream update was performed with `Placement: {}` (empty) then it would trigger a move request. An empty placement object should not be used to trigger a move request, since no (different) placement is specified.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>