### PR TITLE
NRG: Candidate resets vote

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -5047,6 +5047,7 @@ func (n *raft) switchToCandidate() {
 	}
 	// Increment the term.
 	n.term++
+	n.vote = noVote
 	// Clear current Leader.
 	n.updateLeader(noLeader)
 	n.switchState(Candidate)

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -5218,6 +5218,27 @@ func TestNRGInstallSnapshotFromCheckpointAfterTruncateToSnapshot(t *testing.T) {
 	require_Equal(t, count, 1)
 }
 
+func TestNRGSwitchToCandidateResetsVote(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	require_Equal(t, n.term, 0)
+	n.vote = nats0
+	n.switchToCandidate()
+
+	// Confirm the term was incremented and the vote reset.
+	require_Equal(t, n.term, 1)
+	require_Equal(t, n.vote, _EMPTY_)
+
+	// Confirm this was written to disk.
+	term, voted, err := n.readTermVote()
+	require_NoError(t, err)
+	require_Equal(t, term, 1)
+	require_Equal(t, voted, _EMPTY_)
+}
+
 func TestNRGInitSingleMemRaftNodeDefaults(t *testing.T) {
 	n, cleanup := initSingleMemRaftNode(t)
 	defer cleanup()


### PR DESCRIPTION
`n.switchToCandidate()` would increment `n.term` but not reset `n.vote`. A hard kill after the term increment and `n.switchState(Candidate)` (which writes out the term/vote file) could then contain a stale `n.vote` but with an incremented `n.term`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>