### PR TITLE
(2.15) [IMPROVED] Index stream sources to avoid backward scans

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -2218,5 +2218,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSMessageSourceHdrNotAllowedErr",
+    "code": 400,
+    "error_code": 10224,
+    "description": "message stream source header is not allowed",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/errors.json
+++ b/server/errors.json
@@ -2248,5 +2248,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSMessageSourceHdrNotAllowedErr",
+    "code": 400,
+    "error_code": 10227,
+    "description": "message stream source header is not allowed",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/feature_flags.go
+++ b/server/feature_flags.go
@@ -22,6 +22,7 @@ import (
 const (
 	FeatureFlagJsAckFormatV2     = "js_ack_fc_v2"
 	FeatureFlagJsRaftDeleteRange = "js_raft_delete_range"
+	FeatureFlagJsSnapshotSources = "js_snapshot_sources"
 )
 
 var featureFlags = map[string]bool{
@@ -44,6 +45,18 @@ var featureFlags = map[string]bool{
 	// supports receiving `deleteRangeOp`. Older peers panic on apply of an
 	// unknown stream entry operation.
 	FeatureFlagJsRaftDeleteRange: false,
+
+	// Include the stream's sourcing state in the replicated stream snapshot.
+	// Unlike other per-message derived state, it outlives the messages it was
+	// collected from, so a replica that caught up after those messages were
+	// removed can't derive it locally and would resume sourcing from an earlier
+	// position once it becomes leader.
+	// - Introduced: 2.15.0, both encoding versions are accepted, only emitting v1.
+	// - Enabled: TBD, once all supported versions accept v2.
+	//
+	// WARNING: Only enable once every peer in the cluster is on a version that
+	// accepts the v2 encoding. Older peers reject the snapshot outright.
+	FeatureFlagJsSnapshotSources: false,
 }
 
 // getFeatureFlag is used to retrieve either the default or overwritten value for a feature flag.

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -214,6 +214,7 @@ type fileStore struct {
 	scheduling  *MsgScheduling
 	sdm         *SDMMeta
 	lpex        time.Time // Last PurgeEx call.
+	sources     map[string]uint64
 }
 
 // Represents a message store block and its data.
@@ -346,6 +347,11 @@ const (
 
 	// This is the encoded message scheduling file.
 	msgSchedulingStreamStateFile = "sched.db"
+
+	// This is the encoded sources state file. Unlike the other state files it
+	// lives at the FileStoreConfig.StoreDir root rather than under msgDir, so
+	// a full purge does not also purge this file.
+	sourcesStreamStateFile = "sources.db"
 
 	// AEK key sizes
 	minMetaKeySize = 64
@@ -2132,9 +2138,17 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 // Lock should be held.
 func (fs *fileStore) recoverPerMessageState() error {
 	scanSeq := uint64(math.MaxUint64)
-	var ttlSeq, schedSeq uint64
-	var ttlRecover, schedRecover bool
+	var ttlSeq, schedSeq, sourcesSeq uint64
+	var ttlRecover, schedRecover, sourcesRecover bool
 	allowMsgTTL, allowMsgSchedules := fs.cfg.AllowMsgTTL, fs.cfg.AllowMsgSchedules
+
+	var sources map[string]*StreamSource
+	if len(fs.cfg.Sources) > 0 {
+		sources = make(map[string]*StreamSource, len(fs.cfg.Sources))
+		for _, ssi := range fs.cfg.Sources {
+			sources[ssi.composeIName()] = ssi
+		}
+	}
 
 	// Create or delete the THW if needed.
 	if allowMsgTTL && fs.ttls == nil {
@@ -2154,8 +2168,56 @@ func (fs *fileStore) recoverPerMessageState() error {
 		fs.scheduling = nil
 	}
 
+	// Create or delete the source tracking if needed.
+	if sources != nil && fs.sources == nil {
+		sourcesSeq = fs.recoverSourcesState()
+		// Only allow scanning if the index recovered something. If there is no index
+		// yet, then we'll just not do the scan and let the upper layer do so when needed.
+		if fs.sources != nil {
+			sourcesRecover = true
+			scanSeq = min(scanSeq, sourcesSeq)
+		}
+	}
+	if len(sources) > 0 {
+		// Ensure the map exists even on a fresh stream that has no persisted
+		// index yet, so storeRawMsg can validate headers against the configured
+		// set (zero sequence == configured but not yet observed).
+		if fs.sources == nil {
+			fs.sources = make(map[string]uint64, len(sources))
+		}
+		// Remove sources that are tracked but no longer exist.
+		for k := range fs.sources {
+			if _, ok := sources[k]; !ok {
+				delete(fs.sources, k)
+			}
+		}
+		// Seed sources that aren't in the map yet.
+		for k := range sources {
+			if _, ok := fs.sources[k]; !ok {
+				fs.sources[k] = 0
+			}
+		}
+	}
+	if fs.sources != nil {
+		// No sources configured anymore, clear.
+		if len(sources) == 0 {
+			fs.sources = nil
+		}
+		// If all zeros or empty, remove the index from disk.
+		remove := true
+		for _, seq := range fs.sources {
+			if seq > 0 {
+				remove = false
+				break
+			}
+		}
+		if remove {
+			_ = os.Remove(fs.sourcesStatePath())
+		}
+	}
+
 	// Short-circuit if no recovering is required.
-	if !ttlRecover && !schedRecover {
+	if !ttlRecover && !schedRecover && !sourcesRecover {
 		return nil
 	}
 
@@ -2166,12 +2228,24 @@ func (fs *fileStore) recoverPerMessageState() error {
 		defer fs.scheduling.resetTimer()
 	}
 
+	// If only sources need recovering, then we can optimize to a backward scan.
+	if sourcesRecover && !ttlRecover && !schedRecover {
+		if fs.state.Msgs > 0 && sourcesSeq <= fs.state.LastSeq {
+			fs.warn("Sourcing state is outdated; attempting to recover using backward scan (seq %d to %d)", sourcesSeq, fs.state.LastSeq)
+			fs.recoverSourcesBackwardScan(sourcesSeq, sources)
+		}
+		return nil
+	}
+
 	if fs.state.Msgs > 0 && scanSeq <= fs.state.LastSeq {
 		if ttlRecover && ttlSeq <= fs.state.LastSeq {
 			fs.warn("TTL state is outdated; attempting to recover using linear scan (seq %d to %d)", ttlSeq, fs.state.LastSeq)
 		}
 		if schedRecover && schedSeq <= fs.state.LastSeq {
 			fs.warn("Message scheduling state is outdated; attempting to recover using linear scan (seq %d to %d)", schedSeq, fs.state.LastSeq)
+		}
+		if sourcesRecover && sourcesSeq <= fs.state.LastSeq {
+			fs.warn("Sourcing state is outdated; attempting to recover using linear scan (seq %d to %d)", sourcesSeq, fs.state.LastSeq)
 		}
 		var (
 			mb     *msgBlock
@@ -2194,7 +2268,8 @@ func (fs *fileStore) recoverPerMessageState() error {
 			// Check if this block can be skipped.
 			ttlBlock := ttlRecover && mblseq >= ttlSeq
 			schedBlock := schedRecover && mblseq >= schedSeq
-			if (!ttlBlock || mb.ttls == 0) && (!schedBlock || mb.schedules == 0) {
+			sourcesBlock := sourcesRecover && mblseq >= sourcesSeq
+			if !sourcesBlock && (!ttlBlock || mb.ttls == 0) && (!schedBlock || mb.schedules == 0) {
 				// None of the messages in the block have state that needs recovering, so
 				// don't bother doing anything further with this block, skip to the end.
 				seq = mblseq + 1
@@ -2229,6 +2304,16 @@ func (fs *fileStore) recoverPerMessageState() error {
 					if schedule, apiErr := nextMessageSchedule(msg.hdr, msg.ts); apiErr == nil && !schedule.IsZero() {
 						// Copy the subject, as it's stored in the scheduling maps and the backing cache could be reused in the meantime.
 						fs.scheduling.init(seq, copyString(msg.subj), schedule.UnixNano())
+					}
+				}
+				if sourcesRecover && seq >= sourcesSeq {
+					if ss := sliceHeader(JSStreamSource, msg.hdr); len(ss) > 0 {
+						_, indexName, sseq := streamAndSeq(bytesToString(ss))
+						if indexName != _EMPTY_ {
+							if _, ok := sources[indexName]; ok {
+								fs.sources[indexName] = sseq
+							}
+						}
 					}
 				}
 			}
@@ -4633,6 +4718,26 @@ func (fs *fileStore) subjectsTotalsLocked(filter string) map[string]uint64 {
 	return fst
 }
 
+// SourcesState return sources keys and their last sequences.
+func (fs *fileStore) SourcesState() (dst map[string]uint64) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	if len(fs.sources) == 0 {
+		return nil
+	}
+	// Allocate lazily so that a map containing only seeded (zero) entries returns
+	// nil rather than an empty map; zeros must not leak out of SourcesState.
+	for k, seq := range fs.sources {
+		if seq > 0 {
+			if dst == nil {
+				dst = make(map[string]uint64, 1)
+			}
+			dst[k] = seq
+		}
+	}
+	return dst
+}
+
 // RegisterStorageUpdates registers a callback for updates to storage changes.
 // It will present number of messages and bytes as a signed integer and an
 // optional sequence number of the message if a single.
@@ -5016,6 +5121,16 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 			scheduler := getMessageScheduler(hdr)
 			if next, err := time.Parse(time.RFC3339Nano, scheduleNext); err == nil && scheduler != _EMPTY_ {
 				fs.scheduling.update(scheduler, next.UnixNano())
+			}
+		}
+	}
+
+	// Track sources.
+	if len(fs.cfg.Sources) > 0 {
+		if ss := sliceHeader(JSStreamSource, hdr); len(ss) > 0 {
+			_, indexName, sseq := streamAndSeq(bytesToString(ss))
+			if _, ok = fs.sources[indexName]; ok {
+				fs.sources[indexName] = sseq
 			}
 		}
 	}
@@ -9390,7 +9505,12 @@ func (fs *fileStore) LoadPrevMsgMulti(sl *gsl.SimpleSublist, start uint64, smp *
 	}
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()
+	return fs.loadPrevMsgMultiLocked(sl, start, smp)
+}
 
+// loadPrevMsgMultiLocked will find the previous message matching any entry in the sublist.
+// Lock should be held.
+func (fs *fileStore) loadPrevMsgMultiLocked(sl *gsl.SimpleSublist, start uint64, smp *StoreMsg) (sm *StoreMsg, skip uint64, err error) {
 	if fs.state.Msgs == 0 || start < fs.state.FirstSeq {
 		return nil, fs.state.FirstSeq, ErrStoreEOF
 	}
@@ -11873,13 +11993,16 @@ func (fs *fileStore) _writeFullState(force bool) error {
 	fs.dirty -= priorDirty
 	fs.mu.Unlock()
 
-	// Attempt to write both files, an error in one should not prevent the other from being written.
+	// Attempt to write other index files, an error in one should not prevent the other from being written.
 	ttlErr := fs.writeTTLState()
 	schedErr := fs.writeMsgSchedulingState()
+	sourcesErr := fs.writeSourcesState()
 	if ttlErr != nil {
 		return ttlErr
 	} else if schedErr != nil {
 		return schedErr
+	} else if sourcesErr != nil {
+		return sourcesErr
 	}
 	return nil
 }
@@ -11910,6 +12033,193 @@ func (fs *fileStore) writeMsgSchedulingState() error {
 	fs.mu.RUnlock()
 
 	return fs.writeFileWithOptionalSync(fn, buf, defaultFilePerms)
+}
+
+const sourcesHeaderLen = 17 // 1 byte magic + 2x uint64s
+
+func (fs *fileStore) sourcesStatePath() string {
+	return filepath.Join(fs.fcfg.StoreDir, sourcesStreamStateFile)
+}
+
+func (fs *fileStore) writeSourcesState() error {
+	fs.mu.RLock()
+	if fs.sources == nil {
+		fs.mu.RUnlock()
+		return nil
+	}
+	fn := fs.sourcesStatePath()
+
+	// Must be lseq+1 to identify up to which sequence the sources are valid.
+	highSeq := fs.state.LastSeq + 1
+
+	var count, sz uint64
+	for source, seq := range fs.sources {
+		if seq > 0 {
+			count++
+			// 4-byte length prefix + source bytes + seq varint.
+			sz += 4 + uint64(len(source)) + binary.MaxVarintLen64
+		}
+	}
+	// Nothing observed yet, don't persist an empty index. Any stale file is
+	// removed by recoverPerMessageState on recovery.
+	if count == 0 {
+		fs.mu.RUnlock()
+		return nil
+	}
+	buf := make([]byte, 0, sourcesHeaderLen+sz)
+	buf = append(buf, 1)                                 // Magic version
+	buf = binary.LittleEndian.AppendUint64(buf, count)   // Entry count
+	buf = binary.LittleEndian.AppendUint64(buf, highSeq) // Stamp
+	for source, seq := range fs.sources {
+		if seq == 0 {
+			continue
+		}
+		slen := min(uint64(len(source)), math.MaxUint32)
+		buf = binary.LittleEndian.AppendUint32(buf, uint32(slen))
+		buf = append(buf, source[:slen]...)
+		buf = binary.AppendUvarint(buf, seq)
+	}
+	fs.mu.RUnlock()
+
+	return fs.writeFileWithOptionalSync(fn, buf, defaultFilePerms)
+}
+
+// Lock should be held.
+func (fs *fileStore) recoverSourcesState() uint64 {
+	// See if we have a sources index file.
+	<-dios
+	fn := fs.sourcesStatePath()
+	buf, err := os.ReadFile(fn)
+	dios <- struct{}{}
+
+	if err != nil && !os.IsNotExist(err) {
+		fs.warn("Recovering sources state from index errored: %v", err)
+	}
+
+	var sourcesSeq uint64
+	if err == nil {
+		sourcesSeq, err = fs.decodeSourcesState(buf)
+		if err != nil {
+			fs.warn("Error decoding sources state: %s", err)
+			// Remove the file, and reset collected state (if any).
+			_ = os.Remove(fn)
+			fs.sources = nil
+		}
+	}
+
+	if sourcesSeq < fs.state.FirstSeq {
+		sourcesSeq = fs.state.FirstSeq
+	}
+	return sourcesSeq
+}
+
+var errSourcesInvalidVersion = errors.New("sources: encoded version not known")
+
+func (fs *fileStore) decodeSourcesState(b []byte) (uint64, error) {
+	if len(b) < sourcesHeaderLen {
+		return 0, io.ErrShortBuffer
+	}
+	if b[0] != 1 {
+		return 0, errSourcesInvalidVersion
+	}
+
+	count := binary.LittleEndian.Uint64(b[1:])
+	stamp := binary.LittleEndian.Uint64(b[9:])
+	if count > 0 && fs.sources == nil {
+		fs.sources = make(map[string]uint64)
+	}
+	b = b[sourcesHeaderLen:]
+	for i := uint64(0); i < count; i++ {
+		if len(b) < 4 {
+			return 0, io.ErrUnexpectedEOF
+		}
+		sl := int(binary.LittleEndian.Uint32(b))
+		b = b[4:]
+		if len(b) < sl {
+			return 0, io.ErrUnexpectedEOF
+		}
+		source := string(b[:sl])
+		b = b[sl:]
+		seq, vn := binary.Uvarint(b)
+		if vn <= 0 {
+			return 0, io.ErrUnexpectedEOF
+		}
+		fs.sources[source] = seq
+		b = b[vn:]
+	}
+	return stamp, nil
+}
+
+// recoverSourcesBackwardScan recovers fs.sources by scanning the stream backwards,
+// mirroring stream.startingSequenceForSources, down to and including the stopSeq.
+// Lock should be held.
+func (fs *fileStore) recoverSourcesBackwardScan(stopSeq uint64, sources map[string]*StreamSource) {
+	var sl *gsl.SimpleSublist
+	refreshSublist := func() {
+		sl = gsl.NewSimpleSublist()
+		for _, src := range sources {
+			if src.FilterSubject == _EMPTY_ {
+				sl.Insert(fwcs, struct{}{})
+			} else {
+				sl.Insert(src.FilterSubject, struct{}{})
+			}
+			for _, tr := range src.SubjectTransforms {
+				if tr.Destination == _EMPTY_ {
+					sl.Insert(fwcs, struct{}{})
+				} else {
+					sl.Insert(tr.Destination, struct{}{})
+				}
+			}
+		}
+	}
+	refreshSublist()
+
+	update := func(iName string, sseq uint64) {
+		// Only consider sources that are configured and not yet found. The backward
+		// scan visits the highest matching sequence first, so the first hit per source
+		// is the latest and overwrites any older decoded value.
+		if _, ok := sources[iName]; !ok {
+			return
+		}
+		if fs.sources == nil {
+			fs.sources = make(map[string]uint64, 1)
+		}
+		fs.sources[iName] = sseq
+		delete(sources, iName)
+		refreshSublist()
+	}
+
+	var smv StoreMsg
+	for last := fs.state.LastSeq; ; {
+		sm, seq, err := fs.loadPrevMsgMultiLocked(sl, last, &smv)
+		if err != nil {
+			break
+		}
+		// Stop if we've gone below the point where decoded state is still valid.
+		if seq < stopSeq {
+			break
+		}
+		if len(sm.hdr) > 0 {
+			if ss := sliceHeader(JSStreamSource, sm.hdr); len(ss) > 0 {
+				streamName, iName, sseq := streamAndSeq(bytesToString(ss))
+				if iName == _EMPTY_ {
+					// Pre-2.10 message header means it's a match for any source using that stream name.
+					for _, ssi := range fs.cfg.Sources {
+						if streamName == ssi.Name || (ssi.External != nil && streamName == ssi.Name+":"+getHash(ssi.External.ApiPrefix)) {
+							update(ssi.composeIName(), sseq)
+						}
+					}
+				} else {
+					update(iName, sseq)
+				}
+			}
+		}
+		// Done once every source has been resolved, or we've reached the floor.
+		if len(sources) == 0 || seq <= stopSeq {
+			break
+		}
+		last = seq - 1
+	}
 }
 
 // Stop the current filestore.

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -451,15 +451,6 @@ func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created tim
 		}
 	}()
 
-	// Only create a THW if we're going to allow TTLs.
-	if cfg.AllowMsgTTL {
-		fs.ttls = thw.NewHashWheel()
-	}
-	// Only create scheduling data structure if we're going to allow message schedules.
-	if cfg.AllowMsgSchedules {
-		fs.scheduling = newMsgScheduling(fs.runMsgScheduling)
-	}
-
 	// Set flush in place to AsyncFlush which by default is false.
 	fs.fip = !fcfg.AsyncFlush
 
@@ -549,18 +540,10 @@ func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created tim
 		}
 	}()
 
-	// See if we can bring back our TTL timed hash wheel state from disk.
-	if cfg.AllowMsgTTL {
-		if err = fs.recoverTTLState(); err != nil && !os.IsNotExist(err) {
-			fs.warn("Recovering TTL state from index errored: %v", err)
-		}
-	}
-
-	// See if we can bring back our message scheduling state from disk.
-	if cfg.AllowMsgSchedules {
-		if err = fs.recoverMsgSchedulingState(); err != nil && !os.IsNotExist(err) {
-			fs.warn("Recovering message scheduling state from index errored: %v", err)
-		}
+	// Recover per-message state like TTLs and schedules.
+	if err = fs.recoverPerMessageState(); err != nil {
+		fs.mu.Unlock()
+		return nil, err
 	}
 
 	// Also make sure we get rid of old idx and fss files on return.
@@ -704,25 +687,11 @@ func (fs *fileStore) UpdateConfig(cfg *StreamConfig) error {
 		return err
 	}
 
-	// Create or delete the THW if needed.
-	if cfg.AllowMsgTTL && fs.ttls == nil {
-		if err := fs.recoverTTLState(); err != nil {
-			fs.mu.Unlock()
-			return err
-		}
-	} else if !cfg.AllowMsgTTL && fs.ttls != nil {
-		fs.ttls = nil
+	// Recover per-message state like TTLs and schedules.
+	if err := fs.recoverPerMessageState(); err != nil {
+		fs.mu.Unlock()
+		return err
 	}
-	// Create or delete the message scheduling state if needed.
-	if cfg.AllowMsgSchedules && fs.scheduling == nil {
-		if err := fs.recoverMsgSchedulingState(); err != nil {
-			fs.mu.Unlock()
-			return err
-		}
-	} else if !cfg.AllowMsgSchedules && fs.scheduling != nil {
-		fs.scheduling = nil
-	}
-
 	// Limits checks and enforcement.
 	if err := fs.enforceMsgLimit(); err != nil {
 		fs.mu.Unlock()
@@ -2158,8 +2127,120 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 	return nil
 }
 
+// Recover per-message state like TTLs and schedules. Doing a linear scan through the stream
+// only once if both states need to be recovered from the same sequences.
 // Lock should be held.
-func (fs *fileStore) recoverTTLState() error {
+func (fs *fileStore) recoverPerMessageState() error {
+	scanSeq := uint64(math.MaxUint64)
+	var ttlSeq, schedSeq uint64
+	var ttlRecover, schedRecover bool
+	allowMsgTTL, allowMsgSchedules := fs.cfg.AllowMsgTTL, fs.cfg.AllowMsgSchedules
+
+	// Create or delete the THW if needed.
+	if allowMsgTTL && fs.ttls == nil {
+		ttlSeq = fs.recoverTTLState()
+		ttlRecover = true
+		scanSeq = min(scanSeq, ttlSeq)
+	} else if !allowMsgTTL && fs.ttls != nil {
+		fs.ttls = nil
+	}
+
+	// Create or delete the message scheduling state if needed.
+	if allowMsgSchedules && fs.scheduling == nil {
+		schedSeq = fs.recoverMsgSchedulingState()
+		schedRecover = true
+		scanSeq = min(scanSeq, schedSeq)
+	} else if !allowMsgSchedules && fs.scheduling != nil {
+		fs.scheduling = nil
+	}
+
+	// Short-circuit if no recovering is required.
+	if !ttlRecover && !schedRecover {
+		return nil
+	}
+
+	if allowMsgTTL {
+		defer fs.resetAgeChk(0)
+	}
+	if allowMsgSchedules {
+		defer fs.scheduling.resetTimer()
+	}
+
+	if fs.state.Msgs > 0 && scanSeq <= fs.state.LastSeq {
+		if ttlRecover && ttlSeq <= fs.state.LastSeq {
+			fs.warn("TTL state is outdated; attempting to recover using linear scan (seq %d to %d)", ttlSeq, fs.state.LastSeq)
+		}
+		if schedRecover && schedSeq <= fs.state.LastSeq {
+			fs.warn("Message scheduling state is outdated; attempting to recover using linear scan (seq %d to %d)", schedSeq, fs.state.LastSeq)
+		}
+		var (
+			mb     *msgBlock
+			sm     StoreMsg
+			mblseq uint64
+		)
+		for seq := scanSeq; seq <= fs.state.LastSeq; seq++ {
+		retry:
+			if mb == nil {
+				if mb = fs.selectMsgBlock(seq); mb == nil {
+					// Selecting the message block should return a block that contains this sequence,
+					// or a later block if it can't be found.
+					// It's an error if we can't find any block within the bounds of first and last seq.
+					fs.warn("Error loading msg block with seq %d for recovering per-message state", seq)
+					continue
+				}
+				seq = atomic.LoadUint64(&mb.first.seq)
+				mblseq = atomic.LoadUint64(&mb.last.seq)
+			}
+			// Check if this block can be skipped.
+			ttlBlock := ttlRecover && mblseq >= ttlSeq
+			schedBlock := schedRecover && mblseq >= schedSeq
+			if (!ttlBlock || mb.ttls == 0) && (!schedBlock || mb.schedules == 0) {
+				// None of the messages in the block have state that needs recovering, so
+				// don't bother doing anything further with this block, skip to the end.
+				seq = mblseq + 1
+			}
+			if seq > mblseq {
+				// We've reached the end of the loaded block, so let's go back to the
+				// beginning and process the next block.
+				mb.tryForceExpireCache()
+				mb = nil
+				if seq <= fs.state.LastSeq {
+					goto retry
+				}
+				// Done.
+				break
+			}
+			mb.mu.Lock()
+			msg, _, err := mb.fetchMsgNoCopyLocked(seq, &sm)
+			if err != nil {
+				mb.finishedWithCache()
+				mb.mu.Unlock()
+				fs.warn("Error loading msg seq %d for recovering per-message state: %s", seq, err)
+				continue
+			}
+			if len(msg.hdr) > 0 {
+				if ttlRecover && seq >= ttlSeq {
+					if ttl, _ := getMessageTTL(msg.hdr); ttl > 0 {
+						expires := time.Duration(msg.ts) + (time.Second * time.Duration(ttl))
+						fs.ttls.Add(seq, int64(expires))
+					}
+				}
+				if schedRecover && seq >= schedSeq {
+					if schedule, apiErr := nextMessageSchedule(msg.hdr, msg.ts); apiErr == nil && !schedule.IsZero() {
+						// Copy the subject, as it's stored in the scheduling maps and the backing cache could be reused in the meantime.
+						fs.scheduling.init(seq, copyString(msg.subj), schedule.UnixNano())
+					}
+				}
+			}
+			mb.finishedWithCache()
+			mb.mu.Unlock()
+		}
+	}
+	return nil
+}
+
+// Lock should be held.
+func (fs *fileStore) recoverTTLState() uint64 {
 	// See if we have a timed hash wheel for TTLs.
 	<-dios
 	fn := filepath.Join(fs.fcfg.StoreDir, msgDir, ttlStreamStateFile)
@@ -2167,7 +2248,7 @@ func (fs *fileStore) recoverTTLState() error {
 	dios <- struct{}{}
 
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		fs.warn("Recovering TTL state from index errored: %v", err)
 	}
 
 	fs.ttls = thw.NewHashWheel()
@@ -2186,75 +2267,19 @@ func (fs *fileStore) recoverTTLState() error {
 	if ttlseq < fs.state.FirstSeq {
 		ttlseq = fs.state.FirstSeq
 	}
-
-	defer fs.resetAgeChk(0)
-	if fs.state.Msgs > 0 && ttlseq <= fs.state.LastSeq {
-		fs.warn("TTL state is outdated; attempting to recover using linear scan (seq %d to %d)", ttlseq, fs.state.LastSeq)
-		var (
-			mb     *msgBlock
-			sm     StoreMsg
-			mblseq uint64
-		)
-		for seq := ttlseq; seq <= fs.state.LastSeq; seq++ {
-		retry:
-			if mb == nil {
-				if mb = fs.selectMsgBlock(seq); mb == nil {
-					// Selecting the message block should return a block that contains this sequence,
-					// or a later block if it can't be found.
-					// It's an error if we can't find any block within the bounds of first and last seq.
-					fs.warn("Error loading msg block with seq %d for recovering TTL", seq)
-					continue
-				}
-				seq = atomic.LoadUint64(&mb.first.seq)
-				mblseq = atomic.LoadUint64(&mb.last.seq)
-			}
-			if mb.ttls == 0 {
-				// None of the messages in the block have message TTLs so don't
-				// bother doing anything further with this block, skip to the end.
-				seq = atomic.LoadUint64(&mb.last.seq) + 1
-			}
-			if seq > mblseq {
-				// We've reached the end of the loaded block, so let's go back to the
-				// beginning and process the next block.
-				mb.tryForceExpireCache()
-				mb = nil
-				if seq <= fs.state.LastSeq {
-					goto retry
-				}
-				// Done.
-				break
-			}
-			mb.mu.Lock()
-			msg, _, err := mb.fetchMsgNoCopyLocked(seq, &sm)
-			if err != nil {
-				mb.finishedWithCache()
-				mb.mu.Unlock()
-				fs.warn("Error loading msg seq %d for recovering TTL: %s", seq, err)
-				continue
-			}
-			if len(msg.hdr) > 0 {
-				if ttl, _ := getMessageTTL(msg.hdr); ttl > 0 {
-					expires := time.Duration(msg.ts) + (time.Second * time.Duration(ttl))
-					fs.ttls.Add(seq, int64(expires))
-				}
-			}
-			mb.finishedWithCache()
-			mb.mu.Unlock()
-		}
-	}
-	return nil
+	return ttlseq
 }
 
 // Lock should be held.
-func (fs *fileStore) recoverMsgSchedulingState() error {
-	// See if we have a timed hash wheel for TTLs.
+func (fs *fileStore) recoverMsgSchedulingState() uint64 {
+	// See if we have a schedule index file.
 	<-dios
 	fn := filepath.Join(fs.fcfg.StoreDir, msgDir, msgSchedulingStreamStateFile)
 	buf, err := os.ReadFile(fn)
 	dios <- struct{}{}
 
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		fs.warn("Recovering message scheduling state from index errored: %v", err)
 	}
 
 	fs.scheduling = newMsgScheduling(fs.runMsgScheduling)
@@ -2273,63 +2298,7 @@ func (fs *fileStore) recoverMsgSchedulingState() error {
 	if schedSeq < fs.state.FirstSeq {
 		schedSeq = fs.state.FirstSeq
 	}
-
-	defer fs.scheduling.resetTimer()
-	if fs.state.Msgs > 0 && schedSeq <= fs.state.LastSeq {
-		fs.warn("Message scheduling state is outdated; attempting to recover using linear scan (seq %d to %d)", schedSeq, fs.state.LastSeq)
-		var (
-			mb     *msgBlock
-			sm     StoreMsg
-			mblseq uint64
-		)
-		for seq := schedSeq; seq <= fs.state.LastSeq; seq++ {
-		retry:
-			if mb == nil {
-				if mb = fs.selectMsgBlock(seq); mb == nil {
-					// Selecting the message block should return a block that contains this sequence,
-					// or a later block if it can't be found.
-					// It's an error if we can't find any block within the bounds of first and last seq.
-					fs.warn("Error loading msg block with seq %d for recovering message schedules", seq)
-					continue
-				}
-				seq = atomic.LoadUint64(&mb.first.seq)
-				mblseq = atomic.LoadUint64(&mb.last.seq)
-			}
-			if mb.schedules == 0 {
-				// None of the messages in the block have message schedules, so don't
-				// bother doing anything further with this block, skip to the end.
-				seq = atomic.LoadUint64(&mb.last.seq) + 1
-			}
-			if seq > mblseq {
-				// We've reached the end of the loaded block, so let's go back to the
-				// beginning and process the next block.
-				mb.tryForceExpireCache()
-				mb = nil
-				if seq <= fs.state.LastSeq {
-					goto retry
-				}
-				// Done.
-				break
-			}
-			mb.mu.Lock()
-			msg, _, err := mb.fetchMsgNoCopyLocked(seq, &sm)
-			if err != nil {
-				mb.finishedWithCache()
-				mb.mu.Unlock()
-				fs.warn("Error loading msg seq %d for recovering message schedules: %s", seq, err)
-				continue
-			}
-			if len(msg.hdr) > 0 {
-				if schedule, apiErr := nextMessageSchedule(msg.hdr, msg.ts); apiErr == nil && !schedule.IsZero() {
-					// Copy the subject, as it's stored in the scheduling maps and the backing cache could be reused in the meantime.
-					fs.scheduling.init(seq, copyString(msg.subj), schedule.UnixNano())
-				}
-			}
-			mb.finishedWithCache()
-			mb.mu.Unlock()
-		}
-	}
-	return nil
+	return schedSeq
 }
 
 // Grabs last checksum for the named block file.

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4928,6 +4928,31 @@ func (fs *fileStore) subjectsTotalsLocked(filter string) map[string]uint64 {
 	return fst
 }
 
+// ApplySourcesState replaces the tracked sourcing state with the leader's.
+func (fs *fileStore) ApplySourcesState(sources map[string]StreamSourceState) {
+	if len(sources) == 0 {
+		return
+	}
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	// Nil means no sources are configured, so there is nothing to track.
+	if fs.sources == nil {
+		return
+	}
+	clear(fs.sources)
+	for name, ss := range sources {
+		fs.sources[name] = &StreamSourceState{Seq: ss.Seq, Ident: ss.Ident}
+	}
+	// Keep every configured source present, seeded as not yet observed, which is
+	// the invariant recoverPerMessageState and storeRawMsg expect.
+	for _, ssi := range fs.cfg.Sources {
+		if iname := ssi.composeIName(); fs.sources[iname] == nil {
+			fs.sources[iname] = &StreamSourceState{}
+		}
+	}
+	fs.dirty++
+}
+
 // SourcesState return sources keys and their last known state.
 func (fs *fileStore) SourcesState() (dst map[string]StreamSourceState) {
 	fs.mu.RLock()
@@ -12889,9 +12914,12 @@ func (fs *fileStore) readUnlockAllMsgBlocks() {
 }
 
 // Binary encoded state snapshot, >= v2.10 server.
-func (fs *fileStore) EncodedStreamState(failed uint64) ([]byte, error) {
+func (fs *fileStore) EncodedStreamState(failed uint64, withSources bool) ([]byte, error) {
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()
+
+	withSources = withSources && len(fs.sources) > 0
+	version := streamStateVersion
 
 	// Calculate deleted.
 	var numDeleted int64
@@ -12908,6 +12936,26 @@ func (fs *fileStore) EncodedStreamState(failed uint64) ([]byte, error) {
 		uvarintLen(fs.state.FirstSeq) + uvarintLen(fs.state.LastSeq) +
 		uvarintLen(failed) + uvarintLen(uint64(numDeleted))
 
+	var numSources uint64
+	var sourcesLen int
+	if withSources {
+		for name, ss := range fs.sources {
+			if ss.Seq == 0 {
+				continue
+			}
+			numSources++
+			// Length prefix + source bytes + seq varint +
+			// length prefix + identity bytes.
+			sourcesLen += uvarintLen(uint64(len(name))) + len(name) + uvarintLen(ss.Seq) +
+				uvarintLen(uint64(len(ss.Ident))) + len(ss.Ident)
+		}
+		// Nothing observed yet, then there is nothing to carry.
+		if withSources = numSources > 0; withSources {
+			total += uvarintLen(numSources) + sourcesLen
+			version = streamStateVersionSources
+		}
+	}
+
 	var dbs DeleteBlocks
 	if numDeleted > 0 {
 		fs.readLockAllMsgBlocks()
@@ -12918,12 +12966,25 @@ func (fs *fileStore) EncodedStreamState(failed uint64) ([]byte, error) {
 	}
 
 	b := make([]byte, 0, total)
-	b = append(b, streamStateMagic, streamStateVersion)
+	b = append(b, streamStateMagic, version)
 	b = binary.AppendUvarint(b, fs.state.Msgs)
 	b = binary.AppendUvarint(b, fs.state.Bytes)
 	b = binary.AppendUvarint(b, fs.state.FirstSeq)
 	b = binary.AppendUvarint(b, fs.state.LastSeq)
 	b = binary.AppendUvarint(b, failed)
+	if withSources {
+		b = binary.AppendUvarint(b, numSources)
+		for name, ss := range fs.sources {
+			if ss.Seq == 0 {
+				continue
+			}
+			b = binary.AppendUvarint(b, uint64(len(name)))
+			b = append(b, name...)
+			b = binary.AppendUvarint(b, ss.Seq)
+			b = binary.AppendUvarint(b, uint64(len(ss.Ident)))
+			b = append(b, ss.Ident...)
+		}
+	}
 	b = binary.AppendUvarint(b, uint64(numDeleted))
 
 	for _, db := range dbs {

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -468,16 +468,6 @@ func newFileStoreWithCreatedAndMode(fcfg FileStoreConfig, cfg StreamConfig, crea
 		}
 	}()
 
-	// Only create a THW if we're going to allow TTLs.
-	if cfg.AllowMsgTTL {
-		fs.ttls = thw.NewHashWheel()
-	}
-	// Only create scheduling data structure if we're going to allow message schedules.
-	if cfg.AllowMsgSchedules {
-		fs.scheduling = newMsgScheduling(fs.runMsgScheduling)
-		fs.scheduling.paused = recovering
-	}
-
 	// Set flush in place to AsyncFlush which by default is false.
 	fs.fip = !fcfg.AsyncFlush
 
@@ -567,18 +557,10 @@ func newFileStoreWithCreatedAndMode(fcfg FileStoreConfig, cfg StreamConfig, crea
 		}
 	}()
 
-	// See if we can bring back our TTL timed hash wheel state from disk.
-	if cfg.AllowMsgTTL {
-		if err = fs.recoverTTLState(); err != nil && !os.IsNotExist(err) {
-			fs.warn("Recovering TTL state from index errored: %v", err)
-		}
-	}
-
-	// See if we can bring back our message scheduling state from disk.
-	if cfg.AllowMsgSchedules {
-		if err = fs.recoverMsgSchedulingState(); err != nil && !os.IsNotExist(err) {
-			fs.warn("Recovering message scheduling state from index errored: %v", err)
-		}
+	// Recover per-message state like TTLs and schedules.
+	if err = fs.recoverPerMessageState(); err != nil {
+		fs.mu.Unlock()
+		return nil, err
 	}
 
 	// Also make sure we get rid of old idx and fss files on return.
@@ -728,25 +710,11 @@ func (fs *fileStore) UpdateConfig(cfg *StreamConfig) error {
 		return err
 	}
 
-	// Create or delete the THW if needed.
-	if cfg.AllowMsgTTL && fs.ttls == nil {
-		if err := fs.recoverTTLState(); err != nil {
-			fs.mu.Unlock()
-			return err
-		}
-	} else if !cfg.AllowMsgTTL && fs.ttls != nil {
-		fs.ttls = nil
+	// Recover per-message state like TTLs and schedules.
+	if err := fs.recoverPerMessageState(); err != nil {
+		fs.mu.Unlock()
+		return err
 	}
-	// Create or delete the message scheduling state if needed.
-	if cfg.AllowMsgSchedules && fs.scheduling == nil {
-		if err := fs.recoverMsgSchedulingState(); err != nil {
-			fs.mu.Unlock()
-			return err
-		}
-	} else if !cfg.AllowMsgSchedules && fs.scheduling != nil {
-		fs.scheduling = nil
-	}
-
 	// Limits checks and enforcement.
 	if err := fs.enforceMsgLimit(); err != nil {
 		fs.mu.Unlock()
@@ -2222,8 +2190,123 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 	return nil
 }
 
+// Recover per-message state like TTLs and schedules. Doing a linear scan through the stream
+// only once if both states need to be recovered from the same sequences.
 // Lock should be held.
-func (fs *fileStore) recoverTTLState() error {
+func (fs *fileStore) recoverPerMessageState() error {
+	scanSeq := uint64(math.MaxUint64)
+	var ttlSeq, schedSeq uint64
+	var ttlRecover, schedRecover bool
+	allowMsgTTL, allowMsgSchedules := fs.cfg.AllowMsgTTL, fs.cfg.AllowMsgSchedules
+
+	// Create or delete the THW if needed.
+	if allowMsgTTL && fs.ttls == nil {
+		ttlSeq = fs.recoverTTLState()
+		ttlRecover = true
+		scanSeq = min(scanSeq, ttlSeq)
+	} else if !allowMsgTTL && fs.ttls != nil {
+		fs.ttls = nil
+	}
+
+	// Create or delete the message scheduling state if needed.
+	if allowMsgSchedules && fs.scheduling == nil {
+		schedSeq = fs.recoverMsgSchedulingState()
+		schedRecover = true
+		scanSeq = min(scanSeq, schedSeq)
+	} else if !allowMsgSchedules && fs.scheduling != nil {
+		fs.scheduling = nil
+	}
+
+	// Short-circuit if no recovering is required.
+	if !ttlRecover && !schedRecover {
+		return nil
+	}
+
+	if allowMsgTTL {
+		defer fs.resetAgeChk(0)
+	}
+	if allowMsgSchedules {
+		defer fs.scheduling.resetTimer()
+	}
+
+	if fs.state.Msgs > 0 && scanSeq <= fs.state.LastSeq {
+		if ttlRecover && ttlSeq <= fs.state.LastSeq {
+			fs.warn("TTL state is outdated; attempting to recover using linear scan (seq %d to %d)", ttlSeq, fs.state.LastSeq)
+		}
+		if schedRecover && schedSeq <= fs.state.LastSeq {
+			fs.warn("Message scheduling state is outdated; attempting to recover using linear scan (seq %d to %d)", schedSeq, fs.state.LastSeq)
+		}
+		var (
+			mb     *msgBlock
+			sm     StoreMsg
+			mblseq uint64
+		)
+		for seq := scanSeq; seq <= fs.state.LastSeq; seq++ {
+		retry:
+			if mb == nil {
+				if mb = fs.selectMsgBlock(seq); mb == nil {
+					// Selecting the message block should return a block that contains this sequence,
+					// or a later block if it can't be found.
+					// It's an error if we can't find any block within the bounds of first and last seq.
+					fs.warn("Error loading msg block with seq %d for recovering per-message state", seq)
+					continue
+				}
+				seq = atomic.LoadUint64(&mb.first.seq)
+				mblseq = atomic.LoadUint64(&mb.last.seq)
+			}
+			// Check if this block can be skipped.
+			ttlBlock := ttlRecover && mblseq >= ttlSeq
+			schedBlock := schedRecover && mblseq >= schedSeq
+			if (!ttlBlock || mb.ttls == 0) && (!schedBlock || mb.schedules == 0) {
+				// None of the messages in the block have state that needs recovering, so
+				// don't bother doing anything further with this block, skip to the end.
+				seq = mblseq + 1
+			}
+			if seq > mblseq {
+				// We've reached the end of the loaded block, so let's go back to the
+				// beginning and process the next block.
+				mb.tryForceExpireCache()
+				mb = nil
+				if seq <= fs.state.LastSeq {
+					goto retry
+				}
+				// Done.
+				break
+			}
+			mb.mu.Lock()
+			msg, _, err := mb.fetchMsgNoCopyLocked(seq, &sm)
+			if err != nil {
+				mb.finishedWithCache()
+				mb.mu.Unlock()
+				if err == ErrStoreMsgNotFound || err == errDeletedMsg {
+					continue
+				}
+				fs.warn("Error loading msg seq %d for recovering per-message state: %s", seq, err)
+				return err
+			}
+			if len(msg.hdr) > 0 {
+				if ttlRecover && seq >= ttlSeq {
+					if ttl, _ := getMessageTTL(msg.hdr); ttl > 0 {
+						expires := time.Duration(msg.ts) + (time.Second * time.Duration(ttl))
+						fs.ttls.Add(seq, int64(expires))
+					}
+				}
+				if schedRecover && seq >= schedSeq {
+					if schedule, apiErr := nextMessageSchedule(msg.hdr, msg.ts); apiErr == nil && !schedule.IsZero() {
+						// Copy the subject, as it's stored in the scheduling maps and the backing cache could be reused in the meantime.
+						fs.scheduling.init(seq, copyString(msg.subj), schedule.UnixNano())
+					}
+				}
+			}
+			mb.finishedWithCache()
+			mb.mu.Unlock()
+		}
+	}
+	return nil
+}
+
+// Lock should be held.
+func (fs *fileStore) recoverTTLState() uint64 {
 	// See if we have a timed hash wheel for TTLs.
 	fs.dios.acquire()
 	fn := filepath.Join(fs.fcfg.StoreDir, msgDir, ttlStreamStateFile)
@@ -2231,7 +2314,7 @@ func (fs *fileStore) recoverTTLState() error {
 	fs.dios.release()
 
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		fs.warn("Recovering TTL state from index errored: %v", err)
 	}
 
 	fs.ttls = thw.NewHashWheel()
@@ -2250,75 +2333,19 @@ func (fs *fileStore) recoverTTLState() error {
 	if ttlseq < fs.state.FirstSeq {
 		ttlseq = fs.state.FirstSeq
 	}
-
-	defer fs.resetAgeChk(0)
-	if fs.state.Msgs > 0 && ttlseq <= fs.state.LastSeq {
-		fs.warn("TTL state is outdated; attempting to recover using linear scan (seq %d to %d)", ttlseq, fs.state.LastSeq)
-		var (
-			mb     *msgBlock
-			sm     StoreMsg
-			mblseq uint64
-		)
-		for seq := ttlseq; seq <= fs.state.LastSeq; seq++ {
-		retry:
-			if mb == nil {
-				if mb = fs.selectMsgBlock(seq); mb == nil {
-					// Selecting the message block should return a block that contains this sequence,
-					// or a later block if it can't be found.
-					// It's an error if we can't find any block within the bounds of first and last seq.
-					fs.warn("Error loading msg block with seq %d for recovering TTL", seq)
-					continue
-				}
-				seq = atomic.LoadUint64(&mb.first.seq)
-				mblseq = atomic.LoadUint64(&mb.last.seq)
-			}
-			if mb.ttls == 0 {
-				// None of the messages in the block have message TTLs so don't
-				// bother doing anything further with this block, skip to the end.
-				seq = atomic.LoadUint64(&mb.last.seq) + 1
-			}
-			if seq > mblseq {
-				// We've reached the end of the loaded block, so let's go back to the
-				// beginning and process the next block.
-				mb.tryForceExpireCache()
-				mb = nil
-				if seq <= fs.state.LastSeq {
-					goto retry
-				}
-				// Done.
-				break
-			}
-			mb.mu.Lock()
-			msg, _, err := mb.fetchMsgNoCopyLocked(seq, &sm)
-			if err != nil {
-				mb.finishedWithCache()
-				mb.mu.Unlock()
-				fs.warn("Error loading msg seq %d for recovering TTL: %s", seq, err)
-				continue
-			}
-			if len(msg.hdr) > 0 {
-				if ttl, _ := getMessageTTL(msg.hdr); ttl > 0 {
-					expires := time.Duration(msg.ts) + (time.Second * time.Duration(ttl))
-					fs.ttls.Add(seq, int64(expires))
-				}
-			}
-			mb.finishedWithCache()
-			mb.mu.Unlock()
-		}
-	}
-	return nil
+	return ttlseq
 }
 
 // Lock should be held.
-func (fs *fileStore) recoverMsgSchedulingState() error {
-	// See if we have a timed hash wheel for TTLs.
+func (fs *fileStore) recoverMsgSchedulingState() uint64 {
+	// See if we have a schedule index file.
 	fs.dios.acquire()
 	fn := filepath.Join(fs.fcfg.StoreDir, msgDir, msgSchedulingStreamStateFile)
 	buf, err := os.ReadFile(fn)
 	fs.dios.release()
 
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		fs.warn("Recovering message scheduling state from index errored: %v", err)
 	}
 
 	fs.scheduling = newMsgScheduling(fs.runMsgScheduling)
@@ -2339,63 +2366,7 @@ func (fs *fileStore) recoverMsgSchedulingState() error {
 	if schedSeq < fs.state.FirstSeq {
 		schedSeq = fs.state.FirstSeq
 	}
-
-	defer fs.scheduling.resetTimer()
-	if fs.state.Msgs > 0 && schedSeq <= fs.state.LastSeq {
-		fs.warn("Message scheduling state is outdated; attempting to recover using linear scan (seq %d to %d)", schedSeq, fs.state.LastSeq)
-		var (
-			mb     *msgBlock
-			sm     StoreMsg
-			mblseq uint64
-		)
-		for seq := schedSeq; seq <= fs.state.LastSeq; seq++ {
-		retry:
-			if mb == nil {
-				if mb = fs.selectMsgBlock(seq); mb == nil {
-					// Selecting the message block should return a block that contains this sequence,
-					// or a later block if it can't be found.
-					// It's an error if we can't find any block within the bounds of first and last seq.
-					fs.warn("Error loading msg block with seq %d for recovering message schedules", seq)
-					continue
-				}
-				seq = atomic.LoadUint64(&mb.first.seq)
-				mblseq = atomic.LoadUint64(&mb.last.seq)
-			}
-			if mb.schedules == 0 {
-				// None of the messages in the block have message schedules, so don't
-				// bother doing anything further with this block, skip to the end.
-				seq = atomic.LoadUint64(&mb.last.seq) + 1
-			}
-			if seq > mblseq {
-				// We've reached the end of the loaded block, so let's go back to the
-				// beginning and process the next block.
-				mb.tryForceExpireCache()
-				mb = nil
-				if seq <= fs.state.LastSeq {
-					goto retry
-				}
-				// Done.
-				break
-			}
-			mb.mu.Lock()
-			msg, _, err := mb.fetchMsgNoCopyLocked(seq, &sm)
-			if err != nil {
-				mb.finishedWithCache()
-				mb.mu.Unlock()
-				fs.warn("Error loading msg seq %d for recovering message schedules: %s", seq, err)
-				continue
-			}
-			if len(msg.hdr) > 0 {
-				if schedule, apiErr := nextMessageSchedule(msg.hdr, msg.ts); apiErr == nil && !schedule.IsZero() {
-					// Copy the subject, as it's stored in the scheduling maps and the backing cache could be reused in the meantime.
-					fs.scheduling.init(seq, copyString(msg.subj), schedule.UnixNano())
-				}
-			}
-			mb.finishedWithCache()
-			mb.mu.Unlock()
-		}
-	}
-	return nil
+	return schedSeq
 }
 
 // Grabs last checksum for the named block file.

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -219,6 +219,7 @@ type fileStore struct {
 	sdm         *SDMMeta
 	lpex        time.Time // Last PurgeEx call.
 	dios        *diskIOSemaphore
+	sources     map[string]*StreamSourceState
 }
 
 // Represents a message store block and its data.
@@ -355,6 +356,11 @@ const (
 
 	// This is the encoded message scheduling file.
 	msgSchedulingStreamStateFile = "sched.db"
+
+	// This is the encoded sources state file. Unlike the other state files it
+	// lives at the FileStoreConfig.StoreDir root rather than under msgDir, so
+	// a full purge does not also purge this file.
+	sourcesStreamStateFile = "sources.db"
 
 	// AEK key sizes
 	minMetaKeySize = 64
@@ -2195,9 +2201,17 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 // Lock should be held.
 func (fs *fileStore) recoverPerMessageState() error {
 	scanSeq := uint64(math.MaxUint64)
-	var ttlSeq, schedSeq uint64
-	var ttlRecover, schedRecover bool
+	var ttlSeq, schedSeq, sourcesSeq uint64
+	var ttlRecover, schedRecover, sourcesRecover bool
 	allowMsgTTL, allowMsgSchedules := fs.cfg.AllowMsgTTL, fs.cfg.AllowMsgSchedules
+
+	var sources map[string]*StreamSource
+	if len(fs.cfg.Sources) > 0 {
+		sources = make(map[string]*StreamSource, len(fs.cfg.Sources))
+		for _, ssi := range fs.cfg.Sources {
+			sources[ssi.composeIName()] = ssi
+		}
+	}
 
 	// Create or delete the THW if needed.
 	if allowMsgTTL && fs.ttls == nil {
@@ -2217,8 +2231,56 @@ func (fs *fileStore) recoverPerMessageState() error {
 		fs.scheduling = nil
 	}
 
+	// Create or delete the source tracking if needed.
+	if sources != nil && fs.sources == nil {
+		sourcesSeq = fs.recoverSourcesState()
+		// Only allow scanning if the index recovered something. If there is no index
+		// yet, then we'll just not do the scan and let the upper layer do so when needed.
+		if fs.sources != nil {
+			sourcesRecover = true
+			scanSeq = min(scanSeq, sourcesSeq)
+		}
+	}
+	if len(sources) > 0 {
+		// Ensure the map exists even on a fresh stream that has no persisted
+		// index yet, so storeRawMsg can validate headers against the configured
+		// set (zero sequence == configured but not yet observed).
+		if fs.sources == nil {
+			fs.sources = make(map[string]*StreamSourceState, len(sources))
+		}
+		// Remove sources that are tracked but no longer exist.
+		for k := range fs.sources {
+			if _, ok := sources[k]; !ok {
+				delete(fs.sources, k)
+			}
+		}
+		// Seed sources that aren't in the map yet.
+		for k := range sources {
+			if _, ok := fs.sources[k]; !ok {
+				fs.sources[k] = &StreamSourceState{}
+			}
+		}
+	}
+	if fs.sources != nil {
+		// No sources configured anymore, clear.
+		if len(sources) == 0 {
+			fs.sources = nil
+		}
+		// If all zeros or empty, remove the index from disk.
+		remove := true
+		for _, ss := range fs.sources {
+			if ss.Seq > 0 {
+				remove = false
+				break
+			}
+		}
+		if remove {
+			_ = os.Remove(fs.sourcesStatePath())
+		}
+	}
+
 	// Short-circuit if no recovering is required.
-	if !ttlRecover && !schedRecover {
+	if !ttlRecover && !schedRecover && !sourcesRecover {
 		return nil
 	}
 
@@ -2229,12 +2291,26 @@ func (fs *fileStore) recoverPerMessageState() error {
 		defer fs.scheduling.resetTimer()
 	}
 
+	// If only sources need recovering, then we can optimize to a backward scan.
+	if sourcesRecover && !ttlRecover && !schedRecover {
+		if fs.state.Msgs > 0 && sourcesSeq <= fs.state.LastSeq {
+			fs.warn("Sourcing state is outdated; attempting to recover using backward scan (seq %d to %d)", sourcesSeq, fs.state.LastSeq)
+			if err := fs.recoverSourcesBackwardScan(sourcesSeq, sources); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	if fs.state.Msgs > 0 && scanSeq <= fs.state.LastSeq {
 		if ttlRecover && ttlSeq <= fs.state.LastSeq {
 			fs.warn("TTL state is outdated; attempting to recover using linear scan (seq %d to %d)", ttlSeq, fs.state.LastSeq)
 		}
 		if schedRecover && schedSeq <= fs.state.LastSeq {
 			fs.warn("Message scheduling state is outdated; attempting to recover using linear scan (seq %d to %d)", schedSeq, fs.state.LastSeq)
+		}
+		if sourcesRecover && sourcesSeq <= fs.state.LastSeq {
+			fs.warn("Sourcing state is outdated; attempting to recover using linear scan (seq %d to %d)", sourcesSeq, fs.state.LastSeq)
 		}
 		var (
 			mb     *msgBlock
@@ -2257,7 +2333,8 @@ func (fs *fileStore) recoverPerMessageState() error {
 			// Check if this block can be skipped.
 			ttlBlock := ttlRecover && mblseq >= ttlSeq
 			schedBlock := schedRecover && mblseq >= schedSeq
-			if (!ttlBlock || mb.ttls == 0) && (!schedBlock || mb.schedules == 0) {
+			sourcesBlock := sourcesRecover && mblseq >= sourcesSeq
+			if !sourcesBlock && (!ttlBlock || mb.ttls == 0) && (!schedBlock || mb.schedules == 0) {
 				// None of the messages in the block have state that needs recovering, so
 				// don't bother doing anything further with this block, skip to the end.
 				seq = mblseq + 1
@@ -2295,6 +2372,16 @@ func (fs *fileStore) recoverPerMessageState() error {
 					if schedule, apiErr := nextMessageSchedule(msg.hdr, msg.ts); apiErr == nil && !schedule.IsZero() {
 						// Copy the subject, as it's stored in the scheduling maps and the backing cache could be reused in the meantime.
 						fs.scheduling.init(seq, copyString(msg.subj), schedule.UnixNano())
+					}
+				}
+				if sourcesRecover && seq >= sourcesSeq {
+					if ss := sliceHeader(JSStreamSource, msg.hdr); len(ss) > 0 {
+						_, indexName, sseq, ident := streamAndSeq(bytesToString(ss))
+						if indexName != _EMPTY_ {
+							if sss, ok := fs.sources[indexName]; ok {
+								sss.Seq, sss.Ident = sseq, ident
+							}
+						}
 					}
 				}
 			}
@@ -4841,6 +4928,26 @@ func (fs *fileStore) subjectsTotalsLocked(filter string) map[string]uint64 {
 	return fst
 }
 
+// SourcesState return sources keys and their last known state.
+func (fs *fileStore) SourcesState() (dst map[string]StreamSourceState) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	if len(fs.sources) == 0 {
+		return nil
+	}
+	// Allocate lazily so that a map containing only seeded (zero) entries returns
+	// nil rather than an empty map; zeros must not leak out of SourcesState.
+	for k, ss := range fs.sources {
+		if ss.Seq > 0 {
+			if dst == nil {
+				dst = make(map[string]StreamSourceState, 1)
+			}
+			dst[k] = *ss
+		}
+	}
+	return dst
+}
+
 // RegisterStorageUpdates registers a callback for updates to storage changes.
 // It will present number of messages and bytes as a signed integer and an
 // optional sequence number of the message if a single.
@@ -5232,6 +5339,16 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 			scheduler := getMessageScheduler(hdr)
 			if next, err := time.Parse(time.RFC3339Nano, scheduleNext); err == nil && scheduler != _EMPTY_ {
 				fs.scheduling.update(scheduler, next.UnixNano())
+			}
+		}
+	}
+
+	// Track sources.
+	if len(fs.cfg.Sources) > 0 {
+		if ss := sliceHeader(JSStreamSource, hdr); len(ss) > 0 {
+			_, indexName, sseq, ident := streamAndSeq(bytesToString(ss))
+			if sss, ok := fs.sources[indexName]; ok {
+				sss.Seq, sss.Ident = sseq, ident
 			}
 		}
 	}
@@ -9682,7 +9799,12 @@ func (fs *fileStore) LoadPrevMsgMulti(sl *gsl.SimpleSublist, start uint64, smp *
 	}
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()
+	return fs.loadPrevMsgMultiLocked(sl, start, smp)
+}
 
+// loadPrevMsgMultiLocked will find the previous message matching any entry in the sublist.
+// Lock should be held.
+func (fs *fileStore) loadPrevMsgMultiLocked(sl *gsl.SimpleSublist, start uint64, smp *StoreMsg) (sm *StoreMsg, skip uint64, err error) {
 	if fs.state.Msgs == 0 || start < fs.state.FirstSeq {
 		return nil, fs.state.FirstSeq, ErrStoreEOF
 	}
@@ -12178,13 +12300,16 @@ func (fs *fileStore) _writeFullState(force bool) error {
 	fs.dirty -= priorDirty
 	fs.mu.Unlock()
 
-	// Attempt to write both files, an error in one should not prevent the other from being written.
+	// Attempt to write other index files, an error in one should not prevent the other from being written.
 	ttlErr := fs.writeTTLState()
 	schedErr := fs.writeMsgSchedulingState()
+	sourcesErr := fs.writeSourcesState()
 	if ttlErr != nil {
 		return ttlErr
 	} else if schedErr != nil {
 		return schedErr
+	} else if sourcesErr != nil {
+		return sourcesErr
 	}
 	return nil
 }
@@ -12215,6 +12340,210 @@ func (fs *fileStore) writeMsgSchedulingState() error {
 	fs.mu.RUnlock()
 
 	return fs.writeFileWithOptionalSync(fn, buf, defaultFilePerms)
+}
+
+const sourcesHeaderLen = 17 // 1 byte magic + 2x uint64s
+
+func (fs *fileStore) sourcesStatePath() string {
+	return filepath.Join(fs.fcfg.StoreDir, sourcesStreamStateFile)
+}
+
+func (fs *fileStore) writeSourcesState() error {
+	fs.mu.RLock()
+	if fs.sources == nil {
+		fs.mu.RUnlock()
+		return nil
+	}
+	fn := fs.sourcesStatePath()
+
+	// Must be lseq+1 to identify up to which sequence the sources are valid.
+	highSeq := fs.state.LastSeq + 1
+
+	var count, sz uint64
+	for source, ss := range fs.sources {
+		if ss.Seq > 0 {
+			count++
+			// Length prefix + source bytes + seq varint +
+			// length prefix + identity bytes.
+			sz += uint64(uvarintLen(uint64(len(source)))) + uint64(len(source)) + binary.MaxVarintLen64 +
+				uint64(uvarintLen(uint64(len(ss.Ident)))) + uint64(len(ss.Ident))
+		}
+	}
+	// Nothing observed yet, don't persist an empty index. Any stale file is
+	// removed by recoverPerMessageState on recovery.
+	if count == 0 {
+		fs.mu.RUnlock()
+		return nil
+	}
+	buf := make([]byte, 0, sourcesHeaderLen+sz)
+	buf = append(buf, 1)                                 // Magic version
+	buf = binary.LittleEndian.AppendUint64(buf, count)   // Entry count
+	buf = binary.LittleEndian.AppendUint64(buf, highSeq) // Stamp
+	for source, ss := range fs.sources {
+		if ss.Seq == 0 {
+			continue
+		}
+		buf = binary.AppendUvarint(buf, uint64(len(source)))
+		buf = append(buf, source...)
+		buf = binary.AppendUvarint(buf, ss.Seq)
+		buf = binary.AppendUvarint(buf, uint64(len(ss.Ident)))
+		buf = append(buf, ss.Ident...)
+	}
+	fs.mu.RUnlock()
+
+	return fs.writeFileWithOptionalSync(fn, buf, defaultFilePerms)
+}
+
+// Lock should be held.
+func (fs *fileStore) recoverSourcesState() uint64 {
+	// See if we have a sources index file.
+	fs.dios.acquire()
+	fn := fs.sourcesStatePath()
+	buf, err := os.ReadFile(fn)
+	fs.dios.release()
+
+	if err != nil && !os.IsNotExist(err) {
+		fs.warn("Recovering sources state from index errored: %v", err)
+	}
+
+	var sourcesSeq uint64
+	if err == nil {
+		sourcesSeq, err = fs.decodeSourcesState(buf)
+		if err != nil {
+			fs.warn("Error decoding sources state: %s", err)
+			// Remove the file, and reset collected state (if any).
+			_ = os.Remove(fn)
+			fs.sources = nil
+		}
+	}
+
+	if sourcesSeq < fs.state.FirstSeq {
+		sourcesSeq = fs.state.FirstSeq
+	}
+	return sourcesSeq
+}
+
+var errSourcesInvalidVersion = errors.New("sources: encoded version not known")
+
+func (fs *fileStore) decodeSourcesState(b []byte) (uint64, error) {
+	if len(b) < sourcesHeaderLen {
+		return 0, io.ErrShortBuffer
+	}
+	if b[0] != 1 {
+		return 0, errSourcesInvalidVersion
+	}
+
+	count := binary.LittleEndian.Uint64(b[1:])
+	stamp := binary.LittleEndian.Uint64(b[9:])
+	if count > 0 && fs.sources == nil {
+		fs.sources = make(map[string]*StreamSourceState)
+	}
+	b = b[sourcesHeaderLen:]
+	readStr := func() (string, bool) {
+		n, vn := binary.Uvarint(b)
+		if vn <= 0 || uint64(len(b)-vn) < n {
+			return _EMPTY_, false
+		}
+		b = b[vn:]
+		s := string(b[:n])
+		b = b[n:]
+		return s, true
+	}
+	for i := uint64(0); i < count; i++ {
+		source, ok := readStr()
+		if !ok {
+			return 0, io.ErrUnexpectedEOF
+		}
+		seq, vn := binary.Uvarint(b)
+		if vn <= 0 {
+			return 0, io.ErrUnexpectedEOF
+		}
+		b = b[vn:]
+		ident, ok := readStr()
+		if !ok {
+			return 0, io.ErrUnexpectedEOF
+		}
+		fs.sources[source] = &StreamSourceState{Seq: seq, Ident: ident}
+	}
+	return stamp, nil
+}
+
+// recoverSourcesBackwardScan recovers fs.sources by scanning the stream backwards,
+// mirroring stream.startingSequenceForSources, down to and including the stopSeq.
+// Lock should be held.
+func (fs *fileStore) recoverSourcesBackwardScan(stopSeq uint64, sources map[string]*StreamSource) error {
+	var sl *gsl.SimpleSublist
+	refreshSublist := func() {
+		sl = gsl.NewSimpleSublist()
+		for _, src := range sources {
+			if src.FilterSubject == _EMPTY_ {
+				sl.Insert(fwcs, struct{}{})
+			} else {
+				sl.Insert(src.FilterSubject, struct{}{})
+			}
+			for _, tr := range src.SubjectTransforms {
+				if tr.Destination == _EMPTY_ {
+					sl.Insert(fwcs, struct{}{})
+				} else {
+					sl.Insert(tr.Destination, struct{}{})
+				}
+			}
+		}
+	}
+	refreshSublist()
+
+	update := func(iName string, sseq uint64, ident string) {
+		// Only consider sources that are configured and not yet found. The backward
+		// scan visits the highest matching sequence first, so the first hit per source
+		// is the latest and overwrites any older decoded value.
+		if _, ok := sources[iName]; !ok {
+			return
+		}
+		if fs.sources == nil {
+			fs.sources = make(map[string]*StreamSourceState, 1)
+		}
+		fs.sources[iName] = &StreamSourceState{Seq: sseq, Ident: ident}
+		delete(sources, iName)
+		refreshSublist()
+	}
+
+	var smv StoreMsg
+	for last := fs.state.LastSeq; ; {
+		sm, seq, err := fs.loadPrevMsgMultiLocked(sl, last, &smv)
+		if err == ErrStoreEOF {
+			// Done.
+			break
+		}
+		if err != nil {
+			return err
+		}
+		// Stop if we've gone below the point where decoded state is still valid.
+		if seq < stopSeq {
+			break
+		}
+		if len(sm.hdr) > 0 {
+			if ss := sliceHeader(JSStreamSource, sm.hdr); len(ss) > 0 {
+				streamName, iName, sseq, ident := streamAndSeq(bytesToString(ss))
+				if iName == _EMPTY_ {
+					// Pre-2.10 message header means it's a match for any source using that stream name.
+					// Such headers carry no identity, so it is left unset.
+					for _, ssi := range fs.cfg.Sources {
+						if streamName == ssi.Name || (ssi.External != nil && streamName == ssi.Name+":"+getHash(ssi.External.ApiPrefix)) {
+							update(ssi.composeIName(), sseq, _EMPTY_)
+						}
+					}
+				} else {
+					update(iName, sseq, ident)
+				}
+			}
+		}
+		// Done once every source has been resolved, or we've reached the floor.
+		if len(sources) == 0 || seq <= stopSeq {
+			break
+		}
+		last = seq - 1
+	}
+	return nil
 }
 
 // Stop the current filestore.

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -10980,6 +10980,251 @@ func TestFileStoreMessageScheduleDecodeRejectsMalformed(t *testing.T) {
 	}
 }
 
+func TestFileStoreSourcesDecodeRejectsMalformed(t *testing.T) {
+	// Build a valid header that claims a given number of source entries.
+	header := func(count uint64) []byte {
+		b := make([]byte, sourcesHeaderLen)
+		b[0] = 1                                    // Magic version
+		binary.LittleEndian.PutUint64(b[1:], count) // Entry count
+		binary.LittleEndian.PutUint64(b[9:], 0)     // High sequence stamp
+		return b
+	}
+	u32 := func(v uint32) []byte {
+		b := make([]byte, 4)
+		binary.LittleEndian.PutUint32(b, v)
+		return b
+	}
+
+	for _, test := range []struct {
+		title string
+		buf   []byte
+		err   error
+	}{
+		{title: "ShortHeader", buf: make([]byte, sourcesHeaderLen-1), err: io.ErrShortBuffer},
+		{title: "BadVersion", buf: func() []byte { b := header(0); b[0] = 2; return b }(), err: errSourcesInvalidVersion},
+		// Claims one entry but the buffer ends right after the header.
+		{title: "TruncatedAtSourceLen", buf: header(1), err: io.ErrUnexpectedEOF},
+		// Claims one entry but the source-length field itself is truncated (<4 bytes).
+		{title: "PartialSourceLen", buf: append(header(1), 1, 2), err: io.ErrUnexpectedEOF},
+		// Has the source length but the source bytes are missing.
+		{title: "TruncatedSource", buf: append(header(1), u32(5)...), err: io.ErrUnexpectedEOF},
+		// Has the source but the seq varint is missing.
+		{title: "TruncatedSeq", buf: append(append(header(1), u32(3)...), 'f', 'o', 'o'), err: io.ErrUnexpectedEOF},
+	} {
+		t.Run(test.title, func(t *testing.T) {
+			fs := &fileStore{}
+			_, err := fs.decodeSourcesState(test.buf)
+			require_Error(t, err, test.err)
+		})
+	}
+}
+
+func TestFileStoreSourcesRecovery(t *testing.T) {
+	test := func(t *testing.T, remove bool) {
+		dir := t.TempDir()
+		cfg := StreamConfig{
+			Name:     "SOURCE",
+			Subjects: []string{"foo.*"},
+			Storage:  FileStorage,
+			Sources:  []*StreamSource{{Name: "ORIGIN"}},
+		}
+		fcfg := FileStoreConfig{StoreDir: dir, BlockSize: 256}
+
+		fs, err := newFileStore(fcfg, cfg)
+		require_NoError(t, err)
+
+		// Store messages carrying a stream-source header so the sources map is populated.
+		// Header format matches genSourceHeader: "<iName> <seq> <source> <dest> <orig>".
+		const N = 10
+		for i := 1; i <= N; i++ {
+			hdr := genHeader(nil, JSStreamSource, fmt.Sprintf("ORIGIN %d > > foo.bar", i))
+			_, _, err = fs.StoreMsg("foo.bar", hdr, nil, 0)
+			require_NoError(t, err)
+		}
+		require_True(t, fs.numMsgBlocks() >= 2)
+
+		// Sanity check the state before restart, last source seq should win.
+		state := fs.SourcesState()
+		require_NotNil(t, state)
+		require_Equal(t, state["ORIGIN > >"], N)
+		require_NoError(t, fs.Stop())
+
+		if remove {
+			// Delete the persisted sources state.
+			require_NoError(t, os.Remove(filepath.Join(dir, sourcesStreamStateFile)))
+		}
+
+		fs, err = newFileStore(fcfg, cfg)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		state = fs.SourcesState()
+		if remove {
+			// Should not recover the sources state if it didn't exist at least partially.
+			require_True(t, state == nil)
+		} else {
+			require_NotNil(t, state)
+			require_Equal(t, state["ORIGIN > >"], N)
+		}
+	}
+
+	t.Run("Normal", func(t *testing.T) { test(t, false) })
+	t.Run("Remove", func(t *testing.T) { test(t, true) })
+}
+
+func TestFileStoreSourcesPrunedOnRecover(t *testing.T) {
+	dir := t.TempDir()
+	fcfg := FileStoreConfig{StoreDir: dir}
+	cfg := StreamConfig{
+		Name:     "SOURCE",
+		Subjects: []string{"foo.*"},
+		Storage:  FileStorage,
+		Sources:  []*StreamSource{{Name: "ORIGIN1"}, {Name: "ORIGIN2"}},
+	}
+
+	fs, err := newFileStore(fcfg, cfg)
+	require_NoError(t, err)
+
+	h1 := genHeader(nil, JSStreamSource, "ORIGIN1 1 > > foo.a")
+	_, _, err = fs.StoreMsg("foo.a", h1, nil, 0)
+	require_NoError(t, err)
+	h2 := genHeader(nil, JSStreamSource, "ORIGIN2 1 > > foo.b")
+	_, _, err = fs.StoreMsg("foo.b", h2, nil, 0)
+	require_NoError(t, err)
+
+	state := fs.SourcesState()
+	require_Len(t, len(state), 2)
+
+	// Persist the sources state so the recover path takes the decode (not linear-scan)
+	// branch, which is the one that can carry stale keys.
+	require_NoError(t, fs.writeFullState())
+	require_NoError(t, fs.Stop())
+	_, err = os.Stat(filepath.Join(dir, sourcesStreamStateFile))
+	require_NoError(t, err)
+
+	// Reopen with ORIGIN2 removed from the config. Its decoded key must be pruned.
+	cfg.Sources = []*StreamSource{{Name: "ORIGIN1"}}
+	fs, err = newFileStore(fcfg, cfg)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	state = fs.SourcesState()
+	require_Len(t, len(state), 1)
+	_, ok := state["ORIGIN1 > >"]
+	require_True(t, ok)
+	_, ok = state["ORIGIN2 > >"]
+	require_False(t, ok)
+}
+
+func TestFileStoreSourcesNoEmptyIndexWritten(t *testing.T) {
+	dir := t.TempDir()
+	fcfg := FileStoreConfig{StoreDir: dir}
+	cfg := StreamConfig{
+		Name:     "SOURCE",
+		Subjects: []string{"foo.*"},
+		Storage:  FileStorage,
+		Sources:  []*StreamSource{{Name: "ORIGIN"}},
+	}
+
+	fs, err := newFileStore(fcfg, cfg)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	fn := filepath.Join(dir, sourcesStreamStateFile)
+
+	// Sources are configured but nothing has been observed yet, so the map only
+	// holds seeded (zero) entries. Persisting state must not write an empty index.
+	require_True(t, fs.SourcesState() == nil)
+	require_NoError(t, fs.writeFullState())
+	_, err = os.Stat(fn)
+	require_True(t, os.IsNotExist(err))
+
+	// Observe a source, the index should now be written.
+	hdr := genHeader(nil, JSStreamSource, "ORIGIN 1 > > foo.bar")
+	_, _, err = fs.StoreMsg("foo.bar", hdr, nil, 0)
+	require_NoError(t, err)
+	require_NoError(t, fs.writeFullState())
+	_, err = os.Stat(fn)
+	require_NoError(t, err)
+
+	// Drop the sources from the config. recoverPerMessageState (via UpdateConfig)
+	// should prune the now-stale index from disk.
+	ucfg := cfg
+	ucfg.Sources = nil
+	require_NoError(t, fs.UpdateConfig(&ucfg))
+	_, err = os.Stat(fn)
+	require_True(t, os.IsNotExist(err))
+}
+
+func TestFileStoreSourcesRecoveredFromOutdatedState(t *testing.T) {
+	srcs := []*StreamSource{
+		{Name: "ORIGIN1", FilterSubject: "s1.>"},
+		{Name: "ORIGIN2", FilterSubject: "s2.>"},
+		{Name: "ORIGIN3", FilterSubject: "s3.>"},
+	}
+
+	test := func(t *testing.T, withTTL bool) {
+		dir := t.TempDir()
+		fcfg := FileStoreConfig{StoreDir: dir, BlockSize: 256}
+		cfg := StreamConfig{
+			Name:        "SOURCE",
+			Subjects:    []string{">"},
+			Storage:     FileStorage,
+			Sources:     srcs,
+			AllowMsgTTL: withTTL,
+		}
+
+		fs, err := newFileStore(fcfg, cfg)
+		require_NoError(t, err)
+
+		// Store an interleaved batch from each source, then persist the sources state.
+		store := func(round int) {
+			for i, src := range srcs {
+				subj := fmt.Sprintf("s%d.x", i+1)
+				hdr := genHeader(nil, JSStreamSource, fmt.Sprintf("%s %d %s > %s", src.Name, round, src.FilterSubject, subj))
+				_, _, err = fs.StoreMsg(subj, hdr, nil, 0)
+				require_NoError(t, err)
+			}
+		}
+		const firstBatch = 15
+		for r := 1; r <= firstBatch; r++ {
+			store(r)
+		}
+		require_NoError(t, fs.writeFullState())
+
+		// Snapshot the now-current (but soon-to-be-outdated) sources state file.
+		fn := filepath.Join(dir, sourcesStreamStateFile)
+		outdated, err := os.ReadFile(fn)
+		require_NoError(t, err)
+
+		// Store a second batch with higher source sequences, then stop.
+		const lastSeq = 30
+		for r := firstBatch + 1; r <= lastSeq; r++ {
+			store(r)
+		}
+		require_True(t, fs.numMsgBlocks() >= 2)
+		require_NoError(t, fs.Stop())
+
+		// Roll the sources state file back to the outdated snapshot, simulating messages
+		// stored after the last flush of the index.
+		require_NoError(t, os.WriteFile(fn, outdated, defaultFilePerms))
+
+		fs, err = newFileStore(fcfg, cfg)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		// Each source should be recovered to its latest sequence, not the stale one.
+		state := fs.SourcesState()
+		require_Len(t, len(state), len(srcs))
+		for _, src := range srcs {
+			require_Equal(t, state[src.composeIName()], lastSeq)
+		}
+	}
+
+	t.Run("BackwardScan", func(t *testing.T) { test(t, false) })
+	t.Run("ForwardScanWithTTL", func(t *testing.T) { test(t, true) })
+}
+
 func TestFileStoreCorruptedNonOrderedSequences(t *testing.T) {
 	for _, test := range []struct {
 		title   string

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -10274,7 +10274,13 @@ func TestFileStoreNoPanicOnRecoverTTLWithCorruptBlocks(t *testing.T) {
 		atomic.StoreUint64(&lmb.first.seq, fseq)
 		atomic.StoreUint64(&lmb.last.seq, lseq)
 
-		require_NoError(t, fs.recoverTTLState())
+		// Reset TTL state so recoverPerMessageState actually re-runs TTL
+		// recovery and scans the (corrupted) blocks.
+		fs.mu.Lock()
+		fs.ttls = nil
+		fs.mu.Unlock()
+
+		require_NoError(t, fs.recoverPerMessageState())
 	})
 }
 
@@ -10897,6 +10903,11 @@ func TestFileStoreMessageScheduleRecovered(t *testing.T) {
 		require_Equal(t, ss.FirstSeq, 1)
 		require_Equal(t, ss.LastSeq, 1)
 		require_Equal(t, ss.Msgs, 1)
+
+		fs.mu.RLock()
+		defer fs.mu.RUnlock()
+		require_True(t, fs.scheduling != nil)
+		require_Len(t, len(fs.scheduling.schedules), 1)
 	})
 }
 

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -11311,6 +11311,306 @@ func TestFileStoreMessageScheduleDecodeRejectsMalformed(t *testing.T) {
 	}
 }
 
+func TestFileStoreSourcesDecodeRejectsMalformed(t *testing.T) {
+	// Build a valid header that claims a given number of source entries.
+	header := func(count uint64) []byte {
+		b := make([]byte, sourcesHeaderLen)
+		b[0] = 1                                    // Magic version
+		binary.LittleEndian.PutUint64(b[1:], count) // Entry count
+		binary.LittleEndian.PutUint64(b[9:], 0)     // High sequence stamp
+		return b
+	}
+	uvi := func(v uint64) []byte {
+		return binary.AppendUvarint(nil, v)
+	}
+
+	for _, test := range []struct {
+		title string
+		buf   []byte
+		err   error
+	}{
+		{title: "ShortHeader", buf: make([]byte, sourcesHeaderLen-1), err: io.ErrShortBuffer},
+		{title: "BadVersion", buf: func() []byte { b := header(0); b[0] = 2; return b }(), err: errSourcesInvalidVersion},
+		// Claims one entry but the buffer ends right after the header.
+		{title: "TruncatedAtSourceLen", buf: header(1), err: io.ErrUnexpectedEOF},
+		// Has the source length but the source bytes are missing.
+		{title: "TruncatedSource", buf: append(header(1), uvi(5)...), err: io.ErrUnexpectedEOF},
+		// Has the source but the seq varint is missing.
+		{title: "TruncatedSeq", buf: append(append(header(1), uvi(3)...), 'f', 'o', 'o'), err: io.ErrUnexpectedEOF},
+		// Has the source and seq but the identity-length field is missing.
+		{title: "TruncatedAtIdentLen", buf: append(append(append(header(1), uvi(3)...), 'f', 'o', 'o'), uvi(1)...), err: io.ErrUnexpectedEOF},
+		// Has the identity length but the identity bytes are missing.
+		{title: "TruncatedIdent", buf: append(append(append(append(header(1), uvi(3)...), 'f', 'o', 'o'), uvi(1)...), uvi(5)...), err: io.ErrUnexpectedEOF},
+	} {
+		t.Run(test.title, func(t *testing.T) {
+			fs := &fileStore{}
+			_, err := fs.decodeSourcesState(test.buf)
+			require_Error(t, err, test.err)
+		})
+	}
+}
+
+func TestFileStoreSourcesRecovery(t *testing.T) {
+	test := func(t *testing.T, remove bool) {
+		dir := t.TempDir()
+		cfg := StreamConfig{
+			Name:     "SOURCE",
+			Subjects: []string{"foo.*"},
+			Storage:  FileStorage,
+			Sources:  []*StreamSource{{Name: "ORIGIN"}},
+		}
+		fcfg := FileStoreConfig{StoreDir: dir, BlockSize: 256}
+
+		fs, err := newFileStore(fcfg, cfg)
+		require_NoError(t, err)
+
+		// Store messages carrying a stream-source header so the sources map is populated.
+		// Header format matches genSourceHeader: "<iName> <seq> <source> <dest> <orig> <ident>".
+		const N = 10
+		const ident = "IDENTITY1"
+		for i := 1; i <= N; i++ {
+			hdr := genHeader(nil, JSStreamSource, fmt.Sprintf("ORIGIN %d > > foo.bar %s", i, ident))
+			_, _, err = fs.StoreMsg("foo.bar", hdr, nil, 0)
+			require_NoError(t, err)
+		}
+		require_True(t, fs.numMsgBlocks() >= 2)
+
+		// Sanity check the state before restart, last source seq should win.
+		state := fs.SourcesState()
+		require_NotNil(t, state)
+		require_Equal(t, state["ORIGIN > >"].Seq, N)
+		require_Equal(t, state["ORIGIN > >"].Ident, ident)
+		require_NoError(t, fs.Stop())
+
+		if remove {
+			// Delete the persisted sources state.
+			require_NoError(t, os.Remove(filepath.Join(dir, sourcesStreamStateFile)))
+		}
+
+		fs, err = newFileStore(fcfg, cfg)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		state = fs.SourcesState()
+		if remove {
+			// Should not recover the sources state if it didn't exist at least partially.
+			require_True(t, state == nil)
+		} else {
+			// Sequence and identity must both survive the restart, otherwise
+			// stream recreation can't be detected.
+			require_NotNil(t, state)
+			require_Equal(t, state["ORIGIN > >"].Seq, N)
+			require_Equal(t, state["ORIGIN > >"].Ident, ident)
+		}
+	}
+
+	t.Run("Normal", func(t *testing.T) { test(t, false) })
+	t.Run("Remove", func(t *testing.T) { test(t, true) })
+}
+
+func TestFileStoreSourcesStaleConfig(t *testing.T) {
+	// Dropping one of several sources must prune its decoded key on recover.
+	t.Run("PruneKeyOnRecover", func(t *testing.T) {
+		dir := t.TempDir()
+		fcfg := FileStoreConfig{StoreDir: dir}
+		cfg := StreamConfig{
+			Name:     "SOURCE",
+			Subjects: []string{"foo.*"},
+			Storage:  FileStorage,
+			Sources:  []*StreamSource{{Name: "ORIGIN1"}, {Name: "ORIGIN2"}},
+		}
+
+		fs, err := newFileStore(fcfg, cfg)
+		require_NoError(t, err)
+
+		h1 := genHeader(nil, JSStreamSource, "ORIGIN1 1 > > foo.a")
+		_, _, err = fs.StoreMsg("foo.a", h1, nil, 0)
+		require_NoError(t, err)
+		h2 := genHeader(nil, JSStreamSource, "ORIGIN2 1 > > foo.b")
+		_, _, err = fs.StoreMsg("foo.b", h2, nil, 0)
+		require_NoError(t, err)
+
+		state := fs.SourcesState()
+		require_Len(t, len(state), 2)
+
+		// Persist the sources state so the recover path takes the decode (not linear-scan)
+		// branch, which is the one that can carry stale keys.
+		require_NoError(t, fs.writeFullState())
+		require_NoError(t, fs.Stop())
+		_, err = os.Stat(filepath.Join(dir, sourcesStreamStateFile))
+		require_NoError(t, err)
+
+		// Reopen with ORIGIN2 removed from the config. Its decoded key must be pruned.
+		cfg.Sources = []*StreamSource{{Name: "ORIGIN1"}}
+		fs, err = newFileStore(fcfg, cfg)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		state = fs.SourcesState()
+		require_Len(t, len(state), 1)
+		_, ok := state["ORIGIN1 > >"]
+		require_True(t, ok)
+		_, ok = state["ORIGIN2 > >"]
+		require_False(t, ok)
+	})
+
+	// An index with nothing to record, or whose sources are all gone, must
+	// not linger on disk.
+	t.Run("NoStaleIndexOnDisk", func(t *testing.T) {
+		dir := t.TempDir()
+		fcfg := FileStoreConfig{StoreDir: dir}
+		cfg := StreamConfig{
+			Name:     "SOURCE",
+			Subjects: []string{"foo.*"},
+			Storage:  FileStorage,
+			Sources:  []*StreamSource{{Name: "ORIGIN"}},
+		}
+
+		fs, err := newFileStore(fcfg, cfg)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		fn := filepath.Join(dir, sourcesStreamStateFile)
+
+		// Sources are configured but nothing has been observed yet, so the map only
+		// holds seeded (zero) entries. Persisting state must not write an empty index.
+		require_True(t, fs.SourcesState() == nil)
+		require_NoError(t, fs.writeFullState())
+		_, err = os.Stat(fn)
+		require_True(t, os.IsNotExist(err))
+
+		// Observe a source, the index should now be written.
+		hdr := genHeader(nil, JSStreamSource, "ORIGIN 1 > > foo.bar")
+		_, _, err = fs.StoreMsg("foo.bar", hdr, nil, 0)
+		require_NoError(t, err)
+		require_NoError(t, fs.writeFullState())
+		_, err = os.Stat(fn)
+		require_NoError(t, err)
+
+		// Drop the sources from the config. recoverPerMessageState (via UpdateConfig)
+		// should prune the now-stale index from disk.
+		ucfg := cfg
+		ucfg.Sources = nil
+		require_NoError(t, fs.UpdateConfig(&ucfg))
+		_, err = os.Stat(fn)
+		require_True(t, os.IsNotExist(err))
+	})
+}
+
+func TestFileStoreSourcesRecoveredFromOutdatedState(t *testing.T) {
+	srcs := []*StreamSource{
+		{Name: "ORIGIN1", FilterSubject: "s1.>"},
+		{Name: "ORIGIN2", FilterSubject: "s2.>"},
+		{Name: "ORIGIN3", FilterSubject: "s3.>"},
+	}
+
+	test := func(t *testing.T, withTTL bool) {
+		dir := t.TempDir()
+		fcfg := FileStoreConfig{StoreDir: dir, BlockSize: 256}
+		cfg := StreamConfig{
+			Name:        "SOURCE",
+			Subjects:    []string{">"},
+			Storage:     FileStorage,
+			Sources:     srcs,
+			AllowMsgTTL: withTTL,
+		}
+
+		fs, err := newFileStore(fcfg, cfg)
+		require_NoError(t, err)
+
+		// Store an interleaved batch from each source, then persist the sources state.
+		store := func(round int) {
+			for i, src := range srcs {
+				subj := fmt.Sprintf("s%d.x", i+1)
+				hdr := genHeader(nil, JSStreamSource, fmt.Sprintf("%s %d %s > %s", src.Name, round, src.FilterSubject, subj))
+				_, _, err = fs.StoreMsg(subj, hdr, nil, 0)
+				require_NoError(t, err)
+			}
+		}
+		const firstBatch = 15
+		for r := 1; r <= firstBatch; r++ {
+			store(r)
+		}
+		require_NoError(t, fs.writeFullState())
+
+		// Snapshot the now-current (but soon-to-be-outdated) sources state file.
+		fn := filepath.Join(dir, sourcesStreamStateFile)
+		outdated, err := os.ReadFile(fn)
+		require_NoError(t, err)
+
+		// Store a second batch with higher source sequences, then stop.
+		const lastSeq = 30
+		for r := firstBatch + 1; r <= lastSeq; r++ {
+			store(r)
+		}
+		require_True(t, fs.numMsgBlocks() >= 2)
+		require_NoError(t, fs.Stop())
+
+		// Roll the sources state file back to the outdated snapshot, simulating messages
+		// stored after the last flush of the index.
+		require_NoError(t, os.WriteFile(fn, outdated, defaultFilePerms))
+
+		fs, err = newFileStore(fcfg, cfg)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		// Each source should be recovered to its latest sequence, not the stale one.
+		state := fs.SourcesState()
+		require_Len(t, len(state), len(srcs))
+		for _, src := range srcs {
+			require_Equal(t, state[src.composeIName()].Seq, lastSeq)
+		}
+	}
+
+	t.Run("BackwardScan", func(t *testing.T) { test(t, false) })
+	t.Run("ForwardScanWithTTL", func(t *testing.T) { test(t, true) })
+}
+
+func TestFileStoreSourcesRecoveredOneMessageAfterFlush(t *testing.T) {
+	dir := t.TempDir()
+	fcfg := FileStoreConfig{StoreDir: dir}
+	cfg := StreamConfig{
+		Name:     "SOURCE",
+		Subjects: []string{">"},
+		Storage:  FileStorage,
+		Sources:  []*StreamSource{{Name: "ORIGIN"}},
+	}
+
+	fs, err := newFileStore(fcfg, cfg)
+	require_NoError(t, err)
+
+	store := func(sseq uint64) {
+		hdr := genHeader(nil, JSStreamSource, fmt.Sprintf("ORIGIN %d > > foo.bar", sseq))
+		_, _, err = fs.StoreMsg("foo.bar", hdr, nil, 0)
+		require_NoError(t, err)
+	}
+
+	const flushed = 5
+	for i := uint64(1); i <= flushed; i++ {
+		store(i)
+	}
+	require_NoError(t, fs.writeFullState())
+
+	// Snapshot the index as it is right after the flush.
+	fn := filepath.Join(dir, sourcesStreamStateFile)
+	outdated, err := os.ReadFile(fn)
+	require_NoError(t, err)
+
+	// Exactly one message lands after that flush, which is the boundary the
+	// stamp has to get right. If it claims to cover this message the recovery
+	// scan skips it and the source silently resumes from the wrong sequence.
+	const last = flushed + 1
+	store(last)
+	require_NoError(t, fs.Stop())
+	require_NoError(t, os.WriteFile(fn, outdated, defaultFilePerms))
+
+	fs, err = newFileStore(fcfg, cfg)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	require_Equal(t, fs.SourcesState()["ORIGIN > >"].Seq, last)
+}
+
 func TestFileStoreCorruptedNonOrderedSequences(t *testing.T) {
 	for _, test := range []struct {
 		title   string

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -10605,7 +10605,13 @@ func TestFileStoreNoPanicOnRecoverTTLWithCorruptBlocks(t *testing.T) {
 		atomic.StoreUint64(&lmb.first.seq, fseq)
 		atomic.StoreUint64(&lmb.last.seq, lseq)
 
-		require_NoError(t, fs.recoverTTLState())
+		// Reset TTL state so recoverPerMessageState actually re-runs TTL
+		// recovery and scans the (corrupted) blocks.
+		fs.mu.Lock()
+		fs.ttls = nil
+		fs.mu.Unlock()
+
+		require_NoError(t, fs.recoverPerMessageState())
 	})
 }
 
@@ -11228,6 +11234,11 @@ func TestFileStoreMessageScheduleRecovered(t *testing.T) {
 		require_Equal(t, ss.FirstSeq, 1)
 		require_Equal(t, ss.LastSeq, 1)
 		require_Equal(t, ss.Msgs, 1)
+
+		fs.mu.RLock()
+		defer fs.mu.RUnlock()
+		require_True(t, fs.scheduling != nil)
+		require_Len(t, len(fs.scheduling.schedules), 1)
 	})
 }
 

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -15848,3 +15848,86 @@ func Benchmark_FileStoreDeleteMapExists(b *testing.B) {
 	}
 	b.StopTimer()
 }
+
+func TestFileStoreEncodedStreamStateWithSources(t *testing.T) {
+	const iname = "ORIGIN1 > >"
+
+	dir := t.TempDir()
+	fcfg := FileStoreConfig{StoreDir: dir}
+	cfg := StreamConfig{
+		Name:     "SOURCE",
+		Subjects: []string{">"},
+		Storage:  FileStorage,
+		Sources:  []*StreamSource{{Name: "ORIGIN1"}},
+	}
+
+	fs, err := newFileStore(fcfg, cfg)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	hdr := genHeader(nil, JSStreamSource, "ORIGIN1 5 > > foo.a IDENT1")
+	for range 3 {
+		_, _, err = fs.StoreMsg("foo.a", hdr, nil, 0)
+		require_NoError(t, err)
+	}
+	// Interior delete, so the encoding also carries delete blocks, which are read
+	// to the end of the buffer and so must stay last.
+	_, err = fs.RemoveMsg(2)
+	require_NoError(t, err)
+
+	// Without the sources, the encoding stays on the version every server accepts.
+	buf, err := fs.EncodedStreamState(7, false)
+	require_NoError(t, err)
+	require_Equal(t, buf[1], streamStateVersion)
+	require_True(t, IsEncodedStreamState(buf))
+
+	ss, err := DecodeStreamState(buf)
+	require_NoError(t, err)
+	require_Equal(t, len(ss.Sources), 0)
+	require_Equal(t, ss.Failed, 7)
+	require_Len(t, len(ss.Deleted), 1)
+
+	// With the sources, the version is bumped and the state round-trips.
+	buf, err = fs.EncodedStreamState(7, true)
+	require_NoError(t, err)
+	require_Equal(t, buf[1], streamStateVersionSources)
+	require_True(t, IsEncodedStreamState(buf))
+
+	ss, err = DecodeStreamState(buf)
+	require_NoError(t, err)
+	require_Equal(t, ss.Failed, 7)
+	require_Len(t, len(ss.Deleted), 1)
+	require_Len(t, len(ss.Sources), 1)
+	require_Equal(t, ss.Sources[iname].Seq, 5)
+	require_Equal(t, ss.Sources[iname].Ident, "IDENT1")
+
+	fs2, err := newFileStore(FileStoreConfig{StoreDir: t.TempDir()}, cfg)
+	require_NoError(t, err)
+	defer fs2.Stop()
+
+	fs2.ApplySourcesState(ss.Sources)
+	require_Equal(t, fs2.SourcesState()[iname].Seq, 5)
+	require_Equal(t, fs2.SourcesState()[iname].Ident, "IDENT1")
+
+	// The leader's view replaces what we had, it is authoritative even when that
+	// means moving an entry back.
+	fs2.ApplySourcesState(map[string]StreamSourceState{iname: {Seq: 2, Ident: "OLD"}})
+	require_Equal(t, fs2.SourcesState()[iname].Seq, 2)
+	require_Equal(t, fs2.SourcesState()[iname].Ident, "OLD")
+
+	// An empty set says nothing, so it leaves what we have alone.
+	fs2.ApplySourcesState(nil)
+	require_Equal(t, fs2.SourcesState()[iname].Seq, 2)
+
+	// Anything the leader no longer tracks is dropped, but a configured source
+	// stays present as not yet observed.
+	fs2.ApplySourcesState(map[string]StreamSourceState{"OTHER > >": {Seq: 9}})
+	require_Equal(t, fs2.SourcesState()["OTHER > >"].Seq, 9)
+	_, ok := fs2.SourcesState()[iname]
+	require_False(t, ok)
+	fs2.mu.RLock()
+	seeded := fs2.sources[iname]
+	fs2.mu.RUnlock()
+	require_NotNil(t, seeded)
+	require_Equal(t, seeded.Seq, 0)
+}

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -11611,6 +11611,46 @@ func TestFileStoreSourcesRecoveredOneMessageAfterFlush(t *testing.T) {
 	require_Equal(t, fs.SourcesState()["ORIGIN > >"].Seq, last)
 }
 
+func TestFileStoreSourcesRecoveredFromPre210Header(t *testing.T) {
+	dir := t.TempDir()
+	fcfg := FileStoreConfig{StoreDir: dir}
+	cfg := StreamConfig{
+		Name:     "SOURCE",
+		Subjects: []string{">"},
+		Storage:  FileStorage,
+		Sources:  []*StreamSource{{Name: "ORIGIN"}},
+	}
+
+	fs, err := newFileStore(fcfg, cfg)
+	require_NoError(t, err)
+
+	// A modern header first, purely so an index exists on disk and recovery takes
+	// the scan path rather than bailing out.
+	hdr := genHeader(nil, JSStreamSource, "ORIGIN 1 > > foo.bar")
+	_, _, err = fs.StoreMsg("foo.bar", hdr, nil, 0)
+	require_NoError(t, err)
+	require_NoError(t, fs.writeFullState())
+
+	fn := filepath.Join(dir, sourcesStreamStateFile)
+	outdated, err := os.ReadFile(fn)
+	require_NoError(t, err)
+
+	// The message that lands after the flush carries a pre-2.10 header, which has
+	// no index name. Only the stream-name fallback in the scan can match it.
+	const last = 9
+	hdr = genHeader(nil, JSStreamSource, fmt.Sprintf("ORIGIN %d", last))
+	_, _, err = fs.StoreMsg("foo.bar", hdr, nil, 0)
+	require_NoError(t, err)
+	require_NoError(t, fs.Stop())
+	require_NoError(t, os.WriteFile(fn, outdated, defaultFilePerms))
+
+	fs, err = newFileStore(fcfg, cfg)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	require_Equal(t, fs.SourcesState()["ORIGIN > >"].Seq, last)
+}
+
 func TestFileStoreCorruptedNonOrderedSequences(t *testing.T) {
 	for _, test := range []struct {
 		title   string

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -612,6 +612,12 @@ func checkMsgHeadersPreClusteredProposal(
 			}
 			mset.ddMu.Unlock()
 		}
+
+		// Non-sourced messages aren't allowed to have the stream source header.
+		if !sourced && len(sliceHeader(JSStreamSource, hdr)) > 0 {
+			apiErr := NewJSMessageSourceHdrNotAllowedError()
+			return hdr, msg, 0, apiErr, apiErr
+		}
 	}
 
 	// Apply increment for counter.

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -622,6 +622,12 @@ func checkMsgHeadersPreClusteredProposal(
 			}
 			mset.ddMu.Unlock()
 		}
+
+		// Non-sourced messages aren't allowed to have the stream source header.
+		if !sourced && len(sliceHeader(JSStreamSource, hdr)) > 0 {
+			apiErr := NewJSMessageSourceHdrNotAllowedError()
+			return hdr, msg, 0, apiErr, apiErr
+		}
 	}
 
 	// Apply increment for counter.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -11757,7 +11757,10 @@ func (mset *stream) stateSnapshot() []byte {
 func (mset *stream) stateSnapshotLocked() []byte {
 	// Decide if we can support the new style of stream snapshots.
 	if mset.supportsBinarySnapshotLocked() {
-		snap, err := mset.store.EncodedStreamState(mset.getCLFS())
+		// Only include the sourcing state once enabled, a peer that doesn't accept
+		// the encoding rejects the whole snapshot.
+		withSources := mset.srv.getOpts().getFeatureFlag(FeatureFlagJsSnapshotSources)
+		snap, err := mset.store.EncodedStreamState(mset.getCLFS(), withSources)
 		if err != nil {
 			return nil
 		}
@@ -12120,6 +12123,9 @@ var (
 
 // Process a stream snapshot.
 func (mset *stream) processSnapshot(snap *StreamReplicatedState, index uint64) (e error) {
+	// Adopt the leader's sourcing state, we can't always derive it locally.
+	mset.store.ApplySourcesState(snap.Sources)
+
 	// Update any deletes, etc.
 	if err := mset.processSnapshotDeletes(snap); err != nil {
 		return err
@@ -12146,6 +12152,10 @@ func (mset *stream) processSnapshot(snap *StreamReplicatedState, index uint64) (
 			n.ResumeApply()
 		}
 	}()
+
+	// Adopt the leader's sourcing state, we can't always derive it locally.
+	// Do it at the very end, so we catch up messages first (if any) and apply the snapshot state after.
+	defer mset.store.ApplySourcesState(snap.Sources)
 
 	// Bug that would cause this to be empty on stream update.
 	if subject == _EMPTY_ {

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -14137,3 +14137,110 @@ func TestJetStreamClusterMigrationStatusReportedInClusterInfo(t *testing.T) {
 	ci = js.clusterInfo(rg)
 	require_True(t, ci.Desired == nil)
 }
+
+// The sourcing state outlives the messages it was collected from, so unlike other
+// per-message derived state it can't always be rebuilt from what's replicated. A
+// replica that catches up over a stream whose sourced messages are already gone
+// never sees the headers that carried the source's position, and would resume
+// sourcing from an earlier point once it becomes leader.
+func TestJetStreamClusterSourcesStateSnapshot(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		title := "Disabled"
+		if enabled {
+			title = "Enabled"
+		}
+		t.Run(title, func(t *testing.T) {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+
+			for _, s := range c.servers {
+				s.optsMu.Lock()
+				s.opts.FeatureFlags = map[string]bool{FeatureFlagJsSnapshotSources: enabled}
+				s.optsMu.Unlock()
+			}
+
+			nc, js := jsClientConnect(t, c.randomServer())
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     "ORIGIN",
+				Subjects: []string{"foo"},
+				Replicas: 3,
+			})
+			require_NoError(t, err)
+
+			// Start at R1, so the other peers never take part in the sourcing.
+			cfg := &nats.StreamConfig{
+				Name:     "SOURCE",
+				Sources:  []*nats.StreamSource{{Name: "ORIGIN"}},
+				Replicas: 1,
+			}
+			_, err = js.AddStream(cfg)
+			require_NoError(t, err)
+
+			const total = 5
+			for range total {
+				_, err = js.Publish("foo", nil)
+				require_NoError(t, err)
+			}
+
+			c.waitOnStreamLeader(globalAccountName, "SOURCE")
+			sl := c.streamLeader(globalAccountName, "SOURCE")
+			mset, err := sl.globalAccount().lookupStream("SOURCE")
+			require_NoError(t, err)
+
+			checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+				if msgs := mset.store.State().Msgs; msgs != total {
+					return fmt.Errorf("expected %d messages, got %d", total, msgs)
+				}
+				return nil
+			})
+
+			const iname = "ORIGIN > >"
+			require_Equal(t, mset.store.SourcesState()[iname].Seq, total)
+
+			// Purge. The tracked state deliberately survives, but the messages that
+			// established it are gone, so it can no longer be derived by a scan.
+			_, err = mset.purge(nil)
+			require_NoError(t, err)
+			require_Equal(t, mset.store.State().Msgs, 0)
+			require_Equal(t, mset.store.SourcesState()[iname].Seq, total)
+
+			// Scale out. The added replicas catch up over an emptied stream, so they
+			// never see the headers that carried the source's position.
+			cfg.Replicas = 3
+			_, err = js.UpdateStream(cfg)
+			require_NoError(t, err)
+			c.waitOnStreamLeader(globalAccountName, "SOURCE")
+			for _, s := range c.servers {
+				c.waitOnStreamCurrent(s, globalAccountName, "SOURCE")
+			}
+
+			var known int
+			checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+				known = 0
+				for _, s := range c.servers {
+					m, err := s.globalAccount().lookupStream("SOURCE")
+					if err != nil {
+						return err
+					}
+					if m.store.SourcesState()[iname].Seq == total {
+						known++
+					}
+				}
+				if enabled && known != 3 {
+					return fmt.Errorf("expected all 3 replicas to know the source position, got %d", known)
+				}
+				return nil
+			})
+
+			if enabled {
+				// The snapshot carried it, so every replica agrees.
+				require_Equal(t, known, 3)
+			} else {
+				// Only the replica that did the sourcing knows where to resume.
+				require_Equal(t, known, 1)
+			}
+		})
+	}
+}

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -368,6 +368,9 @@ const (
 	// JSMessageSchedulesTimeZoneInvalidErr message schedules time zone is invalid
 	JSMessageSchedulesTimeZoneInvalidErr ErrorIdentifier = 10223
 
+	// JSMessageSourceHdrNotAllowedErr message stream source header is not allowed
+	JSMessageSourceHdrNotAllowedErr ErrorIdentifier = 10224
+
 	// JSMessageTTLDisabledErr per-message TTL is disabled
 	JSMessageTTLDisabledErr ErrorIdentifier = 10166
 
@@ -795,6 +798,7 @@ var (
 		JSMessageSchedulesTTLInvalidErr:              {Code: 400, ErrCode: 10191, Description: "message schedules invalid per-message TTL"},
 		JSMessageSchedulesTargetInvalidErr:           {Code: 400, ErrCode: 10190, Description: "message schedules target is invalid"},
 		JSMessageSchedulesTimeZoneInvalidErr:         {Code: 400, ErrCode: 10223, Description: "message schedules time zone is invalid"},
+		JSMessageSourceHdrNotAllowedErr:              {Code: 400, ErrCode: 10224, Description: "message stream source header is not allowed"},
 		JSMessageTTLDisabledErr:                      {Code: 400, ErrCode: 10166, Description: "per-message TTL is disabled"},
 		JSMessageTTLInvalidErr:                       {Code: 400, ErrCode: 10165, Description: "invalid per-message TTL"},
 		JSMirrorConsumerRequiresAckFCErr:             {Code: 400, ErrCode: 10214, Description: "stream mirror consumer requires flow control ack policy"},
@@ -2225,6 +2229,16 @@ func NewJSMessageSchedulesTimeZoneInvalidError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSMessageSchedulesTimeZoneInvalidErr]
+}
+
+// NewJSMessageSourceHdrNotAllowedError creates a new JSMessageSourceHdrNotAllowedErr error: "message stream source header is not allowed"
+func NewJSMessageSourceHdrNotAllowedError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMessageSourceHdrNotAllowedErr]
 }
 
 // NewJSMessageTTLDisabledError creates a new JSMessageTTLDisabledErr error: "per-message TTL is disabled"

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -374,6 +374,9 @@ const (
 	// JSMessageSchedulesTimeZoneInvalidErr message schedules time zone is invalid
 	JSMessageSchedulesTimeZoneInvalidErr ErrorIdentifier = 10223
 
+	// JSMessageSourceHdrNotAllowedErr message stream source header is not allowed
+	JSMessageSourceHdrNotAllowedErr ErrorIdentifier = 10227
+
 	// JSMessageTTLDisabledErr per-message TTL is disabled
 	JSMessageTTLDisabledErr ErrorIdentifier = 10166
 
@@ -806,6 +809,7 @@ var (
 		JSMessageSchedulesTTLInvalidErr:              {Code: 400, ErrCode: 10191, Description: "message schedules invalid per-message TTL"},
 		JSMessageSchedulesTargetInvalidErr:           {Code: 400, ErrCode: 10190, Description: "message schedules target is invalid"},
 		JSMessageSchedulesTimeZoneInvalidErr:         {Code: 400, ErrCode: 10223, Description: "message schedules time zone is invalid"},
+		JSMessageSourceHdrNotAllowedErr:              {Code: 400, ErrCode: 10227, Description: "message stream source header is not allowed"},
 		JSMessageTTLDisabledErr:                      {Code: 400, ErrCode: 10166, Description: "per-message TTL is disabled"},
 		JSMessageTTLInvalidErr:                       {Code: 400, ErrCode: 10165, Description: "invalid per-message TTL"},
 		JSMirrorConsumerRequiresAckFCErr:             {Code: 400, ErrCode: 10214, Description: "stream mirror consumer requires flow control ack policy"},
@@ -2269,6 +2273,16 @@ func NewJSMessageSchedulesTimeZoneInvalidError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSMessageSchedulesTimeZoneInvalidErr]
+}
+
+// NewJSMessageSourceHdrNotAllowedError creates a new JSMessageSourceHdrNotAllowedErr error: "message stream source header is not allowed"
+func NewJSMessageSourceHdrNotAllowedError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSMessageSourceHdrNotAllowedErr]
 }
 
 // NewJSMessageTTLDisabledError creates a new JSMessageTTLDisabledErr error: "per-message TTL is disabled"

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -24002,6 +24002,142 @@ func TestJetStreamDurableStreamSourcesWithUniqueConsumerNames(t *testing.T) {
 	})
 }
 
+func TestJetStreamSourcesState(t *testing.T) {
+	test := func(t *testing.T, storage nats.StorageType) {
+		s := RunBasicJetStreamServer(t)
+		defer s.Shutdown()
+		port := s.getOpts().Port
+		sd := s.JetStreamConfig().StoreDir
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     "ORIGIN",
+			Storage:  storage,
+			Subjects: []string{"foo"},
+		})
+		require_NoError(t, err)
+
+		cfg := &nats.StreamConfig{
+			Name:    "SOURCE",
+			Storage: storage,
+			Sources: []*nats.StreamSource{{Name: "ORIGIN"}},
+		}
+		_, err = js.AddStream(cfg)
+		require_NoError(t, err)
+
+		mset, err := s.globalAccount().lookupStream("SOURCE")
+		require_NoError(t, err)
+		store := mset.Store()
+		state := store.SourcesState()
+		require_True(t, state == nil)
+
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			if msgs := store.State().Msgs; msgs != 1 {
+				return fmt.Errorf("expected 1 message, got %d", msgs)
+			}
+			return nil
+		})
+		state = store.SourcesState()
+		require_NotNil(t, state)
+		require_Equal(t, state["ORIGIN > >"], 1)
+
+		if storage == nats.FileStorage {
+			s.Shutdown()
+			s = RunJetStreamServerOnPort(port, sd)
+			defer s.Shutdown()
+
+			nc.Close()
+			nc, js = jsClientConnect(t, s)
+			defer nc.Close()
+
+			mset, err = s.globalAccount().lookupStream("SOURCE")
+			require_NoError(t, err)
+			store = mset.Store()
+			state = store.SourcesState()
+			require_NotNil(t, state)
+			require_Equal(t, state["ORIGIN > >"], 1)
+		}
+
+		cfg.Sources = nil
+		_, err = js.UpdateStream(cfg)
+		require_NoError(t, err)
+		state = store.SourcesState()
+		require_True(t, state == nil)
+	}
+
+	t.Run("File", func(t *testing.T) { test(t, nats.FileStorage) })
+	t.Run("Memory", func(t *testing.T) { test(t, nats.MemoryStorage) })
+}
+
+func TestJetStreamSourcesStateResumesAfterPurge(t *testing.T) {
+	test := func(t *testing.T, storage nats.StorageType) {
+		s := RunBasicJetStreamServer(t)
+		defer s.Shutdown()
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     "ORIGIN",
+			Storage:  storage,
+			Subjects: []string{"foo"},
+		})
+		require_NoError(t, err)
+
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:    "SOURCE",
+			Storage: storage,
+			Sources: []*nats.StreamSource{{Name: "ORIGIN"}},
+		})
+		require_NoError(t, err)
+
+		// Publish a handful of messages and wait for them to be sourced over.
+		const total = 5
+		for range total {
+			_, err = js.Publish("foo", nil)
+			require_NoError(t, err)
+		}
+
+		mset, err := s.globalAccount().lookupStream("SOURCE")
+		require_NoError(t, err)
+		store := mset.Store()
+
+		checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+			if msgs := store.State().Msgs; msgs != total {
+				return fmt.Errorf("expected %d messages, got %d", total, msgs)
+			}
+			return nil
+		})
+
+		const iname = "ORIGIN > >"
+		require_Equal(t, store.SourcesState()[iname], total)
+
+		// Purge all destination messages. The persisted source state must
+		// survive this so we can resume rather than start over.
+		_, err = mset.purge(nil)
+		require_NoError(t, err)
+		require_Equal(t, store.State().Msgs, 0)
+		require_Equal(t, store.SourcesState()[iname], total)
+
+		// Simulate the restart / leader election path that recomputes the
+		// per-source starting sequence on an emptied store.
+		mset.mu.Lock()
+		mset.startingSequenceForSources()
+		si := mset.sources[iname]
+		mset.mu.Unlock()
+
+		require_NotNil(t, si)
+		require_Equal(t, si.sseq, total)
+	}
+
+	t.Run("File", func(t *testing.T) { test(t, nats.FileStorage) })
+	t.Run("Memory", func(t *testing.T) { test(t, nats.MemoryStorage) })
+}
+
 func TestJetStreamClusterInfoDoesNotBlockJSMutex(t *testing.T) {
 	// Use a real raft node with its RWMutex held to simulate a Raft
 	// runloop blocked during vote processing, e.g. by dios. clusterInfo

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -24427,3 +24427,35 @@ func TestJetStreamJSAckSuffixCorruption(t *testing.T) {
 	receiver.route = &route{}
 	require_NoError(t, receiver.parse(frame))
 }
+
+func TestJetStreamSourceHeaderNotAllowedIfNotSourced(t *testing.T) {
+	test := func(t *testing.T, replicas int) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", replicas)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     "TEST",
+			Subjects: []string{"foo"},
+			Replicas: replicas,
+		})
+		require_NoError(t, err)
+
+		m := nats.NewMsg("foo")
+		m.Header.Set("Nats-Stream-Source", "bar")
+		_, err = js.PublishMsg(m)
+		require_Error(t, err, NewJSMessageSourceHdrNotAllowedError())
+	}
+
+	t.Run("R1", func(t *testing.T) { test(t, 1) })
+	t.Run("R3", func(t *testing.T) { test(t, 3) })
+}

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -9832,15 +9832,14 @@ func TestJetStreamSourceBasics(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// fake a message that would have been sourced with pre 2.10
-	msg := nats.NewMsg("A.A")
+	// Fake a message that would have been sourced with pre 2.10, as if it
+	// already existed in B's store from an old server.
+	mset, err := s.globalAccount().lookupStream("B")
+	require_NoError(t, err)
 	// pre 2.10 header format just stream name and sequence number
-	msg.Header.Set(JSStreamSource, "A 1")
-	msg.Data = []byte("OK")
-
-	if _, err := js.PublishMsg(msg); err != nil {
-		t.Fatalf("Unexpected publish error: %v", err)
-	}
+	srcHdr := genHeader(nil, JSStreamSource, "A 1")
+	_, _, err = mset.store.StoreMsg("A.A", srcHdr, []byte("OK"), 0)
+	require_NoError(t, err)
 
 	bConfig.Sources = []*nats.StreamSource{{Name: "A"}}
 	if _, err := js.UpdateStream(&bConfig); err != nil {
@@ -9855,6 +9854,21 @@ func TestJetStreamSourceBasics(t *testing.T) {
 		}
 		return nil
 	})
