### PR TITLE
[FIXED] Data race in jsClusteredStreamRequest

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7681,11 +7681,15 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 	if osa := js.streamAssignmentOrInflight(acc.Name, cfg.Name); osa != nil {
 		copyStreamMetadata(cfg, osa.Config)
 		// Set the index name on both to ensure the DeepEqual works
+		currentIName := make(map[string]struct{})
+		for _, s := range osa.Config.Sources {
+			currentIName[s.iname] = struct{}{}
+		}
 		for _, s := range cfg.Sources {
 			s.setIndexName()
-		}
-		for _, s := range osa.Config.Sources {
-			s.setIndexName()
+			if _, ok := currentIName[s.iname]; !ok {
+				s.iname = _EMPTY_
+			}
 		}
 		if !reflect.DeepEqual(osa.Config, cfg) {
 			resp.Error = NewJSStreamNameExistError()


### PR DESCRIPTION
Fixes a data race introduced in https://github.com/nats-io/nats-server/pull/7928. Only populating `s.iname` if already set in the older config.

```
WARNING: DATA RACE
Write at 0x00c00135ad08 by goroutine 81400:
  github.com/nats-io/nats-server/v2/server.(*StreamSource).setIndexName()
      /home/runner/work/nats-server/nats-server/server/stream.go:1111 +0x1b04

Previous read at 0x00c00135ad08 by goroutine 81683:
  github.com/nats-io/nats-server/v2/server.(*stream).setupSourceConsumers()
      /home/runner/work/nats-server/nats-server/server/stream.go:4734 +0x3b7
``` 

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>