### PR TITLE
[FIXED] Mirror last seq mismatch from skipMsgs failure & retry

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -10218,8 +10218,9 @@ func TestJetStreamClusterSkipMsgsRaftDeleteRange(t *testing.T) {
 			}
 			start := time.Now()
 			mset.mu.Lock()
-			mset.skipMsgs(2, gap)
+			err = mset.skipMsgs(2, gap)
 			mset.mu.Unlock()
+			require_NoError(t, err)
 			if elapsed := time.Since(start); elapsed > 2*time.Second {
 				t.Fatalf("Expected to skip msgs in <2s but got %v", elapsed)
 			}
@@ -10324,4 +10325,63 @@ func TestJetStreamClusterApplyDeleteRangeOpIdempotent(t *testing.T) {
 	require_Equal(t, mset.lastSeq(), 2500)
 	mset.store.FastState(&after)
 	require_Equal(t, after.LastSeq, 2500)
+}
+
+func TestJetStreamClusterMirrorSkipMsgsPropagatesProposeFailure(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "SRC",
+		Subjects: []string{"src.>"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	stored := uint64(5)
+	for range stored {
+		_, err = js.Publish("src.a", nil)
+		require_NoError(t, err)
+	}
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "M",
+		Replicas: 3,
+		Mirror:   &nats.StreamSource{Name: "SRC"},
+	})
+	require_NoError(t, err)
+
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		si, err := js.StreamInfo("M")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != stored {
+			return fmt.Errorf("got %d msgs, want %d", si.State.Msgs, stored)
+		}
+		return nil
+	})
+
+	sl := c.streamLeader(globalAccountName, "M")
+	require_NotNil(t, sl)
+	mset, err := sl.globalAccount().lookupStream("M")
+	require_NoError(t, err)
+
+	// Step the mirror's Raft node down so node.Propose / ProposeMulti will return
+	// errNotLeader for any subsequent proposal; including the one skipMsgs makes.
+	require_NoError(t, mset.raftNode().StepDown())
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		if mset.IsLeader() {
+			return fmt.Errorf("still leader")
+		}
+		return nil
+	})
+
+	mset.mu.Lock()
+	err = mset.skipMsgs(stored+1, stored+10)
+	mset.mu.Unlock()
+	require_Error(t, err, errNotLeader)
 }

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -23944,3 +23944,61 @@ func TestJetStreamStreamConfigConcurrentReadWrite(t *testing.T) {
 	close(stop)
 	wg.Wait()
 }
+
+func TestJetStreamMirrorProcessInboundNilDeref(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "M",
+		Subjects: []string{"foo"},
+	})
+	require_NoError(t, err)
+
+	for range 5 {
+		_, err := js.Publish("foo", []byte("seed"))
+		require_NoError(t, err)
+	}
+
+	mset, err := s.globalAccount().lookupStream("M")
+	require_NoError(t, err)
+
+	var (
+		stop atomic.Bool
+		wg   sync.WaitGroup
+	)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for !stop.Load() {
+			mset.mu.Lock()
+			mset.mirror = &sourceInfo{name: "X", cname: "X", sseq: 4}
+			mset.mu.Unlock()
+
+			// With mset.mirror{cname:"X", sseq:4}, sseq==5 takes the
+			// sequential branch and then forces errLastSeqMismatch from
+			// processJetStreamMsg with sseq<=lseq.
+			rply := fmt.Sprintf("$JS.ACK.M.X.1.5.1.%d.0", time.Now().UnixNano())
+			mset.processInboundMirrorMsg(&inMsg{subj: "bar", rply: rply, msg: []byte("x")})
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for !stop.Load() {
+			mset.mu.Lock()
+			mset.mirror = nil
+			mset.mu.Unlock()
+			runtime.Gosched()
+		}
+	}()
+
+	time.Sleep(3 * time.Second)
+	stop.Store(true)
+	wg.Wait()
+}

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -24002,3 +24002,43 @@ func TestJetStreamMirrorProcessInboundNilDeref(t *testing.T) {
 	stop.Store(true)
 	wg.Wait()
 }
