### PR TITLE
Expose Healthz method from Server

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -4011,6 +4011,11 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 	return health
 }
 
+// Healthz returns the health status of the server.
+func (s *Server) Healthz(opts *HealthzOptions) *HealthStatus {
+	return s.healthz(opts)
+}
+
 type ExpvarzStatus struct {
 	Memstats json.RawMessage `json:"memstats"`
 	Cmdline  json.RawMessage `json:"cmdline"`


### PR DESCRIPTION
Add a public Healthz method that wraps the internal healthz method,
useful to be able to handle graceful restarts when embedding the server.

Signed-off-by: Waldemar Quevedo <wally@nats.io>
