### PR TITLE
(2.14) [FIXED] Remove Nats-Scheduler header from sourced message

### DIFF
--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -9770,6 +9770,69 @@ func TestJetStreamClusterScheduledMessageSubjectSourcingFallback(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterScheduledMessageSubjectSourcingRepeatingNotStuck(t *testing.T) {
+	for _, replicas := range []int{1, 3} {
+		for _, storage := range []StorageType{FileStorage, MemoryStorage} {
+			t.Run(fmt.Sprintf("R%d/%s", replicas, storage), func(t *testing.T) {
+				c := createJetStreamClusterExplicit(t, "R3S", 3)
+				defer c.shutdown()
+
+				nc, js := jsClientConnect(t, c.randomServer())
+				defer nc.Close()
+
+				cfg := &StreamConfig{
+					Name:              "SchedulesEnabled",
+					Subjects:          []string{"foo.*"},
+					Storage:           storage,
+					Replicas:          replicas,
+					AllowMsgSchedules: true,
+				}
+				_, err := jsStreamCreate(t, nc, cfg)
+				require_NoError(t, err)
+
+				// Seed foo.data with a message that carries a stale Nats-Scheduler header.
+				m := nats.NewMsg("foo.data")
+				m.Header.Set("Nats-Schedule-Next", "purge")
+				m.Header.Set("Nats-Scheduler", "foo.victim")
+				_, err = js.PublishMsg(m)
+				require_NoError(t, err)
+
+				// Repeating schedule sourcing from foo.data. If the Nats-Scheduler is not
+				// stripped from the source, the scheduled output carries two Nats-Scheduler
+				// headers and the store's schedule update path targets the wrong scheduler
+				// subject. Resulting in the scheduling getting stuck.
+				m = nats.NewMsg("foo.sb")
+				m.Header.Set("Nats-Schedule", "@every 1s")
+				m.Header.Set("Nats-Schedule-Target", "foo.publish")
+				m.Header.Set("Nats-Schedule-Source", "foo.data")
+				_, err = js.PublishMsg(m)
+				require_NoError(t, err)
+
+				// Wait until the schedule has fired multiple times. With the bug it fires
+				// once and then get stuck, without it it keeps firing on its @every 1s cadence.
+				checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+					mi, err := js.StreamInfo("SchedulesEnabled", &nats.StreamInfoRequest{SubjectsFilter: "foo.publish"})
+					if err != nil {
+						return err
+					}
+					if n := mi.State.Subjects["foo.publish"]; n < 3 {
+						return fmt.Errorf("expected at least 3 messages on foo.publish, got %d", n)
+					}
+					return nil
+				})
+
+				// The schedule message itself must still be present.
+				rsm, err := js.GetLastMsg("SchedulesEnabled", "foo.sb")
+				require_NoError(t, err)
+				require_Equal(t, rsm.Header.Get("Nats-Schedule"), "@every 1s")
+				checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+					return checkState(t, c, globalAccountName, "SchedulesEnabled")
+				})
+			})
+		}
+	}
+}
+
 func TestJetStreamClusterScheduledDelayedMessageRollup(t *testing.T) {
 	for _, replicas := range []int{1, 3} {
 		for _, storage := range []StorageType{FileStorage, MemoryStorage} {

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -208,9 +208,10 @@ func (ms *MsgScheduling) getScheduledMessages(loadMsg func(seq uint64, smv *Stor
 			// And in the case of headers, we'll copy all of them, but make changes.
 			hdr, msg := copyBytes(sm.hdr), copyBytes(sm.msg)
 
-			// Strip headers specific to the schedule.
-			hdr = removeHeaderIfPresent(hdr, JSSchedulePattern)
-			hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Schedule-")
+			// Strip headers specific to message scheduling.
+			// Covers Nats-Schedule, Nats-Schedule-*, and Nats-Scheduler.
+			hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Schedule")
+			// Strip headers that could prevent persisting this scheduled message.
 			hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Expected-")
 			hdr = removeHeaderIfPresent(hdr, JSMsgId)
 			hdr = removeHeaderIfPresent(hdr, JSMessageTTL)


### PR DESCRIPTION
Fixes an issue with `Nats-Schedule-Source` that allows to source the content of a delayed message that contains the `Nats-Scheduler` header. The latter would then make the triggering schedule become stuck.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>