### PR TITLE
Reduce lock contention on leafnode client 

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1096,7 +1096,7 @@ func (c *client) setPermissions(perms *Permissions) {
 	if perms.Subscribe != nil {
 		var err error
 		if len(perms.Subscribe.Allow) > 0 {
-			c.perms.sub.allow = NewSublist(slcache)
+			c.perms.sub.allow = NewSublistNoCache()
 		}
 		for _, subSubject := range perms.Subscribe.Allow {
 			sub := &subscription{}
@@ -1108,7 +1108,7 @@ func (c *client) setPermissions(perms *Permissions) {
 			c.perms.sub.allow.Insert(sub)
 		}
 		if len(perms.Subscribe.Deny) > 0 {
-			c.perms.sub.deny = NewSublist(slcache)
+			c.perms.sub.deny = NewSublistNoCache()
 			// Also hold onto this array for later.
 			c.darray = perms.Subscribe.Deny
 		}
@@ -1205,38 +1205,40 @@ func (c *client) mergeDenyPermissions(what denyType, denyPubs []string) {
 	if c.perms == nil {
 		c.perms = &permissions{}
 	}
-	slcache := c.srv != nil && !c.srv.getOpts().NoSublistCache
-	var perms []*perm
-	switch what {
-	case pub:
-		perms = []*perm{&c.perms.pub}
-	case sub:
-		perms = []*perm{&c.perms.sub}
-	case both:
-		perms = []*perm{&c.perms.pub, &c.perms.sub}
-	}
-	for _, p := range perms {
-		if p.deny == nil {
-			p.deny = NewSublist(slcache)
+	if what == pub || what == both {
+		if c.perms.pub.deny == nil {
+			c.perms.pub.deny = NewSublistForServer(c.srv)
 		}
-	FOR_DENY:
-		for _, subj := range denyPubs {
-			r := p.deny.Match(subj)
-			for _, v := range r.qsubs {
-				for _, s := range v {
-					if string(s.subject) == subj {
-						continue FOR_DENY
-					}
-				}
-			}
-			for _, s := range r.psubs {
+		mergeDenyPerm(&c.perms.pub, denyPubs)
+	}
+	if what == sub || what == both {
+		if c.perms.sub.deny == nil {
+			// Avoid sublist cache contention in canSubscribe.
+			c.perms.sub.deny = NewSublistNoCache()
+		}
+		mergeDenyPerm(&c.perms.sub, denyPubs)
+	}
+}
+
+// mergeDenyPerm inserts new deny permissions, skipping subjects that already exist.
+func mergeDenyPerm(p *perm, denyPubs []string) {
+FOR_DENY:
+	for _, subj := range denyPubs {
+		r := p.deny.Match(subj)
+		for _, v := range r.qsubs {
+			for _, s := range v {
 				if string(s.subject) == subj {
 					continue FOR_DENY
 				}
 			}
-			sub := &subscription{subject: []byte(subj)}
-			p.deny.Insert(sub)
 		}
+		for _, s := range r.psubs {
+			if string(s.subject) == subj {
+				continue FOR_DENY
+			}
+		}
+		sub := &subscription{subject: []byte(subj)}
+		p.deny.Insert(sub)
 	}
 }
 

--- a/server/client.go
+++ b/server/client.go
@@ -270,7 +270,7 @@ type client struct {
 	mpay       int32
 	msubs      int32
 	mcl        int32
-	mu         sync.Mutex
+	mu         sync.RWMutex
 	cid        uint64
 	start      time.Time
 	nonce      []byte
@@ -998,6 +998,7 @@ func (c *client) RegisterUser(user *User) {
 		// Reset perms to nil in case client previously had them.
 		c.perms = nil
 		c.mperms = nil
+		c.darray = nil
 	} else {
 		c.setPermissions(user.Permissions)
 	}
@@ -1035,6 +1036,7 @@ func (c *client) RegisterNkeyUser(user *NkeyUser) error {
 		// Reset perms to nil in case client previously had them.
 		c.perms = nil
 		c.mperms = nil
+		c.darray = nil
 	} else {
 		c.setPermissions(user.Permissions)
 	}
@@ -1061,6 +1063,8 @@ func (c *client) setPermissions(perms *Permissions) {
 		return
 	}
 	c.perms = &permissions{}
+	c.mperms = nil
+	c.darray = nil
 	slcache := c.srv != nil && !c.srv.getOpts().NoSublistCache
 
 	// Loop over publish permissions
@@ -3240,9 +3244,9 @@ func (c *client) addShadowSub(sub *subscription, ime *ime) (*subscription, error
 	return &nsub, nil
 }
 
-// canSubscribe determines if the client is authorized to subscribe to the
-// given subject. Assumes caller is holding lock.
-func (c *client) canSubscribe(subject string, optQueue ...string) bool {
+// canSubscribeInternal determines if the client is authorized to subscribe to
+// the given subject. Assumes caller is holding at least a read lock.
+func (c *client) canSubscribeInternal(subject string, optQueue ...string) bool {
 	if c.perms == nil {
 		return true
 	}
@@ -3287,23 +3291,32 @@ func (c *client) canSubscribe(subject string, optQueue ...string) bool {
 			// If the queue appears in the deny list, then DO NOT allow.
 			allowed = !queueMatches(queue, r.qsubs)
 		}
+	}
+	return allowed
+}
 
-		// We use the actual subscription to signal us to spin up the deny mperms
-		// and cache. We check if the subject is a wildcard that intersects any of
-		// the deny clauses.
-		// FIXME(dlc) - We could be smarter and track when these go away and remove.
-		if allowed && c.mperms == nil && subjectHasWildcard(subject) {
-			// Whip through the deny array and check if this wildcard subject can
-			// overlap with any denied deliveries.
-			for _, sub := range c.darray {
-				if SubjectsCollide(sub, subject) {
-					c.loadMsgDenyFilter()
-					break
-				}
+// canSubscribe determines if the client is authorized to subscribe to the
+// given subject and initializes the delivery-time deny filter when needed.
+// Assumes caller is holding the write lock.
+func (c *client) canSubscribe(subject string, optQueue ...string) bool {
+	if !c.canSubscribeInternal(subject, optQueue...) {
+		return false
+	}
+	// We use the actual subscription to signal us to spin up the deny mperms
+	// and cache. We check if the subject is a wildcard that intersects any of
+	// the deny clauses.
+	// FIXME(dlc) - We could be smarter and track when these go away and remove.
+	if c.mperms == nil && subjectHasWildcard(subject) {
+		// Whip through the deny array and check if this wildcard subject can
+		// overlap with any denied deliveries.
+		for _, sub := range c.darray {
+			if SubjectsCollide(sub, subject) {
+				c.loadMsgDenyFilter()
+				break
 			}
 		}
 	}
-	return allowed
+	return true
 }
 
 func queueMatches(queue string, qsubs [][]*subscription) bool {

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -1106,6 +1106,23 @@ func TestClientSubscribeDenyWildcardOverlapBlocksDelivery(t *testing.T) {
 	}
 }
 
+func TestClientSetPermissionsClearsStaleMsgDenyState(t *testing.T) {
+	c := &client{}
+	c.setPermissions(&Permissions{
+		Subscribe: &SubjectPermission{Deny: []string{"foo.secret"}},
+	})
+	require_True(t, c.canSubscribe("foo.*"))
+	require_True(t, c.mperms != nil)
+	require_Len(t, len(c.darray), 1)
+
+	c.setPermissions(&Permissions{})
+	require_True(t, c.mperms == nil)
+	require_Len(t, len(c.darray), 0)
+
+	require_True(t, c.canSubscribe("foo.*"))
+	require_True(t, c.mperms == nil)
+}
+
 func TestClientPubWithQueueSubNoEcho(t *testing.T) {
 	opts := DefaultOptions()
 	s := RunServer(opts)

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2598,26 +2598,36 @@ func (acc *Account) updateLeafNodesEx(sub *subscription, delta int32, hubOnly bo
 		if ln == sub.client {
 			continue
 		}
-		ln.mu.Lock()
+		ln.mu.RLock()
 		// Don't advertise interest from leafnodes to other isolated leafnodes.
 		if sub.client.kind == LEAF && ln.isIsolatedLeafNode() {
-			ln.mu.Unlock()
+			ln.mu.RUnlock()
 			continue
 		}
 		// If `hubOnly` is true, it means that we want to update only leafnodes
 		// that connect to this server (so isHubLeafNode() would return `true`).
 		if hubOnly && !ln.isHubLeafNode() {
-			ln.mu.Unlock()
+			ln.mu.RUnlock()
 			continue
 		}
 		// Check to make sure this sub does not have an origin cluster that matches the leafnode.
 		// If skipped, make sure that we still let go the "$LDS." subscription that allows
 		// the detection of loops as long as different cluster.
 		clusterDifferent := cluster != ln.remoteCluster()
-		if (isLDS && clusterDifferent) || ((cluster == _EMPTY_ || clusterDifferent) && (delta <= 0 || ln.canSubscribe(subject))) {
-			ln.updateSmap(sub, delta, isLDS)
+		update := (isLDS && clusterDifferent) ||
+			((cluster == _EMPTY_ || clusterDifferent) && (delta <= 0 || ln.canSubscribeInternal(subject)))
+		ln.mu.RUnlock()
+		if update {
+			ln.mu.Lock()
+			// The leaf role, isolation mode, and remote cluster are stable
+			// for the connection. Recheck canSubscribe here since permissions
+			// can change, and to initializes mperms for wildcard subscriptions
+			// that collide with deny rules.
+			if isLDS || delta <= 0 || ln.canSubscribe(subject) {
+				ln.updateSmap(sub, delta, isLDS)
+			}
+			ln.mu.Unlock()
 		}
-		ln.mu.Unlock()
 	}
 }
 
@@ -3306,35 +3316,39 @@ func (c *client) leafMsgAllowed() bool {
 		return true
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
+	c.mu.RLock()
 	if c.isSpokeLeafNode() {
 		// Gateway routed replies are forwarded without
 		// permission checks.
 		if isGW || c.leafReceiveAllowed(subjectToCheck) {
+			c.mu.RUnlock()
 			return true
 		}
 	} else if c.leafSendAllowed(subjectToCheck) {
+		c.mu.RUnlock()
 		return true
 	}
+	c.mu.RUnlock()
+
 	// Check tracked reply permissions (allow_responses).
 	// Use the pre-strip subject since deliverMsg tracks
 	// replies under the original form, which includes
 	// the GW routing prefix for routed requests.
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.responseAllowed(bytesToString(wireSubject))
 }
 
 // Returns true if the leaf side ACLs allow importing this subject,
 // based on the permissions received over INFO and any local deny_imports.
-// Lock must be held.
+// At least a read lock must be held.
 func (c *client) leafReceiveAllowed(subject []byte) bool {
-	return c.canSubscribe(bytesToString(subject))
+	return c.canSubscribeInternal(bytesToString(subject))
 }
 
 // Returns true if the hub side ACLs allow the remote leaf to send
 // this subject.
-// Lock must be held.
+// At least a read lock must be held.
 func (c *client) leafSendAllowed(bsubject []byte) bool {
 	// Use the original export ACL captured for this accepted leaf.
 	// The live perms also contain additional JetStream denies used by

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2586,8 +2586,15 @@ func (acc *Account) updateLeafNodesEx(sub *subscription, delta int32, hubOnly bo
 	// Do this once.
 	subject := string(sub.subject)
 
-	// Walk the connected leafnodes.
-	for _, ln := range acc.lleafs {
+	// Walk the connected leafnodes from a random starting point to avoid
+	// concurrent callers all contending over leafs in the same order.
+	nleafs := len(acc.lleafs)
+	start := 0
+	if nleafs > 1 {
+		start = rand.Intn(nleafs)
+	}
+	for i := 0; i < nleafs; i++ {
+		ln := acc.lleafs[(start+i)%nleafs]
 		if ln == sub.client {
 			continue
 		}


### PR DESCRIPTION
This series reduces lock contention on hub-side leaf connections:

- Start leafnode update traversal at a random offset to reduce lock convoys.
- Use a client read lock for read only leaf permission checks, and move deny filter setup to the delivery path so canSubscribe stays read-only.
- Disable subscribe permission sublist caches, since those caches can still add lock contention even when callers only need a client read lock.