### PR TITLE
Docker nightly: Use `APK_NOTRIGGERS` and `update-ca-certificates`

### DIFF
--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -10,7 +10,8 @@ ENV GOOS=$TARGETOS \
     GO111MODULE=on \
     CGO_ENABLED=0
 
-RUN apk add --no-cache git ca-certificates
+RUN APK_NOTRIGGERS=1 apk add --no-cache git ca-certificates
+RUN update-ca-certificates
 RUN mkdir -p /src/nats-server /src/natscli /src/nsc
 
 COPY . /src/nats-server


### PR DESCRIPTION
It would appear that something in Alpine or BusyBox has changed and broken one of the package triggers, which resulted in the following failure in GHA:

```
 > [linux/arm64 builder  2/12] RUN apk add --no-cache git ca-certificates:
2.270 ( 8/13) Installing zstd-libs (1.5.7-r2)
2.295 ( 9/13) Installing libcurl (8.17.0-r1)
2.321 (10/13) Installing libexpat (2.7.3-r0)
2.332 (11/13) Installing pcre2 (10.47-r0)
2.363 (12/13) Installing git (2.52.0-r0)
2.620 (13/13) Installing git-init-template (2.52.0-r0)
2.636 Executing busybox-1.37.0-r29.trigger
2.639 * execve: No such file or directory
2.641 ERROR: lib/apk/exec/busybox-1.37.0-r29.trigger: exited with error 127
2.654 1 error; 21 MiB in 30 packages
```

Disabling package triggers and updating CA certificates ourselves seems to work around this issue.

[skip ci]

Signed-off-by: Neil Twigg <neil@nats.io>