### PR TITLE
Fix data race in processClusterCreateStream

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4464,7 +4464,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 	}
 
 	js.mu.RLock()
-	s, rg := js.srv, sa.Group
+	s, rg, created := js.srv, sa.Group, sa.Created
 	alreadyRunning := rg.node != nil
 	storage := sa.Config.Storage
 	restore := sa.Restore
@@ -4563,7 +4563,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 			mset, err = acc.addStreamWithAssignment(sa.Config, nil, sa, false)
 		}
 		if mset != nil {
-			mset.setCreatedTime(sa.Created)
+			mset.setCreatedTime(created)
 		}
 	}
 
@@ -4650,7 +4650,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 						mset, err = acc.lookupStream(sa.Config.Name)
 						if mset != nil {
 							mset.setStreamAssignment(sa)
-							mset.setCreatedTime(sa.Created)
+							mset.setCreatedTime(created)
 						}
 					}
 					if err != nil {


### PR DESCRIPTION
```
 WARNING: DATA RACE
Write at 0x00c000338c68 by goroutine 67408:
  github.com/nats-io/nats-server/v2/server.TestJetStreamClusterStreamHealthCheckMustNotRecreate.func3()
      /home/runner/work/nats-server/nats-server/server/jetstream_cluster_1_test.go:7273 +0x2d6

Previous read at 0x00c000338c68 by goroutine 67493:
  github.com/nats-io/nats-server/v2/server.(*jetStream).processClusterCreateStream()
      /home/runner/work/nats-server/nats-server/server/jetstream_cluster.go:4566 +0x1b56
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>