### PR TITLE
Upgrade goreleaser's Go version 1.26.4, and go.mod toolchain to 1.25.11

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,7 @@ builds:
     env:
       # This is the toolchain version we use for releases. To override, set the env var, e.g.:
       # GORELEASER_TOOLCHAIN="go1.22.8" TARGET='linux_amd64' goreleaser build --snapshot --clean --single-target
-      - GOTOOLCHAIN={{ envOrDefault "GORELEASER_TOOLCHAIN" "go1.26.3" }}
+      - GOTOOLCHAIN={{ envOrDefault "GORELEASER_TOOLCHAIN" "go1.26.4" }}
       - GO111MODULE=on
       - CGO_ENABLED=0
     goos:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/nats-io/nats-server/v2
 
 go 1.25.0
 
-toolchain go1.25.10
+toolchain go1.25.11
 
 require (
 	github.com/antithesishq/antithesis-sdk-go v0.7.0-default-no-op


### PR DESCRIPTION
<!-- Please make sure to read CONTRIBUTING.md, then delete this notice and replace it with your PR description. Commit sign-offs certify that the contribution is your original work and that you license the work to the project under the Apache-2.0 license. We cannot accept contributions without it. -->

This is to remediate https://github.com/advisories/GHSA-h524-452v-82p9, https://github.com/advisories/GHSA-4279-q6mj-392r, and https://github.com/advisories/GHSA-h3gm-q7m7-mp28.
