### PR TITLE
(2.15) [IMPROVED] Faster durable source/mirror consumer resets

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2875,13 +2875,11 @@ VALID:
 				o.mu.Lock()
 			}
 		}
-
-		// Recalculate pending, and re-trigger message delivery.
-		o.streamNumPending()
-		o.signalNewMessages()
-		return seq, true, nil
 	}
-	return seq, false, nil
+	// Recalculate pending, and re-trigger message delivery.
+	o.streamNumPending()
+	o.signalNewMessages()
+	return seq, true, nil
 }
 
 // Lock should be held.

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2863,7 +2863,7 @@ VALID:
 		}
 		return seq, false, nil
 	}
-	o.resetLocalStartingSeq(seq)
+	recalcPending := o.resetLocalStartingSeq(seq)
 	if o.store != nil {
 		o.store.Reset(seq - 1)
 		// Cleanup messages that lost interest.
@@ -2877,19 +2877,23 @@ VALID:
 		}
 	}
 	// Recalculate pending, and re-trigger message delivery.
-	o.streamNumPending()
+	if recalcPending {
+		o.streamNumPending()
+	}
 	o.signalNewMessages()
 	return seq, true, nil
 }
 
 // Lock should be held.
-func (o *consumer) resetLocalStartingSeq(seq uint64) {
+func (o *consumer) resetLocalStartingSeq(seq uint64) bool {
+	recalcPending := o.sseq != seq || len(o.pending) > 0
 	o.pending, o.rdc = nil, nil
 	o.rdq = nil
 	o.rdqi.Empty()
 	o.sseq, o.dseq = seq, 1
 	o.adflr, o.asflr = o.dseq-1, o.sseq-1
 	o.ldt, o.lat = time.Time{}, time.Time{}
+	return recalcPending
 }
 
 func (o *consumer) loopAndForwardProposals(qch chan struct{}) {

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2943,7 +2943,7 @@ VALID:
 		}
 		return seq, false, nil
 	}
-	o.resetLocalStartingSeq(seq)
+	recalcPending := o.resetLocalStartingSeq(seq)
 	if o.store != nil {
 		o.store.Reset(seq - 1)
 		// Cleanup messages that lost interest.
@@ -2957,19 +2957,30 @@ VALID:
 		}
 	}
 	// Recalculate pending, and re-trigger message delivery.
-	o.streamNumPending()
+	if recalcPending {
+		o.streamNumPending()
+	}
 	o.signalNewMessages()
 	return seq, true, nil
 }
 
 // Lock should be held.
-func (o *consumer) resetLocalStartingSeq(seq uint64) {
+func (o *consumer) resetLocalStartingSeq(seq uint64) bool {
+	recalcPending := o.sseq != seq || len(o.pending) > 0
+	// A reset back to the ack floor can be optimized since we know how many were pending.
+	// But only for AckAll/AckFlowControl, since those guarantee no out-of-order acks.
+	if recalcPending && seq == o.asflr+1 && o.isLeader() &&
+		(o.cfg.AckPolicy == AckAll || o.cfg.AckPolicy == AckFlowControl) {
+		o.npc += int64(len(o.pending))
+		recalcPending = false
+	}
 	o.pending, o.rdc = nil, nil
 	o.rdq = nil
 	o.rdqi.Empty()
 	o.sseq, o.dseq = seq, 1
 	o.adflr, o.asflr = o.dseq-1, o.sseq-1
 	o.ldt, o.lat = time.Time{}, time.Time{}
+	return recalcPending
 }
 
 func (o *consumer) loopAndForwardProposals(node RaftNode, qch, pch chan struct{}, term uint64) {

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2955,13 +2955,11 @@ VALID:
 				o.mu.Lock()
 			}
 		}
-
-		// Recalculate pending, and re-trigger message delivery.
-		o.streamNumPending()
-		o.signalNewMessages()
-		return seq, true, nil
 	}
-	return seq, false, nil
+	// Recalculate pending, and re-trigger message delivery.
+	o.streamNumPending()
+	o.signalNewMessages()
+	return seq, true, nil
 }
 
 // Lock should be held.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3511,7 +3511,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 					s.Errorf("Error applying stream entries to '%s > %s': %v", accName, sa.Config.Name, err)
 					if isClusterResetErr(err) {
 						if mset.isMirror() && mset.IsLeader() {
-							mset.retryMirrorConsumer()
+							mset.retryMirrorConsumer(true)
 							continue
 						}
 						// If the error signals we timed out of a snapshot, we should try to replay the snapshot

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7043,7 +7043,7 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 					return err
 				}
 				o.mu.Lock()
-				o.resetLocalStartingSeq(sseq)
+				recalcPending := o.resetLocalStartingSeq(sseq)
 				if o.store != nil {
 					o.store.Reset(sseq - 1)
 				}
@@ -7060,7 +7060,9 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 				if !o.isLeader() {
 					o.mu.Unlock()
 				} else {
-					o.streamNumPending()
+					if recalcPending {
+						o.streamNumPending()
+					}
 					o.signalNewMessages()
 					s, a := o.srv, o.acc
 					if reply == _EMPTY_ {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8004,7 +8004,7 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 					return err
 				}
 				o.mu.Lock()
-				o.resetLocalStartingSeq(sseq)
+				recalcPending := o.resetLocalStartingSeq(sseq)
 				if o.store != nil {
 					o.store.Reset(sseq - 1)
 				}
@@ -8021,7 +8021,9 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 				if !o.isLeader() {
 					o.mu.Unlock()
 				} else {
-					o.streamNumPending()
+					if recalcPending {
+						o.streamNumPending()
+					}
 					o.signalNewMessages()
 					s, a := o.srv, o.acc
 					if reply == _EMPTY_ {

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -9897,6 +9897,203 @@ func TestJetStreamClusterDurableStreamMirrorServerManaged(t *testing.T) {
 	}
 }
 
+func TestJetStreamDurableStreamMirrorPreExistingSub(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:     "O",
+		Subjects: []string{"foo"},
+		Storage:  FileStorage,
+	})
+	require_NoError(t, err)
+
+	_, err = jsConsumerCreate(t, nc, "O", ConsumerConfig{
+		Durable:        "C",
+		DeliverSubject: "deliver-subject",
+		AckPolicy:      AckFlowControl,
+		Heartbeat:      time.Second,
+	}, false)
+	require_NoError(t, err)
+
+	_, err = js.Publish("foo", []byte("1"))
+	require_NoError(t, err)
+
+	_, err = jsStreamCreate(t, nc, &StreamConfig{
+		Name: "M",
+		Mirror: &StreamSource{
+			Name:     "O",
+			Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: "deliver-subject"},
+		},
+		Storage: FileStorage,
+	})
+	require_NoError(t, err)
+
+	// Wait for the mirror to receive the first message.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("M")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != 1 {
+			return fmt.Errorf("expected 1 msg, got %d", si.State.Msgs)
+		}
+		return nil
+	})
+
+	mset, err := s.globalAccount().lookupStream("M")
+	require_NoError(t, err)
+
+	// Capture the durable subscription and its quit channel.
+	get := func() (*subscription, chan struct{}) {
+		mset.mu.RLock()
+		defer mset.mu.RUnlock()
+		require_NotNil(t, mset.mirror)
+		return mset.mirror.sub, mset.mirror.qch
+	}
+	osub, oqch := get()
+	require_NotNil(t, osub)
+	require_NotNil(t, oqch)
+
+	// Force several soft resets. The durable subscription and goroutine must be
+	// reused (same pointers) and must not be torn down.
+	for range 5 {
+		mset.mu.Lock()
+		// Bypass the retry throttle / in-flight reset for a deterministic resend.
+		mset.mirror.lreq = time.Time{}
+		mset.mirror.sip = false
+		mset.mu.Unlock()
+		require_NoError(t, mset.retryMirrorConsumer(false))
+		nsub, nqch := get()
+		require_Equal(t, nsub, osub)
+		require_Equal(t, nqch, oqch)
+	}
+
+	// Messages keep flowing across resets, in order with no gaps.
+	for i := 2; i <= 20; i++ {
+		_, err = js.Publish("foo", []byte(fmt.Sprintf("%d", i)))
+		require_NoError(t, err)
+	}
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("M")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != 20 {
+			return fmt.Errorf("expected 20 msgs, got %d", si.State.Msgs)
+		}
+		return nil
+	})
+	// Last sequence is present and the durable pipeline is still the same one we started with.
+	_, err = js.GetMsg("M", 20)
+	require_NoError(t, err)
+	fsub, fqch := get()
+	require_Equal(t, fsub, osub)
+	require_Equal(t, fqch, oqch)
+
+	// Soft resets that succeed must not accumulate failures.
+	mset.mu.RLock()
+	fails := mset.mirror.fails
+	mset.mu.RUnlock()
+	require_Equal(t, fails, 0)
+}
+
+func TestJetStreamDurableStreamMirrorRecreateAfterTeardown(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:     "O",
+		Subjects: []string{"foo"},
+		Storage:  FileStorage,
+	})
+	require_NoError(t, err)
+
+	_, err = jsConsumerCreate(t, nc, "O", ConsumerConfig{
+		Durable:        "C",
+		DeliverSubject: "deliver-subject",
+		AckPolicy:      AckFlowControl,
+		Heartbeat:      time.Second,
+	}, false)
+	require_NoError(t, err)
+
+	_, err = js.Publish("foo", []byte("1"))
+	require_NoError(t, err)
+
+	_, err = jsStreamCreate(t, nc, &StreamConfig{
+		Name: "M",
+		Mirror: &StreamSource{
+			Name:     "O",
+			Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: "deliver-subject"},
+		},
+		Storage: FileStorage,
+	})
+	require_NoError(t, err)
+
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("M")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != 1 {
+			return fmt.Errorf("expected 1 msg, got %d", si.State.Msgs)
+		}
+		return nil
+	})
+
+	mset, err := s.globalAccount().lookupStream("M")
+	require_NoError(t, err)
+
+	getSub := func() *subscription {
+		mset.mu.RLock()
+		defer mset.mu.RUnlock()
+		require_NotNil(t, mset.mirror)
+		return mset.mirror.sub
+	}
+	sub0 := getSub()
+	require_NotNil(t, sub0)
+
+	// Simulate transport death: fully tear down the durable pipeline.
+	mset.mu.Lock()
+	mset.cancelMirrorConsumer()
+	require_True(t, mset.mirror.sub == nil)
+	// Allow the next setup to proceed immediately (bypass retry throttle).
+	mset.mirror.lreq = time.Time{}
+	mset.mirror.sip = false
+	mset.mu.Unlock()
+
+	// A retry with no durable sub must rebuild a fresh one.
+	require_NoError(t, mset.retryMirrorConsumer(false))
+	checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+		if getSub() == nil {
+			return errors.New("durable sub not rebuilt yet")
+		}
+		return nil
+	})
+
+	// And the mirror resumes delivery.
+	for i := 2; i <= 10; i++ {
+		_, err = js.Publish("foo", []byte(fmt.Sprintf("%d", i)))
+		require_NoError(t, err)
+	}
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("M")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != 10 {
+			return fmt.Errorf("expected 10 msgs, got %d", si.State.Msgs)
+		}
+		return nil
+	})
+}
+
 func TestJetStreamClusterDurableStreamSource(t *testing.T) {
 	test := func(t *testing.T, replicas int, retention RetentionPolicy) {
 		var s *Server

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -10094,6 +10094,134 @@ func TestJetStreamDurableStreamMirrorRecreateAfterTeardown(t *testing.T) {
 	})
 }
 
