### PR TITLE
(2.12) [FIXED] Filestore cache is expired too early with recent write

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -6514,7 +6514,7 @@ func (mb *msgBlock) resetCacheExpireTimer(td time.Duration) {
 		td = mb.cexp + 100*time.Millisecond
 	}
 	if mb.ctmr == nil {
-		mb.ctmr = time.AfterFunc(td, mb.expireCache)
+		mb.ctmr = time.AfterFunc(td, mb.tryExpireCache)
 	} else {
 		mb.ctmr.Reset(td)
 	}
@@ -6562,10 +6562,10 @@ func (mb *msgBlock) clearCache() {
 }
 
 // Called to possibly expire a message block cache.
-func (mb *msgBlock) expireCache() {
+func (mb *msgBlock) tryExpireCache() {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
-	mb.expireCacheLocked()
+	mb.tryExpireCacheLocked()
 }
 
 func (mb *msgBlock) tryForceExpireCache() {
@@ -6576,10 +6576,10 @@ func (mb *msgBlock) tryForceExpireCache() {
 
 // We will attempt to force expire this by temporarily clearing the last load time.
 func (mb *msgBlock) tryForceExpireCacheLocked() {
-	llts, lwts := mb.llts, mb.lwts
-	mb.llts, mb.lwts = 0, 0
-	mb.expireCacheLocked()
-	mb.llts, mb.lwts = llts, lwts
+	llts := mb.llts
+	mb.llts = 0
+	mb.tryExpireCacheLocked()
+	mb.llts = llts
 }
 
 // This is for expiration of the write cache, which will be partial with fip.
@@ -6591,7 +6591,7 @@ func (mb *msgBlock) tryExpireWriteCache() []byte {
 	}
 	lwts, buf, llts, nra := mb.lwts, mb.cache.buf, mb.llts, mb.cache.nra
 	mb.lwts, mb.cache.nra = 0, true
-	mb.expireCacheLocked()
+	mb.tryExpireCacheLocked()
 	mb.lwts = lwts
 	if mb.cache != nil {
 		mb.cache.nra = nra
@@ -6606,7 +6606,7 @@ func (mb *msgBlock) tryExpireWriteCache() []byte {
 }
 
 // Lock should be held.
-func (mb *msgBlock) expireCacheLocked() {
+func (mb *msgBlock) tryExpireCacheLocked() {
 	var strengthened bool
 	if mb.cache == nil {
 		mb.cache = mb.ecache.Value()
@@ -8189,7 +8189,7 @@ func (mb *msgBlock) flushPendingMsgsLocked() (*LostStreamData, error) {
 
 	// If not, we'll just drop the cache altogether & recycle the buffer.
 	mb.cache.nra = false
-	mb.expireCacheLocked()
+	mb.tryExpireCacheLocked()
 	return nil, mb.werr
 }
 
@@ -8583,7 +8583,7 @@ func (mb *msgBlock) cacheLookupEx(seq uint64, sm *StoreMsg, doCopy bool) (*Store
 	}
 
 	if seq != fsm.seq { // See TestFileStoreInvalidIndexesRebuilt.
-		mb.tryForceExpireCacheLocked()
+		mb.clearCacheAndOffset()
 		return nil, fmt.Errorf("sequence numbers for cache load did not match, %d vs %d", seq, fsm.seq)
 	}
 

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1760,9 +1760,10 @@ func TestFileStoreInvalidIndexesRebuilt(t *testing.T) {
 
 		toSend := 5
 		for i := 0; i < toSend; i++ {
-			fs.StoreMsg("foo", nil, []byte("ok-1"), 0)
+			_, _, err = fs.StoreMsg("foo", nil, []byte("ok-1"), 0)
+			require_NoError(t, err)
 		}
-		fs.FlushAllPending()
+		require_NoError(t, fs.FlushAllPending())
 
 		// Now we're going to mangle the in-memory cache by changing
 		// the sequence number of the first message. We also need to
@@ -5375,7 +5376,7 @@ func TestFileStoreErrPartialLoadOnSyncClose(t *testing.T) {
 	require_True(t, lmb != nil)
 
 	lmb.mu.Lock()
-	lmb.expireCacheLocked()
+	lmb.tryExpireCacheLocked()
 	lmb.dirtyCloseWithRemove(false)
 	lmb.mu.Unlock()
 
@@ -10032,7 +10033,7 @@ func TestFileStoreFirstMatchingMultiExpiry(t *testing.T) {
 
 		fs.mu.RLock()
 		mb := fs.lmb
-		mb.expireCacheLocked()
+		mb.tryExpireCacheLocked()
 		fs.mu.RUnlock()
 
 		sl := gsl.NewSublist[struct{}]()
@@ -13536,6 +13537,44 @@ func TestFileStoreSyncBlocksNoErrorOnConcurrentRemovedBlock(t *testing.T) {
 	defer mb.mu.RUnlock()
 	require_True(t, mb.werr == nil)
 	require_True(t, fs.werr == nil)
+}
+
+func TestFileStoreDontExpireCacheWithRecentWrite(t *testing.T) {
+	fcfg := FileStoreConfig{StoreDir: t.TempDir()}
+	cfg := StreamConfig{Name: "zzz", Storage: FileStorage, Subjects: []string{">"}}
+	fs, err := newFileStore(fcfg, cfg)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	_, _, err = fs.StoreMsg("foo", nil, nil, 0)
+	require_NoError(t, err)
+
+	// Cache should still exist after above write.
+	fmb := fs.getFirstBlock()
+	fmb.mu.Lock()
+	cacheLoaded := fmb.cacheAlreadyLoaded()
+	fmb.llseq = 0
+	fmb.mu.Unlock()
+	require_True(t, cacheLoaded)
+
+	// The load will try to expire the cache, but shouldn't due to the recent write.
+	_, _, err = fs.LoadNextMsg(fwcs, true, 0, nil)
+	require_NoError(t, err)
+
+	fmb.mu.Lock()
+	fmb.llseq = 0
+	cacheLoaded = fmb.cacheAlreadyLoaded()
+	// We update the last write timestamp to be very old, so the next load can expire the cache.
+	fmb.lwts = 0
+	fmb.mu.Unlock()
+	require_True(t, cacheLoaded)
+	_, _, err = fs.LoadNextMsg(fwcs, true, 0, nil)
+	require_NoError(t, err)
+
+	fmb.mu.Lock()
+	cacheLoaded = fmb.cacheAlreadyLoaded()
+	fmb.mu.Unlock()
+	require_False(t, cacheLoaded)
 }
 
 func TestFileStoreNoDirectoryNotEmptyError(t *testing.T) {


### PR DESCRIPTION
This PR fixes a small regression introduced in https://github.com/nats-io/nats-server/pull/7396. By resetting `mb.lwts` before the `mb.expireCacheLocked()` ran it would result in expiring the cache even if there was a recent write. A publish into a block followed by a fast read of a consumer would result in writing to the block, clearing the cache, then loading it again for the next write, etc. etc.

Additionally, this PR also appends the `try*` prefix to make it clear that the method doesn't actually guarantee the cache is expired.

Marked for 2.12+, as the linked PR was only cherry-picked since then.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>