### PR TITLE
[FIXED] Race condition when remapping group

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4498,6 +4498,8 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 			s.Warnf("JetStream cluster detected stream remapping for '%s > %s' from %q to %q",
 				acc, cfg.Name, osa.Group.Name, sa.Group.Name)
 			mset.removeNode()
+			mset.signalMonitorQuit()
+			mset.monitorWg.Wait()
 			alreadyRunning, needsNode = false, true
 			// Make sure to clear from original.
 			js.mu.Lock()
@@ -4535,6 +4537,8 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 		} else if numReplicas == 1 && alreadyRunning {
 			// We downgraded to R1. Make sure we cleanup the raft node and the stream monitor.
 			mset.removeNode()
+			mset.signalMonitorQuit()
+			mset.monitorWg.Wait()
 			// In case we need to shutdown the cluster specific subs, etc.
 			mset.mu.Lock()
 			// Stop responding to sync requests.


### PR DESCRIPTION
When remapping  the Raft group we need not only remove the current node, we also need to wait for the current monitor goroutine to exit. Otherwise we might open a new monitor goroutine too soon such that it exits as the other is still active before it shuts down.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>