### PR TITLE
Revisit filestore `dios`

### DIFF
--- a/server/dios.go
+++ b/server/dios.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"runtime"
+	"sync/atomic"
+	"time"
+)
+
+// Used to limit number of disk IO calls in flight since they could all be blocking an OS thread.
+// https://github.com/nats-io/nats-server/issues/2742
+type diskIOSemaphore struct {
+	ch           chan struct{}
+	waiters      atomic.Int64
+	waits        atomic.Uint64
+	waitNanos    atomic.Uint64
+	maxWaitNanos atomic.Uint64
+}
+
+func newDiskIOSemaphore(n int) *diskIOSemaphore {
+	d := &diskIOSemaphore{ch: make(chan struct{}, n)}
+	for range n {
+		d.ch <- struct{}{}
+	}
+	return d
+}
+
+func defaultDiskIOSemaphore() *diskIOSemaphore {
+	// Limit ourselves to a sensible number of blocking I/O calls.
+	// Range between 4-16 concurrent disk I/Os based on CPU cores,
+	// or 50% of cores if greater than 32 cores.
+	mp := runtime.GOMAXPROCS(-1)
+	nIO := min(16, max(4, mp))
+	if mp > 32 {
+		nIO = max(16, mp/2)
+	}
+	return newDiskIOSemaphore(nIO)
+}
+
+func (d *diskIOSemaphore) acquire() {
+	select {
+	case <-d.ch:
+		return
+	default:
+		// No slot available, count this
+		// waiter before blocking.
+		d.waiters.Add(1)
+		start := time.Now()
+		<-d.ch
+		waited := time.Since(start)
+		d.waiters.Add(-1)
+		d.countWait(uint64(waited.Nanoseconds()))
+	}
+}
+
+func (d *diskIOSemaphore) countWait(ns uint64) {
+	d.waits.Add(1)
+	d.waitNanos.Add(ns)
+	for {
+		cur := d.maxWaitNanos.Load()
+		if ns <= cur || d.maxWaitNanos.CompareAndSwap(cur, ns) {
+			return
+		}
+	}
+}
+
+func (d *diskIOSemaphore) release() {
+	d.ch <- struct{}{}
+}
+
+func (d *diskIOSemaphore) cap() int {
+	return cap(d.ch)
+}

--- a/server/dios.go
+++ b/server/dios.go
@@ -14,7 +14,6 @@
 package server
 
 import (
-	"runtime"
 	"sync/atomic"
 	"time"
 )
