### PR TITLE
fix(conf): treat numbers with a suffix followed by more characters as strings

### DIFF
--- a/conf/lex.go
+++ b/conf/lex.go
@@ -1110,11 +1110,13 @@ func lexConvenientNumber(lx *lexer) stateFn {
 		return lexConvenientNumber
 	}
 	lx.backup()
-	if isNL(r) || r == eof || r == mapEnd || r == optValTerm || r == mapValTerm || isWhitespace(r) || unicode.IsDigit(r) {
+	if isNL(r) || r == eof || r == mapEnd || r == optValTerm || r == mapValTerm || isWhitespace(r) {
 		lx.emit(itemInteger)
 		return lx.pop()
 	}
-	// This is not a number, so treat it as a string.
+	// Anything else following the suffix (including a digit, e.g. "0K1abc"
+	// or "5e7bcd") means this isn't a convenient number after all, so treat
+	// the whole token as a string.
 	lx.stringStateFn = lexString
 	return lexString
 }

--- a/conf/lex_test.go
+++ b/conf/lex_test.go
@@ -340,6 +340,37 @@ func TestConvenientIntegerValues(t *testing.T) {
 	}
 	lx = lex("foo = 4Gb, bar = 5Gø")
 	expect(t, lx, expectedItems)
+
+	// A digit following a size suffix means this is not a convenient
+	// number, so the whole token must be lexed as a string rather than
+	// emitting a partial integer for the leading "0K". See #5186.
+	expectedItems = []item{
+		{itemKey, "foo", 1, 0},
+		{itemString, "0K1abc", 1, 6},
+		{itemEOF, "", 1, 0},
+	}
+	lx = lex("foo = 0K1abc")
+	expect(t, lx, expectedItems)
+
+	// The 'e'/'E' suffix has the same problem: "5e7bcd" must be a string,
+	// not the integer "5e7" followed by stray "bcd". See #5189 and #6891.
+	expectedItems = []item{
+		{itemKey, "foo", 1, 0},
+		{itemString, "5e7bcd", 1, 6},
+		{itemEOF, "", 1, 0},
+	}
+	lx = lex("foo = 5e7bcd")
+	expect(t, lx, expectedItems)
+
+	// Same as above but terminated by a comma, ensuring the trailing
+	// separator still ends the string value cleanly.
+	expectedItems = []item{
+		{itemKey, "foo", 1, 0},
+		{itemString, "4e2abc", 1, 6},
+		{itemEOF, "", 1, 0},
+	}
+	lx = lex("foo = 4e2abc,")
+	expect(t, lx, expectedItems)
 }
 
 func TestSimpleKeyFloatValues(t *testing.T) {

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -178,14 +178,19 @@ func TestBcryptVariable(t *testing.T) {
 // not convenient numbers and must be parsed as plain strings rather than
 // failing to parse. See #5186, #5189 and #6891.
 func TestUnquotedStringStartingWithNumberAndSuffix(t *testing.T) {
-	for _, val := range []string{"0K1abc", "8m4dwr", "5e7bcd-abc10", "4e2abc"} {
+	for _, val := range []string{"0K1abc", "8m4dwr", "5e7bcd-abc10", "4e2abc", "-1k2abc"} {
 		ex := map[string]any{"password": val}
 		test(t, fmt.Sprintf("password: %s", val), ex)
 	}
 
+	ex := map[string]any{
+		"passwords": []any{"4e2abc", "0K1abc"},
+	}
+	test(t, "passwords: [4e2abc, 0K1abc]", ex)
+
 	// Also verify it works inside a map, matching the reported nats.conf
 	// authorization block.
-	ex := map[string]any{
+	ex = map[string]any{
 		"authorization": map[string]any{
 			"user":     "foo",
 			"password": "4e2abc",

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -173,6 +173,27 @@ func TestBcryptVariable(t *testing.T) {
 	test(t, "password: $2a$11$ooo", ex)
 }
 
+// Unquoted values that begin with digits followed by a size suffix (k, m,
+// g, ...) or the 'e'/'E' suffix and then more characters (e.g. a digit) are
+// not convenient numbers and must be parsed as plain strings rather than
+// failing to parse. See #5186, #5189 and #6891.
+func TestUnquotedStringStartingWithNumberAndSuffix(t *testing.T) {
+	for _, val := range []string{"0K1abc", "8m4dwr", "5e7bcd-abc10", "4e2abc"} {
+		ex := map[string]any{"password": val}
+		test(t, fmt.Sprintf("password: %s", val), ex)
+	}
+
+	// Also verify it works inside a map, matching the reported nats.conf
+	// authorization block.
+	ex := map[string]any{
+		"authorization": map[string]any{
+			"user":     "foo",
+			"password": "4e2abc",
+		},
+	}
+	test(t, "authorization { user: foo, password: 4e2abc }", ex)
+}
+
 var easynum = `
 k = 8k
 kb = 4kb


### PR DESCRIPTION
The config lexer mis-parses unquoted values that start with a number, then a size/exponent suffix, then more characters.

`lexConvenientNumber` emitted an integer token as soon as it saw a digit after a suffix (k, m, g, t, p, e and their uppercase forms). So `0K1abc` lexed as the integer `0K` and `5e7bcd` as `5e7`, leaving the trailing characters behind. The parser then failed with errors like:

```
Expected a top-level value to end with a new line, comment or EOF, but got '1' instead.
```

This most often shows up with unquoted passwords that happen to begin with a number and one of those suffix letters (e.g. `password: 4e2abc`).

A digit, or any other non-terminator, after the suffix means the token isn't a convenient number, so it should be lexed as a string. The fix drops the `unicode.IsDigit(r)` clause so an integer is only emitted on an actual value terminator (newline, EOF, map end, value/array terminator, whitespace); anything else falls through to the existing string state. This matches how `1Ghz` is already handled.

Added lexer-level cases to `TestConvenientIntegerValues` and a parser-level `TestUnquotedStringStartingWithNumberAndSuffix` covering `0K1abc`, `8m4dwr`, `5e7bcd-abc10` and `4e2abc`, both at top level and inside an authorization block.

Fixes #5186
Fixes #5189
Fixes #6891
