### PR TITLE
fix(mqtt): allow memory streams

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -1167,6 +1167,12 @@ func (s *Server) mqttCreateAccountSessionManager(acc *Account, quitCh chan struc
 	if replicas <= 0 {
 		replicas = s.mqttDetermineReplicas()
 	}
+
+	streamStorage := FileStorage
+	if opts.MQTT.StreamMemoryStorage {
+		streamStorage = MemoryStorage
+	}
+
 	qname := fmt.Sprintf("[ACC:%s] MQTT ", accName)
 	as := &mqttAccountSessionManager{
 		sessions:   make(map[string]*mqttSession),
@@ -1316,7 +1322,7 @@ func (s *Server) mqttCreateAccountSessionManager(acc *Account, quitCh chan struc
 		cfg := &StreamConfig{
 			Name:       mqttSessStreamName,
 			Subjects:   []string{mqttSessStreamSubjectPrefix + as.domainTk + ">"},
-			Storage:    FileStorage,
+			Storage:    streamStorage,
 			Retention:  LimitsPolicy,
 			Replicas:   replicas,
 			MaxMsgsPer: 1,
@@ -1335,7 +1341,7 @@ func (s *Server) mqttCreateAccountSessionManager(acc *Account, quitCh chan struc
 		cfg := &StreamConfig{
 			Name:      mqttStreamName,
 			Subjects:  []string{mqttStreamSubjectPrefix + ">"},
-			Storage:   FileStorage,
+			Storage:   streamStorage,
 			Retention: InterestPolicy,
 			Replicas:  replicas,
 		}
@@ -1354,7 +1360,7 @@ func (s *Server) mqttCreateAccountSessionManager(acc *Account, quitCh chan struc
 		cfg := &StreamConfig{
 			Name:          mqttQoS2IncomingMsgsStreamName,
 			Subjects:      []string{mqttQoS2IncomingMsgsStreamSubjectPrefix + ">"},
-			Storage:       FileStorage,
+			Storage:       streamStorage,
 			Retention:     LimitsPolicy,
 			Discard:       DiscardNew,
 			MaxMsgsPer:    1,
@@ -1375,7 +1381,7 @@ func (s *Server) mqttCreateAccountSessionManager(acc *Account, quitCh chan struc
 		cfg := &StreamConfig{
 			Name:      mqttOutStreamName,
 			Subjects:  []string{mqttOutSubjectPrefix + ">"},
-			Storage:   FileStorage,
+			Storage:   streamStorage,
 			Retention: InterestPolicy,
 			Replicas:  replicas,
 		}
@@ -1396,7 +1402,7 @@ func (s *Server) mqttCreateAccountSessionManager(acc *Account, quitCh chan struc
 		cfg := &StreamConfig{
 			Name:       mqttRetainedMsgsStreamName,
 			Subjects:   []string{mqttRetainedMsgsStreamSubject + ">"},
-			Storage:    FileStorage,
+			Storage:    streamStorage,
 			Retention:  LimitsPolicy,
 			Replicas:   replicas,
 			MaxMsgsPer: 1,

--- a/server/opts.go
+++ b/server/opts.go
@@ -623,6 +623,10 @@ type MQTTOpts struct {
 	// count is not modified. Use the NATS CLI to update the count if desired.
 	StreamReplicas int
 
+	// Indicate if the streams should be created with memory storage.
+	// Note that existing streams are not modified.
+	StreamMemoryStorage bool
+
 	// Number of replicas for MQTT consumers.
 	// Negative or 0 value means that there is no override and the consumer
 	// will have the same replica factor that the stream it belongs to.

--- a/server/reload.go
+++ b/server/reload.go
@@ -834,6 +834,15 @@ func (o *mqttStreamReplicasReload) Apply(s *Server) {
 	s.Noticef("Reloaded: MQTT stream_replicas = %v", o.newValue)
 }
 
+type mqttStreamMemoryStorageReload struct {
+	noopOption
+	newValue bool
+}
+
+func (o *mqttStreamMemoryStorageReload) Apply(s *Server) {
+	s.Noticef("Reloaded: MQTT stream_memory_storage = %v", o.newValue)
+}
+
 type mqttConsumerReplicasReload struct {
 	noopOption
 	newValue int
@@ -1675,6 +1684,7 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 			diffOpts = append(diffOpts, &mqttAckWaitReload{newValue: newValue.(MQTTOpts).AckWait})
 			diffOpts = append(diffOpts, &mqttMaxAckPendingReload{newValue: newValue.(MQTTOpts).MaxAckPending})
 			diffOpts = append(diffOpts, &mqttStreamReplicasReload{newValue: newValue.(MQTTOpts).StreamReplicas})
+			diffOpts = append(diffOpts, &mqttStreamMemoryStorageReload{newValue: newValue.(MQTTOpts).StreamMemoryStorage})
 			diffOpts = append(diffOpts, &mqttConsumerReplicasReload{newValue: newValue.(MQTTOpts).ConsumerReplicas})
 			diffOpts = append(diffOpts, &mqttConsumerMemoryStorageReload{newValue: newValue.(MQTTOpts).ConsumerMemoryStorage})
 			diffOpts = append(diffOpts, &mqttInactiveThresholdReload{newValue: newValue.(MQTTOpts).ConsumerInactiveThreshold})
@@ -1683,9 +1693,9 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 			// we only fail reload if some that we don't support are changed.
 			tmpOld := oldValue.(MQTTOpts)
 			tmpNew := newValue.(MQTTOpts)
-			tmpOld.TLSConfig, tmpOld.tlsConfigOpts, tmpOld.AckWait, tmpOld.MaxAckPending, tmpOld.StreamReplicas, tmpOld.ConsumerReplicas, tmpOld.ConsumerMemoryStorage = nil, nil, 0, 0, 0, 0, false
+			tmpOld.TLSConfig, tmpOld.tlsConfigOpts, tmpOld.AckWait, tmpOld.MaxAckPending, tmpOld.StreamReplicas, tmpOld.StreamMemoryStorage, tmpOld.ConsumerReplicas, tmpOld.ConsumerMemoryStorage = nil, nil, 0, 0, 0, false, 0, false
 			tmpOld.ConsumerInactiveThreshold = 0
-			tmpNew.TLSConfig, tmpNew.tlsConfigOpts, tmpNew.AckWait, tmpNew.MaxAckPending, tmpNew.StreamReplicas, tmpNew.ConsumerReplicas, tmpNew.ConsumerMemoryStorage = nil, nil, 0, 0, 0, 0, false
+			tmpNew.TLSConfig, tmpNew.tlsConfigOpts, tmpNew.AckWait, tmpNew.MaxAckPending, tmpNew.StreamReplicas, tmpNew.StreamMemoryStorage, tmpNew.ConsumerReplicas, tmpNew.ConsumerMemoryStorage = nil, nil, 0, 0, 0, false, 0, false
 			tmpNew.ConsumerInactiveThreshold = 0
 
 			if !reflect.DeepEqual(tmpOld, tmpNew) {


### PR DESCRIPTION
add config to allow creating mqtt streams in memory, similar to the in memory consumer option

Signed-off-by: Frank Spitulski frank_spitulski@yahoo.com
