### PR TITLE
(2.14) Filestore locking fixes

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5626,7 +5626,6 @@ func (fs *fileStore) removeMsg(seq uint64, secure, viaLimits, needFSLock bool) (
 	}
 	// Always return previous write errors.
 	if err := fs.werr; err != nil {
-		fsUnlock()
 		return false, err
 	}
 	// If in encrypted mode negate secure rewrite here.


### PR DESCRIPTION
Fix two locking issues in filestore:

- werr check outside mutex protection in `purge`
- double unlock path in `removeMsg`

Signed-off-by: Daniele Sciascia <daniele@nats.io>
