### PR TITLE
Fix subject intersection bug due to early return

### DIFF
--- a/server/gsl/gsl.go
+++ b/server/gsl/gsl.go
@@ -389,13 +389,14 @@ func hasInterestStartingIn[T comparable](l *level[T], tokens []string) bool {
 	if l.fwc != nil {
 		return true
 	}
+	found := false
 	if pwc := l.pwc; pwc != nil {
-		return hasInterestStartingIn(pwc.next, tokens[1:])
+		found = found || hasInterestStartingIn(pwc.next, tokens[1:])
 	}
 	if n := l.nodes[token]; n != nil {
-		return hasInterestStartingIn(n.next, tokens[1:])
+		found = found || hasInterestStartingIn(n.next, tokens[1:])
 	}
-	return false
+	return found
 }
 
 // pruneNode is used to prune an empty node from the tree.

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -1257,6 +1257,18 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		require_Len(t, len(got), 2)
 		require_NoDuplicates(t, got)
 	})
+
+	t.Run("LiteralMatchWithOverlappingPWCs", func(t *testing.T) {
+		got := map[string]int{}
+		sl := gsl.NewSublist[int]()
+		require_NoError(t, sl.Insert("one.*.four.five", 11))
+		require_NoError(t, sl.Insert("one.two.three.four", 22))
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+			got[string(subj)]++
+		})
+		require_Len(t, len(got), 1)
+		require_NoDuplicates(t, got)
+	})
 }
 
 func TestSubjectTreeDeleteShortSubjectNoPanic(t *testing.T) {


### PR DESCRIPTION
An early return here meant that a wildcard with differing following literal tokens would mask another literal at the same level as the partial wildcard.

Signed-off-by: Neil Twigg <neil@nats.io>