### PR TITLE
NRG: Preserve papplied on truncate after unapplied catchup snapshot

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3787,9 +3787,6 @@ func (n *raft) truncateWAL(term, index uint64) {
 		if n.applied > n.processed {
 			n.applied = n.processed
 		}
-		if n.papplied > n.applied {
-			n.papplied = n.applied
-		}
 		// Refresh bytes count after truncate.
 		var state StreamState
 		n.wal.FastState(&state)


### PR DESCRIPTION
The `n.papplied` value is meant to represent the applied value (`snap.lastIndex`) of the previous/last snapshot. This could be wrongfully reverted down when truncating away uncommitted entries after having received a catchup snapshot from a leader that wasn't applied yet.

This also fixes an error condition where `snapshot index mismatch` could be returned when using the async snapshots: https://github.com/nats-io/nats-server/pull/7827.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>