### PR TITLE
clarify --signal flag help

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,12 +38,12 @@ Server Options:
     -c, --config <file>              Configuration file
     -t                               Test configuration and exit
     -sl,--signal <command>[=<pid>]   Send a command to a running nats-server:
-                                       ldm - graceful shutdown (evicts clients gradually) (SIGUSR2)
-                                       quit - graceful shutdown (SIGINT)
-                                       term - graceful shutdown (SIGTERM)
-                                       stop - immediate termination (SIGKILL)
-                                       reload - reload configuration (SIGHUP)
-                                       reopen - reopen log files (SIGUSR1)
+                                       ldm - lame duck mode: evicts clients gradually, then shuts down gracefully (SIGUSR2)
+                                       quit - shuts down gracefully (SIGINT)
+                                       term - shuts down gracefully (SIGTERM)
+                                       stop - terminates immediately (SIGKILL)
+                                       reload - reloads server configuration (SIGHUP)
+                                       reopen - reopens log files (SIGUSR1)
                                      <pid> can be either a PID (e.g. 1) or the path to a PID file (e.g. /var/run/nats-server.pid)
         --client_advertise <string>  Client URL to advertise to other servers
         --ports_file_dir <dir>       Creates a ports file in the specified directory (<executable_name>_<pid>.ports).

--- a/main.go
+++ b/main.go
@@ -37,7 +37,13 @@ Server Options:
     -ms,--https_port <port>          Use port for https monitoring
     -c, --config <file>              Configuration file
     -t                               Test configuration and exit
-    -sl,--signal <signal>[=<pid>]    Send signal to nats-server process (ldm, stop, quit, term, reopen, reload)
+    -sl,--signal <command>[=<pid>]   Send a command to a running nats-server:
+                                       ldm - graceful shutdown (evicts clients gradually) (SIGUSR2)
+                                       quit - graceful shutdown (SIGINT)
+                                       term - graceful shutdown (SIGTERM)
+                                       stop - immediate termination (SIGKILL)
+                                       reload - reload configuration (SIGHUP)
+                                       reopen - reopen log files (SIGUSR1)
                                      <pid> can be either a PID (e.g. 1) or the path to a PID file (e.g. /var/run/nats-server.pid)
         --client_advertise <string>  Client URL to advertise to other servers
         --ports_file_dir <dir>       Creates a ports file in the specified directory (<executable_name>_<pid>.ports).


### PR DESCRIPTION
Expand the help to make it obvious what is going on for each command, to remove the need to look up it in the docs or read the code
```
    -sl,--signal <command>[=<pid>]   Send a command to a running nats-server:
                                       ldm - lame duck mode: evicts clients gradually, then shuts down gracefully (SIGUSR2)
                                       quit - shuts down gracefully (SIGINT)
                                       term - shuts down gracefully (SIGTERM)
                                       stop - terminates immediately (SIGKILL)
                                       reload - reloads server configuration (SIGHUP)
                                       reopen - reopens log files (SIGUSR1)
                                     <pid> can be either a PID (e.g. 1) or the path to a PID file (e.g. /var/run/nats-server.pid)file (e.g. /var/run/nats-server.pid)

```        

Signed-off-by: Alex Bozhenko <alexbozhenko@gmail.com>
