### PR TITLE
[FIXED] Enforce DiscardNewPerSubject as stream leader

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -6521,3 +6521,46 @@ func TestJetStreamClusterProcessSnapshotPanicAfterStreamDelete(t *testing.T) {
 	require_True(t, node == nil)
 	require_Error(t, mset.processSnapshot(&StreamReplicatedState{}, 0), errCatchupStreamStopped)
 }
+
+func TestJetStreamClusterDiscardNewPerSubjectRejectsWithoutCLFSBump(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:                 "TEST",
+		Subjects:             []string{"foo"},
+		Replicas:             3,
+		Discard:              nats.DiscardNew,
+		DiscardNewPerSubject: true,
+		MaxMsgsPerSubject:    1,
+	})
+	require_NoError(t, err)
+
+	// First publish should succeed.
+	pubAck, err := js.Publish("foo", nil)
+	require_NoError(t, err)
+	require_Equal(t, pubAck.Sequence, 1)
+
+	// The second should fail, since the limit is hit.
+	_, err = js.Publish("foo", nil)
+	require_Error(t, err, ErrMaxMsgsPerSubject)
+
+	// Retry after deleting, it should succeed afterward.
+	require_NoError(t, js.DeleteMsg("TEST", 1))
+	pubAck, err = js.Publish("foo", nil)
+	require_NoError(t, err)
+	require_Equal(t, pubAck.Sequence, 2)
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		return checkState(t, c, globalAccountName, "TEST")
+	})
+
+	// CLFS should NOT be bumped.
+	for _, s := range c.servers {
+		mset, err := s.globalAccount().lookupStream("TEST")
+		require_NoError(t, err)
+		require_Equal(t, mset.getCLFS(), 0)
+	}
+}


### PR DESCRIPTION
Replicated streams using `DiscardNewPerSubject` and `MaxMsgsPerSubject` had a chance of desyncing given a set of conditions:
- A server either needed to restart or be out-of-date such that it requires stream-level catchup from a snapshot.
- At least one of those messages needs to be deleted, either through the stream's retention or it being manually deleted, but the message delete should not be registered in the above snapshot that's used for catchup (since the delete happened after the snapshot).
- A client would actively try to publish a message on a subject that was blocked by this discard policy.
- And, that deleted message's subject needs to equal what the client was repeatedly publishing to.

Given these conditions, a follower that's being caught up could wrongly decide to not store the original message (since it was deleted in the meantime) and instead store the first client-retried message for that subject after it finished catching up from the snapshot. This follower would then diverge from the other servers in terms of what message data is stored at what sequence.

This PR fixes that by never allowing followers to individually decide to block a message based on the discard policy or not, instead enforcing this at the stream leader. The stream leader can then ensure messages that would fail due to the discard policy are rejected before being proposed to the followers.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>