### PR TITLE
De-flake TestJetStreamClusterConsumerLeak

### DIFF
--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -1905,8 +1905,8 @@ func TestJetStreamClusterAckFloorBetweenLeaderAndFollowers(t *testing.T) {
 
 // https://github.com/nats-io/nats-server/pull/5600
 func TestJetStreamClusterConsumerLeak(t *testing.T) {
-	N := 2000 // runs in under 10s, but significant enough to see the difference.
-	NConcurrent := 100
+	N := 2000
+	NConcurrent := 25
 
 	clusterConf := `
 	listen: 127.0.0.1:-1


### PR DESCRIPTION
## Summary

`TestJetStreamClusterConsumerLeak` has been failing intermittently in CI on the `Test JetStream Cluster 4` shard with `context deadline exceeded` errors during `js.AddConsumer`. Locally on `main` it failed on the first run for me at ~136s.

The test was added in [PR #5600](https://github.com/nats-io/nats-server/pull/5600) (June 2024) as a regression test for memory growth from NRG create/delete operations, with `N=2000, NConcurrent=100`. The accompanying comment ("runs in under 10s") was true at the time. Since then, additional cluster work in the consumer create/delete path has slowed each op down by ~10×; on busy CI runners 100-way concurrency saturates the meta-Raft and individual API requests cross the 10s default JetStream timeout.

This change drops `NConcurrent` from 100 to 25. At that level the cluster keeps up and no `context deadline exceeded` errors surface.

## Detection still works

Validated by reverting the `clear(c.in.pacache)` fix from PR #5600 (single-key `delete` instead of full clear). The modified test fails as expected with `Extra memory usage too high: 199426048` — well over the 100 MB threshold. So the lower concurrency does not weaken the regression signal.

## Tradeoff & open questions

This is the fastest reliable configuration I found. It runs locally in ~150s on my machine. I tried several other angles before settling here:

- **conc=50**: same 143s wallclock as conc=25 — the cluster is the bottleneck, not goroutine parallelism.
- **Tighter poll** (1ms) in the inline equivalent of `cl.waitOnAllCurrent`: shaved 13s (143s → 130s). The cluster Raft work simply absorbed the freed CPU into Add latency, so the saving did not compound.
- **Skipping the `cl.waitOnAllCurrent()` call**: would race the Delete against the Add's NRG replication — exactly the race the [Nov 2024 de-flake](https://github.com/nats-io/nats-server/commit/eeeb43551b7e3498dd7a9bb5b2cbd40f5b629d01) added it to prevent.
- **R=1 stream/consumer**: no NRG → no route subject churn → bug doesn't trigger.
- **R=2 consumer**: only 1 NRG route instead of 3 → ~⅓ the leak signal (~66 MB), under the threshold.
- **Reducing N**: leak signal scales linearly. Below N≈1500 the signal approaches the threshold and risks new flakes.

Per-iteration timing breakdown (with conc=25): ~73% of total time was the `cl.waitOnAllCurrent` poll, ~17% Add, ~4% Delete. The poll dominates only because the meta-Raft is saturated and `applied >= committed` is rarely true; the actual cluster work is the floor.

If 150s feels too expensive for what is ultimately a coarse "is HeapInuse > 100 MB?" assertion, a reasonable alternative is to delete this test and replace it with targeted unit tests for each cleanup path PR #5600 fixed (pacache clear, `filestore.Delete`, `raft.shutdown` cleanup, `processConsumerRemoval` Group.node nil). I'm happy to attempt that if maintainers prefer — though several of those paths are inherently cluster-state and hard to unit-test in isolation.

## Test plan

- [x] `go test -v -run='^TestJetStreamClusterConsumerLeak$' -count=1 ./server` — PASS at ~150s on `main`+this change
- [x] Revert `clear(c.in.pacache)` to single-key `delete`, re-run — FAIL with 199 MB heap growth (regression detected)
- [x] Restore fix, re-run — PASS

Signed-off-by: mikael@wingbits.com