### PR TITLE
[FIXED] Filestore idx mismatch & 'no idx present' errors

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5440,8 +5440,11 @@ func (mb *msgBlock) compactWithFloor(floor uint64, fsDmap *avl.SequenceSet) erro
 
 	var le = binary.LittleEndian
 	var firstSet bool
+	var last uint64
+	var msgs uint64
 
 	fseq := atomic.LoadUint64(&mb.first.seq)
+	lseq := atomic.LoadUint64(&mb.last.seq)
 	isDeleted := func(seq uint64) bool {
 		return seq == 0 || seq&ebit != 0 || mb.dmap.Exists(seq) || seq < fseq
 	}
@@ -5461,6 +5464,7 @@ func (mb *msgBlock) compactWithFloor(floor uint64, fsDmap *avl.SequenceSet) erro
 		}
 		// Only need to process non-deleted messages.
 		seq := le.Uint64(hdr[4:])
+		ts := int64(le.Uint64(hdr[12:]))
 
 		if !isDeleted(seq) {
 			// Check for tombstones.
@@ -5476,10 +5480,16 @@ func (mb *msgBlock) compactWithFloor(floor uint64, fsDmap *avl.SequenceSet) erro
 				}
 			} else {
 				// Normal message here.
+				msgs++
 				nbuf = append(nbuf, buf[index:index+rl]...)
 				if !firstSet {
 					firstSet = true
 					atomic.StoreUint64(&mb.first.seq, seq)
+				}
+				if seq >= last {
+					last = seq
+					atomic.StoreUint64(&mb.last.seq, last)
+					mb.last.ts = ts
 				}
 			}
 		}
@@ -5542,6 +5552,17 @@ func (mb *msgBlock) compactWithFloor(floor uint64, fsDmap *avl.SequenceSet) erro
 	// Remove any seqs from the beginning of the blk.
 	for seq, nfseq := fseq, atomic.LoadUint64(&mb.first.seq); seq < nfseq; seq++ {
 		mb.dmap.Delete(seq)
+	}
+	// Remove any seqs from the ending of the blk.
+	for seq, nlseq := lseq, atomic.LoadUint64(&mb.last.seq); seq > nlseq; seq-- {
+		mb.dmap.Delete(seq)
+	}
+	// If the block itself has no messages anymore (could still contain tombstones though),
+	// then we need to account for that by resetting the last sequence and timestamp.
+	if msgs == 0 {
+		atomic.StoreUint64(&mb.last.seq, fseq-1)
+		mb.last.ts = 0
+		mb.dmap.Empty()
 	}
 	// Make sure we clear the cache since no longer valid.
 	mb.clearCacheAndOffset()
