### PR TITLE
bound node count in avl seqset decode to buffer length

### DIFF
--- a/server/avl/seqset.go
+++ b/server/avl/seqset.go
@@ -302,8 +302,11 @@ func decodev2(buf []byte) (*SequenceSet, int, error) {
 	sz := int(le.Uint32(buf[index+4:]))
 	index += 8
 
-	expectedLen := minLen + (nn * ((numBuckets+1)*8 + 2))
-	if len(buf) < expectedLen {
+	// nn is decoded as a uint32 but held in an int. On 32-bit builds a value
+	// above MaxInt32 turns negative and nn*perNode below overflows, so the
+	// length check would pass for a short buffer and the following make/reads
+	// run off the end. Compare with division so the bound holds on every arch.
+	if nn < 0 || nn > (len(buf)-minLen)/((numBuckets+1)*8+2) {
 		return nil, -1, ErrBadEncoding
 	}
 
@@ -335,8 +338,9 @@ func decodev1(buf []byte) (*SequenceSet, int, error) {
 
 	const v1NumBuckets = 64
 
-	expectedLen := minLen + (nn * ((v1NumBuckets+1)*8 + 2))
-	if len(buf) < expectedLen {
+	// See decodev2: guard the node count without overflowing the multiply so
+	// the bound stays correct on 32-bit builds too.
+	if nn < 0 || nn > (len(buf)-minLen)/((v1NumBuckets+1)*8+2) {
 		return nil, -1, ErrBadEncoding
 	}
 

--- a/server/avl/seqset_test.go
+++ b/server/avl/seqset_test.go
@@ -15,6 +15,7 @@ package avl
 
 import (
 	"encoding/base64"
+	"encoding/binary"
 	"math/rand"
 	"testing"
 )
@@ -302,6 +303,38 @@ FgEDAAAABQAAAABgAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 	require_True(t, ss.Size() == len(seqs))
 	for _, seq := range seqs {
 		require_True(t, ss.Exists(seq))
+	}
+}
+
+func TestSeqSetDecodeNodeCountOverflow(t *testing.T) {
+	// A replicated stream state carries an avl-encoded delete map decoded from
+	// a peer. The node count is read as a uint32 into an int; on 32-bit builds
+	// a value above MaxInt32 turns negative (and a smaller value can overflow
+	// the nn*perNode multiply), defeating the length check so the decode then
+	// panics in make([]node, nn) or reads past the buffer. Both encodings must
+	// reject such counts on every architecture instead.
+	le := binary.LittleEndian
+	for _, ver := range []uint8{1, 2} {
+		buf := make([]byte, minLen)
+		buf[0], buf[1] = magic, ver
+		le.PutUint32(buf[2:], 0xFFFFFFFF) // node count, negative as a 32-bit int
+		if _, _, err := Decode(buf); err != ErrBadEncoding {
+			t.Fatalf("v%d: expected ErrBadEncoding for oversized node count, got %v", ver, err)
+		}
+
+		// Positive on 32-bit but the multiply still overflows for a short buffer.
+		le.PutUint32(buf[2:], 0x00800000)
+		if _, _, err := Decode(buf); err != ErrBadEncoding {
+			t.Fatalf("v%d: expected ErrBadEncoding for overflowing node count, got %v", ver, err)
+		}
+	}
+
+	// A well-formed single-node v2 buffer must still decode.
+	valid := make([]byte, minLen+(numBuckets+1)*8+2)
+	valid[0], valid[1] = magic, version
+	le.PutUint32(valid[2:], 1)
+	if _, _, err := Decode(valid); err != nil {
+		t.Fatalf("valid single-node buffer should decode, got %v", err)
 	}
 }
 


### PR DESCRIPTION
decodev2 and decodev1 in server/avl/seqset.go read the node count as a uint32 into an int, then size-check the buffer with `expectedLen = minLen + nn*perNode`. On the shipped 386 and arm targets an int is 32 bits, so a node count above MaxInt32 goes negative and the multiply overflows, and the length check then passes for a short buffer. The set is peer-supplied: a replicated stream state carries an avl-encoded delete map, so `DecodeStreamState` calls `avl.Decode` on bytes from another server, and a 32-bit follower panics in `make([]node, nn)` with a negative length or reads past the buffer.

Before, the count feeds a multiply that can wrap before the comparison. After, the same bound is checked with division, `nn > (len(buf)-minLen)/perNode`, plus an explicit `nn < 0` reject, neither of which can overflow at any int width. Valid input decodes exactly as before, and keeping the guard in the decoder covers every caller (store.go, filestore.go) instead of each one re-checking. 64-bit builds were already safe here, so the only behavioral change is that the 32-bit targets reject the malformed count instead of crashing.
