### PR TITLE
Fixed tests using DefaultTestOptions

### DIFF
--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -733,7 +733,8 @@ func TestAuthProxyRequired(t *testing.T) {
 	ujwt, err := nuc.Encode(akp)
 	require_NoError(t, err)
 
-	lopts := &DefaultTestOptions
+	dto := DefaultTestOptions
+	lopts := &dto
 	u, err := url.Parse(fmt.Sprintf("nats://%s:%d", o.LeafNode.Host, o.LeafNode.Port))
 	require_NoError(t, err)
 	remote := &RemoteLeafOpts{URLs: []*url.URL{u}}

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -6440,7 +6440,8 @@ func TestLeafNodeSignatureCB(t *testing.T) {
 		t.Fatalf("Error generating user JWT: %v", err)
 	}
 
-	lopts := &DefaultTestOptions
+	dto := DefaultTestOptions
+	lopts := &dto
 	u, err := url.Parse(fmt.Sprintf("nats://%s:%d", opts.LeafNode.Host, opts.LeafNode.Port))
 	if err != nil {
 		t.Fatalf("Error parsing url: %v", err)

--- a/test/log_test.go
+++ b/test/log_test.go
@@ -13,7 +13,8 @@ import (
 
 func RunServerWithLogging(opts *server.Options) *server.Server {
 	if opts == nil {
-		opts = &DefaultTestOptions
+		dto := DefaultTestOptions
+		opts = &dto
 	}
 	opts.NoLog = false
 	opts.Cluster.PoolSize = -1

--- a/test/test.go
+++ b/test/test.go
@@ -51,7 +51,8 @@ var DefaultTestOptions = server.Options{
 
 // RunDefaultServer starts a new Go routine based server using the default options
 func RunDefaultServer() *server.Server {
-	return RunServer(&DefaultTestOptions)
+	dto := DefaultTestOptions
+	return RunServer(&dto)
 }
 
 func RunRandClientPortServer() *server.Server {
@@ -75,7 +76,8 @@ func RunServer(opts *server.Options) *server.Server {
 
 func RunServerCallback(opts *server.Options, callback func(*server.Server)) *server.Server {
 	if opts == nil {
-		opts = &DefaultTestOptions
+		dto := DefaultTestOptions
+		opts = &dto
 	}
 	// Optionally override for individual debugging of tests
 	opts.NoLog = !doLog


### PR DESCRIPTION
Make sure we make a copy of the structure before using it. We used to use a reference to this and some test would then modify the content. It could have an impact on other tests.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
