### PR TITLE
Improved flow control for stream snapshots

### DIFF
--- a/server/norace_2_test.go
+++ b/server/norace_2_test.go
@@ -1373,6 +1373,12 @@ func TestNoRaceMemStoreCompactPerformance(t *testing.T) {
 }
 
 func TestNoRaceJetStreamSnapshotsWithSlowAckDontSlowConsumer(t *testing.T) {
+	// Test takes less time this way.
+	snapshotAckTimeout = 500 * time.Millisecond
+	t.Cleanup(func() {
+		snapshotAckTimeout = defaultSnapshotAckTimeout
+	})
+
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
@@ -1429,7 +1435,7 @@ func TestNoRaceJetStreamSnapshotsWithSlowAckDontSlowConsumer(t *testing.T) {
 		require_Equal(t, msg.Header.Get("Description"), "No Flow Response")
 	case <-ech:
 		t.Fatalf("Got disconnected: %v", err)
-	case <-time.After(5 * time.Second):
+	case <-time.After(snapshotAckTimeout * 2):
 		t.Fatalf("Should have received EOF with error status")
 	}
 }


### PR DESCRIPTION
This PR improves the flow control for stream snapshots:

1. We will now keep a window of slots for in-flight chunks, rather than counting totals and potentially dropping acks, but still targeting 8MB in flight at any time
2. We will now wait for a chunk to be filled (or EOF from the snapshotting goroutine) before sending it rather than opportunistically sending smaller chunks, providing more stable throughput on the wire
3. Increase the amount of time that we can wait for acks from 2 seconds to 5 seconds, to better cope with slow connections
4. Give up early in ack reply subscription handlers if we detect that the process has failed

Signed-off-by: Neil Twigg <neil@nats.io>