### PR TITLE
[FIXED] Preserve meta state on transient JetStream error

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -11584,7 +11584,7 @@ func (fs *fileStore) flushStreamStateLoop(qch, done chan struct{}) {
 				fs.warn("File system permission denied when flushing stream state, disabling JetStream: %v", err)
 				// messages in block cache could be lost in the worst case.
 				// In the clustered mode it is very highly unlikely as a result of replication.
-				fs.srv.DisableJetStream()
+				fs.srv.ShutdownJetStream()
 				return
 			}
 

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -574,7 +574,7 @@ func (s *Server) restartJetStream() error {
 	err := s.EnableJetStream(&cfg)
 	if err != nil {
 		s.Warnf("Can't start JetStream: %v", err)
-		return s.DisableJetStream()
+		return s.ShutdownJetStream()
 	}
 	s.updateJetStreamInfoStatus(true)
 	return nil
@@ -626,7 +626,7 @@ func (s *Server) handleOutOfSpace(mset *stream) {
 			s.Errorf("JetStream out of resources, will be DISABLED")
 		}
 
-		go s.DisableJetStream()
+		go s.ShutdownJetStream()
 
 		adv := &JSServerOutOfSpaceAdvisory{
 			TypedEvent: TypedEvent{
@@ -645,8 +645,23 @@ func (s *Server) handleOutOfSpace(mset *stream) {
 }
 
 // DisableJetStream will turn off JetStream and signals in clustered mode
-// to have the metacontroller remove us from the peer list.
+// to have the metacontroller remove us from the peer list. Persistent
+// meta-raft state on disk is removed. For transient runtime errors where
+// the server should rejoin its existing meta group on restart, use
+// ShutdownJetStream instead.
 func (s *Server) DisableJetStream() error {
+	return s.disableJetStream(true)
+}
+
+// ShutdownJetStream is like DisableJetStream but preserves persistent
+// meta-raft state on disk so the server can rejoin the existing meta
+// group on restart. Use for transient runtime errors that the operator
+// is expected to fix before restarting.
+func (s *Server) ShutdownJetStream() error {
+	return s.disableJetStream(false)
+}
+
+func (s *Server) disableJetStream(deleteState bool) error {
 	if !s.JetStreamEnabled() {
 		return nil
 	}
@@ -677,7 +692,12 @@ func (s *Server) DisableJetStream() error {
 					s.Warnf("JetStream timeout waiting for meta leader transfer")
 				}
 			}
-			meta.Delete()
+			if deleteState {
+				meta.Delete()
+			} else {
+				meta.Stop()
+				meta.WaitForStop()
+			}
 		}
 	}
 
@@ -2891,7 +2911,7 @@ func (s *Server) handleWritePermissionError() {
 	if s.JetStreamEnabled() {
 		s.Errorf("File system permission denied while writing, disabling JetStream")
 
-		go s.DisableJetStream()
+		go s.ShutdownJetStream()
 
 		//TODO Send respective advisory if needed, same as in handleOutOfSpace
 	}

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -3473,6 +3473,93 @@ func TestJetStreamClusterInterestLeakOnDisableJetStream(t *testing.T) {
 	})
 }
 
