### PR TITLE
[FIXED] Aliased fields from filestore's block caches

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5738,7 +5738,6 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 		lhdr, lmsg int
 		ttl        int64
 	)
-	// We don't use a copy as long as that's possible. When unlocking mb or erasing, we'll copy the subject.
 	sm, err := mb.cacheLookupNoCopy(seq, &smv)
 	if err != nil {
 		finishedWithCache()
@@ -5749,7 +5748,9 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 		}
 		return false, err
 	} else if sm != nil {
-		subj = sm.subj
+		// subj aliases mb.cache.buf; copy now because the cache may be erased or
+		// recycled after we drop mb.mu. The rest are scalars stashed for later use.
+		subj = copyString(sm.subj)
 		ts = sm.ts
 		lhdr = len(sm.hdr)
 		lmsg = len(sm.msg)
@@ -5761,8 +5762,6 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 	// when the last block is empty.
 	// If not via limits and not empty (empty writes tombstone below if last) write tombstone.
 	if !viaLimits && !isEmpty && sm != nil {
-		// Need to copy the subject since we unlock and re-acquire, and the cache could change.
-		subj = copyString(subj)
 		mb.mu.Unlock() // Only safe way to checkLastBlock is to unlock here...
 		lmb, err := fs.checkLastBlock(emptyRecordLen)
 		if err != nil {
@@ -5795,9 +5794,6 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 			mb.mu.Unlock()
 			return false, err
 		}
-		// Need to copy the subject, as eraseMsg will overwrite the cache and we won't
-		// be able to access sm.subj anymore later on.
-		subj = copyString(subj)
 		if err := mb.eraseMsg(seq, int(ri), int(msz), isLastBlock); err != nil {
 			finishedWithCache()
 			mb.mu.Unlock()

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2218,18 +2218,22 @@ func (fs *fileStore) recoverTTLState() error {
 				// Done.
 				break
 			}
-			msg, _, err := mb.fetchMsgNoCopy(seq, &sm)
+			mb.mu.Lock()
+			msg, _, err := mb.fetchMsgNoCopyLocked(seq, &sm)
 			if err != nil {
+				mb.finishedWithCache()
+				mb.mu.Unlock()
 				fs.warn("Error loading msg seq %d for recovering TTL: %s", seq, err)
 				continue
 			}
-			if len(msg.hdr) == 0 {
-				continue
+			if len(msg.hdr) > 0 {
+				if ttl, _ := getMessageTTL(msg.hdr); ttl > 0 {
+					expires := time.Duration(msg.ts) + (time.Second * time.Duration(ttl))
+					fs.ttls.Add(seq, int64(expires))
+				}
 			}
-			if ttl, _ := getMessageTTL(msg.hdr); ttl > 0 {
-				expires := time.Duration(msg.ts) + (time.Second * time.Duration(ttl))
-				fs.ttls.Add(seq, int64(expires))
-			}
+			mb.finishedWithCache()
+			mb.mu.Unlock()
 		}
 	}
 	return nil
@@ -2299,18 +2303,22 @@ func (fs *fileStore) recoverMsgSchedulingState() error {
 				// Done.
 				break
 			}
-			msg, _, err := mb.fetchMsgNoCopy(seq, &sm)
+			mb.mu.Lock()
+			msg, _, err := mb.fetchMsgNoCopyLocked(seq, &sm)
 			if err != nil {
+				mb.finishedWithCache()
+				mb.mu.Unlock()
 				fs.warn("Error loading msg seq %d for recovering message schedules: %s", seq, err)
 				continue
 			}
-			if len(msg.hdr) == 0 {
-				continue
+			if len(msg.hdr) > 0 {
+				if schedule, apiErr := nextMessageSchedule(msg.hdr, msg.ts); apiErr == nil && !schedule.IsZero() {
+					// Copy the subject, as it's stored in the scheduling maps and the backing cache could be reused in the meantime.
+					fs.scheduling.init(seq, copyString(msg.subj), schedule.UnixNano())
+				}
 			}
-			if schedule, apiErr := nextMessageSchedule(sm.hdr, sm.ts); apiErr == nil && !schedule.IsZero() {
-				// Copy the subject, as it's stored in the scheduling maps and the backing cache could be reused in the meantime.
-				fs.scheduling.init(seq, copyString(sm.subj), schedule.UnixNano())
-			}
+			mb.finishedWithCache()
+			mb.mu.Unlock()
 		}
 	}
 	return nil
@@ -2765,6 +2773,7 @@ func (fs *fileStore) GetSeqFromTime(t time.Time) uint64 {
 
 	// Using a binary search, but need to be aware of interior deletes in the block.
 	seq := lseq + 1
+	mb.mu.Lock()
 loop:
 	for fseq <= lseq {
 		mid := fseq + (lseq-fseq)/2
@@ -2772,7 +2781,7 @@ loop:
 		// Potentially skip over gaps. We keep the original middle but keep track of a
 		// potential delete range with an offset.
 		for {
-			sm, _, err := mb.fetchMsgNoCopy(mid+off, &smv)
+			sm, _, err := mb.fetchMsgNoCopyLocked(mid+off, &smv)
 			if err != nil || sm == nil {
 				off++
 				if mid+off <= lseq {
@@ -2799,6 +2808,8 @@ loop:
 			fseq = mid + off + 1
 		}
 	}
+	mb.finishedWithCache()
+	mb.mu.Unlock()
 	return seq
 }
 
@@ -6501,10 +6512,9 @@ func (mb *msgBlock) selectNextFirst() {
 	var smv StoreMsg
 	sm, _ := mb.cacheLookupNoCopy(seq, &smv)
 	if sm == nil {
-		// Slow path, need to unlock.
-		mb.mu.Unlock()
-		sm, _, _ = mb.fetchMsgNoCopy(seq, &smv)
-		mb.mu.Lock()
+		// Slow path, cache not loaded.
+		sm, _, _ = mb.fetchMsgNoCopyLocked(seq, &smv)
+		mb.finishedWithCache()
 	}
 	if sm != nil {
 		mb.first.ts = sm.ts
@@ -8471,25 +8481,25 @@ checkCache:
 // We assume the block was selected and is correct, so we do not do range checks.
 // Lock should not be held.
 func (mb *msgBlock) fetchMsg(seq uint64, sm *StoreMsg) (*StoreMsg, bool, error) {
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+	defer mb.finishedWithCache()
 	return mb.fetchMsgEx(seq, sm, true)
 }
 
 // Fetch a message from this block, possibly reading in and caching the messages.
 // We assume the block was selected and is correct, so we do not do range checks.
-// We will not copy the msg data.
-// Lock should not be held.
-func (mb *msgBlock) fetchMsgNoCopy(seq uint64, sm *StoreMsg) (*StoreMsg, bool, error) {
+// We will not copy the msg data, the returned StoreMsg's subj/hdr/msg/buf are aliased
+// into mb.cache.buf and are only safe to read while mb.mu is held.
+func (mb *msgBlock) fetchMsgNoCopyLocked(seq uint64, sm *StoreMsg) (*StoreMsg, bool, error) {
 	return mb.fetchMsgEx(seq, sm, false)
 }
 
 // Fetch a message from this block, possibly reading in and caching the messages.
 // We assume the block was selected and is correct, so we do not do range checks.
 // We will copy the msg data based on doCopy boolean.
-// Lock should not be held.
+// Lock should be held.
 func (mb *msgBlock) fetchMsgEx(seq uint64, sm *StoreMsg, doCopy bool) (*StoreMsg, bool, error) {
-	mb.mu.Lock()
-	defer mb.mu.Unlock()
-
 	fseq, lseq := atomic.LoadUint64(&mb.first.seq), atomic.LoadUint64(&mb.last.seq)
 	if seq < fseq || seq > lseq {
 		return nil, false, ErrStoreMsgNotFound
@@ -8511,7 +8521,6 @@ func (mb *msgBlock) fetchMsgEx(seq uint64, sm *StoreMsg, doCopy bool) (*StoreMsg
 			return nil, false, err
 		}
 	}
-	defer mb.finishedWithCache()
 	llseq := mb.llseq
 
 	fsm, err := mb.cacheLookupEx(seq, sm, doCopy)
@@ -8519,7 +8528,7 @@ func (mb *msgBlock) fetchMsgEx(seq uint64, sm *StoreMsg, doCopy bool) (*StoreMsg
 		return nil, false, err
 	}
 	expireOk := (seq == lseq && llseq == seq-1) || (seq == fseq && llseq == seq+1)
-	return fsm, expireOk, err
+	return fsm, expireOk, nil
 }
 
 var (
@@ -8687,9 +8696,15 @@ func (fs *fileStore) sizeForSeq(seq uint64) int {
 	}
 	var smv StoreMsg
 	if mb := fs.selectMsgBlock(seq); mb != nil {
-		if sm, _, _ := mb.fetchMsgNoCopy(seq, &smv); sm != nil {
-			return int(fileStoreMsgSize(sm.subj, sm.hdr, sm.msg))
+		mb.mu.Lock()
+		sm, _, _ := mb.fetchMsgNoCopyLocked(seq, &smv)
+		var sz int
+		if sm != nil {
+			sz = int(fileStoreMsgSize(sm.subj, sm.hdr, sm.msg))
 		}
+		mb.finishedWithCache()
+		mb.mu.Unlock()
+		return sz
 	}
 	return 0
 }
@@ -8879,9 +8894,17 @@ func (fs *fileStore) SubjectForSeq(seq uint64) (string, error) {
 	mb := fs.selectMsgBlock(seq)
 	fs.mu.RUnlock()
 	if mb != nil {
-		if sm, _, _ := mb.fetchMsgNoCopy(seq, &smv); sm != nil {
+		mb.mu.Lock()
+		sm, _, _ := mb.fetchMsgNoCopyLocked(seq, &smv)
+		var subj string
+		if sm != nil {
 			// Copy the subject, as it's used elsewhere, and the backing cache could be reused in the meantime.
-			return copyString(sm.subj), nil
+			subj = copyString(sm.subj)
+		}
+		mb.finishedWithCache()
+		mb.mu.Unlock()
+		if sm != nil {
+			return subj, nil
 		}
 	}
 	return _EMPTY_, ErrStoreMsgNotFound
@@ -10702,11 +10725,18 @@ func (fs *fileStore) Truncate(seq uint64) (rerr error) {
 	// at the end, after we release the lock.
 	os.Remove(filepath.Join(fs.fcfg.StoreDir, msgDir, streamStreamStateFile))
 
-	var err error
-	var lsm *StoreMsg
+	var hasLsm bool
+	var lastTime int64
 	smb := fs.selectMsgBlock(seq)
 	if smb != nil {
-		lsm, _, err = smb.fetchMsgNoCopy(seq, nil)
+		smb.mu.Lock()
+		lsm, _, err := smb.fetchMsgNoCopyLocked(seq, nil)
+		if lsm != nil {
+			hasLsm = true
+			lastTime = lsm.ts
+		}
+		smb.finishedWithCache()
+		smb.mu.Unlock()
 		if err != nil && err != ErrStoreMsgNotFound && err != errDeletedMsg {
 			fs.mu.Unlock()
 			return err
@@ -10714,13 +10744,12 @@ func (fs *fileStore) Truncate(seq uint64) (rerr error) {
 	}
 
 	// Reset last so new block doesn't contain truncated sequences/timestamps.
-	var lastTime int64
-	if lsm != nil {
-		lastTime = lsm.ts
-	} else if smb != nil {
-		lastTime = smb.last.ts
-	} else {
-		lastTime = fs.state.LastTime.UnixNano()
+	if !hasLsm {
+		if smb != nil {
+			lastTime = smb.last.ts
+		} else {
+			lastTime = fs.state.LastTime.UnixNano()
+		}
 	}
 	fs.state.LastSeq = seq
 	fs.state.LastTime = time.Unix(0, lastTime).UTC()
@@ -10742,7 +10771,7 @@ func (fs *fileStore) Truncate(seq uint64) (rerr error) {
 
 	// If the selected block is not found or the message was deleted, we'll need to write a tombstone
 	// at the truncated sequence so we don't roll backward on our last sequence and timestamp.
-	if lsm == nil || removeSmb {
+	if !hasLsm || removeSmb {
 		if err = fs.writeTombstone(seq, lastTime); err != nil {
 			fs.mu.Unlock()
 			return err

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -43,6 +43,7 @@ import (
 	"testing"
 	"time"
 	"unicode/utf8"
+	"unsafe"
 
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/nats-server/v2/server/ats"
@@ -14097,4 +14098,43 @@ func TestFileStoreConvertToEncryptedDoesNotResurrectXoredCache(t *testing.T) {
 	// block would decrypt to garbage and rebuildStateFromBufLocked would silently
 	// truncate it to zero bytes — losing the message.
 	require_NotEqual(t, len(mb.cache.buf), 0)
+}
+
+func TestFileStoreRemoveMsgViaLimitsCallbackAliasedSubj(t *testing.T) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir()},
+		StreamConfig{Name: "TEST", Storage: FileStorage, MaxMsgs: 1, Discard: DiscardOld},
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	// Capture the data pointer of subj from the removal callback (md == -1).
+	var cbSubjAddr uintptr
+	fs.RegisterStorageUpdates(func(md, _ int64, _ uint64, subj string) {
+		if md == -1 {
+			cbSubjAddr = uintptr(unsafe.Pointer(unsafe.StringData(subj)))
+		}
+	})
+
+	_, _, err = fs.StoreMsg("foo.bar", nil, []byte("payload-1"), 0)
+	require_NoError(t, err)
+	// Second store exceeds MaxMsgs=1, should trigger above callback.
+	_, _, err = fs.StoreMsg("foo.bar", nil, []byte("payload-2"), 0)
+	require_NoError(t, err)
+	require_True(t, cbSubjAddr != 0)
+
+	fs.mu.RLock()
+	mb := fs.blks[0]
+	fs.mu.RUnlock()
+
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+	require_NotNil(t, mb.cache)
+	bufStart := uintptr(unsafe.Pointer(unsafe.SliceData(mb.cache.buf)))
+	bufEnd := bufStart + uintptr(cap(mb.cache.buf))
+
+	if cbSubjAddr >= bufStart && cbSubjAddr < bufEnd {
+		t.Fatalf("subj passed to callback aliases mb.cache.buf (subj@%#x in [%#x,%#x))",
+			cbSubjAddr, bufStart, bufEnd)
+	}
 }

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -14138,3 +14138,103 @@ func TestFileStoreRemoveMsgViaLimitsCallbackAliasedSubj(t *testing.T) {
 			cbSubjAddr, bufStart, bufEnd)
 	}
 }
+
+func TestFileStoreSubjectForSeqAliasRace(t *testing.T) {
+	// Small blocks + many short subjects: many blocks all using the same
+	// buffer-pool tier, maximizing the chance that a recycled buf is grabbed
+	// by another mb's load.
+	fcfg := FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 1024}
+	fs, err := newFileStore(fcfg, StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo.>"},
+		Storage:  FileStorage,
+	})
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	const N = 256
+	subjects := make([]string, N) // indexed by seq-1
+	for i := range subjects {
+		// Distinct, recognizable subject per seq; long enough that mid-buffer
+		// corruption shows up in the prefix/suffix comparison.
+		subjects[i] = fmt.Sprintf("foo.seq-%05d-%s", i+1, strings.Repeat("A", 40))
+		_, _, err = fs.StoreMsg(subjects[i], nil, []byte("payload"), 0)
+		require_NoError(t, err)
+	}
+	require_True(t, fs.numMsgBlocks() >= 4)
+
+	var (
+		stop      atomic.Bool
+		mismatch  atomic.Int64
+		gotSubj   atomic.Value // captured corrupt subj for the failure message
+		gotSeqVal atomic.Uint64
+	)
+
+	var wg sync.WaitGroup
+
+	// Reader workers: random SubjectForSeq lookups, verify subject matches.
+	readers := runtime.GOMAXPROCS(0)
+	if readers < 4 {
+		readers = 4
+	}
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for !stop.Load() {
+				seq := uint64(rand.Intn(N) + 1)
+				got, err := fs.SubjectForSeq(seq)
+				if err != nil {
+					continue
+				}
+				if got != subjects[seq-1] {
+					if mismatch.Add(1) == 1 {
+						gotSubj.Store(got)
+						gotSeqVal.Store(seq)
+					}
+					return
+				}
+			}
+		}()
+	}
+
+	// Thrasher: force-expire each block's cache so its buf is recycled into
+	// the pool while readers may still hold aliased views of it.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for !stop.Load() {
+			fs.mu.RLock()
+			blks := append([]*msgBlock(nil), fs.blks...)
+			fs.mu.RUnlock()
+			for _, mb := range blks {
+				mb.tryForceExpireCache()
+			}
+		}
+	}()
+
+	// Run for up to 5s, exiting early as soon as a mismatch is seen.
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	tick := time.NewTicker(20 * time.Millisecond)
+	defer tick.Stop()
+loop:
+	for {
+		select {
+		case <-deadline.C:
+			break loop
+		case <-tick.C:
+			if mismatch.Load() > 0 {
+				break loop
+			}
+		}
+	}
+	stop.Store(true)
+	wg.Wait()
+
+	if n := mismatch.Load(); n > 0 {
+		corrupt, _ := gotSubj.Load().(string)
+		t.Fatalf("SubjectForSeq returned a corrupted subject %d time(s); seq=%d got=%q want=%q",
+			n, gotSeqVal.Load(), corrupt, subjects[gotSeqVal.Load()-1])
+	}
+}


### PR DESCRIPTION
- `subj` was populated from the block's cache but only copied on some paths. Finally, `finishedWithCache` runs, `mb.mu` is released, and the (still aliased) `subj` is then passed to `fs.scb`. We now always copy `subj` up front to ensure the  cache can't get overwritten underneath it.
- Any usage of `mb.fetchMsgNoCopy` that reached into `sm.subj/hdr/msg` was unsafe: function locked internally, so by the time callers read those fields the lock was gone and the cache could be recycled. It now requires the caller to hold `mb.mu` across the read (and call `finishedWithCache` themselves), renamed to `mb.fetchMsgNoCopyLocked` to make the contract obvious.