### PR TITLE
(2.14) Add fast batch publish support

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4760,6 +4760,10 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 			}
 		} else if c.kind != LEAF || c.pa.hdr < 0 || len(sliceHeader(ClientInfoHdr, msg[:c.pa.hdr])) == 0 {
 			ci = c.getClientInfo(share)
+			// FIXME(mvv): fast batch requires the original subject, test for various topologies (acc bounds, leaf, gateway)
+			if bytes.HasSuffix(c.pa.reply, []byte(FastBatchSuffix)) {
+				ci.Reply = bytesToString(c.pa.reply)
+			}
 			// If we did not share but the imports destination is the system account add in the server and cluster info.
 			if !share && isSysImport {
 				c.addServerAndClusterInfo(ci)

--- a/server/errors.json
+++ b/server/errors.json
@@ -2028,5 +2028,55 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSBatchPublishDisabledErr",
+    "code": 400,
+    "error_code": 10205,
+    "description": "batch publish is disabled",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSBatchPublishInvalidPatternErr",
+    "code": 400,
+    "error_code": 10206,
+    "description": "batch publish pattern is invalid",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSBatchPublishInvalidBatchIDErr",
+    "code": 400,
+    "error_code": 10207,
+    "description": "batch publish ID is invalid",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSBatchPublishUnknownBatchIDErr",
+    "code": 400,
+    "error_code": 10208,
+    "description": "batch publish ID unknown",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSMirrorWithBatchPublishErr",
+    "code": 400,
+    "error_code": 10209,
+    "description": "stream mirrors can not also use batch publishing",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/events.go
+++ b/server/events.go
@@ -328,6 +328,7 @@ type ClientInfo struct {
 	ClientType string        `json:"client_type,omitempty"`
 	MQTTClient string        `json:"client_id,omitempty"` // This is the MQTT client ID
 	Nonce      string        `json:"nonce,omitempty"`
+	Reply      string        `json:"reply,omitempty"` // Original reply subject after a service import (only when needed).
 }
 
 // forAssignmentSnap returns the minimum amount of ClientInfo we need for assignment snapshots.

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -33,34 +34,79 @@ var (
 )
 
 type batching struct {
-	mu    sync.Mutex
-	group map[string]*batchGroup
+	mu     sync.Mutex
+	atomic map[string]*atomicBatch
+	fast   map[string]*fastBatch
 }
 
-type batchGroup struct {
-	lseq  uint64
-	store StreamStore
-	timer *time.Timer
+type atomicBatch struct {
+	timer *time.Timer // Inactivity timer for the batch.
+	lseq  uint64      // The highest sequence for this batch.
+	store StreamStore // Where the batch is staged before committing.
 }
 
+type fastBatch struct {
+	timer          *time.Timer // Inactivity timer for the batch.
+	lseq           uint64      // The highest sequence for this batch.
+	sseq           uint64      // Last persisted stream sequence.
+	pseq           uint64      // Last persisted batch sequence (is always lower or equal to lseq).
+	fseq           uint64      // Sequence of when we last sent a flow message (is always lower or equal to pseq).
+	pending        uint32      // Number of pending messages in the batch waiting to be persisted.
+	ackMessages    uint16      // Ack will be sent every N messages.
+	maxAckMessages uint16      // Maximum ackMessages value the client allows.
+	gapOk          bool        // Whether a gap is okay, if not, the batch would be rejected.
+	commit         bool        // If the batch is committed.
+}
+
+// newAtomicBatch creates an atomic batch publish object.
 // Lock should be held.
-func (batches *batching) newBatchGroup(mset *stream, batchId string) (*batchGroup, error) {
+func (batches *batching) newAtomicBatch(mset *stream, batchId string) (*atomicBatch, error) {
 	store, err := newBatchStore(mset, batchId)
 	if err != nil {
 		return nil, err
 	}
-	b := &batchGroup{store: store}
+	b := &atomicBatch{store: store}
+	b.setupCleanupTimer(mset, batchId, batches)
+	return b, nil
+}
 
+// setupCleanupTimer sets up a timer to clean up the batch after a timeout.
+func (b *atomicBatch) setupCleanupTimer(mset *stream, batchId string, batches *batching) {
 	// Create a timer to clean up after timeout.
-	timeout := streamMaxBatchTimeout
-	if maxBatchTimeout := mset.srv.getOpts().JetStreamLimits.MaxBatchTimeout; maxBatchTimeout > 0 {
-		timeout = maxBatchTimeout
-	}
+	timeout := getCleanupTimeout(mset)
 	b.timer = time.AfterFunc(timeout, func() {
 		b.cleanup(batchId, batches)
 		mset.sendStreamBatchAbandonedAdvisory(batchId, BatchTimeout)
 	})
-	return b, nil
+}
+
+// resetCleanupTimer resets the cleanup timer, allowing to extend the lifetime of the batch.
+// Returns whether the timer was reset without it having expired before.
+func (b *atomicBatch) resetCleanupTimer(mset *stream) bool {
+	timeout := getCleanupTimeout(mset)
+	return b.timer.Reset(timeout)
+}
+
+// cleanup deletes underlying resources associated with the batch and unregisters it from the stream's batches.
+func (b *atomicBatch) cleanup(batchId string, batches *batching) {
+	batches.mu.Lock()
+	defer batches.mu.Unlock()
+	b.cleanupLocked(batchId, batches)
+}
+
+// Lock should be held.
+func (b *atomicBatch) cleanupLocked(batchId string, batches *batching) {
+	globalInflightBatches.Add(-1)
+	b.timer.Stop()
+	b.store.Delete(true)
+	delete(batches.atomic, batchId)
+}
+
+// Lock should be held.
+func (b *atomicBatch) stopLocked() {
+	globalInflightBatches.Add(-1)
+	b.timer.Stop()
+	b.store.Stop()
 }
 
 func getBatchStoreDir(mset *stream, batchId string) (string, string) {
@@ -101,7 +147,7 @@ func newBatchStore(mset *stream, batchId string) (StreamStore, error) {
 // If the timer has already cleaned up the batch, we can't commit.
 // Otherwise, we ensure the timer does not clean up the batch in the meantime.
 // Lock should be held.
-func (b *batchGroup) readyForCommit() bool {
+func (b *atomicBatch) readyForCommit() bool {
 	if !b.timer.Stop() {
 		return false
 	}
@@ -109,26 +155,183 @@ func (b *batchGroup) readyForCommit() bool {
 	return true
 }
 
+// newFastBatch creates a fast batch publish object.
+// Lock should be held.
+func (batches *batching) newFastBatch(mset *stream, batchId string, gapOk bool, maxAckMessages uint16) *fastBatch {
+	// If it's the first batch, just allow what the client wants, otherwise we'll
+	// need to coordinate and slowly ramp up this publisher.
+	// TODO(mvv): fast ingest's initial flow value improvements?
+	ackMessages := min(500, maxAckMessages)
+	if len(batches.fast) > 1 {
+		ackMessages = 1
+	}
+	b := &fastBatch{gapOk: gapOk, ackMessages: ackMessages, maxAckMessages: maxAckMessages}
+	b.setupCleanupTimer(mset, batchId, batches)
+	return b
+}
+
+// fastBatchRegisterSequences registers the highest stored batch and stream sequence and returns
+// whether a PubAck should be sent if the batch has been committed.
+// Lock should be held.
+func (batches *batching) fastBatchRegisterSequences(mset *stream, reply string, batchId string, batchSeq, streamSeq uint64) bool {
+	b, ok := batches.fast[batchId]
+	if !ok {
+		return false
+	}
+	if b.pending > 0 {
+		b.pending--
+	}
+	b.sseq = streamSeq
+	// Store last persisted batch sequence.
+	// If we have no remaining pending writes, we might have had duplicate messages
+	// and need to send additional flow control messages.
+	var skipped bool
+	if b.pending == 0 {
+		skipped = true
+		b.pseq = b.lseq
+	} else {
+		b.pseq = batchSeq
+	}
+	// If the PubAck needs to be sent now as a result of a commit.
+	if b.lseq == b.pseq && b.commit {
+		b.cleanupLocked(batchId, batches)
+		// If we skipped ahead due to duplicate messages, send the PubAck with the highest sequence.
+		if skipped {
+			var buf [256]byte
+			pubAck := append(buf[:0], mset.pubAck...)
+			response := append(pubAck, strconv.FormatUint(b.sseq, 10)...)
+			response = append(response, fmt.Sprintf(",\"batch\":%q,\"count\":%d}", batchId, b.lseq)...)
+			if len(reply) > 0 {
+				mset.outq.sendMsg(reply, response)
+			}
+			return false
+		}
+		return true
+	}
+	b.checkFlowControl(mset, reply, batches)
+	return false
+}
+
+// checkFlowControl checks whether a flow control message should be sent.
+// If so, it updates the flow values to speed up or slow down the publisher if needed.
+// Returns whether a flow control message was sent.
+// Lock should be held.
+func (b *fastBatch) checkFlowControl(mset *stream, reply string, batches *batching) bool {
+	am := uint64(b.ackMessages)
+	if b.pseq < b.fseq+am {
+		return false
+	}
+	// Instead of sending multiple flow control messages, skip ahead to only send the last.
+	steps := (b.pseq - b.fseq) / am
+	b.fseq += steps * am
+
+	// TODO(mvv): fast ingest's dynamic flow value improvements?
+	//  This is currently just a simple value to have a working version. Should take average
+	//  message sizes into account and compare how much this client is contributing to the
+	//  ingest IPQ total size and messages and have publishers share based on that.
+	maxAckMessages := uint16(500 / len(batches.fast))
+	if maxAckMessages < 1 {
+		maxAckMessages = 1
+	}
+	// Limit to the client's allowed maximum.
+	if maxAckMessages > b.maxAckMessages {
+		maxAckMessages = b.maxAckMessages
+	}
+
+	if b.ackMessages < maxAckMessages {
+		// Ramp up.
+		b.ackMessages *= 2
+		if b.ackMessages > maxAckMessages {
+			b.ackMessages = maxAckMessages
+		}
+	} else if b.ackMessages > maxAckMessages {
+		// Slow down.
+		b.ackMessages /= 2
+		if b.ackMessages <= maxAckMessages {
+			b.ackMessages = maxAckMessages
+		}
+	}
+
+	// Finally, send the flow control message.
+	b.sendFlowControl(b.fseq, mset, reply)
+	return true
+}
+
+// sendFlowControl sends a fast batch flow control message for the current highest sequence.
+// Lock should be held.
+func (b *fastBatch) sendFlowControl(batchSeq uint64, mset *stream, reply string) {
+	if len(reply) == 0 {
+		return
+	}
+	response := BatchFlowAck{Sequence: batchSeq, Messages: b.ackMessages}.MarshalJSON()
+	mset.outq.sendMsg(reply, response)
+}
+
+// fastBatchCommit ends the batch and commits the data up to that point. If all messages
+// have already been persisted, a PubAck is sent immediately. Otherwise, it will be sent
+// after the last message has been persisted.
+// Lock should be held.
+func (batches *batching) fastBatchCommit(b *fastBatch, batchId string, mset *stream, reply string) bool {
+	// Mark that this batch commits.
+	b.commit = true
+	// Either we commit now, or we clean up later, so stop the timer.
+	b.timer.Stop()
+	// If the whole batch has been persisted, we can respond with the PubAck now.
+	if b.lseq == b.pseq {
+		b.cleanupLocked(batchId, batches)
+		var buf [256]byte
+		pubAck := append(buf[:0], mset.pubAck...)
+		response := append(pubAck, strconv.FormatUint(b.sseq, 10)...)
+		response = append(response, fmt.Sprintf(",\"batch\":%q,\"count\":%d}", batchId, b.lseq)...)
+		if len(reply) > 0 {
+			mset.outq.sendMsg(reply, response)
+		}
+		return true
+	}
+	// Otherwise, we need to wait and the PubAck will be sent when the last message is persisted.
+	return false
+}
+
+// setupCleanupTimer sets up a timer to clean up the batch after a timeout.
+func (b *fastBatch) setupCleanupTimer(mset *stream, batchId string, batches *batching) {
+	// Create a timer to clean up after timeout.
+	timeout := getCleanupTimeout(mset)
+	b.timer = time.AfterFunc(timeout, func() {
+		b.cleanup(batchId, batches)
+		mset.sendStreamBatchAbandonedAdvisory(batchId, BatchTimeout)
+	})
+}
+
+// resetCleanupTimer resets the cleanup timer, allowing to extend the lifetime of the batch.
+// Returns whether the timer was reset without it having expired before.
+func (b *fastBatch) resetCleanupTimer(mset *stream) bool {
+	if b.commit {
+		return true
+	}
+	timeout := getCleanupTimeout(mset)
+	return b.timer.Reset(timeout)
+}
+
 // cleanup deletes underlying resources associated with the batch and unregisters it from the stream's batches.
-func (b *batchGroup) cleanup(batchId string, batches *batching) {
+func (b *fastBatch) cleanup(batchId string, batches *batching) {
 	batches.mu.Lock()
 	defer batches.mu.Unlock()
 	b.cleanupLocked(batchId, batches)
 }
 
 // Lock should be held.
-func (b *batchGroup) cleanupLocked(batchId string, batches *batching) {
-	globalInflightBatches.Add(-1)
+func (b *fastBatch) cleanupLocked(batchId string, batches *batching) {
 	b.timer.Stop()
-	b.store.Delete(true)
-	delete(batches.group, batchId)
+	delete(batches.fast, batchId)
 }
 
-// Lock should be held.
-func (b *batchGroup) stopLocked() {
-	globalInflightBatches.Add(-1)
-	b.timer.Stop()
-	b.store.Stop()
+// getCleanupTimeout returns the timeout for the batch, taking into account the server's limits.
+func getCleanupTimeout(mset *stream) time.Duration {
+	timeout := streamMaxBatchTimeout
+	if maxBatchTimeout := mset.srv.getOpts().JetStreamLimits.MaxBatchTimeout; maxBatchTimeout > 0 {
+		timeout = maxBatchTimeout
+	}
+	return timeout
 }
 
 // batchStagedDiff stages all changes for consistency checks until commit.
@@ -659,4 +862,62 @@ func checkMsgHeadersPreClusteredProposal(
 	}
 
 	return hdr, msg, 0, nil, nil
+}
+
+// recalculateClusteredSeq initializes or updates mset.clseq, for example after a leader change.
+// This is reused for normal clustered publishing into a stream, and for atomic and fast batch publishing.
+// mset.clMu lock must be held.
+func recalculateClusteredSeq(mset *stream) (lseq uint64) {
+	// Need to unlock and re-acquire the locks in the proper order.
+	mset.clMu.Unlock()
+	// Locking order is stream -> batchMu -> clMu
+	mset.mu.RLock()
+	batch := mset.batchApply
+	var batchCount uint64
+	if batch != nil {
+		batch.mu.Lock()
+		batchCount = batch.count
+	}
+	mset.clMu.Lock()
+	// Re-capture
+	lseq = mset.lseq
+	mset.clseq = lseq + mset.clfs + batchCount
+	// Keep hold of the mset.clMu, but unlock the others.
+	if batch != nil {
+		batch.mu.Unlock()
+	}
+	mset.mu.RUnlock()
+	return lseq
+}
+
+// commitSingleMsg commits and proposes a single message to the node.
+// This is reused both for normal publishing into a stream, and for fast batch publishing.
+// mset.clMu lock must be held.
+func commitSingleMsg(
+	diff *batchStagedDiff, mset *stream, subject string, reply string, hdr []byte, msg []byte, name string,
+	jsa *jsAccount, mt *msgTrace, node RaftNode, replicas int, lseq uint64,
+) {
+	diff.commit(mset)
+	esm := encodeStreamMsgAllowCompress(subject, reply, hdr, msg, mset.clseq, time.Now().UnixNano(), false)
+	var mtKey uint64
+	if mt != nil {
+		mtKey = mset.clseq
+		if mset.mt == nil {
+			mset.mt = make(map[uint64]*msgTrace)
+		}
+		mset.mt[mtKey] = mt
+	}
+
+	// Do proposal.
+	_ = node.Propose(esm)
+	// The proposal can fail, but we always account for trying.
+	mset.clseq++
+	mset.trackReplicationTraffic(node, len(esm), replicas)
+
+	// Check to see if we are being overrun.
+	// TODO(dlc) - Make this a limit where we drop messages to protect ourselves, but allow to be configured.
+	if mset.clseq-(lseq+mset.clfs) > streamLagWarnThreshold {
+		lerr := fmt.Errorf("JetStream stream '%s > %s' has high message lag", jsa.acc().Name, name)
+		mset.srv.RateLimitWarnf("%s", lerr.Error())
+	}
 }

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -9587,25 +9587,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	// Check if we need to set initial value here
 	mset.clMu.Lock()
 	if mset.clseq == 0 || mset.clseq < lseq+mset.clfs {
-		// Need to unlock and re-acquire the locks in the proper order.
-		mset.clMu.Unlock()
-		// Locking order is stream -> batchMu -> clMu
-		mset.mu.RLock()
-		batch := mset.batchApply
-		var batchCount uint64
-		if batch != nil {
-			batch.mu.Lock()
-			batchCount = batch.count
-		}
-		mset.clMu.Lock()
-		// Re-capture
-		lseq = mset.lseq
-		mset.clseq = lseq + mset.clfs + batchCount
-		// Keep hold of the mset.clMu, but unlock the others.
-		if batch != nil {
-			batch.mu.Unlock()
-		}
-		mset.mu.RUnlock()
+		lseq = recalculateClusteredSeq(mset)
 	}
 
 	var (
@@ -9628,53 +9610,14 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 			var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
 			resp.Error = apiErr
 			response, _ = json.Marshal(resp)
-			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
+			outq.sendMsg(reply, response)
 		}
 		return err
 	}
 
-	diff.commit(mset)
-	esm := encodeStreamMsgAllowCompress(subject, reply, hdr, msg, mset.clseq, time.Now().UnixNano(), sourced)
-	var mtKey uint64
-	if mt != nil {
-		mtKey = mset.clseq
-		if mset.mt == nil {
-			mset.mt = make(map[uint64]*msgTrace)
-		}
-		mset.mt[mtKey] = mt
-	}
-
-	// Do proposal.
-	_ = node.Propose(esm)
-	// The proposal can fail, but we always account for trying.
-	mset.clseq++
-	mset.trackReplicationTraffic(node, len(esm), r)
-
-	// Check to see if we are being overrun.
-	// TODO(dlc) - Make this a limit where we drop messages to protect ourselves, but allow to be configured.
-	if mset.clseq-(lseq+mset.clfs) > streamLagWarnThreshold {
-		lerr := fmt.Errorf("JetStream stream '%s > %s' has high message lag", jsa.acc().Name, name)
-		s.RateLimitWarnf("%s", lerr.Error())
-	}
+	commitSingleMsg(diff, mset, subject, reply, hdr, msg, name, jsa, mt, node, r, lseq)
 	mset.clMu.Unlock()
-
-	if err != nil {
-		if mt != nil {
-			mset.getAndDeleteMsgTrace(mtKey)
-		}
-		if canRespond {
-			var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: mset.cfg.Name}}
-			resp.Error = &ApiError{Code: 503, Description: err.Error()}
-			response, _ = json.Marshal(resp)
-			// If we errored out respond here.
-			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
-		}
-		if isOutOfSpaceErr(err) {
-			s.handleOutOfSpace(mset)
-		}
-	}
-
-	return err
+	return nil
 }
 
 func (mset *stream) getAndDeleteMsgTrace(lseq uint64) *msgTrace {

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -35,6 +35,18 @@ const (
 	// JSBadRequestErr bad request
 	JSBadRequestErr ErrorIdentifier = 10003
 
+	// JSBatchPublishDisabledErr batch publish is disabled
+	JSBatchPublishDisabledErr ErrorIdentifier = 10205
+
+	// JSBatchPublishInvalidBatchIDErr batch publish ID is invalid
+	JSBatchPublishInvalidBatchIDErr ErrorIdentifier = 10207
+
+	// JSBatchPublishInvalidPatternErr batch publish pattern is invalid
+	JSBatchPublishInvalidPatternErr ErrorIdentifier = 10206
+
+	// JSBatchPublishUnknownBatchIDErr batch publish ID unknown
+	JSBatchPublishUnknownBatchIDErr ErrorIdentifier = 10208
+
 	// JSClusterIncompleteErr incomplete results
 	JSClusterIncompleteErr ErrorIdentifier = 10004
 
@@ -359,6 +371,9 @@ const (
 	// JSMirrorWithAtomicPublishErr stream mirrors can not also use atomic publishing
 	JSMirrorWithAtomicPublishErr ErrorIdentifier = 10198
 
+	// JSMirrorWithBatchPublishErr stream mirrors can not also use batch publishing
+	JSMirrorWithBatchPublishErr ErrorIdentifier = 10209
+
 	// JSMirrorWithCountersErr stream mirrors can not also calculate counters
 	JSMirrorWithCountersErr ErrorIdentifier = 10173
 
@@ -627,6 +642,10 @@ var (
 		JSAtomicPublishTooLargeBatchErrF:             {Code: 400, ErrCode: 10199, Description: "atomic publish batch is too large: {size}"},
 		JSAtomicPublishUnsupportedHeaderBatchErr:     {Code: 400, ErrCode: 10177, Description: "atomic publish unsupported header used: {header}"},
 		JSBadRequestErr:                              {Code: 400, ErrCode: 10003, Description: "bad request"},
+		JSBatchPublishDisabledErr:                    {Code: 400, ErrCode: 10205, Description: "batch publish is disabled"},
+		JSBatchPublishInvalidBatchIDErr:              {Code: 400, ErrCode: 10207, Description: "batch publish ID is invalid"},
+		JSBatchPublishInvalidPatternErr:              {Code: 400, ErrCode: 10206, Description: "batch publish pattern is invalid"},
+		JSBatchPublishUnknownBatchIDErr:              {Code: 400, ErrCode: 10208, Description: "batch publish ID unknown"},
 		JSClusterIncompleteErr:                       {Code: 503, ErrCode: 10004, Description: "incomplete results"},
 		JSClusterNoPeersErrF:                         {Code: 400, ErrCode: 10005, Description: "{err}"},
 		JSClusterNotActiveErr:                        {Code: 500, ErrCode: 10006, Description: "JetStream not in clustered mode"},
@@ -735,6 +754,7 @@ var (
 		JSMirrorMultipleFiltersNotAllowed:            {Code: 400, ErrCode: 10150, Description: "mirror with multiple subject transforms cannot also have a single subject filter"},
 		JSMirrorOverlappingSubjectFilters:            {Code: 400, ErrCode: 10152, Description: "mirror subject filters can not overlap"},
 		JSMirrorWithAtomicPublishErr:                 {Code: 400, ErrCode: 10198, Description: "stream mirrors can not also use atomic publishing"},
+		JSMirrorWithBatchPublishErr:                  {Code: 400, ErrCode: 10209, Description: "stream mirrors can not also use batch publishing"},
 		JSMirrorWithCountersErr:                      {Code: 400, ErrCode: 10173, Description: "stream mirrors can not also calculate counters"},
 		JSMirrorWithFirstSeqErr:                      {Code: 400, ErrCode: 10143, Description: "stream mirrors can not have first sequence configured"},
 		JSMirrorWithMsgSchedulesErr:                  {Code: 400, ErrCode: 10186, Description: "stream mirrors can not also schedule messages"},
@@ -955,6 +975,46 @@ func NewJSBadRequestError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSBadRequestErr]
+}
+
+// NewJSBatchPublishDisabledError creates a new JSBatchPublishDisabledErr error: "batch publish is disabled"
+func NewJSBatchPublishDisabledError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSBatchPublishDisabledErr]
+}
+
+// NewJSBatchPublishInvalidBatchIDError creates a new JSBatchPublishInvalidBatchIDErr error: "batch publish ID is invalid"
+func NewJSBatchPublishInvalidBatchIDError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSBatchPublishInvalidBatchIDErr]
+}
+
+// NewJSBatchPublishInvalidPatternError creates a new JSBatchPublishInvalidPatternErr error: "batch publish pattern is invalid"
+func NewJSBatchPublishInvalidPatternError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSBatchPublishInvalidPatternErr]
+}
+
+// NewJSBatchPublishUnknownBatchIDError creates a new JSBatchPublishUnknownBatchIDErr error: "batch publish ID unknown"
+func NewJSBatchPublishUnknownBatchIDError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSBatchPublishUnknownBatchIDErr]
 }
 
 // NewJSClusterIncompleteError creates a new JSClusterIncompleteErr error: "incomplete results"
@@ -2137,6 +2197,16 @@ func NewJSMirrorWithAtomicPublishError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSMirrorWithAtomicPublishErr]
+}
+
+// NewJSMirrorWithBatchPublishError creates a new JSMirrorWithBatchPublishErr error: "stream mirrors can not also use batch publishing"
+func NewJSMirrorWithBatchPublishError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMirrorWithBatchPublishErr]
 }
 
 // NewJSMirrorWithCountersError creates a new JSMirrorWithCountersErr error: "stream mirrors can not also calculate counters"

