### PR TITLE
[FIXED] MQTT: Unacknowledged QoS 1/2 messages not re-sent promptly on reconnect

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -176,6 +176,7 @@ const (
 	mqttJSASessPersist    = "SP"
 	mqttJSARetainedMsgDel = "RD"
 	mqttJSAStreamNames    = "SN"
+	mqttJSAConsumerNak    = "NK"
 
 	// This is how long to keep a client in the flappers map before closing the
 	// connection. This prevent quick reconnect from those clients that keep
@@ -335,8 +336,19 @@ type mqttSession struct {
 	// existing PIs.
 	cpending map[string]map[uint64]uint16 // composite key: jsDur, sseq
 
+	// pubRelDone holds stream sequences of stored PUBREL messages whose QoS2
+	// handshake completed (PUBCOMP received) before their JS delivery recorded
+	// an ack subject; the eventual delivery is acked silently instead of
+	// re-sent to the client.
+	pubRelDone map[uint64]struct{}
+
 	// "Last used" publish packet identifier (PI). starting point searching for the next available.
 	last_pi uint16
+
+	// Monotonic allocation ordinal, stamped on pending deliveries as their
+	// packet identifier is assigned; orders replays by original delivery
+	// without 16-bit identifier wraparound ambiguity.
+	allocOrd uint64
 
 	// Maximum number of pending acks for this session.
 	maxp     uint16
@@ -418,6 +430,26 @@ type mqttPending struct {
 	sseq         uint64 // stream sequence
 	jsAckSubject string // the ACK subject to send the ack to
 	jsDur        string // JS durable name
+	ord          uint64 // allocation ordinal (see mqttSession.allocOrd)
+
+	// Original packet of an in-flight retained delivery (no JS consumer), kept
+	// for exact retransmission on session resume [MQTT-4.4.0-1]; the NATS
+	// subject is used to re-check permissions before the replay. The replay is
+	// deferred (retDeferred) behind older still-pending PUBLISHes from the
+	// same subscription, preserving identifier-allocation order.
+	retSubject  string
+	retTopic    string
+	retMsg      []byte
+	retQoS      byte
+	retDeferred bool
+
+	// For a pending PUBREL: the consumer and allocation ordinal of the
+	// original PUBLISH delivery, so a resume replay is deferred (relDeferred)
+	// behind any still-pending earlier PUBLISH from the same consumer,
+	// preserving original message order.
+	origDur     string
+	origOrd     uint64
+	relDeferred bool
 }
 
 type mqttConnectProto struct {
@@ -1717,6 +1749,15 @@ func (jsa *mqttJSA) sendMsg(subj string, msg []byte) {
 	jsa.sendq.push(&mqttJSPubMsg{subj: subj, msg: msg, hdr: -1})
 }
 
+// sendNakRequest NAKs a delivered message on its JS ack subject and waits for
+// the consumer's reply, which is sent only after the NAK has been queued for
+// redelivery. Used on session resume to guarantee the redelivery is in place
+// before the consumer's delivery interest is restored.
+func (jsa *mqttJSA) sendNakRequest(ackSubject string) error {
+	_, err := jsa.newRequestEx(mqttJSAConsumerNak, ackSubject, _EMPTY_, -1, AckNak)
+	return err
+}
+
 func (jsa *mqttJSA) createEphemeralConsumer(cfg *CreateConsumerRequest) (*JSApiConsumerCreateResponse, error) {
 	cfgb, err := json.Marshal(cfg)
 	if err != nil {
@@ -2016,6 +2057,10 @@ func (as *mqttAccountSessionManager) processJSAPIReplies(_ *subscription, pc *cl
 			resp.Error = NewJSInvalidJSONError(err)
 		}
 		out(resp)
+	case mqttJSAConsumerNak:
+		// The reply to a NAK carries no payload of interest; the round trip
+		// itself confirms the consumer processed it. See sendNakRequest.
+		out(nil)
 	default:
 		pc.Warnf("Unknown reply code %q", token)
 	}
@@ -2724,7 +2769,7 @@ func (as *mqttAccountSessionManager) serializeRetainedMsgsForSub(rms map[string]
 			return
 		}
 		if qos > 0 {
-			pi = sess.trackPublishRetained(string(sub.sid))
+			pi = sess.trackPublishRetained(string(sub.sid), string(subj), rm.Topic, rm.Msg, qos)
 
 			// If we failed to get a PI for this message, send it as a QoS0, the
 			// best we can do?
@@ -3331,6 +3376,7 @@ func (sess *mqttSession) clear(noWait bool) error {
 	sess.subs = nil
 	sess.pendingPublish = nil
 	sess.pendingPubRel = nil
+	sess.pubRelDone = nil
 	sess.cpending = nil
 	sess.pubRelConsumer = nil
 	sess.seq = 0
@@ -3338,6 +3384,7 @@ func (sess *mqttSession) clear(noWait bool) error {
 	// Discarded session: reset the PI counter too so a reused session object
 	// does not inherit the previous session's identifiers. Spec [MQTT-3.1.2-6].
 	sess.last_pi = 0
+	sess.allocOrd = 0
 	sess.mu.Unlock()
 
 	for _, dur := range durs {
@@ -3435,10 +3482,12 @@ func mqttRetainedPendingDur(sid string) string {
 // It needs a new PI to be allocated, so we add it to the pendingPublish map,
 // and serialize it in cpending under the subscription's pseudo-durable key
 // (with the PI as the sequence) so consumer teardown purges it; an ack removes
-// both entries via untrackPublish.
+// both entries via untrackPublish. The packet's topic, payload and QoS are
+// recorded so an unacked delivery is retransmitted verbatim on session resume,
+// even if the retained message changes or is deleted meanwhile.
 //
 // Lock held on entry
-func (sess *mqttSession) trackPublishRetained(sid string) uint16 {
+func (sess *mqttSession) trackPublishRetained(sid, subject, topic string, msg []byte, qos byte) uint16 {
 	// Make sure we initialize the tracking maps.
 	if sess.pendingPublish == nil {
 		sess.pendingPublish = make(map[uint16]*mqttPending)
@@ -3458,7 +3507,9 @@ func (sess *mqttSession) trackPublishRetained(sid string) uint16 {
 		sess.cpending[dur] = sseqToPi
 	}
 	sseqToPi[uint64(pi)] = pi
-	sess.pendingPublish[pi] = &mqttPending{jsDur: dur, sseq: uint64(pi)}
+	sess.allocOrd++
+	sess.pendingPublish[pi] = &mqttPending{jsDur: dur, sseq: uint64(pi), ord: sess.allocOrd,
+		retSubject: subject, retTopic: topic, retMsg: msg, retQoS: qos}
 
 	return pi
 }
@@ -3530,10 +3581,12 @@ func (sess *mqttSession) trackPublish(jsDur, jsAckSubject string) (uint16, bool)
 	}
 
 	if ack == nil {
+		sess.allocOrd++
 		sess.pendingPublish[pi] = &mqttPending{
 			jsDur:        jsDur,
 			sseq:         sseq,
 			jsAckSubject: jsAckSubject,
+			ord:          sess.allocOrd,
 		}
 	} else {
 		ack.jsAckSubject = jsAckSubject
@@ -3568,6 +3621,224 @@ func (sess *mqttSession) untrackPublish(pi uint16) (jsAckSubject string) {
 	return ack.jsAckSubject
 }
 
+// resendPendingRedelivery re-sends the session's unacknowledged QoS 1/2
+// PUBLISH and PUBREL packets promptly on session resume, as required by spec
+// [MQTT-4.4.0-1], instead of waiting for the JS consumers' AckWait interval.
+// Pending PUBRELs and in-flight retained deliveries (which have no JS
+// consumer) are re-sent directly; pending PUBLISHes are NAK'd on their JS ack
+// subjects, forcing redelivery with the DUP flag set and the original packet
+// identifiers.
+//
+// It MUST be called BEFORE saved subscriptions are restored: the pending maps
+// then hold only the previous connection's deliveries (fresh ones must not be
+// NAK'd), and queueing the NAKs before the consumers regain delivery interest
+// makes JetStream re-offer those older sequences ahead of messages that
+// arrived while the session was offline, preserving order [MQTT-4.6.0-1].
+// This only takes effect on a same-server reconnect, where the in-memory
+// tracking maps survive; after a restart or failover, redelivery falls back
+// to the AckWait interval.
+//
+// If the disconnect lasted longer than AckWait, the consumer's own pending
+// check may already redeliver a message as interest is re-established; the NAK
+// then produces one extra copy. That is harmless (same packet identifier, DUP
+// set, so the client dedups) and does not happen on a timely reconnect.
+func (sess *mqttSession) resendPendingRedelivery(c *client) {
+	type pendingNak struct {
+		pi         uint16
+		sseq       uint64
+		dur        string
+		ackSubject string
+	}
+	type pendingRetained struct {
+		pi      uint16
+		ord     uint64
+		subject string
+		topic   string
+		msg     []byte
+		qos     byte
+	}
+	sess.mu.Lock()
+	jsa := sess.jsa
+	maxAck := int(sess.maxp)
+	pubNaks := make([]pendingNak, 0, len(sess.pendingPublish))
+	var rets []pendingRetained
+	for pi, ack := range sess.pendingPublish {
+		if ack.jsAckSubject != _EMPTY_ {
+			pubNaks = append(pubNaks, pendingNak{pi, ack.sseq, ack.jsDur, ack.jsAckSubject})
+		} else if ack.retTopic != _EMPTY_ {
+			rets = append(rets, pendingRetained{pi, ack.ord, ack.retSubject, ack.retTopic, ack.retMsg, ack.retQoS})
+		}
+	}
+	rels := make([]uint16, 0, len(sess.pendingPubRel))
+	for pi := range sess.pendingPubRel {
+		rels = append(rels, pi)
+	}
+	sess.mu.Unlock()
+
+	// Reconcile against the messages stream: a QoS1/2 message that was removed
+	// (e.g. by the stream's retention limits) while it was delivered-but-unacked
+	// is gone from the stream, so it can neither be redelivered nor PUBACK'd. Such
+	// an entry would otherwise leak its packet identifier against the in-flight cap
+	// for the life of the session. Drop any entry whose message no longer
+	// exists — below the stream's first sequence, or confirmed absent by an exact
+	// lookup — releasing its packet identifier and skipping its NAK. The lookups
+	// run outside the session lock, and only when something is pending: most
+	// CONNECTs have nothing to reconcile and must not wait on a JS round trip.
+	if len(pubNaks) > 0 {
+		if si, err := jsa.lookupStream(mqttStreamName); err == nil && si != nil {
+			firstSeq := si.State.FirstSeq
+			kept := make([]pendingNak, 0, len(pubNaks))
+			var gone []uint16
+			for _, n := range pubNaks {
+				reaped := n.sseq < firstSeq
+				if !reaped {
+					if _, err := jsa.loadMsg(mqttStreamName, n.sseq); err != nil && !isErrorOtherThan(err, JSNoMessageFoundErr) {
+						reaped = true
+					}
+				}
+				if reaped {
+					gone = append(gone, n.pi)
+				} else {
+					kept = append(kept, n)
+				}
+			}
+			if len(gone) > 0 {
+				sess.mu.Lock()
+				for _, pi := range gone {
+					sess.untrackPublish(pi)
+				}
+				sess.mu.Unlock()
+			}
+			pubNaks = kept
+		}
+	}
+
+	// Replay in-flight retained deliveries and pending PUBRELs directly,
+	// merged in packet-identifier (allocation) order so packets surface to
+	// the client in original message order [MQTT-4.6.0-1]:
+	//
+	// Retained QoS deliveries have no JS consumer to NAK, and the resume path
+	// does not serialize retained messages again (only a client SUBSCRIBE
+	// does), so the exact original packet is re-sent — identifier, topic,
+	// payload and QoS, with DUP and RETAIN set — regardless of how the
+	// retained message changed while offline [MQTT-4.4.0-1]. PUBRELs complete
+	// already-started QoS2 handshakes (the client answers PUBCOMP), and a
+	// placeholder created at PUBREC carries no JS ack subject to NAK at all.
+	//
+	// Either kind is NOT sent now when its original message follows a
+	// still-pending PUBLISH from the same consumer: the client could observe
+	// the newer packet before the older PUBLISH is re-offered. It is deferred
+	// until those earlier deliveries drain (releaseDeferredReplays); for
+	// PUBRELs, AckWait redelivery remains the fallback.
+	if len(rets) > 0 || len(rels) > 0 {
+		type replay struct {
+			pi  uint16
+			ord uint64
+			rel bool
+			ret pendingRetained
+		}
+		replays := make([]replay, 0, len(rets)+len(rels))
+		sess.mu.Lock()
+		for _, ret := range rets {
+			ack := sess.pendingPublish[ret.pi]
+			if ack == nil {
+				continue
+			}
+			if sess.hasPendingPublishBefore(sess.retainedGateDur(ack), ret.ord) {
+				ack.retDeferred = true
+				continue
+			}
+			ack.retDeferred = false
+			replays = append(replays, replay{pi: ret.pi, ord: ret.ord, ret: ret})
+		}
+		for _, pi := range rels {
+			ack := sess.pendingPubRel[pi]
+			if ack == nil {
+				continue
+			}
+			if sess.hasPendingPublishBefore(ack.origDur, ack.origOrd) {
+				ack.relDeferred = true
+				continue
+			}
+			ack.relDeferred = false
+			replays = append(replays, replay{pi: pi, ord: ack.origOrd, rel: true})
+		}
+		sess.mu.Unlock()
+		slices.SortFunc(replays, func(a, b replay) int {
+			if a.ord != b.ord {
+				if a.ord < b.ord {
+					return -1
+				}
+				return 1
+			}
+			return int(a.pi) - int(b.pi)
+		})
+		trace := c.trace
+		var gone []uint16
+		for _, rp := range replays {
+			if rp.rel {
+				c.mqttEnqueuePubResponse(mqttPacketPubRel, rp.pi, trace)
+			} else if !c.mqttReplayRetained(rp.pi, rp.ret.qos, rp.ret.subject, rp.ret.topic, rp.ret.msg) {
+				gone = append(gone, rp.pi)
+			}
+		}
+		if len(gone) > 0 {
+			sess.mu.Lock()
+			for _, pi := range gone {
+				sess.untrackPublish(pi)
+			}
+			sess.mu.Unlock()
+		}
+		// Re-establish the PUBREL delivery subscription only AFTER the
+		// deferrals are marked: restored interest can deliver a stored PUBREL
+		// to mqttDeliverPubRelCb right away, and the callback withholds it
+		// only if relDeferred is already set.
+		if len(rels) > 0 {
+			if err := sess.ensurePubRelConsumerSubscription(c); err != nil {
+				c.Errorf("Unable to re-establish PUBREL delivery on resume: %v", err)
+			}
+		}
+	}
+
+	// PUBLISH redeliveries reuse their packet identifiers and bypass the in-flight
+	// gate, so cap them at the JS MaxAckPending: NAK at most that many, in stream
+	// order; the JS consumer re-offers the rest via AckWait.
+	slices.SortFunc(pubNaks, func(a, b pendingNak) int {
+		switch {
+		case a.sseq < b.sseq:
+			return -1
+		case a.sseq > b.sseq:
+			return 1
+		default:
+			return 0
+		}
+	})
+	if len(pubNaks) > maxAck {
+		pubNaks = pubNaks[:maxAck]
+	}
+	// Each consumer's last NAK is sent as a request and its reply awaited: the
+	// consumer replies only after queueing the redelivery, and acks are handled
+	// in send order, so once the replies are in, every redelivery is in place
+	// before the subscriptions restored after this call give JetStream a way
+	// to deliver anything newer.
+	lastIdx := make(map[string]int, len(pubNaks))
+	for i, n := range pubNaks {
+		lastIdx[n.dur] = i
+	}
+	for i, n := range pubNaks {
+		if lastIdx[n.dur] != i {
+			jsa.sendMsg(n.ackSubject, AckNak)
+		}
+	}
+	for i, n := range pubNaks {
+		if lastIdx[n.dur] == i {
+			if err := jsa.sendNakRequest(n.ackSubject); err != nil {
+				c.Warnf("Resume redelivery NAK not confirmed for %q: %v", n.dur, err)
+			}
+		}
+	}
+}
+
 // trackAsPubRel is invoked in 2 cases: (a) when we receive a PUBREC and we need
 // to change from tracking the PI as a PUBLISH to a PUBREL; and (b) when we
 // attempt to deliver the PUBREL to record the JS ack subject for it.
@@ -3584,9 +3855,19 @@ func (sess *mqttSession) trackAsPubRel(pi uint16, jsAckSubject string) {
 		sess.pendingPubRel = make(map[uint16]*mqttPending)
 	}
 
+	// Preserve the original delivery's ordering info across updates; a
+	// recorded delivery clears any resume deferral (the PUBREL was just sent).
+	var origDur string
+	var origOrd uint64
+	if prev := sess.pendingPubRel[pi]; prev != nil {
+		origDur, origOrd = prev.origDur, prev.origOrd
+	}
+
 	if jsAckSubject == _EMPTY_ {
 		sess.pendingPubRel[pi] = &mqttPending{
-			jsDur: jsDur,
+			jsDur:    jsDur,
+			origDur: origDur,
+			origOrd: origOrd,
 		}
 		return
 	}
@@ -3606,7 +3887,33 @@ func (sess *mqttSession) trackAsPubRel(pi uint16, jsAckSubject string) {
 		jsDur:        sess.pubRelConsumer.Durable,
 		sseq:         sseq,
 		jsAckSubject: jsAckSubject,
+		origDur:      origDur,
+		origOrd:      origOrd,
 	}
+}
+
+// recordPubRelSequence attributes a stored PUBREL's stream sequence to its
+// pending handshake: normally onto the PUBREC placeholder, so a resume replay
+// answered before the JS delivery records an ack subject can be reconciled;
+// or — when the handshake already completed while the store was in flight (a
+// resume replayed the placeholder and the client answered PUBCOMP) — into
+// pubRelDone, so the eventual JS delivery is acked silently instead of being
+// re-sent to the client and re-tracked.
+//
+// Lock NOT held on entry.
+func (sess *mqttSession) recordPubRelSequence(pi uint16, sseq uint64) {
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	if ack, ok := sess.pendingPubRel[pi]; ok {
+		if ack.jsAckSubject == _EMPTY_ && ack.sseq == 0 {
+			ack.sseq = sseq
+		}
+		return
+	}
+	if sess.pubRelDone == nil {
+		sess.pubRelDone = make(map[uint64]struct{})
+	}
+	sess.pubRelDone[sseq] = struct{}{}
 }
 
 // Stops a PI from being tracked as a PUBREL.
@@ -3627,6 +3934,161 @@ func (sess *mqttSession) untrackPubRel(pi uint16) (jsAckSubject string) {
 	}
 
 	return ack.jsAckSubject
+}
+
+// hasPendingPublishBefore returns whether a PUBLISH delivery from the given
+// consumer allocated before ord is still pending (unacknowledged). The
+// allocation ordinal is a 64-bit clock, immune to packet-identifier
+// wraparound even at the maximum in-flight cap.
+//
+// Lock held on entry
+func (sess *mqttSession) hasPendingPublishBefore(dur string, ord uint64) bool {
+	if dur == _EMPTY_ || ord == 0 {
+		return false
+	}
+	for _, ack := range sess.pendingPublish {
+		if ack.jsDur == dur && ack.ord < ord {
+			return true
+		}
+	}
+	return false
+}
+
+// retainedGateDur returns the JS consumer durable whose pending deliveries
+// share a subscription with (and so gate) the given retained delivery, or
+// empty if the subscription has no consumer.
+//
+// Lock held on entry
+func (sess *mqttSession) retainedGateDur(ack *mqttPending) string {
+	sid := strings.TrimPrefix(ack.jsDur, mqttRetainedMsgsStreamName+"/")
+	if cc, ok := sess.cons[sid]; ok {
+		return cc.Durable
+	}
+	return _EMPTY_
+}
+
+// mqttReplayRetained retransmits a pending retained delivery verbatim (DUP and
+// RETAIN set) [MQTT-4.4.0-1], re-checking permissions first — like the
+// original serialization and SUBSCRIBE processing would — since they may have
+// changed while the session was offline. Returns false when the delivery is
+// no longer allowed, so the caller can release its packet identifier.
+func (c *client) mqttReplayRetained(pi uint16, qos byte, subject, topic string, msg []byte) bool {
+	c.mu.Lock()
+	allowed := c.canSubscribeInternal(subject) && !(c.mperms != nil && c.checkDenySub(subject))
+	c.mu.Unlock()
+	if !allowed {
+		return false
+	}
+	flags, headerBytes := mqttMakePublishHeader(pi, qos, true, true, []byte(topic), len(msg))
+	c.mu.Lock()
+	c.enqueueProto(append(headerBytes, msg...))
+	trace := c.trace
+	c.mu.Unlock()
+	if trace {
+		c.traceOutOp("PUBLISH", []byte(mqttPubTrace(&mqttPublish{
+			topic: []byte(topic),
+			flags: flags,
+			pi:    pi,
+			sz:    len(msg),
+		})))
+	}
+	return true
+}
+
+// releaseDeferredReplays sends the retained-PUBLISH and PUBREL replays deferred on
+// session resume behind same-consumer pending PUBLISH redeliveries, once no
+// earlier PUBLISH remains pending. Called when pending PUBLISHes drain (ack,
+// reconcile, or subscription teardown), and bound to the connection that
+// drained the gate: if the session was taken over by another connection
+// meanwhile, the replay is skipped — the new connection must not receive
+// packets before its CONNACK, its own resume path re-evaluates the deferrals,
+// and the PUBREL consumer's AckWait re-offer remains the fallback.
+//
+// Lock NOT held on entry.
+func (sess *mqttSession) releaseDeferredReplays(c *client) {
+	type replay struct {
+		pi             uint16
+		ord            uint64
+		rel            bool
+		qos            byte
+		subject, topic string
+		msg            []byte
+	}
+	sess.mu.Lock()
+	if c == nil || sess.c != c {
+		sess.mu.Unlock()
+		return
+	}
+	var release []replay
+	for pi, ack := range sess.pendingPubRel {
+		if ack.relDeferred && !sess.hasPendingPublishBefore(ack.origDur, ack.origOrd) {
+			ack.relDeferred = false
+			release = append(release, replay{pi: pi, ord: ack.origOrd, rel: true})
+		}
+	}
+	for pi, ack := range sess.pendingPublish {
+		if ack.retDeferred && !sess.hasPendingPublishBefore(sess.retainedGateDur(ack), ack.ord) {
+			ack.retDeferred = false
+			release = append(release, replay{pi: pi, ord: ack.ord, qos: ack.retQoS,
+				subject: ack.retSubject, topic: ack.retTopic, msg: ack.retMsg})
+		}
+	}
+	sess.mu.Unlock()
+	if len(release) == 0 {
+		return
+	}
+	// Merged in identifier (allocation) order, so packets surface to the
+	// client in original message order across kinds [MQTT-4.6.0-1].
+	slices.SortFunc(release, func(a, b replay) int {
+		if a.ord != b.ord {
+			if a.ord < b.ord {
+				return -1
+			}
+			return 1
+		}
+		return int(a.pi) - int(b.pi)
+	})
+	var gone []uint16
+	for _, r := range release {
+		if r.rel {
+			c.mqttEnqueuePubResponse(mqttPacketPubRel, r.pi, c.trace)
+		} else if !c.mqttReplayRetained(r.pi, r.qos, r.subject, r.topic, r.msg) {
+			gone = append(gone, r.pi)
+		}
+	}
+	if len(gone) > 0 {
+		sess.mu.Lock()
+		for _, pi := range gone {
+			sess.untrackPublish(pi)
+		}
+		sess.mu.Unlock()
+	}
+}
+
+// detachDeliverySubs synchronously removes a replaced client's QoS 1/2 and
+// PUBREL delivery subscriptions on session takeover, so redeliveries go to
+// the redelivery queue (and later the new client's subscriptions) instead of
+// being routed to the dying connection and dropped.
+//
+// Lock not held on entry.
+func (sess *mqttSession) detachDeliverySubs(ec *client) {
+	sess.mu.Lock()
+	subjects := make([]string, 0, len(sess.cons)+1)
+	for _, cc := range sess.cons {
+		subjects = append(subjects, cc.DeliverSubject)
+	}
+	if sess.pubRelDeliverySubject != _EMPTY_ {
+		subjects = append(subjects, sess.pubRelDeliverySubject)
+	}
+	sess.mu.Unlock()
+	for _, subj := range subjects {
+		ec.mu.Lock()
+		sub := ec.subs[subj]
+		ec.mu.Unlock()
+		if sub != nil {
+			ec.processUnsub(sub.sid)
+		}
+	}
 }
 
 // Sends a consumer delete request, but does not wait for response.
@@ -4013,6 +4475,12 @@ CHECK:
 			asm.addSessToFlappers(cid)
 			asm.mu.Unlock()
 			c.Warnf("Replacing old client %q since both have the same client ID %q", ec, cid)
+			// Detach the old client's delivery subscriptions BEFORE the resume
+			// path below NAKs pending messages: closeConnection is
+			// asynchronous, and a stale subscription would consume the
+			// redeliveries only to drop them (sess.c has changed), downgrading
+			// the prompt re-send to an AckWait retry.
+			es.detachDeliverySubs(ec)
 			// Close old client in separate go routine
 			go ec.closeConnection(DuplicateClientID)
 		}
@@ -4041,6 +4509,14 @@ CHECK:
 
 	// Spec [MQTT-3.2.0-1]: CONNACK must be the first protocol sent to the session.
 	sendConnAck(mqttConnAckRCConnectionAccepted, sessp)
+
+	// Re-send unacked QoS 1/2 messages (and reconcile any that were removed
+	// while offline) BEFORE restoring subscriptions: the pending maps then hold
+	// only the previous connection's deliveries, and the queued NAKs make
+	// JetStream re-offer them ahead of messages that arrived while the session
+	// was offline. Runs whether or not saved subscriptions exist: a session can
+	// carry unacknowledged PUBRELs with no active subscription.
+	es.resendPendingRedelivery(c)
 
 	// Process possible saved subscriptions.
 	if l := len(es.subs); l > 0 {
@@ -4779,23 +5255,34 @@ func (c *client) mqttProcessPublishReceived(pi uint16, isPubRec bool) (err error
 	}
 	if isPubRec {
 		// The JS ACK subject for the PUBREL will be filled in at the delivery
-		// attempt.
+		// attempt. Carry the original delivery's consumer and sequence onto
+		// the PUBREL so a resume replay preserves original message order.
 		sess.trackAsPubRel(pi, _EMPTY_)
+		if pub, rel := sess.pendingPublish[pi], sess.pendingPubRel[pi]; pub != nil && rel != nil {
+			rel.origDur, rel.origOrd = pub.jsDur, pub.ord
+		}
 	}
 	jsAckSubject = sess.untrackPublish(pi)
 	sess.mu.Unlock()
 
 	if isPubRec {
 		natsMsg, headerLen := mqttNewDeliverablePubRel(pi)
-		_, err = sess.jsa.storeMsg(sess.pubRelSubject, headerLen, natsMsg)
+		resp, err := sess.jsa.storeMsg(sess.pubRelSubject, headerLen, natsMsg)
 		if err != nil {
 			// Failure to send out PUBREL will terminate the connection.
 			return err
+		}
+		if resp != nil && resp.PubAck != nil {
+			sess.recordPubRelSequence(pi, resp.Sequence)
 		}
 	}
 
 	// Send the ack to JS to remove the pending message from the consumer.
 	sess.jsa.sendAck(jsAckSubject)
+
+	// The ack drained a pending PUBLISH: deferred PUBREL replays whose
+	// original message no longer has an earlier one pending may go out now.
+	sess.releaseDeferredReplays(c)
 	return nil
 }
 
@@ -4820,7 +5307,17 @@ func (c *client) mqttProcessPubComp(pi uint16) {
 		sess.mu.Unlock()
 		return
 	}
+	ack := sess.pendingPubRel[pi]
 	jsAckSubject = sess.untrackPubRel(pi)
+	// A placeholder (no ack subject recorded yet) completed via a resume
+	// replay: remember the stored PUBREL's sequence so its eventual JS
+	// delivery is acked silently instead of re-sent to the client.
+	if ack != nil && ack.jsAckSubject == _EMPTY_ && ack.sseq != 0 {
+		if sess.pubRelDone == nil {
+			sess.pubRelDone = make(map[uint64]struct{})
+		}
+		sess.pubRelDone[ack.sseq] = struct{}{}
+	}
 	sess.mu.Unlock()
 
 	// Send the ack to JS to remove the pending message from the consumer.
@@ -5141,6 +5638,34 @@ func mqttDeliverPubRelCb(sub *subscription, pc *client, _ *Account, subject, rep
 
 	sess.mu.Lock()
 	if sess.c != cc || sess.pubRelConsumer == nil {
+		sess.mu.Unlock()
+		return
+	}
+	// This PUBREL's handshake may have completed already, via a resume replay
+	// answered before this delivery recorded an ack subject: ack it silently
+	// and do not re-send it to the client.
+	if len(sess.pubRelDone) > 0 {
+		if sseq, _, _, _, _ := ackReplyInfo(reply); sseq > 0 {
+			if _, ok := sess.pubRelDone[sseq]; ok {
+				delete(sess.pubRelDone, sseq)
+				sess.mu.Unlock()
+				sess.jsa.sendAck(reply)
+				return
+			}
+		}
+	}
+	// A resume-deferred PUBREL stays withheld until earlier same-consumer
+	// PUBLISH deliveries drain (releaseDeferredReplays sends it then): record
+	// this delivery's ack subject but do not send. The message stays unacked
+	// in JS, so AckWait re-offers it here again — and if the gate has drained
+	// without a release (e.g. skipped during a session takeover), this
+	// re-offer falls through and delivers it normally below.
+	if ack := sess.pendingPubRel[pi]; ack != nil && ack.relDeferred &&
+		sess.hasPendingPublishBefore(ack.origDur, ack.origOrd) {
+		sess.trackAsPubRel(pi, reply)
+		if cur := sess.pendingPubRel[pi]; cur != nil {
+			cur.relDeferred = true
+		}
 		sess.mu.Unlock()
 		return
 	}
@@ -5494,6 +6019,9 @@ func (sess *mqttSession) processJSConsumer(c *client, subject, sid string,
 			}
 			sess.mu.Unlock()
 
+			// The purge may have drained the gate of a deferred PUBREL replay.
+			sess.releaseDeferredReplays(c)
+
 			sess.deleteConsumer(cc)
 			if sub != nil {
 				c.processUnsub(sub.sid)
@@ -5667,6 +6195,9 @@ func (c *client) mqttProcessUnsubs(filters []*mqttFilter) error {
 				}
 			}
 			sess.mu.Unlock()
+
+			// The purge may have drained the gate of a deferred PUBREL replay.
+			sess.releaseDeferredReplays(c)
 		}
 	}
 	for _, f := range filters {

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -3211,11 +3211,67 @@ func TestMQTTSubWithNATSStream(t *testing.T) {
 	checkRecv("qos1", mqttPubQos1)
 }
 
+// Replay ordering must hold even when live packet identifiers span more than
+// half the 16-bit space (MaxAckPending is configurable up to 0xFFFF): the
+// allocation ordinal, not identifier distance, decides what was delivered
+// first.
+func TestMQTTPendingOrderLargeIdentifierSpan(t *testing.T) {
+	sess := mqttSession{}
+	dur := mqttRetainedPendingDur("foo")
+
+	pi1 := sess.trackPublishRetained("foo", "foo", "foo", nil, 1) // PI 1
+	sess.last_pi = 39999
+	pi2 := sess.trackPublishRetained("foo", "foo", "foo", nil, 1) // PI 40000
+	if pi1 != 1 || pi2 != 40000 {
+		t.Fatalf("Expected identifiers 1 and 40000, got %v and %v", pi1, pi2)
+	}
+	if !sess.hasPendingPublishBefore(dur, sess.pendingPublish[pi2].ord) {
+		t.Fatalf("Expected PI %v (allocated first) to gate PI %v despite the >0x8000 identifier span", pi1, pi2)
+	}
+	if sess.hasPendingPublishBefore(dur, sess.pendingPublish[pi1].ord) {
+		t.Fatalf("Expected nothing pending before the first allocation")
+	}
+	// And across identifier wraparound.
+	sess.last_pi = 0xFFFF
+	pi3 := sess.trackPublishRetained("foo", "foo", "foo", nil, 1)
+	if !sess.hasPendingPublishBefore(dur, sess.pendingPublish[pi3].ord) {
+		t.Fatalf("Expected earlier pendings to gate PI %v allocated after wraparound", pi3)
+	}
+}
+
+// The PUBREL store round trip can outlive its handshake: a reconnect can
+// replay the placeholder (sseq still 0) and the client PUBCOMP before the
+// store returns. The late-arriving sequence must then be remembered in
+// pubRelDone so the eventual JS delivery is acked silently — not dropped,
+// which would re-send a PUBREL for a completed exchange.
+func TestMQTTPubRelSequenceAfterCompletion(t *testing.T) {
+	sess := mqttSession{pubRelConsumer: &ConsumerConfig{Durable: "d"}}
+
+	// Placeholder created at PUBREC; the handshake completes (resume replay +
+	// PUBCOMP) while the PUBREL store is still in flight.
+	sess.trackAsPubRel(1, _EMPTY_)
+	sess.untrackPubRel(1)
+	sess.recordPubRelSequence(1, 42)
+	if _, ok := sess.pubRelDone[42]; !ok {
+		t.Fatalf("Expected sequence 42 in pubRelDone after the handshake completed mid-store")
+	}
+
+	// The normal case still records onto the placeholder, not pubRelDone.
+	sess.trackAsPubRel(2, _EMPTY_)
+	sess.recordPubRelSequence(2, 43)
+	if got := sess.pendingPubRel[2].sseq; got != 43 {
+		t.Fatalf("Expected sequence 43 on the placeholder, got %v", got)
+	}
+	if _, ok := sess.pubRelDone[43]; ok {
+		t.Fatalf("Sequence 43 must not be in pubRelDone while the handshake is pending")
+	}
+}
+
 func TestMQTTTrackPendingOverrun(t *testing.T) {
 	sess := mqttSession{}
 
 	sess.last_pi = 0xFFFF
-	pi := sess.trackPublishRetained("foo")
+	pi := sess.trackPublishRetained("foo", "foo", "foo", nil, 1)
 	if pi != 1 {
 		t.Fatalf("Expected 1, got %v", pi)
 	}
@@ -3230,7 +3286,7 @@ func TestMQTTTrackPendingOverrun(t *testing.T) {
 	}
 
 	delete(sess.pendingPublish, 1234)
-	pi = sess.trackPublishRetained("foo")
+	pi = sess.trackPublishRetained("foo", "foo", "foo", nil, 1)
 	if pi != 1234 {
 		t.Fatalf("Expected 1234, got %v", pi)
 	}
@@ -6131,6 +6187,803 @@ func TestMQTTQoS0DowngradePurgesPending(t *testing.T) {
 
 	if np, nc := countPending(); np != 0 || nc != 0 {
 		t.Fatalf("Expected pending maps purged after QoS 0 downgrade, got pendingPublish=%v cpending=%v", np, nc)
+	}
+}
+
+// On a same-ClientID takeover, the replaced connection closes asynchronously;
+// its delivery subscriptions must be detached synchronously before the resume
+// path NAKs pending messages, or a stale subscription consumes the
+// redeliveries (dropped since the session's client changed) and the new
+// client waits for AckWait instead of the required prompt re-send.
+func TestMQTTTakeoverRedeliversPendingPublish(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	o.MQTT.AckWait = 3 * testMQTTTimeout
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: false}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+	testMQTTPublish(t, cp, rp, 1, false, false, "foo", 1, []byte("msg"))
+
+	// Receive without acking, and do NOT close: connect a second client with
+	// the same ClientID so the server replaces this one (takeover).
+	pi := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("msg"))
+
+	c2, r2 := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c2.Close()
+	testMQTTCheckConnAck(t, r2, mqttConnAckRCConnectionAccepted, true)
+
+	// The pending message must be re-delivered promptly to the new client,
+	// with DUP and the original packet identifier.
+	rpi := testMQTTCheckPubMsgNoAck(t, c2, r2, "foo", mqttPubQos1|mqttPubFlagDup, []byte("msg"))
+	if rpi != pi {
+		t.Fatalf("Expected redelivery to reuse original packet identifier %v, got %v", pi, rpi)
+	}
+	testMQTTSendPIPacket(mqttPacketPubAck, t, c2, rpi)
+}
+
+// [MQTT-4.4.0-1] On reconnect with CleanSession=0, the server must re-send
+// unacknowledged QoS 1/2 PUBLISH messages (with DUP set). AckWait is kept well
+// above the client read deadline (testMQTTTimeout) so a redelivery arriving
+// proves it was triggered by the reconnect, not by the AckWait timer.
+func TestMQTTReconnectForcesRedeliveryWithDUP(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	o.MQTT.AckWait = 3 * testMQTTTimeout
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: false}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+
+	// Publish a QoS 1 message; receive it (DUP=0) but do not ack.
+	testMQTTPublish(t, cp, rp, 1, false, false, "foo", 1, []byte("msg"))
+	testMQTTDisconnect(t, cp, nil)
+	cp.Close()
+
+	pi := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("msg"))
+
+	// Drop the subscriber's connection without acking.
+	c.Close()
+
+	// Reconnect the same (persistent) session.
+	c, r = testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
+
+	// The unacknowledged message must be re-delivered promptly with DUP set,
+	// well before the 30s AckWait could fire. Same-server reconnect keeps the
+	// session's pending maps, so the original packet identifier is reused.
+	rpi := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagDup, []byte("msg"))
+	if rpi != pi {
+		t.Fatalf("Expected redelivery to reuse original packet identifier %v, got %v", pi, rpi)
+	}
+	testMQTTSendPIPacket(mqttPacketPubAck, t, c, rpi)
+}
+
+// Messages that accumulated while a persistent session was offline are fresh
+// deliveries on resume: they land in pendingPublish as processSubs re-binds the
+// durable consumer, and must not be NAK'd by the reconnect redelivery path
+// (which snapshots pending state before subscriptions are restored). Each must
+// arrive exactly once, without DUP.
+func TestMQTTReconnectNoRedeliveryOfFreshDeliveries(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	o.MQTT.AckWait = 3 * testMQTTTimeout
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	// Subscribe to "foo" plus filler filters: on resume, each saved filter is a
+	// JS consumer re-creation round trip, giving foo's fresh deliveries time to
+	// land in pendingPublish before the (old, buggy) post-processSubs snapshot.
+	filters := []*mqttFilter{{filter: "foo", qos: 1}}
+	for i := 0; i < 8; i++ {
+		filters = append(filters, &mqttFilter{filter: fmt.Sprintf("filler/%d", i), qos: 1})
+	}
+	expected := make([]byte, len(filters))
+	for i := range expected {
+		expected[i] = 1
+	}
+
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: false}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, filters, expected)
+	testMQTTDisconnect(t, c, nil)
+	c.Close()
+
+	// Publish while the subscriber is offline.
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+	const nmsgs = 5
+	for i := 0; i < nmsgs; i++ {
+		testMQTTPublish(t, cp, rp, 1, false, false, "foo", uint16(i+1), []byte(fmt.Sprintf("m%d", i)))
+	}
+	testMQTTDisconnect(t, cp, nil)
+	cp.Close()
+
+	// Resume the session: the accumulated messages arrive as fresh deliveries
+	// (DUP=0). Hold off acking until all are read — like a slow-acking client —
+	// so any wrongly NAK'd fresh delivery shows up as a DUP duplicate here.
+	c, r = testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
+	pis := make([]uint16, 0, nmsgs)
+	for i := 0; i < nmsgs; i++ {
+		pis = append(pis, testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte(fmt.Sprintf("m%d", i))))
+	}
+	// A wrongly NAK'd fresh delivery comes back as a DUP duplicate with a small
+	// lag; wait it out before checking that nothing else arrives.
+	time.Sleep(300 * time.Millisecond)
+	testMQTTExpectNothing(t, r)
+	for _, pi := range pis {
+		testMQTTSendPIPacket(mqttPacketPubAck, t, c, pi)
+	}
+}
+
+// [MQTT-4.6.0-1] On resume, the DUP redelivery of a message left unacked by
+// the previous connection must precede messages that were published while the
+// session was offline: the redelivery NAKs are queued (and confirmed) before
+// the consumer's delivery interest is restored, so JetStream re-offers the
+// older sequence first.
+func TestMQTTReconnectRedeliveryPreservesOrder(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	o.MQTT.AckWait = 3 * testMQTTTimeout
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: false}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+
+	// Receive the first message without acking, then drop the connection.
+	testMQTTPublish(t, cp, rp, 1, false, false, "foo", 1, []byte("m0"))
+	pi := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("m0"))
+	c.Close()
+
+	// Backlog published while the subscriber is offline.
+	testMQTTPublish(t, cp, rp, 1, false, false, "foo", 2, []byte("m1"))
+	testMQTTPublish(t, cp, rp, 1, false, false, "foo", 3, []byte("m2"))
+	testMQTTDisconnect(t, cp, nil)
+	cp.Close()
+
+	// Resume: the unacked message must arrive first (DUP, original packet
+	// identifier), then the offline backlog in order as fresh deliveries.
+	c, r = testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
+	rpi := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagDup, []byte("m0"))
+	if rpi != pi {
+		t.Fatalf("Expected redelivery to reuse original packet identifier %v, got %v", pi, rpi)
+	}
+	pi1 := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("m1"))
+	pi2 := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("m2"))
+	for _, p := range []uint16{rpi, pi1, pi2} {
+		testMQTTSendPIPacket(mqttPacketPubAck, t, c, p)
+	}
+	testMQTTExpectNothing(t, r)
+}
+
+// [MQTT-4.4.0-1] On resume, an in-flight QoS2 handshake (PUBREC received, no
+// PUBCOMP yet) must get its PUBREL re-sent promptly — including when the
+// disconnect happened before the PUBREL delivery recorded a JS ack subject
+// (a PUBREC placeholder), which cannot be NAK'd and would otherwise wait for
+// the AckWait interval.
+func TestMQTTReconnectResendsPendingPubRel(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	o.MQTT.AckWait = 3 * testMQTTTimeout
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: false}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 2}}, []byte{2})
+
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+	testMQTTPublish(t, cp, rp, 2, false, false, "foo", 1, []byte("msg"))
+
+	// Receive the QoS2 PUBLISH and answer PUBREC, then drop the connection
+	// right away, often before the server's PUBREL delivery records its JS
+	// ack subject.
+	pi := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQoS2, []byte("msg"))
+	testMQTTSendPIPacket(mqttPacketPubRec, t, c, pi)
+	c.Close()
+
+	// Resume: the PUBREL must be re-sent promptly, well before AckWait.
+	c, r = testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
+	testMQTTReadPIPacket(mqttPacketPubRel, t, r, pi)
+	testMQTTSendPIPacket(mqttPacketPubComp, t, c, pi)
+}
+
+// A resume replay lets the client PUBCOMP a QoS2 handshake whose PUBREL
+// delivery never recorded a JS ack subject (a PUBREC placeholder). The
+// completion is remembered by the stored PUBREL's stream sequence, so its
+// eventual JS delivery is acked silently: the client must not receive a
+// spurious PUBREL after AckWait, and nothing may stay tracked.
+func TestMQTTReconnectPubRelPlaceholderCompletion(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	o.MQTT.AckWait = 500 * time.Millisecond
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: false}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 2}}, []byte{2})
+
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+	testMQTTPublish(t, cp, rp, 2, false, false, "foo", 1, []byte("msg"))
+
+	// Receive the QoS2 PUBLISH, answer PUBREC, and read the PUBREL without
+	// answering PUBCOMP, so the stored PUBREL stays unacked in JS.
+	pi := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQoS2, []byte("msg"))
+	testMQTTSendPIPacket(mqttPacketPubRec, t, c, pi)
+	testMQTTReadPIPacket(mqttPacketPubRel, t, r, pi)
+
+	// Simulate the disconnect racing ahead of the PUBREL delivery callback:
+	// blank the recorded ack subject, leaving a PUBREC placeholder (stream
+	// sequence recorded at PUBREC, no ack subject).
+	mc := testMQTTGetClient(t, s, "sub")
+	mc.mu.Lock()
+	sess := mc.mqtt.sess
+	mc.mu.Unlock()
+	sess.mu.Lock()
+	ack := sess.pendingPubRel[pi]
+	if ack == nil || ack.sseq == 0 {
+		sess.mu.Unlock()
+		t.Fatalf("Expected pending PUBREL with recorded stream sequence, got %+v", ack)
+	}
+	ack.jsAckSubject = _EMPTY_
+	sess.mu.Unlock()
+	c.Close()
+
+	// Resume: the placeholder PUBREL is replayed promptly; complete it.
+	c, r = testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
+	testMQTTReadPIPacket(mqttPacketPubRel, t, r, pi)
+	testMQTTSendPIPacket(mqttPacketPubComp, t, c, pi)
+
+	// The stored PUBREL is redelivered by JS after AckWait; it must be acked
+	// silently, not re-sent to the client.
+	time.Sleep(3 * o.MQTT.AckWait)
+	testMQTTExpectNothing(t, r)
+	checkFor(t, time.Second, 50*time.Millisecond, func() error {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		if n := len(sess.pendingPubRel); n != 0 {
+			return fmt.Errorf("expected no pending PUBREL, got %v", n)
+		}
+		if n := len(sess.pubRelDone); n != 0 {
+			return fmt.Errorf("expected pubRelDone drained, got %v", n)
+		}
+		return nil
+	})
+}
+
+// On resume with both an older unacknowledged PUBLISH and a newer QoS2
+// message already advanced to PUBREL, the PUBREL replay must not reach the
+// client before the older PUBLISH is re-delivered — a client that surfaces
+// QoS2 messages on PUBREL would observe the topic out of order. The replay is
+// deferred until the earlier delivery drains.
+func TestMQTTReconnectDefersPubRelBehindPendingPublish(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	o.MQTT.AckWait = 3 * testMQTTTimeout
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: false}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 2}}, []byte{2})
+
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+	testMQTTPublish(t, cp, rp, 1, false, false, "foo", 1, []byte("m1"))
+	testMQTTPublish(t, cp, rp, 2, false, false, "foo", 2, []byte("m2"))
+	testMQTTDisconnect(t, cp, nil)
+	cp.Close()
+
+	// Receive both; acknowledge only the newer QoS2 message up to PUBREC, so
+	// it advances to a pending PUBREL while the older QoS1 PUBLISH stays
+	// unacknowledged. Read the PUBREL but do not PUBCOMP, then drop the
+	// connection.
+	piA := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("m1"))
+	piB := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQoS2, []byte("m2"))
+	testMQTTSendPIPacket(mqttPacketPubRec, t, c, piB)
+	testMQTTReadPIPacket(mqttPacketPubRel, t, r, piB)
+	c.Close()
+
+	// Resume: the older PUBLISH must arrive first (DUP, original identifier);
+	// the PUBREL replay must be withheld until that delivery is acknowledged.
+	c, r = testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
+	rpiA := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagDup, []byte("m1"))
+	if rpiA != piA {
+		t.Fatalf("Expected redelivery to reuse original packet identifier %v, got %v", piA, rpiA)
+	}
+	testMQTTExpectNothing(t, r)
+
+	// Acknowledging the older delivery releases the deferred PUBREL.
+	testMQTTSendPIPacket(mqttPacketPubAck, t, c, rpiA)
+	testMQTTReadPIPacket(mqttPacketPubRel, t, r, piB)
+	testMQTTSendPIPacket(mqttPacketPubComp, t, c, piB)
+	testMQTTFlush(t, c, nil, r)
+	testMQTTExpectNothing(t, r)
+
+	// Everything must be drained.
+	mc := testMQTTGetClient(t, s, "sub")
+	mc.mu.Lock()
+	sess := mc.mqtt.sess
+	mc.mu.Unlock()
+	checkFor(t, time.Second, 50*time.Millisecond, func() error {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		if np, nr := len(sess.pendingPublish), len(sess.pendingPubRel); np != 0 || nr != 0 {
+			return fmt.Errorf("expected pending maps drained, got publish=%v pubrel=%v", np, nr)
+		}
+		return nil
+	})
+}
+
+// The deferral of a resumed PUBREL must also hold through the PUBREL
+// consumer's AckWait redeliveries: as long as the earlier PUBLISH stays
+// unacknowledged, JS re-offering the stored PUBREL must not push it to the
+// client; only the redelivered PUBLISH may arrive.
+func TestMQTTReconnectDeferredPubRelSurvivesAckWait(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	o.MQTT.AckWait = 500 * time.Millisecond
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: false}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 2}}, []byte{2})
+
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+	testMQTTPublish(t, cp, rp, 1, false, false, "foo", 1, []byte("m1"))
+	testMQTTPublish(t, cp, rp, 2, false, false, "foo", 2, []byte("m2"))
+	testMQTTDisconnect(t, cp, nil)
+	cp.Close()
+
+	piA := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("m1"))
+	piB := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQoS2, []byte("m2"))
+	testMQTTSendPIPacket(mqttPacketPubRec, t, c, piB)
+	testMQTTReadPIPacket(mqttPacketPubRel, t, r, piB)
+	c.Close()
+
+	// Resume, receive the older PUBLISH, and withhold its PUBACK across two
+	// AckWait cycles: each cycle re-offers both the PUBLISH and the stored
+	// PUBREL to the server; the client may only see the redelivered PUBLISH.
+	// A PUBREL arriving here is the AckWait bypass of the deferral gate.
+	c, r = testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
+	for i := 0; i < 3; i++ {
+		rpi := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagDup, []byte("m1"))
+		if rpi != piA {
+			t.Fatalf("Expected redeliveries to reuse original packet identifier %v, got %v", piA, rpi)
+		}
+	}
+
+	// Acknowledging the PUBLISH releases the deferred PUBREL.
+	testMQTTSendPIPacket(mqttPacketPubAck, t, c, piA)
+	testMQTTReadPIPacket(mqttPacketPubRel, t, r, piB)
+
+	mc := testMQTTGetClient(t, s, "sub")
+	mc.mu.Lock()
+	sess := mc.mqtt.sess
+	mc.mu.Unlock()
+	drained := func() bool {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		return len(sess.pendingPublish) == 0 && len(sess.pendingPubRel) == 0
+	}
+	// Complete the handshake. An AckWait re-offer of the stored PUBREL can
+	// race the PUBCOMP's JS ack and re-track the packet identifier with a
+	// duplicate PUBREL; a real client answers those with PUBCOMP too, so do
+	// the same until the session stays drained.
+	for i := 0; ; i++ {
+		testMQTTSendPIPacket(mqttPacketPubComp, t, c, piB)
+		testMQTTFlush(t, c, nil, r)
+		time.Sleep(300 * time.Millisecond)
+		if drained() {
+			break
+		}
+		if i >= 2 {
+			t.Fatalf("Session not drained after %d PUBCOMPs", i+1)
+		}
+		testMQTTReadPIPacket(mqttPacketPubRel, t, r, piB)
+	}
+}
+
+// An in-flight retained QoS delivery has no JS consumer to NAK and the resume
+// path does not serialize retained messages again, so on reconnect the server
+// must re-send it directly — original packet identifier, DUP and RETAIN set —
+// or the message is never re-sent and its identifier leaks against the
+// in-flight cap for the life of the session.
+func TestMQTTReconnectResendsPendingRetained(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	o.MQTT.AckWait = 3 * testMQTTTimeout
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	// Store a retained QoS 1 message before the subscriber connects.
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+	testMQTTPublish(t, cp, rp, 1, false, true, "foo", 1, []byte("retained"))
+	testMQTTDisconnect(t, cp, nil)
+	cp.Close()
+
+	// Subscribing at QoS 1 delivers the retained message; receive it without
+	// acking, then drop the connection.
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: false}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+	pi := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagRetain, []byte("retained"))
+	c.Close()
+
+	// Resume: the retained delivery must be re-sent promptly with DUP and the
+	// original packet identifier, and be ack-able.
+	c, r = testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
+	rpi := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagRetain|mqttPubFlagDup, []byte("retained"))
+	if rpi != pi {
+		t.Fatalf("Expected redelivery to reuse original packet identifier %v, got %v", pi, rpi)
+	}
+	testMQTTSendPIPacket(mqttPacketPubAck, t, c, rpi)
+	testMQTTFlush(t, c, nil, r)
+
+	// The ack must have released the packet identifier.
+	mc := testMQTTGetClient(t, s, "sub")
+	mc.mu.Lock()
+	sess := mc.mqtt.sess
+	mc.mu.Unlock()
+	sess.mu.Lock()
+	lpi := len(sess.pendingPublish)
+	sess.mu.Unlock()
+	if lpi != 0 {
+		t.Fatalf("Expected no pending publish after ack, got %v", lpi)
+	}
+	testMQTTExpectNothing(t, r)
+}
+
+// A retained replay on resume must re-check permissions: if the client's
+// subscribe access to the topic was revoked while the persistent session was
+// offline, the pending retained delivery must be dropped (identifier
+// released), not sent to the client.
+func TestMQTTReconnectRetainedPermRevoked(t *testing.T) {
+	template := `
+		port: -1
+		jetstream {
+			store_dir = %q
+		}
+		server_name: mqtt
+		authorization {
+			mqtt_perms = {
+				publish = ["foo"]
+				subscribe = [%q, "$MQTT.>"]
+			}
+			users = [
+				{user: mqtt, password: pass, permissions: $mqtt_perms}
+			]
+		}
+		mqtt {
+			port: -1
+		}
+	`
+	tdir := t.TempDir()
+	conf := createConfFile(t, fmt.Appendf(nil, template, tdir, "foo"))
+	s, o := RunServerWithConfig(conf)
+	defer testMQTTShutdownServer(s)
+
+	// Store a retained QoS 1 message.
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true, user: "mqtt", pass: "pass"}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+	testMQTTPublish(t, cp, rp, 1, false, true, "foo", 1, []byte("retained"))
+	testMQTTDisconnect(t, cp, nil)
+	cp.Close()
+
+	// Receive the retained delivery without acking, then drop the connection.
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: false, user: "mqtt", pass: "pass"}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagRetain, []byte("retained"))
+	c.Close()
+	checkClientsCount(t, s, 0)
+
+	// Revoke the subscribe permission on "foo" while the session is offline.
+	reloadUpdateConfig(t, s, conf, fmt.Sprintf(template, tdir, "bar"))
+
+	// Resume: the pending retained delivery must NOT be replayed, and its
+	// packet identifier must be released.
+	c, r = testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
+	testMQTTExpectNothing(t, r)
+
+	mc := testMQTTGetClient(t, s, "sub")
+	mc.mu.Lock()
+	sess := mc.mqtt.sess
+	mc.mu.Unlock()
+	sess.mu.Lock()
+	lpi := len(sess.pendingPublish)
+	sess.mu.Unlock()
+	if lpi != 0 {
+		t.Fatalf("Expected pending retained delivery to be dropped, got %v pending", lpi)
+	}
+}
+
+// When a deferred PUBREL and a deferred retained replay unblock together (the
+// gating older PUBLISH is acked), they must be released merged in packet
+// identifier (allocation) order: a client surfacing QoS2 messages on PUBREL
+// would otherwise observe the later-allocated retained PUBLISH first.
+func TestMQTTReconnectReleasesDeferredReplaysInOrder(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	o.MQTT.AckWait = 3 * testMQTTTimeout
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: false}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 2}}, []byte{2})
+
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+
+	// PI1: an older normal QoS1 PUBLISH, received but not acked.
+	testMQTTPublish(t, cp, rp, 1, false, false, "foo", 1, []byte("m1"))
+	pi1 := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("m1"))
+
+	// PI2: a newer QoS2 PUBLISH advanced to pending PUBREL (PUBREC sent,
+	// PUBREL read, no PUBCOMP).
+	testMQTTPublish(t, cp, rp, 2, false, false, "foo", 2, []byte("m2"))
+	pi2 := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQoS2, []byte("m2"))
+	testMQTTSendPIPacket(mqttPacketPubRec, t, c, pi2)
+	testMQTTReadPIPacket(mqttPacketPubRel, t, r, pi2)
+
+	// PI4: a retained pending allocated after PI2 (the live delivery of the
+	// retained publish is acked; the re-subscribe serializes it again).
+	testMQTTPublish(t, cp, rp, 1, false, true, "foo", 3, []byte("r"))
+	pi3 := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("r"))
+	testMQTTSendPIPacket(mqttPacketPubAck, t, c, pi3)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 2}}, []byte{2})
+	pi4 := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagRetain, []byte("r"))
+	c.Close()
+
+	// Resume: only the oldest pending PUBLISH may arrive; the PUBREL and the
+	// retained replay are both deferred behind it.
+	c, r = testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
+	rpi1 := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagDup, []byte("m1"))
+	if rpi1 != pi1 {
+		t.Fatalf("Expected redelivery to reuse original packet identifier %v, got %v", pi1, rpi1)
+	}
+	testMQTTExpectNothing(t, r)
+
+	// Acking PI1 unblocks both: the PUBREL (PI2) must arrive BEFORE the
+	// later-allocated retained replay (PI4).
+	testMQTTSendPIPacket(mqttPacketPubAck, t, c, rpi1)
+	testMQTTReadPIPacket(mqttPacketPubRel, t, r, pi2)
+	rpi4 := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagRetain|mqttPubFlagDup, []byte("r"))
+	if rpi4 != pi4 {
+		t.Fatalf("Expected retained replay to reuse original packet identifier %v, got %v", pi4, rpi4)
+	}
+	testMQTTSendPIPacket(mqttPacketPubComp, t, c, pi2)
+	testMQTTSendPIPacket(mqttPacketPubAck, t, c, rpi4)
+	testMQTTFlush(t, c, nil, r)
+
+	mc := testMQTTGetClient(t, s, "sub")
+	mc.mu.Lock()
+	sess := mc.mqtt.sess
+	mc.mu.Unlock()
+	checkFor(t, time.Second, 50*time.Millisecond, func() error {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		if np, nr := len(sess.pendingPublish), len(sess.pendingPubRel); np != 0 || nr != 0 {
+			return fmt.Errorf("expected pending maps drained, got publish=%v pubrel=%v", np, nr)
+		}
+		return nil
+	})
+}
+
+// A retained replay allocated AFTER a still-pending normal PUBLISH on the
+// same subscription must not be sent ahead of it on resume: packet
+// identifiers are allocated in delivery order, and the older message is
+// re-offered first [MQTT-4.6.0-1]. The retained replay is deferred until the
+// earlier delivery drains.
+func TestMQTTReconnectDefersRetainedBehindPendingPublish(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	o.MQTT.AckWait = 3 * testMQTTTimeout
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: false}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+
+	// The retained publish arrives as a live delivery; ack it.
+	testMQTTPublish(t, cp, rp, 1, false, true, "foo", 1, []byte("r1"))
+	pi1 := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("r1"))
+	testMQTTSendPIPacket(mqttPacketPubAck, t, c, pi1)
+
+	// A normal publish, received but NOT acked: pending under the consumer.
+	testMQTTPublish(t, cp, rp, 1, false, false, "foo", 2, []byte("m2"))
+	piPub := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("m2"))
+
+	// Re-subscribing serializes the retained message again: a retained
+	// pending with a LATER packet identifier than the normal pending.
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+	piRet := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagRetain, []byte("r1"))
+	c.Close()
+
+	// Resume: the older normal PUBLISH must arrive first (DUP, original
+	// identifier); the retained replay must be withheld until it is acked.
+	c, r = testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
+	rpi := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagDup, []byte("m2"))
+	if rpi != piPub {
+		t.Fatalf("Expected redelivery to reuse original packet identifier %v, got %v", piPub, rpi)
+	}
+	testMQTTExpectNothing(t, r)
+
+	// Acknowledging the older delivery releases the deferred retained replay.
+	testMQTTSendPIPacket(mqttPacketPubAck, t, c, rpi)
+	rpiRet := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagRetain|mqttPubFlagDup, []byte("r1"))
+	if rpiRet != piRet {
+		t.Fatalf("Expected retained replay to reuse original packet identifier %v, got %v", piRet, rpiRet)
+	}
+	testMQTTSendPIPacket(mqttPacketPubAck, t, c, rpiRet)
+	testMQTTFlush(t, c, nil, r)
+
+	mc := testMQTTGetClient(t, s, "sub")
+	mc.mu.Lock()
+	sess := mc.mqtt.sess
+	mc.mu.Unlock()
+	sess.mu.Lock()
+	lpi := len(sess.pendingPublish)
+	sess.mu.Unlock()
+	if lpi != 0 {
+		t.Fatalf("Expected pending maps drained after acks, got %v", lpi)
+	}
+}
+
+// Retransmission on resume must re-send the ORIGINAL unacknowledged PUBLISH
+// packet verbatim — even when the retained message was replaced or deleted
+// while the session was offline — not the retained store's current state
+// under the old packet identifier.
+func TestMQTTReconnectRetainedChangedWhileOffline(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	o.MQTT.AckWait = 3 * testMQTTTimeout
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	// Store retained QoS 1 messages on two topics.
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: true}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+	testMQTTPublish(t, cp, rp, 1, false, true, "foo", 1, []byte("v1"))
+	testMQTTPublish(t, cp, rp, 1, false, true, "bar", 2, []byte("w1"))
+	testMQTTDisconnect(t, cp, nil)
+	cp.Close()
+
+	// Receive both retained deliveries without acking, then drop the
+	// connection.
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: false}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: 1}, {filter: "bar", qos: 1}}, []byte{1, 1})
+	piFoo := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagRetain, []byte("v1"))
+	piBar := testMQTTCheckPubMsgNoAck(t, c, r, "bar", mqttPubQos1|mqttPubFlagRetain, []byte("w1"))
+	c.Close()
+
+	// While the subscriber is offline: replace foo's retained message and
+	// delete bar's (empty retained payload, QoS 0 so nothing is stored for
+	// the subscriber's consumer).
+	cp, rp = testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+	testMQTTPublish(t, cp, rp, 1, false, true, "foo", 1, []byte("v2"))
+	testMQTTPublish(t, cp, rp, 0, false, true, "bar", 0, nil)
+	testMQTTDisconnect(t, cp, nil)
+	cp.Close()
+
+	// Resume: both ORIGINAL packets must be retransmitted verbatim (DUP,
+	// RETAIN, original identifiers and payloads), then foo's replacement
+	// arrives as a fresh consumer delivery.
+	c, r = testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, true)
+	rpiFoo := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1|mqttPubFlagRetain|mqttPubFlagDup, []byte("v1"))
+	rpiBar := testMQTTCheckPubMsgNoAck(t, c, r, "bar", mqttPubQos1|mqttPubFlagRetain|mqttPubFlagDup, []byte("w1"))
+	if rpiFoo != piFoo || rpiBar != piBar {
+		t.Fatalf("Expected original packet identifiers %v/%v, got %v/%v", piFoo, piBar, rpiFoo, rpiBar)
+	}
+	piV2 := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQos1, []byte("v2"))
+	for _, pi := range []uint16{rpiFoo, rpiBar, piV2} {
+		testMQTTSendPIPacket(mqttPacketPubAck, t, c, pi)
+	}
+	testMQTTFlush(t, c, nil, r)
+	testMQTTExpectNothing(t, r)
+
+	// All acks must have released their packet identifiers.
+	mc := testMQTTGetClient(t, s, "sub")
+	mc.mu.Lock()
+	sess := mc.mqtt.sess
+	mc.mu.Unlock()
+	sess.mu.Lock()
+	lpi := len(sess.pendingPublish)
+	sess.mu.Unlock()
+	if lpi != 0 {
+		t.Fatalf("Expected no pending publish after acks, got %v", lpi)
 	}
 }
 


### PR DESCRIPTION
MQTT 3.1.1 [MQTT-4.4.0-1] requires that on reconnect with CleanSession=0 the server re-send unacknowledged QoS 1/2 PUBLISH and PUBREL packets (with DUP set). NATS only redelivered on the JetStream consumer's AckWait interval (30s default), so an unacked message was not re-sent promptly on reconnect and the 3.1.1 conformance test MQTT-3.3.1-1 timed out waiting for it.

On session resume, after subscriptions are re-established, NAK each pending QoS 1/2 message (PUBLISH and PUBREL) on its JS ack subject to force immediate redelivery with the DUP flag set. NAKs are ordered by stream sequence so redeliveries preserve original order [MQTT-4.6.0-1], and re-use the original packet identifiers since the session tracking maps survive a same-server reconnect. After a restart or failover the maps are gone, so redelivery falls back to the AckWait interval.
