### PR TITLE
Add Original Reply Subject to Stream Republished Messages

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -6230,7 +6230,7 @@ func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, 
 				hdr = fmt.Appendf(hdr[:end:end], htho[hoff:], name, subject, seq, tsStr, tlseq, len(msg))
 			}
 		}
-		outq.send(newJSPubMsg(tsubj, _EMPTY_, _EMPTY_, hdr, rpMsg, nil, seq))
+		outq.send(newJSPubMsg(tsubj, subject, reply, hdr, rpMsg, nil, seq))
 	}
 
 	// Send response here.


### PR DESCRIPTION
# Issue
When using Stream Republishing, the republished message will not contain the original reply subject field.
Subscribers receiving the republished message therefore can not reply to a request.

# Minimal Reproducible Example

### Stream Setup
- Basic Republish
- No-Ack to make "nats-cli req" work properly
- Limits with maxAge=1s because we only care about the republish right now

```
nats stream add test-stream --no-ack --republish-source="*" --republish-destination="out-subject" \
--max-age="1s" --retention="limits" --subjects="in-subject" --storage="memory" --defaults
```

### Pub / Sub works as expected

```
# on the pub cli
~ # nats pub in-subject "test"
11:13:25 Published 4 bytes to "in-subject"
```

```
# on the sub cli
~ # nats sub out-subject
11:13:02 Subscribing on out-subject 
[#1] Received on "out-subject"
Nats-Stream: test-stream
Nats-Subject: in-subject
Nats-Sequence: 1
Nats-Time-Stamp: 2026-02-13T11:13:25.193294196Z
Nats-Last-Sequence: 0

test
```

### But Request Reply does not work

```
# on the reply cli
nats reply out-subject "reply!"
11:13:51 Listening on "out-subject" in group "NATS-RPLY-22"
11:14:04 [#0] Received on subject "out-subject":
11:14:04 Nats-Stream: test-stream
11:14:04 Nats-Subject: in-subject
11:14:04 Nats-Sequence: 2
11:14:04 Nats-Time-Stamp: 2026-02-13T11:14:04.262212817Z
11:14:04 Nats-Last-Sequence: 0

test?
11:14:04 Could not publish reply: nats: message does not have a reply
```

```
# on the request cli
nats req in-subject "test?"
11:14:04 Sending request on "in-subject"
```

# Content of this PR

The newJSPubMsg() call to (re-)publish the message will now properly contain the original subject and the reply subject.
A new test "TestJetStreamStreamRepublishReplySubject" was added to jetstream_test.go.

# Tests

All tests in jetstream_test.go (including the new one) run green.

# Why is this useful?

Having support for request reply in republished messages allows us to create fully declarative, server-side routing of request reply. Adding or removing the streams (like above) creates or deletes routes between subjects. Declaring the stream will internally connect two parties which do not need to know a common subject to do a request reply. That way, the stream republish feature can be used as a simple and dynamically declared subject mapping for pub/sub and req/rep.

# Additional Info

The topic was originally discussed on Slack on the 12th of February in the general channel.
Among other discussion points, the following items were brought up by Michael Röschter, that may be considered for this PR as well:

- The current behavior for reply subject is unchanged for the message stored in the stream
- The republished message is modified anyway (additional headers). Its not identical to the stored message. So keeping the reply subject would not violate any contract.
- Its a purely additive change to the current implementation


Signed-off-by: Philipp Schmidt <philipp.schmidt@isarsoft.com>
