### PR TITLE
(2.12) [FIXED] Atomic batch: EOB max-size check & R1 message rewrites

### DIFF
--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -1868,6 +1868,74 @@ func TestJetStreamAtomicBatchPublishExpectedPerSubject(t *testing.T) {
 	t.Run("not-first", func(t *testing.T) { test(t, NotFirst) })
 }
 
+func TestJetStreamAtomicBatchPublishCounterSingleServer(t *testing.T) {
+	test := func(t *testing.T, storage StorageType) {
+		s := RunBasicJetStreamServer(t)
+		defer s.Shutdown()
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		cfg := &StreamConfig{
+			Name:               "TEST",
+			Subjects:           []string{"foo"},
+			Storage:            storage,
+			Retention:          LimitsPolicy,
+			Replicas:           1,
+			AllowAtomicPublish: true,
+			AllowMsgCounter:    true,
+		}
+		_, err := jsStreamCreate(t, nc, cfg)
+		require_NoError(t, err)
+
+		// Publish an atomic batch of two counter increments.
+		m := nats.NewMsg("foo")
+		m.Header.Set("Nats-Batch-Id", "uuid")
+		m.Header.Set("Nats-Batch-Sequence", "1")
+		m.Header.Set("Nats-Incr", "1")
+		require_NoError(t, nc.PublishMsg(m))
+
+		m = nats.NewMsg("foo")
+		m.Header.Set("Nats-Batch-Id", "uuid")
+		m.Header.Set("Nats-Batch-Sequence", "2")
+		m.Header.Set("Nats-Batch-Commit", "1")
+		m.Header.Set("Nats-Incr", "2")
+		rmsg, err := nc.RequestMsg(m, time.Second)
+		require_NoError(t, err)
+
+		var pubAck JSPubAckResponse
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_True(t, pubAck.Error == nil)
+		require_Equal(t, pubAck.Sequence, 2)
+		require_Equal(t, pubAck.BatchId, "uuid")
+		require_Equal(t, pubAck.BatchSize, 2)
+
+		// The stored messages must contain the rewritten counter payloads.
+		rsm, err := js.GetMsg("TEST", 1)
+		require_NoError(t, err)
+		require_Equal(t, string(rsm.Data), `{"val":"1"}`)
+		rsm, err = js.GetMsg("TEST", 2)
+		require_NoError(t, err)
+		require_Equal(t, string(rsm.Data), `{"val":"3"}`)
+
+		// The counter must not be broken, a normal increment should still work.
+		m = nats.NewMsg("foo")
+		m.Header.Set("Nats-Incr", "5")
+		pa, err := js.PublishMsg(m)
+		require_NoError(t, err)
+		require_Equal(t, pa.Sequence, 3)
+		rsm, err = js.GetMsg("TEST", 3)
+		require_NoError(t, err)
+		require_Equal(t, string(rsm.Data), `{"val":"8"}`)
+	}
+
+	for _, storage := range []StorageType{FileStorage, MemoryStorage} {
+		t.Run(storage.String(), func(t *testing.T) {
+			test(t, storage)
+		})
+	}
+}
+
 func TestJetStreamAtomicBatchPublishSingleServerRecovery(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -303,6 +303,80 @@ func TestJetStreamAtomicBatchPublishCommitEob(t *testing.T) {
 	}
 }
 