--- a/server/jetstream_versioning.go
+++ b/server/jetstream_versioning.go
@@ -17,7 +17,7 @@ import "strconv"
 
 const (
 	// JSApiLevel is the maximum supported JetStream API level for this server.
-	JSApiLevel int = 3
+	JSApiLevel int = 4
 
 	JSRequiredLevelMetadataKey = "_nats.req.level"
 	JSServerVersionMetadataKey = "_nats.ver"
@@ -80,6 +80,11 @@ func setStaticStreamMetadata(cfg *StreamConfig) {
 	// Async persist mode was added in v2.12 and requires API level 2.
 	if cfg.PersistMode == AsyncPersistMode {
 		requires(2)
+	}
+
+	// Fast batch publishing was added in v2.14 and requires API level 3.
+	if cfg.AllowBatchPublish {
+		requires(4)
 	}
 
 	cfg.Metadata[JSRequiredLevelMetadataKey] = strconv.Itoa(requiredApiLevel)

--- a/server/jetstream_versioning_test.go
+++ b/server/jetstream_versioning_test.go
@@ -107,6 +107,11 @@ func TestJetStreamSetStaticStreamMetadata(t *testing.T) {
 			cfg:              &StreamConfig{PersistMode: AsyncPersistMode},
 			expectedMetadata: metadataAtLevel("2"),
 		},
+		{
+			desc:             "AllowBatchPublish",
+			cfg:              &StreamConfig{AllowBatchPublish: true},
+			expectedMetadata: metadataAtLevel("4"),
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			setStaticStreamMetadata(test.cfg)

--- a/server/stream.go
+++ b/server/stream.go
@@ -121,6 +121,9 @@ type StreamConfig struct {
 	// PersistMode allows to opt-in to different persistence mode settings.
 	PersistMode PersistModeType `json:"persist_mode,omitempty"`
 
+	// AllowBatchPublish allows fast batch publishing into the stream.
+	AllowBatchPublish bool `json:"allow_batched,omitempty"`
+
 	// Metadata is additional metadata for the Stream.
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
@@ -272,6 +275,71 @@ type CounterValue struct {
 // CounterSources is the body of the Nats-Counter-Sources header.
 // e.g. {"stream":{"subject":"123"}}
 type CounterSources map[string]map[string]string
+
+// BatchFlowAck is used for flow control when fast batch publishing into a stream.
+// This message is vital to handling acknowledgements and flow control.
+// These may technically be lost without the client receiving it. The client can retrieve
+// these by using the "ping" operation if it's expecting acks but not receiving any.
+type BatchFlowAck struct {
+	// Type: "ack"
+	Type string `json:"type"`
+	// Sequence is the sequence of the message that triggered the ack.
+	// If "gap: fail" this means the messages up to and including Sequence were persisted.
+	// If "gap: ok" this means _some_ of the messages up to and including Sequence were persisted.
+	// But there could have been gaps.
+	Sequence uint64 `json:"seq"`
+	// Messages indicates acknowledgements will be sent every N messages.
+	Messages uint16 `json:"msgs"`
+}
+
+func (ack BatchFlowAck) MarshalJSON() []byte {
+	type Alias BatchFlowAck
+	a := Alias(ack)
+	a.Type = "ack"
+	buf, _ := json.Marshal(a)
+	return buf
+}
+
+// BatchFlowGap is used for reporting gaps when fast batch publishing into a stream.
+// This message is purely informational and could technically be lost without the client receiving it.
+type BatchFlowGap struct {
+	// Type: "gap"
+	Type string `json:"type"`
+	// ExpectedLastSequence is the sequence expected to be received next.
+	// Messages starting from ExpectedLastSequence up to (but not including) CurrentSequence were lost.
+	ExpectedLastSequence uint64 `json:"last_seq"`
+	// CurrentSequence is the sequence of the message that just came in and detected the gap.
+	CurrentSequence uint64 `json:"seq"`
+}
+
+func (gap BatchFlowGap) MarshalJSON() []byte {
+	type Alias BatchFlowGap
+	a := Alias(gap)
+	a.Type = "gap"
+	buf, _ := json.Marshal(a)
+	return buf
+}
+
+// BatchFlowErr is used for reporting errors when fast batch publishing into a stream.
+// This message is purely informational and could technically be lost without the client receiving it.
+type BatchFlowErr struct {
+	// Type: "err"
+	Type string `json:"type"`
+	// Sequence is the sequence of the message that triggered the error.
+	// There are no (relative) guarantees whatsoever about whether the messages up to this sequence were persisted.
+	// Such guarantees require the use of "gap: fail" and listening for BatchFlowAck and PubAck.
+	Sequence uint64 `json:"seq"`
+	// Error is used to return the error for the Sequence.
+	Error *ApiError `json:"error"`
+}
+
+func (err BatchFlowErr) MarshalJSON() []byte {
+	type Alias BatchFlowErr
+	a := Alias(err)
+	a.Type = "err"
+	buf, _ := json.Marshal(a)
+	return buf
+}
 
 // StreamInfo shows config and current state for this stream.
 type StreamInfo struct {
@@ -1742,6 +1810,9 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 		if cfg.AllowAtomicPublish {
 			return StreamConfig{}, NewJSMirrorWithAtomicPublishError()
 		}
+		if cfg.AllowBatchPublish {
+			return StreamConfig{}, NewJSMirrorWithBatchPublishError()
+		}
 		if cfg.AllowMsgSchedules {
 			return StreamConfig{}, NewJSMirrorWithMsgSchedulesError()
 		}
@@ -2490,8 +2561,15 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 
 	// If atomic publish is disabled, delete any in-progress batches.
 	if !cfg.AllowAtomicPublish {
-		mset.deleteInflightBatches(false)
+		mset.deleteAtomicBatches(false)
 		mset.deleteBatchApplyState()
+	}
+	// If fast batch publish is disabled, delete any in-progress batches.
+	if !cfg.AllowBatchPublish {
+		mset.deleteFastBatches()
+	}
+	if !cfg.AllowAtomicPublish && !cfg.AllowBatchPublish {
+		mset.batches = nil
 	}
 
 	// Now update config and store's version of our config.
@@ -4514,7 +4592,9 @@ func (mset *stream) unsubscribeToStream(stopping, shuttingDown bool) error {
 		mset.stopSourceConsumers()
 	}
 	// Clear batching state.
-	mset.deleteInflightBatches(shuttingDown)
+	mset.deleteAtomicBatches(shuttingDown)
+	mset.deleteFastBatches()
+	mset.batches = nil
 
 	if stopping {
 		// In case we had a direct get subscriptions.
@@ -4533,10 +4613,10 @@ func (mset *stream) unsubscribeToStream(stopping, shuttingDown bool) error {
 }
 
 // Lock should be held.
-func (mset *stream) deleteInflightBatches(shuttingDown bool) {
+func (mset *stream) deleteAtomicBatches(shuttingDown bool) {
 	if mset.batches != nil {
 		mset.batches.mu.Lock()
-		for batchId, b := range mset.batches.group {
+		for batchId, b := range mset.batches.atomic {
 			// If shutting down, do fixup during startup. In-memory batches don't require manual cleanup.
 			if shuttingDown {
 				b.stopLocked()
@@ -4544,8 +4624,8 @@ func (mset *stream) deleteInflightBatches(shuttingDown bool) {
 				b.cleanupLocked(batchId, mset.batches)
 			}
 		}
+		mset.batches.atomic = nil
 		mset.batches.mu.Unlock()
-		mset.batches = nil
 	}
 }
 
@@ -4557,6 +4637,18 @@ func (mset *stream) deleteBatchApplyState() {
 			bce.ReturnToPool()
 		}
 		mset.batchApply = nil
+	}
+}
+
+// Lock should be held.
+func (mset *stream) deleteFastBatches() {
+	if mset.batches != nil {
+		mset.batches.mu.Lock()
+		for batchId, b := range mset.batches.fast {
+			b.cleanupLocked(batchId, mset.batches)
+		}
+		mset.batches.fast = nil
+		mset.batches.mu.Unlock()
 	}
 }
 
@@ -4956,7 +5048,131 @@ func getBatchId(hdr []byte) string {
 	if len(hdr) == 0 {
 		return _EMPTY_
 	}
-	return string(getHeader(JSBatchId, hdr))
+	if atomicBatchId := sliceHeader(JSBatchId, hdr); atomicBatchId != nil {
+		return string(atomicBatchId)
+	}
+	return _EMPTY_
+}
+
+type FastBatch struct {
+	id        string
+	seq       uint64
+	flow      uint16
+	ping      bool
+	gapOk     bool
+	commit    bool
+	commitEob bool
+}
+
+const (
+	FastBatchSuffix  = ".$FI"
+	FastBatchGapFail = "fail"
+	FastBatchGapOk   = "ok"
+)
+
+const (
+	FastBatchOpStart = iota
+	FastBatchOpAppend
+	FastBatchOpCommit
+	FastBatchOpCommitEob
+	FastBatchOpPing
+)
+
+var fastBatchPool sync.Pool
+
+func getFastBatchFromPool() *FastBatch {
+	idx := fastBatchPool.Get()
+	if idx != nil {
+		return idx.(*FastBatch)
+	}
+	return new(FastBatch)
+}
+
+func (b *FastBatch) returnToPool() {
+	if b == nil {
+		return
+	}
+	// Nil out all values.
+	*b = FastBatch{}
+	fastBatchPool.Put(b)
+}
+
+// getFastBatch gets fast batch info from the reply subject in the form:
+// <prefix>.<uuid>.<initial flow>.<gap mode>.<batch seq>.<operation>.$FI
+func getFastBatch(reply string) (*FastBatch, bool) {
+	lreply := len(reply)
+	if lreply <= 4 || reply[lreply-4:] != FastBatchSuffix {
+		return nil, false
+	}
+
+	n := lreply - 4 // Move to just before the dot
+	o := strings.LastIndexByte(reply[:n], '.')
+	if o == -1 {
+		return nil, true
+	}
+	// Batch operation.
+	ops := reply[o+1 : n]
+	op := parseInt64(stringToBytes(ops))
+	if op < FastBatchOpStart || op > FastBatchOpPing {
+		return nil, true
+	}
+
+	b := getFastBatchFromPool()
+	b.ping = op == FastBatchOpPing
+	b.commitEob = op == FastBatchOpCommitEob
+	b.commit = b.commitEob || op == FastBatchOpCommit
+	p := o
+	// Batch seq.
+	if o = strings.LastIndexByte(reply[:o], '.'); o == -1 {
+		return nil, true
+	} else {
+		a := parseInt64(stringToBytes(reply[o+1 : p]))
+		if a < 1 {
+			return nil, true
+		}
+		b.seq = uint64(a)
+		p = o
+		if b.seq <= 0 {
+			return nil, true
+		}
+		if op == FastBatchOpStart && b.seq != 1 {
+			return nil, true
+		} else if op == FastBatchOpAppend && b.seq <= 1 {
+			return nil, true
+		}
+	}
+	// Gap mode.
+	if o = strings.LastIndexByte(reply[:o], '.'); o == -1 {
+		return nil, true
+	} else {
+		gapMode := reply[o+1 : p]
+		if gapMode != FastBatchGapFail && gapMode != FastBatchGapOk {
+			return nil, true // Not recognized.
+		}
+		b.gapOk = gapMode == FastBatchGapOk
+		p = o
+	}
+	// Ack flow.
+	if o = strings.LastIndexByte(reply[:o], '.'); o == -1 {
+		return nil, true
+	} else {
+		a := parseInt64(stringToBytes(reply[o+1 : p]))
+		if a <= 0 {
+			a = 10
+		} else if a > math.MaxUint16 {
+			a = math.MaxUint16
+		}
+		b.flow = uint16(a)
+		p = o
+	}
+	// Batch id.
+	if o = strings.LastIndexByte(reply[:o], '.'); o == -1 {
+		return nil, true
+	} else {
+		b.id = reply[o+1 : p]
+	}
+
+	return b, false
 }
 
 // Fast lookup of batch sequence.
@@ -5435,7 +5651,11 @@ var (
 )
 
 // processJetStreamMsg is where we try to actually process the stream msg.
-func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, lseq uint64, ts int64, mt *msgTrace, sourced bool, needLock bool) (retErr error) {
+func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, lseq uint64, ts int64, mt *msgTrace, sourced bool, needLock bool) error {
+	return mset.processJetStreamMsgWithBatch(subject, reply, hdr, msg, lseq, ts, mt, sourced, needLock, nil)
+}
+
+func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg []byte, lseq uint64, ts int64, mt *msgTrace, sourced bool, needLock bool, fastBatch *FastBatch) (retErr error) {
 	if mt != nil {
 		// Only the leader/standalone will have mt!=nil. On exit, send the
 		// message trace event.
@@ -5497,11 +5717,28 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 
 	var resp = &JSPubAckResponse{}
 
-	var batchId string
-	var batchSeq uint64
-	if len(hdr) > 0 {
-		// Populate batch details.
+	var (
+		batchId     string
+		batchSeq    uint64
+		batchAtomic bool
+	)
+	// Populate batch details.
+	if fastBatch != nil {
+		// For R1 we can reuse without regenerating.
+		batchId, batchSeq = fastBatch.id, fastBatch.seq
+		// Disable consistency checking if this was already done
+		// earlier as part of the batch consistency check.
+		canConsistencyCheck = traceOnly
+	} else if fastBatch, _ = getFastBatch(reply); fastBatch != nil {
+		defer fastBatch.returnToPool()
+		batchId, batchSeq = fastBatch.id, fastBatch.seq
+		// Disable consistency checking if this was already done
+		// earlier as part of the batch consistency check.
+		canConsistencyCheck = traceOnly
+	}
+	if len(hdr) > 0 && batchId == _EMPTY_ {
 		if batchId = getBatchId(hdr); batchId != _EMPTY_ {
+			batchAtomic = true
 			batchSeq, _ = getBatchSequence(hdr)
 			// Disable consistency checking if this was already done
 			// earlier as part of the batch consistency check.
@@ -6061,6 +6298,18 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		if msgId != _EMPTY_ {
 			mset.storeMsgId(&ddentry{msgId, mset.lseq, ts})
 		}
+		// If using fast batch publish, we occasionally send flow control messages.
+		// And, we need to ensure a PubAck is sent if the commit happens through EOB.
+		if batchId != _EMPTY_ && !batchAtomic && mset.batches != nil {
+			batches := mset.batches
+			batches.mu.Lock()
+			commit := batches.fastBatchRegisterSequences(mset, reply, batchId, batchSeq, mset.lseq)
+			batches.mu.Unlock()
+			if !commit {
+				reply = _EMPTY_
+				canRespond = false
+			}
+		}
 		if canRespond {
 			response = append(pubAck, strconv.FormatUint(mset.lseq, 10)...)
 			if batchId != _EMPTY_ {
@@ -6238,6 +6487,19 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 		outq.send(newJSPubMsg(tsubj, _EMPTY_, _EMPTY_, hdr, rpMsg, nil, seq))
 	}
 
+	// If using fast batch publish, we occasionally send flow control messages.
+	// And, we need to ensure a PubAck is sent if the commit happens through EOB.
+	if batchId != _EMPTY_ && !batchAtomic && mset.batches != nil {
+		batches := mset.batches
+		batches.mu.Lock()
+		commit := batches.fastBatchRegisterSequences(mset, reply, batchId, batchSeq, mset.lseq)
+		batches.mu.Unlock()
+		if !commit {
+			reply = _EMPTY_
+			canRespond = false
+		}
+	}
+
 	// Send response here.
 	if canRespond {
 		response = append(pubAck, strconv.FormatUint(seq, 10)...)
@@ -6265,12 +6527,9 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 	return nil
 }
 
-// processJetStreamBatchMsg processes a JetStream message that's part of an atomic batch publish.
+// processJetStreamAtomicBatchMsg processes a JetStream message that's part of an atomic batch publish.
 // Handles constraints around the batch, storing messages, doing consistency checks, and performing the commit.
-func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr, msg []byte, mt *msgTrace) (retErr error) {
-	// For possible error response.
-	var response []byte
-
+func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply string, hdr, msg []byte, mt *msgTrace) (retErr error) {
 	mset.mu.RLock()
 	canRespond := !mset.cfg.NoAck && len(reply) > 0
 	name, stype := mset.cfg.Name, mset.cfg.Storage
@@ -6297,26 +6556,27 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 		return NewJSClusterNotLeaderError()
 	}
 
+	respondError := func(apiErr *ApiError) error {
+		if canRespond {
+			buf, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: apiErr})
+			outq.sendMsg(reply, buf)
+		}
+		return apiErr
+	}
+
 	// Bail here if sealed.
 	if isSealed {
-		var resp = JSPubAckResponse{PubAck: &PubAck{Stream: mset.name()}, Error: NewJSStreamSealedError()}
-		b, _ := json.Marshal(resp)
-		mset.outq.sendMsg(reply, b)
-		return NewJSStreamSealedError()
+		return respondError(NewJSStreamSealedError())
 	}
 
 	// Check here pre-emptively if we have exceeded this server limits.
 	if js.limitsExceeded(stype) {
 		s.resourcesExceededError(stype)
-		if canRespond {
-			b, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: NewJSInsufficientResourcesError()})
-			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, b, nil, 0))
-		}
 		// Stepdown regardless.
 		if node := mset.raftNode(); node != nil {
 			node.StepDown()
 		}
-		return NewJSInsufficientResourcesError()
+		return respondError(NewJSInsufficientResourcesError())
 	}
 
 	// Check here pre-emptively if we have exceeded our account limits.
@@ -6325,13 +6585,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 			err = NewJSAccountResourcesExceededError()
 		}
 		s.RateLimitWarnf("JetStream account limits exceeded for '%s': %s", jsa.acc().GetName(), err.Error())
-		if canRespond {
-			var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-			resp.Error = err
-			response, _ = json.Marshal(resp)
-			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
-		}
-		return err
+		return respondError(err)
 	}
 
 	// Check msgSize if we have a limit set there. Again this works if it goes through but better to be pre-emptive.
@@ -6339,65 +6593,38 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 	if maxMsgSize >= 0 && (len(hdr) > maxMsgSize || len(msg) > maxMsgSize-len(hdr)) {
 		err := fmt.Errorf("JetStream message size exceeds limits for '%s > %s'", jsa.acc().Name, mset.cfg.Name)
 		s.RateLimitWarnf("%s", err.Error())
-		if canRespond {
-			var resp = &JSPubAckResponse{PubAck: &PubAck{Stream: name}}
-			resp.Error = NewJSStreamMessageExceedsMaximumError()
-			response, _ = json.Marshal(resp)
-			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, response, nil, 0))
-		}
+		_ = respondError(NewJSStreamMessageExceedsMaximumError())
 		return err
 	}
 
 	if !allowAtomicPublish {
-		err := NewJSAtomicPublishDisabledError()
-		if canRespond {
-			b, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
-			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, b, nil, 0))
-		}
-		return err
+		return respondError(NewJSAtomicPublishDisabledError())
 	}
 
 	// Batch ID is too long.
 	if len(batchId) > 64 {
-		err := NewJSAtomicPublishInvalidBatchIDError()
-		if canRespond {
-			b, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
-			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, b, nil, 0))
-		}
-		return err
+		return respondError(NewJSAtomicPublishInvalidBatchIDError())
 	}
 
 	batchSeq, exists := getBatchSequence(hdr)
 	if !exists {
-		err := NewJSAtomicPublishMissingSeqError()
-		if canRespond {
-			b, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
-			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, b, nil, 0))
-		}
-		return err
+		return respondError(NewJSAtomicPublishMissingSeqError())
 	}
 
 	mset.mu.Lock()
 	if mset.batches == nil {
-		mset.batches = &batching{
-			group: make(map[string]*batchGroup, 1),
-		}
+		mset.batches = &batching{}
 	}
 	batches := mset.batches
 	mset.mu.Unlock()
 
 	respondIncompleteBatch := func() error {
-		err := NewJSAtomicPublishIncompleteBatchError()
-		if canRespond {
-			buf, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
-			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, buf, nil, 0))
-		}
-		return err
+		return respondError(NewJSAtomicPublishIncompleteBatchError())
 	}
 
 	// Get batch.
 	batches.mu.Lock()
