### PR TITLE
[CANARY] jwt to v2.8.1 - testing PR #241 (fix-nsc-775)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,11 @@ require (
 	github.com/antithesishq/antithesis-sdk-go v0.4.3-default-no-op
 	github.com/google/go-tpm v0.9.6
 	github.com/klauspost/compress v1.18.1
+
+	// We don't usually pin non-tagged commits but so far no release has
+	// been made that includes https://github.com/minio/highwayhash/pull/29.
+	// This will be updated if a new tag covers this in the future.
+	github.com/minio/highwayhash v1.0.4-0.20251030100505-070ab1a87a76
 	github.com/nats-io/jwt/v2 v2.8.0
 	github.com/nats-io/nats.go v1.47.0
 	github.com/nats-io/nkeys v0.4.11
@@ -16,9 +21,7 @@ require (
 	golang.org/x/crypto v0.43.0
 	golang.org/x/sys v0.38.0
 	golang.org/x/time v0.14.0
-
-	// We don't usually pin non-tagged commits but so far no release has
-	// been made that includes https://github.com/minio/highwayhash/pull/29.
-	// This will be updated if a new tag covers this in the future.
-	github.com/minio/highwayhash v1.0.4-0.20251030100505-070ab1a87a76
 )
+
+// testing jwt PR #241 (fix-nsc-775)
+replace github.com/nats-io/jwt/v2 => github.com/nats-io/jwt/v2 v2.8.1-0.20251114161926-adf3daff28cc

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/klauspost/compress v1.18.1 h1:bcSGx7UbpBqMChDtsF28Lw6v/G94LPrrbMbdC3J
 github.com/klauspost/compress v1.18.1/go.mod h1:ZQFFVG+MdnR0P+l6wpXgIL4NTtwiKIdBnrBd8Nrxr+0=
 github.com/minio/highwayhash v1.0.4-0.20251030100505-070ab1a87a76 h1:KGuD/pM2JpL9FAYvBrnBBeENKZNh6eNtjqytV6TYjnk=
 github.com/minio/highwayhash v1.0.4-0.20251030100505-070ab1a87a76/go.mod h1:GGYsuwP/fPD6Y9hMiXuapVvlIUEhFhMTh0rxU3ik1LQ=
-github.com/nats-io/jwt/v2 v2.8.0 h1:K7uzyz50+yGZDO5o772eRE7atlcSEENpL7P+b74JV1g=
-github.com/nats-io/jwt/v2 v2.8.0/go.mod h1:me11pOkwObtcBNR8AiMrUbtVOUGkqYjMQZ6jnSdVUIA=
+github.com/nats-io/jwt/v2 v2.8.1-0.20251114161926-adf3daff28cc h1:tGuIrVN0oWJM+rk/+8tiZV9PqG2Ew/roVW+ANHGaBQQ=
+github.com/nats-io/jwt/v2 v2.8.1-0.20251114161926-adf3daff28cc/go.mod h1:me11pOkwObtcBNR8AiMrUbtVOUGkqYjMQZ6jnSdVUIA=
 github.com/nats-io/nats.go v1.47.0 h1:YQdADw6J/UfGUd2Oy6tn4Hq6YHxCaJrVKayxxFqYrgM=
 github.com/nats-io/nats.go v1.47.0/go.mod h1:iRWIPokVIFbVijxuMQq4y9ttaBTMe0SFdlZfMDd+33g=
 github.com/nats-io/nkeys v0.4.11 h1:q44qGV008kYd9W1b1nEBkNzvnWxtRSQ7A8BoqRrcfa0=

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -6319,11 +6319,11 @@ func TestJWTMappings(t *testing.T) {
 	aKp, aPub := createKey(t)
 	aClaim := jwt.NewAccountClaims(aPub)
 	aJwtNoM := encodeClaim(t, aClaim, aPub)
-	aClaim.AddMapping("foo1", jwt.WeightedMapping{Subject: "bar1"})
+	aClaim.AddMapping("foo1", jwt.WeightedMapping{Subject: "bar1", Weight: 100})
 	aJwtMap1 := encodeClaim(t, aClaim, aPub)
 
 	aClaim.Mappings = map[jwt.Subject][]jwt.WeightedMapping{}
-	aClaim.AddMapping("foo2", jwt.WeightedMapping{Subject: "bar2"})
+	aClaim.AddMapping("foo2", jwt.WeightedMapping{Subject: "bar2", Weight: 100})
 	aJwtMap2 := encodeClaim(t, aClaim, aPub)
 
 	dirSrv := t.TempDir()


### PR DESCRIPTION
Updated jwt dependency to a pre-release version to test fixes from PR https://github.com/nats-io/jwt/pull/241 addressing nsc issue https://github.com/nats-io/nsc/issues/775. Adjusted go.mod replace directive accordingly.

@neilalexander this is trying to honor a mapping - the reason for the issue has a workaround (remove the mapping) but the ability to have a mapping that removes all traffic is needed - the original work on this didn't include that functionality.

Signed-off-by: Your Name alberto@synadia.com
