### PR TITLE
Fix nbPool buffer recycling in WebSocket and S2 compression paths

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1686,9 +1686,11 @@ func (c *client) flushOutbound() bool {
 
 		cw.Reset(&bb)
 		for _, buf := range collapsed {
-			if _, err = cw.Write(buf); err != nil {
-				break
+			if err == nil {
+				_, err = cw.Write(buf)
 			}
+			// Return always after consumed or error.
+			nbPoolPut(buf)
 		}
 		if err == nil {
 			err = cw.Close()

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -34,6 +34,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"
@@ -3853,5 +3854,46 @@ func TestClientFlushOutboundWriteTimeoutPolicy(t *testing.T) {
 				}
 			})
 		})
+	}
+}
+
+func TestFlushOutboundS2CompressionPoolBufferRecycling(t *testing.T) {
+	opts := DefaultOptions()
+	s := &Server{opts: opts}
+
+	fakeConn := &testConnWritePartial{}
+	c := &client{srv: s, nc: fakeConn, kind: ROUTER}
+	c.initClient()
+	c.out.cw = s2.NewWriter(nil, s2.WriterConcurrency(1))
+
+	payload := make([]byte, 256)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	// Queue multiple buffers per iteration so each leaked pool
+	// buffer adds one extra allocation, making the leak obvious.
+	const numBuffers = 10
+
+	// Warm up: run a few iterations to populate the pool.
+	for i := 0; i < 5; i++ {
+		c.mu.Lock()
+		for j := 0; j < numBuffers; j++ {
+			c.queueOutbound(payload)
+		}
+		c.flushOutbound()
+		c.mu.Unlock()
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		c.mu.Lock()
+		for j := 0; j < numBuffers; j++ {
+			c.queueOutbound(payload)
+		}
+		c.flushOutbound()
+		c.mu.Unlock()
+	})
+	if allocs > 15 {
+		t.Fatalf("Too many allocs per iteration (%.1f); pool buffers are likely being leaked", allocs)
 	}
 }

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1402,7 +1402,7 @@ func (c *client) wsCollapsePtoNB() (net.Buffers, int64) {
 			cp.Reset(buf)
 		}
 		var csz int
-		for _, b := range nb {
+		for i, b := range nb {
 			for len(b) > 0 {
 				n, err := cp.Write(b)
 				if err != nil {
@@ -1414,7 +1414,10 @@ func (c *client) wsCollapsePtoNB() (net.Buffers, int64) {
 				}
 				b = b[n:]
 			}
-			nbPoolPut(b) // No longer needed as contents written to compressor.
+			// Use original slice since capacity will change to zero
+			// in the loop after consuming the buffer, which will make
+			// nbPoolPut discard it.
+			nbPoolPut(nb[i])
 		}
 		if err := cp.Flush(); err != nil {
 			c.Errorf("Error during compression: %v", err)

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -3264,6 +3264,59 @@ func TestWSCompressionFrameSizeLimit(t *testing.T) {
 	}
 }
 
+func TestWSCompressionPoolBufferRecycling(t *testing.T) {
+	opts := testWSOptions()
+	opts.MaxPending = MAX_PENDING_SIZE
+	s := &Server{opts: opts}
+	c := &client{srv: s, ws: &websocket{compress: true}}
+	c.initClient()
+
+	// Use a payload larger than wsCompressThreshold (64 bytes)
+	// to trigger the compression path.
+	payload := make([]byte, 256)
+	for i := range payload {
+		// Semi-random to be compressible.
+		payload[i] = byte(i % 251)
+	}
+
+	// Warm up: populate the pool and initialize the compressor.
+	nbSlice := make(net.Buffers, 1)
+	for i := 0; i < 10; i++ {
+		c.mu.Lock()
+		data := nbPoolGet(len(payload))
+		data = append(data, payload...)
+		nbSlice[0] = data
+		c.out.nb = nbSlice
+		c.out.pb = int64(len(payload))
+		c.ws.fs = 0
+		bufs, _ := c.collapsePtoNB()
+		for _, buf := range bufs {
+			nbPoolPut(buf)
+		}
+		c.out.nb = nil
+		c.mu.Unlock()
+	}
+
+	allocs := testing.AllocsPerRun(500, func() {
+		c.mu.Lock()
+		data := nbPoolGet(len(payload))
+		data = append(data, payload...)
+		nbSlice[0] = data
+		c.out.nb = nbSlice
+		c.out.pb = int64(len(payload))
+		c.ws.fs = 0
+		bufs, _ := c.collapsePtoNB()
+		for _, buf := range bufs {
+			nbPoolPut(buf)
+		}
+		c.out.nb = nil
+		c.mu.Unlock()
+	})
+	if allocs > 2 {
+		t.Fatalf("Too many allocs per iteration (%.1f); pool buffers are likely being leaked", allocs)
+	}
+}
+
 func TestWSBasicAuth(t *testing.T) {
 	for _, test := range []struct {
 		name    string


### PR DESCRIPTION
- Fix `wsCollapsePtoNB` not returning buffers due to slice capacity changing after consuming it.

- Fix `flushOutbound` not returning buffers after compression or errors during compression.

Signed-off-by: Waldemar Quevedo <wally@nats.io>
