### PR TITLE
Reduce log level of TLS handshake timeouts or non-TLS records from clients or leafnodes

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -6571,10 +6571,20 @@ func (c *client) doTLSHandshake(typ string, solicit bool, url *url.URL, tlsConfi
 		if len(subjs) > 0 {
 			detail = fmt.Sprintf(" (%s)", strings.Join(subjs, "; "))
 		}
-		if kind == CLIENT {
-			c.Errorf("TLS handshake error: %v%s", err, detail)
-		} else {
+		if kind == ROUTER || kind == GATEWAY {
+			// Always surface these as errors, as these ports shouldn't be behind a load
+			// balancer or regularly probed.
 			c.Errorf("TLS %s handshake error: %v%s", typ, err, detail)
+		} else {
+			logf := c.Errorf
+			if isClientProbeTLSHandshakeError(err) {
+				logf = c.Debugf
+			}
+			if kind == CLIENT {
+				logf("TLS handshake error: %v%s", err, detail)
+			} else {
+				logf("TLS %s handshake error: %v%s", typ, err, detail)
+			}
 		}
 		c.closeConnection(TLSHandshakeError)
 
@@ -6602,6 +6612,17 @@ func (c *client) doTLSHandshake(typ string, solicit bool, url *url.URL, tlsConfi
 	}
 
 	return false, err
+}
+
+func isClientProbeTLSHandshakeError(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	var recordHeaderErr tls.RecordHeaderError
+	// Conn is only set by crypto/tls when the invalid record was the peer's
+	// initial handshake bytes, which is the non-TLS probe/load-balancer case.
+	return errors.As(err, &recordHeaderErr) && recordHeaderErr.Conn != nil
 }
 
 // getRawAuthUserLock returns the raw auth user for the client.

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -3240,6 +3240,171 @@ func TestTLSClientHandshakeFirstAndInProcessConnection(t *testing.T) {
 	}
 }
 
