### PR TITLE
Fix protocol corruption from `$JS.ACK` suffix append

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -30,6 +30,7 @@ import (
 	"net/url"
 	"regexp"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -4445,7 +4446,7 @@ func (c *client) processInboundClientMsg(msg []byte) (bool, bool) {
 	if c.srv.gateway.enabled {
 		reply := c.pa.reply
 		if len(c.pa.deliver) > 0 && c.kind == JETSTREAM && len(reply) > 0 && !replyHasJSAckSuffix(reply) {
-			reply = append(reply, '@')
+			reply = append(slices.Clip(reply), '@')
 			reply = append(reply, c.pa.deliver...)
 		}
 		didDeliver = c.sendMsgToGateways(acc, msg, c.pa.subject, reply, qnames, false) || didDeliver
@@ -4493,7 +4494,7 @@ func (c *client) handleGWReplyMap(msg []byte) bool {
 	if c.srv.gateway.enabled {
 		reply := c.pa.reply
 		if len(c.pa.deliver) > 0 && c.kind == JETSTREAM && len(reply) > 0 && !replyHasJSAckSuffix(reply) {
-			reply = append(reply, '@')
+			reply = append(slices.Clip(reply), '@')
 			reply = append(reply, c.pa.deliver...)
 		}
 		c.sendMsgToGateways(c.acc, msg, c.pa.subject, reply, nil, false)
@@ -5557,7 +5558,7 @@ sendToRoutesOrLeafs:
 	// already performed, otherwise we'd end up with a duplicate '@' suffix
 	// resulting in a protocol error.
 	if len(deliver) > 0 && len(reply) > 0 && !remapped && !replyHasJSAckSuffix(reply) {
-		reply = append(reply, '@')
+		reply = append(slices.Clip(reply), '@')
 		reply = append(reply, deliver...)
 	}
 

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -24168,3 +24168,85 @@ func TestJetStreamMirrorRetriesOnSeqAlreadySeenMismatch(t *testing.T) {
 		t.Fatal("retryMirrorConsumer was not called after errLastSeqMismatch in the sseq<=lseq branch")
 	}
 }
+
+// https://github.com/nats-io/nats-server/issues/7842
+func TestJetStreamJSAckSuffixCorruption(t *testing.T) {
+	const (
+		accountStr  = "$G"
+		subjectStr  = "foo.bar.baz"
+		replyStr    = "$JS.ACK.STREAM.CONS.1.2.3.4.5"
+		deliverStr  = "DELIVER_HERE"
+		payloadStr  = "hello world"
+		accountName = "ACC"
+	)
+
+	// Lay out a realistic routed pub frame header in one backing array so the
+	// reply field shares storage with the following bytes. The "reply" array
+	// is deliberately given more underlying capacity, as the parser would.
+	backing := make([]byte, 0, 128)
+	backing = append(backing, accountStr...)
+	backing = append(backing, ' ')
+	backing = append(backing, subjectStr...)
+	backing = append(backing, ' ')
+	replyStart := len(backing)
+	backing = append(backing, replyStr...)
+	reply := backing[replyStart : replyStart+len(replyStr) : cap(backing)]
+	backing = append(backing, ' ')
+	sizeBytes := []byte("11")
+	sizeStart := len(backing)
+	backing = append(backing, sizeBytes...)
+	szb := backing[sizeStart : sizeStart+len(sizeBytes)]
+
+	require_False(t, replyHasJSAckSuffix(reply))
+
+	opts := defaultServerOptions
+	srv := New(&opts)
+	sender := &client{
+		srv:  srv,
+		kind: ROUTER,
+		acc:  &Account{Name: accountName},
+		parseState: parseState{
+			pa: pubArg{
+				hdr:     -1,
+				size:    len(payloadStr),
+				account: []byte(accountStr),
+				subject: []byte(subjectStr),
+				reply:   reply,
+				szb:     szb,
+			},
+		},
+	}
+	sender.initClient()
+
+	fakeConn := &testConnWritePartial{}
+	target := &client{
+		srv:   srv,
+		nc:    fakeConn,
+		kind:  ROUTER,
+		route: &route{},
+	}
+	target.initClient()
+	r := &SublistResult{
+		psubs: []*subscription{{client: target}},
+	}
+
+	sender.processMsgResults(
+		sender.acc, r,
+		[]byte(payloadStr+CR_LF),
+		[]byte(deliverStr),
+		[]byte(subjectStr),
+		reply,
+		pmrAllowSendFromRouteToRoute,
+	)
+
+	target.mu.Lock()
+	target.flushOutbound()
+	target.mu.Unlock()
+
+	frame := fakeConn.buf.Bytes()
+	require_LessThan(t, 0, len(frame))
+
+	receiver := dummyRouteClient()
+	receiver.route = &route{}
+	require_NoError(t, receiver.parse(frame))
+}


### PR DESCRIPTION
In cases where `reply` had enough underlying capacity, we could mangle the array that backs `c.pa.reply` and that can affect other fields. This would eventually translate to protocol-level issues.

Should fix #7842.