### PR TITLE
(2.14) Fast batch publish: ramp-up, backward-seq, and off-by-one

### DIFF
--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -157,19 +157,24 @@ func (b *atomicBatch) readyForCommit() *BatchAbandonReason {
 	return nil
 }
 
-// newFastBatch creates a fast batch publish object.
+// newFastBatch creates a fast batch publish object and registers it in batches.fast.
 // Lock should be held.
 func (batches *batching) newFastBatch(mset *stream, batchId string, gapOk bool, maxAckMessages uint16) *fastBatch {
 	b := &fastBatch{gapOk: gapOk, maxAckMessages: maxAckMessages}
+	if batches.fast == nil {
+		batches.fast = make(map[string]*fastBatch, 1)
+	}
+	batches.fast[batchId] = b
 	batches.fastBatchInit(b)
 	b.setupCleanupTimer(mset, batchId, batches)
 	return b
 }
 
 // fastBatchInit (re)initializes the ackMessages field for a fast batch.
+// The batch must already be registered in batches.fast.
 // Lock should be held.
 func (batches *batching) fastBatchInit(b *fastBatch) {
-	// If it's the first batch, just allow what the client wants, otherwise we'll
+	// If it's the only batch, just allow what the client wants, otherwise we'll
 	// need to coordinate and slowly ramp up this publisher.
 	// TODO(mvv): fast ingest's initial flow value improvements?
 	ackMessages := min(500, b.maxAckMessages)
@@ -225,10 +230,6 @@ func (batches *batching) fastBatchRegisterSequences(mset *stream, reply string, 
 			// We'll need a copy as we'll use it as a key and later for cleanup.
 			batchId := copyString(batch.id)
 			b = batches.newFastBatch(mset, batchId, batch.gapOk, batch.flow)
-			if batches.fast == nil {
-				batches.fast = make(map[string]*fastBatch, 1)
-			}
-			batches.fast[batchId] = b
 		}
 		b.sseq = streamSeq
 		b.pseq, b.lseq = batch.seq, batch.seq

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -322,7 +322,7 @@ func (b *fastBatch) sendFlowControl(batchSeq uint64, mset *stream, reply string)
 	if len(reply) == 0 {
 		return
 	}
-	response := BatchFlowAck{Sequence: batchSeq, Messages: b.ackMessages}.MarshalJSON()
+	response, _ := BatchFlowAck{Sequence: batchSeq, Messages: b.ackMessages}.MarshalJSON()
 	mset.outq.sendMsg(reply, response)
 }
 

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -3316,6 +3316,46 @@ func TestJetStreamFastBatchPublishFlowControl(t *testing.T) {
 	}
 }
 
