### PR TITLE
server: fix nil pointer dereference in DirJWTStore.Pack filepath.Walk callback

### DIFF
--- a/server/dirstore.go
+++ b/server/dirstore.go
@@ -230,7 +230,7 @@ func (store *DirJWTStore) Pack(maxJWTs int) (string, error) {
 	}
 	store.Lock()
 	err := filepath.Walk(store.directory, func(path string, info os.FileInfo, err error) error {
-		if !info.IsDir() && strings.HasSuffix(path, fileExtension) { // this is a JWT
+		if info != nil && !info.IsDir() && strings.HasSuffix(path, fileExtension) { // this is a JWT
 			if count == maxJWTs { // won't match negative
 				return nil
 			}


### PR DESCRIPTION
The `Pack` method's `filepath.Walk` callback accesses `info.IsDir()` without first checking if `info` is nil. Per Go's [`filepath.Walk` documentation](https://pkg.go.dev/path/filepath#WalkFunc), the `FileInfo` argument can be nil when the walk encounters an error (e.g., permission denied on `os.Lstat`, broken symlink). This causes a nil pointer dereference panic.

The sibling function `PackWalk` in the same file already guards against this correctly with `info != nil && !info.IsDir()`, so this applies the same pattern to `Pack`.
