### PR TITLE
Offline assets: use strict err

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1349,7 +1349,7 @@ func (a *Account) EnableJetStream(limits map[string]JetStreamAccountLimits) erro
 			if !supported {
 				apiLevel := getRequiredApiLevel(cfg.Metadata)
 				if strictErr != nil {
-					offlineReason = fmt.Sprintf("unsupported - config error: %s", strings.TrimPrefix(err.Error(), "json: "))
+					offlineReason = fmt.Sprintf("unsupported - config error: %s", strings.TrimPrefix(strictErr.Error(), "json: "))
 				} else {
 					offlineReason = fmt.Sprintf("unsupported - required API level: %s, current API level: %d", apiLevel, JSApiLevel)
 				}
@@ -1593,7 +1593,7 @@ func (a *Account) EnableJetStream(limits map[string]JetStreamAccountLimits) erro
 				if !supported {
 					apiLevel := getRequiredApiLevel(cfg.Metadata)
 					if strictErr != nil {
-						offlineReason = fmt.Sprintf("unsupported - config error: %s", strings.TrimPrefix(err.Error(), "json: "))
+						offlineReason = fmt.Sprintf("unsupported - config error: %s", strings.TrimPrefix(strictErr.Error(), "json: "))
 					} else {
 						offlineReason = fmt.Sprintf("unsupported - required API level: %s, current API level: %d", apiLevel, JSApiLevel)
 					}


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/7416, the `strictErr` should be used. Not `err` which was used for different errors.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>