### PR TITLE
Allow `SecP384r1MLKEM1024` and `SecP256r1MLKEM768` when enabled in Go 1.26

### DIFF
--- a/server/ciphersuites.go
+++ b/server/ciphersuites.go
@@ -14,7 +14,6 @@
 package server
 
 import (
-	"crypto/fips140"
 	"crypto/tls"
 )
 
@@ -39,35 +38,4 @@ func defaultCipherSuites() []uint16 {
 		defaults = append(defaults, cs.ID)
 	}
 	return defaults
-}
-
-// Where we maintain available curve preferences
-var curvePreferenceMap = map[string]tls.CurveID{
-	"X25519MLKEM768": tls.X25519MLKEM768,
-	"X25519":         tls.X25519,
-	"CurveP256":      tls.CurveP256,
-	"CurveP384":      tls.CurveP384,
-	"CurveP521":      tls.CurveP521,
-}
-
-// reorder to default to the highest level of security.  See:
-// https://blog.bracebin.com/achieving-perfect-ssl-labs-score-with-go
-func defaultCurvePreferences() []tls.CurveID {
-	if fips140.Enabled() {
-		// X25519 is not FIPS-approved by itself, but it is when
-		// combined with MLKEM768.
-		return []tls.CurveID{
-			tls.X25519MLKEM768, // post-quantum
-			tls.CurveP256,
-			tls.CurveP384,
-			tls.CurveP521,
-		}
-	}
-	return []tls.CurveID{
-		tls.X25519MLKEM768, // post-quantum
-		tls.X25519,         // faster than P256, arguably more secure
-		tls.CurveP256,
-		tls.CurveP384,
-		tls.CurveP521,
-	}
 }

--- a/server/ciphersuites_go125.go
+++ b/server/ciphersuites_go125.go
@@ -1,0 +1,51 @@
+// Copyright 2016-2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !go1.26
+
+package server
+
+import (
+	"crypto/fips140"
+	"crypto/tls"
+)
+
+// Where we maintain available curve preferences
+var curvePreferenceMap = map[string]tls.CurveID{
+	"X25519MLKEM768": tls.X25519MLKEM768,
+	"X25519":         tls.X25519,
+	"CurveP256":      tls.CurveP256,
+	"CurveP384":      tls.CurveP384,
+	"CurveP521":      tls.CurveP521,
+}
+
+// reorder to default to the highest level of security.  See:
+// https://blog.bracebin.com/achieving-perfect-ssl-labs-score-with-go
+func defaultCurvePreferences() []tls.CurveID {
+	if fips140.Enabled() {
+		// X25519 is not FIPS-approved by itself, but it is when combined with MLKEM768.
+		return []tls.CurveID{
+			tls.X25519MLKEM768, // post-quantum
+			tls.CurveP256,
+			tls.CurveP384,
+			tls.CurveP521,
+		}
+	}
+	return []tls.CurveID{
+		tls.X25519MLKEM768, // post-quantum
+		tls.X25519,         // faster than P256, arguably more secure
+		tls.CurveP256,
+		tls.CurveP384,
+		tls.CurveP521,
+	}
+}

