### PR TITLE
[FIXED] Snapshot install can compact the log before the store is durable

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -262,6 +262,7 @@ type msgBlock struct {
 	noTrack     bool
 	needSync    bool
 	needKeySync bool // Key file is written once and immutable, cleared after its one sync.
+	syncing     bool // Set by syncBlocks between clearing the above and the sync itself, and kept until one happens.
 	syncAlways  bool
 	noCompact   bool
 	closed      bool
@@ -5429,7 +5430,109 @@ func (fs *fileStore) FlushAllPending() error {
 	if fs.werr != nil {
 		return fs.werr
 	}
-	return fs.checkAndFlushLastBlock()
+	if err := fs.checkAndFlushLastBlock(); err != nil {
+		return err
+	}
+	// Callers use this before compacting the Raft log that has been covering these
+	// writes, so a write(2) is not enough: the log entries go away and the only
+	// remaining copy would be in the page cache.
+	return fs.syncPendingBlocksLocked()
+}
+
+// syncPendingBlocksLocked fsyncs every block that has been written to since it was
+// last synced. Blocks are append-only and roll over in order, so in practice this is
+// the last block or two, not a walk of the whole store.
+// Lock should be held.
+func (fs *fileStore) syncPendingBlocksLocked() error {
+	var firstErr error
+	var syncedName string
+	for _, mb := range fs.blks {
+		mb.mu.Lock()
+		// syncBlocks clears the flags below before it syncs, and it does not hold the
+		// filestore lock while it runs, so a cleared flag on its own does not mean the
+		// block is durable. It tells us with syncing when its sync is still outstanding,
+		// and then we do not know which of the two it was, so do both.
+		if mb.closed || (!mb.needSync && !mb.syncing) {
+			mb.mu.Unlock()
+			continue
+		}
+		needKeySync, kfn := mb.needKeySync || mb.syncing, mb.kfn
+		mb.mu.Unlock()
+
+		// Sync the key file first if it is also outstanding, so that a block is never
+		// durable while the key needed to read it is not. Done without the block lock,
+		// the same way the background sync does it. The key file has to be there for
+		// the same reason the block file does, and a durable block whose key is gone
+		// is unreadable, so this does not accept a missing one.
+		if needKeySync && kfn != _EMPTY_ {
+			if err := fs.syncFileAndDir(kfn); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			mb.mu.Lock()
+			mb.needKeySync = false
+			mb.mu.Unlock()
+		}
+
+		mb.mu.Lock()
+		if mb.closed {
+			mb.mu.Unlock()
+			continue
+		}
+		fd, didOpen := mb.mfd, false
+		if fd == nil {
+			var err error
+			fs.dios.acquire()
+			fd, err = os.OpenFile(mb.mfn, os.O_RDWR, defaultFilePerms)
+			fs.dios.release()
+			if err != nil {
+				mb.mu.Unlock()
+				// A missing file is not benign here the way it is in syncBlocks. That
+				// walks a snapshot of fs.blks with the filestore lock released, so a
+				// block can be removed underneath it; we hold the lock throughout, and
+				// removal closes the block before it leaves fs.blks. So a block that is
+				// still listed, open and dirty should have its file, and reporting that
+				// it does not is better than letting the log be compacted past it.
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			didOpen = true
+		}
+		err := fd.Sync()
+		if err == nil {
+			// The block is on stable storage now, whatever happens closing our fd.
+			mb.needSync, mb.syncing = false, false
+			syncedName = mb.mfn
+		}
+		if didOpen {
+			if cerr := fd.Close(); err == nil {
+				err = cerr
+			}
+		}
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+		mb.mu.Unlock()
+	}
+	// Syncing a block persists its contents but not the directory entry, which for a
+	// newly rolled block is what makes the file findable at all. One sync of the
+	// message directory covers every block we just synced.
+	if syncedName != _EMPTY_ && canFsyncDirectories {
+		fs.dios.acquire()
+		err := syncDir(syncedName)
+		fs.dios.release()
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if firstErr != nil {
+		fs.setWriteErr(firstErr)
+	}
+	return firstErr
 }
 
 // Lock should be held.
@@ -7899,13 +8002,21 @@ func (fs *fileStore) syncBlocks() {
 			continue
 		}
 		// Check if we need to sync. We will not hold lock during actual sync.
-		needSync := mb.needSync
-		needKeySync, kfn := mb.needKeySync, mb.kfn
+		// A handoff left set by an earlier pass is a sync that never happened, and the
+		// flags saying which of the two files it was are already gone, so redo both.
+		// Without this the assignment below would clear that handoff on a block this pass
+		// is not going to sync either, which is the state it exists to prevent.
+		needSync := mb.needSync || mb.syncing
+		needKeySync, kfn := mb.needKeySync || mb.syncing, mb.kfn
 
 		// Reset. Because we let go of the lock, we could write new data to this mb which might or
 		// might not be synced later if we would've reset after letting go of the lock.
 		mb.needSync = false
 		mb.needKeySync = false
+		// We just cleared the flags that FlushAllPending checks, but have not synced yet.
+		// Record that so it does not mistake this block for one that is already durable.
+		// This only ever sets the handoff; it comes off once a sync has actually happened.
+		mb.syncing = needSync || needKeySync
 		mb.mu.Unlock()
 
 		// Check if we should compact here.
@@ -7954,7 +8065,14 @@ func (fs *fileStore) syncBlocks() {
 		// Check if we need to sync this block's key file.
 		if needKeySync && kfn != _EMPTY_ {
 			if err := fs.syncFileAndDir(kfn); err != nil {
-				storeFsWerr(err)
+				if !os.IsNotExist(err) {
+					storeFsWerr(err)
+				}
+				// A missing file is tolerated for the same reason as the block file
+				// below, and needs the same care: needKeySync has already been consumed,
+				// so leave the handoff set rather than clearing it at the bottom. A block
+				// that is in fact still in use cannot be read without its key, so
+				// FlushAllPending must not be told it is durable.
 				continue
 			}
 		}
@@ -7972,9 +8090,16 @@ func (fs *fileStore) syncBlocks() {
 				fd, err = os.OpenFile(mb.mfn, os.O_RDWR, defaultFilePerms)
 				fs.dios.release()
 				didOpen = true
-				if err != nil && !os.IsNotExist(err) {
+				if err != nil {
 					mb.mu.Unlock()
-					storeFsWerr(err)
+					if !os.IsNotExist(err) {
+						storeFsWerr(err)
+					}
+					// A missing file is tolerated here because the block may have been
+					// removed underneath us, but the flags saying this block was dirty
+					// have already been consumed. Leave the handoff set rather than
+					// clearing it below, so that a block which is in fact still in use
+					// is not reported as durable by FlushAllPending.
 					continue
 				}
 			}
@@ -8000,6 +8125,13 @@ func (fs *fileStore) syncBlocks() {
 			}
 			mb.mu.Unlock()
 		}
+
+		// Sync is done, so the flags are trustworthy again. The paths above that did
+		// not get to sync leave this set, which only costs FlushAllPending a redundant
+		// sync until the next pass through here recomputes it.
+		mb.mu.Lock()
+		mb.syncing = false
+		mb.mu.Unlock()
 	}
 
 	if fs.isClosed() {
@@ -13994,14 +14126,15 @@ func writeAtomically(dios *diskIOSemaphore, name string, data []byte, perm fs.Fi
 	return nil
 }
 
+// syncFileAndDir syncs the named file and the directory holding it. A missing file is
+// reported like any other failure to sync it; whether that is tolerable depends on
+// whether the caller can be racing the removal of what it is syncing, which only the
+// caller knows.
 func (fs *fileStore) syncFileAndDir(name string) error {
 	fs.dios.acquire()
 	defer fs.dios.release()
 	f, err := os.OpenFile(name, os.O_RDWR, defaultFilePerms)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
 		return err
 	}
 	if err = f.Sync(); err != nil {

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -15310,6 +15310,291 @@ func TestFileStoreDeleteMapView(t *testing.T) {
 	checkView(deleteMap(staleBlks))
 }
 
+// Callers use FlushAllPending before compacting the Raft log that has been covering
+// the writes, so it has to leave the data on stable storage and not just written.
+func TestFileStoreFlushAllPendingSyncs(t *testing.T) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 8192, AsyncFlush: true, SyncInterval: time.Hour},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage},
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	msg := make([]byte, 512)
+	for i := 0; i < 100; i++ {
+		_, _, err := fs.StoreMsg("foo", nil, msg, 0)
+		require_NoError(t, err)
+	}
+
+	require_NoError(t, fs.FlushAllPending())
+
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	for _, mb := range fs.blks {
+		mb.mu.RLock()
+		needSync, pending := mb.needSync, mb.pendingWriteSizeLocked()
+		mb.mu.RUnlock()
+		if pending != 0 {
+			t.Fatalf("block %d still has %d bytes pending after FlushAllPending", mb.index, pending)
+		}
+		if needSync {
+			t.Fatalf("block %d was written but not synced by FlushAllPending", mb.index)
+		}
+	}
+}
+
+func TestFileStoreFlushAllPendingSyncsWhileBackgroundSyncInFlight(t *testing.T) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 8192, AsyncFlush: true, SyncInterval: time.Hour},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage},
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	msg := make([]byte, 512)
+	for i := 0; i < 100; i++ {
+		_, _, err := fs.StoreMsg("foo", nil, msg, 0)
+		require_NoError(t, err)
+	}
+	require_NoError(t, fs.FlushAllPending())
+
+	// syncBlocks clears needSync before it syncs, and it does not hold the filestore
+	// lock while it runs, so FlushAllPending can see a cleared flag while the sync is
+	// still outstanding. Put a block in exactly that state.
+	fs.mu.RLock()
+	lmb := fs.lmb
+	fs.mu.RUnlock()
+	require_NotNil(t, lmb)
+
+	lmb.mu.Lock()
+	lmb.needSync = false
+	lmb.syncing = true
+	lmb.mu.Unlock()
+
+	require_NoError(t, fs.FlushAllPending())
+
+	lmb.mu.RLock()
+	defer lmb.mu.RUnlock()
+	if lmb.syncing {
+		t.Fatalf("block %d was skipped by FlushAllPending while its sync was still outstanding", lmb.index)
+	}
+}
+
+func TestFileStoreFlushAllPendingErrorsOnMissingBlock(t *testing.T) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 8192, AsyncFlush: true, SyncInterval: time.Hour},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage},
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	_, _, err = fs.StoreMsg("foo", nil, []byte("hello"), 0)
+	require_NoError(t, err)
+	// Get everything written and synced, so the call under test has nothing left to
+	// flush and is only about the sync.
+	require_NoError(t, fs.FlushAllPending())
+
+	fs.mu.RLock()
+	lmb := fs.lmb
+	fs.mu.RUnlock()
+	require_True(t, lmb != nil)
+
+	// syncBlocks tolerates a block file that has gone missing because it walks a
+	// snapshot of fs.blks with the filestore lock released, so the block may have been
+	// removed underneath it. This path holds the lock throughout, and removal closes a
+	// block before it leaves fs.blks, so a block that is still listed, open and dirty
+	// should have its file. Losing it means the data is gone, and reporting that is
+	// what stops the caller compacting the log entries still covering it.
+	lmb.mu.Lock()
+	if lmb.mfd != nil {
+		require_NoError(t, lmb.mfd.Close())
+		lmb.mfd = nil
+	}
+	lmb.needSync = true
+	mfn := lmb.mfn
+	lmb.mu.Unlock()
+	require_NoError(t, os.Remove(mfn))
+
+	if err := fs.FlushAllPending(); err == nil {
+		t.Fatalf("FlushAllPending reported success with the block file missing")
+	}
+}
+
+func TestFileStoreFlushAllPendingErrorsOnMissingKeyFile(t *testing.T) {
+	fcfg := FileStoreConfig{
+		StoreDir: t.TempDir(), BlockSize: 8192, AsyncFlush: true, SyncInterval: time.Hour,
+		Cipher: AES, Compression: NoCompression,
+	}
+	fs, err := newFileStoreWithCreated(
+		fcfg, StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage},
+		time.Now(), prf(&fcfg), nil,
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	_, _, err = fs.StoreMsg("foo", nil, []byte("hello"), 0)
+	require_NoError(t, err)
+
+	fs.mu.RLock()
+	lmb := fs.lmb
+	fs.mu.RUnlock()
+	require_True(t, lmb != nil)
+
+	lmb.mu.Lock()
+	kfn := lmb.kfn
+	lmb.needSync, lmb.needKeySync = true, true
+	lmb.mu.Unlock()
+	require_True(t, kfn != _EMPTY_)
+
+	// The key file is written once when the block is created, and removing a block
+	// closes it before unlinking either file, so a block that is still listed and open
+	// has its key. A block that is durable while the key needed to read it is gone is
+	// unreadable, which is not something to report success for when the caller is
+	// about to compact the log entries still covering it.
+	require_NoError(t, os.Remove(kfn))
+
+	if err := fs.FlushAllPending(); err == nil {
+		t.Fatalf("FlushAllPending reported success with the block's key file missing")
+	}
+}
+
+func TestFileStoreSyncBlocksKeepsSyncHandoffOnMissingBlock(t *testing.T) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 8192, AsyncFlush: true, SyncInterval: time.Hour},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage},
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	_, _, err = fs.StoreMsg("foo", nil, []byte("hello"), 0)
+	require_NoError(t, err)
+	require_NoError(t, fs.FlushAllPending())
+
+	fs.mu.RLock()
+	lmb := fs.lmb
+	fs.mu.RUnlock()
+	require_True(t, lmb != nil)
+
+	// Make the block dirty with no file, without removing it, so that syncBlocks takes
+	// the missing-file path it tolerates.
+	lmb.mu.Lock()
+	if lmb.mfd != nil {
+		require_NoError(t, lmb.mfd.Close())
+		lmb.mfd = nil
+	}
+	lmb.needSync = true
+	mfn := lmb.mfn
+	lmb.mu.Unlock()
+	require_NoError(t, os.Remove(mfn))
+
+	// syncBlocks clears needSync before it syncs, so if it also cleared the handoff on
+	// a block it did not sync, the block would look durable to the barrier below.
+	fs.syncBlocks()
+
+	// Make sure the failure below is the barrier noticing, not a write error left over
+	// from syncBlocks, which tolerates this case.
+	fs.mu.RLock()
+	werr := fs.werr
+	fs.mu.RUnlock()
+	require_NoError(t, werr)
+
+	if err := fs.FlushAllPending(); err == nil {
+		t.Fatalf("FlushAllPending reported success after syncBlocks skipped a missing block")
+	}
+}
+
+func TestFileStoreSyncBlocksKeepsKeySyncHandoffOnMissingKeyFile(t *testing.T) {
+	fcfg := FileStoreConfig{
+		StoreDir: t.TempDir(), BlockSize: 8192, AsyncFlush: true, SyncInterval: time.Hour,
+		Cipher: AES, Compression: NoCompression,
+	}
+	fs, err := newFileStoreWithCreated(
+		fcfg, StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage},
+		time.Now(), prf(&fcfg), nil,
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	_, _, err = fs.StoreMsg("foo", nil, []byte("hello"), 0)
+	require_NoError(t, err)
+
+	fs.mu.RLock()
+	lmb := fs.lmb
+	fs.mu.RUnlock()
+	require_True(t, lmb != nil)
+
+	// Dirty in both files, with the key gone and the block itself still there, so that
+	// syncBlocks tolerates the missing key and then goes on to sync the block.
+	lmb.mu.Lock()
+	kfn := lmb.kfn
+	lmb.needSync, lmb.needKeySync = true, true
+	lmb.mu.Unlock()
+	require_True(t, kfn != _EMPTY_)
+	require_NoError(t, os.Remove(kfn))
+
+	// Syncing the block is not enough to call it durable when the key needed to read it
+	// is missing, so this must not leave the block looking clean to the barrier below.
+	fs.syncBlocks()
+
+	// Make sure the failure below is the barrier noticing, not a write error left over
+	// from syncBlocks, which tolerates this case.
+	fs.mu.RLock()
+	werr := fs.werr
+	fs.mu.RUnlock()
+	require_NoError(t, werr)
+
+	if err := fs.FlushAllPending(); err == nil {
+		t.Fatalf("FlushAllPending reported success after syncBlocks skipped a missing key file")
+	}
+}
+
+func TestFileStoreSyncBlocksKeepsSyncHandoffAcrossPasses(t *testing.T) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 8192, AsyncFlush: true, SyncInterval: time.Hour},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage},
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	_, _, err = fs.StoreMsg("foo", nil, []byte("hello"), 0)
+	require_NoError(t, err)
+	require_NoError(t, fs.FlushAllPending())
+
+	fs.mu.RLock()
+	lmb := fs.lmb
+	fs.mu.RUnlock()
+	require_True(t, lmb != nil)
+
+	// Make the block dirty with no file, without removing it, so that syncBlocks takes
+	// the missing-file path it tolerates.
+	lmb.mu.Lock()
+	if lmb.mfd != nil {
+		require_NoError(t, lmb.mfd.Close())
+		lmb.mfd = nil
+	}
+	lmb.needSync = true
+	mfn := lmb.mfn
+	lmb.mu.Unlock()
+	require_NoError(t, os.Remove(mfn))
+
+	// The first pass consumes needSync and leaves the handoff set. The second finds a
+	// block with no flags set and must not take that as a block already synced, having
+	// no more synced it than the first pass did.
+	fs.syncBlocks()
+	fs.syncBlocks()
+
+	// Make sure the failure below is the barrier noticing, not a write error left over
+	// from syncBlocks, which tolerates this case.
+	fs.mu.RLock()
+	werr := fs.werr
+	fs.mu.RUnlock()
+	require_NoError(t, werr)
+
+	if err := fs.FlushAllPending(); err == nil {
+		t.Fatalf("FlushAllPending reported success after a second syncBlocks pass cleared the handoff")
+	}
+}
+
 func Benchmark_FileStoreDeleteMap(b *testing.B) {
 	msg := []byte("hello")
 	// Many small blocks with mostly interior deletes, the shape a stream

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -629,6 +629,12 @@ func (s *Server) JetStreamSnapshotStream(account, stream string) error {
 		mset.mu.Unlock()
 		return nil
 	}
+	// Installing a snapshot compacts the log that has been covering these writes,
+	// so they have to be on stable storage before it does.
+	if err := mset.store.FlushAllPending(); err != nil {
+		mset.mu.Unlock()
+		return err
+	}
 	err = mset.node.InstallSnapshot(mset.stateSnapshotLocked(), false)
 	mset.mu.Unlock()
 
@@ -11478,7 +11484,10 @@ func (mset *stream) runCatchup(sendSubject string, sreq *streamSyncRequest) {
 						// Try our best to redo our invalidated snapshot as well.
 						if n := mset.raftNode(); n != nil {
 							if snap := mset.stateSnapshot(); snap != nil {
-								n.InstallSnapshot(snap, true)
+								// Compacts the log, so the store has to be durable first.
+								if err := mset.flushAllPending(); err == nil {
+									n.InstallSnapshot(snap, true)
+								}
 							}
 						}
 						// If we allow gap markers check if we have one pending.

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -10476,6 +10476,85 @@ func TestJetStreamClusterAsyncFlushFileStoreFlushOnSnapshot(t *testing.T) {
 	require_Equal(t, lmb.pendingWriteSize(), 0)
 }
 
+func TestJetStreamClusterSnapshotSyncsStoreBeforeCompact(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := jsStreamCreate(t, nc, &StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Storage:  FileStorage,
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	sl := c.streamLeader(globalAccountName, "TEST")
+	mset, err := sl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	fs := mset.Store().(*fileStore)
+
+	n := mset.raftNode().(*raft)
+	_, _, previousApplied := n.Progress()
+
+	for i := 0; i < 10; i++ {
+		_, err = js.Publish("foo", []byte("hello"))
+		require_NoError(t, err)
+	}
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		return checkState(t, c, globalAccountName, "TEST")
+	})
+
+	fs.mu.RLock()
+	lmb := fs.lmb
+	fs.mu.RUnlock()
+	require_NotNil(t, lmb)
+
+	// Not in sync always mode, so the applied data gets written but not synced.
+	// Wait for the async flush loop to write the block out, which is when needSync
+	// is set. Only an actual sync clears it again.
+	lmb.mu.RLock()
+	syncAlways := lmb.syncAlways
+	lmb.mu.RUnlock()
+	require_False(t, syncAlways)
+
+	checkFor(t, 5*time.Second, 50*time.Millisecond, func() error {
+		lmb.mu.RLock()
+		defer lmb.mu.RUnlock()
+		if !lmb.needSync {
+			return errors.New("block not written out yet")
+		}
+		return nil
+	})
+
+	// Make the upper layer snapshot by sending a leader change signal, the same way
+	// TestJetStreamClusterAsyncFlushFileStoreFlushOnSnapshot does. Installing the
+	// snapshot compacts the log that has been covering the applied data.
+	n.leadc <- leadChange{isLeader: true, term: n.Term()}
+
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		var state StreamState
+		n.wal.FastState(&state)
+		if state.FirstSeq <= previousApplied {
+			return fmt.Errorf("log not compacted yet, first=%d", state.FirstSeq)
+		}
+		return nil
+	})
+
+	// The entries covering the applied data are gone now, so the store must have
+	// been synced rather than left in the page cache.
+	lmb.mu.RLock()
+	defer lmb.mu.RUnlock()
+	if lmb.needSync {
+		var state StreamState
+		n.wal.FastState(&state)
+		t.Fatalf("Log compacted to first index %d, but block %d was never synced",
+			state.FirstSeq, lmb.index)
+	}
+}
+
 func TestJetStreamClusterScheduledDelayedMessage(t *testing.T) {
 	for _, replicas := range []int{1, 3} {
 		for _, storage := range []StorageType{FileStorage, MemoryStorage} {


### PR DESCRIPTION
Resolves #8425.

Installing a snapshot compacts the Raft log that has been covering the applied
data, so `monitorStream` flushes the store first:

```go
// Make sure all pending data is flushed before allowing snapshots.
if err := mset.flushAllPending(); err != nil {
```

That flush is `checkAndFlushLastBlock`, which ends in `flushPendingMsgsLocked`,
and that only syncs when the block is in sync always mode:

```go
if mb.syncAlways {
    if err = mb.mfd.Sync(); err != nil {
...
} else {
    mb.needSync = true
}
```

So with a sync interval configured the flush is a `write(2)`, and the log
entries are compacted away while the applied data is still only in the page
cache. Compaction is driven by log volume rather than by the sync interval, so
under load this window opens seconds after the write.

Two more callers install a snapshot with no flush at all:

- `JetStreamSnapshotStream`
- the "Try our best to redo our invalidated snapshot as well" path in `runCatchup`

Those two do not need power loss to lose data. With async flush the pending
writes are still process memory, while the Raft entries covering them have
already been written out, so a plain process crash after one of those snapshot
installs loses data the log would otherwise have replayed.

### Changes

- `FlushAllPending` now fsyncs the blocks it flushed. Blocks are append-only and
  roll over in order, so in practice that is the last block or two, not a walk of
  the store. Key files are synced first where outstanding, so a block is never
  durable ahead of the key needed to read it.
- `JetStreamSnapshotStream` and the `runCatchup` snapshot-redo path flush before
  installing.
- `syncBlocks` clears `needSync`/`needKeySync` before it performs the sync, and it
  does not hold `fs.mu` while it runs, so a cleared flag on its own does not mean
  the block is durable. It now records that its sync is still outstanding, and
  `FlushAllPending` syncs those blocks instead of skipping them. Getting this
  wrong in the other direction is harmless: a stale marker only costs a redundant
  fsync, and the next pass recomputes it.
- That handoff is kept on the paths where `syncBlocks` returns without syncing: a
  missing block file or key file is tolerated there, and clearing the marker anyway
  would leave a block that is still in use with no flag set at all, so the barrier
  would treat it as durable. It is kept across passes for the same reason — a later
  pass finds those flags already consumed, so it treats an outstanding handoff as
  work to redo rather than recomputing the marker from flags that are gone.
  `mb.syncing` is only ever cleared after a `Sync()` has returned.
- Syncing a block persists its contents but not the directory entry that makes a
  newly rolled block findable, so the message directory is synced once at the end,
  the same way `syncFileAndDir` already handles key files, and under `fs.dios` the
  same way.
- A file that has gone missing is reported rather than skipped, for the block and
  for its key file alike. `syncBlocks` tolerates that case because it walks a
  snapshot of `fs.blks` with the filestore lock released, so a block can be removed
  underneath it; this path holds the lock throughout, and removal closes a block
  before it unlinks either file. A block that is still listed, open and dirty but
  has no file means the data is gone, and one whose key file is gone is durable but
  unreadable — neither is something to return success for when the caller is about
  to compact the log that still covers it. `syncFileAndDir` no longer decides that
  on the caller's behalf: it reports a missing file like any other failure to sync
  one, and its two callers differ in what they do about it — the background sync
  still tolerates it, and keeps its handoff marker set when it does.

### Cost

Under `sync_always` nothing is outstanding and this is a no-op. Otherwise it is
one fsync per snapshot install plus one directory sync, driven by log volume
rather than by message rate, and it is off the publish path.

The one place it is on a publish path is `atomicBatch.readyForCommit`, which
calls `FlushAllPending` on the batch staging store. Happy to split the sync into
a separate store method used only by the snapshot callers if you would rather not
pay it there.

### One thing I would rather flag than have you find

`FlushAllPending` holds `fs.mu` for its whole body, so the sync happens under the
filestore write lock, where `syncBlocks` deliberately snapshots `fs.blks` and
drops the lock first. I kept it simple because it extends a critical section that
already spans the `checkAndFlushLastBlock` write, and it is one fsync per snapshot
install. Note that the two cannot simply be made mutually exclusive with a lock:
`syncBlocks` takes `fs.mu.RLock()` on its compaction path, so a mutex held across
its loop and acquired under `fs.mu` would deadlock. Hence the marker rather than
a lock. If you would prefer a different shape here, say the word.

### Tests

`TestJetStreamClusterSnapshotSyncsStoreBeforeCompact` covers the real call site:
an R3 file-backed stream in the default sync mode, publish, wait for the async
flush loop to write the block out, then trigger the upper-layer snapshot and
assert the store was synced. On an unpatched tree it fails with the log already
compacted past the data:

```
Log compacted to first index 12, but block 1 was never synced
```

(the Raft log goes from `first=1 last=11` to `first=12` while `needSync` is still
set on the block holding those messages).

`TestFileStoreFlushAllPendingSyncs` covers the store contract on its own.
`TestFileStoreFlushAllPendingSyncsWhileBackgroundSyncInFlight` covers the overlap
with `syncBlocks`. `TestFileStoreFlushAllPendingErrorsOnMissingBlock` and
`TestFileStoreFlushAllPendingErrorsOnMissingKeyFile` cover the missing-file cases —
the counterpart to `TestFileStoreSyncBlocksNoErrorOnConcurrentRemovedBlock`, which
asserts the opposite for `syncBlocks` and still passes.
`TestFileStoreSyncBlocksKeepsSyncHandoffOnMissingBlock` and
`TestFileStoreSyncBlocksKeepsKeySyncHandoffOnMissingKeyFile` cover the handoff
surviving those two tolerated paths, and
`TestFileStoreSyncBlocksKeepsSyncHandoffAcrossPasses` covers it surviving the next
pass over the same block. All of them fail without the
corresponding change. `TestJetStreamClusterAsyncFlushFileStoreFlushOnSnapshot` and
`TestJetStreamAtomicBatchPublish` still pass.

This is not a proposal to change the default sync policy — the Raft WAL follows
the same sync interval, so this alone does not make deferred-sync mode crash
safe. It is that the recovery source should not be discarded ahead of the data it
covers.
