### PR TITLE
(2.14) Fast batch limits

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -2078,5 +2078,25 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSAtomicPublishTooManyInflight",
+    "code": 429,
+    "error_code": 10210,
+    "description": "atomic publish too many inflight",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSBatchPublishTooManyInflight",
+    "code": 429,
+    "error_code": 10211,
+    "description": "batch publish too many inflight",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -30,7 +30,8 @@ import (
 
 var (
 	// Tracks the total inflight batches, across all streams and accounts that enable batching.
-	globalInflightBatches atomic.Int32
+	globalInflightAtomicBatches atomic.Int64
+	globalInflightFastBatches   atomic.Int64
 )
 
 type batching struct {
@@ -97,17 +98,27 @@ func (b *atomicBatch) cleanup(batchId string, batches *batching) {
 
 // Lock should be held.
 func (b *atomicBatch) cleanupLocked(batchId string, batches *batching) {
-	globalInflightBatches.Add(-1)
+	if b.timer == nil {
+		return
+	}
+	globalInflightAtomicBatches.Add(-1)
 	b.timer.Stop()
 	b.store.Delete(true)
 	delete(batches.atomic, batchId)
+	// Reset so that another invocation doesn't double-account.
+	b.timer = nil
 }
 
 // Lock should be held.
 func (b *atomicBatch) stopLocked() {
-	globalInflightBatches.Add(-1)
+	if b.timer == nil {
+		return
+	}
+	globalInflightAtomicBatches.Add(-1)
 	b.timer.Stop()
 	b.store.Stop()
+	// Reset so that another invocation doesn't double-account.
+	b.timer = nil
 }
 
 func getBatchStoreDir(mset *stream, batchId string) (string, string) {
@@ -218,6 +229,10 @@ func (batches *batching) fastBatchRegisterSequences(mset *stream, reply string, 
 				// waiting to acquire the lock. We reset the timer here so it doesn't clean up
 				// this batch that we're about to overwrite.
 				b.timer = nil
+			} else {
+				// If this is a new batch for us, even though we're a follower, we still need
+				// to account toward the global inflight limit.
+				globalInflightFastBatches.Add(1)
 			}
 			// We'll need a copy as we'll use it as a key and later for cleanup.
 			batchId := copyString(batch.id)
@@ -391,8 +406,11 @@ func (b *fastBatch) cleanupLocked(batchId string, batches *batching) {
 	if b.timer == nil {
 		return
 	}
+	globalInflightFastBatches.Add(-1)
 	b.timer.Stop()
 	delete(batches.fast, batchId)
+	// Reset so that another invocation doesn't double-account.
+	b.timer = nil
 }
 
 // getCleanupTimeout returns the timeout for the batch, taking into account the server's limits.

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -292,14 +292,14 @@ func TestJetStreamAtomicBatchPublishCommitEob(t *testing.T) {
 }
 
 func TestJetStreamAtomicBatchPublishLimits(t *testing.T) {
-	streamMaxBatchInflightPerStream = 1
-	streamMaxBatchInflightTotal = 1
-	streamMaxBatchSize = 2
+	streamMaxAtomicBatchInflightPerStream = 1
+	streamMaxAtomicBatchInflightTotal = 1
+	streamMaxAtomicBatchSize = 2
 	streamMaxBatchTimeout = 500 * time.Millisecond
 	defer func() {
-		streamMaxBatchInflightPerStream = streamDefaultMaxBatchInflightPerStream
-		streamMaxBatchInflightTotal = streamDefaultMaxBatchInflightTotal
-		streamMaxBatchSize = streamDefaultMaxBatchSize
+		streamMaxAtomicBatchInflightPerStream = streamDefaultMaxAtomicBatchInflightPerStream
+		streamMaxAtomicBatchInflightTotal = streamDefaultMaxAtomicBatchInflightTotal
+		streamMaxAtomicBatchSize = streamDefaultMaxAtomicBatchSize
 		streamMaxBatchTimeout = streamDefaultMaxBatchTimeout
 	}()
 
@@ -369,7 +369,7 @@ func TestJetStreamAtomicBatchPublishLimits(t *testing.T) {
 		require_NoError(t, err)
 		pubAck = JSPubAckResponse{}
 		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
-		require_Error(t, pubAck.Error, NewJSAtomicPublishIncompleteBatchError())
+		require_Error(t, pubAck.Error, NewJSAtomicPublishTooManyInflightError())
 
 		// Another batch on a different stream moves over the server-wide threshold and batch is denied.
 		m = nats.NewMsg("bar")
@@ -380,7 +380,7 @@ func TestJetStreamAtomicBatchPublishLimits(t *testing.T) {
 		require_NoError(t, err)
 		pubAck = JSPubAckResponse{}
 		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
-		require_Error(t, pubAck.Error, NewJSAtomicPublishIncompleteBatchError())
+		require_Error(t, pubAck.Error, NewJSAtomicPublishTooManyInflightError())
 
 		// The first batch should now time out.
 		sl := c.streamLeader(globalAccountName, "FOO")
@@ -414,7 +414,7 @@ func TestJetStreamAtomicBatchPublishLimits(t *testing.T) {
 		require_Error(t, pubAck.Error, NewJSAtomicPublishIncompleteBatchError())
 
 		// Batch should be rejected if going over the max batch size.
-		for _, size := range []int{streamMaxBatchSize, streamMaxBatchSize + 1} {
+		for _, size := range []int{streamMaxAtomicBatchSize, streamMaxAtomicBatchSize + 1} {
 			for i := range size {
 				seq := i + 1
 				m = nats.NewMsg("foo")
@@ -431,11 +431,11 @@ func TestJetStreamAtomicBatchPublishLimits(t *testing.T) {
 				require_NoError(t, err)
 				pubAck = JSPubAckResponse{}
 				require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
-				if size <= streamMaxBatchSize {
+				if size <= streamMaxAtomicBatchSize {
 					require_True(t, pubAck.Error == nil)
 					require_Equal(t, pubAck.BatchSize, size)
 				} else {
-					require_Error(t, pubAck.Error, NewJSAtomicPublishTooLargeBatchError(streamMaxBatchSize))
+					require_Error(t, pubAck.Error, NewJSAtomicPublishTooLargeBatchError(streamMaxAtomicBatchSize))
 				}
 			}
 		}
@@ -758,10 +758,12 @@ func TestJetStreamAtomicBatchPublishCleanup(t *testing.T) {
 
 func TestJetStreamAtomicBatchPublishConfigOpts(t *testing.T) {
 	// Defaults.
-	require_Equal(t, streamMaxBatchInflightPerStream, 50)
-	require_Equal(t, streamMaxBatchInflightTotal, 1000)
-	require_Equal(t, streamMaxBatchSize, 1000)
 	require_Equal(t, streamMaxBatchTimeout, 10*time.Second)
+	require_Equal(t, streamMaxAtomicBatchInflightPerStream, 50)
+	require_Equal(t, streamMaxAtomicBatchInflightTotal, 1000)
+	require_Equal(t, streamMaxAtomicBatchSize, 1000)
+	require_Equal(t, streamMaxFastBatchInflightPerStream, 1000)
+	require_Equal(t, streamMaxFastBatchInflightTotal, 50_000)
 
 	batchingConf := `
 	listen: 127.0.0.1:-1
@@ -2563,7 +2565,7 @@ func TestJetStreamAtomicBatchPublishAdvisories(t *testing.T) {
 			require_NoError(t, err)
 			require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
 			require_NotNil(t, pubAck.Error)
-			require_Error(t, pubAck.Error, NewJSAtomicPublishTooLargeBatchError(streamDefaultMaxBatchSize))
+			require_Error(t, pubAck.Error, NewJSAtomicPublishTooLargeBatchError(streamDefaultMaxAtomicBatchSize))
 		}
 
 		msg, err = sub.NextMsg(time.Second)
@@ -4218,4 +4220,139 @@ func TestJetStreamFastBatchPublishFlowControlOnLeaderChangeAfterFailedCommitProp
 		}
 		return nil
 	})
+}
+
+func TestJetStreamFastBatchPublishLimits(t *testing.T) {
+	streamMaxFastBatchInflightPerStream = 1
+	streamMaxFastBatchInflightTotal = 1
+	streamMaxBatchTimeout = 500 * time.Millisecond
+	defer func() {
+		streamMaxFastBatchInflightPerStream = streamDefaultMaxFastBatchInflightPerStream
+		streamMaxFastBatchInflightTotal = streamDefaultMaxFastBatchInflightTotal
+		streamMaxBatchTimeout = streamDefaultMaxBatchTimeout
+	}()
+
+	test := func(t *testing.T, replicas int) {
+		c := createJetStreamClusterExplicit(t, "R3S", 3)
+		defer c.shutdown()
+
+		nc := clientConnectToServer(t, c.randomServer())
+		defer nc.Close()
+
+		var batchFlowAck BatchFlowAck
+		var pubAck JSPubAckResponse
+
+		cfg := &StreamConfig{
+			Name:              "FOO",
+			Subjects:          []string{"foo"},
+			Storage:           FileStorage,
+			Retention:         LimitsPolicy,
+			Replicas:          replicas,
+			AllowBatchPublish: true,
+		}
+		_, err := jsStreamCreate(t, nc, cfg)
+		require_NoError(t, err)
+
+		// For testing total server-wide maximum inflight batches.
+		cfg = &StreamConfig{
+			Name:              "BAR",
+			Subjects:          []string{"bar"},
+			Storage:           FileStorage,
+			Retention:         LimitsPolicy,
+			Replicas:          replicas,
+			AllowBatchPublish: true,
+		}
+		_, err = jsStreamCreate(t, nc, cfg)
+		require_NoError(t, err)
+
+		inbox := nats.NewInbox()
+		sub, err := nc.SubscribeSync(fmt.Sprintf("%s.>", inbox))
+		require_NoError(t, err)
+		defer sub.Drain()
+
+		// A batch ID must not exceed the maximum length.
+		for _, length := range []int{64, 65} {
+			longBatchId := strings.Repeat("A", length)
+			m := nats.NewMsg("foo")
+			m.Reply = generateFastBatchReply(inbox, longBatchId, 1, 0, FastBatchGapFail, FastBatchOpCommit)
+			require_NoError(t, nc.PublishMsg(m))
+
+			rmsg, err := sub.NextMsg(time.Second)
+			require_NoError(t, err)
+			pubAck = JSPubAckResponse{}
+			require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+			if length <= 64 {
+				require_True(t, pubAck.Error == nil)
+			} else {
+				require_NotNil(t, pubAck.Error)
+				require_Error(t, pubAck.Error, NewJSBatchPublishInvalidBatchIDError())
+			}
+		}
+
+		// One batch is inflight.
+		m := nats.NewMsg("foo")
+		m.Reply = generateFastBatchReply(inbox, "uuid", 1, 0, FastBatchGapFail, FastBatchOpStart)
+		require_NoError(t, nc.PublishMsg(m))
+
+		rmsg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		batchFlowAck = BatchFlowAck{}
+		require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowAck))
+		require_Equal(t, batchFlowAck.Messages, 10)
+		require_Equal(t, batchFlowAck.Sequence, 0)
+
+		// Another batch moves over the threshold and batch is denied.
+		m = nats.NewMsg("foo")
+		m.Reply = generateFastBatchReply(inbox, "exceeds_threshold", 1, 0, FastBatchGapFail, FastBatchOpCommit)
+		require_NoError(t, nc.PublishMsg(m))
+		rmsg, err = sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		pubAck = JSPubAckResponse{}
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_Error(t, pubAck.Error, NewJSBatchPublishTooManyInflightError())
+
+		// Another batch on a different stream moves over the server-wide threshold and batch is denied.
+		m = nats.NewMsg("bar")
+		m.Reply = generateFastBatchReply(inbox, "bar", 1, 0, FastBatchGapFail, FastBatchOpCommit)
+		require_NoError(t, nc.PublishMsg(m))
+		rmsg, err = sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		pubAck = JSPubAckResponse{}
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_Error(t, pubAck.Error, NewJSBatchPublishTooManyInflightError())
+
+		// The first batch should now time out.
+		sl := c.streamLeader(globalAccountName, "FOO")
+		mset, err := sl.globalAccount().lookupStream("FOO")
+		require_NoError(t, err)
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			mset.mu.RLock()
+			batches := mset.batches
+			mset.mu.RUnlock()
+			if batches == nil {
+				return errors.New("batches not found")
+			}
+			batches.mu.Lock()
+			groups := len(batches.fast)
+			batches.mu.Unlock()
+			if groups != 0 {
+				return fmt.Errorf("expected 0 groups, got %d", groups)
+			}
+			return nil
+		})
+
+		// Publishing to the batch should also error since it timed out.
+		m = nats.NewMsg("foo")
+		m.Reply = generateFastBatchReply(inbox, "uuid", 2, 0, FastBatchGapFail, FastBatchOpCommit)
+		require_NoError(t, nc.PublishMsg(m))
+
+		rmsg, err = sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		pubAck = JSPubAckResponse{}
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_Error(t, pubAck.Error, NewJSBatchPublishUnknownBatchIDError())
+	}
+
+	t.Run("R1", func(t *testing.T) { test(t, 1) })
+	t.Run("R3", func(t *testing.T) { test(t, 3) })
 }

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -29,6 +29,9 @@ const (
 	// JSAtomicPublishTooLargeBatchErrF atomic publish batch is too large: {size}
 	JSAtomicPublishTooLargeBatchErrF ErrorIdentifier = 10199
 
+	// JSAtomicPublishTooManyInflight atomic publish too many inflight
+	JSAtomicPublishTooManyInflight ErrorIdentifier = 10210
+
 	// JSAtomicPublishUnsupportedHeaderBatchErr atomic publish unsupported header used: {header}
 	JSAtomicPublishUnsupportedHeaderBatchErr ErrorIdentifier = 10177
 
@@ -43,6 +46,9 @@ const (
 
 	// JSBatchPublishInvalidPatternErr batch publish pattern is invalid
 	JSBatchPublishInvalidPatternErr ErrorIdentifier = 10206
+
+	// JSBatchPublishTooManyInflight batch publish too many inflight
+	JSBatchPublishTooManyInflight ErrorIdentifier = 10211
 
 	// JSBatchPublishUnknownBatchIDErr batch publish ID unknown
 	JSBatchPublishUnknownBatchIDErr ErrorIdentifier = 10208
@@ -640,11 +646,13 @@ var (
 		JSAtomicPublishInvalidBatchIDErr:             {Code: 400, ErrCode: 10179, Description: "atomic publish batch ID is invalid"},
 		JSAtomicPublishMissingSeqErr:                 {Code: 400, ErrCode: 10175, Description: "atomic publish sequence is missing"},
 		JSAtomicPublishTooLargeBatchErrF:             {Code: 400, ErrCode: 10199, Description: "atomic publish batch is too large: {size}"},
+		JSAtomicPublishTooManyInflight:               {Code: 429, ErrCode: 10210, Description: "atomic publish too many inflight"},
 		JSAtomicPublishUnsupportedHeaderBatchErr:     {Code: 400, ErrCode: 10177, Description: "atomic publish unsupported header used: {header}"},
 		JSBadRequestErr:                              {Code: 400, ErrCode: 10003, Description: "bad request"},
 		JSBatchPublishDisabledErr:                    {Code: 400, ErrCode: 10205, Description: "batch publish is disabled"},
 		JSBatchPublishInvalidBatchIDErr:              {Code: 400, ErrCode: 10207, Description: "batch publish ID is invalid"},
 		JSBatchPublishInvalidPatternErr:              {Code: 400, ErrCode: 10206, Description: "batch publish pattern is invalid"},
+		JSBatchPublishTooManyInflight:                {Code: 429, ErrCode: 10211, Description: "batch publish too many inflight"},
 		JSBatchPublishUnknownBatchIDErr:              {Code: 400, ErrCode: 10208, Description: "batch publish ID unknown"},
 		JSClusterIncompleteErr:                       {Code: 503, ErrCode: 10004, Description: "incomplete results"},
 		JSClusterNoPeersErrF:                         {Code: 400, ErrCode: 10005, Description: "{err}"},
@@ -951,6 +959,16 @@ func NewJSAtomicPublishTooLargeBatchError(size interface{}, opts ...ErrorOption)
 	}
 }
 
+// NewJSAtomicPublishTooManyInflightError creates a new JSAtomicPublishTooManyInflight error: "atomic publish too many inflight"
+func NewJSAtomicPublishTooManyInflightError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSAtomicPublishTooManyInflight]
+}
+
 // NewJSAtomicPublishUnsupportedHeaderBatchError creates a new JSAtomicPublishUnsupportedHeaderBatchErr error: "atomic publish unsupported header used: {header}"
 func NewJSAtomicPublishUnsupportedHeaderBatchError(header interface{}, opts ...ErrorOption) *ApiError {
 	eopts := parseOpts(opts)
@@ -1005,6 +1023,16 @@ func NewJSBatchPublishInvalidPatternError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSBatchPublishInvalidPatternErr]
+}
+
+// NewJSBatchPublishTooManyInflightError creates a new JSBatchPublishTooManyInflight error: "batch publish too many inflight"
+func NewJSBatchPublishTooManyInflightError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSBatchPublishTooManyInflight]
 }
 
 // NewJSBatchPublishUnknownBatchIDError creates a new JSBatchPublishUnknownBatchIDErr error: "batch publish ID unknown"

--- a/server/jetstream_versioning.go
+++ b/server/jetstream_versioning.go
@@ -82,7 +82,7 @@ func setStaticStreamMetadata(cfg *StreamConfig) {
 		requires(2)
 	}
 
-	// Fast batch publishing was added in v2.14 and requires API level 3.
+	// Fast batch publishing was added in v2.14 and requires API level 4.
 	if cfg.AllowBatchPublish {
 		requires(4)
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -440,17 +440,25 @@ const (
 
 // For managing stream batches.
 const (
-	streamDefaultMaxBatchInflightPerStream = 50
-	streamDefaultMaxBatchInflightTotal     = 1000
-	streamDefaultMaxBatchSize              = 1000
-	streamDefaultMaxBatchTimeout           = 10 * time.Second
+	streamDefaultMaxBatchTimeout = 10 * time.Second
+	// Atomic batches.
+	streamDefaultMaxAtomicBatchInflightPerStream = 50
+	streamDefaultMaxAtomicBatchInflightTotal     = 1000
+	streamDefaultMaxAtomicBatchSize              = 1000
+	// Fast batches.
+	streamDefaultMaxFastBatchInflightPerStream = 1000
+	streamDefaultMaxFastBatchInflightTotal     = 50_000
 )
 
 var (
-	streamMaxBatchInflightPerStream = streamDefaultMaxBatchInflightPerStream
-	streamMaxBatchInflightTotal     = streamDefaultMaxBatchInflightTotal
-	streamMaxBatchSize              = streamDefaultMaxBatchSize
-	streamMaxBatchTimeout           = streamDefaultMaxBatchTimeout
+	streamMaxBatchTimeout = streamDefaultMaxBatchTimeout
+	// Atomic batches.
+	streamMaxAtomicBatchInflightPerStream = streamDefaultMaxAtomicBatchInflightPerStream
+	streamMaxAtomicBatchInflightTotal     = streamDefaultMaxAtomicBatchInflightTotal
+	streamMaxAtomicBatchSize              = streamDefaultMaxAtomicBatchSize
+	// Fast batches.
+	streamMaxFastBatchInflightPerStream = streamDefaultMaxFastBatchInflightPerStream
+	streamMaxFastBatchInflightTotal     = streamDefaultMaxFastBatchInflightTotal
 )
 
 // Stream is a jetstream stream of messages. When we receive a message internally destined
@@ -6700,7 +6708,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 	if !ok {
 		if batchSeq != 1 {
 			batches.mu.Unlock()
-			maxBatchSize := streamMaxBatchSize
+			maxBatchSize := streamMaxAtomicBatchSize
 			opts := s.getOpts()
 			if opts.JetStreamLimits.MaxBatchSize > 0 {
 				maxBatchSize = opts.JetStreamLimits.MaxBatchSize
@@ -6713,8 +6721,8 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		}
 
 		// Limits.
-		maxInflightPerStream := streamMaxBatchInflightPerStream
-		maxInflightTotal := streamMaxBatchInflightTotal
+		maxInflightPerStream := streamMaxAtomicBatchInflightPerStream
+		maxInflightTotal := streamMaxAtomicBatchInflightTotal
 		opts := s.getOpts()
 		if opts.JetStreamLimits.MaxBatchInflightPerStream > 0 {
 			maxInflightPerStream = opts.JetStreamLimits.MaxBatchInflightPerStream
@@ -6726,20 +6734,20 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		// Confirm we can facilitate an additional batch.
 		if len(batches.atomic)+1 > maxInflightPerStream {
 			batches.mu.Unlock()
-			return respondIncompleteBatch()
+			return respondError(NewJSAtomicPublishTooManyInflightError())
 		}
 
 		// Confirm we'll not exceed the server limit.
-		if globalInflightBatches.Add(1) > int32(maxInflightTotal) {
-			globalInflightBatches.Add(-1)
+		if globalInflightAtomicBatches.Add(1) > int64(maxInflightTotal) {
+			globalInflightAtomicBatches.Add(-1)
 			batches.mu.Unlock()
-			return respondIncompleteBatch()
+			return respondError(NewJSAtomicPublishTooManyInflightError())
 		}
 
 		var err error
 		b, err = batches.newAtomicBatch(mset, batchId)
 		if err != nil {
-			globalInflightBatches.Add(-1)
+			globalInflightAtomicBatches.Add(-1)
 			batches.mu.Unlock()
 			return respondIncompleteBatch()
 		}
@@ -6786,7 +6794,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 	}
 
 	// Confirm the batch doesn't exceed the allowed size.
-	maxSize := streamMaxBatchSize
+	maxSize := streamMaxAtomicBatchSize
 	if maxBatchSize := s.getOpts().JetStreamLimits.MaxBatchSize; maxBatchSize > 0 {
 		maxSize = maxBatchSize
 	}
@@ -7072,6 +7080,31 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 			batches.mu.Unlock()
 			return respondError(NewJSBatchPublishUnknownBatchIDError())
 		}
+
+		// Limits.
+		maxInflightPerStream := streamMaxFastBatchInflightPerStream
+		maxInflightTotal := streamMaxFastBatchInflightTotal
+		opts := s.getOpts()
+		if opts.JetStreamLimits.MaxBatchInflightPerStream > 0 {
+			maxInflightPerStream = opts.JetStreamLimits.MaxBatchInflightPerStream
+		}
+		if opts.JetStreamLimits.MaxBatchInflightTotal > 0 {
+			maxInflightTotal = opts.JetStreamLimits.MaxBatchInflightTotal
+		}
+
+		// Confirm we can facilitate an additional batch.
+		if len(batches.fast)+1 > maxInflightPerStream {
+			batches.mu.Unlock()
+			return respondError(NewJSBatchPublishTooManyInflightError())
+		}
+
+		// Confirm we'll not exceed the server limit.
+		if globalInflightFastBatches.Add(1) > int64(maxInflightTotal) {
+			globalInflightFastBatches.Add(-1)
+			batches.mu.Unlock()
+			return respondError(NewJSBatchPublishTooManyInflightError())
+		}
+
 		// We'll need a copy as we'll use it as a key and later for cleanup.
 		batchId := copyString(batch.id)
 		b = batches.newFastBatch(mset, batchId, batch.gapOk, batch.flow)
@@ -7086,8 +7119,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 		if errorOnRequiredApiLevel(hdr) {
 			b.cleanupLocked(batch.id, batches)
 			batches.mu.Unlock()
-			err := NewJSRequiredApiLevelError()
-			return respondError(err)
+			return respondError(NewJSRequiredApiLevelError())
 		}
 		hdr = removeHeaderIfPresent(hdr, JSRequiredApiLevel)
 	}


### PR DESCRIPTION
Fast batch publishing didn't have per stream or per server limits yet, which could allow excessive resource usage. Now that's bounded to 1k per stream and 50k per server to have lenient defaults in place.

ADR Update: https://github.com/nats-io/nats-architecture-and-design/pull/404

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>