### PR TITLE
Fix heap escape of stack array per call in processRoutedMsgArgs and others

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2916,8 +2916,7 @@ func (c *client) processLeafUnsub(arg []byte) error {
 
 func (c *client) processLeafHeaderMsgArgs(arg []byte) error {
 	// Unroll splitArgs to avoid runtime/heap issues
-	a := [MAX_MSG_ARGS][]byte{}
-	args := a[:0]
+	args := c.argsa[:0]
 	start := -1
 	for i, b := range arg {
 		switch b {
@@ -3000,8 +2999,7 @@ func (c *client) processLeafHeaderMsgArgs(arg []byte) error {
 
 func (c *client) processLeafMsgArgs(arg []byte) error {
 	// Unroll splitArgs to avoid runtime/heap issues
-	a := [MAX_MSG_ARGS][]byte{}
-	args := a[:0]
+	args := c.argsa[:0]
 	start := -1
 	for i, b := range arg {
 		switch b {

--- a/server/parser.go
+++ b/server/parser.go
@@ -32,6 +32,7 @@ type parseState struct {
 	msgBuf  []byte
 	header  http.Header // access via getHeader
 	scratch [MAX_CONTROL_LINE_SIZE]byte
+	argsa   [MAX_HMSG_ARGS + 1][]byte // pre-allocated args array to avoid per-call heap escape
 }
 
 type pubArg struct {

--- a/server/route.go
+++ b/server/route.go
@@ -181,8 +181,7 @@ func (c *client) processAccountUnsub(arg []byte) {
 // we have an origin cluster and we force header semantics.
 func (c *client) processRoutedOriginClusterMsgArgs(arg []byte) error {
 	// Unroll splitArgs to avoid runtime/heap issues
-	a := [MAX_HMSG_ARGS + 1][]byte{}
-	args := a[:0]
+	args := c.argsa[:0]
 	start := -1
 	for i, b := range arg {
 		switch b {
@@ -280,8 +279,7 @@ func (c *client) processRoutedOriginClusterMsgArgs(arg []byte) error {
 // Process an inbound HMSG specification from the remote route.
 func (c *client) processRoutedHeaderMsgArgs(arg []byte) error {
 	// Unroll splitArgs to avoid runtime/heap issues
-	a := [MAX_HMSG_ARGS][]byte{}
-	args := a[:0]
+	args := c.argsa[:0]
 	var an []byte
 	if c.kind == ROUTER {
 		if an = c.route.accName; len(an) > 0 {
@@ -377,8 +375,7 @@ func (c *client) processRoutedHeaderMsgArgs(arg []byte) error {
 // Process an inbound RMSG or LMSG specification from the remote route.
 func (c *client) processRoutedMsgArgs(arg []byte) error {
 	// Unroll splitArgs to avoid runtime/heap issues
-	a := [MAX_RMSG_ARGS][]byte{}
-	args := a[:0]
+	args := c.argsa[:0]
 	var an []byte
 	if c.kind == ROUTER {
 		if an = c.route.accName; len(an) > 0 {

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -5039,3 +5039,112 @@ func TestRouteConfigureWriteTimeoutPolicy(t *testing.T) {
 		})
 	}
 }
+
+// Benchmarks for message arg processing functions to measure heap allocations.
+// These functions parse incoming protocol messages and split arguments.
+
+func BenchmarkProcessRoutedMsgArgs(b *testing.B) {
+	// RMSG format: account subject [reply] size
+	arg := []byte("$G foo.bar _INBOX.xxx 1024")
+	c := &client{kind: ROUTER, route: &route{}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := c.processRoutedMsgArgs(arg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkProcessRoutedHeaderMsgArgs(b *testing.B) {
+	// HMSG format: account subject [reply] headerSize totalSize
+	arg := []byte("$G foo.bar 12 1024")
+	c := &client{kind: ROUTER, route: &route{}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := c.processRoutedHeaderMsgArgs(arg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkProcessRoutedOriginClusterMsgArgs(b *testing.B) {
+	// Origin cluster HMSG format: origin account subject [reply] headerSize totalSize
+	arg := []byte("ORIGIN MY_ACCOUNT foo.bar 12 345")
+	c := &client{kind: ROUTER, route: &route{}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := c.processRoutedOriginClusterMsgArgs(arg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkProcessLeafMsgArgs(b *testing.B) {
+	// LMSG format: subject [reply] size
+	arg := []byte("foo.bar _INBOX.xxx 1024")
+	c := &client{kind: LEAF}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := c.processLeafMsgArgs(arg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkProcessLeafHeaderMsgArgs(b *testing.B) {
+	// Leaf HMSG format: subject headerSize totalSize
+	arg := []byte("foo.bar 12 1024")
+	c := &client{kind: LEAF}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := c.processLeafHeaderMsgArgs(arg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Benchmarks with queue subscribers to exercise the larger arg paths.
+
+func BenchmarkProcessRoutedMsgArgs_Queues(b *testing.B) {
+	// RMSG format with queues: account subject replyIndicator reply queue1 queue2 size
+	arg := []byte("$G foo.bar + _INBOX.xxx queue1 queue2 1024")
+	c := &client{kind: ROUTER, route: &route{}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := c.processRoutedMsgArgs(arg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkProcessRoutedHeaderMsgArgs_Queues(b *testing.B) {
+	// HMSG format with queues: account subject replyIndicator reply queue1 queue2 headerSize totalSize
+	arg := []byte("$G foo.bar + _INBOX.xxx queue1 queue2 12 1024")
+	c := &client{kind: ROUTER, route: &route{}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := c.processRoutedHeaderMsgArgs(arg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkProcessLeafMsgArgs_Queues(b *testing.B) {
+	// LMSG format with queues: subject replyIndicator reply queue1 queue2 size
+	arg := []byte("foo.bar + _INBOX.xxx queue1 queue2 1024")
+	c := &client{kind: LEAF}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := c.processLeafMsgArgs(arg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
`processRoutedMsgArgs` and other similar ones were some of the top allocation sources since the stack array was escaping per call.  Keeping the array on the heap along with the parserState removes the allocs per call and boosts perf.

```
$ go test -bench='BenchmarkProcess(Routed|Leaf)' -benchmem ./server/ -run='^$' -count=10

                                     │   old.txt    │               new.txt               │
                                     │    sec/op    │   sec/op     vs base                │
ProcessRoutedMsgArgs-64                 73.01n ± 1%   35.76n ± 1%  -51.03% (p=0.000 n=10)
ProcessRoutedHeaderMsgArgs-64           75.72n ± 2%   29.78n ± 2%  -60.67% (p=0.000 n=10)
ProcessRoutedOriginClusterMsgArgs-64    85.29n ± 1%   42.98n ± 2%  -49.60% (p=0.000 n=10)
ProcessLeafMsgArgs-64                   58.00n ± 0%   30.25n ± 1%  -47.84% (p=0.000 n=10)
ProcessLeafHeaderMsgArgs-64             51.70n ± 0%   25.11n ± 1%  -51.44% (p=0.000 n=10)
ProcessRoutedMsgArgs_Queues-64         168.85n ± 1%   53.74n ± 1%  -68.17% (p=0.000 n=10)
ProcessRoutedHeaderMsgArgs_Queues-64   206.30n ± 2%   60.22n ± 2%  -70.81% (p=0.000 n=10)
ProcessLeafMsgArgs_Queues-64           131.55n ± 2%   48.04n ± 1%  -63.49% (p=0.000 n=10)
geomean                                 94.72n        39.05n       -58.78%
```


Signed-off-by: Waldemar Quevedo <wally@nats.io>
