### PR TITLE
Fix TestNRGNoResetOnAppendEntryResponse

### DIFF
--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -100,6 +100,18 @@ func (sg smGroup) unlockAll() {
 	}
 }
 
+// Acquire the lock on all follower nodes.
+func (sg smGroup) lockFollowers() []stateMachine {
+	var locked []stateMachine
+	for _, sm := range sg {
+		if !sm.node().Leader() {
+			locked = append(locked, sm)
+			sm.node().(*raft).Lock()
+		}
+	}
+	return locked[:]
+}
+
 // Create a raft group and place on numMembers servers at random.
 // Filestore based.
 func (c *cluster) createRaftGroup(name string, numMembers int, smf smFactory) smGroup {


### PR DESCRIPTION
The test proposes a message and expects it to be committed via rg.waitOnTotal(). This was nondeterministic:

- If the leader first received an AppendEntriesResponse from a follower, the proposed message could be committed.
- If the leader first received the AppendEntriesResponse with a higher term (injected by the test), the leader stepped down and the proposed message could not be committed.

The test would sometimes fail depending on the ordering of these events. This fix ensures that the test always follows the second path, where the leader steps down before the proposal can be committed.

Signed-off-by: Daniele Sciascia <daniele@nats.io>