+
+	// The pre 2.10 sourced message must be honored: B should hold the faked
+	// A.A plus only the newly sourced A.B, not a re-sourced copy of A.A.
+	if m, err := js.GetMsg("B", 1); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	} else if m.Subject != "A.A" {
+		t.Fatalf("Expected subject 'A.A' and got %s", m.Subject)
+	} else if shdr := m.Header.Get(JSStreamSource); shdr != "A 1" {
+		t.Fatalf("Expected pre 2.10 source header 'A 1', got %q", shdr)
+	}
+	if m, err := js.GetMsg("B", 2); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	} else if m.Subject != "A.B" {
+		t.Fatalf("Expected subject 'A.B' and got %s", m.Subject)
+	}
 }
 
 func TestJetStreamSourceWorkingQueueWithLimit(t *testing.T) {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -25206,6 +25206,51 @@ func TestJetStreamSourcesStateStartingSequence(t *testing.T) {
 	})
 }
 
+func TestJetStreamSourcesStateAddedSourceUsesAdoptedState(t *testing.T) {
+	test := func(t *testing.T, storage nats.StorageType) {
+		s := RunBasicJetStreamServer(t)
+		defer s.Shutdown()
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		cfg := &nats.StreamConfig{
+			Name:    "SOURCE",
+			Storage: storage,
+			Sources: []*nats.StreamSource{{Name: "ORIGIN1"}},
+		}
+		_, err := js.AddStream(cfg)
+		require_NoError(t, err)
+
+		mset, err := s.globalAccount().lookupStream("SOURCE")
+		require_NoError(t, err)
+
+		// Adopt a leader's sourcing state that already covers ORIGIN2, which this
+		// stream's own config doesn't have yet. That is what a replica is left
+		// holding when it installs a snapshot before the meta layer adds the
+		// source, and the store has no messages to derive the position from.
+		mset.store.ApplySourcesState(map[string]StreamSourceState{
+			"ORIGIN2 > >": {Seq: 7, Ident: "IDENT2"},
+		})
+
+		// Adding the source has to reuse that state rather than start over.
+		cfg.Sources = append(cfg.Sources, &nats.StreamSource{Name: "ORIGIN2"})
+		_, err = js.UpdateStream(cfg)
+		require_NoError(t, err)
+
+		mset.mu.RLock()
+		si := mset.sources["ORIGIN2 > >"]
+		mset.mu.RUnlock()
+
+		require_NotNil(t, si)
+		require_Equal(t, si.sseq, 7)
+		require_Equal(t, si.ident, "IDENT2")
+	}
+
+	t.Run("File", func(t *testing.T) { test(t, nats.FileStorage) })
+	t.Run("Memory", func(t *testing.T) { test(t, nats.MemoryStorage) })
+}
+
 func TestJetStreamClusterInfoDoesNotBlockJSMutex(t *testing.T) {
 	// Use a real raft node with its RWMutex held to simulate a Raft
 	// runloop blocked during vote processing, e.g. by dios. clusterInfo

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -10817,15 +10817,14 @@ func TestJetStreamSourceBasics(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// fake a message that would have been sourced with pre 2.10
-	msg := nats.NewMsg("A.A")
+	// Fake a message that would have been sourced with pre 2.10, as if it
+	// already existed in B's store from an old server.
+	mset, err := s.globalAccount().lookupStream("B")
+	require_NoError(t, err)
 	// pre 2.10 header format just stream name and sequence number
-	msg.Header.Set(JSStreamSource, "A 1")
-	msg.Data = []byte("OK")
-
-	if _, err := js.PublishMsg(msg); err != nil {
-		t.Fatalf("Unexpected publish error: %v", err)
-	}
+	srcHdr := genHeader(nil, JSStreamSource, "A 1")
+	_, _, err = mset.store.StoreMsg("A.A", srcHdr, []byte("OK"), 0)
+	require_NoError(t, err)
 
 	bConfig.Sources = []*nats.StreamSource{{Name: "A"}}
 	if _, err := js.UpdateStream(&bConfig); err != nil {
@@ -10840,6 +10839,21 @@ func TestJetStreamSourceBasics(t *testing.T) {
 		}
 		return nil
 	})
+
+	// The pre 2.10 sourced message must be honored: B should hold the faked
+	// A.A plus only the newly sourced A.B, not a re-sourced copy of A.A.
+	if m, err := js.GetMsg("B", 1); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	} else if m.Subject != "A.A" {
+		t.Fatalf("Expected subject 'A.A' and got %s", m.Subject)
+	} else if shdr := m.Header.Get(JSStreamSource); shdr != "A 1" {
+		t.Fatalf("Expected pre 2.10 source header 'A 1', got %q", shdr)
+	}
+	if m, err := js.GetMsg("B", 2); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	} else if m.Subject != "A.B" {
+		t.Fatalf("Expected subject 'A.B' and got %s", m.Subject)
+	}
 }
 
 func TestJetStreamSourceWorkingQueueWithLimit(t *testing.T) {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -25038,6 +25038,160 @@ func TestJetStreamDurableStreamSourcesWithUniqueConsumerNames(t *testing.T) {
 	})
 }
 
