### PR TITLE
Fix "then" vs "than" typos in source comments

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -83,7 +83,7 @@ const (
 	// ClientProtoZero is the original Client protocol from 2009.
 	// http://nats.io/documentation/internals/nats-protocol/
 	ClientProtoZero = iota
-	// ClientProtoInfo signals a client can receive more then the original INFO block.
+	// ClientProtoInfo signals a client can receive more than the original INFO block.
 	// This can be used to update clients on other cluster members, etc.
 	ClientProtoInfo
 )

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -3959,7 +3959,7 @@ func (fs *fileStore) NumPending(sseq uint64, filter string, lastPerSubject bool)
 		return 0, validThrough, nil
 	}
 
-	// If sseq is less then our first set to first.
+	// If sseq is less than our first set to first.
 	if sseq < fs.state.FirstSeq {
 		sseq = fs.state.FirstSeq
 	}
@@ -4310,7 +4310,7 @@ func (fs *fileStore) NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPer
 		return 0, validThrough, nil
 	}
 
-	// If sseq is less then our first set to first.
+	// If sseq is less than our first set to first.
 	if sseq < fs.state.FirstSeq {
 		sseq = fs.state.FirstSeq
 	}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2037,7 +2037,7 @@ func (js *jetStream) checkClusterSize() {
 			}
 		}
 	}
-	// If we have less then our cluster size adjust that here. Can not do individual peer removals since
+	// If we have less than our cluster size adjust that here. Can not do individual peer removals since
 	// they will not be in the tracked peers.
 	if totalJS < ps.clusterSize {
 		s.Debugf("Adjusting JetStream cluster size from %d to %d", ps.clusterSize, totalJS)
@@ -9502,7 +9502,7 @@ func (cc *jetStreamCluster) createGroupForConsumer(cfg *ConsumerConfig, sa *stre
 		return nil
 	}
 
-	// If we want less then our parent stream, select from active.
+	// If we want less than our parent stream, select from active.
 	if replicas > 0 && replicas < len(peers) {
 		// Pedantic in case stream is say R5 and consumer is R3 and 3 or more offline, etc.
 		if len(active) < replicas {

--- a/server/server.go
+++ b/server/server.go
@@ -70,7 +70,7 @@ const (
 	// RouteProtoZero is the original Route protocol from 2009.
 	// http://nats.io/documentation/internals/nats-protocol/
 	RouteProtoZero = iota
-	// RouteProtoInfo signals a route can receive more then the original INFO block.
+	// RouteProtoInfo signals a route can receive more than the original INFO block.
 	// This can be used to update remote cluster permissions, etc...
 	RouteProtoInfo
 	// RouteProtoV2 is the new route/cluster protocol that provides account support.

--- a/server/stream.go
+++ b/server/stream.go
@@ -3964,7 +3964,7 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 			req.Config.OptStartSeq = ssi.OptStartSeq
 			req.Config.DeliverPolicy = DeliverByStartSequence
 		} else {
-			// We have not recovered state so check that configured time is less that our first seq time.
+			// We have not recovered state so check that configured time is less than our first seq time.
 			var state StreamState
 			mset.store.FastState(&state)
 			if ssi.OptStartTime != nil {
@@ -4185,7 +4185,7 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 
 // This will process all inbound source msgs.
 // We mux them into one go routine to avoid lock contention and high cpu and thread thrashing.
-// TODO(dlc) make this more then one and pin sources to one of a group.
+// TODO(dlc) make this more than one and pin sources to one of a group.
 func (mset *stream) processAllSourceMsgs() {
 	s := mset.srv
 	defer s.grWG.Done()


### PR DESCRIPTION
Several code comments in the server package contain the grammar errors
`less then`, `more then`, and `less that`, where `than` was intended.
This PR corrects all eight occurrences across five source files.

Files changed:
- `server/client.go`: "more then" → "more than"
- `server/filestore.go`: "less then" → "less than" (two occurrences)
- `server/jetstream_cluster.go`: "less then" → "less than" (two occurrences)
- `server/server.go`: "more then" → "more than"
- `server/stream.go`: "less that" → "less than", "more then" → "more than"

No functional changes; comments only.