### PR TITLE
(2.14) Fast batch: support clean leader changes

### DIFF
--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -54,6 +54,7 @@ type fastBatch struct {
 	pending        uint32      // Number of pending messages in the batch waiting to be persisted.
 	ackMessages    uint16      // Ack will be sent every N messages.
 	maxAckMessages uint16      // Maximum ackMessages value the client allows.
+	reply          string      // The last reply subject seen when persisting a message.
 	gapOk          bool        // Whether a gap is okay, if not, the batch would be rejected.
 	commit         bool        // If the batch is committed.
 }
@@ -160,26 +161,78 @@ func (b *atomicBatch) readyForCommit() *BatchAbandonReason {
 // newFastBatch creates a fast batch publish object.
 // Lock should be held.
 func (batches *batching) newFastBatch(mset *stream, batchId string, gapOk bool, maxAckMessages uint16) *fastBatch {
-	// If it's the first batch, just allow what the client wants, otherwise we'll
-	// need to coordinate and slowly ramp up this publisher.
-	// TODO(mvv): fast ingest's initial flow value improvements?
-	ackMessages := min(500, maxAckMessages)
-	if len(batches.fast) > 1 {
-		ackMessages = 1
-	}
-	b := &fastBatch{gapOk: gapOk, ackMessages: ackMessages, maxAckMessages: maxAckMessages}
+	b := &fastBatch{gapOk: gapOk, maxAckMessages: maxAckMessages}
+	batches.fastBatchInit(b)
 	b.setupCleanupTimer(mset, batchId, batches)
 	return b
 }
 
+// fastBatchInit (re)initializes the ackMessages field for a fast batch.
+// Lock should be held.
+func (batches *batching) fastBatchInit(b *fastBatch) {
+	// If it's the first batch, just allow what the client wants, otherwise we'll
+	// need to coordinate and slowly ramp up this publisher.
+	// TODO(mvv): fast ingest's initial flow value improvements?
+	ackMessages := min(500, b.maxAckMessages)
+	if len(batches.fast) > 1 {
+		ackMessages = 1
+	}
+	b.ackMessages = ackMessages
+}
+
+// fastBatchReset resets the fast batch to an empty state and sends a flow control message.
+// Lock should be held.
+func (batches *batching) fastBatchReset(mset *stream, batchId string, b *fastBatch) {
+	// If the timer already stopped before we could commit, we clean it up.
+	if b.timer == nil || (!b.commit && !b.timer.Stop()) {
+		b.cleanupLocked(batchId, batches)
+		return
+	}
+	// Otherwise, reset the state.
+	batches.fastBatchInit(b)
+	b.timer.Reset(getCleanupTimeout(mset))
+	b.commit = false
+	b.pending = 0
+	b.fseq, b.lseq = b.pseq, b.pseq
+	b.sendFlowControl(b.fseq, mset, b.reply)
+}
+
 // fastBatchRegisterSequences registers the highest stored batch and stream sequence and returns
 // whether a PubAck should be sent if the batch has been committed.
+// If this is called on a follower, it only registers the highest stream and persisted batch sequences.
 // Lock should be held.
-func (batches *batching) fastBatchRegisterSequences(mset *stream, reply string, batchId string, batchSeq, streamSeq uint64) bool {
-	b, ok := batches.fast[batchId]
-	if !ok {
+func (batches *batching) fastBatchRegisterSequences(mset *stream, reply string, streamSeq uint64, isLeader bool, batch *FastBatch) bool {
+	b, ok := batches.fast[batch.id]
+	if !ok || !isLeader {
+		// If this batch has committed, we can clean it up.
+		if batch.commit {
+			if b != nil {
+				b.cleanupLocked(batch.id, batches)
+			}
+			return false
+		}
+		// Otherwise, even as a follower, we record the latest state of this batch.
+		if b == nil || !b.resetCleanupTimer(mset) {
+			if b != nil {
+				// The timer couldn't be reset, this means the timer already runs and is likely
+				// waiting to acquire the lock. We reset the timer here so it doesn't clean up
+				// this batch that we're about to overwrite.
+				b.timer = nil
+			}
+			// We'll need a copy as we'll use it as a key and later for cleanup.
+			batchId := copyString(batch.id)
+			b = batches.newFastBatch(mset, batchId, batch.gapOk, batch.flow)
+			if batches.fast == nil {
+				batches.fast = make(map[string]*fastBatch, 1)
+			}
+			batches.fast[batchId] = b
+		}
+		b.sseq = streamSeq
+		b.pseq, b.lseq = batch.seq, batch.seq
+		b.reply = reply
 		return false
 	}
+	b.reply = reply
 	if b.pending > 0 {
 		b.pending--
 	}
@@ -192,17 +245,17 @@ func (batches *batching) fastBatchRegisterSequences(mset *stream, reply string, 
 		skipped = true
 		b.pseq = b.lseq
 	} else {
-		b.pseq = batchSeq
+		b.pseq = batch.seq
 	}
 	// If the PubAck needs to be sent now as a result of a commit.
 	if b.lseq == b.pseq && b.commit {
-		b.cleanupLocked(batchId, batches)
+		b.cleanupLocked(batch.id, batches)
 		// If we skipped ahead due to duplicate messages, send the PubAck with the highest sequence.
 		if skipped {
 			var buf [256]byte
 			pubAck := append(buf[:0], mset.pubAck...)
 			response := append(pubAck, strconv.FormatUint(b.sseq, 10)...)
-			response = append(response, fmt.Sprintf(",\"batch\":%q,\"count\":%d}", batchId, b.lseq)...)
+			response = append(response, fmt.Sprintf(",\"batch\":%q,\"count\":%d}", batch.id, b.lseq)...)
 			if len(reply) > 0 {
 				mset.outq.sendMsg(reply, response)
 			}
@@ -274,10 +327,14 @@ func (b *fastBatch) sendFlowControl(batchSeq uint64, mset *stream, reply string)
 // after the last message has been persisted.
 // Lock should be held.
 func (batches *batching) fastBatchCommit(b *fastBatch, batchId string, mset *stream, reply string) bool {
+	// Either we commit now, or we clean up later, so stop the timer.
+	if b.timer == nil || (!b.commit && !b.timer.Stop()) {
+		// Shouldn't be possible for the timer to already be stopped if we haven't committed yet,
+		// since we pre-check being able to reset the timer. But guard against it anyhow.
+		return true
+	}
 	// Mark that this batch commits.
 	b.commit = true
-	// Either we commit now, or we clean up later, so stop the timer.
-	b.timer.Stop()
 	// If the whole batch has been persisted, we can respond with the PubAck now.
 	if b.lseq == b.pseq {
 		b.cleanupLocked(batchId, batches)
@@ -300,7 +357,10 @@ func (b *fastBatch) setupCleanupTimer(mset *stream, batchId string, batches *bat
 	timeout := getCleanupTimeout(mset)
 	b.timer = time.AfterFunc(timeout, func() {
 		b.cleanup(batchId, batches)
-		mset.sendStreamBatchAbandonedAdvisory(batchId, BatchTimeout)
+		// Only send the advisory if we're the leader. (Since we do the tracking on followers too)
+		if mset.IsLeader() {
+			mset.sendStreamBatchAbandonedAdvisory(batchId, BatchTimeout)
+		}
 	})
 }
 
@@ -309,6 +369,9 @@ func (b *fastBatch) setupCleanupTimer(mset *stream, batchId string, batches *bat
 func (b *fastBatch) resetCleanupTimer(mset *stream) bool {
 	if b.commit {
 		return true
+	}
+	if b.timer == nil {
+		return false
 	}
 	timeout := getCleanupTimeout(mset)
 	return b.timer.Reset(timeout)
@@ -323,6 +386,11 @@ func (b *fastBatch) cleanup(batchId string, batches *batching) {
 
 // Lock should be held.
 func (b *fastBatch) cleanupLocked(batchId string, batches *batching) {
+	// If the timer is nil, it means this batch has been replaced with a new one.
+	// This can happen on a follower depending on timing.
+	if b.timer == nil {
+		return
+	}
 	b.timer.Stop()
 	delete(batches.fast, batchId)
 }

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -3568,7 +3568,7 @@ func TestJetStreamFastBatchPublishDuplicatesCluster(t *testing.T) {
 
 	// Now simulate the second message we published is processed.
 	reply := generateFastBatchReply(inbox, "uuid", 2, 4, FastBatchGapFail, FastBatchOpAppend)
-	batches.fastBatchRegisterSequences(mset, reply, "uuid", 2, 2)
+	batches.fastBatchRegisterSequences(mset, reply, 2, true, &FastBatch{id: "uuid", seq: 2})
 	batches.mu.Unlock()
 
 	// Normally we'd receive two flow control messages, but since both were triggered due to
@@ -3982,4 +3982,240 @@ func TestJetStreamFastBatchPublishAccImportExport(t *testing.T) {
 	}
 	checkFastBatchPublish("a")
 	checkFastBatchPublish("b")
+}
+
+func TestJetStreamFastBatchPublishFlowControlOnLeaderChange(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc := clientConnectToServer(t, c.randomServer())
+	defer nc.Close()
+
+	cfg := &StreamConfig{
+		Name:              "TEST",
+		Subjects:          []string{"foo"},
+		Storage:           FileStorage,
+		Replicas:          3,
+		AllowBatchPublish: true,
+	}
+
+	_, err := jsStreamCreate(t, nc, cfg)
+	require_NoError(t, err)
+
+	inbox := nats.NewInbox()
+	sub, err := nc.SubscribeSync(fmt.Sprintf("%s.>", inbox))
+	require_NoError(t, err)
+	defer sub.Drain()
+
+	m := nats.NewMsg("foo")
+	for seq := uint64(1); seq <= 3; seq++ {
+		if seq == 1 {
+			m.Reply = generateFastBatchReply(inbox, "uuid", seq, 2, FastBatchGapFail, FastBatchOpStart)
+		} else {
+			m.Reply = generateFastBatchReply(inbox, "uuid", seq, 2, FastBatchGapFail, FastBatchOpAppend)
+		}
+		require_NoError(t, nc.PublishMsg(m))
+	}
+	rmsg, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	var batchFlowAck BatchFlowAck
+	require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowAck))
+	require_Equal(t, batchFlowAck.Messages, 2)
+	require_Equal(t, batchFlowAck.Sequence, 0)
+
+	rmsg, err = sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	batchFlowAck = BatchFlowAck{}
+	require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowAck))
+	require_Equal(t, batchFlowAck.Messages, 2)
+	require_Equal(t, batchFlowAck.Sequence, 2)
+
+	// Should receive a flow ack after a leader change. This sends us a ping, but also informs us which
+	// messages were persisted after the leader change.
+	sl := c.streamLeader(globalAccountName, "TEST")
+	require_NotNil(t, sl)
+	mset, err := sl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	require_NoError(t, mset.raftNode().StepDown())
+
+	rmsg, err = sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	batchFlowAck = BatchFlowAck{}
+	require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowAck))
+	require_Equal(t, batchFlowAck.Messages, 2)
+	require_Equal(t, batchFlowAck.Sequence, 3)
+
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		if err = checkState(t, c, globalAccountName, "TEST"); err != nil {
+			return err
+		}
+		for _, s := range c.servers {
+			mset, err = s.globalAccount().lookupStream("TEST")
+			if err != nil {
+				return err
+			}
+			mset.mu.RLock()
+			var batches int
+			if mset.batches != nil {
+				mset.batches.mu.Lock()
+				batches = len(mset.batches.fast)
+				mset.batches.mu.Unlock()
+			}
+			mset.mu.RUnlock()
+			if batches != 1 {
+				return fmt.Errorf("expected 1 batch on %s, got %d", s.Name(), batches)
+			}
+		}
+		return nil
+	})
+
+	// We now expect a new flow ack after two messages.
+	for seq := uint64(4); seq <= 5; seq++ {
+		m.Reply = generateFastBatchReply(inbox, "uuid", seq, 2, FastBatchGapFail, FastBatchOpAppend)
+		require_NoError(t, nc.PublishMsg(m))
+	}
+	rmsg, err = sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	batchFlowAck = BatchFlowAck{}
+	require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowAck))
+	require_Equal(t, batchFlowAck.Messages, 2)
+	require_Equal(t, batchFlowAck.Sequence, 5)
+
+	// Commit the final message. We expect that the followers also clean up their state.
+	m.Reply = generateFastBatchReply(inbox, "uuid", 6, 2, FastBatchGapFail, FastBatchOpCommit)
+	require_NoError(t, nc.PublishMsg(m))
+	rmsg, err = sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	var pubAck JSPubAckResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+	require_True(t, pubAck.Error == nil)
+	require_Equal(t, pubAck.BatchId, "uuid")
+	require_Equal(t, pubAck.BatchSize, 6)
+	require_Equal(t, pubAck.Sequence, 6)
+
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		if err = checkState(t, c, globalAccountName, "TEST"); err != nil {
+			return err
+		}
+		for _, s := range c.servers {
+			mset, err = s.globalAccount().lookupStream("TEST")
+			if err != nil {
+				return err
+			}
+			mset.mu.RLock()
+			var batches int
+			if mset.batches != nil {
+				mset.batches.mu.Lock()
+				batches = len(mset.batches.fast)
+				mset.batches.mu.Unlock()
+			}
+			mset.mu.RUnlock()
+			if batches > 0 {
+				return fmt.Errorf("expected no batches on %s, got %d", s.Name(), batches)
+			}
+		}
+		return nil
+	})
+}
+
+func TestJetStreamFastBatchPublishFlowControlOnLeaderChangeAfterFailedCommitProposal(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc := clientConnectToServer(t, c.randomServer())
+	defer nc.Close()
+
+	cfg := &StreamConfig{
+		Name:              "TEST",
+		Subjects:          []string{"foo"},
+		Storage:           FileStorage,
+		Replicas:          3,
+		AllowBatchPublish: true,
+	}
+
+	_, err := jsStreamCreate(t, nc, cfg)
+	require_NoError(t, err)
+
+	inbox := nats.NewInbox()
+	sub, err := nc.SubscribeSync(fmt.Sprintf("%s.>", inbox))
+	require_NoError(t, err)
+	defer sub.Drain()
+
+	m := nats.NewMsg("foo")
+	for seq := uint64(1); seq <= 3; seq++ {
+		if seq == 1 {
+			m.Reply = generateFastBatchReply(inbox, "uuid", seq, 0, FastBatchGapFail, FastBatchOpStart)
+		} else {
+			m.Reply = generateFastBatchReply(inbox, "uuid", seq, 0, FastBatchGapFail, FastBatchOpAppend)
+		}
+		require_NoError(t, nc.PublishMsg(m))
+	}
+	rmsg, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	var batchFlowAck BatchFlowAck
+	require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowAck))
+	require_Equal(t, batchFlowAck.Messages, 10)
+	require_Equal(t, batchFlowAck.Sequence, 0)
+
+	// Should receive a flow ack after a leader change. This sends us a ping, but also informs us which
+	// messages were persisted after the leader change.
+	sl := c.streamLeader(globalAccountName, "TEST")
+	require_NotNil(t, sl)
+	mset, err := sl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+
+	mset.mu.Lock()
+	if mset.batches == nil {
+		mset.mu.Unlock()
+		t.Fatal("batches map is nil")
+	}
+	mset.batches.mu.Lock()
+	b := mset.batches.fast["uuid"]
+	if b == nil {
+		mset.batches.mu.Unlock()
+		mset.mu.Unlock()
+		t.Fatal("batch is nil")
+	}
+	// Simulate one more pending message that commits, but the proposal didn't make it due to the leader change.
+	b.commit = true
+	b.pending++
+	mset.batches.mu.Unlock()
+	mset.mu.Unlock()
+
+	// Change to any other leader.
+	require_NoError(t, mset.raftNode().StepDown())
+
+	// Change back to the previous leader.
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+	nl := c.streamLeader(globalAccountName, "TEST")
+	require_NotNil(t, nl)
+	require_NotEqual(t, nl, sl)
+	nmset, err := nl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	require_NoError(t, nmset.raftNode().StepDown(mset.raftNode().ID()))
+
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+	require_Equal(t, c.streamLeader(globalAccountName, "TEST"), sl)
+
+	// The previous leader should now have reset the committed flag as the proposal failed.
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		mset.mu.RLock()
+		defer mset.mu.RUnlock()
+		if mset.batches == nil {
+			return errors.New("batches map is nil")
+		}
+		mset.batches.mu.Lock()
+		defer mset.batches.mu.Unlock()
+		b = mset.batches.fast["uuid"]
+		if b == nil {
+			return errors.New("batch is nil")
+		}
+		if b.pending != 0 {
+			return errors.New("pending isn't reset")
+		}
+		if b.commit {
+			return errors.New("commit isn't reset")
+		}
+		return nil
+	})
 }

