### PR TITLE
Optimise inserts, ranges and deletes on AVL sequence sets

### DIFF
--- a/server/avl/seqset.go
+++ b/server/avl/seqset.go
@@ -42,6 +42,22 @@ type SequenceSet struct {
 // Insert will insert the sequence into the set.
 // The tree will be balanced inline.
 func (ss *SequenceSet) Insert(seq uint64) {
+	// If a node covering seq already exists, setting a bit can not change the
+	// tree shape, so skip the recursive descent and rebalance checks.
+	for n := ss.root; n != nil; {
+		if seq < n.base {
+			n = n.l
+		} else if seq >= n.base+numEntries {
+			n = n.r
+		} else {
+			n.set(seq, &ss.changed)
+			if ss.changed {
+				ss.changed = false
+				ss.size++
+			}
+			return
+		}
+	}
 	if ss.root = ss.root.insert(seq, &ss.changed, &ss.nodes); ss.changed {
 		ss.changed = false
 		ss.size++
@@ -192,12 +208,10 @@ func (ss *SequenceSet) Union(ssa ...*SequenceSet) {
 	for _, sa := range ssa {
 		sa.root.nodeIter(func(n *node) {
 			for nb, b := range n.bits {
-				for pos := uint64(0); b != 0; pos++ {
-					if b&1 == 1 {
-						seq := n.base + (uint64(nb) * uint64(bitsPerBucket)) + pos
-						ss.Insert(seq)
-					}
-					b >>= 1
+				base := n.base + uint64(nb)*bitsPerBucket
+				for b != 0 {
+					ss.Insert(base + uint64(bits.TrailingZeros64(b)))
+					b &= b - 1
 				}
 			}
 		})
@@ -351,12 +365,9 @@ func decodev1(buf []byte) (*SequenceSet, int, error) {
 		for nb := uint64(0); nb < v1NumBuckets; nb++ {
 			n := le.Uint64(buf[index:])
 			// Walk all set bits and insert sequences manually for this decode from v1.
-			for pos := uint64(0); n != 0; pos++ {
-				if n&1 == 1 {
-					seq := base + (nb * uint64(bitsPerBucket)) + pos
-					ss.Insert(seq)
-				}
-				n >>= 1
+			for n != 0 {
+				ss.Insert(base + (nb * uint64(bitsPerBucket)) + uint64(bits.TrailingZeros64(n)))
+				n &= n - 1
 			}
 			index += 8
 		}
@@ -531,10 +542,13 @@ func (n *node) clear(seq uint64, deleted *bool) bool {
 	seq -= n.base
 	i := seq / bitsPerBucket
 	mask := uint64(1) << (seq % bitsPerBucket)
-	if (n.bits[i] & mask) != 0 {
-		n.bits[i] &^= mask
-		*deleted = true
+	if (n.bits[i] & mask) == 0 {
+		// Nothing cleared, and nodes in the tree are never empty,
+		// so no need to scan the buckets.
+		return false
 	}
+	n.bits[i] &^= mask
+	*deleted = true
 	for _, b := range n.bits {
 		if b != 0 {
 			return false
@@ -667,11 +681,13 @@ func (n *node) iter(f func(uint64) bool) bool {
 	if ok := n.l.iter(f); !ok {
 		return false
 	}
-	for num := n.base; num < n.base+numEntries; num++ {
-		if n.exists(num) {
-			if ok := f(num); !ok {
+	for i, b := range n.bits {
+		base := n.base + uint64(i)*bitsPerBucket
+		for b != 0 {
+			if ok := f(base + uint64(bits.TrailingZeros64(b))); !ok {
 				return false
 			}
+			b &= b - 1
 		}
 	}
 	if ok := n.r.iter(f); !ok {

--- a/server/avl/seqset_test.go
+++ b/server/avl/seqset_test.go
@@ -338,6 +338,169 @@ func TestSeqSetDecodeNodeCountOverflow(t *testing.T) {
 	}
 }
 
+func TestSeqSetInsertExistingNodeFastPath(t *testing.T) {
+	var ss SequenceSet
+
+	// Build a multi-node tree with only even sequences set.
+	for i := uint64(0); i < 8*numEntries; i += 2 {
+		ss.Insert(i)
+	}
+	nodes, size := ss.Nodes(), ss.Size()
+
+	// Inserting into existing nodes must not change the tree structure.
+	for i := uint64(1); i < 8*numEntries; i += 2 {
+		ss.Insert(i)
+		require_True(t, ss.Exists(i))
+	}
+	require_True(t, ss.Nodes() == nodes)
+	require_True(t, ss.Size() == size+4*numEntries)
+
+	// Duplicate inserts must not change the size.
+	for i := uint64(0); i < 8*numEntries; i++ {
+		ss.Insert(i)
+	}
+	require_True(t, ss.Size() == 8*numEntries)
+
+	// Heights and balance must still be intact.
+	ss.root.nodeIter(func(n *node) {
+		if n.h != maxH(n)+1 {
+			t.Fatalf("Node height is wrong: %+v", n)
+		}
+	})
+	if bf := balanceF(ss.root); bf > 1 || bf < -1 {
+		t.Fatalf("Unbalanced tree")
+	}
+}
+
+func TestSeqSetInsertUnalignedBase(t *testing.T) {
+	var ss SequenceSet
+
+	// SetInitialMin can create a node whose base is not aligned to numEntries.
+	require_NoError(t, ss.SetInitialMin(1000))
+	for _, seq := range []uint64{1000, 1001, 1000 + numEntries - 1} {
+		ss.Insert(seq)
+		require_True(t, ss.Exists(seq))
+	}
+	require_True(t, ss.Nodes() == 1)
+	require_True(t, ss.Size() == 3)
+
+	// Outside the node's range still creates a new node.
+	ss.Insert(1000 + numEntries)
+	require_True(t, ss.Exists(1000+numEntries))
+	require_True(t, ss.Nodes() == 2)
+	require_True(t, ss.Size() == 4)
+}
+
+func TestSeqSetDeleteNotPresent(t *testing.T) {
+	var ss SequenceSet
+
+	seqs := []uint64{22, 222, 2222, 222_222}
+	for _, seq := range seqs {
+		ss.Insert(seq)
+	}
+	nodes, size := ss.Nodes(), ss.Size()
+
+	// Deleting sequences that are not set, both inside and outside
+	// existing node ranges, must be a no-op and report false.
+	for _, seq := range []uint64{0, 23, 2223, 5000, 100_000, 999_999} {
+		require_True(t, !ss.Delete(seq))
+	}
+	require_True(t, ss.Nodes() == nodes)
+	require_True(t, ss.Size() == size)
+	for _, seq := range seqs {
+		require_True(t, ss.Exists(seq))
+	}
+
+	// Real deletes still work and empty the set.
+	for _, seq := range seqs {
+		require_True(t, ss.Delete(seq))
+	}
+	require_True(t, ss.root == nil)
+}
+
+func TestSeqSetRangeSparse(t *testing.T) {
+	// Cover bucket boundaries, node boundaries and large gaps.
+	seqs := []uint64{0, 1, 63, 64, 127, 128, 2047, 2048, 4095, 4096, 100_000, 1_000_000}
+	var ss SequenceSet
+	for _, seq := range seqs {
+		ss.Insert(seq)
+	}
+
+	var got []uint64
+	ss.Range(func(n uint64) bool {
+		got = append(got, n)
+		return true
+	})
+	require_True(t, len(got) == len(seqs))
+	for i, seq := range seqs {
+		require_True(t, got[i] == seq)
+	}
+
+	// Terminating mid-bucket should stop the iteration immediately.
+	got = got[:0]
+	ss.Range(func(n uint64) bool {
+		got = append(got, n)
+		return n != 64
+	})
+	require_True(t, len(got) == 4)
+	require_True(t, got[3] == 64)
+}
+
+func BenchmarkSeqSetInsertDense(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var ss SequenceSet
+		for s := uint64(0); s < 200_000; s++ {
+			ss.Insert(s)
+		}
+	}
+}
+
+func BenchmarkSeqSetInsertSparse(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var ss SequenceSet
+		for s := uint64(0); s < 200_000; s++ {
+			ss.Insert(s * 7)
+		}
+	}
+}
+
+func BenchmarkSeqSetRangeDense(b *testing.B) {
+	var ss SequenceSet
+	for s := uint64(0); s < 200_000; s++ {
+		ss.Insert(s)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var sum uint64
+		ss.Range(func(n uint64) bool { sum += n; return true })
+	}
+}
+
+func BenchmarkSeqSetRangeSparse(b *testing.B) {
+	var ss SequenceSet
+	for s := uint64(0); s < 10_000; s++ {
+		ss.Insert(s * 211) // ~10 bits per 2048-entry node
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var sum uint64
+		ss.Range(func(n uint64) bool { sum += n; return true })
+	}
+}
+
+func BenchmarkSeqSetDeleteNotPresent(b *testing.B) {
+	var ss SequenceSet
+	for s := uint64(0); s < 200_000; s += 2 {
+		ss.Insert(s)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for s := uint64(1); s < 200_000; s += 2 {
+			ss.Delete(s)
+		}
+	}
+}
+
 func require_NoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {


### PR DESCRIPTION
Made the following optimisations to AVL sequence sets:

1. Inserts where the node already exists covering the range can't modify the tree, so we can save a lot of effort from avoiding the rebalancing checks in those cases and drill down directly. This results in a 4x improvement on dense inserts and a 4.5x improvement on sparse inserts.
2. Iterating over a range was always probing all 2048 positions, which came with some relatively costly operations regardless of how many set bits. This now scales better with the number of positions. This results in a minor 3% improvement on dense ranges but a significant 20x improvement on sparse ranges.
3. Deletes that were no-ops were not returned early, now they are.