### PR TITLE
[FIXED] Consumer's redelivered state replication and cleanup

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3246,6 +3246,24 @@ func (o *consumer) ackWait(next time.Duration) time.Duration {
 	return o.cfg.AckWait + ackWaitDelay
 }
 
+func (o *consumer) removeRedeliveredBelow(seq uint64) {
+	if seq == 0 {
+		return
+	}
+	o.mu.Lock()
+	for sseq := range o.rdc {
+		if sseq < seq {
+			delete(o.rdc, sseq)
+			o.removeFromRedeliverQueue(sseq)
+		}
+	}
+	o.mu.Unlock()
+
+	if o.store != nil {
+		o.store.RemoveRedeliveredBelow(seq)
+	}
+}
+
 // Due to bug in calculation of sequences on restoring redelivered let's do quick sanity check.
 // Lock should be held.
 func (o *consumer) checkRedelivered() {

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -3264,14 +3264,24 @@ func (o *consumer) removeRedeliveredBelow(seq uint64) {
 	}
 }
 
-// Due to bug in calculation of sequences on restoring redelivered let's do quick sanity check.
+// checkRedelivered drops rdq entries at/below asflr or below stream's first sequence.
+// But rdc is kept until the message leaves the stream: needAck relies on rdc to mark
+// messages past MaxDeliver.
 // Lock should be held.
 func (o *consumer) checkRedelivered() {
+	if o.mset == nil {
+		return
+	}
+	var ss StreamState
+	o.mset.store.FastState(&ss)
+
 	var shouldUpdateState bool
 	for sseq := range o.rdc {
-		if sseq <= o.asflr {
-			delete(o.rdc, sseq)
+		if sseq <= o.asflr || sseq < ss.FirstSeq {
 			o.removeFromRedeliverQueue(sseq)
+		}
+		if sseq < ss.FirstSeq {
+			delete(o.rdc, sseq)
 			shouldUpdateState = true
 		}
 	}

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1832,6 +1832,7 @@ func (o *consumer) setLeader(isLeader bool) error {
 		stopAndClearTimer(&o.uptmr)
 		// Make sure to clear out any re-deliver queues
 		o.stopAndClearPtmr()
+		o.rdc = nil
 		o.rdq = nil
 		o.rdqi.Empty()
 		o.pending = nil

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -6439,9 +6439,9 @@ func (o *consumer) purge(sseq uint64, slseq uint64, isWider bool) {
 				}
 				delete(o.pending, seq)
 				delete(o.rdc, seq)
+				o.updateAcks(p.Sequence, seq, _EMPTY_)
 				// rdq handled below.
-			}
-			if isWider && store != nil {
+			} else if isWider && store != nil {
 				// Our filtered subject, which could be all, is wider than the underlying purge.
 				// We need to check if the pending items left are still valid.
 				var smv StoreMsg
@@ -6454,6 +6454,7 @@ func (o *consumer) purge(sseq uint64, slseq uint64, isWider bool) {
 					}
 					delete(o.pending, seq)
 					delete(o.rdc, seq)
+					o.updateAcks(p.Sequence, seq, _EMPTY_)
 				}
 			}
 		}

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -6784,6 +6784,10 @@ func (o *consumer) decStreamPending(sseq uint64, subj string) {
 	var rdc uint64
 	if wasPending {
 		rdc = o.deliveryCount(sseq)
+	} else if _, ok := o.rdc[sseq]; ok && o.isLeader() {
+		delete(o.rdc, sseq)
+		// Pass 0 as the delivered sequence to only remove the redelivered state.
+		o.updateAcks(0, sseq, _EMPTY_)
 	}
 
 	o.mu.Unlock()

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2342,6 +2342,7 @@ func (o *consumer) hasMaxDeliveries(seq uint64) bool {
 		if p, ok := o.pending[seq]; ok && p != nil {
 			delete(o.pending, seq)
 			o.updateDelivered(p.Sequence, seq, dc, p.Timestamp)
+			o.moveAckFloor(p.Sequence, seq)
 		}
 		// Ensure redelivered state is set, if not already.
 		if o.rdc == nil {
@@ -3641,22 +3642,7 @@ func (o *consumer) processAckMsgLocked(sseq, dseq, dc uint64, reply string, doSa
 			delete(o.pending, sseq)
 			// Use the original deliver sequence from our pending record.
 			dseq = p.Sequence
-
-			// Only move floors if we matched an existing pending.
-			if len(o.pending) == 0 {
-				o.adflr = o.dseq - 1
-				o.asflr = o.sseq - 1
-			} else if dseq == o.adflr+1 {
-				o.adflr, o.asflr = dseq, sseq
-				for ss := sseq + 1; ss < o.sseq; ss++ {
-					if p, ok := o.pending[ss]; ok {
-						if p.Sequence > 0 {
-							o.adflr, o.asflr = p.Sequence-1, ss-1
-						}
-						break
-					}
-				}
-			}
+			o.moveAckFloor(dseq, sseq)
 		}
 		delete(o.rdc, sseq)
 		o.removeFromRedeliverQueue(sseq)
@@ -3725,6 +3711,25 @@ func (o *consumer) processAckMsgLocked(sseq, dseq, dc uint64, reply string, doSa
 		o.signalNewMessages()
 	}
 	return ackInPlace
+}
+
+// Lock should be held.
+func (o *consumer) moveAckFloor(dseq, sseq uint64) {
+	// Only move floors if we matched an existing pending.
+	if len(o.pending) == 0 {
+		o.adflr = o.dseq - 1
+		o.asflr = o.sseq - 1
+	} else if dseq == o.adflr+1 {
+		o.adflr, o.asflr = dseq, sseq
+		for ss := sseq + 1; ss < o.sseq; ss++ {
+			if p, ok := o.pending[ss]; ok {
+				if p.Sequence > 0 {
+					o.adflr, o.asflr = p.Sequence-1, ss-1
+				}
+				break
+			}
+		}
+	}
 }
 
 // Determine if this is a truly filtered consumer. Modern clients will place filtered subjects
@@ -4764,6 +4769,7 @@ func (o *consumer) getNextMsg() (*jsPubMsg, uint64, error) {
 				if p, ok := o.pending[seq]; ok && p != nil {
 					delete(o.pending, seq)
 					o.updateDelivered(p.Sequence, seq, dc, p.Timestamp)
+					o.moveAckFloor(p.Sequence, seq)
 				}
 				continue
 			}

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -12832,13 +12832,15 @@ func (o *consumerFileStore) UpdateAcks(dseq, sseq uint64) error {
 		return ErrNoAckPolicy
 	}
 
+	// We do this regardless.
+	delete(o.state.Redelivered, sseq)
+
 	// On restarts the old leader may get a replay from the raft logs that are old.
 	if dseq <= o.state.AckFloor.Consumer {
 		return nil
 	}
 
 	if len(o.state.Pending) == 0 || o.state.Pending[sseq] == nil {
-		delete(o.state.Redelivered, sseq)
 		return ErrStoreMsgNotFound
 	}
 
@@ -12892,8 +12894,6 @@ func (o *consumerFileStore) UpdateAcks(dseq, sseq uint64) error {
 			}
 		}
 	}
