### PR TITLE
[FIXED] SyncBlocks may lose pending writes

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -6916,10 +6916,9 @@ func (fs *fileStore) syncBlocks() {
 			continue
 		}
 		// See if we can close FDs due to being idle.
-		if mb.mfd != nil && mb.sinceLastWriteActivity() > closeFDsIdle {
+		if mb.mfd != nil && mb.sinceLastWriteActivity() > closeFDsIdle && mb.pendingWriteSizeLocked() == 0 {
 			mb.dirtyCloseWithRemove(false)
 		}
-
 		// If our first has moved and we are set to noCompact (which is from tombstones),
 		// clear so that we might cleanup tombstones.
 		if firstMoved && mb.noCompact {
@@ -6933,12 +6932,10 @@ func (fs *fileStore) syncBlocks() {
 			markDirty = true
 		}
 
+		// Flush anything that may be pending.
+		mb.flushPendingMsgsLocked()
 		// Check if we need to sync. We will not hold lock during actual sync.
 		needSync := mb.needSync
-		if needSync {
-			// Flush anything that may be pending.
-			mb.flushPendingMsgsLocked()
-		}
 		mb.mu.Unlock()
 
 		// Check if we should compact here.


### PR DESCRIPTION
If the filestore was configured to be `AsyncFlush`, for example for a replicated stream since 2.12+, if the process was paused for long enough and the `sync_interval` triggered `syncBlocks`. Pending writes that weren't written out yet could be lost.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>