### PR TITLE
(2.14) [FIXED] Stale response received for mirror/source create retry

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -24265,6 +24265,170 @@ func TestJetStreamMirrorProcessInboundNilDeref(t *testing.T) {
 	wg.Wait()
 }
 
+func TestJetStreamMirrorConsumerRetryUsesFreshReplySubject(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	// Route the mirror's consumer create requests to our own fake API, so we fully control
+	// the request/response loop instead of racing the server's real JetStream API handler.
+	const apiPrefix = "$FAKE.API"
+	reqCh := make(chan *nats.Msg, 4)
+	_, err := nc.Subscribe(apiPrefix+".CONSUMER.CREATE.>", func(m *nats.Msg) {
+		reqCh <- m
+	})
+	require_NoError(t, err)
+	require_NoError(t, nc.Flush())
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name: "MIRROR",
+		Mirror: &nats.StreamSource{
+			Name:     "ORIGIN",
+			External: &nats.ExternalStream{APIPrefix: apiPrefix},
+		},
+	})
+	require_NoError(t, err)
+
+	mset, err := s.globalAccount().lookupStream("MIRROR")
+	require_NoError(t, err)
+
+	// Original request.
+	m1 := require_ChanRead(t, reqCh, time.Second)
+	var ccr1 CreateConsumerRequest
+	require_NoError(t, json.Unmarshal(m1.Data, &ccr1))
+	require_True(t, ccr1.Config.Sourcing)
+	reply1 := m1.Reply
+
+	// Answer with a required API level error.
+	errResp, err := json.Marshal(JSApiConsumerCreateResponse{
+		ApiResponse: ApiResponse{Error: NewJSRequiredApiLevelError()},
+	})
+	require_NoError(t, err)
+	require_NoError(t, nc.Publish(reply1, errResp))
+	require_NoError(t, nc.Flush())
+
+	// Retry request.
+	m2 := require_ChanRead(t, reqCh, time.Second)
+	var ccr2 CreateConsumerRequest
+	require_NoError(t, json.Unmarshal(m2.Data, &ccr2))
+	require_False(t, ccr2.Config.Sourcing)
+	reply2 := m2.Reply
+	require_NotEqual(t, reply1, reply2)
+
+	staleResp, err := json.Marshal(JSApiConsumerCreateResponse{
+		ApiResponse: ApiResponse{Error: NewJSStreamNotFoundError()},
+	})
+	require_NoError(t, err)
+	require_NoError(t, nc.Publish(reply1, staleResp))
+
+	okResp, err := json.Marshal(JSApiConsumerCreateResponse{
+		ConsumerInfo: &ConsumerInfo{Name: ccr2.Config.Name, Config: &ccr2.Config},
+	})
+	require_NoError(t, err)
+	require_NoError(t, nc.Publish(reply2, okResp))
+	require_NoError(t, nc.Flush())
+
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		mset.mu.RLock()
+		defer mset.mu.RUnlock()
+		if mset.mirror == nil {
+			return fmt.Errorf("mirror was removed")
+		}
+		if mset.mirror.err != nil {
+			return fmt.Errorf("mirror is in error state: %v", mset.mirror.err)
+		}
+		if mset.mirror.cname != ccr2.Config.Name {
+			return fmt.Errorf("expected consumer name %q, got %q", ccr2.Config.Name, mset.mirror.cname)
+		}
+		return nil
+	})
+}
+
+func TestJetStreamSourceConsumerRetryUsesFreshReplySubject(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	// Route the mirror's consumer create requests to our own fake API, so we fully control
+	// the request/response loop instead of racing the server's real JetStream API handler.
+	const apiPrefix = "$FAKE.API"
+	reqCh := make(chan *nats.Msg, 4)
+	_, err := nc.Subscribe(apiPrefix+".CONSUMER.CREATE.>", func(m *nats.Msg) {
+		reqCh <- m
+	})
+	require_NoError(t, err)
+	require_NoError(t, nc.Flush())
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name: "SOURCE",
+		Sources: []*nats.StreamSource{
+			{
+				Name:     "ORIGIN",
+				External: &nats.ExternalStream{APIPrefix: apiPrefix},
+			},
+		},
+	})
+	require_NoError(t, err)
+
+	mset, err := s.globalAccount().lookupStream("SOURCE")
+	require_NoError(t, err)
+
+	// Original request.
+	m1 := require_ChanRead(t, reqCh, time.Second)
+	var ccr1 CreateConsumerRequest
+	require_NoError(t, json.Unmarshal(m1.Data, &ccr1))
+	require_True(t, ccr1.Config.Sourcing)
+	reply1 := m1.Reply
+
+	// Answer with a required API level error.
+	errResp, err := json.Marshal(JSApiConsumerCreateResponse{
+		ApiResponse: ApiResponse{Error: NewJSRequiredApiLevelError()},
+	})
+	require_NoError(t, err)
+	require_NoError(t, nc.Publish(reply1, errResp))
+	require_NoError(t, nc.Flush())
+
+	// Retry request.
+	m2 := require_ChanRead(t, reqCh, time.Second)
+	var ccr2 CreateConsumerRequest
+	require_NoError(t, json.Unmarshal(m2.Data, &ccr2))
+	require_False(t, ccr2.Config.Sourcing)
+	reply2 := m2.Reply
+	require_NotEqual(t, reply1, reply2)
+
+	staleResp, err := json.Marshal(JSApiConsumerCreateResponse{
+		ApiResponse: ApiResponse{Error: NewJSStreamNotFoundError()},
+	})
+	require_NoError(t, err)
+	require_NoError(t, nc.Publish(reply1, staleResp))
+
+	okResp, err := json.Marshal(JSApiConsumerCreateResponse{
+		ConsumerInfo: &ConsumerInfo{Name: ccr2.Config.Name, Config: &ccr2.Config},
+	})
+	require_NoError(t, err)
+	require_NoError(t, nc.Publish(reply2, okResp))
+	require_NoError(t, nc.Flush())
+
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		mset.mu.RLock()
+		defer mset.mu.RUnlock()
+		for _, si := range mset.sources {
+			if si.err != nil {
+				return fmt.Errorf("source is in error state: %v", si.err)
+			}
+			if si.cname != ccr2.Config.Name {
+				return fmt.Errorf("expected consumer name %q, got %q", ccr2.Config.Name, si.cname)
+			}
+			return nil
+		}
+		return fmt.Errorf("source info not found")
+	})
+}
+
 func TestJetStreamMirrorRetriesOnSeqAlreadySeenMismatch(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/stream.go
+++ b/server/stream.go
@@ -3570,22 +3570,26 @@ func (mset *stream) setupMirrorConsumer() error {
 		}
 	}
 
