### PR TITLE
Improved warning for Observer mode

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -896,6 +896,9 @@ func (js *jetStream) setupMetaGroup() error {
 		}
 		if cfg.Observer {
 			s.Noticef("Turning JetStream metadata controller Observer Mode on")
+			s.Noticef("In cases where the JetStream domain is not intended to be extended through a SYS account leaf node connection")
+			s.Noticef("and waiting for leader election until first contact is not acceptable,")
+			s.Noticef(`manually disable Observer Mode by setting the JetStream Option "extension_hint: %s"`, jsNoExtend)
 		}
 	} else {
 		s.Noticef("JetStream cluster recovering state")
@@ -909,7 +912,7 @@ func (js *jetStream) setupMetaGroup() error {
 				cfg.Observer = false
 			case extUndetermined:
 				s.Noticef("Turning JetStream metadata controller Observer Mode on - no previous contact")
-				s.Noticef("In cases where JetStream will not be extended")
+				s.Noticef("In cases where the JetStream domain is not intended to be extended through a SYS account leaf node connection")
 				s.Noticef("and waiting for leader election until first contact is not acceptable,")
 				s.Noticef(`manually disable Observer Mode by setting the JetStream Option "extension_hint: %s"`, jsNoExtend)
 			}


### PR DESCRIPTION
This is purely a documentation/info update, which catches a situation where a correctly configured leaf cluster would fail to elect a meta leader, but the user would be left completely clueless as to why.

When a cluster is started the first time(!) it will check if leaf nodes connections to SYS are configured. If this is the case the leaf cluster MAY be an extension of a hub cluster. It cannot verify this until the connection is actually made and it can compare jetstream domains (its an extension only if the domains are the same)
As a result the cluster goes into "Observer mode" in which meta leader election is deferred till the hub is connection via a SYS leaf node connection.

BUT, not hint is printed on the FIRST start- only on the SECOND start of the cluster a hint was printed. 
The /healthz probe fails with a 503 and no further details beyond `"JetStream has not established contact with a meta leader"`

This leaves the user completely clueless as to why the meta leader was not elected. `nats server report jetstream` also gives no hint as to the reason.

This change prints the extension_hint warning on first start and extends the explanation.

Signed-off-by: Michael Röschter <michael@roeschter.de>