### PR TITLE
(2.12) [FIXED] PROXY protocol detection, TLS sniffing, and v1 address-family parsing

### DIFF
--- a/server/client_proxyproto.go
+++ b/server/client_proxyproto.go
@@ -205,11 +205,17 @@ foundCRLF:
 		return nil, nil, fmt.Errorf("invalid dest port: %w", err)
 	}
 
-	// Validate protocol matches IP version
-	if protocol == proxyProtoV1TCP4 && srcIP.To4() == nil {
+	// Validate protocol matches IP version. The textual form determines the
+	// family: TCP4 requires dotted-quad addresses, TCP6 requires IPv6
+	// addresses. IPv4-mapped IPv6 addresses (e.g. "::ffff:192.0.2.1") are
+	// valid for TCP6 since dual-stack proxies can emit those for IPv4
+	// clients on IPv6 sockets, matching the v2 parser behavior.
+	srcIsV6 := strings.Contains(parts[1], ":")
+	dstIsV6 := strings.Contains(parts[2], ":")
+	if protocol == proxyProtoV1TCP4 && (srcIsV6 || dstIsV6) {
 		return nil, nil, fmt.Errorf("%w: TCP4 with IPv6 address", errProxyProtoInvalid)
 	}
-	if protocol == proxyProtoV1TCP6 && srcIP.To4() != nil {
+	if protocol == proxyProtoV1TCP6 && (!srcIsV6 || !dstIsV6) {
 		return nil, nil, fmt.Errorf("%w: TCP6 with IPv4 address", errProxyProtoInvalid)
 	}
 	if protocol != proxyProtoV1TCP4 && protocol != proxyProtoV1TCP6 {

--- a/server/client_proxyproto.go
+++ b/server/client_proxyproto.go
@@ -125,7 +125,9 @@ func detectProxyProtoVersion(conn net.Conn) (version int, header []byte, err err
 	case proxyProtoV2Sig[:6]:
 		return 2, header, nil
 	default:
-		return 0, nil, errProxyProtoUnrecognized
+		// Return the consumed bytes so the caller can replay them into the
+		// next protocol layer instead of discarding them.
+		return 0, header, errProxyProtoUnrecognized
 	}
 }
 
@@ -236,10 +238,12 @@ func readProxyProtoHeader(conn net.Conn) (*proxyProtoAddr, []byte, error) {
 	}
 	defer conn.SetReadDeadline(time.Time{})
 
-	// Detect version
+	// Detect version.
+	// On errProxyProtoUnrecognized, firstBytes holds the bytes that were
+	// consumed so the caller can replay them.
 	version, firstBytes, err := detectProxyProtoVersion(conn)
 	if err != nil {
-		return nil, nil, err
+		return nil, firstBytes, err
 	}
 
 	switch version {

--- a/server/client_proxyproto_test.go
+++ b/server/client_proxyproto_test.go
@@ -447,6 +447,40 @@ func TestClientProxyProtoV1ParseTCP6(t *testing.T) {
 	require_Equal(t, addr.dstPort, 4222)
 }
 
+func TestClientProxyProtoV1ParseTCP6IPv4Mapped(t *testing.T) {
+	// Dual-stack proxies can emit IPv4-mapped IPv6 addresses for TCP6
+	// (an IPv4 client connecting to an IPv6 socket). These are valid IPv6
+	// textual addresses and must be accepted, matching the v2 parser.
+	header := buildProxyV1Header(t, "TCP6", "::ffff:192.0.2.1", "::ffff:10.0.0.1", 1234, 4222)
+	conn := newMockConn(header)
+
+	addr, _, err := readProxyProtoHeader(conn)
+	require_NoError(t, err)
+	require_NotNil(t, addr)
+
+	require_Equal(t, addr.srcIP.String(), "192.0.2.1")
+	require_Equal(t, addr.srcPort, 1234)
+
+	require_Equal(t, addr.dstIP.String(), "10.0.0.1")
+	require_Equal(t, addr.dstPort, 4222)
+}
+
+func TestClientProxyProtoV1MismatchedDestProtocol(t *testing.T) {
+	// TCP4 with IPv6 destination address
+	header := buildProxyV1Header(t, "TCP4", "192.168.1.1", "2001:db8::2", 12345, 443)
+	conn := newMockConn(header)
+
+	_, _, err := readProxyProtoHeader(conn)
+	require_Error(t, err, errProxyProtoInvalid)
+
+	// TCP6 with IPv4 destination address
+	header2 := buildProxyV1Header(t, "TCP6", "2001:db8::1", "10.0.0.1", 12345, 443)
+	conn2 := newMockConn(header2)
+
+	_, _, err = readProxyProtoHeader(conn2)
+	require_Error(t, err, errProxyProtoInvalid)
+}
+
 func TestClientProxyProtoV1ParseUnknown(t *testing.T) {
 	header := buildProxyV1Header(t, "UNKNOWN", "", "", 0, 0)
 	conn := newMockConn(header)

--- a/server/client_proxyproto_test.go
+++ b/server/client_proxyproto_test.go
@@ -798,3 +798,94 @@ func TestClientProxyProtoNonProxiedTLSFirstFallback(t *testing.T) {
 	require_True(t, strings.HasPrefix(line, "+OK"))
 	expectPong(t, cr)
 }
+
+// runProxyProtoAllowNonTLSServer starts a server with proxy_protocol and a
+// TLS listener that also allows non-TLS clients (allow_non_tls).
+func runProxyProtoAllowNonTLSServer(t *testing.T) *Server {
+	t.Helper()
+	tc := &TLSConfigOpts{
+		CertFile: "../test/configs/certs/server-cert.pem",
+		KeyFile:  "../test/configs/certs/server-key.pem",
+		CaFile:   "../test/configs/certs/ca.pem",
+	}
+	tlsConfig, err := GenTLSConfig(tc)
+	require_NoError(t, err)
+
+	opts := DefaultOptions()
+	opts.Port = -1
+	opts.ProxyProtocol = true
+	opts.TLSConfig = tlsConfig
+	opts.TLSTimeout = 2
+	opts.AllowNonTLS = true
+	return RunServer(opts)
+}
+
+// testClientProxyProtoAllowNonTLS verifies that with proxy_protocol and
+// allow_non_tls, the TLS-vs-plaintext detection is performed on the first
+// byte of the client's actual traffic, not on the first byte of the PROXY
+// header. Both a TLS client and a plaintext client behind the proxy must
+// be able to connect on the same listener.
+func testClientProxyProtoAllowNonTLS(t *testing.T, header []byte, clientIP string, clientPort uint16) {
+	t.Helper()
+	s := runProxyProtoAllowNonTLSServer(t)
+	defer s.Shutdown()
+
+	// TLS client behind the proxy: the sniff must detect the TLS
+	// ClientHello that follows the PROXY header.
+	cr, tlsConn := connectProxyProtoTLS(t, s.Addr().String(), header)
+	defer tlsConn.Close()
+
+	_, err := tlsConn.Write([]byte("CONNECT {\"verbose\":true,\"pedantic\":false,\"protocol\":1}\r\nPING\r\n"))
+	require_NoError(t, err)
+
+	line, err := cr.ReadString('\n')
+	require_NoError(t, err)
+	require_True(t, strings.HasPrefix(line, "+OK"))
+	expectPong(t, cr)
+
+	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+		if findProxyProtoClient(t, s, clientIP, clientPort) == nil {
+			return fmt.Errorf("no client with PROXY-supplied host/port yet")
+		}
+		return nil
+	})
+
+	// Plaintext client behind the proxy must still be allowed.
+	rawConn, err := net.Dial("tcp", s.Addr().String())
+	require_NoError(t, err)
+	defer rawConn.Close()
+	require_NoError(t, rawConn.SetDeadline(time.Now().Add(5*time.Second)))
+
+	_, err = rawConn.Write(header)
+	require_NoError(t, err)
+
+	plainReader := bufio.NewReader(rawConn)
+	infoLine, err := plainReader.ReadString('\n')
+	require_NoError(t, err)
+	require_True(t, strings.HasPrefix(infoLine, "INFO "))
+
+	_, err = rawConn.Write([]byte("CONNECT {\"verbose\":true,\"pedantic\":false,\"protocol\":1}\r\nPING\r\n"))
+	require_NoError(t, err)
+
+	line, err = plainReader.ReadString('\n')
+	require_NoError(t, err)
+	require_True(t, strings.HasPrefix(line, "+OK"))
+	expectPong(t, plainReader)
+}
+
+// TestClientProxyProtoV1WithAllowNonTLS verifies that a proxied TLS client is
+// detected as TLS (and a proxied plaintext client as non-TLS) when the
+// listener has both tls and allow_non_tls configured, using a PROXY v1 header.
+func TestClientProxyProtoV1WithAllowNonTLS(t *testing.T) {
+	clientIP, clientPort := "203.0.113.60", uint16(54331)
+	header := buildProxyV1Header(t, "TCP4", clientIP, "127.0.0.1", clientPort, 4222)
+	testClientProxyProtoAllowNonTLS(t, header, clientIP, clientPort)
+}
+
+// TestClientProxyProtoV2WithAllowNonTLS is the v2 counterpart to
+// TestClientProxyProtoV1WithAllowNonTLS.
+func TestClientProxyProtoV2WithAllowNonTLS(t *testing.T) {
+	clientIP, clientPort := "203.0.113.61", uint16(54332)
+	header := buildProxyV2Header(t, clientIP, "127.0.0.1", clientPort, 4222, proxyProtoFamilyInet)
+	testClientProxyProtoAllowNonTLS(t, header, clientIP, clientPort)
+}

--- a/server/client_proxyproto_test.go
+++ b/server/client_proxyproto_test.go
@@ -755,3 +755,46 @@ func TestClientProxyProtoV2WithRequiredTLS(t *testing.T) {
 		return nil
 	})
 }
