### PR TITLE
(2.12) [FIXED] Remove recovered streams/consumers if not in catchup meta snapshot

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -10806,6 +10806,7 @@ func TestJetStreamClusterRaftCatchupSignalsMetaRecovery(t *testing.T) {
 	// For this test using two large values so we remain in catchup.
 	meta.Lock()
 	meta.createCatchup(&appendEntry{pterm: 100, pindex: 100})
+	meta.sendCatchupSignal()
 	meta.Unlock()
 
 	// Deleting a stream should be staged, not immediately performed.

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -7257,9 +7257,8 @@ func TestJetStreamClusterReplicasChangeStreamInfo(t *testing.T) {
 	for _, rs := range c.servers {
 		meta := rs.getJetStream().getMetaGroup().(*raft)
 		meta.Lock()
-		indexUpdates := newIPQueue[uint64](rs, "block snapshot")
-		indexUpdates.push(1000)
-		meta.progress = map[string]*ipQueue[uint64]{"peer": indexUpdates}
+		meta.progress = make(map[string]*ipQueue[uint64])
+		meta.progress["blockSnapshots"] = newIPQueue[uint64](meta.s, "blockSnapshots")
 		meta.Unlock()
 	}
 


### PR DESCRIPTION
`TestJetStreamClusterDeleteConsumerWhileServerDown` (and others) would fail if the restarted server couldn't install a snapshot during shutdown. This happened if the server was a follower of the meta layer and committed the consumer create from a heartbeat, which isn't stored in the log. So, when the server restarted it didn't know it could commit/apply this consumer create again (since it already did so prior to restart). Then, when the meta snapshot was received to catch this server up, it would not properly remove the consumer as it wasn't tracked in its assignments.

Marked as 2.12+ as https://github.com/nats-io/nats-server/pull/7540 is only cherry-picked there.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>