### PR TITLE
Implements the second part of sourcing deduplication

### DIFF
--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -7677,7 +7677,7 @@ func TestJetStreamClusterConsumerSetStoreStateOldUpdateRestart(t *testing.T) {
 	}
 }
 
-func TestJetStreamClusterSourcingIntoDiscardNewPerSubject(t *testing.T) {
+func TestJetStreamClusterSourcingDeduplication(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 
@@ -7714,120 +7714,98 @@ func TestJetStreamClusterSourcingIntoDiscardNewPerSubject(t *testing.T) {
 	require_NoError(t, err)
 	require_Equal(t, resp.Error, nil)
 
-	_, err = js.Publish("foo.1", []byte("1"))
+	// Publish a message on foo.1
+	_, err = js.Publish("foo.1", ([]byte)("1"))
 	require_NoError(t, err)
 
-	// This second publish to the same subject should not be sourced
-	// due to discard new per subject with MaxMsgsPer=1.
-	_, err = js.Publish("foo.1", []byte("2"))
-	require_NoError(t, err)
-
+	// Wait for it to get sourced
+	var si *nats.StreamInfo
 	checkFor(t, 4*time.Second, 200*time.Millisecond, func() error {
-		si, err := js.StreamInfo("B")
+		si, err = js.StreamInfo("B")
 		if err != nil {
 			return err
 		}
 		if si.State.Msgs != 1 {
-			return fmt.Errorf("expected 1 message, got %d", si.State.Msgs)
+			return fmt.Errorf("expected 1 messages, got %d", si.State.Msgs)
 		}
 		return nil
 	})
 
-	// Check the message content.
+	// Publish another message that will be skipped as discard new per subject is set
+	_, err = js.Publish("foo.1", ([]byte)("2"))
+	require_NoError(t, err)
+
+	// Then publish another message that will be sourced as the previous one is a duplicate and should have been skipped
+	_, err = js.Publish("foo.2", ([]byte)("1"))
+	require_NoError(t, err)
+
+	checkFor(t, 4*time.Second, 200*time.Millisecond, func() error {
+		si, err = js.StreamInfo("B")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != 2 {
+			return fmt.Errorf("expected 2 messages, got %d", si.State.Msgs)
+		}
+		return nil
+	})
+
+	// Check the messages
 	msgp, err := js.GetMsg("B", uint64(1))
 	require_NoError(t, err)
 	require_Equal(t, msgp.Subject, "foo.1")
 	require_Equal(t, string(msgp.Data), "1")
 
-	// Purge stream B so sourcing can continue past the per-subject limit.
-	require_NoError(t, js.PurgeStream("B"))
-
-	checkFor(t, 4*time.Second, 200*time.Millisecond, func() error {
-		si, err := js.StreamInfo("B")
-		if err != nil {
-			return err
-		}
-		if si.State.Msgs != 1 {
-			return fmt.Errorf("expected 1 message, got %d", si.State.Msgs)
-		}
-		return nil
-	})
-
-	// After purge, the second message should now be sourced.
 	msgp, err = js.GetMsg("B", uint64(2))
-	require_NoError(t, err)
-	require_Equal(t, msgp.Subject, "foo.1")
-	require_Equal(t, string(msgp.Data), "2")
-
-	// Test duplicate message ID handling: publish with explicit Nats-Msg-Id.
-	msg := nats.NewMsg("foo.2")
-	msg.Data = []byte("1")
-	msg.Header.Set("Nats-Msg-Id", "dup1")
-
-	_, err = js.PublishMsg(msg)
-	require_NoError(t, err)
-
-	// Must be able to source the message after the duplicate.
-	checkFor(t, 4*time.Second, 200*time.Millisecond, func() error {
-		si, err := js.StreamInfo("B")
-		if err != nil {
-			return err
-		}
-		if si.State.Msgs != 2 {
-			return fmt.Errorf("expected 2 messages, got %d", si.State.Msgs)
-		}
-		return nil
-	})
-
-	msgp, err = js.GetMsg("B", uint64(3))
 	require_NoError(t, err)
 	require_Equal(t, msgp.Subject, "foo.2")
 	require_Equal(t, string(msgp.Data), "1")
 
-	// Wait for the dedup window on stream A (100ms) to expire.
-	time.Sleep(200 * time.Millisecond)
-
-	// Publish a message with the same Nats-Msg-Id but to a different subject.
-	// Stream A's dedup window has expired, so A will accept it.
-	// Stream B has a 10s dedup window, so it should detect this as a duplicate and skip it.
-	msg = nats.NewMsg("foo.3")
+	// Publish a message on a new subject with the message id set
+	msg := nats.NewMsg("foo.3")
 	msg.Data = []byte("1")
-	msg.Header.Set("Nats-Msg-Id", "dup1")
+	msg.Header.Set("Nats-Msg-Id", "1")
 
 	_, err = js.PublishMsg(msg)
 	require_NoError(t, err)
 
-	// The duplicate should be skipped by B; message count should stay at 2.
-	checkFor(t, 4*time.Second, 200*time.Millisecond, func() error {
-		si, err := js.StreamInfo("B")
-		if err != nil {
-			return err
-		}
-		if si.State.Msgs != 2 {
-			return fmt.Errorf("expected 2 messages, got %d", si.State.Msgs)
-		}
-		return nil
-	})
-
-	// Sourcing must continue processing after the skipped duplicate.
-	_, err = js.Publish("foo.4", []byte("1"))
+	// Then publish another message on a new subject but with the same message id, which should be skipped as a duplicate
+	msg = nats.NewMsg("foo.4")
+	msg.Data = []byte("1")
+	msg.Header.Set("Nats-Msg-Id", "1")
+	_, err = js.PublishMsg(msg)
 	require_NoError(t, err)
 
+	// Finally publish another message that should get sourced to verify the message with duplicate id was skipped
+	_, err = js.Publish("foo.5", ([]byte)("1"))
+	require_NoError(t, err)
+
+	// check expected stream size
 	checkFor(t, 4*time.Second, 200*time.Millisecond, func() error {
-		si, err := js.StreamInfo("B")
+		si, err = js.StreamInfo("B")
 		if err != nil {
 			return err
 		}
-		if si.State.Msgs != 3 {
-			return fmt.Errorf("expected 3 messages, got %d", si.State.Msgs)
+		if si.State.Msgs != 4 {
+			return fmt.Errorf("expected 4 messages, got %d", si.State.Msgs)
 		}
 		return nil
 	})
+
+	// check the messages
+	msgp, err = js.GetMsg("B", uint64(3))
+	require_NoError(t, err)
+	require_Equal(t, msgp.Subject, "foo.3")
+	require_Equal(t, string(msgp.Data), "1")
 
 	msgp, err = js.GetMsg("B", uint64(4))
 	require_NoError(t, err)
-	require_Equal(t, msgp.Subject, "foo.4")
+	require_Equal(t, msgp.Subject, "foo.5")
 	require_Equal(t, string(msgp.Data), "1")
+
+	// check it's really the last message
+	_, err = js.GetMsg("B", uint64(5))
+	require_Error(t, err, nats.ErrMsgNotFound)
 }
 
 func TestJetStreamClusterSourceRetryDoesNotDuplicate(t *testing.T) {

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -7943,6 +7943,7 @@ func TestJetStreamClusterSourcingDeduplication(t *testing.T) {
 	require_NoError(t, err)
 
 	// Then publish another message on a new subject but with the same message id, which should be skipped as a duplicate
+	time.Sleep(200 * time.Millisecond) // Ensure we are outside the dedup window of the A stream so the stream doesn't do the deduplication
 	msg = nats.NewMsg("foo.4")
 	msg.Data = []byte("1")
 	msg.Header.Set("Nats-Msg-Id", "1")

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -23404,7 +23404,7 @@ func TestJetStreamMirrorSetupStartGoRoutineFailMissingWgDone(t *testing.T) {
 	}
 }
 
-func TestJetStreamSourcingIntoDiscardNewPerSubject(t *testing.T) {
+func TestJetStreamSourcingDeduplication(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
@@ -23434,20 +23434,17 @@ func TestJetStreamSourcingIntoDiscardNewPerSubject(t *testing.T) {
 	r, err := nc.Request("$JS.API.STREAM.CREATE.B", req, 5*time.Second)
 	require_NoError(t, err)
 
-	var resp JSApiConsumerCreateResponse
+	var resp JSApiStreamCreateResponse
 	err = json.Unmarshal(r.Data, &resp)
 	require_NoError(t, err)
 	require_Equal(t, resp.Error, nil)
 
+	// Publish a message on foo.1
 	_, err = js.Publish("foo.1", ([]byte)("1"))
 	require_NoError(t, err)
 
-	// this will not be sourced as discard new per subject
-	_, err = js.Publish("foo.1", ([]byte)("2"))
-	require_NoError(t, err)
-
+	// Wait for it to get sourced
 	var si *nats.StreamInfo
-
 	checkFor(t, 4*time.Second, 200*time.Millisecond, func() error {
 		si, err = js.StreamInfo("B")
 		if err != nil {
@@ -23459,99 +23456,81 @@ func TestJetStreamSourcingIntoDiscardNewPerSubject(t *testing.T) {
 		return nil
 	})
 
-	// Check the message
+	// Publish another message that will be skipped as discard new per subject is set
+	_, err = js.Publish("foo.1", ([]byte)("2"))
+	require_NoError(t, err)
+
+	// Then publish another message that will be sourced as the previous one is a duplicate and should have been skipped
+	_, err = js.Publish("foo.2", ([]byte)("1"))
+	require_NoError(t, err)
+
+	checkFor(t, 4*time.Second, 200*time.Millisecond, func() error {
+		si, err = js.StreamInfo("B")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != 2 {
+			return fmt.Errorf("expected 2 messages, got %d", si.State.Msgs)
+		}
+		return nil
+	})
+
+	// Check the messages
 	msgp, err := js.GetMsg("B", uint64(1))
 	require_NoError(t, err)
 	require_Equal(t, msgp.Subject, "foo.1")
 	require_Equal(t, string(msgp.Data), "1")
 
-	// now purge the stream so sourcing can continue
-	require_NoError(t, js.PurgeStream("B"))
-
-	checkFor(t, 4*time.Second, 200*time.Millisecond, func() error {
-		si, err = js.StreamInfo("B")
-		if err != nil {
-			return err
-		}
-		if si.State.Msgs != 1 {
-			return fmt.Errorf("expected 1 messages, got %d", si.State.Msgs)
-		}
-		return nil
-	})
-
-	// check the message
 	msgp, err = js.GetMsg("B", uint64(2))
-	require_NoError(t, err)
-	require_Equal(t, msgp.Subject, "foo.1")
-	require_Equal(t, string(msgp.Data), "2")
-
-	msg := nats.NewMsg("foo.2")
-	msg.Data = []byte("1")
-	msg.Header.Set("Nats-Msg-Id", "1")
-
-	_, err = js.PublishMsg(msg)
-	require_NoError(t, err)
-
-	// Must be able to move on and source the next message after the duplicate
-	checkFor(t, 4*time.Second, 200*time.Millisecond, func() error {
-		si, err = js.StreamInfo("B")
-		if err != nil {
-			return err
-		}
-		if si.State.Msgs != 2 {
-			return fmt.Errorf("expected 2 messages, got %d", si.State.Msgs)
-		}
-		return nil
-	})
-
-	// check the message
-	msgp, err = js.GetMsg("B", uint64(3))
 	require_NoError(t, err)
 	require_Equal(t, msgp.Subject, "foo.2")
 	require_Equal(t, string(msgp.Data), "1")
 
-	time.Sleep(200 * time.Millisecond)
-
-	msg = nats.NewMsg("foo.3")
+	// Publish a message on a new subject with the message id set
+	msg := nats.NewMsg("foo.3")
 	msg.Data = []byte("1")
 	msg.Header.Set("Nats-Msg-Id", "1")
 
 	_, err = js.PublishMsg(msg)
 	require_NoError(t, err)
 
-	// Duplicate message id, should get skipped
-	checkFor(t, 4*time.Second, 200*time.Millisecond, func() error {
-		si, err = js.StreamInfo("B")
-		if err != nil {
-			return err
-		}
-		if si.State.Msgs != 2 {
-			return fmt.Errorf("expected 2 messages, got %d", si.State.Msgs)
-		}
-		return nil
-	})
-
-	// Must be able to move on
-	_, err = js.Publish("foo.4", ([]byte)("1"))
+	// Then publish another message on a new subject but with the same message id, which should be skipped as a duplicate
+	msg = nats.NewMsg("foo.4")
+	msg.Data = []byte("1")
+	msg.Header.Set("Nats-Msg-Id", "1")
+	_, err = js.PublishMsg(msg)
 	require_NoError(t, err)
 
-	// Must be able to move on and source the next message after the duplicate
+	// Finally publish another message that should get sourced to verify the message with duplicate id was skipped
+	_, err = js.Publish("foo.5", ([]byte)("1"))
+	require_NoError(t, err)
+
+	// check expected stream size
 	checkFor(t, 4*time.Second, 200*time.Millisecond, func() error {
 		si, err = js.StreamInfo("B")
 		if err != nil {
 			return err
 		}
-		if si.State.Msgs != 3 {
-			return fmt.Errorf("expected 3 messages, got %d", si.State.Msgs)
+		if si.State.Msgs != 4 {
+			return fmt.Errorf("expected 4 messages, got %d", si.State.Msgs)
 		}
 		return nil
 	})
+
+	// check the messages
+	msgp, err = js.GetMsg("B", uint64(3))
+	require_NoError(t, err)
+	require_Equal(t, msgp.Subject, "foo.3")
+	require_Equal(t, string(msgp.Data), "1")
 
 	msgp, err = js.GetMsg("B", uint64(4))
 	require_NoError(t, err)
-	require_Equal(t, msgp.Subject, "foo.4")
+	require_Equal(t, msgp.Subject, "foo.5")
 	require_Equal(t, string(msgp.Data), "1")
 
+	// check it's really the last message
+	_, err = js.GetMsg("B", uint64(5))
+	require_Error(t, err, nats.ErrMsgNotFound)
 }
 
 func TestJetStreamDurableStreamMirrorAndSourceIncorrectConsumerConfig(t *testing.T) {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -23496,6 +23496,7 @@ func TestJetStreamSourcingDeduplication(t *testing.T) {
 	// Then publish another message on a new subject but with the same message id, which should be skipped as a duplicate
 	msg = nats.NewMsg("foo.4")
 	msg.Data = []byte("1")
+	time.Sleep(200 * time.Millisecond) // Ensure we are outside the dedup window of the A stream so the stream doesn't do the deduplication
 	msg.Header.Set("Nats-Msg-Id", "1")
 	_, err = js.PublishMsg(msg)
 	require_NoError(t, err)

--- a/server/stream.go
+++ b/server/stream.go
@@ -4417,7 +4417,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 			}
 
 			// Duplicates can be skipped, continue to the next message.
-			if errors.Is(err, errMsgIdDuplicate) {
+			if errors.Is(err, errMsgIdDuplicate) || errors.Is(err, ErrMaxMsgsPerSubject) {
 				return true
 			}
 


### PR DESCRIPTION
Implements the second part of sourcing deduplication, extending #7896 to discard new per subject. 

When a sourcing stream hits a max message per subject limit with discard new per subject on a message from a source, rather than blocking that sourcing until message(s) are deleted from the sourcing stream such that the limit is not hit anymore, the (duplicate) message is now skipped.

Signed-off-by: Jean-Noël Moyne <jnmoyne@gmail.com>
