### PR TITLE
(2.14) [FIXED] Schedule drift & fast batch commit on gapOk error & stale /varz leaf remotes

### DIFF
--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -4279,6 +4279,118 @@ func TestJetStreamFastBatchPublishHeaderCheckError(t *testing.T) {
 	}
 }
 
+func TestJetStreamFastBatchPublishHeaderCheckErrorOnCommit(t *testing.T) {
+	test := func(t *testing.T, replicas int, gapMode string, gap bool) {
+		c := createJetStreamClusterExplicit(t, "R3S", 3)
+		defer c.shutdown()
+
+		nc := clientConnectToServer(t, c.randomServer())
+		defer nc.Close()
+
+		var batchFlowAck BatchFlowAck
+		var pubAck JSPubAckResponse
+
+		_, err := jsStreamCreate(t, nc, &StreamConfig{
+			Name:              "TEST",
+			Subjects:          []string{"foo"},
+			Storage:           FileStorage,
+			Replicas:          replicas,
+			AllowBatchPublish: true,
+		})
+		require_NoError(t, err)
+
+		inbox := nats.NewInbox()
+		sub, err := nc.SubscribeSync(fmt.Sprintf("%s.>", inbox))
+		require_NoError(t, err)
+		defer sub.Drain()
+
+		// Send the first message.
+		m := nats.NewMsg("foo")
+		m.Reply = generateFastBatchReply(inbox, "uuid", 1, 0, gapMode, FastBatchOpStart)
+		require_NoError(t, nc.PublishMsg(m))
+
+		// The first message triggered the initial flow control message.
+		rmsg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		batchFlowAck = BatchFlowAck{}
+		require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowAck))
+		require_Equal(t, batchFlowAck.Messages, 10)
+
+		// Now commit the batch, but have the commit message itself fail the header checks.
+		commitSeq := uint64(2)
+		if gap {
+			commitSeq = 3
+		}
+		m.Header.Set(JSExpectedLastSeq, "100")
+		m.Reply = generateFastBatchReply(inbox, "uuid", commitSeq, 0, gapMode, FastBatchOpCommit)
+		require_NoError(t, nc.PublishMsg(m))
+
+		// A forward gap is always reported first.
+		if gap {
+			rmsg, err = sub.NextMsg(time.Second)
+			require_NoError(t, err)
+			var batchFlowGap BatchFlowGap
+			require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowGap))
+			require_Equal(t, batchFlowGap.ExpectedLastSequence, 2)
+			require_Equal(t, batchFlowGap.CurrentSequence, 3)
+		}
+
+		// The commit message should report the error based on the header.
+		rmsg, err = sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		require_True(t, strings.HasPrefix(string(rmsg.Data), "{\"type\":\"err\","))
+		var batchFlowErr BatchFlowErr
+		require_NoError(t, json.Unmarshal(rmsg.Data, &batchFlowErr))
+		require_Equal(t, batchFlowErr.Sequence, commitSeq)
+		require_True(t, batchFlowErr.Error != nil)
+		require_Equal(t, batchFlowErr.Error.Error(), NewJSStreamWrongLastSequenceError(1).Error())
+
+		// Since the commit message errored, the commit must still complete and a PubAck
+		// must be sent containing the last persisted message data. Otherwise, the batch
+		// would be stranded; no PubAck, the cleanup timer stopped, and inflight accounting leaked.
+		rmsg, err = sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		pubAck = JSPubAckResponse{}
+		require_NoError(t, json.Unmarshal(rmsg.Data, &pubAck))
+		require_True(t, pubAck.Error == nil)
+		require_Equal(t, pubAck.Sequence, 1)
+		require_Equal(t, pubAck.BatchId, "uuid")
+		// The batch size reflects the last accepted batch sequence, which includes skipped gaps.
+		require_Equal(t, pubAck.BatchSize, commitSeq-1)
+
+		// The batch must also be unregistered and not leak inflight accounting.
+		sl := c.streamLeader(globalAccountName, "TEST")
+		require_NotNil(t, sl)
+		mset, err := sl.globalAccount().lookupStream("TEST")
+		require_NoError(t, err)
+		mset.mu.RLock()
+		batches := mset.batches
+		mset.mu.RUnlock()
+		require_NotNil(t, batches)
+		checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+			batches.mu.Lock()
+			fastBatches := len(batches.fast)
+			batches.mu.Unlock()
+			if fastBatches != 0 {
+				return fmt.Errorf("expected no inflight fast batches, got %d", fastBatches)
+			}
+			return nil
+		})
+	}
+
+	for _, replicas := range []int{1, 3} {
+		for _, gapMode := range []string{FastBatchGapFail, FastBatchGapOk} {
+			t.Run(fmt.Sprintf("R%d/%s", replicas, gapMode), func(t *testing.T) {
+				test(t, replicas, gapMode, false)
+			})
+		}
+		// A forward gap on the commit message is only allowed in gap-ok mode.
+		t.Run(fmt.Sprintf("R%d/gap/%s", replicas, FastBatchGapOk), func(t *testing.T) {
+			test(t, replicas, FastBatchGapOk, true)
+		})
+	}
+}
+
 func TestJetStreamFastBatchPublishPing(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -22644,6 +22644,22 @@ func TestJetStreamScheduledMessageParse(t *testing.T) {
 		// A schedule can only run at least once every second.
 		_, _, ok = parseMsgSchedule("@every 999ms", nil, 0)
 		require_False(t, ok)
+
+		// The next fire time anchors on the previous fire time rounded to the
+		// nearest second, plus the interval.
+		const interval = 1500 * time.Millisecond
+		anchor := time.Now().UTC().Add(time.Second)
+		sts, repeat, ok = parseMsgSchedule("@every 1500ms", nil, anchor.UnixNano())
+		require_True(t, ok)
+		require_True(t, repeat)
+		require_Equal(t, sts.UnixNano(), anchor.Round(time.Second).Add(interval).UnixNano())
+
+		// Re-arming from that fire time rounds again before adding the interval.
+		prev := sts
+		sts, repeat, ok = parseMsgSchedule("@every 1500ms", nil, sts.UnixNano())
+		require_True(t, ok)
+		require_True(t, repeat)
+		require_Equal(t, sts.UnixNano(), prev.Round(time.Second).Add(interval).UnixNano())
 	})
 
 	// <cron> pattern

