### PR TITLE
(2.12) [FIXED] Atomic batch: batch timeout advisory

### DIFF
--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -58,6 +58,7 @@ func (batches *batching) newBatchGroup(mset *stream, batchId string) (*batchGrou
 	}
 	b.timer = time.AfterFunc(timeout, func() {
 		b.cleanup(batchId, batches)
+		mset.sendStreamBatchAbandonedAdvisory(batchId, BatchTimeout)
 	})
 	return b, nil
 }

--- a/server/stream.go
+++ b/server/stream.go
@@ -6372,7 +6372,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 		if err != nil || seq != batchSeq {
 			b.cleanupLocked(batchId, batches)
 			batches.mu.Unlock()
-			mset.sendStreamBatchAbandonedAdvisory(batchId, BatchTimeout)
+			mset.sendStreamBatchAbandonedAdvisory(batchId, BatchIncomplete)
 			return respondIncompleteBatch()
 		}
 	}


### PR DESCRIPTION
The batch timeout advisory was not sent if the batch timed out and was cleaned up.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>