### PR TITLE
Enable direct message delivery in MQTT stream

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -1392,13 +1392,13 @@ func (s *Server) mqttCreateAccountSessionManager(acc *Account, quitCh chan struc
 	case si == nil:
 		// Create the stream for retained messages.
 		cfg := &StreamConfig{
-			Name:       mqttRetainedMsgsStreamName,
-			Subjects:   []string{mqttRetainedMsgsStreamSubject + ">"},
-			Storage:    FileStorage,
-			Retention:  LimitsPolicy,
-			Replicas:   replicas,
-			MaxMsgsPer: 1,
-			AllowDirect: true
+			Name:        mqttRetainedMsgsStreamName,
+			Subjects:    []string{mqttRetainedMsgsStreamSubject + ">"},
+			Storage:     FileStorage,
+			Retention:   LimitsPolicy,
+			Replicas:    replicas,
+			MaxMsgsPer:  1,
+			AllowDirect: true,
 		}
 		// We will need "si" outside of this block.
 		si, _, err = jsa.createStream(cfg)

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -1398,6 +1398,7 @@ func (s *Server) mqttCreateAccountSessionManager(acc *Account, quitCh chan struc
 			Retention:  LimitsPolicy,
 			Replicas:   replicas,
 			MaxMsgsPer: 1,
+			AllowDirect: true
 		}
 		// We will need "si" outside of this block.
 		si, _, err = jsa.createStream(cfg)


### PR DESCRIPTION
I suggest to enable direct access to MQTT retained message JetStream to give applications access to the published retained messages from MQTT.

Signed-off-by:  Joachim Danmayr 

Fixes #7872 