-	// We do these regardless.
-	delete(o.state.Redelivered, sseq)
 
 	o.kickFlusher()
 	return nil

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -12899,6 +12899,24 @@ func (o *consumerFileStore) UpdateAcks(dseq, sseq uint64) error {
 	return nil
 }
 
+func (o *consumerFileStore) RemoveRedeliveredBelow(seq uint64) {
+	if seq == 0 {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	var removed bool
+	for s := range o.state.Redelivered {
+		if s < seq {
+			delete(o.state.Redelivered, s)
+			removed = true
+		}
+	}
+	if removed {
+		o.kickFlusher()
+	}
+}
+
 const seqsHdrSize = 6*binary.MaxVarintLen64 + hdrLen
 
 // Encode our consumer state, version 2.

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -12150,3 +12150,78 @@ func TestJetStreamConsumerPurgeCleanupIsReplicated(t *testing.T) {
 		return nil
 	})
 }
+
+func TestJetStreamConsumerStepDownResetsPendingAndRdc(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	for range 3 {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+
+	sub, err := js.PullSubscribe(
+		"foo",
+		"CONSUMER",
+		nats.ManualAck(),
+		nats.AckExplicit(),
+		nats.AckWait(time.Hour),
+	)
+	require_NoError(t, err)
+
+	msgs, err := sub.Fetch(3)
+	require_NoError(t, err)
+	require_Len(t, len(msgs), 3)
+
+	// NAK each message so it gets redelivered, which bumps o.rdc through the normal path.
+	for _, m := range msgs {
+		require_NoError(t, m.Nak())
+	}
+	msgs, err = sub.Fetch(3)
+	require_NoError(t, err)
+	require_Len(t, len(msgs), 3)
+
+	cl := c.consumerLeader(globalAccountName, "TEST", "CONSUMER")
+	require_NotNil(t, cl)
+	mset, err := cl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	o := mset.lookupConsumer("CONSUMER")
+	require_NotNil(t, o)
+
+	o.mu.RLock()
+	pending, rdc := len(o.pending), len(o.rdc)
+	o.mu.RUnlock()
+	require_Equal(t, pending, 3)
+	require_Equal(t, rdc, 3)
+
+	// Stepping down the consumer leader must clear both o.pending and o.rdc.
+	n := o.raftNode()
+	require_NotNil(t, n)
+	require_NoError(t, n.StepDown())
+
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		o.mu.RLock()
+		pending, rdc, isLeader := o.pending, o.rdc, o.isLeader()
+		o.mu.RUnlock()
+		if isLeader {
+			return fmt.Errorf("consumer is still leader")
+		}
+		if pending != nil {
+			return fmt.Errorf("expected o.pending to be nil, got %d entries", len(pending))
+		}
+		if rdc != nil {
+			return fmt.Errorf("expected o.rdc to be nil, got %d entries", len(rdc))
+		}
+		return nil
+	})
+}

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -11728,3 +11728,88 @@ func TestJetStreamConsumerWQMaxDeliveryAckFloorAdvancesWithPending(t *testing.T)
 	// Without the fix asflr stalls at 0 even though seqs 1-3 are dead.
 	require_Equal(t, asflr, 3)
 }
