### PR TITLE
NRG: Improve membership changes checks & leader is caught-up for forwarded proposals

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -179,6 +179,8 @@ type raft struct {
 	applied   uint64 // Index of the most recently applied commit
 	papplied  uint64 // First sequence of our log, matches when we last installed a snapshot.
 
+	membChangeIndex uint64 // Index of uncommitted membership change entry (0 means no change in progress)
+
 	aflr uint64 // Index when to signal initial messages have been applied after becoming leader. 0 means signaling is disabled.
 
 	leader string // The ID of the leader
@@ -231,7 +233,6 @@ type raft struct {
 	observer     bool // The node is observing, i.e. not able to become leader
 	initializing bool // The node is new, and "empty log" checks can be temporarily relaxed.
 	scaleUp      bool // The node is part of a scale up, puts us in observer mode until the log contains data.
-	membChanging bool // There is a membership change proposal in progress
 	deleted      bool // If the node was deleted.
 }
 
@@ -954,7 +955,7 @@ func (n *raft) ProposeAddPeer(peer string) error {
 		n.RUnlock()
 		return werr
 	}
-	if n.membChanging {
+	if n.membChangeIndex > 0 {
 		n.RUnlock()
 		return errMembershipChange
 	}
@@ -984,7 +985,7 @@ func (n *raft) ProposeRemovePeer(peer string) error {
 		return nil
 	}
 
-	if n.membChanging {
+	if n.membChangeIndex > 0 {
 		n.RUnlock()
 		return errMembershipChange
 	}
@@ -1004,7 +1005,7 @@ func (n *raft) ProposeRemovePeer(peer string) error {
 func (n *raft) MembershipChangeInProgress() bool {
 	n.RLock()
 	defer n.RUnlock()
-	return n.membChanging
+	return n.membChangeIndex > 0
 }
 
 // ClusterSize reports back the total cluster size.
@@ -2632,7 +2633,7 @@ func (n *raft) handleForwardedRemovePeerProposal(sub *subscription, c *client, _
 		n.RUnlock()
 		return
 	}
-	if n.membChanging {
+	if n.membChangeIndex > 0 {
 		n.debug("Ignoring forwarded peer removal proposal, membership changing")
 		n.RUnlock()
 		return
@@ -2716,14 +2717,16 @@ func (n *raft) sendMembershipChange(e *Entry) bool {
 
 	// Only makes sense to call this with entries that change membership.
 	// Also, ignore if we're already changing membership.
-	if !e.ChangesMembership() || n.membChanging {
+	if !e.ChangesMembership() || n.membChangeIndex > 0 {
 		return false
 	}
 
-	n.membChanging = true
+	// Set to the index where we will store the membership change.
+	// It needs to be before we send, since if we're cluster size 1 we try to commit immediately.
+	n.membChangeIndex = n.pindex + 1
 	err := n.sendAppendEntryLocked([]*Entry{e}, true)
 	if err != nil {
-		n.membChanging = false
+		n.membChangeIndex = 0
 		return false
 	}
 
@@ -3227,7 +3230,7 @@ func (n *raft) applyCommit(index uint64) error {
 			committed = append(committed, e)
 
 			// We are done with this membership change
-			n.membChanging = false
+			n.membChangeIndex = 0
 
 		case EntryRemovePeer:
 			peer := string(e.Data)
@@ -3242,7 +3245,7 @@ func (n *raft) applyCommit(index uint64) error {
 			committed = append(committed, e)
 
 			// We are done with this membership change
-			n.membChanging = false
+			n.membChangeIndex = 0
 
 			// If this is us and we are the leader signal the caller
 			// to attempt to stepdown.
@@ -3589,6 +3592,11 @@ func (n *raft) truncateWAL(term, index uint64) {
 	}
 	// Set after we know we have truncated properly.
 	n.pterm, n.pindex = term, index
+
+	// Check if we're truncating an uncommitted membership change.
+	if n.membChangeIndex > 0 && n.membChangeIndex > index {
+		n.membChangeIndex = 0
+	}
 }
 
 // Reset our WAL. This is equivalent to truncating all data from the log.
@@ -3958,7 +3966,8 @@ CONTINUE:
 			}
 		case EntryAddPeer:
 			// When receiving or restoring, mark membership as changing.
-			n.membChanging = true
+			// Set to the index where this entry was stored (pindex is now this entry's index)
+			n.membChangeIndex = n.pindex
 			if newPeer := string(e.Data); len(newPeer) == idLen {
 				// Track directly, but wait for commit to be official
 				if _, ok := n.peers[newPeer]; !ok {
@@ -3969,7 +3978,8 @@ CONTINUE:
 			}
 		case EntryRemovePeer:
 			// When receiving or restoring, mark membership as changing.
-			n.membChanging = true
+			// Set to the index where this entry was stored (pindex is now this entry's index)
+			n.membChangeIndex = n.pindex
 		}
 	}
 


### PR DESCRIPTION
This PR improves a couple areas in our Raft logic:
- Instead of scanning the log using `logContainsUncommittedMembershipChange` after we've won the leader election, we rely on the scan we do during startup of the Raft node and set `n.membChanging` if we process such an append entry. If the scan of `logContainsUncommittedMembershipChange` takes near the minimum election timeout, we could continuously cycle leader changes without making progress.
- Don't allow concurrent membership changes if we got forwarded a peer-removal.
- Only accept forwarded proposals if we're initially caught up as the new leader. This ensures the new leader gets some time to establish its leadership, up the `n.commit` based on what's in its log, and not be immediately overwhelmed by loads of forwarded proposals (for example due to inactive thresholds deleting consumers). This should help limit the growth of the log if many forwarded proposals are retried.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>