### PR TITLE
[IMPROVED] Register write errors for meta, stream, and consumer

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -502,6 +502,7 @@ type consumer struct {
 	// Clustered.
 	ca        *consumerAssignment
 	node      RaftNode
+	werr      error // If a write error was encountered while applying entries, and if so what error.
 	infoSub   *subscription
 	lqsent    time.Time
 	prm       map[string]struct{}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3598,6 +3598,10 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 					}
 				}
 			}
+			// We may have lost leadership while the restore was running.
+			if err == nil && !isLeader {
+				err = errNotLeader
+			}
 			if err != nil {
 				if mset != nil {
 					mset.delete()
@@ -3618,10 +3622,6 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 				// Send response to the metadata leader. They will forward to the user as needed.
 				s.sendInternalMsgLocked(streamAssignmentSubj, _EMPTY_, nil, result)
 				return
-			}
-
-			if !isLeader {
-				panic("Finished restore but not leader")
 			}
 			// Trigger the stream followers to catchup.
 			if n = mset.raftNode(); n != nil {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -836,6 +836,10 @@ func (js *jetStream) isConsumerHealthy(mset *stream, consumer string, ca *consum
 
 	oNode := o.raftNode()
 	rc, _ := o.replica()
+	var nrgWerr error
+	if node != nil {
+		nrgWerr = node.GetWriteErr()
+	}
 	switch {
 	case rc <= 1:
 		return nil // No further checks for R=1 consumers
@@ -853,6 +857,9 @@ func (js *jetStream) isConsumerHealthy(mset *stream, consumer string, ca *consum
 		mset.mu.RUnlock()
 		s.Warnf("Detected consumer cluster node skew '%s > %s > %s'", accName, streamName, consumer)
 		return errors.New("cluster node skew detected")
+
+	case nrgWerr != nil:
+		return fmt.Errorf("node write error: %v", nrgWerr)
 
 	case !o.isMonitorRunning():
 		return errors.New("monitor goroutine not running")

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3409,7 +3409,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 						aq.recycle(&ces)
 						return
 					}
-					s.Errorf("Error applying entries to '%s > %s': %v", accName, sa.Config.Name, err)
+					s.Errorf("Error applying stream entries to '%s > %s': %v", accName, sa.Config.Name, err)
 					if isClusterResetErr(err) {
 						if mset.isMirror() && mset.IsLeader() {
 							mset.retryMirrorConsumer()
@@ -3937,7 +3937,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 			if op == batchMsgOp {
 				batchId, batchSeq, _, _, err := decodeBatchMsg(buf[1:])
 				if err != nil {
-					panic(err.Error())
+					return 0, err
 				}
 				// Initialize if unset.
 				if batch == nil {
@@ -3977,7 +3977,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 							batch.mu.Unlock()
 							mset.mu.Unlock()
 							if err != nil {
-								panic(err.Error())
+								return 0, err
 							}
 							continue
 						}
@@ -3997,7 +3997,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 			} else if op == batchCommitMsgOp {
 				batchId, batchSeq, _, _, err := decodeBatchMsg(buf[1:])
 				if err != nil {
-					panic(err.Error())
+					return 0, err
 				}
 
 				// Ensure the whole batch is fully isolated, and reads
@@ -4033,7 +4033,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 						batch.mu.Unlock()
 						mset.mu.Unlock()
 						if err != nil {
-							panic(err.Error())
+							return 0, err
 						}
 						continue
 					}
@@ -4058,22 +4058,24 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 						// Otherwise, all entries are used.
 						entries = bce.Entries
 					}
+					clearAndUnlock := func() {
+						// Make sure to return remaining entries to the pool on an error.
+						for _, nce := range batch.entries[j:] {
+							nce.ReturnToPool()
+						}
+						// Important to clear, otherwise we could return the entries to the pool multiple times.
+						batch.clearBatchStateLocked()
+						batch.mu.Unlock()
+						mset.mu.Unlock()
+					}
 					for _, entry := range entries {
 						_, _, op, buf, err = decodeBatchMsg(entry.Data[1:])
 						if err != nil {
-							batch.mu.Unlock()
-							mset.mu.Unlock()
-							panic(err.Error())
+							clearAndUnlock()
+							return 0, err
 						}
 						if err = js.applyStreamMsgOp(mset, op, buf, isRecovering, false); err != nil {
-							// Make sure to return remaining entries to the pool on an error.
-							for _, nce := range batch.entries[j:] {
-								nce.ReturnToPool()
-							}
-							// Important to clear, otherwise we could return the entries to the pool multiple times.
-							batch.clearBatchStateLocked()
-							batch.mu.Unlock()
-							mset.mu.Unlock()
+							clearAndUnlock()
 							return 0, err
 						}
 					}
@@ -4087,19 +4089,21 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 					// Get all entries up to and including the current one.
 					entries = ce.Entries[:i+1]
 				}
+				clearAndUnlock := func() {
+					// Important to clear, otherwise we could return the entries to the pool multiple times.
+					batch.clearBatchStateLocked()
+					batch.mu.Unlock()
+					mset.mu.Unlock()
+				}
 				// Process remaining entries in the current entry.
 				for _, entry := range entries {
 					_, _, op, buf, err = decodeBatchMsg(entry.Data[1:])
 					if err != nil {
-						batch.mu.Unlock()
-						mset.mu.Unlock()
-						panic(err.Error())
+						clearAndUnlock()
+						return 0, err
 					}
 					if err = js.applyStreamMsgOp(mset, op, buf, isRecovering, false); err != nil {
-						// Important to clear, otherwise we could return the entries to the pool multiple times.
-						batch.clearBatchStateLocked()
-						batch.mu.Unlock()
-						mset.mu.Unlock()
+						clearAndUnlock()
 						return 0, err
 					}
 				}
@@ -4128,7 +4132,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 						s.Errorf("JetStream cluster could not decode delete range for '%s > %s' [%s]",
 							mset.account(), mset.name(), node.Group())
 					}
-					panic(err.Error())
+					return 0, err
 				}
 				if dr.Num == 0 {
 					continue
@@ -4163,7 +4167,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 						s.Errorf("JetStream cluster could not decode delete msg for '%s > %s' [%s]",
 							mset.account(), mset.name(), node.Group())
 					}
-					panic(err.Error())
+					return 0, err
 				}
 				s := js.server()
 
@@ -4214,7 +4218,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 						s.Errorf("JetStream cluster could not decode purge msg for '%s > %s' [%s]",
 							mset.account(), mset.name(), node.Group())
 					}