+type captureTLSHandshakeLogger struct {
+	DummyLogger
+	debugCh chan string
+	errCh   chan string
+}
+
+func (l *captureTLSHandshakeLogger) Debugf(format string, v ...any) {
+	select {
+	case l.debugCh <- fmt.Sprintf(format, v...):
+	default:
+	}
+}
+
+func (l *captureTLSHandshakeLogger) Errorf(format string, v ...any) {
+	select {
+	case l.errCh <- fmt.Sprintf(format, v...):
+	default:
+	}
+}
+
+func TestTLSClientHandshakeProbeErrorsLogAsDebug(t *testing.T) {
+	tc := &TLSConfigOpts{
+		CertFile: "../test/configs/certs/server-cert.pem",
+		KeyFile:  "../test/configs/certs/server-key.pem",
+	}
+	tlsConfig, err := GenTLSConfig(tc)
+	require_NoError(t, err)
+
+	for _, test := range []struct {
+		name       string
+		timeout    float64
+		peer       string
+		pCerts     PinnedCertSet
+		wantDebug  bool
+		wantErrLog bool
+	}{
+		{"timeout", 0.01, _EMPTY_, nil, true, false},
+		{"not_tls_first_record", 1, "plain", nil, true, false},
+		{"pinned_cert_failure", 1, "tls", PinnedCertSet{"bad": struct{}{}}, false, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s, err := NewServer(DefaultOptions())
+			require_NoError(t, err)
+			l := &captureTLSHandshakeLogger{
+				debugCh: make(chan string, 4),
+				errCh:   make(chan string, 4),
+			}
+			s.SetLogger(l, true, false)
+
+			serverConn, clientConn := net.Pipe()
+			defer clientConn.Close()
+
+			c := &client{srv: s, nc: serverConn, kind: CLIENT}
+			c.initClient()
+
+			switch test.peer {
+			case "plain":
+				go clientConn.Write([]byte("not tls\r\n"))
+			case "tls":
+				go func() {
+					tlsClient := tls.Client(clientConn, &tls.Config{InsecureSkipVerify: true})
+					tlsClient.Handshake()
+					tlsClient.Close()
+				}()
+			}
+
+			c.mu.Lock()
+			err = c.doTLSServerHandshake(_EMPTY_, tlsConfig, test.timeout, test.pCerts)
+			c.mu.Unlock()
+			require_Error(t, err)
+
+			var gotDebug, gotErrLog bool
+			deadline := time.After(100 * time.Millisecond)
+			for done := false; !done; {
+				select {
+				case msg := <-l.errCh:
+					if strings.Contains(msg, "TLS handshake error") {
+						gotErrLog = true
+					}
+				case msg := <-l.debugCh:
+					if strings.Contains(msg, "TLS handshake error") {
+						gotDebug = true
+					}
+				case <-deadline:
+					done = true
+				}
+			}
+			if gotDebug != test.wantDebug {
+				t.Fatalf("Expected debug TLS handshake error log: %v, got: %v", test.wantDebug, gotDebug)
+			}
+			if gotErrLog != test.wantErrLog {
+				t.Fatalf("Expected error TLS handshake error log: %v, got: %v", test.wantErrLog, gotErrLog)
+			}
+		})
+	}
+}
+
+func TestTLSHandshakeTimerTimeoutLogLevel(t *testing.T) {
+	tc := &TLSConfigOpts{
+		CertFile: "../test/configs/certs/server-cert.pem",
+		KeyFile:  "../test/configs/certs/server-key.pem",
+	}
+	tlsConfig, err := GenTLSConfig(tc)
+	require_NoError(t, err)
+
+	for _, test := range []struct {
+		kind       int
+		wantDebug  bool
+		wantErrLog bool
+	}{
+		{CLIENT, true, false},
+		{LEAF, true, false},
+		{ROUTER, false, true},
+		{GATEWAY, false, true},
+	} {
+		t.Run(kindStringMap[test.kind], func(t *testing.T) {
+			s, err := NewServer(DefaultOptions())
+			require_NoError(t, err)
+			l := &captureTLSHandshakeLogger{
+				debugCh: make(chan string, 4),
+				errCh:   make(chan string, 4),
+			}
+			s.SetLogger(l, true, false)
+
+			serverConn, clientConn := net.Pipe()
+			defer clientConn.Close()
+
+			tlsConn := tls.Server(serverConn, tlsConfig)
+			c := &client{srv: s, nc: tlsConn, kind: test.kind}
+			if test.kind == ROUTER {
+				c.route = &route{}
+			} else if test.kind == GATEWAY {
+				c.gw = &gateway{}
+			}
+			c.initClient()
+			c.flags.set(noReconnect)
+
+			tlsTimeout(c, tlsConn)
+
+			var gotDebug, gotErrLog bool
+			deadline := time.After(100 * time.Millisecond)
+			for done := false; !done; {
+				select {
+				case msg := <-l.errCh:
+					if strings.Contains(msg, "TLS handshake timeout") {
+						gotErrLog = true
+					}
+				case msg := <-l.debugCh:
+					if strings.Contains(msg, "TLS handshake timeout") {
+						gotDebug = true
+					}
+				case <-deadline:
+					done = true
+				}
+			}
+			if gotDebug != test.wantDebug {
+				t.Fatalf("Expected debug TLS handshake timeout log: %v, got: %v", test.wantDebug, gotDebug)
+			}
+			if gotErrLog != test.wantErrLog {
+				t.Fatalf("Expected error TLS handshake timeout log: %v, got: %v", test.wantErrLog, gotErrLog)
+			}
+		})
+	}
+}
+
 func TestRemoveHeaderIfPrefixPresent(t *testing.T) {
 	hdr := []byte("NATS/1.0\r\n\r\n")
 

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -3190,7 +3190,7 @@ func TestLeafNodeWSFailedConnection(t *testing.T) {
 
 	select {
 	case err := <-el.errCh:
-		if !strings.Contains(err, "handshake error") {
+		if !strings.Contains(err, "Error soliciting websocket connection") {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 	case <-time.After(time.Second):

--- a/server/server.go
+++ b/server/server.go
@@ -3646,7 +3646,11 @@ func tlsTimeout(c *client, conn *tls.Conn) {
 	}
 	cs := conn.ConnectionState()
 	if !cs.HandshakeComplete {
-		c.Errorf("TLS handshake timeout")
+		if c.kind == CLIENT || c.kind == LEAF {
+			c.Debugf("TLS handshake timeout")
+		} else {
+			c.Errorf("TLS handshake timeout")
+		}
 		c.sendErr("Secure Connection - TLS Required")
 		c.closeConnection(TLSHandshakeError)
 	}


### PR DESCRIPTION
Load balancers, liveness probes etc on these ports can result in a lot of noise in the logs, so demote those to the debug level specifically for the timeout case. Other handshake errors, and errors on routes and gateways, are unchanged.