### PR TITLE
[IMPROVED] Single subject in FilterSubjects field

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1221,14 +1221,13 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 
 	// If we have multiple filter subjects, create a sublist which we will use
 	// in calling store.LoadNextMsgMulti.
-	if len(o.cfg.FilterSubjects) > 0 {
-		o.filters = gsl.NewSublist[struct{}]()
-		for _, filter := range o.cfg.FilterSubjects {
-			o.filters.Insert(filter, struct{}{})
-		}
-	} else {
-		// Make sure this is nil otherwise.
+	if len(o.subjf) <= 1 {
 		o.filters = nil
+	} else {
+		o.filters = gsl.NewSublist[struct{}]()
+		for _, filter := range o.subjf {
+			o.filters.Insert(filter.subject, struct{}{})
+		}
 	}
 
 	if o.store != nil && o.store.HasState() {


### PR DESCRIPTION
We would populate `o.filters` even if `FilterSubjects` has a single entry, which would make us use `LoadNextMsgMulti` versus `LoadNextMsg`. `o.updateConfig` would already correctly populate `o.subjf` and `o.filters` in the same way.

Resolves https://github.com/nats-io/nats-server/issues/7852

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>