### PR TITLE
[FIXED] JetStream: source added to stream with newer data loses backlog

### DIFF
--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -9579,6 +9579,64 @@ func TestJetStreamMirrorBasics(t *testing.T) {
 
 }
 
+func TestJetStreamSourceOptStartTimeIgnoredForNewlyAddedSource(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	checkCount := func(sname string, expected int) {
+		t.Helper()
+		checkFor(t, 5*time.Second, 50*time.Millisecond, func() error {
+			si, err := js.StreamInfo(sname)
+			if err != nil {
+				return err
+			}
+			if n := si.State.Msgs; n != uint64(expected) {
+				return fmt.Errorf("expected stream %q to have %d messages, got %d", sname, expected, n)
+			}
+			return nil
+		})
+	}
+
+	_, err := js.AddStream(&nats.StreamConfig{Name: "OLD_ORIGIN", Subjects: []string{"old"}})
+	require_NoError(t, err)
+
+	before := time.Now()
+	const oldTotal = 5
+	for i := 0; i < oldTotal; i++ {
+		sendStreamMsg(t, nc, "old", "hello")
+	}
+
+	_, err = js.AddStream(&nats.StreamConfig{Name: "NEW_ORIGIN", Subjects: []string{"new"}})
+	require_NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+	const newTotal = 3
+	for i := 0; i < newTotal; i++ {
+		sendStreamMsg(t, nc, "new", "hello")
+	}
+
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:    "DEST",
+		Sources: []*nats.StreamSource{{Name: "NEW_ORIGIN"}},
+	})
+	require_NoError(t, err)
+
+	checkCount("DEST", newTotal)
+
+	_, err = js.UpdateStream(&nats.StreamConfig{
+		Name: "DEST",
+		Sources: []*nats.StreamSource{
+			{Name: "NEW_ORIGIN"},
+			{Name: "OLD_ORIGIN", OptStartTime: &before},
+		},
+	})
+	require_NoError(t, err)
+	checkCount("DEST", newTotal+oldTotal)
+}
+
 func TestJetStreamMirrorStripExpectedHeaders(t *testing.T) {
 	s := RunBasicJetStreamServer(t)
 	defer s.Shutdown()

--- a/server/stream.go
+++ b/server/stream.go
@@ -3977,7 +3977,7 @@ func (mset *stream) trySetupSourceConsumer(iname string, seq uint64, startTime t
 			var state StreamState
 			mset.store.FastState(&state)
 			if ssi.OptStartTime != nil {
-				if !state.LastTime.IsZero() && ssi.OptStartTime.Before(state.LastTime) {
+				if len(mset.cfg.Sources) == 1 && !state.LastTime.IsZero() && ssi.OptStartTime.Before(state.LastTime) {
 					req.Config.OptStartTime = &state.LastTime
 				} else {
 					req.Config.OptStartTime = ssi.OptStartTime


### PR DESCRIPTION
`trySetupSourceConsumer` clamped a configured `OptStartTime` forward to the destination stream's own LastTime whenever no per-source recovered sequence was found. That LastTime is only guaranteed to originate from the source being set up when it is the stream's sole source; for streams with multiple sources, or a source newly added to a stream that already has unrelated data, the clamp silently drops every origin message between the configured start time and that unrelated LastTime.

Scope the clamp to the single-source case, which is the only case where the destination's LastTime can be safely treated as this source's own last known position. This preserves the original duplicate-prevention behavior from #3559 (purge + restart on a single-source stream) while no longer misfiring when a new source is added alongside existing ones.

Resolves #8387

<!-- Please make sure to read CONTRIBUTING.md, then delete this notice and replace it with your PR description. Commit sign-offs certify that the contribution is your original work and that you license the work to the project under the Apache-2.0 license. We cannot accept contributions without it. -->
