### PR TITLE
(2.14) [FIXED] Fast batch: parse batch seq as uint64

### DIFF
--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -445,7 +445,7 @@ func TestJetStreamAtomicBatchPublishLimits(t *testing.T) {
 				require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
 				if size <= streamMaxAtomicBatchSize {
 					require_True(t, pubAck.Error == nil)
-					require_Equal(t, pubAck.BatchSize, size)
+					require_Equal(t, pubAck.BatchSize, uint64(size))
 				} else {
 					require_Error(t, pubAck.Error, NewJSAtomicPublishTooLargeBatchError(streamMaxAtomicBatchSize))
 				}
@@ -3280,6 +3280,86 @@ func TestJetStreamFastBatchPublishGapDetection(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestJetStreamFastBatchPublishMaxUint64SequenceRejected(t *testing.T) {
+	test := func(t *testing.T, commitEob bool) {
+		c := createJetStreamClusterExplicit(t, "R3S", 3)
+		defer c.shutdown()
+
+		nc := clientConnectToServer(t, c.randomServer())
+		defer nc.Close()
+
+		_, err := jsStreamCreate(t, nc, &StreamConfig{
+			Name:              "TEST",
+			Subjects:          []string{"foo"},
+			Storage:           FileStorage,
+			Replicas:          1,
+			AllowBatchPublish: true,
+		})
+		require_NoError(t, err)
+
+		inbox := nats.NewInbox()
+		sub, err := nc.SubscribeSync(fmt.Sprintf("%s.>", inbox))
+		require_NoError(t, err)
+		defer sub.Drain()
+
+		m := nats.NewMsg("foo")
+		m.Reply = generateFastBatchReply(inbox, "uuid", 1, 1, FastBatchGapOk, FastBatchOpStart)
+		require_NoError(t, nc.PublishMsg(m))
+		rmsg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+
+		var batchFlowAck BatchFlowAck
+		require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowAck))
+		require_Equal(t, batchFlowAck.Messages, 1)
+		require_Equal(t, batchFlowAck.Sequence, 0)
+
+		rmsg, err = sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		require_True(t, strings.HasPrefix(string(rmsg.Data), "{\"type\":\"ack\","))
+		batchFlowAck = BatchFlowAck{}
+		require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowAck))
+		require_Equal(t, batchFlowAck.Messages, 1)
+		require_Equal(t, batchFlowAck.Sequence, 1)
+
+		m.Reply = generateFastBatchReply(inbox, "uuid", math.MaxUint64-1, 1, FastBatchGapOk, FastBatchOpAppend)
+		require_NoError(t, nc.PublishMsg(m))
+		rmsg, err = sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		require_True(t, strings.HasPrefix(string(rmsg.Data), "{\"type\":\"gap\","))
+		var batchFlowGap BatchFlowGap
+		require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowGap))
+		require_Equal(t, batchFlowGap.ExpectedLastSequence, 2)
+		require_Equal(t, batchFlowGap.CurrentSequence, uint64(math.MaxUint64-1))
+
+		rmsg, err = sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		require_True(t, strings.HasPrefix(string(rmsg.Data), "{\"type\":\"ack\","))
+		batchFlowAck = BatchFlowAck{}
+		require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowAck))
+		require_Equal(t, batchFlowAck.Messages, 1)
+		require_Equal(t, batchFlowAck.Sequence, uint64(math.MaxUint64-1))
+
+		// math.MaxUint64 must be rejected so b.lseq cannot be jumped to a value
+		// where the next b.lseq++ would wrap to zero.
+		opCommit := FastBatchOpCommit
+		if commitEob {
+			opCommit = FastBatchOpCommitEob
+		}
+		m.Reply = generateFastBatchReply(inbox, "uuid", math.MaxUint64, 1, FastBatchGapOk, opCommit)
+		require_NoError(t, nc.PublishMsg(m))
+
+		rmsg, err = sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		var pubAck JSPubAckResponse
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_NotNil(t, pubAck.Error)
+		require_Error(t, pubAck.Error, NewJSBatchPublishInvalidPatternError())
+	}
+
+	t.Run("Commit", func(t *testing.T) { test(t, false) })
+	t.Run("CommitEob", func(t *testing.T) { test(t, true) })
 }
 
 func TestJetStreamFastBatchPublishFlowControl(t *testing.T) {

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -3025,6 +3025,28 @@ func TestJetStreamAtomicBatchPublishCommitUnsupported(t *testing.T) {
 	require_Len(t, len(sliceHeader(JSRequiredApiLevel, sm.Header)), 0)
 }
 
+func TestJetStreamAtomicPublishGetBatchSequence(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		hdr    []byte
+		seq    uint64
+		exists bool
+	}{
+		{"missing", nil, 0, false},
+		{"empty-value", genHeader(nil, JSBatchSeq, ""), 0, false},
+		{"valid", genHeader(nil, JSBatchSeq, "42"), 42, true},
+		{"non-numeric", genHeader(nil, JSBatchSeq, "abc"), 0, false},
+		{"negative", genHeader(nil, JSBatchSeq, "-1"), 0, false},
+		{"overflow", genHeader(nil, JSBatchSeq, "18446744073709551616"), 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			seq, exists := getBatchSequence(tc.hdr)
+			require_Equal(t, seq, tc.seq)
+			require_Equal(t, exists, tc.exists)
+		})
+	}
+}
+
 func generateFastBatchReply(inbox string, batchId string, batchSeq uint64, flow uint16, gap string, op int) string {
 	return fmt.Sprintf("%s.%s.%d.%s.%d.%d.$FI", inbox, batchId, flow, gap, batchSeq, op)
 }

