### PR TITLE
Rename TestJetStreamClusterAccountStoreLimits

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8115,7 +8115,7 @@ func TestJetStreamClusterConsumerRemapWaitsForMonitorRoutineQuit(t *testing.T) {
 	})
 }
 
-func TestJetStreamAccountStoreLimits(t *testing.T) {
+func TestJetStreamClusterAccountStoreLimits(t *testing.T) {
 	test := func(t *testing.T, replicas int, storage nats.StorageType) {
 		storeLimit := fileStoreMsgSize("B", nil, nil)
 		memLimit := memStoreMsgSize("B", nil, nil)


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/7895, the test was moved from a R1 test to a clustered test, but the name wasn't changed to be included in the test suite.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>