### PR TITLE
API level 3

### DIFF
--- a/server/jetstream_versioning.go
+++ b/server/jetstream_versioning.go
@@ -17,7 +17,7 @@ import "strconv"
 
 const (
 	// JSApiLevel is the maximum supported JetStream API level for this server.
-	JSApiLevel int = 2
+	JSApiLevel int = 3
 
 	JSRequiredLevelMetadataKey = "_nats.req.level"
 	JSServerVersionMetadataKey = "_nats.ver"


### PR DESCRIPTION
Allows CLI to correctly detect when `window_size` from #7839 is supported or not.

Signed-off-by: Neil Twigg <neil@nats.io>