-					panic(err.Error())
+					return 0, err
 				}
 				// If no explicit request, fill in with leader stamped last sequence to protect ourselves on replay during server start.
 				if sp.Request == nil || sp.Request.Sequence == 0 {
@@ -4250,7 +4254,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 					}
 				}
 			default:
-				panic(fmt.Sprintf("JetStream Cluster Unknown group entry op type: %v", op))
+				return 0, fmt.Errorf("unknown stream entry op type: %v", op)
 			}
 		} else if e.Type == EntrySnapshot {
 			// Everything operates on new replicated state. Will convert legacy snapshots to this for processing.
@@ -4378,22 +4382,24 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 		var err error
 		mbuf, err = s2.Decode(nil, mbuf)
 		if err != nil {
-			panic(err.Error())
+			return err
 		}
 	}
 
 	subject, reply, hdr, msg, lseq, ts, sourced, err := decodeStreamMsg(mbuf)
 	if err != nil {
-		// We're going to panic below, but if we're already holding the stream lock, we should let go now.
-		// Otherwise we'll deadlock when trying to get the raft node.
-		if !needLock {
-			mset.mu.Unlock()
+		if needLock {
+			mset.mu.RLock()
 		}
-		if node := mset.raftNode(); node != nil {
+		acc, name, node := mset.accountLocked(false), mset.nameLocked(false), mset.node
+		if needLock {
+			mset.mu.RUnlock()
+		}
+		if node != nil {
 			s.Errorf("JetStream cluster could not decode stream msg for '%s > %s' [%s]",
-				mset.account(), mset.name(), node.Group())
+				acc, name, node.Group())
 		}
-		panic(err.Error())
+		return err
 	}
 
 	// Check for flowcontrol here.
@@ -10742,7 +10748,7 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 		var err error
 		mbuf, err = s2.Decode(nil, mbuf)
 		if err != nil {
-			panic(err.Error())
+			return 0, errCatchupBadMsg
 		}
 	}
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -10771,6 +10771,14 @@ RETRY:
 					}
 					msgsQ.recycle(&mrecs)
 					return err
