### PR TITLE
(2.12) Deactivate message schedule on missing header

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4447,6 +4447,8 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 		if schedule, ok := getMessageSchedule(hdr); ok && !schedule.IsZero() {
 			fs.scheduling.add(seq, subj, schedule.UnixNano())
 			fs.lmb.schedules++
+		} else {
+			fs.scheduling.removeSubject(subj)
 		}
 	}
 

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -312,6 +312,8 @@ func (ms *memStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, tt
 	if ms.scheduling != nil {
 		if schedule, ok := getMessageSchedule(hdr); ok && !schedule.IsZero() {
 			ms.scheduling.add(seq, subj, schedule.UnixNano())
+		} else {
+			ms.scheduling.removeSubject(subj)
 		}
 	}
 

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -95,6 +95,14 @@ func (ms *MsgScheduling) remove(seq uint64) {
 	}
 }
 
+func (ms *MsgScheduling) removeSubject(subj string) {
+	if sched, ok := ms.schedules[subj]; ok {
+		ms.ttls.Remove(sched.seq, sched.ts)
+		delete(ms.schedules, subj)
+		delete(ms.seqToSubj, sched.seq)
+	}
+}
+
 func (ms *MsgScheduling) clearInflight() {
 	ms.inflight = make(map[string]struct{})
 }


### PR DESCRIPTION
When a schedule is published on a subject `foo.schedule`, if another message is published under the same subject but it is not a schedule then the schedule should be deactivated.

The ADR describes "the last message on a subject holds the current schedule", which means it would be unexpected if a schedule doesn't get deactivated if it's not the last message for that subject anymore.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>