+
+func TestJetStreamConsumerWQMaxDeliveryRdcCleanedOnMaxAge(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Retention: nats.WorkQueuePolicy,
+		MaxAge:    750 * time.Millisecond,
+	})
+	require_NoError(t, err)
+
+	for range 3 {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+
+	sub, err := js.PullSubscribe(_EMPTY_, "CONSUMER",
+		nats.BindStream("TEST"),
+		nats.MaxDeliver(2),
+		nats.AckExplicit(),
+		nats.AckWait(200*time.Millisecond),
+	)
+	require_NoError(t, err)
+	defer sub.Drain()
+
+	// Burn through MaxDeliver for all 3 messages.
+	for range 2 {
+		msgs, err := sub.Fetch(3, nats.MaxWait(time.Second))
+		require_NoError(t, err)
+		require_Len(t, len(msgs), 3)
+	}
+	_, err = sub.Fetch(1, nats.MaxWait(300*time.Millisecond))
+	require_Error(t, err, nats.ErrTimeout)
+
+	mset, err := s.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	o := mset.lookupConsumer("CONSUMER")
+	require_NotNil(t, o)
+
+	// rdc preserved while the messages still exist in the stream so that
+	// needAck keeps the messages "interesting" for out-of-band inspection.
+	o.mu.RLock()
+	rdc := len(o.rdc)
+	o.mu.RUnlock()
+	require_Equal(t, rdc, 3)
+
+	// Wait for maxAge to expire all 3 messages from the store.
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		var state StreamState
+		mset.store.FastState(&state)
+		if state.Msgs != 0 {
+			return fmt.Errorf("expected stream empty, still has %d msgs", state.Msgs)
+		}
+		return nil
+	})
+
+	// rdc should now be cleaned up via decStreamPending as each message was
+	// removed from the store. Verify both the in-memory rdc and the persistent
+	// state.Redelivered are cleaned (the latter is what an R3 follower has).
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		o.mu.RLock()
+		n := len(o.rdc)
+		store := o.store
+		o.mu.RUnlock()
+		if n != 0 {
+			return fmt.Errorf("expected in-memory rdc to be empty after maxAge, got %d entries", n)
+		}
+		state, err := store.State()
+		if err != nil {
+			return err
+		}
+		if state == nil {
+			return nil
+		}
+		if nStore := len(state.Redelivered); nStore != 0 {
+			return fmt.Errorf("expected store state.Redelivered to be empty after maxAge, got %d entries", nStore)
+		}
+		return nil
+	})
+}

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -11667,3 +11667,64 @@ func TestJetStreamConsumerAckFlowControlBasics(t *testing.T) {
 		})
 	}
 }