+				} else if err == errCatchupBadMsg {
+					// A bad/corrupt catchup message (e.g. a failed s2 decode) is a
+					// deterministic failure: requesting a fresh sync from the leader
+					// returns the same bytes, so retrying would churn indefinitely.
+					notifyLeaderStopCatchup(mrec, err)
+					s.Warnf("Catchup for stream '%s > %s' errored, bad message: %v", mset.account(), mset.name(), err)
+					msgsQ.recycle(&mrecs)
+					return err
 				} else {
 					notifyLeaderStopCatchup(mrec, err)
 					s.Warnf("Catchup for stream '%s > %s' errored, will retry: %v", mset.account(), mset.name(), err)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -9892,6 +9892,9 @@ func decodeBatchMsg(buf []byte) (batchId string, batchSeq uint64, op entryOp, mb
 		return _EMPTY_, 0, 0, nil, errBadStreamMsg
 	}
 	buf = buf[n:]
+	if len(buf) < 1 {
+		return _EMPTY_, 0, 0, nil, errBadStreamMsg
+	}
 	op = entryOp(buf[0])
 	mbuf = buf[1:]
 	return batchId, batchSeq, op, mbuf, nil

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -84,6 +84,8 @@ type jetStreamCluster struct {
 	// Track last meta snapshot time and duration for monitoring.
 	lastMetaSnapTime     int64 // Unix nanoseconds
 	lastMetaSnapDuration int64 // Duration in nanoseconds
+	// If a write error was encountered while applying meta entries, and if so what error.
+	werr error
 }
 
 // Used to track inflight stream create/update/delete requests that have been proposed but not yet applied.
@@ -1454,6 +1456,45 @@ func (js *jetStream) isMetaRecovering() bool {
 	return js.metaRecovering
 }
 
+// setMetaWriteErr stores the write error on the meta group.
+func (js *jetStream) setMetaWriteErr(err error) {
+	js.mu.Lock()
+	defer js.mu.Unlock()
+	js.setMetaWriteErrLocked(err)
+}
+
+func (js *jetStream) setMetaWriteErrLocked(err error) {
+	cc := js.cluster
+	if cc == nil || cc.werr != nil {
+		return
+	}
+	// Ignore non-write errors.
+	if err == ErrStoreClosed {
+		return
+	}
+	js.srv.Errorf("JetStream cluster meta group critical write error: %v", err)
+	cc.werr = err
+	assert.Unreachable("Meta group encountered write error", map[string]any{
+		"err": err,
+	})
+
+	// Step down and put into observer mode so another server can pick up the meta leadership.
+	if node := cc.meta; node != nil {
+		node.StepDown()
+		node.SetObserver(true)
+	}
+}
+
+// getMetaWriteErr returns the write error stored on the meta group (if any).
+func (js *jetStream) getMetaWriteErr() error {
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+	if js.cluster == nil {
+		return nil
+	}
+	return js.cluster.werr
+}
+
 // During recovery track any stream and consumer delete and update operations.
 type recoveryUpdates struct {
 	removeStreams   map[string]*streamAssignment
@@ -1906,7 +1947,12 @@ func (js *jetStream) monitorCluster() {
 					}
 					recovering = isRecovering
 				} else {
-					s.Warnf("Error applying JetStream cluster entries: %v", err)
+					s.Errorf("Error applying JetStream cluster entries: %v", err)
+					// Encountered an unexpected error, can't continue.
+					js.setMetaWriteErr(err)
+					ce.ReturnToPool()
+					aq.recycle(&ces)
+					return
 				}
 				ce.ReturnToPool()
 			}
