### PR TITLE
De-flake TestJetStreamLeafNodeDefaultDomainClusterBothEnds

### DIFF
--- a/server/jetstream_leafnode_test.go
+++ b/server/jetstream_leafnode_test.go
@@ -1135,7 +1135,8 @@ default_js_domain: {B:"DHUB"}
 	sLeaf1, _ := RunServerWithConfig(confLeaf1)
 	defer sLeaf1.Shutdown()
 
-	confLeaf2 := createConfFile(t, []byte(fmt.Sprintf(tmplL2, sd3, sHub1.getOpts().LeafNode.Port, sHub1.getOpts().LeafNode.Port)))
+	sd4 := t.TempDir()
+	confLeaf2 := createConfFile(t, []byte(fmt.Sprintf(tmplL2, sd4, sHub1.getOpts().LeafNode.Port, sHub1.getOpts().LeafNode.Port)))
 	sLeaf2, _ := RunServerWithConfig(confLeaf2)
 	defer sLeaf2.Shutdown()
 


### PR DESCRIPTION
The test would create two leaf nodes using the same directory for storage. This would sometimes result in the filestore errors, leading to a leader step down and exit, causing the test to fail with:

jetstream_leafnode_test.go:1144: Expected a cluster leader, got none

Signed-off-by: Daniele Sciascia <daniele@nats.io>
