### PR TITLE
Add linux/arm64 to nightly, make it multiplatform

### DIFF
--- a/.github/actions/nightly-release/action.yaml
+++ b/.github/actions/nightly-release/action.yaml
@@ -26,6 +26,12 @@ runs:
       with:
         go-version: stable
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Build and push Docker images
       # Use commit hash here to avoid a re-tagging attack, as this is a third-party action
       # Commit 9ed2f89a662bf1735a48bc8557fd212fa902bebf = tag v6.1.0

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -14,6 +14,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     mod_timestamp: "{{ .CommitTimestamp }}"
 
 release:
@@ -23,14 +24,40 @@ dockers:
   - goos: linux
     goarch: amd64
     dockerfile: docker/Dockerfile.nightly
-    skip_push: false
+    use: buildx
     build_flag_templates:
+      - '--pull'
+      - '--platform=linux/amd64'
       - '--build-arg=VERSION={{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}'
     image_templates:
-      - synadia/nats-server:{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}
-      - synadia/nats-server:{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}
+      - synadia/nats-server:{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-amd64
+      - synadia/nats-server:{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}-amd64
     extra_files:
       - docker/nats-server.conf
+  - goos: linux
+    goarch: arm64
+    dockerfile: docker/Dockerfile.nightly
+    use: buildx
+    build_flag_templates:
+      - '--pull'
+      - '--platform=linux/arm64'
+      - '--build-arg=VERSION={{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}'
+    image_templates:
+      - synadia/nats-server:{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-arm64
+      - synadia/nats-server:{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}-arm64
+    extra_files:
+      - docker/nats-server.conf
+
+docker_manifests:
+  - name_template: synadia/nats-server:{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}
+    image_templates:
+      - synadia/nats-server:{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-amd64
+      - synadia/nats-server:{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-arm64
+  - name_template: synadia/nats-server:{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}
+    image_templates:
+      - synadia/nats-server:{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}-amd64
+      - synadia/nats-server:{{ if ne .Branch "main" }}{{ replace .Branch "/" "-" }}{{ else }}nightly{{ end }}-{{ time "20060102" }}-arm64
+
 
 checksum:
   name_template: "SHA256SUMS"


### PR DESCRIPTION
Makes nightly multi platform and add support for arm64 which we use more in testing lately.

Generates:

* Single
  - synadia/nats-server:nightly-amd64
  - synadia/nats-server:nightly-arm64
  - synadia/nats-server:nightly-20250905-amd64
  - synadia/nats-server:nightly-20250905-arm64

* Multi
  - synadia/nats-server:nightly (both amd64 and arm64)
  - synadia/nats-server:nightly-20250905

Signed-off-by:  Waldemar Quevedo <wally@nats.io>
