### PR TITLE
reject oversized message length in decodeStreamMsg

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -10052,7 +10052,10 @@ func decodeStreamMsg(buf []byte) (subject, reply string, hdr, msg []byte, lseq u
 	}
 	ml := int(le.Uint32(buf))
 	buf = buf[4:]
-	if len(buf) < ml {
+	// ml is read as a uint32 but held in an int; on 32-bit builds a length with
+	// the high bit set becomes negative, which slips past len(buf) < ml and then
+	// panics on buf[:ml]. Reject a negative length so the bound holds everywhere.
+	if ml < 0 || len(buf) < ml {
 		return _EMPTY_, _EMPTY_, nil, nil, 0, 0, false, errBadStreamMsg
 	}
 	if msg = buf[:ml]; len(msg) == 0 {

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -8688,6 +8688,34 @@ func TestJetStreamClusterDecodeUpdatesRejectMalformed(t *testing.T) {
 	})
 }
 
+func TestJetStreamClusterDecodeStreamMsgRejectOversizedLength(t *testing.T) {
+	// A valid replicated stream msg still round trips.
+	esm := encodeStreamMsg("foo", _EMPTY_, nil, []byte("hello"), 1, 0, false)
+	subject, _, _, msg, lseq, _, _, err := decodeStreamMsg(esm[1:])
+	require_NoError(t, err)
+	require_Equal(t, subject, "foo")
+	require_Equal(t, lseq, 1)
+	require_Equal(t, string(msg), "hello")
+
+	// The message length is read as a uint32 into an int. On 32-bit builds a
+	// value with the high bit set turns negative and slips past the
+	// len(buf) < ml check, so the following buf[:ml] panics. Such a length must
+	// be rejected on every architecture rather than decoded. This mirrors what a
+	// cluster peer could replicate on the applyStreamMsgOp/catchup path.
+	le := binary.LittleEndian
+	var buf []byte
+	buf = le.AppendUint64(buf, 1) // lseq
+	buf = le.AppendUint64(buf, 0) // ts
+	buf = le.AppendUint16(buf, 3) // subject length
+	buf = append(buf, "foo"...)
+	buf = le.AppendUint16(buf, 0)          // reply length
+	buf = le.AppendUint16(buf, 0)          // header length
+	buf = le.AppendUint32(buf, 0xFFFFFFFF) // message length, negative as a 32-bit int
+	if _, _, _, _, _, _, _, err := decodeStreamMsg(buf); err != errBadStreamMsg {
+		t.Fatalf("expected errBadStreamMsg for oversized message length, got %v", err)
+	}
+}
+
 func TestJetStreamClusterApplyEntriesRejectEmptyNormal(t *testing.T) {
 	// The append entry wire format only requires each entry to carry its type
 	// byte, so a cluster peer can replicate an EntryNormal with a zero-length


### PR DESCRIPTION
    panic: runtime error: slice bounds out of range [:-1]
        decodeStreamMsg  server/jetstream_cluster.go  (buf[:ml])

`ml` is `int(le.Uint32(buf))`. On the 386/arm targets `int` is 32 bits, so a length with the high bit set reads back negative and `len(buf) < ml` compares a positive against a negative, which is false. Decode falls through to `buf[:ml]` and panics. The decoder sits behind `applyStreamMsgOp` and `processCatchupMsg`, so one malformed `streamMsgOp` entry from a peer crashes a 32-bit follower's apply/catchup goroutine.

Before: a negative `ml` slips past the guard on 32-bit; a large positive `ml` was already rejected.
After: `ml < 0` is rejected next to the existing `len(buf) < ml`, so the bound holds on every arch.

64-bit builds see no behavior change, since `int(uint32)` is never negative there. The cost is one comparison on the decode path.
