### PR TITLE
(2.14) [IMPROVED] Propose stream skip ranges as single deleteRangeOp

### DIFF
--- a/server/feature_flags.go
+++ b/server/feature_flags.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	FeatureFlagJsAckFormatV2 = "js_ack_fc_v2"
+	FeatureFlagJsAckFormatV2     = "js_ack_fc_v2"
+	FeatureFlagJsRaftDeleteRange = "js_raft_delete_range"
 )
 
 var featureFlags = map[string]bool{
@@ -32,6 +33,17 @@ var featureFlags = map[string]bool{
 	// - v2: $JS.ACK.<domain>.<account hash>.<stream name>.<consumer name>.<num delivered>.<stream sequence>.<consumer sequence>.<timestamp>.<num pending>
 	// See also: https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-15.md#jsack
 	FeatureFlagJsAckFormatV2: false,
+
+	// Propose delete range gaps as a single `deleteRangeOp` Raft append entry
+	// instead of one entry per deleted sequence. Dramatically reduces Raft cost
+	// on mirrors whose origin has a large number of interior deletes.
+	// - Introduced: 2.14.0, apply-side always supports receiving `deleteRangeOp`.
+	// - Enabled: TBD, once all supported versions carry the apply-side.
+	//
+	// WARNING: Only enable once every peer in the cluster is on a version that
+	// supports receiving `deleteRangeOp`. Older peers panic on apply of an
+	// unknown stream entry operation.
+	FeatureFlagJsRaftDeleteRange: false,
 }
 
 // getFeatureFlag is used to retrieve either the default or overwritten value for a feature flag.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4261,7 +4261,7 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 		if needLock {
 			mset.mu.Lock()
 		}
