### PR TITLE
[IMPROVED] Optimize EncodedStreamState encoding size and allocations

### DIFF
--- a/server/avl/seqset.go
+++ b/server/avl/seqset.go
@@ -125,6 +125,52 @@ func (ss *SequenceSet) Range(f func(uint64) bool) {
 	ss.root.iter(f)
 }
 
+// RangeRuns will invoke the given function for each maximal run of
+// consecutive sequences [first, last] present in the set, in ascending order.
+// If the callback returns false we terminate the iteration.
+func (ss *SequenceSet) RangeRuns(f func(first, last uint64) bool) {
+	if ss == nil || ss.root == nil {
+		return
+	}
+	var first, last uint64
+	var open bool
+	if !ss.root.iterRuns(&first, &last, &open, f) {
+		return
+	}
+	if open {
+		f(first, last)
+	}
+}
+
+func (n *node) iterRuns(first, last *uint64, open *bool, f func(first, last uint64) bool) bool {
+	if n == nil {
+		return true
+	}
+	if !n.l.iterRuns(first, last, open, f) {
+		return false
+	}
+	for bi, w := range n.bits {
+		for w != 0 {
+			tz := bits.TrailingZeros64(w)
+			ones := bits.TrailingZeros64(^(w >> tz))
+			s := n.base + uint64(bi*bitsPerBucket) + uint64(tz)
+			e := s + uint64(ones) - 1
+			if *open && s == *last+1 {
+				*last = e
+			} else {
+				if *open && !f(*first, *last) {
+					return false
+				}
+				*first, *last, *open = s, e, true
+			}
+			// Clear the run's bits. A non-constant shift by >= 64 yields 0,
+			// so this also handles a run spanning the whole word (ones == 64).
+			w &^= ((1 << ones) - 1) << tz
+		}
+	}
+	return n.r.iterRuns(first, last, open, f)
+}
+
 // Heights returns the left and right heights of the tree.
 func (ss *SequenceSet) Heights() (l, r int) {
 	if ss.root == nil {

--- a/server/avl/seqset_test.go
+++ b/server/avl/seqset_test.go
@@ -351,3 +351,119 @@ func require_True(t *testing.T, b bool) {
 		t.Fatalf("require true")
 	}
 }
+
+func TestSeqSetRangeRuns(t *testing.T) {
+	// Reference implementation: derive runs from Range.
+	type run struct{ first, last uint64 }
+	refRuns := func(ss *SequenceSet) []run {
+		var runs []run
+		ss.Range(func(n uint64) bool {
+			if l := len(runs); l > 0 && runs[l-1].last+1 == n {
+				runs[l-1].last = n
+			} else {
+				runs = append(runs, run{n, n})
+			}
+			return true
+		})
+		return runs
+	}
+	check := func(t *testing.T, ss *SequenceSet) {
+		t.Helper()
+		var runs []run
+		ss.RangeRuns(func(first, last uint64) bool {
+			runs = append(runs, run{first, last})
+			return true
+		})
+		expected := refRuns(ss)
+		require_True(t, len(runs) == len(expected))
+		for i := range runs {
+			require_True(t, runs[i] == expected[i])
+		}
+	}
+
+	// Empty set.
+	check(t, &SequenceSet{})
+	var nilSet *SequenceSet
+	nilSet.RangeRuns(func(_, _ uint64) bool {
+		t.Fatalf("callback on nil set")
+		return false
+	})
+
+	// Single element, and word/bucket/node boundary shapes.
+	for _, seqs := range [][]uint64{
+		{22},
+		{0},
+		{63, 64},                           // crosses a word
+		{numEntries - 1, numEntries},       // crosses a node
+		{0, 1, 2, 63, 64, 65, 127, 129},    // mixed
+		{5, 7, 9},                          // all singletons
+		{numEntries*3 - 1, numEntries * 5}, // node gap breaks a run
+		{0, numEntries*10 + 22, numEntries*20 + 1000}, // sparse over many nodes
+	} {
+		var ss SequenceSet
+		for _, seq := range seqs {
+			ss.Insert(seq)
+		}
+		check(t, &ss)
+	}
+
+	// Dense contiguous runs, like interior deletes on a stream with
+	// per-subject limits: mostly full coverage with a few live "holes".
+	var ss SequenceSet
+	for seq := uint64(1000); seq < 100_000; seq++ {
+		if seq%1024 != 0 {
+			ss.Insert(seq)
+		}
+	}
+	check(t, &ss)
+
+	// Randomized.
+	for iter := 0; iter < 25; iter++ {
+		var ss SequenceSet
+		max := uint64(rand.Intn(5*numEntries) + 1)
+		for i := 0; i < rand.Intn(4096); i++ {
+			ss.Insert(uint64(rand.Int63n(int64(max))))
+		}
+		check(t, &ss)
+	}
+
+	// Early termination, three runs but we stop after the second.
+	var ess SequenceSet
+	for _, seq := range []uint64{1, 2, 5, 6, 9} {
+		ess.Insert(seq)
+	}
+	var count int
+	ess.RangeRuns(func(_, _ uint64) bool {
+		count++
+		return count < 2
+	})
+	require_True(t, count == 2)
+}
+
+func TestSeqSetEncodeLenExact(t *testing.T) {
+	// EncodeLen must exactly match the bytes Encode writes, and Encode must
+	// write in place when given sufficient capacity: callers pre-size
+	// buffers with EncodeLen and reslice instead of copying the result.
+	check := func(t *testing.T, ss *SequenceSet) {
+		t.Helper()
+		require_True(t, len(ss.Encode(nil)) == ss.EncodeLen())
+		buf := make([]byte, 0, ss.EncodeLen())
+		enc := ss.Encode(buf)
+		require_True(t, len(enc) == ss.EncodeLen())
+		require_True(t, &enc[0] == &buf[:1][0])
+	}
+
+	var ss SequenceSet
+	check(t, &ss)
+	for _, seq := range []uint64{0, 22, 63, 64, numEntries - 1, numEntries, numEntries * 10} {
+		ss.Insert(seq)
+		check(t, &ss)
+	}
+	for iter := 0; iter < 10; iter++ {
+		var ss SequenceSet
+		for i := 0; i < rand.Intn(4096); i++ {
+			ss.Insert(uint64(rand.Int63n(5 * numEntries)))
+		}
+		check(t, &ss)
+	}
+}

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -12413,40 +12413,49 @@ func (fs *fileStore) EncodedStreamState(failed uint64) ([]byte, error) {
 		}
 	}
 
