### PR TITLE
(2.15) [IMPROVED] Source stream recreation detection

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -6304,13 +6304,11 @@ func (o *consumer) selectStartingSeqNo() error {
 			o.sseq = o.cfg.OptStartSeq
 		}
 
-		if state.FirstSeq == 0 && (o.cfg.Direct || o.cfg.OptStartSeq == 0) {
+		if state.FirstSeq == 0 && o.cfg.OptStartSeq == 0 {
 			// If the stream is empty, deliver only new.
-			// But only if mirroring/sourcing, or start seq is unset, otherwise need to respect provided value.
 			o.sseq = 1
-		} else if o.sseq > state.LastSeq && (o.cfg.Direct || o.cfg.OptStartSeq == 0) {
+		} else if o.sseq > state.LastSeq && o.cfg.OptStartSeq == 0 {
 			// If selected sequence is in the future, clamp back down.
-			// But only if mirroring/sourcing, or start seq is unset, otherwise need to respect provided value.
 			o.sseq = state.LastSeq + 1
 		} else if o.sseq < state.FirstSeq {
 			// If the first sequence is further ahead than the starting sequence,

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -152,6 +152,9 @@ type CreateConsumerRequest struct {
 	Config   ConsumerConfig `json:"config"`
 	Action   ConsumerAction `json:"action"`
 	Pedantic bool           `json:"pedantic,omitempty"`
+
+	// Consumer is rejected if the stream identity does not match.
+	StreamIdentity string `json:"stream_identity,omitempty"`
 }
 
 type ConsumerAction int
@@ -4546,6 +4549,7 @@ func (o *consumer) processResetReq(_ *subscription, c *client, a *Account, _, re
 	} else if canRespond {
 		resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
 		resp.ResetSeq = resetSeq
+		resp.StreamIdentity = o.streamIdentity()
 		s.sendInternalAccountMsg(a, reply, s.jsonResponse(&resp))
 	}
 }
@@ -6417,6 +6421,18 @@ func (o *consumer) streamName() string {
 	o.mu.RUnlock()
 	if mset != nil {
 		return mset.name()
+	}
+	return _EMPTY_
+}
+
+// streamIdentity returns the identity of the consumer's stream, which changes
+// if the stream is recreated. Returns empty if the stream is not available.
+func (o *consumer) streamIdentity() string {
+	o.mu.RLock()
+	mset := o.mset
+	o.mu.RUnlock()
+	if mset != nil {
+		return mset.identity()
 	}
 	return _EMPTY_
 }

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -6326,13 +6326,11 @@ func (o *consumer) selectStartingSeqNo() error {
 			o.sseq = o.cfg.OptStartSeq
 		}
 
-		if state.FirstSeq == 0 && (o.cfg.Direct || o.cfg.OptStartSeq == 0) {
+		if state.FirstSeq == 0 && o.cfg.OptStartSeq == 0 {
 			// If the stream is empty, deliver only new.
-			// But only if mirroring/sourcing, or start seq is unset, otherwise need to respect provided value.
 			o.sseq = 1
-		} else if o.sseq > state.LastSeq && (o.cfg.Direct || o.cfg.OptStartSeq == 0) {
+		} else if o.sseq > state.LastSeq && o.cfg.OptStartSeq == 0 {
 			// If selected sequence is in the future, clamp back down.
-			// But only if mirroring/sourcing, or start seq is unset, otherwise need to respect provided value.
 			o.sseq = state.LastSeq + 1
 		} else if o.sseq < state.FirstSeq {
 			// If the first sequence is further ahead than the starting sequence,

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -507,7 +507,7 @@ type consumer struct {
 	infoSub   *subscription
 	lqsent    time.Time
 	prm       map[string]struct{}
-	rsm       map[string]bool // Reset requests that need to be responded to on the internal sys account (if true).
+	rsm       map[string]resetRequest // Reset requests that need to be responded to.
 	prOk      bool
 	uch       chan struct{}
 	retention RetentionPolicy
@@ -1434,7 +1434,7 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 	mset.mu.Unlock()
 
 	if config.Sourcing && standalone {
-		o.resetStartingSeq(0, _EMPTY_, false)
+		o.resetStartingSeq(0, _EMPTY_, false, false)
 	}
 	if config.Direct || standalone {
 		o.setLeader(true, 0)
@@ -2657,7 +2657,7 @@ func (o *consumer) updateConfig(cfg *ConsumerConfig) error {
 	o.cfg = *cfg
 
 	if cfg.Sourcing && (!o.srv.JetStreamIsClustered() && o.srv.standAloneMode()) {
-		o.resetStartingSeqLocked(0, _EMPTY_, false)
+		o.resetStartingSeqLocked(0, _EMPTY_, false, false)
 	}
 	if updatedFilters {
 		// Cleanup messages that lost interest.
@@ -2828,14 +2828,21 @@ func (o *consumer) updateSkipped(seq uint64) {
 	o.propose(b[:])
 }
 
-func (o *consumer) resetStartingSeq(seq uint64, reply string, internal bool) (uint64, bool, error) {
+// resetRequest tracks a reset request that still needs to be responded to
+// once the reset has been applied.
+type resetRequest struct {
+	internal bool // Respond on the internal sys account.
+	identity bool // Include the stream identity header in the response.
+}
+
+func (o *consumer) resetStartingSeq(seq uint64, reply string, internal, identity bool) (uint64, bool, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	return o.resetStartingSeqLocked(seq, reply, internal)
+	return o.resetStartingSeqLocked(seq, reply, internal, identity)
 }
 
 // Lock should be held.
-func (o *consumer) resetStartingSeqLocked(seq uint64, reply string, internal bool) (uint64, bool, error) {
+func (o *consumer) resetStartingSeqLocked(seq uint64, reply string, internal, identity bool) (uint64, bool, error) {
 	// Reset to a specific sequence, or back to the ack floor.
 	if seq == 0 {
 		seq = o.asflr + 1
@@ -2877,9 +2884,9 @@ VALID:
 		o.propose(b[:])
 		if reply != _EMPTY_ {
 			if o.rsm == nil {
-				o.rsm = make(map[string]bool, 1)
+				o.rsm = make(map[string]resetRequest, 1)
 			}
-			o.rsm[reply] = internal
+			o.rsm[reply] = resetRequest{internal: internal, identity: identity}
 		}
 		return seq, false, nil
 	}
@@ -4537,6 +4544,13 @@ func (o *consumer) processResetReq(_ *subscription, c *client, a *Account, _, re
 		return
 	}
 
+	// If the user provided an expected stream identity.
+	// We don't reject the request, we only populate the identity in the response.
+	var streamIdentity string
+	if sliceHeader(JSStreamIdentity, hdr) != nil {
+		streamIdentity = o.streamIdentity()
+	}
+
 	// An empty message resets back to the ack floor, otherwise a custom sequence can be used.
 	var req JSApiConsumerResetRequest
 	if len(msg) > 0 {
@@ -4546,14 +4560,19 @@ func (o *consumer) processResetReq(_ *subscription, c *client, a *Account, _, re
 			return
 		}
 	}
-	resetSeq, canRespond, err := o.resetStartingSeq(req.Seq, reply, false)
+	resetSeq, canRespond, err := o.resetStartingSeq(req.Seq, reply, false, streamIdentity != _EMPTY_)
 	if err != nil {
 		resp.Error = NewJSConsumerInvalidResetError(err)
 		s.sendInternalAccountMsg(a, reply, s.jsonResponse(&resp))
 	} else if canRespond {
 		resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
 		resp.ResetSeq = resetSeq
-		s.sendInternalAccountMsg(a, reply, s.jsonResponse(&resp))
+		if streamIdentity != _EMPTY_ {
+			rhdr := genHeader(nil, JSStreamIdentity, streamIdentity)
+			s.sendInternalAccountMsgWithReply(a, reply, _EMPTY_, rhdr, s.jsonResponse(&resp), false)
+		} else {
+			s.sendInternalAccountMsg(a, reply, s.jsonResponse(&resp))
+		}
 	}
 }
 
@@ -6424,6 +6443,18 @@ func (o *consumer) streamName() string {
 	o.mu.RUnlock()
 	if mset != nil {
 		return mset.name()
+	}
+	return _EMPTY_
+}
+
+// streamIdentity returns the identity of the consumer's stream, which changes
+// if the stream is recreated. Returns empty if the stream is not available.
+func (o *consumer) streamIdentity() string {
+	o.mu.RLock()
+	mset := o.mset
+	o.mu.RUnlock()
+	if mset != nil {
+		return mset.identity()
 	}
 	return _EMPTY_
 }

--- a/server/errors.json
+++ b/server/errors.json
@@ -2218,5 +2218,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerStreamIdentityMismatchF",
+    "code": 400,
+    "error_code": 10224,
+    "description": "consumer's stream identity does not match: {msg}",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/errors.json
+++ b/server/errors.json
@@ -2228,5 +2228,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSConsumerStreamIdentityMismatchF",
+    "code": 400,
+    "error_code": 10225,
+    "description": "consumer's stream identity does not match: {msg}",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -707,6 +707,7 @@ const JSWaitQueueDefaultMax = 512
 type JSApiConsumerCreateResponse struct {
 	ApiResponse
 	*ConsumerInfo
+	StreamIdentity string `json:"stream_identity,omitempty"`
 }
 
 const JSApiConsumerCreateResponseType = "io.nats.jetstream.api.v1.consumer_create_response"
@@ -779,7 +780,8 @@ type JSApiConsumerResetRequest struct {
 type JSApiConsumerResetResponse struct {
 	ApiResponse
 	*ConsumerInfo
-	ResetSeq uint64 `json:"reset_seq"`
+	ResetSeq       uint64 `json:"reset_seq"`
+	StreamIdentity string `json:"stream_identity,omitempty"`
 }
 
 const JSApiConsumerResetResponseType = "io.nats.jetstream.api.v1.consumer_reset_response"
@@ -4573,7 +4575,7 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 	}
 
 	if isClustered && !direct {
-		s.jsClusteredConsumerRequest(ci, acc, subject, reply, rmsg, req.Stream, &req.Config, req.Action, req.Pedantic)
+		s.jsClusteredConsumerRequest(ci, acc, subject, reply, rmsg, &req)
 		return
 	}
 
@@ -4593,6 +4595,14 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 	if stream.offlineReason != _EMPTY_ {
 		resp.Error = NewJSStreamOfflineReasonError(errors.New(stream.offlineReason))
 		s.sendDelayedAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp), nil, errRespDelay)
+		return
+	}
+
+	// If the user provided an expected stream identity, reject the request on a mismatch.
+	streamIdentity := stream.identity()
+	if req.StreamIdentity != _EMPTY_ && req.StreamIdentity != streamIdentity {
+		resp.Error = NewJSConsumerStreamIdentityMismatchError(streamIdentity)
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
 
@@ -4648,6 +4658,7 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 		return
 	}
 	resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.initialInfo())
+	resp.StreamIdentity = streamIdentity
 	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 
 	o.mu.RLock()

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -330,6 +330,10 @@ const (
 const (
 	// JSRequiredApiLevel requires the API level of the responding server to have the specified minimum value.
 	JSRequiredApiLevel = "Nats-Required-Api-Level"
+
+	// JSStreamIdentity is the stream's identity used to reject consumer create on a mismatch, and return
+	// the stream identity in the consumer create/reset responses.
+	JSStreamIdentity = "Nats-Stream-Identity"
 )
 
 var denyAllClientJs = []string{jsAllAPI, "$KV.>", "$OBJ.>"}
@@ -1068,6 +1072,14 @@ func (s *Server) sendAPIResponse(ci *ClientInfo, acc *Account, subject, reply, r
 	acc.trackAPI()
 	if reply != _EMPTY_ {
 		s.sendInternalAccountMsg(nil, reply, response)
+	}
+	s.sendJetStreamAPIAuditAdvisory(ci, acc, subject, request, response)
+}
+
+func (s *Server) sendAPIHdrResponse(ci *ClientInfo, acc *Account, subject, reply, request string, hdr []byte, response string) {
+	acc.trackAPI()
+	if reply != _EMPTY_ {
+		s.sendInternalAccountMsgWithReply(nil, reply, _EMPTY_, hdr, response, false)
 	}
 	s.sendJetStreamAPIAuditAdvisory(ci, acc, subject, request, response)
 }
@@ -4692,7 +4704,7 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 	}
 
 	if isClustered && !direct {
-		s.jsClusteredConsumerRequest(ci, acc, subject, reply, rmsg, req.Stream, &req.Config, req.Action, req.Pedantic)
+		s.jsClusteredConsumerRequest(ci, acc, subject, reply, hdr, msg, &req)
 		return
 	}
 
@@ -4732,6 +4744,17 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 		}
 	}
 
+	// If the user provided an expected stream identity, reject the request on a mismatch.
+	var streamIdentity string
+	if req.Config.Direct || req.Config.Sourcing {
+		streamIdentity = stream.identity()
+		if reqIdentity := sliceHeader(JSStreamIdentity, hdr); len(reqIdentity) > 0 && bytesToString(reqIdentity) != streamIdentity {
+			resp.Error = NewJSConsumerStreamIdentityMismatchError(streamIdentity)
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+			return
+		}
+	}
+
 	if o := stream.lookupConsumer(consumerName); o != nil {
 		if o.offlineReason != _EMPTY_ {
 			resp.Error = NewJSConsumerOfflineReasonError(errors.New(o.offlineReason))
@@ -4767,7 +4790,12 @@ func (s *Server) jsConsumerCreateRequest(sub *subscription, c *client, a *Accoun
 		return
 	}
 	resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.initialInfo())
-	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+	if streamIdentity != _EMPTY_ {
+		rhdr := genHeader(nil, JSStreamIdentity, streamIdentity)
+		s.sendAPIHdrResponse(ci, acc, subject, reply, string(msg), rhdr, s.jsonResponse(resp))
+	} else {
+		s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
+	}
 
 	o.mu.RLock()
 	if o.cfg.PauseUntil != nil && !o.cfg.PauseUntil.IsZero() && time.Now().Before(*o.cfg.PauseUntil) {

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -694,12 +694,14 @@ func TestJetStreamAtomicBatchPublishSourceAndMirror(t *testing.T) {
 		rsm, err = js.GetMsg("S", 1)
 		require_NoError(t, err)
 		require_Len(t, len(rsm.Header), 1)
-		require_Equal(t, rsm.Header.Get(JSStreamSource), "TEST 1 > > foo")
+		src := rsm.Header.Get(JSStreamSource)
+		require_True(t, strings.HasPrefix(src, "TEST 1 > > foo"))
 
 		rsm, err = js.GetMsg("S", 2)
 		require_NoError(t, err)
 		require_Len(t, len(rsm.Header), 1)
-		require_Equal(t, rsm.Header.Get(JSStreamSource), "TEST 3 > > foo")
+		src = rsm.Header.Get(JSStreamSource)
+		require_True(t, strings.HasPrefix(src, "TEST 3 > > foo"))
 	}
 
 	t.Run("R1", func(t *testing.T) { test(t, 1) })
@@ -4025,12 +4027,14 @@ func TestJetStreamFastBatchPublishSourceAndMirror(t *testing.T) {
 		rsm, err = js.GetMsg("S", 1)
 		require_NoError(t, err)
 		require_Len(t, len(rsm.Header), 1)
-		require_Equal(t, rsm.Header.Get(JSStreamSource), "TEST 1 > > foo")
+		src := rsm.Header.Get(JSStreamSource)
+		require_True(t, strings.HasPrefix(src, "TEST 1 > > foo"))
 
 		rsm, err = js.GetMsg("S", 2)
 		require_NoError(t, err)
 		require_Len(t, len(rsm.Header), 1)
-		require_Equal(t, rsm.Header.Get(JSStreamSource), "TEST 3 > > foo")
+		src = rsm.Header.Get(JSStreamSource)
+		require_True(t, strings.HasPrefix(src, "TEST 3 > > foo"))
 	}
 
 	t.Run("R1", func(t *testing.T) { test(t, 1) })

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -694,12 +694,14 @@ func TestJetStreamAtomicBatchPublishSourceAndMirror(t *testing.T) {
 		rsm, err = js.GetMsg("S", 1)
 		require_NoError(t, err)
 		require_Len(t, len(rsm.Header), 1)
-		require_Equal(t, rsm.Header.Get(JSStreamSource), "TEST 1 > > foo")
+		src := rsm.Header.Get(JSStreamSource)
+		require_True(t, strings.HasPrefix(src, "TEST 1 > > foo"))
 
 		rsm, err = js.GetMsg("S", 2)
 		require_NoError(t, err)
 		require_Len(t, len(rsm.Header), 1)
-		require_Equal(t, rsm.Header.Get(JSStreamSource), "TEST 3 > > foo")
+		src = rsm.Header.Get(JSStreamSource)
+		require_True(t, strings.HasPrefix(src, "TEST 3 > > foo"))
 	}
 
 	t.Run("R1", func(t *testing.T) { test(t, 1) })
@@ -4117,12 +4119,14 @@ func TestJetStreamFastBatchPublishSourceAndMirror(t *testing.T) {
 		rsm, err = js.GetMsg("S", 1)
 		require_NoError(t, err)
 		require_Len(t, len(rsm.Header), 1)
-		require_Equal(t, rsm.Header.Get(JSStreamSource), "TEST 1 > > foo")
+		src := rsm.Header.Get(JSStreamSource)
+		require_True(t, strings.HasPrefix(src, "TEST 1 > > foo"))
 
 		rsm, err = js.GetMsg("S", 2)
 		require_NoError(t, err)
 		require_Len(t, len(rsm.Header), 1)
-		require_Equal(t, rsm.Header.Get(JSStreamSource), "TEST 3 > > foo")
+		src = rsm.Header.Get(JSStreamSource)
+		require_True(t, strings.HasPrefix(src, "TEST 3 > > foo"))
 	}
 
 	t.Run("R1", func(t *testing.T) { test(t, 1) })

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -6253,6 +6253,7 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 								s.sendAPIErrResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
 							} else {
 								resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
+								resp.StreamIdentity = mset.identity()
 								s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
 							}
 						},
@@ -6338,11 +6339,13 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 							} else if canRespond {
 								resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
 								resp.ResetSeq = resetSeq
+								resp.StreamIdentity = mset.identity()
 								s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
 							}
 						} else {
 							var resp = JSApiConsumerCreateResponse{ApiResponse: ApiResponse{Type: JSApiConsumerCreateResponseType}}
 							resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
+							resp.StreamIdentity = mset.identity()
 							s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
 						}
 					}
@@ -7079,6 +7082,7 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 						var resp = JSApiConsumerResetResponse{ApiResponse: ApiResponse{Type: JSApiConsumerResetResponseType}}
 						resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
 						resp.ResetSeq = sseq
+						resp.StreamIdentity = o.streamIdentity()
 						s.sendInternalAccountMsg(a, reply, s.jsonResponse(&resp))
 					}
 				}
