### PR TITLE
(2.14) [FIXED] Only use store's DiscardNew error for R1 & off-by-ones

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -8805,7 +8805,7 @@ func TestFileStoreMessageTTLRecoveredOffByOne(t *testing.T) {
 	// the TTL is to look at the original message header, therefore the TTL
 	// must be in the headers for this test to work.
 	hdr := fmt.Appendf(nil, "NATS/1.0\r\n%s: %d\r\n", JSMessageTTL, ttl)
-	require_NoError(t, fs.StoreRawMsg("test", hdr, nil, 1, ts, ttl))
+	require_NoError(t, fs.StoreRawMsg("test", hdr, nil, 1, ts, ttl, false))
 
 	var ss StreamState
 	fs.FastState(&ss)

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -2319,11 +2319,11 @@ func TestJetStreamAtomicBatchPublishPartiallyAppliedBatchOnRecovery(t *testing.T
 		ts := time.Now().UnixNano()
 		hdr := genHeader(nil, "Nats-Batch-Id", "ID")
 		hdr = genHeader(hdr, "Nats-Batch-Sequence", "1")
-		require_NoError(t, mset.store.StoreRawMsg("foo", hdr, nil, 2, ts, 0))
+		require_NoError(t, mset.store.StoreRawMsg("foo", hdr, nil, 2, ts, 0, false))
 
 		hdr = genHeader(nil, "Nats-Batch-Id", "ID")
 		hdr = genHeader(hdr, "Nats-Batch-Sequence", "2")
-		require_NoError(t, mset.store.StoreRawMsg("foo", hdr, nil, 3, ts, 0))
+		require_NoError(t, mset.store.StoreRawMsg("foo", hdr, nil, 3, ts, 0, false))
 
 		// Unpause applies on the remaining follower.
 		for _, s := range c.servers {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -9647,7 +9647,7 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 		if _, err = mset.store.SkipMsg(seq); err != nil {
 			return 0, errCatchupWrongSeqForSkip
 		}
-	} else if err := mset.store.StoreRawMsg(subj, hdr, msg, seq, ts, ttl); err != nil {
+	} else if err := mset.store.StoreRawMsg(subj, hdr, msg, seq, ts, ttl, false); err != nil {
 		return 0, err
 	}
 

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -6848,9 +6848,9 @@ func TestJetStreamClusterSDMMaxAgeProposeExpiryShortRetry(t *testing.T) {
 			require_NoError(t, err)
 
 			if fs, ok := mset.store.(*fileStore); ok {
-				require_NoError(t, fs.StoreRawMsg("foo", nil, nil, 1, 1, 0))
+				require_NoError(t, fs.StoreRawMsg("foo", nil, nil, 1, 1, 0, false))
 			} else if ms, ok := mset.store.(*memStore); ok {
-				require_NoError(t, ms.StoreRawMsg("foo", nil, nil, 1, 1, 0))
+				require_NoError(t, ms.StoreRawMsg("foo", nil, nil, 1, 1, 0, false))
 			}
 
 			cfg.MaxAge = time.Hour

--- a/server/store.go
+++ b/server/store.go
@@ -90,7 +90,7 @@ type ProcessJetStreamMsgHandler func(*inMsg)
 
 type StreamStore interface {
 	StoreMsg(subject string, hdr, msg []byte, ttl int64) (uint64, int64, error)
-	StoreRawMsg(subject string, hdr, msg []byte, seq uint64, ts int64, ttl int64) error
+	StoreRawMsg(subject string, hdr, msg []byte, seq uint64, ts int64, ttl int64, discardNewCheck bool) error
 	SkipMsg(seq uint64) (uint64, error)
 	SkipMsgs(seq uint64, num uint64) error
 	FlushAllPending()

--- a/server/stream.go
+++ b/server/stream.go
@@ -3965,7 +3965,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 				mset.retrySourceConsumerAtSeq(iName, si.sseq)
 				mset.mu.Unlock()
 			} else {
-				// Log some warning for errors other than errLastSeqMismatch or errMaxMsgs.
+				// Log some warning for errors other than errLastSeqMismatch.
 				if !errors.Is(err, errLastSeqMismatch) {
 					s.RateLimitWarnf("Error processing inbound source %q for '%s' > '%s': %v",
 						iName, accName, sname, err)
@@ -6103,7 +6103,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		if mset.hasAllPreAcks(seq, subject) {
 			mset.clearAllPreAcks(seq)
 		}
-		err = store.StoreRawMsg(subject, hdr, msg, seq, ts, ttl)
+		err = store.StoreRawMsg(subject, hdr, msg, seq, ts, ttl, canConsistencyCheck)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Related to https://github.com/nats-io/nats-server/pull/7607, this builds on top of that and ensures the store can NOT make its own choice to reject a message under DiscardNew. If a stream leader told a follower to store a message, it must always do that.

This is reserved for 2.14 since it relies on the fix in above PR to have been backported, for example to 2.12.x. Otherwise, when running a non-backported version against an updated version (including this PR), streams could desync if one follower chose to reject whereas under the new logic it always will store since the leader tells it to.

This does not mean that without this PR the stream can still desync. Instead, this PR ensures we can guarantee for clustered streams the logic must be enforced fully by the stream leader only. This was already done for `processJetStreamMsg` through the `canConsistencyCheck` flag, so this should partially extend into the store logic as well. The above PR makes sure this is properly handled, so this PR is just tying up some loose ends, as well as fixing some small off-by-ones.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>