### PR TITLE
(2.12) [FIXED] Use correct subject when doing batch check

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -6482,7 +6482,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 			return errorOnUnsupported(seq, JSExpectedLastMsgId)
 		}
 
-		if bhdr, bmsg, _, apiErr, err = checkMsgHeadersPreClusteredProposal(diff, mset, subject, bhdr, bmsg, false, name, jsa, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, discard, discardNewPer, maxMsgSize, maxMsgs, maxMsgsPer, maxBytes); err != nil {
+		if bhdr, bmsg, _, apiErr, err = checkMsgHeadersPreClusteredProposal(diff, mset, bsubj, bhdr, bmsg, false, name, jsa, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, discard, discardNewPer, maxMsgSize, maxMsgs, maxMsgsPer, maxBytes); err != nil {
 			rollback(seq)
 			b.cleanupLocked(batchId, batches)
 			batches.mu.Unlock()


### PR DESCRIPTION
Should use the subject for the current entry in the batch, not the last subject that does the commit.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>