### PR TITLE
Refresh inherited JWT default permissions

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3390,7 +3390,13 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 
 	a.mu.Lock()
 	// Clone to update, only select certain fields.
-	old := &Account{Name: a.Name, exports: a.exports, limits: a.limits, signingKeys: a.signingKeys}
+	old := &Account{
+		Name:         a.Name,
+		exports:      a.exports,
+		limits:       a.limits,
+		signingKeys:  a.signingKeys,
+		defaultPerms: a.defaultPerms.clone(),
+	}
 
 	// overwrite claim meta data
 	a.nameTag = ac.Name
@@ -3792,6 +3798,8 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 		a.jsLimits = nil
 	}
 
+	defaultPerms := a.defaultPerms
+	defaultPermsChanged := !reflect.DeepEqual(old.defaultPerms, defaultPerms)
 	a.updated = time.Now()
 	clients := a.getClientsLocked()
 	ajs := a.js
@@ -3870,6 +3878,9 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 		}
 		theJWT := c.opts.JWT
 		c.mu.Unlock()
+		if defaultPermsChanged && c.updateDefaultPermissions(defaultPerms) && defaultPerms != nil {
+			c.processSubsOnConfigReload(nil)
+		}
 		// Check for being revoked here. We use ac one to avoid the account lock.
 		if (ac.Revocations != nil || ac.Limits.DisallowBearer) && theJWT != _EMPTY_ {
 			if juc, err := jwt.DecodeUserClaims(theJWT); err != nil {
@@ -4027,8 +4038,11 @@ func buildInternalNkeyUser(uc *jwt.UserClaims, acts map[string]struct{}, acc *Ac
 
 	// Now check for permissions.
 	var p = buildPermissionsFromJwt(&uc.Permissions)
-	if p == nil && acc.defaultPerms != nil {
-		p = acc.defaultPerms.clone()
+	if p == nil {
+		nu.defaultPerms = true
+		if acc.defaultPerms != nil {
+			p = acc.defaultPerms.clone()
+		}
 	}
 	nu.Permissions = p
 	return nu

--- a/server/auth.go
+++ b/server/auth.go
@@ -69,6 +69,7 @@ type NkeyUser struct {
 	SigningKey             string              `json:"signing_key,omitempty"`
 	AllowedConnectionTypes map[string]struct{} `json:"connection_types,omitempty"`
 	ProxyRequired          bool                `json:"proxy_required,omitempty"`
+	defaultPerms           bool
 }
 
 // User is for multiple accounts/users.

--- a/server/client.go
+++ b/server/client.go
@@ -1052,6 +1052,24 @@ func (c *client) RegisterNkeyUser(user *NkeyUser) error {
 	return nil
 }
 
+func (c *client) updateDefaultPermissions(perms *Permissions) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.user == nil || !c.user.defaultPerms {
+		return false
+	}
+	if perms == nil {
+		c.user.Permissions = nil
+		c.perms = nil
+		c.mperms = nil
+		c.darray = nil
+		return true
+	}
+	c.user.Permissions = perms.clone()
+	c.setPermissions(c.user.Permissions)
+	return true
+}
+
 func splitSubjectQueue(sq string) ([]byte, []byte, error) {
 	vals := strings.Fields(strings.TrimSpace(sq))
 	s := []byte(vals[0])

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -364,6 +364,103 @@ func TestJWTUserPermissionClaims(t *testing.T) {
 	}
 }
 
+func TestJWTAccountDefaultPermissionsUpdateRefreshesClients(t *testing.T) {
+	nac := newJWTTestAccountClaims()
+	nac.DefaultPermissions.Pub.Allow.Add("foo")
+	nac.DefaultPermissions.Sub.Allow.Add("foo")
+
+	s, _, c, cr := setupJWTTestWitAccountClaims(t, nac, "+OK")
+	defer s.Shutdown()
+	defer c.close()
+
+	if l, _ := cr.ReadString('\n'); !strings.HasPrefix(l, "PONG") {
+		t.Fatalf("Expected PONG, got %q", l)
+	}
+
+	c.mu.Lock()
+	acc := c.acc
+	require_True(t, c.pubAllowedFullCheck("foo", true, true))
+	require_True(t, c.canSubscribe("foo"))
+	c.mu.Unlock()
+	require_NotNil(t, acc)
+
+	c.parseAsync("SUB foo 1\r\nPING\r\n")
+	if l, _ := cr.ReadString('\n'); !strings.HasPrefix(l, "+OK") {
+		t.Fatalf("Expected subscription to be accepted, got %q", l)
+	}
+	if l, _ := cr.ReadString('\n'); !strings.HasPrefix(l, "PONG") {
+		t.Fatalf("Expected PONG, got %q", l)
+	}
+
+	nac = jwt.NewAccountClaims(acc.Name)
+	nac.DefaultPermissions.Pub.Allow.Add("bar")
+	nac.DefaultPermissions.Sub.Allow.Add("bar")
+	ajwt, err := nac.Encode(oKp)
+	require_NoError(t, err)
+
+	addAccountToMemResolver(s, acc.Name, ajwt)
+	s.UpdateAccountClaims(acc, nac)
+
+	c.mu.Lock()
+	require_False(t, c.pubAllowedFullCheck("foo", true, true))
+	require_True(t, c.pubAllowedFullCheck("bar", true, true))
+	require_False(t, c.canSubscribe("foo"))
+	require_True(t, c.canSubscribe("bar"))
+	_, ok := c.subs["1"]
+	c.mu.Unlock()
+	require_False(t, ok)
+
+	line, _ := cr.ReadString('\n')
+	require_Contains(t, line, `Permissions Violation for Subscription to "foo"`)
+
+	c.parseAsync("PUB foo 0\r\n\r\n")
+	line, _ = cr.ReadString('\n')
+	require_Contains(t, line, `Permissions Violation for Publish to "foo"`)
+}
+
+func TestJWTAccountDefaultPermissionsUpdateKeepsExplicitUserPermissions(t *testing.T) {
+	nac := newJWTTestAccountClaims()
+	nac.DefaultPermissions.Pub.Allow.Add("foo")
+	nac.DefaultPermissions.Sub.Allow.Add("foo")
+
+	nuc := newJWTTestUserClaims()
+	nuc.Permissions.Pub.Allow.Add("baz")
+	nuc.Permissions.Sub.Allow.Add("baz")
+
+	s, _, c, cr := setupJWTTestWithClaims(t, nac, nuc, "+OK")
+	defer s.Shutdown()
+	defer c.close()
+
+	if l, _ := cr.ReadString('\n'); !strings.HasPrefix(l, "PONG") {
+		t.Fatalf("Expected PONG, got %q", l)
+	}
+
+	c.mu.Lock()
+	acc := c.acc
+	require_True(t, c.pubAllowedFullCheck("baz", true, true))
+	require_False(t, c.pubAllowedFullCheck("foo", true, true))
+	require_True(t, c.canSubscribe("baz"))
+	require_False(t, c.canSubscribe("foo"))
+	c.mu.Unlock()
+	require_NotNil(t, acc)
+
+	nac = jwt.NewAccountClaims(acc.Name)
+	nac.DefaultPermissions.Pub.Allow.Add("bar")
+	nac.DefaultPermissions.Sub.Allow.Add("bar")
+	ajwt, err := nac.Encode(oKp)
+	require_NoError(t, err)
+
+	addAccountToMemResolver(s, acc.Name, ajwt)
+	s.UpdateAccountClaims(acc, nac)
+
+	c.mu.Lock()
+	require_True(t, c.pubAllowedFullCheck("baz", true, true))
+	require_False(t, c.pubAllowedFullCheck("bar", true, true))
+	require_True(t, c.canSubscribe("baz"))
+	require_False(t, c.canSubscribe("bar"))
+	c.mu.Unlock()
+}
+
 func TestJWTUserResponsePermissionClaims(t *testing.T) {
 	nuc := newJWTTestUserClaims()
 	nuc.Permissions.Resp = &jwt.ResponsePermission{


### PR DESCRIPTION
Closes #8273

## Summary
- Track JWT/NKey users whose effective permissions come from account defaults.
- Refresh those inherited permissions when account JWT default permissions change.
- Add regression coverage for stale inherited permissions and explicit user permissions.

## Testing
- go test ./server -run '^(TestJWTAccountDefaultPermissionsUpdateRefreshesClients|TestJWTAccountDefaultPermissionsUpdateKeepsExplicitUserPermissions)$' -count=1
- go test ./server -run '^(TestJWTAccountDefaultPermissionsUpdateRefreshesClients|TestJWTAccountDefaultPermissionsUpdateKeepsExplicitUserPermissions|TestJWTUserPermissionClaims|TestJWTUserResponsePermissionClaims|TestJWTUserResponsePermissionClaimsDefaultValues|TestJWTUserResponsePermissionClaimsNegativeValues|TestJWTAccountRenew|TestJWTAccountExpiresAfterConnect|TestJWTUpdateAccountClaimsStreamAndServiceImportDeadlock)$' -count=1
- go build
- golangci-lint run --timeout=5m --config=.golangci.yml ./server