### PR TITLE
(2.14) [FIXED] Filestore delete map race

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -10669,8 +10669,14 @@ func (fs *fileStore) deleteBlocks() DeleteBlocks {
 // deleteMap returns all interior deletes for each block based on the mb.dmap.
 // Specifically, this will not contain any deletes for blocks that have been removed.
 // This is useful to know whether a tombstone is still relevant and marked as deleted by an active block.
-// All blocks should be at least read locked.
+// No locks should be held.
 func (fs *fileStore) deleteMap() (dmap avl.SequenceSet) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	fs.readLockAllMsgBlocks()
+	defer fs.readUnlockAllMsgBlocks()
+
 	for _, mb := range fs.blks {
 		if mb.dmap.Size() > 0 {
 			mb.dmap.Range(func(seq uint64) bool {


### PR DESCRIPTION
Fixes a data race introduced in https://github.com/nats-io/nats-server/pull/7387:

```
WARNING: DATA RACE
Read at 0x00c0002d17f0 by goroutine 527:
  github.com/nats-io/nats-server/v2/server/avl.(*SequenceSet).Range()
      server/avl/seqset.go:125 +0x3b
  github.com/nats-io/nats-server/v2/server.(*fileStore).deleteMap()
      server/filestore.go:10676 +0x164

Previous write at 0x00c0002d17f0 by goroutine 182:
  github.com/nats-io/nats-server/v2/server/avl.(*SequenceSet).Insert()
      server/avl/seqset.go:45 +0x6d
  github.com/nats-io/nats-server/v2/server.(*fileStore).PurgeEx()
      server/filestore.go:8626 +0x1b0c
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>