### PR TITLE
NRG: Replay snapshot upon timeout instead of reset

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -32,6 +32,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/klauspost/compress/s2"
 	"github.com/minio/highwayhash"
 	"github.com/nats-io/nuid"
@@ -2677,6 +2678,14 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 							mset.retryMirrorConsumer()
 							continue
 						}
+						// If the error signals we timed out of a snapshot, we should try to replay the snapshot
+						// instead of fully resetting the state. Resetting the clustered state may result in
+						// race conditions and should only be used as a last effort attempt.
+						if errors.Is(err, errCatchupAbortedNoLeader) || err == errCatchupTooManyRetries {
+							if node := mset.raftNode(); node != nil && node.DrainAndReplaySnapshot() {
+								break
+							}
+						}
 						// We will attempt to reset our cluster state.
 						if mset.resetClusteredState(err) {
 							aq.recycle(&ces)
@@ -3027,9 +3036,15 @@ func (mset *stream) isMigrating() bool {
 // resetClusteredState is called when a clustered stream had an error (e.g sequence mismatch, bad snapshot) and needs to be reset.
 func (mset *stream) resetClusteredState(err error) bool {
 	mset.mu.RLock()
-	s, js, jsa, sa, acc, node := mset.srv, mset.js, mset.jsa, mset.sa, mset.acc, mset.node
+	s, js, jsa, sa, acc, node, name := mset.srv, mset.js, mset.jsa, mset.sa, mset.acc, mset.node, mset.nameLocked(false)
 	stype, tierName, replicas := mset.cfg.Storage, mset.tier, mset.cfg.Replicas
 	mset.mu.RUnlock()
+
+	assert.Unreachable("Reset clustered state", map[string]any{
+		"stream":  name,
+		"account": acc.Name,
+		"err":     err,
+	})
 
 	// The stream might already be deleted and not assigned to us anymore.
 	// In any case, don't revive the stream if it's already closed.
@@ -9125,6 +9140,14 @@ func (mset *stream) processSnapshot(snap *StreamReplicatedState, index uint64) (
 	qname := fmt.Sprintf("[ACC:%s] stream '%s' snapshot", mset.acc.Name, mset.cfg.Name)
 	mset.mu.Unlock()
 
+	// Always try to resume applies, we might be paused already if we timed out of processing the snapshot previously.
+	defer func() {
+		// Don't bother resuming if server or stream is gone.
+		if e != errCatchupStreamStopped && e != ErrServerNotRunning {
+			n.ResumeApply()
+		}
+	}()
+
 	// Bug that would cause this to be empty on stream update.
 	if subject == _EMPTY_ {
 		return errCatchupCorruptSnapshot
@@ -9139,13 +9162,6 @@ func (mset *stream) processSnapshot(snap *StreamReplicatedState, index uint64) (
 	if err := n.PauseApply(); err != nil {
 		return err
 	}
-
-	defer func() {
-		// Don't bother resuming if server or stream is gone.
-		if e != errCatchupStreamStopped && e != ErrServerNotRunning {
-			n.ResumeApply()
-		}
-	}()
 
 	// Set our catchup state.
 	mset.setCatchingUp()

--- a/server/raft.go
+++ b/server/raft.go
@@ -76,6 +76,7 @@ type RaftNode interface {
 	ApplyQ() *ipQueue[*CommittedEntry]
 	PauseApply() error
 	ResumeApply()
+	DrainAndReplaySnapshot() bool
 	LeadChangeC() <-chan bool
 	QuitC() <-chan struct{}
 	Created() time.Time
@@ -1040,10 +1041,13 @@ func (n *raft) PauseApply() error {
 	if n.State() == Leader {
 		return errAlreadyLeader
 	}
-
 	n.Lock()
 	defer n.Unlock()
+	n.pauseApplyLocked()
+	return nil
+}
 
+func (n *raft) pauseApplyLocked() {
 	// If we are currently a candidate make sure we step down.
 	if n.State() == Candidate {
 		n.stepdownLocked(noLeader)
@@ -1051,11 +1055,11 @@ func (n *raft) PauseApply() error {
 
 	n.debug("Pausing our apply channel")
 	n.paused = true
-	n.hcommit = n.commit
+	if n.hcommit < n.commit {
+		n.hcommit = n.commit
+	}
 	// Also prevent us from trying to become a leader while paused and catching up.
 	n.resetElect(observerModeInterval)
-
-	return nil
 }
 
 // ResumeApply will resume sending applies to the external apply queue. This
@@ -1105,6 +1109,25 @@ func (n *raft) ResumeApply() {
 	} else {
 		n.resetElectionTimeout()
 	}
+}
+
+// DrainAndReplaySnapshot will drain the apply queue and replay the snapshot.
+// Our highest known commit will be preserved by pausing applies. The caller
+// should make sure to call ResumeApply() when handling the snapshot from the
+// queue, which will populate the rest of the committed entries in the queue.
+func (n *raft) DrainAndReplaySnapshot() bool {
+	n.Lock()
+	defer n.Unlock()
+	n.warn("Draining and replaying snapshot")
+	snap, err := n.loadLastSnapshot()
+	if err != nil {
+		return false
+	}
+	n.pauseApplyLocked()
+	n.apply.drain()
+	n.commit = snap.lastIndex
+	n.apply.push(newCommittedEntry(n.commit, []*Entry{{EntrySnapshot, snap.data}}))
+	return true
 }
 
 // Applied is a callback that must be called by the upper layer when it

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -3535,6 +3535,91 @@ func TestNRGSendAppendEntryNotLeader(t *testing.T) {
 	require_True(t, msg == nil)
 }
 
+func TestNRGDrainAndReplaySnapshot(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// Create a sample entry, the content doesn't matter, just that it's stored.
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	// Timeline
+	aeMsg1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+	aeMsg2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 1, entries: entries})
+	aeMsg3 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 2, entries: entries})
+	aeHeartbeat1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 3, pterm: 1, pindex: 3, entries: nil})
+	aeMsg4 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 3, pterm: 1, pindex: 3, entries: entries})
+	aeHeartbeat2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 4, pterm: 1, pindex: 4, entries: nil})
+
+	// Stage some entries as normal.
+	require_Len(t, n.apply.len(), 0)
+	n.processAppendEntry(aeMsg1, n.aesub)
+	n.processAppendEntry(aeMsg2, n.aesub)
+	n.processAppendEntry(aeMsg3, n.aesub)
+	n.processAppendEntry(aeHeartbeat1, n.aesub)
+	require_Equal(t, n.pindex, 3)
+	require_Len(t, n.apply.len(), 3)
+	require_Equal(t, n.commit, 3)
+	require_Equal(t, n.hcommit, 0)
+
+	// Just a sanity-check, if we have no snapshot then this should fail.
+	require_False(t, n.DrainAndReplaySnapshot())
+	require_Len(t, n.apply.len(), 3)
+	require_Equal(t, n.commit, 3)
+	require_Equal(t, n.hcommit, 0)
+
+	// Simulate this server processing a snapshot that requires upper layer catchup.
+	// This catchup timed out and we would then call into DrainAndReplaySnapshot.
+	snap := []byte("snapshot")
+	n.Applied(1)
+	require_NoError(t, n.InstallSnapshot(snap))
+
+	require_True(t, n.DrainAndReplaySnapshot())
+	require_True(t, n.paused)
+	require_Len(t, n.apply.len(), 1)
+	require_Equal(t, n.commit, 1)
+	require_Equal(t, n.hcommit, 3)
+
+	// Simulate snapshot processing being successful and restoring the apply queue when resuming.
+	n.ResumeApply()
+	require_False(t, n.paused)
+	require_Len(t, n.apply.len(), 3)
+	require_Equal(t, n.commit, 3)
+	require_Equal(t, n.hcommit, 0)
+
+	// Now simulate another case where the snapshot processing times out multiple times.
+	require_True(t, n.DrainAndReplaySnapshot())
+	require_True(t, n.paused)
+	require_Len(t, n.apply.len(), 1)
+	require_Equal(t, n.commit, 1)
+	require_Equal(t, n.hcommit, 3)
+
+	// Could receive new messages in the meantime and need to keep tracking the highest known commit properly.
+	n.processAppendEntry(aeMsg4, n.aesub)
+	n.processAppendEntry(aeHeartbeat2, n.aesub)
+	require_Equal(t, n.pindex, 4)
+	require_True(t, n.paused)
+	require_Len(t, n.apply.len(), 1)
+	require_Equal(t, n.commit, 1)
+	require_Equal(t, n.hcommit, 4)
+
+	// Replaying again should preserve the highest known commit.
+	require_True(t, n.DrainAndReplaySnapshot())
+	require_True(t, n.paused)
+	require_Len(t, n.apply.len(), 1)
+	require_Equal(t, n.commit, 1)
+	require_Equal(t, n.hcommit, 4)
+
+	// Resume applies, and ensure correct state.
+	n.ResumeApply()
+	require_False(t, n.paused)
+	require_Len(t, n.apply.len(), 4)
+	require_Equal(t, n.commit, 4)
+	require_Equal(t, n.hcommit, 0)
+}
+
 // This is a RaftChainOfBlocks test where a block is proposed and then we wait for all replicas to apply it before
 // proposing the next one.
 // The test may fail if:


### PR DESCRIPTION
`mset.resetClusteredState` can be the source of many issues due to race conditions. When something has already gone very wrong with replication then it's a good last effort way to try and get us out of this situation. However, we should never be resetting the whole state as a result of a stream snapshot timing out due to no leader or exceeding retries.

This PR changes this such that we "just" replay the snapshot and allow us to re-send entries into the apply queue afterward. When running under Antithesis this has shown to resolve many health-related issues such as "node skew" where the Raft node for the stream/consumer assignment is different than what is actually being used for the stream/consumer. 

Closely related to https://github.com/nats-io/nats-server/pull/7249, this was very likely to be part of the cause of the monitor goroutine not being shutdown. Hypothetically due to the above node skew issue.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
