### PR TITLE
Pool compression buffer in encodeStreamMsgAllowCompressAndBatch

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -9348,6 +9348,30 @@ func encodeStreamMsgAllowCompress(subject, reply string, hdr, msg []byte, lseq u
 // TODO(dlc) - Eventually make configurable.
 const compressThreshold = 8192 // 8k
 
+// Pool for compression scratch buffers to reduce GC pressure.
+// These are only needed transiently during S2 compression and are
+// returned to the pool immediately after use.
+var compressBufPool = sync.Pool{
+	New: func() any {
+		return &[]byte{}
+	},
+}
+
+func getCompressBuf(sz int) []byte {
+	bp := compressBufPool.Get().(*[]byte)
+	buf := *bp
+	if cap(buf) >= sz {
+		return buf[:sz]
+	}
+	// Return undersized buffer to pool, allocate a new one.
+	compressBufPool.Put(bp)
+	return make([]byte, sz)
+}
+
+func putCompressBuf(buf []byte) {
+	compressBufPool.Put(&buf)
+}
+
 // If allowed and contents over the threshold we will compress.
 func encodeStreamMsgAllowCompressAndBatch(subject, reply string, hdr, msg []byte, lseq uint64, ts int64, sourced bool, batchId string, batchSeq uint64, batchCommit bool) []byte {
 	// Clip the subject, reply, header and msgs down. Operate on
@@ -9404,17 +9428,17 @@ func encodeStreamMsgAllowCompressAndBatch(subject, reply string, hdr, msg []byte
 
 	// Check if we should compress.
 	if shouldCompress {
-		nbuf := make([]byte, s2.MaxEncodedLen(elen))
-		if opIndex > 0 {
-			copy(nbuf[:opIndex], buf[:opIndex])
-		}
-		nbuf[opIndex] = byte(compressedStreamMsgOp)
-		ebuf := s2.Encode(nbuf[opIndex+1:], buf[opIndex+1:])
+		nbuf := getCompressBuf(s2.MaxEncodedLen(elen))
+		nbuf[0] = byte(compressedStreamMsgOp)
+		ebuf := s2.Encode(nbuf[1:], buf[opIndex+1:])
 		// Only pay the cost of decode on the other side if we compressed.
 		// S2 will allow us to try without major penalty for non-compressable data.
 		if len(ebuf) < len(buf) {
-			buf = nbuf[:len(ebuf)+opIndex+1]
+			buf[opIndex] = byte(compressedStreamMsgOp)
+			copy(buf[opIndex+1:], ebuf)
+			buf = buf[:len(ebuf)+opIndex+1]
 		}
+		putCompressBuf(nbuf)
 	}
 
 	return buf

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -17,6 +17,7 @@ package server
 
 import (
 	"context"
+	crand "crypto/rand"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -37,6 +38,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nuid"
@@ -7324,6 +7326,148 @@ func TestJetStreamClusterMetaCompactSizeThreshold(t *testing.T) {
 					_, size = cc.meta.Size()
 					require_Equal(t, size, 0)
 					return
+				}
+			}
+		})
+	}
+}
+
+// makeCompressibleData creates a byte slice of exactly the requested size
+// filled with a repeating pattern, simulating typical text/JSON payloads.
+func makeCompressibleData(size int) []byte {
+	const pattern = `{"ts":"2025-06-01T00:00:00Z","stream":"ORDERS","seq":1,"subject":"orders.new"}`
+	buf := make([]byte, size)
+	for i := 0; i < size; i += copy(buf[i:], pattern) {
+	}
+	return buf
+}
+
+// BenchmarkEncodeStreamMsg benchmarks the stream message encoding at various
+// message sizes, both below and above the compression threshold (8KB).
+// Run with: go test -run='^$' -bench='BenchmarkEncodeStreamMsg' -benchmem ./server/
+func BenchmarkEncodeStreamMsg(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"256B", 256},
+		{"1KB", 1024},
+		{"4KB", 4 * 1024},
+		{"8KB", 8 * 1024},     // At compression threshold
+		{"16KB", 16 * 1024},   // Above threshold — compression kicks in
+		{"64KB", 64 * 1024},   // Large message
+		{"256KB", 256 * 1024}, // Very large message
+		{"1MB", 1024 * 1024},  // 1MB message
+	}
+
+	subject := "TEST.stream.encode.benchmark"
+	reply := "INBOX.reply123"
+	hdr := []byte("NATS/1.0\r\nX-Test: true\r\n\r\n")
+	ts := time.Now().UnixNano()
+
+	for _, sz := range sizes {
+		// Compressible data: repeated pattern (typical for JSON/text payloads).
+		compressible := makeCompressibleData(sz.size)
+
+		// Incompressible data: random bytes.
+		incompressible := make([]byte, sz.size)
+		crand.Read(incompressible)
+
+		b.Run(fmt.Sprintf("compressible/%s", sz.name), func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			b.ReportAllocs()
+			for b.Loop() {
+				encodeStreamMsgAllowCompress(subject, reply, hdr, compressible, 1, ts, false)
+			}
+		})
+
+		b.Run(fmt.Sprintf("incompressible/%s", sz.name), func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			b.ReportAllocs()
+			for b.Loop() {
+				encodeStreamMsgAllowCompress(subject, reply, hdr, incompressible, 1, ts, false)
+			}
+		})
+	}
+}
+
+// BenchmarkEncodeStreamMsgBatch benchmarks stream message encoding with batch
+// support, which exercises the additional batch ID and sequence encoding.
+func BenchmarkEncodeStreamMsgBatch(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"4KB", 4 * 1024},
+		{"16KB", 16 * 1024},
+		{"64KB", 64 * 1024},
+	}
+
+	subject := "TEST.stream.batch"
+	reply := ""
+	hdr := []byte("NATS/1.0\r\n\r\n")
+	ts := time.Now().UnixNano()
+	batchId := "batch-abc123"
+
+	for _, sz := range sizes {
+		msg := makeCompressibleData(sz.size)
+
+		b.Run(fmt.Sprintf("nobatch/%s", sz.name), func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			b.ReportAllocs()
+			for b.Loop() {
+				encodeStreamMsgAllowCompressAndBatch(subject, reply, hdr, msg, 1, ts, false, _EMPTY_, 0, false)
+			}
+		})
+
+		b.Run(fmt.Sprintf("batch/%s", sz.name), func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			b.ReportAllocs()
+			for b.Loop() {
+				encodeStreamMsgAllowCompressAndBatch(subject, reply, hdr, msg, 1, ts, false, batchId, 42, false)
+			}
+		})
+	}
+}
+
+// BenchmarkEncodeDecodeStreamMsg benchmarks the full roundtrip of encoding
+// and decoding a stream message, which is the typical hot path during
+// RAFT replication.
+func BenchmarkEncodeDecodeStreamMsg(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"1KB", 1024},
+		{"16KB", 16 * 1024},
+		{"64KB", 64 * 1024},
+	}
+
+	subject := "TEST.roundtrip"
+	reply := "INBOX.rt"
+	hdr := []byte("NATS/1.0\r\nX-Test: true\r\n\r\n")
+	ts := time.Now().UnixNano()
+
+	for _, sz := range sizes {
+		msg := makeCompressibleData(sz.size)
+
+		b.Run(sz.name, func(b *testing.B) {
+			b.SetBytes(int64(sz.size))
+			b.ReportAllocs()
+			for b.Loop() {
+				encoded := encodeStreamMsgAllowCompress(subject, reply, hdr, msg, 1, ts, false)
+				op := entryOp(encoded[0])
+				mbuf := encoded[1:]
+				if op == compressedStreamMsgOp {
+					var err error
+					mbuf, err = s2.Decode(nil, mbuf)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+				_, _, _, _, _, _, _, err := decodeStreamMsg(mbuf)
+				if err != nil {
+					b.Fatal(err)
 				}
 			}
 		})


### PR DESCRIPTION
Try avoiding double allocation happening on messages that are over 8KB by using sync.Pool, release buffer once compression done.

```
go test -run='^$' -bench='BenchmarkEncodeStreamMsg|BenchmarkEncodeDecodeStreamMsg' -benchmem ./server/
```

Signed-off-by:  Waldemar Quevedo <wally@nats.io>
