### PR TITLE
(2.14) [FIXED] Filestore MaxMsgsPer enforcement racing concurrent removal

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -4901,9 +4901,11 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 	mmp := uint64(fs.cfg.MaxMsgsPer)
 	var psmc uint64
 	psmax := mmp > 0 && len(subj) > 0
+	var info *psi
 	if psmax {
-		if info, ok := fs.psim.Find(stringToBytes(subj)); ok {
-			psmc = info.total
+		if info, _ = fs.psim.Find(stringToBytes(subj)); info != nil {
+			// Take current total, but add 1 for the message we are about to store.
+			psmc = info.total + 1
 		}
 	}
 
@@ -4913,7 +4915,7 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 	// the message here since it could cause replicas to drift.
 	if discardNewCheck && fs.cfg.Discard == DiscardNew {
 		var asl bool
-		if psmax && psmc >= mmp {
+		if psmax && psmc > mmp {
 			// If we are instructed to discard new per subject, this is an error.
 			// However, allow rollup messages through since they will purge old
 			// messages for the subject after storing, restoring the limit.
@@ -4923,7 +4925,12 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 			if fseq, err = fs.firstSeqForSubj(subj); err != nil {
 				return err
 			}
-			asl = true
+			// fs.firstSeqForSubj releases and re-acquires the lock, need to fetch the state again.
+			if info, _ = fs.psim.Find(stringToBytes(subj)); info != nil {
+				// Take current total, but add 1 for the message we are about to store.
+				psmc = info.total + 1
+			}
+			asl = psmc > mmp
 		}
 		if fs.cfg.MaxMsgs > 0 && fs.state.Msgs >= uint64(fs.cfg.MaxMsgs) && !asl {
 			return ErrMaxMsgs
@@ -4963,11 +4970,12 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 	}
 
 	// Adjust top level tracking of per subject msg counts.
-	var info *psi
-	var ok bool
 	if len(subj) > 0 && fs.psim != nil {
 		index := fs.lmb.index
-		if info, ok = fs.psim.Find(stringToBytes(subj)); ok {
+		if info == nil {
+			info, _ = fs.psim.Find(stringToBytes(subj))
+		}
+		if info != nil {
 			info.total++
 			if index > info.lblk {
 				info.lblk = index
@@ -4991,41 +4999,33 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 	fs.state.LastTime = now
 
 	// Enforce per message limits.
-	// We snapshotted psmc before our actual write, so >= comparison needed.
-	if psmax && psmc >= mmp {
+	for psmax && psmc > mmp {
 		// We may have done this above.
 		if fseq == 0 {
 			fseq, err = fs.firstSeqForSubj(subj)
 			if err != nil {
 				return err
+			} else if fseq == 0 {
+				break
 			}
+			// fs.firstSeqForSubj releases and re-acquires the lock, need to fetch the state again.
+			if info, _ = fs.psim.Find(stringToBytes(subj)); info != nil {
+				psmc = info.total
+			} else {
+				break
+			}
+			// Re-check if we're at the limit.
+			continue
 		}
-		if ok, err := fs.removeMsgViaLimits(fseq); err != nil {
+		if _, err = fs.removeMsgViaLimits(fseq); err != nil && err != ErrStoreMsgNotFound {
 			return err
-		} else if ok {
-			// Make sure we are below the limit.
-			if psmc--; psmc >= mmp {
-				bsubj := stringToBytes(subj)
-				for info, ok := fs.psim.Find(bsubj); ok && info.total > mmp; info, ok = fs.psim.Find(bsubj) {
-					if seq, err := fs.firstSeqForSubj(subj); err != nil {
-						return err
-					} else if seq == 0 {
-						break
-					} else if ok, err = fs.removeMsgViaLimits(seq); err != nil {
-						return err
-					} else if !ok {
-						break
-					}
-				}
-			}
-		} else if mb := fs.selectMsgBlock(fseq); mb != nil {
-			// If we are here we could not remove fseq from above, so rebuild.
-			var ld *LostStreamData
-			if ld, _, err = mb.rebuildState(); err != nil {
-				return err
-			} else if ld != nil {
-				fs.rebuildStateLocked(ld)
-			}
+		}
+		fseq = 0
+		// fs.removeMsgViaLimits releases and re-acquires the lock, need to fetch the state again.
+		if info, _ = fs.psim.Find(stringToBytes(subj)); info != nil {
+			psmc = info.total
+		} else {
+			break
 		}
 	}
 	// If we only ever store one/last message for a subject, can correct the first block to where we've just written.
@@ -5441,6 +5441,12 @@ func (fs *fileStore) firstSeqForSubj(subj string) (uint64, error) {
 		fs.mu.Unlock()
 
 		mb.mu.Lock()
+		// If marked closed, the block is already gone.
+		if mb.closed {
+			mb.mu.Unlock()
+			fs.mu.Lock()
+			continue
+		}
 		var shouldExpire bool
 		if mb.fssNotLoaded() {
 			// Make sure we have fss loaded.

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -14835,3 +14835,164 @@ func TestFileStoreEncryptionKeyFileSyncedBySyncBlocks(t *testing.T) {
 	lmb.mu.RUnlock()
 	require_False(t, needKeySync)
 }
+
+func TestFileStoreStoreRawMsgVsConcurrentBlockRemovalNoWriteErr(t *testing.T) {
+	fcfg := FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 256}
+	cfg := StreamConfig{Name: "zzz", Subjects: []string{"foo.>"}, Storage: FileStorage, MaxMsgsPer: 1}
+	fs, err := newFileStore(fcfg, cfg)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	const writers = 4
+	const readers = 4
+
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+	var lastSeq atomic.Uint64
+	msg := make([]byte, 128)
+
+	// Writers evict their own previous message on every store; removers race
+	// them for that same sequence, deleting its (single-message) block.
+	for w := 0; w < writers; w++ {
+		seqs := make(chan uint64, 64)
+		subj := fmt.Sprintf("foo.%d", w)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			defer close(seqs)
+			for !stop.Load() {
+				seq, _, err := fs.StoreMsg(subj, nil, msg, 0)
+				if err != nil {
+					return
+				}
+				lastSeq.Store(seq)
+				select {
+				case seqs <- seq:
+				default:
+				}
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for seq := range seqs {
+				fs.RemoveMsg(seq)
+			}
+		}()
+	}
+
+	// Readers keep mb.mu contended so a remover holding fs.mu can barge past
+	// a storer parked on mb.mu inside firstSeqForSubj.
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var smv StoreMsg
+			for !stop.Load() {
+				if seq := lastSeq.Load(); seq > 2 {
+					fs.LoadMsg(seq-2, &smv)
+				}
+			}
+		}()
+	}
+
+	// Run for a fixed period, checking that no write error is ever latched.
+	timeout := time.Now().Add(2 * time.Second)
+	for time.Now().Before(timeout) {
+		fs.mu.RLock()
+		werr := fs.werr
+		fs.mu.RUnlock()
+		if werr != nil {
+			stop.Store(true)
+			wg.Wait()
+			t.Fatalf("store was disabled by a concurrent removal: werr=%v", werr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	stop.Store(true)
+	wg.Wait()
+
+	// The store must still be fully writable.
+	_, _, err = fs.StoreMsg("foo.healthy", nil, msg, 0)
+	require_NoError(t, err)
+}
+
+func TestFileStoreStoreRawMsgVsAgeExpiryNoWriteErr(t *testing.T) {
+	fcfg := FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 256}
+	cfg := StreamConfig{
+		Name: "zzz", Subjects: []string{"foo.>"}, Storage: FileStorage,
+		MaxMsgsPer: 1, MaxAge: time.Millisecond,
+	}
+	fs, err := newFileStore(fcfg, cfg)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	const writers = 16
+	const readers = 4
+
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+	msg := make([]byte, 128)
+
+	prevSeqs := make([]atomic.Uint64, writers)
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			subj := fmt.Sprintf("foo.%d", w)
+			for !stop.Load() {
+				seq, _, err := fs.StoreMsg(subj, nil, msg, 0)
+				if err != nil {
+					return
+				}
+				prevSeqs[w].Store(seq)
+				// Pace so the previous message is expiry-eligible exactly
+				// while this store's eviction is in flight.
+				time.Sleep(time.Millisecond + time.Duration(w%4)*50*time.Microsecond)
+			}
+		}(w)
+	}
+
+	// Readers contend mb.mu on the blocks evictions will target.
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func(r int) {
+			defer wg.Done()
+			var smv StoreMsg
+			for i := 0; !stop.Load(); i++ {
+				if seq := prevSeqs[(r+i)%writers].Load(); seq > 0 {
+					fs.LoadMsg(seq, &smv)
+				}
+			}
+		}(r)
+	}
+
+	// Drive expiry sweeps continuously rather than waiting on the age check
+	// timer, which fires far too infrequently to collide with the eviction
+	// window inside the test's time budget. This runs the exact same sweep
+	// the timer would, just often enough to race every store.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for !stop.Load() {
+			fs.expireMsgs()
+		}
+	}()
+
+	timeout := time.Now().Add(2 * time.Second)
+	for time.Now().Before(timeout) {
+		fs.mu.RLock()
+		werr := fs.werr
+		fs.mu.RUnlock()
+		if werr != nil {
+			stop.Store(true)
+			wg.Wait()
+			t.Fatalf("store was disabled by racing age expiry: werr=%v", werr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	stop.Store(true)
+	wg.Wait()
+
+	_, _, err = fs.StoreMsg("foo.healthy", nil, msg, 0)
+	require_NoError(t, err)
+}


### PR DESCRIPTION
`firstSeqForSubj` and `removeMsgViaLimits` release and re-acquire the filestore lock, so a concurrent removal (`RemoveMsg` or age expiry) could remove the sequence the `MaxMsgsPer` enforcement in `storeRawMsg` was about to evict. The resulting error (`ErrStoreMsgNotFound` or `errNoBlkData`) was latched into `fs.werr`, permanently disabling writes.
