### PR TITLE
NRG: Decouple Raft transport layer

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8318,7 +8318,7 @@ func TestJetStreamClusterDontEncodeConsumerStateInMetaSnapshot(t *testing.T) {
 	meta.RLock()
 	papplied := meta.papplied
 	meta.RUnlock()
-	require_NoError(t, meta.ProposeAddPeer(meta.ID()))
+	require_NoError(t, meta.ProposeRemovePeer(strings.Repeat("x", idLen)))
 	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
 		meta.RLock()
 		defer meta.RUnlock()
@@ -8415,7 +8415,7 @@ func TestJetStreamClusterMetaSnapshotPreservesConsumersOnStreamUpdate(t *testing
 		meta.RLock()
 		papplied := meta.papplied
 		meta.RUnlock()
-		require_NoError(t, meta.ProposeAddPeer(meta.ID()))
+		require_NoError(t, meta.ProposeRemovePeer(strings.Repeat("x", idLen)))
 		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
 			meta.RLock()
 			defer meta.RUnlock()

--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -1810,7 +1810,7 @@ func TestJetStreamJWTClusterAccountNRG(t *testing.T) {
 			// in-account or not.
 			for _, rg := range raftNodes {
 				rg.Lock()
-				rgAcc := rg.acc
+				rgAcc := rg.t.Account()
 				rg.Unlock()
 				switch state {
 				case "system":
@@ -1911,7 +1911,7 @@ func TestJetStreamJWTClusterAccountNRGPersistsAfterRestart(t *testing.T) {
 
 		for _, rg := range raftNodes {
 			rg.Lock()
-			rgAcc := rg.acc
+			rgAcc := rg.t.Account()
 			rg.Unlock()
 			require_Equal(t, rgAcc.Name, aExpPub)
 			require_Equal(t, rza[rg.group].SystemAcc, false)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -4251,8 +4251,10 @@ func (s *Server) Raftz(opts *RaftzOptions) *RaftzStatus {
 			}
 			peer := RaftzGroupPeer{
 				Name:                s.serverNameForNode(id),
-				Known:               p.kp,
 				LastReplicatedIndex: p.li,
+				// The Raft layer no longer distinguishes between
+				// 'known' and 'unknown' peers.
+				Known: true,
 			}
 			if !p.ts.IsZero() {
 				peer.LastSeen = time.Since(p.ts).String()

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -4236,7 +4236,7 @@ func (s *Server) Raftz(opts *RaftzOptions) *RaftzStatus {
 			PTerm:         n.pterm,
 			PIndex:        n.pindex,
 			SystemAcc:     n.IsSystemAccount(),
-			TrafficAcc:    n.acc.GetName(),
+			TrafficAcc:    n.t.Account().GetName(),
 			IPQPropLen:    n.prop.len(),
 			IPQEntryLen:   n.entry.len(),
 			IPQRespLen:    n.resp.len(),

--- a/server/raft.go
+++ b/server/raft.go
@@ -273,7 +273,6 @@ type catchupState struct {
 type lps struct {
 	ts time.Time // Last timestamp
 	li uint64    // Last index replicated
-	kp bool      // Known peer
 }
 
 const (
@@ -995,6 +994,10 @@ func (n *raft) ProposeAddPeer(peer string) error {
 	if werr := n.werr; werr != nil {
 		n.RUnlock()
 		return werr
+	}
+	if _, ok := n.peers[peer]; ok {
+		n.RUnlock()
+		return nil
 	}
 	if n.membChangeIndex > 0 {
 		n.RUnlock()
@@ -2918,19 +2921,14 @@ func (n *raft) addPeer(peer string) {
 		delete(n.removed, peer)
 	}
 
-	if lp, ok := n.peers[peer]; !ok {
+	if _, ok := n.peers[peer]; !ok {
 		// We are not tracking this one automatically so we need
 		// to bump cluster size.
-		n.peers[peer] = &lps{time.Time{}, 0, true}
-	} else {
-		// Mark as added.
-		lp.kp = true
+		n.peers[peer] = &lps{time.Time{}, 0}
 	}
 
 	// Adjust cluster size and quorum if needed.
 	n.adjustClusterSizeAndQuorum()
-	// Write out our new state.
-	n.writePeerState(&peerState{n.peerNames(), n.csz, n.extSt})
 }
 
 // Remove the peer with the given id from our membership,
@@ -2944,7 +2942,50 @@ func (n *raft) removePeer(peer string) {
 	if _, ok := n.peers[peer]; ok {
 		delete(n.peers, peer)
 		n.adjustClusterSizeAndQuorum()
-		n.writePeerState(&peerState{n.peerNames(), n.csz, n.extSt})
+	}
+}
+
+// loadPendingMembershipChange returns a copy of the pending
+// uncommitted membership change tracked in membChangeIndex.
+// Lock should be held.
+func (n *raft) loadPendingMembershipChange() *Entry {
+	if n.membChangeIndex == 0 {
+		return nil
+	}
+
+	ae, err := n.loadEntry(n.membChangeIndex)
+	if ae == nil {
+		n.error("Could not load pending membership change entry: %v", err)
+		return nil
+	}
+	defer ae.returnToPool()
+
+	if len(ae.entries) != 1 || !ae.entries[0].ChangesMembership() {
+		n.error("Did not find a membership change entry at index %v", n.membChangeIndex)
+		return nil
+	}
+
+	e := ae.entries[0]
+	return &Entry{Type: e.Type, Data: copyBytes(e.Data)}
+}
+
+// undoMembershipChange will undo the effects of the given membership change entry.
+// Lock should be held.
+func (n *raft) undoMembershipChange(e *Entry) {
+	if e == nil {
+		return
+	}
+
+	peer := string(e.Data)
+	switch e.Type {
+	case EntryAddPeer:
+		// We could call removePeer, but that
+		// would add `peer` in the removed set,
+		// which could prevent future additions.
+		delete(n.peers, peer)
+		n.adjustClusterSizeAndQuorum()
+	case EntryRemovePeer:
+		n.addPeer(peer)
 	}
 }
 
@@ -3181,13 +3222,7 @@ func (n *raft) runCatchup(ar *appendEntryResponse, indexUpdatesQ *ipQueue[uint64
 		if len(n.progress) == 0 {
 			n.progress = nil
 		}
-		// Check if this is a new peer and if so go ahead and propose adding them.
-		_, exists := n.peers[peer]
 		n.Unlock()
-		if !exists {
-			n.debug("Catchup done for %q, will add into peers", peer)
-			n.ProposeAddPeer(peer)
-		}
 		indexUpdatesQ.unregister()
 	}()
 
@@ -3451,44 +3486,24 @@ func (n *raft) applyCommit(index uint64) error {
 					data:      e.Data,
 				})
 			}
-		case EntryPeerState:
-			if n.State() != Leader {
-				if ps, err := decodePeerState(e.Data); err == nil {
-					n.processPeerState(ps)
-				}
-			}
 		case EntryAddPeer:
-			newPeer := string(e.Data)
-			n.debug("Added peer %q", newPeer)
-
-			// Store our peer in our global peer map for all peers.
-			peers.LoadOrStore(newPeer, newPeer)
-
-			n.addPeer(newPeer)
-
 			// We pass these up as well.
 			committed = append(committed, e)
 
 			// We are done with this membership change
 			n.membChangeIndex = 0
-
+			n.writePeerState(&peerState{n.peerNames(), n.csz, n.extSt})
 		case EntryRemovePeer:
-			peer := string(e.Data)
-			n.debug("Removing peer %q", peer)
-
-			n.removePeer(peer)
-
-			// Remove from string intern map.
-			peers.Delete(peer)
-
 			// We pass these up as well.
 			committed = append(committed, e)
 
 			// We are done with this membership change
 			n.membChangeIndex = 0
+			n.writePeerState(&peerState{n.peerNames(), n.csz, n.extSt})
 
 			// If this is us and we are the leader signal the caller
 			// to attempt to stepdown.
+			peer := string(e.Data)
 			if peer == n.id && n.State() == Leader {
 				return errNodeRemoved
 			}
@@ -3575,25 +3590,20 @@ func (n *raft) trackResponse(ar *appendEntryResponse) bool {
 // Used to adjust cluster size and peer count based on added official peers.
 // lock should be held.
 func (n *raft) adjustClusterSizeAndQuorum() {
-	pcsz, ncsz := n.csz, 0
-	for _, peer := range n.peers {
-		if peer.kp {
-			ncsz++
-		}
-	}
-	n.csz = ncsz
+	pcsz := n.csz
+	n.csz = len(n.peers)
 	n.qn = n.csz/2 + 1
 
-	if ncsz > pcsz {
-		n.debug("Expanding our clustersize: %d -> %d", pcsz, ncsz)
+	if n.csz > pcsz {
+		n.debug("Expanding our clustersize: %d -> %d", pcsz, n.csz)
 		n.lsut = time.Now()
-	} else if ncsz < pcsz {
-		n.debug("Decreasing our clustersize: %d -> %d", pcsz, ncsz)
+	} else if n.csz < pcsz {
+		n.debug("Decreasing our clustersize: %d -> %d", pcsz, n.csz)
 		if n.State() == Leader {
 			go n.sendHeartbeat()
 		}
 	}
-	if ncsz != pcsz {
+	if n.csz != pcsz {
 		n.recreateInternalSubsLocked()
 	}
 }
@@ -3611,7 +3621,7 @@ func (n *raft) trackPeer(peer string) error {
 		}
 	}
 	if n.State() == Leader {
-		if lp, ok := n.peers[peer]; !ok || !lp.kp {
+		if _, ok := n.peers[peer]; !ok {
 			// Check if this peer had been removed previously.
 			needPeerAdd = !isRemoved
 		}
@@ -3820,6 +3830,12 @@ func (n *raft) truncateWAL(term, index uint64) {
 		})
 	}
 
+	// Check if we are truncating an uncommitted membership change.
+	var membChangeEntry *Entry
+	if n.membChangeIndex > 0 && n.membChangeIndex > index {
+		membChangeEntry = n.loadPendingMembershipChange()
+	}
+
 	defer func() {
 		// Check to see if we invalidated any snapshots that might have held state
 		// from the entries we are truncating.
@@ -3850,9 +3866,8 @@ func (n *raft) truncateWAL(term, index uint64) {
 	}
 	// Set after we know we have truncated properly.
 	n.pterm, n.pindex = term, index
-
-	// Check if we're truncating an uncommitted membership change.
 	if n.membChangeIndex > 0 && n.membChangeIndex > index {
+		n.undoMembershipChange(membChangeEntry)
 		n.membChangeIndex = 0
 	}
 }
@@ -4266,22 +4281,28 @@ CONTINUE:
 					}
 				}
 			}
+		case EntryPeerState:
+			if ps, err := decodePeerState(e.Data); err == nil {
+				n.processPeerState(ps)
+			}
 		case EntryAddPeer:
 			// When receiving or restoring, mark membership as changing.
 			// Set to the index where this entry was stored (pindex is now this entry's index)
 			n.membChangeIndex = n.pindex
-			if newPeer := string(e.Data); len(newPeer) == idLen {
-				// Track directly, but wait for commit to be official
-				if _, ok := n.peers[newPeer]; !ok {
-					n.peers[newPeer] = &lps{time.Time{}, 0, false}
-				}
-				// Store our peer in our global peer map for all peers.
-				peers.LoadOrStore(newPeer, newPeer)
-			}
+			peer := string(e.Data)
+			// Store our peer in our global peer map for all peers.
+			peers.LoadOrStore(peer, peer)
+			n.addPeer(peer)
+			n.debug("Added peer %q", peer)
 		case EntryRemovePeer:
 			// When receiving or restoring, mark membership as changing.
 			// Set to the index where this entry was stored (pindex is now this entry's index)
 			n.membChangeIndex = n.pindex
+			peer := string(e.Data)
+			// Remove from string intern map.
+			peers.Delete(peer)
+			n.removePeer(peer)
+			n.debug("Removed peer %q", peer)
 		}
 	}
 
@@ -4347,10 +4368,9 @@ func (n *raft) processPeerState(ps *peerState) {
 	n.peers = make(map[string]*lps)
 	for _, peer := range ps.knownPeers {
 		if lp := old[peer]; lp != nil {
-			lp.kp = true
 			n.peers[peer] = lp
 		} else {
-			n.peers[peer] = &lps{time.Time{}, 0, true}
+			n.peers[peer] = &lps{time.Time{}, 0}
 		}
 	}
 	n.debug("Update peers from leader to %+v", n.peers)
@@ -4594,10 +4614,8 @@ func decodePeerState(buf []byte) (*peerState, error) {
 // Lock should be held.
 func (n *raft) peerNames() []string {
 	var peers []string
-	for name, peer := range n.peers {
-		if peer.kp {
-			peers = append(peers, name)
-		}
+	for name := range n.peers {
+		peers = append(peers, name)
 	}
 	return peers
 }

--- a/server/raft.go
+++ b/server/raft.go
@@ -154,7 +154,6 @@ type raft struct {
 
 	created time.Time      // Time that the group was created
 	accName string         // Account name of the asset this raft group is for
-	acc     *Account       // Account that NRG traffic will be sent/received in
 	group   string         // Raft group
 	sd      string         // Store directory
 	id      string         // Node ID
@@ -201,7 +200,6 @@ type raft struct {
 	vote   string // Our current vote state
 
 	s  *Server    // Reference to top-level server
-	c  *client    // Internal client for subscriptions
 	js *jetStream // JetStream, if running, to see if we are out of resources
 
 	hasleader atomic.Bool // Is there a group leader right now?
@@ -220,7 +218,7 @@ type raft struct {
 	asubj  string // Append entries subject
 	areply string // Append entries responses subject
 
-	sq    *sendq        // Send queue for outbound RPC messages
+	t     raftTransport // Transport that handles Raft messaging
 	aesub *subscription // Subscription for handleAppendEntry callbacks
 
 	wtv []byte // Term and vote to be written
@@ -318,6 +316,8 @@ type RaftConfig struct {
 	// We need to protect against losing state due to the new peers starting with an empty log.
 	// Therefore, these empty servers can't try to become leader until they at least have _some_ state.
 	ScaleUp bool
+
+	Transport raftTransportFactory
 }
 
 var (
@@ -461,6 +461,12 @@ func (s *Server) initRaftNode(accName string, cfg *RaftConfig, labels pprofLabel
 		leadc:    make(chan bool, 32),
 		observer: cfg.Observer,
 	}
+
+	factory := cfg.Transport
+	if factory == nil {
+		factory = defaultRaftTransport
+	}
+	n.t = factory(s, n)
 
 	// Setup our internal subscriptions for proposals, votes and append entries.
 	// If we fail to do this for some reason then this is fatal — we cannot
@@ -656,7 +662,7 @@ func (n *raft) IsSystemAccount() bool {
 func (n *raft) GetTrafficAccountName() string {
 	n.RLock()
 	defer n.RUnlock()
-	return n.acc.GetName()
+	return n.t.Account().GetName()
 }
 
 func (n *raft) RecreateInternalSubs() error {
@@ -706,7 +712,7 @@ func (n *raft) recreateInternalSubsLocked() error {
 			}
 		}
 	}
-	if n.aesub != nil && n.acc == nrgAcc {
+	if n.aesub != nil && n.t.Account() == nrgAcc {
 		// Subscriptions already exist and the account NRG state
 		// hasn't changed.
 		return nil
@@ -717,33 +723,11 @@ func (n *raft) recreateInternalSubsLocked() error {
 	// the next step...
 	n.cancelCatchup()
 
-	// If we have an existing client then tear down any existing
-	// subscriptions and close the internal client.
-	if c := n.c; c != nil {
-		c.mu.Lock()
-		subs := make([]*subscription, 0, len(c.subs))
-		for _, sub := range c.subs {
-			subs = append(subs, sub)
-		}
-		c.mu.Unlock()
-		for _, sub := range subs {
-			n.unsubscribe(sub)
-		}
-		c.closeConnection(InternalClient)
-	}
-
-	if n.acc != nrgAcc {
+	if n.t.Account() != nrgAcc {
 		n.debug("Subscribing in '%s'", nrgAcc.GetName())
 	}
 
-	c := n.s.createInternalSystemClient()
-	c.registerWithAccount(nrgAcc)
-	if nrgAcc.sq == nil {
-		nrgAcc.sq = n.s.newSendQ(nrgAcc)
-	}
-	n.c = c
-	n.sq = nrgAcc.sq
-	n.acc = nrgAcc
+	n.t.Reset(nrgAcc)
 
 	// Recreate any internal subscriptions for voting, append
 	// entries etc in the new account.
@@ -2254,17 +2238,12 @@ func (n *raft) newInbox() string {
 // Our internal subscribe.
 // Lock should be held.
 func (n *raft) subscribe(subject string, cb msgHandler) (*subscription, error) {
-	if n.c == nil {
-		return nil, errNoInternalClient
-	}
-	return n.s.systemSubscribe(subject, _EMPTY_, false, n.c, cb)
+	return n.t.Subscribe(subject, cb)
 }
 
 // Lock should be held.
 func (n *raft) unsubscribe(sub *subscription) {
-	if n.c != nil && sub != nil {
-		n.c.processUnsub(sub.sid)
-	}
+	n.t.Unsubscribe(sub)
 }
 
 // Lock should be held.
@@ -2389,19 +2368,7 @@ runner:
 	n.Lock()
 	defer n.Unlock()
 
-	if c := n.c; c != nil {
-		var subs []*subscription
-		c.mu.Lock()
-		for _, sub := range c.subs {
-			subs = append(subs, sub)
-		}
-		c.mu.Unlock()
-		for _, sub := range subs {
-			n.unsubscribe(sub)
-		}
-		c.closeConnection(InternalClient)
-		n.c = nil
-	}
+	n.t.Close()
 
 	// Unregistering ipQueues do not prevent them from push/pop
 	// just will remove them from the central monitoring map
@@ -4997,15 +4964,11 @@ func (n *raft) requestVote() {
 }
 
 func (n *raft) sendRPC(subject, reply string, msg []byte) {
-	if n.sq != nil {
-		n.sq.send(subject, reply, nil, msg)
-	}
+	n.t.Publish(subject, reply, msg)
 }
 
 func (n *raft) sendReply(subject string, msg []byte) {
-	if n.sq != nil {
-		n.sq.send(subject, _EMPTY_, nil, msg)
-	}
+	n.t.Publish(subject, _EMPTY_, msg)
 }
 
 func (n *raft) wonElection(votes int) bool {

--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -57,7 +57,7 @@ func (sg smGroup) leader() stateMachine {
 	return nil
 }
 
-func (sg smGroup) followers() []stateMachine {
+func (sg smGroup) followers() smGroup {
 	var f []stateMachine
 	for _, sm := range sg {
 		if sm.node().Leader() {

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -3897,9 +3897,6 @@ func TestNRGQuorumAfterLeaderStepdown(t *testing.T) {
 	require_NoError(t, n.trackPeer(nats1))
 	require_True(t, n.Quorum())
 	require_Len(t, len(n.peers), 3)
-	for _, ps := range n.peers {
-		ps.kp = true
-	}
 
 	// If we hand off leadership to another server, we should
 	// still be reporting we have quorum.
@@ -4494,6 +4491,41 @@ func TestNRGUncommittedMembershipChangeGetsTruncated(t *testing.T) {
 	require_Equal(t, n.membChangeIndex, 0)
 }
 
+func TestNRGUncommittedPeerRemovalGetsRolledBackOnTruncate(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	nats1 := "yrzKKRBu" // "nats-1"
+	nats2 := "cnrtt3eg" // "nats-2"
+
+	n.Lock()
+	n.addPeer(nats1)
+	n.addPeer(nats2)
+	initialClusterSize := n.csz
+	initialQuorum := n.qn
+	initialPeers := len(n.peers)
+	n.Unlock()
+
+	entries := []*Entry{newEntry(EntryRemovePeer, []byte(nats2))}
+	aeRemovePeer := encode(t, &appendEntry{leader: nats1, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+
+	n.processAppendEntry(aeRemovePeer, n.aesub)
+	require_True(t, n.MembershipChangeInProgress())
+	require_Equal(t, n.ClusterSize(), initialClusterSize-1)
+	require_Equal(t, n.quorumNeeded(), initialQuorum)
+	n.RLock()
+	require_Equal(t, len(n.peers), initialPeers-1)
+	n.RUnlock()
+
+	n.truncateWAL(n.pterm, n.pindex-1)
+	require_False(t, n.MembershipChangeInProgress())
+	require_Equal(t, n.ClusterSize(), initialClusterSize)
+	require_Equal(t, n.quorumNeeded(), initialQuorum)
+	n.RLock()
+	require_Equal(t, len(n.peers), initialPeers)
+	n.RUnlock()
+}
+
 func TestNRGUncommittedMembershipChangeOnNewLeaderForwardedRemovePeerProposal(t *testing.T) {
 	n, cleanup := initSingleMemRaftNode(t)
 	defer cleanup()
@@ -4764,14 +4796,14 @@ func TestNRGAddPeers(t *testing.T) {
 		rg = append(rg, c.addMemRaftNode("TEST", newStateAdder))
 	}
 
-	checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
-		if leader.node().ClusterSize() != 9 {
-			return errors.New("node additions still in progress")
-		}
-		return nil
-	})
-
-	require_Equal(t, leader.node().ClusterSize(), 9)
+	for _, n := range rg {
+		checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+			if n.node().ClusterSize() != 9 {
+				return errors.New("node additions still in progress")
+			}
+			return nil
+		})
+	}
 }
 
 func TestNRGDisjointMajorities(t *testing.T) {
@@ -5728,4 +5760,188 @@ func TestNRGPartitionedPeerRemove(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+func TestNRGPeerAddAndPartitionLeader(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	hub, rtf, rg := c.createMockMemRaftGroup("MOCK", 3, newStateAdder)
+
+	leader := rg.waitOnLeader()
+	followers := rg.followers()
+
+	// When the leader sends a EntryAddPeer, isolate it from
+	// the rest of the cluster.
+	hub.setAfterMsgHook(func(subject, reply string, msg []byte) {
+		if subject != "$NRG.AE.MOCK" {
+			return
+		}
+		ae, _ := decodeAppendEntry(msg, nil, reply)
+		if ae == nil || len(ae.entries) != 1 {
+			return
+		}
+		if ae.leader != leader.node().ID() {
+			return
+		}
+		if ae.entries[0].Type == EntryAddPeer {
+			hub.partition(leader.node().ID(), 1)
+		}
+	})
+
+	// Add a new node and expect a new leader to be elected
+	newNode := c.addMockMemRaftNode("MOCK", rtf, newStateAdder)
+	newGroup := append(followers, newNode)
+	newLeader := newGroup.waitOnLeader()
+	require_True(t, newLeader != nil)
+
+	// If bug is present: The new leader has not yet committed the
+	// appendEntry containing EntryAddPeer. The new leader (and
+	// followers) would not update their cluster size until the
+	// EntryAddPeer was committed, allowing the following
+	// sequence of events:
+	// 1) the new leader has initially cluster size of 3
+	// 2) it sends a peerState message with cluster size 3
+	// 3) the leader commits the EntryAddPeer from the previous
+	//    leader, and adjusts its cluster size to 4.
+	// 4) the followers commit the EntryAddPeer, incrementing
+	//    their cluster size to 4. Next, the EntryPeerState is
+	//    committed and the cluster size goes back to 3.
+	// 5) At this point cluster size from the leader has diverged
+	//    from the cluster size of its followers.
+
+	// Expect all nodes to report cluster size of 4
+	for _, n := range newGroup {
+		checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+			if n.node().ClusterSize() != 4 {
+				return errors.New("node addition still in progress")
+			}
+			return nil
+		})
+	}
+
+	// Finally bring back the old leader
+	hub.healPartitions()
+	checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+		if leader.node().MembershipChangeInProgress() {
+			return errors.New("membership still in progress")
+		}
+		if leader.node().ClusterSize() != 4 {
+			return errors.New("node addition still in progress")
+		}
+		return nil
+	})
+}
+
+func TestNRGPeerRemoveAndPartitionLeader(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R5S", 5)
+	defer c.shutdown()
+
+	hub, _, rg := c.createMockMemRaftGroup("MOCK", 5, newStateAdder)
+
+	leader := rg.waitOnLeader()
+	followers := rg.followers()
+
+	// When the leader sends a EntryRemovePeer, isolate it from
+	// the rest of the cluster.
+	hub.setAfterMsgHook(func(subject, reply string, msg []byte) {
+		if subject != "$NRG.AE.MOCK" {
+			return
+		}
+		ae, _ := decodeAppendEntry(msg, nil, reply)
+		if ae == nil || len(ae.entries) != 1 {
+			return
+		}
+		if ae.leader != leader.node().ID() {
+			return
+		}
+		if ae.entries[0].Type == EntryRemovePeer {
+			hub.partition(leader.node().ID(), 1)
+		}
+	})
+
+	leader.node().ProposeRemovePeer(leader.node().ID())
+
+	// Expect followers to elect a new leader
+	newLeader := followers.waitOnLeader()
+	require_True(t, newLeader != nil)
+
+	// Expect all nodes to report cluster size 4
+	for _, n := range followers {
+		checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+			if n.node().ClusterSize() != 4 {
+				return errors.New("node addition still in progress")
+			}
+			return nil
+		})
+	}
+}
+
+func TestNRGLeaderWithoutQuorumAfterPeerAdd(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	hub, rtf, rg := c.createMockMemRaftGroup("MOCK", 3, newStateAdder)
+	defer hub.healPartitions()
+
+	leader := rg.waitOnLeader()
+	followers := rg.followers()
+
+	// Setup a after message hook to create a partition as soon as
+	// the leader publishes a EntryAddPeer. The partition will
+	// prevent committing the entry.
+	hub.setAfterMsgHook(func(subject, reply string, msg []byte) {
+		if subject != "$NRG.AE.MOCK" {
+			return
+		}
+		ae, _ := decodeAppendEntry(msg, nil, reply)
+		if ae == nil || len(ae.entries) != 1 {
+			return
+		}
+		if ae.leader != leader.node().ID() {
+			return
+		}
+
+		// After EntryAddPeer is published, partition the
+		// leader and one of the followers. This partition
+		// can't commit the entry.
+		if ae.entries[0].Type == EntryAddPeer {
+			hub.partition(leader.node().ID(), 1)
+			hub.partition(followers[0].node().ID(), 1)
+		}
+	})
+
+	newNode := c.addMockMemRaftNode("MOCK", rtf, newStateAdder)
+
+	// At some point here the cluster gets partitioned in two
+	// parts: {leader, followers[0]} and {newNode, followers[1]}.
+	// Neither side should be able to make progress.
+	newGroup := smGroup{newNode, followers[1]}
+	newLeader := newGroup.waitOnLeader()
+
+	// If the bug is present: we managed to elect a new leader,
+	// in a 4 node cluster, with only two nodes in the partition!
+	// This is because of the following sequence of events:
+	// 1) the follower has received the EntryPeerAdd
+	// 2) the leader and the other follower have partitioned away
+	// 3) the entry is uncommitted, however the follower has added
+	///   the new peer to its peer set, but won't adjust cluster
+	//    size and quorum until after the entry is committed.
+	// 4) follower becomes a canditate and will become leader with
+	//    a single vote from the new node
+	require_Equal(t, newLeader, nil)
+
+	// Check that node addition completes after healing the partition
+	hub.healPartitions()
+	rg = append(rg, newNode)
+	newLeader = rg.waitOnLeader()
+	require_True(t, newLeader != nil)
+	for _, n := range rg {
+		checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+			if n.node().ClusterSize() != 4 {
+				return errors.New("node addition still in progress")
+			}
+			return nil
+		})
+	}
 }

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -5676,3 +5676,56 @@ func TestNRGSwitchToCandidateResetsQuorumPaused(t *testing.T) {
 	require_Equal(t, n.term, 1)
 	require_False(t, n.quorumPaused)
 }
+
+func TestNRGPartitionedPeerRemove(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R2S", 2)
+	defer c.shutdown()
+
+	hub, _, rg := c.createMockMemRaftGroup("MOCK", 2, newStateAdder)
+	defer hub.healPartitions()
+
+	leader := rg.waitOnLeader().node()
+	require_Equal(t, leader.ClusterSize(), 2)
+	require_Equal(t, len(rg.followers()), 1)
+	follower := rg.followers()[0].node()
+
+	// Remove the follower while the leader is partitioned away
+	hub.partition(leader.ID(), 1)
+	leader.ProposeRemovePeer(follower.ID())
+
+	// Follower can't get elected as leader, but let's try anyway
+	follower.CampaignImmediately()
+
+	// Expect progress on the leader side
+	checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+		if leader.ClusterSize() != 1 {
+			return errors.New("node removal still in progress")
+		}
+		return nil
+	})
+
+	checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+		if leader.MembershipChangeInProgress() {
+			return errors.New("membership still in progress")
+		}
+		return nil
+	})
+
+	require_Equal(t, leader.ClusterSize(), 1)
+	require_False(t, leader.MembershipChangeInProgress())
+
+	// Follower has not changed
+	require_Equal(t, follower.State(), Follower)
+	require_Equal(t, follower.ClusterSize(), 2)
+	require_False(t, follower.MembershipChangeInProgress())
+
+	// Heal the partition, and expect the follower to get the bad news...
+	hub.heal(leader.ID())
+
+	checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+		if follower.ClusterSize() != 1 {
+			return errors.New("node removal still in progress")
+		}
+		return nil
+	})
+}

--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -1,0 +1,112 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+// raftTransport is an interface that defines the communication
+// mechanism for Raft nodes.
+type raftTransport interface {
+	// Node returns the RaftNode associated with this transport.
+	Node() RaftNode
+
+	// Account returns the NATS Account this transport operates within.
+	Account() *Account
+
+	// Reset reconfigures the transport for a new account.
+	// This involves tearing down existing client resources and
+	// setting up new ones for the provided account.
+	Reset(acc *Account)
+
+	// Close shuts down the transport, releasing any associated resources
+	// like internal clients and subscriptions.
+	Close()
+
+	// Publish sends a message to the specified subject.
+	Publish(subject string, reply string, msg []byte)
+
+	// Subscribe creates a subscription for to the specified subject.
+	Subscribe(subject string, cb msgHandler) (*subscription, error)
+
+	// Unsubscribe removes a previously established subscription.
+	Unsubscribe(sub *subscription)
+}
+
+type raftTransportFactory func(*Server, RaftNode) raftTransport
+
+// defaultTransport is the default implementation of the raftTransport interface.
+// It uses an internal NATS client to allow communication between Raft nodes.
+type defaultTransport struct {
+	n   RaftNode
+	s   *Server
+	c   *client
+	sq  *sendq
+	acc *Account
+}
+
+func defaultRaftTransport(server *Server, raft RaftNode) raftTransport {
+	return &defaultTransport{s: server, n: raft}
+}
+
+// Node returns the RaftNode associated with this transport.
+func (t *defaultTransport) Node() RaftNode {
+	return t.n
+}
+
+func (t *defaultTransport) Account() *Account {
+	return t.acc
+}
+
+func (t *defaultTransport) Reset(acc *Account) {
+	t.Close()
+
+	t.c = t.s.createInternalSystemClient()
+	t.c.registerWithAccount(acc)
+	if acc.sq == nil {
+		acc.sq = t.s.newSendQ(acc)
+	}
+	t.sq = acc.sq
+	t.acc = acc
+}
+
+func (t *defaultTransport) Close() {
+	if c := t.c; c != nil {
+		c.mu.Lock()
+		subs := make([]*subscription, 0, len(c.subs))
+		for _, sub := range c.subs {
+			subs = append(subs, sub)
+		}
+		c.mu.Unlock()
+		for _, sub := range subs {
+			t.Unsubscribe(sub)
+		}
+		c.closeConnection(InternalClient)
+		t.c = nil
+	}
+}
+
+func (t *defaultTransport) Publish(subject string, reply string, msg []byte) {
+	t.sq.send(subject, reply, nil, msg)
+}
+
+func (t *defaultTransport) Subscribe(subject string, cb msgHandler) (*subscription, error) {
+	if t.c == nil {
+		return nil, errNoInternalClient
+	}
+	return t.s.systemSubscribe(subject, _EMPTY_, false, t.c, cb)
+}
+
+func (t *defaultTransport) Unsubscribe(sub *subscription) {
+	if t.c != nil && sub != nil {
+		t.c.processUnsub(sub.sid)
+	}
+}

--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -95,7 +95,9 @@ func (t *defaultTransport) Close() {
 }
 
 func (t *defaultTransport) Publish(subject string, reply string, msg []byte) {
-	t.sq.send(subject, reply, nil, msg)
+	if t.sq != nil {
+		t.sq.send(subject, reply, nil, msg)
+	}
 }
 
 func (t *defaultTransport) Subscribe(subject string, cb msgHandler) (*subscription, error) {

--- a/server/raft_transport_helpers_test.go
+++ b/server/raft_transport_helpers_test.go
@@ -1,0 +1,173 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains mock raft transport implementations and helper functions
+// for testing. The `raftTransportHub` manages multiple `mockTransport` instances,
+// allowing for the simulation of network partitions (`partition`, `heal`)
+// and message interception (`setAfterMsgHook`). This setup is used to test
+// raft interactions without actual network communication, providing control
+// over message delivery and network conditions.
+
+package server
+
+import (
+	"sync"
+)
+
+type msgHook func(subject, reply string, msg []byte)
+
+type raftTransportHub struct {
+	mu         sync.Mutex
+	transports map[string]*mockTransport
+	partitions map[string]int
+	afterMsg   msgHook
+}
+
+func (h *raftTransportHub) register(t *mockTransport) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.transports[t.Node().ID()] = t
+}
+
+func (h *raftTransportHub) unregister(t *mockTransport) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.transports, t.Node().ID())
+}
+
+// Simulate a network partition. Nodes assigned to different `partitionID`s
+// will not be able to exchange messages, effectively isolating them.
+// By default, all nodes are considered  to be in partition ID 0. `
+// See heal(nodeID)`,  `healPartitions()` to heal a partition.
+func (h *raftTransportHub) partition(nodeID string, partitionID int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.partitions[nodeID] = partitionID
+}
+
+// Reassign the node with the given ID to the default partition 0.
+func (h *raftTransportHub) heal(nodeID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.partitions, nodeID)
+}
+
+// Reassign all nodes to the default partition 0.
+func (h *raftTransportHub) healPartitions() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	clear(h.partitions)
+}
+
+// Set a hook that is called back after a message is published. The after
+// message hook can expect the raftTransportHub to be unlocked. It is OK
+// to interact with the raftTransportHub inside the message hook. On the
+// other hand, the underlying RaftNode that has sent the message remains
+// locked throughout the execution of the hook. The hook can only call
+// methods that do not lock the RaftNode.
+func (h *raftTransportHub) setAfterMsgHook(hook msgHook) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.afterMsg = hook
+}
+
+func (h *raftTransportHub) publish(t *mockTransport, subject, reply string, msg []byte) {
+	h.mu.Lock()
+	afterMsgHook := h.afterMsg
+	sender := t.Node().ID()
+	partition := h.partitions[sender]
+
+	for id, transport := range h.transports {
+		if sender == id {
+			continue
+		}
+
+		if partition != h.partitions[id] {
+			continue
+		}
+
+		res := transport.sub.Match(subject)
+		for _, sub := range res.psubs {
+			sub.icb(sub, nil, transport.acc, subject, reply, msg)
+		}
+	}
+	h.mu.Unlock()
+
+	if afterMsgHook != nil {
+		afterMsgHook(subject, reply, msg)
+	}
+}
+
+type mockTransport struct {
+	server *Server
+	node   RaftNode
+	hub    *raftTransportHub
+	sub    *Sublist
+	acc    *Account
+}
+
+func mockTransportFactory() (*raftTransportHub, raftTransportFactory) {
+	h := &raftTransportHub{
+		partitions: make(map[string]int),
+		transports: make(map[string]*mockTransport),
+		afterMsg:   nil,
+	}
+	return h, func(s *Server, n RaftNode) raftTransport {
+		return &mockTransport{
+			server: s,
+			node:   n,
+			hub:    h,
+		}
+	}
+}
+
+func (t *mockTransport) Reset(acc *Account) {
+	t.Close()
+	t.acc = acc
+	t.sub = NewSublist(false)
+	t.hub.register(t)
+}
+
+func (t *mockTransport) Close() {
+	t.hub.unregister(t)
+	t.sub = nil
+}
+
+func (t *mockTransport) Node() RaftNode {
+	return t.node
+}
+
+func (t *mockTransport) Account() *Account {
+	return t.acc
+}
+
+func (t *mockTransport) Publish(subject string, reply string, msg []byte) {
+	t.hub.publish(t, subject, reply, msg)
+}
+
+func (t *mockTransport) Subscribe(subject string, cb msgHandler) (*subscription, error) {
+	if t.sub == nil {
+		return nil, errNoInternalClient
+	}
+	sub := &subscription{subject: []byte(subject), sid: nil, icb: cb}
+	if err := t.sub.Insert(sub); err != nil {
+		return nil, err
+	}
+	return sub, nil
+}
+
+func (t *mockTransport) Unsubscribe(sub *subscription) {
+	if t.sub != nil {
+		t.sub.Remove(sub)
+	}
+}

--- a/server/raft_transport_helpers_test.go
+++ b/server/raft_transport_helpers_test.go
@@ -47,8 +47,8 @@ func (h *raftTransportHub) unregister(t *mockTransport) {
 
 // Simulate a network partition. Nodes assigned to different `partitionID`s
 // will not be able to exchange messages, effectively isolating them.
-// By default, all nodes are considered  to be in partition ID 0. `
-// See heal(nodeID)`,  `healPartitions()` to heal a partition.
+// By default, all nodes are considered to be in partition ID 0.
+// See `heal(nodeID)`, `healPartitions()` to heal a partition.
 func (h *raftTransportHub) partition(nodeID string, partitionID int) {
 	h.mu.Lock()
 	defer h.mu.Unlock()


### PR DESCRIPTION
The Raft implementation was tightly coupled to the server's internal client and send queue for the RPC communication. This makes it difficult to test scenarios like network partitions in deterministic manner.
The primary benefit of this change is improved testability. A new mockTransport is introduced for testing, which allows for simulating network partitions and for injecting behavior after a message is sent.

Signed-off-by: Daniele Sciascia <daniele@nats.io>
