### PR TITLE
[FIXED] Don't delete consumer on concurrent shutdown and leader change

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1542,7 +1542,6 @@ func (o *consumer) setLeader(isLeader bool) {
 		if o.cfg.AckPolicy != AckNone {
 			if o.ackSub, err = o.subscribeInternal(o.ackSubj, o.pushAck); err != nil {
 				o.mu.Unlock()
-				o.deleteWithoutAdvisory()
 				return
 			}
 		}
@@ -1551,7 +1550,6 @@ func (o *consumer) setLeader(isLeader bool) {
 		// Will error if wrong mode to provide feedback to users.
 		if o.reqSub, err = o.subscribeInternal(o.nextMsgSubj, o.processNextMsgReq); err != nil {
 			o.mu.Unlock()
-			o.deleteWithoutAdvisory()
 			return
 		}
 
@@ -1561,7 +1559,6 @@ func (o *consumer) setLeader(isLeader bool) {
 			fcsubj := fmt.Sprintf(jsFlowControl, stream, o.name)
 			if o.fcSub, err = o.subscribeInternal(fcsubj, o.processFlowControl); err != nil {
 				o.mu.Unlock()
-				o.deleteWithoutAdvisory()
 				return
 			}
 		}


### PR DESCRIPTION
A replicated consumer could be deleted during shutdown that aligns with this server becoming the consumer leader. This was due to the leadership change requiring certain subscriptions to be made, which will not succeed during/after shutdown.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>