-		mset.setLastSeq(last)
+		mset.lseq = last
 		mset.clearAllPreAcks(last)
 		if needLock {
 			mset.mu.Unlock()
@@ -10456,7 +10456,7 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 	mset.mu.Lock()
 	defer mset.mu.Unlock()
 	// Update our lseq.
-	mset.setLastSeq(seq)
+	mset.lseq = seq
 
 	// Check for MsgId and if we have one here make sure to update our internal map.
 	if len(hdr) > 0 {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4261,7 +4261,7 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 		if needLock {
 			mset.mu.Lock()
 		}
-		mset.setLastSeq(last)
+		mset.lseq = last
 		mset.clearAllPreAcks(last)
 		if needLock {
 			mset.mu.Unlock()
@@ -10469,7 +10469,7 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 	mset.mu.Lock()
 	defer mset.mu.Unlock()
 	// Update our lseq.
-	mset.setLastSeq(seq)
+	mset.lseq = seq
 
 	// Check for MsgId and if we have one here make sure to update our internal map.
 	if len(hdr) > 0 {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3930,6 +3930,41 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 					return 0, err
 				}
 
+			case deleteRangeOp:
+				dr, err := decodeDeleteRange(buf[1:])
+				if err != nil {
+					if node := mset.raftNode(); node != nil {
+						s := js.srv
+						s.Errorf("JetStream cluster could not decode delete range for '%s > %s' [%s]",
+							mset.account(), mset.name(), node.Group())
+					}
+					panic(err.Error())
+				}
+				if dr.Num == 0 {
+					continue
+				}
+				mset.mu.Lock()
+				first, num := dr.First, dr.Num
+				lseq := first + num - 1
+				if mset.lseq >= lseq {
+					mset.mu.Unlock()
+					continue
+				}
+				// Trim any prefix already applied so we only skip the uncovered tail.
+				if mset.lseq >= first {
+					first = mset.lseq + 1
+					num = lseq - mset.lseq
+				}
+				if err = mset.store.SkipMsgs(first, num); err != nil {
+					mset.mu.Unlock()
+					js.srv.RateLimitWarnf("JetStream cluster failed to apply delete range [%d..%d] for '%s > %s': %v",
+						first, lseq, mset.account().Name, mset.cfg.Name, err)
+					return 0, err
+				}
+				mset.clearAllPreAcksInRange(first, lseq)
+				mset.lseq = lseq
+				mset.mu.Unlock()
+
 			case deleteMsgOp:
 				md, err := decodeMsgDelete(buf[1:])
 				if err != nil {
@@ -10377,17 +10412,13 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 		// Handle the delete range.
 		// Make sure the sequences match up properly.
 		mset.mu.Lock()
-		if len(mset.preAcks) > 0 {
-			for seq := dr.First; seq < dr.First+dr.Num; seq++ {
-				mset.clearAllPreAcks(seq)
-			}
-		}
+		lseq := dr.First + dr.Num - 1
 		if err = mset.store.SkipMsgs(dr.First, dr.Num); err != nil {
 			mset.mu.Unlock()
 			return 0, errCatchupWrongSeqForSkip
 		}
-		mset.lseq = dr.First + dr.Num - 1
-		lseq := mset.lseq
+		mset.clearAllPreAcksInRange(dr.First, lseq)
+		mset.lseq = lseq
 		mset.mu.Unlock()
 		return lseq, nil
 	}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3930,6 +3930,41 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 					return 0, err
 				}
 
+			case deleteRangeOp:
+				dr, err := decodeDeleteRange(buf[1:])
+				if err != nil {
+					if node := mset.raftNode(); node != nil {
+						s := js.srv
+						s.Errorf("JetStream cluster could not decode delete range for '%s > %s' [%s]",
+							mset.account(), mset.name(), node.Group())
+					}
+					panic(err.Error())
+				}
+				if dr.Num == 0 {
+					continue
+				}
+				mset.mu.Lock()
+				first, num := dr.First, dr.Num
+				lseq := first + num - 1
+				if mset.lseq >= lseq {
+					mset.mu.Unlock()
+					continue
+				}
+				// Trim any prefix already applied so we only skip the uncovered tail.
+				if mset.lseq >= first {
+					first = mset.lseq + 1
+					num = lseq - mset.lseq
+				}
+				if err = mset.store.SkipMsgs(first, num); err != nil {
+					mset.mu.Unlock()
+					js.srv.RateLimitWarnf("JetStream cluster failed to apply delete range [%d..%d] for '%s > %s': %v",
+						first, lseq, mset.account().Name, mset.cfg.Name, err)
+					return 0, err
+				}
+				mset.clearAllPreAcksInRange(first, lseq)
+				mset.lseq = lseq
+				mset.mu.Unlock()
+
 			case deleteMsgOp:
 				md, err := decodeMsgDelete(buf[1:])
 				if err != nil {
@@ -10364,17 +10399,13 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 		// Handle the delete range.
 		// Make sure the sequences match up properly.
 		mset.mu.Lock()
-		if len(mset.preAcks) > 0 {
-			for seq := dr.First; seq < dr.First+dr.Num; seq++ {
-				mset.clearAllPreAcks(seq)
-			}
-		}
+		lseq := dr.First + dr.Num - 1
 		if err = mset.store.SkipMsgs(dr.First, dr.Num); err != nil {
 			mset.mu.Unlock()
 			return 0, errCatchupWrongSeqForSkip
 		}
-		mset.lseq = dr.First + dr.Num - 1
-		lseq := mset.lseq
+		mset.clearAllPreAcksInRange(dr.First, lseq)
+		mset.lseq = lseq
 		mset.mu.Unlock()
 		return lseq, nil
 	}

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -10176,3 +10176,152 @@ func TestJetStreamClusterProposeFailureDoesNotDriftClseq(t *testing.T) {
 		require_False(t, rn.IsDeleted())
 	}
 }
+
+func TestJetStreamClusterSkipMsgsRaftDeleteRange(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		title := "Disabled"
+		if enabled {
+			title = "Enabled"
+		}
+		t.Run(title, func(t *testing.T) {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+
+			for _, s := range c.servers {
+				s.optsMu.Lock()
+				s.opts.FeatureFlags = map[string]bool{FeatureFlagJsRaftDeleteRange: enabled}
+				s.optsMu.Unlock()
+			}
+
+			nc, js := jsClientConnect(t, c.randomServer())
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     "TEST",
+				Subjects: []string{"foo"},
+				Replicas: 3,
+			})
+			require_NoError(t, err)
+
+			_, err = js.Publish("foo", nil)
+			require_NoError(t, err)
+
+			sl := c.streamLeader(globalAccountName, "TEST")
+			mset, err := sl.globalAccount().lookupStream("TEST")
+			require_NoError(t, err)
+
+			// Enabled uses a huge gap to assert the O(1) apply path; disabled
+			// lowers it so the O(n) per-seq path finishes in a reasonable time.
+			gap := uint64(100_000_000)
+			if !enabled {
+				gap = uint64(50_000)
+			}
+			start := time.Now()
+			mset.mu.Lock()
+			mset.skipMsgs(2, gap)
+			mset.mu.Unlock()
+			if elapsed := time.Since(start); elapsed > 2*time.Second {
+				t.Fatalf("Expected to skip msgs in <2s but got %v", elapsed)
+			}
+
+			// Wait for the skip to be applied on the leader before publishing,
+			// since the clustered paths are async.
+			checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+				mset.mu.RLock()
+				lseq := mset.lseq
+				mset.mu.RUnlock()
+				if lseq < gap {
+					return fmt.Errorf("leader lseq=%d, want >=%d", lseq, gap)
+				}
+				return nil
+			})
+
+			// After the skip, publish one more live message so we have a
+			// message at LastSeq to compare against.
+			_, err = js.Publish("foo", nil)
+			require_NoError(t, err)
+			checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+				for _, s := range c.servers {
+					mset, err = s.globalAccount().lookupStream("TEST")
+					if err != nil {
+						return err
+					}
+					var state StreamState
+					mset.store.FastState(&state)
+					if state.LastSeq != gap+1 {
+						return fmt.Errorf("server %s LastSeq=%d, want %d", s.Name(), state.LastSeq, gap+1)
+					}
+					if state.Msgs != 2 {
+						return fmt.Errorf("server %s Msgs=%d, want 2", s.Name(), state.Msgs)
+					}
+				}
+				return nil
+			})
+		})
+	}
+}
+
+func TestJetStreamClusterApplyDeleteRangeOpIdempotent(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	_, err = js.Publish("foo", nil)
+	require_NoError(t, err)
+
+	sl := c.streamLeader(globalAccountName, "TEST")
+	mset, err := sl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	sjs := sl.getJetStream()
+
+	mset.mu.Lock()
+	require_NoError(t, mset.store.SkipMsgs(2, 999))
+	mset.lseq = 1000
+	mset.mu.Unlock()
+
+	var before StreamState
+	mset.store.FastState(&before)
+
+	// Ignore delete range if already applied.
+	replay := newCommittedEntry(1, []*Entry{
+		newEntry(EntryNormal, encodeDeleteRange(&DeleteRange{First: 100, Num: 401})),
+	})
+	_, err = sjs.applyStreamEntries(mset, replay, false)
+	require_NoError(t, err)
+	require_Equal(t, mset.lastSeq(), 1000)
+
+	var after StreamState
+	mset.store.FastState(&after)
+	require_Equal(t, after.FirstSeq, before.FirstSeq)
+	require_Equal(t, after.LastSeq, before.LastSeq)
+	require_Equal(t, after.Msgs, before.Msgs)
+
+	// Full delete range.
+	dr := newCommittedEntry(2, []*Entry{
+		newEntry(EntryNormal, encodeDeleteRange(&DeleteRange{First: 1001, Num: 1000})),
+	})
+	_, err = sjs.applyStreamEntries(mset, dr, false)
+	require_NoError(t, err)
+	require_Equal(t, mset.lastSeq(), 2000)
+	mset.store.FastState(&after)
+	require_Equal(t, after.LastSeq, 2000)
+
+	// Partial delete range.
+	dr = newCommittedEntry(3, []*Entry{
+		newEntry(EntryNormal, encodeDeleteRange(&DeleteRange{First: 1501, Num: 1000})),
+	})
+	_, err = sjs.applyStreamEntries(mset, dr, false)
+	require_NoError(t, err)
+	require_Equal(t, mset.lastSeq(), 2500)
+	mset.store.FastState(&after)
+	require_Equal(t, after.LastSeq, 2500)
+}

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -9968,3 +9968,152 @@ func TestJetStreamDurableStreamSourceDeletesConsumerAfterStreamRemoval(t *testin
 		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) { test(t, replicas) })
 	}
 }
