### PR TITLE
(2.12) Atomic batch: support empty acks

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -6297,6 +6297,10 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 	}
 	if !commit {
 		batches.mu.Unlock()
+		// Send empty ack to let them know we've persisted the data prior to commit.
+		if canRespond {
+			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, nil, nil, 0))
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Add support for empty acks, this allows sending the first (or all) messages as requests instead of fire-and-forget publishes. These empty acks can be used for flow control, making sure the remainder of the batch is not wasted if it would just be rejected when the commit comes in, etc.

In general, clients can use this construct when they need more control.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>