### PR TITLE
 JetStream: Implement MaxAckPendingPerSubject

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2504,9 +2504,21 @@ func (o *consumer) updateConfig(cfg *ConsumerConfig) error {
 		}
 	}
 
+	// MaxAckPendingPerSubject
+	if cfg.MaxAckPendingPerSubject != o.cfg.MaxAckPendingPerSubject {
+		if cfg.MaxAckPendingPerSubject <= 0 {
+			o.ptc = nil
+		}
+	}
+
 	// Record new config for others that do not need special handling.
 	// Allowed but considered no-op, [Description, SampleFrequency, MaxWaiting, HeadersOnly]
+	oldMaxAckPendingPerSubject := o.cfg.MaxAckPendingPerSubject
 	o.cfg = *cfg
+
+	if o.cfg.MaxAckPendingPerSubject > 0 && oldMaxAckPendingPerSubject <= 0 {
+		o.rebuildPerSubjectTracking()
+	}
 
 	if updatedFilters {
 		// Cleanup messages that lost interest.

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -86,25 +86,26 @@ type PriorityGroupState struct {
 }
 
 type ConsumerConfig struct {
-	Durable         string          `json:"durable_name,omitempty"`
-	Name            string          `json:"name,omitempty"`
-	Description     string          `json:"description,omitempty"`
-	DeliverPolicy   DeliverPolicy   `json:"deliver_policy"`
-	OptStartSeq     uint64          `json:"opt_start_seq,omitempty"`
-	OptStartTime    *time.Time      `json:"opt_start_time,omitempty"`
-	AckPolicy       AckPolicy       `json:"ack_policy"`
-	AckWait         time.Duration   `json:"ack_wait,omitempty"`
-	MaxDeliver      int             `json:"max_deliver,omitempty"`
-	BackOff         []time.Duration `json:"backoff,omitempty"`
-	FilterSubject   string          `json:"filter_subject,omitempty"`
-	FilterSubjects  []string        `json:"filter_subjects,omitempty"`
-	ReplayPolicy    ReplayPolicy    `json:"replay_policy"`
-	RateLimit       uint64          `json:"rate_limit_bps,omitempty"` // Bits per sec
-	SampleFrequency string          `json:"sample_freq,omitempty"`
-	MaxWaiting      int             `json:"max_waiting,omitempty"`
-	MaxAckPending   int             `json:"max_ack_pending,omitempty"`
-	FlowControl     bool            `json:"flow_control,omitempty"`
-	HeadersOnly     bool            `json:"headers_only,omitempty"`
+	Durable                 string          `json:"durable_name,omitempty"`
+	Name                    string          `json:"name,omitempty"`
+	Description             string          `json:"description,omitempty"`
+	DeliverPolicy           DeliverPolicy   `json:"deliver_policy"`
+	OptStartSeq             uint64          `json:"opt_start_seq,omitempty"`
+	OptStartTime            *time.Time      `json:"opt_start_time,omitempty"`
+	AckPolicy               AckPolicy       `json:"ack_policy"`
+	AckWait                 time.Duration   `json:"ack_wait,omitempty"`
+	MaxDeliver              int             `json:"max_deliver,omitempty"`
+	BackOff                 []time.Duration `json:"backoff,omitempty"`
+	FilterSubject           string          `json:"filter_subject,omitempty"`
+	FilterSubjects          []string        `json:"filter_subjects,omitempty"`
+	ReplayPolicy            ReplayPolicy    `json:"replay_policy"`
+	RateLimit               uint64          `json:"rate_limit_bps,omitempty"` // Bits per sec
+	SampleFrequency         string          `json:"sample_freq,omitempty"`
+	MaxWaiting              int             `json:"max_waiting,omitempty"`
+	MaxAckPending           int             `json:"max_ack_pending,omitempty"`
+	MaxAckPendingPerSubject int             `json:"max_ack_pending_per_subject,omitempty"`
+	FlowControl             bool            `json:"flow_control,omitempty"`
+	HeadersOnly             bool            `json:"headers_only,omitempty"`
 
 	// Pull based options.
 	MaxRequestBatch    int           `json:"max_batch,omitempty"`
@@ -444,6 +445,7 @@ type consumer struct {
 	nextMsgReqs       *ipQueue[*nextMsgReq]
 	resetSubj         string
 	maxp              int
+	ptc               map[string]int
 	pblimit           int
 	maxpb             int
 	pbytes            int
@@ -2230,7 +2232,7 @@ func (o *consumer) hasMaxDeliveries(seq uint64) bool {
 		// Make sure to remove from pending.
 		if p, ok := o.pending[seq]; ok && p != nil {
 			delete(o.pending, seq)
-			o.updateDelivered(p.Sequence, seq, dc, p.Timestamp)
+			o.updateDelivered(p.Sequence, seq, dc, p.Timestamp, p.Subject)
 		}
 		// Ensure redelivered state is set, if not already.
 		if o.rdc == nil {
@@ -2652,7 +2654,7 @@ func (o *consumer) progressUpdate(seq uint64) {
 	if p, ok := o.pending[seq]; ok {
 		p.Timestamp = time.Now().UnixNano()
 		// Update store system.
-		o.updateDelivered(p.Sequence, seq, 1, p.Timestamp)
+		o.updateDelivered(p.Sequence, seq, 1, p.Timestamp, p.Subject)
 	}
 }
 
@@ -2819,7 +2821,7 @@ func (o *consumer) propose(entry []byte) {
 }
 
 // Lock should be held.
-func (o *consumer) updateDelivered(dseq, sseq, dc uint64, ts int64) {
+func (o *consumer) updateDelivered(dseq, sseq, dc uint64, ts int64, subj string) {
 	// Clustered mode and R>1.
 	if o.node != nil {
 		// Inline for now, use variable compression.
@@ -2830,9 +2832,14 @@ func (o *consumer) updateDelivered(dseq, sseq, dc uint64, ts int64) {
 		n += binary.PutUvarint(b[n:], sseq)
 		n += binary.PutUvarint(b[n:], dc)
 		n += binary.PutVarint(b[n:], ts)
-		o.propose(b[:n])
+		if len(subj) > 0 {
+			buf := append(b[:n], subj...)
+			o.propose(buf)
+		} else {
+			o.propose(b[:n])
+		}
 	} else if o.store != nil {
-		o.store.UpdateDelivered(dseq, sseq, dc, ts)
+		o.store.UpdateDelivered(dseq, sseq, dc, ts, subj)
 	}
 	// Update activity.
 	o.ldt = time.Now()
@@ -3046,7 +3053,7 @@ func (o *consumer) processNak(sseq, dseq, dc uint64, nak []byte) {
 					// now - ackWait is expired now, so offset from there.
 					p.Timestamp = time.Now().Add(-o.cfg.AckWait).Add(d).UnixNano()
 					// Update store system which will update followers as well.
-					o.updateDelivered(p.Sequence, sseq, dc, p.Timestamp)
+					o.updateDelivered(p.Sequence, sseq, dc, p.Timestamp, p.Subject)
 					if o.ptmr != nil {
 						// Want checkPending to run and figure out the next timer ttl.
 						// TODO(dlc) - We could optimize this maybe a bit more and track when we expect the timer to fire.
@@ -3478,9 +3485,11 @@ func (o *consumer) processAckMsg(sseq, dseq, dc uint64, reply string, doSample b
 			if o.maxp > 0 && len(o.pending) >= o.maxp {
 				needSignal = true
 			}
-			delete(o.pending, sseq)
 			// Use the original deliver sequence from our pending record.
 			dseq = p.Sequence
+			if o.removeFromPending(sseq) {
+				needSignal = true
+			}
 
 			// Only move floors if we matched an existing pending.
 			if len(o.pending) == 0 {
@@ -3515,7 +3524,9 @@ func (o *consumer) processAckMsg(sseq, dseq, dc uint64, reply string, doSample b
 		o.adflr, o.asflr = dseq, sseq
 
 		remove := func(seq uint64) {
-			delete(o.pending, seq)
+			if o.removeFromPending(seq) {
+				needSignal = true
+			}
 			delete(o.rdc, seq)
 			o.removeFromRedeliverQueue(seq)
 			if seq < floor {
@@ -4603,7 +4614,7 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 				// Make sure to remove from pending.
 				if p, ok := o.pending[seq]; ok && p != nil {
 					delete(o.pending, seq)
-					o.updateDelivered(p.Sequence, seq, dc, p.Timestamp)
+					o.updateDelivered(p.Sequence, seq, dc, p.Timestamp, p.Subject)
 				}
 				continue
 			}
@@ -4614,6 +4625,17 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 				pmsg, dc = nil, 0
 				// Adjust back deliver count.
 				o.decDeliveryCount(seq)
+			}
+			if sm != nil {
+				if sm != &pmsg.StoreMsg {
+					sm.copy(&pmsg.StoreMsg)
+				}
+				if _, alreadyPending := o.pending[seq]; !alreadyPending && o.pendingSubjectHitLimit(pmsg.subj) {
+					pmsg.returnToPool()
+					dc = 0
+					o.decDeliveryCount(seq)
+					continue
+				}
 			}
 			// Message was scheduled for redelivery but was removed in the meantime.
 			if err == ErrStoreMsgNotFound || err == errDeletedMsg {
@@ -4652,6 +4674,15 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 			pmsg.returnToPool()
 			pmsg = nil
 		}
+		if sm != nil {
+			if sm != &pmsg.StoreMsg {
+				sm.copy(&pmsg.StoreMsg)
+			}
+			if o.pendingSubjectHitLimit(pmsg.subj) {
+				pmsg.returnToPool()
+				return nil, 0, errMaxAckPending
+			}
+		}
 		o.sseq++
 		return pmsg, 1, err
 	}
@@ -4676,6 +4707,14 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 	if sm == nil {
 		pmsg.returnToPool()
 		pmsg = nil
+	} else {
+		if sm != &pmsg.StoreMsg {
+			sm.copy(&pmsg.StoreMsg)
+		}
+		if o.pendingSubjectHitLimit(pmsg.subj) {
+			pmsg.returnToPool()
+			return nil, 0, errMaxAckPending
+		}
 	}
 	// Check if we should move our o.sseq.
 	if sseq >= o.sseq {
@@ -5433,10 +5472,10 @@ func (o *consumer) deliverMsg(dsubj, ackReply string, pmsg *jsPubMsg, dc uint64,
 	seq, ts := pmsg.seq, pmsg.ts
 
 	// Update delivered first.
-	o.updateDelivered(dseq, seq, dc, ts)
+	o.updateDelivered(dseq, seq, dc, ts, pmsg.subj)
 
 	if ap == AckExplicit || ap == AckAll {
-		o.trackPending(seq, dseq)
+		o.trackPending(seq, dseq, pmsg.subj)
 	} else if ap == AckNone {
 		o.adflr = dseq
 		o.asflr = seq
@@ -5551,9 +5590,52 @@ func (o *consumer) sendFlowControl() {
 	o.outq.send(newJSPubMsg(subj, _EMPTY_, rply, hdr, nil, nil, 0))
 }
 
+func (o *consumer) pendingSubjectHitLimit(subj string) bool {
+	if o.cfg.MaxAckPendingPerSubject <= 0 || subj == _EMPTY_ {
+		return false
+	}
+	return o.ptc[subj] >= o.cfg.MaxAckPendingPerSubject
+}
+
+func (o *consumer) incPendingSubject(subj string) {
+	if o.cfg.MaxAckPendingPerSubject <= 0 || subj == _EMPTY_ {
+		return
+	}
+	if o.ptc == nil {
+		o.ptc = make(map[string]int)
+	}
+	o.ptc[subj]++
+}
+
+func (o *consumer) decPendingSubject(subj string) bool {
+	if o.cfg.MaxAckPendingPerSubject <= 0 || subj == _EMPTY_ || o.ptc == nil {
+		return false
+	}
+	var needSignal bool
+	if o.ptc[subj] >= o.cfg.MaxAckPendingPerSubject {
+		needSignal = true
+	}
+	if o.ptc[subj] > 0 {
+		o.ptc[subj]--
+		if o.ptc[subj] == 0 {
+			delete(o.ptc, subj)
+		}
+	}
+	return needSignal
+}
+
+func (o *consumer) removeFromPending(seq uint64) bool {
+	var needSignal bool
+	if p, ok := o.pending[seq]; ok && p != nil {
+		needSignal = o.decPendingSubject(p.Subject)
+		delete(o.pending, seq)
+	}
+	return needSignal
+}
+
 // Tracks our outstanding pending acks. Only applicable to AckExplicit mode.
 // Lock should be held.
-func (o *consumer) trackPending(sseq, dseq uint64) {
+func (o *consumer) trackPending(sseq, dseq uint64, subj string) {
 	if o.pending == nil {
 		o.pending = make(map[uint64]*Pending)
 	}
@@ -5564,7 +5646,8 @@ func (o *consumer) trackPending(sseq, dseq uint64) {
 		// So do not update p.Sequence.
 		p.Timestamp = now.UnixNano()
 	} else {
-		o.pending[sseq] = &Pending{dseq, now.UnixNano()}
+		o.pending[sseq] = &Pending{dseq, now.UnixNano(), subj}
+		o.incPendingSubject(subj)
 	}
 
 	// We could have a backoff that set a timer higher than what we need for this message.
@@ -5733,7 +5816,7 @@ func (o *consumer) checkPending() {
 		}
 		// Check if these are no longer valid.
 		if seq < fseq || seq <= o.asflr {
-			delete(o.pending, seq)
+			o.removeFromPending(seq)
 			delete(o.rdc, seq)
 			o.removeFromRedeliverQueue(seq)
 			shouldUpdateState = true

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2231,7 +2231,9 @@ func (o *consumer) hasMaxDeliveries(seq uint64) bool {
 		}
 		// Make sure to remove from pending.
 		if p, ok := o.pending[seq]; ok && p != nil {
-			o.removeFromPending(seq)
+			if o.removeFromPending(seq) {
+				o.signalNewMessages()
+			}
 			o.updateDelivered(p.Sequence, seq, dc, p.Timestamp, p.Subject)
 		}
 		// Ensure redelivered state is set, if not already.
@@ -3166,6 +3168,7 @@ func (o *consumer) applyState(state *ConsumerState) {
 	o.asflr = state.AckFloor.Stream
 	o.pending = state.Pending
 	o.rdc = state.Redelivered
+	o.rebuildPerSubjectTracking()
 
 	// Setup tracking timer if we have restored pending.
 	if o.isLeader() && len(o.pending) > 0 {
@@ -4613,7 +4616,9 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 				}
 				// Make sure to remove from pending.
 				if p, ok := o.pending[seq]; ok && p != nil {
-					o.removeFromPending(seq)
+					if o.removeFromPending(seq) {
+						o.signalNewMessages()
+					}
 					o.updateDelivered(p.Sequence, seq, dc, p.Timestamp, p.Subject)
 				}
 				continue
@@ -5659,6 +5664,25 @@ func (o *consumer) decPendingSubject(subj string) bool {
 	return needSignal
 }
 
+func (o *consumer) rebuildPerSubjectTracking() {
+	if o.cfg.MaxAckPendingPerSubject <= 0 || len(o.pending) == 0 {
+		return
+	}
+	if o.ptc == nil {
+		o.ptc = make(map[string]int)
+	}
+	for seq, p := range o.pending {
+		if p.Subject == _EMPTY_ && o.mset != nil && o.mset.store != nil {
+			if subj, err := o.mset.store.SubjectForSeq(seq); err == nil {
+				p.Subject = subj
+			}
+		}
+		if p.Subject != _EMPTY_ {
+			o.ptc[p.Subject]++
+		}
+	}
+}
+
 func (o *consumer) removeFromPending(seq uint64) bool {
 	var needSignal bool
 	if p, ok := o.pending[seq]; ok && p != nil {
@@ -5851,7 +5875,9 @@ func (o *consumer) checkPending() {
 		}
 		// Check if these are no longer valid.
 		if seq < fseq || seq <= o.asflr {
-			o.removeFromPending(seq)
+			if o.removeFromPending(seq) {
+				o.signalNewMessages()
+			}
 			delete(o.rdc, seq)
 			o.removeFromRedeliverQueue(seq)
 			shouldUpdateState = true
@@ -6045,10 +6071,16 @@ func (o *consumer) reconcileStateWithStream(streamLastSeq uint64) {
 
 	// Remove pending entries that are beyond the stream's last sequence
 	if len(o.pending) > 0 {
+		var needSignal bool
 		for seq := range o.pending {
 			if seq > streamLastSeq {
-				o.removeFromPending(seq)
+				if o.removeFromPending(seq) {
+					needSignal = true
+				}
 			}
+		}
+		if needSignal {
+			o.signalNewMessages()
 		}
 	}
 
@@ -6302,6 +6334,7 @@ func (o *consumer) purge(sseq uint64, slseq uint64, isWider bool) {
 	if o.asflr < sseq {
 		o.asflr = sseq - 1
 		// We need to remove those no longer relevant from pending.
+		var needSignal bool
 		for seq, p := range o.pending {
 			if seq <= o.asflr {
 				if p.Sequence > o.adflr {
@@ -6310,11 +6343,12 @@ func (o *consumer) purge(sseq uint64, slseq uint64, isWider bool) {
 						o.dseq = o.adflr
 					}
 				}
-				o.removeFromPending(seq)
+				if o.removeFromPending(seq) {
+					needSignal = true
+				}
 				delete(o.rdc, seq)
 				// rdq handled below.
-			}
-			if isWider && store != nil {
+			} else if isWider && store != nil {
 				// Our filtered subject, which could be all, is wider than the underlying purge.
 				// We need to check if the pending items left are still valid.
 				var smv StoreMsg
@@ -6325,10 +6359,15 @@ func (o *consumer) purge(sseq uint64, slseq uint64, isWider bool) {
 							o.dseq = o.adflr
 						}
 					}
-					o.removeFromPending(seq)
+					if o.removeFromPending(seq) {
+						needSignal = true
+					}
 					delete(o.rdc, seq)
 				}
 			}
+		}
+		if needSignal {
+			o.signalNewMessages()
 		}
 	}
 

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2231,7 +2231,7 @@ func (o *consumer) hasMaxDeliveries(seq uint64) bool {
 		}
 		// Make sure to remove from pending.
 		if p, ok := o.pending[seq]; ok && p != nil {
-			delete(o.pending, seq)
+			o.removeFromPending(seq)
 			o.updateDelivered(p.Sequence, seq, dc, p.Timestamp, p.Subject)
 		}
 		// Ensure redelivered state is set, if not already.
@@ -4613,7 +4613,7 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 				}
 				// Make sure to remove from pending.
 				if p, ok := o.pending[seq]; ok && p != nil {
-					delete(o.pending, seq)
+					o.removeFromPending(seq)
 					o.updateDelivered(p.Sequence, seq, dc, p.Timestamp, p.Subject)
 				}
 				continue
@@ -4632,7 +4632,6 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 				}
 				if _, alreadyPending := o.pending[seq]; !alreadyPending && o.pendingSubjectHitLimit(pmsg.subj) {
 					pmsg.returnToPool()
-					dc = 0
 					o.decDeliveryCount(seq)
 					continue
 				}
@@ -4658,7 +4657,7 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 		return nil, 0, errMaxAckPending
 	}
 
-	if o.hasSkipListPending() {
+	for o.hasSkipListPending() {
 		seq := o.lss.seqs[0]
 		if len(o.lss.seqs) == 1 {
 			o.sseq = o.lss.resume
@@ -4680,52 +4679,74 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 			}
 			if o.pendingSubjectHitLimit(pmsg.subj) {
 				pmsg.returnToPool()
-				return nil, 0, errMaxAckPending
+				o.sseq++
+				continue
 			}
 		}
 		o.sseq++
 		return pmsg, 1, err
 	}
 
-	var sseq uint64
-	var err error
-	var sm *StoreMsg
-	var pmsg = getJSPubMsgFromPool()
+	// Save our starting sequence. If all remaining messages are on blocked
+	// subjects, we restore sseq so we don't permanently skip them.
+	savedSseq := o.sseq
 
-	// Grab next message applicable to us.
-	filters, subjf, fseq := o.filters, o.subjf, o.sseq
-	// Check if we are multi-filtered or not.
-	if filters != nil {
-		sm, sseq, err = o.mset.store.LoadNextMsgMulti(filters, fseq, &pmsg.StoreMsg)
-	} else if len(subjf) > 0 { // Means single filtered subject since o.filters means > 1.
-		filter, wc := subjf[0].subject, subjf[0].hasWildcard
-		sm, sseq, err = o.mset.store.LoadNextMsg(filter, wc, fseq, &pmsg.StoreMsg)
-	} else {
-		// No filter here.
-		sm, sseq, err = o.mset.store.LoadNextMsg(_EMPTY_, false, fseq, &pmsg.StoreMsg)
-	}
-	if sm == nil {
-		pmsg.returnToPool()
-		pmsg = nil
-	} else {
+	for {
+		var sseq uint64
+		var err error
+		var sm *StoreMsg
+		var pmsg = getJSPubMsgFromPool()
+
+		// Grab next message applicable to us.
+		filters, subjf, fseq := o.filters, o.subjf, o.sseq
+		// Check if we are multi-filtered or not.
+		if filters != nil {
+			sm, sseq, err = o.mset.store.LoadNextMsgMulti(filters, fseq, &pmsg.StoreMsg)
+		} else if len(subjf) > 0 { // Means single filtered subject since o.filters means > 1.
+			filter, wc := subjf[0].subject, subjf[0].hasWildcard
+			sm, sseq, err = o.mset.store.LoadNextMsg(filter, wc, fseq, &pmsg.StoreMsg)
+		} else {
+			// No filter here.
+			sm, sseq, err = o.mset.store.LoadNextMsg(_EMPTY_, false, fseq, &pmsg.StoreMsg)
+		}
+		if sm == nil {
+			pmsg.returnToPool()
+			// No more messages available. If we skipped any blocked subjects,
+			// restore o.sseq so those messages aren't permanently lost.
+			if o.sseq != savedSseq {
+				o.sseq = savedSseq
+			}
+			return nil, 0, err
+		}
+
 		if sm != &pmsg.StoreMsg {
 			sm.copy(&pmsg.StoreMsg)
 		}
 		if o.pendingSubjectHitLimit(pmsg.subj) {
+			// Skip this message and try the next one so we don't
+			// head-of-line block other subjects.
 			pmsg.returnToPool()
-			return nil, 0, errMaxAckPending
+			if sseq >= o.sseq {
+				o.sseq = sseq + 1
+			}
+			continue
 		}
-	}
-	// Check if we should move our o.sseq.
-	if sseq >= o.sseq {
-		// If we are moving step by step then sseq == o.sseq.
-		// If we have jumped we should update skipped for other replicas.
-		if sseq != o.sseq && err == ErrStoreEOF {
-			o.updateSkipped(sseq + 1)
+
+		// Found an unblocked message. Restore o.sseq to the saved position
+		// so blocked messages earlier in the stream aren't permanently skipped.
+		// Only the delivered message's sequence will be tracked via pending.
+		o.sseq = savedSseq
+		// Check if we should move our o.sseq.
+		if sseq >= o.sseq {
+			// If we are moving step by step then sseq == o.sseq.
+			// If we have jumped we should update skipped for other replicas.
+			if sseq != o.sseq && err == ErrStoreEOF {
+				o.updateSkipped(sseq + 1)
+			}
+			o.sseq = sseq + 1
 		}
-		o.sseq = sseq + 1
+		return pmsg, 1, err
 	}
-	return pmsg, 1, err
 }
 
 // Will check for expiration and lack of interest on waiting requests.
@@ -6012,7 +6033,7 @@ func (o *consumer) reconcileStateWithStream(streamLastSeq uint64) {
 	if len(o.pending) > 0 {
 		for seq := range o.pending {
 			if seq > streamLastSeq {
-				delete(o.pending, seq)
+				o.removeFromPending(seq)
 			}
 		}
 	}
@@ -6275,7 +6296,7 @@ func (o *consumer) purge(sseq uint64, slseq uint64, isWider bool) {
 						o.dseq = o.adflr
 					}
 				}
-				delete(o.pending, seq)
+				o.removeFromPending(seq)
 				delete(o.rdc, seq)
 				// rdq handled below.
 			}
@@ -6290,7 +6311,7 @@ func (o *consumer) purge(sseq uint64, slseq uint64, isWider bool) {
 							o.dseq = o.adflr
 						}
 					}
-					delete(o.pending, seq)
+					o.removeFromPending(seq)
 					delete(o.rdc, seq)
 				}
 			}

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -4690,6 +4690,7 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 	// Save our starting sequence. If all remaining messages are on blocked
 	// subjects, we restore sseq so we don't permanently skip them.
 	savedSseq := o.sseq
+	var skipped bool
 
 	for {
 		var sseq uint64
@@ -4711,9 +4712,19 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 		}
 		if sm == nil {
 			pmsg.returnToPool()
+
+			// If we are at the end of the stream, check if our sequence was behind a purge/compact.
+			if err == ErrStoreEOF || err == ErrStoreClosed {
+				var ss StreamState
+				o.mset.store.FastState(&ss)
+				if o.sseq < ss.FirstSeq {
+					o.sseq = ss.FirstSeq
+				}
+			}
+
 			// No more messages available. If we skipped any blocked subjects,
 			// restore o.sseq so those messages aren't permanently lost.
-			if o.sseq != savedSseq {
+			if skipped && o.sseq != savedSseq {
 				o.sseq = savedSseq
 			}
 			return nil, 0, err
@@ -4729,13 +4740,16 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 			if sseq >= o.sseq {
 				o.sseq = sseq + 1
 			}
+			skipped = true
 			continue
 		}
 
 		// Found an unblocked message. Restore o.sseq to the saved position
 		// so blocked messages earlier in the stream aren't permanently skipped.
 		// Only the delivered message's sequence will be tracked via pending.
-		o.sseq = savedSseq
+		if skipped {
+			o.sseq = savedSseq
+		}
 		// Check if we should move our o.sseq.
 		if sseq >= o.sseq {
 			// If we are moving step by step then sseq == o.sseq.

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -12501,6 +12501,7 @@ func (o *consumerFileStore) UpdateDelivered(dseq, sseq, dc uint64, ts int64, sub
 				// Do not update p.Sequence, that should be the original delivery sequence.
 				p.Timestamp = ts
 			}
+		} else {
 			// Add to pending.
 			o.state.Pending[sseq] = &Pending{dseq, ts, subj}
 		}

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -12475,7 +12475,7 @@ func (o *consumerFileStore) HasState() bool {
 }
 
 // UpdateDelivered is called whenever a new message has been delivered.
-func (o *consumerFileStore) UpdateDelivered(dseq, sseq, dc uint64, ts int64) error {
+func (o *consumerFileStore) UpdateDelivered(dseq, sseq, dc uint64, ts int64, subj string) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
@@ -12501,9 +12501,8 @@ func (o *consumerFileStore) UpdateDelivered(dseq, sseq, dc uint64, ts int64) err
 				// Do not update p.Sequence, that should be the original delivery sequence.
 				p.Timestamp = ts
 			}
-		} else {
 			// Add to pending.
-			o.state.Pending[sseq] = &Pending{dseq, ts}
+			o.state.Pending[sseq] = &Pending{dseq, ts, subj}
 		}
 		// Update delivered as needed.
 		if dseq > o.state.Delivered.Consumer {
@@ -12665,7 +12664,7 @@ func (o *consumerFileStore) Update(state *ConsumerState) error {
 	if len(state.Pending) > 0 {
 		pending = make(map[uint64]*Pending, len(state.Pending))
 		for seq, p := range state.Pending {
-			pending[seq] = &Pending{p.Sequence, p.Timestamp}
+			pending[seq] = &Pending{p.Sequence, p.Timestamp, p.Subject}
 			if seq <= state.AckFloor.Stream || seq > state.Delivered.Stream {
 				return fmt.Errorf("bad pending entry, sequence [%d] out of range", seq)
 			}
@@ -12714,7 +12713,7 @@ func (o *consumerFileStore) ForceUpdate(state *ConsumerState) error {
 	if len(state.Pending) > 0 {
 		pending = make(map[uint64]*Pending, len(state.Pending))
 		for seq, p := range state.Pending {
-			pending[seq] = &Pending{p.Sequence, p.Timestamp}
+			pending[seq] = &Pending{p.Sequence, p.Timestamp, p.Subject}
 			if seq <= state.AckFloor.Stream || seq > state.Delivered.Stream {
 				return fmt.Errorf("bad pending entry, sequence [%d] out of range", seq)
 			}
@@ -12896,7 +12895,7 @@ func checkConsumerHeader(hdr []byte) (uint8, error) {
 func (o *consumerFileStore) copyPending() map[uint64]*Pending {
 	pending := make(map[uint64]*Pending, len(o.state.Pending))
 	for seq, p := range o.state.Pending {
-		pending[seq] = &Pending{p.Sequence, p.Timestamp}
+		pending[seq] = &Pending{p.Sequence, p.Timestamp, p.Subject}
 	}
 	return pending
 }
@@ -12993,7 +12992,7 @@ func (o *consumerFileStore) stateWithCopyLocked(doCopy bool) (*ConsumerState, er
 		if doCopy {
 			o.state.Pending = make(map[uint64]*Pending, len(state.Pending))
 			for seq, p := range state.Pending {
-				o.state.Pending[seq] = &Pending{p.Sequence, p.Timestamp}
+				o.state.Pending[seq] = &Pending{p.Sequence, p.Timestamp, p.Subject}
 			}
 		} else {
 			o.state.Pending = state.Pending
@@ -13119,7 +13118,7 @@ func decodeConsumerState(buf []byte) (*ConsumerState, error) {
 				ts = (mints - ts) * int64(time.Second)
 			}
 			// Store in pending.
-			state.Pending[sseq] = &Pending{dseq, ts}
+			state.Pending[sseq] = &Pending{dseq, ts, _EMPTY_}
 		}
 	}
 

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -2063,11 +2063,11 @@ func TestFileStoreConsumer(t *testing.T) {
 
 		// We should sanity check pending here as well, so will check if a pending value is below
 		// ack floor or above delivered.
-		state.Pending = map[uint64]*Pending{70: {70, tn}}
+		state.Pending = map[uint64]*Pending{70: {70, tn, _EMPTY_}}
 		shouldFail()
-		state.Pending = map[uint64]*Pending{140: {140, tn}}
+		state.Pending = map[uint64]*Pending{140: {140, tn, _EMPTY_}}
 		shouldFail()
-		state.Pending = map[uint64]*Pending{72: {72, tn}} // exact on floor should fail
+		state.Pending = map[uint64]*Pending{72: {72, tn, _EMPTY_}} // exact on floor should fail
 		shouldFail()
 
 		// Put timestamps a second apart.
@@ -2076,7 +2076,7 @@ func TestFileStoreConsumer(t *testing.T) {
 		ago := time.Now().Add(-30 * time.Second).Truncate(time.Second)
 		nt := func() *Pending {
 			ago = ago.Add(time.Second)
-			return &Pending{0, ago.UnixNano()}
+			return &Pending{0, ago.UnixNano(), _EMPTY_}
 		}
 		// Should succeed.
 		state.Pending = map[uint64]*Pending{75: nt(), 80: nt(), 83: nt(), 90: nt(), 111: nt()}
@@ -2143,9 +2143,9 @@ func TestFileStoreConsumerEncodeDecodePendingBelowStreamAckFloor(t *testing.T) {
 
 	now := time.Now().Round(time.Second).Add(-10 * time.Second).UnixNano()
 	state.Pending = map[uint64]*Pending{
-		10782: {1190, now},
-		10810: {1191, now + int64(time.Second)},
-		10815: {1192, now + int64(2*time.Second)},
+		10782: {1190, now, _EMPTY_},
+		10810: {1191, now + int64(time.Second), _EMPTY_},
+		10815: {1192, now + int64(2*time.Second), _EMPTY_},
 	}
 	buf := encodeConsumerState(state)
 
@@ -2562,16 +2562,14 @@ func TestFileStoreConsumerRedeliveredLost(t *testing.T) {
 		}
 
 		ts := time.Now().UnixNano()
-		o.UpdateDelivered(1, 1, 1, ts)
-		o.UpdateDelivered(2, 1, 2, ts)
-		o.UpdateDelivered(3, 1, 3, ts)
-		o.UpdateDelivered(4, 1, 4, ts)
-		o.UpdateDelivered(5, 2, 1, ts)
+		o.UpdateDelivered(1, 1, 1, ts, _EMPTY_)
+		o.UpdateDelivered(2, 1, 2, ts, _EMPTY_)
+		o.UpdateDelivered(3, 1, 3, ts, _EMPTY_)
+		o.UpdateDelivered(4, 1, 4, ts, _EMPTY_)
+		o.UpdateDelivered(5, 2, 1, ts, _EMPTY_)
 
-		restartConsumer()
-
-		o.UpdateDelivered(6, 2, 2, ts)
-		o.UpdateDelivered(7, 3, 1, ts)
+		o.UpdateDelivered(6, 2, 2, ts, _EMPTY_)
+		o.UpdateDelivered(7, 3, 1, ts, _EMPTY_)
 
 		restartConsumer()
 		if state, _ := o.State(); len(state.Pending) != 3 {
@@ -2641,7 +2639,7 @@ func TestFileStoreConsumerDeliveredUpdates(t *testing.T) {
 		testDelivered := func(dseq, sseq uint64) {
 			t.Helper()
 			ts := time.Now().UnixNano()
-			if err := o.UpdateDelivered(dseq, sseq, 1, ts); err != nil {
+			if err := o.UpdateDelivered(dseq, sseq, 1, ts, _EMPTY_); err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 			state, err := o.State()
@@ -2673,7 +2671,7 @@ func TestFileStoreConsumerDeliveredUpdates(t *testing.T) {
 		}
 		// Also if we do an update with a delivery count of anything but 1 here should also give same error.
 		ts := time.Now().UnixNano()
-		if err := o.UpdateDelivered(5, 130, 2, ts); err != ErrNoAckPolicy {
+		if err := o.UpdateDelivered(5, 130, 2, ts, _EMPTY_); err != ErrNoAckPolicy {
 			t.Fatalf("Expected a no ack policy error on update delivered with dc > 1, got %v", err)
 		}
 	})
@@ -2698,7 +2696,7 @@ func TestFileStoreConsumerDeliveredAndAckUpdates(t *testing.T) {
 		testDelivered := func(dseq, sseq uint64) {
 			t.Helper()
 			ts := time.Now().Round(time.Second).UnixNano()
-			if err := o.UpdateDelivered(dseq, sseq, 1, ts); err != nil {
+			if err := o.UpdateDelivered(dseq, sseq, 1, ts, _EMPTY_); err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 			pending++
@@ -2913,7 +2911,7 @@ func TestFileStoreConsumerPerf(t *testing.T) {
 		ts := start.UnixNano()
 
 		for i := uint64(1); i <= toStore; i++ {
-			if err := o.UpdateDelivered(i, i, 1, ts); err != nil {
+			if err := o.UpdateDelivered(i, i, 1, ts, _EMPTY_); err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 		}

--- a/server/jetstream_ack_pending_subject_test.go
+++ b/server/jetstream_ack_pending_subject_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !skip_js_tests
+
 package server
 
 import (

--- a/server/jetstream_ack_pending_subject_test.go
+++ b/server/jetstream_ack_pending_subject_test.go
@@ -1,0 +1,368 @@
+// Copyright 2023-2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func TestJetStreamMaxAckPendingPerSubject(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	// Create stream
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "MAPPS",
+		Subjects: []string{"test.*"},
+	})
+	if err != nil {
+		t.Fatalf("Error adding stream: %v", err)
+	}
+
+	// Create consumer with limit 1
+	req, _ := json.Marshal(&CreateConsumerRequest{
+		Stream: "MAPPS",
+		Config: ConsumerConfig{
+			Durable:                 "CONS",
+			AckPolicy:               AckExplicit,
+			MaxAckPendingPerSubject: 1,
+		},
+	})
+	resp, err := nc.Request(fmt.Sprintf(JSApiDurableCreateT, "MAPPS", "CONS"), req, time.Second)
+	if err != nil {
+		t.Fatalf("Error creating consumer: %v", err)
+	}
+	var ccResp JSApiConsumerCreateResponse
+	json.Unmarshal(resp.Data, &ccResp)
+	if ccResp.Error != nil {
+		t.Fatalf("Consumer create error: %v", ccResp.Error)
+	}
+
+	// Publish 2 messages to same subject
+	js.Publish("test.1", []byte("msg 1"))
+	js.Publish("test.1", []byte("msg 2"))
+
+	sub, err := js.PullSubscribe("", "CONS", nats.BindStream("MAPPS"))
+	if err != nil {
+		t.Fatalf("Error subscribing: %v", err)
+	}
+
+	// 1. Get first message
+	msgs1, err := sub.Fetch(1, nats.MaxWait(time.Second))
+	if err != nil || len(msgs1) != 1 {
+		t.Fatalf("Expected 1 message, got %v (err: %v)", len(msgs1), err)
+	}
+
+	// 2. Try to get second message - should timeout because of limit 1
+	msgs2, err := sub.Fetch(1, nats.MaxWait(200*time.Millisecond))
+	if err == nil && len(msgs2) > 0 {
+		t.Fatalf("Expected timeout because of limit, but got a message")
+	}
+
+	// 3. Ack first message
+	msgs1[0].Ack()
+
+	// 4. Try to get second message - should work now
+	msgs3, err := sub.Fetch(1, nats.MaxWait(time.Second))
+	if err != nil || len(msgs3) != 1 {
+		t.Fatalf("Expected second message after ack, but got %v (err: %v)", len(msgs3), err)
+	}
+}
+
+func TestJetStreamMaxAckPendingPerSubjectReactive(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	// Create stream
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "REACTIVE",
+		Subjects: []string{"test.*"},
+	})
+	if err != nil {
+		t.Fatalf("Error adding stream: %v", err)
+	}
+
+	// Create consumer with limit 1
+	req, _ := json.Marshal(&CreateConsumerRequest{
+		Stream: "REACTIVE",
+		Config: ConsumerConfig{
+			Durable:                 "CONS",
+			AckPolicy:               AckExplicit,
+			MaxAckPendingPerSubject: 1,
+		},
+	})
+	nc.Request(fmt.Sprintf(JSApiDurableCreateT, "REACTIVE", "CONS"), req, time.Second)
+
+	// Publish to different subjects
+	js.Publish("test.1", []byte("a1"))
+	js.Publish("test.2", []byte("b1"))
+
+	sub, err := js.PullSubscribe("", "CONS", nats.BindStream("REACTIVE"))
+	if err != nil {
+		t.Fatalf("Error subscribing: %v", err)
+	}
+
+	// Get a1
+	msgs, _ := sub.Fetch(1, nats.MaxWait(time.Second))
+	if len(msgs) != 1 || string(msgs[0].Data) != "a1" {
+		t.Fatalf("Expected a1")
+	}
+
+	// Get b1 - should work because different subject
+	msgs, err = sub.Fetch(1, nats.MaxWait(time.Second))
+	if err != nil || len(msgs) != 1 || string(msgs[0].Data) != "b1" {
+		t.Fatalf("Expected b1 (err: %v)", err)
+	}
+}
+
+func BenchmarkMaxAckPendingPerSubjectFetch(b *testing.B) {
+	s := RunBasicJetStreamServer(b)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(b, s)
+	defer nc.Close()
+
+	js.AddStream(&nats.StreamConfig{
+		Name:     "BENCH_FETCH",
+		Subjects: []string{"test.*"},
+	})
+
+	req, _ := json.Marshal(&CreateConsumerRequest{
+		Stream: "BENCH_FETCH",
+		Config: ConsumerConfig{
+			Durable:                 "CONS",
+			AckPolicy:               AckExplicit,
+			MaxAckPendingPerSubject: 50,
+		},
+	})
+	nc.Request(fmt.Sprintf(JSApiDurableCreateT, "BENCH_FETCH", "CONS"), req, time.Second)
+
+	// Pre-publish more to avoid constant restarts
+	for i := 0; i < 5000; i++ {
+		js.Publish("test.1", []byte("data"))
+	}
+
+	sub, _ := js.PullSubscribe("", "CONS", nats.BindStream("BENCH_FETCH"))
+
+	groups := []string{"test.group_1", "test.group_2", "test.group_3"}
+	unacked := make(map[string]int)
+	maxUnacked := make(map[string]int)
+	for _, g := range groups {
+		unacked[g] = 0
+		maxUnacked[g] = 0
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; {
+		batch := 100
+		if i+batch > b.N {
+			batch = b.N - i
+		}
+		msgs, err := sub.Fetch(batch, nats.MaxWait(500*time.Millisecond))
+		if err == nil && len(msgs) > 0 {
+			for _, m := range msgs {
+				subj := m.Subject
+				unacked[subj]++
+				if unacked[subj] > maxUnacked[subj] {
+					maxUnacked[subj] = unacked[subj]
+				}
+			}
+			for _, m := range msgs {
+				m.Ack()
+				unacked[m.Subject]--
+			}
+			i += len(msgs)
+		} else {
+			i++ // avoid infinite loop if no msgs
+		}
+
+		if i > 0 && i%5000 == 0 {
+			fmt.Printf("Fetch progress: %d/%d (Max Pending: group_1=%d, group_2=%d, group_3=%d)\n",
+				i, b.N, maxUnacked["test.group_1"], maxUnacked["test.group_2"], maxUnacked["test.group_3"])
+			b.StopTimer()
+			for _, g := range groups {
+				for j := 0; j < 2000; j++ {
+					js.Publish(g, []byte("data"))
+				}
+			}
+			b.StartTimer()
+		}
+	}
+}
+
+func BenchmarkMaxAckPendingPerSubjectCallback(b *testing.B) {
+	s := RunBasicJetStreamServer(b)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(b, s)
+	defer nc.Close()
+
+	js.AddStream(&nats.StreamConfig{
+		Name:     "BENCH_CB",
+		Subjects: []string{"test.*"},
+	})
+
+	// Use a Push consumer for callback benchmark
+	req, _ := json.Marshal(&CreateConsumerRequest{
+		Stream: "BENCH_CB",
+		Config: ConsumerConfig{
+			Durable:                 "CONS",
+			DeliverSubject:          "ds",
+			AckPolicy:               AckExplicit,
+			MaxAckPendingPerSubject: 50,
+		},
+	})
+	nc.Request(fmt.Sprintf(JSApiDurableCreateT, "BENCH_CB", "CONS"), req, time.Second)
+
+	done := make(chan struct{})
+	var count int32
+	groups := []string{"test.group_1", "test.group_2", "test.group_3"}
+	var unacked sync.Map    // string -> *int32
+	var maxUnacked sync.Map // string -> *int32
+
+	for _, g := range groups {
+		var u int32 = 0
+		var m int32 = 0
+		unacked.Store(g, &u)
+		maxUnacked.Store(g, &m)
+	}
+
+	// Use js.Subscribe which will bind to the push consumer
+	sub, _ := js.Subscribe("test.*", func(m *nats.Msg) {
+		subj := m.Subject
+		uPtr, _ := unacked.Load(subj)
+		mPtr, _ := maxUnacked.Load(subj)
+		u := uPtr.(*int32)
+		mx := mPtr.(*int32)
+
+		atomic.AddInt32(u, 1)
+		currU := atomic.LoadInt32(u)
+		for {
+			prevM := atomic.LoadInt32(mx)
+			if currU <= prevM || atomic.CompareAndSwapInt32(mx, prevM, currU) {
+				break
+			}
+		}
+
+		// Simulate minor processing delay to let unacked build up
+		if currU < 50 {
+			time.Sleep(1 * time.Microsecond)
+		}
+
+		m.Ack()
+		atomic.AddInt32(u, -1)
+
+		curr := atomic.AddInt32(&count, 1)
+		if int(curr)%5000 == 0 {
+			m1, _ := maxUnacked.Load("test.group_1")
+			m2, _ := maxUnacked.Load("test.group_2")
+			m3, _ := maxUnacked.Load("test.group_3")
+			fmt.Printf("Callback progress: %d/%d (Max Pending: group_1=%d, group_2=%d, group_3=%d)\n",
+				curr, b.N, atomic.LoadInt32(m1.(*int32)), atomic.LoadInt32(m2.(*int32)), atomic.LoadInt32(m3.(*int32)))
+		}
+		if int(curr) >= b.N {
+			select {
+			case done <- struct{}{}:
+			default:
+			}
+		}
+	}, nats.BindStream("BENCH_CB"), nats.Durable("CONS"), nats.ManualAck())
+
+	b.ResetTimer()
+	// Publish in a separate goroutine
+	go func() {
+		for i := 0; i < b.N; i++ {
+			subj := groups[i%len(groups)]
+			js.Publish(subj, []byte("data"))
+			if (i+1)%5000 == 0 {
+				fmt.Printf("Publish progress: %d/%d\n", i+1, b.N)
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		b.Fatalf("Benchmark timed out at %d/%d", atomic.LoadInt32(&count), b.N)
+	}
+	sub.Unsubscribe()
+}
+
+func TestJetStreamMaxAckPendingPerSubjectVisual(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	js.AddStream(&nats.StreamConfig{
+		Name:     "VISUAL",
+		Subjects: []string{"test.*"},
+	})
+
+	// Set limit to 50
+	req, _ := json.Marshal(&CreateConsumerRequest{
+		Stream: "VISUAL",
+		Config: ConsumerConfig{
+			Durable:                 "CONS",
+			AckPolicy:               AckExplicit,
+			MaxAckPendingPerSubject: 50,
+		},
+	})
+	nc.Request(fmt.Sprintf(JSApiDurableCreateT, "VISUAL", "CONS"), req, time.Second)
+
+	// Publish 100 per group, interleaved
+	groups := []string{"test.group_1", "test.group_2", "test.group_3"}
+	for i := 0; i < 100; i++ {
+		for _, g := range groups {
+			js.Publish(g, []byte("data"))
+		}
+	}
+
+	sub, _ := js.PullSubscribe("", "CONS", nats.BindStream("VISUAL"))
+
+	// Fetch as many as possible
+	fmt.Printf("\n--- Visual Proof of Per-Subject Limits (Limit: 50) ---\n")
+	counts := make(map[string]int)
+	for _, g := range groups {
+		counts[g] = 0
+	}
+
+	// Try to fetch 300 messages total (100 per group available)
+	msgs, _ := sub.Fetch(300, nats.MaxWait(500*time.Millisecond))
+	for _, m := range msgs {
+		counts[m.Subject]++
+	}
+
+	for _, g := range groups {
+		fmt.Printf("Subject: %s | Received: %d | Limit: 50\n", g, counts[g])
+		if counts[g] > 50 {
+			t.Errorf("Subject %s exceeded limit! Got %d", g, counts[g])
+		}
+	}
+	fmt.Printf("---------------------------------------------------\n")
+}

--- a/server/jetstream_ack_pending_subject_test.go
+++ b/server/jetstream_ack_pending_subject_test.go
@@ -158,62 +158,33 @@ func BenchmarkMaxAckPendingPerSubjectFetch(b *testing.B) {
 		Config: ConsumerConfig{
 			Durable:                 "CONS",
 			AckPolicy:               AckExplicit,
-			MaxAckPendingPerSubject: 50,
+			MaxAckPendingPerSubject: 100,
 		},
 	})
 	nc.Request(fmt.Sprintf(JSApiDurableCreateT, "BENCH_FETCH", "CONS"), req, time.Second)
 
-	// Pre-publish more to avoid constant restarts
-	for i := 0; i < 5000; i++ {
-		js.Publish("test.1", []byte("data"))
+	// Pre-publish 100k messages to a few subjects
+	subjects := []string{"test.1", "test.2", "test.3", "test.4", "test.5"}
+	for i := 0; i < 100000; i++ {
+		js.Publish(subjects[i%len(subjects)], []byte("data"))
 	}
 
 	sub, _ := js.PullSubscribe("", "CONS", nats.BindStream("BENCH_FETCH"))
 
-	groups := []string{"test.group_1", "test.group_2", "test.group_3"}
-	unacked := make(map[string]int)
-	maxUnacked := make(map[string]int)
-	for _, g := range groups {
-		unacked[g] = 0
-		maxUnacked[g] = 0
-	}
-
 	b.ResetTimer()
 	for i := 0; i < b.N; {
 		batch := 100
-		if i+batch > b.N {
-			batch = b.N - i
-		}
-		msgs, err := sub.Fetch(batch, nats.MaxWait(500*time.Millisecond))
+		msgs, err := sub.Fetch(batch, nats.MaxWait(time.Second))
 		if err == nil && len(msgs) > 0 {
 			for _, m := range msgs {
-				subj := m.Subject
-				unacked[subj]++
-				if unacked[subj] > maxUnacked[subj] {
-					maxUnacked[subj] = unacked[subj]
-				}
-			}
-			for _, m := range msgs {
 				m.Ack()
-				unacked[m.Subject]--
 			}
 			i += len(msgs)
-		} else {
-			i++ // avoid infinite loop if no msgs
-		}
-
-		if i > 0 && i%5000 == 0 {
-			fmt.Printf("Fetch progress: %d/%d (Max Pending: group_1=%d, group_2=%d, group_3=%d)\n",
-				i, b.N, maxUnacked["test.group_1"], maxUnacked["test.group_2"], maxUnacked["test.group_3"])
-			b.StopTimer()
-			for _, g := range groups {
-				for j := 0; j < 2000; j++ {
-					js.Publish(g, []byte("data"))
-				}
-			}
-			b.StartTimer()
+		} else if err != nil {
+			break
 		}
 	}
+	b.StopTimer()
 }
 
 func BenchmarkMaxAckPendingPerSubjectCallback(b *testing.B) {
@@ -367,4 +338,91 @@ func TestJetStreamMaxAckPendingPerSubjectVisual(t *testing.T) {
 		}
 	}
 	fmt.Printf("---------------------------------------------------\n")
+}
+
+func TestJetStreamMaxAckPendingPerSubjectConfigUpdate(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	// Create stream
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "CONFIG_UPDATE",
+		Subjects: []string{"test.*"},
+	})
+	if err != nil {
+		t.Fatalf("Error adding stream: %v", err)
+	}
+
+	// Create consumer WITHOUT limit (0)
+	req, _ := json.Marshal(&CreateConsumerRequest{
+		Stream: "CONFIG_UPDATE",
+		Config: ConsumerConfig{
+			Durable:   "CONS",
+			AckPolicy: AckExplicit,
+		},
+	})
+	nc.Request(fmt.Sprintf(JSApiDurableCreateT, "CONFIG_UPDATE", "CONS"), req, time.Second)
+
+	// Publish 3 messages to same subject
+	js.Publish("test.1", []byte("msg 1"))
+	js.Publish("test.1", []byte("msg 2"))
+	js.Publish("test.1", []byte("msg 3"))
+
+	sub, err := js.PullSubscribe("", "CONS", nats.BindStream("CONFIG_UPDATE"))
+	if err != nil {
+		t.Fatalf("Error subscribing: %v", err)
+	}
+
+	// 1. Get 2 messages (limit is disabled, so both should come)
+	msgs, err := sub.Fetch(2, nats.MaxWait(time.Second))
+	if err != nil || len(msgs) != 2 {
+		t.Fatalf("Expected 2 messages, got %v (err: %v)", len(msgs), err)
+	}
+
+	// 2. Update consumer config to enable limit = 1
+	req, _ = json.Marshal(&CreateConsumerRequest{
+		Stream: "CONFIG_UPDATE",
+		Config: ConsumerConfig{
+			Durable:                 "CONS",
+			AckPolicy:               AckExplicit,
+			MaxAckPendingPerSubject: 1,
+		},
+	})
+	resp, err := nc.Request(fmt.Sprintf(JSApiDurableCreateT, "CONFIG_UPDATE", "CONS"), req, time.Second)
+	if err != nil {
+		t.Fatalf("Error updating consumer: %v", err)
+	}
+	var ccResp JSApiConsumerCreateResponse
+	json.Unmarshal(resp.Data, &ccResp)
+	if ccResp.Error != nil {
+		t.Fatalf("Consumer update error: %v", ccResp.Error)
+	}
+
+	// 3. Try to get third message - should timeout because current pending on test.1 is 2, and limit is 1
+	// If backfill worked, o.ptc["test.1"] should be 2.
+	msgs2, err := sub.Fetch(1, nats.MaxWait(500*time.Millisecond))
+	if err == nil && len(msgs2) > 0 {
+		t.Fatalf("Expected timeout because of NEW limit, but got a message. Backfill failed?")
+	}
+
+	// 4. Ack 1 message. Pending becomes 1. Limit is 1. Still blocked?
+	// JetStream logic uses >= limit for blocking.
+	msgs[0].Ack()
+
+	msgs3, err := sub.Fetch(1, nats.MaxWait(500*time.Millisecond))
+	if err == nil && len(msgs3) > 0 {
+		t.Fatalf("Expected timeout because pending is 1 and limit is 1. Got a message.")
+	}
+
+	// 5. Ack 2nd message. Pending becomes 0.
+	msgs[1].Ack()
+
+	// 6. Now third message should arrive
+	msgs4, err := sub.Fetch(1, nats.MaxWait(time.Second))
+	if err != nil || len(msgs4) != 1 {
+		t.Fatalf("Expected third message after acks, but got %v (err: %v)", len(msgs4), err)
+	}
 }

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -6480,7 +6480,7 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 			buf := e.Data
 			switch entryOp(buf[0]) {
 			case updateDeliveredOp:
-				dseq, sseq, dc, ts, err := decodeDeliveredUpdate(buf[1:])
+				dseq, sseq, dc, ts, subj, err := decodeDeliveredUpdate(buf[1:])
 				if err != nil {
 					if mset, node := o.streamAndNode(); mset != nil && node != nil {
 						s := js.srv
@@ -6491,7 +6491,7 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 				}
 				// Make sure to update delivered under the lock.
 				o.mu.Lock()
-				err = o.store.UpdateDelivered(dseq, sseq, dc, ts)
+				err = o.store.UpdateDelivered(dseq, sseq, dc, ts, subj)
 				o.ldt = time.Now()
 				// Need to send message to the client, since we have quorum to do so now.
 				if pmsg, ok := o.pendingDeliveries[sseq]; ok {
@@ -6665,24 +6665,28 @@ func decodeAckUpdate(buf []byte) (dseq, sseq uint64, err error) {
 	return dseq, sseq, nil
 }
 
-func decodeDeliveredUpdate(buf []byte) (dseq, sseq, dc uint64, ts int64, err error) {
+func decodeDeliveredUpdate(buf []byte) (dseq, sseq, dc uint64, ts int64, subj string, err error) {
 	var bi, n int
 	if dseq, n = binary.Uvarint(buf); n < 0 {
-		return 0, 0, 0, 0, errBadDeliveredUpdate
+		return 0, 0, 0, 0, "", errBadDeliveredUpdate
 	}
 	bi += n
 	if sseq, n = binary.Uvarint(buf[bi:]); n < 0 {
-		return 0, 0, 0, 0, errBadDeliveredUpdate
+		return 0, 0, 0, 0, "", errBadDeliveredUpdate
 	}
 	bi += n
 	if dc, n = binary.Uvarint(buf[bi:]); n < 0 {
-		return 0, 0, 0, 0, errBadDeliveredUpdate
+		return 0, 0, 0, 0, "", errBadDeliveredUpdate
 	}
 	bi += n
 	if ts, n = binary.Varint(buf[bi:]); n < 0 {
-		return 0, 0, 0, 0, errBadDeliveredUpdate
+		return 0, 0, 0, 0, "", errBadDeliveredUpdate
 	}
-	return dseq, sseq, dc, ts, nil
+	bi += n
+	if bi < len(buf) {
+		subj = string(buf[bi:])
+	}
+	return dseq, sseq, dc, ts, subj, nil
 }
 
 func (js *jetStream) processConsumerLeaderChange(o *consumer, isLeader bool) error {

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -4602,7 +4602,7 @@ func TestJetStreamClusterDontInstallSnapshotWhenStoppingConsumer(t *testing.T) {
 	validateConsumerState(snap)
 
 	// Simulate a message being delivered, but not calling Applied yet.
-	err = o.store.UpdateDelivered(2, 2, 1, time.Now().UnixNano())
+	err = o.store.UpdateDelivered(2, 2, 1, time.Now().UnixNano(), _EMPTY_)
 	require_NoError(t, err)
 
 	// Simulate the consumer being stopped before we're able to call Applied.

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -2400,7 +2400,7 @@ func (o *consumerMemStore) Update(state *ConsumerState) error {
 	if len(state.Pending) > 0 {
 		pending = make(map[uint64]*Pending, len(state.Pending))
 		for seq, p := range state.Pending {
-			pending[seq] = &Pending{p.Sequence, p.Timestamp}
+			pending[seq] = &Pending{p.Sequence, p.Timestamp, p.Subject}
 			if seq <= state.AckFloor.Stream || seq > state.Delivered.Stream {
 				return fmt.Errorf("bad pending entry, sequence [%d] out of range", seq)
 			}
@@ -2445,7 +2445,7 @@ func (o *consumerMemStore) ForceUpdate(state *ConsumerState) error {
 	if len(state.Pending) > 0 {
 		pending = make(map[uint64]*Pending, len(state.Pending))
 		for seq, p := range state.Pending {
-			pending[seq] = &Pending{p.Sequence, p.Timestamp}
+			pending[seq] = &Pending{p.Sequence, p.Timestamp, p.Subject}
 			if seq <= state.AckFloor.Stream || seq > state.Delivered.Stream {
 				return fmt.Errorf("bad pending entry, sequence [%d] out of range", seq)
 			}
@@ -2509,7 +2509,7 @@ func (o *consumerMemStore) HasState() bool {
 	return o.state.Delivered.Consumer != 0 || o.state.Delivered.Stream != 0
 }
 
-func (o *consumerMemStore) UpdateDelivered(dseq, sseq, dc uint64, ts int64) error {
+func (o *consumerMemStore) UpdateDelivered(dseq, sseq, dc uint64, ts int64, subj string) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
@@ -2537,7 +2537,7 @@ func (o *consumerMemStore) UpdateDelivered(dseq, sseq, dc uint64, ts int64) erro
 			}
 		} else {
 			// Add to pending.
-			o.state.Pending[sseq] = &Pending{dseq, ts}
+			o.state.Pending[sseq] = &Pending{dseq, ts, subj}
 		}
 		// Update delivered as needed.
 		if dseq > o.state.Delivered.Consumer {
@@ -2729,7 +2729,7 @@ func (o *consumerMemStore) EncodedState() ([]byte, error) {
 func (o *consumerMemStore) copyPending() map[uint64]*Pending {
 	pending := make(map[uint64]*Pending, len(o.state.Pending))
 	for seq, p := range o.state.Pending {
-		pending[seq] = &Pending{p.Sequence, p.Timestamp}
+		pending[seq] = &Pending{p.Sequence, p.Timestamp, p.Subject}
 	}
 	return pending
 }

--- a/server/norace_1_test.go
+++ b/server/norace_1_test.go
@@ -4173,7 +4173,7 @@ func TestNoRaceJetStreamConsumerFileStoreConcurrentDiskIO(t *testing.T) {
 			defer wg.Done()
 			// Will make everyone run concurrently.
 			<-startCh
-			o.UpdateDelivered(22, 22, 1, ts)
+			o.UpdateDelivered(22, 22, 1, ts, _EMPTY_)
 			buf, _ := o.(*consumerFileStore).encodeState()
 			o.(*consumerFileStore).writeState(buf)
 			o.Delete()

--- a/server/store.go
+++ b/server/store.go
@@ -362,7 +362,7 @@ type ConsumerStore interface {
 	UpdateStarting(sseq uint64)
 	Reset(sseq uint64) error
 	HasState() bool
-	UpdateDelivered(dseq, sseq, dc uint64, ts int64) error
+	UpdateDelivered(dseq, sseq, dc uint64, ts int64, subj string) error
 	UpdateAcks(dseq, sseq uint64) error
 	UpdateConfig(cfg *ConsumerConfig) error
 	Update(*ConsumerState) error
@@ -464,6 +464,7 @@ func encodeConsumerState(state *ConsumerState) []byte {
 type Pending struct {
 	Sequence  uint64
 	Timestamp int64
+	Subject   string
 }
 
 const (


### PR DESCRIPTION
Adds [MaxAckPendingPerSubject](cci:1://file:///d:/zenozaga/Github/accounts/zenozaga/go/nats-server/server/jetstream_ack_pending_subject_test.go:31:0-98:1) to [ConsumerConfig](cci:2://file:///d:/zenozaga/Github/accounts/zenozaga/go/nats-server/server/consumer.go:87:0-140:1) to limit outstanding ACKs on a per-subject basis. This allows for granular flow control and prevents a single subject from exhausting the consumer's total [MaxAckPending](cci:1://file:///d:/zenozaga/Github/accounts/zenozaga/go/nats-server/server/jetstream_ack_pending_subject_test.go:31:0-98:1) capacity.
This implementation resolves nats-io/nats-server#4273.

#### Example
Consider a consumer subscribed to `messaging.group.>` with `MaxAckPending: 10` and `MaxAckPendingPerSubject: 1`. 
This configuration allows the consumer to process messages for up to 10 different groups simultaneously, while restricting each specific child subject to only one message at a time. If multiple messages arrive for `messaging.group.A`, the server delivers the first one and holds the rest, ensuring that the remaining global concurrency slots stay available for other subjects like `messaging.group.B`. As soon as a subject is acknowledged, the server proactively resumes delivery for the next available message of that literal subject.

Signed-off-by: Randy stiven Valentin <zenozaga@gmail.com>