### PR TITLE
[FIXED] Block encryption key file was not synced

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -221,51 +221,52 @@ type fileStore struct {
 // Represents a message store block and its data.
 type msgBlock struct {
 	// Here for 32bit systems and atomic.
-	first      msgId
-	last       msgId
-	mu         sync.RWMutex
-	fs         *fileStore
-	aek        cipher.AEAD
-	bek        cipher.Stream
-	seed       []byte
-	nonce      []byte
-	mfn        string
-	mfd        *os.File
-	cmp        StoreCompression // Effective compression at the time of loading the block
-	liwsz      int64
-	index      uint32
-	bytes      uint64 // User visible bytes count.
-	rbytes     uint64 // Total bytes (raw) including deleted. Used for rolling to new blk.
-	cbytes     uint64 // Bytes count after last compaction. 0 if no compaction happened yet.
-	msgs       uint64 // User visible message count.
-	fss        *stree.SubjectTree[SimpleState]
-	kfn        string
-	lwts       int64
-	llts       int64
-	lrts       int64
-	lsts       int64
-	llseq      uint64
-	hh         *highwayhash.Digest64
-	ecache     elastic.Pointer[cache]
-	cache      *cache
-	cloads     uint64
-	cexp       time.Duration
-	fexp       time.Duration
-	ctmr       *time.Timer
-	werr       error
-	dmap       avl.SequenceSet
-	fch        chan struct{}
-	qch        chan struct{}
-	lchk       [8]byte
-	loading    bool
-	flusher    bool
-	noTrack    bool
-	needSync   bool
-	syncAlways bool
-	noCompact  bool
-	closed     bool
-	ttls       uint64 // How many msgs have TTLs?
-	schedules  uint64 // How many msgs have schedules?
+	first       msgId
+	last        msgId
+	mu          sync.RWMutex
+	fs          *fileStore
+	aek         cipher.AEAD
+	bek         cipher.Stream
+	seed        []byte
+	nonce       []byte
+	mfn         string
+	mfd         *os.File
+	cmp         StoreCompression // Effective compression at the time of loading the block
+	liwsz       int64
+	index       uint32
+	bytes       uint64 // User visible bytes count.
+	rbytes      uint64 // Total bytes (raw) including deleted. Used for rolling to new blk.
+	cbytes      uint64 // Bytes count after last compaction. 0 if no compaction happened yet.
+	msgs        uint64 // User visible message count.
+	fss         *stree.SubjectTree[SimpleState]
+	kfn         string
+	lwts        int64
+	llts        int64
+	lrts        int64
+	lsts        int64
+	llseq       uint64
+	hh          *highwayhash.Digest64
+	ecache      elastic.Pointer[cache]
+	cache       *cache
+	cloads      uint64
+	cexp        time.Duration
+	fexp        time.Duration
+	ctmr        *time.Timer
+	werr        error
+	dmap        avl.SequenceSet
+	fch         chan struct{}
+	qch         chan struct{}
+	lchk        [8]byte
+	loading     bool
+	flusher     bool
+	noTrack     bool
+	needSync    bool
+	needKeySync bool // Key file is written once and immutable, cleared after its one sync.
+	syncAlways  bool
+	noCompact   bool
+	closed      bool
+	ttls        uint64 // How many msgs have TTLs?
+	schedules   uint64 // How many msgs have schedules?
 
 	// Used to mock write failures.
 	mockWriteErr bool
@@ -1443,7 +1444,7 @@ func (mb *msgBlock) convertCipher() error {
 		// the old keyfile back.
 		if err := fs.genEncryptionKeysForBlock(mb); err != nil {
 			keyFile := filepath.Join(mdir, fmt.Sprintf(keyScan, mb.index))
-			fs.writeFileWithOptionalSync(keyFile, ekey, defaultFilePerms)
+			writeFileWithSync(fs.dios, keyFile, ekey, defaultFilePerms)
 			return err
 		}
 		mb.bek.XORKeyStream(buf, buf)
@@ -4862,11 +4863,14 @@ func (fs *fileStore) genEncryptionKeysForBlock(mb *msgBlock) error {
 	if _, err := os.Stat(keyFile); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	err = fs.writeFileWithOptionalSync(keyFile, encrypted, defaultFilePerms)
+	sync := fs.syncAlways.Load()
+	err = writeAtomically(fs.dios, keyFile, encrypted, defaultFilePerms, sync)
 	if err != nil {
 		return err
 	}
 	mb.kfn = keyFile
+	// If we did not sync the key file above, mark it to be synced on the next syncBlocks pass.
+	mb.needKeySync = !sync
 	return nil
 }
 
@@ -7813,10 +7817,12 @@ func (fs *fileStore) syncBlocks() {
 		}
 		// Check if we need to sync. We will not hold lock during actual sync.
 		needSync := mb.needSync
+		needKeySync, kfn := mb.needKeySync, mb.kfn
 
 		// Reset. Because we let go of the lock, we could write new data to this mb which might or
 		// might not be synced later if we would've reset after letting go of the lock.
 		mb.needSync = false
+		mb.needKeySync = false
 		mb.mu.Unlock()
 
 		// Check if we should compact here.
@@ -7860,6 +7866,14 @@ func (fs *fileStore) syncBlocks() {
 					storeFsWerr(err)
 					continue
 				}
+			}
+		}
+
+		// Check if we need to sync this block's key file.
+		if needKeySync && kfn != _EMPTY_ {
+			if err := fs.syncFileAndDir(kfn); err != nil {
+				storeFsWerr(err)
+				continue
 			}
 		}
 
@@ -13826,18 +13840,53 @@ func writeAtomically(dios *diskIOSemaphore, name string, data []byte, perm fs.Fi
 	if sync && canFsyncDirectories {
 		// To ensure that the file rename was persisted on all filesystems,
 		// also try to flush the directory metadata.
-		var d *os.File
-		if d, err = os.Open(filepath.Dir(name)); err != nil {
+		if err = syncDir(name); err != nil {
 			return err
 		}
-		if err = d.Sync(); err != nil {
-			// Close fd, but ignore its error since sync takes precedence.
-			_ = d.Close()
+	}
+	return nil
+}
+
+func (fs *fileStore) syncFileAndDir(name string) error {
+	fs.dios.acquire()
+	defer fs.dios.release()
+	f, err := os.OpenFile(name, os.O_RDWR, defaultFilePerms)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if err = f.Sync(); err != nil {
+		// Close fd, but ignore its error since sync takes precedence.
+		_ = f.Close()
+		return err
+	}
+	if err = f.Close(); err != nil {
+		return err
+	}
+	if canFsyncDirectories {
+		if err = syncDir(name); err != nil {
 			return err
 		}
-		if err = d.Close(); err != nil {
-			return err
-		}
+	}
+	return nil
+}
+
+// Dios should already be held.
+func syncDir(name string) error {
+	var d *os.File
+	var err error
+	if d, err = os.Open(filepath.Dir(name)); err != nil {
+		return err
+	}
+	if err = d.Sync(); err != nil {
+		// Close fd, but ignore its error since sync takes precedence.
+		_ = d.Close()
+		return err
+	}
+	if err = d.Close(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -14789,3 +14789,49 @@ func TestFileStoreSyncDeletedDmapAliasRace(t *testing.T) {
 	// Sanity: store still usable.
 	_ = fs.State()
 }
+
+func TestFileStoreEncryptionKeyFileSyncedBySyncBlocks(t *testing.T) {
+	fcfg := FileStoreConfig{StoreDir: t.TempDir(), Cipher: AES}
+	fs, err := newFileStoreWithCreated(fcfg, StreamConfig{Name: "S1", Storage: FileStorage}, time.Now(), prf(&fcfg), nil)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	_, _, err = fs.StoreMsg("foo", nil, []byte("Hello World"), 0)
+	require_NoError(t, err)
+
+	// The key file is written without a sync, so it should be marked for one.
+	fs.mu.RLock()
+	lmb := fs.lmb
+	fs.mu.RUnlock()
+	require_NotNil(t, lmb)
+	lmb.mu.RLock()
+	needKeySync, kfn := lmb.needKeySync, lmb.kfn
+	lmb.mu.RUnlock()
+	require_True(t, needKeySync)
+	require_True(t, kfn != _EMPTY_)
+
+	// A sync pass should sync the key file and clear the flag.
+	fs.syncBlocks()
+	lmb.mu.RLock()
+	needKeySync = lmb.needKeySync
+	lmb.mu.RUnlock()
+	require_False(t, needKeySync)
+
+	// With SyncAlways the key file write is already synced, so the flag should not be set.
+	fcfg = FileStoreConfig{StoreDir: t.TempDir(), Cipher: AES, SyncAlways: true}
+	fs2, err := newFileStoreWithCreated(fcfg, StreamConfig{Name: "S2", Storage: FileStorage}, time.Now(), prf(&fcfg), nil)
+	require_NoError(t, err)
+	defer fs2.Stop()
+
+	_, _, err = fs2.StoreMsg("foo", nil, []byte("Hello World"), 0)
+	require_NoError(t, err)
+
+	fs2.mu.RLock()
+	lmb = fs2.lmb
+	fs2.mu.RUnlock()
+	require_NotNil(t, lmb)
+	lmb.mu.RLock()
+	needKeySync = lmb.needKeySync
+	lmb.mu.RUnlock()
+	require_False(t, needKeySync)
+}


### PR DESCRIPTION
Can be applied cleanly on the 2.14 line, but will need a custom backport for 2.12 since it doesn't have the additional error handling.