### PR TITLE
MQTT: fix session: when saving fails, remove it also from the JetStream

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -3893,6 +3893,9 @@ CHECK:
 	// running servers that this session is being used.
 	if err := es.save(); err != nil {
 		asm.removeSession(es, true)
+
+		// when saving of the session fails, we need to clear it
+		_ = es.clear(false)
 		return err
 	}
 	c.mu.Lock()


### PR DESCRIPTION
Fixes issue when the session state in memory and in the JetStream does not match, which causes never-ending `unable to persist session`. Restarting the NATS fixes it. 
I added some logs for debugging and found that:
- the session was not found in `asm.sessions[cid]`
- it also was not found in `asm.createOrRestoreSession(cid, s.getOpts())`
- but the session was still in JetStream and we tried to persist new session with seq=0, which fails 

Locally tested clearing the session from JS after the save fails and it recovered without a restart.

```
2025/10/19 18:59:16.543016 [ERR] 192.168.0.168:54080 - mid:37187 - "esp-upstairs-f4cfa276505c" - unable to persist session "esp-upstairs-f4cfa276505c" (seq=51971): wrong last sequence: 0 (10071)
2025/10/19 18:59:31.642105 [ERR] 192.168.0.168:54386 - mid:37192 - "esp-upstairs-f4cfa276505c" - unable to persist session "esp-upstairs-f4cfa276505c" (seq=51974): wrong last sequence: 0 (10071)
2025/10/19 18:59:46.728183 [ERR] 192.168.0.168:50120 - mid:37193 - "esp-upstairs-f4cfa276505c" - unable to persist session "esp-upstairs-f4cfa276505c" (seq=51977): wrong last sequence: 0 (10071)
2025/10/19 19:00:01.833980 [ERR] 192.168.0.168:57608 - mid:37200 - "esp-upstairs-f4cfa276505c" - unable to persist session "esp-upstairs-f4cfa276505c" (seq=51980): wrong last sequence: 0 (10071)
2025/10/19 19:00:16.850324 [ERR] 192.168.0.168:47678 - mid:37203 - "esp-upstairs-f4cfa276505c" - unable to persist session "esp-upstairs-f4cfa276505c" (seq=51983): wrong last sequence: 0 (10071)
2025/10/19 19:00:31.941566 [ERR] 192.168.0.168:42248 - mid:37208 - "esp-upstairs-f4cfa276505c" - unable to persist session "esp-upstairs-f4cfa276505c" (seq=51986): wrong last sequence: 0 (10071)
2025/10/19 19:00:47.006582 [ERR] 192.168.0.168:59012 - mid:37209 - "esp-upstairs-f4cfa276505c" - unable to persist session "esp-upstairs-f4cfa276505c" (seq=51989): wrong last sequence: 0 (10071)
2025/10/19 19:01:01.962248 [ERR] 192.168.0.168:42330 - mid:37212 - "esp-upstairs-f4cfa276505c" - unable to connect: unable to persist session "esp-upstairs-f4cfa276505c" (seq=0): expected stream sequence does not match (10063)
```


Signed-off-by: Ondrej Belusky [zlymeda@gmail.com](mailto:zlymeda@gmail.com)
