### PR TITLE
(2.12) Atomic batch: advisories & general improvements

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -1958,5 +1958,25 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSMirrorWithAtomicPublishErr",
+    "code": 400,
+    "error_code": 10198,
+    "description": "stream mirrors can not also use atomic publishing",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSAtomicPublishTooLargeBatchErr",
+    "code": 400,
+    "error_code": 10199,
+    "description": "atomic publish batch is too large",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -313,6 +313,9 @@ const (
 	// JSAdvisoryStreamQuorumLostPre notification that a stream and its consumers are stalled.
 	JSAdvisoryStreamQuorumLostPre = "$JS.EVENT.ADVISORY.STREAM.QUORUM_LOST"
 
+	// JSAdvisoryStreamBatchAbandonedPre notification that a stream's batch was abandoned.
+	JSAdvisoryStreamBatchAbandonedPre = "$JS.EVENT.ADVISORY.STREAM.BATCH_ABANDONED"
+
 	// JSAdvisoryConsumerLeaderElectedPre notification that a replicated consumer has elected a leader.
 	JSAdvisoryConsumerLeaderElectedPre = "$JS.EVENT.ADVISORY.CONSUMER.LEADER_ELECTED"
 

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -20,6 +20,9 @@ const (
 	// JSAtomicPublishMissingSeqErr atomic publish sequence is missing
 	JSAtomicPublishMissingSeqErr ErrorIdentifier = 10175
 
+	// JSAtomicPublishTooLargeBatchErr atomic publish batch is too large
+	JSAtomicPublishTooLargeBatchErr ErrorIdentifier = 10199
+
 	// JSAtomicPublishUnsupportedHeaderBatchErr atomic publish unsupported header used: {header}
 	JSAtomicPublishUnsupportedHeaderBatchErr ErrorIdentifier = 10177
 
@@ -338,6 +341,9 @@ const (
 	// JSMirrorOverlappingSubjectFilters mirror subject filters can not overlap
 	JSMirrorOverlappingSubjectFilters ErrorIdentifier = 10152
 
+	// JSMirrorWithAtomicPublishErr stream mirrors can not also use atomic publishing
+	JSMirrorWithAtomicPublishErr ErrorIdentifier = 10198
+
 	// JSMirrorWithCountersErr stream mirrors can not also calculate counters
 	JSMirrorWithCountersErr ErrorIdentifier = 10173
 
@@ -601,6 +607,7 @@ var (
 		JSAtomicPublishIncompleteBatchErr:            {Code: 400, ErrCode: 10176, Description: "atomic publish batch is incomplete"},
 		JSAtomicPublishInvalidBatchIDErr:             {Code: 400, ErrCode: 10179, Description: "atomic publish batch ID is invalid"},
 		JSAtomicPublishMissingSeqErr:                 {Code: 400, ErrCode: 10175, Description: "atomic publish sequence is missing"},
+		JSAtomicPublishTooLargeBatchErr:              {Code: 400, ErrCode: 10199, Description: "atomic publish batch is too large"},
 		JSAtomicPublishUnsupportedHeaderBatchErr:     {Code: 400, ErrCode: 10177, Description: "atomic publish unsupported header used: {header}"},
 		JSBadRequestErr:                              {Code: 400, ErrCode: 10003, Description: "bad request"},
 		JSClusterIncompleteErr:                       {Code: 503, ErrCode: 10004, Description: "incomplete results"},
@@ -707,6 +714,7 @@ var (
 		JSMirrorMaxMessageSizeTooBigErr:              {Code: 400, ErrCode: 10030, Description: "stream mirror must have max message size >= source"},
 		JSMirrorMultipleFiltersNotAllowed:            {Code: 400, ErrCode: 10150, Description: "mirror with multiple subject transforms cannot also have a single subject filter"},
 		JSMirrorOverlappingSubjectFilters:            {Code: 400, ErrCode: 10152, Description: "mirror subject filters can not overlap"},
+		JSMirrorWithAtomicPublishErr:                 {Code: 400, ErrCode: 10198, Description: "stream mirrors can not also use atomic publishing"},
 		JSMirrorWithCountersErr:                      {Code: 400, ErrCode: 10173, Description: "stream mirrors can not also calculate counters"},
 		JSMirrorWithFirstSeqErr:                      {Code: 400, ErrCode: 10143, Description: "stream mirrors can not have first sequence configured"},
 		JSMirrorWithMsgSchedulesErr:                  {Code: 400, ErrCode: 10186, Description: "stream mirrors can not also schedule messages"},
@@ -865,6 +873,16 @@ func NewJSAtomicPublishMissingSeqError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSAtomicPublishMissingSeqErr]
+}
+
+// NewJSAtomicPublishTooLargeBatchError creates a new JSAtomicPublishTooLargeBatchErr error: "atomic publish batch is too large"
+func NewJSAtomicPublishTooLargeBatchError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSAtomicPublishTooLargeBatchErr]
 }
 
 // NewJSAtomicPublishUnsupportedHeaderBatchError creates a new JSAtomicPublishUnsupportedHeaderBatchErr error: "atomic publish unsupported header used: {header}"
@@ -2027,6 +2045,16 @@ func NewJSMirrorOverlappingSubjectFiltersError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSMirrorOverlappingSubjectFilters]
+}
+
+// NewJSMirrorWithAtomicPublishError creates a new JSMirrorWithAtomicPublishErr error: "stream mirrors can not also use atomic publishing"
+func NewJSMirrorWithAtomicPublishError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMirrorWithAtomicPublishErr]
 }
 
 // NewJSMirrorWithCountersError creates a new JSMirrorWithCountersErr error: "stream mirrors can not also calculate counters"