@@ -2294,7 +2340,7 @@ func (js *jetStream) collectStreamAndConsumerChanges(c RaftNodeCheckpoint, strea
 					sa, err := decodeStreamAssignment(js.srv, buf[1:])
 					if err != nil {
 						js.srv.Errorf("JetStream cluster failed to decode stream assignment: %q", buf[1:])
-						panic(err)
+						return err
 					}
 					if op == removeStreamOp {
 						ru.removeStream(sa)
@@ -2305,25 +2351,25 @@ func (js *jetStream) collectStreamAndConsumerChanges(c RaftNodeCheckpoint, strea
 					ca, err := decodeConsumerAssignment(buf[1:])
 					if err != nil {
 						js.srv.Errorf("JetStream cluster failed to decode consumer assignment: %q", buf[1:])
-						panic(err)
+						return err
 					}
 					ru.addOrUpdateConsumer(ca)
 				case assignCompressedConsumerOp:
 					ca, err := decodeConsumerAssignmentCompressed(buf[1:])
 					if err != nil {
 						js.srv.Errorf("JetStream cluster failed to decode compressed consumer assignment: %q", buf[1:])
-						panic(err)
+						return err
 					}
 					ru.addOrUpdateConsumer(ca)
 				case removeConsumerOp:
 					ca, err := decodeConsumerAssignment(buf[1:])
 					if err != nil {
 						js.srv.Errorf("JetStream cluster failed to decode consumer assignment: %q", buf[1:])
-						panic(err)
+						return err
 					}
 					ru.removeConsumer(ca)
 				default:
-					panic(fmt.Sprintf("JetStream Cluster Unknown meta entry op type: %v", entryOp(buf[0])))
+					return fmt.Errorf("unknown meta entry op type: %v", entryOp(buf[0]))
 				}
 			}
 		}
@@ -2747,7 +2793,7 @@ func (js *jetStream) applyMetaEntries(entries []*Entry, ru *recoveryUpdates) (bo
 					js.processUpdateStreamAssignment(sa)
 				}
 			default:
-				panic(fmt.Sprintf("JetStream Cluster Unknown meta entry op type: %v", entryOp(buf[0])))
+				return isRecovering, didSnap, fmt.Errorf("unknown meta entry op type: %v", entryOp(buf[0]))
 			}
 		}
 	}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -840,6 +840,7 @@ func (js *jetStream) isConsumerHealthy(mset *stream, consumer string, ca *consum
 	if node != nil {
 		nrgWerr = node.GetWriteErr()
 	}
+	consumerWerr := o.getWriteErr()
 	switch {
 	case rc <= 1:
 		return nil // No further checks for R=1 consumers
@@ -860,6 +861,9 @@ func (js *jetStream) isConsumerHealthy(mset *stream, consumer string, ca *consum
 
 	case nrgWerr != nil:
 		return fmt.Errorf("node write error: %v", nrgWerr)
+
+	case consumerWerr != nil:
+		return fmt.Errorf("consumer write error: %v", consumerWerr)
 
 	case !o.isMonitorRunning():
 		return errors.New("monitor goroutine not running")
@@ -6462,6 +6466,44 @@ func (o *consumer) streamAndNode() (*stream, RaftNode) {
 	return o.mset, o.node
 }
 
+// setWriteErr stores the write error in the consumer.
+func (o *consumer) setWriteErr(err error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.setWriteErrLocked(err)
+}
+
+func (o *consumer) setWriteErrLocked(err error) {
+	if o.werr != nil {
+		return
+	}
+	// Ignore non-write errors.
+	if err == ErrStoreClosed {
+		return
+	}
+	o.srv.Errorf("JetStream consumer '%s > %s > %s' critical write error: %v", o.acc.Name, o.stream, o.name, err)
+	o.werr = err
+	assert.Unreachable("Consumer encountered write error", map[string]any{
+		"account":  o.acc.Name,
+		"stream":   o.stream,
+		"consumer": o.name,
+		"err":      err,
+	})
+
+	// If consumer is replicated, put it in observer mode to make sure another server can pick it up.
+	if node := o.node; node != nil {
+		node.StepDown()
+		node.SetObserver(true)
+	}
+}
+
+// getWriteErr returns the write error stored in the consumer (if any).
+func (o *consumer) getWriteErr() error {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.werr
+}
+
 // Return the replica count for this consumer. If the consumer has been
 // stopped, this will return an error.
 func (o *consumer) replica() (int, error) {
@@ -6641,7 +6683,12 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 						doSnapshot(false)
 					}
 				} else if err != errConsumerClosed {
-					s.Warnf("Error applying consumer entries to '%s > %s'", ca.Client.serviceAccount(), ca.Name)
+					s.Errorf("Error applying consumer entries to '%s > %s': %v", ca.Client.serviceAccount(), ca.Name, err)
+					// Encountered an unexpected error, can't continue.
+					o.setWriteErr(err)
+					ce.ReturnToPool()
+					aq.recycle(&ces)
+					return
 				}
 				ce.ReturnToPool()
 			}
@@ -6806,7 +6853,7 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 						s.Errorf("JetStream cluster could not decode consumer snapshot for '%s > %s > %s' [%s]",
 							mset.account(), mset.name(), o, node.Group())
 					}
