### PR TITLE
[FIXED] Stream and consumer scale down consistency

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8340,26 +8340,7 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 				js.mu.Lock()
 			}
 			// If we identified a leader make sure its part of the new group.
-			selected := make([]string, 0, newCfg.Replicas)
-
-			if curLeader != _EMPTY_ {
-				selected = append(selected, curLeader)
-			}
-			for _, peer := range rg.Peers {
-				if len(selected) == newCfg.Replicas {
-					break
-				}
-				if peer == curLeader {
-					continue
-				}
-				if si, ok := s.nodeToInfo.Load(peer); ok && si != nil {
-					if si.(nodeInfo).offline {
-						continue
-					}
-					selected = append(selected, peer)
-				}
-			}
-			rg.Peers = selected
+			rg.Peers = s.selectScaleDownPeers(rg.Peers, curLeader, newCfg.Replicas)
 			// Single nodes are not recorded by the NRG layer so we can rename.
 			// MUST do this, otherwise a scaleup afterward could potentially lead to inconsistencies.
 			if len(rg.Peers) == 1 {
@@ -8679,6 +8660,43 @@ func (s *Server) allPeersOffline(rg *raftGroup) bool {
 		}
 	}
 	return true
+}
+
+// Select the peers to keep when scaling a raft group down to replicas.
+// The current leader, if known and in peer set, is kept. Online peers are preferred,
+// but we will fall back to offline peers to honor the requested replica count.
+func (s *Server) selectScaleDownPeers(peers []string, curLeader string, replicas int) []string {
+	selected := make([]string, 0, replicas)
+	if curLeader != _EMPTY_ && slices.Contains(peers, curLeader) {
+		selected = append(selected, curLeader)
+		if len(selected) == replicas {
+			return selected
+		}
+	}
+	// Prefer online peers.
+	for _, peer := range peers {
+		if peer == curLeader {
+			continue
+		}
+		if si, ok := s.nodeToInfo.Load(peer); ok && si != nil && !si.(nodeInfo).offline {
+			selected = append(selected, peer)
+			if len(selected) == replicas {
+				return selected
+			}
+		}
+	}
+
+	// Fall back to offline peers for the remainder.
+	for _, peer := range peers {
+		if slices.Contains(selected, peer) {
+			continue
+		}
+		selected = append(selected, peer)
+		if len(selected) == replicas {
+			break
+		}
+	}
+	return selected
 }
 
 // This will do a scatter and gather operation for all streams for this account. This is only called from metadata leader.
