### PR TITLE
(2.12) [FIXED] Filestore restore stale fblk for MaxMsgsPer>1 with FIFO removal

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4703,17 +4703,15 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 	}
 
 	// Adjust top level tracking of per subject msg counts.
-	var info *psi
-	var ok bool
 	if len(subj) > 0 && fs.psim != nil {
 		index := fs.lmb.index
-		if info, ok = fs.psim.Find(stringToBytes(subj)); ok {
+		if info, ok := fs.psim.Find(stringToBytes(subj)); ok {
 			info.total++
 			if index > info.lblk {
 				info.lblk = index
 			}
 		} else {
-			info, _ = fs.psim.Insert(stringToBytes(subj), psi{total: 1, fblk: index, lblk: index})
+			fs.psim.Insert(stringToBytes(subj), psi{total: 1, fblk: index, lblk: index})
 			fs.tsl += len(subj)
 		}
 	}
@@ -4758,10 +4756,6 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 				fs.rebuildStateLocked(ld)
 			}
 		}
-	}
-	// If we only ever store one/last message for a subject, can correct the first block to where we've just written.
-	if info != nil && info.total == 1 && mmp == 1 {
-		info.fblk = info.lblk
 	}
 
 	// Limits checks and enforcement.
@@ -5296,7 +5290,12 @@ func (fs *fileStore) removePerSubject(subj string) uint64 {
 	bsubj := stringToBytes(subj)
 	if info, ok := fs.psim.Find(bsubj); ok {
 		info.total--
-		if info.total == 0 {
+		if info.total == 1 {
+			// This is only correct if the last message for this subject still exists and was
+			// not removed. The 2.12 line can't handle this better sadly, 2.14+ persists both
+			// fblk and lblk, so it does not contain this block.
+			info.fblk = info.lblk
+		} else if info.total == 0 {
 			if _, ok = fs.psim.Delete(bsubj); ok {
 				fs.tsl -= len(subj)
 				return 0

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -6329,10 +6329,11 @@ func TestFileStoreCompactAndPSIMWhenDeletingBlocks(t *testing.T) {
 	psi := *info
 	fs.mu.RUnlock()
 
-	// PSIM remains the same, since we'll not always know
+	// 2.12 (and below) only stores fblk if total=1.
+	// However, 2.14+ correctly asserts PSIM remains the same, since we'll not always know
 	// that the head was removed, instead of the tail.
 	require_Equal(t, psi.total, 1)
-	require_Equal(t, psi.fblk, 1)
+	require_Equal(t, psi.fblk, 4) // would be '1' on 2.14+
 	require_Equal(t, psi.lblk, 4)
 }
 
@@ -8529,6 +8530,76 @@ func TestFileStoreMaxMsgsPerSubjectOneStaleFblkAfterRestart(t *testing.T) {
 	require_Equal(t, info.total, 1)
 	require_Equal(t, info.lblk, 2)
 	require_Equal(t, info.fblk, 2) // Since it's MaxMsgsPer:1, this should be optimized to last block.
+}
+
+func TestFileStoreMaxMsgsPerSubjectStaleFblkAfterRestart(t *testing.T) {
+	for _, mmp := range []int{1, 2} {
+		t.Run(fmt.Sprintf("MaxMsgsPer=%d", mmp), func(t *testing.T) {
+			sd := t.TempDir()
+			fcfg := FileStoreConfig{StoreDir: sd, BlockSize: 256}
+			scfg := StreamConfig{Name: "zzz", Subjects: []string{"foo.*"}, Storage: FileStorage, MaxMsgsPer: int64(mmp)}
+
+			fs, err := newFileStore(fcfg, scfg)
+			require_NoError(t, err)
+			defer fs.Stop()
+
+			// Store "foo.0" into the first block.
+			msg := []byte("hello")
+			fseq, _, err := fs.StoreMsg("foo.0", nil, msg, 0)
+			require_NoError(t, err)
+
+			// Fill the first block with other subjects until a second block is created.
+			for i := 1; fs.numMsgBlocks() < 2; i++ {
+				_, _, err = fs.StoreMsg(fmt.Sprintf("foo.%d", i), nil, msg, 0)
+				require_NoError(t, err)
+			}
+
+			// Store "foo.0" again. This copy lands in the second block.
+			lseq, _, err := fs.StoreMsg("foo.0", nil, msg, 0)
+			require_NoError(t, err)
+
+			// MaxMsgsPer=1 already removed the first-block "foo.0" copy FIFO when lseq was stored.
+			// For MaxMsgsPer>1 both copies are kept, so remove the older (first-block) copy FIFO
+			// ourselves. Either way the only remaining "foo.0" is the newer copy in the second block.
+			if mmp > 1 {
+				removed, err := fs.RemoveMsg(fseq)
+				require_NoError(t, err)
+				require_True(t, removed)
+			}
+
+			// Sanity check before restart: the remaining message is still found in memory.
+			var smv StoreMsg
+			sm, err := fs.LoadLastMsg("foo.0", &smv)
+			require_NoError(t, err)
+			require_Equal(t, sm.seq, lseq)
+
+			// Stop writes the stream state file.
+			require_NoError(t, fs.Stop())
+			_, err = os.Stat(filepath.Join(sd, msgDir, streamStreamStateFile))
+			require_NoError(t, err)
+
+			// Restart, recovering from the stream state file. On v2.12.10 the persisted fblk for
+			// MaxMsgsPer>1 is stale (points at the first block), so the pointer to the message is lost.
+			fs, err = newFileStore(fcfg, scfg)
+			require_NoError(t, err)
+			defer fs.Stop()
+
+			// The remaining message for "foo.0" must still be found after a restart.
+			sm, err = fs.LoadLastMsg("foo.0", &smv)
+			require_NoError(t, err)
+			require_Equal(t, sm.subj, "foo.0")
+			require_Equal(t, sm.seq, lseq)
+
+			// Validate internal subject state.
+			fs.mu.RLock()
+			defer fs.mu.RUnlock()
+			info, ok := fs.psim.Find(stringToBytes("foo.0"))
+			require_True(t, ok)
+			require_Equal(t, info.total, 1)
+			require_Equal(t, info.fblk, 2)
+			require_Equal(t, info.lblk, 2)
+		})
+	}
 }
 
 func Benchmark_FileStoreSubjectStateConsistencyOptimizationPerf(b *testing.B) {
@@ -12630,7 +12701,9 @@ func TestFileStoreRemovePerSubjectWithMultipleBlocks(t *testing.T) {
 	seq, err = fs.firstSeqForSubj("foo")
 	fs.mu.Unlock()
 	require_NoError(t, err)
-	require_Equal(t, seq, 1)
+	// Should be '1', but 2.12 and below updates fblk to the wrong value
+	// for a non-FIFO message delete.
+	require_Equal(t, seq, 0)
 }
 
 func TestFileStoreSchedulingRecoveryAliasCorruption(t *testing.T) {

--- a/server/store_test.go
+++ b/server/store_test.go
@@ -487,13 +487,23 @@ func TestStoreMaxMsgsPerUpdateToOneRemoveNewest(t *testing.T) {
 			// Update max messages per-subject from -1 (unlimited) to 1.
 			// This transition does not run per-subject limit enforcement, so both copies remain.
 			cfg := config()
-			if _, ok := fs.(*fileStore); ok {
+			_, isFilestore := fs.(*fileStore)
+			if isFilestore {
 				cfg.Storage = FileStorage
 			} else {
 				cfg.Storage = MemoryStorage
 			}
 			cfg.MaxMsgsPer = 1
 			require_NoError(t, fs.UpdateConfig(&cfg))
+
+			// This is a bug on 2.12 and below that can't be prevented. 2.14+ stores both
+			// fblk and lblk which allows this lookup to pass.
+			if isFilestore {
+				var smv StoreMsg
+				_, err = fs.LoadLastMsg("foo.0", &smv)
+				require_Error(t, err, ErrStoreMsgNotFound)
+				return
+			}
 
 			ss := fs.SubjectsState("foo.0")["foo.0"]
 			require_Equal(t, ss.Msgs, 1)


### PR DESCRIPTION
This PR reverts the `if info.total == 1 { info.fblk = info.lblk }` block that was removed in commit f8656fe / 2.12.7.

The block is incorrect and doesn't exist on 2.14, because this overwrite assumes all removals happen FIFO. On 2.14 this is fixed:
- `fblk` and `lblk` are always stored in `index.db`, whereas 2.12 and below only stores `fblk` if `total == 1`.
- Setting `info.fblk = info.lblk` is only done if `MaxMsgsPer:1` since commit f063bc4 / 2.12.10.

This PR should only be included in the 2.12 line, since this is a non-issue on 2.14 and is already covered by tests and must not get any changes from this PR (since this technically reintroduces a bug to restore previous behavior).