### PR TITLE
Fix data race in TestFileStoreCompactTombstonesBelowFirstSeq

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -11349,8 +11349,9 @@ func TestFileStoreCompactTombstonesBelowFirstSeq(t *testing.T) {
 
 		lmb.mu.RLock()
 		rbytes := lmb.rbytes
+		shouldCompact := lmb.shouldCompactSync()
 		lmb.mu.RUnlock()
-		require_True(t, lmb.shouldCompactSync())
+		require_True(t, shouldCompact)
 		fs.syncBlocks()
 
 		lmb.mu.RLock()


### PR DESCRIPTION
``` 
WARNING: DATA RACE
Write at 0x00c00077a488 by goroutine 198779:
  github.com/nats-io/nats-server/v2/server.(*msgBlock).atomicOverwriteFile()
      /home/runner/work/nats-server/nats-server/server/filestore.go:6836 +0xf0e

Previous read at 0x00c00077a488 by goroutine 198773:
  github.com/nats-io/nats-server/v2/server.(*msgBlock).shouldCompactSync()
      /home/runner/work/nats-server/nats-server/server/filestore.go:5330 +0x86d
  github.com/nats-io/nats-server/v2/server.TestFileStoreCompactTombstonesBelowFirstSeq.func1()
      /home/runner/work/nats-server/nats-server/server/filestore_test.go:11353 +0x8ae
```



Signed-off-by: Maurice van Veen <github@mauricevanveen.com>