### PR TITLE
(2.14) [FIXED] Don't disable writes on short/oversized block reads

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5017,6 +5017,8 @@ func isReadErr(err error) bool {
 		errors.Is(err, errPartialCache) ||
 		errors.Is(err, errCorruptState) ||
 		errors.Is(err, errPriorState) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, errMsgBlkTooBig) ||
 		errors.As(err, &badMsg)
 }
 
@@ -7029,27 +7031,49 @@ func (fs *fileStore) checkAndFlushLastBlock() error {
 }
 
 // This will check all the checksums on messages and report back any sequence numbers with errors.
-func (fs *fileStore) checkMsgs() *LostStreamData {
+func (fs *fileStore) checkMsgs() (*LostStreamData, error) {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 
-	fs.checkAndFlushLastBlock()
+	var firstErr error
+	storeErr := func(err error) error {
+		fs.warn("checkMsgs: %v", err)
+		if firstErr == nil {
+			firstErr = err
+		}
+		return err
+	}
+
+	if err := fs.checkAndFlushLastBlock(); err != nil {
+		return nil, storeErr(fmt.Errorf("flush of last block failed: %w", err))
+	}
 
 	// Clear any global subject state.
 	fs.psim, fs.tsl = fs.psim.Empty(), 0
 
 	for _, mb := range fs.blks {
 		// Make sure encryption loaded if needed for the block.
-		fs.loadEncryptionForMsgBlock(mb)
+		if err := fs.loadEncryptionForMsgBlock(mb); err != nil {
+			_ = storeErr(fmt.Errorf("loading encryption for block %d failed: %w", mb.index, err))
+			continue
+		}
 		// FIXME(dlc) - check tombstones here too?
-		if ld, _, _ := mb.rebuildState(); ld != nil {
+		ld, _, err := mb.rebuildState()
+		if err != nil {
+			_ = storeErr(fmt.Errorf("rebuildState for block %d failed: %w", mb.index, err))
+			continue
+		}
+		if ld != nil {
 			// Rebuild fs state too.
 			fs.rebuildStateLocked(ld)
 		}
-		fs.populateGlobalPerSubjectInfo(mb)
+		if err = fs.populateGlobalPerSubjectInfo(mb); err != nil {
+			_ = storeErr(fmt.Errorf("populating per-subject info for block %d failed: %w", mb.index, err))
+			continue
+		}
 	}
 
-	return fs.ld
+	return fs.ld, firstErr
 }
 
 // Lock should be held.
@@ -10042,7 +10066,6 @@ func (fs *fileStore) purge(fseq uint64) (purged uint64, rerr error) {
 	fs.addMsgBlock(lmb)
 
 	// Move the msgs directory out of the way, will delete out of band.
-	// FIXME(dlc) - These can error and we need to change api above to propagate?
 	mdir := filepath.Join(fs.fcfg.StoreDir, msgDir)
 	ndir := filepath.Join(fs.fcfg.StoreDir, newMsgDir)
 	pdir := filepath.Join(fs.fcfg.StoreDir, purgeDir)
@@ -12123,8 +12146,18 @@ func (fs *fileStore) Snapshot(deadline time.Duration, checkMsgs, includeConsumer
 	fs.mu.Unlock()
 
 	if checkMsgs {
-		ld := fs.checkMsgs()
+		ld, err := fs.checkMsgs()
+		clearSips := func() {
+			fs.mu.Lock()
+			fs.sips--
+			fs.mu.Unlock()
+		}
+		if err != nil {
+			clearSips()
+			return nil, fmt.Errorf("snapshot check failed: %w", err)
+		}
 		if ld != nil && len(ld.Msgs) > 0 {
+			clearSips()
 			return nil, fmt.Errorf("snapshot check detected %d bad messages", len(ld.Msgs))
 		}
 	}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1314,7 +1314,9 @@ func TestFileStoreBitRot(t *testing.T) {
 			t.Fatalf("Expected %d msgs, got %d", toStore, state.Msgs)
 		}
 
-		if ld := fs.checkMsgs(); ld != nil && len(ld.Msgs) > 0 {
+		if ld, err := fs.checkMsgs(); err != nil {
+			t.Fatalf("Unexpected error from checkMsgs: %v", err)
+		} else if ld != nil && len(ld.Msgs) > 0 {
 			t.Fatalf("Expected to have no corrupt msgs, got %d", len(ld.Msgs))
 		}
 
@@ -1339,7 +1341,8 @@ func TestFileStoreBitRot(t *testing.T) {
 			os.WriteFile(lmb.mfn, contents, 0644)
 			fs.mu.Unlock()
 
-			ld := fs.checkMsgs()
+			ld, err := fs.checkMsgs()
+			require_NoError(t, err)
 			if len(ld.Msgs) > 0 {
 				break
 			}
@@ -1362,7 +1365,9 @@ func TestFileStoreBitRot(t *testing.T) {
 		defer fs.Stop()
 
 		// checkMsgs will repair the underlying store, so checkMsgs should be clean now.
-		if ld := fs.checkMsgs(); ld != nil {
+		if ld, err := fs.checkMsgs(); err != nil {
+			t.Fatalf("Unexpected error from checkMsgs: %v", err)
+		} else if ld != nil {
 			// If we have no msgs left this will report the head msgs as lost again.
 			if state := fs.State(); state.Msgs > 0 {
 				t.Fatalf("Expected no errors restoring checked and fixed filestore, got %+v", ld)
@@ -4904,7 +4909,9 @@ func TestFileStoreMsgBlkFailOnKernelFaultLostDataReporting(t *testing.T) {
 		defer fs.Stop()
 
 		// Need checkMsgs to catch interior one.
-		require_True(t, fs.checkMsgs() != nil)
+		ld, err := fs.checkMsgs()
+		require_NoError(t, err)
+		require_True(t, ld != nil)
 
 		state = fs.State()
 		require_Equal(t, state.FirstSeq, 94)
@@ -13796,6 +13803,15 @@ func TestFileStoreSetWriteErrIgnoresReadErrors(t *testing.T) {
 		errCorruptState,
 		errPriorState,
 		errBadMsg{fn: "block.blk", detail: "invalid checksum"},
+		// Short reads of on-disk blocks surface as io.ErrUnexpectedEOF from
+		// io.ReadFull in loadBlock. Treat like other on-disk-data read errors:
+		// log + rebuild, don't disable writes.
+		io.ErrUnexpectedEOF,
+		// A block whose size doesn't fit in an int is an on-disk-data issue too.
+		errMsgBlkTooBig,
+		// Wrapped variants should also be recognized.
+		fmt.Errorf("wrapped: %w", io.ErrUnexpectedEOF),
+		fmt.Errorf("wrapped: %w", errCorruptState),
 	}
 
 	fs.mu.Lock()


### PR DESCRIPTION
Don't disable writes on short/oversized block reads, which previously stopped the store. Also makes `checkMsgs`, which is called as part of stream backups, propagate any errors instead of allowing a backup to go through. And, remove a (since 2.14) stale FIXME comment.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>