### PR TITLE
(2.15) [FIXED] Consumer remapping on retention change

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -8792,6 +8792,17 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		consumers, _ = js.remapConsumerAssignments(acc.Name, sa, false)
 	}
 
+	// If this is a pure retention change to a non-limits policy, perform the consumer scaling first.
+	if isRetentionChange && !isReplicaChange && !isMoveRequest && sa.Config.Retention != LimitsPolicy {
+		for _, ca := range consumers {
+			if err := meta.Propose(encodeAddConsumerAssignment(ca)); err != nil {
+				return
+			}
+			cc.trackInflightConsumerProposal(acc.Name, sa.Config.Name, ca, false)
+		}
+		consumers = nil
+	}
+
 	if err := meta.Propose(encodeUpdateStreamAssignment(sa)); err != nil {
 		return
 	}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7840,7 +7840,10 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 		}
 		// If the replicas was not 0 make sure it matches here.
 		if cca.Config.Replicas != 0 {
-			cca.Config.Replicas = r
+			// Copy the config before mutating it, since only the assignment was copied.
+			cfg := *cca.Config
+			cfg.Replicas = r
+			cca.Config = &cfg
 		}
 		// Check if all peers are invalid. This can happen with R1 under replicated streams that are being scaled down.
 		// If the old peers are being removed we can't ask them for state, so skip the transfer.

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -16367,8 +16367,8 @@ func TestJetStreamLimitsToInterestPolicy(t *testing.T) {
 	defer nc.Close()
 
 	// This is the index of the consumer that we'll create as R1
-	// instead of R3, just to prove that it blocks the stream
-	// update from happening properly.
+	// instead of R3, just to prove that the switch to interest-based
+	// retention also scales it up to an R3 consumer.
 	singleReplica := 3
 
 	streamCfg := nats.StreamConfig{
@@ -16427,40 +16427,25 @@ func TestJetStreamLimitsToInterestPolicy(t *testing.T) {
 		require_Equal(t, info.AckFloor.Consumer, uint64(count))
 	}
 
-	// Try updating to interest-based. This should fail because
-	// we have a consumer that is R1 on an R3 stream.
+	// Try updating to interest-based. Even though we have a consumer
+	// that is R1 on an R3 stream, this should succeed: the consumer
+	// should be scaled up to match the stream instead of the update
+	// being rejected.
 	streamCfg = stream.Config
 	streamCfg.Retention = nats.InterestPolicy
 	_, err = js.UpdateStream(&streamCfg)
-	require_Error(t, err)
-
-	// Now we'll make the R1 consumer an R3.
-	cname := fmt.Sprintf("test_%d", singleReplica)
-	cinfo, err := js.ConsumerInfo("TEST", cname)
 	require_NoError(t, err)
 
-	cinfo.Config.Replicas = streamCfg.Replicas
-	_, _ = js.UpdateConsumer("TEST", &cinfo.Config)
-	// TODO(nat): The jsConsumerCreateRequest update doesn't always
-	// respond when there are no errors updating a consumer, so this
-	// nearly always returns a timeout, despite actually doing what
-	// it should. We'll make sure the replicas were updated by doing
-	// another consumer info just to be sure.
-	// require_NoError(t, err)
+	// We need to wait for all nodes to have applied the new configs.
 	c.waitOnAllCurrent()
+
+	// The previously R1 consumer should now be R3, matching the stream.
+	cname := fmt.Sprintf("test_%d", singleReplica)
 	c.waitOnConsumerLeader(globalAccountName, "TEST", cname)
-	cinfo, err = js.ConsumerInfo("TEST", cname)
+	cinfo, err := js.ConsumerInfo("TEST", cname)
 	require_NoError(t, err)
 	require_Equal(t, cinfo.Config.Replicas, streamCfg.Replicas)
 	require_Equal(t, len(cinfo.Cluster.Replicas), streamCfg.Replicas-1)
-
-	// This time it should succeed.
-	_, err = js.UpdateStream(&streamCfg)
-	require_NoError(t, err)
-
-	// We need to wait for all nodes to have applied the new stream
-	// configuration.
-	c.waitOnAllCurrent()
 
 	// Now we should only have 10 messages left in the stream, as
 	// each consumer has acked at least the first 10 messages.

--- a/server/stream.go
+++ b/server/stream.go
@@ -2667,17 +2667,6 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 		// a subsequent update to an existing tier will then move from existing past tier to existing new tier
 	}
 
-	if mset.isLeader() && mset.sa != nil && ocfg.Retention != cfg.Retention && cfg.Retention == InterestPolicy {
-		// Before we can update the retention policy for the consumer, we need
-		// the replica count of all consumers to match the stream.
-		for _, c := range mset.sa.consumers {
-			if c.Config.Replicas > 0 && c.Config.Replicas != cfg.Replicas {
-				mset.mu.Unlock()
-				return fmt.Errorf("consumer %q replica count must be %d", c.Name, cfg.Replicas)
-			}
-		}
-	}
-
 	// If atomic publish is disabled, delete any in-progress batches.
 	if !cfg.AllowAtomicPublish {
 		mset.deleteAtomicBatches(false)
@@ -2701,8 +2690,7 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 	mset.cfg = *cfg
 	mset.cfgMu.Unlock()
 
-	// If we're changing retention and haven't errored because of consumer
-	// replicas by now, whip through and update the consumer retention.
+	// If we're changing retention, whip through and update the consumer retention.
 	if ocfg.Retention != cfg.Retention {
 		toUpdate := make([]*consumer, 0, len(mset.consumers))
 		for _, c := range mset.consumers {


### PR DESCRIPTION
- The consumer's config was aliased, which is now copied before updating the replicas. (And the reason why `TestJetStreamLimitsToInterestPolicy` started flaking)
- When changing retention from limits to interest, the consumers should be remapped first before the retention changes.
- Remove the consumer assignments retention check block since it depends on a stream leader existing, and was also a data race since the JS lock was not held while iterating `mset.sa.consumers`.

When the desired meta approach PRs land for 2.15 we can make retention changes and consumer remapping a lot smoother. We could then even support changing between all retention policies safely, but all of that is future work.