### PR TITLE
[IMPROVED] Scale up stalled race condition

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2734,6 +2734,9 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 			}
 
 		case isLeader = <-lch:
+			// Process our leader change.
+			js.processStreamLeaderChange(mset, isLeader)
+
 			if isLeader {
 				if mset != nil && n != nil && sendSnapshot && !isRecovering {
 					// If we *are* recovering at the time then this will get done when the apply queue
@@ -2750,13 +2753,9 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 				}
 				// Always cancel if this was running.
 				stopDirectMonitoring()
-
 			} else if !n.Leaderless() {
 				js.setStreamAssignmentRecovering(sa)
 			}
-
-			// Process our leader change.
-			js.processStreamLeaderChange(mset, isLeader)
 
 			// We may receive a leader change after the stream assignment which would cancel us
 			// monitoring for this closely. So re-assess our state here as well.


### PR DESCRIPTION
During a scale up `sendSnapshot` will be set, and `n.SendSnapshot(snap)` will be called with the stream's snapshot. Followers would react to this snapshot by requesting a catchup from the leader. However, the leader only subscribes to the cluster sync subject when calling `js.processStreamLeaderChange`. Since the latter was done after `n.SendSnapshot` this could result in a race condition where the followers would try to request a catch up but get no response, stall, and retry after 5 seconds, making the scale up take longer than necessary.

Moving `js.processStreamLeaderChange` up means we'll already be subscribed to the cluster sync sub before followers will be able to request a catchup. Ensuring the leader will be able to respond.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>