### PR TITLE
[FIXED] Successful exit code during shutdown

### DIFF
--- a/server/log.go
+++ b/server/log.go
@@ -245,6 +245,10 @@ func (s *Server) RateLimitDebugf(format string, v ...any) {
 
 // Fatalf logs a fatal error
 func (s *Server) Fatalf(format string, v ...any) {
+	if s.isShuttingDown() {
+		s.Errorf(format, v)
+		return
+	}
 	s.executeLogCall(func(logger Logger, format string, v ...any) {
 		logger.Fatalf(format, v...)
 	}, format, v...)


### PR DESCRIPTION
Antithesis can reproduce a non-zero exit code if during startup we immediately get SIGTERM-ed. This is because initialization isn't completed yet when the SIGTERM comes in. We can simply not do a Fatal log. Turning it into an error log instead ensures we don't exit with an unexpected exit code.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>