### PR TITLE
[FIXED] NRG: Quorum reporting after leader stepdown

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3483,6 +3483,7 @@ func (n *raft) resetWAL() {
 
 // Lock should be held
 func (n *raft) updateLeader(newLeader string) {
+	wasLeader := n.leader == n.id
 	n.leader = newLeader
 	n.hasleader.Store(newLeader != _EMPTY_)
 	if !n.pleader.Load() && newLeader != noLeader {
@@ -3499,9 +3500,9 @@ func (n *raft) updateLeader(newLeader string) {
 		}
 	}
 	// Reset last seen timestamps.
-	// If we're the leader we track everyone, and don't reset.
+	// If we are (or were) the leader we track(ed) everyone, and don't reset.
 	// But if we're a follower we only track the leader, and reset all others.
-	if newLeader != n.id {
+	if newLeader != n.id && !wasLeader {
 		for peer, ps := range n.peers {
 			if peer == newLeader {
 				continue


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/7402. When shutting down a server with LDM or having the leader step down, all peer timestamps would be cleared. This resulted in quorum being reported as lost for all Raft nodes that the server was leader for, a "NO quorum, stalled" message to be printed, and an advisory to be sent.

This PR fixes that by ensuring the leader remembers the timestamps after stepping down. Once the new leader comes online the other follower's timestamp can still be cleared.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>