### PR TITLE
[FIXED] Erroneous local consumer cleanup in deleteNotActive

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2233,9 +2233,6 @@ func (o *consumer) deleteNotActive() {
 		"consumer": name,
 	})
 
-	// We will delete locally regardless.
-	defer o.delete()
-
 	// If we are clustered, check if we still have this consumer assigned.
 	// If we do forward a proposal to delete ourselves to the metacontroller leader.
 	if !isDirect && s.JetStreamIsClustered() {
@@ -2293,6 +2290,10 @@ func (o *consumer) deleteNotActive() {
 				return
 			}
 		}
+	} else {
+		// Otherwise, we can delete locally. Either a consumer that's not tracked
+		// by the meta layer (direct), or a standalone non-clustered server.
+		o.delete()
 	}
 }
 

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2141,7 +2141,7 @@ func (o *consumer) deleteNotActive() {
 	cnaStart := consumerNotActiveStartInterval
 
 	o.mu.Lock()
-	if o.mset == nil {
+	if o.mset == nil || !o.isLeader() {
 		o.mu.Unlock()
 		return
 	}

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -1864,6 +1864,52 @@ func TestJetStreamClusterConsumerUpdateRaceWithDeleteNotActiveDefer(t *testing.T
 	}
 }
 
+func TestJetStreamClusterDeleteNotActiveOnFollowerDoesNotDeleteConsumer(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	// Long InactiveThreshold so the normal timer does not fire during the test.
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:           "CONSUMER",
+		AckPolicy:         nats.AckExplicitPolicy,
+		Replicas:          3,
+		InactiveThreshold: time.Hour,
+	})
+	require_NoError(t, err)
+
+	cl := c.consumerLeader(globalAccountName, "TEST", "CONSUMER")
+	require_NotNil(t, cl)
+	cf := c.randomNonConsumerLeader(globalAccountName, "TEST", "CONSUMER")
+	require_NotNil(t, cf)
+	require_NotEqual(t, cl, cf)
+
+	// Get the follower's local consumer object.
+	mset, err := cf.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	o := mset.lookupConsumer("CONSUMER")
+	require_NotNil(t, o)
+	require_False(t, o.isLeader())
+
+	// Simulate a stale cleanup timer firing post-stepdown on a follower.
+	go o.deleteNotActive()
+
+	// Give any erroneous delete proposal time to apply.
+	time.Sleep(2 * time.Second)
+
+	_, err = js.ConsumerInfo("TEST", "CONSUMER")
+	require_NoError(t, err)
+}
+
 func TestJetStreamClusterReplacementPolicyAfterPeerRemove(t *testing.T) {
 	// R3 scenario where there is a redundant node in each unique cloud so removing a peer should result in
 	// an immediate replacement also preserving cloud uniqueness.

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -1766,6 +1766,104 @@ func TestJetStreamClusterGhostEphemeralsAfterRestart(t *testing.T) {
 	})
 }
 
+func TestJetStreamClusterConsumerUpdateRaceWithDeleteNotActiveDefer(t *testing.T) {
+	// Long enough that the retry loop keeps sleeping while we restart the meta
+	// leader and update the consumer, then wakes up to re-check the assignment.
+	consumerNotActiveStartInterval = 5 * time.Second
+	consumerNotActiveMaxInterval = 5 * time.Second
+	t.Cleanup(func() {
+		consumerNotActiveStartInterval = defaultConsumerNotActiveStartInterval
+		consumerNotActiveMaxInterval = defaultConsumerNotActiveMaxInterval
+	})
+
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	// R1 so the consumer lives on a single peer.
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:           "CONSUMER",
+		AckPolicy:         nats.AckExplicitPolicy,
+		Replicas:          1,
+		InactiveThreshold: 1500 * time.Millisecond,
+	})
+	require_NoError(t, err)
+
+	c.waitOnConsumerLeader(globalAccountName, "TEST", "CONSUMER")
+	consumerLeader := c.consumerLeader(globalAccountName, "TEST", "CONSUMER")
+	require_NotNil(t, consumerLeader)
+
+	// Shut down both non-consumer peers so meta loses quorum entirely; just
+	// stopping the meta leader is not enough since the remaining two would
+	// elect a new one within ~1s and the proposal would land normally.
+	var otherPeers []*Server
+	for _, s := range c.servers {
+		if s != consumerLeader {
+			otherPeers = append(otherPeers, s)
+		}
+	}
+	require_Equal(t, len(otherPeers), 2)
+	otherPeers[0].Shutdown()
+	otherPeers[1].Shutdown()
+
+	// Let InactiveThreshold elapse so deleteNotActive fires; its first
+	// ForwardProposal is dropped (no meta leader) and the retry loop sleeps.
+	time.Sleep(3 * time.Second)
+
+	// Restart both peers so the cluster elects a new meta leader.
+	c.restartServer(otherPeers[0])
+	c.restartServer(otherPeers[1])
+	c.waitOnLeader()
+
+	// Reconnect, the original connection might have been to a stopped peer.
+	nc.Close()
+	nc, js = jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// Update the consumer so the new consumerAssignment differs from the one
+	// the inflight deleteNotActive captured.
+	_, err = js.UpdateConsumer("TEST", &nats.ConsumerConfig{
+		Durable:           "CONSUMER",
+		AckPolicy:         nats.AckExplicitPolicy,
+		Replicas:          1,
+		InactiveThreshold: time.Hour,
+	})
+	require_NoError(t, err)
+
+	// Confirm the update actually landed and is visible to the API.
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		ci, err := js.ConsumerInfo("TEST", "CONSUMER")
+		if err != nil {
+			return fmt.Errorf("consumer info failed: %w", err)
+		}
+		if ci.Config.InactiveThreshold != time.Hour {
+			return fmt.Errorf("expected updated InactiveThreshold=1h, got %v", ci.Config.InactiveThreshold)
+		}
+		return nil
+	})
+
+	// During the retry-tick window (between +cnaStart and +2*cnaStart) the loop
+	// must wake up, see the assignment changed, and return without deleting
+	// locally. Continuously verify the consumer remains until we're past the
+	// latest possible tick fire so a regression fails fast.
+	deadline := time.Now().Add(2*consumerNotActiveStartInterval + time.Second)
+	for time.Now().Before(deadline) {
+		ci, err := js.ConsumerInfo("TEST", "CONSUMER")
+		require_NoError(t, err)
+		require_Equal(t, ci.Config.InactiveThreshold, time.Hour)
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
 func TestJetStreamClusterReplacementPolicyAfterPeerRemove(t *testing.T) {
 	// R3 scenario where there is a redundant node in each unique cloud so removing a peer should result in
 	// an immediate replacement also preserving cloud uniqueness.


### PR DESCRIPTION
`o.deleteNotActive()` could erroneously remove a consumer that the cluster still considered valid: the unconditional `defer o.delete()` would fire on every return path of the clustered branch, including when the retry loop correctly bailed because the assignment had changed. This PR drops the deferred local delete in the clustered path (leaving cleanup to the proposal flow) and adds a `!o.isLeader()` guard so followers exit `deleteNotActive` immediately rather than forwarding removal proposals.