### PR TITLE
[FIXED] Consumer ack subscription mismatch with '%' in name 

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1390,7 +1390,7 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 	o.fcSubjOld = fmt.Sprintf(jsFlowControl, cfg.Name, o.name)
 	preOld := fmt.Sprintf(jsAckT, mn, on)
 	o.ackReplyOldT = fmt.Sprintf("%s.%%d.%%d.%%d.%%d.%%d", preOld)
-	o.ackSubjOld = fmt.Sprintf("%s.*.*.*.*.*", preOld)
+	o.ackSubjOld = fmt.Sprintf(jsAckT+".*.*.*.*.*", cfg.Name, o.name)
 
 	// v2 format: $JS.(ACK|FC).<domain>.<accHash>.<stream>.<consumer>.etc.
 	o.fcPre = fmt.Sprintf("%s%s.%s.", jsFlowControlPre, domain, accHash)
@@ -1400,8 +1400,8 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 	// Subscribe on this ack subject for v2, we require 11 tokens, but allow for more tokens/extension.
 	o.ackSubj = fmt.Sprintf("%s.*.*.*.*.>", pre)
 
-	o.nextMsgSubj = fmt.Sprintf(JSApiRequestNextT, mn, o.name)
-	o.resetSubj = fmt.Sprintf(JSApiConsumerResetT, mn, o.name)
+	o.nextMsgSubj = fmt.Sprintf(JSApiRequestNextT, cfg.Name, o.name)
+	o.resetSubj = fmt.Sprintf(JSApiConsumerResetT, cfg.Name, o.name)
 
 	// Check/update the inactive threshold
 	o.updateInactiveThreshold(&o.cfg)

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1377,10 +1377,11 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 	// in consumer.ackReply(), resulting in erroneous formatting of the ack subject.
 	mn := strings.ReplaceAll(cfg.Name, "%", "%%")
 	on := strings.ReplaceAll(o.name, "%", "%%")
-	domain := strings.ReplaceAll(o.srv.getOpts().JetStreamDomain, "%", "%%")
+	domain := o.srv.getOpts().JetStreamDomain
 	if domain == _EMPTY_ {
 		domain = "_"
 	}
+	dn := strings.ReplaceAll(domain, "%", "%%")
 	accHash := getHash(accName)
 
 	o.useV2Ack = s.getOpts().getFeatureFlag(FeatureFlagJsAckFormatV2)
@@ -1395,10 +1396,10 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 	// v2 format: $JS.(ACK|FC).<domain>.<accHash>.<stream>.<consumer>.etc.
 	o.fcPre = fmt.Sprintf("%s%s.%s.", jsFlowControlPre, domain, accHash)
 	o.fcSubj = fmt.Sprintf(jsFlowControlV2, domain, accHash, cfg.Name, o.name)
-	pre := fmt.Sprintf(jsAckTv2, domain, accHash, mn, on)
+	pre := fmt.Sprintf(jsAckTv2, dn, accHash, mn, on)
 	o.ackReplyT = fmt.Sprintf("%s.%%d.%%d.%%d.%%d.%%d", pre)
 	// Subscribe on this ack subject for v2, we require 11 tokens, but allow for more tokens/extension.
-	o.ackSubj = fmt.Sprintf("%s.*.*.*.*.>", pre)
+	o.ackSubj = fmt.Sprintf(jsAckTv2+".*.*.*.*.>", domain, accHash, cfg.Name, o.name)
 
 	o.nextMsgSubj = fmt.Sprintf(JSApiRequestNextT, cfg.Name, o.name)
 	o.resetSubj = fmt.Sprintf(JSApiConsumerResetT, cfg.Name, o.name)

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -3510,6 +3510,48 @@ func TestJetStreamConsumerAckAck(t *testing.T) {
 	testAck(AckTerm)
 }
 
