### PR TITLE
(2.14) [FIXED] Filestore partial purge flushes tombstone

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -9242,6 +9242,7 @@ func (fs *fileStore) purge(fseq uint64) (uint64, error) {
 		fs.writeTombstone(lseq, lmb.last.ts)
 	}
 	// Close FDs since we'll move the file. We re-enable the FD after the purge is complete.
+	lmb.flushPendingMsgs()
 	lmb.closeFDs()
 
 	fs.blks = nil


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/7676, should not forget to flush the tombstone. Especially important for (replicated) streams using `AsyncFlush`, where `writeTombstone` does not immediately flush otherwise.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>