### PR TITLE
[FIXED] Scale down non-durable consumer

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -9078,8 +9078,8 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 			if !s.allPeersOffline(ca.Group) {
 				// Need to release js lock.
 				js.mu.Unlock()
-				if ci, err := sysRequest[ConsumerInfo](s, clusterConsumerInfoT, ci.serviceAccount(), sa.Config.Name, cfg.Durable); err != nil {
-					s.Warnf("Did not receive consumer info results for '%s > %s > %s' due to: %s", acc, sa.Config.Name, cfg.Durable, err)
+				if ci, err := sysRequest[ConsumerInfo](s, clusterConsumerInfoT, ci.serviceAccount(), sa.Config.Name, oname); err != nil {
+					s.Warnf("Did not receive consumer info results for '%s > %s > %s' due to: %s", acc, sa.Config.Name, oname, err)
 				} else if ci != nil {
 					if cl := ci.Cluster; cl != nil {
 						curLeader = getHash(cl.Leader)


### PR DESCRIPTION
When scaling down a consumer from R3 to R1 we check which server is currently the leader. However, the durable name was used to do that check, if the consumer doesn't have a durable name it would send an incorrect request.

Also de-flakes `TestJetStreamClusterScaleDownWaitsForMonitorRoutineQuit`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>