### PR TITLE
[WIP] Added Nats-Schedule-Msg-Id header for deduplicating scheduled messages (#8223)

### DIFF
--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -10786,6 +10786,95 @@ func TestFileStoreMessageSchedule(t *testing.T) {
 	require_Equal(t, bytesToString(getHeader(JSScheduleNext, im.hdr)), JSScheduleNextPurge)
 }
 
+func TestFileStoreMessageScheduleMsgId(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	dir := t.TempDir()
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: dir, srv: s},
+		StreamConfig{Name: "TEST", Subjects: []string{"foo.*"}, Storage: FileStorage, AllowMsgSchedules: true})
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	ch := make(chan *inMsg, 1)
+	fs.pmsgcb = func(im *inMsg) {
+		ch <- im
+	}
+
+	hdr := genHeader(nil, JSSchedulePattern, "@at 1970-01-01T00:00:00Z")
+	hdr = genHeader(hdr, JSScheduleTarget, "foo.target")
+	hdr = genHeader(hdr, JSScheduleMsgId, "fire-1")
+	_, _, err = fs.StoreMsg("foo.schedule", hdr, nil, 0)
+	require_NoError(t, err)
+
+	im := require_ChanRead(t, ch, time.Second*5)
+	require_Equal(t, im.subj, "foo.target")
+	require_Equal(t, bytesToString(getHeader(JSMsgId, im.hdr)), "fire-1")
+	require_Equal(t, len(getHeader(JSScheduleMsgId, im.hdr)), 0)
+}
+
+func TestFileStoreMessageScheduleEmptyMsgId(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	dir := t.TempDir()
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: dir, srv: s},
+		StreamConfig{Name: "TEST", Subjects: []string{"foo.*"}, Storage: FileStorage, AllowMsgSchedules: true})
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	ch := make(chan *inMsg, 1)
+	fs.pmsgcb = func(im *inMsg) {
+		ch <- im
+	}
+
+	hdr := genHeader(nil, JSSchedulePattern, "@at 1970-01-01T00:00:00Z")
+	hdr = genHeader(hdr, JSScheduleTarget, "foo.target")
+	hdr = genHeader(hdr, JSScheduleMsgId, "")
+	_, _, err = fs.StoreMsg("foo.schedule", hdr, nil, 0)
+	require_NoError(t, err)
+
+	im := require_ChanRead(t, ch, time.Second*5)
+	require_Equal(t, im.subj, "foo.target")
+	require_Equal(t, len(getHeader(JSMsgId, im.hdr)), 0)
+}
+
+func TestFileStoreMessageScheduleSourceMsgId(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	dir := t.TempDir()
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: dir, srv: s},
+		StreamConfig{Name: "TEST", Subjects: []string{"foo.*"}, Storage: FileStorage, AllowMsgSchedules: true})
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	ch := make(chan *inMsg, 1)
+	fs.pmsgcb = func(im *inMsg) {
+		ch <- im
+	}
+
+	srcHdr := genHeader(nil, JSMsgId, "source-id")
+	_, _, err = fs.StoreMsg("foo.data", srcHdr, []byte("data"), 0)
+	require_NoError(t, err)
+
+	hdr := genHeader(nil, JSSchedulePattern, "@at 1970-01-01T00:00:00Z")
+	hdr = genHeader(hdr, JSScheduleTarget, "foo.target")
+	hdr = genHeader(hdr, JSScheduleSource, "foo.data")
+	hdr = genHeader(hdr, JSScheduleMsgId, "fire-1")
+	_, _, err = fs.StoreMsg("foo.schedule", hdr, []byte("ignored"), 0)
+	require_NoError(t, err)
+
+	im := require_ChanRead(t, ch, time.Second*5)
+	require_Equal(t, im.subj, "foo.target")
+	require_True(t, bytes.Equal(im.msg, []byte("data")))
+	require_Equal(t, bytesToString(getHeader(JSMsgId, im.hdr)), "fire-1")
+	require_Equal(t, len(getHeader(JSScheduleMsgId, im.hdr)), 0)
+}
+
 func TestFileStoreMessageScheduleRecovered(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -1160,6 +1160,7 @@ func TestJetStreamAtomicBatchPublishStageAndCommit(t *testing.T) {
 					header: nats.Header{
 						JSSchedulePattern: {"@at 1970-01-01T00:00:00Z"},
 						JSScheduleTarget:  {"baz"},
+						JSScheduleMsgId:   {"fire-1"},
 					},
 				},
 				{

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -9921,6 +9921,68 @@ func TestJetStreamClusterScheduledMessageSubjectSourcing(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterScheduledMessageMsgId(t *testing.T) {
+	for _, replicas := range []int{1, 3} {
+		for _, storage := range []StorageType{FileStorage, MemoryStorage} {
+			t.Run(fmt.Sprintf("R%d/%s", replicas, storage), func(t *testing.T) {
+				c := createJetStreamClusterExplicit(t, "R3S", 3)
+				defer c.shutdown()
+
+				nc, js := jsClientConnect(t, c.randomServer())
+				defer nc.Close()
+
+				cfg := &StreamConfig{
+					Name:              "SchedulesEnabled",
+					Subjects:          []string{"foo.*"},
+					Storage:           storage,
+					Replicas:          replicas,
+					AllowMsgSchedules: true,
+					Duplicates:        2 * time.Minute,
+				}
+				_, err := jsStreamCreate(t, nc, cfg)
+				require_NoError(t, err)
+
+				schedulePattern := "@at 1970-01-01T00:00:00Z"
+
+				m := nats.NewMsg("foo.schedule")
+				m.Header.Set("Nats-Schedule", schedulePattern)
+				m.Header.Set("Nats-Schedule-Target", "foo.publish")
+				m.Header.Set("Nats-Msg-Id", "schedule-dedupe-1")
+				m.Header.Set("Nats-Schedule-Msg-Id", "fire-dedupe")
+				_, err = js.PublishMsg(m)
+				require_NoError(t, err)
+
+				m = nats.NewMsg("foo.schedule2")
+				m.Header.Set("Nats-Schedule", schedulePattern)
+				m.Header.Set("Nats-Schedule-Target", "foo.publish")
+				m.Header.Set("Nats-Msg-Id", "schedule-dedupe-2")
+				m.Header.Set("Nats-Schedule-Msg-Id", "fire-dedupe")
+				_, err = js.PublishMsg(m)
+				require_NoError(t, err)
+
+				checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+					mi, err := js.StreamInfo("SchedulesEnabled", &nats.StreamInfoRequest{SubjectsFilter: "foo.publish"})
+					if err != nil {
+						return err
+					}
+					if n := mi.State.Subjects["foo.publish"]; n != 1 {
+						return fmt.Errorf("expected 1 message on foo.publish, got %d", n)
+					}
+					return nil
+				})
+
+				rsm, err := js.GetLastMsg("SchedulesEnabled", "foo.publish")
+				require_NoError(t, err)
+				require_Equal(t, rsm.Header.Get("Nats-Msg-Id"), "fire-dedupe")
+
+				checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+					return checkState(t, c, globalAccountName, "SchedulesEnabled")
+				})
+			})
+		}
+	}
+}
+
 func TestJetStreamClusterScheduledMessageSubjectSourcingFallback(t *testing.T) {
 	for _, replicas := range []int{1, 3} {
 		for _, storage := range []StorageType{FileStorage, MemoryStorage} {

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -1371,6 +1371,92 @@ func TestMemStoreMessageSchedule(t *testing.T) {
 	require_Equal(t, bytesToString(getHeader(JSScheduleNext, im.hdr)), JSScheduleNextPurge)
 }
 
+func TestMemStoreMessageScheduleMsgId(t *testing.T) {
+	fs, err := newMemStore(
+		&StreamConfig{
+			Name: "TEST", Subjects: []string{"foo.*"}, Storage: MemoryStorage,
+			AllowMsgSchedules: true,
+		},
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	ch := make(chan *inMsg, 1)
+	fs.pmsgcb = func(im *inMsg) {
+		ch <- im
+	}
+
+	hdr := genHeader(nil, JSSchedulePattern, "@at 1970-01-01T00:00:00Z")
+	hdr = genHeader(hdr, JSScheduleTarget, "foo.target")
+	hdr = genHeader(hdr, JSScheduleMsgId, "fire-1")
+	_, _, err = fs.StoreMsg("foo.schedule", hdr, nil, 0)
+	require_NoError(t, err)
+
+	im := require_ChanRead(t, ch, time.Second*5)
+	require_Equal(t, im.subj, "foo.target")
+	require_Equal(t, bytesToString(getHeader(JSMsgId, im.hdr)), "fire-1")
+	require_Equal(t, len(getHeader(JSScheduleMsgId, im.hdr)), 0)
+}
+
+func TestMemStoreMessageScheduleEmptyMsgId(t *testing.T) {
+	fs, err := newMemStore(
+		&StreamConfig{
+			Name: "TEST", Subjects: []string{"foo.*"}, Storage: MemoryStorage,
+			AllowMsgSchedules: true,
+		},
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	ch := make(chan *inMsg, 1)
+	fs.pmsgcb = func(im *inMsg) {
+		ch <- im
+	}
+
+	hdr := genHeader(nil, JSSchedulePattern, "@at 1970-01-01T00:00:00Z")
+	hdr = genHeader(hdr, JSScheduleTarget, "foo.target")
+	hdr = genHeader(hdr, JSScheduleMsgId, "")
+	_, _, err = fs.StoreMsg("foo.schedule", hdr, nil, 0)
+	require_NoError(t, err)
+
+	im := require_ChanRead(t, ch, time.Second*5)
+	require_Equal(t, im.subj, "foo.target")
+	require_Equal(t, len(getHeader(JSMsgId, im.hdr)), 0)
+}
+
+func TestMemStoreMessageScheduleSourceMsgId(t *testing.T) {
+	fs, err := newMemStore(
+		&StreamConfig{
+			Name: "TEST", Subjects: []string{"foo.*"}, Storage: MemoryStorage,
+			AllowMsgSchedules: true,
+		},
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	ch := make(chan *inMsg, 1)
+	fs.pmsgcb = func(im *inMsg) {
+		ch <- im
+	}
+
+	srcHdr := genHeader(nil, JSMsgId, "source-id")
+	_, _, err = fs.StoreMsg("foo.data", srcHdr, []byte("data"), 0)
+	require_NoError(t, err)
+
+	hdr := genHeader(nil, JSSchedulePattern, "@at 1970-01-01T00:00:00Z")
+	hdr = genHeader(hdr, JSScheduleTarget, "foo.target")
+	hdr = genHeader(hdr, JSScheduleSource, "foo.data")
+	hdr = genHeader(hdr, JSScheduleMsgId, "fire-1")
+	_, _, err = fs.StoreMsg("foo.schedule", hdr, []byte("ignored"), 0)
+	require_NoError(t, err)
+
+	im := require_ChanRead(t, ch, time.Second*5)
+	require_Equal(t, im.subj, "foo.target")
+	require_True(t, bytes.Equal(im.msg, []byte("data")))
+	require_Equal(t, bytesToString(getHeader(JSMsgId, im.hdr)), "fire-1")
+	require_Equal(t, len(getHeader(JSScheduleMsgId, im.hdr)), 0)
+}
+
 func TestMemStoreNextWildcardMatch(t *testing.T) {
 	cfg := &StreamConfig{
 		Name:     "zzz",

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -200,6 +200,7 @@ func (ms *MsgScheduling) getScheduledMessages(loadMsg func(seq uint64, smv *Stor
 				return true
 			}
 			rollup := getMessageScheduleRollup(sm.hdr)
+			scheduleMsgId := getMessageScheduleMsgId(sm.hdr)
 			source := getMessageScheduleSource(sm.hdr)
 			if source != _EMPTY_ {
 				// Fall back to the scheduled message's own content if the source has no last message.
@@ -233,6 +234,9 @@ func (ms *MsgScheduling) getScheduledMessages(loadMsg func(seq uint64, smv *Stor
 			}
 			if rollup != _EMPTY_ {
 				hdr = genHeader(hdr, JSMsgRollup, rollup)
+			}
+			if scheduleMsgId != _EMPTY_ {
+				hdr = genHeader(hdr, JSMsgId, scheduleMsgId)
 			}
 			msgs = append(msgs, &inMsg{seq: seq, subj: target, hdr: hdr, msg: msg})
 			ms.markInflight(subj)

--- a/server/stream.go
+++ b/server/stream.go
@@ -652,6 +652,7 @@ const (
 	JSScheduleRollup          = "Nats-Schedule-Rollup"
 	JSScheduleTarget          = "Nats-Schedule-Target"
 	JSScheduleSource          = "Nats-Schedule-Source"
+	JSScheduleMsgId           = "Nats-Schedule-Msg-Id"
 )
 
 // Headers for published KV messages.
@@ -5479,6 +5480,18 @@ func getMessageScheduleSource(hdr []byte) string {
 		return _EMPTY_
 	}
 	return string(getHeader(JSScheduleSource, hdr))
+}
+
+// Fast lookup of the message schedule msg-id from headers.
+// Returns empty when the header is absent or empty.
+func getMessageScheduleMsgId(hdr []byte) string {
+	if len(hdr) == 0 {
+		return _EMPTY_
+	}
+	if msgId := string(getHeader(JSScheduleMsgId, hdr)); msgId != _EMPTY_ {
+		return msgId
+	}
+	return _EMPTY_
 }
 
 // Fast lookup of message scheduler.


### PR DESCRIPTION
Resolves #8223 

## Description
This PR adds support for a new Scheduler header, `Nats-Schedule-Msg-Id`.
When a scheduled message fires, the Scheduler reads `Nats-Schedule-Msg-Id` from the schedule record and sets it as `Nats-Msg-Id` on the emitted message. This follows the existing Scheduler header pattern, such as `Nats-Schedule-TTL` becoming `Nats-TTL` and `Nats-Schedule-Rollup` becoming `Nats-Rollup`.
The regular `Nats-Msg-Id` on the schedule record continues to deduplicate the schedule write itself. `Nats-Schedule-Msg-Id` is separate and applies to the message emitted by the Scheduler.
## Use case
Multiple independent timers may create different schedule records that target the same subject and represent the same logical control message. In that case, the application needs a way to assign the same deterministic `Nats-Msg-Id` to the messages emitted by those schedules.
With this change, those schedule records can share the same `Nats-Schedule-Msg-Id`. When they fire, JetStream stream-level duplicate detection can store only the first emitted control message and suppress later duplicate emits within the duplicate window.
## Notes
This PR implements the core support for `Nats-Schedule-Msg-Id`.
The related question of whether `Nats-Schedule-Msg-Id` should be rejected for repeating schedules is left open for maintainer feedback. Repeating schedules would reuse the same message id on each fire, which may suppress later fires within the stream duplicate window. I can add validation to allow this header only for one-shot schedules if that is the preferred behavior.

## Manual check
<img width="720" height="502" alt="SCR-20260521-nhow" src="https://github.com/user-attachments/assets/bb6e6b9c-c4d1-4bd8-b999-15bae4b251c9" />
