### PR TITLE
[FIXED] Inflight meta change tracking

### DIFF
--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -2058,16 +2058,6 @@ func TestJetStreamClusterMaxConsumersMultipleConcurrentRequests(t *testing.T) {
 	if nc := len(names); nc > 1 {
 		t.Fatalf("Expected only 1 consumer, got %d", nc)
 	}
-
-	metaLeader := c.leader()
-	mjs := metaLeader.getJetStream()
-	mjs.mu.RLock()
-	sa := mjs.streamAssignment(globalAccountName, "MAXCC")
-	require_NotNil(t, sa)
-	for _, ca := range sa.consumers {
-		require_False(t, ca.pending)
-	}
-	mjs.mu.RUnlock()
 }
 
 func TestJetStreamClusterAccountMaxStreamsAndConsumersMultipleConcurrentRequests(t *testing.T) {

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -4136,59 +4136,6 @@ func TestJetStreamClusterKeepRaftStateIfStreamCreationFailedDuringShutdown(t *te
 	require_True(t, len(files) > 0)
 }
 
-func TestJetStreamClusterMetaSnapshotMustNotIncludePendingConsumers(t *testing.T) {
-	c := createJetStreamClusterExplicit(t, "R3S", 3)
-	defer c.shutdown()
-
-	nc, js := jsClientConnect(t, c.randomServer())
-	defer nc.Close()
-
-	_, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Replicas: 3})
-	require_NoError(t, err)
-
-	// We're creating an R3 consumer, just so we can copy its state and turn it into pending below.
-	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Name: "consumer", Replicas: 3})
-	require_NoError(t, err)
-	nc.Close()
-
-	// Bypass normal API so we can simulate having a consumer pending to be created.
-	// A snapshot should never create pending consumers, as that would result
-	// in ghost consumers if the meta proposal failed.
-	ml := c.leader()
-	mjs := ml.getJetStream()
-	mjs.mu.Lock()
-	cc := mjs.cluster
-	consumers := cc.streams[globalAccountName]["TEST"].consumers
-	sampleCa := *consumers["consumer"]
-	sampleCa.Name, sampleCa.pending = "pending-consumer", true
-	consumers[sampleCa.Name] = &sampleCa
-	mjs.mu.Unlock()
-
-	// Create snapshot, this should not contain pending consumers.
-	snap, err := mjs.metaSnapshot()
-	require_NoError(t, err)
-
-	ru := &recoveryUpdates{
-		removeStreams:   make(map[string]*streamAssignment),
-		removeConsumers: make(map[string]map[string]*consumerAssignment),
-		addStreams:      make(map[string]*streamAssignment),
-		updateStreams:   make(map[string]*streamAssignment),
-		updateConsumers: make(map[string]map[string]*consumerAssignment),
-	}
-	require_NoError(t, mjs.applyMetaSnapshot(snap, ru, true))
-	require_Len(t, len(ru.updateStreams), 1)
-	for _, sa := range ru.updateStreams {
-		for _, ca := range sa.consumers {
-			require_NotEqual(t, ca.Name, "pending-consumer")
-		}
-	}
-	for _, cas := range ru.updateConsumers {
-		for _, ca := range cas {
-			require_NotEqual(t, ca.Name, "pending-consumer")
-		}
-	}
-}
-
 func TestJetStreamClusterMetaSnapshotReCreateConsistency(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/stream.go
+++ b/server/stream.go
@@ -717,7 +717,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 	}
 	js.mu.RLock()
 	if isClustered {
-		_, reserved = tieredStreamAndReservationCount(js.cluster.streams[a.Name], tier, cfg)
+		_, reserved = js.tieredStreamAndReservationCount(a.Name, tier, cfg)
 	}
 	if err := js.checkAllLimits(&selected, cfg, reserved, 0); err != nil {
 		js.mu.RUnlock()
@@ -2218,7 +2218,7 @@ func (jsa *jsAccount) configUpdateCheck(old, new *StreamConfig, s *Server, pedan
 	js.mu.RLock()
 	defer js.mu.RUnlock()
 	if isClustered {
-		_, reserved = tieredStreamAndReservationCount(js.cluster.streams[acc.Name], tier, &cfg)
+		_, reserved = js.tieredStreamAndReservationCount(acc.Name, tier, &cfg)
 	}
 	// reservation does not account for this stream, hence add the old value
 	if tier == _EMPTY_ && old.Replicas > 1 {
@@ -7821,7 +7821,7 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 	if hasTier {
 		if isClustered {
 			js.mu.RLock()
-			_, reserved = tieredStreamAndReservationCount(js.cluster.streams[a.Name], tier, &cfg)
+			_, reserved = js.tieredStreamAndReservationCount(a.Name, tier, &cfg)
 			js.mu.RUnlock()
 		} else {
 			reserved = jsa.tieredReservation(tier, &cfg)


### PR DESCRIPTION
This PR implements proper inflight meta changes tracking. Importantly, this fixes:
- Concurrent stream updates would not prevent invalid state changes, like unsealing a stream.
- Similar invalid state changes for consumers.
- Don't let the meta leader overwrite the local consumer assignment before applying it, which could prevent an updated consumer from being included in the meta snapshot.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>