### PR TITLE
(2.14) [IMPROVED] Make most StreamConfig/ConsumerConfig fields omitempty

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -99,7 +99,7 @@ type ConsumerConfig struct {
 	BackOff         []time.Duration `json:"backoff,omitempty"`
 	FilterSubject   string          `json:"filter_subject,omitempty"`
 	FilterSubjects  []string        `json:"filter_subjects,omitempty"`
-	ReplayPolicy    ReplayPolicy    `json:"replay_policy"`
+	ReplayPolicy    ReplayPolicy    `json:"replay_policy,omitempty"`
 	RateLimit       uint64          `json:"rate_limit_bps,omitempty"` // Bits per sec
 	SampleFrequency string          `json:"sample_freq,omitempty"`
 	MaxWaiting      int             `json:"max_waiting,omitempty"`

--- a/server/stream.go
+++ b/server/stream.go
@@ -53,11 +53,11 @@ type StreamConfig struct {
 	Description  string           `json:"description,omitempty"`
 	Subjects     []string         `json:"subjects,omitempty"`
 	Retention    RetentionPolicy  `json:"retention"`
-	MaxConsumers int              `json:"max_consumers"`
-	MaxMsgs      int64            `json:"max_msgs"`
-	MaxBytes     int64            `json:"max_bytes"`
-	MaxAge       time.Duration    `json:"max_age"`
-	MaxMsgsPer   int64            `json:"max_msgs_per_subject"`
+	MaxConsumers int              `json:"max_consumers,omitempty"`
+	MaxMsgs      int64            `json:"max_msgs,omitempty"`
+	MaxBytes     int64            `json:"max_bytes,omitempty"`
+	MaxAge       time.Duration    `json:"max_age,omitempty"`
+	MaxMsgsPer   int64            `json:"max_msgs_per_subject,omitempty"`
 	MaxMsgSize   int32            `json:"max_msg_size,omitempty"`
 	Discard      DiscardPolicy    `json:"discard"`
 	Storage      StorageType      `json:"storage"`
@@ -68,7 +68,7 @@ type StreamConfig struct {
 	Placement    *Placement       `json:"placement,omitempty"`
 	Mirror       *StreamSource    `json:"mirror,omitempty"`
 	Sources      []*StreamSource  `json:"sources,omitempty"`
-	Compression  StoreCompression `json:"compression"`
+	Compression  StoreCompression `json:"compression,omitempty"`
 	FirstSeq     uint64           `json:"first_seq,omitempty"`
 
 	// Allow applying a subject transform to incoming messages before doing anything else
@@ -78,9 +78,9 @@ type StreamConfig struct {
 	RePublish *RePublish `json:"republish,omitempty"`
 
 	// Allow higher performance, direct access to get individual messages. E.g. KeyValue
-	AllowDirect bool `json:"allow_direct"`
+	AllowDirect bool `json:"allow_direct,omitempty"`
 	// Allow higher performance and unified direct access for mirrors as well.
-	MirrorDirect bool `json:"mirror_direct"`
+	MirrorDirect bool `json:"mirror_direct,omitempty"`
 
 	// Allow KV like semantics to also discard new on a per subject basis
 	DiscardNewPer bool `json:"discard_new_per_subject,omitempty"`
@@ -88,23 +88,23 @@ type StreamConfig struct {
 	// Optional qualifiers. These can not be modified after set to true.
 
 	// Sealed will seal a stream so no messages can get out or in.
-	Sealed bool `json:"sealed"`
+	Sealed bool `json:"sealed,omitempty"`
 	// DenyDelete will restrict the ability to delete messages.
-	DenyDelete bool `json:"deny_delete"`
+	DenyDelete bool `json:"deny_delete,omitempty"`
 	// DenyPurge will restrict the ability to purge messages.
-	DenyPurge bool `json:"deny_purge"`
+	DenyPurge bool `json:"deny_purge,omitempty"`
 	// AllowRollup allows messages to be placed into the system and purge
 	// all older messages using a special msg header.
-	AllowRollup bool `json:"allow_rollup_hdrs"`
+	AllowRollup bool `json:"allow_rollup_hdrs,omitempty"`
 
 	// The following defaults will apply to consumers when created against
 	// this stream, unless overridden manually.
 	// TODO(nat): Can/should we name these better?
-	ConsumerLimits StreamConsumerLimits `json:"consumer_limits"`
+	ConsumerLimits StreamConsumerLimits `json:"consumer_limits,omitempty"`
 
 	// AllowMsgTTL allows header initiated per-message TTLs. If disabled,
 	// then the `NATS-TTL` header will be ignored.
-	AllowMsgTTL bool `json:"allow_msg_ttl"`
+	AllowMsgTTL bool `json:"allow_msg_ttl,omitempty"`
 
 	// SubjectDeleteMarkerTTL sets the TTL of delete marker messages left behind by
 	// subject delete markers.


### PR DESCRIPTION
The `ConsumerConfig` already had most fields as `omitempty`, do the same for `StreamConfig` so that serializing this into JSON will greatly reduce meta snapshot size and general bandwidth used for stream info/list requests.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>