### PR TITLE
Add `direct-consumers` flag to `jsz` monitoring endpoint

### DIFF
--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -5241,6 +5241,23 @@ func TestMonitorJsz(t *testing.T) {
 			}
 		}
 	})
+	t.Run("direct-consumers", func(t *testing.T) {
+		for _, url := range []string{monUrl1} {
+			info := readJsInfo(url + "?acc=ACC&consumers=true&direct-consumers=true")
+			if len(info.AccountDetails) != 1 {
+				t.Fatalf("expected account ACC to be returned by %s but got %v", url, info)
+			}
+			// It could take time for the sourcing to set up.
+			checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+				if !slices.ContainsFunc(info.AccountDetails[0].Streams, func(stream StreamDetail) bool {
+					return len(stream.DirectConsumer) > 0
+				}) {
+					return fmt.Errorf("expected direct consumer info in detail returned by %v", url)
+				}
+				return nil
+			})
+		}
+	})
 	t.Run("config", func(t *testing.T) {
 		for _, url := range []string{monUrl1, monUrl2} {
 			info := readJsInfo(url + "?acc=ACC&consumers=true&config=true")

--- a/server/stream.go
+++ b/server/stream.go
@@ -7198,6 +7198,20 @@ func (mset *stream) getPublicConsumers() []*consumer {
 	return obs
 }
 
+// This returns all consumers that are DIRECT.
+func (mset *stream) getDirectConsumers() []*consumer {
+	mset.clsMu.RLock()
+	defer mset.clsMu.RUnlock()
+
+	var obs []*consumer
+	for _, o := range mset.cList {
+		if o.cfg.Direct {
+			obs = append(obs, o)
+		}
+	}
+	return obs
+}
+
 // 2 minutes plus up to 30s jitter.
 const (
 	defaultCheckInterestStateT = 2 * time.Minute


### PR DESCRIPTION
It is currently not possible to see direct consumers that are used by sources or mirrors. This extends `jsz` to make it possible to see these direct consumers to help when diagnosing sourcing/mirroring issues.

Signed-off-by: Neil Twigg <neil@nats.io>