### PR TITLE
Allow cancellation of `IntersectGSL`, optimise skip block check

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2850,14 +2850,11 @@ func (mb *msgBlock) firstMatchingMulti(sl *gsl.SimpleSublist, start uint64, sm *
 		// If there are no subject matches then this is effectively no-op.
 		hseq := uint64(math.MaxUint64)
 		var ierr error
-		stree.IntersectGSL(mb.fss, sl, func(subj []byte, ss *SimpleState) {
-			if ierr != nil {
-				return
-			}
+		stree.IntersectGSL(mb.fss, sl, func(subj []byte, ss *SimpleState) bool {
 			if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
 				// mb is already loaded into the cache so should be fast-ish.
 				if ierr = mb.recalculateForSubj(bytesToString(subj), ss); ierr != nil {
-					return
+					return false
 				}
 			}
 			first := max(start, ss.First)
@@ -2865,12 +2862,12 @@ func (mb *msgBlock) firstMatchingMulti(sl *gsl.SimpleSublist, start uint64, sm *
 				// The start cutoff is after the last sequence for this subject,
 				// or we think we already know of a subject with an earlier msg
 				// than our first seq for this subject.
-				return
+				return true
 			}
 			// Need messages loaded from here on out.
 			if mb.cacheNotLoaded() {
 				if ierr = mb.loadMsgsWithLock(); ierr != nil {
-					return
+					return false
 				}
 				didLoad = true
 			}
@@ -2884,7 +2881,7 @@ func (mb *msgBlock) firstMatchingMulti(sl *gsl.SimpleSublist, start uint64, sm *
 					sm = fsm
 					hseq = ss.First
 				}
-				return
+				return true
 			}
 			for seq := first; seq <= ss.Last; seq++ {
 				// Otherwise we have a start floor that intersects where this subject
@@ -2910,6 +2907,7 @@ func (mb *msgBlock) firstMatchingMulti(sl *gsl.SimpleSublist, start uint64, sm *
 				// If we are here we did not match, so put the llseq back.
 				mb.llseq = llseq
 			}
+			return true
 		})
 		if ierr != nil {
 			return nil, false, ierr
@@ -3147,14 +3145,11 @@ func (mb *msgBlock) prevMatchingMulti(sl *gsl.SimpleSublist, start uint64, sm *S
 		// If there are no subject matches then this is effectively no-op.
 		hseq := uint64(0)
 		var ierr error
-		stree.IntersectGSL(mb.fss, sl, func(subj []byte, ss *SimpleState) {
-			if ierr != nil {
-				return
-			}
+		stree.IntersectGSL(mb.fss, sl, func(subj []byte, ss *SimpleState) bool {
 			if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
 				// mb is already loaded into the cache so should be fast-ish.
 				if ierr = mb.recalculateForSubj(bytesToString(subj), ss); ierr != nil {
-					return
+					return false
 				}
 			}
 			first := min(start, ss.Last)
@@ -3163,7 +3158,7 @@ func (mb *msgBlock) prevMatchingMulti(sl *gsl.SimpleSublist, start uint64, sm *S
 			if first < ss.First || first <= hseq {
 				// The start cutoff is before the first sequence for this subject,
 				// or we already know of a subject with a later-or-equal msg.
-				return
+				return true
 			}
 			if first == ss.Last {
 				// If the start floor is above where this subject starts then we can
@@ -3172,7 +3167,7 @@ func (mb *msgBlock) prevMatchingMulti(sl *gsl.SimpleSublist, start uint64, sm *S
 					sm = fsm
 					hseq = ss.Last
 				}
-				return
+				return true
 			}
 			for seq := first; seq >= ss.First; seq-- {
 				// Otherwise we have a start floor that intersects where this subject
@@ -3198,6 +3193,7 @@ func (mb *msgBlock) prevMatchingMulti(sl *gsl.SimpleSublist, start uint64, sm *S
 				// If we are here we did not match, so put the llseq back.
 				mb.llseq = llseq
 			}
+			return true
 		})
 		if ierr != nil {
 			return nil, false, ierr
@@ -3459,16 +3455,29 @@ func (fs *fileStore) checkSkipFirstBlock(filter string, wc bool, bi int) (int, e
 // This is used to see if we can selectively jump start blocks based on filter subjects and a starting block index.
 // Will return -1 and ErrStoreEOF if no matches at all or no more from where we are.
 func (fs *fileStore) checkSkipFirstBlockMulti(sl *gsl.SimpleSublist, bi int) (int, error) {
+	// Don't bother if full wildcard.
+	if sl.MatchesFullWildcard() {
+		return bi + 1, nil
+	}
 	// Move through psim to gather start and stop bounds.
 	start, stop := uint32(math.MaxUint32), uint32(0)
-	stree.IntersectGSL(fs.psim, sl, func(subj []byte, psi *psi) {
+	guard := fs.blks[bi].getIndex() + 1
+	stree.IntersectGSL(fs.psim, sl, func(subj []byte, psi *psi) bool {
 		if psi.fblk < start {
 			start = psi.fblk
+		}
+		if start == guard {
+			// One of the subjects matches the next block, so there's no point in carrying on trying to skip.
+			return false
 		}
 		if psi.lblk > stop {
 			stop = psi.lblk
 		}
+		return true
 	})
+	if start == guard {
+		return bi + 1, nil
+	}
 	// Nothing was found.
 	if start == uint32(math.MaxUint32) {
 		return -1, ErrStoreEOF
@@ -4343,10 +4352,10 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPer
 		mb := fs.blks[seqStart]
 		bi := mb.index
 
-		stree.IntersectGSL(fs.psim, sl, func(subj []byte, psi *psi) {
+		stree.IntersectGSL(fs.psim, sl, func(subj []byte, psi *psi) bool {
 			// If the select blk start is greater than entry's last blk skip.
 			if bi > psi.lblk {
-				return
+				return true
 			}
 			total++
 			// We will track the subjects that are an exact match to the last block.
@@ -4354,6 +4363,7 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPer
 			if psi.lblk == bi {
 				lbm[string(subj)] = true
 			}
+			return true
 		})
 
 		// Now check if we need to inspect the seqStart block.
@@ -4443,18 +4453,11 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPer
 			var ierr error
 			var havePartial bool
 			var updateLLTS bool
-			stree.IntersectGSL[SimpleState](mb.fss, sl, func(bsubj []byte, ss *SimpleState) {
-				if ierr != nil {
-					return
-				}
+			stree.IntersectGSL[SimpleState](mb.fss, sl, func(bsubj []byte, ss *SimpleState) bool {
 				subj := bytesToString(bsubj)
-				if havePartial {
-					// If we already found a partial then don't do anything else.
-					return
-				}
 				if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
 					if ierr = mb.recalculateForSubj(subj, ss); ierr != nil {
-						return
+						return false
 					}
 				}
 				if sseq <= ss.First {
@@ -4462,7 +4465,9 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPer
 				} else if sseq <= ss.Last {
 					// We matched but its a partial.
 					havePartial = true
+					return false
 				}
+				return true
 			})
 			if ierr != nil {
 				mb.mu.Unlock()
@@ -4515,12 +4520,13 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPer
 
 	// If we are here it's better to calculate totals from psim and adjust downward by scanning less blocks.
 	start := uint32(math.MaxUint32)
-	stree.IntersectGSL(fs.psim, sl, func(subj []byte, psi *psi) {
+	stree.IntersectGSL(fs.psim, sl, func(subj []byte, psi *psi) bool {
 		total += psi.total
 		// Keep track of start index for this subject.
 		if psi.fblk < start {
 			start = psi.fblk
 		}
+		return true
 	})
 
 	// See if we were asked for all, if so we are done.
@@ -4566,8 +4572,9 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPer
 				}
 				// Mark fss activity.
 				mb.lsts = ats.AccessTime()
-				stree.IntersectGSL(mb.fss, sl, func(bsubj []byte, ss *SimpleState) {
+				stree.IntersectGSL(mb.fss, sl, func(bsubj []byte, ss *SimpleState) bool {
 					adjust += ss.Msgs
+					return true
 				})
 			}
 		} else {
@@ -9063,12 +9070,13 @@ func (fs *fileStore) LoadNextMsgMulti(sl *gsl.SimpleSublist, start uint64, smp *
 	if start <= fs.state.FirstSeq {
 		var total uint64
 		blkStart := uint32(math.MaxUint32)
-		stree.IntersectGSL(fs.psim, sl, func(subj []byte, psi *psi) {
+		stree.IntersectGSL(fs.psim, sl, func(subj []byte, psi *psi) bool {
 			total += psi.total
 			// Keep track of start index for this subject.
 			if psi.fblk < blkStart {
 				blkStart = psi.fblk
 			}
+			return true
 		})
 		// Nothing available.
 		if total == 0 {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -961,7 +961,7 @@ func (ms *memStore) NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPerS
 	var havePartial bool
 	var totalSkipped uint64
 	// We will track start and end sequences as we go.
-	stree.IntersectGSL[SimpleState](ms.fss, sl, func(subj []byte, fss *SimpleState) {
+	stree.IntersectGSL[SimpleState](ms.fss, sl, func(subj []byte, fss *SimpleState) bool {
 		if fss.firstNeedsUpdate || fss.lastNeedsUpdate {
 			ms.recalculateForSubj(bytesToString(subj), fss)
 		}
@@ -975,6 +975,7 @@ func (ms *memStore) NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPerS
 		} else {
 			totalSkipped += fss.Msgs
 		}
+		return true
 	})
 
 	// If we did not encounter any partials we can return here.

--- a/server/stree/stree.go
+++ b/server/stree/stree.go
@@ -485,7 +485,7 @@ func LazyIntersect[TL, TR any](tl *SubjectTree[TL], tr *SubjectTree[TR], cb func
 // IntersectGSL will match all items in the given subject tree that
 // have interest expressed in the given sublist. The callback will only be called
 // once for each subject, regardless of overlapping subscriptions in the sublist.
-func IntersectGSL[T any, SL comparable](t *SubjectTree[T], sl *gsl.GenericSublist[SL], cb func(subject []byte, val *T)) {
+func IntersectGSL[T any, SL comparable](t *SubjectTree[T], sl *gsl.GenericSublist[SL], cb func(subject []byte, val *T) bool) {
 	if t == nil || t.root == nil || sl == nil {
 		return
 	}
@@ -493,14 +493,14 @@ func IntersectGSL[T any, SL comparable](t *SubjectTree[T], sl *gsl.GenericSublis
 	_intersectGSL(t.root, _pre[:0], sl, cb)
 }
 
-func _intersectGSL[T any, SL comparable](n node, pre []byte, sl *gsl.GenericSublist[SL], cb func(subject []byte, val *T)) {
+func _intersectGSL[T any, SL comparable](n node, pre []byte, sl *gsl.GenericSublist[SL], cb func(subject []byte, val *T) bool) bool {
 	if n.isLeaf() {
 		ln := n.(*leaf[T])
 		subj := append(pre, ln.suffix...)
 		if sl.HasInterest(bytesToString(subj)) {
-			cb(subj, &ln.value)
+			return cb(subj, &ln.value)
 		}
-		return
+		return true
 	}
 	bn := n.base()
 	pre = append(pre, bn.prefix...)
@@ -512,8 +512,11 @@ func _intersectGSL[T any, SL comparable](n node, pre []byte, sl *gsl.GenericSubl
 		if !hasInterestForTokens(sl, subj, len(pre)) {
 			continue
 		}
-		_intersectGSL(cn, pre, sl, cb)
+		if !_intersectGSL(cn, pre, sl, cb) {
+			return false
+		}
 	}
+	return true
 }
 
 // The subject tree can return partial tokens so we need to check starting interest

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -1017,8 +1017,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("one.two.six", 11))
 		require_NoError(t, sl.Insert("eight.nine", 22))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 2)
 		require_NoDuplicates(t, got)
@@ -1028,8 +1029,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		got := map[string]int{}
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("one.two.*.*", 11))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 2)
 		require_NoDuplicates(t, got)
@@ -1040,8 +1042,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("one.two.*.four", 11))
 		require_NoError(t, sl.Insert("one.two.*.*", 22))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 2)
 		require_NoDuplicates(t, got)
@@ -1056,8 +1059,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		require_True(t, sl.HasInterest("foo.bar"))
 		require_True(t, sl.HasInterest("foo.bar.baz"))
 		require_True(t, sl.HasInterest("foo.bar.baz.qux"))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 7)
 		require_NoDuplicates(t, got)
@@ -1067,8 +1071,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		got := map[string]int{}
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("one.>", 11))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 4)
 		require_NoDuplicates(t, got)
@@ -1080,8 +1085,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		require_NoError(t, sl.Insert("one.two.three.four", 11))
 		require_NoError(t, sl.Insert("one.>", 22))
 		require_NoError(t, sl.Insert(">", 33))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 7)
 		require_NoDuplicates(t, got)
@@ -1092,8 +1098,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("stream.A.>", 11))
 		require_NoError(t, sl.Insert("stream.A", 22))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 2)
 		require_NoDuplicates(t, got)
@@ -1104,8 +1111,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("stream.*.child", 11))
 		require_NoError(t, sl.Insert("stream.A", 22))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 2)
 		require_NoDuplicates(t, got)
@@ -1121,8 +1129,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		require_NoError(t, sl.Insert("stream.*.*", 22))
 		require_NoError(t, sl.Insert("*.A.*", 22))
 		require_NoError(t, sl.Insert("*.*.child", 22))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 1)
 		require_NoDuplicates(t, got)
@@ -1136,8 +1145,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		require_NoError(t, sl.Insert("stream.A.*", 22))
 		require_NoError(t, sl.Insert("*.A.*", 22))
 		require_NoError(t, sl.Insert("*.*.child", 22))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 1)
 		require_NoDuplicates(t, got)
@@ -1148,8 +1158,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("stream.A.child", 11))
 		require_NoError(t, sl.Insert("stream.*.*", 22))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 1)
 		require_NoDuplicates(t, got)
@@ -1160,8 +1171,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("stream.A.child", 11))
 		require_NoError(t, sl.Insert("stream.*.>", 22))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 1)
 		require_NoDuplicates(t, got)
@@ -1172,8 +1184,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("stream.A.child", 11))
 		require_NoError(t, sl.Insert("*.*", 22))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 3)
 		require_NoDuplicates(t, got)
@@ -1184,8 +1197,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("stream.A.child", 11))
 		require_NoError(t, sl.Insert("stream.*", 22))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 2)
 		require_NoDuplicates(t, got)
@@ -1196,8 +1210,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("stream.A", 11))
 		require_NoError(t, sl.Insert("*.*.*", 22))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 4)
 		require_NoDuplicates(t, got)
@@ -1207,19 +1222,32 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		got := map[string]int{}
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert(">", 11))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 7)
 		require_NoDuplicates(t, got)
+	})
+
+	t.Run("StopsWhenCallbackReturnsFalse", func(t *testing.T) {
+		var got int
+		sl := gsl.NewSublist[int]()
+		require_NoError(t, sl.Insert(">", 11))
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
+			got++
+			return false
+		})
+		require_Equal(t, got, 1)
 	})
 
 	t.Run("NoMatch", func(t *testing.T) {
 		got := map[string]int{}
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("one", 11))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 0)
 	})
