### PR TITLE
NRG: Parallel catchups can truncate committed

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3594,9 +3594,9 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 	isNew := sub != nil && sub == n.aesub
 
 	// If we are/were catching up ignore old catchup subs, but only if catching up from an older server
-	// that doesn't send the leader term when catching up. We can reject old catchups from newer subs
-	// later, just by checking the append entry is on the correct term.
-	if !isNew && sub != nil && ae.lterm == 0 && (!catchingUp || sub != n.catchup.sub) {
+	// that doesn't send the leader term when catching up or if we would truncate as a result.
+	// We can reject old catchups from newer subs later, just by checking the append entry is on the correct term.
+	if !isNew && sub != nil && (ae.lterm == 0 || ae.pindex < n.pindex) && (!catchingUp || sub != n.catchup.sub) {
 		n.Unlock()
 		n.debug("AppendEntry ignoring old entry from previous catchup")
 		return


### PR DESCRIPTION
Follow-up of a small bug introduced in https://github.com/nats-io/nats-server/pull/7209 that could result in desync under niche conditions.

If a follower is behind it will request catchup from the leader. The leader however could send more catchup data than the follower requested by sending it up to the last known entry. The follower will then mark catchup as finished when it has received what it knew to be all entries, but it may receive more messages from the leader still.

If multiple catchups were running in parallel, this could result in the follower marking the catchup as complete but then still letting an append entry from another catchup through that could truncate the WAL for entries that were already responded to as "can be committed".

This PR simply adds a small guard to not allow truncation from a catchup entry if catchup has completed. Later on we'll need to look at how to improve catchup in general, especially with fast batch ingest that will require Raft catchup to be faster than that as well.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>