### PR TITLE
Surface filestore errors from `loadMsgsWithLock` correctly

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -5041,12 +5041,14 @@ func TestFileStoreNumPendingLargeNumBlks(t *testing.T) {
 	}
 
 	start := time.Now()
-	total, _ := fs.NumPending(4000, "zzz", false)
+	total, _, err := fs.NumPending(4000, "zzz", false)
+	require_NoError(t, err)
 	require_LessThan(t, time.Since(start), 15*time.Millisecond)
 	require_Equal(t, total, 6001)
 
 	start = time.Now()
-	total, _ = fs.NumPending(6000, "zzz", false)
+	total, _, err = fs.NumPending(6000, "zzz", false)
+	require_NoError(t, err)
 	require_LessThan(t, time.Since(start), 25*time.Millisecond)
 	require_Equal(t, total, 4001)
 
@@ -5055,12 +5057,14 @@ func TestFileStoreNumPendingLargeNumBlks(t *testing.T) {
 	fs.RemoveMsg(9000)
 
 	start = time.Now()
-	total, _ = fs.NumPending(4000, "zzz", false)
+	total, _, err = fs.NumPending(4000, "zzz", false)
+	require_NoError(t, err)
 	require_LessThan(t, time.Since(start), 50*time.Millisecond)
 	require_Equal(t, total, 6000)
 
 	start = time.Now()
-	total, _ = fs.NumPending(6000, "zzz", false)
+	total, _, err = fs.NumPending(6000, "zzz", false)
+	require_NoError(t, err)
 	require_LessThan(t, time.Since(start), 50*time.Millisecond)
 	require_Equal(t, total, 4000)
 }
@@ -6481,7 +6485,8 @@ func TestFileStoreNumPendingLastBySubject(t *testing.T) {
 		return cloads
 	}
 
-	total, _ := fs.NumPending(0, "foo.*.*", true)
+	total, _, err := fs.NumPending(0, "foo.*.*", true)
+	require_NoError(t, err)
 	require_Equal(t, total, 1000)
 	// Make sure no blocks were loaded to calculate this as a new consumer.
 	require_Equal(t, calcCacheLoads(), 0)
@@ -6503,7 +6508,8 @@ func TestFileStoreNumPendingLastBySubject(t *testing.T) {
 	// Make sure partials work properly.
 	for _, filter := range []string{"foo.10.*", "*.22.*", "*.*.222", "foo.5.999", "*.2.*"} {
 		sseq := uint64(rand.Intn(250) + 200) // Between 200-450
-		total, _ = fs.NumPending(sseq, filter, true)
+		total, _, err = fs.NumPending(sseq, filter, true)
+		require_NoError(t, err)
 		checkResult(sseq, total, filter)
 	}
 }
