### PR TITLE
[FIXED] Data race on JetStream reserved limits

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -3931,6 +3931,8 @@ func (acc *Account) jsNonClusteredStreamLimitsCheck(cfg *StreamConfig) *ApiError
 	if apiErr != nil {
 		return apiErr
 	}
+	jsa.js.mu.RLock()
+	defer jsa.js.mu.RUnlock()
 	jsa.mu.RLock()
 	defer jsa.mu.RUnlock()
 	if selectedLimits.MaxStreams > 0 && jsa.countStreams(tier, cfg) >= selectedLimits.MaxStreams {


### PR DESCRIPTION
JS read lock was not held upon calling `jsa.js.checkAllLimits`.

Resolves https://github.com/nats-io/nats-server/issues/7288

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>