### PR TITLE
壮举：自动注入JWT用户标签作为消息标题

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -1033,6 +1033,11 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 		c.nameTag = juc.Name
 		c.mu.Unlock()
 
+		// Inject header from jwt tags
+		if len(juc.Tags) > 0 {
+			c.injectHeader(juc.Tags)
+		}
+
 		// Check if we need to set an auth timer if the user jwt expires.
 		c.setExpiration(juc.Claims(), validFor)
 

--- a/server/auth_callout.go
+++ b/server/auth_callout.go
@@ -301,6 +301,11 @@ func (s *Server) processClientOrLeafCallout(c *client, opts *Options) (authorize
 			c.mu.Unlock()
 		}
 
+		// Inject header from jwt tags
+		if len(arc.Tags) > 0 {
+			c.injectHeader(arc.Tags)
+		}
+
 		// Check if we need to set an auth timer if the user jwt expires.
 		c.setExpiration(arc.Claims(), expiration)
 


### PR DESCRIPTION
## Description

Parse JWT user tags ('key:value') and inject as message headers during auth. Enables client apps to track message senders without manual implementation.

## Features

- Support direct JWT auth and auth callout modes
- Validate headers and prevent injection attacks  
- Add comprehensive unit tests

## Use Case

Chat/gaming apps can automatically identify message senders from JWT tags like 'user-id:12345' -> header 'user-id: 12345'

## Implementation Details

- Parse JWT tags in `key:value` format from UserClaims.Tags
- Inject headers in both `auth.go` (direct JWT) and `auth_callout.go` (callout mode)
- Validate header names per HTTP standards (RFC 7230)
- Prevent CRLF injection attacks
- Only apply to CLIENT connections

JWT tags are automatically injected as message headers:

```go
// 1. Set JWT tags once during user creation (using auth_callout to create JWT)
uc := jwt.NewUserClaims(userPubKey)
uc.Tags.Add("user-id:12345")

// 2. Client connects with JWT - tags automatically become headers
nc, _ := nats.Connect("nats://server:4222", nats.UserCredentials("user.creds"))

// 3. Every message automatically includes user identity in headers
nc.Publish("chat.room1", []byte("Hello world"))
// ↓ Automatically includes headers:
// user-id: 12345

// 4. Receivers get user info from headers (no extra database queries needed)
nc.Subscribe("chat.room1", func(msg *nats.Msg) {
    userID := msg.Header.Get("user-id")      // "12345"
    fmt.Printf("Message from %s : %s\n",  userID, string(msg.Data))
})
```

## Testing

Added unit tests covering:
- Basic functionality and validation
- Security (injection attack prevention)
- Edge cases and error handling
- Different client types

Signed-off-by: li-zenghui <lizenghui0827@163.com>