### PR TITLE
Fix filestore not releasing strong cache references correctly

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -3280,6 +3280,13 @@ func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, sseq uint64) (
 		}
 	}
 
+	needsCleanup := mb.cache == nil
+	defer func() {
+		if needsCleanup {
+			mb.finishedWithCache()
+		}
+	}()
+
 	if filter == _EMPTY_ {
 		filter, wc = fwcs, true
 	}
@@ -3359,7 +3366,6 @@ func (mb *msgBlock) filteredPendingLocked(filter string, wc bool, sseq uint64) (
 		}
 		shouldExpire = true
 	}
-	defer mb.finishedWithCache()
 
 	_tsa, _fsa := [32]string{}, [32]string{}
 	tsa, fsa := _tsa[:0], _fsa[:0]
@@ -3928,12 +3934,14 @@ func (fs *fileStore) MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed i
 				delete(subs, bytesToString(bsubj))
 			} else {
 				// Need to search for the real last since recorded last is > maxSeq.
-				var didLoad bool
+				needsCleanup := mb.cache == nil
 				if mb.cacheNotLoaded() {
 					if ierr = mb.loadMsgsWithLock(); ierr != nil {
+						if needsCleanup {
+							mb.finishedWithCache()
+						}
 						return false
 					}
-					didLoad = true
 				}
 				var smv StoreMsg
 				fseq := atomic.LoadUint64(&mb.first.seq)
@@ -3948,7 +3956,7 @@ func (fs *fileStore) MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed i
 					delete(subs, ssubj)
 					break
 				}
-				if didLoad {
+				if needsCleanup {
 					mb.finishedWithCache()
 				}
 			}
@@ -5447,10 +5455,14 @@ func (fs *fileStore) firstSeqForSubj(subj string) (uint64, error) {
 			fs.mu.Lock()
 			continue
 		}
