### PR TITLE
[FIXED] Deal with misaligned DeleteBlocks in SyncDeleted

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -12076,31 +12076,23 @@ func (fs *fileStore) SyncDeleted(dbs DeleteBlocks) error {
 	}
 
 	lseq := fs.state.LastSeq
-	var needsCheck DeleteBlocks
-
 	fs.readLockAllMsgBlocks()
 	mdbs := fs.deleteBlocks()
-	for i, db := range dbs {
-		first, last, num := db.State()
-		// If the block is same as what we have we can skip.
-		if i < len(mdbs) {
-			eFirst, eLast, eNum := mdbs[i].State()
-			if first == eFirst && last == eLast && num == eNum {
-				continue
-			}
-		} else if first > lseq {
-			// Skip blocks not applicable to our current state.
-			continue
-		}
-		// Need to insert these.
-		needsCheck = append(needsCheck, db)
-	}
 	fs.readUnlockAllMsgBlocks()
 
-	for _, db := range needsCheck {
+	for _, db := range dbs {
+		first, last, _ := db.State()
+		if first > lseq {
+			break
+		}
+
+		var prune bool
+		if prune, mdbs = pruneDeleteBlock(db, mdbs); prune {
+			continue
+		}
+
 		var err error
-		if dr, ok := db.(*DeleteRange); ok {
-			first, last, _ := dr.State()
+		if _, ok := db.(*DeleteRange); ok {
 			err = fs.removeMsgsInRange(first, last, true)
 		} else {
 			db.Range(func(dseq uint64) bool {
@@ -12117,6 +12109,34 @@ func (fs *fileStore) SyncDeleted(dbs DeleteBlocks) error {
 		}
 	}
 	return nil
+}
+
+// pruneDeleteBlock tries to find a delete block in the ordered blocks slice
+// that matches db. It skips blocks that are already behind db and returns
+// whether the next candidate matches exactly, along with the remaining
+// suffix to use for the next comparison.
+func pruneDeleteBlock(db DeleteBlock, blocks DeleteBlocks) (bool, DeleteBlocks) {
+	if len(blocks) == 0 {
+		return false, blocks
+	}
+
+	aFirst, aLast, aNum := db.State()
+	bFirst, bLast, bNum := blocks[0].State()
+
+	// Drop blocks that end before db starts.
+	for bLast < aFirst {
+		blocks = blocks[1:]
+		if len(blocks) == 0 {
+			return false, blocks
+		}
+		bFirst, bLast, bNum = blocks[0].State()
+	}
+
+	if aFirst == bFirst && aLast == bLast && aNum == bNum {
+		return true, blocks[1:]
+	}
+
+	return false, blocks
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -12630,6 +12630,64 @@ func makeSequenceSet(seqs []uint64) *avl.SequenceSet {
 	return &set
 }
 
+func TestPruneDeleteBlock(t *testing.T) {
+	dbs := DeleteBlocks{
+		&DeleteRange{First: 5, Num: 1},
+		makeSequenceSet([]uint64{8}),
+		&DeleteRange{First: 9, Num: 2},
+		&DeleteRange{First: 47, Num: 92},
+		&DeleteRange{First: 139, Num: 22},
+		&DeleteRange{First: 200, Num: 21},
+	}
+	local := DeleteBlocks{
+		makeSequenceSet([]uint64{8}),
+		&DeleteRange{First: 9, Num: 2},
+		&DeleteRange{First: 139, Num: 22},
+		&DeleteRange{First: 170, Num: 6},
+		&DeleteRange{First: 200, Num: 11},
+	}
+
+	// New earlier block should not be pruned.
+	prune, local := pruneDeleteBlock(dbs[0], local)
+	require_False(t, prune)
+	require_Equal(t, len(local), 5)
+
+	// Exact SequenceSet match should be pruned.
+	prune, local = pruneDeleteBlock(dbs[1], local)
+	require_True(t, prune)
+	require_Equal(t, len(local), 4)
+
+	// Exact DeleteRange match should be pruned.
+	prune, local = pruneDeleteBlock(dbs[2], local)
+	require_True(t, prune)
+	require_Equal(t, len(local), 3)
+
+	// Overlap alone is not enough to prune.
+	prune, local = pruneDeleteBlock(dbs[3], local)
+	require_False(t, prune)
+	require_Equal(t, len(local), 3)
+
+	// A later exact match should still be pruned after misalignment.
+	prune, local = pruneDeleteBlock(dbs[4], local)
+	require_True(t, prune)
+	require_Equal(t, len(local), 2)
+
+	// The scan should skip earlier local blocks that cannot match.
+	prune, local = pruneDeleteBlock(dbs[5], local)
+	require_False(t, prune)
+	require_Equal(t, len(local), 1)
+
+	// If all remaining local blocks are behind, the scan should exhaust them.
+	prune, local = pruneDeleteBlock(&DeleteRange{First: 300, Num: 1}, local)
+	require_False(t, prune)
+	require_Equal(t, len(local), 0)
+
+	// An empty local slice should be handled without pruning.
+	prune, local = pruneDeleteBlock(&DeleteRange{First: 301, Num: 1}, local)
+	require_False(t, prune)
+	require_Equal(t, len(local), 0)
+}
+
 func TestFileStoreDeleteBlocks(t *testing.T) {
 	fcfg := FileStoreConfig{
 		Cipher:      NoCipher,


### PR DESCRIPTION
SyncDeleted only skipped delete blocks when the incoming and local DeleteBlocks matched at the exact same index. This stopped working as soon as the incoming has shifted or new delete blocks appear in the list.
This commit adds method pruneDeleteBlock which lift the above limitation. It takes an incoming DeleteBlock and a list of local DeleteBlocks. If pruneDeleteBlock finds that the local DeleteBlocks has a matching entry for the incoming DeleteBlock, then it will return true indicating that it can be skipped, avoiding unnecessary deletes.

Signed-off-by: Daniele Sciascia <daniele@nats.io>
