### PR TITLE
[ADDED] Make Client ID available in Custom ClientAuthentication

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -56,6 +56,8 @@ type ClientAuthentication interface {
 	GetNonce() []byte
 	// Kind indicates what type of connection this is matching defined constants like CLIENT, ROUTER, GATEWAY, LEAF etc
 	Kind() int
+	//Gets the ID associated with a client
+	GetID() uint64
 }
 
 // NkeyUser is for multiple nkey based users

--- a/server/client.go
+++ b/server/client.go
@@ -560,6 +560,13 @@ func (c *client) GetNonce() []byte {
 	return c.nonce
 }
 
+// GetID returns the client ID
+func (c *client) GetID() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.cid
+}
+
 // GetName returns the application supplied name for the connection.
 func (c *client) GetName() string {
 	c.mu.Lock()


### PR DESCRIPTION
Make Client ID available in Custom ClientAuthentication

As per https://github.com/nats-io/nats-server/issues/8137

Allows a user of the Custom ClientAuthentication mechanism to make use of the Client ID at a later period of time in order for instance to disconnect the Client.

This means the custom application does not need to run through all the client connections in order to determine the client ID via Nkey or Name for instance.

I created a new branch ClientAuthentication2 - with the updated for the commit sign off.
