### PR TITLE
Expire filestore cache on failed `cacheLookupEx` when `errNoCache`

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7789,7 +7789,10 @@ func (mb *msgBlock) cacheLookupEx(seq uint64, sm *StoreMsg, doCopy bool) (*Store
 		} else {
 			reason = "cache buf empty"
 		}
-		mb.fs.warn("Cache lookup detected no cache: %s", reason)
+		mb.fs.warn("Cache lookup for sequence %d in block %d detected no cache: %s", seq, mb.index, reason)
+		if mb.cache != nil {
+			mb.tryForceExpireCacheLocked()
+		}
 		return nil, errNoCache
 	}
 	// Check partial cache status.


### PR DESCRIPTION
If `cacheLookupEx` results in an `errNoCache` but a cache was loaded, then we should forcefully expire it. This will force the cache to be reloaded and reindexed properly on the next call.

Related: #7626

Signed-off-by: Neil Twigg <neil@nats.io>