### PR TITLE
[FIXED] Fix subject tree intersection to match literals when combined with partial wildcards

### DIFF
--- a/server/gsl/gsl_test.go
+++ b/server/gsl/gsl_test.go
@@ -397,6 +397,18 @@ func TestGenericSublistInterestBasedIntersection(t *testing.T) {
 		require_NoDuplicates(t, got)
 	})
 
+	t.Run("PWCExtended", func(t *testing.T) {
+		got := map[string]int{}
+		sl := NewSublist[int]()
+		require_NoError(t, sl.Insert("stream.*.child", 11))
+		require_NoError(t, sl.Insert("stream.A", 22))
+		IntersectStree(st, sl, func(subj []byte, entry *struct{}) {
+			got[string(subj)]++
+		})
+		require_Len(t, len(got), 2)
+		require_NoDuplicates(t, got)
+	})
+
 	t.Run("FWCAll", func(t *testing.T) {
 		got := map[string]int{}
 		sl := NewSublist[int]()

--- a/server/gsl/gsl_test.go
+++ b/server/gsl/gsl_test.go
@@ -409,6 +409,23 @@ func TestGenericSublistInterestBasedIntersection(t *testing.T) {
 		require_NoDuplicates(t, got)
 	})
 
+	t.Run("PWCExtendedAggressive", func(t *testing.T) {
+		got := map[string]int{}
+		sl := NewSublist[int]()
+		require_NoError(t, sl.Insert("stream.A.child", 11))
+		require_NoError(t, sl.Insert("*.A.child", 22))
+		require_NoError(t, sl.Insert("stream.*.child", 22))
+		require_NoError(t, sl.Insert("stream.A.*", 22))
+		require_NoError(t, sl.Insert("stream.*.*", 22))
+		require_NoError(t, sl.Insert("*.A.*", 22))
+		require_NoError(t, sl.Insert("*.*.child", 22))
+		IntersectStree(st, sl, func(subj []byte, entry *struct{}) {
+			got[string(subj)]++
+		})
+		require_Len(t, len(got), 1)
+		require_NoDuplicates(t, got)
+	})
+
 	t.Run("FWCAll", func(t *testing.T) {
 		got := map[string]int{}
 		sl := NewSublist[int]()

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -1758,13 +1758,14 @@ func intersectStree[T any](st *stree.SubjectTree[T], r *level, subj []byte, cb f
 	if len(nsubj) > 0 {
 		nsubj = append(subj, '.')
 	}
-	switch {
-	case r.fwc != nil:
+	if r.fwc != nil {
 		// We've reached a full wildcard, do a FWC match on the stree at this point
 		// and don't keep iterating downward.
 		nsubj := append(nsubj, '>')
 		st.Match(nsubj, cb)
-	case r.pwc != nil:
+		return
+	}
+	if r.pwc != nil {
 		// We've found a partial wildcard. We'll keep iterating downwards, but first
 		// check whether there's interest at this level (without triggering dupes) and
 		// match if so.
@@ -1775,22 +1776,27 @@ func intersectStree[T any](st *stree.SubjectTree[T], r *level, subj []byte, cb f
 		if r.pwc.next != nil && r.pwc.next.numNodes() > 0 {
 			intersectStree(st, r.pwc.next, nsubj, cb)
 		}
-	default:
-		// Normal node with subject literals, keep iterating.
-		for t, n := range r.nodes {
-			nsubj := append(nsubj, t...)
-			if len(n.psubs)+len(n.qsubs) > 0 {
-				if subjectHasWildcard(bytesToString(nsubj)) {
-					st.Match(nsubj, cb)
-				} else {
-					if e, ok := st.Find(nsubj); ok {
-						cb(nsubj, e)
-					}
+	}
+	// Normal node with subject literals, keep iterating.
+	for t, n := range r.nodes {
+		// Skip if a partial wildcard exists, and this node fully overlaps.
+		if r.pwc != nil &&
+			(r.pwc.next == nil || r.pwc.next.numNodes() == 0) &&
+			(n.next == nil || n.next.numNodes() == 0) {
+			continue
+		}
+		nsubj := append(nsubj, t...)
+		if len(n.psubs)+len(n.qsubs) > 0 {
+			if subjectHasWildcard(bytesToString(nsubj)) {
+				st.Match(nsubj, cb)
+			} else {
+				if e, ok := st.Find(nsubj); ok {
+					cb(nsubj, e)
 				}
 			}
-			if n.next != nil && n.next.numNodes() > 0 {
-				intersectStree(st, n.next, nsubj, cb)
-			}
+		}
+		if n.next != nil && n.next.numNodes() > 0 {
+			intersectStree(st, n.next, nsubj, cb)
 		}
 	}
 }

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -995,6 +995,9 @@ func (n *node) isEmpty() bool {
 
 // Return the number of nodes for the given level.
 func (l *level) numNodes() int {
+	if l == nil {
+		return 0
+	}
 	num := len(l.nodes)
 	if l.pwc != nil {
 		num++
@@ -1769,20 +1772,24 @@ func intersectStree[T any](st *stree.SubjectTree[T], r *level, subj []byte, cb f
 		// We've found a partial wildcard. We'll keep iterating downwards, but first
 		// check whether there's interest at this level (without triggering dupes) and
 		// match if so.
+		var done bool
 		nsubj := append(nsubj, '*')
 		if len(r.pwc.psubs)+len(r.pwc.qsubs) > 0 {
 			st.Match(nsubj, cb)
+			done = true
 		}
-		if r.pwc.next != nil && r.pwc.next.numNodes() > 0 {
+		if r.pwc.next.numNodes() > 0 {
 			intersectStree(st, r.pwc.next, nsubj, cb)
+		}
+		if done {
+			return
 		}
 	}
 	// Normal node with subject literals, keep iterating.
 	for t, n := range r.nodes {
-		// Skip if a partial wildcard exists, and this node fully overlaps.
-		if r.pwc != nil &&
-			(r.pwc.next == nil || r.pwc.next.numNodes() == 0) &&
-			(n.next == nil || n.next.numNodes() == 0) {
+		if r.pwc != nil && r.pwc.next.numNodes() > 0 && n.next.numNodes() > 0 {
+			// A wildcard at the next level will already visit these descendents
+			// so skip so we don't callback the same subject more than once.
 			continue
 		}
 		nsubj := append(nsubj, t...)
@@ -1795,7 +1802,7 @@ func intersectStree[T any](st *stree.SubjectTree[T], r *level, subj []byte, cb f
 				}
 			}
 		}
-		if n.next != nil && n.next.numNodes() > 0 {
+		if n.next.numNodes() > 0 {
 			intersectStree(st, n.next, nsubj, cb)
 		}
 	}

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -2098,6 +2098,23 @@ func TestSublistInterestBasedIntersection(t *testing.T) {
 		require_NoDuplicates(t, got)
 	})
 
+	t.Run("PWCExtendedAggressive", func(t *testing.T) {
+		got := map[string]int{}
+		sl := NewSublistNoCache()
+		sl.Insert(newSub("stream.A.child"))
+		sl.Insert(newSub("*.A.child"))
+		sl.Insert(newSub("stream.*.child"))
+		sl.Insert(newSub("stream.A.*"))
+		sl.Insert(newSub("stream.*.*"))
+		sl.Insert(newSub("*.A.*"))
+		sl.Insert(newSub("*.*.child"))
+		IntersectStree(st, sl, func(subj []byte, entry *struct{}) {
+			got[string(subj)]++
+		})
+		require_Len(t, len(got), 1)
+		require_NoDuplicates(t, got)
+	})
+
 	t.Run("FWCAll", func(t *testing.T) {
 		got := map[string]int{}
 		sl := NewSublistNoCache()

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -2086,6 +2086,18 @@ func TestSublistInterestBasedIntersection(t *testing.T) {
 		require_NoDuplicates(t, got)
 	})
 
+	t.Run("PWCExtended", func(t *testing.T) {
+		got := map[string]int{}
+		sl := NewSublistNoCache()
+		sl.Insert(newSub("stream.*.child"))
+		sl.Insert(newSub("stream.A"))
+		IntersectStree(st, sl, func(subj []byte, entry *struct{}) {
+			got[string(subj)]++
+		})
+		require_Len(t, len(got), 2)
+		require_NoDuplicates(t, got)
+	})
+
 	t.Run("FWCAll", func(t *testing.T) {
 		got := map[string]int{}
 		sl := NewSublistNoCache()


### PR DESCRIPTION
Similar to https://github.com/nats-io/nats-server/pull/6827, but when combining filter subjects of `stream.A` and `stream.*.A`.

Resolves https://github.com/nats-io/nats-server/issues/7336

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>