### PR TITLE
(2.14) [FIXED] Race condition removing messages for replicated WQ/Interest stream

### DIFF
--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -4860,29 +4860,15 @@ func TestJetStreamClusterStreamAckMsgR3SignalsRemovedMsg(t *testing.T) {
 	_, err = js.Publish("foo", nil)
 	require_NoError(t, err)
 
-	getStreamAndConsumer := func(s *Server) (*stream, *consumer, error) {
-		t.Helper()
-		acc, err := s.lookupAccount(globalAccountName)
-		if err != nil {
-			return nil, nil, err
-		}
-		mset, err := acc.lookupStream("TEST")
-		if err != nil {
-			return nil, nil, err
-		}
-		o := mset.lookupConsumer("CONSUMER")
-		if err != nil {
-			return nil, nil, err
-		}
-		return mset, o, nil
-	}
-
 	// Wait for all servers to know about the stream and consumer.
 	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
 		for _, s := range c.servers {
-			_, _, err = getStreamAndConsumer(s)
+			mset, err := s.globalAccount().lookupStream("TEST")
 			if err != nil {
 				return err
+			}
+			if mset.lookupConsumer("CONSUMER") == nil {
+				return errors.New("consumer not found")
 			}
 		}
 		return nil
@@ -4893,27 +4879,41 @@ func TestJetStreamClusterStreamAckMsgR3SignalsRemovedMsg(t *testing.T) {
 		return checkState(t, c, globalAccountName, "TEST")
 	})
 
-	sl := c.consumerLeader(globalAccountName, "TEST", "CONSUMER")
-	sf := c.randomNonConsumerLeader(globalAccountName, "TEST", "CONSUMER")
+	sl := c.streamLeader(globalAccountName, "TEST")
+	sf := c.randomNonStreamLeader(globalAccountName, "TEST")
 
-	msetL, ol, err := getStreamAndConsumer(sl)
+	msetL, err := sl.globalAccount().lookupStream("TEST")
 	require_NoError(t, err)
-	msetF, of, err := getStreamAndConsumer(sf)
+	ol := msetL.lookupConsumer("CONSUMER")
+	require_NotNil(t, ol)
+	msetF, err := sf.globalAccount().lookupStream("TEST")
 	require_NoError(t, err)
+	of := msetF.lookupConsumer("CONSUMER")
+	require_NotNil(t, of)
 
 	// Too high sequence, should register pre-ack and return true allowing for retries.
 	require_True(t, msetL.ackMsg(ol, 100))
 	require_True(t, msetF.ackMsg(of, 100))
 
 	// We're bypassing the normal ack flow, so must set these values ourselves.
-	ol.mu.Lock()
-	ol.sseq, ol.dseq = 2, 2
-	ol.asflr, ol.adflr = 1, 1
-	ol.mu.Unlock()
-	require_NoError(t, of.store.Update(&ConsumerState{
-		Delivered: SequencePair{1, 1},
-		AckFloor:  SequencePair{1, 1},
-	}))
+	for _, s := range c.servers {
+		mset, err := s.globalAccount().lookupStream("TEST")
+		require_NoError(t, err)
+		o := mset.lookupConsumer("CONSUMER")
+		require_NotNil(t, o)
+
+		if o.IsLeader() {
+			o.mu.Lock()
+			o.sseq, o.dseq = 2, 2
+			o.asflr, o.adflr = 1, 1
+			o.mu.Unlock()
+		} else {
+			require_NoError(t, o.store.Update(&ConsumerState{
+				Delivered: SequencePair{1, 1},
+				AckFloor:  SequencePair{1, 1},
+			}))
+		}
+	}
 
 	// Ack message on follower, should not remove message as that's proposed by the leader.
 	// But should still signal message removal.
