### PR TITLE
(2.15) [ADDED] Expose highest sourced seq in StreamSourceInfo

### DIFF
--- a/server/jetstream_benchmark_test.go
+++ b/server/jetstream_benchmark_test.go
@@ -2300,7 +2300,7 @@ func BenchmarkJetStreamScanForSources(b *testing.B) {
 	require_NoError(b, err)
 
 	b.Run("StartingSequenceForSources", func(b *testing.B) {
-		mset.startingSequenceForSources()
+		mset.resetSourceInfo()
 	})
 }
 

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -7292,7 +7292,7 @@ func TestJetStreamClusterSourcesFilteringAndUpdating(t *testing.T) {
 	// check the 'backfill' of messages on "foo" that were published while the source was inactive
 	checkSync(400, 400)
 
-	// causes startingSequenceForSources() to be called
+	// causes resetSourceInfo() to be called
 	nc.Close()
 	c.stopAll()
 	c.restartAll()

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -18292,6 +18292,54 @@ func TestJetStreamSourceRemovalAndReAdd(t *testing.T) {
 	}
 }
 
+func TestJetStreamSourceInfoExposesHighestSourcedSeq(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "ORIGIN",
+		Subjects: []string{"foo"},
+	})
+	require_NoError(t, err)
+
+	for range 3 {
+		_, err = js.Publish("foo", []byte("OK"))
+		require_NoError(t, err)
+	}
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:    "SOURCE",
+		Sources: []*nats.StreamSource{{Name: "ORIGIN"}},
+	})
+	require_NoError(t, err)
+
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		rm, err := nc.Request(fmt.Sprintf(JSApiStreamInfoT, "SOURCE"), nil, time.Second)
+		require_NoError(t, err)
+		var resp JSApiStreamInfoResponse
+		require_NoError(t, json.Unmarshal(rm.Data, &resp))
+		if resp.Error != nil {
+			return resp.Error
+		}
+		si := resp.StreamInfo
+		if len(si.Sources) != 1 {
+			return fmt.Errorf("expected 1 source, got %d", len(si.Sources))
+		} else if si.State.Msgs != 3 {
+			return fmt.Errorf("expected 3 msgs, got %d", si.State.Msgs)
+		}
+		src := si.Sources[0]
+		if src.Name != "ORIGIN" {
+			return fmt.Errorf("expected source name to be ORIGIN, got %q", src.Name)
+		} else if src.Seq != 3 {
+			return fmt.Errorf("expected highest sourced seq of 3, got %d", src.Seq)
+		}
+		return nil
+	})
+}
+
 func TestJetStreamRateLimitHighStreamIngest(t *testing.T) {
 	cfgFmt := []byte(fmt.Sprintf(`
         jetstream: {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -19284,6 +19284,142 @@ func TestJetStreamSourceRemovalAndReAdd(t *testing.T) {
 	}
 }
 
+func TestJetStreamSourceInfoExposesHighestSourcedSeq(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "ORIGIN",
+		Subjects: []string{"foo"},
+	})
+	require_NoError(t, err)
+
+	for range 3 {
+		_, err = js.Publish("foo", []byte("OK"))
+		require_NoError(t, err)
+	}
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:    "SOURCE",
+		Sources: []*nats.StreamSource{{Name: "ORIGIN"}},
+	})
+	require_NoError(t, err)
+
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		rm, err := nc.Request(fmt.Sprintf(JSApiStreamInfoT, "SOURCE"), nil, time.Second)
+		require_NoError(t, err)
+		var resp JSApiStreamInfoResponse
+		require_NoError(t, json.Unmarshal(rm.Data, &resp))
+		if resp.Error != nil {
+			return resp.Error
+		}
+		si := resp.StreamInfo
+		if len(si.Sources) != 1 {
+			return fmt.Errorf("expected 1 source, got %d", len(si.Sources))
+		} else if si.State.Msgs != 3 {
+			return fmt.Errorf("expected 3 msgs, got %d", si.State.Msgs)
+		}
+		src := si.Sources[0]
+		if src.Name != "ORIGIN" {
+			return fmt.Errorf("expected source name to be ORIGIN, got %q", src.Name)
+		} else if src.Seq != 3 {
+			return fmt.Errorf("expected highest sourced seq of 3, got %d", src.Seq)
+		}
+		return nil
+	})
+
+	// The reported sequence must come from the persisted sources state, the
+	// in-memory sourceInfo can be ahead of what's actually been stored.
+	mset, err := s.globalAccount().lookupStream("SOURCE")
+	require_NoError(t, err)
+	const iname = "ORIGIN > >"
+	require_Equal(t, mset.store.SourcesState()[iname].Seq, 3)
+
+	mset.mu.Lock()
+	mset.sources[iname].sseq = 100
+	mset.mu.Unlock()
+
+	sis := mset.sourcesInfo()
+	require_Len(t, len(sis), 1)
+	require_Equal(t, sis[0].Seq, 3)
+
+	// If the source stream is recreated the persisted state still holds the previous
+	// incarnation's identity and sequence, until a new message from the recreated
+	// stream is stored. Don't report that stale sequence as ours.
+	sss := mset.store.SourcesState()[iname]
+	require_True(t, sss.Ident != _EMPTY_)
+
+	mset.mu.Lock()
+	si := mset.sources[iname]
+	ident := si.ident
+	require_Equal(t, ident, sss.Ident)
+	si.ident, si.sseq = "recreated", 0
+	mset.mu.Unlock()
+
+	sis = mset.sourcesInfo()
+	require_Len(t, len(sis), 1)
+	require_Equal(t, sis[0].Seq, 0)
+
+	// Same when we're about to retry due to an identity mismatch, the identity is
+	// unset but the persisted state is still from the previous incarnation.
+	mset.mu.Lock()
+	si.ident, si.rc = _EMPTY_, true
+	mset.mu.Unlock()
+
+	sis = mset.sourcesInfo()
+	require_Len(t, len(sis), 1)
+	require_Equal(t, sis[0].Seq, 0)
+
+	// Once the identities match again we report the persisted sequence.
+	mset.mu.Lock()
+	si.ident, si.rc = ident, false
+	mset.mu.Unlock()
+
+	sis = mset.sourcesInfo()
+	require_Len(t, len(sis), 1)
+	require_Equal(t, sis[0].Seq, 3)
+
+	// The persisted state can legitimately be identity-less, if the last sourced message
+	// was stored before source identities existed. That's unverifiable, but still valid,
+	// so we must keep reporting the persisted sequence.
+	mset.store.ApplySourcesState(map[string]StreamSourceState{iname: {Seq: 3}})
+	require_Equal(t, mset.store.SourcesState()[iname].Ident, _EMPTY_)
+
+	sis = mset.sourcesInfo()
+	require_Len(t, len(sis), 1)
+	require_Equal(t, sis[0].Seq, 3)
+
+	// Unless we know a recreation is in progress.
+	mset.mu.Lock()
+	si.rc = true
+	mset.mu.Unlock()
+
+	sis = mset.sourcesInfo()
+	require_Len(t, len(sis), 1)
+	require_Equal(t, sis[0].Seq, 0)
+
+	// Resetting the source infos, which happens on startup/leader change and can be
+	// followed by a delayed source consumer setup, must seed the identity and sequence
+	// right away. Otherwise we'd report a mismatch and a zero sequence in the meantime.
+	mset.mu.Lock()
+	mset.store.ApplySourcesState(map[string]StreamSourceState{iname: {Seq: 3, Ident: ident}})
+	mset.resetSourceInfo()
+	rsi := mset.sources[iname]
+	mset.mu.Unlock()
+
+	require_NotNil(t, rsi)
+	require_Equal(t, rsi.ident, ident)
+	require_Equal(t, rsi.sseq, 3)
+	require_False(t, rsi.rc)
+
+	sis = mset.sourcesInfo()
+	require_Len(t, len(sis), 1)
+	require_Equal(t, sis[0].Seq, 3)
+}
+
 func TestJetStreamRateLimitHighStreamIngest(t *testing.T) {
 	cfgFmt := []byte(fmt.Sprintf(`
         jetstream: {
@@ -25195,7 +25331,7 @@ func TestJetStreamSourcesStateStartingSequence(t *testing.T) {
 		// goes undetected, and we would resume from a sequence that means nothing
 		// in the new stream.
 		mset.mu.Lock()
-		mset.startingSequenceForSources()
+		mset.resetSourceInfo()
 		si := mset.sources[iname]
 		mset.mu.Unlock()
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -396,6 +396,7 @@ type StreamSourceInfo struct {
 	Name              string                   `json:"name"`
 	External          *ExternalStream          `json:"external,omitempty"`
 	Lag               uint64                   `json:"lag"`
+	Seq               uint64                   `json:"seq,omitempty"`
 	Active            time.Duration            `json:"active"`
 	Error             *ApiError                `json:"error,omitempty"`
 	FilterSubject     string                   `json:"filter_subject,omitempty"`
@@ -2966,7 +2967,7 @@ func (mset *stream) sourceInfo(si *sourceInfo) *StreamSourceInfo {
 		return nil
 	}
 
-	var ssi = StreamSourceInfo{Name: si.name, Lag: si.lag, Error: si.err, FilterSubject: si.sf}
+	var ssi = StreamSourceInfo{Name: si.name, Lag: si.lag, Seq: si.sseq, Error: si.err, FilterSubject: si.sf}
 
 	trConfigs := make([]SubjectTransformConfig, len(si.sfs))
 	for i := range si.sfs {

--- a/server/stream.go
+++ b/server/stream.go
@@ -466,6 +466,7 @@ type StreamSourceInfo struct {
 	Name              string                   `json:"name"`
 	External          *ExternalStream          `json:"external,omitempty"`
 	Lag               uint64                   `json:"lag"`
+	Seq               uint64                   `json:"seq,omitempty"`
 	Active            time.Duration            `json:"active"`
 	Error             *ApiError                `json:"error,omitempty"`
 	FilterSubject     string                   `json:"filter_subject,omitempty"`
@@ -3216,9 +3217,22 @@ func (mset *stream) isMirror() bool {
 func (mset *stream) sourcesInfo() (sis []*StreamSourceInfo) {
 	mset.mu.RLock()
 	defer mset.mu.RUnlock()
+	// Use the persisted source state for the sequences, si.sseq can be ahead of what's stored.
+	var sourcesState map[string]StreamSourceState
+	if mset.store != nil {
+		sourcesState = mset.store.SourcesState()
+	}
 	sis = make([]*StreamSourceInfo, 0, len(mset.sources))
 	for _, si := range mset.sources {
-		sis = append(sis, mset.sourceInfo(si))
+		ssi := mset.sourceInfo(si)
+		if ssi == nil {
+			continue
+		}
+		// Only report the sequence if the persisted state belongs to the same identity (if known).
+		if sss, ok := sourcesState[si.iname]; ok && !si.rc && (sss.Ident == _EMPTY_ || si.ident == sss.Ident) {
+			ssi.Seq = sss.Seq
+		}
+		sis = append(sis, ssi)
 	}
 	return sis
 }
@@ -5022,12 +5036,21 @@ func (mset *stream) setStartingSequenceForSources(iNames map[string]struct{}) {
 	}
 }
 
-// Resets the SourceInfo for all the sources
+// Resets the SourceInfo for all the sources, seeding each with the
+// persisted starting sequence and identity.
 // lock should be held.
 func (mset *stream) resetSourceInfo() {
 	// Reset if needed.
 	mset.stopSourceConsumers()
 	mset.sources = make(map[string]*sourceInfo)
+
+	// The store contains an index of the source state, use it here without doing lookups ourselves.
+	// Seed the source infos with it right away, the actual consumer setup can be delayed and until
+	// then we'd otherwise have no idea how far we've sourced already.
+	var sourcesState map[string]StreamSourceState
+	if mset.store != nil {
+		sourcesState = mset.store.SourcesState()
+	}
 
 	for _, ssi := range mset.cfg.Sources {
 		if ssi.iname == _EMPTY_ {
@@ -5051,36 +5074,10 @@ func (mset *stream) resetSourceInfo() {
 			}
 			si = &sourceInfo{name: ssi.Name, iname: ssi.iname, sfs: sfs, trs: trs}
 		}
-		mset.sources[ssi.iname] = si
-	}
-}
-
-// This will do a reverse scan on startup or leader election
-// searching for the starting sequence number.
-// This can be slow in degenerative cases.
-// Lock should be held.
-func (mset *stream) startingSequenceForSources() {
-	if len(mset.cfg.Sources) == 0 {
-		return
-	}
-
-	// Always reset here.
-	mset.resetSourceInfo()
-
-	// The store contains an index of the source state, use it here without doing lookups ourselves.
-	sourcesState := mset.store.SourcesState()
-	for _, src := range mset.cfg.Sources {
-		iName := src.composeIName()
-		if si, ok := mset.sources[iName]; ok {
-			if sss, ok := sourcesState[iName]; ok {
-				si.sseq = sss.Seq
-				si.dseq = 0
-				si.ident, si.rc = sss.Ident, false
-			} else {
-				// If it doesn't exist, only reset the delivery sequence.
-				si.dseq = 0
-			}
+		if sss, ok := sourcesState[ssi.iname]; ok {
+			si.sseq, si.ident = sss.Seq, sss.Ident
 		}
+		mset.sources[ssi.iname] = si
 	}
 }
 
@@ -5102,7 +5099,7 @@ func (mset *stream) setupSourceConsumers() error {
 		return nil
 	}
 
-	mset.startingSequenceForSources()
+	mset.resetSourceInfo()
 
 	// Setup our consumers at the proper starting position.
 	for _, ssi := range mset.cfg.Sources {


### PR DESCRIPTION
Add a `seq` field to `StreamSourceInfo` that reports the highest stream sequence seen from each source, surfaced via the stream info API.