### PR TITLE
[IMPROVED] Stream/consumer assignment error visibility and cleanup races

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2216,6 +2216,8 @@ func (o *consumer) deleteNotActive() {
 
 	s, js := o.mset.srv, o.srv.js.Load()
 	acc, stream, name, isDirect := o.acc.Name, o.stream, o.name, o.cfg.Direct
+	// Capture our own view of the assignment while we still hold the lock.
+	ca := o.ca
 	var qch, cqch chan struct{}
 	if o.srv != nil {
 		qch = o.srv.quitCh
@@ -2241,8 +2243,11 @@ func (o *consumer) deleteNotActive() {
 			meta        RaftNode
 			removeEntry []byte
 		)
-		ca, cc := js.consumerAssignment(acc, stream, name), js.cluster
-		if ca != nil && cc != nil {
+		nca := js.consumerAssignment(acc, stream, name)
+		// Only propose the delete if the meta-layer assignment still refers to
+		// the consumer we captured, otherwise we'd be racing a recreated
+		// consumer with the same name.
+		if cc := js.cluster; cc != nil && ca != nil && ca.sameIdentity(nca) {
 			meta = cc.meta
 			cca := ca.clone()
 			cca.Reply = _EMPTY_
@@ -2251,7 +2256,7 @@ func (o *consumer) deleteNotActive() {
 		}
 		js.mu.RUnlock()
 
-		if ca != nil && cc != nil {
+		if ca != nil && meta != nil {
 			// Check to make sure we went away.
 			// Don't think this needs to be a monitored go routine.
 			jitter := time.Duration(rand.Int63n(int64(cnaStart)))
@@ -2274,10 +2279,11 @@ func (o *consumer) deleteNotActive() {
 					js.mu.RUnlock()
 					return
 				}
-				nca := js.consumerAssignment(acc, stream, name)
-				js.mu.RUnlock()
+				nca = js.consumerAssignment(acc, stream, name)
 				// Make sure this is the same consumer assignment, and not a new consumer with the same name.
-				if nca != nil && reflect.DeepEqual(nca, ca) {
+				match := ca.sameIdentity(nca)
+				js.mu.RUnlock()
+				if match {
 					s.Warnf("Consumer assignment for '%s > %s > %s' not cleaned up, retrying", acc, stream, name)
 					meta.ForwardProposal(removeEntry)
 					if interval < cnaMax {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -728,6 +728,14 @@ func (js *jetStream) isStreamHealthy(acc *Account, sa *streamAssignment) error {
 		js.mu.RUnlock()
 		return errors.New("stream assignment or group missing")
 	}
+	// Surface any persisted assignment-level error (e.g. failed create on this
+	// peer due to account limits) so the health check reflects the broken state
+	// instead of falling through to runtime-only checks.
+	if sa.err != nil {
+		err := sa.err
+		js.mu.RUnlock()
+		return fmt.Errorf("stream assignment error: %w", err)
+	}
 	streamName := sa.Config.Name
 	node := sa.Group.node
 	js.mu.RUnlock()
@@ -802,6 +810,14 @@ func (js *jetStream) isConsumerHealthy(mset *stream, consumer string, ca *consum
 	if ca == nil || ca.Group == nil {
 		js.mu.RUnlock()
 		return errors.New("consumer assignment or group missing")
+	}
+	// Surface any persisted assignment-level error (e.g. failed create on this
+	// peer) so the health check reflects the broken state instead of falling
+	// through to runtime-only checks.
+	if ca.err != nil {
+		err := ca.err
+		js.mu.RUnlock()
+		return fmt.Errorf("consumer assignment error: %w", err)
 	}
 	created := ca.Created
 	node := ca.Group.node
@@ -5056,6 +5072,7 @@ func (s *Server) removeStream(mset *stream, nsa *streamAssignment) {
 	if js, _ := s.getJetStreamCluster(); js != nil {
 		js.mu.Lock()
 		nsa.Group.node = nil
+		nsa.err = nil
 		isShuttingDown = js.shuttingDown
 		js.mu.Unlock()
 	}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3663,6 +3663,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 					mset.delete()
 				}
 				js.mu.Lock()
+				s.Warnf("Stream restore failed for '%s > %s': %v", sa.Client.serviceAccount(), sa.Config.Name, err)
 				sa.err = err
 				if n != nil {
 					n.Delete()
@@ -5166,9 +5167,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 		mset.setStreamAssignment(sa)
 
 		// Call update.
-		if err = mset.updateWithAdvisory(cfg, !recovering, false); err != nil {
-			s.Warnf("JetStream cluster error updating stream %q for account %q: %v", cfg.Name, acc.Name, err)
-		}
+		err = mset.updateWithAdvisory(cfg, !recovering, false)
 	}
 
 	// If not found we must be expanding into this node since if we are here we know we are a member.
@@ -5179,6 +5178,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 
 	if err != nil {
 		js.mu.Lock()
+		s.Warnf("Stream update failed for '%s > %s': %v", sa.Client.serviceAccount(), sa.Config.Name, err)
 		sa.err = err
 		result := &streamAssignmentResult{
 			Account:  sa.Client.serviceAccount(),
@@ -5356,8 +5356,8 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 			return
 		}
 
+		s.Warnf("Stream create failed for '%s > %s': %v", sa.Client.serviceAccount(), sa.Config.Name, err)
 		if IsNatsErr(err, JSStreamStoreFailedF) {
-			s.Warnf("Stream create failed for '%s > %s': %v", sa.Client.serviceAccount(), sa.Config.Name, err)
 			err = errStreamStoreFailed
 		}
 		js.mu.Lock()
@@ -5437,6 +5437,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 							mset.delete()
 						}
 						js.mu.Lock()
+						s.Warnf("Stream restore failed for '%s > %s': %v", sa.Client.serviceAccount(), sa.Config.Name, err)
 						sa.err = err
 						result := &streamAssignmentResult{
 							Account: sa.Client.serviceAccount(),
@@ -6025,13 +6026,12 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 			return
 		}
 
+		s.Warnf("Consumer create failed for '%s > %s > %s': %v", ca.Client.serviceAccount(), ca.Stream, ca.Name, err)
 		if IsNatsErr(err, JSConsumerStoreFailedErrF) {
-			s.Warnf("Consumer create failed for '%s > %s > %s': %v", ca.Client.serviceAccount(), ca.Stream, ca.Name, err)
 			err = errConsumerStoreFailed
 		}
 
 		js.mu.Lock()
-
 		ca.err = err
 		hasResponded := ca.hasResponded()
 
@@ -7222,9 +7222,17 @@ func (js *jetStream) processStreamAssignmentResults(sub *subscription, c *client
 		}
 		// Remove this assignment if possible.
 		if canDelete {
+			var apiErr *ApiError
+			if result.Response != nil {
+				apiErr = result.Response.Error
+			} else if result.Restore != nil {
+				apiErr = result.Restore.Error
+			}
+			s.Warnf("Stream assignment for '%s > %s' rejected by assigned member: %v", sa.Client.serviceAccount(), sa.Config.Name, apiErr)
 			sa.err = NewJSClusterNotAssignedError()
-			cc.meta.Propose(encodeDeleteStreamAssignment(sa))
-			cc.trackInflightStreamProposal(result.Account, sa, true)
+			if err := cc.meta.Propose(encodeDeleteStreamAssignment(sa)); err == nil {
+				cc.trackInflightStreamProposal(result.Account, sa, true)
+			}
 		}
 	}
 }
@@ -7259,6 +7267,7 @@ func (js *jetStream) processConsumerAssignmentResults(sub *subscription, c *clie
 			// Make sure this is recent response.
 			if result.Response.Error != nil && result.Response.Error != NewJSConsumerNameExistError() && time.Since(ca.Created) < 2*time.Second {
 				// Do not list in consumer names/lists.
+				s.Warnf("Consumer assignment for '%s > %s > %s' rejected by assigned member: %v", ca.Client.serviceAccount(), ca.Stream, ca.Name, result.Response.Error)
 				ca.err = NewJSClusterNotAssignedError()
 			}
 		}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -5100,6 +5100,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 	storage, cfg := sa.Config.Storage, sa.Config
 	recovering := sa.recovering
 	hasResponded := sa.markResponded()
+	hadErr := sa.err != nil
 	js.mu.RUnlock()
 
 	mset, err := acc.lookupStream(cfg.Name)
@@ -5192,6 +5193,10 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 		// Send response to the metadata leader. They will forward to the user as needed.
 		s.sendInternalMsgLocked(streamAssignmentSubj, _EMPTY_, nil, result)
 		return
+	} else if hadErr {
+		js.mu.Lock()
+		sa.err = nil
+		js.mu.Unlock()
 	}
 
 	isLeader := mset.IsLeader()
@@ -5248,6 +5253,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 	storage := sa.Config.Storage
 	restore := sa.Restore
 	recovering := sa.recovering
+	hadErr := sa.err != nil
 	js.mu.RUnlock()
 
 	// Process the raft group and make sure it's running if needed.
@@ -5390,6 +5396,10 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 			s.sendInternalMsgLocked(streamAssignmentSubj, _EMPTY_, nil, result)
 		}
 		return
+	} else if hadErr {
+		js.mu.Lock()
+		sa.err = nil
+		js.mu.Unlock()
 	}
 
 	// Re-capture node.
@@ -6074,8 +6084,14 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 		}
 	} else {
 		js.mu.RLock()
+		hadErr := ca.err != nil
 		node := rg.node
 		js.mu.RUnlock()
+		if hadErr {
+			js.mu.Lock()
+			ca.err = nil
+			js.mu.Unlock()
+		}
 
 		if didCreate {
 			o.setCreatedTime(ca.Created)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -320,6 +320,21 @@ func (ca *consumerAssignment) clearResponded() {
 	ca.responded.Store(false)
 }
 
+// sameIdentity reports whether nca refers to the same logical consumer as ca.
+// Only stable identity fields (Name, Stream, Group name, Created time) are
+// compared; request-routing fields like Client/Reply and transient flags are
+// intentionally excluded since processClusterCreateConsumer may set the
+// per-object o.ca to a clone with the original requester's Client/Reply
+// preserved while the meta-layer holds the newer values.
+func (ca *consumerAssignment) sameIdentity(nca *consumerAssignment) bool {
+	return ca != nil && nca != nil &&
+		nca.Name == ca.Name &&
+		nca.Stream == ca.Stream &&
+		nca.Created.Equal(ca.Created) &&
+		nca.Group != nil && ca.Group != nil &&
+		nca.Group.Name == ca.Group.Name
+}
+
 // clone returns a copy of ca. Field-explicit (rather than `*ca`) and
 // pointer-returning so the embedded atomic.Bool isn't value-copied;
 // responded is transferred via Load/Store. Concurrent callers may write

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -8054,6 +8054,118 @@ func TestJetStreamClusterConsumerHealthCheckSurfacesAssignmentErr(t *testing.T) 
 	require_NoError(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca))
 }
 
+func TestJetStreamClusterStreamHealthCheckRecoversAfterSuccessfulUpdate(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	sl := c.streamLeader(globalAccountName, "TEST")
+	sjs := sl.getJetStream()
+	acc := sl.globalAccount()
+
+	sjs.mu.Lock()
+	sa := sjs.streamAssignment(globalAccountName, "TEST")
+	sjs.mu.Unlock()
+	require_True(t, sa != nil)
+
+	// Plant a transient assignment-level error. Health check must now fail.
+	wantErr := errors.New("synthetic stream assignment failure")
+	sjs.mu.Lock()
+	sa.err = wantErr
+	sjs.mu.Unlock()
+	err = sjs.isStreamHealthy(acc, sa)
+	require_Error(t, err)
+	require_Contains(t, err.Error(), wantErr.Error())
+
+	// A successful update should clear it.
+	_, err = js.UpdateStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo", "bar"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	sjs.mu.RLock()
+	cur := sjs.streamAssignment(globalAccountName, "TEST")
+	var gotErr error
+	if cur != nil {
+		gotErr = cur.err
+	}
+	sjs.mu.RUnlock()
+	require_True(t, cur != nil)
+	require_NoError(t, gotErr)
+	require_NoError(t, sjs.isStreamHealthy(acc, cur))
+}
+
+func TestJetStreamClusterConsumerHealthCheckRecoversAfterSuccessfulUpdate(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:       "CONSUMER",
+		AckPolicy:     nats.AckExplicitPolicy,
+		MaxAckPending: 100,
+	})
+	require_NoError(t, err)
+
+	cl := c.consumerLeader(globalAccountName, "TEST", "CONSUMER")
+	require_NotNil(t, cl)
+	mset, err := cl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+
+	sjs := cl.getJetStream()
+	sjs.mu.Lock()
+	ca := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+	sjs.mu.Unlock()
+	require_True(t, ca != nil)
+
+	// Plant a transient assignment-level error. Health check must now fail.
+	wantErr := errors.New("synthetic consumer assignment failure")
+	sjs.mu.Lock()
+	ca.err = wantErr
+	sjs.mu.Unlock()
+	err = sjs.isConsumerHealthy(mset, "CONSUMER", ca)
+	require_Error(t, err)
+	require_Contains(t, err.Error(), wantErr.Error())
+
+	// A successful update should clear it.
+	_, err = js.UpdateConsumer("TEST", &nats.ConsumerConfig{
+		Durable:       "CONSUMER",
+		AckPolicy:     nats.AckExplicitPolicy,
+		MaxAckPending: 200,
+	})
+	require_NoError(t, err)
+
+	sjs.mu.RLock()
+	cur := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+	var gotErr error
+	if cur != nil {
+		gotErr = cur.err
+	}
+	sjs.mu.RUnlock()
+	require_True(t, cur != nil)
+	require_NoError(t, gotErr)
+	require_NoError(t, sjs.isConsumerHealthy(mset, "CONSUMER", cur))
+}
+
 func TestJetStreamClusterRespectConsumerStartSeq(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -7964,6 +7964,96 @@ func TestJetStreamClusterConsumerHealthCheckDeleted(t *testing.T) {
 	require_NoError(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca))
 }
 
+func TestJetStreamClusterStreamHealthCheckSurfacesAssignmentErr(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	sl := c.streamLeader(globalAccountName, "TEST")
+	sjs := sl.getJetStream()
+	acc := sl.globalAccount()
+
+	sjs.mu.Lock()
+	sa := sjs.streamAssignment(globalAccountName, "TEST")
+	sjs.mu.Unlock()
+	require_True(t, sa != nil)
+
+	// Baseline: healthy.
+	require_NoError(t, sjs.isStreamHealthy(acc, sa))
+
+	// Persisted assignment-level error must surface via the health check.
+	wantErr := errors.New("synthetic stream assignment failure")
+	sjs.mu.Lock()
+	sa.err = wantErr
+	sjs.mu.Unlock()
+
+	err = sjs.isStreamHealthy(acc, sa)
+	require_Error(t, err)
+	require_Contains(t, err.Error(), wantErr.Error())
+
+	// Clearing the err brings health back.
+	sjs.mu.Lock()
+	sa.err = nil
+	sjs.mu.Unlock()
+	require_NoError(t, sjs.isStreamHealthy(acc, sa))
+}
+
+func TestJetStreamClusterConsumerHealthCheckSurfacesAssignmentErr(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Durable: "CONSUMER"})
+	require_NoError(t, err)
+
+	cl := c.consumerLeader(globalAccountName, "TEST", "CONSUMER")
+	require_NotNil(t, cl)
+	mset, err := cl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+
+	sjs := cl.getJetStream()
+	sjs.mu.Lock()
+	ca := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+	sjs.mu.Unlock()
+	require_True(t, ca != nil)
+
+	// Baseline: healthy.
+	require_NoError(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca))
+
+	// Persisted assignment-level error must surface via the health check.
+	wantErr := errors.New("synthetic consumer assignment failure")
+	sjs.mu.Lock()
+	ca.err = wantErr
+	sjs.mu.Unlock()
+
+	err = sjs.isConsumerHealthy(mset, "CONSUMER", ca)
+	require_Error(t, err)
+	require_Contains(t, err.Error(), wantErr.Error())
+
+	// Clearing the err brings health back.
+	sjs.mu.Lock()
+	ca.err = nil
+	sjs.mu.Unlock()
+	require_NoError(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca))
+}
+
 func TestJetStreamClusterRespectConsumerStartSeq(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -1766,16 +1766,7 @@ func TestJetStreamClusterGhostEphemeralsAfterRestart(t *testing.T) {
 	})
 }
 
