### PR TITLE
reject replicated entries with no op byte in apply loops

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2380,6 +2380,9 @@ func (js *jetStream) collectStreamAndConsumerChanges(c RaftNodeCheckpoint, strea
 		for _, e := range ae.entries {
 			if e.Type == EntryNormal {
 				buf := e.Data
+				if len(buf) == 0 {
+					return errBadEntryOp
+				}
 				op := entryOp(buf[0])
 				switch op {
 				case assignStreamOp, updateStreamOp, removeStreamOp:
@@ -2765,6 +2768,9 @@ func (js *jetStream) applyMetaEntries(entries []*Entry, ru *recoveryUpdates) (bo
 			}
 		} else {
 			buf := e.Data
+			if len(buf) == 0 {
+				return isRecovering, didSnap, errBadEntryOp
+			}
 			switch entryOp(buf[0]) {
 			case assignStreamOp:
 				sa, err := decodeStreamAssignment(js.srv, buf[1:])
@@ -4036,6 +4042,9 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 		}
 
 		if e.Type == EntryNormal {
+			if len(e.Data) == 0 {
+				return 0, errBadEntryOp
+			}
 			buf, op := e.Data, entryOp(e.Data[0])
 			if op == batchMsgOp {
 				batchId, batchSeq, _, _, err := decodeBatchMsg(buf[1:])
@@ -6999,6 +7008,9 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 			// Ignore for now.
 		} else {
 			buf := e.Data
+			if len(buf) == 0 {
+				return errBadEntryOp
+			}
 			switch entryOp(buf[0]) {
 			case updateDeliveredOp:
 				dseq, sseq, dc, ts, err := decodeDeliveredUpdate(buf[1:])
@@ -7188,6 +7200,7 @@ func (o *consumer) processReplicatedAck(dseq, sseq uint64) error {
 	return nil
 }
 
+var errBadEntryOp = errors.New("jetstream cluster bad replicated entry")
 var errBadAckUpdate = errors.New("jetstream cluster bad replicated ack update")
 var errBadDeliveredUpdate = errors.New("jetstream cluster bad replicated delivered update")
 var errBadSkipUpdate = errors.New("jetstream cluster bad replicated skip update")

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -8687,3 +8687,34 @@ func TestJetStreamClusterDecodeUpdatesRejectMalformed(t *testing.T) {
 		}
 	})
 }
+
+func TestJetStreamClusterApplyEntriesRejectEmptyNormal(t *testing.T) {
+	// The append entry wire format only requires each entry to carry its type
+	// byte, so a cluster peer can replicate an EntryNormal with a zero-length
+	// body and it still decodes cleanly.
+	le := binary.LittleEndian
+	raw := make([]byte, appendEntryBaseLen)
+	le.PutUint16(raw[40:], 1)            // one entry
+	raw = le.AppendUint32(raw, 1)        // entry length is the type byte only
+	raw = append(raw, byte(EntryNormal)) // no data follows
+	ae, err := decodeAppendEntry(raw, nil, _EMPTY_)
+	require_NoError(t, err)
+	require_Len(t, len(ae.entries), 1)
+	require_Equal(t, ae.entries[0].Type, EntryNormal)
+	require_Len(t, len(ae.entries[0].Data), 0)
+
+	// The apply loops read the op from data[0]; an empty EntryNormal must be
+	// rejected rather than triggering an out-of-bounds access.
+	empty := []*Entry{{EntryNormal, nil}}
+	js := &jetStream{}
+	if _, _, err := js.applyMetaEntries(empty, nil); err != errBadEntryOp {
+		t.Fatalf("expected errBadEntryOp from applyMetaEntries, got %v", err)
+	}
+	ce := &CommittedEntry{Entries: empty}
+	if _, err := js.applyStreamEntries(&stream{}, ce, false); err != errBadEntryOp {
+		t.Fatalf("expected errBadEntryOp from applyStreamEntries, got %v", err)
+	}
+	if err := js.applyConsumerEntries(&consumer{}, ce, false); err != errBadEntryOp {
+		t.Fatalf("expected errBadEntryOp from applyConsumerEntries, got %v", err)
+	}
+}


### PR DESCRIPTION
Feeding an EntryNormal with an empty body into the apply loop:

    panic: runtime error: index out of range [0] with length 0
        server.(*jetStream).applyMetaEntries(...)
            server/jetstream_cluster.go:2768

The append entry wire format only requires each entry to carry its one type byte, so `decodeAppendEntry` accepts an `EntryNormal` whose data is zero-length (encoded entry length of 1). That entry reaches the apply layer, which reads the op from `data[0]`.

Before: `collectStreamAndConsumerChanges`, `applyMetaEntries`, `applyStreamEntries` and `applyConsumerEntries` index `data[0]` with no length check, so an empty replicated `EntryNormal` from a cluster peer panics the apply goroutine.

After: each site rejects a zero-length `EntryNormal` with `errBadEntryOp` before the switch, the same guard `processCatchupMsg` already applies before `entryOp(msg[0])`. Valid entries always carry the op byte, so decoding of real traffic is unchanged.

Tradeoff: a malformed entry now fails the apply along the existing decode-rejection paths (peer state / ack / delivered / skip / reset) instead of being silently tolerated.