### PR TITLE
[FIXED] Filestore desync during stream snapshot

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5167,10 +5167,6 @@ func (fs *fileStore) removeMsg(seq uint64, secure, viaLimits, needFSLock bool) (
 		fsUnlock()
 		return false, ErrStoreClosed
 	}
-	if !viaLimits && fs.sips > 0 {
-		fsUnlock()
-		return false, ErrStoreSnapshotInProgress
-	}
 	// If in encrypted mode negate secure rewrite here.
 	if secure && fs.prf != nil {
 		secure = false
@@ -7006,8 +7002,7 @@ func (mb *msgBlock) ensureRawBytesLoaded() error {
 // Sync msg and index files as needed. This is called from a timer.
 func (fs *fileStore) syncBlocks() {
 	fs.mu.Lock()
-	// If closed or a snapshot is in progress bail.
-	if fs.closed || fs.sips > 0 {
+	if fs.closed {
 		fs.mu.Unlock()
 		return
 	}
@@ -9316,10 +9311,6 @@ func (fs *fileStore) reset() error {
 		fs.mu.Unlock()
 		return ErrStoreClosed
 	}
-	if fs.sips > 0 {
-		fs.mu.Unlock()
-		return ErrStoreSnapshotInProgress
-	}
 
 	var purged, bytes uint64
 	cb := fs.scb
@@ -9465,10 +9456,6 @@ func (fs *fileStore) Truncate(seq uint64) error {
 	if fs.closed {
 		fs.mu.Unlock()
 		return ErrStoreClosed
-	}
-	if fs.sips > 0 {
-		fs.mu.Unlock()
-		return ErrStoreSnapshotInProgress
 	}
 
 	// Any existing state file will no longer be applicable. We will force write a new one

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1934,24 +1934,21 @@ func TestFileStoreSnapshot(t *testing.T) {
 		snap = snapshot()
 		verifySnapshot(snap)
 
-		// Now check to make sure that we get the correct error when trying to delete or erase
-		// a message when a snapshot is in progress and that closing the reader releases that condition.
+		// Now check to make sure that we can still delete/erase messages.
 		sr, err := fs.Snapshot(5*time.Second, false, true)
 		if err != nil {
 			t.Fatalf("Error creating snapshot")
 		}
-		if _, err := fs.RemoveMsg(122); err != ErrStoreSnapshotInProgress {
-			t.Fatalf("Did not get the correct error on remove during snapshot: %v", err)
-		}
-		if _, err := fs.EraseMsg(122); err != ErrStoreSnapshotInProgress {
-			t.Fatalf("Did not get the correct error on remove during snapshot: %v", err)
-		}
+		_, err = fs.RemoveMsg(122)
+		require_NoError(t, err)
 
 		// Now make sure we can do these when we close the reader and release the snapshot condition.
 		sr.Reader.Close()
 		checkFor(t, time.Second, 10*time.Millisecond, func() error {
-			if _, err := fs.RemoveMsg(122); err != nil {
-				return fmt.Errorf("Got an error on remove after snapshot: %v", err)
+			fs.mu.RLock()
+			defer fs.mu.RUnlock()
+			if fs.sips != 0 {
+				return errors.New("snapshot is not finished")
 			}
 			return nil
 		})
@@ -1969,6 +1966,37 @@ func TestFileStoreSnapshot(t *testing.T) {
 		if _, err := sr.Reader.Read(buf[:]); err != io.EOF {
 			t.Fatalf("Expected read to produce an error, got none")
 		}
+	})
+}
+
+func TestFileStoreSnapshotAndSyncBlocks(t *testing.T) {
+	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
+		scfg := StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage}
+		fs, err := newFileStoreWithCreated(fcfg, scfg, time.Now(), prf(&fcfg), nil)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		fs.cancelSyncTimer()
+		fs.syncBlocks()
+
+		fs.mu.Lock()
+		if fs.syncTmr == nil {
+			fs.mu.Unlock()
+			t.Fatal("Expected sync timer to be set")
+		}
+		// Simulate a snapshot being in progress. This should not prevent us syncing blocks.
+		fs.sips++
+		fs.mu.Unlock()
+
+		fs.cancelSyncTimer()
+		fs.syncBlocks()
+
+		fs.mu.Lock()
+		if fs.syncTmr == nil {
+			fs.mu.Unlock()
+			t.Fatal("Expected sync timer to be set")
+		}
+		fs.mu.Unlock()
 	})
 }
 


### PR DESCRIPTION
Performing a stream snapshot on a replicated file-based stream could result in the stream desyncing if a message removal was performed at the same time. Additionally, if `syncBlocks` happened to run while the snapshot is in progress, it would not run again until the server is restarted.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>