### PR TITLE
(2.15) [FIXED] Leafnode JetStream isolation/extension with same domain & sys account

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -552,6 +552,24 @@ func (s *Server) canExtendOtherDomain() bool {
 	return false
 }
 
+// jetStreamNotExtendable returns true if the configuration has this server
+// running standalone JetStream (no meta controller), so it can never take
+// part in a shared JetStream meta group. Config-derived only; see
+// jetStreamLeafNoExtend for the combined check.
+//
+// A standalone server soliciting extension via will_extend reports
+// extendable: leaves chained below it extend through it and must not isolate.
+func (s *Server) jetStreamNotExtendable() bool {
+	opts := s.getOpts()
+	if !opts.JetStream || !s.standAloneMode() {
+		return false
+	}
+	if s.SystemAccount() == nil {
+		return true
+	}
+	return !s.canExtendOtherDomain() || opts.JetStreamExtHint != jsWillExtend
+}
+
 func (s *Server) updateJetStreamInfoStatus(enabled bool) {
 	s.mu.Lock()
 	s.info.JetStream = enabled
@@ -894,6 +912,34 @@ func (s *Server) configAllJetStreamAccounts(tq chan<- func()) error {
 	}
 
 	return nil
+}
+
+// jetStreamStartedWithoutMetaController returns true if JetStream completed
+// startup without a meta controller. Extension is then impossible until a
+// restart, whatever the current configuration claims (e.g. a system account
+// remote added by config reload).
+func (s *Server) jetStreamStartedWithoutMetaController() bool {
+	if !s.getOpts().JetStream {
+		return false
+	}
+	js := s.getJetStream()
+	if js == nil || !js.isStarted() {
+		return false
+	}
+	return js.getMetaGroup() == nil
+}
+
+// jetStreamLeafNoExtend returns true if this server can not take part in a
+// shared JetStream meta group, per configuration or runtime state.
+func (s *Server) jetStreamLeafNoExtend() bool {
+	return s.jetStreamNotExtendable() || s.jetStreamStartedWithoutMetaController()
+}
+
+// Returns whether JetStream startup has fully completed.
+func (js *jetStream) isStarted() bool {
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+	return !js.started.IsZero()
 }
 
 // Mark our started time.

--- a/server/jetstream_leafnode_test.go
+++ b/server/jetstream_leafnode_test.go
@@ -16,6 +16,7 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -726,6 +727,777 @@ cluster: { name: clustL }
 			test(sLA.opts.Port, "clustL")
 		})
 	}