-	b, ok := batches.group[batchId]
+	b, ok := batches.atomic[batchId]
 	if !ok {
 		if batchSeq != 1 {
 			batches.mu.Unlock()
@@ -6408,11 +6635,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 			}
 			if batchSeq > uint64(maxBatchSize) {
 				err := NewJSAtomicPublishTooLargeBatchError(maxBatchSize)
-				if canRespond {
-					buf, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
-					outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, buf, nil, 0))
-				}
-				return err
+				return respondError(err)
 			}
 			return respondIncompleteBatch()
 		}
@@ -6429,7 +6652,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 		}
 
 		// Confirm we can facilitate an additional batch.
-		if len(batches.group)+1 > maxInflightPerStream {
+		if len(batches.atomic)+1 > maxInflightPerStream {
 			batches.mu.Unlock()
 			return respondIncompleteBatch()
 		}
@@ -6442,12 +6665,16 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 		}
 
 		var err error
-		if b, err = batches.newBatchGroup(mset, batchId); err != nil {
+		b, err = batches.newAtomicBatch(mset, batchId)
+		if err != nil {
 			globalInflightBatches.Add(-1)
 			batches.mu.Unlock()
 			return respondIncompleteBatch()
 		}
-		batches.group[batchId] = b
+		if batches.atomic == nil {
+			batches.atomic = make(map[string]*atomicBatch, 1)
+		}
+		batches.atomic[batchId] = b
 	}
 
 	var commit, commitEob bool
