### PR TITLE
Fix nil pointer dereference in sendDomainLeaderElectAdvisory

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -6339,6 +6339,10 @@ func (s *Server) sendDomainLeaderElectAdvisory() {
 	node := cc.meta
 	js.mu.RUnlock()
 
+	if node == nil {
+		return
+	}
+
 	adv := &JSDomainLeaderElectedAdvisory{
 		TypedEvent: TypedEvent{
 			Type: JSDomainLeaderElectedAdvisoryType,


### PR DESCRIPTION
On shutdown, server may find the cluster meta node to be nil. If so, return early from the method.

Signed-off-by: Daniele Sciascia <daniele@nats.io>
