### PR TITLE
[ADDED] Tag-aware queue routing for cluster routes

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -5379,16 +5379,12 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 					// we are connected to an older server and we don't know).
 					// Pick this one and be done.
 					//
-					// When preferMatching is set, defer all remote peers so a
-					// directly-connected sub later in the walk can win. Among
-					// deferred peers, matching tags beat non-matching.
-					// Guard on dst == ROUTER because LEAF subs reach this branch
-					// for gateway-originated traffic (no sub.origin) and have no
-					// route struct.
-					if preferMatching && dst == ROUTER {
-						if sub.client.route.tagsMatch {
-							rsub = sub
-						} else if rsub == nil {
+					// With preferMatching, defer non-matching peers (overwriting
+					// weaker rsubs to preserve ROUTER > leaf priority). dst ==
+					// ROUTER guards the route deref for LEAF subs from gateway
+					// traffic.
+					if preferMatching && dst == ROUTER && !sub.client.route.tagsMatch {
+						if rsub == nil || rsub.client.kind != ROUTER || len(rsub.origin) > 0 {
 							rsub = sub
 						}
 						continue

--- a/server/client.go
+++ b/server/client.go
@@ -5382,7 +5382,10 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 					// When preferMatching is set, defer all remote peers so a
 					// directly-connected sub later in the walk can win. Among
 					// deferred peers, matching tags beat non-matching.
-					if preferMatching {
+					// Guard on dst == ROUTER because LEAF subs reach this branch
+					// for gateway-originated traffic (no sub.origin) and have no
+					// route struct.
+					if preferMatching && dst == ROUTER {
 						if sub.client.route.tagsMatch {
 							rsub = sub
 						} else if rsub == nil {

--- a/server/client.go
+++ b/server/client.go
@@ -5239,7 +5239,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 	// Declared here because of goto.
 	var queues [][]byte
 
-	preferMatching := c.srv.getOpts().Cluster.PreferMatchingTags
+	matchTagsEnabled := len(c.srv.getOpts().Cluster.MatchingTags) > 0
 
 	var leafOrigin string
 	switch c.kind {
@@ -5318,15 +5318,16 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 				}
 			}
 			qsubs = ql
-		} else if preferMatching && len(qsubs) > 1 {
-			// Pre-scan to a unified "AZ-local" pool: local CLIENTs plus
-			// routed CLIENTs whose remote server's tags overlap ours.
-			// When non-empty, restrict the random pick (sindex below) to
-			// this pool so traffic stays in-AZ and balances across local
-			// and matching peers. Empty pool => fall through to the
-			// original cluster-wide selection.
-			var _az [32]*subscription
-			az := _az[:0]
+		} else if matchTagsEnabled && len(qsubs) > 1 {
+			// Pre-scan to a unified locality-local pool: local CLIENTs
+			// plus routed CLIENTs whose remote server satisfies this
+			// server's matching_tags. When non-empty, restrict the
+			// random pick (sindex below) to this pool so traffic stays
+			// local and balances across local subs and matching peers.
+			// Empty pool => fall through to the original cluster-wide
+			// selection.
+			var _local [32]*subscription
+			local := _local[:0]
 			isSpokeLeaf := src == LEAF && c.isSpokeLeafNode()
 			for i := 0; i < len(qsubs); i++ {
 				s := qsubs[i]
@@ -5339,15 +5340,16 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 						continue
 					}
 					if len(s.origin) == 0 && s.client.route.tagsMatch {
-						az = append(az, s)
+						local = append(local, s)
 					}
 				case LEAF:
+					// LEAFs are not tagged; never treat as locality-local.
 				default:
-					az = append(az, s)
+					local = append(local, s)
 				}
 			}
-			if len(az) > 0 {
-				qsubs = az
+			if len(local) > 0 {
+				qsubs = local
 			}
 		}
 

--- a/server/client.go
+++ b/server/client.go
@@ -5339,7 +5339,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 					if isSpokeLeaf {
 						continue
 					}
-					if len(s.origin) == 0 && s.client.route.tagsMatch {
+					if len(s.origin) == 0 && s.client.route.tagsMatch.Load() {
 						local = append(local, s)
 					}
 				case LEAF:

--- a/server/client.go
+++ b/server/client.go
@@ -5318,6 +5318,37 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 				}
 			}
 			qsubs = ql
+		} else if preferMatching && len(qsubs) > 1 {
+			// Pre-scan to a unified "AZ-local" pool: local CLIENTs plus
+			// routed CLIENTs whose remote server's tags overlap ours.
+			// When non-empty, restrict the random pick (sindex below) to
+			// this pool so traffic stays in-AZ and balances across local
+			// and matching peers. Empty pool => fall through to the
+			// original cluster-wide selection.
+			var _az [32]*subscription
+			az := _az[:0]
+			isSpokeLeaf := src == LEAF && c.isSpokeLeafNode()
+			for i := 0; i < len(qsubs); i++ {
+				s := qsubs[i]
+				if s == nil {
+					continue
+				}
+				switch s.client.kind {
+				case ROUTER:
+					if isSpokeLeaf {
+						continue
+					}
+					if len(s.origin) == 0 && s.client.route.tagsMatch {
+						az = append(az, s)
+					}
+				case LEAF:
+				default:
+					az = append(az, s)
+				}
+			}
+			if len(az) > 0 {
+				qsubs = az
+			}
 		}
 
 		sindex := 0
@@ -5378,17 +5409,6 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 					// This is a qsub that is local on the remote server (or
 					// we are connected to an older server and we don't know).
 					// Pick this one and be done.
-					//
-					// With preferMatching, defer non-matching peers (overwriting
-					// weaker rsubs to preserve ROUTER > leaf priority). dst ==
-					// ROUTER guards the route deref for LEAF subs from gateway
-					// traffic.
-					if preferMatching && dst == ROUTER && !sub.client.route.tagsMatch {
-						if rsub == nil || rsub.client.kind != ROUTER || len(rsub.origin) > 0 {
-							rsub = sub
-						}
-						continue
-					}
 					rsub = sub
 					break
 				}

--- a/server/client.go
+++ b/server/client.go
@@ -5239,7 +5239,7 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 	// Declared here because of goto.
 	var queues [][]byte
 