@@ -7291,10 +7295,12 @@ func (js *jetStream) processConsumerLeaderChangeWithAssignment(o *consumer, ca *
 			} else if canRespond {
 				rresp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
 				rresp.ResetSeq = resetSeq
+				rresp.StreamIdentity = o.streamIdentity()
 				s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&rresp))
 			}
 		} else {
 			resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.initialInfo())
+			resp.StreamIdentity = o.streamIdentity()
 			s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
 		}
 		o.sendCreateAdvisory()
@@ -9529,11 +9535,13 @@ func (cc *jetStreamCluster) createGroupForConsumer(cfg *ConsumerConfig, sa *stre
 }
 
 // jsClusteredConsumerRequest is first point of entry to create a consumer in clustered mode.
-func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subject, reply string, rmsg []byte, stream string, cfg *ConsumerConfig, action ConsumerAction, pedantic bool) {
+func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subject, reply string, rmsg []byte, req *CreateConsumerRequest) {
 	js, cc := s.getJetStreamCluster()
 	if js == nil || cc == nil {
 		return
 	}
+
+	stream, cfg, action, pedantic := req.Stream, &req.Config, req.Action, req.Pedantic
 
 	// If the consumer is a direct sourcing consumer, we need to "upgrade" it to be durable without AckNone.
 	// We only get here if the stream is not Limits-based.
@@ -9585,6 +9593,14 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 	sa := js.streamAssignmentOrInflight(acc.Name, stream)
 	if sa == nil {
 		resp.Error = NewJSStreamNotFoundError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+		return
+	}
+
+	// If the user provided an expected stream identity, reject the request on a mismatch.
+	streamIdentity := sa.identity()
+	if req.StreamIdentity != _EMPTY_ && req.StreamIdentity != streamIdentity {
+		resp.Error = NewJSConsumerStreamIdentityMismatchError(streamIdentity)
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return
 	}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -6284,7 +6284,12 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 								s.sendAPIErrResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
 							} else {
 								resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
-								s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+								if resp.Config.Direct || resp.Config.Sourcing {
+									rhdr := genHeader(nil, JSStreamIdentity, mset.identity())
+									s.sendAPIHdrResponse(client, acc, subject, reply, _EMPTY_, rhdr, s.jsonResponse(&resp))
+								} else {
+									s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+								}
 							}
 						},
 						pprofLabels{
@@ -6362,19 +6367,25 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 						// If it's a sourcing consumer, we need to respond after the consumer has been reset instead.
 						if sourcing {
 							var resp = JSApiConsumerResetResponse{ApiResponse: ApiResponse{Type: JSApiConsumerResetResponseType}}
-							resetSeq, canRespond, err := o.resetStartingSeq(0, reply, true)
+							resetSeq, canRespond, err := o.resetStartingSeq(0, reply, true, true)
 							if err != nil {
 								resp.Error = NewJSConsumerInvalidResetError(err)
 								s.sendAPIErrResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
 							} else if canRespond {
 								resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
 								resp.ResetSeq = resetSeq
-								s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+								rhdr := genHeader(nil, JSStreamIdentity, mset.identity())
+								s.sendAPIHdrResponse(client, acc, subject, reply, _EMPTY_, rhdr, s.jsonResponse(&resp))
 							}
 						} else {
 							var resp = JSApiConsumerCreateResponse{ApiResponse: ApiResponse{Type: JSApiConsumerCreateResponseType}}
 							resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
-							s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+							if resp.Config.Direct || resp.Config.Sourcing {
+								rhdr := genHeader(nil, JSStreamIdentity, mset.identity())
+								s.sendAPIHdrResponse(client, acc, subject, reply, _EMPTY_, rhdr, s.jsonResponse(&resp))
+							} else {
+								s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+							}
 						}
 					}
 				}
@@ -7097,7 +7108,7 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 					s, a := o.srv, o.acc
 					if reply == _EMPTY_ {
 						o.mu.Unlock()
-					} else if internal, ok := o.rsm[reply]; !ok {
+					} else if rr, ok := o.rsm[reply]; !ok {
 						o.mu.Unlock()
 					} else {
 						delete(o.rsm, reply)
@@ -7105,13 +7116,18 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 
 						// Check if the reset request needs to be answered on the system account.
 						// This will happen for replicated sourcing consumers that get reset as part of a create/update.
-						if internal {
+						if rr.internal {
 							a = nil
 						}
 						var resp = JSApiConsumerResetResponse{ApiResponse: ApiResponse{Type: JSApiConsumerResetResponseType}}
 						resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
 						resp.ResetSeq = sseq
-						s.sendInternalAccountMsg(a, reply, s.jsonResponse(&resp))
+						if rr.identity {
+							rhdr := genHeader(nil, JSStreamIdentity, o.streamIdentity())
+							s.sendInternalAccountMsgWithReply(a, reply, _EMPTY_, rhdr, s.jsonResponse(&resp), false)
+						} else {
+							s.sendInternalAccountMsg(a, reply, s.jsonResponse(&resp))
+						}
 					}
 				}
 			case addPendingRequest:
@@ -7321,18 +7337,24 @@ func (js *jetStream) processConsumerLeaderChangeWithAssignment(o *consumer, ca *
 		// If it's a sourcing consumer, we need to respond after the consumer has been reset instead.
 		if sourcing {
 			var rresp = JSApiConsumerResetResponse{ApiResponse: ApiResponse{Type: JSApiConsumerResetResponseType}}
-			resetSeq, canRespond, err := o.resetStartingSeq(0, reply, true)
+			resetSeq, canRespond, err := o.resetStartingSeq(0, reply, true, true)
 			if err != nil {
 				rresp.Error = NewJSConsumerInvalidResetError(err)
 				s.sendAPIErrResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&rresp))
 			} else if canRespond {
 				rresp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
 				rresp.ResetSeq = resetSeq
-				s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&rresp))
+				rhdr := genHeader(nil, JSStreamIdentity, o.streamIdentity())
+				s.sendAPIHdrResponse(client, acc, subject, reply, _EMPTY_, rhdr, s.jsonResponse(&rresp))
 			}
 		} else {
 			resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.initialInfo())
-			s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+			if resp.Config.Direct || resp.Config.Sourcing {
+				rhdr := genHeader(nil, JSStreamIdentity, o.streamIdentity())
+				s.sendAPIHdrResponse(client, acc, subject, reply, _EMPTY_, rhdr, s.jsonResponse(&resp))
+			} else {
+				s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
+			}
 		}
 		o.sendCreateAdvisory()
 	}
@@ -9570,11 +9592,13 @@ func (cc *jetStreamCluster) createGroupForConsumer(cfg *ConsumerConfig, sa *stre
 }
 
 // jsClusteredConsumerRequest is first point of entry to create a consumer in clustered mode.
