### PR TITLE
Report the account and user name in USER.INFO request

### DIFF
--- a/server/auth_callout_test.go
+++ b/server/auth_callout_test.go
@@ -278,8 +278,9 @@ func TestAuthCalloutBasics(t *testing.T) {
 	userInfo := response.Data.(*UserInfo)
 
 	dlc := &UserInfo{
-		UserID:  "dlc",
-		Account: globalAccountName,
+		UserID:      "dlc",
+		Account:     globalAccountName,
+		AccountName: globalAccountName,
 		Permissions: &Permissions{
 			Publish: &SubjectPermission{
 				Allow: []string{"$SYS.>"},
@@ -311,8 +312,9 @@ func TestAuthCalloutBasics(t *testing.T) {
 	userInfo = response.Data.(*UserInfo)
 	dlc = &UserInfo{
 		// Token MUST NOT be exposed in user info.
-		UserID:  "[REDACTED]",
-		Account: globalAccountName,
+		UserID:      "[REDACTED]",
+		Account:     globalAccountName,
+		AccountName: globalAccountName,
 		Permissions: &Permissions{
 			Publish: &SubjectPermission{
 				Allow: []string{"$SYS.>"},
@@ -590,8 +592,9 @@ func TestAuthCalloutVerifiedUserCalloutsWithSig(t *testing.T) {
 	userInfo := response.Data.(*UserInfo)
 
 	dlc := &UserInfo{
-		UserID:  "UBO2MQV67TQTVIRV3XFTEZOACM4WLOCMCDMAWN5QVN5PI2N6JHTVDRON",
-		Account: globalAccountName,
+		UserID:      "UBO2MQV67TQTVIRV3XFTEZOACM4WLOCMCDMAWN5QVN5PI2N6JHTVDRON",
+		Account:     globalAccountName,
+		AccountName: globalAccountName,
 		Permissions: &Permissions{
 			Publish: &SubjectPermission{
 				Deny: []string{AuthCalloutSubject}, // Will be auto-added since in auth account.
@@ -807,8 +810,10 @@ func TestAuthCalloutOperatorModeBasics(t *testing.T) {
 
 	userInfo := response.Data.(*UserInfo)
 	expected := &UserInfo{
-		UserID:  upub,
-		Account: apub,
+		UserID:      upub,
+		Account:     apub,
+		AccountName: "AUTH",
+		UserName:    "auth-service",
 		Permissions: &Permissions{
 			Publish: &SubjectPermission{
 				Deny: []string{AuthCalloutSubject}, // Will be auto-added since in auth account.
@@ -991,8 +996,10 @@ func testAuthCalloutScopedUser(t *testing.T, allowAnyAccount bool) {
 
 	userInfo := response.Data.(*UserInfo)
 	expected := &UserInfo{
-		UserID:  upub,
-		Account: apub,
+		UserID:      upub,
+		Account:     apub,
+		AccountName: "AUTH",
+		UserName:    "auth-service",
 		Permissions: &Permissions{
 			Publish: &SubjectPermission{
 				Deny: []string{AuthCalloutSubject}, // Will be auto-added since in auth account.

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -2770,8 +2770,9 @@ func TestClientUserInfoReq(t *testing.T) {
 	userInfo := response.Data.(*UserInfo)
 
 	dlc := &UserInfo{
-		UserID:  "dlc",
-		Account: "A",
+		UserID:      "dlc",
+		Account:     "A",
+		AccountName: "A",
 		Permissions: &Permissions{
 			Publish: &SubjectPermission{
 				Allow: []string{"$SYS.REQ.>"},
@@ -2805,8 +2806,9 @@ func TestClientUserInfoReq(t *testing.T) {
 	userInfo = response.Data.(*UserInfo)
 
 	admin := &UserInfo{
-		UserID:  "admin",
-		Account: "$SYS",
+		UserID:      "admin",
+		Account:     "$SYS",
+		AccountName: "$SYS",
 	}
 	if !reflect.DeepEqual(admin, userInfo) {
 		t.Fatalf("User info for %q did not match", "admin")

--- a/server/events.go
+++ b/server/events.go
@@ -1508,6 +1508,8 @@ func (s *Server) initEventTracking() {
 type UserInfo struct {
 	UserID      string        `json:"user"`
 	Account     string        `json:"account"`
+	AccountName string        `json:"account_name,omitempty"`
+	UserName    string        `json:"user_name,omitempty"`
 	Permissions *Permissions  `json:"permissions,omitempty"`
 	Expires     time.Duration `json:"expires,omitempty"`
 }
@@ -1527,9 +1529,22 @@ func (s *Server) userInfoReq(sub *subscription, c *client, _ *Account, subject, 
 		return
 	}
 
+	// Look up the requester's account directly from ci.Account rather than
+	// using the acc returned by getRequestInfo, which may resolve to the
+	// service account (ci.Service) when the request arrives via a chained
+	// service import.
+	var accountName string
+	if ci.Account != _EMPTY_ {
+		if reqAcc, _ := s.LookupAccount(ci.Account); reqAcc != nil {
+			accountName = reqAcc.getNameTag()
+		}
+	}
+
 	response.Data = &UserInfo{
 		UserID:      ci.User,
 		Account:     ci.Account,
+		AccountName: accountName,
+		UserName:    ci.NameTag,
 		Permissions: c.publicPermissions(),
 		Expires:     c.claimExpiration(),
 	}


### PR DESCRIPTION
This adds similar behaviour as that in `AccountStat` into `UserInfo` for reporting the friendly name of accounts and users

Signed-off-by: R.I.Pienaar <rip@devco.net>
