### PR TITLE
[FIXED] LDM results in max connections exceeded errors

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -5834,7 +5834,8 @@ func (c *client) closeConnection(reason ClosedState) {
 	}
 
 	// If we are shutting down, no need to do all the accounting on subs, etc.
-	if reason == ServerShutdown {
+	// During LDM we'll still do the accounting, otherwise account limits could close others after this reconnects.
+	if reason == ServerShutdown && c.srv.isShuttingDown() {
 		s := c.srv
 		c.mu.Unlock()
 		if s != nil {


### PR DESCRIPTION
An account using the maximum connections setting means that particular account can only have N connections connected at the same time. A server going into "Lame Duck Mode" will slowly start forcing clients to reconnect to other servers. However, these closed connections would not be deducted from counting against the account limit. Every reconnected client would be counted twice during the LDM duration. If the amount of connections was close to the limit, lots of connections that weren't reconnected yet would instead receive the `maximum account active connections exceeded` error.

This PR fixes this condition by continuing to do the full accounting, even while LDM is active. Only if the server is shutting down with `s.Shutdown()` will it close any remaining clients without needing to do the accounting.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>