### PR TITLE
[FIXED] Consumer with overlapping filter subjects but not subset

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -825,7 +825,7 @@ func checkConsumerCfg(
 			return NewJSStreamInvalidConfigError(ErrBadSubject)
 		}
 		for inner, ssubject := range subjectFilters {
-			if inner != outer && SubjectsCollide(subject, ssubject) {
+			if inner != outer && subjectIsSubsetMatch(subject, ssubject) {
 				return NewJSConsumerOverlappingSubjectFiltersError()
 			}
 		}


### PR DESCRIPTION
A consumer should be allowed to have filter subjects like `event.foo.*` and `event.*.foo`. They do collide but one isn't a subset of the other, but it currently fails as having overlapping subjects. This PR relaxes this check by allowing this former case, but still preventing having filter subjects like `event.>` and `event.foo`/`event.*.foo`/etc. since those are subsets (which was maybe too eagerly changed in https://github.com/nats-io/nats-server/pull/5224, as it used to be `subjectIsSubsetMatch` before).

Resolves https://github.com/nats-io/nats-server/issues/7779

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>