### PR TITLE
[FIXED] Filestore MaxMsgs/Bytes purge block accounting

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5373,14 +5373,8 @@ func (fs *fileStore) removeMsg(seq uint64, secure, viaLimits, needFSLock bool) (
 		// If we have a callback registered we need to release lock regardless since cb might need it to lookup msg, etc.
 		fs.mu.Unlock()
 		// Storage updates.
-		if cb != nil {
-			var subj string
-			if sm != nil {
-				subj = sm.subj
-			}
-			delta := int64(msz)
-			cb(-1, -delta, seq, subj)
-		}
+		delta := int64(msz)
+		cb(-1, -delta, seq, sm.subj)
 
 		if !needFSLock {
 			fs.mu.Lock()
@@ -9750,6 +9744,14 @@ func (fs *fileStore) purgeMsgBlock(mb *msgBlock) {
 	mb.finishedWithCache()
 	mb.mu.Unlock()
 	fs.selectNextFirst()
+
+	if cb := fs.scb; cb != nil {
+		// If we have a callback registered, we need to release lock regardless since consumers will recalculate pending.
+		fs.mu.Unlock()
+		// Storage updates.
+		cb(-int64(msgs), -int64(bytes), 0, _EMPTY_)
+		fs.mu.Lock()
+	}
 }
 
 // Called by purge to simply get rid of the cache and close our fds.

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -11233,6 +11233,57 @@ func TestFileStorePurgeMsgBlockRemovesSchedules(t *testing.T) {
 	})
 }
 
+func TestFileStorePurgeMsgBlockAccounting(t *testing.T) {
+	test := func(t *testing.T, update func(cfg *nats.StreamConfig)) {
+		s := RunBasicJetStreamServer(t)
+		defer s.Shutdown()
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		cfg := &nats.StreamConfig{
+			Name:     "TEST",
+			Subjects: []string{"foo"},
+			Storage:  nats.FileStorage,
+		}
+		_, err := js.AddStream(cfg)
+		require_NoError(t, err)
+
+		subj, data := "foo", make([]byte, 1024*1024)
+		for range 10 {
+			_, err = js.Publish(subj, data)
+			require_NoError(t, err)
+		}
+
+		gacc := s.globalAccount()
+		mset, err := gacc.lookupStream("TEST")
+		require_NoError(t, err)
+		state := mset.state()
+		stats := gacc.JetStreamUsage()
+		require_Equal(t, state.Bytes, stats.JetStreamTier.Store)
+
+		update(cfg)
+		_, err = js.UpdateStream(cfg)
+		require_NoError(t, err)
+
+		state = mset.state()
+		stats = gacc.JetStreamUsage()
+		require_Equal(t, state.Bytes, fileStoreMsgSizeRaw(len(subj), 0, len(data)))
+		require_Equal(t, state.Bytes, stats.JetStreamTier.Store)
+	}
+
+	t.Run("MaxMsgs", func(t *testing.T) {
+		test(t, func(cfg *nats.StreamConfig) {
+			cfg.MaxMsgs = 1
+		})
+	})
+	t.Run("MaxBytes", func(t *testing.T) {
+		test(t, func(cfg *nats.StreamConfig) {
+			cfg.MaxBytes = int64(fileStoreMsgSizeRaw(3, 0, 1024*1024))
+		})
+	})
+}
+
 func TestFileStoreMissingDeletesAfterCompact(t *testing.T) {
 	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
 		cfg := StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage}


### PR DESCRIPTION
The filestore optimizes for large purges based on `MaxMsgs`/`MaxBytes` if full blocks can be removed in one go. However, these removed blocks were not accounted for under the JetStream usage stats.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>