### PR TITLE
[FIXED] Deliver service imported messages to stream imports of other accounts

### DIFF
--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -4193,6 +4193,135 @@ func TestAccountServiceImportReplyDroppedAcrossClusterRoutes(t *testing.T) {
 	}
 }
 
+func TestAccountServiceImportDeliveredToStreamImportOfOtherAccount(t *testing.T) {
+	// A pushes into B via a service import, C receives what lands in B via
+	// a stream import. On a single server the message used to be dropped
+	// because service-imported messages skipped all stream import shadow
+	// subscriptions, even those of an account that cannot create a cycle.
+	conf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		accounts {
+			A {
+				users = [{ user: a, password: a }]
+				imports = [{ service: { account: B, subject: "req.>" } }]
+			}
+			B {
+				users = [{ user: b, password: b }]
+				exports = [
+					{ service: "req.>" }
+					{ stream: "req.>" }
+				]
+			}
+			C {
+				users = [{ user: c, password: c }]
+				imports = [{ stream: { account: B, subject: "req.>" } }]
+			}
+		}
+	`))
+	s, _ := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	// Subscriber in C, via the stream import from B.
+	ncC := natsConnect(t, s.ClientURL(), nats.UserInfo("c", "c"))
+	defer ncC.Close()
+	subC := natsSubSync(t, ncC, "req.>")
+	natsFlush(t, ncC)
+
+	// Control subscriber directly in B.
+	ncB := natsConnect(t, s.ClientURL(), nats.UserInfo("b", "b"))
+	defer ncB.Close()
+	subB := natsSubSync(t, ncB, "req.>")
+	natsFlush(t, ncB)
+
+	// Publisher in A, into B via the service import.
+	ncA := natsConnect(t, s.ClientURL(), nats.UserInfo("a", "a"))
+	defer ncA.Close()
+	natsPub(t, ncA, "req.test", []byte("hello"))
+	natsFlush(t, ncA)
+
+	// The subscriber in B sees the service-imported message.
+	msg := natsNexMsg(t, subB, time.Second)
+	require_Equal(t, string(msg.Data), "hello")
+	// The subscriber in C must receive it through the stream import, same
+	// as it already does when publisher and subscriber are on different
+	// servers of a cluster.
+	msg = natsNexMsg(t, subC, time.Second)
+	require_Equal(t, string(msg.Data), "hello")
+}
+
+func TestAccountChainedServiceImportDeliveredOnceToStreamImports(t *testing.T) {
+	// A imports svc from B, B implements it by importing from C, and B
+	// also stream-imports svc from C. Accounts already on the import path
+	// must not get a second copy through their stream import shadow subs,
+	// while an unrelated account D still receives the message.
+	conf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		accounts {
+			A {
+				users = [{ user: a, password: a }]
+				imports = [{ service: { account: B, subject: "svc" } }]
+			}
+			B {
+				users = [{ user: b, password: b }]
+				exports = [{ service: "svc" }]
+				imports = [
+					{ service: { account: C, subject: "svc" } }
+					{ stream: { account: C, subject: "svc" } }
+				]
+			}
+			C {
+				users = [{ user: c, password: c }]
+				exports = [
+					{ service: "svc" }
+					{ stream: "svc" }
+				]
+			}
+			D {
+				users = [{ user: d, password: d }]
+				imports = [{ stream: { account: C, subject: "svc" } }]
+			}
+		}
+	`))
+	s, _ := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	// Subscriber in B, receives on the first hop and must not get a second
+	// copy through its shadow sub in C.
+	ncB := natsConnect(t, s.ClientURL(), nats.UserInfo("b", "b"))
+	defer ncB.Close()
+	subB := natsSubSync(t, ncB, "svc")
+	natsFlush(t, ncB)
+
+	// Responder in C.
+	ncC := natsConnect(t, s.ClientURL(), nats.UserInfo("c", "c"))
+	defer ncC.Close()
+	subC := natsSubSync(t, ncC, "svc")
+	natsFlush(t, ncC)
+
+	// Subscriber in D, via the stream import from C.
+	ncD := natsConnect(t, s.ClientURL(), nats.UserInfo("d", "d"))
+	defer ncD.Close()
+	subD := natsSubSync(t, ncD, "svc")
+	natsFlush(t, ncD)
+
+	ncA := natsConnect(t, s.ClientURL(), nats.UserInfo("a", "a"))
+	defer ncA.Close()
+	natsPub(t, ncA, "svc", []byte("hi"))
+	natsFlush(t, ncA)
+
+	natsNexMsg(t, subC, time.Second)
+	natsNexMsg(t, subB, time.Second)
+	natsNexMsg(t, subD, time.Second)
+	// Nothing should be left over, subscribers in B and C in particular
+	// must not see a duplicate from B's stream import of C.
+	time.Sleep(100 * time.Millisecond)
+	for _, sub := range []*nats.Subscription{subB, subC, subD} {
+		if n, _, _ := sub.Pending(); n != 0 {
+			t.Fatalf("expected no extra copies, got %d", n)
+		}
+	}
+}
+
 func TestStreamActivationExpiredNoMatchDoesNotInvalidate(t *testing.T) {
 	// Account performing the import.
 	a := NewAccount("importer")

--- a/server/client.go
+++ b/server/client.go
@@ -4765,6 +4765,21 @@ var (
 	jsDirectGetPreB   = []byte(jsDirectGetPre)
 )
 
+// Reports whether the given account has already seen the message being
+// processed, either as the publisher's account or as one of the accounts
+// the service import chain passed through.
+func (c *client) accOnServiceImportPath(acc *Account) bool {
+	if acc == c.acc {
+		return true
+	}
+	for _, si := range c.pa.psi {
+		if acc == si.acc {
+			return true
+		}
+	}
+	return false
+}
+
 // processServiceImport is an internal callback when a subscription matches an imported service
 // from another account. This includes response mappings as well.
 func (c *client) processServiceImport(si *serviceImport, acc *Account, msg []byte) bool {
@@ -5249,8 +5264,10 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 
 		// Check for stream import mapped subs (shadow subs). These apply to local subs only.
 		if sub.im != nil {
-			// If this message was a service import do not re-export to an exported stream.
-			if flags&pmrMsgImportedFromService != 0 {
+			// If this message was a service import, deliver only to stream imports
+			// of accounts the message has not passed through yet. Delivering back
+			// to one of those could loop the message or siphon off queue deliveries.
+			if flags&pmrMsgImportedFromService != 0 && c.accOnServiceImportPath(sub.client.acc) {
 				continue
 			}
 			if sub.im.tr != nil {
@@ -5476,8 +5493,10 @@ func (c *client) processMsgResults(acc *Account, r *SublistResult, msg, deliver,
 
 			// Check for stream import mapped subs. These apply to local subs only.
 			if sub.im != nil {
-				// If this message was a service import do not re-export to an exported stream.
-				if flags&pmrMsgImportedFromService != 0 {
+				// If this message was a service import, deliver only to stream imports
+				// of accounts the message has not passed through yet. Delivering back
+				// to one of those could loop the message or siphon off queue deliveries.
+				if flags&pmrMsgImportedFromService != 0 && c.accOnServiceImportPath(sub.client.acc) {
 					continue
 				}
 				if sub.im.tr != nil {


### PR DESCRIPTION
## Problem

With three accounts, where A service-imports from B and C stream-imports from B, a message published from A reaches subscribers in B but never the subscriber in C when both clients are connected to the same server. The same config works across a cluster, since the message is forwarded over the route before the check and the service import flag is not carried on the wire. The receiving server then treats it as a normal routed message and delivers it to the stream import.

The drop comes from 705f8b6 ("Do not forward service import messages to a stream export"), which skips every stream import shadow subscription while processing a service-imported message. That guard protects an account that imports both a stream and a service from the same exporter, where the message could loop back into the importer or its shadow queue subs could grab deliveries meant for the exporter (both covered by TestServiceAndStreamStackOverflow). Keying the skip on the flag alone also suppresses shadow subscriptions of unrelated accounts that can't form such a cycle.

## Fix

Narrow the guard at both spots in processMsgResults so it only skips shadow subscriptions of accounts the message has already passed through, that is the publisher's account plus every hop on the service import chain (c.pa.psi). Same-account behavior is unchanged and TestServiceAndStreamStackOverflow still passes. Stream imports of unrelated accounts now receive the message on a single server the same way they already do across a route.

## Test

Added TestAccountServiceImportDeliveredToStreamImportOfOtherAccount with the three account setup from the issue. It fails on main with the subscriber in C timing out, and passes with the fix. Also added TestAccountChainedServiceImportDeliveredOnceToStreamImports for chained imports (A imports svc from B, B implements it by importing from C and also stream-imports from C), where an intermediate account must not receive a duplicate through its own stream import.

Ran locally:
- go build ./... (also GOARCH=386 and with go1.25.11)
- go vet ./... and golangci-lint run --config=.golangci.yml
- go test -race ./server/ -run 'ServiceImport|StreamImport|Shadow' -count=1
- go test -race ./test/ -run 'ServiceLatency|ServiceAndStream|ServiceImport|CrossAccount' -count=1

Resolves #8338
