### PR TITLE
NRG: prevent peer remove of the last peer

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -319,6 +319,7 @@ var (
 	errBadAppendEntry    = errors.New("raft: append entry corrupt")
 	errNoInternalClient  = errors.New("raft: no internal client")
 	errMembershipChange  = errors.New("raft: membership change in progress")
+	errRemoveLastNode    = errors.New("raft: cannot remove the last peer")
 )
 
 // This will bootstrap a raftNode by writing its config into the store directory.
@@ -987,6 +988,11 @@ func (n *raft) ProposeRemovePeer(peer string) error {
 	if n.membChanging {
 		n.Unlock()
 		return errMembershipChange
+	}
+
+	if len(n.peers) <= 1 {
+		n.Unlock()
+		return errRemoveLastNode
 	}
 
 	prop := n.prop

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -4345,7 +4345,7 @@ func TestNRGProposeRemovePeerLeader(t *testing.T) {
 	require_False(t, newLeader.node().MembershipChangeInProgress())
 }
 
-func TestNRGProposeRemovePeerAllFollowers(t *testing.T) {
+func TestNRGProposeRemovePeerAll(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 
@@ -4368,8 +4368,13 @@ func TestNRGProposeRemovePeerAllFollowers(t *testing.T) {
 	}
 
 	peers := leader.node().Peers()
+	leaderID := leader.node().ID()
+
+	// The leader is the only one left...
 	require_Equal(t, len(peers), 1)
-	require_Equal(t, peers[0].ID, leader.node().ID())
+	require_Equal(t, peers[0].ID, leaderID)
+	// and we can't remove it
+	require_Error(t, leader.node().ProposeRemovePeer(leaderID), errRemoveLastNode)
 }
 
 func TestNRGLeaderResurrectsRemovedPeers(t *testing.T) {


### PR DESCRIPTION
Make sure that a Raft cluster cannot remove its last remaining peer. Attempting to remove the last peer will now return an error, preventing the cluster from entering an invalid state.

Test TestNRGProposeRemovePeerFollowers has been renamed to TestNRGProposeRemovePeerFollowers and updated to cover this new behavior, specifically testing the scenario where an attempt is made to remove the leader when it is the only remaining peer.

Signed-off-by: Daniele Sciascia <daniele@nats.io>
