### PR TITLE
(2.12) [FIXED] Can't disable message schedules

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -2024,6 +2024,11 @@ func (jsa *jsAccount) configUpdateCheck(old, new *StreamConfig, s *Server, pedan
 		return nil, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration update can not change message counter setting"))
 	}
 
+	// Can't disable message schedules setting.
+	if old.AllowMsgSchedules && !cfg.AllowMsgSchedules {
+		return nil, NewJSStreamInvalidConfigError(fmt.Errorf("message schedules can not be disabled"))
+	}
+
 	// Do some adjustments for being sealed.
 	// Pedantic mode will allow those changes to be made, as they are deterministic and important to get a sealed stream.
 	if cfg.Sealed {


### PR DESCRIPTION
Message scheduling can't be disabled once enabled, similar to TTL.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>