### PR TITLE
Add Unix socket support for client listener

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -5821,8 +5821,13 @@ func setBaselineOptions(opts *Options) {
 		opts.Host = DEFAULT_HOST
 	}
 	if opts.HTTPHost == _EMPTY_ {
-		// Default to same bind from server if left undefined
-		opts.HTTPHost = opts.Host
+		// Default to same bind from server if left undefined,
+		// but not if Host is a Unix socket path.
+		if len(opts.Host) > 0 && opts.Host[0] == '/' {
+			opts.HTTPHost = DEFAULT_HOST
+		} else {
+			opts.HTTPHost = opts.Host
+		}
 	}
 	if opts.Port == 0 {
 		opts.Port = DEFAULT_PORT


### PR DESCRIPTION
If the host configuration starts with '/', it is treated as a Unix socket path instead of a TCP address.

Example config:
  host: /var/run/nats.sock

Useful behind reverse proxy like nginx

Signed-off-by: Boris Rybalkin<ribalkin@gmail.com>
