### PR TITLE
[FIXED] Filestore compaction issues

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -11620,3 +11620,36 @@ func TestFileStoreSkipMsgAndCompactRequiresAppend(t *testing.T) {
 		require_NoError(t, mb.loadMsgsWithLock())
 	})
 }
+
+func TestFileStoreCompactRewritesFileWithSwap(t *testing.T) {
+	fcfg := FileStoreConfig{Cipher: NoCipher, Compression: NoCompression, StoreDir: t.TempDir()}
+	fs, err := newFileStoreWithCreated(fcfg, StreamConfig{Name: "zzz", Storage: FileStorage}, time.Now(), prf(&fcfg), nil)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	msg := make([]byte, 256*1024)
+	for range 20 {
+		_, _, err = fs.StoreMsg("foo", nil, msg, 0)
+		require_NoError(t, err)
+	}
+
+	// Compact should realize the block's data was largely removed, the file should be rewritten
+	_, err = fs.Compact(20)
+	require_NoError(t, err)
+
+	state := fs.State()
+	require_Equal(t, state.Msgs, 1)
+	require_Equal(t, state.FirstSeq, 20)
+	require_Equal(t, state.LastSeq, 20)
+
+	mb := fs.getFirstBlock()
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+	mb.clearCacheAndOffset()
+	require_NoError(t, mb.loadMsgsWithLock())
+
+	mbcache := mb.cache
+	require_NotNil(t, mbcache)
+	require_Len(t, len(mbcache.idx), 1)
+	require_Equal(t, mbcache.idx[0], 0)
+}


### PR DESCRIPTION
This PR fixes a couple issues relating to `Compact(seq)`:
1. If an (almost) empty stream would be compacted or purged to `seq=2` and the server would be hard killed after, it would not have written a tombstone to recover this sequence from.
2. A particular sequence of `SkipMsg(seq)`, `Compact(seq)`, `SkipMsg(seq+1)` would preserve the block and tombstones after the compact, but the subsequent `SkipMsg(seq+1)` on the empty block would see the server starting to overwrite block data at the head of the file. Reading that file from disk afterward would appear corrupted and log: `indexCacheBuf corrupt record state`.
3. Compaction of a block that would allow to reclaim over half of the storage size taken up by the file would overwrite the file in place. This could lose messages if the server was hard killed after the file truncation, but before it fully wrote the compacted bytes. We now write the file separately and rename it to overwrite the original file atomically.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>