### PR TITLE
[FIXED] Filestore SyncDeleted could skip sparse delete blocks

### DIFF
--- a/server/avl/seqset.go
+++ b/server/avl/seqset.go
@@ -187,6 +187,23 @@ func (ss *SequenceSet) Clone() *SequenceSet {
 	return css
 }
 
+// Equal returns whether the two sets contain exactly the same sequences.
+func (ss *SequenceSet) Equal(other *SequenceSet) bool {
+	if ss.IsEmpty() || other.IsEmpty() {
+		return ss.IsEmpty() && other.IsEmpty()
+	}
+	if ss.size != other.size {
+		return false
+	}
+	// Sizes are equal, so a one-way membership check suffices.
+	equal := true
+	ss.Range(func(seq uint64) bool {
+		equal = other.Exists(seq)
+		return equal
+	})
+	return equal
+}
+
 // Union will union this SequenceSet with ssa.
 func (ss *SequenceSet) Union(ssa ...*SequenceSet) {
 	for _, sa := range ssa {

--- a/server/avl/seqset_test.go
+++ b/server/avl/seqset_test.go
@@ -223,6 +223,39 @@ func TestSeqSetClone(t *testing.T) {
 	require_True(t, ss.Nodes() == ssc.Nodes())
 }
 
+func TestSeqSetEqual(t *testing.T) {
+	var ss1, ss2, ss3 SequenceSet
+
+	// Empty and nil sets are all equal.
+	var nilSet *SequenceSet
+	require_True(t, ss1.Equal(&ss2))
+	require_True(t, ss1.Equal(nilSet))
+	require_True(t, nilSet.Equal(&ss1))
+
+	// Same state (first, last, size) but different contents.
+	for _, seq := range []uint64{1, 3, 5} {
+		ss1.Insert(seq)
+	}
+	for _, seq := range []uint64{1, 4, 5} {
+		ss2.Insert(seq)
+	}
+	require_False(t, ss1.Equal(&ss2))
+	require_False(t, ss2.Equal(&ss1))
+	require_False(t, ss1.Equal(nilSet))
+	require_False(t, nilSet.Equal(&ss1))
+
+	// Identical contents, insertion order should not matter.
+	for _, seq := range []uint64{5, 1, 3} {
+		ss3.Insert(seq)
+	}
+	require_True(t, ss1.Equal(&ss3))
+	require_True(t, ss3.Equal(&ss1))
+
+	// Differing sizes.
+	ss3.Insert(7)
+	require_False(t, ss1.Equal(&ss3))
+}
+
 func TestSeqSetUnion(t *testing.T) {
 	var ss1, ss2 SequenceSet
 
@@ -349,5 +382,12 @@ func require_True(t *testing.T, b bool) {
 	t.Helper()
 	if !b {
 		t.Fatalf("require true")
+	}
+}
+
+func require_False(t *testing.T, b bool) {
+	t.Helper()
+	if b {
+		t.Fatalf("require false")
 	}
 }

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -12619,10 +12619,41 @@ func pruneDeleteBlock(db DeleteBlock, blocks DeleteBlocks) (bool, DeleteBlocks) 
 	}
 
 	if aFirst == bFirst && aLast == bLast && aNum == bNum {
-		return true, blocks[1:]
+		// Matching state is only conclusive for a dense block; two sparse
+		// sequence sets can share the same state but differ in contents.
+		if aNum == aLast-aFirst+1 || deleteBlockContentsEqual(db, blocks[0]) {
+			return true, blocks[1:]
+		}
 	}
 
 	return false, blocks
+}
+
+// deleteBlockContentsEqual reports whether two sparse delete blocks with
+// identical State() contain the same sequences. If neither block is a
+// sequence set we can't compare cheaply and safely report unequal.
+func deleteBlockContentsEqual(a, b DeleteBlock) bool {
+	ssa, aIsSet := a.(*avl.SequenceSet)
+	ssb, bIsSet := b.(*avl.SequenceSet)
+	if aIsSet && bIsSet {
+		return ssa.Equal(ssb)
+	}
+	// Use whichever side is a SequenceSet for fast Exists lookups.
+	var ss *avl.SequenceSet
+	var other DeleteBlock
+	if bIsSet {
+		ss, other = ssb, a
+	} else if aIsSet {
+		ss, other = ssa, b
+	} else {
+		return false
+	}
+	equal := true
+	other.Range(func(seq uint64) bool {
+		equal = ss.Exists(seq)
+		return equal
+	})
+	return equal
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -13255,6 +13255,30 @@ func TestPruneDeleteBlock(t *testing.T) {
 	prune, local = pruneDeleteBlock(&DeleteRange{First: 301, Num: 1}, local)
 	require_False(t, prune)
 	require_Equal(t, len(local), 0)
+
+	// Sparse sequence sets with the same state but different contents
+	// should not be pruned.
+	local = DeleteBlocks{makeSequenceSet([]uint64{1, 4, 5})}
+	prune, local = pruneDeleteBlock(makeSequenceSet([]uint64{1, 3, 5}), local)
+	require_False(t, prune)
+	require_Equal(t, len(local), 1)
+
+	// Sparse sequence sets with identical contents should be pruned.
+	prune, local = pruneDeleteBlock(makeSequenceSet([]uint64{1, 4, 5}), local)
+	require_True(t, prune)
+	require_Equal(t, len(local), 0)
+
+	// A DeleteRange matching a dense sequence set should be pruned.
+	local = DeleteBlocks{makeSequenceSet([]uint64{7, 8, 9})}
+	prune, local = pruneDeleteBlock(&DeleteRange{First: 7, Num: 3}, local)
+	require_True(t, prune)
+	require_Equal(t, len(local), 0)
+
+	// A dense sequence set matching a DeleteRange should be pruned.
+	local = DeleteBlocks{&DeleteRange{First: 7, Num: 3}}
+	prune, local = pruneDeleteBlock(makeSequenceSet([]uint64{7, 8, 9}), local)
+	require_True(t, prune)
+	require_Equal(t, len(local), 0)
 }
 
 func TestFileStoreDeleteBlocks(t *testing.T) {


### PR DESCRIPTION
`pruneDeleteBlock` treated two delete blocks with equal `State()` as having equal contents. However, it's technically possible for two `avl.SequenceSet` to have the same `State()` but not the same contents, which would make `SyncDeleted` skip deleting messages.