### PR TITLE
MQTT: Return `errMQTTUnsupportedCharacters` for control characters on both pub and sub

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -239,7 +239,7 @@ var (
 	errMQTTEmptyUsername              = errors.New("empty user name not allowed")
 	errMQTTTopicIsEmpty               = errors.New("topic cannot be empty")
 	errMQTTPacketIdentifierIsZero     = errors.New("packet identifier cannot be 0")
-	errMQTTUnsupportedCharacters      = errors.New("character ' ' not supported for MQTT topics")
+	errMQTTUnsupportedCharacters      = errors.New("character not supported for MQTT topics")
 	errMQTTInvalidSession             = errors.New("invalid MQTT session")
 	errMQTTInvalidRetainFlags         = errors.New("invalid retained message flags")
 	errMQTTSessionCollision           = errors.New("stored session does not match client ID")
@@ -3726,7 +3726,7 @@ func (c *client) mqttParseConnect(r *mqttReader, hasMappings bool) (byte, *mqttC
 		if len(topic) == 0 {
 			return 0, nil, errMQTTEmptyWillTopic
 		}
-		if err := mqttValidatePublishTopic(topic, "Will topic"); err != nil {
+		if err := mqttValidateTopic(topic, "Will topic"); err != nil {
 			return 0, nil, err
 		}
 		// Convert MQTT topic to NATS subject
@@ -4080,7 +4080,7 @@ func (c *client) mqttParsePub(r *mqttReader, pl int, pp *mqttPublish, hasMapping
 	if len(pp.topic) == 0 {
 		return errMQTTTopicIsEmpty
 	}
-	if err := mqttValidatePublishTopic(pp.topic, "topic"); err != nil {
+	if err := mqttValidateTopic(pp.topic, "topic"); err != nil {
 		return err
 	}
 	// Convert the topic to a NATS subject. This call will also check that
@@ -4141,22 +4141,6 @@ func mqttValidateTopic(topic []byte, field string) error {
 	}
 	if bytes.IndexByte(topic, 0) >= 0 {
 		return fmt.Errorf("invalid null character in %s %q", field, topic)
-	}
-	return nil
-}
-
-// mqttValidatePublishTopic adds a publish-only rejection of characters that
-// would corrupt the NATS wire protocol when an MQTT topic is forwarded to
-// other connections (e.g. leaf nodes) as a NATS subject. Not applied to
-// SUBSCRIBE/UNSUBSCRIBE filters as those need to reach the per-filter
-// conversion failure path so the client receives a SUBACK failure for that
-// filter rather than being disconnected.
-func mqttValidatePublishTopic(topic []byte, field string) error {
-	if err := mqttValidateTopic(topic, field); err != nil {
-		return err
-	}
-	if bytes.ContainsAny(topic, "\t\n\r\f") {
-		return fmt.Errorf("invalid character in %s %q", field, topic)
 	}
 	return nil
 }
@@ -5729,8 +5713,11 @@ func mqttToNATSSubjectConversion(mt []byte, wcOk bool) ([]byte, error) {
 				}
 				res = append(res, btsep)
 			}
-		case ' ':
-			// As of now, we cannot support ' ' in the MQTT topic/filter.
+		case ' ', '\t', '\n', '\r', '\f':
+			// We cannot support whitespace in the MQTT topic/filter — these
+			// characters would also corrupt the NATS wire protocol when the
+			// subject is forwarded to other connection types (e.g. leaf
+			// nodes) where the resulting control line could be split.
 			return nil, errMQTTUnsupportedCharacters
 		case 0x7f:
 			// SubjectTree uses DEL as an internal pivot marker, so retained

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -2898,6 +2898,38 @@ func TestMQTTSubWithSpaces(t *testing.T) {
 	testMQTTSub(t, 1, mc, r, []*mqttFilter{{filter: "foo bar", qos: 0}}, []byte{mqttSubAckFailure})
 }
 
+// Filters containing characters that would corrupt the NATS wire protocol
+// (\t, \n, \r, \f) must result in a per-filter SUBACK failure, not a
+// connection drop. mqttFilterToNATSSubject rejects them; the SUBSCRIBE
+// parser logs and continues so the failure surfaces as mqttSubAckFailure.
+func TestMQTTSubWithControlChars(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	for _, test := range []struct {
+		name   string
+		filter string
+	}{
+		{"tab", "foo\tbar"},
+		{"line feed", "foo\nbar"},
+		{"carriage return", "foo\rbar"},
+		{"form feed", "foo\fbar"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mc, r := testMQTTConnect(t, &mqttConnInfo{cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+			defer mc.Close()
+			testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+
+			// Mix a bad filter with a good one to prove the good one still
+			// succeeds (the connection is not torn down by the bad filter).
+			testMQTTSub(t, 1, mc, r,
+				[]*mqttFilter{{filter: test.filter, qos: 0}, {filter: "good/topic", qos: 0}},
+				[]byte{mqttSubAckFailure, 0})
+		})
+	}
+}
+
 func TestMQTTSubCaseSensitive(t *testing.T) {
 	o := testMQTTDefaultOptions()
 	s := testMQTTRunServer(t, o)
@@ -4279,6 +4311,10 @@ func TestMQTTPublishTopicErrors(t *testing.T) {
 		{"empty", ""},
 		{"with single level wildcard", "foo/+"},
 		{"with multiple level wildcard", "foo/#"},
+		{"with tab", "foo\tbar"},
+		{"with line feed", "foo\nbar"},
+		{"with carriage return", "foo\rbar"},
+		{"with form feed", "foo\fbar"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			mc, r := testMQTTConnect(t, &mqttConnInfo{cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
@@ -9081,7 +9117,7 @@ func TestMQTTPublishSubjectLeafNodeParserFailures(t *testing.T) {
 
 	convertMQTTTopic := func(t *testing.T, topic []byte) []byte {
 		t.Helper()
-		require_NoError(t, mqttValidatePublishTopic(topic, "topic"))
+		require_NoError(t, mqttValidateTopic(topic, "topic"))
 		subject, err := mqttTopicToNATSPubSubject(topic)
 		require_NoError(t, err)
 		return subject
@@ -9185,7 +9221,7 @@ func TestMQTTPublishSubjectLeafNodeParserFailures(t *testing.T) {
 		{name: "multi level wildcard", topic: []byte("foo/#")},
 	} {
 		t.Run("rejected before leaf forwarding/"+test.name, func(t *testing.T) {
-			if err := mqttValidatePublishTopic(test.topic, "topic"); err == nil {
+			if err := mqttValidateTopic(test.topic, "topic"); err == nil {
 				_, err = mqttTopicToNATSPubSubject(test.topic)
 				require_Error(t, err)
 			}


### PR DESCRIPTION
Replaces #8104.