### PR TITLE
[ADDED] Allow verify_and_map to group TLS clients by certificate attribute

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -755,12 +755,14 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 		pinnedAcounts map[string]struct{}
 	)
 	tlsMap := opts.TLSMap
+	certMapTmpl := tlsCertMapTemplate(opts.tlsConfigOpts)
 	if c.kind == CLIENT {
 		switch c.clientType() {
 		case MQTT:
 			mo := &opts.MQTT
 			// Always override TLSMap.
 			tlsMap = mo.TLSMap
+			certMapTmpl = tlsCertMapTemplate(mo.tlsConfigOpts)
 			// The rest depends on if there was any auth override in
 			// the mqtt's config.
 			if s.mqtt.authOverride {
@@ -774,6 +776,7 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 			wo := &opts.Websocket
 			// Always override TLSMap.
 			tlsMap = wo.TLSMap
+			certMapTmpl = tlsCertMapTemplate(wo.tlsConfigOpts)
 			// The rest depends on if there was any auth override in
 			// the websocket's config.
 			if s.websocket.authOverride {
@@ -786,6 +789,7 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 		}
 	} else {
 		tlsMap = opts.LeafNode.TLSMap
+		certMapTmpl = tlsCertMapTemplate(opts.LeafNode.tlsConfigOpts)
 	}
 
 	if !ao {
@@ -877,54 +881,66 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 	if hasUsers && nkey == nil {
 		// Check if we are tls verify and are mapping users from the client_certificate.
 		if tlsMap {
-			authorized := checkClientTLSCertSubject(c, func(u string, certDN *ldap.DN, _ bool) (string, bool) {
-				// First do literal lookup using the resulting string representation
-				// of RDNSequence as implemented by the pkix package from Go.
-				if u != _EMPTY_ {
+			var authorized bool
+			if certMapTmpl != nil {
+				authorized = mapCertTemplateToUser(c, certMapTmpl, func(u string) (string, bool) {
 					usr, ok := s.users[u]
-					if !ok || !c.connectionTypeAllowed(usr.AllowedConnectionTypes) {
+					if u == _EMPTY_ || !ok || !c.connectionTypeAllowed(usr.AllowedConnectionTypes) {
 						return _EMPTY_, false
 					}
 					user = usr
 					return usr.Username, true
-				}
+				})
+			} else {
+				authorized = checkClientTLSCertSubject(c, func(u string, certDN *ldap.DN, _ bool) (string, bool) {
+					// First do literal lookup using the resulting string representation
+					// of RDNSequence as implemented by the pkix package from Go.
+					if u != _EMPTY_ {
+						usr, ok := s.users[u]
+						if !ok || !c.connectionTypeAllowed(usr.AllowedConnectionTypes) {
+							return _EMPTY_, false
+						}
+						user = usr
+						return usr.Username, true
+					}
 
-				if certDN == nil {
+					if certDN == nil {
+						return _EMPTY_, false
+					}
+
+					// Look through the accounts for a DN that is equal to the one
+					// presented by the certificate.
+					dns := make(map[*User]*ldap.DN)
+					for _, usr := range s.users {
+						if !c.connectionTypeAllowed(usr.AllowedConnectionTypes) {
+							continue
+						}
+						// TODO: Use this utility to make a full validation pass
+						// on start in case tlsmap feature is being used.
+						inputDN, err := ldap.ParseDN(usr.Username)
+						if err != nil {
+							continue
+						}
+						if inputDN.Equal(certDN) {
+							user = usr
+							return usr.Username, true
+						}
+
+						// In case it did not match exactly, then collect the DNs
+						// and try to match later in case the DN was reordered.
+						dns[usr] = inputDN
+					}
+
+					// Check in case the DN was reordered.
+					for usr, inputDN := range dns {
+						if inputDN.RDNsMatch(certDN) {
+							user = usr
+							return usr.Username, true
+						}
+					}
 					return _EMPTY_, false
-				}
-
-				// Look through the accounts for a DN that is equal to the one
-				// presented by the certificate.
-				dns := make(map[*User]*ldap.DN)
-				for _, usr := range s.users {
-					if !c.connectionTypeAllowed(usr.AllowedConnectionTypes) {
-						continue
-					}
-					// TODO: Use this utility to make a full validation pass
-					// on start in case tlsmap feature is being used.
-					inputDN, err := ldap.ParseDN(usr.Username)
-					if err != nil {
-						continue
-					}
-					if inputDN.Equal(certDN) {
-						user = usr
-						return usr.Username, true
-					}
-
-					// In case it did not match exactly, then collect the DNs
-					// and try to match later in case the DN was reordered.
-					dns[usr] = inputDN
-				}
-
-				// Check in case the DN was reordered.
-				for usr, inputDN := range dns {
-					if inputDN.RDNsMatch(certDN) {
-						user = usr
-						return usr.Username, true
-					}
-				}
-				return _EMPTY_, false
-			})
+				})
+			}
 			if !authorized {
 				s.mu.Unlock()
 				return false
@@ -1571,7 +1587,7 @@ func (s *Server) isLeafNodeAuthorized(c *client) bool {
 	} else if len(opts.LeafNode.Users) > 0 {
 		if opts.LeafNode.TLSMap {
 			var user *User
-			found := checkClientTLSCertSubject(c, func(u string, _ *ldap.DN, _ bool) (string, bool) {
+			lookup := func(u string) (string, bool) {
 				// This is expected to be a very small array.
 				for _, usr := range opts.LeafNode.Users {
 					if u == usr.Username {
@@ -1580,7 +1596,15 @@ func (s *Server) isLeafNodeAuthorized(c *client) bool {
 					}
 				}
 				return _EMPTY_, false
-			})
+			}
+			var found bool
+			if tmpl := tlsCertMapTemplate(opts.LeafNode.tlsConfigOpts); tmpl != nil {
+				found = mapCertTemplateToUser(c, tmpl, lookup)
+			} else {
+				found = checkClientTLSCertSubject(c, func(u string, _ *ldap.DN, _ bool) (string, bool) {
+					return lookup(u)
+				})
+			}
 			if !found {
 				return false
 			}

--- a/server/auth.go
+++ b/server/auth.go
@@ -788,6 +788,9 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 			}
 		}
 	} else {
+		// A leaf tunneled over websocket terminates TLS with the websocket{}
+		// config but still maps from here, so a verify_and_map set only
+		// under websocket{} won't apply. Long-standing TLSMap behavior.
 		tlsMap = opts.LeafNode.TLSMap
 		certMapTmpl = tlsCertMapTemplate(opts.LeafNode.tlsConfigOpts)
 	}
@@ -881,18 +884,16 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 	if hasUsers && nkey == nil {
 		// Check if we are tls verify and are mapping users from the client_certificate.
 		if tlsMap {
-			var authorized bool
-			if certMapTmpl != nil {
-				authorized = mapCertTemplateToUser(c, certMapTmpl, func(u string) (string, bool) {
+			authorized := mapCertToUser(c, certMapTmpl,
+				func(u string) (string, bool) {
 					usr, ok := s.users[u]
 					if u == _EMPTY_ || !ok || !c.connectionTypeAllowed(usr.AllowedConnectionTypes) {
 						return _EMPTY_, false
 					}
 					user = usr
 					return usr.Username, true
-				})
-			} else {
-				authorized = checkClientTLSCertSubject(c, func(u string, certDN *ldap.DN, _ bool) (string, bool) {
+				},
+				func(u string, certDN *ldap.DN, _ bool) (string, bool) {
 					// First do literal lookup using the resulting string representation
 					// of RDNSequence as implemented by the pkix package from Go.
 					if u != _EMPTY_ {
@@ -940,7 +941,6 @@ func (s *Server) processClientOrLeafAuthentication(c *client, opts *Options) (au
 					}
 					return _EMPTY_, false
 				})
-			}
 			if !authorized {
 				s.mu.Unlock()
 				return false
@@ -1597,14 +1597,10 @@ func (s *Server) isLeafNodeAuthorized(c *client) bool {
 				}
 				return _EMPTY_, false
 			}
-			var found bool
-			if tmpl := tlsCertMapTemplate(opts.LeafNode.tlsConfigOpts); tmpl != nil {
-				found = mapCertTemplateToUser(c, tmpl, lookup)
-			} else {
-				found = checkClientTLSCertSubject(c, func(u string, _ *ldap.DN, _ bool) (string, bool) {
+			found := mapCertToUser(c, tlsCertMapTemplate(opts.LeafNode.tlsConfigOpts), lookup,
+				func(u string, _ *ldap.DN, _ bool) (string, bool) {
 					return lookup(u)
 				})
-			}
 			if !found {
 				return false
 			}

--- a/server/certidmap.go
+++ b/server/certidmap.go
@@ -27,15 +27,18 @@ import (
 // Subject attributes are slices since a DN may legally repeat an attribute
 // (e.g. more than one OU).
 type certIDMapData struct {
-	CommonName         string
-	SerialNumber       string
-	Organization       []string
-	OrganizationalUnit []string
-	Locality           []string
-	Province           []string
-	Country            []string
-	StreetAddress      []string
-	PostalCode         []string
+	CommonName string
+	// crypto/x509 spells both of these "SerialNumber": the CA-assigned one
+	// on the certificate, the subject DN attribute on its pkix.Name.
+	SerialNumber        string
+	SubjectSerialNumber string
+	Organization        []string
+	OrganizationalUnit  []string
+	Locality            []string
+	Province            []string
+	Country             []string
+	StreetAddress       []string
+	PostalCode          []string
 
 	DNSNames       []string
 	EmailAddresses []string
@@ -45,17 +48,20 @@ type certIDMapData struct {
 
 func newCertIDMapData(cert *x509.Certificate) *certIDMapData {
 	d := &certIDMapData{
-		CommonName:         cert.Subject.CommonName,
-		SerialNumber:       cert.Subject.SerialNumber,
-		Organization:       cert.Subject.Organization,
-		OrganizationalUnit: cert.Subject.OrganizationalUnit,
-		Locality:           cert.Subject.Locality,
-		Province:           cert.Subject.Province,
-		Country:            cert.Subject.Country,
-		StreetAddress:      cert.Subject.StreetAddress,
-		PostalCode:         cert.Subject.PostalCode,
-		DNSNames:           cert.DNSNames,
-		EmailAddresses:     cert.EmailAddresses,
+		CommonName:          cert.Subject.CommonName,
+		SubjectSerialNumber: cert.Subject.SerialNumber,
+		Organization:        cert.Subject.Organization,
+		OrganizationalUnit:  cert.Subject.OrganizationalUnit,
+		Locality:            cert.Subject.Locality,
+		Province:            cert.Subject.Province,
+		Country:             cert.Subject.Country,
+		StreetAddress:       cert.Subject.StreetAddress,
+		PostalCode:          cert.Subject.PostalCode,
+		DNSNames:            cert.DNSNames,
+		EmailAddresses:      cert.EmailAddresses,
+	}
+	if cert.SerialNumber != nil {
+		d.SerialNumber = cert.SerialNumber.String()
 	}
 	for _, ip := range cert.IPAddresses {
 		d.IPAddresses = append(d.IPAddresses, ip.String())
@@ -81,47 +87,62 @@ var certIDMapFuncs = template.FuncMap{
 	},
 }
 
-// sampleCertIDMapData is used to validate a `verify_and_map` template at
-// config-load time. Fields carry 2 entries, not 0, so a fixed-index lookup
-// like `{{index .OrganizationalUnit 1}}` doesn't fail validation just
-// because this sample is thinner than a real cert.
-func sampleCertIDMapData() *certIDMapData {
-	sample := []string{"sample", "sample"}
+// sampleCertIDMapData is the data a template is validated against. n sets
+// both slice length and string length, since index/slice work on strings
+// too; see certIDMapSampleLen.
+func sampleCertIDMapData(n int) *certIDMapData {
+	scalar := "sample"
+	if n > len(scalar) {
+		scalar = strings.Repeat("s", n)
+	}
+	sample := make([]string, n)
+	for i := range sample {
+		sample[i] = scalar
+	}
 	return &certIDMapData{
-		CommonName:         "sample",
-		SerialNumber:       "sample",
-		Organization:       sample,
-		OrganizationalUnit: sample,
-		Locality:           sample,
-		Province:           sample,
-		Country:            sample,
-		StreetAddress:      sample,
-		PostalCode:         sample,
-		DNSNames:           sample,
-		EmailAddresses:     sample,
-		IPAddresses:        sample,
-		URIs:               sample,
+		CommonName:          scalar,
+		SerialNumber:        scalar,
+		SubjectSerialNumber: scalar,
+		Organization:        sample,
+		OrganizationalUnit:  sample,
+		Locality:            sample,
+		Province:            sample,
+		Country:             sample,
+		StreetAddress:       sample,
+		PostalCode:          sample,
+		DNSNames:            sample,
+		EmailAddresses:      sample,
+		IPAddresses:         sample,
+		URIs:                sample,
 	}
 }
 
 // validateCertIDMapTemplate executes every {{if}}/{{else}} branch against
-// sample data, not just whichever branch the sample happens to take, so a
-// mistake gated on a real certificate's value (e.g. an OU of "prod") is
-// still caught at config load.
-//
-// This is only sound because dot always refers to the root certIDMapData:
-// collectCertIDMapBranchLists rejects anything that could rebind it or
-// depend on a value from an enclosing scope.
+// sample data, so a mistake gated on a real certificate's value (an OU of
+// "prod", say) still fails at config load. Executing a branch on its own is
+// only sound because dot can never be rebound - see
+// collectCertIDMapBranchLists.
 func validateCertIDMapTemplate(tmpl *template.Template) error {
-	var lists []*parse.ListNode
-	if err := collectCertIDMapBranchLists(tmpl.Tree.Root, &lists); err != nil {
-		return err
+	var (
+		lists   []*parse.ListNode
+		sampleN = minCertIDMapSampleLen
+	)
+	// A {{define}} block gets its own tree, so tmpl.Tree.Root alone would
+	// leave its contents unvalidated.
+	for _, t := range tmpl.Templates() {
+		if t.Tree == nil {
+			continue
+		}
+		if err := collectCertIDMapBranchLists(t.Tree.Root, &lists); err != nil {
+			return err
+		}
+		if n := certIDMapSampleLen(t.Tree.Root); n > sampleN {
+			sampleN = n
+		}
 	}
-	// Execute each collected branch list as if it were the whole template,
-	// restoring the real root afterwards.
 	root := tmpl.Tree.Root
 	defer func() { tmpl.Tree.Root = root }()
-	data := sampleCertIDMapData()
+	data := sampleCertIDMapData(sampleN)
 	for _, list := range lists {
 		tmpl.Tree.Root = list
 		if err := tmpl.Execute(new(strings.Builder), data); err != nil {
@@ -131,84 +152,44 @@ func validateCertIDMapTemplate(tmpl *template.Template) error {
 	return nil
 }
 
-// collectCertIDMapBranchLists gathers the root list and every {{if}}/{{else}}
-// branch list beneath it, rejecting range/with/template (rebind dot or
-// splice in another template) and variable declarations (undefined once
-// their branch is executed in isolation).
-func collectCertIDMapBranchLists(n parse.Node, lists *[]*parse.ListNode) error {
-	if n == nil {
-		return nil
-	}
-	switch x := n.(type) {
-	case *parse.ListNode:
-		if x == nil {
-			return nil
-		}
-		*lists = append(*lists, x)
-		for _, c := range x.Nodes {
-			if err := collectCertIDMapBranchLists(c, lists); err != nil {
-				return err
+// collectCertIDMapBranchLists gathers a tree's root list and every
+// {{if}}/{{else}} branch list beneath it, rejecting what would make a branch
+// unsafe to execute alone: range, with, template and variable declarations.
+func collectCertIDMapBranchLists(root parse.Node, lists *[]*parse.ListNode) error {
+	return walkCertIDMapNodes(root, func(n parse.Node) error {
+		switch x := n.(type) {
+		case *parse.ListNode:
+			*lists = append(*lists, x)
+		case *parse.RangeNode:
+			return fmt.Errorf("range is not supported in verify_and_map templates")
+		case *parse.WithNode:
+			return fmt.Errorf("with is not supported in verify_and_map templates")
+		case *parse.TemplateNode:
+			return fmt.Errorf("template is not supported in verify_and_map templates")
+		case *parse.PipeNode:
+			if len(x.Decl) > 0 {
+				return fmt.Errorf("variable declarations are not supported in verify_and_map templates")
 			}
-		}
-	case *parse.IfNode:
-		if err := collectCertIDMapBranchLists(x.Pipe, lists); err != nil {
-			return err
-		}
-		if err := collectCertIDMapBranchLists(x.List, lists); err != nil {
-			return err
-		}
-		return collectCertIDMapBranchLists(x.ElseList, lists)
-	case *parse.RangeNode:
-		return fmt.Errorf("range is not supported in verify_and_map templates")
-	case *parse.WithNode:
-		return fmt.Errorf("with is not supported in verify_and_map templates")
-	case *parse.TemplateNode:
-		return fmt.Errorf("template is not supported in verify_and_map templates")
-	case *parse.ActionNode:
-		return collectCertIDMapBranchLists(x.Pipe, lists)
-	case *parse.PipeNode:
-		if x == nil {
-			return nil
-		}
-		if len(x.Decl) > 0 {
-			return fmt.Errorf("variable declarations are not supported in verify_and_map templates")
-		}
-		for _, c := range x.Cmds {
-			if err := collectCertIDMapBranchLists(c, lists); err != nil {
-				return err
+		case *parse.CommandNode:
+			// and/or short-circuit, so give each operand that might be
+			// skipped its own list. Args[1] always runs and the walk already
+			// covers it - starting at Args[2] keeps this linear.
+			if !isCertIDMapShortCircuitCall(x) || len(x.Args) < 3 {
+				return nil
 			}
-		}
-	case *parse.CommandNode:
-		// and/or short-circuit, so an operand after the first may never
-		// actually be evaluated (e.g. `and (has "prod" .OU) .NoSuchField`
-		// never touches .NoSuchField unless the sample OU is "prod") -
-		// give each such operand its own list so it gets executed anyway.
-		if isCertIDMapShortCircuitCall(x) {
-			for _, a := range x.Args[1:] {
-				// nil has no fields or calls to validate, and - unlike
-				// every other literal - isn't valid as a standalone
-				// action (`{{nil}}` fails to execute on its own even
-				// though `and x nil` is a normal operand), so wrapping
-				// it would reject an otherwise valid template.
+			for _, a := range x.Args[2:] {
+				// nil, unlike every other literal, isn't valid as a
+				// standalone action even though it's a normal operand.
 				if isCertIDMapNilOperand(a) {
 					continue
 				}
 				*lists = append(*lists, certIDMapOperandList(a))
 			}
 		}
-		for _, a := range x.Args {
-			if err := collectCertIDMapBranchLists(a, lists); err != nil {
-				return err
-			}
-		}
-	case *parse.ChainNode:
-		return collectCertIDMapBranchLists(x.Node, lists)
-	}
-	return nil
+		return nil
+	})
 }
 
-// isCertIDMapShortCircuitCall reports whether cmd calls the short-circuiting
-// and/or builtins, whose operands after the first aren't always evaluated.
 func isCertIDMapShortCircuitCall(cmd *parse.CommandNode) bool {
 	if len(cmd.Args) == 0 {
 		return false
@@ -217,19 +198,118 @@ func isCertIDMapShortCircuitCall(cmd *parse.CommandNode) bool {
 	return ok && (ident.Ident == "and" || ident.Ident == "or")
 }
 
-// isCertIDMapNilOperand reports whether n is the bare, unparenthesized nil
-// keyword. Parenthesized (nil) is deliberately not matched here: unlike bare
-// nil it's genuinely invalid (text/template errors evaluating it, whether
-// standalone or as a real and/or operand once short-circuiting reaches it),
-// so it must still go through normal validation rather than being skipped.
+// Bare nil only: parenthesized (nil) is genuinely invalid and must still be
+// validated.
 func isCertIDMapNilOperand(n parse.Node) bool {
 	_, ok := n.(*parse.NilNode)
 	return ok
 }
 
-// certIDMapOperandList wraps a single operand node in a standalone action
-// list, so it can be executed on its own even though text/template might
-// never evaluate it in place (see isCertIDMapShortCircuitCall).
+const minCertIDMapSampleLen = 2
+
+// Caps growth so a mistyped huge literal fails validation rather than
+// allocating.
+const maxCertIDMapSampleLen = 4096
+
+// certIDMapSampleLen sizes the sample to cover any literal index/slice bound
+// in the template, so `{{index .OrganizationalUnit 2}}` isn't rejected just
+// for reaching past it.
+func certIDMapSampleLen(root parse.Node) int {
+	n := minCertIDMapSampleLen
+	_ = walkCertIDMapNodes(root, func(node parse.Node) error {
+		cmd, ok := node.(*parse.CommandNode)
+		if !ok || len(cmd.Args) < 2 {
+			return nil
+		}
+		ident, ok := cmd.Args[0].(*parse.IdentifierNode)
+		if !ok || (ident.Ident != "index" && ident.Ident != "slice") {
+			return nil
+		}
+		for _, a := range cmd.Args[1:] {
+			num, ok := certIDMapLiteralNumber(a)
+			if !ok || !num.IsInt || num.Int64 < 0 {
+				continue
+			}
+			if need := int(num.Int64) + 1; need > n && need <= maxCertIDMapSampleLen {
+				n = need
+			}
+		}
+		return nil
+	})
+	return n
+}
+
+// certIDMapLiteralNumber unwraps any parenthesized layers, so `((20))` reads
+// the same as a bare `20`.
+func certIDMapLiteralNumber(n parse.Node) (*parse.NumberNode, bool) {
+	for {
+		p, ok := n.(*parse.PipeNode)
+		if !ok || len(p.Cmds) != 1 || len(p.Cmds[0].Args) != 1 {
+			break
+		}
+		n = p.Cmds[0].Args[0]
+	}
+	num, ok := n.(*parse.NumberNode)
+	return num, ok
+}
+
+// walkCertIDMapNodes calls visit on n and every node beneath it, stopping at
+// the first error. Types with no case here are leaves for the constructs
+// this file accepts.
+func walkCertIDMapNodes(n parse.Node, visit func(parse.Node) error) error {
+	// A missing {{else}} is a nil *ListNode held in a non-nil parse.Node.
+	switch x := n.(type) {
+	case nil:
+		return nil
+	case *parse.ListNode:
+		if x == nil {
+			return nil
+		}
+	case *parse.PipeNode:
+		if x == nil {
+			return nil
+		}
+	}
+	if err := visit(n); err != nil {
+		return err
+	}
+	switch x := n.(type) {
+	case *parse.ListNode:
+		for _, c := range x.Nodes {
+			if err := walkCertIDMapNodes(c, visit); err != nil {
+				return err
+			}
+		}
+	case *parse.IfNode:
+		if err := walkCertIDMapNodes(x.Pipe, visit); err != nil {
+			return err
+		}
+		if err := walkCertIDMapNodes(x.List, visit); err != nil {
+			return err
+		}
+		return walkCertIDMapNodes(x.ElseList, visit)
+	case *parse.ActionNode:
+		return walkCertIDMapNodes(x.Pipe, visit)
+	case *parse.PipeNode:
+		for _, c := range x.Cmds {
+			if err := walkCertIDMapNodes(c, visit); err != nil {
+				return err
+			}
+		}
+	case *parse.CommandNode:
+		for _, a := range x.Args {
+			if err := walkCertIDMapNodes(a, visit); err != nil {
+				return err
+			}
+		}
+	case *parse.ChainNode:
+		return walkCertIDMapNodes(x.Node, visit)
+	}
+	return nil
+}
+
+// certIDMapOperandList wraps an operand in a standalone action list so it can
+// be executed even where and/or would skip it.
 func certIDMapOperandList(n parse.Node) *parse.ListNode {
 	pipe, ok := n.(*parse.PipeNode)
 	if !ok {
@@ -283,9 +363,24 @@ func execCertIDMapTemplate(c *client, tmpl *template.Template) (string, bool) {
 	return sb.String(), true
 }
 
+// mapCertToUser derives a user from the peer certificate, via the
+// `verify_and_map` template if one is configured and the default
+// email -> SAN -> DN precedence otherwise.
+func mapCertToUser(c *client, tmpl *template.Template, lookup func(string) (string, bool), legacy tlsMapAuthFn) bool {
+	if tmpl != nil {
+		return mapCertTemplateToUser(c, tmpl, lookup)
+	}
+	return checkClientTLSCertSubject(c, legacy)
+}
+
 func mapCertTemplateToUser(c *client, tmpl *template.Template, fn func(string) (string, bool)) bool {
 	u, ok := execCertIDMapTemplate(c, tmpl)
 	if !ok {
+		return false
+	}
+	if u == _EMPTY_ {
+		// Centralised so a blank configured username can never match.
+		c.Debugf("User in cert from verify_and_map template is empty")
 		return false
 	}
 	match, ok := fn(u)

--- a/server/certidmap.go
+++ b/server/certidmap.go
@@ -179,6 +179,23 @@ func collectCertIDMapBranchLists(n parse.Node, lists *[]*parse.ListNode) error {
 			}
 		}
 	case *parse.CommandNode:
+		// and/or short-circuit, so an operand after the first may never
+		// actually be evaluated (e.g. `and (has "prod" .OU) .NoSuchField`
+		// never touches .NoSuchField unless the sample OU is "prod") -
+		// give each such operand its own list so it gets executed anyway.
+		if isCertIDMapShortCircuitCall(x) {
+			for _, a := range x.Args[1:] {
+				// nil has no fields or calls to validate, and - unlike
+				// every other literal - isn't valid as a standalone
+				// action (`{{nil}}` fails to execute on its own even
+				// though `and x nil` is a normal operand), so wrapping
+				// it would reject an otherwise valid template.
+				if isCertIDMapNilOperand(a) {
+					continue
+				}
+				*lists = append(*lists, certIDMapOperandList(a))
+			}
+		}
 		for _, a := range x.Args {
 			if err := collectCertIDMapBranchLists(a, lists); err != nil {
 				return err
@@ -188,6 +205,43 @@ func collectCertIDMapBranchLists(n parse.Node, lists *[]*parse.ListNode) error {
 		return collectCertIDMapBranchLists(x.Node, lists)
 	}
 	return nil
+}
+
+// isCertIDMapShortCircuitCall reports whether cmd calls the short-circuiting
+// and/or builtins, whose operands after the first aren't always evaluated.
+func isCertIDMapShortCircuitCall(cmd *parse.CommandNode) bool {
+	if len(cmd.Args) == 0 {
+		return false
+	}
+	ident, ok := cmd.Args[0].(*parse.IdentifierNode)
+	return ok && (ident.Ident == "and" || ident.Ident == "or")
+}
+
+// isCertIDMapNilOperand reports whether n is the bare, unparenthesized nil
+// keyword. Parenthesized (nil) is deliberately not matched here: unlike bare
+// nil it's genuinely invalid (text/template errors evaluating it, whether
+// standalone or as a real and/or operand once short-circuiting reaches it),
+// so it must still go through normal validation rather than being skipped.
+func isCertIDMapNilOperand(n parse.Node) bool {
+	_, ok := n.(*parse.NilNode)
+	return ok
+}
+
+// certIDMapOperandList wraps a single operand node in a standalone action
+// list, so it can be executed on its own even though text/template might
+// never evaluate it in place (see isCertIDMapShortCircuitCall).
+func certIDMapOperandList(n parse.Node) *parse.ListNode {
+	pipe, ok := n.(*parse.PipeNode)
+	if !ok {
+		pipe = &parse.PipeNode{
+			NodeType: parse.NodePipe,
+			Cmds:     []*parse.CommandNode{{NodeType: parse.NodeCommand, Args: []parse.Node{n}}},
+		}
+	}
+	return &parse.ListNode{
+		NodeType: parse.NodeList,
+		Nodes:    []parse.Node{&parse.ActionNode{NodeType: parse.NodeAction, Pipe: pipe}},
+	}
 }
 
 // parseCertIDMapTemplate compiles and validates a `verify_and_map` template,

--- a/server/certidmap.go
+++ b/server/certidmap.go
@@ -1,0 +1,244 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"crypto/x509"
+	"fmt"
+	"slices"
+	"strings"
+	"text/template"
+	"text/template/parse"
+)
+
+// certIDMapData is the value made available to a `verify_and_map` template.
+// Field names mirror crypto/x509.Certificate and crypto/x509/pkix.Name.
+// Subject attributes are slices since a DN may legally repeat an attribute
+// (e.g. more than one OU).
+type certIDMapData struct {
+	CommonName         string
+	SerialNumber       string
+	Organization       []string
+	OrganizationalUnit []string
+	Locality           []string
+	Province           []string
+	Country            []string
+	StreetAddress      []string
+	PostalCode         []string
+
+	DNSNames       []string
+	EmailAddresses []string
+	IPAddresses    []string
+	URIs           []string
+}
+
+func newCertIDMapData(cert *x509.Certificate) *certIDMapData {
+	d := &certIDMapData{
+		CommonName:         cert.Subject.CommonName,
+		SerialNumber:       cert.Subject.SerialNumber,
+		Organization:       cert.Subject.Organization,
+		OrganizationalUnit: cert.Subject.OrganizationalUnit,
+		Locality:           cert.Subject.Locality,
+		Province:           cert.Subject.Province,
+		Country:            cert.Subject.Country,
+		StreetAddress:      cert.Subject.StreetAddress,
+		PostalCode:         cert.Subject.PostalCode,
+		DNSNames:           cert.DNSNames,
+		EmailAddresses:     cert.EmailAddresses,
+	}
+	for _, ip := range cert.IPAddresses {
+		d.IPAddresses = append(d.IPAddresses, ip.String())
+	}
+	for _, u := range cert.URIs {
+		d.URIs = append(d.URIs, u.String())
+	}
+	return d
+}
+
+// certIDMapFuncs adds membership/indexing helpers for multi-valued subject
+// attributes (e.g. `{{if has "eng" .OrganizationalUnit}}`) on top of the
+// standard text/template builtins.
+var certIDMapFuncs = template.FuncMap{
+	"has": func(needle string, haystack []string) bool {
+		return slices.Contains(haystack, needle)
+	},
+	"first": func(s []string) string {
+		if len(s) == 0 {
+			return _EMPTY_
+		}
+		return s[0]
+	},
+}
+
+// sampleCertIDMapData is used to validate a `verify_and_map` template at
+// config-load time. Fields carry 2 entries, not 0, so a fixed-index lookup
+// like `{{index .OrganizationalUnit 1}}` doesn't fail validation just
+// because this sample is thinner than a real cert.
+func sampleCertIDMapData() *certIDMapData {
+	sample := []string{"sample", "sample"}
+	return &certIDMapData{
+		CommonName:         "sample",
+		SerialNumber:       "sample",
+		Organization:       sample,
+		OrganizationalUnit: sample,
+		Locality:           sample,
+		Province:           sample,
+		Country:            sample,
+		StreetAddress:      sample,
+		PostalCode:         sample,
+		DNSNames:           sample,
+		EmailAddresses:     sample,
+		IPAddresses:        sample,
+		URIs:               sample,
+	}
+}
+
+// validateCertIDMapTemplate executes every {{if}}/{{else}} branch against
+// sample data, not just whichever branch the sample happens to take, so a
+// mistake gated on a real certificate's value (e.g. an OU of "prod") is
+// still caught at config load.
+//
+// This is only sound because dot always refers to the root certIDMapData:
+// collectCertIDMapBranchLists rejects anything that could rebind it or
+// depend on a value from an enclosing scope.
+func validateCertIDMapTemplate(tmpl *template.Template) error {
+	var lists []*parse.ListNode
+	if err := collectCertIDMapBranchLists(tmpl.Tree.Root, &lists); err != nil {
+		return err
+	}
+	// Execute each collected branch list as if it were the whole template,
+	// restoring the real root afterwards.
+	root := tmpl.Tree.Root
+	defer func() { tmpl.Tree.Root = root }()
+	data := sampleCertIDMapData()
+	for _, list := range lists {
+		tmpl.Tree.Root = list
+		if err := tmpl.Execute(new(strings.Builder), data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// collectCertIDMapBranchLists gathers the root list and every {{if}}/{{else}}
+// branch list beneath it, rejecting range/with/template (rebind dot or
+// splice in another template) and variable declarations (undefined once
+// their branch is executed in isolation).
+func collectCertIDMapBranchLists(n parse.Node, lists *[]*parse.ListNode) error {
+	if n == nil {
+		return nil
+	}
+	switch x := n.(type) {
+	case *parse.ListNode:
+		if x == nil {
+			return nil
+		}
+		*lists = append(*lists, x)
+		for _, c := range x.Nodes {
+			if err := collectCertIDMapBranchLists(c, lists); err != nil {
+				return err
+			}
+		}
+	case *parse.IfNode:
+		if err := collectCertIDMapBranchLists(x.Pipe, lists); err != nil {
+			return err
+		}
+		if err := collectCertIDMapBranchLists(x.List, lists); err != nil {
+			return err
+		}
+		return collectCertIDMapBranchLists(x.ElseList, lists)
+	case *parse.RangeNode:
+		return fmt.Errorf("range is not supported in verify_and_map templates")
+	case *parse.WithNode:
+		return fmt.Errorf("with is not supported in verify_and_map templates")
+	case *parse.TemplateNode:
+		return fmt.Errorf("template is not supported in verify_and_map templates")
+	case *parse.ActionNode:
+		return collectCertIDMapBranchLists(x.Pipe, lists)
+	case *parse.PipeNode:
+		if x == nil {
+			return nil
+		}
+		if len(x.Decl) > 0 {
+			return fmt.Errorf("variable declarations are not supported in verify_and_map templates")
+		}
+		for _, c := range x.Cmds {
+			if err := collectCertIDMapBranchLists(c, lists); err != nil {
+				return err
+			}
+		}
+	case *parse.CommandNode:
+		for _, a := range x.Args {
+			if err := collectCertIDMapBranchLists(a, lists); err != nil {
+				return err
+			}
+		}
+	case *parse.ChainNode:
+		return collectCertIDMapBranchLists(x.Node, lists)
+	}
+	return nil
+}
+
+// parseCertIDMapTemplate compiles and validates a `verify_and_map` template,
+// so a template mistake fails at config load rather than on first connect.
+func parseCertIDMapTemplate(name, text string) (*template.Template, error) {
+	tmpl, err := template.New(name).Funcs(certIDMapFuncs).Parse(text)
+	if err != nil {
+		return nil, fmt.Errorf("invalid verify_and_map template: %w", err)
+	}
+	if err := validateCertIDMapTemplate(tmpl); err != nil {
+		return nil, fmt.Errorf("invalid verify_and_map template: %w", err)
+	}
+	return tmpl, nil
+}
+
+func tlsCertMapTemplate(tc *TLSConfigOpts) *template.Template {
+	if tc == nil {
+		return nil
+	}
+	return tc.CertMap
+}
+
+func execCertIDMapTemplate(c *client, tmpl *template.Template) (string, bool) {
+	tlsState := c.GetTLSConnectionState()
+	if tlsState == nil || len(tlsState.PeerCertificates) == 0 || tlsState.PeerCertificates[0] == nil {
+		c.Debugf("User required in cert, no peer certificates found")
+		return _EMPTY_, false
+	}
+	cert := tlsState.PeerCertificates[0]
+	if len(tlsState.PeerCertificates) > 1 {
+		c.Debugf("Multiple peer certificates found, selecting first")
+	}
+
+	var sb strings.Builder
+	if err := tmpl.Execute(&sb, newCertIDMapData(cert)); err != nil {
+		c.Debugf("Error executing verify_and_map template: %v", err)
+		return _EMPTY_, false
+	}
+	return sb.String(), true
+}
+
+func mapCertTemplateToUser(c *client, tmpl *template.Template, fn func(string) (string, bool)) bool {
+	u, ok := execCertIDMapTemplate(c, tmpl)
+	if !ok {
+		return false
+	}
+	match, ok := fn(u)
+	if ok {
+		c.Debugf("Using verify_and_map template result for auth [%q]", match)
+	} else {
+		c.Debugf("User in cert [%q] from verify_and_map template, not found", u)
+	}
+	return ok
+}

--- a/server/certidmap.go
+++ b/server/certidmap.go
@@ -379,7 +379,7 @@ func mapCertTemplateToUser(c *client, tmpl *template.Template, fn func(string) (
 		return false
 	}
 	if u == _EMPTY_ {
-		// Centralised so a blank configured username can never match.
+		// Centralized so a blank configured username can never match.
 		c.Debugf("User in cert from verify_and_map template is empty")
 		return false
 	}

--- a/server/certidmap_test.go
+++ b/server/certidmap_test.go
@@ -16,6 +16,7 @@ package server
 import (
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -235,6 +236,28 @@ func TestVerifyAndMapConfigTemplateNotSupportedForCluster(t *testing.T) {
 	}
 }
 
+// gateway{} goes through getTLSConfig rather than the cluster/leafnode/client
+// call sites, so it needs its own coverage that it still rejects a template.
+func TestVerifyAndMapConfigTemplateNotSupportedForGateway(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		gateway {
+			name: A
+			listen: 127.0.0.1:-1
+			tls {
+				cert_file: "../test/configs/certs/tlsauth/server.pem"
+				key_file:  "../test/configs/certs/tlsauth/server-key.pem"
+				ca_file:   "../test/configs/certs/tlsauth/ca.pem"
+				verify_and_map: "{{ .CommonName }}"
+			}
+		}
+	`))
+	_, err := ProcessConfigFile(conf)
+	if err == nil || !strings.Contains(err.Error(), "not supported in this context") {
+		t.Fatalf("Expected a 'not supported in this context' error, got: %v", err)
+	}
+}
+
 // A template-text-only change must be rejected on reload, not silently
 // applied - Options.TLSCertMap mirrors the source text so reload's
 // field-by-field diff can see the change (the compiled template itself
@@ -264,6 +287,61 @@ func TestVerifyAndMapConfigTemplateChangeDetectedOnReload(t *testing.T) {
 	}
 	if err := s.Reload(); err == nil {
 		t.Fatalf("Expected reload to reject a verify_and_map template change")
+	}
+}
+
+// Same as TestVerifyAndMapConfigTemplateChangeDetectedOnReload, but for the
+// websocket{} and mqtt{} blocks - each has its own TLSConfigOpts/TLSCertMap,
+// so the fix for the client listener doesn't automatically cover them.
+func TestVerifyAndMapConfigTemplateChangeDetectedOnReloadWebsocketAndMQTT(t *testing.T) {
+	confText := `
+		listen: 127.0.0.1:-1
+		jetstream: { store_dir: ` + fmt.Sprintf("%q", t.TempDir()) + ` }
+		websocket {
+			listen: 127.0.0.1:-1
+			tls {
+				cert_file: "../test/configs/certs/tlsauth/server.pem"
+				key_file:  "../test/configs/certs/tlsauth/server-key.pem"
+				ca_file:   "../test/configs/certs/tlsauth/ca.pem"
+				verify_and_map: "WSPLACEHOLDER"
+			}
+		}
+		mqtt {
+			listen: 127.0.0.1:-1
+			tls {
+				cert_file: "../test/configs/certs/tlsauth/server.pem"
+				key_file:  "../test/configs/certs/tlsauth/server-key.pem"
+				ca_file:   "../test/configs/certs/tlsauth/ca.pem"
+				verify_and_map: "MQTTPLACEHOLDER"
+			}
+		}
+	`
+	render := func(ws, mqtt string) string {
+		c := strings.ReplaceAll(confText, "WSPLACEHOLDER", ws)
+		return strings.ReplaceAll(c, "MQTTPLACEHOLDER", mqtt)
+	}
+
+	conf := createConfFile(t, []byte(render("{{ first .OrganizationalUnit }}", "{{ first .OrganizationalUnit }}")))
+	opts, err := ProcessConfigFile(conf)
+	if err != nil {
+		t.Fatalf("Error processing config: %v", err)
+	}
+	opts.NoSigs = true
+	s := RunServer(opts)
+	defer s.Shutdown()
+
+	if err := os.WriteFile(conf, []byte(render("{{ .CommonName }}", "{{ first .OrganizationalUnit }}")), 0666); err != nil {
+		t.Fatalf("Error writing config: %v", err)
+	}
+	if err := s.Reload(); err == nil {
+		t.Fatalf("Expected reload to reject a verify_and_map template change on websocket")
+	}
+
+	if err := os.WriteFile(conf, []byte(render("{{ first .OrganizationalUnit }}", "{{ .CommonName }}")), 0666); err != nil {
+		t.Fatalf("Error writing config: %v", err)
+	}
+	if err := s.Reload(); err == nil {
+		t.Fatalf("Expected reload to reject a verify_and_map template change on mqtt")
 	}
 }
 
@@ -403,5 +481,52 @@ func TestCertIDMapTemplateInvalidFieldInUntakenElseBranch(t *testing.T) {
 	_, err := parseCertIDMapTemplate("test", `{{if has "sample" .OrganizationalUnit}}ok{{else}}{{.NoSuchField}}{{end}}`)
 	if err == nil {
 		t.Fatalf("Expected an error for an invalid field reference inside an untaken else branch")
+	}
+}
+
+// and short-circuits: with the sample OU "sample", `has "prod" ...` is
+// false, so and never evaluates .NoSuchField for real. It still has to be
+// rejected, since a cert with OU "prod" would reach it.
+func TestCertIDMapTemplateShortCircuitedAndOperandRejected(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if and (has "prod" .OrganizationalUnit) .NoSuchField}}x{{end}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for a bad field short-circuited by and")
+	}
+}
+
+// or short-circuits the other way: with the sample OU "sample", the first
+// operand is true, so or never evaluates .NoSuchField for real.
+func TestCertIDMapTemplateShortCircuitedOrOperandRejected(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if or (has "sample" .OrganizationalUnit) .NoSuchField}}x{{end}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for a bad field short-circuited by or")
+	}
+}
+
+// A valid parenthesized operand (rather than a bare field) must still work.
+func TestCertIDMapTemplateShortCircuitedOperandValid(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if and (has "sample" .OrganizationalUnit) (has "sample" .Country)}}x{{end}}`)
+	if err != nil {
+		t.Fatalf("Unexpected error for valid and operands: %v", err)
+	}
+}
+
+// Bare nil is a valid and/or operand but, unlike every other literal, isn't
+// valid as a standalone action - wrapping it like any other operand would
+// reject an otherwise-valid template.
+func TestCertIDMapTemplateShortCircuitedNilOperandValid(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if and (has "sample" .OrganizationalUnit) nil}}x{{end}}`)
+	if err != nil {
+		t.Fatalf("Unexpected error for a nil and operand: %v", err)
+	}
+}
+
+// Unlike bare nil, parenthesized (nil) is genuinely invalid - text/template
+// errors evaluating it. It must still be rejected even when short-circuited
+// past by the sample data, the same as any other operand mistake.
+func TestCertIDMapTemplateShortCircuitedParenNilOperandRejected(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if and (has "prod" .OrganizationalUnit) (nil)}}x{{end}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for a parenthesized nil and operand")
 	}
 }

--- a/server/certidmap_test.go
+++ b/server/certidmap_test.go
@@ -1,0 +1,407 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"os"
+	"strings"
+	"testing"
+)
+
+func testCertForIDMap() *x509.Certificate {
+	return &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:         "example.com",
+			OrganizationalUnit: []string{"infrastructure", "eu-west"},
+			Organization:       []string{"Synadia"},
+			Country:            []string{"GB"},
+		},
+		DNSNames:       []string{"example.com"},
+		EmailAddresses: []string{"user@example.com"},
+	}
+}
+
+func TestCertIDMapTemplateFields(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		tmpl     string
+		expected string
+	}{
+		{"common name", "{{.CommonName}}", "example.com"},
+		{"first OU", "{{first .OrganizationalUnit}}", "infrastructure"},
+		{"indexed OU", "{{index .OrganizationalUnit 1}}", "eu-west"},
+		{"has OU true", `{{if has "infrastructure" .OrganizationalUnit}}yes{{else}}no{{end}}`, "yes"},
+		{"has OU false", `{{if has "marketing" .OrganizationalUnit}}yes{{else}}no{{end}}`, "no"},
+		{"organization", "{{first .Organization}}", "Synadia"},
+		{"san email", "{{first .EmailAddresses}}", "user@example.com"},
+		{"san dns", "{{first .DNSNames}}", "example.com"},
+		{"combine fields", "{{.CommonName}}-{{first .OrganizationalUnit}}", "example.com-infrastructure"},
+		{"and combo match", `{{if and (has "infrastructure" .OrganizationalUnit) (has "GB" .Country)}}infra-gb{{end}}`, "infra-gb"},
+		{"or combo match", `{{if or (has "marketing" .OrganizationalUnit) (has "GB" .Country)}}yes{{end}}`, "yes"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpl, err := parseCertIDMapTemplate("test", test.tmpl)
+			if err != nil {
+				t.Fatalf("Error parsing template: %v", err)
+			}
+			var sb strings.Builder
+			if err := tmpl.Execute(&sb, newCertIDMapData(testCertForIDMap())); err != nil {
+				t.Fatalf("Error executing template: %v", err)
+			}
+			if got := sb.String(); got != test.expected {
+				t.Fatalf("Expected %q, got %q", test.expected, got)
+			}
+		})
+	}
+}
+
+// A template can restrict a match to a combination of fields (e.g. this OU,
+// but only in this country) using text/template's `and` plus `has`.
+func TestCertIDMapTemplateComboFields(t *testing.T) {
+	const tmplText = `{{if and (has "infrastructure" .OrganizationalUnit) (has "GB" .Country)}}infra-gb{{end}}`
+	tmpl, err := parseCertIDMapTemplate("test", tmplText)
+	if err != nil {
+		t.Fatalf("Error parsing template: %v", err)
+	}
+
+	for _, test := range []struct {
+		name     string
+		country  string
+		expected string
+	}{
+		{"matching country", "GB", "infra-gb"},
+		{"non-matching country", "US", ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cert := testCertForIDMap()
+			cert.Subject.Country = []string{test.country}
+
+			var sb strings.Builder
+			if err := tmpl.Execute(&sb, newCertIDMapData(cert)); err != nil {
+				t.Fatalf("Error executing template: %v", err)
+			}
+			if got := sb.String(); got != test.expected {
+				t.Fatalf("Expected %q, got %q", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestCertIDMapTemplateInvalidField(t *testing.T) {
+	if _, err := parseCertIDMapTemplate("test", "{{.NoSuchField}}"); err == nil {
+		t.Fatalf("Expected an error parsing/validating a template with an invalid field reference")
+	}
+}
+
+// A bad field reference must be caught even in a branch the sample data
+// never takes (e.g. one gated on OU "prod").
+func TestCertIDMapTemplateInvalidFieldInUntakenBranch(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if has "prod" .OrganizationalUnit}}{{.NoSuchField}}{{end}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for an invalid field reference inside an untaken branch")
+	}
+}
+
+// Same, but the bad field is behind a parenthesized chain: (.CommonName).NoSuchField.
+func TestCertIDMapTemplateInvalidChainedFieldInUntakenBranch(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if has "prod" .OrganizationalUnit}}{{(.CommonName).NoSuchField}}{{end}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for an invalid chained field reference inside an untaken branch")
+	}
+}
+
+// Same, but the bad field is referenced via the root variable: $.NoSuchField.
+func TestCertIDMapTemplateInvalidVariableFieldInUntakenBranch(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if has "prod" .OrganizationalUnit}}{{$.NoSuchField}}{{end}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for an invalid $.Field reference inside an untaken branch")
+	}
+}
+
+func TestCertIDMapTemplateValidRootVariable(t *testing.T) {
+	if _, err := parseCertIDMapTemplate("test", `{{$.CommonName}}`); err != nil {
+		t.Fatalf("Unexpected error for valid $.CommonName: %v", err)
+	}
+	if _, err := parseCertIDMapTemplate("test", `{{($.CommonName).Foo}}`); err == nil {
+		t.Fatalf("Expected an error chaining a field onto $.CommonName (a string, not a struct)")
+	}
+}
+
+func TestCertIDMapTemplateChainOnFunctionResultRejected(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{(first .OrganizationalUnit).Foo}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for a chain built on a function call's result")
+	}
+}
+
+func TestCertIDMapTemplateValidParenthesizedField(t *testing.T) {
+	tmpl, err := parseCertIDMapTemplate("test", `{{(.CommonName)}}`)
+	if err != nil {
+		t.Fatalf("Unexpected error for a valid parenthesized field: %v", err)
+	}
+	var sb strings.Builder
+	if err := tmpl.Execute(&sb, newCertIDMapData(testCertForIDMap())); err != nil {
+		t.Fatalf("Error executing template: %v", err)
+	}
+	if got := sb.String(); got != "example.com" {
+		t.Fatalf("Expected %q, got %q", "example.com", got)
+	}
+}
+
+func TestCertIDMapTemplateRejectsRangeWithVariables(t *testing.T) {
+	for _, tmpl := range []string{
+		`{{range .OrganizationalUnit}}{{.}}{{end}}`,
+		`{{with .CommonName}}{{.}}{{end}}`,
+		`{{$x := .CommonName}}{{$x}}`,
+	} {
+		if _, err := parseCertIDMapTemplate("test", tmpl); err == nil {
+			t.Fatalf("Expected an error rejecting unsupported construct: %s", tmpl)
+		}
+	}
+}
+
+func TestCertIDMapTemplateParseError(t *testing.T) {
+	if _, err := parseCertIDMapTemplate("test", "{{.CommonName"); err == nil {
+		t.Fatalf("Expected an error for malformed template syntax")
+	}
+}
+
+func TestVerifyAndMapConfigTemplate(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		tls {
+			cert_file: "../test/configs/certs/tlsauth/server.pem"
+			key_file:  "../test/configs/certs/tlsauth/server-key.pem"
+			ca_file:   "../test/configs/certs/tlsauth/ca.pem"
+			verify_and_map: "{{ first .OrganizationalUnit }}"
+		}
+	`))
+	opts, err := ProcessConfigFile(conf)
+	if err != nil {
+		t.Fatalf("Unexpected error processing config: %v", err)
+	}
+	if !opts.TLSMap {
+		t.Fatalf("Expected TLSMap to be true")
+	}
+	if opts.tlsConfigOpts == nil || opts.tlsConfigOpts.CertMap == nil {
+		t.Fatalf("Expected a compiled CertMap template")
+	}
+}
+
+func TestVerifyAndMapConfigTemplateBadField(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		tls {
+			cert_file: "../test/configs/certs/tlsauth/server.pem"
+			key_file:  "../test/configs/certs/tlsauth/server-key.pem"
+			ca_file:   "../test/configs/certs/tlsauth/ca.pem"
+			verify_and_map: "{{ .NoSuchField }}"
+		}
+	`))
+	if _, err := ProcessConfigFile(conf); err == nil {
+		t.Fatalf("Expected an error for a template referencing a nonexistent field")
+	}
+}
+
+func TestVerifyAndMapConfigTemplateNotSupportedForCluster(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		cluster {
+			listen: 127.0.0.1:-1
+			tls {
+				cert_file: "../test/configs/certs/tlsauth/server.pem"
+				key_file:  "../test/configs/certs/tlsauth/server-key.pem"
+				ca_file:   "../test/configs/certs/tlsauth/ca.pem"
+				verify_and_map: "{{ .CommonName }}"
+			}
+		}
+	`))
+	_, err := ProcessConfigFile(conf)
+	if err == nil || !strings.Contains(err.Error(), "not supported in this context") {
+		t.Fatalf("Expected a 'not supported in this context' error, got: %v", err)
+	}
+}
+
+// A template-text-only change must be rejected on reload, not silently
+// applied - Options.TLSCertMap mirrors the source text so reload's
+// field-by-field diff can see the change (the compiled template itself
+// lives on the unexported tlsConfigOpts snapshot).
+func TestVerifyAndMapConfigTemplateChangeDetectedOnReload(t *testing.T) {
+	confText := `
+		listen: 127.0.0.1:-1
+		tls {
+			cert_file: "../test/configs/certs/tlsauth/server.pem"
+			key_file:  "../test/configs/certs/tlsauth/server-key.pem"
+			ca_file:   "../test/configs/certs/tlsauth/ca.pem"
+			verify_and_map: "%s"
+		}
+	`
+	conf := createConfFile(t, []byte(strings.ReplaceAll(confText, "%s", "{{ first .OrganizationalUnit }}")))
+	opts, err := ProcessConfigFile(conf)
+	if err != nil {
+		t.Fatalf("Error processing config: %v", err)
+	}
+	opts.NoSigs = true
+	s := RunServer(opts)
+	defer s.Shutdown()
+
+	newConfText := strings.ReplaceAll(confText, "%s", "{{ .CommonName }}")
+	if err := os.WriteFile(conf, []byte(newConfText), 0666); err != nil {
+		t.Fatalf("Error writing config: %v", err)
+	}
+	if err := s.Reload(); err == nil {
+		t.Fatalf("Expected reload to reject a verify_and_map template change")
+	}
+}
+
+// first expects []string, not string - same untaken-branch problem as the
+// field tests above, for a function argument instead of a field.
+func TestCertIDMapTemplateInvalidArgTypeInUntakenBranch(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if has "prod" .OrganizationalUnit}}{{first .CommonName}}{{end}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for a wrong-typed function argument inside an untaken branch")
+	}
+}
+
+func TestCertIDMapTemplateSwappedArgsRejected(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{has .OrganizationalUnit "prod"}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for has() called with swapped argument types")
+	}
+}
+
+func TestCertIDMapTemplateUnknownFunctionChainRejected(t *testing.T) {
+	// len returns an int, which has no field named Foo.
+	_, err := parseCertIDMapTemplate("test", `{{(len .OrganizationalUnit).Foo}}`)
+	if err == nil {
+		t.Fatalf("Expected an error chaining a field onto an unrecognized function's result")
+	}
+}
+
+// Same problem, piped form: `.CommonName | first`.
+func TestCertIDMapTemplateInvalidPipedArgTypeInUntakenBranch(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if has "prod" .OrganizationalUnit}}{{.CommonName | first}}{{end}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for a wrong-typed piped argument inside an untaken branch")
+	}
+}
+
+func TestCertIDMapTemplateValidPipedArg(t *testing.T) {
+	if _, err := parseCertIDMapTemplate("test", `{{.OrganizationalUnit | first}}`); err != nil {
+		t.Fatalf("Unexpected error for valid piped usage: %v", err)
+	}
+}
+
+func TestCertIDMapTemplateMultiStagePipeTypeMismatch(t *testing.T) {
+	// .CommonName | first is a string, piped into first again - []string wanted.
+	_, err := parseCertIDMapTemplate("test", `{{if has "prod" .OrganizationalUnit}}{{.CommonName | first | first}}{{end}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for a type mismatch two pipe stages deep")
+	}
+}
+
+// resolver_tls is outbound-only, so no cert is ever mapped to a user there.
+func TestVerifyAndMapConfigTemplateNotSupportedForResolverTLS(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		operator: "../test/configs/nkeys/op.jwt"
+		resolver: URL("http://localhost:9090/ngs/v1/accounts/")
+		resolver_tls {
+			cert_file: "../test/configs/certs/tlsauth/server.pem"
+			key_file:  "../test/configs/certs/tlsauth/server-key.pem"
+			ca_file:   "../test/configs/certs/tlsauth/ca.pem"
+			verify_and_map: "{{ .CommonName }}"
+		}
+	`))
+	_, err := ProcessConfigFile(conf)
+	if err == nil || !strings.Contains(err.Error(), "not supported in this context") {
+		t.Fatalf("Expected a 'not supported in this context' error, got: %v", err)
+	}
+}
+
+// A leafnode remote's tls block is outbound too - only the inbound leaf{}
+// listener maps a peer cert to a user.
+func TestVerifyAndMapConfigTemplateNotSupportedForLeafRemote(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: 127.0.0.1:-1
+		leaf {
+			remotes [
+				{
+					url: "tls://localhost:1234"
+					tls {
+						cert_file: "../test/configs/certs/tlsauth/client.pem"
+						key_file:  "../test/configs/certs/tlsauth/client-key.pem"
+						ca_file:   "../test/configs/certs/tlsauth/ca.pem"
+						verify_and_map: "{{ .CommonName }}"
+					}
+				}
+			]
+		}
+	`))
+	_, err := ProcessConfigFile(conf)
+	if err == nil || !strings.Contains(err.Error(), "not supported in this context") {
+		t.Fatalf("Expected a 'not supported in this context' error, got: %v", err)
+	}
+}
+
+// Wrong arity, same untaken-branch problem: first wants exactly one argument.
+func TestCertIDMapTemplateTooFewArgsInUntakenBranch(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if has "prod" .OrganizationalUnit}}{{first}}{{end}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for a helper call with too few arguments inside an untaken branch")
+	}
+}
+
+func TestCertIDMapTemplateTooManyArgsInUntakenBranch(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if has "prod" .OrganizationalUnit}}{{has "prod" .OrganizationalUnit "extra"}}{{end}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for a helper call with too many arguments inside an untaken branch")
+	}
+}
+
+func TestCertIDMapTemplateTooFewPipedArgs(t *testing.T) {
+	// has wants two arguments; a single piped value is one short.
+	_, err := parseCertIDMapTemplate("test", `{{.OrganizationalUnit | has}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for a piped helper call with too few arguments")
+	}
+}
+
+// Numeric literals get the same treatment: has wants a string, not an int.
+func TestCertIDMapTemplateNumericLiteralArgInUntakenBranch(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if has "prod" .OrganizationalUnit}}{{has 1 .OrganizationalUnit}}{{end}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for a numeric literal argument inside an untaken branch")
+	}
+}
+
+// Builtins get the same untaken-branch treatment as has/first: eq comparing
+// a string to an int is a runtime error.
+func TestCertIDMapTemplateBuiltinTypeErrorInUntakenBranch(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if has "prod" .OrganizationalUnit}}{{eq .CommonName 1}}{{end}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for a builtin type mismatch inside an untaken branch")
+	}
+}
+
+// The sample data takes the if-branch here, so the bad field in the
+// else-branch is only caught if every branch gets executed.
+func TestCertIDMapTemplateInvalidFieldInUntakenElseBranch(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{if has "sample" .OrganizationalUnit}}ok{{else}}{{.NoSuchField}}{{end}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for an invalid field reference inside an untaken else branch")
+	}
+}

--- a/server/certidmap_test.go
+++ b/server/certidmap_test.go
@@ -69,6 +69,57 @@ func TestCertIDMapTemplateFields(t *testing.T) {
 	}
 }
 
+// An index beyond sampleCertIDMapData's historical 2-element sample must
+// still validate and work against a real (longer) certificate.
+func TestCertIDMapTemplateDeepIndex(t *testing.T) {
+	tmpl, err := parseCertIDMapTemplate("test", `{{index .OrganizationalUnit 2}}`)
+	if err != nil {
+		t.Fatalf("Error parsing template: %v", err)
+	}
+	cert := testCertForIDMap()
+	cert.Subject.OrganizationalUnit = []string{"a", "b", "c"}
+	var sb strings.Builder
+	if err := tmpl.Execute(&sb, newCertIDMapData(cert)); err != nil {
+		t.Fatalf("Error executing template: %v", err)
+	}
+	if got := sb.String(); got != "c" {
+		t.Fatalf("Expected %q, got %q", "c", got)
+	}
+}
+
+// Dynamic sample sizing extends the sample to fit a literal index - it
+// doesn't disable bounds checking.
+func TestCertIDMapTemplateAbsurdIndexRejected(t *testing.T) {
+	_, err := parseCertIDMapTemplate("test", `{{index .OrganizationalUnit 999999999}}`)
+	if err == nil {
+		t.Fatalf("Expected an error for an absurd literal index")
+	}
+}
+
+// index also works on strings (byte offset), not just []string - the
+// scalar fields (CommonName, SerialNumber) need the same deep-index fix.
+func TestCertIDMapTemplateDeepIndexOnScalarField(t *testing.T) {
+	if _, err := parseCertIDMapTemplate("test", `{{index .CommonName 20}}`); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+// index .OrganizationalUnit 0 20 indexes the *string* at element 0, not the
+// slice again - each sample slice element needs to be long enough too.
+func TestCertIDMapTemplateDeepIndexOnSliceElement(t *testing.T) {
+	if _, err := parseCertIDMapTemplate("test", `{{index .OrganizationalUnit 0 20}}`); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+// A parenthesized literal bound, e.g. `(20)`, must size the sample the same
+// as a bare `20` - it's still just a NumberNode once unwrapped.
+func TestCertIDMapTemplateParenthesizedLiteralIndex(t *testing.T) {
+	if _, err := parseCertIDMapTemplate("test", `{{index .OrganizationalUnit ((20))}}`); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
 // A template can restrict a match to a combination of fields (e.g. this OU,
 // but only in this country) using text/template's `and` plus `has`.
 func TestCertIDMapTemplateComboFields(t *testing.T) {
@@ -236,8 +287,8 @@ func TestVerifyAndMapConfigTemplateNotSupportedForCluster(t *testing.T) {
 	}
 }
 
-// gateway{} goes through getTLSConfig rather than the cluster/leafnode/client
-// call sites, so it needs its own coverage that it still rejects a template.
+// gateway{} goes through getTLSConfig, a different call site than
+// cluster/leafnode/client - needs its own coverage.
 func TestVerifyAndMapConfigTemplateNotSupportedForGateway(t *testing.T) {
 	conf := createConfFile(t, []byte(`
 		listen: 127.0.0.1:-1
@@ -290,9 +341,7 @@ func TestVerifyAndMapConfigTemplateChangeDetectedOnReload(t *testing.T) {
 	}
 }
 
-// Same as TestVerifyAndMapConfigTemplateChangeDetectedOnReload, but for the
-// websocket{} and mqtt{} blocks - each has its own TLSConfigOpts/TLSCertMap,
-// so the fix for the client listener doesn't automatically cover them.
+// Same, for websocket{} and mqtt{} - each has its own TLSConfigOpts/TLSCertMap.
 func TestVerifyAndMapConfigTemplateChangeDetectedOnReloadWebsocketAndMQTT(t *testing.T) {
 	confText := `
 		listen: 127.0.0.1:-1
@@ -484,9 +533,8 @@ func TestCertIDMapTemplateInvalidFieldInUntakenElseBranch(t *testing.T) {
 	}
 }
 
-// and short-circuits: with the sample OU "sample", `has "prod" ...` is
-// false, so and never evaluates .NoSuchField for real. It still has to be
-// rejected, since a cert with OU "prod" would reach it.
+// and short-circuits past .NoSuchField with the sample data (OU isn't
+// "prod"), but a real "prod" cert would reach it.
 func TestCertIDMapTemplateShortCircuitedAndOperandRejected(t *testing.T) {
 	_, err := parseCertIDMapTemplate("test", `{{if and (has "prod" .OrganizationalUnit) .NoSuchField}}x{{end}}`)
 	if err == nil {
@@ -494,8 +542,8 @@ func TestCertIDMapTemplateShortCircuitedAndOperandRejected(t *testing.T) {
 	}
 }
 
-// or short-circuits the other way: with the sample OU "sample", the first
-// operand is true, so or never evaluates .NoSuchField for real.
+// Same, but short-circuited the other way: the first operand is true, so
+// or never evaluates .NoSuchField.
 func TestCertIDMapTemplateShortCircuitedOrOperandRejected(t *testing.T) {
 	_, err := parseCertIDMapTemplate("test", `{{if or (has "sample" .OrganizationalUnit) .NoSuchField}}x{{end}}`)
 	if err == nil {
@@ -511,9 +559,8 @@ func TestCertIDMapTemplateShortCircuitedOperandValid(t *testing.T) {
 	}
 }
 
-// Bare nil is a valid and/or operand but, unlike every other literal, isn't
-// valid as a standalone action - wrapping it like any other operand would
-// reject an otherwise-valid template.
+// Bare nil is a valid and/or operand, unlike every other literal it isn't
+// valid as a standalone action.
 func TestCertIDMapTemplateShortCircuitedNilOperandValid(t *testing.T) {
 	_, err := parseCertIDMapTemplate("test", `{{if and (has "sample" .OrganizationalUnit) nil}}x{{end}}`)
 	if err != nil {
@@ -521,9 +568,8 @@ func TestCertIDMapTemplateShortCircuitedNilOperandValid(t *testing.T) {
 	}
 }
 
-// Unlike bare nil, parenthesized (nil) is genuinely invalid - text/template
-// errors evaluating it. It must still be rejected even when short-circuited
-// past by the sample data, the same as any other operand mistake.
+// Unlike bare nil, parenthesized (nil) is genuinely invalid and must still
+// be rejected, even short-circuited past by the sample data.
 func TestCertIDMapTemplateShortCircuitedParenNilOperandRejected(t *testing.T) {
 	_, err := parseCertIDMapTemplate("test", `{{if and (has "prod" .OrganizationalUnit) (nil)}}x{{end}}`)
 	if err == nil {

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1877,6 +1877,82 @@ func TestLeafNodeTLSVerifyAndMap(t *testing.T) {
 	}
 }
 
+func TestLeafNodeTLSVerifyAndMapTemplate(t *testing.T) {
+	accName := "MyAccount"
+	acc := NewAccount(accName)
+	// Client cert subject is "OU=NATS.io, CN=example.com".
+	certUserName := "NATS.io"
+	users := []*User{{Username: certUserName, Account: acc}}
+
+	o := DefaultOptions()
+	o.Accounts = []*Account{acc}
+	o.Users = users
+	o.LeafNode.Host = "127.0.0.1"
+	o.LeafNode.Port = -1
+	tc := &TLSConfigOpts{
+		CertFile: "../test/configs/certs/tlsauth/server.pem",
+		KeyFile:  "../test/configs/certs/tlsauth/server-key.pem",
+		CaFile:   "../test/configs/certs/tlsauth/ca.pem",
+		Verify:   true,
+	}
+	tlsc, err := GenTLSConfig(tc)
+	if err != nil {
+		t.Fatalf("Error creating tls config: %v", err)
+	}
+	tmpl, err := parseCertIDMapTemplate("verify_and_map", "{{ first .OrganizationalUnit }}")
+	if err != nil {
+		t.Fatalf("Error parsing template: %v", err)
+	}
+	tc.CertMap = tmpl
+	o.LeafNode.TLSConfig = tlsc
+	o.LeafNode.TLSMap = true
+	o.LeafNode.tlsConfigOpts = tc
+	s := RunServer(o)
+	defer s.Shutdown()
+
+	slo := DefaultOptions()
+	slo.Cluster.Name = "xyz"
+
+	sltlsc, err := GenTLSConfig(&TLSConfigOpts{
+		CertFile: "../test/configs/certs/tlsauth/client.pem",
+		KeyFile:  "../test/configs/certs/tlsauth/client-key.pem",
+	})
+	if err != nil {
+		t.Fatalf("Error generating tls config: %v", err)
+	}
+	sltlsc.InsecureSkipVerify = true
+	u, _ := url.Parse(fmt.Sprintf("nats://%s:%d", o.LeafNode.Host, o.LeafNode.Port))
+	slo.LeafNode.Remotes = []*RemoteLeafOpts{
+		{
+			TLSConfig: sltlsc,
+			URLs:      []*url.URL{u},
+		},
+	}
+	sl := RunServer(slo)
+	defer sl.Shutdown()
+
+	checkLeafNodeConnected(t, s)
+
+	var uname string
+	var accname string
+	s.mu.Lock()
+	for _, c := range s.leafs {
+		c.mu.Lock()
+		uname = c.opts.Username
+		if c.acc != nil {
+			accname = c.acc.GetName()
+		}
+		c.mu.Unlock()
+	}
+	s.mu.Unlock()
+	if uname != certUserName {
+		t.Fatalf("Expected username %q, got %q", certUserName, uname)
+	}
+	if accname != accName {
+		t.Fatalf("Expected account %q, got %v", accName, accname)
+	}
+}
+
 type chanLogger struct {
 	DummyLogger
 	triggerChan chan string

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1953,6 +1953,60 @@ func TestLeafNodeTLSVerifyAndMapTemplate(t *testing.T) {
 	}
 }
 
+// A template that matches nothing evaluates to "", which must not
+// authenticate even against a blank-username leaf user (which is allowed).
+func TestLeafNodeTLSVerifyAndMapTemplateEmptyResult(t *testing.T) {
+	acc := NewAccount("MyAccount")
+
+	o := DefaultOptions()
+	o.Accounts = []*Account{acc}
+	o.LeafNode.Host = "127.0.0.1"
+	o.LeafNode.Port = -1
+	// Blank username, as omitting `user:` would leave behind.
+	o.LeafNode.Users = []*User{{Username: _EMPTY_, Account: acc}}
+	tc := &TLSConfigOpts{
+		CertFile: "../test/configs/certs/tlsauth/server.pem",
+		KeyFile:  "../test/configs/certs/tlsauth/server-key.pem",
+		CaFile:   "../test/configs/certs/tlsauth/ca.pem",
+		Verify:   true,
+	}
+	tlsc, err := GenTLSConfig(tc)
+	if err != nil {
+		t.Fatalf("Error creating tls config: %v", err)
+	}
+	// The client cert's OU is "NATS.io", so this falls through to "".
+	tmpl, err := parseCertIDMapTemplate("verify_and_map", `{{if has "nomatch" .OrganizationalUnit}}someuser{{end}}`)
+	if err != nil {
+		t.Fatalf("Error parsing template: %v", err)
+	}
+	tc.CertMap = tmpl
+	o.LeafNode.TLSConfig = tlsc
+	o.LeafNode.TLSMap = true
+	o.LeafNode.tlsConfigOpts = tc
+	s := RunServer(o)
+	defer s.Shutdown()
+
+	slo := DefaultOptions()
+	slo.Cluster.Name = "xyz"
+	sltlsc, err := GenTLSConfig(&TLSConfigOpts{
+		CertFile: "../test/configs/certs/tlsauth/client.pem",
+		KeyFile:  "../test/configs/certs/tlsauth/client-key.pem",
+	})
+	if err != nil {
+		t.Fatalf("Error generating tls config: %v", err)
+	}
+	sltlsc.InsecureSkipVerify = true
+	u, _ := url.Parse(fmt.Sprintf("nats://%s:%d", o.LeafNode.Host, o.LeafNode.Port))
+	slo.LeafNode.Remotes = []*RemoteLeafOpts{{TLSConfig: sltlsc, URLs: []*url.URL{u}}}
+	sl := RunServer(slo)
+	defer sl.Shutdown()
+
+	time.Sleep(500 * time.Millisecond)
+	if n := s.NumLeafNodes(); n != 0 {
+		t.Fatalf("Expected no leafnode to be authorized, got %d", n)
+	}
+}
+
 type chanLogger struct {
 	DummyLogger
 	triggerChan chan string

--- a/server/opts.go
+++ b/server/opts.go
@@ -33,6 +33,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"text/template"
 	"time"
 
 	"github.com/nats-io/jwt/v2"
@@ -181,18 +182,23 @@ type RemoteGatewayOpts struct {
 
 // LeafNodeOpts are options for a given server to accept leaf node connections and/or connect to a remote cluster.
 type LeafNodeOpts struct {
-	Host           string        `json:"addr,omitempty"`
-	Port           int           `json:"port,omitempty"`
-	Username       string        `json:"-"`
-	Password       string        `json:"-"`
-	ProxyRequired  bool          `json:"-"`
-	Nkey           string        `json:"-"`
-	Account        string        `json:"-"`
-	Users          []*User       `json:"-"`
-	AuthTimeout    float64       `json:"auth_timeout,omitempty"`
-	TLSConfig      *tls.Config   `json:"-"`
-	TLSTimeout     float64       `json:"tls_timeout,omitempty"`
-	TLSMap         bool          `json:"-"`
+	Host          string      `json:"addr,omitempty"`
+	Port          int         `json:"port,omitempty"`
+	Username      string      `json:"-"`
+	Password      string      `json:"-"`
+	ProxyRequired bool        `json:"-"`
+	Nkey          string      `json:"-"`
+	Account       string      `json:"-"`
+	Users         []*User     `json:"-"`
+	AuthTimeout   float64     `json:"auth_timeout,omitempty"`
+	TLSConfig     *tls.Config `json:"-"`
+	TLSTimeout    float64     `json:"tls_timeout,omitempty"`
+	TLSMap        bool        `json:"-"`
+	// TLSCertMap holds the `verify_and_map` template source, if any, purely
+	// so config reload can detect a template-text change (the compiled
+	// template itself lives on the unexported tlsConfigOpts snapshot, which
+	// reload's field-by-field diff can't see).
+	TLSCertMap     string        `json:"-"`
 	TLSPinnedCerts PinnedCertSet `json:"-"`
 	// When set to true, the server will perform the TLS handshake before
 	// sending the INFO protocol. For remote leafnodes that are not configured
@@ -486,12 +492,17 @@ type Options struct {
 	TLS                        bool              `json:"-"`
 	TLSVerify                  bool              `json:"-"`
 	TLSMap                     bool              `json:"-"`
-	TLSCert                    string            `json:"-"`
-	TLSKey                     string            `json:"-"`
-	TLSCaCert                  string            `json:"-"`
-	TLSConfig                  *tls.Config       `json:"-"`
-	TLSPinnedCerts             PinnedCertSet     `json:"-"`
-	TLSRateLimit               int64             `json:"-"`
+	// TLSCertMap holds the `verify_and_map` template source, if any, purely
+	// so config reload can detect a template-text change (the compiled
+	// template itself lives on the unexported tlsConfigOpts snapshot, which
+	// reload's field-by-field diff can't see).
+	TLSCertMap     string        `json:"-"`
+	TLSCert        string        `json:"-"`
+	TLSKey         string        `json:"-"`
+	TLSCaCert      string        `json:"-"`
+	TLSConfig      *tls.Config   `json:"-"`
+	TLSPinnedCerts PinnedCertSet `json:"-"`
+	TLSRateLimit   int64         `json:"-"`
 	// When set to true, the server will perform the TLS handshake before
 	// sending the INFO protocol. For clients that are not configured
 	// with a similar option, their connection will fail with some sort
@@ -650,6 +661,11 @@ type WebsocketOpts struct {
 	TLSConfig *tls.Config
 	// If true, map certificate values for authentication purposes.
 	TLSMap bool
+	// TLSCertMap holds the `verify_and_map` template source, if any, purely
+	// so config reload can detect a template-text change (the compiled
+	// template itself lives on the unexported tlsConfigOpts snapshot, which
+	// reload's field-by-field diff can't see).
+	TLSCertMap string
 
 	// When present, accepted client certificates (verify/verify_and_map) must be in this list
 	TLSPinnedCerts PinnedCertSet
@@ -739,6 +755,11 @@ type MQTTOpts struct {
 	TLSConfig *tls.Config
 	// If true, map certificate values for authentication purposes.
 	TLSMap bool
+	// TLSCertMap holds the `verify_and_map` template source, if any, purely
+	// so config reload can detect a template-text change (the compiled
+	// template itself lives on the unexported tlsConfigOpts snapshot, which
+	// reload's field-by-field diff can't see).
+	TLSCertMap string
 	// Timeout for the TLS handshake
 	TLSTimeout float64
 	// Set of allowable certificates
@@ -887,6 +908,16 @@ type TLSConfigOpts struct {
 	OCSPPeerConfig       *certidp.OCSPPeerConfig
 	Certificates         []*TLSCertPairOpt
 	MinVersion           uint16
+	// CertMap holds a compiled `verify_and_map` template, used to derive
+	// a user identity from a peer certificate. Nil unless `verify_and_map`
+	// was given a template string instead of a boolean.
+	CertMap *template.Template
+	// CertMapSrc is the `verify_and_map` template source that produced
+	// CertMap. Kept only so it can be copied onto an exported field (see
+	// e.g. Options.TLSCertMap) for config reload to compare - *template.Template
+	// itself can't be meaningfully compared with reflect.DeepEqual since it
+	// embeds non-nil func values, which are never considered equal.
+	CertMapSrc string
 }
 
 // TLSCertPairOpt are the paths to a certificate and private key.
@@ -926,6 +957,11 @@ e.g.
         ca_file:        "./certs/ca.pem"
         verify:         true
         verify_and_map: true
+
+        # verify_and_map may also be a text/template string, used to derive
+        # the user identity from the peer certificate instead of the default
+        # email -> SAN -> DN precedence, e.g.:
+        # verify_and_map: "{{ first .OrganizationalUnit }}"
 
         cipher_suites: [
             "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
@@ -1369,7 +1405,7 @@ func (o *Options) processConfigFileLine(k string, v any, errors *[]error, warnin
 	case "ping_max":
 		o.MaxPingsOut = int(v.(int64))
 	case "tls":
-		tc, err := parseTLS(tk, true)
+		tc, err := parseTLS(tk, true, true)
 		if err != nil {
 			*errors = append(*errors, err)
 			return
@@ -1381,6 +1417,7 @@ func (o *Options) processConfigFileLine(k string, v any, errors *[]error, warnin
 		}
 		o.TLSTimeout = tc.Timeout
 		o.TLSMap = tc.Map
+		o.TLSCertMap = tc.CertMapSrc
 		o.TLSPinnedCerts = tc.PinnedCerts
 		o.TLSRateLimit = tc.RateLimit
 		o.TLSHandshakeFirst = tc.HandshakeFirst
@@ -1658,7 +1695,10 @@ func (o *Options) processConfigFileLine(k string, v any, errors *[]error, warnin
 			*errors = append(*errors, err)
 		}
 	case "resolver_tls":
-		tc, err := parseTLS(tk, true)
+		// Outbound-only (fetching account JWTs over HTTPS): no peer cert is
+		// ever mapped to a user here, so a verify_and_map template would
+		// silently do nothing.
+		tc, err := parseTLS(tk, true, false)
 		if err != nil {
 			*errors = append(*errors, err)
 			return
@@ -2847,7 +2887,7 @@ func parseLeafNodes(v any, opts *Options, errors *[]error, warnings *[]error) er
 		case "reconnect", "reconnect_delay", "reconnect_interval":
 			opts.LeafNode.ReconnectInterval = parseDuration("reconnect", tk, mv, errors, warnings)
 		case "tls":
-			tc, err := parseTLS(tk, true)
+			tc, err := parseTLS(tk, true, true)
 			if err != nil {
 				*errors = append(*errors, err)
 				continue
@@ -2859,6 +2899,7 @@ func parseLeafNodes(v any, opts *Options, errors *[]error, warnings *[]error) er
 			}
 			opts.LeafNode.TLSTimeout = tc.Timeout
 			opts.LeafNode.TLSMap = tc.Map
+			opts.LeafNode.TLSCertMap = tc.CertMapSrc
 			opts.LeafNode.TLSPinnedCerts = tc.PinnedCerts
 			opts.LeafNode.TLSHandshakeFirst = tc.HandshakeFirst
 			opts.LeafNode.TLSHandshakeFirstFallback = tc.FallbackDelay
@@ -3111,7 +3152,10 @@ func parseRemoteLeafNodes(v any, errors *[]error, warnings *[]error) ([]*RemoteL
 				}
 				remote.Nkey = nk
 			case "tls":
-				tc, err := parseTLS(tk, true)
+				// Outbound-only (this is the solicitor side of a leafnode
+				// connection): no peer cert is ever mapped to a user here,
+				// so a verify_and_map template would silently do nothing.
+				tc, err := parseTLS(tk, true, false)
 				if err != nil {
 					*errors = append(*errors, err)
 					continue
@@ -3256,7 +3300,7 @@ func parseRemoteLeafNodes(v any, errors *[]error, warnings *[]error) ([]*RemoteL
 // Parse TLS and returns a TLSConfig and TLSTimeout.
 // Used by cluster and gateway parsing.
 func getTLSConfig(tk token) (*tls.Config, *TLSConfigOpts, error) {
-	tc, err := parseTLS(tk, false)
+	tc, err := parseTLS(tk, false, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -5057,7 +5101,13 @@ func parseTLSVersion(v any) (uint16, error) {
 }
 
 // Helper function to parse TLS configs.
-func parseTLS(v any, isClientCtx bool) (t *TLSConfigOpts, retErr error) {
+// allowCertMapTemplate reports whether a `verify_and_map` template is
+// meaningful for this TLS context: only inbound listener contexts actually
+// map a peer certificate to a user (server/auth.go). Contexts that only use
+// this TLS config to solicit an outbound connection (resolver_tls, a
+// leafnode remote's tls block) never consult CertMap, so a template there
+// would silently do nothing despite parsing successfully.
+func parseTLS(v any, isClientCtx, allowCertMapTemplate bool) (t *TLSConfigOpts, retErr error) {
 	var (
 		tlsm map[string]any
 		tc   = TLSConfigOpts{}
@@ -5102,14 +5152,27 @@ func parseTLS(v any, isClientCtx bool) (t *TLSConfigOpts, retErr error) {
 			}
 			tc.Verify = verify
 		case "verify_and_map":
-			verify, ok := mv.(bool)
-			if !ok {
-				return nil, &configErr{tk, "error parsing tls config, expected 'verify_and_map' to be a boolean"}
+			switch vv := mv.(type) {
+			case bool:
+				if vv {
+					tc.Verify = vv
+				}
+				tc.Map = vv
+			case string:
+				if !isClientCtx || !allowCertMapTemplate {
+					return nil, &configErr{tk, "error parsing tls config, 'verify_and_map' template is not supported in this context, use a boolean"}
+				}
+				tmpl, err := parseCertIDMapTemplate("verify_and_map", vv)
+				if err != nil {
+					return nil, &configErr{tk, fmt.Sprintf("error parsing tls config, 'verify_and_map' %s", err)}
+				}
+				tc.Verify = true
+				tc.Map = true
+				tc.CertMap = tmpl
+				tc.CertMapSrc = vv
+			default:
+				return nil, &configErr{tk, "error parsing tls config, expected 'verify_and_map' to be a boolean or template string"}
 			}
-			if verify {
-				tc.Verify = verify
-			}
-			tc.Map = verify
 		case "verify_cert_and_check_known_urls":
 			verify, ok := mv.(bool)
 			if !ok {
@@ -5474,7 +5537,7 @@ func parseWebsocket(v any, o *Options, errors *[]error, warnings *[]error) error
 		case "no_tls":
 			o.Websocket.NoTLS = mv.(bool)
 		case "tls":
-			tc, err := parseTLS(tk, true)
+			tc, err := parseTLS(tk, true, true)
 			if err != nil {
 				*errors = append(*errors, err)
 				continue
@@ -5485,6 +5548,7 @@ func parseWebsocket(v any, o *Options, errors *[]error, warnings *[]error) error
 				continue
 			}
 			o.Websocket.TLSMap = tc.Map
+			o.Websocket.TLSCertMap = tc.CertMapSrc
 			o.Websocket.TLSPinnedCerts = tc.PinnedCerts
 			o.Websocket.tlsConfigOpts = tc
 		case "same_origin":
@@ -5589,7 +5653,7 @@ func parseMQTT(v any, o *Options, errors *[]error, warnings *[]error) error {
 		case "host", "net":
 			o.MQTT.Host = mv.(string)
 		case "tls":
-			tc, err := parseTLS(tk, true)
+			tc, err := parseTLS(tk, true, true)
 			if err != nil {
 				*errors = append(*errors, err)
 				continue
@@ -5601,6 +5665,7 @@ func parseMQTT(v any, o *Options, errors *[]error, warnings *[]error) error {
 			}
 			o.MQTT.TLSTimeout = tc.Timeout
 			o.MQTT.TLSMap = tc.Map
+			o.MQTT.TLSCertMap = tc.CertMapSrc
 			o.MQTT.TLSPinnedCerts = tc.PinnedCerts
 			o.MQTT.tlsConfigOpts = tc
 		case "authorization", "authentication":

--- a/server/opts.go
+++ b/server/opts.go
@@ -194,10 +194,7 @@ type LeafNodeOpts struct {
 	TLSConfig     *tls.Config `json:"-"`
 	TLSTimeout    float64     `json:"tls_timeout,omitempty"`
 	TLSMap        bool        `json:"-"`
-	// TLSCertMap holds the `verify_and_map` template source, if any, purely
-	// so config reload can detect a template-text change (the compiled
-	// template itself lives on the unexported tlsConfigOpts snapshot, which
-	// reload's field-by-field diff can't see).
+	// See Options.TLSCertMap.
 	TLSCertMap     string        `json:"-"`
 	TLSPinnedCerts PinnedCertSet `json:"-"`
 	// When set to true, the server will perform the TLS handshake before
@@ -492,10 +489,9 @@ type Options struct {
 	TLS                        bool              `json:"-"`
 	TLSVerify                  bool              `json:"-"`
 	TLSMap                     bool              `json:"-"`
-	// TLSCertMap holds the `verify_and_map` template source, if any, purely
-	// so config reload can detect a template-text change (the compiled
-	// template itself lives on the unexported tlsConfigOpts snapshot, which
-	// reload's field-by-field diff can't see).
+	// TLSCertMap holds the `verify_and_map` template source, if any, so that
+	// config reload can spot a template-text change: the compiled template
+	// lives on the unexported tlsConfigOpts, which reload's diff can't see.
 	TLSCertMap     string        `json:"-"`
 	TLSCert        string        `json:"-"`
 	TLSKey         string        `json:"-"`
@@ -661,10 +657,7 @@ type WebsocketOpts struct {
 	TLSConfig *tls.Config
 	// If true, map certificate values for authentication purposes.
 	TLSMap bool
-	// TLSCertMap holds the `verify_and_map` template source, if any, purely
-	// so config reload can detect a template-text change (the compiled
-	// template itself lives on the unexported tlsConfigOpts snapshot, which
-	// reload's field-by-field diff can't see).
+	// See Options.TLSCertMap.
 	TLSCertMap string
 
 	// When present, accepted client certificates (verify/verify_and_map) must be in this list
@@ -755,10 +748,7 @@ type MQTTOpts struct {
 	TLSConfig *tls.Config
 	// If true, map certificate values for authentication purposes.
 	TLSMap bool
-	// TLSCertMap holds the `verify_and_map` template source, if any, purely
-	// so config reload can detect a template-text change (the compiled
-	// template itself lives on the unexported tlsConfigOpts snapshot, which
-	// reload's field-by-field diff can't see).
+	// See Options.TLSCertMap.
 	TLSCertMap string
 	// Timeout for the TLS handshake
 	TLSTimeout float64
@@ -908,15 +898,12 @@ type TLSConfigOpts struct {
 	OCSPPeerConfig       *certidp.OCSPPeerConfig
 	Certificates         []*TLSCertPairOpt
 	MinVersion           uint16
-	// CertMap holds a compiled `verify_and_map` template, used to derive
-	// a user identity from a peer certificate. Nil unless `verify_and_map`
-	// was given a template string instead of a boolean.
+	// Compiled `verify_and_map` template, nil unless it was given a template
+	// string rather than a boolean.
 	CertMap *template.Template
-	// CertMapSrc is the `verify_and_map` template source that produced
-	// CertMap. Kept only so it can be copied onto an exported field (see
-	// e.g. Options.TLSCertMap) for config reload to compare - *template.Template
-	// itself can't be meaningfully compared with reflect.DeepEqual since it
-	// embeds non-nil func values, which are never considered equal.
+	// The source of CertMap, copied onto an exported field (see
+	// Options.TLSCertMap) for reload to compare: a *template.Template embeds
+	// func values, which reflect.DeepEqual never considers equal.
 	CertMapSrc string
 }
 
@@ -962,6 +949,10 @@ e.g.
         # the user identity from the peer certificate instead of the default
         # email -> SAN -> DN precedence, e.g.:
         # verify_and_map: "{{ first .OrganizationalUnit }}"
+        #
+        # The template form is only accepted here and in the leafnode{},
+        # websocket{} and mqtt{} blocks. cluster{}, gateway{}, resolver_tls{}
+        # and a leafnode remote's tls{} take the boolean form only.
 
         cipher_suites: [
             "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
@@ -1695,9 +1686,7 @@ func (o *Options) processConfigFileLine(k string, v any, errors *[]error, warnin
 			*errors = append(*errors, err)
 		}
 	case "resolver_tls":
-		// Outbound-only (fetching account JWTs over HTTPS): no peer cert is
-		// ever mapped to a user here, so a verify_and_map template would
-		// silently do nothing.
+		// Outbound-only: fetching account JWTs over HTTPS.
 		tc, err := parseTLS(tk, true, false)
 		if err != nil {
 			*errors = append(*errors, err)
@@ -3152,9 +3141,7 @@ func parseRemoteLeafNodes(v any, errors *[]error, warnings *[]error) ([]*RemoteL
 				}
 				remote.Nkey = nk
 			case "tls":
-				// Outbound-only (this is the solicitor side of a leafnode
-				// connection): no peer cert is ever mapped to a user here,
-				// so a verify_and_map template would silently do nothing.
+				// Outbound-only: the solicitor side of a leafnode connection.
 				tc, err := parseTLS(tk, true, false)
 				if err != nil {
 					*errors = append(*errors, err)
@@ -5102,11 +5089,9 @@ func parseTLSVersion(v any) (uint16, error) {
 
 // Helper function to parse TLS configs.
 // allowCertMapTemplate reports whether a `verify_and_map` template is
-// meaningful for this TLS context: only inbound listener contexts actually
-// map a peer certificate to a user (server/auth.go). Contexts that only use
-// this TLS config to solicit an outbound connection (resolver_tls, a
-// leafnode remote's tls block) never consult CertMap, so a template there
-// would silently do nothing despite parsing successfully.
+// meaningful here: only inbound listeners map a peer certificate to a user.
+// An outbound context (resolver_tls, a leafnode remote) never consults
+// CertMap, so a template there would parse and then do nothing.
 func parseTLS(v any, isClientCtx, allowCertMapTemplate bool) (t *TLSConfigOpts, retErr error) {
 	var (
 		tlsm map[string]any
@@ -5154,11 +5139,11 @@ func parseTLS(v any, isClientCtx, allowCertMapTemplate bool) (t *TLSConfigOpts, 
 		case "verify_and_map":
 			switch vv := mv.(type) {
 			case bool:
-				if vv {
-					tc.Verify = vv
-				}
 				tc.Map = vv
 			case string:
+				// allowCertMapTemplate decides this; isClientCtx is checked
+				// too so a future non-client caller can't accept a template
+				// it would never consult.
 				if !isClientCtx || !allowCertMapTemplate {
 					return nil, &configErr{tk, "error parsing tls config, 'verify_and_map' template is not supported in this context, use a boolean"}
 				}
@@ -5166,7 +5151,6 @@ func parseTLS(v any, isClientCtx, allowCertMapTemplate bool) (t *TLSConfigOpts, 
 				if err != nil {
 					return nil, &configErr{tk, fmt.Sprintf("error parsing tls config, 'verify_and_map' %s", err)}
 				}
-				tc.Verify = true
 				tc.Map = true
 				tc.CertMap = tmpl
 				tc.CertMapSrc = vv
@@ -5412,6 +5396,13 @@ func parseTLS(v any, isClientCtx, allowCertMapTemplate bool) (t *TLSConfigOpts, 
 	}
 	if len(tc.Certificates) > 0 && tc.CertFile != _EMPTY_ {
 		return nil, &configErr{tk, "error parsing tls config, cannot combine 'cert_file' option with 'certs' option"}
+	}
+
+	// 'verify_and_map' implies 'verify'. Applied after the loop because the
+	// block is walked as an unordered map, so setting it inline would race
+	// with a 'verify' in the same block.
+	if tc.Map {
+		tc.Verify = true
 	}
 
 	// If cipher suites were not specified then use the defaults

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -275,6 +275,83 @@ Loop:
 	}
 }
 
+func TestTLSClientCertificateOUTemplateBasedAuth(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		listen: "localhost:-1"
+		tls {
+			cert_file: "./configs/certs/tlsauth/server.pem"
+			key_file:  "./configs/certs/tlsauth/server-key.pem"
+			ca_file:   "./configs/certs/tlsauth/ca.pem"
+			verify_and_map: "{{ first .OrganizationalUnit }}"
+		}
+		authorization {
+			users [
+				{ user: "NATS.io", permissions: { publish: {allow: ["public.>"]}, subscribe: {allow: ["public.>"]} } }
+				{ user: "CNCF", permissions: { publish: {allow: [">"]}, subscribe: {allow: [">"]} } }
+			]
+		}
+	`))
+	srv, opts := RunServerWithConfig(conf)
+	defer srv.Shutdown()
+	nurl := fmt.Sprintf("tls://%s:%d", opts.Host, opts.Port)
+
+	errCh := make(chan error, 1)
+
+	// client.pem has subject "OU=NATS.io, CN=example.com", mapped by the
+	// template to the restricted "NATS.io" user.
+	nc1, err := nats.Connect(nurl,
+		nats.ClientCert("./configs/certs/tlsauth/client.pem", "./configs/certs/tlsauth/client-key.pem"),
+		nats.RootCAs("./configs/certs/tlsauth/ca.pem"),
+		nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+			errCh <- err
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Expected to connect, got %v", err)
+	}
+	defer nc1.Close()
+
+	// client2.pem has subject "OU=CNCF, CN=example.com", mapped to the
+	// "CNCF" user which can publish/subscribe on '>'.
+	nc2, err := nats.Connect(nurl,
+		nats.ClientCert("./configs/certs/tlsauth/client2.pem", "./configs/certs/tlsauth/client2-key.pem"),
+		nats.RootCAs("./configs/certs/tlsauth/ca.pem"),
+	)
+	if err != nil {
+		t.Fatalf("Expected to connect, got %v", err)
+	}
+	defer nc2.Close()
+
+	sub, err := nc2.SubscribeSync(">")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nc2.Flush()
+
+	if err := nc1.Publish("public.hello", []byte("hi")); err != nil {
+		t.Fatal(err)
+	}
+	nc1.Flush()
+	if _, err := sub.NextMsg(1 * time.Second); err != nil {
+		t.Fatalf("Error during wait for next message: %s", err)
+	}
+
+	// Publishing outside the "NATS.io" user's allowed subject should be
+	// rejected by the server as a permissions violation.
+	if err := nc1.Publish("not.allowed", []byte("hi")); err != nil {
+		t.Fatal(err)
+	}
+	nc1.Flush()
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("Expected a permissions violation error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out expecting a permissions violation error")
+	}
+}
+
 func TestTLSClientCertificateSANsBasedAuth(t *testing.T) {
 	// In this test we have 3 clients, one with permissions defined
 	// for SAN 'app.nats.dev', other for SAN 'app.nats.prod' and another

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -336,8 +336,8 @@ func TestTLSClientCertificateOUTemplateBasedAuth(t *testing.T) {
 		t.Fatalf("Error during wait for next message: %s", err)
 	}
 
-	// Publishing outside the "NATS.io" user's allowed subject should be
-	// rejected by the server as a permissions violation.
+	// Outside the "NATS.io" user's allowed subject: the publish itself
+	// succeeds, the violation arrives asynchronously on errCh.
 	if err := nc1.Publish("not.allowed", []byte("hi")); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Today, `verify_and_map` derives a client's identity from a fixed email → SAN → DN precedence and matches it literally against a configured user. That means every distinct certificate has to be individually enumerated as a user - even when a whole group of certs should share the same access, e.g. anything issued to an "infrastructure" OU, or a specific team/service tier. There's no way to grant access by attribute rather than by identity.

This adds an opt-in template form: `verify_and_map` can now be a text/template string instead of just a boolean, e.g.

    verify_and_map: "{{ first .OrganizationalUnit }}"

so any certificate carrying that OU maps onto one shared user, regardless of its CN, SAN, or any other per-cert detail. Fields can also be combined for finer-grained grouping (e.g. "this OU, but only in this country"):

    verify_and_map: '{{if and (has "infra" .OrganizationalUnit) (has "GB" .Country)}}infra-gb{{end}}'

Multi-valued attributes (a cert can legally carry more than one OU) are handled via a `has` membership check rather than assuming a single value.

Existing `verify_and_map: true` configs are completely unaffected — the legacy cascade is untouched, the template path is purely additive, and a template with a bad field reference is rejected at config load rather than failing silently on first connect.

Not supported for cluster/gateway TLS (those map to a single fixed username rather than a set of users, so grouping doesn't apply there); config parsing rejects a template in that context with a clear error.

---

Resolves #8393