### PR TITLE
Ensure filestore cache `fseq` always relative to indexed slots

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7095,10 +7095,11 @@ func (mb *msgBlock) indexCacheBuf(buf []byte) error {
 					}
 				}
 			}
-			// Add to our index.
-			idx = append(idx, index)
-			// Adjust if we guessed wrong.
-			if seq != 0 && seq < fseq {
+
+			// Add to our index. Set fseq only for the first indexed message. This should
+			// guarantee that slotInfo offsets based off fseq are always relative to idx,
+			// even with leading tombstoned messages etc.
+			if idx = append(idx, index); len(idx) == 1 {
 				fseq = seq
 			}
 


### PR DESCRIPTION
In some cases, like with leading tombstoned messages, the `fseq` may have been incorrectly offset to a message that didn't have a slot position in the index. This could potentially cause issues on later `slotInfo()` calls. This should guarantee that we always take the sequence of the first indexed message instead.

Signed-off-by: Neil Twigg <neil@nats.io>