### PR TITLE
(2.15) [IMPROVED] MQTT: Pipeline QoS2 PUBLISH and PUBREL processing

### DIFF
--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -430,7 +430,8 @@ type mqtt struct {
 	// PUBCOMP instead [MQTT-4.3.3-1]. A new PUBLISH always replaces a released
 	// entry (a new publication per the spec, kept or not); otherwise released
 	// entries last the connection - the discard is fire-and-forget, there is no
-	// safe moment to drop them.
+	// safe moment to drop them. Worst case is one nil entry per packet
+	// identifier, 65535 map entries per connection.
 	qos2Exchanges map[uint16]*mqttPublish
 
 	// Not all entries in qos2Exchanges represent pending PUBLISH, so a separate
@@ -4905,6 +4906,8 @@ func (c *client) mqttRecordQoS2Publish(pp *mqttPublish) {
 		return
 	}
 
+	// Defense in depth: in practice the pipeline window (same size) fills
+	// and blocks the readLoop before the count can get here.
 	if c.mqtt.qos2PendingCount >= mqttMaxAcksInFlight {
 		return
 	}

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -4887,9 +4887,7 @@ func (c *client) mqttQoS2InternalSubject(pi uint16) string {
 // released PI - kept or not - is a new publication [MQTT-4.3.3-1].
 // readLoop only.
 func (c *client) mqttRecordQoS2Publish(pp *mqttPublish) {
-	if c.mqtt.qos2Exchanges == nil {
-		c.mqtt.qos2Exchanges = make(map[uint16]*mqttPublish)
-	} else if prev, ok := c.mqtt.qos2Exchanges[pp.pi]; ok {
+	if prev, ok := c.mqtt.qos2Exchanges[pp.pi]; ok {
 		if prev != nil {
 			// A duplicate PUBLISH: keep the first copy, as the JetStream
 			// stage does (max-msgs-per-subject), so both deliver the same
@@ -4897,8 +4895,14 @@ func (c *client) mqttRecordQoS2Publish(pp *mqttPublish) {
 			return
 		}
 
-		// Released: a new publication. Drop the nil entry.
+		// Released: a new publication, DUP or not [MQTT-4.3.3-1]. Drop the
+		// nil entry.
 		delete(c.mqtt.qos2Exchanges, pp.pi)
+	} else if pp.flags&mqttPubFlagDup != 0 {
+		// A DUP retransmit unknown here may duplicate a stage from a
+		// previous connection; only JetStream knows which bytes were
+		// accepted first, so leave the PUBREL to load them.
+		return
 	}
 
 	if c.mqtt.qos2PendingCount >= mqttMaxAcksInFlight {
@@ -4909,6 +4913,10 @@ func (c *client) mqttRecordQoS2Publish(pp *mqttPublish) {
 	cp.subject = append([]byte(nil), pp.subject...)
 	cp.mapped = append([]byte(nil), pp.mapped...)
 	cp.msg = append([]byte(nil), pp.msg...)
+
+	if c.mqtt.qos2Exchanges == nil {
+		c.mqtt.qos2Exchanges = make(map[uint16]*mqttPublish)
+	}
 	c.mqtt.qos2Exchanges[pp.pi] = &cp
 	c.mqtt.qos2PendingCount++
 }

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -407,9 +407,36 @@ type mqtt struct {
 	sess *mqttSession               // quick reference to session, immutable after processConnect()
 	cid  string                     // client ID
 
-	// Pipelines the PUBACKs of inbound QoS1 PUBLISH messages. Owned by the
-	// readLoop goroutine, no lock.
+	// Pipelines the acknowledgments (PUBACK/PUBREC/PUBCOMP) of inbound
+	// QoS1/QoS2 packets. No locking needed inside the read loop.
 	acks *mqttAckPipeline
+
+	// qos2Exchanges tracks this connection's QoS2 exchanges by packet
+	// identifier. With async submission we can no longer use JetStream as the
+	// source of truth while a store or discard is in flight, so this map keeps
+	// what dedup needs; JetStream stays the long-term source of truth - a
+	// PUBREL that misses here falls back to the load, as the synchronous code
+	// did. read-loop-owned, no locking.
+	//
+	// A non-nil value is a copy of a pending PUBLISH, staged store to PUBREL:
+	// duplicate PUBLISHes dedupe against it (first copy wins, like the stream's
+	// max-msgs-per-subject), and the delivery on PUBREL needs no re-load.
+	// Copies are bounded by mqttMaxAcksInFlight (qos2PendingCount); extras are
+	// not kept.
+	//
+	// A nil value marks a released exchange whose staged-copy discard is still
+	// in flight: the discard too is asynchronous, so a load could still see the
+	// copy and deliver a duplicate - a retransmitted PUBREL gets just its
+	// PUBCOMP instead [MQTT-4.3.3-1]. A new PUBLISH always replaces a released
+	// entry (a new publication per the spec, kept or not); otherwise released
+	// entries last the connection - the discard is fire-and-forget, there is no
+	// safe moment to drop them.
+	qos2Exchanges map[uint16]*mqttPublish
+
+	// Not all entries in qos2Exchanges represent pending PUBLISH, so a separate
+	// count for the max inflight check. mqttRecordQoS2Publish increments per
+	// copy kept; mqttMarkQoS2Released decrements per copy overwritten with nil.
+	qos2PendingCount int
 
 	// rejectQoS2Pub tells the MQTT client to not accept QoS2 PUBLISH, instead
 	// error and terminate the connection.
@@ -1051,7 +1078,7 @@ func (s *Server) mqttHandleClosedClient(c *client) {
 	c.mu.Unlock()
 
 	// Dropping pending entries is safe: the client re-sends unacknowledged
-	// PUBLISH packets on reconnect, Spec [MQTT-4.4.0-1].
+	// PUBLISH and PUBREL packets on reconnect, Spec [MQTT-4.4.0-1].
 	if pipe := c.mqtt.acks; pipe != nil {
 		pipe.shutdown()
 	}
@@ -2034,6 +2061,18 @@ func (jsa *mqttJSA) deleteMsg(stream string, seq uint64, wait bool) error {
 	}
 	dm := dmi.(*JSApiMsgDeleteResponse)
 	return dm.ToError()
+}
+
+// Deletes the message held on the subject (at most one:
+// max-msgs-per-subject=1), without needing its stream sequence.
+// Fire-and-forget, like the unwaited deleteMsg. Implemented as a JS API
+// subject purge.
+func (jsa *mqttJSA) deleteMsgBySubject(stream string, subject string) {
+	req, _ := json.Marshal(&JSApiStreamPurgeRequest{Subject: subject})
+	jsa.sendq.push(&mqttJSPubMsg{
+		subj: jsa.prefixDomain(fmt.Sprintf(JSApiStreamPurgeT, stream)),
+		msg:  req,
+	})
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -4486,11 +4525,18 @@ func (s *Server) mqttProcessPub(c *client, pp *mqttPublish, trace bool) error {
 		// Message before sending the PUBREC or PUBCOMP. When its original
 		// sender receives the PUBREC packet, ownership of the Application
 		// Message is transferred to the receiver.
-		err := s.mqttStoreQoS2MsgOnce(c, pp)
-		if err == nil {
-			c.mqttEnqueuePubResponse(mqttPacketPubRec, pp.pi, trace)
-		}
-		return err
+		//
+		// The first of QoS2's two async JS interactions (see qos2Exchanges):
+		// stage the message as "$MQTT.qos2.<client-id>.<PI>" - no
+		// broadcast until the sender releases it - with the original
+		// subject in the NATS header, and keep a copy so the delivery on
+		// PUBREL needs no re-load. A duplicate PUBLISH's store is a no-op
+		// (see exceptDuplicateError) but still gets its PUBREC, from the
+		// pipeline, in packet order.
+		natsMsg, headerLen := mqttNewDeliverableMessage(pp, true)
+		c.mqttRecordQoS2Publish(pp)
+		return s.mqttPipelineStoreThenAck(c, mqttPacketPubRec, pp.pi,
+			c.mqttQoS2InternalSubject(pp.pi), headerLen, natsMsg)
 
 	default:
 		return fmt.Errorf("unreachable: invalid QoS in mqttProcessPub: %v", qos)
@@ -4499,13 +4545,14 @@ func (s *Server) mqttProcessPub(c *client, pp *mqttPublish, trace bool) error {
 
 //////////////////////////////////////////////////////////////////////////////
 //
-// QoS1 PUBACK pipeline
+// Ack pipeline: PUBACK (QoS1), PUBREC and PUBCOMP (QoS2)
 //
 //////////////////////////////////////////////////////////////////////////////
 
-// Max pipelined inbound QoS1 PUBLISH messages per connection (the server's
+// Max pipelined inbound QoS1/2 packets per connection (the server's
 // effective "Receive Maximum"). A full window blocks the readLoop,
-// backpressuring the client.
+// backpressuring the client. Also caps the staged QoS2 message copies kept
+// in memory (see client.mqttRecordQoS2Publish).
 const mqttMaxAcksInFlight = 1024
 
 // A QoS>0 PUBLISH must carry a non-zero PI, Spec [MQTT-2.3.1-1];
@@ -4522,11 +4569,16 @@ func (pp *mqttPublish) owesPubAck() bool {
 	return mqttGetQoS(pp.flags) == 1 && pp.hasClientPI()
 }
 
-// mqttAckPipeline emits the PUBACKs of asynchronously submitted QoS1
-// stores in the order the PUBLISH packets were received. A failed or
-// timed-out store closes the connection, like the synchronous path did.
-// mqttPipeline* submit work here; mqttEnqueue* write a packet directly to
-// the outbound buffer.
+// mqttAckPipeline emits the acknowledgments of asynchronously submitted
+// stores - PUBACK, PUBREC, PUBCOMP - in the order the packets were
+// received; the single FIFO preserves the per-type ordering of
+// [MQTT-4.6]. A failed or timed-out store closes the connection, like
+// the synchronous path did. mqttPipeline* submit work here; mqttEnqueue*
+// write a packet directly to the outbound buffer.
+//
+// The unit is a packet, not a PI: duplicate PUBLISHes each owe a PUBREC
+// [MQTT-4.3.3-1], so one PI can have several entries in flight. State
+// that spans a QoS2 exchange lives in the PI-keyed qos2Exchanges.
 type mqttAckPipeline struct {
 	jsa      *mqttJSA
 	q        chan *mqttPipelinedAck
@@ -4535,9 +4587,22 @@ type mqttAckPipeline struct {
 }
 
 type mqttPipelinedAck struct {
-	pi    uint16
-	reply string     // JSA reply subject, to clean up if abandoned.
-	done  chan error // Buffered(1), receives the result of the JS store.
+	pi       uint16
+	respType byte       // mqttPacketPubAck, mqttPacketPubRec or mqttPacketPubComp.
+	reply    string     // JSA reply subject, to clean up if abandoned.
+	done     chan error // Buffered(1), receives the result of the JS store.
+}
+
+// Passes the JS store error through, except the benign one: a
+// max-msgs-per-subject rejection of a PUBREC entry is the staging stream
+// deduping a retransmitted PUBLISH, still owed its PUBREC. For
+// PUBACK/PUBCOMP entries ("$MQTT.msgs.>" stores) the same rejection is a
+// real failure.
+func (ack *mqttPipelinedAck) exceptDuplicateError(err error) error {
+	if err != nil && ack.respType == mqttPacketPubRec && mqttIsMaxMsgsPerSubjectErr(err) {
+		return nil
+	}
+	return err
 }
 
 // Idempotent, callable from any goroutine; unblocks a readLoop waiting in
@@ -4561,9 +4626,10 @@ func (pipe *mqttAckPipeline) shutdown() {
 	}
 }
 
-// Emits the PUBACKs in publish order as the JS acks arrive; on a store
-// failure or timeout, stops the pipeline and closes the connection. Runs
-// in its own goroutine, one per connection with inbound QoS1 traffic.
+// Emits the acknowledgments (each entry's respType) in packet order as the
+// JS acks arrive; on a store failure or timeout, stops the pipeline and
+// closes the connection. Runs in its own goroutine, one per connection
+// with inbound QoS1/2 traffic.
 func (s *Server) mqttAckLoop(c *client, pipe *mqttAckPipeline, jsa *mqttJSA) {
 	t := time.NewTimer(time.Hour)
 	stopTimer := func() {
@@ -4581,8 +4647,8 @@ func (s *Server) mqttAckLoop(c *client, pipe *mqttAckPipeline, jsa *mqttJSA) {
 		jsa.replies.Delete(ack.reply)
 		// Unblocks a readLoop waiting for room; shutdown drains the queue.
 		pipe.stop()
-		c.Errorf("unable to store QoS1 message in JetStream (pi=%v): %v; "+
-			"closing the connection, the client will re-send unacknowledged PUBLISH packets on reconnect",
+		c.Errorf("unable to store QoS1/2 message in JetStream (pi=%v): %v; "+
+			"closing the connection, the client will re-send unacknowledged PUBLISH and PUBREL packets on reconnect",
 			ack.pi, err)
 		c.closeConnection(ProtocolViolation)
 	}
@@ -4594,14 +4660,14 @@ func (s *Server) mqttAckLoop(c *client, pipe *mqttAckPipeline, jsa *mqttJSA) {
 			select {
 			case err := <-ack.done:
 				stopTimer()
-				if err != nil {
+				if err = ack.exceptDuplicateError(err); err != nil {
 					fail(ack, err)
 					return
 				}
 				c.mu.Lock()
 				trace := c.trace
 				c.mu.Unlock()
-				c.mqttEnqueuePubResponse(mqttPacketPubAck, ack.pi, trace)
+				c.mqttEnqueuePubResponse(ack.respType, ack.pi, trace)
 
 			case <-t.C:
 				fail(ack, fmt.Errorf("timeout after %v waiting for the JetStream ack", jsa.timeout))
@@ -4629,20 +4695,22 @@ func (s *Server) mqttAckLoop(c *client, pipe *mqttAckPipeline, jsa *mqttJSA) {
 	}
 }
 
-// Submits the JS store; the pipeline sends PUBACK(pi) on its ack, in
-// publish order. readLoop only.
-func (s *Server) mqttPipelineStoreThenPubAck(c *client, pi uint16, subject string, hdrLen int, natsMsg []byte) error {
+// Submits the JS store; the pipeline sends the respType acknowledgment
+// (PUBACK, PUBREC or PUBCOMP) with the given pi on its ack, in packet
+// order. readLoop only.
+func (s *Server) mqttPipelineStoreThenAck(c *client, respType byte, pi uint16, subject string, hdrLen int, natsMsg []byte) error {
 	jsa := c.mqtt.sess.jsa
-	ack := &mqttPipelinedAck{pi: pi, done: make(chan error, 1)}
+	ack := &mqttPipelinedAck{pi: pi, respType: respType, done: make(chan error, 1)}
 	jsa.storeMsgAsync(subject, hdrLen, natsMsg, ack)
 	return s.mqttPipelinePush(c, jsa, ack)
 }
 
-// Sends PUBACK(pi) without a store (e.g. the message was dropped on a
-// permission violation), through the pipeline to preserve ordering.
+// Sends the respType acknowledgment with the given pi without a store
+// (e.g. the message was dropped on a permission violation, or a PUBREL
+// found nothing to deliver), through the pipeline to preserve ordering.
 // readLoop only.
-func (s *Server) mqttPipelinePubAck(c *client, pi uint16) error {
-	ack := &mqttPipelinedAck{pi: pi, done: make(chan error, 1)}
+func (s *Server) mqttPipelineAck(c *client, respType byte, pi uint16) error {
+	ack := &mqttPipelinedAck{pi: pi, respType: respType, done: make(chan error, 1)}
 	ack.done <- nil
 	return s.mqttPipelinePush(c, c.mqtt.sess.jsa, ack)
 }
@@ -4675,19 +4743,19 @@ func (s *Server) mqttPipelinePush(c *client, jsa *mqttJSA, ack *mqttPipelinedAck
 			defer t.Stop()
 			select {
 			case err := <-ack.done:
-				if err != nil {
+				if err = ack.exceptDuplicateError(err); err != nil {
 					return err
 				}
 				c.mu.Lock()
 				trace := c.trace
 				c.mu.Unlock()
-				c.mqttEnqueuePubResponse(mqttPacketPubAck, ack.pi, trace)
+				c.mqttEnqueuePubResponse(ack.respType, ack.pi, trace)
 				return nil
 			case <-t.C:
 				jsa.replies.Delete(ack.reply)
-				return fmt.Errorf("JetStream did not acknowledge the QoS1 message within %v "+
+				return fmt.Errorf("JetStream did not acknowledge the QoS1/2 message within %v "+
 					"(server is shutting down); failing the connection, "+
-					"the client will re-send unacknowledged PUBLISH packets on reconnect", jsa.timeout)
+					"the client will re-send unacknowledged PUBLISH and PUBREL packets on reconnect", jsa.timeout)
 			}
 		}
 		c.mqtt.acks = pipe
@@ -4710,21 +4778,24 @@ func (s *Server) mqttPipelinePush(c *client, jsa *mqttJSA, ack *mqttPipelinedAck
 		return nil
 	case <-pipe.quitCh:
 		jsa.replies.Delete(ack.reply)
-		return errors.New("QoS1 PUBACK pipeline has shut down while admitting a message, " +
+		return errors.New("ack pipeline has shut down while admitting a packet, " +
 			"abandoning the wait for its JetStream ack; failing the connection, " +
-			"the client will re-send unacknowledged PUBLISH packets on reconnect")
+			"the client will re-send unacknowledged PUBLISH and PUBREL packets on reconnect")
 	case <-t.C:
 		jsa.replies.Delete(ack.reply)
-		return fmt.Errorf("QoS1 in-flight window is full (%d messages) and JetStream has not acknowledged "+
-			"the oldest message within %v; failing the connection, "+
-			"the client will re-send unacknowledged PUBLISH packets on reconnect",
+		return fmt.Errorf("in-flight window is full (%d packets) and JetStream has not acknowledged "+
+			"the oldest one within %v; failing the connection, "+
+			"the client will re-send unacknowledged PUBLISH and PUBREL packets on reconnect",
 			mqttMaxAcksInFlight, jsa.timeout)
 	}
 }
 
-func (s *Server) mqttInitiateMsgDelivery(c *client, pp *mqttPublish) error {
-	natsMsg, headerLen := mqttNewDeliverableMessage(pp, false)
-
+// Broadcasts an inbound MQTT message into NATS, delivering it to the
+// matching subscriptions. Returns permIssue true if the message was dropped
+// on a permission violation, and otherwise the "$MQTT.msgs.>" subject to
+// store it under for QoS1+ - captured from c.pa AFTER the broadcast, since
+// account mappings may rewrite the subject. readLoop only.
+func (c *client) mqttDeliverInboundMsg(pp *mqttPublish, natsMsg []byte, headerLen int) (storeSubject string, permIssue bool) {
 	// The delivered message becomes the client's current publish (it is not
 	// the last PARSED packet for a PUBREL- or will-initiated delivery), and
 	// c.pa carries its pubargs; one defer restores both. c.mqtt.pp is
@@ -4750,12 +4821,21 @@ func (s *Server) mqttInitiateMsgDelivery(c *client, pp *mqttPublish) error {
 		c.pa.szb = nil
 	}()
 
-	_, permIssue := c.processInboundClientMsg(natsMsg)
+	if _, permIssue = c.processInboundClientMsg(natsMsg); permIssue {
+		return _EMPTY_, true
+	}
+	return mqttStreamSubjectPrefix + string(c.pa.subject), false
+}
+
+func (s *Server) mqttInitiateMsgDelivery(c *client, pp *mqttPublish) error {
+	natsMsg, headerLen := mqttNewDeliverableMessage(pp, false)
+
+	subject, permIssue := c.mqttDeliverInboundMsg(pp, natsMsg, headerLen)
 	if permIssue {
 		// The message was dropped, but the client may still be owed a
 		// PUBACK (routed through the pipeline to preserve ordering).
 		if pp.owesPubAck() {
-			return s.mqttPipelinePubAck(c, pp.pi)
+			return s.mqttPipelineAck(c, mqttPacketPubAck, pp.pi)
 		}
 		return nil
 	}
@@ -4774,12 +4854,11 @@ func (s *Server) mqttInitiateMsgDelivery(c *client, pp *mqttPublish) error {
 	// see addToPCD and writeLoop for details).
 	c.flushClients(0)
 
-	subject := mqttStreamSubjectPrefix + string(c.pa.subject)
-
-	// QoS1 from the wire is pipelined; wills and QoS2 PUBREL-initiated
-	// deliveries owe no PUBACK and store synchronously.
+	// QoS1 from the wire is pipelined; wills owe no PUBACK and store
+	// synchronously. QoS2 PUBREL-initiated deliveries take
+	// mqttProcessPubRel's own pipelined path, not this one.
 	if pp.owesPubAck() {
-		return s.mqttPipelineStoreThenPubAck(c, pp.pi, subject, headerLen, natsMsg)
+		return s.mqttPipelineStoreThenAck(c, mqttPacketPubAck, pp.pi, subject, headerLen, natsMsg)
 	}
 
 	_, err := c.mqtt.sess.jsa.storeMsg(subject, headerLen, natsMsg)
@@ -4789,74 +4868,146 @@ func (s *Server) mqttInitiateMsgDelivery(c *client, pp *mqttPublish) error {
 
 var mqttMaxMsgErrPattern = fmt.Sprintf("%s (%v)", ErrMaxMsgsPerSubject.Error(), JSStreamStoreFailedF)
 
-func (s *Server) mqttStoreQoS2MsgOnce(c *client, pp *mqttPublish) error {
-	// `true` means encode the MQTT PUBLISH packet in the NATS message header.
-	natsMsg, headerLen := mqttNewDeliverableMessage(pp, true)
-
-	// Do not broadcast the message until it has been deduplicated and released
-	// by the sender. Instead store this QoS2 message as
-	// "$MQTT.qos2.<client-id>.<PI>". If the message is a duplicate, we get back
-	// a ErrMaxMsgsPerSubject, otherwise it does not change the flow, still need
-	// to send a PUBREC back to the client. The original subject (translated
-	// from MQTT topic) is included in the NATS header of the stored message to
-	// use for latter delivery.
-	_, err := c.mqtt.sess.jsa.storeMsg(c.mqttQoS2InternalSubject(pp.pi), headerLen, natsMsg)
-
-	// TODO: would prefer a more robust and performant way of checking the
-	// error, but it comes back wrapped as an API result.
-	if err != nil &&
-		(isErrorOtherThan(err, JSStreamStoreFailedF) || err.Error() != mqttMaxMsgErrPattern) {
-		return err
-	}
-
-	return nil
+// A staged QoS2 store hitting the stream's max-msgs-per-subject limit means
+// the message was already staged by an earlier (duplicate) PUBLISH.
+//
+// TODO: would prefer a more robust and performant way of checking the
+// error, but it comes back wrapped as an API result.
+func mqttIsMaxMsgsPerSubjectErr(err error) bool {
+	return err != nil && !isErrorOtherThan(err, JSStreamStoreFailedF) && err.Error() == mqttMaxMsgErrPattern
 }
 
 func (c *client) mqttQoS2InternalSubject(pi uint16) string {
 	return mqttQoS2IncomingMsgsStreamSubjectPrefix + c.mqtt.cid + "." + strconv.FormatUint(uint64(pi), 10)
 }
 
-// Process a PUBREL packet (QoS2, acting as Receiver).
+// Copies an inbound QoS2 PUBLISH (the slices point into the readLoop
+// buffer) into qos2Exchanges, for its PUBREL to deliver without a
+// re-load. A released entry is always dropped first: any PUBLISH on a
+// released PI - kept or not - is a new publication [MQTT-4.3.3-1].
+// readLoop only.
+func (c *client) mqttRecordQoS2Publish(pp *mqttPublish) {
+	if c.mqtt.qos2Exchanges == nil {
+		c.mqtt.qos2Exchanges = make(map[uint16]*mqttPublish)
+	} else if prev, ok := c.mqtt.qos2Exchanges[pp.pi]; ok {
+		if prev != nil {
+			// A duplicate PUBLISH: keep the first copy, as the JetStream
+			// stage does (max-msgs-per-subject), so both deliver the same
+			// bytes.
+			return
+		}
+
+		// Released: a new publication. Drop the nil entry.
+		delete(c.mqtt.qos2Exchanges, pp.pi)
+	}
+
+	if c.mqtt.qos2PendingCount >= mqttMaxAcksInFlight {
+		return
+	}
+	cp := *pp
+	cp.topic = append([]byte(nil), pp.topic...)
+	cp.subject = append([]byte(nil), pp.subject...)
+	cp.mapped = append([]byte(nil), pp.mapped...)
+	cp.msg = append([]byte(nil), pp.msg...)
+	c.mqtt.qos2Exchanges[pp.pi] = &cp
+	c.mqtt.qos2PendingCount++
+}
+
+// Returns the pending message, if kept; released reports a PUBREL
+// retransmission. (nil, false) means unknown here: fall back to the
+// JetStream load. readLoop only.
+func (c *client) mqttTakeQoS2Publish(pi uint16) (pp *mqttPublish, released bool) {
+	pp, ok := c.mqtt.qos2Exchanges[pi]
+	return pp, ok && pp == nil
+}
+
+// Moves the exchange pending -> released: the delivery is initiated and
+// the staged copy's discard submitted. The released entry screens
+// retransmitted PUBRELs off the JetStream load until the PI is reused.
+// readLoop only.
+func (c *client) mqttMarkQoS2Released(pi uint16) {
+	if c.mqtt.qos2Exchanges == nil {
+		c.mqtt.qos2Exchanges = make(map[uint16]*mqttPublish)
+	} else if pp, ok := c.mqtt.qos2Exchanges[pi]; ok && pp != nil {
+		c.mqtt.qos2PendingCount--
+	}
+	c.mqtt.qos2Exchanges[pi] = nil
+}
+
+// Process a PUBREL (QoS2, acting as Receiver) - the second async JS
+// interaction (see qos2Exchanges): deliver the staged message
+// [MQTT-4.3.3-2], discard its staged copy, and PUBCOMP through the ack
+// pipeline once JetStream acks the delivery store. Delivered from the
+// qos2Exchanges copy; on a miss re-loaded from JetStream, unless the
+// exchange is marked released (a retransmission).
 //
-// Runs from the client's readLoop.
-// No lock held on entry.
+// Runs from the client's readLoop. No lock held on entry.
 func (s *Server) mqttProcessPubRel(c *client, pi uint16, trace bool) error {
-	// Once done with the processing, send a PUBCOMP back to the client.
-	defer c.mqttEnqueuePubResponse(mqttPacketPubComp, pi, trace)
-
-	// See if there is a message pending for this pi. All failures are treated
-	// as "not found".
-	asm := c.mqtt.asm
-	stored, _ := asm.jsa.loadLastMsgFor(mqttQoS2IncomingMsgsStreamName, c.mqttQoS2InternalSubject(pi))
-
-	if stored == nil {
-		// No message found, nothing to do.
-		return nil
+	pp, released := c.mqttTakeQoS2Publish(pi)
+	// A retransmitted PUBREL: just acknowledge, without consulting
+	// JetStream - a load could still see the asynchronously-deleted
+	// staged copy and deliver a duplicate [MQTT-4.3.3-1].
+	if released {
+		return s.mqttPipelineAck(c, mqttPacketPubComp, pi)
 	}
-	// Best attempt to delete the message from the QoS2 stream.
-	asm.jsa.deleteMsg(mqttQoS2IncomingMsgsStreamName, stored.Sequence, true)
-
-	// only MQTT QoS2 messages should be here, and they must have a subject.
-	h := mqttParsePublishNATSHeader(stored.Header)
-	if h == nil || h.qos != 2 || len(h.subject) == 0 {
-		return errors.New("invalid message in QoS2 PUBREL stream")
+	var stagedSeq uint64
+	if pp == nil {
+		// All load failures are treated as "not found".
+		stored, _ := c.mqtt.asm.jsa.loadLastMsgFor(mqttQoS2IncomingMsgsStreamName, c.mqttQoS2InternalSubject(pi))
+		if stored == nil {
+			// Nothing pending for this PI, just acknowledge.
+			return s.mqttPipelineAck(c, mqttPacketPubComp, pi)
+		}
+		// Only MQTT QoS2 messages should be here, and they must have a subject.
+		h := mqttParsePublishNATSHeader(stored.Header)
+		if h == nil || h.qos != 2 || len(h.subject) == 0 {
+			// Delete the corrupt message (by the sequence the load just
+			// returned) before failing the connection, so the retried
+			// PUBREL converges to a clean PUBCOMP. No released mark: it
+			// would die with this connection anyway.
+			c.mqtt.sess.jsa.deleteMsg(mqttQoS2IncomingMsgsStreamName, stored.Sequence, false)
+			return errors.New("invalid message in QoS2 PUBREL stream")
+		}
+		flags := h.qos << 1
+		if h.retained {
+			flags |= mqttPubFlagRetain
+		}
+		pp = &mqttPublish{
+			topic:   natsSubjectToMQTTTopic(h.subject),
+			subject: h.subject,
+			mapped:  h.mapped,
+			msg:     stored.Data,
+			sz:      len(stored.Data),
+			pi:      pi,
+			flags:   flags,
+		}
+		stagedSeq = stored.Sequence
 	}
 
-	flags := h.qos << 1
-	if h.retained {
-		flags |= mqttPubFlagRetain
-	}
-	pp := &mqttPublish{
-		topic:   natsSubjectToMQTTTopic(h.subject),
-		subject: h.subject,
-		mapped:  h.mapped,
-		msg:     stored.Data,
-		sz:      len(stored.Data),
-		pi:      pi,
-		flags:   flags,
+	// Discard the staged copy, fire-and-forget: by sequence when the load
+	// gave us one, else by the (unique) staging subject - needing no
+	// sequence is what made dropping the load possible. FIFO-safe against
+	// PI reuse: the discard is enqueued before the PUBCOMP that frees the
+	// PI. Retransmitted PUBRELs racing it are screened by the released mark.
+	c.mqttMarkQoS2Released(pi)
+	if stagedSeq != 0 {
+		c.mqtt.sess.jsa.deleteMsg(mqttQoS2IncomingMsgsStreamName, stagedSeq, false)
+	} else {
+		c.mqtt.sess.jsa.deleteMsgBySubject(mqttQoS2IncomingMsgsStreamName, c.mqttQoS2InternalSubject(pi))
 	}
 
-	return s.mqttInitiateMsgDelivery(c, pp)
+	// Deliver now, from the readLoop, then store for QoS1+ subscribers.
+	natsMsg, headerLen := mqttNewDeliverableMessage(pp, false)
+	subject, permIssue := c.mqttDeliverInboundMsg(pp, natsMsg, headerLen)
+	if permIssue {
+		// The message was dropped, but the client is still owed the PUBCOMP.
+		return s.mqttPipelineAck(c, mqttPacketPubComp, pi)
+	}
+
+	// See mqttInitiateMsgDelivery for why flushClients is needed before the
+	// store.
+	c.flushClients(0)
+	return s.mqttPipelineStoreThenAck(c, mqttPacketPubComp, pi, subject, headerLen, natsMsg)
 }
 
 // Invoked when processing an inbound client message. If the "retain" flag is

--- a/server/mqtt_ex_bench_test.go
+++ b/server/mqtt_ex_bench_test.go
@@ -123,7 +123,7 @@ func (bc mqttBenchContext) benchmarkPubPipelined(b *testing.B) {
 	m := mqttBenchDefaultMatrix.
 		NoSubscribers().
 		NoTopics().
-		QOS1Only()
+		QOS12Only()
 
 	b.Run("PUBX", func(b *testing.B) {
 		m.runMatrix(b, bc, func(b *testing.B, bc *mqttBenchContext) {
@@ -321,6 +321,11 @@ func (m mqttBenchMatrix) QOS0Only() mqttBenchMatrix {
 
 func (m mqttBenchMatrix) QOS1Only() mqttBenchMatrix {
 	m.QOS = []int{1}
+	return m
+}
+
+func (m mqttBenchMatrix) QOS12Only() mqttBenchMatrix {
+	m.QOS = []int{1, 2}
 	return m
 }
 

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -6386,6 +6386,46 @@ func TestMQTTQoS2RejectPublishDuplicates(t *testing.T) {
 	testMQTTExpectNothing(t, r)
 }
 
+func TestMQTTQoS2RejectPublishDuplicatesAcrossReconnect(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	var qos2 byte = 2
+	cisub := &mqttConnInfo{clientID: "sub", cleanSess: true}
+	c, r := testMQTTConnect(t, cisub, o.MQTT.Host, o.MQTT.Port)
+	defer c.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, c, r, []*mqttFilter{{filter: "foo", qos: qos2}}, []byte{qos2})
+
+	// Stage a message, then lose the connection as if the PUBREC never made
+	// it back to the client.
+	cipub := &mqttConnInfo{clientID: "pub", cleanSess: false}
+	cp, rp := testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, false)
+	var pubPI uint16 = 444
+	testMQTTSendPublishPacket(t, cp, qos2, false, false, "foo", pubPI, []byte("data1"))
+	testMQTTReadPIPacket(mqttPacketPubRec, t, rp, pubPI)
+	cp.Close()
+
+	// Reconnect the session and retransmit with the same PI (DUP set) but a
+	// different payload. [MQTT-4.3.3-1]: the first accepted bytes must win,
+	// as in TestMQTTQoS2RejectPublishDuplicates on one connection.
+	cp, rp = testMQTTConnect(t, cipub, o.MQTT.Host, o.MQTT.Port)
+	defer cp.Close()
+	testMQTTCheckConnAck(t, rp, mqttConnAckRCConnectionAccepted, true)
+	testMQTTSendPublishPacket(t, cp, qos2, true, false, "foo", pubPI, []byte("data2"))
+	testMQTTReadPIPacket(mqttPacketPubRec, t, rp, pubPI)
+	testMQTTSendPIPacket(mqttPacketPubRel|0x2, t, cp, pubPI)
+	testMQTTReadPIPacket(mqttPacketPubComp, t, rp, pubPI)
+
+	subPI := testMQTTCheckPubMsgNoAck(t, c, r, "foo", mqttPubQoS2, []byte("data1"))
+	testMQTTSendPIPacket(mqttPacketPubRec, t, c, subPI)
+	testMQTTReadPIPacket(mqttPacketPubRel, t, r, subPI)
+	testMQTTSendPIPacket(mqttPacketPubComp, t, c, subPI)
+	testMQTTExpectNothing(t, r)
+}
+
 func TestMQTTQoS2RetriesPublish(t *testing.T) {
 	o := testMQTTDefaultOptions()
 	o.MQTT.AckWait = 100 * time.Millisecond

--- a/server/mqtt_test.go
+++ b/server/mqtt_test.go
@@ -10446,3 +10446,229 @@ func TestMQTTQoS1PubAckPipelineShutdownRace(t *testing.T) {
 		}
 	}
 }
+
+// QoS2 acknowledgments flow through the same ack pipeline as QoS1: a burst
+// of PUBLISH packets gets its PUBRECs back in publish order, a burst of
+// PUBRELs its PUBCOMPs in the same order, and every message is delivered
+// exactly once.
+func TestMQTTQoS2AckPipelineOrder(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	mcp, mpr := testMQTTConnect(t, &mqttConnInfo{cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	defer mcp.Close()
+	testMQTTCheckConnAck(t, mpr, mqttConnAckRCConnectionAccepted, false)
+
+	// Subscribe with a second connection so the messages have interest and
+	// flow through the JS store + delivery path.
+	mcs, msr := testMQTTConnect(t, &mqttConnInfo{clientID: "pipesub", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	defer mcs.Close()
+	testMQTTCheckConnAck(t, msr, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, mcs, msr, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTFlush(t, mcs, nil, msr)
+
+	// Send a burst of QoS2 PUBLISH packets without reading any PUBRECs.
+	const numMsgs = 100
+	for pi := uint16(1); pi <= numMsgs; pi++ {
+		testMQTTSendPublishPacket(t, mcp, 2, false, false, "foo", pi, []byte(fmt.Sprintf("msg-%d", pi)))
+	}
+	for pi := uint16(1); pi <= numMsgs; pi++ {
+		testMQTTReadPIPacket(mqttPacketPubRec, t, mpr, pi)
+	}
+
+	// Release them all, again without reading any PUBCOMPs.
+	for pi := uint16(1); pi <= numMsgs; pi++ {
+		testMQTTSendPIPacket(mqttPacketPubRel|0x2, t, mcp, pi)
+	}
+	for pi := uint16(1); pi <= numMsgs; pi++ {
+		testMQTTReadPIPacket(mqttPacketPubComp, t, mpr, pi)
+	}
+
+	// The subscriber must receive every message exactly once, in order.
+	for pi := uint16(1); pi <= numMsgs; pi++ {
+		testMQTTCheckPubMsgNoAck(t, mcs, msr, "foo", mqttPubQos1, []byte(fmt.Sprintf("msg-%d", pi)))
+	}
+	testMQTTExpectNothing(t, msr)
+}
+
+// Closing the connection with pipelined QoS2 exchanges still in flight must
+// not panic, hang, or leak JSA reply registrations, and a successor
+// connection must complete a full exchange cleanly.
+func TestMQTTQoS2AckPipelineConnClose(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	mcs, msr := testMQTTConnect(t, &mqttConnInfo{clientID: "sub", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	defer mcs.Close()
+	testMQTTCheckConnAck(t, msr, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, mcs, msr, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTFlush(t, mcs, nil, msr)
+
+	// A burst of QoS2 PUBLISHes, some released, then an abrupt close with
+	// everything unread.
+	const numMsgs = 50
+	mcp, _ := testMQTTConnect(t, &mqttConnInfo{clientID: "pub", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	for pi := uint16(1); pi <= numMsgs; pi++ {
+		testMQTTSendPublishPacket(t, mcp, 2, false, false, "foo", pi, []byte(fmt.Sprintf("msg-%d", pi)))
+	}
+	for pi := uint16(1); pi <= numMsgs/2; pi++ {
+		testMQTTSendPIPacket(mqttPacketPubRel|0x2, t, mcp, pi)
+	}
+	// inMsgs counts broadcasts, and a QoS2 PUBLISH does not broadcast (it
+	// only stages) - the PUBREL-initiated deliveries do. The PUBRELs were
+	// written after all the PUBLISHes on the same connection, so all of
+	// them delivered implies every packet above was processed.
+	pc := testMQTTGetClient(t, s, "pub")
+	checkFor(t, 2*time.Second, 10*time.Millisecond, func() error {
+		if n := atomic.LoadInt64(&pc.inMsgs); n < numMsgs/2 {
+			return fmt.Errorf("server delivered %v of %v releases", n, numMsgs/2)
+		}
+		return nil
+	})
+	mcp.Close()
+
+	// All JSA reply registrations from the abandoned pipeline must be
+	// cleaned up, by the reply processing or by the pipeline's shutdown.
+	jsa := s.mqttGetJSAForAccount(globalAccountName)
+	if jsa == nil {
+		t.Fatal("no JSA for the global account")
+	}
+	checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+		n := 0
+		jsa.replies.Range(func(_, _ any) bool { n++; return true })
+		if n > 0 {
+			return fmt.Errorf("%v dangling JSA reply registration(s)", n)
+		}
+		return nil
+	})
+
+	// The released messages were delivered (the releases preceded the
+	// close); the unreleased ones must not be.
+	for pi := uint16(1); pi <= numMsgs/2; pi++ {
+		testMQTTCheckPubMsgNoAck(t, mcs, msr, "foo", mqttPubQos1, []byte(fmt.Sprintf("msg-%d", pi)))
+	}
+	testMQTTExpectNothing(t, msr)
+
+	// A successor connection completes a full QoS2 exchange cleanly.
+	mcp2, mpr2 := testMQTTConnect(t, &mqttConnInfo{clientID: "pub", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	defer mcp2.Close()
+	testMQTTCheckConnAck(t, mpr2, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSendPublishPacket(t, mcp2, 2, false, false, "foo", 99, []byte("fresh"))
+	testMQTTReadPIPacket(mqttPacketPubRec, t, mpr2, 99)
+	testMQTTSendPIPacket(mqttPacketPubRel|0x2, t, mcp2, 99)
+	testMQTTReadPIPacket(mqttPacketPubComp, t, mpr2, 99)
+	testMQTTCheckPubMsgNoAck(t, mcs, msr, "foo", mqttPubQos1, []byte("fresh"))
+}
+
+// A corrupt staged message (no Nmqtt-Pub header) must fail the connection
+// on PUBREL - never be acknowledged or delivered - but also be discarded,
+// so the PUBREL the client retries on its next connection converges to a
+// clean PUBCOMP instead of re-loading the same message every time.
+func TestMQTTQoS2PubRelInvalidStagedMessage(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	const cid = "corrupt"
+	const pi = uint16(5)
+	stagedSubject := fmt.Sprintf("%s%s.%d", mqttQoS2IncomingMsgsStreamSubjectPrefix, cid, pi)
+
+	// Wildcard interest to verify the corrupt message is never delivered.
+	mcs, msr := testMQTTConnect(t, &mqttConnInfo{clientID: "sub", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	defer mcs.Close()
+	testMQTTCheckConnAck(t, msr, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, mcs, msr, []*mqttFilter{{filter: "#", qos: 1}}, []byte{1})
+	testMQTTFlush(t, mcs, nil, msr)
+
+	// This connection both creates the account's MQTT streams and owns the
+	// session that the second connection below resumes.
+	ci := &mqttConnInfo{clientID: cid, cleanSess: false}
+	mc, r := testMQTTConnect(t, ci, o.MQTT.Host, o.MQTT.Port)
+	defer mc.Close()
+	testMQTTCheckConnAck(t, r, mqttConnAckRCConnectionAccepted, false)
+
+	// Plant a message with no MQTT headers where the staged copy for pi
+	// would live.
+	// The $-prefixed inbox keeps this connection's JS API replies out of
+	// the MQTT '#' subscription: wildcards must not match $-topics.
+	nc := natsConnect(t, s.ClientURL(), nats.CustomInboxPrefix("$TESTINBOX"))
+	defer nc.Close()
+	js, err := nc.JetStream()
+	if err != nil {
+		t.Fatalf("Unable to get JetStream: %v", err)
+	}
+	if _, err := js.Publish(stagedSubject, []byte("garbage")); err != nil {
+		t.Fatalf("Error planting the corrupt staged message: %v", err)
+	}
+
+	// PUBREL for it: no in-memory copy, the load finds the corrupt message,
+	// and the connection must fail without a PUBCOMP.
+	testMQTTSendPIPacket(mqttPacketPubRel|0x2, t, mc, pi)
+	testMQTTExpectDisconnect(t, mc)
+
+	// The corrupt message is discarded (asynchronously), and not delivered.
+	checkFor(t, 2*time.Second, 25*time.Millisecond, func() error {
+		_, err := js.GetLastMsg(mqttQoS2IncomingMsgsStreamName, stagedSubject)
+		switch {
+		case err == nil:
+			return fmt.Errorf("corrupt staged message still present")
+		case errors.Is(err, nats.ErrMsgNotFound):
+			return nil
+		default:
+			t.Fatalf("Unexpected error checking the staged subject: %v", err)
+			return nil
+		}
+	})
+	testMQTTExpectNothing(t, msr)
+
+	// The PUBREL retried on the next connection of the session finds clean
+	// state and completes with just the PUBCOMP.
+	mc2, r2 := testMQTTConnect(t, ci, o.MQTT.Host, o.MQTT.Port)
+	defer mc2.Close()
+	testMQTTCheckConnAck(t, r2, mqttConnAckRCConnectionAccepted, true)
+	testMQTTSendPIPacket(mqttPacketPubRel|0x2, t, mc2, pi)
+	testMQTTReadPIPacket(mqttPacketPubComp, t, r2, pi)
+	testMQTTExpectNothing(t, msr)
+}
+
+// Reusing a packet identifier for a new publication after its previous
+// exchange was released must deliver every message exactly once: the
+// released mark of the old exchange must not short-circuit the new one,
+// and the new message must not dedupe against the old exchange's staged
+// copy, whose asynchronous discard may still be in flight.
+func TestMQTTQoS2PIReuseAfterRelease(t *testing.T) {
+	o := testMQTTDefaultOptions()
+	s := testMQTTRunServer(t, o)
+	defer testMQTTShutdownServer(s)
+
+	mcs, msr := testMQTTConnect(t, &mqttConnInfo{clientID: "sub", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	defer mcs.Close()
+	testMQTTCheckConnAck(t, msr, mqttConnAckRCConnectionAccepted, false)
+	testMQTTSub(t, 1, mcs, msr, []*mqttFilter{{filter: "foo", qos: 1}}, []byte{1})
+	testMQTTFlush(t, mcs, nil, msr)
+
+	mcp, mpr := testMQTTConnect(t, &mqttConnInfo{clientID: "pub", cleanSess: true}, o.MQTT.Host, o.MQTT.Port)
+	defer mcp.Close()
+	testMQTTCheckConnAck(t, mpr, mqttConnAckRCConnectionAccepted, false)
+
+	// Full compliant exchanges back-to-back on the same PI: each PUBCOMP
+	// legally releases the PI for the next publication, typically while
+	// the previous staged copy's discard is still in flight.
+	const pi = uint16(1)
+	const cycles = 10
+	for i := 1; i <= cycles; i++ {
+		msg := []byte(fmt.Sprintf("cycle-%d", i))
+		testMQTTSendPublishPacket(t, mcp, 2, false, false, "foo", pi, msg)
+		testMQTTReadPIPacket(mqttPacketPubRec, t, mpr, pi)
+		testMQTTSendPIPacket(mqttPacketPubRel|0x2, t, mcp, pi)
+		testMQTTReadPIPacket(mqttPacketPubComp, t, mpr, pi)
+	}
+
+	// Every cycle's message, exactly once, in order.
+	for i := 1; i <= cycles; i++ {
+		testMQTTCheckPubMsgNoAck(t, mcs, msr, "foo", mqttPubQos1, []byte(fmt.Sprintf("cycle-%d", i)))
+	}
+	testMQTTExpectNothing(t, msr)
+}


### PR DESCRIPTION
QoS2 ingest was stop-and-wait on the server side. Each PUBLISH blocked
the publisher's readLoop on the JetStream store of its held copy into
`$MQTT_qos2in`, and each PUBREL on three more round trips: load the
copy back, delete it waiting for the ack, and store it into `$MQTT_msgs`
for delivery. A QoS2 publisher was therefore capped at a few hundred
messages per second whatever its in-flight window.

This PR extends the QoS1 ack pipeline of #8415 to QoS2. The JetStream
operations are submitted asynchronously, the PUBREL delivers from a copy
the connection kept so there is no load, the delete no longer waits, and
the PUBREC and PUBCOMP are sent from the pipeline as the acks arrive, in
packet order. Single-connection QoS2 throughput, flat at 600-800/s on
main whatever the window, reaches ~18K/s at a 256-message window (22x)
and rises with the client's window from 1.4x at a window of 1; aggregate
QoS2 over 100-200 connections improves 1.4-1.5x; QoS1 and QoS0 are
within the run's control spread. Where asynchrony costs the readLoop
its read-your-own-writes view of JetStream, the connection keeps the
state it needs in memory, and a `Nats-Msg-Id` on the delivery store
covers the one case a connection cannot see, a PUBREL retransmitted on
another connection.

## Benchmark

GCP, 6 brokers in two 3-node R3 clusters, generators on separate VMs,
two crossover passes (the builds swap clusters between passes), ratios
pooled. `mqtt-test` sweep, QoS2, main (3c80d8f89) vs this branch
(2eb9772b9):

| in flight | main | this PR | ratio |
|---|---|---|---|
| 1 | 579/s (p99 2.2ms) | 801/s (p99 1.6ms) | 1.4x |
| 10 | 807/s (p99 17.3ms) | 5,827/s (p99 3.0ms) | 7.2x |
| 20 | 814/s (p99 30.6ms) | 8,800/s (p99 3.9ms) | 10.8x |
| 256 | 816/s (p99 346.9ms) | 18,051/s (p99 24.1ms) | 22.1x |

Aggregate, 100 and 200 connections publishing QoS2 at once: 1.5x and
1.4x (about 12K/s to 17.3K/s). QoS1 aggregate and mqtt.js QoS1 1.0x;
QoS1 sweep 0.9-1.0x and the QoS0 control 1.1x, both within this fleet's
placement spread (the unchanged-code control read 0.8x and 1.3x in the
two passes). An earlier run of the same comparison on a quieter fleet
(control 1.00 in both passes) gave 26x at 256, 1.7-1.8x aggregate, and
1.0x for QoS1 at every window. The window-1 gain is the two round trips
removed per exchange (the load and the waited delete); the rest of the
curve is the pipelining. The remaining gap to QoS1's aggregate is
structural: two appends and a delete per message on the account's
streams.

## What runs where

Everything below is per connection unless noted.

- The readLoop (`mqttProcessPub`, `mqttProcessPubRel`) parses the
  packet, pushes the JetStream request(s) to the account's `jsa.sendq`,
  and admits one entry per packet into the connection's ack pipeline, a
  buffered channel of `mqttMaxPipelined` (1024) entries. A full window
  blocks the readLoop, which backpressures the client; no ack for the
  oldest entry within the JS API timeout (5s) fails the connection. The
  readLoop-owned state (`c.mqtt.pipe`, `qos2Exchanges`, `qos2Released`,
  `qos2CachedBytes`) is accessed without a lock, from the readLoop only.
- The ack loop (`mqttAckLoop`) is one go routine per connection with
  inbound QoS1/2 traffic, started with `s.startGoRoutine` on the first
  pipelined packet. It takes entries in order, waits for each entry's
  JetStream ack(s) with one re-armed timer, and enqueues the PUBACK,
  PUBREC, or PUBCOMP under the client lock (`mqttEnqueuePubResponse`).
  The single FIFO preserves the per-type ordering of [MQTT-4.6.0-2] and
  [MQTT-4.6.0-3]. A failed or timed-out operation closes the connection,
  as the synchronous code did; the client re-sends on reconnect
  [MQTT-4.4.0-1]. `mqttHandleClosedClient` stops the loop and drains the
  queue.
- The JS API reply callback (`processJSAPIReplies`, which can run from
  various go routines) claims the entry's reply registration with
  `LoadAndDelete` on the account's `jsa.replies` and completes the
  entry's buffered(1) channel; it never blocks. Every give-up path in
  the pipeline (error, timeout, pipeline stopped, server shutdown, and
  the close drain) removes its registrations, so nothing leaks in the
  account-scoped map. Note that one PUBCOMP entry holds two
  registrations, for the store and for the delete.
- The sendq consumer (`sendJSAPIrequests`) adds the `Nats-Msg-Id`
  header to a delivery store when the request carries one, in the
  buffer rebuild it already does for messages with headers: one
  allocation, the same count as the trailing CRLF append it replaces.

## The QoS2 flow

PUBLISH (Method A of [MQTT-4.3.3-2], as before): the readLoop stores the
message into `$MQTT_qos2in` as `$MQTT.qos2.in.<client id>.<PI>`, with
the packet encoded in the NATS header, and keeps a copy on the
connection in `qos2Exchanges` so the PUBREL needs no load. The copies
are capped per connection at 1024 messages and 4 MB
(`mqttMaxCachedQoS2Msgs`, `mqttMaxCachedQoS2Bytes`); past either cap
the PUBREL loads the copy from the stream, as it does for a resumed
session, so the caps bound memory and cost one load per message beyond
them, never correctness. 1024 is the pipeline window, so a client inside
its window never hits the count; 4 MB is four default `max_payload`s.
Both are constants, like the pipeline window in #8415; making them
options is a small follow-up if wanted. A PUBLISH
retransmitted while the connection holds the publication gets its PUBREC
from the pipeline, in order, and no second store [MQTT-4.3.3-2]: a second
store could be applied after the PUBREL's delete of the first copy
(the delete is a JS API request, the store is not, and nothing orders
the two) and leave a stray copy under the PI. A retransmit the
connection does not hold (a resumed session) is stored and deduped by
the stream's max-msgs-per-subject of 1, as before. The reply callback
records the outcome of the hold store on the cached exchange (an atomic
state plus the held copy's sequence, written before the entry's channel
is completed, so both are set before the PUBREC goes out):
`mqttQoS2HoldStored` with the sequence, or `mqttQoS2HoldDeduped` when
max-msgs-per-subject rejected the store, in which case no sequence came
back and the PUBREL loads the copy from the stream.

PUBREL: the readLoop takes the cached copy, marks the PI released in
`qos2Released` (an `avl.SequenceSet`, 65535 PIs at most), broadcasts the
message as a QoS0 delivery would (`processInboundClientMsg`, the same
call as QoS1), and submits two JetStream requests at once: the delivery
store into `$MQTT_msgs` and the delete of the held copy by its exact
sequence. The PUBCOMP is sent when both are acked. A PUBREL for a PI in
`qos2Released` (a retransmission) is answered with a PUBCOMP without
consulting JetStream, where a load could still see the not-yet-deleted
copy [MQTT-4.3.3-1]. A PUBREL for a PI unknown to the connection (a
session resumed on a new connection, a copy dropped past the cache
caps, or a deduped hold store) loads the copy from `$MQTT_qos2in` as
the synchronous code always did; the load returns the sequence, so the
delete is still by sequence. A new PUBLISH on a released PI is a new
publication [MQTT-4.3.3-2] and clears the released mark.

Note that the delete is by sequence in every case, so it cannot hit a
successor copy on a reused PI. The PUBCOMP waits for the delete ack, and
in a cluster that ack is sent when the delete is applied, so a compliant
client's next PUBLISH on the PI reaches the stream after the old copy is
gone.

## Why the message id

With the delete asynchronous, a PUBCOMP's prerequisites can be in
flight when the client loses its connection. The client retransmits the
PUBREL on reconnect [MQTT-4.4.0-1], possibly to another server, which
has no memory of the exchange, loads the copy if the delete has not
applied yet, and delivers the message a second time. The synchronous
code deleted the copy before delivering, so a retransmitted PUBREL found
nothing.

Every QoS2 delivery store into `$MQTT_msgs` therefore carries a
`Nats-Msg-Id` of `q2-<held copy sequence>`. The held copy's sequence is
the same across retransmits of one publication and distinct across
publications (a client id plus PI would drop a new publication on a
reused PI), so JetStream's duplicate detection drops the second store
wherever it comes from. QoS1 stores carry no id.

The dedupe holds for the stream's duplicates window. `$MQTT_msgs` is
created without an explicit window, as before, so JetStream's two minute
default applies, clamped to the server's `duplicate_window` limit and to
the stream's max age. It is also per leader: the map is rebuilt from the
stream on a restart, and `$MQTT_msgs` is interest based, so a PUBREL
retransmitted later than the window, or across a restart of the stream
leader after the first delivery was consumed, is delivered again. A
store that conflicts with an in-flight store of the same id (JetStream's
"duplicate message id is in process", meaning the first store is
proposed but not yet committed) is an error like any other: the
connection closes, and the retransmitted PUBREL then finds the first
store committed, or stores.

A durable released mark in `$MQTT_qos2in` (overwrite the held subject
with a marker) was considered instead. It changes what a server finds
under the subject, and a server without this PR deletes the message
before parsing it, so a mixed-version cluster would destroy the marker
and then fail the connection or deliver an empty payload. That needs a
two-phase rollout and a marker format kept forever; the message id gives
the same cross-server dedupe with no format change, so the exchange
state stays connection scoped.

## Behavior changes

- PUBREC and PUBCOMP are no longer sent inline; up to 1024 packets per
  connection can be in flight, and PUBCOMP is sent only after both the
  delivery store and the delete are acked. A failure or timeout on
  either closes the connection instead of acknowledging.
- A load failure on PUBREL closes the connection. Before, every failure
  was treated as "not found" and answered with a PUBCOMP, which ended
  the exchange with the copy still held and never delivered.
- A PUBREL that arrives before its PUBREC was sent closes the
  connection. An invalid held message is deleted and the connection
  closed without the PUBCOMP the old code sent via `defer`, so the
  retried PUBREL converges to a clean PUBCOMP.
- QoS0 subscribers and core NATS subscribers can receive a QoS2 message
  twice: the broadcast precedes the delivery store, and the message id
  covers the store only. The case is a PUBREL retransmitted on a new
  connection while the previous connection's delete is still pending.
  They already can for a QoS1 publish the publisher retransmits; QoS1/2
  subscribers, whose delivery comes from `$MQTT_msgs`, are covered by
  the id. This is a loosening of the QoS2 receiver contract for those
  subscribers and should go in the release notes.
- A client that reuses a PI before receiving its PUBCOMP (a violation
  of [MQTT-2.3.1-2]) can have the new publication dropped: its hold
  store can be rejected by max-msgs-per-subject if the previous copy's
  delete has not applied, and the PUBREL then finds either nothing or
  the old copy. The synchronous code ran a PUBREL to completion before
  parsing the next packet and did not have this window.
- A connection holds up to 4 MB of QoS2 copies between PUBREC and
  PUBREL (see the flow section); this memory is outside `max_pending`.

## Compatibility

No stream configuration, subject, or persisted format changes. The
held copies in `$MQTT_qos2in` are written and read as before, so a
mixed-version cluster during a rolling upgrade is fine: a server without
this PR processes its own connections' PUBRELs synchronously as it does
today, and a server with it dedupes on the `Nats-Msg-Id` regardless of
which server leads `$MQTT_msgs`, since the header is core JetStream.
Messages in `$MQTT_msgs` gain the header; the MQTT delivery path only
reads `Nmqtt-Pub` and ignores it. A clean-session connect still does not
purge the client's held copies, same as before.

## Code changes

- One pipelined type per acknowledgment, `mqttPipelinedPubAck`,
  `mqttPipelinedPubRec`, and `mqttPipelinedPubComp`, behind the small
  `mqttPipelined` interface (response type, PI, reply channels to wait
  on, and `abandon` to drop the reply registrations); the reply
  dispatcher translates per type.
- `deleteMsg` lost its `wait` parameter; `deleteMsgAsync` is the fire
  and forget variant, with an optional reply subject for the pipelined
  delete. The "already deleted" error check moved into
  `isMsgAlreadyDeletedErr`.
- PUBREL deliveries route through `mqttInitiateMsgDelivery` via a
  `heldSeq` parameter, so the broadcast code stays in one place, and a
  permission drop still gates its PUBCOMP on the delete.
- The cached exchange copies the four packet slices out of one
  allocation.

## Tests

Added: PUBREC/PUBCOMP burst ordering with exactly-once delivery
(`TestMQTTQoS2AckPipelineOrder`, which also checks the id is on QoS2
stores and not on QoS1 stores); an abrupt close with exchanges in flight
leaks no reply registrations, delivers the released messages and not
the others, and a successor connection works
(`TestMQTTQoS2AckPipelineConnClose`); back-to-back PI reuse across
releases (`TestMQTTQoS2PIReuseAfterRelease`); a PUBLISH retransmitted
without DUP on a resumed session resolving from the stream
(`TestMQTTQoS2RetransmitWithoutDupResolvesFromStream`); PUBCOMP
implying the held copy is gone, checked without polling after each one,
plus a PUBREL retransmitted on a resumed session finding nothing
(`TestMQTTQoS2PubCompImpliesDelete`); and a PUBLISH retransmitted while
held producing its PUBRECs and one hold store, counted on the stream's
subject (`TestMQTTQoS2RetransmitWhileHeldStoresOnce`). The existing
`TestMQTTQoS2RejectPublishDuplicates` fails without the released marks.
All of `TestMQTT` passes under `-race`.
