### PR TITLE
[FIXED] Compressed WebSocket decompression limited to a single max_payload

### DIFF
--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -3061,6 +3061,60 @@ func TestLeafNodeWSBasic(t *testing.T) {
 	}
 }
 
+func TestLeafNodeWSCompressedBurstAboveMaxPayload(t *testing.T) {
+	// Use a low max_payload so that a burst of individually valid messages
+	// easily exceeds the websocket transport limit (8 * max_payload) that
+	// the receiving server enforces per compressed websocket message.
+	o := testDefaultLeafNodeWSOptions()
+	o.MaxPayload = 1024
+	o.Websocket.Compression = true
+	s := RunServer(o)
+	defer s.Shutdown()
+
+	lo := testDefaultRemoteLeafNodeWSOptions(t, o, false)
+	lo.MaxPayload = 1024
+	lo.LeafNode.Remotes[0].Websocket.Compression = true
+	ln := RunServer(lo)
+	defer ln.Shutdown()
+
+	checkLeafNodeConnected(t, s)
+	checkLeafNodeConnected(t, ln)
+
+	// Subscriber on the leaf, publisher on the hub: the hub compresses
+	// what it writes to its accepted websocket leafnode connection.
+	ncLeaf := natsConnect(t, ln.ClientURL())
+	defer ncLeaf.Close()
+	sub := natsSubSync(t, ncLeaf, "foo")
+	natsFlush(t, ncLeaf)
+	checkSubInterest(t, s, globalAccountName, "foo", time.Second)
+
+	ncHub := natsConnect(t, s.ClientURL())
+	defer ncHub.Close()
+
+	// Burst of messages, each within max_payload, that batch up in the
+	// hub's pending output for the leafnode connection. If the writer
+	// compresses them all into a single websocket message, the leaf
+	// rejects it with "maximum payload exceeded" and closes the
+	// connection, dropping the messages.
+	const total = 500
+	payload := make([]byte, 512)
+	for i := 0; i < len(payload); i++ {
+		payload[i] = byte('A' + i%26)
+	}
+	for i := 0; i < total; i++ {
+		natsPub(t, ncHub, "foo", payload)
+	}
+	natsFlush(t, ncHub)
+
+	for i := 0; i < total; i++ {
+		msg := natsNexMsg(t, sub, time.Second)
+		if !bytes.Equal(msg.Data, payload) {
+			t.Fatalf("Invalid message #%v: %q", i, msg.Data)
+		}
+	}
+	checkLeafNodeConnected(t, s)
+}
+
 func TestLeafNodeWSRemoteCompressAndMaskingOptions(t *testing.T) {
 	for _, test := range []struct {
 		name      string

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -196,6 +196,20 @@ func wsMaxMessageSize(mpay int) uint64 {
 	return limit
 }
 
+// Maximum amount of uncompressed pending data that the writer may batch
+// into a single compressed WebSocket message. A receiving nats-server
+// enforces wsMaxMessageSize() on both the compressed input and the inflated
+// output of a message, so headroom is reserved to keep the compressed
+// payload itself within the receiver's limit too. DEFLATE's worst-case
+// expansion of incompressible data is ~0.03% plus a few bytes (RFC 1951:
+// 5 bytes per 16KB stored block); ~1.6% plus 64 bytes is reserved here as
+// a comfortable margin over that.
+func wsMaxSendMessageSize(mpay int) int {
+	limit := int(wsMaxMessageSize(mpay))
+	headroom := limit/64 + 64
+	return max(limit-headroom, 1)
+}
+
 // Returns a slice containing `needed` bytes from the given buffer `buf`
 // starting at position `pos`, and possibly read from the given reader `r`.
 // When bytes are present in `buf`, the `pos` is incremented by the number
@@ -1508,70 +1522,91 @@ func (c *client) wsCollapsePtoNB() (net.Buffers, int64) {
 		if mfs > 0 && c.ws.nocompfrag {
 			mfs = 0
 		}
-		buf := bytes.NewBuffer(nbPoolGet(usz))
+		// Bound the amount of pending data compressed into a single WebSocket message.
+		maxUnc := wsMaxSendMessageSize(int(atomic.LoadInt32(&c.mpay)))
+		bsz := min(usz, maxUnc)
 		cp := c.ws.compressor
-		if cp == nil {
-			c.ws.compressor, _ = flate.NewWriter(buf, flate.BestSpeed)
-			cp = c.ws.compressor
-		} else {
-			cp.Reset(buf)
-		}
 		var csz int
-		for i, b := range nb {
-			for len(b) > 0 {
-				n, err := cp.Write(b)
-				if err != nil {
-					// Whatever this error is, it'll be handled by the cp.Flush()
-					// call below, as the same error will be returned there.
-					// Let the outer loop return all the buffers back to the pool
-					// and fall through naturally.
-					break
-				}
-				b = b[n:]
+		for i, off := 0, 0; i < len(nb); {
+			buf := bytes.NewBuffer(nbPoolGet(bsz))
+			if cp == nil {
+				c.ws.compressor, _ = flate.NewWriter(buf, flate.BestSpeed)
+				cp = c.ws.compressor
+			} else {
+				cp.Reset(buf)
 			}
-			// Use original slice since capacity will change to zero
-			// in the loop after consuming the buffer, which will make
-			// nbPoolPut discard it.
-			nbPoolPut(nb[i])
-		}
-		if err := cp.Flush(); err != nil {
-			c.Errorf("Error during compression: %v", err)
-			c.markConnAsClosed(WriteError)
-			cp.Reset(nil)
-			return nil, 0
-		}
-		b := buf.Bytes()
-		p := b[:len(b)-4]
-		if mfs > 0 && len(p) > mfs {
-			for first, final := true, false; len(p) > 0; first = false {
-				lp := len(p)
-				if lp > mfs {
-					lp = mfs
-				} else {
-					final = true
+			// Add pending buffers to this message up to the uncompressed limit.
+			for sz := 0; i < len(nb) && sz < maxUnc; {
+				b := nb[i][off:]
+				if len(b) > maxUnc-sz {
+					b = b[:maxUnc-sz]
 				}
-				// Only the first frame should be marked as compressed, so pass
-				// `first` for the compressed boolean.
-				fh := nbPoolGet(wsMaxFrameHeaderSize)[:wsMaxFrameHeaderSize]
-				n, key := wsFillFrameHeader(fh, mask, first, final, first, wsBinaryMessage, lp)
+				sz += len(b)
+				off += len(b)
+				for len(b) > 0 {
+					n, err := cp.Write(b)
+					if err != nil {
+						// Whatever this error is, it'll be handled by the cp.Flush()
+						// call below, as the same error will be returned there.
+						// Let the outer loop return all the buffers back to the pool
+						// and fall through naturally.
+						break
+					}
+					b = b[n:]
+				}
+				if off == len(nb[i]) {
+					// Use original slice since capacity will change to zero
+					// in the loop after consuming the buffer, which will make
+					// nbPoolPut discard it.
+					nbPoolPut(nb[i])
+					i, off = i+1, 0
+				}
+			}
+			if err := cp.Flush(); err != nil {
+				c.Errorf("Error during compression: %v", err)
+				c.markConnAsClosed(WriteError)
+				cp.Reset(nil)
+				// Return the buffers not yet consumed back to the pool. A
+				// partially consumed buffer is still returned whole since
+				// the compressed output it contributed to is discarded.
+				for ; i < len(nb); i++ {
+					nbPoolPut(nb[i])
+				}
+				return nil, 0
+			}
+			b := buf.Bytes()
+			p := b[:len(b)-4]
+			if mfs > 0 && len(p) > mfs {
+				for first, final := true, false; len(p) > 0; first = false {
+					lp := len(p)
+					if lp > mfs {
+						lp = mfs
+					} else {
+						final = true
+					}
+					// Only the first frame should be marked as compressed, so pass
+					// `first` for the compressed boolean.
+					fh := nbPoolGet(wsMaxFrameHeaderSize)[:wsMaxFrameHeaderSize]
+					n, key := wsFillFrameHeader(fh, mask, first, final, first, wsBinaryMessage, lp)
+					if mask {
+						wsMaskBuf(key, p[:lp])
+					}
+					bufs = append(bufs, fh[:n], append(nbPoolGet(lp), p[:lp]...))
+					csz += n + lp
+					p = p[lp:]
+				}
+				nbPoolPut(b)
+			} else {
+				ol := len(p)
+				h, key := wsCreateFrameHeader(mask, true, wsBinaryMessage, ol)
 				if mask {
-					wsMaskBuf(key, p[:lp])
+					wsMaskBuf(key, p)
 				}
-				bufs = append(bufs, fh[:n], append(nbPoolGet(lp), p[:lp]...))
-				csz += n + lp
-				p = p[lp:]
+				if ol > 0 {
+					bufs = append(bufs, h, p)
+				}
+				csz += len(h) + ol
 			}
-			nbPoolPut(b)
-		} else {
-			ol := len(p)
-			h, key := wsCreateFrameHeader(mask, true, wsBinaryMessage, ol)
-			if mask {
-				wsMaskBuf(key, p)
-			}
-			if ol > 0 {
-				bufs = append(bufs, h, p)
-			}
-			csz = len(h) + ol
 		}
 		// Make sure that the compressor no longer holds a reference to
 		// the bytes.Buffer, so that the underlying memory gets cleaned

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -475,23 +475,27 @@ func (c *client) wsDecompressAndParse(r *wsReadInfo, b []byte, final bool, mpay 
 		r.coff = 0
 		r.csz = 0
 	}()
-	lr := io.LimitedReader{R: d, N: int64(mpay + 1)}
+	// A single WebSocket message may batch several NATS operations, so the
+	// total decompressed size is capped at the same transport limit used
+	// for the compressed input, not at max_payload, which is enforced per
+	// NATS message by the parser.
+	lr := io.LimitedReader{R: d, N: int64(limit + 1)}
 	buf := make([]byte, 32*1024)
-	total := 0
+	var total uint64
 	for {
 		n, err := lr.Read(buf)
 		if n > 0 {
-			pn := n
-			if total+n > mpay {
-				pn = mpay - total
+			pn := uint64(n)
+			if total+pn > limit {
+				pn = limit - total
 			}
 			if pn > 0 {
 				if err := c.parse(buf[:pn]); err != nil {
 					return err
 				}
 			}
-			total += n
-			if total > mpay {
+			total += uint64(n)
+			if total > limit {
 				return ErrMaxPayload
 			}
 		}

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -2363,8 +2363,16 @@ func TestWSCompressedPubInSingleFrame(t *testing.T) {
 	msg := natsNexMsg(t, sub, time.Second)
 	require_Equal(t, string(msg.Data), "a") // The compressed PUB payload should be delivered.
 	_, err = wsc.Write(testWSCreateClientMsg(wsBinaryMessage, 1, true, true, []byte("PING\r\n")))
-	require_NoError(t, err)                                      // A follow-up compressed PING should still be accepted on the same connection.
-	require_Equal(t, string(testWSReadFrame(t, br)), "PONG\r\n") // The connection should remain alive after the compressed frame.
+	require_NoError(t, err) // A follow-up compressed PING should still be accepted on the same connection.
+	// With such a low max_payload, the writer bounds compressed websocket
+	// messages to a few hundred bytes, so the post-CONNECT INFO and the
+	// PONG may arrive split across several messages. Read until the PONG
+	// to show the connection remains alive after the compressed frame.
+	var stream []byte
+	for i := 0; !bytes.HasSuffix(stream, []byte(pongProto)); i++ {
+		require_True(t, i < 10)
+		stream = append(stream, testWSReadFrame(t, br)...)
+	}
 }
 
 func TestWSCompressedSequentialFramesRemainResponsive(t *testing.T) {
@@ -3534,6 +3542,98 @@ func TestWSCompressionFrameSizeLimit(t *testing.T) {
 			}
 			if !bytes.Equal(uncompressed, uncompressedPayload) {
 				t.Fatalf("Unexpected uncomressed data: %q", uncompressed)
+			}
+		})
+	}
+}
+
+func TestWSCompressionSendBoundedByMaxMessageSize(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		browser bool
+	}{
+		{"single frame per message", false},
+		{"fragmented compressed frames", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			opts := testWSOptions()
+			opts.MaxPending = MAX_PENDING_SIZE
+			s := &Server{opts: opts}
+			c := &client{srv: s, ws: &websocket{compress: true, browser: test.browser}}
+			c.initClient()
+			// Use a low max_payload so that the per-message transport limit
+			// (wsMaxMsgPayloadMultiple * max_payload) is easy to exceed.
+			const mpay = 1024
+			c.mpay = mpay
+			limit := int(wsMaxMessageSize(mpay))
+
+			// Random data does not compress, which also exercises the bound
+			// on the compressed payload, not just on the inflated one.
+			pending := make([]byte, 60000)
+			for i := 0; i < len(pending); i++ {
+				pending[i] = byte(rand.Intn(256))
+			}
+
+			// Queue as unevenly sized buffers, including one much bigger
+			// than the limit, so messages have to split within a buffer.
+			c.mu.Lock()
+			c.out.nb = net.Buffers{pending[:5], pending[5:30000], pending[30000:30007], pending[30007:]}
+			nb, _ := c.collapsePtoNB()
+			c.mu.Unlock()
+
+			var flat []byte
+			for _, b := range nb {
+				flat = append(flat, b...)
+			}
+
+			// Walk the WebSocket frames, grouping fragmented frames into
+			// messages, and verify that each message respects the limits
+			// that a receiving nats-server enforces before inflating.
+			var inflated, wire []byte
+			var msgs int
+			for pos := 0; pos < len(flat); {
+				b0, b1 := flat[pos], flat[pos+1]
+				final := b0&wsFinalBit != 0
+				if b1&wsMaskBit != 0 {
+					t.Fatalf("Unexpected mask bit set")
+				}
+				sz := int(b1 & 0x7F)
+				pos += 2
+				switch sz {
+				case 126:
+					sz = int(binary.BigEndian.Uint16(flat[pos:]))
+					pos += 2
+				case 127:
+					sz = int(binary.BigEndian.Uint64(flat[pos:]))
+					pos += 8
+				}
+				wire = append(wire, flat[pos:pos+sz]...)
+				pos += sz
+				if !final {
+					continue
+				}
+				msgs++
+				// The receiver buffers the compressed payload plus the last
+				// block before inflating, and that must fit in the limit.
+				if len(wire)+len(compressLastBlock) > limit {
+					t.Fatalf("Compressed message of size %v exceeds limit %v", len(wire), limit)
+				}
+				d := flate.NewReader(bytes.NewBuffer(append(wire, compressLastBlock...)))
+				ub, err := io.ReadAll(d)
+				if err != nil {
+					t.Fatalf("Error inflating message: %v", err)
+				}
+				if len(ub) > limit {
+					t.Fatalf("Message inflates to %v bytes, exceeds limit %v", len(ub), limit)
+				}
+				inflated = append(inflated, ub...)
+				wire = nil
+			}
+			if expected := (len(pending) + limit - 1) / limit; msgs < expected {
+				t.Fatalf("Expected pending data to be split into at least %v messages, got %v", expected, msgs)
+			}
+			if !bytes.Equal(inflated, pending) {
+				t.Fatalf("Inflated stream does not match queued data")
 			}
 		})
 	}

--- a/server/websocket_test.go
+++ b/server/websocket_test.go
@@ -4900,6 +4900,66 @@ func TestWSDecompressLimit(t *testing.T) {
 	}
 }
 
+func TestWSDecompressBatchAboveMaxPayload(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: "127.0.0.1:-1"
+		websocket {
+			listen: "127.0.0.1:-1"
+			no_tls: true
+			compression: true
+		}
+		max_payload: 4096
+	`))
+	s, o := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	wsc, br, _ := testNewWSClient(t, testWSClientOptions{
+		compress: true,
+		host:     o.Websocket.Host,
+		port:     o.Websocket.Port,
+		noTLS:    true,
+	})
+	defer wsc.Close()
+
+	// Subscribe to "foo" so we can verify that all batched messages
+	// are properly parsed and delivered.
+	sub := testWSCreateClientMsg(wsBinaryMessage, 1, true, false, []byte("SUB foo 1\r\n"))
+	if _, err := wsc.Write(sub); err != nil {
+		t.Fatalf("Error sending subscription: %v", err)
+	}
+
+	// Build a single compressed WebSocket message that batches several
+	// PUBs, each individually below max_payload, but whose total
+	// decompressed size exceeds max_payload. This is similar to what the
+	// server's own websocket writer does on compressed leafnode links.
+	const numMsgs = 4
+	msgSize := 2000 // each below max_payload (4096), total above.
+	batch := &bytes.Buffer{}
+	payload := make([]byte, msgSize)
+	for i := range payload {
+		payload[i] = byte('A' + (i % 26))
+	}
+	for i := 0; i < numMsgs; i++ {
+		fmt.Fprintf(batch, "PUB foo %d\r\n", msgSize)
+		batch.Write(payload)
+		batch.WriteString("\r\n")
+	}
+	wsmsg := testWSCreateClientMsg(wsBinaryMessage, 1, true, true, batch.Bytes())
+	if _, err := wsc.Write(wsmsg); err != nil {
+		t.Fatalf("Error sending batched message: %v", err)
+	}
+
+	// We should receive all messages back, not an error/connection close.
+	got := 0
+	for got != numMsgs {
+		msg := testWSReadFrame(t, br)
+		if bytes.Contains(msg, []byte("-ERR")) {
+			t.Fatalf("Expected batched messages to be accepted, got %q", msg)
+		}
+		got += bytes.Count(msg, []byte("MSG foo 1 "))
+	}
+}
+
 func TestWSNoAuthUserOverride(t *testing.T) {
 	o := testWSOptions()
 	// WebSocket has its own no_auth_user override pointing at the lower-


### PR DESCRIPTION
A compressed WebSocket message batching several valid PUBs whose total exceeded `max_payload` was rejected with `ErrMaxPayload` and the connection closed, while the same batch uncompressed would've been accepted. The decompressed output is now capped at `limit := wsMaxMessageSize(mpay)` with per-message `max_payload` still enforced by the parser.
