### PR TITLE
Allow refusing all client connections with `max_conns: 0`

### DIFF
--- a/server/configs/reload/max_connections_refuse_all.conf
+++ b/server/configs/reload/max_connections_refuse_all.conf
@@ -1,0 +1,3 @@
+listen:   127.0.0.1:-1
+
+max_connections: 0

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -7123,6 +7123,7 @@ func TestJetStreamClusterAccountMaxConnectionsReconnect(t *testing.T) {
 		_, err := js.AddStream(&nats.StreamConfig{
 			Name:     fmt.Sprintf("foo:%d", i),
 			Subjects: []string{fmt.Sprintf("foo.%d", i)},
+			Replicas: 3, // Must be R3 to stop flaking due to stream placement
 		})
 		require_NoError(t, err)
 

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -585,7 +585,7 @@ func (s *Server) createMQTTClient(conn net.Conn, ws *websocket) *client {
 		return c
 	}
 
-	if opts.MaxConn > 0 && len(s.clients) >= opts.MaxConn {
+	if opts.MaxConn < 0 || (opts.MaxConn > 0 && len(s.clients) >= opts.MaxConn) {
 		s.mu.Unlock()
 		c.maxConnExceeded()
 		return nil

--- a/server/opts.go
+++ b/server/opts.go
@@ -1269,7 +1269,9 @@ func (o *Options) processConfigFileLine(k string, v any, errors *[]error, warnin
 	case "proxy_protocol":
 		o.ProxyProtocol = v.(bool)
 	case "max_connections", "max_conn":
-		o.MaxConn = int(v.(int64))
+		if o.MaxConn = int(v.(int64)); o.MaxConn == 0 {
+			o.MaxConn = -1
+		}
 	case "max_traced_msg_len":
 		o.MaxTracedMsgLen = int(v.(int64))
 	case "max_subscriptions", "max_subs":

--- a/server/server.go
+++ b/server/server.go
@@ -3377,7 +3377,7 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 
 	// If there is a max connections specified, check that adding
 	// this new client would not push us over the max
-	if opts.MaxConn > 0 && len(s.clients) >= opts.MaxConn {
+	if opts.MaxConn < 0 || (opts.MaxConn > 0 && len(s.clients) >= opts.MaxConn) {
 		s.mu.Unlock()
 		c.maxConnExceeded()
 		return nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -588,6 +588,17 @@ func TestMaxConnections(t *testing.T) {
 	}
 }
 
+func TestMaxConnectionsPreventsAll(t *testing.T) {
+	opts := DefaultOptions()
+	opts.MaxConn = -1
+	s := RunServer(opts)
+	defer s.Shutdown()
+
+	addr := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
+	_, err := nats.Connect(addr)
+	require_Error(t, err)
+}
+
 func TestMaxSubscriptions(t *testing.T) {
 	opts := DefaultOptions()
 	opts.MaxSubs = 10

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1324,7 +1324,7 @@ func (s *Server) createWSClient(conn net.Conn, ws *websocket) *client {
 		return c
 	}
 
-	if opts.MaxConn > 0 && len(s.clients) >= opts.MaxConn {
+	if opts.MaxConn < 0 || (opts.MaxConn > 0 && len(s.clients) >= opts.MaxConn) {
 		s.mu.Unlock()
 		c.maxConnExceeded()
 		return nil


### PR DESCRIPTION
By setting `max_conns` to `0`, we will refuse all client, MQTT and WebSocket connections. On reloading `max_conns` to `0`, we will disconnect all clients.

Signed-off-by: Neil Twigg <neil@nats.io>