### PR TITLE
(2.14) Reset consumer to new starting sequence

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -2018,5 +2018,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerInvalidResetErr",
+    "code": 400,
+    "error_code": 10204,
+    "description": "invalid reset: {err}",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -11658,6 +11658,7 @@ func (o *consumerFileStore) flushLoop(fch, qch chan struct{}) {
 func (o *consumerFileStore) SetStarting(sseq uint64) error {
 	o.mu.Lock()
 	o.state.Delivered.Stream = sseq
+	o.state.AckFloor.Stream = sseq
 	buf, err := o.encodeState()
 	o.mu.Unlock()
 	if err != nil {
@@ -11680,6 +11681,14 @@ func (o *consumerFileStore) UpdateStarting(sseq uint64) {
 	}
 	// Make sure we flush to disk.
 	o.kickFlusher()
+}
+
+// Reset all values in the store, and reset the starting sequence.
+func (o *consumerFileStore) Reset(sseq uint64) error {
+	o.mu.Lock()
+	o.state = ConsumerState{}
+	o.mu.Unlock()
+	return o.SetStarting(sseq)
 }
 
 // HasState returns if this store has a recorded state.

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -155,6 +155,9 @@ const (
 	// JSApiRequestNextT is the prefix for the request next message(s) for a consumer in worker/pull mode.
 	JSApiRequestNextT = "$JS.API.CONSUMER.MSG.NEXT.%s.%s"
 
+	// JSApiConsumerResetT is the prefix for resetting a given consumer to a new starting sequence.
+	JSApiConsumerResetT = "$JS.API.CONSUMER.RESET.%s.%s"
+
 	// JSApiConsumerUnpinT is the prefix for unpinning subscription for a given consumer.
 	JSApiConsumerUnpin  = "$JS.API.CONSUMER.UNPIN.*.*"
 	JSApiConsumerUnpinT = "$JS.API.CONSUMER.UNPIN.%s.%s"
@@ -756,6 +759,19 @@ type JSApiConsumerGetNextRequest struct {
 	Heartbeat time.Duration `json:"idle_heartbeat,omitempty"`
 	PriorityGroup
 }
+
+// JSApiConsumerResetRequest is for resetting a consumer to a specific sequence.
+type JSApiConsumerResetRequest struct {
+	Seq uint64 `json:"seq,omitempty"`
+}
+
+type JSApiConsumerResetResponse struct {
+	ApiResponse
+	*ConsumerInfo
+	ResetSeq uint64 `json:"reset_seq"`
+}
+
+const JSApiConsumerResetResponseType = "io.nats.jetstream.api.v1.consumer_reset_response"
 
 // Structure that holds state for a JetStream API request that is processed
 // in a separate long-lived go routine. This is to avoid blocking connections.

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -10764,3 +10764,368 @@ func TestJetStreamConsumerAllowOverlappingSubjectsIfNotSubset(t *testing.T) {
 	require_Equal(t, count, 7)
 	require_Len(t, len(msgs), count)
 }
+
+func TestJetStreamConsumerResetToSequence(t *testing.T) {
+	test := func(replicas int) {
+		c := createJetStreamClusterExplicit(t, "R3S", 3)
+		defer c.shutdown()
+
+		nc, js := jsClientConnect(t, c.randomServer())
+		defer nc.Close()
+
+		cfg := &nats.StreamConfig{
+			Name:     "TEST",
+			Subjects: []string{"foo"},
+			Replicas: replicas,
+		}
+		_, err := js.AddStream(cfg)
+		require_NoError(t, err)
+
+		sub, err := js.PullSubscribe(_EMPTY_, "CONSUMER",
+			nats.BindStream("TEST"),
+			nats.MaxAckPending(1),
+			nats.AckWait(time.Second),
+			nats.ConsumerReplicas(replicas),
+		)
+		require_NoError(t, err)
+		defer sub.Drain()
+
+		for i := range 4 {
+			_, err = js.Publish("foo", []byte(fmt.Sprintf("msg%d", i+1)))
+			require_NoError(t, err)
+		}
+
+		// Fetch and ack the first message.
+		msgs, err := sub.Fetch(1, nats.MaxWait(time.Second))
+		require_NoError(t, err)
+		require_Len(t, len(msgs), 1)
+		require_Equal(t, string(msgs[0].Data), "msg1")
+		require_NoError(t, msgs[0].AckSync())
+
+		// Now switch the stream to interest now that the messages and consumer are all available.
+		cfg.Retention = nats.InterestPolicy
+		_, err = js.UpdateStream(cfg)
+		require_NoError(t, err)
+		sl := c.streamLeader(globalAccountName, "TEST")
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			mset, err := sl.globalAccount().lookupStream("TEST")
+			if err != nil {
+				return err
+			}
+			state := mset.state()
+			if state.FirstSeq != 2 {
+				return fmt.Errorf("expected first seq to be 2, got %v", state)
+			}
+			return checkState(t, c, globalAccountName, "TEST")
+		})
+
+		s := c.consumerLeader(globalAccountName, "TEST", "CONSUMER")
+		mset, err := s.globalAccount().lookupStream("TEST")
+		require_NoError(t, err)
+		o := mset.lookupConsumer("CONSUMER")
+		require_NotNil(t, o)
+
+		type Expected struct{ numPending, numAckPending, dseq, adflr, sseq, asflr uint64 }
+		checkConsumerInfo := func(e Expected) {
+			t.Helper()
+			ci, err := js.ConsumerInfo("TEST", "CONSUMER")
+			require_NoError(t, err)
+			o.mu.RLock()
+			sseq, dseq, adflr, asflr, pending := o.sseq, o.dseq, o.adflr, o.asflr, len(o.pending)
+			o.mu.RUnlock()
+			require_Equal(t, ci.NumPending, e.numPending)
+			// NumAckPending needs to match both in the store and running state.
+			require_Equal(t, ci.NumAckPending, int(e.numAckPending))
+			require_Equal(t, pending, int(e.numAckPending))
+			// Delivered.Consumer needs to match both in the store and running state.
+			require_Equal(t, ci.Delivered.Consumer, e.dseq)
+			require_Equal(t, dseq-1, e.dseq)
+			// AckFloor.Consumer needs to match both in the store and running state.
+			require_Equal(t, ci.AckFloor.Consumer, e.adflr)
+			require_Equal(t, adflr, e.adflr)
+			// Delivered.Stream needs to match both in the store and running state.
+			require_Equal(t, ci.Delivered.Stream, e.sseq)
+			require_Equal(t, sseq-1, e.sseq)
+			// AckFloor.Stream needs to match both in the store and running state.
+			require_Equal(t, ci.AckFloor.Stream, e.asflr)
+			require_Equal(t, asflr, e.asflr)
+		}
+		// A single message was acked, 3 are ready to be delivered.
+		checkConsumerInfo(Expected{
+			numPending: 3, numAckPending: 0,
+			dseq: 1, adflr: 1,
+			sseq: 1, asflr: 1,
+		})
+
+		msgs, err = sub.Fetch(1, nats.MaxWait(time.Second))
+		require_NoError(t, err)
+		require_Len(t, len(msgs), 1)
+		require_Equal(t, string(msgs[0].Data), "msg2")
+		// Don't ack.
+
+		// A message has been delivered and needs to be acked still.
+		checkConsumerInfo(Expected{
+			numPending: 2, numAckPending: 1,
+			dseq: 2, adflr: 1,
+			sseq: 2, asflr: 1,
+		})
+
+		// Resetting the consumer with an empty request results in a reset back to the ack floor.
+		var resp JSApiConsumerResetResponse
+		msg, err := nc.Request("$JS.API.CONSUMER.RESET.TEST.CONSUMER", nil, time.Second)
+		require_NoError(t, err)
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		require_Equal(t, resp.Type, JSApiConsumerResetResponseType)
+		require_Equal(t, resp.ResetSeq, 2)
+		require_Equal(t, resp.Delivered.Stream, 1)
+		require_Equal(t, resp.Delivered.Last, nil)
+		require_Equal(t, resp.AckFloor.Stream, 1)
+		require_Equal(t, resp.AckFloor.Last, nil)
+
+		// Should be back.
+		require_Equal(t, resp.NumPending, 3)
+		checkConsumerInfo(Expected{
+			numPending: 3, numAckPending: 0,
+			dseq: 0, adflr: 0,
+			sseq: 1, asflr: 1,
+		})
+
+		// Trying to reset to zero also resets back to the ack floor.
+		req := JSApiConsumerResetRequest{Seq: 0}
+		data, err := json.Marshal(req)
+		require_NoError(t, err)
+		resp = JSApiConsumerResetResponse{}
+		msg, err = nc.Request("$JS.API.CONSUMER.RESET.TEST.CONSUMER", data, time.Second)
+		require_NoError(t, err)
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		require_Equal(t, resp.Type, JSApiConsumerResetResponseType)
+		require_Equal(t, resp.ResetSeq, 2)
+		require_Equal(t, resp.Delivered.Stream, 1)
+		require_Equal(t, resp.Delivered.Last, nil)
+		require_Equal(t, resp.AckFloor.Stream, 1)
+		require_Equal(t, resp.AckFloor.Last, nil)
+
+		require_Equal(t, resp.NumPending, 3)
+		checkConsumerInfo(Expected{
+			numPending: 3, numAckPending: 0,
+			dseq: 0, adflr: 0,
+			sseq: 1, asflr: 1,
+		})
+
+		// Resetting the consumer to the last message's sequence so it can be delivered still.
+		req = JSApiConsumerResetRequest{Seq: 4}
+		data, err = json.Marshal(req)
+		require_NoError(t, err)
+		resp = JSApiConsumerResetResponse{}
+		msg, err = nc.Request("$JS.API.CONSUMER.RESET.TEST.CONSUMER", data, time.Second)
+		require_NoError(t, err)
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		require_Equal(t, resp.Type, JSApiConsumerResetResponseType)
+		require_Equal(t, resp.ResetSeq, 4)
+		require_Equal(t, resp.Delivered.Stream, 3)
+		require_Equal(t, resp.Delivered.Last, nil)
+		require_Equal(t, resp.AckFloor.Stream, 3)
+		require_Equal(t, resp.AckFloor.Last, nil)
+
+		// One message left as pending, the delivered counts are now zero,
+		// but the sequence and AckFloor are moved up.
+		checkConsumerInfo(Expected{
+			numPending: 1, numAckPending: 0,
+			dseq: 0, adflr: 0,
+			sseq: 3, asflr: 3,
+		})
+
+		// As a result of moving the starting sequence up, some messages
+		// have now lost interest and need to be removed.
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			mset, err := sl.globalAccount().lookupStream("TEST")
+			if err != nil {
+				return err
+			}
+			state := mset.state()
+			if state.FirstSeq != 4 {
+				return fmt.Errorf("expected first seq to be 4, got %v", state)
+			}
+			return checkState(t, c, globalAccountName, "TEST")
+		})
+
+		// We fetch the last message.
+		msgs, err = sub.Fetch(1, nats.MaxWait(2*time.Second))
+		require_NoError(t, err)
+		require_Len(t, len(msgs), 1)
+		require_Equal(t, string(msgs[0].Data), "msg4")
+		checkConsumerInfo(Expected{
+			numPending: 0, numAckPending: 1,
+			dseq: 1, adflr: 0,
+			sseq: 4, asflr: 3,
+		})
+
+		// After acking, the delivered count should only show 1, but the AckFloor is higher.
+		require_NoError(t, msgs[0].AckSync())
+		checkConsumerInfo(Expected{
+			numPending: 0, numAckPending: 0,
+			dseq: 1, adflr: 1,
+			sseq: 4, asflr: 4,
+		})
+
+		// The stream should now be empty.
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			mset, err := sl.globalAccount().lookupStream("TEST")
+			if err != nil {
+				return err
+			}
+			state := mset.state()
+			if state.Msgs != 0 || state.FirstSeq != 5 {
+				return fmt.Errorf("stream is not empty: %v", state)
+			}
+			return checkState(t, c, globalAccountName, "TEST")
+		})
+	}
+
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) {
+			test(replicas)
+		})
+	}
+}
+
+func TestJetStreamConsumerResetToSequenceConstraintOnStartSeq(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+	}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	sub, err := js.PullSubscribe(_EMPTY_, "CONSUMER",
+		nats.BindStream("TEST"),
+		nats.StartSequence(3),
+	)
+	require_NoError(t, err)
+	defer sub.Drain()
+
+	for i := range 4 {
+		_, err = js.Publish("foo", []byte(fmt.Sprintf("msg%d", i+1)))
+		require_NoError(t, err)
+	}
+
+	// Fetch and ack the first message.
+	msgs, err := sub.Fetch(1, nats.MaxWait(time.Second))
+	require_NoError(t, err)
+	require_Len(t, len(msgs), 1)
+	require_Equal(t, string(msgs[0].Data), "msg3")
+	require_NoError(t, msgs[0].AckSync())
+
+	// Trying to reset below the configured starting sequence fails.
+	req := JSApiConsumerResetRequest{Seq: 2}
+	data, err := json.Marshal(req)
+	require_NoError(t, err)
+	var resp JSApiConsumerResetResponse
+	msg, err := nc.Request("$JS.API.CONSUMER.RESET.TEST.CONSUMER", data, time.Second)
+	require_NoError(t, err)
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_Equal(t, resp.Type, JSApiConsumerResetResponseType)
+	require_NotNil(t, resp.Error)
+	require_Error(t, resp.Error, NewJSConsumerInvalidResetError(errors.New("below start seq")))
+
+	// Resetting above or equal to the configured starting sequence succeeds.
+	req = JSApiConsumerResetRequest{Seq: 3}
+	data, err = json.Marshal(req)
+	require_NoError(t, err)
+	resp = JSApiConsumerResetResponse{}
+	msg, err = nc.Request("$JS.API.CONSUMER.RESET.TEST.CONSUMER", data, time.Second)
+	require_NoError(t, err)
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_Equal(t, resp.Type, JSApiConsumerResetResponseType)
+	require_Equal(t, resp.ResetSeq, 3)
+	require_Equal(t, resp.Delivered.Stream, 2)
+	require_Equal(t, resp.Delivered.Last, nil)
+	require_Equal(t, resp.AckFloor.Stream, 2)
+	require_Equal(t, resp.AckFloor.Last, nil)
+
+	// Fetching should now get the same message.
+	msgs, err = sub.Fetch(1, nats.MaxWait(time.Second))
+	require_NoError(t, err)
+	require_Len(t, len(msgs), 1)
+	require_Equal(t, string(msgs[0].Data), "msg3")
+	require_NoError(t, msgs[0].AckSync())
+}
+
+func TestJetStreamConsumerResetToSequenceConstraintOnStartTime(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+	}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	for i := range 2 {
+		_, err = js.Publish("foo", []byte(fmt.Sprintf("msg%d", i+1)))
+		require_NoError(t, err)
+	}
+
+	sub, err := js.PullSubscribe(_EMPTY_, "CONSUMER",
+		nats.BindStream("TEST"),
+		nats.StartTime(time.Now()),
+	)
+	require_NoError(t, err)
+	defer sub.Drain()
+
+	for i := range 2 {
+		_, err = js.Publish("foo", []byte(fmt.Sprintf("msg%d", i+3)))
+		require_NoError(t, err)
+	}
+
+	// Fetch and ack the first message.
+	msgs, err := sub.Fetch(1, nats.MaxWait(time.Second))
+	require_NoError(t, err)
+	require_Len(t, len(msgs), 1)
+	require_Equal(t, string(msgs[0].Data), "msg3")
+	require_NoError(t, msgs[0].AckSync())
+
+	// Trying to reset below the configured starting time fails.
+	req := JSApiConsumerResetRequest{Seq: 2}
+	data, err := json.Marshal(req)
+	require_NoError(t, err)
+	var resp JSApiConsumerResetResponse
+	msg, err := nc.Request("$JS.API.CONSUMER.RESET.TEST.CONSUMER", data, time.Second)
+	require_NoError(t, err)
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_Equal(t, resp.Type, JSApiConsumerResetResponseType)
+	require_NotNil(t, resp.Error)
+	require_Error(t, resp.Error, NewJSConsumerInvalidResetError(errors.New("below start time")))
+
+	// Resetting to a sequence that has a starting time above or equal to the configured starting time succeeds.
+	req = JSApiConsumerResetRequest{Seq: 3}
+	data, err = json.Marshal(req)
+	require_NoError(t, err)
+	resp = JSApiConsumerResetResponse{}
+	msg, err = nc.Request("$JS.API.CONSUMER.RESET.TEST.CONSUMER", data, time.Second)
+	require_NoError(t, err)
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_Equal(t, resp.Type, JSApiConsumerResetResponseType)
+	require_Equal(t, resp.ResetSeq, 3)
+	require_Equal(t, resp.Delivered.Stream, 2)
+	require_Equal(t, resp.Delivered.Last, nil)
+	require_Equal(t, resp.AckFloor.Stream, 2)
+	require_Equal(t, resp.AckFloor.Last, nil)
+
+	// Fetching should now get the same message.
+	msgs, err = sub.Fetch(1, nats.MaxWait(time.Second))
+	require_NoError(t, err)
+	require_Len(t, len(msgs), 1)
+	require_Equal(t, string(msgs[0].Data), "msg3")
+	require_NoError(t, msgs[0].AckSync())
+}

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -167,6 +167,9 @@ const (
 	// JSConsumerInvalidPriorityGroupErr Provided priority group does not exist for this consumer
 	JSConsumerInvalidPriorityGroupErr ErrorIdentifier = 10160
 
+	// JSConsumerInvalidResetErr invalid reset: {err}
+	JSConsumerInvalidResetErr ErrorIdentifier = 10204
+
 	// JSConsumerInvalidSamplingErrF failed to parse consumer sampling configuration: {err}
 	JSConsumerInvalidSamplingErrF ErrorIdentifier = 10095
 
@@ -668,6 +671,7 @@ var (
 		JSConsumerInvalidGroupNameErr:                {Code: 400, ErrCode: 10162, Description: "Valid priority group name must match A-Z, a-z, 0-9, -_/=)+ and may not exceed 16 characters"},
 		JSConsumerInvalidPolicyErrF:                  {Code: 400, ErrCode: 10094, Description: "{err}"},
 		JSConsumerInvalidPriorityGroupErr:            {Code: 400, ErrCode: 10160, Description: "Provided priority group does not exist for this consumer"},
+		JSConsumerInvalidResetErr:                    {Code: 400, ErrCode: 10204, Description: "invalid reset: {err}"},
 		JSConsumerInvalidSamplingErrF:                {Code: 400, ErrCode: 10095, Description: "failed to parse consumer sampling configuration: {err}"},
 		JSConsumerMaxDeliverBackoffErr:               {Code: 400, ErrCode: 10116, Description: "max deliver is required to be > length of backoff values"},
 		JSConsumerMaxPendingAckExcessErrF:            {Code: 400, ErrCode: 10121, Description: "consumer max ack pending exceeds system limit of {limit}"},
@@ -1421,6 +1425,22 @@ func NewJSConsumerInvalidPriorityGroupError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSConsumerInvalidPriorityGroupErr]
+}
+
+// NewJSConsumerInvalidResetError creates a new JSConsumerInvalidResetErr error: "invalid reset: {err}"
+func NewJSConsumerInvalidResetError(err error, opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	e := ApiErrors[JSConsumerInvalidResetErr]
+	args := e.toReplacerArgs([]interface{}{"{err}", err})
+	return &ApiError{
+		Code:        e.Code,
+		ErrCode:     e.ErrCode,
+		Description: strings.NewReplacer(args...).Replace(e.Description),
+	}
 }
 
 // NewJSConsumerInvalidSamplingError creates a new JSConsumerInvalidSamplingErrF error: "failed to parse consumer sampling configuration: {err}"

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -2378,6 +2378,7 @@ func (o *consumerMemStore) Update(state *ConsumerState) error {
 func (o *consumerMemStore) SetStarting(sseq uint64) error {
 	o.mu.Lock()
 	o.state.Delivered.Stream = sseq
+	o.state.AckFloor.Stream = sseq
 	o.mu.Unlock()
 	return nil
 }
@@ -2394,6 +2395,14 @@ func (o *consumerMemStore) UpdateStarting(sseq uint64) {
 			o.state.AckFloor.Stream = sseq
 		}
 	}
