### PR TITLE
bound peer id read in decodePeerState to buffer length

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -4788,7 +4788,7 @@ func decodePeerState(buf []byte) (*peerState, error) {
 	expectedPeers := int(le.Uint32(buf[4:]))
 	buf = buf[8:]
 	ri := 0
-	for i, n := 0, expectedPeers; i < n && ri < len(buf); i++ {
+	for i, n := 0, expectedPeers; i < n && ri+idLen <= len(buf); i++ {
 		ps.knownPeers = append(ps.knownPeers, string(buf[ri:ri+idLen]))
 		ri += idLen
 	}

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -169,6 +169,26 @@ func TestNRGAppendEntryDecodeTruncatedEntryLength(t *testing.T) {
 	require_Error(t, err, errBadAppendEntry)
 }
 
+func TestNRGPeerStateDecodeTruncated(t *testing.T) {
+	ps := &peerState{knownPeers: []string{"12345678", "abcdefgh"}, clusterSize: 2}
+	buf := encodePeerState(ps)
+
+	// Sanity check the round trip.
+	dps, err := decodePeerState(buf)
+	require_NoError(t, err)
+	require_Equal(t, len(dps.knownPeers), 2)
+	require_Equal(t, dps.clusterSize, 2)
+
+	// Header claims one peer but only a partial id (idLen-5 bytes) follows.
+	// len == cap so the partial id can not be read past the slice.
+	truncated := make([]byte, 8+idLen-5)
+	le := binary.LittleEndian
+	le.PutUint32(truncated[0:], 1)
+	le.PutUint32(truncated[4:], 1)
+	_, err = decodePeerState(truncated)
+	require_Error(t, err, errCorruptPeers)
+}
+
 func TestNRGRecoverFromFollowingNoLeader(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()


### PR DESCRIPTION
Slice bounds panic out of decodePeerState (server/raft.go) on a peer state whose trailing id is short:

    panic: runtime error: slice bounds out of range [:8] with capacity 3
        server.decodePeerState(...) raft.go:4792

The per-peer loop guard was `ri < len(buf)`, so it entered the body whenever any byte remained and then sliced a fixed 8-byte id with `buf[ri:ri+idLen]`. EntryPeerState data from a peer reaches this decoder directly, so a body whose last id is shorter than idLen reads past the buffer.

Before: a peer state with fewer than idLen bytes left for the next id read out of bounds and panicked.

After: the guard is `ri+idLen <= len(buf)`, so a partial id leaves knownPeers short of expectedPeers and the existing `len(ps.knownPeers) != expectedPeers` check returns errCorruptPeers, which callers already handle.

Tradeoff: a body that is correctly framed but a whole id short still decodes the ids it has and is rejected by the count check, same as today; the only behavioral change is the truncated-id case moving from panic to errCorruptPeers. Sibling decoders (decodeAppendEntry, decodeAppendEntryResponse, decodeVoteRequest, decodeVoteResponse) use exact-length checks and are unchanged.