+func TestJetStreamDurableStreamMirrorAckFCMismatchDefersPipeline(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:     "O",
+		Subjects: []string{"foo"},
+		Storage:  FileStorage,
+	})
+	require_NoError(t, err)
+
+	// Pre-create the durable consumer WITHOUT AckFlowControl, which durable mirroring requires.
+	_, err = jsConsumerCreate(t, nc, "O", ConsumerConfig{
+		Durable:        "C",
+		DeliverSubject: "deliver-subject",
+		AckPolicy:      AckExplicit,
+		Heartbeat:      time.Second,
+	}, false)
+	require_NoError(t, err)
+
+	_, err = js.Publish("foo", []byte("1"))
+	require_NoError(t, err)
+
+	_, err = jsStreamCreate(t, nc, &StreamConfig{
+		Name: "M",
+		Mirror: &StreamSource{
+			Name:     "O",
+			Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: "deliver-subject"},
+		},
+		Storage: FileStorage,
+	})
+	require_NoError(t, err)
+
+	mset, err := s.globalAccount().lookupStream("M")
+	require_NoError(t, err)
+
+	// Capture the durable subscription and the failure counter (fails > 0 means pipeline
+	// recreation is deferred until a reset succeeds).
+	state := func() (*subscription, int) {
+		mset.mu.RLock()
+		defer mset.mu.RUnlock()
+		require_NotNil(t, mset.mirror)
+		return mset.mirror.sub, mset.mirror.fails
+	}
+
+	// The mismatch must be reported, and the pipeline must be torn down and deferred.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("M")
+		if err != nil {
+			return err
+		}
+		if si.Mirror == nil || si.Mirror.Error == nil {
+			return errors.New("expected mirror error")
+		}
+		if si.Mirror.Error.Description != NewJSMirrorConsumerRequiresAckFCError().Description {
+			return si.Mirror.Error
+		}
+		if sub, fails := state(); sub != nil || fails == 0 {
+			return fmt.Errorf("expected torn down deferred pipeline, got sub!=nil=%v fails=%d", sub != nil, fails)
+		}
+		return nil
+	})
+
+	// Capture the message count once the pipeline is torn down. Across retries the pipeline must
+	// stay torn down (never optimistically recreated) and must not deliver through the invalid
+	// consumer, so the count must not grow.
+	si, err := js.StreamInfo("M")
+	require_NoError(t, err)
+	msgs0 := si.State.Msgs
+
+	for range 5 {
+		mset.mu.Lock()
+		mset.mirror.lreq = time.Time{}
+		mset.mirror.sip = false
+		mset.mu.Unlock()
+		require_NoError(t, mset.retryMirrorConsumer(false))
+		sub, fails := state()
+		require_True(t, sub == nil)
+		require_True(t, fails > 0)
+	}
+	si, err = js.StreamInfo("M")
+	require_NoError(t, err)
+	require_Equal(t, si.State.Msgs, msgs0)
+
+	// Fix the consumer by recreating it with AckFlowControl.
+	require_NoError(t, js.DeleteConsumer("O", "C"))
+	_, err = jsConsumerCreate(t, nc, "O", ConsumerConfig{
+		Durable:        "C",
+		DeliverSubject: "deliver-subject",
+		AckPolicy:      AckFlowControl,
+		Heartbeat:      time.Second,
+	}, false)
+	require_NoError(t, err)
+
+	// On the next successful reset, the pipeline is stood up and the mirror recovers.
+	mset.mu.Lock()
+	mset.mirror.lreq = time.Time{}
+	mset.mirror.sip = false
+	mset.mu.Unlock()
+	require_NoError(t, mset.retryMirrorConsumer(false))
+
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		if sub, fails := state(); sub == nil || fails != 0 {
+			return fmt.Errorf("expected rebuilt pipeline, got sub==nil=%v fails=%d", sub == nil, fails)
+		}
+		return nil
+	})
+
+	// And it keeps flowing, converging on all messages.
+	for i := 2; i <= 10; i++ {
+		_, err = js.Publish("foo", []byte(fmt.Sprintf("%d", i)))
+		require_NoError(t, err)
+	}
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("M")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != 10 {
+			return fmt.Errorf("expected 10 msgs, got %d", si.State.Msgs)
+		}
+		return nil
+	})
+}
+
 func TestJetStreamDurableStreamSourcePreExistingSub(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
@@ -10298,6 +10426,146 @@ func TestJetStreamDurableStreamSourceRecreateAfterTeardown(t *testing.T) {
 	})
 
 	// And the source resumes delivery.
+	for i := 2; i <= 10; i++ {
+		_, err = js.Publish("foo", []byte(fmt.Sprintf("%d", i)))
+		require_NoError(t, err)
+	}
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("S")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != 10 {
+			return fmt.Errorf("expected 10 msgs, got %d", si.State.Msgs)
+		}
+		return nil
+	})
+}
+
+func TestJetStreamDurableStreamSourceAckFCMismatchDefersPipeline(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:     "O",
+		Subjects: []string{"foo"},
+		Storage:  FileStorage,
+	})
+	require_NoError(t, err)
+
+	// Pre-create the durable consumer WITHOUT AckFlowControl, which durable sourcing requires.
+	_, err = jsConsumerCreate(t, nc, "O", ConsumerConfig{
+		Durable:        "C",
+		DeliverSubject: "deliver-subject",
+		AckPolicy:      AckExplicit,
+		Heartbeat:      time.Second,
+	}, false)
+	require_NoError(t, err)
+
+	_, err = js.Publish("foo", []byte("1"))
+	require_NoError(t, err)
+
+	_, err = jsStreamCreate(t, nc, &StreamConfig{
+		Name: "S",
+		Sources: []*StreamSource{{
+			Name:     "O",
+			Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: "deliver-subject"},
+		}},
+		Storage: FileStorage,
+	})
+	require_NoError(t, err)
+
+	mset, err := s.globalAccount().lookupStream("S")
+	require_NoError(t, err)
+
+	// Resolve the single source's index name.
+	var iname string
+	mset.mu.RLock()
+	for name := range mset.sources {
+		iname = name
+	}
+	mset.mu.RUnlock()
+	require_NotEqual(t, iname, _EMPTY_)
+
+	// Capture the durable subscription and the failure counter (fails > 0 means pipeline
+	// recreation is deferred until a reset succeeds).
+	state := func() (*subscription, int) {
+		mset.mu.RLock()
+		defer mset.mu.RUnlock()
+		si := mset.sources[iname]
+		require_NotNil(t, si)
+		return si.sub, si.fails
+	}
+
+	// The mismatch must be reported, and the pipeline must be torn down and deferred.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("S")
+		if err != nil {
+			return err
+		}
+		if len(si.Sources) != 1 || si.Sources[0].Error == nil {
+			return errors.New("expected source error")
+		}
+		if si.Sources[0].Error.Description != NewJSSourceConsumerRequiresAckFCError().Description {
+			return si.Sources[0].Error
+		}
+		if sub, fails := state(); sub != nil || fails == 0 {
+			return fmt.Errorf("expected torn down deferred pipeline, got sub!=nil=%v fails=%d", sub != nil, fails)
+		}
+		return nil
+	})
+
+	// Capture the message count once the pipeline is torn down. Across retries the pipeline must
+	// stay torn down (never optimistically recreated) and must not deliver through the invalid
+	// consumer, so the count must not grow.
+	si, err := js.StreamInfo("S")
+	require_NoError(t, err)
+	msgs0 := si.State.Msgs
+
+	for range 5 {
+		mset.mu.Lock()
+		src := mset.sources[iname]
+		src.lreq = time.Time{}
+		src.sip = false
+		mset.trySetupSourceConsumer(iname, src.sseq+1, time.Time{}, false)
+		mset.mu.Unlock()
+		sub, fails := state()
+		require_True(t, sub == nil)
+		require_True(t, fails > 0)
+	}
+	si, err = js.StreamInfo("S")
+	require_NoError(t, err)
+	require_Equal(t, si.State.Msgs, msgs0)
+
+	// Fix the consumer by recreating it with AckFlowControl.
+	require_NoError(t, js.DeleteConsumer("O", "C"))
+	_, err = jsConsumerCreate(t, nc, "O", ConsumerConfig{
+		Durable:        "C",
+		DeliverSubject: "deliver-subject",
+		AckPolicy:      AckFlowControl,
+		Heartbeat:      time.Second,
+	}, false)
+	require_NoError(t, err)
+
+	// On the next successful reset, the pipeline is stood up and the source recovers.
+	mset.mu.Lock()
+	src := mset.sources[iname]
+	src.lreq = time.Time{}
+	src.sip = false
+	mset.trySetupSourceConsumer(iname, src.sseq+1, time.Time{}, false)
+	mset.mu.Unlock()
+
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		if sub, fails := state(); sub == nil || fails != 0 {
+			return fmt.Errorf("expected rebuilt pipeline, got sub==nil=%v fails=%d", sub == nil, fails)
+		}
+		return nil
+	})
+
+	// And it keeps flowing, converging on all messages.
 	for i := 2; i <= 10; i++ {
 		_, err = js.Publish("foo", []byte(fmt.Sprintf("%d", i)))
 		require_NoError(t, err)

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -10094,6 +10094,226 @@ func TestJetStreamDurableStreamMirrorRecreateAfterTeardown(t *testing.T) {
 	})
 }
 
