### PR TITLE
Set build host in goreleaser to have reproducible rpms

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,6 +68,8 @@ nfpms:
       - src: /usr/bin/nats-server
         dst: /usr/local/bin/nats-server
         type: "symlink"
+    rpm:
+      buildhost: synadia.com
 
 archives:
   - name_template: "{{.ProjectName}}-{{.Tag}}-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}"


### PR DESCRIPTION
Follow-up to https://github.com/nats-io/nats-server/pull/6359 and https://github.com/nats-io/nats-server/pull/6701

Since 2.11.2 version of goreleaser, it is allowed to set buildhost for RPMs
https://github.com/orgs/goreleaser/discussions/5662

I believe with this all the rpms, debs and tars will be reproducible(the binaries have been reproducible for long time) 

## Test plan:
```
# go clean -cache && goreleaser  release --skip=announce,publish,validate --clean -f .goreleaser.yml
```

```
# rpm -qip nats-server-v2.12.0-RC.3-s390x.rpm | grep -i 'Build Host'

Build Host  : synadia.com
```


Signed-off-by: Alex Bozhenko <alexbozhenko@gmail.com>
