### PR TITLE
(2.12) Atomic batch: correctly track partial batch in same append entry

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3218,7 +3218,8 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				// Previous batch (if any) was abandoned.
 				if batch.id != _EMPTY_ && batchId != batch.id {
 					batch.rejectBatchStateLocked(mset)
-				} else if batchSeq == 1 {
+				}
+				if batchSeq == 1 {
 					// If this is the first message in the batch, need to mark the start index.
 					// We'll continue to check batch-completeness and try to find the commit.
 					// At that point we'll commit the whole batch.
@@ -3256,7 +3257,8 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				// Previous batch (if any) was abandoned.
 				if batch.id != _EMPTY_ && batchId != batch.id {
 					batch.rejectBatchStateLocked(mset)
-				} else if batchSeq == 1 {
+				}
+				if batchSeq == 1 {
 					// If this is the first message in the batch, need to mark the start index.
 					// This is a batch of size one that immediately commits.
 					batch.rejectBatchStateLocked(mset)


### PR DESCRIPTION
If a batch was partially committed and a new batch comes in, it would correctly reject the partial batch but it wouldn't do the proper accounting for `entryStart` and `maxApplied` but only if both were in the same append entry.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>