### PR TITLE
Data race in TestJetStreamClusterConsumerSetStoreStateOldUpdateRestart

### DIFF
--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -7567,14 +7567,15 @@ func TestJetStreamClusterConsumerSetStoreStateOldUpdateRestart(t *testing.T) {
 	cc := mljs.cluster
 	ca := mljs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
 	require_NotNil(t, ca)
-	mljs.mu.RUnlock()
 
 	cca := ca.copyGroup()
 	cca.State = &ConsumerState{
 		Delivered: SequencePair{Consumer: 5, Stream: 5},
 		AckFloor:  SequencePair{Consumer: 5, Stream: 5},
 	}
-	require_NoError(t, cc.meta.Propose(encodeAddConsumerAssignment(cca)))
+	consumerAdd := encodeAddConsumerAssignment(cca)
+	mljs.mu.RUnlock()
+	require_NoError(t, cc.meta.Propose(consumerAdd))
 
 	// Wait for the meta leader to apply the entry.
 	time.Sleep(500 * time.Millisecond)


### PR DESCRIPTION
```
Previous read at 0x00c002eb8e50 by goroutine 139242:
  github.com/nats-io/nats-server/v2/server.(*consumerAssignment).copyGroup()
      /home/runner/work/nats-server/nats-server/server/jetstream_cluster.go:2285 +0xc4e
  github.com/nats-io/nats-server/v2/server.TestJetStreamClusterConsumerSetStoreStateOldUpdateRestart()
      /home/runner/work/nats-server/nats-server/server/jetstream_cluster_4_test.go:7572 +0xb99
```

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>