### PR TITLE
(2.14) Support reliable WQ/Interest stream sourcing and mirroring

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -125,7 +125,8 @@ type ConsumerConfig struct {
 	MemoryStorage bool `json:"mem_storage,omitempty"`
 
 	// Don't add to general clients.
-	Direct bool `json:"direct,omitempty"`
+	Direct   bool `json:"direct,omitempty"`
+	Sourcing bool `json:"sourcing,omitempty"`
 
 	// Metadata is additional metadata for the Consumer.
 	Metadata map[string]string `json:"metadata,omitempty"`
@@ -336,6 +337,8 @@ const (
 	AckAll
 	// AckExplicit requires ack or nack for all messages.
 	AckExplicit
+	// AckFlowControl functions like AckAll, but acks based on responses to flow control.
+	AckFlowControl
 )
 
 func (a AckPolicy) String() string {
@@ -344,6 +347,8 @@ func (a AckPolicy) String() string {
 		return "none"
 	case AckAll:
 		return "all"
+	case AckFlowControl:
+		return "flow_control"
 	default:
 		return "explicit"
 	}
@@ -500,6 +505,7 @@ type consumer struct {
 	infoSub   *subscription
 	lqsent    time.Time
 	prm       map[string]struct{}
+	rsm       map[string]bool // Reset requests that need to be responded to on the internal sys account (if true).
 	prOk      bool
 	uch       chan struct{}
 	retention RetentionPolicy
@@ -660,7 +666,7 @@ func setConsumerConfigDefaults(config *ConsumerConfig, streamCfg *StreamConfig, 
 		config.InactiveThreshold = streamCfg.ConsumerLimits.InactiveThreshold
 	}
 	// Set proper default for max ack pending if we are ack explicit and none has been set.
-	if (config.AckPolicy == AckExplicit || config.AckPolicy == AckAll) && config.MaxAckPending == 0 {
+	if config.MaxAckPending == 0 && config.AckPolicy != AckNone {
 		ackPending := JsDefaultMaxAckPending
 		if lim.MaxAckPending > 0 && lim.MaxAckPending < ackPending {
 			ackPending = lim.MaxAckPending
@@ -681,6 +687,12 @@ func setConsumerConfigDefaults(config *ConsumerConfig, streamCfg *StreamConfig, 
 	// set the default value only if pinned policy is used.
 	if config.PriorityPolicy == PriorityPinnedClient && config.PinnedTTL == 0 {
 		config.PinnedTTL = JsDefaultPinnedTTL
+	}
+
+	// Set default values for flow control policy.
+	if config.AckPolicy == AckFlowControl && !pedantic {
+		config.FlowControl = true
+		config.Heartbeat = sourceHealthHB
 	}
 	return nil
 }
@@ -729,6 +741,31 @@ func checkConsumerCfg(
 	}
 	if config.AckWait < 0 {
 		return NewJSConsumerAckWaitNegativeError()
+	}
+
+	// Ack Flow Control policy requires push-based flow-controlled consumer.
+	if config.AckPolicy == AckFlowControl {
+		if config.DeliverSubject == _EMPTY_ {
+			return NewJSConsumerAckFCRequiresPushError()
+		}
+		if !config.FlowControl {
+			return NewJSConsumerAckFCRequiresFCError()
+		}
+		// We currently limit using heartbeat of 1s, since those are used for ephemeral sourcing consumers as well.
+		// We could decide to relax this in the future, but need to be careful to not allow a heartbeat larger
+		// than the stalled source timeout.
+		if config.Heartbeat != sourceHealthHB {
+			return NewJSStreamInvalidConfigError(fmt.Errorf("flow control ack policy heartbeat needs to be 1s"))
+		}
+		if config.MaxAckPending <= 0 {
+			return NewJSConsumerAckFCRequiresMaxAckPendingError()
+		}
+		if config.AckWait != 0 || len(config.BackOff) > 0 {
+			return NewJSConsumerAckFCRequiresNoAckWaitError()
+		}
+		if config.MaxDeliver > 0 {
+			return NewJSConsumerAckFCRequiresNoMaxDeliverError()
+		}
 	}
 
 	// Check if we have a BackOff defined that MaxDeliver is within range etc.
@@ -1081,21 +1118,21 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 		if maxc <= 0 || (selectedLimits.MaxConsumers > 0 && selectedLimits.MaxConsumers < maxc) {
 			maxc = selectedLimits.MaxConsumers
 		}
-		if maxc > 0 && mset.numPublicConsumers() >= maxc {
+		if maxc > 0 && mset.numLimitableConsumers() >= maxc {
 			mset.mu.Unlock()
 			return nil, NewJSMaximumConsumersLimitError()
 		}
 	}
 
 	// Check on stream type conflicts with WorkQueues.
-	if cfg.Retention == WorkQueuePolicy && !config.Direct {
+	if cfg.Retention == WorkQueuePolicy && !config.Direct && !config.Sourcing {
 		// Force explicit acks here.
-		if config.AckPolicy != AckExplicit {
+		if config.AckPolicy != AckExplicit && config.AckPolicy != AckFlowControl {
 			mset.mu.Unlock()
 			return nil, NewJSConsumerWQRequiresExplicitAckError()
 		}
 
-		if len(mset.consumers) > 0 {
+		if mset.numLimitableConsumers() > 0 {
 			subjects := gatherSubjectFilters(config.FilterSubject, config.FilterSubjects)
 			if len(subjects) == 0 {
 				mset.mu.Unlock()
@@ -1381,7 +1418,11 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 	mset.setConsumer(o)
 	mset.mu.Unlock()
 
-	if config.Direct || (!s.JetStreamIsClustered() && s.standAloneMode()) {
+	standalone := !s.JetStreamIsClustered() && s.standAloneMode()
+	if config.Sourcing && standalone {
+		o.resetStartingSeq(0, _EMPTY_, false)
+	}
+	if config.Direct || standalone {
 		o.setLeader(true)
 	}
 
@@ -1625,7 +1666,7 @@ func (o *consumer) setLeader(isLeader bool) {
 		}
 
 		var err error
-		if o.cfg.AckPolicy != AckNone {
+		if o.cfg.AckPolicy != AckNone && o.cfg.AckPolicy != AckFlowControl {
 			if o.ackSubOld, err = o.subscribeInternal(o.ackSubjOld, o.pushAck); err != nil {
 				o.mu.Unlock()
 				return
@@ -1764,6 +1805,7 @@ func (o *consumer) setLeader(isLeader bool) {
 		o.rdq = nil
 		o.rdqi.Empty()
 		o.pending = nil
+		o.rsm = nil
 		o.resetPendingDeliveries()
 		// ok if they are nil, we protect inside unsubscribe()
 		o.unsubscribe(o.ackSubOld)
@@ -2543,6 +2585,9 @@ func (o *consumer) updateConfig(cfg *ConsumerConfig) error {
 	// Allowed but considered no-op, [Description, SampleFrequency, MaxWaiting, HeadersOnly]
 	o.cfg = *cfg
 
+	if cfg.Sourcing && (!o.srv.JetStreamIsClustered() && o.srv.standAloneMode()) {
+		o.resetStartingSeqLocked(0, _EMPTY_, false)
+	}
 	if updatedFilters {
 		// Cleanup messages that lost interest.
 		if o.retention == InterestPolicy {
@@ -2708,10 +2753,14 @@ func (o *consumer) updateSkipped(seq uint64) {
 	o.propose(b[:])
 }
 
-func (o *consumer) resetStartingSeq(seq uint64, reply string) (uint64, bool, error) {
+func (o *consumer) resetStartingSeq(seq uint64, reply string, internal bool) (uint64, bool, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
+	return o.resetStartingSeqLocked(seq, reply, internal)
+}
 
+// Lock should be held.
+func (o *consumer) resetStartingSeqLocked(seq uint64, reply string, internal bool) (uint64, bool, error) {
 	// Reset to a specific sequence, or back to the ack floor.
 	if seq == 0 {
 		seq = o.asflr + 1
@@ -2749,6 +2798,10 @@ VALID:
 		le.PutUint64(b[1:], seq)
 		copy(b[1+8:], reply)
 		o.propose(b[:])
+		if o.rsm == nil {
+			o.rsm = make(map[string]bool, 1)
+		}
+		o.rsm[reply] = internal
 		return seq, false, nil
 	} else if o.store != nil {
 		o.store.Reset(seq - 1)
@@ -3501,7 +3554,9 @@ func (o *consumer) processAckMsgLocked(sseq, dseq, dc uint64, reply string, doSa
 	}
 
 	// Check if this ack is above the current pointer to our next to deliver.
-	if sseq >= o.sseq {
+	// Ignore if it's a flow-controlled consumer, its state could end up further ahead
+	// since its state is not replicated before delivery.
+	if sseq >= o.sseq && !o.cfg.FlowControl {
 		// Let's make sure this is valid.
 		// This is only received on the consumer leader, so should never be higher
 		// than the last stream sequence. But could happen if we've just become
@@ -3561,7 +3616,7 @@ func (o *consumer) processAckMsgLocked(sseq, dseq, dc uint64, reply string, doSa
 		}
 		delete(o.rdc, sseq)
 		o.removeFromRedeliverQueue(sseq)
-	case AckAll:
+	case AckAll, AckFlowControl:
 		// no-op
 		if dseq <= o.adflr || sseq <= o.asflr {
 			unlock()
@@ -3721,7 +3776,7 @@ func (o *consumer) needAck(sseq uint64, subj string) bool {
 	}
 
 	switch o.cfg.AckPolicy {
-	case AckNone, AckAll:
+	case AckNone, AckAll, AckFlowControl:
 		needAck = sseq > asflr
 	case AckExplicit:
 		if sseq > asflr {
@@ -4372,7 +4427,7 @@ func (o *consumer) processResetReq(_ *subscription, c *client, a *Account, _, re
 			return
 		}
 	}
-	resetSeq, canRespond, err := o.resetStartingSeq(req.Seq, reply)
+	resetSeq, canRespond, err := o.resetStartingSeq(req.Seq, reply, false)
 	if err != nil {
 		resp.Error = NewJSConsumerInvalidResetError(err)
 		s.sendInternalAccountMsg(a, reply, s.jsonResponse(&resp))
@@ -5322,9 +5377,13 @@ func (o *consumer) loopAndGatherMsgs(qch chan struct{}) {
 			o.mu.Unlock()
 		case <-hbc:
 			if o.isActive() {
-				o.mu.RLock()
+				o.mu.Lock()
 				o.sendIdleHeartbeat(odsubj)
-				o.mu.RUnlock()
+				// Send flow control on EOS if it's used for acknowledgements.
+				if o.cfg.AckPolicy == AckFlowControl && len(o.pending) > 0 && o.fcid == _EMPTY_ {
+					o.sendFlowControl()
+				}
+				o.mu.Unlock()
 			}
 			// Reset our idle heartbeat timer.
 			hb.Reset(hbd)
@@ -5503,11 +5562,11 @@ func (o *consumer) deliverMsg(dsubj, ackReply string, pmsg *jsPubMsg, dc uint64,
 	// Update delivered first.
 	o.updateDelivered(dseq, seq, dc, ts)
 
-	if ap == AckExplicit || ap == AckAll {
-		o.trackPending(seq, dseq)
-	} else if ap == AckNone {
+	if ap == AckNone {
 		o.adflr = dseq
 		o.asflr = seq
+	} else {
+		o.trackPending(seq, dseq)
 	}
 
 	// Send message.
@@ -5555,6 +5614,10 @@ func (o *consumer) needFlowControl(sz int) bool {
 	if o.fcid == _EMPTY_ && o.pbytes > o.maxpb/2 {
 		return true
 	}
+	// Or, when acking based on flow control, we need to send it if we've hit the max pending limit earlier.
+	if o.fcid == _EMPTY_ && o.cfg.AckPolicy == AckFlowControl && o.maxp > 0 && len(o.pending) >= o.maxp {
+		return true
+	}
 	// If we have an existing outstanding FC, check to see if we need to expand the o.fcsz
 	if o.fcid != _EMPTY_ && (o.pbytes-o.fcsz) >= o.maxpb {
 		o.fcsz += sz
@@ -5562,12 +5625,12 @@ func (o *consumer) needFlowControl(sz int) bool {
 	return false
 }
 
-func (o *consumer) processFlowControl(_ *subscription, c *client, _ *Account, subj, _ string, _ []byte) {
+func (o *consumer) processFlowControl(_ *subscription, c *client, _ *Account, subj, _ string, rmsg []byte) {
 	o.mu.Lock()
-	defer o.mu.Unlock()
 
 	// Ignore if not the latest we have sent out.
 	if subj != o.fcid {
+		o.mu.Unlock()
 		return
 	}
 
@@ -5587,6 +5650,25 @@ func (o *consumer) processFlowControl(_ *subscription, c *client, _ *Account, su
 	o.fcid, o.fcsz = _EMPTY_, 0
 
 	o.signalNewMessages()
+	ackFlowControl := o.cfg.AckPolicy == AckFlowControl
+	o.mu.Unlock()
+
+	if !ackFlowControl {
+		return
+	}
+	hdr, _ := c.msgParts(rmsg)
+	if len(hdr) > 0 {
+		ldseq := parseInt64(sliceHeader(JSLastConsumerSeq, hdr))
+		lsseq := parseInt64(sliceHeader(JSLastStreamSeq, hdr))
+		if lsseq > 0 {
+			// Delivered sequence is allowed to be zero as a response
+			// to flow control without any deliveries.
+			if ldseq <= 0 {
+				ldseq = 0
+			}
+			o.processAckMsg(uint64(lsseq), uint64(ldseq), 1, _EMPTY_, false)
+		}
+	}
 }
 
 // Lock should be held.
@@ -5774,8 +5856,9 @@ func (o *consumer) checkPending() {
 	defer o.mu.Unlock()
 
 	mset := o.mset
+	ttl := int64(o.cfg.AckWait)
 	// On stop, mset and timer will be nil.
-	if o.closed || mset == nil || o.ptmr == nil {
+	if o.closed || mset == nil || o.ptmr == nil || ttl == 0 {
 		o.stopAndClearPtmr()
 		return
 	}
@@ -5786,7 +5869,6 @@ func (o *consumer) checkPending() {
 	fseq := state.FirstSeq
 
 	now := time.Now().UnixNano()
-	ttl := int64(o.cfg.AckWait)
 	next := int64(o.ackWait(0))
 	// However, if there is backoff, initializes with the largest backoff.
 	// It will be adjusted as needed.
@@ -6172,6 +6254,41 @@ func (o *consumer) String() string {
 
 func createConsumerName() string {
 	return getHash(nuid.Next())
+}
+
+// Lock should be held.
+func (mset *stream) createStableConsumerHash() string {
+	id := fmt.Sprintf("%s %s", mset.cfg.Name, mset.acc.Name)
+	if domain := mset.srv.getOpts().JetStreamDomain; domain != _EMPTY_ {
+		id = fmt.Sprintf("%s %s", id, domain)
+	}
+	return getHash(id)
+}
+
+// Lock should be held.
+func (mset *stream) createSourcingConsumerHash(ssi *StreamSource, sources []*StreamSource) string {
+	id := mset.createStableConsumerHash()
+
+	// If the stream sources contain the same stream at least twice, we use a more strict hash of
+	// an ID that also contains filter subjects etc. If the stream name is only used once, we can
+	// support the stable identifier above.
+	var once bool
+	for _, src := range sources {
+		if src.Name == ssi.Name {
+			if once {
+				if ssi.iname == _EMPTY_ {
+					ssi.setIndexName()
+				}
+				// Append identifying information of the filter subjects, etc. to make it unique
+				id = fmt.Sprintf("%s %s", id, ssi.iname)
+				break
+			} else {
+				once = true
+			}
+		}
+	}
+
+	return getHash(id)
 }
 
 // deleteConsumer will delete the consumer from this stream.
@@ -6873,6 +6990,12 @@ func (o *consumer) checkStateForInterestStream(ss *StreamState) error {
 }
 
 func (o *consumer) resetPtmr(delay time.Duration) {
+	// A delay of zero means it should be stopped.
+	if delay == 0 {
+		o.stopAndClearPtmr()
+		return
+	}
+
 	if o.ptmr == nil {
 		o.ptmr = time.AfterFunc(delay, o.checkPending)
 	} else {
@@ -6882,6 +7005,10 @@ func (o *consumer) resetPtmr(delay time.Duration) {
 }
 
 func (o *consumer) stopAndClearPtmr() {
+	// If the end time is unset, short-circuit since the timer will already be stopped.
+	if o.ptmrEnd.IsZero() {
+		return
+	}
 	stopAndClearTimer(&o.ptmr)
 	o.ptmrEnd = time.Time{}
 }

--- a/server/errors.json
+++ b/server/errors.json
@@ -2108,5 +2108,105 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSMirrorDurableConsumerCfgInvalid",
+    "code": 400,
+    "error_code": 10213,
+    "description": "stream mirror consumer config is invalid",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSMirrorConsumerRequiresAckFCErr",
+    "code": 400,
+    "error_code": 10214,
+    "description": "stream mirror consumer requires flow control ack policy",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSSourceDurableConsumerCfgInvalid",
+    "code": 400,
+    "error_code": 10215,
+    "description": "stream source consumer config is invalid",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSSourceDurableConsumerDuplicateDetected",
+    "code": 400,
+    "error_code": 10216,
+    "description": "duplicate stream source consumer detected",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSSourceConsumerRequiresAckFCErr",
+    "code": 400,
+    "error_code": 10217,
+    "description": "stream source consumer requires flow control ack policy",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerAckFCRequiresPushErr",
+    "code": 400,
+    "error_code": 10218,
+    "description": "flow control ack policy requires a push based consumer",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerAckFCRequiresFCErr",
+    "code": 400,
+    "error_code": 10219,
+    "description": "flow control ack policy requires flow control",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerAckFCRequiresMaxAckPendingErr",
+    "code": 400,
+    "error_code": 10220,
+    "description": "flow control ack policy requires max ack pending",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerAckFCRequiresNoAckWaitErr",
+    "code": 400,
+    "error_code": 10221,
+    "description": "flow control ack policy requires unset ack wait",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerAckFCRequiresNoMaxDeliverErr",
+    "code": 400,
+    "error_code": 10222,
+    "description": "flow control ack policy requires unset max deliver",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -12615,11 +12615,8 @@ func (o *consumerFileStore) SetStarting(sseq uint64) error {
 	o.mu.Lock()
 	o.state.Delivered.Stream = sseq
 	o.state.AckFloor.Stream = sseq
-	buf, err := o.encodeState()
+	buf := encodeConsumerState(&o.state)
 	o.mu.Unlock()
-	if err != nil {
-		return err
-	}
 	return o.writeState(buf)
 }
 
@@ -12748,8 +12745,8 @@ func (o *consumerFileStore) UpdateAcks(dseq, sseq uint64) error {
 		return ErrStoreMsgNotFound
 	}
 
-	// Check for AckAll here.
-	if o.cfg.AckPolicy == AckAll {
+	// Check for AckAll here (or AckFlowControl which functions like AckAll).
+	if o.cfg.AckPolicy == AckAll || o.cfg.AckPolicy == AckFlowControl {
 		sgap := sseq - o.state.AckFloor.Stream
 		o.state.AckFloor.Consumer = dseq
 		o.state.AckFloor.Stream = sseq

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -774,6 +774,7 @@ type JSApiConsumerResetRequest struct {
 	Seq uint64 `json:"seq,omitempty"`
 }
 
+// JSApiConsumerResetResponse is a superset of JSApiConsumerCreateResponse, but including an explicit ResetSeq.
 type JSApiConsumerResetResponse struct {
 	ApiResponse
 	*ConsumerInfo
@@ -4361,11 +4362,49 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 	isClustered := s.JetStreamIsClustered()
 
 	// Determine if we should proceed here when we are in clustered mode.
+	direct := req.Config.Direct
 	if isClustered {
-		if req.Config.Direct {
-			// Check to see if we have this stream and are the stream leader.
-			if !acc.JetStreamIsStreamLeader(streamNameFromSubject(subject)) {
-				return
+		if direct {
+			// If it's just a direct consumer, check for stream leader.
+			if !req.Config.Sourcing {
+				// Check to see if we have this stream and are the stream leader.
+				if !acc.JetStreamIsStreamLeader(streamNameFromSubject(subject)) {
+					return
+				}
+			} else {
+				// Otherwise, we either need this to be answered by the stream or meta leader.
+				var cc *jetStreamCluster
+				js, cc = s.getJetStreamCluster()
+				if js == nil || cc == nil {
+					return
+				}
+				js.mu.RLock()
+				sa := js.streamAssignmentOrInflight(acc.Name, streamNameFromSubject(subject))
+				if sa == nil {
+					js.mu.RUnlock()
+					return
+				}
+				// If the stream is WQ or Interest, we need the meta leader to answer.
+				if sa.Config.Retention != LimitsPolicy {
+					direct = false
+				}
+				js.mu.RUnlock()
+				if direct {
+					// Check to see if we have this stream and are the stream leader.
+					if !acc.JetStreamIsStreamLeader(streamNameFromSubject(subject)) {
+						return
+					}
+				} else {
+					if js.isLeaderless() {
+						resp.Error = NewJSClusterNotAvailError()
+						s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+						return
+					}
+					// Make sure we are meta leader.
+					if !s.JetStreamIsLeader() {
+						return
+					}
+				}
 			}
 		} else {
 			var cc *jetStreamCluster
@@ -4409,6 +4448,7 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 		// Legacy ephemeral.
 		rt = ccLegacyEphemeral
 		streamName = streamNameFromSubject(subject)
+		consumerName = req.Config.Name
 	} else {
 		// New style and durable legacy.
 		if tokenAt(subject, 4) == "DURABLE" {
@@ -4500,7 +4540,7 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 		return
 	}
 
-	if isClustered && !req.Config.Direct {
+	if isClustered && !direct {
 		s.jsClusteredConsumerRequest(ci, acc, subject, reply, rmsg, req.Stream, &req.Config, req.Action, req.Pedantic)
 		return
 	}
@@ -4524,6 +4564,23 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 		return
 	}
 
+	// If the consumer is a direct sourcing consumer, we need to "upgrade"
+	// it to be durable without AckNone if not a Limits-based stream.
+	if req.Config.Direct && req.Config.Sourcing && req.Config.Name != _EMPTY_ {
+		if !isClustered && stream.isInterestRetention() {
+			req.Config.Direct = false
+			req.Config.Durable = req.Config.Name
+			req.Config.AckPolicy = AckFlowControl
+			req.Config.AckWait = 0
+			req.Config.MaxDeliver = 0
+			req.Config.InactiveThreshold = 0
+		} else {
+			// Otherwise, need to append a randomized suffix since the source uses a stable name.
+			req.Config.Name = fmt.Sprintf("%s-%s", req.Config.Name, createConsumerName())
+			consumerName = req.Config.Name
+		}
+	}
+
 	if o := stream.lookupConsumer(consumerName); o != nil {
 		if o.offlineReason != _EMPTY_ {
 			resp.Error = NewJSConsumerOfflineReasonError(errors.New(o.offlineReason))
@@ -4534,6 +4591,12 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 		// it back to whatever the current configured value is.
 		o.mu.RLock()
 		req.Config.PauseUntil = o.cfg.PauseUntil
+		// If a durable sourcing consumer is used, we need to reset the deliver policy.
+		if req.Config.Sourcing && req.Config.Durable != _EMPTY_ {
+			req.Config.DeliverPolicy = o.cfg.DeliverPolicy
+			req.Config.OptStartSeq = o.cfg.OptStartSeq
+			req.Config.OptStartTime = o.cfg.OptStartTime
+		}
 		o.mu.RUnlock()
 	}
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4177,7 +4177,7 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 			if needLock {
 				mset.mu.RLock()
 			}
-			mset.sendFlowControlReply(reply)
+			mset.sendFlowControlReply(reply, hdr)
 			if needLock {
 				mset.mu.RUnlock()
 			}
@@ -5975,12 +5975,26 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 				if o.IsLeader() || (!didCreate && needsLocalResponse) {
 					// Process if existing as an update. Double check that this is not recovered.
 					js.mu.RLock()
-					client, subject, reply, recovering := ca.Client, ca.Subject, ca.Reply, ca.recovering
+					client, subject, reply, recovering, sourcing := ca.Client, ca.Subject, ca.Reply, ca.recovering, ca.Config.Sourcing
 					js.mu.RUnlock()
 					if !recovering {
-						var resp = JSApiConsumerCreateResponse{ApiResponse: ApiResponse{Type: JSApiConsumerCreateResponseType}}
-						resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
-						s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+						// If it's a sourcing consumer, we need to respond after the consumer has been reset instead.
+						if sourcing {
+							var resp = JSApiConsumerResetResponse{ApiResponse: ApiResponse{Type: JSApiConsumerResetResponseType}}
+							resetSeq, canRespond, err := o.resetStartingSeq(0, reply, true)
+							if err != nil {
+								resp.Error = NewJSConsumerInvalidResetError(err)
+								s.sendAPIErrResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+							} else if canRespond {
+								resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
+								resp.ResetSeq = resetSeq
+								s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+							}
+						} else {
+							var resp = JSApiConsumerCreateResponse{ApiResponse: ApiResponse{Type: JSApiConsumerCreateResponseType}}
+							resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
+							s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+						}
 					}
 				}
 			}
@@ -6609,8 +6623,19 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 					o.streamNumPending()
 					o.signalNewMessages()
 					s, a := o.srv, o.acc
-					o.mu.Unlock()
-					if reply != _EMPTY_ {
+					if reply == _EMPTY_ {
+						o.mu.Unlock()
+					} else if internal, ok := o.rsm[reply]; !ok {
+						o.mu.Unlock()
+					} else {
+						delete(o.rsm, reply)
+						o.mu.Unlock()
+
+						// Check if the reset request needs to be answered on the system account.
+						// This will happen for replicated sourcing consumers that get reset as part of a create/update.
+						if internal {
+							a = nil
+						}
 						var resp = JSApiConsumerResetResponse{ApiResponse: ApiResponse{Type: JSApiConsumerResetResponseType}}
 						resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
 						resp.ResetSeq = sseq
@@ -6650,7 +6675,7 @@ func (o *consumer) processReplicatedAck(dseq, sseq uint64) error {
 	o.lat = time.Now()
 
 	var sagap uint64
-	if o.cfg.AckPolicy == AckAll {
+	if o.cfg.AckPolicy == AckAll || o.cfg.AckPolicy == AckFlowControl {
 		// Always use the store state, as o.asflr is skipped ahead already.
 		// Capture before updating store.
 		state, err := o.store.BorrowState()
@@ -6755,7 +6780,7 @@ func (js *jetStream) processConsumerLeaderChangeWithAssignment(o *consumer, ca *
 	}
 	js.mu.Lock()
 	s, account, err := js.srv, ca.Client.serviceAccount(), ca.err
-	client, subject, reply, streamName, consumerName := ca.Client, ca.Subject, ca.Reply, ca.Stream, ca.Name
+	client, subject, reply, streamName, consumerName, sourcing := ca.Client, ca.Subject, ca.Reply, ca.Stream, ca.Name, ca.Config.Sourcing
 	hasResponded := ca.responded
 	ca.responded = true
 	js.mu.Unlock()
@@ -6798,8 +6823,22 @@ func (js *jetStream) processConsumerLeaderChangeWithAssignment(o *consumer, ca *
 		resp.Error = NewJSConsumerCreateError(err, Unless(err))
 		s.sendAPIErrResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
 	} else {
-		resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.initialInfo())
-		s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+		// If it's a sourcing consumer, we need to respond after the consumer has been reset instead.
+		if sourcing {
+			var rresp = JSApiConsumerResetResponse{ApiResponse: ApiResponse{Type: JSApiConsumerResetResponseType}}
+			resetSeq, canRespond, err := o.resetStartingSeq(0, reply, true)
+			if err != nil {
+				rresp.Error = NewJSConsumerInvalidResetError(err)
+				s.sendAPIErrResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&rresp))
+			} else if canRespond {
+				rresp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
+				rresp.ResetSeq = resetSeq
+				s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&rresp))
+			}
+		} else {
+			resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.initialInfo())
+			s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+		}
 		o.sendCreateAdvisory()
 	}
 
@@ -8976,6 +9015,17 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 		return
 	}
 
+	// If the consumer is a direct sourcing consumer, we need to "upgrade" it to be durable without AckNone.
+	// We only get here if the stream is not Limits-based.
+	if cfg.Direct && cfg.Sourcing && cfg.Name != _EMPTY_ {
+		cfg.Direct = false
+		cfg.Durable = cfg.Name
+		cfg.AckPolicy = AckFlowControl
+		cfg.AckWait = 0
+		cfg.MaxDeliver = 0
+		cfg.InactiveThreshold = 0
+	}
+
 	var resp = JSApiConsumerCreateResponse{ApiResponse: ApiResponse{Type: JSApiConsumerCreateResponseType}}
 
 	streamCfg, ok := js.clusterStreamConfig(acc.Name, stream)
@@ -9042,13 +9092,13 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 			// we're likely updating an existing consumer, so don't count it. Otherwise
 			// we will incorrectly return NewJSMaximumConsumersLimitError for an update.
 			if oname == _EMPTY_ || js.consumerAssignmentOrInflight(acc.Name, stream, oname) == nil {
-				// Don't count DIRECTS.
+				// Don't count direct/sourcing consumers.
 				total := 0
 				for ca := range js.consumerAssignmentsOrInflightSeq(acc.Name, stream) {
 					if ca.unsupported != nil {
 						continue
 					}
-					if ca.Config != nil && !ca.Config.Direct {
+					if ca.Config != nil && !ca.Config.Direct && !ca.Config.Sourcing {
 						total++
 					}
 				}
@@ -9094,6 +9144,13 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 		if ca = js.consumerAssignmentOrInflight(acc.Name, stream, oname); ca != nil {
 			// Provided config might miss metadata, copy from existing config.
 			copyConsumerMetadata(cfg, ca.Config)
+
+			// If a durable sourcing consumer is used, we need to reset the deliver policy.
+			if cfg.Sourcing && cfg.Durable != _EMPTY_ {
+				cfg.DeliverPolicy = ca.Config.DeliverPolicy
+				cfg.OptStartSeq = ca.Config.OptStartSeq
+				cfg.OptStartTime = ca.Config.OptStartTime
+			}
 
 			if action == ActionCreate && !reflect.DeepEqual(cfg, ca.Config) {
 				resp.Error = NewJSConsumerAlreadyExistsError()
@@ -9180,21 +9237,21 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 
 		// Check if we are work queue policy.
 		// We will do pre-checks here to avoid thrashing meta layer.
-		if sa.Config.Retention == WorkQueuePolicy && !cfg.Direct {
-			if cfg.AckPolicy != AckExplicit {
+		if sa.Config.Retention == WorkQueuePolicy && !cfg.Direct && !cfg.Sourcing {
+			if cfg.AckPolicy != AckExplicit && cfg.AckPolicy != AckFlowControl {
 				resp.Error = NewJSConsumerWQRequiresExplicitAckError()
 				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 				return
 			}
 			subjects := gatherSubjectFilters(cfg.FilterSubject, cfg.FilterSubjects)
-			if len(subjects) == 0 && len(sa.consumers) > 0 {
-				resp.Error = NewJSConsumerWQMultipleUnfilteredError()
-				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
-				return
-			}
 			for oca := range js.consumerAssignmentsOrInflightSeq(acc.Name, stream) {
-				if oca.Name == oname {
+				if oca.Name == oname || oca.Config.Direct || oca.Config.Sourcing {
 					continue
+				}
+				if len(subjects) == 0 {
+					resp.Error = NewJSConsumerWQMultipleUnfilteredError()
+					s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+					return
 				}
 				for _, psubj := range gatherSubjectFilters(oca.Config.FilterSubject, oca.Config.FilterSubjects) {
 					for _, subj := range subjects {

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8989,3 +8989,812 @@ func TestJetStreamClusterStreamLeaderStepsDownIfSnapshotCatchupRequired(t *testi
 		return checkState(t, c, globalAccountName, "TEST")
 	})
 }
+
+func TestJetStreamClusterDurableStreamMirror(t *testing.T) {
+	test := func(t *testing.T, replicas int, retention RetentionPolicy) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := jsStreamCreate(t, nc, &StreamConfig{
+			Name:      "O",
+			Subjects:  []string{"foo"},
+			Storage:   FileStorage,
+			Replicas:  replicas,
+			Retention: retention,
+		})
+		require_NoError(t, err)
+
+		_, err = jsConsumerCreate(t, nc, "O", ConsumerConfig{
+			Durable:        "C",
+			DeliverSubject: "deliver-subject",
+			Replicas:       replicas,
+			AckPolicy:      AckFlowControl,
+			Heartbeat:      time.Second,
+		}, false)
+		require_NoError(t, err)
+
+		pubAck, err := js.Publish("foo", nil)
+		require_NoError(t, err)
+		require_Equal(t, pubAck.Sequence, 1)
+
+		_, err = jsStreamCreate(t, nc, &StreamConfig{
+			Name: "M",
+			Mirror: &StreamSource{
+				Name: "O",
+				Consumer: &StreamConsumerSource{
+					Name:           "C",
+					DeliverSubject: "deliver-subject",
+				},
+			},
+			Storage:  FileStorage,
+			Replicas: replicas,
+		})
+		require_NoError(t, err)
+
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			si, err := js.StreamInfo("M")
+			if err != nil {
+				return err
+			}
+			if si.Mirror == nil {
+				return errors.New("no mirror")
+			}
+			if si.Mirror.Error != nil {
+				return si.Mirror.Error
+			}
+			_, err = js.GetMsg("M", 1)
+			return err
+		})
+	}
+
+	for _, replicas := range []int{1, 3} {
+		for _, retention := range []RetentionPolicy{LimitsPolicy, InterestPolicy, WorkQueuePolicy} {
+			t.Run(fmt.Sprintf("R%d/%s", replicas, retention), func(t *testing.T) {
+				test(t, replicas, retention)
+			})
+		}
+	}
+}
+
+func TestJetStreamClusterDurableStreamMirrorServerManaged(t *testing.T) {
+	test := func(t *testing.T, replicas int, retention RetentionPolicy) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := jsStreamCreate(t, nc, &StreamConfig{
+			Name:      "O",
+			Subjects:  []string{"foo"},
+			Storage:   FileStorage,
+			Replicas:  replicas,
+			Retention: retention,
+		})
+		require_NoError(t, err)
+
+		_, err = js.AddConsumer("O", &nats.ConsumerConfig{Durable: "C", AckPolicy: nats.AckExplicitPolicy})
+		require_NoError(t, err)
+
+		pubAck, err := js.Publish("foo", nil)
+		require_NoError(t, err)
+		require_Equal(t, pubAck.Sequence, 1)
+
+		_, err = jsStreamCreate(t, nc, &StreamConfig{
+			Name:     "M",
+			Mirror:   &StreamSource{Name: "O"},
+			Storage:  FileStorage,
+			Replicas: replicas,
+		})
+		require_NoError(t, err)
+
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			si, err := js.StreamInfo("M")
+			if err != nil {
+				return err
+			}
+			if si.Mirror == nil {
+				return errors.New("no mirror")
+			}
+			if si.Mirror.Error != nil {
+				return si.Mirror.Error
+			}
+			_, err = js.GetMsg("M", 1)
+			return err
+		})
+	}
+
+	for _, replicas := range []int{1, 3} {
+		for _, retention := range []RetentionPolicy{LimitsPolicy, InterestPolicy, WorkQueuePolicy} {
+			t.Run(fmt.Sprintf("R%d/%s", replicas, retention), func(t *testing.T) {
+				test(t, replicas, retention)
+			})
+		}
+	}
+}
+
+func TestJetStreamClusterDurableStreamSource(t *testing.T) {
+	test := func(t *testing.T, replicas int, retention RetentionPolicy) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := jsStreamCreate(t, nc, &StreamConfig{
+			Name:      "O",
+			Subjects:  []string{"foo"},
+			Storage:   FileStorage,
+			Replicas:  replicas,
+			Retention: retention,
+		})
+		require_NoError(t, err)
+
+		_, err = jsConsumerCreate(t, nc, "O", ConsumerConfig{
+			Durable:        "C",
+			DeliverSubject: "deliver-subject",
+			Replicas:       replicas,
+			AckPolicy:      AckFlowControl,
+			Heartbeat:      time.Second,
+		}, false)
+		require_NoError(t, err)
+
+		pubAck, err := js.Publish("foo", nil)
+		require_NoError(t, err)
+		require_Equal(t, pubAck.Sequence, 1)
+
+		_, err = jsStreamCreate(t, nc, &StreamConfig{
+			Name: "S",
+			Sources: []*StreamSource{{
+				Name: "O",
+				Consumer: &StreamConsumerSource{
+					Name:           "C",
+					DeliverSubject: "deliver-subject",
+				},
+			}},
+			Storage:  FileStorage,
+			Replicas: replicas,
+		})
+		require_NoError(t, err)
+
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			si, err := js.StreamInfo("S")
+			if err != nil {
+				return err
+			}
+			if len(si.Sources) != 1 {
+				return errors.New("no source")
+			}
+			if si.Sources[0].Error != nil {
+				return si.Sources[0].Error
+			}
+			_, err = js.GetMsg("S", 1)
+			return err
+		})
+	}
+
+	for _, replicas := range []int{1, 3} {
+		for _, retention := range []RetentionPolicy{LimitsPolicy, InterestPolicy, WorkQueuePolicy} {
+			t.Run(fmt.Sprintf("R%d/%s", replicas, retention), func(t *testing.T) {
+				test(t, replicas, retention)
+			})
+		}
+	}
+}
+
+func TestJetStreamClusterDurableStreamSourceServerManaged(t *testing.T) {
+	test := func(t *testing.T, replicas int, retention RetentionPolicy) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := jsStreamCreate(t, nc, &StreamConfig{
+			Name:      "O",
+			Subjects:  []string{"foo"},
+			Storage:   FileStorage,
+			Replicas:  replicas,
+			Retention: retention,
+		})
+		require_NoError(t, err)
+
+		_, err = js.AddConsumer("O", &nats.ConsumerConfig{Durable: "C", AckPolicy: nats.AckExplicitPolicy})
+		require_NoError(t, err)
+
+		pubAck, err := js.Publish("foo", nil)
+		require_NoError(t, err)
+		require_Equal(t, pubAck.Sequence, 1)
+
+		_, err = jsStreamCreate(t, nc, &StreamConfig{
+			Name:     "S",
+			Sources:  []*StreamSource{{Name: "O"}},
+			Storage:  FileStorage,
+			Replicas: replicas,
+		})
+		require_NoError(t, err)
+
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			si, err := js.StreamInfo("S")
+			if err != nil {
+				return err
+			}
+			if len(si.Sources) != 1 {
+				return errors.New("no source")
+			}
+			if si.Sources[0].Error != nil {
+				return si.Sources[0].Error
+			}
+			_, err = js.GetMsg("S", 1)
+			return err
+		})
+	}
+
+	for _, replicas := range []int{1, 3} {
+		for _, retention := range []RetentionPolicy{LimitsPolicy, InterestPolicy, WorkQueuePolicy} {
+			t.Run(fmt.Sprintf("R%d/%s", replicas, retention), func(t *testing.T) {
+				test(t, replicas, retention)
+			})
+		}
+	}
+}
+
+func TestJetStreamDurableStreamSourcesWQFwcExclusivity(t *testing.T) {
+	test := func(t *testing.T, replicas int) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:      "O",
+			Subjects:  []string{"foo"},
+			Retention: nats.WorkQueuePolicy,
+			Replicas:  replicas,
+		})
+		require_NoError(t, err)
+
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:   "M",
+			Mirror: &nats.StreamSource{Name: "O"},
+		})
+		require_NoError(t, err)
+
+		mset, err := s.globalAccount().lookupStream("O")
+		require_NoError(t, err)
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			if c := mset.numConsumers(); c != 1 {
+				return fmt.Errorf("expected 1 consumer, got %d", c)
+			}
+			return nil
+		})
+
+		// A sourcing consumer already exists, but we should still be able to add an app consumer.
+		// Only this one counts toward WQ exclusivity.
+		_, err = js.AddConsumer("O", &nats.ConsumerConfig{Durable: "CONSUMER", AckPolicy: nats.AckExplicitPolicy})
+		require_NoError(t, err)
+	}
+
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) { test(t, replicas) })
+	}
+}
+
+func TestJetStreamDurableStreamSourcesWQFilterExclusivity(t *testing.T) {
+	test := func(t *testing.T, replicas int) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:      "O",
+			Subjects:  []string{"a", "b"},
+			Retention: nats.WorkQueuePolicy,
+			Replicas:  replicas,
+		})
+		require_NoError(t, err)
+
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name: "M",
+			Mirror: &nats.StreamSource{
+				Name: "O",
+				SubjectTransforms: []nats.SubjectTransformConfig{
+					{Source: "a"},
+					{Source: "b"},
+				},
+			},
+		})
+		require_NoError(t, err)
+
+		mset, err := s.globalAccount().lookupStream("O")
+		require_NoError(t, err)
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			if c := mset.numConsumers(); c != 1 {
+				return fmt.Errorf("expected 1 consumer, got %d", c)
+			}
+			return nil
+		})
+
+		// A sourcing consumer already exists, but we should still be able to add filtered app consumers.
+		// Only these count toward WQ exclusivity.
+		_, err = js.AddConsumer("O", &nats.ConsumerConfig{
+			Durable:       "CONSUMER1",
+			AckPolicy:     nats.AckExplicitPolicy,
+			FilterSubject: "a",
+		})
+		require_NoError(t, err)
+		_, err = js.AddConsumer("O", &nats.ConsumerConfig{
+			Durable:       "CONSUMER2",
+			AckPolicy:     nats.AckExplicitPolicy,
+			FilterSubject: "b",
+		})
+		require_NoError(t, err)
+	}
+
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) { test(t, replicas) })
+	}
+}
+
+func TestJetStreamDurableStreamSourcesMaxConsumers(t *testing.T) {
+	test := func(t *testing.T, replicas int) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:         "O",
+			Subjects:     []string{"foo"},
+			Retention:    nats.WorkQueuePolicy,
+			Replicas:     replicas,
+			MaxConsumers: 1,
+		})
+		require_NoError(t, err)
+
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:   "M",
+			Mirror: &nats.StreamSource{Name: "O"},
+		})
+		require_NoError(t, err)
+
+		mset, err := s.globalAccount().lookupStream("O")
+		require_NoError(t, err)
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			if c := mset.numConsumers(); c != 1 {
+				return fmt.Errorf("expected 1 consumer, got %d", c)
+			}
+			return nil
+		})
+
+		// A sourcing consumer already exists, but we should still be able to add an app consumer.
+		// Only this one counts toward the MaxConsumers limit.
+		_, err = js.AddConsumer("O", &nats.ConsumerConfig{Durable: "CONSUMER", AckPolicy: nats.AckExplicitPolicy})
+		require_NoError(t, err)
+	}
+
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) { test(t, replicas) })
+	}
+}
+
+func TestJetStreamDurableStreamMirrorDeletesConsumerAfterMirrorRemoval(t *testing.T) {
+	test := func(t *testing.T, replicas int) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:      "O",
+			Subjects:  []string{"foo"},
+			Retention: nats.WorkQueuePolicy,
+			Replicas:  replicas,
+		})
+		require_NoError(t, err)
+
+		cfg := &nats.StreamConfig{
+			Name:   "M",
+			Mirror: &nats.StreamSource{Name: "O"},
+		}
+		_, err = js.AddStream(cfg)
+		require_NoError(t, err)
+
+		mset, err := s.globalAccount().lookupStream("O")
+		require_NoError(t, err)
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			if c := mset.numConsumers(); c != 1 {
+				return fmt.Errorf("expected 1 consumer, got %d", c)
+			}
+			return nil
+		})
+
+		// Removing the mirror config should result in the sourcing consumer to be deleted.
+		cfg.Mirror = nil
+		_, err = js.UpdateStream(cfg)
+		require_NoError(t, err)
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			if c := mset.numConsumers(); c != 0 {
+				return fmt.Errorf("expected 0 consumers, got %d", c)
+			}
+			return nil
+		})
+	}
+
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) { test(t, replicas) })
+	}
+}
+
+func TestJetStreamDurableStreamMirrorDeletesConsumerAfterStreamRemoval(t *testing.T) {
+	test := func(t *testing.T, replicas int) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:      "O",
+			Subjects:  []string{"foo"},
+			Retention: nats.WorkQueuePolicy,
+			Replicas:  replicas,
+		})
+		require_NoError(t, err)
+
+		cfg := &nats.StreamConfig{
+			Name:   "M",
+			Mirror: &nats.StreamSource{Name: "O"},
+		}
+		_, err = js.AddStream(cfg)
+		require_NoError(t, err)
+
+		mset, err := s.globalAccount().lookupStream("O")
+		require_NoError(t, err)
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			if c := mset.numConsumers(); c != 1 {
+				return fmt.Errorf("expected 1 consumer, got %d", c)
+			}
+			return nil
+		})
+
+		// Deleting the stream that mirrors should result in the sourcing consumer to be deleted.
+		require_NoError(t, js.DeleteStream("M"))
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			if c := mset.numConsumers(); c != 0 {
+				return fmt.Errorf("expected 0 consumers, got %d", c)
+			}
+			return nil
+		})
+	}
+
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) { test(t, replicas) })
+	}
+}
+
+func TestJetStreamDurableStreamSourceDeletesConsumerAfterSourceUpdate(t *testing.T) {
+	test := func(t *testing.T, replicas int) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:      "O",
+			Subjects:  []string{"a", "b"},
+			Retention: nats.WorkQueuePolicy,
+			Replicas:  replicas,
+		})
+		require_NoError(t, err)
+
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:      "T",
+			Subjects:  []string{"foo"},
+			Retention: nats.WorkQueuePolicy,
+			Replicas:  replicas,
+		})
+		require_NoError(t, err)
+
+		mset, err := s.globalAccount().lookupStream("O")
+		require_NoError(t, err)
+		msetT, err := s.globalAccount().lookupStream("T")
+		require_NoError(t, err)
+
+		t.Run("Basic", func(t *testing.T) {
+			cfg := &nats.StreamConfig{
+				Name:    "S",
+				Sources: []*nats.StreamSource{{Name: "O"}},
+			}
+			_, err = js.AddStream(cfg)
+			require_NoError(t, err)
+			checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+				if c := mset.numConsumers(); c != 1 {
+					return fmt.Errorf("expected 1 consumer, got %d", c)
+				}
+				return nil
+			})
+
+			cfg.Sources = []*nats.StreamSource{
+				{Name: "O", FilterSubject: "a"},
+				{Name: "O", FilterSubject: "b"},
+			}
+			_, err = js.UpdateStream(cfg)
+			require_NoError(t, err)
+			checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+				if c := mset.numConsumers(); c != 2 {
+					return fmt.Errorf("expected 2 consumers, got %d", c)
+				}
+				return nil
+			})
+
+			// Removing the source config should result in the sourcing consumer to be deleted.
+			cfg.Sources = nil
+			_, err = js.UpdateStream(cfg)
+			require_NoError(t, err)
+			checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+				if c := mset.numConsumers(); c != 0 {
+					return fmt.Errorf("expected 0 consumers, got %d", c)
+				}
+				return nil
+			})
+		})
+
+		t.Run("Multiple", func(t *testing.T) {
+			// Now test adding two separate sources that would use the same consumer name but for separate streams.
+			cfg := &nats.StreamConfig{
+				Name: "S",
+				Sources: []*nats.StreamSource{
+					{Name: "O"},
+					{Name: "T"},
+				},
+			}
+			_, err = js.UpdateStream(cfg)
+			require_NoError(t, err)
+
+			var sourceConsumerName string
+			checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+				oc := mset.getPublicConsumers()
+				tc := msetT.getPublicConsumers()
+				if len(oc) != 1 || len(tc) != 1 {
+					return fmt.Errorf("expected 1 consumer on O and 1 consumer on T, got %d and %d", len(oc), len(tc))
+				}
+				occ := oc[0].info()
+				tcc := tc[0].info()
+				if occ.Name != tcc.Name {
+					return fmt.Errorf("expected consumer names to match, got %q and %q", occ.Name, tcc.Name)
+				}
+				sourceConsumerName = tcc.Name
+				return nil
+			})
+
+			// Removing one source should still properly clean up the sourcing consumer.
+			cfg.Sources = []*nats.StreamSource{{Name: "T"}}
+			_, err = js.UpdateStream(cfg)
+			require_NoError(t, err)
+
+			checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+				if c := mset.numConsumers(); c != 0 {
+					return fmt.Errorf("expected 0 consumers on O, got %d", c)
+				}
+				tc := msetT.getPublicConsumers()
+				if len(tc) != 1 {
+					return fmt.Errorf("expected 1 consumer on T, got %d", len(tc))
+				}
+				tcc := tc[0].info()
+				if tcc.Name != sourceConsumerName {
+					return fmt.Errorf("expected consumer names to match, got %q, expected %q", tcc.Name, sourceConsumerName)
+				}
+				return nil
+			})
+		})
+
+		t.Run("Mixed", func(t *testing.T) {
+			cfg := &StreamConfig{
+				Name:    "S",
+				Storage: FileStorage,
+				Sources: []*StreamSource{
+					{Name: "O"},
+				},
+			}
+			_, err = jsStreamUpdate(t, nc, cfg)
+			require_NoError(t, err)
+
+			// Capture the consumer name used for the sourcing.
+			var sourceConsumerName string
+			checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+				oc := mset.getPublicConsumers()
+				if len(oc) != 1 {
+					return fmt.Errorf("expected 1 consumer on O, got %d", len(oc))
+				}
+				occ := oc[0].info()
+				sourceConsumerName = occ.Name
+				return nil
+			})
+
+			checkExpectedCount := func(expected int) {
+				t.Helper()
+				checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+					if c := mset.numConsumers(); c != expected {
+						return fmt.Errorf("expected %d consumer(s) on O, got %d", expected, c)
+					}
+					return nil
+				})
+			}
+
+			// Create a consumer that will be used for the sourcing instead.
+			_, err = js.AddConsumer("O", &nats.ConsumerConfig{Durable: "CONSUMER", AckPolicy: nats.AckExplicitPolicy, DeliverSubject: "deliver"})
+			require_NoError(t, err)
+			checkExpectedCount(2)
+
+			// After the update, the previous sourcing consumer should be cleaned up.
+			cfg.Sources = []*StreamSource{
+				{Name: "O", Consumer: &StreamConsumerSource{Name: "CONSUMER", DeliverSubject: "deliver"}},
+			}
+			_, err = jsStreamUpdate(t, nc, cfg)
+			require_NoError(t, err)
+			checkExpectedCount(1)
+
+			// Recreate the sourcing consumer so we can validate it doesn't get removed if not referenced in the config.
+			_, err = jsConsumerCreate(t, nc, "O", ConsumerConfig{Durable: sourceConsumerName, AckPolicy: AckExplicit, Sourcing: true}, false)
+			require_NoError(t, err)
+			checkExpectedCount(2)
+
+			// Since we used a pre-existing consumer, the above source consumer replica that the source stream
+			// didn't create shouldn't be deleted.
+			cfg.Sources = nil
+			_, err = jsStreamUpdate(t, nc, cfg)
+			require_NoError(t, err)
+			time.Sleep(500 * time.Millisecond)
+			checkExpectedCount(2)
+
+			// Similarly, shouldn't remove the source consumer replica when deleting the source stream entirely.
+			// But need to reset it to contain sources again first.
+			cfg.Sources = []*StreamSource{
+				{Name: "O", Consumer: &StreamConsumerSource{Name: "CONSUMER", DeliverSubject: "deliver"}},
+			}
+			_, err = jsStreamUpdate(t, nc, cfg)
+			require_NoError(t, err)
+			require_NoError(t, js.DeleteStream("S"))
+			time.Sleep(500 * time.Millisecond)
+			checkExpectedCount(2)
+		})
+	}
+
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) { test(t, replicas) })
+	}
+}
+
+func TestJetStreamDurableStreamSourceDeletesConsumerAfterStreamRemoval(t *testing.T) {
+	test := func(t *testing.T, replicas int) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:      "O",
+			Subjects:  []string{"foo"},
+			Retention: nats.WorkQueuePolicy,
+			Replicas:  replicas,
+		})
+		require_NoError(t, err)
+
+		cfg := &nats.StreamConfig{
+			Name:    "S",
+			Sources: []*nats.StreamSource{{Name: "O"}},
+		}
+		_, err = js.AddStream(cfg)
+		require_NoError(t, err)
+
+		mset, err := s.globalAccount().lookupStream("O")
+		require_NoError(t, err)
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			if c := mset.numConsumers(); c != 1 {
+				return fmt.Errorf("expected 1 consumer, got %d", c)
+			}
+			return nil
+		})
+
+		// Deleting the stream that sources should result in the sourcing consumer to be deleted.
+		require_NoError(t, js.DeleteStream("S"))
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			if c := mset.numConsumers(); c != 0 {
+				return fmt.Errorf("expected 0 consumers, got %d", c)
+			}
+			return nil
+		})
+	}
+
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) { test(t, replicas) })
+	}
+}

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -11547,3 +11547,90 @@ func TestJetStreamConsumerAckReplyFormats(t *testing.T) {
 		require_Len(t, len(msg.Data), 0)
 	}
 }
