### PR TITLE
Fix stream publish checks to include filestore max message size

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7551,7 +7551,7 @@ func (fs *fileStore) checkLastBlock(rl uint64) (lmb *msgBlock, err error) {
 func (fs *fileStore) writeMsgRecord(seq uint64, ts int64, subj string, hdr, msg []byte) (uint64, error) {
 	// Get size for this message.
 	rl := fileStoreMsgSize(subj, hdr, msg)
-	if rl&hbit != 0 || rl > rlBadThresh {
+	if isFileStoreMsgTooLarge(rl) {
 		return 0, ErrMsgTooLarge
 	}
 	// Grab our current last message block.
@@ -9650,6 +9650,12 @@ func fileStoreMsgSizeRaw(slen, hlen, mlen int) uint64 {
 
 func fileStoreMsgSize(subj string, hdr, msg []byte) uint64 {
 	return fileStoreMsgSizeRaw(len(subj), len(hdr), len(msg))
+}
+
+// isFileStoreMsgTooLarge reports whether a message record cannot be represented
+// safely by the file store.
+func isFileStoreMsgTooLarge(rl uint64) bool {
+	return rl&hbit != 0 || rl > rlBadThresh
 }
 
 func fileStoreMsgSizeEstimate(slen, maxPayload int) uint64 {

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -537,6 +537,12 @@ func checkMsgHeadersPreClusteredProposal(
 	var incr *big.Int
 	var hasSchedule bool
 
+	// Do this before staging any proposal state. All clustered publish paths,
+	// including atomic and fast batches, use this helper.
+	if mset.store.Type() == FileStorage && isFileStoreMsgTooLarge(fileStoreMsgSize(subject, hdr, msg)) {
+		return hdr, msg, 0, NewJSStreamStoreFailedError(ErrMsgTooLarge), ErrMsgTooLarge
+	}
+
 	// Some header checks must be checked pre proposal.
 	if len(hdr) > 0 {
 		// Since we encode header len as u16 make sure we do not exceed.

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -2841,6 +2841,48 @@ func TestJetStreamClusterLargeHeaders(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterRejectLargePublishesBeforeProposal(t *testing.T) {
+	// Allow a client publish that exceeds the file store's record-size limit.
+	tmpl := strings.Replace(jsClusterTempl, "listen: 127.0.0.1:-1", fmt.Sprintf("listen: 127.0.0.1:-1\nmax_payload: %d", rlBadThresh+2048), 1)
+	c := createJetStreamClusterWithTemplate(t, tmpl, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+		Storage:  nats.FileStorage,
+	})
+	require_NoError(t, err)
+	c.waitOnStreamLeader("$G", "TEST")
+
+	_, err = js.Publish("foo", make([]byte, rlBadThresh+1024))
+	require_Error(t, err)
+	require_Contains(t, err.Error(), ErrMsgTooLarge.Error())
+
+	// The rejected message must never be proposed to the raft group: every
+	// replica remains writable and accepts the next valid publish.
+	pa, err := js.Publish("foo", []byte("ok"))
+	require_NoError(t, err)
+	require_Equal(t, pa.Sequence, 1)
+	c.waitOnAllCurrent()
+
+	for _, s := range c.servers {
+		mset, err := s.GlobalAccount().lookupStream("TEST")
+		require_NoError(t, err)
+		require_Equal(t, mset.state().Msgs, uint64(1))
+		fs, ok := mset.store.(*fileStore)
+		require_True(t, ok)
+		fs.mu.RLock()
+		werr := fs.werr
+		fs.mu.RUnlock()
+		require_NoError(t, werr)
+	}
+}
+
 func TestJetStreamClusterFlowControlRequiresHeartbeats(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -2883,6 +2883,69 @@ func TestJetStreamClusterRejectLargePublishesBeforeProposal(t *testing.T) {
 	}
 }
 
+func TestJetStreamClusterMirrorRejectsLargeMessagesBeforeProposal(t *testing.T) {
+	// The source is memory backed, so it can accept a record that a file-backed
+	// mirror cannot represent.
+	tmpl := strings.Replace(jsClusterTempl, "listen: 127.0.0.1:-1", fmt.Sprintf("listen: 127.0.0.1:-1\nmax_payload: %d", rlBadThresh+2048), 1)
+	c := createJetStreamClusterWithTemplate(t, tmpl, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "SOURCE",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+		Storage:  nats.MemoryStorage,
+	})
+	require_NoError(t, err)
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     "MIRROR",
+		Replicas: 3,
+		Storage:  nats.FileStorage,
+		Mirror:   &nats.StreamSource{Name: "SOURCE"},
+	})
+	require_NoError(t, err)
+	c.waitOnStreamLeader("$G", "SOURCE")
+	c.waitOnStreamLeader("$G", "MIRROR")
+
+	_, err = js.Publish("foo", make([]byte, rlBadThresh+1024))
+	require_NoError(t, err)
+
+	// The mirror receives the source message but must reject it before it is
+	// proposed to its raft group.
+	checkFor(t, 5*time.Second, 50*time.Millisecond, func() error {
+		s := c.streamLeader("$G", "MIRROR")
+		if s == nil {
+			return errors.New("mirror has no leader")
+		}
+		mset, err := s.GlobalAccount().lookupStream("MIRROR")
+		if err != nil {
+			return err
+		}
+		mset.mu.RLock()
+		sseq := mset.mirror.sseq
+		mset.mu.RUnlock()
+		if sseq != 1 {
+			return fmt.Errorf("expected mirror to receive source sequence 1, got %d", sseq)
+		}
+		return nil
+	})
+
+	for _, s := range c.servers {
+		mset, err := s.GlobalAccount().lookupStream("MIRROR")
+		require_NoError(t, err)
+		require_Equal(t, mset.state().Msgs, uint64(0))
+		fs, ok := mset.store.(*fileStore)
+		require_True(t, ok)
+		fs.mu.RLock()
+		werr := fs.werr
+		fs.mu.RUnlock()
+		require_NoError(t, werr)
+	}
+}
+
 func TestJetStreamClusterFlowControlRequiresHeartbeats(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -20307,6 +20307,11 @@ func TestJetStreamRejectLargePublishes(t *testing.T) {
 	_, err = js.Publish("test", make([]byte, rlBadThresh+1024))
 	require_Error(t, err)
 	require_Contains(t, err.Error(), ErrMsgTooLarge.Error())
+
+	// The oversized publish is rejected before reaching StoreMsg, so it must
+	// not prevent later valid publishes.
+	_, err = js.Publish("test", []byte("ok"))
+	require_NoError(t, err)
 }
 
 func TestJetStreamDirectGetSubjectDeleteMarker(t *testing.T) {

--- a/server/stream.go
+++ b/server/stream.go
@@ -3265,7 +3265,9 @@ func (mset *stream) processInboundMirrorMsg(m *inMsg) bool {
 
 	var err error
 	if node != nil {
-		if js.limitsExceeded(stype) {
+		if stype == FileStorage && isFileStoreMsgTooLarge(fileStoreMsgSize(m.subj, m.hdr, m.msg)) {
+			err = ErrMsgTooLarge
+		} else if js.limitsExceeded(stype) {
 			s.resourcesExceededError(stype)
 			err = ApiErrors[JSInsufficientResourcesErr]
 		} else {

--- a/server/stream.go
+++ b/server/stream.go
@@ -6194,6 +6194,16 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 
 	var resp = &JSPubAckResponse{}
 
+	if canConsistencyCheck && stype == FileStorage && isFileStoreMsgTooLarge(fileStoreMsgSize(subject, hdr, msg)) {
+		if canRespond {
+			resp.PubAck = &PubAck{Stream: name}
+			resp.Error = NewJSStreamStoreFailedError(ErrMsgTooLarge)
+			response, _ := json.Marshal(resp)
+			outq.sendMsg(reply, response)
+		}
+		return ErrMsgTooLarge
+	}
+
 	var (
 		batchId  string
 		batchSeq uint64


### PR DESCRIPTION
This should fix #8386 by rejecting messages that are larger than the maximum filestore permitted size. This is only really a problem when `max_payload` has been increased beyond 32MB, which isn't recommended anyway.

We check the max file store size before proposal, otherwise in cluster mode we will run into problems when applying AEs.