### PR TITLE
remove broken Windows ARM builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,6 +43,8 @@ builds:
       - 6
       - 7
     ignore:
+      - goos: windows
+        goarch: arm
       - goos: darwin
         goarch: 386
       - goos: freebsd


### PR DESCRIPTION
ARM (but not arm64) is broken on windows.

Latest Goreleaser(2.12) started to complain about this:
```
# go clean -cache && goreleaser  release --skip=announce,publish,validate --clean -f .goreleaser.yml
...
    ⨯ broken target, use at your own risk            target=windows_arm_6
    ⨯ broken target, use at your own risk            target=windows_arm_7
```

Support is to be removed from Golang. Stop building for ARM on Windows
https://github.com/golang/go/issues/70705
https://go.dev/wiki/GoArm
https://github.com/goreleaser/goreleaser/pull/5951
https://golang.google.cn/doc/go1.24#windows
https://golang.google.cn/doc/go1.25#windows


```
# GOTOOLCHAIN=go1.25.1 go tool dist list -broken -json   | jq '.[] | select(.GOOS == "windows") | select(.Broken == true)'
{
  "GOOS": "windows",
  "GOARCH": "arm",
  "CgoSupported": false,
  "FirstClass": false,
  "Broken": true
}
```

Also, judging by the number of downlads, 
it looks like only automated scripts and not real people download those builds.
https://somsubhra.github.io/github-release-stats/?username=nats-io&repository=nats-server

## Test plan:
```
# go clean -cache && goreleaser  release --skip=announce,publish,validate --clean -f .goreleaser.yml

# diff -u <(ls -1 dist_before/) <(ls -1 dist/)
--- /dev/fd/63  2025-09-12 12:43:38.071393996 -0700
+++ /dev/fd/62  2025-09-12 12:43:38.072393998 -0700
@@ -61,13 +61,7 @@
 nats-server-v2.12.0-RC.3-windows-amd64.zip
 nats-server-v2.12.0-RC.3-windows-arm64.sbom.spdx.json
 nats-server-v2.12.0-RC.3-windows-arm64.zip
-nats-server-v2.12.0-RC.3-windows-arm6.sbom.spdx.json
-nats-server-v2.12.0-RC.3-windows-arm6.zip
-nats-server-v2.12.0-RC.3-windows-arm7.sbom.spdx.json
-nats-server-v2.12.0-RC.3-windows-arm7.zip
 nats-server_windows_386_sse2
 nats-server_windows_amd64_v1
-nats-server_windows_arm_6
 nats-server_windows_arm64_v8.0
-nats-server_windows_arm_7
 SHA256SUMS
```

Signed-off-by: Alex Bozhenko <alexbozhenko@gmail.com>