+
+func TestJetStreamConsumerAckFlowControlBasics(t *testing.T) {
+	test := func(replicas int) {
+		c := createJetStreamClusterExplicit(t, "R3S", 3)
+		defer c.shutdown()
+
+		nc := clientConnectToServer(t, c.randomServer())
+		defer nc.Close()
+
+		_, err := jsStreamCreate(t, nc, &StreamConfig{
+			Name:      "TEST",
+			Subjects:  []string{"foo"},
+			Replicas:  replicas,
+			Storage:   FileStorage,
+			Retention: LimitsPolicy,
+		})
+		require_NoError(t, err)
+
+		checkConfig := func(ccfg *ConsumerConfig) {
+			require_Equal(t, ccfg.AckPolicy, AckFlowControl)
+			require_True(t, ccfg.FlowControl)
+			require_Equal(t, ccfg.Heartbeat, time.Second)
+			require_Equal(t, ccfg.AckWait, 0)
+			require_Equal(t, ccfg.MaxAckPending, JsDefaultMaxAckPending)
+			require_Equal(t, ccfg.MaxDeliver, -1)
+		}
+
+		// Only the deliver subject and policy are required; others are automatically defaulted.
+		cfg := ConsumerConfig{
+			Durable:        "DEFAULT",
+			DeliverSubject: "deliver-subject",
+			AckPolicy:      AckFlowControl,
+		}
+		ccfg, err := jsConsumerCreate(t, nc, "TEST", cfg, false)
+		require_NoError(t, err)
+		checkConfig(ccfg)
+
+		cfg = ConsumerConfig{
+			Durable:        "CONSUMER",
+			AckPolicy:      AckFlowControl,
+			DeliverSubject: _EMPTY_,
+			FlowControl:    false,
+			MaxAckPending:  -1,
+			AckWait:        30 * time.Second,
+			MaxDeliver:     1,
+		}
+		_, err = jsConsumerCreate(t, nc, "TEST", cfg, true)
+		require_Error(t, err, NewJSConsumerAckFCRequiresPushError())
+
+		cfg.DeliverSubject = "deliver-subject"
+		_, err = jsConsumerCreate(t, nc, "TEST", cfg, true)
+		require_Error(t, err, NewJSConsumerAckFCRequiresFCError())
+
+		cfg.FlowControl = true
+		_, err = jsConsumerCreate(t, nc, "TEST", cfg, true)
+		require_Error(t, err, NewJSStreamInvalidConfigError(fmt.Errorf("flow control ack policy heartbeat needs to be 1s")))
+
+		cfg.Heartbeat = time.Second
+		_, err = jsConsumerCreate(t, nc, "TEST", cfg, true)
+		require_Error(t, err, NewJSConsumerAckFCRequiresMaxAckPendingError())
+
+		cfg.MaxAckPending = JsDefaultMaxAckPending
+		_, err = jsConsumerCreate(t, nc, "TEST", cfg, true)
+		require_Error(t, err, NewJSConsumerAckFCRequiresNoAckWaitError())
+
+		cfg.AckWait = time.Second
+		cfg.BackOff = []time.Duration{time.Second, 2 * time.Second}
+		_, err = jsConsumerCreate(t, nc, "TEST", cfg, true)
+		require_Error(t, err, NewJSConsumerAckFCRequiresNoAckWaitError())
+
+		cfg.AckWait = 0
+		cfg.BackOff = nil
+		_, err = jsConsumerCreate(t, nc, "TEST", cfg, true)
+		require_Error(t, err, NewJSConsumerAckFCRequiresNoMaxDeliverError())
+
+		cfg.MaxDeliver = 0
+		_, err = jsConsumerCreate(t, nc, "TEST", cfg, true)
+		require_NoError(t, err)
+		checkConfig(ccfg)
+	}
+
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) {
+			test(replicas)
+		})
+	}
+}

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -89,6 +89,21 @@ const (
 	// JSClusterUnSupportFeatureErr not currently supported in clustered mode
 	JSClusterUnSupportFeatureErr ErrorIdentifier = 10036
 
+	// JSConsumerAckFCRequiresFCErr flow control ack policy requires flow control
+	JSConsumerAckFCRequiresFCErr ErrorIdentifier = 10219
+
+	// JSConsumerAckFCRequiresMaxAckPendingErr flow control ack policy requires max ack pending
+	JSConsumerAckFCRequiresMaxAckPendingErr ErrorIdentifier = 10220
+
+	// JSConsumerAckFCRequiresNoAckWaitErr flow control ack policy requires unset ack wait
+	JSConsumerAckFCRequiresNoAckWaitErr ErrorIdentifier = 10221
+
+	// JSConsumerAckFCRequiresNoMaxDeliverErr flow control ack policy requires unset max deliver
+	JSConsumerAckFCRequiresNoMaxDeliverErr ErrorIdentifier = 10222
+
+	// JSConsumerAckFCRequiresPushErr flow control ack policy requires a push based consumer
+	JSConsumerAckFCRequiresPushErr ErrorIdentifier = 10218
+
 	// JSConsumerAckPolicyInvalidErr consumer ack policy invalid
 	JSConsumerAckPolicyInvalidErr ErrorIdentifier = 10181
 
@@ -356,8 +371,14 @@ const (
 	// JSMessageTTLInvalidErr invalid per-message TTL
 	JSMessageTTLInvalidErr ErrorIdentifier = 10165
 
+	// JSMirrorConsumerRequiresAckFCErr stream mirror consumer requires flow control ack policy
+	JSMirrorConsumerRequiresAckFCErr ErrorIdentifier = 10214
+
 	// JSMirrorConsumerSetupFailedErrF generic mirror consumer setup failure string ({err})
 	JSMirrorConsumerSetupFailedErrF ErrorIdentifier = 10029
+
+	// JSMirrorDurableConsumerCfgInvalid stream mirror consumer config is invalid
+	JSMirrorDurableConsumerCfgInvalid ErrorIdentifier = 10213
 
 	// JSMirrorInvalidStreamName mirrored stream name is invalid
 	JSMirrorInvalidStreamName ErrorIdentifier = 10142
@@ -446,11 +467,20 @@ const (
 	// JSSnapshotDeliverSubjectInvalidErr deliver subject not valid
 	JSSnapshotDeliverSubjectInvalidErr ErrorIdentifier = 10015
 
+	// JSSourceConsumerRequiresAckFCErr stream source consumer requires flow control ack policy
+	JSSourceConsumerRequiresAckFCErr ErrorIdentifier = 10217
+
 	// JSSourceConsumerSetupFailedErrF General source consumer setup failure string ({err})
 	JSSourceConsumerSetupFailedErrF ErrorIdentifier = 10045
 
 	// JSSourceDuplicateDetected source stream, filter and transform (plus external if present) must form a unique combination (duplicate source configuration detected)
 	JSSourceDuplicateDetected ErrorIdentifier = 10140
+
+	// JSSourceDurableConsumerCfgInvalid stream source consumer config is invalid
+	JSSourceDurableConsumerCfgInvalid ErrorIdentifier = 10215
+
+	// JSSourceDurableConsumerDuplicateDetected duplicate stream source consumer detected
+	JSSourceDurableConsumerDuplicateDetected ErrorIdentifier = 10216
 
 	// JSSourceInvalidStreamName sourced stream name is invalid
 	JSSourceInvalidStreamName ErrorIdentifier = 10141
@@ -669,6 +699,11 @@ var (
 		JSClusterServerNotMemberErr:                  {Code: 400, ErrCode: 10044, Description: "server is not a member of the cluster"},
 		JSClusterTagsErr:                             {Code: 400, ErrCode: 10011, Description: "tags placement not supported for operation"},
 		JSClusterUnSupportFeatureErr:                 {Code: 503, ErrCode: 10036, Description: "not currently supported in clustered mode"},
+		JSConsumerAckFCRequiresFCErr:                 {Code: 400, ErrCode: 10219, Description: "flow control ack policy requires flow control"},
+		JSConsumerAckFCRequiresMaxAckPendingErr:      {Code: 400, ErrCode: 10220, Description: "flow control ack policy requires max ack pending"},
+		JSConsumerAckFCRequiresNoAckWaitErr:          {Code: 400, ErrCode: 10221, Description: "flow control ack policy requires unset ack wait"},
+		JSConsumerAckFCRequiresNoMaxDeliverErr:       {Code: 400, ErrCode: 10222, Description: "flow control ack policy requires unset max deliver"},
+		JSConsumerAckFCRequiresPushErr:               {Code: 400, ErrCode: 10218, Description: "flow control ack policy requires a push based consumer"},
 		JSConsumerAckPolicyInvalidErr:                {Code: 400, ErrCode: 10181, Description: "consumer ack policy invalid"},
 		JSConsumerAckWaitNegativeErr:                 {Code: 400, ErrCode: 10183, Description: "consumer ack wait needs to be positive"},
 		JSConsumerAlreadyExists:                      {Code: 400, ErrCode: 10148, Description: "consumer already exists"},
@@ -758,7 +793,9 @@ var (
 		JSMessageSchedulesTargetInvalidErr:           {Code: 400, ErrCode: 10190, Description: "message schedules target is invalid"},
 		JSMessageTTLDisabledErr:                      {Code: 400, ErrCode: 10166, Description: "per-message TTL is disabled"},
 		JSMessageTTLInvalidErr:                       {Code: 400, ErrCode: 10165, Description: "invalid per-message TTL"},
+		JSMirrorConsumerRequiresAckFCErr:             {Code: 400, ErrCode: 10214, Description: "stream mirror consumer requires flow control ack policy"},
 		JSMirrorConsumerSetupFailedErrF:              {Code: 500, ErrCode: 10029, Description: "{err}"},
+		JSMirrorDurableConsumerCfgInvalid:            {Code: 400, ErrCode: 10213, Description: "stream mirror consumer config is invalid"},
 		JSMirrorInvalidStreamName:                    {Code: 400, ErrCode: 10142, Description: "mirrored stream name is invalid"},
 		JSMirrorInvalidSubjectFilter:                 {Code: 400, ErrCode: 10151, Description: "mirror transform source: {err}"},
 		JSMirrorInvalidTransformDestination:          {Code: 400, ErrCode: 10154, Description: "mirror transform: {err}"},
@@ -788,8 +825,11 @@ var (
 		JSRestoreSubscribeFailedErrF:                 {Code: 500, ErrCode: 10042, Description: "JetStream unable to subscribe to restore snapshot {subject}: {err}"},
 		JSSequenceNotFoundErrF:                       {Code: 400, ErrCode: 10043, Description: "sequence {seq} not found"},
 		JSSnapshotDeliverSubjectInvalidErr:           {Code: 400, ErrCode: 10015, Description: "deliver subject not valid"},
+		JSSourceConsumerRequiresAckFCErr:             {Code: 400, ErrCode: 10217, Description: "stream source consumer requires flow control ack policy"},
 		JSSourceConsumerSetupFailedErrF:              {Code: 500, ErrCode: 10045, Description: "{err}"},
 		JSSourceDuplicateDetected:                    {Code: 400, ErrCode: 10140, Description: "duplicate source configuration detected"},
+		JSSourceDurableConsumerCfgInvalid:            {Code: 400, ErrCode: 10215, Description: "stream source consumer config is invalid"},
+		JSSourceDurableConsumerDuplicateDetected:     {Code: 400, ErrCode: 10216, Description: "duplicate stream source consumer detected"},
 		JSSourceInvalidStreamName:                    {Code: 400, ErrCode: 10141, Description: "sourced stream name is invalid"},
 		JSSourceInvalidSubjectFilter:                 {Code: 400, ErrCode: 10145, Description: "source transform source: {err}"},
 		JSSourceInvalidTransformDestination:          {Code: 400, ErrCode: 10146, Description: "source transform: {err}"},
@@ -1173,6 +1213,56 @@ func NewJSClusterUnSupportFeatureError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSClusterUnSupportFeatureErr]
+}
+
+// NewJSConsumerAckFCRequiresFCError creates a new JSConsumerAckFCRequiresFCErr error: "flow control ack policy requires flow control"
+func NewJSConsumerAckFCRequiresFCError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSConsumerAckFCRequiresFCErr]
+}
+
+// NewJSConsumerAckFCRequiresMaxAckPendingError creates a new JSConsumerAckFCRequiresMaxAckPendingErr error: "flow control ack policy requires max ack pending"
+func NewJSConsumerAckFCRequiresMaxAckPendingError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSConsumerAckFCRequiresMaxAckPendingErr]
+}
+
+// NewJSConsumerAckFCRequiresNoAckWaitError creates a new JSConsumerAckFCRequiresNoAckWaitErr error: "flow control ack policy requires unset ack wait"
+func NewJSConsumerAckFCRequiresNoAckWaitError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSConsumerAckFCRequiresNoAckWaitErr]
+}
+
+// NewJSConsumerAckFCRequiresNoMaxDeliverError creates a new JSConsumerAckFCRequiresNoMaxDeliverErr error: "flow control ack policy requires unset max deliver"
+func NewJSConsumerAckFCRequiresNoMaxDeliverError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSConsumerAckFCRequiresNoMaxDeliverErr]
+}
+
+// NewJSConsumerAckFCRequiresPushError creates a new JSConsumerAckFCRequiresPushErr error: "flow control ack policy requires a push based consumer"
+func NewJSConsumerAckFCRequiresPushError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSConsumerAckFCRequiresPushErr]
 }
 
 // NewJSConsumerAckPolicyInvalidError creates a new JSConsumerAckPolicyInvalidErr error: "consumer ack policy invalid"
