### PR TITLE
(2.12) Optimised meta snapshot encoding when `GOEXPERIMENT=jsonv2` enabled

### DIFF
--- a/scripts/runTestsOnTravis.sh
+++ b/scripts/runTestsOnTravis.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+export GOEXPERIMENT=jsonv2
+
 if [ "$1" = "compile" ]; then
     # First check that NATS builds.
     go build -v;

--- a/server/events.go
+++ b/server/events.go
@@ -315,7 +315,7 @@ type ClientInfo struct {
 	Name       string        `json:"name,omitempty"`
 	Lang       string        `json:"lang,omitempty"`
 	Version    string        `json:"ver,omitempty"`
-	RTT        time.Duration `json:"rtt,omitempty"`
+	RTT        time.Duration `json:"rtt,omitempty,format:units"`
 	Server     string        `json:"server,omitempty"`
 	Cluster    string        `json:"cluster,omitempty"`
 	Alternates []string      `json:"alts,omitempty"`

--- a/server/jetstream_cluster_snap_v1.go
+++ b/server/jetstream_cluster_snap_v1.go
@@ -1,0 +1,24 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//go:build !goexperiment.jsonv2
+
+package server
+
+import (
+	"encoding/json"
+)
+
+func (js *jetStream) metaSnapshotJSON(streams []writeableStreamAssignment) ([]byte, error) {
+	return json.Marshal(streams)
+}

--- a/server/jetstream_cluster_snap_v2.go
+++ b/server/jetstream_cluster_snap_v2.go
@@ -1,0 +1,35 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//go:build goexperiment.jsonv2
+
+package server
+
+import (
+	"bytes"
+	jsonv2 "encoding/json/v2"
+	"weak"
+)
+
+func (js *jetStream) metaSnapshotJSON(streams []writeableStreamAssignment) ([]byte, error) {
+	b := js.cluster.lastsnap.Value()
+	if b == nil {
+		b = bytes.NewBuffer(nil)
+		js.cluster.lastsnap = weak.Make(b)
+	}
+	b.Reset()
+	if err := jsonv2.MarshalWrite(b, streams); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}


### PR DESCRIPTION
With the old JSON library:
```
go test -v ./server -run=XXX -bench=BenchmarkJetStreamMetaSnapshot -benchtime=1x
goos: darwin
goarch: arm64
pkg: github.com/nats-io/nats-server/v2/server
cpu: Apple M2 Ultra
BenchmarkJetStreamMetaSnapshot
BenchmarkJetStreamMetaSnapshot/Default
BenchmarkJetStreamMetaSnapshot/Default-24         	       1	 466903916 ns/op
BenchmarkJetStreamMetaSnapshot/AllUnsupported
BenchmarkJetStreamMetaSnapshot/AllUnsupported-24  	       1	 267354584 ns/op
PASS
ok  	github.com/nats-io/nats-server/v2/server	9.826s
```

With the new JSON library:
```
GOEXPERIMENT=jsonv2 go test -v ./server -run=XXX -bench=BenchmarkJetStreamMetaSnapshot -benchtime=1x
goos: darwin
goarch: arm64
pkg: github.com/nats-io/nats-server/v2/server
cpu: Apple M2 Ultra
BenchmarkJetStreamMetaSnapshot
BenchmarkJetStreamMetaSnapshot/Default
BenchmarkJetStreamMetaSnapshot/Default-24         	       1	 196555083 ns/op
BenchmarkJetStreamMetaSnapshot/AllUnsupported
BenchmarkJetStreamMetaSnapshot/AllUnsupported-24  	       1	 205764542 ns/op
PASS
ok  	github.com/nats-io/nats-server/v2/server	9.154s
```

Signed-off-by: Neil Twigg <neil@nats.io>