### PR TITLE
NRG: Invalidate pae cache on WAL truncate and snapshot install

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -1383,6 +1383,11 @@ func (n *raft) installSnapshot(snap *snapshot) error {
 		return err
 	}
 
+	// If installing a snapshot past our commits, clear the cache.
+	if snap.lastIndex > n.commit && len(n.pae) > 0 {
+		n.pae = make(map[uint64]*appendEntry)
+	}
+
 	var state StreamState
 	n.wal.FastState(&state)
 	n.papplied = snap.lastIndex
@@ -4271,13 +4276,10 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 
 			// Inherit state from appendEntry with the leader's snapshot.
 			hadPreviousSnapshot := n.snapfile != _EMPTY_
-			n.pindex = ae.pindex
-			n.pterm = ae.pterm
-			n.commit = ae.pindex
 
 			snap := &snapshot{
-				lastTerm:  n.pterm,
-				lastIndex: n.pindex,
+				lastTerm:  ae.pterm,
+				lastIndex: ae.pindex,
 				peerstate: encodePeerState(&peerState{n.peerNames(), n.csz, n.extSt}),
 				data:      ae.entries[0].Data,
 			}
@@ -4287,6 +4289,9 @@ func (n *raft) processAppendEntry(ae *appendEntry, sub *subscription) {
 				n.Unlock()
 				return
 			}
