### PR TITLE
De-flake TestFileStoreReadCache

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -6679,8 +6679,14 @@ func (mb *msgBlock) tryExpireCacheLocked() {
 	}
 
 	// Check for activity on the cache that would prevent us from expiring.
-	if tns-bufts <= int64(mb.cexp) {
-		mb.resetCacheExpireTimer(mb.cexp - time.Duration(tns-bufts))
+	// Both tns and bufts come from ats.AccessTime(), which means bufts can understate
+	// how recent the last activity actually was by up to one tick.
+	if delta := tns - bufts; delta <= int64(mb.cexp)+int64(ats.TickInterval) {
+		td := mb.cexp - time.Duration(delta)
+		if td <= 0 {
+			td = ats.TickInterval
+		}
+		mb.resetCacheExpireTimer(td)
 		if strengthened {
 			mb.finishedWithCache()
 		}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1704,7 +1704,7 @@ func TestFileStoreCollapseDmap(t *testing.T) {
 
 func TestFileStoreReadCache(t *testing.T) {
 	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
-		fcfg.CacheExpire = 100 * time.Millisecond
+		fcfg.CacheExpire = ats.TickInterval
 
 		subj, msg := "foo.bar", make([]byte, 1024)
 		storedMsgSize := fileStoreMsgSize(subj, nil, msg)
@@ -6800,7 +6800,7 @@ func TestFileStoreExpireCacheOnLinearWalk(t *testing.T) {
 	}
 	// Let them all expire. This way we load as we walk and can test that we expire all blocks without
 	// needing to worry about last write times blocking forced expiration.
-	time.Sleep(expire + ats.TickInterval)
+	time.Sleep(expire + ats.TickInterval*2)
 
 	checkNoCache := func() {
 		t.Helper()


### PR DESCRIPTION
`TestFileStoreReadCache` would sometimes flake with `cache loads not 2, got 3`, due to the less granular timestamps with `ats.TickInterval`. Fixed by allowing one `ats.TickInterval` of slack in the cache expiry check.