### PR TITLE
NRG: Fix uncommitted membership change handling across truncate/snapshot/apply

### DIFF
--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8828,7 +8828,7 @@ func TestJetStreamClusterDontEncodeConsumerStateInMetaSnapshot(t *testing.T) {
 	meta.RLock()
 	papplied := meta.papplied
 	meta.RUnlock()
-	require_NoError(t, meta.ProposeAddPeer(meta.ID()))
+	require_NoError(t, meta.ProposeAddPeer("_random_"))
 	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
 		meta.RLock()
 		defer meta.RUnlock()
@@ -8917,6 +8917,7 @@ func TestJetStreamClusterMetaSnapshotPreservesConsumersOnStreamUpdate(t *testing
 	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Name: "CONSUMER", Replicas: 3})
 	require_NoError(t, err)
 
+	var metaRemove bool
 	triggerMetaSnapshot := func(t *testing.T, c *cluster) {
 		t.Helper()
 		ml := c.leader()
@@ -8925,7 +8926,12 @@ func TestJetStreamClusterMetaSnapshotPreservesConsumersOnStreamUpdate(t *testing
 		meta.RLock()
 		papplied := meta.papplied
 		meta.RUnlock()
-		require_NoError(t, meta.ProposeAddPeer(meta.ID()))
+		if metaRemove {
+			require_NoError(t, meta.ProposeRemovePeer("_random_"))
+		} else {
+			require_NoError(t, meta.ProposeAddPeer("_random_"))
+		}
+		metaRemove = !metaRemove
 		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
 			meta.RLock()
 			defer meta.RUnlock()

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -4282,9 +4282,10 @@ func (s *Server) Raftz(opts *RaftzOptions) *RaftzStatus {
 			if id == n.id {
 				continue
 			}
+			kp := n.membChange == nil || n.membChange.peer != id
 			peer := RaftzGroupPeer{
 				Name:                s.serverNameForNode(id),
-				Known:               p.kp,
+				Known:               kp,
 				LastReplicatedIndex: p.li,
 			}
 			if !p.ts.IsZero() {

--- a/server/raft.go
+++ b/server/raft.go
@@ -193,7 +193,7 @@ type raft struct {
 	applied   uint64 // Index of the most recently applied commit
 	papplied  uint64 // First sequence of our log, matches when we last installed a snapshot.
 
-	membChangeIndex uint64 // Index of uncommitted membership change entry (0 means no change in progress)
+	membChange *membChange // Uncommitted membership change entry at a specific log index.
 
 	aflr uint64 // Index when to signal initial messages have been applied after becoming leader. 0 means signaling is disabled.
 
@@ -276,6 +276,12 @@ type lps struct {
 	ts time.Time // Last timestamp
 	li uint64    // Last index replicated
 	kp bool      // Known peer
+}
+
+type membChange struct {
+	index uint64 // Which entry in the log is the membership change.
+	peer  string // The peer whose membership is being changed.
+	prev  *lps   // The previous membership state if removing, unset if adding.
 }
 
 const (
@@ -1010,7 +1016,7 @@ func (n *raft) ProposeAddPeer(peer string) error {
 		n.RUnlock()
 		return werr
 	}
-	if n.membChangeIndex > 0 {
+	if n.membChange != nil {
 		n.RUnlock()
 		return errMembershipChange
 	}
@@ -1040,7 +1046,7 @@ func (n *raft) ProposeRemovePeer(peer string) error {
 		return nil
 	}
 
-	if n.membChangeIndex > 0 {
+	if n.membChange != nil {
 		n.RUnlock()
 		return errMembershipChange
 	}
@@ -1063,7 +1069,7 @@ func (n *raft) ProposeRemovePeer(peer string) error {
 func (n *raft) MembershipChangeInProgress() bool {
 	n.RLock()
 	defer n.RUnlock()
-	return n.membChangeIndex > 0
+	return n.membChange != nil
 }
 
 // ClusterSize reports back the total cluster size.
@@ -2991,7 +2997,7 @@ func (n *raft) handleForwardedRemovePeerProposal(sub *subscription, c *client, _
 		n.RUnlock()
 		return
 	}
-	if n.membChangeIndex > 0 {
+	if n.membChange != nil {
 		n.debug("Ignoring forwarded peer removal proposal, membership changing")
 		n.RUnlock()
 		return
@@ -3096,11 +3102,10 @@ func (n *raft) removePeer(peer string) {
 		n.removed = map[string]time.Time{}
 	}
 	n.removed[peer] = time.Now()
-	if _, ok := n.peers[peer]; ok {
-		delete(n.peers, peer)
-		n.adjustClusterSizeAndQuorum()
-		n.writePeerState(&peerState{n.peerNames(), n.csz, n.extSt})
-	}
+
+	delete(n.peers, peer)
+	n.adjustClusterSizeAndQuorum()
+	n.writePeerState(&peerState{n.peerNames(), n.csz, n.extSt})
 }
 
 // Build and send appendEntry request for the given entry that changes
@@ -3112,25 +3117,43 @@ func (n *raft) sendMembershipChange(e *Entry) bool {
 
 	// Only makes sense to call this with entries that change membership.
 	// Also, ignore if we're already changing membership.
-	if !e.ChangesMembership() || n.membChangeIndex > 0 {
+	if !e.ChangesMembership() || n.membChange != nil {
 		return false
 	}
 
 	// Set to the index where we will store the membership change.
 	// It needs to be before we send, since if we're cluster size 1 we try to commit immediately.
-	n.membChangeIndex = n.pindex + 1
+	peer := string(e.Data)
+	n.membChange = &membChange{index: n.pindex + 1, peer: peer}
+	ps := n.peers[peer]
+	// Ignore if the peer already exists (add) or is not found (remove).
+	if (e.Type == EntryAddPeer && ps != nil) || (e.Type == EntryRemovePeer && ps == nil) {
+		n.membChange = nil
+		return false
+	}
+	if e.Type == EntryRemovePeer {
+		n.membChange.prev = ps
+	}
 	err := n.sendAppendEntryLocked([]*Entry{e}, true)
 	if err != nil {
-		n.membChangeIndex = 0
+		n.membChange = nil
 		return false
 	}
 
 	if e.Type == EntryAddPeer {
-		n.addPeer(string(e.Data))
+		// Track directly, but wait for commit to be official
+		if _, ok := n.peers[peer]; !ok {
+			n.peers[peer] = &lps{time.Time{}, 0, false}
+			n.adjustClusterSizeAndQuorum()
+		}
 	}
 
 	if e.Type == EntryRemovePeer {
-		n.removePeer(string(e.Data))
+		// Track directly, but wait for commit to be official
+		if _, ok := n.peers[peer]; ok {
+			delete(n.peers, peer)
+			n.adjustClusterSizeAndQuorum()
+		}
 		if n.csz == 1 {
 			n.tryCommit(n.pindex)
 			return true
@@ -3626,7 +3649,7 @@ func (n *raft) applyCommit(index uint64) error {
 			committed = append(committed, e)
 
 			// We are done with this membership change
-			n.membChangeIndex = 0
+			n.membChange = nil
 
 		case EntryRemovePeer:
 			peer := string(e.Data)
@@ -3641,7 +3664,7 @@ func (n *raft) applyCommit(index uint64) error {
 			committed = append(committed, e)
 
 			// We are done with this membership change
-			n.membChangeIndex = 0
+			n.membChange = nil
 
 			// If this is us and we are the leader signal the caller
 			// to attempt to stepdown.
@@ -4021,8 +4044,25 @@ func (n *raft) truncateWAL(term, index uint64) {
 	}
 
 	// Check if we're truncating an uncommitted membership change.
-	if n.membChangeIndex > 0 && n.membChangeIndex > index {
-		n.membChangeIndex = 0
+	if n.membChange != nil && n.membChange.index > index {
+		peer := n.membChange.peer
+		if ps := n.membChange.prev; ps != nil {
+			// This was a removal, add it back.
+			n.peers[peer] = ps
+			// If we were on the removed list, reverse that here.
+			if n.removed != nil {
+				delete(n.removed, peer)
+				if len(n.removed) == 0 {
+					n.removed = nil
+				}
+			}
+		} else {
+			// This was an addition, remove it.
+			delete(n.peers, peer)
+		}
+		n.adjustClusterSizeAndQuorum()
+		n.writePeerState(&peerState{n.peerNames(), n.csz, n.extSt})
+		n.membChange = nil
 	}
 }
 
@@ -4461,19 +4501,30 @@ CONTINUE:
 		case EntryAddPeer:
 			// When receiving or restoring, mark membership as changing.
 			// Set to the index where this entry was stored (pindex is now this entry's index)
-			n.membChangeIndex = n.pindex
 			if newPeer := string(e.Data); len(newPeer) == idLen {
 				// Track directly, but wait for commit to be official
+				n.membChange = &membChange{index: n.pindex, peer: newPeer}
 				if _, ok := n.peers[newPeer]; !ok {
 					n.peers[newPeer] = &lps{time.Time{}, 0, false}
 				}
+				n.adjustClusterSizeAndQuorum()
 				// Store our peer in our global peer map for all peers.
 				peers.LoadOrStore(newPeer, newPeer)
 			}
 		case EntryRemovePeer:
 			// When receiving or restoring, mark membership as changing.
 			// Set to the index where this entry was stored (pindex is now this entry's index)
-			n.membChangeIndex = n.pindex
+			if oldPeer := string(e.Data); len(oldPeer) == idLen {
+				// Track directly, but wait for commit to be official
+				ps, ok := n.peers[oldPeer]
+				if !ok {
+					ps = &lps{time.Time{}, 0, false}
+
+				}
+				n.membChange = &membChange{index: n.pindex, peer: oldPeer, prev: ps}
+				delete(n.peers, oldPeer)
+				n.adjustClusterSizeAndQuorum()
+			}
 		}
 	}
 

--- a/server/raft.go
+++ b/server/raft.go
@@ -1446,8 +1446,8 @@ func (n *raft) createSnapshotCheckpointLocked(force bool) (*checkpoint, error) {
 		return nil, errNoSnapAvailable
 	}
 
-	// Snapshot the current peer state for the current applied index, we'll need it in the snapshot.
-	peerstate := encodePeerState(&peerState{n.peerNames(), n.csz, n.extSt})
+	// Snapshot the committed peer state for the current applied index, we'll need it in the snapshot.
+	peerstate := encodePeerState(n.committedPeerStateLocked(n.applied))
 	snapDir := filepath.Join(n.sd, snapshotsDir)
 	snapFile := filepath.Join(snapDir, fmt.Sprintf(snapFileT, term, n.applied))
 
@@ -3621,7 +3621,7 @@ func (n *raft) applyCommit(index uint64) error {
 				n.installSnapshot(&snapshot{
 					lastTerm:  ae.pterm,
 					lastIndex: ae.commit,
-					peerstate: encodePeerState(&peerState{n.peerNames(), n.csz, n.extSt}),
+					peerstate: encodePeerState(n.committedPeerStateLocked(ae.commit)),
 					data:      e.Data,
 				})
 			}
@@ -4860,6 +4860,39 @@ func (n *raft) currentPeerState() *peerState {
 
 func (n *raft) currentPeerStateLocked() *peerState {
 	return &peerState{n.peerNames(), n.csz, n.extSt}
+}
+
+// committedPeerStateLocked builds peer state from the committed membership as of the given index.
+// Lock should be held.
+func (n *raft) committedPeerStateLocked(index uint64) *peerState {
+	// No pending change or index already covers the pending change.
+	if n.membChange == nil || n.membChange.index <= index {
+		return &peerState{n.peerNames(), n.csz, n.extSt}
+	}
+
+	// Reconstruct the committed peer set by reverting the speculative change.
+	peer := n.membChange.peer
+	if n.membChange.prev != nil {
+		// This was a removal; the peer is still a committed member, add it back.
+		names := make([]string, 0, len(n.peers)+1)
+		for name := range n.peers {
+			names = append(names, name)
+		}
+		if _, ok := n.peers[peer]; !ok {
+			names = append(names, peer)
+		}
+		return &peerState{names, len(names), n.extSt}
+	}
+
+	// This was an addition; exclude the not-yet-committed peer.
+	names := make([]string, 0, len(n.peers))
+	for name := range n.peers {
+		if name == peer {
+			continue
+		}
+		names = append(names, name)
+	}
+	return &peerState{names, len(names), n.extSt}
 }
 
 // sendPeerState will send our current peer state to the cluster.

--- a/server/raft.go
+++ b/server/raft.go
@@ -275,7 +275,6 @@ type catchupState struct {
 type lps struct {
 	ts time.Time // Last timestamp
 	li uint64    // Last index replicated
-	kp bool      // Known peer
 }
 
 type membChange struct {
@@ -2307,7 +2306,7 @@ func (n *raft) Reset() {
 
 	// Reset peer set to just ourselves; a new leader will fold us back into
 	// the cluster's membership view via processPeerState.
-	n.peers = map[string]*lps{n.id: {time.Time{}, 0, true}}
+	n.peers = map[string]*lps{n.id: {time.Time{}, 0}}
 	n.removed = nil
 	n.adjustClusterSizeAndQuorum()
 
@@ -3079,15 +3078,11 @@ func (n *raft) addPeer(peer string) {
 		}
 	}
 
-	if lp, ok := n.peers[peer]; !ok {
+	if _, ok := n.peers[peer]; !ok {
 		// We are not tracking this one automatically so we need
 		// to bump cluster size.
-		n.peers[peer] = &lps{time.Time{}, 0, true}
-	} else {
-		// Mark as added.
-		lp.kp = true
+		n.peers[peer] = &lps{time.Time{}, 0}
 	}
-
 	// Adjust cluster size and quorum if needed.
 	n.adjustClusterSizeAndQuorum()
 	// Write out our new state.
@@ -3143,7 +3138,7 @@ func (n *raft) sendMembershipChange(e *Entry) bool {
 	if e.Type == EntryAddPeer {
 		// Track directly, but wait for commit to be official
 		if _, ok := n.peers[peer]; !ok {
-			n.peers[peer] = &lps{time.Time{}, 0, false}
+			n.peers[peer] = &lps{time.Time{}, 0}
 			n.adjustClusterSizeAndQuorum()
 		}
 	}
@@ -3754,12 +3749,7 @@ func (n *raft) trackResponse(ar *appendEntryResponse) bool {
 // Used to adjust cluster size and peer count based on added official peers.
 // lock should be held.
 func (n *raft) adjustClusterSizeAndQuorum() {
-	pcsz, ncsz := n.csz, 0
-	for _, peer := range n.peers {
-		if peer.kp {
-			ncsz++
-		}
-	}
+	pcsz, ncsz := n.csz, len(n.peers)
 	n.csz = ncsz
 	n.qn = n.csz/2 + 1
 
@@ -3790,7 +3780,7 @@ func (n *raft) trackPeer(peer string) error {
 		}
 	}
 	if n.State() == Leader {
-		if lp, ok := n.peers[peer]; !ok || !lp.kp {
+		if _, ok := n.peers[peer]; !ok {
 			// Check if this peer had been removed previously.
 			needPeerAdd = !isRemoved
 		}
@@ -4505,7 +4495,7 @@ CONTINUE:
 				// Track directly, but wait for commit to be official
 				n.membChange = &membChange{index: n.pindex, peer: newPeer}
 				if _, ok := n.peers[newPeer]; !ok {
-					n.peers[newPeer] = &lps{time.Time{}, 0, false}
+					n.peers[newPeer] = &lps{time.Time{}, 0}
 				}
 				n.adjustClusterSizeAndQuorum()
 				// Store our peer in our global peer map for all peers.
@@ -4518,7 +4508,7 @@ CONTINUE:
 				// Track directly, but wait for commit to be official
 				ps, ok := n.peers[oldPeer]
 				if !ok {
-					ps = &lps{time.Time{}, 0, false}
+					ps = &lps{time.Time{}, 0}
 
 				}
 				n.membChange = &membChange{index: n.pindex, peer: oldPeer, prev: ps}
@@ -4590,11 +4580,10 @@ func (n *raft) processPeerState(ps *peerState) {
 	n.peers = make(map[string]*lps)
 	for _, peer := range ps.knownPeers {
 		if lp := old[peer]; lp != nil {
-			lp.kp = true
 			n.peers[peer] = lp
 			delete(old, peer)
 		} else {
-			n.peers[peer] = &lps{time.Time{}, 0, true}
+			n.peers[peer] = &lps{time.Time{}, 0}
 		}
 		// If we were on the removed list reverse that here.
 		if n.removed != nil {
@@ -4855,11 +4844,9 @@ func decodePeerState(buf []byte) (*peerState, error) {
 
 // Lock should be held.
 func (n *raft) peerNames() []string {
-	var peers []string
-	for name, peer := range n.peers {
-		if peer.kp {
-			peers = append(peers, name)
-		}
+	peers := make([]string, 0, len(n.peers))
+	for name := range n.peers {
+		peers = append(peers, name)
 	}
 	return peers
 }

--- a/server/raft.go
+++ b/server/raft.go
@@ -5396,6 +5396,13 @@ func (n *raft) switchToCandidate() {
 		return
 	}
 
+	// Do not campaign with an uncommitted membership change about us,
+	// otherwise we would try to become leader outside our peer set.
+	if n.membChange != nil && n.membChange.peer == n.id {
+		n.resetElect(minElectionTimeout)
+		return
+	}
+
 	if n.State() != Candidate {
 		n.debug("Switching to candidate")
 	} else {

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -1357,6 +1357,15 @@ func TestNRGTruncateWALRevertsUncommittedAddPeer(t *testing.T) {
 		require_Equal(t, n.membChange.peer, newPeer)
 		require_True(t, n.membChange.prev == nil)
 
+		// Raftz should report the new peer as not known/committed yet.
+		rz := n.s.Raftz(&RaftzOptions{AccountFilter: globalAccountName})
+		require_NotNil(t, rz)
+		gz := (*rz)[globalAccountName]["TEST"]
+		require_NotNil(t, gz)
+		require_Len(t, len(gz.Peers), 2)
+		require_True(t, gz.Peers[nats0].Known)
+		require_False(t, gz.Peers[newPeer].Known)
+
 		// Truncate the uncommitted AddPeer entry. Its speculative effects must be reverted.
 		n.truncateWAL(1, 1)
 		require_Equal(t, n.pindex, 1)
@@ -1365,6 +1374,14 @@ func TestNRGTruncateWALRevertsUncommittedAddPeer(t *testing.T) {
 		require_Equal(t, n.csz, 2)
 		require_Equal(t, n.qn, 2)
 		require_True(t, n.membChange == nil)
+
+		// Raftz should also be reverted.
+		rz = n.s.Raftz(&RaftzOptions{AccountFilter: globalAccountName})
+		require_NotNil(t, rz)
+		gz = (*rz)[globalAccountName]["TEST"]
+		require_NotNil(t, gz)
+		require_Len(t, len(gz.Peers), 1)
+		require_True(t, gz.Peers[nats0].Known)
 	}
 
 	t.Run("Leader", func(t *testing.T) { test(KindLeader) })
@@ -1419,6 +1436,14 @@ func TestNRGTruncateWALRevertsUncommittedRemovePeer(t *testing.T) {
 		require_Equal(t, n.membChange.peer, oldPeer)
 		require_NotNil(t, n.membChange.prev)
 
+		// Raftz shouldn't report the to-be-removed peer anymore.
+		rz := n.s.Raftz(&RaftzOptions{AccountFilter: globalAccountName})
+		require_NotNil(t, rz)
+		gz := (*rz)[globalAccountName]["TEST"]
+		require_NotNil(t, gz)
+		require_Len(t, len(gz.Peers), 1)
+		require_True(t, gz.Peers[nats0].Known)
+
 		// Truncate the uncommitted RemovePeer entry. Its speculative effects must be reverted.
 		n.truncateWAL(1, 1)
 		_, ok = n.peers[oldPeer]
@@ -1428,6 +1453,15 @@ func TestNRGTruncateWALRevertsUncommittedRemovePeer(t *testing.T) {
 		_, ok = n.removed[oldPeer]
 		require_False(t, ok)
 		require_True(t, n.membChange == nil)
+
+		// Raftz should also be reverted.
+		rz = n.s.Raftz(&RaftzOptions{AccountFilter: globalAccountName})
+		require_NotNil(t, rz)
+		gz = (*rz)[globalAccountName]["TEST"]
+		require_NotNil(t, gz)
+		require_Len(t, len(gz.Peers), 2)
+		require_True(t, gz.Peers[nats0].Known)
+		require_True(t, gz.Peers[oldPeer].Known)
 	}
 
 	t.Run("Leader", func(t *testing.T) { test(KindLeader) })
@@ -4303,9 +4337,6 @@ func TestNRGQuorumAfterLeaderStepdown(t *testing.T) {
 	require_NoError(t, n.trackPeer(nats1))
 	require_True(t, n.Quorum())
 	require_Len(t, len(n.peers), 3)
-	for _, ps := range n.peers {
-		ps.kp = true
-	}
 
 	// If we hand off leadership to another server, we should
 	// still be reporting we have quorum.
@@ -6507,7 +6538,7 @@ func TestNRGReset(t *testing.T) {
 
 	// Add another peer in addition to ourselves.
 	other := nats1
-	n.peers[other] = &lps{time.Time{}, 0, true}
+	n.peers[other] = &lps{time.Time{}, 0}
 	n.adjustClusterSizeAndQuorum()
 	n.updateLeader(other)
 

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -25,6 +25,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -6013,6 +6014,93 @@ func TestNRGReplayAddPeerKeepsClusterSize(t *testing.T) {
 	n.Stop()
 	n.WaitForStop()
 	fs.Stop()
+}
+
+func TestNRGSnapshotExcludesUncommittedMembershipChange(t *testing.T) {
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+
+	t.Run("AddPeer", func(t *testing.T) {
+		n, cleanup := initSingleMemRaftNode(t)
+		defer cleanup()
+
+		nats0 := "S1Nunr6R"   // "nats-0"
+		newPeer := "yrzKKRBu" // "nats-1"
+
+		n.Lock()
+		n.addPeer(nats0)
+		n.Unlock()
+		require_Equal(t, len(n.peers), 2)
+
+		aeMsg := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: []*Entry{newEntry(EntryNormal, esm)}})
+		aeAddPeer := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 1, entries: []*Entry{newEntry(EntryAddPeer, []byte(newPeer))}})
+		n.processAppendEntry(aeMsg, n.aesub)
+		n.processAppendEntry(aeAddPeer, n.aesub)
+
+		// The peer is tracked speculatively and the change is inflight at index 2.
+		require_Equal(t, n.commit, 1)
+		_, ok := n.peers[newPeer]
+		require_True(t, ok)
+		require_Equal(t, n.csz, 3)
+		require_NotNil(t, n.membChange)
+		require_Equal(t, n.membChange.index, 2)
+
+		// Apply the committed normal entry, then snapshot at applied (index 1).
+		n.Applied(1)
+		require_NoError(t, n.InstallSnapshot(nil, false))
+
+		// The snapshot's peer state must reflect committed membership only,
+		// i.e. it must not contain the not-yet-committed peer.
+		snap, err := n.loadLastSnapshot()
+		require_NoError(t, err)
+		require_Equal(t, snap.lastIndex, 1)
+		ps, err := decodePeerState(snap.peerstate)
+		require_NoError(t, err)
+		require_Equal(t, ps.clusterSize, 2)
+		require_Len(t, len(ps.knownPeers), 2)
+		require_False(t, slices.Contains(ps.knownPeers, newPeer))
+	})
+
+	t.Run("RemovePeer", func(t *testing.T) {
+		n, cleanup := initSingleMemRaftNode(t)
+		defer cleanup()
+
+		nats0 := "S1Nunr6R"   // "nats-0"
+		oldPeer := "yrzKKRBu" // "nats-1"
+
+		n.Lock()
+		n.addPeer(nats0)
+		n.addPeer(oldPeer)
+		n.Unlock()
+		require_Equal(t, len(n.peers), 3)
+
+		aeMsg := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: []*Entry{newEntry(EntryNormal, esm)}})
+		aeRemovePeer := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 1, entries: []*Entry{newEntry(EntryRemovePeer, []byte(oldPeer))}})
+		n.processAppendEntry(aeMsg, n.aesub)
+		n.processAppendEntry(aeRemovePeer, n.aesub)
+
+		// The peer is removed speculatively and the change is inflight at index 2.
+		require_Equal(t, n.commit, 1)
+		_, ok := n.peers[oldPeer]
+		require_False(t, ok)
+		require_Equal(t, n.csz, 2)
+		require_NotNil(t, n.membChange)
+		require_Equal(t, n.membChange.index, 2)
+
+		// Apply the committed normal entry, then snapshot at applied (index 1).
+		n.Applied(1)
+		require_NoError(t, n.InstallSnapshot(nil, false))
+
+		// The snapshot's peer state must reflect committed membership only,
+		// i.e. it must still include the not-yet-removed peer.
+		snap, err := n.loadLastSnapshot()
+		require_NoError(t, err)
+		require_Equal(t, snap.lastIndex, 1)
+		ps, err := decodePeerState(snap.peerstate)
+		require_NoError(t, err)
+		require_Equal(t, ps.clusterSize, 3)
+		require_Len(t, len(ps.knownPeers), 3)
+		require_True(t, slices.Contains(ps.knownPeers, oldPeer))
+	})
 }
 
 func TestNRGTrackPeerLag(t *testing.T) {

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -1312,6 +1312,129 @@ func TestNRGTruncateWALClearsPendingAppendEntryCache(t *testing.T) {
 	require_NotNil(t, n.pae[1])
 }
 
+func TestNRGTruncateWALRevertsUncommittedAddPeer(t *testing.T) {
+	const (
+		KindLeader = iota
+		KindFollower
+		KindRestart
+	)
+	test := func(kind int) {
+		n, cleanup := initSingleMemRaftNode(t)
+		defer cleanup()
+
+		nats0 := "S1Nunr6R"   // "nats-0"
+		newPeer := "yrzKKRBu" // "nats-1"
+		n.addPeer(nats0)
+		require_Len(t, len(n.peers), 2)
+
+		esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+		normal := []*Entry{newEntry(EntryNormal, esm)}
+		addPeer := newEntry(EntryAddPeer, []byte(newPeer))
+
+		if kind == KindLeader {
+			n.switchToLeader()
+			n.sendMembershipChange(addPeer)
+		} else {
+			// Store a normal entry, then an uncommitted AddPeer entry.
+			ae1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: normal})
+			ae2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 1, entries: []*Entry{addPeer}})
+			aesub := n.aesub
+			if kind == KindRestart {
+				aesub = nil
+			}
+			n.processAppendEntry(ae1, aesub)
+			n.processAppendEntry(ae2, aesub)
+		}
+
+		// The peer is tracked speculatively, and a membership change is now inflight.
+		require_Equal(t, n.pindex, 2)
+		_, ok := n.peers[newPeer]
+		require_True(t, ok)
+		require_Equal(t, n.csz, 3)
+		require_Equal(t, n.qn, 2)
+		require_NotNil(t, n.membChange)
+		require_Equal(t, n.membChange.index, 2)
+		require_Equal(t, n.membChange.peer, newPeer)
+		require_True(t, n.membChange.prev == nil)
+
+		// Truncate the uncommitted AddPeer entry. Its speculative effects must be reverted.
+		n.truncateWAL(1, 1)
+		require_Equal(t, n.pindex, 1)
+		_, ok = n.peers[newPeer]
+		require_False(t, ok)
+		require_Equal(t, n.csz, 2)
+		require_Equal(t, n.qn, 2)
+		require_True(t, n.membChange == nil)
+	}
+
+	t.Run("Leader", func(t *testing.T) { test(KindLeader) })
+	t.Run("Follower", func(t *testing.T) { test(KindFollower) })
+	t.Run("Restart", func(t *testing.T) { test(KindRestart) })
+}
+
+func TestNRGTruncateWALRevertsUncommittedRemovePeer(t *testing.T) {
+	const (
+		KindLeader = iota
+		KindFollower
+		KindRestart
+	)
+	test := func(kind int) {
+		n, cleanup := initSingleMemRaftNode(t)
+		defer cleanup()
+
+		nats0 := "S1Nunr6R"   // "nats-0"
+		oldPeer := "yrzKKRBu" // "nats-1"
+		n.addPeer(nats0)
+		n.addPeer(oldPeer)
+		require_Len(t, len(n.peers), 3)
+
+		esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+		normal := []*Entry{newEntry(EntryNormal, esm)}
+		removePeer := newEntry(EntryRemovePeer, []byte(oldPeer))
+
+		if kind == KindLeader {
+			n.switchToLeader()
+			n.sendMembershipChange(removePeer)
+		} else {
+			// Store a normal entry, then an uncommitted AddPeer entry.
+			ae1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: normal})
+			ae2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 1, entries: []*Entry{removePeer}})
+			aesub := n.aesub
+			if kind == KindRestart {
+				aesub = nil
+			}
+			n.processAppendEntry(ae1, aesub)
+			n.processAppendEntry(ae2, aesub)
+		}
+
+		// The peer is gone and quorum shrank.
+		_, ok := n.peers[oldPeer]
+		require_False(t, ok)
+		require_Equal(t, n.csz, 2)
+		require_Equal(t, n.qn, 2)
+		_, ok = n.removed[oldPeer]
+		require_False(t, ok)
+		require_NotNil(t, n.membChange)
+		require_Equal(t, n.membChange.index, 2)
+		require_Equal(t, n.membChange.peer, oldPeer)
+		require_NotNil(t, n.membChange.prev)
+
+		// Truncate the uncommitted RemovePeer entry. Its speculative effects must be reverted.
+		n.truncateWAL(1, 1)
+		_, ok = n.peers[oldPeer]
+		require_True(t, ok)
+		require_Equal(t, n.csz, 3)
+		require_Equal(t, n.qn, 2)
+		_, ok = n.removed[oldPeer]
+		require_False(t, ok)
+		require_True(t, n.membChange == nil)
+	}
+
+	t.Run("Leader", func(t *testing.T) { test(KindLeader) })
+	t.Run("Follower", func(t *testing.T) { test(KindFollower) })
+	t.Run("Restart", func(t *testing.T) { test(KindRestart) })
+}
+
 func TestNRGResetWALClearsPendingAppendEntryCache(t *testing.T) {
 	n, cleanup := initSingleMemRaftNode(t)
 	defer cleanup()
@@ -4854,17 +4977,17 @@ func TestNRGUncommittedMembershipChangeGetsTruncated(t *testing.T) {
 	n.processAppendEntry(aeAddPeer, n.aesub)
 	require_Equal(t, n.pindex, 2)
 	require_True(t, n.MembershipChangeInProgress())
-	require_Equal(t, n.membChangeIndex, 2)
+	require_Equal(t, n.membChange.index, 2)
 
 	// If the entry containing the membership change isn't truncated, it should remain in progress.
 	n.truncateWAL(n.pterm, n.pindex)
 	require_True(t, n.MembershipChangeInProgress())
-	require_Equal(t, n.membChangeIndex, 2)
+	require_Equal(t, n.membChange.index, 2)
 
 	// If the entry IS truncated, then it shouldn't be in progress anymore.
 	n.truncateWAL(n.pterm, n.pindex-1)
 	require_False(t, n.MembershipChangeInProgress())
-	require_Equal(t, n.membChangeIndex, 0)
+	require_True(t, n.membChange == nil)
 }
 
 func TestNRGUncommittedMembershipChangeOnNewLeaderForwardedRemovePeerProposal(t *testing.T) {

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -6103,6 +6103,53 @@ func TestNRGSnapshotExcludesUncommittedMembershipChange(t *testing.T) {
 	})
 }
 
+func TestNRGDontSwitchToCandidateWithInflightSelfMembershipChange(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+
+	nats0 := "S1Nunr6R" // "nats-0"
+	nats1 := "yrzKKRBu" // "nats-1"
+
+	n.Lock()
+	n.addPeer(nats0)
+	n.addPeer(nats1)
+	n.Unlock()
+	require_Equal(t, len(n.peers), 3)
+
+	// Receive an uncommitted EntryRemovePeer that targets us.
+	aeMsg := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: []*Entry{newEntry(EntryNormal, esm)}})
+	aeRemoveSelf := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 1, entries: []*Entry{newEntry(EntryRemovePeer, []byte(n.id))}})
+	n.processAppendEntry(aeMsg, n.aesub)
+	n.processAppendEntry(aeRemoveSelf, n.aesub)
+
+	// We've speculatively removed ourselves, and the change is inflight at index 2.
+	_, ok := n.peers[n.id]
+	require_False(t, ok)
+	require_NotNil(t, n.membChange)
+	require_Equal(t, n.membChange.peer, n.id)
+	require_Equal(t, n.membChange.index, 2)
+
+	// We must not become a candidate while our own removal is uncommitted.
+	n.Applied(1)
+	n.switchToCandidate()
+	require_Equal(t, n.State(), Follower)
+
+	// Truncate the uncommitted removal back to the committed index. This
+	// restores us to our own peer set and clears the inflight change.
+	n.Lock()
+	n.truncateWAL(1, 1)
+	n.Unlock()
+	_, ok = n.peers[n.id]
+	require_True(t, ok)
+	require_True(t, n.membChange == nil)
+
+	// Now that we're a settled member again, we can campaign.
+	n.switchToCandidate()
+	require_Equal(t, n.State(), Candidate)
+}
+
 func TestNRGTrackPeerLag(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()


### PR DESCRIPTION
When an uncommitted membership change (`EntryAddPeer`/`EntryRemovePeer`) is truncated, the speculative peer-set change wasn't reverted. This PR replaces `membChangeIndex` with a `membChange` struct that records the peer and its previous state (if removing), which can be reverted on truncate.

The follow-up commits drop the redundant known peer flag (`Known: false` is still exposed in `Raftz` for an uncommitted peer add, but now based on the `membChange` struct), and ensures only committed peer state ends up in a snapshot.