### PR TITLE
[IMPROVED] Asynchronous meta stream/consumer assignments snapshots

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -8204,7 +8204,7 @@ func TestJetStreamClusterRecreateConsumerFromMetaSnapshot(t *testing.T) {
 		if s != rs {
 			sjs := s.getJetStream()
 			require_NotNil(t, sjs)
-			snap, err := sjs.metaSnapshot()
+			snap, _, _, err := sjs.metaSnapshot()
 			require_NoError(t, err)
 			sjs.mu.RLock()
 			meta := sjs.cluster.meta
@@ -9702,7 +9702,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterAssetCreateOrUpdate(t *tes
 		t.Helper()
 		for _, s := range c.servers {
 			sjs = s.getJetStream()
-			snap, err := sjs.metaSnapshot()
+			snap, _, _, err := sjs.metaSnapshot()
 			require_NoError(t, err)
 			meta := sjs.getMetaGroup()
 			meta.InstallSnapshot(snap)
@@ -9728,7 +9728,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterAssetCreateOrUpdate(t *tes
 
 	getValidMetaSnapshot := func() (wsas []writeableStreamAssignment) {
 		t.Helper()
-		snap, err := sjs.metaSnapshot()
+		snap, _, _, err := sjs.metaSnapshot()
 		require_NoError(t, err)
 		require_True(t, len(snap) > 0)
 		dec, err := s2.Decode(nil, snap)
@@ -9838,7 +9838,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterAssetCreateOrUpdate(t *tes
 
 	// Deleting a stream should always work, even if it is unsupported.
 	require_NoError(t, js.DeleteStream("DowngradeStreamTest"))
-	snap, err := sjs.metaSnapshot()
+	snap, _, _, err := sjs.metaSnapshot()
 	require_NoError(t, err)
 	require_True(t, snap == nil)
 
@@ -10007,7 +10007,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterDowngrade(t *testing.T) {
 		t.Helper()
 		for _, s := range c.servers {
 			sjs = s.getJetStream()
-			snap, err := sjs.metaSnapshot()
+			snap, _, _, err := sjs.metaSnapshot()
 			require_NoError(t, err)
 			meta := sjs.getMetaGroup()
 			meta.InstallSnapshot(snap)
@@ -10033,7 +10033,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterDowngrade(t *testing.T) {
 
 	getValidMetaSnapshot := func() (wsas []writeableStreamAssignment) {
 		t.Helper()
-		snap, err := sjs.metaSnapshot()
+		snap, _, _, err := sjs.metaSnapshot()
 		require_NoError(t, err)
 		require_True(t, len(snap) > 0)
 		dec, err := s2.Decode(nil, snap)
@@ -10127,7 +10127,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterDowngrade(t *testing.T) {
 
 	// Deleting a stream should always work, even if it is unsupported.
 	require_NoError(t, js.DeleteStream("DowngradeStreamTest"))
-	snap, err := sjs.metaSnapshot()
+	snap, _, _, err := sjs.metaSnapshot()
 	require_NoError(t, err)
 	require_True(t, snap == nil)
 
@@ -10255,7 +10255,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerUpdate(t *testing.T) {
 
 	getValidMetaSnapshot := func() (wsas []writeableStreamAssignment) {
 		t.Helper()
-		snap, err := sjs.metaSnapshot()
+		snap, _, _, err := sjs.metaSnapshot()
 		require_NoError(t, err)
 		require_True(t, len(snap) > 0)
 		dec, err := s2.Decode(nil, snap)

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -7146,7 +7146,7 @@ func TestJetStreamClusterStreamRescaleCatchup(t *testing.T) {
 				}
 				sjs := s.getJetStream()
 				n := sjs.getMetaGroup()
-				snap, err := sjs.metaSnapshot()
+				snap, _, _, err := sjs.metaSnapshot()
 				require_NoError(t, err)
 				require_NoError(t, n.InstallSnapshot(snap))
 			}
@@ -7373,7 +7373,7 @@ func TestJetStreamClusterConsumerRescaleCatchup(t *testing.T) {
 				}
 				sjs := s.getJetStream()
 				n := sjs.getMetaGroup()
-				snap, err := sjs.metaSnapshot()
+				snap, _, _, err := sjs.metaSnapshot()
 				require_NoError(t, err)
 				require_NoError(t, n.InstallSnapshot(snap))
 			}

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -4170,7 +4170,7 @@ func TestJetStreamClusterMetaSnapshotReCreateConsistency(t *testing.T) {
 	mjs.mu.Unlock()
 
 	// Get the snapshot before removing the stream below so we can recover fresh.
-	snap, err := mjs.metaSnapshot()
+	snap, _, _, err := mjs.metaSnapshot()
 	require_NoError(t, err)
 	require_NoError(t, js.DeleteStream("TEST"))
 	nc.Close()
@@ -4244,7 +4244,7 @@ func TestJetStreamClusterMetaSnapshotConsumerDeleteConsistency(t *testing.T) {
 	mjs.mu.Unlock()
 
 	// Get the snapshot before removing the stream below so we can recover fresh.
-	snap, err := mjs.metaSnapshot()
+	snap, _, _, err := mjs.metaSnapshot()
 	require_NoError(t, err)
 	require_NoError(t, js.DeleteStream("TEST"))
 	nc.Close()

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -5347,7 +5347,7 @@ func TestMonitorJsz(t *testing.T) {
 			for _, srv := range srvs {
 				if js := srv.getJetStream(); js != nil {
 					if mg := js.getMetaGroup(); mg != nil {
-						if snap, err := js.metaSnapshot(); err == nil {
+						if snap, _, _, err := js.metaSnapshot(); err == nil {
 							mg.InstallSnapshot(snap)
 						}
 					}

--- a/server/norace_2_test.go
+++ b/server/norace_2_test.go
@@ -2904,7 +2904,7 @@ func TestNoRaceJetStreamClusterLargeMetaSnapshotTiming(t *testing.T) {
 	n := js.getMetaGroup()
 	// Now let's see how long it takes to create a meta snapshot and how big it is.
 	start := time.Now()
-	snap, err := js.metaSnapshot()
+	snap, _, _, err := js.metaSnapshot()
 	require_NoError(t, err)
 	require_NoError(t, n.InstallSnapshot(snap))
 	t.Logf("Took %v to snap meta with size of %v\n", time.Since(start), friendlyBytes(len(snap)))

--- a/server/opts.go
+++ b/server/opts.go
@@ -389,6 +389,7 @@ type Options struct {
 	JetStreamRequestQueueLimit int64
 	JetStreamMetaCompact       uint64
 	JetStreamMetaCompactSize   uint64
+	JetStreamMetaCompactSync   bool
 	StreamMaxBufferedMsgs      int               `json:"-"`
 	StreamMaxBufferedSize      int64             `json:"-"`
 	StoreDir                   string            `json:"-"`
@@ -2653,6 +2654,8 @@ func parseJetStream(v any, opts *Options, errors *[]error, warnings *[]error) er
 					return &configErr{tk, fmt.Sprintf("Expected an absolute size for %q, got %v", mk, mv)}
 				}
 				opts.JetStreamMetaCompactSize = uint64(s)
+			case "meta_compact_sync":
+				opts.JetStreamMetaCompactSync = mv.(bool)
 			default:
 				if !tk.IsUsedVariable() {
 					err := &unknownConfigFieldErr{

--- a/server/reload.go
+++ b/server/reload.go
@@ -1659,7 +1659,7 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 					return nil, fmt.Errorf("config reload not supported for jetstream max memory and store")
 				}
 			}
-		case "jetstreammetacompact", "jetstreammetacompactsize":
+		case "jetstreammetacompact", "jetstreammetacompactsize", "jetstreammetacompactsync":
 			// Allowed at runtime but monitorCluster looks at s.opts directly, so no further work needed here.
 		case "websocket":
 			// Similar to gateways

--- a/server/util.go
+++ b/server/util.go
@@ -165,7 +165,7 @@ func urlsAreEqual(u1, u2 *url.URL) bool {
 // e.g. comma(834142) -> 834,142
 //
 // This function was copied from the github.com/dustin/go-humanize
-// package and is Copyright Dustin Sallings <dustin@spy.net>
+// package (MIT License) and is Copyright Dustin Sallings <dustin@spy.net>
 func comma(v int64) string {
 	sign := ""
 


### PR DESCRIPTION
A NATS system with many 100s of thousands up to millions of stream/consumer assets spread over many nodes will notice occasional freezes of the JetStream API while meta snapshots are generated. These snapshots were created synchronously, inline, and while holding the JS lock. This could hold up new JetStream API requests coming in as well as delay inflight stream/consumer CRUD responses.

This PR improves this, perhaps fixes to a degree, by having these meta snapshots be asynchronous. It will generally take a bit longer to create these asynchronous snapshots (when compared to the sync/blocking ones) as JetStream operations will continue without significant delay or freezes.

Log messages have been updated to clearly differentiate between generating/encoding the snapshot content and blocking/async creation and installation of it (as well as containing human-readable sizes and how much of the log was compacted away as a result of the snapshot):
```
[WRN] Metalayer snapshot generation took 6.792s (streams: 1, consumers: 102048, marshal: 5.645s, s2: 0.373s, uncompressed: 58MB, compressed: 5MB)
[WRN] Metalayer async snapshot took 22.887s (streams: 1, consumers: 110724, compacted: 17MB)
```

Asynchronous snapshots will be used by default, but there can be cases where we need to fall back to synchronous/blocking snapshots:
- The snapshot created during shutdown or shortly after restart will still be blocking. This cleans up the log before allowing new operations in for a server that's recovering.
- While reading in the previous snapshot and the append entries that can be snapshotted, some disk corruption could technically have silently slipped in between us applying the changes before and us reading them in again now. We fall back to blocking snapshots to install it while the system is still running without endangering safety/correctness during runtime, or being unavailable after a restart if this wasn't performed.
- If the server is thoroughly overloaded and the async snapshots take longer to compact the log than users can fill it up with new JetStream operations, the server will force the use of a blocking snapshot. This protects overall system health by not having the disk fill up endlessly. (This shouldn't trigger on a otherwise healthy system, and is primarily a protective measure)
- If the server is continuously catching up other peers, snapshotting is prevented and they will fail, the log will continue growing as new entries come in. If a snapshot fails once it will be retried on a 1 minute interval, ensuring retries aren't spammed. If it keeps failing for more than 10 times, we allow snapshotting even if we are catching other peers up. The server then prioritizes protecting itself and its log size instead of trying to catch up lagging peers. Lagging peers will then also potentially benefit from this new snapshot, as they'll have to then catchup way less than they had to before.

Blocking snapshots will be clearly marked in the logs (as they will temporarily freeze JetStream operations to prioritize the creation of the snapshot):
```
// If an asynchronous snapshot failed, the next snapshot will fall back to be blocking.
[WRN] Error snapshotting JetStream cluster state: <err>, will fall back to blocking snapshot

// A blocking snapshot will always announce it starting and how long it took.
[WRN] Metalayer blocking snapshot starting
[WRN] Metalayer blocking snapshot took 3.425s (streams: 1, consumers: 110724, compacted: 570MB)
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>