### PR TITLE
[FIXED] Scale down/up of consumer monitor race conditions

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3628,7 +3628,7 @@ func (mset *stream) resetClusteredState(err error) bool {
 			js.processClusterCreateStream(acc, sa)
 			// Reset consumers.
 			for _, ca := range consumers {
-				js.processClusterCreateConsumer(ca, nil, false)
+				js.processClusterCreateConsumer(nil, ca, nil, false)
 			}
 		}
 	}()
@@ -5394,7 +5394,9 @@ func (js *jetStream) processConsumerAssignment(ca *consumerAssignment) {
 	// Check if we have an existing consumer assignment.
 	if sa.consumers == nil {
 		sa.consumers = make(map[string]*consumerAssignment)
-	} else if oca := sa.consumers[ca.Name]; oca != nil {
+	}
+	oca := sa.consumers[ca.Name]
+	if oca != nil {
 		wasExisting = true
 		// Copy over private existing state from former CA.
 		if ca.Group != nil {
@@ -5476,7 +5478,7 @@ func (js *jetStream) processConsumerAssignment(ca *consumerAssignment) {
 
 	// Check if this is for us..
 	if isMember {
-		js.processClusterCreateConsumer(ca, state, wasExisting)
+		js.processClusterCreateConsumer(oca, ca, state, wasExisting)
 	} else if mset, _ := acc.lookupStream(sa.Config.Name); mset != nil {
 		if o := mset.lookupConsumer(ca.Name); o != nil {
 			// We have one here even though we are not a member. This can happen on re-assignment.
@@ -5574,7 +5576,7 @@ type consumerAssignmentResult struct {
 }
 
 // processClusterCreateConsumer is when we are a member of the group and need to create the consumer.
-func (js *jetStream) processClusterCreateConsumer(ca *consumerAssignment, state *ConsumerState, wasExisting bool) {
+func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, state *ConsumerState, wasExisting bool) {
 	if ca == nil {
 		return
 	}
@@ -5614,6 +5616,19 @@ func (js *jetStream) processClusterCreateConsumer(ca *consumerAssignment, state 
 
 	// Check if we already have this consumer running.
 	o := mset.lookupConsumer(consumer)
+
+	if o != nil && oca != nil && oca.Group.Name != ca.Group.Name {
+		s.Warnf("JetStream cluster detected consumer remapping for '%s > %s' from %q to %q",
+			acc, ca.Name, oca.Group.Name, ca.Group.Name)
+		o.clearNode()
+		o.signalMonitorQuit()
+		o.monitorWg.Wait()
+		alreadyRunning = false
+		// Make sure to clear from original.
+		js.mu.Lock()
+		oca.Group.node = nil
+		js.mu.Unlock()
+	}
 
 	// Process the raft group and make sure it's running if needed.
 	storage := mset.config().Storage

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8039,3 +8039,78 @@ func TestJetStreamClusterScaleDownWaitsForMonitorRoutineQuit(t *testing.T) {
 		return nil
 	})
 }
+
+func TestJetStreamClusterConsumerRemapWaitsForMonitorRoutineQuit(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// Create R3 stream and consumer.
+	scfg := &nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Replicas: 3}
+	ccfg := &nats.ConsumerConfig{Name: "CONSUMER", Replicas: 3}
+	_, err := js.AddStream(scfg)
+	require_NoError(t, err)
+	_, err = js.AddConsumer("TEST", ccfg)
+	require_NoError(t, err)
+	ml := c.leader()
+	sjs, cc := ml.getJetStreamCluster()
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		if sjs.streamAssignment(globalAccountName, "TEST") == nil {
+			return errors.New("stream not found")
+		}
+		if sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER") == nil {
+			return errors.New("consumer not found")
+		}
+		return nil
+	})
+
+	mset, err := ml.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	o := mset.lookupConsumer("CONSUMER")
+	require_NotNil(t, o)
+
+	// Increment the wait group for this test to confirm the right ordering.
+	o.mu.Lock()
+	inMonitor := o.inMonitor
+	wg := &o.monitorWg
+	wg.Add(1)
+	rn := o.node
+	o.mu.Unlock()
+	require_True(t, inMonitor)
+
+	// Simulate a consumer Raft group remapping that has been collapsed down into just a single update.
+	// Instead of one update to R1 and then to R3, it's just one update straight to the new R3 group.
+	ca := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+	require_NotNil(t, ca)
+	cca := ca.copyGroup()
+	cca.Group.Name = groupNameForConsumer(cca.Group.Peers, cca.Group.Storage)
+	require_NoError(t, cc.meta.Propose(encodeAddConsumerAssignment(cca)))
+
+	// The monitor routine should stop.
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		o.mu.RLock()
+		defer o.mu.RUnlock()
+		if o.inMonitor {
+			return errors.New("consumer still in monitor")
+		}
+		return nil
+	})
+
+	// The previous Raft node should be stopped.
+	require_Equal(t, rn.State(), Closed)
+
+	// Simulate the monitor routine being done now and the new monitor routine being started.
+	wg.Done()
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		o.mu.RLock()
+		defer o.mu.RUnlock()
+		if o.node == nil {
+			return errors.New("consumer has no Raft node yet")
+		} else if !o.inMonitor {
+			return errors.New("consumer monitor not started")
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
Similar to https://github.com/nats-io/nats-server/pull/7820, but now for consumers. We need to wait for the consumer monitor goroutine to have stopped, as we otherwise might not open a new monitor goroutine after scaleup.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>