### PR TITLE
(2.14) fix: release filestore block lock on write error

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4751,6 +4751,7 @@ func (fs *fileStore) newMsgBlockForWrite() (*msgBlock, error) {
 		}
 		// If we had a write error before, don't allow continuing into a new block.
 		if err := lmb.werr; err != nil {
+			lmb.mu.Unlock()
 			return nil, err
 		}
 		// Flush any pending messages.


### PR DESCRIPTION
## Summary

This PR fixes a lock leak in the filestore message block write path.

In `newMsgBlockForWrite`, `lmb.mu` is held while checking the last message block state. If `lmb.werr` is already set, the function currently returns the write error without releasing `lmb.mu`.

This adds the missing `lmb.mu.Unlock()` before returning the error.

Resolves #8231

## Impact

Without this unlock, the message block mutex can remain locked after a filestore write error, which may cause later operations on the same message block to block.

## Changes

- Add the missing `lmb.mu.Unlock()` before returning from the `lmb.werr` error path.

## Detection

This issue was reported by [`goconcurrencylint`](https://github.com/sanbricio/goconcurrencylint).

## Testing

- Not added yet. This is a minimal error-path fix identified by static analysis.

Signed-off-by: Santiago Bricio <sanbriciorojas11@gmail.com>