### PR TITLE
Tweak cache expiry in `firstMatching` or `firstMatchingMulti`

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2705,7 +2705,7 @@ func (mb *msgBlock) firstMatchingMulti(sl *gsl.SimpleSublist, start uint64, sm *
 			if err != nil {
 				continue
 			}
-			expireOk := seq == lseq && mb.llseq == seq
+			expireOk := seq == lseq && mb.llseq != llseq && mb.llseq == seq
 			updateLLTS = false // cacheLookup already updated it.
 			if sl.HasInterest(fsm.subj) {
 				return fsm, expireOk, nil
@@ -2839,7 +2839,7 @@ func (mb *msgBlock) firstMatching(filter string, wc bool, start uint64, sm *Stor
 			continue
 		}
 		updateLLTS = false // cacheLookup already updated it.
-		expireOk := seq == lseq && mb.llseq == seq
+		expireOk := seq == lseq && mb.llseq != llseq && mb.llseq == seq
 		if isAll {
 			return fsm, expireOk, nil
 		}


### PR DESCRIPTION
The first load of the last sequence via `firstMatching` or `firstMatchingMulti` will still continue to flag `expireOk`, as though we're optimising for the linear scan case, but if it becomes apparent that we are continuously reloading the same last sequence over and over again in this way, don't set `expireOk` or we'll just keep expiring and reloading the cache each time.

Signed-off-by: Neil Twigg <neil@nats.io>