@@ -6458,11 +6685,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 			b.cleanupLocked(batchId, batches)
 			batches.mu.Unlock()
 			err := NewJSAtomicPublishInvalidBatchCommitError()
-			if canRespond {
-				b, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
-				outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, b, nil, 0))
-			}
-			return err
+			return respondError(err)
 		}
 		commit = true
 	}
@@ -6473,18 +6696,17 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 			b.cleanupLocked(batchId, batches)
 			batches.mu.Unlock()
 			err := NewJSRequiredApiLevelError()
-			if canRespond {
-				b, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
-				outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, b, nil, 0))
-			}
-			return err
+			return respondError(err)
 		}
 		hdr = removeHeaderIfPresent(hdr, JSRequiredApiLevel)
 	}
 
+	// If cleanup has already happened, we can't continue.
+	cleanup := !b.resetCleanupTimer(mset)
+
 	// Detect gaps.
 	b.lseq++
-	if b.lseq != batchSeq {
+	if b.lseq != batchSeq || cleanup {
 		b.cleanupLocked(batchId, batches)
 		batches.mu.Unlock()
 		mset.sendStreamBatchAbandonedAdvisory(batchId, BatchIncomplete)
@@ -6501,11 +6723,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 		batches.mu.Unlock()
 		mset.sendStreamBatchAbandonedAdvisory(batchId, BatchLarge)
 		err := NewJSAtomicPublishTooLargeBatchError(maxSize)
-		if canRespond {
-			buf, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: err})
-			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, buf, nil, 0))
-		}
-		return err
+		return respondError(err)
 	}
 
 	// Persist, but optimize if we're committing because we already know last.