+func TestJetStreamAtomicBatchPublishCommitEobMaxBatchSize(t *testing.T) {
+	streamMaxAtomicBatchSize = 3
+	defer func() {
+		streamMaxAtomicBatchSize = streamDefaultMaxAtomicBatchSize
+	}()
+
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc := clientConnectToServer(t, s)
+	defer nc.Close()
+
+	cfg := &StreamConfig{
+		Name:               "TEST",
+		Subjects:           []string{"foo"},
+		Storage:            FileStorage,
+		Retention:          LimitsPolicy,
+		Replicas:           1,
+		AllowAtomicPublish: true,
+	}
+	_, err := jsStreamCreate(t, nc, cfg)
+	require_NoError(t, err)
+
+	var pubAck JSPubAckResponse
+
+	// A batch of exactly the maximum size must be accepted when committed via an
+	// "End Of Batch" marker, since the marker itself is not stored as part of the batch.
+	for seq := 1; seq <= streamMaxAtomicBatchSize; seq++ {
+		m := nats.NewMsg("foo")
+		m.Header.Set("Nats-Batch-Id", "uuid")
+		m.Header.Set("Nats-Batch-Sequence", strconv.Itoa(seq))
+		require_NoError(t, nc.PublishMsg(m))
+	}
+	m := nats.NewMsg("foo")
+	m.Header.Set("Nats-Batch-Id", "uuid")
+	m.Header.Set("Nats-Batch-Sequence", strconv.Itoa(streamMaxAtomicBatchSize+1))
+	m.Header.Set("Nats-Batch-Commit", "eob")
+	rmsg, err := nc.RequestMsg(m, time.Second)
+	require_NoError(t, err)
+	require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+	require_True(t, pubAck.Error == nil)
+	require_Equal(t, pubAck.BatchSize, uint64(streamMaxAtomicBatchSize))
+
+	// One message over the maximum size must still be rejected when committed via EOB.
+	for seq := 1; seq <= streamMaxAtomicBatchSize+1; seq++ {
+		m = nats.NewMsg("foo")
+		m.Header.Set("Nats-Batch-Id", "uuid2")
+		m.Header.Set("Nats-Batch-Sequence", strconv.Itoa(seq))
+		require_NoError(t, nc.PublishMsg(m))
+	}
+	m = nats.NewMsg("foo")
+	m.Header.Set("Nats-Batch-Id", "uuid2")
+	m.Header.Set("Nats-Batch-Sequence", strconv.Itoa(streamMaxAtomicBatchSize+2))
+	m.Header.Set("Nats-Batch-Commit", "eob")
+	rmsg, err = nc.RequestMsg(m, time.Second)
+	require_NoError(t, err)
+	pubAck = JSPubAckResponse{}
+	require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+	require_Error(t, pubAck.Error, NewJSAtomicPublishTooLargeBatchError(streamMaxAtomicBatchSize))
+
+	// An EOB commit marker for an unknown batch at sequence maxSize+1 means the batch
+	// itself would have exactly maxSize messages, so it should be reported as incomplete
+	// rather than too large.
+	m = nats.NewMsg("foo")
+	m.Header.Set("Nats-Batch-Id", "uuid3")
+	m.Header.Set("Nats-Batch-Sequence", strconv.Itoa(streamMaxAtomicBatchSize+1))
+	m.Header.Set("Nats-Batch-Commit", "eob")
+	rmsg, err = nc.RequestMsg(m, time.Second)
+	require_NoError(t, err)
+	pubAck = JSPubAckResponse{}
+	require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+	require_Error(t, pubAck.Error, NewJSAtomicPublishIncompleteBatchError())
+}
+
 func TestJetStreamAtomicBatchPublishLimits(t *testing.T) {
 	streamMaxAtomicBatchInflightPerStream = 1
 	streamMaxAtomicBatchInflightTotal = 1

--- a/server/stream.go
+++ b/server/stream.go
@@ -7247,7 +7247,12 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 			if opts.JetStreamLimits.MaxBatchSize > 0 {
 				maxBatchSize = opts.JetStreamLimits.MaxBatchSize
 			}
-			if batchSeq > uint64(maxBatchSize) {
+			size := batchSeq
+			// Don't count the "End Of Batch" marker toward the batch size.
+			if bytes.Equal(sliceHeader(JSBatchCommit, hdr), []byte("eob")) {
+				size--
+			}
+			if size > uint64(maxBatchSize) {
 				err := NewJSAtomicPublishTooLargeBatchError(maxBatchSize)
 				return respondError(err)
 			}
@@ -7339,7 +7344,12 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 	if maxBatchSize := s.getOpts().JetStreamLimits.MaxBatchSize; maxBatchSize > 0 {
 		maxSize = maxBatchSize
 	}
-	if batchSeq > uint64(maxSize) {
+	size := batchSeq
+	// Don't count the "End Of Batch" marker toward the batch size.
+	if commitEob {
+		size--
+	}
+	if size > uint64(maxSize) {
 		b.cleanupLocked(batchId, batches)
 		batches.mu.Unlock()
 		mset.mu.Unlock()

--- a/server/stream.go
+++ b/server/stream.go
@@ -7427,8 +7427,14 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		return apiErr
 	}
 
+	type checkedMsg struct {
+		subj string
+		hdr  []byte
+		msg  []byte
+	}
 	var (
 		entries []*Entry
+		checked []checkedMsg
 		bsubj   string
 		bhdr    []byte
 		bmsg    []byte
@@ -7495,6 +7501,11 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 			esm := encodeStreamMsgAllowCompressAndBatch(bsubj, _reply, bhdr, bmsg, mset.clseq, ts, false, batchId, seq, isCommit)
 			entries = append(entries, newEntry(EntryNormal, esm))
 			sz += len(esm)
+		} else {
+			// Preserve the (possibly rewritten) headers and message, for example for counters and
+			// scheduled messages, so the commit below stores the transformed message.
+			// Need to copy, the staged message buffer is reused on every load.
+			checked = append(checked, checkedMsg{bsubj, copyBytes(bhdr), copyBytes(bmsg)})
 		}
 		mset.clseq++
 	}
@@ -7509,16 +7520,11 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		// can only happen after the full batch is committed.
 		// We keep holding the stream lock.
 		for seq := uint64(1); seq <= batchSeq; seq++ {
-			if seq == batchSeq && !commitEob && b.store.Type() != FileStorage {
-				bsubj, bhdr, bmsg = subject, hdr, msg
-			} else if sm, err = b.store.LoadMsg(seq, &smv); sm != nil && err == nil {
-				bsubj, bhdr, bmsg = sm.subj, sm.hdr, sm.msg
-			} else {
-				// Should not happen, we've already checked this message existed while doing consistency checks.
-				// We'll just exit here, the batch is already inconsistent without the message at this sequence.
-				// No use in trying to still store the rest.
-				break
-			}
+			// Use the checked (and possibly rewritten) message from above, not the raw staged
+			// message, so transformations like counter increments and scheduled message
+			// rollups are persisted just like in the clustered proposal path.
+			cm := checked[seq-1]
+			bsubj, bhdr, bmsg = cm.subj, cm.hdr, cm.msg
 			var _reply string
 			if seq == batchSeq {
 				_reply = reply


### PR DESCRIPTION
Two fixes for atomic batch publishing in `processJetStreamAtomicBatchMsg`:

- Fix a batch of exactly `max_batch_size` messages being rejected with `JSAtomicPublishTooLargeBatchError` when committed via EOB, since the marker carries `seq+1` but is not itself stored.
- Fix the R1 (non-clustered) commit path storing the raw staged message verbatim instead of the transformed subject/headers/payload produced by `checkMsgHeadersPreClusteredProposal`, which left counter messages with empty payloads and permanently broke the counter.