### PR TITLE
memstore: use matchLiteral for wildcard checks in loadNextMsgLocked

### DIFF
--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1906,7 +1906,7 @@ func (ms *memStore) loadNextMsgLocked(filter string, wc bool, start uint64, smp 
 
 	eq := subjectsEqual
 	if wc {
-		eq = subjectIsSubsetMatch
+		eq = matchLiteral
 	}
 
 	for nseq := fseq; nseq <= lseq; nseq++ {


### PR DESCRIPTION
Replace subjectIsSubsetMatch with matchLiteral in loadNextMsgLocked. The latter avoids subject tokenization and is optimized to handle the case where we want to match a literal subject against a filter with wildcards.  subjectIsSubsetMatch is a more generic matcher, where both parameters may contain subjects, which is not needed in loadNextMsgLocked.

Signed-off-by: Daniele Sciascia <daniele@nats.io>
