### PR TITLE
Skip Test*FSModeReadOnly tests in Buildkite

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -8896,6 +8896,9 @@ func TestFileStoreSubjectDeleteMarkers(t *testing.T) {
 }
 
 func TestFileStoreStoreRawMessageThrowsPermissionErrorIfFSModeReadOnly(t *testing.T) {
+	// Test fails in Buildkite environment. Skip it.
+	skipIfBuildkite(t)
+
 	cfg := StreamConfig{Name: "zzz", Subjects: []string{"ev.1"}, Storage: FileStorage}
 	fs, err := newFileStore(FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 1024}, cfg)
 	require_NoError(t, err)
@@ -8920,6 +8923,9 @@ func TestFileStoreStoreRawMessageThrowsPermissionErrorIfFSModeReadOnly(t *testin
 }
 
 func TestFileStoreWriteFullStateThrowsPermissionErrorIfFSModeReadOnly(t *testing.T) {
+	// Test fails in Buildkite environment. Skip it.
+	skipIfBuildkite(t)
+
 	cfg := StreamConfig{Name: "zzz", Subjects: []string{"ev.1"}, Storage: FileStorage}
 	fs, err := newFileStore(FileStoreConfig{StoreDir: t.TempDir()}, cfg)
 	require_NoError(t, err)

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -382,3 +382,9 @@ func runSolicitLeafServerToURL(surl string) (*Server, *Options) {
 	o.LeafNode.ReconnectInterval = 100 * time.Millisecond
 	return RunServer(&o), &o
 }
+
+func skipIfBuildkite(t *testing.T) {
+	if os.Getenv("BUILDKITE") == "true" {
+		t.Skip("skipping test on Buildkite CI")
+	}
+}


### PR DESCRIPTION
These tests verify that writes to readonly files or directories fail when using the filestore. They pass in other environments, but not in Buildkite: `os.Chmod()` sets the mode to readonly, yet the process can still write without error.

Signed-off-by: Daniele Sciascia <daniele@nats.io>

