### PR TITLE
(2.14) Fast batch: support acount imports/exports

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4760,7 +4760,7 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 			}
 		} else if c.kind != LEAF || c.pa.hdr < 0 || len(sliceHeader(ClientInfoHdr, msg[:c.pa.hdr])) == 0 {
 			ci = c.getClientInfo(share)
-			// FIXME(mvv): fast batch requires the original subject, test for various topologies (acc bounds, leaf, gateway)
+			// Fast batch requires knowledge of the original reply subject.
 			if bytes.HasSuffix(c.pa.reply, []byte(FastBatchSuffix)) {
 				ci.Reply = bytesToString(c.pa.reply)
 			}

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -3921,3 +3921,65 @@ func TestJetStreamFastBatchSequentialDuplicateAndErrorPubAck(t *testing.T) {
 	// Technically, we shouldn't return a zero-sequence, but it's unavoidable.
 	require_Equal(t, pubAck.Sequence, 0)
 }
+
+func TestJetStreamFastBatchPublishAccImportExport(t *testing.T) {
+	conf := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: 127.0.0.1:-1
+		jetstream: {max_mem_store: 1MB, max_file_store: 1MB, store_dir: %q}
+		accounts: {
+			A: {
+				jetstream: enabled
+				users: [ {user: a, password: a} ]
+				exports [
+					{ service: "foo" }
+				]
+			},
+			B: {
+				users: [ {user: b, password: b} ]
+				imports [
+					{ service: { subject: "foo", account: A } }
+				]
+			},
+		}
+	`, t.TempDir())))
+
+	s, _ := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	nc, err := nats.Connect(s.ClientURL(), nats.UserInfo("a", "a"))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	cfg := &StreamConfig{
+		Name:              "TEST",
+		Subjects:          []string{"foo"},
+		Storage:           FileStorage,
+		AllowBatchPublish: true,
+	}
+	_, err = jsStreamCreate(t, nc, cfg)
+	require_NoError(t, err)
+
+	checkFastBatchPublish := func(user string) {
+		nc, err := nats.Connect(s.ClientURL(), nats.UserInfo(user, user))
+		require_NoError(t, err)
+		defer nc.Close()
+
+		inbox := nats.NewInbox()
+		sub, err := nc.SubscribeSync(fmt.Sprintf("%s.>", inbox))
+		require_NoError(t, err)
+		defer sub.Drain()
+
+		m := nats.NewMsg("foo")
+		m.Reply = generateFastBatchReply(inbox, "uuid", 1, 0, FastBatchGapFail, FastBatchOpCommit)
+		require_NoError(t, nc.PublishMsg(m))
+		rmsg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		var pubAck JSPubAckResponse
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_True(t, pubAck.Error == nil)
+		require_Equal(t, pubAck.BatchId, "uuid")
+		require_Equal(t, pubAck.BatchSize, 1)
+	}
+	checkFastBatchPublish("a")
+	checkFastBatchPublish("b")
+}

--- a/server/stream.go
+++ b/server/stream.go
@@ -5099,10 +5099,27 @@ func (b *FastBatch) returnToPool() {
 
 // getFastBatch gets fast batch info from the reply subject in the form:
 // <prefix>.<uuid>.<initial flow>.<gap mode>.<batch seq>.<operation>.$FI
-func getFastBatch(reply string) (*FastBatch, bool) {
+func getFastBatch(reply string, hdr []byte) (*FastBatch, bool) {
 	lreply := len(reply)
 	if lreply <= 4 || reply[lreply-4:] != FastBatchSuffix {
-		return nil, false
+		if !isServiceReply(stringToBytes(reply)) {
+			return nil, false
+		}
+		// If account imports/exports are used, the reply might be internal.
+		// Check the client header for the original reply subject.
+		ci := sliceHeader(ClientInfoHdr, hdr)
+		if ci == nil {
+			return nil, false
+		}
+		var cis ClientInfo
+		if err := json.Unmarshal(ci, &cis); err != nil || cis.Reply == _EMPTY_ {
+			return nil, false
+		}
+		reply = cis.Reply
+		lreply = len(reply)
+		if lreply <= 4 || reply[lreply-4:] != FastBatchSuffix {
+			return nil, false
+		}
 	}
 
 	n := lreply - 4 // Move to just before the dot
@@ -5122,56 +5139,55 @@ func getFastBatch(reply string) (*FastBatch, bool) {
 	b.commitEob = op == FastBatchOpCommitEob
 	b.commit = b.commitEob || op == FastBatchOpCommit
 	p := o
+
 	// Batch seq.
 	if o = strings.LastIndexByte(reply[:o], '.'); o == -1 {
 		return nil, true
-	} else {
-		a := parseInt64(stringToBytes(reply[o+1 : p]))
-		if a < 1 {
-			return nil, true
-		}
-		b.seq = uint64(a)
-		p = o
-		if b.seq <= 0 {
-			return nil, true
-		}
-		if op == FastBatchOpStart && b.seq != 1 {
-			return nil, true
-		} else if op == FastBatchOpAppend && b.seq <= 1 {
-			return nil, true
-		}
 	}
+	a := parseInt64(stringToBytes(reply[o+1 : p]))
+	if a < 1 {
+		return nil, true
+	}
+	b.seq = uint64(a)
+	p = o
+	if b.seq <= 0 {
+		return nil, true
+	}
+	if op == FastBatchOpStart && b.seq != 1 {
+		return nil, true
+	} else if op == FastBatchOpAppend && b.seq <= 1 {
+		return nil, true
+	}
+
 	// Gap mode.
 	if o = strings.LastIndexByte(reply[:o], '.'); o == -1 {
 		return nil, true
-	} else {
-		gapMode := reply[o+1 : p]
-		if gapMode != FastBatchGapFail && gapMode != FastBatchGapOk {
-			return nil, true // Not recognized.
-		}
-		b.gapOk = gapMode == FastBatchGapOk
-		p = o
 	}
+	gapMode := reply[o+1 : p]
+	if gapMode != FastBatchGapFail && gapMode != FastBatchGapOk {
+		return nil, true // Not recognized.
+	}
+	b.gapOk = gapMode == FastBatchGapOk
+	p = o
+
 	// Ack flow.
 	if o = strings.LastIndexByte(reply[:o], '.'); o == -1 {
 		return nil, true
-	} else {
-		a := parseInt64(stringToBytes(reply[o+1 : p]))
-		if a <= 0 {
-			a = 10
-		} else if a > math.MaxUint16 {
-			a = math.MaxUint16
-		}
-		b.flow = uint16(a)
-		p = o
 	}
+	a = parseInt64(stringToBytes(reply[o+1 : p]))
+	if a <= 0 {
+		a = 10
+	} else if a > math.MaxUint16 {
+		a = math.MaxUint16
+	}
+	b.flow = uint16(a)
+	p = o
+
 	// Batch id.
 	if o = strings.LastIndexByte(reply[:o], '.'); o == -1 {
 		return nil, true
-	} else {
-		b.id = reply[o+1 : p]
 	}
-
+	b.id = reply[o+1 : p]
 	return b, false
 }
 
@@ -5729,7 +5745,7 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 		// Disable consistency checking if this was already done
 		// earlier as part of the batch consistency check.
 		canConsistencyCheck = traceOnly
-	} else if fastBatch, _ = getFastBatch(reply); fastBatch != nil {
+	} else if fastBatch, _ = getFastBatch(reply, hdr); fastBatch != nil {
 		defer fastBatch.returnToPool()
 		batchId, batchSeq = fastBatch.id, fastBatch.seq
 		// Disable consistency checking if this was already done
@@ -7486,7 +7502,7 @@ func (mset *stream) internalLoop() {
 			ims := msgs.pop()
 			for _, im := range ims {
 				// If we are clustered we need to propose this message to the underlying raft group.
-				if batch, err := getFastBatch(im.rply); batch != nil || err {
+				if batch, err := getFastBatch(im.rply, im.hdr); batch != nil || err {
 					mset.processJetStreamFastBatchMsg(batch, im.subj, im.rply, im.hdr, im.msg, im.mt)
 					batch.returnToPool()
 				} else if batchId := getBatchId(im.hdr); batchId != _EMPTY_ {


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/7778, supporting publishing to a stream using fast batch publish over account imports/exports.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>