### PR TITLE
[IMPROVED] Deterministic max_ha_assets enforcement on the meta leader

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2685,6 +2685,7 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 		cfg.Placement.Tags = append(cfg.Placement.Tags, req.Tags...)
 	}
 
+	js.mu.RLock()
 	peers, e := cc.selectPeerGroup(cfg.Replicas+1, currCluster, &cfg, currPeers, 1, nil)
 	if len(peers) <= cfg.Replicas {
 		// since expanding in the same cluster did not yield a result, try in different cluster
@@ -2709,11 +2710,13 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 			errs.accumulate(e)
 		}
 		if peers == nil {
+			js.mu.RUnlock()
 			resp.Error = NewJSClusterNoPeersError(errs)
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
 	}
+	js.mu.RUnlock()
 
 	cfg.Placement = origPlacement
 
@@ -2931,7 +2934,7 @@ func (s *Server) jsLeaderAccountPurgeRequest(sub *subscription, c *client, _ *Ac
 				s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 				return
 			}
-			cc.trackInflightConsumerProposal(accName, osa.Config.Name, ca, true)
+			js.trackInflightConsumerProposal(accName, osa.Config.Name, ca, true)
 			nc++
 		}
 		sa := &streamAssignment{Group: osa.Group, Config: osa.Config, Subject: subject, Client: osa.Client, Created: osa.Created}
@@ -2941,7 +2944,7 @@ func (s *Server) jsLeaderAccountPurgeRequest(sub *subscription, c *client, _ *Ac
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
-		cc.trackInflightStreamProposal(accName, sa, true)
+		js.trackInflightStreamProposal(accName, sa, true)
 		ns++
 	}
 	js.mu.Unlock()
@@ -5291,7 +5294,7 @@ func (s *Server) jsConsumerPauseRequest(sub *subscription, c *client, _ *Account
 			js.mu.Unlock()
 			return
 		}
-		cc.trackInflightConsumerProposal(acc.Name, stream, nca, false)
+		js.trackInflightConsumerProposal(acc.Name, stream, nca, false)
 		js.mu.Unlock()
 
 		resp.PauseUntil = pauseUTC

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2686,7 +2686,7 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 	}
 
 	js.mu.RLock()