+func TestJetStreamSourcesState(t *testing.T) {
+	test := func(t *testing.T, storage nats.StorageType) {
+		s := RunBasicJetStreamServer(t)
+		defer s.Shutdown()
+		port := s.getOpts().Port
+		sd := s.JetStreamConfig().StoreDir
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     "ORIGIN",
+			Storage:  storage,
+			Subjects: []string{"foo"},
+		})
+		require_NoError(t, err)
+
+		cfg := &nats.StreamConfig{
+			Name:    "SOURCE",
+			Storage: storage,
+			Sources: []*nats.StreamSource{{Name: "ORIGIN"}},
+		}
+		_, err = js.AddStream(cfg)
+		require_NoError(t, err)
+
+		mset, err := s.globalAccount().lookupStream("SOURCE")
+		require_NoError(t, err)
+		store := mset.Store()
+		state := store.SourcesState()
+		require_True(t, state == nil)
+
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			if msgs := store.State().Msgs; msgs != 1 {
+				return fmt.Errorf("expected 1 message, got %d", msgs)
+			}
+			return nil
+		})
+		state = store.SourcesState()
+		require_NotNil(t, state)
+		require_Equal(t, state["ORIGIN > >"].Seq, 1)
+
+		if storage == nats.FileStorage {
+			s.Shutdown()
+			s = RunJetStreamServerOnPort(port, sd)
+			defer s.Shutdown()
+
+			nc.Close()
+			nc, js = jsClientConnect(t, s)
+			defer nc.Close()
+
+			mset, err = s.globalAccount().lookupStream("SOURCE")
+			require_NoError(t, err)
+			store = mset.Store()
+			state = store.SourcesState()
+			require_NotNil(t, state)
+			require_Equal(t, state["ORIGIN > >"].Seq, 1)
+		}
+
+		cfg.Sources = nil
+		_, err = js.UpdateStream(cfg)
+		require_NoError(t, err)
+		state = store.SourcesState()
+		require_True(t, state == nil)
+	}
+
+	t.Run("File", func(t *testing.T) { test(t, nats.FileStorage) })
+	t.Run("Memory", func(t *testing.T) { test(t, nats.MemoryStorage) })
+}
+
+func TestJetStreamSourcesStateStartingSequence(t *testing.T) {
+	test := func(t *testing.T, storage nats.StorageType, purge bool) {
+		s := RunBasicJetStreamServer(t)
+		defer s.Shutdown()
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     "ORIGIN",
+			Storage:  storage,
+			Subjects: []string{"foo"},
+		})
+		require_NoError(t, err)
+
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:    "SOURCE",
+			Storage: storage,
+			Sources: []*nats.StreamSource{{Name: "ORIGIN"}},
+		})
+		require_NoError(t, err)
+
+		const total = 5
+		for range total {
+			_, err = js.Publish("foo", nil)
+			require_NoError(t, err)
+		}
+
+		mset, err := s.globalAccount().lookupStream("SOURCE")
+		require_NoError(t, err)
+		store := mset.Store()
+
+		checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+			if msgs := store.State().Msgs; msgs != total {
+				return fmt.Errorf("expected %d messages, got %d", total, msgs)
+			}
+			return nil
+		})
+
+		origin, err := s.globalAccount().lookupStream("ORIGIN")
+		require_NoError(t, err)
+		ident := origin.identity()
+		require_NotEqual(t, ident, _EMPTY_)
+
+		const iname = "ORIGIN > >"
+		// The source's identity must be tracked alongside its sequence.
+		require_Equal(t, store.SourcesState()[iname].Seq, total)
+		require_Equal(t, store.SourcesState()[iname].Ident, ident)
+
+		if purge {
+			// Purge all destination messages. The tracked source state must survive
+			// this so we can resume rather than start over.
+			_, err = mset.purge(nil)
+			require_NoError(t, err)
+			require_Equal(t, store.State().Msgs, 0)
+			require_Equal(t, store.SourcesState()[iname].Seq, total)
+			require_Equal(t, store.SourcesState()[iname].Ident, ident)
+		}
+
+		// Both sequence and identity must survive the recovery path that runs on
+		// restart and on leader election. Without the identity a recreated origin
+		// goes undetected, and we would resume from a sequence that means nothing
+		// in the new stream.
+		mset.mu.Lock()
+		mset.startingSequenceForSources()
+		si := mset.sources[iname]
+		mset.mu.Unlock()
+
+		require_NotNil(t, si)
+		require_Equal(t, si.sseq, total)
+		require_Equal(t, si.ident, ident)
+	}
+
+	t.Run("File", func(t *testing.T) {
+		t.Run("Fresh", func(t *testing.T) { test(t, nats.FileStorage, false) })
+		t.Run("AfterPurge", func(t *testing.T) { test(t, nats.FileStorage, true) })
+	})
+	t.Run("Memory", func(t *testing.T) {
+		t.Run("Fresh", func(t *testing.T) { test(t, nats.MemoryStorage, false) })
+		t.Run("AfterPurge", func(t *testing.T) { test(t, nats.MemoryStorage, true) })
+	})
+}
+
 func TestJetStreamClusterInfoDoesNotBlockJSMutex(t *testing.T) {
 	// Use a real raft node with its RWMutex held to simulate a Raft
 	// runloop blocked during vote processing, e.g. by dios. clusterInfo

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -26483,3 +26483,35 @@ func TestJetStreamStreamRecoverReplicasNotSupported(t *testing.T) {
 	_, err = s.GlobalAccount().lookupStream("TEST")
 	require_Error(t, err, NewJSStreamNotFoundError())
 }
+
+func TestJetStreamSourceHeaderNotAllowedIfNotSourced(t *testing.T) {
+	test := func(t *testing.T, replicas int) {
+		var s *Server
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c := createJetStreamClusterExplicit(t, "R3S", replicas)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     "TEST",
+			Subjects: []string{"foo"},
+			Replicas: replicas,
+		})
+		require_NoError(t, err)
+
+		m := nats.NewMsg("foo")
+		m.Header.Set("Nats-Stream-Source", "bar")
+		_, err = js.PublishMsg(m)
+		require_Error(t, err, NewJSMessageSourceHdrNotAllowedError())
+	}
+
+	t.Run("R1", func(t *testing.T) { test(t, 1) })
+	t.Run("R3", func(t *testing.T) { test(t, 3) })
+}

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -49,6 +49,7 @@ type memStore struct {
 	ttls        *thw.HashWheel
 	scheduling  *MsgScheduling
 	sdm         *SDMMeta
+	sources     map[string]uint64
 }
 
 func newMemStore(cfg *StreamConfig) (*memStore, error) {
@@ -74,6 +75,14 @@ func newMemStore(cfg *StreamConfig) (*memStore, error) {
 	if cfg.FirstSeq > 0 {
 		if _, err := ms.purge(cfg.FirstSeq); err != nil {
 			return nil, err
+		}
+	}
+	// Seed configured sources (zero sequence == configured but not yet observed),
+	// so storeRawMsg can validate headers against the configured set.
+	if len(cfg.Sources) > 0 {
+		ms.sources = make(map[string]uint64, len(cfg.Sources))
+		for _, ssi := range cfg.Sources {
+			ms.sources[ssi.composeIName()] = 0
 		}
 	}
 
@@ -104,6 +113,35 @@ func (ms *memStore) UpdateConfig(cfg *StreamConfig) error {
 	} else if !cfg.AllowMsgSchedules && ms.scheduling != nil {
 		ms.scheduling = nil
 	}
+
+	// Refresh the source tracking to match the new config.
+	if len(cfg.Sources) == 0 {
+		// If no sources remain, clear.
+		ms.sources = nil
+	} else {
+		// Ensure the map exists even if sources were just added, so storeRawMsg
+		// can validate headers against the configured set.
+		if ms.sources == nil {
+			ms.sources = make(map[string]uint64, len(cfg.Sources))
+		}
+		sources := make(map[string]struct{}, len(cfg.Sources))
+		for _, ssi := range cfg.Sources {
+			sources[ssi.composeIName()] = struct{}{}
+		}
+		// Remove sources that are tracked but no longer exist.
+		for k := range ms.sources {
+			if _, ok := sources[k]; !ok {
+				delete(ms.sources, k)
+			}
+		}
+		// Seed sources that aren't in the map yet.
+		for k := range sources {
+			if _, ok := ms.sources[k]; !ok {
+				ms.sources[k] = 0
+			}
+		}
+	}
+
 	// Limits checks and enforcement.
 	ms.enforceMsgLimit()
 	ms.enforceBytesLimit()
@@ -320,6 +358,16 @@ func (ms *memStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, tt
 			scheduler := getMessageScheduler(hdr)
 			if next, err := time.Parse(time.RFC3339Nano, scheduleNext); err == nil && scheduler != _EMPTY_ {
 				ms.scheduling.update(scheduler, next.UnixNano())
+			}
+		}
+	}
+
+	// Track sources.
+	if len(ms.cfg.Sources) > 0 {
+		if ss := sliceHeader(JSStreamSource, hdr); len(ss) > 0 {
+			_, indexName, sseq := streamAndSeq(bytesToString(ss))
+			if _, ok := ms.sources[indexName]; ok {
+				ms.sources[indexName] = sseq
 			}
 		}
 	}
@@ -913,6 +961,26 @@ func (ms *memStore) subjectsTotalsLocked(filterSubject string) map[string]uint64
 		}
 	})
 	return fst
