### PR TITLE
memstore: take write lock in memstore.State

### DIFF
--- a/server/memstore.go
+++ b/server/memstore.go
@@ -2194,8 +2194,8 @@ func (ms *memStore) FastState(state *StreamState) {
 }
 
 func (ms *memStore) State() StreamState {
-	ms.mu.RLock()
-	defer ms.mu.RUnlock()
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
 
 	state := ms.state
 	state.Consumers = ms.consumers


### PR DESCRIPTION
`memstore.State` may delete stale sequences from `ms.dmap`.

Signed-off-by: Daniele Sciascia <daniele@nats.io>
