### PR TITLE
Reduce allocations in sublist and subject transforms

### DIFF
--- a/server/gsl/gsl.go
+++ b/server/gsl/gsl.go
@@ -15,6 +15,7 @@ package gsl
 
 import (
 	"errors"
+	"strings"
 	"sync"
 	"unsafe"
 
@@ -87,24 +88,13 @@ func NewSublist[T comparable]() *GenericSublist[T] {
 
 // Insert adds a subscription into the sublist
 func (s *GenericSublist[T]) Insert(subject string, value T) error {
-	tsa := [32]string{}
-	tokens := tsa[:0]
-	start := 0
-	for i := 0; i < len(subject); i++ {
-		if subject[i] == btsep {
-			tokens = append(tokens, subject[start:i])
-			start = i + 1
-		}
-	}
-	tokens = append(tokens, subject[start:])
-
 	s.Lock()
 
 	var sfwc bool
 	var n *node[T]
 	l := s.root
 
-	for _, t := range tokens {
+	for t := range strings.SplitSeq(subject, tsep) {
 		lt := len(t)
 		if lt == 0 || sfwc {
 			s.Unlock()
@@ -312,17 +302,6 @@ type lnt[T comparable] struct {
 
 // Raw low level remove, can do batches with lock held outside.
 func (s *GenericSublist[T]) remove(subject string, value T, shouldLock bool) error {
-	tsa := [32]string{}
-	tokens := tsa[:0]
-	start := 0
-	for i := 0; i < len(subject); i++ {
-		if subject[i] == btsep {
-			tokens = append(tokens, subject[start:i])
-			start = i + 1
-		}
-	}
-	tokens = append(tokens, subject[start:])
-
 	if shouldLock {
 		s.Lock()
 		defer s.Unlock()
@@ -336,7 +315,7 @@ func (s *GenericSublist[T]) remove(subject string, value T, shouldLock bool) err
 	var lnts [32]lnt[T]
 	levels := lnts[:0]
 
-	for _, t := range tokens {
+	for t := range strings.SplitSeq(subject, tsep) {
 		lt := len(t)
 		if lt == 0 || sfwc {
 			return ErrInvalidSubject

--- a/server/subject_transform.go
+++ b/server/subject_transform.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"math/rand"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -378,7 +379,7 @@ func transformTokenize(subject string) string {
 	// We need to make the appropriate markers for the wildcards etc.
 	i := 1
 	var nda []string
-	for _, token := range strings.Split(subject, tsep) {
+	for token := range strings.SplitSeq(subject, tsep) {
 		if token == pwcs {
 			nda = append(nda, fmt.Sprintf("$%d", i))
 			i++
@@ -399,7 +400,7 @@ func transformUntokenize(subject string) (string, []string) {
 	var phs []string
 	var nda []string
 
-	for _, token := range strings.Split(subject, tsep) {
+	for token := range strings.SplitSeq(subject, tsep) {
 		if args := getMappingFunctionArgs(wildcardMappingFunctionRegEx, token); (len(token) > 1 && token[0] == '$' && token[1] >= '1' && token[1] <= '9') || (len(args) == 1 && args[0] != _EMPTY_) {
 			phs = append(phs, token)
 			nda = append(nda, pwcs)
@@ -439,7 +440,7 @@ func (tr *subjectTransform) Match(subject string) (string, error) {
 	tts := tokenizeSubject(subject)
 
 	// TODO(jnm): optimization -> not sure this is actually needed but was there in initial code
-	if !isValidLiteralSubject(tts) {
+	if !isValidLiteralSubject(slices.Values(tts)) {
 		return _EMPTY_, ErrBadSubject
 	}
 


### PR DESCRIPTION
In a few places we can use iterators rather than allocating new slices for better performance.

Signed-off-by: Neil Twigg <neil@nats.io>