### PR TITLE
Clear external auth on account claim updates

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3418,6 +3418,8 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 		a.extAuth.AuthUsers.Add(ac.Authorization.AuthUsers...)
 		a.extAuth.AllowedAccounts.Add(ac.Authorization.AllowedAccounts...)
 		a.extAuth.XKey = ac.Authorization.XKey
+	} else {
+		a.extAuth = nil
 	}
 
 	// Reset exports and imports here.

--- a/server/auth_callout_test.go
+++ b/server/auth_callout_test.go
@@ -395,6 +395,42 @@ func TestAuthCalloutBasics(t *testing.T) {
 	}
 }
 
+func TestAuthCalloutUpdateAccountClaimsClearsExternalAuthorization(t *testing.T) {
+	opts := defaultServerOptions
+	s := New(&opts)
+	defer s.Shutdown()
+
+	_, authAccPub := createKey(t)
+	_, authUserPub := createKey(t)
+	_, allowedAccPub := createKey(t)
+	_, deniedAccPub := createKey(t)
+
+	authAcc, err := s.RegisterAccount(authAccPub)
+	require_NoError(t, err)
+
+	claim := jwt.NewAccountClaims(authAccPub)
+	claim.Name = "AUTH"
+	claim.EnableExternalAuthorization(authUserPub)
+	claim.Authorization.AllowedAccounts.Add(allowedAccPub)
+	claim.Authorization.XKey = "test-xkey"
+	s.UpdateAccountClaims(authAcc, claim)
+
+	require_True(t, authAcc.hasExternalAuth())
+	require_True(t, authAcc.isExternalAuthUser(authUserPub))
+	require_True(t, authAcc.isAllowedAcount(allowedAccPub))
+	require_False(t, authAcc.isAllowedAcount(deniedAccPub))
+	require_Equal(t, authAcc.externalAuthXKey(), "test-xkey")
+
+	claim = jwt.NewAccountClaims(authAccPub)
+	claim.Name = "AUTH"
+	s.UpdateAccountClaims(authAcc, claim)
+
+	require_False(t, authAcc.hasExternalAuth())
+	require_False(t, authAcc.isExternalAuthUser(authUserPub))
+	require_False(t, authAcc.isAllowedAcount(allowedAccPub))
+	require_Equal(t, authAcc.externalAuthXKey(), _EMPTY_)
+}
+
 func TestAuthCalloutMQTTJwtPassedInConnectOptions(t *testing.T) {
 	storeDir := t.TempDir()
 	conf := fmt.Sprintf(`


### PR DESCRIPTION
Closes #8272

## Summary
- Clear cached external authorization when refreshed account claims no longer enable external auth.
- Add regression coverage for auth users, allowed accounts, and xkey state being removed by an account claim update.

## Testing
- go test ./server -run TestAuthCallout -count=1
- golangci-lint run --timeout=5m --config=.golangci.yml ./server
- codex review --base upstream/main