### PR TITLE
conf: validate integer suffix overflow

### DIFF
--- a/conf/parse.go
+++ b/conf/parse.go
@@ -39,6 +39,11 @@ import (
 
 const _EMPTY_ = ""
 
+const (
+	maxInt64 = int64(1<<63 - 1)
+	minInt64 = -1 << 63
+)
+
 type parser struct {
 	mapping map[string]any
 	lx      *lexer
@@ -318,34 +323,40 @@ func (p *parser) processItem(it item, fp string) error {
 		// Process a suffix
 		suffix := strings.ToLower(strings.TrimSpace(it.val[lastDigit:]))
 
+		multiplier := int64(1)
 		switch suffix {
 		case "":
-			setValue(it, num)
 		case "k":
-			setValue(it, num*1000)
+			multiplier = 1000
 		case "kb", "ki", "kib":
-			setValue(it, num*1024)
+			multiplier = 1024
 		case "m":
-			setValue(it, num*1000*1000)
+			multiplier = 1000 * 1000
 		case "mb", "mi", "mib":
-			setValue(it, num*1024*1024)
+			multiplier = 1024 * 1024
 		case "g":
-			setValue(it, num*1000*1000*1000)
+			multiplier = 1000 * 1000 * 1000
 		case "gb", "gi", "gib":
-			setValue(it, num*1024*1024*1024)
+			multiplier = 1024 * 1024 * 1024
 		case "t":
-			setValue(it, num*1000*1000*1000*1000)
+			multiplier = 1000 * 1000 * 1000 * 1000
 		case "tb", "ti", "tib":
-			setValue(it, num*1024*1024*1024*1024)
+			multiplier = 1024 * 1024 * 1024 * 1024
 		case "p":
-			setValue(it, num*1000*1000*1000*1000*1000)
+			multiplier = 1000 * 1000 * 1000 * 1000 * 1000
 		case "pb", "pi", "pib":
-			setValue(it, num*1024*1024*1024*1024*1024)
+			multiplier = 1024 * 1024 * 1024 * 1024 * 1024
 		case "e":
-			setValue(it, num*1000*1000*1000*1000*1000*1000)
+			multiplier = 1000 * 1000 * 1000 * 1000 * 1000 * 1000
 		case "eb", "ei", "eib":
-			setValue(it, num*1024*1024*1024*1024*1024*1024)
+			multiplier = 1024 * 1024 * 1024 * 1024 * 1024 * 1024
+		default:
+			return fmt.Errorf("invalid integer suffix '%s' in '%s'", suffix, it.val)
 		}
+		if multiplier > 1 && (num > maxInt64/multiplier || num < minInt64/multiplier) {
+			return fmt.Errorf("integer '%s' is out of the range", it.val)
+		}
+		setValue(it, num*multiplier)
 	case itemFloat:
 		num, err := strconv.ParseFloat(it.val, 64)
 		if err != nil {

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -218,6 +218,22 @@ func TestConvenientNumbers(t *testing.T) {
 	test(t, easynum, ex)
 }
 
+func TestConvenientNumbersInvalidSuffix(t *testing.T) {
+	if _, err := Parse("foo = 1kbb"); err == nil {
+		t.Fatal("Expected err for invalid number suffix")
+	} else if !strings.Contains(err.Error(), "invalid integer suffix") {
+		t.Fatalf("Expected invalid integer suffix error, got %q", err)
+	}
+}
+
+func TestConvenientNumbersOverflow(t *testing.T) {
+	if _, err := Parse("foo = 9223372036854775807k"); err == nil {
+		t.Fatal("Expected err for integer overflow")
+	} else if !strings.Contains(err.Error(), "out of the range") {
+		t.Fatalf("Expected out of range error, got %q", err)
+	}
+}
+
 func TestParseFileWithChecksDigestPreservesConfigKeyUsedAsVariable(t *testing.T) {
 	confFile := filepath.Join(t.TempDir(), "nats.conf")
 	if err := os.WriteFile(confFile, []byte(`


### PR DESCRIPTION
Tiny config parser fix

Before, these passed config test, which is not it:
```conf
port: -1
max_payload: 1kbb
```
```conf
port: -1
max_payload: 9223372036854775807k
```

`nats-server -t -c <file>` reported both as valid on main. The first drops the value, the second wraps during suffix multiplication.

Now invalid suffixes error, and oversized suffixed ints error too. Existing suffixes like `22GB` still work.

Tests:
`go test ./conf -count=1`
`go test ./... -run TestNoSuchTest -count=1`