@@ -2143,6 +2233,16 @@ func NewJSMessageTTLInvalidError(opts ...ErrorOption) *ApiError {
 	return ApiErrors[JSMessageTTLInvalidErr]
 }
 
+// NewJSMirrorConsumerRequiresAckFCError creates a new JSMirrorConsumerRequiresAckFCErr error: "stream mirror consumer requires flow control ack policy"
+func NewJSMirrorConsumerRequiresAckFCError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMirrorConsumerRequiresAckFCErr]
+}
+
 // NewJSMirrorConsumerSetupFailedError creates a new JSMirrorConsumerSetupFailedErrF error: "{err}"
 func NewJSMirrorConsumerSetupFailedError(err error, opts ...ErrorOption) *ApiError {
 	eopts := parseOpts(opts)
@@ -2157,6 +2257,16 @@ func NewJSMirrorConsumerSetupFailedError(err error, opts ...ErrorOption) *ApiErr
 		ErrCode:     e.ErrCode,
 		Description: strings.NewReplacer(args...).Replace(e.Description),
 	}
+}
+
+// NewJSMirrorDurableConsumerCfgInvalidError creates a new JSMirrorDurableConsumerCfgInvalid error: "stream mirror consumer config is invalid"
+func NewJSMirrorDurableConsumerCfgInvalidError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMirrorDurableConsumerCfgInvalid]
 }
 
 // NewJSMirrorInvalidStreamNameError creates a new JSMirrorInvalidStreamName error: "mirrored stream name is invalid"
