### PR TITLE
NRG: do not count messages from removed peers towards quorum

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3257,8 +3257,10 @@ func (n *raft) trackResponse(ar *appendEntryResponse) {
 		return
 	}
 
+	ps := n.peers[ar.peer]
+
 	// Update peer's last index.
-	if ps := n.peers[ar.peer]; ps != nil && ar.index > ps.li {
+	if ps != nil && ar.index > ps.li {
 		ps.li = ar.index
 	}
 
@@ -3269,6 +3271,12 @@ func (n *raft) trackResponse(ar *appendEntryResponse) {
 
 	// Ignore items already committed.
 	if ar.index <= n.commit {
+		n.Unlock()
+		return
+	}
+
+	// Not a peer, can't count this message towards quorum
+	if ps == nil {
 		n.Unlock()
 		return
 	}

--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -57,6 +57,17 @@ func (sg smGroup) leader() stateMachine {
 	return nil
 }
 
+func (sg smGroup) followers() []stateMachine {
+	var f []stateMachine
+	for _, sm := range sg {
+		if sm.node().Leader() {
+			continue
+		}
+		f = append(f, sm)
+	}
+	return f
+}
+
 // Wait on a leader to be elected.
 func (sg smGroup) waitOnLeader() stateMachine {
 	expires := time.Now().Add(10 * time.Second)


### PR DESCRIPTION
Ignore `appendEntryResponse` from removed peers.

Signed-off-by: Daniele Sciascia <daniele@nats.io>
