### PR TITLE
Add log_connection_auth option to toggle logging usernames

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -308,6 +308,7 @@ type Options struct {
 	// TraceHeaders if true will only trace message headers, not the payload
 	TraceHeaders               bool          `json:"-"`
 	LogConnectionInfo          bool          `json:"-"`
+	LogConnectionAuthInfo      bool          `json:"-"`
 	NoLog                      bool          `json:"-"`
 	NoSigs                     bool          `json:"-"`
 	NoSublistCache             bool          `json:"-"`
@@ -1053,6 +1054,9 @@ func (o *Options) processConfigFileLine(k string, v any, errors *[]error, warnin
 	case "log_connection_info":
 		o.LogConnectionInfo = v.(bool)
 		trackExplicitVal(&o.inConfig, "LogConnectionInfo", o.LogConnectionInfo)
+	case "log_connection_auth":
+		o.LogConnectionAuthInfo = v.(bool)
+		trackExplicitVal(&o.inConfig, "LogConnectionAuthInfo", o.LogConnectionAuthInfo)
 	case "logtime":
 		o.Logtime = v.(bool)
 		trackExplicitVal(&o.inConfig, "Logtime", o.Logtime)


### PR DESCRIPTION
This adds a `log_connection_auth` toggle to opt-in into logging usernames and accounts.  Also modifies the logging format so that logs are better aligned:

Before:
```
[TRC] [::1]:53248 - cid:7 - <<- [PING] - Account: Workers - User "js"
[TRC] [::1]:53248 - cid:7 - ->> [PONG] - Account: Workers - User "js"
[TRC] [::1]:53248 - cid:7 - <<- [SUB foo  1] - Account: Workers - User "js"
[TRC] [::1]:53248 - cid:7 - <<- [PING] - Account: Workers - User "js"
[TRC] [::1]:53248 - cid:7 - ->> [PONG] - Account: Workers - User "js"
```

After:

```
[TRC] [::1]:53361 - cid:6 - "Workers/user:js" - <<- [PING]
[TRC] [::1]:53361 - cid:6 - "Workers/user:js" - ->> [PONG]
[TRC] [::1]:53361 - cid:6 - "Workers/user:js" - <<- [SUB foo  1]
[TRC] [::1]:53361 - cid:6 - "Workers/user:js" - <<- [PING]
[TRC] [::1]:53361 - cid:6 - "Workers/user:js" - ->> [PONG]
```

Signed-off-by: Waldemar Quevedo <wally@nats.io>