@@ -7096,7 +7102,8 @@ func TestFileStoreFSSExpireNumPending(t *testing.T) {
 	nb := fs.numMsgBlocks()
 	// Now execute NumPending() such that we load lots of blocks and make sure fss do not expire.
 	start := time.Now()
-	n, _ := fs.NumPending(100_000, "foo.A.*", false)
+	n, _, err := fs.NumPending(100_000, "foo.A.*", false)
+	require_NoError(t, err)
 	elapsed := time.Since(start)
 
 	require_Equal(t, n, 50_000)
@@ -8505,7 +8512,8 @@ func TestFileStoreNumPendingMulti(t *testing.T) {
 	}
 
 	// Use new function.
-	total, _ := fs.NumPendingMulti(startSeq, filters, false)
+	total, _, err := fs.NumPendingMulti(startSeq, filters, false)
+	require_NoError(t, err)
 
 	// Check our results.
 	var checkTotal uint64

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -2335,7 +2335,9 @@ func TestJetStreamSuperClusterConsumerDeliverNewBug(t *testing.T) {
 				if state.Delivered.Consumer != 0 || state.Delivered.Stream != 100 {
 					t.Fatalf("Incorrect consumer state: consumer_seq=%d, stream_seq=%d", state.Delivered.Consumer, state.Delivered.Stream)
 				}
-				if np := o.checkNumPending(); np != 0 {
+				np, err := o.checkNumPending()
+				require_NoError(t, err)
+				if np != 0 {
 					t.Fatalf("Did not expect NumPending, got %d", np)
 				}
 			}

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -22028,7 +22028,8 @@ func TestJetStreamDirectGetBatchParallelWriteDeadlock(t *testing.T) {
 	// We'll lock the message blocks such that we can't read, but NumPending should still function.
 	fs := mset.store.(*fileStore)
 	fs.lockAllMsgBlocks()
-	total, validThrough := fs.NumPending(1, _EMPTY_, false)
+	total, validThrough, err := fs.NumPending(1, _EMPTY_, false)
+	require_NoError(t, err)
 	require_Equal(t, total, 2)
 	require_Equal(t, validThrough, 2)
 

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -690,7 +690,10 @@ func TestMemStoreNumPending(t *testing.T) {
 
 	check := func(sseq uint64, filter string) {
 		t.Helper()
-		np, lvs := ms.NumPending(sseq, filter, false)
+		np, lvs, err := ms.NumPending(sseq, filter, false)
+		if err != nil {
+			t.Fatalf("NumPending error: %v", err)
+		}
 		ss := ms.FilteredState(sseq, filter)
 		sss := sanityCheck(sseq, filter)
 		if lvs != state.LastSeq {
@@ -735,7 +738,10 @@ func TestMemStoreNumPending(t *testing.T) {
 
 	checkLastOnly := func(sseq uint64, filter string) {
 		t.Helper()
-		np, lvs := ms.NumPending(sseq, filter, true)
+		np, lvs, err := ms.NumPending(sseq, filter, true)
+		if err != nil {
+			t.Fatalf("NumPending error: %v", err)
+		}
 		ss := sanityCheckLastOnly(sseq, filter)
 		if lvs != state.LastSeq {
 			t.Fatalf("Expected NumPending to return valid through last of %d but got %d", state.LastSeq, lvs)
@@ -1112,7 +1118,8 @@ func TestMemStoreNumPendingMulti(t *testing.T) {
 	}
 
 	// Use new function.
-	total, _ := ms.NumPendingMulti(startSeq, filters, false)
+	total, _, err := ms.NumPendingMulti(startSeq, filters, false)
+	require_NoError(t, err)
 
 	// Check our results.
 	var checkTotal uint64
@@ -1143,7 +1150,8 @@ func TestMemStoreNumPendingBug(t *testing.T) {
 		ms.StoreMsg(subj, nil, nil, 0)
 		ms.StoreMsg(subj, nil, nil, 0)
 	}
-	total, _ := ms.NumPending(4, "foo.*", false)
+	total, _, err := ms.NumPending(4, "foo.*", false)
+	require_NoError(t, err)
 
 	var checkTotal uint64
 	var smv StoreMsg
@@ -1386,7 +1394,8 @@ func Benchmark_MemStoreNumPendingWithLargeInteriorDeletesScan(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		total, _ := ms.NumPending(600_000, "foo.*.baz", false)
+		total, _, err := ms.NumPending(600_000, "foo.*.baz", false)
+		require_NoError(b, err)
 		if total != 1 {
 			b.Fatalf("Expected total of 2 got %d", total)
 		}
@@ -1413,7 +1422,8 @@ func Benchmark_MemStoreNumPendingWithLargeInteriorDeletesExclude(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		total, _ := ms.NumPending(400_000, "foo.*.baz", false)
+		total, _, err := ms.NumPending(400_000, "foo.*.baz", false)
+		require_NoError(b, err)
 		if total != 1 {
 			b.Fatalf("Expected total of 2 got %d", total)
 		}

--- a/server/norace_1_test.go
+++ b/server/norace_1_test.go
@@ -7612,7 +7612,8 @@ func TestNoRaceFileStoreNumPending(t *testing.T) {
 
 	check := func(sseq uint64, filter string) {
 		t.Helper()
-		np, lvs := fs.NumPending(sseq, filter, false)
+		np, lvs, err := fs.NumPending(sseq, filter, false)
+		require_NoError(t, err)
 		ss := fs.FilteredState(sseq, filter)
 		sss := sanityCheck(sseq, filter)
 		if lvs != state.LastSeq {
@@ -7657,7 +7658,8 @@ func TestNoRaceFileStoreNumPending(t *testing.T) {
 
 	checkLastOnly := func(sseq uint64, filter string) {
 		t.Helper()
-		np, lvs := fs.NumPending(sseq, filter, true)
+		np, lvs, err := fs.NumPending(sseq, filter, true)
+		require_NoError(t, err)
 		ss := sanityCheckLastOnly(sseq, filter)
 		if lvs != state.LastSeq {
 			t.Fatalf("Expected NumPending to return valid through last of %d but got %d", state.LastSeq, lvs)

--- a/server/store.go
+++ b/server/store.go
@@ -113,8 +113,8 @@ type StreamStore interface {
 	AllLastSeqs() ([]uint64, error)
 	MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed int) ([]uint64, error)
 	SubjectForSeq(seq uint64) (string, error)
-	NumPending(sseq uint64, filter string, lastPerSubject bool) (total, validThrough uint64)
-	NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPerSubject bool) (total, validThrough uint64)
+	NumPending(sseq uint64, filter string, lastPerSubject bool) (total, validThrough uint64, err error)
+	NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPerSubject bool) (total, validThrough uint64, err error)
 	State() StreamState
 	FastState(*StreamState)
 	EncodedStreamState(failed uint64) (enc []byte, err error)

--- a/server/stream.go
+++ b/server/stream.go
@@ -5268,7 +5268,10 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 	} else {
 		// This is a batch request, capture initial numPending.
 		isBatchRequest = true
-		np, validThrough = store.NumPending(seq, req.NextFor, false)
+		var err error
+		if np, validThrough, err = store.NumPending(seq, req.NextFor, false); err != nil {
+			return
+		}
 	}
 
 	// Grab MaxBytes
@@ -5361,7 +5364,10 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 	if isBatchRequest {
 		// Update if the stream's last sequence has moved past our validThrough.
 		if mset.lseq > validThrough {
-			np, _ = store.NumPending(seq, req.NextFor, false)
+			var err error
+			if np, _, err = store.NumPending(seq, req.NextFor, false); err != nil {
+				return
+			}
 		}
 		hdr := fmt.Appendf(nil, eob, np, lseq)
 		mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))


### PR DESCRIPTION
Related: #7629

Signed-off-by: Neil Twigg <neil@nats.io>