+			n.pindex = ae.pindex
+			n.pterm = ae.pterm
+			n.commit = ae.pindex
 			n.resetInitializing()
 
 			if !hadPreviousSnapshot {

--- a/server/raft.go
+++ b/server/raft.go
@@ -3904,6 +3904,19 @@ func (n *raft) truncateWAL(term, index uint64) {
 	// Set after we know we have truncated properly.
 	n.pterm, n.pindex = term, index
 
+	// Invalidate cached entries the WAL no longer has.
+	if index == 0 {
+		if len(n.pae) > 0 {
+			n.pae = make(map[uint64]*appendEntry)
+		}
+	} else {
+		for k := range n.pae {
+			if k > index {
+				delete(n.pae, k)
+			}
+		}
+	}
+
 	// Check if we're truncating an uncommitted membership change.
 	if n.membChangeIndex > 0 && n.membChangeIndex > index {
 		n.membChangeIndex = 0

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -1250,6 +1250,78 @@ func TestNRGPendingAppendEntryCacheInvalidation(t *testing.T) {
 	}
 }
 
+func TestNRGTruncateWALClearsPendingAppendEntryCache(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	// Store three entries through the normal path so both the WAL and n.pae
+	// are populated by cachePendingEntry.
+	ae1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+	ae2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 1, entries: entries})
+	ae3 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 2, entries: entries})
+
+	n.processAppendEntry(ae1, n.aesub)
+	n.processAppendEntry(ae2, n.aesub)
+	n.processAppendEntry(ae3, n.aesub)
+
+	n.Lock()
+	defer n.Unlock()
+
+	// Sanity check: WAL and cache both have all three entries.
+	require_Equal(t, n.pindex, 3)
+	require_Equal(t, n.wal.State().Msgs, 3)
+	require_NotNil(t, n.pae[1])
+	require_NotNil(t, n.pae[2])
+	require_NotNil(t, n.pae[3])
+
+	// Truncate WAL back to index 1, dropping entries 2 and 3 from the log.
+	n.truncateWAL(1, 1)
+	require_Equal(t, n.pindex, 1)
+	require_Equal(t, n.wal.State().Msgs, 1)
+
+	// The cache must not retain entries for indices the WAL no longer holds,
+	// otherwise applyCommit could later apply stale entries straight from
+	// the cache (bypassing the WAL load path).
+	require_Len(t, len(n.pae), 1)
+	require_NotNil(t, n.pae[1])
+}
+
+func TestNRGResetWALClearsPendingAppendEntryCache(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	ae1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+	ae2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 1, entries: entries})
+	ae3 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 2, entries: entries})
+
+	n.processAppendEntry(ae1, n.aesub)
+	n.processAppendEntry(ae2, n.aesub)
+	n.processAppendEntry(ae3, n.aesub)
+
+	n.Lock()
+	defer n.Unlock()
+
+	require_Equal(t, n.pindex, 3)
+	require_Equal(t, len(n.pae), 3)
+
+	n.resetWAL()
+	require_Equal(t, n.pindex, 0)
+	require_Equal(t, n.wal.State().Msgs, 0)
+
+	// All cached pending append entries should be gone after a full reset.
+	require_Equal(t, len(n.pae), 0)
+}
+
 func TestNRGCatchupDoesNotTruncateUncommittedEntriesWithQuorum(t *testing.T) {
 	n, cleanup := initSingleMemRaftNode(t)
 	defer cleanup()

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -1322,6 +1322,86 @@ func TestNRGResetWALClearsPendingAppendEntryCache(t *testing.T) {
 	require_Equal(t, len(n.pae), 0)
 }
 
+func TestNRGInstallSnapshotClearsPendingAppendEntryCache(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	// Three appendEntries arrive with commit lagging at 0, so applyCommit
+	// never runs and all three remain cached in n.pae.
+	ae1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+	ae2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 1, entries: entries})
+	ae3 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 2, entries: entries})
+
+	n.processAppendEntry(ae1, n.aesub)
+	n.processAppendEntry(ae2, n.aesub)
+	n.processAppendEntry(ae3, n.aesub)
+
+	n.Lock()
+	defer n.Unlock()
+
+	require_Equal(t, n.pindex, 3)
+	require_Equal(t, n.commit, 0)
+	require_Equal(t, len(n.pae), 3)
+
+	// Install a snapshot covering the entire log. The WAL gets compacted
+	// past index 3, but cached entries 1-3 would otherwise stay in n.pae
+	// since applyCommit never ran for them and cachePendingEntry only
+	// overwrites at the current n.pindex (which won't revisit 1-3).
+	snap := &snapshot{
+		lastTerm:  1,
+		lastIndex: 3,
+		peerstate: encodePeerState(&peerState{n.peerNames(), n.csz, n.extSt}),
+	}
+	require_NoError(t, n.installSnapshot(snap))
+
+	require_Equal(t, n.wal.State().Msgs, 0)
+	require_Equal(t, len(n.pae), 0)
+}
+
+func TestNRGCatchupFromSnapshotClearsPendingAppendEntryCache(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+	snapshotEntries := []*Entry{
+		newEntry(EntrySnapshot, nil),
+		newEntry(EntryPeerState, encodePeerState(&peerState{n.peerNames(), n.csz, n.extSt})),
+	}
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	// Receive two appendEntries normally; commit lags so both stay cached.
+	ae1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+	ae2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 1, entries: entries})
+	n.processAppendEntry(ae1, n.aesub)
+	n.processAppendEntry(ae2, n.aesub)
+	require_Equal(t, n.pindex, 2)
+	require_Equal(t, len(n.pae), 2)
+
+	// Leader is way ahead; this triggers catchup.
+	aeTriggerCatchup := encode(t, &appendEntry{leader: nats0, term: 1, commit: 100, pterm: 1, pindex: 100, entries: nil})
+	n.processAppendEntry(aeTriggerCatchup, n.aesub)
+	require_True(t, n.catchup != nil)
+
+	// Leader sends a snapshot at the catchup point. n.pindex/n.commit jump
+	// to 100 without applyCommit running for indices 1-2, so the cached
+	// entries from before catchup would otherwise leak.
+	aeCatchupSnapshot := encode(t, &appendEntry{leader: nats0, term: 1, commit: 100, pterm: 1, pindex: 100, entries: snapshotEntries})
+	n.processAppendEntry(aeCatchupSnapshot, n.catchup.sub)
+
+	n.Lock()
+	defer n.Unlock()
+	require_Equal(t, n.pindex, 100)
+	require_Equal(t, n.commit, 100)
+	require_Equal(t, len(n.pae), 0)
+}
+
 func TestNRGCatchupDoesNotTruncateUncommittedEntriesWithQuorum(t *testing.T) {
 	n, cleanup := initSingleMemRaftNode(t)
 	defer cleanup()


### PR DESCRIPTION
`n.pae` caches append entries and is normally drained by `applyCommit`. Three paths bypassed that drain: `truncateWAL`, `installSnapshot`, and catchup-from-snapshot. Memory would leak (bounded by `paeDropThreshold`) and the cache would become less efficient, requiring more disk loads until a stepdown or server restart.