### PR TITLE
(2.14) [IMPROVED] Rollup allowed if at DiscardNewPerSubject limit

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4835,7 +4835,9 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 		var asl bool
 		if psmax && psmc >= mmp {
 			// If we are instructed to discard new per subject, this is an error.
-			if fs.cfg.DiscardNewPer {
+			// However, allow rollup messages through since they will purge old
+			// messages for the subject after storing, restoring the limit.
+			if fs.cfg.DiscardNewPer && len(sliceHeader(JSMsgRollup, hdr)) == 0 {
 				return ErrMaxMsgsPerSubject
 			}
 			if fseq, err = fs.firstSeqForSubj(subj); err != nil {

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -934,7 +934,8 @@ func checkMsgHeadersPreClusteredProposal(
 		}
 
 		// Similarly, check DiscardNew per-subject threshold to not need to bump CLFS.
-		if discardNewPer && maxMsgsPer > 0 {
+		// Allow rollup messages through since they will purge after storing.
+		if discardNewPer && maxMsgsPer > 0 && len(sliceHeader(JSMsgRollup, hdr)) == 0 {
 			// Get the current total for this subject.
 			totalMsgsForSubject := mset.store.SubjectsTotals(subject)[subject]
 			// Add inflight count in this batch and for this stream.

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8816,3 +8816,86 @@ func TestJetStreamClusterStreamUpdateCombinedScaleDownWithSourcesRemoved(t *test
 	require_NoError(t, err)
 	require_Len(t, len(si.Sources), 0)
 }
+
+func TestJetStreamClusterRollupWithDiscardNewPerSubject(t *testing.T) {
+	test := func(t *testing.T, replicas int, storage nats.StorageType) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:                 "TEST",
+			Subjects:             []string{"kv.>"},
+			Replicas:             replicas,
+			Storage:              storage,
+			Discard:              nats.DiscardNew,
+			DiscardNewPerSubject: true,
+			MaxMsgsPerSubject:    1,
+			AllowRollup:          true,
+		})
+		require_NoError(t, err)
+
+		// Populate two subjects at their per-subject limit.
+		sendStreamMsg(t, nc, "kv.A", "value-A")
+		sendStreamMsg(t, nc, "kv.B", "value-B")
+
+		si, err := js.StreamInfo("TEST")
+		require_NoError(t, err)
+		require_Equal(t, si.State.Msgs, 2)
+		require_Equal(t, si.State.FirstSeq, 1)
+		require_Equal(t, si.State.LastSeq, 2)
+
+		// Rollup on subject should succeed despite per-subject limit.
+		m := nats.NewMsg("kv.A")
+		m.Data = []byte("rolled-up-A")
+		m.Header.Set(JSMsgRollup, JSMsgRollupSubject)
+		_, err = js.PublishMsg(m)
+		require_NoError(t, err)
+
+		// Should still have 2 messages: the rollup replaced kv.A, kv.B untouched.
+		si, err = js.StreamInfo("TEST")
+		require_NoError(t, err)
+		require_Equal(t, si.State.Msgs, 2)
+		require_Equal(t, si.State.FirstSeq, 2)
+		require_Equal(t, si.State.LastSeq, 3)
+
+		// Verify the rollup message is what we stored.
+		sub, err := js.SubscribeSync("kv.A")
+		require_NoError(t, err)
+		defer sub.Drain()
+		msg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		require_Equal(t, string(msg.Data), "rolled-up-A")
+
+		// Rollup all should also succeed.
+		m = nats.NewMsg("kv.A")
+		m.Data = []byte("rolled-up-all")
+		m.Header.Set(JSMsgRollup, JSMsgRollupAll)
+		_, err = js.PublishMsg(m)
+		require_NoError(t, err)
+
+		// Only the rollup message should remain.
+		si, err = js.StreamInfo("TEST")
+		require_NoError(t, err)
+		require_Equal(t, si.State.Msgs, 1)
+		require_Equal(t, si.State.FirstSeq, 4)
+		require_Equal(t, si.State.LastSeq, 4)
+	}
+
+	for _, replicas := range []int{1, 3} {
+		for _, storage := range []nats.StorageType{nats.FileStorage, nats.MemoryStorage} {
+			t.Run(fmt.Sprintf("R%d/%s", replicas, storage), func(t *testing.T) {
+				test(t, replicas, storage)
+			})
+		}
+	}
+}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -211,7 +211,9 @@ func (ms *memStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, tt
 	// If we are clustered, we do the enforcement above and should not disqualify
 	// the message here since it could cause replicas to drift.
 	if discardNewCheck && ms.cfg.Discard == DiscardNew {
-		if asl && ms.cfg.DiscardNewPer {
+		// Allow rollup messages through since they will purge old
+		// messages for the subject after storing, restoring the limit.
+		if asl && ms.cfg.DiscardNewPer && len(sliceHeader(JSMsgRollup, hdr)) == 0 {
 			return ErrMaxMsgsPerSubject
 		}
 		if ms.cfg.MaxMsgs > 0 && ms.state.Msgs >= uint64(ms.cfg.MaxMsgs) {


### PR DESCRIPTION
When a stream is configured with `DiscardNewPerSubject` and the per-subject message limit is reached, `Nats-Rollup` messages were rejected before being stored. Even though the rollup would result in clearing up space below the `DiscardNewPerSubject` limit. This PR improves this by allowing rollups to go through even if at this limit.

Co-authored-by: Charles Duffy <charles@cmdzero.io>
Signed-off-by: Maurice van Veen <github@mauricevanveen.com>