### PR TITLE
Add meta snapshot metrics to jsz monitoring

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -70,6 +70,9 @@ type jetStreamCluster struct {
 	peerStreamCancelMove *subscription
 	// To pop out the monitorCluster before the raft layer.
 	qch chan struct{}
+	// Track last meta snapshot time and duration for monitoring.
+	lastMetaSnapTime     int64 // Unix nanoseconds
+	lastMetaSnapDuration int64 // Duration in nanoseconds
 }
 
 // Used to track inflight stream add requests to properly re-use same group and sync subject.
@@ -1667,15 +1670,23 @@ func (js *jetStream) metaSnapshot() ([]byte, error) {
 		return nil, err
 	}
 
-	// Track how long it took to compress the JSON
+	// Track how long it took to compress the JSON.
 	cstart := time.Now()
 	snap := s2.Encode(nil, b)
 	cend := time.Since(cstart)
+	took := time.Since(start)
 
-	if took := time.Since(start); took > time.Second {
+	if took > time.Second {
 		s.rateLimitFormatWarnf("Metalayer snapshot took %.3fs (streams: %d, consumers: %d, marshal: %.3fs, s2: %.3fs, uncompressed: %d, compressed: %d)",
 			took.Seconds(), nsa, nca, mend.Seconds(), cend.Seconds(), len(b), len(snap))
 	}
+
+	// Track in jsz monitoring as well.
+	if cc != nil {
+		atomic.StoreInt64(&cc.lastMetaSnapTime, start.UnixNano())
+		atomic.StoreInt64(&cc.lastMetaSnapDuration, int64(took))
+	}
+
 	return snap, nil
 }
 

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -5306,6 +5306,52 @@ func TestMonitorJsz(t *testing.T) {
 			t.Fatalf("received cluster info from multiple nodes")
 		}
 	})
+	t.Run("meta-snapshot-stats", func(t *testing.T) {
+		for _, url := range []string{monUrl1, monUrl2} {
+			info := readJsInfo(url)
+			require_True(t, info.Meta != nil)
+			require_True(t, info.Meta.Snapshot != nil)
+
+			snapshot := info.Meta.Snapshot
+
+			// In case no snapshots have happened there would be some pending entries.
+			if snapshot.LastTime.IsZero() {
+				require_True(t, snapshot.PendingEntries >= 1)
+				require_True(t, snapshot.PendingSize >= 1)
+			}
+
+			// Force meta snapshots on both servers to test snapshot timing.
+			for _, srv := range srvs {
+				if js := srv.getJetStream(); js != nil {
+					if mg := js.getMetaGroup(); mg != nil {
+						if snap, err := js.metaSnapshot(); err == nil {
+							mg.InstallSnapshot(snap)
+						}
+					}
+				}
+			}
+			// Wait for snapshot timing to be recorded
+			time.Sleep(100 * time.Millisecond)
+
+			// Get latest stats again.
+			info = readJsInfo(url)
+			require_True(t, info.Meta != nil)
+			require_True(t, info.Meta.Snapshot != nil)
+
+			snapshot = info.Meta.Snapshot
+
+			require_True(t, !snapshot.LastTime.IsZero())
+			// Assert that snapshot time is in UTC
+			require_Equal(t, snapshot.LastTime.Location(), time.UTC)
+
+			// Assert that duration is non-negative and reasonable
+			require_True(t, snapshot.LastDuration >= 0)
+			require_True(t, snapshot.LastDuration < 30*time.Second)
+
+			// Assert that snapshot time is recent.
+			require_True(t, time.Since(snapshot.LastTime) < 5*time.Minute)
+		}
+	})
 	t.Run("account-non-existing", func(t *testing.T) {
 		for _, url := range []string{monUrl1, monUrl2} {
 			info := readJsInfo(url + "?acc=DOES_NOT_EXIST")


### PR DESCRIPTION
Exposes snapshot related metrics under /jsz

```js
"meta_cluster": {
    "pending": 0,
    "snapshot": {
        "pending_entries": 1,
        "pending_size": 1314,
        "last_time": "2025-11-06T18:14:40.659678019Z", # UTC
        "last_duration": 161096363
     }
}
```

Signed-off-by: Waldemar Quevedo <wally@nats.io>
