### PR TITLE
[FIXED] Parallel stream restore panic

### DIFF
--- a/server/ats/ats.go
+++ b/server/ats/ats.go
@@ -77,7 +77,10 @@ func AccessTime() int64 {
 	// Return last updated time.
 	v := utime.Load()
 	if v == 0 {
-		panic("access time service not running")
+		// Always register a time, the worst case is a stale time.
+		// On startup, we can register in parallel and could previously panic.
+		v = time.Now().UnixNano()
+		utime.Store(v)
 	}
 	return v
 }

--- a/server/ats/ats_test.go
+++ b/server/ats/ats_test.go
@@ -19,15 +19,18 @@ import (
 	"time"
 )
 
-func TestNotRunningPanic(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("Expected function to panic, but it did not")
-		}
-	}()
+func TestNotRunningValue(t *testing.T) {
 	// Set back to zero in case this test gets run multiple times via --count.
 	utime.Store(0)
-	_ = AccessTime()
+	at := AccessTime()
+	if at == 0 {
+		t.Fatal("Expected non-zero access time")
+	}
+
+	atn := AccessTime()
+	if atn != at {
+		t.Fatal("Did not expect updates to access time")
+	}
 }
 
 func TestRegisterAndUnregister(t *testing.T) {


### PR DESCRIPTION
Due to the stream restore parallelization introduced in https://github.com/nats-io/nats-server/pull/7482, we can panic on `access time service not running`. Since `ats.Register()` can now be called in parallel as well.

We can simply store an initial value, on startup it's no issue that this timestamp is only slightly stale.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>