### PR TITLE
Correct and simplify stream assignment check

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1101,18 +1101,7 @@ func (cc *jetStreamCluster) isStreamAssigned(a *Account, stream string) bool {
 	if sa == nil {
 		return false
 	}
-	rg := sa.Group
-	if rg == nil {
-		return false
-	}
-	// Check if we are the leader of this raftGroup assigned to the stream.
-	ourID := cc.meta.ID()
-	for _, peer := range rg.Peers {
-		if peer == ourID {
-			return true
-		}
-	}
-	return false
+	return sa.Group.isMember(cc.meta.ID())
 }
 
 // Read lock should be held.
@@ -5307,15 +5296,7 @@ func (cc *jetStreamCluster) isConsumerAssigned(a *Account, stream, consumer stri
 	if ca == nil {
 		return false
 	}
-	rg := ca.Group
-	// Check if we are the leader of this raftGroup assigned to the stream.
-	ourID := cc.meta.ID()
-	for _, peer := range rg.Peers {
-		if peer == ourID {
-			return true
-		}
-	}
-	return false
+	return ca.Group.isMember(cc.meta.ID())
 }
 
 // Returns our stream and underlying raft node.


### PR DESCRIPTION
Remove misleading comment for the loop at the end of isStreamAssigned: "Check if we are the leader of this raftGroup [...]". This code is checking for membership, not leadership of the group.
Instead of fixing the comment, replace the whole loop with a call to isMember.
Same for isConsumerAssigned.

Signed-off-by: Daniele Sciascia <daniele@nats.io>
