### PR TITLE
(2.14) Repeating schedule on an interval

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -4876,14 +4876,18 @@ func getMessageSchedule(hdr []byte) (time.Time, bool) {
 		return time.Time{}, true
 	}
 	val := bytesToString(sliceHeader(JSSchedulePattern, hdr))
-	if val == _EMPTY_ {
+	schedule, _, ok := parseMsgSchedule(val, time.Now().UTC().UnixNano())
+	return schedule, ok
+}
+
+// Fast lookup and calculation of next message schedule.
+func nextMessageSchedule(hdr []byte, ts int64) (time.Time, bool) {
+	if len(hdr) == 0 {
 		return time.Time{}, true
 	}
-	if !strings.HasPrefix(val, "@at ") {
-		return time.Time{}, false
-	}
-	t, err := time.Parse(time.RFC3339, val[4:])
-	return t, err == nil
+	val := bytesToString(sliceHeader(JSSchedulePattern, hdr))
+	schedule, _, ok := parseMsgSchedule(val, ts)
+	return schedule, ok
 }
 
 // Fast lookup of the message schedule TTL from headers.


### PR DESCRIPTION
Supports a repeating schedule on an interval as described in [ADR-51](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md#intervals).

A schedule like `@every 1s` will publish a message every second. A schedule can't run more quickly than once a second. For the case where the server has been down for a minute and it comes back up, it will not immediately trigger/spam 60 events. Instead it will only trigger once and continue on the same interval.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>