### PR TITLE
 (2.12) Revert to meta leader proposing consumer remaps

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4180,8 +4180,6 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 	hasResponded := sa.responded
 	sa.responded = true
 	recovering := sa.recovering
-	cc := js.cluster
-	meta := cc.meta
 	js.mu.Unlock()
 
 	mset, err := acc.lookupStream(cfg.Name)
@@ -4292,134 +4290,6 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 		return
 	}
 
-	// Remap consumers if needed.
-	// We stage consumer updates and do them after we have responded to the API call.
-	consumers := make([]*consumerAssignment, 0, len(osa.consumers))
-	js.mu.Lock()
-	// Replica change is where the config has changed intentionally by a stream update.
-	// Move request is either a placement change or the number of replicas in the config
-	// hasn't changed but the peer set has (i.e. "scale and move").
-	isReplicaChange := cfg.Replicas != osa.Config.Replicas
-	isMoveRequest := cfg.Placement != nil && !reflect.DeepEqual(osa.Config.Placement, cfg.Placement) || (cfg.Replicas == osa.Config.Replicas && len(rg.Peers) != len(osa.Group.Peers))
-	if isReplicaChange {
-		isScaleUp := cfg.Replicas > osa.Config.Replicas
-		for _, ca := range osa.consumers {
-			// Legacy ephemerals are R=1 but present as R=0, so only auto-remap named consumers, or if we are downsizing the consumer peers.
-			// If stream is interest or workqueue policy always remaps since they require peer parity with stream.
-			numPeers := len(ca.Group.Peers)
-			isAutoScale := ca.Config.Replicas == 0 && (ca.Config.Durable != _EMPTY_ || ca.Config.Name != _EMPTY_)
-			if isAutoScale || numPeers > len(rg.Peers) || cfg.Retention != LimitsPolicy {
-				cca := ca.copyGroup()
-				// Adjust preferred as needed.
-				if numPeers == 1 && isScaleUp {
-					cca.Group.Preferred = ca.Group.Peers[0]
-				} else {
-					cca.Group.Preferred = _EMPTY_
-				}
-				// Assign new peers.
-				cca.Group.Peers = rg.Peers
-				// If the replicas was not 0 make sure it matches here.
-				if cca.Config.Replicas != 0 {
-					cca.Config.Replicas = len(rg.Peers)
-				}
-				// We can not propose here before the stream itself so we collect them.
-				consumers = append(consumers, cca)
-			} else if !isScaleUp {
-				// We decided to leave this consumer's peer group alone but we are also scaling down.
-				// We need to make sure we do not have any peers that are no longer part of the stream.
-				// Note we handle down scaling of a consumer above if its number of peers were > new stream peers.
-				var needReplace []string
-				for _, rp := range ca.Group.Peers {
-					// Check if we have an orphaned peer now for this consumer.
-					if !rg.isMember(rp) {
-						needReplace = append(needReplace, rp)
-					}
-				}
-				if len(needReplace) > 0 {
-					newPeers := copyStrings(rg.Peers)
-					rand.Shuffle(len(newPeers), func(i, j int) { newPeers[i], newPeers[j] = newPeers[j], newPeers[i] })
-					// If we had a small size then the peer set, restrict to the same number.
-					if lp := len(ca.Group.Peers); lp < len(newPeers) {
-						newPeers = newPeers[:lp]
-					}
-					cca := ca.copyGroup()
-					// Assign new peers.
-					cca.Group.Peers = newPeers
-					// If the replicas was not 0 make sure it matches here.
-					if cca.Config.Replicas != 0 {
-						cca.Config.Replicas = len(newPeers)
-					}
-					// Check if all peers are invalid. This can happen with R1 under replicated streams that are being scaled down.
-					if len(needReplace) == len(ca.Group.Peers) {
-						// We have to transfer state to new peers.
-						// we will grab our state and attach to the new assignment.
-						// TODO(dlc) - In practice we would want to make sure the consumer is paused.
-						// Need to release js lock.
-						js.mu.Unlock()
-						if ci, err := sysRequest[ConsumerInfo](s, clusterConsumerInfoT, acc, osa.Config.Name, ca.Name); err != nil {
-							s.Warnf("Did not receive consumer info results for '%s > %s > %s' due to: %s", acc, osa.Config.Name, ca.Name, err)
-						} else if ci != nil {
-							cca.State = &ConsumerState{
-								Delivered: SequencePair{
-									Consumer: ci.Delivered.Consumer,
-									Stream:   ci.Delivered.Stream,
-								},
-								AckFloor: SequencePair{
-									Consumer: ci.AckFloor.Consumer,
-									Stream:   ci.AckFloor.Stream,
-								},
-							}
-						}
-						// Re-acquire here.
-						js.mu.Lock()
-					}
-					// We can not propose here before the stream itself so we collect them.
-					consumers = append(consumers, cca)
-				}
-			}
-		}
-	} else if isMoveRequest {
-		for _, ca := range osa.consumers {
-			cca := ca.copyGroup()
-			r := cca.Config.replicas(osa.Config)
-			// shuffle part of cluster peer set we will be keeping
-			randPeerSet := copyStrings(rg.Peers[len(rg.Peers)-cfg.Replicas:])
-			rand.Shuffle(cfg.Replicas, func(i, j int) { randPeerSet[i], randPeerSet[j] = randPeerSet[j], randPeerSet[i] })
-			// move overlapping peers at the end of randPeerSet and keep a tally of non overlapping peers
-			dropPeerSet := make([]string, 0, len(cca.Group.Peers))
-			for _, p := range cca.Group.Peers {
-				found := false
-				for i, rp := range randPeerSet {
-					if p == rp {
-						randPeerSet[i] = randPeerSet[cfg.Replicas-1]
-						randPeerSet[cfg.Replicas-1] = p
-						found = true
-						break
-					}
-				}
-				if !found {
-					dropPeerSet = append(dropPeerSet, p)
-				}
-			}
-			cPeerSet := randPeerSet[cfg.Replicas-r:]
-			// In case of a set or cancel simply assign
-			if len(rg.Peers) == cfg.Replicas {
-				cca.Group.Peers = cPeerSet
-			} else {
-				cca.Group.Peers = append(dropPeerSet, cPeerSet...)
-			}
-			// make sure it overlaps with peers and remove if not
-			if cca.Group.Preferred != _EMPTY_ {
-				if !slices.Contains(cca.Group.Peers, cca.Group.Preferred) {
-					cca.Group.Preferred = _EMPTY_
-				}
-			}
-			// We can not propose here before the stream itself so we collect them.
-			consumers = append(consumers, cca)
-		}
-	}
-	js.mu.Unlock()
-
 	// Send our response.
 	var resp = JSApiStreamUpdateResponse{ApiResponse: ApiResponse{Type: JSApiStreamUpdateResponseType}}
 	msetCfg := mset.config()
