### PR TITLE
Add metrics for messages to and from clients

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1535,6 +1535,11 @@ func (c *client) readLoop(pre []byte) {
 				acc.stats.Unlock()
 			}
 
+			if c.kind == CLIENT {
+				atomic.AddInt64(&s.inClientMsgs, inMsgs)
+				atomic.AddInt64(&s.inClientBytes, inBytes)
+			}
+
 			atomic.AddInt64(&s.inMsgs, inMsgs)
 			atomic.AddInt64(&s.inBytes, inBytes)
 		}

--- a/server/client.go
+++ b/server/client.go
@@ -5125,6 +5125,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 	var dlvExtraSize int64
 	var dlvRouteMsgs int64
 	var dlvLeafMsgs int64
+	var dlvClientMsgs int64
 
 	// We need to know if this is a MQTT producer because they send messages
 	// without CR_LF (we otherwise remove the size of CR_LF from message size).
@@ -5138,12 +5139,15 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 		totalBytes := dlvMsgs*int64(len(msg)) + dlvExtraSize
 		routeBytes := dlvRouteMsgs*int64(len(msg)) + dlvExtraSize
 		leafBytes := dlvLeafMsgs*int64(len(msg)) + dlvExtraSize
+		// dlvExtraSize applies to route/leaf header overhead, not client deliveries
+		clientBytes := dlvClientMsgs * int64(len(msg))
 
 		// For non MQTT producers, remove the CR_LF * number of messages
 		if !prodIsMQTT {
 			totalBytes -= dlvMsgs * int64(LEN_CR_LF)
 			routeBytes -= dlvRouteMsgs * int64(LEN_CR_LF)
 			leafBytes -= dlvLeafMsgs * int64(LEN_CR_LF)
+			clientBytes -= dlvClientMsgs * int64(LEN_CR_LF)
 		}
 
 		if acc != nil {
@@ -5164,6 +5168,9 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 		if srv := c.srv; srv != nil {
 			atomic.AddInt64(&srv.outMsgs, dlvMsgs)
 			atomic.AddInt64(&srv.outBytes, totalBytes)
+
+			atomic.AddInt64(&srv.outClientMsgs, dlvClientMsgs)
+			atomic.AddInt64(&srv.outClientBytes, clientBytes)
 		}
 	}
 
@@ -5259,6 +5266,9 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 			// We don't count internal deliveries, so do only when sub.icb is nil.
 			if sub.icb == nil {
 				dlvMsgs++
+				if sub.client.kind == CLIENT {
+					dlvClientMsgs++
+				}
 			}
 			didDeliver = true
 		}
@@ -5486,6 +5496,8 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 						dlvRouteMsgs++
 					case LEAF:
 						dlvLeafMsgs++
