### PR TITLE
Fixes handling a batched direct get request where the starting sequence number requested is deleted

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -5134,8 +5134,8 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 			err error
 		)
 		if seq > 0 && req.NextFor == _EMPTY_ {
-			// Only do direct lookup for first in a batch.
-			if i == 0 {
+			// Only do direct lookup for a non batch.
+			if i == 0 && !isBatchRequest {
 				sm, err = store.LoadMsg(seq, &svp)
 			} else {
 				// We want to use load next with fwcs to step over deleted msgs.


### PR DESCRIPTION
When processing a direct get batch (even without NextFor) deleted messages are skipped over. This fixes/extends this so the skipping also happens if the requested sequence number happens to be deleted.

Signed-off-by: Jean-Noël Moyne <jnmoyne@gmail.com>