+func TestJetStreamFastBatchInitAckMessages(t *testing.T) {
+	batches := &batching{}
+	mset := &stream{srv: &Server{opts: &Options{}}}
+	stopTimer := func(b *fastBatch) { b.timer.Stop() }
+
+	// First batch, alone in the map: should get full window clamped to client max.
+	b1 := batches.newFastBatch(mset, "b1", false, 1000)
+	stopTimer(b1)
+	require_Equal(t, b1.ackMessages, 500)
+
+	// Second concurrent batch: must start at 1 to coordinate with sibling.
+	b2 := batches.newFastBatch(mset, "b2", false, 1000)
+	stopTimer(b2)
+	require_Equal(t, b2.ackMessages, 1)
+
+	// Resetting b1 while b2 still exists: also throttled to 1.
+	b1.timer.Reset(time.Hour) // Need to reset, otherwise below is a noop.
+	batches.fastBatchReset(mset, "b1", b1)
+	stopTimer(b1)
+	require_Equal(t, b1.ackMessages, 1)
+
+	// Remove the sibling; a reset now returns to the full window.
+	stopTimer(b2)
+	delete(batches.fast, "b2")
+	batches.fastBatchInit(b1)
+	require_Equal(t, b1.ackMessages, 500)
+
+	// A client-specified max below 500 is respected.
+	stopTimer(b1)
+	delete(batches.fast, "b1")
+	b3 := batches.newFastBatch(mset, "b3", false, 50)
+	stopTimer(b3)
+	require_Equal(t, b3.ackMessages, 50)
+
+	// And throttled to 1 when a sibling is present.
+	b4 := batches.newFastBatch(mset, "b4", false, 50)
+	stopTimer(b4)
+	require_Equal(t, b4.ackMessages, 1)
+}
+
 func TestJetStreamFastBatchPublishSourceAndMirror(t *testing.T) {
 	test := func(t *testing.T, replicas int) {
 		c := createJetStreamClusterExplicit(t, "R3S", 3)

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -3944,6 +3944,64 @@ func TestJetStreamFastBatchPublishPing(t *testing.T) {
 	require_Equal(t, pubAck.BatchSize, 100)
 }
 
+func TestJetStreamFastBatchPublishGapOkBackwardSeq(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc := clientConnectToServer(t, s)
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:              "TEST",
+		Subjects:          []string{"foo"},
+		Storage:           FileStorage,
+		AllowBatchPublish: true,
+	})
+	require_NoError(t, err)
+
+	inbox := nats.NewInbox()
+	sub, err := nc.SubscribeSync(fmt.Sprintf("%s.>", inbox))
+	require_NoError(t, err)
+	defer sub.Drain()
+
+	// Start the batch in gapOk mode.
+	m := nats.NewMsg("foo")
+	m.Reply = generateFastBatchReply(inbox, "uuid", 1, 0, FastBatchGapOk, FastBatchOpStart)
+	require_NoError(t, nc.PublishMsg(m))
+	rmsg, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	var batchFlowAck BatchFlowAck
+	require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowAck))
+
+	// Forward-jump to seq=5; the gap is accepted.
+	m.Reply = generateFastBatchReply(inbox, "uuid", 5, 0, FastBatchGapOk, FastBatchOpAppend)
+	require_NoError(t, nc.PublishMsg(m))
+	rmsg, err = sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	var batchFlowGap BatchFlowGap
+	require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowGap))
+	require_Equal(t, batchFlowGap.ExpectedLastSequence, 1)
+	require_Equal(t, batchFlowGap.CurrentSequence, 5)
+
+	// A backward batch.seq must not rewind b.lseq; it aborts the batch.
+	// No BatchFlowGap should be sent, since gap notifications are only for forward gaps.
+	m.Reply = generateFastBatchReply(inbox, "uuid", 3, 0, FastBatchGapOk, FastBatchOpAppend)
+	require_NoError(t, nc.PublishMsg(m))
+
+	// The batch is committed directly and a PubAck is delivered (would never arrive if the
+	// backward seq were silently accepted and the batch kept running).
+	rmsg, err = sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	var pubAck JSPubAckResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+	require_True(t, pubAck.Error == nil)
+	require_Equal(t, pubAck.BatchId, "uuid")
+
+	// Ensure no stray BatchFlowGap arrived alongside the PubAck.
+	_, err = sub.NextMsg(200 * time.Millisecond)
+	require_Error(t, err, nats.ErrTimeout)
+}
+
 func TestJetStreamFastBatchSequentialDuplicateAndErrorPubAck(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -3177,7 +3177,7 @@ func TestJetStreamFastBatchPublishGapDetection(t *testing.T) {
 		require_True(t, strings.HasPrefix(string(rmsg.Data), "{\"type\":\"gap\","))
 		var batchFlowGap BatchFlowGap
 		require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowGap))
-		require_Equal(t, batchFlowGap.ExpectedLastSequence, 1)
+		require_Equal(t, batchFlowGap.ExpectedLastSequence, 2)
 		require_Equal(t, batchFlowGap.CurrentSequence, 3)
 
 		switch gapMode {
@@ -3980,7 +3980,7 @@ func TestJetStreamFastBatchPublishGapOkBackwardSeq(t *testing.T) {
 	require_NoError(t, err)
 	var batchFlowGap BatchFlowGap
 	require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowGap))
-	require_Equal(t, batchFlowGap.ExpectedLastSequence, 1)
+	require_Equal(t, batchFlowGap.ExpectedLastSequence, 2)
 	require_Equal(t, batchFlowGap.CurrentSequence, 5)
 
 	// A backward batch.seq must not rewind b.lseq; it aborts the batch.