+func TestJetStreamConsumerAckV1NameWithPercent(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	mname := "TE%ST"
+	mset, err := s.globalAccount().addStream(&StreamConfig{Name: mname, Storage: MemoryStorage})
+	require_NoError(t, err)
+	defer mset.delete()
+
+	o, err := mset.addConsumer(&ConsumerConfig{Durable: "wor%ker", AckPolicy: AckExplicit})
+	require_NoError(t, err)
+	defer o.delete()
+
+	nc := clientConnectToServer(t, s)
+	defer nc.Close()
+
+	sendStreamMsg(t, nc, mname, "Hello World!")
+
+	// The pull subject must contain the real names so a client deriving it
+	// from the stream and consumer names reaches the consumer.
+	nextSubj := fmt.Sprintf(JSApiRequestNextT, "TE%ST", "wor%ker")
+	require_Equal(t, o.requestNextMsgSubject(), nextSubj)
+
+	m, err := nc.Request(nextSubj, nil, time.Second)
+	require_NoError(t, err)
+
+	// The reply subject must contain the real names, not a %-escaped form.
+	require_True(t, strings.HasPrefix(m.Reply, "$JS.ACK.TE%ST.wor%ker."))
+
+	// Ack and make sure the server "ack's" the ack, meaning the consumer's
+	// ack subscription actually matches the rendered reply subject.
+	_, err = nc.Request(m.Reply, AckAck, time.Second)
+	require_NoError(t, err)
+
+	checkFor(t, time.Second, 25*time.Millisecond, func() error {
+		if info := o.info(); info.NumAckPending != 0 {
+			return fmt.Errorf("expected no ack pending, got %d", info.NumAckPending)
+		}
+		return nil
+	})
+}
+
 func TestJetStreamConsumerRateLimit(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -3552,6 +3552,54 @@ func TestJetStreamConsumerAckV1NameWithPercent(t *testing.T) {
 	})
 }
 
+func TestJetStreamConsumerAckV2NameWithPercent(t *testing.T) {
+	opts := DefaultTestOptions
+	opts.Port = -1
+	opts.JetStream = true
+	opts.JetStreamDomain = "hu%b"
+	opts.StoreDir = t.TempDir()
+	opts.FeatureFlags = map[string]bool{FeatureFlagJsAckFormatV2: true}
+	s := RunServer(&opts)
+	defer s.Shutdown()
+
+	mname := "TE%ST"
+	mset, err := s.globalAccount().addStream(&StreamConfig{Name: mname, Storage: MemoryStorage})
+	require_NoError(t, err)
+	defer mset.delete()
+
+	o, err := mset.addConsumer(&ConsumerConfig{Durable: "wor%ker", AckPolicy: AckExplicit})
+	require_NoError(t, err)
+	defer o.delete()
+
+	nc := clientConnectToServer(t, s)
+	defer nc.Close()
+
+	sendStreamMsg(t, nc, mname, "Hello World!")
+
+	// The pull subject must contain the real names so a client deriving it
+	// from the stream and consumer names reaches the consumer.
+	nextSubj := fmt.Sprintf(JSApiRequestNextT, "TE%ST", "wor%ker")
+	require_Equal(t, o.requestNextMsgSubject(), nextSubj)
+
+	m, err := nc.Request(nextSubj, nil, time.Second)
+	require_NoError(t, err)
+
+	// The reply subject must contain the real names, not a %-escaped form.
+	require_True(t, strings.HasPrefix(m.Reply, "$JS.ACK.hu%b.szMpdrwD.TE%ST.wor%ker."))
+
+	// Ack and make sure the server "ack's" the ack, meaning the consumer's
+	// ack subscription actually matches the rendered reply subject.
+	_, err = nc.Request(m.Reply, AckAck, time.Second)
+	require_NoError(t, err)
+
+	checkFor(t, time.Second, 25*time.Millisecond, func() error {
+		if info := o.info(); info.NumAckPending != 0 {
+			return fmt.Errorf("expected no ack pending, got %d", info.NumAckPending)
+		}
+		return nil
+	})
+}
+
 func TestJetStreamConsumerRateLimit(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()


### PR DESCRIPTION
The `%%`-escaped stream, consumer, and domain names were also used to build the consumer's literal subscription subjects. The escaped names are now only used for the reply templates.