### PR TITLE
NRG: ignore temporary snapshot files on recovery

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -1610,6 +1610,9 @@ func termAndIndexFromSnapFile(sn string) (term, index uint64, err error) {
 	if n, err := fmt.Sscanf(fn, snapFileT, &term, &index); err != nil || n != 2 {
 		return 0, 0, errBadSnapName
 	}
+	if fn != fmt.Sprintf(snapFileT, term, index) {
+		return 0, 0, errBadSnapName
+	}
 	return term, index, nil
 }
 

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -2870,6 +2870,42 @@ func TestNRGLoadLastSnapshotCleansLegacyZeroIndexSnapshot(t *testing.T) {
 	require_True(t, os.IsNotExist(err))
 }
 
+func TestNRGSetupLastSnapshotIgnoresTmpFile(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// Make a snapshot file
+	snapDir := filepath.Join(n.sd, snapshotsDir)
+	require_NoError(t, os.MkdirAll(snapDir, defaultDirPerms))
+
+	snap := &snapshot{
+		lastTerm:  1,
+		lastIndex: 1,
+		peerstate: encodePeerState(n.currentPeerState()),
+		data:      []byte("snapshot"),
+	}
+
+	sfile := filepath.Join(snapDir, fmt.Sprintf(snapFileT, snap.lastTerm, snap.lastIndex))
+	require_NoError(t, os.WriteFile(sfile, n.encodeSnapshot(snap), defaultFilePerms))
+
+	// Make a empty snapshot file with a higher index, and extension
+	// .tmp to simulate the intermediate step in writeAtomically.
+	tmpSnap := filepath.Join(snapDir, fmt.Sprintf(snapFileT, uint64(1), uint64(2))+".tmp")
+	require_NoError(t, os.WriteFile(tmpSnap, nil, defaultFilePerms))
+
+	// If bug is present: setupLastSnapshot() selects
+	// the higher numbered snapshot file, even if it
+	// has the .tmp extension. The presence of a .tmp
+	// snapshot file means the server crashed, preventing
+	// writeAtomically() to finish. The contents of a
+	// .tmp snapshot file may be incomplete.
+	// Verify that setupLastSnapshot selects the "good"
+	// snapshot.
+	err := n.setupLastSnapshot()
+	require_NoError(t, err)
+	require_Equal(t, n.snapfile, sfile)
+}
+
 func TestNRGKeepRunningOnServerShutdown(t *testing.T) {
 	n, cleanup := initSingleMemRaftNode(t)
 	defer cleanup()


### PR DESCRIPTION
Ensure snapshot file parsing only accepts `snap.<term>.<index>`. This is to avoid the case where a .tmp snapshot file is selected after a crash. If the crash happend right after the temporary file creation and before the server managed to write out the full snapsho, then a subsequent recovery would fail due to finding a corrupt snapshot.