### PR TITLE
[FIXED] Fix TestNRGSwitchStateClearsQueues

### DIFF
--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -413,6 +413,7 @@ func TestNRGSwitchStateClearsQueues(t *testing.T) {
 		prop:  newIPQueue[*proposedEntry](s, "prop"),
 		resp:  newIPQueue[*appendEntryResponse](s, "resp"),
 		leadc: make(chan bool, 1), // for switchState
+		sd:    t.TempDir(),
 	}
 	n.state.Store(int32(Leader))
 	require_Equal(t, n.prop.len(), 0)


### PR DESCRIPTION
The test leaves behind file server/tav.idx. Setting the raft's store to use a temporary directory. This gets automatically removed at the end of test.

Signed-off-by: Daniele Sciascia <daniele@nats.io>