### PR TITLE
Send `JWT` to auth callout from MQTT clients

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -696,7 +696,7 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 		// If we are here we have an auth callout defined and we have failed auth so far
 		// so we will callout to our auth backend for processing.
 		if !skip {
-			authorized, reason = s.processClientOrLeafCallout(c, opts, proxyRequired, trustedProxy)
+			authorized, reason = s.processClientOrLeafCallout(c, opts, proxyRequired, trustedProxy, ujwt)
 		}
 		// Check if we are authorized and in the auth callout account, and if so add in deny publish permissions for the auth subject.
 		if authorized {
@@ -797,12 +797,21 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 		token = opts.Authorization
 	}
 
+	// MQTT can carry JWTs in the password field. Reconstruct it here for auth
+	// processing and auth callout, but do not populate c.opts.JWT yet or it would
+	// be exposed through monitoring and advisory paths even when the password is
+	// not actually a JWT.
+	if ujwt == _EMPTY_ && c.isMqtt() && c.opts.JWT == _EMPTY_ {
+		ujwt = c.opts.Password
+	}
+
 	// Check if we have trustedKeys defined in the server. If so we require a user jwt.
 	if s.trustedKeys != nil {
 		ujwt = c.opts.JWT
 		if ujwt == _EMPTY_ && c.isMqtt() {
-			// For MQTT, we pass the password as the JWT too, but do so here so it's not
-			// publicly exposed in the client options if it isn't a JWT.
+			// When JWT auth is enabled, MQTT may present the JWT in the password field.
+			// Keep using the local ujwt until it has been validated so c.opts.JWT is not
+			// populated with an arbitrary password.
 			ujwt = c.opts.Password
 		}
 		if ujwt == _EMPTY_ && opts.DefaultSentinel != _EMPTY_ {

--- a/server/auth_callout.go
+++ b/server/auth_callout.go
@@ -41,7 +41,7 @@ func titleCase(m string) string {
 }
 
 // Process a callout on this client's behalf.
-func (s *Server) processClientOrLeafCallout(c *client, opts *Options, proxyRequired, trustedProxy bool) (authorized bool, errStr string) {
+func (s *Server) processClientOrLeafCallout(c *client, opts *Options, proxyRequired, trustedProxy bool, ujwt string) (authorized bool, errStr string) {
 	isOperatorMode := len(opts.TrustedKeys) > 0
 
 	// this is the account the user connected in, or the one running the callout
@@ -374,7 +374,7 @@ func (s *Server) processClientOrLeafCallout(c *client, opts *Options, proxyRequi
 	// Grab client info for the request.
 	c.mu.Lock()
 	c.fillClientInfo(&claim.ClientInformation)
-	c.fillConnectOpts(&claim.ConnectOptions)
+	c.fillConnectOpts(&claim.ConnectOptions, ujwt)
 	// If we have a sig in the client opts, fill in nonce.
 	if claim.ConnectOptions.SignedNonce != _EMPTY_ {
 		claim.ClientInformation.Nonce = string(c.nonce)
@@ -474,16 +474,22 @@ func (c *client) fillClientInfo(ci *jwt.ClientInformation) {
 
 // Fill in client options.
 // Lock should be held.
-func (c *client) fillConnectOpts(opts *jwt.ConnectOptions) {
+func (c *client) fillConnectOpts(opts *jwt.ConnectOptions, ujwt string) {
 	if c == nil || (c.kind != CLIENT && c.kind != LEAF && c.kind != JETSTREAM && c.kind != ACCOUNT) {
 		return
 	}
 
 	o := c.opts
+	if ujwt == _EMPTY_ {
+		// The caller may supply a reconstructed JWT that should be sent to auth
+		// callout without storing it in c.opts.JWT. If not, fall back to the client
+		// option as before.
+		ujwt = o.JWT
+	}
 
 	// Do it this way to fail to compile if fields are added to jwt.ClientInformation.
 	*opts = jwt.ConnectOptions{
-		JWT:         o.JWT,
+		JWT:         ujwt,
 		Nkey:        o.Nkey,
 		SignedNonce: o.Sig,
 		Token:       o.Token,

--- a/server/auth_callout_test.go
+++ b/server/auth_callout_test.go
@@ -20,6 +20,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"os"
 	"reflect"
 	"slices"
@@ -40,6 +42,66 @@ func decodeAuthRequest(t *testing.T, ejwt []byte) (string, *jwt.ServerID, *jwt.C
 	ac, err := jwt.DecodeAuthorizationRequestClaims(string(ejwt))
 	require_NoError(t, err)
 	return ac.UserNkey, &ac.Server, &ac.ClientInformation, &ac.ConnectOptions, ac.TLS
+}
+
+func authCalloutMQTTConnectPacket(clientID, user, pass string) []byte {
+	flags := byte(mqttConnFlagCleanSession)
+	if user != _EMPTY_ {
+		flags |= mqttConnFlagUsernameFlag
+	}
+	if pass != _EMPTY_ {
+		flags |= mqttConnFlagPasswordFlag
+	}
+
+	pkLen := 2 + len(mqttProtoName) +
+		1 +
+		1 +
+		2 +
+		2 + len(clientID)
+
+	if user != _EMPTY_ {
+		pkLen += 2 + len(user)
+	}
+	if pass != _EMPTY_ {
+		pkLen += 2 + len(pass)
+	}
+
+	w := newMQTTWriter(0)
+	w.WriteByte(mqttPacketConnect)
+	w.WriteVarInt(pkLen)
+	w.WriteString(string(mqttProtoName))
+	w.WriteByte(0x4)
+	w.WriteByte(flags)
+	w.WriteUint16(0)
+	w.WriteString(clientID)
+	if user != _EMPTY_ {
+		w.WriteString(user)
+	}
+	if pass != _EMPTY_ {
+		w.WriteBytes([]byte(pass))
+	}
+	return w.Bytes()
+}
+
+func authCalloutMQTTConnect(t testing.TB, host string, port int, clientID, user, pass string) (net.Conn, byte) {
+	t.Helper()
+
+	c, err := net.Dial("tcp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	require_NoError(t, err)
+
+	c.SetDeadline(time.Now().Add(2 * time.Second))
+	defer c.SetDeadline(time.Time{})
+
+	_, err = c.Write(authCalloutMQTTConnectPacket(clientID, user, pass))
+	require_NoError(t, err)
+
+	var ack [4]byte
+	_, err = io.ReadFull(c, ack[:])
+	require_NoError(t, err)
+	if ack[0] != mqttPacketConnectAck || ack[1] != 2 {
+		t.Fatalf("Expected MQTT CONNACK, got %v", ack[:])
+	}
+	return c, ack[3]
 }
 
 func TestTitleCaseEmptyString(t *testing.T) {
@@ -331,6 +393,54 @@ func TestAuthCalloutBasics(t *testing.T) {
 	if expires > 10*time.Minute || expires < (10*time.Minute-5*time.Second) {
 		t.Fatalf("Expected expires of ~%v, got %v", 10*time.Minute, expires)
 	}
+}
+
+func TestAuthCalloutMQTTJwtPassedInConnectOptions(t *testing.T) {
+	storeDir := t.TempDir()
+	conf := fmt.Sprintf(`
+		listen: "127.0.0.1:-1"
+		server_name: A
+		jetstream: { max_mem_store: 256MB, max_file_store: 1GB, store_dir: %q }
+		mqtt { host: "127.0.0.1", port: -1 }
+		authorization {
+			timeout: 1s
+			users: [ { user: "auth", password: "pwd" } ]
+			auth_callout {
+				issuer: "ABJHLOVMPA4CI6R5KLNGOB4GSLNIY7IOUPAJC4YFNDLQVIOBYQGUWVLA"
+				auth_users: [ auth ]
+			}
+		}
+	`, storeDir)
+
+	expectedJWT := "mqtt-jwt-token"
+	seenJWT := make(chan string, 1)
+	handler := func(m *nats.Msg) {
+		user, si, _, opts, _ := decodeAuthRequest(t, m.Data)
+		select {
+		case seenJWT <- opts.JWT:
+		default:
+		}
+		if opts.JWT != expectedJWT {
+			m.Respond(nil)
+			return
+		}
+		ujwt := createAuthUser(t, user, _EMPTY_, globalAccountName, "", nil, 10*time.Minute, nil)
+		m.Respond(serviceResponse(t, user, si.ID, ujwt, "", 0))
+	}
+
+	at := NewAuthTest(t, conf, handler, nats.UserInfo("auth", "pwd"))
+	defer at.Cleanup()
+
+	mc, rc := authCalloutMQTTConnect(t, at.srv.getOpts().MQTT.Host, at.srv.getOpts().MQTT.Port, "mqtt-auth-callout", "ignored", expectedJWT)
+	defer mc.Close()
+
+	select {
+	case got := <-seenJWT:
+		require_Equal(t, got, expectedJWT)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Did not receive auth callout request")
+	}
+	require_Equal(t, rc, mqttConnAckRCConnectionAccepted)
 }
 
 func TestAuthCalloutMultiAccounts(t *testing.T) {


### PR DESCRIPTION
This was a regression from the CVE-2026-33216 fix. Fixes #7995.

Signed-off-by: Neil Twigg <neil@nats.io>
