### PR TITLE
Check push consumer deliver subject permissions

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -30,6 +30,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nuid"
 )
 
@@ -4571,6 +4572,11 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
+	if apiErr := s.checkConsumerDeliverSubjectPermission(c, ci, acc, &req.Config); apiErr != nil {
+		resp.Error = apiErr
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
 
 	if isClustered && !direct {
 		s.jsClusteredConsumerRequest(ci, acc, subject, reply, rmsg, req.Stream, &req.Config, req.Action, req.Pedantic)
@@ -4655,6 +4661,156 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 		o.sendPauseAdvisoryLocked(&o.cfg)
 	}
 	o.mu.RUnlock()
+}
+
+func (s *Server) checkConsumerDeliverSubjectPermission(
+	c *client,
+	ci *ClientInfo,
+	acc *Account,
+	cfg *ConsumerConfig,
+) *ApiError {
+	if cfg == nil || cfg.DeliverSubject == _EMPTY_ {
+		return nil
+	}
+	deliver := cfg.DeliverSubject
+	if !subjectIsLiteral(deliver) || !IsValidSubject(deliver) {
+		return nil
+	}
+
+	if rc := s.requestorClient(c, ci); rc != nil {
+		rc.mu.Lock()
+		allowed := rc.pubAllowedFullCheck(deliver, false, true)
+		rc.mu.Unlock()
+		if allowed {
+			return nil
+		}
+		return consumerDeliverSubjectPermissionError(deliver)
+	}
+
+	perms, ok := s.requestorPermissions(c, ci, acc)
+	if !ok || !permissionsCanPublishToSubject(perms, deliver) {
+		return consumerDeliverSubjectPermissionError(deliver)
+	}
+	return nil
+}
+
+func consumerDeliverSubjectPermissionError(deliver string) *ApiError {
+	err := fmt.Errorf("consumer deliver subject %q not permitted by publish permissions", deliver)
+	return NewJSConsumerInvalidPolicyError(err)
+}
+
+func (s *Server) requestorClient(c *client, ci *ClientInfo) *client {
+	if ci != nil && ci.ID != 0 && (ci.Server == _EMPTY_ || ci.Server == s.Name()) {
+		return s.getClient(ci.ID)
+	}
+	if c != nil && c.kind == CLIENT && (ci == nil || ci.ID == 0 || ci.ID == c.cid) {
+		return c
+	}
+	return nil
+}
+
+func (s *Server) requestorPermissions(c *client, ci *ClientInfo, acc *Account) (*Permissions, bool) {
+	if ci == nil || (ci.User == _EMPTY_ && ci.Jwt == _EMPTY_) {
+		return s.requestorPermissionsWithoutIdentity(c, ci, acc)
+	}
+	if ci.Jwt != _EMPTY_ {
+		return requestorJWTPermissions(ci.Jwt, acc)
+	}
+	return s.namedRequestorPermissions(ci, acc)
+}
+
+func (s *Server) requestorPermissionsWithoutIdentity(
+	c *client,
+	ci *ClientInfo,
+	acc *Account,
+) (*Permissions, bool) {
+	if isInternalRequestor(c, ci) {
+		return nil, true
+	}
+	if perms := defaultPermissions(acc); perms != nil {
+		return perms, true
+	}
+	if isRemoteRequestor(ci, s.Name()) {
+		return nil, false
+	}
+	return nil, true
+}
+
+func requestorJWTPermissions(userJWT string, acc *Account) (*Permissions, bool) {
+	uc, err := jwt.DecodeUserClaims(userJWT)
+	if err != nil {
+		return nil, false
+	}
+	perms := buildPermissionsFromJwt(&uc.Permissions)
+	if perms == nil {
+		perms = defaultPermissions(acc)
+	}
+	return perms, true
+}
+
+func (s *Server) namedRequestorPermissions(ci *ClientInfo, acc *Account) (*Permissions, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if nu := s.nkeys[ci.User]; nu != nil && samePermissionsAccount(nu.Account, acc) {
+		return nu.Permissions.clone(), true
+	}
+	if u := s.users[ci.User]; u != nil && samePermissionsAccount(u.Account, acc) {
+		return u.Permissions.clone(), true
+	}
+	return nil, false
+}
+
+func isInternalRequestor(c *client, ci *ClientInfo) bool {
+	if ci != nil {
+		switch ci.Kind {
+		case kindStringMap[JETSTREAM], kindStringMap[SYSTEM], kindStringMap[ACCOUNT]:
+			return true
+		case _EMPTY_:
+		default:
+			return false
+		}
+	}
+	return c != nil && isInternalClient(c.kind)
+}
+
+func isRemoteRequestor(ci *ClientInfo, serverName string) bool {
+	return ci != nil && ci.ID != 0 && ci.Server != _EMPTY_ && ci.Server != serverName
+}
+
+func defaultPermissions(acc *Account) *Permissions {
+	if acc == nil {
+		return nil
+	}
+	acc.mu.RLock()
+	defer acc.mu.RUnlock()
+	return acc.defaultPerms.clone()
+}
+
+func samePermissionsAccount(userAcc, requestAcc *Account) bool {
+	if userAcc == nil || requestAcc == nil {
+		return userAcc == requestAcc
+	}
+	return userAcc.Name == requestAcc.Name
+}
+
+func permissionsCanPublishToSubject(perms *Permissions, subject string) bool {
+	if perms == nil || perms.Publish == nil {
+		return true
+	}
+	for _, deny := range perms.Publish.Deny {
+		if subjectIsSubsetMatch(subject, deny) {
+			return false
+		}
+	}
+	if len(perms.Publish.Allow) == 0 {
+		return true
+	}
+	for _, allow := range perms.Publish.Allow {
+		if subjectIsSubsetMatch(subject, allow) {
+			return true
+		}
+	}
+	return false
 }
 
 // Request for the list of all consumer names.

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -11323,6 +11323,128 @@ func TestJetStreamConsumerLegacyDurableCreateSetsConsumerName(t *testing.T) {
 	require_Equal(t, resp.Config.Name, "CONSUMER")
 }
 
