### PR TITLE
[FIXED] MQTT: Did not reject Packet Identifier set to 0 for SUB/UNSUB

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2025 The NATS Authors
+// Copyright 2020-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -4774,9 +4774,9 @@ func (c *client) mqttParseSubsOrUnsubs(r *mqttReader, b byte, pl int, sub bool) 
 	if rf := b & 0xf; rf != expectedFlag {
 		return 0, nil, fmt.Errorf("wrong %ssubscribe reserved flags: %x", action, rf)
 	}
-	pi, err := r.readUint16("packet identifier")
+	pi, err := mqttParsePIPacket(r)
 	if err != nil {
-		return 0, nil, fmt.Errorf("reading packet identifier: %v", err)
+		return 0, nil, err
 	}
 	end := r.pos + (pl - 2)
 	var filters []*mqttFilter


### PR DESCRIPTION
According to the specification, the server should reject a SUB and UNSUB protocol with a packet indentifier equal to 0.

Resolves #7803

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>