### PR TITLE
[FIXED] Trusted Proxies: Reload log message report added keys as removed

### DIFF
--- a/server/reload.go
+++ b/server/reload.go
@@ -1077,7 +1077,7 @@ func (p *proxiesReload) Apply(s *Server) {
 			c.setAuthError(ErrAuthProxyNotTrusted)
 			c.authViolation()
 		}
-		s.Noticef("Reloaded: proxies trusted keys %q were removed", p.add)
+		s.Noticef("Reloaded: proxies trusted keys %q were removed", p.del)
 	}
 	if len(p.add) > 0 {
 		s.Noticef("Reloaded: proxies trusted keys %q were added", p.add)


### PR DESCRIPTION
When doing a configuration reload and some keys are removed, there is a log message such as:
```
Reloaded: proxies trusted keys ["xxx", "yyy"] were removed
```
However, the list contains the added keys, not the removed ones. The log statement about the added ones is correct.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
