### PR TITLE
[FIXED] "TLS required" logged at startup when allow_non_tls is set

### DIFF
--- a/server/client_test.go
+++ b/server/client_test.go
@@ -3334,6 +3334,67 @@ func TestTLSClientHandshakeFirstFallbackDelayAndAllowNonTLS(t *testing.T) {
 	checkConnInfo(false, false)
 }
 
+func TestTLSClientNoticeWithAllowNonTLS(t *testing.T) {
+	tc := &TLSConfigOpts{
+		CertFile: "../test/configs/certs/server-cert.pem",
+		KeyFile:  "../test/configs/certs/server-key.pem",
+		CaFile:   "../test/configs/certs/ca.pem",
+	}
+	tlsConfig, err := GenTLSConfig(tc)
+	require_NoError(t, err)
+
+	const (
+		tlsRequired  = "TLS required for client connections"
+		tlsAvailable = "TLS available for client connections"
+	)
+	for _, test := range []struct {
+		name        string
+		allowNonTLS bool
+		first       bool
+		fallback    time.Duration
+		expected    string
+	}{
+		{"tls only", false, false, 0, tlsRequired},
+		{"allow non tls", true, false, 0, tlsAvailable},
+		// With "TLS first" and no fallback delay, non TLS clients are rejected
+		// even with allow_non_tls, so TLS is really required.
+		{"allow non tls and tls first", true, true, 0, tlsRequired},
+		// But with a fallback delay, they are accepted once it has expired.
+		{"allow non tls and tls first with fallback", true, true, 25 * time.Millisecond, tlsAvailable},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			o := DefaultOptions()
+			o.TLSConfig = tlsConfig.Clone()
+			o.AllowNonTLS = test.allowNonTLS
+			o.TLSHandshakeFirst = test.first
+			o.TLSHandshakeFirstFallback = test.fallback
+
+			s, err := NewServer(o)
+			require_NoError(t, err)
+			defer s.Shutdown()
+
+			// Set the logger before starting the server so that the notices
+			// emitted by the client accept loop are captured.
+			l := &captureNoticeLogger{}
+			s.SetLogger(l, false, false)
+			go s.Start()
+			require_NoError(t, s.readyForConnections(time.Second))
+
+			var notices []string
+			l.Lock()
+			for _, n := range l.notices {
+				if strings.HasPrefix(n, "TLS ") && strings.HasSuffix(n, " for client connections") {
+					notices = append(notices, n)
+				}
+			}
+			l.Unlock()
+			if len(notices) != 1 || notices[0] != test.expected {
+				t.Fatalf("Expected notice %q, got %q", test.expected, notices)
+			}
+		})
+	}
+}
+
 func TestTLSClientHandshakeFirstAndInProcessConnection(t *testing.T) {
 	conf := createConfFile(t, []byte(`
 		listen: "127.0.0.1:-1"

--- a/server/server.go
+++ b/server/server.go
@@ -2793,8 +2793,15 @@ func (s *Server) AcceptLoop(clr chan struct{}) {
 
 	// Alert of TLS enabled.
 	if opts.TLSConfig != nil {
-		s.Noticef("TLS required for client connections")
-		if opts.TLSHandshakeFirst && opts.TLSHandshakeFirstFallback == 0 {
+		// "TLS Handshake First" without a fallback delay always requires the
+		// handshake, which overrides "allow_non_tls".
+		tlsHandshakeFirstOnly := opts.TLSHandshakeFirst && opts.TLSHandshakeFirstFallback == 0
+		if opts.AllowNonTLS && !tlsHandshakeFirstOnly {
+			s.Noticef("TLS available for client connections")
+		} else {
+			s.Noticef("TLS required for client connections")
+		}
+		if tlsHandshakeFirstOnly {
 			s.Warnf("Clients that are not using \"TLS Handshake First\" option will fail to connect")
 		}
 	}


### PR DESCRIPTION
Resolves #8419

## Problem

The client accept loop emits its TLS startup notice based only on whether a TLS config exists:

```go
// Alert of TLS enabled.
if opts.TLSConfig != nil {
    s.Noticef("TLS required for client connections")
    ...
}
```

`opts.AllowNonTLS` is never consulted, so a server configured with a `tls{}` block **and** `allow_non_tls: true` tells the operator that TLS is required while it is in fact accepting both TLS and plaintext clients on the same port.

Everything else in the server already gets this right:

- `server/server.go:743` — the INFO sent to clients is built with `TLSRequired: tlsReq && !opts.AllowNonTLS`, advertising `TLSAvailable` instead, so clients are correctly told TLS is optional.
- `server/server.go:3410` — the accept path sniffs TLS versus plaintext: `sniffTLS := !tlsFirst && opts.TLSConfig != nil && (inProcess || opts.AllowNonTLS)`.

Only the operator-facing log line disagrees with what the server does. The existing comment, "Alert of TLS enabled", suggests the intent was "TLS is configured", not "TLS is required".

This came out of a 2.12.5 deployment with `tls{cert_file, key_file, ca_file}` plus `allow_non_tls: true`, whose banner read "TLS required for client connections" while its own `/connz` listed, on that same port:

| name | lang | TLS |
| --- | --- | --- |
| `nats-modbus-1-server-id-1-connection` | .NET | 1.3 |
| `nats-iec61850-1-server-id-1-connection` | .NET | 1.3 |
| `ProducerPrimary` | .NET | 1.3 |
| `NATS CLI Version 0.4.0` | go | plaintext |

A `nats sub` / `nats pub` round trip over plain `nats://localhost:4222` succeeded against that server at the same time. The banner is the first thing an operator reads when diagnosing connectivity, and here it asserts a security property the server is not enforcing; it cost real debugging time during an unrelated certificate investigation, because plaintext clients had been ruled out on the strength of that line. The inverse case matters more: on a deployment meant to be TLS-only, the same message hides a stray `allow_non_tls: true` that is still accepting cleartext.

## Change

The notice now distinguishes the two cases:

| config | before | after |
| --- | --- | --- |
| `tls{}` | `TLS required for client connections` | unchanged |
| `tls{}` + `allow_non_tls` | `TLS required for client connections` | `TLS available for client connections` |
| `tls{}` + `allow_non_tls` + `handshake_first: true` | `TLS required for client connections` | unchanged |
| `tls{}` + `allow_non_tls` + `handshake_first` with fallback delay | `TLS required for client connections` | `TLS available for client connections` |

The `TLSHandshakeFirst` warning below it is untouched; the condition it uses is now hoisted into a local and shared with the notice so the two cannot drift apart. No behavioral change beyond the log text, and nothing added to `go.mod`.

**On the wording.** This is vocabulary NATS already uses for this configuration, not something invented here: the INFO protocol distinguishes `tls_required` from `tls_available`, and the TLS documentation describes exactly this setup as configuring the server as "tls available" — "This is done via an empty `tls` block and the `allow_non_tls` flag" ([docs](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/tls)). With `tls {}` + `allow_non_tls: true`, the log line and the docs now say the same words. If you would rather be more explicit, `TLS available for client connections (non-TLS clients allowed)` is fine by me — I picked the terse form only to mirror the protocol field and the docs.

**Why not just `s.info.TLSRequired`.** The condition looks redundant next to `server/server.go:743`, but collapsing it would be wrong. With certs + `allow_non_tls: true` + `handshake_first: true`, `info.TLSRequired` is false, yet TLS is genuinely mandatory — the handshake-first override is applied per connection at `server/server.go:3308-3310`, not on the startup info. I confirmed with a built binary that a raw plaintext socket is refused in that configuration. Hence the explicit handshake-first term, which the third row of the table and the third test case pin down.

## Scope

- This was the only place that reported it wrong. `/varz` (`server/monitor.go:1808`) and `PortsInfo` (`server/server.go:4249`) both derive from `info.TLSRequired` and are already correct under `allow_non_tls`.
- The notice is emitted once from `AcceptLoop` at startup and, as before, is not re-emitted on config reload. `AllowNonTLS` is not reloadable in any case, so the reported scenario is startup-only.
- It describes the TCP client listener. In-process connections (`s.InProcessConn`) negotiate TLS-or-plaintext regardless of `allow_non_tls` (`server/server.go:3289`, `:3410`); that is pre-existing, unchanged here, and `AcceptLoop` is not even entered under `DontListen`.
- **Out of scope:** `server/mqtt.go:550` picks the `tls://` scheme for the MQTT listen line on `TLSConfig != nil`, while `server/mqtt.go:625` honours the same `opts.AllowNonTLS`, so that line has a related inaccuracy. It is a different message with different semantics, so I left it out deliberately — happy to follow up separately if you want it fixed.

## Testing

Added a regression test using the existing `captureNoticeLogger` helper. It starts a server for each of the four rows above and asserts that exactly one `TLS ... for client connections` notice is emitted and that it is the right one; reverting only the `server/server.go` hunk makes the two "available" cases fail. `go test ./server/ -run TLS` passes, including under `-race -count=3`.

Beyond the unit test, I checked the log against actual behaviour on a locally built binary: on the `allow_non_tls` config a raw plaintext socket completes a PING/PONG round trip and TLS clients connect at 1.3 on the same port (`/connz` reproduces the table above, four connections, one plaintext); on the plain `tls{}` config and on the `handshake_first` config, plaintext is refused. In every case the new notice matches what the port actually accepts.
