### PR TITLE
[IMPROVED] Stream peer-remove by ID

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -587,7 +587,7 @@ const JSApiStreamRestoreResponseType = "io.nats.jetstream.api.v1.stream_restore_
 
 // JSApiStreamRemovePeerRequest is the required remove peer request.
 type JSApiStreamRemovePeerRequest struct {
-	// Server name of the peer to be removed.
+	// Server name or peer ID of the peer to be removed.
 	Peer string `json:"peer"`
 }
 
@@ -2387,13 +2387,17 @@ func (s *Server) jsStreamRemovePeerRequest(sub *subscription, c *client, _ *Acco
 		return
 	}
 
-	// Check to see if we are a member of the group and if the group has no leader.
-	// Peers here is a server name, convert to node name.
-	nodeName := getHash(req.Peer)
-
 	js.mu.RLock()
 	rg := sa.Group
+
+	// Check to see if we are a member of the group.
+	// Peer here is either a peer ID or a server name, convert to node name.
+	nodeName := getHash(req.Peer)
 	isMember := rg.isMember(nodeName)
+	if !isMember {
+		nodeName = req.Peer
+		isMember = rg.isMember(nodeName)
+	}
 	js.mu.RUnlock()
 
 	// Make sure we are a member.

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -4920,6 +4920,19 @@ func TestJetStreamClusterStreamRemovePeer(t *testing.T) {
 			t.Fatalf("Expected no replicas for ephemeral, got %d", len(ci.Cluster.Replicas))
 		}
 	}
+
+	// Confirm we can peer-remove by the peer ID instead of the server name too.
+	rs := c.randomNonStreamLeader(globalAccountName, "TEST")
+	nodeName := rs.Node()
+	require_Equal(t, nodeName, getHash(rs.Name()))
+	req = &JSApiStreamRemovePeerRequest{Peer: nodeName}
+	jsreq, err = json.Marshal(req)
+	require_NoError(t, err)
+	resp, err = nc.Request(fmt.Sprintf(JSApiStreamRemovePeerT, "TEST"), jsreq, time.Second)
+	require_NoError(t, err)
+	rpResp = JSApiStreamRemovePeerResponse{}
+	require_NoError(t, json.Unmarshal(resp.Data, &rpResp))
+	require_True(t, rpResp.Success)
 }
 
 func TestJetStreamClusterStreamLeaderStepDown(t *testing.T) {


### PR DESCRIPTION
The stream peer-remove command currently only accepts a server name. However, if you don't know the server name, it's tricky to perform a peer-remove. This PR improves that by also accepting the peer ID instead of only the server name.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>