+
+func TestJetStreamMirrorRetriesOnSeqAlreadySeenMismatch(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "M",
+		Subjects: []string{"foo"},
+	})
+	require_NoError(t, err)
+
+	for range 5 {
+		_, err := js.Publish("foo", []byte("seed"))
+		require_NoError(t, err)
+	}
+
+	mset, err := s.globalAccount().lookupStream("M")
+	require_NoError(t, err)
+
+	qch := make(chan struct{})
+	mset.mu.Lock()
+	mset.mirror = &sourceInfo{name: "X", cname: "X", sseq: 4, qch: qch}
+	mset.mu.Unlock()
+
+	// With mset.mirror{cname:"X", sseq:4}, sseq==5 takes the sequential
+	// branch and then forces errLastSeqMismatch from processJetStreamMsg
+	// with sseq<=lseq.
+	rply := fmt.Sprintf("$JS.ACK.M.X.1.5.1.%d.0", time.Now().UnixNano())
+	mset.processInboundMirrorMsg(&inMsg{subj: "bar", rply: rply, msg: []byte("x")})
+
+	select {
+	case <-qch:
+		// expected: retryMirrorConsumer ran and canceled the mirror.
+	case <-time.After(2 * time.Second):
+		t.Fatal("retryMirrorConsumer was not called after errLastSeqMismatch in the sseq<=lseq branch")
+	}
+}