--- a/server/stream.go
+++ b/server/stream.go
@@ -7622,13 +7622,16 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 	// Detect gaps.
 	b.lseq++
 	if b.lseq != batch.seq || cleanup {
-		// If a gap is detected, we always report about it.
-		buf := BatchFlowGap{ExpectedLastSequence: b.lseq - 1, CurrentSequence: batch.seq}.MarshalJSON()
-		outq.sendMsg(reply, buf)
-		// If the gap is okay, we can continue without rejecting.
-		if b.gapOk && !cleanup {
+		// If a forward gap is detected, we always report about it.
+		if batch.seq > b.lseq {
+			buf := BatchFlowGap{ExpectedLastSequence: b.lseq - 1, CurrentSequence: batch.seq}.MarshalJSON()
+			outq.sendMsg(reply, buf)
+		}
+		// If the forward gap is okay, we can continue without rejecting.
+		if b.gapOk && !cleanup && batch.seq > b.lseq {
 			b.lseq = batch.seq
 		} else {
+			// We've reached either a backward gap, or were cleaned up already, or it's gap-fail mode.
 			// Revert, since we incremented for the gap check.
 			b.lseq--
 			if cleanup = batches.fastBatchCommit(b, batch.id, mset, reply); cleanup {

--- a/server/stream.go
+++ b/server/stream.go
@@ -293,12 +293,11 @@ type BatchFlowAck struct {
 	Messages uint16 `json:"msgs"`
 }
 
-func (ack BatchFlowAck) MarshalJSON() []byte {
+func (ack BatchFlowAck) MarshalJSON() ([]byte, error) {
 	type Alias BatchFlowAck
 	a := Alias(ack)
 	a.Type = "ack"
-	buf, _ := json.Marshal(a)
-	return buf
+	return json.Marshal(a)
 }
 
 // BatchFlowGap is used for reporting gaps when fast batch publishing into a stream.
@@ -313,12 +312,11 @@ type BatchFlowGap struct {
 	CurrentSequence uint64 `json:"seq"`
 }
 
-func (gap BatchFlowGap) MarshalJSON() []byte {
+func (gap BatchFlowGap) MarshalJSON() ([]byte, error) {
 	type Alias BatchFlowGap
 	a := Alias(gap)
 	a.Type = "gap"
-	buf, _ := json.Marshal(a)
-	return buf
+	return json.Marshal(a)
 }
 
 // BatchFlowErr is used for reporting errors when fast batch publishing into a stream.
@@ -334,12 +332,11 @@ type BatchFlowErr struct {
 	Error *ApiError `json:"error"`
 }
 
-func (err BatchFlowErr) MarshalJSON() []byte {
+func (err BatchFlowErr) MarshalJSON() ([]byte, error) {
 	type Alias BatchFlowErr
 	a := Alias(err)
 	a.Type = "err"
-	buf, _ := json.Marshal(a)
-	return buf
+	return json.Marshal(a)
 }
 
 // StreamInfo shows config and current state for this stream.
@@ -7588,7 +7585,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 		// Detect a gap or if the batch was cleaned up in the meantime.
 		if batch.seq > b.lseq || cleanup {
 			// If a gap is detected, we always report about it.
-			buf := BatchFlowGap{ExpectedLastSequence: b.lseq + 1, CurrentSequence: batch.seq + 1}.MarshalJSON()
+			buf, _ := BatchFlowGap{ExpectedLastSequence: b.lseq + 1, CurrentSequence: batch.seq + 1}.MarshalJSON()
 			outq.sendMsg(reply, buf)
 			// If the gap is okay, we can continue without rejecting.
 			if b.gapOk && !cleanup {
@@ -7624,7 +7621,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 	if b.lseq != batch.seq || cleanup {
 		// If a forward gap is detected, we always report about it.
 		if batch.seq > b.lseq {
-			buf := BatchFlowGap{ExpectedLastSequence: b.lseq, CurrentSequence: batch.seq}.MarshalJSON()
+			buf, _ := BatchFlowGap{ExpectedLastSequence: b.lseq, CurrentSequence: batch.seq}.MarshalJSON()
 			outq.sendMsg(reply, buf)
 		}
 		// If the forward gap is okay, we can continue without rejecting.
@@ -7669,7 +7666,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 	// The first message in the batch responds with the settings used for flow control.
 	// If committing immediately, we only send the PubAck.
 	if batch.seq == 1 && canRespond && !batch.commit {
-		buf := BatchFlowAck{Sequence: 0, Messages: b.ackMessages}.MarshalJSON()
+		buf, _ := BatchFlowAck{Sequence: 0, Messages: b.ackMessages}.MarshalJSON()
 		outq.sendMsg(reply, buf)
 	}
 
@@ -7726,7 +7723,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 
 		// We always return the error to the client, unless it's a duplicate.
 		if err != errMsgIdDuplicate {
-			buf := BatchFlowErr{Sequence: batch.seq, Error: apiErr}.MarshalJSON()
+			buf, _ := BatchFlowErr{Sequence: batch.seq, Error: apiErr}.MarshalJSON()
 			outq.sendMsg(reply, buf)
 		}
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -7565,10 +7565,6 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 		// We'll need a copy as we'll use it as a key and later for cleanup.
 		batchId := copyString(batch.id)
 		b = batches.newFastBatch(mset, batchId, batch.gapOk, batch.flow)
-		if batches.fast == nil {
-			batches.fast = make(map[string]*fastBatch, 1)
-		}
-		batches.fast[batchId] = b
 	}
 
 	// The required API level can have the batch be rejected. But the header is always removed.

--- a/server/stream.go
+++ b/server/stream.go
@@ -7624,7 +7624,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 	if b.lseq != batch.seq || cleanup {
 		// If a forward gap is detected, we always report about it.
 		if batch.seq > b.lseq {
-			buf := BatchFlowGap{ExpectedLastSequence: b.lseq - 1, CurrentSequence: batch.seq}.MarshalJSON()
+			buf := BatchFlowGap{ExpectedLastSequence: b.lseq, CurrentSequence: batch.seq}.MarshalJSON()
 			outq.sendMsg(reply, buf)
 		}
 		// If the forward gap is okay, we can continue without rejecting.


### PR DESCRIPTION
Fixes three reliability issues in fast-batch publish:
1. New concurrent batches bypassed flow-control ramp-up because `fastBatchInit` ran before the batch was registered in `batches.fast`.
2. In `gapOk` mode a backward/duplicate `batch.seq` would emit a misleading `BatchFlowGap` and rewind `b.lseq`.
3. `BatchFlowGap.ExpectedLastSequence` was off by one (sent the last-received seq instead of the next-expected one).

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>