### PR TITLE
Make leafnode tcp dialtimeout configurable

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -583,18 +583,30 @@ func (cfg *leafNodeCfg) setConnectDelay(delay time.Duration) {
 	cfg.Unlock()
 }
 
+// leafNodeDialer establishes the TCP connection to a remote leafnode server.
+// It has the same signature as natsDialTimeout(), which is what is used in
+// production. Tests can substitute their own implementation via
+// LeafNodeOpts.dialer in order to observe the resolved dial timeout, or to
+// simulate a slow/unreachable remote, without needing to manipulate the
+// network stack.
+type leafNodeDialer func(network, address string, timeout time.Duration) (net.Conn, error)
+
 // Ensure that non-exported options (used in tests) have
 // been properly set.
 func (s *Server) setLeafNodeNonExportedOptions() {
 	opts := s.getOpts()
-	s.leafNodeOpts.dialTimeout = opts.LeafNode.dialTimeout
-	if s.leafNodeOpts.dialTimeout == 0 {
+	s.leafNodeOpts.dialTimeout = opts.LeafNode.DialTimeout
+	if s.leafNodeOpts.dialTimeout <= 0 {
 		// Use same timeouts as routes for now.
 		s.leafNodeOpts.dialTimeout = DEFAULT_ROUTE_DIAL
 	}
 	s.leafNodeOpts.resolver = opts.LeafNode.resolver
 	if s.leafNodeOpts.resolver == nil {
 		s.leafNodeOpts.resolver = net.DefaultResolver
+	}
+	s.leafNodeOpts.dialer = opts.LeafNode.dialer
+	if s.leafNodeOpts.dialer == nil {
+		s.leafNodeOpts.dialer = natsDialTimeout
 	}
 }
 
@@ -704,6 +716,7 @@ func connectToRemoteLeafNode(s *Server, remote *leafNodeCfg, firstConnect bool) 
 	s.mu.RLock()
 	dialTimeout := s.leafNodeOpts.dialTimeout
 	resolver := s.leafNodeOpts.resolver
+	dialer := s.leafNodeOpts.dialer
 	var isSysAcc bool
 	if s.eventsEnabled() {
 		isSysAcc = remote.LocalAccount == s.sys.account.Name
@@ -738,6 +751,12 @@ func connectToRemoteLeafNode(s *Server, remote *leafNodeCfg, firstConnect bool) 
 	proxyUsername := remote.Proxy.Username
 	proxyPassword := remote.Proxy.Password
 	proxyTimeout := remote.Proxy.Timeout
+	// A remote can override the server-wide dial timeout. This is useful on
+	// high latency links where the default is too short for the TCP handshake
+	// to complete.
+	if remote.DialTimeout > 0 {
+		dialTimeout = remote.DialTimeout
+	}
 	remote.RUnlock()
 
 	// Set default proxy timeout if not specified
@@ -788,7 +807,7 @@ func connectToRemoteLeafNode(s *Server, remote *leafNodeCfg, firstConnect bool) 
 					conn, err = establishHTTPProxyTunnel(proxyURL, targetHost, proxyTimeout, proxyUsername, proxyPassword)
 				} else {
 					// Direct connection
-					conn, err = natsDialTimeout("tcp", url, dialTimeout)
+					conn, err = dialer("tcp", url, dialTimeout)
 				}
 			}
 		}

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -84,7 +84,7 @@ func TestLeafNodeRandomIP(t *testing.T) {
 	o.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{u}}}
 	o.LeafNode.ReconnectInterval = 50 * time.Millisecond
 	o.LeafNode.resolver = resolver
-	o.LeafNode.dialTimeout = 15 * time.Millisecond
+	o.LeafNode.DialTimeout = 15 * time.Millisecond
 	s := RunServer(o)
 	defer s.Shutdown()
 
