### PR TITLE
[FIXED] Consumer reset responses across service imports

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -4522,11 +4522,16 @@ func (o *consumer) processResetReq(_ *subscription, c *client, a *Account, _, re
 
 	s := o.srv
 	var resp = JSApiConsumerResetResponse{ApiResponse: ApiResponse{Type: JSApiConsumerResetResponseType}}
+	sendResponse := func() {
+		// Service import responses use the account's internal client, so allow
+		// it to receive the response.
+		s.sendInternalAccountMsgWithReply(a, reply, _EMPTY_, nil, s.jsonResponse(&resp), true)
+	}
 
 	hdr, msg := c.msgParts(rmsg)
 	if errorOnRequiredApiLevel(hdr) {
 		resp.Error = NewJSRequiredApiLevelError()
-		s.sendInternalAccountMsg(a, reply, s.jsonResponse(&resp))
+		sendResponse()
 		return
 	}
 
@@ -4535,18 +4540,18 @@ func (o *consumer) processResetReq(_ *subscription, c *client, a *Account, _, re
 	if len(msg) > 0 {
 		if err := json.Unmarshal(msg, &req); err != nil {
 			resp.Error = NewJSInvalidJSONError(err)
-			s.sendInternalAccountMsg(a, reply, s.jsonResponse(&resp))
+			sendResponse()
 			return
 		}
 	}
 	resetSeq, canRespond, err := o.resetStartingSeq(req.Seq, reply, false)
 	if err != nil {
 		resp.Error = NewJSConsumerInvalidResetError(err)
-		s.sendInternalAccountMsg(a, reply, s.jsonResponse(&resp))
+		sendResponse()
 	} else if canRespond {
 		resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
 		resp.ResetSeq = resetSeq
-		s.sendInternalAccountMsg(a, reply, s.jsonResponse(&resp))
+		sendResponse()
 	}
 }
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -7071,15 +7071,19 @@ func (js *jetStream) applyConsumerEntries(o *consumer, ce *CommittedEntry, isLea
 						delete(o.rsm, reply)
 						o.mu.Unlock()
 
-						// Check if the reset request needs to be answered on the system account.
-						// This will happen for replicated sourcing consumers that get reset as part of a create/update.
-						if internal {
-							a = nil
-						}
 						var resp = JSApiConsumerResetResponse{ApiResponse: ApiResponse{Type: JSApiConsumerResetResponseType}}
 						resp.ConsumerInfo = setDynamicConsumerInfoMetadata(o.info())
 						resp.ResetSeq = sseq
-						s.sendInternalAccountMsg(a, reply, s.jsonResponse(&resp))
+						response := s.jsonResponse(&resp)
+						// Replicated sourcing consumers that get reset as part of a create/update
+						// need to be answered on the system account.
+						if internal {
+							s.sendInternalAccountMsg(nil, reply, response)
+						} else {
+							// Direct reset replies may need to reach a service import response
+							// on the account's internal client.
+							s.sendInternalAccountMsgWithReply(a, reply, _EMPTY_, nil, response, true)
+						}
 					}
 				}
 			case addPendingRequest:

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -11568,6 +11568,97 @@ func TestJetStreamConsumerResetToSequence(t *testing.T) {
 	}
 }
 