--- a/server/stream.go
+++ b/server/stream.go
@@ -3212,7 +3212,13 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 	} else {
 		// If the deliver sequence matches then the upstream stream has expired or deleted messages.
 		if dseq == mset.mirror.dseq+1 {
-			mset.skipMsgs(mset.mirror.sseq+1, sseq-1)
+			if err := mset.skipMsgs(mset.mirror.sseq+1, sseq-1); err != nil {
+				mset.mirror.sseq = osseq
+				mset.mirror.dseq = odseq
+				mset.mu.Unlock()
+				mset.retryMirrorConsumer()
+				return false
+			}
 			mset.mirror.dseq++
 			mset.mirror.sseq = sseq
 		} else {
@@ -3331,20 +3337,21 @@ func (mset *stream) retryMirrorConsumer() error {
 }
 
 // Lock should be held.
-func (mset *stream) skipMsgs(start, end uint64) {
+func (mset *stream) skipMsgs(start, end uint64) error {
 	node, store := mset.node, mset.store
 	// If we are not clustered we can short circuit now with store.SkipMsgs
 	if node == nil {
-		store.SkipMsgs(start, end-start+1)
+		if err := store.SkipMsgs(start, end-start+1); err != nil {
+			return err
+		}
 		mset.lseq = end
-		return
+		return nil
 	}
 
 	// Must only be enabled once every peer in the cluster supports receiving
 	// deleteRangeOp in the normal apply path; older peers panic on unknown ops.
 	if mset.srv.getOpts().getFeatureFlag(FeatureFlagJsRaftDeleteRange) {
-		node.Propose(encodeDeleteRange(&DeleteRange{First: start, Num: end - start + 1}))
-		return
+		return node.Propose(encodeDeleteRange(&DeleteRange{First: start, Num: end - start + 1}))
 	}
 
 	var entries []*Entry
@@ -3352,7 +3359,9 @@ func (mset *stream) skipMsgs(start, end uint64) {
 		entries = append(entries, newEntry(EntryNormal, encodeStreamMsg(_EMPTY_, _EMPTY_, nil, nil, seq-1, 0, false)))
 		// So a single message does not get too big.
 		if len(entries) > 10_000 {
-			node.ProposeMulti(entries)
+			if err := node.ProposeMulti(entries); err != nil {
+				return err
+			}
 			// We need to re-create `entries` because there is a reference
 			// to it in the node's pae map.
 			entries = entries[:0]
@@ -3360,8 +3369,9 @@ func (mset *stream) skipMsgs(start, end uint64) {
 	}
 	// Send all at once.
 	if len(entries) > 0 {
-		node.ProposeMulti(entries)
+		return node.ProposeMulti(entries)
 	}
+	return nil
 }
 
 const (
@@ -3725,13 +3735,25 @@ func (mset *stream) setupMirrorConsumer() error {
 			state = StreamState{}
 			mset.store.FastState(&state)
 			if state.LastSeq < ccr.ConsumerInfo.Delivered.Stream {
+				// Local helper: abort consumer setup, leaving the mirror in its
+				// pre-setup state so the retry path can re-create it cleanly.
+				failSetup := func(setupErr error) {
+					mset.cancelSourceInfo(mirror)
+					mirror.err = NewJSMirrorConsumerSetupFailedError(setupErr, Unless(setupErr))
+					retry = true
+					mset.mu.Unlock()
+				}
 				// Check to see if delivered is past our last and we have no msgs. This will help the
 				// case when mirroring a stream that has a very high starting sequence number.
 				if state.Msgs == 0 && ccr.ConsumerInfo.Delivered.Stream > state.LastSeq {
-					mset.store.PurgeEx(_EMPTY_, ccr.ConsumerInfo.Delivered.Stream+1, 0)
+					if _, err := mset.store.PurgeEx(_EMPTY_, ccr.ConsumerInfo.Delivered.Stream+1, 0); err != nil {
+						failSetup(err)
+						return
+					}
 					mset.lseq = ccr.ConsumerInfo.Delivered.Stream
-				} else {
-					mset.skipMsgs(state.LastSeq+1, ccr.ConsumerInfo.Delivered.Stream)
+				} else if err := mset.skipMsgs(state.LastSeq+1, ccr.ConsumerInfo.Delivered.Stream); err != nil {
+					failSetup(err)
+					return
 				}
 			}
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -3287,24 +3287,18 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 				accName, sname, err)
 		} else {
 			// We may have missed messages, restart.
-			if lseq := mset.lastSeq(); sseq <= lseq {
-				mset.mu.Lock()
-				if mset.mirror != nil {
-					mset.mirror.lag = olag
+			lseq := mset.lastSeq()
+			mset.mu.Lock()
+			if mset.mirror != nil {
+				mset.mirror.lag = olag
+				mset.mirror.dseq = odseq
+				mset.mirror.sseq = osseq
+				if sseq <= lseq {
 					mset.mirror.sseq = lseq
-					mset.mirror.dseq = odseq
 				}
-				mset.mu.Unlock()
-				return false
-			} else {
-				mset.mu.Lock()
-				if mset.mirror != nil {
-					mset.mirror.dseq = odseq
-					mset.mirror.sseq = osseq
-				}
-				mset.mu.Unlock()
-				mset.retryMirrorConsumer()
 			}
+			mset.mu.Unlock()
+			mset.retryMirrorConsumer()
 		}
 	}
 	return err == nil

--- a/server/stream.go
+++ b/server/stream.go
@@ -3289,15 +3289,19 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 			// We may have missed messages, restart.
 			if lseq := mset.lastSeq(); sseq <= lseq {
 				mset.mu.Lock()
-				mset.mirror.lag = olag
-				mset.mirror.sseq = lseq
-				mset.mirror.dseq = odseq
+				if mset.mirror != nil {
+					mset.mirror.lag = olag
+					mset.mirror.sseq = lseq
+					mset.mirror.dseq = odseq
+				}
 				mset.mu.Unlock()
 				return false
 			} else {
 				mset.mu.Lock()
-				mset.mirror.dseq = odseq
-				mset.mirror.sseq = osseq
+				if mset.mirror != nil {
+					mset.mirror.dseq = odseq
+					mset.mirror.sseq = osseq
+				}
 				mset.mu.Unlock()
 				mset.retryMirrorConsumer()
 			}


### PR DESCRIPTION
- Make `skipMsgs` return errors from the underlying store / Raft `Propose` / `ProposeMulti` calls instead of swallowing them, and propagate failures.
- Fix a potential nil deref in `processInboundMirrorMsg` if `mset.mirror` was cleared while the lock was released.
- Always immediately retry the mirror consumer on a last seq mismatch so a mismatch can't leave the mirror stalled for longer than necessary.
