### PR TITLE
(2.12) Default persist mode for empty string

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -22012,6 +22012,11 @@ func TestJetStreamPersistModeAsync(t *testing.T) {
 	require_NoError(t, err)
 	fs := mset.store.(*fileStore)
 	fs.mu.RLock()
-	defer fs.mu.RUnlock()
-	require_True(t, fs.fcfg.AsyncFlush)
+	asyncFlush := fs.fcfg.AsyncFlush
+	fs.mu.RUnlock()
+	require_True(t, asyncFlush)
+
+	cfg.PersistMode = DefaultPersistMode
+	_, err = jsStreamUpdate(t, nc, cfg)
+	require_Error(t, err, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration update can not change persist mode")))
 }

--- a/server/stream.go
+++ b/server/stream.go
@@ -227,7 +227,7 @@ func (wc PersistModeType) MarshalJSON() ([]byte, error) {
 
 func (wc *PersistModeType) UnmarshalJSON(data []byte) error {
 	switch string(data) {
-	case defaultPersistModeJSONString:
+	case defaultPersistModeJSONString, `""`:
 		*wc = DefaultPersistMode
 	case asyncPersistModeJSONString:
 		*wc = AsyncPersistMode
@@ -2152,6 +2152,10 @@ func (jsa *jsAccount) configUpdateCheck(old, new *StreamConfig, s *Server, pedan
 	// Can't disable message schedules setting.
 	if old.AllowMsgSchedules && !cfg.AllowMsgSchedules {
 		return nil, NewJSStreamInvalidConfigError(fmt.Errorf("message schedules can not be disabled"))
+	}
+
+	if old.PersistMode != cfg.PersistMode {
+		return nil, NewJSStreamInvalidConfigError(fmt.Errorf("stream configuration update can not change persist mode"))
 	}
 
 	// Do some adjustments for being sealed.


### PR DESCRIPTION
Empty string gets turned into the default persist mode. Updating the persist mode is currently not allowed.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>