### PR TITLE
Fix potential deadlock when `clusterInfo` hits Raft lock contention

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -10487,24 +10487,29 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 		return nil
 	}
 	js.mu.RLock()
-	defer js.mu.RUnlock()
-
 	s := js.srv
 	if rg == nil || rg.node == nil {
+		js.mu.RUnlock()
 		return &ClusterInfo{
 			Name:   s.cachedClusterName(),
 			Leader: s.Name(),
 		}
 	}
 
+	// Capture what we need and let go of the lock to ensure that
+	// contention on Raft locks can't happen while holding JS lock.
 	n := rg.node
+	rgName := rg.Name
+	rgPeers := slices.Clone(rg.Peers)
+	js.mu.RUnlock()
+
 	ci := &ClusterInfo{
 		Name:        s.cachedClusterName(),
 		Leader:      s.serverNameForNode(n.GroupLeader()),
 		LeaderSince: n.LeaderSince(),
 		SystemAcc:   n.IsSystemAccount(),
 		TrafficAcc:  n.GetTrafficAccountName(),
-		RaftGroup:   rg.Name,
+		RaftGroup:   rgName,
 	}
 
 	now := time.Now()
@@ -10516,7 +10521,7 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 	}
 
 	for _, rp := range peers {
-		if rp.ID != id && rg.isMember(rp.ID) {
+		if rp.ID != id && slices.Contains(rgPeers, rp.ID) {
 			var lastSeen time.Duration
 			if now.After(rp.Last) && !rp.Last.IsZero() {
 				lastSeen = now.Sub(rp.Last)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -23757,3 +23757,38 @@ func TestJetStreamDurableStreamSourcesWithUniqueConsumerNames(t *testing.T) {
 		return nil
 	})
 }
+
+func TestJetStreamClusterInfoDoesNotBlockJSMutex(t *testing.T) {
+	// Use a real raft node with its RWMutex held to simulate a Raft
+	// runloop blocked during vote processing, e.g. by dios. clusterInfo
+	// calls GroupLeader which needs the raft RLock, so it will block.
+	n := &raft{}
+	n.Lock()
+	defer n.Unlock()
+
+	js := &jetStream{srv: &Server{}}
+	rg := &raftGroup{
+		Name:  "test",
+		Peers: []string{"a", "b"},
+		node:  n,
+	}
+
+	// clusterInfo will block inside n.GroupLeader waiting for Raft RLock.
+	go js.clusterInfo(rg)
+
+	// Give it a moment to enter GroupLeader.
+	time.Sleep(50 * time.Millisecond)
+
+	// If clusterInfo holds js.mu.RLock during Raft calls,
+	// this Lock will block and the test will time out.
+	done := make(chan struct{})
+	go func() {
+		js.mu.Lock()
+		runtime.Gosched()
+		js.mu.Unlock()
+		close(done)
+	}()
+
+	// If contending then this will error.
+	require_ChanRead(t, done, time.Second)
+}


### PR DESCRIPTION
Signed-off-by: Neil Twigg <neil@nats.io>