+
+func TestJetStreamConsumerWQMaxDeliveryAckFloorAdvancesWithPending(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Retention: nats.WorkQueuePolicy,
+	})
+	require_NoError(t, err)
+
+	for range 3 {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+
+	sub, err := js.PullSubscribe(_EMPTY_, "CONSUMER",
+		nats.BindStream("TEST"),
+		nats.MaxDeliver(2),
+		nats.AckExplicit(),
+		nats.AckWait(200*time.Millisecond),
+	)
+	require_NoError(t, err)
+	defer sub.Drain()
+
+	for range 2 {
+		msgs, err := sub.Fetch(3, nats.MaxWait(time.Second))
+		require_NoError(t, err)
+		require_Len(t, len(msgs), 3)
+	}
+
+	_, err = js.Publish("foo", nil)
+	require_NoError(t, err)
+
+	// Wait for AckWait to elapse so checkPending adds 1, 2, 3 to the redeliver queue.
+	time.Sleep(300 * time.Millisecond)
+
+	// This fetch will burn 1, 2, 3 in the redelivery loop and then return msg 4
+	// from the store.
+	msgs, err := sub.Fetch(1, nats.MaxWait(time.Second))
+	require_NoError(t, err)
+	require_Len(t, len(msgs), 1)
+
+	mset, err := s.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	o := mset.lookupConsumer("CONSUMER")
+	require_NotNil(t, o)
+
+	o.mu.RLock()
+	pending, rdc, asflr := len(o.pending), len(o.rdc), o.asflr
+	o.mu.RUnlock()
+	// msg 4 still pending, rdc retained for the burned 1, 2, 3.
+	require_Equal(t, pending, 1)
+	require_Equal(t, rdc, 3)
+	// Without the fix asflr stalls at 0 even though seqs 1-3 are dead.
+	require_Equal(t, asflr, 3)
+}

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -11813,3 +11813,187 @@ func TestJetStreamConsumerWQMaxDeliveryRdcCleanedOnMaxAge(t *testing.T) {
 		return nil
 	})
 }
