### PR TITLE
[FIXED] PROXY v1 parsing may discard client bytes

### DIFF
--- a/server/client_proxyproto.go
+++ b/server/client_proxyproto.go
@@ -131,19 +131,22 @@ func detectProxyProtoVersion(conn net.Conn) (version int, header []byte, err err
 
 // readProxyProtoV1Header parses PROXY protocol v1 text format.
 // Expects the "PROXY " prefix (6 bytes) to have already been consumed.
-func readProxyProtoV1Header(conn net.Conn) (*proxyProtoAddr, error) {
+// Returns any bytes that were read past the trailing CRLF so the caller can
+// replay them into the next protocol layer.
+func readProxyProtoV1Header(conn net.Conn) (*proxyProtoAddr, []byte, error) {
 	// Read rest of line (max 107 bytes total, already read 6)
 	maxRemaining := proxyProtoV1MaxLineLen - 6
 
 	// Read up to maxRemaining bytes at once (more efficient than byte-by-byte)
 	buf := make([]byte, maxRemaining)
 	var line []byte
+	var remaining []byte
 
 	for len(line) < maxRemaining {
 		// Read available data
 		n, err := conn.Read(buf[len(line):])
 		if err != nil {
-			return nil, fmt.Errorf("failed to read v1 line: %w", err)
+			return nil, nil, fmt.Errorf("failed to read v1 line: %w", err)
 		}
 
 		line = buf[:len(line)+n]
@@ -151,7 +154,8 @@ func readProxyProtoV1Header(conn net.Conn) (*proxyProtoAddr, error) {
 		// Look for CRLF in what we've read so far
 		for i := 0; i < len(line)-1; i++ {
 			if line[i] == '\r' && line[i+1] == '\n' {
-				// Found CRLF - extract just the line portion
+				// Found CRLF - keep any over-read bytes for the client parser.
+				remaining = append(remaining, line[i+2:]...)
 				line = line[:i]
 				goto foundCRLF
 			}
@@ -159,7 +163,7 @@ func readProxyProtoV1Header(conn net.Conn) (*proxyProtoAddr, error) {
 	}
 
 	// Exceeded max length without finding CRLF
-	return nil, fmt.Errorf("%w: v1 line too long", errProxyProtoInvalid)
+	return nil, nil, fmt.Errorf("%w: v1 line too long", errProxyProtoInvalid)
 
 foundCRLF:
 	// Get parts from the protocol
@@ -167,17 +171,17 @@ foundCRLF:
 
 	// Validate format
 	if len(parts) < 1 {
-		return nil, fmt.Errorf("%w: invalid v1 format", errProxyProtoInvalid)
+		return nil, nil, fmt.Errorf("%w: invalid v1 format", errProxyProtoInvalid)
 	}
 
 	// Handle UNKNOWN (health check, like v2 LOCAL)
 	if parts[0] == proxyProtoV1Unknown {
-		return nil, nil
+		return nil, remaining, nil
 	}
 
 	// Must have exactly 5 parts: protocol, src-ip, dst-ip, src-port, dst-port
 	if len(parts) != 5 {
-		return nil, fmt.Errorf("%w: invalid v1 format", errProxyProtoInvalid)
+		return nil, nil, fmt.Errorf("%w: invalid v1 format", errProxyProtoInvalid)
 	}
 
 	protocol := parts[0]
@@ -185,29 +189,29 @@ foundCRLF:
 	dstIP := net.ParseIP(parts[2])
 
 	if srcIP == nil || dstIP == nil {
-		return nil, fmt.Errorf("%w: invalid address", errProxyProtoInvalid)
+		return nil, nil, fmt.Errorf("%w: invalid address", errProxyProtoInvalid)
 	}
 
 	// Parse ports
 	srcPort, err := strconv.ParseUint(parts[3], 10, 16)
 	if err != nil {
-		return nil, fmt.Errorf("invalid source port: %w", err)
+		return nil, nil, fmt.Errorf("invalid source port: %w", err)
 	}
 
 	dstPort, err := strconv.ParseUint(parts[4], 10, 16)
 	if err != nil {
-		return nil, fmt.Errorf("invalid dest port: %w", err)
+		return nil, nil, fmt.Errorf("invalid dest port: %w", err)
 	}
 
 	// Validate protocol matches IP version
 	if protocol == proxyProtoV1TCP4 && srcIP.To4() == nil {
-		return nil, fmt.Errorf("%w: TCP4 with IPv6 address", errProxyProtoInvalid)
+		return nil, nil, fmt.Errorf("%w: TCP4 with IPv6 address", errProxyProtoInvalid)
 	}
 	if protocol == proxyProtoV1TCP6 && srcIP.To4() != nil {
-		return nil, fmt.Errorf("%w: TCP6 with IPv4 address", errProxyProtoInvalid)
+		return nil, nil, fmt.Errorf("%w: TCP6 with IPv4 address", errProxyProtoInvalid)
 	}
 	if protocol != proxyProtoV1TCP4 && protocol != proxyProtoV1TCP6 {
-		return nil, fmt.Errorf("%w: invalid protocol %s", errProxyProtoInvalid, protocol)
+		return nil, nil, fmt.Errorf("%w: invalid protocol %s", errProxyProtoInvalid, protocol)
 	}
 
 	return &proxyProtoAddr{
@@ -215,25 +219,27 @@ foundCRLF:
 		srcPort: uint16(srcPort),
 		dstIP:   dstIP,
 		dstPort: uint16(dstPort),
-	}, nil
+	}, remaining, nil
 }
 
 // readProxyProtoHeader reads and parses PROXY protocol (v1 or v2) from the connection.
 // Automatically detects version and routes to appropriate parser.
 // If the command is LOCAL/UNKNOWN (health check), it returns nil for addr and no error.
 // If the command is PROXY, it returns the parsed address information.
+// It also returns any bytes that were read past the v1 header terminator so the
+// caller can replay them into the normal client parser.
 // The connection must be fresh (no data read yet).
-func readProxyProtoHeader(conn net.Conn) (*proxyProtoAddr, error) {
+func readProxyProtoHeader(conn net.Conn) (*proxyProtoAddr, []byte, error) {
 	// Set read deadline to prevent hanging on slow/malicious clients
 	if err := conn.SetReadDeadline(time.Now().Add(proxyProtoReadTimeout)); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer conn.SetReadDeadline(time.Time{})
 
 	// Detect version
 	version, firstBytes, err := detectProxyProtoVersion(conn)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	switch version {
@@ -244,25 +250,26 @@ func readProxyProtoHeader(conn net.Conn) (*proxyProtoAddr, error) {
 		// Read rest of v2 signature (bytes 6-11, total 6 more bytes)
 		remaining := make([]byte, 6)
 		if _, err := io.ReadFull(conn, remaining); err != nil {
-			return nil, fmt.Errorf("failed to read v2 signature: %w", err)
+			return nil, nil, fmt.Errorf("failed to read v2 signature: %w", err)
 		}
 
 		// Verify full signature
 		fullSig := string(firstBytes) + string(remaining)
 		if fullSig != proxyProtoV2Sig {
-			return nil, fmt.Errorf("%w: invalid signature", errProxyProtoInvalid)
+			return nil, nil, fmt.Errorf("%w: invalid signature", errProxyProtoInvalid)
 		}
 
 		// Read rest of header: ver/cmd, fam/proto, addr-len (4 bytes)
 		header := make([]byte, 4)
 		if _, err := io.ReadFull(conn, header); err != nil {
-			return nil, fmt.Errorf("failed to read v2 header: %w", err)
+			return nil, nil, fmt.Errorf("failed to read v2 header: %w", err)
 		}
 
 		// Continue with parsing
-		return parseProxyProtoV2Header(conn, header)
+		addr, err := parseProxyProtoV2Header(conn, header)
+		return addr, nil, err
 	default:
-		return nil, fmt.Errorf("unsupported PROXY protocol version: %d", version)
+		return nil, nil, fmt.Errorf("unsupported PROXY protocol version: %d", version)
 	}
 }
 

--- a/server/client_proxyproto_test.go
+++ b/server/client_proxyproto_test.go
@@ -14,6 +14,7 @@
 package server
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
 	"fmt"
@@ -417,7 +418,7 @@ func TestClientProxyProtoV1ParseTCP4(t *testing.T) {
 	header := buildProxyV1Header(t, "TCP4", "192.168.1.50", "10.0.0.1", 12345, 4222)
 	conn := newMockConn(header)
 
-	addr, err := readProxyProtoHeader(conn)
+	addr, _, err := readProxyProtoHeader(conn)
 	require_NoError(t, err)
 	require_NotNil(t, addr)
 
@@ -432,7 +433,7 @@ func TestClientProxyProtoV1ParseTCP6(t *testing.T) {
 	header := buildProxyV1Header(t, "TCP6", "2001:db8::1", "2001:db8::2", 54321, 4222)
 	conn := newMockConn(header)
 
-	addr, err := readProxyProtoHeader(conn)
+	addr, _, err := readProxyProtoHeader(conn)
 	require_NoError(t, err)
 	require_NotNil(t, addr)
 
@@ -447,9 +448,24 @@ func TestClientProxyProtoV1ParseUnknown(t *testing.T) {
 	header := buildProxyV1Header(t, "UNKNOWN", "", "", 0, 0)
 	conn := newMockConn(header)
 
-	addr, err := readProxyProtoHeader(conn)
+	addr, _, err := readProxyProtoHeader(conn)
 	require_NoError(t, err)
 	require_True(t, addr == nil)
+}
+
+func TestClientProxyProtoV1PreservesCoalescedClientBytes(t *testing.T) {
+	header := buildProxyV1Header(t, "TCP4", "192.168.1.50", "10.0.0.1", 12345, 4222)
+	connect := []byte("CONNECT {\"verbose\":false,\"pedantic\":false,\"protocol\":1}\r\n")
+	conn := newMockConn(append(header, connect...))
+
+	addr, remaining, err := readProxyProtoHeader(conn)
+	require_NoError(t, err)
+	require_NotNil(t, addr)
+	require_Equal(t, string(remaining), string(connect))
+
+	rest, err := io.ReadAll(conn)
+	require_NoError(t, err)
+	require_Equal(t, len(rest), 0)
 }
 
 func TestClientProxyProtoV1InvalidFormat(t *testing.T) {
@@ -457,7 +473,7 @@ func TestClientProxyProtoV1InvalidFormat(t *testing.T) {
 	header := []byte("PROXY TCP4 192.168.1.1\r\n")
 	conn := newMockConn(header)
 
-	_, err := readProxyProtoHeader(conn)
+	_, _, err := readProxyProtoHeader(conn)
 	require_Error(t, err, errProxyProtoInvalid)
 }
 
@@ -467,7 +483,7 @@ func TestClientProxyProtoV1LineTooLong(t *testing.T) {
 	header := fmt.Appendf(nil, "PROXY TCP4 %s 10.0.0.1 12345 443\r\n", longIP)
 	conn := newMockConn(header)
 
-	_, err := readProxyProtoHeader(conn)
+	_, _, err := readProxyProtoHeader(conn)
 	require_Error(t, err, errProxyProtoInvalid)
 }
 
@@ -475,7 +491,7 @@ func TestClientProxyProtoV1InvalidIP(t *testing.T) {
 	header := []byte("PROXY TCP4 not.an.ip.addr 10.0.0.1 12345 443\r\n")
 	conn := newMockConn(header)
 
-	_, err := readProxyProtoHeader(conn)
+	_, _, err := readProxyProtoHeader(conn)
 	require_Error(t, err, errProxyProtoInvalid)
 }
 
@@ -484,14 +500,14 @@ func TestClientProxyProtoV1MismatchedProtocol(t *testing.T) {
 	header := buildProxyV1Header(t, "TCP4", "2001:db8::1", "2001:db8::2", 12345, 443)
 	conn := newMockConn(header)
 
-	_, err := readProxyProtoHeader(conn)
+	_, _, err := readProxyProtoHeader(conn)
 	require_Error(t, err, errProxyProtoInvalid)
 
 	// TCP6 with IPv4 address
 	header2 := buildProxyV1Header(t, "TCP6", "192.168.1.1", "10.0.0.1", 12345, 443)
 	conn2 := newMockConn(header2)
 
-	_, err = readProxyProtoHeader(conn2)
+	_, _, err = readProxyProtoHeader(conn2)
 	require_Error(t, err, errProxyProtoInvalid)
 }
 
@@ -499,7 +515,7 @@ func TestClientProxyProtoV1InvalidPort(t *testing.T) {
 	header := []byte("PROXY TCP4 192.168.1.1 10.0.0.1 99999 443\r\n")
 	conn := newMockConn(header)
 
-	_, err := readProxyProtoHeader(conn)
+	_, _, err := readProxyProtoHeader(conn)
 	require_True(t, err != nil)
 }
 
@@ -520,24 +536,27 @@ func TestClientProxyProtoV1EndToEnd(t *testing.T) {
 	require_NoError(t, err)
 	defer conn.Close()
 
-	// Send PROXY protocol v1 header
+	// Send the PROXY protocol header and first client commands in one write so
+	// the parser must preserve bytes read past the end of the v1 header.
 	clientIP, clientPort := "203.0.113.50", uint16(54321)
 	header := buildProxyV1Header(t, "TCP4", clientIP, "127.0.0.1", clientPort, 4222)
+	payload := append(header, []byte("CONNECT {\"verbose\":true,\"pedantic\":false,\"protocol\":1}\r\nPING\r\n")...)
 
-	_, err = conn.Write(header)
+	_, err = conn.Write(payload)
 	require_NoError(t, err)
 
-	// Send CONNECT message
-	_, err = conn.Write([]byte("CONNECT {\"verbose\":false,\"pedantic\":false,\"protocol\":1}\r\n"))
-	require_NoError(t, err)
+	require_NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	cr := bufio.NewReader(conn)
 
-	// Read INFO and +OK
-	buf := make([]byte, 4096)
-	n, err := conn.Read(buf)
+	line, err := cr.ReadString('\n')
 	require_NoError(t, err)
+	require_True(t, strings.HasPrefix(line, "INFO "))
 
-	response := string(buf[:n])
-	require_True(t, strings.Contains(response, "INFO"))
+	line, err = cr.ReadString('\n')
+	require_NoError(t, err)
+	require_True(t, strings.HasPrefix(line, "+OK"))
+
+	expectPong(t, cr)
 
 	// Give server time to process
 	time.Sleep(100 * time.Millisecond)
@@ -569,7 +588,7 @@ func TestClientProxyProtoVersionDetection(t *testing.T) {
 	v1Header := buildProxyV1Header(t, "TCP4", "192.168.1.1", "10.0.0.1", 12345, 443)
 	conn1 := newMockConn(v1Header)
 
-	addr1, err := readProxyProtoHeader(conn1)
+	addr1, _, err := readProxyProtoHeader(conn1)
 	require_NoError(t, err)
 	require_NotNil(t, addr1)
 	require_Equal(t, addr1.srcIP.String(), "192.168.1.1")
@@ -578,7 +597,7 @@ func TestClientProxyProtoVersionDetection(t *testing.T) {
 	v2Header := buildProxyV2Header(t, "192.168.1.2", "10.0.0.1", 54321, 443, proxyProtoFamilyInet)
 	conn2 := newMockConn(v2Header)
 
-	addr2, err := readProxyProtoHeader(conn2)
+	addr2, _, err := readProxyProtoHeader(conn2)
 	require_NoError(t, err)
 	require_NotNil(t, addr2)
 	require_Equal(t, addr2.srcIP.String(), "192.168.1.2")
@@ -589,6 +608,6 @@ func TestClientProxyProtoUnrecognizedVersion(t *testing.T) {
 	header := []byte("HELLO WORLD\r\n")
 	conn := newMockConn(header)
 
-	_, err := readProxyProtoHeader(conn)
+	_, _, err := readProxyProtoHeader(conn)
 	require_Error(t, err, errProxyProtoUnrecognized)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -3453,7 +3453,7 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 			pre = pre[:n]
 		}
 		conn = &tlsMixConn{conn, bytes.NewBuffer(pre)}
-		addr, err := readProxyProtoHeader(conn)
+		addr, proxyPre, err := readProxyProtoHeader(conn)
 		if err != nil && err != errProxyProtoUnrecognized {
 			// err != errProxyProtoUnrecognized implies that we detected a proxy
 			// protocol header but we failed to parse it, so don't continue.
@@ -3481,7 +3481,7 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 		// that it's a non-proxied connection and we want the pre-read to remain
 		// for the next step.
 		if err == nil {
-			pre = nil
+			pre = proxyPre
 		}
 		// Because we have ProxyProtocol enabled, our earlier INFO message didn't
 		// include the client_ip. If we need to send it again then we will include


### PR DESCRIPTION
If the parser read past the \r\n of a PROXY protocol v1 header, then the remaining bytes, if any, would be dropped. That left the connection desynchronized before normal client parsing saw CONNECT.
`readProxyProtoHeader` now returns the remaining bytes, to be read by the next protocol parsing step.

Signed-off-by: Daniele Sciascia <daniele@nats.io>