### PR TITLE
[FIXED] Filestore unlock when message erase fails

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5086,10 +5086,15 @@ func (fs *fileStore) removeMsg(seq uint64, secure, viaLimits, needFSLock bool) (
 		// Grab record info, but use the pre-computed record length.
 		ri, _, _, err := mb.slotInfo(int(seq - mb.cache.fseq))
 		if err != nil {
+			mb.finishedWithCache()
+			mb.mu.Unlock()
+			fsUnlock()
 			return false, err
 		}
 		if err := mb.eraseMsg(seq, int(ri), int(msz), isLastBlock); err != nil {
 			mb.finishedWithCache()
+			mb.mu.Unlock()
+			fsUnlock()
 			return false, err
 		}
 	}


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/5248, `mb.eraseMsg` and `mb.slotInfo` can fail, so should make sure to unlock if it errors.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>