### PR TITLE
[FIXED] Interest stream desync after consumer filter update

### DIFF
--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -2145,14 +2145,20 @@ func getStreamDetails(t *testing.T, c *cluster, accountName, streamName string) 
 
 func checkState(t *testing.T, c *cluster, accountName, streamName string) error {
 	t.Helper()
+	_, err := checkStateAndErr(t, c, accountName, streamName)
+	return err
+}
+
+func checkStateAndErr(t *testing.T, c *cluster, accountName, streamName string) (StreamState, error) {
+	t.Helper()
 
 	leaderSrv := c.streamLeader(accountName, streamName)
 	if leaderSrv == nil {
-		return fmt.Errorf("no leader server found for stream %q", streamName)
+		return StreamState{}, fmt.Errorf("no leader server found for stream %q", streamName)
 	}
 	streamLeader := getStreamDetails(t, c, accountName, streamName)
 	if streamLeader == nil {
-		return fmt.Errorf("no leader found for stream %q", streamName)
+		return StreamState{}, fmt.Errorf("no leader found for stream %q", streamName)
 	}
 
 	acc, err := leaderSrv.LookupAccount(accountName)
@@ -2224,7 +2230,7 @@ func checkState(t *testing.T, c *cluster, accountName, streamName string) error 
 		errs = append(errs, err)
 	}
 	if len(errs) > 0 {
-		return errors.Join(errs...)
+		return StreamState{}, errors.Join(errs...)
 	}
-	return nil
+	return streamLeader.State, nil
 }

--- a/server/stream.go
+++ b/server/stream.go
@@ -7399,20 +7399,18 @@ func (mset *stream) swapSigSubs(o *consumer, newFilters []string) {
 		o.sigSubs = nil
 	}
 
-	if o.isLeader() {
-		if mset.csl == nil {
-			mset.csl = gsl.NewSublist[*consumer]()
-		}
-		// If no filters are preset, add fwcs to sublist for that consumer.
-		if newFilters == nil {
-			mset.csl.Insert(fwcs, o)
-			o.sigSubs = append(o.sigSubs, fwcs)
-			// If there are filters, add their subjects to sublist.
-		} else {
-			for _, filter := range newFilters {
-				mset.csl.Insert(filter, o)
-				o.sigSubs = append(o.sigSubs, filter)
-			}
+	if mset.csl == nil {
+		mset.csl = gsl.NewSublist[*consumer]()
+	}
+	// If no filters are present, add fwcs to sublist for that consumer.
+	if newFilters == nil {
+		mset.csl.Insert(fwcs, o)
+		o.sigSubs = append(o.sigSubs, fwcs)
+	} else {
+		// If there are filters, add their subjects to sublist.
+		for _, filter := range newFilters {
+			mset.csl.Insert(filter, o)
+			o.sigSubs = append(o.sigSubs, filter)
 		}
 	}
 	o.mu.Unlock()


### PR DESCRIPTION
An interest-based replicated stream could desync after a consumer filter update, with new messages being persisted on some but not all replicas. This was due to the sublist being cleared and only updated for the server that's the consumer leader. The stream on the consumer leader would persist the messages, but followers wouldn't.

Resolves https://github.com/nats-io/nats-server/issues/7760

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>