### PR TITLE
[FIXED] MQTT: Pending QoS 1/2 deliveries leak when a subscription is downgraded to QoS 0

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -380,6 +380,12 @@ type mqttSub struct {
 	qos   byte
 	jsDur string
 
+	// closed marks the subscription as torn down (QoS downgrade to 0, or
+	// unsubscribe) so QoS 1/2 delivery callbacks stop tracking new messages for
+	// it. Guarded like qos/jsDur (sess.mu or sess.subsMu). Unlike clearing
+	// sub.mqtt, this keeps the struct valid for an in-flight enqueue.
+	closed bool
+
 	// Pending serialization of retained messages to be sent when subscription
 	// is registered. The sub's delivery callbacks must wait until `prm` is
 	// ready (can block on sess.mu for that, too).
@@ -2485,6 +2491,8 @@ func (sess *mqttSession) processSub(
 		// accessing it later requires a lock.
 		ss.mqtt.qos = qos
 		ss.mqtt.jsDur = jsDurName
+		// A (re)configured subscription is live; clear any prior teardown mark.
+		ss.mqtt.closed = false
 	}
 
 	if len(rms) > 0 {
@@ -2716,7 +2724,7 @@ func (as *mqttAccountSessionManager) serializeRetainedMsgsForSub(rms map[string]
 			return
 		}
 		if qos > 0 {
-			pi = sess.trackPublishRetained()
+			pi = sess.trackPublishRetained(string(sub.sid))
 
 			// If we failed to get a PI for this message, send it as a QoS0, the
 			// best we can do?
@@ -3414,14 +3422,23 @@ func (sess *mqttSession) bumpPI() uint16 {
 	return sess.last_pi
 }
 
+// mqttRetainedPendingDur returns the pseudo consumer-durable key under which a
+// subscription's in-flight retained QoS deliveries are tracked in cpending.
+// Retained deliveries have no JS consumer, but keying them per subscription
+// lets unsubscribe/downgrade teardown purge them like consumer deliveries.
+// Cannot collide with real durables (idHash+"_"+nuid, $MQTT_PUBREL_ prefix).
+func mqttRetainedPendingDur(sid string) string {
+	return mqttRetainedMsgsStreamName + "/" + sid
+}
+
 // trackPublishRetained is invoked when a retained (QoS) message is published.
-// It need a new PI to be allocated, so we add it to the pendingPublish map,
-// with an empty value. Since cpending (not pending) is used to serialize the PI
-// mappings, we need to add this PI there as well. Make a unique key by using
-// mqttRetainedMsgsStreamName for the durable name, and PI for sseq.
+// It needs a new PI to be allocated, so we add it to the pendingPublish map,
+// and serialize it in cpending under the subscription's pseudo-durable key
+// (with the PI as the sequence) so consumer teardown purges it; an ack removes
+// both entries via untrackPublish.
 //
 // Lock held on entry
-func (sess *mqttSession) trackPublishRetained() uint16 {
+func (sess *mqttSession) trackPublishRetained(sid string) uint16 {
 	// Make sure we initialize the tracking maps.
 	if sess.pendingPublish == nil {
 		sess.pendingPublish = make(map[uint16]*mqttPending)
@@ -3434,7 +3451,14 @@ func (sess *mqttSession) trackPublishRetained() uint16 {
 	if pi == 0 {
 		return 0
 	}
-	sess.pendingPublish[pi] = &mqttPending{}
+	dur := mqttRetainedPendingDur(sid)
+	sseqToPi := sess.cpending[dur]
+	if sseqToPi == nil {
+		sseqToPi = make(map[uint64]uint16)
+		sess.cpending[dur] = sseqToPi
+	}
+	sseqToPi[uint64(pi)] = pi
+	sess.pendingPublish[pi] = &mqttPending{jsDur: dur, sseq: uint64(pi)}
 
 	return pi
 }
@@ -5045,7 +5069,7 @@ func mqttDeliverMsgCbQoS12(sub *subscription, pc *client, _ *Account, subject, r
 	// track of pending acks, etc. There is no need to acquire the subsMu RLock
 	// since sess.Lock is overarching for modifying subscriptions.
 	sess.mu.Lock()
-	if sess.c != cc || sub.mqtt == nil {
+	if sess.c != cc || sub.mqtt == nil || sub.mqtt.closed {
 		sess.mu.Unlock()
 		return
 	}
@@ -5442,8 +5466,32 @@ func (sess *mqttSession) processJSConsumer(c *client, subject, sid string,
 			sub := c.subs[cc.DeliverSubject]
 			c.mu.Unlock()
 
+			// Delete the consumer entry, mark its delivery subscription closed,
+			// and purge its pending QoS 1/2 deliveries — all under the session
+			// lock. Otherwise those packet identifiers leak and count against the
+			// in-flight cap for the life of the session (as mqttProcessUnsubs
+			// purges on unsubscribe). deleteConsumer is asynchronous, so an
+			// in-flight delivery callback could re-populate the maps after the
+			// purge; marking sub.mqtt.closed (guarded by sess.mu and sess.subsMu,
+			// same as delivery) makes mqttDeliverMsgCbQoS12 skip instead. The flag
+			// leaves sub.mqtt valid so an already-committed enqueue does not panic.
 			sess.mu.Lock()
 			delete(sess.cons, sid)
+			if sub != nil && sub.mqtt != nil {
+				sess.subsMu.Lock()
+				sub.mqtt.closed = true
+				sess.subsMu.Unlock()
+			}
+			// Also purge this sid's in-flight retained deliveries, tracked
+			// under a pseudo-durable key (no JS consumer, no redelivery).
+			for _, dur := range [...]string{cc.Durable, mqttRetainedPendingDur(sid)} {
+				if seqPis, ok := sess.cpending[dur]; ok {
+					delete(sess.cpending, dur)
+					for _, pi := range seqPis {
+						delete(sess.pendingPublish, pi)
+					}
+				}
+			}
 			sess.mu.Unlock()
 
 			sess.deleteConsumer(cc)
@@ -5592,14 +5640,31 @@ func (c *client) mqttProcessUnsubs(filters []*mqttFilter) error {
 		if ok {
 			delete(sess.cons, sid)
 			sess.deleteConsumer(cc)
+
+			c.mu.Lock()
+			sub := c.subs[cc.DeliverSubject]
+			c.mu.Unlock()
+
 			// Need lock here since these are accessed by callbacks
 			sess.mu.Lock()
-			if seqPis, ok := sess.cpending[cc.Durable]; ok {
-				delete(sess.cpending, cc.Durable)
-				for _, pi := range seqPis {
-					delete(sess.pendingPublish, pi)
+			// Mark the delivery sub closed so an in-flight QoS 1/2 callback stops
+			// tracking new messages after the purge (deleteConsumer is async);
+			// same barrier as the QoS 0 downgrade path in processJSConsumer.
+			if sub != nil && sub.mqtt != nil {
+				sess.subsMu.Lock()
+				sub.mqtt.closed = true
+				sess.subsMu.Unlock()
+			}
+			// Purge both the consumer's deliveries and this sid's in-flight
+			// retained deliveries (tracked under a pseudo-durable key).
+			for _, dur := range [...]string{cc.Durable, mqttRetainedPendingDur(sid)} {
+				if seqPis, ok := sess.cpending[dur]; ok {
+					delete(sess.cpending, dur)
+					for _, pi := range seqPis {
+						delete(sess.pendingPublish, pi)
+					}
+					// last_pi stays monotonic (see untrackPublish); do not reset here.
 				}
-				// last_pi stays monotonic (see untrackPublish); do not reset here.
 			}
 			sess.mu.Unlock()
 		}

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -3215,7 +3215,7 @@ func TestMQTTTrackPendingOverrun(t *testing.T) {
 	sess := mqttSession{}
 
 	sess.last_pi = 0xFFFF
-	pi := sess.trackPublishRetained()
+	pi := sess.trackPublishRetained("foo")
 	if pi != 1 {
 		t.Fatalf("Expected 1, got %v", pi)
 	}
@@ -3230,7 +3230,7 @@ func TestMQTTTrackPendingOverrun(t *testing.T) {
 	}
 
 	delete(sess.pendingPublish, 1234)
-	pi = sess.trackPublishRetained()
+	pi = sess.trackPublishRetained("foo")
 	if pi != 1234 {
 		t.Fatalf("Expected 1234, got %v", pi)
 	}
@@ -6067,6 +6067,71 @@ func TestMQTTPacketIdentifierMonotonicAfterAck(t *testing.T) {
 		t.Fatalf("Packet identifier was reset and reused after ack: pi1=%v pi2=%v", pi1, pi2)
 	}
 	testMQTTSendPIPacket(mqttPacketPubAck, t, c, pi2)
+}
+
+// Re-subscribing a QoS 1/2 filter at QoS 0 deletes its JS consumer; the
+// consumer's pending (unacknowledged) deliveries must be purged too, otherwise
+// their packet identifiers leak and permanently count against the in-flight cap
+// for the life of the session (as mqttProcessUnsubs already does). Same for
+// in-flight retained deliveries, which have no JS consumer at all.
+func TestMQTTQoS0DowngradePurgesPending(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+
+	// Store a retained QoS 1 message before the subscriber connects.
+	testMQTTPublish(t, cp, rp, 1, false, true, "foo", 1, []byte("retained"))
+
+	ci := &mqttConnInfo{clientID: "sub", cleanSess: true}
+	c, r := testMQTTConnect(t, ci, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+
+	// Subscribing at QoS 1 delivers the retained message; receive it without
+	// acking: tracked as pending under the sid's retained pseudo-durable.
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagRetain, []byte("retained"))
+
+	// Deliver a QoS 1 message and receive it without acking: it is now tracked
+	// as pending against the "foo" consumer.
+	testMQTTPublish(t, cp, rp, 1, false, false, "foo", 2, []byte("msg"))
+	testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("msg"))
+
+	countPending := func() (int, int) {
+		mc := testMQTTGetClient(t, s, "sub")
+		mc.mu.Lock()
+		sess := mc.mqtt.sess
+		mc.mu.Unlock()
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		var np, nc int
+		np = len(sess.pendingPublish)
+		for _, m := range sess.cpending {
+			nc += len(m)
+		}
+		return np, nc
+	}
+
+	if np, nc := countPending(); np != 2 || nc != 2 {
+		t.Fatalf("Expected 2 pending publish/cpending before downgrade, got %v/%v", np, nc)
+	}
+
+	// Re-subscribe the same filter at QoS 0: deletes the JS consumer and must
+	// purge its pending deliveries, consumer-based and retained alike.
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 0}}, []byte{0})
+	// The new subscription re-delivers the retained message, now at QoS 0
+	// (no packet identifier, so nothing new is tracked).
+	testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubFlagRetain, []byte("retained"))
+	testMQTTFlush(t, c, nil, r)
+
+	if np, nc := countPending(); np != 0 || nc != 0 {
+		t.Fatalf("Expected pending maps purged after QoS 0 downgrade, got pendingPublish=%v cpending=%v", np, nc)
+	}
 }
 
 // - [MQTT-3.10.4-3] If a Server deletes a Subscription It MUST complete the


### PR DESCRIPTION
Re-subscribing an existing QoS 1/2 filter at QoS 0 deletes the filter's JS consumer in processJSConsumer, but unlike mqttProcessUnsubs it did not purge the consumer's entries from sess.cpending / sess.pendingPublish. Any message that had a packet identifier assigned but was never acknowledged (e.g. the client disconnected mid-flight) then leaks: no consumer remains to redeliver it, so no PUBACK/PUBCOMP ever arrives, and the identifier permanently counts against the session's in-flight cap (effectiveMaxAck). Over a long-lived session doing repeated QoS 2/1 -> QoS 0 -> QoS 2/1 re-subscribes the budget erodes until QoS 1/2 delivery stalls.

Purge cpending and the associated pendingPublish entries on the QoS 0 downgrade path too. deleteConsumer is asynchronous, so on both teardown paths (downgrade and unsubscribe) an in-flight delivery callback could call trackPublish and repopulate the maps after the purge. Guard against that with a new mqttSub.closed flag, set under sess.mu and sess.subsMu (the delivery-field discipline) in the same critical section as the purge; mqttDeliverMsgCbQoS12 checks it and skips re-tracking. The flag leaves sub.mqtt valid so a delivery already past the guard can still complete its enqueue (which dereferences sub.mqtt) without panicking.

