### PR TITLE
NRG: Fix single node election

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3396,9 +3396,9 @@ func (n *raft) runAsCandidate() {
 	n.requestVote()
 
 	// We vote for ourselves.
-	votes := map[string]struct{}{
-		n.ID(): {},
-	}
+	n.votes.push(&voteResponse{term: n.term, peer: n.ID(), granted: true})
+
+	votes := map[string]struct{}{}
 	emptyVotes := map[string]struct{}{}
 
 	for n.State() == Candidate {
@@ -4205,6 +4205,9 @@ func (n *raft) sendAppendEntryLocked(entries []*Entry, checkLeader bool) error {
 	n.sendRPC(n.asubj, n.areply, ae.buf)
 	if !shouldStore {
 		ae.returnToPool()
+	}
+	if n.csz == 1 {
+		n.tryCommit(n.pindex)
 	}
 	return nil
 }

--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -402,6 +402,9 @@ func (rg smGroup) waitOnTotal(t *testing.T, expected int64) {
 	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
 		var err error
 		for _, sm := range rg {
+			if sm.node().State() == Closed {
+				continue
+			}
 			asm := sm.(*stateAdder)
 			if total := asm.total(); total != expected {
 				err = errors.Join(err, fmt.Errorf("Adder on %v has wrong total: %d vs %d",

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -4571,3 +4571,59 @@ func TestNRGAppendEntryResurrectsLeader(t *testing.T) {
 	require_Equal(t, len(n.peers), 1)
 	require_Equal(t, n.ClusterSize(), 1)
 }
+
+func TestNRGSingleNodeElection(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	rg := c.createMemRaftGroup("TEST", 3, newStateAdder)
+
+	// Remove the cluster leader, and then again
+	for range 2 {
+		leader := rg.waitOnLeader().node()
+		require_NoError(t, leader.ProposeRemovePeer(leader.ID()))
+		checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+			if leader.State() == Leader {
+				return errors.New("Removed node is still leader")
+			}
+			return nil
+		})
+		require_False(t, leader.MembershipChangeInProgress())
+	}
+
+	// The remaining follower must be able to become leader
+	// on its own
+	newLeader := rg.waitOnLeader()
+	require_Equal(t, len(newLeader.node().Peers()), 1)
+	require_Equal(t, newLeader.node().ClusterSize(), 1)
+	require_False(t, newLeader.node().MembershipChangeInProgress())
+
+	adder := newLeader.(*stateAdder)
+	adder.proposeDelta(1)
+	adder.proposeDelta(10)
+	adder.proposeDelta(100)
+
+	rg.waitOnTotal(t, 111)
+
+	// Add two nodes back
+	rg = append(rg, c.addMemRaftNode("TEST", newStateAdder))
+	rg = append(rg, c.addMemRaftNode("TEST", newStateAdder))
+
+	checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+		if newLeader.node().ClusterSize() != 3 {
+			return errors.New("node additions still in progress")
+		}
+		return nil
+	})
+
+	checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+		if newLeader.node().MembershipChangeInProgress() {
+			return errors.New("membership still in progress")
+		}
+		return nil
+	})
+
+	rg.waitOnTotal(t, 111)
+	require_Equal(t, newLeader.node().ClusterSize(), 3)
+	require_False(t, newLeader.node().MembershipChangeInProgress())
+}


### PR DESCRIPTION
This commit fixes single node election: previously, a single node would simply store its vote, and never check if it already reached a majority. So it would never transition to the leader state.

Signed-off-by: Daniele Sciascia <daniele@nats.io>
