### PR TITLE
Apply writer options consistently to s2_fast compression mode

### DIFF
--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -3943,6 +3943,13 @@ func TestRouteCompressionOptions(t *testing.T) {
 	}
 }
 
+func TestS2WriterOptionsForFastCompression(t *testing.T) {
+	opts := s2WriterOptions(CompressionS2Fast)
+	if len(opts) == 0 {
+		t.Fatal("Expected non-empty writer options for fast compression mode")
+	}
+}
+
 type testConnSentBytes struct {
 	net.Conn
 	sync.RWMutex

--- a/server/server.go
+++ b/server/server.go
@@ -659,6 +659,8 @@ func s2WriterOptions(cm string) []s2.WriterOption {
 	switch cm {
 	case CompressionS2Uncompressed:
 		return append(opts, s2.WriterUncompressed())
+	case CompressionS2Fast:
+		return opts
 	case CompressionS2Best:
 		return append(opts, s2.WriterBestCompression())
 	case CompressionS2Better:


### PR DESCRIPTION
Fixes #7037.

## Summary
- include `s2.WriterConcurrency(1)` option for `CompressionS2Fast`
- add regression test `TestS2WriterOptionsForFastCompression`

A maintainer comment on the issue indicated omitting this in fast mode was an oversight.

## Verification
- `go test ./server -run ''TestS2WriterOptionsForFastCompression|TestRouteCompressionOptions'' -count=1`