### PR TITLE
Fix TestJetStreamClusterDontReviveRemovedStream

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -8965,11 +8965,11 @@ func TestJetStreamClusterDontReviveRemovedStream(t *testing.T) {
 				return fmt.Errorf("stream still assigned on %s", s.Name())
 			}
 		}
+		if !mset.closed.Load() {
+			return fmt.Errorf("stream not closed yet")
+		}
 		return nil
 	})
-
-	// Confirm the stream is closed.
-	require_True(t, mset.closed.Load())
 
 	// Simulating the stream was catching up and is resetting after timing out.
 	require_True(t, mset.resetClusteredState(nil))


### PR DESCRIPTION
Test fails as follows:

```
        cfg.Replicas = 1
        _, err = js.UpdateStream(cfg)
        require_NoError(t, err)

        checkFor(..., func() error {
          if s.JetStreamIsStreamAssigned(globalAccountName, "TEST") {
             // some error
           }
        }
        ...
        require_True(t, mset.closed.Load()) // mset.closed still false
```

This can happen because `js.UpdateStream()` will internally `removeStream()`, which will cause nodes to:
 - step down from the Raft group
 - remove themeselves from the stream assignment
 - mark the stream as stopped

Therefore `JetStreamIsStreamassigned()` may return false *before* the stream is marked as closed.

Signed-off-by: Daniele Sciascia <daniele@nats.io>