-func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subject, reply string, rmsg []byte, stream string, cfg *ConsumerConfig, action ConsumerAction, pedantic bool) {
+func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subject, reply string, hdr, msg []byte, req *CreateConsumerRequest) {
 	js, cc := s.getJetStreamCluster()
 	if js == nil || cc == nil {
 		return
 	}
+
+	stream, cfg, action, pedantic := req.Stream, &req.Config, req.Action, req.Pedantic
 
 	// If the consumer is a direct sourcing consumer, we need to "upgrade" it to be durable without AckNone.
 	// We only get here if the stream is not Limits-based.
@@ -9592,26 +9616,26 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 	streamCfg, ok := js.clusterStreamConfig(acc.Name, stream)
 	if !ok {
 		resp.Error = NewJSStreamNotFoundError()
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
 	selectedLimits, _, _, apiErr := acc.selectLimits(cfg.replicas(&streamCfg))
 	if apiErr != nil {
 		resp.Error = apiErr
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
 	srvLim := &s.getOpts().JetStreamLimits
 	// Make sure we have sane defaults
 	if err := setConsumerConfigDefaults(cfg, &streamCfg, srvLim, selectedLimits, pedantic); err != nil {
 		resp.Error = err
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
 
 	if err := checkConsumerCfg(cfg, srvLim, &streamCfg, acc, selectedLimits, false); err != nil {
 		resp.Error = err
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
 
@@ -9626,8 +9650,19 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 	sa := js.streamAssignmentOrInflight(acc.Name, stream)
 	if sa == nil {
 		resp.Error = NewJSStreamNotFoundError()
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
+	}
+
+	// If the user provided an expected stream identity, reject the request on a mismatch.
+	var streamIdentity string
+	if req.Config.Direct || req.Config.Sourcing {
+		streamIdentity = sa.identity()
+		if reqIdentity := sliceHeader(JSStreamIdentity, hdr); len(reqIdentity) > 0 && bytesToString(reqIdentity) != streamIdentity {
+			resp.Error = NewJSConsumerStreamIdentityMismatchError(streamIdentity)
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+			return
+		}
 	}
 
 	// Was a consumer name provided?
@@ -9665,7 +9700,7 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 				}
 				if total >= maxc {
 					resp.Error = NewJSMaximumConsumersLimitError()
-					s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+					s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 					return
 				}
 			}
@@ -9676,7 +9711,7 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 	if cfg.DeliverPolicy == DeliverLastPerSubject {
 		if cfg.FilterSubject == _EMPTY_ && len(cfg.FilterSubjects) == 0 {
 			resp.Error = NewJSConsumerInvalidPolicyError(fmt.Errorf("consumer delivery policy is deliver last per subject, but FilterSubject is not set"))
-			s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
 	}
@@ -9715,19 +9750,19 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 
 			if action == ActionCreate && !reflect.DeepEqual(cfg, ca.Config) {
 				resp.Error = NewJSConsumerAlreadyExistsError()
-				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+				s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 				return
 			}
 			// Do quick sanity check on new cfg to prevent here if possible.
 			if err := acc.checkNewConsumerConfig(ca.Config, cfg); err != nil {
 				resp.Error = NewJSConsumerCreateError(err, Unless(err))
-				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+				s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 				return
 			}
 			// Don't allow updating if all peers are offline.
 			if s.allPeersOffline(ca.Group) {
 				resp.Error = NewJSConsumerOfflineError()
-				s.sendDelayedAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp), nil, errRespDelay)
+				s.sendDelayedAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp), nil, errRespDelay)
 				return
 			}
 		} else {
@@ -9748,13 +9783,13 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 	if ca == nil {
 		if action == ActionUpdate {
 			resp.Error = NewJSConsumerDoesNotExistError()
-			s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
 		rg, err := cc.createGroupForConsumer(cfg, sa)
 		if err != nil {
 			resp.Error = NewJSInsufficientResourcesError()
-			s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
 		// Pick a preferred leader.
@@ -9785,7 +9820,7 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 						ni := ni.(nodeInfo)
 						if stats := ni.stats; stats != nil && stats.HAAssets > maxHaAssets {
 							resp.Error = NewJSInsufficientResourcesError()
-							s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+							s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 							s.Warnf("%s@%s (HA Asset Count: %d) exceeds max ha asset limit of %d"+
 								" for (durable) consumer %s placement on stream %s",
 								ni.name, ni.cluster, ni.stats.HAAssets, maxHaAssets, oname, stream)
@@ -9801,12 +9836,12 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 		if sa.Config.Retention == WorkQueuePolicy && !cfg.Direct && !cfg.Sourcing {
 			if cfg.AckPolicy != AckExplicit && cfg.AckPolicy != AckFlowControl {
 				resp.Error = NewJSConsumerWQRequiresExplicitAckError()
-				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+				s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 				return
 			}
 			if cfg.DeliverPolicy != DeliverAll {
 				resp.Error = NewJSConsumerWQConsumerNotDeliverAllError()
-				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+				s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 				return
 			}
 			subjects := gatherSubjectFilters(cfg.FilterSubject, cfg.FilterSubjects)
@@ -9816,14 +9851,14 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 				}
 				if len(subjects) == 0 {
 					resp.Error = NewJSConsumerWQMultipleUnfilteredError()
-					s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+					s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 					return
 				}
 				for _, psubj := range gatherSubjectFilters(oca.Config.FilterSubject, oca.Config.FilterSubjects) {
 					for _, subj := range subjects {
 						if SubjectsCollide(subj, psubj) {
 							resp.Error = NewJSConsumerWQConsumerNotUniqueError()
-							s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+							s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 							return
 						}
 					}
@@ -9882,7 +9917,7 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 			// Respond with error when there is a config mismatch between the intended config and expected peer size.
 			if len(streamPeerSet) < rAfter {
 				resp.Error = NewJSConsumerReplicasExceedsStreamError()
-				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+				s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 				return
 			}
 			rand.Shuffle(rAfter, func(i, j int) { streamPeerSet[i], streamPeerSet[j] = streamPeerSet[j], streamPeerSet[i] })

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -8492,7 +8492,7 @@ func TestJetStreamClusterConsumerResetDoesNotMutateLocalStateBeforeQuorum(t *tes
 	}
 
 	sseq, dseq, adflr, asflr, pending := o.sseq, o.dseq, o.adflr, o.asflr, len(o.pending)
-	_, _, err = o.resetStartingSeqLocked(0, _EMPTY_, false)
+	_, _, err = o.resetStartingSeqLocked(0, _EMPTY_, false, false)
 	if err != nil {
 		o.mu.Unlock()
 		require_NoError(t, err)

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -8254,7 +8254,7 @@ func TestJetStreamClusterSourceRetryDoesNotDuplicate(t *testing.T) {
 		if len(ss) == 0 {
 			continue
 		}
-		_, _, sseq := streamAndSeq(string(ss))
+		_, _, sseq, _ := streamAndSeq(string(ss))
 		if sseq == replaySseq {
 			dstSeqs = append(dstSeqs, seq)
 		}

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -299,6 +299,9 @@ const (
 	// JSConsumerStoreFailedErrF error creating store for consumer: {err}
 	JSConsumerStoreFailedErrF ErrorIdentifier = 10104
 
+	// JSConsumerStreamIdentityMismatchF consumer's stream identity does not match: {msg}
+	JSConsumerStreamIdentityMismatchF ErrorIdentifier = 10224
+
 	// JSConsumerWQConsumerNotDeliverAllErr consumer must be deliver all on workqueue stream
 	JSConsumerWQConsumerNotDeliverAllErr ErrorIdentifier = 10101
 
@@ -772,6 +775,7 @@ var (
 		JSConsumerReplicasShouldMatchStream:          {Code: 400, ErrCode: 10134, Description: "consumer config replicas must match interest retention stream's replicas"},
 		JSConsumerSmallHeartbeatErr:                  {Code: 400, ErrCode: 10083, Description: "consumer idle heartbeat needs to be >= 100ms"},
 		JSConsumerStoreFailedErrF:                    {Code: 500, ErrCode: 10104, Description: "error creating store for consumer: {err}"},
+		JSConsumerStreamIdentityMismatchF:            {Code: 400, ErrCode: 10224, Description: "consumer's stream identity does not match: {msg}"},
 		JSConsumerWQConsumerNotDeliverAllErr:         {Code: 400, ErrCode: 10101, Description: "consumer must be deliver all on workqueue stream"},
 		JSConsumerWQConsumerNotUniqueErr:             {Code: 400, ErrCode: 10100, Description: "filtered consumer not unique on workqueue stream"},
 		JSConsumerWQMultipleUnfilteredErr:            {Code: 400, ErrCode: 10099, Description: "multiple non-filtered consumers not allowed on workqueue stream"},
@@ -1984,6 +1988,22 @@ func NewJSConsumerStoreFailedError(err error, opts ...ErrorOption) *ApiError {
 
 	e := ApiErrors[JSConsumerStoreFailedErrF]
 	args := e.toReplacerArgs([]interface{}{"{err}", err})
+	return &ApiError{
+		Code:        e.Code,
+		ErrCode:     e.ErrCode,
+		Description: strings.NewReplacer(args...).Replace(e.Description),
+	}
+}
+
+// NewJSConsumerStreamIdentityMismatchError creates a new JSConsumerStreamIdentityMismatchF error: "consumer's stream identity does not match: {msg}"
+func NewJSConsumerStreamIdentityMismatchError(msg interface{}, opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	e := ApiErrors[JSConsumerStreamIdentityMismatchF]
+	args := e.toReplacerArgs([]interface{}{"{msg}", msg})
 	return &ApiError{
 		Code:        e.Code,
 		ErrCode:     e.ErrCode,

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -302,6 +302,9 @@ const (
 	// JSConsumerStoreFailedErrF error creating store for consumer: {err}
 	JSConsumerStoreFailedErrF ErrorIdentifier = 10104
 
+	// JSConsumerStreamIdentityMismatchF consumer's stream identity does not match: {msg}
+	JSConsumerStreamIdentityMismatchF ErrorIdentifier = 10225
+
 	// JSConsumerWQConsumerNotDeliverAllErr consumer must be deliver all on workqueue stream
 	JSConsumerWQConsumerNotDeliverAllErr ErrorIdentifier = 10101
 
@@ -776,6 +779,7 @@ var (
 		JSConsumerReplicasShouldMatchStream:          {Code: 400, ErrCode: 10134, Description: "consumer config replicas must match interest retention stream's replicas"},
 		JSConsumerSmallHeartbeatErr:                  {Code: 400, ErrCode: 10083, Description: "consumer idle heartbeat needs to be >= 100ms"},
 		JSConsumerStoreFailedErrF:                    {Code: 500, ErrCode: 10104, Description: "error creating store for consumer: {err}"},
+		JSConsumerStreamIdentityMismatchF:            {Code: 400, ErrCode: 10225, Description: "consumer's stream identity does not match: {msg}"},
 		JSConsumerWQConsumerNotDeliverAllErr:         {Code: 400, ErrCode: 10101, Description: "consumer must be deliver all on workqueue stream"},
 		JSConsumerWQConsumerNotUniqueErr:             {Code: 400, ErrCode: 10100, Description: "filtered consumer not unique on workqueue stream"},
 		JSConsumerWQMultipleUnfilteredErr:            {Code: 400, ErrCode: 10099, Description: "multiple non-filtered consumers not allowed on workqueue stream"},
@@ -2004,6 +2008,22 @@ func NewJSConsumerStoreFailedError(err error, opts ...ErrorOption) *ApiError {
 
 	e := ApiErrors[JSConsumerStoreFailedErrF]
 	args := e.toReplacerArgs([]interface{}{"{err}", err})
+	return &ApiError{
+		Code:        e.Code,
+		ErrCode:     e.ErrCode,
+		Description: strings.NewReplacer(args...).Replace(e.Description),
+	}
+}
+
+// NewJSConsumerStreamIdentityMismatchError creates a new JSConsumerStreamIdentityMismatchF error: "consumer's stream identity does not match: {msg}"
+func NewJSConsumerStreamIdentityMismatchError(msg interface{}, opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	e := ApiErrors[JSConsumerStreamIdentityMismatchF]
+	args := e.toReplacerArgs([]interface{}{"{msg}", msg})
 	return &ApiError{
 		Code:        e.Code,
 		ErrCode:     e.ErrCode,

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -9773,7 +9773,7 @@ func TestJetStreamSourceBasics(t *testing.T) {
 	require_NoError(t, err)
 	if shdr := m.Header.Get(JSStreamSource); shdr == _EMPTY_ {
 		t.Fatalf("Expected a header, got none")
-	} else if _, _, sseq := streamAndSeq(shdr); sseq != 26 {
+	} else if _, _, sseq, _ := streamAndSeq(shdr); sseq != 26 {
 		t.Fatalf("Expected header sequence of 26, got %d", sseq)
 	}
 
@@ -9801,7 +9801,7 @@ func TestJetStreamSourceBasics(t *testing.T) {
 	}
 	if shdr := m.Header.Get(JSStreamSource); shdr == _EMPTY_ {
 		t.Fatalf("Expected a header, got none")
-	} else if _, _, sseq := streamAndSeq(shdr); sseq != 11 {
+	} else if _, _, sseq, _ := streamAndSeq(shdr); sseq != 11 {
 		t.Fatalf("Expected header sequence of 11, got %d", sseq)
 	}
 	if m.Subject != "dlc2" {
@@ -18456,7 +18456,7 @@ func TestIsJSONObjectOrArray(t *testing.T) {
 	}
 }
 
-func TestJetStreamSourcingClipStartSeq(t *testing.T) {
+func TestJetStreamSourcingDontClipStartSeq(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
@@ -18493,9 +18493,8 @@ func TestJetStreamSourcingClipStartSeq(t *testing.T) {
 	require_True(t, mset != nil)
 	require_Len(t, len(mset.consumers), 1)
 	for _, o := range mset.consumers {
-		// Should have been clipped back to below 20 as only
-		// 10 messages in the origin stream.
-		require_Equal(t, o.sseq, 11)
+		// Should NOT have been clipped back to below 20.
+		require_Equal(t, o.sseq, 20)
 	}
 }
 
@@ -18534,9 +18533,8 @@ func TestJetStreamMirroringClipStartSeq(t *testing.T) {
 	require_True(t, mset != nil)
 	require_Len(t, len(mset.consumers), 1)
 	for _, o := range mset.consumers {
-		// Should have been clipped back to below 20 as only
-		// 10 messages in the origin stream.
-		require_Equal(t, o.sseq, 11)
+		// Should NOT have been clipped back to below 20.
+		require_Equal(t, o.sseq, 20)
 	}
 }
 
@@ -24863,4 +24861,283 @@ func TestJetStreamStreamSubjectsOverlapDataRace(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 	close(stop)
 	wg.Wait()
+}
+
+func TestJetStreamSourceStreamRecreated(t *testing.T) {
+	const (
+		durableConsumer = "C"
+		deliverSubject  = "deliver-subject"
+	)
+
+	test := func(t *testing.T, replicas int, retention RetentionPolicy, durable bool) {
+		var s *Server
+		var c *cluster
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c = createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		lookupStreamOnLeader := func(name string) (*stream, error) {
+			t.Helper()
+			ls := s
+			if c != nil {
+				ls = c.streamLeader(globalAccountName, name)
+			}
+			if ls == nil {
+				return nil, fmt.Errorf("no stream leader")
+			}
+			return ls.globalAccount().lookupStream(name)
+		}
+
+		addOrigin := func() {
+			t.Helper()
+			_, err := jsStreamCreate(t, nc, &StreamConfig{
+				Name:      "ORIGIN",
+				Subjects:  []string{"foo"},
+				Storage:   FileStorage,
+				Retention: retention,
+				Replicas:  replicas,
+			})
+			require_NoError(t, err)
+			if durable {
+				_, err = jsConsumerCreate(t, nc, "ORIGIN", ConsumerConfig{
+					Durable:        durableConsumer,
+					DeliverSubject: deliverSubject,
+					AckPolicy:      AckFlowControl,
+					Heartbeat:      time.Second,
+					Replicas:       replicas,
+				}, false)
+				require_NoError(t, err)
+			}
+		}
+		publish := func(n int) {
+			t.Helper()
+			for range n {
+				_, err := js.Publish("foo", nil)
+				require_NoError(t, err)
+			}
+		}
+		checkSourced := func(msgs uint64) {
+			t.Helper()
+			checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+				si, err := js.StreamInfo("SOURCE")
+				if err != nil {
+					return err
+				}
+				if si.State.Msgs != msgs {
+					return fmt.Errorf("expected %d msgs, got %d", msgs, si.State.Msgs)
+				}
+				return nil
+			})
+		}
+		waitForSourceConsumer := func() {
+			t.Helper()
+			// Must allow for the source consumer to be recreated, which is gated by sourceConsumerRetryThreshold.
+			checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+				if mset, err := lookupStreamOnLeader("ORIGIN"); err != nil {
+					return err
+				} else if n := mset.numConsumers(); n == 0 {
+					return errors.New("no sourcing consumer yet")
+				}
+				return nil
+			})
+		}
+
+		addOrigin()
+		srcCfg := &StreamSource{Name: "ORIGIN"}
+		if durable {
+			srcCfg.Consumer = &StreamConsumerSource{Name: durableConsumer, DeliverSubject: deliverSubject}
+		}
+		_, err := jsStreamCreate(t, nc, &StreamConfig{
+			Name:     "SOURCE",
+			Storage:  FileStorage,
+			Replicas: replicas,
+			Sources:  []*StreamSource{srcCfg},
+		})
+		require_NoError(t, err)
+		waitForSourceConsumer()
+
+		publish(10)
+		checkSourced(10)
+
+		// Delete and recreate the source stream, its sequences start from scratch.
+		require_NoError(t, js.DeleteStream("ORIGIN"))
+		addOrigin()
+
+		// Short-circuit recreation of the source consumers on the SOURCE leader.
+		mset, err := lookupStreamOnLeader("SOURCE")
+		require_NoError(t, err)
+		mset.mu.Lock()
+		err = mset.setupSourceConsumers()
+		mset.mu.Unlock()
+		require_NoError(t, err)
+		waitForSourceConsumer()
+
+		// Sourcing must pick back up, instead of waiting for the source stream
+		// to reach the sequence we had sourced up to before.
+		publish(5)
+		checkSourced(15)
+
+		// There must only be a single consumer on the recreated stream. Having multiple
+		// would show that consumers are leaked.
+		checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+			if mset, err := lookupStreamOnLeader("ORIGIN"); err != nil {
+				return err
+			} else if n := mset.numConsumers(); n != 1 {
+				return fmt.Errorf("expected 1 sourcing consumer, got %d", n)
+			}
+			return nil
+		})
+	}
+
+	for _, replicas := range []int{1, 3} {
+		for _, retention := range []RetentionPolicy{LimitsPolicy, InterestPolicy, WorkQueuePolicy} {
+			for _, durable := range []bool{false, true} {
+				kind := "Implicit"
+				if durable {
+					kind = "Durable"
+				}
+				t.Run(fmt.Sprintf("R%d/%s/%s", replicas, retention, kind), func(t *testing.T) {
+					test(t, replicas, retention, durable)
+				})
+			}
+		}
+	}
+}
+
+func TestJetStreamSourceStreamRecreatedRespectsStartSeq(t *testing.T) {
+	test := func(t *testing.T, replicas int) {
+		var s *Server
+		var c *cluster
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c = createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		lookupStreamOnLeader := func(name string) (*stream, error) {
+			t.Helper()
+			ls := s
+			if c != nil {
+				ls = c.streamLeader(globalAccountName, name)
+			}
+			if ls == nil {
+				return nil, fmt.Errorf("no stream leader")
+			}
+			return ls.globalAccount().lookupStream(name)
+		}
+
+		addOrigin := func() {
+			t.Helper()
+			_, err := jsStreamCreate(t, nc, &StreamConfig{
+				Name:     "ORIGIN",
+				Subjects: []string{"foo"},
+				Storage:  FileStorage,
+				Replicas: replicas,
+			})
+			require_NoError(t, err)
+			if c != nil {
+				c.waitOnStreamLeader(globalAccountName, "ORIGIN")
+			}
+		}
+		// publish sends n messages to the origin, each body carrying "<marker><i>" so we
+		// can assert exactly which origin sequences were sourced into the destination.
+		publish := func(marker string, n int) {
+			t.Helper()
+			for i := 1; i <= n; i++ {
+				_, err := js.Publish("foo", []byte(fmt.Sprintf("%s%d", marker, i)))
+				require_NoError(t, err)
+			}
+		}
+		checkSourced := func(msgs uint64) {
+			t.Helper()
+			checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+				si, err := js.StreamInfo("SOURCE")
+				if err != nil {
+					return err
+				}
+				if si.State.Msgs != msgs {
+					return fmt.Errorf("expected %d msgs, got %d", msgs, si.State.Msgs)
+				}
+				return nil
+			})
+		}
+		requireBody := func(seq uint64, expected string) {
+			t.Helper()
+			m, err := js.GetMsg("SOURCE", seq)
+			require_NoError(t, err)
+			require_Equal(t, string(m.Data), expected)
+		}
+		waitForSourceConsumer := func() {
+			t.Helper()
+			// Must allow for the source consumer to be recreated, which is gated by sourceConsumerRetryThreshold.
+			checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+				if mset, err := lookupStreamOnLeader("ORIGIN"); err != nil {
+					return err
+				} else if n := mset.numConsumers(); n == 0 {
+					return errors.New("no sourcing consumer yet")
+				}
+				return nil
+			})
+		}
+
+		// First incarnation of the origin, sourced with OptStartSeq set.
+		addOrigin()
+		_, err := jsStreamCreate(t, nc, &StreamConfig{
+			Name:     "SOURCE",
+			Storage:  FileStorage,
+			Replicas: replicas,
+			Sources:  []*StreamSource{{Name: "ORIGIN", OptStartSeq: 6}},
+		})
+		require_NoError(t, err)
+		waitForSourceConsumer()
+
+		// Publish origin sequences 1..10. OptStartSeq must be respected, so only origin
+		// sequences 6..10 (5 messages) are sourced, and nothing below the start sequence.
+		publish("a", 10)
+		checkSourced(5)
+		requireBody(1, "a6")
+		requireBody(5, "a10")
+
+		// Delete and recreate the origin, its sequences restart from scratch.
+		require_NoError(t, js.DeleteStream("ORIGIN"))
+		addOrigin()
+
+		// Short-circuit recreation of the source consumer on the SOURCE leader.
+		mset, err := lookupStreamOnLeader("SOURCE")
+		require_NoError(t, err)
+		mset.mu.Lock()
+		err = mset.setupSourceConsumers()
+		mset.mu.Unlock()
+		require_NoError(t, err)
+		waitForSourceConsumer()
+
+		// Publish origin sequences 1..10 on the recreated origin. OptStartSeq must still be
+		// respected, so only origin sequences 6..10 (5 messages) are sourced and nothing
+		// below the start sequence. Sourcing from the beginning would instead pick up
+		// sequence 1 (body "b1") at destination sequence 6.
+		publish("b", 10)
+		checkSourced(10)
+		requireBody(6, "b6")
+		requireBody(10, "b10")
+	}
+
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) {
+			test(t, replicas)
+		})
+	}
 }

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -9579,6 +9579,112 @@ func TestJetStreamMirrorBasics(t *testing.T) {
 
 }
 
+func TestJetStreamSourceStartSeqRespectedOnEmptyOrigin(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	waitForSourcingConsumer := func(origin string) {
+		t.Helper()
+		checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+			mset, err := s.globalAccount().lookupStream(origin)
+			if err != nil {
+				return err
+			}
+			if mset.numDirectConsumers() == 0 {
+				return fmt.Errorf("no sourcing consumer attached to %q yet", origin)
+			}
+			return nil
+		})
+	}
+
+	// Publish origin sequences 1..15, with the body carrying the origin sequence
+	// so we can assert exactly which messages were sourced.
+	publishOrigin := func(subject string) {
+		t.Helper()
+		for i := 1; i <= 15; i++ {
+			_, err := js.Publish(subject, []byte(strconv.Itoa(i)))
+			require_NoError(t, err)
+		}
+	}
+
+	t.Run("mirror", func(t *testing.T) {
+		// Origin stream, empty.
+		_, err := js.AddStream(&nats.StreamConfig{Name: "MO", Subjects: []string{"m"}})
+		require_NoError(t, err)
+
+		// Mirror requesting to start at origin sequence 10, while the origin is empty.
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:   "M",
+			Mirror: &nats.StreamSource{Name: "MO", OptStartSeq: 10},
+		})
+		require_NoError(t, err)
+
+		waitForSourcingConsumer("MO")
+		publishOrigin("m")
+
+		// Mirrors preserve origin sequences, so the mirror must contain exactly
+		// origin sequences 10..15 and nothing below 10.
+		checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+			si, err := js.StreamInfo("M")
+			if err != nil {
+				return err
+			}
+			if si.State.Msgs != 6 {
+				return fmt.Errorf("expected 6 msgs (origin 10..15), got state: %+v", si.State)
+			}
+			if si.State.FirstSeq != 10 {
+				return fmt.Errorf("expected first seq 10, got state: %+v", si.State)
+			}
+			if si.State.LastSeq != 15 {
+				return fmt.Errorf("expected last seq 15, got state: %+v", si.State)
+			}
+			return nil
+		})
+	})
+
+	t.Run("source", func(t *testing.T) {
+		// Origin stream, empty.
+		_, err := js.AddStream(&nats.StreamConfig{Name: "SO", Subjects: []string{"s"}})
+		require_NoError(t, err)
+
+		// Source requesting to start at origin sequence 10, while the origin is empty.
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:    "S",
+			Sources: []*nats.StreamSource{{Name: "SO", OptStartSeq: 10}},
+		})
+		require_NoError(t, err)
+
+		waitForSourcingConsumer("SO")
+		publishOrigin("s")
+
+		// A source re-sequences into the destination, so assert on message count and
+		// on the origin sequences that were actually sourced (carried in the body).
+		checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+			si, err := js.StreamInfo("S")
+			if err != nil {
+				return err
+			}
+			if si.State.Msgs != 6 {
+				return fmt.Errorf("expected 6 msgs (origin 10..15), got state: %+v", si.State)
+			}
+			return nil
+		})
+
+		// The first and last sourced messages must be origin sequences 10 and 15,
+		// proving nothing below the requested start sequence was sourced.
+		first, err := js.GetMsg("S", 1)
+		require_NoError(t, err)
+		require_Equal(t, string(first.Data), "10")
+
+		last, err := js.GetMsg("S", 6)
+		require_NoError(t, err)
+		require_Equal(t, string(last.Data), "15")
+	})
+}
+
 func TestJetStreamMirrorStripExpectedHeaders(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -9811,7 +9811,7 @@ func TestJetStreamSourceBasics(t *testing.T) {
 	require_NoError(t, err)
 	if shdr := m.Header.Get(JSStreamSource); shdr == _EMPTY_ {
 		t.Fatalf("Expected a header, got none")
-	} else if _, _, sseq := streamAndSeq(shdr); sseq != 26 {
+	} else if _, _, sseq, _ := streamAndSeq(shdr); sseq != 26 {
 		t.Fatalf("Expected header sequence of 26, got %d", sseq)
 	}
 
@@ -9839,7 +9839,7 @@ func TestJetStreamSourceBasics(t *testing.T) {
 	}
 	if shdr := m.Header.Get(JSStreamSource); shdr == _EMPTY_ {
 		t.Fatalf("Expected a header, got none")
-	} else if _, _, sseq := streamAndSeq(shdr); sseq != 11 {
+	} else if _, _, sseq, _ := streamAndSeq(shdr); sseq != 11 {
 		t.Fatalf("Expected header sequence of 11, got %d", sseq)
 	}
 	if m.Subject != "dlc2" {
@@ -18494,7 +18494,7 @@ func TestIsJSONObjectOrArray(t *testing.T) {
 	}
 }
 
-func TestJetStreamSourcingClipStartSeq(t *testing.T) {
+func TestJetStreamSourcingDontClipStartSeq(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()
 
@@ -18531,9 +18531,8 @@ func TestJetStreamSourcingClipStartSeq(t *testing.T) {
 	require_True(t, mset != nil)
 	require_Len(t, len(mset.consumers), 1)
 	for _, o := range mset.consumers {
-		// Should have been clipped back to below 20 as only
-		// 10 messages in the origin stream.
-		require_Equal(t, o.sseq, 11)
+		// Should NOT have been clipped back to below 20.
+		require_Equal(t, o.sseq, 20)
 	}
 }
 
@@ -18572,9 +18571,8 @@ func TestJetStreamMirroringClipStartSeq(t *testing.T) {
 	require_True(t, mset != nil)
 	require_Len(t, len(mset.consumers), 1)
 	for _, o := range mset.consumers {
-		// Should have been clipped back to below 20 as only
-		// 10 messages in the origin stream.
-		require_Equal(t, o.sseq, 11)
+		// Should NOT have been clipped back to below 20.
+		require_Equal(t, o.sseq, 20)
 	}
 }
 
@@ -24405,40 +24403,59 @@ func TestJetStreamSourceConsumerRetryUsesFreshReplySubject(t *testing.T) {
 	mset, err := s.globalAccount().lookupStream("SOURCE")
 	require_NoError(t, err)
 
-	// Original request.
-	m1 := require_ChanRead(t, reqCh, time.Second)
-	var ccr1 CreateConsumerRequest
-	require_NoError(t, json.Unmarshal(m1.Data, &ccr1))
-	require_True(t, ccr1.Config.Sourcing)
-	reply1 := m1.Reply
-
-	// Answer with a required API level error.
 	errResp, err := json.Marshal(JSApiConsumerCreateResponse{
 		ApiResponse: ApiResponse{Error: NewJSRequiredApiLevelError()},
 	})
 	require_NoError(t, err)
+
+	// Original request, asking for API level 5 with stream recreation detection.
+	m1 := require_ChanRead(t, reqCh, time.Second)
+	var ccr1 CreateConsumerRequest
+	require_NoError(t, json.Unmarshal(m1.Data, &ccr1))
+	require_True(t, ccr1.Config.Sourcing)
+	require_Equal(t, m1.Header.Get(JSRequiredApiLevel), "5")
+	reply1 := m1.Reply
+
+	// Answer with a required API level error.
 	require_NoError(t, nc.Publish(reply1, errResp))
 	require_NoError(t, nc.Flush())
 
-	// Retry request.
+	// First retry steps down to API level 4, still sourcing.
 	m2 := require_ChanRead(t, reqCh, time.Second)
 	var ccr2 CreateConsumerRequest
 	require_NoError(t, json.Unmarshal(m2.Data, &ccr2))
-	require_False(t, ccr2.Config.Sourcing)
+	require_True(t, ccr2.Config.Sourcing)
+	require_Equal(t, m2.Header.Get(JSRequiredApiLevel), "4")
 	reply2 := m2.Reply
 	require_NotEqual(t, reply1, reply2)
 
+	// Answer with a required API level error again.
+	require_NoError(t, nc.Publish(reply2, errResp))
+	require_NoError(t, nc.Flush())
+
+	// Second retry drops sourcing and the required API level.
+	m3 := require_ChanRead(t, reqCh, time.Second)
+	var ccr3 CreateConsumerRequest
+	require_NoError(t, json.Unmarshal(m3.Data, &ccr3))
+	require_False(t, ccr3.Config.Sourcing)
+	require_Equal(t, m3.Header.Get(JSRequiredApiLevel), _EMPTY_)
+	reply3 := m3.Reply
+	require_NotEqual(t, reply1, reply3)
+	require_NotEqual(t, reply2, reply3)
+
+	// Stale responses on previous reply subjects must not be picked up.
 	staleResp, err := json.Marshal(JSApiConsumerCreateResponse{
 		ApiResponse: ApiResponse{Error: NewJSStreamNotFoundError()},
 	})
 	require_NoError(t, err)
 	require_NoError(t, nc.Publish(reply1, staleResp))
+	require_NoError(t, nc.Publish(reply2, staleResp))
 
 	okResp, err := json.Marshal(JSApiConsumerCreateResponse{
-		ConsumerInfo: &ConsumerInfo{Name: ccr2.Config.Name, Config: &ccr2.Config},
+		ConsumerInfo: &ConsumerInfo{Name: ccr3.Config.Name, Config: &ccr3.Config},
 	})
 	require_NoError(t, err)
-	require_NoError(t, nc.Publish(reply2, okResp))
+	require_NoError(t, nc.Publish(reply3, okResp))
 	require_NoError(t, nc.Flush())
 
 	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
@@ -24448,8 +24465,8 @@ func TestJetStreamSourceConsumerRetryUsesFreshReplySubject(t *testing.T) {
 			if si.err != nil {
 				return fmt.Errorf("source is in error state: %v", si.err)
 			}
-			if si.cname != ccr2.Config.Name {
-				return fmt.Errorf("expected consumer name %q, got %q", ccr2.Config.Name, si.cname)
+			if si.cname != ccr3.Config.Name {
+				return fmt.Errorf("expected consumer name %q, got %q", ccr3.Config.Name, si.cname)
 			}
 			return nil
 		}
@@ -25039,6 +25056,285 @@ func TestJetStreamSourceConsumerCreatePoisonedReply(t *testing.T) {
 				}
 				return nil
 			})
+		})
+	}
+}
+
+func TestJetStreamSourceStreamRecreated(t *testing.T) {
+	const (
+		durableConsumer = "C"
+		deliverSubject  = "deliver-subject"
+	)
+
+	test := func(t *testing.T, replicas int, retention RetentionPolicy, durable bool) {
+		var s *Server
+		var c *cluster
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c = createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		lookupStreamOnLeader := func(name string) (*stream, error) {
+			t.Helper()
+			ls := s
+			if c != nil {
+				ls = c.streamLeader(globalAccountName, name)
+			}
+			if ls == nil {
+				return nil, fmt.Errorf("no stream leader")
+			}
+			return ls.globalAccount().lookupStream(name)
+		}
+
+		addOrigin := func() {
+			t.Helper()
+			_, err := jsStreamCreate(t, nc, &StreamConfig{
+				Name:      "ORIGIN",
+				Subjects:  []string{"foo"},
+				Storage:   FileStorage,
+				Retention: retention,
+				Replicas:  replicas,
+			})
+			require_NoError(t, err)
+			if durable {
+				_, err = jsConsumerCreate(t, nc, "ORIGIN", ConsumerConfig{
+					Durable:        durableConsumer,
+					DeliverSubject: deliverSubject,
+					AckPolicy:      AckFlowControl,
+					Heartbeat:      time.Second,
+					Replicas:       replicas,
+				}, false)
+				require_NoError(t, err)
+			}
+		}
+		publish := func(n int) {
+			t.Helper()
+			for range n {
+				_, err := js.Publish("foo", nil)
+				require_NoError(t, err)
+			}
+		}
+		checkSourced := func(msgs uint64) {
+			t.Helper()
+			checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+				si, err := js.StreamInfo("SOURCE")
+				if err != nil {
+					return err
+				}
+				if si.State.Msgs != msgs {
+					return fmt.Errorf("expected %d msgs, got %d", msgs, si.State.Msgs)
+				}
+				return nil
+			})
+		}
+		waitForSourceConsumer := func() {
+			t.Helper()
+			// Must allow for the source consumer to be recreated, which is gated by sourceConsumerRetryThreshold.
+			checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+				if mset, err := lookupStreamOnLeader("ORIGIN"); err != nil {
+					return err
+				} else if n := mset.numConsumers(); n == 0 {
+					return errors.New("no sourcing consumer yet")
+				}
+				return nil
+			})
+		}
+
+		addOrigin()
+		srcCfg := &StreamSource{Name: "ORIGIN"}
+		if durable {
+			srcCfg.Consumer = &StreamConsumerSource{Name: durableConsumer, DeliverSubject: deliverSubject}
+		}
+		_, err := jsStreamCreate(t, nc, &StreamConfig{
+			Name:     "SOURCE",
+			Storage:  FileStorage,
+			Replicas: replicas,
+			Sources:  []*StreamSource{srcCfg},
+		})
+		require_NoError(t, err)
+		waitForSourceConsumer()
+
+		publish(10)
+		checkSourced(10)
+
+		// Delete and recreate the source stream, its sequences start from scratch.
+		require_NoError(t, js.DeleteStream("ORIGIN"))
+		addOrigin()
+
+		// Short-circuit recreation of the source consumers on the SOURCE leader.
+		mset, err := lookupStreamOnLeader("SOURCE")
+		require_NoError(t, err)
+		mset.mu.Lock()
+		err = mset.setupSourceConsumers()
+		mset.mu.Unlock()
+		require_NoError(t, err)
+		waitForSourceConsumer()
+
+		// Sourcing must pick back up, instead of waiting for the source stream
+		// to reach the sequence we had sourced up to before.
+		publish(5)
+		checkSourced(15)
+
+		// There must only be a single consumer on the recreated stream. Having multiple
+		// would show that consumers are leaked.
+		checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+			if mset, err := lookupStreamOnLeader("ORIGIN"); err != nil {
+				return err
+			} else if n := mset.numConsumers(); n != 1 {
+				return fmt.Errorf("expected 1 sourcing consumer, got %d", n)
+			}
+			return nil
+		})
+	}
+
+	for _, replicas := range []int{1, 3} {
+		for _, retention := range []RetentionPolicy{LimitsPolicy, InterestPolicy, WorkQueuePolicy} {
+			for _, durable := range []bool{false, true} {
+				kind := "Implicit"
+				if durable {
+					kind = "Durable"
+				}
+				t.Run(fmt.Sprintf("R%d/%s/%s", replicas, retention, kind), func(t *testing.T) {
+					test(t, replicas, retention, durable)
+				})
+			}
+		}
+	}
+}
+
+func TestJetStreamSourceStreamRecreatedRespectsStartSeq(t *testing.T) {
+	test := func(t *testing.T, replicas int) {
+		var s *Server
+		var c *cluster
+		if replicas == 1 {
+			s = RunBasicJetStreamServer(t)
+			defer s.Shutdown()
+		} else {
+			c = createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+			s = c.randomServer()
+		}
+
+		nc, js := jsClientConnect(t, s)
+		defer nc.Close()
+
+		lookupStreamOnLeader := func(name string) (*stream, error) {
+			t.Helper()
+			ls := s
+			if c != nil {
+				ls = c.streamLeader(globalAccountName, name)
+			}
+			if ls == nil {
+				return nil, fmt.Errorf("no stream leader")
+			}
+			return ls.globalAccount().lookupStream(name)
+		}
+
+		addOrigin := func() {
+			t.Helper()
+			_, err := jsStreamCreate(t, nc, &StreamConfig{
+				Name:     "ORIGIN",
+				Subjects: []string{"foo"},
+				Storage:  FileStorage,
+				Replicas: replicas,
+			})
+			require_NoError(t, err)
+			if c != nil {
+				c.waitOnStreamLeader(globalAccountName, "ORIGIN")
+			}
+		}
+		// publish sends n messages to the origin, each body carrying "<marker><i>" so we
+		// can assert exactly which origin sequences were sourced into the destination.
+		publish := func(marker string, n int) {
+			t.Helper()
+			for i := 1; i <= n; i++ {
+				_, err := js.Publish("foo", []byte(fmt.Sprintf("%s%d", marker, i)))
+				require_NoError(t, err)
+			}
+		}
+		checkSourced := func(msgs uint64) {
+			t.Helper()
+			checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+				si, err := js.StreamInfo("SOURCE")
+				if err != nil {
+					return err
+				}
+				if si.State.Msgs != msgs {
+					return fmt.Errorf("expected %d msgs, got %d", msgs, si.State.Msgs)
+				}
+				return nil
+			})
+		}
+		requireBody := func(seq uint64, expected string) {
+			t.Helper()
+			m, err := js.GetMsg("SOURCE", seq)
+			require_NoError(t, err)
+			require_Equal(t, string(m.Data), expected)
+		}
+		waitForSourceConsumer := func() {
+			t.Helper()
+			// Must allow for the source consumer to be recreated, which is gated by sourceConsumerRetryThreshold.
+			checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+				if mset, err := lookupStreamOnLeader("ORIGIN"); err != nil {
+					return err
+				} else if n := mset.numConsumers(); n == 0 {
+					return errors.New("no sourcing consumer yet")
+				}
+				return nil
+			})
+		}
+
+		// First incarnation of the origin, sourced with OptStartSeq set.
+		addOrigin()
+		_, err := jsStreamCreate(t, nc, &StreamConfig{
+			Name:     "SOURCE",
+			Storage:  FileStorage,
+			Replicas: replicas,
+			Sources:  []*StreamSource{{Name: "ORIGIN", OptStartSeq: 6}},
+		})
+		require_NoError(t, err)
+		waitForSourceConsumer()
+
+		// Publish origin sequences 1..10. OptStartSeq must be respected, so only origin
+		// sequences 6..10 (5 messages) are sourced, and nothing below the start sequence.
+		publish("a", 10)
+		checkSourced(5)
+		requireBody(1, "a6")
+		requireBody(5, "a10")
+
+		// Delete and recreate the origin, its sequences restart from scratch.
+		require_NoError(t, js.DeleteStream("ORIGIN"))
+		addOrigin()
+
+		// Short-circuit recreation of the source consumer on the SOURCE leader.
+		mset, err := lookupStreamOnLeader("SOURCE")
+		require_NoError(t, err)
+		mset.mu.Lock()
+		err = mset.setupSourceConsumers()
+		mset.mu.Unlock()
+		require_NoError(t, err)
+		waitForSourceConsumer()
+
+		// Publish origin sequences 1..10 on the recreated origin. OptStartSeq must still be
+		// respected, so only origin sequences 6..10 (5 messages) are sourced and nothing
+		// below the start sequence. Sourcing from the beginning would instead pick up
+		// sequence 1 (body "b1") at destination sequence 6.
+		publish("b", 10)
+		checkSourced(10)
+		requireBody(6, "b6")
+		requireBody(10, "b10")
+	}
+
+	for _, replicas := range []int{1, 3} {
+		t.Run(fmt.Sprintf("R%d", replicas), func(t *testing.T) {
+			test(t, replicas)
 		})
 	}
 }

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -9617,6 +9617,112 @@ func TestJetStreamMirrorBasics(t *testing.T) {
 
 }
 
