### PR TITLE
NRG: Don't drain response or proposal queues when switching to leader

### DIFF
--- a/server/ipqueue.go
+++ b/server/ipqueue.go
@@ -230,6 +230,21 @@ func (q *ipQueue[T]) recycle(elts *[]T) {
 	q.pool.Put(elts)
 }
 
+// Renotify will re-fill the notification channel if there are pending
+// reads. Useful if you have read the notification channel but do not
+// intend to pop/popOne/drain etc.
+func (q *ipQueue[T]) renotify() {
+	if q == nil {
+		return
+	}
+	q.Lock()
+	defer q.Unlock()
+	if len(q.elts)-q.pos == 0 {
+		return
+	}
+	q.ch <- struct{}{}
+}
+
 // Returns the current length of the queue.
 func (q *ipQueue[T]) len() int {
 	q.Lock()


### PR DESCRIPTION
The `runAsCandidate` and `runAsFollower` goroutines both try to drain the append entry response and proposal queues if they are still populated from the previous leadership, but we might be blocked in `runAsCandidate` or `runAsFollower` while switching to leader waiting for the state change to complete and accidentally drain incoming proposals.

Signed-off-by: Neil Twigg <neil@nats.io>