### PR TITLE
(2.12) Filestore fixes

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1702,6 +1702,10 @@ func TestFileStorePartialCacheExpiration(t *testing.T) {
 }
 
 func TestFileStorePartialIndexes(t *testing.T) {
+	// TODO(nat): This test is no longer applicable as we no longer have positional
+	// write caches but check before removing whether it proves anything else of value.
+	t.SkipNow()
+
 	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
 		cexp := 10 * time.Millisecond
 		fcfg.CacheExpire = cexp


### PR DESCRIPTION
This PR fixes some of the elastic pointer handling when setting up the write cache.

It also removes the positional/partial write cache and the associated offset altogether. Previously it was possible to create a partial cache for writes with an offset, but this creates a logical race condition between the flusher and whether or not another read happens in the interim. If this happens then the presence of the offset will cause any pending writes to be lost as the cache is considered to be not loaded and therefore is blown away. This creates a consistency issue when async flushes are enabled and can result in corrupted blocks.

It also tweaks the TTL code to satisfy some tests.

Signed-off-by: Neil Twigg <neil@nats.io>