--- a/server/stream.go
+++ b/server/stream.go
@@ -1234,6 +1234,16 @@ func (mset *stream) setLeader(isLeader bool) error {
 			mset.mu.Unlock()
 			return err
 		}
+
+		// Reset any inflight fast batches. We were likely a follower before and need
+		// to send an ack to the publishers so they know we're still there.
+		if mset.batches != nil {
+			mset.batches.mu.Lock()
+			for batchId, b := range mset.batches.fast {
+				mset.batches.fastBatchReset(mset, batchId, b)
+			}
+			mset.batches.mu.Unlock()
+		}
 	} else {
 		// cancel timer to create the source consumers if not fired yet
 		if mset.sourcesConsumerSetup != nil {
@@ -4598,8 +4608,17 @@ func (mset *stream) unsubscribeToStream(stopping, shuttingDown bool) error {
 	}
 	// Clear batching state.
 	mset.deleteAtomicBatches(shuttingDown)
-	mset.deleteFastBatches()
-	mset.batches = nil
+	if stopping || shuttingDown {
+		mset.deleteFastBatches()
+	}
+	if mset.batches != nil {
+		mset.batches.mu.Lock()
+		reset := len(mset.batches.atomic) == 0 && len(mset.batches.fast) == 0
+		mset.batches.mu.Unlock()
+		if reset {
+			mset.batches = nil
+		}
+	}
 
 	if stopping {
 		// In case we had a direct get subscriptions.
@@ -5739,9 +5758,8 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 	var resp = &JSPubAckResponse{}
 
 	var (
-		batchId     string
-		batchSeq    uint64
-		batchAtomic bool
+		batchId  string
+		batchSeq uint64
 	)
 	// Populate batch details.
 	if fastBatch != nil {
@@ -5759,7 +5777,6 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 	}
 	if len(hdr) > 0 && batchId == _EMPTY_ {
 		if batchId = getBatchId(hdr); batchId != _EMPTY_ {
-			batchAtomic = true
 			batchSeq, _ = getBatchSequence(hdr)
 			// Disable consistency checking if this was already done
 			// earlier as part of the batch consistency check.
@@ -6323,11 +6340,14 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 		}
 		// If using fast batch publish, we occasionally send flow control messages.
 		// And, we need to ensure a PubAck is sent if the commit happens through EOB.
-		if batchId != _EMPTY_ && !batchAtomic && mset.batches != nil {
-			batches := mset.batches
-			batches.mu.Lock()
-			commit := batches.fastBatchRegisterSequences(mset, reply, batchId, batchSeq, mset.lseq)
-			batches.mu.Unlock()
+		if fastBatch != nil {
+			if mset.batches == nil {
+				mset.batches = &batching{}
+			}
+			mset.batches.mu.Lock()
+			// Check full leader state so we only send the client an update once we're caught up.
+			commit := mset.batches.fastBatchRegisterSequences(mset, reply, mset.lseq, mset.isLeader(), fastBatch)
+			mset.batches.mu.Unlock()
 			if !commit {
 				reply = _EMPTY_
 				canRespond = false
@@ -6523,11 +6543,14 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 
 	// If using fast batch publish, we occasionally send flow control messages.
 	// And, we need to ensure a PubAck is sent if the commit happens through EOB.
-	if batchId != _EMPTY_ && !batchAtomic && mset.batches != nil {
-		batches := mset.batches
-		batches.mu.Lock()
-		commit := batches.fastBatchRegisterSequences(mset, reply, batchId, batchSeq, mset.lseq)
-		batches.mu.Unlock()
+	if fastBatch != nil {
+		if mset.batches == nil {
+			mset.batches = &batching{}
+		}
+		mset.batches.mu.Lock()
+		// Check full leader state so we only send the client an update once we're caught up.
+		commit := mset.batches.fastBatchRegisterSequences(mset, reply, mset.lseq, mset.isLeader(), fastBatch)
+		mset.batches.mu.Unlock()
 		if !commit {
 			reply = _EMPTY_
 			canRespond = false


### PR DESCRIPTION
During a leader change all fast batches would be dropped. This PR makes this cleaner by tracking the batches on the followers as well, and sending the publishers a flow ack letting them know which messages were persisted. Without this the publishers would get a confusing error message about the batch being unknown. Now, the publishers get slowed down after the leader change and are ramped up again, and gaps will properly be reported.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>