### PR TITLE
(2.12) Add relaxed Raft degraded mode

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1036,6 +1036,7 @@ func (s *Server) shutdownJetStream() {
 			cc.qch, cc.stopped = nil, nil
 		}
 		js.stopUpdatesSub()
+		js.stopManagementSub()
 		if cc.c != nil {
 			cc.c.closeConnection(ClientClosed)
 			cc.c = nil

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -212,6 +212,10 @@ const (
 	JSApiServerStreamCancelMove  = "$JS.API.ACCOUNT.STREAM.CANCEL_MOVE.*.*"
 	JSApiServerStreamCancelMoveT = "$JS.API.ACCOUNT.STREAM.CANCEL_MOVE.%s.%s"
 
+	// JSApiServerDegradedRaftRelax allows Raft groups to temporarily relax consistency checks
+	// to value availability over correctness.
+	JSApiServerDegradedRaftRelax = "$JS.SERVER.DEGRADED.RAFT.RELAX"
+
 	// The prefix for system level account API.
 	jsAPIAccountPre = "$JS.API.ACCOUNT."
 
@@ -783,6 +787,24 @@ type JSApiConsumerResetResponse struct {
 }
 
 const JSApiConsumerResetResponseType = "io.nats.jetstream.api.v1.consumer_reset_response"
+
+type JSApiDegradedRaftRelaxRequest struct {
+	Servers []JSApiDegradedRaftRelaxServer `json:"servers,omitempty"`
+}
+
+type JSApiDegradedRaftRelaxServer struct {
+	// Server name.
+	Server string `json:"peer,omitempty"`
+	// Peer ID of the server.
+	Peer string `json:"peer_id,omitempty"`
+}
+
+type JSApiDegradedRaftRelaxResponse struct {
+	ApiResponse
+	JSApiDegradedRaftRelaxServer
+}
+
+const JSApiDegradedRaftRelaxResponseType = "io.nats.jetstream.api.v1.degraded_raft_relax"
 
 // Structure that holds state for a JetStream API request that is processed
 // in a separate long-lived go routine. This is to avoid blocking connections.
@@ -2841,6 +2863,56 @@ func (s *Server) jsLeaderServerStreamCancelMoveRequest(sub *subscription, c *cli
 
 	// We will always have peers and therefore never do a callout, therefore it is safe to call inline
 	s.jsClusteredStreamUpdateRequest(&ciNew, targetAcc.(*Account), subject, reply, rmsg, &cfg, peers, false)
+}
+
+func (s *Server) jsServerDegradedRaftRelaxRequest(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+	if c == nil || !s.JetStreamEnabled() {
+		return
+	}
+
+	ci, acc, _, msg, err := s.getRequestInfo(c, rmsg)
+	if err != nil {
+		s.Warnf(badAPIRequestT, msg)
+		return
+	}
+
+	if acc != s.SystemAccount() {
+		return
+	}
+
+	js, cc := s.getJetStreamCluster()
+	if js == nil || cc == nil {
+		return
+	}
+
+	var resp = JSApiDegradedRaftRelaxResponse{
+		ApiResponse: ApiResponse{Type: JSApiDegradedRaftRelaxResponseType},
+	}
+	var req JSApiDegradedRaftRelaxRequest
+	if err := s.unmarshalRequest(c, acc, subject, msg, &req); err != nil {
+		resp.Error = NewJSInvalidJSONError(err)
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+
+	name := s.Name()
+	js.mu.RLock()
+	var ourID string
+	if cc.meta != nil {
+		ourID = cc.meta.ID()
+	}
+	js.mu.RUnlock()
+	resp.Server = name
+	resp.Peer = ourID
+
+	// Check if this server is in the requested serves, only relax and respond then.
+	for _, srv := range req.Servers {
+		if srv.Server == name || (ourID != _EMPTY_ && srv.Peer == ourID) {
+			s.setRelaxedEmptyVote()
+			s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+			return
+		}
+	}
 }
 
 // Request to have an account purged

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -77,6 +77,8 @@ type jetStreamCluster struct {
 	peerStreamMove *subscription
 	// System level request to cancel a stream move
 	peerStreamCancelMove *subscription
+	// System level requests to manage degraded mode
+	degradedEmpty *subscription
 	// To pop out the monitorCluster before the raft layer.
 	qch chan struct{}
 	// To notify others that monitorCluster has actually stopped.
@@ -1068,6 +1070,8 @@ func (js *jetStream) setupMetaGroup() error {
 	}
 	atomic.StoreInt32(&js.clustered, 1)
 	c.registerWithAccount(sysAcc)
+
+	js.startManagementSub()
 
 	// Set to true before we start.
 	js.metaRecovering = true
@@ -7294,6 +7298,23 @@ func (js *jetStream) stopUpdatesSub() {
 	if js.accountPurge != nil {
 		cc.s.sysUnsubscribe(js.accountPurge)
 		js.accountPurge = nil
+	}
+}
+
+// Lock should be held.
+func (js *jetStream) startManagementSub() {
+	cc, s, c := js.cluster, js.srv, js.cluster.c
+	if cc.degradedEmpty == nil {
+		cc.degradedEmpty, _ = s.systemSubscribe(JSApiServerDegradedRaftRelax, _EMPTY_, false, c, s.jsServerDegradedRaftRelaxRequest)
+	}
+}
+
+// Lock should be held.
+func (js *jetStream) stopManagementSub() {
+	cc := js.cluster
+	if cc.degradedEmpty != nil {
+		cc.s.sysUnsubscribe(cc.degradedEmpty)
+		cc.degradedEmpty = nil
 	}
 }
 

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -10516,3 +10516,120 @@ func TestJetStreamClusterMirrorSkipMsgsPropagatesProposeFailure(t *testing.T) {
 	mset.mu.Unlock()
 	require_Error(t, err, errNotLeader)
 }
+
+func TestJetStreamClusterDegradedRaftRelaxRecovery(t *testing.T) {
+	// relaxed is process-global with a 60s TTL, so a prior test run
+	// can leave it set and silently relax voting in this test's "no leader"
+	// window. Reset it explicitly here, and again on exit.
+	resetRelax := func() {
+		relaxedMu.Lock()
+		defer relaxedMu.Unlock()
+		relaxed = false
+		if relaxedExpire != nil {
+			relaxedExpire.Stop()
+		}
+	}
+	resetRelax()
+	defer resetRelax()
+
+	c := createJetStreamClusterExplicit(t, "R6S", 6)
+	defer c.shutdown()
+
+	alive := []*Server{c.servers[0], c.servers[1], c.servers[2]}
+	deadNames := make([]string, 0, 3)
+	for _, s := range c.servers[3:6] {
+		deadNames = append(deadNames, s.Name())
+		s.Shutdown()
+		s.WaitForShutdown()
+	}
+
+	expectNoLeaderFor := func(d time.Duration) {
+		t.Helper()
+		deadline := time.Now().Add(d)
+		for time.Now().Before(deadline) {
+			if l := c.leader(); l != nil {
+				t.Fatalf("Did not expect a meta leader, got %s", l.Name())
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	// Wait for the current leader to step down due to lost quorum, then confirm
+	// no new leader can be elected.
+	c.expectNoLeader()
+	expectNoLeaderFor(1500 * time.Millisecond)
+
+	// Add a seventh server with an empty raft log. We cannot use addInNewServer
+	// here because it calls checkClusterFormed against every entry in c.servers,
+	// which would block on the three shut-down servers.
+	storeDir := t.TempDir()
+	seedRoute := fmt.Sprintf("nats-route://127.0.0.1:%d", c.opts[0].Cluster.Port)
+	conf := fmt.Sprintf(jsClusterTempl, "S-7", storeDir, c.name, -1, seedRoute)
+	s7, o7 := RunServerWithConfig(createConfFile(t, []byte(conf)))
+	c.servers = append(c.servers, s7)
+	c.opts = append(c.opts, o7)
+	checkClusterFormed(t, append(alive, s7)...)
+
+	// Even with a fourth live server, the seventh node's empty log means its
+	// vote is treated as empty and the alive servers (csz=6, quorum=4) still
+	// cannot reach quorum: 3 full votes + 1 empty < 4 full votes required.
+	expectNoLeaderFor(1500 * time.Millisecond)
+
+	// Issue the relax API targeting the seventh server. The handler is broadcast-style,
+	// so only the addressed server responds.
+	nc, err := nats.Connect(alive[0].ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	relaxReq := &JSApiDegradedRaftRelaxRequest{
+		Servers: []JSApiDegradedRaftRelaxServer{{Server: s7.Name()}},
+	}
+	jsreq, err := json.Marshal(relaxReq)
+	require_NoError(t, err)
+
+	// The request races with sub propagation between the alive servers and
+	// the new node, so allow a few attempts.
+	var relaxResp JSApiDegradedRaftRelaxResponse
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		rmsg, err := nc.Request(JSApiServerDegradedRaftRelax, jsreq, time.Second)
+		if err != nil {
+			return err
+		}
+		relaxResp = JSApiDegradedRaftRelaxResponse{}
+		if err := json.Unmarshal(rmsg.Data, &relaxResp); err != nil {
+			return err
+		}
+		if relaxResp.Error != nil {
+			return fmt.Errorf("unexpected relax error: %+v", relaxResp.Error)
+		}
+		if relaxResp.Server != s7.Name() {
+			return fmt.Errorf("expected response from %s, got %s", s7.Name(), relaxResp.Server)
+		}
+		return nil
+	})
+
+	// With the new node now casting full votes, the surviving peers can elect
+	// a meta leader — and it must be one of the original alive servers, never s7.
+	c.waitOnLeader()
+	leader := c.leader()
+	require_NotNil(t, leader)
+	require_True(t, slices.Contains(alive, leader))
+
+	// Peer-remove the three dead servers, one by one. Removing non-leader peers
+	// must not cause the meta leader to step down.
+	for _, deadName := range deadNames {
+		req := &JSApiMetaServerRemoveRequest{Server: deadName}
+		payload, err := json.Marshal(req)
+		require_NoError(t, err)
+		rmsg, err := nc.Request(JSApiRemoveServer, payload, 2*time.Second)
+		require_NoError(t, err)
+
+		var resp JSApiMetaServerRemoveResponse
+		require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
+		require_True(t, resp.Error == nil)
+		require_True(t, resp.Success)
+
+		require_False(t, slices.Contains(leader.JetStreamClusterPeers(), deadName))
+		require_Equal(t, c.leader(), leader)
+	}
+}

--- a/server/raft.go
+++ b/server/raft.go
@@ -303,6 +303,37 @@ var (
 	peerRemoveTimeout    = peerRemoveTimeoutDefault
 )
 
+// Empty votes can be relaxed for relaxedTTL amount of time.
+const relaxedTTL = time.Minute
+
+var (
+	relaxedMu     sync.Mutex
+	relaxed       bool
+	relaxedExpire *time.Timer
+)
+
+func (s *Server) setRelaxedEmptyVote() {
+	relaxedMu.Lock()
+	if relaxedExpire != nil {
+		relaxedExpire.Stop()
+	}
+	relaxedExpire = time.AfterFunc(relaxedTTL, func() {
+		relaxedMu.Lock()
+		relaxed = false
+		relaxedMu.Unlock()
+		s.Warnf("Raft relaxed empty-vote mode expired")
+	})
+	relaxed = true
+	relaxedMu.Unlock()
+	s.Warnf("Raft relaxed empty-vote mode set for %s", relaxedTTL)
+}
+
+func isRelaxedEmptyVote() bool {
+	relaxedMu.Lock()
+	defer relaxedMu.Unlock()
+	return relaxed
+}
+
 type RaftConfig struct {
 	Name     string
 	Store    string
@@ -5070,8 +5101,9 @@ func (n *raft) processVoteRequest(vr *voteRequest) error {
 	// Only way we get to yes is through here.
 	voteOk := n.vote == noVote || n.vote == vr.candidate
 
-	// If we have an empty log, but are initializing.
-	if voteOk && vresp.empty && n.initializing {
+	// If we have an empty log, but are initializing or have been temporarily
+	// relaxed by a degraded raft relax request.
+	if voteOk && vresp.empty && (n.initializing || isRelaxedEmptyVote()) {
 		// Reset notion of having an empty log if we're voting during initialization/scale up.
 		// Ensures they only need quorum, and not need to hear from all servers.
 		vresp.empty = false

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -6214,3 +6214,70 @@ func TestNRGReset(t *testing.T) {
 	// Append entry cache cleared.
 	require_Equal(t, len(n.pae), 0)
 }
+
+func TestNRGRelaxedEmptyVote(t *testing.T) {
+	// The relaxed empty-vote flag is process-global with a 60s TTL, so reset
+	// it before and after this test to stay isolated from any earlier run.
+	resetRelaxed := func() {
+		relaxedMu.Lock()
+		defer relaxedMu.Unlock()
+		relaxed = false
+		if relaxedExpire != nil {
+			relaxedExpire.Stop()
+		}
+	}
+	resetRelaxed()
+	defer resetRelaxed()
+
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// We want to exercise the relax path independently of the existing
+	// initializing/scale-up shortcut, which also clears vresp.empty.
+	n.initializing = false
+
+	nats0 := "S1Nunr6R"
+	voteReply := "$TEST"
+	nc, err := nats.Connect(n.s.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	sub, err := nc.SubscribeSync(voteReply)
+	require_NoError(t, err)
+	defer sub.Drain()
+	require_NoError(t, nc.Flush())
+
+	// 1) Without relax (and not initializing), a vote on an empty log must
+	//    be marked empty so the candidate cannot count it toward full quorum.
+	require_False(t, isRelaxedEmptyVote())
+	require_NoError(t, n.processVoteRequest(&voteRequest{term: 1, candidate: nats0, reply: voteReply}))
+	msg, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	vr := decodeVoteResponse(msg.Data)
+	require_True(t, vr.granted)
+	require_True(t, vr.empty)
+
+	// 2) Enable relaxed mode: a degraded raft relax request would call this.
+	//    A subsequent vote on an empty log must NOT be marked empty so the
+	//    candidate can reach quorum across surviving peers.
+	n.s.setRelaxedEmptyVote()
+	require_True(t, isRelaxedEmptyVote())
+
+	require_NoError(t, n.processVoteRequest(&voteRequest{term: 2, candidate: nats0, reply: voteReply}))
+	msg, err = sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	vr = decodeVoteResponse(msg.Data)
+	require_True(t, vr.granted)
+	require_False(t, vr.empty)
+
+	// 3) Clear relaxed mode and the empty-vote suppression must come back.
+	resetRelaxed()
+	require_False(t, isRelaxedEmptyVote())
+
+	require_NoError(t, n.processVoteRequest(&voteRequest{term: 3, candidate: nats0, reply: voteReply}))
+	msg, err = sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	vr = decodeVoteResponse(msg.Data)
+	require_True(t, vr.granted)
+	require_True(t, vr.empty)
+}


### PR DESCRIPTION
Prior to 2.12, given a 6-node cluster for example, it was possible for 3 nodes to go down, lose meta quorum, add a 7th empty node, and get quorum again. However, this is unsafe, since any changes made without quorum (or based on empty state) could potentially lose data. The proper way to restore in such a situation is to bring back one or multiple of those 3 nodes. If that's not possible for some reason, for example if the disks were wiped, it is valid to bring those 3 nodes back with empty disks (but with the same server names as before). And since 3 nodes are lower than the quorum needed of 4 nodes, this will reliably ensure that no data is lost (at least for the meta state, but this may not hold for any stream or consumer data) and the leader that's elected contains all (meta) data, but it does require that all servers are online to be allowed to make that call on their own.

But, there are cases where it's genuinely difficult to recover the system, for example after having made a misconfiguration or having forgotten to peer-remove servers. We'd normally classify that as not properly operating or having misconfigured the system, but alas, there is a use case around having a "break glass" kind of method to get out of this issue outside of what's considered safe.

This PR adds one such "break glass" method. To be clear though: this CAN lose data. In using this API, the user acknowledges that they value availability higher than consistency. Given the example of a 6-node cluster with 3 nodes down, and those 3 being dead without the ability to return as described above, a 7th node can be added. The system will, by default since 2.12, protect itself and not allow the 7th empty node to be admitted until there's quorum, but there's no quorum which is the problem. So, using this API you can send the following to `$JS.SERVER.DEGRADED.RAFT.RELAX`:

```json
  {
    "servers": [
      { "peer": "nats-7", "peer_id": "<peer ID of server>" }
    ]
  }
```

That will temporarily relax the "empty votes" constraint added since 2.12 (https://github.com/nats-io/nats-server/pull/7038), allow one of the remaining 3 nodes to be elected the new meta leader, afterward automatically admit the 7th node, get back to meta quorum, and allow actions like peer-removing the dead 3 nodes.

Again, it's incredibly important to properly operate your system! This API is only to be used when the situation is dire.