### PR TITLE
(2.12) Atomic batch: improve large batch error and advisory

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -1970,10 +1970,10 @@
     "deprecates": ""
   },
   {
-    "constant": "JSAtomicPublishTooLargeBatchErr",
+    "constant": "JSAtomicPublishTooLargeBatchErrF",
     "code": 400,
     "error_code": 10199,
-    "description": "atomic publish batch is too large",
+    "description": "atomic publish batch is too large: {size}",
     "comment": "",
     "help": "",
     "url": "",

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -303,7 +303,7 @@ func TestJetStreamAtomicBatchPublishLimits(t *testing.T) {
 					require_True(t, pubAck.Error == nil)
 					require_Equal(t, pubAck.BatchSize, size)
 				} else {
-					require_Error(t, pubAck.Error, NewJSAtomicPublishIncompleteBatchError())
+					require_Error(t, pubAck.Error, NewJSAtomicPublishTooLargeBatchError(streamMaxBatchSize))
 				}
 			}
 		}
@@ -2052,7 +2052,7 @@ func TestJetStreamAtomicBatchPublishAdvisories(t *testing.T) {
 			require_NoError(t, err)
 			require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
 			require_NotNil(t, pubAck.Error)
-			require_Error(t, pubAck.Error, NewJSAtomicPublishTooLargeBatchError())
+			require_Error(t, pubAck.Error, NewJSAtomicPublishTooLargeBatchError(streamDefaultMaxBatchSize))
 		}
 
 		msg, err = sub.NextMsg(time.Second)
@@ -2060,7 +2060,7 @@ func TestJetStreamAtomicBatchPublishAdvisories(t *testing.T) {
 		advisory = JSStreamBatchAbandonedAdvisory{}
 		require_NoError(t, json.Unmarshal(msg.Data, &advisory))
 		require_Equal(t, advisory.BatchId, "uuid")
-		require_Equal(t, advisory.Reason, BatchTimeout)
+		require_Equal(t, advisory.Reason, BatchLarge)
 	}
 
 	for _, replicas := range []int{1, 3} {

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -20,8 +20,8 @@ const (
 	// JSAtomicPublishMissingSeqErr atomic publish sequence is missing
 	JSAtomicPublishMissingSeqErr ErrorIdentifier = 10175
 
-	// JSAtomicPublishTooLargeBatchErr atomic publish batch is too large
-	JSAtomicPublishTooLargeBatchErr ErrorIdentifier = 10199
+	// JSAtomicPublishTooLargeBatchErrF atomic publish batch is too large: {size}
+	JSAtomicPublishTooLargeBatchErrF ErrorIdentifier = 10199
 
 	// JSAtomicPublishUnsupportedHeaderBatchErr atomic publish unsupported header used: {header}
 	JSAtomicPublishUnsupportedHeaderBatchErr ErrorIdentifier = 10177
@@ -607,7 +607,7 @@ var (
 		JSAtomicPublishIncompleteBatchErr:            {Code: 400, ErrCode: 10176, Description: "atomic publish batch is incomplete"},
 		JSAtomicPublishInvalidBatchIDErr:             {Code: 400, ErrCode: 10179, Description: "atomic publish batch ID is invalid"},
 		JSAtomicPublishMissingSeqErr:                 {Code: 400, ErrCode: 10175, Description: "atomic publish sequence is missing"},
-		JSAtomicPublishTooLargeBatchErr:              {Code: 400, ErrCode: 10199, Description: "atomic publish batch is too large"},
+		JSAtomicPublishTooLargeBatchErrF:             {Code: 400, ErrCode: 10199, Description: "atomic publish batch is too large: {size}"},
 		JSAtomicPublishUnsupportedHeaderBatchErr:     {Code: 400, ErrCode: 10177, Description: "atomic publish unsupported header used: {header}"},
 		JSBadRequestErr:                              {Code: 400, ErrCode: 10003, Description: "bad request"},
 		JSClusterIncompleteErr:                       {Code: 503, ErrCode: 10004, Description: "incomplete results"},
@@ -875,14 +875,20 @@ func NewJSAtomicPublishMissingSeqError(opts ...ErrorOption) *ApiError {
 	return ApiErrors[JSAtomicPublishMissingSeqErr]
 }
 
-// NewJSAtomicPublishTooLargeBatchError creates a new JSAtomicPublishTooLargeBatchErr error: "atomic publish batch is too large"
-func NewJSAtomicPublishTooLargeBatchError(opts ...ErrorOption) *ApiError {
+// NewJSAtomicPublishTooLargeBatchError creates a new JSAtomicPublishTooLargeBatchErrF error: "atomic publish batch is too large: {size}"
+func NewJSAtomicPublishTooLargeBatchError(size interface{}, opts ...ErrorOption) *ApiError {
 	eopts := parseOpts(opts)
 	if ae, ok := eopts.err.(*ApiError); ok {
 		return ae
 	}
 
-	return ApiErrors[JSAtomicPublishTooLargeBatchErr]
+	e := ApiErrors[JSAtomicPublishTooLargeBatchErrF]
+	args := e.toReplacerArgs([]interface{}{"{size}", size})
+	return &ApiError{
+		Code:        e.Code,
+		ErrCode:     e.ErrCode,
+		Description: strings.NewReplacer(args...).Replace(e.Description),
+	}
 }
 
 // NewJSAtomicPublishUnsupportedHeaderBatchError creates a new JSAtomicPublishUnsupportedHeaderBatchErr error: "atomic publish unsupported header used: {header}"

--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -270,6 +270,7 @@ type BatchAbandonReason string
 
 var (
 	BatchTimeout    BatchAbandonReason = "timeout"
+	BatchLarge      BatchAbandonReason = "large"
 	BatchIncomplete BatchAbandonReason = "incomplete"
 )
 


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/7274, improves the advisory when a batch is too large, and improves the error message to return the defined max batch size.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>