### PR TITLE
[FIXED] Panic on malformed fixed32/fixed64 fields

### DIFF
--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -8062,6 +8062,8 @@ func TestMQTTSparkbDeathHandling(t *testing.T) {
 		{"replace at the end", append(protoMetrics, proto0Timestamp...), len(protoMetrics), false},
 		{"replace at the start", append(protoDeadbeefTimestamp, protoMetrics...), 0, false},
 		{"invalid", []byte{0xde, 0xad, 0xbe, 0xef}, 0, true}, // invalid payload
+		{"invalid fixed32", []byte{0x0d, 0x01}, 0, true},
+		{"invalid fixed64", []byte{0x09, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}, 0, true},
 	} {
 		var sendPI uint16
 		for _, topic := range []string{"NDEATH/nnn", "DDEATH/nnn/ddd"} {

--- a/server/proto.go
+++ b/server/proto.go
@@ -63,8 +63,14 @@ func protoScanFieldValue(typ int, b []byte) (size int, err error) {
 	case 0:
 		_, size, err = protoScanVarint(b)
 	case 5: // fixed32
+		if len(b) < 4 {
+			return 0, errProtoInsufficient
+		}
 		size = 4
 	case 1: // fixed64
+		if len(b) < 8 {
+			return 0, errProtoInsufficient
+		}
 		size = 8
 	case 2: // length-delimited
 		size, err = protoScanBytes(b)


### PR DESCRIPTION
Add a length check when scanning for protocol fixed32 and fixed64 fields.

Signed-off-by: Daniele Sciascia <daniele@nats.io>