### PR TITLE
[FIXED] Reject malformed TTL and schedule state on decode

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -2177,7 +2177,9 @@ func (fs *fileStore) recoverTTLState() error {
 		ttlseq, err = fs.ttls.Decode(buf)
 		if err != nil {
 			fs.warn("Error decoding TTL state: %s", err)
+			// Remove the file, and reset collected state (if any).
 			_ = os.Remove(fn)
+			fs.ttls = thw.NewHashWheel()
 		}
 	}
 
@@ -2262,7 +2264,9 @@ func (fs *fileStore) recoverMsgSchedulingState() error {
 		schedSeq, err = fs.scheduling.decode(buf)
 		if err != nil {
 			fs.warn("Error decoding message scheduling state: %s", err)
+			// Remove the file, and reset collected state (if any).
 			_ = os.Remove(fn)
+			fs.scheduling = newMsgScheduling(fs.runMsgScheduling)
 		}
 	}
 

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -10935,6 +10935,40 @@ func TestFileStoreMessageScheduleEncodeDecode(t *testing.T) {
 	}
 }
 
+func TestFileStoreMessageScheduleDecodeRejectsMalformed(t *testing.T) {
+	// Build a valid header that claims a single schedule entry.
+	header := func(count uint64) []byte {
+		b := make([]byte, headerLen)
+		b[0] = 1                                    // Magic version
+		binary.LittleEndian.PutUint64(b[1:], count) // Entry count
+		binary.LittleEndian.PutUint64(b[9:], 0)     // High sequence stamp
+		return b
+	}
+
+	for _, test := range []struct {
+		title string
+		buf   []byte
+		err   error
+	}{
+		{title: "ShortHeader", buf: make([]byte, headerLen-1), err: io.ErrShortBuffer},
+		{title: "BadVersion", buf: func() []byte { b := header(0); b[0] = 2; return b }(), err: ErrMsgScheduleInvalidVersion},
+		// Claims one entry but the buffer ends right after the header.
+		{title: "TruncatedAtSubjLen", buf: header(1), err: io.ErrUnexpectedEOF},
+		// Claims one entry, has the subject length but the subject bytes are missing.
+		{title: "TruncatedSubj", buf: append(header(1), 5, 0), err: io.ErrUnexpectedEOF},
+		// Has the subject but the timestamp/seq varints are missing.
+		{title: "TruncatedVarints", buf: append(header(1), 3, 0, 'f', 'o', 'o'), err: io.ErrUnexpectedEOF},
+		// Has the subject and timestamp varint but the seq varint is missing.
+		{title: "TruncatedSeq", buf: append(append(header(1), 3, 0, 'f', 'o', 'o'), binary.AppendVarint(nil, 12345)...), err: io.ErrUnexpectedEOF},
+	} {
+		t.Run(test.title, func(t *testing.T) {
+			ms := newMsgScheduling(func() {})
+			_, err := ms.decode(test.buf)
+			require_Error(t, err, test.err)
+		})
+	}
+}
+
 func TestFileStoreCorruptedNonOrderedSequences(t *testing.T) {
 	for _, test := range []struct {
 		title   string

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -287,6 +287,9 @@ func (ms *MsgScheduling) decode(b []byte) (uint64, error) {
 	stamp := binary.LittleEndian.Uint64(b[9:])
 	b = b[headerLen:]
 	for i := uint64(0); i < count; i++ {
+		if len(b) < 2 {
+			return 0, io.ErrUnexpectedEOF
+		}
 		sl := int(binary.LittleEndian.Uint16(b))
 		b = b[2:]
 		if len(b) < sl {
@@ -295,11 +298,11 @@ func (ms *MsgScheduling) decode(b []byte) (uint64, error) {
 		subj := string(b[:sl])
 		b = b[sl:]
 		ts, tn := binary.Varint(b)
-		if tn < 0 {
+		if tn <= 0 {
 			return 0, io.ErrUnexpectedEOF
 		}
 		seq, vn := binary.Uvarint(b[tn:])
-		if vn < 0 {
+		if vn <= 0 {
 			return 0, io.ErrUnexpectedEOF
 		}
 		ms.init(seq, subj, ts)

--- a/server/thw/thw.go
+++ b/server/thw/thw.go
@@ -230,11 +230,11 @@ func (hw *HashWheel) Decode(b []byte) (uint64, error) {
 	b = b[headerLen:]
 	for i := uint64(0); i < count; i++ {
 		ts, tn := binary.Varint(b)
-		if tn < 0 {
+		if tn <= 0 {
 			return 0, io.ErrUnexpectedEOF
 		}
 		v, vn := binary.Uvarint(b[tn:])
-		if vn < 0 {
+		if vn <= 0 {
 			return 0, io.ErrUnexpectedEOF
 		}
 		hw.Add(v, ts)

--- a/server/thw/thw_test.go
+++ b/server/thw/thw_test.go
@@ -14,6 +14,8 @@
 package thw
 
 import (
+	"encoding/binary"
+	"io"
 	"math"
 	"testing"
 	"time"
@@ -248,6 +250,36 @@ func TestHashWheelEncodeDecode(t *testing.T) {
 			require_True(t, ok)
 			require_Equal(t, ts, nts)
 		}
+	}
+}
+
+func TestHashWheelDecodeRejectsMalformed(t *testing.T) {
+	// Build a valid header that claims the given number of entries.
+	header := func(count uint64) []byte {
+		b := make([]byte, headerLen)
+		b[0] = 1                                    // Magic version
+		binary.LittleEndian.PutUint64(b[1:], count) // Entry count
+		binary.LittleEndian.PutUint64(b[9:], 0)     // High sequence stamp
+		return b
+	}
+
+	for _, test := range []struct {
+		title string
+		buf   []byte
+		err   error
+	}{
+		{title: "ShortHeader", buf: make([]byte, headerLen-1), err: io.ErrShortBuffer},
+		{title: "BadVersion", buf: func() []byte { b := header(0); b[0] = 2; return b }(), err: ErrInvalidVersion},
+		// Claims one entry but the buffer ends right after the header.
+		{title: "TruncatedAtVarints", buf: header(1), err: io.ErrUnexpectedEOF},
+		// Has the timestamp varint but the seq varint is missing.
+		{title: "TruncatedSeq", buf: append(header(1), binary.AppendVarint(nil, 12345)...), err: io.ErrUnexpectedEOF},
+	} {
+		t.Run(test.title, func(t *testing.T) {
+			hw := NewHashWheel()
+			_, err := hw.Decode(test.buf)
+			require_Error(t, err, test.err)
+		})
 	}
 }
 


### PR DESCRIPTION
Resolves https://github.com/nats-io/nats-server/issues/8268