### PR TITLE
Fix data race in isStreamHealthy

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -636,8 +636,11 @@ func (js *jetStream) isStreamHealthy(acc *Account, sa *streamAssignment) error {
 	}
 
 	msetNode := mset.raftNode()
+	mset.cfgMu.RLock()
+	replicas := mset.cfg.Replicas
+	mset.cfgMu.RUnlock()
 	switch {
-	case mset.cfg.Replicas <= 1:
+	case replicas <= 1:
 		return nil // No further checks for R=1 streams
 
 	case node == nil:


### PR DESCRIPTION
```
WARNING: DATA RACE
Write at 0x00c0000bd7c8 by goroutine 68843:
  github.com/nats-io/nats-server/v2/server.(*stream).updateWithAdvisory()
      /home/runner/work/nats-server/nats-server/server/stream.go:2494 +0x1d9e

Previous read at 0x00c0000bd7c8 by goroutine 67092:
  github.com/nats-io/nats-server/v2/server.(*jetStream).isStreamHealthy()
      /home/runner/work/nats-server/nats-server/server/jetstream_cluster.go:640 +0x2ae
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>