### PR TITLE
NRG: Fence proposals by leadership term

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -502,7 +502,8 @@ type consumer struct {
 	// Clustered.
 	ca        *consumerAssignment
 	node      RaftNode
-	werr      error // If a write error was encountered while applying entries, and if so what error.
+	term      uint64 // Raft term, used to determine if we are still the leader for the current term (if applicable, 0 otherwise).
+	werr      error  // If a write error was encountered while applying entries, and if so what error.
 	infoSub   *subscription
 	lqsent    time.Time
 	prm       map[string]struct{}
@@ -1436,7 +1437,7 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 		o.resetStartingSeq(0, _EMPTY_, false)
 	}
 	if config.Direct || standalone {
-		o.setLeader(true)
+		o.setLeader(true, 0)
 	}
 
 	// This is always true in single server mode.
@@ -1603,18 +1604,112 @@ func (o *consumer) isLeader() bool {
 	return o.leader.Load()
 }
 
-func (o *consumer) setLeader(isLeader bool) error {
-	o.mu.RLock()
+func (o *consumer) setLeader(isLeader bool, term uint64) error {
+	o.mu.Lock()
 	mset, closed := o.mset, o.closed
-	movingToClustered := o.node != nil && o.pch == nil
-	movingToNonClustered := o.node == nil && o.pch != nil
 	wasLeader := o.leader.Swap(isLeader)
 
 	// For clustered new consumers, starting seq selection was deferred from
 	// addConsumerWithAssignment so the scan wouldn't block the meta apply
 	// goroutine, run it here on leader-elect instead.
 	needsSelect := isLeader && !wasLeader && o.dseq == 0 && (o.store == nil || !o.store.HasState())
-	o.mu.RUnlock()
+
+	// We can skip the teardown if we were leader before and are still the leader now.
+	// But only at term 1, since that means scale up from or down to an unreplicated config.
+	// R1 assets have no raft node and use the coerced term 1.
+	if term < 1 {
+		term = 1
+	}
+	skipTeardown := wasLeader && isLeader && term == 1
+	o.term = term
+
+	if skipTeardown {
+		movingToClustered := o.node != nil && o.pch == nil
+		movingToNonClustered := o.node == nil && o.pch != nil
+
+		// If we detect we are scaling up, make sure to create clustered routines and channels.
+		if movingToClustered {
+			// We are moving from R1 to clustered.
+			o.pch = make(chan struct{}, 1)
+			go o.loopAndForwardProposals(o.node, o.qch, o.pch, term)
+			if o.phead != nil {
+				select {
+				case o.pch <- struct{}{}:
+				default:
+				}
+			}
+		} else if movingToNonClustered {
+			// We are moving from clustered to non-clustered now.
+			// Set pch to nil so if we scale back up we will recreate the loopAndForward from above.
+			pch := o.pch
+			o.pch = nil
+			select {
+			case pch <- struct{}{}:
+			default:
+			}
+		}
+		o.mu.Unlock()
+		return nil
+	}
+
+	// Shutdown the go routines and the subscriptions.
+	if o.qch != nil {
+		close(o.qch)
+		o.qch = nil
+	}
+	// Stop any inactivity timers. Should only be running on leaders.
+	stopAndClearTimer(&o.dtmr)
+	// Stop any unpause timers. Should only be running on leaders.
+	stopAndClearTimer(&o.uptmr)
+	// Make sure to clear out any re-deliver queues
+	o.stopAndClearPtmr()
+	o.rdc = nil
+	o.rdq = nil
+	o.rdqi.Empty()
+	o.pending = nil
+	o.rsm = nil
+	o.resetPendingDeliveries()
+	// Reset num pending, these are only authoritative on the leader.
+	o.npc, o.npf = 0, 0
+	// ok if they are nil, we protect inside unsubscribe()
+	o.unsubscribe(o.ackSubOld)
+	o.unsubscribe(o.ackSub)
+	o.unsubscribe(o.reqSub)
+	o.unsubscribe(o.resetSub)
+	o.unsubscribe(o.fcSubOld)
+	o.unsubscribe(o.fcSub)
+	o.ackSubOld, o.ackSub, o.reqSub, o.resetSub, o.fcSubOld, o.fcSub = nil, nil, nil, nil, nil, nil
+	if o.infoSub != nil {
+		o.srv.sysUnsubscribe(o.infoSub)
+		o.infoSub = nil
+	}
+	// Reset waiting if we are in pull mode.
+	if o.isPullMode() {
+		o.waiting = newWaitQueue(o.cfg.MaxWaiting)
+		o.nextMsgReqs.drain()
+	} else if o.srv.gateway.enabled {
+		stopAndClearTimer(&o.gwdtmr)
+	}
+	o.unassignPinId()
+
+	// Make sure to drain queued up acks.
+	o.ackMsgs.drain()
+	// Reset amount of acks that need to be processed.
+	atomic.StoreInt64(&o.awl, 0)
+	// Also remove any pending replies since we should not be the one to respond at this point.
+	o.replies = nil
+
+	// Set pch to nil, we will recreate the loopAndForwardProposals for the new term.
+	if pch := o.pch; pch != nil {
+		o.pch = nil
+		select {
+		case pch <- struct{}{}:
+		default:
+		}
+	}
+	// Clear proposals, none are valid anymore.
+	o.phead, o.ptail = nil, nil
+	o.mu.Unlock()
 
 	// If we are here we have a change in leader status.
 	if isLeader {
@@ -1636,35 +1731,6 @@ func (o *consumer) setLeader(isLeader bool) error {
 				return err
 			}
 			o.mu.Unlock()
-		}
-
-		if wasLeader {
-			// If we detect we are scaling up, make sure to create clustered routines and channels.
-			if movingToClustered {
-				o.mu.Lock()
-				// We are moving from R1 to clustered.
-				o.pch = make(chan struct{}, 1)
-				go o.loopAndForwardProposals(o.qch)
-				if o.phead != nil {
-					select {
-					case o.pch <- struct{}{}:
-					default:
-					}
-				}
-				o.mu.Unlock()
-			} else if movingToNonClustered {
-				// We are moving from clustered to non-clustered now.
-				// Set pch to nil so if we scale back up we will recreate the loopAndForward from above.
-				o.mu.Lock()
-				pch := o.pch
-				o.pch = nil
-				select {
-				case pch <- struct{}{}:
-				default:
-				}
-				o.mu.Unlock()
-			}
-			return nil
 		}
 
 		mset.mu.RLock()
@@ -1771,8 +1837,10 @@ func (o *consumer) setLeader(isLeader bool) error {
 		o.qch = make(chan struct{})
 		qch := o.qch
 		node := o.node
+		var pch chan struct{}
 		if node != nil && o.pch == nil {
 			o.pch = make(chan struct{}, 1)
+			pch = o.pch
 		}
 		pullMode := o.isPullMode()
 		o.mu.Unlock()
@@ -1812,67 +1880,16 @@ func (o *consumer) setLeader(isLeader bool) error {
 		}
 
 		// If we are R>1 spin up our proposal loop.
-		if node != nil {
+		if node != nil && pch != nil {
 			// Determine if we can send pending requests info to the group.
 			// They must be on server versions >= 2.7.1
 			o.checkAndSetPendingRequestsOk()
 			o.checkPendingRequests()
 			go func() {
 				setGoRoutineLabels(labels)
-				o.loopAndForwardProposals(qch)
+				o.loopAndForwardProposals(node, qch, pch, term)
 			}()
 		}
-
-	} else {
-		// Shutdown the go routines and the subscriptions.
-		o.mu.Lock()
-		if o.qch != nil {
-			close(o.qch)
-			o.qch = nil
-		}
-		// Stop any inactivity timers. Should only be running on leaders.
-		stopAndClearTimer(&o.dtmr)
-		// Stop any unpause timers. Should only be running on leaders.
-		stopAndClearTimer(&o.uptmr)
-		// Make sure to clear out any re-deliver queues
-		o.stopAndClearPtmr()
-		o.rdc = nil
-		o.rdq = nil
-		o.rdqi.Empty()
-		o.pending = nil
-		o.rsm = nil
-		o.resetPendingDeliveries()
-		// Reset num pending, these are only authoritative on the leader.
-		o.npc, o.npf = 0, 0
-		// ok if they are nil, we protect inside unsubscribe()
-		o.unsubscribe(o.ackSubOld)
-		o.unsubscribe(o.ackSub)
-		o.unsubscribe(o.reqSub)
-		o.unsubscribe(o.resetSub)
-		o.unsubscribe(o.fcSubOld)
-		o.unsubscribe(o.fcSub)
-		o.ackSubOld, o.ackSub, o.reqSub, o.resetSub, o.fcSubOld, o.fcSub = nil, nil, nil, nil, nil, nil
-		if o.infoSub != nil {
-			o.srv.sysUnsubscribe(o.infoSub)
-			o.infoSub = nil
-		}
-		// Reset waiting if we are in pull mode.
-		if o.isPullMode() {
-			o.waiting = newWaitQueue(o.cfg.MaxWaiting)
-			o.nextMsgReqs.drain()
-		} else if o.srv.gateway.enabled {
-			stopAndClearTimer(&o.gwdtmr)
-		}
-		o.unassignPinId()
-		// If we were the leader make sure to drain queued up acks.
-		if wasLeader {
-			o.ackMsgs.drain()
-			// Reset amount of acks that need to be processed.
-			atomic.StoreInt64(&o.awl, 0)
-			// Also remove any pending replies since we should not be the one to respond at this point.
-			o.replies = nil
-		}
-		o.mu.Unlock()
 	}
 	return nil
 }
@@ -2897,25 +2914,14 @@ func (o *consumer) resetLocalStartingSeq(seq uint64) {
 	o.ldt, o.lat = time.Time{}, time.Time{}
 }
 
-func (o *consumer) loopAndForwardProposals(qch chan struct{}) {
-	// On exit make sure we nil out pch.
-	defer func() {
-		o.mu.Lock()
-		o.pch = nil
-		o.mu.Unlock()
-	}()
-
-	o.mu.RLock()
-	node, pch := o.node, o.pch
-	o.mu.RUnlock()
-
-	if node == nil || pch == nil {
+func (o *consumer) loopAndForwardProposals(node RaftNode, qch, pch chan struct{}, term uint64) {
+	if node == nil || qch == nil || pch == nil {
 		return
 	}
 
 	forwardProposals := func() error {
 		o.mu.Lock()
-		if o.node == nil || !o.node.Leader() {
+		if node == nil || !node.Leader() || o.term != term {
 			o.mu.Unlock()
 			return errors.New("no longer leader")
 		}
@@ -2929,14 +2935,14 @@ func (o *consumer) loopAndForwardProposals(qch chan struct{}) {
 			entries = append(entries, newEntry(EntryNormal, proposal.data))
 			sz += len(proposal.data)
 			if sz > maxBatch {
-				node.ProposeMulti(entries)
+				node.ProposeMulti(term, entries)
 				// We need to re-create `entries` because there is a reference
 				// to it in the node's pae map.
 				sz, entries = 0, nil
 			}
 		}
 		if len(entries) > 0 {
-			node.ProposeMulti(entries)
+			node.ProposeMulti(term, entries)
 		}
 		return nil
 	}

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2925,7 +2925,7 @@ func (s *Server) jsLeaderAccountPurgeRequest(sub *subscription, c *client, _ *Ac
 	for osa := range js.streamAssignmentsOrInflightSeq(accName) {
 		for oca := range js.consumerAssignmentsOrInflightSeq(accName, osa.Config.Name) {
 			ca := &consumerAssignment{Group: oca.Group, Stream: oca.Stream, Name: oca.Name, Config: oca.Config, Subject: subject, Client: oca.Client, Created: oca.Created}
-			if err = meta.Propose(encodeDeleteConsumerAssignment(ca)); err != nil {
+			if err = meta.Propose(cc.term, encodeDeleteConsumerAssignment(ca)); err != nil {
 				js.mu.Unlock()
 				resp.Error = NewJSStreamGeneralError(err)
 				s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -2935,7 +2935,7 @@ func (s *Server) jsLeaderAccountPurgeRequest(sub *subscription, c *client, _ *Ac
 			nc++
 		}
 		sa := &streamAssignment{Group: osa.Group, Config: osa.Config, Subject: subject, Client: osa.Client, Created: osa.Created}
-		if err = meta.Propose(encodeDeleteStreamAssignment(sa)); err != nil {
+		if err = meta.Propose(cc.term, encodeDeleteStreamAssignment(sa)); err != nil {
 			js.mu.Unlock()
 			resp.Error = NewJSStreamGeneralError(err)
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
@@ -5287,7 +5287,7 @@ func (s *Server) jsConsumerPauseRequest(sub *subscription, c *client, _ *Account
 		setStaticConsumerMetadata(nca.Config)
 
 		eca := encodeAddConsumerAssignment(nca)
-		if err = meta.Propose(eca); err != nil {
+		if err = meta.Propose(cc.term, eca); err != nil {
 			js.mu.Unlock()
 			return
 		}

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -1059,11 +1059,11 @@ func recalculateClusteredSeq(mset *stream, needStreamLock bool) (lseq uint64) {
 // mset.clMu lock must be held.
 func commitSingleMsg(
 	diff *batchStagedDiff, mset *stream, subject string, reply string, hdr []byte, msg []byte, name string,
-	jsa *jsAccount, mt *msgTrace, node RaftNode, replicas int, lseq uint64,
+	jsa *jsAccount, mt *msgTrace, node RaftNode, term uint64, replicas int, lseq uint64,
 ) error {
 	// Do proposal.
 	esm := encodeStreamMsgAllowCompress(subject, reply, hdr, msg, mset.clseq, time.Now().UnixNano(), false)
-	if err := node.Propose(esm); err != nil {
+	if err := node.Propose(term, esm); err != nil {
 		return err
 	}
 

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -3181,7 +3181,7 @@ func TestJetStreamAtomicBatchPublishRejectPartialBatchOnLeaderChange(t *testing.
 		entries = append(entries, newEntry(EntryNormal, esm))
 	}
 	n := mset.raftNode()
-	require_NoError(t, n.ProposeMulti(entries))
+	require_NoError(t, n.ProposeMulti(n.Term(), entries))
 
 	// Wait for all servers to have received and populated the partial batch.
 	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {

--- a/server/jetstream_benchmark_test.go
+++ b/server/jetstream_benchmark_test.go
@@ -1023,7 +1023,7 @@ func BenchmarkJetStreamMetaSnapshot(b *testing.B) {
 			cfg, _ := ml.checkStreamCfg(scfg, acc, false)
 			rg, _ := js.createGroupForStream(ci, &cfg)
 			sa := &streamAssignment{Group: rg, Sync: syncSubjForStream(), Config: &cfg, Client: ci, Created: time.Now().UTC()}
-			n.Propose(encodeAddStreamAssignment(sa))
+			n.Propose(n.Term(), encodeAddStreamAssignment(sa))
 
 			for j := 0; j < numConsumers; j++ {
 				ccfg := &ConsumerConfig{
@@ -1036,7 +1036,7 @@ func BenchmarkJetStreamMetaSnapshot(b *testing.B) {
 				setConsumerConfigDefaults(ccfg, &cfg, srvLim, selectedLimits, false)
 				rg = js.cluster.createGroupForConsumer(ccfg, sa)
 				ca := &consumerAssignment{Group: rg, Stream: cfg.Name, Name: ccfg.Durable, Config: ccfg, Client: ci, Created: time.Now().UTC()}
-				n.Propose(encodeAddConsumerAssignment(ca))
+				n.Propose(n.Term(), encodeAddConsumerAssignment(ca))
 			}
 		}
 		js.mu.Unlock()

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -60,6 +60,8 @@ type jetStreamCluster struct {
 	// Holds a map of a peer ID to the reply subject, to only respond after gaining
 	// quorum on the peer-remove action.
 	peerRemoveReply map[string]peerRemoveInfo
+	// Raft term, used to determine if we are still the leader for the current term.
+	term uint64
 	// Signals meta-leader should check the stream assignments.
 	streamsCheck bool
 	// Server.
@@ -1966,9 +1968,10 @@ func (js *jetStream) monitorCluster() {
 			}
 			aq.recycle(&ces)
 
-		case isLeader = <-lch:
+		case lc := <-lch:
+			isLeader = lc.isLeader
 			// Process the change.
-			js.processLeaderChange(isLeader)
+			js.processLeaderChange(isLeader, lc.term)
 			if isLeader {
 				s.sendInternalMsgLocked(serverStatsPingReqSubj, _EMPTY_, nil, nil)
 				// Install a snapshot as we become leader.
@@ -2551,12 +2554,12 @@ func (js *jetStream) processAddPeer(peer string) {
 			csa.Group.Peers = append(csa.Group.Peers, peer)
 			// Send our proposal for this csa. Also use same group definition for all the consumers as well.
 			consumers, _ := js.remapConsumerAssignments(accName, csa, false)
-			if err := cc.meta.Propose(encodeAddStreamAssignment(csa)); err != nil {
+			if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(csa)); err != nil {
 				return
 			}
 			cc.trackInflightStreamProposal(accName, csa, false)
 			for _, cca := range consumers {
-				if err := cc.meta.Propose(encodeAddConsumerAssignment(cca)); err != nil {
+				if err := cc.meta.Propose(cc.term, encodeAddConsumerAssignment(cca)); err != nil {
 					return
 				}
 				cc.trackInflightConsumerProposal(accName, csa.Config.Name, cca, false)
@@ -2643,19 +2646,19 @@ func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer strin
 
 	// Send our proposal for this csa. Also use same group definition for all the consumers as well.
 	consumers, deleted := js.remapConsumerAssignments(accName, csa, true)
-	if err := cc.meta.Propose(encodeAddStreamAssignment(csa)); err != nil {
+	if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(csa)); err != nil {
 		return false
 	}
 	cc.trackInflightStreamProposal(accName, csa, false)
 	for _, cca := range consumers {
-		if err := cc.meta.Propose(encodeAddConsumerAssignment(cca)); err != nil {
+		if err := cc.meta.Propose(cc.term, encodeAddConsumerAssignment(cca)); err != nil {
 			return false
 		}
 		cc.trackInflightConsumerProposal(accName, csa.Config.Name, cca, false)
 	}
 	// These are ephemerals that had all of their peers removed.
 	for _, ca := range deleted {
-		if err := cc.meta.Propose(encodeDeleteConsumerAssignment(ca)); err != nil {
+		if err := cc.meta.Propose(cc.term, encodeDeleteConsumerAssignment(ca)); err != nil {
 			return false
 		}
 		cc.trackInflightConsumerProposal(accName, csa.Config.Name, ca, true)
@@ -3546,9 +3549,10 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 				doSnapshot(false)
 			}
 
-		case isLeader = <-lch:
+		case lc := <-lch:
+			isLeader = lc.isLeader
 			// Process our leader change.
-			js.processStreamLeaderChange(mset, isLeader)
+			js.processStreamLeaderChange(mset, isLeader, lc.term)
 
 			if isLeader {
 				if mset != nil && n != nil && sendSnapshot && !isRecovering {
@@ -3723,10 +3727,12 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 				return
 			}
 			// Trigger the stream followers to catchup.
+			var term uint64
 			if n = mset.raftNode(); n != nil {
 				n.SendSnapshot(mset.stateSnapshot())
+				term = n.Term()
 			}
-			js.processStreamLeaderChange(mset, isLeader)
+			js.processStreamLeaderChange(mset, isLeader, term)
 
 			// Check to see if we have restored consumers here.
 			// These are not currently assigned so we will need to do so here.
@@ -4674,7 +4680,7 @@ func (s *Server) replicas(node RaftNode) []*PeerInfo {
 }
 
 // Process a leader change for the clustered stream.
-func (js *jetStream) processStreamLeaderChange(mset *stream, isLeader bool) {
+func (js *jetStream) processStreamLeaderChange(mset *stream, isLeader bool, term uint64) {
 	if mset == nil {
 		return
 	}
@@ -4745,7 +4751,7 @@ func (js *jetStream) processStreamLeaderChange(mset *stream, isLeader bool) {
 	}
 
 	// Tell stream to switch leader status.
-	mset.setLeader(isLeader)
+	mset.setLeader(isLeader, term)
 
 	if !isLeader || hasResponded {
 		return
@@ -5329,7 +5335,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 
 	// If the stream is scaled down, there is a chance we weren't already the leader.
 	if isLeader && numReplicas == 1 && oldNumReplicas > 1 {
-		js.processStreamLeaderChange(mset, true)
+		js.processStreamLeaderChange(mset, true, 0)
 	}
 
 	// Check for missing syncSubject bug.
@@ -5590,7 +5596,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 						s.sendInternalMsgLocked(streamAssignmentSubj, _EMPTY_, nil, b)
 						return
 					}
-					js.processStreamLeaderChange(mset, true)
+					js.processStreamLeaderChange(mset, true, 0)
 
 					// Check to see if we have restored consumers here.
 					// These are not currently assigned so we will need to do so here.
@@ -5649,7 +5655,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 				}
 			})
 		} else {
-			js.processStreamLeaderChange(mset, true)
+			js.processStreamLeaderChange(mset, true, 0)
 		}
 	}
 }
@@ -6246,7 +6252,7 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 						func() {
 							defer s.grWG.Done()
 							defer o.clearMonitorRunning()
-							err = o.setLeader(true)
+							err = o.setLeader(true, 0)
 							var resp = JSApiConsumerCreateResponse{ApiResponse: ApiResponse{Type: JSApiConsumerCreateResponseType}}
 							if err != nil {
 								resp.Error = NewJSConsumerCreateError(err, Unless(err))
@@ -6286,7 +6292,7 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 					func() {
 						defer s.grWG.Done()
 						defer o.clearMonitorRunning()
-						js.processConsumerLeaderChangeWithAssignment(o, cca, true)
+						js.processConsumerLeaderChangeWithAssignment(o, cca, true, 0)
 					},
 					pprofLabels{
 						"type":     "consumer",
@@ -6764,13 +6770,14 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 			}
 			aq.recycle(&ces)
 
-		case isLeader = <-lch:
+		case lc := <-lch:
+			isLeader = lc.isLeader
 			if recovering && !isLeader {
 				js.setConsumerAssignmentRecovering(ca)
 			}
 
 			// Process the change.
-			if err := js.processConsumerLeaderChange(o, isLeader); err == nil {
+			if err := js.processConsumerLeaderChange(o, isLeader, lc.term); err == nil {
 				// Check our state if we are under an interest based stream.
 				if mset := o.getStream(); mset != nil {
 					var ss StreamState
@@ -7213,11 +7220,11 @@ func decodeResetUpdate(buf []byte) (sseq uint64, reply string, err error) {
 	return binary.LittleEndian.Uint64(buf[:8]), string(buf[8:]), nil
 }
 
-func (js *jetStream) processConsumerLeaderChange(o *consumer, isLeader bool) error {
-	return js.processConsumerLeaderChangeWithAssignment(o, nil, isLeader)
+func (js *jetStream) processConsumerLeaderChange(o *consumer, isLeader bool, term uint64) error {
+	return js.processConsumerLeaderChangeWithAssignment(o, nil, isLeader, term)
 }
 
-func (js *jetStream) processConsumerLeaderChangeWithAssignment(o *consumer, ca *consumerAssignment, isLeader bool) error {
+func (js *jetStream) processConsumerLeaderChangeWithAssignment(o *consumer, ca *consumerAssignment, isLeader bool, term uint64) error {
 	stepDownIfLeader := func() error {
 		if node := o.raftNode(); node != nil && isLeader {
 			node.StepDown()
@@ -7265,7 +7272,7 @@ func (js *jetStream) processConsumerLeaderChangeWithAssignment(o *consumer, ca *
 	}
 
 	// Tell consumer to switch leader status.
-	if lerr := o.setLeader(isLeader); lerr != nil && err == nil {
+	if lerr := o.setLeader(isLeader, term); lerr != nil && err == nil {
 		err = lerr
 	}
 
@@ -7448,14 +7455,14 @@ func (js *jetStream) processStreamAssignmentResults(sub *subscription, c *client
 						// Pick a new preferred leader.
 						rg.setPreferred(s)
 						// Get rid of previous attempt.
-						if err := cc.meta.Propose(encodeDeleteStreamAssignment(sa)); err != nil {
+						if err := cc.meta.Propose(cc.term, encodeDeleteStreamAssignment(sa)); err != nil {
 							return
 						}
 						cc.trackInflightStreamProposal(result.Account, sa, true)
 						// Propose new.
 						nsa := sa.copyGroup()
 						nsa.Group, nsa.err = rg, nil
-						if err := cc.meta.Propose(encodeAddStreamAssignment(nsa)); err != nil {
+						if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(nsa)); err != nil {
 							return
 						}
 						cc.trackInflightStreamProposal(result.Account, nsa, false)
@@ -7490,7 +7497,7 @@ func (js *jetStream) processStreamAssignmentResults(sub *subscription, c *client
 			}
 			s.Warnf("Stream assignment for '%s > %s' rejected by assigned member: %v", sa.Client.serviceAccount(), sa.Config.Name, apiErr)
 			sa.err = NewJSClusterNotAssignedError()
-			if err := cc.meta.Propose(encodeDeleteStreamAssignment(sa)); err != nil {
+			if err := cc.meta.Propose(cc.term, encodeDeleteStreamAssignment(sa)); err != nil {
 				return
 			}
 			cc.trackInflightStreamProposal(result.Account, sa, true)
@@ -7628,7 +7635,7 @@ func (s *Server) sendDomainLeaderElectAdvisory() {
 	s.publishAdvisory(nil, JSAdvisoryDomainLeaderElected, adv)
 }
 
-func (js *jetStream) processLeaderChange(isLeader bool) {
+func (js *jetStream) processLeaderChange(isLeader bool, term uint64) {
 	if js == nil {
 		return
 	}
@@ -7636,8 +7643,6 @@ func (js *jetStream) processLeaderChange(isLeader bool) {
 	if s == nil {
 		return
 	}
-	// Update our server atomic.
-	s.isMetaLeader.Store(isLeader)
 
 	if isLeader {
 		s.Noticef("Self is new JetStream cluster metadata leader")
@@ -7660,6 +7665,10 @@ func (js *jetStream) processLeaderChange(isLeader bool) {
 
 	js.mu.Lock()
 	defer js.mu.Unlock()
+
+	// Update our server atomic, while holding the lock to not race with API requests.
+	s.isMetaLeader.Store(isLeader)
+	js.cluster.term = term
 
 	// Clear replies for peer-removes.
 	js.cluster.peerRemoveReply = nil
@@ -7694,7 +7703,7 @@ func (js *jetStream) processLeaderChange(isLeader bool) {
 				s.Warnf("Stream assignment corrupt for stream '%s > %s'", acc, sa.Config.Name)
 				nsa := &streamAssignment{Group: sa.Group, Config: sa.Config, Subject: sa.Subject, Reply: sa.Reply, Client: sa.Client, Created: sa.Created}
 				nsa.Sync = syncSubjForStream()
-				if err := cc.meta.Propose(encodeUpdateStreamAssignment(nsa)); err != nil {
+				if err := cc.meta.Propose(cc.term, encodeUpdateStreamAssignment(nsa)); err != nil {
 					return
 				}
 				cc.trackInflightStreamProposal(acc, nsa, false)
@@ -8441,7 +8450,7 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 	}
 	// Sync subject for post snapshot sync.
 	sa := &streamAssignment{Group: rg, Sync: syncSubject, Config: cfg, Subject: subject, Reply: reply, Client: ci, Created: time.Now().UTC()}
-	if err := cc.meta.Propose(encodeAddStreamAssignment(sa)); err != nil {
+	if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(sa)); err != nil {
 		return
 	}
 	// On success, add this as an inflight proposal so we can apply limits
@@ -8770,7 +8779,7 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 	// If this is a pure retention change to a non-limits policy, perform the consumer scaling first.
 	if isRetentionChange && !isReplicaChange && !isMoveRequest && sa.Config.Retention != LimitsPolicy {
 		for _, ca := range consumers {
-			if err := meta.Propose(encodeAddConsumerAssignment(ca)); err != nil {
+			if err := meta.Propose(cc.term, encodeAddConsumerAssignment(ca)); err != nil {
 				return
 			}
 			cc.trackInflightConsumerProposal(acc.Name, sa.Config.Name, ca, false)
@@ -8778,14 +8787,14 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		consumers = nil
 	}
 
-	if err := meta.Propose(encodeUpdateStreamAssignment(sa)); err != nil {
+	if err := meta.Propose(cc.term, encodeUpdateStreamAssignment(sa)); err != nil {
 		return
 	}
 	cc.trackInflightStreamProposal(acc.Name, sa, false)
 
 	// Process any staged consumers.
 	for _, ca := range consumers {
-		if err := meta.Propose(encodeAddConsumerAssignment(ca)); err != nil {
+		if err := meta.Propose(cc.term, encodeAddConsumerAssignment(ca)); err != nil {
 			return
 		}
 		cc.trackInflightConsumerProposal(acc.Name, sa.Config.Name, ca, false)
@@ -8814,7 +8823,7 @@ func (s *Server) jsClusteredStreamDeleteRequest(ci *ClientInfo, acc *Account, st
 	}
 
 	sa := &streamAssignment{Group: osa.Group, Config: osa.Config, Subject: subject, Reply: reply, Client: ci, Created: osa.Created}
-	if err := cc.meta.Propose(encodeDeleteStreamAssignment(sa)); err != nil {
+	if err := cc.meta.Propose(cc.term, encodeDeleteStreamAssignment(sa)); err != nil {
 		return
 	}
 	cc.trackInflightStreamProposal(acc.Name, sa, true)
@@ -8830,7 +8839,7 @@ func (s *Server) jsClusteredStreamPurgeRequest(
 	preq *JSApiStreamPurgeRequest,
 ) {
 	js, cc := s.getJetStreamCluster()
-	if js == nil || cc == nil {
+	if js == nil || cc == nil || mset == nil {
 		return
 	}
 
@@ -8845,16 +8854,15 @@ func (s *Server) jsClusteredStreamPurgeRequest(
 	}
 
 	if n := sa.Group.node; n != nil {
-		sp := &streamPurge{Stream: stream, LastSeq: mset.state().LastSeq, Subject: subject, Reply: reply, Client: ci, Request: preq}
-		n.Propose(encodeStreamPurge(sp))
+		sp := encodeStreamPurge(&streamPurge{Stream: stream, LastSeq: mset.state().LastSeq, Subject: subject, Reply: reply, Client: ci, Request: preq})
 		js.mu.Unlock()
+		mset.mu.RLock()
+		term := mset.term
+		mset.mu.RUnlock()
+		n.Propose(term, sp)
 		return
 	}
 	js.mu.Unlock()
-
-	if mset == nil {
-		return
-	}
 
 	var resp = JSApiStreamPurgeResponse{ApiResponse: ApiResponse{Type: JSApiStreamPurgeResponseType}}
 	purged, err := mset.purge(preq)
@@ -8919,7 +8927,7 @@ func (s *Server) jsClusteredStreamRestoreRequest(
 	sa := &streamAssignment{Group: rg, Sync: syncSubjForStream(), Config: &cfg, Subject: subject, Reply: reply, Client: ci, Created: time.Now().UTC()}
 	// Now add in our restore state and pre-select a peer to handle the actual receipt of the snapshot.
 	sa.Restore = &req.State
-	if err := cc.meta.Propose(encodeAddStreamAssignment(sa)); err != nil {
+	if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(sa)); err != nil {
 		return
 	}
 	cc.trackInflightStreamProposal(ci.serviceAccount(), sa, false)
@@ -9344,7 +9352,7 @@ func (s *Server) jsClusteredConsumerDeleteRequest(ci *ClientInfo, acc *Account, 
 		return
 	}
 	ca := &consumerAssignment{Group: oca.Group, Stream: stream, Name: consumer, Config: oca.Config, Subject: subject, Reply: reply, Client: ci, Created: oca.Created}
-	if err := cc.meta.Propose(encodeDeleteConsumerAssignment(ca)); err != nil {
+	if err := cc.meta.Propose(cc.term, encodeDeleteConsumerAssignment(ca)); err != nil {
 		return
 	}
 	cc.trackInflightConsumerProposal(acc.Name, stream, ca, true)
@@ -9379,9 +9387,12 @@ func (s *Server) jsClusteredMsgDeleteRequest(ci *ClientInfo, acc *Account, mset 
 
 	// Check for single replica items.
 	if n := sa.Group.node; n != nil {
-		md := streamMsgDelete{Seq: req.Seq, NoErase: req.NoErase, Stream: stream, Subject: subject, Reply: reply, Client: ci}
-		n.Propose(encodeMsgDelete(&md))
+		md := encodeMsgDelete(&streamMsgDelete{Seq: req.Seq, NoErase: req.NoErase, Stream: stream, Subject: subject, Reply: reply, Client: ci})
 		js.mu.Unlock()
+		mset.mu.RLock()
+		term := mset.term
+		mset.mu.RUnlock()
+		n.Propose(term, md)
 		return
 	}
 	js.mu.Unlock()
@@ -9887,7 +9898,7 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 	}
 
 	// Do formal proposal.
-	if err := cc.meta.Propose(encodeAddConsumerAssignment(ca)); err != nil {
+	if err := cc.meta.Propose(cc.term, encodeAddConsumerAssignment(ca)); err != nil {
 		return
 	}
 	cc.trackInflightConsumerProposal(acc.Name, stream, ca, false)
@@ -10239,7 +10250,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 	canRespond := !mset.cfg.NoAck && len(reply) > 0
 	name, stype := mset.cfg.Name, mset.cfg.Storage
 	discard, discardNewPer, maxMsgs, maxMsgsPer, maxBytes := mset.cfg.Discard, mset.cfg.DiscardNewPer, mset.cfg.MaxMsgs, mset.cfg.MaxMsgsPer, mset.cfg.MaxBytes
-	s, js, jsa, st, r, tierName, outq, node := mset.srv, mset.js, mset.jsa, mset.cfg.Storage, mset.cfg.Replicas, mset.tier, mset.outq, mset.node
+	s, js, jsa, st, r, tierName, outq, node, term := mset.srv, mset.js, mset.jsa, mset.cfg.Storage, mset.cfg.Replicas, mset.tier, mset.outq, mset.node, mset.term
 	maxMsgSize, lseq := int(mset.cfg.MaxMsgSize), mset.lseq
 	isLeader, isSealed, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules := mset.isLeader(), mset.cfg.Sealed, mset.cfg.AllowRollup, mset.cfg.DenyPurge, mset.cfg.AllowMsgTTL, mset.cfg.AllowMsgCounter, mset.cfg.AllowMsgSchedules
 
@@ -10364,7 +10375,7 @@ func (mset *stream) processClusteredInboundMsg(subject, reply string, hdr, msg [
 		return err
 	}
 
-	err = commitSingleMsg(diff, mset, subject, reply, hdr, msg, name, jsa, mt, node, r, lseq)
+	err = commitSingleMsg(diff, mset, subject, reply, hdr, msg, name, jsa, mt, node, term, r, lseq)
 	mset.clMu.Unlock()
 	return err
 }
@@ -10764,7 +10775,7 @@ RETRY:
 	sreq = nil
 
 	// Run our own select loop here.
-	for qch, lch := n.QuitC(), n.LeadChangeC(); ; {
+	for qch := n.QuitC(); ; {
 		select {
 		case <-msgsQ.ch:
 			notActive.Reset(activityInterval)
@@ -10860,16 +10871,16 @@ RETRY:
 				msgsQ.recycle(&mrecs)
 			}
 			s.Warnf("Catchup for stream '%s > %s' stalled", mset.account(), mset.name())
+			// Sanity check that we've not become leader. Shouldn't be possible
+			// since we haven't applied the snapshot yet.
+			if n.State() == Leader {
+				n.StepDown()
+			}
 			goto RETRY
 		case <-s.quitCh:
 			return ErrServerNotRunning
 		case <-qch:
 			return errCatchupStreamStopped
-		case isLeader := <-lch:
-			if isLeader {
-				n.StepDown()
-				goto RETRY
-			}
 		}
 	}
 }

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -4246,6 +4246,324 @@ func TestJetStreamClusterConsumerScaleUp(t *testing.T) {
 	c.waitOnConsumerLeader("$G", "TEST", "DUR")
 }
 
+func TestJetStreamClusterStreamScaleFromAndToR1SkipsTeardown(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{Name: "ORIGIN", Subjects: []string{"foo"}, Replicas: 1})
+	require_NoError(t, err)
+
+	cfg := &nats.StreamConfig{
+		Name:     "S",
+		Sources:  []*nats.StreamSource{{Name: "ORIGIN"}},
+		Replicas: 1,
+	}
+	_, err = js.AddStream(cfg)
+	require_NoError(t, err)
+
+	for range 10 {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+
+	sl := c.streamLeader(globalAccountName, "S")
+	mset, err := sl.GlobalAccount().lookupStream("S")
+	require_NoError(t, err)
+
+	// Wait for the source consumer to be running and capture its subscription as
+	// a canary. A setLeader teardown stops the source consumers and would have
+	// to recreate this subscription.
+	var canary *subscription
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		mset.mu.RLock()
+		defer mset.mu.RUnlock()
+		for _, si := range mset.sources {
+			if si.sub != nil {
+				canary = si.sub
+				return nil
+			}
+		}
+		return fmt.Errorf("source consumer not active yet")
+	})
+
+	// The R1 leader stores the coerced term 1.
+	mset.mu.RLock()
+	term := mset.term
+	mset.mu.RUnlock()
+	require_Equal(t, term, 1)
+
+	// Scale up. The same server is preferred to win the election, at term 1,
+	// which means setLeader skips the teardown.
+	cfg.Replicas = 3
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+	c.waitOnStreamLeader(globalAccountName, "S")
+	require_True(t, c.streamLeader(globalAccountName, "S") == sl)
+
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		mset.mu.RLock()
+		defer mset.mu.RUnlock()
+		if mset.node == nil {
+			return fmt.Errorf("no raft node yet")
+		}
+		if mset.term != 1 {
+			return fmt.Errorf("expected mset.term 1, got %d", mset.term)
+		}
+		// Although the teardown was skipped, the leader must have subscribed to
+		// respond to sync requests now that it's clustered.
+		if mset.syncSub == nil {
+			return fmt.Errorf("expected sync subscription")
+		}
+		return nil
+	})
+
+	// The source consumer must not have been torn down and recreated.
+	mset.mu.RLock()
+	var sub *subscription
+	for _, si := range mset.sources {
+		sub = si.sub
+	}
+	mset.mu.RUnlock()
+	require_True(t, sub == canary)
+
+	// Messages flowing in through the source must replicate to the new followers.
+	for range 10 {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		state, err := checkStateAndErr(t, c, globalAccountName, "S")
+		if err != nil {
+			return err
+		}
+		if state.Msgs != 20 {
+			return fmt.Errorf("expected 20 messages, got %d", state.Msgs)
+		}
+		return nil
+	})
+
+	// Move stream leadership away so the term moves past 1.
+	_, err = nc.Request(fmt.Sprintf(JSApiStreamLeaderStepDownT, "S"), nil, time.Second)
+	require_NoError(t, err)
+	c.waitOnStreamLeader(globalAccountName, "S")
+
+	// Re-capture the canary on the new leader, which was elected at term > 1.
+	nl := c.streamLeader(globalAccountName, "S")
+	mset, err = nl.globalAccount().lookupStream("S")
+	require_NoError(t, err)
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		mset.mu.RLock()
+		defer mset.mu.RUnlock()
+		if mset.term <= 1 {
+			return fmt.Errorf("expected mset.term > 1, got %d", mset.term)
+		}
+		canary = nil
+		for _, si := range mset.sources {
+			if si.sub != nil {
+				canary = si.sub
+			}
+		}
+		if canary == nil {
+			return fmt.Errorf("source consumer not active yet")
+		}
+		return nil
+	})
+
+	// Scale back down. The current leader is always retained, and although it was
+	// elected at term > 1 it remains the continuing leader, so setLeader skips the
+	// teardown and stores the coerced term 1.
+	cfg.Replicas = 1
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+	c.waitOnStreamLeader(globalAccountName, "S")
+	require_True(t, c.streamLeader(globalAccountName, "S") == nl)
+
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		mset.mu.RLock()
+		defer mset.mu.RUnlock()
+		if mset.node != nil {
+			return fmt.Errorf("raft node not removed yet")
+		}
+		if mset.term != 1 {
+			return fmt.Errorf("expected mset.term 1, got %d", mset.term)
+		}
+		return nil
+	})
+
+	// The source consumer must still not have been torn down and recreated.
+	mset.mu.RLock()
+	sub = nil
+	for _, si := range mset.sources {
+		sub = si.sub
+	}
+	mset.mu.RUnlock()
+	require_True(t, sub == canary)
+
+	// Messages flowing in through the source must still be stored after the scale-down.
+	for range 10 {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		state, err := checkStateAndErr(t, c, globalAccountName, "S")
+		if err != nil {
+			return err
+		}
+		if state.Msgs != 30 {
+			return fmt.Errorf("expected 30 messages, got %d", state.Msgs)
+		}
+		return nil
+	})
+}
+
+func TestJetStreamClusterConsumerScaleFromAndToR1SkipsTeardown(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Replicas: 3})
+	require_NoError(t, err)
+
+	cfg := &nats.ConsumerConfig{Durable: "DUR", AckPolicy: nats.AckExplicitPolicy, Replicas: 1}
+	_, err = js.AddConsumer("TEST", cfg)
+	require_NoError(t, err)
+
+	for range 20 {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+
+	sub, err := js.PullSubscribe("foo", "DUR")
+	require_NoError(t, err)
+	msgs, err := sub.Fetch(10)
+	require_NoError(t, err)
+	require_Len(t, len(msgs), 10)
+	for _, m := range msgs {
+		require_NoError(t, m.AckSync())
+	}
+
+	cl := c.consumerLeader(globalAccountName, "TEST", "DUR")
+	mset, err := cl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	o := mset.lookupConsumer("DUR")
+	require_NotNil(t, o)
+
+	// Capture the ack subscription as a canary. A setLeader teardown would have
+	// to unsubscribe and recreate it. The R1 leader stores the coerced term 1.
+	o.mu.RLock()
+	canary, term := o.ackSub, o.term
+	o.mu.RUnlock()
+	require_NotNil(t, canary)
+	require_Equal(t, term, 1)
+
+	// Scale up. The same server is preferred to win the election, at term 1,
+	// which means setLeader skips the teardown.
+	cfg.Replicas = 3
+	_, err = js.UpdateConsumer("TEST", cfg)
+	require_NoError(t, err)
+
+	// The scale-up must have spun up the proposal loop, without tearing down
+	// the running consumer.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		o.mu.RLock()
+		defer o.mu.RUnlock()
+		if o.node == nil {
+			return fmt.Errorf("no raft node yet")
+		}
+		if o.term != 1 {
+			return fmt.Errorf("expected o.term 1, got %d", o.term)
+		}
+		if o.pch == nil {
+			return fmt.Errorf("no proposal channel yet")
+		}
+		return nil
+	})
+	o.mu.RLock()
+	same := o.ackSub == canary
+	o.mu.RUnlock()
+	require_True(t, same)
+
+	// Acks after the scale-up must be replicated to the new followers.
+	msgs, err = sub.Fetch(10)
+	require_NoError(t, err)
+	require_Len(t, len(msgs), 10)
+	for _, m := range msgs {
+		require_NoError(t, m.AckSync())
+	}
+
+	// Move consumer leadership away so the term moves past 1.
+	_, err = nc.Request(fmt.Sprintf(JSApiConsumerLeaderStepDownT, "TEST", "DUR"), nil, 5*time.Second)
+	require_NoError(t, err)
+	c.waitOnConsumerLeader(globalAccountName, "TEST", "DUR")
+
+	// The new leader must agree on the state that was proposed since the scale-up.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		ci, err := js.ConsumerInfo("TEST", "DUR")
+		if err != nil {
+			return err
+		}
+		if ci.AckFloor.Consumer != 20 {
+			return fmt.Errorf("ack floor %d, expected 20", ci.AckFloor.Consumer)
+		}
+		if ci.NumPending != 0 {
+			return fmt.Errorf("num pending %d, expected 0", ci.NumPending)
+		}
+		return nil
+	})
+
+	// Re-capture the canary on the new leader, which was elected at term > 1.
+	cl = c.consumerLeader(globalAccountName, "TEST", "DUR")
+	mset, err = cl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	o = mset.lookupConsumer("DUR")
+	require_NotNil(t, o)
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		o.mu.RLock()
+		defer o.mu.RUnlock()
+		if o.term <= 1 {
+			return fmt.Errorf("expected o.term > 1, got %d", o.term)
+		}
+		if o.ackSub == nil {
+			return fmt.Errorf("no ack subscription yet")
+		}
+		return nil
+	})
+	o.mu.RLock()
+	canary = o.ackSub
+	o.mu.RUnlock()
+
+	// Scale back down to R1. The current leader is always retained, and although
+	// it was elected at term > 1 it remains the continuing leader, so setLeader
+	// skips the teardown, clears the proposal channel/loop, and stores the
+	// coerced term 1.
+	cfg.Replicas = 1
+	_, err = js.UpdateConsumer("TEST", cfg)
+	require_NoError(t, err)
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		o.mu.RLock()
+		defer o.mu.RUnlock()
+		if o.node != nil {
+			return fmt.Errorf("raft node not removed yet")
+		}
+		if o.pch != nil {
+			return fmt.Errorf("proposal channel not cleared yet")
+		}
+		if o.term != 1 {
+			return fmt.Errorf("expected o.term 1, got %d", o.term)
+		}
+		return nil
+	})
+	o.mu.RLock()
+	same = o.ackSub == canary
+	o.mu.RUnlock()
+	require_True(t, same)
+}
+
 func TestJetStreamClusterPeerOffline(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R5S", 5)
 	defer c.shutdown()
@@ -8775,7 +9093,7 @@ func TestJetStreamClusterPeerRemoveStreamConsumerDesync(t *testing.T) {
 	mset.clseq++
 	mset.mu.Unlock()
 	// Propose both remove peer and a normal entry within the same append entry.
-	err = rn.ProposeMulti([]*Entry{
+	err = rn.ProposeMulti(rn.Term(), []*Entry{
 		newEntry(EntryRemovePeer, []byte(peer)),
 		newEntry(EntryNormal, esm),
 	})
@@ -8812,7 +9130,7 @@ func TestJetStreamClusterPeerRemoveStreamConsumerDesync(t *testing.T) {
 	peer = rs.Name()
 	rn = o.raftNode()
 	// Propose both remove peer and a normal entry within the same append entry.
-	err = rn.ProposeMulti([]*Entry{
+	err = rn.ProposeMulti(rn.Term(), []*Entry{
 		newEntry(EntryRemovePeer, []byte(peer)),
 		newEntry(EntryNormal, updateDeliveredBuffer()),
 	})
@@ -9133,7 +9451,7 @@ func TestJetStreamClusterUpgradeStreamVersioning(t *testing.T) {
 	rg, perr := sjs.createGroupForStream(ci, &cfg)
 	require_True(t, perr == nil)
 	sa := &streamAssignment{Group: rg, Sync: syncSubjForStream(), Config: &cfg, Client: ci, Created: time.Now().UTC()}
-	require_NoError(t, rn.Propose(encodeAddStreamAssignment(sa)))
+	require_NoError(t, rn.Propose(rn.Term(), encodeAddStreamAssignment(sa)))
 
 	// Wait for the stream assignment to have gone through.
 	checkFor(t, 2*time.Second, 500*time.Millisecond, func() error {
@@ -9227,7 +9545,7 @@ func TestJetStreamClusterUpgradeConsumerVersioning(t *testing.T) {
 	ci := &ClientInfo{Cluster: "R3S", Account: globalAccountName}
 	rg := sjs.cluster.createGroupForConsumer(cfg, sa)
 	ca := &consumerAssignment{Group: rg, Stream: "TEST", Name: "CONSUMER", Config: cfg, Client: ci, Created: time.Now().UTC()}
-	require_NoError(t, rn.Propose(encodeAddConsumerAssignment(ca)))
+	require_NoError(t, rn.Propose(rn.Term(), encodeAddConsumerAssignment(ca)))
 
 	// Wait for the consumer assignment to have gone through.
 	checkFor(t, 2*time.Second, 500*time.Millisecond, func() error {
@@ -10139,7 +10457,7 @@ func TestJetStreamClusterAsyncFlushFileStoreFlushOnSnapshot(t *testing.T) {
 	// Make the upper layer snapshot by sending leader change signal.
 	// It doesn't matter that we're already leader, it still gets handled.
 	// Previously this used the mqch, but that now only snapshots on shutdown.
-	n.leadc <- true
+	n.leadc <- leadChange{isLeader: true, term: n.Term()}
 
 	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
 		n.Lock()
@@ -11056,7 +11374,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterAssetCreateOrUpdate(t *tes
 		Created: time.Now().UTC(),
 		Client:  ci,
 	}
-	err := cc.meta.Propose(encodeAddStreamAssignment(sa))
+	err := cc.meta.Propose(cc.meta.Term(), encodeAddStreamAssignment(sa))
 	sjs.mu.Unlock()
 	require_NoError(t, err)
 	c.waitOnAllCurrent()
@@ -11112,7 +11430,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterAssetCreateOrUpdate(t *tes
 	// Update a stream that's unsupported.
 	sjs.mu.Lock()
 	scfg.Metadata = map[string]string{"_nats.req.level": strconv.Itoa(math.MaxInt)}
-	err = cc.meta.Propose(encodeUpdateStreamAssignment(sa))
+	err = cc.meta.Propose(cc.meta.Term(), encodeUpdateStreamAssignment(sa))
 	sjs.mu.Unlock()
 	require_NoError(t, err)
 	c.waitOnAllCurrent()
@@ -11161,7 +11479,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterAssetCreateOrUpdate(t *tes
 		Created: time.Now().UTC(),
 		Client:  ci,
 	}
-	err = cc.meta.Propose(encodeAddConsumerAssignment(ca))
+	err = cc.meta.Propose(cc.meta.Term(), encodeAddConsumerAssignment(ca))
 	sjs.mu.Unlock()
 	require_NoError(t, err)
 	c.waitOnAllCurrent()
@@ -11233,7 +11551,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterAssetCreateOrUpdate(t *tes
 	// Update a consumer (with compressed data) that's unsupported.
 	ccfg.Metadata = map[string]string{"_nats.req.level": strconv.Itoa(math.MaxInt)}
 	sjs.mu.Lock()
-	err = cc.meta.Propose(encodeAddConsumerAssignmentCompressed(ca))
+	err = cc.meta.Propose(cc.meta.Term(), encodeAddConsumerAssignmentCompressed(ca))
 	sjs.mu.Unlock()
 	require_NoError(t, err)
 	c.waitOnAllCurrent()
@@ -11361,7 +11679,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterDowngrade(t *testing.T) {
 		Created: time.Now().UTC(),
 		Client:  ci,
 	}
-	err := cc.meta.Propose(encodeAddStreamAssignment(sa))
+	err := cc.meta.Propose(cc.meta.Term(), encodeAddStreamAssignment(sa))
 	sjs.mu.Unlock()
 	require_NoError(t, err)
 	c.waitOnStreamLeader(globalAccountName, "DowngradeStreamTest")
@@ -11413,7 +11731,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterDowngrade(t *testing.T) {
 	// Update a stream to be unsupported.
 	sjs.mu.Lock()
 	scfg.Metadata = map[string]string{"_nats.req.level": strconv.Itoa(math.MaxInt)}
-	err = cc.meta.Propose(encodeUpdateStreamAssignment(sa))
+	err = cc.meta.Propose(cc.meta.Term(), encodeUpdateStreamAssignment(sa))
 	sjs.mu.Unlock()
 	require_NoError(t, err)
 	c.waitOnAllCurrent()
@@ -11456,7 +11774,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterDowngrade(t *testing.T) {
 		Created: time.Now().UTC(),
 		Client:  ci,
 	}
-	err = cc.meta.Propose(encodeAddConsumerAssignment(ca))
+	err = cc.meta.Propose(cc.meta.Term(), encodeAddConsumerAssignment(ca))
 	sjs.mu.Unlock()
 	require_NoError(t, err)
 	c.waitOnConsumerLeader(globalAccountName, "DowngradeConsumerTest", "DowngradeConsumerTest")
@@ -11497,7 +11815,7 @@ func TestJetStreamClusterOfflineStreamAndConsumerAfterDowngrade(t *testing.T) {
 	// Update a consumer to be unsupported.
 	ccfg.Metadata = map[string]string{"_nats.req.level": strconv.Itoa(math.MaxInt)}
 	sjs.mu.Lock()
-	err = cc.meta.Propose(encodeAddConsumerAssignment(ca))
+	err = cc.meta.Propose(cc.meta.Term(), encodeAddConsumerAssignment(ca))
 	sjs.mu.Unlock()
 	require_NoError(t, err)
 	c.waitOnAllCurrent()
@@ -11581,14 +11899,15 @@ func TestJetStreamClusterOfflineStreamAndConsumerUpdate(t *testing.T) {
 	// Update a consumer to be unsupported.
 	sjs.mu.Lock()
 	ca.Config.Metadata = map[string]string{"_nats.req.level": strconv.Itoa(math.MaxInt)}
-	err = sjs.cluster.meta.Propose(encodeAddConsumerAssignment(ca))
+	meta := sjs.cluster.meta
+	err = meta.Propose(meta.Term(), encodeAddConsumerAssignment(ca))
 	sjs.mu.Unlock()
 	require_NoError(t, err)
 
 	// Update the stream to be unsupported.
 	sjs.mu.Lock()
 	sa.Config.Metadata = map[string]string{"_nats.req.level": strconv.Itoa(math.MaxInt)}
-	err = sjs.cluster.meta.Propose(encodeUpdateStreamAssignment(sa))
+	err = meta.Propose(meta.Term(), encodeUpdateStreamAssignment(sa))
 	sjs.mu.Unlock()
 	require_NoError(t, err)
 	c.waitOnAllCurrent()

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -8204,7 +8204,7 @@ func TestJetStreamClusterConsumerRedeliveryAfterUnexpectedReplicatedAck(t *testi
 			n := 1
 			n += binary.PutUvarint(b[n:], dseq)
 			n += binary.PutUvarint(b[n:], sseq)
-			require_NoError(t, rn.Propose(b[:n]))
+			require_NoError(t, rn.Propose(rn.Term(), b[:n]))
 
 			// Wait for ack to be applied.
 			checkFor(t, 2*time.Second, 500*time.Millisecond, func() error {

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8572,7 +8572,7 @@ func TestJetStreamClusterConsumerRemapWaitsForMonitorRoutineQuit(t *testing.T) {
 	require_NotNil(t, ca)
 	cca := ca.copyGroup()
 	cca.Group.Name = groupNameForConsumer(cca.Group.Peers, cca.Group.Storage)
-	require_NoError(t, cc.meta.Propose(encodeAddConsumerAssignment(cca)))
+	require_NoError(t, cc.meta.Propose(cc.meta.Term(), encodeAddConsumerAssignment(cca)))
 
 	// The monitor routine should stop.
 	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
@@ -10631,11 +10631,11 @@ type failProposeRaftNode struct {
 	RaftNode
 }
 
-func (n *failProposeRaftNode) Propose([]byte) error {
+func (n *failProposeRaftNode) Propose(uint64, []byte) error {
 	return errNotLeader
 }
 
-func (n *failProposeRaftNode) ProposeMulti([]*Entry) error {
+func (n *failProposeRaftNode) ProposeMulti(uint64, []*Entry) error {
 	return errNotLeader
 }
 

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -2578,7 +2578,7 @@ func TestJetStreamClusterStreamLeaderChangeDedupeCleanupRace(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		sjs.processStreamLeaderChange(mset, true)
+		sjs.processStreamLeaderChange(mset, true, 0)
 	}()
 
 	// Give the goroutine time to reach the clMu acquisition.
@@ -4580,7 +4580,7 @@ func TestJetStreamClusterConsumerDontSendSnapshotOnLeaderChange(t *testing.T) {
 	require_NoError(t, err)
 
 	// Simulate leader change, we do this so we can check what happens in the upper layer logic.
-	rn.leadc <- true
+	rn.leadc <- leadChange{isLeader: true, term: rn.Term()}
 	rn.SetObserver(false)
 
 	// Since upper layer is async, we don't know whether it will or will not act on the leader change.
@@ -7613,7 +7613,7 @@ func TestJetStreamClusterMetaCompactThreshold(t *testing.T) {
 				// Kicking the leader change channel is the easiest way to
 				// trick monitorCluster() into calling doSnapshot().
 				entries, _ := cc.meta.Size()
-				cc.meta.(*raft).leadc <- true
+				cc.meta.(*raft).leadc <- leadChange{isLeader: true, term: cc.meta.Term()}
 
 				// Should we have compacted on this iteration?
 				if entries > thresh {
@@ -7673,7 +7673,7 @@ func TestJetStreamClusterMetaCompactSizeThreshold(t *testing.T) {
 				// Kicking the leader change channel is the easiest way to
 				// trick monitorCluster() into calling doSnapshot().
 				_, size := cc.meta.Size()
-				cc.meta.(*raft).leadc <- true
+				cc.meta.(*raft).leadc <- leadChange{isLeader: true, term: cc.meta.Term()}
 
 				// Should we have compacted on this iteration?
 				if size > thresh {
@@ -7936,7 +7936,7 @@ func TestJetStreamClusterConsumerSetStoreStateOldUpdateRestart(t *testing.T) {
 	}
 	consumerAdd := encodeAddConsumerAssignment(cca)
 	mljs.mu.RUnlock()
-	require_NoError(t, cc.meta.Propose(consumerAdd))
+	require_NoError(t, cc.meta.Propose(cc.meta.Term(), consumerAdd))
 
 	// Wait for the meta leader to apply the entry.
 	time.Sleep(500 * time.Millisecond)

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -3094,8 +3094,8 @@ func TestJetStreamConsumerSwitchLeaderDuringInflightAck(t *testing.T) {
 
 	// Simulate an ack being pushed, and o.setLeader(false) being called before the ack is processed and resets o.awl
 	atomic.AddInt64(&o.awl, 1)
-	o.setLeader(false)
-	o.setLeader(true)
+	o.setLeader(false, 0)
+	o.setLeader(true, 0)
 
 	msgs, err = sub.Fetch(1, nats.MaxWait(5*time.Second))
 	require_NoError(t, err)
@@ -11156,7 +11156,7 @@ func TestJetStreamConsumerNoDeleteAfterConcurrentShutdownAndLeaderChange(t *test
 	fs.odir = odir
 	fs.mu.Unlock()
 	o.mu.Unlock()
-	o.setLeader(true)
+	o.setLeader(true, 0)
 
 	// Check the consumer was not deleted.
 	s, _ = RunServerWithConfig(conf)

--- a/server/raft.go
+++ b/server/raft.go
@@ -37,8 +37,8 @@ import (
 )
 
 type RaftNode interface {
-	Propose(entry []byte) error
-	ProposeMulti(entries []*Entry) error
+	Propose(term uint64, entry []byte) error
+	ProposeMulti(term uint64, entries []*Entry) error
 	ForwardProposal(entry []byte) error
 	InstallSnapshot(snap []byte, force bool) error
 	CreateSnapshotCheckpoint(force bool) (RaftNodeCheckpoint, error)
@@ -78,7 +78,7 @@ type RaftNode interface {
 	PauseApply() error
 	ResumeApply()
 	DrainAndReplaySnapshot() bool
-	LeadChangeC() <-chan bool
+	LeadChangeC() <-chan leadChange
 	QuitC() <-chan struct{}
 	Created() time.Time
 	Stop()
@@ -236,7 +236,7 @@ type raft struct {
 	apply *ipQueue[*CommittedEntry]      // Apply queue (committed entries to be passed to upper layer)
 	reqs  *ipQueue[*voteRequest]         // Vote requests
 	votes *ipQueue[*voteResponse]        // Vote responses
-	leadc chan bool                      // Leader changes
+	leadc chan leadChange                // Leader changes
 	quit  chan struct{}                  // Raft group shutdown
 
 	lxfer        bool // Are we doing a leadership transfer?
@@ -466,7 +466,7 @@ func (s *Server) initRaftNode(accName string, cfg *RaftConfig, labels pprofLabel
 		resp:     newIPQueue[*appendEntryResponse](s, qpfx+"appendEntryResponse"),
 		apply:    newIPQueue[*CommittedEntry](s, qpfx+"committedEntry"),
 		accName:  accName,
-		leadc:    make(chan bool, 32),
+		leadc:    make(chan leadChange, 1),
 		observer: cfg.Observer,
 	}
 
@@ -905,12 +905,16 @@ func (s *Server) transferRaftLeaders() bool {
 
 // Propose will propose a new entry to the group.
 // This should only be called on the leader.
-func (n *raft) Propose(data []byte) error {
+func (n *raft) Propose(term uint64, data []byte) error {
 	n.Lock()
 	defer n.Unlock()
+	return n.proposeLocked(term, data)
+}
+
+func (n *raft) proposeLocked(term uint64, data []byte) error {
 	// Check state under lock, we might not be leader anymore.
-	if state := n.State(); state != Leader {
-		n.debug("Proposal ignored, not leader (state: %v)", state)
+	if state := n.State(); state != Leader || term != n.term {
+		n.debug("Proposal ignored, not leader (state: %v, cterm: %d, term: %d)", state, term, n.term)
 		return errNotLeader
 	}
 
@@ -934,12 +938,12 @@ func (n *raft) Propose(data []byte) error {
 
 // ProposeMulti will propose multiple entries at once.
 // This should only be called on the leader.
-func (n *raft) ProposeMulti(entries []*Entry) error {
+func (n *raft) ProposeMulti(term uint64, entries []*Entry) error {
 	n.Lock()
 	defer n.Unlock()
 	// Check state under lock, we might not be leader anymore.
-	if state := n.State(); state != Leader {
-		n.debug("Multi proposal ignored, not leader (state: %v)", state)
+	if state := n.State(); state != Leader || term != n.term {
+		n.debug("Multi proposal ignored, not leader (state: %v, cterm: %d, term: %d)", state, term, n.term)
 		return errNotLeader
 	}
 
@@ -984,7 +988,12 @@ func (n *raft) isLeaderOverrun() bool {
 // If we are the leader this is the same as calling propose.
 func (n *raft) ForwardProposal(entry []byte) error {
 	if n.State() == Leader {
-		return n.Propose(entry)
+		n.Lock()
+		defer n.Unlock()
+		// We pass the node's term so the proposal goes through. This is unavoidable with forwarded
+		// proposals, normally the passed term MUST be that of the process triggering the proposals.
+		// So a stale process that is still running isn't allowed to make new proposals past its term.
+		return n.proposeLocked(n.term, entry)
 	}
 
 	// TODO: Currently we do not set a reply subject, even though we are
@@ -2203,7 +2212,7 @@ func (n *raft) ApplyQ() *ipQueue[*CommittedEntry] { return n.apply }
 
 // LeadChangeC returns the leader change channel, notifying when the Raft
 // leader role has moved.
-func (n *raft) LeadChangeC() <-chan bool { return n.leadc }
+func (n *raft) LeadChangeC() <-chan leadChange { return n.leadc }
 
 // QuitC returns the quit channel, notifying when the Raft group has shut down.
 func (n *raft) QuitC() <-chan struct{} { return n.quit }
@@ -5301,13 +5310,21 @@ func (n *raft) quorumNeeded() int {
 	return qn
 }
 
+// leadChange signals a leadership change to the upper layer. The term
+// identifies the leadership epoch the signal belongs to.
+type leadChange struct {
+	isLeader bool
+	term     uint64
+}
+
 // Lock should be held.
 func (n *raft) updateLeadChange(isLeader bool) {
+	lc := leadChange{isLeader: isLeader, term: n.term}
 	// We don't care about values that have not been consumed (transitory states),
 	// so we dequeue any state that is pending and push the new one.
 	for {
 		select {
-		case n.leadc <- isLeader:
+		case n.leadc <- lc:
 			return
 		default:
 			select {
@@ -5337,23 +5354,23 @@ retry:
 	// Reset the election timer.
 	n.resetElectionTimeout()
 
-	var leadChange bool
+	var leadChanged bool
 	if pstate == Leader && state != Leader {
-		leadChange = true
+		leadChanged = true
 		n.updateLeadChange(false)
 		// Drain the append entry response and proposal queues.
 		n.resp.drain()
 		n.prop.drain()
 	} else if state == Leader && pstate != Leader {
 		// Don't updateLeadChange here, it will be done in switchToLeader or after initial messages are applied.
-		leadChange = true
+		leadChanged = true
 		if len(n.pae) > 0 {
 			n.pae = make(map[uint64]*appendEntry)
 		}
 	}
 
 	n.writeTermVote()
-	return leadChange
+	return leadChanged
 }
 
 const (

--- a/server/raft_helpers_test.go
+++ b/server/raft_helpers_test.go
@@ -264,8 +264,8 @@ func smLoop(sm stateMachine) {
 			}
 			aq.recycle(&ces)
 
-		case isLeader := <-lch:
-			sm.leaderChange(isLeader)
+		case lc := <-lch:
+			sm.leaderChange(lc.isLeader)
 		}
 	}
 }

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -482,7 +482,7 @@ func TestNRGSwitchStateClearsQueues(t *testing.T) {
 	n := &raft{
 		prop:  newIPQueue[*proposedEntry](s, "prop"),
 		resp:  newIPQueue[*appendEntryResponse](s, "resp"),
-		leadc: make(chan bool, 1), // for switchState
+		leadc: make(chan leadChange, 1), // for switchState
 		sd:    t.TempDir(),
 		dios:  defaultDiskIOSemaphore(),
 	}
@@ -2774,8 +2774,8 @@ func TestNRGSignalLeadChangeFalseIfCampaignImmediately(t *testing.T) {
 			n.processAppendEntry(aeMsg1, n.aesub)
 
 			select {
-			case isLeader := <-n.LeadChangeC():
-				require_False(t, isLeader)
+			case lc := <-n.LeadChangeC():
+				require_False(t, lc.isLeader)
 			default:
 				t.Error("Expected leadChange signal")
 			}
@@ -6390,17 +6390,86 @@ func TestNRGOnlyCommitIfCurrentTerm(t *testing.T) {
 	require_Equal(t, n.commit, 3)
 }
 
+func TestNRGTermFencedProposals(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// Simulate winning an election.
+	n.switchToCandidate()
+	n.switchToLeader()
+	require_Equal(t, n.State(), Leader)
+	term := n.Term()
+	require_Equal(t, term, 1)
+
+	// Proposals with the current term are accepted.
+	require_NoError(t, n.Propose(term, nil))
+	require_NoError(t, n.ProposeMulti(term, []*Entry{newEntry(EntryNormal, nil)}))
+
+	// Proposals with a stale or future term are rejected, even though we are leader.
+	// Term 0 can never be a valid proposing term, elected leaders always have term >= 1.
+	require_Error(t, n.Propose(0, nil), errNotLeader)
+	require_Error(t, n.Propose(term+1, nil), errNotLeader)
+	require_Error(t, n.ProposeMulti(0, []*Entry{newEntry(EntryNormal, nil)}), errNotLeader)
+	require_Error(t, n.ProposeMulti(term+1, []*Entry{newEntry(EntryNormal, nil)}), errNotLeader)
+	require_Equal(t, n.State(), Leader)
+
+	// Losing leadership signals the upper layer with the term the loss happened in.
+	n.stepdown(noLeader)
+	select {
+	case lc := <-n.LeadChangeC():
+		require_False(t, lc.isLeader)
+		require_Equal(t, lc.term, term)
+	default:
+		t.Fatal("Expected leadChange signal")
+	}
+
+	// Get re-elected at a higher term.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		n.RLock()
+		prop, commit, processed := n.prop.len(), n.commit, n.processed
+		n.RUnlock()
+		if prop > 0 {
+			return fmt.Errorf("expected prop to be 0, got %d", prop)
+		}
+		if processed >= commit {
+			return nil
+		}
+		n.Applied(commit)
+		return fmt.Errorf("processed %d < commit %d", processed, commit)
+	})
+	n.switchToCandidate()
+	n.switchToLeader()
+	newTerm := n.Term()
+	require_Equal(t, newTerm, term+1)
+
+	// A stale process still holding the previous epoch's term must not be able
+	// to propose into the new epoch.
+	require_Error(t, n.Propose(term, nil), errNotLeader)
+	require_Error(t, n.ProposeMulti(term, []*Entry{newEntry(EntryNormal, nil)}), errNotLeader)
+
+	// Proposals with the new term are accepted, and forwarded proposals always
+	// use the node's current term.
+	require_NoError(t, n.Propose(newTerm, nil))
+	require_NoError(t, n.ForwardProposal(nil))
+}
+
 func TestNRGLeaderStepsDownIfOverrun(t *testing.T) {
 	n, cleanup := initSingleMemRaftNode(t)
 	defer cleanup()
 
 	// Proposals are only accepted if we're the leader.
-	require_Error(t, n.Propose(nil), errNotLeader)
-	require_Error(t, n.ProposeMulti(nil), errNotLeader)
+	term := n.Term()
+	require_Equal(t, term, 0)
+	require_Error(t, n.Propose(term, nil), errNotLeader)
+	require_Error(t, n.ProposeMulti(term, nil), errNotLeader)
 
+	// Simulate winning an election.
+	n.switchToCandidate()
 	n.switchToLeader()
-	require_NoError(t, n.Propose(nil))
-	require_NoError(t, n.ProposeMulti(nil))
+	term = n.Term()
+	require_Equal(t, term, 1)
+	require_NoError(t, n.Propose(term, nil))
+	require_NoError(t, n.ProposeMulti(term, nil))
 	require_Equal(t, n.State(), Leader)
 
 	// Too many uncommitted entries in our log.
@@ -6409,17 +6478,17 @@ func TestNRGLeaderStepsDownIfOverrun(t *testing.T) {
 
 		// Proposing while we're exactly at the threshold still succeeds.
 		n.pindex, n.commit, n.applied = pauseQuorumThreshold, 0, 0
-		require_NoError(t, n.Propose(nil))
-		require_NoError(t, n.ProposeMulti(nil))
+		require_NoError(t, n.Propose(term, nil))
+		require_NoError(t, n.ProposeMulti(term, nil))
 		require_Equal(t, n.State(), Leader)
 
 		// While we're over the threshold, we temporarily don't send proposals.
 		n.pindex, n.commit, n.applied = pauseQuorumThreshold+1, 0, 0
-		require_Error(t, n.Propose(nil), errNotLeader)
+		require_Error(t, n.Propose(term, nil), errNotLeader)
 		require_Equal(t, n.State(), Follower)
 
 		n.state.Store(int32(Leader))
-		require_Error(t, n.ProposeMulti(nil), errNotLeader)
+		require_Error(t, n.ProposeMulti(term, nil), errNotLeader)
 		require_Equal(t, n.State(), Follower)
 	})
 
@@ -6429,17 +6498,17 @@ func TestNRGLeaderStepsDownIfOverrun(t *testing.T) {
 
 		// Proposing while we're exactly at the threshold still succeeds.
 		n.pindex, n.commit, n.applied = pauseQuorumThreshold, pauseQuorumThreshold, 0
-		require_NoError(t, n.Propose(nil))
-		require_NoError(t, n.ProposeMulti(nil))
+		require_NoError(t, n.Propose(term, nil))
+		require_NoError(t, n.ProposeMulti(term, nil))
 		require_Equal(t, n.State(), Leader)
 
 		// While we're over the threshold, we temporarily don't send proposals.
 		n.pindex, n.commit, n.applied = pauseQuorumThreshold+1, pauseQuorumThreshold+1, 0
-		require_Error(t, n.Propose(nil), errNotLeader)
+		require_Error(t, n.Propose(term, nil), errNotLeader)
 		require_Equal(t, n.State(), Follower)
 
 		n.state.Store(int32(Leader))
-		require_Error(t, n.ProposeMulti(nil), errNotLeader)
+		require_Error(t, n.ProposeMulti(term, nil), errNotLeader)
 		require_Equal(t, n.State(), Follower)
 	})
 }

--- a/server/stream.go
+++ b/server/stream.go
@@ -480,6 +480,10 @@ type stream struct {
 	// Those subscriptions are for the subjects filters being listened to and captured by the stream.
 	sid atomic.Uint64
 
+	// Whether the stream layer has completed leader setup via setLeader. Unlike isLeader(),
+	// which reads the raft node's current state, this tracks our own processed leadership.
+	leader atomic.Bool
+
 	pubAck    []byte                  // The template (prefix) to generate the pubAck responses for this stream quickly.
 	outq      *jsOutQ                 // Queue of *jsPubMsg for sending messages.
 	msgs      *ipQueue[*inMsg]        // Intra-process queue for the ingress of messages.
@@ -487,6 +491,7 @@ type stream struct {
 	store     StreamStore             // The storage for this stream.
 	ackq      *ipQueue[uint64]        // Intra-process queue for acks.
 	lseq      uint64                  // The sequence number of the last message stored in the stream.
+	term      uint64                  // Raft term, used to determine if we are still the leader for the current term (if applicable, 0 otherwise).
 	lmsgId    string                  // The de-duplication message ID of the last message stored in the stream.
 	consumers map[string]*consumer    // The consumers for this stream.
 	numFilter int                     // The number of filtered consumers.
@@ -1042,7 +1047,7 @@ func (a *Account) addStreamWithAssignment(config *StreamConfig, fsConfig *FileSt
 	// Call directly to set leader if not in clustered mode.
 	// This can be called though before we actually setup clustering, so check both.
 	if singleServerMode {
-		if err := mset.setLeader(true); err != nil {
+		if err := mset.setLeader(true, 0); err != nil {
 			mset.stop(true, false)
 			return nil, err
 		}
@@ -1251,8 +1256,37 @@ func (mset *stream) isLeaderNodeState() bool {
 }
 
 // TODO(dlc) - Check to see if we can accept being the leader or we should step down.
-func (mset *stream) setLeader(isLeader bool) error {
+func (mset *stream) setLeader(isLeader bool, term uint64) error {
 	mset.mu.Lock()
+	wasLeader := mset.leader.Swap(isLeader)
+
+	// We can skip the teardown if we were leader before and are still the leader now.
+	// But only at term 1, since that means scale up from or down to an unreplicated config.
+	// R1 assets have no raft node and use the coerced term 1.
+	if term < 1 {
+		term = 1
+	}
+	skipTeardown := wasLeader && isLeader && term == 1
+	mset.term = term
+	if !skipTeardown {
+		// cancel timer to create the source consumers if not fired yet
+		if mset.sourcesConsumerSetup != nil {
+			mset.sourcesConsumerSetup.Stop()
+			mset.sourcesConsumerSetup = nil
+		} else {
+			// Stop any source consumers
+			mset.stopSourceConsumers()
+		}
+
+		// Stop responding to sync requests.
+		mset.stopClusterSubs()
+		// Unsubscribe from direct stream.
+		mset.unsubscribeToStream(false, false)
+		// Clear catchup state
+		mset.clearAllCatchupPeers()
+		mset.store.ResetState()
+	}
+
 	// If we are here we have a change in leader status.
 	if isLeader {
 		// Make sure we are listening for sync requests.
@@ -1273,31 +1307,14 @@ func (mset *stream) setLeader(isLeader bool) error {
 
 		// Reset any inflight fast batches. We were likely a follower before and need
 		// to send an ack to the publishers so they know we're still there.
-		if mset.batches != nil {
+		if !skipTeardown && mset.batches != nil {
 			mset.batches.mu.Lock()
 			for batchId, b := range mset.batches.fast {
 				mset.batches.fastBatchReset(mset, batchId, b)
 			}
 			mset.batches.mu.Unlock()
 		}
-	} else {
-		// cancel timer to create the source consumers if not fired yet
-		if mset.sourcesConsumerSetup != nil {
-			mset.sourcesConsumerSetup.Stop()
-			mset.sourcesConsumerSetup = nil
-		} else {
-			// Stop any source consumers
-			mset.stopSourceConsumers()
-		}
-
-		// Stop responding to sync requests.
-		mset.stopClusterSubs()
-		// Unsubscribe from direct stream.
-		mset.unsubscribeToStream(false, false)
-		// Clear catchup state
-		mset.clearAllCatchupPeers()
 	}
-	mset.store.ResetState()
 	mset.mu.Unlock()
 
 	// If we are interest based make sure to check consumers.
@@ -3260,7 +3277,7 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 	}
 
 	s, js, stype := mset.srv, mset.js, mset.cfg.Storage
-	node := mset.node
+	node, term := mset.node, mset.term
 	mset.mu.Unlock()
 
 	var err error
@@ -3271,7 +3288,7 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 			s.resourcesExceededError(stype)
 			err = ApiErrors[JSInsufficientResourcesErr]
 		} else {
-			err = node.Propose(encodeStreamMsg(m.subj, _EMPTY_, m.hdr, m.msg, sseq-1, ts, true))
+			err = node.Propose(term, encodeStreamMsg(m.subj, _EMPTY_, m.hdr, m.msg, sseq-1, ts, true))
 		}
 	} else {
 		err = mset.processJetStreamMsg(m.subj, _EMPTY_, m.hdr, m.msg, sseq-1, ts, nil, true, true)
@@ -3352,7 +3369,7 @@ func (mset *stream) skipMsgs(start, end uint64) error {
 	// Must only be enabled once every peer in the cluster supports receiving
 	// deleteRangeOp in the normal apply path; older peers panic on unknown ops.
 	if mset.srv.getOpts().getFeatureFlag(FeatureFlagJsRaftDeleteRange) {
-		return node.Propose(encodeDeleteRange(&DeleteRange{First: start, Num: end - start + 1}))
+		return node.Propose(mset.term, encodeDeleteRange(&DeleteRange{First: start, Num: end - start + 1}))
 	}
 
 	var entries []*Entry
@@ -3360,7 +3377,7 @@ func (mset *stream) skipMsgs(start, end uint64) error {
 		entries = append(entries, newEntry(EntryNormal, encodeStreamMsg(_EMPTY_, _EMPTY_, nil, nil, seq-1, 0, false)))
 		// So a single message does not get too big.
 		if len(entries) > 10_000 {
-			if err := node.ProposeMulti(entries); err != nil {
+			if err := node.ProposeMulti(mset.term, entries); err != nil {
 				return err
 			}
 			// We need to re-create `entries` because there is a reference
@@ -3370,7 +3387,7 @@ func (mset *stream) skipMsgs(start, end uint64) error {
 	}
 	// Send all at once.
 	if len(entries) > 0 {
-		return node.ProposeMulti(entries)
+		return node.ProposeMulti(mset.term, entries)
 	}
 	return nil
 }
@@ -4325,7 +4342,7 @@ func (mset *stream) handleFlowControl(m *inMsg, dseq, sseq uint64) {
 		// Append the current delivery and stream sequences, to be sent after replication.
 		m.hdr = genHeader(m.hdr, JSLastConsumerSeq, strconv.FormatUint(dseq, 10))
 		m.hdr = genHeader(m.hdr, JSLastStreamSeq, strconv.FormatUint(sseq, 10))
-		mset.node.Propose(encodeStreamMsg(_EMPTY_, m.rply, m.hdr, nil, 0, 0, false))
+		mset.node.Propose(mset.term, encodeStreamMsg(_EMPTY_, m.rply, m.hdr, nil, 0, 0, false))
 	} else {
 		const t = "NATS/1.0\r\n%s: %d\r\n%s: %d\r\n\r\n"
 		hdr := fmt.Appendf(nil, t, JSLastConsumerSeq, dseq, JSLastStreamSeq, sseq)
@@ -5173,12 +5190,12 @@ func (mset *stream) setupStore(fsCfg *FileStoreConfig) error {
 	mset.store.RegisterStorageUpdates(mset.storeUpdates)
 	mset.store.RegisterStorageRemoveMsg(func(seq uint64) {
 		if mset.IsClustered() {
-			if mset.IsLeader() {
-				mset.mu.RLock()
+			mset.mu.RLock()
+			if mset.isLeader() {
 				md := streamMsgDelete{Seq: seq, NoErase: true, Stream: mset.cfg.Name}
-				mset.node.Propose(encodeMsgDelete(&md))
-				mset.mu.RUnlock()
+				mset.node.Propose(mset.term, encodeMsgDelete(&md))
 			}
+			mset.mu.RUnlock()
 		} else {
 			mset.removeMsg(seq)
 		}
@@ -7023,7 +7040,7 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 		// If this proposal fails, we retry out-of-band.
 		if isClustered && isLeader {
 			md := streamMsgDelete{Seq: seq, NoErase: true, Stream: mset.cfg.Name}
-			_ = mset.node.Propose(encodeMsgDelete(&md))
+			_ = mset.node.Propose(mset.term, encodeMsgDelete(&md))
 		}
 	}
 
@@ -7553,10 +7570,11 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		}
 		mset.mu.Unlock()
 	} else {
+		term := mset.term
 		mset.mu.Unlock()
 		// Do a single multi proposal. This ensures we get to push all entries to the proposal queue in-order
 		// and not interleaved with other proposals.
-		if err = node.ProposeMulti(entries); err == nil {
+		if err = node.ProposeMulti(term, entries); err == nil {
 			diff.commit(mset)
 			mset.trackReplicationTraffic(node, sz, r)
 
@@ -7583,7 +7601,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 	canRespond := !mset.cfg.NoAck && len(reply) > 0
 	name, stype := mset.cfg.Name, mset.cfg.Storage
 	discard, discardNewPer, maxMsgs, maxMsgsPer, maxBytes := mset.cfg.Discard, mset.cfg.DiscardNewPer, mset.cfg.MaxMsgs, mset.cfg.MaxMsgsPer, mset.cfg.MaxBytes
-	s, js, jsa, st, r, tierName, outq, node := mset.srv, mset.js, mset.jsa, mset.cfg.Storage, mset.cfg.Replicas, mset.tier, mset.outq, mset.node
+	s, js, jsa, st, r, tierName, outq, node, term := mset.srv, mset.js, mset.jsa, mset.cfg.Storage, mset.cfg.Replicas, mset.tier, mset.outq, mset.node, mset.term
 	maxMsgSize, lseq := int(mset.cfg.MaxMsgSize), mset.lseq
 	isLeader, isClustered, isSealed, allowRollup, denyPurge, allowTTL, allowMsgCounter, allowMsgSchedules, allowBatchPublish := mset.isLeader(), mset.isClustered(), mset.cfg.Sealed, mset.cfg.AllowRollup, mset.cfg.DenyPurge, mset.cfg.AllowMsgTTL, mset.cfg.AllowMsgCounter, mset.cfg.AllowMsgSchedules, mset.cfg.AllowBatchPublish
 
@@ -7910,7 +7928,7 @@ func (mset *stream) processJetStreamFastBatchMsg(batch *FastBatch, subject, repl
 		mset.clMu.Unlock()
 		return mset.processJetStreamMsgWithBatch(subject, reply, hdr, msg, 0, 0, mt, false, true, batch)
 	}
-	err = commitSingleMsg(diff, mset, subject, reply, hdr, msg, name, jsa, mt, node, r, lseq)
+	err = commitSingleMsg(diff, mset, subject, reply, hdr, msg, name, jsa, mt, node, term, r, lseq)
 	mset.clMu.Unlock()
 	return err
 }


### PR DESCRIPTION
Require async goroutines to pass the `term` they were started under when doing a proposal, this prevents an async goroutine that wasn't shut down from proposing and mutating state after a quick leader election cycle.

On leadership change `setLeader` now tears down all leader state, including pending proposals, since none of it is valid in the new term. A continuing leader moving between R1 and clustered at term 1 (scale-up/down) skips the teardown so scaling stays optimized/non-disruptive.