### PR TITLE
[FIXED] Mirror consumer data race

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -3149,7 +3149,6 @@ func (mset *stream) setupMirrorConsumer() error {
 	}
 
 	mirror := mset.mirror
-	mirrorWg := &mirror.wg
 
 	// We want to throttle here in terms of how fast we request new consumers,
 	// or if the previous is still in progress.
@@ -3308,7 +3307,16 @@ func (mset *stream) setupMirrorConsumer() error {
 
 		// Wait for previous processMirrorMsgs go routine to be completely done.
 		// If none is running, this will not block.
-		mirrorWg.Wait()
+		mset.mu.Lock()
+		if mset.mirror == nil {
+			// Mirror config has been removed.
+			mset.mu.Unlock()
+			return
+		} else {
+			wg := &mset.mirror.wg
+			mset.mu.Unlock()
+			wg.Wait()
+		}
 
 		select {
 		case ccr := <-respCh:


### PR DESCRIPTION
Follow-up to https://github.com/nats-io/nats-server/pull/7395, since Antithesis still manages to reproduce the data race. Instead of capturing the mirror's `WaitGroup` outside the goroutine, let's capture it in the goroutine itself which allows to check the mirror config hasn't been removed in the meantime (for example due to a leader change and this server not being leader anymore).

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>