### PR TITLE
[FIXED] Commit index regression in processAppendEntry term mismatch path

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -4172,9 +4172,12 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 				}
 			} else {
 				// If terms mismatched, delete that entry and all others past it.
-				// Make sure to cancel any catchups in progress.
-				// Truncate will reset our pterm and pindex. Only do so if we have an entry.
-				n.truncateWAL(eae.pterm, eae.pindex)
+				// But only if we haven't already committed past this point.
+				if eae.pindex < n.commit {
+					success = true
+				} else {
+					n.truncateWAL(eae.pterm, eae.pindex)
+				}
 			}
 			// Cancel regardless if unsuccessful.
 			if !success {

--- a/server/raft.go
+++ b/server/raft.go
@@ -4175,6 +4175,20 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 				// But only if we haven't already committed past this point.
 				if eae.pindex < n.commit {
 					success = true
+					assert.Unreachable("Truncate to earlier entry would lose commits", map[string]any{
+						"n.accName":  n.accName,
+						"n.group":    n.group,
+						"n.id":       n.id,
+						"n.term":     n.term,
+						"n.pindex":   n.pindex,
+						"n.commit":   n.commit,
+						"n.applied":  n.applied,
+						"ae.pindex":  ae.pindex,
+						"ae.pterm":   ae.pterm,
+						"ae.commit":  ae.commit,
+						"eae.pterm":  eae.pterm,
+						"eae.pindex": eae.pindex,
+					})
 				} else {
 					n.truncateWAL(eae.pterm, eae.pindex)
 				}

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -5676,3 +5676,40 @@ func TestNRGSwitchToCandidateResetsQuorumPaused(t *testing.T) {
 	require_Equal(t, n.term, 1)
 	require_False(t, n.quorumPaused)
 }
+
+func TestNRGProcessAppendEntryTermMismatchDoesNotRegressCommit(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// Create a sample entry
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	// Timeline
+	aeMsg1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+	aeMsg2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 1, entries: entries})
+	aeMsg3 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 2, pterm: 1, pindex: 2, entries: entries})
+	aeMsg4 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 3, pterm: 1, pindex: 3, entries: entries})
+	aeMsg5 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 4, pterm: 1, pindex: 4, entries: entries})
+	aeHeartbeat := encode(t, &appendEntry{leader: nats0, term: 1, commit: 5, pterm: 1, pindex: 5, entries: nil})
+
+	// Store five entries and commit.
+	n.processAppendEntry(aeMsg1, n.aesub)
+	n.processAppendEntry(aeMsg2, n.aesub)
+	n.processAppendEntry(aeMsg3, n.aesub)
+	n.processAppendEntry(aeMsg4, n.aesub)
+	n.processAppendEntry(aeMsg5, n.aesub)
+	n.processAppendEntry(aeHeartbeat, n.aesub)
+	require_Equal(t, n.commit, 5)
+	require_Equal(t, n.pindex, 5)
+
+	// Send an append entry with a mismatched pterm. This will trigger
+	// the term mismatch path in processAppendEntry which calls
+	// truncateWAL. The commit must not regress below what was
+	// already committed.
+	aeBadPterm := encode(t, &appendEntry{leader: nats0, term: 2, commit: 5, pterm: 2, pindex: 5, entries: entries})
+	n.processAppendEntry(aeBadPterm, n.aesub)
+	require_Equal(t, n.commit, 5)
+}


### PR DESCRIPTION
processAppendEntry can regress the commit index through the term mismatch branch. When eae.term != ae.pterm, it calls truncateWAL(eae.pterm, eae.pindex) unconditionally. eae.pindex is ae.pindex - 1, so when ae.pindex == n.commit the truncation lands below commit.

1. ae.pindex(5) <= n.pindex(5) — enters the branch
2. ae.pindex(5) < n.commit(5) — false, doesn't bail
3. loadEntry(5) returns eae at index 4, term 1
4. eae.term(1) != ae.pterm(2) — hits the else
5. truncateWAL(1, 4) — pindex goes to 4
6. commit clamps from 5 to 4

The other branches in this block all truncate to ae.pindex (protected by the outer guard) or explicitly check against n.commit. Includes a regression test that demonstrates commit regression from 5 to 4 without the fix.

Signed-off-by: Kevin Leung <leungke@oregonstate.edu>
