### PR TITLE
Fix message block corruption on filestore cipher conversion with cache clear

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1469,6 +1469,13 @@ func (mb *msgBlock) convertToEncrypted() error {
 	// Undo cache from above for later.
 	mb.cache = nil
 	mb.ecache.Set(nil)
+	// Regenerate mb.bek so that the keystream offset is at zero. This matches
+	// what encryptOrDecryptIfNeeded does on read-back, otherwise re-entering
+	// convertToEncrypted with a previously-used mb.bek would write ciphertext at
+	// the wrong stream offset and silently corrupt the block.
+	if mb.bek, err = genBlockEncryptionKey(mb.fs.fcfg.Cipher, mb.seed, mb.nonce); err != nil {
+		return err
+	}
 	mb.bek.XORKeyStream(buf, buf)
 	<-dios
 	err = os.WriteFile(mb.mfn, buf, defaultFilePerms)

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -14047,4 +14047,8 @@ func TestFileStoreConvertToEncryptedDoesNotResurrectXoredCache(t *testing.T) {
 	if mb.cache == sentinelCache {
 		t.Fatalf("setupWriteCache resurrected sentinel cache via mb.ecache after convertToEncrypted")
 	}
+	// If convertToEncrypted wrote ciphertext at the wrong keystream offset, the
+	// block would decrypt to garbage and rebuildStateFromBufLocked would silently
+	// truncate it to zero bytes — losing the message.
+	require_NotEqual(t, len(mb.cache.buf), 0)
 }


### PR DESCRIPTION
This ensures that using an old `mb.bek` doesn't corrupt the block by maintaining an old offset from before the cache clear.