### PR TITLE
ci: pin goreleaser/goreleaser-action@v7 to a full commit SHA (match repo's re-tagging-attack convention)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
           syft-version: "v1.42.3"
 
       - name: Create release
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
Hi, and thank you for NATS.

Small consistency fix in `.github/workflows/release.yaml`. The release job already SHA-pins its other third-party actions with an explicit note:

```
# Use commit hash here to avoid a re-tagging attack, as this is a third-party action
uses: sigstore/cosign-installer@6f9f177...
# Use commit hash here to avoid a re-tagging attack, as this is a third-party action
uses: anchore/sbom-action/download-syft@e22c389...
```

But `goreleaser/goreleaser-action@v7` (line 47) — which runs in the *same* job holding `contents: write` and the release `GITHUB_TOKEN`, and publishes the release artifacts — was left on the mutable `@v7` tag. That's exactly the re-tagging-attack vector your own comment guards against, on the action with the most reach.

This PR pins it to the commit `@v7` currently resolves to (`f06c13b`), matching the convention two lines above. Behaviour is unchanged.

For transparency: I used AI assistance to help identify this and draft the change; I verified the workflow and the tag resolution myself.