+// https://github.com/nats-io/nats-server/issues/8396
+func TestJetStreamConsumerResetResponseAcrossServiceImport(t *testing.T) {
+	const accounts = `
+		system_account: SYS
+		accounts {
+			A {
+				jetstream: enabled
+				users = [{user: a, password: a}]
+				exports = [{service: "$JS.API.CONSUMER.RESET.TEST.*", accounts: [B]}]
+			}
+			B {
+				jetstream: enabled
+				users = [{user: b, password: b}]
+				imports = [{service: {account: A, subject: "$JS.API.CONSUMER.RESET.TEST.*"}, to: "$JS.REMOTE.API.CONSUMER.RESET.TEST.*"}]
+			}
+			SYS {users = [{user: admin, password: admin}]}
+		}
+	`
+
+	test := func(t *testing.T, s *Server, replicas int, requestServer func() *Server) {
+		nc, js := jsClientConnect(t, s, nats.UserInfo("a", "a"))
+		defer nc.Close()
+
+		_, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Replicas: replicas})
+		require_NoError(t, err)
+		_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+			Durable:   "CONSUMER",
+			AckPolicy: nats.AckExplicitPolicy,
+			Replicas:  replicas,
+		})
+		require_NoError(t, err)
+
+		if requestServer != nil {
+			s = requestServer()
+		}
+		ncImport := natsConnect(t, s.ClientURL(), nats.UserInfo("b", "b"))
+		defer ncImport.Close()
+		const resetSubject = "$JS.REMOTE.API.CONSUMER.RESET.TEST.CONSUMER"
+
+		msg, err := ncImport.Request(resetSubject, nil, 2*time.Second)
+		require_NoError(t, err)
+		var resp JSApiConsumerResetResponse
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		require_Equal(t, resp.Type, JSApiConsumerResetResponseType)
+		require_True(t, resp.Error == nil)
+		require_NotNil(t, resp.ConsumerInfo)
+		require_Equal(t, resp.ConsumerInfo.Name, "CONSUMER")
+		require_Equal(t, resp.ResetSeq, 1)
+
+		msg, err = ncImport.Request(resetSubject, []byte("{"), 2*time.Second)
+		require_NoError(t, err)
+		resp = JSApiConsumerResetResponse{}
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		require_Equal(t, resp.Type, JSApiConsumerResetResponseType)
+		require_NotNil(t, resp.Error)
+		require_Equal(t, resp.Error.ErrCode, uint16(JSInvalidJSONErr))
+	}
+
+	t.Run("R1", func(t *testing.T) {
+		conf := createConfFile(t, []byte(fmt.Sprintf(`
+			listen: 127.0.0.1:-1
+			jetstream: {store_dir: %q}
+			%s
+		`, t.TempDir(), accounts)))
+		s, _ := RunServerWithConfig(conf)
+		defer s.Shutdown()
+		test(t, s, 1, nil)
+	})
+
+	t.Run("R3", func(t *testing.T) {
+		const clusterConfig = `
+			listen: 127.0.0.1:-1
+			server_name: %s
+			jetstream: {store_dir: %q}
+			cluster {
+				name: %s
+				listen: 127.0.0.1:%d
+				routes = [%s]
+			}
+		` + accounts
+		c := createJetStreamClusterWithTemplate(t, clusterConfig, "R3S", 3)
+		defer c.shutdown()
+
+		s := c.randomServer()
+		test(t, s, 3, func() *Server {
+			c.waitOnConsumerLeader("A", "TEST", "CONSUMER")
+			return c.consumerLeader("A", "TEST", "CONSUMER")
+		})
+	})
+}
+
 func TestJetStreamConsumerResetToSequenceConstraintOnStartSeq(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()


### PR DESCRIPTION
## Problem

Consumer RESET responses sent through a service import could be dropped. The service-import response subscription and the response publisher share the exporting account's internal client, whose no-echo setting prevented the reply from reaching the importer. This also left cross-account durable source setup inactive when it reused an existing consumer.

## Change

- Allow direct consumer RESET replies to reach service-import response subscriptions.
- Apply the same behavior after replicated consumer resets commit.
- Preserve the system-account response path used by server-managed replicated sourcing consumers.
- Add R1 and R3 regression coverage, including an error response.

## Testing

- `./scripts/runTestsOnTravis.sh js_consumer_tests`
- `go test -race ./server -run '^TestJetStreamConsumerResetResponseAcrossServiceImport$' -count=3`
- Existing reset and durable source/mirror tests, including server-managed variants
- `go build ./...`
- `go vet ./...`
- `golangci-lint v2.9.0`

Resolves #8396