### PR TITLE
[FIXED] WaitGroup reuse panic when resetting streams and consumers

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -511,6 +511,7 @@ type consumer struct {
 	retention RetentionPolicy
 
 	monitorWg sync.WaitGroup
+	monitorMu sync.Mutex // Serializes monitorWg's Add against Wait to prevent a WaitGroup reuse panic.
 	inMonitor bool
 
 	// R>1 proposals
@@ -6920,14 +6921,21 @@ func gatherSubjectFilters(filter string, filters []string) []string {
 // shouldStartMonitor will return true if we should start a monitor
 // goroutine or will return false if one is already running.
 func (o *consumer) shouldStartMonitor() bool {
-	o.mu.Lock()
-	defer o.mu.Unlock()
+	// monitorMu is held across the monitorWg.Add below so that it cannot race
+	// a concurrent monitorWg.Wait in stopMonitoring. It is taken before o.mu to
+	// keep a consistent lock ordering.
+	o.monitorMu.Lock()
+	defer o.monitorMu.Unlock()
 
+	o.mu.Lock()
 	if o.inMonitor {
+		o.mu.Unlock()
 		return false
 	}
-	o.monitorWg.Add(1)
 	o.inMonitor = true
+	o.mu.Unlock()
+
+	o.monitorWg.Add(1)
 	return true
 }
 
@@ -6941,6 +6949,18 @@ func (o *consumer) clearMonitorRunning() {
 		o.monitorWg.Done()
 		o.inMonitor = false
 	}
+}
+
+// stopMonitoring signals any running monitor goroutine to quit and waits for
+// it to fully exit.
+func (o *consumer) stopMonitoring() {
+	// monitorMu is held across both the quit signal and the wait so that a
+	// concurrent shouldStartMonitor cannot slip a new monitor generation in
+	// between.
+	o.monitorMu.Lock()
+	defer o.monitorMu.Unlock()
+	o.signalMonitorQuit()
+	o.monitorWg.Wait()
 }
 
 // Test whether we are in the monitor routine.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3612,7 +3612,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 			// If we were successful lookup up our stream now.
 			if err == nil {
 				if mset, err = acc.lookupStream(sa.Config.Name); mset != nil {
-					mset.monitorWg.Add(1)
+					mset.startMonitorWg()
 					defer mset.monitorWg.Done()
 					mset.checkInMonitor()
 					mset.setStreamAssignment(sa)
@@ -3792,8 +3792,7 @@ func (mset *stream) resetClusteredState(err error) bool {
 
 	// Need to do the rest in a separate Go routine.
 	go func() {
-		mset.signalMonitorQuit()
-		mset.monitorWg.Wait()
+		mset.stopMonitoring()
 		mset.resetAndWaitOnConsumers()
 		// Stop our stream.
 		mset.stop(shouldDelete, false)
@@ -5048,8 +5047,7 @@ func (s *Server) removeStream(mset *stream, nsa *streamAssignment) {
 
 	if !isShuttingDown {
 		// wait for monitor to be shutdown.
-		mset.signalMonitorQuit()
-		mset.monitorWg.Wait()
+		mset.stopMonitoring()
 	}
 	mset.stop(true, false)
 }
@@ -5078,8 +5076,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 			s.Warnf("JetStream cluster detected stream remapping for '%s > %s' from %q to %q",
 				acc, cfg.Name, osa.Group.Name, sa.Group.Name)
 			mset.removeNode()
-			mset.signalMonitorQuit()
-			mset.monitorWg.Wait()
+			mset.stopMonitoring()
 			alreadyRunning, needsNode = false, true
 			// Make sure to clear from original.
 			js.mu.Lock()
@@ -5104,7 +5101,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 					"stream":  mset.name(),
 				})
 			}
-			mset.monitorWg.Add(1)
+			mset.startMonitorWg()
 			// Start monitoring..
 			started := s.startGoRoutine(
 				func() { js.monitorStream(mset, sa, needsNode) },
@@ -5120,8 +5117,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 		} else if numReplicas == 1 && alreadyRunning {
 			// We downgraded to R1. Make sure we cleanup the raft node and the stream monitor.
 			mset.removeNode()
-			mset.signalMonitorQuit()
-			mset.monitorWg.Wait()
+			mset.stopMonitoring()
 			// In case we need to shutdown the cluster specific subs, etc.
 			mset.mu.Lock()
 			// Stop responding to sync requests.
@@ -5373,7 +5369,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 	if node != nil {
 		if !alreadyRunning {
 			if mset != nil {
-				mset.monitorWg.Add(1)
+				mset.startMonitorWg()
 			}
 			started := s.startGoRoutine(
 				func() { js.monitorStream(mset, sa, false) },
@@ -5560,8 +5556,7 @@ func (js *jetStream) processClusterDeleteStream(sa *streamAssignment, isMember, 
 				n.Delete()
 			}
 			// wait for monitor to be shut down
-			mset.signalMonitorQuit()
-			mset.monitorWg.Wait()
+			mset.stopMonitoring()
 			err = mset.stop(true, wasLeader)
 			stopped = true
 		} else if isMember {
@@ -5783,8 +5778,7 @@ func (s *Server) removeConsumer(o *consumer, nca *consumerAssignment) {
 
 	if !isShuttingDown {
 		// wait for monitor to be shutdown.
-		o.signalMonitorQuit()
-		o.monitorWg.Wait()
+		o.stopMonitoring()
 	}
 	o.deleteWithoutAdvisory()
 }
@@ -5891,8 +5885,7 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 		s.Warnf("JetStream cluster detected consumer remapping for '%s > %s' from %q to %q",
 			acc, ca.Name, oca.Group.Name, ca.Group.Name)
 		o.clearNode()
-		o.signalMonitorQuit()
-		o.monitorWg.Wait()
+		o.stopMonitoring()
 		alreadyRunning = false
 		// Make sure to clear from original.
 		js.mu.Lock()
@@ -6058,8 +6051,7 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 			// Check for scale down to 1..
 			if node != nil && len(rg.Peers) == 1 {
 				o.clearNode()
-				o.signalMonitorQuit()
-				o.monitorWg.Wait()
+				o.stopMonitoring()
 				// Need to clear from rg too.
 				js.mu.Lock()
 				rg.node = nil
@@ -6098,8 +6090,7 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 
 		if node == nil {
 			// Wait for the previous routine to stop running.
-			o.signalMonitorQuit()
-			o.monitorWg.Wait()
+			o.stopMonitoring()
 			// Single replica consumer, process manually here.
 			// Force response in case we think this is an update.
 			if !js.isMetaRecovering() && isConfigUpdate {
@@ -6130,8 +6121,7 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 			// Start our monitoring routine if needed.
 			if !alreadyRunning {
 				// Wait for the previous routine to stop running.
-				o.signalMonitorQuit()
-				o.monitorWg.Wait()
+				o.stopMonitoring()
 				if o.shouldStartMonitor() {
 					started := s.startGoRoutine(
 						func() { js.monitorConsumer(o, ca) },

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8077,12 +8077,16 @@ func TestJetStreamClusterScaleDownWaitsForMonitorRoutineQuit(t *testing.T) {
 	require_NotNil(t, o)
 
 	// Increment the wait group for this test to confirm the right ordering.
-	o.mu.Lock()
+	// The Add must be done under monitorMu, just like shouldStartMonitor does,
+	// so it cannot race a concurrent monitorWg.Wait.
+	o.mu.RLock()
 	inMonitor := o.inMonitor
+	o.mu.RUnlock()
+	require_True(t, inMonitor)
+	o.monitorMu.Lock()
 	wg := &o.monitorWg
 	wg.Add(1)
-	o.mu.Unlock()
-	require_True(t, inMonitor)
+	o.monitorMu.Unlock()
 
 	// The monitor routine should stop.
 	ccfg.Replicas = 1
@@ -8115,12 +8119,16 @@ func TestJetStreamClusterScaleDownWaitsForMonitorRoutineQuit(t *testing.T) {
 	require_NoError(t, err)
 
 	// Increment the wait group for this test to confirm the right ordering.
-	mset.mu.Lock()
+	// The Add must be done under monitorMu, just like startMonitorWg does,
+	// so it cannot race a concurrent monitorWg.Wait.
+	mset.mu.RLock()
 	inMonitor = mset.inMonitor
+	mset.mu.RUnlock()
+	require_True(t, inMonitor)
+	mset.monitorMu.Lock()
 	wg = &mset.monitorWg
 	wg.Add(1)
-	mset.mu.Unlock()
-	require_True(t, inMonitor)
+	mset.monitorMu.Unlock()
 
 	// The monitor routine should stop.
 	scfg.Replicas = 1
@@ -8182,13 +8190,17 @@ func TestJetStreamClusterConsumerRemapWaitsForMonitorRoutineQuit(t *testing.T) {
 	require_NotNil(t, o)
 
 	// Increment the wait group for this test to confirm the right ordering.
-	o.mu.Lock()
+	// The Add must be done under monitorMu, just like shouldStartMonitor does,
+	// so it cannot race a concurrent monitorWg.Wait.
+	o.mu.RLock()
 	inMonitor := o.inMonitor
+	rn := o.node
+	o.mu.RUnlock()
+	require_True(t, inMonitor)
+	o.monitorMu.Lock()
 	wg := &o.monitorWg
 	wg.Add(1)
-	rn := o.node
-	o.mu.Unlock()
-	require_True(t, inMonitor)
+	o.monitorMu.Unlock()
 
 	// Simulate a consumer Raft group remapping that has been collapsed down into just a single update.
 	// Instead of one update to R1 and then to R3, it's just one update straight to the new R3 group.
@@ -8223,6 +8235,86 @@ func TestJetStreamClusterConsumerRemapWaitsForMonitorRoutineQuit(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// Must be run with -race.
+func TestJetStreamClusterConsumerMonitorWaitGroupRace(t *testing.T) {
+	o := &consumer{}
+
+	var ready sync.WaitGroup
+	ready.Add(1)
+	done := make(chan struct{})
+
+	var fin sync.WaitGroup
+	fin.Add(2)
+
+	// Repeatedly start and stop the monitor, exercising monitorWg.Add / Done.
+	go func() {
+		defer fin.Done()
+		ready.Wait()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			if o.shouldStartMonitor() {
+				o.clearMonitorRunning()
+			}
+		}
+	}()
+
+	// Repeatedly wait on the monitor, exercising monitorWg.Wait.
+	go func() {
+		defer fin.Done()
+		ready.Done()
+		for range 500_000 {
+			o.stopMonitoring()
+		}
+		close(done)
+	}()
+
+	fin.Wait()
+}
+
+// Must be run with -race.
+func TestJetStreamClusterStreamMonitorWaitGroupRace(t *testing.T) {
+	mset := &stream{}
+
+	var ready sync.WaitGroup
+	ready.Add(1)
+	done := make(chan struct{})
+
+	var fin sync.WaitGroup
+	fin.Add(2)
+
+	// Repeatedly register and unregister a monitor goroutine, exercising
+	// monitorWg.Add (via startMonitorWg) / Done.
+	go func() {
+		defer fin.Done()
+		ready.Wait()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			mset.startMonitorWg()
+			mset.monitorWg.Done()
+		}
+	}()
+
+	// Repeatedly wait on the monitor, exercising monitorWg.Wait.
+	go func() {
+		defer fin.Done()
+		ready.Done()
+		for range 500_000 {
+			mset.stopMonitoring()
+		}
+		close(done)
+	}()
+
+	fin.Wait()
 }
 
 func TestJetStreamClusterAccountStoreLimits(t *testing.T) {

--- a/server/stream.go
+++ b/server/stream.go
@@ -571,6 +571,7 @@ type stream struct {
 	mirrorLastBySub *subscription // Mirrors only.
 
 	monitorWg sync.WaitGroup // Wait group for the monitor routine.
+	monitorMu sync.Mutex     // Serializes monitorWg's Add against Wait to prevent a WaitGroup reuse panic.
 
 	// If standalone/single-server, the offline reason needs to be stored directly in the stream.
 	// Otherwise, if clustered it will be part of the stream assignment.
@@ -8216,10 +8217,7 @@ func (mset *stream) resetAndWaitOnConsumers() {
 			node.StepDown()
 			node.Stop()
 		}
-		if o.isMonitorRunning() {
-			o.signalMonitorQuit()
-			o.monitorWg.Wait()
-		}
+		o.stopMonitoring()
 	}
 }
 
@@ -8323,8 +8321,7 @@ func (mset *stream) stop(deleteFlag, advisory bool) error {
 			// but should we log?
 			o.stopWithFlags(deleteFlag, deleteFlag, false, advisory)
 			if !isShuttingDown {
-				o.signalMonitorQuit()
-				o.monitorWg.Wait()
+				o.stopMonitoring()
 			}
 		}
 	}
@@ -9228,6 +9225,28 @@ func (mset *stream) checkConsumerReplication() {
 		}
 		o.mu.RUnlock()
 	}
+}
+
+// startMonitorWg registers a pending monitor goroutine on monitorWg. It is
+// held under monitorMu so that the monitorWg.Add can never race a concurrent
+// monitorWg.Wait in stopMonitoring. The corresponding monitorWg.Done is done by
+// the monitor goroutine directly and must not be wrapped with monitorMu.
+func (mset *stream) startMonitorWg() {
+	mset.monitorMu.Lock()
+	mset.monitorWg.Add(1)
+	mset.monitorMu.Unlock()
+}
+
+// stopMonitoring signals any running monitor goroutine to quit and waits for
+// it to fully exit.
+func (mset *stream) stopMonitoring() {
+	// monitorMu is held across both the quit signal and the wait so that a
+	// concurrent startMonitorWg cannot slip a new monitor generation in
+	// between.
+	mset.monitorMu.Lock()
+	defer mset.monitorMu.Unlock()
+	mset.signalMonitorQuit()
+	mset.monitorWg.Wait()
 }
 
 // Will check if we are running in the monitor already and if not set the appropriate flag.


### PR DESCRIPTION
```
WARNING: DATA RACE
Read at 0x00c0002bd688 by goroutine 66:
  runtime.raceread()
      <autogenerated>:1 +0x1e
  github.com/nats-io/nats-server/v2/server.(*consumer).shouldStartMonitor()
      server/consumer.go:6929 +0x1e6

Previous write at 0x00c0002bd688 by goroutine 686:
  runtime.racewrite()
      <autogenerated>:1 +0x1e
  github.com/nats-io/nats-server/v2/server.(*stream).resetAndWaitOnConsumers()
      server/stream.go:8221 +0x624
  github.com/nats-io/nats-server/v2/server.(*stream).resetClusteredState.func4()
      server/jetstream_cluster.go:3797 +0xcb

panic: sync: WaitGroup is reused before previous Wait has returned
```

This shouldn't happen normally, since `resetClusteredState` should be prevented when possible, but this guards against a potential panic if it gets called and interleaves with a concurrent create.