### PR TITLE
Log config warnings in the logs, not on stderr

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -511,6 +511,9 @@ type Options struct {
 
 	// configDigest represents the state of configuration.
 	configDigest string
+
+	// configWarnings holds warnings from config parsing to be logged once the server starts.
+	configWarnings []error
 }
 
 // WebsocketOpts are options for websocket
@@ -1027,6 +1030,9 @@ func (o *Options) processConfigFile(configFile string, m map[string]any) error {
 			}
 		}
 	}
+
+	// Store warnings in Options so they can be logged once the server starts.
+	o.configWarnings = warnings
 
 	if len(errors) > 0 || len(warnings) > 0 {
 		return &processConfigErr{
@@ -6186,8 +6192,8 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 			if cerr, ok := err.(*processConfigErr); !ok || len(cerr.Errors()) != 0 {
 				return nil, err
 			}
-			// If we get here we only have warnings and can still continue
-			fmt.Fprint(os.Stderr, err)
+			// If we get here we only have warnings; they are stored in opts.configWarnings
+			// and will be logged when the server starts.
 		} else if opts.CheckConfig {
 			// Report configuration file syntax test was successful and exit.
 			return opts, nil

--- a/server/reload.go
+++ b/server/reload.go
@@ -1174,6 +1174,12 @@ func (s *Server) ReloadOptions(newOpts *Options) error {
 		return err
 	}
 
+	// Log any warnings from config parsing.
+	for _, warn := range newOpts.configWarnings {
+		s.Warnf("Configuration warning: %v", warn)
+	}
+	newOpts.configWarnings = nil
+
 	s.recheckPinnedCerts(curOpts, newOpts)
 
 	s.mu.Lock()

--- a/server/server.go
+++ b/server/server.go
@@ -2332,6 +2332,12 @@ func (s *Server) Start() {
 		s.Noticef("Using configuration file: %s %s", opts.ConfigFile, cd)
 	}
 
+	// Log any warnings from config parsing.
+	for _, warn := range opts.configWarnings {
+		s.Warnf("Configuration warning: %v", warn)
+	}
+	opts.configWarnings = nil
+
 	hasOperators := len(opts.TrustedOperators) > 0
 	if hasOperators {
 		s.Noticef("Trusted Operators")


### PR DESCRIPTION
Currently, config parsing warnings are printed on stderr.
```
# nats-server -c test.conf  --log log.out
test.conf:9:1: invalid use of field "ping_interval": ping_interval should be converted to a duration
```

Depending on how the server is deployed(systemd, k8s, nix, etc...) and how the logs are aggregated, this stderr may be lost and will not show up where all the other nats servers logs are.

## Test plan:


This will make print the config parsing warnings using whatever logging we configured, not on stderr, where it can be never noticed.
```
# ./nats-server -c test.conf  --log log.out
# cat log.out
[95618] 2025/12/05 14:49:44.456825 [INF] Starting nats-server
[95618] 2025/12/05 14:49:44.456893 [INF]   Version:  2.14.0-dev
...
[95618] 2025/12/05 14:49:44.456932 [INF] Using configuration file: test.conf (sha256:d20faaf4b973de79fbfcc43c0c4784365473a235a04d681c8a6df05e5781ba91)
[95618] 2025/12/05 14:49:44.456941 [WRN] Configuration warning: test.conf:9:1: invalid use of field "ping_interval": ping_interval should be converted to a duration
...
[95618] 2025/12/05 14:49:44.459155 [INF] Listening for client connections on 0.0.0.0:4222
[95618] 2025/12/05 14:49:44.459963 [INF] Server is ready

```

Signed-off-by: Alex Bozhenko <alexbozhenko@gmail.com>