@@ -6523,7 +6741,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 		batches.mu.Unlock()
 		// Send empty ack to let them know we've persisted the data prior to commit.
 		if canRespond {
-			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, nil, nil, 0))
+			outq.sendMsg(reply, nil)
 		}
 		return nil
 	}
@@ -6551,25 +6769,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 	// We only use mset.clseq for clustering and in case we run ahead of actual commits.
 	// Check if we need to set initial value here
 	if isClustered && (mset.clseq == 0 || mset.clseq < lseq+mset.clfs) {
-		// Need to unlock and re-acquire the locks in the proper order.
-		mset.clMu.Unlock()
-		// Locking order is stream -> batchMu -> clMu
-		mset.mu.RLock()
-		batch := mset.batchApply
-		var batchCount uint64
-		if batch != nil {
-			batch.mu.Lock()
-			batchCount = batch.count
-		}
-		mset.clMu.Lock()
-		// Re-capture
-		lseq = mset.lseq
-		mset.clseq = lseq + mset.clfs + batchCount
-		// Keep hold of the mset.clMu, but unlock the others.
-		if batch != nil {
-			batch.mu.Unlock()
-		}
-		mset.mu.RUnlock()
+		lseq = recalculateClusteredSeq(mset)
 	}
 
 	rollback := func(seq uint64) {
@@ -6586,10 +6786,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 		rollback(seq)
 		b.cleanupLocked(batchId, batches)
 		batches.mu.Unlock()
-		if canRespond {
-			buf, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: apiErr})
-			outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, buf, nil, 0))
-		}
+		_ = respondError(apiErr)
 		return apiErr
 	}
 
