### PR TITLE
Add recovered stream usage back to dynamic MaxStore on restart

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -50,6 +50,9 @@ type JetStreamConfig struct {
 	CompressOK   bool          `json:"compress_ok,omitempty"`   // CompressOK indicates if compression is supported
 	UniqueTag    string        `json:"unique_tag,omitempty"`    // UniqueTag is the unique tag assigned to this instance
 	Strict       bool          `json:"strict,omitempty"`        // Strict indicates if strict JSON parsing is performed
+	// dynamicMaxStore is true when MaxStore was derived from available disk (not
+	// user-set), so it can be adjusted after recovery. Unexported = not serialized.
+	dynamicMaxStore bool
 }
 
 // Statistics about JetStream for this server.
@@ -514,6 +517,36 @@ func (s *Server) enableJetStream(cfg JetStreamConfig) error {
 	// Enable accounts and restore state before starting clustering.
 	if err := s.enableJetStreamAccounts(); err != nil {
 		return err
+	}
+
+	// In dynamic mode MaxStore was derived from free disk only, so JetStream's own
+	// usage shrinks the limit on each restart. After recovering file-based streams,
+	// add their reported bytes back into the dynamic limit so it doesn't regress.
+	if standAlone && !canExtend && js.config.dynamicMaxStore {
+		var streams []*stream
+		js.mu.RLock()
+		for _, jsa := range js.accounts {
+			jsa.mu.RLock()
+			for _, mset := range jsa.streams {
+				if mset.stype == FileStorage && mset.store != nil {
+					streams = append(streams, mset)
+				}
+			}
+			jsa.mu.RUnlock()
+		}
+		js.mu.RUnlock()
+
+		var used int64
+		for _, mset := range streams {
+			used += int64(mset.state().Bytes)
+		}
+		// Apply the same 75% factor diskAvailable() uses, so the limit reflects
+		// 75% of (free + used) and stays stable across restarts instead of
+		// ratcheting upward toward the whole disk on repeated fill/restart cycles.
+		js.mu.Lock()
+		js.config.MaxStore += used / 4 * 3
+		atomic.StoreInt64(&js.storeMax, js.config.MaxStore)
+		js.mu.Unlock()
 	}
 
 	// If we are in clustered mode go ahead and start the meta controller.
@@ -2724,6 +2757,7 @@ func (s *Server) dynJetStreamConfig(storeDir string, maxStore, maxMem int64) *Je
 		jsc.MaxStore = maxStore
 	} else {
 		jsc.MaxStore = diskAvailable(jsc.StoreDir)
+		jsc.dynamicMaxStore = true
 	}
 
 	if maxMem > 0 || (opts.maxMemSet && maxMem == 0) {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -7497,6 +7497,62 @@ func TestJetStreamConfigExplicitZeroLimits(t *testing.T) {
 	require_Equal(t, jsc.MaxStore, 0)
 }
 
+func TestJetStreamDynamicMaxStoreNoRegressionOnRestart(t *testing.T) {
+	// Persistent store dir so stream data survives the restart.
+	sd := t.TempDir()
+
+	// Dynamic mode: max_file_store: -1 means "derive the limit from available disk".
+	conf := createConfFile(t, []byte(fmt.Sprintf(`
+                listen: 127.0.0.1:-1
+                jetstream: {max_mem_store: -1, max_file_store: -1, store_dir: %q}
+        `, sd)))
+
+	// --- First boot ---
+	s, _ := RunServerWithConfig(conf)
+
+	nc, js := jsClientConnect(t, s)
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"TEST"},
+		Storage:  nats.FileStorage,
+	})
+	require_NoError(t, err)
+
+	// Write a few MB so JetStream consumes real disk space.
+	msg := make([]byte, 1024)
+	for i := range msg {
+		msg[i] = byte(i)
+	}
+	for i := 0; i < 4000; i++ {
+		_, err := js.Publish("TEST", msg)
+		require_NoError(t, err)
+	}
+
+	// Reported on-disk usage of the stream (used to size the assertion tolerance below).
+	si, err := js.StreamInfo("TEST")
+	require_NoError(t, err)
+	usedBytes := int64(si.State.Bytes)
+
+	// Capture the dynamic limit on first boot.
+	firstMaxStore := s.JetStreamConfig().MaxStore
+	require_True(t, firstMaxStore > 0)
+
+	nc.Close()
+	s.Shutdown()
+
+	// --- Restart with the same store dir ---
+	s, _ = RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	secondMaxStore := s.JetStreamConfig().MaxStore
+
+	// Before the fix the dynamic limit was recomputed from current free disk only,
+	// so it shrank by ~75% of usage after restart. With the fix the limit reflects
+	// 75% of (free + used) and stays stable, so it must not drop by that amount.
+	require_True(t, secondMaxStore >= firstMaxStore-usedBytes/2)
+}
+
 // From 2.2.2 to 2.2.3 we fixed a bug that would not consistently place a jetstream directory
 // under the store directory configured. However there were some cases where the directory was
 // created that way and therefore 2.2.3 would start and not recognize the existing accounts,


### PR DESCRIPTION
Resolves #8322.

### Problem
In dynamic mode (no explicit `max_file_store`), `MaxStore` is computed from `diskAvailable()` — ~75% of *currently free* disk. That excludes the space JetStream's own `StoreDir` already uses, so each restart recomputes a smaller ceiling as data grows, and previously-valid stream budgets can start failing with `10047 insufficient storage resources`.

### Change
Following @MauriceVanVeen's suggestion on the issue: after recovering file-based streams on startup, sum their reported bytes and add that back into the dynamic limit, so the ceiling reflects (free + already-used-by-JetStream) and doesn't regress across restarts.

- Applies only when the limit is dynamic and the server is standalone and explicit user limits and clustered setups are untouched.
- Uses the streams' own reported byte counts (post-recovery), not a filesystem walk.
- Recovery already loads streams without enforcing the limit, so streams still always start; this only adjusts the ceiling afterward.

### Test
`TestJetStreamDynamicMaxStoreNoRegressionOnRestart`: boots a standalone dynamic server, writes a few MB to a file stream, restarts with the same store dir, and asserts `MaxStore` does not regress.

### Notes
As discussed on the issue, dynamic mode remains best-effort (shared-disk and the static `disk_avail_windows.go` caveats still apply); production setups should set `max_file_store` explicitly. This is a best-effort improvement for the local/ephemeral default.

First-time contributor - feedback very welcome!
