### PR TITLE
Make JSZ still use streamNumPending for consumer info details

### DIFF
--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -8133,6 +8133,69 @@ func TestJetStreamConsumerInfoNumPending(t *testing.T) {
 	require_Equal(t, ci.NumPending, 100)
 }
 
+func TestJetStreamJSZConsumerInfoStreamNumPending(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+	})
+	require_NoError(t, err)
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "CONSUMER",
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	// Publish some messages.
+	for i := 0; i < 10; i++ {
+		_, err = js.Publish("foo", []byte("msg"))
+		require_NoError(t, err)
+	}
+
+	acc, err := s.lookupAccount(globalAccountName)
+	require_NoError(t, err)
+	mset, err := acc.lookupStream("TEST")
+	require_NoError(t, err)
+	o := mset.lookupConsumer("CONSUMER")
+	require_NotNil(t, o)
+
+	// Both should report accurate count initially.
+	ci := o.info()
+	require_Equal(t, ci.NumPending, 10)
+
+	ciAccurate := o.infoWithStreamNumPending()
+	require_Equal(t, ciAccurate.NumPending, 10)
+
+	// Simulate npc drift by setting it higher than actual messages.
+	// This can happen due to race conditions described in checkNumPending comments.
+	o.mu.Lock()
+	o.npc = 1000 // Set artificially high
+	o.mu.Unlock()
+
+	// info() uses checkNumPending() which caps npc to state.Msgs
+	ci = o.info()
+	require_Equal(t, ci.NumPending, 10) // Capped to actual stream messages
+
+	// infoWithStreamNumPending() uses checkNumPendingRecalc() which triggers
+	// streamNumPending() recalculation since npc > state.Msgs
+	ciAccurate = o.infoWithStreamNumPending()
+	require_Equal(t, ciAccurate.NumPending, 10) // Accurate recalculation
+
+	// Verify JSZ also gets accurate NumPending via Jsz() which uses infoWithStreamNumPending()
+	jsz, err := s.Jsz(&JSzOptions{Accounts: true, Streams: true, Consumer: true})
+	require_NoError(t, err)
+	require_Equal(t, len(jsz.AccountDetails), 1)
+	require_Equal(t, len(jsz.AccountDetails[0].Streams), 1)
+	require_Equal(t, len(jsz.AccountDetails[0].Streams[0].Consumer), 1)
+	require_Equal(t, jsz.AccountDetails[0].Streams[0].Consumer[0].NumPending, 10)
+}
+
 func TestJetStreamConsumerDontDecrementPendingCountOnSkippedMsg(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3103,7 +3103,7 @@ func (s *Server) accountDetail(jsa *jsAccount, optStreams, optConsumers, optDire
 			}
 			if optConsumers {
 				for _, consumer := range stream.getPublicConsumers() {
-					cInfo := consumer.info()
+					cInfo := consumer.infoWithStreamNumPending()
 					if cInfo == nil {
 						continue
 					}
@@ -3122,7 +3122,7 @@ func (s *Server) accountDetail(jsa *jsAccount, optStreams, optConsumers, optDire
 				}
 				if optDirectConsumers {
 					for _, consumer := range stream.getDirectConsumers() {
-						cInfo := consumer.info()
+						cInfo := consumer.infoWithStreamNumPending()
 						if cInfo == nil {
 							continue
 						}


### PR DESCRIPTION
Add infoWithStreamNumPending() method to consumer that still uses streamNumPending() for accurate results.

Follow up from https://github.com/nats-io/nats-server/pull/7758

Signed-off-by: Waldemar Quevedo <wally@nats.io>
