### PR TITLE
(2.14) [FIXED] Scheduled message falls back to own content if source is empty

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -9699,6 +9699,77 @@ func TestJetStreamClusterScheduledMessageSubjectSourcing(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterScheduledMessageSubjectSourcingFallback(t *testing.T) {
+	for _, replicas := range []int{1, 3} {
+		for _, storage := range []StorageType{FileStorage, MemoryStorage} {
+			t.Run(fmt.Sprintf("R%d/%s", replicas, storage), func(t *testing.T) {
+				c := createJetStreamClusterExplicit(t, "R3S", 3)
+				defer c.shutdown()
+
+				nc, js := jsClientConnect(t, c.randomServer())
+				defer nc.Close()
+
+				cfg := &StreamConfig{
+					Name:              "SchedulesEnabled",
+					Subjects:          []string{"foo.*"},
+					Storage:           storage,
+					Replicas:          replicas,
+					AllowMsgSchedules: true,
+					AllowMsgTTL:       true,
+				}
+				_, err := jsStreamCreate(t, nc, cfg)
+				require_NoError(t, err)
+
+				// Publish the schedule WITHOUT first publishing to the source subject.
+				// The schedule should fall back to its own content when the source has no last message.
+				m := nats.NewMsg("foo.schedule")
+				m.Header.Set("Nats-Schedule", "@at 1970-01-01T00:00:00Z")
+				m.Header.Set("Nats-Schedule-Target", "foo.publish")
+				m.Header.Set("Nats-Schedule-Source", "foo.data")
+				m.Header.Set("Header", "Fallback")
+				m.Data = []byte("fallback")
+
+				pubAck, err := js.PublishMsg(m)
+				require_NoError(t, err)
+				require_Equal(t, pubAck.Sequence, 1)
+
+				sl := c.streamLeader(globalAccountName, "SchedulesEnabled")
+				mset, err := sl.globalAccount().lookupStream("SchedulesEnabled")
+				require_NoError(t, err)
+
+				state := mset.state()
+				require_Equal(t, state.LastSeq, 1)
+				require_Equal(t, state.Msgs, 1)
+
+				// Waiting for the delayed message to be published using the fallback content.
+				checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+					state = mset.state()
+					if state.LastSeq != 2 {
+						return fmt.Errorf("expected last seq 2, got %d", state.LastSeq)
+					} else if state.Msgs != 1 {
+						// Only the published message remains; the schedule itself is purged.
+						return fmt.Errorf("expected 1 msg, got %d", state.Msgs)
+					}
+					return nil
+				})
+
+				// Confirm the published message contains the scheduled message's own content.
+				rsm, err := js.GetLastMsg("SchedulesEnabled", "foo.publish")
+				require_NoError(t, err)
+				require_Equal(t, rsm.Sequence, 2)
+				require_True(t, bytes.Equal(rsm.Data, []byte("fallback")))
+				require_Len(t, len(rsm.Header), 3)
+				require_Equal(t, rsm.Header.Get("Nats-Scheduler"), "foo.schedule")
+				require_Equal(t, rsm.Header.Get("Nats-Schedule-Next"), "purge")
+				require_Equal(t, rsm.Header.Get("Header"), "Fallback")
+				checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+					return checkState(t, c, globalAccountName, "SchedulesEnabled")
+				})
+			})
+		}
+	}
+}
+
 func TestJetStreamClusterScheduledDelayedMessageRollup(t *testing.T) {
 	for _, replicas := range []int{1, 3} {
 		for _, storage := range []StorageType{FileStorage, MemoryStorage} {

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -157,9 +157,10 @@ func (ms *MsgScheduling) resetTimer() {
 
 func (ms *MsgScheduling) getScheduledMessages(loadMsg func(seq uint64, smv *StoreMsg) *StoreMsg, loadLast func(subj string, smv *StoreMsg) *StoreMsg) []*inMsg {
 	var (
-		smv  StoreMsg
-		sm   *StoreMsg
-		msgs []*inMsg
+		smv    StoreMsg
+		srcSmv StoreMsg
+		sm     *StoreMsg
+		msgs   []*inMsg
 	)
 	ms.ttls.ExpireTasks(func(seq uint64, ts int64) bool {
 		// Need to grab the message for the specified sequence, and check
@@ -197,9 +198,9 @@ func (ms *MsgScheduling) getScheduledMessages(loadMsg func(seq uint64, smv *Stor
 			rollup := getMessageScheduleRollup(sm.hdr)
 			source := getMessageScheduleSource(sm.hdr)
 			if source != _EMPTY_ {
-				if sm = loadLast(source, &smv); sm == nil {
-					ms.remove(seq)
-					return true
+				// Fall back to the scheduled message's own content if the source has no last message.
+				if srcSm := loadLast(source, &srcSmv); srcSm != nil {
+					sm = srcSm
 				}
 			}
 


### PR DESCRIPTION
Previously, when a scheduled message referenced a `Nats-Schedule-Source` subject that had no last message at fire time, the schedule was silently removed. This change falls back to the scheduled message's own headers and payload in that case, so the schedule still fires and uses whatever content was published with it.

Relates to https://github.com/nats-io/nats-architecture-and-design/pull/406

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>