### PR TITLE
(2.14) fix: JetStream consumer lock leak on start sequence error

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1336,6 +1336,8 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 		// Clustered non-direct consumers defer this to setLeader so the
 		// expensive store scans don't block the meta apply goroutine.
 		if err := o.selectStartingSeqNo(); err != nil {
+			mset.mu.Unlock()
+			o.deleteWithoutAdvisory()
 			return nil, err
 		}
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -8563,14 +8563,16 @@ func (mset *stream) setConsumer(o *consumer) {
 
 // Lock should be held.
 func (mset *stream) removeConsumer(o *consumer) {
-	if o.cfg.FilterSubject != _EMPTY_ && mset.numFilter > 0 {
-		mset.numFilter--
-	}
-	if (o.cfg.Direct || o.cfg.Sourcing) && mset.sourcingConsumers > 0 {
-		mset.sourcingConsumers--
-	}
-	if mset.consumers != nil {
+	if _, ok := mset.consumers[o.name]; ok {
 		delete(mset.consumers, o.name)
+
+		if o.cfg.FilterSubject != _EMPTY_ && mset.numFilter > 0 {
+			mset.numFilter--
+		}
+		if (o.cfg.Direct || o.cfg.Sourcing) && mset.sourcingConsumers > 0 {
+			mset.sourcingConsumers--
+		}
+
 		// Now update consumers list as well
 		mset.clsMu.Lock()
 		for i, ol := range mset.cList {


### PR DESCRIPTION
## Summary

This PR fixes a lock leak in JetStream consumer creation.

In `addConsumerWithAssignment`, `mset.mu` is held while creating a consumer. In the direct/standalone path, if `o.selectStartingSeqNo()` returns an error, the function currently returns without releasing `mset.mu`.

This adds the missing `mset.mu.Unlock()` before returning the error.

Resolves #8229 

## Impact

Without this unlock, the stream mutex can remain locked after a starting sequence error, which may cause later operations on the same stream to block.

## Changes

- Add the missing `mset.mu.Unlock()` before returning from the `selectStartingSeqNo()` error path.

## Detection

This issue was reported by [`goconcurrencylint`](https://github.com/sanbricio/goconcurrencylint).

## Testing

- Not added yet. This is a minimal error-path fix identified by static analysis.

Signed-off-by: Santiago Bricio <sanbriciorojas11@gmail.com>