### PR TITLE
[IMPROVED] Always compact, even for non-changed state

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/klauspost/compress/s2"
-	"github.com/minio/highwayhash"
 	"github.com/nats-io/nuid"
 )
 
@@ -2974,13 +2973,6 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 	}
 	accName := acc.GetName()
 
-	// Used to represent how we can detect a changed state quickly and without representing
-	// a complete and detailed state which could be costly in terms of memory, cpu and GC.
-	// This only entails how many messages, and the first and last sequence of the stream.
-	// This is all that is needed to detect a change, and we can get this from FilteredState()
-	// with an empty filter.
-	var lastState SimpleState
-
 	// Don't allow the upper layer to install snapshots until we have
 	// fully recovered from disk.
 	isRecovering := true
@@ -2990,19 +2982,6 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 		// Suppress during recovery.
 		// If snapshots have failed, and we're not forced to, we'll wait for the timer since it'll now be forced.
 		if mset == nil || isRecovering || isRestore || (!force && failedSnapshots > 0) {
-			return
-		}
-
-		// Before we actually calculate the detailed state and encode it, let's check the
-		// simple state to detect any changes.
-		curState, _ := mset.store.FilteredState(0, _EMPTY_)
-
-		// If the state hasn't changed but the log has gone way over
-		// the compaction size then we will want to compact anyway.
-		// This shouldn't happen for streams like it can for pull
-		// consumers on idle streams but better to be safe than sorry!
-		ne, nb := n.Size()
-		if curState == lastState && ne < compactNumMin && nb < compactSizeMin {
 			return
 		}
 
@@ -3026,7 +3005,6 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 		// protects our log size from growing indefinitely.
 		forceSnapshot := failedSnapshots > 4
 		if err := n.InstallSnapshot(mset.stateSnapshot(), forceSnapshot); err == nil {
-			lastState = curState
 			// If there was a failed snapshot before, we reduced the timer's interval.
 			// Reset it back to the original interval now.
 			if failedSnapshots > 0 {
@@ -6182,8 +6160,6 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 	key := make([]byte, 32)
 	crand.Read(key)
 
-	// Hash of the last snapshot (fixed size in memory).
-	var lastSnap []byte
 	var lastSnapTime time.Time
 
 	// Don't allow the upper layer to install snapshots until we have
@@ -6198,45 +6174,30 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 			return
 		}
 
-		// Check several things to see if we need a snapshot.
-		ne, nb := n.Size()
-		if !n.NeedSnapshot() {
-			// Check if we should compact etc. based on size of log.
-			if !force && ne < compactNumMin && nb < compactSizeMin {
-				return
-			}
-		}
-
 		if snap, err := o.store.EncodedState(); err == nil {
-			hash := highwayhash.Sum(snap, key)
-			// If the state hasn't changed but the log has gone way over
-			// the compaction size then we will want to compact anyway.
-			// This can happen for example when a pull consumer fetches a
-			// lot on an idle stream, log entries get distributed but the
-			// state never changes, therefore the log never gets compacted.
-			if !bytes.Equal(hash[:], lastSnap) || ne >= compactNumMin || nb >= compactSizeMin {
-				// If we had a significant number of failed snapshots, start relaxing Raft-layer checks
-				// to force it through. We might have been catching up a peer for a long period, and this
-				// protects our log size from growing indefinitely.
-				forceSnapshot := failedSnapshots > 4
-				if err := n.InstallSnapshot(snap, forceSnapshot); err == nil {
-					lastSnap, lastSnapTime = hash[:], time.Now()
-					// If there was a failed snapshot before, we reduced the timer's interval.
-					// Reset it back to the original interval now.
-					if failedSnapshots > 0 {
-						t.Reset(compactInterval + rci)
-					}
-					failedSnapshots = 0
-				} else if err != errNoSnapAvailable && err != errNodeClosed && err != errCatchupsRunning {
-					s.RateLimitWarnf("Failed to install snapshot for '%s > %s > %s' [%s]: %v", o.acc.Name, ca.Stream, ca.Name, n.Group(), err)
-					// If this is the first failure, reduce the interval of the snapshot timer.
-					// This ensures we're not waiting too long for snapshotting to eventually become forced.
-					if failedSnapshots == 0 {
-						t.Reset(compactMinInterval)
-					}
-					failedSnapshots++
+			// If we had a significant number of failed snapshots, start relaxing Raft-layer checks
+			// to force it through. We might have been catching up a peer for a long period, and this
+			// protects our log size from growing indefinitely.
+			forceSnapshot := failedSnapshots > 4
+			if err := n.InstallSnapshot(snap, forceSnapshot); err == nil {
+				lastSnapTime = time.Now()
+				// If there was a failed snapshot before, we reduced the timer's interval.
+				// Reset it back to the original interval now.
+				if failedSnapshots > 0 {
+					t.Reset(compactInterval + rci)
 				}
+				failedSnapshots = 0
+			} else if err != errNoSnapAvailable && err != errNodeClosed && err != errCatchupsRunning {
+				s.RateLimitWarnf("Failed to install snapshot for '%s > %s > %s' [%s]: %v", o.acc.Name, ca.Stream, ca.Name, n.Group(), err)
+				// If this is the first failure, reduce the interval of the snapshot timer.
+				// This ensures we're not waiting too long for snapshotting to eventually become forced.
+				if failedSnapshots == 0 {
+					t.Reset(compactMinInterval)
+				}
+				failedSnapshots++
 			}
+		} else {
+			s.RateLimitWarnf("Failed to install snapshot for '%s > %s > %s' [%s]: %v", o.acc.Name, ca.Stream, ca.Name, n.Group(), err)
 		}
 	}
 
@@ -8199,7 +8160,11 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		rg.Preferred = _EMPTY_
 	}
 
-	sa := &streamAssignment{Group: rg, Sync: osa.Sync, Created: osa.Created, Config: newCfg, Subject: subject, Reply: reply, Client: ci}
+	syncSubject := osa.Sync
+	if syncSubject == _EMPTY_ {
+		syncSubject = syncSubjForStream()
+	}
+	sa := &streamAssignment{Group: rg, Sync: syncSubject, Created: osa.Created, Config: newCfg, Subject: subject, Reply: reply, Client: ci}
 	if err := meta.Propose(encodeUpdateStreamAssignment(sa)); err != nil {
 		return
 	}

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -9755,6 +9755,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterAssetCreateOrUpdate(t *tes
 	}
 	sa := &streamAssignment{
 		Config:  scfg,
+		Sync:    syncSubjForStream(),
 		Group:   rg,
 		Created: time.Now().UTC(),
 		Client:  ci,
@@ -10059,6 +10060,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterDowngrade(t *testing.T) {
 	}
 	sa := &streamAssignment{
 		Config:  scfg,
+		Sync:    syncSubjForStream(),
 		Group:   rg,
 		Created: time.Now().UTC(),
 		Client:  ci,


### PR DESCRIPTION
These conditions were effectively noops. We need to snapshot/compact when we reach minimum compaction limits, and this compaction needs to happen regardless of if stream/consumer state changed or not. Actually in the case of consumers, `EncodedState` isn't guaranteed to equal byte-by-byte either, since `Pending` and `Redelivered` are maps and are iterated randomly by Go (credit to @wallyqs for this one).

This PR is purely a code improvement and doesn't have any functional differences.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>