### PR TITLE
[FIXED] Don't advance clseq when proposal fails

### DIFF
--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -1029,9 +1029,13 @@ func recalculateClusteredSeq(mset *stream, needStreamLock bool) (lseq uint64) {
 func commitSingleMsg(
 	diff *batchStagedDiff, mset *stream, subject string, reply string, hdr []byte, msg []byte, name string,
 	jsa *jsAccount, mt *msgTrace, node RaftNode, replicas int, lseq uint64,
-) {
-	diff.commit(mset)
+) error {
+	// Do proposal.
 	esm := encodeStreamMsgAllowCompress(subject, reply, hdr, msg, mset.clseq, time.Now().UnixNano(), false)
+	if err := node.Propose(esm); err != nil {
+		return err
+	}
+
 	var mtKey uint64
 	if mt != nil {
 		mtKey = mset.clseq
@@ -1041,9 +1045,7 @@ func commitSingleMsg(
 		mset.mt[mtKey] = mt
 	}
 
-	// Do proposal.
-	_ = node.Propose(esm)
-	// The proposal can fail, but we always account for trying.
+	diff.commit(mset)
 	mset.clseq++
 	mset.trackReplicationTraffic(node, len(esm), replicas)
 
@@ -1053,4 +1055,5 @@ func commitSingleMsg(
 		lerr := fmt.Errorf("JetStream stream '%s > %s' has high message lag", jsa.acc().Name, name)
 		mset.srv.RateLimitWarnf("%s", lerr.Error())
 	}
+	return nil
 }

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4422,15 +4422,15 @@ func (js *jetStream) processStreamLeaderChange(mset *stream, isLeader bool) {
 		if node := mset.raftNode(); node != nil && !node.Quorum() && time.Since(node.Created()) > 5*time.Second {
 			s.sendStreamLostQuorumAdvisory(mset)
 		}
-
-		// Clear clseq. If we become leader again, it will be fixed up
-		// automatically on the next mset.setLeader call.
-		mset.clMu.Lock()
-		if mset.clseq > 0 {
-			mset.clseq = 0
-		}
-		mset.clMu.Unlock()
 	}
+
+	// Clear clseq on every leader transition. recalculateClusteredSeq
+	// repopulates it on the next proposal.
+	mset.clMu.Lock()
+	if mset.clseq > 0 {
+		mset.clseq = 0
+	}
+	mset.clMu.Unlock()
 
 	// Tell stream to switch leader status.
 	mset.setLeader(isLeader)
@@ -9869,9 +9869,9 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 		return err
 	}
 
-	commitSingleMsg(diff, mset, subject, reply, hdr, msg, name, jsa, mt, node, r, lseq)
+	err = commitSingleMsg(diff, mset, subject, reply, hdr, msg, name, jsa, mt, node, r, lseq)
 	mset.clMu.Unlock()
-	return nil
+	return err
 }
 
 func (mset *stream) getAndDeleteMsgTrace(lseq uint64) *msgTrace {

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -10083,3 +10083,96 @@ func TestJetStreamClusterConsumerSelectStartingSeqDeferred(t *testing.T) {
 		return nil
 	})
 }
+
+func TestJetStreamClusterProposeFailureDoesNotDriftClseq(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:               "TEST",
+		Subjects:           []string{"foo"},
+		Replicas:           3,
+		Storage:            FileStorage,
+		AllowAtomicPublish: true,
+	})
+	require_NoError(t, err)
+
+	// Populate the stream with some messages.
+	for range 10 {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		return checkState(t, c, globalAccountName, "TEST")
+	})
+
+	sl := c.streamLeader(globalAccountName, "TEST")
+	mset, err := sl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	rn := mset.raftNode().(*raft)
+
+	// forceProposeFailure quickly switches the underlying Raft state, so any
+	// node.Propose / node.ProposeMulti call inside fn returns errNotLeader.
+	// We deliberately do NOT touch n.leaderState, the upper layer still sees
+	// the node as leader, reproducing the race window.
+	forceProposeFailure := func(fn func() error) error {
+		prevState := rn.state.Swap(int32(Follower))
+		err = fn()
+		rn.state.Store(prevState)
+		return err
+	}
+
+	readClseq := func() uint64 {
+		mset.clMu.Lock()
+		defer mset.clMu.Unlock()
+		return mset.clseq
+	}
+
+	t.Run("SingleMessage", func(t *testing.T) {
+		before := readClseq()
+		err = forceProposeFailure(func() error {
+			return mset.processClusteredInboundMsg("foo", _EMPTY_, nil, nil, nil, false)
+		})
+		require_Error(t, err, errNotLeader)
+		require_Equal(t, readClseq(), before)
+	})
+
+	t.Run("AtomicBatch", func(t *testing.T) {
+		hdr := genHeader(nil, "Nats-Batch-Id", "uuid")
+		hdr = genHeader(hdr, "Nats-Batch-Sequence", "1")
+		hdr = genHeader(hdr, "Nats-Batch-Commit", "1")
+
+		before := readClseq()
+		err = forceProposeFailure(func() error {
+			return mset.processJetStreamAtomicBatchMsg("uuid", "foo", _EMPTY_, hdr, nil, nil)
+		})
+		require_Error(t, err, errNotLeader)
+		require_Equal(t, readClseq(), before)
+	})
+
+	// Confirm we can still publish a new message.
+	_, err = js.Publish("foo", nil)
+	require_NoError(t, err)
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		state, err := checkStateAndErr(t, c, globalAccountName, "TEST")
+		if err != nil {
+			return err
+		}
+		if state.Msgs != 11 {
+			return fmt.Errorf("expected 11 messages, got %d", state.Msgs)
+		}
+		return nil
+	})
+
+	// Verify no Raft node on any replica reports itself as deleted.
+	for _, s := range c.servers {
+		mset, err = s.globalAccount().lookupStream("TEST")
+		require_NoError(t, err)
+		rn = mset.raftNode().(*raft)
+		require_NotNil(t, rn)
+		require_False(t, rn.IsDeleted())
+	}
+}

