### PR TITLE
[FIXED] ParseFileWithChecksDigest deletes referenced config entries

### DIFF
--- a/conf/parse.go
+++ b/conf/parse.go
@@ -114,42 +114,28 @@ func ParseFileWithChecks(fp string) (map[string]any, error) {
 	return p.mapping, nil
 }
 
-// cleanupUsedEnvVars will recursively remove all already used
-// environment variables which might be in the parsed tree.
-func cleanupUsedEnvVars(m map[string]any) {
-	for k, v := range m {
-		t := v.(*token)
-		if t.usedVariable {
-			delete(m, k)
-			continue
-		}
-		// Cleanup any other env var that is still in the map.
-		if tm, ok := t.value.(map[string]any); ok {
-			cleanupUsedEnvVars(tm)
-		}
+// configDigest returns a digest for the parsed config.
+func configDigest(m map[string]any) (string, error) {
+	digest := sha256.New()
+	e := json.NewEncoder(digest)
+	if err := e.Encode(m); err != nil {
+		return _EMPTY_, err
 	}
+	return fmt.Sprintf("sha256:%x", digest.Sum(nil)), nil
 }
 
 // ParseFileWithChecksDigest returns the processed config and a digest
 // that represents the configuration.
 func ParseFileWithChecksDigest(fp string) (map[string]any, string, error) {
-	data, err := os.ReadFile(fp)
+	m, err := ParseFileWithChecks(fp)
 	if err != nil {
 		return nil, _EMPTY_, err
 	}
-	p, err := parse(string(data), fp, true)
+	digest, err := configDigest(m)
 	if err != nil {
 		return nil, _EMPTY_, err
 	}
-	// Filter out any environment variables before taking the digest.
-	cleanupUsedEnvVars(p.mapping)
-	digest := sha256.New()
-	e := json.NewEncoder(digest)
-	err = e.Encode(p.mapping)
-	if err != nil {
-		return nil, _EMPTY_, err
-	}
-	return p.mapping, fmt.Sprintf("sha256:%x", digest.Sum(nil)), nil
+	return m, digest, nil
 }
 
 type token struct {

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -218,6 +218,24 @@ func TestConvenientNumbers(t *testing.T) {
 	test(t, easynum, ex)
 }
 
+func TestParseFileWithChecksDigestPreservesConfigKeyUsedAsVariable(t *testing.T) {
+	confFile := filepath.Join(t.TempDir(), "nats.conf")
+	if err := os.WriteFile(confFile, []byte(`
+		port = 4222
+		monitor_port = $port
+	`), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	m, _, err := ParseFileWithChecksDigest(confFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m["port"]; !ok {
+		t.Fatal("expected config key used as a variable reference to be preserved")
+	}
+}
+
 var sample1 = `
 foo  {
   host {
@@ -919,7 +937,7 @@ func TestParseDigest(t *testing.T) {
                         very { nested { env { VAR = 'NESTED', quux = $VAR }}}
                         `,
 			nil,
-			"sha256:34f8faf3f269fe7509edc4742f20c8c4a7ad51fe21f8b361764314b533ac3ab5",
+			"sha256:bddb282343249c26d3edcef9bfaa9d2711505fc67210380e871405ba394a9186",
 		},
 		{
 			`# substitutions, same as previous one without env vars.
@@ -942,7 +960,7 @@ func TestParseDigest(t *testing.T) {
                         }
                         `,
 			nil,
-			"sha256:f5d943b4ed22b80c6199203f8a7eaa8eb68ef7b2d46ef6b1b26f05e21f8beb13",
+			"sha256:b0e2ba0b8ec2cb75681b5c5d61789cda0c9942c2f9fe16cdb7f6703364485360",
 		},
 		{
 			`# substitutions


### PR DESCRIPTION
ParseFileWithChecksDigest removed entries marked as `usedVariables` before returning the parsed config. 
This caused real config fields to disappear from the returned config.
Digest is now computed without cleaning up `usedVariables`.

Signed-off-by: Daniele Sciascia <daniele@nats.io>