### PR TITLE
[FIXED] Clustered WorkQueue DeliverPolicy check

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1140,7 +1140,10 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 			mset.mu.Unlock()
 			return nil, NewJSConsumerWQRequiresExplicitAckError()
 		}
-
+		if config.DeliverPolicy != DeliverAll {
+			mset.mu.Unlock()
+			return nil, NewJSConsumerWQConsumerNotDeliverAllError()
+		}
 		if mset.numLimitableConsumers() > 0 {
 			subjects := gatherSubjectFilters(config.FilterSubject, config.FilterSubjects)
 			if len(subjects) == 0 {
@@ -1167,10 +1170,6 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 					return nil, NewJSConsumerWQConsumerNotUniqueError()
 				}
 			}
-		}
-		if config.DeliverPolicy != DeliverAll {
-			mset.mu.Unlock()
-			return nil, NewJSConsumerWQConsumerNotDeliverAllError()
 		}
 	}
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -9424,6 +9424,11 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 				return
 			}
+			if cfg.DeliverPolicy != DeliverAll {
+				resp.Error = NewJSConsumerWQConsumerNotDeliverAllError()
+				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+				return
+			}
 			subjects := gatherSubjectFilters(cfg.FilterSubject, cfg.FilterSubjects)
 			for oca := range js.consumerAssignmentsOrInflightSeq(acc.Name, stream) {
 				if oca.Name == oname || oca.Config.Direct || oca.Config.Sourcing {

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -8338,3 +8338,37 @@ func TestJetStreamClusterSourceStartingSeqIgnoresInflight(t *testing.T) {
 			got, stored+inflight, stored, inflight, got+1, inflight)
 	}
 }
+
+func TestJetStreamClusterWorkQueueConsumerCreateRejectionNoOrphan(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "WQ",
+		Subjects:  []string{"wq.>"},
+		Replicas:  3,
+		Retention: nats.WorkQueuePolicy,
+	})
+	require_NoError(t, err)
+
+	_, err = js.AddConsumer("WQ", &nats.ConsumerConfig{
+		Name:          "CONSUMER",
+		AckPolicy:     nats.AckExplicitPolicy,
+		DeliverPolicy: nats.DeliverByStartSequencePolicy,
+		OptStartSeq:   1,
+	})
+	require_Error(t, err, NewJSConsumerWQConsumerNotDeliverAllError())
+
+	for _, s := range c.servers {
+		sjs := s.getJetStream()
+		sjs.mu.RLock()
+		ca := sjs.consumerAssignment(globalAccountName, "WQ", "CONSUMER")
+		sjs.mu.RUnlock()
+		if ca != nil {
+			t.Fatalf("orphan assignment present on %s", s.Name())
+		}
+	}
+}


### PR DESCRIPTION
The clustered check for a consumer on a `WorkQueue` did not include a check for `DeliverPolicyAll`.

Resolves https://github.com/nats-io/nats-server/issues/8123