### PR TITLE
[IMPROVED] Preallocate EncodedStreamState encoding buffer

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -12434,51 +12434,61 @@ func (fs *fileStore) EncodedStreamState(failed uint64) ([]byte, error) {
 		}
 	}
 
-	// Encoded is Msgs, Bytes, FirstSeq, LastSeq, Failed, NumDeleted and optional DeletedBlocks
-	var buf [1024]byte
-	buf[0], buf[1] = streamStateMagic, streamStateVersion
-	n := hdrLen
-	n += binary.PutUvarint(buf[n:], fs.state.Msgs)
-	n += binary.PutUvarint(buf[n:], fs.state.Bytes)
-	n += binary.PutUvarint(buf[n:], fs.state.FirstSeq)
-	n += binary.PutUvarint(buf[n:], fs.state.LastSeq)
-	n += binary.PutUvarint(buf[n:], failed)
-	n += binary.PutUvarint(buf[n:], uint64(numDeleted))
+	// Encoded is Msgs, Bytes, FirstSeq, LastSeq, Failed, NumDeleted and optional DeletedBlocks.
+	// Calculate the exact encoded size up front so the buffer is allocated once.
+	total := hdrLen + uvarintLen(fs.state.Msgs) + uvarintLen(fs.state.Bytes) +
+		uvarintLen(fs.state.FirstSeq) + uvarintLen(fs.state.LastSeq) +
+		uvarintLen(failed) + uvarintLen(uint64(numDeleted))
 
-	b := buf[0:n]
-
+	var dbs DeleteBlocks
 	if numDeleted > 0 {
-		var scratch [4 * 1024]byte
-
 		fs.readLockAllMsgBlocks()
 		defer fs.readUnlockAllMsgBlocks()
+		var sz int
+		dbs, sz = fs.deleteBlocks()
+		total += sz
+	}
 