-	// Encoded is Msgs, Bytes, FirstSeq, LastSeq, Failed, NumDeleted and optional DeletedBlocks
-	var buf [1024]byte
-	buf[0], buf[1] = streamStateMagic, streamStateVersion
-	n := hdrLen
-	n += binary.PutUvarint(buf[n:], fs.state.Msgs)
-	n += binary.PutUvarint(buf[n:], fs.state.Bytes)
-	n += binary.PutUvarint(buf[n:], fs.state.FirstSeq)
-	n += binary.PutUvarint(buf[n:], fs.state.LastSeq)
-	n += binary.PutUvarint(buf[n:], failed)
-	n += binary.PutUvarint(buf[n:], uint64(numDeleted))
+	// Encoded is Msgs, Bytes, FirstSeq, LastSeq, Failed, NumDeleted and optional DeletedBlocks.
+	// Calculate the exact encoded size up front so the buffer is allocated once.
+	total := hdrLen + uvarintLen(fs.state.Msgs) + uvarintLen(fs.state.Bytes) +
+		uvarintLen(fs.state.FirstSeq) + uvarintLen(fs.state.LastSeq) +
+		uvarintLen(failed) + uvarintLen(uint64(numDeleted))
 
-	b := buf[0:n]
-
+	var dbs DeleteBlocks
 	if numDeleted > 0 {
-		var scratch [4 * 1024]byte
-
 		fs.readLockAllMsgBlocks()
 		defer fs.readUnlockAllMsgBlocks()
+		var sz int
+		dbs, sz = fs.deleteBlocks()
+		total += sz
+	}
 