+		needsCleanup := mb.cache == nil
 		var shouldExpire bool
 		if mb.fssNotLoaded() {
 			// Make sure we have fss loaded.
 			if err := mb.loadMsgsWithLock(); err != nil {
+				if needsCleanup {
+					mb.finishedWithCache()
+				}
 				mb.mu.Unlock()
 				// Re-acquire fs lock
 				fs.mu.Lock()
@@ -5485,7 +5497,7 @@ func (fs *fileStore) firstSeqForSubj(subj string) (uint64, error) {
 		if shouldExpire {
 			// Expire this cache before moving on.
 			mb.tryForceExpireCacheLocked()
-		} else {
+		} else if needsCleanup {
 			mb.finishedWithCache()
 		}
 		mb.mu.Unlock()
@@ -5819,16 +5831,18 @@ func (fs *fileStore) removeMsgFromBlock(mb *msgBlock, seq uint64, secure, viaLim
 	// We used to not have to load in the messages except with callbacks or the filtered subject state (which is now always on).
 	// Now just load regardless.
 	// TODO(dlc) - Figure out a way not to have to load it in, we need subject tracking outside main data block.
-	var didLoad bool
+	needsCleanup := mb.cache == nil
 	if mb.cacheNotLoaded() {
 		if err := mb.loadMsgsWithLock(); err != nil {
+			if needsCleanup {
+				mb.finishedWithCache()
+			}
 			mb.mu.Unlock()
 			return false, err
 		}
-		didLoad = true
 	}
 	finishedWithCache := func() {
-		if didLoad {
+		if needsCleanup {
 			mb.finishedWithCache()
 		}
 	}
@@ -9106,18 +9120,20 @@ func (fs *fileStore) loadLastLocked(subj string, sm *StoreMsg) (lsm *StoreMsg, e
 				return nil, err
 			}
 		}
-		var didLoad bool
+		needsCleanup := mb.cache == nil
 		if l > 0 {
 			if mb.cacheNotLoaded() {
 				if err := mb.loadMsgsWithLock(); err != nil {
+					if needsCleanup {
+						mb.finishedWithCache()
+					}
 					mb.mu.Unlock()
 					return nil, err
 				}
-				didLoad = true
 			}
 			lsm, err = mb.cacheLookup(l, sm)
 		}
-		if didLoad {
+		if needsCleanup {
 			mb.finishedWithCache()
 		}
 		mb.mu.Unlock()
@@ -11451,15 +11467,21 @@ func (mb *msgBlock) generatePerSubjectInfo() error {
 		return nil
 	}
 
+	needsCleanup := mb.cache == nil
 	if mb.cacheNotLoaded() {
 		if err := mb.loadMsgsWithLock(); err != nil {
+			if needsCleanup {
+				mb.finishedWithCache()
+			}
 			return err
 		}
-		// indexCacheBuf can produce fss now, so if non-nil we are good.
-		if mb.fss != nil {
-			return nil
-		}
+	}
+	if needsCleanup {
 		defer mb.finishedWithCache()
+	}
+	// indexCacheBuf can produce fss now, so if non-nil we are good.
+	if mb.fss != nil {
+		return nil
 	}
 
 	// Create new one regardless.

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1756,6 +1756,99 @@ func TestFileStoreReadCache(t *testing.T) {
 	})
 }
 
+func TestFileStoreWeakCachePromotionCleanup(t *testing.T) {
+	newTestStore := func(t *testing.T) (*fileStore, *msgBlock, *cache) {
+		t.Helper()
+		fs, err := newFileStore(
+			FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 8192},
+			StreamConfig{Name: "zzz", Storage: FileStorage, Subjects: []string{"foo", "bar"}},
+		)
+		require_NoError(t, err)
+		t.Cleanup(func() { fs.Stop() })
+
+		for i := 0; i < 4; i++ {
+			_, _, err = fs.StoreMsg("foo", nil, []byte("hello"), 0)
+			require_NoError(t, err)
+		}
+		_, _, err = fs.StoreMsg("bar", nil, []byte("hello"), 0)
+		require_NoError(t, err)
+		require_NoError(t, fs.FlushAllPending())
+
+		fs.mu.Lock()
+		defer fs.mu.Unlock()
+
+		mb := fs.lmb
+		mb.mu.Lock()
+		defer mb.mu.Unlock()
+
+		require_NoError(t, mb.loadMsgsWithLock())
+		require_NotNil(t, mb.cache)
+		c := mb.cache
+		mb.ecache.Set(c)
+		mb.ecache.Weaken()
+		mb.cache = nil
+		mb.fss = nil
+		if info, ok := fs.psim.Find(stringToBytes("foo")); ok {
+			info.fblk, info.lblk = mb.index, mb.index
+		}
+		if info, ok := fs.psim.Find(stringToBytes("bar")); ok {
+			info.fblk, info.lblk = mb.index, mb.index
+		}
+		require_NotNil(t, mb.ecache.Value())
+
+		return fs, mb, c
+	}
+
+	require_NoStrongCache := func(t *testing.T, mb *msgBlock, c *cache) {
+		t.Helper()
+		require_True(t, mb.cache == nil)
+		require_True(t, mb.ecache.Value() == c)
+		runtime.KeepAlive(c)
+	}
+
+	t.Run("removeMsgFromBlock", func(t *testing.T) {
+		fs, mb, c := newTestStore(t)
+		removed, err := fs.removeMsg(2, false, true, true)
+		require_NoError(t, err)
+		require_True(t, removed)
+		mb.mu.Lock()
+		defer mb.mu.Unlock()
+		require_NoStrongCache(t, mb, c)
+	})
+
+	t.Run("generatePerSubjectInfo", func(t *testing.T) {
+		_, mb, c := newTestStore(t)
+		mb.mu.Lock()
+		defer mb.mu.Unlock()
+		require_NoError(t, mb.generatePerSubjectInfo())
+		require_NotNil(t, mb.fss)
+		require_NoStrongCache(t, mb, c)
+	})
+
+	t.Run("filteredPending", func(t *testing.T) {
+		_, mb, c := newTestStore(t)
+		total, first, last, err := mb.filteredPending("foo", false, 1)
+		require_NoError(t, err)
+		require_Equal(t, total, uint64(4))
+		require_Equal(t, first, uint64(1))
+		require_Equal(t, last, uint64(4))
+		mb.mu.Lock()
+		defer mb.mu.Unlock()
+		require_NoStrongCache(t, mb, c)
+	})
+
+	t.Run("loadLast", func(t *testing.T) {
+		fs, mb, c := newTestStore(t)
+		sm, err := fs.loadLast("foo", nil)
+		require_NoError(t, err)
+		require_NotNil(t, sm)
+		require_Equal(t, sm.seq, uint64(4))
+		mb.mu.Lock()
+		defer mb.mu.Unlock()
+		require_NoStrongCache(t, mb, c)
+	})
+}
+
 func TestFileStorePartialCacheExpiration(t *testing.T) {
 	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
 		cexp := 10 * time.Millisecond


### PR DESCRIPTION
In some cases, we weren't correctly releasing strong filestore block cache pointers back to weak status, which meant that the server could hold onto them for longer than intended under certain usage patterns. This would push up memory usage and, in the worst case, push up against the GC.