@@ -12635,4 +12635,117 @@ func TestLeafNodeRemoteIgnoreGossip(t *testing.T) {
 
 	checkSubNoInterest(t, leaf, globalAccountName, "foo", time.Second)
 	checkSubInterest(t, leaf, globalAccountName, "bar", time.Second)
+}
+
+// Verify that the dial timeout handed to the dialer is resolved in this order:
+// remote's `dial_timeout`, then the leafnodes{} block `dial_timeout`, then
+// DEFAULT_ROUTE_DIAL.
+//
+// We install a test dialer instead of relying on a genuinely slow network,
+// because a userspace listener/proxy completes the TCP handshake immediately
+// and would therefore never exercise the dial timeout at all. Reproducing a
+// real dial timeout requires delaying or dropping the SYN in the kernel (for
+// instance with tc/netem), which is not something a unit test can rely on.
+func TestLeafNodeDialTimeoutOption(t *testing.T) {
+	// The remote does not need to exist: the test dialer never connects, it
+	// just records the timeout it was given and returns an error, which sends
+	// the connect loop into its normal retry path.
+	u, err := url.Parse("nats-leaf://127.0.0.1:1234")
+	require_NoError(t, err)
+
+	for _, test := range []struct {
+		name     string
+		server   time.Duration
+		remote   time.Duration
+		expected time.Duration
+	}{
+		{"not set", 0, 0, DEFAULT_ROUTE_DIAL},
+		{"server level", 3 * time.Second, 0, 3 * time.Second},
+		{"remote level", 0, 4 * time.Second, 4 * time.Second},
+		{"remote overrides server", 3 * time.Second, 4 * time.Second, 4 * time.Second},
+		{"invalid server level", -1, 0, DEFAULT_ROUTE_DIAL},
+		{"invalid remote level", 3 * time.Second, -1, 3 * time.Second},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ch := make(chan time.Duration, 1)
+
+			o := DefaultOptions()
+			o.Host = "127.0.0.1"
+			o.Port = -1
+			o.LeafNode.Port = 0
+			o.LeafNode.ReconnectInterval = 50 * time.Millisecond
+			o.LeafNode.DialTimeout = test.server
+			o.LeafNode.Remotes = []*RemoteLeafOpts{{URLs: []*url.URL{u}, DialTimeout: test.remote}}
+			o.LeafNode.dialer = func(network, address string, timeout time.Duration) (net.Conn, error) {
+				// Non-blocking send: the connect loop will keep retrying and
+				// we only care about the first invocation.
+				select {
+				case ch <- timeout:
+				default:
+				}
+				return nil, fmt.Errorf("test dialer does not connect")
+			}
+			s := RunServer(o)
+			defer s.Shutdown()
+
+			select {
+			case got := <-ch:
+				require_Equal(t, got, test.expected)
+			case <-time.After(2 * time.Second):
+				t.Fatal("Leafnode dialer was never invoked")
+			}
+		})
+	}
+}
+
+// Verify that `dial_timeout` is accepted both in the leafnodes{} block and on
+// an individual remote.
+func TestLeafNodeDialTimeoutConfig(t *testing.T) {
+	conf := createConfFile(t, []byte(`
+		leafnodes {
+			dial_timeout: "5s"
+			remotes = [
+				{ url: "nats-leaf://127.0.0.1:1234" }
+				{ url: "nats-leaf://127.0.0.1:5678", dial_timeout: "15s" }
+			]
+		}
+	`))
+	o, err := ProcessConfigFile(conf)
+	require_NoError(t, err)
+
+	require_Equal(t, o.LeafNode.DialTimeout, 5*time.Second)
+	require_Len(t, len(o.LeafNode.Remotes), 2)
+	// Not set on this remote, so the leafnodes{} block value applies.
+	require_Equal(t, o.LeafNode.Remotes[0].DialTimeout, time.Duration(0))
+	require_Equal(t, o.LeafNode.Remotes[1].DialTimeout, 15*time.Second)
+}
+
+// An invalid duration should be reported as a config error rather than being
+// silently ignored.
+func TestLeafNodeDialTimeoutConfigInvalid(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		conf string
+	}{
+		{"server level", `
+			leafnodes {
+				dial_timeout: abc
+			}
+		`},
+		{"remote level", `
+			leafnodes {
+				remotes = [
+					{ url: "nats-leaf://127.0.0.1:1234", dial_timeout: abc }
+				]
+			}
+		`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			conf := createConfFile(t, []byte(test.conf))
+			if _, err := ProcessConfigFile(conf); err == nil ||
+				!strings.Contains(err.Error(), "error parsing dial_timeout") {
+				t.Fatalf("Expected error parsing dial_timeout, got %v", err)
+			}
+		})
+	}
 }