@@ -2485,6 +2595,16 @@ func NewJSSnapshotDeliverSubjectInvalidError(opts ...ErrorOption) *ApiError {
 	return ApiErrors[JSSnapshotDeliverSubjectInvalidErr]
 }
 
+// NewJSSourceConsumerRequiresAckFCError creates a new JSSourceConsumerRequiresAckFCErr error: "stream source consumer requires flow control ack policy"
+func NewJSSourceConsumerRequiresAckFCError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSSourceConsumerRequiresAckFCErr]
+}
+
 // NewJSSourceConsumerSetupFailedError creates a new JSSourceConsumerSetupFailedErrF error: "{err}"
 func NewJSSourceConsumerSetupFailedError(err error, opts ...ErrorOption) *ApiError {
 	eopts := parseOpts(opts)
@@ -2509,6 +2629,26 @@ func NewJSSourceDuplicateDetectedError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSSourceDuplicateDetected]
+}
+
+// NewJSSourceDurableConsumerCfgInvalidError creates a new JSSourceDurableConsumerCfgInvalid error: "stream source consumer config is invalid"
+func NewJSSourceDurableConsumerCfgInvalidError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSSourceDurableConsumerCfgInvalid]
+}
+
+// NewJSSourceDurableConsumerDuplicateDetectedError creates a new JSSourceDurableConsumerDuplicateDetected error: "duplicate stream source consumer detected"
+func NewJSSourceDurableConsumerDuplicateDetectedError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSSourceDurableConsumerDuplicateDetected]
 }
 
 // NewJSSourceInvalidStreamNameError creates a new JSSourceInvalidStreamName error: "sourced stream name is invalid"

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -1330,6 +1330,27 @@ func jsStreamUpdate(t testing.TB, nc *nats.Conn, cfg *StreamConfig) (*StreamConf
 	return &resp.Config, nil
 }
 
