### PR TITLE
Add JetStream option to mirror advisories into the system account

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1918,9 +1918,14 @@ func (o *consumer) sendAdvisory(subject string, e any) {
 	}
 
 	// If there is no one listening for this advisory then save ourselves the effort
-	// and don't bother encoding the JSON or sending it.
+	// and don't bother encoding the JSON or sending it. We still emit it when
+	// advisory forwarding to the system account is enabled so that operators can
+	// observe advisories even when the originating account has no local interest;
+	// the forwarding itself happens lock-safely in the stream's internalLoop.
 	if sl := o.acc.sl; (sl != nil && !sl.HasInterest(subject)) && !o.srv.hasGatewayInterest(o.acc.Name, subject) {
-		return
+		if !o.srv.getOpts().JetStreamForwardAdvisories {
+			return
+		}
 	}
 
 	j, err := json.Marshal(e)

--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -15,8 +15,51 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 )
+
+// jsAdvisoryForwardSubj is the subject template used when forwarding a copy of a
+// JetStream advisory into the system account for cross-account operational
+// visibility. The originating account name is encoded as a token so advisories
+// from different accounts can be distinguished, e.g.
+// "$SYS.ACCOUNT.<account>.JS.EVENT.ADVISORY.STREAM.CREATED.<stream>".
+const jsAdvisoryForwardSubj = "$SYS.ACCOUNT.%s.%s"
+
+// isJSAdvisoryOrMetricSubject reports whether subject is a JetStream advisory or
+// metric subject (under $JS.EVENT.ADVISORY or $JS.EVENT.METRIC).
+func isJSAdvisoryOrMetricSubject(subject string) bool {
+	return strings.HasPrefix(subject, JSAdvisoryPrefix+".") || strings.HasPrefix(subject, JSMetricPrefix+".")
+}
+
+// jsAdvisoriesForwarded reports whether JetStream advisories for the named
+// account should be mirrored into the system account. Advisories that already
+// originate in the system account are never forwarded to itself.
+func (s *Server) jsAdvisoriesForwarded(accName string) bool {
+	if accName == _EMPTY_ || !s.getOpts().JetStreamForwardAdvisories {
+		return false
+	}
+	sysAcc := s.SystemAccount()
+	return sysAcc != nil && accName != sysAcc.Name
+}
+
+// forwardJSAdvisoryToSysAcct mirrors an already-encoded advisory payload into the
+// system account, namespaced by the originating account name so a system
+// operator can observe advisories across all accounts. Callers should gate on
+// jsAdvisoriesForwarded first. The payload is copied because the system send
+// queue delivers it asynchronously and the caller's buffer may be reused.
+func (s *Server) forwardJSAdvisoryToSysAcct(accName, subject string, payload []byte) {
+	sysAcc := s.SystemAccount()
+	if sysAcc == nil {
+		return
+	}
+	fsubj := fmt.Sprintf(jsAdvisoryForwardSubj, accName, strings.TrimPrefix(subject, "$"))
+	cp := append([]byte(nil), payload...)
+	if err := s.sendInternalAccountMsg(sysAcc, fsubj, cp); err != nil {
+		s.Warnf("Advisory could not be forwarded to system account for account %q: %v", accName, err)
+	}
+}
 
 // publishAdvisory sends the given advisory into the account. Returns true if
 // it was sent, false if not (i.e. due to lack of interest or a marshal error).
@@ -28,20 +71,34 @@ func (s *Server) publishAdvisory(acc *Account, subject string, adv any) bool {
 		}
 	}
 
-	// If there is no one listening for this advisory then save ourselves the effort
-	// and don't bother encoding the JSON or sending it.
+	// Determine whether to mirror this advisory into the system account. This is
+	// independent of interest in the originating account, since a system operator
+	// typically observes advisories without the originating account subscribing.
+	forward := s.jsAdvisoriesForwarded(acc.Name)
+
+	// If there is no one listening for this advisory and we are not forwarding it,
+	// then save ourselves the effort and don't bother encoding the JSON or sending it.
+	hasInterest := true
 	if sl := acc.sl; (sl != nil && !sl.HasInterest(subject)) && !s.hasGatewayInterest(acc.Name, subject) {
+		hasInterest = false
+	}
+	if !hasInterest && !forward {
 		return false
 	}
 
 	ej, err := json.Marshal(adv)
