### PR TITLE
(2.14) [IMPROVED] Defer consumer reset local state until raft apply

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2813,21 +2813,27 @@ VALID:
 	if seq <= 0 {
 		seq = 1
 	}
-	o.resetLocalStartingSeq(seq)
-	// Clustered mode and R>1.
+	// The replicated path requires quorum first before the reset actually takes effect.
 	if o.node != nil {
+		if !o.isLeader() {
+			return 0, false, nil
+		}
 		b := make([]byte, 1+8+len(reply))
 		b[0] = byte(resetSeqOp)
 		var le = binary.LittleEndian
 		le.PutUint64(b[1:], seq)
 		copy(b[1+8:], reply)
 		o.propose(b[:])
-		if o.rsm == nil {
-			o.rsm = make(map[string]bool, 1)
+		if reply != _EMPTY_ {
+			if o.rsm == nil {
+				o.rsm = make(map[string]bool, 1)
+			}
+			o.rsm[reply] = internal
 		}
-		o.rsm[reply] = internal
 		return seq, false, nil
-	} else if o.store != nil {
+	}
+	o.resetLocalStartingSeq(seq)
+	if o.store != nil {
 		o.store.Reset(seq - 1)
 		// Cleanup messages that lost interest.
 		if o.retention == InterestPolicy {

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -7917,6 +7917,76 @@ func TestJetStreamClusterConsumerResetStartingSequenceToAgreedState(t *testing.T
 	}
 }
 
+func TestJetStreamClusterConsumerResetDoesNotMutateLocalStateBeforeQuorum(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	sub, err := js.PullSubscribe("foo", "CONSUMER", nats.ConsumerReplicas(3))
+	require_NoError(t, err)
+	defer sub.Unsubscribe()
+
+	for range 3 {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+
+	// Deliver two messages without acking so pending/dseq/sseq advance.
+	msgs, err := sub.Fetch(2, nats.MaxWait(time.Second))
+	require_NoError(t, err)
+	require_Len(t, len(msgs), 2)
+
+	cl := c.consumerLeader(globalAccountName, "TEST", "CONSUMER")
+	require_NotNil(t, cl)
+	mset, err := cl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	o := mset.lookupConsumer("CONSUMER")
+	require_NotNil(t, o)
+
+	// Hold the consumer lock while we call resetStartingSeqLocked and then
+	// immediately inspect state. Holding the lock blocks applyConsumerEntries,
+	// so any state change we observe here must have been done synchronously
+	// by the reset path itself.
+	o.mu.Lock()
+	if !o.isLeader() {
+		o.mu.Unlock()
+		t.Fatal("consumer leader changed")
+	}
+
+	sseq, dseq, adflr, asflr, pending := o.sseq, o.dseq, o.adflr, o.asflr, len(o.pending)
+	_, _, err = o.resetStartingSeqLocked(0, _EMPTY_, false)
+	if err != nil {
+		o.mu.Unlock()
+		require_NoError(t, err)
+	}
+
+	if sseq != o.sseq || dseq != o.dseq || adflr != o.adflr || asflr != o.asflr || pending != len(o.pending) {
+		o.mu.Unlock()
+		t.Fatal("leader local state mutated before raft apply")
+	}
+	o.mu.Unlock()
+
+	// The reset should still apply once the Raft entry commits.
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		o.mu.RLock()
+		defer o.mu.RUnlock()
+		if o.sseq != 1 || o.dseq != 1 || len(o.pending) != 0 {
+			return fmt.Errorf("reset has not applied yet: sseq=%d dseq=%d pending=%d",
+				o.sseq, o.dseq, len(o.pending))
+		}
+		return nil
+	})
+}
+
 func TestJetStreamClusterSubjectDeleteMarkers(t *testing.T) {
 	for _, storage := range []StorageType{FileStorage, MemoryStorage} {
 		t.Run(storage.String(), func(t *testing.T) {


### PR DESCRIPTION
When using the consumer reset API for a replicated consumer, the reset would happen twice: once for the leader and then again in the apply path. We should wait for the reset to get quorum before actually performing it, otherwise if the consumer is actively in use, this would appear as a double reset.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>