### PR TITLE
(2.12) Allow configuring `X25519MLKEM768` curve

### DIFF
--- a/server/ciphersuites.go
+++ b/server/ciphersuites.go
@@ -42,17 +42,19 @@ func defaultCipherSuites() []uint16 {
 
 // Where we maintain available curve preferences
 var curvePreferenceMap = map[string]tls.CurveID{
-	"X25519":    tls.X25519,
-	"CurveP256": tls.CurveP256,
-	"CurveP384": tls.CurveP384,
-	"CurveP521": tls.CurveP521,
+	"X25519MLKEM768": tls.X25519MLKEM768,
+	"X25519":         tls.X25519,
+	"CurveP256":      tls.CurveP256,
+	"CurveP384":      tls.CurveP384,
+	"CurveP521":      tls.CurveP521,
 }
 
 // reorder to default to the highest level of security.  See:
 // https://blog.bracebin.com/achieving-perfect-ssl-labs-score-with-go
 func defaultCurvePreferences() []tls.CurveID {
 	return []tls.CurveID{
-		tls.X25519, // faster than P256, arguably more secure
+		tls.X25519MLKEM768, // post-quantum
+		tls.X25519,         // faster than P256, arguably more secure
 		tls.CurveP256,
 		tls.CurveP384,
 		tls.CurveP521,


### PR DESCRIPTION
This fixes #7279.

Signed-off-by: Neil Twigg <neil@nats.io>