--- a/server/opts.go
+++ b/server/opts.go
@@ -229,10 +229,18 @@ type LeafNodeOpts struct {
 	// east-west propagation.
 	IsolateLeafnodeInterest bool `json:"-"`
 
+	// DialTimeout is the amount of time the server will wait for the TCP
+	// connection to a remote server to be established. This is useful on high
+	// latency links where the default (DEFAULT_ROUTE_DIAL, 1 second) is not
+	// enough for the handshake to complete. It applies to all remotes, but can
+	// be overridden on a per-remote basis with RemoteLeafOpts.DialTimeout.
+	// If not set (or <= 0), DEFAULT_ROUTE_DIAL is used.
+	DialTimeout time.Duration `json:"-"`
+
 	// Not exported, for tests.
-	resolver    netResolver
-	dialTimeout time.Duration
-	connDelay   time.Duration
+	resolver  netResolver
+	connDelay time.Duration
+	dialer    leafNodeDialer
 
 	// Snapshot of configured TLS options.
 	tlsConfigOpts *TLSConfigOpts
@@ -263,6 +271,13 @@ type RemoteLeafOpts struct {
 	// initial INFO protocol from the remote server before closing the
 	// connection.
 	FirstInfoTimeout time.Duration `json:"-"`
+
+	// DialTimeout is the amount of time the server will wait for the TCP
+	// connection to this remote server to be established. This is useful on
+	// high latency links where the default is not enough for the handshake to
+	// complete. If not set (or <= 0), the server-wide LeafNodeOpts.DialTimeout
+	// is used, which itself defaults to DEFAULT_ROUTE_DIAL (1 second).
+	DialTimeout time.Duration `json:"-"`
 
 	// Compression options for this remote. Each remote could have a different
 	// setting and also be different from the LeafNode options.
@@ -2846,6 +2861,8 @@ func parseLeafNodes(v any, opts *Options, errors *[]error, warnings *[]error) er
 			opts.LeafNode.Remotes = remotes
 		case "reconnect", "reconnect_delay", "reconnect_interval":
 			opts.LeafNode.ReconnectInterval = parseDuration("reconnect", tk, mv, errors, warnings)
+		case "dial_timeout":
+			opts.LeafNode.DialTimeout = parseDuration("dial_timeout", tk, mv, errors, warnings)
 		case "tls":
 			tc, err := parseTLS(tk, true)
 			if err != nil {
@@ -3183,6 +3200,8 @@ func parseRemoteLeafNodes(v any, errors *[]error, warnings *[]error) ([]*RemoteL
 				}
 			case "first_info_timeout":
 				remote.FirstInfoTimeout = parseDuration(k, tk, v, errors, warnings)
+			case "dial_timeout":
+				remote.DialTimeout = parseDuration(k, tk, v, errors, warnings)
 			case "disabled":
 				remote.Disabled = v.(bool)
 			case "proxy":

--- a/server/server.go
+++ b/server/server.go
@@ -233,6 +233,7 @@ type Server struct {
 	leafNodeOpts        struct {
 		resolver    netResolver
 		dialTimeout time.Duration
+		dialer      leafNodeDialer
 	}
 	leafRemoteCfgs     map[*leafNodeCfg]struct{}
 	rmLeafRemoteCfgs   map[string]*leafNodeCfg


### PR DESCRIPTION
Fixes  https://github.com/nats-io/nats-server/issues/8426  

Tentative fix - there is no tooling in the project to unit test network delay during connection setup (raw packet delay).

Signed-off-by: Michael Röschter <michael@roeschter.de>
