### PR TITLE
(2.14) [FIXED] Slow meta changes during fast stream/consumer rescale can desync

### DIFF
--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -4175,8 +4175,7 @@ func TestJetStreamClusterMetaSnapshotMustNotIncludePendingConsumers(t *testing.T
 		updateStreams:   make(map[string]*streamAssignment),
 		updateConsumers: make(map[string]map[string]*consumerAssignment),
 	}
-	err = mjs.applyMetaSnapshot(snap, ru, true, true)
-	require_NoError(t, err)
+	require_NoError(t, mjs.applyMetaSnapshot(snap, ru, true))
 	require_Len(t, len(ru.updateStreams), 1)
 	for _, sa := range ru.updateStreams {
 		for _, ca := range sa.consumers {


### PR DESCRIPTION
Due to Raft group names being reused after a scale down to R1 and back up to replicated, a server that still thinks it's part of a replicated stream due to the scale down being slow to apply on the meta layer could lead to stream desync if this server would become stream leader and accepted new writes.

This PR fixes that by always renaming the Raft group if the stream is scaled down to a R1.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>