+}
+
+// SourcesState return sources keys and their last sequences.
+func (ms *memStore) SourcesState() (dst map[string]uint64) {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	if len(ms.sources) == 0 {
+		return nil
+	}
+	// Allocate lazily so that a map containing only seeded (zero) entries returns
+	// nil rather than an empty map; zeros must not leak out of SourcesState.
+	for k, seq := range ms.sources {
+		if seq > 0 {
+			if dst == nil {
+				dst = make(map[string]uint64, 1)
+			}
+			dst[k] = seq
+		}
+	}
+	return dst
 }
 
 // NumPending will return the number of pending messages matching the filter subject starting at sequence.

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -52,6 +52,7 @@ type memStore struct {
 	ttls        *thw.HashWheel
 	scheduling  *MsgScheduling
 	sdm         *SDMMeta
+	sources     map[string]*StreamSourceState
 }
 
 func newMemStore(cfg *StreamConfig) (*memStore, error) {
@@ -85,6 +86,14 @@ func newMemStoreWithMode(cfg *StreamConfig, recovering bool) (*memStore, error) 
 			return nil, err
 		}
 	}
+	// Seed configured sources (zero sequence == configured but not yet observed),
+	// so storeRawMsg can validate headers against the configured set.
+	if len(cfg.Sources) > 0 {
+		ms.sources = make(map[string]*StreamSourceState, len(cfg.Sources))
+		for _, ssi := range cfg.Sources {
+			ms.sources[ssi.composeIName()] = &StreamSourceState{}
+		}
+	}
 
 	// Register with access time service.
 	ats.Register()
