### PR TITLE
(2.14) [FIXED] Schedule source matches stream subjects 

### DIFF
--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -827,7 +827,7 @@ func checkMsgHeadersPreClusteredProposal(
 			} else if scheduleTtl != _EMPTY_ && !allowTTL {
 				return hdr, msg, 0, NewJSMessageTTLDisabledError(), errMsgTTLDisabled
 			} else if scheduleTarget := getMessageScheduleTarget(hdr); scheduleTarget == _EMPTY_ ||
-				!IsValidPublishSubject(scheduleTarget) || SubjectsCollide(scheduleTarget, subject) {
+				!IsValidPublishSubject(scheduleTarget) || scheduleTarget == subject {
 				apiErr := NewJSMessageSchedulesTargetInvalidError()
 				return hdr, msg, 0, apiErr, apiErr
 			} else if scheduleSource := getMessageScheduleSource(hdr); scheduleSource != _EMPTY_ &&

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -839,11 +839,22 @@ func checkMsgHeadersPreClusteredProposal(
 				match := slices.ContainsFunc(mset.cfg.Subjects, func(subj string) bool {
 					return SubjectsCollide(subj, scheduleTarget)
 				})
-				mset.cfgMu.RUnlock()
 				if !match {
+					mset.cfgMu.RUnlock()
 					apiErr := NewJSMessageSchedulesTargetInvalidError()
 					return hdr, msg, 0, apiErr, apiErr
 				}
+				if scheduleSource != _EMPTY_ {
+					match = slices.ContainsFunc(mset.cfg.Subjects, func(subj string) bool {
+						return SubjectsCollide(subj, scheduleSource)
+					})
+					if !match {
+						mset.cfgMu.RUnlock()
+						apiErr := NewJSMessageSchedulesSourceInvalidError()
+						return hdr, msg, 0, apiErr, apiErr
+					}
+				}
+				mset.cfgMu.RUnlock()
 
 				// Add a rollup sub header if it doesn't already exist.
 				// Otherwise, it must exist already as a rollup on the subject.

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -9648,7 +9648,8 @@ func TestJetStreamClusterScheduledMessageSubjectSourcing(t *testing.T) {
 				// Invalid sources include if the subject:
 				// - matches the schedule/target subject
 				// - contains wildcard/is not literal
-				for _, src := range []string{"foo.schedule", "foo.publish", "foo.*", "foo.>"} {
+				// - doesn't match the stream subjects
+				for _, src := range []string{"foo.schedule", "foo.publish", "foo.*", "foo.>", "bar"} {
 					m.Header.Set("Nats-Schedule-Source", src)
 					_, err = js.PublishMsg(m)
 					require_Error(t, err, NewJSMessageSchedulesSourceInvalidError())

--- a/server/stream.go
+++ b/server/stream.go
@@ -6438,6 +6438,21 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 						}
 						return apiErr
 					}
+					if scheduleSource != _EMPTY_ {
+						match = slices.ContainsFunc(mset.cfg.Subjects, func(subj string) bool {
+							return SubjectsCollide(subj, scheduleSource)
+						})
+						if !match {
+							apiErr := NewJSMessageSchedulesSourceInvalidError()
+							if canRespond {
+								resp.PubAck = &PubAck{Stream: name}
+								resp.Error = apiErr
+								b, _ := json.Marshal(resp)
+								outq.sendMsg(reply, b)
+							}
+							return apiErr
+						}
+					}
 
 					// Add a rollup sub header if it doesn't already exist.
 					// Otherwise, it must exist already as a rollup on the subject.

--- a/server/stream.go
+++ b/server/stream.go
@@ -6405,7 +6405,7 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 					}
 					return errMsgTTLDisabled
 				} else if scheduleTarget := getMessageScheduleTarget(hdr); scheduleTarget == _EMPTY_ ||
-					!IsValidPublishSubject(scheduleTarget) || SubjectsCollide(scheduleTarget, subject) {
+					!IsValidPublishSubject(scheduleTarget) || scheduleTarget == subject {
 					apiErr := NewJSMessageSchedulesTargetInvalidError()
 					if canRespond {
 						resp.PubAck = &PubAck{Stream: name}


### PR DESCRIPTION
Make sure the `Nats-Schedule-Source` matches one of the stream subjects, just like with `Nats-Schedule-Target`.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>