### PR TITLE
Reduce allocations in `LoadPrevMsg`, `LoadNextMsg`, `LoadNextMsgMulti`, `LoadLastMsg`

### DIFF
--- a/server/store.go
+++ b/server/store.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"time"
 	"unsafe"
@@ -743,13 +744,14 @@ func isClusterResetErr(err error) bool {
 
 // Copy all fields.
 func (smo *StoreMsg) copy(sm *StoreMsg) {
-	if sm.buf != nil {
-		sm.buf = sm.buf[:0]
+	if sm == smo {
+		sm.buf = slices.Clone(smo.buf)
+	} else {
+		sm.buf = append(sm.buf[:0], smo.buf...)
 	}
-	sm.buf = append(sm.buf, smo.buf...)
 	// We set cap on header in case someone wants to expand it.
 	sm.hdr, sm.msg = sm.buf[:len(smo.hdr):len(smo.hdr)], sm.buf[len(smo.hdr):]
-	sm.subj, sm.seq, sm.ts = smo.subj, smo.seq, smo.ts
+	sm.subj, sm.seq, sm.ts = copyString(smo.subj), smo.seq, smo.ts
 }
 
 // Clear all fields except underlying buffer but reset that if present to [:0].


### PR DESCRIPTION
This optimises a number of filestore operations by avoiding new allocations and copies during intersections or scans, instead only copying the final return message. This results in far less GC garbage during these operations, particularly when intersecting large numbers of subjects or scanning large sequence ranges.

Comparative profile of `-bench=Benchmark_FileStoreLoadNextMsg` where the green shows the reduction in total allocations:

<img width="1887" height="447" alt="Screenshot 2025-10-29 at 12 33 03" src="https://github.com/user-attachments/assets/15dbe927-c6a8-4c3b-a190-849374d88eaa" />

Signed-off-by: Neil Twigg <neil@nats.io>
