### PR TITLE
(2.14) Scheduling: validation, inflight leak, and target schedule replace

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4991,7 +4991,7 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 		if schedule, ok := nextMessageSchedule(hdr, ts); ok && !schedule.IsZero() {
 			fs.scheduling.add(seq, subj, schedule.UnixNano())
 			fs.lmb.schedules++
-		} else {
+		} else if getMessageScheduler(hdr) == _EMPTY_ {
 			fs.scheduling.removeSubject(subj)
 		}
 

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -855,14 +855,19 @@ func checkMsgHeadersPreClusteredProposal(
 			}
 		}
 		if scheduleNext := sliceHeader(JSScheduleNext, hdr); len(scheduleNext) > 0 && !sourced {
-			// If Nats-Schedule-Next is set, Nats-Scheduler should be set too, but:
+			// Clients may only use Nats-Schedule-Next to purge a schedule.
+			if bytesToString(scheduleNext) != JSScheduleNextPurge {
+				apiErr := NewJSMessageSchedulesSchedulerInvalidError()
+				return hdr, msg, 0, apiErr, apiErr
+			}
+			// Nats-Scheduler must accompany the purge and:
 			// - it must NOT be empty.
 			// - it must NOT match the publish subject.
 			if scheduler := sliceHeader(JSScheduler, hdr); len(scheduler) == 0 ||
 				bytesToString(scheduler) == subject || !IsValidPublishSubject(bytesToString(scheduler)) {
 				apiErr := NewJSMessageSchedulesSchedulerInvalidError()
 				return hdr, msg, 0, apiErr, apiErr
-			} else if bytesToString(scheduleNext) == JSScheduleNextPurge && !allowMsgSchedules {
+			} else if !allowMsgSchedules {
 				apiErr := NewJSMessageSchedulesDisabledError()
 				return hdr, msg, 0, apiErr, apiErr
 			}

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -9882,6 +9882,51 @@ func TestJetStreamClusterScheduledPurgeHeadersRequiresSchedulingEnabled(t *testi
 	}
 }
 
