### PR TITLE
[FIXED] Data race on deduplication seq

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -5792,7 +5792,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 				mset.ddMu.Unlock()
 				if seq > 0 {
 					if canRespond {
-						response := append(pubAck, strconv.FormatUint(dde.seq, 10)...)
+						response := append(pubAck, strconv.FormatUint(seq, 10)...)
 						response = append(response, ",\"duplicate\": true}"...)
 						outq.sendMsg(reply, response)
 					}


### PR DESCRIPTION
We already capture the `dde.seq` under the lock and store it under `seq`, should reuse that for the response. Using `dde.seq` could race with `mset.purgeMsgIds()` running.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>