### PR TITLE
Enforce cardinality threshold on `checkSkipFirstBlock` and `checkSkipFirstBlockMulti`

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -377,6 +377,10 @@ const (
 	rlBadThresh = 32 * 1024 * 1024
 	// Checksum size for hash for msg records.
 	recordHashSize = 8
+
+	// Above this number of subjects, index.db may not be written regularly anymore, and
+	// certain psim optimisations may not be used.
+	highCardinalityThreshold = 1_000_000
 )
 
 func newFileStore(fcfg FileStoreConfig, cfg StreamConfig) (*fileStore, error) {
@@ -3434,6 +3438,9 @@ func (fs *fileStore) checkSkipFirstBlock(filter string, wc bool, bi int) (int, e
 	// Move through psim to gather start and stop bounds.
 	start, stop := uint32(math.MaxUint32), uint32(0)
 	if wc {
+		if fs.psim.Size() > highCardinalityThreshold {
+			return bi + 1, nil
+		}
 		fs.psim.Match(stringToBytes(filter), func(_ []byte, psi *psi) {
 			if psi.fblk < start {
 				start = psi.fblk
@@ -3456,7 +3463,7 @@ func (fs *fileStore) checkSkipFirstBlock(filter string, wc bool, bi int) (int, e
 // Will return -1 and ErrStoreEOF if no matches at all or no more from where we are.
 func (fs *fileStore) checkSkipFirstBlockMulti(sl *gsl.SimpleSublist, bi int) (int, error) {
 	// Don't bother if full wildcard.
-	if sl.MatchesFullWildcard() {
+	if sl.MatchesFullWildcard() || fs.psim.Size() > highCardinalityThreshold {
 		return bi + 1, nil
 	}
 	// Move through psim to gather start and stop bounds.
@@ -11701,13 +11708,12 @@ func (fs *fileStore) _writeFullState(force bool) error {
 	// We will base off of number of subjects and interior deletes. A very large number of msg blocks could also
 	// be used, but for next server version will redo all meta handling to be disk based. So this is temporary.
 	if !force {
-		const numThreshold = 1_000_000
 		// Calculate interior deletes.
 		var numDeleted int
 		if fs.state.LastSeq > fs.state.FirstSeq {
 			numDeleted = int((fs.state.LastSeq - fs.state.FirstSeq + 1) - fs.state.Msgs)
 		}
-		if numSubjects > numThreshold || numDeleted > numThreshold {
+		if numSubjects > highCardinalityThreshold || numDeleted > highCardinalityThreshold {
 			fs.mu.RUnlock()
 			return errStateTooBig
 		}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -12590,6 +12590,67 @@ func TestFileStoreLoadNextMsgMultiSkipAhead(t *testing.T) {
 	}
 }
 
+func BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint(b *testing.B) {
+	if testing.Short() {
+		b.Skip("performance-oriented benchmark")
+	}
+
+	start := uint64(2)
+	cases := []int{1_000, 10_000, 100_000, 500_000, 1_000_000, 1_500_000, 2_000_000}
+	const fillerBlocks = 4096
+	const totalMsgs = 4_000_000
+	msg := []byte("ok")
+
+	for _, uniqueSubjects := range cases {
+		b.Run(fmt.Sprintf("UniqueSubjects/%d", uniqueSubjects), func(b *testing.B) {
+			fs, err := newFileStore(
+				FileStoreConfig{
+					StoreDir:  b.TempDir(),
+					BlockSize: 1 << 20,
+				},
+				StreamConfig{Name: "zzz", Subjects: []string{"foo.>"}, Storage: FileStorage})
+			require_NoError(b, err)
+			defer func() { _ = fs.Stop() }()
+
+			for i := range fillerBlocks {
+				_, _, err = fs.StoreMsg("foo.fill", nil, msg, 0)
+				require_NoError(b, err)
+				if i < fillerBlocks-1 {
+					_, err = fs.newMsgBlockForWrite()
+					require_NoError(b, err)
+				}
+			}
+
+			matchingMsgs := totalMsgs - fillerBlocks
+			for i := range matchingMsgs {
+				subj := fmt.Sprintf("foo.%d.bar", i%uniqueSubjects)
+				_, _, err = fs.StoreMsg(subj, nil, msg, 0)
+				require_NoError(b, err)
+			}
+
+			sl := gsl.NewSublist[struct{}]()
+			require_NoError(b, sl.Insert("foo.*.bar", struct{}{}))
+			require_NoError(b, sl.Insert("zzz.nope", struct{}{}))
+
+			var sm StoreMsg
+			_, _, err = fs.LoadNextMsgMulti(sl, start, &sm)
+			require_NoError(b, err)
+
+			fs.mu.RLock()
+			psimSize := fs.psim.Size()
+			fs.mu.RUnlock()
+
+			b.ReportMetric(float64(psimSize), "psim")
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _, err = fs.LoadNextMsgMulti(sl, start, &sm)
+				require_NoError(b, err)
+			}
+		})
+	}
+}
+
 func TestFileStoreDeleteRangeTwoGaps(t *testing.T) {
 	fcfg := FileStoreConfig{
 		Cipher:      NoCipher,


### PR DESCRIPTION
At a certain threshold, intersecting the entire stream subject state becomes considerably more expensive than just walking forward normally, so we should avoid doing that. In other places in the filestore, we tweak operations at 1 million subjects, and that seems to roughly align here too.

Before:
```
goos: darwin
goarch: arm64
pkg: github.com/nats-io/nats-server/v2/server
cpu: Apple M2 Ultra
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/1000
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/1000-24         	    6747	    173332 ns/op
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/10000
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/10000-24        	     735	   1651734 ns/op
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/100000
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/100000-24       	     144	   8261559 ns/op
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/500000
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/500000-24       	      27	  42628478 ns/op
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/1000000
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/1000000-24      	      13	  87825721 ns/op
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/1500000
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/1500000-24      	       8	 135479005 ns/op
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/2000000
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/2000000-24      	       6	 184404188 ns/op
PASS
ok  	github.com/nats-io/nats-server/v2/server	206.401s
```

After:
```
goos: darwin
goarch: arm64
pkg: github.com/nats-io/nats-server/v2/server
cpu: Apple M2 Ultra
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/1000
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/1000-24         	    6710	    176134 ns/op
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/10000
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/10000-24        	     733	   1632970 ns/op
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/100000
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/100000-24       	     144	   8714612 ns/op
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/500000
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/500000-24       	      27	  42293265 ns/op
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/1000000
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/1000000-24      	      19	  60804603 ns/op
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/1500000
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/1500000-24      	      18	  61275975 ns/op
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/2000000
BenchmarkFileStoreCheckSkipFirstBlockMultiTippingPoint/UniqueSubjects/2000000-24      	      18	  62452965 ns/op
PASS
ok  	github.com/nats-io/nats-server/v2/server	198.327s
```