### PR TITLE
(2.12) [FIXED] DirectGet batch deadlock with parallel write

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -5287,8 +5287,8 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 
 	// If batch was requested send EOB.
 	if isBatchRequest {
-		// Update if the stream's lasts sequence has moved past our validThrough.
-		if mset.lastSeq() > validThrough {
+		// Update if the stream's last sequence has moved past our validThrough.
+		if mset.lseq > validThrough {
 			np, _ = store.NumPending(seq, req.NextFor, false)
 		}
 		hdr := fmt.Appendf(nil, eob, np, lseq)


### PR DESCRIPTION
Fixes a deadlock where since 2.12 the stream's read lock is held for the whole duration of `mset.getDirectRequest` to ensure atomic reads, while the call to `mset.lastSeq()` also tries to acquire the read lock. If a write happened in between, this would deadlock.

To reproduce: this requires `AllowDirect` on the stream, a DirectGet request to be sent, that needs to be a batch request with `req.Batch>0`, and a write happens in parallel.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>