### PR TITLE
Enforce schedule target and source permissions

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -5677,12 +5677,24 @@ func (c *client) pubPermissionViolation(subject []byte) {
 }
 
 func (c *client) subPermissionViolation(sub *subscription) {
-	errTxt := fmt.Sprintf("Permissions Violation for Subscription to %q", sub.subject)
-	logTxt := fmt.Sprintf("Subscription Violation - Subject %q, SID %s", sub.subject, sub.sid)
+	c.subPermissionViolationForSubjectAndQueue(sub.subject, sub.queue, sub.sid)
+}
 
-	if sub.queue != nil {
-		errTxt = fmt.Sprintf("Permissions Violation for Subscription to %q using queue %q", sub.subject, sub.queue)
-		logTxt = fmt.Sprintf("Subscription Violation - Subject %q, Queue: %q, SID %s", sub.subject, sub.queue, sub.sid)
+func (c *client) subPermissionViolationForSubject(subject string) {
+	c.subPermissionViolationForSubjectAndQueue(stringToBytes(subject), nil, nil)
+}
+
+func (c *client) subPermissionViolationForSubjectAndQueue(subject, queue, sid []byte) {
+	errTxt := fmt.Sprintf("Permissions Violation for Subscription to %q", subject)
+	logTxt := fmt.Sprintf("Subscription Violation - Subject %q, SID %s", subject, sid)
+
+	if queue != nil {
+		errTxt = fmt.Sprintf(
+			"Permissions Violation for Subscription to %q using queue %q",
+			subject, queue)
+		logTxt = fmt.Sprintf(
+			"Subscription Violation - Subject %q, Queue: %q, SID %s",
+			subject, queue, sid)
 	}
 
 	c.sendErr(errTxt)

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -22453,6 +22453,180 @@ func TestJetStreamScheduledMessageNotTriggering(t *testing.T) {
 	}
 }
 
+type jetStreamSchedulePermissionTest struct {
+	name             string
+	publish          *SubjectPermission
+	subscribe        *SubjectPermission
+	source           string
+	schedulerHeaders bool
+	err              string
+}
+
+func TestJetStreamScheduledMessageRespectsClientPermissions(t *testing.T) {
+	for _, test := range []jetStreamSchedulePermissionTest{
+		{
+			name: "DeniedTarget",
+			publish: &SubjectPermission{
+				Allow: []string{"foo.schedule"},
+				Deny:  []string{"foo.out"},
+			},
+			err: `Permissions Violation for Publish to "foo.out"`,
+		},
+		{
+			name: "DeniedTargetWithSchedulerHeaders",
+			publish: &SubjectPermission{
+				Allow: []string{"foo.schedule"},
+				Deny:  []string{"foo.out"},
+			},
+			schedulerHeaders: true,
+			err:              `Permissions Violation for Publish to "foo.out"`,
+		},
+		{
+			name: "DeniedSource",
+			publish: &SubjectPermission{
+				Allow: []string{"foo.schedule", "foo.out"},
+			},
+			subscribe: &SubjectPermission{
+				Allow: []string{"_INBOX.>"},
+				Deny:  []string{"foo.source"},
+			},
+			source: "foo.source",
+			err:    `Permissions Violation for Subscription to "foo.source"`,
+		},
+		{
+			name: "DeniedSourceWithSchedulerHeaders",
+			publish: &SubjectPermission{
+				Allow: []string{"foo.schedule", "foo.out"},
+			},
+			subscribe: &SubjectPermission{
+				Allow: []string{"_INBOX.>"},
+				Deny:  []string{"foo.source"},
+			},
+			source:           "foo.source",
+			schedulerHeaders: true,
+			err:              `Permissions Violation for Subscription to "foo.source"`,
+		},
+		{
+			name: "AllowedTargetAndSource",
+			publish: &SubjectPermission{
+				Allow: []string{"foo.schedule", "foo.out"},
+			},
+			subscribe: &SubjectPermission{
+				Allow: []string{"_INBOX.>", "foo.source"},
+			},
+			source: "foo.source",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			test.run(t)
+		})
+	}
+}
+
+func (test jetStreamSchedulePermissionTest) run(t *testing.T) {
+	s := runJetStreamSchedulePermissionServer(t, test.publish, test.subscribe)
+	defer s.Shutdown()
+
+	admin, js := jsClientConnect(t, s, nats.UserInfo("admin", "pwd"))
+	defer admin.Close()
+
+	_, err := jsStreamCreate(t, admin, &StreamConfig{
+		Name:              "S",
+		Subjects:          []string{"foo.*"},
+		Storage:           MemoryStorage,
+		AllowMsgSchedules: true,
+	})
+	require_NoError(t, err)
+
+	_, err = js.Publish("foo.source", []byte("SOURCE"))
+	require_NoError(t, err)
+
+	errCh := make(chan error, 1)
+	nc := connectSchedulePermissionClient(t, s, errCh)
+	defer nc.Close()
+
+	msg := nats.NewMsg("foo.schedule")
+	msg.Header.Set(JSSchedulePattern, "@at 1970-01-01T00:00:00Z")
+	msg.Header.Set(JSScheduleTarget, "foo.out")
+	if test.source != _EMPTY_ {
+		msg.Header.Set(JSScheduleSource, test.source)
+	}
+	if test.schedulerHeaders {
+		msg.Header.Set(JSScheduleNext, JSScheduleNextPurge)
+		msg.Header.Set(JSScheduler, "foo.other")
+	}
+	msg.Data = []byte("fallback")
+
+	require_NoError(t, nc.PublishMsg(msg))
+	require_NoError(t, nc.Flush())
+
+	if test.err != _EMPTY_ {
+		requireSchedulePermissionError(t, errCh, test.err)
+		_, err = js.GetLastMsg("S", "foo.out")
+		require_Error(t, err, nats.ErrMsgNotFound)
+		return
+	}
+
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		sm, err := js.GetLastMsg("S", "foo.out")
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(sm.Data, []byte("SOURCE")) {
+			return fmt.Errorf("expected scheduled output to copy source, got %q", sm.Data)
+		}
+		return nil
+	})
+}
+
+func runJetStreamSchedulePermissionServer(
+	t *testing.T, publish, subscribe *SubjectPermission,
+) *Server {
+	t.Helper()
+	opts := DefaultTestOptions
+	opts.Port = -1
+	opts.JetStream = true
+	opts.StoreDir = t.TempDir()
+	opts.Users = []*User{
+		{Username: "admin", Password: "pwd"},
+		{
+			Username: "client",
+			Password: "pwd",
+			Permissions: &Permissions{
+				Publish:   publish,
+				Subscribe: subscribe,
+			},
+		},
+	}
+	return RunServer(&opts)
+}
+
+func connectSchedulePermissionClient(
+	t *testing.T, s *Server, errCh chan<- error,
+) *nats.Conn {
+	t.Helper()
+	nc, err := nats.Connect(s.ClientURL(),
+		nats.UserInfo("client", "pwd"),
+		nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+			select {
+			case errCh <- err:
+			default:
+			}
+		}))
+	require_NoError(t, err)
+	return nc
+}
+
+func requireSchedulePermissionError(t *testing.T, errCh <-chan error, want string) {
+	t.Helper()
+	select {
+	case err := <-errCh:
+		require_Contains(t, err.Error(), want)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Expected permission violation %q", want)
+	}
+}
+
 func TestJetStreamScheduledMessageIncompatibleSettings(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/stream.go
+++ b/server/stream.go
@@ -6108,6 +6108,9 @@ func (mset *stream) processInboundJetStreamMsg(_ *subscription, c *client, _ *Ac
 		// object.
 		mt.addJetStreamEvent(mset.name())
 	}
+	if !mset.checkMsgScheduleSubjectPermissions(c, subject, hdr) {
+		return
+	}
 	mset.queueInbound(mset.msgs, subject, reply, hdr, msg, nil, c.pa.trace)
 }
 