@@ -6607,6 +6628,14 @@ func (mb *msgBlock) writeMsgRecordLocked(rl, seq uint64, subj string, mhdr, msg 
 			mb.cache.fseq = seq
 		}
 	} else {
+		// If the block is empty, still adjust the accounting accordingly.
+		tseq := seq &^ tbit
+		if mb.msgs == 0 && tseq > atomic.LoadUint64(&mb.last.seq) {
+			atomic.StoreUint64(&mb.last.seq, tseq)
+			mb.last.ts = ts
+			atomic.StoreUint64(&mb.first.seq, tseq+1)
+			mb.first.ts = 0
+		}
 		// Make sure to account for tombstones in rbytes.
 		mb.rbytes += rl
 	}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -3257,8 +3257,8 @@ func TestFileStoreSparseCompaction(t *testing.T) {
 			tb, ub, _ := fs.Utilization()
 
 			fs.mu.RLock()
-			if len(fs.blks) == 0 {
-				t.Fatalf("No blocks?")
+			if len(fs.blks) < 2 {
+				t.Fatalf("Not enough blocks?")
 			}
 			mb := fs.blks[0]
 			fs.mu.RUnlock()
@@ -3269,7 +3269,7 @@ func TestFileStoreSparseCompaction(t *testing.T) {
 
 			fs.FastState(&ssa)
 			if !reflect.DeepEqual(ssb, ssa) {
-				t.Fatalf("States do not match; %+v vs %+v", ssb, ssa)
+				t.Fatalf("States do not match\n; %+v \nvs %+v", ssb, ssa)
 			}
 			ta, ua, _ := fs.Utilization()
 			if ub != ua {
@@ -3283,6 +3283,16 @@ func TestFileStoreSparseCompaction(t *testing.T) {
 		// Actual testing here.
 		loadMsgs(1000)
 		checkState(1000, 1, 1000)
+
+		// Create a new lmb, since we'll compact the current one and that's not allowed on lmb.
+		fs.mu.RLock()
+		blks := len(fs.blks)
+		fs.mu.RUnlock()
+		require_Len(t, blks, 1)
+		state := fs.State()
+		_, err = fs.newMsgBlockForWrite()
+		require_NoError(t, err)
+		require_NoError(t, fs.writeTombstone(state.LastSeq, state.LastTime.UnixNano()))
 
 		// Now delete a few messages.
 		deleteMsgs(1)
@@ -11237,14 +11247,13 @@ func TestFileStoreMissingDeletesAfterCompact(t *testing.T) {
 		fmb.dmap.Empty()
 		require_NoError(t, fmb.loadMsgsWithLock())
 		require_Equal(t, atomic.LoadUint64(&fmb.first.seq), 2)
-		require_Equal(t, atomic.LoadUint64(&fmb.last.seq), 6)
+		require_Equal(t, atomic.LoadUint64(&fmb.last.seq), 5)
 		require_Equal(t, fmb.msgs, 2)
-		require_Len(t, fmb.dmap.Size(), 3)
+		require_Len(t, fmb.dmap.Size(), 2)
 		require_True(t, fmb.dmap.Exists(3))
 		require_True(t, fmb.dmap.Exists(4))
-		require_True(t, fmb.dmap.Exists(6))
 
-		// Rebuilding should update the last sequence.
+		// Rebuilding should have the state remain the same.
 		_, _, err = fmb.rebuildStateLocked()
 		require_NoError(t, err)
 		require_Equal(t, atomic.LoadUint64(&fmb.first.seq), 2)
@@ -11261,18 +11270,17 @@ func TestFileStoreMissingDeletesAfterCompact(t *testing.T) {
 		fmb.dmap.Empty()
 		require_NoError(t, fmb.loadMsgsWithLock())
 		require_Equal(t, atomic.LoadUint64(&fmb.first.seq), 2)
-		require_Equal(t, atomic.LoadUint64(&fmb.last.seq), 5)
+		require_Equal(t, atomic.LoadUint64(&fmb.last.seq), 2)
 		require_Equal(t, fmb.msgs, 1)
-		require_Len(t, fmb.dmap.Size(), 3)
-		require_True(t, fmb.dmap.Exists(3))
-		require_True(t, fmb.dmap.Exists(4))
-		require_True(t, fmb.dmap.Exists(5))
+		require_Len(t, fmb.dmap.Size(), 0)
 
-		// Rebuilding should update the first/last sequences to a single message.
+		// Rebuilding should have the state remain the same.
 		_, _, err = fmb.rebuildStateLocked()
 		require_NoError(t, err)
 		require_Equal(t, atomic.LoadUint64(&fmb.first.seq), 2)
 		require_Equal(t, atomic.LoadUint64(&fmb.last.seq), 2)
+		require_Equal(t, fmb.msgs, 1)
+		require_Len(t, fmb.dmap.Size(), 0)
 	})
 }
 
@@ -11921,5 +11929,101 @@ func TestFileStoreIndexCacheBufEraseMsgMismatch(t *testing.T) {
 			return fmt.Errorf("expected state\n of %+v,\n got %+v", before, state)
 		}
 		return nil
+	})
+}
+
+func TestFileStoreCompactRestoresLastSeq(t *testing.T) {
+	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
+		fs, err := newFileStoreWithCreated(fcfg, StreamConfig{Name: "zzz", Storage: FileStorage}, time.Now(), prf(&fcfg), nil)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		var tss []int64
+		for range 4 {
+			_, ts, err := fs.StoreMsg("foo", nil, nil, 0)
+			require_NoError(t, err)
+			tss = append(tss, ts)
+		}
+
+		checkMbState := func(fseq, lseq, msgs uint64) {
+			t.Helper()
+			mb := fs.getFirstBlock()
+			mb.mu.Lock()
+			defer mb.mu.Unlock()
+
+			require_Equal(t, atomic.LoadUint64(&mb.first.seq), fseq)
+			require_Equal(t, atomic.LoadUint64(&mb.last.seq), lseq)
+			require_Equal(t, mb.first.ts, tss[fseq-1])
+			require_Equal(t, mb.last.ts, tss[lseq-1])
+			require_Equal(t, mb.msgs, msgs)
+			deletes := lseq - fseq + 1 - msgs
+			require_Equal(t, mb.dmap.Size(), int(deletes))
+		}
+		checkMbState(1, 4, 4)
+
+		_, err = fs.RemoveMsg(1)
+		require_NoError(t, err)
+		checkMbState(2, 4, 3)
+
+		_, err = fs.RemoveMsg(4)
+		require_NoError(t, err)
+		checkMbState(2, 4, 2)
+
+		mb := fs.getFirstBlock()
+		mb.mu.Lock()
+		err = mb.compactWithFloor(0, nil)
+		mb.mu.Unlock()
+		require_NoError(t, err)
+		checkMbState(2, 3, 2)
+	})
+}
+
+func TestFileStoreCompactFullyResetsFirstAndLastSeq(t *testing.T) {
+	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
+		fs, err := newFileStoreWithCreated(fcfg, StreamConfig{Name: "zzz", Storage: FileStorage}, time.Now(), prf(&fcfg), nil)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		var tss []int64
+		for range 2 {
+			_, ts, err := fs.StoreMsg("foo", nil, nil, 0)
+			require_NoError(t, err)
+			tss = append(tss, ts)
+		}
+
+		checkMbState := func(fseq, lseq, msgs uint64) {
+			t.Helper()
+			mb := fs.getFirstBlock()
+			mb.mu.Lock()
+			defer mb.mu.Unlock()
+
+			require_Equal(t, atomic.LoadUint64(&mb.first.seq), fseq)
+			require_Equal(t, mb.first.ts, tss[fseq-1])
+			if lseq == 0 {
+				require_Equal(t, atomic.LoadUint64(&mb.last.seq), fseq-1)
+				require_Equal(t, mb.last.ts, 0)
+			} else {
+				require_Equal(t, atomic.LoadUint64(&mb.last.seq), lseq)
+				require_Equal(t, mb.last.ts, tss[lseq-1])
+			}
+			require_Equal(t, mb.msgs, msgs)
+			deletes := lseq - fseq + 1 - msgs
+			require_Equal(t, mb.dmap.Size(), int(deletes))
+		}
+		checkMbState(1, 2, 2)
+
+		mb := fs.getFirstBlock()
+		// Load the cache before compacting so that the compact itself needs to (re)load it.
+		require_NoError(t, mb.loadMsgs())
+		mb.mu.Lock()
+		// Manually 'delete' the whole block contents such that a call to rebuildState and indexCacheBuf
+		// can't fix this. A call to compact needs to end with correctly resetting the first and last seq.
+		mb.dmap.Insert(1)
+		mb.dmap.Insert(2)
+		mb.msgs = 0
+		err = mb.compactWithFloor(0, nil)
+		mb.mu.Unlock()
+		require_NoError(t, err)
+		checkMbState(1, 0, 0)
 	})
 }

