### PR TITLE
(2.12) Atomic batch: support deduplication

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -1988,5 +1988,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSAtomicPublishContainsDuplicateMessageErr",
+    "code": 400,
+    "error_code": 10201,
+    "description": "atomic publish batch contains duplicate message id",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -303,7 +303,7 @@ func checkMsgHeadersPreClusteredProposal(
 		if msgId := getMsgId(hdr); msgId != _EMPTY_ {
 			// Dedupe if staged.
 			if _, ok = diff.msgIds[msgId]; ok {
-				return hdr, msg, 0, nil, errMsgIdDuplicate
+				return hdr, msg, 0, NewJSAtomicPublishContainsDuplicateMessageError(), errMsgIdDuplicate
 			}
 			mset.ddMu.Lock()
 			if dde := mset.checkMsgId(msgId); dde != nil {
@@ -311,7 +311,7 @@ func checkMsgHeadersPreClusteredProposal(
 				mset.ddMu.Unlock()
 				// Should not return an invalid sequence, in that case error.
 				if seq > 0 {
-					return hdr, msg, seq, nil, errMsgIdDuplicate
+					return hdr, msg, seq, NewJSAtomicPublishContainsDuplicateMessageError(), errMsgIdDuplicate
 				} else {
 					return hdr, msg, 0, NewJSStreamDuplicateMessageConflictError(), errMsgIdDuplicate
 				}

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -8,6 +8,9 @@ const (
 	// JSAccountResourcesExceededErr resource limits exceeded for account
 	JSAccountResourcesExceededErr ErrorIdentifier = 10002
 
+	// JSAtomicPublishContainsDuplicateMessageErr atomic publish batch contains duplicate message id
+	JSAtomicPublishContainsDuplicateMessageErr ErrorIdentifier = 10201
+
 	// JSAtomicPublishDisabledErr atomic publish is disabled
 	JSAtomicPublishDisabledErr ErrorIdentifier = 10174
 
@@ -606,6 +609,7 @@ const (
 var (
 	ApiErrors = map[ErrorIdentifier]*ApiError{
 		JSAccountResourcesExceededErr:                {Code: 400, ErrCode: 10002, Description: "resource limits exceeded for account"},
+		JSAtomicPublishContainsDuplicateMessageErr:   {Code: 400, ErrCode: 10201, Description: "atomic publish batch contains duplicate message id"},
 		JSAtomicPublishDisabledErr:                   {Code: 400, ErrCode: 10174, Description: "atomic publish is disabled"},
 		JSAtomicPublishIncompleteBatchErr:            {Code: 400, ErrCode: 10176, Description: "atomic publish batch is incomplete"},
 		JSAtomicPublishInvalidBatchCommitErr:         {Code: 400, ErrCode: 10200, Description: "atomic publish batch commit is invalid"},
@@ -837,6 +841,16 @@ func NewJSAccountResourcesExceededError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSAccountResourcesExceededErr]
+}
+
+// NewJSAtomicPublishContainsDuplicateMessageError creates a new JSAtomicPublishContainsDuplicateMessageErr error: "atomic publish batch contains duplicate message id"
+func NewJSAtomicPublishContainsDuplicateMessageError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSAtomicPublishContainsDuplicateMessageErr]
 }
 
 // NewJSAtomicPublishDisabledError creates a new JSAtomicPublishDisabledErr error: "atomic publish is disabled"

--- a/server/stream.go
+++ b/server/stream.go
@@ -6505,9 +6505,6 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 		}
 
 		// Reject unsupported headers.
-		if msgId := getMsgId(bhdr); msgId != _EMPTY_ {
-			return errorOnUnsupported(seq, JSMsgId)
-		}
 		if getExpectedLastMsgId(hdr) != _EMPTY_ {
 			return errorOnUnsupported(seq, JSExpectedLastMsgId)
 		}


### PR DESCRIPTION
> 2.12.0 released atomic batch publish, but didn't contain deduplication support yet. Now that we've decided to have both atomic batch publishing (atomic & consistent) and non-atomic high-speed publishing (performance), we can make a decision around how deduplication works as well.
>
> When the `Nats-Msg-Id` deduplication header is used and a duplicate message is detected, the whole batch gets rejected with an error: `atomic publish batch contains duplicate message id`. This ensures the all-or-nothing-gets-persisted atomic nature is preserved, also when deduplication is used. There are no exceptions.
>
> The high-speed non-atomic batching could then support deduplication differently by allowing them to be omitted from the stored messages, similar to how `js.PublishAsync` would work.

ADR-50 update: https://github.com/nats-io/nats-architecture-and-design/pull/385



Resolves https://github.com/nats-io/nats-server/issues/6980

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>