### PR TITLE
Add warning about legacy snapshot

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8775,6 +8775,7 @@ func (mset *stream) stateSnapshotLocked() []byte {
 		Deleted:  state.Deleted,
 	}
 	b, _ := json.Marshal(snap)
+	mset.srv.RateLimitWarnf("Stream %q: Using legacy JSON snapshot format. Snapshot length: %d bytes", mset.cfg.Name, len(b))
 	return b
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/nats-io/nats-server/pull/7479
There we fixed the default, but there is no test that we do not revert to the old behavior.
It is possible to imagine a scenario where some regression/race condition is introduced, and we fall back to legacy JSON again.

Add a  warning  that we should never see. And if we do see it, we would immediately know there is a problem.

Signed-off-by: Alex Bozhenko <alexbozhenko@gmail.com> 