@@ -6632,10 +6829,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 			rollback(seq)
 			b.cleanupLocked(batchId, batches)
 			batches.mu.Unlock()
-			if canRespond {
-				buf, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: apiErr})
-				outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, nil, buf, nil, 0))
-			}
+			_ = respondError(apiErr)
 			return err
 		}
 
@@ -6684,7 +6878,7 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 					bhdr = genHeader(bhdr, JSBatchCommit, "1")
 				}
 			}
-			mset.processJetStreamMsg(bsubj, _reply, bhdr, bmsg, 0, 0, mt, false, false)
+			_ = mset.processJetStreamMsg(bsubj, _reply, bhdr, bmsg, 0, 0, mt, false, false)
 		}
 		mset.mu.Unlock()
 	} else {
@@ -6705,6 +6899,295 @@ func (mset *stream) processJetStreamBatchMsg(batchId, subject, reply string, hdr
 	}
 	b.cleanupLocked(batchId, batches)
 	batches.mu.Unlock()
+	return nil
+}
+
+// processJetStreamFastBatchMsg processes a JetStream message that's part of an atomic batch publish.
+// Handles constraints around the batch, storing messages, doing consistency checks, and performing the commit.
+func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, reply string, hdr, msg []byte, mt *msgTrace) (retErr error) {
+	mset.mu.RLock()
+	canRespond := !mset.cfg.NoAck && len(reply) > 0
+	name, stype := mset.cfg.Name, mset.cfg.Storage
+	discard, discardNewPer, maxMsgs, maxMsgsPer, maxBytes := mset.cfg.Discard, mset.cfg.DiscardNewPer, mset.cfg.MaxMsgs, mset.cfg.MaxMsgsPer, mset.cfg.MaxBytes
+	s, js, jsa, st, r, tierName, outq, node := mset.srv, mset.js, mset.jsa, mset.cfg.Storage, mset.cfg.Replicas, mset.tier, mset.outq, mset.node
+	maxMsgSize, lseq := int(mset.cfg.MaxMsgSize), mset.lseq
+	isLeader, isClustered, isSealed, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, allowBatchPublish := mset.isLeader(), mset.isClustered(), mset.cfg.Sealed, mset.cfg.AllowRollup, mset.cfg.DenyPurge, mset.cfg.AllowMsgTTL, mset.cfg.AllowMsgCounter, mset.cfg.AllowMsgSchedules, mset.cfg.AllowBatchPublish
+	mset.mu.RUnlock()
+
+	// If message tracing (with message delivery), we will need to send the
+	// event on exit in case there was an error (if message was not proposed).
+	// Otherwise, the event will be sent from processJetStreamMsg when
+	// invoked by the leader (from applyStreamEntries).
+	if mt != nil {
+		defer func() {
+			if retErr != nil {
+				mt.sendEventFromJetStream(retErr)
+			}
+		}()
+	}
+
+	// Check that we are the leader. This can be false if we have scaled up from an R1 that had inbound queued messages.
+	if !isLeader {
+		return NewJSClusterNotLeaderError()
+	}
+
+	respondError := func(apiErr *ApiError) error {
+		if canRespond {
+			buf, _ := json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: apiErr})
+			outq.sendMsg(reply, buf)
+		}
+		return apiErr
+	}
+
+	// Bail here if sealed.
+	if isSealed {
+		return respondError(NewJSStreamSealedError())
+	}
+
+	// Check here pre-emptively if we have exceeded this server limits.
+	if js.limitsExceeded(stype) {
+		s.resourcesExceededError(stype)
+		// Stepdown regardless.
+		if node := mset.raftNode(); node != nil {
+			node.StepDown()
+		}
+		return respondError(NewJSInsufficientResourcesError())
+	}
+
+	// Check here pre-emptively if we have exceeded our account limits.
+	if exceeded, err := jsa.wouldExceedLimits(st, tierName, r, subject, hdr, msg); exceeded {
+		if err == nil {
+			err = NewJSAccountResourcesExceededError()
+		}
+		s.RateLimitWarnf("JetStream account limits exceeded for '%s': %s", jsa.acc().GetName(), err.Error())
+		return respondError(err)
+	}
+
+	// Check msgSize if we have a limit set there. Again this works if it goes through but better to be pre-emptive.
+	// Subtract to prevent against overflows.
+	if maxMsgSize >= 0 && (len(hdr) > maxMsgSize || len(msg) > maxMsgSize-len(hdr)) {
+		err := fmt.Errorf("JetStream message size exceeds limits for '%s > %s'", jsa.acc().Name, mset.cfg.Name)
+		s.RateLimitWarnf("%s", err.Error())
+		_ = respondError(NewJSStreamMessageExceedsMaximumError())
+		return err
+	}
+
+	if !allowBatchPublish {
+		return respondError(NewJSBatchPublishDisabledError())
+	}
+
+	if batch == nil {
+		return respondError(NewJSBatchPublishInvalidPatternError())
+	}
+
+	// Batch ID is too long.
+	if len(batch.id) > 64 {
+		return respondError(NewJSBatchPublishInvalidBatchIDError())
+	}
+
+	mset.mu.Lock()
+	if mset.batches == nil {
+		mset.batches = &batching{}
+	}
+	batches := mset.batches
+	mset.mu.Unlock()
+
+	// Get batch.
+	batches.mu.Lock()
+	b, ok := batches.fast[batch.id]
+	if !ok {
+		if batch.seq != 1 {
+			batches.mu.Unlock()
+			return respondError(NewJSBatchPublishUnknownBatchIDError())
+		}
+		// We'll need a copy as we'll use it as a key and later for cleanup.
+		batchId := copyString(batch.id)
+		b = batches.newFastBatch(mset, batchId, batch.gapOk, batch.flow)
+		if batches.fast == nil {
+			batches.fast = make(map[string]*fastBatch, 1)
+		}
+		batches.fast[batchId] = b
+	}
+
+	// The required API level can have the batch be rejected. But the header is always removed.
+	if len(sliceHeader(JSRequiredApiLevel, hdr)) != 0 {
+		if errorOnRequiredApiLevel(hdr) {
+			b.cleanupLocked(batch.id, batches)
+			batches.mu.Unlock()
+			err := NewJSRequiredApiLevelError()
+			return respondError(err)
+		}
+		hdr = removeHeaderIfPresent(hdr, JSRequiredApiLevel)
+	}
+
+	// Fast publishing resets the cleanup timer.
+	// If cleanup has already happened, we can't continue.
+	cleanup := !b.resetCleanupTimer(mset)
+
+	// A ping operation confirms we've received a minimum amount of data and resends ack messages.
+	if batch.ping {
+		sendFlowControl := true
+		// Detect a gap or if the batch was cleaned up in the meantime.
+		if batch.seq > b.lseq || cleanup {
+			// If a gap is detected, we always report about it.
+			buf := BatchFlowGap{ExpectedLastSequence: b.lseq + 1, CurrentSequence: batch.seq + 1}.MarshalJSON()
+			outq.sendMsg(reply, buf)
+			// If the gap is okay, we can continue without rejecting.
+			if b.gapOk && !cleanup {
+				b.lseq = batch.seq
+				if b.pending == 0 {
+					b.pseq = b.lseq
+				}
+				sendFlowControl = !b.checkFlowControl(mset, reply, batches)
+			} else if cleanup = batches.fastBatchCommit(b, batch.id, mset, reply); cleanup {
+				b.cleanupLocked(batch.id, batches)
+				sendFlowControl = false
+			}
+		}
+		if sendFlowControl {
+			b.sendFlowControl(b.fseq, mset, reply)
+		}
+		batches.mu.Unlock()
+		return nil
+	}
+
+	// If the batch is committing, due to an error, we can't add more messages.
+	// We simply skip, since the client will be waiting for the PubAck.
+	if b.commit {
+		// MUST NOT clean up, that will happen when the commit completes.
+		batches.mu.Unlock()
+		return nil
+	}
+
+	// Detect gaps.
+	b.lseq++
+	if b.lseq != batch.seq || cleanup {
+		// If a gap is detected, we always report about it.
+		buf := BatchFlowGap{ExpectedLastSequence: b.lseq - 1, CurrentSequence: batch.seq}.MarshalJSON()
+		outq.sendMsg(reply, buf)
+		// If the gap is okay, we can continue without rejecting.
+		if b.gapOk && !cleanup {
+			b.lseq = batch.seq
+		} else {
+			// Revert, since we incremented for the gap check.
+			b.lseq--
+			if cleanup = batches.fastBatchCommit(b, batch.id, mset, reply); cleanup {
+				b.cleanupLocked(batch.id, batches)
+			}
+			batches.mu.Unlock()
+			return nil
+		}
+	}
+
+	if batch.commit {
+		if batch.commitEob {
+			// Revert, since we incremented for the gap check.
+			b.lseq--
+			// If there is none pending, correct the persisted sequence as we need to commit below.
+			if b.pending == 0 {
+				b.pseq = b.lseq
+			}
+		}
+		// We'll try to immediately send a PubAck if we can.
+		// Only possible if EOB is used and the last message was already persisted
+		// Otherwise, this sets up the commit for the last message we're about to propose.
+		cleanup = batches.fastBatchCommit(b, batch.id, mset, reply)
+		if batch.commitEob {
+			if cleanup {
+				b.cleanupLocked(batch.id, batches)
+			}
+			batches.mu.Unlock()
+			return nil
+		}
+	}
+
+	// The first message in the batch responds with the settings used for flow control.
+	// If committing immediately, we only send the PubAck.
+	if batch.seq == 1 && canRespond && !batch.commit {
+		buf := BatchFlowAck{Sequence: 0, Messages: b.ackMessages}.MarshalJSON()
+		outq.sendMsg(reply, buf)
+	}
+
+	// Proceed with proposing this message.
+
+	// We only use mset.clseq for clustering and in case we run ahead of actual commits.
+	// Check if we need to set initial value here
+	mset.clMu.Lock()
+	if mset.clseq == 0 || mset.clseq < lseq+mset.clfs {
+		lseq = recalculateClusteredSeq(mset)
+	}
+
+	var (
+		dseq   uint64
+		apiErr *ApiError
+		err    error
+	)
+	diff := &batchStagedDiff{}
+	if hdr, msg, dseq, apiErr, err = checkMsgHeadersPreClusteredProposal(diff, mset, subject, hdr, msg, false, name, jsa, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, discard, discardNewPer, maxMsgSize, maxMsgs, maxMsgsPer, maxBytes); err != nil {
+		mset.clMu.Unlock()
+
+		// If the message is a duplicate, and we have no pending messages, we should check if we need to
+		// send the flow control message here.
+		if err == errMsgIdDuplicate {
+			if b.pending == 0 {
+				b.pseq = batch.seq
+				b.checkFlowControl(mset, reply, batches)
+			}
+			if !batch.commit {
+				// Otherwise, just skip.
+				batches.mu.Unlock()
+				return err
+			}
+		}
+
+		// If a batch immediately errors, we send the same response as we would a normal publish.
+		if !batch.gapOk && b.lseq == 1 {
+			var response []byte
+			if err == errMsgIdDuplicate && dseq > 0 {
+				var buf [256]byte
+				response = append(buf[:0], mset.pubAck...)
+				response = append(response, strconv.FormatUint(dseq, 10)...)
+				response = append(response, fmt.Sprintf(",\"duplicate\": true,\"batch\":%q,\"count\":%d}", batch.id, batch.seq)...)
+			} else {
+				response, _ = json.Marshal(&JSPubAckResponse{PubAck: &PubAck{Stream: name}, Error: apiErr})
+			}
+			b.cleanupLocked(batch.id, batches)
+			batches.mu.Unlock()
+			outq.sendMsg(reply, response)
+			return err
+		}
+
+		// We always return the error to the client, unless it's a duplicate.
+		if err != errMsgIdDuplicate {
+			buf := BatchFlowErr{Sequence: batch.seq, Error: apiErr}.MarshalJSON()
+			outq.sendMsg(reply, buf)
+		}
+
+		// If gaps are okay, we just allow them to continue.
+		if batch.gapOk {
+			batches.mu.Unlock()
+			return err
+		}
+
+		// Revert the last sequence, we might be able to immediately return the PubAck as part of the commit.
+		// Otherwise, the batch is cleaned up automatically later.
+		if err != errMsgIdDuplicate {
+			b.lseq--
+		}
+		if cleanup = batches.fastBatchCommit(b, batch.id, mset, reply); cleanup {
+			b.cleanupLocked(batch.id, batches)
+		}
+		batches.mu.Unlock()
+		return err
+	}
+	b.pending++
+	batches.mu.Unlock()
+	if !isClustered {
+		mset.clMu.Unlock()
+		return mset.processJetStreamMsgWithBatch(subject, reply, hdr, msg, 0, 0, mt, false, true, batch)
+	}
+	commitSingleMsg(diff, mset, subject, reply, hdr, msg, name, jsa, mt, node, r, lseq)
+	mset.clMu.Unlock()
 	return nil
 }
 
