### PR TITLE
(2.15) [ADDED] Domain prefixed JetStream API in the system account

### DIFF
--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -595,8 +595,19 @@ func (s *Server) checkJetStreamExports() {
 
 func (s *Server) setupJetStreamExports() {
 	// Setup our internal system export.
-	if err := s.SystemAccount().AddServiceExport(jsAllAPI, nil); err != nil {
+	sacc := s.SystemAccount()
+	if err := sacc.AddServiceExport(jsAllAPI, nil); err != nil {
 		s.Warnf("Error setting up jetstream service exports: %v", err)
+	}
+	// Map the domain prefixed API too, so an isolated JetStream is addressable by
+	// domain like an account is. Unprefixed always means this server's own JetStream.
+	if domain := s.getOpts().JetStreamDomain; domain != _EMPTY_ {
+		src, dest := fmt.Sprintf(jsDomainAPI, domain), jsAllAPI
+		if err := sacc.AddMapping(src, dest); err != nil {
+			s.Errorf("Error adding JetStream domain mapping to system account: %v", err)
+		} else {
+			s.Debugf("Adding JetStream Domain Mapping %q -> %s to system account", src, dest)
+		}
 	}
 }
 

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -1071,6 +1071,110 @@ func TestJetStreamClusterDomainsAndAPIResponses(t *testing.T) {
 	}
 }
 
+// Removes a peer from a meta group, returning the API error if any.
+func metaPeerRemove(t *testing.T, nc *nats.Conn, subject, peer string) *ApiError {
+	t.Helper()
+	req, err := json.Marshal(&JSApiMetaServerRemoveRequest{Server: peer})
+	require_NoError(t, err)
+	rmsg, err := nc.Request(subject, req, 5*time.Second)
+	require_NoError(t, err)
+	var resp JSApiMetaServerRemoveResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
+	return resp.Error
+}
+
+// An isolated leafnode's system account API is only addressable by domain.
+func TestJetStreamClusterSystemAccountDomainAPIIsolated(t *testing.T) {
+	tmpl := strings.Replace(jsClusterTempl, "store_dir:", `domain: "HUB", store_dir:`, 1)
+	c := createJetStreamClusterWithTemplate(t, tmpl, "HUB", 3)
+	defer c.shutdown()
+
+	lc := c.createLeafNodes("LEAF", 3, "LEAF")
+	defer lc.shutdown()
+
+	// Two separate JetStreams, the domains differ so the hub is not extended.
+	c.waitOnPeerCount(3)
+	lc.waitOnPeerCount(3)
+
+	hubSys := natsConnect(t, c.randomServer().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	defer hubSys.Close()
+	leafSys := natsConnect(t, lc.randomServer().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	defer leafSys.Close()
+
+	// Addressing a domain only affects that domain, the hub's leader stays put.
+	hubLeader, leafLeader := c.leader(), lc.leader()
+	rmsg, err := hubSys.Request("$JS.LEAF.API.META.LEADER.STEPDOWN", nil, 5*time.Second)
+	require_NoError(t, err)
+	var sdResp JSApiLeaderStepDownResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &sdResp))
+	require_True(t, sdResp.Error == nil)
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		if l := lc.leader(); l == nil || l == leafLeader {
+			return fmt.Errorf("leaf meta leader did not step down")
+		}
+		return nil
+	})
+	hubLeaderNew := c.leader()
+	require_NotNil(t, hubLeaderNew)
+	require_Equal(t, hubLeaderNew.Name(), hubLeader.Name())
+
+	hubPeer, leafPeer := c.randomNonLeader().Name(), lc.randomNonLeader().Name()
+
+	// Unprefixed stays scoped to the connected server's own JetStream.
+	apiErr := metaPeerRemove(t, leafSys, JSApiRemoveServer, hubPeer)
+	require_True(t, apiErr != nil)
+	require_Equal(t, apiErr.ErrCode, uint16(JSClusterServerNotMemberErr))
+	apiErr = metaPeerRemove(t, hubSys, JSApiRemoveServer, leafPeer)
+	require_True(t, apiErr != nil)
+	require_Equal(t, apiErr.ErrCode, uint16(JSClusterServerNotMemberErr))
+
+	// Prefixed with the domain both are addressable, in both directions.
+	apiErr = metaPeerRemove(t, leafSys, "$JS.HUB.API.SERVER.REMOVE", hubPeer)
+	require_True(t, apiErr == nil)
+	c.waitOnPeerCount(2)
+
+	apiErr = metaPeerRemove(t, hubSys, "$JS.LEAF.API.SERVER.REMOVE", leafPeer)
+	require_True(t, apiErr == nil)
+	lc.waitOnPeerCount(2)
+}
+
+// An extending leafnode is one system, addressable with and without the domain.
+func TestJetStreamClusterSystemAccountDomainAPIExtended(t *testing.T) {
+	tmpl := strings.Replace(jsClusterTempl, "store_dir:", `domain: "HUB", store_dir:`, 1)
+	c := createJetStreamClusterWithTemplate(t, tmpl, "HUB", 3)
+	defer c.shutdown()
+
+	lc := c.createLeafNodes("LEAF", 3, "HUB")
+	defer lc.shutdown()
+
+	// One JetStream, the leaf servers joined the hub's meta group as observers.
+	c.waitOnPeerCount(6)
+	lc.expectNoLeader()
+
+	leafSys := natsConnect(t, lc.randomServer().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	defer leafSys.Close()
+
+	// Two distinct hub peers to remove, leaving the meta leader in place.
+	var peers []string
+	ml := c.leader()
+	for _, s := range c.servers {
+		if s != ml {
+			peers = append(peers, s.Name())
+		}
+	}
+	require_Equal(t, len(peers), 2)
+
+	// Addressable as one system from the leaf, unprefixed.
+	apiErr := metaPeerRemove(t, leafSys, JSApiRemoveServer, peers[0])
+	require_True(t, apiErr == nil)
+	c.waitOnPeerCount(5)
+
+	// And through the domain both sides share.
+	apiErr = metaPeerRemove(t, leafSys, "$JS.HUB.API.SERVER.REMOVE", peers[1])
+	require_True(t, apiErr == nil)
+	c.waitOnPeerCount(4)
+}
+
 // Issue #2202
 func TestJetStreamClusterDomainsAndSameNameSources(t *testing.T) {
 	tmpl := strings.Replace(jsClusterAccountsTempl, "store_dir:", "domain: CORE, store_dir:", 1)

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -7853,3 +7853,63 @@ func TestJWTUserLimitsOverflowInt32SubPub(t *testing.T) {
 		}
 	})
 }
