### PR TITLE
feat: add Unix Domain Socket support for local client connections

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -399,6 +399,7 @@ type Options struct {
 	ServerName      string `json:"server_name"`
 	Host            string `json:"addr"`
 	Port            int    `json:"port"`
+	Socket          string `json:"socket,omitempty"`
 	DontListen      bool   `json:"dont_listen"`
 	ClientAdvertise string `json:"-"`
 	Trace           bool   `json:"-"`
@@ -1138,6 +1139,8 @@ func (o *Options) processConfigFileLine(k string, v any, errors *[]error, warnin
 		o.ClientAdvertise = v.(string)
 	case "port":
 		o.Port = int(v.(int64))
+	case "socket":
+		o.Socket = v.(string)
 	case "server_name":
 		sn := v.(string)
 		if strings.Contains(sn, " ") {
@@ -5845,6 +5848,11 @@ func MergeOptions(fileOpts, flagOpts *Options) *Options {
 
 	if flagOpts.Port != 0 {
 		opts.Port = flagOpts.Port
+		opts.Socket = _EMPTY_ // Clear socket if CLI explicitly sets port
+	}
+	if flagOpts.Socket != _EMPTY_ {
+		opts.Socket = flagOpts.Socket
+		opts.Port = 0 // Clear port if CLI explicitly sets socket
 	}
 	if flagOpts.Host != _EMPTY_ {
 		opts.Host = flagOpts.Host
@@ -5949,9 +5957,10 @@ func setBaselineOptions(opts *Options) {
 		// Default to same bind from server if left undefined
 		opts.HTTPHost = opts.Host
 	}
-	if opts.Port == 0 {
+	// Only assign the default TCP port if no Unix Socket is requested
+	if opts.Port == 0 && opts.Socket == _EMPTY_ {
 		opts.Port = DEFAULT_PORT
-	} else if opts.Port == RANDOM_PORT {
+	} else if opts.Port == RANDOM_PORT && opts.Socket == _EMPTY_ {
 		// Choose randomly inside of net.Listen
 		opts.Port = 0
 	}
@@ -6166,6 +6175,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.BoolVar(&showHelp, "help", false, "Show this message.")
 	fs.IntVar(&opts.Port, "port", 0, "Port to listen on.")
 	fs.IntVar(&opts.Port, "p", 0, "Port to listen on.")
+	fs.StringVar(&opts.Socket, "socket", _EMPTY_, "Unix Domain Socket path to listen on.")
 	fs.StringVar(&opts.ServerName, "n", _EMPTY_, "Server name.")
 	fs.StringVar(&opts.ServerName, "name", _EMPTY_, "Server name.")
 	fs.StringVar(&opts.ServerName, "server_name", _EMPTY_, "Server name.")

--- a/server/server.go
+++ b/server/server.go
@@ -38,6 +38,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	// Allow dynamic profiling.
@@ -1142,6 +1143,24 @@ func validatePinnedCerts(pinned PinnedCertSet) error {
 }
 
 func validateOptions(o *Options) error {
+	if o.Socket != _EMPTY_ {
+		if o.Port != 0 {
+			return fmt.Errorf("cannot configure both a network port (%d) and a unix domain socket (%s)", o.Port, o.Socket)
+		}
+
+		// Unix socket paths are strictly limited by the OS kernel (usually 104 or 108 chars max)
+		if len(o.Socket) > 104 {
+			return fmt.Errorf("unix socket path %q is too long (max 104 characters)", o.Socket)
+		}
+
+		// Ensure the parent directory exists so we can actually create the file
+		parentDir := filepath.Dir(o.Socket)
+		if info, err := os.Stat(parentDir); err != nil {
+			return fmt.Errorf("parent directory for socket %q does not exist: %v", o.Socket, err)
+		} else if !info.IsDir() {
+			return fmt.Errorf("parent path %q for socket is not a directory", parentDir)
+		}
+	}
 	if o.LameDuckDuration > 0 && o.LameDuckGracePeriod >= o.LameDuckDuration {
 		return fmt.Errorf("lame duck grace period (%v) should be strictly lower than lame duck duration (%v)",
 			o.LameDuckGracePeriod, o.LameDuckDuration)
@@ -2775,16 +2794,29 @@ func (s *Server) AcceptLoop(clr chan struct{}) {
 
 	// Setup state that can enable shutdown
 	s.mu.Lock()
-	hp := net.JoinHostPort(opts.Host, strconv.Itoa(opts.Port))
-	l, e := s.getServerListener(hp)
+	var l net.Listener
+	var e error
+
+	if opts.Socket != _EMPTY_ {
+		l, e = s.getUnixListener(opts.Socket)
+		if e == nil {
+			s.Noticef("Listening for client connections on %s", opts.Socket)
+		}
+	} else {
+		hp := net.JoinHostPort(opts.Host, strconv.Itoa(opts.Port))
+		l, e = s.getServerListener(hp)
+		if e == nil {
+			s.Noticef("Listening for client connections on %s",
+				net.JoinHostPort(opts.Host, strconv.Itoa(l.Addr().(*net.TCPAddr).Port)))
+		}
+	}
+
 	s.listenerErr = e
 	if e != nil {
 		s.mu.Unlock()
-		s.Fatalf("Error listening on port: %s, %q", hp, e)
+		s.Fatalf("Error listening on: %v", e)
 		return
 	}
-	s.Noticef("Listening for client connections on %s",
-		net.JoinHostPort(opts.Host, strconv.Itoa(l.Addr().(*net.TCPAddr).Port)))
 
 	// Alert if PROXY protocol is enabled
 	if opts.ProxyProtocol {
@@ -2797,11 +2829,14 @@ func (s *Server) AcceptLoop(clr chan struct{}) {
 		if opts.TLSHandshakeFirst && opts.TLSHandshakeFirstFallback == 0 {
 			s.Warnf("Clients that are not using \"TLS Handshake First\" option will fail to connect")
 		}
+		if opts.Socket != _EMPTY_ {
+			s.Warnf("TLS is configured on a Unix Domain Socket. This is redundant and will negatively impact performance.")
+		}
 	}
 
 	// If server was started with RANDOM_PORT (-1), opts.Port would be equal
 	// to 0 at the beginning this function. So we need to get the actual port
-	if opts.Port == 0 {
+	if opts.Port == 0 && opts.Socket == _EMPTY_ {
 		// Write resolved port back to options.
 		opts.Port = l.Addr().(*net.TCPAddr).Port
 	}
@@ -2903,6 +2938,14 @@ func (s *Server) setInfoHostPort() error {
 	// port (if option was originally set to RANDOM), even during a config
 	// reload. So use of s.opts.Port is safe.
 	opts := s.getOpts()
+
+	// Explicitly mark the INFO block as a Unix socket
+	if opts.Socket != _EMPTY_ {
+		s.info.Host = "unix"
+		s.info.Port = 0
+		return nil
+	}
+
 	if opts.ClientAdvertise != _EMPTY_ {
 		h, p, err := parseHostPort(opts.ClientAdvertise, opts.Port)
 		if err != nil {
@@ -3222,6 +3265,32 @@ func (c *tlsMixConn) Read(b []byte) (int, error) {
 	return c.Conn.Read(b)
 }
 
+func (s *Server) getUnixListener(socketPath string) (net.Listener, error) {
+	if s.listener != nil {
+		return s.listener, s.listenerErr
+	}
+
+	// Connect-to-Test: Clean up stale sockets from unexpected crashes
+	if info, err := os.Stat(socketPath); err == nil {
+		// Ensure we are only deleting a socket file!
+		if info.Mode()&os.ModeSocket == 0 {
+			return nil, fmt.Errorf("file %s exists and is not a socket", socketPath)
+		}
+		if conn, err := net.Dial("unix", socketPath); err == nil {
+			conn.Close()
+			return nil, fmt.Errorf("socket %s already in use by another running server", socketPath)
+		} else if !errors.Is(err, syscall.ECONNREFUSED) {
+			// CRITICAL: If the error is Permission Denied, or anything other than
+			// Connection Refused, it might be a live socket we can't access. Do NOT delete!
+			return nil, fmt.Errorf("socket %s exists and cannot be safely verified as stale: %v", socketPath, err)
+		}
+		// File exists, is a socket, and connection was explicitly refused; it's a dead socket. Remove it.
+		os.Remove(socketPath)
+	}
+
+	return net.Listen("unix", socketPath)
+}
+
 func (s *Server) createClient(conn net.Conn) *client {
 	return s.createClientEx(conn, false)
 }
@@ -3295,6 +3364,12 @@ func (s *Server) createClientEx(conn net.Conn, inProcess bool) *client {
 
 	// Initialize
 	c.initClient()
+
+	// Ensure UDS clients are cleanly identified in monitoring
+	if _, ok := conn.RemoteAddr().(*net.UnixAddr); ok {
+		c.host = "unix"
+		c.port = 0
+	}
 
 	c.Debugf("Client connection created")
 
@@ -4105,6 +4180,13 @@ func (s *Server) closedClients() []*closedClient {
 func (s *Server) getClientConnectURLs() []string {
 	// Snapshot server options.
 	opts := s.getOpts()
+
+	// If we are strictly on a Unix socket, do not advertise it.
+	// Unix sockets are local to the machine and unusable by remote cluster members.
+	if opts.Socket != _EMPTY_ {
+		return nil
+	}
+
 	// Ignore error here since we know that if there is client advertise, the
 	// parseHostPort is correct because we did it right before calling this
 	// function in Server.New().
@@ -4194,28 +4276,33 @@ func (s *Server) getNonLocalIPsIfHostIsIPAny(host string, all bool) (bool, []str
 // if the ip is not specified, attempt to resolve it
 func resolveHostPorts(addr net.Listener) []string {
 	hostPorts := make([]string, 0)
-	hp := addr.Addr().(*net.TCPAddr)
-	port := strconv.Itoa(hp.Port)
-	if hp.IP.IsUnspecified() {
-		var ip net.IP
-		ifaces, _ := net.Interfaces()
-		for _, i := range ifaces {
-			addrs, _ := i.Addrs()
-			for _, addr := range addrs {
-				switch v := addr.(type) {
-				case *net.IPNet:
-					ip = v.IP
-					hostPorts = append(hostPorts, net.JoinHostPort(ip.String(), port))
-				case *net.IPAddr:
-					ip = v.IP
-					hostPorts = append(hostPorts, net.JoinHostPort(ip.String(), port))
-				default:
-					continue
+
+	switch hp := addr.Addr().(type) {
+	case *net.UnixAddr:
+		hostPorts = append(hostPorts, hp.Name)
+	case *net.TCPAddr:
+		port := strconv.Itoa(hp.Port)
+		if hp.IP.IsUnspecified() {
+			var ip net.IP
+			ifaces, _ := net.Interfaces()
+			for _, i := range ifaces {
+				addrs, _ := i.Addrs()
+				for _, addr := range addrs {
+					switch v := addr.(type) {
+					case *net.IPNet:
+						ip = v.IP
+						hostPorts = append(hostPorts, net.JoinHostPort(ip.String(), port))
+					case *net.IPAddr:
+						ip = v.IP
+						hostPorts = append(hostPorts, net.JoinHostPort(ip.String(), port))
+					default:
+						continue
+					}
 				}
 			}
+		} else {
+			hostPorts = append(hostPorts, net.JoinHostPort(hp.IP.String(), port))
 		}
-	} else {
-		hostPorts = append(hostPorts, net.JoinHostPort(hp.IP.String(), port))
 	}
 	return hostPorts
 }
@@ -4437,6 +4524,7 @@ func (s *Server) lameDuckMode() {
 	s.listener = nil
 	expected += s.closeWebsocketServer()
 	s.ldmCh = make(chan bool, expected)
+
 	opts := s.getOpts()
 	gp := opts.LameDuckGracePeriod
 	// For tests, we want the grace period to be in some cases bigger


### PR DESCRIPTION
### Description
This PR adds support for Unix Domain Sockets (UDS) for local client connections, providing a high-performance, secure IPC alternative to loopback TCP. This is particularly useful for sidecar deployments where administrators want to rely on OS-level file permissions instead of managing application-level authentication, and wish to bypass the TCP network stack overhead.

UDS support is intentionally scoped strictly to the primary client listener (`Options.Socket`). Clustering, gateways, and leafnodes remain exclusively TCP-based to preserve distributed topology stability.

### Changes Made
* Added `Socket` string field to `Options` and configuration parsing.
* Added strict validation in `validateOptions` to ensure `Port` and `Socket` are mutually exclusive, and to validate path length and parent directory permissions.
* Implemented a "Connect-to-Test" pattern in `getUnixListener` to safely remove orphaned `.sock` files resulting from unexpected crashes/power loss without deleting active sockets.
* Updated `AcceptLoop` to support `net.UnixAddr`, bypassing the `net.TCPAddr` casts.
* Handled client metadata overrides: UDS clients are identified with `c.host = "unix"` and `c.port = 0` to preserve `/connz` and `/varz` monitoring stability.
* `PortsInfo` and the `INFO` protocol payload now accurately broadcast the UDS path instead of falling back to `0.0.0.0:0`.
* Configured dynamic cleanup of the `.sock` file during graceful `Shutdown()` and `lameDuckMode()`.
* Added a startup warning if a user redundantly configures both a `tls{}` block and a Unix socket to help operators optimize CPU usage.

### Testing
* Config validation prevents mixing TCP ports and sockets.
* Verified no panics occur during `net.Addr` casts in standard lifecycle or HTTP monitoring endpoints.
* Validated live config reload (`SIGHUP`) does not orphan active socket files if the configuration path changes.

Signed-off-by: Dirk Pauw <dirk@tavas.tech>
