### PR TITLE
Fix MetaClusterInfo.Snapshot not populated in Varz and Statsz responses

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -1061,6 +1061,7 @@ func (s *Server) sendStatsz(subj string) {
 					jStat.Meta.PendingInfos = ipq.len()
 				}
 				jStat.Meta.Pending = jStat.Meta.PendingRequests + jStat.Meta.PendingInfos
+				jStat.Meta.Snapshot = s.metaClusterSnapshotStats(js, mg)
 			}
 		}
 		jStat.Limits = &s.getOpts().JetStreamLimits

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1576,6 +1576,7 @@ func (s *Server) updateJszVarz(js *jetStream, v *JetStreamVarz, doConfig bool) {
 				v.Meta.PendingInfos = ipq.len()
 			}
 			v.Meta.Pending = v.Meta.PendingRequests + v.Meta.PendingInfos
+			v.Meta.Snapshot = s.metaClusterSnapshotStats(js, mg)
 		}
 	}
 }
@@ -3012,6 +3013,32 @@ type MetaSnapshotStats struct {
 	LastDuration   time.Duration `json:"last_duration,omitempty"` // LastDuration is how long the last meta snapshot took
 }
 
+// metaClusterSnapshotStats returns snapshot statistics for the meta group.
+func (s *Server) metaClusterSnapshotStats(js *jetStream, mg RaftNode) *MetaSnapshotStats {
+	entries, bytes := mg.Size()
+	snap := &MetaSnapshotStats{
+		PendingEntries: entries,
+		PendingSize:    bytes,
+	}
+
+	js.mu.RLock()
+	cluster := js.cluster
+	js.mu.RUnlock()
+
+	if cluster != nil {
+		timeNanos := atomic.LoadInt64(&cluster.lastMetaSnapTime)
+		durationNanos := atomic.LoadInt64(&cluster.lastMetaSnapDuration)
+		if timeNanos > 0 {
+			snap.LastTime = time.Unix(0, timeNanos).UTC()
+		}
+		if durationNanos > 0 {
+			snap.LastDuration = time.Duration(durationNanos)
+		}
+	}
+
+	return snap
+}
+
 // MetaClusterInfo shows information about the meta group.
 type MetaClusterInfo struct {
 	Name            string             `json:"name,omitempty"`     // Name is the name of the cluster
@@ -3239,7 +3266,6 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 
 	if mg := js.getMetaGroup(); mg != nil {
 		if ci := s.raftNodeToClusterInfo(mg); ci != nil {
-			entries, bytes := mg.Size()
 			jsi.Meta = &MetaClusterInfo{Name: ci.Name, Leader: ci.Leader, Peer: getHash(ci.Leader), Size: mg.ClusterSize()}
 			if isLeader {
 				jsi.Meta.Replicas = ci.Replicas
@@ -3251,24 +3277,7 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 				jsi.Meta.PendingInfos = ipq.len()
 			}
 			jsi.Meta.Pending = jsi.Meta.PendingRequests + jsi.Meta.PendingInfos
-			// Add meta snapshot stats
-			jsi.Meta.Snapshot = &MetaSnapshotStats{
-				PendingEntries: entries,
-				PendingSize:    bytes,
-			}
-			js.mu.RLock()
-			cluster := js.cluster
-			js.mu.RUnlock()
-			if cluster != nil {
-				timeNanos := atomic.LoadInt64(&cluster.lastMetaSnapTime)
-				durationNanos := atomic.LoadInt64(&cluster.lastMetaSnapDuration)
-				if timeNanos > 0 {
-					jsi.Meta.Snapshot.LastTime = time.Unix(0, timeNanos).UTC()
-				}
-				if durationNanos > 0 {
-					jsi.Meta.Snapshot.LastDuration = time.Duration(durationNanos)
-				}
-			}
+			jsi.Meta.Snapshot = s.metaClusterSnapshotStats(js, mg)
 		}
 	}
 

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -6601,3 +6601,67 @@ func TestMonitorVarzTLSCertEndDate(t *testing.T) {
 	check(t, v.MQTT.TLSCertNotAfter)
 	check(t, v.Websocket.TLSCertNotAfter)
 }
+
+func TestMetaClusterInfoSnapshotStats(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	// Create a stream to generate some meta activity.
+	s := c.randomNonLeader()
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	leader := c.leader()
+	require_True(t, leader != nil)
+
+	// Check Jsz() includes Snapshot.
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		jsi, err := leader.Jsz(nil)
+		if err != nil {
+			return err
+		}
+		if jsi.Meta == nil {
+			return errors.New("expected meta cluster info from Jsz")
+		}
+		if jsi.Meta.Snapshot == nil {
+			return errors.New("expected snapshot stats in Jsz meta cluster info")
+		}
+		return nil
+	})
+
+	// Check Varz() includes Snapshot.
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		v, err := leader.Varz(nil)
+		if err != nil {
+			return err
+		}
+		if v.JetStream.Meta == nil {
+			return errors.New("expected meta cluster info from Varz")
+		}
+		if v.JetStream.Meta.Snapshot == nil {
+			return errors.New("expected snapshot stats in Varz meta cluster info")
+		}
+		return nil
+	})
+
+	// Check STATSZ event includes Snapshot.
+	snc, _ := jsClientConnect(t, c.randomServer(), nats.UserInfo("admin", "s3cr3t!"))
+	defer snc.Close()
+
+	ch := make(chan *nats.Msg, 1)
+	_, err = snc.ChanSubscribe(fmt.Sprintf(serverStatsSubj, leader.ID()), ch)
+	require_NoError(t, err)
+
+	msg := require_ChanRead(t, ch, 5*time.Second)
+	var m ServerStatsMsg
+	require_NoError(t, json.Unmarshal(msg.Data, &m))
+	require_True(t, m.Stats.JetStream != nil)
+	require_True(t, m.Stats.JetStream.Meta != nil)
+	require_True(t, m.Stats.JetStream.Meta.Snapshot != nil)
+}


### PR DESCRIPTION
Extract snapshot stats logic from Jsz() into a reusable helper method and call it from updateJszVarz() and sendStatsz() so that the Snapshot field is consistently populated across all endpoints: /jsz, /varz, $SYS.REQ.SERVER.PING, and $SYS.SERVER.*.STATSZ.

Signed-off-by: R.I.Pienaar <rip@devco.net>
