### PR TITLE
[IMPROVED] Demote noisy per-connection log lines to debug

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -1099,7 +1099,7 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 				}
 			}
 			if len(deniedPub) > 0 || len(deniedSub) > 0 {
-				c.Noticef("Connected %s has JetStream denied on pub: %v sub: %v", c.kindString(), deniedPub, deniedSub)
+				c.Debugf("Connected %s has JetStream denied on pub: %v sub: %v", c.kindString(), deniedPub, deniedSub)
 			}
 		}
 

--- a/server/client.go
+++ b/server/client.go
@@ -972,11 +972,11 @@ func (c *client) applyAccountLimits() {
 	}
 	wasUnlimited := c.mpay == jwt.NoLimit
 	if minLimit(&c.mpay, mPay) && !wasUnlimited {
-		c.Errorf("Max Payload set to %d from server overrides account or user config", opts.MaxPayload)
+		c.Debugf("Max Payload set to %d from server overrides account or user config", opts.MaxPayload)
 	}
 	wasUnlimited = c.msubs == jwt.NoLimit
 	if minLimit(&c.msubs, mSubs) && !wasUnlimited {
-		c.Errorf("Max Subscriptions set to %d from server overrides account or user config", opts.MaxSubs)
+		c.Debugf("Max Subscriptions set to %d from server overrides account or user config", opts.MaxSubs)
 	}
 	if c.subsAtLimit() {
 		go func() {


### PR DESCRIPTION
Demote the per-connection "JetStream denied" notice and the "Max Payload/Subscriptions overrides account or user config" errors to debug level so high client-connection churn no longer floods the server logs.