@@ -7003,8 +7486,11 @@ func (mset *stream) internalLoop() {
 			ims := msgs.pop()
 			for _, im := range ims {
 				// If we are clustered we need to propose this message to the underlying raft group.
-				if batchId := getBatchId(im.hdr); batchId != _EMPTY_ {
-					mset.processJetStreamBatchMsg(batchId, im.subj, im.rply, im.hdr, im.msg, im.mt)
+				if batch, err := getFastBatch(im.rply); batch != nil || err {
+					mset.processJetStreamFastBatchMsg(batch, im.subj, im.rply, im.hdr, im.msg, im.mt)
+					batch.returnToPool()
+				} else if batchId := getBatchId(im.hdr); batchId != _EMPTY_ {
+					mset.processJetStreamAtomicBatchMsg(batchId, im.subj, im.rply, im.hdr, im.msg, im.mt)
 				} else if isClustered {
 					mset.processClusteredInboundMsg(im.subj, im.rply, im.hdr, im.msg, im.mt, false)
 				} else {


### PR DESCRIPTION
Implements [ADR-50: Fast-ingest Batch Publishing](https://github.com/nats-io/nats-architecture-and-design/blob/92e3d9de94a6031c12352ef6b37ad7ec012b991d/adr/ADR-50.md#fast-ingest-batch-publishing)

Current PR:
- Added `AllowBatchPublish` to the `StreamConfig`, requiring JetStream API level 3.
- Parses the reply subject for fast batch metadata, and reuses the `FastBatch` structs with a `sync.Pool`.
- Static and simple flow control: maximum 500 messages per ack divided by the amount of publishers (with a minimum of 'every message requires 1 ack'). Server allows ramping up and slowing down publishers for 'slow start' scenarios as well as when publishers join or leave.
- The `batching` struct now contains separate `*atomicBatch` and `*fastBatch` storage for better alignment. While atomic batches are limited (as messages get staged in a separate `StreamStore` prior to commit), fast batches are meant to not be limited as they only contain metadata without staging messages.
- Some refactoring to reduce code duplication:
  - Recalculation of the `mset.clseq` was moved to `recalculateClusteredSeq`, to be reused in all three places where it's used.
  - Proposing a single replicated message is now done with the reused `commitSingleMsg`.
- Small update to atomic batch publish to extend the cleanup timer to be "10s after receiving the last message", instead of "10s after receiving the first message".

Future work:
- More intelligent flow control. Basing it on the configured `max_buffered_msgs` and `max_buffered_size` (instead of just static 500 divided by publisher count). Ensuring if all fast publishers would all publish their N messages at once, it all fits within this buffer.
- Efficient handling of leader changes. Followers should also keep track of the fast batches that are inflight, such that they can intelligently report back to the client about detected gaps or batch failures, without all clients needing to restart their batches all at once due to unknown batch ID errors.
- When using account imports/exports the original reply subject is lost. The `ClientInfoHdr` can be extended to contain the original `Reply string`. Support for this should be added, as well as tests. The imports/exports and usage of this header will somewhat slow down performance (when compared to being connected to the correct account), but it should be supported.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>