### PR TITLE
(2.14) [CHANGED] Message Tracing: Do not rewrite `traceparent` header

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4825,8 +4825,7 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 				// We also need to disable the message trace headers so that
 				// if the message is routed, it does not initialize tracing in the
 				// remote.
-				positions := disableTraceHeaders(c, msg)
-				defer enableTraceHeaders(msg, positions)
+				msg = c.setHeader(MsgTraceDest, MsgTraceDestDisabled, msg)
 			}
 		}
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -5401,7 +5401,7 @@ func (mset *stream) processInboundJetStreamMsg(_ *subscription, c *client, _ *Ac
 		// to prevent a trace event to be generated when a stored message
 		// is delivered to a consumer and routed.
 		if !traceOnly {
-			disableTraceHeaders(c, hdr)
+			hdr = setHeader(MsgTraceDest, MsgTraceDestDisabled, hdr)
 		}
 		// This will add the jetstream event while in the client read loop.
 		// Since the event will be updated in a different go routine, the


### PR DESCRIPTION
An issue was reported (https://github.com/nats-io/nats-architecture-and-design/issues/392) stating that users don't want the `traceparent` header to be changed to `Xraceparent` by the server (in order to disable tracing) because it may break their applications that rely on its presence.

The header will no longer be changed, including its case. The specification (https://www.w3.org/TR/trace-context/#header-name) says:
```
Vendors MUST expect the header in any case (upper, lower, mixed), and
SHOULD send the header name in lowercase.
```

Since it was "SHOULD", we have no obligation to rewrite it in lower case.

In the ADR issue, it was discussed to add a new header that would disable tracing (and will leave `traceparent` header name untouched) but the issue with that is that in a mixed environment (newer and older servers), the older servers would not know about the new header and would possibly emit traces when they should not.

The approach in this PR is to add or update the content of `Nats-Trace-Dest` header to a specific invalid subject ("trace disabled") instead of changing the `Nats-Trace-Dest` and/or `traceparent` headers to `Xats-Trace-Dest` and `Xraceparent`.

For newer server, when processing an inbound message that has the `Nats-Trace-Dest` header set to this specific value, regardless of the presence of `traceparent` or not, we understand it as a way to disable tracing, do not report any error and consider the tracing disabled (and process the message normally).

For older servers, the presence of `Nats-Trace-Dest` takes precedence, so `traceparent` will be ignored, but since the trace destination is an invalid NATS subject, the error:

`Destination "trace disabled" is not valid, won't be able to trace events`

will be logged, and the message will not be traced. It is not ideal that an error message is printed, but this allows for backward compatibility. The message is still processed normally, so in this context the error can be safely ignored by the user.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

