### PR TITLE
Fix config-check creating resolver directories

### DIFF
--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -16,6 +16,8 @@ package server
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -2632,5 +2634,24 @@ func TestConfigCheckMultipleErrors(t *testing.T) {
 		if !strings.Contains(errMsg, extra) {
 			t.Fatalf("Expected to find error %q (%s)", extra, errMsg)
 		}
+	}
+}
+
+func TestConfigCheckResolverDoesNotCreateDir(t *testing.T) {
+	baseDir := t.TempDir()
+	resolverDir := filepath.Join(baseDir, "resolver", "jwt")
+	conf := createConfFile(t, []byte(fmt.Sprintf(`
+		resolver: {
+			type: "full"
+			dir: %q
+		}
+	`, filepath.ToSlash(resolverDir))))
+
+	opts := &Options{CheckConfig: true}
+	if err := opts.ProcessConfigFile(conf); err != nil {
+		t.Fatalf("Unexpected error processing config in check mode: %v", err)
+	}
+	if _, err := os.Stat(resolverDir); !os.IsNotExist(err) {
+		t.Fatalf("Expected resolver directory to not be created in check mode, got err=%v", err)
 	}
 }

--- a/server/opts.go
+++ b/server/opts.go
@@ -1615,7 +1615,11 @@ func (o *Options) processConfigFileLine(k string, v any, errors *[]error, warnin
 				if hdel_set {
 					*errors = append(*errors, &configErr{tk, "CACHE does not accept hard_delete"})
 				}
-				res, err = NewCacheDirAccResolver(dir, limit, ttl, opts...)
+				if o.CheckConfig {
+					res = &MemAccResolver{}
+				} else {
+					res, err = NewCacheDirAccResolver(dir, limit, ttl, opts...)
+				}
 			case "FULL":
 				checkDir()
 				if ttl != 0 {
@@ -1632,7 +1636,11 @@ func (o *Options) processConfigFileLine(k string, v any, errors *[]error, warnin
 						delete = RenameDeleted
 					}
 				}
-				res, err = NewDirAccResolver(dir, limit, sync, delete, opts...)
+				if o.CheckConfig {
+					res = &MemAccResolver{}
+				} else {
+					res, err = NewDirAccResolver(dir, limit, sync, delete, opts...)
+				}
 			case "MEM", "MEMORY":
 				res = &MemAccResolver{}
 			}


### PR DESCRIPTION
## Summary
- prevent -t / CheckConfig mode from instantiating disk-backed account resolvers
- keep resolver option validation behavior intact
- add regression test to ensure config-check does not create resolver directories

## Repro
Before this change, running config check with a FULL resolver path could create the resolver directory as a side effect.

## Verification
- go test ./server -run TestConfigCheckResolverDoesNotCreateDir -count=1
- manual repro with go run . -t -c <config> confirms resolver dir is not created

Fixes #5708

Signed-off-by: Shiro Oni <shiroonigami23@gmail.com>