### PR TITLE
(2.12) Atomic batch: fix R1 expected last seq

### DIFF
--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -444,6 +444,10 @@ func checkMsgHeadersPreClusteredProposal(
 			mlseq := mset.clseq - mset.clfs
 			err := fmt.Errorf("last sequence mismatch: %d vs %d", seq, mlseq)
 			return hdr, msg, 0, NewJSStreamWrongLastSequenceError(mlseq), err
+		} else if exists && len(diff.inflight) > 0 {
+			// Only the first message in a batch can contain an expected last sequence.
+			err := fmt.Errorf("last sequence mismatch")
+			return hdr, msg, 0, NewJSStreamWrongLastSequenceConstantError(), err
 		}
 
 		// Expected last sequence per subject.


### PR DESCRIPTION
`Nats-Expected-Last-Sequence` would not work correctly when batching on a R1 stream. It now also properly errors when the header is used but it's not the first message in the batch.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>