### PR TITLE
[FIXED] Idempotent stream sources create

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7680,6 +7680,13 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 	// Capture if we have existing/inflight assignment first.
 	if osa := js.streamAssignmentOrInflight(acc.Name, cfg.Name); osa != nil {
 		copyStreamMetadata(cfg, osa.Config)
+		// Set the index name on both to ensure the DeepEqual works
+		for _, s := range cfg.Sources {
+			s.setIndexName()
+		}
+		for _, s := range osa.Config.Sources {
+			s.setIndexName()
+		}
 		if !reflect.DeepEqual(osa.Config, cfg) {
 			resp.Error = NewJSStreamNameExistError()
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8288,3 +8288,52 @@ func TestJetStreamClusterDontEncodeConsumerStateInMetaSnapshot(t *testing.T) {
 	require_NotNil(t, consumer)
 	require_True(t, consumer.State == nil)
 }
+
+func TestJetStreamClusteredStreamCreateIdempotentWithSources(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "JSC", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "SOURCE",
+		Subjects: []string{"source.>"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	cfg := &nats.StreamConfig{
+		Name:     "SOURCED",
+		Subjects: []string{"sourced.>"},
+		Replicas: 3,
+		Sources: []*nats.StreamSource{
+			{
+				Name:          "SOURCE",
+				FilterSubject: "source.>",
+			},
+		},
+	}
+	_, err = js.AddStream(cfg)
+	require_NoError(t, err)
+
+	// Step down the stream leader until it lands on the meta leader.
+	// This ensures the meta leader's stored assignment has iname populated
+	// via the shared StreamSource pointer.
+	ml := c.leader()
+	require_NotNil(t, ml)
+	sl := c.streamLeader(globalAccountName, "SOURCED")
+	require_NotNil(t, sl)
+	if sl != ml {
+		mset, err := sl.globalAccount().lookupStream("SOURCED")
+		require_NoError(t, err)
+		require_NoError(t, mset.raftNode().StepDown(ml.Node()))
+		c.waitOnStreamLeader(globalAccountName, "SOURCED")
+		sl = c.streamLeader(globalAccountName, "SOURCED")
+	}
+	require_Equal(t, ml, sl)
+
+	// The second create should be idempotent, and succeed even though iname was set.
+	_, err = js.AddStream(cfg)
+	require_NoError(t, err)
+}


### PR DESCRIPTION
The clustered stream create would fail due to a source's `iname` field being populated on the current config but not the incoming config.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>