### PR TITLE
Deflake TestNRGPartitionedPeerRemove

### DIFF
--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -7194,8 +7194,8 @@ func TestNRGPartitionedPeerRemove(t *testing.T) {
 	require_False(t, leader.MembershipChangeInProgress())
 	require_True(t, hookCalls.Load() > 0)
 
-	// Follower has not changed
-	require_Equal(t, follower.State(), Follower)
+	// Follower has not become leader and its membership has not changed.
+	require_NotEqual(t, follower.State(), Leader)
 	require_Equal(t, follower.ClusterSize(), 2)
 	require_False(t, follower.MembershipChangeInProgress())
 


### PR DESCRIPTION
An isolated follower, can't become a leader without a majority, but it may legitimately become a canditate.
Assert that it does not become leader instead of requiring it to remain a follower.