### PR TITLE
[FIXED] Panic on inflight stream and consumer iteration

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -6030,6 +6030,9 @@ func (js *jetStream) consumerAssignmentsOrInflightSeq(account, stream string) it
 			}
 		}
 		sa := js.streamAssignment(account, stream)
+		if sa == nil {
+			return
+		}
 		for _, ca := range sa.consumers {
 			// Skip if we already iterated over it as inflight.
 			if _, ok := inflight[ca.Name]; ok {

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8402,3 +8402,24 @@ func TestJetStreamClusterMetaSnapshotPreservesConsumersOnStreamUpdate(t *testing
 	require_NotNil(t, stream)
 	require_NotNil(t, stream.consumers["CONSUMER"])
 }
+
+func TestJetStreamClusterConsumerAssignmentsOrInflightSeqWithInflightStream(t *testing.T) {
+	const acc, stream, consumer = "A", "S", "C"
+	js := &jetStream{cluster: &jetStreamCluster{
+		streams: map[string]map[string]*streamAssignment{},
+		inflightStreams: map[string]map[string]*inflightStreamInfo{
+			acc: {stream: {streamAssignment: &streamAssignment{Config: &StreamConfig{Name: stream}}}},
+		},
+		inflightConsumers: map[string]map[string]map[string]*inflightConsumerInfo{
+			acc: {stream: {consumer: {consumerAssignment: &consumerAssignment{Name: consumer}}}},
+		},
+	}}
+
+	var got []string
+	for ca := range js.consumerAssignmentsOrInflightSeq(acc, stream) {
+		got = append(got, ca.Name)
+	}
+	if len(got) != 1 || got[0] != consumer {
+		t.Fatalf("Unexpected consumers: %+v", got)
+	}
+}


### PR DESCRIPTION
Given an inflight stream create and an inflight consumer create for that stream, updating a stream to scale down while the former are still inflight could result in a panic. This will be very rare in practice, but can be guarded against easily.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>