### PR TITLE
NRG: Fix cluster size drop to 1 on replaying EntryAddPeer after restart

### DIFF
--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -438,7 +438,8 @@ func initSingleMemRaftNodeWithCluster(t *testing.T) (*raft, *cluster) {
 	require_NoError(t, err)
 	cfg := &RaftConfig{Name: "TEST", Store: t.TempDir(), Log: ms}
 
-	err = s.bootstrapRaftNode(cfg, nil, false)
+	id := s.sys.shash[:idLen]
+	err = s.bootstrapRaftNode(cfg, []string{id}, true)
 	require_NoError(t, err)
 	n, err := s.initRaftNode(globalAccountName, cfg, pprofLabels{})
 	require_NoError(t, err)


### PR DESCRIPTION
On restart, replaying EntryAddPeer could incorrectly leave a raft node at cluster size 1 instead of restoring the expected size and quorum from persisted state.
This bug could lead to the following scenario: a node in a 3 node cluster could restart, reset set cluster size to 1. If the node did not receive any message from other nodes, it could campaign to become leader. Being in a single node cluster, it would win the election. Resulting in the original cluster splitting into two clusters (or two leaders at the same time).
Specifically, if an EntryAddPeer was replayed on from the log, it would overwrite the cluster size and quorum to 1. The peer set is now restored before the log is replayed, and it is taken from the snapshot (if no snapshot is present then we fallback to peer.idx).
If a log entry that changes membership is replayed, it will now update the cluster and quorum size correctly.

Signed-off-by: Daniele Sciascia <daniele@nats.io>