@@ -38,15 +37,11 @@ func newDiskIOSemaphore(n int) *diskIOSemaphore {
 }
 
 func defaultDiskIOSemaphore() *diskIOSemaphore {
-	// Limit ourselves to a sensible number of blocking I/O calls.
-	// Range between 4-16 concurrent disk I/Os based on CPU cores,
-	// or 50% of cores if greater than 32 cores.
-	mp := runtime.GOMAXPROCS(-1)
-	nIO := min(16, max(4, mp))
-	if mp > 32 {
-		nIO = max(16, mp/2)
-	}
-	return newDiskIOSemaphore(nIO)
+	// The disk IO semaphore used to be sized based on the number
+	// of CPU cores. That policy led to poor use of devices that
+	// can handle many requests in parallel, so simply cap the
+	// number of concurrent IO requests handed to the Go runtime.
+	return newDiskIOSemaphore(512)
 }
 
 func (d *diskIOSemaphore) acquire() {

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -214,6 +214,7 @@ type fileStore struct {
 	scheduling  *MsgScheduling
 	sdm         *SDMMeta
 	lpex        time.Time // Last PurgeEx call.
+	dios        *diskIOSemaphore
 }
 
 // Represents a message store block and its data.
@@ -410,6 +411,7 @@ func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created tim
 	if fcfg.SyncInterval == 0 {
 		fcfg.SyncInterval = defaultSyncInterval
 	}
+	dios := fcfg.srv.diskIOSemaphore()
 
 	// Check the directory
 	if stat, err := os.Stat(fcfg.StoreDir); os.IsNotExist(err) {
@@ -425,12 +427,13 @@ func newFileStoreWithCreated(fcfg FileStoreConfig, cfg StreamConfig, created tim
 	}
 
 	tmpfile.Close()
-	<-dios
+	dios.acquire()
 	os.Remove(tmpfile.Name())
-	dios <- struct{}{}
+	dios.release()
 
 	fs = &fileStore{
 		fcfg:   fcfg,
+		dios:   dios,
 		psim:   stree.NewSubjectTree[psi](),
 		bim:    make(map[uint32]*msgBlock),
 		cfg:    FileStreamInfo{Created: created, StreamConfig: cfg},
@@ -1439,9 +1442,9 @@ func (mb *msgBlock) convertCipher() error {
 			return err
 		}
 		mb.bek.XORKeyStream(buf, buf)
-		<-dios
+		mb.fs.dios.acquire()
 		err = os.WriteFile(mb.mfn, buf, defaultFilePerms)
-		dios <- struct{}{}
+		mb.fs.dios.release()
 		if err != nil {
 			return err
 		}
@@ -1481,9 +1484,9 @@ func (mb *msgBlock) convertToEncrypted() error {
 		return err
 	}
 	mb.bek.XORKeyStream(buf, buf)
-	<-dios
+	mb.fs.dios.acquire()
 	err = os.WriteFile(mb.mfn, buf, defaultFilePerms)
-	dios <- struct{}{}
+	mb.fs.dios.release()
 	if err != nil {
 		return err
 	}
@@ -1604,9 +1607,9 @@ func (mb *msgBlock) rebuildStateFromBufLocked(buf []byte, allowTruncate bool) (*
 		if mb.mfd != nil {
 			fd = mb.mfd
 		} else {
-			<-dios
+			mb.fs.dios.acquire()
 			fd, err = os.OpenFile(mb.mfn, os.O_RDWR, defaultFilePerms)
-			dios <- struct{}{}
+			mb.fs.dios.release()
 			if err == nil {
 				defer fd.Close()
 			}
@@ -1873,15 +1876,15 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 	defer fs.mu.Unlock()
 
 	// Check for any left over purged messages.
-	<-dios
+	fs.dios.acquire()
 	if err := fs.recoverPartialPurge(); err != nil {
-		dios <- struct{}{}
+		fs.dios.release()
 		return err
 	}
 	// Grab our stream state file and load it in.
 	fn := filepath.Join(fs.fcfg.StoreDir, msgDir, streamStreamStateFile)
 	buf, err := os.ReadFile(fn)
-	dios <- struct{}{}
+	fs.dios.release()
 
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -2110,12 +2113,12 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 	mdir := filepath.Join(fs.fcfg.StoreDir, msgDir)
 	var dirs []os.DirEntry
 
-	<-dios
+	fs.dios.acquire()
 	if f, err := os.Open(mdir); err == nil {
 		dirs, _ = f.ReadDir(-1)
 		f.Close()
 	}
-	dios <- struct{}{}
+	fs.dios.release()
 
 	var index uint32
 	for _, fi := range dirs {
@@ -2161,10 +2164,10 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 // Lock should be held.
 func (fs *fileStore) recoverTTLState() error {
 	// See if we have a timed hash wheel for TTLs.
-	<-dios
+	fs.dios.acquire()
 	fn := filepath.Join(fs.fcfg.StoreDir, msgDir, ttlStreamStateFile)
 	buf, err := os.ReadFile(fn)
-	dios <- struct{}{}
+	fs.dios.release()
 
 	if err != nil && !os.IsNotExist(err) {
 		return err
@@ -2248,10 +2251,10 @@ func (fs *fileStore) recoverTTLState() error {
 // Lock should be held.
 func (fs *fileStore) recoverMsgSchedulingState() error {
 	// See if we have a timed hash wheel for TTLs.
-	<-dios
+	fs.dios.acquire()
 	fn := filepath.Join(fs.fcfg.StoreDir, msgDir, msgSchedulingStreamStateFile)
 	buf, err := os.ReadFile(fn)
-	dios <- struct{}{}
+	fs.dios.release()
 
 	if err != nil && !os.IsNotExist(err) {
 		return err
@@ -2373,9 +2376,9 @@ func (fs *fileStore) cleanupOldMeta() {
 	mdir := filepath.Join(fs.fcfg.StoreDir, msgDir)
 	fs.mu.RUnlock()
 
-	<-dios
+	fs.dios.acquire()
 	f, err := os.Open(mdir)
-	dios <- struct{}{}
+	fs.dios.release()
 	if err != nil {
 		return
 	}
@@ -2400,20 +2403,20 @@ func (fs *fileStore) recoverMsgs() error {
 	defer fs.mu.Unlock()
 
 	// Check for any left over purged messages.
-	<-dios
+	fs.dios.acquire()
 	if err := fs.recoverPartialPurge(); err != nil {
-		dios <- struct{}{}
+		fs.dios.release()
 		return err
 	}
 	mdir := filepath.Join(fs.fcfg.StoreDir, msgDir)
 	f, err := os.Open(mdir)
 	if err != nil {
-		dios <- struct{}{}
+		fs.dios.release()
 		return errNotReadable
 	}
 	dirs, err := f.ReadDir(-1)
 	f.Close()
-	dios <- struct{}{}
+	fs.dios.release()
 
 	if err != nil {
 		return errNotReadable
@@ -4807,9 +4810,9 @@ func (fs *fileStore) newMsgBlockForWrite() (*msgBlock, error) {
 	}
 	mb.hh = hh
 
-	<-dios
+	fs.dios.acquire()
 	mfd, err := os.OpenFile(mb.mfn, os.O_CREATE|os.O_RDWR, defaultFilePerms)
-	dios <- struct{}{}
+	fs.dios.release()
 
 	if err != nil {
 		if isPermissionError(err) {
@@ -6135,9 +6138,9 @@ func (mb *msgBlock) compactWithFloor(floor uint64, fsDmap *avl.SequenceSet) erro
 
 	// We will write to a new file and mv/rename it in case of failure.
 	mfn := filepath.Join(mb.fs.fcfg.StoreDir, msgDir, fmt.Sprintf(newScan, mb.index))
-	<-dios
+	mb.fs.dios.acquire()
 	err := os.WriteFile(mfn, nbuf, defaultFilePerms)
-	dios <- struct{}{}
+	mb.fs.dios.release()
 	if err != nil {
 		_ = os.Remove(mfn)
 		return err
@@ -7132,9 +7135,9 @@ func (mb *msgBlock) enableForWriting(fip bool) error {
 	if mb.mfd != nil {
 		return nil
 	}
-	<-dios
+	mb.fs.dios.acquire()
 	mfd, err := os.OpenFile(mb.mfn, os.O_CREATE|os.O_RDWR, defaultFilePerms)
-	dios <- struct{}{}
+	mb.fs.dios.release()
 	if err != nil {
 		return fmt.Errorf("error opening msg block file [%q]: %v", mb.mfn, err)
 	}
@@ -7527,9 +7530,9 @@ func (mb *msgBlock) recompressOnDiskIfNeeded() error {
 	//    header, in which case we do nothing.
 	// 2. The block will be uncompressed, in which case we will compress it
 	//    and then write it back out to disk, re-encrypting if necessary.
-	<-dios
+	mb.fs.dios.acquire()
 	origBuf, err := os.ReadFile(mb.mfn)
-	dios <- struct{}{}
+	mb.fs.dios.release()
 
 	if err != nil {
 		return fmt.Errorf("failed to read original block from disk: %w", err)
@@ -7583,9 +7586,9 @@ func (mb *msgBlock) atomicOverwriteFile(buf []byte, allowCompress bool) error {
 	// operation if something goes wrong), create a new temporary file. We will
 	// write out the new block here and then swap the files around afterwards
 	// once everything else has succeeded correctly.
-	<-dios
+	mb.fs.dios.acquire()
 	tmpFD, err := os.OpenFile(tmpFN, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, defaultFilePerms)
-	dios <- struct{}{}
+	mb.fs.dios.release()
 
 	if err != nil {
 		return fmt.Errorf("failed to create temporary file: %w", err)
@@ -7832,9 +7835,9 @@ func (fs *fileStore) syncBlocks() {
 			if mb.mfd != nil {
 				fd = mb.mfd
 			} else {
-				<-dios
+				fs.dios.acquire()
 				fd, err = os.OpenFile(mb.mfn, os.O_RDWR, defaultFilePerms)
-				dios <- struct{}{}
+				fs.dios.release()
 				didOpen = true
 				if err != nil && !os.IsNotExist(err) {
 					mb.mu.Unlock()
@@ -7881,9 +7884,9 @@ func (fs *fileStore) syncBlocks() {
 		fn := filepath.Join(fs.fcfg.StoreDir, msgDir, streamStreamStateFile)
 		var fd *os.File
 		var err error
-		<-dios
+		fs.dios.acquire()
 		fd, err = os.OpenFile(fn, os.O_RDWR, defaultFilePerms)
-		dios <- struct{}{}
+		fs.dios.release()
 		if err != nil && !os.IsNotExist(err) {
 			fs.setWriteErr(err)
 			return
@@ -8194,9 +8197,9 @@ func (mb *msgBlock) writeAt(buf []byte, woff int64) (int, error) {
 		mb.mockWriteErr = false
 		return 0, errors.New("mock write error")
 	}
-	<-dios
+	mb.fs.dios.acquire()
 	n, err := mb.mfd.WriteAt(buf, woff)
-	dios <- struct{}{}
+	mb.fs.dios.release()
 	return n, err
 }
 
@@ -8356,9 +8359,9 @@ func (mb *msgBlock) fssNotLoaded() bool {
 // Lock should be held
 func (mb *msgBlock) openBlock() (*os.File, error) {
 	// Gate with concurrent IO semaphore.
-	<-dios
+	mb.fs.dios.acquire()
 	f, err := os.Open(mb.mfn)
-	dios <- struct{}{}
+	mb.fs.dios.release()
 	return f, err
 }
 
@@ -8403,9 +8406,9 @@ func (mb *msgBlock) loadBlock(buf []byte) ([]byte, error) {
 		buf = getMsgBlockBuf(sz)
 	}
 
-	<-dios
+	mb.fs.dios.acquire()
 	n, err := io.ReadFull(f, buf[:sz])
-	dios <- struct{}{}
+	mb.fs.dios.release()
 	// On success capture raw bytes size.
 	if err == nil {
 		mb.rbytes = uint64(n)
@@ -10144,35 +10147,35 @@ func (fs *fileStore) purge(fseq uint64) (purged uint64, rerr error) {
 	mdir := filepath.Join(fs.fcfg.StoreDir, msgDir)
 	ndir := filepath.Join(fs.fcfg.StoreDir, newMsgDir)
 	pdir := filepath.Join(fs.fcfg.StoreDir, purgeDir)
-	<-dios
+	fs.dios.acquire()
 	// If purge directory still exists then we need to wait
 	// in place and remove since rename would fail.
 	if _, err := os.Stat(ndir); err == nil {
 		if err = os.RemoveAll(ndir); err != nil {
-			dios <- struct{}{}
+			fs.dios.release()
 			fs.mu.Unlock()
 			return purged, err
 		}
 	} else if !os.IsNotExist(err) {
-		dios <- struct{}{}
+		fs.dios.release()
 		fs.mu.Unlock()
 		return purged, err
 	}
 	if _, err := os.Stat(pdir); err == nil {
 		if err = os.RemoveAll(pdir); err != nil {
-			dios <- struct{}{}
+			fs.dios.release()
 			fs.mu.Unlock()
 			return purged, err
 		}
 	} else if !os.IsNotExist(err) {
-		dios <- struct{}{}
+		fs.dios.release()
 		fs.mu.Unlock()
 		return purged, err
 	}
 
 	// Create directory to move the new tombstone to.
 	if err := os.MkdirAll(ndir, defaultDirPerms); err != nil {
-		dios <- struct{}{}
+		fs.dios.release()
 		fs.mu.Unlock()
 		return purged, err
 	}
@@ -10183,30 +10186,30 @@ func (fs *fileStore) purge(fseq uint64) (purged uint64, rerr error) {
 		b := filepath.Join(mdir, mbf)
 		a := filepath.Join(ndir, mbf)
 		if err := os.Rename(b, a); err != nil && !os.IsNotExist(err) {
-			dios <- struct{}{}
+			fs.dios.release()
 			fs.mu.Unlock()
 			return purged, err
 		}
 	}
 	// Purge all remaining messages.
 	if err := os.Rename(mdir, pdir); err != nil {
-		dios <- struct{}{}
+		fs.dios.release()
 		fs.mu.Unlock()
 		return purged, err
 	}
 	// Rename the directory back to be left only with the tombstone.
 	if err := os.Rename(ndir, mdir); err != nil {
-		dios <- struct{}{}
+		fs.dios.release()
 		fs.mu.Unlock()
 		return purged, err
 	}
-	dios <- struct{}{}
+	fs.dios.release()
 
 	// Remove the purged messages directory asynchronously.
 	go func() {
-		<-dios
+		fs.dios.acquire()
 		_ = os.RemoveAll(pdir)
-		dios <- struct{}{}
+		fs.dios.release()
 	}()
 
 	// Re-enable writing for the lmb.
@@ -10486,9 +10489,9 @@ func (fs *fileStore) compact(seq uint64) (purged uint64, rerr error) {
 
 			// We will write to a new file and mv/rename it in case of failure.
 			mfn := filepath.Join(smb.fs.fcfg.StoreDir, msgDir, fmt.Sprintf(newScan, smb.index))
-			<-dios
+			fs.dios.acquire()
 			err = os.WriteFile(mfn, nbuf, defaultFilePerms)
-			dios <- struct{}{}
+			fs.dios.release()
 			if err != nil {
 				_ = os.Remove(mfn)
 				smb.mu.Unlock()
@@ -11470,19 +11473,19 @@ func (fs *fileStore) populateGlobalPerSubjectInfo(mb *msgBlock) error {
 // Calls os.RemoveAll on the given `dir` directory, but if an error occurs,
 // retries up to one second. If that still fails, returns the last error
 // that os.RemoveAll returned.
-func removeAllWithRetry(dir string) error {
-	<-dios
+func removeAllWithRetry(dios *diskIOSemaphore, dir string) error {
+	dios.acquire()
 	err := os.RemoveAll(dir)
-	dios <- struct{}{}
+	dios.release()
 	if err == nil {
 		return nil
 	}
 	ttl := time.Now().Add(time.Second)
 	for time.Now().Before(ttl) {
 		time.Sleep(10 * time.Millisecond)
-		<-dios
+		dios.acquire()
 		err = os.RemoveAll(dir)
-		dios <- struct{}{}
+		dios.release()
 		if err == nil {
 			return nil
 		}
@@ -11591,11 +11594,11 @@ func (fs *fileStore) Delete(inline bool) error {
 	// Do this in separate Go routine in case lots of blocks.
 	// Purge above protects us as does the removal of meta artifacts above.
 	if inline {
-		if err := removeAllWithRetry(ndir); err != nil {
+		if err := removeAllWithRetry(fs.dios, ndir); err != nil {
 			return err
 		}
 	} else {
-		go removeAllWithRetry(ndir)
+		go removeAllWithRetry(fs.dios, ndir)
 	}
 	return nil
 }
@@ -11891,10 +11894,10 @@ func (fs *fileStore) _writeFullState(force bool) error {
 
 	// Write our update index.db
 	// Protect with dios.
-	<-dios
+	fs.dios.acquire()
 	err := os.WriteFile(fn, buf, defaultFilePerms)
 	// if file system is not writable isPermissionError is set to true
-	dios <- struct{}{}
+	fs.dios.release()
 	if err != nil {
 		return err
 	}
@@ -13146,29 +13149,6 @@ func (o *consumerFileStore) encryptState(buf []byte) ([]byte, error) {
 	return o.aek.Seal(nonce, nonce, buf, nil), nil
 }
 
-// Used to limit number of disk IO calls in flight since they could all be blocking an OS thread.
-// https://github.com/nats-io/nats-server/issues/2742
-var dios chan struct{}
-
-// Used to setup our simplistic counting semaphore using buffered channels.
-// golang.org's semaphore seemed a bit heavy.
-func init() {
-	// Limit ourselves to a sensible number of blocking I/O calls. Range between
-	// 4-16 concurrent disk I/Os based on CPU cores, or 50% of cores if greater
-	// than 32 cores.
-	mp := runtime.GOMAXPROCS(-1)
-	nIO := min(16, max(4, mp))
-	if mp > 32 {
-		// If the system has more than 32 cores then limit dios to 50% of cores.
-		nIO = max(16, min(mp, mp/2))
-	}
-	dios = make(chan struct{}, nIO)
-	// Fill it up to start.
-	for i := 0; i < nIO; i++ {
-		dios <- struct{}{}
-	}
-}
-
 func (o *consumerFileStore) writeState(buf []byte) error {
 	// Check if we have the index file open.
 	o.mu.Lock()
@@ -13349,9 +13329,9 @@ func (o *consumerFileStore) stateWithCopyLocked(doCopy bool) (*ConsumerState, er
 	}
 
 	// Read the state in here from disk..
-	<-dios
+	o.fs.dios.acquire()
 	buf, err := os.ReadFile(o.ifn)
-	dios <- struct{}{}
+	o.fs.dios.release()
 
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
@@ -13612,7 +13592,7 @@ func (o *consumerFileStore) delete(streamDeleted bool) error {
 
 	// If our stream was not deleted this will remove the directories.
 	if odir != _EMPTY_ && !streamDeleted {
-		if err := removeAllWithRetry(odir); err != nil {
+		if err := removeAllWithRetry(o.fs.dios, odir); err != nil {
 			return err
 		}
 	}
@@ -13753,27 +13733,25 @@ func (alg StoreCompression) Decompress(buf []byte) ([]byte, error) {
 // sets O_SYNC on the open file if SyncAlways is set. The dios semaphore is
 // handled automatically by this function, so don't wrap calls to it in dios.
 func (fs *fileStore) writeFileWithOptionalSync(name string, data []byte, perm fs.FileMode) error {
-	return writeAtomically(name, data, perm, fs.fcfg.SyncAlways)
+	return writeAtomically(fs.dios, name, data, perm, fs.fcfg.SyncAlways)
 }
 
-func writeFileWithSync(name string, data []byte, perm fs.FileMode) error {
-	return writeAtomically(name, data, perm, true)
+func writeFileWithSync(dios *diskIOSemaphore, name string, data []byte, perm fs.FileMode) error {
+	return writeAtomically(dios, name, data, perm, true)
 }
 
 // Windows does not support fsyncing directory metadata, it results in a panic, so
 // we need to skip doing this there.
 const canFsyncDirectories = runtime.GOOS != "windows"
 
-func writeAtomically(name string, data []byte, perm fs.FileMode, sync bool) error {
+func writeAtomically(dios *diskIOSemaphore, name string, data []byte, perm fs.FileMode, sync bool) error {
 	tmp := name + ".tmp"
 	flags := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
 	if sync {
 		flags = flags | os.O_SYNC
 	}
-	<-dios
-	defer func() {
-		dios <- struct{}{}
-	}()
+	dios.acquire()
+	defer dios.release()
 	f, err := os.OpenFile(tmp, flags, perm)
 	if err != nil {
 		return err

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -8759,6 +8759,77 @@ func Benchmark_FileStoreSyncDeletedPartialBlocks(b *testing.B) {
 	}
 }
 
+// Based on TestNoRaceJetStreamConsumerFileStoreConcurrentDiskIO, a test that
+// was introduced together with the disk IO semaphore "dios".
+func BenchmarkFileStoreConsumerStoreConcurrentDiskIO(b *testing.B) {
+	const consumersPerIteration = 10000
+
+	// This compares the same operations of that using a filestore configure with
+	// default "dios", against a filestore with an unbounded "dios" (make it as
+	// (large as the number of consumer stores created by the test).
+	for _, test := range []struct {
+		name string
+		dios *diskIOSemaphore
+	}{
+		{name: "default_dios", dios: defaultDiskIOSemaphore()},
+		{name: "unbounded_dios", dios: newDiskIOSemaphore(consumersPerIteration)},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			storeRoot := benchmarkDir(b)
+			var dioLimit int
+
+			b.StopTimer()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				storeDir := filepath.Join(storeRoot, fmt.Sprintf("%d", i))
+				fs, err := newFileStore(FileStoreConfig{StoreDir: storeDir}, StreamConfig{Name: "MT", Storage: FileStorage})
+				require_NoError(b, err)
+				fs.dios = test.dios
+				dioLimit = fs.dios.cap()
+
+				var wg sync.WaitGroup
+				ts := time.Now().UnixNano()
+
+				b.StartTimer()
+				for j := 1; j <= consumersPerIteration; j++ {
+					name := fmt.Sprintf("o%d", j)
+					o, err := fs.ConsumerStore(name, time.Time{}, &ConsumerConfig{AckPolicy: AckExplicit})
+					require_NoError(b, err)
+					wg.Add(1)
+
+					go func(o ConsumerStore) {
+						defer wg.Done()
+						if err := o.UpdateDelivered(22, 22, 1, ts); err != nil {
+							panic(err)
+						}
+						cfs := o.(*consumerFileStore)
+						buf, err := cfs.encodeState()
+						if err != nil {
+							panic(err)
+						}
+						if err := cfs.writeState(buf); err != nil {
+							panic(err)
+						}
+						if err := o.Delete(); err != nil {
+							panic(err)
+						}
+					}(o)
+				}
+
+				wg.Wait()
+				b.StopTimer()
+
+				require_NoError(b, fs.Stop())
+			}
+
+			b.ReportMetric(0, "ns/op")
+			b.ReportMetric(float64(dioLimit), "dios_limit")
+			b.ReportMetric(float64(b.N*consumersPerIteration)/b.Elapsed().Seconds(), "consumer_ops/s")
+		})
+	}
+}
+
 func TestFileStoreWriteFullStateDetectCorruptState(t *testing.T) {
 	fs, err := newFileStore(
 		FileStoreConfig{StoreDir: t.TempDir()},

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -14231,9 +14231,9 @@ func TestFileStoreConvertToEncryptedDoesNotResurrectXoredCache(t *testing.T) {
 	rbek, err := genBlockEncryptionKey(fcfg.Cipher, mb.seed, mb.nonce)
 	require_NoError(t, err)
 	rbek.XORKeyStream(encBuf, encBuf)
-	<-dios
+	fs.dios.acquire()
 	err = os.WriteFile(mb.mfn, encBuf, defaultFilePerms)
-	dios <- struct{}{}
+	fs.dios.release()
 	require_NoError(t, err)
 	recycleMsgBlockBuf(encBuf)
 

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -716,7 +716,7 @@ func (s *Server) disableJetStream(deleteState bool) error {
 func (s *Server) enableJetStreamAccounts() error {
 	// Reuse the same task workers across all accounts, so that we don't explode
 	// with a large number of goroutines on multi-account systems.
-	tq := parallelTaskQueue(len(dios))
+	tq := parallelTaskQueue(s.diskIOSemaphore().cap())
 	defer close(tq)
 
 	// If we have no configured accounts setup then setup imports on global account.

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -129,8 +129,8 @@ func getBatchStoreDir(storeDir, streamName, batchId string) (string, string) {
 func newBatchStore(mset *stream, batchId string, replicas int, storage StorageType, storeDir, streamName string) (StreamStore, error) {
 	if replicas == 1 && storage == FileStorage {
 		bname, storeDir := getBatchStoreDir(storeDir, streamName, batchId)
-		fcfg := FileStoreConfig{AsyncFlush: true, BlockSize: defaultLargeBlockSize, StoreDir: storeDir}
 		s := mset.srv
+		fcfg := FileStoreConfig{AsyncFlush: true, BlockSize: defaultLargeBlockSize, StoreDir: storeDir, srv: s}
 		prf := s.jsKeyGen(s.getOpts().JetStreamKey, mset.acc.Name)
 		if prf != nil {
 			// We are encrypted here, fill in correct cipher selection.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1030,7 +1030,7 @@ func (js *jetStream) setupMetaGroup() error {
 	cfg.Observer = s.canExtendOtherDomain() && s.getOpts().JetStreamExtHint != jsNoExtend
 
 	var bootstrap bool
-	if ps, err := readPeerState(storeDir); err != nil {
+	if ps, err := readPeerState(s.diskIOSemaphore(), storeDir); err != nil {
 		s.Noticef("JetStream cluster bootstrapping")
 		bootstrap = true
 		peers := s.ActivePeers()
@@ -1064,7 +1064,7 @@ func (js *jetStream) setupMetaGroup() error {
 			// To track possible configuration changes, responsible for an altered value of cfg.Observer,
 			// set extension state to undetermined.
 			ps.domainExt = extUndetermined
-			if err := writePeerState(storeDir, ps); err != nil {
+			if err := writePeerState(s.diskIOSemaphore(), storeDir, ps); err != nil {
 				return err
 			}
 		}
@@ -2933,7 +2933,7 @@ retry:
 
 		cfg := &RaftConfig{Name: rgName, Store: storeDir, Log: store, Track: true, Recovering: recovering, ScaleUp: rgScaleUp}
 
-		if _, err := readPeerState(storeDir); err != nil {
+		if _, err := readPeerState(s.diskIOSemaphore(), storeDir); err != nil {
 			s.bootstrapRaftNode(cfg, rgPeers, true)
 		}
 

--- a/server/jetstream_meta_benchmark_test.go
+++ b/server/jetstream_meta_benchmark_test.go
@@ -17,9 +17,13 @@ package server
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/nats-io/nats.go"
 )
@@ -347,4 +351,160 @@ func BenchmarkJetStreamCreateConsumers(b *testing.B) {
 			},
 		)
 	}
+}
+
+func BenchmarkJetStreamMetaLeaderShutdownWithStreams(b *testing.B) {
+	numStreams := getEnvOrDefault(b, "NATS_BENCH_STREAMS", 1024)
+	concurrency := getEnvOrDefault(b, "NATS_BENCH_STREAM_CREATE_CONCURRENCY", 64)
+
+	b.Run(fmt.Sprintf("streams=%d", numStreams), func(b *testing.B) {
+		var setupTotal time.Duration
+		var shutdownTotal time.Duration
+		var recoveryTotal time.Duration
+		var cleanupTotal time.Duration
+
+		for b.Loop() {
+
+			// Create a cluster with 3 replicas
+			storeRoot := benchmarkDir(b)
+			modify := func(serverName, _, helperStoreDir, conf string) string {
+				storeDir := filepath.Join(storeRoot, serverName)
+				require_NoError(b, os.MkdirAll(storeDir, defaultDirPerms))
+				return strings.Replace(conf, helperStoreDir, filepath.ToSlash(storeDir), 1)
+			}
+			c := createJetStreamClusterWithTemplateAndModHook(b, jsClusterTempl, "R3S", 3, modify)
+			c.waitOnClusterReadyWithNumPeers(3)
+			c.waitOnLeader()
+
+			// Create numStream streams
+			nc, js := jsClientConnect(b, c.leader())
+			setupStart := time.Now()
+			addMetaBenchmarkStreams(b, c.leader().ClientURL(), js, numStreams, concurrency)
+			setupElapsed := time.Since(setupStart)
+			setupTotal += setupElapsed
+			nc.Close()
+
+			// Shutdown the leader, keep track of how much time
+			// is required to:
+			// - meta_leader_shutdown: shutdown the meta leader server
+			// - leader_recovery: until all streams have a new leader
+			// - cluster_shutdown: time for the remaining nodes to shutdown
+			target := c.leader()
+			if target == nil {
+				b.Fatal("expected meta leader")
+			}
+			shutdownStart := time.Now()
+			target.Shutdown()
+			target.WaitForShutdown()
+			shutdownElapsed := time.Since(shutdownStart)
+			shutdownTotal += shutdownElapsed
+
+			c.waitOnLeader()
+			recoveryNC, recoveryJS := jsClientConnect(b, c.leader())
+			waitForMetaBenchmarkStreamLeaders(b, recoveryJS, numStreams, target.Name())
+			recoveryNC.Close()
+			recoveryElapsed := time.Since(shutdownStart)
+			recoveryTotal += recoveryElapsed
+
+			clusterShutdownStart := time.Now()
+			c.shutdown()
+			clusterShutdownElapsed := time.Since(clusterShutdownStart)
+			cleanupTotal += clusterShutdownElapsed
+		}
+
+		b.ReportMetric(float64(setupTotal/time.Millisecond)/float64(b.N), "ms/setup")
+		b.ReportMetric(float64(shutdownTotal/time.Millisecond)/float64(b.N), "ms/meta_leader_shutdown")
+		b.ReportMetric(float64(recoveryTotal/time.Millisecond)/float64(b.N), "ms/leader_recovery")
+		b.ReportMetric(float64(cleanupTotal/time.Millisecond)/float64(b.N), "ms/cluster_shutdown")
+		b.ReportMetric(float64(0), "ns/op")
+	})
+}
+
+func addMetaBenchmarkStreams(t testing.TB, url string, js nats.JetStreamContext, numStreams, concurrency int) {
+	t.Helper()
+
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	errCh := make(chan error, concurrency)
+
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			defer wg.Done()
+
+			nc, wjs := jsClientConnectURL(t, url)
+			defer nc.Close()
+
+			for {
+				n := int(next.Add(1)) - 1
+				if n >= numStreams {
+					return
+				}
+
+				name := fmt.Sprintf("S%05d", n)
+				_, err := wjs.AddStream(&nats.StreamConfig{
+					Name:     name,
+					Subjects: []string{fmt.Sprintf("S.%05d.>", n)},
+					Storage:  nats.FileStorage,
+					Replicas: 3,
+				}, nats.MaxWait(30*time.Second))
+				if err != nil {
+					errCh <- fmt.Errorf("add stream %q: %w", name, err)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	waitForMetaBenchmarkStreamLeaders(t, js, numStreams, _EMPTY_)
+}
+
+func waitForMetaBenchmarkStreamLeaders(t testing.TB, js nats.JetStreamContext, expected int, staleLeader string) {
+	t.Helper()
+
+	found := make([]bool, expected)
+	foundCount := 0
+	checkFor(t, 2*time.Minute, 500*time.Millisecond, func() error {
+		leaderless := 0
+		stale := 0
+		leaders := make(map[string]int)
+		for i := range expected {
+			if found[i] {
+				continue
+			}
+			si, err := js.StreamInfo(fmt.Sprintf("S%05d", i), nats.MaxWait(2*time.Second))
+			if err != nil {
+				continue
+			}
+			if si == nil || si.Cluster == nil || si.Cluster.Leader == _EMPTY_ {
+				leaderless++
+				continue
+			}
+			leaders[si.Cluster.Leader]++
+			if staleLeader != _EMPTY_ && si.Cluster.Leader == staleLeader {
+				stale++
+				continue
+			}
+			found[i] = true
+			foundCount++
+		}
+		if foundCount != expected {
+			t.Log("waiting for streams", expected, foundCount, "leaderless", leaderless, "stale", stale, "leaders", leaders)
+			return fmt.Errorf("have %d streams with current leaders, want %d", foundCount, expected)
+		}
+		return nil
+	})
 }

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2033,7 +2033,7 @@ func (s *Server) addLeafNodeConnection(c *client, srvName, clusterName string, c
 				meta.setObserver(false, extNotExtended)
 				c.Debugf("Turning JetStream metadata controller Observer Mode off")
 				// Take note that the domain was not extended to avoid this state from startup.
-				writePeerState(js.config.StoreDir, meta.currentPeerState())
+				writePeerState(c.srv.diskIOSemaphore(), js.config.StoreDir, meta.currentPeerState())
 				// Meta controller can't be leader yet.
 				// Yet it is possible that due to observer mode every server already stopped campaigning.
 				// Therefore this server needs to be kicked into campaigning gear explicitly.

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1296,6 +1296,7 @@ type Varz struct {
 	OCSPResponseCache     *OCSPResponseCacheVarz `json:"ocsp_peer_cache,omitempty"`         // OCSPResponseCache is the state of the OCSP cache
 	SlowConsumersStats    *SlowConsumersStats    `json:"slow_consumer_stats"`               // SlowConsumersStats are statistics about all detected Slow Consumer
 	StaleConnectionStats  *StaleConnectionStats  `json:"stale_connection_stats,omitempty"`  // StaleConnectionStats are statistics about all detected Stale Connections
+	DiskIOWaitStats       *DiskIOWaitStats       `json:"disk_io_wait_stats"`                // DiskIOWaitStats are statistics about disk I/O semaphore contention
 	Proxies               *ProxiesOptsVarz       `json:"proxies,omitempty"`                 // Proxies hold information about network proxy devices
 	TLSCertNotAfter       time.Time              `json:"tls_cert_not_after,omitzero"`       // TLSCertNotAfter is the expiration date of the TLS certificate of this server
 }
@@ -1453,6 +1454,14 @@ type StaleConnectionStats struct {
 	Routes   uint64 `json:"routes"`   // Routes is how many Route connections became stale connections
 	Gateways uint64 `json:"gateways"` // Gateways is how many Gateway connections became stale connections
 	Leafs    uint64 `json:"leafs"`    // Leafs is how many Leafnode connections became stale connections
+}
+
+// DiskIOWaitStats contains information about disk I/O semaphore contention.
+type DiskIOWaitStats struct {
+	Waiters     int64  `json:"waiters"`       // Waiters is the number of goroutines waiting on the dios
+	Waits       uint64 `json:"waits"`         // Waits is the number of dios acquires that had to wait
+	WaitTime    uint64 `json:"wait_time"`     // WaitTime is the cumulative time spent waiting for dios
+	MaxWaitTime uint64 `json:"max_wait_time"` // MaxWaitTime is the longest observed wait
 }
 
 func myUptime(d time.Duration) string {
@@ -1967,6 +1976,19 @@ func (s *Server) updateVarzRuntimeFields(v *Varz, forceUpdate bool, pcpu float64
 				stats.Unknowns,
 			}
 		}
+	}
+	v.DiskIOWaitStats = diskIOWaitStats(s.dios)
+}
+
+func diskIOWaitStats(d *diskIOSemaphore) *DiskIOWaitStats {
+	if d == nil {
+		return &DiskIOWaitStats{}
+	}
+	return &DiskIOWaitStats{
+		Waiters:     d.waiters.Load(),
+		Waits:       d.waits.Load(),
+		WaitTime:    d.waitNanos.Load(),
+		MaxWaitTime: d.maxWaitNanos.Load(),
 	}
 }
 

--- a/server/raft.go
+++ b/server/raft.go
@@ -160,6 +160,7 @@ type raft struct {
 	id      string         // Node ID
 	wg      sync.WaitGroup // Wait for running goroutines to exit on shutdown
 
+	dios  *diskIOSemaphore
 	wal   WAL         // WAL store (filestore or memstore)
 	wtype StorageType // WAL type, e.g. FileStorage or MemoryStorage
 	bytes uint64      // Total amount of bytes stored in the WAL. (Saves us from needing to call wal.FastState very often)
@@ -405,13 +406,13 @@ func (s *Server) bootstrapRaftNode(cfg *RaftConfig, knownPeers []string, allPeer
 	tmpfile.Close()
 	os.Remove(tmpfile.Name())
 
-	return writePeerState(cfg.Store, &peerState{knownPeers, expected, extUndetermined})
+	return writePeerState(s.diskIOSemaphore(), cfg.Store, &peerState{knownPeers, expected, extUndetermined})
 }
 
 // initRaftNode will initialize the raft node, to be used by startRaftNode or when testing to not run the Go routine.
 func (s *Server) initRaftNode(accName string, cfg *RaftConfig, labels pprofLabels) (*raft, error) {
 	restorePeerState := func(n *raft) error {
-		ps, err := readPeerState(cfg.Store)
+		ps, err := readPeerState(s.diskIOSemaphore(), cfg.Store)
 		if err != nil {
 			return err
 		}
@@ -442,6 +443,7 @@ func (s *Server) initRaftNode(accName string, cfg *RaftConfig, labels pprofLabel
 		sd:       cfg.Store,
 		wal:      cfg.Log,
 		wtype:    cfg.Log.Type(),
+		dios:     s.diskIOSemaphore(),
 		track:    cfg.Track,
 		peers:    make(map[string]*lps),
 		acks:     make(map[uint64]map[string]struct{}),
@@ -1367,7 +1369,7 @@ func (n *raft) installSnapshot(snap *snapshot) error {
 	sn := fmt.Sprintf(snapFileT, snap.lastTerm, snap.lastIndex)
 	sfile := filepath.Join(snapDir, sn)
 
-	if err := writeFileWithSync(sfile, n.encodeSnapshot(snap), defaultFilePerms); err != nil {
+	if err := writeFileWithSync(n.dios, sfile, n.encodeSnapshot(snap), defaultFilePerms); err != nil {
 		// We could set write err here, but if this is a temporary situation, too many open files etc.
 		// we want to retry and snapshots are not fatal.
 		return err
@@ -1547,7 +1549,7 @@ func (c *checkpoint) InstallSnapshot(data []byte) (uint64, error) {
 
 	// Unlock while writing.
 	n.Unlock()
-	err := writeFileWithSync(c.snapFile, encoded, defaultFilePerms)
+	err := writeFileWithSync(n.dios, c.snapFile, encoded, defaultFilePerms)
 	n.Lock()
 	// On either failure path, drop the file we just wrote so it doesn't get
 	// picked up by setupLastSnapshot on restart. Skip the remove if it's the
@@ -1720,9 +1722,9 @@ func (n *raft) loadLastSnapshot() (*snapshot, error) {
 		return nil, errNoSnapAvailable
 	}
 
-	<-dios
+	n.dios.acquire()
 	buf, err := os.ReadFile(n.snapfile)
-	dios <- struct{}{}
+	n.dios.release()
 
 	if err != nil {
 		n.warn("Error reading snapshot: %v", err)
@@ -4864,25 +4866,25 @@ func (n *raft) writePeerState(ps *peerState) {
 	}
 	// Stamp latest and write the peer state file.
 	n.wps = pse
-	if err := writePeerState(n.sd, ps); err != nil && !n.isClosed() {
+	if err := writePeerState(n.dios, n.sd, ps); err != nil && !n.isClosed() {
 		n.setWriteErrLocked(err)
 		n.warn("Error writing peer state file for %q: %v", n.group, err)
 	}
 }
 
 // Writes out our peer state outside of a specific raft context.
-func writePeerState(sd string, ps *peerState) error {
+func writePeerState(dios *diskIOSemaphore, sd string, ps *peerState) error {
 	psf := filepath.Join(sd, peerStateFile)
 	if _, err := os.Stat(psf); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	return writeFileWithSync(psf, encodePeerState(ps), defaultFilePerms)
+	return writeFileWithSync(dios, psf, encodePeerState(ps), defaultFilePerms)
 }
 
-func readPeerState(sd string) (ps *peerState, err error) {
-	<-dios
+func readPeerState(dios *diskIOSemaphore, sd string) (ps *peerState, err error) {
+	dios.acquire()
 	buf, err := os.ReadFile(filepath.Join(sd, peerStateFile))
-	dios <- struct{}{}
+	dios.release()
 
 	if err != nil {
 		return nil, err
@@ -4895,20 +4897,20 @@ const termLen = 8 // uint64
 const termVoteLen = idLen + termLen
 
 // Writes out our term & vote outside of a specific raft context.
-func writeTermVote(sd string, wtv []byte) error {
+func writeTermVote(dios *diskIOSemaphore, sd string, wtv []byte) error {
 	psf := filepath.Join(sd, termVoteFile)
 	if _, err := os.Stat(psf); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	return writeFileWithSync(psf, wtv, defaultFilePerms)
+	return writeFileWithSync(dios, psf, wtv, defaultFilePerms)
 }
 
 // readTermVote will read the largest term and who we voted from to stable storage.
 // Lock should be held.
 func (n *raft) readTermVote() (term uint64, voted string, err error) {
-	<-dios
+	n.dios.acquire()
 	buf, err := os.ReadFile(filepath.Join(n.sd, termVoteFile))
-	dios <- struct{}{}
+	n.dios.release()
 
 	if err != nil {
 		return 0, noVote, err
@@ -5010,7 +5012,7 @@ func (n *raft) writeTermVote() error {
 	}
 	// Stamp latest and write the term & vote file.
 	n.wtv = b
-	if err := writeTermVote(n.sd, n.wtv); err != nil && !n.isClosed() {
+	if err := writeTermVote(n.dios, n.sd, n.wtv); err != nil && !n.isClosed() {
 		// Clear wtv since we failed.
 		n.wtv = nil
 		n.setWriteErrLocked(err)

--- a/server/raft.go
+++ b/server/raft.go
@@ -181,6 +181,7 @@ type raft struct {
 	pae     map[uint64]*appendEntry        // Pending append entries
 
 	elect  *time.Timer // Election timer, normally accessed via electTimer
+	etbo   int         // Election timer backoff after repeated candidacy attempts
 	etlr   time.Time   // Election timer last reset time, for unit tests only
 	active time.Time   // Last activity time, i.e. for heartbeats
 	llqrt  time.Time   // Last quorum lost time
@@ -282,6 +283,7 @@ type lps struct {
 const (
 	minElectionTimeoutDefault      = 4 * time.Second
 	maxElectionTimeoutDefault      = 9 * time.Second
+	maxElectionTimeoutBackoff      = 4
 	minCampaignTimeoutDefault      = 100 * time.Millisecond
 	maxCampaignTimeoutDefault      = 8 * minCampaignTimeoutDefault
 	hbIntervalDefault              = 1 * time.Second
@@ -2378,11 +2380,17 @@ func randElectionTimeout() time.Duration {
 
 // Lock should be held.
 func (n *raft) resetElectionTimeout() {
-	n.resetElect(randElectionTimeout())
+	timeout := randElectionTimeout()
+	if n.State() == Candidate {
+		timeout *= time.Duration(max(1, n.etbo))
+	}
+	n.resetElect(timeout)
 }
 
 func (n *raft) resetElectionTimeoutWithLock() {
-	n.resetElectWithLock(randElectionTimeout())
+	n.Lock()
+	defer n.Unlock()
+	n.resetElectionTimeout()
 }
 
 // Lock should be held.
@@ -5309,12 +5317,15 @@ func (n *raft) switchToCandidate() {
 
 	if n.State() != Candidate {
 		n.debug("Switching to candidate")
+		n.etbo = 1
 	} else {
 		if n.lostQuorumLocked() && time.Since(n.llqrt) > 20*time.Second {
 			// We signal to the upper layers such that can alert on quorum lost.
 			n.updateLeadChange(false)
 			n.llqrt = time.Now()
 		}
+		// Back off repeated candidate retries until we leave candidate state.
+		n.etbo = min(n.etbo+1, maxElectionTimeoutBackoff)
 	}
 	// Increment the term.
 	n.term++

--- a/server/raft_benchmark_test.go
+++ b/server/raft_benchmark_test.go
@@ -42,6 +42,7 @@ func benchmarkWriteTermVote(b *testing.B, workers int) {
 		wtvs[i] = wtv
 	}
 
+	dios := defaultDiskIOSemaphore()
 	var next atomic.Uint64
 	var wg sync.WaitGroup
 	type latencyStats struct {
@@ -67,7 +68,7 @@ func benchmarkWriteTermVote(b *testing.B, workers int) {
 				}
 				binary.LittleEndian.PutUint64(wtv[:termLen], n)
 				start := time.Now()
-				if err := writeTermVote(dir, wtv); err != nil {
+				if err := writeTermVote(dios, dir, wtv); err != nil {
 					b.Errorf("writeTermVote failed: %v", err)
 					return
 				}

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -447,6 +447,7 @@ func TestNRGSwitchStateClearsQueues(t *testing.T) {
 		resp:  newIPQueue[*appendEntryResponse](s, "resp"),
 		leadc: make(chan bool, 1), // for switchState
 		sd:    t.TempDir(),
+		dios:  defaultDiskIOSemaphore(),
 	}
 	n.state.Store(int32(Leader))
 	require_Equal(t, n.prop.len(), 0)
@@ -3008,7 +3009,7 @@ func TestNRGLoadLastSnapshotCleansLegacyZeroIndexSnapshot(t *testing.T) {
 		data:      []byte("legacy"),
 	}
 	sfile := filepath.Join(snapDir, fmt.Sprintf(snapFileT, legacy.lastTerm, legacy.lastIndex))
-	require_NoError(t, writeFileWithSync(sfile, n.encodeSnapshot(legacy), defaultFilePerms))
+	require_NoError(t, writeFileWithSync(n.dios, sfile, n.encodeSnapshot(legacy), defaultFilePerms))
 
 	n.Lock()
 	n.snapfile = sfile
@@ -5634,7 +5635,7 @@ func TestNRGCheckpointInstallSnapshotAbortDuringWrite(t *testing.T) {
 		drain:
 			for {
 				select {
-				case <-dios:
+				case <-n.dios.ch:
 					drained++
 				default:
 					break drain
@@ -5642,7 +5643,7 @@ func TestNRGCheckpointInstallSnapshotAbortDuringWrite(t *testing.T) {
 			}
 			refill := func() {
 				for i := 0; i < drained; i++ {
-					dios <- struct{}{}
+					n.dios.ch <- struct{}{}
 				}
 				drained = 0
 			}
@@ -6426,7 +6427,7 @@ func TestNRGBootstrapExpectedClusterSize(t *testing.T) {
 			// allPeersKnown=false forces the estimate path.
 			require_NoError(t, s.bootstrapRaftNode(cfg, nil, false))
 
-			ps, err := readPeerState(cfg.Store)
+			ps, err := readPeerState(s.diskIOSemaphore(), cfg.Store)
 			require_NoError(t, err)
 			require_Equal(t, ps.clusterSize, test.expected)
 		})

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -657,6 +657,21 @@ func TestNRGUnsuccessfulVoteRequestCampaignEarly(t *testing.T) {
 	require_Equal(t, n.etlr, time.Time{})
 }
 
+func TestNRGElectionTimerBackoff(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	for i := 1; i <= maxElectionTimeoutBackoff+1; i++ {
+		n.switchToCandidate()
+		backoff := min(i, maxElectionTimeoutBackoff)
+		require_Equal(t, n.etbo, backoff)
+	}
+
+	n.switchToFollower(noLeader)
+	n.switchToCandidate()
+	require_Equal(t, n.etbo, 1)
+}
+
 func TestNRGInvalidTAVDoesntPanic(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/server.go
+++ b/server/server.go
@@ -190,6 +190,7 @@ type Server struct {
 	sys                 *internal
 	sysAcc              atomic.Pointer[Account]
 	js                  atomic.Pointer[jetStream]
+	dios                *diskIOSemaphore
 	isMetaLeader        atomic.Bool
 	jsClustered         atomic.Bool
 	accounts            sync.Map
@@ -773,6 +774,7 @@ func NewServer(opts *Options) (*Server, error) {
 		rateLimitLoggingCh: make(chan time.Duration, 1),
 		leafNodeEnabled:    opts.LeafNode.Port != 0 || len(opts.LeafNode.Remotes) > 0,
 		syncOutSem:         make(chan struct{}, maxConcurrentSyncRequests),
+		dios:               defaultDiskIOSemaphore(),
 	}
 
 	// Delayed API response queue. Create regardless if JetStream is configured
@@ -4761,4 +4763,11 @@ func (s *Server) LDMClientByID(id uint64) error {
 	} else {
 		return errors.New("client does not support Lame Duck Mode or is not ready to receive the notification")
 	}
+}
+
+func (s *Server) diskIOSemaphore() *diskIOSemaphore {
+	if s == nil || s.dios == nil {
+		return defaultDiskIOSemaphore()
+	}
+	return s.dios
 }

--- a/server/test_test.go
+++ b/server/test_test.go
@@ -19,7 +19,9 @@ import (
 	"math/rand"
 	"net/url"
 	"os"
+	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -395,4 +397,43 @@ func skipIfBuildkite(t *testing.T) {
 	if os.Getenv("BUILDKITE") == "true" {
 		t.Skip("skipping test on Buildkite CI")
 	}
+}
+
+func getEnvOrDefault(b *testing.B, name string, defaultValue int) int {
+	b.Helper()
+	v := os.Getenv(name)
+	if v == _EMPTY_ {
+		return defaultValue
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 {
+		b.Fatalf("invalid %s=%q", name, v)
+	}
+	return n
+}
+
+// benchmarkDir creates a benchmark work directory under NATS_BENCH_DIR, or
+// .tmp under the package working directory when unset, so disk benchmarks do
+// not default to /tmp.
+func benchmarkDir(b *testing.B) string {
+	b.Helper()
+
+	root := os.Getenv("NATS_BENCH_DIR")
+	cleanupRoot := _EMPTY_
+	if root == _EMPTY_ {
+		var err error
+		root, err = os.Getwd()
+		require_NoError(b, err)
+		root = filepath.Join(root, ".tmp")
+		cleanupRoot = root
+	}
+	root = filepath.Join(root, b.Name())
+	require_NoError(b, os.MkdirAll(root, defaultDirPerms))
+	b.Cleanup(func() {
+		_ = os.RemoveAll(root)
+		if cleanupRoot != _EMPTY_ {
+			_ = os.Remove(cleanupRoot)
+		}
+	})
+	return root
 }


### PR DESCRIPTION
This PR revisits disk I/O limiting originally introduced in #2764 and later extended in #5022.

It makes the disk I/O semaphore (`dios`) server-scoped. This avoids sharing the same semaphore across multiple servers running in the same process, which matters for tests and benchmarks that spawn several nodes.

It also extends `dios` with wait statistics and exposes them through monitoring, making `dios` contention visible from `/varz`.

The PR changes the default `dios` sizing policy from CPU based sizing to a fixed concurrency cap. The previous policy could be too conservative for low-core systems backed by fast storage devices such as SSDs, NVMe, or cloud block storage. In those cases, only a few concurrent disk operations were allowed even though the device could handle many more requests in parallel.

This matters during shutdown or crash scenarios where many Raft groups may need to run elections at the same time. Those elections write and sync term/vote state to disk. If those writes are serialized too aggressively, elections can timeout. Those timeouts trigger more elections, which trigger more term/vote writes, creating a feedback loop where some Raft groups may fail to elect a new leader.

Using a higher fixed `dios` cap, combined with election backoff, avoids that feedback loop while still bounding the
number of disk I/O operations handed to the Go runtime.