+func TestJetStreamClusterScheduledRearmHeaderRejectedFromClient(t *testing.T) {
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+
+			nc, js := jsClientConnect(t, c.randomServer())
+			defer nc.Close()
+
+			_, err := jsStreamCreate(t, nc, &StreamConfig{
+				Name:              "TEST",
+				Storage:           FileStorage,
+				Subjects:          []string{"foo.>"},
+				Replicas:          replicas,
+				AllowMsgSchedules: true,
+			})
+			require_NoError(t, err)
+
+			// Arm a schedule that fires shortly.
+			fireIn := 500 * time.Millisecond
+			m := nats.NewMsg("foo.schedule")
+			m.Header.Set("Nats-Schedule", fmt.Sprintf("@at %s", time.Now().Add(fireIn).Format(time.RFC3339Nano)))
+			m.Header.Set("Nats-Schedule-Target", "foo.msg")
+			_, err = js.PublishMsg(m)
+			require_NoError(t, err)
+
+			// An attacker with publish access should not be able to shift
+			// the schedule's next fire time by forging Nats-Schedule-Next.
+			attack := nats.NewMsg("foo.attacker")
+			attack.Header.Set(JSScheduleNext, time.Now().Add(100*365*24*time.Hour).Format(time.RFC3339Nano))
+			attack.Header.Set(JSScheduler, "foo.schedule")
+			_, err = js.PublishMsg(attack)
+			require_Error(t, err, NewJSMessageSchedulesSchedulerInvalidError())
+
+			// The schedule must still fire on time.
+			checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+				if _, err = js.GetLastMsg("TEST", "foo.msg"); err != nil {
+					return err
+				}
+				return nil
+			})
+		})
+	}
+}
+
 func TestJetStreamClusterScheduledDelayedMessageReversedHeaderOrder(t *testing.T) {
 	for _, replicas := range []int{1, 3} {
 		for _, storage := range []StorageType{FileStorage, MemoryStorage} {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -22295,6 +22295,58 @@ func TestJetStreamScheduledMessageNotDeactivated(t *testing.T) {
 	}
 }
 
+func TestJetStreamScheduledMessageDeliveryPreservesTargetSchedule(t *testing.T) {
+	for _, storageType := range []StorageType{FileStorage, MemoryStorage} {
+		t.Run(storageType.String(), func(t *testing.T) {
+			s := RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+
+			nc, js := jsClientConnect(t, s)
+			defer nc.Close()
+
+			_, err := jsStreamCreate(t, nc, &StreamConfig{
+				Name:              "TEST",
+				Subjects:          []string{"foo.>"},
+				Storage:           storageType,
+				AllowMsgSchedules: true,
+			})
+			require_NoError(t, err)
+
+			delay := func(d time.Duration) string {
+				return fmt.Sprintf("@at %s", time.Now().Add(d).Format(time.RFC3339Nano))
+			}
+
+			// Schedule on foo.A fires quickly and delivers onto foo.B.
+			mA := nats.NewMsg("foo.A")
+			mA.Header.Set("Nats-Schedule", delay(500*time.Millisecond))
+			mA.Header.Set("Nats-Schedule-Target", "foo.B")
+			_, err = js.PublishMsg(mA)
+			require_NoError(t, err)
+
+			// Independent schedule on foo.B fires later and delivers onto foo.C.
+			// Storing the fired delivery from foo.A onto foo.B must not tear
+			// down foo.B's own schedule.
+			mB := nats.NewMsg("foo.B")
+			mB.Header.Set("Nats-Schedule", delay(2*time.Second))
+			mB.Header.Set("Nats-Schedule-Target", "foo.C")
+			_, err = js.PublishMsg(mB)
+			require_NoError(t, err)
+
+			// Wait for the foo.A schedule to fire onto foo.B.
+			checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+				_, err = js.GetLastMsg("TEST", "foo.B")
+				return err
+			})
+
+			// foo.B's schedule must still fire onto foo.C.
+			checkFor(t, 4*time.Second, 200*time.Millisecond, func() error {
+				_, err = js.GetLastMsg("TEST", "foo.C")
+				return err
+			})
+		})
+	}
+}
+
 func TestJetStreamScheduledMessageParse(t *testing.T) {
 	// @at <ts>
 	t.Run("@at", func(t *testing.T) {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -311,7 +311,7 @@ func (ms *memStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, tt
 	if ms.scheduling != nil {
 		if schedule, ok := nextMessageSchedule(hdr, ts); ok && !schedule.IsZero() {
 			ms.scheduling.add(seq, subj, schedule.UnixNano())
-		} else {
+		} else if getMessageScheduler(hdr) == _EMPTY_ {
 			ms.scheduling.removeSubject(subj)
 		}
 

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -103,8 +103,7 @@ func (ms *MsgScheduling) isInflight(subj string) bool {
 
 func (ms *MsgScheduling) remove(seq uint64) {
 	if subj, ok := ms.seqToSubj[seq]; ok {
-		delete(ms.seqToSubj, seq)
-		delete(ms.schedules, subj)
+		ms.removeSubject(subj)
 	}
 }
 
@@ -113,6 +112,7 @@ func (ms *MsgScheduling) removeSubject(subj string) {
 		ms.ttls.Remove(sched.seq, sched.ts)
 		delete(ms.schedules, subj)
 		delete(ms.seqToSubj, sched.seq)
+		delete(ms.inflight, subj)
 	}
 }
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -5148,10 +5148,10 @@ func (mset *stream) setupStore(fsCfg *FileStoreConfig) error {
 	mset.store.RegisterProcessJetStreamMsg(func(im *inMsg) {
 		if mset.IsClustered() {
 			if mset.IsLeader() {
-				mset.processClusteredInboundMsg(im.subj, im.rply, im.hdr, im.msg, im.mt, false)
+				mset.processClusteredInboundMsg(im.subj, im.rply, im.hdr, im.msg, im.mt, true)
 			}
 		} else {
-			mset.processJetStreamMsg(im.subj, im.rply, im.hdr, im.msg, 0, 0, im.mt, false, true)
+			mset.processJetStreamMsg(im.subj, im.rply, im.hdr, im.msg, 0, 0, im.mt, true, true)
 		}
 	})
 	mset.mu.Unlock()
@@ -6460,7 +6460,18 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 				}
 			}
 			if scheduleNext := sliceHeader(JSScheduleNext, hdr); len(scheduleNext) > 0 && !sourced {
-				// If Nats-Schedule-Next is set, Nats-Scheduler should be set too, but:
+				// Clients may only use Nats-Schedule-Next to purge a schedule.
+				if bytesToString(scheduleNext) != JSScheduleNextPurge {
+					apiErr := NewJSMessageSchedulesSchedulerInvalidError()
+					if canRespond {
+						resp.PubAck = &PubAck{Stream: name}
+						resp.Error = apiErr
+						b, _ := json.Marshal(resp)
+						outq.sendMsg(reply, b)
+					}
+					return apiErr
+				}
+				// Nats-Scheduler must accompany the purge and:
 				// - it must NOT be empty.
 				// - it must NOT match the publish subject.
 				if scheduler := sliceHeader(JSScheduler, hdr); len(scheduler) == 0 ||
@@ -6473,7 +6484,7 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 						outq.sendMsg(reply, b)
 					}
 					return apiErr
-				} else if bytesToString(scheduleNext) == JSScheduleNextPurge && !allowMsgSchedules {
+				} else if !allowMsgSchedules {
 					apiErr := NewJSMessageSchedulesDisabledError()
 					if canRespond {
 						resp.PubAck = &PubAck{Stream: name}

--- a/server/thw/thw.go
+++ b/server/thw/thw.go
@@ -155,8 +155,11 @@ func (hw *HashWheel) expireTasks(ts int64, callback func(seq uint64, expires int
 		slotLowest := int64(math.MaxInt64)
 		for seq, expires := range s.entries {
 			if expires <= ts && callback(seq, expires) {
-				delete(s.entries, seq)
-				hw.count--
+				// Only remove if not done so already by the callback.
+				if _, ok := s.entries[seq]; ok {
+					delete(s.entries, seq)
+					hw.count--
+				}
 				continue
 			}
 			if expires < slotLowest {


### PR DESCRIPTION
Fixes three small issues with message scheduling:
1. Reject client publishes with a `Nats-Schedule-Next` header that does not equal `purge`. Ensures clients can not change the timestamps of the schedules, if they're not updating the schedule directly.
2. Inflight state could leak if schedule was removed while there was still one inflight.
3. A schedule can only be updated/removed if it is not by a scheduled message.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>