### PR TITLE
(2.14) [FIXED] Repeating schedule on an interval after shutdown

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -21994,10 +21994,11 @@ func TestJetStreamScheduledMessageParse(t *testing.T) {
 	require_Equal(t, now.Add(5*time.Second), sts)
 
 	// A schedule on an interval should not spam loads of times if it hasn't run in a long while.
+	now = time.Now().UTC().Round(time.Second)
 	sts, repeat, ok = parseMsgSchedule("@every 5s", 0)
 	require_True(t, ok)
 	require_True(t, repeat)
-	require_True(t, sts.After(time.Unix(0, 0).UTC().Add(5*time.Second)))
+	require_True(t, !sts.Before(now.Add(5*time.Second)))
 
 	// A schedule can only run at least once every second.
 	_, _, ok = parseMsgSchedule("@every 999ms", 0)

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -312,8 +312,8 @@ func parseMsgSchedule(pattern string, ts int64) (time.Time, bool, bool) {
 		}
 		// If this schedule would trigger multiple times, for example after a restart, skip ahead and only fire once.
 		next := time.Unix(0, ts).UTC().Round(time.Second).Add(dur)
-		if now := time.Now().UTC().Round(time.Second); next.Before(now) {
-			next = now
+		if now := time.Now().UTC(); next.Before(now) {
+			next = now.Round(time.Second).Add(dur)
 		}
 		return next, true, true
 	}


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/7504, which mentions:
> For the case where the server has been down for a minute and it comes back up, it will not immediately trigger/spam 60 events. Instead it will only trigger once and continue on the same interval.

However, for an interval of 15 seconds and the server being down for several minutes, it would fire two events immediately (instead of only one) and only after follow the interval. This PR fixes that by firing one event immediately, and the next one to continue after the interval as intended.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>