### PR TITLE
[IMPROVED] Replace time.After with reusable timer in snapshot and catchup loops

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -4315,7 +4315,7 @@ func (s *Server) streamSnapshot(acc *Account, mset *stream, sr *SnapshotResult, 
 	var hdr []byte
 	chunk := make([]byte, chunkSize)
 	ackTimer := time.NewTimer(snapshotAckTimeout)
-	defer ackTimer.Stop()
+	defer stopAndClearTimer(&ackTimer)
 	for index := 1; ; index++ {
 		select {
 		case <-slots:
@@ -4347,12 +4347,6 @@ func (s *Server) streamSnapshot(acc *Account, mset *stream, sr *SnapshotResult, 
 			hdr = []byte("NATS/1.0 204\r\n\r\n")
 		}
 		mset.outq.send(newJSPubMsg(reply, _EMPTY_, ackReply, nil, chunk, nil, 0))
-		if !ackTimer.Stop() {
-			select {
-			case <-ackTimer.C:
-			default:
-			}
-		}
 		ackTimer.Reset(snapshotAckTimeout)
 	}
 

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -4314,6 +4314,8 @@ func (s *Server) streamSnapshot(acc *Account, mset *stream, sr *SnapshotResult, 
 
 	var hdr []byte
 	chunk := make([]byte, chunkSize)
+	ackTimer := time.NewTimer(snapshotAckTimeout)
+	defer ackTimer.Stop()
 	for index := 1; ; index++ {
 		select {
 		case <-slots:
@@ -4326,7 +4328,7 @@ func (s *Server) streamSnapshot(acc *Account, mset *stream, sr *SnapshotResult, 
 			// The snapshotting goroutine has failed for some reason.
 			hdr = []byte(fmt.Sprintf("NATS/1.0 500 %s\r\n\r\n", err))
 			goto done
-		case <-time.After(snapshotAckTimeout):
+		case <-ackTimer.C:
 			// It's taking a very long time for the receiver to send us acks,
 			// they have probably stalled or there is high loss on the link.
 			hdr = []byte("NATS/1.0 408 No Flow Response\r\n\r\n")
@@ -4345,6 +4347,13 @@ func (s *Server) streamSnapshot(acc *Account, mset *stream, sr *SnapshotResult, 
 			hdr = []byte("NATS/1.0 204\r\n\r\n")
 		}
 		mset.outq.send(newJSPubMsg(reply, _EMPTY_, ackReply, nil, chunk, nil, 0))
+		if !ackTimer.Stop() {
+			select {
+			case <-ackTimer.C:
+			default:
+			}
+		}
+		ackTimer.Reset(snapshotAckTimeout)
 	}
 
 done:

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -11158,6 +11158,8 @@ func (mset *stream) runCatchup(sendSubject string, sreq *streamSyncRequest) {
 
 	// Run as long as we are still active and need catchup.
 	// FIXME(dlc) - Purge event? Stream delete?
+	retryTimer := time.NewTimer(500 * time.Millisecond)
+	defer retryTimer.Stop()
 	for {
 		// Get this each time, will be non-nil if globally blocked and we will close to wake everyone up.
 		cbKick := s.cbKickChan()
@@ -11184,12 +11186,19 @@ func (mset *stream) runCatchup(sendSubject string, sreq *streamSyncRequest) {
 				mset.clearCatchupPeer(sreq.Peer)
 				return
 			}
-		case <-time.After(500 * time.Millisecond):
+		case <-retryTimer.C:
 			if !sendNextBatchAndContinue(qch) {
 				mset.clearCatchupPeer(sreq.Peer)
 				return
 			}
 		}
+		if !retryTimer.Stop() {
+			select {
+			case <-retryTimer.C:
+			default:
+			}
+		}
+		retryTimer.Reset(500 * time.Millisecond)
 	}
 }
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -11159,7 +11159,7 @@ func (mset *stream) runCatchup(sendSubject string, sreq *streamSyncRequest) {
 	// Run as long as we are still active and need catchup.
 	// FIXME(dlc) - Purge event? Stream delete?
 	retryTimer := time.NewTimer(500 * time.Millisecond)
-	defer retryTimer.Stop()
+	defer stopAndClearTimer(&retryTimer)
 	for {
 		// Get this each time, will be non-nil if globally blocked and we will close to wake everyone up.
 		cbKick := s.cbKickChan()
@@ -11190,12 +11190,6 @@ func (mset *stream) runCatchup(sendSubject string, sreq *streamSyncRequest) {
 			if !sendNextBatchAndContinue(qch) {
 				mset.clearCatchupPeer(sreq.Peer)
 				return
-			}
-		}
-		if !retryTimer.Stop() {
-			select {
-			case <-retryTimer.C:
-			default:
 			}
 		}
 		retryTimer.Reset(500 * time.Millisecond)


### PR DESCRIPTION
## Overview

`time.After` creates a new channel and timer that cannot be garbage collected until the timer fires. When used inside a loop, each iteration leaks a timer for the full timeout duration.

PR #4756 fixed identical instances in `client.go`, `consumer.go`, `jetstream_cluster.go`, and `mqtt.go`, but two instances were missed (or introduced later):

1. **`server/jetstream_api.go`, snapshot chunk-streaming loop** (introduced in #7828):
   The `for index := 1; ; index++` loop runs once per snapshot chunk. A 1 GB snapshot with 128 KB chunks creates ~8,000 iterations, each leaking a 5-second timer (`snapshotAckTimeout`).

2. **`server/jetstream_cluster.go`, `runCatchup` loop** (introduced in #5454):
   The `for { select { ... } }` loop runs continuously during stream catchup. When `nextBatchC` or `cbKick` fires instead of the 500 ms timer, the timer is abandoned every iteration.

## Changes

Replace `time.After(duration)` with a `time.NewTimer` created before the loop, using the `Stop`/drain/`Reset` pattern to reuse it across iterations. This matches the exact pattern established in #4756.

## Testing

Existing snapshot and catchup tests pass:
- `TestJetStreamSnapshots` (0.61s)
- `TestJetStreamSnapshotsAPI` (0.24s)
- `TestJetStreamSnapshotRestoreStallAndHealthz` (0.04s)
- `TestJetStreamClusterStreamCatchupNoState` (5.68s)
- `TestJetStreamClusterStreamCatchupWithTruncateAndPriorSnapshot` (2.25s)
- `TestJetStreamClusterStreamCatchupInteriorNilMsgs` (1.12s)

Closes #8185. Relates to #4756.