### PR TITLE
(2.14) [IMPROVED] NRG: Step down/pause quorum if we're being overrun

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -4111,6 +4111,8 @@ type RaftzGroup struct {
 	QuorumNeeded  int                       `json:"quorum_needed"`
 	Observer      bool                      `json:"observer,omitempty"`
 	Paused        bool                      `json:"paused,omitempty"`
+	Overrun       bool                      `json:"overrun,omitempty"`
+	OverrunCount  uint64                    `json:"overrun_count,omitempty"`
 	Committed     uint64                    `json:"committed"`
 	Applied       uint64                    `json:"applied"`
 	CatchingUp    bool                      `json:"catching_up,omitempty"`
@@ -4219,6 +4221,8 @@ func (s *Server) Raftz(opts *RaftzOptions) *RaftzStatus {
 			QuorumNeeded:  n.qn,
 			Observer:      n.observer,
 			Paused:        n.paused,
+			Overrun:       n.quorumPaused || n.isLeaderOverrun(),
+			OverrunCount:  n.overrunCount,
 			Committed:     n.commit,
 			Applied:       n.applied,
 			CatchingUp:    n.catchup != nil,

--- a/server/raft.go
+++ b/server/raft.go
@@ -249,6 +249,9 @@ type raft struct {
 	scaleUp      bool // The node is part of a scale up, puts us in observer mode until the log contains data.
 	deleted      bool // If the node was deleted.
 	snapshotting bool // Snapshot is in progress.
+	quorumPaused bool // Pause replication and quorum participation to prevent log growth during slow applies.
+
+	overrunCount uint64 // Counter of how many times we were overrun, either as follower or as leader.
 }
 
 type proposedEntry struct {
@@ -920,6 +923,16 @@ func (n *raft) Propose(data []byte) error {
 	if werr := n.werr; werr != nil {
 		return werr
 	}
+
+	if n.isLeaderOverrun() {
+		var state StreamState
+		n.wal.FastState(&state)
+		n.warn("Leader falling behind, stepping down: pindex %d, commit %d, applied %d, WAL size %s", n.pindex, n.commit, n.applied, friendlyBytes(state.Bytes))
+		// Stepdown without leader transfer, likely all replicas will be overrun, and we need time to recover.
+		n.stepdownLocked(noLeader)
+		n.overrunCount++
+		return errNotLeader
+	}
 	n.prop.push(newProposedEntry(newEntry(EntryNormal, data), _EMPTY_))
 	return nil
 }
@@ -939,10 +952,37 @@ func (n *raft) ProposeMulti(entries []*Entry) error {
 	if werr := n.werr; werr != nil {
 		return werr
 	}
+
+	if n.isLeaderOverrun() {
+		var state StreamState
+		n.wal.FastState(&state)
+		n.warn("Leader falling behind, stepping down: pindex %d, commit %d, applied %d, WAL size %s", n.pindex, n.commit, n.applied, friendlyBytes(state.Bytes))
+		// Stepdown without leader transfer, likely all replicas will be overrun, and we need time to recover.
+		n.stepdownLocked(noLeader)
+		n.overrunCount++
+		return errNotLeader
+	}
 	for _, e := range entries {
 		n.prop.push(newProposedEntry(e, _EMPTY_))
 	}
 	return nil
+}
+
+// isLeaderOverrun returns whether we are overrun and should step down due to continuously increasing
+// uncommitted or unapplied entries. If triggered, this means we're being severely overrun by
+// incoming proposals or the system is degraded such that it's too slow (or unable) to process them.
+// Stepping down means the system gets to "breathe" for a bit, until a new leader can be elected.
+// Lock should be held.
+func (n *raft) isLeaderOverrun() bool {
+	applied := max(n.applied, n.papplied)
+	commit := max(n.commit, n.papplied)
+	// We only do this past a high threshold to protect ourselves.
+	// Worst-case we'll have 2x the threshold, once in uncommitted and once in unapplied entries.
+	// Either the number of uncommitted entries is over the threshold: we're not getting quorum from our followers.
+	uncommittedThreshold := n.pindex > commit && n.pindex-commit > pauseQuorumThreshold
+	// Or, the number of in-memory committed but not yet applied entries is over the threshold: we're slow to apply.
+	unappliedThreshold := commit > applied && commit-applied > pauseQuorumThreshold
+	return uncommittedThreshold || unappliedThreshold
 }
 
 // ForwardProposal will forward the proposal to the leader if known.
@@ -2877,22 +2917,29 @@ func (n *raft) handleForwardedProposal(sub *subscription, c *client, _ *Account,
 	// Need to copy since this is underlying client/route buffer.
 	msg = copyBytes(msg)
 
-	n.RLock()
+	n.Lock()
+	defer n.Unlock()
 	// Check state under lock, we might not be leader anymore.
 	if n.State() != Leader || !n.leaderState.Load() {
 		n.debug("Ignoring forwarded proposal, not leader")
-		n.RUnlock()
 		return
 	}
-	prop, werr := n.prop, n.werr
-	n.RUnlock()
 
 	// Ignore if we have had a write error previous.
-	if werr != nil {
+	if n.werr != nil {
 		return
 	}
 
-	prop.push(newProposedEntry(newEntry(EntryNormal, msg), reply))
+	if n.isLeaderOverrun() {
+		var state StreamState
+		n.wal.FastState(&state)
+		n.warn("Leader falling behind, stepping down: pindex %d, commit %d, applied %d, WAL size %s", n.pindex, n.commit, n.applied, friendlyBytes(state.Bytes))
+		// Stepdown without leader transfer, likely all replicas will be overrun, and we need time to recover.
+		n.stepdownLocked(noLeader)
+		n.overrunCount++
+		return
+	}
+	n.prop.push(newProposedEntry(newEntry(EntryNormal, msg), reply))
 }
 
 // Adds peer with the given id to our membership,
@@ -4050,6 +4097,36 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 		}
 	}
 
+	// If commits are outpacing our applies, temporarily stop accepting new entries to avoid falling further behind.
+	// This encourages the leader to sync us via a snapshot instead. We use max(applied, papplied) to avoid
+	// incorrectly triggering this pause immediately after receiving a snapshot.
+	applied := max(n.applied, n.papplied)
+	commit := max(n.commit, n.papplied)
+	if sub != nil && (commit > applied || n.quorumPaused) {
+		diff := commit - applied
+		if n.quorumPaused {
+			if diff > paeWarnThreshold {
+				n.Unlock()
+				return
+			}
+			// Once we're sufficiently below the threshold, we continue again. We'll likely receive a snapshot
+			// from the leader.
+			n.quorumPaused = false
+			var state StreamState
+			n.wal.FastState(&state)
+			n.warn("Quorum resumed: commit %d, applied %d, WAL size %s", commit, applied, friendlyBytes(state.Bytes))
+		} else if diff > pauseQuorumThreshold {
+			// It takes a while until we reach the pause threshold, but once we do we enter a "cooldown period".
+			n.quorumPaused = true
+			n.overrunCount++
+			var state StreamState
+			n.wal.FastState(&state)
+			n.warn("Quorum paused, falling behind: commit %d != applied %d, WAL size %s", commit, applied, friendlyBytes(state.Bytes))
+			n.Unlock()
+			return
+		}
+	}
+
 	if ae.pterm != n.pterm || ae.pindex != n.pindex {
 		// Check if this is a lower or equal index than what we were expecting.
 		if ae.pindex <= n.pindex {
@@ -4429,9 +4506,10 @@ func (n *raft) storeToWAL(ae *appendEntry) error {
 }
 
 const (
-	paeDropThreshold = 20_000
-	paeWarnThreshold = 10_000
-	paeWarnModulo    = 5_000
+	pauseQuorumThreshold = 100_000
+	paeDropThreshold     = 20_000
+	paeWarnThreshold     = 10_000
+	paeWarnModulo        = 5_000
 )
 
 func (n *raft) sendAppendEntry(entries []*Entry) {
@@ -5056,6 +5134,8 @@ func (n *raft) switchToCandidate() {
 	// Increment the term.
 	n.term++
 	n.vote = noVote
+	// Reset quorum paused. If it was previously set, we checked above that we've applied all committed entries.
+	n.quorumPaused = false
 	// Clear current Leader.
 	n.updateLeader(noLeader)
 	n.switchState(Candidate)

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -5509,3 +5509,170 @@ func TestNRGOnlyCommitIfCurrentTerm(t *testing.T) {
 	n.processAppendEntryResponse(&appendEntryResponse{term: 4, index: 3, peer: s2, success: true})
 	require_Equal(t, n.commit, 3)
 }
+
+func TestNRGLeaderStepsDownIfOverrun(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// Proposals are only accepted if we're the leader.
+	require_Error(t, n.Propose(nil), errNotLeader)
+	require_Error(t, n.ProposeMulti(nil), errNotLeader)
+
+	n.switchToLeader()
+	require_NoError(t, n.Propose(nil))
+	require_NoError(t, n.ProposeMulti(nil))
+	require_Equal(t, n.State(), Leader)
+
+	// Too many uncommitted entries in our log.
+	t.Run("Uncommitted", func(t *testing.T) {
+		n.state.Store(int32(Leader))
+
+		// Proposing while we're exactly at the threshold still succeeds.
+		n.pindex, n.commit, n.applied = pauseQuorumThreshold, 0, 0
+		require_NoError(t, n.Propose(nil))
+		require_NoError(t, n.ProposeMulti(nil))
+		require_Equal(t, n.State(), Leader)
+
+		// While we're over the threshold, we temporarily don't send proposals.
+		n.pindex, n.commit, n.applied = pauseQuorumThreshold+1, 0, 0
+		require_Error(t, n.Propose(nil), errNotLeader)
+		require_Equal(t, n.State(), Follower)
+
+		n.state.Store(int32(Leader))
+		require_Error(t, n.ProposeMulti(nil), errNotLeader)
+		require_Equal(t, n.State(), Follower)
+	})
+
+	// Too many unapplied entries in our log and in-memory.
+	t.Run("Unapplied", func(t *testing.T) {
+		n.state.Store(int32(Leader))
+
+		// Proposing while we're exactly at the threshold still succeeds.
+		n.pindex, n.commit, n.applied = pauseQuorumThreshold, pauseQuorumThreshold, 0
+		require_NoError(t, n.Propose(nil))
+		require_NoError(t, n.ProposeMulti(nil))
+		require_Equal(t, n.State(), Leader)
+
+		// While we're over the threshold, we temporarily don't send proposals.
+		n.pindex, n.commit, n.applied = pauseQuorumThreshold+1, pauseQuorumThreshold+1, 0
+		require_Error(t, n.Propose(nil), errNotLeader)
+		require_Equal(t, n.State(), Follower)
+
+		n.state.Store(int32(Leader))
+		require_Error(t, n.ProposeMulti(nil), errNotLeader)
+		require_Equal(t, n.State(), Follower)
+	})
+}
+
+func TestNRGFollowerPausesQuorumIfOverrun(t *testing.T) {
+	test := func(t *testing.T, new bool) {
+		n, cleanup := initSingleMemRaftNode(t)
+		defer cleanup()
+
+		aeReply := "$TEST"
+		nc, err := nats.Connect(n.s.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+		require_NoError(t, err)
+		defer nc.Close()
+
+		sub, err := nc.SubscribeSync(aeReply)
+		require_NoError(t, err)
+		defer sub.Drain()
+		require_NoError(t, nc.Flush())
+
+		// Timeline
+		nats0 := "S1Nunr6R" // "nats-0"
+		aeHeartbeat := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: nil, reply: aeReply})
+
+		aesub := n.aesub
+		if !new {
+			aesub = nil
+		}
+
+		n.processAppendEntry(aeHeartbeat, aesub)
+		msg, err := sub.NextMsg(200 * time.Millisecond)
+		if new {
+			require_NoError(t, err)
+			ar := decodeAppendEntryResponse(msg.Data)
+			require_True(t, ar.success)
+			require_Equal(t, msg.Reply, _EMPTY_)
+		} else {
+			require_Error(t, err, nats.ErrTimeout)
+		}
+
+		// Processing while we're exactly at the threshold still succeeds.
+		n.commit, n.applied = pauseQuorumThreshold, 0
+		n.processAppendEntry(aeHeartbeat, aesub)
+		msg, err = sub.NextMsg(200 * time.Millisecond)
+		if new {
+			require_NoError(t, err)
+			ar := decodeAppendEntryResponse(msg.Data)
+			require_True(t, ar.success)
+			require_Equal(t, msg.Reply, _EMPTY_)
+		} else {
+			require_Error(t, err, nats.ErrTimeout)
+		}
+
+		// When we're over the threshold, we pause processing until we're sufficiently below it again.
+		n.commit, n.applied = pauseQuorumThreshold+1, 0
+		n.processAppendEntry(aeHeartbeat, aesub)
+		_, err = sub.NextMsg(200 * time.Millisecond)
+		require_Error(t, err, nats.ErrTimeout)
+		require_Equal(t, n.quorumPaused, new)
+
+		// Confirm we remain paused while we're almost at the unpause threshold.
+		n.applied = n.commit - paeWarnThreshold - 1
+		n.processAppendEntry(aeHeartbeat, aesub)
+		_, err = sub.NextMsg(200 * time.Millisecond)
+		require_Error(t, err, nats.ErrTimeout)
+		require_Equal(t, n.quorumPaused, new)
+
+		// Once we're at the lower threshold, we should be unpaused and accept new entries again.
+		// Afterward we'd likely catch up from a snapshot instead of normal append entries.
+		n.applied = n.commit - paeWarnThreshold
+		n.processAppendEntry(aeHeartbeat, aesub)
+		require_False(t, n.quorumPaused)
+
+		msg, err = sub.NextMsg(200 * time.Millisecond)
+		if new {
+			require_NoError(t, err)
+			ar := decodeAppendEntryResponse(msg.Data)
+			require_True(t, ar.success)
+			require_Equal(t, msg.Reply, _EMPTY_)
+		} else {
+			require_Error(t, err, nats.ErrTimeout)
+		}
+
+		if new {
+			// Guard against an underflow. We should unpause shortly after snapshot install.
+			n.quorumPaused = true
+			n.applied, n.papplied = paeWarnThreshold, paeWarnThreshold
+			n.commit = 0
+			n.processAppendEntry(aeHeartbeat, aesub)
+			require_False(t, n.quorumPaused)
+
+			msg, err = sub.NextMsg(200 * time.Millisecond)
+			require_NoError(t, err)
+			ar := decodeAppendEntryResponse(msg.Data)
+			require_True(t, ar.success)
+			require_Equal(t, msg.Reply, _EMPTY_)
+		}
+	}
+
+	t.Run("Replay", func(t *testing.T) { test(t, false) })
+	t.Run("New", func(t *testing.T) { test(t, true) })
+}
+
+func TestNRGSwitchToCandidateResetsQuorumPaused(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// Manually set the quorumPaused flag as if the follower was overrun.
+	n.quorumPaused = true
+	require_Equal(t, n.term, 0)
+
+	// Switching to a candidate has a similar prerequisite to check all committed entries
+	// have been applied. We can therefore reset quorumPaused.
+	n.switchToCandidate()
+	require_Equal(t, n.term, 1)
+	require_False(t, n.quorumPaused)
+}


### PR DESCRIPTION
This PR adds a protective measure to ensure we can guard against unbounded WAL growth. Currently, overloaded servers could see their meta log (or any replicated stream/consumer log) grow well over several GBs, eventually requiring the log to be manually deleted on the server in order to recover.
- The leader will step down if it has reached a certain threshold of uncommitted and unapplied entries. We already wait to apply all entries in the log before we signal we're the leader to the upper-layer, so this has no impact during leader changes. This protection ensures once we're leader we're not being spammed with proposals faster than we can commit and apply them.
- The followers will store entries in their logs before the leader can mark them as having quorum/being committed. If a follower is slower to apply entries than the leader can make it add new entries and mark them as committed, the WAL on this follower will grow unbounded. And since all to-be-applied entries are pushed into the apply queue, this eventually makes the server go OOM. This protection ensures the follower will temporarily stop accepting new writes to work through the apply backlog first. This bounds the total committed but not-yet-applied entries. Allowing the follower to be caught up by the leader from a snapshot, instead of continuously storing new append entries and indefinitely growing its log.

The threshold is reasonably high. We keep incoming append entries cached in `n.pae` and this starts logging a warning at `paeWarnThreshold: 10k` and eventually caps the cache size at `paeDropThreshold: 20k` at which point new entries aren't cached and need to be loaded from disk instead when they are committed. Both the above protective measures only kick in when going over `pauseQuorumThreshold: 100k` append entries that haven't gotten quorum on the leader, or that have been committed but not yet applied on the follower. Slow followers that are not required for quorum will bound their log growth. If the leader itself is being overrun/slow we step it down. Under normal circumstances the natural flow control will ensure neither the followers nor the leader can fall behind. However, followers outside of quorum should "pause quorum" earlier than the leader steps down. The latter might help finding another server to become leader that's faster than the previous one, or the system as a whole is overloaded and we slow down to protect ourselves.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>