+func TestJetStreamPushConsumerDeliverSubjectRequiresPublishPermission(t *testing.T) {
+	conf := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: "127.0.0.1:-1"
+		jetstream: {store_dir: %q}
+		authorization {
+			users: [
+				{user: admin, password: pwd}
+				{
+					user: attacker
+					password: pwd
+					permissions: {
+						publish: {
+							allow: ["foo.in", "$JS.API.CONSUMER.CREATE.S.C"]
+							deny: ["victim.>"]
+						}
+						subscribe: {allow: "_INBOX.>"}
+					}
+				}
+			]
+		}
+	`, t.TempDir())))
+	s, _ := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	adminNC, adminJS := jsClientConnect(t, s, nats.UserInfo("admin", "pwd"))
+	defer adminNC.Close()
+
+	_, err := adminJS.AddStream(&nats.StreamConfig{
+		Name:     "S",
+		Subjects: []string{"foo.in"},
+		Storage:  nats.MemoryStorage,
+	})
+	require_NoError(t, err)
+
+	sub, err := adminNC.SubscribeSync("victim.inbox")
+	require_NoError(t, err)
+	require_NoError(t, adminNC.Flush())
+
+	errCh := make(chan error, 2)
+	attackerNC := natsConnect(t, s.ClientURL(),
+		nats.UserInfo("attacker", "pwd"),
+		nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+			select {
+			case errCh <- err:
+			default:
+			}
+		}))
+	defer attackerNC.Close()
+
+	require_NoError(t, attackerNC.Publish("victim.inbox", []byte("direct denied")))
+	require_NoError(t, attackerNC.Flush())
+	select {
+	case err := <-errCh:
+		require_Contains(t, err.Error(), `Permissions Violation for Publish to "victim.inbox"`)
+	case <-time.After(time.Second):
+		t.Fatal("Expected direct publish to victim.inbox to be denied")
+	}
+
+	req, err := json.Marshal(&CreateConsumerRequest{
+		Stream: "S",
+		Config: ConsumerConfig{
+			Name:           "C",
+			DeliverSubject: "victim.inbox",
+			DeliverPolicy:  DeliverAll,
+			AckPolicy:      AckNone,
+		},
+	})
+	require_NoError(t, err)
+
+	msg, err := attackerNC.Request("$JS.API.CONSUMER.CREATE.S.C", req, time.Second)
+	require_NoError(t, err)
+	var resp JSApiConsumerCreateResponse
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	if resp.Error == nil {
+		t.Fatal("Expected consumer create to be rejected")
+	}
+	require_Contains(t, resp.Error.Description, "consumer deliver subject")
+	require_Contains(t, resp.Error.Description, "not permitted")
+
+	require_NoError(t, attackerNC.Publish("foo.in", []byte("blocked by consumer create")))
+	require_NoError(t, attackerNC.Flush())
+
+	_, err = sub.NextMsg(250 * time.Millisecond)
+	require_Error(t, err)
+}
+
+func TestJetStreamPushConsumerDeliverSubjectRejectsUnknownRemoteClient(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	ci := &ClientInfo{
+		ID:      22,
+		Account: globalAccountName,
+		User:    "dynamic",
+		Server:  "remote-server",
+		Kind:    kindStringMap[CLIENT],
+	}
+	cfg := &ConsumerConfig{DeliverSubject: "victim.inbox"}
+	if apiErr := s.checkConsumerDeliverSubjectPermission(nil, ci, s.globalAccount(), cfg); apiErr == nil {
+		t.Fatal("Expected unknown remote client identity to be rejected")
+	}
+}
+
+func TestJetStreamPushConsumerDeliverSubjectAllowsInternalRequestor(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	acc := s.globalAccount()
+	acc.mu.Lock()
+	acc.defaultPerms = &Permissions{Publish: &SubjectPermission{Deny: []string{">"}}}
+	acc.mu.Unlock()
+
+	ci := &ClientInfo{
+		Account: globalAccountName,
+		Kind:    kindStringMap[JETSTREAM],
+	}
+	cfg := &ConsumerConfig{DeliverSubject: "$JS.S.123"}
+	if apiErr := s.checkConsumerDeliverSubjectPermission(nil, ci, acc, cfg); apiErr != nil {
+		t.Fatalf("Expected internal requestor to be allowed, got %v", apiErr)
+	}
+}
+
 // https://github.com/nats-io/nats-server/issues/7852
 func TestJetStreamConsumerSingleFilterSubjectInFilterSubjects(t *testing.T) {
 	s := RunBasicJetStreamServer(t)


### PR DESCRIPTION
Closes #8274

## Summary
- Reject push consumer create requests when the creator cannot publish to the configured deliver subject.
- Use live client permissions for local requestors and request-info identity for routed/clustered API handling.
- Preserve internal JetStream source/mirror setup and reject unresolved remote client identities instead of treating them as allow-all.
- Add regression coverage for direct publish denial, unresolved remote identity handling, and internal JetStream requestors.

## Testing
- go test ./server -run '^(TestJetStreamPushConsumerDeliverSubjectRequiresPublishPermission|TestJetStreamPushConsumerDeliverSubjectRejectsUnknownRemoteClient|TestJetStreamPushConsumerDeliverSubjectAllowsInternalRequestor)$' -count=1
- go test ./server -run '^(TestJetStreamPushConsumerDeliverSubjectRequiresPublishPermission|TestJetStreamPushConsumerDeliverSubjectRejectsUnknownRemoteClient|TestJetStreamPushConsumerDeliverSubjectAllowsInternalRequestor|TestJetStreamConsumerLegacyDurableCreateSetsConsumerName|TestJetStreamConsumerSingleFilterSubjectInFilterSubjects)$' -count=1
- git diff --check -- server/jetstream_api.go server/jetstream_consumer_test.go
- go build ./...
- golangci-lint run --timeout=5m --config=.golangci.yml ./server
