### PR TITLE
[FIXED] Stream update loses consumers in async meta snapshot

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2228,6 +2228,10 @@ func (js *jetStream) collectStreamAndConsumerChanges(c RaftNodeCheckpoint, strea
 			as = make(map[string]*streamAssignment)
 			streams[sa.Client.serviceAccount()] = as
 		}
+		// Preserve consumers from the previous assignment.
+		if osa := as[sa.Config.Name]; osa != nil {
+			sa.consumers = osa.consumers
+		}
 		as[sa.Config.Name] = sa
 	}
 	for _, cas := range ru.updateConsumers {

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8337,3 +8337,68 @@ func TestJetStreamClusteredStreamCreateIdempotentWithSources(t *testing.T) {
 	_, err = js.AddStream(cfg)
 	require_NoError(t, err)
 }
+
+func TestJetStreamClusterMetaSnapshotPreservesConsumersOnStreamUpdate(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Replicas: 3}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Name: "CONSUMER", Replicas: 3})
+	require_NoError(t, err)
+
+	triggerMetaSnapshot := func(t *testing.T, c *cluster) {
+		t.Helper()
+		ml := c.leader()
+		require_NotNil(t, ml)
+		meta := ml.getJetStream().getMetaGroup().(*raft)
+		meta.RLock()
+		papplied := meta.papplied
+		meta.RUnlock()
+		require_NoError(t, meta.ProposeAddPeer(meta.ID()))
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			meta.RLock()
+			defer meta.RUnlock()
+			if papplied == meta.papplied {
+				return errors.New("no snapshot yet")
+			}
+			return nil
+		})
+	}
+
+	loadSnapshotStreams := func(t *testing.T, c *cluster) map[string]map[string]*streamAssignment {
+		t.Helper()
+		ml := c.leader()
+		require_NotNil(t, ml)
+		meta := ml.getJetStream().getMetaGroup().(*raft)
+		snap, err := meta.loadLastSnapshot()
+		require_NoError(t, err)
+		sjs := ml.getJetStream()
+		accStreams, err := sjs.decodeMetaSnapshot(snap.data)
+		require_NoError(t, err)
+		return accStreams
+	}
+
+	// Create a baseline snapshot that includes consumers.
+	triggerMetaSnapshot(t, c)
+	accStreams := loadSnapshotStreams(t, c)
+	stream := accStreams[globalAccountName]["TEST"]
+	require_NotNil(t, stream)
+	require_NotNil(t, stream.consumers["CONSUMER"])
+
+	// Update stream config, then create a new snapshot from the previous checkpoint.
+	cfg.Description = "updated"
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+	triggerMetaSnapshot(t, c)
+
+	// Updated snapshots must preserve existing stream consumers.
+	accStreams = loadSnapshotStreams(t, c)
+	stream = accStreams[globalAccountName]["TEST"]
+	require_NotNil(t, stream)
+	require_NotNil(t, stream.consumers["CONSUMER"])
+}


### PR DESCRIPTION
If a stream update was performed, an async meta snapshot would not preserve any pre-existing consumers and essentially lose them on a restart. This can be mitigated in the meantime prior to a restart by configuring `jetstream.meta_compact_sync: true` and reloading the config. This is only for 2.12.5 since async snapshots got introduced as the default there.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>