### PR TITLE
Switch `stree` to use strings for prefixes internally

### DIFF
--- a/server/stree/leaf.go
+++ b/server/stree/leaf.go
@@ -13,10 +13,6 @@
 
 package stree
 
-import (
-	"bytes"
-)
-
 // Leaf node
 // Order of struct fields for best memory alignment (as per govet/fieldalignment)
 type leaf[T any] struct {
@@ -24,23 +20,25 @@ type leaf[T any] struct {
 	// This could be the whole subject, but most likely just the suffix portion.
 	// We will only store the suffix here and assume all prior prefix paths have
 	// been checked once we arrive at this leafnode.
-	suffix []byte
+	suffix string
 }
 
 func newLeaf[T any](suffix []byte, value T) *leaf[T] {
-	return &leaf[T]{value, copyBytes(suffix)}
+	return &leaf[T]{value, string(suffix)}
 }
 
-func (n *leaf[T]) isLeaf() bool                               { return true }
-func (n *leaf[T]) base() *meta                                { return nil }
-func (n *leaf[T]) match(subject []byte) bool                  { return bytes.Equal(subject, n.suffix) }
-func (n *leaf[T]) setSuffix(suffix []byte)                    { n.suffix = copyBytes(suffix) }
-func (n *leaf[T]) isFull() bool                               { return true }
-func (n *leaf[T]) matchParts(parts [][]byte) ([][]byte, bool) { return matchParts(parts, n.suffix) }
-func (n *leaf[T]) iter(f func(node) bool)                     {}
-func (n *leaf[T]) children() []node                           { return nil }
-func (n *leaf[T]) numChildren() uint16                        { return 0 }
-func (n *leaf[T]) path() []byte                               { return n.suffix }
+func (n *leaf[T]) isLeaf() bool              { return true }
+func (n *leaf[T]) base() *meta               { return nil }
+func (n *leaf[T]) match(subject []byte) bool { return string(subject) == n.suffix }
+func (n *leaf[T]) setSuffix(suffix []byte)   { n.suffix = string(suffix) }
+func (n *leaf[T]) isFull() bool              { return true }
+func (n *leaf[T]) matchParts(parts [][]byte) ([][]byte, bool) {
+	return matchParts(parts, n.suffix)
+}
+func (n *leaf[T]) iter(f func(node) bool) {}
+func (n *leaf[T]) children() []node       { return nil }
+func (n *leaf[T]) numChildren() uint16    { return 0 }
+func (n *leaf[T]) path() string           { return n.suffix }
 
 // Not applicable to leafs and should not be called, so panic if we do.
 func (n *leaf[T]) setPrefix(pre []byte)    { panic("setPrefix called on leaf") }

--- a/server/stree/node.go
+++ b/server/stree/node.go
@@ -29,11 +29,11 @@ type node interface {
 	iter(f func(node) bool)
 	children() []node
 	numChildren() uint16
-	path() []byte
+	path() string
 }
 
 type meta struct {
-	prefix []byte
+	prefix string
 	size   uint16
 }
 
@@ -41,11 +41,11 @@ func (n *meta) isLeaf() bool { return false }
 func (n *meta) base() *meta  { return n }
 
 func (n *meta) setPrefix(pre []byte) {
-	n.prefix = append([]byte(nil), pre...)
+	n.prefix = string(pre)
 }
 
 func (n *meta) numChildren() uint16 { return n.size }
-func (n *meta) path() []byte        { return n.prefix }
+func (n *meta) path() string        { return n.prefix }
 
 // Will match parts against our prefix.
 func (n *meta) matchParts(parts [][]byte) ([][]byte, bool) {

--- a/server/stree/node10.go
+++ b/server/stree/node10.go
@@ -52,7 +52,8 @@ func (n *node10) findChild(c byte) *node {
 func (n *node10) isFull() bool { return n.size >= 10 }
 
 func (n *node10) grow() node {
-	nn := newNode16(n.prefix)
+	nn := &node16{}
+	nn.prefix = n.prefix
 	for i := 0; i < 10; i++ {
 		nn.addChild(n.key[i], n.child[i])
 	}

--- a/server/stree/node16.go
+++ b/server/stree/node16.go
@@ -50,7 +50,8 @@ func (n *node16) findChild(c byte) *node {
 func (n *node16) isFull() bool { return n.size >= 16 }
 
 func (n *node16) grow() node {
-	nn := newNode48(n.prefix)
+	nn := &node48{}
+	nn.prefix = n.prefix
 	for i := 0; i < 16; i++ {
 		nn.addChild(n.key[i], n.child[i])
 	}

--- a/server/stree/node4.go
+++ b/server/stree/node4.go
@@ -49,7 +49,8 @@ func (n *node4) findChild(c byte) *node {
 func (n *node4) isFull() bool { return n.size >= 4 }
 
 func (n *node4) grow() node {
-	nn := newNode10(n.prefix)
+	nn := &node10{}
+	nn.prefix = n.prefix
 	for i := 0; i < 4; i++ {
 		nn.addChild(n.key[i], n.child[i])
 	}

--- a/server/stree/node48.go
+++ b/server/stree/node48.go
@@ -50,7 +50,8 @@ func (n *node48) findChild(c byte) *node {
 func (n *node48) isFull() bool { return n.size >= 48 }
 
 func (n *node48) grow() node {
-	nn := newNode256(n.prefix)
+	nn := &node256{}
+	nn.prefix = n.prefix
 	for c := 0; c < len(n.key); c++ {
 		if i := n.key[byte(c)]; i > 0 {
 			nn.addChild(byte(c), n.child[i-1])

--- a/server/stree/parts.go
+++ b/server/stree/parts.go
@@ -14,7 +14,7 @@
 package stree
 
 import (
-	"bytes"
+	"strings"
 )
 
 // genParts will break a filter subject up into parts.
@@ -74,8 +74,9 @@ func genParts(filter []byte, parts [][]byte) [][]byte {
 	return parts
 }
 
-// Match our parts against a fragment, which could be prefix for nodes or a suffix for leafs.
-func matchParts(parts [][]byte, frag []byte) ([][]byte, bool) {
+// Match our parts against a stored fragment, which could be a prefix for nodes
+// or a suffix for leaves.
+func matchParts(parts [][]byte, frag string) ([][]byte, bool) {
 	lf := len(frag)
 	if lf == 0 {
 		return parts, true
@@ -92,7 +93,7 @@ func matchParts(parts [][]byte, frag []byte) ([][]byte, bool) {
 		// Check for pwc or fwc place holders.
 		if lp == 1 {
 			if part[0] == pwc {
-				index := bytes.IndexByte(frag[si:], tsep)
+				index := strings.IndexByte(frag[si:], tsep)
 				// We are trying to match pwc and did not find our tsep.
 				// Will need to move to next node from caller.
 				if index < 0 {
@@ -114,7 +115,7 @@ func matchParts(parts [][]byte, frag []byte) ([][]byte, bool) {
 			// Frag is smaller then part itself.
 			part = part[:end-si]
 		}
-		if !bytes.Equal(part, frag[si:end]) {
+		if string(part) != frag[si:end] {
 			return parts, false
 		}
 		// If we still have a portion of the fragment left, update and continue.

--- a/server/stree/stree.go
+++ b/server/stree/stree.go
@@ -16,6 +16,7 @@ package stree
 import (
 	"bytes"
 	"slices"
+	"strings"
 	"unsafe"
 
 	"github.com/nats-io/nats-server/v2/server/gsl"
@@ -87,7 +88,7 @@ func (t *SubjectTree[T]) Find(subject []byte) (*T, bool) {
 		// We are a node type here, grab meta portion.
 		if bn := n.base(); len(bn.prefix) > 0 {
 			end := min(si+len(bn.prefix), len(subject))
-			if !bytes.Equal(subject[si:end], bn.prefix) {
+			if string(subject[si:end]) != bn.prefix {
 				return nil, false
 			}
 			// Increment our subject index.
@@ -181,12 +182,12 @@ func (t *SubjectTree[T]) insert(np *node, subject []byte, value T, si int) (*T, 
 			return &old, true
 		}
 		// Here we need to split this leaf.
-		cpi := commonPrefixLen(ln.suffix, subject[si:])
+		cpi := commonPrefixLen(stringToBytes(ln.suffix), subject[si:])
 		nn := newNode4(subject[si : si+cpi])
-		ln.setSuffix(ln.suffix[cpi:])
+		ln.setSuffix(stringToBytes(ln.suffix[cpi:]))
 		si += cpi
 		// Make sure we have different pivot, normally this will be the case unless we have overflowing prefixes.
-		if p := pivot(ln.suffix, 0); cpi > 0 && si < len(subject) && p == subject[si] {
+		if p := pivot(stringToBytes(ln.suffix), 0); cpi > 0 && si < len(subject) && p == subject[si] {
 			// We need to split the original leaf. Recursively call into insert.
 			t.insert(np, subject, value, si)
 			// Now add the update version of *np as a child to the new node4.
@@ -194,9 +195,9 @@ func (t *SubjectTree[T]) insert(np *node, subject []byte, value T, si int) (*T, 
 		} else {
 			// Can just add this new leaf as a sibling.
 			nl := newLeaf(subject[si:], value)
-			nn.addChild(pivot(nl.suffix, 0), nl)
+			nn.addChild(pivot(stringToBytes(nl.suffix), 0), nl)
 			// Add back original.
-			nn.addChild(pivot(ln.suffix, 0), ln)
+			nn.addChild(pivot(stringToBytes(ln.suffix), 0), ln)
 		}
 		*np = nn
 		return nil, false
@@ -205,7 +206,7 @@ func (t *SubjectTree[T]) insert(np *node, subject []byte, value T, si int) (*T, 
 	// Non-leaf nodes.
 	bn := n.base()
 	if len(bn.prefix) > 0 {
-		cpi := commonPrefixLen(bn.prefix, subject[si:])
+		cpi := commonPrefixLen(stringToBytes(bn.prefix), subject[si:])
 		if pli := len(bn.prefix); cpi >= pli {
 			// Move past this node. We look for an existing child node to recurse into.
 			// If one does not exist we can create a new leaf node.
@@ -227,8 +228,8 @@ func (t *SubjectTree[T]) insert(np *node, subject []byte, value T, si int) (*T, 
 			// We will insert a new node4 and attach our current node below after adjusting prefix.
 			nn := newNode4(prefix)
 			// Shift the prefix for our original node.
-			n.setPrefix(bn.prefix[cpi:])
-			nn.addChild(pivot(bn.prefix[:], 0), n)
+			n.setPrefix(stringToBytes(bn.prefix[cpi:]))
+			nn.addChild(pivot(stringToBytes(bn.prefix), 0), n)
 			// Add in our new leaf.
 			nn.addChild(pivot(subject[si:], 0), newLeaf(subject[si:], value))
 			// Update our node reference.
@@ -269,7 +270,7 @@ func (t *SubjectTree[T]) delete(np *node, subject []byte, si int) (*T, bool) {
 		if len(subject) < si+len(bn.prefix) {
 			return nil, false
 		}
-		if !bytes.Equal(subject[si:si+len(bn.prefix)], bn.prefix) {
+		if string(subject[si:si+len(bn.prefix)]) != bn.prefix {
 			return nil, false
 		}
 		// Increment our subject index.
@@ -288,18 +289,16 @@ func (t *SubjectTree[T]) delete(np *node, subject []byte, si int) (*T, bool) {
 
 			if sn := n.shrink(); sn != nil {
 				bn := n.base()
-				// Make sure to set cap so we force an append to copy below.
-				pre := bn.prefix[:len(bn.prefix):len(bn.prefix)]
+				pre := bn.prefix
 				// Need to fix up prefixes/suffixes.
 				if sn.isLeaf() {
 					ln := sn.(*leaf[T])
-					// Make sure to set cap so we force an append to copy.
-					ln.suffix = append(pre, ln.suffix...)
+					ln.suffix = pre + ln.suffix
 				} else {
 					// We are a node here, we need to add in the old prefix.
 					if len(pre) > 0 {
 						bsn := sn.base()
-						sn.setPrefix(append(pre, bsn.prefix...))
+						bsn.prefix = pre + bsn.prefix
 					}
 				}
 				*np = sn
@@ -367,7 +366,7 @@ func (t *SubjectTree[T]) match(n node, parts [][]byte, pre []byte, cb func(subje
 						if !cb(append(pre, ln.suffix...), &ln.value) {
 							return false
 						}
-					} else if hasTermPWC && bytes.IndexByte(ln.suffix, tsep) < 0 {
+					} else if hasTermPWC && strings.IndexByte(ln.suffix, tsep) < 0 {
 						if !cb(append(pre, ln.suffix...), &ln.value) {
 							return false
 						}
@@ -446,7 +445,7 @@ func (t *SubjectTree[T]) iter(n node, pre []byte, ordered bool, cb func(subject 
 		}
 	}
 	// Now sort.
-	slices.SortStableFunc(nodes, func(a, b node) int { return bytes.Compare(a.path(), b.path()) })
+	slices.SortStableFunc(nodes, func(a, b node) int { return strings.Compare(a.path(), b.path()) })
 	// Now walk the nodes in order and call into next iter.
 	for i := range nodes {
 		if !t.iter(nodes[i], pre, true, cb) {
@@ -540,4 +539,14 @@ func bytesToString(b []byte) string {
 	}
 	p := unsafe.SliceData(b)
 	return unsafe.String(p, len(b))
+}
+
+// Note this will avoid a copy of the string data, but the returned slice must
+// only be used for reading since strings are immutable.
+func stringToBytes(s string) []byte {
+	if len(s) == 0 {
+		return nil
+	}
+	p := unsafe.StringData(s)
+	return unsafe.Slice(p, len(s))
 }

--- a/server/stree/stree_test.go
+++ b/server/stree/stree_test.go
@@ -19,6 +19,8 @@ import (
 	"flag"
 	"fmt"
 	"math/rand"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -794,6 +796,86 @@ func TestSubjectTreeIterPerf(t *testing.T) {
 		return true
 	})
 	t.Logf("Iter took %s and matched %d entries", time.Since(start), count)
+}
+
+func TestSubjectTreeMemoryPerf(t *testing.T) {
+	if !*runResults {
+		t.Skip()
+	}
+
+	const entries = 250_000
+	subjects := make([][]byte, entries)
+	for i := range subjects {
+		subjects[i] = []byte("account." + strconv.Itoa(i%1000) + ".stream." + strconv.Itoa(i))
+	}
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	start := time.Now()
+	st := NewSubjectTree[int]()
+	for i, subject := range subjects {
+		st.Insert(subject, i)
+	}
+	buildTime := time.Since(start)
+
+	runtime.GC()
+	runtime.KeepAlive(st)
+	runtime.ReadMemStats(&after)
+
+	const lookupRounds = 8
+	start = time.Now()
+	found := 0
+	for range lookupRounds {
+		for _, subject := range subjects {
+			if _, ok := st.Find(subject); ok {
+				found++
+			}
+		}
+	}
+	findTime := time.Since(start)
+
+	const traversalRounds = 20
+	start = time.Now()
+	iterated := 0
+	for range traversalRounds {
+		st.IterFast(func(_ []byte, _ *int) bool {
+			iterated++
+			return true
+		})
+	}
+	iterTime := time.Since(start)
+
+	filter := []byte("account.*.stream.>")
+	start = time.Now()
+	matched := 0
+	for range traversalRounds {
+		st.Match(filter, func(_ []byte, _ *int) {
+			matched++
+		})
+	}
+	matchTime := time.Since(start)
+
+	iterAllocs := testing.AllocsPerRun(20, func() {
+		st.IterFast(func(_ []byte, _ *int) bool { return true })
+	})
+	matchAllocs := testing.AllocsPerRun(20, func() {
+		st.Match(filter, func(_ []byte, _ *int) {})
+	})
+
+	t.Logf("Build took %s for %d entries, allocated %d bytes total and retained %d heap bytes across %d allocations",
+		buildTime, st.Size(), after.TotalAlloc-before.TotalAlloc,
+		after.HeapAlloc-before.HeapAlloc, after.Mallocs-before.Mallocs)
+	t.Logf("Find took %s for %d lookups and found %d entries",
+		findTime, entries*lookupRounds, found)
+	t.Logf("IterFast took %s for %d entries with %.0f allocations per traversal",
+		iterTime, iterated, iterAllocs)
+	t.Logf("Match took %s for %d entries with %.0f allocations per traversal",
+		matchTime, matched, matchAllocs)
+
+	runtime.KeepAlive(subjects)
+	runtime.KeepAlive(st)
 }
 
 func TestSubjectTreeNode48(t *testing.T) {
@@ -1953,7 +2035,7 @@ func TestMatchPartsEdgeCases(t *testing.T) {
 
 	// Test with a fragment that will cause partial matching
 	frag := b("foo.test")
-	remaining, matched := matchParts(parts, frag)
+	remaining, matched := matchParts(parts, string(frag))
 	require_True(t, matched)
 	require_True(t, len(remaining) > 0)
 }
@@ -2093,7 +2175,7 @@ func TestMatchPartsMoreEdgeCases(t *testing.T) {
 	// Test the remaining 2.6% of matchParts
 	// Case where frag is empty
 	parts := genParts(b("foo.*"), nil)
-	remaining, matched := matchParts(parts, b(""))
+	remaining, matched := matchParts(parts, "")
 	require_True(t, matched)
 	require_Equal(t, len(remaining), len(parts))
 }

--- a/server/stree/util.go
+++ b/server/stree/util.go
@@ -32,16 +32,6 @@ func commonPrefixLen(s1, s2 []byte) int {
 	return i
 }
 
-// Helper to copy bytes.
-func copyBytes(src []byte) []byte {
-	if len(src) == 0 {
-		return nil
-	}
-	dst := make([]byte, len(src))
-	copy(dst, src)
-	return dst
-}
-
 type position interface{ int | uint16 }
 
 // No pivot available.


### PR DESCRIPTION
In Go, `[]byte` headers are 24 bytes, whereas `string` headers are only 16 bytes. We don't generally care about slice capacity in the context of prefixes as we are always managing the copies ourselves, so using native strings can save us some memory per subject.

The included benchmark builds a tree containing 250,000 subjects shaped as:

```text
account.<0-999>.stream.<sequence>
```

Average results across a few runs vs `main`:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Retained heap | 17.86 MB | 14.73 MB | **−17.5%** |
| Total allocation while building | 20.87 MB | 17.28 MB | **−17.2%** |
| Construction allocations | 699,978 | 623,430 | **−10.9%** |
| Find, 2 million lookups | 141.71 ms | 142.24 ms | +0.4% |
| `IterFast`, 5 million entries | 39.21 ms | 38.67 ms | −1.4% |
| Match, 5 million entries | 69.24 ms | 68.72 ms | −0.8% |