--- a/server/norace_2_test.go
+++ b/server/norace_2_test.go
@@ -487,7 +487,7 @@ func TestNoRaceFilestoreBinaryStreamSnapshotEncodingLargeGaps(t *testing.T) {
 	require_Equal(t, ss.FirstSeq, 1)
 	require_Equal(t, ss.LastSeq, 20_000)
 	require_Equal(t, ss.Msgs, 2)
-	require_Equal(t, len(ss.Deleted), 2)
+	require_Equal(t, len(ss.Deleted), 1)
 	require_Equal(t, ss.Deleted.NumDeleted(), 19_998)
 }
 


### PR DESCRIPTION
The `mb.cache.idx` could be mismatched with `mb.first.seq` and `mb.last.seq` leading to `no idx present` errors, since the `idx` might be empty or contain less entries than required. This is usually caused by a stale `index.db` that's still aligned with the checksum of the last block and all prior blocks exist on disk as well, but those prior blocks could have changed in state since. For example, due to compacting the blocks in the meantime, which will be the usual way this can happen.

`indexCacheBuf` now checks that the in-memory state of the message block matches with the resulting `mb.cache.idx` size and the first and last sequences it observed. If not, it will rebuild and try again as part of `mb.loadMsgsWithLock`.

Additionally, `mb.compact` would leave the `mb.last.seq` as high as it was previously, and deleted entries at the tail would be kept in `mb.dmap` even if the last sequence went down due to the compaction. `mb.compact` now moves `mb.last.seq` down as desired, removes deletes from the tail if needed, and generally keeps `mb.last.seq` up-to-date properly. This was important, since without it a mismatch would immediately be detected by `indexCacheBuf` requiring a reload.

Resolves https://github.com/nats-io/nats-server/issues/7626

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>