+func TestJetStreamSourceStartSeqRespectedOnEmptyOrigin(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	waitForSourcingConsumer := func(origin string) {
+		t.Helper()
+		checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+			mset, err := s.globalAccount().lookupStream(origin)
+			if err != nil {
+				return err
+			}
+			if mset.numDirectConsumers() == 0 {
+				return fmt.Errorf("no sourcing consumer attached to %q yet", origin)
+			}
+			return nil
+		})
+	}
+
+	// Publish origin sequences 1..15, with the body carrying the origin sequence
+	// so we can assert exactly which messages were sourced.
+	publishOrigin := func(subject string) {
+		t.Helper()
+		for i := 1; i <= 15; i++ {
+			_, err := js.Publish(subject, []byte(strconv.Itoa(i)))
+			require_NoError(t, err)
+		}
+	}
+
+	t.Run("mirror", func(t *testing.T) {
+		// Origin stream, empty.
+		_, err := js.AddStream(&nats.StreamConfig{Name: "MO", Subjects: []string{"m"}})
+		require_NoError(t, err)
+
+		// Mirror requesting to start at origin sequence 10, while the origin is empty.
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:   "M",
+			Mirror: &nats.StreamSource{Name: "MO", OptStartSeq: 10},
+		})
+		require_NoError(t, err)
+
+		waitForSourcingConsumer("MO")
+		publishOrigin("m")
+
+		// Mirrors preserve origin sequences, so the mirror must contain exactly
+		// origin sequences 10..15 and nothing below 10.
+		checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+			si, err := js.StreamInfo("M")
+			if err != nil {
+				return err
+			}
+			if si.State.Msgs != 6 {
+				return fmt.Errorf("expected 6 msgs (origin 10..15), got state: %+v", si.State)
+			}
+			if si.State.FirstSeq != 10 {
+				return fmt.Errorf("expected first seq 10, got state: %+v", si.State)
+			}
+			if si.State.LastSeq != 15 {
+				return fmt.Errorf("expected last seq 15, got state: %+v", si.State)
+			}
+			return nil
+		})
+	})
+
+	t.Run("source", func(t *testing.T) {
+		// Origin stream, empty.
+		_, err := js.AddStream(&nats.StreamConfig{Name: "SO", Subjects: []string{"s"}})
+		require_NoError(t, err)
+
+		// Source requesting to start at origin sequence 10, while the origin is empty.
+		_, err = js.AddStream(&nats.StreamConfig{
+			Name:    "S",
+			Sources: []*nats.StreamSource{{Name: "SO", OptStartSeq: 10}},
+		})
+		require_NoError(t, err)
+
+		waitForSourcingConsumer("SO")
+		publishOrigin("s")
+
+		// A source re-sequences into the destination, so assert on message count and
+		// on the origin sequences that were actually sourced (carried in the body).
+		checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+			si, err := js.StreamInfo("S")
+			if err != nil {
+				return err
+			}
+			if si.State.Msgs != 6 {
+				return fmt.Errorf("expected 6 msgs (origin 10..15), got state: %+v", si.State)
+			}
+			return nil
+		})
+
+		// The first and last sourced messages must be origin sequences 10 and 15,
+		// proving nothing below the requested start sequence was sourced.
+		first, err := js.GetMsg("S", 1)
+		require_NoError(t, err)
+		require_Equal(t, string(first.Data), "10")
+
+		last, err := js.GetMsg("S", 6)
+		require_NoError(t, err)
+		require_Equal(t, string(last.Data), "15")
+	})
+}
+
 func TestJetStreamMirrorStripExpectedHeaders(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/jetstream_versioning.go
+++ b/server/jetstream_versioning.go
@@ -17,7 +17,7 @@ import "strconv"
 
 const (
 	// JSApiLevel is the maximum supported JetStream API level for this server.
-	JSApiLevel int = 4
+	JSApiLevel int = 5
 
 	JSRequiredLevelMetadataKey = "_nats.req.level"
 	JSServerVersionMetadataKey = "_nats.ver"

--- a/server/stream.go
+++ b/server/stream.go
@@ -599,6 +599,7 @@ type sourceInfo struct {
 	name  string        // The name of the stream being sourced.
 	iname string        // The unique index name of this particular source.
 	cname string        // The name of the current consumer for this source.
+	ident string        // The identity of this source, a recreated stream results in a different ident.
 	sub   *subscription // The subscription to the consumer.
 
 	msgs  *ipQueue[*inMsg]    // Intra-process queue for incoming messages.
@@ -611,6 +612,7 @@ type sourceInfo struct {
 	lreq  time.Time           // The last time setupMirrorConsumer/setupSourceConsumer was called.
 	qch   chan struct{}       // Quit channel.
 	sip   bool                // Setup in progress.
+	rc    bool                // Recreate based on a stream identity mismatch.
 	wg    sync.WaitGroup      // WaitGroup for the consumer's go routine.
 	sf    string              // The subject filter.
 	sfs   []string            // The subject filters.
@@ -1188,6 +1190,17 @@ func (mset *stream) setStreamAssignment(sa *streamAssignment) {
 	case mset.uch <- struct{}{}:
 	default:
 	}
+}
+
+// identity returns a hash of the stream's creation time, used to detect stream recreation.
+func (mset *stream) identity() string {
+	return getHash(mset.createdTime().UTC().Format(time.RFC3339Nano))
+}
+
+// identity returns a hash of the stream's creation time, used to detect stream recreation.
+// JS lock should be held.
+func (sa *streamAssignment) identity() string {
+	return getHash(sa.Created.UTC().Format(time.RFC3339Nano))
 }
 
 func (mset *stream) monitorQuitC() <-chan struct{} {
@@ -3960,6 +3973,7 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 			InactiveThreshold: sourceHealthCheckInterval,
 			Metadata:          metadata,
 		},
+		StreamIdentity: si.ident,
 	}
 
 	// If starting, check any configs.
@@ -3981,7 +3995,7 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 					req.Config.OptStartTime = ssi.OptStartTime
 				}
 				req.Config.DeliverPolicy = DeliverByStartTime
-			} else if state.FirstSeq > 1 && !state.LastTime.IsZero() {
+			} else if state.FirstSeq > 1 && !state.LastTime.IsZero() && !si.rc {
 				req.Config.OptStartTime = &state.LastTime
 				req.Config.DeliverPolicy = DeliverByStartTime
 			}
