### PR TITLE
[IMPROVED] Support HTTP proxy connection from leaf nodes also for TCP

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -691,9 +691,8 @@ func (s *Server) connectToRemoteLeafNode(remote *leafNodeCfg, firstConnect bool)
 			} else {
 				s.Debugf("Trying to connect as leafnode to remote server on %q%s", rURL.Host, ipStr)
 
-				// Check if proxy is configured first, then check if URL supports it
-				if proxyURL != _EMPTY_ && isWSURL(rURL) {
-					// Use proxy for WebSocket connections - use original hostname, resolved IP for connection
+				// Check if proxy is configured
+				if proxyURL != _EMPTY_ {
 					targetHost := rURL.Host
 					// If URL doesn't include port, add the default port for the scheme
 					if rURL.Port() == _EMPTY_ {


### PR DESCRIPTION
The leafnode connection via a HTTP proxy does also work for nats via TCP.

HTTP Connect results in a plain TCP connection via a proxy where any TCP protocol can be transmitted.

Signed-off-by: Tim Burkert <tim.burkert@trumpf.com>