-func TestJetStreamClusterConsumerUpdateRaceWithDeleteNotActiveDefer(t *testing.T) {
-	// Long enough that the retry loop keeps sleeping while we restart the meta
-	// leader and update the consumer, then wakes up to re-check the assignment.
-	consumerNotActiveStartInterval = 5 * time.Second
-	consumerNotActiveMaxInterval = 5 * time.Second
-	t.Cleanup(func() {
-		consumerNotActiveStartInterval = defaultConsumerNotActiveStartInterval
-		consumerNotActiveMaxInterval = defaultConsumerNotActiveMaxInterval
-	})
-
+func TestJetStreamClusterConsumerAssignmentSameIdentity(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 
@@ -1789,79 +1780,68 @@ func TestJetStreamClusterConsumerUpdateRaceWithDeleteNotActiveDefer(t *testing.T
 	})
 	require_NoError(t, err)
 
-	// R1 so the consumer lives on a single peer.
 	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
-		Durable:           "CONSUMER",
-		AckPolicy:         nats.AckExplicitPolicy,
-		Replicas:          1,
-		InactiveThreshold: 1500 * time.Millisecond,
+		Durable:   "CONSUMER",
+		Replicas:  1,
+		AckPolicy: nats.AckExplicitPolicy,
 	})
 	require_NoError(t, err)
 