@@ -4434,11 +4304,6 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 	}
 
 	s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
-
-	// Process any staged consumer updates.
-	for _, ca := range consumers {
-		meta.ForwardProposal(encodeAddConsumerAssignment(ca))
-	}
 }
 
 // processClusterCreateStream is called when we have a stream assignment that
@@ -7235,6 +7100,9 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 	// Check for replica changes.
 	isReplicaChange := newCfg.Replicas != osa.Config.Replicas
 
+	// We stage consumer updates and do them after the stream update.
+	var consumers []*consumerAssignment
+
 	// Check if this is a move request, but no cancellation, and we are already moving this stream.
 	if isMoveRequest && !isMoveCancel && osa.Config.Replicas != len(rg.Peers) {
 		// obtain stats to include in error message
@@ -7355,6 +7223,85 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 			}
 			rg.Peers = selected
 		}
+
+		// Need to remap any consumers.
+		for _, ca := range osa.consumers {
+			// Legacy ephemerals are R=1 but present as R=0, so only auto-remap named consumers, or if we are downsizing the consumer peers.
+			// If stream is interest or workqueue policy always remaps since they require peer parity with stream.
+			numPeers := len(ca.Group.Peers)
+			isAutoScale := ca.Config.Replicas == 0 && (ca.Config.Durable != _EMPTY_ || ca.Config.Name != _EMPTY_)
+			if isAutoScale || numPeers > len(rg.Peers) || cfg.Retention != LimitsPolicy {
+				cca := ca.copyGroup()
+				// Adjust preferred as needed.
+				if numPeers == 1 && isScaleUp {
+					cca.Group.Preferred = ca.Group.Peers[0]
+				} else {
+					cca.Group.Preferred = _EMPTY_
+				}
+				// Assign new peers.
+				cca.Group.Peers = rg.Peers
+				// If the replicas was not 0 make sure it matches here.
+				if cca.Config.Replicas != 0 {
+					cca.Config.Replicas = len(rg.Peers)
+				}
+				// We can not propose here before the stream itself so we collect them.
+				consumers = append(consumers, cca)
+
+			} else if !isScaleUp {
+				// We decided to leave this consumer's peer group alone but we are also scaling down.
+				// We need to make sure we do not have any peers that are no longer part of the stream.
+				// Note we handle down scaling of a consumer above if its number of peers were > new stream peers.
+				var needReplace []string
+				for _, rp := range ca.Group.Peers {
+					// Check if we have an orphaned peer now for this consumer.
+					if !rg.isMember(rp) {
+						needReplace = append(needReplace, rp)
+					}
+				}
+				if len(needReplace) > 0 {
+					newPeers := copyStrings(rg.Peers)
+					rand.Shuffle(len(newPeers), func(i, j int) { newPeers[i], newPeers[j] = newPeers[j], newPeers[i] })
+					// If we had a small size then the peer set, restrict to the same number.
+					if lp := len(ca.Group.Peers); lp < len(newPeers) {
+						newPeers = newPeers[:lp]
+					}
+					cca := ca.copyGroup()
+					// Assign new peers.
+					cca.Group.Peers = newPeers
+					// If the replicas was not 0 make sure it matches here.
+					if cca.Config.Replicas != 0 {
+						cca.Config.Replicas = len(newPeers)
+					}
+					// Check if all peers are invalid. This can happen with R1 under replicated streams that are being scaled down.
+					if len(needReplace) == len(ca.Group.Peers) {
+						// We have to transfer state to new peers.
+						// we will grab our state and attach to the new assignment.
+						// TODO(dlc) - In practice we would want to make sure the consumer is paused.
+						// Need to release js lock.
+						js.mu.Unlock()
+						if ci, err := sysRequest[ConsumerInfo](s, clusterConsumerInfoT, acc, osa.Config.Name, ca.Name); err != nil {
+							s.Warnf("Did not receive consumer info results for '%s > %s > %s' due to: %s", acc, osa.Config.Name, ca.Name, err)
+						} else if ci != nil {
+							cca.State = &ConsumerState{
+								Delivered: SequencePair{
+									Consumer: ci.Delivered.Consumer,
+									Stream:   ci.Delivered.Stream,
+								},
+								AckFloor: SequencePair{
+									Consumer: ci.AckFloor.Consumer,
+									Stream:   ci.AckFloor.Stream,
+								},
+							}
+						}
+						// Re-acquire here.
+						js.mu.Lock()
+					}
+					// We can not propose here before the stream itself so we collect them.
+					consumers = append(consumers, cca)
+				}
+			}
+		}
+
 	} else if isMoveRequest {
 		if len(peerSet) == 0 {
 			nrg, err := js.createGroupForStream(ci, newCfg)
@@ -7375,6 +7322,45 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 			rg.Preferred = peerSet[0]
 		}
 		rg.Peers = peerSet
+
+		for _, ca := range osa.consumers {
+			cca := ca.copyGroup()
+			r := cca.Config.replicas(osa.Config)
+			// shuffle part of cluster peer set we will be keeping
+			randPeerSet := copyStrings(peerSet[len(peerSet)-newCfg.Replicas:])
+			rand.Shuffle(newCfg.Replicas, func(i, j int) { randPeerSet[i], randPeerSet[j] = randPeerSet[j], randPeerSet[i] })
+			// move overlapping peers at the end of randPeerSet and keep a tally of non overlapping peers
+			dropPeerSet := make([]string, 0, len(cca.Group.Peers))
+			for _, p := range cca.Group.Peers {
+				found := false
+				for i, rp := range randPeerSet {
+					if p == rp {
+						randPeerSet[i] = randPeerSet[newCfg.Replicas-1]
+						randPeerSet[newCfg.Replicas-1] = p
+						found = true
+						break
+					}
+				}
+				if !found {
+					dropPeerSet = append(dropPeerSet, p)
+				}
+			}
+			cPeerSet := randPeerSet[newCfg.Replicas-r:]
+			// In case of a set or cancel simply assign
+			if len(peerSet) == newCfg.Replicas {
+				cca.Group.Peers = cPeerSet
+			} else {
+				cca.Group.Peers = append(dropPeerSet, cPeerSet...)
+			}
+			// make sure it overlaps with peers and remove if not
+			if cca.Group.Preferred != _EMPTY_ {
+				if !slices.Contains(cca.Group.Peers, cca.Group.Preferred) {
+					cca.Group.Preferred = _EMPTY_
+				}
+			}
+			// We can not propose here before the stream itself so we collect them.
+			consumers = append(consumers, cca)
+		}
 	} else {
 		// All other updates make sure no preferred is set.
 		rg.Preferred = _EMPTY_
@@ -7382,6 +7368,11 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 
 	sa := &streamAssignment{Group: rg, Sync: osa.Sync, Created: osa.Created, Config: newCfg, Subject: subject, Reply: reply, Client: ci}
 	meta.Propose(encodeUpdateStreamAssignment(sa))
+
+	// Process any staged consumers.
+	for _, ca := range consumers {
+		meta.Propose(encodeAddConsumerAssignment(ca))
+	}
 }
 
 func (s *Server) jsClusteredStreamDeleteRequest(ci *ClientInfo, acc *Account, stream, subject, reply string, rmsg []byte) {


### PR DESCRIPTION
Revert https://github.com/nats-io/nats-server/pull/7071, since it would result in losing consumer state when scaling down a replicated stream and the consumer state would need to be moved, but the current stream leader doesn't host that consumer.

`TestJetStreamClusterConsumerReplicasAfterScale` started flaking due to this bug. `TestJetStreamClusterConsumerReplicasAfterScaleMoveConsumer` has been added in this PR which specifically tests for this situation (the former test would only hit that randomly, hence it flaking).

We'll need to revisit this later when implementing the stream-managed consumers, which isn't going to be for 2.12.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>