### PR TITLE
Preliminary UNIX domain socket support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -346,6 +346,23 @@ jobs:
       - name: Run unit tests
         run: ./scripts/runTestsOnTravis.sh mqtt_tests
 
+  uds:
+    name: Test UDS
+    needs: [build-latest, build-supported, lint]
+    runs-on: ${{ vars.GHA_WORKER_SMALL || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Run unit tests
+        run: ./scripts/runTestsOnTravis.sh uds_tests
+
   msgtrace:
     name: Test Message Tracing
     needs: [build-latest, build-supported, lint]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+(This is for experimenting with features I need, see https://github.com/nats-io/nats-server/discussions/7677)
+
 <p align="center">
   <img src="logos/nats-horizontal-color.png" width="300" alt="NATS Logo">
 </p>

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ Server Options:
                                      <pid> can be either a PID (e.g. 1) or the path to a PID file (e.g. /var/run/nats-server.pid)
         --client_advertise <string>  Client URL to advertise to other servers
         --ports_file_dir <dir>       Creates a ports file in the specified directory (<executable_name>_<pid>.ports).
+        --uds <path;opts>            UNIX domain socket: "/path;group=grp;mode=0660" (Linux only).
 
 Logging Options:
     -l, --log <file>                 File to redirect log output

--- a/scripts/runTestsOnTravis.sh
+++ b/scripts/runTestsOnTravis.sh
@@ -112,6 +112,12 @@ elif [ "$1" = "msgtrace_tests" ]; then
 
     go test $RACE -v -p=1 -run=TestMsgTrace ./server -count=1 -vet=off -timeout=30m -failfast
 
+elif [ "$1" = "uds_tests" ]; then
+
+    # Run UDS (Unix Domain Socket) tests. By convention, all UDS tests start with `TestUDS`.
+
+    go test $RACE -v -p=1 -run=TestUDS ./server -count=1 -vet=off -timeout=30m -failfast
+
 elif [ "$1" = "srv_pkg_non_js_tests" ]; then
 
     # Run all non JetStream tests in the server package. We exclude the

--- a/server/client.go
+++ b/server/client.go
@@ -6455,7 +6455,8 @@ func convertAllowedConnectionTypes(cts []string) (map[string]struct{}, error) {
 		case jwt.ConnectionTypeStandard, jwt.ConnectionTypeWebsocket,
 			jwt.ConnectionTypeLeafnode, jwt.ConnectionTypeLeafnodeWS,
 			jwt.ConnectionTypeMqtt, jwt.ConnectionTypeMqttWS,
-			jwt.ConnectionTypeInProcess:
+			jwt.ConnectionTypeInProcess,
+			ConnectionTypeUnix: // see uds.go
 			m[i] = struct{}{}
 		default:
 			unknown = append(unknown, i)

--- a/server/reload.go
+++ b/server/reload.go
@@ -1259,7 +1259,7 @@ func imposeOrder(value any) error {
 		slices.Sort(value.AllowedOrigins)
 	case string, bool, uint8, uint16, uint64, int, int32, int64, time.Duration, float64, nil, LeafNodeOpts, ClusterOpts, *tls.Config, PinnedCertSet,
 		*URLAccResolver, *MemAccResolver, *DirAccResolver, *CacheDirAccResolver, Authentication, MQTTOpts, jwt.TagList,
-		*OCSPConfig, map[string]string, JSLimitOpts, StoreCipher, *OCSPResponseCacheConfig, *ProxiesConfig, WriteTimeoutPolicy:
+		*OCSPConfig, map[string]string, JSLimitOpts, StoreCipher, *OCSPResponseCacheConfig, *ProxiesConfig, WriteTimeoutPolicy, UDSOptions:
 		// explicitly skipped types
 	case *AuthCallout:
 	case JSTpmOpts:

--- a/server/uds.go
+++ b/server/uds.go
@@ -1,0 +1,420 @@
+// Copyright 2020-2025 Michael Utech
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// UDSOptions holds UNIX domain socket configuration options.
+type UDSOptions struct {
+	Path  string
+	Group string
+	Mode  string
+}
+
+// UDSInfo is the UDS information exposed to clients in the INFO message.
+type UDSInfo struct {
+	Path string `json:"path"`
+}
+
+// ParseUDSOption parses a UDS option string in the format "/path;group=grp;mode=0660".
+// The path is required, group and mode are optional.
+func ParseUDSOption(s string) (UDSOptions, error) {
+	var opts UDSOptions
+	parts := strings.Split(s, ";")
+	opts.Path = parts[0]
+
+	if opts.Path == _EMPTY_ {
+		return UDSOptions{}, fmt.Errorf("invalid path: '' (expected absolute path to UNIX domain socket)")
+	}
+
+	for _, part := range parts[1:] {
+		if part == _EMPTY_ {
+			continue
+		}
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			return UDSOptions{}, fmt.Errorf("invalid UDS option format: %q (expected <option>=<value>)", part)
+		}
+		key, value := kv[0], kv[1]
+		switch key {
+		case "group":
+			opts.Group = value
+		case "mode":
+			opts.Mode = value
+		default:
+			return UDSOptions{}, fmt.Errorf("unknown UDS option: %q (expected 'group' or 'mode')", key)
+		}
+	}
+
+	return opts, nil
+}
+
+type udsSocketSpec struct {
+	path string
+	gid  int // -1 = no change
+	mode int // -1 = no change, 0 = 0000
+}
+
+type udsServerState struct {
+	socket                udsSocketSpec
+	listener              net.Listener
+	listenerErr           error
+	peerCredentialQueries map[string]PeerCredQueryFunc
+}
+
+// Connection types are defined in nats-io/jwt, I don't want to fork that just for a constant.
+// This type is "reused" to differentiate permission granting/restricting rules from
+// authenticating rules. The presence of AllowedConnectionTypes in users signifies that
+// matching peers are allowed to connect. There is no good reason to
+// allow or restrict connection types for UDS, because if any other auth mechanism triggered
+// before, the peer cred mechanism would not be used at all. It would be cleaner to add
+// a "connect" permission to user.permissions to accomplish this. It would also be cleaner
+// if AllowedConnectionTypes == [] would mean none, but it's interpreted as all. The value of
+// being able to restrict connections based on peer credentials seems to justify this hack
+// (better: adding an explicit setting).
+const ConnectionTypeUnix = "UNIXSOCKET" // named to follow convention in jwt (e.g.: WEBSOCKET)
+
+// Determines whether a User entry matching peer credentials authorizes connection via UDS.
+// This is semantically equivalent to an existing user entry for a matching TLS certificate.
+func (user *User) grantsUdsConnectionPermission() bool {
+	_, ok := user.AllowedConnectionTypes[ConnectionTypeUnix]
+	return user.AllowedConnectionTypes != nil && ok
+}
+
+// UDSPeerCreds holds UNIX domain socket peer credentials.
+// Exported for use in PeerCredQueryFunc implementations.
+// Not all UNIX derivatives have PID, some have GROUP. Group
+// is referenced as "pid:gid", on Linux via lookup, if BSDs
+// are supported, may add Groups field.
+type UDSPeerCreds struct {
+	UID int // User ID, >= 0
+	GID int // Group ID, >= 0
+	PID int // Process ID, -1 if not supported, > 0 otherwise
+}
+
+// Determines if a client is connected via a UNIX domain socket
+func (c *client) isUDSPeer() bool {
+	_, ok := c.nc.(*net.UnixConn)
+	return ok
+}
+
+func (s *Server) hasUDSPeerCredentialSupport() bool {
+	return s.uds != nil && s.uds.peerCredentialQueries != nil
+}
+
+func (s *Server) udsListenerErr() error {
+	if s.uds == nil {
+		return nil
+	}
+	return s.uds.listenerErr
+}
+
+// Determines if a user name can be a peer credential pattern and is likely not
+// a valid user/passwd or TLS subject name. It might still be an invalid peercred
+// pattern or a different convention. This should be good enough to justify
+// a warning if a user name matches and is not a valid pattern.
+// (/^[ugp]id[:!=]/ is unlikely to be anything but a possibly invalid peer-cred pattern)
+func maybePeerCredPattern(u string) bool {
+	return len(u) >= 4 &&
+		u[1] == 'i' && u[2] == 'd' &&
+		(u[3] == ':' || u[3] == '=' || u[3] == '!') &&
+		(u[0] == 'u' || u[0] == 'g' || u[0] == 'p')
+}
+
+// Used to iterate over peer credential pattern tokens (separated by ',')
+type peerCredPatternToken struct {
+	pattern    string
+	startIndex int
+	length     int    // pattern[startIndex+length] == ',' or EOS
+	query      string // "uid", "gid", "pid", "uid:name", "pid:gid:name" (suppl. groups), "pid:systemd-unit"
+	negated    bool   // "!=" instead of "="
+	value      string
+}
+
+// Scans a single match expression. Space handling is rigid, allows space before
+// query (uid/pid:some/...) and inside values (not leading trailing), not around operators
+func scanPeerCredToken(pattern string, startIndex int) (peerCredPatternToken, error) {
+	// Implementation note: we could just use indexes and do query matching inline.
+	// - That would avoid string extraction and allocs
+	// - Makes the code much less readable
+	// - It's not in the hot message loop, only once per connection
+	// - Should be good enough reason to justify favoring readability
+
+	if startIndex >= len(pattern) {
+		return peerCredPatternToken{}, fmt.Errorf("'%s': startIndex %d out of bounds", pattern, startIndex)
+	}
+
+	// Skip leading spaces (allows "uid=1000, gid=100") - convenience only
+	for startIndex < len(pattern) && pattern[startIndex] == ' ' {
+		startIndex++
+	}
+
+	if startIndex >= len(pattern) {
+		return peerCredPatternToken{}, fmt.Errorf("'%s': trailing spaces at end", pattern)
+	}
+
+	result := peerCredPatternToken{
+		pattern:    pattern,
+		startIndex: startIndex,
+	}
+
+	// Find the operator (= or !=)
+	i := startIndex
+	for i < len(pattern) && pattern[i] != '=' && pattern[i] != '!' && pattern[i] != ',' {
+		i++
+	}
+
+	if i >= len(pattern) || pattern[i] == ',' {
+		return result, fmt.Errorf("'%s': missing operator at position %d", pattern, startIndex)
+	}
+
+	result.query = pattern[startIndex:i]
+
+	// Check for != or =
+	if pattern[i] == '!' {
+		if i+1 >= len(pattern) || pattern[i+1] != '=' {
+			return result, fmt.Errorf("'%s': invalid '!' without '=' at position %d", pattern, i)
+		}
+		result.negated = true
+		i += 2
+	} else {
+		// pattern[i] == '='
+		i++
+	}
+
+	// Find the value (until ',' or end)
+	valueStart := i
+	for i < len(pattern) && pattern[i] != ',' {
+		i++
+	}
+
+	result.value = pattern[valueStart:i]
+	result.length = i - startIndex
+
+	// Reject leading/trailing non-visible chars in value (likely a typo)
+	// This is protection from unexpected+silent mismatch of deny rules, etc.
+	// Allow inner spaces in the unlikely case they might be legit
+	// Generally, IDs, user names, services, paths should not contain leading/trailing spaces
+	if len(result.value) > 0 {
+		if result.value[0] <= ' ' {
+			return result, fmt.Errorf("'%s': leading whitespace in value at position %d", pattern, valueStart)
+		}
+		if result.value[len(result.value)-1] <= ' ' {
+			return result, fmt.Errorf("'%s': trailing whitespace in value at position %d", pattern, valueStart)
+		}
+	}
+
+	return result, nil
+}
+
+// peerCredsMatchPattern determines whether credentials match all tokens in pattern (AND logic).
+// Returns error if pattern is invalid or query handler not found.
+// Standalone function for testability.
+func peerCredsMatchPattern(queries map[string]PeerCredQueryFunc, creds UDSPeerCreds, pattern string) (bool, error) {
+	i := 0
+	for i < len(pattern) {
+		token, err := scanPeerCredToken(pattern, i)
+		if err != nil {
+			return false, err
+		}
+
+		handler, ok := queries[token.query]
+		if !ok {
+			return false, fmt.Errorf("'%s': unknown query '%s'", pattern, token.query)
+		}
+
+		matched, err := handler(creds, token.value)
+		if err != nil {
+			return false, fmt.Errorf("'%s': query '%s' failed: %w", pattern, token.query, err)
+		}
+
+		if token.negated {
+			matched = !matched
+		}
+
+		if !matched {
+			return false, nil
+		}
+
+		// Move to next token (skip comma)
+		i = token.startIndex + token.length
+		if i < len(pattern) && pattern[i] == ',' {
+			i++
+			if i >= len(pattern) {
+				return false, fmt.Errorf("'%s': trailing comma", pattern)
+			}
+		}
+	}
+
+	return true, nil
+}
+
+// udsPeerCredsMatchPattern is a Server method wrapper for peerCredsMatchPattern.
+func (s *Server) udsPeerCredsMatchPattern(creds UDSPeerCreds, pattern string) (bool, error) {
+	if s.uds == nil || s.uds.peerCredentialQueries == nil {
+		s.Fatalf("udsPeerCredsMatchPattern called with nil query registry")
+		return false, nil // unreachable, but satisfies compiler
+	}
+	return peerCredsMatchPattern(s.uds.peerCredentialQueries, creds, pattern)
+}
+
+type udsPeerAuthResult struct {
+	authenticated      bool
+	authenticatingRule string
+	identity           string
+	account            *Account
+	permissions        *Permissions
+	warnings           []string
+}
+
+func udsAuthenticatePeer(users map[string]*User, queries map[string]PeerCredQueryFunc, peerCreds UDSPeerCreds) (udsPeerAuthResult, error) {
+	identity := fmt.Sprintf("uid=%d,gid=%d,pid=%d", peerCreds.UID, peerCreds.GID, peerCreds.PID)
+	result := udsPeerAuthResult{
+		identity: identity,
+	}
+
+	var pubAllow, pubDeny, subAllow, subDeny []string
+	var respMaxMsgs int
+	var respExpires time.Duration
+	hasPermissions := false
+
+	for _, u := range users {
+		if !maybePeerCredPattern(u.Username) {
+			continue
+		}
+		matched, err := peerCredsMatchPattern(queries, peerCreds, u.Username)
+		if err != nil {
+			return result, fmt.Errorf("pattern %q: %w", u.Username, err)
+		}
+		if !matched {
+			continue
+		}
+
+		// Check for conflicting accounts
+		if u.Account != nil {
+			if result.account != nil && result.account != u.Account {
+				return result, fmt.Errorf("%q: conflicting accounts: %q redefines %q", result.identity, u.Username, result.authenticatingRule)
+			}
+			result.authenticated = true
+			result.authenticatingRule = u.Username // overwrite possible name of authenticating non-account rule
+			result.account = u.Account
+		}
+
+		if u.grantsUdsConnectionPermission() {
+			result.authenticated = true
+			if result.authenticatingRule == _EMPTY_ {
+				// only record first authenticating rule
+				result.authenticatingRule = u.Username
+			}
+		}
+
+		// Merge permissions
+		if u.Permissions != nil {
+			hasPermissions = true
+			if u.Permissions.Publish != nil {
+				pubAllow = append(pubAllow, u.Permissions.Publish.Allow...)
+				pubDeny = append(pubDeny, u.Permissions.Publish.Deny...)
+			}
+			if u.Permissions.Subscribe != nil {
+				subAllow = append(subAllow, u.Permissions.Subscribe.Allow...)
+				subDeny = append(subDeny, u.Permissions.Subscribe.Deny...)
+			}
+			if u.Permissions.Response != nil {
+				if u.Permissions.Response.MaxMsgs > respMaxMsgs {
+					respMaxMsgs = u.Permissions.Response.MaxMsgs
+				}
+				if u.Permissions.Response.Expires > respExpires {
+					respExpires = u.Permissions.Response.Expires
+				}
+			}
+		}
+	}
+
+	if !result.authenticated {
+		return result, nil
+	}
+	if !hasPermissions {
+		result.authenticated = false
+		result.warnings = append(result.warnings, fmt.Sprintf("%q: no permissions defined", result.identity))
+		return result, nil
+	}
+	if len(pubAllow) == 0 && len(pubDeny) == 0 && len(subAllow) == 0 && len(subDeny) == 0 {
+		result.authenticated = false
+		result.warnings = append(result.warnings, fmt.Sprintf("%q: empty permissions (no default allow policy for UDS connections)", result.identity))
+		return result, nil
+	}
+
+	// Build merged permissions
+	result.permissions = &Permissions{
+		Publish:   &SubjectPermission{Allow: pubAllow, Deny: pubDeny},
+		Subscribe: &SubjectPermission{Allow: subAllow, Deny: subDeny},
+	}
+	if respMaxMsgs > 0 || respExpires > 0 {
+		result.permissions.Response = &ResponsePermission{
+			MaxMsgs: respMaxMsgs,
+			Expires: respExpires,
+		}
+	}
+
+	return result, nil
+}
+
+// PeerCredQueryFunc evaluates a peercred query.
+// Returns (matched, error). If negated, caller inverts the result.
+type PeerCredQueryFunc func(creds UDSPeerCreds, value string) (bool, error)
+
+// RegisterUDSPeerCredQuery registers a query function for a credential/query pair.
+// Must be called before Server.Start(). Returns error if server is already running.
+// Returns the previous handler for this query (nil if none).
+func (s *Server) RegisterUDSPeerCredQuery(query string, fn PeerCredQueryFunc) (PeerCredQueryFunc, error) {
+	if s.isRunning() {
+		return nil, fmt.Errorf("cannot register UDS peer credential query after server start")
+	}
+	if s.uds == nil {
+		return nil, fmt.Errorf("UDS not configured")
+	}
+	result := s.uds.peerCredentialQueries[query]
+	s.uds.peerCredentialQueries[query] = fn
+	return result, nil
+}
+
+func peerCredQueryUID(c UDSPeerCreds, v string) (bool, error) {
+	id, err := strconv.Atoi(v)
+	if err != nil {
+		return false, fmt.Errorf("invalid uid value %q: %w", v, err)
+	}
+	return c.UID == id, nil
+}
+
+func peerCredQueryGID(c UDSPeerCreds, v string) (bool, error) {
+	id, err := strconv.Atoi(v)
+	if err != nil {
+		return false, fmt.Errorf("invalid gid value %q: %w", v, err)
+	}
+	return c.GID == id, nil
+}
+
+func peerCredQueryPID(c UDSPeerCreds, v string) (bool, error) {
+	id, err := strconv.Atoi(v)
+	if err != nil {
+		return false, fmt.Errorf("invalid pid value %q: %w", v, err)
+	}
+	return c.PID == id, nil
+}

--- a/server/uds_auth_test.go
+++ b/server/uds_auth_test.go
@@ -1,0 +1,823 @@
+// Copyright 2020-2025 Michael Utech
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestUDS_Auth_MaybePeerCredPattern_Valid(t *testing.T) {
+	valid := []string{
+		"uid=", "gid=", "pid=",
+		"uid:", "gid:", "pid:",
+		"uid=1000", "gid=100", "pid=1234",
+		"uid:name=alice", "pid:exe=/bin/bash",
+		"uid!=0", "gid!=0",
+	}
+	for _, p := range valid {
+		if !maybePeerCredPattern(p) {
+			t.Errorf("expected true for %q", p)
+		}
+	}
+}
+
+func TestUDS_Auth_MaybePeerCredPattern_Invalid(t *testing.T) {
+	invalid := []string{
+		"", "u", "ui", "uid",
+		"xid=1", "uix=1", "uidx",
+		"UID=1", "Uid=1",
+		"user=alice", "group=wheel",
+	}
+	for _, p := range invalid {
+		if maybePeerCredPattern(p) {
+			t.Errorf("expected false for %q", p)
+		}
+	}
+}
+
+func TestUDS_Auth_ScanPeerCredToken_Basic(t *testing.T) {
+	tests := []struct {
+		pattern string
+		query   string
+		value   string
+		negated bool
+		length  int
+	}{
+		{"uid=1000", "uid", "1000", false, 8},
+		{"gid=100", "gid", "100", false, 7},
+		{"pid=1234", "pid", "1234", false, 8},
+		{"uid!=0", "uid", "0", true, 6},
+		{"uid:name=alice", "uid:name", "alice", false, 14},
+		{"pid:exe=/usr/bin/nats", "pid:exe", "/usr/bin/nats", false, 21},
+		{"uid=", "uid", "", false, 4},
+	}
+	for _, tc := range tests {
+		tok, err := scanPeerCredToken(tc.pattern, 0)
+		if err != nil {
+			t.Errorf("%q: unexpected error: %v", tc.pattern, err)
+			continue
+		}
+		if tok.query != tc.query {
+			t.Errorf("%q: query = %q, want %q", tc.pattern, tok.query, tc.query)
+		}
+		if tok.value != tc.value {
+			t.Errorf("%q: value = %q, want %q", tc.pattern, tok.value, tc.value)
+		}
+		if tok.negated != tc.negated {
+			t.Errorf("%q: negated = %v, want %v", tc.pattern, tok.negated, tc.negated)
+		}
+		if tok.length != tc.length {
+			t.Errorf("%q: length = %d, want %d", tc.pattern, tok.length, tc.length)
+		}
+	}
+}
+
+func TestUDS_Auth_ScanPeerCredToken_MultipleTokens(t *testing.T) {
+	pattern := "uid=1000,gid=100,pid!=1"
+
+	tok1, err := scanPeerCredToken(pattern, 0)
+	if err != nil {
+		t.Fatalf("token 1: %v", err)
+	}
+	if tok1.query != "uid" || tok1.value != "1000" || tok1.length != 8 {
+		t.Errorf("token 1: got {%s,%s,%d}", tok1.query, tok1.value, tok1.length)
+	}
+
+	tok2, err := scanPeerCredToken(pattern, 9)
+	if err != nil {
+		t.Fatalf("token 2: %v", err)
+	}
+	if tok2.query != "gid" || tok2.value != "100" || tok2.length != 7 {
+		t.Errorf("token 2: got {%s,%s,%d}", tok2.query, tok2.value, tok2.length)
+	}
+
+	tok3, err := scanPeerCredToken(pattern, 17)
+	if err != nil {
+		t.Fatalf("token 3: %v", err)
+	}
+	if tok3.query != "pid" || tok3.value != "1" || !tok3.negated || tok3.length != 6 {
+		t.Errorf("token 3: got {%s,%s,%v,%d}", tok3.query, tok3.value, tok3.negated, tok3.length)
+	}
+}
+
+func TestUDS_Auth_ScanPeerCredToken_LeadingSpaces(t *testing.T) {
+	tok, err := scanPeerCredToken("uid=1000, gid=100", 9)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok.query != "gid" || tok.value != "100" {
+		t.Errorf("got query=%q value=%q, want gid/100", tok.query, tok.value)
+	}
+
+	tok, err = scanPeerCredToken("uid=1000,   gid=100", 9)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok.query != "gid" {
+		t.Errorf("got query=%q, want gid", tok.query)
+	}
+}
+
+func TestUDS_Auth_ScanPeerCredToken_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		start   int
+	}{
+		{"StartOutOfBounds", "uid=1", 10},
+		{"StartAtEnd", "uid=1", 5},
+		{"MissingOperator", "uid", 0},
+		{"MissingOperatorComma", "uid,gid=1", 0},
+		{"BangWithoutEquals", "uid!1000", 0},
+		{"BangAtEnd", "uid!", 0},
+		{"EmptyPattern", "", 0},
+		{"TrailingSpaceInValue", "uid=1000 ", 0},
+		{"TrailingSpaceBeforeComma", "uid=1 , gid=2", 0},
+		{"LeadingSpaceInValue", "uid= 1000", 0},
+		{"TrailingTabInValue", "uid=1000\t", 0},
+		{"LeadingTabInValue", "uid=\t1000", 0},
+		{"TrailingNewlineInValue", "uid=1000\n", 0},
+		{"LeadingControlCharInValue", "uid=\x011000", 0},
+		{"TrailingSpacesAtEnd", "uid=1000, ", 9},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := scanPeerCredToken(tc.pattern, tc.start)
+			if err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func TestUDS_Auth_MatchPattern_EmptyPattern(t *testing.T) {
+	s := &Server{uds: &udsServerState{peerCredentialQueries: map[string]PeerCredQueryFunc{}}}
+	creds := UDSPeerCreds{UID: 1000, GID: 100, PID: 1234}
+
+	matched, err := s.udsPeerCredsMatchPattern(creds, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !matched {
+		t.Error("empty pattern should match (vacuous truth)")
+	}
+}
+
+func TestUDS_Auth_MatchPattern_SingleToken(t *testing.T) {
+	s := &Server{uds: &udsServerState{peerCredentialQueries: map[string]PeerCredQueryFunc{
+		"uid": func(c UDSPeerCreds, v string) (bool, error) {
+			return fmt.Sprintf("%d", c.UID) == v, nil
+		},
+	}}}
+	creds := UDSPeerCreds{UID: 1000, GID: 100, PID: 1234}
+
+	matched, err := s.udsPeerCredsMatchPattern(creds, "uid=1000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !matched {
+		t.Error("should match uid=1000")
+	}
+
+	matched, err = s.udsPeerCredsMatchPattern(creds, "uid=999")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matched {
+		t.Error("should not match uid=999")
+	}
+}
+
+func TestUDS_Auth_MatchPattern_Negation(t *testing.T) {
+	s := &Server{uds: &udsServerState{peerCredentialQueries: map[string]PeerCredQueryFunc{
+		"uid": func(c UDSPeerCreds, v string) (bool, error) {
+			return fmt.Sprintf("%d", c.UID) == v, nil
+		},
+	}}}
+	creds := UDSPeerCreds{UID: 1000, GID: 100, PID: 1234}
+
+	matched, err := s.udsPeerCredsMatchPattern(creds, "uid!=0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !matched {
+		t.Error("uid!=0 should match when UID=1000")
+	}
+
+	matched, err = s.udsPeerCredsMatchPattern(creds, "uid!=1000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matched {
+		t.Error("uid!=1000 should not match when UID=1000")
+	}
+}
+
+func TestUDS_Auth_MatchPattern_MultipleTokensAND(t *testing.T) {
+	s := &Server{uds: &udsServerState{peerCredentialQueries: map[string]PeerCredQueryFunc{
+		"uid": func(c UDSPeerCreds, v string) (bool, error) {
+			return fmt.Sprintf("%d", c.UID) == v, nil
+		},
+		"gid": func(c UDSPeerCreds, v string) (bool, error) {
+			return fmt.Sprintf("%d", c.GID) == v, nil
+		},
+	}}}
+	creds := UDSPeerCreds{UID: 1000, GID: 100, PID: 1234}
+
+	matched, err := s.udsPeerCredsMatchPattern(creds, "uid=1000,gid=100")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !matched {
+		t.Error("both conditions true, should match")
+	}
+
+	matched, err = s.udsPeerCredsMatchPattern(creds, "uid=1000,gid=999")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matched {
+		t.Error("second condition false, should not match")
+	}
+
+	matched, err = s.udsPeerCredsMatchPattern(creds, "uid=999,gid=100")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matched {
+		t.Error("first condition false, should not match")
+	}
+}
+
+func TestUDS_Auth_MatchPattern_UnknownQuery(t *testing.T) {
+	s := &Server{uds: &udsServerState{peerCredentialQueries: map[string]PeerCredQueryFunc{}}}
+	creds := UDSPeerCreds{UID: 1000, GID: 100, PID: 1234}
+
+	_, err := s.udsPeerCredsMatchPattern(creds, "uid=1000")
+	if err == nil {
+		t.Error("expected error for unknown query")
+	}
+}
+
+func TestUDS_Auth_MatchPattern_HandlerError(t *testing.T) {
+	s := &Server{uds: &udsServerState{peerCredentialQueries: map[string]PeerCredQueryFunc{
+		"uid": func(c UDSPeerCreds, v string) (bool, error) {
+			return false, fmt.Errorf("lookup failed")
+		},
+	}}}
+	creds := UDSPeerCreds{UID: 1000, GID: 100, PID: 1234}
+
+	_, err := s.udsPeerCredsMatchPattern(creds, "uid=1000")
+	if err == nil {
+		t.Error("expected error from handler")
+	}
+}
+
+func TestUDS_Auth_MatchPattern_InvalidPattern(t *testing.T) {
+	s := &Server{uds: &udsServerState{peerCredentialQueries: map[string]PeerCredQueryFunc{
+		"uid": func(c UDSPeerCreds, v string) (bool, error) { return true, nil },
+	}}}
+	creds := UDSPeerCreds{UID: 1000, GID: 100, PID: 1234}
+
+	invalid := []string{
+		"uid=1000,",
+		",uid=1000",
+		"uid=1000,,gid=100",
+		"uid",
+		"=1000",
+	}
+	for _, p := range invalid {
+		_, err := s.udsPeerCredsMatchPattern(creds, p)
+		if err == nil {
+			t.Errorf("%q: expected error", p)
+		}
+	}
+}
+
+func TestUDS_Auth_RegisterQuery(t *testing.T) {
+	uds, err := newUDSServerState(&Options{UDS: UDSOptions{Path: "/tmp/test.sock"}})
+	if err != nil {
+		t.Fatalf("newUDSServerState failed: %v", err)
+	}
+	s := &Server{uds: uds}
+
+	called := false
+	fn := func(c UDSPeerCreds, v string) (bool, error) {
+		called = true
+		return true, nil
+	}
+
+	prev, err := s.RegisterUDSPeerCredQuery("test", fn)
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	if prev != nil {
+		t.Error("expected nil previous handler")
+	}
+
+	if s.uds.peerCredentialQueries["test"] == nil {
+		t.Fatal("handler not registered")
+	}
+
+	s.uds.peerCredentialQueries["test"](UDSPeerCreds{}, "")
+	if !called {
+		t.Error("registered handler not called")
+	}
+}
+
+func TestUDS_Auth_RegisterQuery_Replace(t *testing.T) {
+	uds, err := newUDSServerState(&Options{UDS: UDSOptions{Path: "/tmp/test.sock"}})
+	if err != nil {
+		t.Fatalf("newUDSServerState failed: %v", err)
+	}
+	s := &Server{uds: uds}
+
+	fn1 := func(c UDSPeerCreds, v string) (bool, error) { return false, nil }
+	fn2 := func(c UDSPeerCreds, v string) (bool, error) { return true, nil }
+
+	s.RegisterUDSPeerCredQuery("test", fn1)
+	prev, _ := s.RegisterUDSPeerCredQuery("test", fn2)
+
+	if prev == nil {
+		t.Error("expected previous handler")
+	}
+
+	result, _ := s.uds.peerCredentialQueries["test"](UDSPeerCreds{}, "")
+	if !result {
+		t.Error("new handler should return true")
+	}
+}
+
+func TestUDS_Auth_RegisterQuery_NoUDS(t *testing.T) {
+	s := &Server{}
+
+	fn := func(c UDSPeerCreds, v string) (bool, error) { return true, nil }
+	_, err := s.RegisterUDSPeerCredQuery("test", fn)
+	if err == nil {
+		t.Error("expected error when UDS not configured")
+	}
+}
+
+func TestUDS_Auth_AuthenticatePeer_EmptyUsers(t *testing.T) {
+	result, err := udsAuthenticatePeer(map[string]*User{}, nil, UDSPeerCreds{UID: 1000})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.authenticated {
+		t.Error("expected not authenticated")
+	}
+}
+
+var defaultPeerCredQueries = map[string]PeerCredQueryFunc{
+	"uid": peerCredQueryUID,
+	"gid": peerCredQueryGID,
+	"pid": peerCredQueryPID,
+}
+
+func TestUDS_Auth_AuthenticatePeer_NoMatchingPattern(t *testing.T) {
+	users := map[string]*User{
+		"uid=2000": {
+			Username:               "uid=2000",
+			AllowedConnectionTypes: map[string]struct{}{ConnectionTypeUnix: {}},
+			Permissions:            &Permissions{Publish: &SubjectPermission{Allow: []string{">"}}},
+		},
+	}
+
+	result, err := udsAuthenticatePeer(users, defaultPeerCredQueries, UDSPeerCreds{UID: 1000})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.authenticated {
+		t.Error("expected not authenticated")
+	}
+}
+
+func TestUDS_Auth_AuthenticatePeer_NoAuthenticatingRule(t *testing.T) {
+	users := map[string]*User{
+		"uid=1000": {
+			Username:    "uid=1000",
+			Permissions: &Permissions{Publish: &SubjectPermission{Allow: []string{">"}}},
+		},
+	}
+
+	result, err := udsAuthenticatePeer(users, defaultPeerCredQueries, UDSPeerCreds{UID: 1000})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.authenticated {
+		t.Error("expected not authenticated")
+	}
+}
+
+func TestUDS_Auth_AuthenticatePeer_NoPermissionsDefined(t *testing.T) {
+	users := map[string]*User{
+		"uid=1000": {
+			Username:               "uid=1000",
+			AllowedConnectionTypes: map[string]struct{}{ConnectionTypeUnix: {}},
+		},
+	}
+
+	result, err := udsAuthenticatePeer(users, defaultPeerCredQueries, UDSPeerCreds{UID: 1000})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.authenticated {
+		t.Error("expected not authenticated")
+	}
+	if len(result.warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d", len(result.warnings))
+	}
+}
+
+func TestUDS_Auth_AuthenticatePeer_EmptyPermissions(t *testing.T) {
+	users := map[string]*User{
+		"uid=1000": {
+			Username:               "uid=1000",
+			AllowedConnectionTypes: map[string]struct{}{ConnectionTypeUnix: {}},
+			Permissions:            &Permissions{},
+		},
+	}
+
+	result, err := udsAuthenticatePeer(users, defaultPeerCredQueries, UDSPeerCreds{UID: 1000})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.authenticated {
+		t.Error("expected not authenticated")
+	}
+	if len(result.warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d", len(result.warnings))
+	}
+}
+
+func TestUDS_Auth_AuthenticatePeer_ConflictingAccounts(t *testing.T) {
+	users := map[string]*User{
+		"uid=1000": {Username: "uid=1000", Account: &Account{Name: "acc1"}},
+		"gid=1000": {Username: "gid=1000", Account: &Account{Name: "acc2"}},
+	}
+
+	_, err := udsAuthenticatePeer(users, defaultPeerCredQueries, UDSPeerCreds{UID: 1000, GID: 1000})
+	if err == nil {
+		t.Fatal("expected error for conflicting accounts")
+	}
+}
+
+func TestUDS_Auth_AuthenticatePeer_WithAccount(t *testing.T) {
+	acc := &Account{Name: "testaccount"}
+	users := map[string]*User{
+		"uid=1000": {
+			Username:    "uid=1000",
+			Account:     acc,
+			Permissions: &Permissions{Publish: &SubjectPermission{Allow: []string{"foo.>"}}},
+		},
+	}
+
+	result, err := udsAuthenticatePeer(users, defaultPeerCredQueries, UDSPeerCreds{UID: 1000})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.authenticated {
+		t.Fatal("expected authenticated")
+	}
+	if result.account != acc {
+		t.Error("expected account to be set")
+	}
+	if result.authenticatingRule != "uid=1000" {
+		t.Errorf("expected authenticatingRule 'uid=1000', got %q", result.authenticatingRule)
+	}
+}
+
+func TestUDS_Auth_AuthenticatePeer_WithConnectionType(t *testing.T) {
+	users := map[string]*User{
+		"uid=1000": {
+			Username:               "uid=1000",
+			AllowedConnectionTypes: map[string]struct{}{ConnectionTypeUnix: {}},
+			Permissions:            &Permissions{Subscribe: &SubjectPermission{Allow: []string{"events.>"}}},
+		},
+	}
+
+	result, err := udsAuthenticatePeer(users, defaultPeerCredQueries, UDSPeerCreds{UID: 1000})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.authenticated {
+		t.Fatal("expected authenticated")
+	}
+	if result.authenticatingRule != "uid=1000" {
+		t.Errorf("expected authenticatingRule 'uid=1000', got %q", result.authenticatingRule)
+	}
+}
+
+func TestUDS_Auth_AuthenticatePeer_PermissionsMerged(t *testing.T) {
+	users := map[string]*User{
+		"uid=1000": {
+			Username:               "uid=1000",
+			AllowedConnectionTypes: map[string]struct{}{ConnectionTypeUnix: {}},
+			Permissions:            &Permissions{Publish: &SubjectPermission{Allow: []string{"foo.>"}}},
+		},
+		"gid=1000": {
+			Username:    "gid=1000",
+			Permissions: &Permissions{Publish: &SubjectPermission{Allow: []string{"bar.>"}}},
+		},
+	}
+
+	result, err := udsAuthenticatePeer(users, defaultPeerCredQueries, UDSPeerCreds{UID: 1000, GID: 1000})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.authenticated {
+		t.Fatal("expected authenticated")
+	}
+	if len(result.permissions.Publish.Allow) != 2 {
+		t.Errorf("expected 2 publish allows, got %d", len(result.permissions.Publish.Allow))
+	}
+}
+
+func TestUDS_Auth_AuthenticatePeer_AccountRuleOverridesAuthRule(t *testing.T) {
+	users := map[string]*User{
+		"uid=1000": {
+			Username:               "uid=1000",
+			AllowedConnectionTypes: map[string]struct{}{ConnectionTypeUnix: {}},
+			Permissions:            &Permissions{Publish: &SubjectPermission{Allow: []string{"foo.>"}}},
+		},
+		"gid=1000": {
+			Username:    "gid=1000",
+			Account:     &Account{Name: "testaccount"},
+			Permissions: &Permissions{Publish: &SubjectPermission{Allow: []string{"bar.>"}}},
+		},
+	}
+
+	result, err := udsAuthenticatePeer(users, defaultPeerCredQueries, UDSPeerCreds{UID: 1000, GID: 1000})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.authenticated {
+		t.Fatal("expected authenticated")
+	}
+	if result.authenticatingRule != "gid=1000" {
+		t.Errorf("expected authenticatingRule 'gid=1000' (account rule), got %q", result.authenticatingRule)
+	}
+}
+
+func TestUDS_Auth_AuthenticatePeer_ResponsePermissionsMerged(t *testing.T) {
+	users := map[string]*User{
+		"uid=1000": {
+			Username:               "uid=1000",
+			AllowedConnectionTypes: map[string]struct{}{ConnectionTypeUnix: {}},
+			Permissions: &Permissions{
+				Publish:  &SubjectPermission{Allow: []string{"foo"}},
+				Response: &ResponsePermission{MaxMsgs: 5, Expires: 100},
+			},
+		},
+		"gid=1000": {
+			Username: "gid=1000",
+			Permissions: &Permissions{
+				Publish:  &SubjectPermission{Allow: []string{"bar"}},
+				Response: &ResponsePermission{MaxMsgs: 10, Expires: 50},
+			},
+		},
+	}
+
+	result, err := udsAuthenticatePeer(users, defaultPeerCredQueries, UDSPeerCreds{UID: 1000, GID: 1000})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.permissions.Response == nil {
+		t.Fatal("expected response permissions")
+	}
+	if result.permissions.Response.MaxMsgs != 10 {
+		t.Errorf("expected MaxMsgs 10 (max), got %d", result.permissions.Response.MaxMsgs)
+	}
+	if result.permissions.Response.Expires != 100 {
+		t.Errorf("expected Expires 100 (max), got %d", result.permissions.Response.Expires)
+	}
+}
+
+func TestUDS_Auth_AuthenticatePeer_DenyListsMerged(t *testing.T) {
+	users := map[string]*User{
+		"uid=1000": {
+			Username:               "uid=1000",
+			AllowedConnectionTypes: map[string]struct{}{ConnectionTypeUnix: {}},
+			Permissions: &Permissions{
+				Publish:   &SubjectPermission{Allow: []string{">"}, Deny: []string{"secret.>"}},
+				Subscribe: &SubjectPermission{Allow: []string{">"}, Deny: []string{"admin.>"}},
+			},
+		},
+		"gid=1000": {
+			Username: "gid=1000",
+			Permissions: &Permissions{
+				Publish:   &SubjectPermission{Deny: []string{"internal.>"}},
+				Subscribe: &SubjectPermission{Deny: []string{"system.>"}},
+			},
+		},
+	}
+
+	result, err := udsAuthenticatePeer(users, defaultPeerCredQueries, UDSPeerCreds{UID: 1000, GID: 1000})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.permissions.Publish.Deny) != 2 {
+		t.Errorf("expected 2 publish denies, got %d", len(result.permissions.Publish.Deny))
+	}
+	if len(result.permissions.Subscribe.Deny) != 2 {
+		t.Errorf("expected 2 subscribe denies, got %d", len(result.permissions.Subscribe.Deny))
+	}
+}
+
+func TestUDS_Auth_AuthenticatePeer_IdentityFormat(t *testing.T) {
+	users := map[string]*User{
+		"uid=1000": {
+			Username:               "uid=1000",
+			AllowedConnectionTypes: map[string]struct{}{ConnectionTypeUnix: {}},
+			Permissions:            &Permissions{Publish: &SubjectPermission{Allow: []string{">"}}},
+		},
+	}
+
+	result, err := udsAuthenticatePeer(users, defaultPeerCredQueries, UDSPeerCreds{UID: 1000, GID: 500, PID: 12345})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.identity != "uid=1000,gid=500,pid=12345" {
+		t.Errorf("unexpected identity format: %q", result.identity)
+	}
+}
+
+func TestUDS_Auth_AuthenticatePeer_MixedPubSubPermissions(t *testing.T) {
+	users := map[string]*User{
+		"uid=1000": {
+			Username:               "uid=1000",
+			AllowedConnectionTypes: map[string]struct{}{ConnectionTypeUnix: {}},
+			Permissions:            &Permissions{Publish: &SubjectPermission{Allow: []string{"pub.>"}}},
+		},
+		"gid=1000": {
+			Username:    "gid=1000",
+			Permissions: &Permissions{Subscribe: &SubjectPermission{Allow: []string{"sub.>"}}},
+		},
+	}
+
+	result, err := udsAuthenticatePeer(users, defaultPeerCredQueries, UDSPeerCreds{UID: 1000, GID: 1000})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.permissions.Publish.Allow) != 1 || result.permissions.Publish.Allow[0] != "pub.>" {
+		t.Errorf("unexpected publish allows: %v", result.permissions.Publish.Allow)
+	}
+	if len(result.permissions.Subscribe.Allow) != 1 || result.permissions.Subscribe.Allow[0] != "sub.>" {
+		t.Errorf("unexpected subscribe allows: %v", result.permissions.Subscribe.Allow)
+	}
+}
+
+func TestUDS_Auth_AuthenticatePeer_PatternError(t *testing.T) {
+	users := map[string]*User{
+		"uid=1000": {
+			Username:               "uid=1000",
+			AllowedConnectionTypes: map[string]struct{}{ConnectionTypeUnix: {}},
+			Permissions:            &Permissions{Publish: &SubjectPermission{Allow: []string{">"}}},
+		},
+	}
+
+	_, err := udsAuthenticatePeer(users, map[string]PeerCredQueryFunc{}, UDSPeerCreds{UID: 1000})
+	if err == nil {
+		t.Fatal("expected error for unknown query")
+	}
+}
+
+func TestUDS_Auth_QueryUID(t *testing.T) {
+	tests := []struct {
+		uid   int
+		value string
+		match bool
+		err   bool
+	}{
+		{1000, "1000", true, false},
+		{1000, "999", false, false},
+		{0, "0", true, false},
+		{1000, "abc", false, true},
+		{1000, "", false, true},
+	}
+	for _, tc := range tests {
+		creds := UDSPeerCreds{UID: tc.uid}
+		match, err := peerCredQueryUID(creds, tc.value)
+		if tc.err && err == nil {
+			t.Errorf("uid=%d value=%q: expected error", tc.uid, tc.value)
+		}
+		if !tc.err && err != nil {
+			t.Errorf("uid=%d value=%q: unexpected error: %v", tc.uid, tc.value, err)
+		}
+		if !tc.err && match != tc.match {
+			t.Errorf("uid=%d value=%q: match=%v, want %v", tc.uid, tc.value, match, tc.match)
+		}
+	}
+}
+
+func TestUDS_Auth_QueryGID(t *testing.T) {
+	tests := []struct {
+		gid   int
+		value string
+		match bool
+		err   bool
+	}{
+		{100, "100", true, false},
+		{100, "999", false, false},
+		{0, "0", true, false},
+		{100, "abc", false, true},
+	}
+	for _, tc := range tests {
+		creds := UDSPeerCreds{GID: tc.gid}
+		match, err := peerCredQueryGID(creds, tc.value)
+		if tc.err && err == nil {
+			t.Errorf("gid=%d value=%q: expected error", tc.gid, tc.value)
+		}
+		if !tc.err && err != nil {
+			t.Errorf("gid=%d value=%q: unexpected error: %v", tc.gid, tc.value, err)
+		}
+		if !tc.err && match != tc.match {
+			t.Errorf("gid=%d value=%q: match=%v, want %v", tc.gid, tc.value, match, tc.match)
+		}
+	}
+}
+
+func TestUDS_Auth_QueryPID(t *testing.T) {
+	tests := []struct {
+		pid   int
+		value string
+		match bool
+		err   bool
+	}{
+		{1234, "1234", true, false},
+		{1234, "999", false, false},
+		{1, "1", true, false},
+		{1234, "abc", false, true},
+	}
+	for _, tc := range tests {
+		creds := UDSPeerCreds{PID: tc.pid}
+		match, err := peerCredQueryPID(creds, tc.value)
+		if tc.err && err == nil {
+			t.Errorf("pid=%d value=%q: expected error", tc.pid, tc.value)
+		}
+		if !tc.err && err != nil {
+			t.Errorf("pid=%d value=%q: unexpected error: %v", tc.pid, tc.value, err)
+		}
+		if !tc.err && match != tc.match {
+			t.Errorf("pid=%d value=%q: match=%v, want %v", tc.pid, tc.value, match, tc.match)
+		}
+	}
+}
+
+func TestUDS_ParseUDSOption(t *testing.T) {
+	tests := []struct {
+		input   string
+		path    string
+		group   string
+		mode    string
+		wantErr bool
+	}{
+		// Valid cases
+		{"/tmp/nats.sock", "/tmp/nats.sock", "", "", false},
+		{"/tmp/nats.sock;group=nats", "/tmp/nats.sock", "nats", "", false},
+		{"/tmp/nats.sock;mode=0660", "/tmp/nats.sock", "", "0660", false},
+		{"/tmp/nats.sock;group=nats;mode=0660", "/tmp/nats.sock", "nats", "0660", false},
+		{"/tmp/nats.sock;mode=0660;group=nats", "/tmp/nats.sock", "nats", "0660", false},
+		{"/path/with spaces/sock;group=123", "/path/with spaces/sock", "123", "", false},
+		// Error cases
+		{"", "", "", "", true},                  // empty string
+		{";group=nats", "", "", "", true},       // empty path
+		{"/tmp/sock;invalid", "", "", "", true}, // missing =
+		{"/tmp/sock;foo=bar", "", "", "", true}, // unknown option
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			opts, err := ParseUDSOption(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error for input %q", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if opts.Path != tc.path {
+				t.Errorf("path: got %q, want %q", opts.Path, tc.path)
+			}
+			if opts.Group != tc.group {
+				t.Errorf("group: got %q, want %q", opts.Group, tc.group)
+			}
+			if opts.Mode != tc.mode {
+				t.Errorf("mode: got %q, want %q", opts.Mode, tc.mode)
+			}
+		})
+	}
+}

--- a/server/uds_linux.go
+++ b/server/uds_linux.go
@@ -1,0 +1,401 @@
+// Copyright 2020-2025 Michael Utech
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package server
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func (c *client) getUDSPeerCreds() (UDSPeerCreds, error) {
+	conn, ok := c.nc.(*net.UnixConn)
+	if !ok {
+		return UDSPeerCreds{UID: -1, GID: -1, PID: -1}, fmt.Errorf("connection is not a UNIX domain socket")
+	}
+
+	return getUDSPeerCreds(conn)
+}
+
+func getUDSPeerCreds(conn *net.UnixConn) (UDSPeerCreds, error) {
+	result := UDSPeerCreds{UID: -1, GID: -1, PID: -1}
+
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return result, err
+	}
+
+	// Avoid setting the connection to blocking mode via conn.File, use raw socket instead:
+	err = raw.Control(func(fd uintptr) {
+		ucred, callerr := syscall.GetsockoptUcred(int(fd), syscall.SOL_SOCKET, syscall.SO_PEERCRED)
+		if callerr != nil {
+			err = callerr
+			return
+		}
+		result = UDSPeerCreds{
+			UID: int(ucred.Uid),
+			GID: int(ucred.Gid),
+			PID: int(ucred.Pid),
+		}
+	})
+
+	return result, err
+}
+
+func (s *Server) UDSAcceptLoop(clr chan struct{}) {
+	// If we were to exit before the listener is setup properly,
+	// make sure we close the channel.
+	defer func() {
+		if clr != nil {
+			close(clr)
+		}
+	}()
+
+	if s.isShuttingDown() {
+		return
+	}
+
+	// Snapshot server options.
+	opts := s.getOpts()
+
+	if opts.UDS.Path == _EMPTY_ {
+		return
+	}
+
+	// Setup state that can enable shutdown
+	s.mu.Lock()
+	if s.uds == nil {
+		s.mu.Unlock()
+		return
+	}
+	path := s.uds.socket.path
+	if s.uds.listener == nil {
+		s.uds.listener, s.uds.listenerErr = natsListen("unix", path)
+		if s.uds.listenerErr != nil {
+			conn, dialErr := net.Dial("unix", path)
+			if dialErr == nil {
+				defer conn.Close()
+
+				// Socket is active - someone else is using it
+				unixConn := conn.(*net.UnixConn)
+				creds, credErr := getUDSPeerCreds(unixConn)
+				s.mu.Unlock()
+				if credErr != nil {
+					s.Fatalf("UNIX domain socket %s in use, PID not available: %v", path, credErr)
+					return
+				}
+				s.Fatalf("UNIX domain socket %s already in use by PID %d (UID %d)", path, creds.PID, creds.UID)
+				return
+			}
+			// Dial failed - socket is stale, remove and retry
+			s.Noticef("UNIX domain socket %s appears stale, removing...", path)
+			os.Remove(path)
+			s.uds.listener, s.uds.listenerErr = natsListen("unix", path)
+		}
+	}
+	if s.uds.listenerErr != nil {
+		s.mu.Unlock()
+		s.Fatalf("Error listening on UNIX domain socket: %s, %q", path, s.uds.listenerErr)
+		return
+	}
+
+	// Apply socket permissions if configured
+	if err := applyUdsPermissions(s.uds.listener, path, s.uds.socket.gid, s.uds.socket.mode); err != nil {
+		s.mu.Unlock()
+		s.Fatalf("Error setting UNIX domain socket permissions: %v", err)
+		return
+	}
+
+	s.Noticef("Listening for client connections on UNIX domain socket %s", path)
+
+	// Alert if PROXY protocol is enabled
+	if opts.ProxyProtocol {
+		s.Noticef("PROXY protocol enabled for client connections")
+	}
+
+	// Alert of TLS enabled.
+	if opts.TLSConfig != nil {
+		s.Noticef("TLS required for client connections")
+		if opts.TLSHandshakeFirst && opts.TLSHandshakeFirstFallback == 0 {
+			s.Warnf("Clients that are not using \"TLS Handshake First\" option will fail to connect")
+		}
+	}
+
+	s.info.UDS = []UDSInfo{{Path: path}}
+
+	// We do not advertize UDS sockets since they are not remotely available and clients connected
+	// via UDS already know the path. Advertizing local UDS to remote is useless and might break clients.
+
+	go s.acceptConnections(s.uds.listener, "Client",
+		func(conn net.Conn) {
+			s.createClient(conn)
+			// TODO: perform UDS specific initialization, either here or in createClient()
+		},
+		func(_ error) bool {
+			if s.isLameDuckMode() {
+				// Signal that we are not accepting new clients
+				s.ldmCh <- true
+				// Now wait for the Shutdown...
+				<-s.quitCh
+				return true
+			}
+			return false
+		})
+	s.mu.Unlock()
+
+	// Let the caller know that we are ready
+	if clr != nil {
+		close(clr)
+	}
+	clr = nil
+}
+
+// peerCredQueryUIDName looks up peer's UID and compares username with value.
+// Returns true if username equals value. If UID has no passwd entry, username is empty.
+func peerCredQueryUIDName(c UDSPeerCreds, v string) (bool, error) {
+	u, err := user.LookupId(strconv.Itoa(c.UID))
+	if err != nil {
+		var unknownUID user.UnknownUserIdError
+		if errors.As(err, &unknownUID) {
+			// No passwd entry for this UID - treat as empty username
+			return v == "", nil
+		}
+		return false, fmt.Errorf("user lookup for uid %d: %w", c.UID, err)
+	}
+	return u.Username == v, nil
+}
+
+// peerCredQueryGIDName looks up peer's GID and compares group name with value.
+// Returns true if group name equals value. If GID has no group entry, name is empty.
+func peerCredQueryGIDName(c UDSPeerCreds, v string) (bool, error) {
+	g, err := user.LookupGroupId(strconv.Itoa(c.GID))
+	if err != nil {
+		var unknownGID user.UnknownGroupIdError
+		if errors.As(err, &unknownGID) {
+			// No group entry for this GID - treat as empty name
+			return v == "", nil
+		}
+		return false, fmt.Errorf("group lookup for gid %d: %w", c.GID, err)
+	}
+	return g.Name == v, nil
+}
+
+// getProcessSupplementalGroups reads supplemental groups from /proc/<pid>/status.
+func getProcessSupplementalGroups(pid int) ([]int, error) {
+	if pid <= 0 {
+		return nil, fmt.Errorf("invalid pid %d", pid)
+	}
+	f, err := os.Open(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		return nil, fmt.Errorf("open /proc/%d/status: %w", pid, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "Groups:") {
+			fields := strings.Fields(line[7:])
+			groups := make([]int, 0, len(fields))
+			for _, field := range fields {
+				gid, err := strconv.Atoi(field)
+				if err != nil {
+					return nil, fmt.Errorf("invalid gid %q in /proc/%d/status: %w", field, pid, err)
+				}
+				groups = append(groups, gid)
+			}
+			return groups, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read /proc/%d/status: %w", pid, err)
+	}
+	return nil, fmt.Errorf("/proc/%d/status: Groups line not found", pid)
+}
+
+// peerCredQueryPIDGID matches GID against process supplemental groups.
+func peerCredQueryPIDGID(c UDSPeerCreds, v string) (bool, error) {
+	gid, err := strconv.Atoi(v)
+	if err != nil {
+		return false, fmt.Errorf("invalid gid value %q: %w", v, err)
+	}
+	groups, err := getProcessSupplementalGroups(c.PID)
+	if err != nil {
+		return false, err
+	}
+	for _, g := range groups {
+		if g == gid {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// peerCredQueryPIDGIDName matches group name against process supplemental groups.
+func peerCredQueryPIDGIDName(c UDSPeerCreds, v string) (bool, error) {
+	g, err := user.LookupGroup(v)
+	if err != nil {
+		return false, fmt.Errorf("group lookup %q: %w", v, err)
+	}
+	gid, err := strconv.Atoi(g.Gid)
+	if err != nil {
+		return false, fmt.Errorf("invalid gid from lookup %q: %w", g.Gid, err)
+	}
+	groups, err := getProcessSupplementalGroups(c.PID)
+	if err != nil {
+		return false, err
+	}
+	for _, grp := range groups {
+		if grp == gid {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// applyUdsPermissions sets group ownership and mode on the socket file.
+// Also drains and closes any connections that may have been accepted during
+// the race window between listen() and permission application.
+func applyUdsPermissions(listener net.Listener, path string, gid, mode int) error {
+	// Apply permissions first
+	if gid >= 0 {
+		if err := os.Chown(path, -1, gid); err != nil {
+			return fmt.Errorf("chown %s: %w", path, err)
+		}
+	}
+	if mode >= 0 {
+		if err := os.Chmod(path, os.FileMode(mode)); err != nil {
+			return fmt.Errorf("chmod %s: %w", path, err)
+		}
+	}
+
+	// Drain any connections that snuck in during the race window
+	if gid >= 0 || mode >= 0 {
+		unixListener := listener.(*net.UnixListener)
+		unixListener.SetDeadline(time.Now())
+		for {
+			conn, err := unixListener.Accept()
+			if err != nil {
+				break // No more pending connections (or deadline hit)
+			}
+			conn.Close() // Reject connection from race window
+		}
+		unixListener.SetDeadline(time.Time{}) // Clear deadline
+	}
+
+	return nil
+}
+
+// newDefaultPeerCredQueries returns the default peer credential query handlers.
+func newDefaultPeerCredQueries() map[string]PeerCredQueryFunc {
+	return map[string]PeerCredQueryFunc{
+		"uid":          peerCredQueryUID,
+		"gid":          peerCredQueryGID,
+		"pid":          peerCredQueryPID,
+		"uid:name":     peerCredQueryUIDName,
+		"gid:name":     peerCredQueryGIDName,
+		"pid:gid":      peerCredQueryPIDGID,
+		"pid:gid:name": peerCredQueryPIDGIDName,
+	}
+}
+
+// newUDSServerState creates UDS server state from options.
+// Returns nil, nil if UDS is not configured.
+func newUDSServerState(opts *Options) (*udsServerState, error) {
+	if opts.UDS.Path == _EMPTY_ {
+		return nil, nil
+	}
+	spec, err := newUdsSocketSpec(opts.UDS.Path, opts.UDS.Group, opts.UDS.Mode)
+	if err != nil {
+		return nil, fmt.Errorf("UDS configuration error: %w", err)
+	}
+	return &udsServerState{
+		socket:                spec,
+		peerCredentialQueries: newDefaultPeerCredQueries(),
+	}, nil
+}
+
+// newUdsSocketSpec creates a validated udsSocketSpec from raw config values.
+// path required to be absolute and canonical (no .., //, etc.), group and mode are optional (empty string = no change after listen).
+func newUdsSocketSpec(path, group, mode string) (udsSocketSpec, error) {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return udsSocketSpec{}, fmt.Errorf("invalid path '%s', expect canonical absolute path", path)
+	}
+
+	spec := udsSocketSpec{
+		path: path,
+		gid:  -1,
+		mode: -1,
+	}
+
+	if mode != "" {
+		m, err := parseFileMode(mode)
+		if err != nil {
+			return udsSocketSpec{}, err
+		}
+		spec.mode = int(m)
+	}
+
+	if group != "" {
+		// Try numeric GID first
+		if gid, err := strconv.Atoi(group); err == nil {
+			if gid < 0 {
+				return udsSocketSpec{}, fmt.Errorf("invalid group '%s': negative ID", group)
+			}
+			spec.gid = gid
+		} else {
+			// Fall back to group name lookup
+			g, err := user.LookupGroup(group)
+			if err != nil {
+				return udsSocketSpec{}, fmt.Errorf("invalid group '%s': %w", group, err)
+			}
+			gid, err := strconv.Atoi(g.Gid)
+			if err != nil {
+				return udsSocketSpec{}, fmt.Errorf("invalid group '%s'.Gid: '%s': %w", group, g.Gid, err)
+			}
+			spec.gid = gid
+		}
+	}
+
+	return spec, nil
+}
+
+// parseFileMode parses a 4-digit octal mode string (e.g. "0660") to os.FileMode.
+func parseFileMode(s string) (os.FileMode, error) {
+	if len(s) != 4 || s[0] != '0' {
+		return 0, fmt.Errorf("invalid file mode '%s', expected 4 digit octal (e.g. 0660)", s)
+	}
+	var m os.FileMode
+	for i := 1; i < 4; i++ {
+		d := s[i] - '0'
+		if d > 7 {
+			return 0, fmt.Errorf("invalid file mode '%s', expected 4 digit octal (e.g. 0660)", s)
+		}
+		m = m<<3 | os.FileMode(d)
+	}
+	if m > 0o777 {
+		panic("Contract violation: investigate parseFileMode")
+	}
+	return m, nil
+}

--- a/server/uds_linux_test.go
+++ b/server/uds_linux_test.go
@@ -1,0 +1,608 @@
+// Copyright 2020-2025 Michael Utech
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestUDS_Auth_QueryUIDName(t *testing.T) {
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Skipf("current user not available: %v", err)
+	}
+	uid, _ := strconv.Atoi(currentUser.Uid)
+
+	// Match current user by name
+	match, err := peerCredQueryUIDName(UDSPeerCreds{UID: uid}, currentUser.Username)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !match {
+		t.Errorf("expected match for current user %q", currentUser.Username)
+	}
+
+	// No match for different UID (non-existent UID returns empty username)
+	match, err = peerCredQueryUIDName(UDSPeerCreds{UID: uid + 99999}, currentUser.Username)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if match {
+		t.Error("expected no match for different UID")
+	}
+
+	// Non-existent UID matches empty string
+	match, err = peerCredQueryUIDName(UDSPeerCreds{UID: uid + 99999}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !match {
+		t.Error("expected non-existent UID to match empty string")
+	}
+
+	// Existing UID does not match different username
+	match, err = peerCredQueryUIDName(UDSPeerCreds{UID: uid}, "nonexistent_user_12345")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if match {
+		t.Error("expected no match for different username")
+	}
+}
+
+func TestUDS_Auth_QueryGIDName(t *testing.T) {
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Skipf("current user not available: %v", err)
+	}
+	gid, _ := strconv.Atoi(currentUser.Gid)
+
+	// Look up the group name for the current user's primary GID
+	group, err := user.LookupGroupId(currentUser.Gid)
+	if err != nil {
+		t.Skipf("current group not available: %v", err)
+	}
+
+	// Match current group by name
+	match, err := peerCredQueryGIDName(UDSPeerCreds{GID: gid}, group.Name)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !match {
+		t.Errorf("expected match for current group %q", group.Name)
+	}
+
+	// No match for different GID (non-existent GID returns empty name)
+	match, err = peerCredQueryGIDName(UDSPeerCreds{GID: gid + 99999}, group.Name)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if match {
+		t.Error("expected no match for different GID")
+	}
+
+	// Non-existent GID matches empty string
+	match, err = peerCredQueryGIDName(UDSPeerCreds{GID: gid + 99999}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !match {
+		t.Error("expected non-existent GID to match empty string")
+	}
+
+	// Existing GID does not match different group name
+	match, err = peerCredQueryGIDName(UDSPeerCreds{GID: gid}, "nonexistent_group_12345")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if match {
+		t.Error("expected no match for different group name")
+	}
+}
+
+func TestUDS_Auth_GetProcessSupplementalGroups(t *testing.T) {
+	pid := os.Getpid()
+
+	groups, err := getProcessSupplementalGroups(pid)
+	if err != nil {
+		t.Fatalf("failed to get supplemental groups: %v", err)
+	}
+
+	// Should have at least zero groups (empty is valid)
+	if groups == nil {
+		t.Error("expected non-nil groups slice")
+	}
+
+	// Test with invalid PID
+	_, err = getProcessSupplementalGroups(0)
+	if err == nil {
+		t.Error("expected error for PID 0")
+	}
+
+	_, err = getProcessSupplementalGroups(-1)
+	if err == nil {
+		t.Error("expected error for negative PID")
+	}
+
+	// Test with non-existent PID (very high number)
+	_, err = getProcessSupplementalGroups(999999999)
+	if err == nil {
+		t.Error("expected error for non-existent PID")
+	}
+}
+
+func TestUDS_Auth_QueryPIDGID(t *testing.T) {
+	pid := os.Getpid()
+
+	groups, err := getProcessSupplementalGroups(pid)
+	if err != nil {
+		t.Fatalf("failed to get supplemental groups: %v", err)
+	}
+
+	if len(groups) > 0 {
+		// Match a supplemental group
+		gidStr := strconv.Itoa(groups[0])
+		match, err := peerCredQueryPIDGID(UDSPeerCreds{PID: pid}, gidStr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !match {
+			t.Errorf("expected match for supplemental group %s", gidStr)
+		}
+	}
+
+	// No match for non-existent group (very high number)
+	match, err := peerCredQueryPIDGID(UDSPeerCreds{PID: pid}, "999999999")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if match {
+		t.Error("expected no match for non-existent supplemental group")
+	}
+
+	// Error for invalid GID value
+	_, err = peerCredQueryPIDGID(UDSPeerCreds{PID: pid}, "abc")
+	if err == nil {
+		t.Error("expected error for invalid GID value")
+	}
+
+	// Error for invalid PID
+	_, err = peerCredQueryPIDGID(UDSPeerCreds{PID: -1}, "1000")
+	if err == nil {
+		t.Error("expected error for invalid PID")
+	}
+}
+
+func TestUDS_Auth_QueryPIDGIDName(t *testing.T) {
+	pid := os.Getpid()
+
+	groups, err := getProcessSupplementalGroups(pid)
+	if err != nil {
+		t.Fatalf("failed to get supplemental groups: %v", err)
+	}
+
+	if len(groups) > 0 {
+		// Look up the group name
+		group, err := user.LookupGroupId(strconv.Itoa(groups[0]))
+		if err != nil {
+			t.Skipf("could not lookup group %d: %v", groups[0], err)
+		}
+
+		// Match by group name
+		match, err := peerCredQueryPIDGIDName(UDSPeerCreds{PID: pid}, group.Name)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !match {
+			t.Errorf("expected match for supplemental group %q", group.Name)
+		}
+	}
+
+	// Error for non-existent group name
+	_, err = peerCredQueryPIDGIDName(UDSPeerCreds{PID: pid}, "nonexistent_group_12345")
+	if err == nil {
+		t.Error("expected error for non-existent group")
+	}
+
+	// Error for invalid PID
+	_, err = peerCredQueryPIDGIDName(UDSPeerCreds{PID: -1}, "root")
+	if err == nil {
+		t.Error("expected error for invalid PID")
+	}
+}
+
+// TestUDSAuth_PeerCredAuth_Integration tests the full UDS peer credential
+// authentication flow: server with UDS + peer cred users, client connects,
+// auth succeeds based on UID.
+func TestUDS_Auth_PeerCredAuth_Integration(t *testing.T) {
+	// Get current UID for the peer cred pattern
+	uid := os.Getuid()
+	uidPattern := fmt.Sprintf("uid=%d", uid)
+
+	// Create temp socket path
+	tmpDir := t.TempDir()
+	sockPath := filepath.Join(tmpDir, "nats.sock")
+
+	// Configure server with UDS and peer credential user
+	opts := &Options{
+		Host:       "127.0.0.1",
+		Port:       -1,
+		DontListen: true, // no TCP
+		UDS:        UDSOptions{Path: sockPath},
+		NoLog:      true,
+		NoSigs:     true,
+		Users: []*User{
+			{
+				Username:               uidPattern,
+				AllowedConnectionTypes: map[string]struct{}{ConnectionTypeUnix: {}},
+				Permissions: &Permissions{
+					Publish:   &SubjectPermission{Allow: []string{"test.>"}, Deny: []string{"test.deny.>"}},
+					Subscribe: &SubjectPermission{Allow: []string{"test.>"}},
+				},
+			},
+		},
+	}
+
+	s, err := NewServer(opts)
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+
+	s.Start()
+	defer s.Shutdown()
+
+	// Wait for UDS listener to be ready
+	if err := s.readyForConnections(5 * time.Second); err != nil {
+		t.Fatalf("server not ready: %v", err)
+	}
+
+	// Connect via UDS
+	conn, err := net.DialTimeout("unix", sockPath, 3*time.Second)
+	if err != nil {
+		t.Fatalf("failed to connect to UDS: %v", err)
+	}
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+
+	// Read INFO
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to read INFO: %v", err)
+	}
+	if !strings.HasPrefix(line, "INFO ") {
+		t.Fatalf("expected INFO, got: %q", line)
+	}
+
+	// Send CONNECT (no user/pass - peer cred auth)
+	_, err = conn.Write([]byte("CONNECT {\"verbose\":false,\"pedantic\":false}\r\n"))
+	if err != nil {
+		t.Fatalf("failed to send CONNECT: %v", err)
+	}
+
+	// Send PING
+	_, err = conn.Write([]byte("PING\r\n"))
+	if err != nil {
+		t.Fatalf("failed to send PING: %v", err)
+	}
+
+	// Read response - should be PONG (auth success) or -ERR (auth failure)
+	line, err = reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+
+	if strings.HasPrefix(line, "-ERR") {
+		t.Fatalf("authentication failed: %s", strings.TrimSpace(line))
+	}
+	if !strings.HasPrefix(line, "PONG") {
+		t.Fatalf("expected PONG, got: %q", line)
+	}
+
+	// Test publish permission - should succeed for allowed subject
+	_, err = conn.Write([]byte("PUB test.foo 5\r\nhello\r\n"))
+	if err != nil {
+		t.Fatalf("failed to send PUB: %v", err)
+	}
+
+	// Send another PING to flush and check for errors
+	_, err = conn.Write([]byte("PING\r\n"))
+	if err != nil {
+		t.Fatalf("failed to send PING: %v", err)
+	}
+
+	line, err = reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+	if strings.HasPrefix(line, "-ERR") {
+		t.Fatalf("publish to allowed subject failed: %s", strings.TrimSpace(line))
+	}
+	if !strings.HasPrefix(line, "PONG") {
+		t.Fatalf("expected PONG after publish, got: %q", line)
+	}
+
+	// Test publish to denied subject - should get permission error
+	_, err = conn.Write([]byte("PUB denied.foo 5\r\nhello\r\n"))
+	if err != nil {
+		t.Fatalf("failed to send PUB: %v", err)
+	}
+
+	// Read error for denied publish
+	line, err = reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+	if !strings.Contains(line, "Permissions Violation") {
+		t.Fatalf("expected permission violation for denied subject, got: %q", line)
+	}
+
+	// Test publish to explicitly denied subject (deny overrides allow)
+	_, err = conn.Write([]byte("PUB test.deny.foo 5\r\nhello\r\n"))
+	if err != nil {
+		t.Fatalf("failed to send PUB: %v", err)
+	}
+
+	line, err = reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+	if !strings.Contains(line, "Permissions Violation") {
+		t.Fatalf("expected permission violation for explicitly denied subject, got: %q", line)
+	}
+}
+
+func TestUDS_NewSocketSpec(t *testing.T) {
+	// Get root group for name lookup test (always exists)
+	rootGroup, err := user.LookupGroupId("0")
+	if err != nil {
+		t.Fatalf("cannot lookup gid 0: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		group   string
+		mode    string
+		wantGid int
+		wantErr bool
+		errMsg  string // substring to check in error
+	}{
+		// Valid cases - defaults
+		{"valid path only", "/var/run/nats.sock", "", "", -1, false, ""},
+		{"valid with mode", "/var/run/nats.sock", "", "0660", -1, false, ""},
+
+		// Valid cases - group by numeric GID (Atoi path)
+		{"numeric gid", "/var/run/nats.sock", "1000", "", 1000, false, ""},
+		{"numeric gid 0", "/var/run/nats.sock", "0", "", 0, false, ""},
+
+		// Valid cases - group by name (lookup path)
+		{"group name lookup", "/var/run/nats.sock", rootGroup.Name, "", 0, false, ""},
+
+		// Path attack vectors
+		{"empty path", "", "", "", -1, true, "expect canonical absolute path"},
+		{"relative path", "var/run/nats.sock", "", "", -1, true, "expect canonical absolute path"},
+		{"dot relative", "./nats.sock", "", "", -1, true, "expect canonical absolute path"},
+		{"parent traversal", "/var/run/../nats.sock", "", "", -1, true, "expect canonical absolute path"},
+		{"double slash", "/var//run/nats.sock", "", "", -1, true, "expect canonical absolute path"},
+		{"trailing slash", "/var/run/nats.sock/", "", "", -1, true, "expect canonical absolute path"},
+		{"dot in path", "/var/run/./nats.sock", "", "", -1, true, "expect canonical absolute path"},
+		{"double dot end", "/var/run/nats.sock/..", "", "", -1, true, "expect canonical absolute path"},
+		{"just slash", "/", "", "", -1, false, ""}, // technically valid, will fail at listen
+
+		// Mode validation (parseFileMode tests cover details, verify integration)
+		{"invalid mode format", "/var/run/nats.sock", "", "666", -1, true, "invalid file mode"},
+		{"invalid mode octal", "/var/run/nats.sock", "", "0888", -1, true, "invalid file mode"},
+
+		// Group validation - errors
+		{"nonexistent group name", "/var/run/nats.sock", "nonexistent_group_xyz_12345", "", -1, true, "invalid group"},
+		{"negative gid", "/var/run/nats.sock", "-1", "", -1, true, "negative ID"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, err := newUdsSocketSpec(tt.path, tt.group, tt.mode)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newUdsSocketSpec(%q, %q, %q) error = %v, wantErr %v",
+					tt.path, tt.group, tt.mode, err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.errMsg)
+			}
+			if !tt.wantErr {
+				if spec.path != tt.path {
+					t.Errorf("spec.path = %q, want %q", spec.path, tt.path)
+				}
+				if spec.gid != tt.wantGid {
+					t.Errorf("spec.gid = %d, want %d", spec.gid, tt.wantGid)
+				}
+			}
+		})
+	}
+}
+
+func TestUDS_ParseFileMode(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    os.FileMode
+		wantErr bool
+	}{
+		// Valid modes
+		{"0000", 0o000, false},
+		{"0600", 0o600, false},
+		{"0644", 0o644, false},
+		{"0660", 0o660, false},
+		{"0700", 0o700, false},
+		{"0755", 0o755, false},
+		{"0777", 0o777, false},
+
+		// Wrong length
+		{"", 0, true},
+		{"0", 0, true},
+		{"00", 0, true},
+		{"000", 0, true},
+		{"00000", 0, true},
+		{"07777", 0, true},
+
+		// Wrong first char
+		{"1777", 0, true},
+		{"a777", 0, true},
+		{" 777", 0, true},
+
+		// Invalid octal digit in position 1
+		{"0800", 0, true},
+		{"0900", 0, true},
+		{"0a00", 0, true},
+
+		// Invalid octal digit in position 2
+		{"0080", 0, true},
+		{"0090", 0, true},
+		{"00a0", 0, true},
+
+		// Invalid octal digit in position 3
+		{"0008", 0, true},
+		{"0009", 0, true},
+		{"000a", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseFileMode(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseFileMode(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseFileMode(%q) = %o, want %o", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUDS_CLI_Option(t *testing.T) {
+	defer func() { FlagSnapshot = nil }()
+
+	// Helper to parse CLI args and return options
+	mustNotFail := func(args []string) *Options {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		opts, err := ConfigureOptions(fs, args, PrintServerAndExit, fs.Usage, PrintTLSHelpAndDie)
+		if err != nil {
+			t.Fatalf("Error on configure: %v", err)
+		}
+		return opts
+	}
+
+	// Helper to expect failure
+	expectToFail := func(args []string) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fs.SetOutput(&bytes.Buffer{}) // silence errors
+		opts, err := ConfigureOptions(fs, args, PrintServerAndExit, fs.Usage, PrintTLSHelpAndDie)
+		if opts != nil || err == nil {
+			t.Fatalf("Expected error for args %v, got opts=%v err=%v", args, opts, err)
+		}
+	}
+
+	// Basic path only
+	opts := mustNotFail([]string{"--uds", "/tmp/nats.sock"})
+	if opts.UDS.Path != "/tmp/nats.sock" {
+		t.Fatalf("Expected path /tmp/nats.sock, got %q", opts.UDS.Path)
+	}
+
+	// Path with group
+	opts = mustNotFail([]string{"--uds", "/tmp/nats.sock;group=nats"})
+	if opts.UDS.Path != "/tmp/nats.sock" || opts.UDS.Group != "nats" {
+		t.Fatalf("Expected path=/tmp/nats.sock group=nats, got path=%q group=%q", opts.UDS.Path, opts.UDS.Group)
+	}
+
+	// Path with mode
+	opts = mustNotFail([]string{"--uds", "/tmp/nats.sock;mode=0660"})
+	if opts.UDS.Path != "/tmp/nats.sock" || opts.UDS.Mode != "0660" {
+		t.Fatalf("Expected path=/tmp/nats.sock mode=0660, got path=%q mode=%q", opts.UDS.Path, opts.UDS.Mode)
+	}
+
+	// Path with group and mode
+	opts = mustNotFail([]string{"--uds", "/tmp/nats.sock;group=nats;mode=0660"})
+	if opts.UDS.Path != "/tmp/nats.sock" || opts.UDS.Group != "nats" || opts.UDS.Mode != "0660" {
+		t.Fatalf("Expected path=/tmp/nats.sock group=nats mode=0660, got path=%q group=%q mode=%q",
+			opts.UDS.Path, opts.UDS.Group, opts.UDS.Mode)
+	}
+
+	// Empty value should fail
+	expectToFail([]string{"--uds", ""})
+
+	// Missing path should fail
+	expectToFail([]string{"--uds", ";group=nats"})
+}
+
+func TestUDS_Config_Block(t *testing.T) {
+	// Create temp config file with uds block
+	conf := `
+		uds {
+			path: "/tmp/nats.sock"
+			group: "nats"
+			mode: "0660"
+		}
+	`
+	confFile := filepath.Join(t.TempDir(), "test.conf")
+	if err := os.WriteFile(confFile, []byte(conf), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	opts, err := ProcessConfigFile(confFile)
+	if err != nil {
+		t.Fatalf("Error processing config: %v", err)
+	}
+
+	if opts.UDS.Path != "/tmp/nats.sock" {
+		t.Errorf("Expected path /tmp/nats.sock, got %q", opts.UDS.Path)
+	}
+	if opts.UDS.Group != "nats" {
+		t.Errorf("Expected group nats, got %q", opts.UDS.Group)
+	}
+	if opts.UDS.Mode != "0660" {
+		t.Errorf("Expected mode 0660, got %q", opts.UDS.Mode)
+	}
+}
+
+func TestUDS_Config_PathOnly(t *testing.T) {
+	// Test path-only config (no group/mode)
+	conf := `uds { path: "/tmp/nats.sock" }`
+	confFile := filepath.Join(t.TempDir(), "test.conf")
+	if err := os.WriteFile(confFile, []byte(conf), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	opts, err := ProcessConfigFile(confFile)
+	if err != nil {
+		t.Fatalf("Error processing config: %v", err)
+	}
+
+	if opts.UDS.Path != "/tmp/nats.sock" {
+		t.Errorf("Expected path /tmp/nats.sock, got %q", opts.UDS.Path)
+	}
+}

--- a/server/uds_unsupported.go
+++ b/server/uds_unsupported.go
@@ -1,0 +1,88 @@
+// Copyright 2020-2025 Michael Utech
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+// TODO: check build/test on platforms other than Linux
+
+package server
+
+import (
+	"fmt"
+	"os"
+)
+
+func (c *client) getUDSPeerCreds() (UDSPeerCreds, error) {
+	result := UDSPeerCreds{UID: -1, GID: -1, PID: -1}
+
+	return result, fmt.Errorf("UNIX domain peer credentials not supported")
+}
+
+func (s *Server) UDSAcceptLoop(clr chan struct{}) {
+	// If we were to exit before the listener is setup properly,
+	// make sure we close the channel.
+	defer func() {
+		if clr != nil {
+			close(clr)
+		}
+	}()
+
+	if s.isShuttingDown() {
+		return
+	}
+
+	// Snapshot server options.
+	opts := s.getOpts()
+
+	if opts.UDS.Path != _EMPTY_ {
+		s.Warnf("UNIX domain sockets are only supported on Linux")
+	}
+	return
+}
+
+var errUnsupportedPlatform = fmt.Errorf("not supported on this platform")
+
+func peerCredQueryUIDName(c UDSPeerCreds, v string) (bool, error) {
+	return false, errUnsupportedPlatform
+}
+
+func peerCredQueryGIDName(c UDSPeerCreds, v string) (bool, error) {
+	return false, errUnsupportedPlatform
+}
+
+func peerCredQueryPIDGID(c UDSPeerCreds, v string) (bool, error) {
+	return false, errUnsupportedPlatform
+}
+
+func peerCredQueryPIDGIDName(c UDSPeerCreds, v string) (bool, error) {
+	return false, errUnsupportedPlatform
+}
+
+func parseFileMode(s string) (os.FileMode, error) {
+	return 0, errUnsupportedPlatform
+}
+
+func newUdsSocketSpec(path, group, mode string) (udsSocketSpec, error) {
+	return udsSocketSpec{}, errUnsupportedPlatform
+}
+
+func newDefaultPeerCredQueries() map[string]PeerCredQueryFunc {
+	return nil
+}
+
+func newUDSServerState(opts *Options) (*udsServerState, error) {
+	if opts.UDS.Path != _EMPTY_ {
+		return nil, fmt.Errorf("UDS not supported on this platform")
+	}
+	return nil, nil
+}

--- a/test/bench_transport_test.go
+++ b/test/bench_transport_test.go
@@ -1,0 +1,229 @@
+package test
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+)
+
+type dialFunc func() (net.Conn, error)
+
+func dialTCP(port int) dialFunc {
+	return func() (net.Conn, error) {
+		return net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 3*time.Second)
+	}
+}
+
+func dialUDS(path string) dialFunc {
+	return func() (net.Conn, error) {
+		return net.DialTimeout("unix", path, 3*time.Second)
+	}
+}
+
+func dialInProc(s *server.Server) dialFunc {
+	return func() (net.Conn, error) {
+		return s.InProcessConn()
+	}
+}
+
+func runServerTCP(port int) *server.Server {
+	opts := DefaultTestOptions
+	opts.Port = port
+	opts.DisableShortFirstPing = true
+	s := RunServer(&opts)
+	s.ReadyForConnections(5 * time.Second)
+	return s
+}
+
+func runServerUDS(path string) *server.Server {
+	os.Remove(path)
+	opts := DefaultTestOptions
+	opts.Port = -1
+	opts.DontListen = true
+	opts.UDS.Path = path
+	opts.DisableShortFirstPing = true
+	s := RunServer(&opts)
+	s.ReadyForConnections(5 * time.Second)
+	return s
+}
+
+func runServerInProc() *server.Server {
+	opts := DefaultTestOptions
+	opts.Port = -1
+	opts.DontListen = true
+	opts.DisableShortFirstPing = true
+	s := RunServer(&opts)
+	s.ReadyForConnections(5 * time.Second)
+	return s
+}
+
+// Read and discard possibly multiple responses non-blocking.
+// Simulate async read on client without consuming threads.
+func drainRead(c net.Conn, buf []byte) {
+	c.SetReadDeadline(time.Now())
+	_, err := c.Read(buf)
+	if err != nil {
+		return
+	}
+	for {
+		c.SetReadDeadline(time.Now())
+		_, err = c.Read(buf)
+		if err != nil {
+			return
+		}
+	}
+}
+
+func sendRecv(c net.Conn, msg []byte, n int) time.Duration {
+	buf := make([]byte, 4096)
+	start := time.Now()
+	for i := 0; i < n; i++ {
+		c.Write(msg)
+		drainRead(c, buf)
+	}
+	return time.Since(start)
+}
+
+func benchMsg(b *testing.B, dial dialFunc, msg []byte, numClients int) {
+	b.StopTimer()
+
+	conns := make([]net.Conn, numClients)
+	for i := range conns {
+		c, err := dial()
+		if err != nil {
+			b.Fatalf("dial failed: %v", err)
+		}
+		conns[i] = c
+		doDefaultConnect(b, c)
+	}
+	defer func() {
+		for _, c := range conns {
+			c.Close()
+		}
+	}()
+
+	msgsPerClient := b.N / numClients
+	if msgsPerClient < 1 {
+		msgsPerClient = 1
+	}
+
+	var wg sync.WaitGroup
+	times := make([]time.Duration, numClients)
+	start := make(chan struct{})
+
+	for i := range conns {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			times[idx] = sendRecv(conns[idx], msg, msgsPerClient)
+		}(i)
+	}
+
+	b.StartTimer()
+	close(start)
+	wg.Wait()
+	b.StopTimer()
+
+	nsPerMsg := make([]float64, numClients)
+	for i, d := range times {
+		nsPerMsg[i] = float64(d.Nanoseconds()) / float64(msgsPerClient)
+	}
+	slices.Sort(nsPerMsg)
+
+	var sum float64
+	for _, ns := range nsPerMsg {
+		sum += ns
+	}
+
+	b.ReportMetric(nsPerMsg[0], "ns/msg-min")
+	b.ReportMetric(nsPerMsg[len(nsPerMsg)-1], "ns/msg-max")
+	b.ReportMetric(sum/float64(numClients), "ns/msg-avg")
+	b.ReportMetric(nsPerMsg[len(nsPerMsg)/2], "ns/msg-med")
+}
+
+func benchTransports(b *testing.B, msg []byte, numClients int) {
+	b.Run("TCP", func(b *testing.B) {
+		s := runServerTCP(8423)
+		defer s.Shutdown()
+		benchMsg(b, dialTCP(8423), msg, numClients)
+	})
+	b.Run("UDS", func(b *testing.B) {
+		s := runServerUDS("/tmp/nats-bench.sock")
+		defer s.Shutdown()
+		benchMsg(b, dialUDS("/tmp/nats-bench.sock"), msg, numClients)
+	})
+	b.Run("InProc", func(b *testing.B) {
+		s := runServerInProc()
+		defer s.Shutdown()
+		benchMsg(b, dialInProc(s), msg, numClients)
+	})
+}
+
+var ping = []byte("PING\r\n")
+
+func makePub(size int) []byte {
+	// PUB x <size>\r\n<payload>\r\n
+	header := fmt.Sprintf("PUB x %d\r\n", size)
+	msg := make([]byte, len(header)+size+2)
+	for i := range msg {
+		msg[i] = '.'
+	}
+	copy(msg, header)
+	copy(msg[len(msg)-2:], "\r\n")
+	return msg
+}
+
+var (
+	pub256 = makePub(256)
+	pub512 = makePub(512)
+	pub1k  = makePub(1024)
+)
+
+func Benchmark_Transport_Ping_1(b *testing.B)          { benchTransports(b, ping, 1) }
+func Benchmark_Transport_Ping_2(b *testing.B)          { benchTransports(b, ping, 2) }
+func Benchmark_Transport_Ping_3(b *testing.B)          { benchTransports(b, ping, 3) }
+func Benchmark_Transport_Ping_4(b *testing.B)          { benchTransports(b, ping, 4) }
+func Benchmark_Transport_Ping_5(b *testing.B)          { benchTransports(b, ping, 5) }
+func Benchmark_Transport_Ping_Cores_x0_5(b *testing.B) { benchTransports(b, ping, runtime.NumCPU()/2) }
+func Benchmark_Transport_Ping_Cores_x1(b *testing.B)   { benchTransports(b, ping, runtime.NumCPU()) }
+func Benchmark_Transport_Ping_Cores_x1_5(b *testing.B) {
+	benchTransports(b, ping, runtime.NumCPU()*3/2)
+}
+
+func Benchmark_Transport_Pub256_1(b *testing.B) { benchTransports(b, pub256, 1) }
+func Benchmark_Transport_Pub256_4(b *testing.B) { benchTransports(b, pub256, 4) }
+func Benchmark_Transport_Pub256_Cores_x0_5(b *testing.B) {
+	benchTransports(b, pub256, runtime.NumCPU()/2)
+}
+func Benchmark_Transport_Pub256_Cores_x1(b *testing.B) { benchTransports(b, pub256, runtime.NumCPU()) }
+func Benchmark_Transport_Pub256_Cores_x1_5(b *testing.B) {
+	benchTransports(b, pub256, runtime.NumCPU()*3/2)
+}
+
+func Benchmark_Transport_Pub512_1(b *testing.B) { benchTransports(b, pub512, 1) }
+func Benchmark_Transport_Pub512_4(b *testing.B) { benchTransports(b, pub512, 4) }
+func Benchmark_Transport_Pub512_Cores_x0_5(b *testing.B) {
+	benchTransports(b, pub512, runtime.NumCPU()/2)
+}
+func Benchmark_Transport_Pub512_Cores_x1(b *testing.B) { benchTransports(b, pub512, runtime.NumCPU()) }
+func Benchmark_Transport_Pub512_Cores_x1_5(b *testing.B) {
+	benchTransports(b, pub512, runtime.NumCPU()*3/2)
+}
+
+func Benchmark_Transport_Pub1k_1(b *testing.B) { benchTransports(b, pub1k, 1) }
+func Benchmark_Transport_Pub1k_4(b *testing.B) { benchTransports(b, pub1k, 4) }
+func Benchmark_Transport_Pub1k_Cores_x0_5(b *testing.B) {
+	benchTransports(b, pub1k, runtime.NumCPU()/2)
+}
+func Benchmark_Transport_Pub1k_Cores_x1(b *testing.B) { benchTransports(b, pub1k, runtime.NumCPU()) }
+func Benchmark_Transport_Pub1k_Cores_x1_5(b *testing.B) {
+	benchTransports(b, pub1k, runtime.NumCPU()*3/2)
+}

--- a/uds_main_test.go
+++ b/uds_main_test.go
@@ -1,0 +1,46 @@
+// Copyright 2020-2025 Michael Utech
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/nats-io/nats-server/v2/server"
+)
+
+func TestUDS_HelpTextSync(t *testing.T) {
+	// Ensure main.go usageStr stays in sync with flag definition in opts.go
+	defer func() { server.FlagSnapshot = nil }()
+
+	// Get the authoritative usage text from flag definition
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(&bytes.Buffer{})
+	server.ConfigureOptions(fs, []string{}, nil, nil, nil)
+
+	f := fs.Lookup("uds")
+	if f == nil {
+		t.Fatal("--uds flag not registered")
+	}
+	definedUsage := f.Usage
+
+	// Verify the defined usage text appears in usageStr (main.go)
+	if !strings.Contains(usageStr, definedUsage) {
+		t.Errorf("usageStr missing flag usage text.\nExpected to find: %q\nusageStr:\n%s", definedUsage, usageStr)
+	}
+}


### PR DESCRIPTION
  Adds UNIX domain socket support for local clients (Linux only for now):
  - Socket permissions (group/mode)
  - Peer credential authentication (uid/gid/pid-based rules)
  - ~3x faster than local TCP for low-concurrency workloads

See [the fork's Wiki](https://github.com/mutech/nats-server/wiki/UNIX-domain-sockets) for more details.

This is just a preview for you to see if the implementation is acceptable if you were to decide you want UDS support in NATS.

There are a couple of hacks I'm going to remove, the UDS permissions are going to change.

That being said, is the way I am integrating this "the right way"?

Signed-off-by: Michael Utech <michael@utech.de>