+}
+
+// checkSysLeafDenied verifies that the leaf connection bound to the system
+// account on s has the JS API denies merged in both directions, i.e. that
+// s itself treats the connection as isolated rather than relying on the
+// other end to hold back traffic.
+func checkSysLeafDenied(t *testing.T, s *Server) {
+	t.Helper()
+	sysAcc := s.SystemAccount()
+	checkFor(t, 2*time.Second, 25*time.Millisecond, func() error {
+		var found, denied bool
+		s.mu.RLock()
+		for _, ln := range s.leafs {
+			ln.mu.Lock()
+			if ln.acc == sysAcc {
+				found = true
+				if ln.perms != nil && ln.perms.pub.deny != nil && ln.perms.sub.deny != nil {
+					rp := ln.perms.pub.deny.Match(jsAllAPI)
+					rs := ln.perms.sub.deny.Match(jsAllAPI)
+					denied = len(rp.psubs)+len(rp.qsubs) > 0 && len(rs.psubs)+len(rs.qsubs) > 0
+				}
+			}
+			ln.mu.Unlock()
+		}
+		s.mu.RUnlock()
+		if !found {
+			return fmt.Errorf("no system account leaf connection on %q", s.Name())
+		}
+		if !denied {
+			return fmt.Errorf("system account leaf connection on %q is missing JS API denies", s.Name())
+		}
+		return nil
+	})
+}
+
+// Config templates shared by the leaf node domain / system account tests
+// below. Hub slots: server name, store dir, optional cluster block.
+// Leaf slots: server name, JS domain, store dir, optional extension_hint
+// line, optional cluster block, remotes.
+const lnDomainHubTmpl = `
+listen: 127.0.0.1:-1
+server_name: %s
+accounts {
+	A { jetstream: enabled, users: [ { user: a, password: pwd } ] }
+	SYS { users: [ { user: s, password: pwd } ] }
+}
+system_account: SYS
+jetstream {
+	domain: hub
+	store_dir: '%s'
+	max_mem: 50Mb
+	max_file: 50Mb
+}
+%s
+leafnodes {
+	listen: 127.0.0.1:-1
+	no_advertise: true
+}
+`
+
+const lnDomainLeafTmpl = `
+listen: 127.0.0.1:-1
+server_name: %s
+accounts {
+	A { jetstream: enabled, users: [ { user: a, password: pwd } ] }
+	SYS { users: [ { user: s, password: pwd } ] }
+}
+system_account: SYS
+jetstream {
+	domain: %s
+	store_dir: '%s'
+	max_mem: 50Mb
+	max_file: 50Mb
+	%s
+}
+%s
+leafnodes {
+	remotes [
+		%s
+	]
+}
+`
+
+// Like lnDomainLeafTmpl, but the server also runs its own leafnode listener so
+// further leaves can chain below it. Slots: server name, JS domain, store dir,
+// optional extension_hint line, remotes.
+const lnDomainLeafHubTmpl = `
+listen: 127.0.0.1:-1
+server_name: %s
+accounts {
+	A { jetstream: enabled, users: [ { user: a, password: pwd } ] }
+	SYS { users: [ { user: s, password: pwd } ] }
+}
+system_account: SYS
+jetstream {
+	domain: %s
+	store_dir: '%s'
+	max_mem: 50Mb
+	max_file: 50Mb
+	%s
+}
+leafnodes {
+	listen: 127.0.0.1:-1
+	no_advertise: true
+	remotes [
+		%s
+	]
+}
+`
+
+// lnDomainClusterBlock renders the cluster block for the templates above.
+func lnDomainClusterBlock(name string, listen, route int) string {
+	return fmt.Sprintf(`cluster {
+	name: %s
+	listen: 127.0.0.1:%d
+	routes = [nats-route://127.0.0.1:%d]
+	no_advertise: true
+}`, name, listen, route)
+}
+
+// lnDomainRemotes renders leafnode remotes pointing at lnPort, always binding
+// account A and, if shareSys is set, the system account as well.
+func lnDomainRemotes(lnPort int, shareSys bool) string {
+	remotes := fmt.Sprintf(`{ url: "nats://a:pwd@127.0.0.1:%d", account: A }`, lnPort)
+	if shareSys {
+		remotes += fmt.Sprintf("\n\t\t{ url: \"nats://s:pwd@127.0.0.1:%d\", account: SYS }", lnPort)
+	}
+	return remotes
+}
+
+// checkSysJSAPICross checks whether subject interest and messages on
+// $JS.API.> in the (shared) system account cross the leaf connection, probing
+// both directions. A control subject proves the link itself propagates
+// interest either way.
+func checkSysJSAPICross(t *testing.T, hub, leaf *Server, expectCross bool) {
+	t.Helper()
+	ncLeaf := natsConnect(t, fmt.Sprintf("nats://s:pwd@127.0.0.1:%d", leaf.opts.Port))
+	defer ncLeaf.Close()
+	ncHub := natsConnect(t, fmt.Sprintf("nats://s:pwd@127.0.0.1:%d", hub.opts.Port))
+	defer ncHub.Close()
+
+	// Leaf-side subscriptions probe the hub->leaf direction, hub-side
+	// subscriptions the leaf->hub direction.
+	ctlLeaf, err := ncLeaf.SubscribeSync("sysprobe.ctl.leaf")
+	require_NoError(t, err)
+	probeLeaf, err := ncLeaf.SubscribeSync("$JS.API.SYSPROBE.LEAF")
+	require_NoError(t, err)
+	require_NoError(t, ncLeaf.Flush())
+	ctlHub, err := ncHub.SubscribeSync("sysprobe.ctl.hub")
+	require_NoError(t, err)
+	probeHub, err := ncHub.SubscribeSync("$JS.API.SYSPROBE.HUB")
+	require_NoError(t, err)
+	require_NoError(t, ncHub.Flush())
+
+	// Wait until the control subject interest crossed the connection(s).
+	checkSubInterest(t, hub, "SYS", "sysprobe.ctl.leaf", 2*time.Second)
+	checkSubInterest(t, leaf, "SYS", "sysprobe.ctl.hub", 2*time.Second)
+
+	require_NoError(t, ncHub.Publish("sysprobe.ctl.leaf", nil))
+	require_NoError(t, ncHub.Publish("$JS.API.SYSPROBE.LEAF", nil))
+	require_NoError(t, ncHub.Flush())
+	require_NoError(t, ncLeaf.Publish("sysprobe.ctl.hub", nil))
+	require_NoError(t, ncLeaf.Publish("$JS.API.SYSPROBE.HUB", nil))
+	require_NoError(t, ncLeaf.Flush())
+
+	_, err = ctlLeaf.NextMsg(2 * time.Second)
+	require_NoError(t, err)
+	_, err = ctlHub.NextMsg(2 * time.Second)
+	require_NoError(t, err)
+	for direction, probe := range map[string]*nats.Subscription{"hub->leaf": probeLeaf, "leaf->hub": probeHub} {
+		_, err = probe.NextMsg(500 * time.Millisecond)
+		if expectCross && err != nil {
+			t.Fatalf("Expected JS API traffic to cross %s, got %v", direction, err)
+		} else if !expectCross && err == nil {
+			t.Fatalf("Expected no JS API traffic to cross %s, but it did", direction)
+		}
+	}
+}
+
+// TestJetStreamLeafNodeDomainSysAccountPermutations verifies leaf node + JetStream
+// behavior for the permutations of same/different JS domain and shared/not-shared
+// system account between hub and leaf.
+func TestJetStreamLeafNodeDomainSysAccountPermutations(t *testing.T) {
+	const cport1, cport2 = 23320, 23321
+	const lport1, lport2 = 23330, 23331
+
+	startHub := func(t *testing.T) (*Server, *Server) {
+		t.Helper()
+		conf1 := createConfFile(t, []byte(fmt.Sprintf(lnDomainHubTmpl, "HUB1", t.TempDir(), lnDomainClusterBlock("HUB", cport1, cport2))))
+		h1, _ := RunServerWithConfig(conf1)
+		t.Cleanup(h1.Shutdown)
+		conf2 := createConfFile(t, []byte(fmt.Sprintf(lnDomainHubTmpl, "HUB2", t.TempDir(), lnDomainClusterBlock("HUB", cport2, cport1))))
+		h2, _ := RunServerWithConfig(conf2)
+		t.Cleanup(h2.Shutdown)
+		checkClusterFormed(t, h1, h2)
+		c := cluster{t: t, servers: []*Server{h1, h2}}
+		c.waitOnLeader()
+		return h1, h2
+	}
+	startLeaf := func(t *testing.T, hub *Server, domain string, shareSys bool, hint string) *Server {
+		t.Helper()
+		if hint != _EMPTY_ {
+			hint = fmt.Sprintf("extension_hint: %s", hint)
+		}
+		remotes := lnDomainRemotes(hub.opts.LeafNode.Port, shareSys)
+		conf := createConfFile(t, []byte(fmt.Sprintf(lnDomainLeafTmpl, "LEAF", domain, t.TempDir(), hint, _EMPTY_, remotes)))
+		s, _ := RunServerWithConfig(conf)
+		t.Cleanup(s.Shutdown)
+		return s
+	}
+
+	startHubSingle := func(t *testing.T) *Server {
+		t.Helper()
+		conf := createConfFile(t, []byte(fmt.Sprintf(lnDomainHubTmpl, "SHUB", t.TempDir(), _EMPTY_)))
+		s, _ := RunServerWithConfig(conf)
+		t.Cleanup(s.Shutdown)
+		return s
+	}
+	startLeafCluster := func(t *testing.T, hub *Server, domain string, shareSys bool) (*Server, *Server) {
+		t.Helper()
+		remotes := lnDomainRemotes(hub.opts.LeafNode.Port, shareSys)
+		conf1 := createConfFile(t, []byte(fmt.Sprintf(lnDomainLeafTmpl, "LEAF1", domain, t.TempDir(), _EMPTY_, lnDomainClusterBlock("LEAF", lport1, lport2), remotes)))
+		l1, _ := RunServerWithConfig(conf1)
+		t.Cleanup(l1.Shutdown)
+		conf2 := createConfFile(t, []byte(fmt.Sprintf(lnDomainLeafTmpl, "LEAF2", domain, t.TempDir(), _EMPTY_, lnDomainClusterBlock("LEAF", lport2, lport1), remotes)))
+		l2, _ := RunServerWithConfig(conf2)
+		t.Cleanup(l2.Shutdown)
+		checkClusterFormed(t, l1, l2)
+		return l1, l2
+	}
+
+	// accountDomain asks the JS account info API and returns the reported domain.
+	accountDomain := func(t *testing.T, nc *nats.Conn) string {
+		t.Helper()
+		resp, err := nc.Request(JSApiAccountInfo, nil, 2*time.Second)
+		require_NoError(t, err)
+		var info JSApiAccountInfoResponse
+		require_NoError(t, json.Unmarshal(resp.Data, &info))
+		require_True(t, info.Error == nil)
+		return info.Domain
+	}
+
+	// countJSAPIResponses sends a single account info request and counts how many
+	// servers answer it. More than one response means JS API cross-talk over the
+	// leaf node connection.
+	countJSAPIResponses := func(t *testing.T, nc *nats.Conn) int {
+		t.Helper()
+		inbox := nats.NewInbox()
+		sub, err := nc.SubscribeSync(inbox)
+		require_NoError(t, err)
+		defer sub.Unsubscribe()
+		require_NoError(t, nc.PublishRequest(JSApiAccountInfo, inbox, nil))
+		require_NoError(t, nc.Flush())
+		time.Sleep(500 * time.Millisecond)
+		n, _, err := sub.Pending()
+		require_NoError(t, err)
+		return n
+	}
+
+	metaPeerCount := func(s *Server) int {
+		if js := s.getJetStream(); js != nil {
+			if mg := js.getMetaGroup(); mg != nil {
+				return len(mg.Peers())
+			}
+		}
+		return 0
+	}
+
+	t.Run("different-domain-different-sysacct", func(t *testing.T) {
+		h1, _ := startHub(t)
+		leaf := startLeaf(t, h1, "leaf", false, _EMPTY_)
+		checkLeafNodeConnectedCount(t, h1, 1)
+		checkLeafNodeConnectedCount(t, leaf, 1)
+
+		ncHub, jsHub := jsClientConnect(t, h1, nats.UserInfo("a", "pwd"))
+		defer ncHub.Close()
+		ncLeaf, jsLeaf := jsClientConnect(t, leaf, nats.UserInfo("a", "pwd"))
+		defer ncLeaf.Close()
+
+		// Each side serves its own domain.
+		require_Equal(t, accountDomain(t, ncHub), "hub")
+		require_Equal(t, accountDomain(t, ncLeaf), "leaf")
+
+		// Both sides can create a stream with the same name: fully isolated.
+		_, err := jsHub.AddStream(&nats.StreamConfig{Name: "CLASH", Subjects: []string{"hub.foo"}})
+		require_NoError(t, err)
+		_, err = jsLeaf.AddStream(&nats.StreamConfig{Name: "CLASH", Subjects: []string{"leaf.foo"}})
+		require_NoError(t, err)
+
+		// A stream created on the leaf is not visible from the hub.
+		_, err = jsLeaf.AddStream(&nats.StreamConfig{Name: "LEAFONLY", Subjects: []string{"leaf.only"}})
+		require_NoError(t, err)
+		_, err = jsHub.StreamInfo("LEAFONLY")
+		require_Error(t, err, nats.ErrStreamNotFound)
+
+		// Exactly one server answers a JS API request: no cross-talk.
+		require_Equal(t, countJSAPIResponses(t, ncHub), 1)
+		require_Equal(t, countJSAPIResponses(t, ncLeaf), 1)
+
+		// Hub meta cluster does not contain the leaf, leaf runs standalone.
+		require_Equal(t, metaPeerCount(h1), 2)
+		require_Equal(t, metaPeerCount(leaf), 0)
+	})
+
+	t.Run("same-domain-same-sysacct-extension", func(t *testing.T) {
+		h1, h2 := startHub(t)
+		leaf := startLeaf(t, h1, "hub", true, jsWillExtend)
+		checkLeafNodeConnectedCount(t, h1, 2)
+		checkLeafNodeConnectedCount(t, leaf, 2)
+
+		// The leaf extends the hub's JS domain: it joins the meta cluster.
+		c := cluster{t: t, servers: []*Server{h1, h2}}
+		c.waitOnLeader()
+		c.waitOnPeerCount(3)
+
+		ncHub, jsHub := jsClientConnect(t, h1, nats.UserInfo("a", "pwd"))
+		defer ncHub.Close()
+		ncLeaf, jsLeaf := jsClientConnect(t, leaf, nats.UserInfo("a", "pwd"))
+		defer ncLeaf.Close()
+
+		// Both sides report the same domain.
+		require_Equal(t, accountDomain(t, ncHub), "hub")
+		require_Equal(t, accountDomain(t, ncLeaf), "hub")
+
+		// A stream created via the leaf is visible from the hub: one JS domain.
+		_, err := jsLeaf.AddStream(&nats.StreamConfig{Name: "EXT", Subjects: []string{"ext.foo"}})
+		require_NoError(t, err)
+		_, err = jsHub.StreamInfo("EXT")
+		require_NoError(t, err)
+
+		// Exactly one response to JS API requests, even with multiple servers.
+		require_Equal(t, countJSAPIResponses(t, ncHub), 1)
+		require_Equal(t, countJSAPIResponses(t, ncLeaf), 1)
+
+		// System account JS API traffic is expected to cross the leaf connection.
+		checkSysJSAPICross(t, h1, leaf, true)
+	})
+
+	t.Run("same-domain-different-sysacct", func(t *testing.T) {
+		h1, _ := startHub(t)
+		leaf := startLeaf(t, h1, "hub", false, _EMPTY_)
+		checkLeafNodeConnectedCount(t, h1, 1)
+		checkLeafNodeConnectedCount(t, leaf, 1)
+
+		ncHub, jsHub := jsClientConnect(t, h1, nats.UserInfo("a", "pwd"))
+		defer ncHub.Close()
+		ncLeaf, jsLeaf := jsClientConnect(t, leaf, nats.UserInfo("a", "pwd"))
+		defer ncLeaf.Close()
+
+		// Both claim the same domain name, but are two independent JS instances.
+		require_Equal(t, accountDomain(t, ncHub), "hub")
+		require_Equal(t, accountDomain(t, ncLeaf), "hub")
+
+		_, err := jsHub.AddStream(&nats.StreamConfig{Name: "CLASH", Subjects: []string{"hub.foo"}})
+		require_NoError(t, err)
+		_, err = jsLeaf.AddStream(&nats.StreamConfig{Name: "CLASH", Subjects: []string{"leaf.foo"}})
+		require_NoError(t, err)
+
+		_, err = jsLeaf.AddStream(&nats.StreamConfig{Name: "LEAFONLY", Subjects: []string{"leaf.only"}})
+		require_NoError(t, err)
+		_, err = jsHub.StreamInfo("LEAFONLY")
+		require_Error(t, err, nats.ErrStreamNotFound)
+
+		// Despite the same domain name, the automatic client JS API denies
+		// prevent duplicate answers over the leaf connection.
+		require_Equal(t, countJSAPIResponses(t, ncHub), 1)
+		require_Equal(t, countJSAPIResponses(t, ncLeaf), 1)
+
+		require_Equal(t, metaPeerCount(h1), 2)
+		require_Equal(t, metaPeerCount(leaf), 0)
+	})
+
+	t.Run("different-domain-same-sysacct", func(t *testing.T) {
+		h1, _ := startHub(t)
+		leaf := startLeaf(t, h1, "leaf", true, _EMPTY_)
+		checkLeafNodeConnectedCount(t, h1, 2)
+		checkLeafNodeConnectedCount(t, leaf, 2)
+
+		ncHub, jsHub := jsClientConnect(t, h1, nats.UserInfo("a", "pwd"))
+		defer ncHub.Close()
+		ncLeaf, jsLeaf := jsClientConnect(t, leaf, nats.UserInfo("a", "pwd"))
+		defer ncLeaf.Close()
+
+		// Isolated domains, each side answers with its own.
+		require_Equal(t, accountDomain(t, ncHub), "hub")
+		require_Equal(t, accountDomain(t, ncLeaf), "leaf")
+
+		// Streams stay local to each domain.
+		_, err := jsHub.AddStream(&nats.StreamConfig{Name: "CLASH", Subjects: []string{"hub.foo"}})
+		require_NoError(t, err)
+		_, err = jsLeaf.AddStream(&nats.StreamConfig{Name: "CLASH", Subjects: []string{"leaf.foo"}})
+		require_NoError(t, err)
+		_, err = jsLeaf.AddStream(&nats.StreamConfig{Name: "LEAFONLY", Subjects: []string{"leaf.only"}})
+		require_NoError(t, err)
+		_, err = jsHub.StreamInfo("LEAFONLY")
+		require_Error(t, err, nats.ErrStreamNotFound)
+
+		require_Equal(t, countJSAPIResponses(t, ncHub), 1)
+		require_Equal(t, countJSAPIResponses(t, ncLeaf), 1)
+
+		// The leaf never joins the hub's meta cluster and runs standalone.
+		require_Equal(t, metaPeerCount(h1), 2)
+		require_Equal(t, metaPeerCount(leaf), 0)
+
+		// Crucially: JS API (meta) traffic on the shared system account must NOT
+		// cross the leaf connection since the domains differ.
+		checkSysJSAPICross(t, h1, leaf, false)
+
+		// Cross-domain access via the domain-prefixed API works through the
+		// shared user account: the hub client can address the leaf domain.
+		resp, err := ncHub.Request("$JS.leaf.API.INFO", nil, 2*time.Second)
+		require_NoError(t, err)
+		var info JSApiAccountInfoResponse
+		require_NoError(t, json.Unmarshal(resp.Data, &info))
+		require_True(t, info.Error == nil)
+		require_Equal(t, info.Domain, "leaf")
+	})
+
+	// Misconfiguration: the leaf shares the system account and uses the same
+	// domain, but is a standalone server without "extension_hint: will_extend".
+	// It then does NOT extend the hub's JS domain but runs its own JetStream
+	// under the same domain name. Since a standalone JetStream server can not
+	// take part in a shared meta group, both sides must treat this connection
+	// as isolated and deny JS API traffic on the system account.
+	t.Run("same-domain-same-sysacct-standalone-no-hint", func(t *testing.T) {
+		h1, _ := startHub(t)
+		leaf := startLeaf(t, h1, "hub", true, _EMPTY_)
+		checkLeafNodeConnectedCount(t, h1, 2)
+		checkLeafNodeConnectedCount(t, leaf, 2)
+
+		ncHub, _ := jsClientConnect(t, h1, nats.UserInfo("a", "pwd"))
+		defer ncHub.Close()
+		ncLeaf, _ := jsClientConnect(t, leaf, nats.UserInfo("a", "pwd"))
+		defer ncLeaf.Close()
+
+		// The leaf did not join the meta cluster: two JS instances, one domain name.
+		require_Equal(t, metaPeerCount(h1), 2)
+		require_Equal(t, metaPeerCount(leaf), 0)
+
+		// The connection is treated as isolated: JS API traffic on the shared
+		// system account does NOT cross the leaf connection.
+		checkSysJSAPICross(t, h1, leaf, false)
+
+		// Both ends must have merged the denies themselves: the leaf from its
+		// own local check, the hub from the CONNECT echo of the leaf's
+		// standalone state.
+		checkSysLeafDenied(t, leaf)
+		checkSysLeafDenied(t, h1)
+
+		// User account requests are wrapped in a service import on the local
+		// server, so they still get exactly one answer.
+		require_Equal(t, countJSAPIResponses(t, ncHub), 1)
+		require_Equal(t, countJSAPIResponses(t, ncLeaf), 1)
+	})
+
+	// A clustered leaf has its own meta controller and CAN extend: same domain
+	// plus shared system account must still merge the meta groups (and needs no
+	// extension hint).
+	t.Run("clustered-leaf-same-domain-same-sysacct-extension", func(t *testing.T) {
+		h1, h2 := startHub(t)
+		l1, l2 := startLeafCluster(t, h1, "hub", true)
+		checkLeafNodeConnectedCount(t, h1, 4)
+		checkLeafNodeConnectedCount(t, l1, 2)
+		checkLeafNodeConnectedCount(t, l2, 2)
+
+		// Hub cluster (2) plus leaf cluster (2) form one meta group.
+		c := cluster{t: t, servers: []*Server{h1, h2}}
+		c.waitOnLeader()
+		c.waitOnPeerCount(4)
+
+		ncHub, jsHub := jsClientConnect(t, h1, nats.UserInfo("a", "pwd"))
+		defer ncHub.Close()
+		ncLeaf, jsLeaf := jsClientConnect(t, l1, nats.UserInfo("a", "pwd"))
+		defer ncLeaf.Close()
+
+		require_Equal(t, accountDomain(t, ncHub), "hub")
+		require_Equal(t, accountDomain(t, ncLeaf), "hub")
+
+		_, err := jsLeaf.AddStream(&nats.StreamConfig{Name: "EXT", Subjects: []string{"ext.foo"}})
+		require_NoError(t, err)
+		_, err = jsHub.StreamInfo("EXT")
+		require_NoError(t, err)
+
+		checkSysJSAPICross(t, h1, l1, true)
+	})
+
+	// Clustered leaf with its own domain sharing the system account: isolated,
+	// the leaf cluster keeps its own meta group.
+	t.Run("clustered-leaf-different-domain-same-sysacct", func(t *testing.T) {
+		h1, _ := startHub(t)
+		l1, l2 := startLeafCluster(t, h1, "leaf", true)
+		checkLeafNodeConnectedCount(t, h1, 4)
+
+		// The leaf cluster starts in observer mode (system account remote), and
+		// must recover to its own meta group once domains turn out to differ.
+		cl := cluster{t: t, servers: []*Server{l1, l2}}
+		cl.waitOnLeader()
+		cl.waitOnPeerCount(2)
+
+		ncHub, jsHub := jsClientConnect(t, h1, nats.UserInfo("a", "pwd"))
+		defer ncHub.Close()
+		ncLeaf, jsLeaf := jsClientConnect(t, l1, nats.UserInfo("a", "pwd"))
+		defer ncLeaf.Close()
+
+		require_Equal(t, accountDomain(t, ncHub), "hub")
+		require_Equal(t, accountDomain(t, ncLeaf), "leaf")
+
+		_, err := jsLeaf.AddStream(&nats.StreamConfig{Name: "LEAFONLY", Subjects: []string{"leaf.only"}})
+		require_NoError(t, err)
+		_, err = jsHub.StreamInfo("LEAFONLY")
+		require_Error(t, err, nats.ErrStreamNotFound)
+
+		require_Equal(t, metaPeerCount(h1), 2)
+
+		checkSysJSAPICross(t, h1, l1, false)
+	})
+
+	// A clustered leaf pointed at a standalone JetStream hub: the hub has no
+	// meta controller, so nothing can be extended even though domains match and
+	// the system account is shared. The hub advertises this, the leaf cluster
+	// must isolate (deny JS API on the system account), leave observer mode and
+	// elect its own meta leader instead of waiting forever for extension.
+	t.Run("clustered-leaf-same-domain-same-sysacct-standalone-hub", func(t *testing.T) {
+		hub := startHubSingle(t)
+		l1, l2 := startLeafCluster(t, hub, "hub", true)
+		checkLeafNodeConnectedCount(t, hub, 4)
+
+		cl := cluster{t: t, servers: []*Server{l1, l2}}
+		cl.waitOnLeader()
+		cl.waitOnPeerCount(2)
+
+		ncHub, jsHub := jsClientConnect(t, hub, nats.UserInfo("a", "pwd"))
+		defer ncHub.Close()
+		ncLeaf, jsLeaf := jsClientConnect(t, l1, nats.UserInfo("a", "pwd"))
+		defer ncLeaf.Close()
+
+		// Both sides are functional and independent, one domain name.
+		require_Equal(t, accountDomain(t, ncHub), "hub")
+		require_Equal(t, accountDomain(t, ncLeaf), "hub")
+
+		_, err := jsHub.AddStream(&nats.StreamConfig{Name: "CLASH", Subjects: []string{"hub.foo"}})
+		require_NoError(t, err)
+		_, err = jsLeaf.AddStream(&nats.StreamConfig{Name: "CLASH", Subjects: []string{"leaf.foo"}})
+		require_NoError(t, err)
+		_, err = jsLeaf.AddStream(&nats.StreamConfig{Name: "LEAFONLY", Subjects: []string{"leaf.only"}})
+		require_NoError(t, err)
+		_, err = jsHub.StreamInfo("LEAFONLY")
+		require_Error(t, err, nats.ErrStreamNotFound)
+
+		// The standalone hub has no meta group, the leaf cluster has its own.
+		require_Equal(t, metaPeerCount(hub), 0)
+
+		// JS API traffic on the shared system account must not cross.
+		checkSysJSAPICross(t, hub, l1, false)
+
+		// Both ends must have merged the denies themselves: the hub from its
+		// own local check, the leaf from the hub's INFO.
+		checkSysLeafDenied(t, hub)
+		checkSysLeafDenied(t, l1)
+	})
+
+	// Both sides standalone, same domain, shared system account, no extension
+	// hint: neither side has a meta controller, so nothing can be extended in
+	// either direction. Both must isolate and stay independently functional.
+	t.Run("standalone-hub-standalone-leaf-no-hint", func(t *testing.T) {
+		hub := startHubSingle(t)
+		leaf := startLeaf(t, hub, "hub", true, _EMPTY_)
+		checkLeafNodeConnectedCount(t, hub, 2)
+		checkLeafNodeConnectedCount(t, leaf, 2)
+
+		ncHub, jsHub := jsClientConnect(t, hub, nats.UserInfo("a", "pwd"))
+		defer ncHub.Close()
+		ncLeaf, jsLeaf := jsClientConnect(t, leaf, nats.UserInfo("a", "pwd"))
+		defer ncLeaf.Close()
+
+		// Two independent JS instances, one domain name, no meta groups at all.
+		require_Equal(t, accountDomain(t, ncHub), "hub")
+		require_Equal(t, accountDomain(t, ncLeaf), "hub")
+		require_Equal(t, metaPeerCount(hub), 0)
+		require_Equal(t, metaPeerCount(leaf), 0)
+
+		_, err := jsHub.AddStream(&nats.StreamConfig{Name: "CLASH", Subjects: []string{"hub.foo"}})
+		require_NoError(t, err)
+		_, err = jsLeaf.AddStream(&nats.StreamConfig{Name: "CLASH", Subjects: []string{"leaf.foo"}})
+		require_NoError(t, err)
+		_, err = jsLeaf.AddStream(&nats.StreamConfig{Name: "LEAFONLY", Subjects: []string{"leaf.only"}})
+		require_NoError(t, err)
+		_, err = jsHub.StreamInfo("LEAFONLY")
+		require_Error(t, err, nats.ErrStreamNotFound)
+
+		require_Equal(t, countJSAPIResponses(t, ncHub), 1)
+		require_Equal(t, countJSAPIResponses(t, ncLeaf), 1)
+
+		checkSysJSAPICross(t, hub, leaf, false)
+		checkSysLeafDenied(t, hub)
+		checkSysLeafDenied(t, leaf)
+	})
+
+	// A standalone leaf soliciting a standalone hub WITH will_extend: the
+	// leaf runs a meta controller solely to join the hub's meta group, but
+	// the hub advertises that it can never produce a meta leader. A single
+	// server must not form a meta group of its own, so the leaf stays in
+	// observer mode without a leader and its JetStream remains unavailable
+	// until the configuration is corrected. The connection is still isolated
+	// in both directions.
+	t.Run("standalone-hub-standalone-leaf-will-extend", func(t *testing.T) {
+		hub := startHubSingle(t)
+		leaf := startLeaf(t, hub, "hub", true, jsWillExtend)
+		checkLeafNodeConnectedCount(t, hub, 2)
+		checkLeafNodeConnectedCount(t, leaf, 2)
+
+		// Isolation applies on both ends; this also proves the extension
+		// decision has been made on both sides before checking meta state.
+		checkSysLeafDenied(t, hub)
+		checkSysLeafDenied(t, leaf)
+		checkSysJSAPICross(t, hub, leaf, false)
+
+		// The leaf keeps its meta controller in observer mode, leaderless.
+		mg := leaf.getJetStream().getMetaGroup()
+		require_True(t, mg != nil)
+		require_True(t, mg.IsObserver())
+		require_Equal(t, mg.GroupLeader(), _EMPTY_)
+		require_Equal(t, metaPeerCount(hub), 0)
+
+		// The hub's JetStream works normally.
+		ncHub, jsHub := jsClientConnect(t, hub, nats.UserInfo("a", "pwd"))
+		defer ncHub.Close()
+		require_Equal(t, accountDomain(t, ncHub), "hub")
+		_, err := jsHub.AddStream(&nats.StreamConfig{Name: "HUBSTREAM", Subjects: []string{"hub.foo"}})
+		require_NoError(t, err)
+
+		// The leaf's JetStream is unavailable: no meta leader can answer.
+		ncLeaf := natsConnect(t, fmt.Sprintf("nats://a:pwd@127.0.0.1:%d", leaf.opts.Port))
+		defer ncLeaf.Close()
+		jsLeaf, err := ncLeaf.JetStream(nats.MaxWait(time.Second))
+		require_NoError(t, err)
+		_, err = jsLeaf.AddStream(&nats.StreamConfig{Name: "LEAFONLY", Subjects: []string{"leaf.only"}})
+		require_Error(t, err)
+	})
+
+	// A standalone will_extend server joins the upstream meta group, so it
+	// must keep advertising itself as extendable on its own leafnode listener:
+	// a leaf chained below it extends the domain THROUGH it and must not be
+	// told to isolate. This is the reason a standalone server soliciting
+	// extension reports extendable.
+	t.Run("chained-leaf-through-standalone-will-extend", func(t *testing.T) {
+		h1, h2 := startHub(t)
+		hint := fmt.Sprintf("extension_hint: %s", jsWillExtend)
+
+		// Middle: standalone will_extend server extending the hub's domain,
+		// with its own leafnode listener.
+		midConf := createConfFile(t, []byte(fmt.Sprintf(lnDomainLeafHubTmpl, "MID", "hub", t.TempDir(), hint,
+			lnDomainRemotes(h1.opts.LeafNode.Port, true))))
+		mid, _ := RunServerWithConfig(midConf)
+		t.Cleanup(mid.Shutdown)
+		checkLeafNodeConnectedCount(t, mid, 2)
+
+		c := cluster{t: t, servers: []*Server{h1, h2}}
+		c.waitOnLeader()
+		c.waitOnPeerCount(3)
+
+		// Bottom: another standalone will_extend leaf, chained below the
+		// middle server. It must extend through it and join the meta group.
+		bottom := startLeaf(t, mid, "hub", true, jsWillExtend)
+		checkLeafNodeConnectedCount(t, bottom, 2)
+		c.waitOnPeerCount(4)
+
+		ncHub, jsHub := jsClientConnect(t, h1, nats.UserInfo("a", "pwd"))
+		defer ncHub.Close()
+		ncBottom, jsBottom := jsClientConnect(t, bottom, nats.UserInfo("a", "pwd"))
+		defer ncBottom.Close()
+
+		require_Equal(t, accountDomain(t, ncBottom), "hub")
+
+		// A stream created via the bottom leaf is visible from the hub: one
+		// JS domain across both hops.
+		_, err := jsBottom.AddStream(&nats.StreamConfig{Name: "CHAINED", Subjects: []string{"chained.foo"}})
+		require_NoError(t, err)
+		_, err = jsHub.StreamInfo("CHAINED")
+		require_NoError(t, err)
+
+		// System account JS API traffic crosses both hops.
+		checkSysJSAPICross(t, h1, bottom, true)
+	})
+}
+
+// A leaf that boots with will_extend but NO system account remote
+// (standalone JS, no meta controller). A config reload then adds the system
+// account remote. Config-derived capability now claims extendable while the
+// runtime is still standalone.
+func TestJetStreamLeafNodeSysRemoteAddedByReloadNotExtended(t *testing.T) {
+	h1Conf := createConfFile(t, []byte(fmt.Sprintf(lnDomainHubTmpl, "HUB1", t.TempDir(), lnDomainClusterBlock("HUB", 23480, 23481))))
+	h1, _ := RunServerWithConfig(h1Conf)
+	defer h1.Shutdown()
+	h2Conf := createConfFile(t, []byte(fmt.Sprintf(lnDomainHubTmpl, "HUB2", t.TempDir(), lnDomainClusterBlock("HUB", 23481, 23480))))
+	h2, _ := RunServerWithConfig(h2Conf)
+	defer h2.Shutdown()
+	checkClusterFormed(t, h1, h2)
+	c := cluster{t: t, servers: []*Server{h1, h2}}
+	c.waitOnLeader()
+
+	sd := t.TempDir()
+	hint := fmt.Sprintf("extension_hint: %s", jsWillExtend)
+	lnPort := h1.opts.LeafNode.Port
+	leafConf := createConfFile(t, []byte(fmt.Sprintf(lnDomainLeafTmpl, "LEAF", "hub", sd, hint, _EMPTY_, lnDomainRemotes(lnPort, false))))
+	leaf, _ := RunServerWithConfig(leafConf)
+	defer leaf.Shutdown()
+	checkLeafNodeConnectedCount(t, leaf, 1)
+
+	// Boot state: standalone JS, no meta controller.
+	require_True(t, leaf.getJetStream().getMetaGroup() == nil)
+
+	// Reload: add the system account remote.
+	reloadUpdateConfig(t, leaf, leafConf, fmt.Sprintf(lnDomainLeafTmpl, "LEAF", "hub", sd, hint, _EMPTY_, lnDomainRemotes(lnPort, true)))
+	checkLeafNodeConnectedCount(t, leaf, 2)
+
+	// Still no meta controller after the reload.
+	require_True(t, leaf.getJetStream().getMetaGroup() == nil)
+
+	// Check that sys account JS API traffic does NOT cross.
+	checkSysJSAPICross(t, h1, leaf, false)
+
+	// Both ends must have merged the denies themselves: the leaf from its
+	// runtime check, the hub from the CONNECT advertising the leaf's runtime
+	// state.
+	checkSysLeafDenied(t, leaf)
+	checkSysLeafDenied(t, h1)
+}
+
+// A chained middle server (standalone will_extend with its own leafnode
+// listener) boots extendable and joins the hub's meta group. A config reload
+// then removes the system account remote: the middle server can no longer
+// take part in the shared meta group and must stop advertising extendability
+// in its leafnode INFO, so a downstream leaf connecting AFTER the reload
+// isolates on its own side instead of waiting in observer mode for an
+// extension that can not happen.
+func TestJetStreamLeafNodeSysRemoteRemovedByReloadNotExtendable(t *testing.T) {
+	h1Conf := createConfFile(t, []byte(fmt.Sprintf(lnDomainHubTmpl, "HUB1", t.TempDir(), lnDomainClusterBlock("HUB", 23490, 23491))))
+	h1, _ := RunServerWithConfig(h1Conf)
+	defer h1.Shutdown()
+	h2Conf := createConfFile(t, []byte(fmt.Sprintf(lnDomainHubTmpl, "HUB2", t.TempDir(), lnDomainClusterBlock("HUB", 23491, 23490))))
+	h2, _ := RunServerWithConfig(h2Conf)
+	defer h2.Shutdown()
+	checkClusterFormed(t, h1, h2)
+	c := cluster{t: t, servers: []*Server{h1, h2}}
+	c.waitOnLeader()
+
+	// Middle: standalone will_extend server with its own leafnode listener,
+	// extending the hub's domain.
+	sd := t.TempDir()
+	hint := fmt.Sprintf("extension_hint: %s", jsWillExtend)
+	midConf := createConfFile(t, []byte(fmt.Sprintf(lnDomainLeafHubTmpl, "MID", "hub", sd, hint, lnDomainRemotes(h1.opts.LeafNode.Port, true))))
+	mid, _ := RunServerWithConfig(midConf)
+	defer mid.Shutdown()
+	checkLeafNodeConnectedCount(t, mid, 2)
+	c.waitOnPeerCount(3)
+
+	// Reload: remove the system account remote from the middle server.
+	reloadUpdateConfig(t, mid, midConf, fmt.Sprintf(lnDomainLeafHubTmpl, "MID", "hub", sd, hint, lnDomainRemotes(h1.opts.LeafNode.Port, false)))
+	checkLeafNodeConnectedCount(t, mid, 1)
+
+	// A downstream leaf soliciting the middle server after the reload must
+	// isolate on its own side, based on the refreshed INFO.
+	bottomConf := createConfFile(t, []byte(fmt.Sprintf(lnDomainLeafTmpl, "LEAF", "hub", t.TempDir(), hint, _EMPTY_, lnDomainRemotes(mid.opts.LeafNode.Port, true))))
+	bottom, _ := RunServerWithConfig(bottomConf)
+	defer bottom.Shutdown()
+	checkLeafNodeConnectedCount(t, bottom, 2)
+
+	checkSysLeafDenied(t, mid)
+	checkSysLeafDenied(t, bottom)
+	checkSysJSAPICross(t, mid, bottom, false)
 }
 
 func TestJetStreamLeafNodeCredsDenies(t *testing.T) {

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -29,6 +29,7 @@ import (
 	"path"
 	"regexp"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -79,6 +80,10 @@ type leaf struct {
 	remoteServer string
 	// domain name of remote server
 	remoteDomain string
+	// remote runs standalone JetStream and can never be part of a shared meta
+	// group. From the hub's INFO when solicited, from the CONNECT echo when
+	// accepted.
+	remoteNoExt bool
 	// account name of remote server
 	remoteAccName string
 	// Whether or not we want to propagate east-west interest from other LNs.
@@ -976,6 +981,10 @@ func (s *Server) startLeafNodeAcceptLoop() {
 		return
 	}
 
+	// Compute before taking the server lock: the runtime part reads JetStream
+	// state under its own lock.
+	jsNoExt := s.jetStreamLeafNoExtend()
+
 	s.mu.Lock()
 	hp := net.JoinHostPort(opts.LeafNode.Host, strconv.Itoa(port))
 	l, e := natsListen("tcp", hp)
@@ -1009,6 +1018,8 @@ func (s *Server) startLeafNodeAcceptLoop() {
 		Proto:         s.getServerProto(),
 		InfoOnConnect: true,
 		JSApiLevel:    JSApiLevel,
+
+		JetStreamNotExtendable: jsNoExt,
 	}
 	// If we have selected a random port...
 	if port == 0 {
@@ -1055,9 +1066,10 @@ func (s *Server) startLeafNodeAcceptLoop() {
 // RegEx to match a creds file with user JWT and Seed.
 var credsRe = regexp.MustCompile(`\s*(?:(?:[-]{3,}.*[-]{3,}\r?\n)([\w\-.=]+)(?:\r?\n[-]{3,}.*[-]{3,}(\r?\n|\z)))`)
 
-// clusterName is provided as argument to avoid lock ordering issues with the locked client c
+// clusterName and jsNoExt are provided as arguments to avoid lock ordering
+// issues with the locked client c.
 // Lock should be held entering here.
-func (c *client) sendLeafConnect(clusterName string, headers bool) error {
+func (c *client) sendLeafConnect(clusterName string, headers, jsNoExt bool) error {
 	// We support basic user/pass and operator based user JWT with signatures.
 	cinfo := leafConnectInfo{
 		Version:       VERSION,
@@ -1073,6 +1085,8 @@ func (c *client) sendLeafConnect(clusterName string, headers bool) error {
 		RemoteAccount: c.acc.GetName(),
 		Proto:         c.srv.getServerProto(),
 		Isolate:       c.leaf.remote.RequestIsolation,
+
+		JetStreamNotExtendable: jsNoExt,
 	}
 
 	// If a signature callback is specified, this takes precedence over anything else.
@@ -1215,6 +1229,20 @@ func (s *Server) generateLeafNodeInfoJSON() {
 	s.leafNodeInfo.LeafNodeURLs = s.leafURLsMap.getAsStringSlice()
 	s.leafNodeInfo.WSConnectURLs = s.websocket.connectURLsMap.getAsStringSlice()
 	s.leafNodeInfoJSON = generateInfoJSON(&s.leafNodeInfo)
+}
+
+// updateLeafNodeJSNoExtInfo recomputes whether this leaf can extend the
+// remote's meta group over a shared system account.
+func (s *Server) updateLeafNodeJSNoExtInfo() {
+	// Compute before taking the server lock: the runtime part reads JetStream
+	// state under its own lock.
+	noExt := s.jetStreamLeafNoExtend()
+	s.mu.Lock()
+	if s.leafNodeInfo.JetStreamNotExtendable != noExt {
+		s.leafNodeInfo.JetStreamNotExtendable = noExt
+		s.generateLeafNodeInfoJSON()
+	}
+	s.mu.Unlock()
 }
 
 // Sends an async INFO protocol so that the connected servers can update
@@ -1669,6 +1697,7 @@ func (c *client) processLeafnodeInfo(info *Info) {
 			c.leaf.remoteServer = info.Name
 		}
 		c.leaf.remoteDomain = info.Domain
+		c.leaf.remoteNoExt = info.JetStreamNotExtendable
 		c.leaf.remoteCluster = info.Cluster
 		// We send the protocol version in the INFO protocol.
 		// Keep track of it, so we know if this connection supports message
@@ -1932,6 +1961,7 @@ func (s *Server) addLeafNodeConnection(c *client, srvName, clusterName string, c
 		accName = acc.Name
 	}
 	myRemoteDomain := c.leaf.remoteDomain
+	myRemoteNoExt := c.leaf.remoteNoExt
 	mySrvName := c.leaf.remoteServer
 	remoteAccName := c.leaf.remoteAccName
 	myClustName := c.leaf.remoteCluster
@@ -2029,6 +2059,15 @@ func (s *Server) addLeafNodeConnection(c *client, srvName, clusterName string, c
 		}
 	}
 
+	// A standalone JetStream server (no meta controller) on either side can
+	// never be part of a shared meta group: treat it like a domain mismatch
+	// and isolate.
+	confNoExt := s.jetStreamNotExtendable()
+	// Runtime state: JetStream started without a meta controller (e.g. the
+	// system account remote was added by config reload), only a restart helps.
+	localNoExtRestart := !confNoExt && s.jetStreamStartedWithoutMetaController()
+	localNoExt := confNoExt || localNoExtRestart
+
 	// If the server has JS disabled, it may still be part of a JetStream that could be extended.
 	// This is either signaled by js being disabled and a domain set,
 	// or in cases where no domain name exists, an extension hint is set.
@@ -2036,27 +2075,57 @@ func (s *Server) addLeafNodeConnection(c *client, srvName, clusterName string, c
 	//
 	// If the system account connects but default domains are present, JetStream can't be extended.
 	if opts.JetStreamDomain != myRemoteDomain || (!opts.JetStream && (opts.JetStreamDomain == _EMPTY_ && opts.JetStreamExtHint != jsWillExtend)) ||
-		sysAcc == nil || acc == nil || forceSysAccDeny {
+		sysAcc == nil || acc == nil || forceSysAccDeny || myRemoteNoExt || localNoExt {
 		// If domain names mismatch always deny. This applies to system accounts as well as non system accounts.
 		// Not having a system account, account or JetStream disabled is considered a mismatch as well.
 		if acc != nil && acc == sysAcc {
 			c.Noticef("System account connected from %s", srvDecorated())
-			c.Noticef("JetStream not extended, domains differ")
+			if opts.JetStreamDomain == myRemoteDomain && (myRemoteNoExt || localNoExt) {
+				if localNoExt {
+					c.Noticef("JetStream not extended, this server runs standalone JetStream and can not take part in a JetStream meta group")
+					if localNoExtRestart {
+						c.Noticef("Restart the server to be able to extend the JetStream domain")
+					} else if s.canExtendOtherDomain() {
+						c.Noticef(`To extend instead, set the JetStream Option "extension_hint: %s"`, jsWillExtend)
+					}
+				} else {
+					c.Noticef("JetStream not extended, remote server runs standalone JetStream and can not be extended")
+				}
+			} else {
+				c.Noticef("JetStream not extended, domains differ")
+			}
 			c.mergeDenyPermissionsLocked(both, denyAllJs)
 			// When a remote with a system account is present in a server, unless otherwise disabled, the server will be
 			// started in observer mode. Now that it is clear that this not used, turn the observer mode off.
 			if solicited && meta != nil && meta.IsObserver() {
-				meta.setObserver(false, extNotExtended)
-				c.Debugf("Turning JetStream metadata controller Observer Mode off")
-				// Take note that the domain was not extended to avoid this state from startup.
-				writePeerState(c.srv.diskIOSemaphore(), js.config.StoreDir, meta.currentPeerState())
-				// Meta controller can't be leader yet.
-				// Yet it is possible that due to observer mode every server already stopped campaigning.
-				// Therefore this server needs to be kicked into campaigning gear explicitly.
-				meta.Campaign()
+				if s.standAloneMode() {
+					// A standalone server runs a meta controller solely to join the remote's
+					// meta group (soliciting extension via will_extend). A single server must
+					// not form a meta group of its own, so stay in observer mode: JetStream
+					// remains unavailable until the configuration is corrected.
+					c.Warnf("JetStream can not be extended over this connection and a single standalone server can not form its own meta group, JetStream will be unavailable")
+					c.Warnf(`Remove the JetStream Option "extension_hint: %s" and restart to run JetStream standalone instead`, jsWillExtend)
+				} else {
+					meta.setObserver(false, extNotExtended)
+					c.Debugf("Turning JetStream metadata controller Observer Mode off")
+					// Take note that the domain was not extended to avoid this state from startup.
+					writePeerState(c.srv.diskIOSemaphore(), js.config.StoreDir, meta.currentPeerState())
+					// Meta controller can't be leader yet.
+					// Yet it is possible that due to observer mode every server already stopped campaigning.
+					// Therefore this server needs to be kicked into campaigning gear explicitly.
+					meta.Campaign()
+				}
 			}
 		} else {
-			c.Noticef("JetStream using domains: local %q, remote %q", opts.JetStreamDomain, myRemoteDomain)
+			if opts.JetStreamDomain == myRemoteDomain {
+				if opts.JetStreamDomain != _EMPTY_ {
+					c.Noticef("JetStream isolated: remote server uses the same JetStream domain %q but is not part of this JetStream", opts.JetStreamDomain)
+				} else {
+					c.Noticef("JetStream isolated: remote server is not part of this JetStream")
+				}
+			} else {
+				c.Noticef("JetStream using domains: local %q, remote %q", opts.JetStreamDomain, myRemoteDomain)
+			}
 			c.mergeDenyPermissionsLocked(both, denyAllClientJs)
 		}
 		blockMappingOutgoing = true
@@ -2068,6 +2137,25 @@ func (s *Server) addLeafNodeConnection(c *client, srvName, clusterName string, c
 		// Therefore, server with a remote that are not already in observer mode, need to be put into it.
 		if solicited && meta != nil && !meta.IsObserver() {
 			c.Debugf("Turning JetStream metadata controller Observer Mode on - System Account Connected")
+			// If this server operated its own meta group before extending, for example because
+			// it ran isolated while the remote could not be extended, or it was started with a
+			// wrong extension hint, all of its own assignments are orphaned and locally created
+			// assets will be deleted.
+			var nStreams, nConsumers int
+			js.mu.RLock()
+			if cc := js.cluster; cc != nil {
+				for _, asa := range cc.streams {
+					nStreams += len(asa)
+					for _, sa := range asa {
+						nConsumers += len(sa.consumers)
+					}
+				}
+			}
+			js.mu.RUnlock()
+			if nStreams > 0 || nConsumers > 0 {
+				c.Warnf("Extending JetStream domain %q orphans local JetStream state: %d stream(s) and %d consumer(s) created while not part of the extended JetStream will be deleted",
+					myRemoteDomain, nStreams, nConsumers)
+			}
 			// Discard any local metagroup state accumulated before the SYS-account
 			// leaf came up (e.g. the wrong-hint case where this server bootstrapped
 			// its own metagroup). The parent's view is now authoritative; without
@@ -2084,6 +2172,21 @@ func (s *Server) addLeafNodeConnection(c *client, srvName, clusterName string, c
 		c.Debugf("Adding deny %+v for account %q", denyAllClientJs, accName)
 		c.mergeDenyPermissionsLocked(both, denyAllClientJs)
 	}
+	// Two servers can use the same domain name without sharing the system
+	// account, in which case they are two independent JetStreams that both
+	// claim the same domain name, and the domain no longer uniquely identifies
+	// one JetStream. Only the soliciting side can detect this, by knowing that
+	// none of its remotes binds the system account.
+	if solicited && acc != nil && acc != sysAcc && sysAcc != nil &&
+		opts.JetStream && opts.JetStreamDomain != _EMPTY_ && opts.JetStreamDomain == myRemoteDomain {
+		sysName := sysAcc.GetName()
+		hasSysRemote := slices.ContainsFunc(opts.LeafNode.Remotes, func(r *RemoteLeafOpts) bool {
+			return r.LocalAccount == sysName
+		})
+		if !hasSysRemote {
+			c.Warnf("Remote server uses the same JetStream domain %q without sharing the system account, both JetStreams remain independent", opts.JetStreamDomain)
+		}
+	}
 	// If we have a specified JetStream domain we will want to add a mapping to
 	// allow access cross domain for each non-system account.
 	if opts.JetStreamDomain != _EMPTY_ && opts.JetStream && acc != nil && acc != sysAcc {
@@ -2094,13 +2197,16 @@ func (s *Server) addLeafNodeConnection(c *client, srvName, clusterName string, c
 				c.Debugf("Adding JetStream Domain Mapping %q -> %s to account %q", src, dest, accName)
 			}
 		}
-		if blockMappingOutgoing {
+		// When the remote reports the SAME domain name (an isolated connection
+		// due to a standalone JetStream server on either end), the remote has
+		// identical domain mappings and propagates subscription interest for
+		// them. A deny for the domain API would then trigger permission
+		// violations that close the connection. Domain mappings rewrite the
+		// subject at the entry server anyway, so nothing crosses in that case.
+		if blockMappingOutgoing && opts.JetStreamDomain != myRemoteDomain {
 			src := fmt.Sprintf(jsDomainAPI, opts.JetStreamDomain)
-			// make sure that messages intended for this domain, do not leave the cluster via this leaf node connection
-			// This is a guard against a miss-config with two identical domain names and will only cover some forms
-			// of this issue, not all of them.
-			// This guards against a hub and a spoke having the same domain name.
-			// But not two spokes having the same one and the request coming from the hub.
+			// Make sure that messages intended for this domain do not leave the
+			// cluster via this leaf node connection.
 			c.mergeDenyPermissionsLocked(pub, []string{src})
 			c.Debugf("Adding deny %q for outgoing messages to account %q", src, accName)
 		}
@@ -2160,6 +2266,10 @@ type leafConnectInfo struct {
 	JetStream bool     `json:"jetstream,omitempty"`
 	DenyPub   []string `json:"deny_pub,omitempty"`
 	Isolate   bool     `json:"isolate,omitempty"`
+
+	// Mirror of Info.JetStreamNotExtendable, so the accept side can isolate
+	// the connection as well. Old servers never set this.
+	JetStreamNotExtendable bool `json:"js_no_ext,omitempty"`
 
 	// There was an existing field called:
 	// >> Comp bool `json:"compression,omitempty"`
@@ -2278,6 +2388,7 @@ func (c *client) processLeafNodeConnect(s *Server, arg []byte, lang string) erro
 	}
 
 	c.leaf.remoteDomain = proto.Domain
+	c.leaf.remoteNoExt = proto.JetStreamNotExtendable
 
 	// When a leaf solicits a connection to a hub, the perms that it will use on the soliciting leafnode's
 	// behalf are correct for them, but inside the hub need to be reversed since data is flowing in the opposite direction.
@@ -3672,13 +3783,16 @@ const connectProcessTimeout = 2 * time.Second
 // protocol.
 func (s *Server) leafNodeResumeConnectProcess(c *client) {
 	clusterName := s.ClusterName()
+	// Advertise the standalone state, so the accept side isolates the
+	// connection just like we do.
+	jsNoExt := s.jetStreamLeafNoExtend()
 
 	c.mu.Lock()
 	if c.isClosed() {
 		c.mu.Unlock()
 		return
 	}
-	if err := c.sendLeafConnect(clusterName, c.headers); err != nil {
+	if err := c.sendLeafConnect(clusterName, c.headers, jsNoExt); err != nil {
 		c.mu.Unlock()
 		c.closeConnection(WriteError)
 		return

--- a/server/reload.go
+++ b/server/reload.go
@@ -1214,6 +1214,9 @@ func (l *leafNodeOption) Apply(s *Server) {
 			checkRemovedLeafNodeCfgsAsync(s)
 		}
 	}
+	// Changed remotes can change whether this server could take part in a
+	// shared JetStream meta group; refresh what is advertised to leafnodes.
+	s.updateLeafNodeJSNoExtInfo()
 }
 
 // Go through the removed remote leafnode configs map to check if the

--- a/server/server.go
+++ b/server/server.go
@@ -136,6 +136,10 @@ type Info struct {
 	RemoteAccount     string   `json:"remote_account,omitempty"` // Lets the client or leafnode side know the remote account that they bind to.
 	IsSystemAccount   bool     `json:"acc_is_sys,omitempty"`     // Indicates if the account is a system account.
 	JSApiLevel        int      `json:"api_lvl,omitempty"`
+	// Leafnode specific: indicates this server runs JetStream in standalone
+	// mode (no meta controller) and can never be part of a shared JetStream
+	// meta group. Old servers never set this, which preserves their behavior.
+	JetStreamNotExtendable bool `json:"js_no_ext,omitempty"`
 
 	// Route Specific
 	Import        *SubjectPermission `json:"import,omitempty"`


### PR DESCRIPTION
The extend/isolate decision for leafnode connections binding the system account only compared configuration claims (same JetStream domain + shared system account), without checking whether either side actually has a meta controller to extend. A standalone JetStream server (no cluster/gateway, or a solicited side without `extension_hint: will_extend`) never starts one, yet the extend branch was still taken. Resulting misbehavior:

- Two independent JetStreams under the same domain kept exchanging system account JS API/raft traffic (`$JS.API.>`, `$NRG.>`, `$JSC.>`) across the leafnode connection.
- A leaf running a meta group for extension, soliciting a standalone hub, waited in observer mode forever, leaving its JetStream unusable. However, a standalone leaf with an explicit `will_extend` will remain in observer mode until the leaf/hub is properly configured.

Servers now advertise whether they can take part in a shared meta group (`js_no_ext` in the leafnode INFO and CONNECT), derived from configuration and runtime state (since remotes can be config reloaded to add/remove the system account connection and must then not return to bad behavior). If either side can't extend, the connection is isolated with the same denies as a domain mismatch, on both ends independently. Old servers never set the field, so mixed-version links keep their existing behavior.

Additionally, log messages are improved: leaf extension now warns when locally created streams/consumers are orphaned and deleted as a result of adopting the parent's meta state, and isolation/extension log messages are clarified.

Intended configurations are the following:
- No extension: separate JetStream domains, system accounts are allowed to be shared for monitoring purposes, etc.
- With extension: both the JetStream domain and system account are shared and the hub is clustered.

Other permutations are deemed as misconfigurations, and the server will now properly isolate in these cases.