### PR TITLE
[IMPROVED] Stream catchup shows up in health check

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -641,11 +641,11 @@ func (js *jetStream) isStreamHealthy(acc *Account, sa *streamAssignment) error {
 	case !mset.isMonitorRunning():
 		return errors.New("monitor goroutine not running")
 
-	case !node.Healthy():
-		return errors.New("group node unhealthy")
-
 	case mset.isCatchingUp():
 		return errors.New("stream catching up")
+
+	case !node.Healthy():
+		return errors.New("group node unhealthy")
 
 	default:
 		return nil


### PR DESCRIPTION
The health check would report `group node unhealthy` while a stream is catching up and would never reach the `stream catching up` path, as the Raft state will not advance until after the catchup completes. Change the ordering such that we can properly report the catching up state.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>