@@ -9526,7 +9544,7 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 				if ci, err := sysRequest[ConsumerInfo](s, clusterConsumerInfoT, ci.serviceAccount(), sa.Config.Name, oname); err != nil {
 					s.Warnf("Did not receive consumer info results for '%s > %s > %s' due to: %s", acc, sa.Config.Name, oname, err)
 				} else if ci != nil {
-					if cl := ci.Cluster; cl != nil {
+					if cl := ci.Cluster; cl != nil && cl.Leader != _EMPTY_ {
 						curLeader = getHash(cl.Leader)
 					}
 				}
@@ -9570,20 +9588,9 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 			nca.Group.Preferred = curLeader
 			nca.Group.ScaleUp = true
 		} else if rBefore > rAfter {
-			newPeerSet := nca.Group.Peers
-			// mark leader preferred and move it to end
+			// Mark the current leader as preferred, it will be kept in the new peer set.
 			nca.Group.Preferred = curLeader
-			if nca.Group.Preferred != _EMPTY_ {
-				for i, p := range newPeerSet {
-					if nca.Group.Preferred == p {
-						newPeerSet[i] = newPeerSet[len(newPeerSet)-1]
-						newPeerSet[len(newPeerSet)-1] = p
-					}
-				}
-			}
-			// scale down by removing peers from the end
-			newPeerSet = newPeerSet[len(newPeerSet)-rAfter:]
-			nca.Group.Peers = newPeerSet
+			nca.Group.Peers = s.selectScaleDownPeers(nca.Group.Peers, curLeader, rAfter)
 			// Single nodes are not recorded by the NRG layer so we can rename.
 			// MUST do this, otherwise a scaleup afterward could potentially lead to inconsistencies.
 			if len(nca.Group.Peers) == 1 {

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -10808,3 +10808,235 @@ func TestJetStreamClusterMirrorSkipMsgsPropagatesProposeFailure(t *testing.T) {
 	mset.mu.Unlock()
 	require_Error(t, err, errNotLeader)
 }
+
+func TestJetStreamClusterStreamScaleDownOfflinePeersHonorsReplicaCount(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R7S", 7)
+	defer c.shutdown()
+
+	// Connect to the meta leader, it is guaranteed to remain running.
+	ml := c.leader()
+	nc, js := jsClientConnect(t, ml)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 5,
+	})
+	require_NoError(t, err)
+
+	// Map peer IDs to servers.
+	peerSrv := make(map[string]*Server, len(c.servers))
+	srvPeer := make(map[*Server]string, len(c.servers))
+	for _, s := range c.servers {
+		peerSrv[s.Node()] = s
+		srvPeer[s] = s.Node()
+	}
+
+	// Get the stream peer set from the meta leader.
+	mjs := ml.getJetStream()
+	mjs.mu.RLock()
+	sa := mjs.streamAssignment(globalAccountName, "TEST")
+	var streamPeers []string
+	if sa != nil {
+		streamPeers = copyStrings(sa.Group.Peers)
+	}
+	mjs.mu.RUnlock()
+	require_Len(t, len(streamPeers), 5)
+
+	// Shut down three of the stream's peers. Only two of the five stream peers remain online.
+	sl := c.streamLeader(globalAccountName, "TEST")
+	var offline []*Server
+	for _, p := range streamPeers {
+		if len(offline) == 3 {
+			break
+		}
+		if s := peerSrv[p]; s != sl && s != ml {
+			offline = append(offline, s)
+		}
+	}
+	require_Len(t, len(offline), 3)
+	for _, s := range offline {
+		s.Shutdown()
+	}
+
+	// Wait for the meta leader to mark the stopped servers as offline.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		for _, s := range offline {
+			if ni, ok := ml.nodeToInfo.Load(srvPeer[s]); !ok || !ni.(nodeInfo).offline {
+				return fmt.Errorf("server %q not marked offline yet", s.Name())
+			}
+		}
+		return nil
+	})
+
+	// Scale the stream down to R3. Only two of the five peers are online, but
+	// the stream must still end up with the requested number of replicas.
+	_, err = js.UpdateStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	// Wait for the scale down to be applied in the meta layer.
+	var newPeers []string
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		sa := mjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil {
+			return fmt.Errorf("stream assignment not found")
+		}
+		if len(sa.Group.Peers) == len(streamPeers) {
+			return fmt.Errorf("scale down not applied yet, still %d peers", len(sa.Group.Peers))
+		}
+		newPeers = copyStrings(sa.Group.Peers)
+		return nil
+	})
+
+	// The stream peer set must reflect the requested replica count.
+	require_Len(t, len(newPeers), 3)
+
+	// The online peers must be preferred and part of the new peer set.
+	for _, p := range streamPeers {
+		if slices.Contains(offline, peerSrv[p]) {
+			continue
+		}
+		if !slices.Contains(newPeers, p) {
+			t.Fatalf("Online peer %q not selected by the scale down", peerSrv[p].Name())
+		}
+	}
+}
+
+func TestJetStreamClusterConsumerScaleDownPrefersOnlinePeers(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R5S", 5)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 5,
+	})
+	require_NoError(t, err)
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "DUR",
+		AckPolicy: nats.AckExplicitPolicy,
+		Replicas:  5,
+	})
+	require_NoError(t, err)
+
+	// Map peer IDs to servers.
+	peerSrv := make(map[string]*Server, len(c.servers))
+	srvPeer := make(map[*Server]string, len(c.servers))
+	for _, s := range c.servers {
+		peerSrv[s.Node()] = s
+		srvPeer[s] = s.Node()
+	}
+
+	// Get the consumer peer set, in order, from the meta leader.
+	c.waitOnLeader()
+	ml := c.leader()
+	mjs := ml.getJetStream()
+	mjs.mu.RLock()
+	ca := mjs.consumerAssignment(globalAccountName, "TEST", "DUR")
+	var consumerPeers []string
+	if ca != nil {
+		consumerPeers = copyStrings(ca.Group.Peers)
+	}
+	mjs.mu.RUnlock()
+	require_Len(t, len(consumerPeers), 5)
+
+	cl := c.consumerLeader(globalAccountName, "TEST", "DUR")
+	require_NotNil(t, cl)
+	leaderPeer := srvPeer[cl]
+
+	// Simulate which peers the old scale down to R3 would keep: the current
+	// leader is moved to the end of the peer list, and the last three peers
+	// of the list are kept.
+	sim := copyStrings(consumerPeers)
+	for i, p := range sim {
+		if p == leaderPeer {
+			sim[i] = sim[len(sim)-1]
+			sim[len(sim)-1] = p
+		}
+	}
+	keep := sim[len(sim)-3:]
+	require_Equal(t, keep[2], leaderPeer)
+
+	// Reconnect the client to the consumer leader, it remains running.
+	nc.Close()
+	nc, js = jsClientConnect(t, cl)
+	defer nc.Close()
+
+	// Shut down the two non-leader peers that the scale down will keep. The
+	// other two peers, as well as the consumer leader, remain online.
+	var offline []*Server
+	for _, p := range keep[:2] {
+		s := peerSrv[p]
+		require_True(t, s != cl)
+		s.Shutdown()
+		offline = append(offline, s)
+	}
+	require_Len(t, len(offline), 2)
+
+	// The meta leader might have been shut down, wait for a new one.
+	c.waitOnLeader()
+	ml = c.leader()
+
+	// Wait for the meta leader to mark the stopped servers as offline.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		for _, s := range offline {
+			if ni, ok := ml.nodeToInfo.Load(srvPeer[s]); !ok || !ni.(nodeInfo).offline {
+				return fmt.Errorf("server %q not marked offline yet", s.Name())
+			}
+		}
+		return nil
+	})
+
+	// The consumer kept quorum (3 of 5 peers online), the leader must not
+	// have changed.
+	c.waitOnConsumerLeader(globalAccountName, "TEST", "DUR")
+	require_Equal(t, c.consumerLeader(globalAccountName, "TEST", "DUR").Name(), cl.Name())
+
+	// Scale the consumer down to R3. The consumer leader and two more peers
+	// are online, so the scale down must select those peers and not the
+	// offline ones.
+	_, err = js.UpdateConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "DUR",
+		AckPolicy: nats.AckExplicitPolicy,
+		Replicas:  3,
+	})
+	require_NoError(t, err)
+
+	// Wait for the scale down to be applied in the meta layer.
+	mjs = ml.getJetStream()
+	var newPeers []string
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		ca := mjs.consumerAssignment(globalAccountName, "TEST", "DUR")
+		if ca == nil {
+			return fmt.Errorf("consumer assignment not found")
+		}
+		if len(ca.Group.Peers) != 3 {
+			return fmt.Errorf("scale down not applied yet, still %d peers", len(ca.Group.Peers))
+		}
+		newPeers = copyStrings(ca.Group.Peers)
+		return nil
+	})
+
+	// The leader must have been preserved.
+	require_True(t, slices.Contains(newPeers, leaderPeer))
+
+	// The new peer set must consist of online peers only.
+	for _, s := range offline {
+		if slices.Contains(newPeers, srvPeer[s]) {
+			t.Fatalf("Scale down selected offline peer %q over online peers", s.Name())
+		}
+	}
+}


### PR DESCRIPTION
Fix two inconsistent scale down paths:
- A stream scale down would only select online peers, producing fewer peers if some replicas were offline.
- A consumer scale down would only scale down to the "last N" peers where N is the replica count to scale down to. This didn't take offline servers into account, so could scale down such that there is no quorum for the consumer to continue.

Both paths now: keep the current leader (if possible), prefer online peers, fall back to offline peers.