-		for _, db := range fs.deleteBlocks() {
-			switch db := db.(type) {
-			case *DeleteRange:
-				first, _, num := db.State()
-				scratch[0] = runLengthMagic
-				i := 1
-				i += binary.PutUvarint(scratch[i:], first)
-				i += binary.PutUvarint(scratch[i:], num)
-				b = append(b, scratch[0:i]...)
-			case *avl.SequenceSet:
-				buf := db.Encode(scratch[:0])
-				b = append(b, buf...)
-			default:
-				return nil, errors.New("no impl")
+	b := make([]byte, 0, total)
+	b = append(b, streamStateMagic, streamStateVersion)
+	b = binary.AppendUvarint(b, fs.state.Msgs)
+	b = binary.AppendUvarint(b, fs.state.Bytes)
+	b = binary.AppendUvarint(b, fs.state.FirstSeq)
+	b = binary.AppendUvarint(b, fs.state.LastSeq)
+	b = binary.AppendUvarint(b, failed)
+	b = binary.AppendUvarint(b, uint64(numDeleted))
+
+	for _, db := range dbs {
+		switch db := db.(type) {
+		case *DeleteRange:
+			b = appendRunLength(b, db.First, db.Num)
+		case *avl.SequenceSet:
+			enc := db.Encode(b[len(b):])
+			if n := len(b) + len(enc); n <= cap(b) {
+				b = b[:n]
+			} else {
+				// Fallback if the buffer didn't have spare capacity.
+				b = append(b, enc...)
+				assert.Unreachable("Filestore EncodedStreamState size accounting mismatch", map[string]any{
+					"name":   fs.cfg.Name,
+					"total":  total,
+					"length": len(b),
+				})
 			}
+		default:
+			return nil, errors.New("no impl")
 		}
 	}
 
@@ -12454,15 +12463,51 @@ func (fs *fileStore) EncodedStreamState(failed uint64) ([]byte, error) {
 }
 
 // deleteBlocks returns DeleteBlocks representing interior deletes
-// and gaps between blocks.
+// and gaps between blocks, as well as their total binary encoded size.
 // All blocks should be at least read locked.
-func (fs *fileStore) deleteBlocks() DeleteBlocks {
-	var dbs DeleteBlocks
+func (fs *fileStore) deleteBlocks() (dbs DeleteBlocks, sz int) {
+	// First pass: per block with interior deletes, pick the smaller
+	// representation between run-length ranges and the AVL bitmap dmap.
+	// The encoded size for each block is added here.
+	var numRanges, numGaps, numBitmaps int
+	var useRuns []bool
 	var prevLast uint64
+	for i, mb := range fs.blks {
+		if prevLast > 0 && prevLast+1 != atomic.LoadUint64(&mb.first.seq) {
+			numGaps++
+		}
+		prevLast = atomic.LoadUint64(&mb.last.seq)
+		if mb.dmap.Size() == 0 {
+			continue
+		}
+		elen, runs := seqSetEncodeLen(&mb.dmap)
+		sz += elen
+		if runs > 0 {
+			if useRuns == nil {
+				useRuns = make([]bool, len(fs.blks))
+			}
+			useRuns[i] = true
+			numRanges += runs
+		} else {
+			numBitmaps++
+		}
+	}
+
+	// Second pass: allocate once, and populate the delete blocks. All ranges
+	// are carved out of a single backing slice; its capacity is an upper
+	// bound (gaps can merge below), so it cannot grow and the pointers stay
+	// stable, which also allows gap ranges to be extended in place.
+	// The encoded size for the gaps between blocks is added here.
+	dbs = make(DeleteBlocks, 0, numRanges+numGaps+numBitmaps)
+	ranges := make([]DeleteRange, 0, numRanges+numGaps)
+	addRange := func(first, num uint64) *DeleteRange {
+		ranges = append(ranges, DeleteRange{First: first, Num: num})
+		return &ranges[len(ranges)-1]
+	}
 	var prevRange *DeleteRange
 	var msgsSinceGap bool
-
-	for _, mb := range fs.blks {
+	prevLast = 0
+	for i, mb := range fs.blks {
 		// Detect if we have a gap between these blocks.
 		fseq := atomic.LoadUint64(&mb.first.seq)
 		if prevLast > 0 && prevLast+1 != fseq {
@@ -12472,24 +12517,31 @@ func (fs *fileStore) deleteBlocks() DeleteBlocks {
 			// blocks containing messages between the
 			// two gaps.
 			if prevRange != nil && !msgsSinceGap {
+				sz -= runLengthEncodeLen(prevRange.First, prevRange.Num)
 				prevRange.Num += gapSize
+				sz += runLengthEncodeLen(prevRange.First, prevRange.Num)
 			} else {
-				prevRange = &DeleteRange{
-					First: prevLast + 1,
-					Num:   gapSize,
-				}
+				prevRange = addRange(prevLast+1, gapSize)
+				sz += runLengthEncodeLen(prevRange.First, prevRange.Num)
 				msgsSinceGap = false
 				dbs = append(dbs, prevRange)
 			}
 		}
 		if mb.dmap.Size() > 0 {
-			dbs = append(dbs, &mb.dmap)
+			if useRuns != nil && useRuns[i] {
+				mb.dmap.RangeRuns(func(first, last uint64) bool {
+					dbs = append(dbs, addRange(first, last-first+1))
+					return true
+				})
+			} else {
+				dbs = append(dbs, &mb.dmap)
+			}
 			prevRange = nil
 		}
 		prevLast = atomic.LoadUint64(&mb.last.seq)
 		msgsSinceGap = msgsSinceGap || mb.msgs > 0
 	}
-	return dbs
+	return dbs, sz
 }
 
 // deleteMap returns all interior deletes for each block based on the mb.dmap.
@@ -12535,7 +12587,7 @@ func (fs *fileStore) SyncDeleted(dbs DeleteBlocks) error {
 
 	lseq := fs.state.LastSeq
 	fs.readLockAllMsgBlocks()
-	mdbs := fs.deleteBlocks()
+	mdbs, _ := fs.deleteBlocks()
 	// We'll release the locks below, so need to copy the ones that are references
 	// which are only safe while the locks are still held.
 	for i, db := range mdbs {

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -12989,7 +12989,7 @@ func TestFileStoreDeleteRangeTwoGaps(t *testing.T) {
 
 	checkDeleteBlocks := func(exp DeleteBlocks) {
 		t.Helper()
-		dBlocks := fs.deleteBlocks()
+		dBlocks, _ := fs.deleteBlocks()
 		require_Equal(t, len(exp), len(dBlocks))
 
 		for i, found := range dBlocks {
@@ -13039,7 +13039,7 @@ func TestFileStoreDeleteBlocksWithSingleMessageBlocks(t *testing.T) {
 	defer fs.Stop()
 
 	checkDeleteBlocks := func(exp DeleteBlocks) {
-		dBlocks := fs.deleteBlocks()
+		dBlocks, _ := fs.deleteBlocks()
 		require_Equal(t, len(exp), len(dBlocks))
 
 		for i, found := range dBlocks {
@@ -13214,7 +13214,8 @@ func TestFileStoreDeleteBlocks(t *testing.T) {
 	defer fs.Stop()
 
 	checkDeleteBlocks := func(exp DeleteBlocks) {
-		dBlocks := fs.deleteBlocks()
+		t.Helper()
+		dBlocks, _ := fs.deleteBlocks()
 		require_Equal(t, len(exp), len(dBlocks))
 
 		for i, found := range dBlocks {
@@ -13272,7 +13273,7 @@ func TestFileStoreDeleteBlocks(t *testing.T) {
 	// block 5: [17,20]
 	fs.RemoveMsg(8)
 	checkDeleteBlocks(DeleteBlocks{
-		makeSequenceSet([]uint64{8}),
+		&DeleteRange{First: 8, Num: 1},
 		&DeleteRange{First: 9, Num: 2},
 	})
 
@@ -13285,7 +13286,7 @@ func TestFileStoreDeleteBlocks(t *testing.T) {
 	fs.RemoveMsg(18)
 	fs.RemoveMsg(17)
 	checkDeleteBlocks(DeleteBlocks{
-		makeSequenceSet([]uint64{8}),
+		&DeleteRange{First: 8, Num: 1},
 		&DeleteRange{First: 9, Num: 2},
 		&DeleteRange{First: 17, Num: 2},
 	})
@@ -13312,7 +13313,7 @@ func TestFileStoreDeleteBlocks(t *testing.T) {
 	checkDeleteBlocks(DeleteBlocks{
 		&DeleteRange{First: 5, Num: 6},
 		&DeleteRange{First: 17, Num: 2},
-		makeSequenceSet([]uint64{20}),
+		&DeleteRange{First: 20, Num: 1},
 	})
 
 	// Remove the last message
@@ -13359,7 +13360,7 @@ func TestFileStoreDeleteBlocksWithManyEmptyBlocks(t *testing.T) {
 
 	checkDeleteBlocks := func(exp DeleteBlocks) {
 		t.Helper()
-		dBlocks := fs.deleteBlocks()
+		dBlocks, _ := fs.deleteBlocks()
 		require_Equal(t, len(exp), len(dBlocks))
 
 		for i, found := range dBlocks {
@@ -13405,7 +13406,7 @@ func TestFileStoreDeleteBlocksWithManyEmptyBlocks(t *testing.T) {
 	}
 
 	checkDeleteBlocks(DeleteBlocks{
-		makeSequenceSet([]uint64{2, 3, 4, 5, 6}),
+		&DeleteRange{First: 2, Num: 5},
 		&DeleteRange{First: 7, Num: 8},
 	})
 
@@ -13565,7 +13566,7 @@ func TestFileStoreRemoveMsgsInRange(t *testing.T) {
 	defer fs.mu.Unlock()
 
 	checkDeleteBlocks := func(exp DeleteBlocks) {
-		dBlocks := fs.deleteBlocks()
+		dBlocks, _ := fs.deleteBlocks()
 		require_Equal(t, len(exp), len(dBlocks))
 
 		for i, found := range dBlocks {
@@ -14809,7 +14810,7 @@ func TestFileStoreSyncDeletedDmapAliasRace(t *testing.T) {
 	// Snapshot the delete blocks to feed back into SyncDeleted.
 	fs.mu.Lock()
 	fs.readLockAllMsgBlocks()
-	live := fs.deleteBlocks()
+	live, _ := fs.deleteBlocks()
 	dbs := make(DeleteBlocks, len(live))
 	for i, db := range live {
 		switch d := db.(type) {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -2395,22 +2395,33 @@ func (ms *memStore) EncodedStreamState(failed uint64) ([]byte, error) {
 		numDeleted = 0
 	}
 
-	// Encoded is Msgs, Bytes, FirstSeq, LastSeq, Failed, NumDeleted and optional DeletedBlocks
-	var buf [1024]byte
-	buf[0], buf[1] = streamStateMagic, streamStateVersion
-	n := hdrLen
-	n += binary.PutUvarint(buf[n:], ms.state.Msgs)
-	n += binary.PutUvarint(buf[n:], ms.state.Bytes)
-	n += binary.PutUvarint(buf[n:], ms.state.FirstSeq)
-	n += binary.PutUvarint(buf[n:], ms.state.LastSeq)
-	n += binary.PutUvarint(buf[n:], failed)
-	n += binary.PutUvarint(buf[n:], uint64(numDeleted))
-
-	b := buf[0:n]
+	// Encoded is Msgs, Bytes, FirstSeq, LastSeq, Failed, NumDeleted and optional DeletedBlocks.
+	// Calculate the exact encoded size up front so the buffer is allocated once.
+	total := hdrLen + uvarintLen(ms.state.Msgs) + uvarintLen(ms.state.Bytes) +
+		uvarintLen(ms.state.FirstSeq) + uvarintLen(ms.state.LastSeq) +
+		uvarintLen(failed) + uvarintLen(uint64(numDeleted))
 
 	if numDeleted > 0 {
-		buf := ms.dmap.Encode(nil)
-		b = append(b, buf...)
+		total += ms.dmap.EncodeLen()
+	}
+
+	b := make([]byte, 0, total)
+	b = append(b, streamStateMagic, streamStateVersion)
+	b = binary.AppendUvarint(b, ms.state.Msgs)
+	b = binary.AppendUvarint(b, ms.state.Bytes)
+	b = binary.AppendUvarint(b, ms.state.FirstSeq)
+	b = binary.AppendUvarint(b, ms.state.LastSeq)
+	b = binary.AppendUvarint(b, failed)
+	b = binary.AppendUvarint(b, uint64(numDeleted))
+
+	if numDeleted > 0 {
+		enc := ms.dmap.Encode(b[len(b):])
+		if n := len(b) + len(enc); n <= cap(b) {
+			b = b[:n]
+		} else {
+			// Fallback if the buffer didn't have spare capacity.
+			b = append(b, enc...)
+		}
 	}
 
 	return b, nil

--- a/server/store.go
+++ b/server/store.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/bits"
 	"os"
 	"strings"
 	"time"
@@ -305,6 +306,50 @@ func DecodeStreamState(buf []byte) (*StreamReplicatedState, error) {
 	}
 
 	return ss, nil
+}
+
+// uvarintLen returns the number of bytes binary.PutUvarint/AppendUvarint
+// write for v: ceil(bits/7), with v=0 taking one byte.
+func uvarintLen(v uint64) int {
+	return (bits.Len64(v|1) + 6) / 7
+}
+
+// runLengthEncodeLen returns the encoded size of a run-length delete record,
+// exactly matching what appendRunLength writes.
+func runLengthEncodeLen(first, num uint64) int {
+	return 1 + uvarintLen(first) + uvarintLen(num)
+}
+
+// appendRunLength appends a run-length encoded delete record for num
+// deleted sequences starting at first.
+func appendRunLength(b []byte, first, num uint64) []byte {
+	b = append(b, runLengthMagic)
+	b = binary.AppendUvarint(b, first)
+	b = binary.AppendUvarint(b, num)
+	return b
+}
+
+// seqSetEncodeLen returns the exact encoded size of the smaller of the
+// run-length and AVL bitmap encodings of ss (DecodeStreamState accepts them
+// interleaved). If runs > 0 the run-length encoding is the one to use, with
+// sz covering that many runs; runs == 0 means the bitmap encoding is smaller
+// (or equal, in which case the bitmap is preferred).
+// For streams with dense interior deletes around a few live messages,
+// run-length encoding is an order of magnitude smaller than the bitmap.
+func seqSetEncodeLen(ss *avl.SequenceSet) (sz, runs int) {
+	var runsLen int
+	avlLen := ss.EncodeLen()
+	ss.RangeRuns(func(first, last uint64) bool {
+		runs++
+		runsLen += runLengthEncodeLen(first, last-first+1)
+		// Stop early once the bitmap encoding provably wins, the exact
+		// run-length size is only needed when the runs are smaller.
+		return runsLen < avlLen
+	})
+	if runsLen < avlLen {
+		return runsLen, runs
+	}
+	return avlLen, 0
 }
 
 // DeleteRange is a run length encoded delete range.

--- a/server/store_test.go
+++ b/server/store_test.go
@@ -16,7 +16,9 @@
 package server
 
 import (
+	"encoding/binary"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1390,6 +1392,61 @@ func TestStoreNumPendingLastPerSubjectExcludeOvercount(t *testing.T) {
 			total, _, err = fs.NumPendingMulti(13, filters, true)
 			require_NoError(t, err)
 			require_Equal(t, total, 2)
+		},
+	)
+}
+
+func TestStoreRunLengthEncodeLen(t *testing.T) {
+	// Values around every uvarint width boundary.
+	values := []uint64{0, 1, 127, 128, 16383, 16384, 1<<21 - 1, 1 << 21,
+		1<<28 - 1, 1 << 28, 1<<35 - 1, 1 << 35, 1<<42 - 1, 1 << 42,
+		1<<49 - 1, 1 << 49, 1<<56 - 1, 1 << 56, 1<<63 - 1, 1 << 63,
+		math.MaxUint64}
+
+	var scratch [binary.MaxVarintLen64]byte
+	for _, v := range values {
+		require_Equal(t, uvarintLen(v), binary.PutUvarint(scratch[:], v))
+	}
+	// The predicted record size must exactly match what appendRunLength writes.
+	for _, first := range values {
+		for _, num := range values {
+			b := appendRunLength(nil, first, num)
+			require_Equal(t, len(b), runLengthEncodeLen(first, num))
+		}
+	}
+}
+
+func TestStoreSyncDeletedRunPartitionedBlocks(t *testing.T) {
+	testAllStoreAllPermutations(
+		t, false,
+		StreamConfig{Name: "zzz", Subjects: []string{"foo"}},
+		func(t *testing.T, fs StreamStore) {
+			for range 20 {
+				_, _, err := fs.StoreMsg("foo", nil, nil, 0)
+				require_NoError(t, err)
+			}
+			// Interior deletes forming the runs [3,5] and [10,12].
+			for _, seq := range []uint64{3, 4, 5, 10, 11, 12} {
+				_, err := fs.RemoveMsg(seq)
+				require_NoError(t, err)
+			}
+			before := fs.State()
+
+			// Same deleted state partitioned as run-length blocks, like a
+			// run-length encoded snapshot from a leader. Must be a no-op.
+			dbs := DeleteBlocks{
+				&DeleteRange{First: 3, Num: 3},
+				&DeleteRange{First: 10, Num: 3},
+			}
+			require_NoError(t, fs.SyncDeleted(dbs))
+			require_True(t, reflect.DeepEqual(before, fs.State()))
+
+			// An extra deleted sequence must still be applied.
+			dbs = append(dbs, &DeleteRange{First: 15, Num: 1})
+			require_NoError(t, fs.SyncDeleted(dbs))
+			state := fs.State()
+			require_Equal(t, state.Msgs, before.Msgs-1)
+			require_Equal(t, state.NumDeleted, before.NumDeleted+1)
 		},
 	)
 }


### PR DESCRIPTION
Replicated streams encode the stream state in a snapshot, which contains the interior deletes from the various blocks in the filestore. However, this was always each block's encoded AVL bitmap, even if representing this with run-length encoding would be significantly smaller.

`fs.deleteBlocks()` now picks the smaller representation per block, run-length ranges or the AVL bitmap, using the new `SequenceSet.RangeRuns` iterator. This means a single block's interior deletes may now be encoded as multiple ranges instead of one bitmap. Allocations are also significantly reduced by pre-allocating the output buffer at the right size, as well as the ranges that represent the deletes. A benchmark with ~50k blocks and 332M interior deletes at ~10 non-deleted messages per block resulted in:
- Encoded snapshot size: 55.6 MB -> 4.3 MB (-92%)
- Allocation per encode: 304 MB / 549K allocs -> 21 MB / 4 allocs

The format is otherwise unchanged and is fully compatible with older versions. This PR does not introduce new deleted message representations.
