### PR TITLE
(2.12) Add isolated to leafz

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -2320,6 +2320,7 @@ type LeafInfo struct {
 	ID          uint64     `json:"id"`
 	Name        string     `json:"name"`
 	IsSpoke     bool       `json:"is_spoke"`
+	IsIsolated  bool       `json:"is_isolated,omitempty"`
 	Account     string     `json:"account"`
 	IP          string     `json:"ip"`
 	Port        int        `json:"port"`
@@ -2364,6 +2365,7 @@ func (s *Server) Leafz(opts *LeafzOptions) (*Leafz, error) {
 				ID:          ln.cid,
 				Name:        ln.leaf.remoteServer,
 				IsSpoke:     ln.isSpokeLeafNode(),
+				IsIsolated:  ln.leaf.isolated,
 				Account:     ln.acc.Name,
 				IP:          ln.host,
 				Port:        int(ln.port),

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -4049,6 +4049,7 @@ func TestMonitorLeafz(t *testing.T) {
 			}
 		}
 		leafnodes {
+			isolate_leafnode_interest: true
 			remotes = [
 				{
 					account: "%s"
@@ -4144,6 +4145,9 @@ func TestMonitorLeafz(t *testing.T) {
 			}
 			if !ln.IsSpoke {
 				t.Fatal("Expected leafnode connection to be spoke")
+			}
+			if !ln.IsIsolated {
+				t.Fatal("Expected leafnode connection to be isolated")
 			}
 			if ln.RTT == "" {
 				t.Fatalf("RTT not tracked?")


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/7238, exposing the isolated property in leafz.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>