### PR TITLE
[FIXED] Avoid parsing trace headers from HPUB payload

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -2808,9 +2808,10 @@ func (c *client) processHeaderPub(arg, remaining []byte) error {
 		// look for the tracing header and if found, we will generate a
 		// trace event with the max payload ingress error.
 		// Do this only for CLIENT connections.
-		if c.kind == CLIENT && len(remaining) > 0 {
-			if td := getHeader(MsgTraceDest, remaining); len(td) > 0 {
-				c.initAndSendIngressErrEvent(remaining, string(td), ErrMaxPayload)
+		if c.kind == CLIENT && c.pa.hdr > 0 && len(remaining) > 0 {
+			hdr := remaining[:min(len(remaining), c.pa.hdr)]
+			if td := getHeader(MsgTraceDest, hdr); len(td) > 0 {
+				c.initAndSendIngressErrEvent(hdr, string(td), ErrMaxPayload)
 			}
 		}
 		c.maxPayloadViolation(c.pa.size, maxPayload)

--- a/server/msgtrace_test.go
+++ b/server/msgtrace_test.go
@@ -371,6 +371,42 @@ func TestMsgTraceIngressMaxPayloadError(t *testing.T) {
 	}
 }
 
+func TestMsgTraceIngressMaxPayloadErrorDoesNotScanPayloadForTraceDest(t *testing.T) {
+	o := DefaultOptions()
+	o.MaxPayload = 1024
+	s := RunServer(o)
+	defer s.Shutdown()
+
+	nc := natsConnect(t, s.ClientURL())
+	defer nc.Close()
+
+	traceSub := natsSubSync(t, nc, "my.trace.subj")
+	natsFlush(t, nc)
+
+	checkSubInterest(t, s, globalAccountName, "my.trace.subj", time.Second)
+
+	nc2, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", o.Port))
+	require_NoError(t, err)
+	defer nc2.Close()
+
+	_, err = nc2.Write([]byte("CONNECT {\"protocol\":1,\"headers\":true,\"no_responders\":true}\r\n"))
+	require_NoError(t, err)
+
+	// Payload contains a valid header, but the server should
+	// not interpret it as such.
+	payload := fmt.Sprintf("AA\r\n%s:%s\r\n", MsgTraceDest, traceSub.Subject)
+
+	hPub := fmt.Sprintf("HPUB foo %d 2048\r\n%s%s", len(hdrLine), hdrLine, payload)
+	_, err = nc2.Write([]byte(hPub))
+	require_NoError(t, err)
+
+	// If bug is present: we receive a trace msg, even though
+	// no trace header was set.
+	if traceMsg, err := traceSub.NextMsg(250 * time.Millisecond); err == nil {
+		t.Fatalf("Should not have received trace message: %s", traceMsg.Data)
+	}
+}
+
 func TestMsgTraceIngressErrors(t *testing.T) {
 	conf := createConfFile(t, []byte(`
 		port: -1


### PR DESCRIPTION
During a HPUB operation, a MaxPayload violation could
result in attempts to extract Nats-Trace-Dest header
from payload bytes. The fix consists in limiting
processHeaderPub to inspect the header part of the
remaining bytes, to avoid interpreting payload.

Signed-off-by: Daniele Sciascia <daniele@nats.io>