### PR TITLE
(2.12) [FIXED] Remove msg schedule header in reverse order

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4337,7 +4337,7 @@ func (c *client) setupResponseServiceImport(acc *Account, si *serviceImport, tra
 
 // Will remove a header if present.
 func removeHeaderIfPresent(hdr []byte, key string) []byte {
-	start := bytes.Index(hdr, []byte(key))
+	start := bytes.Index(hdr, []byte(key+":"))
 	// key can't be first and we want to check that it is preceded by a '\n'
 	if start < 1 || hdr[start-1] != '\n' {
 		return hdr


### PR DESCRIPTION
The same issue that was fixed here: https://github.com/nats-io/nats-server/pull/7065, but now for removing the `Nats-Schedule-Target` and `Nats-Schedule` header for the delayed message. The latter header was not removed if the target header was defined first. This would prevent the delayed message from being scheduled.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>