### PR TITLE
Skip expired JWT accounts in JetStream healthz scans

### DIFF
--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -1198,6 +1198,14 @@ func TestJetStreamJWTHealthzIgnoresExpiredAccounts(t *testing.T) {
 	explicit := s.healthz(&HealthzOptions{Account: apub})
 	require_True(t, explicit.Status == "unavailable")
 	require_True(t, explicit.StatusCode == http.StatusServiceUnavailable)
+
+	// With details + stream, keep the expired-account error instead of a 404 for
+	// a stream that was never examined because the account was skipped.
+	detailed := s.healthz(&HealthzOptions{Account: apub, Stream: "TEST", Details: true})
+	require_True(t, detailed.Status == "error")
+	require_True(t, detailed.StatusCode == http.StatusServiceUnavailable)
+	require_True(t, len(detailed.Errors) == 1)
+	require_True(t, detailed.Errors[0].Type == HealthzErrorAccount)
 }
 
 func TestJetStreamJWTDeletedAccountDoesNotLeakSubscriptions(t *testing.T) {

--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1117,6 +1118,81 @@ func TestJetStreamJWTExpiredAccountWorksAfterExpirationUpdated(t *testing.T) {
 
 	_, err = js.Publish("foo", []byte("hello"))
 	require_NoError(t, err)
+}
+
+// TestJetStreamJWTHealthzIgnoresExpiredAccounts verifies that a general
+// healthz scan does not report unavailable solely because a JWT account with
+// JetStream assets has expired (issue #8084).
+func TestJetStreamJWTHealthzIgnoresExpiredAccounts(t *testing.T) {
+	sysKp, spub := createKey(t)
+	sysClaim := jwt.NewAccountClaims(spub)
+	sysClaim.Name = "$SYS"
+	sysJwt, err := sysClaim.Encode(oKp)
+	require_NoError(t, err)
+	sysCreds := newUser(t, sysKp)
+
+	akp, apub := createKey(t)
+	accClaim := jwt.NewAccountClaims(apub)
+	accClaim.Name = "TEST"
+	accClaim.Limits.JetStreamLimits = jwt.JetStreamLimits{MemoryStorage: 1024 * 1024, DiskStorage: 2048 * 1024, Streams: 1}
+	accJwt, err := accClaim.Encode(oKp)
+	require_NoError(t, err)
+
+	dirSrv := filepath.ToSlash(t.TempDir())
+	dir := filepath.ToSlash(t.TempDir())
+	conf := createConfFile(t, []byte(fmt.Sprintf(`
+				listen: 127.0.0.1:-1
+				jetstream: {max_mem_store: 10Mb, max_file_store: 10Mb, store_dir: "%s"}
+				operator: %s
+				system_account: %s
+				resolver: {
+					type: full
+					allow_delete: true
+					dir: '%s'
+				}
+			`, dirSrv, ojwt, spub, dir)))
+	defer removeFile(t, conf)
+
+	s, _ := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	updateJwt(t, s.ClientURL(), sysCreds, sysJwt, 1)
+	updateJwt(t, s.ClientURL(), sysCreds, accJwt, 1)
+
+	userCreds := newUser(t, akp)
+	nc, js := jsClientConnect(t, s, nats.UserCredentials(userCreds), nats.NoReconnect())
+	defer nc.Close()
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+	})
+	require_NoError(t, err)
+	nc.Close()
+
+	// Expire the account and wait until LookupAccount sees it as expired.
+	expires := time.Now().Add(2 * time.Second)
+	accClaim.Expires = expires.Unix()
+	accJwt = encodeClaim(t, accClaim, apub)
+	updateJwt(t, s.ClientURL(), sysCreds, accJwt, 1)
+
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		acc, err := s.LookupAccount(apub)
+		if err != nil {
+			if errors.Is(err, ErrAccountExpired) {
+				return nil
+			}
+			return err
+		}
+		if acc.IsExpired() {
+			return nil
+		}
+		return fmt.Errorf("account %s not expired yet", apub)
+	})
+
+	status := s.healthz(nil)
+	require_True(t, status.Status == "ok")
+	require_True(t, status.StatusCode == http.StatusOK)
 }
 
 func TestJetStreamJWTDeletedAccountDoesNotLeakSubscriptions(t *testing.T) {

--- a/server/jetstream_jwt_test.go
+++ b/server/jetstream_jwt_test.go
@@ -1193,6 +1193,11 @@ func TestJetStreamJWTHealthzIgnoresExpiredAccounts(t *testing.T) {
 	status := s.healthz(nil)
 	require_True(t, status.Status == "ok")
 	require_True(t, status.StatusCode == http.StatusOK)
+
+	// Explicit account healthz must still report unavailable for an expired account.
+	explicit := s.healthz(&HealthzOptions{Account: apub})
+	require_True(t, explicit.Status == "unavailable")
+	require_True(t, explicit.StatusCode == http.StatusServiceUnavailable)
 }
 
 func TestJetStreamJWTDeletedAccountDoesNotLeakSubscriptions(t *testing.T) {

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3733,7 +3733,9 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 					Account: fi.Name(),
 					Error:   msg,
 				})
