### PR TITLE
[FIXED] Return /connz timestamps in UTC

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -577,8 +577,8 @@ func (ci *ConnInfo) fill(client *client, nc net.Conn, now time.Time, auth bool) 
 	ci.MQTTClient = client.getMQTTClientID()
 	ci.Kind = client.kindString()
 	ci.Type = client.clientTypeString()
-	ci.Start = client.start
-	ci.LastActivity = client.last
+	ci.Start = client.start.UTC()
+	ci.LastActivity = client.last.UTC()
 	ci.Uptime = myUptime(now.Sub(client.start))
 	ci.Idle = myUptime(now.Sub(client.last))
 	ci.RTT = rtt.String()

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -493,6 +493,61 @@ func TestMonitorConnz(t *testing.T) {
 	}
 }
 
+func TestMonitorConnzTimestampsUTC(t *testing.T) {
+	s := runMonitorServer()
+	defer s.Shutdown()
+
+	nc := createClientConnSubscribeAndPublish(t, s)
+	cid, err := nc.GetClientID()
+	require_NoError(t, err)
+	client := s.getClient(cid)
+	if client == nil {
+		t.Fatalf("Expected to find client %d", cid)
+	}
+	nonUTC := time.FixedZone("UTC-7", -7*60*60)
+	setNonUTC := func() {
+		client.mu.Lock()
+		client.start = client.start.In(nonUTC)
+		client.last = client.last.In(nonUTC)
+		client.mu.Unlock()
+	}
+	setNonUTC()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/", s.MonitorAddr().Port)
+	checkUTC := func(name string, timestamp time.Time) {
+		t.Helper()
+		if timestamp.Location() != time.UTC {
+			t.Fatalf("Expected %s to use UTC, got %s", name, timestamp.Location())
+		}
+	}
+	checkConn := func(ci *ConnInfo, closed bool) {
+		t.Helper()
+		checkUTC("start", ci.Start)
+		checkUTC("last activity", ci.LastActivity)
+		if closed {
+			if ci.Stop == nil {
+				t.Fatal("Expected stop time for closed connection")
+			}
+			checkUTC("stop", *ci.Stop)
+		}
+	}
+
+	for mode := 0; mode < 2; mode++ {
+		c := pollConnz(t, s, mode, url+"connz", nil)
+		require_Len(t, len(c.Conns), 1)
+		checkConn(c.Conns[0], false)
+	}
+
+	setNonUTC()
+	nc.Close()
+	checkClosedConns(t, s, 1, time.Second)
+	for mode := 0; mode < 2; mode++ {
+		c := pollConnz(t, s, mode, url+"connz?state=closed", &ConnzOptions{State: ConnClosed})
+		require_Len(t, len(c.Conns), 1)
+		checkConn(c.Conns[0], true)
+	}
+}
+
 func TestMonitorConnzBadParams(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()

--- a/server/server.go
+++ b/server/server.go
@@ -3563,7 +3563,8 @@ func (s *Server) saveClosedClient(c *client, nc net.Conn, subs map[string]*subsc
 	// Note that cc.fill is using len(c.subs), which may have been set to nil by now,
 	// so replace cc.NumSubs with len(subs).
 	cc.NumSubs = uint32(len(subs))
-	cc.Stop = &now
+	stop := now.UTC()
+	cc.Stop = &stop
 	cc.Reason = reason.String()
 
 	// Do subs, do not place by default in main ConnInfo


### PR DESCRIPTION
## Summary

`/connz` currently exposes connection timestamps using whichever location is stored internally, so `start` and `last_activity` can use inconsistent time zones.

This change converts `start`, `last_activity`, and closed-connection `stop` timestamps to UTC at the monitoring boundary while preserving internal timestamps for monotonic elapsed-time calculations. The regression test covers both HTTP `/connz` responses and direct `Connz()` calls for open and closed connections.

Resolves #6694.

## Testing

- `go test ./server -run '^TestMonitorConnzTimestampsUTC$' -count=100`
- `go test -race ./server -run '^TestMonitorConnzTimestampsUTC$' -count=10`
- `RACE=-race ./scripts/runTestsOnTravis.sh srv_pkg_non_js_tests`
- `go build ./...`
- `go vet ./...`
- `GOOS=linux GOARCH=amd64 go build ./...`
- `GOOS=linux GOARCH=386 go build ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run --timeout=5m --config=.golangci.yml`

I certify that this contribution is my original work and that I license it to the project under the Apache-2.0 license.