@@ -113,6 +122,35 @@ func (ms *memStore) UpdateConfig(cfg *StreamConfig) error {
 	} else if !cfg.AllowMsgSchedules && ms.scheduling != nil {
 		ms.scheduling = nil
 	}
+
+	// Refresh the source tracking to match the new config.
+	if len(cfg.Sources) == 0 {
+		// If no sources remain, clear.
+		ms.sources = nil
+	} else {
+		// Ensure the map exists even if sources were just added, so storeRawMsg
+		// can validate headers against the configured set.
+		if ms.sources == nil {
+			ms.sources = make(map[string]*StreamSourceState, len(cfg.Sources))
+		}
+		sources := make(map[string]struct{}, len(cfg.Sources))
+		for _, ssi := range cfg.Sources {
+			sources[ssi.composeIName()] = struct{}{}
+		}
+		// Remove sources that are tracked but no longer exist.
+		for k := range ms.sources {
+			if _, ok := sources[k]; !ok {
+				delete(ms.sources, k)
+			}
+		}
+		// Seed sources that aren't in the map yet.
+		for k := range sources {
+			if _, ok := ms.sources[k]; !ok {
+				ms.sources[k] = &StreamSourceState{}
+			}
+		}
+	}
+
 	// Limits checks and enforcement.
 	ms.enforceMsgLimit()
 	ms.enforceBytesLimit()
