### PR TITLE
Consumer inactive threshold cleanup should stop when consumer stops

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2045,6 +2045,7 @@ func (o *consumer) deleteNotActive() {
 	if o.srv != nil {
 		qch = o.srv.quitCh
 	}
+	oqch := o.qch
 	o.mu.Unlock()
 	if js != nil {
 		cqch = js.clusterQuitC()
@@ -2092,6 +2093,9 @@ func (o *consumer) deleteNotActive() {
 				case <-qch:
 					return
 				case <-cqch:
+					return
+				case <-oqch:
+					// The consumer has stopped already, likely by an earlier delete proposal being applied.
 					return
 				}
 				js.mu.RLock()


### PR DESCRIPTION
This avoids lingering goroutines.

Signed-off-by: Neil Twigg <neil@nats.io>