### PR TITLE
[FIXED] Filestore missing deletes

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7137,8 +7137,8 @@ func (mb *msgBlock) indexCacheBuf(buf []byte) error {
 	// earlier loop if we've ran out of block file to look at, but should
 	// be easily noticed because the seq will be below the last seq from
 	// the index.
-	if seq > 0 && seq+1 <= mbLastSeq {
-		for dseq := seq + 1; dseq <= mbLastSeq; dseq++ {
+	if last > 0 && last+1 >= mbFirstSeq && last+1 <= mbLastSeq {
+		for dseq := last + 1; dseq <= mbLastSeq; dseq++ {
 			idx = append(idx, dbit)
 			if dms == 0 {
 				mb.dmap.Insert(dseq)


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/7508. There would be missing deletes due to the `seq` in `indexCacheBuf` taking the last sequence which could be a tombstone. Instead should take the `last` known to be good sequence and base it from there.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>