### PR TITLE
[FIXED] Reset leaf meta state when SYS extends parent domain

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2034,12 +2034,14 @@ func (s *Server) addLeafNodeConnection(c *client, srvName, clusterName string, c
 		// In an extension use case, pin leadership to server remotes connect to.
 		// Therefore, server with a remote that are not already in observer mode, need to be put into it.
 		if solicited && meta != nil && !meta.IsObserver() {
-			meta.setObserver(true, extExtended)
 			c.Debugf("Turning JetStream metadata controller Observer Mode on - System Account Connected")
-			// Take note that the domain was not extended to avoid this state next startup.
-			writePeerState(js.config.StoreDir, meta.currentPeerState())
-			// If this server is the leader already, step down so a new leader can be elected (that is not an observer)
-			meta.StepDown()
+			// Discard any local metagroup state accumulated before the SYS-account
+			// leaf came up (e.g. the wrong-hint case where this server bootstrapped
+			// its own metagroup). The parent's view is now authoritative; without
+			// this reset the two raft logs stay forked because the standalone log's
+			// commit prefix short-circuits the follower's AE handling.
+			meta.setObserver(true, extExtended)
+			meta.Reset()
 		}
 	} else {
 		// This deny is needed in all cases (system account shared or not)

--- a/server/raft.go
+++ b/server/raft.go
@@ -86,6 +86,7 @@ type RaftNode interface {
 	WaitForStop()
 	Delete()
 	IsDeleted() bool
+	Reset()
 	RecreateInternalSubs() error
 	IsSystemAccount() bool
 	GetTrafficAccountName() string
@@ -2230,6 +2231,61 @@ func (n *raft) shutdown() {
 		n.leaderSince.Store(nil)
 		close(n.quit)
 	}
+}
+
+// Reset discards this node's local raft state (log, snapshots, peer set,
+// term/vote) so it can be caught up cleanly by another group with the same
+// name. The caller is responsible for parking the node first (typically via
+// SetObserver) if it should not compete for leadership immediately after;
+// Reset itself steps the node down but does not flip observer mode.
+func (n *raft) Reset() {
+	n.Lock()
+	defer n.Unlock()
+
+	n.debug("Resetting Raft state")
+
+	n.stepdownLocked(_EMPTY_)
+
+	// Cancel any in-flight catchup so it does not race the reset.
+	n.cancelCatchup()
+
+	// Drop proposals and inbound entries; they are no longer meaningful
+	// against whatever log this node ends up following.
+	n.prop.drain()
+	n.entry.drain()
+	n.resp.drain()
+	n.apply.drain()
+	n.reqs.drain()
+	n.votes.drain()
+
+	// Remove every snapshot under our snapshots dir, not just the one referenced
+	// by n.snapfile. Orphans (e.g. from a crash between install and the previous
+	// file's removal) would otherwise be picked up by setupLastSnapshot on the
+	// next restart and reseed the state we are discarding here.
+	snapDir := filepath.Join(n.sd, snapshotsDir)
+	if err := os.RemoveAll(snapDir); err != nil {
+		n.warn("Error removing snapshots directory during reset: %v", err)
+	}
+	if err := os.MkdirAll(snapDir, defaultDirPerms); err != nil {
+		n.warn("Error recreating snapshots directory during reset: %v", err)
+	}
+	n.snapfile = _EMPTY_
+
+	// Reset the WAL, but reset these first to not trip the assertion.
+	n.commit, n.hcommit, n.applied, n.processed, n.papplied = 0, 0, 0, 0, 0
+	n.resetWAL()
+
+	// Reset peer set to just ourselves; a new leader will fold us back into
+	// the cluster's membership view via processPeerState.
+	n.peers = map[string]*lps{n.id: {time.Time{}, 0, true}}
+	n.removed = nil
+	n.adjustClusterSizeAndQuorum()
+
+	n.term, n.vote = 0, _EMPTY_
+	n.writeTermVote()
+
+	// Persist the cleared peer state so a restart picks up the reset.
+	n.writePeerState(n.currentPeerStateLocked())
 }
 
 const (

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -6092,3 +6092,125 @@ func TestNRGProcessAppendEntryTermMismatchDoesNotRegressCommit(t *testing.T) {
 	n.processAppendEntry(aeBadPterm, n.aesub)
 	require_Equal(t, n.commit, 5)
 }
+
+func TestNRGReset(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// Simulate this node having operated as its own group: WAL entries,
+	// extra peers, advanced commit/applied, a snapshot file, and a known
+	// leader. Reset must clear all of it.
+	nats0 := "S1Nunr6R" // "nats-0"
+	nats1 := "yrzKKRBu" // "nats-1"
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	aeMsg1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: []*Entry{newEntry(EntryNormal, esm)}})
+	aeMsg2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 1, entries: []*Entry{newEntry(EntryNormal, esm)}})
+	require_NoError(t, n.storeToWAL(aeMsg1))
+	require_NoError(t, n.storeToWAL(aeMsg2))
+	require_Equal(t, n.pindex, 2)
+
+	// Populate the cache, to check that it gets reset below.
+	n.pae[1] = &appendEntry{leader: nats0, term: 1, pindex: 0}
+	n.pae[2] = &appendEntry{leader: nats0, term: 1, pindex: 1}
+
+	n.commit = 2
+	n.applied = 2
+	n.processed = 2
+	n.papplied = 1
+	n.hcommit = 2
+	n.term = 7
+	n.vote = nats1
+	n.writeTermVote()
+
+	// Add another peer in addition to ourselves.
+	other := nats1
+	n.peers[other] = &lps{time.Time{}, 0, true}
+	n.adjustClusterSizeAndQuorum()
+	n.updateLeader(other)
+
+	// Drop a fake snapshot file plus an orphan to verify the whole
+	// snapshots directory is wiped, not just n.snapfile.
+	snapDir := filepath.Join(n.sd, snapshotsDir)
+	require_NoError(t, os.MkdirAll(snapDir, defaultDirPerms))
+	sfile := filepath.Join(snapDir, "snap.fake")
+	require_NoError(t, os.WriteFile(sfile, []byte("stale"), defaultFilePerms))
+	orphan := filepath.Join(snapDir, "snap.orphan")
+	require_NoError(t, os.WriteFile(orphan, []byte("orphan"), defaultFilePerms))
+	n.snapfile = sfile
+
+	// Push something onto each queue so we can verify they are drained.
+	_, err := n.prop.push(&proposedEntry{&Entry{}, _EMPTY_})
+	require_NoError(t, err)
+	_, err = n.entry.push(&appendEntry{})
+	require_NoError(t, err)
+	_, err = n.resp.push(&appendEntryResponse{})
+	require_NoError(t, err)
+	_, err = n.apply.push(newCommittedEntry(1, nil))
+	require_NoError(t, err)
+	_, err = n.reqs.push(&voteRequest{})
+	require_NoError(t, err)
+	_, err = n.votes.push(&voteResponse{})
+	require_NoError(t, err)
+
+	// Park the node before resetting, mirroring how callers (e.g. the SYS-account
+	// leaf extension path) use Reset: observer mode is set first so the
+	// node doesn't compete for leadership immediately after step-down.
+	n.setObserver(true, extExtended)
+	n.Reset()
+
+	// All log state cleared.
+	require_Equal(t, n.pterm, 0)
+	require_Equal(t, n.pindex, 0)
+	require_Equal(t, n.commit, 0)
+	require_Equal(t, n.applied, 0)
+	require_Equal(t, n.processed, 0)
+	require_Equal(t, n.papplied, 0)
+	require_Equal(t, n.hcommit, 0)
+
+	// Peer set reset to just self, cluster size and quorum adjusted.
+	require_Equal(t, len(n.peers), 1)
+	if _, ok := n.peers[n.id]; !ok {
+		t.Fatalf("expected self %q to remain in peers after reset, got %v", n.id, n.peers)
+	}
+	require_Equal(t, n.csz, 1)
+	require_Equal(t, n.qn, 1)
+
+	// Leader forgotten so the parent leader can re-establish via heartbeat.
+	require_Equal(t, n.leader, noLeader)
+
+	// State transitions: stepped down to follower, observer mode left as the
+	// caller set it, term/vote cleared so the new leader's term wins.
+	require_Equal(t, n.State(), Follower)
+	require_True(t, n.observer)
+	require_Equal(t, n.extSt, extExtended)
+	require_Equal(t, n.term, 0)
+	require_Equal(t, n.vote, noVote)
+
+	// Snapshot reference cleared, and the entire snapshots directory was
+	// wiped (both the referenced file and the orphan), then recreated empty.
+	require_Equal(t, n.snapfile, _EMPTY_)
+	if _, err = os.Stat(sfile); !os.IsNotExist(err) {
+		t.Fatalf("expected snapshot file %q to be removed, stat err=%v", sfile, err)
+	}
+	if _, err = os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("expected orphan snapshot %q to be removed, stat err=%v", orphan, err)
+	}
+	snapEntries, err := os.ReadDir(snapDir)
+	require_NoError(t, err)
+	require_Equal(t, len(snapEntries), 0)
+
+	// Queues drained.
+	require_Equal(t, n.prop.len(), 0)
+	require_Equal(t, n.entry.len(), 0)
+	require_Equal(t, n.resp.len(), 0)
+	require_Equal(t, n.apply.len(), 0)
+	require_Equal(t, n.reqs.len(), 0)
+	require_Equal(t, n.votes.len(), 0)
+
+	// WAL is empty.
+	walEntries, _ := n.Size()
+	require_Equal(t, walEntries, 0)
+
+	// Append entry cache cleared.
+	require_Equal(t, len(n.pae), 0)
+}


### PR DESCRIPTION
De-flakes `TestJetStreamLeafNodeClusterExtensionWithSystemAccount`.

A leaf node would start and spin up its own meta group, but once its meta group got extended it would not reset its own local meta log. This could result in the leaf node's prefix diverging from the parent meta group.