+
+func TestJetStreamConsumerMaxDeliveryRdcCleanedOnStreamPurge(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Replicas:  3,
+		Retention: nats.WorkQueuePolicy,
+	})
+	require_NoError(t, err)
+
+	for range 3 {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+
+	sub, err := js.PullSubscribe(_EMPTY_, "CONSUMER",
+		nats.BindStream("TEST"),
+		nats.MaxDeliver(2),
+		nats.AckExplicit(),
+		nats.AckWait(200*time.Millisecond),
+	)
+	require_NoError(t, err)
+	defer sub.Drain()
+
+	// Burn through MaxDeliver. Populates state.Redelivered on every replica
+	// via the dc>maxdc UpdateDelivered op (delete state.Pending, set state.Redelivered).
+	for range 2 {
+		msgs, err := sub.Fetch(3, nats.MaxWait(time.Second))
+		require_NoError(t, err)
+		require_Len(t, len(msgs), 3)
+	}
+	_, err = sub.Fetch(1, nats.MaxWait(500*time.Millisecond))
+	require_Error(t, err, nats.ErrTimeout)
+
+	// Confirm every replica has the 3 state.Redelivered entries, and the leader
+	// also has the 3 in-memory rdc entries populated by hasMaxDeliveries.
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		for _, s := range c.servers {
+			mset, err := s.GlobalAccount().lookupStream("TEST")
+			if err != nil {
+				return err
+			}
+			o := mset.lookupConsumer("CONSUMER")
+			if o == nil {
+				return fmt.Errorf("consumer not found on %s", s.Name())
+			}
+			state, err := o.store.State()
+			if err != nil {
+				return err
+			}
+			if state == nil || len(state.Redelivered) != 3 {
+				return fmt.Errorf("server %s has %d state.Redelivered entries (expected 3)", s.Name(), len(state.Redelivered))
+			}
+			if o.IsLeader() {
+				o.mu.RLock()
+				n := len(o.rdc)
+				o.mu.RUnlock()
+				if n != 3 {
+					return fmt.Errorf("leader %s has %d in-memory rdc entries (expected 3)", s.Name(), n)
+				}
+			}
+		}
+		return nil
+	})
+
+	// Purge the stream. Advances FirstSeq past the 3 burned sequences on
+	// every replica via the propagated streamMsgPurge op.
+	require_NoError(t, js.PurgeStream("TEST"))
+
+	// Every replica's state.Redelivered should now be empty (all entries are
+	// below the new stream FirstSeq). On every replica the in-memory rdc must
+	// also be empty: on the leader cleared via o.purge() + removeRedeliveredBelow,
+	// on followers via removeRedeliveredBelow from storeUpdates' batch path.
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		for _, s := range c.servers {
+			mset, err := s.GlobalAccount().lookupStream("TEST")
+			if err != nil {
+				return err
+			}
+			o := mset.lookupConsumer("CONSUMER")
+			if o == nil {
+				return fmt.Errorf("consumer not found on %s", s.Name())
+			}
+			state, err := o.store.State()
+			if err != nil {
+				return err
+			}
+			if n := len(state.Redelivered); n != 0 {
+				return fmt.Errorf("server %s has %d state.Redelivered entries left after purge", s.Name(), n)
+			}
+			o.mu.RLock()
+			n := len(o.rdc)
+			o.mu.RUnlock()
+			if n != 0 {
+				return fmt.Errorf("server %s has %d in-memory rdc entries left after purge", s.Name(), n)
+			}
+		}
+		return nil
+	})
+}
+
+func TestJetStreamConsumerMaxDeliveryRdcNoLeakOnBatchRemoval(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+	})
+	require_NoError(t, err)
+
+	for range 5 {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+
+	sub, err := js.PullSubscribe(_EMPTY_, "CONSUMER",
+		nats.BindStream("TEST"),
+		nats.MaxDeliver(2),
+		nats.AckExplicit(),
+		nats.AckWait(200*time.Millisecond),
+	)
+	require_NoError(t, err)
+	defer sub.Drain()
+
+	// Burn all 5 messages through MaxDeliver. After this, o.pending is empty
+	// and o.rdc has entries {1..5}. State.Redelivered also has {1..5}.
+	for range 2 {
+		msgs, err := sub.Fetch(5, nats.MaxWait(time.Second))
+		require_NoError(t, err)
+		require_Len(t, len(msgs), 5)
+	}
+	_, err = sub.Fetch(1, nats.MaxWait(500*time.Millisecond))
+	require_Error(t, err, nats.ErrTimeout)
+
+	mset, err := s.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	o := mset.lookupConsumer("CONSUMER")
+	require_NotNil(t, o)
+
+	// Sanity: rdc populated, pending empty.
+	o.mu.RLock()
+	rdc, pending := len(o.rdc), len(o.pending)
+	o.mu.RUnlock()
+	require_Equal(t, rdc, 5)
+	require_Equal(t, pending, 0)
+
+	// Compact the stream store directly. This invokes the scb with
+	// (-N, -bytes, 0, _EMPTY_), which lands in storeUpdates' md<0 batch branch
+	// — NOT the per-message decStreamPending path.
+	_, err = mset.store.Compact(6)
+	require_NoError(t, err)
+
+	// Persistent state.Redelivered is cleaned via removeRedeliveredBelow.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		state, err := o.store.State()
+		if err != nil {
+			return err
+		}
+		if state == nil {
+			return nil
+		}
+		if n := len(state.Redelivered); n != 0 {
+			return fmt.Errorf("expected state.Redelivered cleaned, got %d entries", n)
+		}
+		return nil
+	})
+
+	// But the leader's in-memory o.rdc is NOT cleaned — entries 1..5 are all
+	// below the new FirstSeq=6, yet they remain in the map.
+	o.mu.RLock()
+	rdcAfter := len(o.rdc)
+	o.mu.RUnlock()
+	require_Equal(t, rdcAfter, 0)
+}

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -11997,3 +11997,76 @@ func TestJetStreamConsumerMaxDeliveryRdcNoLeakOnBatchRemoval(t *testing.T) {
 	o.mu.RUnlock()
 	require_Equal(t, rdcAfter, 0)
 }