@@ -4922,7 +4922,7 @@ func TestJetStreamClusterStreamAckMsgR3SignalsRemovedMsg(t *testing.T) {
 	// Confirm all servers have the message.
 	var smv StoreMsg
 	for _, s := range c.servers {
-		mset, _, err := getStreamAndConsumer(s)
+		mset, err := s.globalAccount().lookupStream("TEST")
 		require_NoError(t, err)
 		sm, err := mset.store.LoadMsg(1, &smv)
 		require_NoError(t, err)
@@ -4933,7 +4933,7 @@ func TestJetStreamClusterStreamAckMsgR3SignalsRemovedMsg(t *testing.T) {
 	require_True(t, msetL.ackMsg(ol, 1))
 	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
 		for _, s := range c.servers {
-			mset, _, err := getStreamAndConsumer(s)
+			mset, err := s.globalAccount().lookupStream("TEST")
 			if err != nil {
 				return err
 			}

--- a/server/stream.go
+++ b/server/stream.go
@@ -6439,10 +6439,6 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 	} else {
 		// Make sure to take into account any message assignments that we had to skip (clfs).
 		seq = lseq + 1 - clfs
-		// Check for preAcks and the need to clear it.
-		if mset.hasAllPreAcks(seq, subject) {
-			mset.clearAllPreAcks(seq)
-		}
 		err = store.StoreRawMsg(subject, hdr, msg, seq, ts, ttl, canConsistencyCheck)
 	}
 
@@ -6477,6 +6473,18 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 			outq.sendMsg(reply, response)
 		}
 		return err
+	}
+
+	// Check for preAcks and the need to clear it.
+	if mset.hasAllPreAcks(seq, subject) {
+		mset.clearAllPreAcks(seq)
+		// If we're clustered and the stream leader, we can now propose deleting this message.
+		// We still store it below, so we remain properly synchronized with our followers.
+		// If this proposal fails, we retry out-of-band.
+		if isClustered && isLeader {
+			md := streamMsgDelete{Seq: seq, NoErase: true, Stream: mset.cfg.Name}
+			_ = mset.node.Propose(encodeMsgDelete(&md))
+		}
 	}
 
 	// If here we succeeded in storing the message.
@@ -8285,9 +8293,13 @@ func (mset *stream) ackMsg(o *consumer, seq uint64) bool {
 		return true
 	}
 
-	// Only propose message deletion to the stream if we're consumer leader, otherwise all followers would also propose.
-	// We must be the consumer leader, since we know for sure we've stored the message and don't register as pre-ack.
-	if o != nil && !o.IsLeader() {
+	// Only propose message deletion to the stream if we're the leader, otherwise followers would also propose.
+	// We must be the stream leader, since we are the only one that can guarantee message ordering and ack handling.
+	// Either we've stored the message, and we know for sure all consumers have acked the message.
+	// Or, we've not stored the message yet (rare), and all consumers have registered as pre-acks,
+	// then we do the message delete proposal after we've stored the message instead.
+	// Except for a Direct AckNone consumer, as that has a nil consumer here, we still forward the delete proposal.
+	if o != nil && !mset.isLeader() {
 		// Currently, interest-based streams can race on "no interest" because consumer creates/updates go over
 		// the meta layer and published messages go over the stream layer. Some servers could then either store
 		// or not store some initial set of messages that gained new interest. To get the stream back in sync,
@@ -8306,6 +8318,7 @@ func (mset *stream) ackMsg(o *consumer, seq uint64) bool {
 	}
 
 	md := streamMsgDelete{Seq: seq, NoErase: true, Stream: mset.cfg.Name}
+	// Directly proposes if stream leader, otherwise forwards it.
 	mset.node.ForwardProposal(encodeMsgDelete(&md))
 	mset.mu.Unlock()
 	return true


### PR DESCRIPTION
While working on https://github.com/nats-io/nats-server/pull/7613 I noticed that `TestJetStreamClusterMirrorAndSourceWorkQueues` was flaky. This was due to only forwarding message delete proposals on consumer leaders and not on the stream leader. This could result in a race condition where consumer leader A wouldn't remove the message since consumer B had yet to ack it, and similarly consumer leader B wouldn't remove it since consumer A had yet to ack it. Two consumers acking at the roughly the same time and leaders being on different servers with some delay could result in a message not being removed in a timely fashion.

This PR fixes that by always letting the stream leader handle this. This has the added benefit of less network traffic since there don't need to be any forwarded delete proposals. But, this does come with needing to handle a rare potential edge case where all consumers have already acked the message but the stream leader hasn't stored the message yet (which is possible due to our use of async queues).

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>