### PR TITLE
Add client stalls to ServerStatsz

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -375,8 +375,9 @@ type ServerStats struct {
 	Received             DataStats             `json:"received"`
 	SlowConsumers        int64                 `json:"slow_consumers"`
 	SlowConsumersStats   *SlowConsumersStats   `json:"slow_consumer_stats,omitempty"`
-	StaleConnections     int64                 `json:"stale_connections"`
+	StaleConnections     int64                 `json:"stale_connections,omitempty"`
 	StaleConnectionStats *StaleConnectionStats `json:"stale_connection_stats,omitempty"`
+	Stalls               int64                 `json:"stalls,omitempty"`
 	Routes               []*RouteStat          `json:"routes,omitempty"`
 	Gateways             []*GatewayStat        `json:"gateways,omitempty"`
 	ActiveServers        int                   `json:"active_servers,omitempty"`
@@ -958,6 +959,7 @@ func (s *Server) sendStatsz(subj string) {
 		m.Stats.SlowConsumersStats = scs
 	}
 	m.Stats.StaleConnections = atomic.LoadInt64(&s.staleConnections)
+	m.Stats.Stalls = atomic.LoadInt64(&s.stalls)
 	stcs := &StaleConnectionStats{
 		Clients:  s.NumStaleConnectionsClients(),
 		Routes:   s.NumStaleConnectionsRoutes(),

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1951,6 +1951,8 @@ func TestServerEventsStatsZ(t *testing.T) {
 			t.Fatalf("Expected server A's route to B to have Name set to %q, got %q", "B", sr.Name)
 		}
 	}
+	// Increment stalls to confirm they are reported.
+	atomic.AddInt64(&sb.stalls, 3)
 
 	// Now query B and check that route's name is "A"
 	subj = fmt.Sprintf(serverStatsReqSubj, sb.ID())
@@ -1971,6 +1973,7 @@ func TestServerEventsStatsZ(t *testing.T) {
 			t.Fatalf("Expected server B's route to A to have Name set to %q, got %q", "A_SRV", sr.Name)
 		}
 	}
+	require_Equal(t, m.Stats.Stalls, 3)
 }
 
 func TestServerEventsHealthZSingleServer(t *testing.T) {


### PR DESCRIPTION
Also adds `omitempty` to StaleConnections

Signed-off-by: Waldemar Quevedo <wally@nats.io>
