### PR TITLE
(2.14) Linearizable read leases

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -563,7 +563,7 @@ func (cc *jetStreamCluster) isLeader() bool {
 		// Non-clustered mode
 		return true
 	}
-	return cc.meta != nil && cc.meta.Leader()
+	return cc.meta != nil && cc.meta.LeaderLease()
 }
 
 // isStreamCurrent will determine if the stream is up to date.
@@ -1140,7 +1140,7 @@ func (cc *jetStreamCluster) isStreamLeader(account, stream string) bool {
 	ourID := cc.meta.ID()
 	for _, peer := range rg.Peers {
 		if peer == ourID {
-			if len(rg.Peers) == 1 || (rg.node != nil && rg.node.Leader()) {
+			if len(rg.Peers) == 1 || (rg.node != nil && rg.node.LeaderLease()) {
 				return true
 			}
 		}
@@ -1174,7 +1174,7 @@ func (cc *jetStreamCluster) isConsumerLeader(account, stream, consumer string) b
 	ourID := cc.meta.ID()
 	for _, peer := range rg.Peers {
 		if peer == ourID {
-			if len(rg.Peers) == 1 || (rg.node != nil && rg.node.Leader()) {
+			if len(rg.Peers) == 1 || (rg.node != nil && rg.node.LeaderLease()) {
 				return true
 			}
 		}

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -11223,11 +11223,11 @@ func TestJetStreamClusterMetaPeerRemoveResponseAfterQuorum(t *testing.T) {
 	jsreq, err := json.Marshal(req)
 	require_NoError(t, err)
 	require_NoError(t, nc.PublishRequest(JSApiRemoveServer, reply, jsreq))
-	_, err = sub.NextMsg(time.Second)
+	_, err = sub.NextMsg(200 * time.Millisecond)
 	require_Error(t, err, nats.ErrTimeout)
 
 	// Retrying the request should fail, as the leader has already removed it as its peer.
-	rmsg, err := nc.Request(JSApiRemoveServer, jsreq, time.Second)
+	rmsg, err := nc.Request(JSApiRemoveServer, jsreq, 200*time.Millisecond)
 	require_NoError(t, err)
 	var resp JSApiMetaServerRemoveResponse
 	require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
@@ -11237,7 +11237,7 @@ func TestJetStreamClusterMetaPeerRemoveResponseAfterQuorum(t *testing.T) {
 	require_Error(t, resp.Error, NewJSClusterServerMemberChangeInflightError())
 
 	// Audit should reflect the same.
-	rmsg, err = auditSub.NextMsg(time.Second)
+	rmsg, err = auditSub.NextMsg(200 * time.Millisecond)
 	require_NoError(t, err)
 	var auditResp JSAPIAudit
 	require_NoError(t, json.Unmarshal(rmsg.Data, &auditResp))

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -4466,7 +4466,7 @@ func TestJetStreamClusterConsumerDontSendSnapshotOnLeaderChange(t *testing.T) {
 		return nil
 	})
 
-	// We should only have 'Normal' entries.
+	// We should only have 'Normal' and 'Noop' entries.
 	// If we'd get a 'Snapshot' entry, that would mean it had incomplete state and would be reverting committed state.
 	var state StreamState
 	rn.wal.FastState(&state)
@@ -4474,7 +4474,9 @@ func TestJetStreamClusterConsumerDontSendSnapshotOnLeaderChange(t *testing.T) {
 		ae, err = rn.loadEntry(seq)
 		require_NoError(t, err)
 		for _, entry := range ae.entries {
-			require_Equal(t, entry.Type, EntryNormal)
+			if entry.Type != EntryNormal && entry.Type != EntryNoop {
+				t.Fatalf("Unexpected entry type: %v", entry.Type)
+			}
 		}
 	}
 }
@@ -5218,7 +5220,7 @@ func TestJetStreamClusterConsistencyAfterLeaderChange(t *testing.T) {
 				// Or there are gaps, which would mean the JetStream layer would run into errLastSeqMismatch.
 				require_Equal(t, lseq, clseq)
 				clseq++
-			} else if e.Type != EntryPeerState {
+			} else if e.Type != EntryPeerState && e.Type != EntryNoop {
 				t.Fatalf("Received unhandled entry type: %s\n", e.Type)
 			}
 		}
@@ -6713,9 +6715,9 @@ func TestJetStreamClusterSDMMsgTTLReverseExpiry(t *testing.T) {
 			require_Equal(t, sm.Subject, "foo")
 			require_Equal(t, sm.Header.Get(JSMarkerReason), JSMarkerReasonMaxAge)
 
-			// Expect three entries, one leader change, the subject delete marker rollup, and one published message.
+			// Expect four entries, one leader change, one noop entry, the subject delete marker rollup, and one published message.
 			nindex, _, _ := rn.Progress()
-			require_Equal(t, nindex, pindex+3)
+			require_Equal(t, nindex, pindex+4)
 		})
 	}
 }

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -46,7 +46,7 @@ import (
 
 func init() {
 	// Speed up raft for tests.
-	hbInterval = 50 * time.Millisecond
+	hbInterval = 100 * time.Millisecond
 	minElectionTimeout = 1500 * time.Millisecond
 	maxElectionTimeout = 3500 * time.Millisecond
 	lostQuorumInterval = 2 * time.Second


### PR DESCRIPTION
This PR implements leader leases to ensure linearizable reads for parts of the JS API, like MsgGet, but does NOT include APIs like DirectGet currently. Ensuring an old leader (that can't refresh the lease) doesn't answer read requests after its lease expires.

This is safe based on the "LeaseGuard: Raft Leases Done Right" paper describing using the Raft log to renew the leader lease. Although we don't use the 'inherited lease reads' and 'deferred writes' optimizations, since any changes depend on the former ones being applied (especially for a stream).

Although the paper describes needing to take clock uncertainty/skew into account, in "5.3. Leases without bounded-uncertainty clocks" it describes using local timers instead. Since we use Go's monotonic clock with a lease timeout that equals the minimum election timeout, this has minimal to no impact on our current Raft implementation in terms of _when_ elections take place.

This PR adds a "noop-entry" to be able to write and renew the leader lease. Since this entry is otherwise empty, this poses no backward-compatibility issues either. An old server version will know how to handle it without issue, that is: 'do nothing except store it in the log', which is intended.

Relates to https://github.com/nats-io/nats-architecture-and-design/pull/390

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>