-	respCh := make(chan *JSApiConsumerCreateResponse, 1)
-	reply := infoReplySubject()
-	crSub, err := mset.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-		_, msg := c.msgParts(rmsg)
+	newReplySubscription := func() (string, chan *JSApiConsumerCreateResponse, *subscription, error) {
+		respCh := make(chan *JSApiConsumerCreateResponse, 1)
+		reply := infoReplySubject()
+		crSub, err := mset.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+			_, msg := c.msgParts(rmsg)
 
-		var ccr JSApiConsumerCreateResponse
-		if err := json.Unmarshal(msg, &ccr); err != nil {
-			c.Warnf("JetStream bad mirror consumer create response: %q", msg)
-			mset.setMirrorErr(ApiErrors[JSInvalidJSONErr])
-			return
-		}
-		select {
-		case respCh <- &ccr:
-		default:
-		}
-	})
+			var ccr JSApiConsumerCreateResponse
+			if err := json.Unmarshal(msg, &ccr); err != nil {
+				c.Warnf("JetStream bad mirror consumer create response: %q", msg)
+				mset.setMirrorErr(ApiErrors[JSInvalidJSONErr])
+				return
+			}
+			select {
+			case respCh <- &ccr:
+			default:
+			}
+		})
+		return reply, respCh, crSub, err
+	}
+	reply, respCh, crSub, err := newReplySubscription()
 	if err != nil {
 		mirror.err = NewJSMirrorConsumerSetupFailedError(err, Unless(err))
 		mset.scheduleSetupMirrorConsumerRetry()
@@ -3688,6 +3692,14 @@ func (mset *stream) setupMirrorConsumer() error {
 					b, _ := json.Marshal(req)
 					// Regenerate subject since the previous name could've been included in it.
 					subject = generateSubject()
+					// Recreate the reply subscription so we don't get stale responses from other servers.
+					mset.unsubscribe(crSub)
+					if reply, respCh, crSub, err = newReplySubscription(); err != nil {
+						mirror.err = NewJSMirrorConsumerSetupFailedError(err, Unless(err))
+						retry = true
+						mset.mu.Unlock()
+						return
+					}
 					mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, nil, b, nil, 0))
 					mset.mu.Unlock()
 					goto SELECT
@@ -4004,20 +4016,24 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 	}
 	req.Config.FilterSubjects = filterSubjects
 
-	respCh := make(chan *JSApiConsumerCreateResponse, 1)
-	reply := infoReplySubject()
-	crSub, err := mset.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-		_, msg := c.msgParts(rmsg)
-		var ccr JSApiConsumerCreateResponse
-		if err := json.Unmarshal(msg, &ccr); err != nil {
-			c.Warnf("JetStream bad source consumer create response: %q", msg)
-			return
-		}
-		select {
-		case respCh <- &ccr:
-		default:
-		}
-	})
+	newReplySubscription := func() (string, chan *JSApiConsumerCreateResponse, *subscription, error) {
+		respCh := make(chan *JSApiConsumerCreateResponse, 1)
+		reply := infoReplySubject()
+		crSub, err := mset.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+			_, msg := c.msgParts(rmsg)
+			var ccr JSApiConsumerCreateResponse
+			if err := json.Unmarshal(msg, &ccr); err != nil {
+				c.Warnf("JetStream bad source consumer create response: %q", msg)
+				return
+			}
+			select {
+			case respCh <- &ccr:
+			default:
+			}
+		})
+		return reply, respCh, crSub, err
+	}
+	reply, respCh, crSub, err := newReplySubscription()
 	if err != nil {
 		si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
 		mset.setupSourceConsumer(iname, seq, startTime)
@@ -4109,6 +4125,14 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 						b, _ := json.Marshal(req)
 						// Regenerate subject since the previous name could've been included in it.
 						subject = generateSubject()
+						// Recreate the reply subscription so we don't get stale responses from other servers.
+						mset.unsubscribe(crSub)
+						if reply, respCh, crSub, err = newReplySubscription(); err != nil {
+							si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
+							retry = true
+							mset.mu.Unlock()
+							return
+						}
 						mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, nil, b, nil, 0))
 						mset.mu.Unlock()
 						goto SELECT


### PR DESCRIPTION
The mirror/source recreation path used the same reply subject and subscription. Since many servers might have returned error responses, we need to recreate the reply subject and subscription to not receive stale error responses.