### PR TITLE
Rename Stalls -> StalledClients

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -377,7 +377,7 @@ type ServerStats struct {
 	SlowConsumersStats   *SlowConsumersStats   `json:"slow_consumer_stats,omitempty"`
 	StaleConnections     int64                 `json:"stale_connections,omitempty"`
 	StaleConnectionStats *StaleConnectionStats `json:"stale_connection_stats,omitempty"`
-	Stalls               int64                 `json:"stalls,omitempty"`
+	StalledClients       int64                 `json:"stalled_clients,omitempty"`
 	Routes               []*RouteStat          `json:"routes,omitempty"`
 	Gateways             []*GatewayStat        `json:"gateways,omitempty"`
 	ActiveServers        int                   `json:"active_servers,omitempty"`
@@ -959,7 +959,7 @@ func (s *Server) sendStatsz(subj string) {
 		m.Stats.SlowConsumersStats = scs
 	}
 	m.Stats.StaleConnections = atomic.LoadInt64(&s.staleConnections)
-	m.Stats.Stalls = atomic.LoadInt64(&s.stalls)
+	m.Stats.StalledClients = atomic.LoadInt64(&s.stalls)
 	stcs := &StaleConnectionStats{
 		Clients:  s.NumStaleConnectionsClients(),
 		Routes:   s.NumStaleConnectionsRoutes(),

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1973,7 +1973,7 @@ func TestServerEventsStatsZ(t *testing.T) {
 			t.Fatalf("Expected server B's route to A to have Name set to %q, got %q", "A_SRV", sr.Name)
 		}
 	}
-	require_Equal(t, m.Stats.Stalls, 3)
+	require_Equal(t, m.Stats.StalledClients, 3)
 }
 
 func TestServerEventsHealthZSingleServer(t *testing.T) {


### PR DESCRIPTION
Align ServerStats to use `stalled_clients`

Signed-off-by: Waldemar Quevedo <wally@nats.io>