+func TestJetStreamClusterDisableVsShutdownJetStreamMetaState(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.leader())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+	c.waitOnAllCurrent()
+
+	var followers []*Server
+	for _, s := range c.servers {
+		if s.Running() && !s.JetStreamIsLeader() {
+			followers = append(followers, s)
+		}
+	}
+	require_True(t, len(followers) >= 2)
+	sShutdown, sDisable := followers[0], followers[1]
+
+	// ShutdownJetStream preserves meta-raft state on disk.
+	shutdownDir := filepath.Join(sShutdown.JetStreamConfig().StoreDir, DEFAULT_SYSTEM_ACCOUNT, defaultStoreDirName, defaultMetaGroupName)
+	tavFile := filepath.Join(shutdownDir, termVoteFile)
+	peersFile := filepath.Join(shutdownDir, peerStateFile)
+	for _, f := range []string{shutdownDir, tavFile, peersFile} {
+		if _, err := os.Stat(f); err != nil {
+			t.Fatalf("expected %s to exist before Shutdown: %v", f, err)
+		}
+	}
+	require_NoError(t, sShutdown.ShutdownJetStream())
+	for _, f := range []string{shutdownDir, tavFile, peersFile} {
+		if _, err := os.Stat(f); err != nil {
+			t.Fatalf("expected %s to be preserved after Shutdown: %v", f, err)
+		}
+	}
+
+	// DisableJetStream wipes meta-raft state on disk.
+	disableDir := filepath.Join(sDisable.JetStreamConfig().StoreDir, DEFAULT_SYSTEM_ACCOUNT, defaultStoreDirName, defaultMetaGroupName)
+	if _, err := os.Stat(disableDir); err != nil {
+		t.Fatalf("expected %s to exist before Disable: %v", disableDir, err)
+	}
+	require_NoError(t, sDisable.DisableJetStream())
+	if _, err := os.Stat(disableDir); !os.IsNotExist(err) {
+		t.Fatalf("expected %s to be removed after Disable, got err=%v", disableDir, err)
+	}
+}
+
+// https://github.com/nats-io/nats-server/issues/8150
+func TestJetStreamClusterHandleWritePermissionErrorPreservesMetaState(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.leader())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+	c.waitOnAllCurrent()
+
+	s := c.randomNonLeader()
+	tavFile := filepath.Join(s.JetStreamConfig().StoreDir, DEFAULT_SYSTEM_ACCOUNT, defaultStoreDirName, defaultMetaGroupName, termVoteFile)
+	if _, err := os.Stat(tavFile); err != nil {
+		t.Fatalf("expected %s to exist before the simulated permission error: %v", tavFile, err)
+	}
+
+	s.handleWritePermissionError()
+
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		if s.JetStreamEnabled() {
+			return fmt.Errorf("JetStream still enabled")
+		}
+		return nil
+	})
+
+	if _, err := os.Stat(tavFile); err != nil {
+		t.Fatalf("meta state was wiped after a transient permission error: %v", err)
+	}
+}
+
 func TestJetStreamClusterNoLeadersDuringLameDuck(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/stream.go
+++ b/server/stream.go
@@ -3274,7 +3274,7 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 	if err != nil {
 		if strings.Contains(err.Error(), "no space left") {
 			s.Errorf("JetStream out of space, will be DISABLED")
-			s.DisableJetStream()
+			s.ShutdownJetStream()
 			return false
 		}
 		if err != errLastSeqMismatch {
@@ -4424,7 +4424,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 		s := mset.srv
 		if strings.Contains(err.Error(), "no space left") {
 			s.Errorf("JetStream out of space, will be DISABLED")
-			s.DisableJetStream()
+			s.ShutdownJetStream()
 		} else {
 			mset.mu.RLock()
 			accName, sname, iName := mset.acc.Name, mset.cfg.Name, si.iname
@@ -6962,7 +6962,7 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 		if isPermissionError(err) {
 			// messages in block cache could be lost in the worst case.
 			// In the clustered mode it is very highly unlikely as a result of replication.
-			go mset.srv.DisableJetStream()
+			go mset.srv.ShutdownJetStream()
 			mset.srv.Warnf("Filesystem permission denied while writing msg, disabling JetStream: %v", err)
 			return err
 		}


### PR DESCRIPTION
`DisableJetStream` shuts down JetStream and deletes the meta state from disk. However, there were calls where the intention was purely to shut down JetStream, for example on transient runtime errors. This PR introduces `ShutdownJetStream` for that purpose, which doesn't delete meta state.

Relates to https://github.com/nats-io/nats-server/issues/8150