@@ -4054,6 +4068,14 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 	si.err = nil
 	si.sip = true
 
+	// Three API levels can be tried:
+	// - API level 5: stream recreation detection.
+	// - API level 4: durable sourcing, AckFlowControl, and consumer reset.
+	// - not specified: used as fallback.
+	apiLevel := 5
+	if req.StreamIdentity == _EMPTY_ {
+		apiLevel = 4
+	}
 	if durableDeliverSubject != _EMPTY_ {
 		// Send the consumer reset request
 		mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, nil, nil, nil, 0))
@@ -4062,14 +4084,14 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 		b, _ := json.Marshal(req)
 
 		// Send the consumer create request
-		// Confirm the server supports API level 4, which contains durable sourcing, AckFlowControl, and consumer reset.
-		hdr := genHeader(nil, JSRequiredApiLevel, "4")
+		hdr := genHeader(nil, JSRequiredApiLevel, strconv.Itoa(apiLevel))
 		mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, hdr, b, nil, 0))
 	}
 
 	go func() {
 
 		var retry bool
+		var recreate bool
 		defer func() {
 			mset.mu.Lock()
 			// Check that this is still valid and if so, clear the "setup in progress" flag.
@@ -4078,7 +4100,9 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 				// If we need to retry, schedule now
 				// If sub is not nil means we re-established somewhere else so do not re-attempt here.
 				if retry && si.sub == nil {
-					si.fails++
+					if !recreate {
+						si.fails++
+					}
 					// Cancel here since we can not do anything with this consumer at this point.
 					mset.cancelSourceInfo(si)
 					mset.setupSourceConsumer(iname, seq, startTime)
@@ -4101,9 +4125,39 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 				si.err = nil
 
 				if ccr.Error != nil || ccr.ConsumerInfo == nil {
-					// If the responding server doesn't support sourcing consumers, retry without it.
+					// Retry after unsetting the expected stream's identity.
+					if ccr.Error != nil && ccr.Error.ErrCode == uint16(JSConsumerStreamIdentityMismatchF) {
+						mset.unsubscribe(crSub)
+						seq, si.sseq, si.dseq = 0, 0, 0
+						si.ident, si.rc = _EMPTY_, true
+						retry, recreate = true, true
+						mset.mu.Unlock()
+						return
+					}
+
+					// If the responding server doesn't support certain request settings, retry a 'downgraded' request.
 					if req.Config.Sourcing && ccr.Error != nil &&
 						(ccr.Error.ErrCode == uint16(JSRequiredApiLevelErr) || ccr.Error.ErrCode == uint16(JSInvalidJSONErr)) {
+						if apiLevel > 4 {
+							apiLevel--
+							// Unset for retry.
+							req.StreamIdentity = _EMPTY_
+							b, _ := json.Marshal(req)
+							// Recreate the reply subscription so we don't get stale responses from other servers.
+							mset.unsubscribe(crSub)
+							if reply, respCh, crSub, err = newReplySubscription(); err != nil {
+								si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
+								retry = true
+								mset.mu.Unlock()
+								return
+							}
+							hdr := genHeader(nil, JSRequiredApiLevel, strconv.Itoa(apiLevel))
+							mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, hdr, b, nil, 0))
+							mset.mu.Unlock()
+							goto SELECT
+						}
+
+						// If the responding server doesn't support sourcing consumers, retry without it.
 						// Unset for retry.
 						req.Config.Sourcing = false
 						// Specify a unique consumer name, as the other end will not know to do this.
@@ -4159,6 +4213,15 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 						},
 					)
 				}
