### PR TITLE
Panic on concurrent JetStream startup/shutdown

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1139,6 +1139,12 @@ func (a *Account) EnableJetStream(limits map[string]JetStreamAccountLimits, tq c
 	}
 
 	js.mu.Lock()
+	// Accounts get reset to nil on shutdown, since we re-acquire the locks here, we need to check again.
+	if js.accounts == nil {
+		js.mu.Unlock()
+		return NewJSNotEnabledError()
+	}
+
 	if jsa, ok := js.accounts[a.Name]; ok {
 		a.mu.Lock()
 		a.js = jsa


### PR DESCRIPTION
If a server was starting up and enabling JetStream but was shut down at the same time, it could panic since `js.accounts` gets reset to nil.

```
 panic: assignment to entry in nil map 
 goroutine 1 [running]:
 github.com/nats-io/nats-server/v2/server.(*Account).EnableJetStream(0xc000132388, 0xc0001aa660, 0xc00029c000)
 	server/jetstream.go:1171 +0xd32
 github.com/nats-io/nats-server/v2/server.(*Server).configJetStream(0xc00015a008, 0xc000132388, 0xc00029c000)
 	server/jetstream.go:788 +0x1c9
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>