### PR TITLE
[FIXED] Inconsistent un-tiered account reservation across stream create/update

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -2431,53 +2431,69 @@ func (jsa *jsAccount) wouldExceedLimits(storeType StorageType, tierName string, 
 
 // Check account limits.
 // Read Lock should be held
-func (js *jetStream) checkAccountLimits(selected *JetStreamAccountLimits, config *StreamConfig, currentRes int64) error {
-	return js.checkLimits(selected, config, false, currentRes, 0)
+func (js *jetStream) checkAccountLimits(selected *JetStreamAccountLimits, tier string, config *StreamConfig, currentRes int64) error {
+	return js.checkLimits(selected, tier, config, false, currentRes, 0)
 }
 
 // Check account and server limits.
 // Read Lock should be held
-func (js *jetStream) checkAllLimits(selected *JetStreamAccountLimits, config *StreamConfig, currentRes, maxBytesOffset int64) error {
-	return js.checkLimits(selected, config, true, currentRes, maxBytesOffset)
+func (js *jetStream) checkAllLimits(selected *JetStreamAccountLimits, tier string, config *StreamConfig, currentRes, maxBytesOffset int64) error {
+	return js.checkLimits(selected, tier, config, true, currentRes, maxBytesOffset)
 }
 
 // Check if a new proposed msg set while exceed our account limits.
 // Lock should be held.
-func (js *jetStream) checkLimits(selected *JetStreamAccountLimits, config *StreamConfig, checkServer bool, currentRes, maxBytesOffset int64) error {
+func (js *jetStream) checkLimits(selected *JetStreamAccountLimits, tier string, config *StreamConfig, checkServer bool, currentRes, maxBytesOffset int64) error {
 	// Check MaxConsumers
 	if config.MaxConsumers > 0 && selected.MaxConsumers > 0 && config.MaxConsumers > selected.MaxConsumers {
 		return NewJSMaximumConsumersLimitError()
 	}
 	// stream limit is checked separately on stream create only!
 	// Check storage, memory or disk.
-	return js.checkBytesLimits(selected, config.MaxBytes, config.Storage, checkServer, currentRes, maxBytesOffset)
+	return js.checkBytesLimits(selected, tier, config.MaxBytes, config.Replicas, config.Storage, checkServer, currentRes, maxBytesOffset)
+}
+
+// accountReservation returns how many bytes count against the account limit
+// for a stream with the given replica count. Un-tiered limits are flat, so R>1
+// is counted as Replicas*bytes; tiered limits already bake in replication.
+func accountReservation(tier string, replicas int, bytes int64) int64 {
+	if bytes <= 0 {
+		return 0
+	}
+	if tier == _EMPTY_ && replicas > 1 {
+		return mulSaturate(int64(replicas), bytes)
+	}
+	return bytes
 }
 
 // Check if additional bytes will exceed our account limits and optionally the server itself.
 // Read Lock should be held.
-func (js *jetStream) checkBytesLimits(selectedLimits *JetStreamAccountLimits, addBytes int64, storage StorageType, checkServer bool, currentRes, maxBytesOffset int64) error {
+func (js *jetStream) checkBytesLimits(selectedLimits *JetStreamAccountLimits, tier string, addBytes int64, replicas int, storage StorageType, checkServer bool, currentRes, maxBytesOffset int64) error {
 	if addBytes < 0 {
 		addBytes = 1
 	}
-	totalBytes := addSaturate(addBytes, maxBytesOffset)
+	// The per-server footprint is a single replica's worth of bytes; the
+	// account footprint additionally accounts for replication in un-tiered setups.
+	serverBytes := addSaturate(addBytes, maxBytesOffset)
+	accountBytes := accountReservation(tier, replicas, serverBytes)
 
 	switch storage {
 	case MemoryStorage:
 		// Account limits defined.
-		if selectedLimits.MaxMemory >= 0 && (currentRes > selectedLimits.MaxMemory || totalBytes > selectedLimits.MaxMemory-currentRes) {
+		if selectedLimits.MaxMemory >= 0 && (currentRes > selectedLimits.MaxMemory || accountBytes > selectedLimits.MaxMemory-currentRes) {
 			return NewJSMemoryResourcesExceededError()
 		}
 		// Check if this server can handle request.
-		if checkServer && (js.memReserved > js.config.MaxMemory || totalBytes > js.config.MaxMemory-js.memReserved) {
+		if checkServer && (js.memReserved > js.config.MaxMemory || serverBytes > js.config.MaxMemory-js.memReserved) {
 			return NewJSMemoryResourcesExceededError()
 		}
 	case FileStorage:
 		// Account limits defined.
-		if selectedLimits.MaxStore >= 0 && (currentRes > selectedLimits.MaxStore || totalBytes > selectedLimits.MaxStore-currentRes) {
+		if selectedLimits.MaxStore >= 0 && (currentRes > selectedLimits.MaxStore || accountBytes > selectedLimits.MaxStore-currentRes) {
 			return NewJSStorageResourcesExceededError()
 		}
 		// Check if this server can handle request.
-		if checkServer && (js.storeReserved > js.config.MaxStore || totalBytes > js.config.MaxStore-js.storeReserved) {
+		if checkServer && (js.storeReserved > js.config.MaxStore || serverBytes > js.config.MaxStore-js.storeReserved) {
 			return NewJSStorageResourcesExceededError()
 		}
 	}

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1361,13 +1361,7 @@ func (jsa *jsAccount) tieredReservation(tier string, cfg *StreamConfig) int64 {
 			continue
 		}
 		if (tier == _EMPTY_ || isSameTier(replicas, cfg.Replicas)) && maxBytes > 0 && storage == cfg.Storage {
-			// If tier is empty, all storage is flat and we should adjust for replicas.
-			// Otherwise if tiered, storage replication already taken into consideration.
-			if tier == _EMPTY_ && replicas > 1 {
-				reservation = addSaturate(reservation, mulSaturate(int64(replicas), maxBytes))
-			} else {
-				reservation = addSaturate(reservation, maxBytes)
-			}
+			reservation = addSaturate(reservation, accountReservation(tier, replicas, maxBytes))
 		}
 	}
 	return reservation
@@ -3785,7 +3779,7 @@ func (acc *Account) jsNonClusteredStreamLimitsCheck(cfg *StreamConfig) *ApiError
 		return NewJSMaximumStreamsLimitError()
 	}
 	reserved := jsa.tieredReservation(tier, cfg)
-	if err := jsa.js.checkAllLimits(selectedLimits, cfg, reserved, 0); err != nil {
+	if err := jsa.js.checkAllLimits(selectedLimits, tier, cfg, reserved, 0); err != nil {
 		return NewJSStreamLimitsError(err, Unless(err))
 	}
 	return nil

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5307,7 +5307,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 			}
 		} else if err == NewJSStreamNotFoundError() {
 			// Add in the stream here.
-			mset, err = acc.addStreamWithAssignment(sa.Config, nil, sa, false, false)
+			mset, err = acc.addStreamWithAssignment(sa.Config, nil, sa, false, true)
 		}
 		if mset != nil {
 			mset.setCreatedTime(created)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7860,13 +7860,7 @@ func (js *jetStream) tieredStreamAndReservationCount(accName, tier string, cfg *
 		if tier == _EMPTY_ || isSameTier(sa.Config.Replicas, cfg.Replicas) {
 			numStreams++
 			if sa.Config.MaxBytes > 0 && sa.Config.Storage == cfg.Storage {
-				// If tier is empty, all storage is flat and we should adjust for replicas.
-				// Otherwise if tiered, storage replication already taken into consideration.
-				if tier == _EMPTY_ && sa.Config.Replicas > 1 {
-					reservation = addSaturate(reservation, mulSaturate(int64(sa.Config.Replicas), sa.Config.MaxBytes))
-				} else {
-					reservation = addSaturate(reservation, sa.Config.MaxBytes)
-				}
+				reservation = addSaturate(reservation, accountReservation(tier, sa.Config.Replicas, sa.Config.MaxBytes))
 			}
 		}
 	}
@@ -7942,7 +7936,7 @@ func (js *jetStream) jsClusteredStreamLimitsCheck(acc *Account, cfg *StreamConfi
 		return NewJSMaximumStreamsLimitError()
 	}
 	// Check for account limits here before proposing.
-	if err := js.checkAccountLimits(selectedLimits, cfg, reservations); err != nil {
+	if err := js.checkAccountLimits(selectedLimits, tier, cfg, reservations); err != nil {
 		return NewJSStreamLimitsError(err, Unless(err))
 	}
 	return nil

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -3923,6 +3923,59 @@ func TestJetStreamClusterConfigUpdateCheckOverLimitStreamCanShrink(t *testing.T)
 	require_NoError(t, err)
 }
 
+func TestJetStreamClusterAccountReservationsRecoveryOfOverLimitStream(t *testing.T) {
+	c := createJetStreamClusterWithTemplate(t, jsClusterMaxBytesAccountLimitTempl, "C1", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	const GB = 1024 * 1024 * 1024
+
+	// R3 * 1GB = 3GB fills the un-tiered 3GB account limit exactly.
+	cfg := &nats.StreamConfig{
+		Name:     "S",
+		Subjects: []string{"s"},
+		Replicas: 3,
+		MaxBytes: 1 * GB,
+	}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+	c.waitOnStreamLeader("$U", "S")
+	nc.Close()
+
+	// Pick a non-leader, wipe its local state, and restart it.
+	rs := c.randomNonStreamLeader("$U", "S")
+	require_NotNil(t, rs)
+
+	// Persist the lowered limit into the server's config file so the restarted
+	// peer comes up with max_file: 1GB instead of the original 3GB.
+	opts := rs.getOpts()
+	cfile := opts.ConfigFile
+	conf, err := os.ReadFile(cfile)
+	require_NoError(t, err)
+	newConf := strings.ReplaceAll(string(conf), "max_file:  3GB", "max_file:  1GB")
+	require_True(t, newConf != string(conf))
+	require_NoError(t, os.WriteFile(cfile, []byte(newConf), 0644))
+
+	rs.Shutdown()
+	removeDir(t, opts.StoreDir)
+
+	// Prior to the recovery-path fix, addStreamWithAssignment was called with
+	// recovering=false here, so the post-fix account check rejected this
+	// already-over-the-limit stream and the wiped peer never re-materialized it.
+	rs = c.restartServer(rs)
+	c.waitOnAllCurrent()
+	c.waitOnStreamLeader("$U", "S")
+	c.waitOnStreamCurrent(rs, "$U", "S")
+
+	// Check that the stream actually exists.
+	acc, err := rs.LookupAccount("$U")
+	require_NoError(t, err)
+	_, err = acc.lookupStream("S")
+	require_NoError(t, err)
+}
+
 func TestJetStreamClusterConcurrentAccountLimits(t *testing.T) {
 	c := createJetStreamClusterWithTemplate(t, jsClusterMaxBytesAccountLimitTempl, "cluster", 3)
 	defer c.shutdown()

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -3788,6 +3788,141 @@ func TestJetStreamClusterAccountReservations(t *testing.T) {
 	test(t, 1)
 }
 
+func TestJetStreamClusterAccountReservationsCreateUpdateConsistency(t *testing.T) {
+	c := createJetStreamClusterWithTemplate(t, jsClusterMaxBytesAccountLimitTempl, "C1", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// The account has an un-tiered limit of max_file: 3GB. In an un-tiered setup the account
+	// limit is "flat", so a stream is counted as Replicas*MaxBytes (see tieredReservation and
+	// tieredStreamAndReservationCount). An R3 stream therefore reserves 3*MaxBytes, and the
+	// create and update paths must agree on that accounting. The effective limit must not
+	// differ depending on whether the stream is being created or already exists.
+	const GB = 1024 * 1024 * 1024
+
+	// R3 * 3GB = 9GB exceeds the 3GB account limit, so create must be rejected,
+	// consistent with how the stream is accounted for once it exists.
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "S1",
+		Subjects: []string{"s1"},
+		Replicas: 3,
+		MaxBytes: 3 * GB,
+	})
+	require_Error(t, err, NewJSStorageResourcesExceededError())
+
+	// R1 * 3GB = 3GB fits the account limit exactly.
+	cfg := &nats.StreamConfig{
+		Name:     "S",
+		Subjects: []string{"s"},
+		Replicas: 1,
+		MaxBytes: 3 * GB,
+	}
+	_, err = js.AddStream(cfg)
+	require_NoError(t, err)
+
+	// A no-op update of the same config must still be accepted.
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+	require_NoError(t, js.DeleteStream(cfg.Name))
+
+	// R3 * 1GB = 3GB fits the account limit exactly.
+	cfg = &nats.StreamConfig{
+		Name:     "S",
+		Subjects: []string{"s"},
+		Replicas: 3,
+		MaxBytes: 1 * GB,
+	}
+	_, err = js.AddStream(cfg)
+	require_NoError(t, err)
+
+	// A no-op update of the same config must still be accepted.
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+
+	// Growing the stream past the account limit must be rejected on update,
+	// just as the equivalent create would be.
+	cfg.MaxBytes++
+	_, err = js.UpdateStream(cfg)
+	require_Error(t, err, NewJSStorageResourcesExceededError())
+}
+
+func TestJetStreamClusterConfigUpdateCheckReplicaScalingReservation(t *testing.T) {
+	c := createJetStreamClusterWithTemplate(t, jsClusterMaxBytesAccountLimitTempl, "C1", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// The account has an un-tiered limit of max_file: 3GB.
+	const GB = 1024 * 1024 * 1024
+
+	// R3 * 1GB = 3GB fills the account limit exactly.
+	cfg := &nats.StreamConfig{
+		Name:     "S",
+		Subjects: []string{"s"},
+		Replicas: 3,
+		MaxBytes: 1 * GB,
+	}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	// Scale down to R1 while raising MaxBytes to 2GB. The new footprint
+	// R1 * 2GB = 2GB fits the 3GB account limit, just as creating R1 * 2GB
+	// from scratch would.
+	cfg.Replicas = 1
+	cfg.MaxBytes = 2 * GB
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+
+	require_NoError(t, js.DeleteStream(cfg.Name))
+	_, err = js.AddStream(cfg)
+	require_NoError(t, err)
+}
+
+func TestJetStreamClusterConfigUpdateCheckOverLimitStreamCanShrink(t *testing.T) {
+	c := createJetStreamClusterWithTemplate(t, jsClusterMaxBytesAccountLimitTempl, "C1", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	const GB = 1024 * 1024 * 1024
+
+	// R3 * 1GB = 3GB fills the un-tiered 3GB account limit exactly.
+	cfg := &nats.StreamConfig{
+		Name:     "S",
+		Subjects: []string{"s"},
+		Replicas: 3,
+		MaxBytes: 1 * GB,
+	}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	// Make the stream "pre-existing and over the limit" by lowering the
+	// account's un-tiered file limit below the stream's 3GB footprint.
+	for _, s := range c.servers {
+		acc, err := s.LookupAccount("$U")
+		require_NoError(t, err)
+		require_NoError(t, acc.UpdateJetStreamLimits(map[string]JetStreamAccountLimits{
+			_EMPTY_: {MaxMemory: 128 * 1024 * 1024, MaxStore: 1 * GB, MaxStreams: -1, MaxConsumers: -1},
+		}))
+	}
+
+	// Growing it further must still be rejected: the account is already over.
+	cfg.MaxBytes = 2 * GB
+	_, err = js.UpdateStream(cfg)
+	require_Error(t, err, NewJSStorageResourcesExceededError())
+
+	// Shrinking it must be accepted: the new footprint R3 * 0.25GB = 0.75GB is
+	// within the lowered 1GB limit. The pre-fix accounting added back the old
+	// 3GB footprint and wrongly rejected this, leaving the account unfixable.
+	cfg.MaxBytes = GB / 4
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+}
+
 func TestJetStreamClusterConcurrentAccountLimits(t *testing.T) {
 	c := createJetStreamClusterWithTemplate(t, jsClusterMaxBytesAccountLimitTempl, "cluster", 3)
 	defer c.shutdown()

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -6558,7 +6558,7 @@ func TestJetStreamClusterTieredReservationConsistency(t *testing.T) {
 
 func TestJetStreamClusterTieredReservationOverflow(t *testing.T) {
 	tmpl := strings.Replace(jsClusterMaxBytesAccountLimitTempl, "max_file_store: 4GB", "max_file_store: 9223372036854775807", 1)
-	tmpl = strings.Replace(tmpl, "max_file:  3GB", "max_file:  5000000000000000000", 1)
+	tmpl = strings.Replace(tmpl, "max_file:  3GB", "max_file:  9223372036854775807", 1)
 	c := createJetStreamClusterWithTemplate(t, tmpl, "R3S", 3)
 	defer c.shutdown()
 
@@ -6568,8 +6568,8 @@ func TestJetStreamClusterTieredReservationOverflow(t *testing.T) {
 	// Create a stream with R=3 and MaxBytes large enough that
 	// Replicas * MaxBytes overflows int64:
 	//   3 * 4e18 = 12e18 > MaxInt64 (9.22e18)
-	// The first stream passes the limit check because there are no
-	// existing reservations: 0 + 4e18 < 5e18 (account limit).
+	// The account limit is MaxInt64, so the first stream is accepted: its
+	// reservation saturates to MaxInt64 rather than wrapping negative.
 	_, err := js.AddStream(&nats.StreamConfig{
 		Name:     "S1",
 		Subjects: []string{"s1"},
@@ -6578,9 +6578,9 @@ func TestJetStreamClusterTieredReservationOverflow(t *testing.T) {
 	})
 	require_NoError(t, err)
 
-	// The true reservation for S1 is 3 * 4e18 = 12e18, which already
-	// exceeds the account limit of 5e18. Creating any additional stream
-	// should be rejected. With the overflow bug, the reservation
+	// The true reservation for S1 is 3 * 4e18 = 12e18, which saturates to
+	// MaxInt64 and consumes the whole account. Creating any additional
+	// stream should be rejected. With the overflow bug, the reservation
 	// computation wraps to a negative value, making the account appear
 	// to have plenty of room.
 	_, err = js.AddStream(&nats.StreamConfig{

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -3109,12 +3109,12 @@ func TestJetStreamCheckBytesLimitsOverflow(t *testing.T) {
 	// hdr.Size and can be non-zero when addBytes is near MaxInt64.
 	// Previously this silently wrapped negative, bypassing the limit.
 	js.mu.RLock()
-	err := js.checkBytesLimits(limits, math.MaxInt64, FileStorage, false, 0, 1)
+	err := js.checkBytesLimits(limits, _EMPTY_, math.MaxInt64, 1, FileStorage, false, 0, 1)
 	js.mu.RUnlock()
 	require_Error(t, err)
 
 	js.mu.RLock()
-	err = js.checkBytesLimits(limits, math.MaxInt64, MemoryStorage, false, 0, 1)
+	err = js.checkBytesLimits(limits, _EMPTY_, math.MaxInt64, 1, MemoryStorage, false, 0, 1)
 	js.mu.RUnlock()
 	require_Error(t, err)
 
@@ -3125,7 +3125,7 @@ func TestJetStreamCheckBytesLimitsOverflow(t *testing.T) {
 	js.mu.Unlock()
 
 	js.mu.RLock()
-	err = js.checkBytesLimits(limits, 2, FileStorage, true, 0, 0)
+	err = js.checkBytesLimits(limits, _EMPTY_, 2, 1, FileStorage, true, 0, 0)
 	js.mu.RUnlock()
 	require_Error(t, err)
 
@@ -3140,13 +3140,49 @@ func TestJetStreamCheckBytesLimitsOverflow(t *testing.T) {
 	js.mu.Unlock()
 
 	js.mu.RLock()
-	err = js.checkBytesLimits(limits, 2, MemoryStorage, true, 0, 0)
+	err = js.checkBytesLimits(limits, _EMPTY_, 2, 1, MemoryStorage, true, 0, 0)
 	js.mu.RUnlock()
 	require_Error(t, err)
 
 	js.mu.Lock()
 	js.memReserved = origMem
 	js.mu.Unlock()
+}
+
+func TestJetStreamAccountReservation(t *testing.T) {
+	const maxInt64 = int64(math.MaxInt64)
+	for _, test := range []struct {
+		name     string
+		tier     string
+		replicas int
+		bytes    int64
+		expected int64
+	}{
+		// Non-positive bytes never reserve anything, regardless of tier/replicas.
+		{"zero bytes", _EMPTY_, 3, 0, 0},
+		{"negative bytes untiered", _EMPTY_, 3, -100, 0},
+		{"negative bytes tiered", "R3", 3, -1, 0},
+		// Un-tiered (flat) account limit: an R>1 stream counts as Replicas*bytes.
+		{"untiered R1", _EMPTY_, 1, 100, 100},
+		{"untiered R0 treated as single", _EMPTY_, 0, 100, 100},
+		{"untiered R3", _EMPTY_, 3, 100, 300},
+		{"untiered R5", _EMPTY_, 5, 100, 500},
+		// Tiered account limit: replication is baked into the tier, counted as-is.
+		{"tiered R1", "R1", 1, 100, 100},
+		{"tiered R3", "R3", 3, 100, 100},
+		// Replicas*bytes saturates at MaxInt64 instead of overflowing.
+		{"untiered R3 saturates", _EMPTY_, 3, maxInt64, maxInt64},
+		{"untiered R2 saturates", _EMPTY_, 2, maxInt64/2 + 1, maxInt64},
+		// Tiered does not multiply, so large bytes pass through untouched.
+		{"tiered large no multiply", "R3", 3, maxInt64, maxInt64},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := accountReservation(test.tier, test.replicas, test.bytes); got != test.expected {
+				t.Fatalf("accountReservation(%q, %d, %d) = %d, want %d",
+					test.tier, test.replicas, test.bytes, got, test.expected)
+			}
+		})
+	}
 }
 
 func TestJetStreamSnapshots(t *testing.T) {

--- a/server/stream.go
+++ b/server/stream.go
@@ -818,7 +818,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 		if isClustered {
 			_, reserved = js.tieredStreamAndReservationCount(a.Name, tier, cfg)
 		}
-		if err := js.checkAllLimits(&selected, cfg, reserved, 0); err != nil {
+		if err := js.checkAllLimits(&selected, tier, cfg, reserved, 0); err != nil {
 			js.mu.RUnlock()
 			return nil, err
 		}
@@ -2342,11 +2342,10 @@ func (jsa *jsAccount) configUpdateCheck(old, new *StreamConfig, s *Server, pedan
 
 	// Save the user configured MaxBytes.
 	newMaxBytes := cfg.MaxBytes
-	maxBytesOffset := int64(0)
 
 	// We temporarily set cfg.MaxBytes to maxBytesDiff because checkAllLimits
 	// adds cfg.MaxBytes to the current reserved limit and checks if we've gone
-	// over. However, we don't want an addition cfg.MaxBytes, we only want to
+	// over. However, we don't want an additional cfg.MaxBytes, we only want to
 	// reserve the difference between the new and the old values.
 	cfg.MaxBytes = maxBytesDiff
 
@@ -2373,15 +2372,13 @@ func (jsa *jsAccount) configUpdateCheck(old, new *StreamConfig, s *Server, pedan
 	if isClustered {
 		_, reserved = js.tieredStreamAndReservationCount(acc.Name, tier, &cfg)
 	}
-	// reservation does not account for this stream, hence add the old value
-	if old.MaxBytes > 0 {
-		if tier == _EMPTY_ && old.Replicas > 1 {
-			reserved = addSaturate(reserved, mulSaturate(int64(old.Replicas), old.MaxBytes))
-		} else {
-			reserved = addSaturate(reserved, old.MaxBytes)
-		}
-	}
-	if err := js.checkAllLimits(&selected, &cfg, reserved, maxBytesOffset); err != nil {
+	// reserved covers only the other streams. checkAllLimits adds this stream's
+	// footprint via cfg.MaxBytes, which is currently maxBytesDiff, so it only
+	// adds the diff. Add the remaining (newMaxBytes - maxBytesDiff) here so the
+	// two together equal this stream's true new footprint, even when Replicas
+	// changes on update.
+	reserved = addSaturate(reserved, accountReservation(tier, cfg.Replicas, newMaxBytes-maxBytesDiff))
+	if err := js.checkAllLimits(&selected, tier, &cfg, reserved, 0); err != nil {
 		return nil, err
 	}
 	// Restore the user configured MaxBytes.
@@ -9051,7 +9048,7 @@ func (a *Account) RestoreStream(ncfg *StreamConfig, r io.Reader) (*stream, error
 		}
 		bc += hdr.Size
 		js.mu.RLock()
-		err = js.checkAllLimits(&selected, &cfg, reserved, bc)
+		err = js.checkAllLimits(&selected, tier, &cfg, reserved, bc)
 		js.mu.RUnlock()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Centralize the un-tiered `Replicas*MaxBytes` account calculation in a single `accountReservation` helper so stream create, update, and limit checks agree on a stream's footprint. Previously, create under-counted (an R3 stream was charged only `MaxBytes`, then immediately appeared over-limit once stored), and update used the old replica count when adding the stream's existing footprint back, so legitimate scaling updates were wrongly rejected and over-limit streams couldn't be shrunk back into compliance.

Also flips the clustered stream recreation path (`processClusterCreateStream`) to recovering mode, so an existing stream, including one silently over-committed under the old check, still materializes on a peer rebuilding state (peer rejoin after disk loss, snapshot install, peer add). Without this, the corrected account check would reject the rebuild and the cluster could not heal.

Note: clusters that had silently over-committed un-tiered streams under the old check may now see new creates or grows on those accounts rejected. Shrinking such streams is still allowed. Streams can still recover properly on startup, ignoring the new limit even if they would now exceed it.