-	if err == nil {
-		err = s.sendInternalAccountMsg(acc, subject, ej)
-		if err != nil {
+	if err != nil {
+		s.Warnf("Advisory could not be serialized for account %q: %v", acc.Name, err)
+		return false
+	}
+
+	if hasInterest {
+		if err = s.sendInternalAccountMsg(acc, subject, ej); err != nil {
 			s.Warnf("Advisory could not be sent for account %q: %v", acc.Name, err)
 		}
-	} else {
-		s.Warnf("Advisory could not be serialized for account %q: %v", acc.Name, err)
+	}
+	if forward {
+		s.forwardJSAdvisoryToSysAcct(acc.Name, subject, ej)
 	}
 	return err == nil
 }

--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -46,10 +46,16 @@ func (s *Server) jsAdvisoriesForwarded(accName string) bool {
 
 // forwardJSAdvisoryToSysAcct mirrors an already-encoded advisory payload into the
 // system account, namespaced by the originating account name so a system
-// operator can observe advisories across all accounts. Callers should gate on
-// jsAdvisoriesForwarded first. The payload is copied because the system send
-// queue delivers it asynchronously and the caller's buffer may be reused.
+// operator can observe advisories across all accounts. Only advisory/metric
+// subjects are forwarded; the subject guard keeps the invariant local so a future
+// caller cannot inadvertently leak non-advisory traffic into the system account.
+// Callers should gate on jsAdvisoriesForwarded first. The payload is copied
+// because the system send queue delivers it asynchronously and the caller's
+// buffer may be reused.
 func (s *Server) forwardJSAdvisoryToSysAcct(accName, subject string, payload []byte) {
+	if !isJSAdvisoryOrMetricSubject(subject) {
+		return
+	}
 	sysAcc := s.SystemAccount()
 	if sysAcc == nil {
 		return
@@ -61,8 +67,12 @@ func (s *Server) forwardJSAdvisoryToSysAcct(accName, subject string, payload []b
 	}
 }
 
-// publishAdvisory sends the given advisory into the account. Returns true if
-// it was sent, false if not (i.e. due to lack of interest or a marshal error).
+// publishAdvisory marshals adv and delivers it to the originating account (when
+// it has local interest) and/or mirrors it into the system account (when
+// forwarding is enabled). It returns false on a marshal error, when there is
+// neither local interest nor forwarding, or when the originating-account send
+// fails; the success of a system-account forward is logged but not reflected in
+// the return value.
 func (s *Server) publishAdvisory(acc *Account, subject string, adv any) bool {
 	if acc == nil {
 		acc = s.SystemAccount()

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -8492,6 +8492,90 @@ func TestJetStreamAccountImportJSAdvisoriesAsService(t *testing.T) {
 	}
 }
 
+// TestJetStreamForwardAdvisoriesToSystemAccount verifies that with the jetstream
+// forward_advisories option enabled, advisories from every account are mirrored
+// into the system account under $SYS.ACCOUNT.<account>.JS.EVENT.ADVISORY.>, so a
+// system operator can observe them and tell accounts apart by the subject token.
+func TestJetStreamForwardAdvisoriesToSystemAccount(t *testing.T) {
+	// %q store_dir, %v forward_advisories.
+	tmpl := `
+		listen: 127.0.0.1:-1
+		jetstream: {store_dir: %q, forward_advisories: %v}
+		system_account: SYS
+		accounts {
+			JS  { jetstream: enabled, users: [ {user: pp, password: foo} ] }
+			SYS { users: [ {user: admin, password: foo} ] }
+		}
+	`
+
+	// setup subscribes a system-account observer to the forwarding subject, then
+	// creates a stream and consumer to trigger advisories on both emission paths
+	// (publishAdvisory for the API audit, the stream outq for the created events).
+	setup := func(t *testing.T, forward bool) (*nats.Subscription, func()) {
+		t.Helper()
+		conf := createConfFile(t, []byte(fmt.Sprintf(tmpl, t.TempDir(), forward)))
+		s, _ := RunServerWithConfig(conf)
+
+		ncSys, err := nats.Connect(s.ClientURL(), nats.UserInfo("admin", "foo"))
+		require_NoError(t, err)
+		sub, err := ncSys.SubscribeSync("$SYS.ACCOUNT.*.JS.EVENT.ADVISORY.>")
+		require_NoError(t, err)
+		require_NoError(t, ncSys.Flush())
+
+		ncJS, err := nats.Connect(s.ClientURL(), nats.UserInfo("pp", "foo"))
+		require_NoError(t, err)
+		js, err := ncJS.JetStream()
+		require_NoError(t, err)
+		_, err = js.AddStream(&nats.StreamConfig{Name: "ORDERS"})
+		require_NoError(t, err)
+		_, err = js.AddConsumer("ORDERS", &nats.ConsumerConfig{Durable: "dur", AckPolicy: nats.AckExplicitPolicy})
+		require_NoError(t, err)
+
+		return sub, func() {
+			ncSys.Close()
+			ncJS.Close()
+			s.Shutdown()
+		}
+	}
+
+	t.Run("enabled", func(t *testing.T) {
+		sub, cleanup := setup(t, true)
+		defer cleanup()
+
+		// All namespaced under the JS account, covering both emission paths.
+		want := map[string]bool{
+			"$SYS.ACCOUNT.JS.JS.EVENT.ADVISORY.STREAM.CREATED.ORDERS":       false,
+			"$SYS.ACCOUNT.JS.JS.EVENT.ADVISORY.API":                         false,
+			"$SYS.ACCOUNT.JS.JS.EVENT.ADVISORY.CONSUMER.CREATED.ORDERS.dur": false,
+		}
+		remaining := len(want)
+		deadline := time.Now().Add(5 * time.Second)
+		for remaining > 0 {
+			msg, err := sub.NextMsg(time.Until(deadline))
+			if err != nil {
+				break
+			}
+			if seen, ok := want[msg.Subject]; ok && !seen {
+				want[msg.Subject], remaining = true, remaining-1
+			}
+		}
+		for subj, seen := range want {
+			if !seen {
+				t.Fatalf("did not receive forwarded advisory on %q", subj)
+			}
+		}
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		sub, cleanup := setup(t, false)
+		defer cleanup()
+
+		if msg, err := sub.NextMsg(time.Second); err == nil {
+			t.Fatalf("expected no forwarded advisory, got %q", msg.Subject)
+		}
+	})
+}
+
 // This tests whether we are able to aggregate all JetStream advisory events
 // from all accounts into a single account. Config for this test uses
 // stream imports and exports as that allows for gathering all events

--- a/server/opts.go
+++ b/server/opts.go
@@ -463,6 +463,7 @@ type Options struct {
 	JetStreamMetaCompactSize   uint64
 	JetStreamMetaCompactSync   bool
 	JetStreamConcurrentIOs     int
+	JetStreamForwardAdvisories bool
 	StreamMaxBufferedMsgs      int               `json:"-"`
 	StreamMaxBufferedSize      int64             `json:"-"`
 	StoreDir                   string            `json:"-"`
@@ -2769,6 +2770,8 @@ func parseJetStream(v any, opts *Options, errors *[]error, warnings *[]error) er
 					return &configErr{tk, fmt.Sprintf("Expected an absolute size for %q between 4 and 8192, got %v", mk, mv)}
 				}
 				opts.JetStreamConcurrentIOs = int(dios)
+			case "forward_advisories":
+				opts.JetStreamForwardAdvisories = mv.(bool)
 			default:
 				if !tk.IsUsedVariable() {
 					err := &unknownConfigFieldErr{

--- a/server/reload.go
+++ b/server/reload.go
@@ -1873,6 +1873,9 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 			} else {
 				newOpts.JetStreamConcurrentIOs = oldValue.(int)
 			}
+		case "jetstreamforwardadvisories":
+			// Allowed at runtime; read live via getOpts() when advisories are
+			// emitted, so the change takes effect immediately with no further work.
 		case "websocket":
 			// Similar to gateways
 			tmpOld := oldValue.(WebsocketOpts)

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -1828,6 +1828,52 @@ func reloadUpdateConfig(t *testing.T, s *Server, conf, content string) {
 	}
 }
 
+func TestConfigReloadJetStreamForwardAdvisories(t *testing.T) {
+	storeDir := t.TempDir()
+	// %q store_dir, %v forward_advisories.
+	tmpl := `
+		listen: 127.0.0.1:-1
+		jetstream: {store_dir: %q, forward_advisories: %v}
+		system_account: SYS
+		accounts {
+			JS  { jetstream: enabled, users: [ {user: pp, password: foo} ] }
+			SYS { users: [ {user: admin, password: foo} ] }
+		}
+	`
+	conf := createConfFile(t, []byte(fmt.Sprintf(tmpl, storeDir, false)))
+	s, _ := RunServerWithConfig(conf)
+	defer s.Shutdown()
+	require_False(t, s.getOpts().JetStreamForwardAdvisories)
+
+	// Must be reloadable (the diff otherwise rejects the changed field) and take
+	// effect immediately, so a sys-account observer sees JS-account advisories.
+	reloadUpdateConfig(t, s, conf, fmt.Sprintf(tmpl, storeDir, true))
+	require_True(t, s.getOpts().JetStreamForwardAdvisories)
+
+	ncSys, err := nats.Connect(s.ClientURL(), nats.UserInfo("admin", "foo"))
+	require_NoError(t, err)
+	defer ncSys.Close()
+	sub, err := ncSys.SubscribeSync("$SYS.ACCOUNT.JS.JS.EVENT.ADVISORY.>")
+	require_NoError(t, err)
+	require_NoError(t, ncSys.Flush())
+
+	ncJS, err := nats.Connect(s.ClientURL(), nats.UserInfo("pp", "foo"))
+	require_NoError(t, err)
+	defer ncJS.Close()
+	js, err := ncJS.JetStream()
+	require_NoError(t, err)
+	_, err = js.AddStream(&nats.StreamConfig{Name: "ORDERS"})
+	require_NoError(t, err)
+
+	msg, err := sub.NextMsg(2 * time.Second)
+	require_NoError(t, err)
+	require_True(t, strings.HasPrefix(msg.Subject, "$SYS.ACCOUNT.JS.JS.EVENT.ADVISORY."))
+
+	// Disabling again must also be supported.
+	reloadUpdateConfig(t, s, conf, fmt.Sprintf(tmpl, storeDir, false))
+	require_False(t, s.getOpts().JetStreamForwardAdvisories)
+}
+
 func TestConfigReloadClusterAdvertise(t *testing.T) {
 	s, _, conf := runReloadServerWithContent(t, []byte(`
 		listen: "0.0.0.0:-1"

--- a/server/stream.go
+++ b/server/stream.go
@@ -8110,6 +8110,7 @@ func (mset *stream) internalLoop() {
 	c := s.createInternalJetStreamClient()
 	c.registerWithAccount(mset.acc)
 	defer c.closeConnection(ClientClosed)
+	accName := mset.acc.Name
 	outq, qch, msgs, gets := mset.outq, mset.qch, mset.msgs, mset.gets
 
 	// For the ack msgs queue for interest retention.
@@ -8186,6 +8187,14 @@ func (mset *stream) internalLoop() {
 				// we failed to deliver the message. If so alert the consumer.
 				if pm.o != nil && pm.seq > 0 && !didDeliver {
 					pm.o.didNotDeliver(pm.seq, pm.dsubj)
+				}
+
+				// Mirror stream/consumer advisories into the system account if
+				// enabled. Consumer deliveries (pm.o != nil) are excluded cheaply;
+				// only advisory/metric subjects are forwarded. This is the lock-safe
+				// convergence point for all advisories emitted via the stream outq.
+				if pm.o == nil && isJSAdvisoryOrMetricSubject(pm.dsubj) && s.jsAdvisoriesForwarded(accName) {
+					s.forwardJSAdvisoryToSysAcct(accName, pm.dsubj, pm.msg)
 				}
 				pm.returnToPool()
 			}


### PR DESCRIPTION
Add an opt-in `forward_advisories` option that auto-mirrors every JetStream advisory and metric from all accounts into the system account under an account-namespaced subject:

  $SYS.ACCOUNT.<account>.JS.EVENT.ADVISORY.>
  $SYS.ACCOUNT.<account>.JS.EVENT.METRIC.>

This lets a system operator observe advisories across all accounts with a single subscription. Most advisory payloads carry no account field, so the originating account is encoded as a subject token to keep advisories distinguishable.

Advisories are emitted via two disjoint paths, so forwarding hooks both: publishAdvisory forwards directly (independent of local interest), while consumer/stream advisories are forwarded from stream.internalLoop, the lock-safe convergence point for the outq (avoids the s.mu->o.mu inversion that would occur forwarding from the *Locked advisory emitters). The consumer interest gate is relaxed when the option is on so advisories still reach the outq when the owning account has no local subscriber. The option is hot-reloadable.

Signed-off-by: Byron Ruth <byron@nats.io>