### PR TITLE
Don't use sublist caches when disabled

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1061,18 +1061,19 @@ func (c *client) setPermissions(perms *Permissions) {
 		return
 	}
 	c.perms = &permissions{}
+	slcache := c.srv != nil && !c.srv.getOpts().NoSublistCache
 
 	// Loop over publish permissions
 	if perms.Publish != nil {
 		if perms.Publish.Allow != nil {
-			c.perms.pub.allow = NewSublistWithCache()
+			c.perms.pub.allow = NewSublist(slcache)
 		}
 		for _, pubSubject := range perms.Publish.Allow {
 			sub := &subscription{subject: []byte(pubSubject)}
 			c.perms.pub.allow.Insert(sub)
 		}
 		if len(perms.Publish.Deny) > 0 {
-			c.perms.pub.deny = NewSublistWithCache()
+			c.perms.pub.deny = NewSublist(slcache)
 		}
 		for _, pubSubject := range perms.Publish.Deny {
 			sub := &subscription{subject: []byte(pubSubject)}
@@ -1091,7 +1092,7 @@ func (c *client) setPermissions(perms *Permissions) {
 	if perms.Subscribe != nil {
 		var err error
 		if len(perms.Subscribe.Allow) > 0 {
-			c.perms.sub.allow = NewSublistWithCache()
+			c.perms.sub.allow = NewSublist(slcache)
 		}
 		for _, subSubject := range perms.Subscribe.Allow {
 			sub := &subscription{}
@@ -1103,7 +1104,7 @@ func (c *client) setPermissions(perms *Permissions) {
 			c.perms.sub.allow.Insert(sub)
 		}
 		if len(perms.Subscribe.Deny) > 0 {
-			c.perms.sub.deny = NewSublistWithCache()
+			c.perms.sub.deny = NewSublist(slcache)
 			// Also hold onto this array for later.
 			c.darray = perms.Subscribe.Deny
 		}
@@ -1200,6 +1201,7 @@ func (c *client) mergeDenyPermissions(what denyType, denyPubs []string) {
 	if c.perms == nil {
 		c.perms = &permissions{}
 	}
+	slcache := c.srv != nil && !c.srv.getOpts().NoSublistCache
 	var perms []*perm
 	switch what {
 	case pub:
@@ -1211,7 +1213,7 @@ func (c *client) mergeDenyPermissions(what denyType, denyPubs []string) {
 	}
 	for _, p := range perms {
 		if p.deny == nil {
-			p.deny = NewSublistWithCache()
+			p.deny = NewSublist(slcache)
 		}
 	FOR_DENY:
 		for _, subj := range denyPubs {

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1979,7 +1979,7 @@ func (c *client) processGatewayRUnsub(arg []byte) error {
 		return nil
 	} else {
 		// Plain sub, assume optimistic sends, create entry.
-		e = &outsie{ni: make(map[string]struct{}), sl: NewSublistWithCache()}
+		e = &outsie{ni: make(map[string]struct{}), sl: NewSublistForServer(c.srv)}
 		newe = true
 	}
 	// This is when a sub or queue sub is supposed to be in
@@ -2088,7 +2088,7 @@ func (c *client) processGatewayRSub(arg []byte) error {
 	} else if queue == nil {
 		return nil
 	} else {
-		e = &outsie{ni: make(map[string]struct{}), sl: NewSublistWithCache()}
+		e = &outsie{ni: make(map[string]struct{}), sl: NewSublistForServer(c.srv)}
 		newe = true
 		useSl = true
 	}
@@ -3209,7 +3209,7 @@ func (c *client) gatewayAllSubsReceiveStart(info *Info) {
 		e.mode = Transitioning
 		e.Unlock()
 	} else {
-		e := &outsie{sl: NewSublistWithCache()}
+		e := &outsie{sl: NewSublistForServer(c.srv)}
 		e.mode = Transitioning
 		c.mu.Lock()
 		c.gw.outsim.Store(account, e)

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -7743,6 +7743,9 @@ func TestGatewayProcessRSubNoBlockingAccountFetch(t *testing.T) {
 	// Receiving a R+ should not be blocking, since we're in the gateway's readLoop.
 	start := time.Now()
 	require_NoError(t, c.processGatewayRSub(fmt.Appendf(nil, "%s subj queue 0", accPub)))
+	ei, ok := c.gw.outsim.Load(accPub)
+	require_True(t, ok)
+	require_True(t, ei.(*outsie).sl.CacheEnabled())
 	c.mu.Lock()
 	subs := len(c.subs)
 	c.mu.Unlock()
@@ -7757,4 +7760,16 @@ func TestGatewayProcessRSubNoBlockingAccountFetch(t *testing.T) {
 	c.mu.Unlock()
 	require_Len(t, subs, 0)
 	require_LessThan(t, time.Since(start), 100*time.Millisecond)
+
+	c2 := s.createInternalAccountClient()
+	c2.mu.Lock()
+	c2.gw = &gateway{}
+	c2.gw.outsim = &sync.Map{}
+	c2.nc = &net.IPConn{}
+	c2.mu.Unlock()
+
+	require_NoError(t, c2.processGatewayRUnsub(fmt.Appendf(nil, "%s subj", accPub)))
+	ei, ok = c2.gw.outsim.Load(accPub)
+	require_True(t, ok)
+	require_True(t, ei.(*outsie).sl.CacheEnabled())
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1931,12 +1931,7 @@ func (s *Server) registerAccount(acc *Account) *Account {
 // Helper to set the sublist based on preferences.
 func (s *Server) setAccountSublist(acc *Account) {
 	if acc != nil && acc.sl == nil {
-		opts := s.getOpts()
-		if opts != nil && opts.NoSublistCache {
-			acc.sl = NewSublistNoCache()
-		} else {
-			acc.sl = NewSublistWithCache()
-		}
+		acc.sl = NewSublistForServer(s)
 	}
 }
 

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -121,6 +121,18 @@ func NewSublist(enableCache bool) *Sublist {
 	return &Sublist{root: newLevel()}
 }
 
+// NewSublistForServer will create a default sublist with caching enabled determined
+// by the server options.
+func NewSublistForServer(srv *Server) *Sublist {
+	if srv == nil {
+		return NewSublistNoCache() // Probably just unit tests.
+	}
+	if opts := srv.getOpts(); opts != nil {
+		return NewSublist(!opts.NoSublistCache)
+	}
+	return NewSublistNoCache()
+}
+
 // NewSublistWithCache will create a default sublist with caching enabled.
 func NewSublistWithCache() *Sublist {
 	return NewSublist(true)

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -119,6 +119,30 @@ func TestSublistInit(t *testing.T) {
 	verifyCount(s, 0, t)
 }
 
+func TestSublistForServerNoOpts(t *testing.T) {
+	s := NewSublistForServer(&Server{})
+	if s == nil {
+		t.Fatal("Expected a sublist")
+	}
+	if s.CacheEnabled() {
+		t.Fatal("Expected cache to be disabled when server options are nil")
+	}
+}
+
+func TestSetAccountSublistNoOpts(t *testing.T) {
+	s := &Server{}
+	acc := NewAccount("foo")
+
+	s.setAccountSublist(acc)
+
+	if acc.sl == nil {
+		t.Fatal("Expected account sublist to be initialized")
+	}
+	if acc.sl.CacheEnabled() {
+		t.Fatal("Expected cache to be disabled when server options are nil")
+	}
+}
+
 func TestSublistInsertCount(t *testing.T) {
 	testSublistInsertCount(t, NewSublistWithCache())
 }


### PR DESCRIPTION
Fixes #8077, we were using cached sublists in a few places when the global server option to disable them was set.

Signed-off-by: Neil Twigg <neil@nats.io>