### PR TITLE
[FIXED] Compressed data coalesced with INFO causing disconnect

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1386,7 +1386,6 @@ func (c *client) readLoop(pre []byte) {
 	if ws {
 		masking = c.ws.maskread
 	}
-	checkCompress := c.kind == ROUTER || c.kind == LEAF
 	c.mu.Unlock()
 
 	defer func() {
@@ -1480,6 +1479,31 @@ func (c *client) readLoop(pre []byte) {
 					// We don't need to do any of the things below, simply return.
 					return
 				}
+				if err == ErrCompressionSwitchPending {
+					// If we are a ROUTER/LEAF and have processed an INFO, it is possible that
+					// we are asked to switch to compression now.
+					c.in.flags.clear(switchToCompression)
+					// c.as points past the INFO line. Any remaining bytes in the
+					// buffer are compressed and must be fed into the s2 reader
+					// before subsequent network reads.
+					var readers []io.Reader
+					if remaining := bufs[i][c.as:]; len(remaining) > 0 {
+						readers = append(readers, bytes.NewReader(remaining))
+					}
+					// Also add any remaining buffers
+					for j := i + 1; j < len(bufs); j++ {
+						readers = append(readers, bytes.NewReader(bufs[j]))
+					}
+					// For now we support only s2 compression...
+					if len(readers) == 0 {
+						reader = s2.NewReader(nc)
+					} else {
+						readers = append(readers, nc)
+						reader = s2.NewReader(io.MultiReader(readers...))
+					}
+					decompress = true
+					break
+				}
 				if dur := time.Since(c.in.start); dur >= readLoopReportThreshold {
 					c.Warnf("Readloop processing time: %v", dur)
 				}
@@ -1499,15 +1523,6 @@ func (c *client) readLoop(pre []byte) {
 				c.rateLimitFormatWarnf("Producer was stalled for a total of %v", c.in.tst.Round(time.Millisecond))
 			}
 			c.in.tst = 0
-		}
-
-		// If we are a ROUTER/LEAF and have processed an INFO, it is possible that
-		// we are asked to switch to compression now.
-		if checkCompress && c.in.flags.isSet(switchToCompression) {
-			c.in.flags.clear(switchToCompression)
-			// For now we support only s2 compression...
-			reader = s2.NewReader(nc)
-			decompress = true
 		}
 
 		// Updates stats for client and server that were collected

--- a/server/errors.go
+++ b/server/errors.go
@@ -216,6 +216,11 @@ var (
 	// ErrMinimumVersionRequired is returned when a connection is not at the minimum version required.
 	ErrMinimumVersionRequired = errors.New("minimum version required")
 
+	// ErrCompressionSwitchPending is returned by the parser when an INFO triggered
+	// a switch to compression. Remaining bytes in the buffer are compressed and
+	// must be fed into a new decompression reader.
+	ErrCompressionSwitchPending = errors.New("compression switch pending")
+
 	// ErrInvalidMappingDestination is used for all subject mapping destination errors
 	ErrInvalidMappingDestination = errors.New("invalid mapping destination")
 

--- a/server/parser.go
+++ b/server/parser.go
@@ -1084,6 +1084,13 @@ func (c *client) parse(buf []byte) error {
 					return err
 				}
 				c.drop, c.as, c.state = 0, i+1, OP_START
+				// If processInfo negotiated compression, any remaining bytes
+				// in this buffer are compressed. Stop parsing and let readLoop
+				// switch to the decompression reader. c.as already points to
+				// the first byte after the INFO line.
+				if c.in.flags.isSet(switchToCompression) {
+					return ErrCompressionSwitchPending
+				}
 			default:
 				if c.argBuf != nil {
 					c.argBuf = append(c.argBuf, b)

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -35,6 +35,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"
@@ -4077,6 +4078,102 @@ func TestRouteCompression(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRouteCompressionBufferCoalescing(t *testing.T) {
+	// 1. Start a single server with compression enabled and pool_size: -1
+	//    (no pooling simplifies the handshake — no pool index negotiation).
+	opts := DefaultOptions()
+	opts.ServerName = "S1"
+	opts.Cluster.Name = "local"
+	opts.Cluster.Host = "127.0.0.1"
+	opts.Cluster.Port = -1
+	opts.Cluster.PoolSize = -1
+	opts.Cluster.Compression = CompressionOpts{Mode: CompressionS2Fast}
+	s := RunServer(opts)
+	defer s.Shutdown()
+
+	// 2. Dial the cluster port directly via raw TCP.
+	addr := fmt.Sprintf("127.0.0.1:%d", opts.Cluster.Port)
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	require_NoError(t, err)
+	defer conn.Close()
+
+	// 3. Read the server's initial INFO (plain text).
+	//    The server sends INFO immediately on accept since didSolicit=false
+	//    and compression doesn't delay INFO for non-solicited routes.
+	br := bufio.NewReader(conn)
+	infoLine, err := br.ReadString('\n')
+	require_NoError(t, err)
+	// Parse server's INFO to extract its ID (needed so we don't trigger
+	// "route to self" detection).
+	var srvInfo serverInfo
+	require_NoError(t, json.Unmarshal([]byte(infoLine[5:]), &srvInfo))
+
+	// 4. Build the CONNECT protocol (plain text).
+	connectOp := "CONNECT {\"verbose\":false,\"name\":\"fake-route\",\"cluster\":\"local\"}\r\n"
+
+	// 5. Build the INFO protocol that triggers compression negotiation.
+	//    The Compression field tells the server we want s2_fast.
+	routeInfo := Info{
+		ID:            "FAKE_REMOTE_ID",
+		Name:          "fake-route",
+		Cluster:       "local",
+		Compression:   CompressionS2Fast,
+		RoutePoolSize: -1,
+	}
+	infoJSON, err := json.Marshal(routeInfo)
+	require_NoError(t, err)
+	infoOp := fmt.Sprintf("INFO %s\r\n", infoJSON)
+
+	// 6. Compress a PING using s2 — this simulates compressed data that
+	//    arrives in the same TCP read buffer as the INFO above.
+	var compBuf bytes.Buffer
+	sw := s2.NewWriter(&compBuf, s2.WriterConcurrency(1))
+	_, err = sw.Write([]byte("PING\r\n"))
+	require_NoError(t, err)
+	require_NoError(t, sw.Close())
+	compressedPing := compBuf.Bytes()
+
+	// 7. Write CONNECT + INFO + compressed PING in a SINGLE TCP write.
+	//    The CONNECT is processed first (sets up route metadata).
+	//    The INFO triggers compression negotiation (sets switchToCompression).
+	//    The compressed PING is the leftover bytes that the readLoop must
+	//    correctly feed into the s2 reader instead of parsing as plain text.
+	var combined bytes.Buffer
+	combined.WriteString(connectOp)
+	combined.WriteString(infoOp)
+	combined.Write(compressedPing)
+	_, err = conn.Write(combined.Bytes())
+	require_NoError(t, err)
+
+	// 8. Read the server's response using an s2 reader.
+	//    After the server processes our INFO and negotiates compression, it:
+	//    (a) Switches its write side to s2 (c.out.cw = s2.NewWriter)
+	//    (b) Sends a compressed INFO back to us
+	//    (c) Switches its read side to s2 (switchToCompression flag)
+	//    (d) Decompresses our compressed PING, responds with compressed PONG
+	//
+	//    So we need to read compressed data from the connection.
+	//    Note: there may be leftover plain-text bytes in br's buffer from
+	//    the initial read, but after the server switches, all new data is
+	//    compressed. We wrap the connection in an s2 reader.
+	require_NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	sr := s2.NewReader(br)
+	buf := make([]byte, 1024)
+	var received string
+	// Read until we see PONG in the decompressed output.
+	for i := 0; i < 10; i++ {
+		n, err := sr.Read(buf)
+		if err != nil {
+			t.Fatalf("Error reading compressed response: %v (received so far: %q)", err, received)
+		}
+		received += string(buf[:n])
+		if strings.Contains(received, "PONG\r\n") {
+			break
+		}
+	}
+	require_Contains(t, received, "PONG\r\n")
 }
 
 func TestRouteCompressionMatrixModes(t *testing.T) {


### PR DESCRIPTION
When route/leafnode connections negotiate S2 compression, compressed data can arrive coalesced with the INFO message in the same TCP read buffer (although probably unlikely in practice, as this would require a route/leaf to be optimistic about the switch to S2). The parser would continue iterating the buffer after processing INFO, interpreting compressed bytes as plain-text NATS protocol and triggering a disconnect. This fix introduces `ErrCompressionSwitchPending` so the parser stops immediately after an INFO that sets `switchToCompression`, and `readLoop` feeds any remaining bytes in the buffer into the new s2 decompression reader via `io.MultiReader`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>