### PR TITLE
[FIXED] Propagate meta snapshot apply errors

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2499,7 +2499,9 @@ func (js *jetStream) applyMetaEntries(entries []*Entry, ru *recoveryUpdates) (bo
 		}
 
 		if e.Type == EntrySnapshot {
-			js.applyMetaSnapshot(e.Data, ru, isRecovering)
+			if err := js.applyMetaSnapshot(e.Data, ru, isRecovering); err != nil {
+				return isRecovering, didSnap, err
+			}
 			didSnap = true
 		} else if e.Type == EntryRemovePeer {
 			if !js.isMetaRecovering() {

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -4301,6 +4301,20 @@ func TestJetStreamClusterMetaSnapshotConsumerDeleteConsistency(t *testing.T) {
 	})
 }
 
+func TestJetStreamClusterMetaSnapshotDecodeError(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	js := c.leader().getJetStream()
+
+	isRecovering, didSnap, err := js.applyMetaEntries(
+		[]*Entry{newEntry(EntrySnapshot, []byte("not a valid snapshot"))}, nil)
+
+	require_Error(t, err)
+	require_False(t, isRecovering)
+	require_False(t, didSnap)
+}
+
 func TestJetStreamClusterConsumerDontSendSnapshotOnLeaderChange(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()


### PR DESCRIPTION
Propagate `applyMetaSnapshot` failures from `applyMetaEntries`. `applyMetaSnapshot` currently only fails if the decoding of the snapshot fails. That should never happen in practice. Should that happen, `monitorCluster` will log an error and will not advance the raft applied index.

Signed-off-by: Daniele Sciascia <daniele@nats.io>