### PR TITLE
Don't rebuild subject state in filestore on `noTrack` stores after truncate

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -10011,6 +10011,9 @@ func (mb *msgBlock) recalculateForSubj(subj string, ss *SimpleState) {
 func (fs *fileStore) resetGlobalPerSubjectInfo() {
 	// Clear any global subject state.
 	fs.psim, fs.tsl = fs.psim.Empty(), 0
+	if fs.noTrackSubjects() {
+		return
+	}
 	for _, mb := range fs.blks {
 		fs.populateGlobalPerSubjectInfo(mb)
 	}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -12108,3 +12108,22 @@ func TestFileStoreCompactFullyResetsFirstAndLastSeq(t *testing.T) {
 		checkMbState(1, 0, 0)
 	})
 }
+
+func TestFileStoreDoesntRebuildSubjectStateWithNoTrack(t *testing.T) {
+	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
+		fs, err := newFileStoreWithCreated(fcfg, StreamConfig{Name: "zzz", Storage: FileStorage}, time.Now(), prf(&fcfg), nil)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		_, _, err = fs.StoreMsg("foo", nil, nil, 0)
+		require_NoError(t, err)
+
+		// This implicitly was calling resetGlobalPerSubjectInfo and
+		// populating "foo" back into the psim.
+		require_NoError(t, fs.Truncate(1))
+
+		fs.mu.Lock()
+		defer fs.mu.Unlock()
+		require_Equal(t, fs.psim.Size(), 0)
+	})
+}


### PR DESCRIPTION
This can be expensive for no good reason on large WALs in particular.

Signed-off-by: Neil Twigg <neil@nats.io>