--- a/server/stream.go
+++ b/server/stream.go
@@ -7298,18 +7298,19 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		lseq = recalculateClusteredSeq(mset, false)
 	}
 
-	rollback := func(seq uint64) {
+	oclseq := mset.clseq
+	rollback := func() {
 		if isClustered {
 			// Only need to move the clustered sequence back if the batch fails to commit.
 			// Other changes were staged but not applied, so this is the only thing we need to do.
-			mset.clseq -= seq - 1
+			mset.clseq = oclseq
 		}
 		mset.clMu.Unlock()
 	}
 
-	errorOnUnsupported := func(seq uint64, header string) *ApiError {
+	errorOnUnsupported := func(header string) *ApiError {
 		apiErr := NewJSAtomicPublishUnsupportedHeaderBatchError(header)
-		rollback(seq)
+		rollback()
 		b.cleanupLocked(batchId, batches)
 		batches.mu.Unlock()
 		mset.mu.Unlock()
@@ -7341,7 +7342,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		} else if sm, err = b.store.LoadMsg(seq, &smv); sm != nil && err == nil {
 			bsubj, bhdr, bmsg = sm.subj, sm.hdr, sm.msg
 		} else {
-			rollback(seq)
+			rollback()
 			b.cleanupLocked(batchId, batches)
 			batches.mu.Unlock()
 			mset.mu.Unlock()
@@ -7360,11 +7361,11 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 
 		// Reject unsupported headers.
 		if getExpectedLastMsgId(bhdr) != _EMPTY_ {
-			return errorOnUnsupported(seq, JSExpectedLastMsgId)
+			return errorOnUnsupported(JSExpectedLastMsgId)
 		}
 
 		if bhdr, bmsg, _, apiErr, err = checkMsgHeadersPreClusteredProposal(diff, mset, csubj, bsubj, bhdr, bmsg, false, name, jsa, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, discard, discardNewPer, maxMsgSize, maxMsgs, maxMsgsPer, maxBytes); err != nil {
-			rollback(seq)
+			rollback()
 			b.cleanupLocked(batchId, batches)
 			batches.mu.Unlock()
 			mset.mu.Unlock()
@@ -7424,22 +7425,24 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		mset.mu.Unlock()
 		// Do a single multi proposal. This ensures we get to push all entries to the proposal queue in-order
 		// and not interleaved with other proposals.
-		diff.commit(mset)
-		_ = node.ProposeMulti(entries)
-		// The proposal can fail, but we always account for trying.
-		mset.trackReplicationTraffic(node, sz, r)
+		if err = node.ProposeMulti(entries); err == nil {
+			diff.commit(mset)
+			mset.trackReplicationTraffic(node, sz, r)
 
-		// Check to see if we are being overrun.
-		// TODO(dlc) - Make this a limit where we drop messages to protect ourselves, but allow to be configured.
-		if mset.clseq-(lseq+mset.clfs) > streamLagWarnThreshold {
-			lerr := fmt.Errorf("JetStream stream '%s > %s' has high message lag", jsa.acc().Name, name)
-			s.RateLimitWarnf("%s", lerr.Error())
+			// Check to see if we are being overrun.
+			// TODO(dlc) - Make this a limit where we drop messages to protect ourselves, but allow to be configured.
+			if mset.clseq-(lseq+mset.clfs) > streamLagWarnThreshold {
+				lerr := fmt.Errorf("JetStream stream '%s > %s' has high message lag", jsa.acc().Name, name)
+				s.RateLimitWarnf("%s", lerr.Error())
+			}
+		} else {
+			mset.clseq = oclseq
 		}
 		mset.clMu.Unlock()
 	}
 	b.cleanupLocked(batchId, batches)
 	batches.mu.Unlock()
-	return nil
+	return err
 }
 
 // processJetStreamFastBatchMsg processes a JetStream message that's part of an atomic batch publish.
@@ -7771,9 +7774,9 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 		mset.clMu.Unlock()
 		return mset.processJetStreamMsgWithBatch(subject, reply, hdr, msg, 0, 0, mt, false, true, batch)
 	}
-	commitSingleMsg(diff, mset, subject, reply, hdr, msg, name, jsa, mt, node, r, lseq)
+	err = commitSingleMsg(diff, mset, subject, reply, hdr, msg, name, jsa, mt, node, r, lseq)
 	mset.clMu.Unlock()
-	return nil
+	return err
 }
 
 // Used to signal inbound message to registered consumers.


### PR DESCRIPTION
Depending on timing, replicas could log the following error message:
```
Error applying entries to 'acc > stream': last sequence mismatch
```

This would result in `mset.resetClusteredState` being called and subsequently violating Raft guarantees due to deleting the Raft state.

Timeline:
- `processClusteredInboundMsg` has `isLeader=true`, so it continues.
- In the meantime this server steps down as leader.
- `commitSingleMsg` tries the proposal, silently fails with `errNotLeader`, but still increments `mset.clseq`.
- This server is re-elected as leader.
- `processClusteredInboundMsg` receives the next message and successfully proposes an entry with a too high `mset.clseq`, which results in the `errLastSeqMismatch` when applying.

Since `processStreamLeaderChange`, `processClusteredInboundMsg` and Raft logic are all handled asynchronously, this can happen under rare circumstances. Normally though these will execute such that `mset.clseq` is reset to zero in `processStreamLeaderChange`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>