+
+func TestJetStreamConsumerCheckRedeliveredUpdatesRdc(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+	})
+	require_NoError(t, err)
+
+	for range 5 {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+
+	_, err = js.PullSubscribe(_EMPTY_, "CONSUMER",
+		nats.BindStream("TEST"),
+		nats.MaxDeliver(2),
+		nats.AckExplicit(),
+		nats.AckWait(time.Second),
+	)
+	require_NoError(t, err)
+
+	mset, err := s.GlobalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	o := mset.lookupConsumer("CONSUMER")
+	require_NotNil(t, o)
+
+	// Simulate the post-MaxDeliver state for seqs 1, 2, 3: rdc populated,
+	// rdq populated, ack floor advanced past them. seq 4 represents an
+	// entry above asflr that must remain untouched.
+	o.mu.Lock()
+	o.rdc = map[uint64]uint64{1: 2, 2: 2, 3: 2, 4: 1}
+	o.addToRedeliverQueue(1, 2, 3, 4)
+	o.asflr = 3
+	o.checkRedelivered()
+	rdcLen := len(o.rdc)
+	_, has1 := o.rdc[1]
+	_, has2 := o.rdc[2]
+	_, has3 := o.rdc[3]
+	_, has4 := o.rdc[4]
+	on1 := o.onRedeliverQueue(1)
+	on2 := o.onRedeliverQueue(2)
+	on3 := o.onRedeliverQueue(3)
+	on4 := o.onRedeliverQueue(4)
+	o.mu.Unlock()
+
+	// rdc entries are preserved — the messages are still in the stream.
+	require_Equal(t, rdcLen, 4)
+	require_True(t, has1)
+	require_True(t, has2)
+	require_True(t, has3)
+	require_True(t, has4)
+	// rdq is cleaned for sseqs <= asflr; the entry above asflr stays.
+	require_False(t, on1)
+	require_False(t, on2)
+	require_False(t, on3)
+	require_True(t, on4)
+
+	// Purge the stream so FirstSeq advances past 1, 2, 3 (and 4). The next
+	// checkRedelivered must drop those rdc entries.
+	require_NoError(t, js.PurgeStream("TEST"))
+
+	o.mu.Lock()
+	o.checkRedelivered()
+	rdcLen = len(o.rdc)
+	o.mu.Unlock()
+	require_Equal(t, rdcLen, 0)
+}

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -12070,3 +12070,83 @@ func TestJetStreamConsumerCheckRedeliveredUpdatesRdc(t *testing.T) {
 	o.mu.Unlock()
 	require_Equal(t, rdcLen, 0)
 }
+
+func TestJetStreamConsumerPurgeCleanupIsReplicated(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	for range 5 {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+
+	sub, err := js.PullSubscribe(_EMPTY_, "CONSUMER",
+		nats.BindStream("TEST"),
+		nats.AckExplicit(),
+		nats.AckWait(time.Hour),
+	)
+	require_NoError(t, err)
+	defer sub.Drain()
+
+	// All 5 messages delivered, none acked: state.Pending={1..5} on every replica.
+	msgs, err := sub.Fetch(5, nats.MaxWait(time.Second))
+	require_NoError(t, err)
+	require_Len(t, len(msgs), 5)
+
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		for _, s := range c.servers {
+			mset, err := s.globalAccount().lookupStream("TEST")
+			if err != nil {
+				return err
+			}
+			o := mset.lookupConsumer("CONSUMER")
+			if o == nil {
+				return fmt.Errorf("consumer not found on %s", s.Name())
+			}
+			state, err := o.store.State()
+			if err != nil {
+				return err
+			}
+			if len(state.Pending) != 5 {
+				return fmt.Errorf("server %s state.Pending=%d (want 5)", s.Name(), len(state.Pending))
+			}
+		}
+		return nil
+	})
+
+	// Purge the stream. On the leader, o.purge() clears in-memory pending+rdc
+	// and proposes ack updates so followers also clear their persistent state.Pending.
+	require_NoError(t, js.PurgeStream("TEST"))
+
+	// All replicas should have empty state.Pending, since the purge cleanup was replicated.
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		for _, s := range c.servers {
+			mset, err := s.globalAccount().lookupStream("TEST")
+			if err != nil {
+				return err
+			}
+			o := mset.lookupConsumer("CONSUMER")
+			if o == nil {
+				return fmt.Errorf("consumer not found on %s", s.Name())
+			}
+			state, err := o.store.State()
+			if err != nil {
+				return err
+			}
+			if len(state.Pending) != 0 {
+				return fmt.Errorf("server %s state.Pending=%d (want 0)", s.Name(), len(state.Pending))
+			}
+		}
+		return nil
+	})
+}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -2661,6 +2661,19 @@ func (o *consumerMemStore) UpdateAcks(dseq, sseq uint64) error {
 	return nil
 }
 