+
+				// Capture identity to detect stream recreation.
+				recreated := si.rc || (ccr.StreamIdentity != _EMPTY_ && si.ident != _EMPTY_ && si.ident != ccr.StreamIdentity)
+				if recreated {
+					mset.srv.Warnf("JetStream source stream %q for stream '%s > %s' was recreated, resetting source state",
+						si.name, mset.acc.Name, mset.cfg.Name)
+					si.sseq = 0
+				}
+				si.ident, si.rc = ccr.StreamIdentity, false
 
 				// Setup actual subscription to process messages from our source.
 				if si.sseq < ccr.ConsumerInfo.Delivered.Stream {
@@ -4409,7 +4472,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 	} else {
 		si.lag = pending - 1
 	}
-	node := mset.node
+	node, ident := mset.node, si.ident
 	mset.mu.Unlock()
 
 	hdr, msg := m.hdr, m.msg
@@ -4423,7 +4486,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 		hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Batch-")
 	}
 	// Hold onto the origin reply which has all the metadata.
-	hdr = genHeader(hdr, JSStreamSource, si.genSourceHeader(m.subj, m.rply))
+	hdr = genHeader(hdr, JSStreamSource, si.genSourceHeader(m.subj, m.rply, ident))
 
 	// Do the subject transform for the source if there's one
 	if len(si.trs) > 0 {
@@ -4488,7 +4551,9 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 }
 
 // Generate a new (2.10) style source header (stream name, sequence number, source filter, source destination transform).
