### PR TITLE
[FIXED] Nil pointer panic when resolver dir parent is not traversable

### DIFF
--- a/server/dirstore.go
+++ b/server/dirstore.go
@@ -48,8 +48,11 @@ func validatePathExists(path string, dir bool) (string, error) {
 	}
 
 	var finfo os.FileInfo
-	if finfo, err = os.Stat(abs); os.IsNotExist(err) {
-		return _EMPTY_, fmt.Errorf("the path [%s] doesn't exist", abs)
+	if finfo, err = os.Stat(abs); err != nil {
+		if os.IsNotExist(err) {
+			return _EMPTY_, fmt.Errorf("the path [%s] doesn't exist", abs)
+		}
+		return _EMPTY_, fmt.Errorf("error accessing path [%s]: %v", abs, err)
 	}
 
 	mode := finfo.Mode()

--- a/server/dirstore_test.go
+++ b/server/dirstore_test.go
@@ -21,6 +21,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -193,6 +194,31 @@ func TestCreateMakesDir(t *testing.T) {
 
 	_, err = os.Stat(fullPath)
 	require_NoError(t, err)
+}
+
+func TestDirStoreInaccessibleParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permission bits do not block traversal on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permission checks")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	parent := filepath.Join(dir, "parent")
+	require_NoError(t, os.Mkdir(parent, 0o755))
+	child := filepath.Join(parent, "child")
+	require_NoError(t, os.Mkdir(child, 0o755))
+
+	// Remove the search bit on the parent so stat of child returns EACCES
+	// rather than IsNotExist. Previously this panicked with a nil pointer
+	// dereference instead of returning an error.
+	require_NoError(t, os.Chmod(parent, 0o000))
+	t.Cleanup(func() { os.Chmod(parent, 0o755) })
+
+	_, err := NewDirJWTStore(child, false, true)
+	require_Error(t, err)
 }
 
 func TestShardedDirStorePackMerge(t *testing.T) {


### PR DESCRIPTION
Fixes #8318.

`validatePathExists` only returned early when `os.Stat` failed with `IsNotExist`, then dereferenced `finfo.Mode()`. Any other stat error left `finfo` nil and caused a panic. This is hit when a resolver `dir`'s parent is not traversable (EACCES): stat returns a permission error rather than not-exist, and `nats-server -c <conf>` (or `-t`) panics instead of reporting the directory as inaccessible.

Now a non-`IsNotExist` stat error is surfaced as a normal error, so the existing "accessible directory" config error is reported. Added a regression test that makes the parent directory untraversable and confirms a clean error instead of a panic.

Signed-off-by certifies original work per CONTRIBUTING.md.
