### PR TITLE
Add HTTP endpoint authentication for username/password

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@
 - Watch [a video overview](https://rethink.synadia.com/episodes/1/) of NATS.
 - Watch [this video from SCALE 13x](https://www.youtube.com/watch?v=sm63oAVPqAM) to learn more about its origin story and design philosophy.
 
+## HTTP Endpoint Authentication
+
+The NATS server supports delegating username/password authentication to an external HTTP endpoint. When clients connect with credentials, the server validates them by POSTing to your auth service. This is useful when integrating with existing identity providers or custom auth backends.
+
+**Configuration example:**
+
+```conf
+authorization {
+  auth_http {
+    url: "http://auth-service:8080/verify"
+    timeout: 5
+  }
+}
+```
+
+The auth endpoint receives a POST request with JSON body `{"username": "...", "password": "..."}`. Return HTTP 2xx for success; 4xx/5xx for authentication failure.
+
+**Alternative: Auth Callout (NATS subject)** — For JWT-based or NATS-native auth, you can use `auth_callout` which subscribes to the `$SYS.REQ.USER.AUTH` subject. Your auth service responds to requests on that subject. See the [auth callout documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_callout) for details.
+
 ## Contact
 
 - [Twitter](https://twitter.com/nats_io): Follow us on Twitter!

--- a/README.md
+++ b/README.md
@@ -29,7 +29,20 @@ authorization {
 }
 ```
 
-The auth endpoint receives a POST request with JSON body `{"username": "...", "password": "..."}`. Return HTTP 2xx for success; 4xx/5xx for authentication failure.
+The auth endpoint receives a POST request with JSON body `{"username": "...", "password": "..."}`.
+
+**Response:**
+- **2xx** = authentication success. The response body may optionally include permissions to restrict publish/subscribe access:
+  ```json
+  {
+    "permissions": {
+      "publish":   { "allow": ["foo.*", "bar.>"], "deny": ["secret.>"] },
+      "subscribe": { "allow": ["foo.*", "bar.>"], "deny": ["secret.>"] }
+    }
+  }
+  ```
+  Omit `permissions` or leave the body empty for full access.
+- **4xx/5xx** = authentication failure.
 
 **Alternative: Auth Callout (NATS subject)** — For JWT-based or NATS-native auth, you can use `auth_callout` which subscribes to the `$SYS.REQ.USER.AUTH` subject. Your auth service responds to requests on that subject. See the [auth callout documentation](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_callout) for details.
 

--- a/server/auth.go
+++ b/server/auth.go
@@ -24,6 +24,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -1133,10 +1134,12 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 		if proxyRequired = opts.ProxyRequired; proxyRequired && !trustedProxy {
 			return setProxyAuthError(ErrAuthProxyRequired)
 		}
-		if s.checkAuthHTTP(opts.AuthHTTP, c.opts.Username, c.opts.Password) {
+		perms, ok := s.checkAuthHTTP(opts.AuthHTTP, c.opts.Username, c.opts.Password)
+		if ok {
 			authUser := &User{
-				Username: c.opts.Username,
-				Account:  nil, // global account
+				Username:    c.opts.Username,
+				Account:     nil, // global account
+				Permissions: perms,
 			}
 			c.RegisterUser(authUser)
 			return true
@@ -1614,10 +1617,29 @@ func comparePasswords(serverPassword, clientPassword string) bool {
 	return true
 }
 
+// authHTTPResponse is the expected JSON structure from the auth HTTP endpoint.
+// When the endpoint returns 2xx, the body may include permissions to restrict
+// what subjects the user can publish to and subscribe to.
+type authHTTPResponse struct {
+	Permissions *authHTTPPermissions `json:"permissions,omitempty"`
+}
+
+type authHTTPPermissions struct {
+	Publish   *authHTTPSubjectPermission `json:"publish,omitempty"`
+	Subscribe *authHTTPSubjectPermission `json:"subscribe,omitempty"`
+}
+
+type authHTTPSubjectPermission struct {
+	Allow []string `json:"allow,omitempty"`
+	Deny  []string `json:"deny,omitempty"`
+}
+
 // checkAuthHTTP validates username and password against an external HTTP endpoint.
 // The server POSTs JSON {"username": "...", "password": "..."} to the URL.
 // A 2xx response indicates success; 4xx/5xx or network errors indicate failure.
-func (s *Server) checkAuthHTTP(ah *AuthHTTP, username, password string) bool {
+// On success, the response body may include a "permissions" object to restrict
+// publish/subscribe access. If omitted or invalid, the user gets full access.
+func (s *Server) checkAuthHTTP(ah *AuthHTTP, username, password string) (*Permissions, bool) {
 	timeout := ah.Timeout
 	if timeout <= 0 {
 		timeout = 5 * time.Second
@@ -1630,25 +1652,83 @@ func (s *Server) checkAuthHTTP(ah *AuthHTTP, username, password string) bool {
 	})
 	if err != nil {
 		s.Debugf("HTTP auth: failed to marshal request: %v", err)
-		return false
+		return nil, false
 	}
 
 	req, err := http.NewRequest(http.MethodPost, ah.URL, bytes.NewReader(body))
 	if err != nil {
 		s.Debugf("HTTP auth: failed to create request: %v", err)
-		return false
+		return nil, false
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {
 		s.Debugf("HTTP auth: request failed: %v", err)
-		return false
+		return nil, false
 	}
 	defer resp.Body.Close()
 
-	// 2xx status codes indicate successful authentication
-	return resp.StatusCode >= 200 && resp.StatusCode < 300
+	// 4xx/5xx indicate authentication failure
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, false
+	}
+
+	// Parse optional permissions from response body
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		s.Debugf("HTTP auth: failed to read response: %v", err)
+		return nil, true // auth succeeded, use full access
+	}
+
+	if len(respBody) == 0 {
+		return nil, true // empty body, full access
+	}
+
+	var authResp authHTTPResponse
+	if err := json.Unmarshal(respBody, &authResp); err != nil {
+		s.Debugf("HTTP auth: failed to parse response (using full access): %v", err)
+		return nil, true // invalid JSON, backward compat: full access
+	}
+
+	if authResp.Permissions == nil {
+		return nil, true // no permissions in response, full access
+	}
+
+	perms := authHTTPPermissionsToPermissions(authResp.Permissions)
+	if perms != nil {
+		validateResponsePermissions(perms)
+	}
+	return perms, true
+}
+
+// authHTTPPermissionsToPermissions converts the HTTP response format to server Permissions.
+func authHTTPPermissionsToPermissions(p *authHTTPPermissions) *Permissions {
+	if p == nil {
+		return nil
+	}
+	// If both are nil/empty, treat as full access
+	if (p.Publish == nil || (len(p.Publish.Allow) == 0 && len(p.Publish.Deny) == 0)) &&
+		(p.Subscribe == nil || (len(p.Subscribe.Allow) == 0 && len(p.Subscribe.Deny) == 0)) {
+		return nil
+	}
+	perms := &Permissions{}
+	if p.Publish != nil && (len(p.Publish.Allow) > 0 || len(p.Publish.Deny) > 0) {
+		perms.Publish = &SubjectPermission{
+			Allow: p.Publish.Allow,
+			Deny:  p.Publish.Deny,
+		}
+	}
+	if p.Subscribe != nil && (len(p.Subscribe.Allow) > 0 || len(p.Subscribe.Deny) > 0) {
+		perms.Subscribe = &SubjectPermission{
+			Allow: p.Subscribe.Allow,
+			Deny:  p.Subscribe.Deny,
+		}
+	}
+	if perms.Publish == nil && perms.Subscribe == nil {
+		return nil
+	}
+	return perms
 }
 
 func validateAuth(o *Options) error {

--- a/server/auth.go
+++ b/server/auth.go
@@ -14,6 +14,7 @@
 package server
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"crypto/subtle"
 	"crypto/tls"
@@ -21,8 +22,10 @@ import (
 	"encoding/asn1"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"regexp"
 	"slices"
@@ -279,6 +282,8 @@ func (s *Server) configureAuthorization() {
 		s.nkeys, s.users = s.buildNkeysAndUsersFromOptions(opts.Nkeys, opts.Users)
 		s.info.AuthRequired = true
 	} else if opts.Username != _EMPTY_ || opts.Authorization != _EMPTY_ {
+		s.info.AuthRequired = true
+	} else if opts.AuthHTTP != nil {
 		s.info.AuthRequired = true
 	} else {
 		s.users = nil
@@ -1123,6 +1128,23 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 		return ok
 	}
 
+	// Check for HTTP-based authentication when auth_http is configured.
+	if opts.AuthHTTP != nil && c.opts.Username != _EMPTY_ && c.opts.Password != _EMPTY_ {
+		if proxyRequired = opts.ProxyRequired; proxyRequired && !trustedProxy {
+			return setProxyAuthError(ErrAuthProxyRequired)
+		}
+		if s.checkAuthHTTP(opts.AuthHTTP, c.opts.Username, c.opts.Password) {
+			authUser := &User{
+				Username: c.opts.Username,
+				Account:  nil, // global account
+			}
+			c.RegisterUser(authUser)
+			return true
+		}
+		c.Debugf("HTTP authentication failed for user %q", c.opts.Username)
+		return false
+	}
+
 	// Check for the use of simple auth.
 	if c.kind == CLIENT || c.kind == LEAF {
 		if proxyRequired = opts.ProxyRequired; proxyRequired && !trustedProxy {
@@ -1590,6 +1612,43 @@ func comparePasswords(serverPassword, clientPassword string) bool {
 		}
 	}
 	return true
+}
+
+// checkAuthHTTP validates username and password against an external HTTP endpoint.
+// The server POSTs JSON {"username": "...", "password": "..."} to the URL.
+// A 2xx response indicates success; 4xx/5xx or network errors indicate failure.
+func (s *Server) checkAuthHTTP(ah *AuthHTTP, username, password string) bool {
+	timeout := ah.Timeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	client := &http.Client{Timeout: timeout}
+
+	body, err := json.Marshal(map[string]string{
+		"username": username,
+		"password": password,
+	})
+	if err != nil {
+		s.Debugf("HTTP auth: failed to marshal request: %v", err)
+		return false
+	}
+
+	req, err := http.NewRequest(http.MethodPost, ah.URL, bytes.NewReader(body))
+	if err != nil {
+		s.Debugf("HTTP auth: failed to create request: %v", err)
+		return false
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		s.Debugf("HTTP auth: request failed: %v", err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	// 2xx status codes indicate successful authentication
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
 func validateAuth(o *Options) error {

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"reflect"
@@ -759,4 +761,99 @@ func TestAuthProxyRequired(t *testing.T) {
 
 	s.Shutdown()
 	drainLog()
+}
+
+func TestAuthHTTPWithPermissions(t *testing.T) {
+	// Mock auth endpoint that validates user/pass and returns permissions
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if req.Username != "alice" || req.Password != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// Return permissions: allow publish/subscribe to "allowed.>", deny "denied.>"
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"permissions": map[string]any{
+				"publish":   map[string]any{"allow": []string{"allowed.>"}, "deny": []string{"denied.>"}},
+				"subscribe": map[string]any{"allow": []string{"allowed.>"}, "deny": []string{"denied.>"}},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	conf := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: 127.0.0.1:-1
+		authorization {
+			auth_http {
+				url: "%s"
+				timeout: 5
+			}
+		}
+	`, ts.URL)))
+	s, _ := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	errChan := make(chan error, 1)
+	nc, err := nats.Connect(s.ClientURL(), nats.UserInfo("alice", "secret"),
+		nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+			if err != nil {
+				select {
+				case errChan <- err:
+				default:
+				}
+			}
+		}))
+	if err != nil {
+		t.Fatalf("Expected to connect, got %v", err)
+	}
+	defer nc.Close()
+
+	// Publish to allowed subject should succeed
+	if err := nc.Publish("allowed.foo", []byte("ok")); err != nil {
+		t.Fatalf("Expected publish to allowed.foo to succeed, got %v", err)
+	}
+	nc.Flush()
+
+	// Publish to denied subject should fail with permission violation (error arrives async)
+	if err := nc.Publish("denied.foo", []byte("nope")); err != nil {
+		t.Fatalf("Publish buffers, should not return error: %v", err)
+	}
+	nc.Flush()
+	select {
+	case err := <-errChan:
+		if !strings.Contains(err.Error(), "Permissions Violation") {
+			t.Fatalf("Expected permission violation error, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Expected permission violation error for publish to denied.foo")
+	}
+
+	// Subscribe to allowed subject should succeed
+	sub, err := nc.SubscribeSync("allowed.bar")
+	if err != nil {
+		t.Fatalf("Expected subscribe to allowed.bar to succeed, got %v", err)
+	}
+	sub.Unsubscribe()
+
+	// Subscribe to denied subject should fail
+	_, err = nc.SubscribeSync("denied.bar")
+	if err != nil {
+		t.Fatalf("SubscribeSync may not return error immediately: %v", err)
+	}
+	nc.Flush()
+	if err := nc.LastError(); err == nil || !strings.Contains(err.Error(), "Permissions Violation") {
+		t.Fatalf("Expected permission violation for subscribe to denied.bar, got %v", err)
+	}
 }

