### PR TITLE
Fix configuring `cluster_traffic` in config mode

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -299,6 +299,7 @@ func (a *Account) shallowCopy(na *Account) {
 	na.Nkey = a.Nkey
 	na.Issuer = a.Issuer
 	na.traceDest, na.traceDestSampling = a.traceDest, a.traceDestSampling
+	na.nrgAccount = a.nrgAccount
 
 	if a.imports.streams != nil {
 		na.imports.streams = make([]*streamImport, 0, len(a.imports.streams))

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -2142,6 +2142,7 @@ func TestJetStreamClusterAccountNRGConfigNoPanic(t *testing.T) {
 
 		accounts {
 			ONE { jetstream: { cluster_traffic: system } }
+			TWO { jetstream: { cluster_traffic: owner } }
 		}
 	`
 
@@ -2152,6 +2153,10 @@ func TestJetStreamClusterAccountNRGConfigNoPanic(t *testing.T) {
 		acc, err := s.lookupAccount("ONE")
 		require_NoError(t, err)
 		require_Equal(t, acc.nrgAccount, _EMPTY_) // Empty for the system account
+
+		acc, err = s.lookupAccount("TWO")
+		require_NoError(t, err)
+		require_Equal(t, acc.nrgAccount, "TWO")
 	}
 }
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -2326,7 +2326,7 @@ func parseJetStreamForAccount(v any, acc *Account, errors *[]error) error {
 			case "cluster_traffic":
 				vv, ok := mv.(string)
 				if !ok {
-					return &configErr{tk, fmt.Sprintf("Expected either 'system' or 'account' string value for %q, got %v", mk, mv)}
+					return &configErr{tk, fmt.Sprintf("Expected either 'system' or 'owner' string value for %q, got %v", mk, mv)}
 				}
 				switch vv {
 				case "system", _EMPTY_:


### PR DESCRIPTION
The configuration field was not being copied in `(*Account).shallowCopy()` and was therefore lost between the config code and the Raft code.

Fixes #7722.

Signed-off-by: Neil Twigg <neil@nats.io>