### PR TITLE
feat(Ack.InProgress): publish advisory message

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2555,7 +2555,7 @@ func (o *consumer) processAck(subject, reply string, hdr int, rmsg []byte) {
 	case bytes.HasPrefix(msg, AckNak):
 		o.processNak(sseq, dseq, dc, msg)
 	case bytes.Equal(msg, AckProgress):
-		o.progressUpdate(sseq)
+		o.progressUpdate(sseq, dseq, dc)
 	case bytes.HasPrefix(msg, AckTerm):
 		var reason string
 		if buf := msg[len(AckTerm):]; len(buf) > 0 {
@@ -2574,15 +2574,34 @@ func (o *consumer) processAck(subject, reply string, hdr int, rmsg []byte) {
 }
 
 // Used to process a working update to delay redelivery.
-func (o *consumer) progressUpdate(seq uint64) {
+func (o *consumer) progressUpdate(sseq, dseq, dc uint64) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	if p, ok := o.pending[seq]; ok {
-		p.Timestamp = time.Now().UnixNano()
+	t := time.Now()
+	if p, ok := o.pending[sseq]; ok {
+		p.Timestamp = t.UnixNano()
 		// Update store system.
-		o.updateDelivered(p.Sequence, seq, 1, p.Timestamp)
+		o.updateDelivered(p.Sequence, sseq, 1, p.Timestamp)
 	}
+
+	// Deliver an advisory
+	e := JSConsumerDeliveryInProgress{
+		TypedEvent: TypedEvent{
+			Type: JSConsumerDeliveryInProgressType,
+			ID:   nuid.Next(),
+			Time: t.UTC(),
+		},
+		Stream:      o.stream,
+		Consumer:    o.name,
+		ConsumerSeq: dseq,
+		StreamSeq:   sseq,
+		Deliveries:  dc,
+		Domain:      o.srv.getOpts().JetStreamDomain,
+	}
+
+	subj := JSAdvisoryConsumerMsgInProgress + "." + o.stream + "." + o.name
+	o.sendAdvisory(subj, e)
 }
 
 // Lock should be held.

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -268,6 +268,9 @@ const (
 	// JSAdvisoryConsumerMsgTerminatedPre is a notification published when a message has been terminated.
 	JSAdvisoryConsumerMsgTerminatedPre = "$JS.EVENT.ADVISORY.CONSUMER.MSG_TERMINATED"
 
+	// JSAdvisoryConsumerMsgInProgress is a notification published when a message is marked as in-progress.
+	JSAdvisoryConsumerMsgInProgress = "$JS.EVENT.ADVISORY.CONSUMER.IN_PROGRESS"
+
 	// JSAdvisoryStreamCreatedPre notification that a stream was created.
 	JSAdvisoryStreamCreatedPre = "$JS.EVENT.ADVISORY.STREAM.CREATED"
 

--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -160,6 +160,21 @@ type JSConsumerDeliveryTerminatedAdvisory struct {
 	Domain      string `json:"domain,omitempty"`
 }
 
+// JSConsumerDeliveryInProgressType is the schema type for JSConsumerDeliveryInProgress
+const JSConsumerDeliveryInProgressType = "io.nats.jetstream.advisory.v1.in_progress"
+
+// JSConsumerDeliveryInProgress is a advisory informing that a message was
+// InProgress'ed by a consumer
+type JSConsumerDeliveryInProgress struct {
+	TypedEvent
+	Stream      string `json:"stream"`
+	StreamSeq   uint64 `json:"stream_seq"`
+	Consumer    string `json:"consumer"`
+	ConsumerSeq uint64 `json:"consumer_seq"`
+	Deliveries  uint64 `json:"deliveries"`
+	Domain      string `json:"domain,omitempty"`
+}
+
 // JSConsumerDeliveryTerminatedAdvisoryType is the schema type for JSConsumerDeliveryTerminatedAdvisory
 const JSConsumerDeliveryTerminatedAdvisoryType = "io.nats.jetstream.advisory.v1.terminated"
 


### PR DESCRIPTION
~~This allows a job queue controller to detect whether a job has started / is being worked on.~~
InProgress is also the only ACK message that does not have a corresponding advisory message, so this fills the gap.

<!-- Please make sure to read CONTRIBUTING.md, then delete this notice and replace it with your PR description. The below sign-off certifies that the contribution is your original work and that you license the work to the project under the Apache-2.0 license. We cannot accept contributions without it. -->

Signed-off-by: Benjamin Sparks <b.sparks@alugha.com>
