### PR TITLE
[FIXED] Only use store limits for resources exceeded

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -2322,8 +2322,10 @@ func tierName(replicas int) string {
 }
 
 func isSameTier(cfgA, cfgB *StreamConfig) bool {
+	a := max(1, cfgA.Replicas)
+	b := max(1, cfgB.Replicas)
 	// TODO (mh) this is where we could select based off a placement tag as well "qos:tier"
-	return cfgA.Replicas == cfgB.Replicas
+	return a == b
 }
 
 func (jsa *jsAccount) jetStreamAndClustered() (*jetStream, bool) {
@@ -2398,17 +2400,11 @@ func (jsa *jsAccount) wouldExceedLimits(storeType StorageType, tierName string, 
 	// Since tiers are flat we need to scale limit up by replicas when checking.
 	if storeType == MemoryStorage {
 		totalMem := inUse.total.mem + (int64(memStoreMsgSize(subj, hdr, msg)) * r)
-		if selectedLimits.MemoryMaxStreamBytes > 0 && totalMem > selectedLimits.MemoryMaxStreamBytes*lr {
-			return true, nil
-		}
 		if selectedLimits.MaxMemory >= 0 && totalMem > selectedLimits.MaxMemory*lr {
 			return true, nil
 		}
 	} else {
 		totalStore := inUse.total.store + (int64(fileStoreMsgSize(subj, hdr, msg)) * r)
-		if selectedLimits.StoreMaxStreamBytes > 0 && totalStore > selectedLimits.StoreMaxStreamBytes*lr {
-			return true, nil
-		}
 		if selectedLimits.MaxStore >= 0 && totalStore > selectedLimits.MaxStore*lr {
 			return true, nil
 		}

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1314,7 +1314,7 @@ func (jsa *jsAccount) tieredReservation(tier string, cfg *StreamConfig) int64 {
 		if sa.cfg.Name == cfg.Name {
 			continue
 		}
-		if (tier == _EMPTY_ || sa.cfg.Replicas == cfg.Replicas) && sa.cfg.MaxBytes > 0 && sa.cfg.Storage == cfg.Storage {
+		if (tier == _EMPTY_ || isSameTier(&sa.cfg, cfg)) && sa.cfg.MaxBytes > 0 && sa.cfg.Storage == cfg.Storage {
 			// If tier is empty, all storage is flat and we should adjust for replicas.
 			// Otherwise if tiered, storage replication already taken into consideration.
 			if tier == _EMPTY_ && sa.cfg.Replicas > 1 {

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -6078,7 +6078,7 @@ func TestJetStreamClusterLimitsBasedStreamFileStoreDesync(t *testing.T) {
 	    ]
 	  }
 	  js {
-	    jetstream = { store_max_stream_bytes = 3mb }
+	    jetstream = { max_store = 3mb }
 	    users = [
 	      { user: js, pass: js }
 	    ]
@@ -8113,4 +8113,112 @@ func TestJetStreamClusterConsumerRemapWaitsForMonitorRoutineQuit(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+func TestJetStreamAccountStoreLimits(t *testing.T) {
+	test := func(t *testing.T, replicas int, storage nats.StorageType) {
+		storeLimit := fileStoreMsgSize("B", nil, nil)
+		memLimit := memStoreMsgSize("B", nil, nil)
+		limit := JetStreamAccountLimits{
+			MaxMemory:            int64(memLimit * 6),
+			MemoryMaxStreamBytes: int64(memLimit * 3),
+			MaxStore:             int64(storeLimit * 6),
+			StoreMaxStreamBytes:  int64(storeLimit * 3),
+			MaxBytesRequired:     true,
+		}
+		tier := fmt.Sprintf("R%d", replicas)
+		limits := map[string]JetStreamAccountLimits{tier: limit}
+
+		var s *Server
+		var c *cluster
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+			require_NoError(t, s.globalAccount().UpdateJetStreamLimits(limits))
+		} else {
+			c = createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			for _, cs := range c.servers {
+				require_NoError(t, cs.globalAccount().UpdateJetStreamLimits(limits))
+			}
+			s = c.randomServer()
+		}
+
+		resourcesErr := NewJSStorageResourcesExceededError()
+		maxAcc, maxBytes := limit.MaxStore, limit.StoreMaxStreamBytes
+		if storage == nats.MemoryStorage {
+			resourcesErr = NewJSMemoryResourcesExceededError()
+			maxAcc, maxBytes = limit.MaxMemory, limit.MemoryMaxStreamBytes
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		// No MaxBytes errors because it's required.
+		_, err := js.AddStream(&nats.StreamConfig{Name: "A", Replicas: replicas, Storage: storage})
+		require_Error(t, err, NewJSStreamMaxBytesRequiredError())
+
+		// MaxBytes larger than account limit errors.
+		_, err = js.AddStream(&nats.StreamConfig{Name: "A", Replicas: replicas, Storage: storage, MaxBytes: maxAcc + 1})
+		if replicas == 1 {
+			require_Error(t, err, resourcesErr)
+		} else {
+			require_Error(t, err, NewJSStreamMaxStreamBytesExceededError())
+		}
+
+		// MaxBytes larger than bytes limit errors.
+		_, err = js.AddStream(&nats.StreamConfig{Name: "A", Replicas: replicas, Storage: storage, MaxBytes: maxBytes + 1})
+		require_Error(t, err, NewJSStreamMaxStreamBytesExceededError())
+
+		// Create two streams that exactly fit the limit.
+		for _, subj := range []string{"A", "B"} {
+			_, err = js.AddStream(&nats.StreamConfig{Name: subj, Replicas: replicas, Storage: storage, MaxBytes: maxBytes})
+			require_NoError(t, err)
+		}
+
+		// Another stream over the limit errors.
+		_, err = js.AddStream(&nats.StreamConfig{Name: "C", Replicas: replicas, Storage: storage, MaxBytes: 1})
+		require_Error(t, err, resourcesErr)
+
+		// We can publish more than the maximum bytes into the stream as it is DiscardOld.
+		for range 10 {
+			_, err = js.Publish("A", nil)
+			require_NoError(t, err)
+		}
+
+		// Once the last stream fills up too close to the account limit, we eventually get an error.
+		start := time.Now()
+		for i := 0; ; i++ {
+			if time.Since(start) > 5*time.Second {
+				t.Fatalf("timed out waiting for error")
+			}
+			_, err = js.Publish("B", nil)
+			if i < 3 {
+				require_NoError(t, err)
+			} else if replicas == 1 {
+				// Expect an error immediately after we hit the limit if we're R1.
+				require_Error(t, err, NewJSAccountResourcesExceededError())
+				break
+			} else if err != nil {
+				// For replicated this might take some time as servers report about their usage.
+				require_Error(t, err, NewJSAccountResourcesExceededError())
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		// If clustered, confirm all is in sync still.
+		if c != nil {
+			checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+				return checkState(t, c, globalAccountName, "B")
+			})
+		}
+	}
+
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) {
+			t.Run("Memory", func(t *testing.T) { test(t, replicas, nats.MemoryStorage) })
+			t.Run("File", func(t *testing.T) { test(t, replicas, nats.FileStorage) })
+		})
+	}
 }

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -5601,7 +5601,7 @@ func TestJWTJetStreamMaxAckPending(t *testing.T) {
 	require_True(t, ci.Config.MaxAckPending == 2000)
 }
 
-func TestJWTJetStreamMaxStreamBytes(t *testing.T) {
+func TestJWTJetStreamMaxStore(t *testing.T) {
 	sysKp, syspub := createKey(t)
 	sysJwt := encodeClaim(t, jwt.NewAccountClaims(syspub), syspub)
 	sysCreds := newUser(t, sysKp)
@@ -5610,7 +5610,7 @@ func TestJWTJetStreamMaxStreamBytes(t *testing.T) {
 	accClaim := jwt.NewAccountClaims(accPub)
 	accClaim.Name = "acc"
 	accClaim.Limits.JetStreamTieredLimits["R1"] = jwt.JetStreamLimits{
-		DiskStorage: jwt.NoLimit, MemoryStorage: jwt.NoLimit,
+		DiskStorage: 1024, MemoryStorage: jwt.NoLimit,
 		Consumer: jwt.NoLimit, Streams: jwt.NoLimit,
 		DiskMaxStreamBytes: 1024, MaxBytesRequired: false,
 	}
@@ -5650,30 +5650,26 @@ func TestJWTJetStreamMaxStreamBytes(t *testing.T) {
 	require_NoError(t, err)
 
 	_, err = js.AddStream(&nats.StreamConfig{Name: "foo", Replicas: 1, MaxBytes: 2048})
-	require_Error(t, err)
-	require_Equal(t, err.Error(), "nats: stream max bytes exceeds account limit max stream bytes")
+	require_Error(t, err, NewJSStorageResourcesExceededError())
 	_, err = js.AddStream(&nats.StreamConfig{Name: "foo", Replicas: 1, MaxBytes: 1024})
 	require_NoError(t, err)
 
 	msg := [900]byte{}
-	_, err = js.AddStream(&nats.StreamConfig{Name: "baz", Replicas: 1})
+	_, err = js.Publish("foo", msg[:])
 	require_NoError(t, err)
-	_, err = js.Publish("baz", msg[:])
-	require_NoError(t, err)
-	_, err = js.Publish("baz", msg[:]) // exceeds max stream bytes
+	_, err = js.Publish("foo", msg[:]) // exceeds storage limit
 	require_Error(t, err)
 	require_Equal(t, err.Error(), "nats: resource limits exceeded for account")
 
 	time.Sleep(time.Second - time.Since(start)) // make sure the time stamp changes
 	accClaim.Limits.JetStreamTieredLimits["R1"] = jwt.JetStreamLimits{
-		DiskStorage: jwt.NoLimit, MemoryStorage: jwt.NoLimit, Consumer: jwt.NoLimit, Streams: jwt.NoLimit,
+		DiskStorage: 3072, MemoryStorage: jwt.NoLimit, Consumer: jwt.NoLimit, Streams: jwt.NoLimit,
 		DiskMaxStreamBytes: 2048, MaxBytesRequired: true}
 	accJwt2 := encodeClaim(t, accClaim, accPub)
 	updateJwt(t, s.ClientURL(), sysCreds, accJwt2, 1)
 
 	_, err = js.AddStream(&nats.StreamConfig{Name: "bar", Replicas: 1, MaxBytes: 3000})
-	require_Error(t, err)
-	require_Equal(t, err.Error(), "nats: stream max bytes exceeds account limit max stream bytes")
+	require_Error(t, err, NewJSStorageResourcesExceededError())
 	_, err = js.AddStream(&nats.StreamConfig{Name: "bar", Replicas: 1, MaxBytes: 2048})
 	require_NoError(t, err)
 
@@ -5682,22 +5678,26 @@ func TestJWTJetStreamMaxStreamBytes(t *testing.T) {
 	require_Equal(t, ainfo.Tiers["R1"].Store, 933)
 
 	// This should be exactly at the limit of the account.
-	_, err = js.Publish("baz", []byte(strings.Repeat("A", 1082)))
+	_, err = js.Publish("foo", []byte(strings.Repeat("A", 991)))
 	require_NoError(t, err)
-
 	ainfo, err = js.AccountInfo()
 	require_NoError(t, err)
-	require_Equal(t, ainfo.Tiers["R1"].Store, 2048)
+	require_Equal(t, ainfo.Tiers["R1"].Store, 1024)
+	_, err = js.Publish("bar", []byte(strings.Repeat("A", 2015)))
+	require_NoError(t, err)
+	ainfo, err = js.AccountInfo()
+	require_NoError(t, err)
+	require_Equal(t, ainfo.Tiers["R1"].Store, 3072)
 
-	// Exceed max stream bytes limit.
-	_, err = js.Publish("baz", []byte("1"))
+	// Exceed storage limit.
+	_, err = js.Publish("bar", []byte("1"))
 	require_Error(t, err)
 	require_Equal(t, err.Error(), "nats: resource limits exceeded for account")
 
 	// Confirm no changes after rejected publish.
 	ainfo, err = js.AccountInfo()
 	require_NoError(t, err)
-	require_Equal(t, ainfo.Tiers["R1"].Store, 2048)
+	require_Equal(t, ainfo.Tiers["R1"].Store, 3072)
 
 	// test disabling max bytes required
 	_, err = js.UpdateStream(&nats.StreamConfig{Name: "bar", Replicas: 1})


### PR DESCRIPTION
Both `MaxStore` and `StoreMaxStreamBytes` were used to determine whether account resources are exceeded. However, the latter shouldn't be used. Imagine `StoreMaxStreamBytes: 1GB` and `MaxStore: 10GB`, this should allow you to have at most 10 streams with `MaxBytes: 1GB` to fit within these limits. However, since `StoreMaxStreamBytes` was also used for the resources check, this would actually mean you can't store any more data than 1GB.

This PR fixes this:
- `MaxStore/MaxMemory` expresses how much storage resources you can use within the account, regardless of the amount of streams.
- `StoreMaxStreamBytes/MemoryMaxStreamBytes` expresses the highest value that `MaxBytes` can be set to. (whereas now we also use this to express the storage resources like above)

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>