### PR TITLE
feat: add NewServerFromConfig function for embedded server config processing

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -697,6 +697,15 @@ func New(opts *Options) *Server {
 	return s
 }
 
+func NewServerFromConfig(opts *Options) (*Server, error) {
+	if opts.ConfigFile != _EMPTY_ && opts.configDigest == "" {
+		if err := opts.ProcessConfigFile(opts.ConfigFile); err != nil {
+			return nil, err
+		}
+	}
+	return NewServer(opts)
+}
+
 // NewServer will setup a new server struct after parsing the options.
 // Could return an error if options can not be validated.
 // The provided Options type should not be re-used afterwards.


### PR DESCRIPTION
# Add NewServerFromConfig function for embedded server config processing

## Overview

Resolves #7092

This PR introduces a new `NewServerFromConfig()` function that automatically processes configuration files for embedded NATS servers.

## Problem

When using NATS embedded in Go applications, developers (such as me) often pass the `ConfigFile` field in the `Options` struct, but `NewServer(opts *Options)` doesn't automatically process this configuration file. This leads to confusion and requires additional manual steps to load the configuration.

## Solution

### Approach Comparison

In pr #7333, a solution was proposed to directly modify `NewServer()`:

```go
func NewServer(opts *Options) (*Server, error) {
    if opts.ConfigFile != _EMPTY_ && opts.configDigest == "" {
        if err := opts.ProcessConfigFile(opts.ConfigFile); err != nil {
            return nil, err
        }
    }
    // ...original code
}
```

However, directly modifying `NewServer()` might raise concerns about backward compatibility. Therefore, this PR introduces a dedicated `NewServerFromConfig()` function specifically to handle the `ConfigFile` field of `*Options`.

### Implementation

This PR adds:

```go
func NewServerFromConfig(opts *Options) (*Server, error) {
    if opts.ConfigFile != _EMPTY_ && opts.configDigest == "" {
        if err := opts.ProcessConfigFile(opts.ConfigFile); err != nil {
            return nil, err
        }
    }
    return NewServer(opts)
}
```

## Testing

Added comprehensive test coverage:

- **`TestNewServerFromConfigFunctionality`**: Tests basic functionality and error handling scenarios
- **`TestNewServerFromConfigVsLoadConfig`**: Validates equivalence with traditional `LoadConfig()` approach using deep equality checks

## Acknowledgments

Thanks to @ripienaar for the suggestion to create a separate function instead of modifying `NewServer()` directly.

## Signing Off

Signed-off-by: orician lzjzxOYX201905@gmail.com