### PR TITLE
(2.12) Add trace logging for msg delivery

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -305,7 +305,7 @@ type Options struct {
 	Debug           bool   `json:"-"`
 	TraceVerbose    bool   `json:"-"`
 
-	// TraceHeaders if true will only trace message headers, not the payload
+	// TraceHeaders if true will only trace message headers, not the payload.
 	TraceHeaders               bool          `json:"-"`
 	NoLog                      bool          `json:"-"`
 	NoSigs                     bool          `json:"-"`


### PR DESCRIPTION
Enables showing the headers and/or payload of the message that was routed across multiple hops then delivered (`->>`).

```
cid:5 - <<- [HPUB _INBOX.d3lXYRzwIiKASPZQIMYov4.639bgwnJ 24 33]
cid:5 - <<- MSG_PAYLOAD: ["NATS/1.0\r\nA: 1\r\nB: 2"]
cid:6 - ->> [HMSG _INBOX.d3lXYRzwIiKASPZQIMYov4.639bgwnJ 1 24 33]
cid:6 - ->> MSG_PAYLOAD: ["NATS/1.0\r\nA: 1\r\nB: 2"]
```

Signed-off-by: Waldemar Quevedo <wally@nats.io>