-	matchTagsEnabled := len(c.srv.getOpts().Cluster.MatchingTags) > 0
+	matchTagsEnabled := c.srv.matchTagsEnabled.Load()
 
 	var leafOrigin string
 	switch c.kind {

--- a/server/client.go
+++ b/server/client.go
@@ -5239,6 +5239,8 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 	// Declared here because of goto.
 	var queues [][]byte
 
+	preferMatching := c.srv.getOpts().Cluster.PreferMatchingTags
+
 	var leafOrigin string
 	switch c.kind {
 	case ROUTER:
@@ -5376,6 +5378,18 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 					// This is a qsub that is local on the remote server (or
 					// we are connected to an older server and we don't know).
 					// Pick this one and be done.
+					//
+					// When preferMatching is set, defer all remote peers so a
+					// directly-connected sub later in the walk can win. Among
+					// deferred peers, matching tags beat non-matching.
+					if preferMatching {
+						if sub.client.route.tagsMatch {
+							rsub = sub
+						} else if rsub == nil {
+							rsub = sub
+						}
+						continue
+					}
 					rsub = sub
 					break
 				}

--- a/server/client.go
+++ b/server/client.go
@@ -5326,8 +5326,18 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 			// local and balances across local subs and matching peers.
 			// Empty pool => fall through to the original cluster-wide
 			// selection.
+			//
+			// We also remember the first non-matching peer ROUTER as a
+			// fallback rsub. If every candidate in the pool fails
+			// deliverMsg (slow consumer / closed sub), the post-loop
+			// addSubToRouteTargets forwards to that peer instead of
+			// dropping the message. The delivery loop clears rsub on
+			// successful local delivery and overwrites it when it
+			// picks a matching peer, so locality and route-beats-leaf
+			// priorities are preserved.
 			var _local [32]*subscription
 			local := _local[:0]
+			var fallback *subscription
 			isSpokeLeaf := src == LEAF && c.isSpokeLeafNode()
 			for i := 0; i < len(qsubs); i++ {
 				s := qsubs[i]
@@ -5339,8 +5349,12 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 					if isSpokeLeaf {
 						continue
 					}
-					if len(s.origin) == 0 && s.client.route.tagsMatch.Load() {
-						local = append(local, s)
+					if len(s.origin) == 0 {
+						if s.client.route.tagsMatch.Load() {
+							local = append(local, s)
+						} else if fallback == nil {
+							fallback = s
+						}
 					}
 				case LEAF:
 					// LEAFs are not tagged; never treat as locality-local.
@@ -5350,6 +5364,9 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 			}
 			if len(local) > 0 {
 				qsubs = local
+				if fallback != nil {
+					rsub = fallback
+				}
 			}
 		}
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -63,31 +63,31 @@ type PinnedCertSet map[string]struct{}
 // NOTE: This structure is no longer used for monitoring endpoints
 // and json tags are deprecated and may be removed in the future.
 type ClusterOpts struct {
-	Name               string             `json:"-"`
-	Host               string             `json:"addr,omitempty"`
-	Port               int                `json:"cluster_port,omitempty"`
-	Username           string             `json:"-"`
-	Password           string             `json:"-"`
-	AuthTimeout        float64            `json:"auth_timeout,omitempty"`
-	Permissions        *RoutePermissions  `json:"-"`
-	TLSTimeout         float64            `json:"-"`
-	TLSConfig          *tls.Config        `json:"-"`
-	TLSMap             bool               `json:"-"`
-	TLSCheckKnownURLs  bool               `json:"-"`
-	TLSPinnedCerts     PinnedCertSet      `json:"-"`
-	ListenStr          string             `json:"-"`
-	Advertise          string             `json:"-"`
-	NoAdvertise        bool               `json:"-"`
-	ConnectRetries     int                `json:"-"`
-	ConnectBackoff     bool               `json:"-"`
-	PoolSize           int                `json:"-"`
-	PinnedAccounts     []string           `json:"-"`
-	Compression        CompressionOpts    `json:"-"`
-	PingInterval       time.Duration      `json:"-"`
-	MaxPingsOut        int                `json:"-"`
-	WriteDeadline      time.Duration      `json:"-"`
-	WriteTimeout       WriteTimeoutPolicy `json:"-"`
-	MatchingTags       jwt.TagList        `json:"-"`
+	Name              string             `json:"-"`
+	Host              string             `json:"addr,omitempty"`
+	Port              int                `json:"cluster_port,omitempty"`
+	Username          string             `json:"-"`
+	Password          string             `json:"-"`
+	AuthTimeout       float64            `json:"auth_timeout,omitempty"`
+	Permissions       *RoutePermissions  `json:"-"`
+	TLSTimeout        float64            `json:"-"`
+	TLSConfig         *tls.Config        `json:"-"`
+	TLSMap            bool               `json:"-"`
+	TLSCheckKnownURLs bool               `json:"-"`
+	TLSPinnedCerts    PinnedCertSet      `json:"-"`
+	ListenStr         string             `json:"-"`
+	Advertise         string             `json:"-"`
+	NoAdvertise       bool               `json:"-"`
+	ConnectRetries    int                `json:"-"`
+	ConnectBackoff    bool               `json:"-"`
+	PoolSize          int                `json:"-"`
+	PinnedAccounts    []string           `json:"-"`
+	Compression       CompressionOpts    `json:"-"`
+	PingInterval      time.Duration      `json:"-"`
+	MaxPingsOut       int                `json:"-"`
+	WriteDeadline     time.Duration      `json:"-"`
+	WriteTimeout      WriteTimeoutPolicy `json:"-"`
+	MatchingTags      jwt.TagList        `json:"-"`
 
 	// Not exported (used in tests)
 	resolver netResolver

--- a/server/opts.go
+++ b/server/opts.go
@@ -63,30 +63,31 @@ type PinnedCertSet map[string]struct{}
 // NOTE: This structure is no longer used for monitoring endpoints
 // and json tags are deprecated and may be removed in the future.
 type ClusterOpts struct {
-	Name              string             `json:"-"`
-	Host              string             `json:"addr,omitempty"`
-	Port              int                `json:"cluster_port,omitempty"`
-	Username          string             `json:"-"`
-	Password          string             `json:"-"`
-	AuthTimeout       float64            `json:"auth_timeout,omitempty"`
-	Permissions       *RoutePermissions  `json:"-"`
-	TLSTimeout        float64            `json:"-"`
-	TLSConfig         *tls.Config        `json:"-"`
-	TLSMap            bool               `json:"-"`
-	TLSCheckKnownURLs bool               `json:"-"`
-	TLSPinnedCerts    PinnedCertSet      `json:"-"`
-	ListenStr         string             `json:"-"`
-	Advertise         string             `json:"-"`
-	NoAdvertise       bool               `json:"-"`
-	ConnectRetries    int                `json:"-"`
-	ConnectBackoff    bool               `json:"-"`
-	PoolSize          int                `json:"-"`
-	PinnedAccounts    []string           `json:"-"`
-	Compression       CompressionOpts    `json:"-"`
-	PingInterval      time.Duration      `json:"-"`
-	MaxPingsOut       int                `json:"-"`
-	WriteDeadline     time.Duration      `json:"-"`
-	WriteTimeout      WriteTimeoutPolicy `json:"-"`
+	Name               string             `json:"-"`
+	Host               string             `json:"addr,omitempty"`
+	Port               int                `json:"cluster_port,omitempty"`
+	Username           string             `json:"-"`
+	Password           string             `json:"-"`
+	AuthTimeout        float64            `json:"auth_timeout,omitempty"`
+	Permissions        *RoutePermissions  `json:"-"`
+	TLSTimeout         float64            `json:"-"`
+	TLSConfig          *tls.Config        `json:"-"`
+	TLSMap             bool               `json:"-"`
+	TLSCheckKnownURLs  bool               `json:"-"`
+	TLSPinnedCerts     PinnedCertSet      `json:"-"`
+	ListenStr          string             `json:"-"`
+	Advertise          string             `json:"-"`
+	NoAdvertise        bool               `json:"-"`
+	ConnectRetries     int                `json:"-"`
+	ConnectBackoff     bool               `json:"-"`
+	PoolSize           int                `json:"-"`
+	PinnedAccounts     []string           `json:"-"`
+	Compression        CompressionOpts    `json:"-"`
+	PingInterval       time.Duration      `json:"-"`
+	MaxPingsOut        int                `json:"-"`
+	WriteDeadline      time.Duration      `json:"-"`
+	WriteTimeout       WriteTimeoutPolicy `json:"-"`
+	PreferMatchingTags bool               `json:"-"`
 
 	// Not exported (used in tests)
 	resolver netResolver
@@ -2138,6 +2139,8 @@ func parseCluster(v any, opts *Options, errors *[]error, warnings *[]error) erro
 			opts.Cluster.WriteDeadline = parseDuration("write_deadline", tk, mv, errors, warnings)
 		case "write_timeout":
 			opts.Cluster.WriteTimeout = parseWriteDeadlinePolicy(tk, mv.(string), errors)
+		case "prefer_matching_tags":
+			opts.Cluster.PreferMatchingTags = mv.(bool)
 		default:
 			if !tk.IsUsedVariable() {
 				err := &unknownConfigFieldErr{

--- a/server/opts.go
+++ b/server/opts.go
@@ -87,7 +87,7 @@ type ClusterOpts struct {
 	MaxPingsOut        int                `json:"-"`
 	WriteDeadline      time.Duration      `json:"-"`
 	WriteTimeout       WriteTimeoutPolicy `json:"-"`
-	PreferMatchingTags bool               `json:"-"`
+	MatchingTags       jwt.TagList        `json:"-"`
 
 	// Not exported (used in tests)
 	resolver netResolver
@@ -2139,8 +2139,34 @@ func parseCluster(v any, opts *Options, errors *[]error, warnings *[]error) erro
 			opts.Cluster.WriteDeadline = parseDuration("write_deadline", tk, mv, errors, warnings)
 		case "write_timeout":
 			opts.Cluster.WriteTimeout = parseWriteDeadlinePolicy(tk, mv.(string), errors)
-		case "prefer_matching_tags":
-			opts.Cluster.PreferMatchingTags = mv.(bool)
+		case "matching_tags":
+			var err error
+			switch v := mv.(type) {
+			case string:
+				opts.Cluster.MatchingTags.Add(v)
+			case []string:
+				opts.Cluster.MatchingTags.Add(v...)
+			case []any:
+				for _, t := range v {
+					if token, ok := t.(token); ok {
+						if ts, ok := token.Value().(string); ok {
+							opts.Cluster.MatchingTags.Add(ts)
+							continue
+						} else {
+							err = &configErr{tk, fmt.Sprintf("error parsing matching_tags: unsupported type %T where string is expected", token)}
+						}
+					} else {
+						err = &configErr{tk, fmt.Sprintf("error parsing matching_tags: unsupported type %T", t)}
+					}
+					break
+				}
+			default:
+				err = &configErr{tk, fmt.Sprintf("error parsing matching_tags: unsupported type %T", v)}
+			}
+			if err != nil {
+				*errors = append(*errors, err)
+				continue
+			}
 		default:
 			if !tk.IsUsedVariable() {
 				err := &unknownConfigFieldErr{

--- a/server/reload.go
+++ b/server/reload.go
@@ -472,7 +472,7 @@ func (c *clusterOption) Apply(s *Server) {
 		s.forEachRoute(func(r *client) {
 			r.mu.Lock()
 			if r.route != nil {
-				r.route.tagsMatch = tagsContainAll(r.route.remoteTags, mt)
+				r.route.tagsMatch.Store(tagsContainAll(r.route.remoteTags, mt))
 			}
 			r.mu.Unlock()
 		})

--- a/server/reload.go
+++ b/server/reload.go
@@ -362,9 +362,19 @@ type tagsOption struct {
 }
 
 func (u *tagsOption) Apply(server *Server) {
-	// Refresh routeInfo.Tags so reconnecting routes advertise the new tags.
+	// Refresh routeInfo.Tags so reconnecting routes advertise the new tags,
+	// and recompute tagsMatch on existing routes so queue routing decisions
+	// on this server reflect the new tags immediately.
 	server.mu.Lock()
-	server.routeInfo.Tags = server.getOpts().Tags
+	newTags := server.getOpts().Tags
+	server.routeInfo.Tags = newTags
+	server.forEachRoute(func(r *client) {
+		r.mu.Lock()
+		if r.route != nil {
+			r.route.tagsMatch = tagsOverlap(newTags, r.route.remoteTags)
+		}
+		r.mu.Unlock()
+	})
 	server.mu.Unlock()
 	server.Noticef("Reloaded: tags")
 }

--- a/server/reload.go
+++ b/server/reload.go
@@ -362,12 +362,25 @@ type tagsOption struct {
 }
 
 func (u *tagsOption) Apply(server *Server) {
-	// Refresh routeInfo.Tags so routes that reconnect advertise the new
-	// tags. tagsMatch on existing routes is driven by Cluster.MatchingTags,
-	// not server_tags, so we don't recompute it here.
+	// Refresh routeInfo.Tags and broadcast async INFO so peers recompute
+	// their tagsMatch view of us. Our own routes' tagsMatch is driven by
+	// Cluster.MatchingTags, not server_tags, so we don't recompute it here.
 	server.mu.Lock()
 	server.routeInfo.Tags = server.getOpts().Tags
+	infoJSON := generateInfoJSON(&server.routeInfo)
+	var routes []*client
+	server.forEachRoute(func(r *client) {
+		routes = append(routes, r)
+	})
 	server.mu.Unlock()
+
+	for _, r := range routes {
+		r.mu.Lock()
+		if r.opts.Protocol >= RouteProtoInfo {
+			r.enqueueProto(infoJSON)
+		}
+		r.mu.Unlock()
+	}
 	server.Noticef("Reloaded: tags")
 }
 

--- a/server/reload.go
+++ b/server/reload.go
@@ -484,6 +484,7 @@ func (c *clusterOption) Apply(s *Server) {
 	}
 	if c.matchingTagsChanged {
 		mt := c.newValue.MatchingTags
+		s.matchTagsEnabled.Store(len(mt) > 0)
 		s.forEachRoute(func(r *client) {
 			r.mu.Lock()
 			if r.route != nil {

--- a/server/reload.go
+++ b/server/reload.go
@@ -366,6 +366,8 @@ func (u *tagsOption) Apply(server *Server) {
 	// their tagsMatch view of us. Our own routes' tagsMatch is driven by
 	// Cluster.MatchingTags, not server_tags, so we don't recompute it here.
 	server.mu.Lock()
+	// Slice-header alias is safe: reload installs a fresh *Options with a fresh
+	// Tags backing array, so this header is replaced (never mutated in place).
 	server.routeInfo.Tags = server.getOpts().Tags
 	infoJSON := generateInfoJSON(&server.routeInfo)
 	var routes []*client

--- a/server/reload.go
+++ b/server/reload.go
@@ -362,6 +362,10 @@ type tagsOption struct {
 }
 
 func (u *tagsOption) Apply(server *Server) {
+	// Refresh routeInfo.Tags so reconnecting routes advertise the new tags.
+	server.mu.Lock()
+	server.routeInfo.Tags = server.getOpts().Tags
+	server.mu.Unlock()
 	server.Noticef("Reloaded: tags")
 }
 

--- a/server/reload.go
+++ b/server/reload.go
@@ -362,19 +362,11 @@ type tagsOption struct {
 }
 
 func (u *tagsOption) Apply(server *Server) {
-	// Refresh routeInfo.Tags so reconnecting routes advertise the new tags,
-	// and recompute tagsMatch on existing routes so queue routing decisions
-	// on this server reflect the new tags immediately.
+	// Refresh routeInfo.Tags so routes that reconnect advertise the new
+	// tags. tagsMatch on existing routes is driven by Cluster.MatchingTags,
+	// not server_tags, so we don't recompute it here.
 	server.mu.Lock()
-	newTags := server.getOpts().Tags
-	server.routeInfo.Tags = newTags
-	server.forEachRoute(func(r *client) {
-		r.mu.Lock()
-		if r.route != nil {
-			r.route.tagsMatch = tagsOverlap(newTags, r.route.remoteTags)
-		}
-		r.mu.Unlock()
-	})
+	server.routeInfo.Tags = server.getOpts().Tags
 	server.mu.Unlock()
 	server.Noticef("Reloaded: tags")
 }
@@ -419,12 +411,13 @@ func (u *nkeysOption) Apply(server *Server) {
 // clusterOption implements the option interface for the `cluster` setting.
 type clusterOption struct {
 	authOption
-	newValue        ClusterOpts
-	permsChanged    bool
-	accsAdded       []string
-	accsRemoved     []string
-	poolSizeChanged bool
-	compressChanged bool
+	newValue            ClusterOpts
+	permsChanged        bool
+	accsAdded           []string
+	accsRemoved         []string
+	poolSizeChanged     bool
+	compressChanged     bool
+	matchingTagsChanged bool
 }
 
 // Apply the cluster change.
@@ -470,6 +463,16 @@ func (c *clusterOption) Apply(s *Server) {
 				// Simply change the compression writer
 				r.out.cw = s2.NewWriter(nil, s2WriterOptions(newMode)...)
 				r.route.compression = newMode
+			}
+			r.mu.Unlock()
+		})
+	}
+	if c.matchingTagsChanged {
+		mt := c.newValue.MatchingTags
+		s.forEachRoute(func(r *client) {
+			r.mu.Lock()
+			if r.route != nil {
+				r.route.tagsMatch = tagsContainAll(r.route.remoteTags, mt)
 			}
 			r.mu.Unlock()
 		})
@@ -1704,9 +1707,10 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 				return nil, err
 			}
 			co := &clusterOption{
-				newValue:        newClusterOpts,
-				permsChanged:    !reflect.DeepEqual(newClusterOpts.Permissions, oldClusterOpts.Permissions),
-				compressChanged: !oldClusterOpts.Compression.equals(&newClusterOpts.Compression),
+				newValue:            newClusterOpts,
+				permsChanged:        !reflect.DeepEqual(newClusterOpts.Permissions, oldClusterOpts.Permissions),
+				compressChanged:     !oldClusterOpts.Compression.equals(&newClusterOpts.Compression),
+				matchingTagsChanged: !reflect.DeepEqual(oldClusterOpts.MatchingTags, newClusterOpts.MatchingTags),
 			}
 			co.diffPoolAndAccounts(&oldClusterOpts)
 			// If there are added accounts, first make sure that we can look them up.

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -7447,23 +7447,35 @@ func TestConfigReloadServerTags(t *testing.T) {
 	}
 }
 
-func TestConfigReloadServerTagsRecomputesRouteMatch(t *testing.T) {
-	tmpl := `
+func TestConfigReloadMatchingTagsRecomputesRouteMatch(t *testing.T) {
+	// matching_tags reload must recompute tagsMatch on existing routes,
+	// since tagsMatch is driven by the local matching_tags filter against
+	// each route's cached remoteTags.
+	s1Tmpl := `
 		port: -1
-		server_name: %s
-		server_tags: [%s]
+		server_name: S1
+		server_tags: [az1]
 		cluster {
 			name: tagaware
 			port: -1
-			%s
+			matching_tags: [%q]
 		}
 	`
-	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", ""))
+	s1Conf := createConfFile(t, fmt.Appendf(nil, s1Tmpl, "az1"))
 	s1, o1 := RunServerWithConfig(s1Conf)
 	defer s1.Shutdown()
 
-	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az1",
-		fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)))
+	s2Conf := createConfFile(t, fmt.Appendf(nil, `
+		port: -1
+		server_name: S2
+		server_tags: [az1]
+		cluster {
+			name: tagaware
+			port: -1
+			routes: ["nats://127.0.0.1:%d"]
+			matching_tags: [az1]
+		}
+	`, o1.Cluster.Port))
 	s2, _ := RunServerWithConfig(s2Conf)
 	defer s2.Shutdown()
 
@@ -7485,29 +7497,24 @@ func TestConfigReloadServerTagsRecomputesRouteMatch(t *testing.T) {
 	}
 
 	if !routeTagsMatch(s1) {
-		t.Fatal("expected initial tagsMatch=true on S1's route")
+		t.Fatal("expected initial tagsMatch=true on S1's route (az1 ⊆ [az1])")
 	}
 
-	reloadUpdateConfig(t, s1, s1Conf, `
-		port: -1
-		server_name: S1
-		server_tags: [az2]
-		cluster {
-			name: tagaware
-			port: -1
-		}
-	`)
+	// Reload S1 with matching_tags=[az2]. S2's remoteTags=[az1] no longer
+	// satisfy the new filter, so tagsMatch must flip to false without any
+	// route reconnect or peer change.
+	reloadUpdateConfig(t, s1, s1Conf, fmt.Sprintf(s1Tmpl, "az2"))
 
 	if routeTagsMatch(s1) {
-		t.Fatal("expected tagsMatch=false on S1's route after reload to az2")
+		t.Fatal("expected tagsMatch=false on S1's route after matching_tags reload to [az2]")
 	}
 }
 
-func TestConfigReloadPreferMatchingTags(t *testing.T) {
-	// 3 nodes, S1 az1, S2 az1 (matching), S3 az2 (non-matching). Publisher on
-	// S1, queue subs on S2 and S3. With prefer_matching_tags off the cluster-
-	// wide selection delivers to both peers; after reloading S1 with the flag
-	// on, the AZ pre-scan must restrict delivery to S2.
+func TestConfigReloadMatchingTags(t *testing.T) {
+	// 3 nodes, all with server_tags set. Publisher S1, queue subs on S2
+	// (same locality as S1) and S3 (different). Without matching_tags the
+	// cluster-wide selection delivers to both peers; after reloading S1
+	// with matching_tags=[az1], the pre-scan must restrict delivery to S2.
 	s1Tmpl := `
 		port: -1
 		server_name: S1
@@ -7515,10 +7522,10 @@ func TestConfigReloadPreferMatchingTags(t *testing.T) {
 		cluster {
 			name: tagaware
 			port: -1
-			prefer_matching_tags: %t
+			%s
 		}
 	`
-	s1Conf := createConfFile(t, fmt.Appendf(nil, s1Tmpl, false))
+	s1Conf := createConfFile(t, fmt.Appendf(nil, s1Tmpl, ""))
 	s1, o1 := RunServerWithConfig(s1Conf)
 	defer s1.Shutdown()
 
@@ -7573,32 +7580,23 @@ func TestConfigReloadPreferMatchingTags(t *testing.T) {
 		})
 	}
 
-	// Phase 1: flag off — both peers receive.
+	// Phase 1: matching_tags unset — both peers receive.
 	publish(200)
 	if s2Count.Load() == 0 || s3Count.Load() == 0 {
-		t.Fatalf("flag off: expected both peers to receive, got S2=%d S3=%d",
+		t.Fatalf("matching_tags off: expected both peers to receive, got S2=%d S3=%d",
 			s2Count.Load(), s3Count.Load())
 	}
 
-	reloadUpdateConfig(t, s1, s1Conf, fmt.Sprintf(`
-		port: -1
-		server_name: S1
-		server_tags: [az1]
-		cluster {
-			name: tagaware
-			port: -1
-			prefer_matching_tags: %t
-		}
-	`, true))
+	reloadUpdateConfig(t, s1, s1Conf, fmt.Sprintf(s1Tmpl, `matching_tags: [az1]`))
 
-	// Phase 2: flag on — only the matching peer (S2) should receive.
+	// Phase 2: matching_tags=[az1] — only the matching peer (S2) receives.
 	s2Count.Store(0)
 	s3Count.Store(0)
 	publish(200)
 	if s3Count.Load() != 0 {
-		t.Fatalf("flag on: S3 (non-matching) received %d, expected 0", s3Count.Load())
+		t.Fatalf("matching_tags on: S3 (non-matching) received %d, expected 0", s3Count.Load())
 	}
 	if s2Count.Load() == 0 {
-		t.Fatalf("flag on: S2 (matching) received 0, expected all")
+		t.Fatalf("matching_tags on: S2 (matching) received 0, expected all")
 	}
 }

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -7488,7 +7488,7 @@ func TestConfigReloadMatchingTagsRecomputesRouteMatch(t *testing.T) {
 		s.forEachRoute(func(r *client) {
 			r.mu.Lock()
 			if r.route != nil {
-				match = r.route.tagsMatch
+				match = r.route.tagsMatch.Load()
 			}
 			r.mu.Unlock()
 		})

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -7600,3 +7600,71 @@ func TestConfigReloadMatchingTags(t *testing.T) {
 		t.Fatalf("matching_tags on: S2 (matching) received 0, expected all")
 	}
 }
+
+func TestConfigReloadServerTagsPropagatesToPeers(t *testing.T) {
+	// server_tags reload on S1 must propagate via async INFO so that S2
+	// recomputes its tagsMatch view of S1 without requiring a route
+	// reconnect. Symmetric with how matching_tags reload behaves.
+	s1Tmpl := `
+		port: -1
+		server_name: S1
+		server_tags: [%q]
+		cluster {
+			name: tagaware
+			port: -1
+		}
+	`
+	s1Conf := createConfFile(t, fmt.Appendf(nil, s1Tmpl, "az1"))
+	s1, o1 := RunServerWithConfig(s1Conf)
+	defer s1.Shutdown()
+
+	s2Conf := createConfFile(t, fmt.Appendf(nil, `
+		port: -1
+		server_name: S2
+		server_tags: [az1]
+		cluster {
+			name: tagaware
+			port: -1
+			routes: ["nats://127.0.0.1:%d"]
+			matching_tags: [az1]
+		}
+	`, o1.Cluster.Port))
+	s2, _ := RunServerWithConfig(s2Conf)
+	defer s2.Shutdown()
+
+	checkClusterFormed(t, s1, s2)
+
+	routeToS1State := func() (remoteTags []string, match bool) {
+		t.Helper()
+		s2.mu.RLock()
+		s2.forEachRoute(func(r *client) {
+			r.mu.Lock()
+			if r.route != nil && r.route.remoteName == "S1" {
+				remoteTags = append([]string(nil), r.route.remoteTags...)
+				match = r.route.tagsMatch.Load()
+			}
+			r.mu.Unlock()
+		})
+		s2.mu.RUnlock()
+		return
+	}
+
+	tags, match := routeToS1State()
+	if !reflect.DeepEqual(tags, []string{"az1"}) || !match {
+		t.Fatalf("initial: expected remoteTags=[az1] tagsMatch=true, got tags=%v match=%v", tags, match)
+	}
+
+	// Reload S1 with [az2]. S2 must observe the change without a reconnect.
+	reloadUpdateConfig(t, s1, s1Conf, fmt.Sprintf(s1Tmpl, "az2"))
+
+	checkFor(t, 2*time.Second, 25*time.Millisecond, func() error {
+		tags, match := routeToS1State()
+		if !reflect.DeepEqual(tags, []string{"az2"}) {
+			return fmt.Errorf("remoteTags=%v, want [az2]", tags)
+		}
+		if match {
+			return fmt.Errorf("tagsMatch=true, want false ([az2] does not satisfy [az1])")
+		}
+		return nil
+	})
+}

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -34,6 +34,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -7408,4 +7409,196 @@ func TestJetStreamReloadMaxMemAndStore(t *testing.T) {
 	cfg = s.JetStreamConfig()
 	require_Equal(t, cfg.MaxMemory, 512*1024*1024)
 	require_Equal(t, cfg.MaxStore, 512*1024*1024)
+}
+
+func TestConfigReloadServerTags(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		port: -1
+		server_tags: [az1]
+		cluster {
+			name: tagaware
+			port: -1
+		}
+	`))
+	s, _ := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	s.mu.RLock()
+	got := append([]string(nil), s.routeInfo.Tags...)
+	s.mu.RUnlock()
+	if !reflect.DeepEqual(got, []string{"az1"}) {
+		t.Fatalf("expected initial routeInfo.Tags=[az1], got %v", got)
+	}
+
+	reloadUpdateConfig(t, s, conf, `
+		port: -1
+		server_tags: [az2]
+		cluster {
+			name: tagaware
+			port: -1
+		}
+	`)
+
+	s.mu.RLock()
+	got = append([]string(nil), s.routeInfo.Tags...)
+	s.mu.RUnlock()
+	if !reflect.DeepEqual(got, []string{"az2"}) {
+		t.Fatalf("expected reloaded routeInfo.Tags=[az2], got %v", got)
+	}
+}
+
+func TestConfigReloadServerTagsRecomputesRouteMatch(t *testing.T) {
+	tmpl := `
+		port: -1
+		server_name: %s
+		server_tags: [%s]
+		cluster {
+			name: tagaware
+			port: -1
+			%s
+		}
+	`
+	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", ""))
+	s1, o1 := RunServerWithConfig(s1Conf)
+	defer s1.Shutdown()
+
+	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az1",
+		fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)))
+	s2, _ := RunServerWithConfig(s2Conf)
+	defer s2.Shutdown()
+
+	checkClusterFormed(t, s1, s2)
+
+	routeTagsMatch := func(s *Server) bool {
+		t.Helper()
+		var match bool
+		s.mu.RLock()
+		s.forEachRoute(func(r *client) {
+			r.mu.Lock()
+			if r.route != nil {
+				match = r.route.tagsMatch
+			}
+			r.mu.Unlock()
+		})
+		s.mu.RUnlock()
+		return match
+	}
+
+	if !routeTagsMatch(s1) {
+		t.Fatal("expected initial tagsMatch=true on S1's route")
+	}
+
+	reloadUpdateConfig(t, s1, s1Conf, `
+		port: -1
+		server_name: S1
+		server_tags: [az2]
+		cluster {
+			name: tagaware
+			port: -1
+		}
+	`)
+
+	if routeTagsMatch(s1) {
+		t.Fatal("expected tagsMatch=false on S1's route after reload to az2")
+	}
+}
+
+func TestConfigReloadPreferMatchingTags(t *testing.T) {
+	// 3 nodes, S1 az1, S2 az1 (matching), S3 az2 (non-matching). Publisher on
+	// S1, queue subs on S2 and S3. With prefer_matching_tags off the cluster-
+	// wide selection delivers to both peers; after reloading S1 with the flag
+	// on, the AZ pre-scan must restrict delivery to S2.
+	s1Tmpl := `
+		port: -1
+		server_name: S1
+		server_tags: [az1]
+		cluster {
+			name: tagaware
+			port: -1
+			prefer_matching_tags: %t
+		}
+	`
+	s1Conf := createConfFile(t, fmt.Appendf(nil, s1Tmpl, false))
+	s1, o1 := RunServerWithConfig(s1Conf)
+	defer s1.Shutdown()
+
+	peerTmpl := `
+		port: -1
+		server_name: %s
+		server_tags: [%q]
+		cluster {
+			name: tagaware
+			port: -1
+			routes: ["nats://127.0.0.1:%d"]
+		}
+	`
+	s2Conf := createConfFile(t, fmt.Appendf(nil, peerTmpl, "S2", "az1", o1.Cluster.Port))
+	s2, _ := RunServerWithConfig(s2Conf)
+	defer s2.Shutdown()
+
+	s3Conf := createConfFile(t, fmt.Appendf(nil, peerTmpl, "S3", "az2", o1.Cluster.Port))
+	s3, _ := RunServerWithConfig(s3Conf)
+	defer s3.Shutdown()
+
+	checkClusterFormed(t, s1, s2, s3)
+
+	var s2Count, s3Count atomic.Int32
+	nc2 := natsConnect(t, s2.ClientURL())
+	defer nc2.Close()
+	_, err := nc2.QueueSubscribe("foo", "QG", func(*nats.Msg) { s2Count.Add(1) })
+	require_NoError(t, err)
+	require_NoError(t, nc2.Flush())
+
+	nc3 := natsConnect(t, s3.ClientURL())
+	defer nc3.Close()
+	_, err = nc3.QueueSubscribe("foo", "QG", func(*nats.Msg) { s3Count.Add(1) })
+	require_NoError(t, err)
+	require_NoError(t, nc3.Flush())
+
+	checkSubInterest(t, s1, globalAccountName, "foo", 2*time.Second)
+
+	publish := func(numMsgs int) {
+		t.Helper()
+		ncPub := natsConnect(t, s1.ClientURL())
+		defer ncPub.Close()
+		for i := 0; i < numMsgs; i++ {
+			require_NoError(t, ncPub.Publish("foo", []byte("hi")))
+		}
+		require_NoError(t, ncPub.Flush())
+		checkFor(t, 2*time.Second, 25*time.Millisecond, func() error {
+			if total := s2Count.Load() + s3Count.Load(); total != int32(numMsgs) {
+				return fmt.Errorf("delivered %d/%d", total, numMsgs)
+			}
+			return nil
+		})
+	}
+
+	// Phase 1: flag off — both peers receive.
+	publish(200)
+	if s2Count.Load() == 0 || s3Count.Load() == 0 {
+		t.Fatalf("flag off: expected both peers to receive, got S2=%d S3=%d",
+			s2Count.Load(), s3Count.Load())
+	}
+
+	reloadUpdateConfig(t, s1, s1Conf, fmt.Sprintf(`
+		port: -1
+		server_name: S1
+		server_tags: [az1]
+		cluster {
+			name: tagaware
+			port: -1
+			prefer_matching_tags: %t
+		}
+	`, true))
+
+	// Phase 2: flag on — only the matching peer (S2) should receive.
+	s2Count.Store(0)
+	s3Count.Store(0)
+	publish(200)
+	if s3Count.Load() != 0 {
+		t.Fatalf("flag on: S3 (non-matching) received %d, expected 0", s3Count.Load())
+	}
+	if s2Count.Load() == 0 {
+		t.Fatalf("flag on: S2 (matching) received 0, expected all")
+	}
 }

--- a/server/route.go
+++ b/server/route.go
@@ -57,7 +57,7 @@ type route struct {
 	remoteID     string
 	remoteName   string
 	remoteTags   []string
-	tagsMatch    bool
+	tagsMatch    atomic.Bool
 	didSolicit   bool
 	retry        bool
 	lnoc         bool
@@ -835,7 +835,7 @@ func (c *client) processRouteInfo(info *Info) {
 	c.route.gatewayURL = info.GatewayURL
 	c.route.remoteName = info.Name
 	c.route.remoteTags = info.Tags
-	c.route.tagsMatch = tagsContainAll(info.Tags, opts.Cluster.MatchingTags)
+	c.route.tagsMatch.Store(tagsContainAll(info.Tags, opts.Cluster.MatchingTags))
 	c.route.lnoc = info.LNOC
 	c.route.lnocu = info.LNOCU
 	c.route.jetstream = info.JetStream

--- a/server/route.go
+++ b/server/route.go
@@ -149,17 +149,25 @@ var (
 	routeMaxPingInterval = defaultRouteMaxPingInterval
 )
 
-// tagsOverlap reports whether a and b share at least one element.
-// Both slices must be normalized (lower-cased, trimmed) by callers.
-func tagsOverlap(a, b []string) bool {
-	for _, x := range a {
-		for _, y := range b {
-			if x == y {
-				return true
+// tagsContainAll reports whether every tag in required is present in have.
+// Empty required returns false: the caller treats this as "matching disabled",
+// so no peer should be classified as locality-matched.
+// Both slices must be normalized (lower-cased, trimmed) by callers; the
+// jwt.TagList.Add path used by config parsing handles that.
+func tagsContainAll(have, required []string) bool {
+	if len(required) == 0 {
+		return false
+	}
+outer:
+	for _, r := range required {
+		for _, h := range have {
+			if h == r {
+				continue outer
 			}
 		}
+		return false
 	}
-	return false
+	return true
 }
 
 // removeReplySub is called when we trip the max on remoteReply subs.
@@ -827,7 +835,7 @@ func (c *client) processRouteInfo(info *Info) {
 	c.route.gatewayURL = info.GatewayURL
 	c.route.remoteName = info.Name
 	c.route.remoteTags = info.Tags
-	c.route.tagsMatch = tagsOverlap(opts.Tags, info.Tags)
+	c.route.tagsMatch = tagsContainAll(info.Tags, opts.Cluster.MatchingTags)
 	c.route.lnoc = info.LNOC
 	c.route.lnocu = info.LNOCU
 	c.route.jetstream = info.JetStream

--- a/server/route.go
+++ b/server/route.go
@@ -57,6 +57,7 @@ type route struct {
 	remoteID     string
 	remoteName   string
 	remoteTags   []string
+	tagsMatch    bool
 	didSolicit   bool
 	retry        bool
 	lnoc         bool
@@ -147,6 +148,19 @@ var (
 	routeConnectMaxDelay = DEFAULT_ROUTE_CONNECT_MAX
 	routeMaxPingInterval = defaultRouteMaxPingInterval
 )
+
+// tagsOverlap reports whether a and b share at least one element.
+// Both slices must be normalized (lower-cased, trimmed) by callers.
+func tagsOverlap(a, b []string) bool {
+	for _, x := range a {
+		for _, y := range b {
+			if x == y {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 // removeReplySub is called when we trip the max on remoteReply subs.
 func (c *client) removeReplySub(sub *subscription) {
@@ -813,6 +827,7 @@ func (c *client) processRouteInfo(info *Info) {
 	c.route.gatewayURL = info.GatewayURL
 	c.route.remoteName = info.Name
 	c.route.remoteTags = info.Tags
+	c.route.tagsMatch = tagsOverlap(opts.Tags, info.Tags)
 	c.route.lnoc = info.LNOC
 	c.route.lnocu = info.LNOCU
 	c.route.jetstream = info.JetStream

--- a/server/route.go
+++ b/server/route.go
@@ -56,6 +56,7 @@ var (
 type route struct {
 	remoteID     string
 	remoteName   string
+	remoteTags   []string
 	didSolicit   bool
 	retry        bool
 	lnoc         bool
@@ -811,6 +812,7 @@ func (c *client) processRouteInfo(info *Info) {
 	c.route.tlsRequired = info.TLSRequired
 	c.route.gatewayURL = info.GatewayURL
 	c.route.remoteName = info.Name
+	c.route.remoteTags = info.Tags
 	c.route.lnoc = info.LNOC
 	c.route.lnocu = info.LNOCU
 	c.route.jetstream = info.JetStream
@@ -2745,6 +2747,7 @@ func (s *Server) startRouteAcceptLoop() {
 		Dynamic:      s.isClusterNameDynamic(),
 		LNOC:         true,
 		LNOCU:        true,
+		Tags:         opts.Tags,
 	}
 	// For tests that want to simulate old servers, do not set the compression
 	// on the INFO protocol if configured with CompressionNotSupported.

--- a/server/route.go
+++ b/server/route.go
@@ -736,6 +736,13 @@ func (c *client) processRouteInfo(info *Info) {
 		} else {
 			// Update only if we detect a difference
 			updateRoutePerms = !reflect.DeepEqual(c.opts.Import, info.Import) || !reflect.DeepEqual(c.opts.Export, info.Export)
+			// Refresh tags if the remote sent an updated set. tagsMatch
+			// is recomputed against this server's current matching_tags
+			// filter so locality routing converges without a reconnect.
+			if !reflect.DeepEqual(c.route.remoteTags, info.Tags) {
+				c.route.remoteTags = info.Tags
+				c.route.tagsMatch.Store(tagsContainAll(info.Tags, opts.Cluster.MatchingTags))
+			}
 		}
 		c.mu.Unlock()
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -5284,7 +5284,7 @@ func BenchmarkProcessLeafMsgArgs_Queues(b *testing.B) {
 	}
 }
 
-func TestRouteQueuePreferMatchingTags(t *testing.T) {
+func TestRouteQueueMatchingTags(t *testing.T) {
 	tmpl := `
 		port: -1
 		server_name: %s
@@ -5293,22 +5293,28 @@ func TestRouteQueuePreferMatchingTags(t *testing.T) {
 			name: "tagaware"
 			port: -1
 			%s
-			prefer_matching_tags: %t
+			%s
 		}
 	`
 
-	startCluster := func(t *testing.T, prefer bool) (s1, s2, s3 *Server) {
+	startCluster := func(t *testing.T, enable bool) (s1, s2, s3 *Server) {
 		t.Helper()
-		s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", "", prefer))
+		mt := func(tag string) string {
+			if enable {
+				return fmt.Sprintf(`matching_tags: [%q]`, tag)
+			}
+			return ""
+		}
+		s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", "", mt("az1")))
 		s1, o1 := RunServerWithConfig(s1Conf)
 		t.Cleanup(s1.Shutdown)
 
 		routes := fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)
-		s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az1", routes, prefer))
+		s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az1", routes, mt("az1")))
 		s2, _ = RunServerWithConfig(s2Conf)
 		t.Cleanup(s2.Shutdown)
 
-		s3Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S3", "az2", routes, prefer))
+		s3Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S3", "az2", routes, mt("az2")))
 		s3, _ = RunServerWithConfig(s3Conf)
 		t.Cleanup(s3.Shutdown)
 
@@ -5316,9 +5322,9 @@ func TestRouteQueuePreferMatchingTags(t *testing.T) {
 		return s1, s2, s3
 	}
 
-	runScenario := func(t *testing.T, prefer bool) (matchCount, otherCount int32) {
+	runScenario := func(t *testing.T, enable bool) (matchCount, otherCount int32) {
 		t.Helper()
-		s1, s2, s3 := startCluster(t, prefer)
+		s1, s2, s3 := startCluster(t, enable)
 
 		ncMatch := natsConnect(t, s2.ClientURL())
 		t.Cleanup(ncMatch.Close)
@@ -5373,7 +5379,7 @@ func TestRouteQueuePreferMatchingTags(t *testing.T) {
 	})
 }
 
-func TestRouteQueuePreferMatchingTagsRouteBeatsLeaf(t *testing.T) {
+func TestRouteQueueMatchingTagsRouteBeatsLeaf(t *testing.T) {
 	// HubAz1 (tag az1) and HubAz2 (tag az2) form a cluster. A leaf attaches
 	// to HubAz1. Queue subs land on HubAz2 (non-matching peer, via route)
 	// and on the leaf. Publisher on HubAz1 has no local sub. We expect the
@@ -5387,15 +5393,15 @@ func TestRouteQueuePreferMatchingTagsRouteBeatsLeaf(t *testing.T) {
 			name: tagaware
 			port: -1
 			%s
-			prefer_matching_tags: true
+			matching_tags: [%q]
 		}
 	`
-	h1Conf := createConfFile(t, fmt.Appendf(nil, hubTmpl, "HubAz1", "az1", ""))
+	h1Conf := createConfFile(t, fmt.Appendf(nil, hubTmpl, "HubAz1", "az1", "", "az1"))
 	h1, h1Opts := RunServerWithConfig(h1Conf)
 	defer h1.Shutdown()
 
 	h2Conf := createConfFile(t, fmt.Appendf(nil, hubTmpl, "HubAz2", "az2",
-		fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, h1Opts.Cluster.Port)))
+		fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, h1Opts.Cluster.Port), "az2"))
 	h2, _ := RunServerWithConfig(h2Conf)
 	defer h2.Shutdown()
 
@@ -5448,10 +5454,10 @@ func TestRouteQueuePreferMatchingTagsRouteBeatsLeaf(t *testing.T) {
 	}
 }
 
-func TestRouteQueuePreferMatchingTagsBalancesWithMatchingPeer(t *testing.T) {
-	// With preferMatching, a local CLIENT sub and a matching-tag peer ROUTER
-	// are equally cheap; selection should remain 50/50 random across the two
-	// to preserve queue-group load balancing within an AZ.
+func TestRouteQueueMatchingTagsBalancesWithMatchingPeer(t *testing.T) {
+	// With matching_tags set, a local CLIENT sub and a matching-tag peer
+	// ROUTER are equally cheap; selection should remain 50/50 random across
+	// the two to preserve queue-group load balancing within the locality.
 	tmpl := `
 		port: -1
 		server_name: %s
@@ -5460,15 +5466,15 @@ func TestRouteQueuePreferMatchingTagsBalancesWithMatchingPeer(t *testing.T) {
 			name: "tagaware"
 			port: -1
 			%s
-			prefer_matching_tags: true
+			matching_tags: [%q]
 		}
 	`
-	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", ""))
+	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", "", "az1"))
 	s1, o1 := RunServerWithConfig(s1Conf)
 	defer s1.Shutdown()
 
 	routes := fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)
-	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az1", routes))
+	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az1", routes, "az1"))
 	s2, _ := RunServerWithConfig(s2Conf)
 	defer s2.Shutdown()
 
@@ -5511,7 +5517,7 @@ func TestRouteQueuePreferMatchingTagsBalancesWithMatchingPeer(t *testing.T) {
 	}
 }
 
-func TestRouteQueuePreferMatchingTagsLocalSubWins(t *testing.T) {
+func TestRouteQueueMatchingTagsLocalSubWins(t *testing.T) {
 	tmpl := `
 		port: -1
 		server_name: %s
@@ -5520,15 +5526,15 @@ func TestRouteQueuePreferMatchingTagsLocalSubWins(t *testing.T) {
 			name: "tagaware"
 			port: -1
 			%s
-			prefer_matching_tags: true
+			matching_tags: [%q]
 		}
 	`
-	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", ""))
+	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", "", "az1"))
 	s1, o1 := RunServerWithConfig(s1Conf)
 	defer s1.Shutdown()
 
 	routes := fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)
-	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az2", routes))
+	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az2", routes, "az2"))
 	s2, _ := RunServerWithConfig(s2Conf)
 	defer s2.Shutdown()
 
@@ -5573,11 +5579,11 @@ func TestRouteQueuePreferMatchingTagsLocalSubWins(t *testing.T) {
 	}
 }
 
-func TestRouteQueuePreferMatchingTagsExcludesCrossAZ(t *testing.T) {
-	// 2 servers per AZ across 2 AZs, queue subs on every node, publisher on
-	// S1a with a local sub. The pre-scan AZ pool on S1a is [LocalS1a,
-	// RouteToS2a] (matching), so traffic must split between those two and
-	// AZ2 peers must receive none.
+func TestRouteQueueMatchingTagsExcludesCrossLocality(t *testing.T) {
+	// 2 servers per locality across 2 localities, queue subs on every node,
+	// publisher on S1a with a local sub. The pre-scan local pool on S1a is
+	// [LocalS1a, RouteToS2a] (matching), so traffic must split between
+	// those two and az2 peers must receive none.
 	tmpl := `
 		port: -1
 		server_name: %s
@@ -5586,23 +5592,23 @@ func TestRouteQueuePreferMatchingTagsExcludesCrossAZ(t *testing.T) {
 			name: "tagaware"
 			port: -1
 			%s
-			prefer_matching_tags: true
+			matching_tags: [%q]
 		}
 	`
-	s1aConf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1a", "az1", ""))
+	s1aConf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1a", "az1", "", "az1"))
 	s1a, o1 := RunServerWithConfig(s1aConf)
 	defer s1a.Shutdown()
 
 	routes := fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)
-	s2aConf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2a", "az1", routes))
+	s2aConf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2a", "az1", routes, "az1"))
 	s2a, _ := RunServerWithConfig(s2aConf)
 	defer s2a.Shutdown()
 
-	s3bConf := createConfFile(t, fmt.Appendf(nil, tmpl, "S3b", "az2", routes))
+	s3bConf := createConfFile(t, fmt.Appendf(nil, tmpl, "S3b", "az2", routes, "az2"))
 	s3b, _ := RunServerWithConfig(s3bConf)
 	defer s3b.Shutdown()
 
-	s4bConf := createConfFile(t, fmt.Appendf(nil, tmpl, "S4b", "az2", routes))
+	s4bConf := createConfFile(t, fmt.Appendf(nil, tmpl, "S4b", "az2", routes, "az2"))
 	s4b, _ := RunServerWithConfig(s4bConf)
 	defer s4b.Shutdown()
 
@@ -5640,20 +5646,20 @@ func TestRouteQueuePreferMatchingTagsExcludesCrossAZ(t *testing.T) {
 	})
 
 	if s3bCount.Load() != 0 || s4bCount.Load() != 0 {
-		t.Fatalf("AZ2 received traffic, expected 0: S3b=%d S4b=%d",
+		t.Fatalf("az2 received traffic, expected 0: S3b=%d S4b=%d",
 			s3bCount.Load(), s4bCount.Load())
 	}
 	if s1aCount.Load() == 0 || s2aCount.Load() == 0 {
-		t.Fatalf("AZ1 candidates not balanced: S1a=%d S2a=%d",
+		t.Fatalf("az1 candidates not balanced: S1a=%d S2a=%d",
 			s1aCount.Load(), s2aCount.Load())
 	}
 }
 
-func TestRouteQueuePreferMatchingTagsNoAZLocalFallback(t *testing.T) {
+func TestRouteQueueMatchingTagsNoLocalFallback(t *testing.T) {
 	// Publisher's server has neither a local sub nor a matching peer; the
-	// AZ pool is empty and the pre-scan must fall through to the original
-	// cluster-wide selection so messages still distribute across the
-	// non-matching peers.
+	// local pool is empty and the pre-scan must fall through to the
+	// original cluster-wide selection so messages still distribute across
+	// the non-matching peers.
 	tmpl := `
 		port: -1
 		server_name: %s
@@ -5662,19 +5668,19 @@ func TestRouteQueuePreferMatchingTagsNoAZLocalFallback(t *testing.T) {
 			name: "tagaware"
 			port: -1
 			%s
-			prefer_matching_tags: true
+			matching_tags: [%q]
 		}
 	`
-	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", ""))
+	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", "", "az1"))
 	s1, o1 := RunServerWithConfig(s1Conf)
 	defer s1.Shutdown()
 
 	routes := fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)
-	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az2", routes))
+	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az2", routes, "az2"))
 	s2, _ := RunServerWithConfig(s2Conf)
 	defer s2.Shutdown()
 
-	s3Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S3", "az3", routes))
+	s3Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S3", "az3", routes, "az3"))
 	s3, _ := RunServerWithConfig(s3Conf)
 	defer s3.Shutdown()
 
@@ -5714,5 +5720,78 @@ func TestRouteQueuePreferMatchingTagsNoAZLocalFallback(t *testing.T) {
 	if s2Count.Load() == 0 || s3Count.Load() == 0 {
 		t.Fatalf("expected both non-matching peers to receive messages, got S2=%d S3=%d",
 			s2Count.Load(), s3Count.Load())
+	}
+}
+
+func TestRouteQueueMatchingTagsSubsetSemantics(t *testing.T) {
+	// Each server carries two tag axes (locality + role). matching_tags pins
+	// matching to the locality axis only. The cross-locality peer that
+	// shares the role tag must NOT be classified as matching — this is the
+	// regression guard against "any-overlap" semantics.
+	tmpl := `
+		port: -1
+		server_name: %s
+		server_tags: [%q, %q]
+		cluster {
+			name: "tagaware"
+			port: -1
+			%s
+			matching_tags: [%q]
+		}
+	`
+	// S1: az=az1, role=edge, requires az1.
+	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", "role-edge", "", "az1"))
+	s1, o1 := RunServerWithConfig(s1Conf)
+	defer s1.Shutdown()
+
+	routes := fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)
+	// S2: az=az2 (different locality) but shares role=edge.
+	// Old overlap semantics would falsely classify S2 as matching.
+	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az2", "role-edge", routes, "az2"))
+	s2, _ := RunServerWithConfig(s2Conf)
+	defer s2.Shutdown()
+
+	// S3: az=az1 (same locality as S1).
+	s3Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S3", "az1", "role-storage", routes, "az1"))
+	s3, _ := RunServerWithConfig(s3Conf)
+	defer s3.Shutdown()
+
+	checkClusterFormed(t, s1, s2, s3)
+
+	var s2Count, s3Count atomic.Int32
+	nc2 := natsConnect(t, s2.ClientURL())
+	defer nc2.Close()
+	_, err := nc2.QueueSubscribe("foo", "QG", func(*nats.Msg) { s2Count.Add(1) })
+	require_NoError(t, err)
+	require_NoError(t, nc2.Flush())
+
+	nc3 := natsConnect(t, s3.ClientURL())
+	defer nc3.Close()
+	_, err = nc3.QueueSubscribe("foo", "QG", func(*nats.Msg) { s3Count.Add(1) })
+	require_NoError(t, err)
+	require_NoError(t, nc3.Flush())
+
+	checkSubInterest(t, s1, globalAccountName, "foo", 2*time.Second)
+
+	ncPub := natsConnect(t, s1.ClientURL())
+	defer ncPub.Close()
+	const numMsgs = 200
+	for i := 0; i < numMsgs; i++ {
+		require_NoError(t, ncPub.Publish("foo", []byte("hi")))
+	}
+	require_NoError(t, ncPub.Flush())
+
+	checkFor(t, 2*time.Second, 25*time.Millisecond, func() error {
+		if total := s2Count.Load() + s3Count.Load(); total != numMsgs {
+			return fmt.Errorf("delivered %d/%d", total, numMsgs)
+		}
+		return nil
+	})
+
+	if s2Count.Load() != 0 {
+		t.Fatalf("cross-locality peer S2 (shares role=edge) received %d, expected 0", s2Count.Load())
+	}
+	if s3Count.Load() != numMsgs {
+		t.Fatalf("matching peer S3 received %d, expected %d", s3Count.Load(), numMsgs)
 	}
 }

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -5798,3 +5798,80 @@ func TestRouteQueueMatchingTagsSubsetSemantics(t *testing.T) {
 		t.Fatalf("matching peer S3 received %d, expected %d", s3Count.Load(), numMsgs)
 	}
 }
+
+func TestRouteQueueMatchingTagsRemoteFallbackOnLocalFailure(t *testing.T) {
+	// When matching_tags is set and the locality pool consists only of local
+	// CLIENTs (no matching peer ROUTER), and every local CLIENT fails to
+	// deliver (here simulated by sub.close() leaving the sub in the
+	// sublist — the same window as a slow-consumer or mid-delivery
+	// disconnect), the message must still fall back to a non-matching peer
+	// rather than being silently dropped.
+	tmpl := `
+		port: -1
+		server_name: %s
+		server_tags: [%q]
+		cluster {
+			name: "tagaware"
+			port: -1
+			%s
+			matching_tags: [%q]
+		}
+	`
+	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", "", "az1"))
+	s1, o1 := RunServerWithConfig(s1Conf)
+	defer s1.Shutdown()
+
+	routes := fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)
+	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az2", routes, "az2"))
+	s2, _ := RunServerWithConfig(s2Conf)
+	defer s2.Shutdown()
+
+	checkClusterFormed(t, s1, s2)
+
+	ncLocal := natsConnect(t, s1.ClientURL())
+	defer ncLocal.Close()
+	_, err := ncLocal.QueueSubscribe("foo", "QG", func(*nats.Msg) {})
+	require_NoError(t, err)
+	require_NoError(t, ncLocal.Flush())
+
+	ncRemote := natsConnect(t, s2.ClientURL())
+	defer ncRemote.Close()
+	var remote atomic.Int32
+	_, err = ncRemote.QueueSubscribe("foo", "QG", func(*nats.Msg) { remote.Add(1) })
+	require_NoError(t, err)
+	require_NoError(t, ncRemote.Flush())
+
+	checkSubInterest(t, s1, globalAccountName, "foo", 2*time.Second)
+
+	// Mark the local CLIENT sub closed without removing it from S1's
+	// sublist. closeConnection would issue UNSUB and prune the sub; here
+	// we want the exact window where Match still returns the sub but
+	// deliverMsg returns false.
+	acc, err := s1.LookupAccount(globalAccountName)
+	require_NoError(t, err)
+	res := acc.sl.Match("foo")
+	require_True(t, len(res.qsubs) == 1)
+	var closed bool
+	for _, qs := range res.qsubs[0] {
+		if qs.client != nil && qs.client.kind == CLIENT {
+			qs.close()
+			closed = true
+		}
+	}
+	require_True(t, closed)
+
+	ncPub := natsConnect(t, s1.ClientURL())
+	defer ncPub.Close()
+	const numMsgs = 50
+	for i := 0; i < numMsgs; i++ {
+		require_NoError(t, ncPub.Publish("foo", []byte("hi")))
+	}
+	require_NoError(t, ncPub.Flush())
+
+	checkFor(t, 2*time.Second, 25*time.Millisecond, func() error {
+		if got := remote.Load(); got != int32(numMsgs) {
+			return fmt.Errorf("non-matching peer received %d/%d (locality pool fully failed; expected fallback)", got, numMsgs)
+		}
+		return nil
+	})
+}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -5283,3 +5283,216 @@ func BenchmarkProcessLeafMsgArgs_Queues(b *testing.B) {
 		}
 	}
 }
+
+func TestRouteQueuePreferMatchingTags(t *testing.T) {
+	tmpl := `
+		port: -1
+		server_name: %s
+		server_tags: [%q]
+		cluster {
+			name: "tagaware"
+			port: -1
+			%s
+			prefer_matching_tags: %t
+		}
+	`
+
+	startCluster := func(t *testing.T, prefer bool) (s1, s2, s3 *Server) {
+		t.Helper()
+		s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", "", prefer))
+		s1, o1 := RunServerWithConfig(s1Conf)
+		t.Cleanup(s1.Shutdown)
+
+		routes := fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)
+		s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az1", routes, prefer))
+		s2, _ = RunServerWithConfig(s2Conf)
+		t.Cleanup(s2.Shutdown)
+
+		s3Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S3", "az2", routes, prefer))
+		s3, _ = RunServerWithConfig(s3Conf)
+		t.Cleanup(s3.Shutdown)
+
+		checkClusterFormed(t, s1, s2, s3)
+		return s1, s2, s3
+	}
+
+	runScenario := func(t *testing.T, prefer bool) (matchCount, otherCount int32) {
+		t.Helper()
+		s1, s2, s3 := startCluster(t, prefer)
+
+		ncMatch := natsConnect(t, s2.ClientURL())
+		t.Cleanup(ncMatch.Close)
+		var match atomic.Int32
+		_, err := ncMatch.QueueSubscribe("foo", "QG", func(*nats.Msg) { match.Add(1) })
+		require_NoError(t, err)
+		require_NoError(t, ncMatch.Flush())
+
+		ncOther := natsConnect(t, s3.ClientURL())
+		t.Cleanup(ncOther.Close)
+		var other atomic.Int32
+		_, err = ncOther.QueueSubscribe("foo", "QG", func(*nats.Msg) { other.Add(1) })
+		require_NoError(t, err)
+		require_NoError(t, ncOther.Flush())
+
+		checkSubInterest(t, s1, globalAccountName, "foo", 2*time.Second)
+
+		ncPub := natsConnect(t, s1.ClientURL())
+		t.Cleanup(ncPub.Close)
+		const numMsgs = 200
+		for i := 0; i < numMsgs; i++ {
+			require_NoError(t, ncPub.Publish("foo", []byte("hi")))
+		}
+		require_NoError(t, ncPub.Flush())
+
+		checkFor(t, 2*time.Second, 25*time.Millisecond, func() error {
+			if total := match.Load() + other.Load(); total != numMsgs {
+				return fmt.Errorf("delivered %d/%d", total, numMsgs)
+			}
+			return nil
+		})
+		return match.Load(), other.Load()
+	}
+
+	t.Run("disabled gives random distribution", func(t *testing.T) {
+		match, other := runScenario(t, false)
+		// With 200 messages and uniform random selection, the chance of
+		// either side getting zero is ~2^-199; treat that as a clear failure.
+		if match == 0 || other == 0 {
+			t.Fatalf("expected both peers to receive messages, got match=%d other=%d", match, other)
+		}
+	})
+
+	t.Run("enabled routes only to matching peer", func(t *testing.T) {
+		match, other := runScenario(t, true)
+		if other != 0 {
+			t.Fatalf("non-matching peer received %d messages, expected 0", other)
+		}
+		if match != 200 {
+			t.Fatalf("matching peer received %d messages, expected 200", match)
+		}
+	})
+}
+
+func TestRouteQueuePreferMatchingTagsLocalBeatsMatchingPeer(t *testing.T) {
+	tmpl := `
+		port: -1
+		server_name: %s
+		server_tags: [%q]
+		cluster {
+			name: "tagaware"
+			port: -1
+			%s
+			prefer_matching_tags: true
+		}
+	`
+	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", ""))
+	s1, o1 := RunServerWithConfig(s1Conf)
+	defer s1.Shutdown()
+
+	routes := fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)
+	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az1", routes))
+	s2, _ := RunServerWithConfig(s2Conf)
+	defer s2.Shutdown()
+
+	checkClusterFormed(t, s1, s2)
+
+	ncLocal := natsConnect(t, s1.ClientURL())
+	defer ncLocal.Close()
+	var local atomic.Int32
+	_, err := ncLocal.QueueSubscribe("foo", "QG", func(*nats.Msg) { local.Add(1) })
+	require_NoError(t, err)
+	require_NoError(t, ncLocal.Flush())
+
+	ncPeer := natsConnect(t, s2.ClientURL())
+	defer ncPeer.Close()
+	var peer atomic.Int32
+	_, err = ncPeer.QueueSubscribe("foo", "QG", func(*nats.Msg) { peer.Add(1) })
+	require_NoError(t, err)
+	require_NoError(t, ncPeer.Flush())
+
+	checkSubInterest(t, s1, globalAccountName, "foo", 2*time.Second)
+
+	ncPub := natsConnect(t, s1.ClientURL())
+	defer ncPub.Close()
+	const numMsgs = 200
+	for i := 0; i < numMsgs; i++ {
+		require_NoError(t, ncPub.Publish("foo", []byte("hi")))
+	}
+	require_NoError(t, ncPub.Flush())
+
+	checkFor(t, 2*time.Second, 25*time.Millisecond, func() error {
+		if total := local.Load() + peer.Load(); total != numMsgs {
+			return fmt.Errorf("delivered %d/%d", total, numMsgs)
+		}
+		return nil
+	})
+
+	if peer.Load() != 0 {
+		t.Fatalf("matching peer received %d messages, expected 0 (local should win)", peer.Load())
+	}
+	if local.Load() != numMsgs {
+		t.Fatalf("local sub received %d messages, expected %d", local.Load(), numMsgs)
+	}
+}
+
+func TestRouteQueuePreferMatchingTagsLocalSubWins(t *testing.T) {
+	tmpl := `
+		port: -1
+		server_name: %s
+		server_tags: [%q]
+		cluster {
+			name: "tagaware"
+			port: -1
+			%s
+			prefer_matching_tags: true
+		}
+	`
+	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", ""))
+	s1, o1 := RunServerWithConfig(s1Conf)
+	defer s1.Shutdown()
+
+	routes := fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)
+	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az2", routes))
+	s2, _ := RunServerWithConfig(s2Conf)
+	defer s2.Shutdown()
+
+	checkClusterFormed(t, s1, s2)
+
+	ncLocal := natsConnect(t, s1.ClientURL())
+	defer ncLocal.Close()
+	var local atomic.Int32
+	_, err := ncLocal.QueueSubscribe("foo", "QG", func(*nats.Msg) { local.Add(1) })
+	require_NoError(t, err)
+	require_NoError(t, ncLocal.Flush())
+
+	ncRemote := natsConnect(t, s2.ClientURL())
+	defer ncRemote.Close()
+	var remote atomic.Int32
+	_, err = ncRemote.QueueSubscribe("foo", "QG", func(*nats.Msg) { remote.Add(1) })
+	require_NoError(t, err)
+	require_NoError(t, ncRemote.Flush())
+
+	checkSubInterest(t, s1, globalAccountName, "foo", 2*time.Second)
+
+	ncPub := natsConnect(t, s1.ClientURL())
+	defer ncPub.Close()
+	const numMsgs = 200
+	for i := 0; i < numMsgs; i++ {
+		require_NoError(t, ncPub.Publish("foo", []byte("hi")))
+	}
+	require_NoError(t, ncPub.Flush())
+
+	checkFor(t, 2*time.Second, 25*time.Millisecond, func() error {
+		if total := local.Load() + remote.Load(); total != numMsgs {
+			return fmt.Errorf("delivered %d/%d", total, numMsgs)
+		}
+		return nil
+	})
+
+	if remote.Load() != 0 {
+		t.Fatalf("remote (non-matching) sub received %d messages, expected 0", remote.Load())
+	}
+	if local.Load() != numMsgs {
+		t.Fatalf("local sub received %d messages, expected %d", local.Load(), numMsgs)
+	}
+}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -5484,6 +5484,62 @@ func TestRouteInfoTagsReload(t *testing.T) {
 	}
 }
 
+func TestRouteTagsReloadRecomputesTagsMatch(t *testing.T) {
+	tmpl := `
+		port: -1
+		server_name: %s
+		server_tags: [%s]
+		cluster {
+			name: tagaware
+			port: -1
+			%s
+		}
+	`
+	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", ""))
+	s1, o1 := RunServerWithConfig(s1Conf)
+	defer s1.Shutdown()
+
+	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az1",
+		fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)))
+	s2, _ := RunServerWithConfig(s2Conf)
+	defer s2.Shutdown()
+
+	checkClusterFormed(t, s1, s2)
+
+	routeTagsMatch := func(s *Server) bool {
+		t.Helper()
+		var match bool
+		s.mu.RLock()
+		s.forEachRoute(func(r *client) {
+			r.mu.Lock()
+			if r.route != nil {
+				match = r.route.tagsMatch
+			}
+			r.mu.Unlock()
+		})
+		s.mu.RUnlock()
+		return match
+	}
+
+	if !routeTagsMatch(s1) {
+		t.Fatal("expected initial tagsMatch=true on S1's route")
+	}
+
+	reloadUpdateConfig(t, s1, s1Conf, `
+		port: -1
+		server_name: S1
+		server_tags: [az2]
+		cluster {
+			name: tagaware
+			port: -1
+		}
+	`)
+
+	if routeTagsMatch(s1) {
+		t.Fatal("expected tagsMatch=false on S1's route after reload to az2")
+	}
+}
+
 func TestRouteQueuePreferMatchingTagsBalancesWithMatchingPeer(t *testing.T) {
 	// With preferMatching, a local CLIENT sub and a matching-tag peer ROUTER
 	// are equally cheap; selection should remain 50/50 random across the two

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -5448,98 +5448,6 @@ func TestRouteQueuePreferMatchingTagsRouteBeatsLeaf(t *testing.T) {
 	}
 }
 
-func TestRouteInfoTagsReload(t *testing.T) {
-	conf := createConfFile(t, []byte(`
-		port: -1
-		server_tags: [az1]
-		cluster {
-			name: tagaware
-			port: -1
-		}
-	`))
-	s, _ := RunServerWithConfig(conf)
-	defer s.Shutdown()
-
-	s.mu.RLock()
-	got := append([]string(nil), s.routeInfo.Tags...)
-	s.mu.RUnlock()
-	if !reflect.DeepEqual(got, []string{"az1"}) {
-		t.Fatalf("expected initial routeInfo.Tags=[az1], got %v", got)
-	}
-
-	reloadUpdateConfig(t, s, conf, `
-		port: -1
-		server_tags: [az2]
-		cluster {
-			name: tagaware
-			port: -1
-		}
-	`)
-
-	s.mu.RLock()
-	got = append([]string(nil), s.routeInfo.Tags...)
-	s.mu.RUnlock()
-	if !reflect.DeepEqual(got, []string{"az2"}) {
-		t.Fatalf("expected reloaded routeInfo.Tags=[az2], got %v", got)
-	}
-}
-
-func TestRouteTagsReloadRecomputesTagsMatch(t *testing.T) {
-	tmpl := `
-		port: -1
-		server_name: %s
-		server_tags: [%s]
-		cluster {
-			name: tagaware
-			port: -1
-			%s
-		}
-	`
-	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", ""))
-	s1, o1 := RunServerWithConfig(s1Conf)
-	defer s1.Shutdown()
-
-	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az1",
-		fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)))
-	s2, _ := RunServerWithConfig(s2Conf)
-	defer s2.Shutdown()
-
-	checkClusterFormed(t, s1, s2)
-
-	routeTagsMatch := func(s *Server) bool {
-		t.Helper()
-		var match bool
-		s.mu.RLock()
-		s.forEachRoute(func(r *client) {
-			r.mu.Lock()
-			if r.route != nil {
-				match = r.route.tagsMatch
-			}
-			r.mu.Unlock()
-		})
-		s.mu.RUnlock()
-		return match
-	}
-
-	if !routeTagsMatch(s1) {
-		t.Fatal("expected initial tagsMatch=true on S1's route")
-	}
-
-	reloadUpdateConfig(t, s1, s1Conf, `
-		port: -1
-		server_name: S1
-		server_tags: [az2]
-		cluster {
-			name: tagaware
-			port: -1
-		}
-	`)
-
-	if routeTagsMatch(s1) {
-		t.Fatal("expected tagsMatch=false on S1's route after reload to az2")
-	}
-}
-
 func TestRouteQueuePreferMatchingTagsBalancesWithMatchingPeer(t *testing.T) {
 	// With preferMatching, a local CLIENT sub and a matching-tag peer ROUTER
 	// are equally cheap; selection should remain 50/50 random across the two
@@ -5662,5 +5570,149 @@ func TestRouteQueuePreferMatchingTagsLocalSubWins(t *testing.T) {
 	}
 	if local.Load() != numMsgs {
 		t.Fatalf("local sub received %d messages, expected %d", local.Load(), numMsgs)
+	}
+}
+
+func TestRouteQueuePreferMatchingTagsExcludesCrossAZ(t *testing.T) {
+	// 2 servers per AZ across 2 AZs, queue subs on every node, publisher on
+	// S1a with a local sub. The pre-scan AZ pool on S1a is [LocalS1a,
+	// RouteToS2a] (matching), so traffic must split between those two and
+	// AZ2 peers must receive none.
+	tmpl := `
+		port: -1
+		server_name: %s
+		server_tags: [%q]
+		cluster {
+			name: "tagaware"
+			port: -1
+			%s
+			prefer_matching_tags: true
+		}
+	`
+	s1aConf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1a", "az1", ""))
+	s1a, o1 := RunServerWithConfig(s1aConf)
+	defer s1a.Shutdown()
+
+	routes := fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)
+	s2aConf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2a", "az1", routes))
+	s2a, _ := RunServerWithConfig(s2aConf)
+	defer s2a.Shutdown()
+
+	s3bConf := createConfFile(t, fmt.Appendf(nil, tmpl, "S3b", "az2", routes))
+	s3b, _ := RunServerWithConfig(s3bConf)
+	defer s3b.Shutdown()
+
+	s4bConf := createConfFile(t, fmt.Appendf(nil, tmpl, "S4b", "az2", routes))
+	s4b, _ := RunServerWithConfig(s4bConf)
+	defer s4b.Shutdown()
+
+	checkClusterFormed(t, s1a, s2a, s3b, s4b)
+
+	var s1aCount, s2aCount, s3bCount, s4bCount atomic.Int32
+	sub := func(srv *Server, c *atomic.Int32) {
+		nc := natsConnect(t, srv.ClientURL())
+		t.Cleanup(nc.Close)
+		_, err := nc.QueueSubscribe("foo", "QG", func(*nats.Msg) { c.Add(1) })
+		require_NoError(t, err)
+		require_NoError(t, nc.Flush())
+	}
+	sub(s1a, &s1aCount)
+	sub(s2a, &s2aCount)
+	sub(s3b, &s3bCount)
+	sub(s4b, &s4bCount)
+
+	checkSubInterest(t, s1a, globalAccountName, "foo", 2*time.Second)
+
+	ncPub := natsConnect(t, s1a.ClientURL())
+	defer ncPub.Close()
+	const numMsgs = 400
+	for i := 0; i < numMsgs; i++ {
+		require_NoError(t, ncPub.Publish("foo", []byte("hi")))
+	}
+	require_NoError(t, ncPub.Flush())
+
+	checkFor(t, 2*time.Second, 25*time.Millisecond, func() error {
+		total := s1aCount.Load() + s2aCount.Load() + s3bCount.Load() + s4bCount.Load()
+		if total != numMsgs {
+			return fmt.Errorf("delivered %d/%d", total, numMsgs)
+		}
+		return nil
+	})
+
+	if s3bCount.Load() != 0 || s4bCount.Load() != 0 {
+		t.Fatalf("AZ2 received traffic, expected 0: S3b=%d S4b=%d",
+			s3bCount.Load(), s4bCount.Load())
+	}
+	if s1aCount.Load() == 0 || s2aCount.Load() == 0 {
+		t.Fatalf("AZ1 candidates not balanced: S1a=%d S2a=%d",
+			s1aCount.Load(), s2aCount.Load())
+	}
+}
+
+func TestRouteQueuePreferMatchingTagsNoAZLocalFallback(t *testing.T) {
+	// Publisher's server has neither a local sub nor a matching peer; the
+	// AZ pool is empty and the pre-scan must fall through to the original
+	// cluster-wide selection so messages still distribute across the
+	// non-matching peers.
+	tmpl := `
+		port: -1
+		server_name: %s
+		server_tags: [%q]
+		cluster {
+			name: "tagaware"
+			port: -1
+			%s
+			prefer_matching_tags: true
+		}
+	`
+	s1Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S1", "az1", ""))
+	s1, o1 := RunServerWithConfig(s1Conf)
+	defer s1.Shutdown()
+
+	routes := fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, o1.Cluster.Port)
+	s2Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S2", "az2", routes))
+	s2, _ := RunServerWithConfig(s2Conf)
+	defer s2.Shutdown()
+
+	s3Conf := createConfFile(t, fmt.Appendf(nil, tmpl, "S3", "az3", routes))
+	s3, _ := RunServerWithConfig(s3Conf)
+	defer s3.Shutdown()
+
+	checkClusterFormed(t, s1, s2, s3)
+
+	nc2 := natsConnect(t, s2.ClientURL())
+	defer nc2.Close()
+	var s2Count atomic.Int32
+	_, err := nc2.QueueSubscribe("foo", "QG", func(*nats.Msg) { s2Count.Add(1) })
+	require_NoError(t, err)
+	require_NoError(t, nc2.Flush())
+
+	nc3 := natsConnect(t, s3.ClientURL())
+	defer nc3.Close()
+	var s3Count atomic.Int32
+	_, err = nc3.QueueSubscribe("foo", "QG", func(*nats.Msg) { s3Count.Add(1) })
+	require_NoError(t, err)
+	require_NoError(t, nc3.Flush())
+
+	checkSubInterest(t, s1, globalAccountName, "foo", 2*time.Second)
+
+	ncPub := natsConnect(t, s1.ClientURL())
+	defer ncPub.Close()
+	const numMsgs = 200
+	for i := 0; i < numMsgs; i++ {
+		require_NoError(t, ncPub.Publish("foo", []byte("hi")))
+	}
+	require_NoError(t, ncPub.Flush())
+
+	checkFor(t, 2*time.Second, 25*time.Millisecond, func() error {
+		if total := s2Count.Load() + s3Count.Load(); total != numMsgs {
+			return fmt.Errorf("delivered %d/%d", total, numMsgs)
+		}
+		return nil
+	})
+
+	if s2Count.Load() == 0 || s3Count.Load() == 0 {
+		t.Fatalf("expected both non-matching peers to receive messages, got S2=%d S3=%d",
+			s2Count.Load(), s3Count.Load())
 	}
 }

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -5373,6 +5373,42 @@ func TestRouteQueuePreferMatchingTags(t *testing.T) {
 	})
 }
 
+func TestRouteInfoTagsReload(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		port: -1
+		server_tags: [az1]
+		cluster {
+			name: tagaware
+			port: -1
+		}
+	`))
+	s, _ := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	s.mu.RLock()
+	got := append([]string(nil), s.routeInfo.Tags...)
+	s.mu.RUnlock()
+	if !reflect.DeepEqual(got, []string{"az1"}) {
+		t.Fatalf("expected initial routeInfo.Tags=[az1], got %v", got)
+	}
+
+	reloadUpdateConfig(t, s, conf, `
+		port: -1
+		server_tags: [az2]
+		cluster {
+			name: tagaware
+			port: -1
+		}
+	`)
+
+	s.mu.RLock()
+	got = append([]string(nil), s.routeInfo.Tags...)
+	s.mu.RUnlock()
+	if !reflect.DeepEqual(got, []string{"az2"}) {
+		t.Fatalf("expected reloaded routeInfo.Tags=[az2], got %v", got)
+	}
+}
+
 func TestRouteQueuePreferMatchingTagsLocalBeatsMatchingPeer(t *testing.T) {
 	tmpl := `
 		port: -1

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -5361,10 +5361,10 @@ func TestRouteQueueMatchingTags(t *testing.T) {
 
 	t.Run("disabled gives random distribution", func(t *testing.T) {
 		match, other := runScenario(t, false)
-		// With 200 messages and uniform random selection, the chance of
-		// either side getting zero is ~2^-199; treat that as a clear failure.
-		if match == 0 || other == 0 {
-			t.Fatalf("expected both peers to receive messages, got match=%d other=%d", match, other)
+		const minPerSide = 200 / 4
+		if match < minPerSide || other < minPerSide {
+			t.Fatalf("expected balanced distribution, got match=%d other=%d (each must be >= %d)",
+				match, other, minPerSide)
 		}
 	})
 
@@ -5511,9 +5511,10 @@ func TestRouteQueueMatchingTagsBalancesWithMatchingPeer(t *testing.T) {
 		return nil
 	})
 
-	if local.Load() == 0 || peer.Load() == 0 {
-		t.Fatalf("expected both candidates to receive messages, got local=%d peer=%d",
-			local.Load(), peer.Load())
+	const minPerSide = numMsgs / 4
+	if local.Load() < minPerSide || peer.Load() < minPerSide {
+		t.Fatalf("expected balanced distribution, got local=%d peer=%d (each must be >= %d)",
+			local.Load(), peer.Load(), minPerSide)
 	}
 }
 
@@ -5649,9 +5650,10 @@ func TestRouteQueueMatchingTagsExcludesCrossLocality(t *testing.T) {
 		t.Fatalf("az2 received traffic, expected 0: S3b=%d S4b=%d",
 			s3bCount.Load(), s4bCount.Load())
 	}
-	if s1aCount.Load() == 0 || s2aCount.Load() == 0 {
-		t.Fatalf("az1 candidates not balanced: S1a=%d S2a=%d",
-			s1aCount.Load(), s2aCount.Load())
+	const minPerSide = numMsgs / 4
+	if s1aCount.Load() < minPerSide || s2aCount.Load() < minPerSide {
+		t.Fatalf("az1 candidates not balanced: S1a=%d S2a=%d (each must be >= %d)",
+			s1aCount.Load(), s2aCount.Load(), minPerSide)
 	}
 }
 
@@ -5717,9 +5719,10 @@ func TestRouteQueueMatchingTagsNoLocalFallback(t *testing.T) {
 		return nil
 	})
 
-	if s2Count.Load() == 0 || s3Count.Load() == 0 {
-		t.Fatalf("expected both non-matching peers to receive messages, got S2=%d S3=%d",
-			s2Count.Load(), s3Count.Load())
+	const minPerSide = numMsgs / 4
+	if s2Count.Load() < minPerSide || s3Count.Load() < minPerSide {
+		t.Fatalf("expected balanced distribution, got S2=%d S3=%d (each must be >= %d)",
+			s2Count.Load(), s3Count.Load(), minPerSide)
 	}
 }
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -5373,6 +5373,81 @@ func TestRouteQueuePreferMatchingTags(t *testing.T) {
 	})
 }
 
+func TestRouteQueuePreferMatchingTagsRouteBeatsLeaf(t *testing.T) {
+	// HubAz1 (tag az1) and HubAz2 (tag az2) form a cluster. A leaf attaches
+	// to HubAz1. Queue subs land on HubAz2 (non-matching peer, via route)
+	// and on the leaf. Publisher on HubAz1 has no local sub. We expect the
+	// non-matching ROUTER to still beat the LEAF candidate.
+	hubTmpl := `
+		port: -1
+		server_name: %s
+		server_tags: [%q]
+		leafnodes { port: -1 }
+		cluster {
+			name: tagaware
+			port: -1
+			%s
+			prefer_matching_tags: true
+		}
+	`
+	h1Conf := createConfFile(t, fmt.Appendf(nil, hubTmpl, "HubAz1", "az1", ""))
+	h1, h1Opts := RunServerWithConfig(h1Conf)
+	defer h1.Shutdown()
+
+	h2Conf := createConfFile(t, fmt.Appendf(nil, hubTmpl, "HubAz2", "az2",
+		fmt.Sprintf(`routes: ["nats://127.0.0.1:%d"]`, h1Opts.Cluster.Port)))
+	h2, _ := RunServerWithConfig(h2Conf)
+	defer h2.Shutdown()
+
+	checkClusterFormed(t, h1, h2)
+
+	leafConf := createConfFile(t, fmt.Appendf(nil, `
+		port: -1
+		server_name: Leaf
+		leafnodes { remotes = [{ url: "nats-leaf://127.0.0.1:%d" }] }
+	`, h1Opts.LeafNode.Port))
+	leaf, _ := RunServerWithConfig(leafConf)
+	defer leaf.Shutdown()
+
+	checkLeafNodeConnected(t, leaf)
+
+	ncRoute := natsConnect(t, h2.ClientURL())
+	defer ncRoute.Close()
+	var routeCount atomic.Int32
+	natsQueueSub(t, ncRoute, "foo", "QG", func(*nats.Msg) { routeCount.Add(1) })
+	natsFlush(t, ncRoute)
+
+	ncLeaf := natsConnect(t, leaf.ClientURL())
+	defer ncLeaf.Close()
+	var leafCount atomic.Int32
+	natsQueueSub(t, ncLeaf, "foo", "QG", func(*nats.Msg) { leafCount.Add(1) })
+	natsFlush(t, ncLeaf)
+
+	checkSubInterest(t, h1, globalAccountName, "foo", 2*time.Second)
+
+	ncPub := natsConnect(t, h1.ClientURL())
+	defer ncPub.Close()
+	const numMsgs = 200
+	for i := 0; i < numMsgs; i++ {
+		natsPub(t, ncPub, "foo", []byte("hi"))
+	}
+	natsFlush(t, ncPub)
+
+	checkFor(t, 2*time.Second, 25*time.Millisecond, func() error {
+		if total := routeCount.Load() + leafCount.Load(); total != numMsgs {
+			return fmt.Errorf("delivered %d/%d", total, numMsgs)
+		}
+		return nil
+	})
+
+	if leafCount.Load() != 0 {
+		t.Fatalf("leaf received %d messages, expected 0 (route should win)", leafCount.Load())
+	}
+	if routeCount.Load() != numMsgs {
+		t.Fatalf("route peer received %d, expected %d", routeCount.Load(), numMsgs)
+	}
+}
+
 func TestRouteInfoTagsReload(t *testing.T) {
 	conf := createConfFile(t, []byte(`
 		port: -1
@@ -5409,7 +5484,10 @@ func TestRouteInfoTagsReload(t *testing.T) {
 	}
 }
 
-func TestRouteQueuePreferMatchingTagsLocalBeatsMatchingPeer(t *testing.T) {
+func TestRouteQueuePreferMatchingTagsBalancesWithMatchingPeer(t *testing.T) {
+	// With preferMatching, a local CLIENT sub and a matching-tag peer ROUTER
+	// are equally cheap; selection should remain 50/50 random across the two
+	// to preserve queue-group load balancing within an AZ.
 	tmpl := `
 		port: -1
 		server_name: %s
@@ -5463,11 +5541,9 @@ func TestRouteQueuePreferMatchingTagsLocalBeatsMatchingPeer(t *testing.T) {
 		return nil
 	})
 
-	if peer.Load() != 0 {
-		t.Fatalf("matching peer received %d messages, expected 0 (local should win)", peer.Load())
-	}
-	if local.Load() != numMsgs {
-		t.Fatalf("local sub received %d messages, expected %d", local.Load(), numMsgs)
+	if local.Load() == 0 || peer.Load() == 0 {
+		t.Fatalf("expected both candidates to receive messages, got local=%d peer=%d",
+			local.Load(), peer.Load())
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -148,7 +148,7 @@ type Info struct {
 	RouteAccount  string             `json:"route_account,omitempty"`
 	RouteAccReqID string             `json:"route_acc_add_reqid,omitempty"`
 	GossipMode    byte               `json:"gossip_mode,omitempty"`
-	Tags          []string           `json:"tags,omitempty"`
+	Tags          []string           `json:"tags,omitempty"` // Route-only — must not leak to client/leaf/gateway Info.
 
 	// Gateways Specific
 	Gateway           string   `json:"gateway,omitempty"`             // Name of the origin Gateway (sent by gateway's INFO)

--- a/server/server.go
+++ b/server/server.go
@@ -379,6 +379,11 @@ type Server struct {
 	// Currently used by unit tests to simulate nodes not supporting account NRG.
 	accountNRGAllowed atomic.Bool
 
+	// Cached toggle for cluster.matching_tags so the route delivery
+	// hot path can skip the optsMu RLock in getOpts() per dispatch.
+	// Updated on startup and on cluster reload.
+	matchTagsEnabled atomic.Bool
+
 	// List of proxies trusted keys in `KeyPair` form so we can do signature
 	// verification when processing incoming proxy connections.
 	proxiesKeyPairs []nkeys.KeyPair
@@ -777,6 +782,9 @@ func NewServer(opts *Options) (*Server, error) {
 
 	// By default we'll allow account NRG.
 	s.accountNRGAllowed.Store(true)
+
+	// Seed the matching_tags hot-path toggle from the initial opts.
+	s.matchTagsEnabled.Store(len(opts.Cluster.MatchingTags) > 0)
 
 	// Fill up the maximum in flight syncRequests for this server.
 	// Used in JetStream catchup semantics.

--- a/server/server.go
+++ b/server/server.go
@@ -148,6 +148,7 @@ type Info struct {
 	RouteAccount  string             `json:"route_account,omitempty"`
 	RouteAccReqID string             `json:"route_acc_add_reqid,omitempty"`
 	GossipMode    byte               `json:"gossip_mode,omitempty"`
+	Tags          []string           `json:"tags,omitempty"`
 
 	// Gateways Specific
 	Gateway           string   `json:"gateway,omitempty"`             // Name of the origin Gateway (sent by gateway's INFO)


### PR DESCRIPTION
Resolves #8072.

## Summary

Adds opt-in `cluster.matching_tags` for tag-aware queue-group routing. When
set, the publisher's server prefers a locality-local pool of [local CLIENTs
+ routed peers whose tags satisfy the filter]. Unset, behavior is unchanged.

## Design

- Route INFO carries a new `Tags` field, populated from `opts.Tags`.
- `cluster.matching_tags` is an explicit tag list; a peer route is
  "matching" iff every required tag is present in its advertised `Tags`
  (subset semantic).
- `tagsMatch` is precomputed per route as `atomic.Bool` — written under
  the route mutex on INFO/reload, read lock-free in the hot path.
- `processMsgResults` pre-scans `qsubs` into the locality-local pool. If
  non-empty, it replaces `qsubs` for the random pick; otherwise the
  original cluster-wide selection runs unchanged.

Within the pool, a local CLIENT and a matching peer ROUTER are **co-equal**
random candidates, preserving queue-group balance inside the locality.
LEAFs are excluded (not tagged); their fallback role is preserved when
the pool is empty.

Both `server_tags` and `matching_tags` reload without bouncing routes:
`server_tags` broadcasts async INFO so peers refresh their view;
`matching_tags` recomputes `tagsMatch` locally on existing routes.

## Trade-off

Asymmetric consumer placement (e.g., 1 on A, 5 on B in the same AZ)
splits A's publishes ~50/50 between A's local sub and a matched route
to B (where existing per-server fan-out then balances B's 5 workers).
Co-equal locality is the explicit design.

## Tests

`server/routes_test.go` — 7 routing tests (`TestRouteQueueMatchingTags*`)
covering: disabled baseline, matching-only delivery, in-pool 50/50
balance, local-sub-wins, route-beats-leaf, cross-AZ exclusion, empty-pool
fallback, subset-semantics regression guard.

`server/reload_test.go` — 4 reload tests (`TestConfigReload*Tags*`)
covering: `routeInfo.Tags` refresh, `matching_tags` recomputation on
existing routes, end-to-end reload, server_tags propagation to peers
without reconnect.

Pass under `-race`.

## Empirical validation

Kind cluster, 4 pods (2× `az1`, 2× `az2`), one queue sub per zone.
10 trials × 100 messages from a publisher with no local sub:

|                                              | Cross-AZ deliveries |
|----------------------------------------------|--------------------:|
| `nats:latest`                                | 982 / 2,000 (~49%)  |
| This branch, `matching_tags: [az1]` on az1   | 0 / 2,000 (0%)      |

## Test plan

- [ ] CI passes
- [ ] Reviewer agreement on co-equal-locality (local CLIENT and
      matching peer share equal weight in the random pick)

Signed-off-by: Mikael Sundberg <mikael@wingbits.com>