--- a/server/memstore_test.go
+++ b/server/memstore_test.go
@@ -1371,6 +1371,48 @@ func TestMemStoreMessageSchedule(t *testing.T) {
 	require_Equal(t, bytesToString(getHeader(JSScheduleNext, im.hdr)), JSScheduleNextPurge)
 }
 
+func TestMemStoreMessageScheduleEverySubSecondPrecision(t *testing.T) {
+	fs, err := newMemStore(
+		&StreamConfig{
+			Name: "TEST", Subjects: []string{"foo.*"}, Storage: MemoryStorage,
+			AllowMsgSchedules: true,
+		},
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	// Capture message schedule proposals.
+	ch := make(chan *inMsg, 1)
+	fs.pmsgcb = func(im *inMsg) {
+		ch <- im
+	}
+
+	// Store a repeating message schedule with a sub-second remainder.
+	hdr := genHeader(nil, JSSchedulePattern, "@every 1500ms")
+	hdr = genHeader(hdr, JSScheduleTarget, "foo.target")
+	_, ts, err := fs.StoreMsg("foo.schedule", hdr, nil, 0)
+	require_NoError(t, err)
+
+	// We should have published a scheduled message.
+	im := require_ChanRead(t, ch, time.Second*3)
+	require_Equal(t, im.subj, "foo.target")
+	require_Equal(t, bytesToString(getHeader(JSScheduler, im.hdr)), "foo.schedule")
+
+	// The re-arm header is written with RFC3339Nano so the sub-second component
+	// of the next fire time survives the round trip through the header. Each
+	// fire time anchors on the previous one rounded to the nearest second, plus
+	// the interval: the first fire is round(store time) + 1500ms, and the
+	// re-arm rounds that again (up, .5s rounds away from zero) before adding
+	// another 1500ms.
+	const interval = 1500 * time.Millisecond
+	first := time.Unix(0, ts).UTC().Round(time.Second).Add(interval)
+	expected := first.Round(time.Second).Add(interval)
+	scheduleNext := bytesToString(getHeader(JSScheduleNext, im.hdr))
+	next, err := time.Parse(time.RFC3339Nano, scheduleNext)
+	require_NoError(t, err)
+	require_Equal(t, next.UnixNano(), expected.UnixNano())
+}
+
 func TestMemStoreNextWildcardMatch(t *testing.T) {
 	cfg := &StreamConfig{
 		Name:     "zzz",

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1746,34 +1746,40 @@ func (s *Server) createVarz(pcpu float64, rss int64) *Varz {
 		}
 		varz.Gateway.Gateways = rgwa
 	}
-	if l := len(ln.Remotes); l > 0 {
-		rlna := make([]RemoteLeafOptsVarz, l)
-		for i, r := range ln.Remotes {
-			var deny *DenyRules
-			if len(r.DenyImports) > 0 || len(r.DenyExports) > 0 {
-				deny = &DenyRules{
-					Imports: r.DenyImports,
-					Exports: r.DenyExports,
-				}
-			}
-			remoteTlsOCSPPeerVerify := s.ocspPeerVerify && r.tlsConfigOpts != nil && r.tlsConfigOpts.OCSPPeerConfig != nil && r.tlsConfigOpts.OCSPPeerConfig.Verify
-
-			rlna[i] = RemoteLeafOptsVarz{
-				LocalAccount:      r.LocalAccount,
-				URLs:              urlsToStrings(r.URLs),
-				TLSTimeout:        r.TLSTimeout,
-				Deny:              deny,
-				TLSOCSPPeerVerify: remoteTlsOCSPPeerVerify,
-			}
-		}
-		varz.LeafNode.Remotes = rlna
-	}
-
 	// Finish setting it up with fields that can be updated during
 	// configuration reload and runtime.
 	s.updateVarzConfigReloadableFields(varz)
 	s.updateVarzRuntimeFields(varz, true, pcpu, rss)
 	return varz
+}
+
+// Builds the list of remote leafnodes for Varz from the given options.
+// Server lock is held on entry.
+func (s *Server) varzLeafNodeRemotes(opts *Options) []RemoteLeafOptsVarz {
+	l := len(opts.LeafNode.Remotes)
+	if l == 0 {
+		return nil
+	}
+	rlna := make([]RemoteLeafOptsVarz, l)
+	for i, r := range opts.LeafNode.Remotes {
+		var deny *DenyRules
+		if len(r.DenyImports) > 0 || len(r.DenyExports) > 0 {
+			deny = &DenyRules{
+				Imports: r.DenyImports,
+				Exports: r.DenyExports,
+			}
+		}
+		remoteTlsOCSPPeerVerify := s.ocspPeerVerify && r.tlsConfigOpts != nil && r.tlsConfigOpts.OCSPPeerConfig != nil && r.tlsConfigOpts.OCSPPeerConfig.Verify
+
+		rlna[i] = RemoteLeafOptsVarz{
+			LocalAccount:      r.LocalAccount,
+			URLs:              urlsToStrings(r.URLs),
+			TLSTimeout:        r.TLSTimeout,
+			Deny:              deny,
+			TLSOCSPPeerVerify: remoteTlsOCSPPeerVerify,
+		}
+	}
+	return rlna
 }
 
 func urlsToStrings(urls []*url.URL) []string {
@@ -1829,6 +1835,7 @@ func (s *Server) updateVarzConfigReloadableFields(v *Varz) {
 	v.Cluster.TLSCertNotAfter = tlsCertNotAfter(opts.Cluster.TLSConfig)
 	v.Gateway.TLSCertNotAfter = tlsCertNotAfter(opts.Gateway.TLSConfig)
 	v.LeafNode.TLSCertNotAfter = tlsCertNotAfter(opts.LeafNode.TLSConfig)
+	v.LeafNode.Remotes = s.varzLeafNodeRemotes(opts)
 	v.MQTT.TLSCertNotAfter = tlsCertNotAfter(opts.MQTT.TLSConfig)
 	v.Websocket.TLSCertNotAfter = tlsCertNotAfter(opts.Websocket.TLSConfig)
 

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -7260,6 +7260,77 @@ func TestConfigReloadAddRemoveRemoteLeafNodes(t *testing.T) {
 	checkLeafs(nil)
 }
 
+func TestConfigReloadAddRemoveRemoteLeafNodesVarz(t *testing.T) {
+	conf1 := createConfFile(t, []byte(`
+		port: -1
+		server_name: "A"
+		leafnodes {
+			port: -1
+		}
+	`))
+	s1, o1 := RunServerWithConfig(conf1)
+	defer s1.Shutdown()
+
+	tmpl2 := `
+		port: -1
+		http: -1
+		server_name: "B"
+		accounts {
+			A: {users:[{user: "A", password: "pwd"}]}
+			B: {users:[{user: "B", password: "pwd"}]}
+		}
+		leafnodes {
+			remotes [
+				%s
+				%s
+			]
+		}
+	`
+	remoteTmpl := fmt.Sprintf(`{ url: "nats://127.0.0.1:%d"`, o1.LeafNode.Port) + ", account=%q}"
+	accA := fmt.Sprintf(remoteTmpl, "A")
+	accB := fmt.Sprintf(remoteTmpl, "B")
+	conf2 := createConfFile(t, fmt.Appendf(nil, tmpl2, accA, _EMPTY_))
+	s2, _ := RunServerWithConfig(conf2)
+	defer s2.Shutdown()
+
+	checkLeafNodeConnectedCount(t, s2, 1)
+
+	checkRemotes := func(accs ...string) {
+		t.Helper()
+		// Check both the HTTP endpoint (mode 0), which caches the Varz
+		// object, and the programmatic API (mode 1).
+		url := fmt.Sprintf("http://127.0.0.1:%d/varz", s2.MonitorAddr().Port)
+		for mode := 0; mode < 2; mode++ {
+			v := pollVarz(t, s2, mode, url, nil)
+			require_Len(t, len(v.LeafNode.Remotes), len(accs))
+			for _, acc := range accs {
+				var ok bool
+				for _, r := range v.LeafNode.Remotes {
+					if r.LocalAccount == acc {
+						ok = true
+						break
+					}
+				}
+				if !ok {
+					t.Fatalf("Mode %d: did not find account %q in varz remotes: %+v", mode, acc, v.LeafNode.Remotes)
+				}
+			}
+		}
+	}
+	// This will also populate the cached s.varz used by the HTTP endpoint.
+	checkRemotes("A")
+
+	// Add a remote with local account "B".
+	reloadUpdateConfig(t, s2, conf2, fmt.Sprintf(tmpl2, accA, accB))
+	checkLeafNodeConnectedCount(t, s2, 2)
+	checkRemotes("A", "B")
+
+	// Remove the remote with local account "A".
+	reloadUpdateConfig(t, s2, conf2, fmt.Sprintf(tmpl2, _EMPTY_, accB))
+	checkLeafNodeConnectedCount(t, s2, 1)
+	checkRemotes("B")
+}
+
 func TestConfigReloadRemoteLeafNodeNkeyChange(t *testing.T) {
 	conf1 := createConfFile(t, []byte(`
 		listen: "127.0.0.1:-1"

--- a/server/scheduler.go
+++ b/server/scheduler.go
@@ -226,7 +226,7 @@ func (ms *MsgScheduling) getScheduledMessages(loadMsg func(seq uint64, smv *Stor
 			if !repeat {
 				hdr = genHeader(hdr, JSScheduleNext, JSScheduleNextPurge) // Purge the schedule message itself.
 			} else {
-				hdr = genHeader(hdr, JSScheduleNext, next.Format(time.RFC3339)) // Next time the schedule fires.
+				hdr = genHeader(hdr, JSScheduleNext, next.Format(time.RFC3339Nano)) // Next time the schedule fires.
 			}
 			if ttl != _EMPTY_ {
 				hdr = genHeader(hdr, JSMessageTTL, ttl)

--- a/server/stream.go
+++ b/server/stream.go
@@ -7867,7 +7867,8 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 		}
 
 		// If gaps are okay, we just allow them to continue.
-		if batch.gapOk {
+		// Unless this is the commit message, in which case we must still complete it below.
+		if batch.gapOk && !batch.commit {
 			batches.mu.Unlock()
 			return err
 		}
@@ -7876,6 +7877,10 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 		// Otherwise, the batch is cleaned up automatically later.
 		if err != errMsgIdDuplicate {
 			b.lseq--
+			// If there is none pending, correct the persisted sequence as we need to commit below.
+			if b.pending == 0 {
+				b.pseq = b.lseq
+			}
 		}
 		if cleanup = batches.fastBatchCommit(b, batch.id, mset, reply); cleanup {
 			b.cleanupLocked(batch.id, batches)


### PR DESCRIPTION
Fixes three 2.14 bugs:

- **Scheduler**: `getScheduledMessages` formatted the `Nats-Schedule-Next` header with whole-second `RFC3339` precision, causing `@every` schedules with sub-second intervals (e.g. `@every 1500ms`) to collapse to whole-second cadence after the first fire.
- **Fast batch**: a commit message failing `checkMsgHeadersPreClusteredProposal` in `gapOk` mode returned early without completing the commit, stranding the batch.
- **Monitoring**: `updateVarzConfigReloadableFields` never rebuilt `varz.LeafNode.Remotes`, so the cached `/varz` endpoint kept serving the pre-reload leafnode remotes list after a config reload.