+					case CLIENT:
+						dlvClientMsgs++
 					}
 				}
 				// Do the rest even when message delivery was skipped.

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -4292,52 +4292,98 @@ func TestClientRepeatConnectSwitchesAccountAndCleansOldSubs(t *testing.T) {
 
 func TestClientMsgsMetric(t *testing.T) {
 	o1 := DefaultOptions()
+	o1.ServerName = "S1"
 	s1 := RunServer(o1)
 	defer s1.Shutdown()
 
 	o2 := DefaultOptions()
+	o2.ServerName = "S2"
 	o2.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", o1.Cluster.Port))
 	s2 := RunServer(o2)
 	defer s2.Shutdown()
 
 	checkClusterFormed(t, s1, s2)
 
-	nc1 := natsConnect(t, s1.ClientURL())
-	defer nc1.Close()
+	ncS1 := natsConnect(t, s1.ClientURL())
+	defer ncS1.Close()
 
-	nc2 := natsConnect(t, s2.ClientURL())
-	defer nc1.Close()
+	ncS2 := natsConnect(t, s2.ClientURL())
+	defer ncS2.Close()
 
-	natsSub(t, nc1, "foo", func(m *nats.Msg) {
-		m.Respond(m.Data)
-	})
-	natsSub(t, nc2, "bar", func(m *nats.Msg) {
-		m.Respond(m.Data)
-	})
-	nc1.Flush()
-	nc2.Flush()
+	natsSub(t, ncS1, "foo", func(m *nats.Msg) { m.Respond(m.Data) })
+	natsSub(t, ncS2, "bar", func(m *nats.Msg) { m.Respond(m.Data) })
+	ncS1.Flush()
+	ncS2.Flush()
 
-	_, err := nc2.Request("foo", []byte("6bytes"), 3*time.Second)
+	fooMsg := "6bytes"
+	// Requesting foo from S1 and bar from S2
+	// to verify to make sure client messages are counted correctly
+	_, err := ncS2.Request("foo", []byte(fooMsg), 3*time.Second)
 	if err != nil {
 		t.Fatalf("Error on receiving: %v", err)
 	}
-	_, err = nc1.Request("bar", []byte("ninebytes"), 3*time.Second)
+	barMsg := "ninebytes"
+	_, err = ncS1.Request("bar", []byte(barMsg), 3*time.Second)
 	if err != nil {
 		t.Fatalf("Error on receiving: %v", err)
 	}
-	nc1.Flush()
-	nc2.Flush()
+	ncS1.Flush()
+	ncS2.Flush()
 
-	// inMsgs and inBytes counts include routed messages
+	// in/out Msgs/Bytes counts include routed messages
 	require_Equal(t, atomic.LoadInt64(&s1.inMsgs), 4)
-	require_Equal(t, atomic.LoadInt64(&s1.inBytes), 6+6+9+9)
+	require_Equal(t, atomic.LoadInt64(&s1.inBytes), int64(len(fooMsg)*2+len(barMsg)*2))
 	require_Equal(t, atomic.LoadInt64(&s2.inMsgs), 4)
-	require_Equal(t, atomic.LoadInt64(&s2.inBytes), 6+6+9+9)
+	require_Equal(t, atomic.LoadInt64(&s2.inBytes), int64(len(fooMsg)*2+len(barMsg)*2))
 
-	// only count messages received from clients
+	require_Equal(t, atomic.LoadInt64(&s1.outMsgs), 4)
+	require_Equal(t, atomic.LoadInt64(&s1.outBytes), int64(len(fooMsg)*2+len(barMsg)*2))
+	require_Equal(t, atomic.LoadInt64(&s2.outMsgs), 4)
+	require_Equal(t, atomic.LoadInt64(&s2.outBytes), int64(len(fooMsg)*2+len(barMsg)*2))
+
+	// in/out ClientMsgs/Bytes only count client messages
 	require_Equal(t, atomic.LoadInt64(&s1.inClientMsgs), 2)
-	require_Equal(t, atomic.LoadInt64(&s1.inClientBytes), 6+9)
+	require_Equal(t, atomic.LoadInt64(&s1.inClientBytes), int64(len(fooMsg)+len(barMsg)))
 	require_Equal(t, atomic.LoadInt64(&s2.inClientMsgs), 2)
-	require_Equal(t, atomic.LoadInt64(&s2.inClientBytes), 6+9)
+	require_Equal(t, atomic.LoadInt64(&s2.inClientBytes), int64(len(fooMsg)+len(barMsg)))
 
+	require_Equal(t, atomic.LoadInt64(&s1.outClientMsgs), 2)
+	require_Equal(t, atomic.LoadInt64(&s1.outClientBytes), int64(len(fooMsg)+len(barMsg)))
+	require_Equal(t, atomic.LoadInt64(&s2.outClientMsgs), 2)
+	require_Equal(t, atomic.LoadInt64(&s2.outClientBytes), int64(len(fooMsg)+len(barMsg)))
+
+	natsQueueSub(t, ncS1, "orders.new", "workers", func(m *nats.Msg) { m.Respond(m.Data) })
+	natsQueueSub(t, ncS2, "orders.new", "workers", func(m *nats.Msg) { m.Respond(m.Data) })
+	ncS1.Flush()
+	ncS2.Flush()
+
+	orderMsg := "order"
+	_, err = ncS1.Request("orders.new", []byte(orderMsg), 3*time.Second)
+	if err != nil {
+		t.Fatalf("Error on receiving: %v", err)
+	}
+	ncS1.Flush()
+	ncS2.Flush()
+
+	if atomic.LoadInt64(&s1.outClientMsgs) == 4 {
+		require_Equal(t, atomic.LoadInt64(&s2.outClientMsgs), 2)
+
+		require_Equal(t, atomic.LoadInt64(&s1.outClientBytes),
+			int64(len(fooMsg)+len(barMsg)+len(orderMsg)*2))
+
+		require_Equal(t, atomic.LoadInt64(&s2.outClientBytes),
+			int64(len(fooMsg)+len(barMsg)))
+
+	} else if atomic.LoadInt64(&s1.outClientMsgs) == 3 {
+		require_Equal(t, atomic.LoadInt64(&s2.outClientMsgs), 3)
+
+		require_Equal(t, atomic.LoadInt64(&s1.outClientBytes),
+			int64(len(fooMsg)+len(barMsg)+len(orderMsg)))
+
+		require_Equal(t, atomic.LoadInt64(&s2.outClientBytes),
+			int64(len(fooMsg)+len(barMsg)+len(orderMsg)))
+
+	} else {
+		t.Fatalf("Did not get expected outClientMsg/Bytes for message sent on qsub")
+	}
 }

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -4304,44 +4304,56 @@ func TestClientMsgsMetric(t *testing.T) {
 
 	checkClusterFormed(t, s1, s2)
 
-	ncS1 := natsConnect(t, s1.ClientURL())
+	ncS1 := natsConnect(t, s1.ClientURL(), nats.IgnoreDiscoveredServers())
 	defer ncS1.Close()
 
-	ncS2 := natsConnect(t, s2.ClientURL())
+	ncS2 := natsConnect(t, s2.ClientURL(), nats.IgnoreDiscoveredServers())
 	defer ncS2.Close()
 
+	// Echo the message back
 	natsSub(t, ncS1, "foo", func(m *nats.Msg) { m.Respond(m.Data) })
 	natsSub(t, ncS2, "bar", func(m *nats.Msg) { m.Respond(m.Data) })
 	ncS1.Flush()
 	ncS2.Flush()
 
+	checkSubInterest(t, s1, globalAccountName, "bar", 5*time.Second)
+	checkSubInterest(t, s2, globalAccountName, "foo", 5*time.Second)
+
+	// Request foo and bar from non-local servers,
+	// to make sure client messages are counted correctly.
 	fooMsg := "6bytes"
-	// Requesting foo from S1 and bar from S2
-	// to verify to make sure client messages are counted correctly
-	_, err := ncS2.Request("foo", []byte(fooMsg), 3*time.Second)
+	_, err := ncS2.Request("foo", []byte(fooMsg), 5*time.Second)
 	if err != nil {
 		t.Fatalf("Error on receiving: %v", err)
 	}
 	barMsg := "ninebytes"
-	_, err = ncS1.Request("bar", []byte(barMsg), 3*time.Second)
+	_, err = ncS1.Request("bar", []byte(barMsg), 5*time.Second)
 	if err != nil {
 		t.Fatalf("Error on receiving: %v", err)
 	}
-	ncS1.Flush()
-	ncS2.Flush()
+	err = ncS1.Flush()
+	if err != nil {
+		t.Fatalf("Error on flushing connection: %v", err)
+	}
+	err = ncS2.Flush()
+	if err != nil {
+		t.Fatalf("Error on flushing connection: %v", err)
+	}
 
-	// in/out Msgs/Bytes counts include routed messages
-	require_Equal(t, atomic.LoadInt64(&s1.inMsgs), 4)
-	require_Equal(t, atomic.LoadInt64(&s1.inBytes), int64(len(fooMsg)*2+len(barMsg)*2))
-	require_Equal(t, atomic.LoadInt64(&s2.inMsgs), 4)
-	require_Equal(t, atomic.LoadInt64(&s2.inBytes), int64(len(fooMsg)*2+len(barMsg)*2))
+	// In/out Msgs/Bytes include routed messages, including STATSZ heartbeats too.
+	// So there should be at least 2 foo and 2 bar messages received and sent by each server,
+	// but depending on the test timing, we may also catch some STATSZ messages.
+	require_True(t, atomic.LoadInt64(&s1.inMsgs) >= 4)
+	require_True(t, atomic.LoadInt64(&s1.inBytes) >= int64(len(fooMsg)*2+len(barMsg)*2))
+	require_True(t, atomic.LoadInt64(&s2.inMsgs) >= 4)
+	require_True(t, atomic.LoadInt64(&s2.inBytes) >= int64(len(fooMsg)*2+len(barMsg)*2))
 
-	require_Equal(t, atomic.LoadInt64(&s1.outMsgs), 4)
-	require_Equal(t, atomic.LoadInt64(&s1.outBytes), int64(len(fooMsg)*2+len(barMsg)*2))
-	require_Equal(t, atomic.LoadInt64(&s2.outMsgs), 4)
-	require_Equal(t, atomic.LoadInt64(&s2.outBytes), int64(len(fooMsg)*2+len(barMsg)*2))
+	require_True(t, atomic.LoadInt64(&s1.outMsgs) >= 4)
+	require_True(t, atomic.LoadInt64(&s1.outBytes) >= int64(len(fooMsg)*2+len(barMsg)*2))
+	require_True(t, atomic.LoadInt64(&s2.outMsgs) >= 4)
+	require_True(t, atomic.LoadInt64(&s2.outBytes) >= int64(len(fooMsg)*2+len(barMsg)*2))
 
-	// in/out ClientMsgs/Bytes only count client messages
+	// In/out ClientMsgs/Bytes only count client messages.
 	require_Equal(t, atomic.LoadInt64(&s1.inClientMsgs), 2)
 	require_Equal(t, atomic.LoadInt64(&s1.inClientBytes), int64(len(fooMsg)+len(barMsg)))
 	require_Equal(t, atomic.LoadInt64(&s2.inClientMsgs), 2)
@@ -4352,19 +4364,29 @@ func TestClientMsgsMetric(t *testing.T) {
 	require_Equal(t, atomic.LoadInt64(&s2.outClientMsgs), 2)
 	require_Equal(t, atomic.LoadInt64(&s2.outClientBytes), int64(len(fooMsg)+len(barMsg)))
 
+	// Now test that messages delivered as part of queue subscriptions are counted correctly
 	natsQueueSub(t, ncS1, "orders.new", "workers", func(m *nats.Msg) { m.Respond(m.Data) })
 	natsQueueSub(t, ncS2, "orders.new", "workers", func(m *nats.Msg) { m.Respond(m.Data) })
 	ncS1.Flush()
 	ncS2.Flush()
 
 	orderMsg := "order"
-	_, err = ncS1.Request("orders.new", []byte(orderMsg), 3*time.Second)
+	_, err = ncS1.Request("orders.new", []byte(orderMsg), 5*time.Second)
 	if err != nil {
 		t.Fatalf("Error on receiving: %v", err)
 	}
-	ncS1.Flush()
-	ncS2.Flush()
+	err = ncS1.Flush()
+	if err != nil {
+		t.Fatalf("Error on flushing connection: %v", err)
+	}
+	err = ncS2.Flush()
+	if err != nil {
+		t.Fatalf("Error on flushing connection: %v", err)
+	}
 
+	// We do not know which client the message will be routed to, so check both cases.
+	// If the queue subscriber on S1 receives the message, S1 will send total 4 client messages:
+	// 2 messages from previous step, qsub message, and echo reply.
 	if atomic.LoadInt64(&s1.outClientMsgs) == 4 {
 		require_Equal(t, atomic.LoadInt64(&s2.outClientMsgs), 2)
 
@@ -4374,6 +4396,7 @@ func TestClientMsgsMetric(t *testing.T) {
 		require_Equal(t, atomic.LoadInt64(&s2.outClientBytes),
 			int64(len(fooMsg)+len(barMsg)))
 
+		// If message received by S2, both servers will have 3 messages total.
 	} else if atomic.LoadInt64(&s1.outClientMsgs) == 3 {
 		require_Equal(t, atomic.LoadInt64(&s2.outClientMsgs), 3)
 

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -4289,3 +4289,55 @@ func TestClientRepeatConnectSwitchesAccountAndCleansOldSubs(t *testing.T) {
 		})
 	}
 }
+
+func TestClientMsgsMetric(t *testing.T) {
+	o1 := DefaultOptions()
+	s1 := RunServer(o1)
+	defer s1.Shutdown()
+
+	o2 := DefaultOptions()
+	o2.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", o1.Cluster.Port))
+	s2 := RunServer(o2)
+	defer s2.Shutdown()
+
+	checkClusterFormed(t, s1, s2)
+
+	nc1 := natsConnect(t, s1.ClientURL())
+	defer nc1.Close()
+
+	nc2 := natsConnect(t, s2.ClientURL())
+	defer nc1.Close()
+
+	natsSub(t, nc1, "foo", func(m *nats.Msg) {
+		m.Respond(m.Data)
+	})
+	natsSub(t, nc2, "bar", func(m *nats.Msg) {
+		m.Respond(m.Data)
+	})
+	nc1.Flush()
+	nc2.Flush()
+
+	_, err := nc2.Request("foo", []byte("6bytes"), 3*time.Second)
+	if err != nil {
+		t.Fatalf("Error on receiving: %v", err)
+	}
+	_, err = nc1.Request("bar", []byte("ninebytes"), 3*time.Second)
+	if err != nil {
+		t.Fatalf("Error on receiving: %v", err)
+	}
+	nc1.Flush()
+	nc2.Flush()
+
+	// inMsgs and inBytes counts include routed messages
+	require_Equal(t, atomic.LoadInt64(&s1.inMsgs), 4)
+	require_Equal(t, atomic.LoadInt64(&s1.inBytes), 6+6+9+9)
+	require_Equal(t, atomic.LoadInt64(&s2.inMsgs), 4)
+	require_Equal(t, atomic.LoadInt64(&s2.inBytes), 6+6+9+9)
+
+	// only count messages received from clients
+	require_Equal(t, atomic.LoadInt64(&s1.inClientMsgs), 2)
+	require_Equal(t, atomic.LoadInt64(&s1.inClientBytes), 6+9)
+	require_Equal(t, atomic.LoadInt64(&s2.inClientMsgs), 2)
+	require_Equal(t, atomic.LoadInt64(&s2.inClientBytes), 6+9)
+
+}

--- a/server/events.go
+++ b/server/events.go
@@ -374,6 +374,7 @@ type ServerStats struct {
 	ActiveAccounts       int                   `json:"active_accounts"`
 	NumSubs              uint32                `json:"subscriptions"`
 	Sent                 DataStats             `json:"sent"`
+	SentToClients        DataStats             `json:"sent_to_clients"`
 	Received             DataStats             `json:"received"`
 	ReceivedFromClients  DataStats             `json:"received_from_clients"`
 	SlowConsumers        int64                 `json:"slow_consumers"`
@@ -953,6 +954,8 @@ func (s *Server) sendStatsz(subj string) {
 	m.Stats.ReceivedFromClients.Bytes = atomic.LoadInt64(&s.inClientBytes)
 	m.Stats.Sent.Msgs = atomic.LoadInt64(&s.outMsgs)
 	m.Stats.Sent.Bytes = atomic.LoadInt64(&s.outBytes)
+	m.Stats.SentToClients.Msgs = atomic.LoadInt64(&s.outClientMsgs)
+	m.Stats.SentToClients.Bytes = atomic.LoadInt64(&s.outClientBytes)
 	m.Stats.SlowConsumers = atomic.LoadInt64(&s.slowConsumers)
 	// Evaluate the slow consumer stats, but set it only if one of the value is not 0.
 	scs := &SlowConsumersStats{

--- a/server/events.go
+++ b/server/events.go
@@ -375,6 +375,7 @@ type ServerStats struct {
 	NumSubs              uint32                `json:"subscriptions"`
 	Sent                 DataStats             `json:"sent"`
 	Received             DataStats             `json:"received"`
+	ReceivedFromClients  DataStats             `json:"received_from_clients"`
 	SlowConsumers        int64                 `json:"slow_consumers"`
 	SlowConsumersStats   *SlowConsumersStats   `json:"slow_consumer_stats,omitempty"`
 	StaleConnections     int64                 `json:"stale_connections,omitempty"`
@@ -948,6 +949,8 @@ func (s *Server) sendStatsz(subj string) {
 	m.Stats.ActiveAccounts = int(atomic.LoadInt32(&s.activeAccounts))
 	m.Stats.Received.Msgs = atomic.LoadInt64(&s.inMsgs)
 	m.Stats.Received.Bytes = atomic.LoadInt64(&s.inBytes)
+	m.Stats.ReceivedFromClients.Msgs = atomic.LoadInt64(&s.inClientMsgs)
+	m.Stats.ReceivedFromClients.Bytes = atomic.LoadInt64(&s.inClientBytes)
 	m.Stats.Sent.Msgs = atomic.LoadInt64(&s.outMsgs)
 	m.Stats.Sent.Bytes = atomic.LoadInt64(&s.outBytes)
 	m.Stats.SlowConsumers = atomic.LoadInt64(&s.slowConsumers)

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1885,6 +1885,13 @@ func TestServerEventsStatsZ(t *testing.T) {
 	if m.Stats.Received.Msgs < 1 {
 		t.Fatalf("Did not match received msgs of >=1, got %d", m.Stats.Received.Msgs)
 	}
+	if m.Stats.ReceivedFromClients.Msgs != 1 {
+		t.Fatalf("Did not match received from client msgs of 1, got %d", m.Stats.ReceivedFromClients.Msgs)
+	}
+	if m.Stats.ReceivedFromClients.Bytes != 11 {
+		t.Fatalf("Did not match received from client bytes of 11, got %d", m.Stats.ReceivedFromClients.Bytes)
+	}
+
 	// Default pool size + 1 for system account
 	expectedRoutes := DEFAULT_ROUTE_POOL_SIZE + 1
 	if lr := len(m.Stats.Routes); lr != expectedRoutes {

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -1885,11 +1885,17 @@ func TestServerEventsStatsZ(t *testing.T) {
 	if m.Stats.Received.Msgs < 1 {
 		t.Fatalf("Did not match received msgs of >=1, got %d", m.Stats.Received.Msgs)
 	}
-	if m.Stats.ReceivedFromClients.Msgs != 1 {
-		t.Fatalf("Did not match received from client msgs of 1, got %d", m.Stats.ReceivedFromClients.Msgs)
+	if m.Stats.ReceivedFromClients.Msgs < 1 {
+		t.Fatalf("Did not match received from client msgs of >=1, got %d", m.Stats.ReceivedFromClients.Msgs)
 	}
-	if m.Stats.ReceivedFromClients.Bytes != 11 {
-		t.Fatalf("Did not match received from client bytes of 11, got %d", m.Stats.ReceivedFromClients.Bytes)
+	if m.Stats.ReceivedFromClients.Bytes < 1 {
+		t.Fatalf("Did not match received from client bytes of >=1, got %d", m.Stats.ReceivedFromClients.Bytes)
+	}
+	if m.Stats.SentToClients.Msgs < 1 {
+		t.Fatalf("Did not match sent to client msgs of >= 1, got %d", m.Stats.SentToClients.Msgs)
+	}
+	if m.Stats.SentToClients.Bytes < 1 {
+		t.Fatalf("Did not match sent to client bytes of >= 1, got %d", m.Stats.SentToClients.Bytes)
 	}
 
 	// Default pool size + 1 for system account

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1271,12 +1271,14 @@ type Varz struct {
 	Routes                int                    `json:"routes"`                            // Routes is the number of connected route servers
 	Remotes               int                    `json:"remotes"`                           // Remotes is the configured route remote endpoints
 	Leafs                 int                    `json:"leafnodes"`                         // Leafs is the number connected leafnode clients
-	InMsgs                int64                  `json:"in_msgs"`                           // InMsgs is the total number of messages this server received. This includes messages from the clients, routers, gateways and leaf nodes.
-	OutMsgs               int64                  `json:"out_msgs"`                          // OutMsgs is the number of message this server sent
-	InBytes               int64                  `json:"in_bytes"`                          // InBytes is the total number of bytes this server received. This includes messages from the clients, routers, gateways and leaf nodes.
-	OutBytes              int64                  `json:"out_bytes"`                         // OutMsgs is the number of bytes this server sent
+	InMsgs                int64                  `json:"in_msgs"`                           // InMsgs is the total number of messages this server received. This includes messages from the clients, routers, gateways and leaf nodes
+	InBytes               int64                  `json:"in_bytes"`                          // InBytes is the total number of bytes this server received. This includes messages from the clients, routers, gateways and leaf nodes
 	InClientMsgs          int64                  `json:"in_client_msgs"`                    // InClientMsgs is the number of messages this server received from the clients
 	InClientBytes         int64                  `json:"in_client_bytes"`                   // InClientBytes is the number of bytes this server received from the clients
+	OutMsgs               int64                  `json:"out_msgs"`                          // OutMsgs is the total number of message this server sent. This includes messages sent to the clients, routers, gateways and leaf nodes
+	OutBytes              int64                  `json:"out_bytes"`                         // OutBytes is the total number of bytes this server sent. This includes messages sent to the clients, routers, gateways and leaf nodes
+	OutClientMsgs         int64                  `json:"out_client_msgs"`                   // OutClientMsgs is the number of messages this server sent to the clients
+	OutClientBytes        int64                  `json:"out_client_bytes"`                  // OutClientBytes is the number of bytes this server sent to the clients
 	SlowConsumers         int64                  `json:"slow_consumers"`                    // SlowConsumers is the total count of clients that were disconnected since start due to being slow consumers
 	StaleConnections      int64                  `json:"stale_connections"`                 // StaleConnections is the total count of stale connections that were detected
 	StalledClients        int64                  `json:"stalled_clients"`                   // StalledClients is the total number of times that clients have been stalled.
@@ -1876,11 +1878,13 @@ func (s *Server) updateVarzRuntimeFields(v *Varz, forceUpdate bool, pcpu float64
 	v.Remotes = s.numRemotes()
 	v.Leafs = len(s.leafs)
 	v.InMsgs = atomic.LoadInt64(&s.inMsgs)
-	v.InClientMsgs = atomic.LoadInt64(&s.inClientMsgs)
 	v.InBytes = atomic.LoadInt64(&s.inBytes)
-	v.InClientBytes = atomic.LoadInt64(&s.inClientBytes)
 	v.OutMsgs = atomic.LoadInt64(&s.outMsgs)
 	v.OutBytes = atomic.LoadInt64(&s.outBytes)
+	v.InClientMsgs = atomic.LoadInt64(&s.inClientMsgs)
+	v.InClientBytes = atomic.LoadInt64(&s.inClientBytes)
+	v.OutClientMsgs = atomic.LoadInt64(&s.outClientMsgs)
+	v.OutClientBytes = atomic.LoadInt64(&s.outClientBytes)
 	v.SlowConsumers = atomic.LoadInt64(&s.slowConsumers)
 	v.StalledClients = atomic.LoadInt64(&s.stalls)
 	v.SlowConsumersStats = &SlowConsumersStats{

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1271,10 +1271,12 @@ type Varz struct {
 	Routes                int                    `json:"routes"`                            // Routes is the number of connected route servers
 	Remotes               int                    `json:"remotes"`                           // Remotes is the configured route remote endpoints
 	Leafs                 int                    `json:"leafnodes"`                         // Leafs is the number connected leafnode clients
-	InMsgs                int64                  `json:"in_msgs"`                           // InMsgs is the number of messages this server received
+	InMsgs                int64                  `json:"in_msgs"`                           // InMsgs is the total number of messages this server received. This includes messages from the clients, routers, gateways and leaf nodes.
 	OutMsgs               int64                  `json:"out_msgs"`                          // OutMsgs is the number of message this server sent
-	InBytes               int64                  `json:"in_bytes"`                          // InBytes is the number of bytes this server received
+	InBytes               int64                  `json:"in_bytes"`                          // InBytes is the total number of bytes this server received. This includes messages from the clients, routers, gateways and leaf nodes.
 	OutBytes              int64                  `json:"out_bytes"`                         // OutMsgs is the number of bytes this server sent
+	InClientMsgs          int64                  `json:"in_client_msgs"`                    // InClientMsgs is the number of messages this server received from the clients
+	InClientBytes         int64                  `json:"in_client_bytes"`                   // InClientBytes is the number of bytes this server received from the clients
 	SlowConsumers         int64                  `json:"slow_consumers"`                    // SlowConsumers is the total count of clients that were disconnected since start due to being slow consumers
 	StaleConnections      int64                  `json:"stale_connections"`                 // StaleConnections is the total count of stale connections that were detected
 	StalledClients        int64                  `json:"stalled_clients"`                   // StalledClients is the total number of times that clients have been stalled.
@@ -1874,7 +1876,9 @@ func (s *Server) updateVarzRuntimeFields(v *Varz, forceUpdate bool, pcpu float64
 	v.Remotes = s.numRemotes()
 	v.Leafs = len(s.leafs)
 	v.InMsgs = atomic.LoadInt64(&s.inMsgs)
+	v.InClientMsgs = atomic.LoadInt64(&s.inClientMsgs)
 	v.InBytes = atomic.LoadInt64(&s.inBytes)
+	v.InClientBytes = atomic.LoadInt64(&s.inClientBytes)
 	v.OutMsgs = atomic.LoadInt64(&s.outMsgs)
 	v.OutBytes = atomic.LoadInt64(&s.outBytes)
 	v.SlowConsumers = atomic.LoadInt64(&s.slowConsumers)

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -307,20 +307,26 @@ func TestMonitorHandleVarz(t *testing.T) {
 		if v.InMsgs != 1 {
 			t.Fatalf("Expected InMsgs of 1, got %v\n", v.InMsgs)
 		}
-		if v.InClientMsgs != 1 {
-			t.Fatalf("Expected InClientMsgs of 1, got %v\n", v.InClientMsgs)
+		if v.InBytes != 5 {
+			t.Fatalf("Expected InBytes of 5, got %v\n", v.InBytes)
 		}
 		if v.OutMsgs != 1 {
 			t.Fatalf("Expected OutMsgs of 1, got %v\n", v.OutMsgs)
 		}
-		if v.InBytes != 5 {
-			t.Fatalf("Expected InBytes of 5, got %v\n", v.InBytes)
+		if v.OutBytes != 5 {
+			t.Fatalf("Expected OutBytes of 5, got %v\n", v.OutBytes)
+		}
+		if v.InClientMsgs != 1 {
+			t.Fatalf("Expected InClientMsgs of 1, got %v\n", v.InClientMsgs)
 		}
 		if v.InClientBytes != 5 {
 			t.Fatalf("Expected InClientBytes of 5, got %v\n", v.InClientBytes)
 		}
-		if v.OutBytes != 5 {
-			t.Fatalf("Expected OutBytes of 5, got %v\n", v.OutBytes)
+		if v.OutClientMsgs != 1 {
+			t.Fatalf("Expected OutClientMsgs of 1, got %v\n", v.OutClientMsgs)
+		}
+		if v.OutClientBytes != 5 {
+			t.Fatalf("Expected OutClientBytes of 5, got %v\n", v.OutClientBytes)
 		}
 		if v.Subscriptions <= 10 {
 			t.Fatalf("Expected Subscriptions of at least 10, got %v\n", v.Subscriptions)

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -307,11 +307,17 @@ func TestMonitorHandleVarz(t *testing.T) {
 		if v.InMsgs != 1 {
 			t.Fatalf("Expected InMsgs of 1, got %v\n", v.InMsgs)
 		}
+		if v.InClientMsgs != 1 {
+			t.Fatalf("Expected InClientMsgs of 1, got %v\n", v.InClientMsgs)
+		}
 		if v.OutMsgs != 1 {
 			t.Fatalf("Expected OutMsgs of 1, got %v\n", v.OutMsgs)
 		}
 		if v.InBytes != 5 {
 			t.Fatalf("Expected InBytes of 5, got %v\n", v.InBytes)
+		}
+		if v.InClientBytes != 5 {
+			t.Fatalf("Expected InClientBytes of 5, got %v\n", v.InClientBytes)
 		}
 		if v.OutBytes != 5 {
 			t.Fatalf("Expected OutBytes of 5, got %v\n", v.OutBytes)

--- a/server/server.go
+++ b/server/server.go
@@ -403,10 +403,10 @@ type nodeInfo struct {
 type stats struct {
 	inMsgs           int64
 	inBytes          int64
-	outMsgs          int64
-	outBytes         int64
 	inClientMsgs     int64
 	inClientBytes    int64
+	outMsgs          int64
+	outBytes         int64
 	outClientMsgs    int64
 	outClientBytes   int64
 	slowConsumers    int64

--- a/server/server.go
+++ b/server/server.go
@@ -405,6 +405,8 @@ type stats struct {
 	outMsgs          int64
 	inBytes          int64
 	outBytes         int64
+	inClientMsgs     int64
+	inClientBytes    int64
 	slowConsumers    int64
 	staleConnections int64
 	stalls           int64

--- a/server/server.go
+++ b/server/server.go
@@ -402,11 +402,13 @@ type nodeInfo struct {
 
 type stats struct {
 	inMsgs           int64
-	outMsgs          int64
 	inBytes          int64
+	outMsgs          int64
 	outBytes         int64
 	inClientMsgs     int64
 	inClientBytes    int64
+	outClientMsgs    int64
+	outClientBytes   int64
 	slowConsumers    int64
 	staleConnections int64
 	stalls           int64


### PR DESCRIPTION
Existing In/Out Msgs/Bytes metrics account for traffic from clients, routes, leafnodes and gateways.
So it is hard to see how actual offered load and what is sent to clients changes over time.

Add new metrics that only counts messages from and to clients.

On this Surveyor dashboard screenshot, I was publishing to s1 and subscribing on s3.
Old and new graphs show different picture:
<img width="915" height="1572" alt="image" src="https://github.com/user-attachments/assets/0e2bbf00-e396-40e9-96fc-6b16d51a9076" />

And here is an example of values in /varz:
```
curl -Ss http://localhost:8222/varz http://localhost:8223/varz http://localhost:8224/varz | jq    '{server: .server_name,  in_msgs: .in_msgs, in_bytes: .in_bytes, in_client_msgs: .in_client_msgs,  in_client_bytes: .in_client_bytes, out_msgs: .out_msgs,    out_bytes: .out_bytes, out_client_msgs: .out_client_msgs, out_client_bytes: .out_client_bytes }'
{
  "server": "s1",
  "in_msgs": 10000152,
  "in_bytes": 1280031039,
  "in_client_msgs": 10000000,
  "in_client_bytes": 1280000000,
  "out_msgs": 8451913,
  "out_bytes": 1081861183,
  "out_client_msgs": 0,
  "out_client_bytes": 0
}
{
  "server": "s2",
  "in_msgs": 107,
  "in_bytes": 33648,
  "in_client_msgs": 0,
  "in_client_bytes": 0,
  "out_msgs": 98,
  "out_bytes": 29726,
  "out_client_msgs": 0,
  "out_client_bytes": 0
}
{
  "server": "s3",
  "in_msgs": 8451882,
  "in_bytes": 1081857677,
  "in_client_msgs": 0,
  "in_client_bytes": 0,
  "out_msgs": 8451885,
  "out_bytes": 1081856095,
  "out_client_msgs": 8451755,
  "out_client_bytes": 1081824640
}
```

Signed-off-by: Alex Bozhenko <alexbozhenko@gmail.com>
