### PR TITLE
Data race in NRG tests

### DIFF
--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -5187,9 +5187,10 @@ func TestNRGAppendEntryResurrectsLeader(t *testing.T) {
 
 	S2 := "z3WIzPtj" // S-2
 
+	n.Lock()
 	n.addPeer(S2)
-
-	require_Equal(t, len(n.peers), 2)
+	n.Unlock()
+	require_Len(t, len(n.Peers()), 2)
 	require_Equal(t, n.ClusterSize(), 2)
 
 	// PeerRemove S2
@@ -5203,7 +5204,7 @@ func TestNRGAppendEntryResurrectsLeader(t *testing.T) {
 		leader: S2, term: 1, commit: 1, pterm: 1, pindex: 1, entries: nil})
 	n.processAppendEntry(aeHeartBeat, n.aesub)
 
-	require_Equal(t, len(n.peers), 1)
+	require_Len(t, len(n.Peers()), 1)
 	require_Equal(t, n.ClusterSize(), 1)
 
 	// If bug is present: receiving a appendEntry from the old leader
@@ -5214,7 +5215,7 @@ func TestNRGAppendEntryResurrectsLeader(t *testing.T) {
 	n.processAppendEntry(aeHeartBeat2, n.aesub)
 
 	// Expect the cluster size to be unchanged
-	require_Equal(t, len(n.peers), 1)
+	require_Len(t, len(n.Peers()), 1)
 	require_Equal(t, n.ClusterSize(), 1)
 }
 
@@ -5939,8 +5940,10 @@ func TestNRGOnlyCommitIfCurrentTerm(t *testing.T) {
 	s2 := getHash("S-2")
 	s3 := getHash("S-3")
 
+	n.Lock()
 	n.addPeer(s2)
 	n.addPeer(s3)
+	n.Unlock()
 	require_Len(t, len(n.Peers()), 3)
 
 	// The below timeline describes a test ensuring a leader doesn't commit entries from previous terms.


### PR DESCRIPTION
```
WARNING: DATA RACE
Write at 0x00c00044dbf0 by goroutine 44590:
  runtime.mapassign_faststr()
      /opt/hostedtoolcache/go/1.26.4/x64/src/internal/runtime/maps/runtime_faststr.go:263 +0x0
  github.com/nats-io/nats-server/v2/server.(*raft).addPeer()
      /home/runner/work/nats-server/nats-server/server/raft.go:3062 +0x248

Previous read at 0x00c00044dbf0 by goroutine 44594:
  runtime.mapIterStart()
      /opt/hostedtoolcache/go/1.26.4/x64/src/runtime/map.go:156 +0x0
  github.com/nats-io/nats-server/v2/server.(*raft).checkAccountNRGStatus()
      /home/runner/work/nats-server/nats-server/server/raft.go:640 +0xbe
```