@@ -330,6 +368,16 @@ func (ms *memStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, tt
 			scheduler := getMessageScheduler(hdr)
 			if next, err := time.Parse(time.RFC3339Nano, scheduleNext); err == nil && scheduler != _EMPTY_ {
 				ms.scheduling.update(scheduler, next.UnixNano())
+			}
+		}
+	}
+
+	// Track sources.
+	if len(ms.cfg.Sources) > 0 {
+		if ss := sliceHeader(JSStreamSource, hdr); len(ss) > 0 {
+			_, indexName, sseq, ident := streamAndSeq(bytesToString(ss))
+			if sss, ok := ms.sources[indexName]; ok {
+				sss.Seq, sss.Ident = sseq, ident
 			}
 		}
 	}
@@ -976,6 +1024,26 @@ func (ms *memStore) subjectsTotalsLocked(filterSubject string) map[string]uint64
 		}
 	})
 	return fst
+}
+
+// SourcesState return sources keys and their last known state.
+func (ms *memStore) SourcesState() (dst map[string]StreamSourceState) {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	if len(ms.sources) == 0 {
+		return nil
+	}
+	// Allocate lazily so that a map containing only seeded (zero) entries returns
+	// nil rather than an empty map; zeros must not leak out of SourcesState.
+	for k, ss := range ms.sources {
+		if ss.Seq > 0 {
+			if dst == nil {
+				dst = make(map[string]StreamSourceState, 1)
+			}
+			dst[k] = *ss
+		}
+	}
+	return dst
 }
 
 // NumPending will return the number of pending messages matching the filter subject starting at sequence.

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -1026,6 +1026,27 @@ func (ms *memStore) subjectsTotalsLocked(filterSubject string) map[string]uint64
 	return fst
 }
 