+
+func TestJetStreamClusterSkipMsgsRaftDeleteRange(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		title := "Disabled"
+		if enabled {
+			title = "Enabled"
+		}
+		t.Run(title, func(t *testing.T) {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+
+			for _, s := range c.servers {
+				s.optsMu.Lock()
+				s.opts.FeatureFlags = map[string]bool{FeatureFlagJsRaftDeleteRange: enabled}
+				s.optsMu.Unlock()
+			}
+
+			nc, js := jsClientConnect(t, c.randomServer())
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     "TEST",
+				Subjects: []string{"foo"},
+				Replicas: 3,
+			})
+			require_NoError(t, err)
+
+			_, err = js.Publish("foo", nil)
+			require_NoError(t, err)
+
+			sl := c.streamLeader(globalAccountName, "TEST")
+			mset, err := sl.globalAccount().lookupStream("TEST")
+			require_NoError(t, err)
+
+			// Enabled uses a huge gap to assert the O(1) apply path; disabled
+			// lowers it so the O(n) per-seq path finishes in a reasonable time.
+			gap := uint64(100_000_000)
+			if !enabled {
+				gap = uint64(50_000)
+			}
+			start := time.Now()
+			mset.mu.Lock()
+			mset.skipMsgs(2, gap)
+			mset.mu.Unlock()
+			if elapsed := time.Since(start); elapsed > 2*time.Second {
+				t.Fatalf("Expected to skip msgs in <2s but got %v", elapsed)
+			}
+
+			// Wait for the skip to be applied on the leader before publishing,
+			// since the clustered paths are async.
+			checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+				mset.mu.RLock()
+				lseq := mset.lseq
+				mset.mu.RUnlock()
+				if lseq < gap {
+					return fmt.Errorf("leader lseq=%d, want >=%d", lseq, gap)
+				}
+				return nil
+			})
+
+			// After the skip, publish one more live message so we have a
+			// message at LastSeq to compare against.
+			_, err = js.Publish("foo", nil)
+			require_NoError(t, err)
+			checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+				for _, s := range c.servers {
+					mset, err = s.globalAccount().lookupStream("TEST")
+					if err != nil {
+						return err
+					}
+					var state StreamState
+					mset.store.FastState(&state)
+					if state.LastSeq != gap+1 {
+						return fmt.Errorf("server %s LastSeq=%d, want %d", s.Name(), state.LastSeq, gap+1)
+					}
+					if state.Msgs != 2 {
+						return fmt.Errorf("server %s Msgs=%d, want 2", s.Name(), state.Msgs)
+					}
+				}
+				return nil
+			})
+		})
+	}
+}
+
+func TestJetStreamClusterApplyDeleteRangeOpIdempotent(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	_, err = js.Publish("foo", nil)
+	require_NoError(t, err)
+
+	sl := c.streamLeader(globalAccountName, "TEST")
+	mset, err := sl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	sjs := sl.getJetStream()
+
+	mset.mu.Lock()
+	require_NoError(t, mset.store.SkipMsgs(2, 999))
+	mset.lseq = 1000
+	mset.mu.Unlock()
+
+	var before StreamState
+	mset.store.FastState(&before)
+
+	// Ignore delete range if already applied.
+	replay := newCommittedEntry(1, []*Entry{
+		newEntry(EntryNormal, encodeDeleteRange(&DeleteRange{First: 100, Num: 401})),
+	})
+	_, err = sjs.applyStreamEntries(mset, replay, false)
+	require_NoError(t, err)
+	require_Equal(t, mset.lastSeq(), 1000)
+
+	var after StreamState
+	mset.store.FastState(&after)
+	require_Equal(t, after.FirstSeq, before.FirstSeq)
+	require_Equal(t, after.LastSeq, before.LastSeq)
+	require_Equal(t, after.Msgs, before.Msgs)
+
+	// Full delete range.
+	dr := newCommittedEntry(2, []*Entry{
+		newEntry(EntryNormal, encodeDeleteRange(&DeleteRange{First: 1001, Num: 1000})),
+	})
+	_, err = sjs.applyStreamEntries(mset, dr, false)
+	require_NoError(t, err)
+	require_Equal(t, mset.lastSeq(), 2000)
+	mset.store.FastState(&after)
+	require_Equal(t, after.LastSeq, 2000)
+
+	// Partial delete range.
+	dr = newCommittedEntry(3, []*Entry{
+		newEntry(EntryNormal, encodeDeleteRange(&DeleteRange{First: 1501, Num: 1000})),
+	})
+	_, err = sjs.applyStreamEntries(mset, dr, false)
+	require_NoError(t, err)
+	require_Equal(t, mset.lastSeq(), 2500)
+	mset.store.FastState(&after)
+	require_Equal(t, after.LastSeq, 2500)
+}

