### PR TITLE
Fix time.After leaks in long-running reconnect and OCSP loops

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -738,6 +738,10 @@ func connectToRemoteLeafNode(s *Server, remote *leafNodeCfg, firstConnect bool) 
 		defer remote.cancelMigrateTimer()
 	}
 
+	reconnectTimer := time.NewTimer(reconnectDelay)
+	reconnectTimer.Stop()
+	defer stopAndClearTimer(&reconnectTimer)
+
 	for s.isRunning() && remote.stillValid() {
 		rURL := remote.pickNextURL()
 		url, err := s.getRandomIP(resolver, rURL.Host, nil)
@@ -789,12 +793,13 @@ func connectToRemoteLeafNode(s *Server, remote *leafNodeCfg, firstConnect bool) 
 				})
 			}
 			remote.Unlock()
+			reconnectTimer.Reset(delay)
 			select {
 			case <-s.quitCh:
 				return false
 			case <-remote.quitCh:
 				return false
-			case <-time.After(delay):
+			case <-reconnectTimer.C:
 				// Check if we should migrate any JetStream assets immediately while this remote is down.
 				// This will be used if JetStreamClusterMigrateDelay was not set
 				if jetstreamMigrateDelay == 0 {

--- a/server/ocsp.go
+++ b/server/ocsp.go
@@ -308,10 +308,13 @@ func (oc *OCSPMonitor) run() {
 		return
 	}
 
+	nextRunTimer := time.NewTimer(nextRun)
+	defer stopAndClearTimer(&nextRunTimer)
+
 	for {
 		// On reload, if the certificate changes then need to stop this monitor.
 		select {
-		case <-time.After(nextRun):
+		case <-nextRunTimer.C:
 		case <-stopCh:
 			// In case of reload and have to restart the OCSP stapling monitoring.
 			return
@@ -323,6 +326,7 @@ func (oc *OCSPMonitor) run() {
 		if err != nil {
 			nextRun = oc.getNextRun()
 			s.Errorf("Bad OCSP status update for certificate '%s': %s, trying again in %v", certFile, err, nextRun)
+			nextRunTimer.Reset(nextRun)
 			continue
 		}
 
@@ -334,6 +338,7 @@ func (oc *OCSPMonitor) run() {
 				"Received OCSP status for %s certificate '%s': good, next update %s, checking again in %s",
 				kind, certFile, t, nextRun,
 			)
+			nextRunTimer.Reset(nextRun)
 			continue
 		default:
 			s.Errorf("Received OCSP status for %s certificate '%s': %s", kind, certFile, ocspStatusString(n))

--- a/server/route.go
+++ b/server/route.go
@@ -2904,6 +2904,10 @@ func (s *Server) connectToRoute(rURL *url.URL, rtype RouteType, firstConnect boo
 	s.mu.RUnlock()
 
 	attemptDelay := routeConnectDelay
+	reconnectTimer := time.NewTimer(attemptDelay)
+	reconnectTimer.Stop()
+	defer stopAndClearTimer(&reconnectTimer)
+
 	for attempts := 0; s.isRunning(); {
 		if tryForEver {
 			if !s.routeStillValid(rURL) {
@@ -2943,10 +2947,11 @@ func (s *Server) connectToRoute(rURL *url.URL, rtype RouteType, firstConnect boo
 					return
 				}
 			}
+			reconnectTimer.Reset(attemptDelay)
 			select {
 			case <-s.quitCh:
 				return
-			case <-time.After(attemptDelay):
+			case <-reconnectTimer.C:
 				if opts.Cluster.ConnectBackoff {
 					// Use exponential backoff for connection attempts.
 					attemptDelay *= 2


### PR DESCRIPTION
## Summary

Replace `time.After` with `time.NewTimer` in three long-running loops where the timer fires infrequently relative to loop iterations:

- `server/ocsp.go`: OCSP monitor loop (24h timer)
- `server/leafnode.go`: leafnode reconnect loop
- `server/route.go`: route reconnect loop

Each `time.After` call creates a timer that cannot be GC'd until it fires. In loops that run for the server's lifetime, these accumulate. This is a follow-up to #8186 which fixed the same pattern in `jetstream_api.go` and `jetstream_cluster.go`.

## Pattern used

Uses the project's `stopAndClearTimer(&timer)` helper (defined in `server/consumer.go`) for deferred cleanup, consistent with the established codebase convention. Go 1.25+ (`go.mod`) means `timer.Reset()` is safe without draining the channel.

## Timer placement

- **OCSP (`ocsp.go`):** `Reset` is placed before each `continue` (after work), correctly measuring only wait time since `nextRun` is recomputed during work.
- **Leafnode/Route:** `Reset` is placed immediately before `select` on the error path, matching the original `time.After` semantics where the timer starts counting at select evaluation time.

## Bug origin

| File | Author | Date |
|------|--------|------|
| `server/ocsp.go:314` | Jaime Pina | 2021-05-06 |
| `server/leafnode.go:797` | Waldemar Quevedo | 2023-08-15 |
| `server/route.go:2949` | Maurice van Veen | 2025-07-07 |

## Test plan

- `TestLeafNode*` passes with `-race` (95.6s)
- `TestRoute*` passes with `-race` (98.0s)
- `TestOCSPPeerNextUpdateUnset` passes with `-race` (7.1s)
- `gofmt`, `go vet`, `go build` all clean

Signed-off-by: Sebastien Tardif <sebtardif@ncf.ca>