-	peers, e := cc.selectPeerGroup(cfg.Replicas+1, currCluster, &cfg, currPeers, 1, nil)
+	peers, e := js.selectPeerGroup(cfg.Replicas+1, currCluster, &cfg, currPeers, 1, nil)
 	if len(peers) <= cfg.Replicas {
 		// since expanding in the same cluster did not yield a result, try in different cluster
 		peers = nil
@@ -2701,7 +2701,7 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 		errs := &selectPeerError{}
 		errs.accumulate(e)
 		for cluster := range clusters {
-			newPeers, e := cc.selectPeerGroup(cfg.Replicas, cluster, &cfg, nil, 0, nil)
+			newPeers, e := js.selectPeerGroup(cfg.Replicas, cluster, &cfg, nil, 0, nil)
 			if len(newPeers) >= cfg.Replicas {
 				peers = append([]string{}, currPeers...)
 				peers = append(peers, newPeers[:cfg.Replicas]...)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4985,9 +4985,8 @@ func (js *jetStream) streamAssignmentOrInflight(account, stream string) *streamA
 		if inflight, ok := streams[stream]; ok {
 			if !inflight.deleted {
 				return inflight.streamAssignment
-			} else {
-				return nil
 			}
+			return nil
 		}
 	}
 
@@ -6537,14 +6536,17 @@ func (js *jetStream) consumerAssignmentOrInflight(account, stream, consumer stri
 	if cc == nil {
 		return nil
 	}
+	// If the stream itself is deleted, the consumer is as well.
+	if js.streamAssignmentOrInflight(account, stream) == nil {
+		return nil
+	}
 	if streams, ok := cc.inflightConsumers[account]; ok {
 		if consumers, ok := streams[stream]; ok {
 			if inflight, ok := consumers[consumer]; ok {
 				if !inflight.deleted {
 					return inflight.consumerAssignment
-				} else {
-					return nil
 				}
+				return nil
 			}
 		}
 	}
@@ -6562,7 +6564,10 @@ func (js *jetStream) consumerAssignmentsOrInflightSeq(account, stream string) it
 		if cc == nil {
 			return
 		}
-
+		// If the stream itself is deleted, the consumer is as well.
+		if js.streamAssignmentOrInflight(account, stream) == nil {
+			return
+		}
 		var inflight map[string]*inflightConsumerInfo
 		if streams, ok := cc.inflightConsumers[account]; ok {
 			inflight = streams[stream]

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1322,6 +1322,15 @@ func (cc *jetStreamCluster) isConsumerLeader(account, stream, consumer string) b
 	return false
 }
 
+// haAssetPeers the last replicas peers, similar to genPeerInfo to take
+// stream/consumer moves into account.
+func haAssetPeers(peers []string, replicas int) []string {
+	if replicas > 1 && len(peers) > replicas {
+		return peers[len(peers)-replicas:]
+	}
+	return peers
+}
+
 // Track the stream for the account `accName` in the inflight proposals map.
 // This is done after proposing a stream change.
 // (Write) Lock held on entry.
@@ -1331,7 +1340,7 @@ func (js *jetStream) trackInflightStreamProposal(accName string, sa *streamAssig
 	// Perform max HA asset accounting.
 	if osa != nil {
 		if osa.Config.Replicas > 1 {
-			for _, peer := range osa.Group.Peers {
+			for _, peer := range haAssetPeers(osa.Group.Peers, osa.Config.Replicas) {
 				cc.peerHAAssets[peer]--
 				if cc.peerHAAssets[peer] <= 0 {
 					delete(cc.peerHAAssets, peer)
@@ -1349,7 +1358,7 @@ func (js *jetStream) trackInflightStreamProposal(accName string, sa *streamAssig
 					continue
 				}
 				if oldReplicas > 1 {
-					for _, peer := range oca.Group.Peers {
+					for _, peer := range haAssetPeers(oca.Group.Peers, oldReplicas) {
 						cc.peerHAAssets[peer]--
 						if cc.peerHAAssets[peer] <= 0 {
 							delete(cc.peerHAAssets, peer)
@@ -1361,7 +1370,7 @@ func (js *jetStream) trackInflightStreamProposal(accName string, sa *streamAssig
 				// but when the consumer makes the accounting changes, it only knows the new stream.
 				// So we must adjust the accounting here while we know both the old and new stream.
 				if !deleted && newReplicas > 1 {
-					for _, peer := range oca.Group.Peers {
+					for _, peer := range haAssetPeers(oca.Group.Peers, newReplicas) {
 						cc.peerHAAssets[peer]++
 					}
 				}
@@ -1369,7 +1378,7 @@ func (js *jetStream) trackInflightStreamProposal(accName string, sa *streamAssig
 		}
 	}
 	if !deleted && sa.Config.Replicas > 1 {
-		for _, peer := range sa.Group.Peers {
+		for _, peer := range haAssetPeers(sa.Group.Peers, sa.Config.Replicas) {
 			cc.peerHAAssets[peer]++
 		}
 	}
@@ -1423,16 +1432,18 @@ func (js *jetStream) trackInflightConsumerProposal(accName, streamName string, c
 	}
 
 	// Perform max HA asset accounting.
-	if oca != nil && oca.Config.replicas(osa.Config) > 1 {
-		for _, peer := range oca.Group.Peers {
-			cc.peerHAAssets[peer]--
-			if cc.peerHAAssets[peer] <= 0 {
-				delete(cc.peerHAAssets, peer)
+	if oca != nil {
+		if r := oca.Config.replicas(osa.Config); r > 1 {
+			for _, peer := range haAssetPeers(oca.Group.Peers, r) {
+				cc.peerHAAssets[peer]--
+				if cc.peerHAAssets[peer] <= 0 {
+					delete(cc.peerHAAssets, peer)
+				}
 			}
 		}
 	}
-	if !deleted && ca.Config.replicas(osa.Config) > 1 {
-		for _, peer := range ca.Group.Peers {
+	if r := ca.Config.replicas(osa.Config); !deleted && r > 1 {
+		for _, peer := range haAssetPeers(ca.Group.Peers, r) {
 			cc.peerHAAssets[peer]++
 		}
 	}
@@ -1492,13 +1503,13 @@ func (cc *jetStreamCluster) rebuildPeerAssets() {
 	for _, asa := range cc.streams {
 		for _, sa := range asa {
 			if sa.Config.Replicas > 1 {
-				for _, peer := range sa.Group.Peers {
+				for _, peer := range haAssetPeers(sa.Group.Peers, sa.Config.Replicas) {
 					cc.peerHAAssets[peer]++
 				}
 			}
 			for _, ca := range sa.consumers {
 				if r := ca.Config.replicas(sa.Config); r > 1 {
-					for _, peer := range ca.Group.Peers {
+					for _, peer := range haAssetPeers(ca.Group.Peers, r) {
 						cc.peerHAAssets[peer]++
 					}
 				}
@@ -3222,6 +3233,11 @@ func (mset *stream) removeNode() {
 // Helper function to generate peer info.
 // lists and sets for old and new.
 func genPeerInfo(peers []string, split int) (newPeers, oldPeers []string, newPeerSet, oldPeerSet map[string]bool) {
+	if split < 0 {
+		split = 0
+	} else if split > len(peers) {
+		split = len(peers)
+	}
 	newPeers = peers[split:]
 	oldPeers = peers[:split]
 	newPeerSet = make(map[string]bool, len(newPeers))

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2728,7 +2728,7 @@ func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer strin
 	if cc == nil || cc.meta == nil {
 		return false
 	}
-	replaced := cc.remapStreamAssignment(csa, peer)
+	replaced := js.remapStreamAssignment(csa, peer)
 	accName := sa.Client.serviceAccount()
 	if !replaced {
 		s.Warnf("JetStream cluster could not replace peer for stream '%s > %s'", accName, sa.Config.Name)
@@ -7788,7 +7788,7 @@ func (js *jetStream) processLeaderChange(isLeader bool) {
 }
 
 // Lock should be held.
-func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, removePeer string) bool {
+func (js *jetStream) remapStreamAssignment(sa *streamAssignment, removePeer string) bool {
 	// Invoke placement algo passing RG peers that stay (existing) and the peer that is being removed (ignore)
 	var retain, ignore []string
 	for _, v := range sa.Group.Peers {
@@ -7799,7 +7799,7 @@ func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, removePe
 		}
 	}
 
-	newPeers, placementError := cc.selectPeerGroup(len(sa.Group.Peers), sa.Group.Cluster, sa.Config, retain, 0, ignore)
+	newPeers, placementError := js.selectPeerGroup(len(sa.Group.Peers), sa.Group.Cluster, sa.Config, retain, 0, ignore)
 
 	if placementError == nil {
 		sa.Group.Peers = newPeers
@@ -7923,8 +7923,9 @@ func (e *selectPeerError) accumulate(eAdd *selectPeerError) {
 // selectPeerGroup will select a group of peers to start a raft group.
 // when peers exist already the unique tag prefix check for the replaceFirstExisting will be skipped
 // js lock should be held.
-func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamConfig, existing []string, replaceFirstExisting int, ignore []string) ([]string, *selectPeerError) {
-	if cluster == _EMPTY_ || cfg == nil {
+func (js *jetStream) selectPeerGroup(r int, cluster string, cfg *StreamConfig, existing []string, replaceFirstExisting int, ignore []string) ([]string, *selectPeerError) {
+	cc := js.cluster
+	if cluster == _EMPTY_ || cfg == nil || cc == nil {
 		return nil, &selectPeerError{misc: true}
 	}
 
@@ -8022,14 +8023,9 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 
 	// Grab the number of streams currently assigned to each peer.
 	peerStreams := make(map[string]int, len(peers))
-	for _, asa := range cc.streams {
-		for _, sa := range asa {
-			if sa.unsupported != nil {
-				continue
-			}
-			for _, peer := range sa.Group.Peers {
-				peerStreams[peer]++
-			}
+	for _, sa := range js.streamAssignmentsOrInflightSeqAllAccounts() {
+		for _, peer := range sa.Group.Peers {
+			peerStreams[peer]++
 		}
 	}
 
@@ -8258,7 +8254,7 @@ func (js *jetStream) createGroupForStream(ci *ClientInfo, cfg *StreamConfig) (*r
 	}
 
 	// Default connected cluster from the request origin.
-	cc, cluster := js.cluster, ci.Cluster
+	cluster := ci.Cluster
 	// If specified, override the default.
 	clusterDefined := cfg.Placement != nil && cfg.Placement.Cluster != _EMPTY_
 	if clusterDefined {
@@ -8272,7 +8268,7 @@ func (js *jetStream) createGroupForStream(ci *ClientInfo, cfg *StreamConfig) (*r
 	// Need to create a group here.
 	errs := &selectPeerError{}
 	for _, cn := range clusters {
-		peers, err := cc.selectPeerGroup(replicas, cn, cfg, nil, 0, nil)
+		peers, err := js.selectPeerGroup(replicas, cn, cfg, nil, 0, nil)
 		if len(peers) < replicas {
 			errs.accumulate(err)
 			continue
@@ -8656,7 +8652,7 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 					rg.Cluster = ci.Cluster
 				}
 			}
-			peers, err := cc.selectPeerGroup(newCfg.Replicas, rg.Cluster, newCfg, rg.Peers, 0, nil)
+			peers, err := js.selectPeerGroup(newCfg.Replicas, rg.Cluster, newCfg, rg.Peers, 0, nil)
 			if err != nil {
 				resp.Error = NewJSClusterNoPeersError(err)
 				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -53,6 +53,8 @@ type jetStreamCluster struct {
 	// a response but they need to be same group, peers etc. and sync subjects.
 	inflightStreams   map[string]map[string]*inflightStreamInfo
 	inflightConsumers map[string]map[string]map[string]*inflightConsumerInfo
+	// Per-peer count of HA assets, used by the meta leader to enforce max_ha_assets.
+	peerHAAssets map[string]int
 	// Tracks raft groups currently being started by createRaftGroup, so that
 	// concurrent callers for the same group can wait without holding js.mu
 	// across the disk I/O performed during startup.
@@ -1323,7 +1325,55 @@ func (cc *jetStreamCluster) isConsumerLeader(account, stream, consumer string) b
 // Track the stream for the account `accName` in the inflight proposals map.
 // This is done after proposing a stream change.
 // (Write) Lock held on entry.
-func (cc *jetStreamCluster) trackInflightStreamProposal(accName string, sa *streamAssignment, deleted bool) {
+func (js *jetStream) trackInflightStreamProposal(accName string, sa *streamAssignment, deleted bool) {
+	cc, osa := js.cluster, js.streamAssignmentOrInflight(accName, sa.Config.Name)
+
+	// Perform max HA asset accounting.
+	if osa != nil {
+		if osa.Config.Replicas > 1 {
+			for _, peer := range osa.Group.Peers {
+				cc.peerHAAssets[peer]--
+				if cc.peerHAAssets[peer] <= 0 {
+					delete(cc.peerHAAssets, peer)
+				}
+			}
+		}
+
+		// If the stream is deleted or replicas are updated, also clean up consumer tracking.
+		if deleted || osa.Config.Replicas != sa.Config.Replicas {
+			for oca := range js.consumerAssignmentsOrInflightSeq(accName, sa.Config.Name) {
+				oldReplicas := oca.Config.replicas(osa.Config)
+				newReplicas := oca.Config.replicas(sa.Config)
+				// Can skip if the replicas didn't change.
+				if !deleted && oldReplicas == newReplicas {
+					continue
+				}
+				if oldReplicas > 1 {
+					for _, peer := range oca.Group.Peers {
+						cc.peerHAAssets[peer]--
+						if cc.peerHAAssets[peer] <= 0 {
+							delete(cc.peerHAAssets, peer)
+						}
+					}
+				}
+				// If not deleted, then the replicas changed, re-add under the new replica count.
+				// Important that we still use the old consumer peers! This feels slightly odd,
+				// but when the consumer makes the accounting changes, it only knows the new stream.
+				// So we must adjust the accounting here while we know both the old and new stream.
+				if !deleted && newReplicas > 1 {
+					for _, peer := range oca.Group.Peers {
+						cc.peerHAAssets[peer]++
+					}
+				}
+			}
+		}
+	}
+	if !deleted && sa.Config.Replicas > 1 {
+		for _, peer := range sa.Group.Peers {
+			cc.peerHAAssets[peer]++
+		}
+	}
+
 	if cc.inflightStreams == nil {
 		cc.inflightStreams = make(map[string]map[string]*inflightStreamInfo)
 	}
@@ -1364,7 +1414,29 @@ func (cc *jetStreamCluster) removeInflightStreamProposal(accName, streamName str
 // Track the consumer for the `streamName` and account `accName` in the inflight proposals map.
 // This is done after proposing a consumer change.
 // (Write) Lock held on entry.
-func (cc *jetStreamCluster) trackInflightConsumerProposal(accName, streamName string, ca *consumerAssignment, deleted bool) {
+func (js *jetStream) trackInflightConsumerProposal(accName, streamName string, ca *consumerAssignment, deleted bool) {
+	cc, osa, oca := js.cluster, js.streamAssignmentOrInflight(accName, streamName), js.consumerAssignmentOrInflight(accName, streamName, ca.Name)
+
+	// If the stream is deleted, we've accounted for it there, and we can't do anything here.
+	if osa == nil {
+		return
+	}
+
+	// Perform max HA asset accounting.
+	if oca != nil && oca.Config.replicas(osa.Config) > 1 {
+		for _, peer := range oca.Group.Peers {
+			cc.peerHAAssets[peer]--
+			if cc.peerHAAssets[peer] <= 0 {
+				delete(cc.peerHAAssets, peer)
+			}
+		}
+	}
+	if !deleted && ca.Config.replicas(osa.Config) > 1 {
+		for _, peer := range ca.Group.Peers {
+			cc.peerHAAssets[peer]++
+		}
+	}
+
 	if cc.inflightConsumers == nil {
 		cc.inflightConsumers = make(map[string]map[string]map[string]*inflightConsumerInfo)
 	}
@@ -1408,6 +1480,29 @@ func (cc *jetStreamCluster) removeInflightConsumerProposal(accName, streamName, 
 		}
 		if len(streams) == 0 {
 			delete(cc.inflightConsumers, accName)
+		}
+	}
+}
+
+// rebuildPeerAssets recomputes the authoritative per-peer HA asset counts from the
+// applied cluster state. Only HA (replicated, R>1) streams and consumers are counted.
+// js write lock must be held.
+func (cc *jetStreamCluster) rebuildPeerAssets() {
+	cc.peerHAAssets = make(map[string]int)
+	for _, asa := range cc.streams {
+		for _, sa := range asa {
+			if sa.Config.Replicas > 1 {
+				for _, peer := range sa.Group.Peers {
+					cc.peerHAAssets[peer]++
+				}
+			}
+			for _, ca := range sa.consumers {
+				if r := ca.Config.replicas(sa.Config); r > 1 {
+					for _, peer := range ca.Group.Peers {
+						cc.peerHAAssets[peer]++
+					}
+				}
+			}
 		}
 	}
 }
@@ -2544,7 +2639,7 @@ func (js *jetStream) processAddPeer(peer string) {
 			if err := cc.meta.Propose(encodeAddStreamAssignment(csa)); err != nil {
 				return
 			}
-			cc.trackInflightStreamProposal(accName, csa, false)
+			js.trackInflightStreamProposal(accName, csa, false)
 			for ca := range js.consumerAssignmentsOrInflightSeq(accName, csa.Config.Name) {
 				if ca.unsupported != nil {
 					continue
@@ -2556,7 +2651,7 @@ func (js *jetStream) processAddPeer(peer string) {
 					if err := cc.meta.Propose(encodeAddConsumerAssignment(cca)); err != nil {
 						return
 					}
-					cc.trackInflightConsumerProposal(accName, csa.Config.Name, cca, false)
+					js.trackInflightConsumerProposal(accName, csa.Config.Name, cca, false)
 				}
 			}
 		}
@@ -2643,7 +2738,7 @@ func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer strin
 	if err := cc.meta.Propose(encodeAddStreamAssignment(csa)); err != nil {
 		return false
 	}
-	cc.trackInflightStreamProposal(accName, csa, false)
+	js.trackInflightStreamProposal(accName, csa, false)
 	rg := csa.Group
 	for ca := range js.consumerAssignmentsOrInflightSeq(accName, sa.Config.Name) {
 		if ca.unsupported != nil {
@@ -2656,13 +2751,13 @@ func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer strin
 			if err := cc.meta.Propose(encodeAddConsumerAssignment(cca)); err != nil {
 				return false
 			}
-			cc.trackInflightConsumerProposal(accName, csa.Config.Name, cca, false)
+			js.trackInflightConsumerProposal(accName, csa.Config.Name, cca, false)
 		} else if ca.Group.isMember(peer) {
 			// These are ephemerals. Check to see if we deleted this peer.
 			if err := cc.meta.Propose(encodeDeleteConsumerAssignment(ca)); err != nil {
 				return false
 			}
-			cc.trackInflightConsumerProposal(accName, csa.Config.Name, ca, true)
+			js.trackInflightConsumerProposal(accName, csa.Config.Name, ca, true)
 		}
 	}
 	return replaced
@@ -2975,16 +3070,6 @@ retry:
 	if sysAcc == nil {
 		s.Debugf("JetStream cluster detected shutdown processing raft group: %+v", rg)
 		return nil, errors.New("shutting down")
-	}
-
-	// Check here to see if we have a max HA Assets limit set.
-	if maxHaAssets := s.getOpts().JetStreamLimits.MaxHAAssets; maxHaAssets > 0 {
-		if s.numRaftNodes()+len(cc.creatingRaftGroups) > maxHaAssets {
-			s.Warnf("Maximum HA Assets limit reached: %d", maxHaAssets)
-			// Since the meta leader assigned this, send a statsz update to them to get them up to date.
-			go s.sendStatszUpdate()
-			return nil, errors.New("system limit reached")
-		}
 	}
 
 	// Register an in-flight sentinel so concurrent callers for the same group
@@ -7444,14 +7529,14 @@ func (js *jetStream) processStreamAssignmentResults(sub *subscription, c *client
 						if err := cc.meta.Propose(encodeDeleteStreamAssignment(sa)); err != nil {
 							return
 						}
-						cc.trackInflightStreamProposal(result.Account, sa, true)
+						js.trackInflightStreamProposal(result.Account, sa, true)
 						// Propose new.
 						nsa := sa.copyGroup()
 						nsa.Group, nsa.err = rg, nil
 						if err := cc.meta.Propose(encodeAddStreamAssignment(nsa)); err != nil {
 							return
 						}
-						cc.trackInflightStreamProposal(result.Account, nsa, false)
+						js.trackInflightStreamProposal(result.Account, nsa, false)
 						// When the new stream assignment is processed, sa.reassigning will be
 						// automatically set back to false. Until then, don't process any more
 						// assignment results.
@@ -7486,7 +7571,7 @@ func (js *jetStream) processStreamAssignmentResults(sub *subscription, c *client
 			if err := cc.meta.Propose(encodeDeleteStreamAssignment(sa)); err != nil {
 				return
 			}
-			cc.trackInflightStreamProposal(result.Account, sa, true)
+			js.trackInflightStreamProposal(result.Account, sa, true)
 		}
 	}
 }
@@ -7629,6 +7714,7 @@ func (js *jetStream) processLeaderChange(isLeader bool) {
 	if s == nil {
 		return
 	}
+
 	// Update our server atomic.
 	s.isMetaLeader.Store(isLeader)
 
@@ -7661,14 +7747,17 @@ func (js *jetStream) processLeaderChange(isLeader bool) {
 	js.cluster.inflightStreams = nil
 	js.cluster.inflightConsumers = nil
 
+	// Clear per-peer HA asset counts, only re-populate on the meta leader.
+	js.cluster.peerHAAssets = nil
+
 	if isLeader {
+		js.cluster.rebuildPeerAssets()
+
 		if meta := js.cluster.meta; meta != nil && meta.IsObserver() {
 			meta.StepDown()
 			return
 		}
-	}
 
-	if isLeader {
 		js.startUpdatesSub()
 	} else {
 		js.stopUpdatesSub()
@@ -7690,7 +7779,7 @@ func (js *jetStream) processLeaderChange(isLeader bool) {
 				if err := cc.meta.Propose(encodeUpdateStreamAssignment(nsa)); err != nil {
 					return
 				}
-				cc.trackInflightStreamProposal(acc, nsa, false)
+				js.trackInflightStreamProposal(acc, nsa, false)
 			}
 		}
 		// Clear check.
@@ -7931,21 +8020,15 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 		}
 	}
 
-	// Grab the number of streams and HA assets currently assigned to each peer.
-	// HAAssets under usage is async, so calculate here in realtime based on assignments.
+	// Grab the number of streams currently assigned to each peer.
 	peerStreams := make(map[string]int, len(peers))
-	peerHA := make(map[string]int, len(peers))
 	for _, asa := range cc.streams {
 		for _, sa := range asa {
 			if sa.unsupported != nil {
 				continue
 			}
-			isHA := len(sa.Group.Peers) > 1
 			for _, peer := range sa.Group.Peers {
 				peerStreams[peer]++
-				if isHA {
-					peerHA[peer]++
-				}
 			}
 		}
 	}
@@ -8049,10 +8132,12 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 			err.noStorage = true
 			continue
 		}
-		// HAAssets contain _meta_ which we want to ignore, hence > and not >=.
-		if maxHaAssets > 0 && ni.stats != nil && ni.stats.HAAssets > maxHaAssets {
+		// Only HA (replicated, R>1) assets count against and are limited by max_ha_assets.
+		// R1 assets do have a Raft group while moving, but explicitly ignore this guard.
+		ha := cc.peerHAAssets[p.ID]
+		if cfg.Replicas > 1 && maxHaAssets > 0 && ha >= maxHaAssets {
 			s.Warnf("Peer selection: discard %s@%s (HA Asset Count: %d) exceeds max ha asset limit of %d for stream placement",
-				ni.name, ni.cluster, ni.stats.HAAssets, maxHaAssets)
+				ni.name, ni.cluster, ha, maxHaAssets)
 			err.misc = true
 			continue
 		}
@@ -8071,7 +8156,7 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 			}
 		}
 		// Add to our list of potential nodes.
-		nodes = append(nodes, wn{p.ID, available, ni.offline, peerHA[p.ID], peerStreams[p.ID]})
+		nodes = append(nodes, wn{p.ID, available, ni.offline, ha, peerStreams[p.ID]})
 		if !ni.offline {
 			onlinePeers++
 		}
@@ -8331,7 +8416,7 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 	// On success, add this as an inflight proposal so we can apply limits
 	// on concurrent create requests while this stream assignment has
 	// possibly not been processed yet.
-	cc.trackInflightStreamProposal(acc.Name, sa, false)
+	js.trackInflightStreamProposal(acc.Name, sa, false)
 }
 
 var (
@@ -8772,14 +8857,14 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 	if err := meta.Propose(encodeUpdateStreamAssignment(sa)); err != nil {
 		return
 	}
-	cc.trackInflightStreamProposal(acc.Name, sa, false)
+	js.trackInflightStreamProposal(acc.Name, sa, false)
 
 	// Process any staged consumers.
 	for _, ca := range consumers {
 		if err := meta.Propose(encodeAddConsumerAssignment(ca)); err != nil {
 			return
 		}
-		cc.trackInflightConsumerProposal(acc.Name, sa.Config.Name, ca, false)
+		js.trackInflightConsumerProposal(acc.Name, sa.Config.Name, ca, false)
 	}
 }
 
@@ -8808,7 +8893,7 @@ func (s *Server) jsClusteredStreamDeleteRequest(ci *ClientInfo, acc *Account, st
 	if err := cc.meta.Propose(encodeDeleteStreamAssignment(sa)); err != nil {
 		return
 	}
-	cc.trackInflightStreamProposal(acc.Name, sa, true)
+	js.trackInflightStreamProposal(acc.Name, sa, true)
 }
 
 // Process a clustered purge request.
@@ -8913,7 +8998,7 @@ func (s *Server) jsClusteredStreamRestoreRequest(
 	if err := cc.meta.Propose(encodeAddStreamAssignment(sa)); err != nil {
 		return
 	}
-	cc.trackInflightStreamProposal(ci.serviceAccount(), sa, false)
+	js.trackInflightStreamProposal(ci.serviceAccount(), sa, false)
 }
 
 // Determine if all peers for this group are offline.
@@ -9338,7 +9423,7 @@ func (s *Server) jsClusteredConsumerDeleteRequest(ci *ClientInfo, acc *Account, 
 	if err := cc.meta.Propose(encodeDeleteConsumerAssignment(ca)); err != nil {
 		return
 	}
-	cc.trackInflightConsumerProposal(acc.Name, stream, ca, true)
+	js.trackInflightConsumerProposal(acc.Name, stream, ca, true)
 }
 
 func encodeMsgDelete(md *streamMsgDelete) []byte {
@@ -9731,16 +9816,18 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 		if len(rg.Peers) > 1 {
 			if maxHaAssets := s.getOpts().JetStreamLimits.MaxHAAssets; maxHaAssets != 0 {
 				for _, peer := range rg.Peers {
-					if ni, ok := s.nodeToInfo.Load(peer); ok {
-						ni := ni.(nodeInfo)
-						if stats := ni.stats; stats != nil && stats.HAAssets > maxHaAssets {
-							resp.Error = NewJSInsufficientResourcesError()
-							s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
-							s.Warnf("%s@%s (HA Asset Count: %d) exceeds max ha asset limit of %d"+
-								" for (durable) consumer %s placement on stream %s",
-								ni.name, ni.cluster, ni.stats.HAAssets, maxHaAssets, oname, stream)
-							return
+					if ha := cc.peerHAAssets[peer]; ha >= maxHaAssets {
+						resp.Error = NewJSInsufficientResourcesError()
+						s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+						name, cluster := peer, _EMPTY_
+						if ni, ok := s.nodeToInfo.Load(peer); ok {
+							ni := ni.(nodeInfo)
+							name, cluster = ni.name, ni.cluster
 						}
+						s.Warnf("%s@%s (HA Asset Count: %d) exceeds max ha asset limit of %d"+
+							" for (durable) consumer %s placement on stream %s",
+							name, cluster, ha, maxHaAssets, oname, stream)
+						return
 					}
 				}
 			}
@@ -9881,7 +9968,7 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 	if err := cc.meta.Propose(encodeAddConsumerAssignment(ca)); err != nil {
 		return
 	}
-	cc.trackInflightConsumerProposal(acc.Name, stream, ca, false)
+	js.trackInflightConsumerProposal(acc.Name, stream, ca, false)
 }
 
 func encodeAddConsumerAssignment(ca *consumerAssignment) []byte {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -1507,6 +1507,45 @@ func (cc *jetStreamCluster) rebuildPeerAssets() {
 	}
 }
 
+// updateExceedsMaxHAAssets reports whether replacing the stream and consumers
+// old assignments with the new assignments would exceed the max_ha_assets.
+// Lock must be held.
+func (js *jetStream) updateExceedsMaxHAAssets(accName string, osa, sa *streamAssignment, consumers []*consumerAssignment) bool {
+	cc := js.cluster
+	maxHaAssets := js.srv.getOpts().JetStreamLimits.MaxHAAssets
+	if maxHaAssets <= 0 || cc == nil {
+		return false
+	}
+
+	delta := make(map[string]int)
+	add := func(replicas int, peers []string, sign int) {
+		if replicas > 1 {
+			for _, peer := range peers {
+				delta[peer] += sign
+			}
+		}
+	}
+	if osa != nil {
+		add(osa.Config.Replicas, osa.Group.Peers, -1)
+	}
+	add(sa.Config.Replicas, sa.Group.Peers, +1)
+	for _, cca := range consumers {
+		if osa != nil {
+			if oca := js.consumerAssignmentOrInflight(accName, osa.Config.Name, cca.Name); oca != nil {
+				add(oca.Config.replicas(osa.Config), oca.Group.Peers, -1)
+			}
+		}
+		add(cca.Config.replicas(sa.Config), cca.Group.Peers, +1)
+	}
+
+	for peer, d := range delta {
+		if d > 0 && cc.peerHAAssets[peer]+d > maxHaAssets {
+			return true
+		}
+	}
+	return false
+}
+
 // Return the cluster quit chan.
 func (js *jetStream) clusterQuitC() chan struct{} {
 	js.mu.RLock()
@@ -2636,6 +2675,8 @@ func (js *jetStream) processAddPeer(peer string) {
 			csa := sa.copyGroup()
 			csa.Group.Peers = append(csa.Group.Peers, peer)
 			// Send our proposal for this csa. Also use same group definition for all the consumers as well.
+			// We intentionally ignore max_ha_assets since this is a system-level command, and we'd rather
+			// have the streams and consumers be fully operational as soon as possible.
 			if err := cc.meta.Propose(encodeAddStreamAssignment(csa)); err != nil {
 				return
 			}
@@ -2735,6 +2776,8 @@ func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer strin
 	}
 
 	// Send our proposal for this csa. Also use same group definition for all the consumers as well.
+	// We intentionally ignore max_ha_assets since this is a system-level command, and we'd rather
+	// have the streams and consumers be fully operational as soon as possible.
 	if err := cc.meta.Propose(encodeAddStreamAssignment(csa)); err != nil {
 		return false
 	}
@@ -8855,6 +8898,14 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		syncSubject = syncSubjForStream()
 	}
 	sa := &streamAssignment{Group: rg, Sync: syncSubject, Created: osa.Created, Config: newCfg, Subject: subject, Reply: reply, Client: ci}
+
+	// Confirm we'll still satisfy max_ha_assets after the update.
+	if js.updateExceedsMaxHAAssets(acc.Name, osa, sa, consumers) {
+		resp.Error = NewJSInsufficientResourcesError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+		return
+	}
+
 	if err := meta.Propose(encodeUpdateStreamAssignment(sa)); err != nil {
 		return
 	}
@@ -9946,6 +9997,13 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 			nca.Group.Peers = newPeerSet
 			nca.Group.Preferred = curLeader
 			nca.Group.ScaleUp = true
+
+			// Confirm we'll still satisfy max_ha_assets after the update.
+			if js.updateExceedsMaxHAAssets(acc.Name, sa, sa, []*consumerAssignment{nca}) {
+				resp.Error = NewJSInsufficientResourcesError()
+				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+				return
+			}
 		} else if rBefore > rAfter {
 			// Mark the current leader as preferred, it will be kept in the new peer set.
 			nca.Group.Preferred = curLeader

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -9945,7 +9945,7 @@ func TestJetStreamClusterSetPreferredToOnlineNode(t *testing.T) {
 	js = ml.getJetStream()
 	cc = js.cluster
 	require_NotNil(t, cc)
-	peers, err := cc.selectPeerGroup(3, "R3S", cfg, nil, 0, nil)
+	peers, err := js.selectPeerGroup(3, "R3S", cfg, nil, 0, nil)
 	// Need explicit nil-check.
 	if err != nil {
 		require_NoError(t, err)

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -1239,7 +1239,7 @@ func TestJetStreamClusterScaleDownWhileNoQuorum(t *testing.T) {
 }
 
 // We noticed that ha_assets enforcement seemed to not be upheld when assets created in a rapid fashion.
-func TestJetStreamClusterHAssetsEnforcement(t *testing.T) {
+func TestJetStreamClusterMaxHAAssetsEnforcement(t *testing.T) {
 	tmpl := strings.Replace(jsClusterTempl, "store_dir:", "limits: {max_ha_assets: 2}, store_dir:", 1)
 	c := createJetStreamClusterWithTemplateAndModHook(t, tmpl, "R3S", 3, nil)
 	defer c.shutdown()
@@ -1270,6 +1270,83 @@ func TestJetStreamClusterHAssetsEnforcement(t *testing.T) {
 		Replicas: 3,
 	})
 	require_Error(t, err, exceededErrs...)
+}
+
+func TestJetStreamClusterMaxHAAssetsLoweredBelowExistingOnRestart(t *testing.T) {
+	c := createJetStreamClusterWithTemplate(t, jsClusterTempl, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	streams := []string{"S1", "S2"}
+	for _, name := range streams {
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     name,
+			Subjects: []string{name},
+			Replicas: 3,
+		})
+		require_NoError(t, err)
+		checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+			return checkState(t, c, globalAccountName, name)
+		})
+	}
+
+	for _, s := range c.servers {
+		jsz, err := s.Jsz(nil)
+		require_NoError(t, err)
+		require_Equal(t, jsz.HAAssets, 3) // _meta_ + S1 + S2
+	}
+	nc.Close()
+
+	// Stop everything, then lower the limit to 1 by editing each config file on
+	// disk before restarting.
+	c.stopAll()
+	for _, o := range c.opts {
+		cfgPath := o.ConfigFile
+		b, err := os.ReadFile(cfgPath)
+		require_NoError(t, err)
+		newCfg := strings.Replace(string(b), "store_dir:", "limits: {max_ha_assets: 1}, store_dir:", 1)
+		require_True(t, strings.Contains(newCfg, "max_ha_assets: 1"))
+		require_NoError(t, os.WriteFile(cfgPath, []byte(newCfg), defaultFilePerms))
+	}
+
+	c.restartAll()
+	c.waitOnClusterReady()
+
+	// Confirm the new limit is actually in effect on every server.
+	for _, s := range c.servers {
+		require_Equal(t, s.getOpts().JetStreamLimits.MaxHAAssets, 1)
+	}
+
+	nc, js = jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// Any HA assets already assigned must ALL come up, even if they exceed the new limit.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		total := 0
+		for _, s := range c.servers {
+			jsz, err := s.Jsz(nil)
+			if err != nil {
+				return err
+			}
+			total += jsz.HAAssets
+		}
+		if total != 9 {
+			return fmt.Errorf("expected 9 total HA assets (3 meta + 2x3 stream slots), got %d", total)
+		}
+		return nil
+	})
+
+	for _, name := range streams {
+		c.waitOnStreamLeader(globalAccountName, name)
+
+		_, err := js.Publish(name, nil)
+		require_NoError(t, err)
+		checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+			return checkState(t, c, globalAccountName, name)
+		})
+	}
 }
 
 func TestJetStreamClusterInterestStreamConsumer(t *testing.T) {
@@ -7966,9 +8043,8 @@ func TestJetStreamClusterMetaLeaderRespectsInflight(t *testing.T) {
 	ml := c.leader()
 	require_NotNil(t, ml)
 
-	sjs, cc := ml.getJetStreamCluster()
+	sjs := ml.getJetStream()
 	require_NotNil(t, sjs)
-	require_NotNil(t, cc)
 
 	ci := &ClientInfo{Account: globalAccountName}
 	rg := &raftGroup{Name: "INFLIGHT_G", Peers: []string{"offline"}, Storage: MemoryStorage}
@@ -7988,8 +8064,8 @@ func TestJetStreamClusterMetaLeaderRespectsInflight(t *testing.T) {
 		Config:  &ConsumerConfig{},
 		Group:   rg,
 	}
-	cc.trackInflightStreamProposal(globalAccountName, sa, false)
-	cc.trackInflightConsumerProposal(globalAccountName, "S", ca, false)
+	sjs.trackInflightStreamProposal(globalAccountName, sa, false)
+	sjs.trackInflightConsumerProposal(globalAccountName, "S", ca, false)
 
 	asa := sjs.streamAssignment(globalAccountName, "S")
 	isa := sjs.streamAssignmentOrInflight(globalAccountName, "S")

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -6397,6 +6397,148 @@ func TestJetStreamClusterMaxHAAssetsRebuildAfterLeaderChange(t *testing.T) {
 	})
 }
 
+func TestJetStreamClusterMaxHAAssetsScaleUpConsumerRideAlong(t *testing.T) {
+	const maxAssets = 2
+	tmpl := strings.Replace(jsClusterTempl, "store_dir:", fmt.Sprintf("limits: {max_ha_assets: %d}, store_dir:", maxAssets), 1)
+	c := createJetStreamClusterWithTemplateAndModHook(t, tmpl, "R3S", 3, nil)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// Snapshot of the meta leader's authoritative per-peer HA asset counts.
+	peerHAAssets := func() map[string]int {
+		sjs := c.leader().getJetStream()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		m := make(map[string]int, len(sjs.cluster.peerHAAssets))
+		for k, v := range sjs.cluster.peerHAAssets {
+			m[k] = v
+		}
+		return m
+	}
+
+	// An R1 stream with two durable consumers. Nothing is HA yet, so the meta
+	// leader tracks no HA assets.
+	cfg := &nats.StreamConfig{Name: "S", Subjects: []string{"s"}, Replicas: 1}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+	for _, d := range []string{"C1", "C2"} {
+		_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: d, AckPolicy: nats.AckExplicitPolicy})
+		require_NoError(t, err)
+	}
+	require_Len(t, len(peerHAAssets()), 0)
+
+	// Scaling to R3 would place the stream plus both consumers (3 HA assets) on
+	// every peer, exceeding max_ha_assets=2. The update must be rejected up-front
+	// (insufficient resources, not "no suitable peers") and leave no accounting.
+	cfg.Replicas = 3
+	_, err = js.UpdateStream(cfg)
+	require_Error(t, err)
+	require_True(t, strings.Contains(err.Error(), "insufficient resources"))
+	require_Len(t, len(peerHAAssets()), 0)
+
+	// Dropping one consumer brings the post-scale footprint to exactly the limit
+	// (stream + one consumer = 2 per peer), so the same scale-up now succeeds.
+	require_NoError(t, js.DeleteConsumer("S", "C2"))
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+	ha := peerHAAssets()
+	require_Len(t, len(ha), 3)
+	for _, n := range ha {
+		require_Equal(t, n, 2)
+	}
+}
+
+func TestJetStreamClusterMaxHAAssetsProcessAddPeerIgnoresLimit(t *testing.T) {
+	c := createJetStreamClusterWithTemplate(t, jsClusterTempl, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// R3 stream with two durable consumers: 3 HA assets on each of the 3 peers.
+	_, err := js.AddStream(&nats.StreamConfig{Name: "S", Subjects: []string{"s"}, Replicas: 3})
+	require_NoError(t, err)
+	for _, d := range []string{"C1", "C2"} {
+		_, err = js.AddConsumer("S", &nats.ConsumerConfig{Durable: d, AckPolicy: nats.AckExplicitPolicy})
+		require_NoError(t, err)
+	}
+	nc.Close()
+
+	// Lower max_ha_assets to 2 on disk and restart, so each existing peer already
+	// holds more HA assets (3) than the new limit allows.
+	c.stopAll()
+	for _, o := range c.opts {
+		b, err := os.ReadFile(o.ConfigFile)
+		require_NoError(t, err)
+		newCfg := strings.Replace(string(b), "store_dir:", "limits: {max_ha_assets: 2}, store_dir:", 1)
+		require_True(t, strings.Contains(newCfg, "max_ha_assets: 2"))
+		require_NoError(t, os.WriteFile(o.ConfigFile, []byte(newCfg), defaultFilePerms))
+	}
+	c.restartAll()
+	c.waitOnClusterReady()
+	c.waitOnStreamLeader(globalAccountName, "S")
+
+	// Pick a stream replica that is neither the stream nor meta leader, then remove
+	// it so S becomes under-replicated (R2) with no spare peer to refill it.
+	nc, js = jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+	si, err := js.StreamInfo("S")
+	require_NoError(t, err)
+	require_True(t, si.Cluster != nil && len(si.Cluster.Replicas) >= 1)
+
+	ml := c.leader()
+	var toRemove string
+	for _, r := range si.Cluster.Replicas {
+		if r.Name != si.Cluster.Leader && r.Name != ml.Name() {
+			toRemove = r.Name
+			break
+		}
+	}
+	require_NotEqual(t, toRemove, _EMPTY_)
+
+	snc, err := nats.Connect(ml.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer snc.Close()
+	jsreq, err := json.Marshal(&JSApiMetaServerRemoveRequest{Server: toRemove})
+	require_NoError(t, err)
+	rmsg, err := snc.Request(JSApiRemoveServer, jsreq, 5*time.Second)
+	require_NoError(t, err)
+	var rresp JSApiMetaServerRemoveResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &rresp))
+	require_True(t, rresp.Error == nil)
+	c.waitOnPeerCount(2)
+
+	// Add a fresh server. processAddPeer is a system-level command that intentionally
+	// ignores max_ha_assets, so it refills the under-replicated stream onto the new peer
+	// even though S plus its two consumers (3 HA assets) exceed the max_ha_assets=2 limit.
+	rs := c.addInNewServer()
+	c.waitOnServerCurrent(rs)
+	c.waitOnPeerCount(3)
+
+	// S must be brought back up to R3 onto the new peer despite the limit.
+	checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
+		si, err := js.StreamInfo("S")
+		if err != nil {
+			return err
+		}
+		if replicas := len(si.Cluster.Replicas) + 1; replicas != 3 {
+			return fmt.Errorf("expected S to be refilled to R3, got R%d", replicas)
+		}
+		for _, r := range si.Cluster.Replicas {
+			if r.Name == rs.Name() {
+				return nil
+			}
+		}
+		if si.Cluster.Leader == rs.Name() {
+			return nil
+		}
+		return fmt.Errorf("expected new peer %s to be added to S, got leader %q replicas %v",
+			rs.Name(), si.Cluster.Leader, si.Cluster.Replicas)
+	})
+}
+
 func TestJetStreamClusterTrackInflightHAAssetAccounting(t *testing.T) {
 	const n1, n2, n3, n4 = "n1", "n2", "n3", "n4"
 

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -6308,72 +6308,301 @@ func TestJetStreamClusterParallelCreateRaftGroupHighConcurrency(t *testing.T) {
 	require_False(t, sentinelLeft)
 }
 
-func TestJetStreamClusterParallelCreateRaftGroupHAAssetsLimit(t *testing.T) {
+func TestJetStreamClusterParallelCreateMaxHAAssetsLimit(t *testing.T) {
 	const maxAssets = 2
 	tmpl := strings.Replace(jsClusterTempl, "store_dir:", fmt.Sprintf("limits: {max_ha_assets: %d}, store_dir:", maxAssets), 1)
 	c := createJetStreamClusterWithTemplateAndModHook(t, tmpl, "R3S", 3, nil)
 	defer c.shutdown()
 
-	ml := c.leader()
-	sjs := ml.getJetStream()
-	cc := sjs.cluster
-	require_NotNil(t, cc)
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
 
-	acc, err := ml.lookupAccount(globalAccountName)
-	require_NoError(t, err)
-
-	metaPeers := cc.meta.Peers()
-	require_Len(t, len(metaPeers), 3)
-	peers := make([]string, 0, len(metaPeers))
-	for _, p := range metaPeers {
-		peers = append(peers, p.ID)
-	}
-
+	// Fire off many concurrent R3 stream creates. Each R3 stream consumes a HA
+	// asset slot on all three peers, so at most maxAssets of them can be placed.
+	// The meta leader must enforce this authoritatively (accounting for inflight
+	// proposals), so concurrent requests cannot overshoot the limit.
 	const N = 8
 	var (
-		ready sync.WaitGroup
-		start = make(chan struct{})
-		done  sync.WaitGroup
-		mu    sync.Mutex
-		nodes []RaftNode
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		success int
 	)
-	ready.Add(N)
-	done.Add(N)
+	wg.Add(N)
 	for i := range N {
-		rg := &raftGroup{
-			Name:    fmt.Sprintf("RG-%d", i),
-			Storage: FileStorage,
-			Peers:   slices.Clone(peers),
-			Cluster: "R3S",
-		}
-		go func() {
-			defer done.Done()
-			ready.Done()
-			<-start
-			n, _ := sjs.createRaftGroup(acc.GetName(), rg, false, FileStorage, pprofLabels{})
-			if n != nil {
+		go func(i int) {
+			defer wg.Done()
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     fmt.Sprintf("S-%d", i),
+				Replicas: 3,
+			})
+			if err == nil {
 				mu.Lock()
-				nodes = append(nodes, n)
+				success++
 				mu.Unlock()
 			}
-		}()
+		}(i)
 	}
-	ready.Wait()
-	close(start)
-	done.Wait()
+	wg.Wait()
 
-	defer func() {
-		mu.Lock()
-		defer mu.Unlock()
-		for _, n := range nodes {
-			n.Stop()
+	// Exactly maxAssets streams should have been created; the rest rejected.
+	require_Equal(t, success, maxAssets)
+
+	// The meta leader's authoritative per-peer counts must not exceed the limit.
+	ml := c.leader()
+	sjs := ml.getJetStream()
+	sjs.mu.Lock()
+	defer sjs.mu.Unlock()
+	for _, n := range sjs.cluster.peerHAAssets {
+		require_True(t, n <= maxAssets)
+	}
+}
+
+func TestJetStreamClusterMaxHAAssetsRebuildAfterLeaderChange(t *testing.T) {
+	const maxAssets = 2
+	tmpl := strings.Replace(jsClusterTempl, "store_dir:", fmt.Sprintf("limits: {max_ha_assets: %d}, store_dir:", maxAssets), 1)
+	c := createJetStreamClusterWithTemplateAndModHook(t, tmpl, "R3S", 3, nil)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// Fill every peer to the limit with two R3 streams.
+	for _, name := range []string{"S1", "S2"} {
+		_, err := js.AddStream(&nats.StreamConfig{Name: name, Replicas: 3})
+		require_NoError(t, err)
+	}
+
+	// Force a meta leadership change. The new leader must rebuild its per-peer HA
+	// asset counts from applied state and keep enforcing the limit.
+	require_NoError(t, c.leader().getJetStream().getMetaGroup().StepDown())
+	c.waitOnLeader()
+
+	// A third R3 stream must still be rejected by the new leader.
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		_, err := js.AddStream(&nats.StreamConfig{Name: "S3", Replicas: 3})
+		if err == nil {
+			return fmt.Errorf("expected S3 to be rejected, but it was created")
 		}
-	}()
+		if !strings.Contains(err.Error(), "no suitable peers for placement") {
+			return err
+		}
+		return nil
+	})
 
-	mu.Lock()
-	got := len(nodes)
-	mu.Unlock()
-	require_True(t, got <= maxAssets)
+	// Freeing a slot lets a new R3 stream be placed again.
+	require_NoError(t, js.DeleteStream("S1"))
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		_, err := js.AddStream(&nats.StreamConfig{Name: "S3", Replicas: 3})
+		return err
+	})
+}
+
+func TestJetStreamClusterTrackInflightHAAssetAccounting(t *testing.T) {
+	const n1, n2, n3, n4 = "n1", "n2", "n3", "n4"
+
+	type op struct {
+		consumer bool
+		stream   string
+		name     string // consumer name, when consumer is true
+		replicas int    // configured replicas (0 == inherit from stream for a durable consumer)
+		peers    []string
+		deleted  bool
+	}
+	str := func(name string, replicas int, peers ...string) op {
+		return op{stream: name, replicas: replicas, peers: peers}
+	}
+	strDel := func(name string, replicas int, peers ...string) op {
+		return op{stream: name, replicas: replicas, peers: peers, deleted: true}
+	}
+	con := func(stream, name string, replicas int, peers ...string) op {
+		return op{consumer: true, stream: stream, name: name, replicas: replicas, peers: peers}
+	}
+	conDel := func(stream, name string, replicas int, peers ...string) op {
+		return op{consumer: true, stream: stream, name: name, replicas: replicas, peers: peers, deleted: true}
+	}
+
+	for _, test := range []struct {
+		name string
+		ops  []op
+		want map[string]int
+	}{
+		{
+			name: "R1 stream",
+			ops:  []op{str("S", 1, n1)},
+			want: map[string]int{},
+		},
+		{
+			name: "R1 stream with inherited consumer",
+			ops: []op{
+				str("S", 1, n1, n2, n3),
+				con("S", "C", 0, n1, n2, n3),
+			},
+			want: map[string]int{},
+		},
+		{
+			name: "R3 stream",
+			ops:  []op{str("S", 3, n1, n2, n3)},
+			want: map[string]int{n1: 1, n2: 1, n3: 1}, // stream on each peer
+		},
+		{
+			name: "R3 stream with inherited consumer",
+			ops: []op{
+				str("S", 3, n1, n2, n3),
+				con("S", "C", 0, n1, n2, n3),
+			},
+			want: map[string]int{n1: 2, n2: 2, n3: 2}, // stream + consumer on each peer
+		},
+		{
+			name: "R3 stream with inherited consumer delete",
+			ops: []op{
+				str("S", 3, n1, n2, n3),
+				con("S", "C", 0, n1, n2, n3),
+				conDel("S", "C", 0, n1, n2, n3),
+			},
+			want: map[string]int{n1: 1, n2: 1, n3: 1}, // stream on each peer
+		},
+		{
+			name: "R1 to R3 stream",
+			ops: []op{
+				str("S", 1, n1),
+				con("S", "C", 0, n1), // inherits R1, not HA yet
+				str("S", 3, n1, n2, n3),
+				con("S", "C", 0, n1, n2, n3), // consumer grows to match
+			},
+			want: map[string]int{n1: 2, n2: 2, n3: 2},
+		},
+		{
+			name: "R3 to R1 stream",
+			ops: []op{
+				str("S", 3, n1, n2, n3),
+				con("S", "C", 0, n1, n2, n3),
+				str("S", 1, n1), // stream scaled down; consumer now inherits R1, no longer HA
+				conDel("S", "C", 0, n1),
+				strDel("S", 1, n1),
+			},
+			want: map[string]int{},
+		},
+		{
+			name: "R3 stream delete",
+			ops: []op{
+				str("S", 3, n1, n2, n3),
+				con("S", "C", 3, n1, n2, n3), // explicit R3 consumer, never explicitly deleted
+				strDel("S", 3, n1, n2, n3),
+			},
+			want: map[string]int{},
+		},
+		{
+			name: "R3 stream with explicit R1 consumer",
+			ops: []op{
+				str("S", 3, n1, n2, n3),
+				con("S", "C", 1, n1),
+				conDel("S", "C", 1, n1),
+			},
+			want: map[string]int{n1: 1, n2: 1, n3: 1},
+		},
+		{
+			name: "R3 and R2 streams",
+			ops: []op{
+				str("A", 3, n1, n2, n3),
+				str("B", 2, n1, n2),
+			},
+			want: map[string]int{n1: 2, n2: 2, n3: 1},
+		},
+		{
+			name: "R3 and R2 streams with delete",
+			ops: []op{
+				str("A", 3, n1, n2, n3),
+				str("B", 2, n1, n2),
+				strDel("A", 3, n1, n2, n3),
+			},
+			want: map[string]int{n1: 1, n2: 1},
+		},
+		{
+			name: "R3 stream repeated",
+			ops: []op{
+				str("S", 3, n1, n2, n3),
+				str("S", 3, n1, n2, n3),
+			},
+			want: map[string]int{n1: 1, n2: 1, n3: 1},
+		},
+		{
+			name: "R3 consumer repeated",
+			ops: []op{
+				str("S", 3, n1, n2, n3),
+				con("S", "C", 0, n1, n2, n3),
+				con("S", "C", 0, n1, n2, n3),
+			},
+			want: map[string]int{n1: 2, n2: 2, n3: 2},
+		},
+		{
+			name: "R3 stream peer replacement",
+			ops: []op{
+				str("S", 3, n1, n2, n3),
+				str("S", 3, n1, n2, n4),
+			},
+			want: map[string]int{n1: 1, n2: 1, n4: 1}, // n3 dropped, n4 added
+		},
+		{
+			name: "R3 consumer peer replacement",
+			ops: []op{
+				str("S", 4, n1, n2, n3, n4),
+				con("S", "C", 3, n1, n2, n3),
+				con("S", "C", 3, n1, n2, n4),
+			},
+			want: map[string]int{n1: 2, n2: 2, n3: 1, n4: 2}, // consumer's n3 dropped for n4
+		},
+		{
+			name: "R2 to R3 stream with consumer untouched",
+			ops: []op{
+				str("S", 2, n1, n2),
+				con("S", "C", 2, n1, n2),
+				str("S", 3, n1, n2, n3), // stream R changes, but consumer stays R2
+			},
+			want: map[string]int{n1: 2, n2: 2, n3: 1},
+		},
+		{
+			name: "R3 stream delete with multiple consumers",
+			ops: []op{
+				str("S", 3, n1, n2, n3),
+				con("S", "C1", 0, n1, n2, n3),
+				con("S", "C2", 0, n1, n2, n3),
+				strDel("S", 3, n1, n2, n3),
+			},
+			want: map[string]int{},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			js := &jetStream{cluster: &jetStreamCluster{peerHAAssets: map[string]int{}}}
+			cc := js.cluster
+
+			for _, o := range test.ops {
+				if o.consumer {
+					ca := &consumerAssignment{
+						Name:   o.name,
+						Stream: o.stream,
+						Config: &ConsumerConfig{Durable: o.name, Replicas: o.replicas},
+						Group:  &raftGroup{Name: o.name, Peers: o.peers},
+					}
+					js.trackInflightConsumerProposal(globalAccountName, o.stream, ca, o.deleted)
+				} else {
+					sa := &streamAssignment{
+						Config: &StreamConfig{Name: o.stream, Replicas: o.replicas},
+						Group:  &raftGroup{Name: o.stream, Peers: o.peers},
+					}
+					js.trackInflightStreamProposal(globalAccountName, sa, o.deleted)
+				}
+			}
+			// Invariant: only positive counts are ever retained (decrements clamp to deletion).
+			for peer, n := range cc.peerHAAssets {
+				require_True(t, n > 0)
+				require_NotEqual(t, peer, _EMPTY_)
+			}
+			require_Len(t, len(cc.peerHAAssets), len(test.want))
+			for peer, n := range test.want {
+				require_Equal(t, cc.peerHAAssets[peer], n)
+			}
+		})
+	}
 }
 
 func TestJetStreamClusterSubjectDeleteMarkersMinimumTTL(t *testing.T) {

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -6685,6 +6685,29 @@ func TestJetStreamClusterTrackInflightHAAssetAccounting(t *testing.T) {
 			want: map[string]int{n1: 1, n2: 1, n4: 1}, // n3 dropped, n4 added
 		},
 		{
+			name: "R3 stream move",
+			ops: []op{
+				str("S", 3, n1, n2, n3),
+				str("S", 3, n1, n2, n3, n4),
+			},
+			want: map[string]int{n2: 1, n3: 1, n4: 1}, // Only the final peers are counted.
+		},
+		{
+			name: "R3 consumer move",
+			ops: []op{
+				str("S", 3, n1, n2, n3, n4),
+				con("S", "C", 0, n1, n2, n3, n4),
+			},
+			want: map[string]int{n2: 2, n3: 2, n4: 2}, // Only the final peers are counted.
+		},
+		{
+			name: "R3 stream under-replicated",
+			ops: []op{
+				str("S", 3, n1, n2),
+			},
+			want: map[string]int{n1: 1, n2: 1},
+		},
+		{
 			name: "R3 consumer peer replacement",
 			ops: []op{
 				str("S", 4, n1, n2, n3, n4),
@@ -6745,6 +6768,36 @@ func TestJetStreamClusterTrackInflightHAAssetAccounting(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestJetStreamClusterGenPeerInfoSplitClamp(t *testing.T) {
+	peers := []string{"a", "b", "c"}
+
+	// In-range split behaves normally: leading=old, trailing=new.
+	newPeers, oldPeers, newSet, oldSet := genPeerInfo(peers, 1)
+	require_Len(t, len(oldPeers), 1)
+	require_Len(t, len(newPeers), 2)
+	require_True(t, oldSet["a"] && newSet["b"] && newSet["c"])
+
+	// Negative split (under-replicated / not-yet-expanded group): clamped to 0,
+	// so there are no old peers and every peer is new.
+	newPeers, oldPeers, newSet, oldSet = genPeerInfo(peers, -2)
+	require_Len(t, len(oldPeers), 0)
+	require_Len(t, len(newPeers), 3)
+	require_Len(t, len(oldSet), 0)
+	require_Len(t, len(newSet), 3)
+
+	// Split beyond len: clamped to len, so every peer is old and none are new.
+	newPeers, oldPeers, newSet, oldSet = genPeerInfo(peers, 5)
+	require_Len(t, len(oldPeers), 3)
+	require_Len(t, len(newPeers), 0)
+	require_Len(t, len(oldSet), 3)
+	require_Len(t, len(newSet), 0)
+
+	// Empty peers with a negative split must not panic.
+	newPeers, oldPeers, _, _ = genPeerInfo(nil, -1)
+	require_Len(t, len(oldPeers), 0)
+	require_Len(t, len(newPeers), 0)
 }
 
 func TestJetStreamClusterTrackInflightAssignmentVisibility(t *testing.T) {

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -6605,6 +6605,194 @@ func TestJetStreamClusterTrackInflightHAAssetAccounting(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterTrackInflightAssignmentVisibility(t *testing.T) {
+	type op struct {
+		consumer bool
+		stream   string
+		name     string // consumer name, when consumer is true
+		deleted  bool
+	}
+	str := func(name string) op {
+		return op{stream: name}
+	}
+	strDel := func(name string) op {
+		return op{stream: name, deleted: true}
+	}
+	con := func(stream, name string) op {
+		return op{consumer: true, stream: stream, name: name}
+	}
+	conDel := func(stream, name string) op {
+		return op{consumer: true, stream: stream, name: name, deleted: true}
+	}
+
+	for _, test := range []struct {
+		name string
+		ops  []op
+		// Expected visible streams and, per stream, expected visible consumers.
+		streams   []string
+		consumers map[string][]string
+	}{
+		{
+			name:    "stream visible",
+			ops:     []op{str("S")},
+			streams: []string{"S"},
+		},
+		{
+			// A deleted stream is not returned.
+			name:    "stream deleted",
+			ops:     []op{str("S"), strDel("S")},
+			streams: nil,
+		},
+		{
+			name:      "consumer visible",
+			ops:       []op{str("S"), con("S", "C")},
+			streams:   []string{"S"},
+			consumers: map[string][]string{"S": {"C"}},
+		},
+		{
+			// A deleted consumer is not returned.
+			name:      "consumer deleted",
+			ops:       []op{str("S"), con("S", "C"), conDel("S", "C")},
+			streams:   []string{"S"},
+			consumers: map[string][]string{"S": nil},
+		},
+		{
+			// A consumer for a deleted stream is not returned.
+			name:      "consumer of deleted stream",
+			ops:       []op{str("S"), con("S", "C"), strDel("S")},
+			streams:   nil,
+			consumers: map[string][]string{"S": nil},
+		},
+		{
+			// A non-delete stream update must not hide the stream's consumers.
+			name:      "consumer survives stream update",
+			ops:       []op{str("S"), con("S", "C"), str("S")},
+			streams:   []string{"S"},
+			consumers: map[string][]string{"S": {"C"}},
+		},
+		{
+			// Deleting one stream leaves the other (and its consumer) untouched.
+			name: "delete one of two streams",
+			ops: []op{
+				str("A"), con("A", "CA"),
+				str("B"), con("B", "CB"),
+				strDel("A"),
+			},
+			streams:   []string{"B"},
+			consumers: map[string][]string{"A": nil, "B": {"CB"}},
+		},
+		{
+			// Deleting one consumer leaves its sibling on the same stream.
+			name: "delete one of two consumers",
+			ops: []op{
+				str("S"),
+				con("S", "C1"), con("S", "C2"),
+				conDel("S", "C1"),
+			},
+			streams:   []string{"S"},
+			consumers: map[string][]string{"S": {"C2"}},
+		},
+		{
+			// Re-creating a deleted stream restores its consumer's visibility.
+			name:      "stream recreated restores consumer",
+			ops:       []op{str("S"), con("S", "C"), strDel("S"), str("S")},
+			streams:   []string{"S"},
+			consumers: map[string][]string{"S": {"C"}},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			js := &jetStream{cluster: &jetStreamCluster{peerHAAssets: map[string]int{}}}
+
+			// Collect the universe of names mentioned, so we can also assert that
+			// the ones that should be gone are not returned.
+			allStreams := map[string]struct{}{}
+			allConsumers := map[string]map[string]struct{}{}
+			for _, o := range test.ops {
+				allStreams[o.stream] = struct{}{}
+				if o.consumer {
+					if allConsumers[o.stream] == nil {
+						allConsumers[o.stream] = map[string]struct{}{}
+					}
+					allConsumers[o.stream][o.name] = struct{}{}
+				}
+			}
+
+			for _, o := range test.ops {
+				if o.consumer {
+					ca := &consumerAssignment{
+						Name:   o.name,
+						Stream: o.stream,
+						Config: &ConsumerConfig{Durable: o.name},
+						Group:  &raftGroup{Name: o.name},
+					}
+					js.trackInflightConsumerProposal(globalAccountName, o.stream, ca, o.deleted)
+				} else {
+					sa := &streamAssignment{
+						Config: &StreamConfig{Name: o.stream},
+						Group:  &raftGroup{Name: o.stream},
+					}
+					js.trackInflightStreamProposal(globalAccountName, sa, o.deleted)
+				}
+			}
+
+			wantStreams := map[string]struct{}{}
+			for _, s := range test.streams {
+				wantStreams[s] = struct{}{}
+			}
+
+			// Single-stream lookups for every stream ever mentioned.
+			for s := range allStreams {
+				_, visible := wantStreams[s]
+				require_Equal(t, js.streamAssignmentOrInflight(globalAccountName, s) != nil, visible)
+			}
+
+			// Per-account stream iterator.
+			gotStreams := map[string]struct{}{}
+			for sa := range js.streamAssignmentsOrInflightSeq(globalAccountName) {
+				gotStreams[sa.Config.Name] = struct{}{}
+			}
+			require_Len(t, len(gotStreams), len(wantStreams))
+			for s := range wantStreams {
+				_, ok := gotStreams[s]
+				require_True(t, ok)
+			}
+
+			// All-accounts stream iterator.
+			gotAll := map[string]struct{}{}
+			for accName, sa := range js.streamAssignmentsOrInflightSeqAllAccounts() {
+				require_Equal(t, accName, globalAccountName)
+				gotAll[sa.Config.Name] = struct{}{}
+			}
+			require_Len(t, len(gotAll), len(wantStreams))
+			for s := range wantStreams {
+				_, ok := gotAll[s]
+				require_True(t, ok)
+			}
+
+			// Consumer lookups for every (stream, consumer) ever mentioned.
+			for s, cs := range allConsumers {
+				wantConsumers := map[string]struct{}{}
+				for _, c := range test.consumers[s] {
+					wantConsumers[c] = struct{}{}
+				}
+				for c := range cs {
+					_, visible := wantConsumers[c]
+					require_Equal(t, js.consumerAssignmentOrInflight(globalAccountName, s, c) != nil, visible)
+				}
+				gotConsumers := map[string]struct{}{}
+				for ca := range js.consumerAssignmentsOrInflightSeq(globalAccountName, s) {
+					gotConsumers[ca.Name] = struct{}{}
+				}
+				require_Len(t, len(gotConsumers), len(wantConsumers))
+				for c := range wantConsumers {
+					_, ok := gotConsumers[c]
+					require_True(t, ok)
+				}
+			}
+		})
+	}
+}
+
 func TestJetStreamClusterSubjectDeleteMarkersMinimumTTL(t *testing.T) {
 	for _, storageType := range []StorageType{FileStorage, MemoryStorage} {
 		for _, replicas := range []int{1, 3} {

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -3948,6 +3948,197 @@ func TestJetStreamSuperClusterPeerEvacuationAndStreamReassignment(t *testing.T) 
 	})
 }
 
+func TestJetStreamSuperClusterR1MoveAcrossClustersWithMaxHAAssets(t *testing.T) {
+	// Use a config with max_ha_assets set to 1 cluster-wide.
+	tmpl := strings.Replace(jsClusterTempl, "store_dir:", "limits: {max_ha_assets: 1}, store_dir:", 1)
+	s := createJetStreamSuperClusterWithTemplateAndModHook(t, tmpl, 3, 2,
+		func(serverName, clusterName, storeDir, conf string) string {
+			return fmt.Sprintf("%s\nserver_tags: [cluster:%s, server:%s]", conf, clusterName, serverName)
+		}, nil)
+	defer s.shutdown()
+
+	c := s.clusterForName("C1")
+	srv := c.randomNonLeader()
+	nc, js := jsClientConnect(t, srv)
+	defer nc.Close()
+
+	// R1 stream in C1 with a durable consumer (inherits R1) and some data.
+	cfg := &nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 1,
+	}
+	si, err := js.AddStream(cfg)
+	require_NoError(t, err)
+	require_Equal(t, si.Cluster.Name, "C1")
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Durable: "DUR", AckPolicy: nats.AckExplicitPolicy})
+	require_NoError(t, err)
+
+	const numMsgs = 100
+	for range numMsgs {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+
+	// Move the stream (and its consumer) to C2. Must succeed despite max_ha_assets: 1.
+	cfg.Placement = &nats.Placement{Tags: []string{"cluster:C2"}}
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+
+	// Wait until the stream has fully migrated to C2, still R1, with data intact.
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("TEST", nats.MaxWait(time.Second))
+		if err != nil {
+			return fmt.Errorf("could not fetch stream info: %v", err)
+		}
+		if si.Cluster == nil || si.Cluster.Name != "C2" {
+			return fmt.Errorf("stream not in C2 yet: %+v", si.Cluster)
+		}
+		if si.Cluster.Leader == _EMPTY_ {
+			return fmt.Errorf("no leader yet")
+		}
+		if len(si.Cluster.Replicas) != 0 {
+			return fmt.Errorf("expected R1, still has %d replicas", len(si.Cluster.Replicas))
+		}
+		if si.Config.Replicas != 1 {
+			return fmt.Errorf("bad replica count %d", si.Config.Replicas)
+		}
+		if si.State.Msgs != numMsgs {
+			return fmt.Errorf("expected %d msgs, got %d", numMsgs, si.State.Msgs)
+		}
+		return nil
+	})
+
+	// The consumer must have moved along with the stream and still be usable.
+	ci, err := js.ConsumerInfo("TEST", "DUR")
+	require_NoError(t, err)
+	require_Equal(t, ci.Cluster.Name, "C2")
+
+	sub, err := js.PullSubscribe("foo", "DUR")
+	require_NoError(t, err)
+	msgs, err := sub.Fetch(numMsgs, nats.MaxWait(time.Second))
+	require_NoError(t, err)
+	require_Equal(t, len(msgs), numMsgs)
+
+	// The R1 stream + consumer must never have consumed any HA asset budget on the
+	// meta leader's authoritative accounting.
+	ml := s.leader()
+	require_NotNil(t, ml)
+	sjs := ml.getJetStream()
+	sjs.mu.RLock()
+	defer sjs.mu.RUnlock()
+	require_Equal(t, len(sjs.cluster.peerHAAssets), 0)
+}
+
+func TestJetStreamSuperClusterR1MoveIntoSaturatedClusterWithMaxHAAssets(t *testing.T) {
+	// Use a config with max_ha_assets set to 1 cluster-wide.
+	tmpl := strings.Replace(jsClusterTempl, "store_dir:", "limits: {max_ha_assets: 1}, store_dir:", 1)
+	s := createJetStreamSuperClusterWithTemplateAndModHook(t, tmpl, 3, 2,
+		func(serverName, clusterName, storeDir, conf string) string {
+			return fmt.Sprintf("%s\nserver_tags: [cluster:%s, server:%s]", conf, clusterName, serverName)
+		}, nil)
+	defer s.shutdown()
+
+	c := s.clusterForName("C1")
+	srv := c.randomNonLeader()
+	nc, js := jsClientConnect(t, srv)
+	defer nc.Close()
+
+	// Saturate every C2 peer: one R3 stream pinned to C2 puts an HA asset on all
+	// three C2 peers, so each is now at the max_ha_assets: 1 limit.
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "HA",
+		Subjects:  []string{"ha"},
+		Replicas:  3,
+		Placement: &nats.Placement{Tags: []string{"cluster:C2"}},
+	})
+	require_NoError(t, err)
+
+	// A second HA asset in C2 must be rejected: confirms C2 is truly saturated and
+	// that genuine HA assets are still limited.
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:      "HA2",
+		Subjects:  []string{"ha2"},
+		Replicas:  3,
+		Placement: &nats.Placement{Tags: []string{"cluster:C2"}},
+	})
+	require_Error(t, err)
+
+	// R1 stream in C1 (empty cluster, so it lands there) with a durable consumer
+	// (inherits R1) and some data.
+	cfg := &nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 1,
+	}
+	si, err := js.AddStream(cfg)
+	require_NoError(t, err)
+	require_Equal(t, si.Cluster.Name, "C1")
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Durable: "DUR", AckPolicy: nats.AckExplicitPolicy})
+	require_NoError(t, err)
+
+	const numMsgs = 100
+	for range numMsgs {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+
+	// Move the R1 stream into the saturated C2. With R1 exempt from the HA limit,
+	// this must succeed even though every C2 peer is already at max_ha_assets.
+	cfg.Placement = &nats.Placement{Tags: []string{"cluster:C2"}}
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+
+	// Wait until TEST has fully migrated to C2, still R1, with data intact.
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("TEST", nats.MaxWait(time.Second))
+		if err != nil {
+			return fmt.Errorf("could not fetch stream info: %v", err)
+		}
+		if si.Cluster == nil || si.Cluster.Name != "C2" {
+			return fmt.Errorf("stream not in C2 yet: %+v", si.Cluster)
+		}
+		if si.Cluster.Leader == _EMPTY_ {
+			return fmt.Errorf("no leader yet")
+		}
+		if len(si.Cluster.Replicas) != 0 {
+			return fmt.Errorf("expected R1, still has %d replicas", len(si.Cluster.Replicas))
+		}
+		if si.Config.Replicas != 1 {
+			return fmt.Errorf("bad replica count %d", si.Config.Replicas)
+		}
+		if si.State.Msgs != numMsgs {
+			return fmt.Errorf("expected %d msgs, got %d", numMsgs, si.State.Msgs)
+		}
+		return nil
+	})
+
+	// Consumer moved with the stream and is still usable.
+	ci, err := js.ConsumerInfo("TEST", "DUR")
+	require_NoError(t, err)
+	require_Equal(t, ci.Cluster.Name, "C2")
+
+	sub, err := js.PullSubscribe("foo", "DUR")
+	require_NoError(t, err)
+	msgs, err := sub.Fetch(numMsgs, nats.MaxWait(10*time.Second))
+	require_NoError(t, err)
+	require_Equal(t, len(msgs), numMsgs)
+
+	// The saturated HA stream is untouched, and the R1 move added no HA budget:
+	// exactly the 3 C2 peers of HA are counted, each still at the limit of 1.
+	ml := s.leader()
+	require_NotNil(t, ml)
+	sjs := ml.getJetStream()
+	sjs.mu.RLock()
+	defer sjs.mu.RUnlock()
+	require_Equal(t, len(sjs.cluster.peerHAAssets), 3)
+	for _, n := range sjs.cluster.peerHAAssets {
+		require_Equal(t, n, 1)
+	}
+}
+
 func TestJetStreamSuperClusterMirrorInheritsAllowDirect(t *testing.T) {
 	sc := createJetStreamTaggedSuperCluster(t)
 	defer sc.shutdown()

--- a/server/opts.go
+++ b/server/opts.go
@@ -360,7 +360,7 @@ func generateRemoteLeafOptsName(r *RemoteLeafOpts, redacted bool) string {
 type JSLimitOpts struct {
 	MaxRequestBatch           int           `json:"max_request_batch,omitempty"`             // MaxRequestBatch is the maximum amount of updates that can be sent in a batch
 	MaxAckPending             int           `json:"max_ack_pending,omitempty"`               // MaxAckPending is the server limit for maximum amount of outstanding Acks
-	MaxHAAssets               int           `json:"max_ha_assets,omitempty"`                 // MaxHAAssets is the maximum of Streams and Consumers that may have more than 1 replica
+	MaxHAAssets               int           `json:"max_ha_assets,omitempty"`                 // MaxHAAssets is the maximum number of Streams and Consumers that may have more than 1 replica, per server, enforced by the meta leader.
 	Duplicates                time.Duration `json:"max_duplicate_window,omitempty"`          // Duplicates is the maximum value for duplicate tracking on Streams
 	MaxBatchInflightPerStream int           `json:"max_batch_inflight_per_stream,omitempty"` // MaxBatchInflightPerStream is the maximum amount of open batches per stream
 	MaxBatchInflightTotal     int           `json:"max_batch_inflight_total,omitempty"`      // MaxBatchInflightTotal is the maximum amount of total open batches per server


### PR DESCRIPTION
Enforcement of `max_ha_assets` relied on each peer's `HAAssets` stat reported asynchronously via statsz, which made enforcement inherently racy. Followers could additionally choose not to start an assigned stream/consumer because they went over the local limit, one of the obvious issues being a server that's configured with a lower `max_ha_assets` value than is possible based on the in-use assets.

This PR fixes these issues by doing the HA asset accounting on the meta leader, aligned with the way that inflight assignment tracking is done. Upon becoming meta leader it calculates the HA assets per-peer, and keeps it up-to-date through its lifetime.

The definition of a "HA asset" is also slightly changed. It used to mean "anything that has a Raft group/node", it now means "a stream or consumer with replicas > 1". This is important when trying to move a stream with its consumers from one cluster to another, since the move requires replication and would hit against the `max_ha_assets` limit if it was too low. Because only `replicas > 1` are now counted as HA, a move from R1 to R1 will always be allowed since the HA-aspect required for the move is only temporary.

However, if nodes are peer-removed or a missing peer for a stream/consumer is backfilled, this intentionally ignores the `max_ha_assets` limit to ease system management and takes it into account on a best-effort basis. When peer-removing a node that is still hosting streams and consumers there is not much choice to either pick a new peer to host it (as we do today) or stall and wait for conditions to change. The latter would make operations significantly harder when at the limit, so it's intentionally ignored. To keep this strict enforcement, it's recommend to move streams and consumers off a node before it's peer-removed, either while it's still alive or when it's already down, but at least based on the stream/consumer update endpoints that do enforce `max_ha_assets`.

Additionally contains some consistency and data race fixes, as well as a missing implementation to enforce `max_ha_assets` when scaling up a stream or backfilling a missing peer.