### PR TITLE
NRG: Removed leader may reappear in membership

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3801,8 +3801,6 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 	if isNew && ae.leader != noLeader && ae.leader == n.leader {
 		if ps := n.peers[ae.leader]; ps != nil {
 			ps.ts = time.Now()
-		} else {
-			n.peers[ae.leader] = &lps{time.Now(), 0, true}
 		}
 	}
 

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -1565,6 +1565,10 @@ func TestNRGSnapshotAndTruncateToApplied(t *testing.T) {
 	nats1 := "yrzKKRBu" // "nats-1"
 	nats0 := "S1Nunr6R" // "nats-0"
 
+	n.Lock()
+	n.addPeer(nats1)
+	n.Unlock()
+
 	// Timeline, other leader
 	aeMsg1 := encode(t, &appendEntry{leader: nats1, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
 	aeMsg2 := encode(t, &appendEntry{leader: nats1, term: 1, commit: 1, pterm: 1, pindex: 1, entries: entries})
@@ -2032,6 +2036,10 @@ func TestNRGHealthCheckWaitForCatchup(t *testing.T) {
 
 	nats0 := "S1Nunr6R" // "nats-0"
 
+	n.Lock()
+	n.addPeer(nats0)
+	n.Unlock()
+
 	// Timeline
 	aeMsg1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
 	aeMsg2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 1, entries: entries})
@@ -2090,6 +2098,10 @@ func TestNRGHealthCheckWaitForDoubleCatchup(t *testing.T) {
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 
 	nats0 := "S1Nunr6R" // "nats-0"
+
+	n.Lock()
+	n.addPeer(nats0)
+	n.Unlock()
 
 	// Timeline
 	aeMsg1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
@@ -2173,6 +2185,10 @@ func TestNRGHealthCheckWaitForPendingCommitsWhenPaused(t *testing.T) {
 
 	nats0 := "S1Nunr6R" // "nats-0"
 
+	n.Lock()
+	n.addPeer(nats0)
+	n.Unlock()
+
 	// Timeline
 	aeMsg1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
 	aeMsg2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 1, entries: entries})
@@ -2221,6 +2237,10 @@ func TestNRGAppendEntryCanEstablishQuorumAfterLeaderChange(t *testing.T) {
 	entries := []*Entry{newEntry(EntryNormal, esm)}
 
 	nats0 := "S1Nunr6R" // "nats-0"
+
+	n.Lock()
+	n.addPeer(nats0)
+	n.Unlock()
 
 	// Timeline
 	aeMsg := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
@@ -4252,6 +4272,11 @@ func TestNRGUncommittedMembershipChangeOnNewLeader(t *testing.T) {
 	nats1 := "yrzKKRBu" // "nats-1"
 	nats2 := "cnrtt3eg" // "nats-2"
 
+	n.Lock()
+	n.addPeer(nats1)
+	n.addPeer(nats2)
+	n.Unlock()
+
 	entries := []*Entry{newEntry(EntryRemovePeer, []byte(nats2))}
 	aeRemovePeer := encode(t, &appendEntry{leader: nats1, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
 
@@ -4508,4 +4533,41 @@ func TestNRGDisjointMajorities(t *testing.T) {
 
 	require_Equal(t, leader.node().ClusterSize(), 4)
 	require_Equal(t, leader.node().MembershipChangeInProgress(), true)
+}
+
+func TestNRGAppendEntryResurrectsLeader(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	S2 := "z3WIzPtj" // S-2
+
+	n.addPeer(S2)
+
+	require_Equal(t, len(n.peers), 2)
+	require_Equal(t, n.ClusterSize(), 2)
+
+	// PeerRemove S2
+	entries := []*Entry{newEntry(EntryRemovePeer, []byte(S2))}
+	aeRemovePeer := encode(t, &appendEntry{
+		leader: S2, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+	n.processAppendEntry(aeRemovePeer, n.aesub)
+
+	// Heartbeat commits the PeerRemove
+	aeHeartBeat := encode(t, &appendEntry{
+		leader: S2, term: 1, commit: 1, pterm: 1, pindex: 1, entries: nil})
+	n.processAppendEntry(aeHeartBeat, n.aesub)
+
+	require_Equal(t, len(n.peers), 1)
+	require_Equal(t, n.ClusterSize(), 1)
+
+	// If bug is present: receiving a appendEntry from the old leader
+	// will resurrect it. In practice, this has been observed with
+	// LeaderTransfer entries, but any type of entry will do...
+	aeHeartBeat2 := encode(t, &appendEntry{
+		leader: S2, term: 1, commit: 1, pterm: 1, pindex: 1, entries: nil})
+	n.processAppendEntry(aeHeartBeat2, n.aesub)
+
+	// Expect the cluster size to be unchanged
+	require_Equal(t, len(n.peers), 1)
+	require_Equal(t, n.ClusterSize(), 1)
 }


### PR DESCRIPTION
When a leader is peer-removed it will send a EntryPeerRemove followed by EntryLeaderTransfer. Normally a follower will commit EntryPeerRemove after receiving processing EntryLeaderTranfer. However, if the leader sneaks in a hearbeat in between, the heartbeat will commit the EntryPeerRemove. When EntryPeerRemove is committed, then `n.peers` will no longer contain the remove leader. However, when EntryLeaderTransfer is processed, the follower would re-create an entry for the removed leader in its `n.peers` set.

Signed-off-by: Daniele Sciascia <daniele@nats.io>