### PR TITLE
(2.15) [FIXED] Batch apply state data race

### DIFF
--- a/locksordering.txt
+++ b/locksordering.txt
@@ -35,12 +35,11 @@ The "clsMu" lock protects the consumer list on a stream, used for signalling con
 
     stream -> clsMu
 
-The "clMu", "ddMu" and "batchMu" locks protect clustered, dedupe and batch state respectively.
-The stream lock (`mset.mu`) is optional, but if holding "clMu", "ddMu" or "batchMu",
+The "clMu" and "ddMu" locks protect clustered and dedupe state respectively.
+The stream lock (`mset.mu`) is optional, but if holding "clMu" or "ddMu",
 locking the stream lock afterward would violate locking order.
 
     stream -> clMu
-    stream -> batchMu -> clMu
     stream -> clMu -> ddMu
 
 The "mset.batches.mu" lock protects the batching state without needing to hold the stream lock.

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -497,7 +497,6 @@ func (diff *batchStagedDiff) commit(mset *stream) {
 }
 
 type batchApply struct {
-	mu         sync.Mutex
 	id         string            // ID of the current batch.
 	count      uint64            // Number of entries in the batch, for consistency checks.
 	entries    []*CommittedEntry // Previous entries that are part of this batch.
@@ -505,9 +504,8 @@ type batchApply struct {
 	maxApplied uint64            // Applied value before the entry containing the first message of the batch.
 }
 
-// clearBatchStateLocked clears in-memory apply-batch-related state.
-// batch.mu lock should be held.
-func (batch *batchApply) clearBatchStateLocked() {
+// clearBatchState clears in-memory apply-batch-related state.
+func (batch *batchApply) clearBatchState() {
 	batch.id = _EMPTY_
 	batch.count = 0
 	batch.entries = nil
@@ -517,8 +515,7 @@ func (batch *batchApply) clearBatchStateLocked() {
 
 // rejectBatchStateLocked rejects the batch and clears in-memory apply-batch-related state.
 // Corrects mset.clfs to take the failed batch into account.
-// batch.mu lock should be held.
-func (batch *batchApply) rejectBatchStateLocked(mset *stream) {
+func (batch *batchApply) rejectBatchState(mset *stream) {
 	mset.clMu.Lock()
 	mset.clfs += batch.count
 	mset.clMu.Unlock()
@@ -526,13 +523,7 @@ func (batch *batchApply) rejectBatchStateLocked(mset *stream) {
 	for _, bce := range batch.entries {
 		bce.ReturnToPool()
 	}
-	batch.clearBatchStateLocked()
-}
-
-func (batch *batchApply) rejectBatchState(mset *stream) {
-	batch.mu.Lock()
-	defer batch.mu.Unlock()
-	batch.rejectBatchStateLocked(mset)
+	batch.clearBatchState()
 }
 
 // checkMsgHeadersPreClusteredProposal checks the message for expected/consistency headers.
@@ -1041,25 +1032,16 @@ func checkMsgHeadersPreClusteredProposal(
 // mset.clMu lock must be held.
 func recalculateClusteredSeq(mset *stream, needStreamLock bool) (lseq uint64) {
 	// Need to unlock and re-acquire the locks in the proper order.
-	mset.clMu.Unlock()
-	// Locking order is stream -> batchMu -> clMu
+	// Locking order is stream -> clMu
 	if needStreamLock {
+		mset.clMu.Unlock()
 		mset.mu.RLock()
+		mset.clMu.Lock()
 	}
-	batch := mset.batchApply
-	var batchCount uint64
-	if batch != nil {
-		batch.mu.Lock()
-		batchCount = batch.count
-	}
-	mset.clMu.Lock()
 	// Re-capture
 	lseq = mset.lseq
-	mset.clseq = lseq + mset.clfs + batchCount
+	mset.clseq = lseq + mset.clfs
 	// Keep hold of the mset.clMu, but unlock the others.
-	if batch != nil {
-		batch.mu.Unlock()
-	}
 	if needStreamLock {
 		mset.mu.RUnlock()
 	}

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -736,10 +736,8 @@ func TestJetStreamAtomicBatchPublishCleanup(t *testing.T) {
 		require_NoError(t, err)
 		mset.mu.RLock()
 		batches := mset.batches
-		batch := mset.batchApply
 		mset.mu.RUnlock()
 		require_True(t, batches == nil)
-		require_True(t, batch == nil)
 
 		// Enabling doesn't need to populate the batching state.
 		cfg.AllowAtomicPublish = true
@@ -747,10 +745,8 @@ func TestJetStreamAtomicBatchPublishCleanup(t *testing.T) {
 		require_NoError(t, err)
 		mset.mu.RLock()
 		batches = mset.batches
-		batch = mset.batchApply
 		mset.mu.RUnlock()
 		require_True(t, batches == nil)
-		require_True(t, batch == nil)
 
 		// Publish a partial batch that needs to be cleaned up.
 		m := nats.NewMsg("foo")
@@ -766,10 +762,8 @@ func TestJetStreamAtomicBatchPublishCleanup(t *testing.T) {
 
 		mset.mu.RLock()
 		batches = mset.batches
-		batch = mset.batchApply
 		mset.mu.RUnlock()
 		require_NotNil(t, batches)
-		require_NotNil(t, batch)
 		batches.mu.Lock()
 		groups := len(batches.atomic)
 		b := batches.atomic["uuid"]
@@ -778,7 +772,6 @@ func TestJetStreamAtomicBatchPublishCleanup(t *testing.T) {
 		require_NotNil(t, b)
 		store := b.store
 		require_Equal(t, store.State().Msgs, 1)
-		clfs := mset.getCLFS()
 
 		// Should fully clean up the in-progress batch.
 		switch mode {
@@ -818,59 +811,12 @@ func TestJetStreamAtomicBatchPublishCleanup(t *testing.T) {
 			}
 			return nil
 		})
-		// Should clean up the batch apply state.
-		if mode == Disable || mode == Delete {
-			checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
-				mset.mu.RLock()
-				batch = mset.batchApply
-				mset.mu.RUnlock()
-				nclfs := mset.getCLFS()
-				if batch != nil {
-					return fmt.Errorf("expected no batch apply")
-				}
-				if clfs != nclfs {
-					return fmt.Errorf("expected no change in CLFS")
-				}
-				return nil
-			})
-		}
 	}
 
 	t.Run("Disable", func(t *testing.T) { test(t, Disable) })
 	t.Run("StepDown", func(t *testing.T) { test(t, StepDown) })
 	t.Run("Delete", func(t *testing.T) { test(t, Delete) })
 	t.Run("Commit", func(t *testing.T) { test(t, Commit) })
-}
-
-func TestJetStreamAtomicBatchDeleteBatchApplyStateNoDoublePut(t *testing.T) {
-	mset := &stream{}
-	batch := &batchApply{
-		id:         "test-batch",
-		count:      3,
-		entryStart: 5,
-		maxApplied: 42,
-		entries:    []*CommittedEntry{{Index: 1}, {Index: 2}, {Index: 3}},
-	}
-	mset.batchApply = batch
-
-	mset.mu.Lock()
-	mset.deleteBatchApplyState()
-	mset.mu.Unlock()
-
-	require_True(t, mset.batchApply == nil)
-
-	batch.mu.Lock()
-	require_True(t, batch.entries == nil)
-	require_Equal(t, batch.id, _EMPTY_)
-	require_Equal(t, batch.count, uint64(0))
-	require_Equal(t, batch.entryStart, 0)
-	require_Equal(t, batch.maxApplied, uint64(0))
-
-	// Count was zeroed above, so the reject path must not bump clfs.
-	preCLFS := mset.clfs
-	batch.rejectBatchStateLocked(mset)
-	batch.mu.Unlock()
-	require_Equal(t, mset.clfs, preCLFS)
 }
 
 func TestJetStreamAtomicBatchPublishConfigOpts(t *testing.T) {
@@ -3112,15 +3058,10 @@ func TestJetStreamAtomicBatchPublishPartialBatchInSharedAppendEntry(t *testing.T
 			newEntry(EntryNormal, esm1),
 			newEntry(EntryNormal, esm2),
 		})
-		_, err = js.applyStreamEntries(mset, ce, false)
+		batch := &batchApply{}
+		_, err = js.applyStreamEntries(mset, ce, false, batch)
 		require_NoError(t, err)
-
-		mset.mu.RLock()
-		batch := mset.batchApply
-		mset.mu.RUnlock()
-		batch.mu.Lock()
 		entryStart, maxApplied := batch.entryStart, batch.maxApplied
-		batch.mu.Unlock()
 
 		if !commit {
 			require_Equal(t, entryStart, 1)
@@ -3171,24 +3112,18 @@ func TestJetStreamAtomicBatchPublishCatchupMarkerMidBatch(t *testing.T) {
 	hdr1 = genHeader(hdr1, "Nats-Batch-Sequence", "1")
 	esm1 := encodeStreamMsgAllowCompressAndBatch("foo", _EMPTY_, hdr1, []byte("hello"), 0, ts, false, "uuid", 1, false)
 	ce1 := newCommittedEntry(1, []*Entry{newEntry(EntryNormal, esm1)})
-	_, err = js.applyStreamEntries(mset, ce1, false)
+	batch := &batchApply{}
+	_, err = js.applyStreamEntries(mset, ce1, false, batch)
 	require_NoError(t, err)
 
 	// Confirm the batch is in progress.
-	mset.mu.RLock()
-	batch := mset.batchApply
-	mset.mu.RUnlock()
-	require_NotNil(t, batch)
-	batch.mu.Lock()
-	inProgress := batch.id != _EMPTY_
-	batch.mu.Unlock()
-	require_True(t, inProgress)
+	require_True(t, batch.id != _EMPTY_)
 
 	// 2) A Raft-level catchup starts mid-batch. This pushes a marker entry with
 	//    Type==EntryCatchup and Data==nil (see raft.sendCatchupSignal). The
 	//    in-progress batch must remain intact and buffer this marker.
 	catchupCE := newCommittedEntry(0, []*Entry{{EntryCatchup, nil}})
-	_, err = js.applyStreamEntries(mset, catchupCE, false)
+	_, err = js.applyStreamEntries(mset, catchupCE, false, batch)
 	require_NoError(t, err)
 
 	// 3) Apply the batch commit (seq 2). The replay loop must skip the buffered
@@ -3204,10 +3139,9 @@ func TestJetStreamAtomicBatchPublishCatchupMarkerMidBatch(t *testing.T) {
 	var panicked any
 	func() {
 		defer func() { panicked = recover() }()
-		_, err = js.applyStreamEntries(mset, ce2, false)
+		_, err = js.applyStreamEntries(mset, ce2, false, batch)
 	}()
 	if panicked != nil {
-		batch.mu.Unlock()
 		mset.mu.Unlock()
 		t.Fatalf("applyStreamEntries panicked committing a batch with a buffered EntryCatchup entry: %v", panicked)
 	}
@@ -3251,23 +3185,26 @@ func TestJetStreamAtomicBatchPublishRejectPartialBatchOnLeaderChange(t *testing.
 
 	// Wait for all servers to have received and populated the partial batch.
 	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		var pindexMax uint64
 		for _, s := range c.servers {
 			mset2, err := s.globalAccount().lookupStream("TEST")
 			if err != nil {
 				return err
 			}
-			mset2.mu.RLock()
-			batch := mset2.batchApply
-			mset2.mu.RUnlock()
-			if batch == nil {
-				return fmt.Errorf("expected batch to be set")
+			rn := mset2.raftNode().(*raft)
+			rn.RLock()
+			prop, pindex, processed := rn.prop.len(), rn.pindex, rn.processed
+			rn.RUnlock()
+			if prop > 0 {
+				return fmt.Errorf("still has inflight proposals")
+			} else if pindex != processed {
+				return fmt.Errorf("pindex %d != processed %d", pindex, processed)
+			} else if pindexMax == 0 {
+				pindexMax = pindex
+			} else if pindex != pindexMax {
+				return fmt.Errorf("pindex %d != max %d", pindex, pindexMax)
 			}
-			batch.mu.Lock()
-			count := batch.count
-			batch.mu.Unlock()
-			if count != 10 {
-				return fmt.Errorf("expected batch count to be 10, got: %d", count)
-			}
+
 		}
 		return nil
 	})

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3419,6 +3419,15 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 		sendSnapshot = false
 	}
 
+	// State to check for atomic batch completeness before applying it.
+	batch := &batchApply{}
+	defer func() {
+		for _, bce := range batch.entries {
+			bce.ReturnToPool()
+		}
+		batch.clearBatchState()
+	}()
+
 	for {
 		select {
 		case <-s.quitCh:
@@ -3470,13 +3479,8 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 					continue
 				} else if len(ce.Entries) == 0 {
 					// If we have a partial batch, it needs to be rejected to ensure CLFS is correct.
-					if mset != nil {
-						mset.mu.RLock()
-						batch := mset.batchApply
-						mset.mu.RUnlock()
-						if batch != nil {
-							batch.rejectBatchState(mset)
-						}
+					if mset != nil && batch != nil && batch.id != _EMPTY_ {
+						batch.rejectBatchState(mset)
 					}
 
 					// Entry could be empty on a restore when mset is nil.
@@ -3486,7 +3490,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 				}
 
 				// Apply our entries.
-				if maxApplied, err := js.applyStreamEntries(mset, ce, isRecovering); err == nil {
+				if maxApplied, err := js.applyStreamEntries(mset, ce, isRecovering, batch); err == nil {
 					// Update our applied.
 					if maxApplied > 0 {
 						// Indicate we've processed (but not applied) everything up to this point.
@@ -4010,11 +4014,7 @@ func isControlHdr(hdr []byte) bool {
 
 // Apply our stream entries.
 // Return maximum allowed applied value, if currently inside a batch, zero otherwise.
-func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isRecovering bool) (uint64, error) {
-	mset.mu.RLock()
-	batch := mset.batchApply
-	mset.mu.RUnlock()
-
+func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isRecovering bool, batch *batchApply) (uint64, error) {
 	for i, e := range ce.Entries {
 		// Ignore if lower-level catchup is started.
 		// We don't need to optimize during this, all entries are handled as normal.
@@ -4037,29 +4037,21 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				if err != nil {
 					return 0, err
 				}
-				// Initialize if unset.
-				if batch == nil {
-					batch = &batchApply{}
-					mset.mu.Lock()
-					mset.batchApply = batch
-					mset.mu.Unlock()
-				}
 
-				// Need to grab the stream lock before the batch lock.
+				// Need to grab the stream lock first.
 				if isRecovering {
 					mset.mu.Lock()
 				}
-				batch.mu.Lock()
 
 				// Previous batch (if any) was abandoned.
 				if batch.id != _EMPTY_ && batchId != batch.id {
-					batch.rejectBatchStateLocked(mset)
+					batch.rejectBatchState(mset)
 				}
 				if batchSeq == 1 {
 					// If this is the first message in the batch, need to mark the start index.
 					// We'll continue to check batch-completeness and try to find the commit.
 					// At that point we'll commit the whole batch.
-					batch.rejectBatchStateLocked(mset)
+					batch.rejectBatchState(mset)
 					batch.entryStart = i
 					batch.maxApplied = ce.Index - 1
 				}
@@ -4072,7 +4064,6 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				if isRecovering {
 					if batchSeq > 1 && batch.count == 0 {
 						if skip, err := mset.skipBatchIfRecovering(batch, buf); err != nil || skip {
-							batch.mu.Unlock()
 							mset.mu.Unlock()
 							if err != nil {
 								return 0, err
@@ -4086,11 +4077,9 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				batch.count++
 				// If the sequence is not monotonically increasing/we identify gaps, the batch can't be accepted.
 				if batchSeq != batch.count {
-					batch.rejectBatchStateLocked(mset)
-					batch.mu.Unlock()
+					batch.rejectBatchState(mset)
 					continue
 				}
-				batch.mu.Unlock()
 				continue
 			} else if op == batchCommitMsgOp {
 				batchId, batchSeq, _, _, err := decodeBatchMsg(buf[1:])
@@ -4102,21 +4091,14 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				// can only happen after the full batch is committed.
 				mset.mu.Lock()
 
-				// Initialize if unset.
-				if batch == nil {
-					batch = &batchApply{}
-					mset.batchApply = batch
-				}
-				batch.mu.Lock()
-
 				// Previous batch (if any) was abandoned.
 				if batch.id != _EMPTY_ && batchId != batch.id {
-					batch.rejectBatchStateLocked(mset)
+					batch.rejectBatchState(mset)
 				}
 				if batchSeq == 1 {
 					// If this is the first message in the batch, need to mark the start index.
 					// This is a batch of size one that immediately commits.
-					batch.rejectBatchStateLocked(mset)
+					batch.rejectBatchState(mset)
 					batch.entryStart = i
 					batch.maxApplied = ce.Index - 1
 				}
@@ -4128,7 +4110,6 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				// If we still see the first message of the batch, we don't skip any messages of the batch here.
 				if isRecovering && batchSeq > 1 && batch.count == 0 {
 					if skip, err := mset.skipBatchIfRecovering(batch, buf); err != nil || skip {
-						batch.mu.Unlock()
 						mset.mu.Unlock()
 						if err != nil {
 							return 0, err
@@ -4140,8 +4121,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				batch.count++
 				// Detected a gap, reject the batch.
 				if batchSeq != batch.count {
-					batch.rejectBatchStateLocked(mset)
-					batch.mu.Unlock()
+					batch.rejectBatchState(mset)
 					mset.mu.Unlock()
 					continue
 				}
@@ -4162,8 +4142,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 							nce.ReturnToPool()
 						}
 						// Important to clear, otherwise we could return the entries to the pool multiple times.
-						batch.clearBatchStateLocked()
-						batch.mu.Unlock()
+						batch.clearBatchState()
 						mset.mu.Unlock()
 					}
 					for _, entry := range entries {
@@ -4193,8 +4172,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				}
 				clearAndUnlock := func() {
 					// Important to clear, otherwise we could return the entries to the pool multiple times.
-					batch.clearBatchStateLocked()
-					batch.mu.Unlock()
+					batch.clearBatchState()
 					mset.mu.Unlock()
 				}
 				// Process remaining entries in the current entry.
@@ -4214,8 +4192,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 					}
 				}
 				// Clear state, batch was successful.
-				batch.clearBatchStateLocked()
-				batch.mu.Unlock()
+				batch.clearBatchState()
 				mset.mu.Unlock()
 				continue
 			} else if batch != nil && batch.id != _EMPTY_ {
@@ -4434,21 +4411,19 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 	// If we're still actively processing a batch, must store the entry in-memory
 	// to come back to it later once we find the commit.
 	if batch != nil && batch.id != _EMPTY_ {
-		batch.mu.Lock()
 		if batch.entries == nil {
 			batch.entries = []*CommittedEntry{ce}
 		} else {
 			batch.entries = append(batch.entries, ce)
 		}
 		maxApplied := batch.maxApplied
-		batch.mu.Unlock()
 		return maxApplied, nil
 	}
 	return 0, nil
 }
 
 // skipBatchIfRecovering returns whether the batched message can be skipped because the batch was already fully applied.
-// Stream and batch.mu locks should be held.
+// Stream lock should be held.
 func (mset *stream) skipBatchIfRecovering(batch *batchApply, buf []byte) (bool, error) {
 	_, _, op, mbuf, err := decodeBatchMsg(buf[1:])
 	if err != nil {
@@ -4475,7 +4450,7 @@ func (mset *stream) skipBatchIfRecovering(batch *batchApply, buf []byte) (bool, 
 			mset.accountLocked(false), mset.nameLocked(false), lseq+1-clfs, last)
 		// Check for any preAcks in case we are interest based.
 		mset.clearAllPreAcks(lseq + 1 - clfs)
-		batch.clearBatchStateLocked()
+		batch.clearBatchState()
 		return true, nil
 	}
 	return false, nil

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -10856,7 +10856,8 @@ func TestJetStreamClusterApplyDeleteRangeOpIdempotent(t *testing.T) {
 	replay := newCommittedEntry(1, []*Entry{
 		newEntry(EntryNormal, encodeDeleteRange(&DeleteRange{First: 100, Num: 401})),
 	})
-	_, err = sjs.applyStreamEntries(mset, replay, false)
+	batch := &batchApply{}
+	_, err = sjs.applyStreamEntries(mset, replay, false, batch)
 	require_NoError(t, err)
 	require_Equal(t, mset.lastSeq(), 1000)
 
@@ -10870,7 +10871,7 @@ func TestJetStreamClusterApplyDeleteRangeOpIdempotent(t *testing.T) {
 	dr := newCommittedEntry(2, []*Entry{
 		newEntry(EntryNormal, encodeDeleteRange(&DeleteRange{First: 1001, Num: 1000})),
 	})
-	_, err = sjs.applyStreamEntries(mset, dr, false)
+	_, err = sjs.applyStreamEntries(mset, dr, false, batch)
 	require_NoError(t, err)
 	require_Equal(t, mset.lastSeq(), 2000)
 	mset.store.FastState(&after)
@@ -10880,7 +10881,7 @@ func TestJetStreamClusterApplyDeleteRangeOpIdempotent(t *testing.T) {
 	dr = newCommittedEntry(3, []*Entry{
 		newEntry(EntryNormal, encodeDeleteRange(&DeleteRange{First: 1501, Num: 1000})),
 	})
-	_, err = sjs.applyStreamEntries(mset, dr, false)
+	_, err = sjs.applyStreamEntries(mset, dr, false, batch)
 	require_NoError(t, err)
 	require_Equal(t, mset.lastSeq(), 2500)
 	mset.store.FastState(&after)

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -8739,7 +8739,7 @@ func TestJetStreamClusterApplyEntriesRejectEmptyNormal(t *testing.T) {
 		t.Fatalf("expected errBadEntryOp from applyMetaEntries, got %v", err)
 	}
 	ce := &CommittedEntry{Entries: empty}
-	if _, err := js.applyStreamEntries(&stream{}, ce, false); err != errBadEntryOp {
+	if _, err := js.applyStreamEntries(&stream{}, ce, false, nil); err != errBadEntryOp {
 		t.Fatalf("expected errBadEntryOp from applyStreamEntries, got %v", err)
 	}
 	if err := js.applyConsumerEntries(&consumer{}, ce, false); err != errBadEntryOp {

--- a/server/stream.go
+++ b/server/stream.go
@@ -577,8 +577,7 @@ type stream struct {
 	// Otherwise, if clustered it will be part of the stream assignment.
 	offlineReason string
 
-	batches    *batching   // Inflight batches prior to committing them.
-	batchApply *batchApply // State to check for batch completeness before applying it.
+	batches *batching // Inflight batches prior to committing them.
 }
 
 // inflightSubjectRunningTotal stores a running total of inflight messages for a specific subject.
@@ -2681,7 +2680,6 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 	// If atomic publish is disabled, delete any in-progress batches.
 	if !cfg.AllowAtomicPublish {
 		mset.deleteAtomicBatches(false)
-		mset.deleteBatchApplyState()
 	}
 	// If fast batch publish is disabled, delete any in-progress batches.
 	if !cfg.AllowBatchPublish {
@@ -5079,21 +5077,6 @@ func (mset *stream) deleteAtomicBatches(shuttingDown bool) {
 		}
 		mset.batches.atomic = nil
 		mset.batches.mu.Unlock()
-	}
-}
-
-// Lock should be held.
-func (mset *stream) deleteBatchApplyState() {
-	if batch := mset.batchApply; batch != nil {
-		// Clear under batch.mu so a stale reference held by the stream monitor
-		// can't re-pool entries we already returned.
-		batch.mu.Lock()
-		for _, bce := range batch.entries {
-			bce.ReturnToPool()
-		}
-		batch.clearBatchStateLocked()
-		batch.mu.Unlock()
-		mset.batchApply = nil
 	}
 }
 
@@ -9327,9 +9310,6 @@ func (mset *stream) clearMonitorRunning() {
 	mset.mu.Lock()
 	defer mset.mu.Unlock()
 	mset.inMonitor = false
-
-	// We've stopped running the monitor goroutine, now also do additional cleanup.
-	mset.deleteBatchApplyState()
 }
 
 // Check if our monitor is running.


### PR DESCRIPTION
There was a data race on accessing `batch.id` without holding the lock. Instead moved `batchApply` out of `mset` so it requires no locks to be held.

```
=== RUN   TestJetStreamAtomicBatchPublishCleanup/Disable
==================
WARNING: DATA RACE
Write at 0x00c000c779a8 by goroutine 25560:
  github.com/nats-io/nats-server/v2/server.(*batchApply).clearBatchStateLocked()
      /home/runner/work/nats-server/nats-server/server/jetstream_batching.go:511 +0xd6

Previous read at 0x00c000c779a8 by goroutine 25707:
  github.com/nats-io/nats-server/v2/server.(*jetStream).applyStreamEntries()
      /home/runner/work/nats-server/nats-server/server/jetstream_cluster.go:4548 +0x3b55
```