### PR TITLE
Account for existing store usage when computing dynamic JetStream MaxStore

### DIFF
--- a/server/disk_avail.go
+++ b/server/disk_avail.go
@@ -17,8 +17,20 @@ package server
 
 import (
 	"os"
+	"path/filepath"
 	"syscall"
 )
+
+func dirSize(path string) int64 {
+	var size int64
+	filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() {
+			size += info.Size()
+		}
+		return nil
+	})
+	return size
+}
 
 func diskAvailable(storeDir string) int64 {
 	var ba int64
@@ -28,7 +40,7 @@ func diskAvailable(storeDir string) int64 {
 	var fs syscall.Statfs_t
 	if err := syscall.Statfs(storeDir, &fs); err == nil {
 		// Estimate 75% of available storage.
-		ba = int64(uint64(fs.Bavail) * uint64(fs.Bsize) / 4 * 3)
+		ba = int64((uint64(fs.Bavail)*uint64(fs.Bsize) + uint64(dirSize(storeDir))) / 4 * 3)
 	} else {
 		// Used 1TB default as a guess if all else fails.
 		ba = JetStreamMaxStoreDefault

--- a/server/disk_avail_openbsd.go
+++ b/server/disk_avail_openbsd.go
@@ -17,8 +17,20 @@ package server
 
 import (
 	"os"
+	"path/filepath"
 	"syscall"
 )
+
+func dirSize(path string) int64 {
+	var size int64
+	filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() {
+			size += info.Size()
+		}
+		return nil
+	})
+	return size
+}
 
 func diskAvailable(storeDir string) int64 {
 	var ba int64
@@ -28,7 +40,7 @@ func diskAvailable(storeDir string) int64 {
 	var fs syscall.Statfs_t
 	if err := syscall.Statfs(storeDir, &fs); err == nil {
 		// Estimate 75% of available storage.
-		ba = int64(uint64(fs.F_bavail) * uint64(fs.F_bsize) / 4 * 3)
+		ba = int64((uint64(fs.F_bavail)*uint64(fs.F_bsize) + uint64(dirSize(storeDir))) / 4 * 3)
 	} else {
 		// Used 1TB default as a guess if all else fails.
 		ba = JetStreamMaxStoreDefault

--- a/server/disk_avail_solaris.go
+++ b/server/disk_avail_solaris.go
@@ -17,8 +17,21 @@ package server
 
 import (
 	"os"
+	"path/filepath"
+
 	"golang.org/x/sys/unix"
 )
+
+func dirSize(path string) int64 {
+	var size int64
+	filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() {
+			size += info.Size()
+		}
+		return nil
+	})
+	return size
+}
 
 func diskAvailable(storeDir string) int64 {
 	var ba int64
@@ -28,7 +41,7 @@ func diskAvailable(storeDir string) int64 {
 	var fs unix.Statvfs_t
 	if err := unix.Statvfs(storeDir, &fs); err == nil {
 		// Estimate 75% of available storage.
-		ba = int64(uint64(fs.Frsize) * uint64(fs.Bavail) / 4 * 3)
+		ba = int64((uint64(fs.Frsize)*uint64(fs.Bavail) + uint64(dirSize(storeDir))) / 4 * 3)
 	} else {
 		// Used 1TB default as a guess if all else fails.
 		ba = JetStreamMaxStoreDefault

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -7487,6 +7487,27 @@ func TestJetStreamProgrammaticMaxStoreAndMaxMemory(t *testing.T) {
 	}
 }
 
+func TestJetStreamDiskAvailableAccountsForExistingStoreUsage(t *testing.T) {
+	dir := t.TempDir()
+
+	// Baseline: no JetStream data written yet.
+	before := diskAvailable(dir)
+	require_True(t, before > 0)
+
+	// Simulate JetStream having already written data into its own store
+	// directory across a previous run.
+	data := make([]byte, 50*1024*1024) // 50MB
+	require_NoError(t, os.WriteFile(filepath.Join(dir, "existing.blk"), data, 0644))
+
+	after := diskAvailable(dir)
+
+	// Before the fix, `after` drops by roughly 75% of the 50MB we just wrote,
+	// since existing JetStream usage was never added back before the 75%
+	// calculation. After the fix, that usage is added back, so `after`
+	// should stay roughly level with `before` rather than shrinking.
+	require_True(t, after >= before-(1024*1024)) // small slack for rounding/fs overhead
+}
+
 func TestJetStreamDynConfigBothPositive(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()


### PR DESCRIPTION
When JetStream runs in dynamic storage mode (no explicit max_file_store configured), the server computes MaxStore as roughly 75% of the currently free disk space on the store directory's filesystem. This calculation is redone on every server restart.

The problem: as JetStream writes data to disk over time, free disk space naturally drops, so the computed MaxStore ceiling also drops on each subsequent restart, even though nothing is actually misconfigured. In practice this means stream configs (sum of max_bytes) that were valid when first created can start failing to update or recreate after a restart, with insufficient storage resources available (err_code=10047), purely because the dynamic ceiling ratcheted downward.

This PR fixes the calculation by adding back the current on-disk size of the JetStream store directory before applying the 75% estimate, so a server that restarts with existing data ends up with a dynamic MaxStore roughly consistent with what it had before, rather than one that shrinks every time.

Resolves #8322

Related: #4140, which raised the same underlying issue with the calculation not accounting for existing usage.

### Changes

- Added a dirSize helper that walks a directory and sums file sizes, used to measure the current size of the JetStream store directory.
- Updated the three platform implementations that perform a real filesystem-based calculation (disk_avail.go for Linux/macOS/BSD, disk_avail_openbsd.go, disk_avail_solaris.go) to add the store directory's current size back into available space before the 75% estimate.
- Left disk_avail_windows.go, disk_avail_netbsd.go, and disk_avail_wasm.go untouched, since these already return a flat default rather than performing a real calculation.
- Added TestJetStreamDiskAvailableAccountsForExistingStoreUsage, which writes data into a temp store directory and asserts the computed available space does not meaningfully drop as a result, reproducing the bug directly against diskAvailable before this fix.

### Testing

Ran the new test in isolation and the broader TestJetStream suite locally to check for regressions in dynamic config behavior.

Note: while running the full test suite, TestJetStreamClusterSnapshotStreamAssetOnShutdown and TestJetStreamClusterStreamResetOnExpirationDuringPeerDownAndRestartWithLeaderChange failed once under load. Both pass reliably in isolation and on a clean checkout without this change, so this appears to be pre-existing flakiness unrelated to this fix.