### PR TITLE
[FIXED] Encrypted partial purge recovery

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -10137,26 +10137,40 @@ func (fs *fileStore) purge(fseq uint64) (purged uint64, rerr error) {
 
 // Lock and dios should be held.
 func (fs *fileStore) recoverPartialPurge() error {
+	mdir := filepath.Join(fs.fcfg.StoreDir, msgDir)
 	ndir := filepath.Join(fs.fcfg.StoreDir, newMsgDir)
 	if entries, err := os.ReadDir(ndir); err != nil && !os.IsNotExist(err) {
 		return err
 	} else if err == nil {
-		// If it's empty, that means we got hard killed before moving the tombstone, and we need to remove it.
-		isEmpty := !slices.ContainsFunc(entries, func(e os.DirEntry) bool {
-			// The directory is considered empty if it's missing a block file.
+		hasBlk := slices.ContainsFunc(entries, func(e os.DirEntry) bool {
 			return strings.HasSuffix(e.Name(), blkSuffix)
 		})
-		if isEmpty {
-			_ = os.RemoveAll(ndir)
-		} else {
-			// Otherwise, it contains the tombstone after purge, and the old messages need to be purged instead.
-			mdir := filepath.Join(fs.fcfg.StoreDir, msgDir)
+		if hasBlk {
+			// We have a tombstone, we can purge the old messages.
 			if err = os.RemoveAll(mdir); err != nil {
 				return err
 			}
 			if err = os.Rename(ndir, mdir); err != nil {
 				return err
 			}
+		} else {
+			// No .blk means the purge did not complete, so clear
+			// any progress made by the partial purge.
+			for _, entry := range entries {
+				var index uint32
+				if n, err := fmt.Sscanf(entry.Name(), keyScan, &index); err != nil || n != 1 {
+					continue
+				}
+				// Found a key file, remove the corresponding .blk, if any.
+				// Recovery may otherwise wrongly conclude that the .blk is
+				// is plaintext, and consider it corrupt when trying to open it.
+				err := os.Remove(filepath.Join(mdir, fmt.Sprintf(blkScan, index)))
+				if err != nil && !os.IsNotExist(err) {
+					return err
+				}
+			}
+			_ = os.RemoveAll(ndir)
+			return nil
 		}
 	}
 	pdir := filepath.Join(fs.fcfg.StoreDir, purgeDir)

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -819,6 +819,76 @@ func TestFileStorePurge(t *testing.T) {
 	})
 }
 
+func TestFileStoreEncryptedPurgeRecoveryAfterKeyRename(t *testing.T) {
+	fcfg := FileStoreConfig{
+		StoreDir:    t.TempDir(),
+		Cipher:      AES,
+		Compression: NoCompression,
+		BlockSize:   64 * 1024,
+	}
+	created := time.Now()
+	cfg := StreamConfig{Name: "zzz", Storage: FileStorage}
+
+	fs, err := newFileStoreWithCreated(fcfg, cfg, created, prf(&fcfg), nil)
+	require_NoError(t, err)
+
+	subj, msg := "foo", make([]byte, 8*1024)
+	toStore := uint64(1024)
+	for i := uint64(0); i < toStore; i++ {
+		_, _, err = fs.StoreMsg(subj, nil, msg, 0)
+		require_NoError(t, err)
+	}
+	baseline := fs.State()
+
+	storeDir := fcfg.StoreDir
+	mdir := filepath.Join(storeDir, msgDir)
+	preMsgs := filepath.Join(storeDir, "msgs.pre")
+	// Snapshot the pre-purge msg directory so we can recreate the crash window.
+	require_NoError(t, copyDir(t, preMsgs, mdir))
+
+	// Run a real purge once to create a valid encrypted tombstone block + key.
+	_, err = fs.Purge()
+	require_NoError(t, err)
+
+	fs.mu.RLock()
+	tombIdx := fs.lmb.index
+	fs.mu.RUnlock()
+
+	require_NoError(t, fs.stop(false, false))
+
+	postMsgs := filepath.Join(storeDir, "msgs.post")
+	require_NoError(t, os.Rename(mdir, postMsgs))
+	require_NoError(t, copyDir(t, mdir, preMsgs))
+	// Force recovery from the block files instead of a fresh full-state snapshot.
+	require_NoError(t, os.RemoveAll(filepath.Join(mdir, streamStreamStateFile)))
+
+	tombBlk := fmt.Sprintf(blkScan, tombIdx)
+	tombKey := fmt.Sprintf(keyScan, tombIdx)
+	require_NoError(t, os.Rename(filepath.Join(postMsgs, tombBlk), filepath.Join(mdir, tombBlk)))
+
+	ndir := filepath.Join(storeDir, newMsgDir)
+	require_NoError(t, os.MkdirAll(ndir, defaultDirPerms))
+	// Simulate a crash after moving N.key into __new_msgs__ but before moving N.blk.
+	require_NoError(t, os.Rename(filepath.Join(postMsgs, tombKey), filepath.Join(ndir, tombKey)))
+
+	fs, err = newFileStoreWithCreated(fcfg, cfg, created, prf(&fcfg), nil)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	state := fs.State()
+	require_Equal(t, state.Msgs, baseline.Msgs)
+	require_Equal(t, state.Bytes, baseline.Bytes)
+	require_Equal(t, state.FirstSeq, baseline.FirstSeq)
+	require_Equal(t, state.LastSeq, baseline.LastSeq)
+
+	if _, err := os.Stat(filepath.Join(mdir, tombBlk)); !os.IsNotExist(err) {
+		t.Fatalf("Expected rollback to remove %q, got err=%v", tombBlk, err)
+	}
+	if _, err := os.Stat(ndir); !os.IsNotExist(err) {
+		t.Fatalf("Expected rollback to remove %q, got err=%v", ndir, err)
+	}
+}
+
 func TestFileStoreCompact(t *testing.T) {
 	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
 		fcfg.BlockSize = 350


### PR DESCRIPTION
A purge operation involves moving a tombstone .block and its corresponding key file into __new_msgs__.
If the server crashed in after moving the key file, before moving the block file, then a stranded block file would be left behind without its key.
On restart, recover would find the tombstone block, without its key file, and would go throuhg the plaintext conversion path. However the blocks was actually encrypted, eventually causing the recovery to fail due to finding the block corrupt.

Treat a __new_msgs__ directory without any block file as a partial "uncommitted" purge. In that case remove the matching tombstone block still left in msgs/ and clear __new_msgs__.


Signed-off-by: Daniele Sciascia <daniele@nats.io>