### PR TITLE
[FIXED] Treat zero consumer limits as unlimited on stream update

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8307,6 +8307,31 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		return
 	}
 
+	// In the event that some of the stream-level limits have changed, yell appropriately
+	// if any of the consumers exceed that limit.
+	oldInactiveThreshold, newInactiveThreshold := osa.Config.ConsumerLimits.InactiveThreshold, newCfg.ConsumerLimits.InactiveThreshold
+	oldMaxAckPending, newMaxAckPending := osa.Config.ConsumerLimits.MaxAckPending, newCfg.ConsumerLimits.MaxAckPending
+	updateLimits := (newInactiveThreshold > 0 && oldInactiveThreshold != newInactiveThreshold) ||
+		(newMaxAckPending > 0 && oldMaxAckPending != newMaxAckPending)
+	if updateLimits {
+		var errorConsumers []string
+		for ca := range js.consumerAssignmentsOrInflightSeq(acc.Name, cfg.Name) {
+			if ca.Config == nil {
+				continue
+			}
+			if (newInactiveThreshold > 0 && ca.Config.InactiveThreshold > newInactiveThreshold) ||
+				(newMaxAckPending > 0 && ca.Config.MaxAckPending > newMaxAckPending) {
+				errorConsumers = append(errorConsumers, ca.Name)
+			}
+		}
+		if len(errorConsumers) > 0 {
+			err := fmt.Errorf("change to limits violates consumers: %s", strings.Join(errorConsumers, ", "))
+			resp.Error = NewJSStreamUpdateError(err)
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+			return
+		}
+	}
+
 	// Make copy so to not change original.
 	rg := osa.copyGroup().Group
 

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -5976,6 +5976,84 @@ func TestJetStreamClusterConsumerDefaultsFromStream(t *testing.T) {
 	})
 }
 
+func TestJetStreamClusterConsumerLimitsUpdateGatedAtMetaLeader(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	cfg := &StreamConfig{
+		Name:     "test",
+		Subjects: []string{"test.*"},
+		Storage:  MemoryStorage,
+		Replicas: 3,
+		ConsumerLimits: StreamConsumerLimits{
+			MaxAckPending:     20,
+			InactiveThreshold: 10 * time.Second,
+		},
+	}
+	_, err := jsStreamCreate(t, nc, cfg)
+	require_NoError(t, err)
+
+	// Consumer sits right at the current stream limit.
+	_, err = js.AddConsumer("test", &nats.ConsumerConfig{
+		Name:          "consumer",
+		AckPolicy:     nats.AckExplicitPolicy,
+		MaxAckPending: 20,
+	})
+	require_NoError(t, err)
+
+	// Reads the consumer limits the meta leader currently has assigned.
+	metaLeaderLimits := func() StreamConsumerLimits {
+		t.Helper()
+		var limits StreamConsumerLimits
+		checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+			ml := c.leader()
+			if ml == nil {
+				return errors.New("no meta leader")
+			}
+			sjs := ml.getJetStream()
+			sjs.mu.RLock()
+			sa := sjs.streamAssignment(globalAccountName, "test")
+			if sa == nil || sa.Config == nil {
+				sjs.mu.RUnlock()
+				return errors.New("no stream assignment")
+			}
+			limits = sa.Config.ConsumerLimits
+			sjs.mu.RUnlock()
+			return nil
+		})
+		return limits
+	}
+
+	// Sanity: the meta leader has the original limits assigned.
+	require_Equal(t, metaLeaderLimits().MaxAckPending, 20)
+
+	// Lowering MaxAckPending below the existing consumer must be rejected.
+	badCfg := *cfg
+	badCfg.ConsumerLimits.MaxAckPending = 10
+	_, err = jsStreamUpdate(t, nc, &badCfg)
+	require_Error(t, err, NewJSStreamUpdateError(fmt.Errorf("change to limits violates consumers: consumer")))
+
+	// And crucially, the meta leader must not have committed the rejected config:
+	// the assignment should still carry the original limit, not the rejected one.
+	require_Equal(t, metaLeaderLimits().MaxAckPending, 20)
+
+	// A valid update (raise the limit) should still succeed.
+	goodCfg := *cfg
+	goodCfg.ConsumerLimits.MaxAckPending = 30
+	_, err = jsStreamUpdate(t, nc, &goodCfg)
+	require_NoError(t, err)
+	require_Equal(t, metaLeaderLimits().MaxAckPending, 30)
+
+	// Clearing a limit to zero (unlimited) must not be treated as a violation.
+	clearCfg := *cfg
+	clearCfg.ConsumerLimits.MaxAckPending = 0
+	_, err = jsStreamUpdate(t, nc, &clearCfg)
+	require_NoError(t, err)
+}
+
 // Discovered that we are not properly setting certain default filestore blkSizes.
 func TestJetStreamClusterCheckFileStoreBlkSizes(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -7712,6 +7712,63 @@ func TestJetStreamConsumerDefaultsFromStream(t *testing.T) {
 			t.Fatalf("stream update should have errored but didn't")
 		}
 	})