-					panic(err.Error())
+					return err
 				}
 
 				if err = o.store.Update(state); err != nil && err != ErrStoreOldUpdate {
@@ -6861,7 +6908,7 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 						s.Errorf("JetStream cluster could not decode consumer delivered update for '%s > %s > %s' [%s]",
 							mset.account(), mset.name(), o, node.Group())
 					}
-					panic(err.Error())
+					return err
 				}
 				// Make sure to update delivered under the lock.
 				o.mu.Lock()
@@ -6886,7 +6933,7 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 				}
 				o.mu.Unlock()
 				if err != nil {
-					panic(err.Error())
+					return err
 				}
 			case updateAcksOp:
 				dseq, sseq, err := decodeAckUpdate(buf[1:])
@@ -6896,7 +6943,7 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 						s.Errorf("JetStream cluster could not decode consumer ack update for '%s > %s > %s' [%s]",
 							mset.account(), mset.name(), o, node.Group())
 					}
-					panic(err.Error())
+					return err
 				}
 				if err := o.processReplicatedAck(dseq, sseq); err == errConsumerClosed {
 					return err
@@ -6977,7 +7024,7 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 				}
 				o.mu.Unlock()
 			default:
-				panic(fmt.Sprintf("JetStream Cluster Unknown group entry op type: %v", entryOp(buf[0])))
+				return fmt.Errorf("unknown consumer entry op type: %v", entryOp(buf[0]))
 			}
 		}
 	}

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -12641,6 +12641,39 @@ func TestJetStreamClusterMalformedConsumerEntrySetsWriteErr(t *testing.T) {
 	require_True(t, cl.Running())
 }
 
+func TestJetStreamClusterMalformedMetaEntrySetsWriteErr(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	// Confirm the meta group is healthy and has no write error to begin with.
+	ml := c.leader()
+	require_True(t, ml != nil)
+	mjs := ml.getJetStream()
+	require_True(t, mjs != nil)
+	require_NoError(t, mjs.getMetaWriteErr())
+	require_Equal(t, ml.healthz(nil).Error, _EMPTY_)
+
+	// Craft a malformed meta entry using an unknown op, this must surface as a meta write error.
+	bad := []byte{255, 1, 2, 3}
+	n := mjs.getMetaGroup().(*raft)
+	n.sendAppendEntry([]*Entry{newEntry(EntryNormal, bad)})
+
+	checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+		werr := mjs.getMetaWriteErr()
+		if werr == nil {
+			return fmt.Errorf("meta write error not set yet")
+		}
+		// Healthz must now reflect the broken state.
+		if hs := ml.healthz(nil); hs.Error == _EMPTY_ {
+			return fmt.Errorf("meta group still reported healthy")
+		}
+		return nil
+	})
+
+	// Sanity: the server must still be running (no panic took it down).
+	require_True(t, ml.Running())
+}
+
 //
 // DO NOT ADD NEW TESTS IN THIS FILE (unless to balance test times)
 // Add at the end of jetstream_cluster_<n>_test.go, with <n> being the highest value.

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -12587,6 +12587,60 @@ func TestJetStreamClusterMalformedEntrySetsWriteErr(t *testing.T) {
 	require_True(t, sl.Running())
 }
 
