### PR TITLE
(2.14) [FIXED] Perform replicated consistency checks on transformed subject

### DIFF
--- a/locksordering.txt
+++ b/locksordering.txt
@@ -46,4 +46,4 @@ locking the stream lock afterward would violate locking order.
 The "mset.batches.mu" lock protects the batching state without needing to hold the stream lock.
 If "clMu" is used to commit a batch, it should only be acquired while already holding the batch lock.
 
-    mset.batches.mu -> clMu
+    stream -> mset.batches.mu -> clMu

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1556,13 +1556,13 @@ func (a *Account) EnableJetStream(limits map[string]JetStreamAccountLimits, tq c
 			}
 			// We've observed a partial batch write. Write the remainder of the batch.
 			batchSeq++
-			_, batchStoreDir = getBatchStoreDir(mset, batchId)
+			_, batchStoreDir = getBatchStoreDir(jsa.storeDir, cfg.Name, batchId)
 			if _, err = os.Stat(batchStoreDir); err != nil {
 				s.Errorf("  Failed restoring partial batch write for stream '%s > %s' at sequence %d: %v",
 					mset.accName(), mset.name(), batchSeq, err)
 				goto SKIP
 			}
-			store, err = newBatchStore(mset, batchId)
+			store, err = newBatchStore(mset, batchId, cfg.Replicas, cfg.Storage, jsa.storeDir, cfg.Name)
 			if err != nil {
 				s.Errorf("  Failed restoring partial batch write for stream '%s > %s' at sequence %d: %v",
 					mset.accName(), mset.name(), batchSeq, err)

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -415,6 +415,7 @@ type batchStagedDiff struct {
 	msgIds             map[string]struct{}
 	counter            map[string]*msgCounterRunningTotal
 	inflight           map[string]*inflightSubjectRunningTotal
+	inflightTransform  map[uint64]string
 	expectedPerSubject map[string]*batchExpectedPerSubject
 }
 
@@ -456,6 +457,16 @@ func (diff *batchStagedDiff) commit(mset *stream) {
 			} else {
 				mset.inflight[subj] = i
 			}
+		}
+	}
+
+	// Track inflight subject transforms.
+	if len(diff.inflightTransform) > 0 {
+		if mset.inflightTransform == nil {
+			mset.inflightTransform = make(map[uint64]string, len(diff.inflightTransform))
+		}
+		for clseq, subj := range diff.inflightTransform {
+			mset.inflightTransform[clseq] = subj
 		}
 	}
 
