### PR TITLE
Allow variables to be used as part of a value in configuration.

### DIFF
--- a/conf/lex_test.go
+++ b/conf/lex_test.go
@@ -531,6 +531,14 @@ func TestVariableValues(t *testing.T) {
 	}
 	lx = lex("foo $bar")
 	expect(t, lx, expectedItems)
+
+	expectedItems = []item{
+		{itemKey, "foo", 1, 0},
+		{itemVariable, "bar", 1, 8},
+		{itemEOF, "", 1, 0},
+	}
+	lx = lex("foo = ${bar}")
+	expect(t, lx, expectedItems)
 }
 
 func TestArrays(t *testing.T) {
@@ -708,6 +716,22 @@ func TestNestedMaps(t *testing.T) {
 	}
 
 	lx := lex(nestedMap)
+	expect(t, lx, expectedItems)
+}
+
+func TestSimpleMapWithVariable(t *testing.T) {
+	expectedItems := []item{
+		{itemKey, "foo", 1, 0},
+		{itemMapStart, "", 1, 7},
+		{itemKey, "ip", 1, 7},
+		{itemVariable, "IP", 1, 12},
+		{itemKey, "port", 1, 17},
+		{itemVariable, "PORT", 1, 26},
+		{itemMapEnd, "", 1, 32},
+		{itemEOF, "", 1, 0},
+	}
+
+	lx := lex("foo = {ip=${IP}, port = ${PORT}}")
 	expect(t, lx, expectedItems)
 }
 

--- a/conf/parse.go
+++ b/conf/parse.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -287,6 +288,7 @@ func (p *parser) processItem(it item, fp string) error {
 		setValue(it, p.popContext())
 	case itemString:
 		// FIXME(dlc) sanitize string?
+		p.checkForEmbeddedVariables(&it)
 		setValue(it, it.val)
 	case itemInteger:
 		lastDigit := 0
@@ -429,6 +431,33 @@ const pkey = "pk"
 
 // We special case raw strings here that are bcrypt'd. This allows us not to force quoting the strings
 const bcryptPrefix = "2a$"
+
+// To match embedded variables.
+var varPat = regexp.MustCompile(`\$\$[^@\s]+`)
+
+// checkForEmbeddedVariable will check for embedded variables in an itemString.
+// If they are found and we can look them up we will replace them in item, otherwise will error.
+func (p *parser) checkForEmbeddedVariables(it *item) error {
+	if !strings.ContainsAny(it.val, "$$") {
+		return nil
+	}
+	// We have some embedded variables.
+	for _, m := range varPat.FindAllString(it.val, -1) {
+		value, found, err := p.lookupVariable(m[2:]) // Strip leading $$ for lookup.
+		if err != nil {
+			return fmt.Errorf("variable reference for '%s' on line %d could not be parsed: %s",
+				m, it.line, err)
+		}
+		if !found {
+			return fmt.Errorf("variable reference for '%s' on line %d can not be found",
+				m, it.line)
+		}
+		if v, ok := value.(string); ok {
+			it.val = strings.Replace(it.val, m, v, 1)
+		}
+	}
+	return nil
+}
 
 // lookupVariable will lookup a variable reference. It will use block scoping on keys
 // it has seen before, with the top level scoping being the environment variables. We

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -242,6 +242,17 @@ func TestEnvVariableEmbeddedOutsideOfQuotes(t *testing.T) {
 	}
 }
 
+func TestEnvVariableEmbeddedSYS(t *testing.T) {
+	// https://github.com/nats-io/nats-server/pull/5544#discussion_r1641577620
+	cluster := `
+		system_account: "$SYS"
+		`
+	ex := map[string]any{
+		"system_account": "$SYS",
+	}
+	test(t, cluster, ex)
+}
+
 func TestBcryptVariable(t *testing.T) {
 	ex := map[string]any{
 		"password": "$2a$11$ooo",


### PR DESCRIPTION
Resolves: https://github.com/nats-io/nats-server/issues/5320

Based on https://github.com/nats-io/nats-server/pull/5544

Requires braces in strings to use variables (similar to using an environment variable in a shell). This solves @wallyqs's comment on the original pull request by preventing values like "$SYS" getting misinterpreted as a variable.

Note that using braces outside of string quotes is invalid, except as a whole value: `password: ${TOKEN}` and `password: $TOKEN` are equivalent. Existing parsing behavior of a single dollar sign outside of quotes remains unaffected.

Given variable `SYS` = `abc`,

| Form              | Result             | Changed by this PR |
| ----------------- | ------------------ | ------------------ |
| `key: $VAR`       | `abc`              | ❌                  |
| `key: "$VAR"`     | `$VAR` literal     | ❌                  |
| `key: "x-$VAR-y"` | `x-$VAR-y` literal | ❌                  |
| `key: x-$VAR-y`   | `x-$VAR-y` literal | ❌                  |

| Form                | Result    | Changed by this PR |
| ------------------- | --------- | ------------------ |
| `key: ${VAR}`       | `abc`     | ✅                  |
| `key: "${VAR}"`     | `abc`     | ✅                  |
| `key: "x-${VAR}-y"` | `x-abc-y` | ✅                  |
| `key: x-${VAR}-y`   | `x-abc-y` | ✅                  |


For all variable resolving, an error is return if undefined.

Signed-off-by: Joseph Riddle joe@synadia.com
