### PR TITLE
Add WebSocket-specific ping interval configuration option

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -5503,6 +5503,9 @@ func (c *client) processPingTimer() {
 	if c.kind == ROUTER && opts.Cluster.PingInterval > 0 {
 		pingInterval = opts.Cluster.PingInterval
 	}
+	if c.isWebsocket() && opts.Websocket.PingInterval > 0 {
+		pingInterval = opts.Websocket.PingInterval
+	}
 	pingInterval = adjustPingInterval(c.kind, pingInterval)
 	now := time.Now()
 	needRTT := c.rtt == 0 || now.Sub(c.rttStart) > DEFAULT_RTT_MEASUREMENT_INTERVAL
@@ -5584,6 +5587,9 @@ func (c *client) setPingTimer() {
 	d := opts.PingInterval
 	if c.kind == ROUTER && opts.Cluster.PingInterval > 0 {
 		d = opts.Cluster.PingInterval
+	}
+	if c.isWebsocket() && opts.Websocket.PingInterval > 0 {
+		d = opts.Websocket.PingInterval
 	}
 	d = adjustPingInterval(c.kind, d)
 	c.ping.tmr = time.AfterFunc(d, c.processPingTimer)
@@ -6618,6 +6624,9 @@ func (c *client) setFirstPingTimer() {
 
 	if c.kind == ROUTER && opts.Cluster.PingInterval > 0 {
 		d = opts.Cluster.PingInterval
+	}
+	if c.isWebsocket() && opts.Websocket.PingInterval > 0 {
+		d = opts.Websocket.PingInterval
 	}
 	if !opts.DisableShortFirstPing {
 		if c.kind != CLIENT {

--- a/server/opts.go
+++ b/server/opts.go
@@ -595,6 +595,11 @@ type WebsocketOpts struct {
 	// time needed for the TLS Handshake.
 	HandshakeTimeout time.Duration
 
+	// How often to send pings to WebSocket clients. When set to a non-zero
+	// duration, this overrides the default PingInterval for WebSocket connections.
+	// If not set or zero, the server's default PingInterval will be used.
+	PingInterval time.Duration
+
 	// Headers to be added to the upgrade response.
 	// Useful for adding custom headers like Strict-Transport-Security.
 	Headers map[string]string
@@ -1685,7 +1690,7 @@ func (o *Options) processConfigFileLine(k string, v any, errors *[]error, warnin
 	case "reconnect_error_reports":
 		o.ReconnectErrorReports = int(v.(int64))
 	case "websocket", "ws":
-		if err := parseWebsocket(tk, o, errors); err != nil {
+		if err := parseWebsocket(tk, o, errors, warnings); err != nil {
 			*errors = append(*errors, err)
 			return
 		}
@@ -5313,7 +5318,7 @@ func parseStringArray(fieldName string, tk token, lt *token, mv any, errors *[]e
 	}
 }
 
-func parseWebsocket(v any, o *Options, errors *[]error) error {
+func parseWebsocket(v any, o *Options, errors *[]error, warnings *[]error) error {
 	var lt token
 	defer convertPanicToErrorList(&lt, errors)
 
@@ -5414,6 +5419,8 @@ func parseWebsocket(v any, o *Options, errors *[]error) error {
 					o.Websocket.Headers[key] = headerValue
 				}
 			}
+		case "ping_interval":
+			o.Websocket.PingInterval = parseDuration("ping_interval", tk, mv, errors, warnings)
 		default:
 			if !tk.IsUsedVariable() {
 				err := &unknownConfigFieldErr{

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -4119,3 +4119,64 @@ func TestWriteTimeoutConfigParsing(t *testing.T) {
 		}
 	}
 }
+
+func TestWebsocketPingIntervalConfig(t *testing.T) {
+	// Test with string format (duration string)
+	confFile := createConfFile(t, []byte(`
+		websocket {
+			port: 8080
+			ping_interval: "30s"
+		}
+	`))
+	opts, err := ProcessConfigFile(confFile)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if opts.Websocket.PingInterval != 30*time.Second {
+		t.Fatalf("Expected websocket ping_interval to be 30s, got %v", opts.Websocket.PingInterval)
+	}
+
+	// Test with integer format (seconds)
+	confFile = createConfFile(t, []byte(`
+		websocket {
+			port: 8080
+			ping_interval: 45
+		}
+	`))
+	opts, err = ProcessConfigFile(confFile)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if opts.Websocket.PingInterval != 45*time.Second {
+		t.Fatalf("Expected websocket ping_interval to be 45s, got %v", opts.Websocket.PingInterval)
+	}
+
+	// Test with different duration format
+	confFile = createConfFile(t, []byte(`
+		websocket {
+			port: 8080
+			ping_interval: "2m"
+		}
+	`))
+	opts, err = ProcessConfigFile(confFile)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if opts.Websocket.PingInterval != 2*time.Minute {
+		t.Fatalf("Expected websocket ping_interval to be 2m, got %v", opts.Websocket.PingInterval)
+	}
+
+	// Test without ping_interval (should be zero/unset)
+	confFile = createConfFile(t, []byte(`
+		websocket {
+			port: 8080
+		}
+	`))
+	opts, err = ProcessConfigFile(confFile)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if opts.Websocket.PingInterval != 0 {
+		t.Fatalf("Expected websocket ping_interval to be 0 (unset), got %v", opts.Websocket.PingInterval)
+	}
+}


### PR DESCRIPTION
Adds support to set a custom ping interval specifically for WebSocket connections, independent from the default NATS client ping interval:

```
websocket {
  port: 8080
  ping_interval: "30s"
}
```

Signed-off-by: Waldemar Quevedo <wally@nats.io>
