### PR TITLE
[FIXED] Stream/consumer INFO returns 404 when inflight

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1874,7 +1874,7 @@ func (s *Server) jsStreamInfoRequest(sub *subscription, c *client, a *Account, s
 	if cc != nil {
 		// Check to make sure the stream is assigned.
 		js.mu.RLock()
-		isLeader, sa := cc.isLeader(), js.streamAssignment(acc.Name, streamName)
+		isLeader, sa := cc.isLeader(), js.streamAssignmentOrInflight(acc.Name, streamName)
 		var offline bool
 		if sa != nil {
 			clusterWideConsCount = len(sa.consumers)
@@ -2103,7 +2103,7 @@ func (s *Server) jsStreamLeaderStepDownRequest(sub *subscription, c *client, _ *
 	}
 
 	js.mu.RLock()
-	isLeader, sa := cc.isLeader(), js.streamAssignment(acc.Name, name)
+	isLeader, sa := cc.isLeader(), js.streamAssignmentOrInflight(acc.Name, name)
 	js.mu.RUnlock()
 
 	if isLeader && sa == nil {
@@ -2220,7 +2220,7 @@ func (s *Server) jsConsumerLeaderStepDownRequest(sub *subscription, c *client, _
 	consumer := tokenAt(subject, 7)
 
 	js.mu.RLock()
-	isLeader, sa := cc.isLeader(), js.streamAssignment(acc.Name, stream)
+	isLeader, sa := cc.isLeader(), js.streamAssignmentOrInflight(acc.Name, stream)
 	js.mu.RUnlock()
 
 	if isLeader && sa == nil {
@@ -3221,7 +3221,7 @@ func (s *Server) jsMsgDeleteRequest(sub *subscription, c *client, _ *Account, su
 		}
 
 		js.mu.RLock()
-		isLeader, sa := cc.isLeader(), js.streamAssignment(acc.Name, stream)
+		isLeader, sa := cc.isLeader(), js.streamAssignmentOrInflight(acc.Name, stream)
 		js.mu.RUnlock()
 
 		if isLeader && sa == nil {
@@ -3346,7 +3346,7 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, _ *Account, subje
 		}
 
 		js.mu.RLock()
-		isLeader, sa := cc.isLeader(), js.streamAssignment(acc.Name, stream)
+		isLeader, sa := cc.isLeader(), js.streamAssignmentOrInflight(acc.Name, stream)
 		js.mu.RUnlock()
 
 		if isLeader && sa == nil {
@@ -3641,7 +3641,7 @@ func (s *Server) jsStreamPurgeRequest(sub *subscription, c *client, _ *Account, 
 		}
 
 		js.mu.RLock()
-		isLeader, sa := cc.isLeader(), js.streamAssignment(acc.Name, stream)
+		isLeader, sa := cc.isLeader(), js.streamAssignmentOrInflight(acc.Name, stream)
 		js.mu.RUnlock()
 
 		if isLeader && sa == nil {
@@ -4906,7 +4906,7 @@ func (s *Server) jsConsumerInfoRequest(sub *subscription, c *client, _ *Account,
 		groupCreated := meta.Created()
 
 		js.mu.RLock()
-		isLeader, sa, ca := cc.isLeader(), js.streamAssignment(acc.Name, streamName), js.consumerAssignment(acc.Name, streamName, consumerName)
+		isLeader, sa, ca := cc.isLeader(), js.streamAssignmentOrInflight(acc.Name, streamName), js.consumerAssignmentOrInflight(acc.Name, streamName, consumerName)
 		var rg *raftGroup
 		var offline, isMember bool
 		if ca != nil {

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -7599,6 +7599,60 @@ func TestJetStreamClusterConcurrentStreamUpdate(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterMetaLeaderRespectsInflight(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	ml := c.leader()
+	require_NotNil(t, ml)
+
+	sjs, cc := ml.getJetStreamCluster()
+	require_NotNil(t, sjs)
+	require_NotNil(t, cc)
+
+	ci := &ClientInfo{Account: globalAccountName}
+	rg := &raftGroup{Name: "INFLIGHT_G", Peers: []string{"offline"}, Storage: MemoryStorage}
+
+	sjs.mu.Lock()
+	sa := &streamAssignment{
+		Client:  ci,
+		Created: time.Now(),
+		Config:  &StreamConfig{Name: "S"},
+		Group:   rg,
+	}
+	ca := &consumerAssignment{
+		Client:  ci,
+		Created: time.Now(),
+		Name:    "C",
+		Stream:  "S",
+		Config:  &ConsumerConfig{},
+		Group:   rg,
+	}
+	cc.trackInflightStreamProposal(globalAccountName, sa, false)
+	cc.trackInflightConsumerProposal(globalAccountName, "S", ca, false)
+
+	asa := sjs.streamAssignment(globalAccountName, "S")
+	isa := sjs.streamAssignmentOrInflight(globalAccountName, "S")
+	aca := sjs.consumerAssignment(globalAccountName, "S", "C")
+	ica := sjs.consumerAssignmentOrInflight(globalAccountName, "S", "C")
+	sjs.mu.Unlock()
+
+	require_True(t, asa == nil)
+	require_True(t, aca == nil)
+	require_NotNil(t, isa)
+	require_NotNil(t, ica)
+
+	// Meta leader should return Offline (inflight assignment with no live peers)
+	// rather than NotFound, because it sees the inflight proposal.
+	nc, js := jsClientConnect(t, ml)
+	defer nc.Close()
+
+	_, err := js.StreamInfo("S")
+	require_Error(t, err, NewJSStreamOfflineError())
+	_, err = js.ConsumerInfo("S", "C")
+	require_Error(t, err, NewJSConsumerOfflineError())
+}
+
 func TestJetStreamClusterConcurrentConsumerCreateWithMaxConsumers(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()


### PR DESCRIPTION
Prevent stream/consumer INFO (and related) requests from returning 404 while the assignment is still inflight by using the inflight lookup variants.

The issue was introduced as a side-effect from correctly separating inflight from applied stream/consumer state in https://github.com/nats-io/nats-server/pull/7798. This could result in a consumer create followed by an info returning a "consumer not found".

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>