+func TestJetStreamDurableStreamSourcePreExistingSub(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:     "O",
+		Subjects: []string{"foo"},
+		Storage:  FileStorage,
+	})
+	require_NoError(t, err)
+
+	_, err = jsConsumerCreate(t, nc, "O", ConsumerConfig{
+		Durable:        "C",
+		DeliverSubject: "deliver-subject",
+		AckPolicy:      AckFlowControl,
+		Heartbeat:      time.Second,
+	}, false)
+	require_NoError(t, err)
+
+	_, err = js.Publish("foo", []byte("1"))
+	require_NoError(t, err)
+
+	_, err = jsStreamCreate(t, nc, &StreamConfig{
+		Name: "S",
+		Sources: []*StreamSource{{
+			Name:     "O",
+			Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: "deliver-subject"},
+		}},
+		Storage: FileStorage,
+	})
+	require_NoError(t, err)
+
+	// Wait for the source to receive the first message.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("S")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != 1 {
+			return fmt.Errorf("expected 1 msg, got %d", si.State.Msgs)
+		}
+		return nil
+	})
+
+	mset, err := s.globalAccount().lookupStream("S")
+	require_NoError(t, err)
+
+	// Resolve the single source's index name.
+	var iname string
+	mset.mu.RLock()
+	for name := range mset.sources {
+		iname = name
+	}
+	mset.mu.RUnlock()
+	require_NotEqual(t, iname, _EMPTY_)
+
+	// Capture the durable subscription and its quit channel.
+	get := func() (*subscription, chan struct{}) {
+		mset.mu.RLock()
+		defer mset.mu.RUnlock()
+		si := mset.sources[iname]
+		require_NotNil(t, si)
+		return si.sub, si.qch
+	}
+	osub, oqch := get()
+	require_NotNil(t, osub)
+	require_NotNil(t, oqch)
+
+	// Force several soft resets. The durable subscription and shared goroutine
+	// must be reused (same pointers) and must not be torn down.
+	for range 5 {
+		mset.mu.Lock()
+		si := mset.sources[iname]
+		// Bypass the in-flight reset guard for a deterministic resend.
+		si.sip = false
+		mset.trySetupSourceConsumer(iname, si.sseq+1, time.Time{}, false)
+		mset.mu.Unlock()
+		nsub, nqch := get()
+		require_Equal(t, nsub, osub)
+		require_Equal(t, nqch, oqch)
+	}
+
+	// Messages keep flowing across resets, in order with no gaps.
+	for i := 2; i <= 20; i++ {
+		_, err = js.Publish("foo", []byte(fmt.Sprintf("%d", i)))
+		require_NoError(t, err)
+	}
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("S")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != 20 {
+			return fmt.Errorf("expected 20 msgs, got %d", si.State.Msgs)
+		}
+		return nil
+	})
+	// Last sequence is present and the durable pipeline is still the same one we started with.
+	_, err = js.GetMsg("S", 20)
+	require_NoError(t, err)
+	fsub, fqch := get()
+	require_Equal(t, fsub, osub)
+	require_Equal(t, fqch, oqch)
+
+	// Soft resets that succeed must not accumulate failures.
+	mset.mu.RLock()
+	fails := mset.sources[iname].fails
+	mset.mu.RUnlock()
+	require_Equal(t, fails, 0)
+}
+
+func TestJetStreamDurableStreamSourceRecreateAfterTeardown(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:     "O",
+		Subjects: []string{"foo"},
+		Storage:  FileStorage,
+	})
+	require_NoError(t, err)
+
+	_, err = jsConsumerCreate(t, nc, "O", ConsumerConfig{
+		Durable:        "C",
+		DeliverSubject: "deliver-subject",
+		AckPolicy:      AckFlowControl,
+		Heartbeat:      time.Second,
+	}, false)
+	require_NoError(t, err)
+
+	_, err = js.Publish("foo", []byte("1"))
+	require_NoError(t, err)
+
+	_, err = jsStreamCreate(t, nc, &StreamConfig{
+		Name: "S",
+		Sources: []*StreamSource{{
+			Name:     "O",
+			Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: "deliver-subject"},
+		}},
+		Storage: FileStorage,
+	})
+	require_NoError(t, err)
+
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("S")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != 1 {
+			return fmt.Errorf("expected 1 msg, got %d", si.State.Msgs)
+		}
+		return nil
+	})
+
+	mset, err := s.globalAccount().lookupStream("S")
+	require_NoError(t, err)
+
+	var iname string
+	mset.mu.RLock()
+	for name := range mset.sources {
+		iname = name
+	}
+	mset.mu.RUnlock()
+	require_NotEqual(t, iname, _EMPTY_)
+
+	getSub := func() *subscription {
+		mset.mu.RLock()
+		defer mset.mu.RUnlock()
+		si := mset.sources[iname]
+		require_NotNil(t, si)
+		return si.sub
+	}
+	sub0 := getSub()
+	require_NotNil(t, sub0)
+
+	// Simulate transport death: fully tear down the durable pipeline.
+	mset.mu.Lock()
+	si := mset.sources[iname]
+	mset.cancelSourceInfo(si)
+	subNil := si.sub == nil
+	sseq := si.sseq
+	// Allow the next setup to proceed immediately (bypass in-flight guard).
+	si.sip = false
+	mset.mu.Unlock()
+	require_True(t, subNil)
+
+	// A retry with no durable sub must rebuild a fresh one.
+	mset.mu.Lock()
+	mset.trySetupSourceConsumer(iname, sseq+1, time.Time{}, false)
+	mset.mu.Unlock()
+	checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+		if getSub() == nil {
+			return errors.New("durable sub not rebuilt yet")
+		}
+		return nil
+	})
+
+	// And the source resumes delivery.
+	for i := 2; i <= 10; i++ {
+		_, err = js.Publish("foo", []byte(fmt.Sprintf("%d", i)))
+		require_NoError(t, err)
+	}
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("S")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != 10 {
+			return fmt.Errorf("expected 10 msgs, got %d", si.State.Msgs)
+		}
+		return nil
+	})
+}
+
 func TestJetStreamClusterDurableStreamSource(t *testing.T) {
 	test := func(t *testing.T, replicas int, retention RetentionPolicy) {
 		var s *Server

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -9894,9 +9894,9 @@ func TestJetStreamDurableProbeShortCircuitsBackoff(t *testing.T) {
 		}
 		t.Run(kind, func(t *testing.T) {
 			// Make every request time out, so we always end up backing off.
-			owt := srcConsumerWaitTime
-			srcConsumerWaitTime = time.Nanosecond
-			defer func() { srcConsumerWaitTime = owt }()
+			owt := srcDurableConsumerWaitTime
+			srcDurableConsumerWaitTime = time.Nanosecond
+			defer func() { srcDurableConsumerWaitTime = owt }()
 
 			s := RunBasicJetStreamServer(t)
 			defer s.Shutdown()

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -9886,6 +9886,82 @@ func TestJetStreamClusterDurableStreamMirrorServerManaged(t *testing.T) {
 	}
 }
 
+func TestJetStreamDurableProbeShortCircuitsBackoff(t *testing.T) {
+	for _, mirror := range []bool{false, true} {
+		kind := "Source"
+		if mirror {
+			kind = "Mirror"
+		}
+		t.Run(kind, func(t *testing.T) {
+			// Make every request time out, so we always end up backing off.
+			owt := srcConsumerWaitTime
+			srcConsumerWaitTime = time.Nanosecond
+			defer func() { srcConsumerWaitTime = owt }()
+
+			s := RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+
+			nc, _ := jsClientConnect(t, s)
+			defer nc.Close()
+
+			_, err := jsStreamCreate(t, nc, &StreamConfig{
+				Name:     "O",
+				Subjects: []string{"foo"},
+				Storage:  FileStorage,
+			})
+			require_NoError(t, err)
+			_, err = jsConsumerCreate(t, nc, "O", ConsumerConfig{
+				Durable:        "C",
+				DeliverSubject: "d",
+				AckPolicy:      AckFlowControl,
+				Heartbeat:      time.Second,
+			}, false)
+			require_NoError(t, err)
+
+			cfg := &StreamConfig{Name: "S", Storage: FileStorage}
+			ss := &StreamSource{Name: "O", Consumer: &StreamConsumerSource{Name: "C", DeliverSubject: "d"}}
+			if mirror {
+				cfg.Mirror = ss
+			} else {
+				cfg.Sources = []*StreamSource{ss}
+			}
+			_, err = jsStreamCreate(t, nc, cfg)
+			require_NoError(t, err)
+
+			mset, err := s.globalAccount().lookupStream("S")
+			require_NoError(t, err)
+
+			// Mirrors and sources share the sourceInfo, and only one of the two is set,
+			// so the rest of the test does not need to care which we are.
+			lastReq := func() time.Time {
+				mset.mu.RLock()
+				defer mset.mu.RUnlock()
+				si := mset.mirror
+				for _, ss := range mset.sources {
+					si = ss
+				}
+				return si.lreq
+			}
+
+			// The consumer is alive and pushing at us, so the probe we put up on each
+			// timeout must keep cutting the backoff short, and must be put back up for
+			// the timeout after that. Without it the next request would be 10s out and
+			// climbing, with it we only wait out the retry throttle.
+			var requests int
+			last := lastReq()
+			checkFor(t, 8*time.Second, 50*time.Millisecond, func() error {
+				if lreq := lastReq(); lreq.After(last) {
+					requests, last = requests+1, lreq
+				}
+				if requests < 2 {
+					return fmt.Errorf("only %d requests, backoff is not being cut short", requests)
+				}
+				return nil
+			})
+		})
+	}
+}
+
 func TestJetStreamClusterDurableStreamSource(t *testing.T) {
 	test := func(t *testing.T, replicas int, retention RetentionPolicy) {
 		var s *Server

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -11448,6 +11448,12 @@ func TestJetStreamConsumerResetToSequence(t *testing.T) {
 			dseq: 2, adflr: 1,
 			sseq: 2, asflr: 1,
 		})
+		// Confirm the initial pending values.
+		o.mu.RLock()
+		npc, npf := o.npc, o.npf
+		o.mu.RUnlock()
+		require_Equal(t, npc, 2)
+		require_Equal(t, npf, 0)
 
 		// Resetting the consumer with an empty request results in a reset back to the ack floor.
 		var resp JSApiConsumerResetResponse
@@ -11468,6 +11474,14 @@ func TestJetStreamConsumerResetToSequence(t *testing.T) {
 			dseq: 0, adflr: 0,
 			sseq: 1, asflr: 1,
 		})
+		// Confirm pending was recalculated.
+		o.mu.Lock()
+		npc, npf = o.npc, o.npf
+		// Reset so we can check pending isn't recalculated if there's nothing to reset later.
+		o.npf = 0
+		o.mu.Unlock()
+		require_Equal(t, npc, 3)
+		require_Equal(t, npf, 4)
 
 		// Trying to reset to zero also resets back to the ack floor.
 		req := JSApiConsumerResetRequest{Seq: 0}
@@ -11490,6 +11504,12 @@ func TestJetStreamConsumerResetToSequence(t *testing.T) {
 			dseq: 0, adflr: 0,
 			sseq: 1, asflr: 1,
 		})
+		// Confirm pending was not recalculated, since it was already accurate.
+		o.mu.RLock()
+		npc, npf = o.npc, o.npf
+		o.mu.RUnlock()
+		require_Equal(t, npc, 3)
+		require_Equal(t, npf, 0)
 
 		// Resetting the consumer to the last message's sequence so it can be delivered still.
 		req = JSApiConsumerResetRequest{Seq: 4}
@@ -11513,6 +11533,12 @@ func TestJetStreamConsumerResetToSequence(t *testing.T) {
 			dseq: 0, adflr: 0,
 			sseq: 3, asflr: 3,
 		})
+		// Confirm pending was recalculated.
+		o.mu.RLock()
+		npc, npf = o.npc, o.npf
+		o.mu.RUnlock()
+		require_Equal(t, npc, 1)
+		require_Equal(t, npf, 4)
 
 		// As a result of moving the starting sequence up, some messages
 		// have now lost interest and need to be removed.

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -11345,7 +11345,7 @@ func TestJetStreamConsumerAllowOverlappingSubjectsIfNotSubset(t *testing.T) {
 }
 
 func TestJetStreamConsumerResetToSequence(t *testing.T) {
-	test := func(replicas int) {
+	test := func(replicas int, ackPolicy AckPolicy) {
 		c := createJetStreamClusterExplicit(t, "R3S", 3)
 		defer c.shutdown()
 
@@ -11360,8 +11360,18 @@ func TestJetStreamConsumerResetToSequence(t *testing.T) {
 		_, err := js.AddStream(cfg)
 		require_NoError(t, err)
 
+		var ackOpt nats.SubOpt
+		switch ackPolicy {
+		case AckExplicit:
+			ackOpt = nats.AckExplicit()
+		case AckAll:
+			ackOpt = nats.AckAll()
+		default:
+			t.Fatalf("unsupported ack policy for this test: %v", ackPolicy)
+		}
 		sub, err := js.PullSubscribe(_EMPTY_, "CONSUMER",
 			nats.BindStream("TEST"),
+			ackOpt,
 			nats.MaxAckPending(1),
 			nats.AckWait(time.Second),
 			nats.ConsumerReplicas(replicas),
@@ -11448,6 +11458,12 @@ func TestJetStreamConsumerResetToSequence(t *testing.T) {
 			dseq: 2, adflr: 1,
 			sseq: 2, asflr: 1,
 		})
+		// Confirm the initial pending values.
+		o.mu.RLock()
+		npc, npf := o.npc, o.npf
+		o.mu.RUnlock()
+		require_Equal(t, npc, 2)
+		require_Equal(t, npf, 0)
 
 		// Resetting the consumer with an empty request results in a reset back to the ack floor.
 		var resp JSApiConsumerResetResponse
@@ -11468,6 +11484,17 @@ func TestJetStreamConsumerResetToSequence(t *testing.T) {
 			dseq: 0, adflr: 0,
 			sseq: 1, asflr: 1,
 		})
+		// AckAll can use the ack-floor fast path and leaves the floor as-is;
+		// AckExplicit always requires full recalculation here.
+		o.mu.RLock()
+		npc, npf = o.npc, o.npf
+		o.mu.RUnlock()
+		require_Equal(t, npc, 3)
+		if ackPolicy == AckAll {
+			require_Equal(t, npf, 0)
+		} else {
+			require_Equal(t, npf, 4)
+		}
 
 		// Trying to reset to zero also resets back to the ack floor.
 		req := JSApiConsumerResetRequest{Seq: 0}
@@ -11490,6 +11517,16 @@ func TestJetStreamConsumerResetToSequence(t *testing.T) {
 			dseq: 0, adflr: 0,
 			sseq: 1, asflr: 1,
 		})
+		// Same as above.
+		o.mu.RLock()
+		npc, npf = o.npc, o.npf
+		o.mu.RUnlock()
+		require_Equal(t, npc, 3)
+		if ackPolicy == AckAll {
+			require_Equal(t, npf, 0)
+		} else {
+			require_Equal(t, npf, 4)
+		}
 
 		// Resetting the consumer to the last message's sequence so it can be delivered still.
 		req = JSApiConsumerResetRequest{Seq: 4}
@@ -11513,6 +11550,12 @@ func TestJetStreamConsumerResetToSequence(t *testing.T) {
 			dseq: 0, adflr: 0,
 			sseq: 3, asflr: 3,
 		})
+		// Confirm pending was recalculated.
+		o.mu.RLock()
+		npc, npf = o.npc, o.npf
+		o.mu.RUnlock()
+		require_Equal(t, npc, 1)
+		require_Equal(t, npf, 4)
 
 		// As a result of moving the starting sequence up, some messages
 		// have now lost interest and need to be removed.
@@ -11562,9 +11605,11 @@ func TestJetStreamConsumerResetToSequence(t *testing.T) {
 	}
 
 	for _, replicas := range []int{1, 3} {
-		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) {
-			test(replicas)
-		})
+		for _, ackPolicy := range []AckPolicy{AckExplicit, AckAll} {
+			t.Run(fmt.Sprintf("R%d/%s", replicas, ackPolicy), func(t *testing.T) {
+				test(replicas, ackPolicy)
+			})
+		}
 	}
 }
 

