### PR TITLE
Enforce service import max payload

### DIFF
--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -1556,6 +1556,53 @@ func TestServiceImportWithWildcards(t *testing.T) {
 	}
 }
 
+func TestServiceImportRequestInfoRespectsMaxPayload(t *testing.T) {
+	opts := defaultServerOptions
+	opts.MaxPayload = 64
+	s := New(&opts)
+	defer s.Shutdown()
+
+	serviceAcc, err := s.RegisterAccount("$service")
+	require_NoError(t, err)
+	callerAcc, err := s.RegisterAccount("$caller")
+	require_NoError(t, err)
+	require_NoError(t, serviceAcc.AddServiceExport("svc.remote", nil))
+	require_NoError(t, callerAcc.AddServiceImport(serviceAcc, "svc.local", "svc.remote"))
+
+	delivered := make(chan int, 1)
+	sub, err := serviceAcc.subscribeInternalEx(
+		"svc.remote",
+		func(_ *subscription, c *client, _ *Account, _, _ string, _ []byte) {
+			delivered <- c.pa.size
+		},
+		false,
+	)
+	require_NoError(t, err)
+	defer serviceAcc.unsubscribeInternal(sub)
+
+	caller, crCaller, _ := newClientForServer(s)
+	defer caller.close()
+	require_NoError(t, caller.registerWithAccount(callerAcc))
+
+	payload := strings.Repeat("a", int(opts.MaxPayload)-1)
+	proto := fmt.Sprintf("PUB svc.local reply %d\r\n%s\r\n", len(payload), payload)
+	require_NoError(t, caller.parse([]byte(proto)))
+
+	select {
+	case size := <-delivered:
+		if size <= int(opts.MaxPayload) {
+			t.Fatalf("Expected test message to exceed max_payload after import, got %d", size)
+		}
+		t.Fatalf("Expected oversized service import request to be suppressed, got %d", size)
+	default:
+	}
+
+	require_NoError(t, caller.parse([]byte("PING\r\n")))
+	line, err := crCaller.ReadString('\n')
+	require_NoError(t, err)
+	require_Equal(t, line, "PONG\r\n")
+}
+
 // Make sure the AddStreamExport function is additive if called multiple times.
 func TestAddStreamExport(t *testing.T) {
 	s, fooAcc, barAcc := simpleAccountServer(t)

--- a/server/client.go
+++ b/server/client.go
@@ -2478,6 +2478,11 @@ func (c *client) maxPayloadViolation(sz int, max int32) {
 	c.closeConnection(MaxPayloadExceeded)
 }
 
+func (c *client) serviceImportMaxPayloadExceeded() bool {
+	maxPayload := atomic.LoadInt32(&c.mpay)
+	return maxPayload != jwt.NoLimit && int64(c.pa.size) > int64(maxPayload)
+}
+
 // queueOutbound queues data for a clientconnection.
 // Lock should be held.
 func (c *client) queueOutbound(data []byte) {
@@ -4947,6 +4952,12 @@ func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byt
 			if b, _ := json.Marshal(ci); b != nil {
 				msg = c.setHeader(ClientInfoHdr, bytesToString(b), msg)
 			}
+		}
+		if c.serviceImportMaxPayloadExceeded() {
+			siAcc.removeRespServiceImport(rsi, rsiNoDelivery)
+			c.pa = pacopy
+			c.pa.delivered = false
+			return false
 		}
 	}
 

--- a/server/norace_1_test.go
+++ b/server/norace_1_test.go
@@ -4274,7 +4274,7 @@ func TestNoRaceJetStreamStreamInfoSubjectDetailsLimits(t *testing.T) {
 		  default: {
 			jetstream: true
 			users: [ {user: me, password: pwd} ]
-			limits { max_payload: 512 }
+			limits { max_payload: 768 }
 		  }
 		}
 	`, t.TempDir())))
@@ -4291,11 +4291,11 @@ func TestNoRaceJetStreamStreamInfoSubjectDetailsLimits(t *testing.T) {
 	// Make sure to flush so we process the 2nd INFO.
 	nc.Flush()
 
-	// Make sure we cannot send larger than 512 bytes.
+	// Make sure we cannot send larger than 768 bytes.
 	// But we can receive larger.
 	sub, err := nc.SubscribeSync("foo")
 	require_NoError(t, err)
-	err = nc.Publish("foo", []byte(strings.Repeat("A", 600)))
+	err = nc.Publish("foo", []byte(strings.Repeat("A", 800)))
 	require_Error(t, err, nats.ErrMaxPayload)
 	sub.Unsubscribe()
 


### PR DESCRIPTION
Closes #8271

## Summary
- Check the expanded service-import request size after `Nats-Request-Info` is added.
- Suppress oversized imported requests and clean up temporary response imports.
- Add regression coverage for a request accepted at ingress that exceeds `max_payload` after service-import metadata.

## Testing
- go test ./server -run '^TestServiceImportRequestInfoRespectsMaxPayload$' -count=1
- go test ./server -run '^TestServiceImport' -count=1
- go test ./server -run '^TestAccountDuplicateServiceImportSubject$' -count=1
- git diff --check
- go build
- golangci-lint run --timeout=5m --config=.golangci.yml ./server

Review: `codex review --base upstream/main` reported no actionable findings.
