### PR TITLE
Fix a jetStream / jsAccount lock ordering violation

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -829,9 +829,9 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 
 	// Add created timestamp used for the store, must match that of the stream assignment if it exists.
 	if sa != nil {
-		js.mu.RLock()
+		// The following assignment does not require mutex
+		// protection: sa.Created is immutable.
 		mset.created = sa.Created
-		js.mu.RUnlock()
 	}
 
 	// Start our signaling routine to process consumers.


### PR DESCRIPTION
Method `addStreamWithAssignment` could cause a deadlock when acquiring the jetStream lock while holding the jsAccount lock, a lock ordering violation.
This would cause a deadlock when attempting to shutdown and a a stream was created concurrrently. Easiliy reproduced when running `BenchmarkJetStreamCreate` benchmark.
The jetstream lock was acquired to protect the following assignment:

```
        mset.create = sa.Created
```
It appears unnecessary to lock jetstream for that, so the fix removes the locking.

Signed-off-by: Daniele Sciascia <daniele@nats.io>
