### PR TITLE
(2.14) [IMPROVED] Filestore error handling

### DIFF
--- a/server/avl/norace_test.go
+++ b/server/avl/norace_test.go
@@ -98,8 +98,7 @@ func TestNoRaceSeqSetEncodeLarge(t *testing.T) {
 	expected := time.Millisecond
 
 	start := time.Now()
-	b, err := ss.Encode(nil)
-	require_NoError(t, err)
+	b := ss.Encode(nil)
 
 	if elapsed := time.Since(start); elapsed > expected {
 		t.Fatalf("Expected encode of %d items with encoded size %v to take less than %v, got %v",

--- a/server/avl/seqset.go
+++ b/server/avl/seqset.go
@@ -239,7 +239,7 @@ func (ss SequenceSet) EncodeLen() int {
 	return minLen + (ss.Nodes() * ((numBuckets+1)*8 + 2))
 }
 
-func (ss SequenceSet) Encode(buf []byte) ([]byte, error) {
+func (ss SequenceSet) Encode(buf []byte) []byte {
 	nn, encLen := ss.Nodes(), ss.EncodeLen()
 
 	if cap(buf) < encLen {
@@ -268,7 +268,7 @@ func (ss SequenceSet) Encode(buf []byte) ([]byte, error) {
 		le.PutUint16(buf[i:], uint16(n.h))
 		i += 2
 	})
-	return buf[:i], nil
+	return buf[:i]
 }
 
 // ErrBadEncoding is returned when we can not decode properly.

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1279,7 +1279,9 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 		}
 	} else {
 		// Select starting sequence number
-		o.selectStartingSeqNo()
+		if err := o.selectStartingSeqNo(); err != nil {
+			return nil, err
+		}
 	}
 
 	// Now register with mset and create the ack subscription.
@@ -5961,7 +5963,7 @@ func (o *consumer) reconcileStateWithStream(streamLastSeq uint64) {
 }
 
 // Will select the starting sequence.
-func (o *consumer) selectStartingSeqNo() {
+func (o *consumer) selectStartingSeqNo() error {
 	if o.mset == nil || o.mset.store == nil {
 		o.sseq = 1
 	} else {
@@ -5976,7 +5978,10 @@ func (o *consumer) selectStartingSeqNo() {
 				} else {
 					// If we are partitioned here this will be properly set when we become leader.
 					for _, filter := range o.subjf {
-						ss := o.mset.store.FilteredState(1, filter.subject)
+						ss, err := o.mset.store.FilteredState(1, filter.subject)
+						if err != nil {
+							return err
+						}
 						if ss.Last > o.sseq {
 							o.sseq = ss.Last
 						}
@@ -6022,7 +6027,10 @@ func (o *consumer) selectStartingSeqNo() {
 					nseq := state.LastSeq
 					for _, filter := range o.subjf {
 						// Use first sequence since this is more optimized atm.
-						ss := o.mset.store.FilteredState(state.FirstSeq, filter.subject)
+						ss, err := o.mset.store.FilteredState(state.FirstSeq, filter.subject)
+						if err != nil {
+							return err
+						}
 						if ss.First >= o.sseq && ss.First < nseq {
 							nseq = ss.First
 						}
@@ -6064,8 +6072,11 @@ func (o *consumer) selectStartingSeqNo() {
 	// Set our starting sequence state.
 	// But only if we're not clustered, if clustered we propose upon becoming leader.
 	if o.store != nil && o.sseq > 0 && o.cfg.replicas(&o.mset.cfg) == 1 {
-		o.store.SetStarting(o.sseq - 1)
+		if err := o.store.SetStarting(o.sseq - 1); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // Test whether a config represents a durable subscriber.

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -33,6 +33,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"slices"
 	"sort"
 	"strings"
@@ -40,6 +41,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/klauspost/compress/s2"
 	"github.com/minio/highwayhash"
 	"github.com/nats-io/nats-server/v2/server/ats"
@@ -200,6 +202,7 @@ type fileStore struct {
 	fsld        chan struct{}
 	cmu         sync.RWMutex
 	cfs         []ConsumerStore
+	werr        error
 	sips        int
 	dirty       int
 	closing     bool
@@ -567,7 +570,10 @@ func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created tim
 	// Check if we have any left over tombstones to process.
 	if len(fs.tombs) > 0 {
 		for _, seq := range fs.tombs {
-			fs.removeMsg(seq, false, true, false)
+			_, err = fs.removeMsg(seq, false, true, false)
+			if err != nil && err != ErrStoreEOF && err != ErrStoreMsgNotFound {
+				return nil, err
+			}
 			fs.removeFromLostData(seq)
 		}
 		// Not needed after this phase.
@@ -575,13 +581,16 @@ func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created tim
 	}
 
 	// Limits checks and enforcement.
-	fs.enforceMsgLimit()
-	fs.enforceBytesLimit()
+	if err = fs.enforceMsgLimit(); err != nil {
+		return nil, err
+	}
+	if err = fs.enforceBytesLimit(); err != nil {
+		return nil, err
+	}
 
 	// Do age checks too, make sure to call in place.
 	if fs.cfg.MaxAge != 0 {
-		err := fs.expireMsgsOnRecover()
-		if isPermissionError(err) {
+		if err = fs.expireMsgsOnRecover(); err != nil {
 			return nil, err
 		}
 		fs.startAgeChk()
@@ -589,7 +598,9 @@ func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created tim
 
 	// If we have max msgs per subject make sure the is also enforced.
 	if fs.cfg.MaxMsgsPer > 0 {
-		fs.enforceMsgPerSubjectLimit(false)
+		if err = fs.enforceMsgPerSubjectLimit(false); err != nil {
+			return nil, err
+		}
 	}
 
 	// Grab first sequence for check below while we have lock.
@@ -691,20 +702,32 @@ func (fs *fileStore) UpdateConfig(cfg *StreamConfig) error {
 
 	// Create or delete the THW if needed.
 	if cfg.AllowMsgTTL && fs.ttls == nil {
-		fs.recoverTTLState()
+		if err := fs.recoverTTLState(); err != nil {
+			fs.mu.Unlock()
+			return err
+		}
 	} else if !cfg.AllowMsgTTL && fs.ttls != nil {
 		fs.ttls = nil
 	}
 	// Create or delete the message scheduling state if needed.
 	if cfg.AllowMsgSchedules && fs.scheduling == nil {
-		fs.recoverMsgSchedulingState()
+		if err := fs.recoverMsgSchedulingState(); err != nil {
+			fs.mu.Unlock()
+			return err
+		}
 	} else if !cfg.AllowMsgSchedules && fs.scheduling != nil {
 		fs.scheduling = nil
 	}
 
 	// Limits checks and enforcement.
-	fs.enforceMsgLimit()
-	fs.enforceBytesLimit()
+	if err := fs.enforceMsgLimit(); err != nil {
+		fs.mu.Unlock()
+		return err
+	}
+	if err := fs.enforceBytesLimit(); err != nil {
+		fs.mu.Unlock()
+		return err
+	}
 
 	// Do age timers.
 	if fs.ageChk == nil && fs.cfg.MaxAge != 0 {
@@ -717,7 +740,10 @@ func (fs *fileStore) UpdateConfig(cfg *StreamConfig) error {
 	}
 
 	if fs.cfg.MaxMsgsPer > 0 && (old_cfg.MaxMsgsPer == 0 || fs.cfg.MaxMsgsPer < old_cfg.MaxMsgsPer) {
-		fs.enforceMsgPerSubjectLimit(true)
+		if err := fs.enforceMsgPerSubjectLimit(true); err != nil {
+			fs.mu.Unlock()
+			return err
+		}
 	}
 
 	if lmb := fs.lmb; lmb != nil {
@@ -743,8 +769,12 @@ func (fs *fileStore) UpdateConfig(cfg *StreamConfig) error {
 				close(lmb.qch)
 				lmb.qch = nil
 			}
-			lmb.flushPendingMsgsLocked()
+			_, err := lmb.flushPendingMsgsLocked()
 			lmb.mu.Unlock()
+			if err != nil {
+				fs.mu.Unlock()
+				return err
+			}
 		}
 		// Set flush in place to AsyncFlush which by default is false.
 		fs.fip = !fs.fcfg.AsyncFlush
@@ -1162,7 +1192,9 @@ func (fs *fileStore) recoverMsgBlock(index uint32) (*msgBlock, error) {
 	}
 
 	// Make sure encryption loaded if needed.
-	fs.loadEncryptionForMsgBlock(mb)
+	if err = fs.loadEncryptionForMsgBlock(mb); err != nil {
+		return nil, err
+	}
 
 	// Grab last checksum from main block file.
 	var lchk [8]byte
@@ -1176,12 +1208,14 @@ func (fs *fileStore) recoverMsgBlock(index uint32) (*msgBlock, error) {
 			}
 			// We can recycle it now.
 			recycleMsgBlockBuf(buf)
-		} else {
-			file.ReadAt(lchk[:], int64(mb.rbytes)-checksumSize)
+		} else if _, err = file.ReadAt(lchk[:], int64(mb.rbytes)-checksumSize); err != nil {
+			return nil, err
 		}
 	}
 
-	file.Close()
+	if err = file.Close(); err != nil {
+		return nil, err
+	}
 
 	// Read our index file. Use this as source of truth if possible.
 	// This not applicable in >= 2.10 servers. Here for upgrade paths from < 2.10.
@@ -1190,7 +1224,9 @@ func (fs *fileStore) recoverMsgBlock(index uint32) (*msgBlock, error) {
 		// Note this only checks that the message blk file is not newer then this file, or is empty and we expect empty.
 		if (mb.rbytes == 0 && mb.msgs == 0) || bytes.Equal(lchk[:], mb.lchk[:]) {
 			if mb.msgs > 0 && !mb.noTrack && fs.psim != nil {
-				fs.populateGlobalPerSubjectInfo(mb)
+				if err = fs.populateGlobalPerSubjectInfo(mb); err != nil {
+					return nil, err
+				}
 				// Try to dump any state we needed on recovery.
 				mb.tryForceExpireCacheLocked()
 			}
@@ -1200,8 +1236,10 @@ func (fs *fileStore) recoverMsgBlock(index uint32) (*msgBlock, error) {
 	}
 
 	// If we get data loss rebuilding the message block state record that with the fs itself.
-	ld, tombs, _ := mb.rebuildState()
-	if ld != nil {
+	ld, tombs, err := mb.rebuildState()
+	if err != nil {
+		return nil, err
+	} else if ld != nil {
 		fs.addLostData(ld)
 	}
 	// Collect all tombstones.
@@ -1210,12 +1248,16 @@ func (fs *fileStore) recoverMsgBlock(index uint32) (*msgBlock, error) {
 	}
 
 	if mb.msgs > 0 && !mb.noTrack && fs.psim != nil {
-		fs.populateGlobalPerSubjectInfo(mb)
+		if err = fs.populateGlobalPerSubjectInfo(mb); err != nil {
+			return nil, err
+		}
 		// Try to dump any state we needed on recovery.
 		mb.tryForceExpireCacheLocked()
 	}
 
-	mb.closeFDs()
+	if err = mb.closeFDs(); err != nil {
+		return nil, err
+	}
 	fs.addMsgBlock(mb)
 
 	return mb, nil
@@ -1459,6 +1501,10 @@ func (mb *msgBlock) rebuildStateLocked() (*LostStreamData, []uint64, error) {
 	defer recycleMsgBlockBuf(buf)
 
 	if err != nil || len(buf) == 0 {
+		// Only allow continuing to mark lost data if the file itself doesn't exist, or was empty.
+		if err != nil && err != errNoBlkData {
+			return nil, nil, err
+		}
 		var ld *LostStreamData
 		// No data to rebuild from here.
 		if mb.msgs > 0 {
@@ -1475,7 +1521,7 @@ func (mb *msgBlock) rebuildStateLocked() (*LostStreamData, []uint64, error) {
 			mb.dmap.Empty()
 			atomic.StoreUint64(&mb.first.seq, atomic.LoadUint64(&mb.last.seq)+1)
 		}
-		return ld, nil, err
+		return ld, nil, nil
 	}
 
 	// Check if we need to decrypt.
@@ -1509,15 +1555,37 @@ func (mb *msgBlock) rebuildStateFromBufLocked(buf []byte, allowTruncate bool) (*
 		mb.dmap.Insert(seq)
 	}
 
+	// For tombstones that we find and collect.
+	var (
+		tombstones      []uint64
+		maxTombstoneSeq uint64
+		maxTombstoneTs  int64
+	)
+
+	defer func() {
+		// For empty msg blocks make sure we recover last seq correctly based off of first.
+		// Or if we seem to have no messages but had a tombstone, which we use to remember
+		// sequences and timestamps now, use that to properly setup the first and last.
+		if mb.msgs == 0 {
+			fseq := atomic.LoadUint64(&mb.first.seq)
+			if fseq > 0 {
+				atomic.StoreUint64(&mb.last.seq, fseq-1)
+			} else if fseq == 0 && maxTombstoneSeq > 0 {
+				atomic.StoreUint64(&mb.first.seq, maxTombstoneSeq+1)
+				mb.first.ts = 0
+				if mb.last.seq == 0 {
+					atomic.StoreUint64(&mb.last.seq, maxTombstoneSeq)
+					mb.last.ts = maxTombstoneTs
+				}
+			}
+		}
+	}()
+
 	var le = binary.LittleEndian
 
-	truncate := func(index uint32) {
-		// There are cases where we're not allowed to truncate, like for an encrypted or compressed
-		// block since the index will be the decrypted and decompressed index.
-		if !allowTruncate {
-			return
-		}
-
+	// There are cases where we're not allowed to truncate, like for an encrypted or compressed
+	// block since the index will be the decrypted and decompressed index.
+	truncate := func(index uint32) error {
 		var fd *os.File
 		if mb.mfd != nil {
 			fd = mb.mfd
@@ -1530,17 +1598,24 @@ func (mb *msgBlock) rebuildStateFromBufLocked(buf []byte, allowTruncate bool) (*
 			}
 		}
 		if fd == nil {
-			return
+			return nil
 		}
-		if err := fd.Truncate(int64(index)); err == nil {
-			// Update our checksum.
-			if index >= 8 {
-				var lchk [8]byte
-				fd.ReadAt(lchk[:], int64(index-8))
-				copy(mb.lchk[0:], lchk[:])
+		if err := fd.Truncate(int64(index)); err != nil {
+			return err
+		}
+
+		// Update our checksum.
+		if index >= 8 {
+			var lchk [8]byte
+			if _, err = fd.ReadAt(lchk[:], int64(index-8)); err != nil {
+				return err
 			}
-			fd.Sync()
+			copy(mb.lchk[0:], lchk[:])
 		}
+		if err = fd.Sync(); err != nil {
+			return err
+		}
+		return nil
 	}
 
 	gatherLost := func(lb uint32) *LostStreamData {
@@ -1551,13 +1626,6 @@ func (mb *msgBlock) rebuildStateFromBufLocked(buf []byte, allowTruncate bool) (*
 		ld.Bytes = uint64(lb)
 		return &ld
 	}
-
-	// For tombstones that we find and collect.
-	var (
-		tombstones      []uint64
-		maxTombstoneSeq uint64
-		maxTombstoneTs  int64
-	)
 
 	// To detect gaps from compaction, and to ensure the sequence keeps moving up.
 	var last uint64
@@ -1582,8 +1650,13 @@ func (mb *msgBlock) rebuildStateFromBufLocked(buf []byte, allowTruncate bool) (*
 
 	for index, lbuf := uint32(0), uint32(len(buf)); index < lbuf; {
 		if index+msgHdrSize > lbuf {
-			truncate(index)
-			return gatherLost(lbuf - index), tombstones, nil
+			err = errBadMsg{mb.mfn, fmt.Sprintf("message overrun (index %d lbuf %d)", index, lbuf)}
+			if allowTruncate {
+				if err = truncate(index); err != nil {
+					return nil, nil, err
+				}
+			}
+			return gatherLost(lbuf - index), tombstones, err
 		}
 
 		hdr := buf[index : index+msgHdrSize]
@@ -1599,8 +1672,13 @@ func (mb *msgBlock) rebuildStateFromBufLocked(buf []byte, allowTruncate bool) (*
 		dlen := int(rl) - msgHdrSize
 		// Do some quick sanity checks here.
 		if dlen < 0 || shlen > (dlen-recordHashSize) || dlen > int(rl) || index+rl > lbuf || rl > rlBadThresh {
-			truncate(index)
-			return gatherLost(lbuf - index), tombstones, errBadMsg{mb.mfn, fmt.Sprintf("sanity check failed (dlen %d slen %d rl %d index %d lbuf %d)", dlen, slen, rl, index, lbuf)}
+			err = errBadMsg{mb.mfn, fmt.Sprintf("sanity check failed (dlen %d slen %d rl %d index %d lbuf %d)", dlen, slen, rl, index, lbuf)}
+			if allowTruncate {
+				if err = truncate(index); err != nil {
+					return nil, nil, err
+				}
+			}
+			return gatherLost(lbuf - index), tombstones, err
 		}
 
 		// Check for checksum failures before additional processing.
@@ -1617,8 +1695,13 @@ func (mb *msgBlock) rebuildStateFromBufLocked(buf []byte, allowTruncate bool) (*
 			}
 			checksum := hh.Sum(hb[:0])
 			if !bytes.Equal(checksum, data[len(data)-recordHashSize:]) {
-				truncate(index)
-				return gatherLost(lbuf - index), tombstones, errBadMsg{mb.mfn, "invalid checksum"}
+				err = errBadMsg{mb.mfn, "invalid checksum"}
+				if allowTruncate {
+					if err = truncate(index); err != nil {
+						return nil, nil, err
+					}
+				}
+				return gatherLost(lbuf - index), tombstones, err
 			}
 			copy(mb.lchk[0:], checksum)
 		}
@@ -1713,6 +1796,16 @@ func (fs *fileStore) warn(format string, args ...any) {
 	fs.srv.Warnf(fmt.Sprintf("Filestore [%s] %s", fs.cfg.Name, format), args...)
 }
 
+// For doing error logging.
+// Lock should be held.
+func (fs *fileStore) error(format string, args ...any) {
+	// No-op if no server configured.
+	if fs.srv == nil {
+		return
+	}
+	fs.srv.Errorf(fmt.Sprintf("Filestore [%s] %s", fs.cfg.Name, format), args...)
+}
+
 // For doing debug logging.
 // Lock should be held.
 func (fs *fileStore) debug(format string, args ...any) {
@@ -1757,7 +1850,10 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 
 	// Check for any left over purged messages.
 	<-dios
-	fs.recoverPartialPurge()
+	if err := fs.recoverPartialPurge(); err != nil {
+		dios <- struct{}{}
+		return err
+	}
 	// Grab our stream state file and load it in.
 	fn := filepath.Join(fs.fcfg.StoreDir, msgDir, streamStreamStateFile)
 	buf, err := os.ReadFile(fn)
@@ -1772,7 +1868,7 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 
 	const minLen = 32
 	if len(buf) < minLen {
-		os.Remove(fn)
+		_ = os.Remove(fn)
 		fs.warn("Stream state too short (%d bytes)", len(buf))
 		return errCorruptState
 	}
@@ -1784,7 +1880,7 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 	fs.hh.Write(buf)
 	var hb [highwayhash.Size64]byte
 	if !bytes.Equal(h, fs.hh.Sum(hb[:0])) {
-		os.Remove(fn)
+		_ = os.Remove(fn)
 		fs.warn("Stream state checksum did not match")
 		return errCorruptState
 	}
@@ -1803,7 +1899,7 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 
 	version := buf[1]
 	if buf[0] != fullStateMagic || version < fullStateMinVersion || version > fullStateVersion {
-		os.Remove(fn)
+		_ = os.Remove(fn)
 		fs.warn("Stream state magic and version mismatch")
 		return errCorruptState
 	}
@@ -1858,7 +1954,7 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 		for i := 0; i < numSubjects; i++ {
 			if lsubj := int(readU64()); lsubj > 0 {
 				if bi+lsubj > len(buf) {
-					os.Remove(fn)
+					_ = os.Remove(fn)
 					fs.warn("Stream state bad subject len (%d)", lsubj)
 					return errCorruptState
 				}
@@ -1869,7 +1965,7 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 				// We had a bug that could cause memory corruption in the PSIM that could have gotten stored to disk.
 				// Only would affect subjects, so do quick check.
 				if !isValidSubject(bytesToString(subj), true) {
-					os.Remove(fn)
+					_ = os.Remove(fn)
 					fs.warn("Stream state corrupt subject detected")
 					return errCorruptState
 				}
@@ -1903,7 +1999,7 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 				schedules = readU64()
 			}
 			if bi < 0 {
-				os.Remove(fn)
+				_ = os.Remove(fn)
 				return errCorruptState
 			}
 			mb := fs.initMsgBlock(index)
@@ -1916,7 +2012,7 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 			if numDeleted > 0 {
 				dmap, n, err := avl.Decode(buf[bi:])
 				if err != nil {
-					os.Remove(fn)
+					_ = os.Remove(fn)
 					fs.warn("Stream state error decoding avl dmap: %v", err)
 					return errCorruptState
 				}
@@ -1955,7 +2051,7 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 
 	// Check if we had any errors.
 	if bi < 0 {
-		os.Remove(fn)
+		_ = os.Remove(fn)
 		fs.warn("Stream state has no checksum present")
 		return errCorruptState
 	}
@@ -1968,7 +2064,7 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 	var matched bool
 	mb := fs.lmb
 	if mb == nil || mb.index != blkIndex {
-		os.Remove(fn)
+		_ = os.Remove(fn)
 		fs.warn("Stream state block does not exist or index mismatch")
 		return errCorruptState
 	}
@@ -2030,7 +2126,7 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 	// We check first and last seq and number of msgs and bytes. If there is a difference,
 	// return and error so we rebuild from the message block state on disk.
 	if !trackingStatesEqual(&fs.state, &mstate) {
-		os.Remove(fn)
+		_ = os.Remove(fn)
 		fs.warn("Stream state encountered internal inconsistency on recover")
 		return errCorruptState
 	}
@@ -2057,7 +2153,7 @@ func (fs *fileStore) recoverTTLState() error {
 		ttlseq, err = fs.ttls.Decode(buf)
 		if err != nil {
 			fs.warn("Error decoding TTL state: %s", err)
-			os.Remove(fn)
+			_ = os.Remove(fn)
 		}
 	}
 
@@ -2138,7 +2234,7 @@ func (fs *fileStore) recoverMsgSchedulingState() error {
 		schedSeq, err = fs.scheduling.decode(buf)
 		if err != nil {
 			fs.warn("Error decoding message scheduling state: %s", err)
-			os.Remove(fn)
+			_ = os.Remove(fn)
 		}
 	}
 
@@ -2216,7 +2312,7 @@ func (mb *msgBlock) lastChecksum() []byte {
 		return lchk[:]
 	}
 	// Encrypted?
-	if err := mb.checkAndLoadEncryption(); err != nil {
+	if err = mb.checkAndLoadEncryption(); err != nil {
 		return nil
 	}
 	if mb.bek != nil {
@@ -2225,9 +2321,11 @@ func (mb *msgBlock) lastChecksum() []byte {
 				return nil
 			}
 			copy(lchk[0:], buf[len(buf)-checksumSize:])
+		} else {
+			return nil
 		}
-	} else {
-		f.ReadAt(lchk[:], int64(mb.rbytes)-checksumSize)
+	} else if _, err = f.ReadAt(lchk[:], int64(mb.rbytes)-checksumSize); err != nil {
+		return nil
 	}
 	return lchk[:]
 }
@@ -2266,7 +2364,10 @@ func (fs *fileStore) recoverMsgs() error {
 
 	// Check for any left over purged messages.
 	<-dios
-	fs.recoverPartialPurge()
+	if err := fs.recoverPartialPurge(); err != nil {
+		dios <- struct{}{}
+		return err
+	}
 	mdir := filepath.Join(fs.fcfg.StoreDir, msgDir)
 	f, err := os.Open(mdir)
 	if err != nil {
@@ -2302,7 +2403,10 @@ func (fs *fileStore) recoverMsgs() error {
 			// out from underneath of us this is possible.
 			mb.mu.Lock()
 			if atomic.LoadUint64(&mb.first.seq) == 0 {
-				mb.dirtyCloseWithRemove(true)
+				if err := mb.dirtyCloseWithRemove(true); err != nil {
+					mb.mu.Unlock()
+					return err
+				}
 				fs.removeMsgBlockFromList(mb)
 				mb.mu.Unlock()
 				continue
@@ -2349,8 +2453,8 @@ func (fs *fileStore) recoverMsgs() error {
 
 	if len(fs.blks) > 0 {
 		fs.lmb = fs.blks[len(fs.blks)-1]
-	} else {
-		_, err = fs.newMsgBlockForWrite()
+	} else if _, err = fs.newMsgBlockForWrite(); err != nil {
+		return err
 	}
 
 	// Check if we encountered any lost data.
@@ -2364,13 +2468,12 @@ func (fs *fileStore) recoverMsgs() error {
 		for _, mb := range emptyBlks {
 			// Need the mb lock here.
 			mb.mu.Lock()
-			fs.forceRemoveMsgBlock(mb)
+			err = fs.forceRemoveMsgBlock(mb)
 			mb.mu.Unlock()
+			if err != nil {
+				return err
+			}
 		}
-	}
-
-	if err != nil {
-		return err
 	}
 
 	// Check for keyfiles orphans.
@@ -2426,7 +2529,9 @@ func (fs *fileStore) expireMsgsOnRecover() error {
 			last.ts = mb.last.ts
 		}
 		// Make sure we do subject cleanup as well.
-		mb.ensurePerSubjectInfoLoaded()
+		if err := mb.ensurePerSubjectInfoLoaded(); err != nil {
+			return err
+		}
 		mb.fss.IterOrdered(func(bsubj []byte, ss *SimpleState) bool {
 			subj := bytesToString(bsubj)
 			for i := uint64(0); i < ss.Msgs; i++ {
@@ -2434,8 +2539,7 @@ func (fs *fileStore) expireMsgsOnRecover() error {
 			}
 			return true
 		})
-		err := mb.dirtyCloseWithRemove(true)
-		if isPermissionError(err) {
+		if err := mb.dirtyCloseWithRemove(true); err != nil {
 			return err
 		}
 		deleted++
@@ -2455,7 +2559,7 @@ func (fs *fileStore) expireMsgsOnRecover() error {
 			bytes += mb.bytes
 			err := deleteEmptyBlock(mb)
 			mb.mu.Unlock()
-			if isPermissionError(err) {
+			if err != nil {
 				return err
 			}
 			continue
@@ -2465,7 +2569,7 @@ func (fs *fileStore) expireMsgsOnRecover() error {
 		// This will load fss as well.
 		if err := mb.loadMsgsWithLock(); err != nil {
 			mb.mu.Unlock()
-			break
+			return err
 		}
 
 		var smv StoreMsg
@@ -2519,7 +2623,11 @@ func (fs *fileStore) expireMsgsOnRecover() error {
 			}
 			// Update fss
 			// Make sure we have fss loaded.
-			mb.removeSeqPerSubject(sm.subj, seq)
+			if _, err = mb.removeSeqPerSubject(sm.subj, seq); err != nil {
+				mb.finishedWithCache()
+				mb.mu.Unlock()
+				return err
+			}
 			fs.removePerSubject(sm.subj)
 		}
 		// Make sure we have a proper next first sequence.
@@ -2527,11 +2635,15 @@ func (fs *fileStore) expireMsgsOnRecover() error {
 			mb.selectNextFirst()
 		}
 		// Check if empty after processing, could happen if tail of messages are all deleted.
+		var err error
 		if mb.msgs == 0 {
-			deleteEmptyBlock(mb)
+			err = deleteEmptyBlock(mb)
 		}
 		mb.finishedWithCache()
 		mb.mu.Unlock()
+		if err != nil {
+			return err
+		}
 		break
 	}
 
@@ -2567,13 +2679,20 @@ func (fs *fileStore) expireMsgsOnRecover() error {
 		fs.state.Bytes = 0
 	}
 	// Make sure to we properly set the fs first sequence and timestamp.
-	fs.selectNextFirst()
+	if err := fs.selectNextFirst(); err != nil {
+		return err
+	}
 
 	// Check if we have no messages and blocks left.
 
 	if fs.lmb == nil && last.seq != 0 {
-		if lmb, _ := fs.newMsgBlockForWrite(); lmb != nil {
-			fs.writeTombstone(last.seq, last.ts)
+		if lmb, err := fs.newMsgBlockForWrite(); err != nil || lmb == nil {
+			if err == nil {
+				err = errors.New("lmb missing")
+			}
+			return err
+		} else if err = fs.writeTombstone(last.seq, last.ts); err != nil {
+			return err
 		}
 		// Clear any global subject state.
 		fs.psim, fs.tsl = fs.psim.Empty(), 0
@@ -2705,7 +2824,9 @@ func (mb *msgBlock) firstMatchingMulti(sl *gsl.SimpleSublist, start uint64, sm *
 			}
 			if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
 				// mb is already loaded into the cache so should be fast-ish.
-				mb.recalculateForSubj(bytesToString(subj), ss)
+				if ierr = mb.recalculateForSubj(bytesToString(subj), ss); ierr != nil {
+					return
+				}
 			}
 			first := max(start, ss.First)
 			if first > ss.Last || first >= hseq {
@@ -2878,17 +2999,28 @@ func (mb *msgBlock) firstMatching(filter string, wc bool, start uint64, sm *Stor
 		// If we have a wildcard match against all tracked subjects we know about.
 		fseq = lseq + 1
 		if bfilter := stringToBytes(filter); wc {
+			var ierr error
 			mb.fss.Match(bfilter, func(bsubj []byte, ss *SimpleState) {
+				if ierr != nil {
+					return
+				}
 				if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
-					mb.recalculateForSubj(bytesToString(bsubj), ss)
+					if ierr = mb.recalculateForSubj(bytesToString(bsubj), ss); ierr != nil {
+						return
+					}
 				}
 				if start <= ss.Last {
 					fseq = min(fseq, max(start, ss.First))
 				}
 			})
+			if ierr != nil {
+				return nil, false, ierr
+			}
 		} else if ss, _ := mb.fss.Find(bfilter); ss != nil {
 			if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
-				mb.recalculateForSubj(filter, ss)
+				if err := mb.recalculateForSubj(filter, ss); err != nil {
+					return nil, false, err
+				}
 			}
 			if start <= ss.Last {
 				fseq = min(fseq, max(start, ss.First))
@@ -2982,10 +3114,16 @@ func (mb *msgBlock) prevMatchingMulti(sl *gsl.SimpleSublist, start uint64, sm *S
 	if uint64(mb.fss.Size()) < start-lseq {
 		// If there are no subject matches then this is effectively no-op.
 		hseq := uint64(0)
+		var ierr error
 		stree.IntersectGSL(mb.fss, sl, func(subj []byte, ss *SimpleState) {
+			if ierr != nil {
+				return
+			}
 			if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
 				// mb is already loaded into the cache so should be fast-ish.
-				mb.recalculateForSubj(bytesToString(subj), ss)
+				if ierr = mb.recalculateForSubj(bytesToString(subj), ss); ierr != nil {
+					return
+				}
 			}
 			first := min(start, ss.Last)
 			// Skip if cutoff is before this subject's first, or if we already
@@ -3029,6 +3167,9 @@ func (mb *msgBlock) prevMatchingMulti(sl *gsl.SimpleSublist, start uint64, sm *S
 				mb.llseq = llseq
 			}
 		})
+		if ierr != nil {
+			return nil, false, ierr
+		}
 		if hseq > 0 && sm != nil {
 			return sm, didLoad && start == lseq, nil
 		}
@@ -3059,7 +3200,7 @@ func (mb *msgBlock) prevMatchingMulti(sl *gsl.SimpleSublist, start uint64, sm *S
 }
 
 // This will traverse a message block and generate the filtered pending.
-func (mb *msgBlock) filteredPending(subj string, wc bool, seq uint64) (total, first, last uint64) {
+func (mb *msgBlock) filteredPending(subj string, wc bool, seq uint64) (total, first, last uint64, err error) {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
 	return mb.filteredPendingLocked(subj, wc, seq)
@@ -3067,14 +3208,14 @@ func (mb *msgBlock) filteredPending(subj string, wc bool, seq uint64) (total, fi
 
 // This will traverse a message block and generate the filtered pending.
 // Lock should be held.
-func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, sseq uint64) (total, first, last uint64) {
+func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, sseq uint64) (total, first, last uint64, err error) {
 	isAll := filter == _EMPTY_ || filter == fwcs
 
 	// First check if we can optimize this part.
 	// This means we want all and the starting sequence was before this block.
 	if isAll {
 		if fseq := atomic.LoadUint64(&mb.first.seq); sseq <= fseq {
-			return mb.msgs, fseq, atomic.LoadUint64(&mb.last.seq)
+			return mb.msgs, fseq, atomic.LoadUint64(&mb.last.seq), nil
 		}
 	}
 
@@ -3093,7 +3234,9 @@ func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, sseq uint64) (
 	}
 
 	// Make sure we have fss loaded.
-	mb.ensurePerSubjectInfoLoaded()
+	if err = mb.ensurePerSubjectInfoLoaded(); err != nil {
+		return 0, 0, 0, err
+	}
 
 	var havePartial bool
 
@@ -3101,7 +3244,9 @@ func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, sseq uint64) (
 	if !wc {
 		if ss, ok := mb.fss.Find(stringToBytes(filter)); ok && ss != nil {
 			if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
-				mb.recalculateForSubj(filter, ss)
+				if err = mb.recalculateForSubj(filter, ss); err != nil {
+					return 0, 0, 0, err
+				}
 			}
 			if sseq <= ss.First {
 				update(ss)
@@ -3112,12 +3257,17 @@ func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, sseq uint64) (
 		}
 	} else {
 		mb.fss.Match(stringToBytes(filter), func(bsubj []byte, ss *SimpleState) {
+			if err != nil {
+				return
+			}
 			if havePartial {
 				// If we already found a partial then don't do anything else.
 				return
 			}
 			if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
-				mb.recalculateForSubj(bytesToString(bsubj), ss)
+				if err = mb.recalculateForSubj(bytesToString(bsubj), ss); err != nil {
+					return
+				}
 			}
 			if sseq <= ss.First {
 				update(ss)
@@ -3126,11 +3276,14 @@ func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, sseq uint64) (
 				havePartial = true
 			}
 		})
+		if err != nil {
+			return 0, 0, 0, err
+		}
 	}
 
 	// If we did not encounter any partials we can return here.
 	if !havePartial {
-		return total, first, last
+		return total, first, last, nil
 	}
 
 	// If we are here we need to scan the msgs.
@@ -3140,7 +3293,9 @@ func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, sseq uint64) (
 	// If we load the cache for a linear scan we want to expire that cache upon exit.
 	var shouldExpire bool
 	if mb.cacheNotLoaded() {
-		mb.loadMsgsWithLock()
+		if err = mb.loadMsgsWithLock(); err != nil {
+			return 0, 0, 0, err
+		}
 		shouldExpire = true
 	}
 	defer mb.finishedWithCache()
@@ -3184,11 +3339,11 @@ func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, sseq uint64) (
 		mb.tryForceExpireCacheLocked()
 	}
 
-	return total, first, last
+	return total, first, last, nil
 }
 
 // FilteredState will return the SimpleState associated with the filtered subject and a proposed starting sequence.
-func (fs *fileStore) FilteredState(sseq uint64, subj string) SimpleState {
+func (fs *fileStore) FilteredState(sseq uint64, subj string) (SimpleState, error) {
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()
 
@@ -3205,14 +3360,16 @@ func (fs *fileStore) FilteredState(sseq uint64, subj string) SimpleState {
 		// Make sure we track sequences
 		ss.First = fs.state.FirstSeq
 		ss.Last = fs.state.LastSeq
-		return ss
+		return ss, nil
 	}
 
 	// If we want all msgs that match we can shortcircuit.
 	// TODO(dlc) - This can be extended for all cases but would
 	// need to be careful on total msgs calculations etc.
 	if sseq == fs.state.FirstSeq {
-		fs.numFilteredPending(subj, &ss)
+		if err := fs.numFilteredPending(subj, &ss); err != nil {
+			return ss, err
+		}
 	} else {
 		wc := subjectHasWildcard(subj)
 		// Tracking subject state.
@@ -3222,7 +3379,10 @@ func (fs *fileStore) FilteredState(sseq uint64, subj string) SimpleState {
 			if sseq > atomic.LoadUint64(&mb.last.seq) {
 				continue
 			}
-			t, f, l := mb.filteredPending(subj, wc, sseq)
+			t, f, l, err := mb.filteredPending(subj, wc, sseq)
+			if err != nil {
+				return ss, err
+			}
 			ss.Msgs += t
 			if ss.First == 0 || (f > 0 && f < ss.First) {
 				ss.First = f
@@ -3233,7 +3393,7 @@ func (fs *fileStore) FilteredState(sseq uint64, subj string) SimpleState {
 		}
 	}
 
-	return ss
+	return ss, nil
 }
 
 // This is used to see if we can selectively jump start blocks based on filter subject and a starting block index.
@@ -3305,20 +3465,20 @@ func (fs *fileStore) selectSkipFirstBlock(bi int, start, stop uint32) (int, erro
 
 // Optimized way for getting all num pending matching a filter subject.
 // Lock should be held.
-func (fs *fileStore) numFilteredPending(filter string, ss *SimpleState) {
-	fs.numFilteredPendingWithLast(filter, true, ss)
+func (fs *fileStore) numFilteredPending(filter string, ss *SimpleState) error {
+	return fs.numFilteredPendingWithLast(filter, true, ss)
 }
 
 // Optimized way for getting all num pending matching a filter subject and first sequence only.
 // Lock should be held.
-func (fs *fileStore) numFilteredPendingNoLast(filter string, ss *SimpleState) {
-	fs.numFilteredPendingWithLast(filter, false, ss)
+func (fs *fileStore) numFilteredPendingNoLast(filter string, ss *SimpleState) error {
+	return fs.numFilteredPendingWithLast(filter, false, ss)
 }
 
 // Optimized way for getting all num pending matching a filter subject.
 // Optionally look up last sequence. Sometimes do not need last and this avoids cost.
 // Read lock should be held.
-func (fs *fileStore) numFilteredPendingWithLast(filter string, last bool, ss *SimpleState) {
+func (fs *fileStore) numFilteredPendingWithLast(filter string, last bool, ss *SimpleState) error {
 	isAll := filter == _EMPTY_ || filter == fwcs
 
 	// If isAll we do not need to do anything special to calculate the first and last and total.
@@ -3326,7 +3486,7 @@ func (fs *fileStore) numFilteredPendingWithLast(filter string, last bool, ss *Si
 		ss.First = fs.state.FirstSeq
 		ss.Last = fs.state.LastSeq
 		ss.Msgs = fs.state.Msgs
-		return
+		return nil
 	}
 	// Always reset.
 	ss.First, ss.Last, ss.Msgs = 0, 0, 0
@@ -3353,13 +3513,16 @@ func (fs *fileStore) numFilteredPendingWithLast(filter string, last bool, ss *Si
 
 	// Did not find anything.
 	if stop == 0 {
-		return
+		return nil
 	}
 
 	// Do start
 	mb := fs.bim[start]
 	if mb != nil {
-		_, f, _ := mb.filteredPending(filter, wc, 0)
+		_, f, _, err := mb.filteredPending(filter, wc, 0)
+		if err != nil {
+			return err
+		}
 		ss.First = f
 	}
 
@@ -3374,7 +3537,9 @@ func (fs *fileStore) numFilteredPendingWithLast(filter string, last bool, ss *Si
 			if mb == nil {
 				continue
 			}
-			if _, f, _ := mb.filteredPending(filter, wc, 0); f > 0 {
+			if _, f, _, err := mb.filteredPending(filter, wc, 0); err != nil {
+				return err
+			} else if f > 0 {
 				ss.First = f
 				break
 			}
@@ -3403,10 +3568,14 @@ func (fs *fileStore) numFilteredPendingWithLast(filter string, last bool, ss *Si
 	// Now gather last sequence if asked to do so.
 	if last {
 		if mb = fs.bim[stop]; mb != nil {
-			_, _, l := mb.filteredPending(filter, wc, 0)
+			_, _, l, err := mb.filteredPending(filter, wc, 0)
+			if err != nil {
+				return err
+			}
 			ss.Last = l
 		}
 	}
+	return nil
 }
 
 // SubjectsState returns a map of SimpleState for all matching subjects.
@@ -3461,10 +3630,16 @@ func (fs *fileStore) SubjectsState(subject string) map[string]SimpleState {
 		}
 		// Mark fss activity.
 		mb.lsts = ats.AccessTime()
+		var ierr error
 		mb.fss.Match(stringToBytes(subject), func(bsubj []byte, ss *SimpleState) {
+			if ierr != nil {
+				return
+			}
 			subj := string(bsubj)
 			if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
-				mb.recalculateForSubj(subj, ss)
+				if ierr = mb.recalculateForSubj(subj, ss); ierr != nil {
+					return
+				}
 			}
 			oss := fss[subj]
 			if oss.First == 0 { // New
@@ -3482,7 +3657,9 @@ func (fs *fileStore) SubjectsState(subject string) map[string]SimpleState {
 			mb.finishedWithCache()
 		}
 		mb.mu.Unlock()
-
+		if ierr != nil {
+			return nil
+		}
 		if mb == stop {
 			break
 		}
@@ -3527,13 +3704,16 @@ func (fs *fileStore) allLastSeqsLocked() ([]uint64, error) {
 			shouldExpire = true
 		}
 
+		var ierr error
 		mb.fss.IterFast(func(bsubj []byte, ss *SimpleState) bool {
 			// Check if already been processed and accounted.
 			if _, ok := subs[string(bsubj)]; !ok {
 				// Check if we need to recalculate. We only care about the last sequence.
 				if ss.lastNeedsUpdate {
 					// mb is already loaded into the cache so should be fast-ish.
-					mb.recalculateForSubj(bytesToString(bsubj), ss)
+					if ierr = mb.recalculateForSubj(bytesToString(bsubj), ss); ierr != nil {
+						return false
+					}
 				}
 				seqs = append(seqs, ss.Last)
 				subs[string(bsubj)] = struct{}{}
@@ -3546,6 +3726,9 @@ func (fs *fileStore) allLastSeqsLocked() ([]uint64, error) {
 		}
 		mb.finishedWithCache()
 		mb.mu.Unlock()
+		if ierr != nil {
+			return nil, ierr
+		}
 	}
 
 	slices.Sort(seqs)
@@ -3641,11 +3824,14 @@ func (fs *fileStore) MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed i
 		}
 		// We can start properly looking here.
 		mb.mu.Lock()
-		mb.ensurePerSubjectInfoLoaded()
+		var ierr error
+		if ierr = mb.ensurePerSubjectInfoLoaded(); ierr != nil {
+			mb.mu.Unlock()
+			return nil, ierr
+		}
 
 		// Iterate the fss and check against our subs. We will delete from subs as we add.
 		// Once len(subs) == 0 we are done.
-		var ierr error
 		mb.fss.IterFast(func(bsubj []byte, ss *SimpleState) bool {
 			// Already been processed and accounted for was not matched in the first place.
 			if subs[string(bsubj)] == nil {
@@ -3654,7 +3840,9 @@ func (fs *fileStore) MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed i
 			// Check if we need to recalculate. We only care about the last sequence.
 			if ss.lastNeedsUpdate {
 				// mb is already loaded into the cache so should be fast-ish.
-				mb.recalculateForSubj(bytesToString(bsubj), ss)
+				if ierr = mb.recalculateForSubj(bytesToString(bsubj), ss); ierr != nil {
+					return false
+				}
 			}
 			// If we are equal or below just add to seqs slice.
 			if ss.Last <= maxSeq {
@@ -3881,15 +4069,21 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 			mb.lsts = ats.AccessTime()
 
 			var t uint64
+			var ierr error
 			var havePartial bool
 			mb.fss.Match(stringToBytes(filter), func(bsubj []byte, ss *SimpleState) {
+				if ierr != nil {
+					return
+				}
 				if havePartial {
 					// If we already found a partial then don't do anything else.
 					return
 				}
 				subj := bytesToString(bsubj)
 				if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
-					mb.recalculateForSubj(subj, ss)
+					if ierr = mb.recalculateForSubj(subj, ss); ierr != nil {
+						return
+					}
 				}
 				if sseq <= ss.First {
 					t += ss.Msgs
@@ -3898,6 +4092,10 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 					havePartial = true
 				}
 			})
+			if ierr != nil {
+				mb.mu.Unlock()
+				return 0, 0, ierr
+			}
 
 			// See if we need to scan msgs here.
 			if havePartial {
@@ -4210,16 +4408,22 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPer
 			mb.lsts = ats.AccessTime()
 
 			var t uint64
+			var ierr error
 			var havePartial bool
 			var updateLLTS bool
 			stree.IntersectGSL[SimpleState](mb.fss, sl, func(bsubj []byte, ss *SimpleState) {
+				if ierr != nil {
+					return
+				}
 				subj := bytesToString(bsubj)
 				if havePartial {
 					// If we already found a partial then don't do anything else.
 					return
 				}
 				if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
-					mb.recalculateForSubj(subj, ss)
+					if ierr = mb.recalculateForSubj(subj, ss); ierr != nil {
+						return
+					}
 				}
 				if sseq <= ss.First {
 					t += ss.Msgs
@@ -4228,6 +4432,10 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPer
 					havePartial = true
 				}
 			})
+			if ierr != nil {
+				mb.mu.Unlock()
+				return 0, 0, ierr
+			}
 
 			// See if we need to scan msgs here.
 			if havePartial {
@@ -4495,8 +4703,15 @@ func (fs *fileStore) newMsgBlockForWrite() (*msgBlock, error) {
 			close(lmb.qch)
 			lmb.qch = nil
 		}
+		// If we had a write error before, don't allow continuing into a new block.
+		if err := lmb.werr; err != nil {
+			return nil, err
+		}
 		// Flush any pending messages.
-		lmb.flushPendingMsgsLocked()
+		if _, err := lmb.flushPendingMsgsLocked(); err != nil {
+			lmb.mu.Unlock()
+			return nil, err
+		}
 		// Determine if we can reclaim any resources here.
 		lmb.closeFDsLockedNoCheck()
 		if lmb.cache != nil {
@@ -4511,7 +4726,8 @@ func (fs *fileStore) newMsgBlockForWrite() (*msgBlock, error) {
 			go func() {
 				lmb.mu.Lock()
 				defer lmb.mu.Unlock()
-				lmb.recompressOnDiskIfNeeded()
+				// Might error, but we can't handle it here anyway.
+				_ = lmb.recompressOnDiskIfNeeded()
 			}()
 		}
 	}
@@ -4548,7 +4764,7 @@ func (fs *fileStore) newMsgBlockForWrite() (*msgBlock, error) {
 		if isPermissionError(err) {
 			return nil, err
 		}
-		mb.dirtyCloseWithRemove(true)
+		_ = mb.dirtyCloseWithRemove(true)
 		return nil, fmt.Errorf("Error creating msg block file: %v", err)
 	}
 	mb.mfd = mfd
@@ -4645,6 +4861,17 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 		seq = fs.state.LastSeq + 1
 	}
 
+	// Return previous write errors immediately.
+	if fs.werr != nil {
+		return fs.werr
+	}
+	// Persist any returned errors to be used in the future.
+	defer func() {
+		if err != nil {
+			fs.setWriteErr(err)
+		}
+	}()
+
 	// Write msg record.
 	// Add expiry bit to sequence if needed. This is so that if we need to
 	// rebuild, we know which messages to look at more quickly.
@@ -4684,18 +4911,25 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 	if psmax && psmc >= mmp {
 		// We may have done this above.
 		if fseq == 0 {
-			fseq, _ = fs.firstSeqForSubj(subj)
+			fseq, err = fs.firstSeqForSubj(subj)
+			if err != nil {
+				return err
+			}
 		}
-		if ok, _ := fs.removeMsgViaLimits(fseq); ok {
+		if ok, err := fs.removeMsgViaLimits(fseq); err != nil {
+			return err
+		} else if ok {
 			// Make sure we are below the limit.
 			if psmc--; psmc >= mmp {
 				bsubj := stringToBytes(subj)
 				for info, ok := fs.psim.Find(bsubj); ok && info.total > mmp; info, ok = fs.psim.Find(bsubj) {
-					if seq, _ := fs.firstSeqForSubj(subj); seq > 0 {
-						if ok, _ := fs.removeMsgViaLimits(seq); !ok {
-							break
-						}
-					} else {
+					if seq, err := fs.firstSeqForSubj(subj); err != nil {
+						return err
+					} else if seq == 0 {
+						break
+					} else if ok, err = fs.removeMsgViaLimits(seq); err != nil {
+						return err
+					} else if !ok {
 						break
 					}
 				}
@@ -4703,7 +4937,9 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 		} else if mb := fs.selectMsgBlock(fseq); mb != nil {
 			// If we are here we could not remove fseq from above, so rebuild.
 			var ld *LostStreamData
-			if ld, _, _ = mb.rebuildState(); ld != nil {
+			if ld, _, err = mb.rebuildState(); err != nil {
+				return err
+			} else if ld != nil {
 				fs.rebuildStateLocked(ld)
 			}
 		}
@@ -4712,8 +4948,12 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 	// Limits checks and enforcement.
 	// If they do any deletions they will update the
 	// byte count on their own, so no need to compensate.
-	fs.enforceMsgLimit()
-	fs.enforceBytesLimit()
+	if err = fs.enforceMsgLimit(); err != nil {
+		return err
+	}
+	if err = fs.enforceBytesLimit(); err != nil {
+		return err
+	}
 
 	// Per-message TTL.
 	if ttl > 0 {
@@ -4755,9 +4995,37 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 	return nil
 }
 
+// Lock should be held.
+func (fs *fileStore) setWriteErr(err error) {
+	if fs.werr != nil {
+		return
+	}
+	// Ignore non-write errors.
+	if err == ErrStoreClosed {
+		return
+	}
+	// If this is a not found report but do not disable.
+	if os.IsNotExist(err) {
+		fs.warn("Resource not found: %v", err)
+		return
+	}
+	fs.error("Critical write error: %v", err)
+	fs.werr = err
+	assert.Unreachable("Filestore encountered write error", map[string]any{
+		"name":  fs.cfg.Name,
+		"err":   err,
+		"stack": string(debug.Stack()),
+	})
+}
+
 // StoreRawMsg stores a raw message with expected sequence number and timestamp.
 func (fs *fileStore) StoreRawMsg(subj string, hdr, msg []byte, seq uint64, ts, ttl int64, discardNewCheck bool) error {
 	fs.mu.Lock()
+	// Always return previous write errors.
+	if err := fs.werr; err != nil {
+		fs.mu.Unlock()
+		return err
+	}
 	err := fs.storeRawMsg(subj, hdr, msg, seq, ts, ttl, discardNewCheck)
 	cb := fs.scb
 	// Check if first message timestamp requires expiry
@@ -4778,6 +5046,11 @@ func (fs *fileStore) StoreRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 // Store stores a message. We hold the main filestore lock for any write operation.
 func (fs *fileStore) StoreMsg(subj string, hdr, msg []byte, ttl int64) (uint64, int64, error) {
 	fs.mu.Lock()
+	// Always return previous write errors.
+	if err := fs.werr; err != nil {
+		fs.mu.Unlock()
+		return 0, 0, err
+	}
 	seq, ts := fs.state.LastSeq+1, time.Now().UnixNano()
 	// This is called for a R1 with no expected sequence number, so perform DiscardNew checks on the store-level.
 	err := fs.storeRawMsg(subj, hdr, msg, seq, ts, ttl, true)
@@ -4798,13 +5071,17 @@ func (fs *fileStore) StoreMsg(subj string, hdr, msg []byte, ttl int64) (uint64, 
 // we will place an empty record marking the sequence as used. The
 // sequence will be marked erased.
 // fs lock should be held.
-func (mb *msgBlock) skipMsg(seq uint64, now int64) {
+func (mb *msgBlock) skipMsg(seq uint64, now int64) error {
 	if mb == nil {
-		return
+		return nil
 	}
 	var needsRecord bool
 
 	mb.mu.Lock()
+	if err := mb.werr; err != nil {
+		mb.mu.Unlock()
+		return err
+	}
 	// If we are empty can just do meta.
 	if mb.msgs == 0 {
 		atomic.StoreUint64(&mb.last.seq, seq)
@@ -4817,12 +5094,16 @@ func (mb *msgBlock) skipMsg(seq uint64, now int64) {
 		mb.dmap.Insert(seq)
 	}
 	if needsRecord {
-		mb.writeMsgRecordLocked(emptyRecordLen, seq|ebit, _EMPTY_, nil, nil, now, true, true)
+		if err := mb.writeMsgRecordLocked(emptyRecordLen, seq|ebit, _EMPTY_, nil, nil, now, true, true); err != nil {
+			mb.mu.Unlock()
+			return err
+		}
 	}
 	mb.mu.Unlock()
 	if !needsRecord {
 		mb.kickFlusher()
 	}
+	return nil
 }
 
 // SkipMsg will use the next sequence number but not store anything.
@@ -4832,6 +5113,11 @@ func (fs *fileStore) SkipMsg(seq uint64) (uint64, error) {
 
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
+
+	// Always return previous write errors.
+	if err := fs.werr; err != nil {
+		return 0, err
+	}
 
 	// Check sequence matches our last sequence.
 	if seq != fs.state.LastSeq+1 {
@@ -4848,7 +5134,10 @@ func (fs *fileStore) SkipMsg(seq uint64) (uint64, error) {
 	}
 
 	// Write skip msg.
-	mb.skipMsg(seq, now)
+	if err = mb.skipMsg(seq, now); err != nil {
+		fs.setWriteErr(err)
+		return 0, err
+	}
 
 	// Update fs state.
 	fs.state.LastSeq, fs.state.LastTime = seq, time.Unix(0, now).UTC()
@@ -4864,10 +5153,15 @@ func (fs *fileStore) SkipMsg(seq uint64) (uint64, error) {
 	return seq, nil
 }
 
-// Skip multiple msgs. We will determine if we can fit into current lmb or we need to create a new block.
+// SkipMsgs skips multiple msgs. We will determine if we can fit into current lmb or we need to create a new block.
 func (fs *fileStore) SkipMsgs(seq uint64, num uint64) error {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
+
+	// Always return previous write errors.
+	if err := fs.werr; err != nil {
+		return err
+	}
 
 	// Check sequence matches our last sequence.
 	if seq != fs.state.LastSeq+1 {
@@ -4901,6 +5195,10 @@ func (fs *fileStore) SkipMsgs(seq uint64, num uint64) error {
 	lseq := seq + num - 1
 
 	mb.mu.Lock()
+	if err := mb.werr; err != nil {
+		mb.mu.Unlock()
+		return err
+	}
 	// If we are empty update meta directly.
 	if mb.msgs == 0 {
 		atomic.StoreUint64(&mb.last.seq, lseq)
@@ -4913,8 +5211,12 @@ func (fs *fileStore) SkipMsgs(seq uint64, num uint64) error {
 		}
 	}
 	// Write out our placeholder.
-	mb.writeMsgRecordLocked(emptyRecordLen, lseq|ebit, _EMPTY_, nil, nil, now, true, true)
+	err := mb.writeMsgRecordLocked(emptyRecordLen, lseq|ebit, _EMPTY_, nil, nil, now, true, true)
 	mb.mu.Unlock()
+	if err != nil {
+		fs.setWriteErr(err)
+		return err
+	}
 
 	// Now update FS accounting.
 	// Update fs state.
@@ -4930,20 +5232,24 @@ func (fs *fileStore) SkipMsgs(seq uint64, num uint64) error {
 }
 
 // FlushAllPending flushes all data that was still pending to be written.
-func (fs *fileStore) FlushAllPending() {
+func (fs *fileStore) FlushAllPending() error {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
-	fs.checkAndFlushLastBlock()
+	// Return previous write errors immediately.
+	if fs.werr != nil {
+		return fs.werr
+	}
+	return fs.checkAndFlushLastBlock()
 }
 
 // Lock should be held.
-func (fs *fileStore) rebuildFirst() {
+func (fs *fileStore) rebuildFirst() error {
 	if len(fs.blks) == 0 {
-		return
+		return nil
 	}
 	fmb := fs.blks[0]
 	if fmb == nil {
-		return
+		return nil
 	}
 
 	ld, _, _ := fmb.rebuildState()
@@ -4952,11 +5258,17 @@ func (fs *fileStore) rebuildFirst() {
 	fmb.mu.RUnlock()
 	if isEmpty {
 		fmb.mu.Lock()
-		fs.forceRemoveMsgBlock(fmb)
+		err := fs.forceRemoveMsgBlock(fmb)
 		fmb.mu.Unlock()
+		if err != nil {
+			return err
+		}
 	}
-	fs.selectNextFirst()
+	if err := fs.selectNextFirst(); err != nil {
+		return err
+	}
 	fs.rebuildStateLocked(ld)
+	return nil
 }
 
 // Optimized helper function to return first sequence.
@@ -5000,8 +5312,9 @@ func (fs *fileStore) firstSeqForSubj(subj string) (uint64, error) {
 
 		bsubj := stringToBytes(subj)
 		if ss, ok := mb.fss.Find(bsubj); ok && ss != nil {
+			var err error
 			if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
-				mb.recalculateForSubj(subj, ss)
+				err = mb.recalculateForSubj(subj, ss)
 			}
 			mb.mu.Unlock()
 			// Re-acquire fs lock
@@ -5011,6 +5324,9 @@ func (fs *fileStore) firstSeqForSubj(subj string) (uint64, error) {
 				if info, ok := fs.psim.Find(bsubj); ok {
 					info.fblk = i
 				}
+			}
+			if err != nil {
+				return 0, err
 			}
 			return ss.First, nil
 		}
@@ -5030,12 +5346,12 @@ func (fs *fileStore) firstSeqForSubj(subj string) (uint64, error) {
 
 // Will check the msg limit and drop firstSeq msg if needed.
 // Lock should be held.
-func (fs *fileStore) enforceMsgLimit() {
+func (fs *fileStore) enforceMsgLimit() error {
 	if fs.cfg.Discard != DiscardOld {
-		return
+		return nil
 	}
 	if fs.cfg.MaxMsgs <= 0 || fs.state.Msgs <= uint64(fs.cfg.MaxMsgs) {
-		return
+		return nil
 	}
 	for nmsgs := fs.state.Msgs; nmsgs > uint64(fs.cfg.MaxMsgs); nmsgs = fs.state.Msgs {
 		// If the first block can be removed fully, purge it entirely without needing to walk sequences.
@@ -5045,25 +5361,29 @@ func (fs *fileStore) enforceMsgLimit() {
 			msgs := fmb.msgs
 			fmb.mu.RUnlock()
 			if nmsgs-msgs > uint64(fs.cfg.MaxMsgs) {
-				fs.purgeMsgBlock(fmb)
+				if err := fs.purgeMsgBlock(fmb); err != nil {
+					return err
+				}
 				continue
 			}
 		}
-		if removed, err := fs.deleteFirstMsg(); err != nil || !removed {
-			fs.rebuildFirst()
-			return
+		if removed, err := fs.deleteFirstMsg(); err != nil {
+			return err
+		} else if !removed {
+			return fs.rebuildFirst()
 		}
 	}
+	return nil
 }
 
 // Will check the bytes limit and drop msgs if needed.
 // Lock should be held.
-func (fs *fileStore) enforceBytesLimit() {
+func (fs *fileStore) enforceBytesLimit() error {
 	if fs.cfg.Discard != DiscardOld {
-		return
+		return nil
 	}
 	if fs.cfg.MaxBytes <= 0 || fs.state.Bytes <= uint64(fs.cfg.MaxBytes) {
-		return
+		return nil
 	}
 	for bs := fs.state.Bytes; bs > uint64(fs.cfg.MaxBytes); bs = fs.state.Bytes {
 		// If the first block can be removed fully, purge it entirely without needing to walk sequences.
@@ -5073,22 +5393,26 @@ func (fs *fileStore) enforceBytesLimit() {
 			bytes := fmb.bytes
 			fmb.mu.RUnlock()
 			if bs-bytes > uint64(fs.cfg.MaxBytes) {
-				fs.purgeMsgBlock(fmb)
+				if err := fs.purgeMsgBlock(fmb); err != nil {
+					return err
+				}
 				continue
 			}
 		}
-		if removed, err := fs.deleteFirstMsg(); err != nil || !removed {
-			fs.rebuildFirst()
-			return
+		if removed, err := fs.deleteFirstMsg(); err != nil {
+			return err
+		} else if !removed {
+			return fs.rebuildFirst()
 		}
 	}
+	return nil
 }
 
 // Will make sure we have limits honored for max msgs per subject on recovery or config update.
 // We will make sure to go through all msg blocks etc. but in practice this
 // will most likely only be the last one, so can take a more conservative approach.
 // Lock should be held.
-func (fs *fileStore) enforceMsgPerSubjectLimit(fireCallback bool) {
+func (fs *fileStore) enforceMsgPerSubjectLimit(fireCallback bool) error {
 	start := time.Now()
 	defer func() {
 		if took := time.Since(start); took > time.Minute {
@@ -5133,10 +5457,14 @@ func (fs *fileStore) enforceMsgPerSubjectLimit(fireCallback bool) {
 		fs.psim, fs.tsl = fs.psim.Empty(), 0
 		for _, mb := range fs.blks {
 			ld, _, err := mb.rebuildState()
-			if err != nil && ld != nil {
+			if err != nil {
+				return err
+			} else if ld != nil {
 				fs.addLostData(ld)
 			}
-			fs.populateGlobalPerSubjectInfo(mb)
+			if err = fs.populateGlobalPerSubjectInfo(mb); err != nil {
+				return err
+			}
 		}
 		// Rebuild fs state too.
 		fs.rebuildStateLocked(nil)
@@ -5159,7 +5487,7 @@ func (fs *fileStore) enforceMsgPerSubjectLimit(fireCallback bool) {
 
 	// If nothing to do then stop.
 	if fblk == math.MaxUint32 {
-		return
+		return nil
 	}
 
 	// Collect all the msgBlks we alter.
@@ -5174,7 +5502,10 @@ func (fs *fileStore) enforceMsgPerSubjectLimit(fireCallback bool) {
 			continue
 		}
 		mb.mu.Lock()
-		mb.ensurePerSubjectInfoLoaded()
+		if err := mb.ensurePerSubjectInfoLoaded(); err != nil {
+			mb.mu.Unlock()
+			return err
+		}
 		// It isn't safe to intersect mb.fss directly, because removeMsgViaLimits modifies it
 		// during the iteration, which can cause us to miss keys. We won't copy the entire
 		// SimpleState structs though but rather just take pointers for speed.
@@ -5184,15 +5515,19 @@ func (fs *fileStore) enforceMsgPerSubjectLimit(fireCallback bool) {
 			return true
 		})
 		mb.mu.Unlock()
+		var ierr error
 		stree.LazyIntersect(needAttention, fss, func(subj []byte, total *uint64, ssptr **SimpleState) {
-			if ssptr == nil || total == nil {
+			if ssptr == nil || total == nil || ierr != nil {
 				return
 			}
 			ss := *ssptr
 			if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
 				mb.mu.Lock()
-				mb.recalculateForSubj(bytesToString(subj), ss)
+				ierr = mb.recalculateForSubj(bytesToString(subj), ss)
 				mb.mu.Unlock()
+				if ierr != nil {
+					return
+				}
 			}
 			for first := ss.First; *total > maxMsgsPer && first <= ss.Last; {
 				m, _, err := mb.firstMatching(bytesToString(subj), false, first, &sm)
@@ -5206,6 +5541,9 @@ func (fs *fileStore) enforceMsgPerSubjectLimit(fireCallback bool) {
 				}
 			}
 		})
+		if ierr != nil {
+			return ierr
+		}
 	}
 
 	// Expire the cache if we can.
@@ -5216,6 +5554,7 @@ func (fs *fileStore) enforceMsgPerSubjectLimit(fireCallback bool) {
 		}
 		mb.mu.Unlock()
 	}
+	return nil
 }
 
 // Lock should be held.
@@ -5285,6 +5624,11 @@ func (fs *fileStore) removeMsg(seq uint64, secure, viaLimits, needFSLock bool) (
 	if fs.isClosed() {
 		return false, ErrStoreClosed
 	}
+	// Always return previous write errors.
+	if err := fs.werr; err != nil {
+		fsUnlock()
+		return false, err
+	}
 	// If in encrypted mode negate secure rewrite here.
 	if secure && fs.prf != nil {
 		secure = false
@@ -5304,7 +5648,7 @@ func (fs *fileStore) removeMsg(seq uint64, secure, viaLimits, needFSLock bool) (
 
 // Remove a message from the given block, optionally rewriting the mb file.
 // fs lock should be held.
-func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLimits bool) (bool, error) {
+func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLimits bool) (removed bool, rerr error) {
 	mb.mu.Lock()
 
 	// See if we are closed or the sequence number is still relevant or if we know its deleted.
@@ -5312,6 +5656,13 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 		mb.mu.Unlock()
 		return false, nil
 	}
+
+	// Persist any write errors.
+	defer func() {
+		if rerr != nil {
+			fs.setWriteErr(rerr)
+		}
+	}()
 
 	fifo := seq == atomic.LoadUint64(&mb.first.seq)
 	isLastBlock := mb == fs.lmb
@@ -5347,7 +5698,7 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 		finishedWithCache()
 		mb.mu.Unlock()
 		// Mimic err behavior from above check to dmap. No error returned if already removed.
-		if err == errDeletedMsg {
+		if err == ErrStoreMsgNotFound || err == errDeletedMsg {
 			err = nil
 		}
 		return false, err
@@ -5369,11 +5720,15 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 		mb.mu.Unlock() // Only safe way to checkLastBlock is to unlock here...
 		lmb, err := fs.checkLastBlock(emptyRecordLen)
 		if err != nil {
+			mb.mu.Lock()
 			finishedWithCache()
+			mb.mu.Unlock()
 			return false, err
 		}
 		if err := lmb.writeTombstone(seq, ts); err != nil {
+			mb.mu.Lock()
 			finishedWithCache()
+			mb.mu.Unlock()
 			return false, err
 		}
 		mb.mu.Lock() // We'll need the lock back to carry on safely.
@@ -5431,10 +5786,18 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 	fs.dirty++
 
 	// If we are tracking subjects here make sure we update that accounting.
-	mb.ensurePerSubjectInfoLoaded()
+	if err = mb.ensurePerSubjectInfoLoaded(); err != nil {
+		finishedWithCache()
+		mb.mu.Unlock()
+		return false, err
+	}
 
 	// If we are tracking multiple subjects here make sure we update that accounting.
-	mb.removeSeqPerSubject(subj, seq)
+	if _, err = mb.removeSeqPerSubject(subj, seq); err != nil {
+		finishedWithCache()
+		mb.mu.Unlock()
+		return false, err
+	}
 	fs.removePerSubject(subj)
 	if fs.ttls != nil && ttl > 0 {
 		expires := time.Duration(ts) + (time.Second * time.Duration(ttl))
@@ -5462,7 +5825,11 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 		// Note that we do not have to store empty records for the deleted, so don't use to calculate.
 		// TODO(dlc) - This should not be inline, should kick the sync routine.
 		if !isLastBlock && mb.shouldCompactInline() {
-			mb.compact()
+			if err = mb.compact(); err != nil {
+				finishedWithCache()
+				mb.mu.Unlock()
+				return false, err
+			}
 		}
 	}
 
@@ -5478,7 +5845,11 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 	var firstSeqNeedsUpdate bool
 	if isEmpty {
 		// This writes tombstone iff mb == lmb, so no need to do above.
-		fs.removeMsgBlock(mb)
+		if err = fs.removeMsgBlock(mb); err != nil {
+			finishedWithCache()
+			mb.mu.Unlock()
+			return false, err
+		}
 		firstSeqNeedsUpdate = seq == fs.state.FirstSeq
 	}
 	finishedWithCache()
@@ -5488,7 +5859,9 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 	// then we need to jump message blocks. We will also write the index so
 	// we don't lose track of the first sequence.
 	if firstSeqNeedsUpdate {
-		fs.selectNextFirst()
+		if err = fs.selectNextFirst(); err != nil {
+			return false, err
+		}
 	}
 
 	if cb := fs.scb; cb != nil {
@@ -5506,18 +5879,17 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 
 // Remove all messages in the range [first, last]
 // Lock should be held.
-func (fs *fileStore) removeMsgsInRange(first, last uint64, viaLimits bool) {
+func (fs *fileStore) removeMsgsInRange(first, last uint64, viaLimits bool) error {
 	last = min(last, fs.state.LastSeq)
 	if first > last {
-		return
+		return nil
 	}
 
 	firstBlock := sort.Search(len(fs.blks), func(i int) bool {
 		return atomic.LoadUint64(&fs.blks[i].last.seq) >= first
 	})
-
 	if firstBlock >= len(fs.blks) {
-		return
+		return nil
 	}
 
 	for i := firstBlock; i < len(fs.blks); {
@@ -5534,16 +5906,21 @@ func (fs *fileStore) removeMsgsInRange(first, last uint64, viaLimits bool) {
 			// purgeMgsBlock, which also removes the block from fs.blks.
 			// After purgeMsgBlock, i will be the index of the following
 			// msgBlock, if any. Therefore, continue without incrementing i.
-			fs.purgeMsgBlock(mb)
+			if err := fs.purgeMsgBlock(mb); err != nil {
+				return err
+			}
 		} else {
 			from := max(first, mbFirstSeq)
 			to := min(last, mbLastSeq)
 			for seq := from; seq <= to; seq++ {
-				fs.removeMsgFromBlock(mb, seq, false, viaLimits)
+				if _, err := fs.removeMsgFromBlock(mb, seq, false, viaLimits); err != nil {
+					return err
+				}
 			}
 			i++
 		}
 	}
+	return nil
 }
 
 // Tests whether we should try to compact this block while inline removing msgs.
@@ -5564,8 +5941,8 @@ func (mb *msgBlock) shouldCompactSync() bool {
 
 // This will compact and rewrite this block. This version will not process any tombstone cleanup.
 // Write lock needs to be held.
-func (mb *msgBlock) compact() {
-	mb.compactWithFloor(0, nil)
+func (mb *msgBlock) compact() error {
+	return mb.compactWithFloor(0, nil)
 }
 
 // This will compact and rewrite this block. This should only be called when we know we want to rewrite this block.
@@ -5684,11 +6061,11 @@ func (mb *msgBlock) compactWithFloor(floor uint64, fsDmap *avl.SequenceSet) erro
 	err := os.WriteFile(mfn, nbuf, defaultFilePerms)
 	dios <- struct{}{}
 	if err != nil {
-		os.Remove(mfn)
+		_ = os.Remove(mfn)
 		return err
 	}
 	if err := os.Rename(mfn, mb.mfn); err != nil {
-		os.Remove(mfn)
+		_ = os.Remove(mfn)
 		return err
 	}
 
@@ -5866,7 +6243,8 @@ func (mb *msgBlock) flushLoop(fch, qch chan struct{}) {
 					ts *= 2
 				}
 
-				mb.flushPendingMsgs()
+				// Ignore error here, the error is persisted as mb.werr and will be bubbled up later.
+				_ = mb.flushPendingMsgs()
 			}
 
 			// Check if we are no longer the last message block. If we are
@@ -6018,11 +6396,17 @@ func (mb *msgBlock) truncate(tseq uint64, ts int64) (nmsgs, nbytes uint64, err e
 			return 0, 0, err
 		}
 	} else if mb.mfd != nil {
-		mb.mfd.Truncate(eof)
-		mb.mfd.Sync()
+		if err = mb.mfd.Truncate(eof); err != nil {
+			return 0, 0, err
+		}
+		if err = mb.mfd.Sync(); err != nil {
+			return 0, 0, err
+		}
 		// Update our checksum.
 		var lchk [8]byte
-		mb.mfd.ReadAt(lchk[:], eof-8)
+		if _, err = mb.mfd.ReadAt(lchk[:], eof-8); err != nil {
+			return 0, 0, err
+		}
 		copy(mb.lchk[0:], lchk[:])
 	} else {
 		return 0, 0, fmt.Errorf("failed to truncate msg block %d, file not open", mb.index)
@@ -6036,7 +6420,9 @@ func (mb *msgBlock) truncate(tseq uint64, ts int64) (nmsgs, nbytes uint64, err e
 	mb.clearCacheAndOffset()
 
 	// Redo per subject info for this block.
-	mb.resetPerSubjectInfo()
+	if err = mb.resetPerSubjectInfo(); err != nil {
+		return purged, bytes, err
+	}
 
 	// Load msgs again.
 	return purged, bytes, mb.loadMsgsWithLock()
@@ -6088,7 +6474,7 @@ func (mb *msgBlock) selectNextFirst() {
 // Select the next FirstSeq
 // Also cleans up empty blocks at the start only containing tombstones.
 // Lock should be held.
-func (fs *fileStore) selectNextFirst() {
+func (fs *fileStore) selectNextFirst() error {
 	if len(fs.blks) > 0 {
 		for len(fs.blks) > 1 {
 			mb := fs.blks[0]
@@ -6098,8 +6484,11 @@ func (fs *fileStore) selectNextFirst() {
 				mb.mu.Unlock()
 				break
 			}
-			fs.forceRemoveMsgBlock(mb)
+			err := fs.forceRemoveMsgBlock(mb)
 			mb.mu.Unlock()
+			if err != nil {
+				return err
+			}
 		}
 		mb := fs.blks[0]
 		mb.mu.RLock()
@@ -6117,6 +6506,7 @@ func (fs *fileStore) selectNextFirst() {
 	}
 	// Mark first as moved. Plays into tombstone cleanup for syncBlocks.
 	fs.firstMoved = true
+	return nil
 }
 
 // Lock should be held.
@@ -6578,20 +6968,31 @@ func (fs *fileStore) runMsgScheduling() {
 }
 
 // Lock should be held.
-func (fs *fileStore) checkAndFlushLastBlock() {
+func (fs *fileStore) checkAndFlushLastBlock() error {
 	lmb := fs.lmb
 	if lmb == nil {
-		return
+		return nil
 	}
-	if lmb.pendingWriteSize() > 0 {
-		// Since fs lock is held need to pull this apart in case we need to rebuild state.
-		lmb.mu.Lock()
-		ld, _ := lmb.flushPendingMsgsLocked()
+	lmb.mu.Lock()
+	if err := lmb.werr; err != nil {
 		lmb.mu.Unlock()
-		if ld != nil {
-			fs.rebuildStateLocked(ld)
-		}
+		return err
 	}
+
+	if lmb.pendingWriteSizeLocked() == 0 {
+		lmb.mu.Unlock()
+		return nil
+	}
+	ld, err := lmb.flushPendingMsgsLocked()
+	lmb.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	// Since fs lock is held need to unlock the mb in case we need to rebuild state.
+	if ld != nil {
+		fs.rebuildStateLocked(ld)
+	}
+	return nil
 }
 
 // This will check all the checksums on messages and report back any sequence numbers with errors.
@@ -6608,7 +7009,7 @@ func (fs *fileStore) checkMsgs() *LostStreamData {
 		// Make sure encryption loaded if needed for the block.
 		fs.loadEncryptionForMsgBlock(mb)
 		// FIXME(dlc) - check tombstones here too?
-		if ld, _, err := mb.rebuildState(); err != nil && ld != nil {
+		if ld, _, _ := mb.rebuildState(); ld != nil {
 			// Rebuild fs state too.
 			fs.rebuildStateLocked(ld)
 		}
@@ -6666,7 +7067,24 @@ func (mb *msgBlock) writeMsgRecord(rl, seq uint64, subj string, mhdr, msg []byte
 // Will write the message record to the underlying message block.
 // filestore lock will be held.
 // mb lock should be held.
-func (mb *msgBlock) writeMsgRecordLocked(rl, seq uint64, subj string, mhdr, msg []byte, ts int64, flush, kick bool) error {
+func (mb *msgBlock) writeMsgRecordLocked(rl, seq uint64, subj string, mhdr, msg []byte, ts int64, flush, kick bool) (rerr error) {
+	// Return previous write errors immediately.
+	if mb.werr != nil {
+		return mb.werr
+	}
+	// Persist any returned errors to be used in the future.
+	defer func() {
+		if rerr != nil && mb.werr == nil {
+			mb.werr = rerr
+			assert.Unreachable("Filestore msg block encountered write error", map[string]any{
+				"name":     mb.fs.cfg.Name,
+				"mb.index": mb.index,
+				"err":      rerr,
+				"stack":    string(debug.Stack()),
+			})
+		}
+	}()
+
 	// Enable for writing if our mfd is not open.
 	if mb.mfd == nil {
 		if err := mb.enableForWriting(flush && kick); err != nil {
@@ -6799,9 +7217,12 @@ func (mb *msgBlock) writeMsgRecordLocked(rl, seq uint64, subj string, mhdr, msg 
 	}
 
 	fch, werr := mb.fch, mb.werr
+	if werr != nil {
+		return werr
+	}
 
 	// If we should be flushing, or had a write error, do so here.
-	if (flush && mb.fs.fip) || werr != nil {
+	if flush && mb.fs.fip {
 		ld, err := mb.flushPendingMsgsLocked()
 		if ld != nil {
 			// We have the mb lock here, this needs the mb locks so do in its own go routine.
@@ -6856,7 +7277,7 @@ func (mb *msgBlock) closeFDsLocked() error {
 
 func (mb *msgBlock) closeFDsLockedNoCheck() {
 	if mb.mfd != nil {
-		mb.mfd.Close()
+		_ = mb.mfd.Close()
 		mb.mfd = nil
 	}
 }
@@ -7049,8 +7470,8 @@ func (mb *msgBlock) atomicOverwriteFile(buf []byte, allowCompress bool) error {
 	}
 
 	errorCleanup := func(err error) error {
-		tmpFD.Close()
-		os.Remove(tmpFN)
+		_ = tmpFD.Close()
+		_ = os.Remove(tmpFN)
 		return err
 	}
 
@@ -7168,11 +7589,21 @@ func (fs *fileStore) syncBlocks() {
 		return
 	}
 	fs.mu.Lock()
+	if err := fs.werr; err != nil {
+		fs.mu.Unlock()
+		return
+	}
 	blks := append([]*msgBlock(nil), fs.blks...)
 	lmb, firstMoved, firstSeq := fs.lmb, fs.firstMoved, fs.state.FirstSeq
 	// Clear first moved.
 	fs.firstMoved = false
 	fs.mu.Unlock()
+
+	storeFsWerr := func(err error) {
+		fs.mu.Lock()
+		defer fs.mu.Unlock()
+		fs.setWriteErr(err)
+	}
 
 	var fsDmapLoaded bool
 	var fsDmap avl.SequenceSet
@@ -7185,9 +7616,19 @@ func (fs *fileStore) syncBlocks() {
 			mb.mu.Unlock()
 			continue
 		}
+		// Bubble up an individual block error into the broader filestore.
+		if err := mb.werr; err != nil {
+			mb.mu.Unlock()
+			storeFsWerr(err)
+			continue
+		}
 		// See if we can close FDs due to being idle.
 		if mb.mfd != nil && mb.sinceLastWriteActivity() > closeFDsIdle && mb.pendingWriteSizeLocked() == 0 {
-			mb.dirtyCloseWithRemove(false)
+			if err := mb.dirtyCloseWithRemove(false); err != nil {
+				mb.mu.Unlock()
+				storeFsWerr(err)
+				continue
+			}
 		}
 		// If our first has moved and we are set to noCompact (which is from tombstones),
 		// clear so that we might cleanup tombstones.
@@ -7203,9 +7644,17 @@ func (fs *fileStore) syncBlocks() {
 		}
 
 		// Flush anything that may be pending.
-		mb.flushPendingMsgsLocked()
+		if _, err := mb.flushPendingMsgsLocked(); err != nil {
+			mb.mu.Unlock()
+			storeFsWerr(err)
+			continue
+		}
 		// Check if we need to sync. We will not hold lock during actual sync.
 		needSync := mb.needSync
+
+		// Reset. Because we let go of the lock, we could write new data to this mb which might or
+		// might not be synced later if we would've reset after letting go of the lock.
+		mb.needSync = false
 		mb.mu.Unlock()
 
 		// Check if we should compact here.
@@ -7220,21 +7669,35 @@ func (fs *fileStore) syncBlocks() {
 			}
 			fs.mu.RLock()
 			mb.mu.Lock()
-			mb.compactWithFloor(firstSeq, &fsDmap)
+			// If the block has already been removed in the meantime, we can simply skip.
+			if _, ok := fs.bim[mb.index]; !ok {
+				mb.mu.Unlock()
+				fs.mu.RUnlock()
+				continue
+			}
+			err := mb.compactWithFloor(firstSeq, &fsDmap)
 			// If this compact removed all raw bytes due to tombstone cleanup, schedule to remove.
 			shouldRemove := mb.rbytes == 0
 			mb.mu.Unlock()
 			fs.mu.RUnlock()
+			if err != nil {
+				storeFsWerr(err)
+				continue
+			}
 
 			// Check if we should remove. This will not be common, so we will re-take fs write lock here vs changing
 			//  it above which we would prefer to be a readlock such that other lookups can occur while compacting this block.
 			if shouldRemove {
 				fs.mu.Lock()
 				mb.mu.Lock()
-				fs.removeMsgBlock(mb)
+				err = fs.removeMsgBlock(mb)
 				mb.mu.Unlock()
 				fs.mu.Unlock()
 				needSync = false
+				if err != nil {
+					storeFsWerr(err)
+					continue
+				}
 			}
 		}
 
@@ -7242,25 +7705,39 @@ func (fs *fileStore) syncBlocks() {
 		if needSync {
 			mb.mu.Lock()
 			var fd *os.File
+			var err error
 			var didOpen bool
 			if mb.mfd != nil {
 				fd = mb.mfd
 			} else {
 				<-dios
-				fd, _ = os.OpenFile(mb.mfn, os.O_RDWR, defaultFilePerms)
+				fd, err = os.OpenFile(mb.mfn, os.O_RDWR, defaultFilePerms)
 				dios <- struct{}{}
 				didOpen = true
+				if err != nil && !os.IsNotExist(err) {
+					mb.mu.Unlock()
+					storeFsWerr(err)
+					continue
+				}
 			}
 			// If we have an fd.
 			if fd != nil {
-				canClear := fd.Sync() == nil
+				if err = fd.Sync(); err != nil {
+					// Close fd if we opened it, but ignore its error since sync takes precedence.
+					if didOpen {
+						_ = fd.Close()
+					}
+					mb.mu.Unlock()
+					storeFsWerr(err)
+					continue
+				}
 				// If we opened the file close the fd.
 				if didOpen {
-					fd.Close()
-				}
-				// Only clear sync flag on success.
-				if canClear {
-					mb.needSync = false
+					if err = fd.Close(); err != nil {
+						mb.mu.Unlock()
+						storeFsWerr(err)
+						continue
+					}
 				}
 			}
 			mb.mu.Unlock()
@@ -7271,6 +7748,7 @@ func (fs *fileStore) syncBlocks() {
 		return
 	}
 	fs.mu.Lock()
+	defer fs.mu.Unlock()
 	fs.setSyncTimer()
 	if markDirty {
 		fs.dirty++
@@ -7279,15 +7757,28 @@ func (fs *fileStore) syncBlocks() {
 	// Sync state file if we are not running with sync always.
 	if !fs.fcfg.SyncAlways {
 		fn := filepath.Join(fs.fcfg.StoreDir, msgDir, streamStreamStateFile)
+		var fd *os.File
+		var err error
 		<-dios
-		fd, _ := os.OpenFile(fn, os.O_RDWR, defaultFilePerms)
+		fd, err = os.OpenFile(fn, os.O_RDWR, defaultFilePerms)
 		dios <- struct{}{}
+		if err != nil && !os.IsNotExist(err) {
+			fs.setWriteErr(err)
+			return
+		}
 		if fd != nil {
-			fd.Sync()
-			fd.Close()
+			if err = fd.Sync(); err != nil {
+				// Close fd, but ignore its error since sync takes precedence.
+				_ = fd.Close()
+				fs.setWriteErr(err)
+				return
+			}
+			if err = fd.Close(); err != nil {
+				fs.setWriteErr(err)
+				return
+			}
 		}
 	}
-	fs.mu.Unlock()
 }
 
 // Select the message block where this message should be found.
@@ -7590,16 +8081,13 @@ func (mb *msgBlock) writeAt(buf []byte, woff int64) (int, error) {
 // flushPendingMsgsLocked writes out any messages for this message block.
 // Lock should be held.
 func (mb *msgBlock) flushPendingMsgsLocked() (*LostStreamData, error) {
-	// Signals us that we need to rebuild filestore state.
-	var fsLostData *LostStreamData
-
 	var weakenCache bool
 	if mb.cache == nil {
 		mb.cache = mb.ecache.Value()
 		weakenCache = mb.cache != nil
 	}
-	if mb.cache == nil || mb.mfd == nil {
-		return nil, errNoCache
+	if mb.cache == nil || mb.mfd == nil || mb.werr != nil {
+		return nil, mb.werr
 	}
 
 	buf, err := mb.bytesPending()
@@ -7640,9 +8128,16 @@ func (mb *msgBlock) flushPendingMsgsLocked() (*LostStreamData, error) {
 	for lbb := lob; lbb > 0; lbb = len(buf) {
 		n, err := mb.writeAt(buf, wp)
 		if err != nil {
-			mb.dirtyCloseWithRemove(false)
+			// Ignore the errors here, we'll try reloading just to figure out and return the lost data if we can.
+			_ = mb.dirtyCloseWithRemove(false)
 			ld, _, _ := mb.rebuildStateLocked()
 			mb.werr = err
+			assert.Unreachable("Filestore msg block encountered flush error", map[string]any{
+				"name":     mb.fs.cfg.Name,
+				"mb.index": mb.index,
+				"err":      err,
+				"stack":    string(debug.Stack()),
+			})
 			return ld, err
 		}
 		// Update our write offset.
@@ -7650,12 +8145,9 @@ func (mb *msgBlock) flushPendingMsgsLocked() (*LostStreamData, error) {
 		buf = buf[n:]
 	}
 
-	// Clear any error.
-	mb.werr = nil
-
 	// Cache may be gone.
 	if mb.cache == nil || mb.mfd == nil {
-		return fsLostData, mb.werr
+		return nil, mb.werr
 	}
 
 	// Update write pointer.
@@ -7663,7 +8155,16 @@ func (mb *msgBlock) flushPendingMsgsLocked() (*LostStreamData, error) {
 
 	// Check if we are in sync always mode.
 	if mb.syncAlways {
-		mb.mfd.Sync()
+		if err = mb.mfd.Sync(); err != nil {
+			mb.werr = err
+			assert.Unreachable("Filestore msg block encountered sync error", map[string]any{
+				"name":     mb.fs.cfg.Name,
+				"mb.index": mb.index,
+				"err":      err,
+				"stack":    string(debug.Stack()),
+			})
+			return nil, err
+		}
 	} else {
 		mb.needSync = true
 	}
@@ -7673,7 +8174,7 @@ func (mb *msgBlock) flushPendingMsgsLocked() (*LostStreamData, error) {
 	// not releasing the lock during I/O operation. Therefore this will always
 	// return zero.
 	if mb.pendingWriteSizeLocked() > 0 {
-		return fsLostData, mb.werr
+		return nil, mb.werr
 	}
 
 	// Check last access time. If we think the block still has read interest
@@ -7684,13 +8185,13 @@ func (mb *msgBlock) flushPendingMsgsLocked() (*LostStreamData, error) {
 			mb.ecache.Weaken()
 		}
 		mb.resetCacheExpireTimer(0)
-		return fsLostData, mb.werr
+		return nil, mb.werr
 	}
 
 	// If not, we'll just drop the cache altogether & recycle the buffer.
 	mb.cache.nra = false
 	mb.expireCacheLocked()
-	return fsLostData, mb.werr
+	return nil, mb.werr
 }
 
 // Lock should be held.
@@ -7840,7 +8341,7 @@ checkCache:
 	if err != nil {
 		mb.fs.warn("loadBlock error: %v", err)
 		if err == errNoBlkData {
-			if ld, _, err := mb.rebuildStateLocked(); err != nil && ld != nil {
+			if ld, _, _ := mb.rebuildStateLocked(); ld != nil {
 				// Rebuild fs state too.
 				go mb.fs.rebuildState(ld)
 			}
@@ -8364,7 +8865,7 @@ func (fs *fileStore) loadLastLocked(subj string, sm *StoreMsg) (lsm *StoreMsg, e
 			continue
 		}
 		mb.mu.Lock()
-		if err := mb.ensurePerSubjectInfoLoaded(); err != nil {
+		if err = mb.ensurePerSubjectInfoLoaded(); err != nil {
 			mb.mu.Unlock()
 			return nil, err
 		}
@@ -8378,13 +8879,22 @@ func (fs *fileStore) loadLastLocked(subj string, sm *StoreMsg) (lsm *StoreMsg, e
 				// Check if we need to recalculate. We only care about the last sequence.
 				if ss.lastNeedsUpdate {
 					// mb is already loaded into the cache so should be fast-ish.
-					mb.recalculateForSubj(subj, ss)
+					if err = mb.recalculateForSubj(subj, ss); err != nil {
+						if err != nil {
+							mb.mu.Unlock()
+							return nil, err
+						}
+					}
 				}
 				l = ss.Last
 			}
 		}
 		if l == 0 {
-			_, _, l = mb.filteredPendingLocked(subj, wc, atomic.LoadUint64(&mb.first.seq))
+			_, _, l, err = mb.filteredPendingLocked(subj, wc, atomic.LoadUint64(&mb.first.seq))
+			if err != nil {
+				mb.mu.Unlock()
+				return nil, err
+			}
 		}
 		var didLoad bool
 		if l > 0 {
@@ -8524,7 +9034,9 @@ func (fs *fileStore) LoadNextMsg(filter string, wc bool, start uint64, sm *Store
 	// let's check the psim to see if we can skip ahead.
 	if start <= fs.state.FirstSeq {
 		var ss SimpleState
-		fs.numFilteredPendingNoLast(filter, &ss)
+		if err := fs.numFilteredPendingNoLast(filter, &ss); err != nil {
+			return nil, 0, err
+		}
 		// Nothing available.
 		if ss.Msgs == 0 {
 			return nil, fs.state.LastSeq, ErrStoreEOF
@@ -9012,6 +9524,15 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 		}
 	}
 
+	// Persist any write errors.
+	defer func() {
+		if err != nil {
+			fs.mu.Lock()
+			fs.setWriteErr(err)
+			fs.mu.Unlock()
+		}
+	}()
+
 	// Make sure to not leave subject if empty and we reach this spot.
 	if subject == _EMPTY_ {
 		subject = fwcs
@@ -9024,9 +9545,9 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 	// If we have a "keep" designation need to get full filtered state so we know how many to purge.
 	var maxp uint64
 	if keep > 0 {
-		ss := fs.FilteredState(1, subject)
-		if keep >= ss.Msgs {
-			return 0, nil
+		ss, err := fs.FilteredState(1, subject)
+		if err != nil || keep >= ss.Msgs {
+			return 0, err
 		}
 		maxp = ss.Msgs - keep
 	}
@@ -9035,7 +9556,15 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 	var tombs []msgId
 	var lowSeq uint64
 
+	if fs.isClosed() {
+		return purged, ErrStoreClosed
+	}
 	fs.mu.Lock()
+	// Always return previous write errors.
+	if err := fs.werr; err != nil {
+		fs.mu.Unlock()
+		return purged, err
+	}
 	// We may remove blocks as we purge, so don't range directly on fs.blks
 	// otherwise we may jump over some (see https://github.com/nats-io/nats-server/issues/3528)
 	for i := 0; i < len(fs.blks); i++ {
@@ -9045,7 +9574,12 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 		// If we do not have our fss, try to expire the cache if we have no items in this block.
 		shouldExpire := mb.fssNotLoaded()
 
-		t, f, l := mb.filteredPendingLocked(subject, wc, atomic.LoadUint64(&mb.first.seq))
+		t, f, l, err := mb.filteredPendingLocked(subject, wc, atomic.LoadUint64(&mb.first.seq))
+		if err != nil {
+			mb.mu.Unlock()
+			fs.mu.Unlock()
+			return purged, err
+		}
 		if t == 0 {
 			// Expire if we were responsible for loading.
 			if shouldExpire {
@@ -9094,7 +9628,12 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 					bytes += rl
 				}
 				// PSIM and FSS updates.
-				nr := mb.removeSeqPerSubject(sm.subj, seq)
+				nr, err := mb.removeSeqPerSubject(sm.subj, seq)
+				if err != nil {
+					mb.mu.Unlock()
+					fs.mu.Unlock()
+					return purged, err
+				}
 				nrg = fs.removePerSubject(sm.subj)
 
 				// Track tombstones we need to write.
@@ -9109,7 +9648,11 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 					if mb.isEmpty() {
 						// Since we are removing this block don't need to write tombstones.
 						tombs = tombs[:te]
-						fs.removeMsgBlock(mb)
+						if err = fs.removeMsgBlock(mb); err != nil {
+							mb.mu.Unlock()
+							fs.mu.Unlock()
+							return 0, err
+						}
 						i--
 						// keep flag set, if set previously
 						firstSeqNeedsUpdate = firstSeqNeedsUpdate || seq == fs.state.FirstSeq
@@ -9156,7 +9699,10 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 		}
 	}
 	if firstSeqNeedsUpdate {
-		fs.selectNextFirst()
+		if err = fs.selectNextFirst(); err != nil {
+			fs.mu.Unlock()
+			return purged, err
+		}
 	}
 
 	// Update the last purgeEx call time.
@@ -9166,14 +9712,17 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 	// When writing multiple tombstones we will flush at the end.
 	if len(tombs) > 0 {
 		for _, tomb := range tombs {
-			if err := fs.writeTombstoneNoFlush(tomb.seq, tomb.ts); err != nil {
+			if err = fs.writeTombstoneNoFlush(tomb.seq, tomb.ts); err != nil {
 				fs.mu.Unlock()
 				return purged, err
 			}
 		}
 		// Flush any pending. If we change blocks the newMsgBlockForWrite() will flush any pending for us.
 		if lmb := fs.lmb; lmb != nil {
-			lmb.flushPendingMsgs()
+			if err = lmb.flushPendingMsgs(); err != nil {
+				fs.mu.Unlock()
+				return purged, err
+			}
 		}
 	}
 
@@ -9199,14 +9748,28 @@ func (fs *fileStore) Purge() (uint64, error) {
 	return fs.purge(0)
 }
 
-func (fs *fileStore) purge(fseq uint64) (uint64, error) {
+func (fs *fileStore) purge(fseq uint64) (purged uint64, rerr error) {
 	if fs.isClosed() {
 		return 0, ErrStoreClosed
 	}
+	// Always return previous write errors.
+	if err := fs.werr; err != nil {
+		fs.mu.Unlock()
+		return 0, err
+	}
+
+	// Persist any write errors.
+	defer func() {
+		if rerr != nil {
+			fs.mu.Lock()
+			fs.setWriteErr(rerr)
+			fs.mu.Unlock()
+		}
+	}()
 
 	fs.mu.Lock()
 
-	purged := fs.state.Msgs
+	purged = fs.state.Msgs
 	rbytes := int64(fs.state.Bytes)
 
 	fs.state.FirstSeq = fs.state.LastSeq + 1
@@ -9239,11 +9802,20 @@ func (fs *fileStore) purge(fseq uint64) (uint64, error) {
 	if lseq := atomic.LoadUint64(&lmb.last.seq); lseq > 0 {
 		// Leave a tombstone so we can remember our starting sequence in case
 		// full state becomes corrupted.
-		fs.writeTombstone(lseq, lmb.last.ts)
+		if err := fs.writeTombstone(lseq, lmb.last.ts); err != nil {
+			fs.mu.Unlock()
+			return purged, err
+		}
 	}
 	// Close FDs since we'll move the file. We re-enable the FD after the purge is complete.
-	lmb.flushPendingMsgs()
-	lmb.closeFDs()
+	if err := lmb.flushPendingMsgs(); err != nil {
+		fs.mu.Unlock()
+		return purged, err
+	}
+	if err := lmb.closeFDs(); err != nil {
+		fs.mu.Unlock()
+		return purged, err
+	}
 
 	fs.blks = nil
 	fs.lmb = nil
@@ -9264,39 +9836,75 @@ func (fs *fileStore) purge(fseq uint64) (uint64, error) {
 	// If purge directory still exists then we need to wait
 	// in place and remove since rename would fail.
 	if _, err := os.Stat(ndir); err == nil {
-		os.RemoveAll(ndir)
+		if err = os.RemoveAll(ndir); err != nil {
+			dios <- struct{}{}
+			fs.mu.Unlock()
+			return purged, err
+		}
+	} else if !os.IsNotExist(err) {
+		dios <- struct{}{}
+		fs.mu.Unlock()
+		return purged, err
 	}
 	if _, err := os.Stat(pdir); err == nil {
-		os.RemoveAll(pdir)
+		if err = os.RemoveAll(pdir); err != nil {
+			dios <- struct{}{}
+			fs.mu.Unlock()
+			return purged, err
+		}
+	} else if !os.IsNotExist(err) {
+		dios <- struct{}{}
+		fs.mu.Unlock()
+		return purged, err
 	}
 
 	// Create directory to move the new tombstone to.
-	os.MkdirAll(ndir, defaultDirPerms)
+	if err := os.MkdirAll(ndir, defaultDirPerms); err != nil {
+		dios <- struct{}{}
+		fs.mu.Unlock()
+		return purged, err
+	}
 	// Move out the block containing the tombstone. Also move the key file if encrypted.
 	// The block file itself MUST be moved last to ensure we can assume the prior renames
 	// were successful during recovery.
 	for _, mbf := range []string{fmt.Sprintf(keyScan, lmb.index), fmt.Sprintf(blkScan, lmb.index)} {
 		b := filepath.Join(mdir, mbf)
 		a := filepath.Join(ndir, mbf)
-		os.Rename(b, a)
+		if err := os.Rename(b, a); err != nil && !os.IsNotExist(err) {
+			dios <- struct{}{}
+			fs.mu.Unlock()
+			return purged, err
+		}
 	}
 	// Purge all remaining messages.
-	os.Rename(mdir, pdir)
+	if err := os.Rename(mdir, pdir); err != nil {
+		dios <- struct{}{}
+		fs.mu.Unlock()
+		return purged, err
+	}
 	// Rename the directory back to be left only with the tombstone.
-	os.Rename(ndir, mdir)
+	if err := os.Rename(ndir, mdir); err != nil {
+		dios <- struct{}{}
+		fs.mu.Unlock()
+		return purged, err
+	}
 	dios <- struct{}{}
 
 	// Remove the purged messages directory asynchronously.
 	go func() {
 		<-dios
-		os.RemoveAll(pdir)
+		_ = os.RemoveAll(pdir)
 		dios <- struct{}{}
 	}()
 
 	// Re-enable writing for the lmb.
 	lmb.mu.Lock()
-	lmb.enableForWriting(fs.fip)
+	err := lmb.enableForWriting(fs.fip)
 	lmb.mu.Unlock()
+	if err != nil {
+		fs.mu.Unlock()
+		return purged, err
+	}
 
 	cb := fs.scb
 	fs.mu.Unlock()
@@ -9314,27 +9922,34 @@ func (fs *fileStore) purge(fseq uint64) (uint64, error) {
 }
 
 // Lock and dios should be held.
-func (fs *fileStore) recoverPartialPurge() {
+func (fs *fileStore) recoverPartialPurge() error {
 	ndir := filepath.Join(fs.fcfg.StoreDir, newMsgDir)
-	if entries, err := os.ReadDir(ndir); err == nil {
+	if entries, err := os.ReadDir(ndir); err != nil && !os.IsNotExist(err) {
+		return err
+	} else if err == nil {
 		// If it's empty, that means we got hard killed before moving the tombstone, and we need to remove it.
 		isEmpty := !slices.ContainsFunc(entries, func(e os.DirEntry) bool {
 			// The directory is considered empty if it's missing a block file.
 			return strings.HasSuffix(e.Name(), blkSuffix)
 		})
 		if isEmpty {
-			os.RemoveAll(ndir)
+			_ = os.RemoveAll(ndir)
 		} else {
 			// Otherwise, it contains the tombstone after purge, and the old messages need to be purged instead.
 			mdir := filepath.Join(fs.fcfg.StoreDir, msgDir)
-			os.RemoveAll(mdir)
-			os.Rename(ndir, mdir)
+			if err = os.RemoveAll(mdir); err != nil {
+				return err
+			}
+			if err = os.Rename(ndir, mdir); err != nil {
+				return err
+			}
 		}
 	}
 	pdir := filepath.Join(fs.fcfg.StoreDir, purgeDir)
 	if _, err := os.Stat(pdir); err == nil {
-		os.RemoveAll(pdir)
+		_ = os.RemoveAll(pdir)
 	}
+	return nil
 }
 
 // Compact will remove all messages from this store up to
@@ -9344,14 +9959,20 @@ func (fs *fileStore) Compact(seq uint64) (uint64, error) {
 	return fs.compact(seq)
 }
 
-func (fs *fileStore) compact(seq uint64) (uint64, error) {
+func (fs *fileStore) compact(seq uint64) (purged uint64, rerr error) {
+	if fs.isClosed() {
+		return 0, ErrStoreClosed
+	}
 	if seq == 0 {
 		return fs.purge(seq)
 	}
 
-	var purged, bytes uint64
-
 	fs.mu.Lock()
+	// Always return previous write errors.
+	if err := fs.werr; err != nil {
+		fs.mu.Unlock()
+		return 0, err
+	}
 	// Same as purge all.
 	if lseq := fs.state.LastSeq; seq > lseq {
 		fs.mu.Unlock()
@@ -9369,6 +9990,17 @@ func (fs *fileStore) compact(seq uint64) (uint64, error) {
 		return 0, nil
 	}
 
+	// Persist any write errors.
+	defer func() {
+		if rerr != nil {
+			fs.mu.Lock()
+			fs.setWriteErr(rerr)
+			fs.mu.Unlock()
+		}
+	}()
+
+	var bytes uint64
+
 	// All msgblocks up to this one can be thrown away.
 	var deleted int
 	for _, mb := range fs.blks {
@@ -9379,7 +10011,11 @@ func (fs *fileStore) compact(seq uint64) (uint64, error) {
 		purged += mb.msgs
 		bytes += mb.bytes
 		// Make sure we do subject cleanup as well.
-		mb.ensurePerSubjectInfoLoaded()
+		if err := mb.ensurePerSubjectInfoLoaded(); err != nil {
+			mb.mu.Unlock()
+			fs.mu.Unlock()
+			return 0, err
+		}
 		mb.fss.IterOrdered(func(bsubj []byte, ss *SimpleState) bool {
 			subj := bytesToString(bsubj)
 			for i := uint64(0); i < ss.Msgs; i++ {
@@ -9388,8 +10024,12 @@ func (fs *fileStore) compact(seq uint64) (uint64, error) {
 			return true
 		})
 		// Now close.
-		mb.dirtyCloseWithRemove(true)
+		err := mb.dirtyCloseWithRemove(true)
 		mb.mu.Unlock()
+		if err != nil {
+			fs.mu.Unlock()
+			return purged, err
+		}
 		deleted++
 	}
 
@@ -9407,7 +10047,9 @@ func (fs *fileStore) compact(seq uint64) (uint64, error) {
 	// Make sure we have the messages loaded.
 	if smb.cacheNotLoaded() {
 		if err = smb.loadMsgsWithLock(); err != nil {
-			goto SKIP
+			smb.mu.Unlock()
+			fs.mu.Unlock()
+			return purged, err
 		}
 		defer func() {
 			// The lock is released once we get here, so need to re-acquire.
@@ -9435,7 +10077,11 @@ func (fs *fileStore) compact(seq uint64) (uint64, error) {
 				purged++
 			}
 			// Update fss
-			smb.removeSeqPerSubject(sm.subj, mseq)
+			if _, err := smb.removeSeqPerSubject(sm.subj, mseq); err != nil {
+				smb.mu.Unlock()
+				fs.mu.Unlock()
+				return purged, err
+			}
 			fs.removePerSubject(sm.subj)
 			tombs = append(tombs, msgId{sm.seq, sm.ts})
 		}
@@ -9445,7 +10091,11 @@ func (fs *fileStore) compact(seq uint64) (uint64, error) {
 	if isEmpty := smb.msgs == 0; isEmpty {
 		// Only remove if not the last block.
 		if smb != fs.lmb {
-			smb.dirtyCloseWithRemove(true)
+			if err = smb.dirtyCloseWithRemove(true); err != nil {
+				smb.mu.Unlock()
+				fs.mu.Unlock()
+				return purged, err
+			}
 			deleted++
 		} else {
 			// Make sure to sync changes.
@@ -9475,7 +10125,11 @@ func (fs *fileStore) compact(seq uint64) (uint64, error) {
 		if smb.rbytes > compactMinimum && smb.bytes*2 < smb.rbytes {
 			var moff uint32
 			moff, _, _, err = smb.slotInfo(int(atomic.LoadUint64(&smb.first.seq) - smb.cache.fseq))
-			if err != nil || moff >= uint32(len(smb.cache.buf)) {
+			if err != nil {
+				smb.mu.Unlock()
+				fs.mu.Unlock()
+				return purged, err
+			} else if moff >= uint32(len(smb.cache.buf)) {
 				goto SKIP
 			}
 			buf := smb.cache.buf[moff:]
@@ -9488,7 +10142,9 @@ func (fs *fileStore) compact(seq uint64) (uint64, error) {
 				// Recreate to reset counter.
 				bek, err := genBlockEncryptionKey(smb.fs.fcfg.Cipher, smb.seed, smb.nonce)
 				if err != nil {
-					goto SKIP
+					smb.mu.Unlock()
+					fs.mu.Unlock()
+					return purged, err
 				}
 				// For future writes make sure to set smb.bek to keep counter correct.
 				smb.bek = bek
@@ -9497,21 +10153,27 @@ func (fs *fileStore) compact(seq uint64) (uint64, error) {
 			// Recompress if necessary (smb.cmp contains the algorithm used when
 			// the block was loaded from disk, or defaults to NoCompression if not)
 			if nbuf, err = smb.cmp.Compress(nbuf); err != nil {
-				goto SKIP
+				smb.mu.Unlock()
+				fs.mu.Unlock()
+				return purged, err
 			}
 
 			// We will write to a new file and mv/rename it in case of failure.
 			mfn := filepath.Join(smb.fs.fcfg.StoreDir, msgDir, fmt.Sprintf(newScan, smb.index))
 			<-dios
-			err := os.WriteFile(mfn, nbuf, defaultFilePerms)
+			err = os.WriteFile(mfn, nbuf, defaultFilePerms)
 			dios <- struct{}{}
 			if err != nil {
-				os.Remove(mfn)
-				goto SKIP
+				_ = os.Remove(mfn)
+				smb.mu.Unlock()
+				fs.mu.Unlock()
+				return purged, err
 			}
-			if err := os.Rename(mfn, smb.mfn); err != nil {
-				os.Remove(mfn)
-				goto SKIP
+			if err = os.Rename(mfn, smb.mfn); err != nil {
+				_ = os.Remove(mfn)
+				smb.mu.Unlock()
+				fs.mu.Unlock()
+				return purged, err
 			}
 
 			// Make sure to remove fss state.
@@ -9530,14 +10192,17 @@ SKIP:
 	// When writing multiple tombstones we will flush at the end.
 	if len(tombs) > 0 {
 		for _, tomb := range tombs {
-			if err := fs.writeTombstoneNoFlush(tomb.seq, tomb.ts); err != nil {
+			if err = fs.writeTombstoneNoFlush(tomb.seq, tomb.ts); err != nil {
 				fs.mu.Unlock()
 				return purged, err
 			}
 		}
 		// Flush any pending. If we change blocks the newMsgBlockForWrite() will flush any pending for us.
 		if lmb := fs.lmb; lmb != nil {
-			lmb.flushPendingMsgs()
+			if err = lmb.flushPendingMsgs(); err != nil {
+				fs.mu.Unlock()
+				return purged, err
+			}
 		}
 	}
 
@@ -9606,8 +10271,12 @@ func (fs *fileStore) reset() error {
 		mb.mu.Lock()
 		purged += mb.msgs
 		bytes += mb.bytes
-		mb.dirtyCloseWithRemove(true)
+		err := mb.dirtyCloseWithRemove(true)
 		mb.mu.Unlock()
+		if err != nil {
+			fs.mu.Unlock()
+			return err
+		}
 	}
 
 	// Reset
@@ -9739,7 +10408,7 @@ func (mb *msgBlock) numPriorTombsLocked() int {
 }
 
 // Truncate will truncate a stream store up to seq. Sequence needs to be valid.
-func (fs *fileStore) Truncate(seq uint64) error {
+func (fs *fileStore) Truncate(seq uint64) (rerr error) {
 	if fs.isClosed() {
 		return ErrStoreClosed
 	}
@@ -9750,15 +10419,34 @@ func (fs *fileStore) Truncate(seq uint64) error {
 	}
 
 	fs.mu.Lock()
+	// Always return previous write errors.
+	if err := fs.werr; err != nil {
+		fs.mu.Unlock()
+		return err
+	}
+
+	// Persist any write errors.
+	defer func() {
+		if rerr != nil {
+			fs.mu.Lock()
+			fs.setWriteErr(rerr)
+			fs.mu.Unlock()
+		}
+	}()
 
 	// Any existing state file will no longer be applicable. We will force write a new one
 	// at the end, after we release the lock.
 	os.Remove(filepath.Join(fs.fcfg.StoreDir, msgDir, streamStreamStateFile))
 
+	var err error
 	var lsm *StoreMsg
 	smb := fs.selectMsgBlock(seq)
 	if smb != nil {
-		lsm, _, _ = smb.fetchMsgNoCopy(seq, nil)
+		lsm, _, err = smb.fetchMsgNoCopy(seq, nil)
+		if err != nil && err != ErrStoreMsgNotFound && err != errDeletedMsg {
+			fs.mu.Unlock()
+			return err
+		}
 	}
 
 	// Reset last so new block doesn't contain truncated sequences/timestamps.
@@ -9791,7 +10479,10 @@ func (fs *fileStore) Truncate(seq uint64) error {
 	// If the selected block is not found or the message was deleted, we'll need to write a tombstone
 	// at the truncated sequence so we don't roll backward on our last sequence and timestamp.
 	if lsm == nil || removeSmb {
-		fs.writeTombstone(seq, lastTime)
+		if err = fs.writeTombstone(seq, lastTime); err != nil {
+			fs.mu.Unlock()
+			return err
+		}
 	}
 
 	var purged, bytes uint64
@@ -9819,13 +10510,20 @@ func (fs *fileStore) Truncate(seq uint64) error {
 			mb.mu.Unlock()
 			for _, tomb := range tombs {
 				if tomb.seq < seq {
-					fs.writeTombstone(tomb.seq, tomb.ts)
+					if err = fs.writeTombstone(tomb.seq, tomb.ts); err != nil {
+						fs.mu.Unlock()
+						return err
+					}
 				}
 			}
 			mb.mu.Lock()
 		}
-		fs.forceRemoveMsgBlock(mb)
+		err = fs.forceRemoveMsgBlock(mb)
 		mb.mu.Unlock()
+		if err != nil {
+			fs.mu.Unlock()
+			return err
+		}
 	}
 
 	hasWrittenTombstones := len(tmb.tombs()) > 0
@@ -9841,13 +10539,20 @@ func (fs *fileStore) Truncate(seq uint64) error {
 				smb.mu.Unlock()
 				for _, tomb := range tombs {
 					if tomb.seq < seq {
-						fs.writeTombstone(tomb.seq, tomb.ts)
+						if err = fs.writeTombstone(tomb.seq, tomb.ts); err != nil {
+							fs.mu.Unlock()
+							return err
+						}
 					}
 				}
 				smb.mu.Lock()
 			}
-			fs.forceRemoveMsgBlock(smb)
+			err = fs.forceRemoveMsgBlock(smb)
 			smb.mu.Unlock()
+			if err != nil {
+				fs.mu.Unlock()
+				return err
+			}
 			goto SKIP
 		}
 
@@ -9888,8 +10593,12 @@ SKIP:
 	if !hasWrittenTombstones {
 		fs.lmb = smb
 		tmb.mu.Lock()
-		fs.forceRemoveMsgBlock(tmb)
+		err = fs.forceRemoveMsgBlock(tmb)
 		tmb.mu.Unlock()
+		if err != nil {
+			fs.mu.Unlock()
+			return err
+		}
 	}
 
 	// Reset last.
@@ -9906,7 +10615,10 @@ SKIP:
 	fs.state.Bytes -= bytes
 
 	// Reset our subject lookup info.
-	fs.resetGlobalPerSubjectInfo()
+	if err = fs.resetGlobalPerSubjectInfo(); err != nil {
+		fs.mu.Unlock()
+		return err
+	}
 
 	fs.dirty++
 
@@ -9966,41 +10678,59 @@ func (fs *fileStore) removeMsgBlockFromList(mb *msgBlock) {
 
 // Removes the msgBlock
 // Both locks should be held.
-func (fs *fileStore) removeMsgBlock(mb *msgBlock) {
+func (fs *fileStore) removeMsgBlock(mb *msgBlock) error {
 	// Check for us being last message block
 	lseq, lts := atomic.LoadUint64(&mb.last.seq), mb.last.ts
 	if mb == fs.lmb {
 		// Creating a new message write block requires that the lmb lock is not held.
 		mb.mu.Unlock()
 		// Write the tombstone to remember since this was last block.
-		if lmb, _ := fs.newMsgBlockForWrite(); lmb != nil {
-			fs.writeTombstone(lseq, lts)
+		if lmb, err := fs.newMsgBlockForWrite(); err != nil || lmb == nil {
+			if err != nil {
+				err = errors.New("lmb missing")
+			}
+			// Re-acquire mb lock
+			mb.mu.Lock()
+			return err
+		} else if err = fs.writeTombstone(lseq, lts); err != nil {
+			// Re-acquire mb lock
+			mb.mu.Lock()
+			return err
 		}
 		mb.mu.Lock()
 	} else if lseq == fs.state.LastSeq {
 		// Need to write a tombstone for the last sequence if we're removing the block containing it.
-		fs.writeTombstone(lseq, lts)
+		if err := fs.writeTombstone(lseq, lts); err != nil {
+			return err
+		}
 	}
 	// Only delete message block after (potentially) writing a tombstone.
 	// But only if it doesn't contain any tombstones for prior blocks.
-	if mb.numPriorTombsLocked() == 0 {
-		fs.forceRemoveMsgBlock(mb)
+	if mb.numPriorTombsLocked() > 0 {
+		return nil
 	}
+	return fs.forceRemoveMsgBlock(mb)
 }
 
 // Removes the msgBlock, without writing tombstones to ensure the last sequence is preserved.
 // Both locks should be held.
-func (fs *fileStore) forceRemoveMsgBlock(mb *msgBlock) {
-	mb.dirtyCloseWithRemove(true)
+func (fs *fileStore) forceRemoveMsgBlock(mb *msgBlock) error {
+	if err := mb.dirtyCloseWithRemove(true); err != nil {
+		return err
+	}
 	fs.removeMsgBlockFromList(mb)
+	return nil
 }
 
 // Purges and removes the msgBlock from the store.
 // Lock should be held.
-func (fs *fileStore) purgeMsgBlock(mb *msgBlock) {
+func (fs *fileStore) purgeMsgBlock(mb *msgBlock) error {
 	mb.mu.Lock()
 	// Adjust per-subject tracking if present.
-	if err := mb.ensurePerSubjectInfoLoaded(); err == nil && mb.fss != nil {
+	if err := mb.ensurePerSubjectInfoLoaded(); err != nil {
+		mb.mu.Unlock()
+		return err
+	} else if mb.fss != nil {
 		mb.fss.IterFast(func(bsubj []byte, ss *SimpleState) bool {
 			subj := bytesToString(bsubj)
 			for range ss.Msgs {
@@ -10011,21 +10741,25 @@ func (fs *fileStore) purgeMsgBlock(mb *msgBlock) {
 	}
 	// Clean up scheduled message metadata if we know this block contained any.
 	if fs.scheduling != nil && mb.schedules > 0 {
-		cacheLoaded := !mb.cacheNotLoaded()
-		if !cacheLoaded {
-			cacheLoaded = mb.loadMsgsWithLock() == nil
+		if mb.cacheNotLoaded() {
+			if err := mb.loadMsgsWithLock(); err != nil {
+				mb.mu.Unlock()
+				return err
+			}
 		}
-		if cacheLoaded {
-			var smv StoreMsg
-			fseq, lseq := atomic.LoadUint64(&mb.first.seq), atomic.LoadUint64(&mb.last.seq)
-			for seq := fseq; seq <= lseq; seq++ {
-				sm, err := mb.cacheLookupNoCopy(seq, &smv)
-				if err != nil || sm == nil {
-					continue
-				}
-				if schedule, ok := getMessageSchedule(sm.hdr); ok && !schedule.IsZero() {
-					fs.scheduling.remove(seq)
-				}
+		var smv StoreMsg
+		fseq, lseq := atomic.LoadUint64(&mb.first.seq), atomic.LoadUint64(&mb.last.seq)
+		for seq := fseq; seq <= lseq; seq++ {
+			sm, err := mb.cacheLookupNoCopy(seq, &smv)
+			if err != nil && err != errDeletedMsg {
+				mb.mu.Unlock()
+				return err
+			}
+			if sm == nil {
+				continue
+			}
+			if schedule, ok := getMessageSchedule(sm.hdr); ok && !schedule.IsZero() {
+				fs.scheduling.remove(seq)
 			}
 		}
 	}
@@ -10039,11 +10773,16 @@ func (fs *fileStore) purgeMsgBlock(mb *msgBlock) {
 	}
 	fs.state.Msgs -= msgs
 	fs.state.Bytes -= bytes
-	fs.removeMsgBlock(mb)
+	if err := fs.removeMsgBlock(mb); err != nil {
+		mb.mu.Unlock()
+		return err
+	}
 	mb.tryForceExpireCacheLocked()
 	mb.finishedWithCache()
 	mb.mu.Unlock()
-	fs.selectNextFirst()
+	if err := fs.selectNextFirst(); err != nil {
+		return err
+	}
 
 	if cb := fs.scb; cb != nil {
 		// If we have a callback registered, we need to release lock regardless since consumers will recalculate pending.
@@ -10052,6 +10791,7 @@ func (fs *fileStore) purgeMsgBlock(mb *msgBlock) {
 		cb(-int64(msgs), -int64(bytes), 0, _EMPTY_)
 		fs.mu.Lock()
 	}
+	return nil
 }
 
 // Called by purge to simply get rid of the cache and close our fds.
@@ -10079,23 +10819,23 @@ func (mb *msgBlock) dirtyCloseWithRemove(remove bool) error {
 		close(mb.qch)
 		mb.qch = nil
 	}
-	if mb.mfd != nil {
-		mb.mfd.Close()
+	if fd := mb.mfd; fd != nil {
 		mb.mfd = nil
+		if err := fd.Close(); err != nil && !os.IsNotExist(err) {
+			return err
+		}
 	}
 	if remove {
 		// Clear any tracking by subject if we are removing.
 		mb.fss = nil
 		if mb.mfn != _EMPTY_ {
-			err := os.Remove(mb.mfn)
-			if isPermissionError(err) {
+			if err := os.Remove(mb.mfn); err != nil && !os.IsNotExist(err) {
 				return err
 			}
 			mb.mfn = _EMPTY_
 		}
 		if mb.kfn != _EMPTY_ {
-			err := os.Remove(mb.kfn)
-			if isPermissionError(err) {
+			if err := os.Remove(mb.kfn); err != nil && !os.IsNotExist(err) {
 				return err
 			}
 		}
@@ -10105,21 +10845,23 @@ func (mb *msgBlock) dirtyCloseWithRemove(remove bool) error {
 
 // Remove a seq from the fss and select new first.
 // Lock should be held.
-func (mb *msgBlock) removeSeqPerSubject(subj string, seq uint64) uint64 {
-	mb.ensurePerSubjectInfoLoaded()
+func (mb *msgBlock) removeSeqPerSubject(subj string, seq uint64) (uint64, error) {
+	if err := mb.ensurePerSubjectInfoLoaded(); err != nil {
+		return 0, err
+	}
 	if mb.fss == nil {
-		return 0
+		return 0, nil
 	}
 	bsubj := stringToBytes(subj)
 	ss, ok := mb.fss.Find(bsubj)
 	if !ok || ss == nil {
-		return 0
+		return 0, nil
 	}
 
 	mb.fs.sdm.removeSeqAndSubject(seq, subj)
 	if ss.Msgs == 1 {
 		mb.fss.Delete(bsubj)
-		return 0
+		return 0, nil
 	}
 
 	ss.Msgs--
@@ -10129,12 +10871,12 @@ func (mb *msgBlock) removeSeqPerSubject(subj string, seq uint64) uint64 {
 		if !ss.lastNeedsUpdate && seq != ss.Last {
 			ss.First = ss.Last
 			ss.firstNeedsUpdate = false
-			return 1
+			return 1, nil
 		}
 		if !ss.firstNeedsUpdate && seq != ss.First {
 			ss.Last = ss.First
 			ss.lastNeedsUpdate = false
-			return 1
+			return 1, nil
 		}
 	}
 
@@ -10142,16 +10884,16 @@ func (mb *msgBlock) removeSeqPerSubject(subj string, seq uint64) uint64 {
 	ss.firstNeedsUpdate = seq == ss.First || ss.firstNeedsUpdate
 	ss.lastNeedsUpdate = seq == ss.Last || ss.lastNeedsUpdate
 
-	return ss.Msgs
+	return ss.Msgs, nil
 }
 
 // Will recalculate the first and/or last sequence for this subject in this block.
 // Will avoid slower path message lookups and scan the cache directly instead.
-func (mb *msgBlock) recalculateForSubj(subj string, ss *SimpleState) {
+func (mb *msgBlock) recalculateForSubj(subj string, ss *SimpleState) error {
 	// Need to make sure messages are loaded.
 	if mb.cacheNotLoaded() {
 		if err := mb.loadMsgsWithLock(); err != nil {
-			return
+			return err
 		}
 		defer mb.finishedWithCache()
 	}
@@ -10164,7 +10906,7 @@ func (mb *msgBlock) recalculateForSubj(subj string, ss *SimpleState) {
 		ss.First = ss.Last
 		ss.firstNeedsUpdate = false
 		ss.lastNeedsUpdate = false
-		return
+		return nil
 	}
 
 	endSlot := int(ss.Last - mb.cache.fseq)
@@ -10172,7 +10914,7 @@ func (mb *msgBlock) recalculateForSubj(subj string, ss *SimpleState) {
 		endSlot = 0
 	}
 	if endSlot >= len(mb.cache.idx) || startSlot > endSlot {
-		return
+		return nil
 	}
 
 	var le = binary.LittleEndian
@@ -10195,7 +10937,7 @@ func (mb *msgBlock) recalculateForSubj(subj string, ss *SimpleState) {
 				ss.First = ss.Last
 				// Only need to reset ss.lastNeedsUpdate, ss.firstNeedsUpdate is already reset above.
 				ss.lastNeedsUpdate = false
-				return
+				return nil
 			}
 			buf := mb.cache.buf[li:]
 			hdr := buf[:msgHdrSize]
@@ -10209,7 +10951,7 @@ func (mb *msgBlock) recalculateForSubj(subj string, ss *SimpleState) {
 				if ss.Msgs == 1 {
 					ss.Last = seq
 					ss.lastNeedsUpdate = false
-					return
+					return nil
 				}
 				// Skip the start slot ahead, if we need to recalculate last we can stop early.
 				startSlot = slot
@@ -10234,7 +10976,7 @@ func (mb *msgBlock) recalculateForSubj(subj string, ss *SimpleState) {
 			li := int(bi)
 			if li >= len(mb.cache.buf) {
 				// Can't overwrite ss.Last, just skip.
-				return
+				return nil
 			}
 			buf := mb.cache.buf[li:]
 			hdr := buf[:msgHdrSize]
@@ -10253,22 +10995,26 @@ func (mb *msgBlock) recalculateForSubj(subj string, ss *SimpleState) {
 					ss.First = seq
 					ss.firstNeedsUpdate = false
 				}
-				return
+				return nil
 			}
 		}
 	}
+	return nil
 }
 
 // Lock should be held.
-func (fs *fileStore) resetGlobalPerSubjectInfo() {
+func (fs *fileStore) resetGlobalPerSubjectInfo() error {
 	// Clear any global subject state.
 	fs.psim, fs.tsl = fs.psim.Empty(), 0
 	if fs.noTrackSubjects() {
-		return
+		return nil
 	}
 	for _, mb := range fs.blks {
-		fs.populateGlobalPerSubjectInfo(mb)
+		if err := fs.populateGlobalPerSubjectInfo(mb); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // Lock should be held.
@@ -10358,12 +11104,12 @@ func (mb *msgBlock) ensurePerSubjectInfoLoaded() error {
 
 // Called on recovery to populate the global psim state.
 // Lock should be held.
-func (fs *fileStore) populateGlobalPerSubjectInfo(mb *msgBlock) {
+func (fs *fileStore) populateGlobalPerSubjectInfo(mb *msgBlock) error {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
 
 	if err := mb.ensurePerSubjectInfoLoaded(); err != nil {
-		return
+		return err
 	}
 
 	// Now populate psim.
@@ -10381,6 +11127,7 @@ func (fs *fileStore) populateGlobalPerSubjectInfo(mb *msgBlock) {
 		}
 		return true
 	})
+	return nil
 }
 
 // Close the message block.
@@ -10448,10 +11195,8 @@ func (fs *fileStore) Delete(inline bool) error {
 	}
 
 	pdir := filepath.Join(fs.fcfg.StoreDir, purgeDir)
-	// If purge directory still exists then we need to wait
-	// in place and remove since rename would fail.
 	if _, err := os.Stat(pdir); err == nil {
-		os.RemoveAll(pdir)
+		_ = os.RemoveAll(pdir)
 	}
 
 	// Quickly close all blocks and simulate a purge w/o overhead an new write block.
@@ -10735,7 +11480,7 @@ func (fs *fileStore) _writeFullState(force bool) error {
 		buf = binary.AppendUvarint(buf, mb.ttls)      // Field is new in version 2
 		buf = binary.AppendUvarint(buf, mb.schedules) // Field is new in version 3
 		if numDeleted > 0 {
-			dmap, _ := mb.dmap.Encode(scratch[:0])
+			dmap := mb.dmap.Encode(scratch[:0])
 			dmapTotalLen += len(dmap)
 			buf = append(buf, dmap...)
 		}
@@ -10809,16 +11554,14 @@ func (fs *fileStore) _writeFullState(force bool) error {
 	err := os.WriteFile(fn, buf, defaultFilePerms)
 	// if file system is not writable isPermissionError is set to true
 	dios <- struct{}{}
-	if isPermissionError(err) {
+	if err != nil {
 		return err
 	}
 
 	// Update dirty if successful.
-	if err == nil {
-		fs.mu.Lock()
-		fs.dirty -= priorDirty
-		fs.mu.Unlock()
-	}
+	fs.mu.Lock()
+	fs.dirty -= priorDirty
+	fs.mu.Unlock()
 
 	// Attempt to write both files, an error in one should not prevent the other from being written.
 	ttlErr := fs.writeTTLState()
@@ -11234,10 +11977,7 @@ func (fs *fileStore) EncodedStreamState(failed uint64) ([]byte, error) {
 				i += binary.PutUvarint(scratch[i:], num)
 				b = append(b, scratch[0:i]...)
 			case *avl.SequenceSet:
-				buf, err := db.Encode(scratch[:0])
-				if err != nil {
-					return nil, err
-				}
+				buf := db.Encode(scratch[:0])
 				b = append(b, buf...)
 			default:
 				return nil, errors.New("no impl")
@@ -11311,13 +12051,22 @@ func (fs *fileStore) deleteMap() (dmap avl.SequenceSet) {
 
 // SyncDeleted will make sure this stream has same deleted state as dbs.
 // This will only process deleted state within our current state.
-func (fs *fileStore) SyncDeleted(dbs DeleteBlocks) {
+func (fs *fileStore) SyncDeleted(dbs DeleteBlocks) error {
+	if fs.isClosed() {
+		return ErrStoreClosed
+	}
+
 	if len(dbs) == 0 {
-		return
+		return nil
 	}
 
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
+
+	// Always return previous write errors.
+	if err := fs.werr; err != nil {
+		return err
+	}
 
 	lseq := fs.state.LastSeq
 	var needsCheck DeleteBlocks
@@ -11342,16 +12091,25 @@ func (fs *fileStore) SyncDeleted(dbs DeleteBlocks) {
 	fs.readUnlockAllMsgBlocks()
 
 	for _, db := range needsCheck {
+		var err error
 		if dr, ok := db.(*DeleteRange); ok {
 			first, last, _ := dr.State()
-			fs.removeMsgsInRange(first, last, true)
+			err = fs.removeMsgsInRange(first, last, true)
 		} else {
 			db.Range(func(dseq uint64) bool {
-				fs.removeMsg(dseq, false, true, false)
-				return true
+				_, err = fs.removeMsg(dseq, false, true, false)
+				// Can continue safely if the message doesn't exist.
+				if err == ErrStoreEOF || err == ErrStoreMsgNotFound {
+					err = nil
+				}
+				return err == nil
 			})
 		}
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -11392,7 +12150,9 @@ func (fs *fileStore) ConsumerStore(name string, created time.Time, cfg *Consumer
 	if cfg.MemoryStorage {
 		// Create directly here.
 		o := &consumerMemStore{ms: fs, cfg: *cfg}
-		fs.AddConsumer(o)
+		if err := fs.AddConsumer(o); err != nil {
+			return nil, err
+		}
 		return o, nil
 	}
 
@@ -11458,7 +12218,7 @@ func (fs *fileStore) ConsumerStore(name string, created time.Time, cfg *Consumer
 	if _, err := os.Stat(meta); err != nil && os.IsNotExist(err) {
 		didCreate = true
 		if err := o.writeConsumerMeta(); err != nil {
-			os.RemoveAll(odir)
+			_ = os.RemoveAll(odir)
 			return nil, err
 		}
 	}
@@ -11470,7 +12230,7 @@ func (fs *fileStore) ConsumerStore(name string, created time.Time, cfg *Consumer
 		if _, err := os.Stat(keyFile); err != nil && os.IsNotExist(err) {
 			if err := o.writeConsumerMeta(); err != nil {
 				if didCreate {
-					os.RemoveAll(odir)
+					_ = os.RemoveAll(odir)
 				}
 				return nil, err
 			}
@@ -11484,7 +12244,7 @@ func (fs *fileStore) ConsumerStore(name string, created time.Time, cfg *Consumer
 					err = fs.writeFileWithOptionalSync(o.ifn, state, defaultFilePerms)
 					if err != nil {
 						if didCreate {
-							os.RemoveAll(odir)
+							_ = os.RemoveAll(odir)
 						}
 						return nil, err
 					}
@@ -11496,7 +12256,6 @@ func (fs *fileStore) ConsumerStore(name string, created time.Time, cfg *Consumer
 	// Create channels to control our flush go routine.
 	o.fch = make(chan struct{}, 1)
 	o.qch = make(chan struct{})
-	go o.flushLoop(o.fch, o.qch)
 
 	// Make sure to load in our state from disk if needed.
 	if err = o.loadState(); err != nil {
@@ -11504,8 +12263,11 @@ func (fs *fileStore) ConsumerStore(name string, created time.Time, cfg *Consumer
 	}
 
 	// Assign to filestore.
-	fs.AddConsumer(o)
+	if err = fs.AddConsumer(o); err != nil {
+		return nil, err
+	}
 
+	go o.flushLoop(o.fch, o.qch)
 	return o, nil
 }
 
@@ -12401,7 +13163,9 @@ func (o *consumerFileStore) Stop() error {
 	ifn, fs := o.ifn, o.fs
 	o.mu.Unlock()
 
-	fs.RemoveConsumer(o)
+	if err = fs.RemoveConsumer(o); err != nil {
+		return err
+	}
 
 	if len(buf) > 0 {
 		o.waitOnFlusher()
@@ -12456,10 +13220,15 @@ func (o *consumerFileStore) delete(streamDeleted bool) error {
 		<-dios
 		err = os.RemoveAll(odir)
 		dios <- struct{}{}
+		if err != nil {
+			return err
+		}
 	}
 
 	if !streamDeleted {
-		fs.RemoveConsumer(o)
+		if err = fs.RemoveConsumer(o); err != nil {
+			return err
+		}
 	}
 
 	return err
@@ -12614,6 +13383,7 @@ func writeAtomically(name string, data []byte, perm fs.FileMode, sync bool) erro
 		return err
 	}
 	if _, err := f.Write(data); err != nil {
+		// Close fd, but ignore its error since write takes precedence.
 		_ = f.Close()
 		_ = os.Remove(tmp)
 		return err
@@ -12629,9 +13399,17 @@ func writeAtomically(name string, data []byte, perm fs.FileMode, sync bool) erro
 	if sync {
 		// To ensure that the file rename was persisted on all filesystems,
 		// also try to flush the directory metadata.
-		if d, err := os.Open(filepath.Dir(name)); err == nil {
-			_ = d.Sync()
+		var d *os.File
+		if d, err = os.Open(filepath.Dir(name)); err != nil {
+			return err
+		}
+		if err = d.Sync(); err != nil {
+			// Close fd, but ignore its error since sync takes precedence.
 			_ = d.Close()
+			return err
+		}
+		if err = d.Close(); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1926,8 +1926,9 @@ func TestFileStoreSnapshot(t *testing.T) {
 			// Should not call compact on last msg block.
 			if mb != fs.lmb {
 				mb.mu.Lock()
-				mb.compact()
+				err = mb.compact()
 				mb.mu.Unlock()
+				require_NoError(t, err)
 			}
 		}
 		fs.mu.RUnlock()
@@ -3099,7 +3100,8 @@ func TestFileStoreExpireMsgsOnStart(t *testing.T) {
 		// Check the filtered subject state and make sure that is tracked properly.
 		checkFiltered := func(subject string, ss SimpleState) {
 			t.Helper()
-			fss := fs.FilteredState(1, subject)
+			fss, err := fs.FilteredState(1, subject)
+			require_NoError(t, err)
 			if fss != ss {
 				t.Fatalf("Expected FilteredState of %+v, got %+v", ss, fss)
 			}
@@ -3293,8 +3295,9 @@ func TestFileStoreSparseCompaction(t *testing.T) {
 			fs.mu.RUnlock()
 
 			mb.mu.Lock()
-			mb.compact()
+			err = mb.compact()
 			mb.mu.Unlock()
+			require_NoError(t, err)
 
 			fs.FastState(&ssa)
 			if !reflect.DeepEqual(ssb, ssa) {
@@ -3366,8 +3369,14 @@ func TestFileStoreSparseCompactionWithInteriorDeletes(t *testing.T) {
 		// Do compact by hand, make sure we can still access msgs past the interior deletes.
 		fs.mu.RLock()
 		lmb := fs.lmb
-		lmb.dirtyCloseWithRemove(false)
-		lmb.compact()
+		if err = lmb.dirtyCloseWithRemove(false); err != nil {
+			fs.mu.RUnlock()
+			require_NoError(t, err)
+		}
+		if err = lmb.compact(); err != nil {
+			fs.mu.RUnlock()
+			require_NoError(t, err)
+		}
 		fs.mu.RUnlock()
 
 		if _, err = fs.LoadMsg(900, nil); err != nil {
@@ -3394,7 +3403,9 @@ func TestFileStorePurgeExKeepOneBug(t *testing.T) {
 		fs.StoreMsg("A", nil, []byte("META"), 0)
 		fs.StoreMsg("B", nil, fill, 0)
 
-		if fss := fs.FilteredState(1, "A"); fss.Msgs != 2 {
+		fss, err := fs.FilteredState(1, "A")
+		require_NoError(t, err)
+		if fss.Msgs != 2 {
 			t.Fatalf("Expected to find 2 `A` msgs, got %d", fss.Msgs)
 		}
 
@@ -3405,7 +3416,9 @@ func TestFileStorePurgeExKeepOneBug(t *testing.T) {
 		if n != 1 {
 			t.Fatalf("Expected PurgeEx to remove 1 `A` msgs, got %d", n)
 		}
-		if fss := fs.FilteredState(1, "A"); fss.Msgs != 1 {
+		fss, err = fs.FilteredState(1, "A")
+		require_NoError(t, err)
+		if fss.Msgs != 1 {
 			t.Fatalf("Expected to find 1 `A` msgs, got %d", fss.Msgs)
 		}
 	})
@@ -3418,15 +3431,19 @@ func TestFileStoreFilteredPendingBug(t *testing.T) {
 		require_NoError(t, err)
 		defer fs.Stop()
 
-		fs.StoreMsg("foo", nil, []byte("msg"), 0)
-		fs.StoreMsg("bar", nil, []byte("msg"), 0)
-		fs.StoreMsg("baz", nil, []byte("msg"), 0)
+		_, _, err = fs.StoreMsg("foo", nil, []byte("msg"), 0)
+		require_NoError(t, err)
+		_, _, err = fs.StoreMsg("bar", nil, []byte("msg"), 0)
+		require_NoError(t, err)
+		_, _, err = fs.StoreMsg("baz", nil, []byte("msg"), 0)
+		require_NoError(t, err)
 
 		fs.mu.Lock()
 		mb := fs.lmb
 		fs.mu.Unlock()
 
-		total, f, l := mb.filteredPending("foo", false, 3)
+		total, f, l, err := mb.filteredPending("foo", false, 3)
+		require_NoError(t, err)
 		if total != 0 {
 			t.Fatalf("Expected total of 0 but got %d", total)
 		}
@@ -3724,8 +3741,9 @@ func TestFileStoreRebuildStateDmapAccountingBug(t *testing.T) {
 		check()
 
 		mb.mu.Lock()
-		mb.compact()
+		err = mb.compact()
 		mb.mu.Unlock()
+		require_NoError(t, err)
 
 		// Now delete first.
 		_, err = fs.RemoveMsg(1)
@@ -4438,7 +4456,9 @@ func TestFileStoreFSSExpireNumPendingBug(t *testing.T) {
 		_, _, err = fs.StoreMsg("KV.X", nil, []byte("Y"), 0)
 		require_NoError(t, err)
 
-		if fss := fs.FilteredState(1, "KV.X"); fss.Msgs != 1 {
+		fss, err := fs.FilteredState(1, "KV.X")
+		require_NoError(t, err)
+		if fss.Msgs != 1 {
 			t.Fatalf("Expected only 1 msg, got %d", fss.Msgs)
 		}
 	})
@@ -4847,7 +4867,8 @@ func TestFileStoreAllFilteredStateWithDeleted(t *testing.T) {
 		}
 
 		checkFilteredState := func(start, msgs, first, last int) {
-			fss := fs.FilteredState(uint64(start), _EMPTY_)
+			fss, err := fs.FilteredState(uint64(start), _EMPTY_)
+			require_NoError(t, err)
 			if fss.Msgs != uint64(msgs) {
 				t.Fatalf("Expected %d msgs, got %d", msgs, fss.Msgs)
 			}
@@ -6048,8 +6069,9 @@ func TestFileStoreMsgBlockCompactionAndHoles(t *testing.T) {
 
 	// Do compaction, should remove all excess now.
 	mb.mu.Lock()
-	mb.compact()
+	err = mb.compact()
 	mb.mu.Unlock()
+	require_NoError(t, err)
 
 	ta, ua, _ := fs.Utilization()
 	require_Equal(t, ub, ua)
@@ -6881,8 +6903,9 @@ func TestFileStoreEraseMsgWithDbitSlots(t *testing.T) {
 	fs.mu.RUnlock()
 	// Compact.
 	mb.mu.Lock()
-	mb.compact()
+	err = mb.compact()
 	mb.mu.Unlock()
+	require_NoError(t, err)
 
 	removed, err := fs.EraseMsg(1)
 	require_NoError(t, err)
@@ -6909,8 +6932,9 @@ func TestFileStoreEraseMsgWithAllTrailingDbitSlots(t *testing.T) {
 	fs.mu.RUnlock()
 	// Compact.
 	mb.mu.Lock()
-	mb.compact()
+	err = mb.compact()
 	mb.mu.Unlock()
+	require_NoError(t, err)
 
 	removed, err := fs.EraseMsg(2)
 	require_NoError(t, err)
@@ -7220,8 +7244,9 @@ func TestFileStoreRecoverWithRemovesAndNoIndexDB(t *testing.T) {
 	lmb := fs.lmb
 	fs.mu.RUnlock()
 	lmb.mu.Lock()
-	lmb.compact()
+	err = lmb.compact()
 	lmb.mu.Unlock()
+	require_NoError(t, err)
 	// Stop but remove index.db
 	sfile := filepath.Join(sd, msgDir, streamStreamStateFile)
 	fs.Stop()
@@ -7389,8 +7414,9 @@ func TestFileStoreFilteredPendingPSIMFirstBlockUpdate(t *testing.T) {
 	// No make sure that a call to numFilterPending which will initially walk all blocks if starting from seq 1 updates psi.
 	var ss SimpleState
 	fs.mu.RLock()
-	fs.numFilteredPending("foo.baz", &ss)
+	err = fs.numFilteredPending("foo.baz", &ss)
 	fs.mu.RUnlock()
+	require_NoError(t, err)
 	require_Equal(t, ss.Msgs, 2)
 	require_Equal(t, ss.First, 1002)
 	require_Equal(t, ss.Last, 1003)
@@ -7465,8 +7491,9 @@ func TestFileStoreWildcardFilteredPendingPSIMFirstBlockUpdate(t *testing.T) {
 	// No make sure that a call to numFilterPending which will initially walk all blocks if starting from seq 1 updates psi.
 	var ss SimpleState
 	fs.mu.RLock()
-	fs.numFilteredPending("foo.22.*", &ss)
+	err = fs.numFilteredPending("foo.22.*", &ss)
 	fs.mu.RUnlock()
+	require_NoError(t, err)
 	require_Equal(t, ss.Msgs, 4)
 	require_Equal(t, ss.First, 1003)
 	require_Equal(t, ss.Last, 1006)
@@ -7544,8 +7571,9 @@ func TestFileStoreFilteredPendingPSIMFirstBlockUpdateNextBlock(t *testing.T) {
 	// Call into numFilterePending(), we want to make sure it updates fblk.
 	var ss SimpleState
 	fs.mu.Lock()
-	fs.numFilteredPending("foo.22.bar", &ss)
+	err = fs.numFilteredPending("foo.22.bar", &ss)
 	fs.mu.Unlock()
+	require_NoError(t, err)
 	require_Equal(t, ss.Msgs, 3)
 	require_Equal(t, ss.First, 3)
 	require_Equal(t, ss.Last, 7)
@@ -7576,8 +7604,9 @@ func TestFileStoreFilteredPendingPSIMFirstBlockUpdateNextBlock(t *testing.T) {
 
 	// Now call wildcard version of numFilteredPending to make sure it clears.
 	fs.mu.Lock()
-	fs.numFilteredPending("foo.*.baz", &ss)
+	err = fs.numFilteredPending("foo.*.baz", &ss)
 	fs.mu.Unlock()
+	require_NoError(t, err)
 	require_Equal(t, ss.Msgs, 3)
 	require_Equal(t, ss.First, 4)
 	require_Equal(t, ss.Last, 8)
@@ -7915,7 +7944,10 @@ func TestFileStoreDmapBlockRecoverAfterCompact(t *testing.T) {
 	// Compact and rebuild the first blk. Do not have it call indexCacheBuf which will fix it up.
 	mb := fs.getFirstBlock()
 	mb.mu.Lock()
-	mb.compact()
+	if err = mb.compact(); err != nil {
+		mb.mu.Unlock()
+		require_NoError(t, err)
+	}
 	// Empty out dmap state.
 	mb.dmap.Empty()
 	ld, tombs, err := mb.rebuildStateLocked()
@@ -8047,9 +8079,10 @@ func TestFileStoreRestoreDeleteTombstonesExceedingMaxBlkSize(t *testing.T) {
 			mb.ensureRawBytesLoaded()
 			bytes, rbytes, shouldCompact := mb.bytes, mb.rbytes, mb.shouldCompactSync()
 			// Do the compact and make sure nothing changed.
-			mb.compact()
+			err = mb.compact()
 			nbytes, nrbytes := mb.bytes, mb.rbytes
 			mb.mu.Unlock()
+			require_NoError(t, err)
 			require_True(t, shouldCompact)
 			require_Equal(t, bytes, nbytes)
 			require_Equal(t, rbytes, nrbytes)
@@ -9110,7 +9143,7 @@ func TestFileStoreDontSpamCompactWhenMostlyTombstones(t *testing.T) {
 	require_True(t, fmb.shouldCompactInline())
 
 	// Compact will be successful, but since it doesn't clean up tombstones it will be ineffective.
-	fmb.compact()
+	require_NoError(t, fmb.compact())
 
 	// We should not allow compacting again as we're not removing tombstones inline.
 	// Otherwise, we would spam compaction.
@@ -11483,7 +11516,7 @@ func TestFileStoreMissingDeletesAfterCompact(t *testing.T) {
 		require_True(t, fmb.dmap.Exists(6))
 
 		// Now compact and reload and the block should still have the correct deletes.
-		fmb.compact()
+		require_NoError(t, fmb.compact())
 		fmb.clearCache()
 		fmb.dmap.Empty()
 		require_NoError(t, fmb.loadMsgsWithLock())
@@ -11506,7 +11539,7 @@ func TestFileStoreMissingDeletesAfterCompact(t *testing.T) {
 		_, err = fs.RemoveMsg(5)
 		fmb.mu.Lock()
 		require_NoError(t, err)
-		fmb.compact()
+		require_NoError(t, fmb.compact())
 		fmb.clearCache()
 		fmb.dmap.Empty()
 		require_NoError(t, fmb.loadMsgsWithLock())
@@ -13358,8 +13391,9 @@ func TestFileStoreCorruptionSetsHbitWithoutHeaders(t *testing.T) {
 				mb.mu.Unlock()
 				require_Error(t, err, errCorruptState)
 			case KindRebuildState:
-				require_NoError(t, mb.flushPendingMsgs())
-				_, _, err = mb.rebuildState()
+				mb.mu.Lock()
+				_, _, err = mb.rebuildStateFromBufLocked(cache.buf, false)
+				mb.mu.Unlock()
 				require_True(t, err != nil)
 				require_True(t, strings.Contains(err.Error(), "sanity check failed"))
 			default:
@@ -13370,4 +13404,78 @@ func TestFileStoreCorruptionSetsHbitWithoutHeaders(t *testing.T) {
 	t.Run("msgFromBuf", func(t *testing.T) { test(t, KindMsgFromBuf) })
 	t.Run("indexCacheBuf", func(t *testing.T) { test(t, KindIndexCacheBuf) })
 	t.Run("rebuildState", func(t *testing.T) { test(t, KindRebuildState) })
+}
+
+func TestFileStoreSyncBlocksNoErrorOnConcurrentRemovedBlock(t *testing.T) {
+	fcfg := FileStoreConfig{Cipher: NoCipher, Compression: NoCompression, StoreDir: t.TempDir()}
+	fs, err := newFileStoreWithCreated(fcfg, StreamConfig{Name: "zzz", Storage: FileStorage}, time.Now(), prf(&fcfg), nil)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	fs.mu.Lock()
+	if fs.syncTmr != nil {
+		fs.syncTmr.Stop()
+		fs.syncTmr = nil
+	}
+	fs.mu.Unlock()
+
+	// 1.blk
+	for range 2 {
+		_, _, err = fs.StoreMsg("foo", nil, nil, 0)
+		require_NoError(t, err)
+	}
+
+	// 2.blk
+	_, err = fs.newMsgBlockForWrite()
+	require_NoError(t, err)
+	_, _, err = fs.StoreMsg("foo", nil, nil, 0)
+	require_NoError(t, err)
+	_, err = fs.RemoveMsg(2)
+	require_NoError(t, err)
+
+	// 3.blk
+	_, err = fs.newMsgBlockForWrite()
+	require_NoError(t, err)
+	_, _, err = fs.StoreMsg("foo", nil, nil, 0)
+	require_NoError(t, err)
+	_, err = fs.RemoveMsg(3)
+	require_NoError(t, err)
+
+	fs.mu.RLock()
+	mb := fs.blks[1]
+	fs.mu.RUnlock()
+	require_Equal(t, mb.index, 2)
+	mb.mu.RLock()
+	shouldCompactSync := mb.shouldCompactSync()
+	mb.mu.RUnlock()
+	require_True(t, shouldCompactSync)
+
+	var ready sync.WaitGroup
+	var wg sync.WaitGroup
+	ready.Add(1)
+	wg.Add(1)
+	mb.mu.Lock()
+	go func() {
+		ready.Done()
+		defer wg.Done()
+		// Wait some time for fs.syncBlocks to wait on the mb's lock.
+		time.Sleep(200 * time.Millisecond)
+		// Remove the block while fs.syncBlocks is still waiting.
+		fs.mu.Lock()
+		err = fs.forceRemoveMsgBlock(mb)
+		fs.mu.Unlock()
+		mb.mu.Unlock()
+		require_NoError(t, err)
+	}()
+
+	ready.Wait()
+	fs.syncBlocks()
+	wg.Wait()
+
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	mb.mu.RLock()
+	defer mb.mu.RUnlock()
+	require_True(t, mb.werr == nil)
+	require_True(t, fs.werr == nil)
 }

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -147,12 +147,14 @@ func newBatchStore(mset *stream, batchId string) (StreamStore, error) {
 // If the timer has already cleaned up the batch, we can't commit.
 // Otherwise, we ensure the timer does not clean up the batch in the meantime.
 // Lock should be held.
-func (b *atomicBatch) readyForCommit() bool {
+func (b *atomicBatch) readyForCommit() *BatchAbandonReason {
 	if !b.timer.Stop() {
-		return false
+		return &BatchTimeout
 	}
-	b.store.FlushAllPending()
-	return true
+	if b.store.FlushAllPending() != nil {
+		return &BatchIncomplete
+	}
+	return nil
 }
 
 // newFastBatch creates a fast batch publish object.

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -1625,9 +1625,9 @@ func TestJetStreamAtomicBatchPublishSingleServerRecovery(t *testing.T) {
 		batches.mu.Unlock()
 		require_NoError(t, err)
 	}
-	commitReady := b.readyForCommit()
+	abandonReason := b.readyForCommit()
 	batches.mu.Unlock()
-	require_True(t, commitReady)
+	require_True(t, abandonReason == nil)
 
 	// Simulate the first message of the batch is committed.
 	err = mset.processJetStreamMsg("foo", _EMPTY_, hdr1, nil, 0, 0, nil, false, true)
@@ -1715,9 +1715,9 @@ func TestJetStreamAtomicBatchPublishSingleServerRecoveryCommitEob(t *testing.T) 
 		batches.mu.Unlock()
 		require_NoError(t, err)
 	}
-	commitReady := b.readyForCommit()
+	abandonReason := b.readyForCommit()
 	batches.mu.Unlock()
-	require_True(t, commitReady)
+	require_True(t, abandonReason == nil)
 
 	// Simulate the first message of the batch is committed.
 	err = mset.processJetStreamMsg("foo", _EMPTY_, hdr1, nil, 0, 0, nil, false, true)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -649,6 +649,11 @@ func (js *jetStream) isStreamHealthy(acc *Account, sa *streamAssignment) error {
 	mset.cfgMu.RLock()
 	replicas := mset.cfg.Replicas
 	mset.cfgMu.RUnlock()
+	var nrgWerr error
+	if node != nil {
+		nrgWerr = node.GetWriteErr()
+	}
+	streamWerr := mset.getWriteErr()
 	switch {
 	case replicas <= 1:
 		return nil // No further checks for R=1 streams
@@ -663,6 +668,12 @@ func (js *jetStream) isStreamHealthy(acc *Account, sa *streamAssignment) error {
 	case node != msetNode:
 		s.Warnf("Detected stream cluster node skew '%s > %s'", acc.GetName(), streamName)
 		return errors.New("cluster node skew detected")
+
+	case nrgWerr != nil:
+		return fmt.Errorf("node write error: %v", nrgWerr)
+
+	case streamWerr != nil:
+		return fmt.Errorf("stream write error: %v", streamWerr)
 
 	case !mset.isMonitorRunning():
 		return errors.New("monitor goroutine not running")
@@ -2986,7 +2997,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 
 		// Before we actually calculate the detailed state and encode it, let's check the
 		// simple state to detect any changes.
-		curState := mset.store.FilteredState(0, _EMPTY_)
+		curState, _ := mset.store.FilteredState(0, _EMPTY_)
 
 		// If the state hasn't changed but the log has gone way over
 		// the compaction size then we will want to compact anyway.
@@ -2998,7 +3009,19 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 		}
 
 		// Make sure all pending data is flushed before allowing snapshots.
-		mset.flushAllPending()
+		if err := mset.flushAllPending(); err != nil {
+			// If the pending data couldn't be flushed, we have no safe way to continue.
+			s.Errorf("Failed to flush pending data for '%s > %s' [%s]: %v", accName, mset.name(), n.Group(), err)
+			assert.Unreachable("Stream snapshot flush failed", map[string]any{
+				"account": accName,
+				"stream":  mset.name(),
+				"group":   n.Group(),
+				"err":     err,
+			})
+			mset.setWriteErr(err)
+			n.Stop()
+			return
+		}
 
 		// If we had a significant number of failed snapshots, start relaxing Raft-layer checks
 		// to force it through. We might have been catching up a peer for a long period, and this
@@ -3171,7 +3194,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 						aq.recycle(&ces)
 						return
 					}
-					s.Warnf("Error applying entries to '%s > %s': %v", accName, sa.Config.Name, err)
+					s.Errorf("Error applying entries to '%s > %s': %v", accName, sa.Config.Name, err)
 					if isClusterResetErr(err) {
 						if mset.isMirror() && mset.IsLeader() {
 							mset.retryMirrorConsumer()
@@ -3193,6 +3216,11 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 					} else if isOutOfSpaceErr(err) {
 						// If applicable this will tear all of this down, but don't assume so and return.
 						s.handleOutOfSpace(mset)
+					} else {
+						// Encountered an unexpected error, can't continue.
+						mset.setWriteErr(err)
+						aq.recycle(&ces)
+						return
 					}
 				}
 			}
@@ -3988,7 +4016,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 			}
 
 			if isRecovering || !mset.IsLeader() {
-				if err := mset.processSnapshot(ss, ce.Index); err != nil {
+				if err := mset.processSnapshot(ss, ce.Index); err != nil && err != errAlreadyLeader {
 					return 0, err
 				}
 			}
@@ -4138,7 +4166,10 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 	// Messages to be skipped have no subject or timestamp or msg or hdr.
 	if subject == _EMPTY_ && ts == 0 && len(msg) == 0 && len(hdr) == 0 {
 		// Skip and update our lseq.
-		last, _ := mset.store.SkipMsg(0)
+		last, err := mset.store.SkipMsg(0)
+		if err != nil {
+			return err
+		}
 		if needLock {
 			mset.mu.Lock()
 		}
@@ -4223,9 +4254,11 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 			// should be reset. This is possible if the other side has a stale snapshot and no longer
 			// has those messages. So compact and retry to reset.
 			if state.Msgs == 0 {
-				mset.store.Compact(lseq + 1)
-				// Retry
-				err = mset.processJetStreamMsg(subject, reply, hdr, msg, lseq, ts, mt, sourced, needLock)
+				_, err = mset.store.Compact(lseq + 1)
+				if err == nil {
+					// Retry
+					err = mset.processJetStreamMsg(subject, reply, hdr, msg, lseq, ts, mt, sourced, needLock)
+				}
 			}
 			// FIXME(dlc) - We could just run a catchup with a request defining the span between what we expected
 			// and what we got.
@@ -4237,6 +4270,11 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 		}
 		s.Debugf("Apply stream entries for '%s > %s' got error processing message: %v",
 			mset.accountLocked(needLock), mset.nameLocked(needLock), err)
+
+		// There are some errors that we can't recover from.
+		if err != ErrMaxMsgs && err != ErrMaxBytes && err != ErrMaxMsgsPerSubject && err != ErrMsgTooLarge && err != ErrStoreClosed {
+			return err
+		}
 	}
 	return nil
 }
@@ -9711,14 +9749,17 @@ func (mset *stream) calculateSyncRequest(state *StreamState, snap *StreamReplica
 
 // processSnapshotDeletes will update our current store based on the snapshot
 // but only processing deletes and new FirstSeq / purges.
-func (mset *stream) processSnapshotDeletes(snap *StreamReplicatedState) {
+func (mset *stream) processSnapshotDeletes(snap *StreamReplicatedState) error {
 	mset.mu.Lock()
 	var state StreamState
 	mset.store.FastState(&state)
 	// Always adjust if FirstSeq has moved beyond our state.
 	var didReset bool
 	if snap.FirstSeq > state.FirstSeq {
-		mset.store.Compact(snap.FirstSeq)
+		if _, err := mset.store.Compact(snap.FirstSeq); err != nil {
+			mset.mu.Unlock()
+			return err
+		}
 		mset.store.FastState(&state)
 		mset.lseq = state.LastSeq
 		mset.clearAllPreAcksBelowFloor(state.FirstSeq)
@@ -9733,8 +9774,9 @@ func (mset *stream) processSnapshotDeletes(snap *StreamReplicatedState) {
 	}
 
 	if len(snap.Deleted) > 0 {
-		mset.store.SyncDeleted(snap.Deleted)
+		return mset.store.SyncDeleted(snap.Deleted)
 	}
+	return nil
 }
 
 func (mset *stream) setCatchupPeer(peer string, lag uint64) {
@@ -9844,7 +9886,9 @@ var (
 // Process a stream snapshot.
 func (mset *stream) processSnapshot(snap *StreamReplicatedState, index uint64) (e error) {
 	// Update any deletes, etc.
-	mset.processSnapshotDeletes(snap)
+	if err := mset.processSnapshotDeletes(snap); err != nil {
+		return err
+	}
 	mset.setCLFS(snap.Failed)
 
 	mset.mu.Lock()
@@ -10059,9 +10103,13 @@ RETRY:
 					if lseq >= snap.LastSeq {
 						// We MUST ensure all data is flushed up to this point, if the store hadn't already.
 						// Because the snapshot needs to represent what has been persisted.
-						mset.flushAllPending()
-						s.Noticef("Catchup for stream '%s > %s' complete (took %v)", mset.account(), mset.name(), time.Since(start).Round(time.Millisecond))
-						return nil
+						err = mset.flushAllPending()
+						if err == nil {
+							s.Noticef("Catchup for stream '%s > %s' complete (took %v)", mset.account(), mset.name(), time.Since(start).Round(time.Millisecond))
+						} else {
+							s.Noticef("Catchup for stream '%s > %s' errored: %v (took %v)", mset.account(), mset.name(), err, time.Since(start).Round(time.Millisecond))
+						}
+						return err
 					}
 
 					// Make sure we do not spin and make things worse.
@@ -10233,8 +10281,8 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 }
 
 // flushAllPending will flush any pending writes as a result of installing a snapshot or performing catchup.
-func (mset *stream) flushAllPending() {
-	mset.store.FlushAllPending()
+func (mset *stream) flushAllPending() error {
+	return mset.store.FlushAllPending()
 }
 
 func (mset *stream) handleClusterSyncRequest(sub *subscription, c *client, _ *Account, subject, reply string, msg []byte) {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -19399,7 +19399,7 @@ func TestJetStreamRecoversStreamFirstSeqWhenNotEmpty(t *testing.T) {
 		require_NoError(t, os.Truncate(filepath.Join(path, f.Name()), st.Size()-1))
 	}
 
-	s.restartJetStream()
+	require_NoError(t, s.restartJetStream())
 
 	si, err = js.StreamInfo("TEST")
 	require_NoError(t, err)

--- a/server/log.go
+++ b/server/log.go
@@ -227,6 +227,14 @@ func (s *Server) rateLimitFormatWarnf(format string, v ...any) {
 	s.Warnf("%s", statement)
 }
 
+func (s *Server) RateLimitErrorf(format string, v ...any) {
+	statement := fmt.Sprintf(format, v...)
+	if _, loaded := s.rateLimitLogging.LoadOrStore(statement, time.Now()); loaded {
+		return
+	}
+	s.Errorf("%s", statement)
+}
+
 func (s *Server) RateLimitWarnf(format string, v ...any) {
 	statement := fmt.Sprintf(format, v...)
 	if _, loaded := s.rateLimitLogging.LoadOrStore(statement, time.Now()); loaded {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -421,8 +421,9 @@ func (ms *memStore) SkipMsgs(seq uint64, num uint64) error {
 }
 
 // FlushAllPending flushes all data that was still pending to be written.
-func (ms *memStore) FlushAllPending() {
+func (ms *memStore) FlushAllPending() error {
 	// Noop, in-memory store doesn't use async applying.
+	return nil
 }
 
 // RegisterStorageUpdates registers a callback for updates to storage changes.
@@ -528,13 +529,13 @@ loop:
 }
 
 // FilteredState will return the SimpleState associated with the filtered subject and a proposed starting sequence.
-func (ms *memStore) FilteredState(sseq uint64, subj string) SimpleState {
+func (ms *memStore) FilteredState(sseq uint64, subj string) (SimpleState, error) {
 	// This needs to be a write lock, as filteredStateLocked can
 	// mutate the per-subject state.
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 
-	return ms.filteredStateLocked(sseq, subj, false)
+	return ms.filteredStateLocked(sseq, subj, false), nil
 }
 
 func (ms *memStore) filteredStateLocked(sseq uint64, filter string, lastPerSubject bool) SimpleState {
@@ -1442,7 +1443,7 @@ func (ms *memStore) PurgeEx(subject string, sequence, keep uint64) (purged uint6
 
 	}
 	eq := compareFn(subject)
-	if ss := ms.FilteredState(1, subject); ss.Msgs > 0 {
+	if ss, _ := ms.FilteredState(1, subject); ss.Msgs > 0 {
 		if keep > 0 {
 			if keep >= ss.Msgs {
 				return 0, nil
@@ -2346,10 +2347,7 @@ func (ms *memStore) EncodedStreamState(failed uint64) ([]byte, error) {
 	b := buf[0:n]
 
 	if numDeleted > 0 {
-		buf, err := ms.dmap.Encode(nil)
-		if err != nil {
-			return nil, err
-		}
+		buf := ms.dmap.Encode(nil)
 		b = append(b, buf...)
 	}
 
@@ -2357,7 +2355,11 @@ func (ms *memStore) EncodedStreamState(failed uint64) ([]byte, error) {
 }
 
 // SyncDeleted will make sure this stream has same deleted state as dbs.
-func (ms *memStore) SyncDeleted(dbs DeleteBlocks) {
+func (ms *memStore) SyncDeleted(dbs DeleteBlocks) error {
+	if len(dbs) == 0 {
+		return nil
+	}
+
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 
@@ -2366,7 +2368,7 @@ func (ms *memStore) SyncDeleted(dbs DeleteBlocks) {
 	if len(dbs) == 1 {
 		min, max, num := ms.dmap.State()
 		if pmin, pmax, pnum := dbs[0].State(); pmin == min && pmax == max && pnum == num {
-			return
+			return nil
 		}
 	}
 	lseq := ms.state.LastSeq
@@ -2380,6 +2382,7 @@ func (ms *memStore) SyncDeleted(dbs DeleteBlocks) {
 			return true
 		})
 	}
+	return nil
 }
 
 func (o *consumerMemStore) Update(state *ConsumerState) error {

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -694,7 +694,8 @@ func TestMemStoreNumPending(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NumPending error: %v", err)
 		}
-		ss := ms.FilteredState(sseq, filter)
+		ss, err := ms.FilteredState(sseq, filter)
+		require_NoError(t, err)
 		sss := sanityCheck(sseq, filter)
 		if lvs != state.LastSeq {
 			t.Fatalf("Expected NumPending to return valid through last of %d but got %d", state.LastSeq, lvs)

--- a/server/norace_1_test.go
+++ b/server/norace_1_test.go
@@ -6393,7 +6393,8 @@ func TestNoRaceFileStoreFilteredStateWithLargeDeletes(t *testing.T) {
 	defer debug.SetGCPercent(gcp)
 
 	start := time.Now()
-	fss := fs.FilteredState(1, _EMPTY_)
+	fss, err := fs.FilteredState(1, _EMPTY_)
+	require_NoError(t, err)
 	elapsed := time.Since(start)
 
 	require_True(t, fss.Msgs == uint64(toStore/2))
@@ -7614,7 +7615,8 @@ func TestNoRaceFileStoreNumPending(t *testing.T) {
 		t.Helper()
 		np, lvs, err := fs.NumPending(sseq, filter, false)
 		require_NoError(t, err)
-		ss := fs.FilteredState(sseq, filter)
+		ss, err := fs.FilteredState(sseq, filter)
+		require_NoError(t, err)
 		sss := sanityCheck(sseq, filter)
 		if lvs != state.LastSeq {
 			t.Fatalf("Expected NumPending to return valid through last of %d but got %d", state.LastSeq, lvs)

--- a/server/raft.go
+++ b/server/raft.go
@@ -89,6 +89,7 @@ type RaftNode interface {
 	RecreateInternalSubs() error
 	IsSystemAccount() bool
 	GetTrafficAccountName() string
+	GetWriteErr() error
 }
 
 // RaftNodeCheckpoint is used as an alternative to a direct InstallSnapshot.
@@ -4699,11 +4700,18 @@ func (n *raft) setWriteErrLocked(err error) {
 	}
 	// If this is a not found report but do not disable.
 	if os.IsNotExist(err) {
-		n.error("Resource not found: %v", err)
+		n.warn("Resource not found: %v", err)
 		return
 	}
 	n.error("Critical write error: %v", err)
 	n.werr = err
+	n.shutdown()
+	assert.Unreachable("Raft encountered write error", map[string]any{
+		"n.accName": n.accName,
+		"n.group":   n.group,
+		"n.id":      n.id,
+		"err":       err,
+	})
 
 	if isPermissionError(err) {
 		go n.s.handleWritePermissionError()
@@ -4718,6 +4726,13 @@ func (n *raft) setWriteErrLocked(err error) {
 // Helper to check if we are closed when we do not hold a lock already.
 func (n *raft) isClosed() bool {
 	return n.State() == Closed
+}
+
+// GetWriteErr returns the write error (if any).
+func (n *raft) GetWriteErr() error {
+	n.RLock()
+	defer n.RUnlock()
+	return n.werr
 }
 
 // Capture our write error if any and hold.

--- a/server/store.go
+++ b/server/store.go
@@ -93,7 +93,7 @@ type StreamStore interface {
 	StoreRawMsg(subject string, hdr, msg []byte, seq uint64, ts int64, ttl int64, discardNewCheck bool) error
 	SkipMsg(seq uint64) (uint64, error)
 	SkipMsgs(seq uint64, num uint64) error
-	FlushAllPending()
+	FlushAllPending() error
 	LoadMsg(seq uint64, sm *StoreMsg) (*StoreMsg, error)
 	LoadNextMsg(filter string, wc bool, start uint64, smp *StoreMsg) (sm *StoreMsg, skip uint64, err error)
 	LoadNextMsgMulti(sl *gsl.SimpleSublist, start uint64, smp *StoreMsg) (sm *StoreMsg, skip uint64, err error)
@@ -107,7 +107,7 @@ type StreamStore interface {
 	Compact(seq uint64) (uint64, error)
 	Truncate(seq uint64) error
 	GetSeqFromTime(t time.Time) uint64
-	FilteredState(seq uint64, subject string) SimpleState
+	FilteredState(seq uint64, subject string) (SimpleState, error)
 	SubjectsState(filterSubject string) map[string]SimpleState
 	SubjectsTotals(filterSubject string) map[string]uint64
 	AllLastSeqs() ([]uint64, error)
@@ -118,7 +118,7 @@ type StreamStore interface {
 	State() StreamState
 	FastState(*StreamState)
 	EncodedStreamState(failed uint64) (enc []byte, err error)
-	SyncDeleted(dbs DeleteBlocks)
+	SyncDeleted(dbs DeleteBlocks) error
 	Type() StorageType
 	RegisterStorageUpdates(StorageUpdateHandler)
 	RegisterStorageRemoveMsg(StorageRemoveMsgHandler)

--- a/server/stream.go
+++ b/server/stream.go
@@ -33,6 +33,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/nats-server/v2/server/gsl"
 	"github.com/nats-io/nuid"
@@ -542,6 +543,7 @@ type stream struct {
 	lqsent    time.Time         // The time at which the last lost quorum advisory was sent. Used to rate limit.
 	uch       chan struct{}     // The channel to signal updates to the monitor routine.
 	inMonitor bool              // True if the monitor routine has been started.
+	werr      error             // If a write error was encountered, and if so what error.
 
 	inflight                    map[string]*inflightSubjectRunningTotal // Inflight message sizes per subject.
 	clusteredCounterTotal       map[string]*msgCounterRunningTotal      // Inflight counter totals.
@@ -2685,7 +2687,10 @@ func (mset *stream) purgeLocked(preq *JSApiStreamPurgeRequest, needLock bool) (p
 	// Purge consumers.
 	// Check for filtered purge.
 	if preq != nil && preq.Subject != _EMPTY_ {
-		ss := store.FilteredState(fseq, preq.Subject)
+		ss, err := store.FilteredState(fseq, preq.Subject)
+		if err != nil {
+			return purged, err
+		}
 		fseq = ss.First
 	}
 
@@ -5777,7 +5782,9 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 				var state StreamState
 				mset.store.FastState(&state)
 				if state.FirstSeq == 0 {
-					mset.store.Compact(lseq + 1)
+					if _, err := mset.store.Compact(lseq + 1); err != nil {
+						return err
+					}
 					mset.lseq = lseq
 					isMisMatch = false
 				}
@@ -6404,17 +6411,22 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 			mset.srv.Warnf("Filesystem permission denied while writing msg, disabling JetStream: %v", err)
 			return err
 		}
-		// If we did not succeed increment clfs in case we are clustered.
-		bumpCLFS()
 
 		switch err {
 		case ErrMaxMsgs, ErrMaxBytes, ErrMaxMsgsPerSubject, ErrMsgTooLarge:
 			s.RateLimitDebugf("JetStream failed to store a msg on stream '%s > %s': %v", accName, name, err)
 		case ErrStoreClosed:
 		default:
-			s.Errorf("JetStream failed to store a msg on stream '%s > %s': %v", accName, name, err)
+			// We don't want to respond back to the user, and definitely not up CLFS either.
+			// This was likely an IO issue, so only log and return the error. This will stop
+			// the stream if it was replicated.
+			s.RateLimitErrorf("JetStream failed to store a msg on stream '%s > %s': %v", accName, name, err)
+			mset.setWriteErrLocked(err)
+			return err
 		}
 
+		// If we did not succeed increment clfs in case we are clustered.
+		bumpCLFS()
 		if canRespond {
 			resp.PubAck = &PubAck{Stream: name}
 			resp.Error = NewJSStreamStoreFailedError(err, Unless(err))
@@ -6447,14 +6459,20 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 
 	// No errors, this is the normal path.
 	if rollupSub {
-		mset.purgeLocked(&JSApiStreamPurgeRequest{Subject: subject, Keep: 1}, false)
+		if _, err = mset.purgeLocked(&JSApiStreamPurgeRequest{Subject: subject, Keep: 1}, false); err != nil {
+			return err
+		}
 	} else if rollupAll {
-		mset.purgeLocked(&JSApiStreamPurgeRequest{Keep: 1}, false)
+		if _, err = mset.purgeLocked(&JSApiStreamPurgeRequest{Keep: 1}, false); err != nil {
+			return err
+		}
 	} else if scheduleNext := sliceHeader(JSScheduleNext, hdr); len(scheduleNext) > 0 && bytesToString(scheduleNext) == JSScheduleNextPurge {
 		// Purge the message schedule.
 		scheduler := getMessageScheduler(hdr)
 		if scheduler != _EMPTY_ {
-			mset.purgeLocked(&JSApiStreamPurgeRequest{Subject: scheduler}, false)
+			if _, err = mset.purgeLocked(&JSApiStreamPurgeRequest{Subject: scheduler}, false); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -6747,10 +6765,10 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 	}
 
 	// Ensure the batch is prepared for the commit and will not be cleaned up while committing.
-	if !b.readyForCommit() {
+	if abandonReason := b.readyForCommit(); abandonReason != nil {
 		// Don't do cleanup, this is already done.
 		batches.mu.Unlock()
-		mset.sendStreamBatchAbandonedAdvisory(batchId, BatchTimeout)
+		mset.sendStreamBatchAbandonedAdvisory(batchId, *abandonReason)
 		return respondIncompleteBatch()
 	}
 
@@ -8539,6 +8557,43 @@ func (mset *stream) isMonitorRunning() bool {
 	mset.mu.RLock()
 	defer mset.mu.RUnlock()
 	return mset.inMonitor
+}
+
+// setWriteErr stores the write error in the stream.
+func (mset *stream) setWriteErr(err error) {
+	mset.mu.Lock()
+	defer mset.mu.Unlock()
+	mset.setWriteErrLocked(err)
+}
+
+func (mset *stream) setWriteErrLocked(err error) {
+	if mset.werr != nil {
+		return
+	}
+	// Ignore non-write errors.
+	if err == ErrStoreClosed {
+		return
+	}
+	mset.srv.Errorf("JetStream stream '%s > %s' critical write error: %v", mset.acc.Name, mset.cfg.Name, err)
+	mset.werr = err
+	assert.Unreachable("Stream encountered write error", map[string]any{
+		"account": mset.acc.Name,
+		"stream":  mset.cfg.Name,
+		"err":     err,
+	})
+
+	// If stream is replicated, put it in observer mode to make sure another server can pick it up.
+	if node := mset.node; node != nil {
+		node.StepDown()
+		node.SetObserver(true)
+	}
+}
+
+// getWriteErr returns the write error stored in the stream (if any).
+func (mset *stream) getWriteErr() error {
+	mset.mu.RLock()
+	defer mset.mu.RUnlock()
+	return mset.werr
 }
 
 // Adjust accounting for sent messages as part of replication.


### PR DESCRIPTION
This PR adds error handling to the filestore such that any IO errors will be properly reported. These write errors bubble up into the stream layer such that:
- No IO issue goes unnoticed.
- These errors are stored in the stream and are reported in healthz.
- Replicated streams make the leader step down and enter observer mode. Ensuring if the leader has an IO error, it immediately allows a new server to become the new leader.
- Once an error occurs, the stream/filestore will stop accepting new writes/changes. The server can still serve core traffic (as well as streams that didn't error), but the server will need to be restarted to allow this stream to be used again.

Resolves https://github.com/nats-io/nats-server/issues/7629

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>