### PR TITLE
[FIXED] Recreate monitor quit channel

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1409,8 +1409,12 @@ func (o *consumer) monitorQuitC() <-chan struct{} {
 	if o == nil {
 		return nil
 	}
-	o.mu.RLock()
-	defer o.mu.RUnlock()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	// Recreate if a prior monitor routine was stopped.
+	if o.mqch == nil {
+		o.mqch = make(chan struct{})
+	}
 	return o.mqch
 }
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -1082,8 +1082,12 @@ func (mset *stream) monitorQuitC() <-chan struct{} {
 	if mset == nil {
 		return nil
 	}
-	mset.mu.RLock()
-	defer mset.mu.RUnlock()
+	mset.mu.Lock()
+	defer mset.mu.Unlock()
+	// Recreate if a prior monitor routine was stopped.
+	if mset.mqch == nil {
+		mset.mqch = make(chan struct{})
+	}
 	return mset.mqch
 }
 


### PR DESCRIPTION
Recreate the monitor quit channel (`mset.mqch/o.mqch`) when retrieving it. If the previous `monitorStream/Consumer` was quit, but we restarted it under a different Raft group, we need to recreate the quit channel or we'll not be able to quit unless the Raft group does.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>