### PR TITLE
NRG: Install leader snapshot on scaleup

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -4744,7 +4744,7 @@ func TestJetStreamClusterSnapshotAndRestoreWithHealthz(t *testing.T) {
 
 	checkHealth := func() {
 		t.Helper()
-		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
 			for _, s := range c.servers {
 				status := s.healthz(nil)
 				if status.Error != _EMPTY_ {


### PR DESCRIPTION
When scaling up a stream from R1 to R3 a snapshot is made of the R1 stream and `SendSnapshot` is called to share the initial state with the new peers. However, this snapshot would solely be in the log and not installed. If the upper layer JetStream catchup were to fail halfway, the two incomplete peers could try to become the leader. This could then result in the stream becoming desynced.

We can ensure these peers never become leader before they're fully synced by installing the snapshot, as that ensures the upper layer can process it during recovery. If the previous R1 leader is not online to perform the catchup, the follower can now successfully call `n.DrainAndReplaySnapshot()` without needing to reset clustered state. Allowing it to reuse the installed snapshot and not become leader until after the snapshot has been successfully processed.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>