### PR TITLE
feat: allow adding custom storage providers

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1832,11 +1832,11 @@ func (jsa *jsAccount) reservedStorage(tier string) (mem, store uint64) {
 		storage, replicas, maxBytes := mset.cfg.Storage, mset.cfg.Replicas, mset.cfg.MaxBytes
 		mset.cfgMu.RUnlock()
 		if (tier == _EMPTY_ || tier == tierName(replicas)) && maxBytes > 0 {
-			switch storage {
-			case FileStorage:
-				store += uint64(maxBytes)
-			case MemoryStorage:
+			// Custom storage providers are persistent and counted as file store.
+			if storage == MemoryStorage {
 				mem += uint64(maxBytes)
+			} else {
+				store += uint64(maxBytes)
 			}
 		}
 	}
@@ -1849,11 +1849,11 @@ func reservedStorage(sas map[string]*streamAssignment, tier string) (mem, store 
 	for _, sa := range sas {
 		cfg := sa.Config
 		if (tier == _EMPTY_ || tier == tierName(cfg.Replicas)) && cfg.MaxBytes > 0 {
-			switch cfg.Storage {
-			case FileStorage:
-				store += uint64(cfg.MaxBytes)
-			case MemoryStorage:
+			// Custom storage providers are persistent and counted as file store.
+			if cfg.Storage == MemoryStorage {
 				mem += uint64(cfg.MaxBytes)
+			} else {
+				store += uint64(cfg.MaxBytes)
 			}
 		}
 	}
@@ -2494,8 +2494,8 @@ func (js *jetStream) checkBytesLimits(selectedLimits *JetStreamAccountLimits, ti
 	serverBytes := addSaturate(addBytes, maxBytesOffset)
 	accountBytes := accountReservation(tier, replicas, serverBytes)
 
-	switch storage {
-	case MemoryStorage:
+	// Custom storage providers are persistent and accounted against the file store.
+	if storage == MemoryStorage {
 		// Account limits defined.
 		if selectedLimits.MaxMemory >= 0 && (currentRes > selectedLimits.MaxMemory || accountBytes > selectedLimits.MaxMemory-currentRes) {
 			return NewJSMemoryResourcesExceededError()
@@ -2504,7 +2504,7 @@ func (js *jetStream) checkBytesLimits(selectedLimits *JetStreamAccountLimits, ti
 		if checkServer && (js.memReserved > js.config.MaxMemory || serverBytes > js.config.MaxMemory-js.memReserved) {
 			return NewJSMemoryResourcesExceededError()
 		}
-	case FileStorage:
+	} else {
 		// Account limits defined.
 		if selectedLimits.MaxStore >= 0 && (currentRes > selectedLimits.MaxStore || accountBytes > selectedLimits.MaxStore-currentRes) {
 			return NewJSStorageResourcesExceededError()
@@ -2654,10 +2654,10 @@ func (js *jetStream) reserveStreamResources(cfg *StreamConfig) {
 	}
 
 	js.mu.Lock()
-	switch cfg.Storage {
-	case MemoryStorage:
+	// Custom storage providers are persistent and reserved against the file store.
+	if cfg.Storage == MemoryStorage {
 		js.memReserved += cfg.MaxBytes
-	case FileStorage:
+	} else {
 		js.storeReserved += cfg.MaxBytes
 	}
 	s, clustered := js.srv, !js.standAlone
@@ -2675,10 +2675,10 @@ func (js *jetStream) releaseStreamResources(cfg *StreamConfig) {
 	}
 
 	js.mu.Lock()
-	switch cfg.Storage {
-	case MemoryStorage:
+	// Custom storage providers are persistent and reserved against the file store.
+	if cfg.Storage == MemoryStorage {
 		js.memReserved -= cfg.MaxBytes
-	case FileStorage:
+	} else {
 		js.storeReserved -= cfg.MaxBytes
 	}
 	s, clustered := js.srv, !js.standAlone

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -128,18 +128,29 @@ func getBatchStoreDir(storeDir, streamName, batchId string) (string, string) {
 }
 
 func newBatchStore(mset *stream, batchId string, replicas int, storage StorageType, storeDir, streamName string) (StreamStore, error) {
-	if replicas == 1 && storage == FileStorage {
-		bname, storeDir := getBatchStoreDir(storeDir, streamName, batchId)
-		fcfg := FileStoreConfig{AsyncFlush: true, BlockSize: defaultLargeBlockSize, StoreDir: storeDir}
-		s := mset.srv
-		prf := s.jsKeyGen(s.getOpts().JetStreamKey, mset.acc.Name)
-		if prf != nil {
-			// We are encrypted here, fill in correct cipher selection.
-			fcfg.Cipher = s.getOpts().JetStreamCipher
+	// For R1 streams we stage batches in a persistent store so they survive hard
+	// kills. Custom providers are persistent and get their own staging namespace.
+	if replicas == 1 {
+		if provider := streamStoreProvider(storage); provider != nil {
+			bname, storeDir := getBatchStoreDir(storeDir, streamName, batchId)
+			return provider(StreamStoreConfig{
+				StreamConfig: &StreamConfig{Name: bname, Storage: storage},
+				FileConfig:   &FileStoreConfig{AsyncFlush: true, BlockSize: defaultLargeBlockSize, StoreDir: storeDir},
+			})
 		}
-		oldprf := s.jsKeyGen(s.getOpts().JetStreamOldKey, mset.acc.Name)
-		cfg := StreamConfig{Name: bname, Storage: FileStorage}
-		return newFileStoreWithCreated(fcfg, cfg, time.Time{}, prf, oldprf)
+		if storage == FileStorage {
+			bname, storeDir := getBatchStoreDir(storeDir, streamName, batchId)
+			fcfg := FileStoreConfig{AsyncFlush: true, BlockSize: defaultLargeBlockSize, StoreDir: storeDir}
+			s := mset.srv
+			prf := s.jsKeyGen(s.getOpts().JetStreamKey, mset.acc.Name)
+			if prf != nil {
+				// We are encrypted here, fill in correct cipher selection.
+				fcfg.Cipher = s.getOpts().JetStreamCipher
+			}
+			oldprf := s.jsKeyGen(s.getOpts().JetStreamOldKey, mset.acc.Name)
+			cfg := StreamConfig{Name: bname, Storage: FileStorage}
+			return newFileStoreWithCreated(fcfg, cfg, time.Time{}, prf, oldprf)
+		}
 	}
 	return newMemStore(&StreamConfig{Name: _EMPTY_, Storage: MemoryStorage})
 }
@@ -953,7 +964,8 @@ func checkMsgHeadersPreClusteredProposal(
 		diff.inflight = make(map[string]*inflightSubjectRunningTotal, 1)
 	}
 	var sz uint64
-	if mset.store.Type() == FileStorage {
+	// Custom storage providers are persistent and sized like the file store.
+	if mset.store.Type() != MemoryStorage {
 		sz = fileStoreMsgSizeRaw(len(subject), len(hdr), len(msg))
 	} else {
 		sz = memStoreMsgSizeRaw(len(subject), len(hdr), len(msg))

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3005,7 +3005,18 @@ retry:
 
 	n, err := func() (RaftNode, error) {
 		var store StreamStore
-		if storage == FileStorage {
+		if provider := streamStoreProvider(storage); provider != nil {
+			ps, err := provider(StreamStoreConfig{
+				StreamConfig: &StreamConfig{Name: rgName, Storage: storage, Metadata: labels},
+				FileConfig:   &FileStoreConfig{StoreDir: storeDir, BlockSize: defaultMediumBlockSize},
+				Created:      time.Now().UTC(),
+			})
+			if err != nil {
+				s.Errorf("Error creating provider WAL: %v", err)
+				return nil, err
+			}
+			store = ps
+		} else if storage == FileStorage {
 			opts := s.getOpts()
 			fs, err := newFileStoreWithCreated(
 				FileStoreConfig{StoreDir: storeDir, BlockSize: defaultMediumBlockSize, AsyncFlush: false, SyncAlways: opts.SyncAlways, SyncInterval: opts.SyncInterval, srv: s},
@@ -4593,7 +4604,8 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 			// Decrement from pending operations. Once it reaches zero, it can be deleted.
 			if i.ops > 0 {
 				var sz uint64
-				if mset.store.Type() == FileStorage {
+				// Custom storage providers are persistent and sized like the file store.
+				if mset.store.Type() != MemoryStorage {
 					sz = fileStoreMsgSizeRaw(len(csubject), len(hdr), len(msg))
 				} else {
 					sz = memStoreMsgSizeRaw(len(csubject), len(hdr), len(msg))
@@ -8022,8 +8034,8 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 
 		var available uint64
 		if ni.stats != nil {
-			switch cfg.Storage {
-			case MemoryStorage:
+			// Custom storage providers are accounted against the file store bucket.
+			if cfg.Storage == MemoryStorage {
 				used := ni.stats.ReservedMemory
 				if ni.stats.Memory > used {
 					used = ni.stats.Memory
@@ -8031,7 +8043,7 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 				if ni.cfg.MaxMemory > int64(used) {
 					available = uint64(ni.cfg.MaxMemory) - used
 				}
-			case FileStorage:
+			} else {
 				used := ni.stats.ReservedStore
 				if ni.stats.Store > used {
 					used = ni.stats.Store

--- a/server/raft.go
+++ b/server/raft.go
@@ -4672,7 +4672,8 @@ func (n *raft) storeToWAL(ae *appendEntry) error {
 	}
 
 	var sz uint64
-	if n.wtype == FileStorage {
+	// Custom storage providers are persistent and sized like the file store.
+	if n.wtype != MemoryStorage {
 		sz = fileStoreMsgSize(_EMPTY_, nil, ae.buf)
 	} else {
 		sz = memStoreMsgSize(_EMPTY_, nil, ae.buf)

--- a/server/store.go
+++ b/server/store.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unsafe"
 
@@ -79,6 +81,64 @@ type StoreMsg struct {
 	ts   int64
 }
 
+// Set stores message fields in sm for StreamStore implementations outside this package.
+func (sm *StoreMsg) Set(subject string, hdr, msg []byte, seq uint64, ts int64) {
+	if sm == nil {
+		return
+	}
+	sm.buf = append(sm.buf[:0], hdr...)
+	sm.buf = append(sm.buf, msg...)
+	if len(hdr) > 0 {
+		sm.hdr = sm.buf[:len(hdr):len(hdr)]
+	} else {
+		sm.hdr = nil
+	}
+	sm.msg = sm.buf[len(hdr):]
+	sm.subj = subject
+	sm.seq = seq
+	sm.ts = ts
+}
+
+// Subject returns the stored message subject.
+func (sm *StoreMsg) Subject() string {
+	if sm == nil {
+		return _EMPTY_
+	}
+	return sm.subj
+}
+
+// Header returns the stored message header bytes.
+func (sm *StoreMsg) Header() []byte {
+	if sm == nil {
+		return nil
+	}
+	return sm.hdr
+}
+
+// Message returns the stored message payload bytes.
+func (sm *StoreMsg) Message() []byte {
+	if sm == nil {
+		return nil
+	}
+	return sm.msg
+}
+
+// Sequence returns the stored message sequence.
+func (sm *StoreMsg) Sequence() uint64 {
+	if sm == nil {
+		return 0
+	}
+	return sm.seq
+}
+
+// TimeStamp returns the stored message timestamp as Unix nanoseconds.
+func (sm *StoreMsg) TimeStamp() int64 {
+	if sm == nil {
+		return 0
+	}
+	return sm.ts
+}
+
 // Used to call back into the upper layers to report on changes in storage resources.
 // For the cases where its a single message we will also supply sequence number and subject.
 type StorageUpdateHandler func(msgs, bytes int64, seq uint64, subj string)
@@ -89,6 +149,66 @@ type StorageRemoveMsgHandler func(seq uint64)
 // Used to call back into the upper layers to process a JetStream message.
 // Will propose the message if the stream is replicated.
 type ProcessJetStreamMsgHandler func(*inMsg)
+
+// StreamStoreProvider constructs a StreamStore for a registered storage type.
+type StreamStoreProvider func(StreamStoreConfig) (StreamStore, error)
+
+// StreamStoreConfig contains the inputs needed to construct a stream store.
+type StreamStoreConfig struct {
+	StreamConfig *StreamConfig
+	FileConfig   *FileStoreConfig
+	Created      time.Time
+}
+
+type storageProviderRegistration struct {
+	name        string
+	displayName string
+	provider    StreamStoreProvider
+}
+
+var storageProviders = struct {
+	sync.RWMutex
+	byType map[StorageType]storageProviderRegistration
+	byName map[string]StorageType
+}{
+	byType: make(map[StorageType]storageProviderRegistration),
+	byName: make(map[string]StorageType),
+}
+
+// RegisterStreamStoreProvider registers an external StreamStore provider.
+//
+// Custom providers are treated as persistent, file-like storage for resource
+// accounting, placement and replication. The provider must be registered
+// before JetStream is enabled so that persisted stream assignments referencing
+// the custom storage type can be unmarshaled and recovered. In a cluster the
+// same provider (storage type and name) must be registered on every node that
+// may host the stream, including its replicas.
+func RegisterStreamStoreProvider(storage StorageType, name string, provider StreamStoreProvider) error {
+	if storage == FileStorage || storage == MemoryStorage || name == _EMPTY_ || provider == nil {
+		return fmt.Errorf("invalid stream store provider")
+	}
+	jsonName := strings.ToLower(name)
+	if jsonName == memoryStorageString || jsonName == fileStorageString {
+		return fmt.Errorf("stream store provider name %q is reserved", name)
+	}
+	storageProviders.Lock()
+	defer storageProviders.Unlock()
+	if _, ok := storageProviders.byType[storage]; ok {
+		return fmt.Errorf("stream store provider already registered for storage type %d", int(storage))
+	}
+	if _, ok := storageProviders.byName[jsonName]; ok {
+		return fmt.Errorf("stream store provider already registered for %q", name)
+	}
+	storageProviders.byType[storage] = storageProviderRegistration{name: jsonName, displayName: name, provider: provider}
+	storageProviders.byName[jsonName] = storage
+	return nil
+}
+
+func streamStoreProvider(storage StorageType) StreamStoreProvider {
+	storageProviders.RLock()
+	defer storageProviders.RUnlock()
+	return storageProviders.byType[storage].provider
+}
 
 type StreamStore interface {
 	StoreMsg(subject string, hdr, msg []byte, ttl int64) (uint64, int64, error)
@@ -555,8 +675,11 @@ func (dp *DiscardPolicy) UnmarshalJSON(data []byte) error {
 }
 
 const (
-	memoryStorageJSONString = `"memory"`
-	fileStorageJSONString   = `"file"`
+	memoryStorageString = "memory"
+	fileStorageString   = "file"
+
+	memoryStorageJSONString = `"` + memoryStorageString + `"`
+	fileStorageJSONString   = `"` + fileStorageString + `"`
 )
 
 var (
@@ -571,6 +694,11 @@ func (st StorageType) String() string {
 	case FileStorage:
 		return "File"
 	default:
+		storageProviders.RLock()
+		defer storageProviders.RUnlock()
+		if registered, ok := storageProviders.byType[st]; ok {
+			return registered.displayName
+		}
 		return "Unknown Storage Type"
 	}
 }
@@ -582,6 +710,11 @@ func (st StorageType) MarshalJSON() ([]byte, error) {
 	case FileStorage:
 		return fileStorageJSONBytes, nil
 	default:
+		storageProviders.RLock()
+		defer storageProviders.RUnlock()
+		if registered, ok := storageProviders.byType[st]; ok {
+			return []byte(strconv.Quote(registered.name)), nil
+		}
 		return nil, fmt.Errorf("can not marshal %v", st)
 	}
 }
@@ -593,6 +726,14 @@ func (st *StorageType) UnmarshalJSON(data []byte) error {
 	case fileStorageJSONString:
 		*st = FileStorage
 	default:
+		name := strings.Trim(strings.ToLower(string(data)), `"`)
+		storageProviders.RLock()
+		storage, ok := storageProviders.byName[name]
+		storageProviders.RUnlock()
+		if ok {
+			*st = storage
+			return nil
+		}
 		return fmt.Errorf("can not unmarshal %q", data)
 	}
 	return nil

--- a/server/stream.go
+++ b/server/stream.go
@@ -5138,30 +5138,42 @@ func (mset *stream) unsubscribe(sub *subscription) {
 
 func (mset *stream) setupStore(fsCfg *FileStoreConfig) error {
 	mset.mu.Lock()
-	switch mset.cfg.Storage {
-	case MemoryStorage:
-		ms, err := newMemStore(&mset.cfg)
+	if provider := streamStoreProvider(mset.cfg.Storage); provider != nil {
+		store, err := provider(StreamStoreConfig{StreamConfig: &mset.cfg, FileConfig: fsCfg, Created: mset.created})
 		if err != nil {
 			mset.mu.Unlock()
 			return err
 		}
-		mset.store = ms
-	case FileStorage:
-		s := mset.srv
-		prf := s.jsKeyGen(s.getOpts().JetStreamKey, mset.acc.Name)
-		if prf != nil {
-			// We are encrypted here, fill in correct cipher selection.
-			fsCfg.Cipher = s.getOpts().JetStreamCipher
-		}
-		oldprf := s.jsKeyGen(s.getOpts().JetStreamOldKey, mset.acc.Name)
-		cfg := *fsCfg
-		cfg.srv = s
-		fs, err := newFileStoreWithCreated(cfg, mset.cfg, mset.created, prf, oldprf)
-		if err != nil {
+		mset.store = store
+	} else {
+		switch mset.cfg.Storage {
+		case MemoryStorage:
+			ms, err := newMemStore(&mset.cfg)
+			if err != nil {
+				mset.mu.Unlock()
+				return err
+			}
+			mset.store = ms
+		case FileStorage:
+			s := mset.srv
+			prf := s.jsKeyGen(s.getOpts().JetStreamKey, mset.acc.Name)
+			if prf != nil {
+				// We are encrypted here, fill in correct cipher selection.
+				fsCfg.Cipher = s.getOpts().JetStreamCipher
+			}
+			oldprf := s.jsKeyGen(s.getOpts().JetStreamOldKey, mset.acc.Name)
+			cfg := *fsCfg
+			cfg.srv = s
+			fs, err := newFileStoreWithCreated(cfg, mset.cfg, mset.created, prf, oldprf)
+			if err != nil {
+				mset.mu.Unlock()
+				return err
+			}
+			mset.store = fs
+		default:
 			mset.mu.Unlock()
-			return err
+			return fmt.Errorf("no stream store provider registered for storage type %v", mset.cfg.Storage)
 		}
-		mset.store = fs
 	}
 	// This will fire the callback but we do not require the lock since md will be 0 here.
 	mset.store.RegisterStorageUpdates(mset.storeUpdates)
@@ -7359,8 +7371,8 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 	}
 
 	// Persist, but optimize if we're committing because we already know last.
-	// If the underlying store is file-based we need to persist everything to survive hard kills, because we're R1.
-	if !commit || b.store.Type() == FileStorage {
+	// If the underlying store is persistent we need to persist everything to survive hard kills, because we're R1.
+	if !commit || b.store.Type() != MemoryStorage {
 		seq, _, err := b.store.StoreMsg(subject, hdr, msg, 0)
 		if err != nil || seq != batchSeq {
 			b.cleanupLocked(batchId, batches)
@@ -7452,7 +7464,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 
 	diff := &batchStagedDiff{}
 	for seq := uint64(1); seq <= batchSeq; seq++ {
-		if seq == batchSeq && !commitEob && b.store.Type() != FileStorage {
+		if seq == batchSeq && !commitEob && b.store.Type() == MemoryStorage {
 			bsubj, bhdr, bmsg = subject, hdr, msg
 		} else if sm, err = b.store.LoadMsg(seq, &smv); sm != nil && err == nil {
 			bsubj, bhdr, bmsg = sm.subj, sm.hdr, sm.msg


### PR DESCRIPTION
When running NATS server on a platform that does not provide regular storage APIs this will allow providing custom backends. My particular use case is running a NATS server on baremetal Go with no operating system providing a storage API at all and using the simple mem backend provides no persistence.