+// jsConsumerCreate is for sending a consumer create for fields that nats.go does not know about yet.
+func jsConsumerCreate(t testing.TB, nc *nats.Conn, stream string, cfg ConsumerConfig, pedantic bool) (*ConsumerConfig, error) {
+	t.Helper()
+
+	j, err := json.Marshal(CreateConsumerRequest{Stream: stream, Config: cfg, Pedantic: pedantic})
+	require_NoError(t, err)
+
+	msg, err := nc.Request(fmt.Sprintf(JSApiDurableCreateT, stream, cfg.Durable), j, time.Second*3)
+	require_NoError(t, err)
+
+	var resp JSApiConsumerCreateResponse
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	require_NotNil(t, resp.ConsumerInfo)
+	return resp.Config, nil
+}
+
 func checkSubsPending(t *testing.T, sub *nats.Subscription, numExpected int) {
 	t.Helper()
 	checkFor(t, 10*time.Second, 20*time.Millisecond, func() error {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -23199,3 +23199,207 @@ func TestJetStreamSourcingIntoDiscardNewPerSubject(t *testing.T) {
 	require_Equal(t, string(msgp.Data), "1")
 
 }
+
+func TestJetStreamDurableStreamMirrorAndSourceIncorrectConsumerConfig(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:      "O",
+		Subjects:  []string{"foo"},
+		Storage:   FileStorage,
+		Retention: WorkQueuePolicy,
+	})
+	require_NoError(t, err)
+
+	_, err = jsConsumerCreate(t, nc, "O", ConsumerConfig{
+		Durable:        "C",
+		DeliverSubject: "deliver-subject",
+		AckPolicy:      AckExplicit,
+	}, false)
+	require_NoError(t, err)
+
+	checkMirror := func(expected string) {
+		t.Helper()
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			si, err := js.StreamInfo("M")
+			if err != nil {
+				return err
+			}
+			if si.Mirror == nil {
+				return errors.New("no mirror")
+			}
+			if si.Mirror.Error == nil {
+				return errors.New("expected mirror error")
+			}
+			if si.Mirror.Error.Description != expected {
+				return si.Mirror.Error
+			}
+			return nil
+		})
+	}
+
+	// Mirror.
+	cfg := &StreamConfig{
+		Name:    "M",
+		Mirror:  &StreamSource{Name: "O", Consumer: &StreamConsumerSource{Name: "", DeliverSubject: "deliver-subject"}},
+		Storage: FileStorage,
+	}
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSMirrorDurableConsumerCfgInvalidError())
+
+	cfg.Mirror = &StreamSource{Name: "O", Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: ""}}
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSMirrorDurableConsumerCfgInvalidError())
+
+	// Reject invalid consumer name.
+	cfg.Mirror = &StreamSource{Name: "O", Consumer: &StreamConsumerSource{Name: "C.b", DeliverSubject: "deliver-subject"}}
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSMirrorDurableConsumerCfgInvalidError())
+
+	// Reject invalid deliver subject.
+	cfg.Mirror = &StreamSource{Name: "O", Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: "deliver.."}}
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSMirrorDurableConsumerCfgInvalidError())
+
+	cfg.Mirror = &StreamSource{Name: "O", Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: "deliver-subject"}}
+
+	// Setting start seq shouldn't be allowed.
+	cfg.Mirror.OptStartSeq = 1
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSMirrorDurableConsumerCfgInvalidError())
+
+	// Setting start time shouldn't be allowed.
+	now := time.Now()
+	cfg.Mirror.OptStartSeq = 0
+	cfg.Mirror.OptStartTime = &now
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSMirrorDurableConsumerCfgInvalidError())
+
+	// Setting filter subject shouldn't be allowed.
+	cfg.Mirror.OptStartTime = nil
+	cfg.Mirror.FilterSubject = "filter"
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSMirrorDurableConsumerCfgInvalidError())
+
+	cfg.Mirror = &StreamSource{Name: "O", Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: "deliver-subject"}}
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_NoError(t, err)
+	checkMirror(NewJSMirrorConsumerRequiresAckFCError().Description)
+
+	// Check mirror config is not updatable.
+	cfg.Mirror.SubjectTransforms = []SubjectTransformConfig{{Source: ">", Destination: "a.>"}}
+	_, err = jsStreamUpdate(t, nc, cfg)
+	require_Error(t, err, NewJSStreamMirrorNotUpdatableError())
+
+	checkSource := func(expected string) {
+		t.Helper()
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			si, err := js.StreamInfo("S")
+			if err != nil {
+				return err
+			}
+			if len(si.Sources) != 1 {
+				return errors.New("no source")
+			}
+			sourceErr := si.Sources[0].Error
+			if sourceErr == nil {
+				return errors.New("expected source error")
+			}
+			if sourceErr.Description != expected {
+				return sourceErr
+			}
+			return nil
+		})
+	}
+
+	// Source.
+	cfg = &StreamConfig{
+		Name:    "S",
+		Sources: []*StreamSource{{Name: "O", Consumer: &StreamConsumerSource{Name: "", DeliverSubject: "deliver-subject"}}},
+		Storage: FileStorage,
+	}
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSSourceDurableConsumerCfgInvalidError())
+
+	cfg.Sources = []*StreamSource{{Name: "O", Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: ""}}}
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSSourceDurableConsumerCfgInvalidError())
+
+	// Reject invalid consumer name.
+	cfg.Sources = []*StreamSource{{Name: "O", Consumer: &StreamConsumerSource{Name: "C.b", DeliverSubject: "deliver-subject"}}}
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSSourceDurableConsumerCfgInvalidError())
+
+	// Reject invalid deliver subject.
+	cfg.Sources = []*StreamSource{{Name: "O", Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: "deliver.."}}}
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSSourceDurableConsumerCfgInvalidError())
+
+	cfg.Sources = []*StreamSource{
+		{Name: "O", SubjectTransforms: []SubjectTransformConfig{{Source: ">", Destination: "a.>"}}, Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: "a"}},
+		{Name: "O", SubjectTransforms: []SubjectTransformConfig{{Source: ">", Destination: "b.>"}}, Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: "b"}},
+	}
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSSourceDurableConsumerDuplicateDetectedError())
+
+	cfg.Sources = []*StreamSource{{Name: "O", Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: "deliver-subject"}}}
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_NoError(t, err)
+	checkSource(NewJSSourceConsumerRequiresAckFCError().Description)
+	require_NoError(t, js.DeleteStream("S"))
+
+	// Setting start seq shouldn't be allowed.
+	cfg.Sources[0].OptStartSeq = 1
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSSourceDurableConsumerCfgInvalidError())
+
+	// Setting start time shouldn't be allowed.
+	cfg.Sources[0].OptStartSeq = 0
+	cfg.Sources[0].OptStartTime = &now
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSSourceDurableConsumerCfgInvalidError())
+
+	// Setting filter subject shouldn't be allowed.
+	cfg.Sources[0].OptStartTime = nil
+	cfg.Sources[0].FilterSubject = "filter"
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_Error(t, err, NewJSSourceDurableConsumerCfgInvalidError())
+}
+
+func TestJetStreamDurableStreamSourcesWithUniqueConsumerNames(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "O",
+		Subjects:  []string{"a", "b"},
+		Retention: nats.WorkQueuePolicy,
+	})
+	require_NoError(t, err)
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name: "S",
+		Sources: []*nats.StreamSource{
+			{Name: "O", FilterSubject: "a"},
+			{Name: "O", FilterSubject: "b"},
+		},
+	})
+	require_NoError(t, err)
+
+	// Expect two separate sourcing consumers to be created for the above sourcing stream.
+	mset, err := s.globalAccount().lookupStream("O")
+	require_NoError(t, err)
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		if c := mset.numConsumers(); c != 2 {
+			return fmt.Errorf("expected 2 consumers, got %d", c)
+		}
+		return nil
+	})
+}

--- a/server/jetstream_versioning.go
+++ b/server/jetstream_versioning.go
@@ -163,6 +163,11 @@ func setStaticConsumerMetadata(cfg *ConsumerConfig) {
 		requires(1)
 	}
 
+	// Added in 2.14
+	if cfg.AckPolicy == AckFlowControl {
+		requires(4)
+	}
+
 	cfg.Metadata[JSRequiredLevelMetadataKey] = strconv.Itoa(requiredApiLevel)
 }
 

--- a/server/jetstream_versioning_test.go
+++ b/server/jetstream_versioning_test.go
@@ -254,6 +254,11 @@ func TestJetStreamSetStaticConsumerMetadata(t *testing.T) {
 			cfg:              &ConsumerConfig{PriorityPolicy: PriorityPinnedClient, PriorityGroups: []string{"a"}},
 			expectedMetadata: metadataAtLevel("1"),
 		},