--- a/server/ciphersuites_go126.go
+++ b/server/ciphersuites_go126.go
@@ -1,0 +1,58 @@
+// Copyright 2016-2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.26
+
+package server
+
+import (
+	"crypto/fips140"
+	"crypto/tls"
+)
+
+// Where we maintain available curve preferences
+var curvePreferenceMap = map[string]tls.CurveID{
+	"SecP384r1MLKEM1024": tls.SecP384r1MLKEM1024,
+	"SecP256r1MLKEM768":  tls.SecP256r1MLKEM768,
+	"X25519MLKEM768":     tls.X25519MLKEM768,
+	"X25519":             tls.X25519,
+	"CurveP256":          tls.CurveP256,
+	"CurveP384":          tls.CurveP384,
+	"CurveP521":          tls.CurveP521,
+}
+
+// reorder to default to the highest level of security.  See:
+// https://blog.bracebin.com/achieving-perfect-ssl-labs-score-with-go
+func defaultCurvePreferences() []tls.CurveID {
+	if fips140.Enabled() {
+		// X25519 is not FIPS-approved by itself, but it is when combined with MLKEM768.
+		// SecP256r1MLKEM768 and SecP384r1MLKEM1024 are both FIPS-approved hybrids.
+		return []tls.CurveID{
+			tls.X25519MLKEM768,     // post-quantum
+			tls.SecP384r1MLKEM1024, // post-quantum
+			tls.SecP256r1MLKEM768,  // post-quantum
+			tls.CurveP256,
+			tls.CurveP384,
+			tls.CurveP521,
+		}
+	}
+	return []tls.CurveID{
+		tls.X25519MLKEM768,     // post-quantum
+		tls.SecP384r1MLKEM1024, // post-quantum
+		tls.SecP256r1MLKEM768,  // post-quantum
+		tls.X25519,             // faster than P256, arguably more secure
+		tls.CurveP256,
+		tls.CurveP384,
+		tls.CurveP521,
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -340,6 +340,112 @@ func TestTLSCipher(t *testing.T) {
 	require_Equal(t, tls.CipherSuiteName(0x9999), "0x9999")
 }
 
+func TestTLSDefaultCipherAndCurvePreferences(t *testing.T) {
+	// The module still targets Go 1.25 in go.mod, so Go 1.26 keeps the SecP ML-KEM
+	// groups disabled by default unless the test opts in explicitly.
+	t.Setenv("GODEBUG", "tlssecpmlkem=1")
+
+	runTLSServer := func(t *testing.T, cipherSuites []uint16, curvePreferences []tls.CurveID, minVersion, maxVersion uint16) *Server {
+		t.Helper()
+		tc := &TLSConfigOpts{
+			Certificates: []*TLSCertPairOpt{
+				{
+					CertFile: "../test/configs/certs/server-cert.pem",
+					KeyFile:  "../test/configs/certs/server-key.pem",
+				},
+				{
+					CertFile: "../test/configs/certs/tlsauth/certstore/ecdsa_server.pem",
+					KeyFile:  "../test/configs/certs/tlsauth/certstore/ecdsa_server.key",
+				},
+			},
+			Ciphers:          cipherSuites,
+			CurvePreferences: curvePreferences,
+			MinVersion:       minVersion,
+		}
+		config, err := GenTLSConfig(tc)
+		require_NoError(t, err)
+		config.MaxVersion = maxVersion
+
+		opts := DefaultOptions()
+		opts.TLSConfig = config
+		opts.TLSHandshakeFirst = true
+		return RunServer(opts)
+	}
+
+	dial := func(s *Server, config *tls.Config) (*tls.Conn, error) {
+		return tls.Dial("tcp", s.Addr().String(), config)
+	}
+
+	t.Run("cipher suites", func(t *testing.T) {
+		for _, id := range defaultCipherSuites() {
+			cs := cipherMapByID[id]
+			if !slices.Contains(cs.SupportedVersions, tls.VersionTLS12) {
+				continue // t.Skip("tls.Config.CipherSuites does not configure TLS 1.3 cipher suites")
+			}
+
+			t.Run(cs.Name, func(t *testing.T) {
+				tlsConfig := &tls.Config{
+					InsecureSkipVerify: true,
+					ServerName:         "localhost",
+					MinVersion:         tls.VersionTLS12,
+					MaxVersion:         tls.VersionTLS12,
+					CipherSuites:       []uint16{cs.ID},
+					CurvePreferences:   defaultCurvePreferences(),
+				}
+
+				s := runTLSServer(t, []uint16{cs.ID}, tlsConfig.CurvePreferences, tlsConfig.MinVersion, tlsConfig.MaxVersion)
+				defer s.Shutdown()
+
+				// Prove that we can connect with the right curve preference.
+				conn, err := dial(s, tlsConfig)
+				require_NoError(t, err)
+				defer conn.Close()
+				require_Equal(t, conn.ConnectionState().CipherSuite, cs.ID)
+
+				// Now configure other ciphers and check that we fail to connect.
+				tlsConfig.CipherSuites = slices.DeleteFunc(slices.Clone(defaultCipherSuites()), func(id uint16) bool {
+					return id == cs.ID || !slices.Contains(cipherMapByID[id].SupportedVersions, tls.VersionTLS12)
+				})
+				if conn, err = dial(s, tlsConfig); conn != nil {
+					defer conn.Close()
+				}
+				require_Error(t, err)
+			})
+		}
+	})
+
+	t.Run("curve preferences", func(t *testing.T) {
+		for name, curve := range curvePreferenceMap {
+			t.Run(name, func(t *testing.T) {
+				tlsConfig := &tls.Config{
+					InsecureSkipVerify: true,
+					MinVersion:         tls.VersionTLS13,
+					MaxVersion:         tls.VersionTLS13,
+					CurvePreferences:   []tls.CurveID{curve},
+				}
+
+				s := runTLSServer(t, nil, []tls.CurveID{curve}, tlsConfig.MinVersion, tlsConfig.MaxVersion)
+				defer s.Shutdown()
+
+				// Prove that we can connect with the right cipher suites.
+				conn, err := dial(s, tlsConfig)
+				require_NoError(t, err)
+				defer conn.Close()
+				require_Equal(t, conn.ConnectionState().CurveID, curve)
+
+				// Now configure other curves and check that we fail to connect.
+				tlsConfig.CurvePreferences = slices.DeleteFunc(slices.Clone(defaultCurvePreferences()), func(id tls.CurveID) bool {
+					return id == curve
+				})
+				if conn, err = dial(s, tlsConfig); conn != nil {
+					defer conn.Close()
+				}
+				require_Error(t, err)
+			})
+		}
+	})
+}
+
 func TestGetConnectURLs(t *testing.T) {
 	opts := DefaultOptions()
 	opts.Port = 4222


### PR DESCRIPTION
Right now, SecP + ML-KEM aren't enabled in Go 1.26 by default until the `go.mod` version targets a minimum of Go 1.26. However, they can also be enabled by setting `GODEBUG=tlssecpmlkem=1` and will become available by default when we move up to a minimum Go 1.26. Allow them to be configured and negotiated if available.

The added unit test verifies that all works right when configuring a server and client with the same specific algorithms.