### PR TITLE
Add extra test for payload corruption via headers

### DIFF
--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -4978,6 +4978,221 @@ func TestRouteImplicitJoinsSeparateGroups(t *testing.T) {
 	}
 }
 
+// Extra regression test for issue fixed via:
+//
+// https://github.com/nats-io/nats-server/commit/d5ef552ae46d7c284e4bfdf01211f97893b2f38f
+func TestRouteMsgWithManyHeadersDoesNotCorruptJSON(t *testing.T) {
+	tmpl := `
+		port: -1
+		server_name: "%s"
+		accounts {
+			A {
+				users: [ { user: a, password: pwd } ]
+				exports: [ { service: "svc.>" } ]
+			}
+			B {
+				users: [ { user: b, password: pwd } ]
+				imports: [ { service: { account: A, subject: "svc.>" } } ]
+			}
+		}
+		cluster {
+			name: "TEST"
+			port: -1
+			compression: s2_fast
+			%s
+		}
+	`
+	conf1 := createConfFile(t, []byte(fmt.Sprintf(tmpl, "S1", "")))
+	s1, o1 := RunServerWithConfig(conf1)
+	defer s1.Shutdown()
+
+	conf2 := createConfFile(t, []byte(fmt.Sprintf(tmpl, "S2",
+		fmt.Sprintf("routes: [\"nats://127.0.0.1:%d\"]", o1.Cluster.Port))))
+	s2, _ := RunServerWithConfig(conf2)
+	defer s2.Shutdown()
+
+	checkClusterFormed(t, s1, s2)
+
+	// Account A responder on S2 — the destination of the service import.
+	ncAResp := natsConnect(t, s2.ClientURL(), nats.UserInfo("a", "pwd"))
+	defer ncAResp.Close()
+	respCount := atomic.Int64{}
+	_, err := ncAResp.Subscribe("svc.>", func(m *nats.Msg) {
+		respCount.Add(1)
+	})
+	require_NoError(t, err)
+	require_NoError(t, ncAResp.Flush())
+
+	// Account B subscriber on S2 — receives over the route from S1.
+	ncB2 := natsConnect(t, s2.ClientURL(), nats.UserInfo("b", "pwd"))
+	defer ncB2.Close()
+	subB2, err := ncB2.SubscribeSync("svc.>")
+	require_NoError(t, err)
+	defer subB2.Unsubscribe()
+	require_NoError(t, subB2.SetPendingLimits(-1, -1))
+	require_NoError(t, ncB2.Flush())
+
+	checkSubInterest(t, s1, "A", "svc.foo", time.Second)
+	checkSubInterest(t, s1, "B", "svc.foo", time.Second)
+	checkSubInterest(t, s2, "B", "svc.foo", time.Second)
+
+	total := 3000
+	bodies := make([][]byte, total)
+	for i := 0; i < total; i++ {
+		filler := strings.Repeat("x", 32+rand.Intn(12*1024))
+		body := fmt.Sprintf(
+			`{"branch":"main","idx":%d,`+
+				`"some_tag":"tag-aaaaaaaaaaaaaaaaaaaaaaaa",`+
+				`"data":{"context":{"commit":"0123456789abcdef0123456789abcdef01234567",`+
+				`"scope":"api","filler":%q},`+
+				`"payload":{"client_ip_address":"2001:db8::1","seq":%d}}}`,
+			i, filler, i)
+		bodies[i] = []byte(body)
+	}
+
+	producers := 8
+	var pwg sync.WaitGroup
+	for p := 0; p < producers; p++ {
+		pwg.Add(1)
+		go func(p int) {
+			defer pwg.Done()
+			pnc := natsConnect(t, s1.ClientURL(), nats.UserInfo("b", "pwd"))
+			defer pnc.Close()
+			for i := p; i < total; i += producers {
+				m := nats.NewMsg(fmt.Sprintf("svc.%d", i%64))
+				m.Data = bodies[i]
+				// Many headers, varying sizes, in a mix that sorts before and after "Nats-Request-Info"
+				// so that it has both leading and trailing neighbors.
+				m.Header.Set("Idx", strconv.Itoa(i))
+				m.Header.Set("Nats-Msg-Id", fmt.Sprintf("msg-%06d", i))
+				// Extra header which will be removed on the fly.
+				m.Header.Set("Nats-Request-Info", `{"acc":"B","user":"b","host":"prefilled"}`)
+				m.Header.Set("Trace-Id", "trace-aaaaaaaaaaaaaaaaaaaaaaaa")
+				m.Header.Set("Span-Id", "span-bbbbbbbbbbbbbbbbbbbbbbbb")
+				m.Header.Set("Request-Id", "request-cccccccccccccccccccccccc")
+				m.Header.Set("Source-App", "test-app")
+				m.Header.Set("X-Filler", strings.Repeat("filler-", 16)+strconv.Itoa(rand.Int()))
+				m.Header.Set("X-Tail-Header", fmt.Sprintf("idx=%d-stable-tail-data", i))
+				if err := pnc.PublishMsg(m); err != nil {
+					t.Errorf("publish %d: %v", i, err)
+					return
+				}
+			}
+			_ = pnc.Flush()
+		}(p)
+	}
+	pwg.Wait()
+
+	seen := make(map[int]bool, total)
+	deadline := time.Now().Add(120 * time.Second)
+	for len(seen) < total {
+		if time.Now().After(deadline) {
+			t.Fatalf("subB2: timed out: got %d/%d", len(seen), total)
+		}
+		m, err := subB2.NextMsg(2 * time.Second)
+		if err != nil {
+			continue
+		}
+		var parsed struct {
+			Branch string `json:"branch"`
+			Idx    int    `json:"idx"`
+			Tag    string `json:"some_tag"`
+			Data   struct {
+				Context struct {
+					Commit string `json:"commit"`
+					Scope  string `json:"scope"`
+					Filler string `json:"filler"`
+				} `json:"context"`
+				Payload struct {
+					ClientIPAddress string `json:"client_ip_address"`
+					Seq             int    `json:"seq"`
+				} `json:"payload"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(m.Data, &parsed); err != nil {
+			t.Fatalf("subB2 json.Unmarshal failed: %v: data[:256]=%q",
+				err, m.Data[:min(256, len(m.Data))])
+		}
+		// Ensure all headers are still present.
+		idxStr := m.Header.Get("Idx")
+		if idxStr == "" {
+			keys := make([]string, 0, len(m.Header))
+			for k := range m.Header {
+				keys = append(keys, k)
+			}
+			t.Fatalf("subB2: received message with no/empty Idx header (corruption): subj=%s data[:128]=%q allHeaderKeys=%v",
+				m.Subject, m.Data[:min(128, len(m.Data))], keys)
+		}
+		// Detect garbage header keys (e.g., 'c"' from leftover '"acc":"B"...')
+		// and silently dropped expected keys.
+		expectedKeys := map[string]bool{
+			"Idx": true, "Nats-Msg-Id": true, "Nats-Request-Info": true,
+			"Trace-Id": true, "Span-Id": true, "Request-Id": true,
+			"Source-App": true, "X-Filler": true, "X-Tail-Header": true,
+		}
+		gotKeys := make(map[string]bool, len(m.Header))
+		for k := range m.Header {
+			gotKeys[k] = true
+		}
+		for k := range gotKeys {
+			if !expectedKeys[k] {
+				keys := make([]string, 0, len(gotKeys))
+				for kk := range gotKeys {
+					keys = append(keys, kk)
+				}
+				t.Fatalf("subB2 idx=%s: unexpected header key %q (corruption); allKeys=%v",
+					idxStr, k, keys)
+			}
+		}
+		for k := range expectedKeys {
+			if !gotKeys[k] {
+				keys := make([]string, 0, len(gotKeys))
+				for kk := range gotKeys {
+					keys = append(keys, kk)
+				}
+				t.Fatalf("subB2 idx=%s: expected header key %q missing (corruption); allKeys=%v",
+					idxStr, k, keys)
+			}
+		}
+		idx, err := strconv.Atoi(idxStr)
+		require_NoError(t, err)
+		// Bounds check so corruption that rewrites Idx to an out-of-range value
+		// cannot inflate len(seen) and produce a false negative.
+		if idx < 0 || idx >= total {
+			t.Fatalf("subB2: Idx header out of range (corruption): idx=%d total=%d data[:128]=%q",
+				idx, total, m.Data[:min(128, len(m.Data))])
+		}
+
+		// Check that parsed JSON contains the expected data.
+		if parsed.Idx != idx {
+			t.Fatalf("subB2 idx=%d: parsed idx mismatch got=%d", idx, parsed.Idx)
+		}
+		if parsed.Data.Payload.Seq != idx {
+			t.Fatalf("subB2 idx=%d: parsed payload.seq mismatch got=%d", idx, parsed.Data.Payload.Seq)
+		}
+		// Headers should round-trip intact.
+		if got := m.Header.Get("Idx"); got != idxStr {
+			t.Fatalf("subB2 idx=%d: Idx header corrupted, got=%q", idx, got)
+		}
+		if got := m.Header.Get("Nats-Msg-Id"); got != fmt.Sprintf("msg-%06d", idx) {
+			t.Fatalf("subB2 idx=%d: Nats-Msg-Id corrupted, got=%q", idx, got)
+		}
+		wantTail := fmt.Sprintf("idx=%d-stable-tail-data", idx)
+		if got := m.Header.Get("X-Tail-Header"); got != wantTail {
+			t.Fatalf("subB2 idx=%d: X-Tail-Header corrupted, got=%q want=%q", idx, got, wantTail)
+		}
+		seen[idx] = true
+	}
+
+	// Check that all messages were received.
+	checkFor(t, 5*time.Second, 50*time.Millisecond, func() error {
+		if got := respCount.Load(); got != int64(total) {
+			return fmt.Errorf("Account A responder: got %d/%d messages", got, total)
+		}
+		return nil
+	})
+}
+
 func TestRouteConfigureWriteDeadline(t *testing.T) {
 	o1, o2 := DefaultOptions(), DefaultOptions()
 


### PR DESCRIPTION
This was fixed at:

https://github.com/nats-io/nats-server/commit/d5ef552ae46d7c284e4bfdf01211f97893b2f38f

Some operations done on the headers would have corrupted headers or the payload under some conditions.

Signed-off-by: Waldemar Quevedo <wally@nats.io>
