### PR TITLE
test: data race in checkStateAndErr

### DIFF
--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -2189,7 +2189,7 @@ func checkStateAndErr(t *testing.T, c *cluster, accountName, streamName string) 
 	mset, err := acc.lookupStream(streamName)
 	require_NoError(t, err)
 
-	cfgReplicas := mset.cfg.Replicas
+	cfgReplicas := mset.config().Replicas
 	foundReplicas := 1 // We already know the leader.
 	var errs []error
 	for _, srv := range c.servers {


### PR DESCRIPTION
```
WARNING: DATA RACE
Write at 0x00c00193d348 by goroutine 75256:
  github.com/nats-io/nats-server/v2/server.(*stream).updateWithAdvisory()
      /home/runner/work/nats-server/nats-server/server/stream.go:2698 +0x1f08

Previous read at 0x00c00193d348 by goroutine 75229:
  github.com/nats-io/nats-server/v2/server.checkStateAndErr()
      /home/runner/work/nats-server/nats-server/server/jetstream_helpers_test.go:2269 +0x1ca
```