### PR TITLE
Fix subject tree invalid handling of non-terminating full wildcard

### DIFF
--- a/server/stree/parts.go
+++ b/server/stree/parts.go
@@ -36,7 +36,6 @@ func genParts(filter []byte, parts [][]byte) [][]byte {
 				}
 				start = i + 1
 			} else if i < e && filter[i+1] == fwc && i+1 == e {
-				// We have a fwc
 				if i > start {
 					parts = append(parts, filter[start:i+1])
 				}
@@ -52,6 +51,10 @@ func genParts(filter []byte, parts [][]byte) [][]byte {
 			// Wildcard must be at the end or followed by tsep.
 			if next := i + 1; next == e || next < e && filter[next] != tsep {
 				continue
+			}
+			// Full wildcard must be terminal.
+			if filter[i] == fwc && i < e {
+				break
 			}
 			// We start with a pwc or fwc.
 			parts = append(parts, filter[i:i+1])

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -628,8 +628,10 @@ func TestSubjectTreeMatchInvalidWildcard(t *testing.T) {
 	st.Insert(b("foo.123"), 22)
 	st.Insert(b("one.two.three.four.five"), 22)
 	st.Insert(b("'*.123"), 22)
+	st.Insert(b("bar"), 22)
 	match(t, st, "invalid.>", 0)
-	match(t, st, ">", 3)
+	match(t, st, "foo.>.bar", 0)
+	match(t, st, ">", 4)
 	match(t, st, `'*.*`, 1)
 	match(t, st, `'*.*.*'`, 0)
 	// None of these should match.


### PR DESCRIPTION
A bug in `genParts` meant that the incorrect filter `foo.>.bar` could match `bar` unexpectedly. This is now fixed by ensuring that the full wildcard is handled as terminating in all cases.

Signed-off-by: Neil Twigg <neil@nats.io>
