### PR TITLE
feat(cluster): add solicit_tls config for solicited routes

### DIFF
--- a/server/ocsp.go
+++ b/server/ocsp.go
@@ -627,6 +627,16 @@ func (s *Server) configureOCSP() []*tlsConfigKind {
 		}
 		configs = append(configs, o)
 	}
+	if config := sopts.Cluster.SolicitTLSConfig; config != nil {
+		opts := sopts.Cluster.solicitTLSConfigOpts
+		o := &tlsConfigKind{
+			kind:      kindStringMap[ROUTER],
+			tlsConfig: config,
+			tlsOpts:   opts,
+			apply:     func(tc *tls.Config) { sopts.Cluster.SolicitTLSConfig = tc },
+		}
+		configs = append(configs, o)
+	}
 	if config := sopts.LeafNode.TLSConfig; config != nil {
 		opts := sopts.LeafNode.tlsConfigOpts
 		o := &tlsConfigKind{

--- a/server/opts.go
+++ b/server/opts.go
@@ -88,10 +88,17 @@ type ClusterOpts struct {
 	WriteDeadline     time.Duration      `json:"-"`
 	WriteTimeout      WriteTimeoutPolicy `json:"-"`
 
+	// Optional separate TLS config for solicited (outbound) routes.
+	SolicitTLSTimeout     float64       `json:"-"`
+	SolicitTLSConfig      *tls.Config   `json:"-"`
+	SolicitTLSPinnedCerts PinnedCertSet `json:"-"`
+
 	// Not exported (used in tests)
 	resolver netResolver
 	// Snapshot of configured TLS options.
 	tlsConfigOpts *TLSConfigOpts
+	// Snapshot of configured solicit TLS options.
+	solicitTLSConfigOpts *TLSConfigOpts
 }
 
 // CompressionOpts defines the compression mode and optional configuration.
@@ -814,6 +821,9 @@ func (o *Options) Clone() *Options {
 	}
 	if o.Cluster.TLSConfig != nil {
 		clone.Cluster.TLSConfig = o.Cluster.TLSConfig.Clone()
+	}
+	if o.Cluster.SolicitTLSConfig != nil {
+		clone.Cluster.SolicitTLSConfig = o.Cluster.SolicitTLSConfig.Clone()
 	}
 	if o.Gateway.TLSConfig != nil {
 		clone.Gateway.TLSConfig = o.Gateway.TLSConfig.Clone()
@@ -2001,6 +2011,7 @@ func parseListen(v any) (*hostPort, error) {
 // parseCluster will parse the cluster config.
 func parseCluster(v any, opts *Options, errors *[]error, warnings *[]error) error {
 	var lt token
+	var solicitTLSTok token
 	defer convertPanicToErrorList(&lt, errors)
 
 	tk, v := unwrapValue(v, &lt)
@@ -2095,6 +2106,17 @@ func parseCluster(v any, opts *Options, errors *[]error, warnings *[]error) erro
 			opts.Cluster.TLSPinnedCerts = tlsopts.PinnedCerts
 			opts.Cluster.TLSCheckKnownURLs = tlsopts.TLSCheckKnownURLs
 			opts.Cluster.tlsConfigOpts = tlsopts
+		case "solicit_tls":
+			solicitTLSTok = tk
+			config, tlsopts, err := getTLSConfig(tk)
+			if err != nil {
+				*errors = append(*errors, err)
+				continue
+			}
+			opts.Cluster.SolicitTLSConfig = config
+			opts.Cluster.SolicitTLSTimeout = tlsopts.Timeout
+			opts.Cluster.SolicitTLSPinnedCerts = tlsopts.PinnedCerts
+			opts.Cluster.solicitTLSConfigOpts = tlsopts
 		case "cluster_advertise", "advertise":
 			opts.Cluster.Advertise = mv.(string)
 		case "no_advertise":
@@ -2150,6 +2172,10 @@ func parseCluster(v any, opts *Options, errors *[]error, warnings *[]error) erro
 				continue
 			}
 		}
+	}
+	if opts.Cluster.SolicitTLSConfig != nil && opts.Cluster.TLSConfig == nil {
+		*errors = append(*errors, &configErr{solicitTLSTok,
+			"cluster 'solicit_tls' requires 'tls' to also be configured"})
 	}
 	return nil
 }
@@ -5969,6 +5995,9 @@ func setBaselineOptions(opts *Options) {
 		}
 		if opts.Cluster.TLSTimeout == 0 {
 			opts.Cluster.TLSTimeout = float64(TLS_TIMEOUT) / float64(time.Second)
+		}
+		if opts.Cluster.SolicitTLSConfig != nil && opts.Cluster.SolicitTLSTimeout == 0 {
+			opts.Cluster.SolicitTLSTimeout = float64(TLS_TIMEOUT) / float64(time.Second)
 		}
 		if opts.Cluster.AuthTimeout == 0 {
 			opts.Cluster.AuthTimeout = getDefaultAuthTimeout(opts.Cluster.TLSConfig, opts.Cluster.TLSTimeout)

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -967,6 +967,66 @@ func TestTlsPinnedCertificates(t *testing.T) {
 	check(opts.Websocket.TLSPinnedCerts)
 }
 
+// Test the optional separate TLS config for solicited (outbound) routes.
+func TestClusterSolicitTLSConfig(t *testing.T) {
+	confFileName := createConfFile(t, []byte(`
+	cluster {
+		port: -1
+		name: "abc"
+		tls {
+			cert_file: "./configs/certs/server.pem"
+			key_file: "./configs/certs/key.pem"
+			timeout: 2
+		}
+		solicit_tls {
+			cert_file: "./configs/certs/server.pem"
+			key_file: "./configs/certs/key.pem"
+			timeout: 3
+			pinned_certs: ["7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069"]
+		}
+	}`))
+	opts, err := ProcessConfigFile(confFileName)
+	if err != nil {
+		t.Fatalf("Received an error reading config file: %v", err)
+	}
+	if opts.Cluster.TLSConfig == nil {
+		t.Fatalf("Expected cluster TLSConfig to be set")
+	}
+	if opts.Cluster.SolicitTLSConfig == nil {
+		t.Fatalf("Expected cluster SolicitTLSConfig to be set")
+	}
+	// The solicit config must be a distinct object from the inbound one.
+	if opts.Cluster.SolicitTLSConfig == opts.Cluster.TLSConfig {
+		t.Fatalf("Expected SolicitTLSConfig to be a separate config from TLSConfig")
+	}
+	if opts.Cluster.SolicitTLSTimeout != 3 {
+		t.Fatalf("Expected SolicitTLSTimeout to be 3, got %v", opts.Cluster.SolicitTLSTimeout)
+	}
+	if l := len(opts.Cluster.SolicitTLSPinnedCerts); l != 1 {
+		t.Fatalf("Expected 1 solicit pinned certificate, got %d", l)
+	}
+}
+
+// 'solicit_tls' has no effect without a 'tls' block and must be rejected.
+func TestClusterSolicitTLSConfigRequiresTLS(t *testing.T) {
+	confFileName := createConfFile(t, []byte(`
+	cluster {
+		port: -1
+		name: "abc"
+		solicit_tls {
+			cert_file: "./configs/certs/server.pem"
+			key_file: "./configs/certs/key.pem"
+		}
+	}`))
+	_, err := ProcessConfigFile(confFileName)
+	if err == nil {
+		t.Fatalf("Expected an error for 'solicit_tls' without 'tls'")
+	}
+	if !strings.Contains(err.Error(), "solicit_tls") {
+		t.Fatalf("Expected error to mention solicit_tls, got %v", err)
+	}
+}
+
 func TestNkeyUsersDefaultPermissionsConfig(t *testing.T) {
 	confFileName := createConfFile(t, []byte(`
 	authorization {

--- a/server/reload.go
+++ b/server/reload.go
@@ -1332,8 +1332,24 @@ func (s *Server) recheckPinnedCerts(curOpts *Options, newOpts *Options) {
 		checkClients(LEAF, s.leafs, newOpts.LeafNode.TLSPinnedCerts)
 	}
 	if !reflect.DeepEqual(newOpts.Cluster.TLSPinnedCerts, curOpts.Cluster.TLSPinnedCerts) {
+		hasSolicitTLS := newOpts.Cluster.SolicitTLSConfig != nil
 		s.forEachRoute(func(c *client) {
+			if hasSolicitTLS && c.route != nil && c.route.didSolicit {
+				return
+			}
 			if !c.matchesPinnedCert(newOpts.Cluster.TLSPinnedCerts) {
+				disconnectClients = append(disconnectClients, c)
+			}
+		})
+	}
+	newSolicitSet := newOpts.Cluster.SolicitTLSPinnedCerts
+	if newOpts.Cluster.SolicitTLSConfig == nil {
+		newSolicitSet = newOpts.Cluster.TLSPinnedCerts
+	}
+	solicitRemoved := curOpts.Cluster.SolicitTLSConfig != nil && newOpts.Cluster.SolicitTLSConfig == nil
+	if solicitRemoved || !reflect.DeepEqual(newOpts.Cluster.SolicitTLSPinnedCerts, curOpts.Cluster.SolicitTLSPinnedCerts) {
+		s.forEachRoute(func(c *client) {
+			if c.route != nil && c.route.didSolicit && !c.matchesPinnedCert(newSolicitSet) {
 				disconnectClients = append(disconnectClients, c)
 			}
 		})

--- a/server/route.go
+++ b/server/route.go
@@ -1977,12 +1977,19 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL, rtype RouteType, goss
 	// Check for TLS
 	if tlsRequired {
 		tlsConfig := opts.Cluster.TLSConfig
+		tlsTimeout := opts.Cluster.TLSTimeout
+		tlsPinnedCerts := opts.Cluster.TLSPinnedCerts
 		if didSolicit {
+			if opts.Cluster.SolicitTLSConfig != nil {
+				tlsConfig = opts.Cluster.SolicitTLSConfig
+				tlsTimeout = opts.Cluster.SolicitTLSTimeout
+				tlsPinnedCerts = opts.Cluster.SolicitTLSPinnedCerts
+			}
 			// Copy off the config to add in ServerName if we need to.
 			tlsConfig = tlsConfig.Clone()
 		}
 		// Perform (server or client side) TLS handshake.
-		if resetTLSName, err := c.doTLSHandshake("route", didSolicit, rURL, tlsConfig, tlsName, opts.Cluster.TLSTimeout, opts.Cluster.TLSPinnedCerts); err != nil {
+		if resetTLSName, err := c.doTLSHandshake("route", didSolicit, rURL, tlsConfig, tlsName, tlsTimeout, tlsPinnedCerts); err != nil {
 			c.mu.Unlock()
 			if resetTLSName {
 				s.mu.Lock()

--- a/server/server.go
+++ b/server/server.go
@@ -1099,6 +1099,9 @@ func validateCluster(o *Options) error {
 	if err := validatePinnedCerts(o.Cluster.TLSPinnedCerts); err != nil {
 		return fmt.Errorf("cluster: %v", err)
 	}
+	if err := validatePinnedCerts(o.Cluster.SolicitTLSPinnedCerts); err != nil {
+		return fmt.Errorf("cluster: %v", err)
+	}
 	// Check that cluster name if defined matches any gateway name.
 	// Note that we have already verified that the gateway name does not have spaces.
 	if o.Gateway.Name != _EMPTY_ && o.Gateway.Name != o.Cluster.Name {

--- a/test/cluster_tls_test.go
+++ b/test/cluster_tls_test.go
@@ -173,3 +173,277 @@ func TestClusterTLSInsecure(t *testing.T) {
 		t.Fatalf("Did not get warning about using cluster's insecure setting")
 	}
 }
+
+func TestClusterSolicitTLSConfig(t *testing.T) {
+	confB := createConfFile(t, []byte(`
+		port: -1
+		cluster {
+			name: "xyz"
+			listen: "127.0.0.1:-1"
+			pool_size: -1
+			compression: "disabled"
+			tls {
+				cert_file: "./configs/certs/server-cert.pem"
+				key_file:  "./configs/certs/server-key.pem"
+				ca_file:   "./configs/certs/ca.pem"
+				timeout: 2
+			}
+		}
+	`))
+	srvB, optsB := RunServerWithConfig(confB)
+	defer srvB.Shutdown()
+
+	// A's 'tls' cert is untrusted by B; only 'solicit_tls' is trusted, so the
+	// cluster forms only if the solicited route uses 'solicit_tls'.
+	confA := createConfFile(t, []byte(fmt.Sprintf(`
+		port: -1
+		cluster {
+			name: "xyz"
+			listen: "127.0.0.1:-1"
+			pool_size: -1
+			compression: "disabled"
+			tls {
+				cert_file: "./configs/certs/tlsauth/server.pem"
+				key_file:  "./configs/certs/tlsauth/server-key.pem"
+				ca_file:   "./configs/certs/tlsauth/ca.pem"
+				timeout: 2
+			}
+			solicit_tls {
+				cert_file: "./configs/certs/client-cert.pem"
+				key_file:  "./configs/certs/client-key.pem"
+				ca_file:   "./configs/certs/ca.pem"
+				timeout: 2
+			}
+			routes [
+				"nats://%s:%d"
+			]
+		}
+	`, optsB.Cluster.Host, optsB.Cluster.Port)))
+	srvA, _ := RunServerWithConfig(confA)
+	defer srvA.Shutdown()
+
+	checkClusterFormed(t, srvA, srvB)
+}
+
+func TestClusterSolicitTLSConfigUntrusted(t *testing.T) {
+	confB := createConfFile(t, []byte(`
+		port: -1
+		cluster {
+			name: "xyz"
+			listen: "127.0.0.1:-1"
+			pool_size: -1
+			compression: "disabled"
+			tls {
+				cert_file: "./configs/certs/server-cert.pem"
+				key_file:  "./configs/certs/server-key.pem"
+				ca_file:   "./configs/certs/tlsauth/ca.pem"
+				timeout: 2
+			}
+		}
+	`))
+	srvB, optsB := RunServerWithConfig(confB)
+	defer srvB.Shutdown()
+
+	l := &captureTLSError{ch: make(chan struct{}, 1)}
+	srvB.SetLogger(l, false, false)
+
+	confA := createConfFile(t, []byte(fmt.Sprintf(`
+		port: -1
+		cluster {
+			name: "xyz"
+			listen: "127.0.0.1:-1"
+			pool_size: -1
+			compression: "disabled"
+			tls {
+				cert_file: "./configs/certs/server-cert.pem"
+				key_file:  "./configs/certs/server-key.pem"
+				ca_file:   "./configs/certs/ca.pem"
+				timeout: 2
+			}
+			solicit_tls {
+				cert_file: "./configs/certs/client-cert.pem"
+				key_file:  "./configs/certs/client-key.pem"
+				ca_file:   "./configs/certs/ca.pem"
+				timeout: 2
+			}
+			routes [
+				"nats://%s:%d"
+			]
+		}
+	`, optsB.Cluster.Host, optsB.Cluster.Port)))
+	srvA, _ := RunServerWithConfig(confA)
+	defer srvA.Shutdown()
+
+	// Expect B to reject the outbound handshake.
+	select {
+	case <-l.ch:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("Did not get TLS handshake error")
+	}
+
+	if nr := srvA.NumRoutes(); nr != 0 {
+		t.Fatalf("Expected no routes on srvA, got %d", nr)
+	}
+	if nr := srvB.NumRoutes(); nr != 0 {
+		t.Fatalf("Expected no routes on srvB, got %d", nr)
+	}
+}
+
+func TestClusterSolicitTLSPinnedCertsReload(t *testing.T) {
+	const (
+		fpServerCert = "89386860ea1222698ea676fc97310bdf2bff6f7e2b0420fac3b3f8f5a08fede5"
+		fpClientCert = "bf6f821f09fde09451411ba3b42c0f74727d61a974c69fd3cf5257f39c75f0e9"
+		fpBad        = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	confB := createConfFile(t, []byte(`
+		port: -1
+		cluster {
+			name: "xyz"
+			listen: "127.0.0.1:-1"
+			pool_size: -1
+			compression: "disabled"
+			tls {
+				cert_file: "./configs/certs/server-cert.pem"
+				key_file:  "./configs/certs/server-key.pem"
+				ca_file:   "./configs/certs/ca.pem"
+				timeout: 2
+			}
+		}
+	`))
+	srvB, optsB := RunServerWithConfig(confB)
+	defer srvB.Shutdown()
+
+	// A's tls pinned_certs uses client-cert's fingerprint, blocking B (which
+	// presents server-cert.pem) from reconnecting inbound after reload.
+	// A's solicit_tls pins server-cert.pem so the initial outbound route forms.
+	tmplA := `
+		port: -1
+		cluster {
+			name: "xyz"
+			listen: "127.0.0.1:-1"
+			pool_size: -1
+			compression: "disabled"
+			tls {
+				cert_file: "./configs/certs/client-cert.pem"
+				key_file:  "./configs/certs/client-key.pem"
+				ca_file:   "./configs/certs/ca.pem"
+				timeout: 2
+				pinned_certs: ["%s"]
+			}
+			solicit_tls {
+				cert_file: "./configs/certs/client-cert.pem"
+				key_file:  "./configs/certs/client-key.pem"
+				ca_file:   "./configs/certs/ca.pem"
+				timeout: 2
+				pinned_certs: ["%s"]
+			}
+			routes: ["nats://127.0.0.1:%d"]
+		}
+	`
+	confA := createConfFile(t, []byte(fmt.Sprintf(tmplA, fpClientCert, fpServerCert, optsB.Cluster.Port)))
+	srvA, _ := RunServerWithConfig(confA)
+	defer srvA.Shutdown()
+
+	checkClusterFormed(t, srvA, srvB)
+
+	// Reload with a bad solicit pinned cert. The outbound route must drop.
+	if err := os.WriteFile(confA, []byte(fmt.Sprintf(tmplA, fpClientCert, fpBad, optsB.Cluster.Port)), 0660); err != nil {
+		t.Fatalf("Error rewriting file: %v", err)
+	}
+	if err := srvA.Reload(); err != nil {
+		t.Fatalf("on Reload got %v", err)
+	}
+	checkNumRoutes(t, srvA, 0)
+	checkNumRoutes(t, srvB, 0)
+}
+
+func TestClusterTLSPinnedCertsReloadKeepsSolicitedRoute(t *testing.T) {
+	const (
+		fpServerCert = "89386860ea1222698ea676fc97310bdf2bff6f7e2b0420fac3b3f8f5a08fede5"
+		fpClientCert = "bf6f821f09fde09451411ba3b42c0f74727d61a974c69fd3cf5257f39c75f0e9"
+		fpBad        = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	confB := createConfFile(t, []byte(`
+		port: -1
+		cluster {
+			name: "xyz"
+			listen: "127.0.0.1:-1"
+			pool_size: -1
+			compression: "disabled"
+			tls {
+				cert_file: "./configs/certs/server-cert.pem"
+				key_file:  "./configs/certs/server-key.pem"
+				ca_file:   "./configs/certs/ca.pem"
+				timeout: 2
+			}
+		}
+	`))
+	srvB, optsB := RunServerWithConfig(confB)
+	defer srvB.Shutdown()
+
+	// Reload tls.pinned_certs to a bogus value; the solicited route should
+	// survive because it is governed by solicit_tls.pinned_certs, which still
+	// matches B's server cert.
+	tmplA := `
+		port: -1
+		cluster {
+			name: "xyz"
+			listen: "127.0.0.1:-1"
+			pool_size: -1
+			compression: "disabled"
+			tls {
+				cert_file: "./configs/certs/client-cert.pem"
+				key_file:  "./configs/certs/client-key.pem"
+				ca_file:   "./configs/certs/ca.pem"
+				timeout: 2
+				pinned_certs: ["%s"]
+			}
+			solicit_tls {
+				cert_file: "./configs/certs/client-cert.pem"
+				key_file:  "./configs/certs/client-key.pem"
+				ca_file:   "./configs/certs/ca.pem"
+				timeout: 2
+				pinned_certs: ["%s"]
+			}
+			routes: ["nats://127.0.0.1:%d"]
+		}
+	`
+	confA := createConfFile(t, []byte(fmt.Sprintf(tmplA, fpClientCert, fpServerCert, optsB.Cluster.Port)))
+	srvA, _ := RunServerWithConfig(confA)
+	defer srvA.Shutdown()
+
+	checkClusterFormed(t, srvA, srvB)
+
+	rzBefore, err := srvA.Routez(nil)
+	if err != nil {
+		t.Fatalf("Routez err: %v", err)
+	}
+	if len(rzBefore.Routes) == 0 {
+		t.Fatalf("Expected at least one route on srvA")
+	}
+	ridsBefore := make(map[uint64]bool, len(rzBefore.Routes))
+	for _, r := range rzBefore.Routes {
+		ridsBefore[r.Rid] = true
+	}
+
+	if err := os.WriteFile(confA, []byte(fmt.Sprintf(tmplA, fpBad, fpServerCert, optsB.Cluster.Port)), 0660); err != nil {
+		t.Fatalf("Error rewriting file: %v", err)
+	}
+	if err := srvA.Reload(); err != nil {
+		t.Fatalf("on Reload got %v", err)
+	}
+
+	checkClusterFormed(t, srvA, srvB)
+
+	rzAfter, err := srvA.Routez(nil)
+	if err != nil {
+		t.Fatalf("Routez err: %v", err)
+	}
+	for _, r := range rzAfter.Routes {
+		if !ridsBefore[r.Rid] {
+			t.Fatalf("Solicited route was reset after reload (new rid=%d)", r.Rid)
+		}
+	}
+}

--- a/test/ocsp_test.go
+++ b/test/ocsp_test.go
@@ -1235,6 +1235,79 @@ func TestOCSPCluster(t *testing.T) {
 	}
 }
 
+// B requires OCSP staples from connecting peers. A uses solicit_tls with a
+// separate must-staple cert. The cluster must form, proving SolicitTLSConfig
+// is wired into the OCSP subsystem so A attaches a staple when it connects.
+func TestOCSPClusterSolicitTLS(t *testing.T) {
+	const (
+		caCert = "configs/certs/ocsp/ca-cert.pem"
+		caKey  = "configs/certs/ocsp/ca-key.pem"
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ocspr := NewOCSPResponder(t, caCert, caKey)
+	defer ocspr.Shutdown(ctx)
+	addr := fmt.Sprintf("http://%s", ocspr.Addr)
+	SetOCSPStatus(t, addr, "configs/certs/ocsp/server-status-request-url-01-cert.pem", ocsp.Good)
+	SetOCSPStatus(t, addr, "configs/certs/ocsp/server-status-request-url-02-cert.pem", ocsp.Good)
+	SetOCSPStatus(t, addr, "configs/certs/ocsp/server-status-request-url-03-cert.pem", ocsp.Good)
+
+	storeDirA := t.TempDir()
+	storeDirB := t.TempDir()
+
+	confB := createConfFile(t, []byte(fmt.Sprintf(`
+		host: "127.0.0.1"
+		port: -1
+		server_name: "B"
+		store_dir: '%s'
+		cluster {
+			name: OCSPSolicit
+			host: "127.0.0.1"
+			port: -1
+			pool_size: -1
+			tls {
+				cert_file: "configs/certs/ocsp/server-status-request-url-01-cert.pem"
+				key_file:  "configs/certs/ocsp/server-status-request-url-01-key.pem"
+				ca_file:   "configs/certs/ocsp/ca-cert.pem"
+				timeout: 5
+			}
+		}
+	`, storeDirB)))
+	srvB, optsB := RunServerWithConfig(confB)
+	defer srvB.Shutdown()
+
+	confA := createConfFile(t, []byte(fmt.Sprintf(`
+		host: "127.0.0.1"
+		port: -1
+		server_name: "A"
+		store_dir: '%s'
+		cluster {
+			name: OCSPSolicit
+			host: "127.0.0.1"
+			port: -1
+			pool_size: -1
+			connect_retries: 10
+			routes: ["nats://127.0.0.1:%d"]
+			tls {
+				cert_file: "configs/certs/ocsp/server-status-request-url-02-cert.pem"
+				key_file:  "configs/certs/ocsp/server-status-request-url-02-key.pem"
+				ca_file:   "configs/certs/ocsp/ca-cert.pem"
+				timeout: 5
+			}
+			solicit_tls {
+				cert_file: "configs/certs/ocsp/server-status-request-url-03-cert.pem"
+				key_file:  "configs/certs/ocsp/server-status-request-url-03-key.pem"
+				ca_file:   "configs/certs/ocsp/ca-cert.pem"
+				timeout: 5
+			}
+		}
+	`, storeDirA, optsB.Cluster.Port)))
+	srvA, _ := RunServerWithConfig(confA)
+	defer srvA.Shutdown()
+
+	checkClusterFormed(t, srvA, srvB)
+}
+
 func TestOCSPLeaf(t *testing.T) {
 	const (
 		caCert = "configs/certs/ocsp/ca-cert.pem"


### PR DESCRIPTION
Allow a separate TLS config (cert, timeout, pinned certs) to be applied to solicited (outbound) cluster routes via a 'solicit_tls' block, falling back to 'tls' when not set. Requires a 'tls' block to also be configured.

Addresses #8016 