-	c.waitOnConsumerLeader(globalAccountName, "TEST", "CONSUMER")
-	consumerLeader := c.consumerLeader(globalAccountName, "TEST", "CONSUMER")
-	require_NotNil(t, consumerLeader)
-
-	// Shut down both non-consumer peers so meta loses quorum entirely; just
-	// stopping the meta leader is not enough since the remaining two would
-	// elect a new one within ~1s and the proposal would land normally.
-	var otherPeers []*Server
-	for _, s := range c.servers {
-		if s != consumerLeader {
-			otherPeers = append(otherPeers, s)
-		}
+	// Snapshot the original assignment from the meta leader.
+	captureCa := func() *consumerAssignment {
+		ml := c.leader()
+		require_NotNil(t, ml)
+		mjs := ml.getJetStream()
+		require_NotNil(t, mjs)
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		ca := mjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+		require_NotNil(t, ca)
+		// Clone so it survives subsequent delete/recreate of the live entry.
+		return ca.clone()
 	}
-	require_Equal(t, len(otherPeers), 2)
-	otherPeers[0].Shutdown()
-	otherPeers[1].Shutdown()
+	oldCa := captureCa()
 
-	// Let InactiveThreshold elapse so deleteNotActive fires; its first
-	// ForwardProposal is dropped (no meta leader) and the retry loop sleeps.
-	time.Sleep(3 * time.Second)
-
-	// Restart both peers so the cluster elects a new meta leader.
-	c.restartServer(otherPeers[0])
-	c.restartServer(otherPeers[1])
-	c.waitOnLeader()
-
-	// Reconnect, the original connection might have been to a stopped peer.
-	nc.Close()
-	nc, js = jsClientConnect(t, c.randomServer())
-	defer nc.Close()
-
-	// Update the consumer so the new consumerAssignment differs from the one
-	// the inflight deleteNotActive captured.
+	// A config update keeps the same Name/Stream/Group/Created, so an inflight
+	// deleteNotActive holding the prior ca must still consider this the same
+	// logical consumer.
 	_, err = js.UpdateConsumer("TEST", &nats.ConsumerConfig{
 		Durable:           "CONSUMER",
-		AckPolicy:         nats.AckExplicitPolicy,
 		Replicas:          1,
+		AckPolicy:         nats.AckExplicitPolicy,
 		InactiveThreshold: time.Hour,
 	})
 	require_NoError(t, err)
 
-	// Confirm the update actually landed and is visible to the API.
 	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
-		ci, err := js.ConsumerInfo("TEST", "CONSUMER")
-		if err != nil {
-			return fmt.Errorf("consumer info failed: %w", err)
+		updatedCa := captureCa()
+		if updatedCa.Config.InactiveThreshold != time.Hour {
+			return fmt.Errorf("update not yet reflected, got %v", updatedCa.Config.InactiveThreshold)
 		}
-		if ci.Config.InactiveThreshold != time.Hour {
-			return fmt.Errorf("expected updated InactiveThreshold=1h, got %v", ci.Config.InactiveThreshold)
+		if !oldCa.sameIdentity(updatedCa) {
+			return fmt.Errorf("expected same identity across update")
 		}
 		return nil
 	})
 
-	// During the retry-tick window (between +cnaStart and +2*cnaStart) the loop
-	// must wake up, see the assignment changed, and return without deleting
-	// locally. Continuously verify the consumer remains until we're past the
-	// latest possible tick fire so a regression fails fast.
-	deadline := time.Now().Add(2*consumerNotActiveStartInterval + time.Second)
-	for time.Now().Before(deadline) {
-		ci, err := js.ConsumerInfo("TEST", "CONSUMER")
-		require_NoError(t, err)
-		require_Equal(t, ci.Config.InactiveThreshold, time.Hour)
-		time.Sleep(200 * time.Millisecond)
-	}
+	// Delete and recreate. The new consumer must have a distinct identity so a
+	// stale deleteNotActive holding oldCa would correctly skip the proposal.
+	require_NoError(t, js.DeleteConsumer("TEST", "CONSUMER"))
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "CONSUMER",
+		Replicas:  1,
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		newCa := captureCa()
+		if oldCa.sameIdentity(newCa) {
+			return fmt.Errorf("expected different identity across recreate (old.Created=%v new.Created=%v old.Group=%q new.Group=%q)",
+				oldCa.Created, newCa.Created, oldCa.Group.Name, newCa.Group.Name)
+		}
+		return nil
+	})
 }
 
 func TestJetStreamClusterDeleteNotActiveOnFollowerDoesNotDeleteConsumer(t *testing.T) {


### PR DESCRIPTION
- Consumer's `deleteNotActive` compares against object-local assignment: Relaxes the identity check to not be a `reflect.DeepEqual` and capture `o.ca` under lock.
- Surface assignment errors in stream/consumer health checks: A peer that failed to create the stream/consumer now reports unhealthy via `isStreamHealthy/isConsumerHealthy`, so these surface directly instead of with a generic "not found" error.
- Surface assignment errors in stream/consumer log messages: Every create/update/restore failure now emits a warning naming the account, stream, and consumer, so operators can diagnose stuck assignments from logs. Also track the inflight meta change properly for a failed stream assignment.
- Clear stale `sa/ca.err` values after success: When a previously-failed stream/consumer create/update later succeeds, it should be cleared such that the health check reports healthy again.