-		for _, db := range fs.deleteBlocks() {
-			switch db := db.(type) {
-			case *DeleteRange:
-				first, _, num := db.State()
-				scratch[0] = runLengthMagic
-				i := 1
-				i += binary.PutUvarint(scratch[i:], first)
-				i += binary.PutUvarint(scratch[i:], num)
-				b = append(b, scratch[0:i]...)
-			case *avl.SequenceSet:
-				buf := db.Encode(scratch[:0])
-				b = append(b, buf...)
-			default:
-				return nil, errors.New("no impl")
+	b := make([]byte, 0, total)
+	b = append(b, streamStateMagic, streamStateVersion)
+	b = binary.AppendUvarint(b, fs.state.Msgs)
+	b = binary.AppendUvarint(b, fs.state.Bytes)
+	b = binary.AppendUvarint(b, fs.state.FirstSeq)
+	b = binary.AppendUvarint(b, fs.state.LastSeq)
+	b = binary.AppendUvarint(b, failed)
+	b = binary.AppendUvarint(b, uint64(numDeleted))
+
+	for _, db := range dbs {
+		switch db := db.(type) {
+		case *DeleteRange:
+			b = appendRunLength(b, db.First, db.Num)
+		case *avl.SequenceSet:
+			enc := db.Encode(b[len(b):])
+			if n := len(b) + len(enc); n <= cap(b) {
+				b = b[:n]
+			} else {
+				// Fallback if the buffer didn't have spare capacity.
+				b = append(b, enc...)
 			}
+		default:
+			return nil, errors.New("no impl")
 		}
 	}
 
+	if len(b) != total {
+		assert.Unreachable("Filestore EncodedStreamState size accounting mismatch", map[string]any{
+			"name":   fs.cfg.Name,
+			"total":  total,
+			"length": len(b),
+		})
+	}
 	return b, nil
 }
 
 // deleteBlocks returns DeleteBlocks representing interior deletes
-// and gaps between blocks.
+// and gaps between blocks, as well as their total binary encoded size.
 // All blocks should be at least read locked.
-func (fs *fileStore) deleteBlocks() DeleteBlocks {
-	var dbs DeleteBlocks
+func (fs *fileStore) deleteBlocks() (dbs DeleteBlocks, sz int) {
 	var prevLast uint64
 	var prevRange *DeleteRange
 	var msgsSinceGap bool
@@ -12493,24 +12503,28 @@ func (fs *fileStore) deleteBlocks() DeleteBlocks {
 			// blocks containing messages between the
 			// two gaps.
 			if prevRange != nil && !msgsSinceGap {
+				sz -= runLengthEncodeLen(prevRange.First, prevRange.Num)
 				prevRange.Num += gapSize
+				sz += runLengthEncodeLen(prevRange.First, prevRange.Num)
 			} else {
 				prevRange = &DeleteRange{
 					First: prevLast + 1,
 					Num:   gapSize,
 				}
+				sz += runLengthEncodeLen(prevRange.First, prevRange.Num)
 				msgsSinceGap = false
 				dbs = append(dbs, prevRange)
 			}
 		}
 		if mb.dmap.Size() > 0 {
 			dbs = append(dbs, &mb.dmap)
+			sz += mb.dmap.EncodeLen()
 			prevRange = nil
 		}
 		prevLast = atomic.LoadUint64(&mb.last.seq)
 		msgsSinceGap = msgsSinceGap || mb.msgs > 0
 	}
-	return dbs
+	return dbs, sz
 }
 
 // deleteMap returns all interior deletes for each block based on the mb.dmap.
@@ -12556,7 +12570,7 @@ func (fs *fileStore) SyncDeleted(dbs DeleteBlocks) error {
 
 	lseq := fs.state.LastSeq
 	fs.readLockAllMsgBlocks()
-	mdbs := fs.deleteBlocks()
+	mdbs, _ := fs.deleteBlocks()
 	// We'll release the locks below, so need to copy the ones that are references
 	// which are only safe while the locks are still held.
 	for i, db := range mdbs {

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -13044,7 +13044,7 @@ func TestFileStoreDeleteRangeTwoGaps(t *testing.T) {
 
 	checkDeleteBlocks := func(exp DeleteBlocks) {
 		t.Helper()
-		dBlocks := fs.deleteBlocks()
+		dBlocks, _ := fs.deleteBlocks()
 		require_Equal(t, len(exp), len(dBlocks))
 
 		for i, found := range dBlocks {
@@ -13094,7 +13094,7 @@ func TestFileStoreDeleteBlocksWithSingleMessageBlocks(t *testing.T) {
 	defer fs.Stop()
 
 	checkDeleteBlocks := func(exp DeleteBlocks) {
-		dBlocks := fs.deleteBlocks()
+		dBlocks, _ := fs.deleteBlocks()
 		require_Equal(t, len(exp), len(dBlocks))
 
 		for i, found := range dBlocks {
@@ -13269,7 +13269,7 @@ func TestFileStoreDeleteBlocks(t *testing.T) {
 	defer fs.Stop()
 
 	checkDeleteBlocks := func(exp DeleteBlocks) {
-		dBlocks := fs.deleteBlocks()
+		dBlocks, _ := fs.deleteBlocks()
 		require_Equal(t, len(exp), len(dBlocks))
 
 		for i, found := range dBlocks {
@@ -13414,7 +13414,7 @@ func TestFileStoreDeleteBlocksWithManyEmptyBlocks(t *testing.T) {
 
 	checkDeleteBlocks := func(exp DeleteBlocks) {
 		t.Helper()
-		dBlocks := fs.deleteBlocks()
+		dBlocks, _ := fs.deleteBlocks()
 		require_Equal(t, len(exp), len(dBlocks))
 
 		for i, found := range dBlocks {
@@ -13620,7 +13620,7 @@ func TestFileStoreRemoveMsgsInRange(t *testing.T) {
 	defer fs.mu.Unlock()
 
 	checkDeleteBlocks := func(exp DeleteBlocks) {
-		dBlocks := fs.deleteBlocks()
+		dBlocks, _ := fs.deleteBlocks()
 		require_Equal(t, len(exp), len(dBlocks))
 
 		for i, found := range dBlocks {
@@ -14864,7 +14864,7 @@ func TestFileStoreSyncDeletedDmapAliasRace(t *testing.T) {
 	// Snapshot the delete blocks to feed back into SyncDeleted.
 	fs.mu.Lock()
 	fs.readLockAllMsgBlocks()
-	live := fs.deleteBlocks()
+	live, _ := fs.deleteBlocks()
 	dbs := make(DeleteBlocks, len(live))
 	for i, db := range live {
 		switch d := db.(type) {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/nats-io/nats-server/v2/server/ats"
 	"github.com/nats-io/nats-server/v2/server/avl"
 	"github.com/nats-io/nats-server/v2/server/gsl"
@@ -2395,24 +2396,42 @@ func (ms *memStore) EncodedStreamState(failed uint64) ([]byte, error) {
 		numDeleted = 0
 	}
 
-	// Encoded is Msgs, Bytes, FirstSeq, LastSeq, Failed, NumDeleted and optional DeletedBlocks
-	var buf [1024]byte
-	buf[0], buf[1] = streamStateMagic, streamStateVersion
-	n := hdrLen
-	n += binary.PutUvarint(buf[n:], ms.state.Msgs)
-	n += binary.PutUvarint(buf[n:], ms.state.Bytes)
-	n += binary.PutUvarint(buf[n:], ms.state.FirstSeq)
-	n += binary.PutUvarint(buf[n:], ms.state.LastSeq)
-	n += binary.PutUvarint(buf[n:], failed)
-	n += binary.PutUvarint(buf[n:], uint64(numDeleted))
-
-	b := buf[0:n]
+	// Encoded is Msgs, Bytes, FirstSeq, LastSeq, Failed, NumDeleted and optional DeletedBlocks.
+	// Calculate the exact encoded size up front so the buffer is allocated once.
+	total := hdrLen + uvarintLen(ms.state.Msgs) + uvarintLen(ms.state.Bytes) +
+		uvarintLen(ms.state.FirstSeq) + uvarintLen(ms.state.LastSeq) +
+		uvarintLen(failed) + uvarintLen(uint64(numDeleted))
 
 	if numDeleted > 0 {
-		buf := ms.dmap.Encode(nil)
-		b = append(b, buf...)
+		total += ms.dmap.EncodeLen()
 	}
 
+	b := make([]byte, 0, total)
+	b = append(b, streamStateMagic, streamStateVersion)
+	b = binary.AppendUvarint(b, ms.state.Msgs)
+	b = binary.AppendUvarint(b, ms.state.Bytes)
+	b = binary.AppendUvarint(b, ms.state.FirstSeq)
+	b = binary.AppendUvarint(b, ms.state.LastSeq)
+	b = binary.AppendUvarint(b, failed)
+	b = binary.AppendUvarint(b, uint64(numDeleted))
+
+	if numDeleted > 0 {
+		enc := ms.dmap.Encode(b[len(b):])
+		if n := len(b) + len(enc); n <= cap(b) {
+			b = b[:n]
+		} else {
+			// Fallback if the buffer didn't have spare capacity.
+			b = append(b, enc...)
+		}
+	}
+
+	if len(b) != total {
+		assert.Unreachable("Memstore EncodedStreamState size accounting mismatch", map[string]any{
+			"name":   ms.cfg.Name,
+			"total":  total,
+			"length": len(b),
+		})
+	}
 	return b, nil
 }
 

--- a/server/store.go
+++ b/server/store.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/bits"
 	"os"
 	"strings"
 	"time"
@@ -305,6 +306,27 @@ func DecodeStreamState(buf []byte) (*StreamReplicatedState, error) {
 	}
 
 	return ss, nil
+}
+
+// uvarintLen returns the number of bytes binary.PutUvarint/binary.AppendUvarint
+// write for v: ceil(bits/7), with v=0 taking one byte.
+func uvarintLen(v uint64) int {
+	return (bits.Len64(v|1) + 6) / 7
+}
+
+// runLengthEncodeLen returns the encoded size of a run-length delete record,
+// exactly matching what appendRunLength writes.
+func runLengthEncodeLen(first, num uint64) int {
+	return 1 + uvarintLen(first) + uvarintLen(num)
+}
+
+// appendRunLength appends a run-length encoded delete record for num
+// deleted sequences starting at first.
+func appendRunLength(b []byte, first, num uint64) []byte {
+	b = append(b, runLengthMagic)
+	b = binary.AppendUvarint(b, first)
+	b = binary.AppendUvarint(b, num)
+	return b
 }
 
 // DeleteRange is a run length encoded delete range.


### PR DESCRIPTION
`EncodedStreamState` encoded into a fixed 1KB buffer and grew it by appending. For streams with many interior deletes this caused repeated buffer growth and copying, resulting in significant allocation churn. This PR improves that by calculating the total size once and preallocating what's needed. This drops the number of required allocations, as well as reduces time spent by 1-3x since no time is wasted on re-allocating. The encoded content itself is unchanged.

Replaces https://github.com/nats-io/nats-server/pull/8402