+
+func TestClientProxyProtoNonProxiedTLSFirstFallback(t *testing.T) {
+	tc := &TLSConfigOpts{
+		CertFile: "../test/configs/certs/server-cert.pem",
+		KeyFile:  "../test/configs/certs/server-key.pem",
+		CaFile:   "../test/configs/certs/ca.pem",
+	}
+	tlsConfig, err := GenTLSConfig(tc)
+	require_NoError(t, err)
+
+	opts := DefaultOptions()
+	opts.Port = -1
+	opts.ProxyProtocol = true
+	opts.TLSConfig = tlsConfig
+	opts.TLSTimeout = 2
+	opts.TLSHandshakeFirst = true
+	opts.TLSHandshakeFirstFallback = 250 * time.Millisecond
+	s := RunServer(opts)
+	defer s.Shutdown()
+
+	rawConn, err := net.Dial("tcp", s.Addr().String())
+	require_NoError(t, err)
+	defer rawConn.Close()
+	require_NoError(t, rawConn.SetDeadline(time.Now().Add(5*time.Second)))
+
+	// Direct TLS-first client: start the handshake right away (within the
+	// fallback delay), no PROXY header.
+	tlsConn := tls.Client(rawConn, proxyProtoTLSClientConfig(t))
+	require_NoError(t, tlsConn.Handshake())
+
+	cr := bufio.NewReader(tlsConn)
+	infoLine, err := cr.ReadString('\n')
+	require_NoError(t, err)
+	require_True(t, strings.HasPrefix(infoLine, "INFO "))
+
+	_, err = tlsConn.Write([]byte("CONNECT {\"verbose\":true,\"pedantic\":false,\"protocol\":1}\r\nPING\r\n"))
+	require_NoError(t, err)
+
+	line, err := cr.ReadString('\n')
+	require_NoError(t, err)
+	require_True(t, strings.HasPrefix(line, "+OK"))
+	expectPong(t, cr)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -3402,17 +3402,14 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 	// If we have both TLS and non-TLS allowed we need to see which
 	// one the client wants. We'll always allow this for in-process
 	// connections.
-	if !isClosed && !tlsFirst && opts.TLSConfig != nil && (inProcess || opts.AllowNonTLS) {
+	sniffTLS := !tlsFirst && opts.TLSConfig != nil && (inProcess || opts.AllowNonTLS)
+	if !isClosed && sniffTLS {
 		pre = make([]byte, 6) // Minimum 6 bytes for proxy proto in next step.
 		c.nc.SetReadDeadline(time.Now().Add(secondsToDuration(opts.TLSTimeout)))
 		n, _ := io.ReadFull(c.nc, pre[:])
 		c.nc.SetReadDeadline(time.Time{})
 		pre = pre[:n]
-		if n > 0 && pre[0] == 0x16 {
-			tlsRequired = true
-		} else {
-			tlsRequired = false
-		}
+		tlsRequired = n > 0 && pre[0] == 0x16
 	}
 
 	// Check for proxy protocol if enabled. The PROXY header is sent as
@@ -3459,6 +3456,20 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 		//    may include bytes read directly from the socket beyond the
 		//    original pre-read), so they must be replayed to the next step.
 		pre = proxyPre
+		if err == nil && sniffTLS {
+			// If we sniffed for TLS-vs-plaintext above, the byte we looked
+			// at belonged to the PROXY header, not to the client's actual
+			// traffic. Re-evaluate using the first byte that follows the
+			// header (reading it from the connection if needed).
+			if len(pre) == 0 {
+				buf := make([]byte, 1)
+				c.nc.SetReadDeadline(time.Now().Add(secondsToDuration(opts.TLSTimeout)))
+				n, _ := io.ReadFull(c.nc, buf)
+				c.nc.SetReadDeadline(time.Time{})
+				pre = buf[:n]
+			}
+			tlsRequired = len(pre) > 0 && pre[0] == 0x16
+		}
 		// Because we have ProxyProtocol enabled, our earlier INFO message didn't
 		// include the client_ip. If we need to send it again then we will include
 		// it, but sending it here immediately can confuse clients who have just

--- a/server/server.go
+++ b/server/server.go
@@ -3452,15 +3452,13 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 			c.port = addr.srcPort
 		}
 		// At this point, err is either:
-		//  - nil => we parsed the proxy protocol header successfully
-		//  - errProxyProtoUnrecognized => we didn't detect proxy protocol at all
-		// We only clear the pre-read if we successfully read the protocol header
-		// so that the next step doesn't re-read it. Otherwise we have to assume
-		// that it's a non-proxied connection and we want the pre-read to remain
-		// for the next step.
-		if err == nil {
-			pre = proxyPre
-		}
+		//  - nil => we parsed the proxy protocol header successfully and
+		//    proxyPre holds any bytes read past the header
+		//  - errProxyProtoUnrecognized => we didn't detect proxy protocol at
+		//    all and proxyPre holds the bytes that detection consumed (which
+		//    may include bytes read directly from the socket beyond the
+		//    original pre-read), so they must be replayed to the next step.
+		pre = proxyPre
 		// Because we have ProxyProtocol enabled, our earlier INFO message didn't
 		// include the client_ip. If we need to send it again then we will include
 		// it, but sending it here immediately can confuse clients who have just


### PR DESCRIPTION
Fixes three bugs in PROXY protocol handling:
- **PROXY detection discarded over-read bytes on non-proxied connections**: with `proxy_protocol` enabled, detection always consumes 6 bytes but the TLS-first fallback only pre-buffers 4, so 2 bytes of the ClientHello were silently dropped and corrupted the TLS handshake; the consumed bytes are now always replayed into the next protocol layer.
- **TLS detection with `allow_non_tls` inspected the PROXY header byte**: the TLS-vs-plaintext sniff ran on the first wire byte, which for proxied connections is the PROXY header itself, so proxied TLS clients were always routed to the plaintext parser; `tlsRequired` is now re-evaluated on the first byte after the PROXY header is stripped.
- **PROXY v1 rejected TCP6 headers carrying IPv4-mapped IPv6 addresses (e.g. `::ffff:192.0.2.1`)**: the family check used `To4() != nil`, which is non-nil for mapped addresses; the family is now derived from the textual form and validated symmetrically for `src` and `dst`, matching the v2 parser's behavior.
