### PR TITLE
[IMPROVED] Consumer interest check with large gap

### DIFF
--- a/server/norace_2_test.go
+++ b/server/norace_2_test.go
@@ -3290,7 +3290,7 @@ func TestNoRaceJetStreamClusterConsumerDeleteInterestPolicyPerf(t *testing.T) {
 		t.Fatalf("Deleting AckNone consumer took too long: %v", elapsed)
 	}
 
-	expectedStreamMsgs(499_995)
+	expectedStreamMsgs(499_950)
 
 	// Now do AckAll
 	start = time.Now()
@@ -3300,7 +3300,7 @@ func TestNoRaceJetStreamClusterConsumerDeleteInterestPolicyPerf(t *testing.T) {
 		t.Fatalf("Deleting AckAll consumer took too long: %v", elapsed)
 	}
 
-	expectedStreamMsgs(499_995)
+	expectedStreamMsgs(499_950)
 
 	// Now do AckExplicit
 	start = time.Now()


### PR DESCRIPTION
In `o.checkStateForInterestStream` we used to have a linear scan between the ack floor and the highest delivered sequence. For every message that is not pending, we'd call `o.needAck`. This is incredibly expensive when there are very large gaps, either due to deleted messages or messages that don't match the filter subjects. Now we rely on the store's `LoadNextMsg` to efficiently skip over these messages.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>