### PR TITLE
Return 400 for unknown /connz query parameters

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -714,8 +714,36 @@ func decodeSubs(w http.ResponseWriter, r *http.Request) (subs bool, subsDet bool
 	return
 }
 
+func decodeUnknownParams(w http.ResponseWriter, r *http.Request, allowed map[string]struct{}) error {
+	for key := range r.URL.Query() {
+		if _, ok := allowed[key]; !ok {
+			w.WriteHeader(http.StatusBadRequest)
+			err := fmt.Errorf("Unknown parameter %q", key)
+			w.Write([]byte(err.Error()))
+			return err
+		}
+	}
+	return nil
+}
+
 // HandleConnz process HTTP requests for connection information.
 func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
+	if err := decodeUnknownParams(w, r, map[string]struct{}{
+		"sort":        {},
+		"auth":        {},
+		"subs":        {},
+		"offset":      {},
+		"limit":       {},
+		"cid":         {},
+		"state":       {},
+		"user":        {},
+		"acc":         {},
+		"mqtt_client": {},
+		"callback":    {},
+	}); err != nil {
+		return
+	}
+
 	sortOpt := SortOpt(r.URL.Query().Get("sort"))
 	auth, err := decodeBool(w, r, "auth")
 	if err != nil {

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -438,6 +438,7 @@ func TestMonitorConnzBadParams(t *testing.T) {
 	readBodyEx(t, url+"offset=xxx", http.StatusBadRequest, textPlain)
 	readBodyEx(t, url+"limit=xxx", http.StatusBadRequest, textPlain)
 	readBodyEx(t, url+"state=xxx", http.StatusBadRequest, textPlain)
+	readBodyEx(t, url+"testpub=foo", http.StatusBadRequest, textPlain)
 }
 
 func TestMonitorConnzWithSubs(t *testing.T) {


### PR DESCRIPTION
Fixes #704.

## Summary
- validate query params for `/connz`
- return `400 Bad Request` for unknown parameters
- keep `callback` allowed for JSONP support
- add regression test for `/connz?testpub=foo`

## Verification
- `go test ./server -run ^(TestMonitorConnzBadParams|TestMonitorConnz)$ -count=1`