### PR TITLE
Log invalid JWT imports as server errors

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3610,7 +3610,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 				err = a.AddStreamImportWithClaim(acc, from, to, i)
 			}
 			if err != nil {
-				s.Debugf("Error adding stream import to account [%s]: %v", tl, err.Error())
+				s.Errorf("Error adding stream import to account [%s]: %v", tl, err.Error())
 				incompleteImports = append(incompleteImports, i)
 			}
 		case jwt.Service:
@@ -3620,7 +3620,7 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 			}
 			s.Debugf("Adding service import %s:%q for %s:%q", atl, from, tl, to)
 			if err := a.AddServiceImportWithClaim(acc, from, to, i); err != nil {
-				s.Debugf("Error adding service import to account [%s]: %v", tl, err.Error())
+				s.Errorf("Error adding service import to account [%s]: %v", tl, err.Error())
 				incompleteImports = append(incompleteImports, i)
 			}
 		}

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -1970,8 +1970,8 @@ func TestJWTAccountURLResolverPermanentFetchFailure(t *testing.T) {
 	o := LoadConfig(confA)
 	sA := RunServer(o)
 	defer sA.Shutdown()
-	l := &captureDebugLogger{dbgCh: make(chan string, 100)} // has enough space to not block
-	sA.SetLogger(l, true, false)
+	l := &captureErrorLogger{errCh: make(chan string, 100)} // has enough space to not block
+	sA.SetLogger(l, false, false)
 	// Create clients
 	ncA := natsConnect(t, sA.ClientURL(), createUserCreds(t, nil, impkp))
 	defer ncA.Close()
@@ -1988,17 +1988,17 @@ func TestJWTAccountURLResolverPermanentFetchFailure(t *testing.T) {
 	defer tmr.Stop()
 	for {
 		select {
-		case line := <-l.dbgCh:
-			if strings.HasPrefix(line, "Error adding stream import to account") {
-				importErrCnt++
+			case line := <-l.errCh:
+				if strings.HasPrefix(line, "Error adding stream import to account") {
+					importErrCnt++
+				}
+			case <-tmr.C:
+				// connecting and updating, each cause 3 traces (2 + 1 on iteration) + 1 xtra fetch
+				if importErrCnt != 7 {
+					t.Fatalf("Expected 7 error logs, got %d", importErrCnt)
+				}
+				return
 			}
-		case <-tmr.C:
-			// connecting and updating, each cause 3 traces (2 + 1 on iteration) + 1 xtra fetch
-			if importErrCnt != 7 {
-				t.Fatalf("Expected 7 debug traces, got %d", importErrCnt)
-			}
-			return
-		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- promote JWT import add failures from debug to server error logs
- keep retry/reconciliation behavior unchanged; only log severity changes
- update resolver regression test to assert error logs instead of debug traces

## Why
When decentralized/JWT account imports are invalid (for example due to export authorization constraints), operators should see actionable startup/runtime errors without requiring debug logging.

Closes #7983.