### PR TITLE
(2.14) Cron schedules

### DIFF
--- a/server/cron.go
+++ b/server/cron.go
@@ -46,31 +46,36 @@ import (
 )
 
 // parseCron parses the given cron pattern and returns the next time it will fire based on the provided ts.
-func parseCron(pattern string, ts int64) (time.Time, error) {
+func parseCron(pattern string, tz string, ts int64) (time.Time, error) {
 	fields := strings.Fields(pattern)
 	if len(fields) != 6 {
 		return time.Time{}, fmt.Errorf("pattern requires 6 fields, got %d", len(fields))
 	}
 
-	var err error
-	field := func(field string, r bounds) uint64 {
-		if err != nil {
-			return 0
-		}
-		var bits uint64
-		bits, err = getField(field, r)
-		return bits
+	// Load the time zone.
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return time.Time{}, err
 	}
 
-	var (
-		second     = field(fields[0], seconds)
-		minute     = field(fields[1], minutes)
-		hour       = field(fields[2], hours)
-		dayOfMonth = field(fields[3], dom)
-		month      = field(fields[4], months)
-		dayOfWeek  = field(fields[5], dow)
-	)
-	if err != nil {
+	// Parse each field.
+	var second, minute, hour, dayOfMonth, month, dayOfWeek uint64
+	if second, err = getField(fields[0], seconds); err != nil {
+		return time.Time{}, err
+	}
+	if minute, err = getField(fields[1], minutes); err != nil {
+		return time.Time{}, err
+	}
+	if hour, err = getField(fields[2], hours); err != nil {
+		return time.Time{}, err
+	}
+	if dayOfMonth, err = getField(fields[3], dom); err != nil {
+		return time.Time{}, err
+	}
+	if month, err = getField(fields[4], months); err != nil {
+		return time.Time{}, err
+	}
+	if dayOfWeek, err = getField(fields[5], dow); err != nil {
 		return time.Time{}, err
 	}
 
@@ -81,7 +86,7 @@ func parseCron(pattern string, ts int64) (time.Time, error) {
 	// If the field doesn't match the schedule, then increment the field until it matches.
 	// While incrementing the field, a wrap-around brings it back to the beginning
 	// of the field list (since it is necessary to re-verify previous field values)
-	next := time.Unix(0, ts).UTC()
+	next := time.Unix(0, ts).In(loc)
 
 	// Start at the earliest possible time (the upcoming second).
 	next = next.Truncate(time.Second).Add(time.Second)
@@ -99,7 +104,7 @@ WRAP:
 	for 1<<uint(next.Month())&month == 0 {
 		if !truncated {
 			truncated = true
-			next = time.Date(next.Year(), next.Month(), 1, 0, 0, 0, 0, time.UTC)
+			next = time.Date(next.Year(), next.Month(), 1, 0, 0, 0, 0, loc)
 		}
 		if next = next.AddDate(0, 1, 0); next.Month() == time.January {
 			goto WRAP
@@ -108,7 +113,7 @@ WRAP:
 	for !dayMatches(dayOfMonth, dayOfWeek, next) {
 		if !truncated {
 			truncated = true
-			next = time.Date(next.Year(), next.Month(), next.Day(), 0, 0, 0, 0, time.UTC)
+			next = time.Date(next.Year(), next.Month(), next.Day(), 0, 0, 0, 0, loc)
 		}
 		if next = next.AddDate(0, 0, 1); next.Day() == 1 {
 			goto WRAP
@@ -117,7 +122,7 @@ WRAP:
 	for 1<<uint(next.Hour())&hour == 0 {
 		if !truncated {
 			truncated = true
-			next = time.Date(next.Year(), next.Month(), next.Day(), next.Hour(), 0, 0, 0, time.UTC)
+			next = time.Date(next.Year(), next.Month(), next.Day(), next.Hour(), 0, 0, 0, loc)
 		}
 		if next = next.Add(time.Hour); next.Hour() == 0 {
 			goto WRAP
@@ -149,8 +154,8 @@ WRAP:
 // list of "ranges".
 func getField(field string, r bounds) (uint64, error) {
 	var bits uint64
-	ranges := strings.FieldsFunc(field, func(r rune) bool { return r == ',' })
-	for _, expr := range ranges {
+	ranges := strings.FieldsFuncSeq(field, func(r rune) bool { return r == ',' })
+	for expr := range ranges {
 		bit, err := getRange(expr, r)
 		if err != nil {
 			return bits, err

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -22049,7 +22049,7 @@ func TestJetStreamScheduledMessageParse(t *testing.T) {
 	// @at <ts>
 	t.Run("@at", func(t *testing.T) {
 		ts := time.Now().UTC()
-		sts, repeat, ok := parseMsgSchedule(fmt.Sprintf("@at %s", ts.Format(time.RFC3339Nano)), 0)
+		sts, repeat, ok := parseMsgSchedule(fmt.Sprintf("@at %s", ts.Format(time.RFC3339Nano)), _EMPTY_, 0)
 		require_True(t, ok)
 		require_False(t, repeat)
 		require_Equal(t, ts, sts)
@@ -22058,41 +22058,41 @@ func TestJetStreamScheduledMessageParse(t *testing.T) {
 	// @every <duration>
 	t.Run("@every", func(t *testing.T) {
 		now := time.Now().UTC().Round(time.Second)
-		sts, repeat, ok := parseMsgSchedule("@every 5s", now.UnixNano())
+		sts, repeat, ok := parseMsgSchedule("@every 5s", _EMPTY_, now.UnixNano())
 		require_True(t, ok)
 		require_True(t, repeat)
 		require_Equal(t, now.Add(5*time.Second), sts)
 
 		// A schedule on an interval should not spam loads of times if it hasn't run in a long while.
 		now = time.Now().UTC().Round(time.Second)
-		sts, repeat, ok = parseMsgSchedule("@every 5s", 0)
+		sts, repeat, ok = parseMsgSchedule("@every 5s", _EMPTY_, 0)
 		require_True(t, ok)
 		require_True(t, repeat)
 		require_True(t, !sts.Before(now.Add(5*time.Second)))
 
 		// A schedule can only run at least once every second.
-		_, _, ok = parseMsgSchedule("@every 999ms", 0)
+		_, _, ok = parseMsgSchedule("@every 999ms", _EMPTY_, 0)
 		require_False(t, ok)
 	})
 
 	// <cron> pattern
 	t.Run("cron", func(t *testing.T) {
 		now := time.Now().UTC().Round(time.Second)
-		sts, repeat, ok := parseMsgSchedule("* * * * * *", now.UnixNano())
+		sts, repeat, ok := parseMsgSchedule("* * * * * *", _EMPTY_, now.UnixNano())
 		require_True(t, ok)
 		require_True(t, repeat)
 		require_Equal(t, now.Add(time.Second), sts)
 
 		// A schedule based on a cron should run the earliest "next" second.
 		now = time.Now().UTC().Truncate(time.Second).Add(time.Second - time.Nanosecond)
-		sts, repeat, ok = parseMsgSchedule("* * * * * *", now.UnixNano())
+		sts, repeat, ok = parseMsgSchedule("* * * * * *", _EMPTY_, now.UnixNano())
 		require_True(t, ok)
 		require_True(t, repeat)
 		require_Equal(t, now.Truncate(time.Second).Add(time.Second), sts)
 
 		// A schedule based on cron should not spam loads of times if it hasn't run in a long while.
 		now = time.Now().UTC().Round(time.Second)
-		sts, repeat, ok = parseMsgSchedule("* * * * * *", 0)
+		sts, repeat, ok = parseMsgSchedule("* * * * * *", _EMPTY_, 0)
 		require_True(t, ok)
 		require_True(t, repeat)
 		require_True(t, !sts.Before(now.Add(time.Second)))
@@ -22133,12 +22133,25 @@ func TestJetStreamScheduledMessageParse(t *testing.T) {
 						now = now.AddDate(0, 0, 1)
 					}
 				}
-				sts, repeat, ok = parseMsgSchedule(p.pattern, now.UnixNano())
+				sts, repeat, ok = parseMsgSchedule(p.pattern, _EMPTY_, now.UnixNano())
 				require_True(t, ok)
 				require_True(t, repeat)
 				require_Equal(t, p.delay(now), sts)
 			})
 		}
+	})
+
+	// <cron> pattern with time zone
+	t.Run("cron_tz", func(t *testing.T) {
+		tz := "Europe/Amsterdam"
+		loc, err := time.LoadLocation(tz)
+		require_NoError(t, err)
+
+		now := time.Now().UTC().Round(time.Second)
+		sts, repeat, ok := parseMsgSchedule("* * * * * *", tz, now.UnixNano())
+		require_True(t, ok)
+		require_True(t, repeat)
+		require_Equal(t, now.In(loc).Add(time.Second).String(), sts.String())
 	})
 }
 

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -178,7 +178,8 @@ func (ms *MsgScheduling) getScheduledMessages(loadMsg func(seq uint64, smv *Stor
 				ms.remove(seq)
 				return true
 			}
-			next, repeat, ok := parseMsgSchedule(pattern, ts)
+			tz := bytesToString(sliceHeader(JSScheduleTimeZone, sm.hdr))
+			next, repeat, ok := parseMsgSchedule(pattern, tz, ts)
 			if !ok {
 				ms.remove(seq)
 				return true
@@ -299,17 +300,25 @@ func (ms *MsgScheduling) decode(b []byte) (uint64, error) {
 
 // parseMsgSchedule parses a message schedule pattern and returns the time
 // to fire, whether it is a repeating schedule, and whether the pattern was valid.
-func parseMsgSchedule(pattern string, ts int64) (time.Time, bool, bool) {
+func parseMsgSchedule(pattern string, tz string, ts int64) (time.Time, bool, bool) {
 	if pattern == _EMPTY_ {
 		return time.Time{}, false, true
 	}
 	// Exact time.
 	if strings.HasPrefix(pattern, "@at ") {
+		// Time zone is not supported for @at.
+		if tz != _EMPTY_ {
+			return time.Time{}, false, false
+		}
 		t, err := time.Parse(time.RFC3339, pattern[4:])
 		return t, false, err == nil
 	}
 	// Repeating on a simple interval.
 	if strings.HasPrefix(pattern, "@every ") {
+		// Time zone is not supported for @every.
+		if tz != _EMPTY_ {
+			return time.Time{}, false, false
+		}
 		dur, err := time.ParseDuration(pattern[7:])
 		if err != nil {
 			return time.Time{}, false, false
@@ -341,14 +350,14 @@ func parseMsgSchedule(pattern string, ts int64) (time.Time, bool, bool) {
 	}
 
 	// Parse the cron pattern.
-	next, err := parseCron(pattern, ts)
+	next, err := parseCron(pattern, tz, ts)
 	if err != nil {
 		return time.Time{}, false, false
 	}
 	// If this schedule would trigger multiple times, for example after a restart, skip ahead and only fire once.
 	if now := time.Now().UTC(); next.Before(now) {
 		ts = now.Round(time.Second).UnixNano()
-		next, err = parseCron(pattern, ts)
+		next, err = parseCron(pattern, tz, ts)
 		if err != nil {
 			return time.Time{}, false, false
 		}

--- a/server/stream.go
+++ b/server/stream.go
@@ -632,6 +632,7 @@ const (
 	JSBatchSeq                = "Nats-Batch-Sequence"
 	JSBatchCommit             = "Nats-Batch-Commit"
 	JSSchedulePattern         = "Nats-Schedule"
+	JSScheduleTimeZone        = "Nats-Schedule-Time-Zone"
 	JSScheduleTTL             = "Nats-Schedule-TTL"
 	JSScheduleTarget          = "Nats-Schedule-Target"
 	JSScheduleSource          = "Nats-Schedule-Source"
@@ -5015,9 +5016,7 @@ func getMessageSchedule(hdr []byte) (time.Time, bool) {
 	if len(hdr) == 0 {
 		return time.Time{}, true
 	}
-	val := bytesToString(sliceHeader(JSSchedulePattern, hdr))
-	schedule, _, ok := parseMsgSchedule(val, time.Now().UTC().UnixNano())
-	return schedule, ok
+	return nextMessageSchedule(hdr, time.Now().UTC().UnixNano())
 }
 
 // Fast lookup and calculation of next message schedule.
@@ -5026,7 +5025,8 @@ func nextMessageSchedule(hdr []byte, ts int64) (time.Time, bool) {
 		return time.Time{}, true
 	}
 	val := bytesToString(sliceHeader(JSSchedulePattern, hdr))
-	schedule, _, ok := parseMsgSchedule(val, ts)
+	tz := bytesToString(sliceHeader(JSScheduleTimeZone, hdr))
+	schedule, _, ok := parseMsgSchedule(val, tz, ts)
 	return schedule, ok
 }
 


### PR DESCRIPTION
Add support for [cron-like schedules as described in the ADR](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md#cron-like-schedules).

This PR builds on top of the added 'repeating schedules' support: https://github.com/nats-io/nats-server/pull/7504. Adding cron based on https://github.com/robfig/cron, but adapted to only use what's necessary, and added to a separate `cron.go` file.

Resolves https://github.com/nats-io/nats-server/issues/6381

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>