### PR TITLE
[IMPROVED] Filestore syncBlocks delete map build cost and locking

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -6148,7 +6148,7 @@ func (mb *msgBlock) compact() error {
 // writing new messages. We will silently bail on any issues with the underlying block and let someone else detect.
 // if fseq > 0 we will attempt to cleanup stale tombstones.
 // Write lock needs to be held.
-func (mb *msgBlock) compactWithFloor(floor uint64, fsDmap *avl.SequenceSet) error {
+func (mb *msgBlock) compactWithFloor(floor uint64, fsDmap *interiorDeletes) error {
 	wasLoaded := mb.cache != nil && mb.cacheAlreadyLoaded()
 	if !wasLoaded {
 		if err := mb.loadMsgsWithLock(); err != nil {
@@ -7855,8 +7855,7 @@ func (fs *fileStore) syncBlocks() {
 		fs.setWriteErr(err)
 	}
 
-	var fsDmapLoaded bool
-	var fsDmap avl.SequenceSet
+	var fsDmap *interiorDeletes
 
 	var markDirty bool
 	for _, mb := range blks {
@@ -7915,9 +7914,8 @@ func (fs *fileStore) syncBlocks() {
 			// Load a delete map containing only interior deletes.
 			// This is used when compacting to know if tombstones are still relevant,
 			// and if not they can be compacted.
-			if !fsDmapLoaded {
-				fsDmapLoaded = true
-				fsDmap = fs.deleteMap()
+			if fsDmap == nil {
+				fsDmap = deleteMap(blks)
 			}
 			fs.mu.RLock()
 			mb.mu.Lock()
@@ -7927,7 +7925,7 @@ func (fs *fileStore) syncBlocks() {
 				fs.mu.RUnlock()
 				continue
 			}
-			err := mb.compactWithFloor(firstSeq, &fsDmap)
+			err := mb.compactWithFloor(firstSeq, fsDmap)
 			// If this compact removed all raw bytes due to tombstone cleanup, schedule to remove.
 			shouldRemove := mb.rbytes == 0
 			mb.mu.Unlock()
@@ -12513,26 +12511,58 @@ func (fs *fileStore) deleteBlocks() DeleteBlocks {
 	return dbs
 }
 
-// deleteMap returns all interior deletes for each block based on the mb.dmap.
-// Specifically, this will not contain any deletes for blocks that have been removed.
-// This is useful to know whether a tombstone is still relevant and marked as deleted by an active block.
-// No locks should be held.
-func (fs *fileStore) deleteMap() (dmap avl.SequenceSet) {
-	fs.mu.RLock()
-	defer fs.mu.RUnlock()
+// interiorDeletes is a point-in-time view of the interior deletes tracked by
+// the live message blocks, held as per-block clones of each mb.dmap. Blocks
+// own disjoint ascending sequence ranges, so a lookup binary searches for the
+// owning clone. Reads require no locks.
+type interiorDeletes struct {
+	sets []*avl.SequenceSet // Per-block dmap clones, ascending disjoint ranges.
+	maxs []uint64           // Last sequence of the block owning each clone.
+	last int                // Clone index of the previous lookup.
+}
 
-	fs.readLockAllMsgBlocks()
-	defer fs.readUnlockAllMsgBlocks()
-
-	for _, mb := range fs.blks {
-		if mb.dmap.Size() > 0 {
-			mb.dmap.Range(func(seq uint64) bool {
-				dmap.Insert(seq)
-				return true
-			})
-		}
+// Exists returns whether the sequence was marked as an interior delete by a
+// live block at the time the view was built.
+// Not safe for concurrent use.
+func (v *interiorDeletes) Exists(seq uint64) bool {
+	if v == nil {
+		return false
 	}
-	return dmap
+	// Check the clone that answered the previous lookup first, sequences are
+	// mostly checked in ascending order and cluster per block.
+	if i := v.last; i < len(v.maxs) && seq <= v.maxs[i] && (i == 0 || v.maxs[i-1] < seq) {
+		return v.sets[i].Exists(seq)
+	}
+	// First clone whose max is >= seq is the only one that can contain it.
+	i, _ := slices.BinarySearch(v.maxs, seq)
+	if i == len(v.sets) {
+		return false
+	}
+	v.last = i
+	return v.sets[i].Exists(seq)
+}
+
+// deleteMap returns a view of all interior deletes for each of the given blocks,
+// based on the mb.dmap. Specifically, this will not contain any deletes for blocks
+// that had already been removed. This is useful to know whether a tombstone is
+// still relevant and marked as deleted by an active block.
+// No locks should be held on entry.
+func deleteMap(blks []*msgBlock) *interiorDeletes {
+	v := interiorDeletes{
+		sets: make([]*avl.SequenceSet, 0, len(blks)),
+		maxs: make([]uint64, 0, len(blks)),
+	}
+	for _, mb := range blks {
+		mb.mu.RLock()
+		if !mb.closed && mb.dmap.Size() > 0 {
+			// The block's last sequence bounds all of its dmap entries and
+			// preserves the ascending disjoint ordering across clones.
+			v.sets = append(v.sets, mb.dmap.Clone())
+			v.maxs = append(v.maxs, atomic.LoadUint64(&mb.last.seq))
+		}
+		mb.mu.RUnlock()
+	}
+	return &v
 }
 
 // SyncDeleted will make sure this stream has same deleted state as dbs.

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -15184,3 +15184,179 @@ func TestFileStoreCompactStoreMsgRace(t *testing.T) {
 	require_Equal(t, state.FirstSeq, 2)
 	require_Equal(t, state.LastSeq, 2)
 }
+
+func TestFileStoreDeleteMapView(t *testing.T) {
+	msg := []byte("hello")
+	// Size blocks to hold 10 messages each.
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 10 * fileStoreMsgSize("foo", nil, msg)},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage})
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	const numMsgs = 100
+	for range numMsgs {
+		_, _, err = fs.StoreMsg("foo", nil, msg, 0)
+		require_NoError(t, err)
+	}
+
+	// Create interior deletes in every block. Keep each block's first and
+	// last message alive so all removals stay interior to their block; a
+	// removal at a block's edge would advance the block's first sequence and
+	// turn it into a gap delete, which the view excludes by design.
+	expected := make(map[uint64]bool)
+	for seq := uint64(1); seq <= numMsgs; seq++ {
+		if seq%10 == 1 || seq%10 == 0 {
+			continue
+		}
+		_, err = fs.RemoveMsg(seq)
+		require_NoError(t, err)
+		expected[seq] = true
+	}
+
+	snapshotBlks := func() []*msgBlock {
+		fs.mu.RLock()
+		defer fs.mu.RUnlock()
+		return append([]*msgBlock(nil), fs.blks...)
+	}
+
+	checkView := func(v *interiorDeletes) {
+		t.Helper()
+		var total int
+		for _, ss := range v.sets {
+			total += ss.Size()
+		}
+		require_Equal(t, total, len(expected))
+		// Ascending probes mostly hit the cursor fast path.
+		for seq := uint64(0); seq <= numMsgs+1; seq++ {
+			require_Equal(t, v.Exists(seq), expected[seq])
+		}
+		// Descending probes mostly take the binary search path.
+		for seq := uint64(numMsgs + 1); ; seq-- {
+			require_Equal(t, v.Exists(seq), expected[seq])
+			if seq == 0 {
+				break
+			}
+		}
+		// Random probes mix both paths.
+		rng := rand.New(rand.NewSource(0))
+		for i := 0; i < numMsgs*4; i++ {
+			seq := uint64(rng.Intn(numMsgs + 2))
+			require_Equal(t, v.Exists(seq), expected[seq])
+		}
+	}
+	checkView(deleteMap(snapshotBlks()))
+
+	// Empty out one interior block completely. The store removes the block,
+	// and its deletes become a gap that the view must exclude.
+	fs.mu.RLock()
+	mb := fs.blks[3]
+	mb.mu.RLock()
+	fseq, lseq := atomic.LoadUint64(&mb.first.seq), atomic.LoadUint64(&mb.last.seq)
+	mb.mu.RUnlock()
+	nblks := len(fs.blks)
+	fs.mu.RUnlock()
+
+	for seq := fseq; seq <= lseq; seq++ {
+		if !expected[seq] {
+			_, err = fs.RemoveMsg(seq)
+			require_NoError(t, err)
+		}
+		delete(expected, seq)
+	}
+	fs.mu.RLock()
+	lblks := len(fs.blks)
+	fs.mu.RUnlock()
+	require_Equal(t, lblks, nblks-1)
+
+	checkView(deleteMap(snapshotBlks()))
+
+	// Remove whole blocks while holding a stale snapshot, mirroring blocks
+	// being removed between syncBlocks capturing its block list and building
+	// the view. Compact removes the blocks wholesale, which marks them closed
+	// but leaves their dmap populated; the view must exclude their deletes.
+	staleBlks := snapshotBlks()
+	_, err = fs.Compact(41)
+	require_NoError(t, err)
+	for seq := range expected {
+		if seq < 41 {
+			delete(expected, seq)
+		}
+	}
+	checkView(deleteMap(staleBlks))
+}
+
+func Benchmark_FileStoreDeleteMap(b *testing.B) {
+	msg := []byte("hello")
+	// Many small blocks with mostly interior deletes, the shape a stream
+	// with MaxMsgsPerSubject=1 and steady per-subject overwrites converges
+	// to. Keep two messages alive per block so every block survives with a
+	// dense interior delete map.
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: b.TempDir(), BlockSize: 100 * fileStoreMsgSize("foo", nil, msg)},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage})
+	require_NoError(b, err)
+	defer fs.Stop()
+
+	const numMsgs = 50_000
+	for range numMsgs {
+		_, _, err = fs.StoreMsg("foo", nil, msg, 0)
+		require_NoError(b, err)
+	}
+	for seq := uint64(2); seq < numMsgs; seq++ {
+		if seq%50 == 0 {
+			continue
+		}
+		_, err = fs.RemoveMsg(seq)
+		require_NoError(b, err)
+	}
+
+	fs.mu.RLock()
+	blks := append([]*msgBlock(nil), fs.blks...)
+	fs.mu.RUnlock()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if v := deleteMap(blks); len(v.sets) == 0 {
+			b.Fatalf("Expected a non-empty delete map view")
+		}
+	}
+	b.StopTimer()
+}
+
+func Benchmark_FileStoreDeleteMapExists(b *testing.B) {
+	msg := []byte("hello")
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: b.TempDir(), BlockSize: 100 * fileStoreMsgSize("foo", nil, msg)},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage})
+	require_NoError(b, err)
+	defer fs.Stop()
+
+	const numMsgs = 50_000
+	for range numMsgs {
+		_, _, err = fs.StoreMsg("foo", nil, msg, 0)
+		require_NoError(b, err)
+	}
+	for seq := uint64(2); seq < numMsgs; seq++ {
+		if seq%50 == 0 {
+			continue
+		}
+		_, err = fs.RemoveMsg(seq)
+		require_NoError(b, err)
+	}
+
+	fs.mu.RLock()
+	blks := append([]*msgBlock(nil), fs.blks...)
+	fs.mu.RUnlock()
+	v := deleteMap(blks)
+
+	// Probe ascending across the whole span, the same order compactWithFloor
+	// checks tombstones in.
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		v.Exists(uint64(i%numMsgs) + 1)
+	}
+	b.StopTimer()
+}


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/7387

The creation of `fs.deleteMap()` became more expensive to build the more total interior deletes the stream holds, blocking any reads or writes while it's running. This PR improves that by cloning the delete maps while only holding the locks temporarily and searching through them more efficiently, instead of ranging over all deletes and inserting them into a fresh map with all locks held throughout.

A synthetic benchmark at ~300M interior deletes: 23.1s -> 17.7ms per `deleteMap`,