-func (si *sourceInfo) genSourceHeader(orig, reply string) string {
+// The source's ident must be passed in, as it can be mutated under the stream lock, which is not held here.
+// Format: <stream> <seq> <filter> <transform> <orig> [<ident>]
+func (si *sourceInfo) genSourceHeader(orig, reply, ident string) string {
 	var b strings.Builder
 	iNameParts := strings.Split(si.iname, " ")
 
@@ -4519,6 +4584,10 @@ func (si *sourceInfo) genSourceHeader(orig, reply string) string {
 	b.WriteString(iNameParts[2])
 	b.WriteByte(' ')
 	b.WriteString(orig)
+	if ident != _EMPTY_ {
+		b.WriteByte(' ')
+		b.WriteString(ident)
+	}
 	return b.String()
 }
 
@@ -4563,22 +4632,33 @@ func consumerFromAckReply(reply string) string {
 
 // Extract the stream name, the source index name and the message sequence number from the source header.
 // Uses the filter and transform arguments to provide backwards compatibility
-func streamAndSeq(shdr string) (string, string, uint64) {
+// Format: <stream> <seq> <filter> <transform> <orig> [<ident>]
+func streamAndSeq(shdr string) (string, string, uint64, string) {
 	if strings.HasPrefix(shdr, jsAckPre) {
-		return streamAndSeqFromAckReply(shdr)
+		streamName, iname, seq := streamAndSeqFromAckReply(shdr)
+		return streamName, iname, seq, _EMPTY_
 	}
 	// New version which is stream index name <SPC> sequence
 	fields := strings.Split(shdr, " ")
 	nFields := len(fields)
 
 	if nFields != 2 && nFields <= 3 {
-		return _EMPTY_, _EMPTY_, 0
+		return _EMPTY_, _EMPTY_, 0, _EMPTY_
 	}
 
+	streamName := fields[0]
 	if nFields >= 4 {
-		return fields[0], strings.Join([]string{fields[0], fields[2], fields[3]}, " "), uint64(parseAckReplyNum(fields[1]))
+		iname := strings.Join([]string{fields[0], fields[2], fields[3]}, " ")
+		seq := uint64(parseAckReplyNum(fields[1]))
+		var identity string
+		if nFields >= 6 {
+			// Copy, since it's stored on the sourceInfo.
+			identity = copyString(fields[5])
+		}
+		return streamName, iname, seq, identity
 	} else {
-		return fields[0], _EMPTY_, uint64(parseAckReplyNum(fields[1]))
+		seq := uint64(parseAckReplyNum(fields[1]))
+		return streamName, _EMPTY_, seq, _EMPTY_
 	}
 
 }
@@ -4649,11 +4729,12 @@ func (mset *stream) setStartingSequenceForSources(iNames map[string]struct{}) {
 			continue
 		}
 
-		streamName, indexName, sseq := streamAndSeq(bytesToString(ss))
+		streamName, indexName, sseq, identity := streamAndSeq(bytesToString(ss))
 		if _, ok := iNames[indexName]; ok {
 			si := mset.sources[indexName]
 			si.sseq = sseq
 			si.dseq = 0
+			si.ident, si.rc = identity, false
 			delete(iNames, indexName)
 			refreshSublist()
 		} else if indexName == _EMPTY_ && streamName != _EMPTY_ {
@@ -4663,6 +4744,7 @@ func (mset *stream) setStartingSequenceForSources(iNames map[string]struct{}) {
 					(mset.streamSource(iName).External != nil && streamName == si.name+":"+getHash(mset.streamSource(iName).External.ApiPrefix)) {
 					si.sseq = sseq
 					si.dseq = 0
+					si.ident, si.rc = _EMPTY_, false
 					delete(iNames, iName)
 					refreshSublist()
 					break
@@ -4728,24 +4810,6 @@ func (mset *stream) startingSequenceForSources() {
 		return
 	}
 
-	// For short circuiting return.
-	expected := len(mset.cfg.Sources)
-	seqs := make(map[string]uint64)
-
-	// Stamp our si seq records on the way out.
-	defer func() {
-		for sname, seq := range seqs {
-			// Ignore if not set.
-			if seq == 0 {
-				continue
-			}
-			if si := mset.sources[sname]; si != nil {
-				si.sseq = seq
-				si.dseq = 0
-			}
-		}
-	}()
-
 	// Generate a list of sources and, from that, a sublist that contains
 	// the interested filters (including transforms). As we figure out the
 	// starting sequence for each source, we will eliminate the source from
@@ -4779,11 +4843,19 @@ func (mset *stream) startingSequenceForSources() {
 	}
 	refreshSublist()
 
-	update := func(iName string, seq uint64) {
+	update := func(iName string, seq uint64, ident string) {
 		// Only update active in case we have older ones in here that got configured out.
 		if si := mset.sources[iName]; si != nil {
-			if _, ok := seqs[iName]; !ok {
-				seqs[iName] = seq
+			if _, ok := sources[iName]; ok {
+				// Ignore if not set.
+				if seq == 0 {
+					delete(sources, iName)
+					refreshSublist()
+					return
+				}
+				si.sseq = seq
+				si.dseq = 0
+				si.ident, si.rc = ident, false
 				delete(sources, iName)
 				refreshSublist()
 			}
@@ -4805,17 +4877,17 @@ func (mset *stream) startingSequenceForSources() {
 			continue
 		}
 
-		streamName, iName, sseq := streamAndSeq(bytesToString(ss))
+		streamName, iName, sseq, identity := streamAndSeq(bytesToString(ss))
 		if iName == _EMPTY_ { // Pre-2.10 message header means it's a match for any source using that stream name
 			for _, ssi := range mset.cfg.Sources {
 				if streamName == ssi.Name || (ssi.External != nil && streamName == ssi.Name+":"+getHash(ssi.External.ApiPrefix)) {
-					update(ssi.iname, sseq)
+					update(ssi.iname, sseq, _EMPTY_)
 				}
 			}
 		} else {
-			update(iName, sseq)
+			update(iName, sseq, identity)
 		}
-		if len(seqs) == expected {
+		if len(sources) == 0 {
 			return
 		}
 	}

--- a/server/stream.go
+++ b/server/stream.go
@@ -604,6 +604,7 @@ type sourceInfo struct {
 	name  string        // The name of the stream being sourced.
 	iname string        // The unique index name of this particular source.
 	cname string        // The name of the current consumer for this source.
+	ident string        // The identity of this source, a recreated stream results in a different ident.
 	sub   *subscription // The subscription to the consumer.
 
 	msgs  *ipQueue[*inMsg]    // Intra-process queue for incoming messages.
@@ -616,6 +617,7 @@ type sourceInfo struct {
 	lreq  time.Time           // The last time setupMirrorConsumer/setupSourceConsumer was called.
 	qch   chan struct{}       // Quit channel.
 	sip   bool                // Setup in progress.
+	rc    bool                // Recreate based on a stream identity mismatch.
 	wg    sync.WaitGroup      // WaitGroup for the consumer's go routine.
 	sf    string              // The subject filter.
 	sfs   []string            // The subject filters.
@@ -1193,6 +1195,17 @@ func (mset *stream) setStreamAssignment(sa *streamAssignment) {
 	case mset.uch <- struct{}{}:
 	default:
 	}
+}
+
+// identity returns a hash of the stream's creation time, used to detect stream recreation.
+func (mset *stream) identity() string {
+	return getHash(mset.createdTime().UTC().Format(time.RFC3339Nano))
+}
+
+// identity returns a hash of the stream's creation time, used to detect stream recreation.
+// JS lock should be held.
+func (sa *streamAssignment) identity() string {
+	return getHash(sa.Created.UTC().Format(time.RFC3339Nano))
 }
 
 func (mset *stream) monitorQuitC() <-chan struct{} {
@@ -4004,7 +4017,7 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 					req.Config.OptStartTime = ssi.OptStartTime
 				}
 				req.Config.DeliverPolicy = DeliverByStartTime
-			} else if state.FirstSeq > 1 && !state.LastTime.IsZero() {
+			} else if state.FirstSeq > 1 && !state.LastTime.IsZero() && !si.rc {
 				req.Config.OptStartTime = &state.LastTime
 				req.Config.DeliverPolicy = DeliverByStartTime
 			}
@@ -4025,18 +4038,26 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 	}
 	req.Config.FilterSubjects = filterSubjects
 
-	newReplySubscription := func() (string, chan *JSApiConsumerCreateResponse, *subscription, error) {
-		respCh := make(chan *JSApiConsumerCreateResponse, 1)
+	type consumerCreateResp struct {
+		ccr   *JSApiConsumerCreateResponse
+		ident string
+	}
+	newReplySubscription := func() (string, chan *consumerCreateResp, *subscription, error) {
+		respCh := make(chan *consumerCreateResp, 1)
 		reply := infoReplySubject()
 		crSub, err := mset.subscribeInternal(reply, func(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
-			_, msg := c.msgParts(rmsg)
+			hdr, msg := c.msgParts(rmsg)
 			var ccr JSApiConsumerCreateResponse
 			if err := json.Unmarshal(msg, &ccr); err != nil {
 				c.Warnf("JetStream bad source consumer create response: %q", msg)
 				return
 			}
+			var ident string
+			if si := sliceHeader(JSStreamIdentity, hdr); si != nil {
+				ident = string(si)
+			}
 			select {
-			case respCh <- &ccr:
+			case respCh <- &consumerCreateResp{ccr: &ccr, ident: ident}:
 			default:
 			}
 		})
@@ -4077,22 +4098,28 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 	si.err = nil
 	si.sip = true
 
+	// Three API levels can be tried:
+	// - API level 5: stream recreation detection.
+	// - API level 4: durable sourcing, AckFlowControl, and consumer reset.
+	// - not specified: used as fallback.
+	apiLevel := 5
+	hdr := genHeader(nil, JSRequiredApiLevel, strconv.Itoa(apiLevel))
+	hdr = genHeader(hdr, JSStreamIdentity, si.ident)
 	if durableDeliverSubject != _EMPTY_ {
 		// Send the consumer reset request
-		mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, nil, nil, nil, 0))
+		mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, hdr, nil, nil, 0))
 	} else {
 		// Marshal request.
 		b, _ := json.Marshal(req)
 
 		// Send the consumer create request
-		// Confirm the server supports API level 4, which contains durable sourcing, AckFlowControl, and consumer reset.
-		hdr := genHeader(nil, JSRequiredApiLevel, "4")
 		mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, hdr, b, nil, 0))
 	}
 
 	go func() {
 
 		var retry bool
+		var recreate bool
 		defer func() {
 			mset.mu.Lock()
 			// Check that this is still valid and if so, clear the "setup in progress" flag.
@@ -4101,7 +4128,9 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 				// If we need to retry, schedule now
 				// If sub is not nil means we re-established somewhere else so do not re-attempt here.
 				if retry && si.sub == nil {
-					si.fails++
+					if !recreate {
+						si.fails++
+					}
 					// Cancel here since we can not do anything with this consumer at this point.
 					mset.cancelSourceInfo(si)
 					mset.setupSourceConsumer(iname, seq, startTime)
@@ -4115,7 +4144,8 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 
 	SELECT:
 		select {
-		case ccr := <-respCh:
+		case resp := <-respCh:
+			ccr, streamIdentity := resp.ccr, resp.ident
 			mset.mu.Lock()
 			// Check that it has not been removed or canceled (si.sub would be nil)
 			if si := mset.sources[iname]; si == nil {
@@ -4124,9 +4154,41 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 				si.err = nil
 
 				if ccr.Error != nil || ccr.ConsumerInfo == nil || ccr.ConsumerInfo.Config == nil {
-					// If the responding server doesn't support sourcing consumers, retry without it.
+					// Retry after unsetting the expected stream's identity.
+					if ccr.Error != nil && ccr.Error.ErrCode == uint16(JSConsumerStreamIdentityMismatchF) {
+						mset.unsubscribe(crSub)
+						seq, si.sseq, si.dseq = 0, 0, 0
+						si.ident, si.rc = _EMPTY_, true
+						retry, recreate = true, true
+						mset.mu.Unlock()
+						return
+					}
+
+					// If the responding server doesn't support certain request settings, retry a 'downgraded' request.
 					if req.Config.Sourcing && ccr.Error != nil &&
 						(ccr.Error.ErrCode == uint16(JSRequiredApiLevelErr) || ccr.Error.ErrCode == uint16(JSInvalidJSONErr)) {
+						if apiLevel > 4 {
+							apiLevel--
+							// Recreate the reply subscription so we don't get stale responses from other servers.
+							mset.unsubscribe(crSub)
+							if reply, respCh, crSub, err = newReplySubscription(); err != nil {
+								si.err = NewJSSourceConsumerSetupFailedError(err, Unless(err))
+								retry = true
+								mset.mu.Unlock()
+								return
+							}
+							// Retry without stream identity.
+							hdr := genHeader(nil, JSRequiredApiLevel, strconv.Itoa(apiLevel))
+							var b []byte
+							if durableDeliverSubject == _EMPTY_ {
+								b, _ = json.Marshal(req)
+							}
+							mset.outq.send(newJSPubMsg(subject, _EMPTY_, reply, hdr, b, nil, 0))
+							mset.mu.Unlock()
+							goto SELECT
+						}
+
+						// If the responding server doesn't support sourcing consumers, retry without it.
 						// Unset for retry.
 						req.Config.Sourcing = false
 						// Specify a unique consumer name, as the other end will not know to do this.
@@ -4186,6 +4248,15 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 						},
 					)
 				}
+
+				// Capture identity to detect stream recreation.
+				recreated := si.rc || (streamIdentity != _EMPTY_ && si.ident != _EMPTY_ && si.ident != streamIdentity)
+				if recreated {
+					mset.srv.Warnf("JetStream source stream %q for stream '%s > %s' was recreated, resetting source state",
+						si.name, mset.acc.Name, mset.cfg.Name)
+					si.sseq = 0
+				}
+				si.ident, si.rc = streamIdentity, false
 
 				// Setup actual subscription to process messages from our source.
 				if si.sseq < ccr.ConsumerInfo.Delivered.Stream {
@@ -4436,7 +4507,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 	} else {
 		si.lag = pending - 1
 	}
-	node := mset.node
+	node, ident := mset.node, si.ident
 	mset.mu.Unlock()
 
 	hdr, msg := m.hdr, m.msg
@@ -4450,7 +4521,7 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 		hdr = removeHeaderIfPrefixPresent(hdr, "Nats-Batch-")
 	}
 	// Hold onto the origin reply which has all the metadata.
-	hdr = genHeader(hdr, JSStreamSource, si.genSourceHeader(m.subj, m.rply))
+	hdr = genHeader(hdr, JSStreamSource, si.genSourceHeader(m.subj, m.rply, ident))
 
 	// Do the subject transform for the source if there's one
 	if len(si.trs) > 0 {
@@ -4515,7 +4586,9 @@ func (mset *stream) processInboundSourceMsg(si *sourceInfo, m *inMsg) bool {
 }
 
 // Generate a new (2.10) style source header (stream name, sequence number, source filter, source destination transform).
-func (si *sourceInfo) genSourceHeader(orig, reply string) string {
+// The source's ident must be passed in, as it can be mutated under the stream lock, which is not held here.
+// Format: <stream> <seq> <filter> <transform> <orig> [<ident>]
+func (si *sourceInfo) genSourceHeader(orig, reply, ident string) string {
 	var b strings.Builder
 	iNameParts := strings.Split(si.iname, " ")
 
@@ -4546,6 +4619,10 @@ func (si *sourceInfo) genSourceHeader(orig, reply string) string {
 	b.WriteString(iNameParts[2])
 	b.WriteByte(' ')
 	b.WriteString(orig)
+	if ident != _EMPTY_ {
+		b.WriteByte(' ')
+		b.WriteString(ident)
+	}
 	return b.String()
 }
 
@@ -4590,22 +4667,33 @@ func consumerFromAckReply(reply string) string {
 
 // Extract the stream name, the source index name and the message sequence number from the source header.
 // Uses the filter and transform arguments to provide backwards compatibility
-func streamAndSeq(shdr string) (string, string, uint64) {
+// Format: <stream> <seq> <filter> <transform> <orig> [<ident>]
+func streamAndSeq(shdr string) (string, string, uint64, string) {
 	if strings.HasPrefix(shdr, jsAckPre) {
-		return streamAndSeqFromAckReply(shdr)
+		streamName, iname, seq := streamAndSeqFromAckReply(shdr)
+		return streamName, iname, seq, _EMPTY_
 	}
 	// New version which is stream index name <SPC> sequence
 	fields := strings.Split(shdr, " ")
 	nFields := len(fields)
 
 	if nFields != 2 && nFields <= 3 {
-		return _EMPTY_, _EMPTY_, 0
+		return _EMPTY_, _EMPTY_, 0, _EMPTY_
 	}
 
+	streamName := fields[0]
 	if nFields >= 4 {
-		return fields[0], strings.Join([]string{fields[0], fields[2], fields[3]}, " "), uint64(parseAckReplyNum(fields[1]))
+		iname := strings.Join([]string{fields[0], fields[2], fields[3]}, " ")
+		seq := uint64(parseAckReplyNum(fields[1]))
+		var identity string
+		if nFields >= 6 {
+			// Copy, since it's stored on the sourceInfo.
+			identity = copyString(fields[5])
+		}
+		return streamName, iname, seq, identity
 	} else {
-		return fields[0], _EMPTY_, uint64(parseAckReplyNum(fields[1]))
+		seq := uint64(parseAckReplyNum(fields[1]))
+		return streamName, _EMPTY_, seq, _EMPTY_
 	}
 
 }
@@ -4676,11 +4764,12 @@ func (mset *stream) setStartingSequenceForSources(iNames map[string]struct{}) {
 			continue
 		}
 
-		streamName, indexName, sseq := streamAndSeq(bytesToString(ss))
+		streamName, indexName, sseq, identity := streamAndSeq(bytesToString(ss))
 		if _, ok := iNames[indexName]; ok {
 			si := mset.sources[indexName]
 			si.sseq = sseq
 			si.dseq = 0
+			si.ident, si.rc = identity, false
 			delete(iNames, indexName)
 			refreshSublist()
 		} else if indexName == _EMPTY_ && streamName != _EMPTY_ {
@@ -4690,6 +4779,7 @@ func (mset *stream) setStartingSequenceForSources(iNames map[string]struct{}) {
 					(mset.streamSource(iName).External != nil && streamName == si.name+":"+getHash(mset.streamSource(iName).External.ApiPrefix)) {
 					si.sseq = sseq
 					si.dseq = 0
+					si.ident, si.rc = _EMPTY_, false
 					delete(iNames, iName)
 					refreshSublist()
 					break
@@ -4755,24 +4845,6 @@ func (mset *stream) startingSequenceForSources() {
 		return
 	}
 
-	// For short circuiting return.
-	expected := len(mset.cfg.Sources)
-	seqs := make(map[string]uint64)
-
-	// Stamp our si seq records on the way out.
-	defer func() {
-		for sname, seq := range seqs {
-			// Ignore if not set.
-			if seq == 0 {
-				continue
-			}
-			if si := mset.sources[sname]; si != nil {
-				si.sseq = seq
-				si.dseq = 0
-			}
-		}
-	}()
-
 	// Generate a list of sources and, from that, a sublist that contains
 	// the interested filters (including transforms). As we figure out the
 	// starting sequence for each source, we will eliminate the source from
@@ -4806,11 +4878,19 @@ func (mset *stream) startingSequenceForSources() {
 	}
 	refreshSublist()
 
-	update := func(iName string, seq uint64) {
+	update := func(iName string, seq uint64, ident string) {
 		// Only update active in case we have older ones in here that got configured out.
 		if si := mset.sources[iName]; si != nil {
-			if _, ok := seqs[iName]; !ok {
-				seqs[iName] = seq
+			if _, ok := sources[iName]; ok {
+				// Ignore if not set.
+				if seq == 0 {
+					delete(sources, iName)
+					refreshSublist()
+					return
+				}
+				si.sseq = seq
+				si.dseq = 0
+				si.ident, si.rc = ident, false
 				delete(sources, iName)
 				refreshSublist()
 			}
@@ -4832,17 +4912,17 @@ func (mset *stream) startingSequenceForSources() {
 			continue
 		}
 
-		streamName, iName, sseq := streamAndSeq(bytesToString(ss))
+		streamName, iName, sseq, identity := streamAndSeq(bytesToString(ss))
 		if iName == _EMPTY_ { // Pre-2.10 message header means it's a match for any source using that stream name
 			for _, ssi := range mset.cfg.Sources {
 				if streamName == ssi.Name || (ssi.External != nil && streamName == ssi.Name+":"+getHash(ssi.External.ApiPrefix)) {
-					update(ssi.iname, sseq)
+					update(ssi.iname, sseq, _EMPTY_)
 				}
 			}
 		} else {
-			update(iName, sseq)
+			update(iName, sseq, identity)
 		}
-		if len(seqs) == expected {
+		if len(sources) == 0 {
 			return
 		}
 	}


### PR DESCRIPTION
Previously if you started sourcing from a stream that was recreated, it would wait for the recreated stream's sequence to move back up to the last sourced sequence before it accepted new messages. This PR detects a stream being recreated by noticing a changed `Nats-Stream-Identity`, which is the hash of the stream's created time. There exists no unique identifier for a stream/consumer lifetime apart from the created time, so that's used and is the most practical since collisions are unlikely enough.

- This hash is appended to the source header to know what "identity" of the stream was associated with the highest sequence for that source. (source header before: `TEST 1 > > foo`, after: `TEST 1 > > foo sLkPMPK6`)
- This identity is passed in the consumer create request to prevent a consumer from being created based on sequences derived from the previous stream. An error is returned (`JSConsumerStreamIdentityMismatch`) if a mismatch is detected, the request is then retried with reset sequences to allow sourcing from the beginning.
- The consumer reset request does not allow for the identity to be passed in, and instead relies on the caller to notice a different identity and subsequent in-memory state reset. This prevents unnecessary churn of requests since the reset will always happen based on a consumer that already exists and needs to be reset anyway.
- Both the consumer create and reset responses contain this identity to get informed of the latest identity of the stream, which is then passed into the source header.

This PR additionally requires that the starting sequence for a consumer is respected, even for sourcing consumers that were previously (incorrectly) clamped within the sourced stream's first/last sequence range.

Upgrade note: the servers on both ends will need to be updated for this mechanism to kick in. A downgrade should ignore the extra appended identity from the header and fall back to the previous behavior.

Resolves https://github.com/nats-io/nats-server/issues/8346, https://github.com/nats-io/nats-server/issues/6206, https://github.com/nats-io/nats-server/issues/5847