### PR TITLE
[FIXED] Correct max_subs reload unit test

### DIFF
--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -1973,18 +1973,69 @@ func TestConfigReloadClusterName(t *testing.T) {
 	}
 }
 
-func TestConfigReloadMaxSubsUnsupported(t *testing.T) {
-	s, _, conf := runReloadServerWithContent(t, []byte(`
-		port: -1
-		max_subs: 1
-		`))
+func TestConfigReloadAccountMaxSubs(t *testing.T) {
+	config := func(maxSubs int) string {
+		return fmt.Sprintf(`
+			listen: "127.0.0.1:-1"
+			accounts {
+				TEST {
+					users = [{user: "user", password: "pwd"}]
+					limits { max_subs: %d }
+				}
+			}
+		`, maxSubs)
+	}
+
+	s, _, conf := runReloadServerWithContent(t, []byte(config(1)))
 	defer s.Shutdown()
 
-	if err := os.WriteFile(conf, []byte(`max_subs: 10`), 0666); err != nil {
-		t.Fatalf("Error writing config file: %v", err)
+	errCh := make(chan error, 1)
+	closed := make(chan struct{}, 1)
+	nc := natsConnect(t, s.ClientURL(),
+		nats.UserInfo("user", "pwd"),
+		nats.NoReconnect(),
+		nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+			errCh <- err
+		}),
+		nats.ClosedHandler(func(*nats.Conn) {
+			closed <- struct{}{}
+		}))
+	defer nc.Close()
+
+	initialSubs := s.NumSubscriptions()
+	if _, err := nc.SubscribeSync("foo.1"); err != nil {
+		t.Fatalf("Error subscribing: %v", err)
 	}
-	if err := s.Reload(); err == nil {
-		t.Fatal("Expected Reload to return an error")
+	if err := nc.Flush(); err != nil {
+		t.Fatalf("Error flushing subscription: %v", err)
+	}
+
+	reloadUpdateConfig(t, s, conf, config(3))
+	for _, subject := range []string{"foo.2", "foo.3"} {
+		if _, err := nc.SubscribeSync(subject); err != nil {
+			t.Fatalf("Error subscribing to %q: %v", subject, err)
+		}
+	}
+	if err := nc.Flush(); err != nil {
+		t.Fatalf("Error flushing subscriptions: %v", err)
+	}
+	if got, want := s.NumSubscriptions(), initialSubs+3; got != want {
+		t.Fatalf("Expected %d subscriptions after increasing max_subs, got %d", want, got)
+	}
+
+	reloadUpdateConfig(t, s, conf, config(2))
+	select {
+	case err := <-errCh:
+		if !strings.Contains(err.Error(), "maximum subscriptions exceeded") {
+			t.Fatalf("Unexpected error after decreasing max_subs: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Expected a maximum subscriptions error")
+	}
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Expected connection to close after decreasing max_subs")
 	}
 }
 


### PR DESCRIPTION
The existing `TestConfigReloadMaxSubsUnsupported` test starts the server on a random client port, but rewrites the configuration without preserving that setting. As a result, it can pass because of the unsupported port change instead of validating `max_subs` reload behavior.

Replace it with behavioral coverage for per-account `max_subs` reloads:

- increasing the limit allows the connected client to add subscriptions;
- decreasing the limit below the active subscription count reports `maximum subscriptions exceeded` and closes the violating connection.

This changes regression coverage only; server behavior is unchanged.

Resolves #4173

## Testing

- `go test ./server -run '^TestConfigReloadAccountMaxSubs$' -count=100`
- `go test -race ./server -run '^TestConfigReloadAccountMaxSubs$' -count=10`
- `go test ./server -run '^TestConfigReloadMaxConnections$' -count=1`
- `go test ./server -run '^TestConfigReloadMaxPayload$' -count=1`
- `./scripts/runTestsOnTravis.sh srv_pkg_non_js_tests`
- `go build ./...`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run --timeout=5m --config=.golangci.yml`

I certify that this contribution is my original work and that I license it to the project under the Apache-2.0 license.