--- a/server/stream.go
+++ b/server/stream.go
@@ -5612,7 +5612,7 @@ func getBatchSequence(hdr []byte) (uint64, bool) {
 	if len(bseq) == 0 {
 		return 0, false
 	}
-	return uint64(parseInt64(bseq)), true
+	return parseUint64(bseq)
 }
 
 // Signal if we are clustered. Will acquire rlock.

--- a/server/stream.go
+++ b/server/stream.go
@@ -264,7 +264,7 @@ type PubAck struct {
 	Duplicate bool   `json:"duplicate,omitempty"`
 	Value     string `json:"val,omitempty"`
 	BatchId   string `json:"batch,omitempty"`
-	BatchSize int    `json:"count,omitempty"`
+	BatchSize uint64 `json:"count,omitempty"`
 }
 
 // CounterValue is the body of a message when used as a counter.
@@ -5558,15 +5558,14 @@ func getFastBatch(reply string, hdr []byte) (*FastBatch, bool) {
 	if o = strings.LastIndexByte(reply[:o], '.'); o == -1 {
 		return nil, true
 	}
-	a := parseInt64(stringToBytes(reply[o+1 : p]))
-	if a < 1 {
+	seq, ok := parseUint64(stringToBytes(reply[o+1 : p]))
+	// Reject math.MaxUint64 to prevent b.lseq overflowing on the next b.lseq++.
+	if !ok || seq == 0 || seq == math.MaxUint64 {
 		return nil, true
 	}
-	b.seq = uint64(a)
+	b.seq = seq
 	p = o
-	if b.seq <= 0 {
-		return nil, true
-	} else if b.seq == 1 && b.commitEob {
+	if b.seq == 1 && b.commitEob {
 		return nil, true
 	}
 	if op == FastBatchOpStart && b.seq != 1 {
@@ -5590,7 +5589,7 @@ func getFastBatch(reply string, hdr []byte) (*FastBatch, bool) {
 	if o = strings.LastIndexByte(reply[:o], '.'); o == -1 {
 		return nil, true
 	}
-	a = parseInt64(stringToBytes(reply[o+1 : p]))
+	a := parseInt64(stringToBytes(reply[o+1 : p]))
 	if a <= 0 {
 		a = 10
 	} else if a > math.MaxUint16 {

--- a/server/util.go
+++ b/server/util.go
@@ -124,6 +124,26 @@ func parseInt64(d []byte) (n int64) {
 	return n
 }
 
+// parseUint64 expects decimal positive numbers. Returns the value and true on success,
+// or 0 and false on invalid input or overflow.
+func parseUint64(d []byte) (uint64, bool) {
+	if len(d) == 0 {
+		return 0, false
+	}
+	var n uint64
+	for _, dec := range d {
+		if dec < asciiZero || dec > asciiNine {
+			return 0, false
+		}
+		digit := uint64(dec) - asciiZero
+		if n > math.MaxUint64/10 || (n == math.MaxUint64/10 && digit > math.MaxUint64%10) {
+			return 0, false
+		}
+		n = n*10 + digit
+	}
+	return n, true
+}
+
 // Helper to move from float seconds to time.Duration
 func secondsToDuration(seconds float64) time.Duration {
 	ttl := seconds * float64(time.Second)


### PR DESCRIPTION
The batch sequence was intended to be `uint64` but ended up being a mix of types: `getFastBatch` used `parseInt64` and `BatchSize` was of type `int`, whereas everything else was already a `uint64`. This would previously reject a batch sequence if it exceeded `math.MaxInt64`, similarly a `PubAck` could not contain such a large `BatchSize` if allowed.