+func TestJetStreamClusterMalformedConsumerEntrySetsWriteErr(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "CONS",
+		AckPolicy: nats.AckExplicitPolicy,
+		Replicas:  3,
+	})
+	require_NoError(t, err)
+
+	// Confirm the consumer is healthy and has no write error to begin with.
+	cl := c.consumerLeader(globalAccountName, "TEST", "CONS")
+	mset, err := cl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	o := mset.lookupConsumer("CONS")
+	require_True(t, o != nil)
+	require_NoError(t, o.getWriteErr())
+
+	cjs := cl.getJetStream()
+	ca := o.consumerAssignment()
+	require_NoError(t, cjs.isConsumerHealthy(mset, "CONS", ca))
+
+	// Craft a malformed consumer entry using an unknown op, this must surface as a consumer write error.
+	bad := []byte{255, 1, 2, 3}
+	n := o.raftNode().(*raft)
+	n.sendAppendEntry([]*Entry{newEntry(EntryNormal, bad)})
+
+	checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+		werr := o.getWriteErr()
+		if werr == nil {
+			return fmt.Errorf("consumer write error not set yet")
+		}
+		// Healthz must now reflect the broken state.
+		if err := cjs.isConsumerHealthy(mset, "CONS", ca); err == nil {
+			return fmt.Errorf("consumer still reported healthy")
+		}
+		return nil
+	})
+
+	// Sanity: the server must still be running (no panic took it down).
+	require_True(t, cl.Running())
+}
+
 //
 // DO NOT ADD NEW TESTS IN THIS FILE (unless to balance test times)
 // Add at the end of jetstream_cluster_<n>_test.go, with <n> being the highest value.

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -12546,6 +12546,47 @@ func TestJetStreamClusterStreamPeerRemovePeerSetDesync(t *testing.T) {
 	})
 }
 
+func TestJetStreamClusterMalformedEntrySetsWriteErr(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	// Confirm the stream is healthy and has no write error to begin with.
+	_, err = js.Publish("foo", []byte("ok"))
+	require_NoError(t, err)
+
+	sl := c.streamLeader(globalAccountName, "TEST")
+	mset, err := sl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	require_NoError(t, mset.getWriteErr())
+
+	// Craft a malformed streamMsgOp, this must surface as a stream write error.
+	bad := append([]byte{byte(streamMsgOp)}, 1, 2, 3)
+	n := mset.raftNode().(*raft)
+	n.sendAppendEntry([]*Entry{newEntry(EntryNormal, bad)})
+
+	checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+		werr := mset.getWriteErr()
+		if werr == nil {
+			return fmt.Errorf("stream write error not set yet")
+		}
+		require_Error(t, werr, errBadStreamMsg)
+		return nil
+	})
+
+	// Sanity: the server must still be running (no panic took it down).
+	require_True(t, sl.Running())
+}
+
 //
 // DO NOT ADD NEW TESTS IN THIS FILE (unless to balance test times)
 // Add at the end of jetstream_cluster_<n>_test.go, with <n> being the highest value.

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -8576,3 +8576,56 @@ func TestJetStreamClusterDecodeBatchMsgRejectsMalformed(t *testing.T) {
 		})
 	}
 }
+
+func TestJetStreamClusterCatchupBadMsgStopsRetrying(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		return checkState(t, c, globalAccountName, "TEST")
+	})
+
+	rs := c.randomNonStreamLeader(globalAccountName, "TEST")
+	mset, err := rs.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	sa := mset.streamAssignment()
+
+	// Make sure this server can't become the leader.
+	n := mset.raftNode().(*raft)
+	n.SetObserver(true)
+
+	sysNc, err := nats.Connect(rs.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer sysNc.Close()
+
+	sjs := rs.getJetStream()
+	sjs.mu.RLock()
+	syncSubj := sa.Sync
+	sjs.mu.RUnlock()
+
+	// Respond to the catchup with a corrupt compressed message.
+	var count atomic.Int32
+	sub, err := sysNc.Subscribe(syncSubj, func(msg *nats.Msg) {
+		count.Add(1)
+		// {0x80} is an incomplete varint and fails s2.Decode with corrupt input.
+		msg.Respond(append([]byte{byte(compressedStreamMsgOp)}, 0x80))
+	})
+	require_NoError(t, err)
+	defer sub.Drain()
+	require_NoError(t, sysNc.Flush()) // Must flush, otherwise our subscription could be too late.
+
+	err = mset.processSnapshot(&StreamReplicatedState{FirstSeq: 1, LastSeq: 1}, 1)
+	require_Error(t, err, errCatchupBadMsg)
+
+	// We must not have retried the catchup, a bad message bails out immediately.
+	require_Equal(t, count.Load(), 1)
+}

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -8446,3 +8446,133 @@ func TestJetStreamClusterWorkQueueConsumerCreateRejectionNoOrphan(t *testing.T) 
 		}
 	}
 }
