### PR TITLE
(2.14) [FIXED] Failed recovery with truncated block key file

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -1205,6 +1205,10 @@ func (fs *fileStore) recoverMsgBlock(index uint32) (*msgBlock, error) {
 
 	// Make sure encryption loaded if needed.
 	if err = fs.loadEncryptionForMsgBlock(mb); err != nil {
+		// If the encryption key is truncated or unrecoverable, return the block so it can be deleted.
+		if err == errBadKeySize || err == errKeyInvalid {
+			return mb, err
+		}
 		return nil, err
 	}
 
@@ -1455,7 +1459,7 @@ func (mb *msgBlock) convertCipher() error {
 		}
 		return nil
 	}
-	return fmt.Errorf("unable to recover keys")
+	return errKeyInvalid
 }
 
 // Convert a plaintext block to encrypted.
@@ -2491,6 +2495,18 @@ func (fs *fileStore) recoverMsgs() error {
 				mb.last.ts = fs.state.LastTime.UnixNano()
 			}
 			mb.mu.Unlock()
+		} else if (err == errBadKeySize || err == errKeyInvalid) && mb != nil {
+			// If we can't load the encryption key, we can't decrypt the block's data.
+			// We'll revert to deleting this block until there is peer-based recovery. This still
+			// catches up from the leader if it happened in the stream's tail.
+			mb.mu.Lock()
+			if err := mb.dirtyCloseWithRemove(true); err != nil {
+				mb.mu.Unlock()
+				return err
+			}
+			fs.removeMsgBlockFromList(mb)
+			mb.mu.Unlock()
+			continue
 		} else {
 			return err
 		}
@@ -8612,6 +8628,7 @@ var (
 	errPendingData   = errors.New("pending data still present")
 	errNoEncryption  = errors.New("encryption not enabled")
 	errBadKeySize    = errors.New("encryption bad key size")
+	errKeyInvalid    = errors.New("unable to recover keys")
 	errNoMsgBlk      = errors.New("no message block")
 	errMsgBlkTooBig  = errors.New("message block size exceeded int capacity")
 	errUnknownCipher = errors.New("unknown cipher")

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -8938,6 +8938,77 @@ func TestJetStreamClusterDesyncAfterDiskResetDuringRollout(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterEncryptedReplicaRecoversFromCorruptKeyFile(t *testing.T) {
+	test := func(truncateTo int64) {
+		c := createJetStreamClusterWithTemplate(t, jsClusterEncryptedTempl, "C", 3)
+		defer c.shutdown()
+
+		nc, js := jsClientConnect(t, c.randomServer())
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:     "TEST",
+			Subjects: []string{"foo"},
+			Replicas: 3,
+		})
+		require_NoError(t, err)
+
+		for range 100 {
+			_, err = js.Publish("foo", nil)
+			require_NoError(t, err)
+		}
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			return checkState(t, c, globalAccountName, "TEST")
+		})
+
+		// Take down a caught-up follower to stand in for a host that loses power.
+		nsl := c.randomNonStreamLeader(globalAccountName, "TEST")
+		require_NotNil(t, nsl)
+		mset, err := nsl.globalAccount().lookupStream("TEST")
+		require_NoError(t, err)
+		rg := mset.raftGroup().Name
+		sd := nsl.getOpts().StoreDir
+		nsl.Shutdown()
+
+		// Truncate the WAL's key files, simulating an unsynced write.
+		walMsgs := filepath.Join(sd, "jetstream", "$SYS", "_js_", rg, msgDir)
+		keys, err := filepath.Glob(filepath.Join(walMsgs, "*.key"))
+		require_NoError(t, err)
+		require_True(t, len(keys) > 0)
+		for _, k := range keys {
+			require_NoError(t, os.Truncate(k, truncateTo))
+		}
+
+		// Advance the stream while the follower is down, so it must catch up to return.
+		for range 100 {
+			_, err = js.Publish("foo", nil)
+			require_NoError(t, err)
+		}
+		rs := c.restartServer(nsl)
+
+		// The replica should reset its corrupt WAL and rebuild from the leader.
+		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+			state, err := checkStateAndErr(t, c, globalAccountName, "TEST")
+			if err != nil {
+				return err
+			}
+			if state.Msgs != 200 {
+				return fmt.Errorf("expected 200 messages, got %d", state.Msgs)
+			}
+			return nil
+		})
+		c.waitOnServerHealthz(rs)
+	}
+
+	// Truncate below minBlkKeySize (64) fails fast with errBadKeySize, while truncation to
+	// 64-71 bytes passes the size check but fails to open/convert the key.
+	for _, size := range []int64{0, 70} {
+		t.Run(fmt.Sprintf("TruncateTo%d", size), func(t *testing.T) {
+			test(size)
+		})
+	}
+}
+
 //
 // DO NOT ADD NEW TESTS IN THIS FILE  (unless to balance test times)
 // Add at the end of jetstream_cluster_<n>_test.go, with <n> being the highest value.


### PR DESCRIPTION
An unsynced and truncated block key file would result in `encryption bad key size` preventing the filestore from starting. This PR reverts to the effective 2.12 and below behavior of removing the block file, while still handling the error, since without the key the data can't be recovered. This allows for recovery through catchup from the leader, but is not fully correct and should be replaced by a peer-based recovery method in the future.