### PR TITLE
(2.14?) NRG: Don't reset WAL when failing to load last snapshot

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -2916,8 +2916,6 @@ func (n *raft) sendSnapshotToFollower(subject string) (uint64, error) {
 	if err != nil {
 		// We need to stepdown here when this happens.
 		n.stepdownLocked(noLeader)
-		// We need to reset our state here as well.
-		n.resetWAL()
 		return 0, err
 	}
 	// Go ahead and send the snapshot and peerstate here as first append entry to the catchup follower.


### PR DESCRIPTION
In most cases we can either install a new snapshot before shutting down, or if not, we can better detect the situation on the next startup.

ref: #7556

Signed-off-by: Neil Twigg <neil@nats.io>