### PR TITLE
[IMPROVED] Remove no interest messages from head of stream

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -9251,6 +9251,11 @@ func (fs *fileStore) compact(seq uint64) (uint64, error) {
 		fs.mu.Unlock()
 		return fs.purge(seq)
 	}
+	// Short-circuit if the store was already compacted past this point.
+	if fs.state.FirstSeq > seq {
+		fs.mu.Unlock()
+		return purged, nil
+	}
 	// We have to delete interior messages.
 	smb := fs.selectMsgBlock(seq)
 	if smb == nil {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1507,6 +1507,12 @@ func (ms *memStore) compact(seq uint64) (uint64, error) {
 	var purged, bytes uint64
 
 	ms.mu.Lock()
+	// Short-circuit if the store was already compacted past this point.
+	if ms.state.FirstSeq > seq {
+		ms.mu.Unlock()
+		return purged, nil
+	}
+
 	cb := ms.scb
 	if seq <= ms.state.LastSeq {
 		fseq := ms.state.FirstSeq


### PR DESCRIPTION
When using interest-based streams, messages that no longer have interest should be removed. For example when deleting a consumer that was the last one marking interest of subject A, then all messages matching subject A should be purged from the stream. If this goes above a 100k threshold, this linear scan will be expensive to perform so we don't block any other progress from happening. However, this would leave those messages around until a stream limit is reached.

This PR doesn't fully fix the issue, since the full scan is still expensive, but it does remove any messages at the "head" of the stream that have lost interest. For an active interest stream that's continuously consumed, these messages will be removed naturally without needing to block by going through them and removing immediately, as they'll naturally end up at the "head" of the stream and are eligible for removal.

Resolves https://github.com/nats-io/nats-server/issues/6747, https://github.com/nats-io/nats-server/issues/7754

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>