### PR TITLE
Fix article "an URL" → "a URL" in comments

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -6249,7 +6249,7 @@ func (c *client) reconnect() {
 		return
 	}
 	if c.route != nil {
-		// A route is marked as solicited if it was given an URL to connect to,
+		// A route is marked as solicited if it was given a URL to connect to,
 		// which would be the case even with implicit (due to gossip), so mark this
 		// as a retry for a route that is solicited and not explicit.
 		retryImplicit = c.route.retry || (c.route.didSolicit && c.route.routeType == Implicit)

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -545,7 +545,7 @@ func (cfg *leafNodeCfg) stillValid() bool {
 	return !cfg.Disabled && !cfg.removed
 }
 
-// Will pick an URL from the list of available URLs.
+// Will pick a URL from the list of available URLs.
 func (cfg *leafNodeCfg) pickNextURL() *url.URL {
 	cfg.Lock()
 	defer cfg.Unlock()

--- a/server/opts.go
+++ b/server/opts.go
@@ -268,7 +268,7 @@ type RemoteLeafOpts struct {
 	// setting and also be different from the LeafNode options.
 	Compression CompressionOpts `json:"-"`
 
-	// When an URL has the "ws" (or "wss") scheme, then the server will initiate the
+	// When a URL has the "ws" (or "wss") scheme, then the server will initiate the
 	// connection as a websocket connection. By default, the websocket frames will be
 	// masked (as if this server was a websocket client to the remote server). The
 	// NoMasking option will change this behavior and will send umasked frames.

--- a/server/server.go
+++ b/server/server.go
@@ -911,7 +911,7 @@ func NewServer(opts *Options) (*Server, error) {
 	if err := s.configureResolver(); err != nil {
 		return nil, err
 	}
-	// If there is an URL account resolver, do basic test to see if anyone is home.
+	// If there is a URL account resolver, do basic test to see if anyone is home.
 	if ar := opts.AccountResolver; ar != nil {
 		if ur, ok := ar.(*URLAccResolver); ok {
 			if _, err := ur.Fetch(_EMPTY_); err != nil {


### PR DESCRIPTION
"URL" is pronounced letter by letter as "U-R-L" where "U" makes the "yoo" sound,
which starts with the consonant "y". The correct indefinite article before a
consonant sound is "a", not "an". This PR corrects four occurrences across four
source files:

- `server/server.go`: "an URL account resolver" → "a URL account resolver"
- `server/client.go`: "given an URL to connect to" → "given a URL to connect to"
- `server/opts.go`: "When an URL has the..." → "When a URL has the..."
- `server/leafnode.go`: "pick an URL from the list" → "pick a URL from the list"

No functional changes; comments only.