### PR TITLE
[ADDED] - `riscv64` support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,6 +38,8 @@ builds:
       - mips64le
       - s390x
       - ppc64le
+      # RISC-V currently only supported on Linux
+      - riscv64
     goarm:
       - 6
       - 7
@@ -52,6 +54,12 @@ builds:
         goarch: arm64
       - goos: freebsd
         goarch: 386
+      - goos: darwin
+        goarch: riscv64
+      - goos: windows
+        goarch: riscv64
+      - goos: freebsd
+        goarch: riscv64
     mod_timestamp: "{{ .CommitTimestamp }}"
 
 nfpms:


### PR DESCRIPTION
* New Features
  * Added official `riscv64` build support for supported platforms (e.g., Linux), providing downloadable binaries for that architecture and broadening platform availability.

* Chores
  * Updated the release pipeline to include riscv64 in the build matrix while excluding unsupported OS combinations to ensure reliable releases.
  * No changes to application behavior, public APIs, or user workflows; this is a build/configuration-only update.
  
Signed-off-by: Rodney Osodo <socials@rodneyosodo.com>