### PR TITLE
[FIXED] Clustered consumer create races stream meta apply

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2063,10 +2063,12 @@ type writeableStreamAssignment struct {
 	Consumers  []*writeableConsumerAssignment
 }
 
+// Returns the stream config as registered in the meta layer, from an inflight
+// proposal that has not been applied yet, or from an applied assignment otherwise.
 func (js *jetStream) clusterStreamConfig(accName, streamName string) (StreamConfig, bool) {
 	js.mu.RLock()
 	defer js.mu.RUnlock()
-	if sa, ok := js.cluster.streams[accName][streamName]; ok {
+	if sa := js.streamAssignmentOrInflight(accName, streamName); sa != nil {
 		return *sa.Config, true
 	}
 	return StreamConfig{}, false

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -9024,6 +9024,48 @@ func TestJetStreamClusterConsumerAssignmentsOrInflightSeqWithInflightStream(t *t
 	}
 }
 
+func TestJetStreamClusterStreamConfigConsidersInflight(t *testing.T) {
+	const acc, stream = "A", "S"
+	appliedCfg := &StreamConfig{Name: stream, Replicas: 1}
+	inflightCfg := &StreamConfig{Name: stream, Replicas: 3}
+
+	js := &jetStream{cluster: &jetStreamCluster{}}
+	expectCfg := func(expected *StreamConfig) {
+		t.Helper()
+		cfg, ok := js.clusterStreamConfig(acc, stream)
+		require_Equal(t, ok, expected != nil)
+		if expected != nil {
+			require_True(t, reflect.DeepEqual(cfg, *expected))
+		}
+	}
+
+	// Unknown stream.
+	expectCfg(nil)
+
+	// A stream create that has been proposed but not applied yet must already be
+	// visible, so a consumer create for it that races ahead of the meta apply
+	// loop is not rejected with 'stream not found'.
+	js.cluster.inflightStreams = map[string]map[string]*inflightStreamInfo{
+		acc: {stream: {streamAssignment: &streamAssignment{Config: inflightCfg}}},
+	}
+	expectCfg(inflightCfg)
+
+	// The inflight proposal is more recent than an applied assignment.
+	js.cluster.streams = map[string]map[string]*streamAssignment{
+		acc: {stream: {Config: appliedCfg}},
+	}
+	expectCfg(inflightCfg)
+
+	// An inflight delete means the stream is going away, even if the applied
+	// assignment still exists.
+	js.cluster.inflightStreams[acc][stream].deleted = true
+	expectCfg(nil)
+
+	// Only an applied assignment remains.
+	js.cluster.inflightStreams = nil
+	expectCfg(appliedCfg)
+}
+
 func TestJetStreamClusterApiPagedRequestOffsetValidation(t *testing.T) {
 	test := func(t *testing.T, replicas int) {
 		var s *Server


### PR DESCRIPTION
A stream create immediately followed by a consumer create could fail with a `stream not found`. This can happen if the stream leader applies and answers the stream creation faster than that the meta layer applies it. This PR fixes that by making `clusterStreamConfig` be aware of inflight proposals.