+// ApplySourcesState replaces the tracked sourcing state with the leader's.
+func (ms *memStore) ApplySourcesState(sources map[string]StreamSourceState) {
+	if len(sources) == 0 {
+		return
+	}
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if ms.sources == nil {
+		return
+	}
+	clear(ms.sources)
+	for name, ss := range sources {
+		ms.sources[name] = &StreamSourceState{Seq: ss.Seq, Ident: ss.Ident}
+	}
+	for _, ssi := range ms.cfg.Sources {
+		if iname := ssi.composeIName(); ms.sources[iname] == nil {
+			ms.sources[iname] = &StreamSourceState{}
+		}
+	}
+}
+
 // SourcesState return sources keys and their last known state.
 func (ms *memStore) SourcesState() (dst map[string]StreamSourceState) {
 	ms.mu.RLock()
@@ -2549,9 +2570,12 @@ func (ms *memStore) Snapshot(_ time.Duration, _, _ bool) (*SnapshotResult, error
 }
 
 // Binary encoded state snapshot, >= v2.10 server.
-func (ms *memStore) EncodedStreamState(failed uint64) ([]byte, error) {
+func (ms *memStore) EncodedStreamState(failed uint64, withSources bool) ([]byte, error) {
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
+
+	withSources = withSources && len(ms.sources) > 0
+	version := streamStateVersion
 
 	// Quick calculate num deleted.
 	numDeleted := int((ms.state.LastSeq - ms.state.FirstSeq + 1) - ms.state.Msgs)
@@ -2565,17 +2589,49 @@ func (ms *memStore) EncodedStreamState(failed uint64) ([]byte, error) {
 		uvarintLen(ms.state.FirstSeq) + uvarintLen(ms.state.LastSeq) +
 		uvarintLen(failed) + uvarintLen(uint64(numDeleted))
 
+	var numSources uint64
+	var sourcesLen int
+	if withSources {
+		for name, ss := range ms.sources {
+			if ss.Seq == 0 {
+				continue
+			}
+			numSources++
+			// Length prefix + source bytes + seq varint +
+			// length prefix + identity bytes.
+			sourcesLen += uvarintLen(uint64(len(name))) + len(name) + uvarintLen(ss.Seq) +
+				uvarintLen(uint64(len(ss.Ident))) + len(ss.Ident)
+		}
+		// Nothing observed yet, then there is nothing to carry.
+		if withSources = numSources > 0; withSources {
+			total += uvarintLen(numSources) + sourcesLen
+			version = streamStateVersionSources
+		}
+	}
 	if numDeleted > 0 {
 		total += ms.dmap.EncodeLen()
 	}
 
 	b := make([]byte, 0, total)
-	b = append(b, streamStateMagic, streamStateVersion)
+	b = append(b, streamStateMagic, version)
 	b = binary.AppendUvarint(b, ms.state.Msgs)
 	b = binary.AppendUvarint(b, ms.state.Bytes)
 	b = binary.AppendUvarint(b, ms.state.FirstSeq)
 	b = binary.AppendUvarint(b, ms.state.LastSeq)
 	b = binary.AppendUvarint(b, failed)
+	if withSources {
+		b = binary.AppendUvarint(b, numSources)
+		for name, ss := range ms.sources {
+			if ss.Seq == 0 {
+				continue
+			}
+			b = binary.AppendUvarint(b, uint64(len(name)))
+			b = append(b, name...)
+			b = binary.AppendUvarint(b, ss.Seq)
+			b = binary.AppendUvarint(b, uint64(len(ss.Ident)))
+			b = append(b, ss.Ident...)
+		}
+	}
 	b = binary.AppendUvarint(b, uint64(numDeleted))
 
 	if numDeleted > 0 {

--- a/server/norace_2_test.go
+++ b/server/norace_2_test.go
@@ -439,7 +439,7 @@ func TestNoRaceBinaryStreamSnapshotEncodingBasic(t *testing.T) {
 	mset, err := s.GlobalAccount().lookupStream("TEST")
 	require_NoError(t, err)
 
-	snap, err := mset.store.EncodedStreamState(0)
+	snap, err := mset.store.EncodedStreamState(0, false)
 	require_NoError(t, err)
 
 	// Now decode the snapshot.
@@ -476,7 +476,7 @@ func TestNoRaceFilestoreBinaryStreamSnapshotEncodingLargeGaps(t *testing.T) {
 	// The tombstones from above will only be cleaned up when syncing blocks.
 	fs.syncBlocks()
 
-	snap, err := fs.EncodedStreamState(0)
+	snap, err := fs.EncodedStreamState(0, false)
 	require_NoError(t, err)
 	require_LessThan(t, len(snap), 512)
 
@@ -620,7 +620,7 @@ func TestNoRaceStoreStreamEncoderDecoder(t *testing.T) {
 					continue
 				}
 				start := time.Now()
-				snap, err := gs.EncodedStreamState(0)
+				snap, err := gs.EncodedStreamState(0, false)
 				require_NoError(t, err)
 				elapsed := time.Since(start)
 				// Should take <1ms without race but if CI/CD is slow we will give it a bit of room.

--- a/server/store.go
+++ b/server/store.go
@@ -112,6 +112,7 @@ type StreamStore interface {
 	FilteredState(seq uint64, subject string) (SimpleState, error)
 	SubjectsState(filterSubject string) map[string]SimpleState
 	SubjectsTotals(filterSubject string) map[string]uint64
+	SourcesState() map[string]uint64
 	AllLastSeqs() ([]uint64, error)
 	MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed int) ([]uint64, error)
 	SubjectForSeq(seq uint64) (string, error)

--- a/server/store.go
+++ b/server/store.go
@@ -115,6 +115,7 @@ type StreamStore interface {
 	FilteredState(seq uint64, subject string) (SimpleState, error)
 	SubjectsState(filterSubject string) map[string]SimpleState
 	SubjectsTotals(filterSubject string) map[string]uint64
+	SourcesState() map[string]StreamSourceState
 	AllLastSeqs() ([]uint64, error)
 	MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed int) ([]uint64, error)
 	MultiLastMsgs(filters []string, minSeq, maxSeq uint64, maxAllowed int, cb func(sm *StoreMsg, np uint64) bool) (uint64, uint64, error)

--- a/server/store.go
+++ b/server/store.go
@@ -124,7 +124,8 @@ type StreamStore interface {
 	NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPerSubject bool) (total, validThrough uint64, err error)
 	State() StreamState
 	FastState(*StreamState)
-	EncodedStreamState(failed uint64) (enc []byte, err error)
+	EncodedStreamState(failed uint64, withSources bool) (enc []byte, err error)
+	ApplySourcesState(sources map[string]StreamSourceState)
 	SyncDeleted(dbs DeleteBlocks) error
 	Type() StorageType
 	RegisterStorageUpdates(StorageUpdateHandler)
@@ -213,6 +214,10 @@ const (
 	streamStateMagic = uint8(42)
 	// Version
 	streamStateVersion = uint8(1)
+	// Version that additionally carries the stream's sourcing state. Only emitted
+	// when explicitly enabled, since a server that only understands the previous
+	// version rejects the encoding outright.
+	streamStateVersionSources = uint8(2)
 	// Magic / Identifier for run length encodings.
 	runLengthMagic = uint8(33)
 	// Magic / Identifier for AVL seqsets.
@@ -240,20 +245,27 @@ type StreamReplicatedState struct {
 	LastSeq  uint64
 	Failed   uint64
 	Deleted  DeleteBlocks
+	// Sources is the stream's sourcing state, only present in encodings of
+	// streamStateVersionSources and above. It can't be derived from the messages
+	// alone, since it outlives the messages it was collected from.
+	Sources map[string]StreamSourceState
 }
 
 // Determine if this is an encoded stream state.
 func IsEncodedStreamState(buf []byte) bool {
-	return len(buf) >= hdrLen && buf[0] == streamStateMagic && buf[1] == streamStateVersion
+	return len(buf) >= hdrLen && buf[0] == streamStateMagic &&
+		(buf[1] == streamStateVersion || buf[1] == streamStateVersionSources)
 }
 
 var ErrBadStreamStateEncoding = errors.New("bad stream state encoding")
 
 func DecodeStreamState(buf []byte) (*StreamReplicatedState, error) {
 	ss := &StreamReplicatedState{}
-	if len(buf) < hdrLen || buf[0] != streamStateMagic || buf[1] != streamStateVersion {
+	if len(buf) < hdrLen || buf[0] != streamStateMagic ||
+		(buf[1] != streamStateVersion && buf[1] != streamStateVersionSources) {
 		return nil, ErrBadStreamStateEncoding
 	}
+	withSources := buf[1] == streamStateVersionSources
 	var bi = hdrLen
 
 	readU64 := func() uint64 {
@@ -282,6 +294,42 @@ func DecodeStreamState(buf []byte) (*StreamReplicatedState, error) {
 
 	if parserFailed() {
 		return nil, ErrCorruptStreamState
+	}
+
+	// Sources come before the deleted blocks, since those are read up to the end
+	// of the buffer and can't be followed by anything else.
+	if withSources {
+		numSources := readU64()
+		if parserFailed() {
+			return nil, ErrCorruptStreamState
+		}
+		// Same entry layout as the on-disk sources index, all lengths as varints
+		// since both strings are short.
+		readStr := func() (string, bool) {
+			n := readU64()
+			if parserFailed() || uint64(len(buf)-bi) < n {
+				bi = -1
+				return _EMPTY_, false
+			}
+			s := string(buf[bi : bi+int(n)])
+			bi += int(n)
+			return s, true
+		}
+		for i := uint64(0); i < numSources; i++ {
+			name, ok := readStr()
+			if !ok {
+				return nil, ErrCorruptStreamState
+			}
+			seq := readU64()
+			ident, ok := readStr()
+			if !ok || parserFailed() {
+				return nil, ErrCorruptStreamState
+			}
+			if ss.Sources == nil {
+				ss.Sources = make(map[string]StreamSourceState, numSources)
+			}
+			ss.Sources[name] = StreamSourceState{Seq: seq, Ident: ident}
+		}
 	}
 
 	if numDeleted := readU64(); numDeleted > 0 {

--- a/server/store_test.go
+++ b/server/store_test.go
@@ -1548,3 +1548,58 @@ func Benchmark_StoreMultiLastSeqsManyBlocks(b *testing.B) {
 		run(b, fs)
 	})
 }
+
+func TestStoreSourcesOnlyTracksConfiguredSources(t *testing.T) {
+	testAllStoreAllPermutations(
+		t, false,
+		StreamConfig{
+			Name:     "SOURCE",
+			Subjects: []string{">"},
+			Sources:  []*StreamSource{{Name: "ORIGIN1"}},
+		},
+		func(t *testing.T, fs StreamStore) {
+			h1 := genHeader(nil, JSStreamSource, "ORIGIN1 5 > > foo.a IDENT1")
+			_, _, err := fs.StoreMsg("foo.a", h1, nil, 0)
+			require_NoError(t, err)
+
+			// Only configured sources are seeded into the map, so a header naming one that
+			// isn't configured is not tracked. It is recovered by a scan if it is added.
+			h2 := genHeader(nil, JSStreamSource, "ORIGIN2 7 > > foo.b IDENT2")
+			_, _, err = fs.StoreMsg("foo.b", h2, nil, 0)
+			require_NoError(t, err)
+
+			// Nor is a pre-2.10 header, which carries no index name at all.
+			h3 := genHeader(nil, JSStreamSource, "ORIGIN3 9")
+			_, _, err = fs.StoreMsg("foo.c", h3, nil, 0)
+			require_NoError(t, err)
+
+			state := fs.SourcesState()
+			require_Len(t, len(state), 1)
+			require_Equal(t, state["ORIGIN1 > >"].Seq, 5)
+			require_Equal(t, state["ORIGIN1 > >"].Ident, "IDENT1")
+
+			var tracked int
+			if fss, ok := fs.(*fileStore); ok {
+				fss.mu.RLock()
+				tracked = len(fss.sources)
+				fss.mu.RUnlock()
+			} else if mss, ok := fs.(*memStore); ok {
+				mss.mu.RLock()
+				tracked = len(mss.sources)
+				mss.mu.RUnlock()
+			} else {
+				t.Fatal("unknown store")
+			}
+			require_Equal(t, tracked, 1)
+
+			// A new message should update both the sequence and identity.
+			h4 := genHeader(nil, JSStreamSource, "ORIGIN1 2 > > foo.a IDENT3")
+			_, _, err = fs.StoreMsg("foo.a", h4, nil, 0)
+			require_NoError(t, err)
+			state = fs.SourcesState()
+			require_Len(t, len(state), 1)
+			require_Equal(t, state["ORIGIN1 > >"].Seq, 2)
+			require_Equal(t, state["ORIGIN1 > >"].Ident, "IDENT3")
+		},
+	)
+}

--- a/server/stream.go
+++ b/server/stream.go
@@ -6624,6 +6624,18 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 				}
 				return apiErr
 			}
+
+			// Non-sourced messages aren't allowed to have the stream source header.
+			if !sourced && len(sliceHeader(JSStreamSource, hdr)) > 0 {
+				apiErr := NewJSMessageSourceHdrNotAllowedError()
+				if canRespond {
+					resp.PubAck = &PubAck{Stream: name}
+					resp.Error = apiErr
+					b, _ := json.Marshal(resp)
+					outq.sendMsg(reply, b)
+				}
+				return apiErr
+			}
 		}
 
 		// Dedupe detection. This is done at the cluster level for dedupe detection above the

--- a/server/stream.go
+++ b/server/stream.go
@@ -4582,6 +4582,21 @@ func (mset *stream) setStartingSequenceForSources(iNames map[string]struct{}) {
 		return
 	}
 
+	// Collect known sources state and reuse where possible.
+	sourcesState := mset.store.SourcesState()
+	for iName := range iNames {
+		if sseq, ok := sourcesState[iName]; ok {
+			if si, ok := mset.sources[iName]; ok {
+				si.sseq = sseq
+				si.dseq = 0
+				delete(iNames, iName)
+			}
+		}
+	}
+	if len(iNames) == 0 {
+		return
+	}
+
 	// From the provided list of sources, we build a sublist that contains
 	// the interested filters (including transforms). As we figure out the
 	// starting sequence for each source, we will eliminate the source from
@@ -4618,7 +4633,7 @@ func (mset *stream) setStartingSequenceForSources(iNames map[string]struct{}) {
 	var smv StoreMsg
 	for last := state.LastSeq; ; {
 		sm, seq, err := mset.store.LoadPrevMsgMulti(sl, last, &smv)
-		if err == ErrStoreEOF || err != nil {
+		if err != nil {
 			break
 		}
 		last = seq - 1
@@ -4704,11 +4719,6 @@ func (mset *stream) startingSequenceForSources() {
 	var state StreamState
 	mset.store.FastState(&state)
 
-	// Bail if no messages, meaning no context.
-	if state.Msgs == 0 {
-		return
-	}
-
 	// For short circuiting return.
 	expected := len(mset.cfg.Sources)
 	seqs := make(map[string]uint64)
@@ -4771,10 +4781,28 @@ func (mset *stream) startingSequenceForSources() {
 		}
 	}
 
+	// Collect known sources state and reuse where possible. This persisted
+	// state survives a full purge/expiry of the destination messages. Otherwise,
+	// we would reset every source back to the origin's beginning.
+	sourcesState := mset.store.SourcesState()
+	for iName := range sources {
+		if sseq, ok := sourcesState[iName]; ok {
+			update(iName, sseq)
+		}
+	}
+	if len(seqs) == expected {
+		return
+	}
+
+	// Bail if no messages, meaning no further context to scan for.
+	if state.Msgs == 0 {
+		return
+	}
+
 	var smv StoreMsg
 	for last := state.LastSeq; ; {
 		sm, seq, err := mset.store.LoadPrevMsgMulti(sl, last, &smv)
-		if err == ErrStoreEOF || err != nil {
+		if err != nil {
 			break
 		}
 		last = seq - 1

--- a/server/stream.go
+++ b/server/stream.go
@@ -679,6 +679,17 @@ type msgCounterRunningTotal struct {
 	ops     uint64         // Inflight operations. If this reaches zero, we can remove the running total.
 }
 
+// StreamSourceState is the tracked state for a single stream source, as
+// persisted by the store so it survives a restart or a leader change.
+type StreamSourceState struct {
+	// Seq is the last stream message sequence number seen from the source.
+	Seq uint64
+	// Ident is the identity of the source stream, used to detect that it was
+	// recreated. Empty if the source did not report one, i.e. it is an older
+	// server or a pre-2.10 message header.
+	Ident string
+}
+
 type sourceInfo struct {
 	name  string        // The name of the stream being sourced.
 	iname string        // The unique index name of this particular source.
@@ -4847,6 +4858,24 @@ func (mset *stream) setStartingSequenceForSources(iNames map[string]struct{}) {
 	var state StreamState
 	mset.store.FastState(&state)
 
+	// Collect known sources state and reuse where possible. This persisted state
+	// survives a full purge/expiry of the destination messages, so it has to be
+	// consulted before bailing out below on an emptied store.
+	sourcesState := mset.store.SourcesState()
+	for iName := range iNames {
+		if sss, ok := sourcesState[iName]; ok {
+			if si, ok := mset.sources[iName]; ok {
+				si.sseq = sss.Seq
+				si.dseq = 0
+				si.ident, si.rc = sss.Ident, false
+				delete(iNames, iName)
+			}
+		}
+	}
+	if len(iNames) == 0 {
+		return
+	}
+
 	// Do not reset sseq here so we can remember when purge/expiration happens.
 	if state.Msgs == 0 {
 		for iName := range iNames {
@@ -4896,7 +4925,7 @@ func (mset *stream) setStartingSequenceForSources(iNames map[string]struct{}) {
 	var smv StoreMsg
 	for last := state.LastSeq; ; {
 		sm, seq, err := mset.store.LoadPrevMsgMulti(sl, last, &smv)
-		if err == ErrStoreEOF || err != nil {
+		if err != nil {
 			break
 		}
 		last = seq - 1
@@ -4984,11 +5013,6 @@ func (mset *stream) startingSequenceForSources() {
 	var state StreamState
 	mset.store.FastState(&state)
 
-	// Bail if no messages, meaning no context.
-	if state.Msgs == 0 {
-		return
-	}
-
 	// Generate a list of sources and, from that, a sublist that contains
 	// the interested filters (including transforms). As we figure out the
 	// starting sequence for each source, we will eliminate the source from
@@ -5041,10 +5065,28 @@ func (mset *stream) startingSequenceForSources() {
 		}
 	}
 
+	// Collect known sources state and reuse where possible. This persisted
+	// state survives a full purge/expiry of the destination messages. Otherwise,
+	// we would reset every source back to the origin's beginning.
+	sourcesState := mset.store.SourcesState()
+	for iName := range sources {
+		if sss, ok := sourcesState[iName]; ok {
+			update(iName, sss.Seq, sss.Ident)
+		}
+	}
+	if len(sources) == 0 {
+		return
+	}
+
+	// Bail if no messages, meaning no further context to scan for.
+	if state.Msgs == 0 {
+		return
+	}
+
 	var smv StoreMsg
 	for last := state.LastSeq; ; {
 		sm, seq, err := mset.store.LoadPrevMsgMulti(sl, last, &smv)
-		if err == ErrStoreEOF || err != nil {
+		if err != nil {
 			break
 		}
 		last = seq - 1

--- a/server/stream.go
+++ b/server/stream.go
@@ -6900,6 +6900,18 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 				}
 				return apiErr
 			}
+
+			// Non-sourced messages aren't allowed to have the stream source header.
+			if !sourced && len(sliceHeader(JSStreamSource, hdr)) > 0 {
+				apiErr := NewJSMessageSourceHdrNotAllowedError()
+				if canRespond {
+					resp.PubAck = &PubAck{Stream: name}
+					resp.Error = apiErr
+					b, _ := json.Marshal(resp)
+					outq.sendMsg(reply, b)
+				}
+				return apiErr
+			}
 		}
 
 		// Dedupe detection. This is done at the cluster level for dedupe detection above the


### PR DESCRIPTION
The first commit refactors `fs.recoverTTLState()` and `fs.recoverMsgSchedulingState()`, since if both required recovering that would result in two separate linear scans, instead of one linear scan reused for recovering both.

The second commit introduces indexing for stream sources, which will ensure that backward scanning for pre-existing stream sources is eliminated.
- As messages come in, their `Nats-Stream-Source` is inspected and the source key is mapped to the sequence that's sourced.
- That state is kept in-memory and can be reused by methods like `mset.startingSequenceForSources()` to use the index, and only fall back to backward scanning remaining sources if necessary.
- This index is written to disk as `sources.db` when using file-based streams, similar to the `thw.db` and `sched.db` files.

The approach of having an index that scales by sources versus that scans the stream by messages results in a tremendous performance improvement, especially as streams get larger and the backward scan would otherwise need to reach way further back.

The `sources.db` file is stored at the stream's root, as opposed to in the `msgs` directory, since it should not be removed if the stream is purged:
```diff
  streams/<stream>/
  ├── meta.inf, meta.sum,meta.key
+ ├── sources.db
  ├── msgs/
  │   ├── 1.blk, 2.blk, …
  │   ├── index.db, thw.db, sched.db
  └── obs/
      └── <consumer>/…
```

The third commit adds a check preventing users from publishing messages with the `Nats-Stream-Source` header directly. The fourth commit restores pre-2.10 test coverage.

The fifth commit ensures the source state is replicated if the stream is, ensuring all replicas (especially as followers go offline, miss messages and are later caught up) end up at the same source state. Since it requires stream snapshot format changes, it requires an explicit opt-in of the `js_snapshot_sources` feature flag, which can become the default in 2.16.