@@ -6119,6 +6122,109 @@ var (
 	errStreamMismatch    = errors.New("expected stream does not match")
 	errMsgTTLDisabled    = errors.New("message TTL disabled")
 )
+
+type msgSchedulePermissionViolation int
+
+const (
+	msgSchedulePermissionOK msgSchedulePermissionViolation = iota
+	msgScheduleTargetPermissionViolation
+	msgScheduleSourcePermissionViolation
+)
+
+func (mset *stream) checkMsgScheduleSubjectPermissions(c *client, subject string, hdr []byte) bool {
+	violation, subject := mset.msgScheduleSubjectPermissionViolation(c, subject, hdr)
+	switch violation {
+	case msgSchedulePermissionOK:
+		return true
+	case msgScheduleTargetPermissionViolation:
+		c.pubPermissionViolation(stringToBytes(subject))
+	case msgScheduleSourcePermissionViolation:
+		c.subPermissionViolationForSubject(subject)
+	}
+	return false
+}
+
+func (mset *stream) msgScheduleSubjectPermissionViolation(
+	c *client, subject string, hdr []byte,
+) (msgSchedulePermissionViolation, string) {
+	if len(hdr) == 0 {
+		return msgSchedulePermissionOK, _EMPTY_
+	}
+	schedule, apiErr := getMessageSchedule(hdr)
+	if apiErr != nil || schedule.IsZero() {
+		return msgSchedulePermissionOK, _EMPTY_
+	}
+	scheduleTtl, ok := getMessageScheduleTTL(hdr)
+	if !ok {
+		return msgSchedulePermissionOK, _EMPTY_
+	}
+	if scheduleRollup := getMessageScheduleRollup(hdr); scheduleRollup != _EMPTY_ &&
+		scheduleRollup != JSMsgRollupSubject {
+		return msgSchedulePermissionOK, _EMPTY_
+	}
+	if rollup := getRollup(hdr); rollup != _EMPTY_ && rollup != JSMsgRollupSubject {
+		return msgSchedulePermissionOK, _EMPTY_
+	}
+	target := getMessageScheduleTarget(hdr)
+	if target == _EMPTY_ || !IsValidPublishSubject(target) || target == subject {
+		return msgSchedulePermissionOK, _EMPTY_
+	}
+	source := getMessageScheduleSource(hdr)
+	if source != _EMPTY_ {
+		if source == target || source == subject || !IsValidPublishSubject(source) {
+			return msgSchedulePermissionOK, _EMPTY_
+		}
+	}
+	if !mset.msgScheduleConfigAllowsSubjects(scheduleTtl, target, source) {
+		return msgSchedulePermissionOK, _EMPTY_
+	}
+	if !c.canPublishMsgScheduleTarget(target) {
+		return msgScheduleTargetPermissionViolation, target
+	}
+	if source != _EMPTY_ && !c.canSubscribeMsgScheduleSource(source) {
+		return msgScheduleSourcePermissionViolation, source
+	}
+	return msgSchedulePermissionOK, _EMPTY_
+}
+
+func (mset *stream) msgScheduleConfigAllowsSubjects(scheduleTtl, target, source string) bool {
+	mset.cfgMu.RLock()
+	defer mset.cfgMu.RUnlock()
+	if !mset.cfg.AllowMsgSchedules || scheduleTtl != _EMPTY_ && !mset.cfg.AllowMsgTTL {
+		return false
+	}
+	matches := func(subject string) bool {
+		return slices.ContainsFunc(mset.cfg.Subjects, func(streamSubject string) bool {
+			return SubjectsCollide(streamSubject, subject)
+		})
+	}
+	if !matches(target) {
+		return false
+	}
+	return source == _EMPTY_ || matches(source)
+}
+
+func (c *client) canPublishMsgScheduleTarget(subject string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.kind == CLIENT {
+		bsubj := stringToBytes(subject)
+		if hasGWRoutedReplyPrefix(bsubj) {
+			return false
+		}
+		if bytes.HasPrefix(bsubj, clientNRGPrefix) && c.srv != nil &&
+			c.acc != c.srv.SystemAccount() {
+			return false
+		}
+	}
+	return c.pubAllowedFullCheck(subject, false, true)
+}
+
+func (c *client) canSubscribeMsgScheduleSource(subject string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.canSubscribeInternal(subject)
+}
 
 // processJetStreamMsg is where we try to actually process the stream msg.
 func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, lseq uint64, ts int64, mt *msgTrace, sourced bool, needLock bool) error {


### PR DESCRIPTION
## Summary
- Check JetStream message schedule targets against the publishing client's publish permissions before queueing the scheduled message.
- Check `Nats-Schedule-Source` subjects against the publishing client's subscribe permissions before allowing a schedule to copy from that source.
- Add regression coverage for denied target, denied source, scheduler-header variants, and an allowed target/source copy.

Refs trailofbits/ptp-nats-server#26.
Reference patch: trailofbits/ptp-nats-server#79.

## Testing
- `go test ./server -run '^TestJetStreamScheduledMessageRespectsClientPermissions$' -count=1 -v`
- `go test ./server -run '^TestJetStreamScheduled(MessageNotTriggering|MessageRespectsClientPermissions|MessageIncompatibleSettings|PurgeHeadersRequiresSchedulingEnabled|MessageNotDeactivated|MessageDeliveryPreservesTargetSchedule|MessageParse)$' -count=1`
- `go build ./...`
- `GOARCH=amd64 GOOS=linux go build`
- `GOARCH=386 GOOS=linux go build`
- `go vet ./server`
- `golangci-lint run --timeout=5m --config=.golangci.yml`