+func (o *consumerMemStore) RemoveRedeliveredBelow(seq uint64) {
+	if seq == 0 {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	for s := range o.state.Redelivered {
+		if s < seq {
+			delete(o.state.Redelivered, s)
+		}
+	}
+}
+
 func (o *consumerMemStore) UpdateConfig(cfg *ConsumerConfig) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -2595,13 +2595,15 @@ func (o *consumerMemStore) UpdateAcks(dseq, sseq uint64) error {
 		return ErrNoAckPolicy
 	}
 
+	// We do this regardless.
+	delete(o.state.Redelivered, sseq)
+
 	// On restarts the old leader may get a replay from the raft logs that are old.
 	if dseq <= o.state.AckFloor.Consumer {
 		return nil
 	}
 
 	if len(o.state.Pending) == 0 || o.state.Pending[sseq] == nil {
-		delete(o.state.Redelivered, sseq)
 		return ErrStoreMsgNotFound
 	}
 
@@ -2655,8 +2657,6 @@ func (o *consumerMemStore) UpdateAcks(dseq, sseq uint64) error {
 			}
 		}
 	}
-	// We do these regardless.
-	delete(o.state.Redelivered, sseq)
 
 	return nil
 }

--- a/server/store.go
+++ b/server/store.go
@@ -364,6 +364,7 @@ type ConsumerStore interface {
 	HasState() bool
 	UpdateDelivered(dseq, sseq, dc uint64, ts int64) error
 	UpdateAcks(dseq, sseq uint64) error
+	RemoveRedeliveredBelow(seq uint64)
 	UpdateConfig(cfg *ConsumerConfig) error
 	Update(*ConsumerState) error
 	ForceUpdate(*ConsumerState) error

--- a/server/stream.go
+++ b/server/stream.go
@@ -5180,9 +5180,12 @@ func (mset *stream) storeUpdates(md, bd int64, seq uint64, subj string) {
 		mset.clsMu.RUnlock()
 	} else if md < 0 {
 		// Batch decrements we need to force consumers to re-calculate num pending.
+		var ss StreamState
+		mset.store.FastState(&ss)
 		mset.clsMu.RLock()
 		for _, o := range mset.cList {
 			o.streamNumPendingLocked()
+			o.removeRedeliveredBelow(ss.FirstSeq)
 		}
 		mset.clsMu.RUnlock()
 	}


### PR DESCRIPTION
Several paths left consumer state (`rdc`, `state.Redelivered`, `state.Pending`, ack floor) drifting from the underlying stream: most visibly on WorkQueue/Interest with `MaxDeliver`, on single-message removal, and on purge/compact (including replicated followers).

- Move ack floor if `MaxDeliver` exceeded: without this, the ack floor stalls behind sequences that exceeded `MaxDeliver`.
- Cleanup redelivery on message delete: `rdc`-only entries (no pending) for a removed message would otherwise leak forever, and persistent state on followers would diverge from the leader.
- Cleanup redelivery on stream purge: batch removals (like purge) bypassed the per-message cleanup path, leaving orphan `rdc` / `state.Redelivered` entries on every replica.
- `checkRedelivered` only removes below stream's first seq: `rdc` must outlive `asflr` so `needAck` keeps marking messages past `MaxDeliver` until the message is removed.
- Cleanup pending on stream purge: leader-side `pending` cleanup wasn't replicated, so followers' `state.Pending` survived the purge and diverged.
- Reset `o.rdc` on leader stepdown: followers would preserve stale `o.rdc`, whereas other state was reset on `o.setLeader(false)`.