### PR TITLE
[FIXED] Filestore message block binary search

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2305,9 +2305,11 @@ func (fs *fileStore) recoverMsgs() error {
 		if mb, err := fs.recoverMsgBlock(uint32(index)); err == nil && mb != nil {
 			// This is a truncate block with possibly no index. If the OS got shutdown
 			// out from underneath of us this is possible.
+			mb.mu.Lock()
 			if mb.first.seq == 0 {
 				mb.dirtyCloseWithRemove(true)
 				fs.removeMsgBlockFromList(mb)
+				mb.mu.Unlock()
 				continue
 			}
 			// If the stream is empty, reset the first/last sequences so these can
@@ -2337,6 +2339,14 @@ func (fs *fileStore) recoverMsgs() error {
 			}
 			fs.state.Msgs += mb.msgs
 			fs.state.Bytes += mb.bytes
+			// If the block is empty, correct the sequences to be aligned with the current filestore state.
+			if mb.msgs == 0 {
+				atomic.StoreUint64(&mb.first.seq, fs.state.LastSeq+1)
+				mb.first.ts = 0
+				atomic.StoreUint64(&mb.last.seq, fs.state.LastSeq)
+				mb.last.ts = fs.state.LastTime.UnixNano()
+			}
+			mb.mu.Unlock()
 		} else {
 			return err
 		}


### PR DESCRIPTION
`fs.selectMsgBlockWithIndex` uses a binary search when the file-based stream contains more than 32 blocks. During normal operations, this will work well to efficiently skip to the correct message block. However, if the block only contains tombstones for prior blocks, and if the server restarts ungracefully (or when restoring a backup), it will recover with lower sequences only representing the tombstones inside of it and potentially not be in-order with the sequences of the other blocks.

Binary search requires the list (in this case `fs.blks`) to be sorted, so it could in some situations not select the right block if the blocks weren't technically "sorted" after such a restart/recovery/restore. This PR fixes that by correcting recovered empty blocks to be aligned with the filestore state.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>