### PR TITLE
fsync while writing last tombstone in purge

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -9044,7 +9044,7 @@ func (fs *fileStore) purge(fseq uint64) (uint64, error) {
 		// Leave a tombstone so we can remember our starting sequence in case
 		// full state becomes corrupted.
 		fs.writeTombstone(lseq, lmb.last.ts)
-		if lmb.mfd != nil {
+		if !lmb.syncAlways && fs.cfg.Replicas == 1 && lmb.mfd != nil {
 			// We must ensure tombstone is durably written to disk before returning;
 			// otherwise, a crash could leave the stream in an unrecoverable state with no sequence
 			lmb.mfd.Sync()


### PR DESCRIPTION
This PR adds  `Sync()` that ensures tombstones are durably persisted after stream purge operations. After purge completes, the message block and index files may become 0 bytes (whole directory moves to new dir). New changes might reflect partially in disk, In this state, the tombstone becomes the sole persistent record of the stream's last sequence number.

 Without an explicit sync, the tombstone remains buffered in the OS page cache and is lost on power failure, leaving the stream unable to recover its sequence history and resulting in 0,0 state.

Signed-off-by: Tilak Raj <tilak.raj94@gmail.com>