-				continue
+				// Return so later stream/consumer not-found checks do not
+				// replace this with a misleading 404 for assets we skipped.
+				return health
 			}
 			if err != nil {
 				if !details {
@@ -4054,7 +4056,8 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 				Account: accName,
 				Error:   msg,
 			})
-			continue
+			// Return so later health checks do not obscure the expired account.
+			return health
 		}
 		if err != nil && len(asa) > 0 {
 			if !details {

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -3716,9 +3716,23 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 			acc, err := s.LookupAccount(fi.Name())
 			// Expired accounts are not a JetStream health problem; skip them when
 			// scanning all accounts. Still surface an error if this account was
-			// explicitly requested.
+			// explicitly requested — including the err==nil + IsExpired() case.
 			expired := (err != nil && errors.Is(err, ErrAccountExpired)) || (err == nil && acc.IsExpired())
-			if expired && opts.Account == _EMPTY_ {
+			if expired {
+				if opts.Account == _EMPTY_ {
+					continue
+				}
+				msg := fmt.Sprintf("JetStream account '%s' is expired", fi.Name())
+				if !details {
+					health.Status = na
+					health.Error = msg
+					return health
+				}
+				health.Errors = append(health.Errors, HealthzError{
+					Type:    HealthzErrorAccount,
+					Account: fi.Name(),
+					Error:   msg,
+				})
 				continue
 			}
 			if err != nil {
@@ -4023,9 +4037,23 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 		acc, err := s.LookupAccount(accName)
 		// Expired accounts are not a JetStream health problem; skip them when
 		// scanning all accounts. Still surface an error if this account was
-		// explicitly requested.
+		// explicitly requested — including the err==nil + IsExpired() case.
 		expired := (err != nil && errors.Is(err, ErrAccountExpired)) || (err == nil && acc.IsExpired())
-		if len(asa) > 0 && expired && opts.Account == _EMPTY_ {
+		if expired {
+			if opts.Account == _EMPTY_ {
+				continue
+			}
+			msg := fmt.Sprintf("JetStream account %q is expired", accName)
+			if !details {
+				health.Status = na
+				health.Error = msg
+				return health
+			}
+			health.Errors = append(health.Errors, HealthzError{
+				Type:    HealthzErrorAccount,
+				Account: accName,
+				Error:   msg,
+			})
 			continue
 		}
 		if err != nil && len(asa) > 0 {

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"expvar"
 	"fmt"
 	"maps"
@@ -3713,6 +3714,13 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 				accFound = true
 			}
 			acc, err := s.LookupAccount(fi.Name())
+			// Expired accounts are not a JetStream health problem; skip them when
+			// scanning all accounts. Still surface an error if this account was
+			// explicitly requested.
+			expired := (err != nil && errors.Is(err, ErrAccountExpired)) || (err == nil && acc.IsExpired())
+			if expired && opts.Account == _EMPTY_ {
+				continue
+			}
 			if err != nil {
 				if !details {
 					health.Status = na
@@ -4013,6 +4021,13 @@ func (s *Server) healthz(opts *HealthzOptions) *HealthStatus {
 	// Use our copy to traverse so we do not need to hold the js lock.
 	for accName, asa := range streams {
 		acc, err := s.LookupAccount(accName)
+		// Expired accounts are not a JetStream health problem; skip them when
+		// scanning all accounts. Still surface an error if this account was
+		// explicitly requested.
+		expired := (err != nil && errors.Is(err, ErrAccountExpired)) || (err == nil && acc.IsExpired())
+		if len(asa) > 0 && expired && opts.Account == _EMPTY_ {
+			continue
+		}
 		if err != nil && len(asa) > 0 {
 			if !details {
 				health.Status = na


### PR DESCRIPTION
## Summary
- Do not mark `/healthz` unavailable when JetStream account lookup fails because a JWT account has expired
- Applies to both single-server store recovery and clustered stream assignment health checks
- Explicit `Account` healthz requests still surface expired-account errors
- Adds regression coverage in `TestJetStreamJWTHealthzIgnoresExpiredAccounts`

Fixes #8084

## Test plan
- [x] `go test ./server -run TestJetStreamJWTHealthzIgnoresExpiredAccounts -count=1`
- [ ] Confirm cluster `/healthz` remains OK when an expired JWT account still has JetStream assets