### PR TITLE
[ADDED] Support PROXY protocol for websocket listeners

### DIFF
--- a/server/client_proxyproto.go
+++ b/server/client_proxyproto.go
@@ -236,6 +236,12 @@ func readProxyProtoHeader(conn net.Conn) (*proxyProtoAddr, []byte, error) {
 	}
 	defer conn.SetReadDeadline(time.Time{})
 
+	return readProxyProtoHeaderNoDeadline(conn)
+}
+
+// readProxyProtoHeaderNoDeadline parses PROXY protocol without changing read deadlines.
+// The caller is responsible for setting any deadline required by its accept/read path.
+func readProxyProtoHeaderNoDeadline(conn net.Conn) (*proxyProtoAddr, []byte, error) {
 	// Detect version
 	version, firstBytes, err := detectProxyProtoVersion(conn)
 	if err != nil {

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1410,6 +1410,7 @@ type WebsocketOptsVarz struct {
 	SameOrigin        bool          `json:"same_origin,omitempty"`          // SameOrigin indicates if same origin connections are allowed
 	AllowedOrigins    []string      `json:"allowed_origins,omitempty"`      // AllowedOrigins list of configured trusted origins
 	Compression       bool          `json:"compression,omitempty"`          // Compression indicates if compression is supported
+	ProxyProtocol     bool          `json:"proxy_protocol,omitempty"`       // ProxyProtocol indicates if PROXY protocol is supported
 	TLSOCSPPeerVerify bool          `json:"tls_ocsp_peer_verify,omitempty"` // TLSOCSPPeerVerify indicates if OCSP verification will be done
 	TLSCertNotAfter   time.Time     `json:"tls_cert_not_after,omitzero"`    // TLSCertNotAfter is the expiration date of the TLS certificate
 }
@@ -1715,6 +1716,7 @@ func (s *Server) createVarz(pcpu float64, rss int64) *Varz {
 			SameOrigin:        ws.SameOrigin,
 			AllowedOrigins:    copyStrings(ws.AllowedOrigins),
 			Compression:       ws.Compression,
+			ProxyProtocol:     ws.ProxyProtocol,
 			HandshakeTimeout:  ws.HandshakeTimeout,
 			TLSOCSPPeerVerify: wsTlsOCSPPeerVerify,
 		},

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -5734,6 +5734,7 @@ func TestMonitorWebsocket(t *testing.T) {
 		SameOrigin:       true,
 		AllowedOrigins:   []string{"https://origin1", "https://origin2"},
 		Compression:      true,
+		ProxyProtocol:    true,
 		HandshakeTimeout: 4 * time.Second,
 	}
 	s := RunServer(o)
@@ -5752,6 +5753,7 @@ func TestMonitorWebsocket(t *testing.T) {
 		SameOrigin:       true,
 		AllowedOrigins:   []string{"https://origin1", "https://origin2"},
 		Compression:      true,
+		ProxyProtocol:    true,
 		HandshakeTimeout: 4 * time.Second,
 	}
 	url := fmt.Sprintf("http://127.0.0.1:%d/varz", s.MonitorAddr().Port)

--- a/server/opts.go
+++ b/server/opts.go
@@ -666,6 +666,10 @@ type WebsocketOpts struct {
 	// be negotiated between both endpoints
 	Compression bool
 
+	// If true, websocket connections can be prefixed with a PROXY protocol
+	// header to preserve the original client address.
+	ProxyProtocol bool
+
 	// Total time allowed for the server to read the client request
 	// and write the response back to the client. This include the
 	// time needed for the TLS Handshake.
@@ -5504,6 +5508,8 @@ func parseWebsocket(v any, o *Options, errors *[]error, warnings *[]error) error
 			o.Websocket.HandshakeTimeout = ht
 		case "compress", "compression":
 			o.Websocket.Compression = mv.(bool)
+		case "proxy_protocol":
+			o.Websocket.ProxyProtocol = mv.(bool)
 		case "authorization", "authentication":
 			auth := parseSimpleAuth(tk, errors)
 			o.Websocket.Username = auth.user

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1384,15 +1384,37 @@ func (l *websocketProxyProtoListener) Accept() (net.Conn, error) {
 
 type websocketProxyProtoConn struct {
 	net.Conn
-	srv      *Server
-	parsed   bool
-	parseErr error
+	srv          *Server
+	parsed       bool
+	parseErr     error
+	deadlineMu   sync.Mutex
+	readDeadline time.Time
+}
+
+func (c *websocketProxyProtoConn) SetDeadline(t time.Time) error {
+	c.deadlineMu.Lock()
+	c.readDeadline = t
+	c.deadlineMu.Unlock()
+	return c.Conn.SetDeadline(t)
+}
+
+func (c *websocketProxyProtoConn) SetReadDeadline(t time.Time) error {
+	c.deadlineMu.Lock()
+	c.readDeadline = t
+	c.deadlineMu.Unlock()
+	return c.Conn.SetReadDeadline(t)
+}
+
+func (c *websocketProxyProtoConn) currentReadDeadline() time.Time {
+	c.deadlineMu.Lock()
+	defer c.deadlineMu.Unlock()
+	return c.readDeadline
 }
 
 func (c *websocketProxyProtoConn) Read(b []byte) (int, error) {
 	if !c.parsed {
 		c.parsed = true
-		wrapped, err := readWebsocketProxyProtoHeader(c.Conn)
+		wrapped, err := readWebsocketProxyProtoHeader(c)
 		if err != nil {
 			c.parseErr = err
 			c.srv.Warnf("Error reading PROXY protocol header from %s: %v", c.Conn.RemoteAddr(), err)
@@ -1406,31 +1428,38 @@ func (c *websocketProxyProtoConn) Read(b []byte) (int, error) {
 	return c.Conn.Read(b)
 }
 
-func readWebsocketProxyProtoHeader(conn net.Conn) (net.Conn, error) {
-	pre := make([]byte, 6)
-	if err := conn.SetReadDeadline(time.Now().Add(proxyProtoReadTimeout)); err != nil {
+func readWebsocketProxyProtoHeader(conn *websocketProxyProtoConn) (net.Conn, error) {
+	baseConn := conn.Conn
+	orgReadDeadline := conn.currentReadDeadline()
+	proxyReadDeadline := time.Now().Add(proxyProtoReadTimeout)
+	if !orgReadDeadline.IsZero() && orgReadDeadline.Before(proxyReadDeadline) {
+		proxyReadDeadline = orgReadDeadline
+	}
+	if err := conn.SetReadDeadline(proxyReadDeadline); err != nil {
 		return nil, err
 	}
-	n, err := io.ReadFull(conn, pre)
-	conn.SetReadDeadline(time.Time{})
+	defer conn.SetReadDeadline(orgReadDeadline)
+
+	pre := make([]byte, 6)
+	n, err := io.ReadFull(baseConn, pre)
 	pre = pre[:n]
 	if err != nil && n < 6 {
 		return nil, fmt.Errorf("failed to read PROXY protocol header: %w", err)
 	}
 
-	pconn := &tlsMixConn{Conn: conn, pre: bytes.NewBuffer(pre)}
-	addr, proxyPre, err := readProxyProtoHeader(pconn)
+	pconn := &tlsMixConn{Conn: baseConn, pre: bytes.NewBuffer(pre)}
+	addr, proxyPre, err := readProxyProtoHeaderNoDeadline(pconn)
 	if err == errProxyProtoUnrecognized {
 		if len(pre) == 0 {
-			return conn, nil
+			return baseConn, nil
 		}
-		return &tlsMixConn{Conn: conn, pre: bytes.NewBuffer(pre)}, nil
+		return &tlsMixConn{Conn: baseConn, pre: bytes.NewBuffer(pre)}, nil
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	var wrapped net.Conn = conn
+	var wrapped net.Conn = baseConn
 	if addr != nil {
 		wrapped = &proxyConn{Conn: wrapped, remoteAddr: addr}
 	}

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1291,6 +1291,9 @@ func (s *Server) startWebsocketServer() {
 		s.Fatalf("Unable to listen for websocket connections: %v", err)
 		return
 	}
+	if o.ProxyProtocol {
+		hl = &websocketProxyProtoListener{Listener: hl, srv: s}
+	}
 	if config != nil {
 		hl = tls.NewListener(hl, config)
 	}
@@ -1364,6 +1367,60 @@ func (s *Server) startWebsocketServer() {
 		s.done <- true
 	}()
 	s.mu.Unlock()
+}
+
+type websocketProxyProtoListener struct {
+	net.Listener
+	srv *Server
+}
+
+func (l *websocketProxyProtoListener) Accept() (net.Conn, error) {
+	for {
+		conn, err := l.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		wrapped, err := readWebsocketProxyProtoHeader(conn)
+		if err == nil {
+			return wrapped, nil
+		}
+		l.srv.Warnf("Error reading PROXY protocol header from %s: %v", conn.RemoteAddr(), err)
+		conn.Close()
+	}
+}
+
+func readWebsocketProxyProtoHeader(conn net.Conn) (net.Conn, error) {
+	pre := make([]byte, 6)
+	if err := conn.SetReadDeadline(time.Now().Add(proxyProtoReadTimeout)); err != nil {
+		return nil, err
+	}
+	n, err := io.ReadFull(conn, pre)
+	conn.SetReadDeadline(time.Time{})
+	pre = pre[:n]
+	if err != nil && n < 6 {
+		return nil, fmt.Errorf("failed to read PROXY protocol header: %w", err)
+	}
+
+	pconn := &tlsMixConn{Conn: conn, pre: bytes.NewBuffer(pre)}
+	addr, proxyPre, err := readProxyProtoHeader(pconn)
+	if err == errProxyProtoUnrecognized {
+		if len(pre) == 0 {
+			return conn, nil
+		}
+		return &tlsMixConn{Conn: conn, pre: bytes.NewBuffer(pre)}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var wrapped net.Conn = conn
+	if addr != nil {
+		wrapped = &proxyConn{Conn: wrapped, remoteAddr: addr}
+	}
+	if len(proxyPre) > 0 {
+		wrapped = &tlsMixConn{Conn: wrapped, pre: bytes.NewBuffer(proxyPre)}
+	}
+	return wrapped, nil
 }
 
 // The TLS configuration is passed to the listener when the websocket

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1375,18 +1375,35 @@ type websocketProxyProtoListener struct {
 }
 
 func (l *websocketProxyProtoListener) Accept() (net.Conn, error) {
-	for {
-		conn, err := l.Listener.Accept()
-		if err != nil {
-			return nil, err
-		}
-		wrapped, err := readWebsocketProxyProtoHeader(conn)
-		if err == nil {
-			return wrapped, nil
-		}
-		l.srv.Warnf("Error reading PROXY protocol header from %s: %v", conn.RemoteAddr(), err)
-		conn.Close()
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
 	}
+	return &websocketProxyProtoConn{Conn: conn, srv: l.srv}, nil
+}
+
+type websocketProxyProtoConn struct {
+	net.Conn
+	srv      *Server
+	parsed   bool
+	parseErr error
+}
+
+func (c *websocketProxyProtoConn) Read(b []byte) (int, error) {
+	if !c.parsed {
+		c.parsed = true
+		wrapped, err := readWebsocketProxyProtoHeader(c.Conn)
+		if err != nil {
+			c.parseErr = err
+			c.srv.Warnf("Error reading PROXY protocol header from %s: %v", c.Conn.RemoteAddr(), err)
+		} else {
+			c.Conn = wrapped
+		}
+	}
+	if c.parseErr != nil {
+		return 0, c.parseErr
+	}
+	return c.Conn.Read(b)
 }
 
 func readWebsocketProxyProtoHeader(conn net.Conn) (net.Conn, error) {

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -2271,6 +2271,34 @@ func TestWSProxyProtocolNonProxiedConnection(t *testing.T) {
 	wsc.Close()
 }
 
+func TestWSProxyProtocolPreservesHandshakeTimeout(t *testing.T) {
+	o := testWSOptions()
+	o.Websocket.ProxyProtocol = true
+	o.Websocket.HandshakeTimeout = 10 * time.Millisecond
+	s := RunServer(o)
+	defer s.Shutdown()
+
+	addr := net.JoinHostPort(o.Websocket.Host, fmt.Sprintf("%d", o.Websocket.Port))
+	raw, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Error creating ws connection: %v", err)
+	}
+	defer raw.Close()
+
+	preTLS := buildProxyV2Header(t, "203.0.113.60", "127.0.0.1", 43210, uint16(o.Websocket.Port), proxyProtoFamilyInet)
+	if _, err := raw.Write(preTLS); err != nil {
+		t.Fatalf("Error writing PROXY protocol header: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	tlsConn := tls.Client(raw, &tls.Config{InsecureSkipVerify: true})
+	tlsConn.SetDeadline(time.Now().Add(time.Second))
+	if err := tlsConn.Handshake(); err == nil {
+		t.Fatal("Expected TLS handshake to fail after websocket handshake timeout")
+	}
+}
+
 func testWSReadFrame(t testing.TB, br *bufio.Reader) []byte {
 	t.Helper()
 	fh := [2]byte{}

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -1585,6 +1585,7 @@ func TestWSParseOptions(t *testing.T) {
 		{"bad advertise type", `websocket: { advertise: 123 }`, nil, "not string"},
 		{"bad tls", `websocket: { tls: 123 }`, nil, "not map[string]interface {}"},
 		{"bad same origin", `websocket: { same_origin: "abc" }`, nil, "not bool"},
+		{"bad proxy protocol", `websocket: { proxy_protocol: "abc" }`, nil, "not bool"},
 		{"bad allowed origins type", `websocket: { allowed_origins: {} }`, nil, "unsupported type"},
 		{"bad allowed origins values", `websocket: { allowed_origins: [ {} ] }`, nil, "unsupported type in array"},
 		{"bad handshake timeout type", `websocket: { handshake_timeout: [] }`, nil, "unsupported type"},
@@ -1686,6 +1687,17 @@ func TestWSParseOptions(t *testing.T) {
 			`, func(wo *WebsocketOpts) error {
 				if !wo.Compression {
 					return fmt.Errorf("Compression should have been set")
+				}
+				return nil
+			}, ""},
+		{"proxy protocol",
+			`
+			websocket {
+				proxy_protocol: true
+			}
+			`, func(wo *WebsocketOpts) error {
+				if !wo.ProxyProtocol {
+					return fmt.Errorf("ProxyProtocol should have been set")
 				}
 				return nil
 			}, ""},
@@ -2003,6 +2015,7 @@ type testWSClientOptions struct {
 	host                 string
 	port                 int
 	extraHeaders         map[string][]string
+	preTLS               []byte
 	noTLS                bool
 	path                 string
 	extraResponseHeaders map[string]string
@@ -2022,6 +2035,12 @@ func testNewWSClientWithError(t testing.TB, o testWSClientOptions) (net.Conn, *b
 	wsc, err := net.Dial("tcp", addr)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("Error creating ws connection: %v", err)
+	}
+	if len(o.preTLS) > 0 {
+		if _, err := wsc.Write(o.preTLS); err != nil {
+			wsc.Close()
+			return nil, nil, nil, fmt.Errorf("Error writing ws connection prefix: %v", err)
+		}
 	}
 	if !o.noTLS {
 		wsc = tls.Client(wsc, &tls.Config{InsecureSkipVerify: true})
@@ -2197,6 +2216,59 @@ func testWSCreateClient(t testing.TB, compress, web bool, host string, port int)
 		t.Fatalf("Expected PONG, got %s", msg)
 	}
 	return wsc, br
+}
+
+func TestWSProxyProtocol(t *testing.T) {
+	o := testWSOptions()
+	o.Websocket.ProxyProtocol = true
+	s := RunServer(o)
+	defer s.Shutdown()
+
+	clientIP := "203.0.113.60"
+	clientPort := uint16(43210)
+	preTLS := buildProxyV2Header(t, clientIP, "127.0.0.1", clientPort, uint16(o.Websocket.Port), proxyProtoFamilyInet)
+	wsc, br, _ := testNewWSClient(t, testWSClientOptions{
+		host:   o.Websocket.Host,
+		port:   o.Websocket.Port,
+		preTLS: preTLS,
+	})
+	defer wsc.Close()
+
+	wsmsg := testWSCreateClientMsg(wsBinaryMessage, 1, true, false, []byte("CONNECT {\"verbose\":false,\"protocol\":1}\r\nPING\r\n"))
+	if _, err := wsc.Write(wsmsg); err != nil {
+		t.Fatalf("Error sending message: %v", err)
+	}
+	if msg := testWSReadFrame(t, br); !bytes.HasPrefix(msg, []byte("PONG\r\n")) {
+		t.Fatalf("Expected PONG, got %s", msg)
+	}
+
+	checkFor(t, time.Second, 15*time.Millisecond, func() error {
+		s.mu.Lock()
+		clients := make([]*client, 0, len(s.clients))
+		for _, c := range s.clients {
+			clients = append(clients, c)
+		}
+		s.mu.Unlock()
+		for _, c := range clients {
+			c.mu.Lock()
+			host, port := c.host, c.port
+			c.mu.Unlock()
+			if host == clientIP && port == clientPort {
+				return nil
+			}
+		}
+		return fmt.Errorf("did not find websocket client with proxied address %s:%d", clientIP, clientPort)
+	})
+}
+
+func TestWSProxyProtocolNonProxiedConnection(t *testing.T) {
+	o := testWSOptions()
+	o.Websocket.ProxyProtocol = true
+	s := RunServer(o)
+	defer s.Shutdown()
+
+	wsc, _ := testWSCreateClient(t, false, false, o.Websocket.Host, o.Websocket.Port)
+	wsc.Close()
 }
 
 func testWSReadFrame(t testing.TB, br *bufio.Reader) []byte {


### PR DESCRIPTION
Add websocket `proxy_protocol` support by parsing optional PROXY headers on the raw listener before TLS and HTTP upgrade processing. Non-proxied websocket clients continue to work because pre-read bytes are replayed into the next protocol layer, and the setting is exposed in `/varz`.

Validation:
- `go test -v ./server -run '^(TestWSParseOptions|TestWSProxyProtocol|TestWSProxyProtocolNonProxiedConnection|TestMonitorWebsocket)$' -count=1 -vet=off`\n- `git diff --check`\n\nResolves https://github.com/nats-io/nats-server/issues/7924