### PR TITLE
[FIXED] Preserve max delivered messages with WorkQueue retention

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -7715,15 +7715,8 @@ func (mset *stream) ackMsg(o *consumer, seq uint64) bool {
 		return false
 	}
 
-	var shouldRemove bool
-	switch mset.cfg.Retention {
-	case WorkQueuePolicy:
-		// Normally we just remove a message when its ack'd here but if we have direct consumers
-		// from sources and/or mirrors we need to make sure they have delivered the msg.
-		shouldRemove = mset.directs <= 0 || mset.noInterest(seq, o)
-	case InterestPolicy:
-		shouldRemove = mset.noInterest(seq, o)
-	}
+	// If there's no interest left on this message for all consumers, we can remove it.
+	shouldRemove := mset.noInterest(seq, nil)
 
 	// If nothing else to do.
 	if !shouldRemove {


### PR DESCRIPTION
Once messages aren't pending anymore, are only in the redelivered state, and are below the ack floor, then `mset.checkInterestState` would clean them up. `shouldRemove` would be set due to `mset.directs <= 0` but it was skipped in `mset.noInterest(seq, o)` otherwise too, as that ignores that consumer thus doesn't know it needs to keep it due to reaching max deliveries. Now we always call `mset.noInterest(seq, nil)` (without passing the consumer) to ensure there are no consumers left with interest (including messages left as max deliveries), in which case we can remove the message.

Resolves https://github.com/nats-io/nats-server/issues/7817

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>