--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -253,6 +253,26 @@ type JSStreamQuorumLostAdvisory struct {
 	Domain   string      `json:"domain,omitempty"`
 }
 
+// JSStreamBatchAbandonedAdvisoryType is sent when a stream's atomic batch is abandoned.
+const JSStreamBatchAbandonedAdvisoryType = "io.nats.jetstream.advisory.v1.stream_batch_abandoned"
+
+// JSStreamBatchAbandonedAdvisory indicates that a stream's batch was abandoned.
+type JSStreamBatchAbandonedAdvisory struct {
+	TypedEvent
+	Account string             `json:"account,omitempty"`
+	Stream  string             `json:"stream"`
+	Domain  string             `json:"domain,omitempty"`
+	BatchId string             `json:"batch"`
+	Reason  BatchAbandonReason `json:"reason"`
+}
+
+type BatchAbandonReason string
+
+var (
+	BatchTimeout    BatchAbandonReason = "timeout"
+	BatchIncomplete BatchAbandonReason = "incomplete"
+)
+
 // JSConsumerLeaderElectedAdvisoryType is sent when the system elects a leader for a consumer.
 const JSConsumerLeaderElectedAdvisoryType = "io.nats.jetstream.advisory.v1.consumer_leader_elected"
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -1361,6 +1361,34 @@ func (mset *stream) sendUpdateAdvisoryLocked() {
 	}
 }
 
+func (mset *stream) sendStreamBatchAbandonedAdvisory(batchId string, reason BatchAbandonReason) {
+	if mset == nil {
+		return
+	}
+	s := mset.srv
+	stream, acc := mset.name(), mset.account()
+	subj := JSAdvisoryStreamBatchAbandonedPre + "." + stream
+	adv := &JSStreamBatchAbandonedAdvisory{
+		TypedEvent: TypedEvent{
+			Type: JSStreamBatchAbandonedAdvisoryType,
+			ID:   nuid.Next(),
+			Time: time.Now().UTC(),
+		},
+		Stream:  stream,
+		Domain:  s.getOpts().JetStreamDomain,
+		BatchId: batchId,
+		Reason:  reason,
+	}
+
+	// Send to the user's account if not the system account.
+	if acc != s.SystemAccount() {
+		s.publishAdvisory(acc, subj, adv)
+	}
+	// Now do system level one. Place account info in adv, and nil account means system.
+	adv.Account = acc.GetName()
+	s.publishAdvisory(nil, subj, adv)
+}
+
 // Created returns created time.
 func (mset *stream) createdTime() time.Time {
 	mset.mu.RLock()
@@ -1616,6 +1644,9 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 		}
 		if cfg.AllowMsgCounter {
 			return StreamConfig{}, NewJSMirrorWithCountersError()
+		}
+		if cfg.AllowAtomicPublish {
+			return StreamConfig{}, NewJSMirrorWithAtomicPublishError()
 		}
 		if cfg.AllowMsgSchedules {
 			return StreamConfig{}, NewJSMirrorWithMsgSchedulesError()
@@ -6217,6 +6248,19 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 	if !ok {
 		if batchSeq != 1 {
 			batches.mu.Unlock()
+			maxBatchSize := streamMaxBatchSize
+			opts := s.getOpts()
+			if opts.JetStreamLimits.MaxBatchSize > 0 {
+				maxBatchSize = opts.JetStreamLimits.MaxBatchSize
+			}
+			if batchSeq > uint64(maxBatchSize) {
+				err := NewJSAtomicPublishTooLargeBatchError()
+				if canRespond {
+					buf, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
+					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, buf, nil, 0))
+				}
+				return err
+			}
 			return respondIncompleteBatch()
 		}
 
@@ -6258,6 +6302,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 	if b.lseq != batchSeq {
 		b.cleanupLocked(batchId, batches)
 		batches.mu.Unlock()
+		mset.sendStreamBatchAbandonedAdvisory(batchId, BatchIncomplete)
 		return respondIncompleteBatch()
 	}
 
@@ -6269,6 +6314,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 	if batchSeq > uint64(maxSize) {
 		b.cleanupLocked(batchId, batches)
 		batches.mu.Unlock()
+		mset.sendStreamBatchAbandonedAdvisory(batchId, BatchTimeout)
 		return respondIncompleteBatch()
 	}
 
@@ -6279,6 +6325,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 		if err != nil || seq != batchSeq {
 			b.cleanupLocked(batchId, batches)
 			batches.mu.Unlock()
+			mset.sendStreamBatchAbandonedAdvisory(batchId, BatchTimeout)
 			return respondIncompleteBatch()
 		}
 	}
@@ -6291,6 +6338,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 	if !b.readyForCommit() {
 		// Don't do cleanup, this is already done.
 		batches.mu.Unlock()
+		mset.sendStreamBatchAbandonedAdvisory(batchId, BatchTimeout)
 		return respondIncompleteBatch()
 	}
 


### PR DESCRIPTION
Add batch abandoned advisories, for example when the batch timed out or when it was incomplete due to gaps. Also including some general improvements, with a specific error when trying to publish a too large batch, as well as not allowing batching on mirrors.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>