### PR TITLE
[FIXED] Avoid nil deref on mirror state restore

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -3274,15 +3274,19 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 			// We may have missed messages, restart.
 			if lseq := mset.lastSeq(); sseq <= lseq {
 				mset.mu.Lock()
-				mset.mirror.lag = olag
-				mset.mirror.sseq = lseq
-				mset.mirror.dseq = odseq
+				if mset.mirror != nil {
+					mset.mirror.lag = olag
+					mset.mirror.sseq = lseq
+					mset.mirror.dseq = odseq
+				}
 				mset.mu.Unlock()
 				return false
 			} else {
 				mset.mu.Lock()
-				mset.mirror.dseq = odseq
-				mset.mirror.sseq = osseq
+				if mset.mirror != nil {
+					mset.mirror.dseq = odseq
+					mset.mirror.sseq = osseq
+				}
 				mset.mu.Unlock()
 				mset.retryMirrorConsumer()
 			}


### PR DESCRIPTION
Guard `mset.mirror` against nil when restoring sequence/lag state after a failed persist in `processInboundMirrorMsg`, preventing a potential nil deref if the mirror was removed concurrently.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>