--- a/server/stream.go
+++ b/server/stream.go
@@ -1476,12 +1476,6 @@ func (mset *stream) lastSeq() uint64 {
 	return mset.lseq
 }
 
-// Set last seq.
-// Write lock should be held.
-func (mset *stream) setLastSeq(lseq uint64) {
-	mset.lseq = lseq
-}
-
 func (mset *stream) sendCreateAdvisory() {
 	mset.mu.RLock()
 	name := mset.cfg.Name
@@ -2864,7 +2858,7 @@ func (mset *stream) purgeLocked(preq *JSApiStreamPurgeRequest, needLock bool) (p
 
 	// Check if our last has moved past what our original last sequence was, if so reset.
 	if lseq > mlseq {
-		mset.setLastSeq(lseq)
+		mset.lseq = lseq
 	}
 
 	// Clear any pending acks below first seq.

--- a/server/stream.go
+++ b/server/stream.go
@@ -3334,8 +3334,13 @@ func (mset *stream) skipMsgs(start, end uint64) {
 		return
 	}
 
-	// FIXME (dlc) - We should allow proposals of DeleteRange, but would need to make sure all peers support.
-	// With syncRequest was easy to add bool into request.
+	// Must only be enabled once every peer in the cluster supports receiving
+	// deleteRangeOp in the normal apply path; older peers panic on unknown ops.
+	if mset.srv.getOpts().getFeatureFlag(FeatureFlagJsRaftDeleteRange) {
+		node.Propose(encodeDeleteRange(&DeleteRange{First: start, Num: end - start + 1}))
+		return
+	}
+
 	var entries []*Entry
 	for seq := start; seq <= end; seq++ {
 		entries = append(entries, newEntry(EntryNormal, encodeStreamMsg(_EMPTY_, _EMPTY_, nil, nil, seq-1, 0, false)))
@@ -8711,6 +8716,17 @@ func (mset *stream) clearAllPreAcks(seq uint64) {
 func (mset *stream) clearAllPreAcksBelowFloor(floor uint64) {
 	for seq := range mset.preAcks {
 		if seq < floor {
+			delete(mset.preAcks, seq)
+		}
+	}
+}
+
+// Clear all preAcks in [first, last]. Iterates the preAcks map, not the
+// range, so callers can pass very wide ranges cheaply.
+// Write lock should be held.
+func (mset *stream) clearAllPreAcksInRange(first, last uint64) {
+	for seq := range mset.preAcks {
+		if seq >= first && seq <= last {
 			delete(mset.preAcks, seq)
 		}
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -3339,8 +3339,13 @@ func (mset *stream) skipMsgs(start, end uint64) {
 		return
 	}
 
-	// FIXME (dlc) - We should allow proposals of DeleteRange, but would need to make sure all peers support.
-	// With syncRequest was easy to add bool into request.
+	// Must only be enabled once every peer in the cluster supports receiving
+	// deleteRangeOp in the normal apply path; older peers panic on unknown ops.
+	if mset.srv.getOpts().getFeatureFlag(FeatureFlagJsRaftDeleteRange) {
+		node.Propose(encodeDeleteRange(&DeleteRange{First: start, Num: end - start + 1}))
+		return
+	}
+
 	var entries []*Entry
 	for seq := start; seq <= end; seq++ {
 		entries = append(entries, newEntry(EntryNormal, encodeStreamMsg(_EMPTY_, _EMPTY_, nil, nil, seq-1, 0, false)))
@@ -8749,6 +8754,17 @@ func (mset *stream) clearAllPreAcks(seq uint64) {
 func (mset *stream) clearAllPreAcksBelowFloor(floor uint64) {
 	for seq := range mset.preAcks {
 		if seq < floor {
+			delete(mset.preAcks, seq)
+		}
+	}
+}
+
+// Clear all preAcks in [first, last]. Iterates the preAcks map, not the
+// range, so callers can pass very wide ranges cheaply.
+// Write lock should be held.
+func (mset *stream) clearAllPreAcksInRange(first, last uint64) {
+	for seq := range mset.preAcks {
+		if seq >= first && seq <= last {
 			delete(mset.preAcks, seq)
 		}
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -1473,12 +1473,6 @@ func (mset *stream) lastSeq() uint64 {
 	return mset.lseq
 }
 
-// Set last seq.
-// Write lock should be held.
-func (mset *stream) setLastSeq(lseq uint64) {
-	mset.lseq = lseq
-}
-
 func (mset *stream) sendCreateAdvisory() {
 	mset.mu.RLock()
 	name := mset.cfg.Name
@@ -2861,7 +2855,7 @@ func (mset *stream) purgeLocked(preq *JSApiStreamPurgeRequest, needLock bool) (p
 
 	// Check if our last has moved past what our original last sequence was, if so reset.
 	if lseq > mlseq {
-		mset.setLastSeq(lseq)
+		mset.lseq = lseq
 	}
 
 	// Clear any pending acks below first seq.


### PR DESCRIPTION
A stream with a large number of deletes which is mirrored would propose deletes for every single sequence in that range (but chunked into less individual append entries). For wide gaps this produced a huge number of Raft entries. This PR improves that by proposing a single `deleteRangeOp` covering the full gap, and adds support for `deleteRangeOp` in the normal stream apply path (previously only the catchup path handled it).

Because older peers panic on an unknown entry op, the propose-side is gated behind a new `js_raft_delete_range` feature flag (default off). We can make this the default in a future release (probably 2.15 or later), but users can opt-in earlier if needed.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>
