### PR TITLE
(2.15) [FIXED] Consumer peer set remapping

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8595,7 +8595,7 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 	}
 
 	// Check for subject collisions here.
-	if js.subjectsOverlap(acc.Name, cfg.Subjects, osa) {
+	if js.subjectsOverlap(acc.Name, newCfg.Subjects, osa) {
 		resp.Error = NewJSStreamSubjectOverlapError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return
@@ -8609,7 +8609,7 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		(newMaxAckPending > 0 && oldMaxAckPending != newMaxAckPending)
 	if updateLimits {
 		var errorConsumers []string
-		for ca := range js.consumerAssignmentsOrInflightSeq(acc.Name, cfg.Name) {
+		for ca := range js.consumerAssignmentsOrInflightSeq(acc.Name, newCfg.Name) {
 			if ca.Config == nil {
 				continue
 			}
@@ -8665,7 +8665,7 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		} else {
 			// Need to release js lock.
 			js.mu.Unlock()
-			if si, err := sysRequest[StreamInfo](s, clusterStreamInfoT, ci.serviceAccount(), cfg.Name); err != nil {
+			if si, err := sysRequest[StreamInfo](s, clusterStreamInfoT, ci.serviceAccount(), newCfg.Name); err != nil {
 				msg = fmt.Sprintf("error retrieving info: %s", err.Error())
 			} else if si != nil {
 				currentCount := 0
@@ -8745,8 +8745,8 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 			if !s.allPeersOffline(rg) {
 				// Need to release js lock.
 				js.mu.Unlock()
-				if si, err := sysRequest[StreamInfo](s, clusterStreamInfoT, ci.serviceAccount(), cfg.Name); err != nil {
-					s.Warnf("Did not receive stream info results for '%s > %s' due to: %s", acc, cfg.Name, err)
+				if si, err := sysRequest[StreamInfo](s, clusterStreamInfoT, ci.serviceAccount(), newCfg.Name); err != nil {
+					s.Warnf("Did not receive stream info results for '%s > %s' due to: %s", acc, newCfg.Name, err)
 				} else if si != nil {
 					if cl := si.Cluster; cl != nil && cl.Leader != _EMPTY_ {
 						curLeader = getHash(cl.Leader)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2550,23 +2550,16 @@ func (js *jetStream) processAddPeer(peer string) {
 			csa := sa.copyGroup()
 			csa.Group.Peers = append(csa.Group.Peers, peer)
 			// Send our proposal for this csa. Also use same group definition for all the consumers as well.
+			consumers, _ := js.remapConsumerAssignments(accName, csa, false)
 			if err := cc.meta.Propose(encodeAddStreamAssignment(csa)); err != nil {
 				return
 			}
 			cc.trackInflightStreamProposal(accName, csa, false)
-			for ca := range js.consumerAssignmentsOrInflightSeq(accName, csa.Config.Name) {
-				if ca.unsupported != nil {
-					continue
+			for _, cca := range consumers {
+				if err := cc.meta.Propose(encodeAddConsumerAssignment(cca)); err != nil {
+					return
 				}
-				// Ephemerals are R=1, so only auto-remap durables, or R>1.
-				if ca.Config.Durable != _EMPTY_ || len(ca.Group.Peers) > 1 {
-					cca := ca.copyGroup()
-					cca.Group.Peers = csa.Group.Peers
-					if err := cc.meta.Propose(encodeAddConsumerAssignment(cca)); err != nil {
-						return
-					}
-					cc.trackInflightConsumerProposal(accName, csa.Config.Name, cca, false)
-				}
+				cc.trackInflightConsumerProposal(accName, csa.Config.Name, cca, false)
 			}
 		}
 	}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2649,30 +2649,23 @@ func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer strin
 	}
 
 	// Send our proposal for this csa. Also use same group definition for all the consumers as well.
+	consumers, deleted := js.remapConsumerAssignments(accName, csa, true)
 	if err := cc.meta.Propose(encodeAddStreamAssignment(csa)); err != nil {
 		return false
 	}
 	cc.trackInflightStreamProposal(accName, csa, false)
-	rg := csa.Group
-	for ca := range js.consumerAssignmentsOrInflightSeq(accName, sa.Config.Name) {
-		if ca.unsupported != nil {
-			continue
+	for _, cca := range consumers {
+		if err := cc.meta.Propose(encodeAddConsumerAssignment(cca)); err != nil {
+			return false
 		}
-		// Ephemerals are R=1, so only auto-remap durables, or R>1.
-		if ca.Config.Durable != _EMPTY_ {
-			cca := ca.copyGroup()
-			cca.Group.Peers, cca.Group.Preferred = rg.Peers, _EMPTY_
-			if err := cc.meta.Propose(encodeAddConsumerAssignment(cca)); err != nil {
-				return false
-			}
-			cc.trackInflightConsumerProposal(accName, csa.Config.Name, cca, false)
-		} else if ca.Group.isMember(peer) {
-			// These are ephemerals. Check to see if we deleted this peer.
-			if err := cc.meta.Propose(encodeDeleteConsumerAssignment(ca)); err != nil {
-				return false
-			}
-			cc.trackInflightConsumerProposal(accName, csa.Config.Name, ca, true)
+		cc.trackInflightConsumerProposal(accName, csa.Config.Name, cca, false)
+	}
+	// These are ephemerals that had all of their peers removed.
+	for _, ca := range deleted {
+		if err := cc.meta.Propose(encodeDeleteConsumerAssignment(ca)); err != nil {
+			return false
 		}
+		cc.trackInflightConsumerProposal(accName, csa.Config.Name, ca, true)
 	}
 	return replaced
 }
@@ -7782,9 +7775,7 @@ func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, removePe
 }
 
 // Lock should be held.
-func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignment) []*consumerAssignment {
-	var consumers []*consumerAssignment
-
+func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignment, remove bool) (consumers, deleted []*consumerAssignment) {
 	rg := sa.Group
 	targetPeers := rg.Peers
 	if len(rg.Peers) > sa.Config.Replicas {
@@ -7814,6 +7805,11 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 			} else {
 				keepOld = append(keepOld, p)
 			}
+		}
+		// If an ephemeral lost all of its peers to removal, we delete it rather than move it.
+		if kept == 0 && remove && !isDurableConsumer(ca.Config) {
+			deleted = append(deleted, ca)
+			continue
 		}
 		// Backfill from the shuffled target set until the consumer has its desired number of target peers.
 		if len(tail) < r {
@@ -7854,7 +7850,8 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 			cca.Config.Replicas = r
 		}
 		// Check if all peers are invalid. This can happen with R1 under replicated streams that are being scaled down.
-		if kept == 0 && !js.srv.allPeersOffline(ca.Group) {
+		// If the old peers are being removed we can't ask them for state, so skip the transfer.
+		if kept == 0 && !remove && !js.srv.allPeersOffline(ca.Group) {
 			// We have to transfer state to new peers.
 			// we will grab our state and attach to the new assignment.
 			// TODO(dlc) - In practice we would want to make sure the consumer is paused.
@@ -7880,7 +7877,7 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 		// We can not propose here before the stream itself so we collect them.
 		consumers = append(consumers, cca)
 	}
-	return consumers
+	return consumers, deleted
 }
 
 type selectPeerError struct {
@@ -8796,7 +8793,7 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 
 	// Need to remap any consumers.
 	if isReplicaChange || isMoveRequest || isRetentionChange {
-		consumers = js.remapConsumerAssignments(acc.Name, sa)
+		consumers, _ = js.remapConsumerAssignments(acc.Name, sa, false)
 	}
 
 	if err := meta.Propose(encodeUpdateStreamAssignment(sa)); err != nil {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7781,6 +7781,108 @@ func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, removePe
 	return false
 }
 
+// Lock should be held.
+func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignment) []*consumerAssignment {
+	var consumers []*consumerAssignment
+
+	rg := sa.Group
+	targetPeers := rg.Peers
+	if len(rg.Peers) > sa.Config.Replicas {
+		targetPeers = rg.Peers[len(rg.Peers)-sa.Config.Replicas:]
+	}
+	for ca := range js.consumerAssignmentsOrInflightSeq(accName, sa.Config.Name) {
+		if ca.Config == nil || ca.unsupported != nil {
+			continue
+		}
+		numPeers := len(ca.Group.Peers)
+		// Determine the desired replica count.
+		r := ca.Config.replicas(sa.Config)
+		// If stream is interest or workqueue policy always remaps since they require peer parity with stream.
+		if sa.Config.Retention != LimitsPolicy {
+			r = sa.Config.Replicas
+		}
+		// Drop peers that are no longer part of the stream. If moving, the tail MUST be the new peer set.
+		var keepOld, tail []string
+		kept := 0
+		for _, p := range ca.Group.Peers {
+			if !rg.isMember(p) {
+				continue
+			}
+			kept++
+			if slices.Contains(targetPeers, p) {
+				tail = append(tail, p)
+			} else {
+				keepOld = append(keepOld, p)
+			}
+		}
+		// Backfill from the shuffled target set until the consumer has its desired number of target peers.
+		if len(tail) < r {
+			backfill := copyStrings(targetPeers)
+			rand.Shuffle(len(backfill), func(i, j int) { backfill[i], backfill[j] = backfill[j], backfill[i] })
+			for _, p := range backfill {
+				if len(tail) >= r {
+					break
+				}
+				if !slices.Contains(tail, p) {
+					tail = append(tail, p)
+				}
+			}
+		} else if len(tail) > r {
+			tail = tail[:r]
+		}
+		newPeers := append(keepOld, tail...)
+		// Leave the consumer alone if its peer set is unaffected.
+		if kept == numPeers && len(newPeers) == numPeers {
+			continue
+		}
+		cca := ca.copyGroup()
+		// Adjust preferred as needed.
+		if numPeers == 1 && kept == 1 && len(newPeers) > 1 {
+			// This is scale up from being a singleton, set preferred to that singleton.
+			cca.Group.Preferred = ca.Group.Peers[0]
+		} else {
+			cca.Group.Preferred = _EMPTY_
+		}
+		// Assign new peers.
+		cca.Group.Peers = newPeers
+		// Single nodes are not recorded by the NRG layer so we can rename.
+		if len(newPeers) == 1 || numPeers == 1 {
+			cca.Group.Name = groupNameForConsumer(newPeers, cca.Group.Storage)
+		}
+		// If the replicas was not 0 make sure it matches here.
+		if cca.Config.Replicas != 0 {
+			cca.Config.Replicas = r
+		}
+		// Check if all peers are invalid. This can happen with R1 under replicated streams that are being scaled down.
+		if kept == 0 && !js.srv.allPeersOffline(ca.Group) {
+			// We have to transfer state to new peers.
+			// we will grab our state and attach to the new assignment.
+			// TODO(dlc) - In practice we would want to make sure the consumer is paused.
+			// Need to release js lock.
+			js.mu.Unlock()
+			if ci, err := sysRequest[ConsumerInfo](js.srv, clusterConsumerInfoT, accName, sa.Config.Name, ca.Name); err != nil {
+				js.srv.Warnf("Did not receive consumer info results for '%s > %s > %s' due to: %s", accName, sa.Config.Name, ca.Name, err)
+			} else if ci != nil {
+				cca.State = &ConsumerState{
+					Delivered: SequencePair{
+						Consumer: ci.Delivered.Consumer,
+						Stream:   ci.Delivered.Stream,
+					},
+					AckFloor: SequencePair{
+						Consumer: ci.AckFloor.Consumer,
+						Stream:   ci.AckFloor.Stream,
+					},
+				}
+			}
+			// Re-acquire here.
+			js.mu.Lock()
+		}
+		// We can not propose here before the stream itself so we collect them.
+		consumers = append(consumers, cca)
+	}
+	return consumers
+}
+
 type selectPeerError struct {
 	excludeTag  bool
 	offline     bool
@@ -8548,6 +8650,8 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 
 	// Check for replica changes.
 	isReplicaChange := newCfg.Replicas != osa.Config.Replicas
+	// A retention change might result in consumer replica changes.
+	isRetentionChange := newCfg.Retention != osa.Config.Retention
 
 	// We stage consumer updates and do them after the stream update.
 	var consumers []*consumerAssignment
@@ -8659,93 +8763,6 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 				rg.Name = groupNameForStream(rg.Peers, rg.Storage)
 			}
 		}
-
-		// Need to remap any consumers.
-		for ca := range js.consumerAssignmentsOrInflightSeq(acc.Name, osa.Config.Name) {
-			// Legacy ephemerals are R=1 but present as R=0, so only auto-remap named consumers, or if we are downsizing the consumer peers.
-			// If stream is interest or workqueue policy always remaps since they require peer parity with stream.
-			numPeers := len(ca.Group.Peers)
-			isAutoScale := ca.Config.Replicas == 0 && (ca.Config.Durable != _EMPTY_ || ca.Config.Name != _EMPTY_)
-			if isAutoScale || numPeers > len(rg.Peers) || cfg.Retention != LimitsPolicy {
-				cca := ca.copyGroup()
-				// Adjust preferred as needed.
-				if numPeers == 1 && isScaleUp {
-					cca.Group.Preferred = ca.Group.Peers[0]
-				} else {
-					cca.Group.Preferred = _EMPTY_
-				}
-				// Assign new peers.
-				cca.Group.Peers = rg.Peers
-				// Single nodes are not recorded by the NRG layer so we can rename.
-				if len(cca.Group.Peers) == 1 || numPeers == 1 {
-					cca.Group.Name = groupNameForConsumer(cca.Group.Peers, cca.Group.Storage)
-				}
-				// If the replicas was not 0 make sure it matches here.
-				if cca.Config.Replicas != 0 {
-					cca.Config.Replicas = len(rg.Peers)
-				}
-				// We can not propose here before the stream itself so we collect them.
-				consumers = append(consumers, cca)
-
-			} else if !isScaleUp {
-				// We decided to leave this consumer's peer group alone but we are also scaling down.
-				// We need to make sure we do not have any peers that are no longer part of the stream.
-				// Note we handle down scaling of a consumer above if its number of peers were > new stream peers.
-				var needReplace []string
-				for _, rp := range ca.Group.Peers {
-					// Check if we have an orphaned peer now for this consumer.
-					if !rg.isMember(rp) {
-						needReplace = append(needReplace, rp)
-					}
-				}
-				if len(needReplace) > 0 {
-					newPeers := copyStrings(rg.Peers)
-					rand.Shuffle(len(newPeers), func(i, j int) { newPeers[i], newPeers[j] = newPeers[j], newPeers[i] })
-					// If we had a small size then the peer set, restrict to the same number.
-					if lp := len(ca.Group.Peers); lp < len(newPeers) {
-						newPeers = newPeers[:lp]
-					}
-					cca := ca.copyGroup()
-					// Assign new peers.
-					cca.Group.Peers = newPeers
-					// Single nodes are not recorded by the NRG layer so we can rename.
-					if len(cca.Group.Peers) == 1 || numPeers == 1 {
-						cca.Group.Name = groupNameForConsumer(cca.Group.Peers, cca.Group.Storage)
-					}
-					// If the replicas was not 0 make sure it matches here.
-					if cca.Config.Replicas != 0 {
-						cca.Config.Replicas = len(newPeers)
-					}
-					// Check if all peers are invalid. This can happen with R1 under replicated streams that are being scaled down.
-					if len(needReplace) == len(ca.Group.Peers) {
-						// We have to transfer state to new peers.
-						// we will grab our state and attach to the new assignment.
-						// TODO(dlc) - In practice we would want to make sure the consumer is paused.
-						// Need to release js lock.
-						js.mu.Unlock()
-						if ci, err := sysRequest[ConsumerInfo](s, clusterConsumerInfoT, acc, osa.Config.Name, ca.Name); err != nil {
-							s.Warnf("Did not receive consumer info results for '%s > %s > %s' due to: %s", acc, osa.Config.Name, ca.Name, err)
-						} else if ci != nil {
-							cca.State = &ConsumerState{
-								Delivered: SequencePair{
-									Consumer: ci.Delivered.Consumer,
-									Stream:   ci.Delivered.Stream,
-								},
-								AckFloor: SequencePair{
-									Consumer: ci.AckFloor.Consumer,
-									Stream:   ci.AckFloor.Stream,
-								},
-							}
-						}
-						// Re-acquire here.
-						js.mu.Lock()
-					}
-					// We can not propose here before the stream itself so we collect them.
-					consumers = append(consumers, cca)
-				}
-			}
-		}
-
 	} else if isMoveRequest {
 		if len(peerSet) == 0 {
 			nrg, err := js.createGroupForStream(ci, newCfg)
@@ -8766,45 +8783,6 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 			rg.Preferred = peerSet[0]
 		}
 		rg.Peers = peerSet
-
-		for ca := range js.consumerAssignmentsOrInflightSeq(acc.Name, osa.Config.Name) {
-			cca := ca.copyGroup()
-			r := cca.Config.replicas(osa.Config)
-			// shuffle part of cluster peer set we will be keeping
-			randPeerSet := copyStrings(peerSet[len(peerSet)-newCfg.Replicas:])
-			rand.Shuffle(newCfg.Replicas, func(i, j int) { randPeerSet[i], randPeerSet[j] = randPeerSet[j], randPeerSet[i] })
-			// move overlapping peers at the end of randPeerSet and keep a tally of non overlapping peers
-			dropPeerSet := make([]string, 0, len(cca.Group.Peers))
-			for _, p := range cca.Group.Peers {
-				found := false
-				for i, rp := range randPeerSet {
-					if p == rp {
-						randPeerSet[i] = randPeerSet[newCfg.Replicas-1]
-						randPeerSet[newCfg.Replicas-1] = p
-						found = true
-						break
-					}
-				}
-				if !found {
-					dropPeerSet = append(dropPeerSet, p)
-				}
-			}
-			cPeerSet := randPeerSet[newCfg.Replicas-r:]
-			// In case of a set or cancel simply assign
-			if len(peerSet) == newCfg.Replicas {
-				cca.Group.Peers = cPeerSet
-			} else {
-				cca.Group.Peers = append(dropPeerSet, cPeerSet...)
-			}
-			// make sure it overlaps with peers and remove if not
-			if cca.Group.Preferred != _EMPTY_ {
-				if !slices.Contains(cca.Group.Peers, cca.Group.Preferred) {
-					cca.Group.Preferred = _EMPTY_
-				}
-			}
-			// We can not propose here before the stream itself so we collect them.
-			consumers = append(consumers, cca)
-		}
 	} else {
 		// All other updates make sure no preferred is set.
 		rg.Preferred = _EMPTY_
@@ -8815,6 +8793,12 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		syncSubject = syncSubjForStream()
 	}
 	sa := &streamAssignment{Group: rg, Sync: syncSubject, Created: osa.Created, Config: newCfg, Subject: subject, Reply: reply, Client: ci}
+
+	// Need to remap any consumers.
+	if isReplicaChange || isMoveRequest || isRetentionChange {
+		consumers = js.remapConsumerAssignments(acc.Name, sa)
+	}
+
 	if err := meta.Propose(encodeUpdateStreamAssignment(sa)); err != nil {
 		return
 	}

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -13416,6 +13416,135 @@ func TestJetStreamClusterStreamPeerRemoveEphemeralDeleted(t *testing.T) {
 	})
 }
 
+func TestJetStreamClusterStreamAddPeerConsumerRemap(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	// An R1 durable, its single peer should be left alone when the stream gains a peer.
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "R1",
+		AckPolicy: nats.AckExplicitPolicy,
+		Replicas:  1,
+	})
+	require_NoError(t, err)
+
+	// An R3 durable, it should be scaled back up along with the stream once a new peer comes in.
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "R3",
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	// An ephemeral, it should stay untouched on its own single peer throughout.
+	sub, err := js.SubscribeSync("foo")
+	require_NoError(t, err)
+	defer sub.Unsubscribe()
+	eci, err := sub.ConsumerInfo()
+	require_NoError(t, err)
+	ephemeral, ephemeralPeer := eci.Name, eci.Cluster.Leader
+
+	ci, err := js.ConsumerInfo("TEST", "R1")
+	require_NoError(t, err)
+	require_Len(t, len(ci.Cluster.Replicas), 0)
+	r1Peer := ci.Cluster.Leader
+
+	// Remove a stream peer that hosts neither the R1 durable nor the ephemeral. With only
+	// three servers there is no replacement, which leaves the stream with a missing peer.
+	si, err := js.StreamInfo("TEST")
+	require_NoError(t, err)
+	peers := []string{si.Cluster.Leader}
+	for _, r := range si.Cluster.Replicas {
+		peers = append(peers, r.Name)
+	}
+	var toRemove string
+	for _, p := range peers {
+		if p != r1Peer && p != ephemeralPeer {
+			toRemove = p
+			break
+		}
+	}
+	require_NotEqual(t, toRemove, _EMPTY_)
+
+	b, err := json.Marshal(JSApiStreamRemovePeerRequest{Peer: toRemove})
+	require_NoError(t, err)
+	msg, err := nc.Request(fmt.Sprintf(JSApiStreamRemovePeerT, "TEST"), b, time.Second)
+	require_NoError(t, err)
+	var resp JSApiStreamRemovePeerResponse
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	// The peer could not be replaced, but it is still removed from the stream.
+	require_False(t, resp.Success)
+	require_Error(t, resp.Error, NewJSPeerRemapError())
+
+	checkStreamPeers := func(replicas int) {
+		t.Helper()
+		checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+			si, err := js.StreamInfo("TEST", nats.MaxWait(time.Second))
+			if err != nil {
+				return err
+			}
+			if si.Cluster == nil || si.Cluster.Leader == _EMPTY_ {
+				return fmt.Errorf("no stream leader yet")
+			}
+			if len(si.Cluster.Replicas) != replicas {
+				return fmt.Errorf("expected %d replicas, got %d", replicas, len(si.Cluster.Replicas))
+			}
+			if si.Cluster.Leader == toRemove {
+				return fmt.Errorf("removed peer still stream leader")
+			}
+			for _, r := range si.Cluster.Replicas {
+				if r.Name == toRemove {
+					return fmt.Errorf("removed peer still in stream peer set")
+				}
+			}
+			return nil
+		})
+	}
+	checkStreamPeers(1)
+
+	// Now add in a new server, the stream should get its missing peer backfilled.
+	c.addInNewServer()
+	c.waitOnPeerCount(4)
+	checkStreamPeers(2)
+
+	// The R3 durable should scale back up to the full stream peer set.
+	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+		ci, err := js.ConsumerInfo("TEST", "R3", nats.MaxWait(time.Second))
+		if err != nil {
+			return err
+		}
+		if ci.Cluster == nil || ci.Cluster.Leader == _EMPTY_ {
+			return fmt.Errorf("no consumer leader yet")
+		}
+		if len(ci.Cluster.Replicas) != 2 {
+			return fmt.Errorf("expected 2 replicas, got %d", len(ci.Cluster.Replicas))
+		}
+		return nil
+	})
+
+	// The R1 durable must be left alone and specifically must NOT be scaled up
+	// to the full new stream peer set.
+	ci, err = js.ConsumerInfo("TEST", "R1")
+	require_NoError(t, err)
+	require_Equal(t, ci.Cluster.Leader, r1Peer)
+	require_Len(t, len(ci.Cluster.Replicas), 0)
+
+	// Same for the ephemeral, and it should not have been deleted either.
+	eci, err = js.ConsumerInfo("TEST", ephemeral)
+	require_NoError(t, err)
+	require_Equal(t, eci.Cluster.Leader, ephemeralPeer)
+	require_Len(t, len(eci.Cluster.Replicas), 0)
+}
+
 //
 // DO NOT ADD NEW TESTS IN THIS FILE (unless to balance test times)
 // Add at the end of jetstream_cluster_<n>_test.go, with <n> being the highest value.

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -13004,6 +13004,253 @@ func TestJetStreamClusterMalformedMetaEntrySetsWriteErr(t *testing.T) {
 	require_True(t, ml.Running())
 }
 
+func TestJetStreamClusterConsumerAutoScaleWithStream(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		cfg       *nats.ConsumerConfig
+		autoScale bool // when the consumer is expected to follow the stream's replica count
+	}{
+		{
+			name: "EphemeralAutoName",
+			cfg: &nats.ConsumerConfig{
+				AckPolicy:         nats.AckExplicitPolicy,
+				InactiveThreshold: time.Minute,
+			},
+			autoScale: false,
+		},
+		{
+			name: "EphemeralProvidedName",
+			cfg: &nats.ConsumerConfig{
+				Name:              "EPH",
+				AckPolicy:         nats.AckExplicitPolicy,
+				InactiveThreshold: time.Minute,
+			},
+			autoScale: false,
+		},
+		{
+			name: "Durable",
+			cfg: &nats.ConsumerConfig{
+				Durable:   "DUR",
+				AckPolicy: nats.AckExplicitPolicy,
+			},
+			autoScale: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+
+			nc, js := jsClientConnect(t, c.randomServer())
+			defer nc.Close()
+
+			// Start the stream out at R1.
+			cfg := &nats.StreamConfig{
+				Name:     "TEST",
+				Subjects: []string{"foo"},
+				Replicas: 1,
+			}
+			_, err := js.AddStream(cfg)
+			require_NoError(t, err)
+
+			ci, err := js.AddConsumer("TEST", test.cfg)
+			require_NoError(t, err)
+			cname := ci.Name
+			require_NotEqual(t, cname, _EMPTY_)
+
+			observedReplicas := func() (int, error) {
+				ci, err := js.ConsumerInfo("TEST", cname, nats.MaxWait(time.Second))
+				if err != nil {
+					return 0, err
+				}
+				if ci.Cluster == nil || ci.Cluster.Leader == _EMPTY_ {
+					return 0, fmt.Errorf("no consumer leader yet")
+				}
+				return len(ci.Cluster.Replicas) + 1, nil
+			}
+
+			scaleAndCheck := func(replicas int) {
+				t.Helper()
+				cfg.Replicas = replicas
+				_, err := js.UpdateStream(cfg)
+				require_NoError(t, err)
+
+				wantR := 1
+				if test.autoScale {
+					wantR = replicas
+				}
+
+				// Ephemeral consumers must never follow the stream's replica count, not even transiently.
+				if !test.autoScale {
+					until := time.Now().Add(500 * time.Millisecond)
+					for time.Now().Before(until) {
+						if gotR, err := observedReplicas(); err == nil && gotR > 1 {
+							t.Fatalf("stream R%d: %s consumer %q scaled to R%d, expected to stay R1",
+								replicas, test.name, cname, gotR)
+						}
+						time.Sleep(100 * time.Millisecond)
+					}
+				}
+
+				// Every consumer must converge to and hold the expected replica count.
+				c.waitOnStreamLeader(globalAccountName, "TEST")
+				checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+					gotR, err := observedReplicas()
+					if err != nil {
+						return err
+					}
+					if gotR != wantR {
+						return fmt.Errorf("stream R%d: expected consumer R%d, got R%d", replicas, wantR, gotR)
+					}
+					return nil
+				})
+				c.waitOnConsumerLeader(globalAccountName, "TEST", cname)
+			}
+
+			// Scale up and back down.
+			for _, streamR := range []int{1, 2, 3, 2, 1} {
+				scaleAndCheck(streamR)
+			}
+		})
+	}
+}
+
+func TestJetStreamClusterConsumerNoAutoScaleOnRetentionChange(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R5S", 5)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// Interest retention stream at R3. Under interest policy consumers keep peer
+	// parity with the stream, so the legacy ephemeral starts out at R3.
+	cfg := &nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Retention: nats.InterestPolicy,
+		Replicas:  3,
+	}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	// Legacy ephemeral, presents as R=0.
+	ci, err := js.AddConsumer("TEST", &nats.ConsumerConfig{
+		AckPolicy:         nats.AckExplicitPolicy,
+		InactiveThreshold: time.Minute,
+	})
+	require_NoError(t, err)
+	cname := ci.Name
+	require_NotEqual(t, cname, _EMPTY_)
+
+	observedReplicas := func() (int, error) {
+		ci, err := js.ConsumerInfo("TEST", cname, nats.MaxWait(time.Second))
+		if err != nil {
+			return 0, err
+		}
+		if ci.Cluster == nil || ci.Cluster.Leader == _EMPTY_ {
+			return 0, fmt.Errorf("no consumer leader yet")
+		}
+		return len(ci.Cluster.Replicas) + 1, nil
+	}
+	// Confirm the consumer follows the interest stream up to R3 to begin with.
+	gotR, err := observedReplicas()
+	require_NoError(t, err)
+	require_Equal(t, gotR, 3)
+
+	// Switch to limits retention while also scaling the stream up to R5.
+	// The ephemeral must not be auto scaled to follow the stream's replica count,
+	// not even transiently. Switching the retention policy is not an auto scale event.
+	cfg.Retention = nats.LimitsPolicy
+	cfg.Replicas = 5
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+
+	start := time.Now()
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		gotR, err := observedReplicas()
+		if err != nil {
+			return err
+		}
+		if gotR > 3 {
+			t.Fatalf("ephemeral consumer %q scaled to R%d, expected to never follow the stream up to R5",
+				cname, gotR)
+		}
+		if gotR != 1 {
+			return fmt.Errorf("expected ephemeral consumer to downscale to R1, got R%d", gotR)
+		}
+		if elapsed := time.Since(start); elapsed < 2*time.Second {
+			return fmt.Errorf("at R1, still observing for the full window (%v elapsed)", elapsed.Round(time.Millisecond))
+		}
+		return nil
+	})
+}
+
+func TestJetStreamClusterConsumerScaleOnRetentionChange(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// Interest retention stream at R3. Under interest policy consumers keep peer
+	// parity with the stream, so the legacy ephemeral starts out at R3.
+	cfg := &nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Retention: nats.InterestPolicy,
+		Replicas:  3,
+	}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	// Legacy ephemeral, presents as R=0.
+	ci, err := js.AddConsumer("TEST", &nats.ConsumerConfig{
+		AckPolicy:         nats.AckExplicitPolicy,
+		InactiveThreshold: time.Minute,
+	})
+	require_NoError(t, err)
+	cname := ci.Name
+	require_NotEqual(t, cname, _EMPTY_)
+
+	observedReplicas := func() (int, error) {
+		ci, err := js.ConsumerInfo("TEST", cname, nats.MaxWait(time.Second))
+		if err != nil {
+			return 0, err
+		}
+		if ci.Cluster == nil || ci.Cluster.Leader == _EMPTY_ {
+			return 0, fmt.Errorf("no consumer leader yet")
+		}
+		return len(ci.Cluster.Replicas) + 1, nil
+	}
+	// Confirm the consumer follows the interest stream up to R3 to begin with.
+	gotR, err := observedReplicas()
+	require_NoError(t, err)
+	require_Equal(t, gotR, 3)
+
+	updateRetentionAndCheck := func(retention nats.RetentionPolicy, wantR int) {
+		t.Helper()
+		cfg.Retention = retention
+		_, err = js.UpdateStream(cfg)
+		require_NoError(t, err)
+
+		checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+			gotR, err := observedReplicas()
+			if err != nil {
+				return err
+			}
+			if gotR != wantR {
+				return fmt.Errorf("expected ephemeral consumer at R%d, got R%d", wantR, gotR)
+			}
+			return nil
+		})
+	}
+
+	// Switching to limits retention must downscale the legacy ephemeral to R1,
+	// switching back to interest retention must restore peer parity with the stream.
+	updateRetentionAndCheck(nats.LimitsPolicy, 1)
+	updateRetentionAndCheck(nats.InterestPolicy, 3)
+}
+
 //
 // DO NOT ADD NEW TESTS IN THIS FILE (unless to balance test times)
 // Add at the end of jetstream_cluster_<n>_test.go, with <n> being the highest value.

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -13251,6 +13251,171 @@ func TestJetStreamClusterConsumerScaleOnRetentionChange(t *testing.T) {
 	updateRetentionAndCheck(nats.InterestPolicy, 3)
 }
 
