### PR TITLE
[FIXED] R1 mset.lseq desync when exceeding limits

### DIFF
--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -6847,11 +6847,16 @@ func TestJetStreamClusterSDMMaxAgeProposeExpiryShortRetry(t *testing.T) {
 			mset, err := acc.lookupStream("TEST")
 			require_NoError(t, err)
 
+			// Manually store a message with a timestamp far in the past.
 			if fs, ok := mset.store.(*fileStore); ok {
 				require_NoError(t, fs.StoreRawMsg("foo", nil, nil, 1, 1, 0, false))
 			} else if ms, ok := mset.store.(*memStore); ok {
 				require_NoError(t, ms.StoreRawMsg("foo", nil, nil, 1, 1, 0, false))
 			}
+			// We'll also need to manually adjust the upper-layer last sequence.
+			mset.mu.Lock()
+			mset.lseq = 1
+			mset.mu.Unlock()
 
 			cfg.MaxAge = time.Hour
 			_, err = jsStreamUpdate(t, nc, cfg)

--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -719,8 +719,17 @@ func TestJetStreamJWTClusteredDeleteTierWithStreamAndMove(t *testing.T) {
 	_, err = js.AddStream(cfg)
 	require_NoError(t, err)
 
+	sl := c.streamLeader(aExpPub, "testR1-1")
+	require_NotNil(t, sl)
+	acc, err := sl.lookupAccount(aExpPub)
+	require_NoError(t, err)
+	mset, err := acc.lookupStream("testR1-1")
+	require_NoError(t, err)
+	require_Equal(t, mset.lastSeq(), 0)
+
 	_, err = js.Publish("testR1-1", nil)
 	require_NoError(t, err)
+	require_Equal(t, mset.lastSeq(), 1)
 
 	time.Sleep(time.Second - time.Since(start)) // make sure the time stamp changes
 	delete(accClaim.Limits.JetStreamTieredLimits, "R1")
@@ -739,6 +748,7 @@ func TestJetStreamJWTClusteredDeleteTierWithStreamAndMove(t *testing.T) {
 	_, err = js.Publish("testR1-1", nil)
 	require_Error(t, err)
 	require_Equal(t, err.Error(), "nats: no JetStream default or applicable tiered limit present")
+	require_Equal(t, mset.lastSeq(), 1)
 
 	cfg.Replicas = 3
 	_, err = js.UpdateStream(cfg)


### PR DESCRIPTION
`mset.lseq` is incremented for every successful call to `processJetStreamMsg` that results in storing a message. However, this wasn't fully true. An invalid TTL header or (more commonly) exceeding resource limits would see `mset.lseq` pre-incremented and not reset after an error. Normally this would not result in an error, but the stream can't scale up cleanly when in this state, resulting in `ErrSequenceMismatch`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>