### PR TITLE
NRG: tighten append entry length decoding bounds

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -2784,9 +2784,9 @@ func decodeAppendEntry(msg []byte, sub *subscription, reply string) (*appendEntr
 	ae.reply, ae.sub = reply, sub
 
 	// Decode Entries.
-	ne, ri := int(le.Uint16(msg[40:])), uint64(42)
+	ne, ri := int(le.Uint16(msg[40:])), uint64(appendEntryBaseLen)
 	for i, max := 0, uint64(len(msg)); i < ne; i++ {
-		if ri >= max-1 {
+		if max-ri < 4 {
 			return nil, errBadAppendEntry
 		}
 		ml := uint64(le.Uint32(msg[ri:]))

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -151,6 +151,23 @@ func TestNRGAppendEntryDecode(t *testing.T) {
 	}
 }
 
+func TestNRGAppendEntryDecodeTruncatedEntryLength(t *testing.T) {
+	ae := &appendEntry{
+		leader:  "12345678",
+		term:    1,
+		entries: []*Entry{newEntry(EntryNormal, nil)},
+	}
+
+	buf, err := ae.encode(nil)
+	require_NoError(t, err)
+
+	// Truncate the 4 byte length field of the first entry.
+	// The decoder wants to read 4 bytes, finds only 2 bytes left.
+	truncated := buf[:appendEntryBaseLen+2]
+	_, err = decodeAppendEntry(truncated, nil, _EMPTY_)
+	require_Error(t, err, errBadAppendEntry)
+}
+
 func TestNRGRecoverFromFollowingNoLeader(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()


### PR DESCRIPTION
decodeAppendEntry could panic if it was given a buffer containing a truncated append entry. The function
did not correctly check that there are at least
4 bytes left before decoding the length of the entry.