### PR TITLE
Filestore fixes

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7106,11 +7106,10 @@ func (mb *msgBlock) flushPendingMsgsLocked() (*LostStreamData, error) {
 	} else {
 		if cap(mb.cache.buf) <= maxBufReuse {
 			buf = mb.cache.buf[:0]
-		} else {
+		} else if moreBytes == 0 {
 			recycleMsgBlockBuf(mb.cache.buf)
 			buf = nil
-		}
-		if moreBytes > 0 {
+		} else {
 			nbuf := mb.cache.buf[len(mb.cache.buf)-moreBytes:]
 			if moreBytes > (len(mb.cache.buf)/4*3) && cap(nbuf) <= maxBufReuse {
 				buf = nbuf

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7262,7 +7262,7 @@ func (mb *msgBlock) loadMsgsWithLock() error {
 checkCache:
 	nchecks++
 	if nchecks > 8 {
-		return errCorruptState
+		return errNoCache
 	}
 
 	// Check to see if we have a full cache.


### PR DESCRIPTION
This PR fixes the following filestore bugs:

- `flushPendingMsgsLocked` could, in some cases, hold onto a buffer after returning it to the pool, which could result in corruption
- `flushPendingMsgsLocked` was not making best use of reused buffers as the head of the buffer was left as "dead space" rather than reclaiming it
- `loadMsgsWithLock` would incorrectly report failing to load the cache as though there is corruption

Signed-off-by: Neil Twigg <neil@nats.io>