### PR TITLE
[FIXED] MQTT: QoS2 message released on a resumed session lost its QoS and PI

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -72,6 +72,7 @@ const (
 	mqttPubFlagRetain = byte(0x01)
 	mqttPubFlagQoS    = byte(0x06)
 	mqttPubFlagDup    = byte(0x08)
+	mqttPubFlags      = mqttPubFlagRetain | mqttPubFlagQoS | mqttPubFlagDup // 0x0f, the fixed-header flags nibble
 	mqttPubQos1       = byte(0x1 << 1)
 	mqttPubQoS2       = byte(0x2 << 1)
 
@@ -482,6 +483,13 @@ const (
 	// NATS header that indicates that the message originated from MQTT and
 	// stores the published message QOS.
 	mqttNatsHeader = "Nmqtt-Pub"
+	// A staged QoS2 message's mqttNatsHeader value carries a second byte after
+	// the QoS: the MQTT PUBLISH flags nibble (mqttPubFlags) as one hex char,
+	// e.g. "25" for a retained QoS2 message (0x5 = retain|QoS2). The value is a
+	// persisted, cross-version contract: byte 0 stays the bare QoS forever
+	// (older servers read only it), a missing flags byte reads as no flags, and
+	// extensions may only append bytes (a second hex char = a full private
+	// byte), never change the meaning of existing ones.
 
 	// NATS headers to store retained message metadata (along with the original
 	// message as binary).
@@ -500,9 +508,10 @@ const (
 )
 
 type mqttParsedPublishNATSHeader struct {
-	qos     byte
-	subject []byte
-	mapped  []byte
+	qos      byte
+	retained bool
+	subject  []byte
+	mapped   []byte
 }
 
 func (s *Server) startMQTT() {
@@ -1134,6 +1143,28 @@ func (s *Server) mqttStoreQoSMsgForAccountOnNewSubject(hdr int, msg []byte, acc,
 	jsa.storeMsg(mqttStreamSubjectPrefix+subject, hdr, msg)
 }
 
+// Encodes the MQTT PUBLISH flags nibble (mqttPubFlags) as one hex char, the
+// flags byte that follows the QoS in a mqttNatsHeader value.
+func mqttNatsHeaderEncodeFlags(ppFlags byte) byte {
+	return "0123456789abcdef"[ppFlags&mqttPubFlags]
+}
+
+// Decodes the MQTT flags nibble carried after the QoS in a mqttNatsHeader
+// value; values without the flags byte read as no flags set. Callers test the
+// result with the mqttPubFlag* bits.
+func mqttNatsHeaderDecodeFlags(value []byte) byte {
+	if len(value) < 2 {
+		return 0
+	}
+	switch c := value[1]; {
+	case c >= '0' && c <= '9':
+		return c - '0'
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10
+	}
+	return 0
+}
+
 func mqttParsePublishNATSHeader(headerBytes []byte) *mqttParsedPublishNATSHeader {
 	if len(headerBytes) == 0 {
 		return nil
@@ -1144,9 +1175,10 @@ func mqttParsePublishNATSHeader(headerBytes []byte) *mqttParsedPublishNATSHeader
 		return nil
 	}
 	return &mqttParsedPublishNATSHeader{
-		qos:     pubValue[0] - '0',
-		subject: getHeader(mqttNatsHeaderSubject, headerBytes),
-		mapped:  getHeader(mqttNatsHeaderMapped, headerBytes),
+		qos:      pubValue[0] - '0',
+		retained: mqttIsRetained(mqttNatsHeaderDecodeFlags(pubValue)),
+		subject:  getHeader(mqttNatsHeaderSubject, headerBytes),
+		mapped:   getHeader(mqttNatsHeaderMapped, headerBytes),
 	}
 }
 
@@ -4080,14 +4112,16 @@ func (s *Server) mqttHandleWill(c *client) {
 		c.mu.Unlock()
 		return
 	}
-	pp := c.mqtt.pp
-	pp.topic = will.topic
-	pp.subject = will.subject
-	pp.mapped = will.mapped
-	pp.msg = will.message
-	pp.sz = len(will.message)
-	pp.pi = 0
-	pp.flags = will.qos << 1
+	// Create a synthetic PUBLISH packet to be delivered to the session's
+	// subscriptions, regardless of what is currently in c.mqtt.pp.
+	pp := &mqttPublish{
+		topic:   will.topic,
+		subject: will.subject,
+		mapped:  will.mapped,
+		msg:     will.message,
+		sz:      len(will.message),
+		flags:   will.qos << 1,
+	}
 	if will.retain {
 		pp.flags |= mqttPubFlagRetain
 	}
@@ -4227,6 +4261,7 @@ func mqttComputeNatsMsgSize(pp *mqttPublish, encodePP bool) int {
 		2 + // end-of-header CRLF
 		pp.sz
 	if encodePP {
+		size++                                   // for the flags byte
 		size += len(mqttNatsHeaderSubject) + 1 + // +1 for ':'
 			len(pp.subject) + 2 // 2 for CRLF
 
@@ -4258,6 +4293,9 @@ func mqttNewDeliverableMessage(pp *mqttPublish, encodePP bool) (natsMsg []byte, 
 	buf.WriteString(mqttNatsHeader)
 	buf.WriteByte(':')
 	buf.WriteByte(qos + '0')
+	if encodePP {
+		buf.WriteByte(mqttNatsHeaderEncodeFlags(pp.flags))
+	}
 	buf.WriteString(_CRLF_)
 
 	if encodePP {
@@ -4360,7 +4398,13 @@ func (s *Server) mqttProcessPub(c *client, pp *mqttPublish, trace bool) error {
 func (s *Server) mqttInitiateMsgDelivery(c *client, pp *mqttPublish) error {
 	natsMsg, headerLen := mqttNewDeliverableMessage(pp, false)
 
-	// Set the client's pubarg for processing.
+	// The delivered message becomes the client's current publish (it is not
+	// the last PARSED packet for a PUBREL- or will-initiated delivery), and
+	// c.pa carries its pubargs; one defer restores both. c.mqtt.pp is
+	// readLoop-owned, like c.pa.
+	prevPP := c.mqtt.pp
+	c.mqtt.pp = pp
+
 	c.pa.subject = pp.subject
 	c.pa.mapped = pp.mapped
 	c.pa.reply = nil
@@ -4369,6 +4413,7 @@ func (s *Server) mqttInitiateMsgDelivery(c *client, pp *mqttPublish) error {
 	c.pa.size = len(natsMsg)
 	c.pa.szb = []byte(strconv.FormatInt(int64(c.pa.size), 10))
 	defer func() {
+		c.mqtt.pp = prevPP
 		c.pa.subject = nil
 		c.pa.mapped = nil
 		c.pa.reply = nil
@@ -4456,6 +4501,10 @@ func (s *Server) mqttProcessPubRel(c *client, pi uint16, trace bool) error {
 		return errors.New("invalid message in QoS2 PUBREL stream")
 	}
 
+	flags := h.qos << 1
+	if h.retained {
+		flags |= mqttPubFlagRetain
+	}
 	pp := &mqttPublish{
 		topic:   natsSubjectToMQTTTopic(h.subject),
 		subject: h.subject,
@@ -4463,7 +4512,7 @@ func (s *Server) mqttProcessPubRel(c *client, pi uint16, trace bool) error {
 		msg:     stored.Data,
 		sz:      len(stored.Data),
 		pi:      pi,
-		flags:   h.qos << 1,
+		flags:   flags,
 	}
 
 	return s.mqttInitiateMsgDelivery(c, pp)

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -2495,6 +2495,48 @@ func TestMQTTParsePub(t *testing.T) {
 	}
 }
 
+func TestMQTTNatsHeaderFlags(t *testing.T) {
+	// Round-trip every MQTT flags nibble through the header byte.
+	for flags := byte(0); flags <= mqttPubFlags; flags++ {
+		enc := mqttNatsHeaderEncodeFlags(flags)
+		if enc < '0' || (enc > '9' && enc < 'a') || enc > 'f' {
+			t.Fatalf("flags 0x%x encoded to non-hex byte %q", flags, enc)
+		}
+		// Decode reads value[1]; value[0] is the (irrelevant here) QoS char.
+		if got := mqttNatsHeaderDecodeFlags([]byte{'0', enc}); got != flags {
+			t.Fatalf("flags 0x%x: round-trip got 0x%x", flags, got)
+		}
+	}
+
+	// Bits above the nibble (e.g. a stray high bit) are not encoded.
+	if enc := mqttNatsHeaderEncodeFlags(0xf0 | mqttPubFlagRetain); enc != '1' {
+		t.Fatalf("high bits leaked into flags byte: %q", enc)
+	}
+
+	// Named examples, including the "25" from the header contract comment.
+	for _, test := range []struct {
+		flags byte
+		enc   byte
+	}{
+		{0, '0'},
+		{mqttPubFlagRetain, '1'},
+		{mqttPubQoS2 | mqttPubFlagRetain, '5'},
+		{mqttPubFlags, 'f'},
+	} {
+		if enc := mqttNatsHeaderEncodeFlags(test.flags); enc != test.enc {
+			t.Fatalf("flags 0x%x encoded to %q, want %q", test.flags, enc, test.enc)
+		}
+	}
+
+	// Cross-version contract: a value with no flags byte (older sender) reads
+	// as no flags set, never a panic.
+	for _, value := range [][]byte{nil, {}, {'2'}} {
+		if got := mqttNatsHeaderDecodeFlags(value); got != 0 {
+			t.Fatalf("value %q: want no flags, got 0x%x", value, got)
+		}
+	}
+}
+
 func TestMQTTParsePIMsg(t *testing.T) {
 	for _, test := range []struct {
 		name  string
@@ -9900,4 +9942,67 @@ func BenchmarkMQTT_QoS1_PubSub2_256b_Payload(b *testing.B) {
 
 func BenchmarkMQTT_QoS1_PubSub2___1K_Payload(b *testing.B) {
 	mqttBenchPubQoS1(b, mqttPubSubj, sizedString(1024), 2)
+}
+
+// A PUBREL arriving on a different connection than its PUBLISH (session
+// resumed after a reconnect) has no staged in-memory copy and must fall
+// back to loading the message from JetStream, still delivering it exactly
+// once and completing the exchange.
+func TestMQTTQoS2PubRelResumedSessionDelivery(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	mcs, msr := testMQTTConnect(t, &mqttConnInfo{clientID: "sub", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	defer mcs.Close()
+	testMQTTCheckConnAck(t, msr, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, mcs, msr, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTFlush(t, mcs, nil, msr)
+
+	// Publish QoS2 retained and PUBREC it, then drop before the PUBREL.
+	const pubPI = 7
+	ci := &mqttConnInfo{clientID: "pub", cleanSess: false}
+	mcp, mpr := testMQTTConnect(t, ci, o.MQTT.Host, o.MQTT.Port)
+	testMQTTCheckConnAck(t, mpr, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSendPublishPacket(t, mcp, 2, false, true, "foo", pubPI, []byte("m"))
+	testMQTTReadPIPacket(mqttPacketPubRec, t, mpr, pubPI)
+	testMQTTDisconnect(t, mcp, nil)
+	mcp.Close()
+	testMQTTExpectNothing(t, msr)
+
+	// Resume the session; the PUBREL now delivers the message, at the sub's QoS.
+	mcp2, mpr2 := testMQTTConnect(t, ci, o.MQTT.Host, o.MQTT.Port)
+	defer mcp2.Close()
+	testMQTTCheckConnAck(t, mpr2, mqttConnAckRCConnectionAccepted, true)
+	testMQTTSendPIPacket(mqttPacketPubRel|0x2, t, mcp2, pubPI)
+	testMQTTReadPIPacket(mqttPacketPubComp, t, mpr2, pubPI)
+	testMQTTCheckPubMsgNoAck(t, mcs, msr, "foo", mqttPubQos1, []byte("m"))
+	testMQTTExpectNothing(t, msr)
+
+	// A repeated PUBREL is acked without redelivering.
+	testMQTTSendPIPacket(mqttPacketPubRel|0x2, t, mcp2, pubPI)
+	testMQTTReadPIPacket(mqttPacketPubComp, t, mpr2, pubPI)
+	testMQTTExpectNothing(t, msr)
+
+	// The retain flag must survive the staging round-trip: a new
+	// subscriber gets the message as retained.
+	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+		acc, err := s.lookupAccount(globalAccountName)
+		if err != nil {
+			return err
+		}
+		mset, err := acc.lookupStream(mqttRetainedMsgsStreamName)
+		if err != nil {
+			return err
+		}
+		if mset.state().Msgs != 1 {
+			return errors.New("retained message not stored")
+		}
+		return nil
+	})
+	mcs2, msr2 := testMQTTConnect(t, &mqttConnInfo{clientID: "sub2", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	defer mcs2.Close()
+	testMQTTCheckConnAck(t, msr2, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, mcs2, msr2, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTCheckPubMsgNoAck(t, mcs2, msr2, "foo", mqttPubQos1|mqttPubFlagRetain, []byte("m"))
 }


### PR DESCRIPTION
This came up while testing with https://github.com/ConnectEverything/mqtt-test/pull/4

Two root causes. The delivery callbacks and the retain handling read the publishing connection's c.mqtt.pp — the last PUBLISH parsed — which is stale for a PUBREL- or will-initiated delivery, so a QoS2 message released after a reconnect was delivered as QoS0 with no packet identifier. And the staged copy in $MQTT_qos2in never persisted the retain flag, so it could not be recovered on another connection at all. Same-connection flows worked only while the scratch happened to still hold the right packet. Because of the interplay, the two must be fixed together.

The delivered message now becomes the client's current publish for the duration of the broadcast (swapped into the readLoop-owned c.mqtt.pp, restored by the same defer as the pubargs); wills build their own mqttPublish and use the common path instead of writing into the scratch by hand. The staged copy
persists the retain flag in a second, flags byte of the Nmqtt-Pub header value, restored when the PUBREL rebuilds the publish; older servers read only the first (QoS) byte, and messages without a flags byte read as not retained.

Retained QoS2 messages now survive an in-flight reconnect: a PUBLISH staged on one connection and released by the PUBREL on the next stores the retained message, where before the retain bit died with the first connection's parser state. This matches Spec [MQTT-4.3.3] Method A as implemented by mosquitto, which likewise persists the retain flag with the staged message and applies it at release, together with the delivery.

Added regression tests: a PUBREL on a resumed session delivers at the subscription's QoS exactly once, a retransmitted PUBREL is acknowledged without redelivering, and the retain flag survives the staging round trip.