+
+	t.Run("UpdateStreamSpuriousMaxAckPending", func(t *testing.T) {
+		_, err := acc.addStream(&StreamConfig{
+			Name:     "spurious-maxack",
+			Subjects: []string{"spurious-maxack.*"},
+		})
+		require_NoError(t, err)
+
+		_, err = js.AddConsumer("spurious-maxack", &nats.ConsumerConfig{
+			Name:      "consumer",
+			AckPolicy: nats.AckExplicitPolicy,
+		})
+		require_NoError(t, err)
+
+		mset, err := acc.lookupStream("spurious-maxack")
+		require_NoError(t, err)
+
+		require_NoError(t, mset.update(&StreamConfig{
+			Name:     "spurious-maxack",
+			Subjects: []string{"spurious-maxack.*"},
+			ConsumerLimits: StreamConsumerLimits{
+				InactiveThreshold: 10 * time.Second,
+			},
+		}))
+	})
+
+	t.Run("UpdateStreamClearInactiveThreshold", func(t *testing.T) {
+		_, err := acc.addStream(&StreamConfig{
+			Name:     "spurious-inactive",
+			Subjects: []string{"spurious-inactive.*"},
+			ConsumerLimits: StreamConsumerLimits{
+				InactiveThreshold: 10 * time.Second,
+				MaxAckPending:     1000,
+			},
+		})
+		require_NoError(t, err)
+
+		_, err = js.AddConsumer("spurious-inactive", &nats.ConsumerConfig{
+			Name:              "consumer",
+			AckPolicy:         nats.AckExplicitPolicy,
+			InactiveThreshold: 5 * time.Second,
+			MaxAckPending:     500,
+		})
+		require_NoError(t, err)
+
+		mset, err := acc.lookupStream("spurious-inactive")
+		require_NoError(t, err)
+
+		require_NoError(t, mset.update(&StreamConfig{
+			Name:     "spurious-inactive",
+			Subjects: []string{"spurious-inactive.*"},
+			ConsumerLimits: StreamConsumerLimits{
+				InactiveThreshold: 0,
+				MaxAckPending:     2000,
+			},
+		}))
+	})
 }
 
 // Server issue 4685

--- a/server/stream.go
+++ b/server/stream.go
@@ -2420,8 +2420,10 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 
 	// In the event that some of the stream-level limits have changed, yell appropriately
 	// if any of the consumers exceed that limit.
-	updateLimits := ocfg.ConsumerLimits.InactiveThreshold != cfg.ConsumerLimits.InactiveThreshold ||
-		ocfg.ConsumerLimits.MaxAckPending != cfg.ConsumerLimits.MaxAckPending
+	oldInactiveThreshold, newInactiveThreshold := ocfg.ConsumerLimits.InactiveThreshold, cfg.ConsumerLimits.InactiveThreshold
+	oldMaxAckPending, newMaxAckPending := ocfg.ConsumerLimits.MaxAckPending, cfg.ConsumerLimits.MaxAckPending
+	updateLimits := (newInactiveThreshold > 0 && oldInactiveThreshold != newInactiveThreshold) ||
+		(newMaxAckPending > 0 && oldMaxAckPending != newMaxAckPending)
 	if updateLimits {
 		var errorConsumers []string
 		consumers := map[string]*ConsumerConfig{}
@@ -2435,8 +2437,8 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 			}
 		}
 		for name, ccfg := range consumers {
-			if ccfg.InactiveThreshold > cfg.ConsumerLimits.InactiveThreshold ||
-				ccfg.MaxAckPending > cfg.ConsumerLimits.MaxAckPending {
+			if (newInactiveThreshold > 0 && ccfg.InactiveThreshold > newInactiveThreshold) ||
+				(newMaxAckPending > 0 && ccfg.MaxAckPending > newMaxAckPending) {
 				errorConsumers = append(errorConsumers, name)
 			}
 		}


### PR DESCRIPTION
Stream updates no longer reject unrelated consumer limit changes. A zero (unset) `inactive_threshold`/`max_ack_pending` is now treated consistently as unlimited.