### PR TITLE
Preliminary Plan 9 support

### DIFF
--- a/logger/syslog.go
+++ b/logger/syslog.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
+//go:build !windows && !plan9
 
 package logger
 

--- a/logger/syslog_plan9.go
+++ b/logger/syslog_plan9.go
@@ -1,0 +1,90 @@
+// Copyright 2012-2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package logger logs to the windows event log
+package logger
+
+import (
+	"fmt"
+	"os"
+)
+
+var natsEventSource = "NATS-Server"
+
+// SetSyslogName sets the name to use for the system log event source
+func SetSyslogName(name string) {
+	natsEventSource = name
+}
+
+// SysLogger placeholder
+type SysLogger struct {
+	debug  bool
+	trace  bool
+}
+
+// NewSysLogger creates a placeholder log
+func NewSysLogger(debug, trace bool) *SysLogger {
+	return &SysLogger{
+		debug:  debug,
+		trace:  trace,
+	}
+}
+
+// NewRemoteSysLogger creates a placeholder remote event logger
+func NewRemoteSysLogger(fqn string, debug, trace bool) *SysLogger {
+	return &SysLogger{
+		debug:  debug,
+		trace:  trace,
+	}
+}
+
+func formatMsg(tag, format string, v ...any) string {
+	orig := fmt.Sprintf(format, v...)
+	return fmt.Sprintf("pid[%d][%s]: %s", os.Getpid(), tag, orig)
+}
+
+// Noticef logs a notice statement
+func (l *SysLogger) Noticef(format string, v ...any) {
+	fmt.Fprintln(os.Stderr, formatMsg("NOTICE", format, v...))
+}
+
+// Warnf logs a warning statement
+func (l *SysLogger) Warnf(format string, v ...any) {
+	fmt.Fprintln(os.Stderr, formatMsg("WARN", format, v...))
+}
+
+// Fatalf logs a fatal error
+func (l *SysLogger) Fatalf(format string, v ...any) {
+	msg := formatMsg("FATAL", format, v...)
+	fmt.Fprintln(os.Stderr, msg)
+	panic(msg)
+}
+
+// Errorf logs an error statement
+func (l *SysLogger) Errorf(format string, v ...any) {
+	fmt.Fprintln(os.Stderr, formatMsg("ERROR", format, v...))
+}
+
+// Debugf logs a debug statement
+func (l *SysLogger) Debugf(format string, v ...any) {
+	if l.debug {
+		fmt.Fprintln(os.Stderr, formatMsg("DEBUG", format, v...))
+	}
+}
+
+// Tracef logs a trace statement
+func (l *SysLogger) Tracef(format string, v ...any) {
+	if l.trace {
+		fmt.Fprintln(os.Stderr, formatMsg("TRACE", format, v...))
+	}
+}

--- a/server/disk_avail_plan9.go
+++ b/server/disk_avail_plan9.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2025 The NATS Authors
+// Copyright 2022-2025 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,27 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows && !openbsd && !netbsd && !wasm && !illumos && !solaris && !plan9
+//go:build plan9
 
 package server
 
-import (
-	"os"
-	"syscall"
-)
-
 func diskAvailable(storeDir string) int64 {
-	var ba int64
-	if _, err := os.Stat(storeDir); os.IsNotExist(err) {
-		os.MkdirAll(storeDir, defaultDirPerms)
-	}
-	var fs syscall.Statfs_t
-	if err := syscall.Statfs(storeDir, &fs); err == nil {
-		// Estimate 75% of available storage.
-		ba = int64(uint64(fs.Bavail) * uint64(fs.Bsize) / 4 * 3)
-	} else {
-		// Used 1TB default as a guess if all else fails.
-		ba = JetStreamMaxStoreDefault
-	}
-	return ba
+	return JetStreamMaxStoreDefault
 }

--- a/server/pse/pse_plan9.go
+++ b/server/pse/pse_plan9.go
@@ -1,0 +1,25 @@
+// Copyright 2022-2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build plan9
+
+package pse
+
+// This is a placeholder for now.
+func ProcUsage(pcpu *float64, rss, vss *int64) error {
+	*pcpu = 0.0
+	*rss = 0
+	*vss = 0
+
+	return nil
+}

--- a/server/signal.go
+++ b/server/signal.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows && !wasm
+//go:build !windows && !wasm && !plan9
 
 package server
 

--- a/server/signal_plan9.go
+++ b/server/signal_plan9.go
@@ -1,0 +1,24 @@
+// Copyright 2022-2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build plan9
+
+package server
+
+func (s *Server) handleSignals() {
+
+}
+
+func ProcessSignal(command Command, service string) error {
+	return nil
+}

--- a/server/sysmem/mem_plan9.go
+++ b/server/sysmem/mem_plan9.go
@@ -1,0 +1,21 @@
+// Copyright 2022-2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build plan9
+
+package sysmem
+
+func Memory() int64 {
+	// TODO: We don't know the system memory
+	return 0
+}


### PR DESCRIPTION
Since Plan 9 does not support most unix-specific system interfaces, the included code for plan9 is copied from the general windows/wasm case where available. The only exception is the logger where I chose to log to stderr, as even though Plan 9 has a [syslog function](https://9p.io/magic/man2html/2/perror), it is not implemented in Go, and would be an arguably substantial effort. This PR aims to only bring preliminary support, and make the code compile.

What do you think?

Signed-off-by: Arusekk <floss@arusekk.pl>