--- a/server/jetstream_leafnode_test.go
+++ b/server/jetstream_leafnode_test.go
@@ -1721,7 +1721,7 @@ func TestJetStreamLeafNodeAndMirrorResyncAfterConnectionDown(t *testing.T) {
 			for iname, si := range mset.sources {
 				resetSourceInfo(si)
 				mset.cancelSourceInfo(si)
-				mset.setupSourceConsumer(iname, si.sseq+1, time.Time{})
+				mset.setupSourceConsumer(iname, si.sseq+1, time.Time{}, true)
 			}
 		}
 		mset.mu.Unlock()

--- a/server/stream.go
+++ b/server/stream.go
@@ -3128,7 +3128,7 @@ func (mset *stream) processMirrorMsgs(mirror *sourceInfo, ready *sync.WaitGroup)
 			}
 			// We are stalled.
 			if stalled {
-				mset.retryMirrorConsumer()
+				mset.retryMirrorConsumer(true)
 			}
 		}
 	}
@@ -3172,7 +3172,7 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 		} else {
 			// For idle heartbeats make sure we did not miss anything and check if we are considered stalled.
 			if ldseq := parseInt64(sliceHeader(JSLastConsumerSeq, m.hdr)); ldseq > 0 && uint64(ldseq) != mset.mirror.dseq {
-				needsRetry = true
+				needsRetry = !mset.mirror.sip
 			} else if fcReply := sliceHeader(JSConsumerStalled, m.hdr); len(fcReply) > 0 {
 				// Other side thinks we are stalled, so send flow control reply.
 				mset.outq.sendMsg(string(fcReply), nil)
@@ -3180,7 +3180,7 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 		}
 		mset.mu.Unlock()
 		if needsRetry {
-			mset.retryMirrorConsumer()
+			mset.retryMirrorConsumer(false)
 		}
 		return !needsRetry
 	}