@@ -517,7 +528,7 @@ func (batch *batchApply) rejectBatchState(mset *stream) {
 // mset.mu lock must NOT be held or used.
 // mset.clMu lock must be held.
 func checkMsgHeadersPreClusteredProposal(
-	diff *batchStagedDiff, mset *stream, subject string, hdr []byte, msg []byte, sourced bool, name string,
+	diff *batchStagedDiff, mset *stream, subject, rsubject string, hdr []byte, msg []byte, sourced bool, name string,
 	jsa *jsAccount, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules bool,
 	discard DiscardPolicy, discardNewPer bool, maxMsgSize int, maxMsgs int64, maxMsgsPer int64, maxBytes int64,
 ) ([]byte, []byte, uint64, *ApiError, error) {
@@ -890,6 +901,19 @@ func checkMsgHeadersPreClusteredProposal(
 		diff.inflight[subject] = i
 	}
 
+	// Subject transform.
+	if subject != rsubject {
+		// The 'subject' is a transformed subject used for consistency checks.
+		// But since we propose the original (raw) subject to our peers, we need
+		// to store the transformed subject separately for when we apply.
+		// TODO(mvv): since subject transforms are handled by each replica individually, this has a
+		//  potential for desync given out-of-order stream subject transform updates.
+		if diff.inflightTransform == nil {
+			diff.inflightTransform = make(map[uint64]string, 1)
+		}
+		diff.inflightTransform[mset.clseq] = subject
+	}
+
 	// Check if we have discard new with max msgs or bytes.
 	// We need to deny here otherwise we'd need to bump CLFS, and it could succeed on some
 	// peers and not others depending on consumer ack state (if interest policy).
@@ -944,11 +968,13 @@ func checkMsgHeadersPreClusteredProposal(
 // recalculateClusteredSeq initializes or updates mset.clseq, for example after a leader change.
 // This is reused for normal clustered publishing into a stream, and for atomic and fast batch publishing.
 // mset.clMu lock must be held.
-func recalculateClusteredSeq(mset *stream) (lseq uint64) {
+func recalculateClusteredSeq(mset *stream, needStreamLock bool) (lseq uint64) {
 	// Need to unlock and re-acquire the locks in the proper order.
 	mset.clMu.Unlock()
 	// Locking order is stream -> batchMu -> clMu
-	mset.mu.RLock()
+	if needStreamLock {
+		mset.mu.RLock()
+	}
 	batch := mset.batchApply
 	var batchCount uint64
 	if batch != nil {
@@ -963,7 +989,9 @@ func recalculateClusteredSeq(mset *stream) (lseq uint64) {
 	if batch != nil {
 		batch.mu.Unlock()
 	}
-	mset.mu.RUnlock()
+	if needStreamLock {
+		mset.mu.RUnlock()
+	}
 	return lseq
 }
 

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -62,8 +62,8 @@ type fastBatch struct {
 
 // newAtomicBatch creates an atomic batch publish object.
 // Lock should be held.
-func (batches *batching) newAtomicBatch(mset *stream, batchId string) (*atomicBatch, error) {
-	store, err := newBatchStore(mset, batchId)
+func (batches *batching) newAtomicBatch(mset *stream, batchId string, replicas int, storage StorageType, storeDir, streamName string) (*atomicBatch, error) {
+	store, err := newBatchStore(mset, batchId, replicas, storage, storeDir, streamName)
 	if err != nil {
 		return nil, err
 	}
@@ -121,26 +121,14 @@ func (b *atomicBatch) stopLocked() {
 	b.timer = nil
 }
 
-func getBatchStoreDir(mset *stream, batchId string) (string, string) {
-	mset.mu.RLock()
-	jsa, name := mset.jsa, mset.cfg.Name
-	mset.mu.RUnlock()
-
-	jsa.mu.RLock()
-	sd := jsa.storeDir
-	jsa.mu.RUnlock()
-
+func getBatchStoreDir(storeDir, streamName, batchId string) (string, string) {
 	bname := getHash(batchId)
-	return bname, filepath.Join(sd, streamsDir, name, batchesDir, bname)
+	return bname, filepath.Join(storeDir, streamsDir, streamName, batchesDir, bname)
 }
 
-func newBatchStore(mset *stream, batchId string) (StreamStore, error) {
-	mset.mu.RLock()
-	replicas, storage := mset.cfg.Replicas, mset.cfg.Storage
-	mset.mu.RUnlock()
-
+func newBatchStore(mset *stream, batchId string, replicas int, storage StorageType, storeDir, streamName string) (StreamStore, error) {
 	if replicas == 1 && storage == FileStorage {
-		bname, storeDir := getBatchStoreDir(mset, batchId)
+		bname, storeDir := getBatchStoreDir(storeDir, streamName, batchId)
 		fcfg := FileStoreConfig{AsyncFlush: true, BlockSize: defaultLargeBlockSize, StoreDir: storeDir}
 		s := mset.srv
 		prf := s.jsKeyGen(s.getOpts().JetStreamKey, mset.acc.Name)

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -839,10 +839,11 @@ func TestJetStreamAtomicBatchPublishDenyHeaders(t *testing.T) {
 
 func TestJetStreamAtomicBatchPublishStageAndCommit(t *testing.T) {
 	type BatchItem struct {
-		subject string
-		header  nats.Header
-		msg     []byte
-		err     error
+		subject  string
+		rsubject string
+		header   nats.Header
+		msg      []byte
+		err      error
 	}
 
 	type BatchTest struct {
@@ -1384,6 +1385,23 @@ func TestJetStreamAtomicBatchPublishStageAndCommit(t *testing.T) {
 				{subject: "foo", header: nats.Header{JSMsgRollup: {JSMsgRollupSubject}}, err: errors.New("batch rollup sub invalid")},
 			},
 		},
+		{
+			title: "subject-transform",
+			batch: []BatchItem{
+				{subject: "bar", rsubject: "foo"},
+				{subject: "bar"},
+			},
+			validate: func(mset *stream, commit bool) {
+				if !commit {
+					require_Len(t, len(mset.inflight), 0)
+				} else {
+					require_Len(t, len(mset.inflight), 1)
+					require_Equal(t, *mset.inflight["bar"], inflightSubjectRunningTotal{bytes: 38, ops: 2})
+					require_Len(t, len(mset.inflightTransform), 1)
+					require_Equal(t, mset.inflightTransform[0], "bar")
+				}
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -1435,7 +1453,12 @@ func TestJetStreamAtomicBatchPublishStageAndCommit(t *testing.T) {
 						hdr = genHeader(hdr, key, value)
 					}
 				}
-				_, _, _, _, err = checkMsgHeadersPreClusteredProposal(diff, mset, m.subject, hdr, m.msg, false, "TEST", nil, test.allowRollup, test.denyPurge, test.allowTTL, test.allowMsgCounter, test.allowMsgSchedules, discard, discardNewPer, -1, maxMsgs, maxMsgsPer, maxBytes)
+				// Potential subject transform.
+				rsubject := m.subject
+				if m.rsubject != _EMPTY_ {
+					rsubject = m.rsubject
+				}
+				_, _, _, _, err = checkMsgHeadersPreClusteredProposal(diff, mset, m.subject, rsubject, hdr, m.msg, false, "TEST", nil, test.allowRollup, test.denyPurge, test.allowTTL, test.allowMsgCounter, test.allowMsgSchedules, discard, discardNewPer, -1, maxMsgs, maxMsgsPer, maxBytes)
 				if m.err != nil {
 					require_Error(t, err, m.err)
 				} else if err != nil {

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -1604,9 +1604,13 @@ func TestJetStreamAtomicBatchPublishSingleServerRecovery(t *testing.T) {
 	mset.mu.Lock()
 	batches := &batching{}
 	mset.batches = batches
+	jsa := mset.jsa
 	mset.mu.Unlock()
+	jsa.mu.RLock()
+	storeDir := jsa.storeDir
+	jsa.mu.RUnlock()
 	batches.mu.Lock()
-	b, err := batches.newAtomicBatch(mset, "uuid")
+	b, err := batches.newAtomicBatch(mset, "uuid", 1, FileStorage, storeDir, "TEST")
 	if err != nil {
 		batches.mu.Unlock()
 		require_NoError(t, err)
@@ -1686,9 +1690,13 @@ func TestJetStreamAtomicBatchPublishSingleServerRecoveryCommitEob(t *testing.T) 
 	mset.mu.Lock()
 	batches := &batching{}
 	mset.batches = batches
+	jsa := mset.jsa
 	mset.mu.Unlock()
+	jsa.mu.RLock()
+	storeDir := jsa.storeDir
+	jsa.mu.RUnlock()
 	batches.mu.Lock()
-	b, err := batches.newAtomicBatch(mset, "uuid")
+	b, err := batches.newAtomicBatch(mset, "uuid", 1, FileStorage, storeDir, "TEST")
 	if err != nil {
 		batches.mu.Unlock()
 		require_NoError(t, err)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4171,19 +4171,31 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 	// Process the actual message here.
 	err = mset.processJetStreamMsg(subject, reply, hdr, msg, lseq, ts, mt, sourced, needLock)
 
+	// Take into account subject transforms, if any.
+	// The untransformed subject is replicated, but the transformed subject is used for consistency checks below.
+	csubject := subject
+	if mset.inflightTransform != nil {
+		mset.clMu.Lock()
+		if subj, found := mset.inflightTransform[lseq]; found {
+			csubject = subj
+			delete(mset.inflightTransform, lseq)
+		}
+		mset.clMu.Unlock()
+	}
+
 	// If we have inflight make sure to clear after processing.
 	// TODO(dlc) - technically check on inflight != nil could cause datarace.
 	// But do not want to acquire lock since tracking this will be rare.
 	if mset.inflight != nil {
 		mset.clMu.Lock()
-		if i, found := mset.inflight[subject]; found {
+		if i, found := mset.inflight[csubject]; found {
 			// Decrement from pending operations. Once it reaches zero, it can be deleted.
 			if i.ops > 0 {
 				var sz uint64
 				if mset.store.Type() == FileStorage {
-					sz = fileStoreMsgSizeRaw(len(subject), len(hdr), len(msg))
+					sz = fileStoreMsgSizeRaw(len(csubject), len(hdr), len(msg))
 				} else {
-					sz = memStoreMsgSizeRaw(len(subject), len(hdr), len(msg))
+					sz = memStoreMsgSizeRaw(len(csubject), len(hdr), len(msg))
 				}
 				if i.bytes >= sz {
 					i.bytes -= sz
@@ -4193,7 +4205,7 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 				i.ops--
 			}
 			if i.ops == 0 {
-				delete(mset.inflight, subject)
+				delete(mset.inflight, csubject)
 			}
 		}
 		mset.clMu.Unlock()
@@ -4202,13 +4214,13 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 	// Update running total for counter.
 	if mset.clusteredCounterTotal != nil {
 		mset.clMu.Lock()
-		if counter, found := mset.clusteredCounterTotal[subject]; found {
+		if counter, found := mset.clusteredCounterTotal[csubject]; found {
 			// Decrement from pending operations. Once it reaches zero, it can be deleted.
 			if counter.ops > 0 {
 				counter.ops--
 			}
 			if counter.ops == 0 {
-				delete(mset.clusteredCounterTotal, subject)
+				delete(mset.clusteredCounterTotal, csubject)
 			}
 		}
 		mset.clMu.Unlock()
@@ -4311,6 +4323,7 @@ func (js *jetStream) processStreamLeaderChange(mset *stream, isLeader bool) {
 	mset.clMu.Lock()
 	// Clear inflight if we have it.
 	mset.inflight = nil
+	mset.inflightTransform = nil
 	// Clear running counter totals.
 	mset.clusteredCounterTotal = nil
 	// Clear expected per subject state.
@@ -9591,6 +9604,16 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	s, js, jsa, st, r, tierName, outq, node := mset.srv, mset.js, mset.jsa, mset.cfg.Storage, mset.cfg.Replicas, mset.tier, mset.outq, mset.node
 	maxMsgSize, lseq := int(mset.cfg.MaxMsgSize), mset.lseq
 	isLeader, isSealed, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules := mset.isLeader(), mset.cfg.Sealed, mset.cfg.AllowRollup, mset.cfg.DenyPurge, mset.cfg.AllowMsgTTL, mset.cfg.AllowMsgCounter, mset.cfg.AllowMsgSchedules
+
+	// Apply the input subject transform if any
+	csubject := subject
+	if mset.itr != nil {
+		ts, err := mset.itr.Match(csubject)
+		if err == nil {
+			// no filtering: if the subject doesn't map the source of the transform, don't change it
+			csubject = ts
+		}
+	}
 	mset.mu.RUnlock()
 
 	// This should not happen but possible now that we allow scale up, and scale down where this could trigger.
@@ -9641,7 +9664,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	}
 
 	// Check here pre-emptively if we have exceeded our account limits.
-	if exceeded, err := jsa.wouldExceedLimits(st, tierName, r, subject, hdr, msg); exceeded {
+	if exceeded, err := jsa.wouldExceedLimits(st, tierName, r, csubject, hdr, msg); exceeded {
 		if err == nil {
 			err = NewJSAccountResourcesExceededError()
 		}
@@ -9675,7 +9698,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	// Check if we need to set initial value here
 	mset.clMu.Lock()
 	if mset.clseq == 0 || mset.clseq < lseq+mset.clfs {
-		lseq = recalculateClusteredSeq(mset)
+		lseq = recalculateClusteredSeq(mset, true)
 	}
 
 	var (
@@ -9684,7 +9707,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 		err    error
 	)
 	diff := &batchStagedDiff{}
-	if hdr, msg, dseq, apiErr, err = checkMsgHeadersPreClusteredProposal(diff, mset, subject, hdr, msg, sourced, name, jsa, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, discard, discardNewPer, maxMsgSize, maxMsgs, maxMsgsPer, maxBytes); err != nil {
+	if hdr, msg, dseq, apiErr, err = checkMsgHeadersPreClusteredProposal(diff, mset, csubject, subject, hdr, msg, sourced, name, jsa, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, discard, discardNewPer, maxMsgSize, maxMsgs, maxMsgsPer, maxBytes); err != nil {
 		mset.clMu.Unlock()
 		if err == errMsgIdDuplicate && dseq > 0 {
 			var buf [256]byte

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8950,6 +8950,176 @@ func TestJetStreamClusterInterestStreamMsgWithNoInterestStillAppliesRollup(t *te
 	}
 }
 
+func TestJetStreamClusterSubjectTransformWithExpectedSubjectSequenceHeader(t *testing.T) {
+	test := func(t *testing.T, replicas int) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := jsStreamCreate(t, nc, &StreamConfig{
+			Name:     "TEST",
+			Subjects: []string{"foo", "bar"},
+			Replicas: replicas,
+			Storage:  FileStorage,
+			SubjectTransform: &SubjectTransformConfig{
+				Source:      "foo",
+				Destination: "bar",
+			},
+			AllowBatchPublish:  true,
+			AllowAtomicPublish: true,
+		})
+		require_NoError(t, err)
+
+		// We publish on "foo", but it gets mapped to "bar".
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+
+		// Check the subject transform worked.
+		msg, err := js.GetMsg("TEST", 1)
+		require_NoError(t, err)
+		require_Equal(t, msg.Subject, "bar")
+
+		inbox := nats.NewInbox()
+		sub, err := nc.SubscribeSync(fmt.Sprintf("%s.>", inbox))
+		require_NoError(t, err)
+		defer sub.Drain()
+
+		// Publishing to either subject should pass consistency checks under the "bar" subject after transform.
+		for _, subj := range []string{"bar", "foo"} {
+			// Normal publish.
+			m := nats.NewMsg(subj)
+			m.Header.Set("Nats-Expected-Last-Subject-Sequence", "0")
+			_, err = js.PublishMsg(m)
+			require_Error(t, err, NewJSStreamWrongLastSequenceError(1))
+
+			// Fast batch publish.
+			m.Reply = generateFastBatchReply(inbox, "uuid", 1, 0, FastBatchGapFail, FastBatchOpCommit)
+			require_NoError(t, nc.PublishMsg(m))
+			rmsg, err := sub.NextMsg(time.Second)
+			require_NoError(t, err)
+			var pubAck JSPubAckResponse
+			require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+			require_NotNil(t, pubAck.Error)
+			require_Error(t, pubAck.Error, NewJSStreamWrongLastSequenceError(1))
+
+			// Atomic batch publish.
+			m.Header.Set("Nats-Expected-Last-Subject-Sequence", "0")
+			m.Header.Set("Nats-Batch-Id", "uuid")
+			m.Header.Set("Nats-Batch-Sequence", "1")
+			m.Header.Set("Nats-Batch-Commit", "1")
+			_, err = js.PublishMsg(m)
+			require_Error(t, err, NewJSStreamWrongLastSequenceError(1))
+		}
+
+		// Fast batch publish, but without consistency checks.
+		m := nats.NewMsg("foo")
+		m.Reply = generateFastBatchReply(inbox, "uuid", 1, 0, FastBatchGapFail, FastBatchOpCommit)
+		require_NoError(t, nc.PublishMsg(m))
+		rmsg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		var pubAck JSPubAckResponse
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_True(t, pubAck.Error == nil)
+	}
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) { test(t, replicas) })
+	}
+}
+
+func TestJetStreamClusterSubjectTransformDoesntCycle(t *testing.T) {
+	test := func(t *testing.T, replicas int) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := jsStreamCreate(t, nc, &StreamConfig{
+			Name:     "TEST",
+			Subjects: []string{"foo"},
+			Replicas: replicas,
+			Storage:  FileStorage,
+			// Use a subject transform that can cycle if applied multiple times.
+			// Applying this transform on X twice would result in dst.X.X.
+			// A subject transform must only be applied once, so such a transform is invalid.
+			SubjectTransform: &SubjectTransformConfig{
+				Source:      ">",
+				Destination: "dst.>",
+			},
+			AllowBatchPublish:  true,
+			AllowAtomicPublish: true,
+		})
+		require_NoError(t, err)
+
+		inbox := nats.NewInbox()
+		sub, err := nc.SubscribeSync(fmt.Sprintf("%s.>", inbox))
+		require_NoError(t, err)
+		defer sub.Drain()
+
+		// Normal publish.
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+		msg, err := js.GetMsg("TEST", 1)
+		require_NoError(t, err)
+		require_Equal(t, msg.Subject, "dst.foo")
+
+		// Fast batch publish.
+		m := nats.NewMsg("foo")
+		m.Reply = generateFastBatchReply(inbox, "uuid", 1, 0, FastBatchGapFail, FastBatchOpCommit)
+		require_NoError(t, nc.PublishMsg(m))
+		rmsg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		var pubAck JSPubAckResponse
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_True(t, pubAck.Error == nil)
+		msg, err = js.GetMsg("TEST", 2)
+		require_NoError(t, err)
+		require_Equal(t, msg.Subject, "dst.foo")
+
+		// Atomic batch publish.
+		m.Header.Set("Nats-Batch-Id", "uuid")
+		m.Header.Set("Nats-Batch-Sequence", "1")
+		m.Header.Set("Nats-Batch-Commit", "1")
+		_, err = js.PublishMsg(m)
+		require_NoError(t, err)
+		msg, err = js.GetMsg("TEST", 3)
+		require_NoError(t, err)
+		require_Equal(t, msg.Subject, "dst.foo")
+
+		// Fast batch publish, but without consistency checks.
+		m = nats.NewMsg("foo")
+		m.Reply = generateFastBatchReply(inbox, "uuid", 1, 0, FastBatchGapFail, FastBatchOpCommit)
+		require_NoError(t, nc.PublishMsg(m))
+		rmsg, err = sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		pubAck = JSPubAckResponse{}
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_True(t, pubAck.Error == nil)
+		msg, err = js.GetMsg("TEST", 4)
+		require_NoError(t, err)
+		require_Equal(t, msg.Subject, "dst.foo")
+	}
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) { test(t, replicas) })
+	}
+}
+
 func TestJetStreamClusterStreamLeaderStepsDownIfSnapshotCatchupRequired(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/stream.go
+++ b/server/stream.go
@@ -7159,14 +7159,17 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 		mset.batches = &batching{}
 	}
 	batches := mset.batches
-	mset.mu.Unlock()
+	// Acquire the batches lock.
+	// Can't release the stream lock now, we need to keep holding it while we hold the batches lock.
+	// Re-acquiring the stream lock with the batches lock already held would be a lock inversion.
+	batches.mu.Lock()
 
 	// Get batch.
-	batches.mu.Lock()
 	b, ok := batches.fast[batch.id]
 	if !ok {
 		if batch.seq != 1 {
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			return respondError(NewJSBatchPublishUnknownBatchIDError())
 		}
 
@@ -7184,6 +7187,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 		// Confirm we can facilitate an additional batch.
 		if len(batches.fast)+1 > maxInflightPerStream {
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			return respondError(NewJSBatchPublishTooManyInflightError())
 		}
 
@@ -7191,6 +7195,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 		if globalInflightFastBatches.Add(1) > int64(maxInflightTotal) {
 			globalInflightFastBatches.Add(-1)
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			return respondError(NewJSBatchPublishTooManyInflightError())
 		}
 
@@ -7208,6 +7213,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 		if errorOnRequiredApiLevel(hdr) {
 			b.cleanupLocked(batch.id, batches)
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			return respondError(NewJSRequiredApiLevelError())
 		}
 		hdr = removeHeaderIfPresent(hdr, JSRequiredApiLevel)
@@ -7241,6 +7247,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 			b.sendFlowControl(b.fseq, mset, reply)
 		}
 		batches.mu.Unlock()
+		mset.mu.Unlock()
 		return nil
 	}
 
@@ -7249,6 +7256,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 	if b.commit {
 		// MUST NOT clean up, that will happen when the commit completes.
 		batches.mu.Unlock()
+		mset.mu.Unlock()
 		return nil
 	}
 
@@ -7268,6 +7276,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 				b.cleanupLocked(batch.id, batches)
 			}
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			return nil
 		}
 	}
@@ -7290,6 +7299,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 				b.cleanupLocked(batch.id, batches)
 			}
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			return nil
 		}
 	}
@@ -7307,8 +7317,10 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 	// Check if we need to set initial value here
 	mset.clMu.Lock()
 	if mset.clseq == 0 || mset.clseq < lseq+mset.clfs {
-		lseq = recalculateClusteredSeq(mset, true)
+		lseq = recalculateClusteredSeq(mset, false)
 	}
+	// We can now unlock, since we've potentially recalculated the clustered seq above.
+	mset.mu.Unlock()
 
 	var (
 		dseq   uint64

--- a/server/stream.go
+++ b/server/stream.go
@@ -6661,7 +6661,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 	canRespond := !mset.cfg.NoAck && len(reply) > 0
 	name, stype := mset.cfg.Name, mset.cfg.Storage
 	discard, discardNewPer, maxMsgs, maxMsgsPer, maxBytes := mset.cfg.Discard, mset.cfg.DiscardNewPer, mset.cfg.MaxMsgs, mset.cfg.MaxMsgsPer, mset.cfg.MaxBytes
-	s, js, jsa, st, r, tierName, outq, node := mset.srv, mset.js, mset.jsa, mset.cfg.Storage, mset.cfg.Replicas, mset.tier, mset.outq, mset.node
+	s, js, jsa, r, tierName, outq, node := mset.srv, mset.js, mset.jsa, mset.cfg.Replicas, mset.tier, mset.outq, mset.node
 	maxMsgSize, lseq := int(mset.cfg.MaxMsgSize), mset.lseq
 	isLeader, isClustered, isSealed, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, allowAtomicPublish := mset.isLeader(), mset.isClustered(), mset.cfg.Sealed, mset.cfg.AllowRollup, mset.cfg.DenyPurge, mset.cfg.AllowMsgTTL, mset.cfg.AllowMsgCounter, mset.cfg.AllowMsgSchedules, mset.cfg.AllowAtomicPublish
 	mset.mu.RUnlock()
@@ -6707,7 +6707,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 	}
 
 	// Check here pre-emptively if we have exceeded our account limits.
-	if exceeded, err := jsa.wouldExceedLimits(st, tierName, r, subject, hdr, msg); exceeded {
+	if exceeded, err := jsa.wouldExceedLimits(stype, tierName, r, subject, hdr, msg); exceeded {
 		if err == nil {
 			err = NewJSAccountResourcesExceededError()
 		}
@@ -6737,6 +6737,10 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 	if !exists {
 		return respondError(NewJSAtomicPublishMissingSeqError())
 	}
+
+	jsa.mu.RLock()
+	storeDir := jsa.storeDir
+	jsa.mu.RUnlock()
 
 	mset.mu.Lock()
 	if mset.batches == nil {
@@ -6792,7 +6796,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		}
 
 		var err error
-		b, err = batches.newAtomicBatch(mset, batchId)
+		b, err = batches.newAtomicBatch(mset, batchId, r, stype, storeDir, name)
 		if err != nil {
 			globalInflightAtomicBatches.Add(-1)
 			batches.mu.Unlock()

--- a/server/stream.go
+++ b/server/stream.go
@@ -554,6 +554,7 @@ type stream struct {
 	werr      error             // If a write error was encountered, and if so what error.
 
 	inflight                    map[string]*inflightSubjectRunningTotal // Inflight message sizes per subject.
+	inflightTransform           map[uint64]string                       // Inflight message's optional transformed subject.
 	clusteredCounterTotal       map[string]*msgCounterRunningTotal      // Inflight counter totals.
 	expectedPerSubjectSequence  map[uint64]string                       // Inflight 'expected per subject' subjects per clseq.
 	expectedPerSubjectInProcess map[string]struct{}                     // Current 'expected per subject' subjects in process.
@@ -6747,18 +6748,21 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		mset.batches = &batching{}
 	}
 	batches := mset.batches
-	mset.mu.Unlock()
+	// Acquire the batches lock.
+	// Can't release the stream lock now, we need to keep holding it while we hold the batches lock.
+	// Re-acquiring the stream lock with the batches lock already held would be a lock inversion.
+	batches.mu.Lock()
 
 	respondIncompleteBatch := func() error {
 		return respondError(NewJSAtomicPublishIncompleteBatchError())
 	}
 
 	// Get batch.
-	batches.mu.Lock()
 	b, ok := batches.atomic[batchId]
 	if !ok {
 		if batchSeq != 1 {
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			maxBatchSize := streamMaxAtomicBatchSize
 			opts := s.getOpts()
 			if opts.JetStreamLimits.MaxBatchSize > 0 {
@@ -6785,6 +6789,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		// Confirm we can facilitate an additional batch.
 		if len(batches.atomic)+1 > maxInflightPerStream {
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			return respondError(NewJSAtomicPublishTooManyInflightError())
 		}
 
@@ -6792,6 +6797,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		if globalInflightAtomicBatches.Add(1) > int64(maxInflightTotal) {
 			globalInflightAtomicBatches.Add(-1)
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			return respondError(NewJSAtomicPublishTooManyInflightError())
 		}
 
@@ -6800,6 +6806,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		if err != nil {
 			globalInflightAtomicBatches.Add(-1)
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			return respondIncompleteBatch()
 		}
 		if batches.atomic == nil {
@@ -6815,6 +6822,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		if !commitEob && !bytes.Equal(c, []byte("1")) {
 			b.cleanupLocked(batchId, batches)
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			err := NewJSAtomicPublishInvalidBatchCommitError()
 			return respondError(err)
 		}
@@ -6826,6 +6834,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		if errorOnRequiredApiLevel(hdr) {
 			b.cleanupLocked(batchId, batches)
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			err := NewJSRequiredApiLevelError()
 			return respondError(err)
 		}
@@ -6840,6 +6849,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 	if b.lseq != batchSeq || cleanup {
 		b.cleanupLocked(batchId, batches)
 		batches.mu.Unlock()
+		mset.mu.Unlock()
 		mset.sendStreamBatchAbandonedAdvisory(batchId, BatchIncomplete)
 		return respondIncompleteBatch()
 	}
@@ -6852,6 +6862,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 	if batchSeq > uint64(maxSize) {
 		b.cleanupLocked(batchId, batches)
 		batches.mu.Unlock()
+		mset.mu.Unlock()
 		mset.sendStreamBatchAbandonedAdvisory(batchId, BatchLarge)
 		err := NewJSAtomicPublishTooLargeBatchError(maxSize)
 		return respondError(err)
@@ -6864,12 +6875,14 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		if err != nil || seq != batchSeq {
 			b.cleanupLocked(batchId, batches)
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			mset.sendStreamBatchAbandonedAdvisory(batchId, BatchIncomplete)
 			return respondIncompleteBatch()
 		}
 	}
 	if !commit {
 		batches.mu.Unlock()
+		mset.mu.Unlock()
 		// Send empty ack to let them know we've persisted the data prior to commit.
 		if canRespond {
 			outq.sendMsg(reply, nil)
@@ -6881,6 +6894,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 	if abandonReason := b.readyForCommit(); abandonReason != nil {
 		// Don't do cleanup, this is already done.
 		batches.mu.Unlock()
+		mset.mu.Unlock()
 		mset.sendStreamBatchAbandonedAdvisory(batchId, *abandonReason)
 		return respondIncompleteBatch()
 	}
@@ -6900,7 +6914,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 	// We only use mset.clseq for clustering and in case we run ahead of actual commits.
 	// Check if we need to set initial value here
 	if isClustered && (mset.clseq == 0 || mset.clseq < lseq+mset.clfs) {
-		lseq = recalculateClusteredSeq(mset)
+		lseq = recalculateClusteredSeq(mset, false)
 	}
 
 	rollback := func(seq uint64) {
@@ -6917,6 +6931,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		rollback(seq)
 		b.cleanupLocked(batchId, batches)
 		batches.mu.Unlock()
+		mset.mu.Unlock()
 		_ = respondError(apiErr)
 		return apiErr
 	}
@@ -6948,7 +6963,18 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 			rollback(seq)
 			b.cleanupLocked(batchId, batches)
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			return respondIncompleteBatch()
+		}
+
+		// Apply the input subject transform if any
+		csubj := bsubj
+		if mset.itr != nil {
+			ts, err := mset.itr.Match(csubj)
+			if err == nil {
+				// no filtering: if the subject doesn't map the source of the transform, don't change it
+				csubj = ts
+			}
 		}
 
 		// Reject unsupported headers.
@@ -6956,10 +6982,11 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 			return errorOnUnsupported(seq, JSExpectedLastMsgId)
 		}
 
-		if bhdr, bmsg, _, apiErr, err = checkMsgHeadersPreClusteredProposal(diff, mset, bsubj, bhdr, bmsg, false, name, jsa, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, discard, discardNewPer, maxMsgSize, maxMsgs, maxMsgsPer, maxBytes); err != nil {
+		if bhdr, bmsg, _, apiErr, err = checkMsgHeadersPreClusteredProposal(diff, mset, csubj, bsubj, bhdr, bmsg, false, name, jsa, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, discard, discardNewPer, maxMsgSize, maxMsgs, maxMsgsPer, maxBytes); err != nil {
 			rollback(seq)
 			b.cleanupLocked(batchId, batches)
 			batches.mu.Unlock()
+			mset.mu.Unlock()
 			_ = respondError(apiErr)
 			return err
 		}
@@ -6989,7 +7016,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 
 		// Ensure the whole batch is fully isolated, and reads
 		// can only happen after the full batch is committed.
-		mset.mu.Lock()
+		// We keep holding the stream lock.
 		for seq := uint64(1); seq <= batchSeq; seq++ {
 			if seq == batchSeq && !commitEob && b.store.Type() != FileStorage {
 				bsubj, bhdr, bmsg = subject, hdr, msg
@@ -7013,6 +7040,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		}
 		mset.mu.Unlock()
 	} else {
+		mset.mu.Unlock()
 		// Do a single multi proposal. This ensures we get to push all entries to the proposal queue in-order
 		// and not interleaved with other proposals.
 		diff.commit(mset)
@@ -7043,6 +7071,16 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 	s, js, jsa, st, r, tierName, outq, node := mset.srv, mset.js, mset.jsa, mset.cfg.Storage, mset.cfg.Replicas, mset.tier, mset.outq, mset.node
 	maxMsgSize, lseq := int(mset.cfg.MaxMsgSize), mset.lseq
 	isLeader, isClustered, isSealed, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, allowBatchPublish := mset.isLeader(), mset.isClustered(), mset.cfg.Sealed, mset.cfg.AllowRollup, mset.cfg.DenyPurge, mset.cfg.AllowMsgTTL, mset.cfg.AllowMsgCounter, mset.cfg.AllowMsgSchedules, mset.cfg.AllowBatchPublish
+
+	// Apply the input subject transform if any
+	csubject := subject
+	if mset.itr != nil {
+		ts, err := mset.itr.Match(csubject)
+		if err == nil {
+			// no filtering: if the subject doesn't map the source of the transform, don't change it
+			csubject = ts
+		}
+	}
 	mset.mu.RUnlock()
 
 	// If message tracing (with message delivery), we will need to send the
@@ -7086,7 +7124,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 	}
 
 	// Check here pre-emptively if we have exceeded our account limits.
-	if exceeded, err := jsa.wouldExceedLimits(st, tierName, r, subject, hdr, msg); exceeded {
+	if exceeded, err := jsa.wouldExceedLimits(st, tierName, r, csubject, hdr, msg); exceeded {
 		if err == nil {
 			err = NewJSAccountResourcesExceededError()
 		}
@@ -7269,7 +7307,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 	// Check if we need to set initial value here
 	mset.clMu.Lock()
 	if mset.clseq == 0 || mset.clseq < lseq+mset.clfs {
-		lseq = recalculateClusteredSeq(mset)
+		lseq = recalculateClusteredSeq(mset, true)
 	}
 
 	var (
@@ -7278,7 +7316,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 		err    error
 	)
 	diff := &batchStagedDiff{}
-	if hdr, msg, dseq, apiErr, err = checkMsgHeadersPreClusteredProposal(diff, mset, subject, hdr, msg, false, name, jsa, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, discard, discardNewPer, maxMsgSize, maxMsgs, maxMsgsPer, maxBytes); err != nil {
+	if hdr, msg, dseq, apiErr, err = checkMsgHeadersPreClusteredProposal(diff, mset, csubject, subject, hdr, msg, false, name, jsa, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, discard, discardNewPer, maxMsgSize, maxMsgs, maxMsgsPer, maxBytes); err != nil {
 		mset.clMu.Unlock()
 
 		// If the message is a duplicate, and we have no pending messages, we should check if we need to


### PR DESCRIPTION
Clustered consistency checks were performed on the publish subject instead of the transformed subject, if a subject transform for the stream was specified. An expected subject sequence check would then compare to the wrong subject leading to inconsistent results when compared to how a R1 stream behaves.

Also contains a commit for 2.12 to fix a lock inversion issue with atomic batches.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>