+
+func TestJWTSystemAccountJetStreamDomainMapping(t *testing.T) {
+	sysKp, sysPub := createKey(t)
+	sysClaim := jwt.NewAccountClaims(sysPub)
+	sysJwt := encodeClaim(t, sysClaim, sysPub)
+	sysCreds := newUser(t, sysKp)
+
+	conf := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: 127.0.0.1:-1
+		server_name: SYSDOMAIN
+		jetstream: { domain: HUB, store_dir: %q }
+		operator: %s
+		system_account: %s
+		resolver: {
+			type: full
+			dir: %q
+		}
+		resolver_preload: {
+			%s: %s
+		}
+	`, t.TempDir(), ojwt, sysPub, t.TempDir(), sysPub, sysJwt)))
+	s, _ := RunServerWithConfig(conf)
+	defer s.Shutdown()
+
+	sacc := s.SystemAccount()
+	require_True(t, sacc != nil)
+
+	domainAPI := fmt.Sprintf(jsDomainAPI, "HUB")
+	hasDomainMapping := func() bool {
+		sacc.mu.RLock()
+		defer sacc.mu.RUnlock()
+		for _, m := range sacc.mappings {
+			if m.src == domainAPI {
+				return true
+			}
+		}
+		return false
+	}
+
+	// The domain prefixed API is mapped into the system account on startup.
+	require_True(t, hasDomainMapping())
+
+	// An account update can not carry the mapping, it is not part of the JWT.
+	// Make sure updating the system account does not drop it.
+	sysClaim.Mappings = jwt.Mapping{"foo": []jwt.WeightedMapping{{Subject: "bar"}}}
+	require_Equal(t, updateJwt(t, s.ClientURL(), sysCreds, encodeClaim(t, sysClaim, sysPub), 1), 1)
+
+	checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+		if !hasDomainMapping() {
+			return fmt.Errorf("mapping %q was removed by the account update", domainAPI)
+		}
+		return nil
+	})
+
+	// And it must still resolve, getting a response at all proves the mapping.
+	nc := natsConnect(t, s.ClientURL(), nats.UserCredentials(sysCreds))
+	defer nc.Close()
+	_, err := nc.Request(domainAPI[:len(domainAPI)-1]+"INFO", nil, 2*time.Second)
+	require_NoError(t, err)
+}

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -2085,13 +2085,16 @@ func (s *Server) addLeafNodeConnection(c *client, srvName, clusterName string, c
 		c.mergeDenyPermissionsLocked(both, denyAllClientJs)
 	}
 	// If we have a specified JetStream domain we will want to add a mapping to
-	// allow access cross domain for each non-system account.
-	if opts.JetStreamDomain != _EMPTY_ && opts.JetStream && acc != nil && acc != sysAcc {
-		for src, dest := range generateJSMappingTable(opts.JetStreamDomain) {
-			if err := acc.AddMapping(src, dest); err != nil {
-				c.Debugf("Error adding JetStream domain mapping: %s", err.Error())
-			} else {
-				c.Debugf("Adding JetStream Domain Mapping %q -> %s to account %q", src, dest, accName)
+	// allow access cross domain for each non-system account. The system account
+	// is mapped in setupJetStreamExports, it only needs the outgoing block here.
+	if opts.JetStreamDomain != _EMPTY_ && opts.JetStream && acc != nil {
+		if acc != sysAcc {
+			for src, dest := range generateJSMappingTable(opts.JetStreamDomain) {
+				if err := acc.AddMapping(src, dest); err != nil {
+					c.Debugf("Error adding JetStream domain mapping: %s", err.Error())
+				} else {
+					c.Debugf("Adding JetStream Domain Mapping %q -> %s to account %q", src, dest, accName)
+				}
 			}
 		}
 		if blockMappingOutgoing {


### PR DESCRIPTION
The system account can be shared between a hub and leaf cluster, but having different domains. This ensures they are treated as two separate JetStream meta groups. Before this PR it wasn't possible to administer the leaf cluster from the hub, since the system account's JS API wasn't domain-aware, and the servers added automatic pub/sub denies to `$JS.API.>` so JetStreams of different domains don't cross-talk about a system JS API request. This PR preserves the pub/sub denies and adds support for the domain-aware JS API, by allowing the same `$JS.<domain>.API.>` convention that accounts use.