--- a/server/opts.go
+++ b/server/opts.go
@@ -320,6 +320,16 @@ type AuthCallout struct {
 	AllowedAccounts []string
 }
 
+// AuthHTTP option for delegating username/password authentication to an external HTTP endpoint.
+// When configured, the server will POST the client's credentials to the endpoint for validation.
+// A 2xx response indicates successful authentication; 4xx/5xx indicates failure.
+type AuthHTTP struct {
+	// URL is the HTTP endpoint to validate credentials (e.g. "http://auth-service:8080/verify").
+	URL string
+	// Timeout is the maximum time to wait for the HTTP response (default: 5s).
+	Timeout time.Duration
+}
+
 // Options block for nats-server.
 // NOTE: This structure is no longer used for monitoring endpoints
 // and json tags are deprecated and may be removed in the future.
@@ -359,6 +369,7 @@ type Options struct {
 	ProxyProtocol              bool          `json:"-"`
 	Authorization              string        `json:"-"`
 	AuthCallout                *AuthCallout  `json:"-"`
+	AuthHTTP                  *AuthHTTP     `json:"-"`
 	PingInterval               time.Duration `json:"ping_interval"`
 	MaxPingsOut                int           `json:"ping_max"`
 	HTTPHost                   string        `json:"http_host"`
@@ -784,6 +795,8 @@ type authorization struct {
 	defaultPermissions *Permissions
 	// Auth Callouts
 	callout *AuthCallout
+	// HTTP Auth - delegate username/password validation to external endpoint
+	httpAuth *AuthHTTP
 }
 
 // TLSConfigOpts holds the parsed tls config information,
@@ -1126,6 +1139,12 @@ func (o *Options) processConfigFileLine(k string, v any, errors *[]error, warnin
 		o.Authorization = auth.token
 		o.AuthTimeout = auth.timeout
 		o.AuthCallout = auth.callout
+		o.AuthHTTP = auth.httpAuth
+
+		if auth.callout != nil && auth.httpAuth != nil {
+			err := &configErr{tk, "Cannot have both auth_callout and auth_http in authorization block"}
+			*errors = append(*errors, err)
+		}
 
 		if (auth.user != _EMPTY_ || auth.pass != _EMPTY_) && auth.token != _EMPTY_ {
 			err := &configErr{tk, "Cannot have a user/pass and token"}
@@ -1958,6 +1977,11 @@ func parseCluster(v any, opts *Options, errors *[]error, warnings *[]error) erro
 				*errors = append(*errors, err)
 				continue
 			}
+			if auth.httpAuth != nil {
+				err := &configErr{tk, "Cluster authorization does not support auth_http"}
+				*errors = append(*errors, err)
+				continue
+			}
 
 			opts.Cluster.Username = auth.user
 			opts.Cluster.Password = auth.pass
@@ -2196,6 +2220,11 @@ func parseGateway(v any, o *Options, errors *[]error, warnings *[]error) error {
 			}
 			if auth.callout != nil {
 				err := &configErr{tk, "Gateway authorization does not support callouts"}
+				*errors = append(*errors, err)
+				continue
+			}
+			if auth.httpAuth != nil {
+				err := &configErr{tk, "Gateway authorization does not support auth_http"}
 				*errors = append(*errors, err)
 				continue
 			}
@@ -4457,6 +4486,13 @@ func parseAuthorization(v any, errors, warnings *[]error) (*authorization, error
 				continue
 			}
 			auth.callout = ac
+		case "auth_http", "http_auth":
+			ah, err := parseAuthHTTP(tk, errors)
+			if err != nil {
+				*errors = append(*errors, err)
+				continue
+			}
+			auth.httpAuth = ah
 		case "proxy_required":
 			auth.proxyRequired = mv.(bool)
 		default:
@@ -4657,6 +4693,63 @@ func parseAuthCallout(mv any, errors *[]error) (*AuthCallout, error) {
 		return nil, &configErr{tk, "Authorization callouts require authorized users to be specified"}
 	}
 	return ac, nil
+}
+
+// Helper function to parse HTTP auth endpoint config.
+func parseAuthHTTP(mv any, errors *[]error) (*AuthHTTP, error) {
+	var (
+		tk token
+		lt token
+		ah = &AuthHTTP{Timeout: 5 * time.Second}
+	)
+	defer convertPanicToErrorList(&lt, errors)
+
+	tk, mv = unwrapValue(mv, &lt)
+	pm, ok := mv.(map[string]any)
+	if !ok {
+		return nil, &configErr{tk, fmt.Sprintf("Expected auth_http to be a map/struct, got %+v", mv)}
+	}
+	for k, v := range pm {
+		tk, mv = unwrapValue(v, &lt)
+
+		switch strings.ToLower(k) {
+		case "url", "endpoint":
+			ah.URL = mv.(string)
+			if ah.URL == _EMPTY_ {
+				return nil, &configErr{tk, "auth_http requires a non-empty url"}
+			}
+			if _, err := url.Parse(ah.URL); err != nil {
+				return nil, &configErr{tk, fmt.Sprintf("auth_http url is not valid: %v", err)}
+			}
+		case "timeout":
+			switch mv := mv.(type) {
+			case int64:
+				ah.Timeout = time.Duration(mv) * time.Second
+			case float64:
+				ah.Timeout = time.Duration(mv * float64(time.Second))
+			case string:
+				d, err := time.ParseDuration(mv)
+				if err != nil {
+					return nil, &configErr{tk, fmt.Sprintf("error parsing auth_http timeout: %s", err)}
+				}
+				ah.Timeout = d
+			default:
+				return nil, &configErr{tk, "auth_http timeout must be a number or duration string"}
+			}
+			if ah.Timeout <= 0 {
+				return nil, &configErr{tk, "auth_http timeout must be positive"}
+			}
+		default:
+			if !tk.IsUsedVariable() {
+				err := &configErr{tk, fmt.Sprintf("Unknown field %q parsing auth_http", k)}
+				*errors = append(*errors, err)
+			}
+		}
+	}
+	if ah.URL == _EMPTY_ {
+		return nil, &configErr{tk, "auth_http requires url to be specified"}
+	}
+	return ah, nil
 }
 
 // Helper function to parse user/account permissions

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -571,6 +571,30 @@ func TestMultipleUsersConfig(t *testing.T) {
 	setBaselineOptions(opts)
 }
 
+func TestAuthHTTPConfig(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		authorization {
+			auth_http {
+				url: "http://auth-service:8080/verify"
+				timeout: 5
+			}
+		}
+	`))
+	opts, err := ProcessConfigFile(conf)
+	if err != nil {
+		t.Fatalf("Received an error reading config file: %v", err)
+	}
+	if opts.AuthHTTP == nil {
+		t.Fatal("Expected AuthHTTP to be configured")
+	}
+	if opts.AuthHTTP.URL != "http://auth-service:8080/verify" {
+		t.Fatalf("Expected AuthHTTP URL %q, got %q", "http://auth-service:8080/verify", opts.AuthHTTP.URL)
+	}
+	if opts.AuthHTTP.Timeout != 5*time.Second {
+		t.Fatalf("Expected AuthHTTP timeout 5s, got %v", opts.AuthHTTP.Timeout)
+	}
+}
+
 // Test highly depends on contents of the config file listed below. Any changes to that file
 // may very well break this test.
 func TestAuthorizationConfig(t *testing.T) {

--- a/server/reload.go
+++ b/server/reload.go
@@ -1261,6 +1261,7 @@ func imposeOrder(value any) error {
 		*OCSPConfig, map[string]string, JSLimitOpts, StoreCipher, *OCSPResponseCacheConfig, *ProxiesConfig, WriteTimeoutPolicy:
 		// explicitly skipped types
 	case *AuthCallout:
+	case *AuthHTTP:
 	case JSTpmOpts:
 	default:
 		// this will fail during unit tests


### PR DESCRIPTION
## Summary

Adds support for delegating username/password authentication to an external HTTP endpoint via the new `auth_http` configuration option. When clients connect with credentials, the server validates them by POSTing to the configured URL instead of checking against locally configured users.

The auth endpoint can optionally return permissions in its response to restrict which subjects each user can publish to and subscribe to. If omitted, the user gets full access.

This enables integration with existing identity providers, LDAP, OAuth backends, or custom auth services without requiring a NATS-aware auth service (unlike `auth_callout` which uses NATS subjects).

## Configuration

Add the `auth_http` block inside your `authorization` section:

    authorization {
      auth_http {
        url: "http://your-auth-service:8080/verify"
        timeout: 5
      }
    }

- **url** (required): HTTP endpoint to validate credentials (POST request)
- **timeout** (optional): Request timeout in seconds (default: 5)

## Request/Response Protocol

**Request:** The server POSTs JSON to the endpoint:

    {"username": "...", "password": "..."}

**Response:**
- **2xx** = authentication success. The response body may optionally include permissions:

    {
      "permissions": {
        "publish":   { "allow": ["foo.*", "bar.>"], "deny": ["secret.>"] },
        "subscribe": { "allow": ["foo.*", "bar.>"], "deny": ["secret.>"] }
      }
    }

  Omit `permissions` or leave the body empty for full access.
- **4xx/5xx** = authentication failure.

## Changes

- **Config**: New `auth_http` block in `authorization` with `url` and optional `timeout` (default 5s)
- **Protocol**: Server POSTs credentials; on 2xx, optionally parses `permissions` from response body
- **Auth flow**: When `auth_http` is configured and a client sends username/password, credentials are validated via HTTP; on success the client is registered with the returned permissions (or full access if none)
- **Validation**: `auth_http` and `auth_callout` are mutually exclusive; `auth_http` is not supported for cluster/gateway authorization

## Files changed

- `server/opts.go` – AuthHTTP struct, config parsing
- `server/auth.go` – HTTP auth check logic, permissions parsing, configureAuthorization
- `server/reload.go` – Reload support for AuthHTTP
- `server/opts_test.go` – TestAuthHTTPConfig
- `server/auth_test.go` – TestAuthHTTPWithPermissions (integration test)
- `README.md` – Documentation and examples

## Testing

- `TestAuthHTTPConfig` – verifies config parsing
- `TestAuthHTTPWithPermissions` – integration test with mock auth endpoint returning permissions; verifies publish/subscribe to allowed subjects succeeds and to denied subjects fails

Signed-off-by: Hamid <emami.he@gmail.com>