### PR TITLE
Fix auth callout overriding successful local auth

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -693,9 +693,9 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 			}
 		}
 
-		// If we are here we have an auth callout defined and we have failed auth so far
+		// If we are here we have an auth callout defined and we have failed auth so far,
 		// so we will callout to our auth backend for processing.
-		if !skip {
+		if !authorized && !skip {
 			authorized, reason = s.processClientOrLeafCallout(c, opts, proxyRequired, trustedProxy, ujwt)
 		}
 		// Check if we are authorized and in the auth callout account, and if so add in deny publish permissions for the auth subject.

--- a/server/auth_callout_test.go
+++ b/server/auth_callout_test.go
@@ -395,6 +395,46 @@ func TestAuthCalloutBasics(t *testing.T) {
 	}
 }
 
+func TestAuthCalloutConfiguredUserBypassesCallout(t *testing.T) {
+	conf := `
+		listen: "127.0.0.1:-1"
+		server_name: A
+		authorization {
+			timeout: 1s
+			users: [
+				{ user: "auth", password: "pwd" }
+				{ user: "local", password: "pwd" }
+			]
+			auth_callout {
+				# Needs to be a public account nkey, will work for both server config and operator mode.
+				issuer: "ABJHLOVMPA4CI6R5KLNGOB4GSLNIY7IOUPAJC4YFNDLQVIOBYQGUWVLA"
+				# users that will power the auth callout service.
+				auth_users: [ auth ]
+			}
+		}
+	`
+	callouts := uint32(0)
+	handler := func(m *nats.Msg) {
+		atomic.AddUint32(&callouts, 1)
+		m.Respond(nil)
+	}
+	at := NewAuthTest(t, conf, handler, nats.UserInfo("auth", "pwd"))
+	defer at.Cleanup()
+
+	// Configured user should authenticate locally and not be delegated.
+	nc := at.Connect(nats.UserInfo("local", "pwd"))
+	defer nc.Close()
+	if got := atomic.LoadUint32(&callouts); got != 0 {
+		t.Fatalf("Expected no auth callout for configured user, got %v", got)
+	}
+
+	// Unknown users should still use callout (and fail since handler returns nil).
+	at.RequireConnectError(nats.UserInfo("unknown", "pwd"))
+	if got := atomic.LoadUint32(&callouts); got == 0 {
+		t.Fatal("Expected auth callout to be invoked for unknown user")
+	}
+}
+
 func TestAuthCalloutMQTTJwtPassedInConnectOptions(t *testing.T) {
 	storeDir := t.TempDir()
 	conf := fmt.Sprintf(`


### PR DESCRIPTION
## Summary
- make auth callout a true fallback in config mode: only invoke callout when prior local auth did not already succeed
- add regression test proving configured users bypass callout
- keep delegation behavior for unknown users

## Why
Issue #8044 reports that enabling auth callout can override other auth modes (user/password, token, cert mapping). This patch preserves existing local success and only delegates on failed local auth.

Closes #8044.