### PR TITLE
[FIXED] Make server shutdown idempotent

### DIFF
--- a/server/events.go
+++ b/server/events.go
@@ -1880,6 +1880,10 @@ func (s *Server) shutdownEventing() {
 	}
 
 	s.mu.Lock()
+	if s.sys == nil || s.sys.resetCh == nil {
+		s.mu.Unlock()
+		return
+	}
 	clearTimer(&s.sys.sweeper)
 	clearTimer(&s.sys.stmr)
 	rc := s.sys.resetCh

--- a/server/server.go
+++ b/server/server.go
@@ -2555,6 +2555,10 @@ func (s *Server) Shutdown() {
 	if s == nil {
 		return
 	}
+	// Prevent issues with multiple calls.
+	if !s.shutdown.CompareAndSwap(false, true) {
+		return
+	}
 	// This is for JetStream R1 Pull Consumers to allow signaling
 	// that pending pull requests are invalid.
 	s.signalPullConsumers()
@@ -2568,11 +2572,6 @@ func (s *Server) Shutdown() {
 	// eventing items associated with accounts.
 	s.shutdownEventing()
 
-	// Prevent issues with multiple calls.
-	if s.isShuttingDown() {
-		return
-	}
-
 	s.mu.Lock()
 	s.Noticef("Initiating Shutdown...")
 
@@ -2580,7 +2579,6 @@ func (s *Server) Shutdown() {
 
 	opts := s.getOpts()
 
-	s.shutdown.Store(true)
 	s.running.Store(false)
 	s.grMu.Lock()
 	s.grRunning = false

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -200,6 +200,44 @@ func TestStartupAndShutdown(t *testing.T) {
 	}
 }
 
+func TestConcurrentShutdown(t *testing.T) {
+	opts := DefaultOptions()
+	opts.DisableShortFirstPing = true
+	opts.Accounts = []*Account{NewAccount("$SYS")}
+	opts.SystemAccount = "$SYS"
+
+	s := RunServer(opts)
+	if !s.EventsEnabled() {
+		t.Fatal("Expected events to be enabled")
+	}
+
+	const callers = 32
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			s.Shutdown()
+		}()
+	}
+	close(start)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for concurrent shutdown calls")
+	}
+	s.WaitForShutdown()
+}
+
 func TestTLSVersions(t *testing.T) {
 	for _, test := range []struct {
 		name     string


### PR DESCRIPTION
Prevent concurrent `Shutdown()` calls from racing through eventing teardown and closing shared shutdown state more than once.

The shutdown flag now atomically claims ownership before teardown begins, and eventing cleanup tolerates an already-cleared reset channel.

Validation:
- `go test -v ./server -run '^TestConcurrentShutdown$' -count=1 -vet=off`\n- `git diff --check`\n\nResolves https://github.com/nats-io/nats-server/issues/6358