### PR TITLE
(2.12) Add `isolate_leafnode_interest` for suppressing east-west leafnode interest propagation

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -189,6 +189,10 @@ type LeafNodeOpts struct {
 	// least" test).
 	MinVersion string
 
+	// Isolate subject interest from other leafnode connections, preventing
+	// east-west propagation.
+	IsolateLeafnodeInterest bool `json:"-"`
+
 	// Not exported, for tests.
 	resolver    netResolver
 	dialTimeout time.Duration
@@ -2682,6 +2686,8 @@ func parseLeafNodes(v any, opts *Options, errors *[]error, warnings *[]error) er
 				*errors = append(*errors, err)
 				continue
 			}
+		case "isolate_leafnode_interest", "isolate":
+			opts.LeafNode.IsolateLeafnodeInterest = mv.(bool)
 		default:
 			if !tk.IsUsedVariable() {
 				err := &unknownConfigFieldErr{


### PR DESCRIPTION
This allows configuring the `isolate_leafnode_interest` item in the `leafnode` configuration block for the leafnode listener. When enabled, interest from leafnodes is not propagated to other isolated leafnodes, suppressing a potential storm of east-west interest when there are many leafnodes connected to an account.

Signed-off-by: Neil Twigg <neil@nats.io>