### PR TITLE
(2.14) Schedule subject sourcing/sampling

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -2008,5 +2008,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSMessageSchedulesSourceInvalidErr",
+    "code": 400,
+    "error_code": 10203,
+    "description": "message schedules source is invalid",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -534,6 +534,10 @@ func checkMsgHeadersPreClusteredProposal(
 				!IsValidPublishSubject(scheduleTarget) || SubjectsCollide(scheduleTarget, subject) {
 				apiErr := NewJSMessageSchedulesTargetInvalidError()
 				return hdr, msg, 0, apiErr, apiErr
+			} else if scheduleSource := getMessageScheduleSource(hdr); scheduleSource != _EMPTY_ &&
+				(scheduleSource == scheduleTarget || scheduleSource == subject || !IsValidPublishSubject(scheduleSource)) {
+				apiErr := NewJSMessageSchedulesSourceInvalidError()
+				return hdr, msg, 0, apiErr, apiErr
 			} else {
 				mset.cfgMu.RLock()
 				match := slices.ContainsFunc(mset.cfg.Subjects, func(subj string) bool {

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -9468,6 +9468,93 @@ func TestJetStreamClusterScheduledDelayedMessage(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterScheduledMessageSubjectSourcing(t *testing.T) {
+	for _, replicas := range []int{1, 3} {
+		for _, storage := range []StorageType{FileStorage, MemoryStorage} {
+			t.Run(fmt.Sprintf("R%d/%s", replicas, storage), func(t *testing.T) {
+				c := createJetStreamClusterExplicit(t, "R3S", 3)
+				defer c.shutdown()
+
+				nc, js := jsClientConnect(t, c.randomServer())
+				defer nc.Close()
+
+				cfg := &StreamConfig{
+					Name:              "SchedulesEnabled",
+					Subjects:          []string{"foo.*"},
+					Storage:           storage,
+					Replicas:          replicas,
+					AllowMsgSchedules: true,
+					AllowMsgTTL:       true,
+				}
+				_, err := jsStreamCreate(t, nc, cfg)
+				require_NoError(t, err)
+
+				m := nats.NewMsg("foo.data")
+				m.Header.Set("Header", "Value")
+				m.Data = []byte("data")
+
+				pubAck, err := js.PublishMsg(m)
+				require_NoError(t, err)
+				require_Equal(t, pubAck.Sequence, 1)
+
+				m = nats.NewMsg("foo.schedule")
+				m.Header.Set("Nats-Schedule", "@at 1970-01-01T00:00:00Z")
+				m.Header.Set("Nats-Schedule-Target", "foo.publish")
+
+				// Invalid sources include if the subject:
+				// - matches the schedule/target subject
+				// - contains wildcard/is not literal
+				for _, src := range []string{"foo.schedule", "foo.publish", "foo.*", "foo.>"} {
+					m.Header.Set("Nats-Schedule-Source", src)
+					_, err = js.PublishMsg(m)
+					require_Error(t, err, NewJSMessageSchedulesSourceInvalidError())
+				}
+
+				// Now publish using a correct source subject.
+				m.Header.Set("Nats-Schedule-Source", "foo.data")
+				pubAck, err = js.PublishMsg(m)
+				require_NoError(t, err)
+				require_Equal(t, pubAck.Sequence, 2)
+
+				sl := c.streamLeader(globalAccountName, "SchedulesEnabled")
+				mset, err := sl.globalAccount().lookupStream("SchedulesEnabled")
+				require_NoError(t, err)
+
+				state := mset.state()
+				require_Equal(t, state.LastSeq, 2)
+				require_Equal(t, state.Msgs, 2)
+
+				// Waiting for the delayed message to be published.
+				checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+					state = mset.state()
+					if state.LastSeq != 3 {
+						return fmt.Errorf("expected last seq 3, got %d", state.LastSeq)
+					} else if state.Msgs != 2 {
+						// One is the scheduled message, one is the sourced message.
+						return fmt.Errorf("expected 2 msgs, got %d", state.Msgs)
+					}
+					return nil
+				})
+
+				// Confirm the scheduled message has the correct data.
+				rsm, err := js.GetLastMsg("SchedulesEnabled", "foo.publish")
+				require_NoError(t, err)
+				require_Equal(t, rsm.Sequence, 3)
+				require_True(t, bytes.Equal(rsm.Data, []byte("data")))
+				require_Len(t, len(rsm.Header), 3)
+				require_Equal(t, rsm.Header.Get("Nats-Scheduler"), "foo.schedule")
+				require_Equal(t, rsm.Header.Get("Nats-Schedule-Next"), "purge")
+				require_Equal(t, rsm.Header.Get("Header"), "Value")
+
+				// Servers should be synced.
+				checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+					return checkState(t, c, globalAccountName, "SchedulesEnabled")
+				})
+			})
+		}
+	}
+}
+
 func TestJetStreamClusterScheduledDelayedMessageReversedHeaderOrder(t *testing.T) {
 	for _, replicas := range []int{1, 3} {
 		for _, storage := range []StorageType{FileStorage, MemoryStorage} {

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -317,6 +317,9 @@ const (
 	// JSMessageSchedulesRollupInvalidErr message schedules invalid rollup
 	JSMessageSchedulesRollupInvalidErr ErrorIdentifier = 10192
 
+	// JSMessageSchedulesSourceInvalidErr message schedules source is invalid
+	JSMessageSchedulesSourceInvalidErr ErrorIdentifier = 10203
+
 	// JSMessageSchedulesTTLInvalidErr message schedules invalid per-message TTL
 	JSMessageSchedulesTTLInvalidErr ErrorIdentifier = 10191
 
@@ -715,6 +718,7 @@ var (
 		JSMessageSchedulesDisabledErr:                {Code: 400, ErrCode: 10188, Description: "message schedules is disabled"},
 		JSMessageSchedulesPatternInvalidErr:          {Code: 400, ErrCode: 10189, Description: "message schedules pattern is invalid"},
 		JSMessageSchedulesRollupInvalidErr:           {Code: 400, ErrCode: 10192, Description: "message schedules invalid rollup"},
+		JSMessageSchedulesSourceInvalidErr:           {Code: 400, ErrCode: 10203, Description: "message schedules source is invalid"},
 		JSMessageSchedulesTTLInvalidErr:              {Code: 400, ErrCode: 10191, Description: "message schedules invalid per-message TTL"},
 		JSMessageSchedulesTargetInvalidErr:           {Code: 400, ErrCode: 10190, Description: "message schedules target is invalid"},
 		JSMessageTTLDisabledErr:                      {Code: 400, ErrCode: 10166, Description: "per-message TTL is disabled"},
@@ -1965,6 +1969,16 @@ func NewJSMessageSchedulesRollupInvalidError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSMessageSchedulesRollupInvalidErr]
+}
+
+// NewJSMessageSchedulesSourceInvalidError creates a new JSMessageSchedulesSourceInvalidErr error: "message schedules source is invalid"
+func NewJSMessageSchedulesSourceInvalidError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMessageSchedulesSourceInvalidErr]
 }
 
 // NewJSMessageSchedulesTTLInvalidError creates a new JSMessageSchedulesTTLInvalidErr error: "message schedules invalid per-message TTL"


### PR DESCRIPTION
Supports a subject sourcing/sampling as described in [ADR-51](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md#subject-sampling).

A schedule can contain a `Nats-Schedule-Source` to grab the last message data and headers for that subject to be included in the scheduled message.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>