+func TestJetStreamClusterStreamPeerRemoveConsumerRemap(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R5S", 5)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	// An R1 durable, its single peer should be left alone if it's not the peer being removed.
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "R1",
+		AckPolicy: nats.AckExplicitPolicy,
+		Replicas:  1,
+	})
+	require_NoError(t, err)
+
+	// An R3 durable, it should be remapped along with the stream.
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "R3",
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	// An ephemeral, it should survive as long as its peer is not the one being removed.
+	sub, err := js.SubscribeSync("foo")
+	require_NoError(t, err)
+	defer sub.Unsubscribe()
+	eci, err := sub.ConsumerInfo()
+	require_NoError(t, err)
+	ephemeral, ephemeralPeer := eci.Name, eci.Cluster.Leader
+
+	ci, err := js.ConsumerInfo("TEST", "R1")
+	require_NoError(t, err)
+	require_Len(t, len(ci.Cluster.Replicas), 0)
+	r1Peer := ci.Cluster.Leader
+
+	// Remove a stream peer that hosts neither the R1 durable nor the ephemeral.
+	si, err := js.StreamInfo("TEST")
+	require_NoError(t, err)
+	peers := []string{si.Cluster.Leader}
+	for _, r := range si.Cluster.Replicas {
+		peers = append(peers, r.Name)
+	}
+	var toRemove string
+	for _, p := range peers {
+		if p != r1Peer && p != ephemeralPeer {
+			toRemove = p
+			break
+		}
+	}
+	require_NotEqual(t, toRemove, _EMPTY_)
+
+	b, err := json.Marshal(JSApiStreamRemovePeerRequest{Peer: toRemove})
+	require_NoError(t, err)
+	msg, err := nc.Request(fmt.Sprintf(JSApiStreamRemovePeerT, "TEST"), b, time.Second)
+	require_NoError(t, err)
+	var resp JSApiStreamRemovePeerResponse
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_True(t, resp.Success)
+
+	// Wait for the stream to be back at R3 with the removed peer replaced.
+	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+		si, err := js.StreamInfo("TEST", nats.MaxWait(time.Second))
+		if err != nil {
+			return err
+		}
+		if si.Cluster == nil || si.Cluster.Leader == _EMPTY_ {
+			return fmt.Errorf("no stream leader yet")
+		}
+		if len(si.Cluster.Replicas) != 2 {
+			return fmt.Errorf("expected 2 replicas, got %d", len(si.Cluster.Replicas))
+		}
+		if si.Cluster.Leader == toRemove {
+			return fmt.Errorf("removed peer still stream leader")
+		}
+		for _, r := range si.Cluster.Replicas {
+			if r.Name == toRemove {
+				return fmt.Errorf("removed peer still in stream peer set")
+			}
+		}
+		return nil
+	})
+
+	// The R3 durable should have been remapped off of the removed peer.
+	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+		ci, err := js.ConsumerInfo("TEST", "R3", nats.MaxWait(time.Second))
+		if err != nil {
+			return err
+		}
+		if ci.Cluster == nil || ci.Cluster.Leader == _EMPTY_ {
+			return fmt.Errorf("no consumer leader yet")
+		}
+		if len(ci.Cluster.Replicas) != 2 {
+			return fmt.Errorf("expected 2 replicas, got %d", len(ci.Cluster.Replicas))
+		}
+		if ci.Cluster.Leader == toRemove {
+			return fmt.Errorf("removed peer still consumer leader")
+		}
+		for _, r := range ci.Cluster.Replicas {
+			if r.Name == toRemove {
+				return fmt.Errorf("removed peer still in consumer peer set")
+			}
+		}
+		return nil
+	})
+
+	// The R1 durable was not on the removed peer, it must be left alone and specifically
+	// must NOT be scaled up to the full new stream peer set.
+	ci, err = js.ConsumerInfo("TEST", "R1")
+	require_NoError(t, err)
+	require_Equal(t, ci.Cluster.Leader, r1Peer)
+	require_Len(t, len(ci.Cluster.Replicas), 0)
+
+	// The ephemeral was not on the removed peer either, it should still exist.
+	_, err = js.ConsumerInfo("TEST", ephemeral)
+	require_NoError(t, err)
+}
+
+func TestJetStreamClusterStreamPeerRemoveEphemeralDeleted(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R5S", 5)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	sub, err := js.SubscribeSync("foo")
+	require_NoError(t, err)
+	defer sub.Unsubscribe()
+	eci, err := sub.ConsumerInfo()
+	require_NoError(t, err)
+	ephemeral, ephemeralPeer := eci.Name, eci.Cluster.Leader
+
+	// Remove the ephemeral's peer from the stream.
+	b, err := json.Marshal(JSApiStreamRemovePeerRequest{Peer: ephemeralPeer})
+	require_NoError(t, err)
+	msg, err := nc.Request(fmt.Sprintf(JSApiStreamRemovePeerT, "TEST"), b, time.Second)
+	require_NoError(t, err)
+	var resp JSApiStreamRemovePeerResponse
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_True(t, resp.Success)
+
+	// The ephemeral had its only peer removed, it should be deleted rather than moved.
+	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+		_, err := js.ConsumerInfo("TEST", ephemeral, nats.MaxWait(time.Second))
+		if err == nil {
+			return fmt.Errorf("expected ephemeral consumer to be deleted")
+		}
+		require_Error(t, err, NewJSConsumerNotFoundError())
+		return nil
+	})
+}
+
 //
 // DO NOT ADD NEW TESTS IN THIS FILE (unless to balance test times)
 // Add at the end of jetstream_cluster_<n>_test.go, with <n> being the highest value.


### PR DESCRIPTION
When a stream's replica count is updated, durable consumers are meant to auto scale with them if `num_replicas: 0` was set in the consumer config. However, the `isAutoScale` variable also included named ephemeral consumers in this auto scaling, whereas they aren't supposed to do that. They'd still converge to the allowed replica count based on the consumer migration code, but this PR fixes that by not needlessly scaling up these consumers for them to then be migrated back down, which results in noticeable churn.

Additionally, this PR refactors the 3 consumer peer set remap paths into a single reusable method. Marked as 2.15 for the time being, since I'll want to get rid of the `sysRequest` separately, since it requires an unsafe JS release and re-acquire.