@@ -1230,8 +1258,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		require_NoError(t, sl.Insert("one", 11))
 		require_NoError(t, sl.Insert("eight", 22))
 		require_NoError(t, sl.Insert("ten", 33))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 0)
 	})
@@ -1241,8 +1270,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("stream.A.not-child", 11))
 		require_NoError(t, sl.Insert("stream.A.child.>", 22))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 0)
 		require_NoDuplicates(t, got)
@@ -1253,8 +1283,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("one.*.six", 11))
 		require_NoError(t, sl.Insert("one.two.seven", 22))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 2)
 		require_NoDuplicates(t, got)
@@ -1266,8 +1297,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		require_NoError(t, sl.Insert("one.*.*.four", 11))
 		require_NoError(t, sl.Insert("one.*.*.five", 22))
 		require_NoError(t, sl.Insert("one.*.three", 33))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 2)
 		require_NoDuplicates(t, got)
@@ -1283,8 +1315,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("one.two.*.*", 33))
 		require_NoError(t, sl.Insert("*.two.three.four", 55))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		// Due to bitmask comparison, one.two.*.* may be skipped in favor of *.two.three.four
 		// This results in only one.two.three.four being matched, missing one.two.three.five
@@ -1297,8 +1330,9 @@ func TestSubjectTreeGSLIntersection(t *testing.T) {
 		sl := gsl.NewSublist[int]()
 		require_NoError(t, sl.Insert("one.*.four.five", 11))
 		require_NoError(t, sl.Insert("one.two.three.four", 22))
-		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) {
+		IntersectGSL(st, sl, func(subj []byte, entry *struct{}) bool {
 			got[string(subj)]++
+			return true
 		})
 		require_Len(t, len(got), 1)
 		require_NoDuplicates(t, got)


### PR DESCRIPTION
Cancelling intersection mid-flight allows us to optimise the `checkSkipFirstBlockMulti` check by exiting early if we find that the optimisation is wasted because we're going to end up at the next block anyway.