### PR TITLE
NRG: Decouple Raft transport layer

### DIFF
--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -1806,7 +1806,7 @@ func TestJetStreamJWTClusterAccountNRG(t *testing.T) {
 			checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
 				for _, rg := range raftNodes {
 					rg.Lock()
-					rgAcc := rg.acc
+					rgAcc := rg.t.Account()
 					rg.Unlock()
 					want := syspub
 					if state == "owner" {
@@ -1831,7 +1831,7 @@ func TestJetStreamJWTClusterAccountNRG(t *testing.T) {
 			// in-account or not.
 			for _, rg := range raftNodes {
 				rg.Lock()
-				rgAcc := rg.acc
+				rgAcc := rg.t.Account()
 				rg.Unlock()
 				switch state {
 				case "system":
@@ -1932,7 +1932,7 @@ func TestJetStreamJWTClusterAccountNRGPersistsAfterRestart(t *testing.T) {
 
 		for _, rg := range raftNodes {
 			rg.Lock()
-			rgAcc := rg.acc
+			rgAcc := rg.t.Account()
 			rg.Unlock()
 			require_Equal(t, rgAcc.Name, aExpPub)
 			require_Equal(t, rza[rg.group].SystemAcc, false)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -4250,7 +4250,7 @@ func (s *Server) Raftz(opts *RaftzOptions) *RaftzStatus {
 			PTerm:         n.pterm,
 			PIndex:        n.pindex,
 			SystemAcc:     n.IsSystemAccount(),
-			TrafficAcc:    n.acc.GetName(),
+			TrafficAcc:    n.t.Account().GetName(),
 			IPQPropLen:    n.prop.len(),
 			IPQEntryLen:   n.entry.len(),
 			IPQRespLen:    n.resp.len(),

--- a/server/raft.go
+++ b/server/raft.go
@@ -154,7 +154,6 @@ type raft struct {
 
 	created time.Time      // Time that the group was created
 	accName string         // Account name of the asset this raft group is for
-	acc     *Account       // Account that NRG traffic will be sent/received in
 	group   string         // Raft group
 	sd      string         // Store directory
 	id      string         // Node ID
@@ -201,7 +200,6 @@ type raft struct {
 	vote   string // Our current vote state
 
 	s  *Server    // Reference to top-level server
-	c  *client    // Internal client for subscriptions
 	js *jetStream // JetStream, if running, to see if we are out of resources
 
 	hasleader atomic.Bool // Is there a group leader right now?
@@ -220,7 +218,7 @@ type raft struct {
 	asubj  string // Append entries subject
 	areply string // Append entries responses subject
 
-	sq    *sendq        // Send queue for outbound RPC messages
+	t     raftTransport // Transport that handles Raft messaging
 	aesub *subscription // Subscription for handleAppendEntry callbacks
 
 	wtv []byte // Term and vote to be written
@@ -323,6 +321,11 @@ type RaftConfig struct {
 	// We need to protect against losing state due to the new peers starting with an empty log.
 	// Therefore, these empty servers can't try to become leader until they at least have _some_ state.
 	ScaleUp bool
+
+	// NewTransport creates the transport used for Raft node communication.
+	// This is mainly for tests to inject a custom transport.
+	// If nil, the default transport is used.
+	NewTransport newTransportFunc
 }
 
 var (
@@ -463,6 +466,12 @@ func (s *Server) initRaftNode(accName string, cfg *RaftConfig, labels pprofLabel
 		accName:  accName,
 		leadc:    make(chan bool, 32),
 		observer: cfg.Observer,
+	}
+
+	if cfg.NewTransport != nil {
+		n.t = cfg.NewTransport(s, n)
+	} else {
+		n.t = defaultRaftTransport(s, n)
 	}
 
 	// Setup our internal subscriptions for proposals, votes and append entries.
@@ -659,7 +668,10 @@ func (n *raft) IsSystemAccount() bool {
 func (n *raft) GetTrafficAccountName() string {
 	n.RLock()
 	defer n.RUnlock()
-	return n.acc.GetName()
+	if n.t == nil {
+		return (*Account)(nil).GetName()
+	}
+	return n.t.Account().GetName()
 }
 
 func (n *raft) RecreateInternalSubs() error {
@@ -709,7 +721,7 @@ func (n *raft) recreateInternalSubsLocked() error {
 			}
 		}
 	}
-	if n.aesub != nil && n.acc == nrgAcc {
+	if n.aesub != nil && n.t.Account() == nrgAcc {
 		// Subscriptions already exist and the account NRG state
 		// hasn't changed.
 		return nil
@@ -720,33 +732,11 @@ func (n *raft) recreateInternalSubsLocked() error {
 	// the next step...
 	n.cancelCatchup()
 
-	// If we have an existing client then tear down any existing
-	// subscriptions and close the internal client.
-	if c := n.c; c != nil {
-		c.mu.Lock()
-		subs := make([]*subscription, 0, len(c.subs))
-		for _, sub := range c.subs {
-			subs = append(subs, sub)
-		}
-		c.mu.Unlock()
-		for _, sub := range subs {
-			n.unsubscribe(sub)
-		}
-		c.closeConnection(InternalClient)
-	}
-
-	if n.acc != nrgAcc {
+	if n.t.Account() != nrgAcc {
 		n.debug("Subscribing in '%s'", nrgAcc.GetName())
 	}
 
-	c := n.s.createInternalSystemClient()
-	c.registerWithAccount(nrgAcc)
-	if nrgAcc.sq == nil {
-		nrgAcc.sq = n.s.newSendQ(nrgAcc)
-	}
-	n.c = c
-	n.sq = nrgAcc.sq
-	n.acc = nrgAcc
+	n.t.Reset(nrgAcc)
 
 	// Recreate any internal subscriptions for voting, append
 	// entries etc in the new account.
@@ -2351,17 +2341,12 @@ func (n *raft) newInbox() string {
 // Our internal subscribe.
 // Lock should be held.
 func (n *raft) subscribe(subject string, cb msgHandler) (*subscription, error) {
-	if n.c == nil {
-		return nil, errNoInternalClient
-	}
-	return n.s.systemSubscribe(subject, _EMPTY_, false, n.c, cb)
+	return n.t.Subscribe(subject, cb)
 }
 
 // Lock should be held.
 func (n *raft) unsubscribe(sub *subscription) {
-	if n.c != nil && sub != nil {
-		n.c.processUnsub(sub.sid)
-	}
+	n.t.Unsubscribe(sub)
 }
 
 // Lock should be held.
@@ -2486,19 +2471,7 @@ runner:
 	n.Lock()
 	defer n.Unlock()
 
-	if c := n.c; c != nil {
-		var subs []*subscription
-		c.mu.Lock()
-		for _, sub := range c.subs {
-			subs = append(subs, sub)
-		}
-		c.mu.Unlock()
-		for _, sub := range subs {
-			n.unsubscribe(sub)
-		}
-		c.closeConnection(InternalClient)
-		n.c = nil
-	}
+	n.t.Close()
 
 	// Unregistering ipQueues do not prevent them from push/pop
 	// just will remove them from the central monitoring map
@@ -5288,15 +5261,11 @@ func (n *raft) requestVote() {
 }
 
 func (n *raft) sendRPC(subject, reply string, msg []byte) {
-	if n.sq != nil {
-		n.sq.send(subject, reply, nil, msg)
-	}
+	n.t.Publish(subject, reply, msg)
 }
 
 func (n *raft) sendReply(subject string, msg []byte) {
-	if n.sq != nil {
-		n.sq.send(subject, _EMPTY_, nil, msg)
-	}
+	n.t.Publish(subject, _EMPTY_, msg)
 }
 
 func (n *raft) wonElection(votes int) bool {

--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -57,7 +57,7 @@ func (sg smGroup) leader() stateMachine {
 	return nil
 }
 
-func (sg smGroup) followers() []stateMachine {
+func (sg smGroup) followers() smGroup {
 	var f []stateMachine
 	for _, sm := range sg {
 		if sm.node().Leader() {

--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -126,21 +126,26 @@ func (sg smGroup) lockFollowers() []stateMachine {
 // Create a raft group and place on numMembers servers at random.
 // Filestore based.
 func (c *cluster) createRaftGroup(name string, numMembers int, smf smFactory) smGroup {
-	return c.createRaftGroupEx(name, numMembers, smf, FileStorage)
+	return c.createRaftGroupEx(name, numMembers, smf, defaultRaftTransport, FileStorage)
 }
 
 func (c *cluster) createMemRaftGroup(name string, numMembers int, smf smFactory) smGroup {
-	return c.createRaftGroupEx(name, numMembers, smf, MemoryStorage)
+	return c.createRaftGroupEx(name, numMembers, smf, defaultRaftTransport, MemoryStorage)
 }
 
-func (c *cluster) createRaftGroupEx(name string, numMembers int, smf smFactory, st StorageType) smGroup {
+func (c *cluster) createMockMemRaftGroup(name string, members int, smf smFactory) (*raftTransportHub, smGroup) {
+	hub := newRaftTransportHub()
+	return hub, c.createRaftGroupEx(name, members, smf, hub.newTransport, MemoryStorage)
+}
+
+func (c *cluster) createRaftGroupEx(name string, numMembers int, smf smFactory, rtf newTransportFunc, st StorageType) smGroup {
 	c.t.Helper()
 	if numMembers > len(c.servers) {
 		c.t.Fatalf("Members > Peers: %d vs  %d", numMembers, len(c.servers))
 	}
 	servers := append([]*Server{}, c.servers...)
 	rand.Shuffle(len(servers), func(i, j int) { servers[i], servers[j] = servers[j], servers[i] })
-	return c.createRaftGroupWithPeers(name, servers[:numMembers], smf, st)
+	return c.createRaftGroupWithPeers(name, servers[:numMembers], smf, rtf, st)
 }
 
 func (c *cluster) createWAL(name string, st StorageType) WAL {
@@ -189,7 +194,7 @@ func (c *cluster) createStateMachine(s *Server, cfg *RaftConfig, peers []string,
 	return sm
 }
 
-func (c *cluster) createRaftGroupWithPeers(name string, servers []*Server, smf smFactory, st StorageType) smGroup {
+func (c *cluster) createRaftGroupWithPeers(name string, servers []*Server, smf smFactory, rtf newTransportFunc, st StorageType) smGroup {
 	c.t.Helper()
 
 	var sg smGroup
@@ -197,9 +202,10 @@ func (c *cluster) createRaftGroupWithPeers(name string, servers []*Server, smf s
 
 	for _, s := range servers {
 		cfg := &RaftConfig{
-			Name:  name,
-			Store: c.t.TempDir(),
-			Log:   c.createWAL(name, st)}
+			Name:         name,
+			Store:        c.t.TempDir(),
+			Log:          c.createWAL(name, st),
+			NewTransport: rtf}
 		sg = append(sg, c.createStateMachine(s, cfg, peers, smf))
 	}
 
@@ -208,26 +214,31 @@ func (c *cluster) createRaftGroupWithPeers(name string, servers []*Server, smf s
 	return sg
 }
 
-func (c *cluster) addNodeEx(name string, smf smFactory, st StorageType) stateMachine {
+func (c *cluster) addNodeEx(name string, smf smFactory, rtf newTransportFunc, st StorageType) stateMachine {
 	c.t.Helper()
 
 	server := c.addInNewServer()
 
 	cfg := &RaftConfig{
-		Name:  name,
-		Store: c.t.TempDir(),
-		Log:   c.createWAL(name, st)}
+		Name:         name,
+		Store:        c.t.TempDir(),
+		Log:          c.createWAL(name, st),
+		NewTransport: rtf}
 
 	peers := serverPeerNames(c.servers)
 	return c.createStateMachine(server, cfg, peers, smf)
 }
 
 func (c *cluster) addRaftNode(name string, smf smFactory) stateMachine {
-	return c.addNodeEx(name, smf, FileStorage)
+	return c.addNodeEx(name, smf, defaultRaftTransport, FileStorage)
 }
 
 func (c *cluster) addMemRaftNode(name string, smf smFactory) stateMachine {
-	return c.addNodeEx(name, smf, MemoryStorage)
+	return c.addNodeEx(name, smf, defaultRaftTransport, MemoryStorage)
+}
+
+func (c *cluster) addMockMemRaftNode(name string, hub *raftTransportHub, smf smFactory) stateMachine {
+	return c.addNodeEx(name, smf, hub.newTransport, MemoryStorage)
 }
 
 // Driver program for the state machine.

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -7100,3 +7100,153 @@ func TestNRGPartitionedPeerRemove(t *testing.T) {
 		return nil
 	})
 }
+
+func TestNRGPeerAddAndPartitionLeader(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	hub, rg := c.createMockMemRaftGroup("MOCK", 3, newStateAdder)
+
+	leader := rg.waitOnLeader()
+	followers := rg.followers()
+
+	// When the leader sends a EntryAddPeer, isolate it from
+	// the rest of the cluster.
+	hub.setAfterMsgHook(func(subject, reply string, msg []byte) {
+		if subject != "$NRG.AE.MOCK" {
+			return
+		}
+		ae, _ := decodeAppendEntry(msg, nil, reply)
+		if ae == nil || len(ae.entries) != 1 {
+			return
+		}
+		if ae.leader != leader.node().ID() {
+			return
+		}
+		if ae.entries[0].Type == EntryAddPeer {
+			hub.partition(leader.node().ID(), 1)
+		}
+	})
+
+	// Add a new node and expect a new leader to be elected
+	newNode := c.addMockMemRaftNode("MOCK", hub, newStateAdder)
+	newGroup := append(followers, newNode)
+	newLeader := newGroup.waitOnLeader()
+	require_True(t, newLeader != nil)
+
+	// If bug is present: The new leader has not yet committed the
+	// appendEntry containing EntryAddPeer. The new leader (and
+	// followers) would not update their cluster size until the
+	// EntryAddPeer was committed, allowing the following
+	// sequence of events:
+	// 1) the new leader has initially cluster size of 3
+	// 2) it sends a peerState message with cluster size 3
+	// 3) the leader commits the EntryAddPeer from the previous
+	//    leader, and adjusts its cluster size to 4.
+	// 4) the followers commit the EntryAddPeer, incrementing
+	//    their cluster size to 4. Next, the EntryPeerState is
+	//    committed and the cluster size goes back to 3.
+	// 5) At this point cluster size from the leader has diverged
+	//    from the cluster size of its followers.
+
+	// Expect all nodes to report cluster size of 4
+	for _, n := range newGroup {
+		checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+			if n.node().ClusterSize() != 4 {
+				return errors.New("node addition still in progress")
+			}
+			return nil
+		})
+	}
+
+	// Finally bring back the old leader
+	hub.healPartitions()
+	checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+		if leader.node().MembershipChangeInProgress() {
+			return errors.New("membership still in progress")
+		}
+		if leader.node().ClusterSize() != 4 {
+			return errors.New("node addition still in progress")
+		}
+		return nil
+	})
+
+	for _, n := range newGroup {
+		checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+			if n.node().ClusterSize() != 4 {
+				return errors.New("node addition still in progress")
+			}
+			return nil
+		})
+	}
+
+}
+
+func TestNRGLeaderWithoutQuorumAfterPeerAdd(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	hub, rg := c.createMockMemRaftGroup("MOCK", 3, newStateAdder)
+	defer hub.healPartitions()
+
+	leader := rg.waitOnLeader()
+	followers := rg.followers()
+
+	// Setup a after message hook to create a partition as soon as
+	// the leader publishes a EntryAddPeer. The partition will
+	// prevent committing the entry.
+	hub.setAfterMsgHook(func(subject, reply string, msg []byte) {
+		if subject != "$NRG.AE.MOCK" {
+			return
+		}
+		ae, _ := decodeAppendEntry(msg, nil, reply)
+		if ae == nil || len(ae.entries) != 1 {
+			return
+		}
+		if ae.leader != leader.node().ID() {
+			return
+		}
+
+		// After EntryAddPeer is published, partition the
+		// leader and one of the followers. This partition
+		// can't commit the entry.
+		if ae.entries[0].Type == EntryAddPeer {
+			hub.partition(leader.node().ID(), 1)
+			hub.partition(followers[0].node().ID(), 1)
+		}
+	})
+
+	newNode := c.addMockMemRaftNode("MOCK", hub, newStateAdder)
+
+	// At some point here the cluster gets partitioned in two
+	// parts: {leader, followers[0]} and {newNode, followers[1]}.
+	// Neither side should be able to make progress.
+	newGroup := smGroup{newNode, followers[1]}
+	newLeader := newGroup.waitOnLeader()
+
+	// If the bug is present: we managed to elect a new leader,
+	// in a 4 node cluster, with only two nodes in the partition!
+	// This is because of the following sequence of events:
+	// 1) the follower has received the EntryPeerAdd
+	// 2) the leader and the other follower have partitioned away
+	// 3) the entry is uncommitted, however the follower has added
+	///   the new peer to its peer set, but won't adjust cluster
+	//    size and quorum until after the entry is committed.
+	// 4) follower becomes a canditate and will become leader with
+	//    a single vote from the new node
+	require_Equal(t, newLeader, nil)
+
+	// Check that node addition completes after healing the partition
+	hub.healPartitions()
+	rg = append(rg, newNode)
+	newLeader = rg.waitOnLeader()
+	require_True(t, newLeader != nil)
+	for _, n := range rg {
+		checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+			if n.node().ClusterSize() != 4 {
+				return errors.New("node addition still in progress")
+			}
+			return nil
+		})
+	}
+}

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -28,6 +28,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -7039,4 +7040,63 @@ func TestNRGProcessAppendEntryResponseTermRace(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 	close(stop)
 	wg.Wait()
+}
+
+func TestNRGPartitionedPeerRemove(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R2S", 2)
+	defer c.shutdown()
+
+	hub, rg := c.createMockMemRaftGroup("MOCK", 2, newStateAdder)
+	defer hub.healPartitions()
+
+	leader := rg.waitOnLeader().node()
+	require_Equal(t, leader.ClusterSize(), 2)
+	require_Equal(t, len(rg.followers()), 1)
+	follower := rg.followers()[0].node()
+
+	var hookCalls atomic.Int64
+	hub.setAfterMsgHook(func(subject, reply string, msg []byte) {
+		hookCalls.Add(1)
+	})
+
+	// Remove the follower while the leader is partitioned away
+	hub.partition(leader.ID(), 1)
+	leader.ProposeRemovePeer(follower.ID())
+
+	// Follower can't get elected as leader, but let's try anyway
+	follower.CampaignImmediately()
+
+	// Expect progress on the leader side
+	checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+		if leader.ClusterSize() != 1 {
+			return errors.New("node removal still in progress")
+		}
+		return nil
+	})
+
+	checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+		if leader.MembershipChangeInProgress() {
+			return errors.New("membership still in progress")
+		}
+		return nil
+	})
+
+	require_Equal(t, leader.ClusterSize(), 1)
+	require_False(t, leader.MembershipChangeInProgress())
+	require_True(t, hookCalls.Load() > 0)
+
+	// Follower has not changed
+	require_Equal(t, follower.State(), Follower)
+	require_Equal(t, follower.ClusterSize(), 2)
+	require_False(t, follower.MembershipChangeInProgress())
+
+	// Heal the partition, and expect the follower to get the bad news...
+	hub.heal(leader.ID())
+
+	checkFor(t, 1*time.Second, 10*time.Millisecond, func() error {
+		if follower.ClusterSize() != 1 {
+			return errors.New("node removal still in progress")
+		}
+		return nil
+	})
 }

--- a/server/raft_transport.go
+++ b/server/raft_transport.go
@@ -1,0 +1,114 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+// raftTransport is an interface that defines the communication
+// mechanism for Raft nodes.
+type raftTransport interface {
+	// Node returns the RaftNode associated with this transport.
+	Node() RaftNode
+
+	// Account returns the NATS Account this transport operates within.
+	Account() *Account
+
+	// Reset reconfigures the transport for a new account.
+	// This involves tearing down existing client resources and
+	// setting up new ones for the provided account.
+	Reset(acc *Account)
+
+	// Close shuts down the transport, releasing any associated resources
+	// like internal clients and subscriptions.
+	Close()
+
+	// Publish sends a message to the specified subject.
+	Publish(subject string, reply string, msg []byte)
+
+	// Subscribe creates a subscription for to the specified subject.
+	Subscribe(subject string, cb msgHandler) (*subscription, error)
+
+	// Unsubscribe removes a previously established subscription.
+	Unsubscribe(sub *subscription)
+}
+
+type newTransportFunc func(*Server, RaftNode) raftTransport
+
+// defaultTransport is the default implementation of the raftTransport interface.
+// It uses an internal NATS client to allow communication between Raft nodes.
+type defaultTransport struct {
+	n   RaftNode
+	s   *Server
+	c   *client
+	sq  *sendq
+	acc *Account
+}
+
+func defaultRaftTransport(server *Server, raft RaftNode) raftTransport {
+	return &defaultTransport{s: server, n: raft}
+}
+
+func (t *defaultTransport) Node() RaftNode {
+	return t.n
+}
+
+func (t *defaultTransport) Account() *Account {
+	return t.acc
+}
+
+func (t *defaultTransport) Reset(acc *Account) {
+	t.Close()
+
+	t.c = t.s.createInternalSystemClient()
+	t.c.registerWithAccount(acc)
+	if acc.sq == nil {
+		acc.sq = t.s.newSendQ(acc)
+	}
+	t.sq = acc.sq
+	t.acc = acc
+}
+
+func (t *defaultTransport) Close() {
+	if c := t.c; c != nil {
+		c.mu.Lock()
+		subs := make([]*subscription, 0, len(c.subs))
+		for _, sub := range c.subs {
+			subs = append(subs, sub)
+		}
+		c.mu.Unlock()
+		for _, sub := range subs {
+			t.Unsubscribe(sub)
+		}
+		c.closeConnection(InternalClient)
+		t.c = nil
+	}
+}
+
+func (t *defaultTransport) Publish(subject string, reply string, msg []byte) {
+	if t.sq == nil {
+		return
+	}
+	t.sq.send(subject, reply, nil, msg)
+}
+
+func (t *defaultTransport) Subscribe(subject string, cb msgHandler) (*subscription, error) {
+	if t.c == nil {
+		return nil, errNoInternalClient
+	}
+	return t.s.systemSubscribe(subject, _EMPTY_, false, t.c, cb)
+}
+
+func (t *defaultTransport) Unsubscribe(sub *subscription) {
+	if t.c != nil && sub != nil {
+		t.c.processUnsub(sub.sid)
+	}
+}

--- a/server/raft_transport_helpers_test.go
+++ b/server/raft_transport_helpers_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains mock raft transport implementations and helper functions
+// for testing. The `raftTransportHub` manages multiple `mockTransport` instances,
+// allowing for the simulation of network partitions (`partition`, `heal`)
+// and message interception (`setAfterMsgHook`). This setup is used to test
+// raft interactions without actual network communication, providing control
+// over message delivery and network conditions.
+
+package server
+
+import (
+	"sync"
+)
+
+type msgHook func(subject, reply string, msg []byte)
+
+type raftTransportHub struct {
+	mu         sync.Mutex
+	transports map[string]*mockTransport
+	partitions map[string]int
+	afterMsg   msgHook
+}
+
+func newRaftTransportHub() *raftTransportHub {
+	return &raftTransportHub{
+		partitions: make(map[string]int),
+		transports: make(map[string]*mockTransport),
+	}
+}
+
+func (h *raftTransportHub) newTransport(s *Server, n RaftNode) raftTransport {
+	return &mockTransport{
+		server: s,
+		node:   n,
+		hub:    h,
+	}
+}
+
+func (h *raftTransportHub) register(t *mockTransport) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.transports[t.Node().ID()] = t
+}
+
+func (h *raftTransportHub) unregister(t *mockTransport) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.transports, t.Node().ID())
+}
+
+// Simulate a network partition. Nodes assigned to different `partitionID`s
+// will not be able to exchange messages, effectively isolating them.
+// By default, all nodes are considered to be in partition ID 0.
+// See `heal(nodeID)` and `healPartitions()` to heal a partition.
+func (h *raftTransportHub) partition(nodeID string, partitionID int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.partitions[nodeID] = partitionID
+}
+
+// Reassign the node with the given ID to the default partition 0.
+func (h *raftTransportHub) heal(nodeID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.partitions, nodeID)
+}
+
+// Reassign all nodes to the default partition 0.
+func (h *raftTransportHub) healPartitions() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	clear(h.partitions)
+}
+
+// Set a hook that is called back after a message is published. The after
+// message hook can expect the raftTransportHub to be unlocked. It is OK
+// to interact with the raftTransportHub inside the message hook. On the
+// other hand, the underlying RaftNode that has sent the message remains
+// locked throughout the execution of the hook. The hook can only call
+// methods that do not lock the RaftNode.
+func (h *raftTransportHub) setAfterMsgHook(hook msgHook) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.afterMsg = hook
+}
+
+func (h *raftTransportHub) publish(t *mockTransport, subject, reply string, msg []byte) {
+	h.mu.Lock()
+	afterMsgHook := h.afterMsg
+	sender := t.Node().ID()
+	partition := h.partitions[sender]
+
+	for id, transport := range h.transports {
+		if sender == id {
+			continue
+		}
+
+		if partition != h.partitions[id] {
+			continue
+		}
+
+		res := transport.sub.Match(subject)
+		for _, sub := range res.psubs {
+			sub.icb(sub, nil, transport.acc, subject, reply, msg)
+		}
+	}
+	h.mu.Unlock()
+
+	if afterMsgHook != nil {
+		afterMsgHook(subject, reply, msg)
+	}
+}
+
+type mockTransport struct {
+	server *Server
+	node   RaftNode
+	hub    *raftTransportHub
+	sub    *Sublist
+	acc    *Account
+}
+
+func (t *mockTransport) Reset(acc *Account) {
+	t.Close()
+	t.acc = acc
+	t.sub = NewSublist(false)
+	t.hub.register(t)
+}
+
+func (t *mockTransport) Close() {
+	t.hub.unregister(t)
+	t.sub = nil
+}
+
+func (t *mockTransport) Node() RaftNode {
+	return t.node
+}
+
+func (t *mockTransport) Account() *Account {
+	return t.acc
+}
+
+func (t *mockTransport) Publish(subject string, reply string, msg []byte) {
+	t.hub.publish(t, subject, reply, msg)
+}
+
+func (t *mockTransport) Subscribe(subject string, cb msgHandler) (*subscription, error) {
+	if t.sub == nil {
+		return nil, errNoInternalClient
+	}
+	sub := &subscription{subject: []byte(subject), sid: nil, icb: cb}
+	if err := t.sub.Insert(sub); err != nil {
+		return nil, err
+	}
+	return sub, nil
+}
+
+func (t *mockTransport) Unsubscribe(sub *subscription) {
+	if t.sub != nil {
+		t.sub.Remove(sub)
+	}
+}


### PR DESCRIPTION
The Raft implementation was tightly coupled to the server's internal client and send queue for Raft RPC communication. This made it difficult to test scenarios such as network partitions deterministically.

Introduce a raftTransport abstraction and keep the existing internal client/send queue behavior as the default transport. Tests can now inject a mock transport to simulate partitions and observe message delivery.