+}
+
+// Reset all values in the store, and reset the starting sequence.
+func (o *consumerMemStore) Reset(sseq uint64) error {
+	o.mu.Lock()
+	o.state = ConsumerState{}
+	o.mu.Unlock()
+	return o.SetStarting(sseq)
 }
 
 // HasState returns if this store has a recorded state.

--- a/server/store.go
+++ b/server/store.go
@@ -358,6 +358,7 @@ func (dbs DeleteBlocks) NumDeleted() (total uint64) {
 type ConsumerStore interface {
 	SetStarting(sseq uint64) error
 	UpdateStarting(sseq uint64)
+	Reset(sseq uint64) error
 	HasState() bool
 	UpdateDelivered(dseq, sseq, dc uint64, ts int64) error
 	UpdateAcks(dseq, sseq uint64) error


### PR DESCRIPTION
Currently we don't offer durable ordered consumption of a stream. We do support ephemeral ordered push consumers, but those can be problematic when using those on WQ/Interest streams as as soon as the server sends the message the "ack" happens immediately, resulting in the message to be removed. Similarly recreating the consumer (through delete+create) may lose interest and remove messages. Durable consumers could be used for guaranteed ordered consumption by using the "pinning" introduced in 2.11, ensuring only one app instance, combined with resetting it to a sequence. Setting the `FilterSubject(s)` to all subjects that need sequential ordering.

This PR introduces a new API to reset the starting sequence of a consumer, such that it can be used for ordered durable consumption. Sending a request to `$JS.API.CONSUMER.RESET.<stream>.<consumer>` with `{"seq":10}` will reset all state of the consumer and move it (either forwards or backwards) to the specified sequence. When fetching messages, the first message to be delivered will be the one with the specified sequence, the consumer's delivered sequence will (re)start at 1.

This feature unlocks ordering guarantees for durable consumers. When combined with "pinning", there's ordered consumption to a specific app instance, until it's unpinned and the ordered delivery continues to another app.

Resolves https://github.com/nats-io/nats-server/issues/4121, https://github.com/nats-io/nats-server/issues/7106, https://github.com/nats-io/nats-server/issues/4855, https://github.com/nats-io/nats-server/issues/2090
Relates to https://github.com/nats-io/nats-server/issues/7493, https://github.com/nats-io/nats-server/issues/4273, https://github.com/nats-io/nats-server/issues/2043

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>