+
+func TestJetStreamClusterDecodeStreamMsgRejectsMalformed(t *testing.T) {
+	// The field lengths are deliberately large enough that every field
+	// boundary lands past the 26-byte minimum.
+	const (
+		subjLen  = 20
+		replyLen = 10
+		hdrLen   = 10
+		msgLen   = 10
+	)
+	subject := strings.Repeat("s", subjLen)
+	reply := strings.Repeat("r", replyLen)
+	hdr := []byte(strings.Repeat("h", hdrLen))
+	body := []byte(strings.Repeat("b", msgLen))
+	valid := encodeStreamMsg(subject, reply, hdr, body, 12345, 67890, true)[1:]
+
+	// Sanity check that the valid buffer round-trips.
+	gotSubj, gotReply, gotHdr, gotMsg, lseq, ts, sourced, err := decodeStreamMsg(valid)
+	require_NoError(t, err)
+	require_Equal(t, gotSubj, subject)
+	require_Equal(t, gotReply, reply)
+	require_Equal(t, string(gotHdr), string(hdr))
+	require_Equal(t, string(gotMsg), string(body))
+	require_Equal(t, lseq, 12345)
+	require_Equal(t, ts, 67890)
+	require_True(t, sourced)
+
+	// Field boundary offsets within valid. The decoder reads, in order:
+	// lseq(8) + ts(8) + subjLen(2) + subject + replyLen(2) + reply +
+	// hdrLen(2) + hdr + msgLen(4) + msg + flags(uvarint).
+	const (
+		fixedEnd    = 8 + 8        // after lseq + ts
+		subjLenEnd  = fixedEnd + 2 // after subject length prefix
+		subjEnd     = subjLenEnd + subjLen
+		replyLenEnd = subjEnd + 2 // after reply length prefix
+		replyEnd    = replyLenEnd + replyLen
+		hdrLenEnd   = replyEnd + 2 // after hdr length prefix
+		hdrEnd      = hdrLenEnd + hdrLen
+		msgLenEnd   = hdrEnd + 4 // after msg length prefix
+		msgEnd      = msgLenEnd + msgLen
+	)
+
+	// Dropping the trailing optional flags still decodes successfully.
+	_, _, _, _, _, _, sourced, err = decodeStreamMsg(valid[:msgEnd])
+	require_NoError(t, err)
+	require_False(t, sourced) // No flags means not sourced.
+
+	for _, test := range []struct {
+		title string
+		buf   []byte
+	}{
+		{title: "Empty", buf: nil},
+		// Smaller than the fixed-size prefix (lseq+ts+subjLen+...), trips the initial length guard.
+		{title: "TooShort", buf: valid[:25]},
+		// Past the guard, but the subject claims more bytes than remain.
+		{title: "TruncatedSubj", buf: valid[:subjEnd-1]},
+		// Subject present, but the reply length prefix is missing.
+		{title: "TruncatedReplyLen", buf: valid[:subjEnd]},
+		// Reply claims more bytes than remain.
+		{title: "TruncatedReply", buf: valid[:replyEnd-1]},
+		// Subject+reply present, but the header length prefix is missing.
+		{title: "TruncatedHdrLen", buf: valid[:replyEnd]},
+		// Header claims more bytes than remain.
+		{title: "TruncatedHdr", buf: valid[:hdrEnd-1]},
+		// Subject+reply+hdr present, but the msg length prefix (4 bytes) is missing.
+		{title: "TruncatedMsgLen", buf: valid[:hdrEnd]},
+		// Msg claims more bytes than remain.
+		{title: "TruncatedMsg", buf: valid[:msgEnd-1]},
+	} {
+		t.Run(test.title, func(t *testing.T) {
+			_, _, _, _, _, _, _, err = decodeStreamMsg(test.buf)
+			require_Error(t, err, errBadStreamMsg)
+		})
+	}
+}
+
+func TestJetStreamClusterDecodeBatchMsgRejectsMalformed(t *testing.T) {
+	// Build a valid encoded batch msg payload (the buffer passed to
+	// decodeBatchMsg is everything after the leading batch op byte).
+	full := encodeStreamMsgAllowCompressAndBatch("foo", _EMPTY_, nil, []byte("body"), 1, 2, false, "batch", 7, false)
+	valid := full[1:]
+
+	// Sanity check that the valid buffer round-trips.
+	batchId, batchSeq, op, mbuf, err := decodeBatchMsg(valid)
+	require_NoError(t, err)
+	require_Equal(t, batchId, "batch")
+	require_Equal(t, batchSeq, 7)
+	require_Equal(t, op, streamMsgOp)
+	require_True(t, len(mbuf) > 0)
+
+	// The mbuf left over from a valid batch msg must itself decode as a valid stream msg.
+	subject, reply, hdr, msg, lseq, ts, sourced, err := decodeStreamMsg(mbuf)
+	require_NoError(t, err)
+	require_Equal(t, subject, "foo")
+	require_Equal(t, reply, _EMPTY_)
+	require_Equal(t, len(hdr), 0)
+	require_Equal(t, string(msg), "body")
+	require_Equal(t, lseq, 1)
+	require_Equal(t, ts, 2)
+	require_False(t, sourced)
+
+	// Field boundary offsets within valid. The decoder reads, in order:
+	// batchIdLen(2) + batchId("batch") + batchSeq(uvarint, 1 byte for 7) + op(1).
+	const (
+		batchIdLenEnd = 2                            // after batchId length prefix
+		batchIdEnd    = batchIdLenEnd + len("batch") // after batchId bytes
+		batchSeqEnd   = batchIdEnd + 1               // after the single-byte seq varint
+	)
+
+	for _, test := range []struct {
+		title string
+		buf   []byte
+	}{
+		{title: "Empty", buf: nil},
+		// Smaller than the 2-byte batchId length prefix.
+		{title: "TooShort", buf: valid[:1]},
+		// Claims a batchId longer than the remaining bytes.
+		{title: "TruncatedBatchId", buf: valid[:batchIdEnd-1]},
+		// batchId present, but the batchSeq varint is missing.
+		{title: "TruncatedSeq", buf: valid[:batchIdEnd]},
+		// batchId+batchSeq present, but the op byte is missing.
+		// This previously caused an index-out-of-range panic.
+		{title: "TruncatedOp", buf: valid[:batchSeqEnd]},
+	} {
+		t.Run(test.title, func(t *testing.T) {
+			_, _, _, _, err := decodeBatchMsg(test.buf)
+			require_Error(t, err, errBadStreamMsg)
+		})
+	}
+}

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3836,11 +3836,16 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 		metaUnhealthy = !meta.Healthy()
 		metaWerr = meta.GetWriteErr()
 	}
