### PR TITLE
[FIXED] MQTT: Reuse of QoS 1/2 packet identifiers within a delivery burst

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -3327,6 +3327,9 @@ func (sess *mqttSession) clear(noWait bool) error {
 	sess.pubRelConsumer = nil
 	sess.seq = 0
 	sess.tmaxack = 0
+	// Discarded session: reset the PI counter too so a reused session object
+	// does not inherit the previous session's identifiers. Spec [MQTT-3.1.2-6].
+	sess.last_pi = 0
 	sess.mu.Unlock()
 
 	for _, dur := range durs {
@@ -3528,9 +3531,9 @@ func (sess *mqttSession) untrackPublish(pi uint16) (jsAckSubject string) {
 	}
 
 	delete(sess.pendingPublish, pi)
-	if len(sess.pendingPublish) == 0 {
-		sess.last_pi = 0
-	}
+	// Do NOT reset last_pi here: it is a monotonic rolling counter (see bumpPI) so
+	// a just-freed id is not reused within a delivery burst, which a client would
+	// read as a duplicate. Spec [MQTT-2.3.1-4].
 
 	if len(sess.cpending) != 0 && ack.jsDur != _EMPTY_ {
 		if sseqToPi := sess.cpending[ack.jsDur]; sseqToPi != nil {
@@ -5596,9 +5599,7 @@ func (c *client) mqttProcessUnsubs(filters []*mqttFilter) error {
 				for _, pi := range seqPis {
 					delete(sess.pendingPublish, pi)
 				}
-				if len(sess.pendingPublish) == 0 {
-					sess.last_pi = 0
-				}
+				// last_pi stays monotonic (see untrackPublish); do not reset here.
 			}
 			sess.mu.Unlock()
 		}

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -6032,6 +6032,43 @@ func TestMQTTRedeliveryAckWait(t *testing.T) {
 	}
 }
 
+// [MQTT-2.3.1-4] A QoS 1/2 packet identifier must not be reused while it (or an
+// earlier one) is still in flight, and clients treat a just-freed identifier
+// re-appearing within a delivery burst as a duplicate. Deliver-and-ack one
+// message so pendingPublish momentarily empties, then deliver a second: its
+// packet identifier must advance rather than reset to the first one.
+func TestMQTTPacketIdentifierMonotonicAfterAck(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: true}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+
+	// First message: receive it, then PUBACK so pendingPublish drains back to
+	// empty before the next delivery is assigned an identifier.
+	testMQTTPublish(t, cp, rp, 1, false, false, "foo", 1, []byte("msg1"))
+	pi1 := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("msg1"))
+	testMQTTSendPIPacket(mqttPacketPubAck, t, c, pi1)
+	testMQTTFlush(t, c, nil, r)
+
+	// Second message: its identifier must not reuse the freed one.
+	testMQTTPublish(t, cp, rp, 1, false, false, "foo", 1, []byte("msg2"))
+	pi2 := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("msg2"))
+	if pi2 == pi1 {
+		t.Fatalf("Packet identifier was reset and reused after ack: pi1=%v pi2=%v", pi1, pi2)
+	}
+	testMQTTSendPIPacket(mqttPacketPubAck, t, c, pi2)
+}
+
 // - [MQTT-3.10.4-3] If a Server deletes a Subscription It MUST complete the
 // delivery of any QoS 1 or QoS 2 messages which it has started to send to the
 // Client.


### PR DESCRIPTION
bumpPI assigns QoS 1/2 packet identifiers by scanning from sess.last_pi. untrackPublish (on PUBACK/PUBCOMP) and the unsubscribe cleanup reset last_pi to 0 whenever pendingPublish became empty, restarting numbering from 1. During a burst of QoS 1 deliveries where the client's PUBACKs interleave between deliveries, pendingPublish momentarily empties, so a just-freed identifier is reused within the same burst. Clients and the 3.1.1 conformance suite (MQTT-2.3.1-4, MQTT-4.6.0-4) treat that as a duplicate / reused-before-ack packet identifier.

Keep last_pi as a monotonic rolling counter (bumpPI already wraps at 0xFFFF and skips in-use identifiers) and reset it only in sess.clear(), so a discarded/reused session does not inherit the previous session's identifiers either. Spec [MQTT-2.3.1-4], [MQTT-3.1.2-6].

