### PR TITLE
Allow WebSockets on FIPS-enforced builds when built with Go 1.26 or later

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -304,6 +304,13 @@ func validateLeafNode(o *Options) error {
 				return fmt.Errorf("remote leaf node configuration cannot have a mix of websocket and non-websocket urls: %q", redactURLList(rcfg.URLs))
 			}
 		}
+		if !wsAllowedFIPS() {
+			for _, u := range rcfg.URLs {
+				if isWSURL(u) {
+					return fmt.Errorf("remote leaf node URL %q cannot be used in FIPS-140 mode when built with this Go version, use Go 1.26 or later", redactURLString(u.String()))
+				}
+			}
+		}
 		// Validate compression settings
 		if rcfg.Compression.Mode != _EMPTY_ {
 			if err := validateAndNormalizeCompressionOption(&rcfg.Compression, CompressionS2Auto); err != nil {

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -2878,6 +2878,52 @@ func TestLeafNodeWSMixURLs(t *testing.T) {
 	}
 }
 
+func TestLeafNodeWSFIPSValidation(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		url  string
+	}{
+		{
+			name: "no credentials",
+			url:  "wss://127.0.0.1:1234",
+		},
+		{
+			name: "redacted credentials",
+			url:  "wss://user:pass@example:7422",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			u, err := url.Parse(test.url)
+			if err != nil {
+				t.Fatalf("Error parsing url: %v", err)
+			}
+
+			o := DefaultOptions()
+			o.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{u}}}
+
+			err = validateLeafNode(o)
+			if wsAllowedFIPS() {
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("Expected FIPS validation error, got none")
+			}
+			if strings.Contains(err.Error(), "user:pass") {
+				t.Fatalf("Password was not redacted: %v", err)
+			}
+			if strings.Contains(err.Error(), "user:pass@") {
+				t.Fatalf("Credentials were not redacted: %v", err)
+			}
+			if !strings.Contains(err.Error(), "FIPS-140 mode") {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 type testConnTrackSize struct {
 	sync.Mutex
 	net.Conn

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2025 The NATS Authors
+// Copyright 2020-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,7 +16,6 @@ package server
 import (
 	"bytes"
 	crand "crypto/rand"
-	"crypto/sha1"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/binary"
@@ -1107,15 +1106,6 @@ func wsGetHostAndPort(tls bool, hostport string) (string, string, error) {
 	return strings.ToLower(host), port, err
 }
 
-// Concatenate the key sent by the client with the GUID, then computes the SHA1 hash
-// and returns it as a based64 encoded string.
-func wsAcceptKey(key string) string {
-	h := sha1.New()
-	h.Write([]byte(key))
-	h.Write(wsGUID)
-	return base64.StdEncoding.EncodeToString(h.Sum(nil))
-}
-
 func wsMakeChallengeKey() (string, error) {
 	p := make([]byte, 16)
 	if _, err := io.ReadFull(crand.Reader, p); err != nil {
@@ -1130,6 +1120,9 @@ func validateWebsocketOptions(o *Options) error {
 	// If no port is defined, we don't care about other options
 	if wo.Port == 0 {
 		return nil
+	}
+	if !wsAllowedFIPS() {
+		return fmt.Errorf("websocket: cannot be used in FIPS-140 mode when built with this Go version, use Go 1.26 or later")
 	}
 	// Enforce TLS... unless NoTLS is set to true.
 	if wo.TLSConfig == nil && !wo.NoTLS {

--- a/server/websocket_go125.go
+++ b/server/websocket_go125.go
@@ -1,0 +1,38 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !go1.26
+
+package server
+
+import (
+	"crypto/fips140"
+	"crypto/sha1"
+	"encoding/base64"
+)
+
+func wsAllowedFIPS() bool {
+	// SHA-1 is not permitted on Go 1.25 FIPS builds because we cannot avoid its
+	// enforcement for Sec-WebSocket-Key and Sec-WebSocket-Accept, it will result
+	// in a panic.
+	return !fips140.Enabled()
+}
+
+// Concatenate the key sent by the client with the GUID, then computes the SHA1 hash
+// and returns it as a based64 encoded string.
+func wsAcceptKey(key string) string {
+	h := sha1.New()
+	h.Write([]byte(key))
+	h.Write(wsGUID)
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}

--- a/server/websocket_go126.go
+++ b/server/websocket_go126.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.26
+
+package server
+
+import (
+	"crypto/fips140"
+	"crypto/sha1"
+	"encoding/base64"
+)
+
+func wsAllowedFIPS() bool {
+	// As SHA-1 is only used for Sec-WebSocket-Key and Sec-WebSocket-Accept, we
+	// can continue to allow it in FIPS builds as long as they are built with
+	// Go 1.26 or later only.
+	return true
+}
+
+// Concatenate the key sent by the client with the GUID, then computes the SHA1 hash
+// and returns it as a based64 encoded string.
+func wsAcceptKey(key string) string {
+	var r []byte
+	fips140.WithoutEnforcement(func() {
+		h := sha1.New()
+		h.Write([]byte(key))
+		h.Write(wsGUID)
+		r = h.Sum(nil)
+	})
+	return base64.StdEncoding.EncodeToString(r)
+}

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -1855,9 +1855,22 @@ func TestWSValidateOptions(t *testing.T) {
 			o.Websocket.Headers = map[string]string{"Nats-No-Masking": "false"}
 			return o
 		}, `websocket: invalid header "Nats-No-Masking" not allowed`},
+		{"disabled websocket listener", func() *Options {
+			o := wso.Clone()
+			o.Websocket.Port = 0
+			return o
+		}, ""},
+		{"fips websocket listener", func() *Options {
+			return wso.Clone()
+		}, func() string {
+			if wsAllowedFIPS() {
+				return ""
+			}
+			return "websocket: cannot be used in FIPS-140 mode when built with this Go version, use Go 1.26 or later"
+		}()},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			err := validateWebsocketOptions(test.getOpts())
+			err := validateOptions(test.getOpts())
 			if test.err == "" && err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			} else if test.err != "" && (err == nil || !strings.Contains(err.Error(), test.err)) {


### PR DESCRIPTION
On Go 1.25 we have no way to avoid the panic-on-SHA1 enforcement since `fips140.WithoutEnforcement()` didn't exist yet, but we can do this on Go 1.26 or later. WebSockets only use SHA-1 for determining if they're handshaking with something that understands WebSockets (via `Sec-WebSocket-Key` and `Sec-WebSocket-Accept` headers), it's not used for any cryptographic property, so allowing its use should be fine.