### PR TITLE
NRG: Ignore votes from removed peers during elections

### DIFF
--- a/server/raft.go
+++ b/server/raft.go
@@ -3755,6 +3755,19 @@ func (n *raft) adjustClusterSizeAndQuorum() {
 	}
 }
 
+// Returns true if we should count vote responses from this peer.
+// Lock should be held.
+func (n *raft) shouldCountVoteFromPeer(peer string) bool {
+	if _, ok := n.peers[peer]; ok {
+		return true
+	}
+	// During bootstrap, we may know fewer peer ids
+	// than the declared cluster size. Initially, we
+	// may need to accept votes from peers that are
+	// not yet in the peer set.
+	return len(n.peers) < n.csz
+}
+
 // Track interactions with this peer.
 func (n *raft) trackPeer(peer string) error {
 	n.Lock()
@@ -3826,15 +3839,18 @@ func (n *raft) runAsCandidate() {
 			n.RLock()
 			nterm := n.term
 			csz := n.csz
+			countVote := n.shouldCountVoteFromPeer(vresp.peer)
 			n.RUnlock()
 
 			if vresp.granted && nterm == vresp.term {
 				// only track peers that would be our followers
 				n.trackPeer(vresp.peer)
-				if !vresp.empty {
-					votes[vresp.peer] = struct{}{}
-				} else {
-					emptyVotes[vresp.peer] = struct{}{}
+				if countVote {
+					if !vresp.empty {
+						votes[vresp.peer] = struct{}{}
+					} else {
+						emptyVotes[vresp.peer] = struct{}{}
+					}
 				}
 				if n.wonElection(len(votes)) {
 					// Become LEADER if we have won and gotten a quorum with everyone we should hear from.

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -7255,3 +7255,51 @@ func TestNRGLeaderWithoutQuorumAfterPeerAdd(t *testing.T) {
 		})
 	}
 }
+
+func TestNRGRemovedPeerVoteDoesNotElectLeader(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R4S", 4)
+	defer c.shutdown()
+
+	hub, rg := c.createMockMemRaftGroup("MOCK", 4, newStateAdder)
+	defer hub.healPartitions()
+
+	nodeA := rg.waitOnLeader()
+	require_NotNil(t, nodeA)
+
+	followers := rg.followers()
+	require_Equal(t, len(followers), 3)
+	nodeB, nodeC, nodeD := followers[0], followers[1], followers[2]
+
+	// Partition D away and then remove it.
+	// D never learns that it is no longer part of the group.
+	hub.partition(nodeD.node().ID(), 1)
+
+	require_NoError(t, nodeA.node().ProposeRemovePeer(nodeD.node().ID()))
+	valid := smGroup{nodeA, nodeB, nodeC}
+	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+		for _, sm := range valid {
+			node := sm.node()
+			if size := node.ClusterSize(); size != 3 {
+				return fmt.Errorf("%q has cluster size %d", node.ID(), size)
+			}
+		}
+		return nil
+	})
+
+	// Partition C with D, leaving two partitions:
+	//  - {A, B} which has a valid quorum
+	//  - {C, D} which is not supposed to have a leader
+	hub.partition(nodeC.node().ID(), 1)
+	require_NoError(t, nodeC.node().CampaignImmediately())
+
+	err := checkForErr(time.Second, 10*time.Millisecond, func() error {
+		if nodeC.node().State() == Leader {
+			return nil
+		}
+		return fmt.Errorf("%q has not become leader", nodeC.node().ID())
+	})
+	if err == nil {
+		t.Fatalf("removed peer %q helped elect second leader %q while %q was leader",
+			nodeD.node().ID(), nodeC.node().ID(), nodeA.node().ID())
+	}
+}


### PR DESCRIPTION
Make sure that candidates do not accept vote responses from peers that are no longer part of membership.
Keep accepting votes from peers that are not in `n.peers` during bootstrap, when the declared cluster size may still be larger than the peer set.
