### PR TITLE
[FIXED] PurgeEx inconsistencies

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -9780,6 +9780,10 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 		if sequence > 1 {
 			return fs.compact(sequence)
 		}
+		// Make sure to not leave subject if empty.
+		if subject == _EMPTY_ {
+			subject = fwcs
+		}
 	}
 
 	// Persist any write errors.
@@ -9790,11 +9794,6 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 			fs.mu.Unlock()
 		}
 	}()
-
-	// Make sure to not leave subject if empty and we reach this spot.
-	if subject == _EMPTY_ {
-		subject = fwcs
-	}
 
 	eq, wc := compareFn(subject), subjectHasWildcard(subject)
 	var firstSeqNeedsUpdate bool

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -9769,6 +9769,10 @@ func compareFn(subject string) func(string, string) bool {
 // PurgeEx will remove messages based on subject filters, sequence and number of messages to keep.
 // Will return the number of purged messages.
 func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint64, err error) {
+	// sequence == 1 means "purge up to but not including 1", a no-op.
+	if sequence == 1 {
+		return 0, nil
+	}
 	if subject == _EMPTY_ || subject == fwcs {
 		if keep == 0 && sequence == 0 {
 			return fs.purge(0)
@@ -9879,7 +9883,10 @@ func (fs *fileStore) PurgeEx(subject string, sequence, keep uint64) (purged uint
 			continue
 		}
 
-		if sequence > 1 && sequence <= l {
+		// "Purge up to but not including sequence": sequence == 0 means no
+		// sequence filter; sequence >= 1 clamps the per-block upper bound to
+		// sequence-1 (so sequence == 1 leaves nothing to process).
+		if sequence >= 1 && sequence <= l {
 			l = sequence - 1
 		}
 

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -3913,7 +3913,7 @@ func TestFileStorePurgeExWithSubject(t *testing.T) {
 		require_True(t, len(buf) > 0)
 
 		// This should purge all "foo.1"
-		p, err := fs.PurgeEx("foo.1", 1, 0)
+		p, err := fs.PurgeEx("foo.1", 0, 0)
 		require_NoError(t, err)
 		require_Equal(t, p, uint64(total))
 
@@ -3993,7 +3993,7 @@ func TestFileStorePurgeExNoTombsOnBlockRemoval(t *testing.T) {
 
 		// This should purge all "foo.1". This will remove the blocks so we want to make sure
 		// we do not write excessive tombstones here.
-		p, err := fs.PurgeEx("foo.1", 1, 0)
+		p, err := fs.PurgeEx("foo.1", 0, 0)
 		require_NoError(t, err)
 		require_Equal(t, p, uint64(total))
 
@@ -6759,7 +6759,7 @@ func TestFileStorePurgeExBufPool(t *testing.T) {
 		fs.StoreMsg("foo.bar", nil, msg, 0)
 	}
 
-	p, err := fs.PurgeEx("foo.bar", 1, 0)
+	p, err := fs.PurgeEx("foo.bar", 0, 0)
 	require_NoError(t, err)
 	require_Equal(t, p, 1000)
 
@@ -6798,7 +6798,7 @@ func TestFileStoreFSSMeta(t *testing.T) {
 	// Let cache's expire before PurgeEx which will load them back in.
 	time.Sleep(500 * time.Millisecond)
 
-	p, err := fs.PurgeEx("A", 1, 0)
+	p, err := fs.PurgeEx("A", 0, 0)
 	require_NoError(t, err)
 	require_Equal(t, p, 2)
 

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1438,18 +1438,10 @@ func (ms *memStore) PurgeEx(subject string, sequence, keep uint64) (purged uint6
 		if sequence > 1 {
 			return ms.compact(sequence)
 		}
-		// Keep-based trimming only applies when no sequence filter is set.
-		if sequence == 0 && keep > 0 {
-			ms.mu.RLock()
-			msgs, lseq := ms.state.Msgs, ms.state.LastSeq
-			ms.mu.RUnlock()
-			if keep >= msgs {
-				return 0, nil
-			}
-			return ms.compact(lseq - keep + 1)
+		// Make sure to not leave subject if empty.
+		if subject == _EMPTY_ {
+			subject = fwcs
 		}
-		return 0, nil
-
 	}
 	eq := compareFn(subject)
 	if ss, _ := ms.FilteredState(1, subject); ss.Msgs > 0 {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1444,32 +1444,53 @@ func (ms *memStore) PurgeEx(subject string, sequence, keep uint64) (purged uint6
 		}
 	}
 	eq := compareFn(subject)
-	if ss, _ := ms.FilteredState(1, subject); ss.Msgs > 0 {
-		if keep > 0 {
-			if keep >= ss.Msgs {
-				return 0, nil
-			}
-			ss.Msgs -= keep
+
+	// FilteredState narrows the search range.
+	ss, _ := ms.FilteredState(1, subject)
+	if ss.Msgs == 0 {
+		return 0, nil
+	}
+	// If we have a "keep" designation need to know how many to purge.
+	var maxp uint64
+	if keep > 0 {
+		if keep >= ss.Msgs {
+			return 0, nil
 		}
-		// "Purge up to but not including sequence": sequence == 0 means no
-		// sequence filter; sequence >= 1 clamps the upper bound to sequence-1
-		// (so sequence == 1 purges nothing).
-		last := ss.Last
-		if sequence >= 1 {
-			last = sequence - 1
-		}
-		ms.mu.Lock()
-		for seq := ss.First; seq <= last; seq++ {
-			if sm, ok := ms.msgs[seq]; ok && eq(sm.subj, subject) {
-				if ok := ms.removeMsg(sm.seq, false); ok {
-					purged++
-					if purged >= ss.Msgs {
-						break
-					}
+		maxp = ss.Msgs - keep
+	}
+	// "Purge up to but not including sequence": sequence == 0 means no
+	// sequence filter; sequence >= 1 clamps the upper bound to sequence-1
+	// (so sequence == 1 purges nothing).
+	last := ss.Last
+	if sequence >= 1 {
+		last = sequence - 1
+	}
+	var bytes, lowSeq uint64
+	var lowSubj string
+	ms.mu.Lock()
+	for seq := ss.First; seq <= last; seq++ {
+		if sm, ok := ms.msgs[seq]; ok && eq(sm.subj, subject) {
+			if subj, sz, ok := ms.removeMsgNoCB(sm.seq, false); ok {
+				purged++
+				bytes += sz
+				if lowSeq == 0 {
+					lowSeq, lowSubj = sm.seq, subj
+				}
+				if maxp > 0 && purged >= maxp {
+					break
 				}
 			}
 		}
-		ms.mu.Unlock()
+	}
+	cb := ms.scb
+	ms.mu.Unlock()
+
+	if cb != nil && purged > 0 {
+		if purged == 1 {
+			cb(-1, -int64(bytes), lowSeq, lowSubj)
+		} else {
+			cb(-int64(purged), -int64(bytes), 0, _EMPTY_)
+		}
 	}
 	return purged, nil
 }
@@ -2126,20 +2147,38 @@ func (ms *memStore) recalculateForSubj(subj string, ss *SimpleState) {
 // Removes the message referenced by seq.
 // Lock should be held.
 func (ms *memStore) removeMsg(seq uint64, secure bool) bool {
-	var ss uint64
-	sm, ok := ms.msgs[seq]
+	subj, size, ok := ms.removeMsgNoCB(seq, secure)
 	if !ok {
 		return false
 	}
+	if ms.scb != nil {
+		// We do not want to hold any locks here.
+		ms.mu.Unlock()
+		if ms.scb != nil {
+			ms.scb(-1, -int64(size), seq, subj)
+		}
+		ms.mu.Lock()
+	}
+	return true
+}
 
-	ss = memStoreMsgSize(sm.subj, sm.hdr, sm.msg)
+// Removes the message referenced by seq, but without calling the storage callback.
+// Returns the removed message's subject and size.
+// Lock should be held.
+func (ms *memStore) removeMsgNoCB(seq uint64, secure bool) (subj string, size uint64, ok bool) {
+	sm, ok := ms.msgs[seq]
+	if !ok {
+		return _EMPTY_, 0, false
+	}
+
+	size = memStoreMsgSize(sm.subj, sm.hdr, sm.msg)
 
 	if ms.state.Msgs > 0 {
 		ms.state.Msgs--
-		if ss > ms.state.Bytes {
-			ss = ms.state.Bytes
+		if size > ms.state.Bytes {
+			size = ms.state.Bytes
 		}
-		ms.state.Bytes -= ss
+		ms.state.Bytes -= size
 	}
 	ms.dmap.Insert(seq)
 	ms.updateFirstSeq(seq)
@@ -2168,17 +2207,7 @@ func (ms *memStore) removeMsg(seq uint64, secure bool) bool {
 	// Must delete message after updating per-subject info, to be consistent with file store.
 	delete(ms.msgs, seq)
 
-	if ms.scb != nil {
-		// We do not want to hold any locks here.
-		ms.mu.Unlock()
-		if ms.scb != nil {
-			delta := int64(ss)
-			ms.scb(-1, -delta, seq, sm.subj)
-		}
-		ms.mu.Lock()
-	}
-
-	return ok
+	return sm.subj, size, true
 }
 
 // Type returns the type of the underlying store.

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1427,13 +1427,19 @@ func (ms *memStore) runMsgScheduling() {
 // PurgeEx will remove messages based on subject filters, sequence and number of messages to keep.
 // Will return the number of purged messages.
 func (ms *memStore) PurgeEx(subject string, sequence, keep uint64) (purged uint64, err error) {
+	// sequence == 1 means "purge up to but not including 1", a no-op.
+	if sequence == 1 {
+		return 0, nil
+	}
 	if subject == _EMPTY_ || subject == fwcs {
 		if keep == 0 && sequence == 0 {
 			return ms.purge(0)
 		}
 		if sequence > 1 {
 			return ms.compact(sequence)
-		} else if keep > 0 {
+		}
+		// Keep-based trimming only applies when no sequence filter is set.
+		if sequence == 0 && keep > 0 {
 			ms.mu.RLock()
 			msgs, lseq := ms.state.Msgs, ms.state.LastSeq
 			ms.mu.RUnlock()
@@ -1453,8 +1459,11 @@ func (ms *memStore) PurgeEx(subject string, sequence, keep uint64) (purged uint6
 			}
 			ss.Msgs -= keep
 		}
+		// "Purge up to but not including sequence": sequence == 0 means no
+		// sequence filter; sequence >= 1 clamps the upper bound to sequence-1
+		// (so sequence == 1 purges nothing).
 		last := ss.Last
-		if sequence > 1 {
+		if sequence >= 1 {
 			last = sequence - 1
 		}
 		ms.mu.Lock()

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -445,7 +445,7 @@ func TestMemStorePurgeExWithSubject(t *testing.T) {
 	}
 
 	// This should purge all.
-	ms.PurgeEx("foo", 1, 0)
+	ms.PurgeEx("foo", 0, 0)
 	require_True(t, ms.State().Msgs == 0)
 }
 

--- a/server/norace_2_test.go
+++ b/server/norace_2_test.go
@@ -2939,7 +2939,7 @@ func TestNoRaceStoreReverseWalkWithDeletesPerf(t *testing.T) {
 		require_Equal(t, ss.Msgs, 1_000_002)
 
 		// Create a bunch of interior deletes.
-		p, err := store.PurgeEx("foo.B", 1, 0)
+		p, err := store.PurgeEx("foo.B", 0, 0)
 		require_NoError(t, err)
 		require_Equal(t, p, 1_000_000)
 

--- a/server/store_test.go
+++ b/server/store_test.go
@@ -572,6 +572,36 @@ func TestStorePurgeExZero(t *testing.T) {
 	)
 }
 
+func TestStorePurgeExSequenceOne(t *testing.T) {
+	testAllStoreAllPermutations(
+		t, true,
+		StreamConfig{Name: "TEST", Subjects: []string{"foo", "bar"}},
+		func(t *testing.T, fs StreamStore) {
+			for range 5 {
+				_, _, err := fs.StoreMsg("foo", nil, nil, 0)
+				require_NoError(t, err)
+				_, _, err = fs.StoreMsg("bar", nil, nil, 0)
+				require_NoError(t, err)
+			}
+			before := fs.State()
+			check := func(t *testing.T, subject string, keep uint64) {
+				n, err := fs.PurgeEx(subject, 1, keep)
+				require_NoError(t, err)
+				require_Equal(t, n, 0)
+				after := fs.State()
+				require_Equal(t, after.Msgs, before.Msgs)
+				require_Equal(t, after.FirstSeq, before.FirstSeq)
+				require_Equal(t, after.LastSeq, before.LastSeq)
+			}
+			t.Run("empty-subject", func(t *testing.T) { check(t, _EMPTY_, 0) })
+			t.Run("wildcard-subject", func(t *testing.T) { check(t, fwcs, 0) })
+			t.Run("specific-subject", func(t *testing.T) { check(t, "foo", 0) })
+			t.Run("empty-subject-with-keep", func(t *testing.T) { check(t, _EMPTY_, 3) })
+			t.Run("specific-subject-with-keep", func(t *testing.T) { check(t, "foo", 3) })
+		},
+	)
+}
+
 func TestStoreUpdateConfigTTLState(t *testing.T) {
 	config := func() StreamConfig {
 		return StreamConfig{Name: "TEST", Subjects: []string{"foo"}}

--- a/server/store_test.go
+++ b/server/store_test.go
@@ -602,6 +602,38 @@ func TestStorePurgeExSequenceOne(t *testing.T) {
 	)
 }
 
+func TestStorePurgeExKeepWithInteriorDeletes(t *testing.T) {
+	testAllStoreAllPermutations(
+		t, false,
+		StreamConfig{Name: "TEST", Subjects: []string{"foo"}},
+		func(t *testing.T, fs StreamStore) {
+			for range 50 {
+				_, _, err := fs.StoreMsg("foo", nil, nil, 0)
+				require_NoError(t, err)
+			}
+			// Remove every other message to create interior gaps.
+			for seq := uint64(2); seq <= 50; seq += 2 {
+				_, err := fs.RemoveMsg(seq)
+				require_NoError(t, err)
+			}
+			ss := fs.State()
+			require_Equal(t, ss.Msgs, 25)
+			require_Equal(t, ss.FirstSeq, 1)
+			require_Equal(t, ss.LastSeq, 50)
+
+			// Keep the 5 newest. Newest 5 existing seqs are 41, 43, 45, 47, 49.
+			n, err := fs.PurgeEx(_EMPTY_, 0, 5)
+			require_NoError(t, err)
+			require_Equal(t, n, 20)
+
+			ss = fs.State()
+			require_Equal(t, ss.Msgs, 5)
+			require_Equal(t, ss.FirstSeq, 41)
+			require_Equal(t, ss.LastSeq, 50)
+		},
+	)
+}
+
 func TestStoreUpdateConfigTTLState(t *testing.T) {
 	config := func() StreamConfig {
 		return StreamConfig{Name: "TEST", Subjects: []string{"foo"}}


### PR DESCRIPTION
Two fixes and one performance improvement to `PurgeEx` to match its documented semantics and bring memstore in line with filestore.

- When passing `sequence`, it's documented to "Purge up to but not including sequence". However, when passing `sequence=1` it would incorrectly purge the whole stream anyway. Passing a `sequence=1` is a noop since there's no messages before sequence 1 that can be removed.
- When passing `keep`, it's documented to "Number of messages to keep". However, when passing `keep` on an in-memory stream with interior deletes, it would not keep N messages, it would compact to the last N sequences which could be interior deletes. This is now made consistent with the filestore, which already took interior deletes into account to keep the last N non-deleted messages.
- The memstore is now also optimized to do accounting for the purged size and do a single storage update callback (like the filestore), instead of doing so for every single purged message.

Would be worth calling out at least the `sequence=1` fix in the release notes, or post-poning releasing this fix to a minor bump like 2.15?