### PR TITLE
[IMPROVED] Reduce JS write lock contention on leader changes and Raft group creation

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1442,7 +1442,7 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 		if !s.standAloneMode() && ca == nil {
 			suppress = true
 		} else if ca != nil {
-			suppress = ca.responded
+			suppress = ca.hasResponded()
 		}
 		if !suppress {
 			o.sendCreateAdvisory()
@@ -2238,16 +2238,15 @@ func (o *consumer) deleteNotActive() {
 	if !isDirect && s.JetStreamIsClustered() {
 		js.mu.RLock()
 		var (
-			cca         consumerAssignment
 			meta        RaftNode
 			removeEntry []byte
 		)
 		ca, cc := js.consumerAssignment(acc, stream, name), js.cluster
 		if ca != nil && cc != nil {
 			meta = cc.meta
-			cca = *ca
+			cca := ca.clone()
 			cca.Reply = _EMPTY_
-			removeEntry = encodeDeleteConsumerAssignment(&cca)
+			removeEntry = encodeDeleteConsumerAssignment(cca)
 			meta.ForwardProposal(removeEntry)
 		}
 		js.mu.RUnlock()

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -5239,7 +5239,7 @@ func (s *Server) jsConsumerPauseRequest(sub *subscription, c *client, _ *Account
 			return
 		}
 
-		nca := *ca
+		nca := ca.clone()
 		// We're only holding the read lock and release below,
 		// we need a copy to prevent concurrent reads/writes.
 		ncfg := *ca.Config
@@ -5258,7 +5258,7 @@ func (s *Server) jsConsumerPauseRequest(sub *subscription, c *client, _ *Account
 		// Only PauseUntil is updated above, so reuse config for both.
 		setStaticConsumerMetadata(nca.Config)
 
-		eca := encodeAddConsumerAssignment(&nca)
+		eca := encodeAddConsumerAssignment(nca)
 		meta.Propose(eca)
 
 		resp.PauseUntil = pauseUTC

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -174,12 +174,51 @@ type streamAssignment struct {
 	Restore    *StreamState    `json:"restore_state,omitempty"`
 	// Internal
 	consumers   map[string]*consumerAssignment
-	responded   bool
+	responded   atomic.Bool // copied via clone() to satisfy go vet's noCopy check
 	recovering  bool
 	reassigning bool // i.e. due to placement issues, lack of resources, etc.
 	resetting   bool // i.e. there was an error, and we're stopping and starting the stream
 	err         error
 	unsupported *unsupportedStreamAssignment
+}
+
+func (sa *streamAssignment) hasResponded() bool {
+	return sa.responded.Load()
+}
+
+// markResponded sets the responded flag and returns the prior value.
+func (sa *streamAssignment) markResponded() bool {
+	return sa.responded.Swap(true)
+}
+
+func (sa *streamAssignment) clearResponded() {
+	sa.responded.Store(false)
+}
+
+// clone returns a copy of sa. Field-explicit (rather than `*sa`) and
+// pointer-returning so the embedded atomic.Bool isn't value-copied;
+// responded is transferred via Load/Store. Concurrent callers may write
+// responded via markResponded/clearResponded without holding js.mu.
+func (sa *streamAssignment) clone() *streamAssignment {
+	csa := &streamAssignment{
+		Client:      sa.Client,
+		Created:     sa.Created,
+		ConfigJSON:  sa.ConfigJSON,
+		Config:      sa.Config,
+		Group:       sa.Group,
+		Sync:        sa.Sync,
+		Subject:     sa.Subject,
+		Reply:       sa.Reply,
+		Restore:     sa.Restore,
+		consumers:   sa.consumers,
+		recovering:  sa.recovering,
+		reassigning: sa.reassigning,
+		resetting:   sa.resetting,
+		err:         sa.err,
+		unsupported: sa.unsupported,
+	}
+	csa.responded.Store(sa.responded.Load())
+	return csa
 }
 
 type unsupportedStreamAssignment struct {
@@ -258,10 +297,47 @@ type consumerAssignment struct {
 	Reply      string          `json:"reply,omitempty"`
 	State      *ConsumerState  `json:"state,omitempty"`
 	// Internal
-	responded   bool
+	responded   atomic.Bool // copied via clone() to satisfy go vet's noCopy check
 	recovering  bool
 	err         error
 	unsupported *unsupportedConsumerAssignment
+}
+
+func (ca *consumerAssignment) hasResponded() bool {
+	return ca.responded.Load()
+}
+
+// markResponded sets the responded flag and returns the prior value.
+func (ca *consumerAssignment) markResponded() bool {
+	return ca.responded.Swap(true)
+}
+
+func (ca *consumerAssignment) clearResponded() {
+	ca.responded.Store(false)
+}
+
+// clone returns a copy of ca. Field-explicit (rather than `*ca`) and
+// pointer-returning so the embedded atomic.Bool isn't value-copied;
+// responded is transferred via Load/Store. Concurrent callers may write
+// responded via markResponded/clearResponded without holding js.mu.
+func (ca *consumerAssignment) clone() *consumerAssignment {
+	cca := &consumerAssignment{
+		Client:      ca.Client,
+		Created:     ca.Created,
+		Name:        ca.Name,
+		Stream:      ca.Stream,
+		ConfigJSON:  ca.ConfigJSON,
+		Config:      ca.Config,
+		Group:       ca.Group,
+		Subject:     ca.Subject,
+		Reply:       ca.Reply,
+		State:       ca.State,
+		recovering:  ca.recovering,
+		err:         ca.err,
+		unsupported: ca.unsupported,
+	}
+	cca.responded.Store(ca.responded.Load())
+	return cca
 }
 
 type unsupportedConsumerAssignment struct {
@@ -2253,7 +2329,7 @@ func (js *jetStream) collectStreamAndConsumerChanges(c RaftNodeCheckpoint, strea
 func (js *jetStream) setStreamAssignmentRecovering(sa *streamAssignment) {
 	js.mu.Lock()
 	defer js.mu.Unlock()
-	sa.responded = true
+	sa.markResponded()
 	sa.recovering = true
 	sa.Restore = nil
 	if sa.Group != nil {
@@ -2266,7 +2342,7 @@ func (js *jetStream) setStreamAssignmentRecovering(sa *streamAssignment) {
 func (js *jetStream) setConsumerAssignmentRecovering(ca *consumerAssignment) {
 	js.mu.Lock()
 	defer js.mu.Unlock()
-	ca.responded = true
+	ca.markResponded()
 	ca.recovering = true
 	if ca.Group != nil {
 		ca.Group.Preferred = _EMPTY_
@@ -2277,19 +2353,19 @@ func (js *jetStream) setConsumerAssignmentRecovering(ca *consumerAssignment) {
 // Just copies over and changes out the group so it can be encoded.
 // Lock should be held.
 func (sa *streamAssignment) copyGroup() *streamAssignment {
-	csa, cg := *sa, *sa.Group
+	csa, cg := sa.clone(), *sa.Group
 	csa.Group = &cg
 	csa.Group.Peers = copyStrings(sa.Group.Peers)
-	return &csa
+	return csa
 }
 
 // Just copies over and changes out the group so it can be encoded.
 // Lock should be held.
 func (ca *consumerAssignment) copyGroup() *consumerAssignment {
-	cca, cg := *ca, *ca.Group
+	cca, cg := ca.clone(), *ca.Group
 	cca.Group = &cg
 	cca.Group.Peers = copyStrings(ca.Group.Peers)
-	return &cca
+	return cca
 }
 
 // Lock should be held.
@@ -4439,12 +4515,11 @@ func (js *jetStream) processStreamLeaderChange(mset *stream, isLeader bool) {
 	mset.expectedPerSubjectInProcess = nil
 	mset.clMu.Unlock()
 
-	js.mu.Lock()
+	js.mu.RLock()
 	s, account, err := js.srv, sa.Client.serviceAccount(), sa.err
 	client, subject, reply := sa.Client, sa.Subject, sa.Reply
-	hasResponded := sa.responded
-	sa.responded = true
-	js.mu.Unlock()
+	hasResponded := sa.markResponded()
+	js.mu.RUnlock()
 
 	streamName := mset.name()
 
@@ -4709,7 +4784,9 @@ func (js *jetStream) processStreamAssignment(sa *streamAssignment) {
 				sa.Group.node = osa.Group.node
 			}
 			sa.consumers = osa.consumers
-			sa.responded = osa.responded
+			if osa.hasResponded() {
+				sa.markResponded()
+			}
 			sa.err = osa.err
 		}
 		// Unsubscribe if it was previously unsupported.
@@ -4725,7 +4802,7 @@ func (js *jetStream) processStreamAssignment(sa *streamAssignment) {
 	// Update our state.
 	accStreams[stream] = sa
 	cc.streams[accName] = accStreams
-	hasResponded := sa.responded
+	hasResponded := sa.hasResponded()
 
 	// If unsupported, we can't register any further.
 	if sa.unsupported != nil {
@@ -4843,7 +4920,7 @@ func (js *jetStream) processUpdateStreamAssignment(sa *streamAssignment) {
 
 	// Make sure we respond if we are a member.
 	if isMember {
-		sa.responded = false
+		sa.clearResponded()
 	} else {
 		// Make sure to clean up any old node in case this stream moves back here.
 		if sa.Group != nil {
@@ -4939,16 +5016,15 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 		return
 	}
 
-	js.mu.Lock()
+	js.mu.RLock()
 	s, rg := js.srv, sa.Group
 	client, subject, reply := sa.Client, sa.Subject, sa.Reply
 	alreadyRunning, oldNumReplicas, numReplicas := osa.Group.node != nil, len(osa.Group.Peers), len(rg.Peers)
 	needsNode := rg.node == nil
 	storage, cfg := sa.Config.Storage, sa.Config
-	hasResponded := sa.responded
-	sa.responded = true
 	recovering := sa.recovering
-	js.mu.Unlock()
+	hasResponded := sa.markResponded()
+	js.mu.RUnlock()
 
 	mset, err := acc.lookupStream(cfg.Name)
 	if err == nil && mset != nil {
@@ -5214,7 +5290,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 		js.mu.Lock()
 
 		sa.err = err
-		hasResponded := sa.responded
+		hasResponded := sa.hasResponded()
 
 		// If out of space do nothing for now.
 		if isOutOfSpaceErr(err) {
@@ -5549,7 +5625,9 @@ func (js *jetStream) processConsumerAssignment(ca *consumerAssignment) {
 		if ca.Group != nil {
 			ca.Group.node = oca.Group.node
 		}
-		ca.responded = oca.responded
+		if oca.hasResponded() {
+			ca.markResponded()
+		}
 		ca.err = oca.err
 
 		// Unsubscribe if it was previously unsupported.
@@ -5833,13 +5911,13 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 		// Check if we already had a consumer assignment and its still pending.
 		cca, oca := ca, o.consumerAssignment()
 		if oca != nil {
-			if !oca.responded {
+			if !oca.hasResponded() {
 				// We can't override info for replying here otherwise leader once elected can not respond.
 				// So copy over original client and the reply from the old ca.
-				cac := *ca
+				cac := ca.clone()
 				cac.Client = oca.Client
 				cac.Reply = oca.Reply
-				cca = &cac
+				cca = cac
 				needsLocalResponse = true
 			}
 			// If we look like we are scaling up, let's send our current state to the group.
@@ -5885,7 +5963,7 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 		js.mu.Lock()
 
 		ca.err = err
-		hasResponded := ca.responded
+		hasResponded := ca.hasResponded()
 
 		// If out of space do nothing for now.
 		if isOutOfSpaceErr(err) {
@@ -5978,12 +6056,10 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 			o.signalMonitorQuit()
 			o.monitorWg.Wait()
 			// Single replica consumer, process manually here.
-			js.mu.Lock()
 			// Force response in case we think this is an update.
-			if !js.metaRecovering && isConfigUpdate {
-				ca.responded = false
+			if !js.isMetaRecovering() && isConfigUpdate {
+				ca.clearResponded()
 			}
-			js.mu.Unlock()
 			cca := o.consumerAssignment()
 			// Perform the leader change in a goroutine, otherwise we could block meta operations.
 			if o.shouldStartMonitor() {
@@ -6837,12 +6913,11 @@ func (js *jetStream) processConsumerLeaderChangeWithAssignment(o *consumer, ca *
 	if ca == nil {
 		return stepDownIfLeader()
 	}
-	js.mu.Lock()
+	js.mu.RLock()
 	s, account, err := js.srv, ca.Client.serviceAccount(), ca.err
 	client, subject, reply, streamName, consumerName, sourcing := ca.Client, ca.Subject, ca.Reply, ca.Stream, ca.Name, ca.Config.Sourcing
-	hasResponded := ca.responded
-	ca.responded = true
-	js.mu.Unlock()
+	hasResponded := ca.markResponded()
+	js.mu.RUnlock()
 
 	acc, _ := s.LookupAccount(account)
 	if acc == nil {
@@ -7074,8 +7149,8 @@ func (js *jetStream) processStreamAssignmentResults(sub *subscription, c *client
 		} else if result.Restore != nil {
 			resp = s.jsonResponse(result.Restore)
 		}
-		if !sa.responded || result.Update {
-			sa.responded = true
+		if !sa.hasResponded() || result.Update {
+			sa.markResponded()
 			js.srv.sendAPIErrResponse(sa.Client, acc, sa.Subject, sa.Reply, _EMPTY_, resp)
 		}
 		// Remove this assignment if possible.
@@ -7108,9 +7183,9 @@ func (js *jetStream) processConsumerAssignmentResults(sub *subscription, c *clie
 	}
 
 	if sa := js.streamAssignment(result.Account, result.Stream); sa != nil && sa.consumers != nil {
-		if ca := sa.consumers[result.Consumer]; ca != nil && !ca.responded {
+		if ca := sa.consumers[result.Consumer]; ca != nil && !ca.hasResponded() {
 			js.srv.sendAPIErrResponse(ca.Client, acc, ca.Subject, ca.Reply, _EMPTY_, s.jsonResponse(result.Response))
-			ca.responded = true
+			ca.markResponded()
 
 			// Check if this failed.
 			// TODO(dlc) - Could have mixed results, should track per peer.
@@ -8950,7 +9025,7 @@ func (s *Server) jsClusteredMsgDeleteRequest(ci *ClientInfo, acc *Account, mset 
 }
 
 func encodeAddStreamAssignment(sa *streamAssignment) []byte {
-	csa := *sa
+	csa := sa.clone()
 	csa.Client = csa.Client.forProposal()
 	csa.ConfigJSON, _ = json.Marshal(sa.Config)
 	var bb bytes.Buffer
@@ -8960,7 +9035,7 @@ func encodeAddStreamAssignment(sa *streamAssignment) []byte {
 }
 
 func encodeUpdateStreamAssignment(sa *streamAssignment) []byte {
-	csa := *sa
+	csa := sa.clone()
 	csa.Client = csa.Client.forProposal()
 	csa.ConfigJSON, _ = json.Marshal(sa.Config)
 	var bb bytes.Buffer
@@ -8970,7 +9045,7 @@ func encodeUpdateStreamAssignment(sa *streamAssignment) []byte {
 }
 
 func encodeDeleteStreamAssignment(sa *streamAssignment) []byte {
-	csa := *sa
+	csa := sa.clone()
 	csa.Client = csa.Client.forProposal()
 	csa.ConfigJSON, _ = json.Marshal(sa.Config)
 	var bb bytes.Buffer
@@ -9440,7 +9515,7 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 }
 
 func encodeAddConsumerAssignment(ca *consumerAssignment) []byte {
-	cca := *ca
+	cca := ca.clone()
 	cca.Client = cca.Client.forProposal()
 	cca.ConfigJSON, _ = json.Marshal(ca.Config)
 	var bb bytes.Buffer
@@ -9450,7 +9525,7 @@ func encodeAddConsumerAssignment(ca *consumerAssignment) []byte {
 }
 
 func encodeDeleteConsumerAssignment(ca *consumerAssignment) []byte {
-	cca := *ca
+	cca := ca.clone()
 	cca.Client = cca.Client.forProposal()
 	cca.ConfigJSON, _ = json.Marshal(ca.Config)
 	var bb bytes.Buffer
@@ -9491,7 +9566,7 @@ func decodeConsumerAssignmentConfig(ca *consumerAssignment) error {
 }
 
 func encodeAddConsumerAssignmentCompressed(ca *consumerAssignment) []byte {
-	cca := *ca
+	cca := ca.clone()
 	cca.Client = cca.Client.forProposal()
 	cca.ConfigJSON, _ = json.Marshal(ca.Config)
 	var bb bytes.Buffer

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -53,6 +53,10 @@ type jetStreamCluster struct {
 	// a response but they need to be same group, peers etc. and sync subjects.
 	inflightStreams   map[string]map[string]*inflightStreamInfo
 	inflightConsumers map[string]map[string]map[string]*inflightConsumerInfo
+	// Tracks raft groups currently being started by createRaftGroup, so that
+	// concurrent callers for the same group can wait without holding js.mu
+	// across the disk I/O performed during startup.
+	creatingRaftGroups map[string]chan struct{}
 	// Holds a map of a peer ID to the reply subject, to only respond after gaining
 	// quorum on the peer-remove action.
 	peerRemoveReply map[string]peerRemoveInfo
@@ -2747,9 +2751,11 @@ func (rg *raftGroup) setPreferred(s *Server) {
 
 // createRaftGroup is called to spin up this raft group if needed.
 func (js *jetStream) createRaftGroup(accName string, rg *raftGroup, recovering bool, storage StorageType, labels pprofLabels) (RaftNode, error) {
-	// Must hold JS lock throughout, otherwise two parallel calls for the same raft group could result
-	// in duplicate instances for the same identifier, if the current Raft node is shutting down.
-	// We can release the lock temporarily while waiting for the Raft node to shut down.
+	// js.mu protects the lookup/registration of raft groups so that two parallel
+	// calls for the same identifier can't end up creating duplicate instances.
+	// It is released around blocking work (waiting for a previous instance to
+	// shut down, and the disk I/O inside startRaftNode); concurrent callers for
+	// the same rg.Name are gated through cc.creatingRaftGroups instead.
 	js.mu.Lock()
 	defer js.mu.Unlock()
 
@@ -2764,8 +2770,21 @@ func (js *jetStream) createRaftGroup(accName string, rg *raftGroup, recovering b
 		return nil, nil
 	}
 
-	// Check if we already have this assigned.
 retry:
+	// If another goroutine is mid-creation for this raft group, wait for it
+	// to finish (without holding js.mu) and then retry the lookup.
+	if ch, ok := cc.creatingRaftGroups[rg.Name]; ok {
+		js.mu.Unlock()
+		<-ch
+		js.mu.Lock()
+		// js.cluster could have been swapped out (shutdown).
+		if js.cluster == nil || js.cluster.meta == nil {
+			return nil, NewJSClusterNotActiveError()
+		}
+		cc = js.cluster
+		goto retry
+	}
+	// Check if we already have this assigned.
 	if node := s.lookupRaftNode(rg.Name); node != nil {
 		if node.State() == Closed {
 			// We're waiting for this node to finish shutting down before we replace it.
@@ -2822,7 +2841,7 @@ retry:
 
 	// Check here to see if we have a max HA Assets limit set.
 	if maxHaAssets := s.getOpts().JetStreamLimits.MaxHAAssets; maxHaAssets > 0 {
-		if s.numRaftNodes() > maxHaAssets {
+		if s.numRaftNodes()+len(cc.creatingRaftGroups) > maxHaAssets {
 			s.Warnf("Maximum HA Assets limit reached: %d", maxHaAssets)
 			// Since the meta leader assigned this, send a statsz update to them to get them up to date.
 			go s.sendStatszUpdate()
@@ -2830,45 +2849,70 @@ retry:
 		}
 	}
 
+	// Register an in-flight sentinel so concurrent callers for the same group
+	// will wait for us. Then drop js.mu around all the blocking work below
+	// (file store creation, peer state read, snapshot replay, fsyncs) so we
+	// don't serialize every stream/consumer assignment behind one disk fsync.
+	if cc.creatingRaftGroups == nil {
+		cc.creatingRaftGroups = make(map[string]chan struct{})
+	}
+	doneCh := make(chan struct{})
+	cc.creatingRaftGroups[rg.Name] = doneCh
+
+	// Snapshot rg fields; we drop js.mu below and rg is shared.
+	rgName, rgScaleUp := rg.Name, rg.ScaleUp
+	rgPeers := copyStrings(rg.Peers)
 	storeDir := filepath.Join(js.config.StoreDir, sysAcc.Name, defaultStoreDirName, rg.Name)
-	var store StreamStore
-	if storage == FileStorage {
-		// If the server is set to sync always, do the same for the Raft log.
-		js.srv.optsMu.RLock()
-		syncAlways := js.srv.opts.SyncAlways
-		syncInterval := js.srv.opts.SyncInterval
-		js.srv.optsMu.RUnlock()
-		fs, err := newFileStoreWithCreated(
-			FileStoreConfig{StoreDir: storeDir, BlockSize: defaultMediumBlockSize, AsyncFlush: false, SyncAlways: syncAlways, SyncInterval: syncInterval, srv: s},
-			StreamConfig{Name: rg.Name, Storage: FileStorage, Metadata: labels},
-			time.Now().UTC(),
-			s.jsKeyGen(s.getOpts().JetStreamKey, rg.Name),
-			s.jsKeyGen(s.getOpts().JetStreamOldKey, rg.Name),
-		)
-		if err != nil {
-			s.Errorf("Error creating filestore WAL: %v", err)
+	js.mu.Unlock()
+
+	n, err := func() (RaftNode, error) {
+		var store StreamStore
+		if storage == FileStorage {
+			opts := s.getOpts()
+			fs, err := newFileStoreWithCreated(
+				FileStoreConfig{StoreDir: storeDir, BlockSize: defaultMediumBlockSize, AsyncFlush: false, SyncAlways: opts.SyncAlways, SyncInterval: opts.SyncInterval, srv: s},
+				StreamConfig{Name: rgName, Storage: FileStorage, Metadata: labels},
+				time.Now().UTC(),
+				s.jsKeyGen(opts.JetStreamKey, rgName),
+				s.jsKeyGen(opts.JetStreamOldKey, rgName),
+			)
+			if err != nil {
+				s.Errorf("Error creating filestore WAL: %v", err)
+				return nil, err
+			}
+			store = fs
+		} else {
+			ms, err := newMemStore(&StreamConfig{Name: rgName, Storage: MemoryStorage})
+			if err != nil {
+				s.Errorf("Error creating memstore WAL: %v", err)
+				return nil, err
+			}
+			store = ms
+		}
+
+		cfg := &RaftConfig{Name: rgName, Store: storeDir, Log: store, Track: true, Recovering: recovering, ScaleUp: rgScaleUp}
+
+		if _, err := readPeerState(storeDir); err != nil {
+			s.bootstrapRaftNode(cfg, rgPeers, true)
+		}
+
+		n, err := s.startRaftNode(accName, cfg, labels)
+		if err != nil || n == nil {
+			s.Debugf("Error creating raft group: %v", err)
 			return nil, err
 		}
-		store = fs
-	} else {
-		ms, err := newMemStore(&StreamConfig{Name: rg.Name, Storage: MemoryStorage})
-		if err != nil {
-			s.Errorf("Error creating memstore WAL: %v", err)
-			return nil, err
-		}
-		store = ms
-	}
+		return n, nil
+	}()
 
-	cfg := &RaftConfig{Name: rg.Name, Store: storeDir, Log: store, Track: true, Recovering: recovering, ScaleUp: rg.ScaleUp}
-
-	if _, err := readPeerState(storeDir); err != nil {
-		s.bootstrapRaftNode(cfg, rg.Peers, true)
-	}
-
-	n, err := s.startRaftNode(accName, cfg, labels)
+	js.mu.Lock()
+	delete(cc.creatingRaftGroups, rg.Name)
+	close(doneCh)
 	if err != nil || n == nil {
-		s.Debugf("Error creating raft group: %v", err)
 		return nil, err
+	}
+	if js.cluster == nil || js.cluster.meta == nil {
+		// Cluster was torn down while we were creating; let n be reaped at shutdown.
+		return nil, NewJSClusterNotActiveError()
 	}
 	// Need JS lock to be held for the assignment to avoid data-race reports
 	rg.node = n

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -6823,9 +6823,9 @@ func TestJetStreamClusterProcessClusterUpdateStreamNilStreamAssignment(t *testin
 			Storage: realOsa.Group.Storage,
 		}
 	}
-	osa := *realOsa
+	osa := realOsa.clone()
 	osa.Group = cloneGroup()
-	sa := osa
+	sa := osa.clone()
 	cfg := *realOsa.Config
 	cfg.MaxMsgs = 1_000
 	sa.Config = &cfg
@@ -6843,7 +6843,7 @@ func TestJetStreamClusterProcessClusterUpdateStreamNilStreamAssignment(t *testin
 	}
 	mset.mu.Unlock()
 
-	sjs.processClusterUpdateStream(acc, &osa, &sa)
+	sjs.processClusterUpdateStream(acc, osa, sa)
 
 	mset.mu.RLock()
 	got := mset.sa

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -6066,6 +6066,179 @@ func TestJetStreamClusterParallelCreateRaftGroup(t *testing.T) {
 	require_Equal(t, nodes[0], nodes[1])
 }
 
+func TestJetStreamClusterParallelCreateRaftGroupHighConcurrency(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+	checkFor(t, time.Second, 100*time.Millisecond, func() error {
+		return checkState(t, c, globalAccountName, "TEST")
+	})
+
+	ml := c.leader()
+	sjs := ml.getJetStream()
+	sa := sjs.streamAssignment(globalAccountName, "TEST")
+	require_NotNil(t, sa)
+	acc, err := ml.lookupAccount(globalAccountName)
+	require_NoError(t, err)
+	mset, err := acc.lookupStream("TEST")
+	require_NoError(t, err)
+
+	rg, storage := sa.Group, sa.Group.Storage
+
+	// Fully stop the existing node so it unregisters from s.raftNodes;
+	// concurrent createRaftGroup callers must therefore reach the
+	// "build a new node" path rather than the existing-node short-circuit.
+	rn := mset.raftNode()
+	rn.Stop()
+	rn.WaitForStop()
+
+	sjs.mu.Lock()
+	rg.node = nil
+	sjs.mu.Unlock()
+
+	const N = 25
+	var (
+		ready sync.WaitGroup
+		start = make(chan struct{})
+		done  sync.WaitGroup
+		mu    sync.Mutex
+		nodes []RaftNode
+		errs  []error
+	)
+
+	// Without the creatingRaftGroups gate, parallel callers each build
+	// their own RaftNode; only the last registered stays in s.raftNodes
+	// and the rest leak with goroutines + file handles, so c.shutdown()
+	// hangs. Stop every distinct node we got back so the test can exit
+	// cleanly even when the assertions below fail.
+	defer func() {
+		mu.Lock()
+		defer mu.Unlock()
+		seen := make(map[RaftNode]struct{}, len(nodes))
+		for _, n := range nodes {
+			if n == nil {
+				continue
+			}
+			if _, ok := seen[n]; ok {
+				continue
+			}
+			seen[n] = struct{}{}
+			n.Stop()
+		}
+	}()
+
+	ready.Add(N)
+	done.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer done.Done()
+			ready.Done()
+			<-start
+			n, rerr := sjs.createRaftGroup(acc.GetName(), rg, false, storage, pprofLabels{})
+			mu.Lock()
+			nodes = append(nodes, n)
+			errs = append(errs, rerr)
+			mu.Unlock()
+		}()
+	}
+	ready.Wait()
+	close(start)
+	done.Wait()
+
+	// Every caller must have received the same RaftNode instance —
+	// without the creatingRaftGroups gate, parallel callers each build
+	// their own node and clobber each other in s.raftNodes, returning
+	// distinct pointers.
+	require_Len(t, len(nodes), N)
+	for i := range N {
+		require_NoError(t, errs[i])
+		require_NotNil(t, nodes[i])
+		require_Equal(t, nodes[0], nodes[i])
+	}
+
+	// The in-flight sentinel must be cleaned up once creation completed.
+	sjs.mu.Lock()
+	_, sentinelLeft := sjs.cluster.creatingRaftGroups[rg.Name]
+	sjs.mu.Unlock()
+	require_False(t, sentinelLeft)
+}
+
+func TestJetStreamClusterParallelCreateRaftGroupHAAssetsLimit(t *testing.T) {
+	const maxAssets = 2
+	tmpl := strings.Replace(jsClusterTempl, "store_dir:", fmt.Sprintf("limits: {max_ha_assets: %d}, store_dir:", maxAssets), 1)
+	c := createJetStreamClusterWithTemplateAndModHook(t, tmpl, "R3S", 3, nil)
+	defer c.shutdown()
+
+	ml := c.leader()
+	sjs := ml.getJetStream()
+	cc := sjs.cluster
+	require_NotNil(t, cc)
+
+	acc, err := ml.lookupAccount(globalAccountName)
+	require_NoError(t, err)
+
+	metaPeers := cc.meta.Peers()
+	require_Len(t, len(metaPeers), 3)
+	peers := make([]string, 0, len(metaPeers))
+	for _, p := range metaPeers {
+		peers = append(peers, p.ID)
+	}
+
+	const N = 8
+	var (
+		ready sync.WaitGroup
+		start = make(chan struct{})
+		done  sync.WaitGroup
+		mu    sync.Mutex
+		nodes []RaftNode
+	)
+	ready.Add(N)
+	done.Add(N)
+	for i := range N {
+		rg := &raftGroup{
+			Name:    fmt.Sprintf("RG-%d", i),
+			Storage: FileStorage,
+			Peers:   slices.Clone(peers),
+			Cluster: "R3S",
+		}
+		go func() {
+			defer done.Done()
+			ready.Done()
+			<-start
+			n, _ := sjs.createRaftGroup(acc.GetName(), rg, false, FileStorage, pprofLabels{})
+			if n != nil {
+				mu.Lock()
+				nodes = append(nodes, n)
+				mu.Unlock()
+			}
+		}()
+	}
+	ready.Wait()
+	close(start)
+	done.Wait()
+
+	defer func() {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, n := range nodes {
+			n.Stop()
+		}
+	}()
+
+	mu.Lock()
+	got := len(nodes)
+	mu.Unlock()
+	require_True(t, got <= maxAssets)
+}
+
 func TestJetStreamClusterSubjectDeleteMarkersMinimumTTL(t *testing.T) {
 	for _, storageType := range []StorageType{FileStorage, MemoryStorage} {
 		for _, replicas := range []int{1, 3} {

--- a/server/stream.go
+++ b/server/stream.go
@@ -1056,7 +1056,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 				suppress = true
 			}
 		} else if sa != nil {
-			suppress = sa.responded
+			suppress = sa.hasResponded()
 		}
 		if !suppress {
 			mset.sendCreateAdvisory()


### PR DESCRIPTION
- `createRaftGroup` no longer holds `js.mu` across filestore/snapshot init and `startRaftNode`; allowing other JS requests to still be serviced without waiting for this single Raft node to initialize.                                                                                                                              
- `sa/ca.responded` become atomic, allowing `processStreamLeaderChange` and `processConsumerLeaderChange` to take the read lock, so leader changes run concurrently.