### PR TITLE
[FIXED] Header remove prefix with prefix in value

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -4540,7 +4540,8 @@ func removeHeaderIfPrefixPresent(hdr []byte, prefix string) []byte {
 		}
 		index += start
 		if index < 1 || hdr[index-1] != '\n' {
-			return hdr
+			index += len(prefix)
+			continue
 		}
 
 		end := bytes.Index(hdr[index+len(prefix):], []byte(_CRLF_))

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -3259,6 +3259,23 @@ func TestRemoveHeaderIfPrefixPresentSkipsValueMatches(t *testing.T) {
 	}
 }
 
+func TestRemoveHeaderIfPresentSkipsValueMatches(t *testing.T) {
+	hdr := []byte("NATS/1.0\r\n\r\n")
+
+	// "Nats-Msg-Id" appearing inside another header's value must not stop
+	// the scan: the real Nats-Msg-Id header below it still needs to be
+	// removed, and the header containing the substring must be left intact.
+	hdr = genHeader(hdr, "X-Note", "Nats-Msg-Id is set below")
+	hdr = genHeader(hdr, "Nats-Msg-Id", "real-id")
+	hdr = genHeader(hdr, "c", "3")
+
+	hdr = removeHeaderIfPresent(hdr, "Nats-Msg-Id")
+	expected := []byte("NATS/1.0\r\nX-Note: Nats-Msg-Id is set below\r\nc: 3\r\n\r\n")
+	if !bytes.Equal(hdr, expected) {
+		t.Fatalf("Expected %q, got %q", expected, hdr)
+	}
+}
+
 func TestRemoveHeaderIfPresentDuplicates(t *testing.T) {
 	hdr := []byte("NATS/1.0\r\n\r\n")
 

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -3241,6 +3241,24 @@ func TestRemoveHeaderIfPrefixPresent(t *testing.T) {
 	}
 }
 
+func TestRemoveHeaderIfPrefixPresentSkipsValueMatches(t *testing.T) {
+	hdr := []byte("NATS/1.0\r\n\r\n")
+
+	// "Nats-Expected-Stream" embedded in another header's value must not
+	// short-circuit the scan: the real Nats-Expected-* headers below it
+	// still need to be removed.
+	hdr = genHeader(hdr, "X-Note", "see Nats-Expected-Stream below")
+	hdr = genHeader(hdr, JSExpectedStream, "my-stream")
+	hdr = genHeader(hdr, JSExpectedLastSeq, "22")
+	hdr = genHeader(hdr, "c", "3")
+
+	hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Expected-")
+	expected := []byte("NATS/1.0\r\nX-Note: see Nats-Expected-Stream below\r\nc: 3\r\n\r\n")
+	if !bytes.Equal(hdr, expected) {
+		t.Fatalf("Expected %q, got %q", expected, hdr)
+	}
+}
+
 func TestRemoveHeaderIfPresentDuplicates(t *testing.T) {
 	hdr := []byte("NATS/1.0\r\n\r\n")
 


### PR DESCRIPTION
`removeHeaderIfPrefixPresent` would not remove later headers if the prefix was also present in an earlier header value.