@@ -3215,14 +3215,14 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 				mset.mirror.sseq = osseq
 				mset.mirror.dseq = odseq
 				mset.mu.Unlock()
-				mset.retryMirrorConsumer()
+				mset.retryMirrorConsumer(false)
 				return false
 			}
 			mset.mirror.dseq++
 			mset.mirror.sseq = sseq
 		} else {
 			mset.mu.Unlock()
-			mset.retryMirrorConsumer()
+			mset.retryMirrorConsumer(false)
 			return false
 		}
 	}
@@ -3299,7 +3299,7 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 				}
 			}
 			mset.mu.Unlock()
-			mset.retryMirrorConsumer()
+			mset.retryMirrorConsumer(false)
 		}
 	}
 	return err == nil
@@ -3327,11 +3327,16 @@ func (mset *stream) cancelMirrorConsumer() {
 // indicating that there is a retry.
 //
 // Lock is acquired in this function
-func (mset *stream) retryMirrorConsumer() error {
+func (mset *stream) retryMirrorConsumer(force bool) error {
 	mset.mu.Lock()
 	defer mset.mu.Unlock()
 	mset.srv.Debugf("Retrying mirror consumer for '%s > %s'", mset.acc.Name, mset.cfg.Name)
-	mset.cancelMirrorConsumer()
+	// For durable mirrors with a durable subscription, a retry is a "soft reset", unless forced.
+	mirror, cfg := mset.mirror, mset.cfg.Mirror
+	durableSub := mirror != nil && mirror.sub != nil && cfg != nil && cfg.Consumer != nil
+	if force || !durableSub {
+		mset.cancelMirrorConsumer()
+	}
 	return mset.setupMirrorConsumer()
 }
 
@@ -3421,6 +3426,52 @@ func (mset *stream) scheduleSetupMirrorConsumerRetry() {
 // How long we wait for a response from a consumer create request for a source or mirror.
 var srcConsumerWaitTime = 30 * time.Second
 
+// How long we wait for a response from a consumer reset request for a durable source or mirror.
+var srcDurableConsumerWaitTime = 5 * time.Second
+
+// createMirrorPipeline creates the subscription and its message queue for a mirror.
+// Lock should be held.
+func (mset *stream) createMirrorPipeline(mirror *sourceInfo, deliverSubject string) error {
+	qname := fmt.Sprintf("[ACC:%s] stream mirror '%s' of '%s' msgs", mset.acc.Name, mset.cfg.Name, mset.cfg.Mirror.Name)
+	// Create a new queue each time
+	mirror.msgs = newIPQueue[*inMsg](mset.srv, qname)
+	msgs := mirror.msgs
+	sub, err := mset.subscribeInternal(deliverSubject, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+		hdr, msg := c.msgParts(copyBytes(rmsg)) // Need to copy.
+		if len(hdr) > 0 {
+			// Remove any Nats-Expected- headers as we don't want to validate them.
+			hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Expected-")
+			// Remove any Nats-Batch- headers, batching is not supported when mirroring.
+			hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Batch-")
+		}
+		mset.queueInbound(msgs, subject, reply, hdr, msg, nil, nil)
+		mirror.last.Store(time.Now().UnixNano())
+	})
+	if err != nil {
+		return err
+	}
+	// Save our sub.
+	mirror.sub = sub
+	return nil
+}
+
+// createMirrorRoutine creates the goroutine that processes mirror messages.
+// Lock should be held.
+func (mset *stream) createMirrorRoutine(mirror *sourceInfo, ready *sync.WaitGroup) {
+	if !mset.srv.startGoRoutine(
+		func() { mset.processMirrorMsgs(mirror, ready) },
+		pprofLabels{
+			"type":     "mirror",
+			"account":  mset.acc.Name,
+			"stream":   mset.cfg.Name,
+			"consumer": mirror.cname,
+		},
+	) {
+		mirror.wg.Done()
+		ready.Done()
+	}
+}
+
 // Setup our mirror consumer.
 // Lock should be held.
 func (mset *stream) setupMirrorConsumer() error {
@@ -3441,10 +3492,19 @@ func (mset *stream) setupMirrorConsumer() error {
 		return errors.New("invalid mirror configuration")
 	}
 
+	// Durable mirror consumers' subscription is created independently and kept alive
+	// across resets/retries.
+	durable := mset.cfg.Mirror.Consumer != nil
+	durableSub := durable && mset.mirror != nil && mset.mirror.sub != nil
+
 	// If this is the first time
 	if mset.mirror == nil {
 		mset.mirror = &sourceInfo{name: mset.cfg.Mirror.Name}
-	} else {
+	} else if mset.mirror.sip {
+		// If setup already in progress, nothing to do.
+		return nil
+	} else if !durableSub {
+		// Tear down a previous pipeline.
 		mset.cancelSourceInfo(mset.mirror)
 		mset.mirror.sseq = mset.lseq
 	}
@@ -3456,9 +3516,8 @@ func (mset *stream) setupMirrorConsumer() error {
 
 	mirror := mset.mirror
 
-	// We want to throttle here in terms of how fast we request new consumers,
-	// or if the previous is still in progress.
-	if last := time.Since(mirror.lreq); last < sourceConsumerRetryThreshold || mirror.sip {
+	// We want to throttle here in terms of how fast we request new consumers.
+	if last := time.Since(mirror.lreq); last < sourceConsumerRetryThreshold {
 		mset.scheduleSetupMirrorConsumerRetry()
 		return nil
 	}
@@ -3600,9 +3659,36 @@ func (mset *stream) setupMirrorConsumer() error {
 	subject := generateSubject()
 
 	// Reset
-	mirror.msgs = nil
 	mirror.err = nil
 	mirror.sip = true
+
+	if durable {
+		// Stand up the durable subscription and its processing goroutine up front.
+		if mirror.sub == nil {
+			if err = mset.createMirrorPipeline(mirror, durableDeliverSubject); err != nil {
+				mirror.err = NewJSMirrorConsumerSetupFailedError(err, Unless(err))
+				mirror.sip = false
+				mset.unsubscribe(crSub)
+				mset.scheduleSetupMirrorConsumerRetry()
+				return nil
+			}
+			// Baseline the stream sequence to our applied position; from here it is
+			// monotonic and owned by the per-message logic (never lowered on reset).
+			mirror.sseq = mset.lseq
+			mirror.qch = make(chan struct{})
+			mirror.wg.Add(1)
+			// Unlike the ephemeral path, we don't ready.Wait() below. The durable
+			// goroutine is started once and kept alive across resets. Waiting would
+			// also deadlock since we're holding the stream lock.
+			ready := &sync.WaitGroup{}
+			ready.Add(1)
+			mset.createMirrorRoutine(mirror, ready)
+		}
+		// Clear the delivery sequence, since we'll reset.
+		mirror.dseq = 0
+	} else {
+		mirror.msgs = nil
+	}
 
 	if durableDeliverSubject != _EMPTY_ {
 		// Send the consumer reset request
@@ -3618,6 +3704,12 @@ func (mset *stream) setupMirrorConsumer() error {
 	}
 
 	go func() {
+		// Use a longer timeout for ephemeral consumers, since they need to be created from scratch.
+		timeout := srcConsumerWaitTime
+		if durable {
+			// Use a shorter timeout for durable consumers, since they only need to be reset.
+			timeout = srcDurableConsumerWaitTime
+		}
 
 		var retry bool
 		defer func() {
@@ -3625,12 +3717,15 @@ func (mset *stream) setupMirrorConsumer() error {
 			// Check that this is still valid and if so, clear the "setup in progress" flag.
 			if mset.mirror != nil {
 				mset.mirror.sip = false
-				// If we need to retry, schedule now
+				// If we need to retry, schedule now.
 				// If sub is not nil means we re-established somewhere else so do not re-attempt here.
-				if retry && mset.mirror.sub == nil {
+				// Unless we're durable, in which case we always have the sub populated.
+				if retry && (durable || mset.mirror.sub == nil) {
 					mset.mirror.fails++
-					// Cancel here since we can not do anything with this consumer at this point.
-					mset.cancelSourceInfo(mset.mirror)
+					if !durable {
+						// Cancel here since we can not do anything with this consumer at this point.
+						mset.cancelSourceInfo(mset.mirror)
+					}
 					mset.scheduleSetupMirrorConsumerRetry()
 				} else {
 					// Clear on success.
@@ -3642,16 +3737,19 @@ func (mset *stream) setupMirrorConsumer() error {
 
 		// Wait for previous processMirrorMsgs go routine to be completely done.
 		// If none is running, this will not block.
-		mset.mu.Lock()
-		if mset.mirror == nil {
-			// Mirror config has been removed.
-			mset.unsubscribe(crSub)
+		// For durable mirrors the processing goroutine remains alive, so don't wait.
+		if !durable {
+			mset.mu.Lock()
+			if mset.mirror == nil {
+				// Mirror config has been removed.
+				mset.unsubscribe(crSub)
+				mset.mu.Unlock()
+				return
+			}
+			wg := &mset.mirror.wg
 			mset.mu.Unlock()
-			return
+			wg.Wait()
 		}
-		wg := &mset.mirror.wg
-		mset.mu.Unlock()
-		wg.Wait()
 
 	SELECT:
 		select {
@@ -3669,7 +3767,7 @@ func (mset *stream) setupMirrorConsumer() error {
 
 			if ccr.Error != nil || ccr.ConsumerInfo == nil {
 				// If the responding server doesn't support sourcing consumers, retry without it.
-				if req.Config.Sourcing && ccr.Error != nil &&
+				if !durable && req.Config.Sourcing && ccr.Error != nil &&
 					(ccr.Error.ErrCode == uint16(JSRequiredApiLevelErr) || ccr.Error.ErrCode == uint16(JSInvalidJSONErr)) {
 					// Unset for retry.
 					req.Config.Sourcing = false
@@ -3711,35 +3809,17 @@ func (mset *stream) setupMirrorConsumer() error {
 			// We can now unsubscribe.
 			mset.unsubscribe(crSub)
 
-			// Setup actual subscription to process messages from our source.
-			qname := fmt.Sprintf("[ACC:%s] stream mirror '%s' of '%s' msgs", mset.acc.Name, mset.cfg.Name, mset.cfg.Mirror.Name)
-			// Create a new queue each time
-			mirror.msgs = newIPQueue[*inMsg](mset.srv, qname)
-			msgs := mirror.msgs
-			if durableDeliverSubject != _EMPTY_ {
-				deliverSubject = durableDeliverSubject
-			} else {
+			// For ephemeral mirrors, set up the subscription now that we know the
+			// deliver subject from the response.
+			if !durable {
 				deliverSubject = ccr.ConsumerInfo.Config.DeliverSubject
-			}
-			sub, err := mset.subscribeInternal(deliverSubject, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-				hdr, msg := c.msgParts(copyBytes(rmsg)) // Need to copy.
-				if len(hdr) > 0 {
-					// Remove any Nats-Expected- headers as we don't want to validate them.
-					hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Expected-")
-					// Remove any Nats-Batch- headers, batching is not supported when mirroring.
-					hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Batch-")
+				if err = mset.createMirrorPipeline(mirror, deliverSubject); err != nil {
+					mirror.err = NewJSMirrorConsumerSetupFailedError(err, Unless(err))
+					retry = true
+					mset.mu.Unlock()
+					return
 				}
-				mset.queueInbound(msgs, subject, reply, hdr, msg, nil, nil)
-				mirror.last.Store(time.Now().UnixNano())
-			})
-			if err != nil {
-				mirror.err = NewJSMirrorConsumerSetupFailedError(err, Unless(err))
-				retry = true
-				mset.mu.Unlock()
-				return
 			}
-			// Save our sub.
-			mirror.sub = sub
 
 			// Check if we need to skip messages.
 			// Re-capture state since the previous may be stale.
@@ -3768,30 +3848,25 @@ func (mset *stream) setupMirrorConsumer() error {
 				}
 			}
 
-			// Capture consumer name.
-			mirror.cname = ccr.ConsumerInfo.Name
-			mirror.dseq = 0
-			mirror.sseq = max(ccr.ConsumerInfo.Delivered.Stream, state.LastSeq)
-			mirror.qch = make(chan struct{})
-			mirror.wg.Add(1)
-			ready.Add(1)
-			if !mset.srv.startGoRoutine(
-				func() { mset.processMirrorMsgs(mirror, &ready) },
-				pprofLabels{
-					"type":     "mirror",
-					"account":  mset.acc.Name,
-					"stream":   mset.cfg.Name,
-					"consumer": mirror.cname,
-				},
-			) {
-				mirror.wg.Done()
-				ready.Done()
+			if durable {
+				// The subscription and goroutine already exist, only raise the stream sequence.
+				mirror.sseq = max(mirror.sseq, ccr.ConsumerInfo.Delivered.Stream)
+				mset.mu.Unlock()
+			} else {
+				// Capture consumer name.
+				mirror.cname = ccr.ConsumerInfo.Name
+				mirror.dseq = 0
+				mirror.sseq = max(ccr.ConsumerInfo.Delivered.Stream, state.LastSeq)
+				mirror.qch = make(chan struct{})
+				mirror.wg.Add(1)
+				ready.Add(1)
+				mset.createMirrorRoutine(mirror, &ready)
+				mset.mu.Unlock()
+				ready.Wait()
 			}
-			mset.mu.Unlock()
-			ready.Wait()
-		case <-time.After(srcConsumerWaitTime):
+		case <-time.After(timeout):
 			mset.unsubscribe(crSub)
-			// We already waited 30 seconds, let's retry now.
+			// We already waited long enough, let's retry now.
 			retry = true
 		}
 	}()

--- a/server/stream.go
+++ b/server/stream.go
@@ -3663,8 +3663,9 @@ func (mset *stream) setupMirrorConsumer() error {
 	mirror.sip = true
 
 	if durable {
-		// Stand up the durable subscription and its processing goroutine up front.
-		if mirror.sub == nil {
+		// Optimistically stand up the durable subscription and shared processing goroutine up front.
+		// If it was closed as part of a request failure, only recreate after a successful response.
+		if mirror.sub == nil && mirror.fails == 0 {
 			if err = mset.createMirrorPipeline(mirror, durableDeliverSubject); err != nil {
 				mirror.err = NewJSMirrorConsumerSetupFailedError(err, Unless(err))
 				mirror.sip = false
@@ -3800,6 +3801,7 @@ func (mset *stream) setupMirrorConsumer() error {
 			// If using durable sourcing, we need the consumer to use acks based on flow control.
 			if durableDeliverSubject != _EMPTY_ && ccr.ConsumerInfo.Config.AckPolicy != AckFlowControl {
 				mset.unsubscribe(crSub)
+				mset.cancelSourceInfo(mirror)
 				mirror.err = NewJSMirrorConsumerRequiresAckFCError()
 				retry = true
 				mset.mu.Unlock()
@@ -3849,7 +3851,26 @@ func (mset *stream) setupMirrorConsumer() error {
 			}
 
 			if durable {
-				// The subscription and goroutine already exist, only raise the stream sequence.
+				// If the pipeline was deferred (e.g. after an AckFlowControl mismatch), stand it
+				// up now that we have a successful response.
+				if mirror.sub == nil {
+					if err = mset.createMirrorPipeline(mirror, durableDeliverSubject); err != nil {
+						mirror.err = NewJSMirrorConsumerSetupFailedError(err, Unless(err))
+						retry = true
+						mset.mu.Unlock()
+						return
+					}
+					// Baseline the stream sequence to our applied position; from here it is
+					// monotonic and owned by the per-message logic (never lowered on reset).
+					mirror.sseq = mset.lseq
+					mirror.qch = make(chan struct{})
+					mirror.wg.Add(1)
+					// As in the optimistic path, we don't ready.Wait(): the durable goroutine is
+					// started once and kept alive across resets.
+					ready.Add(1)
+					mset.createMirrorRoutine(mirror, &ready)
+				}
+				// The subscription and goroutine exist now, only raise the stream sequence.
 				mirror.sseq = max(mirror.sseq, ccr.ConsumerInfo.Delivered.Stream)
 				mset.mu.Unlock()
 			} else {
@@ -4165,8 +4186,9 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 	si.sip = true
 
 	if durable {
-		// Stand up the durable subscription and shared processing goroutine up front.
-		if si.sub == nil {
+		// Optimistically stand up the durable subscription and shared processing goroutine up front.
+		// If it was closed as part of a request failure, only recreate after a successful response.
+		if si.sub == nil && si.fails == 0 {
 			if err = mset.createSourcePipeline(si, durableDeliverSubject); err != nil {
 				si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
 				si.sip = false
@@ -4277,6 +4299,7 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 				// If using durable sourcing, we need the consumer to use acks based on flow control.
 				if durableDeliverSubject != _EMPTY_ && ccr.ConsumerInfo.Config.AckPolicy != AckFlowControl {
 					mset.unsubscribe(crSub)
+					mset.cancelSourceInfo(si)
 					si.err = NewJSSourceConsumerRequiresAckFCError()
 					retry = true
 					mset.mu.Unlock()
@@ -4287,7 +4310,19 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 				mset.unsubscribe(crSub)
 
 				if durable {
-					// The subscription and shared goroutine already exist, only raise the stream sequence.
+					// If the pipeline was deferred (e.g. after an AckFlowControl mismatch), stand
+					// it up now that we have a successful response.
+					if si.sub == nil {
+						if err = mset.createSourcePipeline(si, durableDeliverSubject); err != nil {
+							si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
+							retry = true
+							mset.mu.Unlock()
+							return
+						}
+						si.qch = make(chan struct{})
+						si.last.Store(time.Now().UnixNano())
+					}
+					// The subscription and shared goroutine exist now, only raise the stream sequence.
 					si.sseq = max(si.sseq, ccr.ConsumerInfo.Delivered.Stream)
 				} else {
 					// Setup actual subscription to process messages from our source.

--- a/server/stream.go
+++ b/server/stream.go
@@ -2585,7 +2585,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 			}
 			mset.setStartingSequenceForSources(needsStartingSeqNum)
 			for iName := range neededCopy {
-				mset.setupSourceConsumer(iName, mset.sources[iName].sseq+1, time.Time{})
+				mset.setupSourceConsumer(iName, mset.sources[iName].sseq+1, time.Time{}, true)
 			}
 		}
 	}
@@ -3046,7 +3046,7 @@ func (mset *stream) retryDisconnectedSyncConsumers() {
 	} else {
 		for _, si := range mset.sources {
 			if shouldRetry(si) {
-				mset.setupSourceConsumer(si.iname, si.sseq+1, time.Time{})
+				mset.setupSourceConsumer(si.iname, si.sseq+1, time.Time{}, true)
 			}
 		}
 	}
@@ -3884,13 +3884,13 @@ func (mset *stream) streamSource(iname string) *StreamSource {
 }
 
 // Lock should be held.
-func (mset *stream) retrySourceConsumerAtSeq(iName string, seq uint64) {
+func (mset *stream) retrySourceConsumerAtSeq(iName string, seq uint64, force bool) {
 	s := mset.srv
 
 	s.Debugf("Retrying source consumer for '%s > %s'", mset.acc.Name, mset.cfg.Name)
 
 	// setupSourceConsumer will check that the source is still configured.
-	mset.setupSourceConsumer(iName, seq, time.Time{})
+	mset.setupSourceConsumer(iName, seq, time.Time{}, force)
 }
 
 // Lock should be held.
@@ -3934,7 +3934,7 @@ const sourceConsumerRetryThreshold = 2 * time.Second
 // It actually only does the scheduling of the execution of trySetupSourceConsumer in order to implement retry backoff
 // and throttle the number of requests.
 // Lock should be held.
-func (mset *stream) setupSourceConsumer(iname string, seq uint64, startTime time.Time) {
+func (mset *stream) setupSourceConsumer(iname string, seq uint64, startTime time.Time, force bool) {
 	if mset.sourceSetupSchedules == nil {
 		mset.sourceSetupSchedules = map[string]*time.Timer{}
 	}
@@ -3972,29 +3972,65 @@ func (mset *stream) setupSourceConsumer(iname string, seq uint64, startTime time
 		defer mset.mu.Unlock()
 
 		delete(mset.sourceSetupSchedules, iname)
-		mset.trySetupSourceConsumer(iname, seq, startTime)
+		mset.trySetupSourceConsumer(iname, seq, startTime, force)
 	})
+}
+
+// createSourcePipeline ensures the shared source message queue is running and
+// spins up a processing goroutine for a source.
+// Lock should be held.
+func (mset *stream) createSourcePipeline(si *sourceInfo, deliverSubject string) error {
+	// Check if our shared msg queue and go routine is running or not.
+	if mset.smsgs == nil {
+		qname := fmt.Sprintf("[ACC:%s] stream sources '%s' msgs", mset.acc.Name, mset.cfg.Name)
+		mset.smsgs = newIPQueue[*inMsg](mset.srv, qname)
+		mset.srv.startGoRoutine(func() { mset.processAllSourceMsgs() },
+			pprofLabels{
+				"type":    "source",
+				"account": mset.acc.Name,
+				"stream":  mset.cfg.Name,
+			},
+		)
+	}
+	msgs := mset.smsgs
+	sub, err := mset.subscribeInternal(deliverSubject, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+		hdr, msg := c.msgParts(copyBytes(rmsg)) // Need to copy.
+		mset.queueInbound(msgs, subject, reply, hdr, msg, si, nil)
+		si.last.Store(time.Now().UnixNano())
+	})
+	if err != nil {
+		return err
+	}
+	// Save our sub.
+	si.sub = sub
+	return nil
 }
 
 // This is where we will actually try to create a new consumer for the source
 // Lock should be held.
-func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime time.Time) {
+func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime time.Time, force bool) {
 	// Ignore if closed or not leader.
 	if mset.closed.Load() || !mset.isLeader() {
 		return
 	}
 
 	si := mset.sources[iname]
-	if si == nil {
+	if si == nil || si.sip {
 		return
 	}
 
-	// Cancel previous instance if applicable
-	mset.cancelSourceInfo(si)
-
 	ssi := mset.streamSource(iname)
 	if ssi == nil {
+		// Source is no longer configured, cancel and bail.
+		mset.cancelSourceInfo(si)
 		return
+	}
+
+	// For durable sources with a durable subscription, a retry is a "soft reset", unless forced.
+	durable := ssi.Consumer != nil
+	durableSub := durable && si.sub != nil
+	if force || !durableSub {
+		mset.cancelSourceInfo(si)
 	}
 
 	si.lreq = time.Now()
@@ -4097,7 +4133,7 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 	reply, respCh, crSub, err := newReplySubscription()
 	if err != nil {
 		si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
-		mset.setupSourceConsumer(iname, seq, startTime)
+		mset.setupSourceConsumer(iname, seq, startTime, force)
 		return
 	}
 
@@ -4125,9 +4161,28 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 	subject := generateSubject()
 
 	// Reset
-	si.msgs = nil
 	si.err = nil
 	si.sip = true
+
+	if durable {
+		// Stand up the durable subscription and shared processing goroutine up front.
+		if si.sub == nil {
+			if err = mset.createSourcePipeline(si, durableDeliverSubject); err != nil {
+				si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
+				si.sip = false
+				mset.unsubscribe(crSub)
+				mset.setupSourceConsumer(iname, seq, startTime, force)
+				return
+			}
+			si.qch = make(chan struct{})
+			// Set the last seen as now so that we don't fail at the first check.
+			si.last.Store(time.Now().UnixNano())
+		}
+		// Clear the delivery sequence, since we'll reset.
+		si.dseq = 0
+	} else {
+		si.msgs = nil
+	}
 
 	if durableDeliverSubject != _EMPTY_ {
 		// Send the consumer reset request
@@ -4143,6 +4198,12 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 	}
 
 	go func() {
+		// Use a longer timeout for ephemeral consumers, since they need to be created from scratch.
+		timeout := srcConsumerWaitTime
+		if durable {
+			// Use a shorter timeout for durable consumers, since they only need to be reset.
+			timeout = srcDurableConsumerWaitTime
+		}
 
 		var retry bool
 		defer func() {
@@ -4150,13 +4211,16 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 			// Check that this is still valid and if so, clear the "setup in progress" flag.
 			if si := mset.sources[iname]; si != nil {
 				si.sip = false
-				// If we need to retry, schedule now
+				// If we need to retry, schedule now.
 				// If sub is not nil means we re-established somewhere else so do not re-attempt here.
-				if retry && si.sub == nil {
+				// Unless we're durable, in which case we always have the sub populated.
+				if retry && (durable || si.sub == nil) {
 					si.fails++
-					// Cancel here since we can not do anything with this consumer at this point.
-					mset.cancelSourceInfo(si)
-					mset.setupSourceConsumer(iname, seq, startTime)
+					if !durable {
+						// Cancel here since we can not do anything with this consumer at this point.
+						mset.cancelSourceInfo(si)
+					}
+					mset.setupSourceConsumer(iname, seq, startTime, force)
 				} else {
 					// Clear on success.
 					si.fails = 0
@@ -4177,7 +4241,7 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 
 				if ccr.Error != nil || ccr.ConsumerInfo == nil {
 					// If the responding server doesn't support sourcing consumers, retry without it.
-					if req.Config.Sourcing && ccr.Error != nil &&
+					if !durable && req.Config.Sourcing && ccr.Error != nil &&
 						(ccr.Error.ErrCode == uint16(JSRequiredApiLevelErr) || ccr.Error.ErrCode == uint16(JSInvalidJSONErr)) {
 						// Unset for retry.
 						req.Config.Sourcing = false
@@ -4222,56 +4286,36 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 				// We can now unsubscribe.
 				mset.unsubscribe(crSub)
 
-				// Check if our shared msg queue and go routine is running or not.
-				if mset.smsgs == nil {
-					qname := fmt.Sprintf("[ACC:%s] stream sources '%s' msgs", mset.acc.Name, mset.cfg.Name)
-					mset.smsgs = newIPQueue[*inMsg](mset.srv, qname)
-					mset.srv.startGoRoutine(func() { mset.processAllSourceMsgs() },
-						pprofLabels{
-							"type":    "source",
-							"account": mset.acc.Name,
-							"stream":  mset.cfg.Name,
-						},
-					)
-				}
-
-				// Setup actual subscription to process messages from our source.
-				if si.sseq < ccr.ConsumerInfo.Delivered.Stream {
-					si.sseq = ccr.ConsumerInfo.Delivered.Stream
-				}
-				// Capture consumer name.
-				si.cname = ccr.ConsumerInfo.Name
-
-				// Do not set si.sseq to seq here. si.sseq will be set in processInboundSourceMsg
-				si.dseq = 0
-				si.qch = make(chan struct{})
-				// Set the last seen as now so that we don't fail at the first check.
-				si.last.Store(time.Now().UnixNano())
-
-				msgs := mset.smsgs
-				if durableDeliverSubject != _EMPTY_ {
-					deliverSubject = durableDeliverSubject
+				if durable {
+					// The subscription and shared goroutine already exist, only raise the stream sequence.
+					si.sseq = max(si.sseq, ccr.ConsumerInfo.Delivered.Stream)
 				} else {
-					deliverSubject = ccr.ConsumerInfo.Config.DeliverSubject
-				}
-				sub, err := mset.subscribeInternal(deliverSubject, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-					hdr, msg := c.msgParts(copyBytes(rmsg)) // Need to copy.
-					mset.queueInbound(msgs, subject, reply, hdr, msg, si, nil)
+					// Setup actual subscription to process messages from our source.
+					if si.sseq < ccr.ConsumerInfo.Delivered.Stream {
+						si.sseq = ccr.ConsumerInfo.Delivered.Stream
+					}
+					// Capture consumer name.
+					si.cname = ccr.ConsumerInfo.Name
+
+					// Do not set si.sseq to seq here. si.sseq will be set in processInboundSourceMsg
+					si.dseq = 0
+					si.qch = make(chan struct{})
+					// Set the last seen as now so that we don't fail at the first check.
 					si.last.Store(time.Now().UnixNano())
-				})
-				if err != nil {
-					si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
-					retry = true
-					mset.mu.Unlock()
-					return
+
+					deliverSubject = ccr.ConsumerInfo.Config.DeliverSubject
+					if err = mset.createSourcePipeline(si, deliverSubject); err != nil {
+						si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
+						retry = true
+						mset.mu.Unlock()
+						return
+					}
 				}
-				// Save our sub.
-				si.sub = sub
 			}
 			mset.mu.Unlock()
-		case <-time.After(srcConsumerWaitTime):
+		case <-time.After(timeout):
 			mset.unsubscribe(crSub)
-			// We already waited 30 seconds, let's retry now.
+			// We already waited long enough, let's retry now.
 			retry = true
 		}
 	}()
@@ -4355,7 +4399,7 @@ func (mset *stream) processAllSourceMsgs() {
 					mset.mu.Lock()
 					defer mset.mu.Unlock()
 					for _, si := range stalled {
-						mset.setupSourceConsumer(si.iname, si.sseq+1, time.Time{})
+						mset.setupSourceConsumer(si.iname, si.sseq+1, time.Time{}, true)
 					}
 				}()
 			}
@@ -4434,12 +4478,14 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 		} else {
 			// For idle heartbeats make sure we did not miss anything.
 			if ldseq := parseInt64(sliceHeader(JSLastConsumerSeq, m.hdr)); ldseq > 0 && uint64(ldseq) != si.dseq {
-				needsRetry = true
-				mset.retrySourceConsumerAtSeq(si.iname, si.sseq+1)
+				needsRetry = !si.sip
 			} else if fcReply := sliceHeader(JSConsumerStalled, m.hdr); len(fcReply) > 0 {
 				// Other side thinks we are stalled, so send flow control reply.
 				mset.outq.sendMsg(string(fcReply), nil)
 			}
+		}
+		if needsRetry {
+			mset.retrySourceConsumerAtSeq(si.iname, si.sseq+1, false)
 		}
 		mset.mu.Unlock()
 		return !needsRetry
@@ -4470,7 +4516,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 			si.cname = cname
 			si.dseq, si.sseq = dseq, sseq
 		} else {
-			mset.retrySourceConsumerAtSeq(si.iname, si.sseq+1)
+			mset.retrySourceConsumerAtSeq(si.iname, si.sseq+1, false)
 			mset.mu.Unlock()
 			return false
 		}
@@ -4553,7 +4599,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 			mset.mu.Lock()
 			si.dseq = odseq
 			si.sseq = osseq
-			mset.retrySourceConsumerAtSeq(iName, sseq)
+			mset.retrySourceConsumerAtSeq(iName, sseq, false)
 			mset.mu.Unlock()
 		}
 		return false
@@ -4919,7 +4965,7 @@ func (mset *stream) setupSourceConsumers() error {
 	// Setup our consumers at the proper starting position.
 	for _, ssi := range mset.cfg.Sources {
 		if si := mset.sources[ssi.iname]; si != nil {
-			mset.setupSourceConsumer(ssi.iname, si.sseq+1, time.Time{})
+			mset.setupSourceConsumer(ssi.iname, si.sseq+1, time.Time{}, true)
 		}
 	}
 

--- a/server/stream.go
+++ b/server/stream.go
@@ -3597,6 +3597,10 @@ func (mset *stream) scheduleSetupMirrorConsumerRetry() {
 // How long we wait for a response from a consumer create request for a source or mirror.
 var srcConsumerWaitTime = 30 * time.Second
 
+// How long we wait for a response from a consumer reset request for a durable source or
+// mirror. Shorter than a create, since the consumer is only repositioned, not stood up.
+var srcDurableConsumerWaitTime = 5 * time.Second
+
 // Setup our mirror consumer.
 // Lock should be held.
 func (mset *stream) setupMirrorConsumer() error {
@@ -3794,6 +3798,12 @@ func (mset *stream) setupMirrorConsumer() error {
 	}
 
 	go func() {
+		// A durable consumer only needs to be reset, so don't wait as long as we would
+		// for a consumer that still has to be created from scratch.
+		timeout := srcConsumerWaitTime
+		if durableDeliverSubject != _EMPTY_ {
+			timeout = srcDurableConsumerWaitTime
+		}
 
 		var retry bool
 		var timedOut bool
@@ -3980,9 +3990,9 @@ func (mset *stream) setupMirrorConsumer() error {
 			}
 			mset.mu.Unlock()
 			ready.Wait()
-		case <-time.After(srcConsumerWaitTime):
+		case <-time.After(timeout):
 			mset.unsubscribe(crSub)
-			// We already waited 30 seconds, let's retry now.
+			// We already waited long enough, let's retry now.
 			retry, timedOut = true, true
 		}
 	}()
@@ -4299,6 +4309,12 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 	}
 
 	go func() {
+		// A durable consumer only needs to be reset, so don't wait as long as we would
+		// for a consumer that still has to be created from scratch.
+		timeout := srcConsumerWaitTime
+		if durableDeliverSubject != _EMPTY_ {
+			timeout = srcDurableConsumerWaitTime
+		}
 
 		var retry bool
 		var recreate bool
@@ -4488,9 +4504,9 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 				si.sub = sub
 			}
 			mset.mu.Unlock()
-		case <-time.After(srcConsumerWaitTime):
+		case <-time.After(timeout):
 			mset.unsubscribe(crSub)
-			// We already waited 30 seconds, let's retry now.
+			// We already waited long enough, let's retry now.
 			retry, timedOut = true, true
 		}
 	}()

--- a/server/stream.go
+++ b/server/stream.go
@@ -3796,6 +3796,7 @@ func (mset *stream) setupMirrorConsumer() error {
 	go func() {
 
 		var retry bool
+		var timedOut bool
 		defer func() {
 			mset.mu.Lock()
 			// Check that this is still valid and if so, clear the "setup in progress" flag.
@@ -3808,6 +3809,16 @@ func (mset *stream) setupMirrorConsumer() error {
 					// Cancel here since we can not do anything with this consumer at this point.
 					mset.cancelSourceInfo(mset.mirror)
 					mset.scheduleSetupMirrorConsumerRetry()
+					if timedOut && durableDeliverSubject != _EMPTY_ {
+						mset.startProbeSubscription(mset.mirror, durableDeliverSubject, func() {
+							// Skip if one is already running.
+							if t := mset.mirrorConsumerSetup; t != nil && !t.Stop() {
+								return
+							}
+							mset.mirrorConsumerSetup = nil
+							mset.scheduleSetupMirrorConsumerRetry()
+						})
+					}
 				} else {
 					// Clear on success.
 					mset.mirror.fails = 0
@@ -3972,7 +3983,7 @@ func (mset *stream) setupMirrorConsumer() error {
 		case <-time.After(srcConsumerWaitTime):
 			mset.unsubscribe(crSub)
 			// We already waited 30 seconds, let's retry now.
-			retry = true
+			retry, timedOut = true, true
 		}
 	}()
 
@@ -4031,6 +4042,33 @@ func (mset *stream) cancelSourceInfo(si *sourceInfo) {
 		t.Stop()
 		delete(mset.sourceSetupSchedules, si.iname)
 	}
+}
+
+// startProbeSubscription watches a durable consumer's deliver subject after a request for
+// it timed out, and stays up for as long as we are backing off. When we receive a heartbeat
+// or message, we can short-circuit on retrying the reset request.
+// Lock should be held.
+func (mset *stream) startProbeSubscription(si *sourceInfo, deliverSubject string, retry func()) {
+	if si == nil || si.sub != nil || deliverSubject == _EMPTY_ {
+		return
+	}
+	sub, err := mset.subscribeInternal(deliverSubject, func(_ *subscription, _ *client, _ *Account, _, _ string, _ []byte) {
+		mset.mu.Lock()
+		defer mset.mu.Unlock()
+		// Only short-circuit a backoff we are still in. si.fails is back to zero if we
+		// already did so, and si.sip means a request is in flight that tears us down anyway.
+		if si.sub == nil || si.sip || si.fails == 0 {
+			return
+		}
+		// si.fails only drives the retry backoff, which does not apply to a consumer we
+		// can see is alive, so clear it and ask again now.
+		si.fails = 0
+		retry()
+	})
+	if err != nil {
+		return
+	}
+	si.sub = sub
 }
 
 const sourceConsumerRetryThreshold = 2 * time.Second
@@ -4264,6 +4302,7 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 
 		var retry bool
 		var recreate bool
+		var timedOut bool
 		defer func() {
 			mset.mu.Lock()
 			// Check that this is still valid and if so, clear the "setup in progress" flag.
@@ -4278,6 +4317,19 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 					// Cancel here since we can not do anything with this consumer at this point.
 					mset.cancelSourceInfo(si)
 					mset.setupSourceConsumer(iname, seq, startTime)
+					if timedOut && durableDeliverSubject != _EMPTY_ {
+						mset.startProbeSubscription(si, durableDeliverSubject, func() {
+							// Drop the scheduled retry, we are going again right now.
+							if t, ok := mset.sourceSetupSchedules[iname]; ok {
+								// Skip if one is already running.
+								if !t.Stop() {
+									return
+								}
+								delete(mset.sourceSetupSchedules, iname)
+							}
+							mset.setupSourceConsumer(iname, seq, startTime)
+						})
+					}
 				} else {
 					// Clear on success.
 					si.fails = 0
@@ -4439,7 +4491,7 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 		case <-time.After(srcConsumerWaitTime):
 			mset.unsubscribe(crSub)
 			// We already waited 30 seconds, let's retry now.
-			retry = true
+			retry, timedOut = true, true
 		}
 	}()
 }


### PR DESCRIPTION
This PR contains a number of improvements to how durable consumers are used for mirroring/sourcing.

On consumer reset, pending is only recalculated when the starting sequence actually changes or there were pending messages. Repeated resets back to the ack floor (or any other sequence) with no delivery in between are therefore idempotent and recalculate pending only once. Additionally, consumers using `AckAll` or `AckFlowControl` can't perform out-of-order acks, so they get a further optimization of not recalculating pending at all and instead just doing `o.npc += len(o.pending)` when resetting back to the ack floor.

For durable mirror/source consumers a timed out reset request or one that is in a long backoff would not short-circuit even if the durable consumer could technically send heartbeats on the delivery subject. If we've timed out of a reset request, we now start a dummy subscription listening on the delivery subject for heartbeats or messages. If any is received it short-circuits the request backoff and immediately retries. Since the reset request itself is very cheap to perform, we can quickly stop our dummy subscription, send the reset request, get the response, and then set up our real subscription that processes the messages. The timeout on a reset request is now also lowered to 5s from 30s.