### PR TITLE
[TEST] Campaign early on NRG tests

### DIFF
--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -202,6 +202,9 @@ func (c *cluster) createRaftGroupWithPeers(name string, servers []*Server, smf s
 			Log:   c.createWAL(name, st)}
 		sg = append(sg, c.createStateMachine(s, cfg, peers, smf))
 	}
+
+	// Start campaigning early to speed up bootstrap leader election.
+	sg[0].node().CampaignImmediately()
 	return sg
 }
 


### PR DESCRIPTION
Makes the `TestNRG*` tests run ~24% faster overall.