### PR TITLE
[FIXED] Double-encoded reply subject in $JS.ACK routing

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4180,6 +4180,37 @@ func isJSAckSubject(subject []byte) bool {
 	return len(subject) > jsAckPreLen && bytesToString(subject[:jsAckPreLen]) == jsAckPre
 }
 
+// jsAckDeliverIdx returns the byte offset of the `@` separator in an encoded
+// `$JS.ACK....@<deliver>` reply, or -1 if reply is not in that form. Stream,
+// consumer, and subject tokens may legally contain `@`, so we accept only the
+// first `@` that follows the eight dots of the JS ACK token:
+//
+//	$JS.ACK.<stream>.<consumer>.<delivered>.<sseq>.<cseq>.<tm>.<pending>@<deliver>
+func jsAckDeliverIdx(reply []byte) int {
+	if !isJSAckSubject(reply) {
+		return -1
+	}
+	dots := 0
+	for i, b := range reply {
+		switch b {
+		case '.':
+			dots++
+		case '@':
+			if dots >= 8 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// replyHasJSAckSuffix reports whether reply is already in `$JS.ACK....@<deliver>`
+// form, so callers don't double-append the suffix on a re-entrant pass
+// (service-import or chained JS push).
+func replyHasJSAckSuffix(reply []byte) bool {
+	return jsAckDeliverIdx(reply) != -1
+}
+
 // Test whether a reply subject is a service import or a gateway routed reply.
 func isReservedReply(reply []byte) bool {
 	if isServiceReply(reply) {
@@ -4387,7 +4418,7 @@ func (c *client) processInboundClientMsg(msg []byte) (bool, bool) {
 	// Now deal with gateways
 	if c.srv.gateway.enabled {
 		reply := c.pa.reply
-		if len(c.pa.deliver) > 0 && c.kind == JETSTREAM && len(c.pa.reply) > 0 {
+		if len(c.pa.deliver) > 0 && c.kind == JETSTREAM && len(reply) > 0 && !replyHasJSAckSuffix(reply) {
 			reply = append(reply, '@')
 			reply = append(reply, c.pa.deliver...)
 		}
@@ -4435,7 +4466,7 @@ func (c *client) handleGWReplyMap(msg []byte) bool {
 	}
 	if c.srv.gateway.enabled {
 		reply := c.pa.reply
-		if len(c.pa.deliver) > 0 && c.kind == JETSTREAM && len(c.pa.reply) > 0 {
+		if len(c.pa.deliver) > 0 && c.kind == JETSTREAM && len(reply) > 0 && !replyHasJSAckSuffix(reply) {
 			reply = append(reply, '@')
 			reply = append(reply, c.pa.deliver...)
 		}
@@ -5064,21 +5095,9 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 	// Check for JetStream encoded reply subjects.
 	// For now these will only be on $JS.ACK prefixed reply subjects.
 	var remapped bool
-	if len(creply) > 0 && c.kind != CLIENT && !isInternalClient(c.kind) && bytes.HasPrefix(creply, []byte(jsAckPre)) {
+	if len(creply) > 0 && c.kind != CLIENT && !isInternalClient(c.kind) {
 		// We need to rewrite the subject and the reply.
-		// But, we must be careful that the stream name, consumer name, and subject can contain '@' characters.
-		// JS ACK contains at least 8 dots, find the first @ after this prefix.
-		// - $JS.ACK.<stream>.<consumer>.<delivered>.<sseq>.<cseq>.<tm>.<pending>
-		counter := 0
-		li := bytes.IndexFunc(creply, func(rn rune) bool {
-			if rn == '.' {
-				counter++
-			} else if rn == '@' {
-				return counter >= 8
-			}
-			return false
-		})
-		if li != -1 && li < len(creply)-1 {
+		if li := jsAckDeliverIdx(creply); li != -1 && li < len(creply)-1 {
 			remapped = true
 			subj, creply = creply[li+1:], creply[:li]
 		}
@@ -5498,7 +5517,7 @@ sendToRoutesOrLeafs:
 	// at the end of the reply subject if it exists. But only if this wasn't
 	// already performed, otherwise we'd end up with a duplicate '@' suffix
 	// resulting in a protocol error.
-	if len(deliver) > 0 && len(reply) > 0 && !remapped {
+	if len(deliver) > 0 && len(reply) > 0 && !remapped && !replyHasJSAckSuffix(reply) {
 		reply = append(reply, '@')
 		reply = append(reply, deliver...)
 	}

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -3300,6 +3300,29 @@ func TestSliceHeaderOrderingPrefix(t *testing.T) {
 	require_True(t, bytes.Equal(sliced, copied))
 }
 
+func TestReplyHasJSAckSuffix(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		reply string
+		want  bool
+	}{
+		{"plain JSAck no suffix", "$JS.ACK.STREAM.CONS.1.2.3.4.5", false},
+		{"single @ encoded", "$JS.ACK.STREAM.CONS.1.2.3.4.5@deliver.subject", true},
+		{"double @ encoded (already corrupted)", "$JS.ACK.STREAM.CONS.1.2.3.4.5@inner@outer", true},
+		{"non-JSAck reply with @", "_INBOX.abc@xyz", false},
+		{"@ before 8 dots", "$JS.ACK.STREAM@oops.1.2.3.4.5", false},
+		{"empty", "", false},
+		{"JSAck prefix only no fields", "$JS.ACK.", false},
+		// Cross-domain v2 token has more dots, but still 8+ before the @.
+		{"v2 token encoded", "$JS.ACK.dom.acct.STREAM.CONS.1.2.3.4.5@deliver", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := replyHasJSAckSuffix([]byte(test.reply))
+			require_Equal(t, got, test.want)
+		})
+	}
+}
+
 func TestSliceHeaderOrderingSuffix(t *testing.T) {
 	hdr := []byte("NATS/1.0\r\n\r\n")
 

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -2368,6 +2368,138 @@ func TestJetStreamClusterPushConsumerQueueGroup(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterJSInternalEncodedReplyNotReEncodedOnRoute(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "JSC", 2)
+	defer c.shutdown()
+
+	s1, s2 := c.servers[0], c.servers[1]
+
+	const (
+		deliverSubj = "deliver.subj"
+		streamSubj  = "stream.subj.id"
+		ackToken    = "$JS.ACK.stream.consumer.1.13266774.12547470.1708328638063395796.1"
+	)
+	encodedOnce := ackToken + "@" + streamSubj
+
+	nc2, _ := jsClientConnect(t, s2)
+	defer nc2.Close()
+	sub, err := nc2.SubscribeSync(deliverSubj)
+	require_NoError(t, err)
+	require_NoError(t, nc2.Flush())
+
+	// Wait for s2's interest to propagate to s1 via the route.
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		acc, err := s1.LookupAccount(globalAccountName)
+		if err != nil {
+			return err
+		}
+		if r := acc.sl.Match(deliverSubj); len(r.psubs)+len(r.qsubs) == 0 {
+			return fmt.Errorf("no route interest on %q at s1 yet", deliverSubj)
+		}
+		return nil
+	})
+
+	// Stand up a JETSTREAM-kind internal client on s1 and synthesize the state
+	// that internalLoop produces for a chained delivery with an already-encoded reply.
+	js := s1.createInternalJetStreamClient()
+	require_NotNil(t, js)
+	acc, err := s1.LookupAccount(globalAccountName)
+	require_NoError(t, err)
+	require_NoError(t, js.registerWithAccount(acc))
+
+	body := []byte("payload\r\n")
+	js.mu.Lock()
+	js.pa.subject = []byte(deliverSubj)
+	js.pa.deliver = []byte(streamSubj)
+	js.pa.reply = []byte(encodedOnce)
+	js.pa.hdr = -1
+	js.pa.hdb = nil
+	js.pa.size = len(body) - LEN_CR_LF
+	js.pa.szb = []byte(strconv.Itoa(js.pa.size))
+	js.mu.Unlock()
+
+	js.processInboundClientMsg(body)
+	js.flushClients(0)
+
+	received, err := sub.NextMsg(2 * time.Second)
+	require_NoError(t, err)
+
+	// s2's remap splits the encoded reply at the first `@`. If the encoding
+	// was applied twice on s1 the trailing `@<deliver>` would leak into Subject.
+	if strings.Contains(received.Subject, "@") {
+		t.Fatalf("routed reply was double-encoded: subject leaked an `@` after remap (Subject=%q, Reply=%q)",
+			received.Subject, received.Reply)
+	}
+	require_Equal(t, received.Subject, streamSubj)
+	require_Equal(t, received.Reply, ackToken)
+}
+
+func TestJetStreamClusterJSInternalEncodedReplyNotReEncodedOnGateway(t *testing.T) {
+	ob := testDefaultOptionsForGateway("B")
+	sb := runGatewayServer(ob)
+	defer sb.Shutdown()
+
+	oa := testGatewayOptionsFromToWithServers(t, "A", "B", sb)
+	sa := runGatewayServer(oa)
+	defer sa.Shutdown()
+
+	waitForOutboundGateways(t, sa, 1, 2*time.Second)
+	waitForOutboundGateways(t, sb, 1, 2*time.Second)
+	waitForInboundGateways(t, sa, 1, 2*time.Second)
+	waitForInboundGateways(t, sb, 1, 2*time.Second)
+
+	const (
+		deliverSubj = "deliver.subj"
+		streamSubj  = "stream.subj.id"
+		ackToken    = "$JS.ACK.stream.consumer.1.13266774.12547470.1708328638063395796.1"
+	)
+	encodedOnce := ackToken + "@" + streamSubj
+
+	ncB := natsConnect(t, sb.ClientURL())
+	defer ncB.Close()
+	sub, err := ncB.SubscribeSync(deliverSubj)
+	require_NoError(t, err)
+	require_NoError(t, ncB.Flush())
+
+	// Wait for sb's interest on deliverSubj to be visible on sa's outbound
+	// gateway so the message will actually cross.
+	checkGWInterestOnlyModeInterestOn(t, sa, "B", globalAccountName, deliverSubj)
+
+	// Synthesize the JETSTREAM-kind state with an already-encoded reply,
+	// matching what internalLoop produces on a chained delivery hop.
+	js := sa.createInternalJetStreamClient()
+	require_NotNil(t, js)
+	acc, err := sa.LookupAccount(globalAccountName)
+	require_NoError(t, err)
+	require_NoError(t, js.registerWithAccount(acc))
+
+	body := []byte("payload\r\n")
+	js.mu.Lock()
+	js.pa.subject = []byte(deliverSubj)
+	js.pa.deliver = []byte(streamSubj)
+	js.pa.reply = []byte(encodedOnce)
+	js.pa.hdr = -1
+	js.pa.hdb = nil
+	js.pa.size = len(body) - LEN_CR_LF
+	js.pa.szb = []byte(strconv.Itoa(js.pa.size))
+	js.mu.Unlock()
+
+	js.processInboundClientMsg(body)
+	js.flushClients(0)
+
+	received, err := sub.NextMsg(2 * time.Second)
+	require_NoError(t, err)
+
+	// sb's remap splits the encoded reply at the first `@`. If the encoding
+	// was applied twice on sa the trailing `@<deliver>` would leak into Subject.
+	if strings.Contains(received.Subject, "@") {
+		t.Fatalf("gateway reply was double-encoded: subject leaked an `@` after remap (Subject=%q, Reply=%q)",
+			received.Subject, received.Reply)
+	}
+	require_Equal(t, received.Subject, streamSubj)
+	require_Equal(t, received.Reply, ackToken)
+}
+
 func TestJetStreamClusterConsumerLastActiveReporting(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()


### PR DESCRIPTION
The `$JS.ACK` reply subject is encoded with the deliver subject (`$JS.ACK...@<deliver>`), to allow sending the message to a client's inbox, but with a different deliver subject (which is the subject of the message stored in the stream) after a route/gateway hop. If this encoding would be performed more than once, it would result in a protocol error.

Follow-up of: https://github.com/nats-io/nats-server/pull/7579