### PR TITLE
[IMPROVED] Keep leafMsgAllowed denied/response path on the read lock

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -3335,6 +3335,15 @@ func (c *client) leafMsgAllowed() bool {
 		c.mu.RUnlock()
 		return true
 	}
+
+	// If allow_responses is not configured, or there is no tracked reply for
+	// this subject, the answer is "denied" and we can return it while still
+	// holding only the read lock.
+	replySubject := bytesToString(wireSubject)
+	if c.perms == nil || c.perms.resp == nil || c.replies[replySubject] == nil {
+		c.mu.RUnlock()
+		return false
+	}
 	c.mu.RUnlock()
 
 	// Check tracked reply permissions (allow_responses).
@@ -3343,7 +3352,7 @@ func (c *client) leafMsgAllowed() bool {
 	// the GW routing prefix for routed requests.
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.responseAllowed(bytesToString(wireSubject))
+	return c.responseAllowed(replySubject)
 }
 
 // Returns true if the leaf side ACLs allow importing this subject,


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/8139