+	// Surface an application-level meta write error (e.g. an undecodable meta entry)
+	// in addition to the node-level write error above.
+	metaApplyErr := js.getMetaWriteErr()
 	metaRecovering := js.isMetaRecovering()
-	if meta == nil || metaNoLeader || metaClosed || metaUnhealthy || metaWerr != nil || metaRecovering {
+	if meta == nil || metaNoLeader || metaClosed || metaUnhealthy || metaWerr != nil || metaApplyErr != nil || metaRecovering {
 		var desc string
 		if metaWerr != nil {
 			desc = fmt.Sprintf("JetStream meta layer write error: %v", metaWerr)
+		} else if metaApplyErr != nil {
+			desc = fmt.Sprintf("JetStream meta layer apply error: %v", metaApplyErr)
 		} else if metaClosed {
 			desc = "JetStream meta layer is not running"
 		} else if meta != nil && metaRecovering {


### PR DESCRIPTION
This PR removes all `panic` calls from `jetstream_cluster.go` and turns them into graceful write errors that freeze the respective layer and exposes it in `/healthz`. This aligns with 2.14 already exposing stream write errors in `/healthz`, and relies on tooling to detect this.

- General fixes:
  - Handle an out of bounds read in `decodeBatchMsg` that would result in a `panic`. Note that a `decodeBatchMsg` error would still `panic` either way until the 2.15 changes below.
  - If a replicated stream restore finishes while the server is _somehow_ no longer leader, it would previously `panic`, this is now returned as a normal error response.
-  2.14: Expose consumer Raft write errors in `/healthz`, as stream and meta write errors already were.
- 2.15: Remove remaining panics from `jetstream_cluster.go`, and expose them as write errors for meta, stream, and consumer layers.