+		{
+			desc:             "AckFlowControl",
+			cfg:              &ConsumerConfig{AckPolicy: AckFlowControl},
+			expectedMetadata: metadataAtLevel("4"),
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			setStaticConsumerMetadata(test.cfg)

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -2605,8 +2605,8 @@ func (o *consumerMemStore) UpdateAcks(dseq, sseq uint64) error {
 		return ErrStoreMsgNotFound
 	}
 
-	// Check for AckAll here.
-	if o.cfg.AckPolicy == AckAll {
+	// Check for AckAll here (or AckFlowControl which functions like AckAll).
+	if o.cfg.AckPolicy == AckAll || o.cfg.AckPolicy == AckFlowControl {
 		sgap := sseq - o.state.AckFloor.Stream
 		o.state.AckFloor.Consumer = dseq
 		o.state.AckFloor.Stream = sseq

--- a/server/store.go
+++ b/server/store.go
@@ -597,15 +597,17 @@ func (st *StorageType) UnmarshalJSON(data []byte) error {
 }
 
 const (
-	ackNonePolicyJSONString     = `"none"`
-	ackAllPolicyJSONString      = `"all"`
-	ackExplicitPolicyJSONString = `"explicit"`
+	ackNonePolicyJSONString        = `"none"`
+	ackAllPolicyJSONString         = `"all"`
+	ackExplicitPolicyJSONString    = `"explicit"`
+	ackFlowControlPolicyJSONString = `"flow_control"`
 )
 
 var (
-	ackNonePolicyJSONBytes     = []byte(ackNonePolicyJSONString)
-	ackAllPolicyJSONBytes      = []byte(ackAllPolicyJSONString)
-	ackExplicitPolicyJSONBytes = []byte(ackExplicitPolicyJSONString)
+	ackNonePolicyJSONBytes        = []byte(ackNonePolicyJSONString)
+	ackAllPolicyJSONBytes         = []byte(ackAllPolicyJSONString)
+	ackExplicitPolicyJSONBytes    = []byte(ackExplicitPolicyJSONString)
+	ackFlowControlPolicyJSONBytes = []byte(ackFlowControlPolicyJSONString)
 )
 
 func (ap AckPolicy) MarshalJSON() ([]byte, error) {
@@ -616,6 +618,8 @@ func (ap AckPolicy) MarshalJSON() ([]byte, error) {
 		return ackAllPolicyJSONBytes, nil
 	case AckExplicit:
 		return ackExplicitPolicyJSONBytes, nil
+	case AckFlowControl:
+		return ackFlowControlPolicyJSONBytes, nil
 	default:
 		return nil, fmt.Errorf("can not marshal %v", ap)
 	}
@@ -629,6 +633,8 @@ func (ap *AckPolicy) UnmarshalJSON(data []byte) error {
 		*ap = AckAll
 	case ackExplicitPolicyJSONString:
 		*ap = AckExplicit
+	case ackFlowControlPolicyJSONString:
+		*ap = AckFlowControl
 	default:
 		return fmt.Errorf("can not unmarshal %q", data)
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -413,9 +413,16 @@ type StreamSource struct {
 	FilterSubject     string                   `json:"filter_subject,omitempty"`
 	SubjectTransforms []SubjectTransformConfig `json:"subject_transforms,omitempty"`
 	External          *ExternalStream          `json:"external,omitempty"`
+	Consumer          *StreamConsumerSource    `json:"consumer,omitempty"`
 
 	// Internal
 	iname string // For indexing when stream names are the same for multiple sources.
+}
+
+// StreamConsumerSource dictates a durable consumer with a specific name is used for sourcing.
+type StreamConsumerSource struct {
+	Name           string `json:"name,omitempty"`
+	DeliverSubject string `json:"deliver_subject,omitempty"`
 }
 
 // ExternalStream allows you to qualify access to a stream source in another account or domain.
@@ -513,8 +520,8 @@ type stream struct {
 	sourcesConsumerSetup *time.Timer
 	smsgs                *ipQueue[*inMsg] // Intra-process queue for all incoming sourced messages.
 
-	// Indicates we have direct consumers.
-	directs int
+	// Indicates we have direct/sourcing consumers.
+	sourcingConsumers int
 
 	// For input subject transform.
 	itr *subjectTransform
@@ -1075,6 +1082,9 @@ func (ssi *StreamSource) composeIName() string {
 	if ssi.External != nil {
 		iName = iName + ":" + getHash(ssi.External.ApiPrefix)
 	}
+	if ssi.Consumer != nil {
+		iName = iName + ":C=" + getHash(ssi.Consumer.Name)
+	}
 
 	source := ssi.FilterSubject
 	destination := fwcs
@@ -1111,6 +1121,23 @@ func (ssi *StreamSource) composeIName() string {
 // Sets the index name.
 func (ssi *StreamSource) setIndexName() {
 	ssi.iname = ssi.composeIName()
+}
+
+// Composes the consumer index name. Contains the stream name and consumer name used for durable sourcing (if any).
+// When the stream is external we will use the api prefix as part of the index name
+// (as the same stream and consumer names could be used in multiple JS domains)
+func (ssi *StreamSource) composeCName() string {
+	var iName = ssi.Name
+
+	if ssi.External != nil {
+		iName = iName + ":" + getHash(ssi.External.ApiPrefix)
+	}
+	var c string
+	if ssi.Consumer != nil {
+		c = ssi.Consumer.Name
+	}
+
+	return strings.Join([]string{iName, c}, " ")
 }
 
 func (mset *stream) streamAssignment() *streamAssignment {
@@ -1838,6 +1865,20 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 		if cfg.AllowMsgSchedules {
 			return StreamConfig{}, NewJSMirrorWithMsgSchedulesError()
 		}
+		if c := cfg.Mirror.Consumer; c != nil {
+			if !isValidName(c.Name) {
+				return StreamConfig{}, NewJSMirrorDurableConsumerCfgInvalidError()
+			}
+			if !subjectIsLiteral(c.DeliverSubject) || !IsValidSubject(c.DeliverSubject) {
+				return StreamConfig{}, NewJSMirrorDurableConsumerCfgInvalidError()
+			}
+			if cfg.Mirror.OptStartSeq != 0 || cfg.Mirror.OptStartTime != nil {
+				return StreamConfig{}, NewJSMirrorDurableConsumerCfgInvalidError()
+			}
+			if cfg.Mirror.FilterSubject != _EMPTY_ {
+				return StreamConfig{}, NewJSMirrorDurableConsumerCfgInvalidError()
+			}
+		}
 		if cfg.Mirror.FilterSubject != _EMPTY_ && len(cfg.Mirror.SubjectTransforms) != 0 {
 			return StreamConfig{}, NewJSMirrorMultipleFiltersNotAllowedError()
 		}
@@ -1921,6 +1962,7 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 
 	// check sources for duplicates
 	var iNames = make(map[string]struct{})
+	var cNames = make(map[string]struct{})
 	for _, src := range cfg.Sources {
 		if src == nil || !isValidName(src.Name) {
 			return StreamConfig{}, NewJSSourceInvalidStreamNameError()
@@ -1951,6 +1993,27 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 				if inner != outer && subjectIsSubsetMatch(tr.Source, innertr.Source) {
 					return StreamConfig{}, NewJSSourceOverlappingSubjectFiltersError()
 				}
+			}
+		}
+
+		if c := src.Consumer; c != nil {
+			if !isValidName(c.Name) {
+				return StreamConfig{}, NewJSSourceDurableConsumerCfgInvalidError()
+			}
+			if !subjectIsLiteral(c.DeliverSubject) || !IsValidSubject(c.DeliverSubject) {
+				return StreamConfig{}, NewJSSourceDurableConsumerCfgInvalidError()
+			}
+			if src.OptStartSeq != 0 || src.OptStartTime != nil {
+				return StreamConfig{}, NewJSSourceDurableConsumerCfgInvalidError()
+			}
+			if src.FilterSubject != _EMPTY_ {
+				return StreamConfig{}, NewJSSourceDurableConsumerCfgInvalidError()
+			}
+			// Reusing the same consumer for multiple sources of the same stream isn't allowed.
+			if _, ok := cNames[src.composeCName()]; !ok {
+				cNames[src.composeCName()] = struct{}{}
+			} else {
+				return StreamConfig{}, NewJSSourceDurableConsumerDuplicateDetectedError()
 			}
 		}
 
@@ -2398,6 +2461,10 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 	if mset.active {
 		// Check for mirror promotion.
 		if ocfg.Mirror != nil && cfg.Mirror == nil {
+			// Only try deleting the sourcing consumer if one wasn't provided to us.
+			if ocfg.Mirror.Consumer == nil {
+				mset.tryDeleteMirrorConsumer(ocfg.Mirror)
+			}
 			mset.cancelMirrorConsumer()
 			mset.mirror = nil
 		}
@@ -2439,10 +2506,22 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 		// Check for Sources.
 		if len(cfg.Sources) > 0 || len(ocfg.Sources) > 0 {
 			currentIName := make(map[string]struct{})
+			currentConsumers := make(map[string]*StreamSource)
 			needsStartingSeqNum := make(map[string]struct{})
 
+			getSourcingConsumerIName := func(ssi *StreamSource, sources []*StreamSource) string {
+				var iName = ssi.Name
+				if ssi.External != nil {
+					iName = iName + ":" + getHash(ssi.External.ApiPrefix)
+				}
+				return fmt.Sprintf("%s %s", iName, mset.createSourcingConsumerHash(ssi, sources))
+			}
 			for _, s := range ocfg.Sources {
 				currentIName[s.iname] = struct{}{}
+				// Only track the sourcing consumer for deletion if one wasn't provided to us.
+				if s.Consumer == nil {
+					currentConsumers[getSourcingConsumerIName(s, ocfg.Sources)] = s
+				}
 			}
 			for _, s := range cfg.Sources {
 				s.setIndexName()
@@ -2479,6 +2558,16 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 					// source already exists
 					delete(currentIName, s.iname)
 				}
+
+				// Remove the source if it still exists, but only if not using a pre-existing consumer.
+				if s.Consumer == nil {
+					delete(currentConsumers, getSourcingConsumerIName(s, cfg.Sources))
+				}
+			}
+			// Delete source consumers if any aren't used anymore.
+			for _, s := range currentConsumers {
+				id := mset.createSourcingConsumerHash(s, ocfg.Sources)
+				mset.tryDeleteSourceConsumer(id, s)
 			}
 			// What is left in currentIName needs to be deleted.
 			for iName := range currentIName {
@@ -2655,6 +2744,80 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 	mset.store.UpdateConfig(cfg)
 
 	return nil
+}
+
+// tryDeleteMirrorConsumer is a best-effort single try to delete a consumer used for stream mirroring.
+// Lock should be held.
+func (mset *stream) tryDeleteMirrorConsumer(mirror *StreamSource) {
+	id := mset.createStableConsumerHash()
+	consumerName := fmt.Sprintf("JS_MIRROR_%s", id)
+	log := mset.mirror != nil && mset.mirror.cname == consumerName
+	mset.tryDeleteSourcingConsumer("mirror", mirror, consumerName, log)
+}
+
+// tryDeleteSourceConsumer is a best-effort single try to delete a consumer used for stream sourcing.
+// Lock should be held.
+func (mset *stream) tryDeleteSourceConsumer(id string, source *StreamSource) {
+	consumerName := fmt.Sprintf("JS_SRC_%s", id)
+	si := mset.sources[source.iname]
+	log := si != nil && si.cname == consumerName
+	mset.tryDeleteSourcingConsumer("source", source, consumerName, log)
+}
+
+// tryDeleteSourcingConsumer is a best-effort single try to delete a sourcing consumer.
+// Lock should be held.
+func (mset *stream) tryDeleteSourcingConsumer(kind string, source *StreamSource, consumerName string, log bool) {
+	acc := mset.acc
+	accName, streamName, sourceName := acc.Name, mset.cfg.Name, source.Name
+	subject := fmt.Sprintf(JSApiConsumerDeleteT, sourceName, consumerName)
+	if source.External != nil {
+		subject = strings.Replace(subject, JSApiPrefix, source.External.ApiPrefix, 1)
+		subject = strings.ReplaceAll(subject, "..", ".")
+	}
+	s := mset.srv
+	go func() {
+		warn := func(err error) {
+			if log {
+				s.Warnf("Cleanup of %s consumer '%s > %s' failed for stream '%s > %s': %v", kind, sourceName, consumerName, accName, streamName, err)
+			}
+		}
+
+		respCh := make(chan *JSApiConsumerDeleteResponse, 1)
+		reply := infoReplySubject()
+		cdSub, err := acc.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+			_, msg := c.msgParts(rmsg)
+
+			var cdr JSApiConsumerDeleteResponse
+			if err := json.Unmarshal(msg, &cdr); err != nil {
+				warn(err)
+				return
+			}
+			select {
+			case respCh <- &cdr:
+			default:
+			}
+		})
+		if err != nil {
+			warn(err)
+			return
+		}
+		defer acc.unsubscribeInternal(cdSub)
+
+		// Send the delete request.
+		err = s.sendInternalAccountMsgWithReply(acc, subject, reply, nil, nil, false)
+		if err != nil {
+			warn(err)
+			return
+		}
+		select {
+		case cdr := <-respCh:
+			if cdr.Error != nil {
+				warn(cdr.Error)
+			}
+		case <-time.After(sourceHealthCheckInterval):
+			warn(errors.New("timed out"))
+		}
+	}()
 }
 
 // Small helper to return the Name field from mset.cfg, protected by
@@ -2999,12 +3162,12 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 		var needsRetry bool
 		// Flow controls have reply subjects.
 		if m.rply != _EMPTY_ {
-			mset.handleFlowControl(m)
+			mset.handleFlowControl(m, mset.mirror.dseq, mset.mirror.sseq)
 		} else {
 			// For idle heartbeats make sure we did not miss anything and check if we are considered stalled.
-			if ldseq := parseInt64(getHeader(JSLastConsumerSeq, m.hdr)); ldseq > 0 && uint64(ldseq) != mset.mirror.dseq {
+			if ldseq := parseInt64(sliceHeader(JSLastConsumerSeq, m.hdr)); ldseq > 0 && uint64(ldseq) != mset.mirror.dseq {
 				needsRetry = true
-			} else if fcReply := getHeader(JSConsumerStalled, m.hdr); len(fcReply) > 0 {
+			} else if fcReply := sliceHeader(JSConsumerStalled, m.hdr); len(fcReply) > 0 {
 				// Other side thinks we are stalled, so send flow control reply.
 				mset.outq.sendMsg(string(fcReply), nil)
 			}
@@ -3025,13 +3188,17 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 
 	// Mirror info tracking.
 	olag, osseq, odseq := mset.mirror.lag, mset.mirror.sseq, mset.mirror.dseq
-	if sseq == mset.mirror.sseq+1 {
-		mset.mirror.dseq = dseq
-		mset.mirror.sseq++
-	} else if sseq <= mset.mirror.sseq {
+	if sseq <= mset.mirror.sseq {
 		// Ignore older messages.
+		// If the deliver sequence matches, we only update delivered accounting.
+		if dseq == mset.mirror.dseq+1 {
+			mset.mirror.dseq++
+		}
 		mset.mu.Unlock()
 		return true
+	} else if sseq == mset.mirror.sseq+1 {
+		mset.mirror.dseq = dseq
+		mset.mirror.sseq++
 	} else if mset.mirror.cname == _EMPTY_ {
 		mset.mirror.cname = cname
 		mset.mirror.dseq, mset.mirror.sseq = dseq, sseq
@@ -3107,10 +3274,10 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 				accName, sname, err)
 		} else {
 			// We may have missed messages, restart.
-			if sseq <= mset.lastSeq() {
+			if lseq := mset.lastSeq(); sseq <= lseq {
 				mset.mu.Lock()
 				mset.mirror.lag = olag
-				mset.mirror.sseq = osseq
+				mset.mirror.sseq = lseq
 				mset.mirror.dseq = odseq
 				mset.mu.Unlock()
 				return false
@@ -3278,9 +3445,12 @@ func (mset *stream) setupMirrorConsumer() error {
 
 	// Determine subjects etc.
 	var deliverSubject string
+	var durableDeliverSubject string
 	ext := mset.cfg.Mirror.External
-
-	if ext != nil && ext.DeliverPrefix != _EMPTY_ {
+	if mset.cfg.Mirror.Consumer != nil {
+		durableDeliverSubject = mset.cfg.Mirror.Consumer.DeliverSubject
+		mirror.cname = mset.cfg.Mirror.Consumer.Name
+	} else if ext != nil && ext.DeliverPrefix != _EMPTY_ {
 		deliverSubject = strings.ReplaceAll(ext.DeliverPrefix+syncSubject(".M"), "..", ".")
 	} else {
 		deliverSubject = syncSubject("$JS.M")
@@ -3292,9 +3462,18 @@ func (mset *stream) setupMirrorConsumer() error {
 	var state StreamState
 	mset.store.FastState(&state)
 
+	id := mset.createStableConsumerHash()
+	metadata := map[string]string{}
+	metadata["_nats.mirror.stream"] = mset.cfg.Name
+	metadata["_nats.mirror.acc"] = mset.acc.Name
+	if domain := mset.srv.getOpts().JetStreamDomain; domain != _EMPTY_ {
+		metadata["_nats.mirror.domain"] = domain
+	}
+
 	req := &CreateConsumerRequest{
 		Stream: mset.cfg.Mirror.Name,
 		Config: ConsumerConfig{
+			Name:              fmt.Sprintf("JS_MIRROR_%s", id),
 			DeliverSubject:    deliverSubject,
 			DeliverPolicy:     DeliverByStartSequence,
 			OptStartSeq:       state.LastSeq + 1,
@@ -3304,7 +3483,9 @@ func (mset *stream) setupMirrorConsumer() error {
 			Heartbeat:         sourceHealthHB,
 			FlowControl:       true,
 			Direct:            true,
+			Sourcing:          true,
 			InactiveThreshold: sourceHealthCheckInterval,
+			Metadata:          metadata,
 		},
 	}
 
@@ -3357,7 +3538,6 @@ func (mset *stream) setupMirrorConsumer() error {
 	respCh := make(chan *JSApiConsumerCreateResponse, 1)
 	reply := infoReplySubject()
 	crSub, err := mset.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-		mset.unsubscribe(sub)
 		_, msg := c.msgParts(rmsg)
 
 		var ccr JSApiConsumerCreateResponse
@@ -3377,28 +3557,40 @@ func (mset *stream) setupMirrorConsumer() error {
 		return nil
 	}
 
-	var subject string
-	if req.Config.FilterSubject != _EMPTY_ {
-		req.Config.Name = fmt.Sprintf("mirror-%s", createConsumerName())
-		subject = fmt.Sprintf(JSApiConsumerCreateExT, mset.cfg.Mirror.Name, req.Config.Name, req.Config.FilterSubject)
-	} else {
-		subject = fmt.Sprintf(JSApiConsumerCreateT, mset.cfg.Mirror.Name)
+	generateSubject := func() (subject string) {
+		if durableDeliverSubject != _EMPTY_ {
+			// If we're using a pre-existing consumer, we'll send a consumer reset request instead.
+			subject = fmt.Sprintf(JSApiConsumerResetT, mset.cfg.Mirror.Name, mirror.cname)
+		} else if req.Config.FilterSubject != _EMPTY_ {
+			subject = fmt.Sprintf(JSApiConsumerCreateExT, mset.cfg.Mirror.Name, req.Config.Name, req.Config.FilterSubject)
+		} else {
+			subject = fmt.Sprintf(JSApiConsumerCreateT, mset.cfg.Mirror.Name)
+		}
+		if ext != nil {
+			subject = strings.Replace(subject, JSApiPrefix, ext.ApiPrefix, 1)
+			subject = strings.ReplaceAll(subject, "..", ".")
+		}
+		return subject
 	}
-	if ext != nil {
-		subject = strings.Replace(subject, JSApiPrefix, ext.ApiPrefix, 1)
-		subject = strings.ReplaceAll(subject, "..", ".")
-	}
-
-	// Marshal now that we are done with `req`.
-	b, _ := json.Marshal(req)
+	subject := generateSubject()
 
 	// Reset
 	mirror.msgs = nil
 	mirror.err = nil
 	mirror.sip = true
 
-	// Send the consumer create request
-	mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, nil, b, nil, 0))
+	if durableDeliverSubject != _EMPTY_ {
+		// Send the consumer reset request
+		mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, nil, nil, nil, 0))
+	} else {
+		// Marshal now that we are done with `req`.
+		b, _ := json.Marshal(req)
+
+		// Send the consumer create request
+		// Confirm the server supports API level 4, which contains durable sourcing, AckFlowControl, and consumer reset.
+		hdr := genHeader(nil, JSRequiredApiLevel, "4")
+		mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, hdr, b, nil, 0))
+	}
 
 	go func() {
 
@@ -3428,94 +3620,127 @@ func (mset *stream) setupMirrorConsumer() error {
 		mset.mu.Lock()
 		if mset.mirror == nil {
 			// Mirror config has been removed.
+			mset.unsubscribe(crSub)
 			mset.mu.Unlock()
 			return
-		} else {
-			wg := &mset.mirror.wg
-			mset.mu.Unlock()
-			wg.Wait()
 		}
+		wg := &mset.mirror.wg
+		mset.mu.Unlock()
+		wg.Wait()
 
+	SELECT:
 		select {
 		case ccr := <-respCh:
 			mset.mu.Lock()
 			// Mirror config has been removed.
 			if mset.mirror == nil {
+				mset.unsubscribe(crSub)
 				mset.mu.Unlock()
 				return
 			}
 			ready := sync.WaitGroup{}
 			mirror := mset.mirror
 			mirror.err = nil
+
 			if ccr.Error != nil || ccr.ConsumerInfo == nil {
+				// If the responding server doesn't support sourcing consumers, retry without it.
+				if req.Config.Sourcing && ccr.Error != nil &&
+					(ccr.Error.ErrCode == uint16(JSRequiredApiLevelErr) || ccr.Error.ErrCode == uint16(JSInvalidJSONErr)) {
+					// Unset for retry.
+					req.Config.Sourcing = false
+					// Specify a unique consumer name, as the other end will not know to do this.
+					req.Config.Name = fmt.Sprintf("JS_MIRROR_%s_%s", id, createConsumerName())
+					b, _ := json.Marshal(req)
+					// Regenerate subject since the previous name could've been included in it.
+					subject = generateSubject()
+					mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, nil, b, nil, 0))
+					mset.mu.Unlock()
+					goto SELECT
+				}
+				mset.unsubscribe(crSub)
 				mset.srv.Warnf("JetStream error response for create mirror consumer: %+v", ccr.Error)
 				mirror.err = ccr.Error
 				// Let's retry as soon as possible, but we are gated by sourceConsumerRetryThreshold
 				retry = true
 				mset.mu.Unlock()
 				return
+			}
+
+			// If using durable sourcing, we need the consumer to use acks based on flow control.
+			if durableDeliverSubject != _EMPTY_ && ccr.ConsumerInfo.Config.AckPolicy != AckFlowControl {
+				mset.unsubscribe(crSub)
+				mirror.err = NewJSMirrorConsumerRequiresAckFCError()
+				retry = true
+				mset.mu.Unlock()
+				return
+			}
+
+			// We can now unsubscribe.
+			mset.unsubscribe(crSub)
+
+			// Setup actual subscription to process messages from our source.
+			qname := fmt.Sprintf("[ACC:%s] stream mirror '%s' of '%s' msgs", mset.acc.Name, mset.cfg.Name, mset.cfg.Mirror.Name)
+			// Create a new queue each time
+			mirror.msgs = newIPQueue[*inMsg](mset.srv, qname)
+			msgs := mirror.msgs
+			if durableDeliverSubject != _EMPTY_ {
+				deliverSubject = durableDeliverSubject
 			} else {
-				// Setup actual subscription to process messages from our source.
-				qname := fmt.Sprintf("[ACC:%s] stream mirror '%s' of '%s' msgs", mset.acc.Name, mset.cfg.Name, mset.cfg.Mirror.Name)
-				// Create a new queue each time
-				mirror.msgs = newIPQueue[*inMsg](mset.srv, qname)
-				msgs := mirror.msgs
-				sub, err := mset.subscribeInternal(deliverSubject, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-					hdr, msg := c.msgParts(copyBytes(rmsg)) // Need to copy.
-					if len(hdr) > 0 {
-						// Remove any Nats-Expected- headers as we don't want to validate them.
-						hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Expected-")
-						// Remove any Nats-Batch- headers, batching is not supported when mirroring.
-						hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Batch-")
-					}
-					mset.queueInbound(msgs, subject, reply, hdr, msg, nil, nil)
-					mirror.last.Store(time.Now().UnixNano())
-				})
-				if err != nil {
-					mirror.err = NewJSMirrorConsumerSetupFailedError(err, Unless(err))
-					retry = true
-					mset.mu.Unlock()
-					return
+				deliverSubject = ccr.ConsumerInfo.Config.DeliverSubject
+			}
+			sub, err := mset.subscribeInternal(deliverSubject, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+				hdr, msg := c.msgParts(copyBytes(rmsg)) // Need to copy.
+				if len(hdr) > 0 {
+					// Remove any Nats-Expected- headers as we don't want to validate them.
+					hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Expected-")
+					// Remove any Nats-Batch- headers, batching is not supported when mirroring.
+					hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Batch-")
 				}
-				// Save our sub.
-				mirror.sub = sub
+				mset.queueInbound(msgs, subject, reply, hdr, msg, nil, nil)
+				mirror.last.Store(time.Now().UnixNano())
+			})
+			if err != nil {
+				mirror.err = NewJSMirrorConsumerSetupFailedError(err, Unless(err))
+				retry = true
+				mset.mu.Unlock()
+				return
+			}
+			// Save our sub.
+			mirror.sub = sub
 
-				// When an upstream stream expires messages or in general has messages that we want
-				// that are no longer available we need to adjust here.
-				var state StreamState
-				mset.store.FastState(&state)
-
-				// Check if we need to skip messages.
-				if state.LastSeq != ccr.ConsumerInfo.Delivered.Stream {
-					// Check to see if delivered is past our last and we have no msgs. This will help the
-					// case when mirroring a stream that has a very high starting sequence number.
-					if state.Msgs == 0 && ccr.ConsumerInfo.Delivered.Stream > state.LastSeq {
-						mset.store.PurgeEx(_EMPTY_, ccr.ConsumerInfo.Delivered.Stream+1, 0)
-						mset.lseq = ccr.ConsumerInfo.Delivered.Stream
-					} else {
-						mset.skipMsgs(state.LastSeq+1, ccr.ConsumerInfo.Delivered.Stream)
-					}
+			// Check if we need to skip messages.
+			// Re-capture state since the previous may be stale.
+			state = StreamState{}
+			mset.store.FastState(&state)
+			if state.LastSeq < ccr.ConsumerInfo.Delivered.Stream {
+				// Check to see if delivered is past our last and we have no msgs. This will help the
+				// case when mirroring a stream that has a very high starting sequence number.
+				if state.Msgs == 0 && ccr.ConsumerInfo.Delivered.Stream > state.LastSeq {
+					mset.store.PurgeEx(_EMPTY_, ccr.ConsumerInfo.Delivered.Stream+1, 0)
+					mset.lseq = ccr.ConsumerInfo.Delivered.Stream
+				} else {
+					mset.skipMsgs(state.LastSeq+1, ccr.ConsumerInfo.Delivered.Stream)
 				}
+			}
 
-				// Capture consumer name.
-				mirror.cname = ccr.ConsumerInfo.Name
-				mirror.dseq = 0
-				mirror.sseq = ccr.ConsumerInfo.Delivered.Stream
-				mirror.qch = make(chan struct{})
-				mirror.wg.Add(1)
-				ready.Add(1)
-				if !mset.srv.startGoRoutine(
-					func() { mset.processMirrorMsgs(mirror, &ready) },
-					pprofLabels{
-						"type":     "mirror",
-						"account":  mset.acc.Name,
-						"stream":   mset.cfg.Name,
-						"consumer": mirror.cname,
-					},
-				) {
-					mirror.wg.Done()
-					ready.Done()
-				}
+			// Capture consumer name.
+			mirror.cname = ccr.ConsumerInfo.Name
+			mirror.dseq = 0
+			mirror.sseq = max(ccr.ConsumerInfo.Delivered.Stream, state.LastSeq)
+			mirror.qch = make(chan struct{})
+			mirror.wg.Add(1)
+			ready.Add(1)
+			if !mset.srv.startGoRoutine(
+				func() { mset.processMirrorMsgs(mirror, &ready) },
+				pprofLabels{
+					"type":     "mirror",
+					"account":  mset.acc.Name,
+					"stream":   mset.cfg.Name,
+					"consumer": mirror.cname,
+				},
+			) {
+				mirror.wg.Done()
+				ready.Done()
 			}
 			mset.mu.Unlock()
 			ready.Wait()
@@ -3656,17 +3881,29 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 
 	// Determine subjects etc.
 	var deliverSubject string
+	var durableDeliverSubject string
 	ext := ssi.External
-
-	if ext != nil && ext.DeliverPrefix != _EMPTY_ {
+	if ssi.Consumer != nil {
+		durableDeliverSubject = ssi.Consumer.DeliverSubject
+		si.cname = ssi.Consumer.Name
+	} else if ext != nil && ext.DeliverPrefix != _EMPTY_ {
 		deliverSubject = strings.ReplaceAll(ext.DeliverPrefix+syncSubject(".S"), "..", ".")
 	} else {
 		deliverSubject = syncSubject("$JS.S")
 	}
 
+	id := mset.createSourcingConsumerHash(ssi, mset.cfg.Sources)
+	metadata := map[string]string{}
+	metadata["_nats.src.stream"] = mset.cfg.Name
+	metadata["_nats.src.acc"] = mset.acc.Name
+	if domain := mset.srv.getOpts().JetStreamDomain; domain != _EMPTY_ {
+		metadata["_nats.src.domain"] = domain
+	}
+
 	req := &CreateConsumerRequest{
 		Stream: si.name,
 		Config: ConsumerConfig{
+			Name:              fmt.Sprintf("JS_SRC_%s", id),
 			DeliverSubject:    deliverSubject,
 			AckPolicy:         AckNone,
 			AckWait:           22 * time.Hour,
@@ -3674,7 +3911,9 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 			Heartbeat:         sourceHealthHB,
 			FlowControl:       true,
 			Direct:            true,
+			Sourcing:          true,
 			InactiveThreshold: sourceHealthCheckInterval,
+			Metadata:          metadata,
 		},
 	}
 
@@ -3721,7 +3960,6 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 	respCh := make(chan *JSApiConsumerCreateResponse, 1)
 	reply := infoReplySubject()
 	crSub, err := mset.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-		mset.unsubscribe(sub)
 		_, msg := c.msgParts(rmsg)
 		var ccr JSApiConsumerCreateResponse
 		if err := json.Unmarshal(msg, &ccr); err != nil {
@@ -3739,35 +3977,46 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 		return
 	}
 
-	var subject string
-	if req.Config.FilterSubject != _EMPTY_ {
-		req.Config.Name = fmt.Sprintf("src-%s", createConsumerName())
-		subject = fmt.Sprintf(JSApiConsumerCreateExT, si.name, req.Config.Name, req.Config.FilterSubject)
-	} else if len(req.Config.FilterSubjects) == 1 {
-		req.Config.Name = fmt.Sprintf("src-%s", createConsumerName())
-		// It is necessary to switch to using FilterSubject here as the extended consumer
-		// create API checks for it, so as to not accidentally allow multiple filtered subjects.
-		req.Config.FilterSubject = req.Config.FilterSubjects[0]
-		req.Config.FilterSubjects = nil
-		subject = fmt.Sprintf(JSApiConsumerCreateExT, si.name, req.Config.Name, req.Config.FilterSubject)
-	} else {
-		subject = fmt.Sprintf(JSApiConsumerCreateT, si.name)
+	generateSubject := func() (subject string) {
+		if durableDeliverSubject != _EMPTY_ {
+			// If we're using a pre-existing consumer, we'll send a consumer reset request instead.
+			subject = fmt.Sprintf(JSApiConsumerResetT, si.name, si.cname)
+		} else if req.Config.FilterSubject != _EMPTY_ {
+			subject = fmt.Sprintf(JSApiConsumerCreateExT, si.name, req.Config.Name, req.Config.FilterSubject)
+		} else if len(req.Config.FilterSubjects) == 1 {
+			// It is necessary to switch to using FilterSubject here as the extended consumer
+			// create API checks for it, so as to not accidentally allow multiple filtered subjects.
+			req.Config.FilterSubject = req.Config.FilterSubjects[0]
+			req.Config.FilterSubjects = nil
+			subject = fmt.Sprintf(JSApiConsumerCreateExT, si.name, req.Config.Name, req.Config.FilterSubject)
+		} else {
+			subject = fmt.Sprintf(JSApiConsumerCreateT, si.name)
+		}
+		if ext != nil {
+			subject = strings.Replace(subject, JSApiPrefix, ext.ApiPrefix, 1)
+			subject = strings.ReplaceAll(subject, "..", ".")
+		}
+		return subject
 	}
-	if ext != nil {
-		subject = strings.Replace(subject, JSApiPrefix, ext.ApiPrefix, 1)
-		subject = strings.ReplaceAll(subject, "..", ".")
-	}
-
-	// Marshal request.
-	b, _ := json.Marshal(req)
+	subject := generateSubject()
 
 	// Reset
 	si.msgs = nil
 	si.err = nil
 	si.sip = true
 
-	// Send the consumer create request
-	mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, nil, b, nil, 0))
+	if durableDeliverSubject != _EMPTY_ {
+		// Send the consumer reset request
+		mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, nil, nil, nil, 0))
+	} else {
+		// Marshal request.
+		b, _ := json.Marshal(req)
+
+		// Send the consumer create request
+		// Confirm the server supports API level 4, which contains durable sourcing, AckFlowControl, and consumer reset.
+		hdr := genHeader(nil, JSRequiredApiLevel, "4")
+		mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, hdr, b, nil, 0))
+	}
 
 	go func() {
 
@@ -3792,13 +4041,32 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 			mset.mu.Unlock()
 		}()
 
+	SELECT:
 		select {
 		case ccr := <-respCh:
 			mset.mu.Lock()
 			// Check that it has not been removed or canceled (si.sub would be nil)
-			if si := mset.sources[iname]; si != nil {
+			if si := mset.sources[iname]; si == nil {
+				mset.unsubscribe(crSub)
+			} else {
 				si.err = nil
+
 				if ccr.Error != nil || ccr.ConsumerInfo == nil {
+					// If the responding server doesn't support sourcing consumers, retry without it.
+					if req.Config.Sourcing && ccr.Error != nil &&
+						(ccr.Error.ErrCode == uint16(JSRequiredApiLevelErr) || ccr.Error.ErrCode == uint16(JSInvalidJSONErr)) {
+						// Unset for retry.
+						req.Config.Sourcing = false
+						// Specify a unique consumer name, as the other end will not know to do this.
+						req.Config.Name = fmt.Sprintf("JS_SRC_%s_%s", id, createConsumerName())
+						b, _ := json.Marshal(req)
+						// Regenerate subject since the previous name could've been included in it.
+						subject = generateSubject()
+						mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, nil, b, nil, 0))
+						mset.mu.Unlock()
+						goto SELECT
+					}
+					mset.unsubscribe(crSub)
 					// Note: this warning can happen a few times when starting up the server when sourcing streams are
 					// defined, this is normal as the streams are re-created in no particular order and it is possible
 					// that a stream sourcing another could come up before all of its sources have been recreated.
@@ -3808,48 +4076,65 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 					retry = true
 					mset.mu.Unlock()
 					return
-				} else {
-					// Check if our shared msg queue and go routine is running or not.
-					if mset.smsgs == nil {
-						qname := fmt.Sprintf("[ACC:%s] stream sources '%s' msgs", mset.acc.Name, mset.cfg.Name)
-						mset.smsgs = newIPQueue[*inMsg](mset.srv, qname)
-						mset.srv.startGoRoutine(func() { mset.processAllSourceMsgs() },
-							pprofLabels{
-								"type":    "source",
-								"account": mset.acc.Name,
-								"stream":  mset.cfg.Name,
-							},
-						)
-					}
-
-					// Setup actual subscription to process messages from our source.
-					if si.sseq != ccr.ConsumerInfo.Delivered.Stream {
-						si.sseq = ccr.ConsumerInfo.Delivered.Stream + 1
-					}
-					// Capture consumer name.
-					si.cname = ccr.ConsumerInfo.Name
-
-					// Do not set si.sseq to seq here. si.sseq will be set in processInboundSourceMsg
-					si.dseq = 0
-					si.qch = make(chan struct{})
-					// Set the last seen as now so that we don't fail at the first check.
-					si.last.Store(time.Now().UnixNano())
-
-					msgs := mset.smsgs
-					sub, err := mset.subscribeInternal(deliverSubject, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-						hdr, msg := c.msgParts(copyBytes(rmsg)) // Need to copy.
-						mset.queueInbound(msgs, subject, reply, hdr, msg, si, nil)
-						si.last.Store(time.Now().UnixNano())
-					})
-					if err != nil {
-						si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
-						retry = true
-						mset.mu.Unlock()
-						return
-					}
-					// Save our sub.
-					si.sub = sub
 				}
+
+				// If using durable sourcing, we need the consumer to use acks based on flow control.
+				if durableDeliverSubject != _EMPTY_ && ccr.ConsumerInfo.Config.AckPolicy != AckFlowControl {
+					mset.unsubscribe(crSub)
+					si.err = NewJSSourceConsumerRequiresAckFCError()
+					retry = true
+					mset.mu.Unlock()
+					return
+				}
+
+				// We can now unsubscribe.
+				mset.unsubscribe(crSub)
+
+				// Check if our shared msg queue and go routine is running or not.
+				if mset.smsgs == nil {
+					qname := fmt.Sprintf("[ACC:%s] stream sources '%s' msgs", mset.acc.Name, mset.cfg.Name)
+					mset.smsgs = newIPQueue[*inMsg](mset.srv, qname)
+					mset.srv.startGoRoutine(func() { mset.processAllSourceMsgs() },
+						pprofLabels{
+							"type":    "source",
+							"account": mset.acc.Name,
+							"stream":  mset.cfg.Name,
+						},
+					)
+				}
+
+				// Setup actual subscription to process messages from our source.
+				if si.sseq < ccr.ConsumerInfo.Delivered.Stream {
+					si.sseq = ccr.ConsumerInfo.Delivered.Stream
+				}
+				// Capture consumer name.
+				si.cname = ccr.ConsumerInfo.Name
+
+				// Do not set si.sseq to seq here. si.sseq will be set in processInboundSourceMsg
+				si.dseq = 0
+				si.qch = make(chan struct{})
+				// Set the last seen as now so that we don't fail at the first check.
+				si.last.Store(time.Now().UnixNano())
+
+				msgs := mset.smsgs
+				if durableDeliverSubject != _EMPTY_ {
+					deliverSubject = durableDeliverSubject
+				} else {
+					deliverSubject = ccr.ConsumerInfo.Config.DeliverSubject
+				}
+				sub, err := mset.subscribeInternal(deliverSubject, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+					hdr, msg := c.msgParts(copyBytes(rmsg)) // Need to copy.
+					mset.queueInbound(msgs, subject, reply, hdr, msg, si, nil)
+					si.last.Store(time.Now().UnixNano())
+				})
+				if err != nil {
+					si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
+					retry = true
+					mset.mu.Unlock()
+					return
+				}
+				// Save our sub.
+				si.sub = sub
 			}
 			mset.mu.Unlock()
 		case <-time.After(srcConsumerWaitTime):
@@ -3953,20 +4238,39 @@ func (m *inMsg) isControlMsg() bool {
 
 // Sends a reply to a flow control request.
 // Lock should be held.
-func (mset *stream) sendFlowControlReply(reply string) {
+func (mset *stream) sendFlowControlReply(reply string, hdr []byte) {
 	if mset.isLeader() && mset.outq != nil {
-		mset.outq.sendMsg(reply, nil)
+		dseq := parseInt64(sliceHeader(JSLastConsumerSeq, hdr))
+		sseq := parseInt64(sliceHeader(JSLastStreamSeq, hdr))
+
+		// If we're responding to flow control without being delivered messages (for example after a restart),
+		// we'll only have the stream sequence.
+		if sseq > 0 {
+			if dseq < 0 {
+				dseq = 0
+			}
+			const t = "NATS/1.0\r\n%s: %d\r\n%s: %d\r\n\r\n"
+			hdr = fmt.Appendf(nil, t, JSLastConsumerSeq, dseq, JSLastStreamSeq, sseq)
+			mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
+		} else {
+			mset.outq.sendMsg(reply, nil)
+		}
 	}
 }
 
 // handleFlowControl will properly handle flow control messages for both R==1 and R>1.
 // Lock should be held.
-func (mset *stream) handleFlowControl(m *inMsg) {
+func (mset *stream) handleFlowControl(m *inMsg, dseq, sseq uint64) {
 	// If we are clustered we will send the flow control message through the replication stack.
 	if mset.isClustered() {
+		// Append the current delivery and stream sequences, to be sent after replication.
+		m.hdr = genHeader(m.hdr, JSLastConsumerSeq, strconv.FormatUint(dseq, 10))
+		m.hdr = genHeader(m.hdr, JSLastStreamSeq, strconv.FormatUint(sseq, 10))
 		mset.node.Propose(encodeStreamMsg(_EMPTY_, m.rply, m.hdr, nil, 0, 0, false))
 	} else {
-		mset.outq.sendMsg(m.rply, nil)
+		const t = "NATS/1.0\r\n%s: %d\r\n%s: %d\r\n\r\n"
+		hdr := fmt.Appendf(nil, t, JSLastConsumerSeq, dseq, JSLastStreamSeq, sseq)
+		mset.outq.send(newJSPubMsg(m.rply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
 	}
 }
 
@@ -3994,13 +4298,13 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 		var needsRetry bool
 		// Flow controls have reply subjects.
 		if m.rply != _EMPTY_ {
-			mset.handleFlowControl(m)
+			mset.handleFlowControl(m, si.dseq, si.sseq)
 		} else {
 			// For idle heartbeats make sure we did not miss anything.
-			if ldseq := parseInt64(getHeader(JSLastConsumerSeq, m.hdr)); ldseq > 0 && uint64(ldseq) != si.dseq {
+			if ldseq := parseInt64(sliceHeader(JSLastConsumerSeq, m.hdr)); ldseq > 0 && uint64(ldseq) != si.dseq {
 				needsRetry = true
 				mset.retrySourceConsumerAtSeq(si.iname, si.sseq+1)
-			} else if fcReply := getHeader(JSConsumerStalled, m.hdr); len(fcReply) > 0 {
+			} else if fcReply := sliceHeader(JSConsumerStalled, m.hdr); len(fcReply) > 0 {
 				// Other side thinks we are stalled, so send flow control reply.
 				mset.outq.sendMsg(string(fcReply), nil)
 			}
@@ -4017,7 +4321,16 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 	}
 
 	// Tracking is done here.
-	if dseq == si.dseq+1 {
+	osseq, odseq := si.sseq, si.dseq
+	if sseq <= si.sseq {
+		// Ignore older messages.
+		// If the deliver sequence matches, we only update delivered accounting.
+		if dseq == si.dseq+1 {
+			si.dseq++
+		}
+		mset.mu.Unlock()
+		return true
+	} else if dseq == si.dseq+1 {
 		si.dseq++
 		si.sseq = sseq
 	} else if dseq > si.dseq {
@@ -4093,7 +4406,9 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 				// Do not need to do a full retry that includes finding the last sequence in the stream
 				// for that source. Just re-create starting with the seq we couldn't store instead.
 				mset.mu.Lock()
-				mset.retrySourceConsumerAtSeq(iName, si.sseq)
+				si.dseq = odseq
+				si.sseq = osseq
+				mset.retrySourceConsumerAtSeq(iName, sseq)
 				mset.mu.Unlock()
 			} else {
 				// Log some warning for errors other than errLastSeqMismatch.
@@ -4781,7 +5096,6 @@ func (mset *stream) unsubscribeInternal(subject string) error {
 	return nil
 }
 
-// Lock should be held.
 func (mset *stream) unsubscribe(sub *subscription) {
 	if sub == nil || mset.closed.Load() {
 		return
@@ -7760,6 +8074,20 @@ func (mset *stream) stop(deleteFlag, advisory bool) error {
 	// Mark closed.
 	mset.closed.Store(true)
 
+	// Both flags set mean a delete where we are the stream leader.
+	// Try to clean up any consumers used for sourcing (if one wasn't provided to us).
+	if deleteFlag && advisory {
+		if mset.cfg.Mirror != nil && mset.cfg.Mirror.Consumer == nil {
+			mset.tryDeleteMirrorConsumer(mset.cfg.Mirror)
+		}
+		for _, s := range mset.cfg.Sources {
+			if s.Consumer == nil {
+				id := mset.createSourcingConsumerHash(s, mset.cfg.Sources)
+				mset.tryDeleteSourceConsumer(id, s)
+			}
+		}
+	}
+
 	// Signal to the monitor loop.
 	// Can't use qch here.
 	if mset.mqch != nil {
@@ -7939,9 +8267,11 @@ func (mset *stream) getConsumers() []*consumer {
 	return append([]*consumer(nil), mset.cList...)
 }
 
+// numLimitableConsumers returns the number of consumers that are not direct/sourcing consumers.
+// Used to limit the number of consumers for MaxConsumers limits or WQ exclusivity.
 // Lock should be held for this one.
-func (mset *stream) numPublicConsumers() int {
-	return len(mset.consumers) - mset.directs
+func (mset *stream) numLimitableConsumers() int {
+	return len(mset.consumers) - mset.sourcingConsumers
 }
 
 // This returns all consumers that are not DIRECT.
@@ -8038,8 +8368,8 @@ func (mset *stream) setConsumer(o *consumer) {
 	if len(o.subjf) > 0 {
 		mset.numFilter++
 	}
-	if o.cfg.Direct {
-		mset.directs++
+	if o.cfg.Direct || o.cfg.Sourcing {
+		mset.sourcingConsumers++
 	}
 	// Now update consumers list as well
 	mset.clsMu.Lock()
@@ -8058,8 +8388,8 @@ func (mset *stream) removeConsumer(o *consumer) {
 	if o.cfg.FilterSubject != _EMPTY_ && mset.numFilter > 0 {
 		mset.numFilter--
 	}
-	if o.cfg.Direct && mset.directs > 0 {
-		mset.directs--
+	if (o.cfg.Direct || o.cfg.Sourcing) && mset.sourcingConsumers > 0 {
+		mset.sourcingConsumers--
 	}
 	if mset.consumers != nil {
 		delete(mset.consumers, o.name)
@@ -8181,7 +8511,7 @@ func (mset *stream) Store() StreamStore {
 	return mset.store
 }
 
-// Determines if the new proposed partition is unique amongst all consumers.
+// Determines if the new proposed partition is unique amongst all public consumers.
 // Lock should be held.
 func (mset *stream) partitionUnique(name string, partitions []string) bool {
 	for _, partition := range partitions {
@@ -8191,6 +8521,11 @@ func (mset *stream) partitionUnique(name string, partitions []string) bool {
 				continue
 			}
 			o.mu.RLock()
+			// Ignore direct/sourcing consumers.
+			if o.cfg.Direct || o.cfg.Sourcing {
+				o.mu.RUnlock()
+				continue
+			}
 			if o.subjf == nil {
 				o.mu.RUnlock()
 				return false


### PR DESCRIPTION
Implements reliable stream sourcing/mirroring on WQ/Interest streams as described in this ADR: https://github.com/nats-io/nats-architecture-and-design/pull/389. Built on top of the consumer reset API: https://github.com/nats-io/nats-server/pull/7489.

The server knows when it's sourcing from a WQ/Interest stream and "upgrades" the consumer to be durable and use `AckPolicy: AckFlowControl`. Instead of acknowledging messages immediately (like with `AckNone`), messages will be acknowledged by the receiving end based on flow control, or triggered by the heartbeat. Additionally, `MaxAckPending` specifies the upper bound for pending messages, if this is reached a flow control message will also be sent, if not already, to acknowledge messages.

`AckPolicy: AckFlowControl` is special in that it only allows for infinite retries for `MaxDeliver` and has no `AckWait` or `BackOff`. Messages are meant to reliably flow from one place to the other, the heartbeat somewhat functions like `AckWait` but acknowledgements may happen either earlier or later depending on how many messages are sent, how large they are (larger means flow control happens sooner), or when `MaxAckPending` is hit.

Importantly, this durable consumer can reliably source and mirror messages from Interest and WorkQueue retention streams, without the user needing to specify this, whereas this is not fully reliable with the current ephemeral consumer approach.

Additionally, users can "bring their own consumer" to be used for mirroring/sourcing, but this is an opt-in.

Resolves https://github.com/nats-io/nats-server/issues/4109, https://github.com/nats-io/nats-server/issues/7292

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>