### PR TITLE
[IMPROVED] Recycle msg block buffer on weak cache GC

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -5479,6 +5479,9 @@ func (fs *fileStore) firstSeqForSubj(subj string) (uint64, error) {
 			if ss.firstNeedsUpdate || ss.lastNeedsUpdate {
 				err = mb.recalculateForSubj(subj, ss)
 			}
+			if needsCleanup {
+				mb.finishedWithCache()
+			}
 			mb.mu.Unlock()
 			// Re-acquire fs lock
 			fs.mu.Lock()
@@ -11333,10 +11336,13 @@ func (mb *msgBlock) removeSeqPerSubject(subj string, seq uint64) (uint64, error)
 // Will avoid slower path message lookups and scan the cache directly instead.
 func (mb *msgBlock) recalculateForSubj(subj string, ss *SimpleState) error {
 	// Need to make sure messages are loaded.
+	needsCleanup := mb.cache == nil
 	if mb.cacheNotLoaded() {
 		if err := mb.loadMsgsWithLock(); err != nil {
 			return err
 		}
+	}
+	if needsCleanup {
 		defer mb.finishedWithCache()
 	}
 

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -279,6 +279,9 @@ type cache struct {
 	idx  []uint32
 	fseq uint64
 	nra  bool
+	// When GC collects this cache due to it being a weak pointer,
+	// recycle the buf back into the block buffer pools.
+	clean runtime.Cleanup
 }
 
 type msgId struct {
@@ -1054,6 +1057,37 @@ func getMsgBlockBuf(sz int) (buf []byte) {
 	}
 }
 
+// registerRecycle arranges for the cache's buffer to be returned to the
+// block buffer pools when the cache itself is garbage collected due to it
+// remaining as a weak pointer. Without it, subsequent block loads would
+// allocate fresh buffers, which could result in GC re-running, which is
+// pathological under sustained block loads.
+func (c *cache) registerRecycle() {
+	if c == nil {
+		return
+	}
+	// Any previous registration is canceled first.
+	c.stopRecycle()
+	// Skip if recycle isn't allowed or nothing to recycle.
+	if c.nra || cap(c.buf) == 0 {
+		return
+	}
+	// Don't make this cleanup conditional (e.g. skip if under memory pressure), GC
+	// will drain the block buffer pools separately, so this doesn't pin memory.
+	// Skipping would be worse, we'd delay freeing the buffer until the next GC cycle.
+	c.clean = runtime.AddCleanup(c, recycleMsgBlockBuf, c.buf)
+}
+
+// stopRecycle cancels a pending recycle registration. Must be called before
+// the buffer is recycled or handed off explicitly, otherwise the cleanup
+// could return the same buffer to the pool a second time while it is in use.
+func (c *cache) stopRecycle() {
+	if c.clean != (runtime.Cleanup{}) {
+		c.clean.Stop()
+		c.clean = runtime.Cleanup{}
+	}
+}
+
 // Recycle the msg block.
 func recycleMsgBlockBuf(buf []byte) {
 	switch cap(buf) {
@@ -1441,6 +1475,7 @@ func (mb *msgBlock) convertCipher() error {
 		}
 
 		// Reset the cache since we just read everything in.
+		mb.cache.stopRecycle()
 		mb.cache = nil
 		mb.ecache.Set(nil)
 
@@ -1484,6 +1519,7 @@ func (mb *msgBlock) convertToEncrypted() error {
 		return err
 	}
 	// Undo cache from above for later.
+	mb.cache.stopRecycle()
 	mb.cache = nil
 	mb.ecache.Set(nil)
 	// Regenerate mb.bek so that the keystream offset is at zero. This matches
@@ -4755,6 +4791,7 @@ func (mb *msgBlock) setupWriteCache(buf []byte) error {
 
 	// Looks like there isn't an existing file on disk, mint a new cache.
 	mb.cache = &cache{buf: buf}
+	mb.cache.registerRecycle()
 	mb.ecache.Set(mb.cache)
 	mb.llts = ats.AccessTime()
 	mb.startCacheExpireTimer()
@@ -6719,6 +6756,7 @@ func (mb *msgBlock) clearCache() {
 	buf := mbcache.buf
 	mb.cache = nil
 	mb.ecache.Set(nil)
+	mbcache.stopRecycle()
 	recycleMsgBlockBuf(buf)
 }
 
@@ -6762,6 +6800,10 @@ func (mb *msgBlock) tryExpireWriteCache() []byte {
 		// Clear last write time since we now are about to move on to a new lmb.
 		mb.lwts = 0
 		return buf[:0]
+	}
+	// The cache may have expired above without recycling the buffer.
+	if mb.cache == nil && !nra {
+		recycleMsgBlockBuf(buf)
 	}
 	return nil
 }
@@ -6817,6 +6859,7 @@ func (mb *msgBlock) tryExpireCacheLocked() {
 	// If we are here we will at least expire the core msg buffer.
 	// We need to capture offset in case we do a write next before a full load.
 	if mb.cache != nil {
+		mb.cache.stopRecycle()
 		if !mb.cache.nra {
 			recycleMsgBlockBuf(mb.cache.buf)
 		}
@@ -7325,11 +7368,13 @@ func (mb *msgBlock) writeMsgRecordLocked(rl, seq uint64, subj string, mhdr, msg 
 	// from the next pool size up to save us from reallocating in append() below.
 	if nsz := len(mb.cache.buf) + int(rl); cap(mb.cache.buf) < nsz {
 		prev := mb.cache.buf
+		mb.cache.stopRecycle()
 		mb.cache.buf = getMsgBlockBuf(nsz)
 		if prev != nil {
 			mb.cache.buf = mb.cache.buf[:copy(mb.cache.buf[:nsz], prev)]
 			recycleMsgBlockBuf(prev)
 		}
+		mb.cache.registerRecycle()
 	}
 
 	// Indexing
@@ -8108,6 +8153,7 @@ func (mb *msgBlock) indexCacheBuf(buf []byte) error {
 		// The buf arg already came from the pool probably, so there's
 		// no point in reusing mb.cache.buf's underlying capacity here.
 		// Just recycle it for the next block load.
+		mb.cache.stopRecycle()
 		recycleMsgBlockBuf(mb.cache.buf)
 	}
 	if idx = mb.cache.idx; uint64(cap(idx)) >= idxSz {
@@ -8258,6 +8304,7 @@ func (mb *msgBlock) indexCacheBuf(buf []byte) error {
 	mb.cache.wp = int(lbuf)
 	mb.ttls = ttls
 	mb.schedules = schedules
+	mb.cache.registerRecycle()
 
 	return nil
 }

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -1847,6 +1847,61 @@ func TestFileStoreWeakCachePromotionCleanup(t *testing.T) {
 		defer mb.mu.Unlock()
 		require_NoStrongCache(t, mb, c)
 	})
+
+	t.Run("recalculateForSubj", func(t *testing.T) {
+		fs, mb, c := newTestStore(t)
+		// Removing the first msg for "foo" marks its SimpleState as needing
+		// a lazy first sequence recalculation.
+		removed, err := fs.removeMsg(1, false, true, true)
+		require_NoError(t, err)
+		require_True(t, removed)
+		mb.mu.Lock()
+		defer mb.mu.Unlock()
+		ss, ok := mb.fss.Find(stringToBytes("foo"))
+		require_True(t, ok)
+		require_True(t, ss.firstNeedsUpdate)
+		// The cache is only weakly referenced, so recalculateForSubj will
+		// promote it and must release the strong reference again.
+		require_True(t, mb.cache == nil)
+		require_NoError(t, mb.recalculateForSubj("foo", ss))
+		require_Equal(t, ss.First, uint64(2))
+		require_NoStrongCache(t, mb, c)
+	})
+
+	t.Run("firstSeqForSubj", func(t *testing.T) {
+		fs, mb, _ := newTestStore(t)
+		// Clear the weak reference too, forcing firstSeqForSubj to reload
+		// the block from disk to get fss, taking a strong cache reference.
+		mb.mu.Lock()
+		mb.ecache.Set(nil)
+		mb.mu.Unlock()
+		fs.mu.Lock()
+		seq, err := fs.firstSeqForSubj("foo")
+		fs.mu.Unlock()
+		require_NoError(t, err)
+		require_Equal(t, seq, uint64(1))
+		mb.mu.Lock()
+		defer mb.mu.Unlock()
+		require_True(t, mb.cache == nil)
+		require_NotNil(t, mb.ecache.Value())
+	})
+
+	t.Run("firstSeqForSubjRecalculate", func(t *testing.T) {
+		fs, mb, c := newTestStore(t)
+		// Removing the first msg for "foo" marks its SimpleState as needing
+		// a lazy first sequence recalculation, done inside firstSeqForSubj.
+		removed, err := fs.removeMsg(1, false, true, true)
+		require_NoError(t, err)
+		require_True(t, removed)
+		fs.mu.Lock()
+		seq, err := fs.firstSeqForSubj("foo")
+		fs.mu.Unlock()
+		require_NoError(t, err)
+		require_Equal(t, seq, uint64(2))
+		mb.mu.Lock()
+		defer mb.mu.Unlock()
+		require_NoStrongCache(t, mb, c)
+	})
 }
 
 func TestFileStorePartialCacheExpiration(t *testing.T) {

--- a/server/norace_2_test.go
+++ b/server/norace_2_test.go
@@ -3607,3 +3607,253 @@ func TestNoRaceQuickMultipleConfigReloadRemoteLeafNoDuplicate(t *testing.T) {
 		})
 	}
 }
+
+// This test observes buffers being returned to the block buffer sync.Pools.
+// Under the race detector sync.Pool randomly drops puts by design, so it
+// cannot run with -race.
+func TestNoRaceFileStoreWeakCacheGCRecyclesBuf(t *testing.T) {
+	// Run everything on a single P so all sync.Pool puts/gets use the same
+	// P-local pool: buffers recycled by the GC cleanup goroutine would
+	// otherwise often land in another P's private slot, which Get on this
+	// goroutine can never steal from and the test couldn't observe them.
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(1))
+
+	// All cache buffers in this test come from the tiny block pool, identify
+	// them by their backing array so we can spot them in the pool.
+	bufArr := func(buf []byte) *[defaultTinyBlockSize]byte {
+		return (*[defaultTinyBlockSize]byte)(buf[0:defaultTinyBlockSize])
+	}
+	// Wait for the GC cleanup to recycle the buffer back into the pool.
+	// GC and polling must be interleaved carefully: every GC cycle also
+	// drains the sync.Pools, so polling Get while triggering GCs could
+	// evict the recycled buffer before we get a chance to observe it.
+	expectRecycled := func(t *testing.T, arr *[defaultTinyBlockSize]byte) {
+		t.Helper()
+		for attempts := 0; attempts < 10; attempts++ {
+			runtime.GC()
+			// Poll without triggering more GCs so the pool isn't drained
+			// while we look for the buffer.
+			for range 20 {
+				if blkPoolTiny.Get().(*[defaultTinyBlockSize]byte) == arr {
+					return
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+		}
+		t.Fatalf("buffer was not recycled into the pool")
+	}
+	// Ensure the buffer does not (re)appear in the pool through a GC cleanup.
+	expectNotRecycled := func(t *testing.T, arr *[defaultTinyBlockSize]byte) {
+		t.Helper()
+		for attempts := 0; attempts < 3; attempts++ {
+			runtime.GC()
+			// Give a (faulty) cleanup time to run, then poll without
+			// triggering more GCs so we would reliably see its recycle.
+			time.Sleep(20 * time.Millisecond)
+			for range 20 {
+				if blkPoolTiny.Get().(*[defaultTinyBlockSize]byte) == arr {
+					t.Fatalf("buffer was recycled into the pool, but should not have been")
+				}
+				time.Sleep(2 * time.Millisecond)
+			}
+		}
+	}
+
+	newTestStore := func(t *testing.T) *msgBlock {
+		t.Helper()
+		fs, err := newFileStore(
+			FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 8192},
+			StreamConfig{Name: "zzz", Storage: FileStorage, Subjects: []string{"foo"}},
+		)
+		require_NoError(t, err)
+		t.Cleanup(func() { fs.Stop() })
+
+		for range 4 {
+			_, _, err = fs.StoreMsg("foo", nil, []byte("hello"), 0)
+			require_NoError(t, err)
+		}
+		require_NoError(t, fs.FlushAllPending())
+
+		fs.mu.Lock()
+		mb := fs.lmb
+		fs.mu.Unlock()
+		return mb
+	}
+
+	t.Run("recycledOnGC", func(t *testing.T) {
+		arr := func() *[defaultTinyBlockSize]byte {
+			c := &cache{buf: getMsgBlockBuf(1)}
+			c.registerRecycle()
+			require_True(t, c.clean != (runtime.Cleanup{}))
+			return bufArr(c.buf)
+		}()
+		// The cache is unreachable now, GC should recycle its buffer.
+		expectRecycled(t, arr)
+	})
+
+	t.Run("stopRecycle", func(t *testing.T) {
+		arr := func() *[defaultTinyBlockSize]byte {
+			c := &cache{buf: getMsgBlockBuf(1)}
+			c.registerRecycle()
+			c.stopRecycle()
+			require_True(t, c.clean == (runtime.Cleanup{}))
+			return bufArr(c.buf)
+		}()
+		expectNotRecycled(t, arr)
+	})
+
+	t.Run("registerRecycleTwice", func(t *testing.T) {
+		arr := func() *[defaultTinyBlockSize]byte {
+			c := &cache{buf: getMsgBlockBuf(1)}
+			// Registering again must cancel the previous registration,
+			// otherwise the buffer would be recycled twice.
+			c.registerRecycle()
+			c.registerRecycle()
+			return bufArr(c.buf)
+		}()
+		expectRecycled(t, arr)
+		expectNotRecycled(t, arr)
+	})
+
+	t.Run("noRecycleNRA", func(t *testing.T) {
+		arr := func() *[defaultTinyBlockSize]byte {
+			c := &cache{buf: getMsgBlockBuf(1), nra: true}
+			c.registerRecycle()
+			require_True(t, c.clean == (runtime.Cleanup{}))
+			return bufArr(c.buf)
+		}()
+		expectNotRecycled(t, arr)
+	})
+
+	t.Run("noRecycleEmptyBuf", func(t *testing.T) {
+		c := &cache{}
+		c.registerRecycle()
+		require_True(t, c.clean == (runtime.Cleanup{}))
+		// Stopping without a registration, or twice, must not panic.
+		c.stopRecycle()
+		c.stopRecycle()
+		// Neither must registering on a nil cache.
+		(*cache)(nil).registerRecycle()
+	})
+
+	t.Run("weakWriteCacheGC", func(t *testing.T) {
+		mb := newTestStore(t)
+		arr := func() *[defaultTinyBlockSize]byte {
+			mb.mu.Lock()
+			defer mb.mu.Unlock()
+			// The write path registered the recycle cleanup when it grew
+			// the write cache buffer from the pool.
+			require_NotNil(t, mb.cache)
+			require_True(t, mb.cache.clean != (runtime.Cleanup{}))
+			require_Equal(t, cap(mb.cache.buf), defaultTinyBlockSize)
+			arr := bufArr(mb.cache.buf)
+			// Drop the strong references so only the weak pointer remains.
+			mb.finishedWithCache()
+			require_True(t, mb.cache == nil)
+			mb.ecache.Weaken()
+			require_NotNil(t, mb.ecache.Value())
+			return arr
+		}()
+
+		// GC collects the weakly referenced cache and recycles its buffer.
+		expectRecycled(t, arr)
+		mb.mu.Lock()
+		defer mb.mu.Unlock()
+		require_True(t, mb.ecache.Value() == nil)
+	})
+
+	t.Run("weakLoadedCacheGC", func(t *testing.T) {
+		mb := newTestStore(t)
+		arr := func() *[defaultTinyBlockSize]byte {
+			mb.mu.Lock()
+			defer mb.mu.Unlock()
+			// Reload the block from disk so indexCacheBuf registers the cleanup.
+			mb.clearCache()
+			require_True(t, mb.cache == nil)
+			require_NoError(t, mb.loadMsgsWithLock())
+			require_NotNil(t, mb.cache)
+			require_True(t, mb.cache.clean != (runtime.Cleanup{}))
+			require_Equal(t, cap(mb.cache.buf), defaultTinyBlockSize)
+			arr := bufArr(mb.cache.buf)
+			mb.finishedWithCache()
+			require_True(t, mb.cache == nil)
+			mb.ecache.Weaken()
+			require_NotNil(t, mb.ecache.Value())
+			return arr
+		}()
+
+		expectRecycled(t, arr)
+		mb.mu.Lock()
+		defer mb.mu.Unlock()
+		require_True(t, mb.ecache.Value() == nil)
+	})
+
+	t.Run("clearCacheNoDoubleRecycle", func(t *testing.T) {
+		mb := newTestStore(t)
+		arr := func() *[defaultTinyBlockSize]byte {
+			mb.mu.Lock()
+			defer mb.mu.Unlock()
+			require_NotNil(t, mb.cache)
+			require_Equal(t, cap(mb.cache.buf), defaultTinyBlockSize)
+			arr := bufArr(mb.cache.buf)
+			mb.clearCache()
+			require_True(t, mb.cache == nil)
+			require_True(t, mb.ecache.Value() == nil)
+			return arr
+		}()
+
+		// clearCache recycled the buffer into the pool explicitly once...
+		expectRecycled(t, arr)
+		// ...and GC of the disused cache must not recycle it a second time.
+		expectNotRecycled(t, arr)
+	})
+
+	t.Run("writeCacheHandoffNoRecycle", func(t *testing.T) {
+		mb := newTestStore(t)
+		arr, buf := func() (*[defaultTinyBlockSize]byte, []byte) {
+			mb.mu.Lock()
+			defer mb.mu.Unlock()
+			require_NotNil(t, mb.cache)
+			require_Equal(t, cap(mb.cache.buf), defaultTinyBlockSize)
+			arr := bufArr(mb.cache.buf)
+			// Pretend the block was never loaded for reads, so the write cache
+			// buffer is handed off for reuse by the next write block.
+			mb.llts = 0
+			buf := mb.tryExpireWriteCache()
+			require_True(t, buf != nil)
+			require_True(t, bufArr(buf) == arr)
+			// Drop any remaining references to the old cache object.
+			mb.cache = nil
+			mb.ecache.Set(nil)
+			return arr, buf
+		}()
+
+		// The handed-off buffer is still in use, so GC of the old cache
+		// object must not recycle it into the pool.
+		expectNotRecycled(t, arr)
+		runtime.KeepAlive(buf)
+	})
+
+	t.Run("expiredWriteCacheNoHandoffRecycles", func(t *testing.T) {
+		mb := newTestStore(t)
+		arr := func() *[defaultTinyBlockSize]byte {
+			mb.mu.Lock()
+			defer mb.mu.Unlock()
+			require_NotNil(t, mb.cache)
+			require_Equal(t, cap(mb.cache.buf), defaultTinyBlockSize)
+			arr := bufArr(mb.cache.buf)
+			// Pretend the block was read, but long ago. The cache will
+			// expire, but the stale read blocks the buffer handoff.
+			mb.llts = 1
+			buf := mb.tryExpireWriteCache()
+			require_True(t, buf == nil)
+			require_True(t, mb.cache == nil)
+			return arr
+		}()
+
+		// The buffer was recycled into the pool explicitly once...
+		expectRecycled(t, arr)
+		// ...and GC of the disused cache must not recycle it a second time.
+		expectNotRecycled(t, arr)
+	})
+}


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/8380.

In `firstSeqForSubj` and `recalculateForSubj` the weak cache would be loaded as a side-effect of `if mb.cacheNotLoaded()` but would not be weakened again due to missing `mb.finishedWithCache()` calls.

Additionally, if any block's weak caches were GC'ed their buffers wouldn't be recycled, potentially requiring to re-allocate new buffers that would otherwise have been recycled for reuse. This PR updates that too, when a weak cache is garbage collected, it recycles the cache's buffer back into the block pool. This should prevent pathological cases where GC runs and collects many weak caches and buffers, to then require a bunch of allocations of fresh buffers for subsequent block loads, only to then trigger GC and collect those buffers again.