### PR TITLE
[FIXED] Skipped messages set last time to now

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5157,7 +5157,7 @@ func (fs *fileStore) StoreMsg(subj string, hdr, msg []byte, ttl int64) (uint64, 
 // we will place an empty record marking the sequence as used. The
 // sequence will be marked erased.
 // fs lock should be held.
-func (mb *msgBlock) skipMsg(seq uint64, now int64) error {
+func (mb *msgBlock) skipMsg(seq uint64, ts int64) error {
 	if mb == nil {
 		return nil
 	}
@@ -5171,7 +5171,7 @@ func (mb *msgBlock) skipMsg(seq uint64, now int64) error {
 	// If we are empty can just do meta.
 	if mb.msgs == 0 {
 		atomic.StoreUint64(&mb.last.seq, seq)
-		mb.last.ts = now
+		mb.last.ts = ts
 		atomic.StoreUint64(&mb.first.seq, seq+1)
 		mb.first.ts = 0
 		needsRecord = mb == mb.fs.lmb
@@ -5180,7 +5180,7 @@ func (mb *msgBlock) skipMsg(seq uint64, now int64) error {
 		mb.dmap.Insert(seq)
 	}
 	if needsRecord {
-		if err := mb.writeMsgRecordLocked(emptyRecordLen, seq|ebit, _EMPTY_, nil, nil, now, true, true); err != nil {
+		if err := mb.writeMsgRecordLocked(emptyRecordLen, seq|ebit, _EMPTY_, nil, nil, ts, true, true); err != nil {
 			mb.mu.Unlock()
 			return err
 		}
@@ -5194,9 +5194,16 @@ func (mb *msgBlock) skipMsg(seq uint64, now int64) error {
 
 // SkipMsg will use the next sequence number but not store anything.
 func (fs *fileStore) SkipMsg(seq uint64) (uint64, error) {
-	// Grab time.
-	now := ats.AccessTime()
+	return fs.skipMsg(seq, false)
+}
 
+// SkipMsgNoInterest will use the next sequence number but not store anything.
+// Unlike SkipMsg it also advances LastTime, which is used for Interest retention.
+func (fs *fileStore) SkipMsgNoInterest(seq uint64) (uint64, error) {
+	return fs.skipMsg(seq, true)
+}
+
+func (fs *fileStore) skipMsg(seq uint64, noInterest bool) (uint64, error) {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 
@@ -5219,14 +5226,26 @@ func (fs *fileStore) SkipMsg(seq uint64) (uint64, error) {
 		return 0, err
 	}
 
+	// Only update time if not already set or for Interest retention.
+	var ts int64
+	updateTime := noInterest || fs.state.LastTime.IsZero()
+	if updateTime {
+		ts = ats.AccessTime()
+	} else {
+		ts = fs.state.LastTime.UnixNano()
+	}
+
 	// Write skip msg.
-	if err = mb.skipMsg(seq, now); err != nil {
+	if err = mb.skipMsg(seq, ts); err != nil {
 		fs.setWriteErr(err)
 		return 0, err
 	}
 
 	// Update fs state.
-	fs.state.LastSeq, fs.state.LastTime = seq, time.Unix(0, now).UTC()
+	fs.state.LastSeq = seq
+	if updateTime {
+		fs.state.LastTime = time.Unix(0, ts).UTC()
+	}
 	if fs.state.Msgs == 0 {
 		fs.state.FirstSeq, fs.state.FirstTime = seq, time.Time{}
 	}
@@ -5277,7 +5296,12 @@ func (fs *fileStore) SkipMsgs(seq uint64, num uint64) error {
 	}
 
 	// Insert into dmap all entries and place last as marker.
-	now := ats.AccessTime()
+	var ts int64
+	if !fs.state.LastTime.IsZero() {
+		ts = fs.state.LastTime.UnixNano()
+	} else {
+		ts = ats.AccessTime()
+	}
 	lseq := seq + num - 1
 
 	mb.mu.Lock()
@@ -5288,7 +5312,7 @@ func (fs *fileStore) SkipMsgs(seq uint64, num uint64) error {
 	// If we are empty update meta directly.
 	if mb.msgs == 0 {
 		atomic.StoreUint64(&mb.last.seq, lseq)
-		mb.last.ts = now
+		mb.last.ts = ts
 		atomic.StoreUint64(&mb.first.seq, lseq+1)
 		mb.first.ts = 0
 	} else {
@@ -5297,7 +5321,7 @@ func (fs *fileStore) SkipMsgs(seq uint64, num uint64) error {
 		}
 	}
 	// Write out our placeholder.
-	err := mb.writeMsgRecordLocked(emptyRecordLen, lseq|ebit, _EMPTY_, nil, nil, now, true, true)
+	err := mb.writeMsgRecordLocked(emptyRecordLen, lseq|ebit, _EMPTY_, nil, nil, ts, true, true)
 	mb.mu.Unlock()
 	if err != nil {
 		fs.setWriteErr(err)
@@ -5306,7 +5330,10 @@ func (fs *fileStore) SkipMsgs(seq uint64, num uint64) error {
 
 	// Now update FS accounting.
 	// Update fs state.
-	fs.state.LastSeq, fs.state.LastTime = lseq, time.Unix(0, now).UTC()
+	fs.state.LastSeq = lseq
+	if fs.state.LastTime.IsZero() {
+		fs.state.LastTime = time.Unix(0, ts).UTC()
+	}
 	if fs.state.Msgs == 0 {
 		fs.state.FirstSeq, fs.state.FirstTime = lseq+1, time.Time{}
 	}

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -41,6 +41,7 @@ import (
 	"time"
 
 	"github.com/nats-io/jwt/v2"
+	"github.com/nats-io/nats-server/v2/server/ats"
 	"github.com/nats-io/nats-server/v2/server/sysmem"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
@@ -24306,4 +24307,137 @@ func TestJetStreamJSAckSuffixCorruption(t *testing.T) {
 	receiver := dummyRouteClient()
 	receiver.route = &route{}
 	require_NoError(t, receiver.parse(frame))
+}
+
+func TestJetStreamMirrorDeliverByStartTime(t *testing.T) {
+	test := func(t *testing.T, storage nats.StorageType) {
+		s := RunBasicJetStreamServer(t)
+		defer s.Shutdown()
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     "S",
+			Subjects: []string{"data.>"},
+			Storage:  storage,
+		})
+		require_NoError(t, err)
+
+		// Seed source stream with old timestamps.
+		mset, err := s.globalAccount().lookupStream("S")
+		require_NoError(t, err)
+
+		base := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Minute)
+		payload := bytes.Repeat([]byte("A"), 64*1024)
+		const (
+			units = 200        // matching messages
+			gap   = uint64(20) // non-matching messages between each
+		)
+
+		var seq uint64
+		for i := range units {
+			seq++
+			ts := base.Add(time.Duration(i) * time.Minute).UnixNano()
+			require_NoError(t, mset.store.StoreRawMsg("data.one", nil, payload, seq, ts, 0, false))
+			for g := range gap {
+				seq++
+				fts := ts + int64(g+1)*int64(time.Second)
+				require_NoError(t, mset.store.StoreRawMsg("data.other", nil, []byte("O"), seq, fts, 0, false))
+			}
+		}
+		// Correct the stream's last sequence.
+		mset.mu.Lock()
+		mset.lseq = seq
+		mset.mu.Unlock()
+
+		// Create a filtered mirror.
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:    "M",
+			Storage: storage,
+			Mirror:  &nats.StreamSource{Name: "S", FilterSubject: "data.one"},
+		})
+		require_NoError(t, err)
+
+		// Wait for the mirror to backfill all matching messages.
+		checkFor(t, 30*time.Second, 100*time.Millisecond, func() error {
+			si, err := js.StreamInfo("M")
+			if err != nil {
+				return err
+			}
+			if si.State.Msgs != units {
+				return fmt.Errorf("mirror has %d msgs, want %d", si.State.Msgs, units)
+			}
+			return nil
+		})
+
+		// Request a start time ~2/3 into the data.
+		startIdx := 130
+		start := base.Add(time.Duration(startIdx) * time.Minute)
+
+		sub, err := js.PullSubscribe(_EMPTY_, _EMPTY_, nats.BindStream("M"), nats.StartTime(start))
+		require_NoError(t, err)
+		defer sub.Unsubscribe()
+
+		msgs, err := sub.Fetch(1, nats.MaxWait(time.Second))
+		require_NoError(t, err)
+		require_Equal(t, len(msgs), 1)
+		meta, err := msgs[0].Metadata()
+		require_NoError(t, err)
+		ts := meta.Timestamp.UTC()
+		require_True(t, ts.Equal(start))
+
+		// The mirror preserves source sequences. Pin the exact sequence so
+		// an over-skip (resolving too late) can't masquerade as a pass.
+		require_Equal(t, meta.Sequence.Stream, uint64(startIdx)*(gap+1)+1)
+	}
+
+	t.Run("Memory", func(t *testing.T) { test(t, nats.MemoryStorage) })
+	t.Run("File", func(t *testing.T) { test(t, nats.FileStorage) })
+}
+
+func TestJetStreamInterestStreamNoInterestSkipAdvancesLastTime(t *testing.T) {
+	test := func(t *testing.T, storage nats.StorageType) {
+		s := RunBasicJetStreamServer(t)
+		defer s.Shutdown()
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:      "TEST",
+			Subjects:  []string{"foo"},
+			Storage:   storage,
+			Retention: nats.InterestPolicy,
+		})
+		require_NoError(t, err)
+
+		// A publish without interest still increases the stream sequence.
+		pubAck, err := js.Publish("foo", []byte("one"))
+		require_NoError(t, err)
+		require_Equal(t, pubAck.Sequence, uint64(1))
+
+		si, err := js.StreamInfo("TEST")
+		require_NoError(t, err)
+		require_Equal(t, si.State.Msgs, uint64(0))
+		require_Equal(t, si.State.LastSeq, uint64(1))
+		first := si.State.LastTime
+
+		// Let the clock advance past the access time service granularity.
+		time.Sleep(2 * ats.TickInterval)
+
+		// The second publish still has no interest, but should update both the sequence and time.
+		pubAck, err = js.Publish("foo", []byte("two"))
+		require_NoError(t, err)
+		require_Equal(t, pubAck.Sequence, uint64(2))
+
+		si, err = js.StreamInfo("TEST")
+		require_NoError(t, err)
+		require_Equal(t, si.State.Msgs, uint64(0))
+		require_Equal(t, si.State.LastSeq, uint64(2))
+		require_True(t, si.State.LastTime.After(first))
+	}
+
+	t.Run("Memory", func(t *testing.T) { test(t, nats.MemoryStorage) })
+	t.Run("File", func(t *testing.T) { test(t, nats.FileStorage) })
 }

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -368,9 +368,16 @@ func (ms *memStore) StoreMsg(subj string, hdr, msg []byte, ttl int64) (uint64, i
 
 // SkipMsg will use the next sequence number but not store anything.
 func (ms *memStore) SkipMsg(seq uint64) (uint64, error) {
-	// Grab time.
-	now := time.Unix(0, ats.AccessTime()).UTC()
+	return ms.skipMsg(seq, false)
+}
 
+// SkipMsgNoInterest will use the next sequence number but not store anything.
+// Unlike SkipMsg it also advances LastTime, which is used for Interest retention.
+func (ms *memStore) SkipMsgNoInterest(seq uint64) (uint64, error) {
+	return ms.skipMsg(seq, true)
+}
+
+func (ms *memStore) skipMsg(seq uint64, noInterest bool) (uint64, error) {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 
@@ -383,7 +390,10 @@ func (ms *memStore) SkipMsg(seq uint64) (uint64, error) {
 	}
 
 	ms.state.LastSeq = seq
-	ms.state.LastTime = now
+	// Only update time if not already set or for Interest retention.
+	if noInterest || ms.state.LastTime.IsZero() {
+		ms.state.LastTime = time.Unix(0, ats.AccessTime()).UTC()
+	}
 	if ms.state.Msgs == 0 {
 		ms.state.FirstSeq = seq + 1
 		ms.state.FirstTime = time.Time{}
@@ -395,9 +405,6 @@ func (ms *memStore) SkipMsg(seq uint64) (uint64, error) {
 
 // Skip multiple msgs.
 func (ms *memStore) SkipMsgs(seq uint64, num uint64) error {
-	// Grab time.
-	now := time.Unix(0, ats.AccessTime()).UTC()
-
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 
@@ -411,7 +418,10 @@ func (ms *memStore) SkipMsgs(seq uint64, num uint64) error {
 	lseq := seq + num - 1
 
 	ms.state.LastSeq = lseq
-	ms.state.LastTime = now
+	// Only update time if not already set.
+	if ms.state.LastTime.IsZero() {
+		ms.state.LastTime = time.Unix(0, ats.AccessTime()).UTC()
+	}
 	if ms.state.Msgs == 0 {
 		ms.state.FirstSeq, ms.state.FirstTime = lseq+1, time.Time{}
 	} else {

--- a/server/store.go
+++ b/server/store.go
@@ -94,6 +94,7 @@ type StreamStore interface {
 	StoreMsg(subject string, hdr, msg []byte, ttl int64) (uint64, int64, error)
 	StoreRawMsg(subject string, hdr, msg []byte, seq uint64, ts int64, ttl int64, discardNewCheck bool) error
 	SkipMsg(seq uint64) (uint64, error)
+	SkipMsgNoInterest(seq uint64) (uint64, error)
 	SkipMsgs(seq uint64, num uint64) error
 	FlushAllPending() error
 	LoadMsg(seq uint64, sm *StoreMsg) (*StoreMsg, error)

--- a/server/store_test.go
+++ b/server/store_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats-server/v2/server/ats"
 	"github.com/nats-io/nats-server/v2/server/gsl"
 )
 
@@ -1131,6 +1132,158 @@ func TestStoreGetSeqFromTimeWithTrailingDeletes(t *testing.T) {
 			require_NoError(t, err)
 			ts := time.Unix(0, start).UTC()
 			require_Equal(t, fs.GetSeqFromTime(ts), 2)
+		},
+	)
+}
+
+func TestStoreSkipMsgsCarryForwardLastTime(t *testing.T) {
+	testAllStoreAllPermutations(
+		t, false,
+		StreamConfig{Name: "zzz", Subjects: []string{"foo"}},
+		func(t *testing.T, fs StreamStore) {
+			// Store a message with an old timestamp.
+			old := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
+			err := fs.StoreRawMsg("foo", nil, nil, 1, old.UnixNano(), 0, false)
+			require_NoError(t, err)
+
+			var ss StreamState
+			fs.FastState(&ss)
+			require_Equal(t, ss.LastSeq, 1)
+			require_Equal(t, ss.LastTime.UnixNano(), old.UnixNano())
+
+			// SkipMsgs should not move the last time forward.
+			require_NoError(t, fs.SkipMsgs(2, 10))
+			fs.FastState(&ss)
+			require_Equal(t, ss.LastSeq, 11)
+			require_Equal(t, ss.LastTime.UnixNano(), old.UnixNano())
+
+			// SkipMsg should not move the last time forward.
+			seq, err := fs.SkipMsg(12)
+			require_NoError(t, err)
+			require_Equal(t, seq, 12)
+			fs.FastState(&ss)
+			require_Equal(t, ss.LastSeq, 12)
+			require_Equal(t, ss.LastTime.UnixNano(), old.UnixNano())
+
+			// Another chained skip should not move the last time forward.
+			require_NoError(t, fs.SkipMsgs(13, 5))
+			fs.FastState(&ss)
+			require_Equal(t, ss.LastSeq, 17)
+			require_Equal(t, ss.LastTime.UnixNano(), old.UnixNano())
+
+			// Time-based lookups must resolve across the skip gaps.
+			newer := old.Add(15 * 24 * time.Hour)
+			err = fs.StoreRawMsg("foo", nil, nil, 18, newer.UnixNano(), 0, false)
+			require_NoError(t, err)
+			require_Equal(t, fs.GetSeqFromTime(old), 1)
+			require_Equal(t, fs.GetSeqFromTime(old.Add(5*24*time.Hour)), 18)
+			require_Equal(t, fs.GetSeqFromTime(newer), 18)
+		},
+	)
+}
+
+func TestStoreSkipMsgsCarryForwardLastTimeFromEmpty(t *testing.T) {
+	t.Run("SkipMsg", func(t *testing.T) {
+		testAllStoreAllPermutations(
+			t, false,
+			StreamConfig{Name: "zzz", Subjects: []string{"foo"}},
+			func(t *testing.T, fs StreamStore) {
+				var ss StreamState
+				fs.FastState(&ss)
+				require_Equal(t, ss.LastSeq, uint64(0))
+				require_True(t, ss.LastTime.IsZero())
+
+				// Zero state, so falls back to ats.AccessTime().
+				before := ats.AccessTime()
+				seq, err := fs.SkipMsg(0)
+				require_NoError(t, err)
+				require_Equal(t, seq, uint64(1))
+
+				fs.FastState(&ss)
+				require_Equal(t, ss.LastSeq, uint64(1))
+				require_False(t, ss.LastTime.IsZero())
+				require_True(t, ss.LastTime.UnixNano() >= before)
+				require_True(t, ss.LastTime.UnixNano() <= ats.AccessTime())
+				first := ss.LastTime
+
+				// Advance the clock; a subsequent skip must preserve the time.
+				time.Sleep(2 * ats.TickInterval)
+
+				seq, err = fs.SkipMsg(0)
+				require_NoError(t, err)
+				require_Equal(t, seq, uint64(2))
+
+				fs.FastState(&ss)
+				require_Equal(t, ss.LastSeq, uint64(2))
+				require_Equal(t, ss.LastTime.UnixNano(), first.UnixNano())
+			},
+		)
+	})
+
+	t.Run("SkipMsgs", func(t *testing.T) {
+		testAllStoreAllPermutations(
+			t, false,
+			StreamConfig{Name: "zzz", Subjects: []string{"foo"}},
+			func(t *testing.T, fs StreamStore) {
+				var ss StreamState
+				fs.FastState(&ss)
+				require_Equal(t, ss.LastSeq, uint64(0))
+				require_True(t, ss.LastTime.IsZero())
+
+				// Zero state, so falls back to ats.AccessTime().
+				before := ats.AccessTime()
+				require_NoError(t, fs.SkipMsgs(1, 5))
+
+				fs.FastState(&ss)
+				require_Equal(t, ss.LastSeq, uint64(5))
+				require_False(t, ss.LastTime.IsZero())
+				require_True(t, ss.LastTime.UnixNano() >= before)
+				require_True(t, ss.LastTime.UnixNano() <= ats.AccessTime())
+				first := ss.LastTime
+
+				// Advance the clock; a subsequent skip must preserve the time.
+				time.Sleep(2 * ats.TickInterval)
+
+				seq, err := fs.SkipMsg(0)
+				require_NoError(t, err)
+				require_Equal(t, seq, uint64(6))
+
+				fs.FastState(&ss)
+				require_Equal(t, ss.LastSeq, uint64(6))
+				require_Equal(t, ss.LastTime.UnixNano(), first.UnixNano())
+			},
+		)
+	})
+}
+
+func TestStoreSkipMsgNoInterestAdvancesLastTime(t *testing.T) {
+	testAllStoreAllPermutations(
+		t, false,
+		StreamConfig{Name: "zzz", Subjects: []string{"foo"}},
+		func(t *testing.T, fs StreamStore) {
+			// A skip without interest still increases the sequence.
+			seq, err := fs.SkipMsgNoInterest(0)
+			require_NoError(t, err)
+			require_Equal(t, seq, uint64(1))
+
+			var ss StreamState
+			fs.FastState(&ss)
+			require_Equal(t, ss.Msgs, uint64(0))
+			require_Equal(t, ss.LastSeq, uint64(1))
+			first := ss.LastTime
+
+			// Let the clock advance past the access time service granularity.
+			time.Sleep(2 * ats.TickInterval)
+
+			// The second skip still has no interest, but should update both the sequence and time.
+			seq, err = fs.SkipMsgNoInterest(0)
+			require_NoError(t, err)
+			require_Equal(t, seq, uint64(2))
+
+			fs.FastState(&ss)
+			require_Equal(t, ss.Msgs, uint64(0))
+			require_Equal(t, ss.LastSeq, uint64(2))
+			require_True(t, ss.LastTime.After(first))
 		},
 	)
 }

--- a/server/stream.go
+++ b/server/stream.go
@@ -6854,7 +6854,7 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 
 	// Skip msg here.
 	if noInterest {
-		mset.lseq, _ = store.SkipMsg(0)
+		mset.lseq, _ = store.SkipMsgNoInterest(0)
 		mset.lmsgId = msgId
 		// If we have a msgId make sure to save.
 		if msgId != _EMPTY_ {


### PR DESCRIPTION
`SkipMsg` and `SkipMsgs` would set the store's `LastTime` to "now", and this would be stamped into the filestore's block as well. However, a late replicated stream catchup or a filtered mirror would violate (_mostly_) monotonic increase of start times, leading to issues when searching by start time since the filestore's binary search would act on unordered block timestamps. This PR fixes that by having `SkipMsg(s)` only carry forward the `LastTime` if already set.

This change has mostly upsides, but one downside is that Interest-based streams with `noInterest` on a message would not store the message, but still move both the stream's last sequence AND last timestamp forward (now it is only the sequence). This is probably fine, but a slight behavioral change due to the shared code paths. Overall though, preserving the correct timestamps is more valuable than increasing a timestamp relating to a message that is not actually stored, especially since it could otherwise mean wrong messages are delivered.