### PR TITLE
(2.15) [ADDED] Meta peer set rescue for disaster recovery

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -2218,5 +2218,15 @@
     "help": "",
     "url": "",
     "deprecates": ""
+  },
+  {
+    "constant": "JSClusterRescueErr",
+    "code": 400,
+    "error_code": 10224,
+    "description": "JetStream system rescue not applied: {err}",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
   }
 ]

--- a/server/events.go
+++ b/server/events.go
@@ -1044,21 +1044,29 @@ func (s *Server) sendStatsz(subj string) {
 			if mg.Leader() {
 				if ci := s.raftNodeToClusterInfo(mg); ci != nil {
 					jStat.Meta = &MetaClusterInfo{
-						Name:     ci.Name,
-						Leader:   ci.Leader,
-						Peer:     getHash(ci.Leader),
-						Replicas: ci.Replicas,
-						Size:     mg.ClusterSize(),
+						Name:         ci.Name,
+						Leader:       ci.Leader,
+						Replicas:     ci.Replicas,
+						Size:         mg.ClusterSize(),
+						QuorumNeeded: mg.QuorumNeeded(),
+						Rescue:       mg.InRescue(),
+					}
+					if ci.Leader != _EMPTY_ {
+						jStat.Meta.Peer = getHash(ci.Leader)
 					}
 				}
 			} else {
 				// non leader only include a shortened version without peers
 				leader := s.serverNameForNode(mg.GroupLeader())
 				jStat.Meta = &MetaClusterInfo{
-					Name:   mg.Group(),
-					Leader: leader,
-					Peer:   getHash(leader),
-					Size:   mg.ClusterSize(),
+					Name:         mg.Group(),
+					Leader:       leader,
+					Size:         mg.ClusterSize(),
+					QuorumNeeded: mg.QuorumNeeded(),
+					Rescue:       mg.InRescue(),
+				}
+				if leader != _EMPTY_ {
+					jStat.Meta.Peer = getHash(leader)
 				}
 			}
 			if jStat.Meta != nil {

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1064,6 +1064,10 @@ func (s *Server) shutdownJetStream() {
 			cc.qch, cc.stopped = nil, nil
 		}
 		js.stopUpdatesSub()
+		if cc.metaRescue != nil {
+			s.sysUnsubscribe(cc.metaRescue)
+			cc.metaRescue = nil
+		}
 		if cc.c != nil {
 			cc.c.closeConnection(ClientClosed)
 			cc.c = nil

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1053,6 +1053,10 @@ func (s *Server) shutdownJetStream() {
 			cc.qch, cc.stopped = nil, nil
 		}
 		js.stopUpdatesSub()
+		if cc.metaRescue != nil {
+			s.sysUnsubscribe(cc.metaRescue)
+			cc.metaRescue = nil
+		}
 		if cc.c != nil {
 			cc.c.closeConnection(ClientClosed)
 			cc.c = nil

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -194,6 +194,14 @@ const (
 	// Will return JSON response.
 	JSApiRemoveServer = "$JS.API.SERVER.REMOVE"
 
+	// JSApiMetaRescue is the endpoint to unsafely lower the meta group's quorum
+	// requirement on the surviving servers for disaster recovery.
+	// This is a broadcast subject, every online server evaluates and responds
+	// to the request independently.
+	// Only works from system account.
+	// Will return JSON response.
+	JSApiMetaRescue = "$JS.API.META.RESCUE"
+
 	// JSApiAccountPurge is the endpoint to purge the js content of an account
 	// Only works from system account.
 	// Will return JSON response.
@@ -305,6 +313,10 @@ const (
 
 	// JSAdvisoryServerRemoved notification that a server has been removed from the system.
 	JSAdvisoryServerRemoved = "$JS.EVENT.ADVISORY.SERVER.REMOVED"
+
+	// JSAdvisoryMetaRescue notification that a server has unsafely lowered the
+	// meta group's quorum requirement for disaster recovery.
+	JSAdvisoryMetaRescue = "$JS.EVENT.ADVISORY.SERVER.META_RESCUE"
 
 	// JSAdvisoryAPILimitReached notification that a server has reached the JS API hard limit.
 	JSAdvisoryAPILimitReached = "$JS.EVENT.ADVISORY.API.LIMIT_REACHED"
@@ -648,6 +660,31 @@ type JSApiMetaServerRemoveResponse struct {
 
 const JSApiMetaServerRemoveResponseType = "io.nats.jetstream.api.v1.meta_server_remove_response"
 
+// JSApiMetaRescueRequest will unsafely lower the meta group's quorum requirement
+// on the receiving server for disaster recovery.
+type JSApiMetaRescueRequest struct {
+	// The new, temporarily lowered, quorum size the receiving servers should
+	// apply to the meta group. Must be at least 1 and no larger than the
+	// receiving server's current effective quorum.
+	QuorumNeeded int `json:"quorum_needed"`
+}
+
+// JSApiMetaRescueResponse is the response to a meta rescue request. Since the
+// request is a broadcast, each online server responds independently.
+type JSApiMetaRescueResponse struct {
+	ApiResponse
+	// Server name of the responding server.
+	Server string `json:"server"`
+	// Server ID of the responding server.
+	ServerID string `json:"server_id"`
+	// The effective quorum before the rescue was applied.
+	PrevQuorum int `json:"prev_quorum,omitempty"`
+	// The effective quorum after the rescue was applied.
+	NewQuorum int `json:"new_quorum,omitempty"`
+}
+
+const JSApiMetaRescueResponseType = "io.nats.jetstream.api.v1.meta_rescue_response"
+
 // JSApiMetaServerStreamMoveRequest will move a stream on a server to another
 // response to this will come as JSApiStreamUpdateResponse/JSApiStreamUpdateResponseType
 type JSApiMetaServerStreamMoveRequest struct {
@@ -797,9 +834,10 @@ type jsAPIRoutedReq struct {
 }
 
 func (js *jetStream) apiDispatch(sub *subscription, c *client, acc *Account, subject, reply string, rmsg []byte) {
-	// Ignore system level directives meta stepdown and peer remove requests here.
+	// Ignore system level directives meta stepdown, peer remove and meta rescue requests here.
 	if subject == JSApiLeaderStepDown ||
 		subject == JSApiRemoveServer ||
+		subject == JSApiMetaRescue ||
 		strings.HasPrefix(subject, jsAPIAccountPre) {
 		return
 	}
@@ -2531,6 +2569,81 @@ func (s *Server) jsLeaderServerRemoveRequest(sub *subscription, c *client, _ *Ac
 	}
 	// Only copy the request, the subject and reply are already copied.
 	cc.peerRemoveReply[found] = peerRemoveInfo{ci: ci, subject: subject, reply: reply, request: string(msg)}
+}
+
+// jsMetaRescueRequest handles $JS.API.META.RESCUE requests. This is a broadcast
+// subject, every online server that receives the request evaluates and applies
+// it locally, responding independently.
+func (s *Server) jsMetaRescueRequest(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+	if c == nil || !s.JetStreamEnabled() {
+		return
+	}
+
+	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
+	if err != nil {
+		s.Warnf(badAPIRequestT, msg)
+		return
+	}
+	if acc != s.SystemAccount() {
+		return
+	}
+
+	js := s.getJetStream()
+	if js == nil {
+		return
+	}
+	meta := js.getMetaGroup()
+	if meta == nil {
+		return
+	}
+
+	var resp = JSApiMetaRescueResponse{
+		ApiResponse: ApiResponse{Type: JSApiMetaRescueResponseType},
+		Server:      s.Name(),
+		ServerID:    s.ID(),
+	}
+	if errorOnRequiredApiLevel(hdr) {
+		resp.Error = NewJSRequiredApiLevelError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+
+	if isEmptyRequest(msg) {
+		resp.Error = NewJSBadRequestError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+
+	var req JSApiMetaRescueRequest
+	if err := s.unmarshalRequest(c, acc, subject, msg, &req); err != nil {
+		resp.Error = NewJSInvalidJSONError(err)
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+
+	prev, cur, err := meta.RescueQuorum(req.QuorumNeeded)
+	if err != nil {
+		resp.Error = NewJSClusterRescueError(err, Unless(err))
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+	resp.PrevQuorum, resp.NewQuorum = prev, cur
+
+	s.publishAdvisory(nil, JSAdvisoryMetaRescue, &JSMetaRescueAdvisory{
+		TypedEvent: TypedEvent{
+			Type: JSMetaRescueAdvisoryType,
+			ID:   nuid.Next(),
+			Time: time.Now().UTC(),
+		},
+		Server:     s.Name(),
+		ServerID:   s.ID(),
+		PrevQuorum: prev,
+		NewQuorum:  cur,
+		Cluster:    s.cachedClusterName(),
+		Domain:     s.getOpts().JetStreamDomain,
+	})
+
+	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 }
 
 func (s *Server) peerSetToNames(ps []string) []string {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -79,6 +79,10 @@ type jetStreamCluster struct {
 	peerStreamMove *subscription
 	// System level request to cancel a stream move
 	peerStreamCancelMove *subscription
+	// System level broadcast request to unsafely rescue the meta group.
+	// Unlike the subscriptions above, this is active on every server,
+	// not only on the meta leader.
+	metaRescue *subscription
 	// To pop out the monitorCluster before the raft layer.
 	qch chan struct{}
 	// To notify others that monitorCluster has actually stopped.
@@ -1115,6 +1119,10 @@ func (js *jetStream) setupMetaGroup() error {
 	}
 	atomic.StoreInt32(&js.clustered, 1)
 	c.registerWithAccount(sysAcc)
+
+	// Every server listens for meta rescue requests, they must be handled
+	// even (especially) when the meta group has no leader.
+	js.cluster.metaRescue, _ = s.systemSubscribe(JSApiMetaRescue, _EMPTY_, false, c, s.jsMetaRescueRequest)
 
 	// Set to true before we start.
 	js.metaRecovering = true

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -11765,3 +11765,372 @@ func TestJetStreamClusterAckAllAfterConsumerFilterUpdate(t *testing.T) {
 		return nil
 	})
 }
+
+func TestJetStreamClusterMetaRescueRejectedWithLeader(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	s := c.randomServer()
+	nc, err := nats.Connect(s.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	inbox := nats.NewInbox()
+	sub, err := nc.SubscribeSync(inbox)
+	require_NoError(t, err)
+
+	req, err := json.Marshal(&JSApiMetaRescueRequest{QuorumNeeded: 1})
+	require_NoError(t, err)
+	require_NoError(t, nc.PublishRequest(JSApiMetaRescue, inbox, req))
+
+	// This is a broadcast subject, every online server evaluates and responds
+	// to the request independently. All of them know of a healthy meta leader
+	// so all must reject the rescue.
+	for range 3 {
+		msg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		var resp JSApiMetaRescueResponse
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		require_True(t, resp.Error != nil)
+		require_Equal(t, resp.Error.ErrCode, uint16(JSClusterRescueErr))
+		require_True(t, strings.Contains(resp.Error.Description, errRescueLeaderKnown.Error()))
+		require_Equal(t, resp.NewQuorum, 0)
+		require_NotEqual(t, resp.Server, _EMPTY_)
+		require_NotEqual(t, resp.ServerID, _EMPTY_)
+	}
+	// And no more responses than that.
+	_, err = sub.NextMsg(250 * time.Millisecond)
+	require_Error(t, err, nats.ErrTimeout)
+}
+
+func TestJetStreamClusterMetaRescue(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R5S", 5)
+	defer c.shutdown()
+
+	// Keep two servers that are not the meta leader, and shut down the other
+	// three without peer-removing them. The meta group still believes its size
+	// is 5 and needs 3 votes for quorum, so the meta layer is now stuck.
+	leader := c.leader()
+	var survivors []*Server
+	var downed []string
+	for _, s := range c.servers {
+		if s != leader && len(survivors) < 2 {
+			survivors = append(survivors, s)
+			continue
+		}
+		downed = append(downed, s.Name())
+		s.Shutdown()
+		s.WaitForShutdown()
+	}
+	require_Len(t, len(survivors), 2)
+	require_Len(t, len(downed), 3)
+
+	// Wait until the survivors see no meta leader.
+	checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
+		for _, s := range survivors {
+			if leader := s.getJetStream().getMetaGroup().GroupLeader(); leader != _EMPTY_ {
+				return fmt.Errorf("server %q still sees meta leader %q", s.Name(), leader)
+			}
+		}
+		return nil
+	})
+
+	nc, err := nats.Connect(survivors[0].ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	// Listen for the rescue advisories.
+	advSub, err := nc.SubscribeSync(JSAdvisoryMetaRescue)
+	require_NoError(t, err)
+	// Make sure interest has propagated to the other survivor.
+	checkSubInterest(t, survivors[1], "$SYS", JSAdvisoryMetaRescue, time.Second)
+
+	inbox := nats.NewInbox()
+	sub, err := nc.SubscribeSync(inbox)
+	require_NoError(t, err)
+	checkSubInterest(t, survivors[1], "$SYS", inbox, time.Second)
+
+	req, err := json.Marshal(&JSApiMetaRescueRequest{QuorumNeeded: 2})
+	require_NoError(t, err)
+	require_NoError(t, nc.PublishRequest(JSApiMetaRescue, inbox, req))
+
+	// Both survivors respond independently. At least one must have applied the
+	// rescue, the other may already know of a new leader by the time it
+	// evaluates the request and reject it.
+	var applied int
+	for range 2 {
+		msg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		var resp JSApiMetaRescueResponse
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		if resp.Error != nil {
+			require_Equal(t, resp.Error.ErrCode, uint16(JSClusterRescueErr))
+			require_True(t, strings.Contains(resp.Error.Description, errRescueLeaderKnown.Error()))
+			continue
+		}
+		// No error means the rescue was applied and the new quorum is set.
+		require_Equal(t, resp.PrevQuorum, 3)
+		require_Equal(t, resp.NewQuorum, 2)
+		applied++
+	}
+	require_True(t, applied >= 1)
+
+	// Every server that applied the rescue also published an advisory.
+	for range applied {
+		msg, err := advSub.NextMsg(time.Second)
+		require_NoError(t, err)
+		var adv JSMetaRescueAdvisory
+		require_NoError(t, json.Unmarshal(msg.Data, &adv))
+		require_Equal(t, adv.Type, JSMetaRescueAdvisoryType)
+		require_Equal(t, adv.PrevQuorum, 3)
+		require_Equal(t, adv.NewQuorum, 2)
+		require_Equal(t, adv.Cluster, c.name)
+	}
+
+	// With the lowered quorum the survivors can now elect a meta leader.
+	var metaLeader string
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		for _, s := range survivors {
+			if leader := s.getJetStream().getMetaGroup().GroupLeader(); leader != _EMPTY_ {
+				metaLeader = leader
+				return nil
+			}
+		}
+		return fmt.Errorf("expected a meta leader among the survivors")
+	})
+	require_True(t, metaLeader == getHash(survivors[0].Name()) || metaLeader == getHash(survivors[1].Name()))
+
+	// While the rescue is active, JSZ exposes the lowered quorum and the
+	// rescue state on the servers that applied it.
+	var inRescue int
+	for _, s := range survivors {
+		jsz, err := s.Jsz(nil)
+		require_NoError(t, err)
+		require_True(t, jsz.Meta != nil)
+		if jsz.Meta.Rescue {
+			require_Equal(t, jsz.Meta.QuorumNeeded, 2)
+			inRescue++
+		}
+	}
+	require_True(t, inRescue >= applied)
+
+	// The meta layer is unblocked, use the normal peer-remove path to
+	// permanently drop the lost peers.
+	for _, name := range downed {
+		rmReq, err := json.Marshal(&JSApiMetaServerRemoveRequest{Server: name})
+		require_NoError(t, err)
+		rmsg, err := nc.Request(JSApiRemoveServer, rmReq, 2*time.Second)
+		require_NoError(t, err)
+		var resp JSApiMetaServerRemoveResponse
+		require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
+		require_True(t, resp.Error == nil)
+		require_True(t, resp.Success)
+	}
+
+	// The peer set should now only contain the survivors, and with the natural
+	// quorum of the shrunken peer set the meta group operates normally.
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		for _, s := range survivors {
+			if cs := s.getJetStream().getMetaGroup().ClusterSize(); cs != 2 {
+				return fmt.Errorf("expected cluster size 2 on %q, got %d", s.Name(), cs)
+			}
+			if qn := s.getJetStream().getMetaGroup().QuorumNeeded(); qn != 2 {
+				return fmt.Errorf("expected quorum 2 on %q, got %d", s.Name(), qn)
+			}
+			// The natural quorum of the shrunken peer set reached the rescued
+			// value, which stops the rescue.
+			if s.getJetStream().getMetaGroup().InRescue() {
+				return fmt.Errorf("expected rescue to be stopped on %q", s.Name())
+			}
+		}
+		return nil
+	})
+}
+
+func TestJetStreamClusterMetaRescueBadRequest(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	s := c.randomServer()
+	nc, err := nats.Connect(s.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	inbox := nats.NewInbox()
+	sub, err := nc.SubscribeSync(inbox)
+	require_NoError(t, err)
+
+	// Empty request.
+	require_NoError(t, nc.PublishRequest(JSApiMetaRescue, inbox, nil))
+	for range 3 {
+		msg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		var resp JSApiMetaRescueResponse
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		require_True(t, resp.Error != nil)
+		require_Equal(t, resp.Error.ErrCode, uint16(JSBadRequestErr))
+	}
+
+	// Quorum larger than the current effective quorum, it can only be
+	// lowered. This is checked before the leader-known check would reject it.
+	req, err := json.Marshal(&JSApiMetaRescueRequest{QuorumNeeded: 4})
+	require_NoError(t, err)
+	require_NoError(t, nc.PublishRequest(JSApiMetaRescue, inbox, req))
+	for range 3 {
+		msg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		var resp JSApiMetaRescueResponse
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		require_True(t, resp.Error != nil)
+		require_Equal(t, resp.Error.ErrCode, uint16(JSClusterRescueErr))
+		require_True(t, strings.Contains(resp.Error.Description, errRescueBadQuorum.Error()))
+	}
+}
+
+func TestJetStreamClusterMetaRescueSingleSurvivor(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	// Keep the first server, it seeds the routes for the servers added in
+	// later. Shut down the other two without peer-removing them, the meta
+	// group still believes its size is 3 and needs 2 votes for quorum.
+	survivor := c.servers[0]
+	var downed []string
+	for _, s := range c.servers[1:] {
+		downed = append(downed, s.Name())
+		s.Shutdown()
+		s.WaitForShutdown()
+	}
+	// Only track the survivor, so the servers added in later join through it.
+	c.servers = c.servers[:1]
+	c.opts = c.opts[:1]
+
+	// Wait until the survivor sees no meta leader. If the survivor was the
+	// meta leader itself, it steps down once it detects the lost quorum.
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		if leader := survivor.getJetStream().getMetaGroup().GroupLeader(); leader != _EMPTY_ {
+			return fmt.Errorf("survivor still sees meta leader %q", leader)
+		}
+		return nil
+	})
+
+	nc, err := nats.Connect(survivor.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	inbox := nats.NewInbox()
+	sub, err := nc.SubscribeSync(inbox)
+	require_NoError(t, err)
+
+	req, err := json.Marshal(&JSApiMetaRescueRequest{QuorumNeeded: 1})
+	require_NoError(t, err)
+	require_NoError(t, nc.PublishRequest(JSApiMetaRescue, inbox, req))
+
+	// Only the survivor is online to respond, and it applies the rescue.
+	msg, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	var resp JSApiMetaRescueResponse
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_True(t, resp.Error == nil)
+	require_Equal(t, resp.PrevQuorum, 2)
+	require_Equal(t, resp.NewQuorum, 1)
+	_, err = sub.NextMsg(250 * time.Millisecond)
+	require_Error(t, err, nats.ErrTimeout)
+
+	// With a quorum of 1 the survivor can elect itself.
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		if !survivor.JetStreamIsLeader() {
+			return fmt.Errorf("survivor is not meta leader yet")
+		}
+		return nil
+	})
+
+	// The meta layer is unblocked, use the normal peer-remove path to
+	// permanently drop the lost peers.
+	for _, name := range downed {
+		rmReq, err := json.Marshal(&JSApiMetaServerRemoveRequest{Server: name})
+		require_NoError(t, err)
+		rmsg, err := nc.Request(JSApiRemoveServer, rmReq, 2*time.Second)
+		require_NoError(t, err)
+		var resp JSApiMetaServerRemoveResponse
+		require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
+		require_True(t, resp.Error == nil)
+		require_True(t, resp.Success)
+	}
+
+	// The peer set shrunk to just the survivor. The natural quorum reached
+	// the rescued value, which stops the rescue.
+	checkFor(t, 2*time.Second, 250*time.Millisecond, func() error {
+		meta := survivor.getJetStream().getMetaGroup()
+		if cs := meta.ClusterSize(); cs != 1 {
+			return fmt.Errorf("expected cluster size 1, got %d", cs)
+		}
+		if qn := meta.QuorumNeeded(); qn != 1 {
+			return fmt.Errorf("expected quorum 1, got %d", qn)
+		}
+		if meta.InRescue() {
+			return fmt.Errorf("expected rescue to be stopped")
+		}
+		return nil
+	})
+
+	// Add two new servers to go back to R3, under names not seen before.
+	// Reusing the names of the peer-removed servers would not work, they
+	// map to the same peer IDs which are marked as removed and can not
+	// immediately be re-added to the peer set.
+	for _, sn := range []string{"S-NEW-1", "S-NEW-2"} {
+		seedRoute := fmt.Sprintf("nats-route://127.0.0.1:%d", c.opts[0].Cluster.Port)
+		conf := fmt.Sprintf(jsClusterTempl, sn, t.TempDir(), c.name, -1, seedRoute)
+		s, o := RunServerWithConfig(createConfFile(t, []byte(conf)))
+		c.servers = append(c.servers, s)
+		c.opts = append(c.opts, o)
+	}
+	c.checkClusterFormed()
+	c.waitOnPeerCount(3)
+
+	// Quorum is back at its natural value for the new R3 peer set.
+	checkFor(t, 2*time.Second, 250*time.Millisecond, func() error {
+		meta := survivor.getJetStream().getMetaGroup()
+		if qn := meta.QuorumNeeded(); qn != 2 {
+			return fmt.Errorf("expected quorum 2, got %d", qn)
+		}
+		return nil
+	})
+
+	// And the meta layer is fully operational again.
+	ncjs, js := jsClientConnect(t, survivor)
+	defer ncjs.Close()
+	_, err = js.AddStream(&nats.StreamConfig{Name: "TEST", Replicas: 3})
+	require_NoError(t, err)
+}
+
+func TestJetStreamClusterMetaReplicasInJsz(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	// The configured meta peer set must be visible on every server, not just
+	// the meta leader, so it can be inspected during disaster recovery when
+	// there is no meta leader.
+	checkFor(t, 2*time.Second, 250*time.Millisecond, func() error {
+		for _, s := range c.servers {
+			jsz, err := s.Jsz(nil)
+			if err != nil {
+				return err
+			}
+			if jsz.Meta == nil {
+				return fmt.Errorf("no meta cluster info on %q", s.Name())
+			}
+			// Excludes the server itself, hence one less than the peer set size.
+			if len(jsz.Meta.Replicas) != 2 {
+				return fmt.Errorf("expected 2 meta replicas on %q, got %d", s.Name(), len(jsz.Meta.Replicas))
+			}
+			if jsz.Meta.QuorumNeeded != 2 {
+				return fmt.Errorf("expected quorum 2 on %q, got %d", s.Name(), jsz.Meta.QuorumNeeded)
+			}
+			if jsz.Meta.Rescue {
+				return fmt.Errorf("expected no active rescue on %q", s.Name())
+			}
+		}
+		return nil
+	})
+}

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -11220,3 +11220,372 @@ func TestJetStreamClusterConsumerScaleDownPrefersOnlinePeers(t *testing.T) {
 		}
 	}
 }
+
+func TestJetStreamClusterMetaRescueRejectedWithLeader(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	s := c.randomServer()
+	nc, err := nats.Connect(s.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	inbox := nats.NewInbox()
+	sub, err := nc.SubscribeSync(inbox)
+	require_NoError(t, err)
+
+	req, err := json.Marshal(&JSApiMetaRescueRequest{QuorumNeeded: 1})
+	require_NoError(t, err)
+	require_NoError(t, nc.PublishRequest(JSApiMetaRescue, inbox, req))
+
+	// This is a broadcast subject, every online server evaluates and responds
+	// to the request independently. All of them know of a healthy meta leader
+	// so all must reject the rescue.
+	for range 3 {
+		msg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		var resp JSApiMetaRescueResponse
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		require_True(t, resp.Error != nil)
+		require_Equal(t, resp.Error.ErrCode, uint16(JSClusterRescueErr))
+		require_True(t, strings.Contains(resp.Error.Description, errRescueLeaderKnown.Error()))
+		require_Equal(t, resp.NewQuorum, 0)
+		require_NotEqual(t, resp.Server, _EMPTY_)
+		require_NotEqual(t, resp.ServerID, _EMPTY_)
+	}
+	// And no more responses than that.
+	_, err = sub.NextMsg(250 * time.Millisecond)
+	require_Error(t, err, nats.ErrTimeout)
+}
+
+func TestJetStreamClusterMetaRescue(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R5S", 5)
+	defer c.shutdown()
+
+	// Keep two servers that are not the meta leader, and shut down the other
+	// three without peer-removing them. The meta group still believes its size
+	// is 5 and needs 3 votes for quorum, so the meta layer is now stuck.
+	leader := c.leader()
+	var survivors []*Server
+	var downed []string
+	for _, s := range c.servers {
+		if s != leader && len(survivors) < 2 {
+			survivors = append(survivors, s)
+			continue
+		}
+		downed = append(downed, s.Name())
+		s.Shutdown()
+		s.WaitForShutdown()
+	}
+	require_Len(t, len(survivors), 2)
+	require_Len(t, len(downed), 3)
+
+	// Wait until the survivors see no meta leader.
+	checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
+		for _, s := range survivors {
+			if leader := s.getJetStream().getMetaGroup().GroupLeader(); leader != _EMPTY_ {
+				return fmt.Errorf("server %q still sees meta leader %q", s.Name(), leader)
+			}
+		}
+		return nil
+	})
+
+	nc, err := nats.Connect(survivors[0].ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	// Listen for the rescue advisories.
+	advSub, err := nc.SubscribeSync(JSAdvisoryMetaRescue)
+	require_NoError(t, err)
+	// Make sure interest has propagated to the other survivor.
+	checkSubInterest(t, survivors[1], "$SYS", JSAdvisoryMetaRescue, time.Second)
+
+	inbox := nats.NewInbox()
+	sub, err := nc.SubscribeSync(inbox)
+	require_NoError(t, err)
+	checkSubInterest(t, survivors[1], "$SYS", inbox, time.Second)
+
+	req, err := json.Marshal(&JSApiMetaRescueRequest{QuorumNeeded: 2})
+	require_NoError(t, err)
+	require_NoError(t, nc.PublishRequest(JSApiMetaRescue, inbox, req))
+
+	// Both survivors respond independently. At least one must have applied the
+	// rescue, the other may already know of a new leader by the time it
+	// evaluates the request and reject it.
+	var applied int
+	for range 2 {
+		msg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		var resp JSApiMetaRescueResponse
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		if resp.Error != nil {
+			require_Equal(t, resp.Error.ErrCode, uint16(JSClusterRescueErr))
+			require_True(t, strings.Contains(resp.Error.Description, errRescueLeaderKnown.Error()))
+			continue
+		}
+		// No error means the rescue was applied and the new quorum is set.
+		require_Equal(t, resp.PrevQuorum, 3)
+		require_Equal(t, resp.NewQuorum, 2)
+		applied++
+	}
+	require_True(t, applied >= 1)
+
+	// Every server that applied the rescue also published an advisory.
+	for range applied {
+		msg, err := advSub.NextMsg(time.Second)
+		require_NoError(t, err)
+		var adv JSMetaRescueAdvisory
+		require_NoError(t, json.Unmarshal(msg.Data, &adv))
+		require_Equal(t, adv.Type, JSMetaRescueAdvisoryType)
+		require_Equal(t, adv.PrevQuorum, 3)
+		require_Equal(t, adv.NewQuorum, 2)
+		require_Equal(t, adv.Cluster, c.name)
+	}
+
+	// With the lowered quorum the survivors can now elect a meta leader.
+	var metaLeader string
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		for _, s := range survivors {
+			if leader := s.getJetStream().getMetaGroup().GroupLeader(); leader != _EMPTY_ {
+				metaLeader = leader
+				return nil
+			}
+		}
+		return fmt.Errorf("expected a meta leader among the survivors")
+	})
+	require_True(t, metaLeader == getHash(survivors[0].Name()) || metaLeader == getHash(survivors[1].Name()))
+
+	// While the rescue is active, JSZ exposes the lowered quorum and the
+	// rescue state on the servers that applied it.
+	var inRescue int
+	for _, s := range survivors {
+		jsz, err := s.Jsz(nil)
+		require_NoError(t, err)
+		require_True(t, jsz.Meta != nil)
+		if jsz.Meta.Rescue {
+			require_Equal(t, jsz.Meta.QuorumNeeded, 2)
+			inRescue++
+		}
+	}
+	require_True(t, inRescue >= applied)
+
+	// The meta layer is unblocked, use the normal peer-remove path to
+	// permanently drop the lost peers.
+	for _, name := range downed {
+		rmReq, err := json.Marshal(&JSApiMetaServerRemoveRequest{Server: name})
+		require_NoError(t, err)
+		rmsg, err := nc.Request(JSApiRemoveServer, rmReq, 2*time.Second)
+		require_NoError(t, err)
+		var resp JSApiMetaServerRemoveResponse
+		require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
+		require_True(t, resp.Error == nil)
+		require_True(t, resp.Success)
+	}
+
+	// The peer set should now only contain the survivors, and with the natural
+	// quorum of the shrunken peer set the meta group operates normally.
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		for _, s := range survivors {
+			if cs := s.getJetStream().getMetaGroup().ClusterSize(); cs != 2 {
+				return fmt.Errorf("expected cluster size 2 on %q, got %d", s.Name(), cs)
+			}
+			if qn := s.getJetStream().getMetaGroup().QuorumNeeded(); qn != 2 {
+				return fmt.Errorf("expected quorum 2 on %q, got %d", s.Name(), qn)
+			}
+			// The natural quorum of the shrunken peer set reached the rescued
+			// value, which stops the rescue.
+			if s.getJetStream().getMetaGroup().InRescue() {
+				return fmt.Errorf("expected rescue to be stopped on %q", s.Name())
+			}
+		}
+		return nil
+	})
+}
+
+func TestJetStreamClusterMetaRescueBadRequest(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	s := c.randomServer()
+	nc, err := nats.Connect(s.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	inbox := nats.NewInbox()
+	sub, err := nc.SubscribeSync(inbox)
+	require_NoError(t, err)
+
+	// Empty request.
+	require_NoError(t, nc.PublishRequest(JSApiMetaRescue, inbox, nil))
+	for range 3 {
+		msg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		var resp JSApiMetaRescueResponse
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		require_True(t, resp.Error != nil)
+		require_Equal(t, resp.Error.ErrCode, uint16(JSBadRequestErr))
+	}
+
+	// Quorum larger than the current effective quorum, it can only be
+	// lowered. This is checked before the leader-known check would reject it.
+	req, err := json.Marshal(&JSApiMetaRescueRequest{QuorumNeeded: 4})
+	require_NoError(t, err)
+	require_NoError(t, nc.PublishRequest(JSApiMetaRescue, inbox, req))
+	for range 3 {
+		msg, err := sub.NextMsg(time.Second)
+		require_NoError(t, err)
+		var resp JSApiMetaRescueResponse
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		require_True(t, resp.Error != nil)
+		require_Equal(t, resp.Error.ErrCode, uint16(JSClusterRescueErr))
+		require_True(t, strings.Contains(resp.Error.Description, errRescueBadQuorum.Error()))
+	}
+}
+
+func TestJetStreamClusterMetaRescueSingleSurvivor(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	// Keep the first server, it seeds the routes for the servers added in
+	// later. Shut down the other two without peer-removing them, the meta
+	// group still believes its size is 3 and needs 2 votes for quorum.
+	survivor := c.servers[0]
+	var downed []string
+	for _, s := range c.servers[1:] {
+		downed = append(downed, s.Name())
+		s.Shutdown()
+		s.WaitForShutdown()
+	}
+	// Only track the survivor, so the servers added in later join through it.
+	c.servers = c.servers[:1]
+	c.opts = c.opts[:1]
+
+	// Wait until the survivor sees no meta leader. If the survivor was the
+	// meta leader itself, it steps down once it detects the lost quorum.
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		if leader := survivor.getJetStream().getMetaGroup().GroupLeader(); leader != _EMPTY_ {
+			return fmt.Errorf("survivor still sees meta leader %q", leader)
+		}
+		return nil
+	})
+
+	nc, err := nats.Connect(survivor.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+
+	inbox := nats.NewInbox()
+	sub, err := nc.SubscribeSync(inbox)
+	require_NoError(t, err)
+
+	req, err := json.Marshal(&JSApiMetaRescueRequest{QuorumNeeded: 1})
+	require_NoError(t, err)
+	require_NoError(t, nc.PublishRequest(JSApiMetaRescue, inbox, req))
+
+	// Only the survivor is online to respond, and it applies the rescue.
+	msg, err := sub.NextMsg(time.Second)
+	require_NoError(t, err)
+	var resp JSApiMetaRescueResponse
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_True(t, resp.Error == nil)
+	require_Equal(t, resp.PrevQuorum, 2)
+	require_Equal(t, resp.NewQuorum, 1)
+	_, err = sub.NextMsg(250 * time.Millisecond)
+	require_Error(t, err, nats.ErrTimeout)
+
+	// With a quorum of 1 the survivor can elect itself.
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		if !survivor.JetStreamIsLeader() {
+			return fmt.Errorf("survivor is not meta leader yet")
+		}
+		return nil
+	})
+
+	// The meta layer is unblocked, use the normal peer-remove path to
+	// permanently drop the lost peers.
+	for _, name := range downed {
+		rmReq, err := json.Marshal(&JSApiMetaServerRemoveRequest{Server: name})
+		require_NoError(t, err)
+		rmsg, err := nc.Request(JSApiRemoveServer, rmReq, 2*time.Second)
+		require_NoError(t, err)
+		var resp JSApiMetaServerRemoveResponse
+		require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
+		require_True(t, resp.Error == nil)
+		require_True(t, resp.Success)
+	}
+
+	// The peer set shrunk to just the survivor. The natural quorum reached
+	// the rescued value, which stops the rescue.
+	checkFor(t, 2*time.Second, 250*time.Millisecond, func() error {
+		meta := survivor.getJetStream().getMetaGroup()
+		if cs := meta.ClusterSize(); cs != 1 {
+			return fmt.Errorf("expected cluster size 1, got %d", cs)
+		}
+		if qn := meta.QuorumNeeded(); qn != 1 {
+			return fmt.Errorf("expected quorum 1, got %d", qn)
+		}
+		if meta.InRescue() {
+			return fmt.Errorf("expected rescue to be stopped")
+		}
+		return nil
+	})
+
+	// Add two new servers to go back to R3, under names not seen before.
+	// Reusing the names of the peer-removed servers would not work, they
+	// map to the same peer IDs which are marked as removed and can not
+	// immediately be re-added to the peer set.
+	for _, sn := range []string{"S-NEW-1", "S-NEW-2"} {
+		seedRoute := fmt.Sprintf("nats-route://127.0.0.1:%d", c.opts[0].Cluster.Port)
+		conf := fmt.Sprintf(jsClusterTempl, sn, t.TempDir(), c.name, -1, seedRoute)
+		s, o := RunServerWithConfig(createConfFile(t, []byte(conf)))
+		c.servers = append(c.servers, s)
+		c.opts = append(c.opts, o)
+	}
+	c.checkClusterFormed()
+	c.waitOnPeerCount(3)
+
+	// Quorum is back at its natural value for the new R3 peer set.
+	checkFor(t, 2*time.Second, 250*time.Millisecond, func() error {
+		meta := survivor.getJetStream().getMetaGroup()
+		if qn := meta.QuorumNeeded(); qn != 2 {
+			return fmt.Errorf("expected quorum 2, got %d", qn)
+		}
+		return nil
+	})
+
+	// And the meta layer is fully operational again.
+	ncjs, js := jsClientConnect(t, survivor)
+	defer ncjs.Close()
+	_, err = js.AddStream(&nats.StreamConfig{Name: "TEST", Replicas: 3})
+	require_NoError(t, err)
+}
+
+func TestJetStreamClusterMetaReplicasInJsz(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	// The configured meta peer set must be visible on every server, not just
+	// the meta leader, so it can be inspected during disaster recovery when
+	// there is no meta leader.
+	checkFor(t, 2*time.Second, 250*time.Millisecond, func() error {
+		for _, s := range c.servers {
+			jsz, err := s.Jsz(nil)
+			if err != nil {
+				return err
+			}
+			if jsz.Meta == nil {
+				return fmt.Errorf("no meta cluster info on %q", s.Name())
+			}
+			// Excludes the server itself, hence one less than the peer set size.
+			if len(jsz.Meta.Replicas) != 2 {
+				return fmt.Errorf("expected 2 meta replicas on %q, got %d", s.Name(), len(jsz.Meta.Replicas))
+			}
+			if jsz.Meta.QuorumNeeded != 2 {
+				return fmt.Errorf("expected quorum 2 on %q, got %d", s.Name(), jsz.Meta.QuorumNeeded)
+			}
+			if jsz.Meta.Rescue {
+				return fmt.Errorf("expected no active rescue on %q", s.Name())
+			}
+		}
+		return nil
+	})
+}

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -77,6 +77,9 @@ const (
 	// JSClusterRequiredErr JetStream clustering support required
 	JSClusterRequiredErr ErrorIdentifier = 10010
 
+	// JSClusterRescueErr JetStream system rescue not applied: {err}
+	JSClusterRescueErr ErrorIdentifier = 10224
+
 	// JSClusterServerMemberChangeInflightErr cluster member change is in progress
 	JSClusterServerMemberChangeInflightErr ErrorIdentifier = 10202
 
@@ -698,6 +701,7 @@ var (
 		JSClusterNotLeaderErr:                        {Code: 500, ErrCode: 10009, Description: "JetStream cluster can not handle request"},
 		JSClusterPeerNotMemberErr:                    {Code: 400, ErrCode: 10040, Description: "peer not a member"},
 		JSClusterRequiredErr:                         {Code: 503, ErrCode: 10010, Description: "JetStream clustering support required"},
+		JSClusterRescueErr:                           {Code: 400, ErrCode: 10224, Description: "JetStream system rescue not applied: {err}"},
 		JSClusterServerMemberChangeInflightErr:       {Code: 400, ErrCode: 10202, Description: "cluster member change is in progress"},
 		JSClusterServerNotMemberErr:                  {Code: 400, ErrCode: 10044, Description: "server is not a member of the cluster"},
 		JSClusterTagsErr:                             {Code: 400, ErrCode: 10011, Description: "tags placement not supported for operation"},
@@ -1177,6 +1181,22 @@ func NewJSClusterRequiredError(opts ...ErrorOption) *ApiError {
 	}
 
 	return ApiErrors[JSClusterRequiredErr]
+}
+
+// NewJSClusterRescueError creates a new JSClusterRescueErr error: "JetStream system rescue not applied: {err}"
+func NewJSClusterRescueError(err error, opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	e := ApiErrors[JSClusterRescueErr]
+	args := e.toReplacerArgs([]interface{}{"{err}", err})
+	return &ApiError{
+		Code:        e.Code,
+		ErrCode:     e.ErrCode,
+		Description: strings.NewReplacer(args...).Replace(e.Description),
+	}
 }
 
 // NewJSClusterServerMemberChangeInflightError creates a new JSClusterServerMemberChangeInflightErr error: "cluster member change is in progress"

--- a/server/jetstream_events.go
+++ b/server/jetstream_events.go
@@ -354,6 +354,22 @@ type JSServerRemovedAdvisory struct {
 	Domain   string `json:"domain,omitempty"`
 }
 
+// JSMetaRescueAdvisoryType is sent when a server unsafely lowers the meta
+// group's quorum requirement for disaster recovery.
+const JSMetaRescueAdvisoryType = "io.nats.jetstream.advisory.v1.meta_rescue"
+
+// JSMetaRescueAdvisory indicates that a server has unsafely lowered the meta
+// group's quorum requirement for disaster recovery.
+type JSMetaRescueAdvisory struct {
+	TypedEvent
+	Server     string `json:"server"`
+	ServerID   string `json:"server_id"`
+	PrevQuorum int    `json:"prev_quorum"`
+	NewQuorum  int    `json:"new_quorum"`
+	Cluster    string `json:"cluster"`
+	Domain     string `json:"domain,omitempty"`
+}
+
 // JSAPILimitReachedAdvisoryType is sent when the JS API request queue limit is reached.
 const JSAPILimitReachedAdvisoryType = "io.nats.jetstream.advisory.v1.api_limit_reached"
 

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -4603,12 +4603,13 @@ func TestJetStreamSuperClusterGWOfflineSatus(t *testing.T) {
 	c2.shutdown()
 
 	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
-		var ok int
+		// Replicas are populated on every server, not just the meta leader.
 		for _, s := range c.servers {
 			jsz, err := s.Jsz(nil)
 			if err != nil {
 				return err
 			}
+			var ok int
 			for _, r := range jsz.Meta.Replicas {
 				if r.Name == "RS-1" && r.Offline {
 					ok++
@@ -4616,9 +4617,9 @@ func TestJetStreamSuperClusterGWOfflineSatus(t *testing.T) {
 					ok++
 				}
 			}
-		}
-		if ok != 2 {
-			return fmt.Errorf("RS-1 or RS-2 still marked as online")
+			if ok != 2 {
+				return fmt.Errorf("%s: RS-1 or RS-2 still marked as online", s.Name())
+			}
 		}
 		return nil
 	})

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1587,9 +1587,16 @@ func (s *Server) updateJszVarz(js *jetStream, v *JetStreamVarz, doConfig bool) {
 	v.Limits = &s.getOpts().JetStreamLimits
 	if mg := js.getMetaGroup(); mg != nil {
 		if ci := s.raftNodeToClusterInfo(mg); ci != nil {
-			v.Meta = &MetaClusterInfo{Name: ci.Name, Leader: ci.Leader, Peer: getHash(ci.Leader), Size: mg.ClusterSize()}
-			if ci.Leader == s.info.Name {
-				v.Meta.Replicas = ci.Replicas
+			v.Meta = &MetaClusterInfo{
+				Name:         ci.Name,
+				Leader:       ci.Leader,
+				Replicas:     ci.Replicas,
+				Size:         mg.ClusterSize(),
+				QuorumNeeded: mg.QuorumNeeded(),
+				Rescue:       mg.InRescue(),
+			}
+			if ci.Leader != _EMPTY_ {
+				v.Meta.Peer = getHash(ci.Leader)
 			}
 			if ipq := s.jsAPIRoutedReqs; ipq != nil {
 				v.Meta.PendingRequests = ipq.len()
@@ -3092,6 +3099,8 @@ type MetaClusterInfo struct {
 	Peer            string             `json:"peer,omitempty"`     // Peer is unique ID of the leader
 	Replicas        []*PeerInfo        `json:"replicas,omitempty"` // Replicas is a list of known peers
 	Size            int                `json:"cluster_size"`       // Size is the known size of the cluster
+	QuorumNeeded    int                `json:"quorum_needed"`      // QuorumNeeded is this server's current effective quorum size
+	Rescue          bool               `json:"rescue,omitempty"`   // Rescue indicates the quorum is unsafely lowered by an active rescue
 	Pending         int                `json:"pending"`            // Pending is how many RAFT messages are not yet processed
 	PendingRequests int                `json:"pending_requests"`   // PendingRequests is how many CRUD operations are queued for processing
 	PendingInfos    int                `json:"pending_infos"`      // PendingInfos is how many info operations are queued for processing
@@ -3312,9 +3321,16 @@ func (s *Server) Jsz(opts *JSzOptions) (*JSInfo, error) {
 
 	if mg := js.getMetaGroup(); mg != nil {
 		if ci := s.raftNodeToClusterInfo(mg); ci != nil {
-			jsi.Meta = &MetaClusterInfo{Name: ci.Name, Leader: ci.Leader, Peer: getHash(ci.Leader), Size: mg.ClusterSize()}
-			if isLeader {
-				jsi.Meta.Replicas = ci.Replicas
+			jsi.Meta = &MetaClusterInfo{
+				Name:         ci.Name,
+				Leader:       ci.Leader,
+				Replicas:     ci.Replicas,
+				Size:         mg.ClusterSize(),
+				QuorumNeeded: mg.QuorumNeeded(),
+				Rescue:       mg.InRescue(),
+			}
+			if ci.Leader != _EMPTY_ {
+				jsi.Meta.Peer = getHash(ci.Leader)
 			}
 			if ipq := s.jsAPIRoutedReqs; ipq != nil {
 				jsi.Meta.PendingRequests = ipq.len()

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -5620,29 +5620,20 @@ func TestMonitorJsz(t *testing.T) {
 		}
 	})
 	t.Run("cluster-info", func(t *testing.T) {
-		found := 0
-		for i, url := range []string{monUrl1, monUrl2} {
+		for _, url := range []string{monUrl1, monUrl2} {
 			info := readJsInfo(url + "")
 			if info.Meta.Peer != getHash(info.Meta.Leader) {
 				t.Fatalf("Invalid Peer: %+v", info.Meta)
 			}
-			if info.Meta.Replicas != nil {
-				found++
-				for _, r := range info.Meta.Replicas {
-					if r.Peer == _EMPTY_ {
-						t.Fatalf("Replicas' Peer is empty: %+v", r)
-					}
-				}
-				if info.Meta.Leader != srvs[i].Name() {
-					t.Fatalf("received cluster info from non leader: leader %s, server: %s", info.Meta.Leader, srvs[i].Name())
+			// Replicas are populated on every server, not just the meta leader.
+			if len(info.Meta.Replicas) == 0 {
+				t.Fatalf("Expected replicas to be populated: %+v", info.Meta)
+			}
+			for _, r := range info.Meta.Replicas {
+				if r.Peer == _EMPTY_ {
+					t.Fatalf("Replicas' Peer is empty: %+v", r)
 				}
 			}
-		}
-		if found == 0 {
-			t.Fatalf("did not receive cluster info from any node")
-		}
-		if found > 1 {
-			t.Fatalf("received cluster info from multiple nodes")
 		}
 	})
 	t.Run("meta-snapshot-stats", func(t *testing.T) {

--- a/server/raft.go
+++ b/server/raft.go
@@ -73,7 +73,10 @@ type RaftNode interface {
 	MembershipChangeInProgress() bool
 	AdjustClusterSize(csz int) error
 	AdjustBootClusterSize(csz int) error
+	RescueQuorum(qn int) (prev, cur int, err error)
+	InRescue() bool
 	ClusterSize() int
+	QuorumNeeded() int
 	ApplyQ() *ipQueue[*CommittedEntry]
 	PauseApply() error
 	ResumeApply()
@@ -179,6 +182,7 @@ type raft struct {
 	acks    map[uint64]map[string]struct{} // Append entry responses/acks, map of entry index -> peer ID
 	pae     map[uint64]*appendEntry        // Pending append entries
 
+	rescue *time.Timer // Non-nil while an unsafe quorum rescue is active (see RescueQuorum)
 	elect  *time.Timer // Election timer, normally accessed via electTimer
 	etlr   time.Time   // Election timer last reset time, for unit tests only
 	active time.Time   // Last activity time, i.e. for heartbeats
@@ -292,6 +296,7 @@ const (
 	lostQuorumCheckIntervalDefault = hbIntervalDefault * 10 // 10 seconds
 	observerModeIntervalDefault    = 48 * time.Hour
 	peerRemoveTimeoutDefault       = 5 * time.Minute
+	rescueQuorumTimeoutDefault     = 5 * time.Minute
 )
 
 var (
@@ -304,6 +309,7 @@ var (
 	lostQuorumCheck      = lostQuorumCheckIntervalDefault
 	observerModeInterval = observerModeIntervalDefault
 	peerRemoveTimeout    = peerRemoveTimeoutDefault
+	rescueQuorumTimeout  = rescueQuorumTimeoutDefault
 )
 
 type RaftConfig struct {
@@ -343,6 +349,10 @@ var (
 	errSnapInProgress    = errors.New("raft: snapshot is already in progress")
 	errSnapAborted       = errors.New("raft: snapshot was aborted")
 	errCatchupsRunning   = errors.New("raft: snapshot can not be installed while catchups running")
+	errRescueBadQuorum   = errors.New("raft: rescue quorum must be between 1 and current quorum")
+	errRescueLeaderKnown = errors.New("raft: leader is known")
+	errRescueNotVoting   = errors.New("raft: not a voting member")
+	errRescueEmptyLog    = errors.New("raft: log is empty")
 	errSnapshotCorrupt   = errors.New("raft: snapshot corrupt")
 	errTooManyPrefs      = errors.New("raft: stepdown requires at most one preferred new leader")
 	errNoPeerState       = errors.New("raft: no peerstate")
@@ -1097,7 +1107,7 @@ func (n *raft) AdjustBootClusterSize(csz int) error {
 	// Adjust the cluster size and the number of nodes needed to establish
 	// a quorum.
 	n.csz = csz
-	n.qn = n.csz/2 + 1
+	n.recalcQuorum()
 
 	return nil
 }
@@ -1120,10 +1130,95 @@ func (n *raft) AdjustClusterSize(csz int) error {
 	// Adjust the cluster size and the number of nodes needed to establish
 	// a quorum.
 	n.csz = csz
-	n.qn = n.csz/2 + 1
+	n.recalcQuorum()
 
 	n.sendPeerState()
 	return nil
+}
+
+// recalcQuorum recalculates the number of nodes needed to establish quorum.
+// While an unsafe quorum rescue is active (see RescueQuorum) the rescued quorum
+// is kept, unless the natural quorum drops to be equal or below it.
+// Lock should be held.
+func (n *raft) recalcQuorum() {
+	qn := n.csz/2 + 1
+	if n.rescue != nil {
+		if qn > n.qn {
+			return
+		}
+		n.warn("Unsafe quorum rescue stopped, quorum updated to %d", qn)
+		n.rescue.Stop()
+		n.rescue = nil
+	}
+	n.qn = qn
+}
+
+// RescueQuorum unsafely lowers the number of nodes needed to establish quorum.
+// This is a disaster recovery measure for a group that has permanently lost enough
+// peers that it can't elect a leader anymore, allowing the surviving peers to
+// re-form quorum and peer-remove the lost peers.
+func (n *raft) RescueQuorum(qn int) (prev, cur int, err error) {
+	n.Lock()
+	defer n.Unlock()
+
+	prev = n.qn
+	if n.State() == Closed {
+		return prev, 0, errNodeClosed
+	}
+	// The quorum can only be lowered. The current effective quorum is never
+	// larger than the peer set size, so this also bounds qn to the peer set.
+	if qn < 1 || qn > n.qn {
+		return prev, 0, errRescueBadQuorum
+	}
+	// Only allowed if the group is genuinely stuck. We must not know of a
+	// current leader, and must be a voting member that could participate in
+	// an election.
+	if n.leader != noLeader {
+		return prev, 0, errRescueLeaderKnown
+	}
+	if n.observer || n.peers[n.id] == nil {
+		return prev, 0, errRescueNotVoting
+	}
+	// Refuse to rescue a server with an empty log. It could never win an
+	// election against peers with data, but a lowered quorum could let it be
+	// elected off empty votes while the lost peers hold the only copies of
+	// the data. The rescue must be issued on a surviving server with data.
+	// If all servers are empty, this requires a cluster bootstrap.
+	if n.pindex == 0 {
+		return prev, 0, errRescueEmptyLog
+	}
+
+	// Cancel any previous rescue.
+	if n.rescue != nil {
+		n.rescue.Stop()
+	}
+	var t *time.Timer
+	t = time.AfterFunc(rescueQuorumTimeout, func() {
+		n.Lock()
+		defer n.Unlock()
+		// Read of t must be under the lock.
+		n.expireRescueLocked(t)
+	})
+	n.rescue = t
+	n.qn = qn
+	n.warn("Unsafe quorum rescue applied, quorum lowered %d -> %d for %v", prev, qn, rescueQuorumTimeout)
+
+	// Make sure an election can happen soon.
+	n.resetElect(randCampaignTimeout())
+	return prev, qn, nil
+}
+
+// expireRescueLocked runs when the rescue timeout fires and restores the natural quorum.
+// Lock should be held.
+func (n *raft) expireRescueLocked(t *time.Timer) {
+	if n.State() == Closed || n.rescue != t {
+		return
+	}
+	// Must clear the timer first, recalcQuorum keeps the rescued quorum
+	// while it sees an active rescue.
+	n.rescue = nil
+	n.recalcQuorum()
+	n.warn("Unsafe quorum rescue expired, quorum restored to %d", n.qn)
 }
 
 // PauseApply will allow us to pause processing of append entries onto our
@@ -3136,7 +3231,7 @@ func (n *raft) sendMembershipChange(e *Entry) bool {
 			delete(n.peers, peer)
 			n.adjustClusterSizeAndQuorum()
 		}
-		if n.csz == 1 {
+		if n.qn <= 1 {
 			n.tryCommit(n.pindex)
 			return true
 		}
@@ -3751,7 +3846,7 @@ func (n *raft) trackResponse(ar *appendEntryResponse) bool {
 func (n *raft) adjustClusterSizeAndQuorum() {
 	pcsz, ncsz := n.csz, len(n.peers)
 	n.csz = ncsz
-	n.qn = n.csz/2 + 1
+	n.recalcQuorum()
 
 	if ncsz > pcsz {
 		n.debug("Expanding our clustersize: %d -> %d", pcsz, ncsz)
@@ -3852,13 +3947,17 @@ func (n *raft) runAsCandidate() {
 			nterm := n.term
 			csz := n.csz
 			countVote := n.shouldCountVoteFromPeer(vresp.peer)
+			// While an unsafe quorum rescue is active (see RescueQuorum), grants
+			// from empty voters count toward quorum, but only if our own log is
+			// non-empty. Empty servers must never form quorum among themselves.
+			countEmpty := n.rescue != nil && n.pindex > 0
 			n.RUnlock()
 
 			if vresp.granted && nterm == vresp.term {
 				// only track peers that would be our followers
 				n.trackPeer(vresp.peer)
 				if countVote {
-					if !vresp.empty {
+					if !vresp.empty || countEmpty {
 						votes[vresp.peer] = struct{}{}
 					} else {
 						emptyVotes[vresp.peer] = struct{}{}
@@ -4590,7 +4689,7 @@ func (n *raft) processPeerState(ps *peerState) {
 	// Update our version of peers to that of the leader. Calculate
 	// the number of nodes needed to establish a quorum.
 	n.csz = ps.clusterSize
-	n.qn = n.csz/2 + 1
+	n.recalcQuorum()
 
 	old := n.peers
 	n.peers = make(map[string]*lps)
@@ -4787,7 +4886,7 @@ func (n *raft) sendAppendEntryLocked(entries []*Entry, checkLeader bool) error {
 	if !shouldStore {
 		ae.returnToPool()
 	}
-	if n.csz == 1 {
+	if n.qn <= 1 {
 		n.tryCommit(n.pindex)
 	}
 	return nil
@@ -5214,6 +5313,8 @@ func (n *raft) processVoteRequest(vr *voteRequest) error {
 		n.term = vr.term
 		n.vote = noVote
 		n.writeTermVote()
+		// Clear current Leader since it belonged to an old term.
+		n.updateLeader(noLeader)
 	}
 
 	// Only way we get to yes is through here.
@@ -5299,15 +5400,22 @@ func (n *raft) sendReply(subject string, msg []byte) {
 }
 
 func (n *raft) wonElection(votes int) bool {
-	return votes >= n.quorumNeeded()
+	return votes >= n.QuorumNeeded()
 }
 
-// Return the quorum size for a given cluster config.
-func (n *raft) quorumNeeded() int {
+// QuorumNeeded returns the current effective quorum size.
+func (n *raft) QuorumNeeded() int {
 	n.RLock()
 	qn := n.qn
 	n.RUnlock()
 	return qn
+}
+
+// InRescue returns whether an unsafe quorum rescue is currently active.
+func (n *raft) InRescue() bool {
+	n.RLock()
+	defer n.RUnlock()
+	return n.rescue != nil
 }
 
 // leadChange signals a leadership change to the upper layer. The term

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -7407,3 +7407,274 @@ func TestNRGRemovedPeerVoteDoesNotElectLeader(t *testing.T) {
 			nodeD.node().ID(), nodeC.node().ID(), nodeA.node().ID())
 	}
 }
+
+// rescueStoreEntry stores a single entry so the node's log is non-empty, and
+// clears the notion of a leader again so a rescue can be applied.
+func rescueStoreEntry(t *testing.T, n *raft) {
+	t.Helper()
+	nats0 := "S1Nunr6R" // "nats-0"
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+	aeMsg := encode(t, &appendEntry{leader: nats0, term: 1, lterm: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+	n.processAppendEntry(aeMsg, n.aesub)
+	require_Equal(t, n.pindex, 1)
+	n.Lock()
+	n.updateLeader(noLeader)
+	n.Unlock()
+}
+
+func TestNRGRescueQuorum(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	// Pretend to be part of a 5-node group.
+	n.csz, n.qn = 5, 3
+
+	// Invalid quorum sizes, the quorum can only be lowered.
+	_, _, err := n.RescueQuorum(0)
+	require_Error(t, err, errRescueBadQuorum)
+	_, _, err = n.RescueQuorum(4)
+	require_Error(t, err, errRescueBadQuorum)
+
+	// Reject if we know of a current leader.
+	n.leader = nats0
+	_, _, err = n.RescueQuorum(2)
+	require_Error(t, err, errRescueLeaderKnown)
+	n.leader = noLeader
+
+	// Reject if we are not a voting member.
+	n.observer = true
+	_, _, err = n.RescueQuorum(2)
+	require_Error(t, err, errRescueNotVoting)
+	n.observer = false
+
+	lp := n.peers[n.id]
+	delete(n.peers, n.id)
+	_, _, err = n.RescueQuorum(2)
+	require_Error(t, err, errRescueNotVoting)
+	n.peers[n.id] = lp
+
+	// Reject while our own log is still empty.
+	_, _, err = n.RescueQuorum(2)
+	require_Error(t, err, errRescueEmptyLog)
+	rescueStoreEntry(t, n)
+
+	// A quorum equal to the current effective quorum also applies, arming
+	// the rescue without changing the quorum.
+	prev, cur, err := n.RescueQuorum(3)
+	require_NoError(t, err)
+	require_Equal(t, prev, 3)
+	require_Equal(t, cur, 3)
+	require_Equal(t, n.qn, 3)
+	require_True(t, n.rescue != nil)
+
+	// Lower the quorum.
+	prev, cur, err = n.RescueQuorum(2)
+	require_NoError(t, err)
+	require_Equal(t, prev, 3)
+	require_Equal(t, cur, 2)
+	require_Equal(t, n.qn, 2)
+	require_True(t, n.rescue != nil)
+
+	// And lower it further.
+	prev, cur, err = n.RescueQuorum(1)
+	require_NoError(t, err)
+	require_Equal(t, prev, 2)
+	require_Equal(t, cur, 1)
+	require_Equal(t, n.qn, 1)
+	require_True(t, n.rescue != nil)
+
+	// The rescued quorum is now the effective quorum, it can't be raised.
+	_, _, err = n.RescueQuorum(2)
+	require_Error(t, err, errRescueBadQuorum)
+	require_Equal(t, n.qn, 1)
+	n.Lock()
+	n.rescue.Stop()
+	n.rescue = nil
+	n.Unlock()
+}
+
+func TestNRGRescueQuorumRecalc(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	rescueStoreEntry(t, n)
+	n.csz, n.qn = 5, 3
+	_, _, err := n.RescueQuorum(2)
+	require_NoError(t, err)
+
+	// Peer set changes that would recompute quorum above the rescued
+	// value keep the rescued quorum.
+	n.Lock()
+	n.csz = 4
+	n.recalcQuorum()
+	n.Unlock()
+	require_Equal(t, n.qn, 2)
+	require_True(t, n.rescue != nil)
+
+	// Once the natural quorum reaches the rescued value the rescue is
+	// automatically stopped.
+	n.Lock()
+	n.csz = 2
+	n.recalcQuorum()
+	n.Unlock()
+	require_Equal(t, n.qn, 2)
+	require_True(t, n.rescue == nil)
+
+	// With the rescue stopped, quorum recalculation applies as usual.
+	n.Lock()
+	n.csz = 1
+	n.recalcQuorum()
+	n.Unlock()
+	require_Equal(t, n.qn, 1)
+	require_True(t, n.rescue == nil)
+}
+
+func TestNRGRescueQuorumKeptOnPeerState(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	nats0 := "S1Nunr6R" // "nats-0"
+	nats1 := "yrzKKRBu" // "nats-1"
+
+	rescueStoreEntry(t, n)
+	n.csz, n.qn = 3, 2
+	_, _, err := n.RescueQuorum(1)
+	require_NoError(t, err)
+
+	// A peer state update from a newly elected leader must not undo the rescue.
+	n.Lock()
+	n.processPeerState(&peerState{knownPeers: []string{n.id, nats0, nats1}, clusterSize: 3})
+	n.Unlock()
+	require_Equal(t, n.csz, 3)
+	require_Equal(t, n.qn, 1)
+	require_True(t, n.rescue != nil)
+	n.Lock()
+	n.rescue.Stop()
+	n.rescue = nil
+	n.Unlock()
+}
+
+func TestNRGRescueQuorumExpires(t *testing.T) {
+	rescueQuorumTimeout = 100 * time.Millisecond
+	defer func() { rescueQuorumTimeout = rescueQuorumTimeoutDefault }()
+
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	rescueStoreEntry(t, n)
+	n.csz, n.qn = 5, 3
+	_, _, err := n.RescueQuorum(2)
+	require_NoError(t, err)
+	require_Equal(t, n.qn, 2)
+
+	// When the rescue expires the natural quorum is restored.
+	checkFor(t, 2*time.Second, 25*time.Millisecond, func() error {
+		n.RLock()
+		defer n.RUnlock()
+		if n.rescue != nil {
+			return fmt.Errorf("rescue still active")
+		}
+		if n.qn != 3 {
+			return fmt.Errorf("expected quorum restored to 3, got %d", n.qn)
+		}
+		return nil
+	})
+}
+
+func TestNRGRescueQuorumCountsEmptyVotes(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	// Store an entry so our own log is non-empty.
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+	aeMsg := encode(t, &appendEntry{leader: nats0, term: 1, lterm: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+	n.processAppendEntry(aeMsg, n.aesub)
+	require_Equal(t, n.pindex, 1)
+
+	// Pretend to be part of a 5-node group that can't elect a leader anymore,
+	// and rescue the quorum down to 2. The peer must be added first, adding
+	// it adjusts the cluster size to the known peers.
+	n.Lock()
+	n.addPeer(nats0)
+	n.csz, n.qn = 5, 3
+	n.updateLeader(noLeader)
+	n.Unlock()
+	_, cur, err := n.RescueQuorum(2)
+	require_NoError(t, err)
+	require_Equal(t, cur, 2)
+
+	// The other survivor grants its vote, but has an empty log.
+	nc, err := nats.Connect(n.s.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+	sub, err := nc.Subscribe(n.vsubj, func(m *nats.Msg) {
+		req := decodeVoteRequest(m.Data, m.Reply)
+		resp := voteResponse{term: req.term, peer: nats0, granted: true, empty: true}
+		m.Respond(resp.encode())
+	})
+	require_NoError(t, err)
+	defer sub.Drain()
+	require_NoError(t, nc.Flush())
+
+	// During an active rescue an empty grant counts toward quorum for a
+	// candidate with a non-empty log, so we must win the election.
+	n.switchToCandidate()
+	require_Equal(t, n.State(), Candidate)
+	n.runAsCandidate()
+	require_Equal(t, n.State(), Leader)
+
+	n.Lock()
+	n.rescue.Stop()
+	n.rescue = nil
+	n.Unlock()
+}
+
+func TestNRGRescueQuorumEmptyVotesRequireRescue(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	// Store an entry so our own log is non-empty.
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+	aeMsg := encode(t, &appendEntry{leader: nats0, term: 1, lterm: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+	n.processAppendEntry(aeMsg, n.aesub)
+	require_Equal(t, n.pindex, 1)
+
+	// Pretend to be part of a 5-node group with the same lowered quorum as an
+	// active rescue would apply, but without arming the rescue itself. The
+	// peer must be added first, adding it adjusts the cluster size to the
+	// known peers.
+	n.Lock()
+	n.addPeer(nats0)
+	n.csz, n.qn = 5, 2
+	n.updateLeader(noLeader)
+	n.Unlock()
+
+	// The other server grants its vote, but has an empty log.
+	nc, err := nats.Connect(n.s.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer nc.Close()
+	sub, err := nc.Subscribe(n.vsubj, func(m *nats.Msg) {
+		req := decodeVoteRequest(m.Data, m.Reply)
+		resp := voteResponse{term: req.term, peer: nats0, granted: true, empty: true}
+		m.Respond(resp.encode())
+	})
+	require_NoError(t, err)
+	defer sub.Drain()
+	require_NoError(t, nc.Flush())
+
+	// Without an active rescue, empty grants never count toward quorum.
+	// The election times out instead.
+	n.switchToCandidate()
+	require_Equal(t, n.State(), Candidate)
+	n.runAsCandidate()
+	require_NotEqual(t, n.State(), Leader)
+}


### PR DESCRIPTION
Implements ADR: [Reconfiguring the JetStream meta peer set for disaster recovery](https://github.com/nats-io/nats-architecture-and-design/pull/418)

This PR adds a `$JS.API.META.RESCUE` endpoint taking `{"quorum_needed": <number>}` to temporarily lower the number of required servers for quorum. For example: in a 5-node cluster where 3 nodes are dead and won't come back, the cluster is stuck and will not be able to elect a meta leader. The meta rescue command can be used to change quorum to 2 (which automatically expires after 5 minutes). The system is then able to elect a meta leader, allowing the user to peer-remove the dead servers. Once the system detects that the cluster's natural `quorum_needed` arrives at or below the configured rescue `quorum_needed` this "rescue mode" is automatically stopped and the cluster is operational again as normal.

> [!WARNING]
> This is ONLY to be used for disaster recovery where it's impossible for nodes to come back. Using this endpoint allows leader election and commits with fewer acknowledgements than true quorum, which can split-brain a cluster if misused/abused. The intended usage is to request JSZ from the various servers first, which as part of this PR will now report their cluster size, quorum needed, replicas and whether they are in `rescue` mode even if there is no meta leader (replicas was previously limited to just the meta leader). The rescue's `quorum_needed` should then be set equal to the total number of nodes that are still alive or can still come back. It can be set lower if the natural quorum would be lower, but this requires you to be more careful. Blindly sending `quorum_needed: 1` on a system that has 3 alive servers to re-form the meta group can result in split-brain.