### PR TITLE
[FIXED] Don't encode consumer state in meta snapshot

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -336,7 +336,6 @@ type writeableConsumerAssignment struct {
 	Stream     string          `json:"stream"`
 	ConfigJSON json.RawMessage `json:"consumer"`
 	Group      *raftGroup      `json:"group"`
-	State      *ConsumerState  `json:"state,omitempty"`
 }
 
 // streamPurge is what the stream leader will replicate when purging a stream.
@@ -2069,7 +2068,7 @@ func (js *jetStream) decodeMetaSnapshot(buf []byte) (map[string]map[string]*stre
 				if wca.Stream == _EMPTY_ {
 					wca.Stream = sa.Config.Name // Rehydrate from the stream name.
 				}
-				ca := &consumerAssignment{Client: wca.Client, Created: wca.Created, Name: wca.Name, Stream: wca.Stream, ConfigJSON: wca.ConfigJSON, Group: wca.Group, State: wca.State}
+				ca := &consumerAssignment{Client: wca.Client, Created: wca.Created, Name: wca.Name, Stream: wca.Stream, ConfigJSON: wca.ConfigJSON, Group: wca.Group}
 				if err := decodeConsumerAssignmentConfig(ca); err != nil {
 					return nil, err
 				}
@@ -2109,7 +2108,6 @@ func (js *jetStream) encodeMetaSnapshot(streams map[string]map[string]*streamAss
 					Stream:     ca.Stream,
 					ConfigJSON: ca.ConfigJSON,
 					Group:      ca.Group,
-					State:      ca.State,
 				}
 				wsa.Consumers = append(wsa.Consumers, &wca)
 				nca++

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8222,3 +8222,69 @@ func TestJetStreamClusterAccountStoreLimits(t *testing.T) {
 		})
 	}
 }
+
+func TestJetStreamClusterDontEncodeConsumerStateInMetaSnapshot(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// Add a replicated stream and a single replica consumer.
+	scfg := &nats.StreamConfig{Name: "TEST", Replicas: 3}
+	_, err := js.AddStream(scfg)
+	require_NoError(t, err)
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Name: "CONSUMER", Replicas: 1})
+	require_NoError(t, err)
+
+	// Ensure the stream and consumer leaders differ.
+	sl := c.streamLeader(globalAccountName, "TEST")
+	cl := c.consumerLeader(globalAccountName, "TEST", "CONSUMER")
+	if sl == cl {
+		mset, err := sl.globalAccount().lookupStream("TEST")
+		require_NoError(t, err)
+		require_NoError(t, mset.raftNode().StepDown())
+		c.waitOnStreamLeader(globalAccountName, "TEST")
+		sl = c.streamLeader(globalAccountName, "TEST")
+	}
+	require_NotEqual(t, sl, cl)
+
+	// Scale down the stream so the R1 consumer needs to be moved to a different server.
+	scfg.Replicas = 1
+	_, err = js.UpdateStream(scfg)
+	require_NoError(t, err)
+
+	// Signal that the meta leader should create a snapshot. We need to do this indirectly
+	// through a noop peer change, as we need the monitor goroutine to perform the snapshot.
+	ml := c.leader()
+	require_NotNil(t, ml)
+	meta := ml.getJetStream().getMetaGroup().(*raft)
+	meta.RLock()
+	papplied := meta.papplied
+	meta.RUnlock()
+	require_NoError(t, meta.ProposeAddPeer(meta.ID()))
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		meta.RLock()
+		defer meta.RUnlock()
+		if papplied == meta.papplied {
+			return errors.New("no snapshot yet")
+		}
+		return nil
+	})
+
+	// Load the new snapshot and validate consumer state isn't preserved.
+	snap, err := meta.loadLastSnapshot()
+	require_NoError(t, err)
+	sjs := ml.getJetStream()
+	accStreams, err := sjs.decodeMetaSnapshot(snap.data)
+	require_NoError(t, err)
+	require_Len(t, len(accStreams), 1)
+	streams := accStreams[globalAccountName]
+	require_Len(t, len(streams), 1)
+	stream := streams["TEST"]
+	require_NotNil(t, stream)
+	require_Len(t, len(stream.consumers), 1)
+	consumer := stream.consumers["CONSUMER"]
+	require_NotNil(t, consumer)
+	require_True(t, consumer.State == nil)
+}


### PR DESCRIPTION
Related to https://github.com/nats-io/nats-server/pull/7905, the meta snapshots should never contain `ca.State` as this is only used to signal updating to specific state in the apply path, not during recovery from a snapshot.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>