### PR TITLE
[FIXED] avoid uint64 underflow in readIndexInfo for empty blocks

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -8859,7 +8859,13 @@ func (mb *msgBlock) readIndexInfo() error {
 	}
 
 	// Check for consistency if accounting. If something is off bail and we will rebuild.
-	if mb.msgs != (atomic.LoadUint64(&mb.last.seq)-atomic.LoadUint64(&mb.first.seq)+1)-dmapLen {
+	var expected uint64
+	if mb.isEmpty() {
+		expected = 0
+	} else {
+		expected = (atomic.LoadUint64(&mb.last.seq) - atomic.LoadUint64(&mb.first.seq) + 1) - dmapLen
+	}
+	if mb.msgs != expected {
 		os.Remove(ifn)
 		return fmt.Errorf("accounting inconsistent")
 	}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -13167,3 +13167,87 @@ func TestFileStoreRemoveMsgsInRangeWithTombstones(t *testing.T) {
 	checkBlock(fs.blks[1], 13, 12, []uint64{4, 3, 2, 10})
 	checkBlock(fs.blks[2], 18, 20, []uint64{9, 11, 17})
 }
+
+// Test readIndexInfo upgrade scenario: old < 2.10 .idx file with empty block.
+// Simulates upgrading from pre-2.10 server that wrote .idx files.
+func TestFileStoreReadIndexInfoUpgradeEmptyBlock(t *testing.T) {
+	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
+		cfg := StreamConfig{Name: "zzz", Storage: FileStorage}
+		created := time.Now()
+
+		// Simulate old server (< 2.10) that wrote .idx files.
+		// Create a store, add messages, then manually create an old-format .idx file.
+		fs, err := newFileStoreWithCreated(fcfg, cfg, created, prf(&fcfg), nil)
+		require_NoError(t, err)
+
+		// Store messages
+		for i := 0; i < 3; i++ {
+			_, _, err = fs.StoreMsg("foo", nil, []byte("msg"), 0)
+			require_NoError(t, err)
+		}
+
+		fs.mu.RLock()
+		mb := fs.blks[0]
+		fs.mu.RUnlock()
+
+		mb.mu.Lock()
+		last := atomic.LoadUint64(&mb.last.seq)
+		mb.mu.Unlock()
+
+		require_NoError(t, fs.Stop())
+
+		// Simulate old server wrote .idx file with empty block state (after purge).
+		// In old server, after purge: first = last + 1 (empty block).
+		// Create .idx file as if it was written by old server before upgrade.
+		ifn := filepath.Join(fcfg.StoreDir, msgDir, fmt.Sprintf("%d.idx", mb.index))
+		buf := make([]byte, 0, 100)
+		buf = append(buf, 22, 1) // magic, version (old format)
+
+		// Empty block: first > last (e.g., first=4, last=3 after purge)
+		emptyFirst := last + 1
+		emptyLast := last
+
+		buf = binary.AppendUvarint(buf, 0)          // msgs = 0
+		buf = binary.AppendUvarint(buf, 0)          // bytes = 0
+		buf = binary.AppendUvarint(buf, emptyFirst) // first.seq
+		buf = binary.AppendVarint(buf, 0)           // first.ts
+		buf = binary.AppendUvarint(buf, emptyLast)  // last.seq
+		buf = binary.AppendVarint(buf, 0)           // last.ts
+		buf = binary.AppendUvarint(buf, 1)          // dmapLen > 0 (had deleted entries before purge)
+
+		// For old format (version 1), dmapLen entries follow as offsets from first.seq
+		// Add one deleted entry offset (0 = first.seq itself was deleted)
+		buf = binary.AppendUvarint(buf, 0)
+
+		// Checksum (8 bytes) - for empty block, checksum check passes if rbytes==0 && msgs==0
+		// So we can use zeros here since the block will be empty
+		buf = append(buf, make([]byte, 8)...)
+
+		require_NoError(t, os.WriteFile(ifn, buf, 0644))
+
+		// Also create empty .blk file to match empty state
+		blkFile := filepath.Join(fcfg.StoreDir, msgDir, fmt.Sprintf("%d.blk", mb.index))
+		require_NoError(t, os.WriteFile(blkFile, nil, 0644))
+
+		// Now simulate upgrade: new server (>= 2.10) reads old .idx file
+		fs2, err := newFileStoreWithCreated(fcfg, cfg, created, prf(&fcfg), nil)
+		require_NoError(t, err)
+		defer fs2.Stop()
+
+		// Verify upgrade succeeded: readIndexInfo should accept empty block with dmapLen > 0
+		fs2.mu.RLock()
+		require_True(t, len(fs2.blks) > 0)
+		mb2 := fs2.blks[0]
+		fs2.mu.RUnlock()
+
+		mb2.mu.RLock()
+		// Block should be recognized as empty
+		require_True(t, mb2.isEmpty())
+		require_Equal(t, mb2.msgs, uint64(0))
+		mb2.mu.RUnlock()
+
+		// Verify .idx file was not removed (recovery succeeded)
+		_, err = os.Stat(ifn)
+		require_NoError(t, err)
+	})
+}


### PR DESCRIPTION
## What

In `readIndexInfo()`, the accounting consistency check used:
`(last - first + 1) - dmapLen` for all blocks.

Empty/purged blocks have `first > last` (see `isEmpty()`). In that case
`(last - first + 1)` underflows in uint64, so the check could wrongly
reject valid index files with "accounting inconsistent" and remove them.

## Change

- Handle empty blocks explicitly: use `isEmpty()` and expect `expected == 0`
  for empty blocks.
- For non-empty blocks, keep the existing formula
  `(last - first + 1) - dmapLen`.

Empty/purged blocks: (last - first + 1) would underflow in uint64; use
isEmpty() and expect 0.

## Why

- `compact()` sets `last = fseq-1` when `msgs == 0` → first > last.
- `rebuildStateLocked` does the same for recovered empty blocks.
- New blocks and tombstone-only writes also use first > last.
- So this state can be read from disk on recovery/upgrade; the check must
  handle it without underflow.

Signed-off-by: Sadık Sünbül <ssunbul.dev@gmail.com>