### PR TITLE
[IMPROVED] Use negative sublist cache resutls in numInterest

### DIFF
--- a/server/sublist.go
+++ b/server/sublist.go
@@ -638,9 +638,10 @@ func (s *Sublist) hasInterest(subject string, doLock bool, np, nq *int) bool {
 	if doLock {
 		s.RLock()
 	}
-	var matched bool
+	var matched, ok bool
 	if s.cache != nil {
-		if r, ok := s.cache[subject]; ok {
+		var r *SublistResult
+		if r, ok = s.cache[subject]; ok {
 			if np != nil && nq != nil {
 				*np += len(r.psubs)
 				for _, qsub := range r.qsubs {
@@ -653,9 +654,9 @@ func (s *Sublist) hasInterest(subject string, doLock bool, np, nq *int) bool {
 	if doLock {
 		s.RUnlock()
 	}
-	if matched {
+	if ok {
 		atomic.AddUint64(&s.cacheHits, 1)
-		return true
+		return matched
 	}
 
 	tsa := [32]string{}

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -1652,8 +1652,11 @@ func TestSublistHasInterest(t *testing.T) {
 	}
 
 	// Call Match on a subject we know there is no match.
+	hits := sl.cacheHits
 	sl.Match("bar")
 	require_False(t, sl.HasInterest("bar"))
+	// The sublist caches "negative" results as well, expect a cache hit.
+	require_Equal(t, sl.cacheHits, hits+1)
 
 	// Remove fooSub and check interest again
 	sl.Remove(fooSub)
@@ -1833,8 +1836,11 @@ func TestSublistNumInterest(t *testing.T) {
 	}
 
 	// Call Match on a subject we know there is no match.
+	hits := sl.cacheHits
 	sl.Match("bar")
 	require_NumInterest(t, "bar", 0, 0)
+	// The sublist caches "negative" results as well, expect a cache hit.
+	require_Equal(t, sl.cacheHits, hits+1)
 
 	// Remove fooSub and check interest again
 	sl.Remove(fooSub)


### PR DESCRIPTION
hasInterest would ignored emptyResult from the sublist cache. If the cache contains an empty result we can avoid traversing the trie unnecessarily.