### PR TITLE
reject malformed replicated ack and delivered updates on decode

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7190,11 +7190,11 @@ var errBadDeliveredUpdate = errors.New("jetstream cluster bad replicated deliver
 
 func decodeAckUpdate(buf []byte) (dseq, sseq uint64, err error) {
 	var bi, n int
-	if dseq, n = binary.Uvarint(buf); n < 0 {
+	if dseq, n = binary.Uvarint(buf); n <= 0 {
 		return 0, 0, errBadAckUpdate
 	}
 	bi += n
-	if sseq, n = binary.Uvarint(buf[bi:]); n < 0 {
+	if sseq, n = binary.Uvarint(buf[bi:]); n <= 0 {
 		return 0, 0, errBadAckUpdate
 	}
 	return dseq, sseq, nil
@@ -7202,19 +7202,19 @@ func decodeAckUpdate(buf []byte) (dseq, sseq uint64, err error) {
 
 func decodeDeliveredUpdate(buf []byte) (dseq, sseq, dc uint64, ts int64, err error) {
 	var bi, n int
-	if dseq, n = binary.Uvarint(buf); n < 0 {
+	if dseq, n = binary.Uvarint(buf); n <= 0 {
 		return 0, 0, 0, 0, errBadDeliveredUpdate
 	}
 	bi += n
-	if sseq, n = binary.Uvarint(buf[bi:]); n < 0 {
+	if sseq, n = binary.Uvarint(buf[bi:]); n <= 0 {
 		return 0, 0, 0, 0, errBadDeliveredUpdate
 	}
 	bi += n
-	if dc, n = binary.Uvarint(buf[bi:]); n < 0 {
+	if dc, n = binary.Uvarint(buf[bi:]); n <= 0 {
 		return 0, 0, 0, 0, errBadDeliveredUpdate
 	}
 	bi += n
-	if ts, n = binary.Varint(buf[bi:]); n < 0 {
+	if ts, n = binary.Varint(buf[bi:]); n <= 0 {
 		return 0, 0, 0, 0, errBadDeliveredUpdate
 	}
 	return dseq, sseq, dc, ts, nil

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -8629,3 +8629,35 @@ func TestJetStreamClusterCatchupBadMsgStopsRetrying(t *testing.T) {
 	// We must not have retried the catchup, a bad message bails out immediately.
 	require_Equal(t, count.Load(), 1)
 }
+
+func TestJetStreamClusterDecodeUpdatesRejectMalformed(t *testing.T) {
+	// binary.Uvarint/Varint return n == 0 when the buffer is too short to
+	// hold a full varint, so a truncated replicated update must be rejected
+	// rather than silently decoded as zero-valued fields.
+	t.Run("AckUpdate", func(t *testing.T) {
+		valid := binary.AppendUvarint(nil, 10)
+		valid = binary.AppendUvarint(valid, 20)
+		if _, _, err := decodeAckUpdate(valid); err != nil {
+			t.Fatalf("expected valid ack update to decode, got %v", err)
+		}
+		for _, buf := range [][]byte{nil, valid[:1]} {
+			if _, _, err := decodeAckUpdate(buf); err != errBadAckUpdate {
+				t.Fatalf("expected errBadAckUpdate for %v, got %v", buf, err)
+			}
+		}
+	})
+	t.Run("DeliveredUpdate", func(t *testing.T) {
+		valid := binary.AppendUvarint(nil, 10)
+		valid = binary.AppendUvarint(valid, 20)
+		valid = binary.AppendUvarint(valid, 1)
+		valid = binary.AppendVarint(valid, time.Now().UnixNano())
+		if _, _, _, _, err := decodeDeliveredUpdate(valid); err != nil {
+			t.Fatalf("expected valid delivered update to decode, got %v", err)
+		}
+		for _, buf := range [][]byte{nil, valid[:1], valid[:2], valid[:3]} {
+			if _, _, _, _, err := decodeDeliveredUpdate(buf); err != errBadDeliveredUpdate {
+				t.Fatalf("expected errBadDeliveredUpdate for %v, got %v", buf, err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
decodeAckUpdate and decodeDeliveredUpdate check the varint result with `n < 0`, which only flags a 64-bit overflow. binary.Uvarint and binary.Varint return n == 0 when the buffer is too short to hold a full varint, so a truncated replicated ack or delivered update from a peer slips past the guard and decodes to zeroed fields. The caller then applies that as a real update (UpdateDelivered / processReplicatedAck) instead of treating the entry as corrupt.

Switch the guards to `n <= 0` so a short buffer is rejected the same way an overflow already is. Before: a truncated entry returned a nil error and silently advanced consumer state. After: it returns errBadAckUpdate / errBadDeliveredUpdate and is handled as malformed, matching DecodeStreamState and the filestore block decoders that already use `n <= 0`. The tradeoff is that a short entry now surfaces as a decode error rather than being absorbed, which is the same behavior the overflow case already had.
