### PR TITLE
[FIXED] Nil account panic in processLeafNodeConnect

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2154,6 +2154,13 @@ func (c *client) processLeafNodeConnect(s *Server, arg []byte, lang string) erro
 	acc := c.acc
 	c.mu.Unlock()
 
+	// If the account is not set (e.g. connection was closed due to auth
+	// timeout while still being processed), bail out to avoid a panic.
+	if acc == nil {
+		c.closeConnection(MissingAccount)
+		return ErrMissingAccount
+	}
+
 	// Register the cluster, even if empty, as long as we are acting as a hub.
 	if !proto.Hub {
 		acc.registerLeafNodeCluster(proto.Cluster)

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -11244,3 +11244,51 @@ func TestLeafNodeNoAccPanicOnLeafSubBeforeConnectOperatorMode(t *testing.T) {
 		t.Fatal("Server should not have shutdown")
 	}
 }
+
+func TestLeafNodeNoAccPanicOnProcessLeafNodeConnect(t *testing.T) {
+	o := DefaultOptions()
+	o.LeafNode.Port = -1
+	o.LeafNode.AuthTimeout = 0.001 // Very short auth timeout (1ms)
+	s := RunServer(o)
+	defer s.Shutdown()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", o.LeafNode.Port)
+	c, err := net.Dial("tcp", addr)
+	require_NoError(t, err)
+	defer c.Close()
+
+	// Read the INFO.
+	br := bufio.NewReader(c)
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	l, _, err := br.ReadLine()
+	require_NoError(t, err)
+	if !strings.HasPrefix(string(l), "INFO") {
+		t.Fatalf("Expected INFO, got %q", l)
+	}
+
+	// Wait for the auth timeout to fire, then send CONNECT with cluster.
+	// This races with the auth timeout closing the connection, which is
+	// the scenario from #7989 where c.acc ends up nil.
+	time.Sleep(5 * time.Millisecond)
+
+	connect := `CONNECT {"verbose":false,"pedantic":false,"cluster":"test-cluster"}`
+	c.Write([]byte(connect + "\r\n"))
+
+	// The server should close the connection without panicking.
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 256)
+	for {
+		_, err = c.Read(buf)
+		if err != nil {
+			break
+		}
+	}
+
+	// Make sure the server is still running (not panicked).
+	s.mu.Lock()
+	shutdown := s.isShuttingDown()
+	s.mu.Unlock()
+	if shutdown {
+		t.Fatal("Server should not have shutdown")
+	}
+}


### PR DESCRIPTION
## What

Fixes a nil pointer panic in `processLeafNodeConnect` when `c.acc` is nil.

## Stack trace from #7989

```
panic: runtime error: invalid memory address or nil pointer dereference

goroutine 100415 [running]:
github.com/nats-io/nats-server/v2/server.(*Account).registerLeafNodeCluster(0x0, ...)
        server/accounts.go:993 +0x2d
github.com/nats-io/nats-server/v2/server.(*client).processLeafNodeConnect(...)
        server/leafnode.go:2159 +0x595
```

The logs show `Authentication Timeout` followed by `connection closed` right before the panic. The account was never set on the client because the connection was closed during auth.

## Fix

Add a nil guard for `acc` after reading `c.acc`, consistent with the same pattern used in other code paths within the same file (lines 2259, 2758, 2890).

Resolves #7989