### PR TITLE
Add expvarz to http endpoints

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1501,7 +1501,8 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 	<a href=.%s>LeafNodes<span class="endpoint"> %s</span></a>
 	<a href=.%s>Gateways<span class="endpoint"> %s</span></a>
 	<a href=.%s>Raft Groups<span class="endpoint"> %s</span></a>
-	<a href=.%s class=last>Health Probe<span class="endpoint"> %s</span></a>
+	<a href=.%s>Health Probe<span class="endpoint"> %s</span></a>
+	<a href=.%s class=last>Expvar<span class="endpoint"> %s</span></a>
     <a href=https://docs.nats.io/running-a-nats-service/nats_admin/monitoring class="help">Help</a>
   </body>
 </html>`,
@@ -1518,6 +1519,7 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 		s.basePath(GatewayzPath), GatewayzPath,
 		s.basePath(RaftzPath), RaftzPath,
 		s.basePath(HealthzPath), HealthzPath,
+		s.basePath(ExpvarzPath), ExpvarzPath,
 	)
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -44,6 +44,8 @@ import (
 	// Allow dynamic profiling.
 	_ "net/http/pprof"
 
+	"expvar"
+
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats-server/v2/logger"
@@ -3017,6 +3019,7 @@ const (
 	HealthzPath      = "/healthz"
 	IPQueuesPath     = "/ipqueuesz"
 	RaftzPath        = "/raftz"
+	ExpvarzPath      = "/debug/vars"
 )
 
 func (s *Server) basePath(p string) string {
@@ -3135,6 +3138,8 @@ func (s *Server) startMonitoring(secure bool) error {
 	mux.HandleFunc(s.basePath(IPQueuesPath), s.HandleIPQueuesz)
 	// Raftz
 	mux.HandleFunc(s.basePath(RaftzPath), s.HandleRaftz)
+	// Expvarz
+	mux.Handle(s.basePath(ExpvarzPath), expvar.Handler())
 
 	// Do not set a WriteTimeout because it could cause cURL/browser
 	// to return empty response or unable to display page if the


### PR DESCRIPTION
It is already possible to get [expvars](https://pkg.go.dev/expvar) using system account request:
```
nats request '$SYS.REQ.SERVER.PING.EXPVARZ' '' --raw | jq '.'
```

Add it under standard path: http://localhost:8222/debug/vars
so it can be used by existing tooling,  like [datadog](https://docs.datadoghq.com/integrations/go-expvar/?tab=host#prepare-the-service), for example

Signed-off-by: Alex Bozhenko <alexbozhenko@gmail.com>
