### PR TITLE
reject malformed replicated skip and reset consumer updates

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7049,9 +7049,11 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 					return err
 				}
 			case updateSkipOp:
+				sseq, err := decodeSkipUpdate(buf[1:])
+				if err != nil {
+					return err
+				}
 				o.mu.Lock()
-				var le = binary.LittleEndian
-				sseq := le.Uint64(buf[1:])
 				if !o.isLeader() && sseq > o.sseq {
 					o.sseq = sseq
 				}
@@ -7063,10 +7065,11 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 				}
 				o.mu.Unlock()
 			case resetSeqOp:
+				sseq, reply, err := decodeResetUpdate(buf[1:])
+				if err != nil {
+					return err
+				}
 				o.mu.Lock()
-				var le = binary.LittleEndian
-				sseq := le.Uint64(buf[1:9])
-				reply := string(buf[9:])
 				o.resetLocalStartingSeq(sseq)
 				if o.store != nil {
 					o.store.Reset(sseq - 1)
@@ -7187,6 +7190,8 @@ func (o *consumer) processReplicatedAck(dseq, sseq uint64) error {
 
 var errBadAckUpdate = errors.New("jetstream cluster bad replicated ack update")
 var errBadDeliveredUpdate = errors.New("jetstream cluster bad replicated delivered update")
+var errBadSkipUpdate = errors.New("jetstream cluster bad replicated skip update")
+var errBadResetUpdate = errors.New("jetstream cluster bad replicated reset update")
 
 func decodeAckUpdate(buf []byte) (dseq, sseq uint64, err error) {
 	var bi, n int
@@ -7218,6 +7223,20 @@ func decodeDeliveredUpdate(buf []byte) (dseq, sseq, dc uint64, ts int64, err err
 		return 0, 0, 0, 0, errBadDeliveredUpdate
 	}
 	return dseq, sseq, dc, ts, nil
+}
+
+func decodeSkipUpdate(buf []byte) (sseq uint64, err error) {
+	if len(buf) < 8 {
+		return 0, errBadSkipUpdate
+	}
+	return binary.LittleEndian.Uint64(buf), nil
+}
+
+func decodeResetUpdate(buf []byte) (sseq uint64, reply string, err error) {
+	if len(buf) < 8 {
+		return 0, _EMPTY_, errBadResetUpdate
+	}
+	return binary.LittleEndian.Uint64(buf[:8]), string(buf[8:]), nil
 }
 
 func (js *jetStream) processConsumerLeaderChange(o *consumer, isLeader bool) error {

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -8660,4 +8660,30 @@ func TestJetStreamClusterDecodeUpdatesRejectMalformed(t *testing.T) {
 			}
 		}
 	})
+	// updateSkipOp and resetSeqOp read a fixed-width little-endian uint64 for
+	// the sequence, so a buffer shorter than 8 bytes must be rejected rather
+	// than triggering an out-of-bounds slice access.
+	t.Run("SkipUpdate", func(t *testing.T) {
+		valid := binary.LittleEndian.AppendUint64(nil, 10)
+		if sseq, err := decodeSkipUpdate(valid); err != nil || sseq != 10 {
+			t.Fatalf("expected valid skip update to decode, got sseq=%d err=%v", sseq, err)
+		}
+		for _, buf := range [][]byte{nil, valid[:1], valid[:7]} {
+			if _, err := decodeSkipUpdate(buf); err != errBadSkipUpdate {
+				t.Fatalf("expected errBadSkipUpdate for %v, got %v", buf, err)
+			}
+		}
+	})
+	t.Run("ResetUpdate", func(t *testing.T) {
+		valid := binary.LittleEndian.AppendUint64(nil, 10)
+		valid = append(valid, "reply"...)
+		if sseq, reply, err := decodeResetUpdate(valid); err != nil || sseq != 10 || reply != "reply" {
+			t.Fatalf("expected valid reset update to decode, got sseq=%d reply=%q err=%v", sseq, reply, err)
+		}
+		for _, buf := range [][]byte{nil, valid[:1], valid[:7]} {
+			if _, _, err := decodeResetUpdate(buf); err != errBadResetUpdate {
+				t.Fatalf("expected errBadResetUpdate for %v, got %v", buf, err)
+			}
+		}
+	})
 }


### PR DESCRIPTION
applyConsumerEntries reads the sequence for the updateSkipOp and resetSeqOp consumer ops with a fixed-width le.Uint64 straight off the entry buffer, without checking there are 8 bytes after the op byte. A replicated entry from a peer whose data is the op byte plus fewer than 8 bytes makes le.Uint64(buf[1:]) / le.Uint64(buf[1:9]) run off the end and panic the apply goroutine. The neighboring updateDeliveredOp and updateAcksOp already decode through decodeDeliveredUpdate/decodeAckUpdate, which reject short buffers; these two ops were the outliers.

Before: the two ops indexed the buffer directly and crashed on a truncated entry. After: they go through decodeSkipUpdate/decodeResetUpdate, which return an error for anything under 8 bytes, so a malformed entry is rejected the same way the sibling ops already are. Keeping the read behind a helper matches the existing consumer-op decoders and puts the length check in one place; the tradeoff is two more small functions instead of an inline guard, which reads better sitting next to the ack and delivered decoders.