### PR TITLE
[FIXED] Avoid panic on legacy zero index snapshot recovery

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -1742,7 +1742,7 @@ func (n *raft) loadLastSnapshot() (*snapshot, error) {
 		n.warn("Snapshot with last index 0 is invalid, cleaning up")
 		os.Remove(n.snapfile)
 		n.snapfile = _EMPTY_
-		return nil, nil
+		return nil, errNoSnapAvailable
 	}
 
 	return snap, nil

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -2824,6 +2824,35 @@ func TestNRGSnapshotRecovery(t *testing.T) {
 	require_Equal(t, n.applied, 0)
 }
 
+func TestNRGLoadLastSnapshotCleansLegacyZeroIndexSnapshot(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	snapDir := filepath.Join(n.sd, snapshotsDir)
+	require_NoError(t, os.MkdirAll(snapDir, defaultDirPerms))
+
+	legacy := &snapshot{
+		lastTerm:  1,
+		lastIndex: 0,
+		peerstate: encodePeerState(&peerState{n.peerNames(), n.csz, n.extSt}),
+		data:      []byte("legacy"),
+	}
+	sfile := filepath.Join(snapDir, fmt.Sprintf(snapFileT, legacy.lastTerm, legacy.lastIndex))
+	require_NoError(t, writeFileWithSync(sfile, n.encodeSnapshot(legacy), defaultFilePerms))
+
+	n.Lock()
+	n.snapfile = sfile
+	snap, err := n.loadLastSnapshot()
+	snapfile := n.snapfile
+	n.Unlock()
+
+	require_Error(t, err, errNoSnapAvailable)
+	require_True(t, snap == nil)
+	require_Equal(t, snapfile, _EMPTY_)
+	_, err = os.Stat(sfile)
+	require_True(t, os.IsNotExist(err))
+}
+
 func TestNRGKeepRunningOnServerShutdown(t *testing.T) {
 	n, cleanup := initSingleMemRaftNode(t)
 	defer cleanup()


### PR DESCRIPTION
Return `errNoSnapAvailable` after cleaning up a legacy snapshot with `lastIndex == 0` instead of returning `(nil, nil)`. That avoids nil dereferences during snapshot recovery.
Fixes up `85cf3eb9bbecb87f5662dd6779097eb852a4f1ed`

Signed-off-by: Daniele Sciascia <daniele@nats.io>
