### PR TITLE
(2.12) [FIXED] Atomic batch 'unsupported' advisory

### DIFF
--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -361,10 +361,6 @@ func (b *fastBatch) setupCleanupTimer(mset *stream, batchId string, batches *bat
 	timeout := getCleanupTimeout(mset)
 	b.timer = time.AfterFunc(timeout, func() {
 		b.cleanup(batchId, batches)
-		// Only send the advisory if we're the leader. (Since we do the tracking on followers too)
-		if mset.IsLeader() {
-			mset.sendStreamBatchAbandonedAdvisory(batchId, BatchTimeout)
-		}
 	})
 }
 

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -2630,6 +2630,20 @@ func TestJetStreamAtomicBatchPublishAdvisories(t *testing.T) {
 		require_NoError(t, json.Unmarshal(msg.Data, &advisory))
 		require_Equal(t, advisory.BatchId, "uuid")
 		require_Equal(t, advisory.Reason, BatchTimeout)
+
+		// Should receive an advisory if the batch has an unsupported required API level.
+		m = nats.NewMsg("foo")
+		m.Header.Set("Nats-Batch-Id", "uuid")
+		m.Header.Set("Nats-Batch-Sequence", "1")
+		m.Header.Set("Nats-Required-Api-Level", strconv.Itoa(math.MaxInt))
+		require_NoError(t, nc.PublishMsg(m))
+
+		msg, err = sub.NextMsg(3 * time.Second)
+		require_NoError(t, err)
+		advisory = JSStreamBatchAbandonedAdvisory{}
+		require_NoError(t, json.Unmarshal(msg.Data, &advisory))
+		require_Equal(t, advisory.BatchId, "uuid")
+		require_Equal(t, advisory.Reason, BatchRequirementsNotMet)
 	}
 
 	for _, replicas := range []int{1, 3} {

--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -268,9 +268,10 @@ type JSStreamBatchAbandonedAdvisory struct {
 type BatchAbandonReason string
 
 var (
-	BatchTimeout    BatchAbandonReason = "timeout"
-	BatchLarge      BatchAbandonReason = "large"
-	BatchIncomplete BatchAbandonReason = "incomplete"
+	BatchTimeout            BatchAbandonReason = "timeout"
+	BatchLarge              BatchAbandonReason = "large"
+	BatchIncomplete         BatchAbandonReason = "incomplete"
+	BatchRequirementsNotMet BatchAbandonReason = "unsupported"
 )
 
 // JSConsumerLeaderElectedAdvisoryType is sent when the system elects a leader for a consumer.

--- a/server/stream.go
+++ b/server/stream.go
@@ -7230,6 +7230,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 			b.cleanupLocked(batchId, batches)
 			batches.mu.Unlock()
 			mset.mu.Unlock()
+			mset.sendStreamBatchAbandonedAdvisory(batchId, BatchRequirementsNotMet)
 			err := NewJSRequiredApiLevelError()
 			return respondError(err)
 		}


### PR DESCRIPTION
Atomic batch was missing the 'unsupported' advisory based on a too high required API level. Fast batch only had the timeout advisory, but this was agreed to drop for the time being, since it was the only one currently anyway.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>