### PR TITLE
(2.14) [IMPROVED] Invalid schedule time zone returns a specific error

### DIFF
--- a/server/cron.go
+++ b/server/cron.go
@@ -46,19 +46,19 @@ import (
 )
 
 // parseCron parses the given cron pattern and returns the next time it will fire based on the provided ts.
-func parseCron(pattern string, tz string, ts int64) (time.Time, error) {
+func parseCron(pattern string, loc *time.Location, ts int64) (time.Time, error) {
 	fields := strings.Fields(pattern)
 	if len(fields) != 6 {
 		return time.Time{}, fmt.Errorf("pattern requires 6 fields, got %d", len(fields))
 	}
 
-	// Load the time zone.
-	loc, err := time.LoadLocation(tz)
-	if err != nil {
-		return time.Time{}, err
+	// If no time zone is passed, default to UTC.
+	if loc == nil {
+		loc = time.UTC
 	}
 
 	// Parse each field.
+	var err error
 	var second, minute, hour, dayOfMonth, month, dayOfWeek uint64
 	if second, err = getField(fields[0], seconds); err != nil {
 		return time.Time{}, err

--- a/server/errors.json
+++ b/server/errors.json
@@ -2208,5 +2208,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSMessageSchedulesTimeZoneInvalidErr",
+    "code": 400,
+    "error_code": 10223,
+    "description": "message schedules time zone is invalid",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2297,7 +2297,7 @@ func (fs *fileStore) recoverMsgSchedulingState() error {
 			if len(msg.hdr) == 0 {
 				continue
 			}
-			if schedule, ok := nextMessageSchedule(sm.hdr, sm.ts); ok && !schedule.IsZero() {
+			if schedule, apiErr := nextMessageSchedule(sm.hdr, sm.ts); apiErr == nil && !schedule.IsZero() {
 				// Copy the subject, as it's stored in the scheduling maps and the backing cache could be reused in the meantime.
 				fs.scheduling.init(seq, copyString(sm.subj), schedule.UnixNano())
 			}
@@ -4989,7 +4989,7 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 
 	// Message scheduling.
 	if fs.scheduling != nil {
-		if schedule, ok := nextMessageSchedule(hdr, ts); ok && !schedule.IsZero() {
+		if schedule, apiErr := nextMessageSchedule(hdr, ts); apiErr == nil && !schedule.IsZero() {
 			fs.scheduling.add(seq, subj, schedule.UnixNano())
 			fs.lmb.schedules++
 		} else if getMessageScheduler(hdr) == _EMPTY_ {
@@ -11010,7 +11010,7 @@ func (fs *fileStore) purgeMsgBlock(mb *msgBlock) error {
 			if sm == nil {
 				continue
 			}
-			if schedule, ok := getMessageSchedule(sm.hdr); ok && !schedule.IsZero() {
+			if schedule, apiErr := getMessageSchedule(sm.hdr); apiErr == nil && !schedule.IsZero() {
 				fs.scheduling.remove(seq)
 			}
 		}

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -804,8 +804,7 @@ func checkMsgHeadersPreClusteredProposal(
 		// Message scheduling.
 		if sourced {
 			// noop, sourced messages were already validated by the origin stream.
-		} else if schedule, ok := getMessageSchedule(hdr); !ok {
-			apiErr := NewJSMessageSchedulesPatternInvalidError()
+		} else if schedule, apiErr := getMessageSchedule(hdr); apiErr != nil {
 			if !allowMsgSchedules {
 				apiErr = NewJSMessageSchedulesDisabledError()
 			}

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -1035,6 +1035,34 @@ func TestJetStreamAtomicBatchPublishStageAndCommit(t *testing.T) {
 			},
 		},
 		{
+			title:             "msg-schedules-invalid-time-zone",
+			allowMsgSchedules: true,
+			batch: []BatchItem{
+				{
+					subject: "foo",
+					header: nats.Header{
+						JSSchedulePattern:  {"0 * * * * *"},
+						JSScheduleTimeZone: {"Not/A/Zone"},
+					},
+					err: NewJSMessageSchedulesTimeZoneInvalidError(),
+				},
+			},
+		},
+		{
+			title:             "msg-schedules-empty-time-zone",
+			allowMsgSchedules: true,
+			batch: []BatchItem{
+				{
+					subject: "foo",
+					header: nats.Header{
+						JSSchedulePattern:  {"0 * * * * *"},
+						JSScheduleTimeZone: {""},
+					},
+					err: NewJSMessageSchedulesTimeZoneInvalidError(),
+				},
+			},
+		},
+		{
 			title:             "msg-schedules-target-mismatch",
 			allowMsgSchedules: true,
 			batch: []BatchItem{

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -9490,6 +9490,25 @@ func TestJetStreamClusterScheduledDelayedMessage(t *testing.T) {
 				_, err = js.PublishMsg(m)
 				require_Error(t, err, NewJSMessageSchedulesPatternInvalidError())
 
+				// Unknown time zone must be reported as time-zone-invalid, not pattern-invalid.
+				m = nats.NewMsg("foo.invalid")
+				m.Header.Set("Nats-Schedule", "0 * * * * *")
+				m.Header.Set("Nats-Schedule-Time-Zone", "Not/A/Zone")
+				_, err = js.PublishMsg(m)
+				require_Error(t, err, NewJSMessageSchedulesTimeZoneInvalidError())
+
+				// An empty time zone is also invalid.
+				m.Header.Set("Nats-Schedule-Time-Zone", "")
+				_, err = js.PublishMsg(m)
+				require_Error(t, err, NewJSMessageSchedulesTimeZoneInvalidError())
+
+				// A valid time zone with an invalid pattern still surfaces as pattern-invalid.
+				m = nats.NewMsg("foo.invalid")
+				m.Header.Set("Nats-Schedule", "invalid")
+				m.Header.Set("Nats-Schedule-Time-Zone", "UTC")
+				_, err = js.PublishMsg(m)
+				require_Error(t, err, NewJSMessageSchedulesPatternInvalidError())
+
 				m = nats.NewMsg("foo.invalid")
 				m.Header.Set("Nats-Schedule", schedulePattern)
 				m.Header.Set("Nats-Schedule-Target", "not.matching")

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -365,6 +365,9 @@ const (
 	// JSMessageSchedulesTargetInvalidErr message schedules target is invalid
 	JSMessageSchedulesTargetInvalidErr ErrorIdentifier = 10190
 
+	// JSMessageSchedulesTimeZoneInvalidErr message schedules time zone is invalid
+	JSMessageSchedulesTimeZoneInvalidErr ErrorIdentifier = 10223
+
 	// JSMessageTTLDisabledErr per-message TTL is disabled
 	JSMessageTTLDisabledErr ErrorIdentifier = 10166
 
@@ -791,6 +794,7 @@ var (
 		JSMessageSchedulesSourceInvalidErr:           {Code: 400, ErrCode: 10203, Description: "message schedules source is invalid"},
 		JSMessageSchedulesTTLInvalidErr:              {Code: 400, ErrCode: 10191, Description: "message schedules invalid per-message TTL"},
 		JSMessageSchedulesTargetInvalidErr:           {Code: 400, ErrCode: 10190, Description: "message schedules target is invalid"},
+		JSMessageSchedulesTimeZoneInvalidErr:         {Code: 400, ErrCode: 10223, Description: "message schedules time zone is invalid"},
 		JSMessageTTLDisabledErr:                      {Code: 400, ErrCode: 10166, Description: "per-message TTL is disabled"},
 		JSMessageTTLInvalidErr:                       {Code: 400, ErrCode: 10165, Description: "invalid per-message TTL"},
 		JSMirrorConsumerRequiresAckFCErr:             {Code: 400, ErrCode: 10214, Description: "stream mirror consumer requires flow control ack policy"},
@@ -2211,6 +2215,16 @@ func NewJSMessageSchedulesTargetInvalidError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSMessageSchedulesTargetInvalidErr]
+}
+
+// NewJSMessageSchedulesTimeZoneInvalidError creates a new JSMessageSchedulesTimeZoneInvalidErr error: "message schedules time zone is invalid"
+func NewJSMessageSchedulesTimeZoneInvalidError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMessageSchedulesTimeZoneInvalidErr]
 }
 
 // NewJSMessageTTLDisabledError creates a new JSMessageTTLDisabledErr error: "per-message TTL is disabled"

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -22375,7 +22375,7 @@ func TestJetStreamScheduledMessageParse(t *testing.T) {
 	// @at <ts>
 	t.Run("@at", func(t *testing.T) {
 		ts := time.Now().UTC()
-		sts, repeat, ok := parseMsgSchedule(fmt.Sprintf("@at %s", ts.Format(time.RFC3339Nano)), _EMPTY_, 0)
+		sts, repeat, ok := parseMsgSchedule(fmt.Sprintf("@at %s", ts.Format(time.RFC3339Nano)), nil, 0)
 		require_True(t, ok)
 		require_False(t, repeat)
 		require_Equal(t, ts, sts)
@@ -22384,41 +22384,41 @@ func TestJetStreamScheduledMessageParse(t *testing.T) {
 	// @every <duration>
 	t.Run("@every", func(t *testing.T) {
 		now := time.Now().UTC().Round(time.Second)
-		sts, repeat, ok := parseMsgSchedule("@every 5s", _EMPTY_, now.UnixNano())
+		sts, repeat, ok := parseMsgSchedule("@every 5s", nil, now.UnixNano())
 		require_True(t, ok)
 		require_True(t, repeat)
 		require_Equal(t, now.Add(5*time.Second), sts)
 
 		// A schedule on an interval should not spam loads of times if it hasn't run in a long while.
 		now = time.Now().UTC().Round(time.Second)
-		sts, repeat, ok = parseMsgSchedule("@every 5s", _EMPTY_, 0)
+		sts, repeat, ok = parseMsgSchedule("@every 5s", nil, 0)
 		require_True(t, ok)
 		require_True(t, repeat)
 		require_True(t, !sts.Before(now.Add(5*time.Second)))
 
 		// A schedule can only run at least once every second.
-		_, _, ok = parseMsgSchedule("@every 999ms", _EMPTY_, 0)
+		_, _, ok = parseMsgSchedule("@every 999ms", nil, 0)
 		require_False(t, ok)
 	})
 
 	// <cron> pattern
 	t.Run("cron", func(t *testing.T) {
 		now := time.Now().UTC().Round(time.Second)
-		sts, repeat, ok := parseMsgSchedule("* * * * * *", _EMPTY_, now.UnixNano())
+		sts, repeat, ok := parseMsgSchedule("* * * * * *", nil, now.UnixNano())
 		require_True(t, ok)
 		require_True(t, repeat)
 		require_Equal(t, now.Add(time.Second), sts)
 
 		// A schedule based on a cron should run the earliest "next" second.
 		now = time.Now().UTC().Truncate(time.Second).Add(time.Second - time.Nanosecond)
-		sts, repeat, ok = parseMsgSchedule("* * * * * *", _EMPTY_, now.UnixNano())
+		sts, repeat, ok = parseMsgSchedule("* * * * * *", nil, now.UnixNano())
 		require_True(t, ok)
 		require_True(t, repeat)
 		require_Equal(t, now.Truncate(time.Second).Add(time.Second), sts)
 
 		// A schedule based on cron should not spam loads of times if it hasn't run in a long while.
 		now = time.Now().UTC().Round(time.Second)
-		sts, repeat, ok = parseMsgSchedule("* * * * * *", _EMPTY_, 0)
+		sts, repeat, ok = parseMsgSchedule("* * * * * *", nil, 0)
 		require_True(t, ok)
 		require_True(t, repeat)
 		require_True(t, !sts.Before(now.Add(time.Second)))
@@ -22459,7 +22459,7 @@ func TestJetStreamScheduledMessageParse(t *testing.T) {
 						now = now.AddDate(0, 0, 1)
 					}
 				}
-				sts, repeat, ok = parseMsgSchedule(p.pattern, _EMPTY_, now.UnixNano())
+				sts, repeat, ok = parseMsgSchedule(p.pattern, nil, now.UnixNano())
 				require_True(t, ok)
 				require_True(t, repeat)
 				require_Equal(t, p.delay(now), sts)
@@ -22469,12 +22469,11 @@ func TestJetStreamScheduledMessageParse(t *testing.T) {
 
 	// <cron> pattern with time zone
 	t.Run("cron_tz", func(t *testing.T) {
-		tz := "Europe/Amsterdam"
-		loc, err := time.LoadLocation(tz)
+		loc, err := time.LoadLocation("Europe/Amsterdam")
 		require_NoError(t, err)
 
 		now := time.Now().UTC().Round(time.Second)
-		sts, repeat, ok := parseMsgSchedule("* * * * * *", tz, now.UnixNano())
+		sts, repeat, ok := parseMsgSchedule("* * * * * *", loc, now.UnixNano())
 		require_True(t, ok)
 		require_True(t, repeat)
 		require_Equal(t, now.In(loc).Add(time.Second).String(), sts.String())

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -184,7 +184,7 @@ func (ms *memStore) recoverMsgSchedulingState() {
 		if len(sm.hdr) == 0 {
 			continue
 		}
-		if schedule, ok := nextMessageSchedule(sm.hdr, sm.ts); ok && !schedule.IsZero() {
+		if schedule, apiErr := nextMessageSchedule(sm.hdr, sm.ts); apiErr == nil && !schedule.IsZero() {
 			ms.scheduling.init(seq, sm.subj, schedule.UnixNano())
 		}
 	}
@@ -309,7 +309,7 @@ func (ms *memStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, tt
 
 	// Message scheduling.
 	if ms.scheduling != nil {
-		if schedule, ok := nextMessageSchedule(hdr, ts); ok && !schedule.IsZero() {
+		if schedule, apiErr := nextMessageSchedule(hdr, ts); apiErr == nil && !schedule.IsZero() {
 			ms.scheduling.add(seq, subj, schedule.UnixNano())
 		} else if getMessageScheduler(hdr) == _EMPTY_ {
 			ms.scheduling.removeSubject(subj)

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -179,8 +179,12 @@ func (ms *MsgScheduling) getScheduledMessages(loadMsg func(seq uint64, smv *Stor
 				ms.remove(seq)
 				return true
 			}
-			tz := bytesToString(sliceHeader(JSScheduleTimeZone, sm.hdr))
-			next, repeat, ok := parseMsgSchedule(pattern, tz, ts)
+			loc, apiErr := loadMessageScheduleLocation(sm.hdr)
+			if apiErr != nil {
+				ms.remove(seq)
+				return true
+			}
+			next, repeat, ok := parseMsgSchedule(pattern, loc, ts)
 			if !ok {
 				ms.remove(seq)
 				return true
@@ -306,14 +310,14 @@ func (ms *MsgScheduling) decode(b []byte) (uint64, error) {
 
 // parseMsgSchedule parses a message schedule pattern and returns the time
 // to fire, whether it is a repeating schedule, and whether the pattern was valid.
-func parseMsgSchedule(pattern string, tz string, ts int64) (time.Time, bool, bool) {
+func parseMsgSchedule(pattern string, loc *time.Location, ts int64) (time.Time, bool, bool) {
 	if pattern == _EMPTY_ {
 		return time.Time{}, false, true
 	}
 	// Exact time.
 	if strings.HasPrefix(pattern, "@at ") {
 		// Time zone is not supported for @at.
-		if tz != _EMPTY_ {
+		if loc != nil {
 			return time.Time{}, false, false
 		}
 		t, err := time.Parse(time.RFC3339, pattern[4:])
@@ -322,7 +326,7 @@ func parseMsgSchedule(pattern string, tz string, ts int64) (time.Time, bool, boo
 	// Repeating on a simple interval.
 	if strings.HasPrefix(pattern, "@every ") {
 		// Time zone is not supported for @every.
-		if tz != _EMPTY_ {
+		if loc != nil {
 			return time.Time{}, false, false
 		}
 		dur, err := time.ParseDuration(pattern[7:])
@@ -356,14 +360,14 @@ func parseMsgSchedule(pattern string, tz string, ts int64) (time.Time, bool, boo
 	}
 
 	// Parse the cron pattern.
-	next, err := parseCron(pattern, tz, ts)
+	next, err := parseCron(pattern, loc, ts)
 	if err != nil {
 		return time.Time{}, false, false
 	}
 	// If this schedule would trigger multiple times, for example after a restart, skip ahead and only fire once.
 	if now := time.Now().UTC(); next.Before(now) {
 		ts = now.Round(time.Second).UnixNano()
-		next, err = parseCron(pattern, tz, ts)
+		next, err = parseCron(pattern, loc, ts)
 		if err != nil {
 			return time.Time{}, false, false
 		}

--- a/server/stream.go
+++ b/server/stream.go
@@ -5373,22 +5373,46 @@ func getMessageIncr(hdr []byte) (*big.Int, bool) {
 }
 
 // Fast lookup of message schedule.
-func getMessageSchedule(hdr []byte) (time.Time, bool) {
+func getMessageSchedule(hdr []byte) (time.Time, *ApiError) {
 	if len(hdr) == 0 {
-		return time.Time{}, true
+		return time.Time{}, nil
 	}
 	return nextMessageSchedule(hdr, time.Now().UTC().UnixNano())
 }
 
 // Fast lookup and calculation of next message schedule.
-func nextMessageSchedule(hdr []byte, ts int64) (time.Time, bool) {
+func nextMessageSchedule(hdr []byte, ts int64) (time.Time, *ApiError) {
 	if len(hdr) == 0 {
-		return time.Time{}, true
+		return time.Time{}, nil
+	}
+	loc, apiErr := loadMessageScheduleLocation(hdr)
+	if apiErr != nil {
+		return time.Time{}, apiErr
 	}
 	val := bytesToString(sliceHeader(JSSchedulePattern, hdr))
-	tz := bytesToString(sliceHeader(JSScheduleTimeZone, hdr))
-	schedule, _, ok := parseMsgSchedule(val, tz, ts)
-	return schedule, ok
+	schedule, _, ok := parseMsgSchedule(val, loc, ts)
+	if !ok {
+		return time.Time{}, NewJSMessageSchedulesPatternInvalidError()
+	}
+	return schedule, nil
+}
+
+// loadMessageScheduleLocation returns the *time.Location for the schedule's
+// time zone header. Returns nil loc when the header is absent. A header that
+// is present but empty or names an unknown zone yields a TimeZoneInvalid error.
+func loadMessageScheduleLocation(hdr []byte) (*time.Location, *ApiError) {
+	tz := sliceHeader(JSScheduleTimeZone, hdr)
+	if tz == nil {
+		return nil, nil
+	}
+	if len(tz) == 0 {
+		return nil, NewJSMessageSchedulesTimeZoneInvalidError()
+	}
+	loc, err := time.LoadLocation(bytesToString(tz))
+	if err != nil {
+		return nil, NewJSMessageSchedulesTimeZoneInvalidError()
+	}
+	return loc, nil
 }
 
 // Fast lookup of the message schedule TTL from headers.
@@ -6357,8 +6381,7 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 			// Message scheduling.
 			if sourced {
 				// noop, sourced messages were already validated by the origin stream.
-			} else if schedule, ok := getMessageSchedule(hdr); !ok {
-				apiErr := NewJSMessageSchedulesPatternInvalidError()
+			} else if schedule, apiErr := getMessageSchedule(hdr); apiErr != nil {
 				if !allowMsgSchedules {
 					apiErr = NewJSMessageSchedulesDisabledError()
 				}


### PR DESCRIPTION
An invalid or unrecognized schedule time zone would return a "schedule pattern invalid" error, which was misleading. This PR improves this by having a separate error to indicate the issue is with the time zone (for example on missing tzdata), and not the pattern itself.