### PR TITLE
Don't recalculate num pending inline on consumer info

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -5129,8 +5129,8 @@ func (o *consumer) checkNumPending() (uint64, error) {
 		// pending calculation that this replaces had the same problem though.
 		if o.sseq > state.LastSeq {
 			o.npc = 0
-		} else if npc > 0 || npc > state.Msgs {
-			o.npc = int64(min(npc, state.Msgs))
+		} else if npc > 0 {
+			o.npc = int64(min(npc, state.Msgs, state.LastSeq-o.sseq+1))
 		}
 	}
 	return o.numPending(), nil


### PR DESCRIPTION
Recalculating num pending inline on consumer info can make them considerably more expensive than intended and can result in unexpectedly taking out the lock on the underlying store of the stream, creating contention with other resources. 

We will now only make simple adjustments just to make sure that the numbers aren't completely unrealistic. Num pending calculations still take place when becoming leader or updating the subject filters in the consumer config.

Signed-off-by: Neil Twigg <neil@nats.io>