### PR TITLE
(2.15) [ADDED] Desired state reconcilitation for scaling and moves

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2745,7 +2745,11 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 	if sa != nil {
 		cfg = *sa.Config.clone()
 		streamFound = true
-		currPeers = copyStrings(sa.Group.Peers)
+		if sa.Group.Desired != nil {
+			currPeers = copyStrings(sa.Group.Desired.Peers)
+		} else {
+			currPeers = copyStrings(sa.Group.Peers)
+		}
 		currCluster = sa.Group.Cluster
 	}
 	js.mu.RUnlock()

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2802,6 +2802,7 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 		cfg.Placement.Tags = append(cfg.Placement.Tags, req.Tags...)
 	}
 
+	// FIXME(mvv): scaffolded desired state into the move API for now, this endpoint needs to be refactored
 	peers, e := cc.selectPeerGroup(cfg.Replicas+1, currCluster, &cfg, currPeers, 1, nil)
 	if len(peers) <= cfg.Replicas {
 		// since expanding in the same cluster did not yield a result, try in different cluster
@@ -2821,6 +2822,8 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 			if len(newPeers) >= cfg.Replicas {
 				peers = append([]string{}, currPeers...)
 				peers = append(peers, newPeers[:cfg.Replicas]...)
+				// Keep only the new peers.
+				peers = peers[len(peers)-cfg.Replicas:]
 				break
 			}
 			errs.accumulate(e)
@@ -2830,6 +2833,9 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 			return
 		}
+	} else {
+		// Keep only the new peers.
+		peers = peers[len(peers)-cfg.Replicas:]
 	}
 
 	cfg.Placement = origPlacement
@@ -2892,20 +2898,56 @@ func (s *Server) jsLeaderServerStreamCancelMoveRequest(sub *subscription, c *cli
 	streamFound := false
 	cfg := StreamConfig{}
 	currPeers := []string{}
-	js.mu.RLock()
+	js.mu.Lock()
 	sa := js.streamAssignmentOrInflight(accName, streamName)
 	if sa != nil {
 		cfg = *sa.Config.clone()
 		streamFound = true
 		currPeers = copyStrings(sa.Group.Peers)
 	}
-	js.mu.RUnlock()
 
 	if !streamFound {
+		js.mu.Unlock()
 		resp.Error = NewJSStreamNotFoundError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
+
+	// FIXME(mvv): scaffolded desired state into the cancel move API for now, this endpoint needs to be refactored
+	if sa.Group.Desired != nil {
+		origin := sa.Group.Desired.Origin
+		if origin == nil {
+			js.mu.Unlock()
+			resp.Error = NewJSStreamMoveNotInProgressError()
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+			return
+		}
+
+		csa := sa.copyGroup()
+		// Need to respond to the client that cancels.
+		csa.Reply = reply
+		// Revert replicas and placement in the config immediately.
+		cfg.Replicas = origin.Replicas
+		cfg.Placement = origin.Placement
+		csa.Config = &cfg
+		// Move back to the initial peer set via desired state.
+		csa.Group.Peers = copyStrings(origin.Peers)
+		csa.Group.Cluster = origin.Cluster
+		csa.Group = sa.Group.withDesired(csa.Group)
+		// FIXME(mvv): does origin need to be cleared now?
+
+		s.Noticef("Requested cancel of move: R=%d '%s > %s' to peer set %+v and restore previous peer set %+v",
+			origin.Replicas, accName, streamName, s.peerSetToNames(currPeers), s.peerSetToNames(origin.Peers))
+
+		if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(csa)); err != nil {
+			js.mu.Unlock()
+			return
+		}
+		cc.trackInflightStreamProposal(accName, csa, false)
+		js.mu.Unlock()
+		return
+	}
+	js.mu.Unlock()
 
 	if len(currPeers) <= cfg.Replicas {
 		resp.Error = NewJSStreamMoveNotInProgressError()

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -169,8 +169,40 @@ type raftGroup struct {
 	Cluster   string      `json:"cluster,omitempty"`
 	Preferred string      `json:"preferred,omitempty"`
 	ScaleUp   bool        `json:"scale_up,omitempty"`
+	// Desired holds the target placement while this group is being moved or
+	// scaled; it is nil when the group is stable.
+	Desired *desiredRaftGroup `json:"desired,omitempty"`
 	// Internal
 	node RaftNode
+}
+
+// desiredGroupPlacement specifies the desired peer set.
+// A stream or consumer raftGroup can be scaled or moved safely based on this desired state.
+type desiredRaftGroup struct {
+	ID string `json:"id"`
+	// Term is the raft term of the group leader driving this desired state. It acts as a
+	// fencing token; reconcile requests from older leadership terms are rejected.
+	Term      uint64   `json:"term,omitempty"`
+	Peers     []string `json:"peers"`
+	Cluster   string   `json:"cluster,omitempty"`
+	Preferred string   `json:"preferred,omitempty"`
+
+	ScaleUp   bool `json:"scale_up,omitempty"`
+	ScaleDown bool `json:"scale_down,omitempty"`
+
+	Origin *desiredRaftGroupOrigin `json:"origin,omitempty"`
+}
+
+// desiredRaftGroupOrigin specifies the original properties of the asset before any desired state changes were made.
+// Multiple desired state changes MUST NOT update these values, only the initial values must be set, allowing to
+// revert to before any changes were made.
+type desiredRaftGroupOrigin struct {
+	Peers     []string   `json:"peers"`
+	Cluster   string     `json:"cluster,omitempty"`
+	Replicas  int        `json:"replicas"`
+	Placement *Placement `json:"placement,omitempty"`
+	// When changing between retention policies, this retention remains active until unset.
+	Retention *RetentionPolicy `json:"retention,omitempty"`
 }
 
 // streamAssignment is what the meta controller uses to assign streams to peers.
@@ -2512,19 +2544,38 @@ func (js *jetStream) setConsumerAssignmentRecovering(ca *consumerAssignment) {
 // Just copies over and changes out the group so it can be encoded.
 // Lock should be held.
 func (sa *streamAssignment) copyGroup() *streamAssignment {
-	csa, cg := sa.clone(), *sa.Group
-	csa.Group = &cg
-	csa.Group.Peers = copyStrings(sa.Group.Peers)
+	csa := sa.clone()
+	csa.Group = sa.Group.copyGroup()
 	return csa
 }
 
 // Just copies over and changes out the group so it can be encoded.
 // Lock should be held.
 func (ca *consumerAssignment) copyGroup() *consumerAssignment {
-	cca, cg := ca.clone(), *ca.Group
-	cca.Group = &cg
-	cca.Group.Peers = copyStrings(ca.Group.Peers)
+	cca := ca.clone()
+	cca.Group = ca.Group.copyGroup()
 	return cca
+}
+
+// copyGroup returns a copy of rg whose Peers slice and nested Desired placement
+// are independent of the original, so it can be mutated and encoded.
+// Lock should be held.
+func (rg *raftGroup) copyGroup() *raftGroup {
+	if rg == nil {
+		return nil
+	}
+	cg := *rg
+	cg.Peers = copyStrings(rg.Peers)
+	if rg.Desired != nil {
+		cd := *rg.Desired
+		cd.Peers = copyStrings(rg.Desired.Peers)
+		if rg.Desired.Origin != nil {
+			cr := *rg.Desired.Origin
+			cd.Origin = &cr
+		}
+		cg.Desired = &cd
+	}
+	return &cg
 }
 
 // Lock should be held.
@@ -11046,72 +11097,130 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 	}
 	js.mu.RLock()
 	s := js.srv
-	if rg == nil || rg.node == nil {
+	if rg == nil || (rg.node == nil && rg.Desired == nil) {
 		js.mu.RUnlock()
 		return &ClusterInfo{
 			Name:   s.cachedClusterName(),
 			Leader: s.Name(),
 		}
 	}
-
 	// Capture what we need and let go of the lock to ensure that
 	// contention on Raft locks can't happen while holding JS lock.
 	n := rg.node
 	rgName := rg.Name
-	rgPeers := slices.Clone(rg.Peers)
+	rgPeers := copyStrings(rg.Peers)
+	var (
+		desired      *DesiredClusterInfo
+		desiredPeers []string
+	)
+	if d := rg.Desired; d != nil {
+		desired = &DesiredClusterInfo{
+			Name: d.Cluster,
+		}
+		// If desired state can be rolled back, include what can be rolled back to.
+		if d.Origin != nil {
+			desired.Origin = &DesiredClusterInfoOrigin{
+				Replicas:  d.Origin.Replicas,
+				Placement: d.Origin.Placement,
+				Retention: d.Origin.Retention,
+			}
+		}
+		// Don't populate peers if scaling down, since the peers aren't the desired set, it's
+		// the set that the group leader selects the peers to scale down to from.
+		if !d.ScaleDown {
+			desiredPeers = copyStrings(d.Peers)
+		}
+	}
 	js.mu.RUnlock()
 
 	ci := &ClusterInfo{
-		Name:        s.cachedClusterName(),
-		Leader:      s.serverNameForNode(n.GroupLeader()),
-		LeaderSince: n.LeaderSince(),
-		SystemAcc:   n.IsSystemAccount(),
-		TrafficAcc:  n.GetTrafficAccountName(),
-		RaftGroup:   rgName,
+		Name:      s.cachedClusterName(),
+		RaftGroup: rgName,
 	}
 
-	now := time.Now()
-	id, peers := n.ID(), n.Peers()
+	id := s.Node()
+	if n != nil {
+		ci.Leader = s.serverNameForNode(n.GroupLeader())
+		ci.LeaderSince = n.LeaderSince()
+		ci.SystemAcc = n.IsSystemAccount()
+		ci.TrafficAcc = n.GetTrafficAccountName()
 
-	// If we are leaderless, do not suppress putting us in the peer list.
-	if ci.Leader == _EMPTY_ {
-		id = _EMPTY_
-	}
-
-	for _, rp := range peers {
-		if rp.ID != id && slices.Contains(rgPeers, rp.ID) {
-			var lastSeen time.Duration
-			if now.After(rp.Last) && !rp.Last.IsZero() {
-				lastSeen = now.Sub(rp.Last)
-			}
-			current := rp.Current
-			if current && lastSeen > lostQuorumInterval {
-				current = false
-			}
-			// Create a peer info with common settings if the peer has not been seen
-			// yet (which can happen after the whole cluster is stopped and only some
-			// of the nodes are restarted).
-			pi := &PeerInfo{
-				Current: current,
-				Offline: true,
-				Active:  lastSeen,
-				Lag:     rp.Lag,
-				Peer:    rp.ID,
-			}
-			// If node is found, complete/update the settings.
-			if sir, ok := s.nodeToInfo.Load(rp.ID); ok && sir != nil {
-				si := sir.(nodeInfo)
-				pi.Name, pi.Offline, pi.cluster = si.name, si.offline, si.cluster
-			} else {
-				// If not, then add a name that indicates that the server name
-				// is unknown at this time, and clear the lag since it is misleading
-				// (the node may not have that much lag).
-				// Note: We return now the Peer ID in PeerInfo, so the "(peerID: %s)"
-				// would technically not be required, but keeping it for now.
-				pi.Name, pi.Lag = fmt.Sprintf("Server name unknown at this time (peerID: %s)", rp.ID), 0
-			}
-			ci.Replicas = append(ci.Replicas, pi)
+		// If we are leaderless, do not suppress putting us in the peer list.
+		if ci.Leader == _EMPTY_ {
+			id = _EMPTY_
 		}
+
+		now := time.Now()
+		for _, rp := range n.Peers() {
+			// The peer is either in the actual or desired peer set.
+			if rp.ID != id && (slices.Contains(rgPeers, rp.ID) || slices.Contains(desiredPeers, rp.ID)) {
+				var lastSeen time.Duration
+				if now.After(rp.Last) && !rp.Last.IsZero() {
+					lastSeen = now.Sub(rp.Last)
+				}
+				current := rp.Current
+				if current && lastSeen > lostQuorumInterval {
+					current = false
+				}
+				// Create a peer info with common settings if the peer has not been seen
+				// yet (which can happen after the whole cluster is stopped and only some
+				// of the nodes are restarted).
+				pi := &PeerInfo{
+					Current: current,
+					Offline: true,
+					Active:  lastSeen,
+					Lag:     rp.Lag,
+					Peer:    rp.ID,
+				}
+				// If node is found, complete/update the settings.
+				if sir, ok := s.nodeToInfo.Load(rp.ID); ok && sir != nil {
+					si := sir.(nodeInfo)
+					pi.Name, pi.Offline, pi.cluster = si.name, si.offline, si.cluster
+				} else {
+					// If not, then add a name that indicates that the server name
+					// is unknown at this time, and clear the lag since it is misleading
+					// (the node may not have that much lag).
+					// Note: We return now the Peer ID in PeerInfo, so the "(peerID: %s)"
+					// would technically not be required, but keeping it for now.
+					pi.Name, pi.Lag = fmt.Sprintf("Server name unknown at this time (peerID: %s)", rp.ID), 0
+				}
+				ci.Replicas = append(ci.Replicas, pi)
+			}
+		}
+	}
+
+	generatePeer := func(peer string) *PeerInfo {
+		pi := &PeerInfo{
+			Current: false,
+			Offline: true,
+			Peer:    peer,
+		}
+		// If node is found, complete/update the settings.
+		if sir, ok := s.nodeToInfo.Load(peer); ok && sir != nil {
+			si := sir.(nodeInfo)
+			pi.Name, pi.Offline, pi.cluster = si.name, si.offline, si.cluster
+		} else {
+			// If not, then add a name that indicates that the server name
+			// is unknown at this time, and clear the lag since it is misleading
+			// (the node may not have that much lag).
+			// Note: We return now the Peer ID in PeerInfo, so the "(peerID: %s)"
+			// would technically not be required, but keeping it for now.
+			pi.Name = fmt.Sprintf("Server name unknown at this time (peerID: %s)", peer)
+		}
+		return pi
+	}
+	if desired != nil {
+		ci.Desired = desired
+		for _, peer := range desiredPeers {
+			ci.Desired.Replicas = append(ci.Desired.Replicas, generatePeer(peer))
+		}
+	}
+	for _, peer := range rgPeers {
+		// Skip if the peer is already present.
+		if peer == id || slices.ContainsFunc(ci.Replicas, func(info *PeerInfo) bool { return info.Peer == peer }) {
+			continue
+		}
+		ci.Replicas = append(ci.Replicas, generatePeer(peer))
 	}
 	// Order the result based on the name so that we get something consistent
 	// when doing repeated stream info in the CLI, etc...

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -71,6 +71,9 @@ type jetStreamCluster struct {
 	// Processing assignment results.
 	streamResults   *subscription
 	consumerResults *subscription
+	// Processing desired assignment reconciliation.
+	streamReconcile   *subscription
+	consumerReconcile *subscription
 	// System level request to have the leader stepdown.
 	stepdown *subscription
 	// System level requests to remove a peer.
@@ -203,6 +206,52 @@ type desiredRaftGroupOrigin struct {
 	Placement *Placement `json:"placement,omitempty"`
 	// When changing between retention policies, this retention remains active until unset.
 	Retention *RetentionPolicy `json:"retention,omitempty"`
+}
+
+// withDesired returns a copy of rg with target expressed as the desired state.
+// target MUST already be a copy or fresh group, as it's directly referenced.
+func (rg *raftGroup) withDesired(target *raftGroup) *raftGroup {
+	// When scaling up from a single replica, set it as preferred, as it has the data.
+	if len(rg.Peers) == 1 {
+		target.Preferred = rg.Peers[0]
+	} else if target.Preferred != _EMPTY_ && !slices.Contains(target.Peers, target.Preferred) {
+		// Don't carry a stale preferred into the desired group.
+		target.Preferred = _EMPTY_
+	}
+	var term uint64
+	if target.Desired != nil {
+		term = target.Desired.Term
+	}
+	ng := rg.copyGroup()
+	ng.Name = target.Name
+	ng.Desired = &desiredRaftGroup{
+		ID:        nuid.Next(),
+		Term:      term,
+		Peers:     target.Peers,
+		Cluster:   target.Cluster,
+		Preferred: target.Preferred,
+	}
+	// Must preserve the prior origin (if any).
+	if rg.Desired != nil && rg.Desired.Origin != nil {
+		origin := *rg.Desired.Origin
+		ng.Desired.Origin = &origin
+	}
+	return ng
+}
+
+// atDesiredOrigin returns a copy of the config with the desired origin applied (if any).
+func (cfg *StreamConfig) atDesiredOrigin(rg *raftGroup) *StreamConfig {
+	if rg.Desired == nil || rg.Desired.Origin == nil {
+		return cfg
+	}
+	newCfg := cfg.clone()
+	if rg.Desired.Origin.Placement != nil {
+		newCfg.Placement = rg.Desired.Origin.Placement
+	}
+	if rg.Desired.Origin.Retention != nil {
+		newCfg.Retention = *rg.Desired.Origin.Retention
+	}
+	return newCfg
 }
 
 // streamAssignment is what the meta controller uses to assign streams to peers.
@@ -2618,8 +2667,14 @@ func (js *jetStream) processAddPeer(peer string) {
 			// If we are here we can add in this peer.
 			csa := sa.copyGroup()
 			csa.Group.Peers = append(csa.Group.Peers, peer)
+			// Keep the desired peer set in sync.
+			if d := csa.Group.Desired; d != nil {
+				d.ID = nuid.Next()
+				d.Peers = csa.Group.Peers
+				d.Preferred = _EMPTY_
+			}
 			// Send our proposal for this csa. Also use same group definition for all the consumers as well.
-			consumers, _ := js.remapConsumerAssignments(accName, csa, false)
+			consumers, _, _ := js.remapConsumerAssignments(accName, csa, false)
 			if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(csa)); err != nil {
 				return
 			}
@@ -2711,7 +2766,7 @@ func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer strin
 	}
 
 	// Send our proposal for this csa. Also use same group definition for all the consumers as well.
-	consumers, deleted := js.remapConsumerAssignments(accName, csa, true)
+	consumers, deleted, _ := js.remapConsumerAssignments(accName, csa, true)
 	if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(csa)); err != nil {
 		return false
 	}
@@ -2970,7 +3025,7 @@ func (js *jetStream) createRaftGroup(accName string, rg *raftGroup, recovering b
 	}
 
 	// If this is a single peer raft group or we are not a member return.
-	if len(rg.Peers) <= 1 || !rg.isMember(cc.meta.ID()) {
+	if (rg.Desired == nil && len(rg.Peers) <= 1) || !rg.isMember(cc.meta.ID()) {
 		// Nothing to do here.
 		return nil, nil
 	}
@@ -3121,8 +3176,12 @@ retry:
 	}
 	// Need JS lock to be held for the assignment to avoid data-race reports
 	rg.node = n
+	preferred := rg.Preferred
+	if rg.Desired != nil {
+		preferred = rg.Desired.Preferred
+	}
 	// See if we are preferred and should start campaign immediately.
-	if n.ID() == rg.Preferred && n.Term() == 0 {
+	if n.ID() == preferred && n.Term() == 0 {
 		n.CampaignImmediately()
 	}
 	return n, nil
@@ -5189,7 +5248,7 @@ func (js *jetStream) processUpdateStreamAssignment(sa *streamAssignment) {
 	sa.err = osa.err
 
 	// If we detect we are scaling down to 1, non-clustered, and we had a previous node, clear it here.
-	if sa.Config.Replicas == 1 && sa.Group.node != nil {
+	if sa.Config.Replicas == 1 && sa.Group.node != nil && sa.Group.Desired == nil {
 		sa.Group.node = nil
 	}
 
@@ -5296,11 +5355,13 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 	}
 
 	js.mu.RLock()
-	s, rg := js.srv, sa.Group
+	s, rg, desired := js.srv, sa.Group, sa.Group.Desired
 	client, subject, reply := sa.Client, sa.Subject, sa.Reply
-	alreadyRunning, oldNumReplicas, numReplicas := osa.Group.node != nil, len(osa.Group.Peers), len(rg.Peers)
+	alreadyRunning, numReplicas := osa.Group.node != nil, len(rg.Peers)
+	wasClustered := len(osa.Group.Peers) > 1 || osa.Group.Desired != nil
 	needsNode := rg.node == nil
 	storage, cfg := sa.Config.Storage, sa.Config
+	newCfg := cfg.atDesiredOrigin(rg)
 	recovering := sa.recovering
 	hasResponded := sa.markResponded()
 	hadErr := sa.err != nil
@@ -5321,7 +5382,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 			js.mu.Unlock()
 		}
 
-		if !alreadyRunning && numReplicas > 1 {
+		if !alreadyRunning && (numReplicas > 1 || desired != nil) {
 			if needsNode {
 				// Must run before startClusterSubs reads mset.sa.Sync.
 				mset.setStreamAssignment(sa)
@@ -5351,7 +5412,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 			if !started {
 				mset.monitorWg.Done()
 			}
-		} else if numReplicas == 1 && alreadyRunning {
+		} else if numReplicas == 1 && desired == nil && alreadyRunning {
 			// We downgraded to R1. Make sure we cleanup the raft node and the stream monitor.
 			mset.removeNode()
 			mset.stopMonitoring()
@@ -5371,7 +5432,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 		mset.setStreamAssignment(sa)
 
 		// Call update.
-		err = mset.updateWithAdvisory(cfg, !recovering, false)
+		err = mset.updateWithAdvisory(newCfg, !recovering, false)
 	}
 
 	// If not found we must be expanding into this node since if we are here we know we are a member.
@@ -5405,7 +5466,7 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 	isLeader := mset.IsLeader()
 
 	// If the stream is scaled down, there is a chance we weren't already the leader.
-	if isLeader && numReplicas == 1 && oldNumReplicas > 1 {
+	if isLeader && numReplicas == 1 && desired == nil && wasClustered {
 		js.processStreamLeaderChange(mset, true, 0)
 	}
 
@@ -5453,6 +5514,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 	js.mu.RLock()
 	s, rg, created := js.srv, sa.Group, sa.Created
 	alreadyRunning := rg.node != nil
+	newCfg := sa.Config.atDesiredOrigin(rg)
 	storage := sa.Config.Storage
 	restore := sa.Restore
 	recovering := sa.recovering
@@ -5528,8 +5590,8 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 			mset.setStreamAssignment(sa)
 			// Check if our config has really been updated.
 			cfg := mset.config()
-			if !reflect.DeepEqual(&cfg, sa.Config) {
-				if err = mset.updateWithAdvisory(sa.Config, false, false); err != nil {
+			if !reflect.DeepEqual(&cfg, newCfg) {
+				if err = mset.updateWithAdvisory(newCfg, false, false); err != nil {
 					if js.isShuttingDown() {
 						s.Debugf("Could not update stream, JetStream shutting down")
 						return
@@ -5551,7 +5613,7 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 			}
 		} else if err == NewJSStreamNotFoundError() {
 			// Add in the stream here.
-			mset, err = acc.addStreamWithAssignment(sa.Config, nil, sa, false, true)
+			mset, err = acc.addStreamWithAssignment(newCfg, nil, sa, false, true)
 		}
 		if mset != nil {
 			mset.setCreatedTime(created)
@@ -6219,7 +6281,7 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 				needsLocalResponse = true
 			}
 			// If we look like we are scaling up, let's send our current state to the group.
-			sendState = len(ca.Group.Peers) > len(oca.Group.Peers) && o.IsLeader() && n != nil
+			sendState = (len(ca.Group.Peers) > len(oca.Group.Peers) || ca.Group.Desired != nil) && o.IsLeader() && n != nil
 			// Signal that this is an update
 			if ca.Reply != _EMPTY_ {
 				isConfigUpdate = true
@@ -6314,7 +6376,7 @@ func (js *jetStream) processClusterCreateConsumer(oca, ca *consumerAssignment, s
 			o.setCreatedTime(ca.Created)
 		} else {
 			// Check for scale down to 1..
-			if node != nil && len(rg.Peers) == 1 {
+			if node != nil && len(rg.Peers) == 1 && rg.Desired == nil {
 				o.clearNode()
 				o.stopMonitoring()
 				// Need to clear from rg too.
@@ -7623,9 +7685,254 @@ func (js *jetStream) processConsumerAssignmentResults(sub *subscription, c *clie
 	}
 }
 
+type streamAssignmentReconcile struct {
+	Account string `json:"account"` // Account of the stream.
+	Stream  string `json:"stream"`  // The stream name itself.
+	desiredAssignmentUpdate
+}
+
+type consumerAssignmentReconcile struct {
+	Account  string `json:"account"`  // Account of the consumer.
+	Stream   string `json:"stream"`   // Stream of the consumer.
+	Consumer string `json:"consumer"` // The consumer name itself.
+	desiredAssignmentUpdate
+}
+
+type desiredAssignmentUpdate struct {
+	ID   string `json:"id,omitempty"` // Desired state ID. Empty if there is no desired state yet.
+	Term uint64 `json:"term"`         // Raft term of the group leader sending this update, used for fencing.
+
+	// The below fields are mutually exclusive.
+	ScaleDownPeers []string `json:"scale_down_peers,omitempty"` // If the desired state was about scaledown, this is the selected peer set.
+	MetaPeers      []string `json:"meta_peers,omitempty"`       // Which peers the assignment should be updated to.
+
+	PeersMatch bool `json:"match,omitempty"` // Actual peer set matches with the passed MetaPeers.
+}
+
+// reconcileDesiredStreamAssignment runs on the meta leader and reconciles a stream's assignment.
+func (js *jetStream) reconcileDesiredStreamAssignment(_ *subscription, _ *client, _ *Account, _, _ string, msg []byte) {
+	var reconcile streamAssignmentReconcile
+	decoder := json.NewDecoder(bytes.NewReader(msg))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&reconcile); err != nil {
+		return
+	}
+
+	js.mu.Lock()
+	defer js.mu.Unlock()
+
+	cc := js.cluster
+	if cc == nil || cc.meta == nil {
+		return
+	}
+	osa := js.streamAssignmentOrInflight(reconcile.Account, reconcile.Stream)
+	if osa == nil || osa.Group == nil || osa.unsupported != nil || reconcile.Term == 0 {
+		return
+	}
+
+	// We stage consumer updates and do them after the stream update.
+	var consumers []*consumerAssignment
+
+	// If any consumers need to be remapped, we can't mark the stream's desired state done yet.
+	var done bool
+
+	// A legacy in-progress move/scale (no desired state, more peers than replicas)
+	// first needs desired state initialized below. Remapping consumers now would
+	// propose direct peer swaps without migrating them, so postpone until the next
+	// cycle when they can move through desired state.
+	legacyMove := osa.Group.Desired == nil && len(osa.Group.Peers) > osa.Config.Replicas
+
+	// If the stream is scaling down and hasn't selected its final peer set yet,
+	// we need to wait before we remap.
+	if !legacyMove && (osa.Group.Desired == nil || !osa.Group.Desired.ScaleDown) {
+		// Need to remap any consumers.
+		consumers, _, done = js.remapConsumerAssignments(reconcile.Account, osa, false)
+	}
+
+	ng := osa.Group.reconcileDesiredState(reconcile.desiredAssignmentUpdate, osa.Config.Replicas, done)
+	if ng != nil {
+		sa := osa.copyGroup()
+		sa.Group = ng
+		// Single nodes are not recorded by the NRG layer so we can rename.
+		// MUST do this, otherwise a scaleup afterward could potentially lead to inconsistencies.
+		if sa.Group.Desired == nil && len(sa.Group.Peers) == 1 {
+			sa.Group.Name = groupNameForStream(sa.Group.Peers, sa.Group.Storage)
+		}
+		if err := cc.meta.Propose(cc.term, encodeUpdateStreamAssignment(sa)); err != nil {
+			return
+		}
+		cc.trackInflightStreamProposal(reconcile.Account, sa, false)
+	}
+
+	// Process any staged consumers.
+	for _, ca := range consumers {
+		if err := cc.meta.Propose(cc.term, encodeAddConsumerAssignment(ca)); err != nil {
+			return
+		}
+		cc.trackInflightConsumerProposal(reconcile.Account, reconcile.Stream, ca, false)
+	}
+}
+
+// reconcileDesiredConsumerAssignment runs on the meta leader and reconciles a consumer's assignment.
+func (js *jetStream) reconcileDesiredConsumerAssignment(_ *subscription, _ *client, _ *Account, _, _ string, msg []byte) {
+	var reconcile consumerAssignmentReconcile
+	decoder := json.NewDecoder(bytes.NewReader(msg))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&reconcile); err != nil {
+		return
+	}
+
+	js.mu.Lock()
+	defer js.mu.Unlock()
+
+	cc := js.cluster
+	if cc == nil || cc.meta == nil {
+		return
+	}
+
+	osa := js.streamAssignmentOrInflight(reconcile.Account, reconcile.Stream)
+	if osa == nil || osa.Group == nil {
+		return
+	}
+	oca := js.consumerAssignmentOrInflight(reconcile.Account, reconcile.Stream, reconcile.Consumer)
+	if oca == nil || oca.Group == nil || oca.unsupported != nil || reconcile.Term == 0 {
+		return
+	}
+	// Sanity check that the consumer isn't trying to scale to a peer that isn't
+	// in the stream's peer assignment yet. Otherwise, we'd add a consumer peer where
+	// a stream isn't hosted yet.
+	if len(reconcile.MetaPeers) > 0 {
+		for _, peer := range reconcile.MetaPeers {
+			if slices.Contains(oca.Group.Peers, peer) {
+				continue
+			}
+			if !slices.Contains(osa.Group.Peers, peer) {
+				return
+			}
+		}
+	}
+	replicas := oca.Config.replicas(osa.Config)
+	ng := oca.Group.reconcileDesiredState(reconcile.desiredAssignmentUpdate, replicas, true)
+	if ng == nil {
+		return
+	}
+	ca := oca.copyGroup()
+	ca.Group = ng
+	// Single nodes are not recorded by the NRG layer so we can rename.
+	// MUST do this, otherwise a scaleup afterward could potentially lead to inconsistencies.
+	if ca.Group.Desired == nil && len(ca.Group.Peers) == 1 {
+		ca.Group.Name = groupNameForConsumer(ca.Group.Peers, ca.Group.Storage)
+	}
+	if err := cc.meta.Propose(cc.term, encodeAddConsumerAssignment(ca)); err != nil {
+		return
+	}
+	cc.trackInflightConsumerProposal(reconcile.Account, reconcile.Stream, ca, false)
+}
+
+func (rg *raftGroup) reconcileDesiredState(reconcile desiredAssignmentUpdate, replicas int, done bool) *raftGroup {
+	// Fields are mutually exclusive.
+	if reconcile.ScaleDownPeers != nil && reconcile.MetaPeers != nil {
+		return nil
+	}
+
+	// Initialize desired state if not set.
+	if rg.Desired == nil {
+		// Request is about state that we don't have.
+		if reconcile.ID != _EMPTY_ {
+			return nil
+		}
+		ng := rg.copyGroup()
+		newPeers := rg.Peers
+		if len(newPeers) > replicas {
+			newPeers = newPeers[len(newPeers)-replicas:]
+		}
+		ng.Peers = newPeers
+		ng = rg.withDesired(ng)
+		ng.Desired.Term = reconcile.Term
+		return ng
+	}
+
+	// Requests from an older leadership term are stale, fence them off. Raft guarantees at most
+	// one leader per term, so anything below the recorded term can't be from the current leader.
+	if reconcile.Term < rg.Desired.Term {
+		return nil
+	}
+
+	// Skip if this request is not about our latest desired state.
+	if rg.Desired.ID == _EMPTY_ || rg.Desired.ID != reconcile.ID {
+		return nil
+	}
+
+	// Desired state is set, but a new leadership term MUST first be recorded before its updates
+	// are accepted. The group leader waits with sending update requests until it sees its own term.
+	// The desired state ID is updated to prevent the group leader from sending an update request early.
+	if rg.Desired.Term == 0 || reconcile.Term > rg.Desired.Term {
+		ng := rg.copyGroup()
+		ng.Desired.ID = nuid.Next()
+		ng.Desired.Term = reconcile.Term
+		return ng
+	}
+
+	// A scale down requires selected peers to scale down to first. The group leader is allowed to pick
+	// a subset of the passed desired peer set.
+	if rg.Desired.ScaleDown {
+		if reconcile.ScaleDownPeers == nil {
+			return nil
+		}
+		// All scale down peers should be a subset, ignore if not.
+		for _, peer := range reconcile.ScaleDownPeers {
+			if !slices.Contains(rg.Desired.Peers, peer) {
+				return nil
+			}
+		}
+		// Reset scaledown and save the selected peers.
+		ng := rg.copyGroup()
+		ng.Desired.ID = nuid.Next()
+		ng.Desired.ScaleDown = false
+		ng.Desired.Peers = reconcile.ScaleDownPeers
+		return ng
+	}
+
+	// Final check to make sure it's about a meta assignment peer set update.
+	// If not, then it's likely just a nudge to remap consumers.
+	if reconcile.MetaPeers == nil {
+		return nil
+	}
+
+	// Always update the actual peers.
+	ng := rg.copyGroup()
+	prevPeers := ng.Peers
+	ng.Peers = reconcile.MetaPeers
+
+	// Compare on sorted copies, so we don't clobber the peer ordering.
+	desiredPeers := copyStrings(rg.Desired.Peers)
+	metaPeers := copyStrings(reconcile.MetaPeers)
+	slices.Sort(desiredPeers)
+	slices.Sort(metaPeers)
+	exactMatch := slices.Equal(desiredPeers, metaPeers)
+	if exactMatch && reconcile.PeersMatch && done {
+		// We're done, reset the desired state fields and finalize the assignment.
+		ng.Peers = ng.Desired.Peers
+		ng.Cluster = ng.Desired.Cluster
+		ng.Preferred = _EMPTY_
+		ng.Desired = nil
+	} else {
+		// Skip if the peer set is unchanged.
+		slices.Sort(prevPeers)
+		if slices.Equal(metaPeers, prevPeers) {
+			return nil
+		}
+		// Still converging toward the desired peer set.
+		ng.Desired.ID = nuid.Next()
+	}
+	return ng
+}
+
 const (
-	streamAssignmentSubj   = "$SYS.JSC.STREAM.ASSIGNMENT.RESULT"
-	consumerAssignmentSubj = "$SYS.JSC.CONSUMER.ASSIGNMENT.RESULT"
+	streamAssignmentSubj            = "$SYS.JSC.STREAM.ASSIGNMENT.RESULT"
+	streamAssignmentReconcileSubj   = "$SYS.JSC.STREAM.ASSIGNMENT.RECONCILE"
+	consumerAssignmentSubj          = "$SYS.JSC.CONSUMER.ASSIGNMENT.RESULT"
+	consumerAssignmentReconcileSubj = "$SYS.JSC.CONSUMER.ASSIGNMENT.RECONCILE"
 )
 
 // Lock should be held.
@@ -7636,6 +7943,12 @@ func (js *jetStream) startUpdatesSub() {
 	}
 	if cc.consumerResults == nil {
 		cc.consumerResults, _ = s.systemSubscribe(consumerAssignmentSubj, _EMPTY_, false, c, js.processConsumerAssignmentResults)
+	}
+	if cc.streamReconcile == nil {
+		cc.streamReconcile, _ = s.systemSubscribe(streamAssignmentReconcileSubj, _EMPTY_, false, c, js.reconcileDesiredStreamAssignment)
+	}
+	if cc.consumerReconcile == nil {
+		cc.consumerReconcile, _ = s.systemSubscribe(consumerAssignmentReconcileSubj, _EMPTY_, false, c, js.reconcileDesiredConsumerAssignment)
 	}
 	if cc.stepdown == nil {
 		cc.stepdown, _ = s.systemSubscribe(JSApiLeaderStepDown, _EMPTY_, false, c, s.jsLeaderStepDownRequest)
@@ -7664,6 +7977,14 @@ func (js *jetStream) stopUpdatesSub() {
 	if cc.consumerResults != nil {
 		cc.s.sysUnsubscribe(cc.consumerResults)
 		cc.consumerResults = nil
+	}
+	if cc.streamReconcile != nil {
+		cc.s.sysUnsubscribe(cc.streamReconcile)
+		cc.streamReconcile = nil
+	}
+	if cc.consumerReconcile != nil {
+		cc.s.sysUnsubscribe(cc.consumerReconcile)
+		cc.consumerReconcile = nil
 	}
 	if cc.stepdown != nil {
 		cc.s.sysUnsubscribe(cc.stepdown)
@@ -7797,22 +8118,34 @@ func (js *jetStream) processLeaderChange(isLeader bool, term uint64) {
 
 // Lock should be held.
 func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, removePeer string) bool {
+	// If the group is already converging toward a desired peer set, that set is what
+	// actually drives membership, so base the replacement on it. Otherwise we'd hand back
+	// a peer set that the in-flight migration reconciles right back over.
+	basePeers, baseCluster := sa.Group.Peers, sa.Group.Cluster
+	if d := sa.Group.Desired; d != nil {
+		basePeers, baseCluster = d.Peers, d.Cluster
+	}
+
 	// Invoke placement algo passing RG peers that stay (existing) and the peer that is being removed (ignore)
-	var retain, ignore []string
-	for _, v := range sa.Group.Peers {
-		if v == removePeer {
-			ignore = append(ignore, v)
-		} else {
+	retain, ignore := make([]string, 0, len(basePeers)), []string{removePeer}
+	for _, v := range basePeers {
+		if v != removePeer {
 			retain = append(retain, v)
 		}
 	}
 
-	newPeers, placementError := cc.selectPeerGroup(len(sa.Group.Peers), sa.Group.Cluster, sa.Config, retain, 0, ignore)
+	newPeers, placementError := cc.selectPeerGroup(len(basePeers), baseCluster, sa.Config, retain, 0, ignore)
 
 	if placementError == nil {
 		sa.Group.Peers = newPeers
 		// Don't influence preferred leader.
 		sa.Group.Preferred = _EMPTY_
+		// Keep the desired peer set in sync, it must not retain the removed peer.
+		if d := sa.Group.Desired; d != nil {
+			d.ID = nuid.Next()
+			d.Peers = newPeers
+			d.Preferred = _EMPTY_
+		}
 		return true
 	}
 
@@ -7822,28 +8155,46 @@ func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, removePe
 	}
 
 	// If we are here let's remove the peer at least, as long as we are R>1
-	for i, peer := range sa.Group.Peers {
-		if peer == removePeer {
-			sa.Group.Peers[i] = sa.Group.Peers[len(sa.Group.Peers)-1]
-			sa.Group.Peers = sa.Group.Peers[:len(sa.Group.Peers)-1]
-			break
+	removeFrom := func(peers []string) []string {
+		for i, peer := range peers {
+			if peer == removePeer {
+				peers[i] = peers[len(peers)-1]
+				return peers[:len(peers)-1]
+			}
 		}
+		return peers
+	}
+	sa.Group.Peers = removeFrom(sa.Group.Peers)
+	if d := sa.Group.Desired; d != nil {
+		d.ID = nuid.Next()
+		d.Peers = removeFrom(d.Peers)
 	}
 	return false
 }
 
+// Remaps the stream's consumers onto its target peer set. Also reports if all consumers have
+// converged, meaning none need to be remapped and none are still moving toward their desired
+// peer set.
 // Lock should be held.
-func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignment, remove bool) (consumers, deleted []*consumerAssignment) {
-	rg := sa.Group
-	targetPeers := rg.Peers
-	if len(rg.Peers) > sa.Config.Replicas {
-		targetPeers = rg.Peers[len(rg.Peers)-sa.Config.Replicas:]
+func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignment, remove bool) (consumers, deleted []*consumerAssignment, done bool) {
+	targetPeers := sa.Group.Peers
+	if sa.Group.Desired != nil {
+		targetPeers = sa.Group.Desired.Peers
+	} else if len(targetPeers) > sa.Config.Replicas {
+		// If the stream is already moving, without desired state, the last N peers are the target.
+		targetPeers = targetPeers[len(targetPeers)-sa.Config.Replicas:]
 	}
+	done = true
 	for ca := range js.consumerAssignmentsOrInflightSeq(accName, sa.Config.Name) {
 		if ca.Config == nil || ca.unsupported != nil {
 			continue
 		}
-		numPeers := len(ca.Group.Peers)
+		consumerPeers := ca.Group.Peers
+		if ca.Group.Desired != nil {
+			// Still moving toward its desired peer set.
+			done = false
+			consumerPeers = ca.Group.Desired.Peers
+		}
 		// Determine the desired replica count.
 		r := ca.Config.replicas(sa.Config)
 		// If stream is interest or workqueue policy always remaps since they require peer parity with stream.
@@ -7853,8 +8204,8 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 		// Drop peers that are no longer part of the stream. If moving, the tail MUST be the new peer set.
 		var keepOld, tail []string
 		kept := 0
-		for _, p := range ca.Group.Peers {
-			if !rg.isMember(p) {
+		for _, p := range consumerPeers {
+			if !sa.Group.isMember(p) {
 				continue
 			}
 			kept++
@@ -7886,22 +8237,22 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 		}
 		newPeers := append(keepOld, tail...)
 		// Leave the consumer alone if its peer set is unaffected.
-		if kept == numPeers && len(newPeers) == numPeers {
+		if kept == len(consumerPeers) && len(newPeers) == len(consumerPeers) {
 			continue
 		}
 		cca := ca.copyGroup()
 		// Adjust preferred as needed.
-		if numPeers == 1 && kept == 1 && len(newPeers) > 1 {
+		if len(consumerPeers) == 1 && kept == 1 && len(newPeers) > 1 {
 			// This is scale up from being a singleton, set preferred to that singleton.
-			cca.Group.Preferred = ca.Group.Peers[0]
+			cca.Group.Preferred = consumerPeers[0]
 		} else {
 			cca.Group.Preferred = _EMPTY_
 		}
 		// Assign new peers.
 		cca.Group.Peers = newPeers
 		// Single nodes are not recorded by the NRG layer so we can rename.
-		if len(newPeers) == 1 || numPeers == 1 {
-			cca.Group.Name = groupNameForConsumer(newPeers, cca.Group.Storage)
+		if len(ca.Group.Peers) == 1 && ca.Group.Desired == nil {
+			cca.Group.Name = groupNameForConsumer(cca.Group.Peers, cca.Group.Storage)
 		}
 		// If the replicas was not 0 make sure it matches here.
 		if cca.Config.Replicas != 0 {
@@ -7910,9 +8261,16 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 			cfg.Replicas = r
 			cca.Config = &cfg
 		}
+		// Only use desired state if the stream did as well.
+		if sa.Group.Desired != nil {
+			cca.Group = ca.Group.withDesired(cca.Group)
+			// Scaled down if we kept at least one peer, but removed others.
+			cca.Group.Desired.ScaleDown = kept > 0 && kept != len(consumerPeers)
+		}
+
 		// Check if all peers are invalid. This can happen with R1 under replicated streams that are being scaled down.
 		// If the old peers are being removed we can't ask them for state, so skip the transfer.
-		if kept == 0 && !remove && !js.srv.allPeersOffline(ca.Group) {
+		if cca.Group.Desired == nil && kept == 0 && !remove && !js.srv.allPeersOffline(ca.Group) {
 			// We have to transfer state to new peers.
 			// we will grab our state and attach to the new assignment.
 			// TODO(dlc) - In practice we would want to make sure the consumer is paused.
@@ -7935,10 +8293,13 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 			// Re-acquire here.
 			js.mu.Lock()
 		}
+
 		// We can not propose here before the stream itself so we collect them.
 		consumers = append(consumers, cca)
 	}
-	return consumers, deleted
+	// Any consumer we remap here still needs to move onto its new peer set.
+	done = done && len(consumers) == 0
+	return consumers, deleted, done
 }
 
 type selectPeerError struct {
@@ -8859,7 +9220,7 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 
 	// Need to remap any consumers.
 	if isReplicaChange || isMoveRequest || isRetentionChange {
-		consumers, _ = js.remapConsumerAssignments(acc.Name, sa, false)
+		consumers, _, _ = js.remapConsumerAssignments(acc.Name, sa, false)
 	}
 
 	// If this is a pure retention change to a non-limits policy, perform the consumer scaling first.

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3054,39 +3054,6 @@ retry:
 			goto retry
 		}
 		s.Debugf("JetStream cluster already has raft group %q assigned", rg.Name)
-		// Check and see if the group has the same peers. If not then we
-		// will update the known peers, which will send a peerstate if leader.
-		groupPeerIDs := append([]string{}, rg.Peers...)
-		var samePeers bool
-		if nodePeers := node.Peers(); len(rg.Peers) == len(nodePeers) {
-			nodePeerIDs := make([]string, 0, len(nodePeers))
-			for _, n := range nodePeers {
-				nodePeerIDs = append(nodePeerIDs, n.ID)
-			}
-			slices.Sort(groupPeerIDs)
-			slices.Sort(nodePeerIDs)
-			samePeers = slices.Equal(groupPeerIDs, nodePeerIDs)
-		}
-		if !samePeers {
-			// At this point we have no way of knowing:
-			// 1. Whether the group has lost enough nodes to cause a quorum
-			//    loss, in which case a proposal may fail, therefore we will
-			//    force a peerstate write;
-			// 2. Whether nodes in the group have other applies queued up
-			//    that could change the peerstate again, therefore the leader
-			//    should send out a new proposal anyway too just to make sure
-			//    that this change gets captured in the log.
-			node.UpdateKnownPeers(groupPeerIDs)
-
-			// If the peers changed as a result of an update by the meta layer, we must reflect that in the log of
-			// this group. Otherwise, a new peer would come up and instantly reset the peer state back to whatever is
-			// in the log at that time, overwriting what the meta layer told it.
-			// Will need to address this properly later on, by for example having the meta layer decide the new
-			// placement, but have the leader of this group propose it through its own log instead.
-			if node.Leader() {
-				node.ProposeKnownPeers(groupPeerIDs)
-			}
-		}
 		rg.node = node
 		return node, nil
 	}
@@ -3150,7 +3117,7 @@ retry:
 			store = ms
 		}
 
-		cfg := &RaftConfig{Name: rgName, Store: storeDir, Log: store, Track: true, Recovering: recovering, ScaleUp: rgScaleUp}
+		cfg := &RaftConfig{Name: rgName, Store: storeDir, Log: store, Track: true, Managed: true, Recovering: recovering, ScaleUp: rgScaleUp}
 
 		if _, err := readPeerState(s.diskIOSemaphore(), storeDir); err != nil {
 			s.bootstrapRaftNode(cfg, rgPeers, true)
@@ -3215,23 +3182,6 @@ func (mset *stream) removeNode() {
 		n.Delete()
 		mset.node = nil
 	}
-}
-
-// Helper function to generate peer info.
-// lists and sets for old and new.
-func genPeerInfo(peers []string, split int) (newPeers, oldPeers []string, newPeerSet, oldPeerSet map[string]bool) {
-	newPeers = peers[split:]
-	oldPeers = peers[:split]
-	newPeerSet = make(map[string]bool, len(newPeers))
-	oldPeerSet = make(map[string]bool, len(oldPeers))
-	for i, peer := range peers {
-		if i < split {
-			oldPeerSet[peer] = true
-		} else {
-			newPeerSet[peer] = true
-		}
-	}
-	return
 }
 
 // This will wait for a period of time until all consumers are registered and have
@@ -3353,6 +3303,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 
 	js.mu.RLock()
 	isLeader := cc.isStreamLeader(sa.Client.serviceAccount(), sa.Config.Name)
+	var leaderTerm uint64
 	isRestore := sa.Restore != nil
 	js.mu.RUnlock()
 
@@ -3482,17 +3433,29 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 	restoreDoneCh := make(<-chan error)
 
 	// For migration tracking.
-	mmtd := 500 * time.Millisecond
-	var mmt *time.Ticker
+	var mmt *time.Timer
 	var mmtc <-chan time.Time
 
-	startMigrationMonitoring := func() {
-		if mmt == nil {
-			mmt = time.NewTicker(mmtd)
-			mmtc = mmt.C
+	resetMigrationMonitoring := func(delay time.Duration) {
+		if mmt != nil {
+			if !mmt.Stop() {
+				// Drain if the timer wasn't stopped.
+				select {
+				case <-mmt.C:
+				default:
+				}
+			}
+			mmt.Reset(delay)
 		}
 	}
-
+	startMigrationMonitoring := func() {
+		if mmt == nil {
+			mmt = time.NewTimer(migrateFastCheckInterval)
+			mmtc = mmt.C
+		} else {
+			resetMigrationMonitoring(migrateFastCheckInterval)
+		}
+	}
 	stopMigrationMonitoring := func() {
 		if mmt != nil {
 			mmt.Stop()
@@ -3617,6 +3580,16 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 					continue
 				}
 
+				// While migrating, react quickly to peer add/remove entries.
+				if mmt != nil {
+					for _, e := range ce.Entries {
+						if e.Type == EntryAddPeer || e.Type == EntryRemovePeer {
+							startMigrationMonitoring()
+							break
+						}
+					}
+				}
+
 				// Apply our entries.
 				if maxApplied, err := js.applyStreamEntries(mset, ce, isRecovering, batch); err == nil {
 					// Update our applied.
@@ -3675,7 +3648,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 			}
 
 		case lc := <-lch:
-			isLeader = lc.isLeader
+			isLeader, leaderTerm = lc.isLeader, lc.term
 			// Process our leader change.
 			js.processStreamLeaderChange(mset, isLeader, lc.term)
 
@@ -3793,10 +3766,9 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 				stopMigrationMonitoring()
 				continue
 			}
-			if done := js.runStreamMigration(mset, sa, n); done {
-				stopMigrationMonitoring()
-				continue
-			}
+			// Reset to the slower fallback speed.
+			resetMigrationMonitoring(migrateFallbackCheckInterval)
+			js.runStreamMigration(mset, sa, n, leaderTerm)
 
 		case err := <-restoreDoneCh:
 			// We have completed a restore from snapshot on this server. The stream assignment has
@@ -3924,94 +3896,178 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 }
 
 // Migrate a stream from peer set A to peer set B. Returns true when migration is done.
-func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n RaftNode) bool {
+func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n RaftNode, leaderTerm uint64) {
 	ourPeerId, cc, s := n.ID(), js.cluster, js.srv
+
+	// FIXME(mvv): a move should make sure that peers are also upper-layer current
+	//  should peers where we're moving to, become required for quorum before we move?
+	//// Check to see where we are..
+	//rg := mset.raftGroup()
+	//
+	//// Make sure we have correct cluster information on the other peers.
+	//ci := js.clusterInfo(rg)
+	//mset.checkClusterInfo(ci)
 
 	js.mu.RLock()
 	// We are shutting down.
 	if cc == nil || cc.meta == nil {
 		js.mu.RUnlock()
-		return true
+		return
+	}
+	if sa == nil || sa.Group == nil {
+		js.mu.RUnlock()
+		return
 	}
 	meta := cc.meta
-	accName, streamName := sa.Client.serviceAccount(), sa.Config.Name
-	js.mu.RUnlock()
+	accName, streamName, replicas := sa.Client.serviceAccount(), sa.Config.Name, sa.Config.Replicas
 
-	// Check to see where we are..
-	rg := mset.raftGroup()
-
-	// Track the new peers and check the ones that are current.
-	mset.mu.RLock()
-	replicas := mset.cfg.Replicas
-	mset.mu.RUnlock()
-	if len(rg.Peers) <= replicas {
-		// Migration no longer happening, so not our job anymore
-		return true
+	update := desiredAssignmentUpdate{Term: leaderTerm}
+	sendMetaUpdate := func() {
+		reconcile := &streamAssignmentReconcile{Account: accName, Stream: streamName, desiredAssignmentUpdate: update}
+		s.sendInternalMsgLocked(streamAssignmentReconcileSubj, _EMPTY_, nil, reconcile)
 	}
 
-	// Make sure we have correct cluster information on the other peers.
-	ci := js.clusterInfo(rg)
-	mset.checkClusterInfo(ci)
+	// If desired state is missing, inform the meta leader to create desired state.
+	// Or, if the recorded leader term isn't ours, then get that updated first.
+	desired := sa.Group.Desired
+	if desired != nil {
+		update.ID = desired.ID
+	}
+	if desired == nil || desired.ID == _EMPTY_ || desired.Term != leaderTerm {
+		js.mu.RUnlock()
+		sendMetaUpdate()
+		return
+	}
 
-	newPeers, _, newPeerSet, oldPeerSet := genPeerInfo(rg.Peers, len(rg.Peers)-replicas)
+	// If a membership change is in progress, we just wait for it to clear.
+	if n.MembershipChangeInProgress() {
+		js.mu.RUnlock()
+		return
+	}
 
-	// If we are part of the new peerset and we have been passed the baton.
-	// We will handle scale down.
-	if newPeerSet[ourPeerId] {
+	actual := n.Peers()
+	actualPeers := make([]string, 0, len(actual))
+	for _, p := range actual {
+		actualPeers = append(actualPeers, p.ID)
+	}
+	desiredPeers := desired.Peers
+
+	// A raft member that is not current member or no longer part of the meta group,
+	// has been evicted from the cluster, e.g. by a server peer-remove. It can't take
+	// part in this migration, so remove it from the group right away rather than
+	// waiting for the rest of the migration to complete.
+	current, metaPeers := copyStrings(sa.Group.Peers), meta.PeerNames()
+	var evicted []string
+	for _, peer := range actualPeers {
+		if !slices.Contains(current, peer) || !slices.Contains(metaPeers, peer) {
+			evicted = append(evicted, peer)
+		}
+	}
+	if len(evicted) > 0 {
+		// Remove evicted peers one at a time, the leader last so leadership stays
+		// stable throughout. Step down and perform a leader transfer if we'd remove
+		// ourselves, preferring a successor that is already in the desired peer set.
+		remove := s.selectPeerToRemove(ourPeerId, actual, evicted)
+		if remove == ourPeerId {
+			preferred := s.selectStepDownPreferred(ourPeerId, actual, desiredPeers)
+			js.mu.RUnlock()
+			n.StepDown(preferred)
+		} else {
+			js.mu.RUnlock()
+			n.ProposeRemovePeer(remove)
+		}
+		return
+	}
+
+	// Extend the actual peer set through the log, but only if it's part of the desired set.
+	for _, peer := range current {
+		if !slices.Contains(actualPeers, peer) && slices.Contains(desiredPeers, peer) {
+			js.mu.RUnlock()
+			n.ProposeAddPeer(peer)
+			return
+		}
+	}
+
+	// If scaling down, we need to select where to.
+	if desired.ScaleDown {
+		update.ScaleDownPeers = s.selectScaleDownPeers(ourPeerId, actual, desired.Peers, replicas)
+		js.mu.RUnlock()
+		sendMetaUpdate()
+		return
+	}
+
+	// Add peers in our desired peer set.
+	foundAll := true
+	for _, peer := range desiredPeers {
+		if !slices.Contains(current, peer) {
+			foundAll = false
+			break
+		}
+	}
+	if !foundAll {
+		combined := current
+		for _, peer := range desiredPeers {
+			if !slices.Contains(current, peer) {
+				combined = append(combined, peer)
+				// FIXME(mvv): for testing only add one replica per cycle.
+				break
+			}
+		}
+		update.MetaPeers = combined
+		js.mu.RUnlock()
+		sendMetaUpdate()
+		return
+	}
+
+	slices.Sort(current)
+	slices.Sort(actualPeers)
+	exactMatch := slices.Equal(current, actualPeers)
+
+	// Remove peers not in our desired peer set.
+	var remaining []string
+	for _, peer := range actualPeers {
+		if !slices.Contains(desiredPeers, peer) {
+			remaining = append(remaining, peer)
+		}
+	}
+
+	// If the peer sets are an exact match, we can remove a peer.
+	if len(remaining) > 0 && exactMatch {
 		// First need to check on any consumers and make sure they have moved properly before scaling down ourselves.
-		js.mu.RLock()
-		var needToWait bool
 		for name, c := range sa.consumers {
 			if c.unsupported != nil {
 				continue
 			}
 			for _, peer := range c.Group.Peers {
 				// If we have peers still in the old set block.
-				if oldPeerSet[peer] {
-					s.Debugf("Scale down of '%s > %s' blocked by consumer '%s'", accName, streamName, name)
-					needToWait = true
-					break
-				}
-			}
-			if needToWait {
-				break
-			}
-		}
-		js.mu.RUnlock()
-		if needToWait {
-			return false
-		}
-		// We are good to go, can scale down here.
-		n.ProposeKnownPeers(newPeers)
-
-		csa := sa.copyGroup()
-		csa.Group.Peers = newPeers
-		csa.Group.Preferred = ourPeerId
-		csa.Group.Cluster = s.cachedClusterName()
-		meta.ForwardProposal(encodeUpdateStreamAssignment(csa))
-		s.Noticef("Scaling down '%s > %s' to %+v", accName, streamName, s.peerSetToNames(newPeers))
-	} else {
-		// We are the old leader here, from the original peer set.
-		// We are simply waiting on the new peerset to be caught up so we can transfer leadership.
-		var newLeaderPeer, newLeader string
-		neededCurrent, current := replicas/2+1, 0
-
-		for _, r := range ci.Replicas {
-			if r.Current && newPeerSet[r.Peer] {
-				current++
-				if newLeader == _EMPTY_ {
-					newLeaderPeer, newLeader = r.Peer, r.Name
+				if !slices.Contains(desiredPeers, peer) {
+					s.Debugf("Scale down of '%s > %s' blocked by consumer '%s'", sa.Client.serviceAccount(), sa.Config.Name, name)
+					js.mu.RUnlock()
+					// We need to wait but still nudge the meta leader since it might need to remap consumers.
+					sendMetaUpdate()
+					return
 				}
 			}
 		}
-		// Check if we have a quorom.
-		if current >= neededCurrent {
-			s.Noticef("Transfer of stream leader for '%s > %s' to '%s'", accName, streamName, newLeader)
-			n.ProposeKnownPeers(newPeers)
-			n.StepDown(newLeaderPeer)
+		// Step down and perform a leader transfer if we'd remove ourselves. We are
+		// selected last, so leadership changes at most once, and every remaining
+		// member is already in the desired peer set so any successor works.
+		remove := s.selectPeerToRemove(ourPeerId, actual, remaining)
+		if remove == ourPeerId {
+			js.mu.RUnlock()
+			n.StepDown()
+		} else {
+			js.mu.RUnlock()
+			n.ProposeRemovePeer(remove)
 		}
+		return
 	}
-	return false
+
+	// We're done.
+	update.MetaPeers = actualPeers
+	update.PeersMatch = exactMatch
+	js.mu.RUnlock()
+	sendMetaUpdate()
 }
 
 // Determine if we are migrating
@@ -4032,9 +4088,22 @@ func (mset *stream) isMigrating() bool {
 	if sa == nil || sa.Group == nil || sa.Group.node == nil {
 		return false
 	}
+	if sa.Group.Desired != nil {
+		return true
+	}
 	// The sign of migration is if our group peer count != configured replica count.
 	if sa.Config.Replicas != len(sa.Group.Peers) {
 		return true
+	}
+	// Final sanity check is that the actual peer set equals the one in the assignment.
+	peers := sa.Group.node.PeerNames()
+	if sa.Config.Replicas != len(peers) {
+		return true
+	}
+	for _, peer := range sa.Group.Peers {
+		if !slices.Contains(peers, peer) {
+			return true
+		}
 	}
 	return false
 }
@@ -4919,6 +4988,15 @@ func (js *jetStream) processStreamLeaderChange(mset *stream, isLeader bool, term
 // Fixed value ok for now.
 const lostQuorumAdvInterval = 10 * time.Second
 
+// Migration monitoring intervals for streams and consumers. We check quickly
+// after observing a relevant change (an assignment update or a peer
+// add/remove), and otherwise poll on a slower fallback interval so blocked
+// migrations don't spam the meta leader with reconcile requests.
+const (
+	migrateFastCheckInterval     = 50 * time.Millisecond
+	migrateFallbackCheckInterval = 500 * time.Millisecond
+)
+
 // Determines if we should send lost quorum advisory. We throttle these after first one.
 func (mset *stream) shouldSendLostQuorum() bool {
 	mset.mu.Lock()
@@ -5398,6 +5476,10 @@ func (js *jetStream) processClusterUpdateStream(acc *Account, osa, sa *streamAss
 					"account": mset.accName(),
 					"stream":  mset.name(),
 				})
+
+				// Re-link the assignment so mset.node picks up the newly created
+				// node before the monitor starts.
+				mset.setStreamAssignment(sa)
 			}
 			mset.startMonitorWg()
 			// Start monitoring..
@@ -6833,17 +6915,29 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 	}
 
 	// For migration tracking.
-	mmtd := 500 * time.Millisecond
-	var mmt *time.Ticker
+	var mmt *time.Timer
 	var mmtc <-chan time.Time
 
-	startMigrationMonitoring := func() {
-		if mmt == nil {
-			mmt = time.NewTicker(mmtd)
-			mmtc = mmt.C
+	resetMigrationMonitoring := func(delay time.Duration) {
+		if mmt != nil {
+			if !mmt.Stop() {
+				// Drain if the timer wasn't stopped.
+				select {
+				case <-mmt.C:
+				default:
+				}
+			}
+			mmt.Reset(delay)
 		}
 	}
-
+	startMigrationMonitoring := func() {
+		if mmt == nil {
+			mmt = time.NewTimer(migrateFastCheckInterval)
+			mmtc = mmt.C
+		} else {
+			resetMigrationMonitoring(migrateFastCheckInterval)
+		}
+	}
 	stopMigrationMonitoring := func() {
 		if mmt != nil {
 			mmt.Stop()
@@ -6854,6 +6948,7 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 
 	// Track if we are leader.
 	var isLeader bool
+	var leaderTerm uint64
 
 	for {
 		select {
@@ -6886,6 +6981,15 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 					}
 					continue
 				}
+				// While migrating, react quickly to peer add/remove entries.
+				if mmt != nil {
+					for _, e := range ce.Entries {
+						if e.Type == EntryAddPeer || e.Type == EntryRemovePeer {
+							startMigrationMonitoring()
+							break
+						}
+					}
+				}
 				if err := js.applyConsumerEntries(o, ce, isLeader); err == nil {
 					var ne, nb uint64
 					// We can't guarantee writes are flushed while we're shutting down. Just rely on replay during recovery.
@@ -6909,7 +7013,7 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 			aq.recycle(&ces)
 
 		case lc := <-lch:
-			isLeader = lc.isLeader
+			isLeader, leaderTerm = lc.isLeader, lc.term
 			if recovering && !isLeader {
 				js.setConsumerAssignmentRecovering(ca)
 			}
@@ -6951,10 +7055,9 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 				stopMigrationMonitoring()
 				continue
 			}
-			if done := js.runConsumerMigration(o, ca, n); done {
-				stopMigrationMonitoring()
-				continue
-			}
+			// Reset to the slower fallback speed.
+			resetMigrationMonitoring(migrateFallbackCheckInterval)
+			js.runConsumerMigration(ca, n, leaderTerm)
 
 		case <-t.C:
 			// Start forcing snapshots if they failed previously.
@@ -6965,60 +7068,167 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 }
 
 // Migrate a consumer from peer set A to peer set B. Returns true when migration is done.
-func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n RaftNode) bool {
+func (js *jetStream) runConsumerMigration(ca *consumerAssignment, n RaftNode, leaderTerm uint64) {
 	ourPeerId, cc, s := n.ID(), js.cluster, js.srv
 
 	js.mu.RLock()
 	// We are shutting down.
 	if cc == nil || cc.meta == nil {
 		js.mu.RUnlock()
-		return true
+		return
 	}
 	meta := cc.meta
 	accName, streamName, consumerName := ca.Client.serviceAccount(), ca.Stream, ca.Name
-	js.mu.RUnlock()
 
-	rg := o.raftGroup()
-	ci := js.clusterInfo(rg)
-	replicas, err := o.replica()
-	if err != nil {
-		return true
+	osa := js.streamAssignment(accName, streamName)
+	if osa == nil {
+		js.mu.RUnlock()
+		return
 	}
-	if len(rg.Peers) <= replicas {
-		// Migration no longer happening, so not our job anymore
-		return true
+
+	replicas := ca.Config.replicas(osa.Config)
+
+	update := desiredAssignmentUpdate{Term: leaderTerm}
+	sendMetaUpdate := func() {
+		reconcile := &consumerAssignmentReconcile{Account: accName, Stream: streamName, Consumer: consumerName, desiredAssignmentUpdate: update}
+		s.sendInternalMsgLocked(consumerAssignmentReconcileSubj, _EMPTY_, nil, reconcile)
 	}
-	newPeers, _, newPeerSet, _ := genPeerInfo(rg.Peers, len(rg.Peers)-replicas)
 
-	// If we are part of the new peerset and we have been passed the baton.
-	// We will handle scale down.
-	if newPeerSet[ourPeerId] {
-		n.ProposeKnownPeers(newPeers)
-		cca := ca.copyGroup()
-		cca.Group.Peers = newPeers
-		cca.Group.Cluster = s.cachedClusterName()
-		meta.ForwardProposal(encodeAddConsumerAssignment(cca))
-		s.Noticef("Scaling down '%s > %s > %s' to %+v", accName, streamName, consumerName, s.peerSetToNames(newPeers))
+	// If desired state is missing, inform the meta leader to create desired state.
+	// Or, if the recorded leader term isn't ours, then get that updated first.
+	desired := ca.Group.Desired
+	if desired != nil {
+		update.ID = desired.ID
+	}
+	if desired == nil || desired.ID == _EMPTY_ || desired.Term != leaderTerm {
+		js.mu.RUnlock()
+		sendMetaUpdate()
+		return
+	}
 
-	} else {
-		var newLeaderPeer, newLeader, newCluster string
-		neededCurrent, current := replicas/2+1, 0
-		for _, r := range ci.Replicas {
-			if r.Current && newPeerSet[r.Peer] {
-				current++
-				if newCluster == _EMPTY_ {
-					newLeaderPeer, newLeader, newCluster = r.Peer, r.Name, r.cluster
-				}
+	// If a membership change is in progress, we just wait for it to clear.
+	if n.MembershipChangeInProgress() {
+		js.mu.RUnlock()
+		return
+	}
+
+	actual := n.Peers()
+	actualPeers := make([]string, 0, len(actual))
+	for _, p := range actual {
+		actualPeers = append(actualPeers, p.ID)
+	}
+	desiredPeers := desired.Peers
+
+	// A raft member that is not current member or no longer part of the meta group,
+	// has been evicted from the cluster, e.g. by a server peer-remove. It can't take
+	// part in this migration, so remove it from the group right away rather than
+	// waiting for the rest of the migration to complete.
+	current, metaPeers := copyStrings(ca.Group.Peers), meta.PeerNames()
+	var evicted []string
+	for _, peer := range actualPeers {
+		if !slices.Contains(current, peer) || !slices.Contains(metaPeers, peer) {
+			evicted = append(evicted, peer)
+		}
+	}
+	if len(evicted) > 0 {
+		// Remove evicted peers one at a time, the leader last so leadership stays
+		// stable throughout. Step down and perform a leader transfer if we'd remove
+		// ourselves, preferring a successor that is already in the desired peer set.
+		remove := s.selectPeerToRemove(ourPeerId, actual, evicted)
+		if remove == ourPeerId {
+			preferred := s.selectStepDownPreferred(ourPeerId, actual, desiredPeers)
+			js.mu.RUnlock()
+			n.StepDown(preferred)
+		} else {
+			js.mu.RUnlock()
+			n.ProposeRemovePeer(remove)
+		}
+		return
+	}
+
+	// Extend the actual peer set through the log, but only if it's part of the desired set.
+	for _, peer := range current {
+		if !slices.Contains(actualPeers, peer) && slices.Contains(desiredPeers, peer) {
+			js.mu.RUnlock()
+			n.ProposeAddPeer(peer)
+			return
+		}
+	}
+
+	// If scaling down, we need to select where to.
+	if desired.ScaleDown {
+		update.ScaleDownPeers = s.selectScaleDownPeers(ourPeerId, actual, desired.Peers, replicas)
+		js.mu.RUnlock()
+		sendMetaUpdate()
+		return
+	}
+
+	// Add peers in our desired peer set.
+	foundAll := true
+	for _, peer := range desiredPeers {
+		if !slices.Contains(current, peer) {
+			foundAll = false
+			break
+		}
+	}
+	if !foundAll {
+		// Only add a peer once the stream is actually hosted on it. A consumer can't
+		// move to a peer earlier until the stream is hosted there.
+		var nextPeer string
+		for _, peer := range desiredPeers {
+			if slices.Contains(current, peer) {
+				continue
 			}
+			if !slices.Contains(osa.Group.Peers, peer) {
+				continue
+			}
+			nextPeer = peer
+			break
 		}
+		if nextPeer == _EMPTY_ {
+			js.mu.RUnlock()
+			return
+		}
+		// FIXME(mvv): for testing only add one replica per cycle.
+		update.MetaPeers = append(current, nextPeer)
+		js.mu.RUnlock()
+		sendMetaUpdate()
+		return
+	}
 
-		// Check if we have a quorom
-		if current >= neededCurrent {
-			s.Noticef("Transfer of consumer leader for '%s > %s > %s' to '%s'", accName, streamName, consumerName, newLeader)
-			n.StepDown(newLeaderPeer)
+	slices.Sort(current)
+	slices.Sort(actualPeers)
+	exactMatch := slices.Equal(current, actualPeers)
+
+	// Remove peers not in our desired peer set.
+	var remaining []string
+	for _, peer := range actualPeers {
+		if !slices.Contains(desiredPeers, peer) {
+			remaining = append(remaining, peer)
 		}
 	}
-	return false
+
+	// If the peer sets are an exact match, we can remove a peer.
+	if len(remaining) > 0 && exactMatch {
+		// Step down and perform a leader transfer if we'd remove ourselves. We are
+		// selected last, so leadership changes at most once, and every remaining
+		// member is already in the desired peer set so any successor works.
+		remove := s.selectPeerToRemove(ourPeerId, actual, remaining)
+		if remove == ourPeerId {
+			js.mu.RUnlock()
+			n.StepDown()
+		} else {
+			js.mu.RUnlock()
+			n.ProposeRemovePeer(remove)
+		}
+		return
+	}
+
+	// We're done.
+	update.MetaPeers = actualPeers
+	update.PeersMatch = exactMatch
+	js.mu.RUnlock()
+	sendMetaUpdate()
 }
 
 // Determine if we are migrating
@@ -7043,9 +7253,22 @@ func (o *consumer) isMigrating() bool {
 	if ca == nil || ca.Group == nil || ca.Group.node == nil {
 		return false
 	}
+	if ca.Group.Desired != nil {
+		return true
+	}
 	// The sign of migration is if our group peer count != configured replica count.
 	if replicas != len(ca.Group.Peers) {
 		return true
+	}
+	// Final sanity check is that the actual peer set equals the one in the assignment.
+	peers := ca.Group.node.PeerNames()
+	if replicas != len(peers) {
+		return true
+	}
+	for _, peer := range ca.Group.Peers {
+		if !slices.Contains(peers, peer) {
+			return true
+		}
 	}
 	return false
 }
@@ -7836,6 +8059,7 @@ func (rg *raftGroup) reconcileDesiredState(reconcile desiredAssignmentUpdate, re
 	}
 
 	// Initialize desired state if not set.
+	// FIXME(mvv): test with pre-existing move state without desired.
 	if rg.Desired == nil {
 		// Request is about state that we don't have.
 		if reconcile.ID != _EMPTY_ {
@@ -8202,17 +8426,12 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 			r = sa.Config.Replicas
 		}
 		// Drop peers that are no longer part of the stream. If moving, the tail MUST be the new peer set.
-		var keepOld, tail []string
+		var newPeers []string
 		kept := 0
 		for _, p := range consumerPeers {
-			if !sa.Group.isMember(p) {
-				continue
-			}
-			kept++
 			if slices.Contains(targetPeers, p) {
-				tail = append(tail, p)
-			} else {
-				keepOld = append(keepOld, p)
+				kept++
+				newPeers = append(newPeers, p)
 			}
 		}
 		// If an ephemeral lost all of its peers to removal, we delete it rather than move it.
@@ -8221,21 +8440,20 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 			continue
 		}
 		// Backfill from the shuffled target set until the consumer has its desired number of target peers.
-		if len(tail) < r {
+		if len(newPeers) < r {
 			backfill := copyStrings(targetPeers)
 			rand.Shuffle(len(backfill), func(i, j int) { backfill[i], backfill[j] = backfill[j], backfill[i] })
 			for _, p := range backfill {
-				if len(tail) >= r {
+				if len(newPeers) >= r {
 					break
 				}
-				if !slices.Contains(tail, p) {
-					tail = append(tail, p)
+				if !slices.Contains(newPeers, p) {
+					newPeers = append(newPeers, p)
 				}
 			}
-		} else if len(tail) > r {
-			tail = tail[:r]
+		} else if len(newPeers) > r {
+			newPeers = newPeers[:r]
 		}
-		newPeers := append(keepOld, tail...)
 		// Leave the consumer alone if its peer set is unaffected.
 		if kept == len(consumerPeers) && len(newPeers) == len(consumerPeers) {
 			continue
@@ -8262,38 +8480,12 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 			cca.Config = &cfg
 		}
 		// Only use desired state if the stream did as well.
+		// FIXME(mvv): improve peer-remove
 		if sa.Group.Desired != nil {
 			cca.Group = ca.Group.withDesired(cca.Group)
 			// Scaled down if we kept at least one peer, but removed others.
 			cca.Group.Desired.ScaleDown = kept > 0 && kept != len(consumerPeers)
 		}
-
-		// Check if all peers are invalid. This can happen with R1 under replicated streams that are being scaled down.
-		// If the old peers are being removed we can't ask them for state, so skip the transfer.
-		if cca.Group.Desired == nil && kept == 0 && !remove && !js.srv.allPeersOffline(ca.Group) {
-			// We have to transfer state to new peers.
-			// we will grab our state and attach to the new assignment.
-			// TODO(dlc) - In practice we would want to make sure the consumer is paused.
-			// Need to release js lock.
-			js.mu.Unlock()
-			if ci, err := sysRequest[ConsumerInfo](js.srv, clusterConsumerInfoT, accName, sa.Config.Name, ca.Name); err != nil {
-				js.srv.Warnf("Did not receive consumer info results for '%s > %s > %s' due to: %s", accName, sa.Config.Name, ca.Name, err)
-			} else if ci != nil {
-				cca.State = &ConsumerState{
-					Delivered: SequencePair{
-						Consumer: ci.Delivered.Consumer,
-						Stream:   ci.Delivered.Stream,
-					},
-					AckFloor: SequencePair{
-						Consumer: ci.AckFloor.Consumer,
-						Stream:   ci.AckFloor.Stream,
-					},
-				}
-			}
-			// Re-acquire here.
-			js.mu.Lock()
-		}
-
 		// We can not propose here before the stream itself so we collect them.
 		consumers = append(consumers, cca)
 	}
@@ -8906,60 +9098,6 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 	cc.trackInflightStreamProposal(acc.Name, sa, false)
 }
 
-var (
-	errReqTimeout = errors.New("timeout while waiting for response")
-	errReqSrvExit = errors.New("server shutdown while waiting for response")
-)
-
-// blocking utility call to perform requests on the system account
-// returns (synchronized) v or error
-func sysRequest[T any](s *Server, subjFormat string, args ...any) (*T, error) {
-	isubj := fmt.Sprintf(subjFormat, args...)
-
-	s.mu.Lock()
-	if s.sys == nil {
-		s.mu.Unlock()
-		return nil, ErrNoSysAccount
-	}
-	inbox := s.newRespInbox()
-	results := make(chan *T, 1)
-	s.sys.replies[inbox] = func(_ *subscription, _ *client, _ *Account, _, _ string, msg []byte) {
-		var v T
-		if err := json.Unmarshal(msg, &v); err != nil {
-			s.Warnf("Error unmarshalling response for request '%s':%v", isubj, err)
-			return
-		}
-		select {
-		case results <- &v:
-		default:
-			s.Warnf("Failed placing request response on internal channel")
-		}
-	}
-	s.mu.Unlock()
-
-	s.sendInternalMsgLocked(isubj, inbox, nil, nil)
-
-	defer func() {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		if s.sys != nil && s.sys.replies != nil {
-			delete(s.sys.replies, inbox)
-		}
-	}()
-
-	ttl := time.NewTimer(2 * time.Second)
-	defer ttl.Stop()
-
-	select {
-	case <-s.quitCh:
-		return nil, errReqSrvExit
-	case <-ttl.C:
-		return nil, errReqTimeout
-	case data := <-results:
-		return data, nil
-	}
-}
-
 func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, subject, reply string, rmsg []byte, cfg *StreamConfig, peerSet []string, pedantic bool) {
 	js, cc := s.getJetStreamCluster()
 	if js == nil || cc == nil {
@@ -9077,54 +9215,49 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 	// A retention change might result in consumer replica changes.
 	isRetentionChange := newCfg.Retention != osa.Config.Retention
 
-	// We stage consumer updates and do them after the stream update.
-	var consumers []*consumerAssignment
-
-	// Check if this is a move request, but no cancellation, and we are already moving this stream.
-	if isMoveRequest && !isMoveCancel && osa.Config.Replicas != len(rg.Peers) {
-		// obtain stats to include in error message
-		msg := _EMPTY_
-		if s.allPeersOffline(rg) {
-			msg = fmt.Sprintf("all %d peers offline", len(rg.Peers))
-		} else {
-			// Need to release js lock.
-			js.mu.Unlock()
-			if si, err := sysRequest[StreamInfo](s, clusterStreamInfoT, ci.serviceAccount(), newCfg.Name); err != nil {
-				msg = fmt.Sprintf("error retrieving info: %s", err.Error())
-			} else if si != nil {
-				currentCount := 0
-				if si.Cluster.Leader != _EMPTY_ {
-					currentCount++
-				}
-				combinedLag := uint64(0)
-				for _, r := range si.Cluster.Replicas {
-					if r.Current {
-						currentCount++
-					}
-					combinedLag += r.Lag
-				}
-				msg = fmt.Sprintf("total peers: %d, current peers: %d, combined lag: %d",
-					len(rg.Peers), currentCount, combinedLag)
-			}
-			// Re-acquire here.
-			js.mu.Lock()
-		}
-		resp.Error = NewJSStreamMoveInProgressError(msg)
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
-		return
-	}
-
-	// Can not move and scale at same time.
-	if isMoveRequest && isReplicaChange {
-		resp.Error = NewJSStreamMoveAndScaleError()
-		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
-		return
-	}
+	// FIXME(mvv): should move be prevented if already ongoing? maybe accept but with group size limits?
+	_ = isMoveCancel
+	//// Check if this is a move request, but no cancellation, and we are already moving this stream.
+	//if isMoveRequest && !isMoveCancel && osa.Config.Replicas != len(rg.Peers) {
+	//	resp.Error = NewJSStreamMoveInProgressError()
+	//	s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+	//	return
+	//}
+	//
+	//// Can not move and scale at same time.
+	//if isMoveRequest && isReplicaChange {
+	//	resp.Error = NewJSStreamMoveAndScaleError()
+	//	s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+	//	return
+	//}
 
 	// Reset notion of scaling up, if this was done in a previous update.
 	rg.ScaleUp = false
-	if isReplicaChange {
-		isScaleUp := newCfg.Replicas > len(rg.Peers)
+	if isMoveRequest {
+		if len(peerSet) == 0 {
+			nrg, err := js.createGroupForStream(ci, newCfg)
+			if err != nil {
+				resp.Error = NewJSClusterNoPeersError(err)
+				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+				return
+			}
+			// Overwrite to the new group, but MUST keep the same group name.
+			name := rg.Name
+			rg = nrg
+			rg.Name = name
+		} else {
+			if len(rg.Peers) == 1 {
+				rg.Preferred = peerSet[0]
+			}
+			rg.Peers = peerSet
+		}
+		rg = osa.Group.withDesired(rg)
+	} else if isReplicaChange {
+		currentPeers := rg.Peers
+		if osa.Group.Desired != nil {
+			currentPeers = osa.Group.Desired.Peers
+		}
+		isScaleUp := newCfg.Replicas > len(currentPeers)
 		// We are adding new peers here.
 		if isScaleUp {
 			// Check that we have the allocation available.
@@ -9145,71 +9278,66 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 					rg.Cluster = ci.Cluster
 				}
 			}
-			peers, err := cc.selectPeerGroup(newCfg.Replicas, rg.Cluster, newCfg, rg.Peers, 0, nil)
+			peers, err := cc.selectPeerGroup(newCfg.Replicas, rg.Cluster, newCfg, currentPeers, 0, nil)
 			if err != nil {
 				resp.Error = NewJSClusterNoPeersError(err)
 				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 				return
 			}
 			// Single nodes are not recorded by the NRG layer so we can rename.
-			if len(peers) == 1 || osa.Config.Replicas == 1 {
+			if len(osa.Group.Peers) == 1 && osa.Group.Desired == nil {
 				rg.Name = groupNameForStream(peers, rg.Storage)
 			}
-			if len(rg.Peers) == 1 {
+			if len(currentPeers) == 1 {
 				// This is scale up from being a singleton, set preferred to that singleton.
-				rg.Preferred = rg.Peers[0]
+				rg.Preferred = currentPeers[0]
 			}
-			rg.ScaleUp = true
 			rg.Peers = peers
+			rg = osa.Group.withDesired(rg)
+			rg.Desired.ScaleUp = true
 		} else {
-			// We are deleting nodes here. We want to do our best to preserve the current leader.
-			// We have support now from above that guarantees we are in our own Go routine, so can
-			// ask for stream info from the stream leader to make sure we keep the leader in the new list.
-			var curLeader string
-			if !s.allPeersOffline(rg) {
-				// Need to release js lock.
-				js.mu.Unlock()
-				if si, err := sysRequest[StreamInfo](s, clusterStreamInfoT, ci.serviceAccount(), newCfg.Name); err != nil {
-					s.Warnf("Did not receive stream info results for '%s > %s' due to: %s", acc, newCfg.Name, err)
-				} else if si != nil {
-					if cl := si.Cluster; cl != nil && cl.Leader != _EMPTY_ {
-						curLeader = getHash(cl.Leader)
-					}
-				}
-				// Re-acquire here.
-				js.mu.Lock()
-			}
-			// If we identified a leader make sure its part of the new group.
-			rg.Peers = s.selectScaleDownPeers(rg.Peers, curLeader, newCfg.Replicas)
-			// Single nodes are not recorded by the NRG layer so we can rename.
-			// MUST do this, otherwise a scaleup afterward could potentially lead to inconsistencies.
-			if len(rg.Peers) == 1 {
-				rg.Name = groupNameForStream(rg.Peers, rg.Storage)
-			}
+			// Mark the group as scaling down, the current leader will be preserved.
+			rg.Peers = currentPeers
+			rg = osa.Group.withDesired(rg)
+			rg.Desired.ScaleDown = true
 		}
-	} else if isMoveRequest {
-		if len(peerSet) == 0 {
-			nrg, err := js.createGroupForStream(ci, newCfg)
-			if err != nil {
-				resp.Error = NewJSClusterNoPeersError(err)
-				s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
-				return
-			}
-			// filter peers present in both sets
-			for _, peer := range rg.Peers {
-				if !slices.Contains(nrg.Peers, peer) {
-					peerSet = append(peerSet, peer)
-				}
-			}
-			peerSet = append(peerSet, nrg.Peers...)
-		}
-		if len(rg.Peers) == 1 {
-			rg.Preferred = peerSet[0]
-		}
-		rg.Peers = peerSet
 	} else {
 		// All other updates make sure no preferred is set.
 		rg.Preferred = _EMPTY_
+	}
+
+	// If we're the first to specify an origin, capture it.
+	if rg.Desired != nil && rg.Desired.Origin == nil {
+		rg.Desired.Origin = &desiredRaftGroupOrigin{
+			Peers:     osa.Group.Peers,
+			Cluster:   osa.Group.Cluster,
+			Replicas:  osa.Config.Replicas,
+			Placement: osa.Config.Placement,
+		}
+	}
+
+	// A retention change should go through desired state, unless it is a singleton without desired state.
+	if isRetentionChange && !(rg.Desired == nil && len(rg.Peers) == 1) {
+		// Must always register desired state.
+		if rg.Desired == nil {
+			rg = osa.Group.withDesired(rg)
+		}
+		// But moving to Limits MUST be applied immediately, since there are no consumer parity restrictions there.
+		// FIXME(mvv): should previous origin retention be removed?
+		if newCfg.Retention != LimitsPolicy {
+			// Only record the retention if we hadn't already recorded it.
+			if d := osa.Group.Desired; d == nil || d.Origin == nil || d.Origin.Retention == nil {
+				if rg.Desired.Origin == nil {
+					rg.Desired.Origin = &desiredRaftGroupOrigin{
+						Peers:     osa.Group.Peers,
+						Cluster:   osa.Group.Cluster,
+						Replicas:  osa.Config.Replicas,
+						Placement: osa.Config.Placement,
+					}
+				}
+				rg.Desired.Origin.Retention = &osa.Config.Retention
+			}
+		}
 	}
 
 	syncSubject := osa.Sync
@@ -9217,35 +9345,10 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		syncSubject = syncSubjForStream()
 	}
 	sa := &streamAssignment{Group: rg, Sync: syncSubject, Created: osa.Created, Config: newCfg, Subject: subject, Reply: reply, Client: ci}
-
-	// Need to remap any consumers.
-	if isReplicaChange || isMoveRequest || isRetentionChange {
-		consumers, _, _ = js.remapConsumerAssignments(acc.Name, sa, false)
-	}
-
-	// If this is a pure retention change to a non-limits policy, perform the consumer scaling first.
-	if isRetentionChange && !isReplicaChange && !isMoveRequest && sa.Config.Retention != LimitsPolicy {
-		for _, ca := range consumers {
-			if err := meta.Propose(cc.term, encodeAddConsumerAssignment(ca)); err != nil {
-				return
-			}
-			cc.trackInflightConsumerProposal(acc.Name, sa.Config.Name, ca, false)
-		}
-		consumers = nil
-	}
-
 	if err := meta.Propose(cc.term, encodeUpdateStreamAssignment(sa)); err != nil {
 		return
 	}
 	cc.trackInflightStreamProposal(acc.Name, sa, false)
-
-	// Process any staged consumers.
-	for _, ca := range consumers {
-		if err := meta.Propose(cc.term, encodeAddConsumerAssignment(ca)); err != nil {
-			return
-		}
-		cc.trackInflightConsumerProposal(acc.Name, sa.Config.Name, ca, false)
-	}
 }
 
 func (s *Server) jsClusteredStreamDeleteRequest(ci *ClientInfo, acc *Account, stream, subject, reply string, rmsg []byte) {
@@ -9396,41 +9499,100 @@ func (s *Server) allPeersOffline(rg *raftGroup) bool {
 	return true
 }
 
-// Select the peers to keep when scaling a raft group down to replicas.
-// The current leader, if known and in peer set, is kept. Online peers are preferred,
-// but we will fall back to offline peers to honor the requested replica count.
-func (s *Server) selectScaleDownPeers(peers []string, curLeader string, replicas int) []string {
-	selected := make([]string, 0, replicas)
-	if curLeader != _EMPTY_ && slices.Contains(peers, curLeader) {
-		selected = append(selected, curLeader)
-		if len(selected) == replicas {
-			return selected
-		}
+// sortScaleDownPeers returns the candidate peers sorted by how preferable
+// they are to keep when scaling a raft group down, most preferable first:
+//  1. the current leader, if known and a candidate
+//  2. peers in the current peer set that are online, least lag first
+//  3. peers in the current peer set that are offline, least lag first
+//  4. peers not in the current peer set, these are treated as offline
+func (s *Server) sortScaleDownPeers(curLeader string, current []*Peer, candidates []string) []string {
+	peers := make(map[string]*Peer, len(current))
+	for _, p := range current {
+		peers[p.ID] = p
 	}
-	// Prefer online peers.
-	for _, peer := range peers {
-		if peer == curLeader {
+
+	// Rank each candidate: a lower tier is more preferable to keep, lag breaks
+	// ties within a tier. Candidate order breaks any remaining ties.
+	type rank struct {
+		tier int
+		lag  uint64
+	}
+	ranks := make(map[string]rank, len(candidates))
+	for _, id := range candidates {
+		if id == curLeader {
+			ranks[id] = rank{tier: 0}
 			continue
 		}
-		if si, ok := s.nodeToInfo.Load(peer); ok && si != nil && !si.(nodeInfo).offline {
-			selected = append(selected, peer)
-			if len(selected) == replicas {
-				return selected
-			}
+		p := peers[id]
+		if p == nil {
+			ranks[id] = rank{tier: 3}
+			continue
+		}
+		// Unknown peers are treated as offline.
+		offline := true
+		if si, ok := s.nodeToInfo.Load(id); ok && si != nil {
+			offline = si.(nodeInfo).offline
+		}
+		if offline {
+			ranks[id] = rank{tier: 2, lag: p.Lag}
+		} else {
+			ranks[id] = rank{tier: 1, lag: p.Lag}
 		}
 	}
 
-	// Fall back to offline peers for the remainder.
-	for _, peer := range peers {
-		if slices.Contains(selected, peer) {
-			continue
+	sorted := copyStrings(candidates)
+	slices.SortStableFunc(sorted, func(a, b string) int {
+		ra, rb := ranks[a], ranks[b]
+		if ra.tier != rb.tier {
+			return cmp.Compare(ra.tier, rb.tier)
 		}
-		selected = append(selected, peer)
-		if len(selected) == replicas {
-			break
+		return cmp.Compare(ra.lag, rb.lag)
+	})
+	return sorted
+}
+
+// Select the peers to keep when scaling a raft group down to replicas.
+// The current leader, if known and a candidate, is always kept. Online peers
+// with the least lag are preferred, but we will fall back to offline peers to
+// honor the requested replica count.
+func (s *Server) selectScaleDownPeers(curLeader string, current []*Peer, peers []string, replicas int) []string {
+	sorted := s.sortScaleDownPeers(curLeader, current, peers)
+	if len(sorted) > replicas {
+		sorted = sorted[:replicas]
+	}
+	return sorted
+}
+
+// selectPeerToRemove picks the peer from remaining that is most preferable to
+// remove during scale-down: peers unknown to the group first, then offline
+// peers, then online peers with the most lag. The current leader, if among the
+// candidates, is picked last so leadership is transferred at most once.
+func (s *Server) selectPeerToRemove(curLeader string, current []*Peer, remaining []string) string {
+	if len(remaining) == 0 {
+		return _EMPTY_
+	}
+	sorted := s.sortScaleDownPeers(curLeader, current, remaining)
+	if len(sorted) == 0 {
+		return _EMPTY_
+	}
+	return sorted[len(sorted)-1]
+}
+
+// selectStepDownPreferred picks the peer to transfer leadership to before the
+// current leader removes itself from the group: the most preferable member of
+// the desired peer set. Empty if no desired peer is part of the group yet.
+func (s *Server) selectStepDownPreferred(ourPeerId string, current []*Peer, desired []string) string {
+	var candidates []string
+	for _, p := range current {
+		if p.ID != ourPeerId && slices.Contains(desired, p.ID) {
+			candidates = append(candidates, p.ID)
 		}
 	}
-	return selected
+	sorted := s.sortScaleDownPeers(_EMPTY_, current, candidates)
+	if len(sorted) == 0 {
+		return _EMPTY_
+	}
+	return sorted[0]
 }
 
 // This will do a scatter and gather operation for all streams for this account. This is only called from metadata leader.
@@ -10271,26 +10433,6 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 		rBefore := nca.Config.replicas(sa.Config)
 		rAfter := cfg.replicas(sa.Config)
 
-		var curLeader string
-		if rBefore != rAfter {
-			// We are modifying nodes here. We want to do our best to preserve the current leader.
-			// We have support now from above that guarantees we are in our own Go routine, so can
-			// ask for stream info from the stream leader to make sure we keep the leader in the new list.
-			if !s.allPeersOffline(ca.Group) {
-				// Need to release js lock.
-				js.mu.Unlock()
-				if ci, err := sysRequest[ConsumerInfo](s, clusterConsumerInfoT, ci.serviceAccount(), sa.Config.Name, oname); err != nil {
-					s.Warnf("Did not receive consumer info results for '%s > %s > %s' due to: %s", acc, sa.Config.Name, oname, err)
-				} else if ci != nil {
-					if cl := ci.Cluster; cl != nil && cl.Leader != _EMPTY_ {
-						curLeader = getHash(cl.Leader)
-					}
-				}
-				// Re-acquire here.
-				js.mu.Lock()
-			}
-		}
-
 		if rBefore < rAfter {
 			newPeerSet := nca.Group.Peers
 			// Scale up by adding new members from the stream peer set that are not yet in the consumer peer set.
@@ -10319,21 +10461,16 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 				}
 			}
 			// Single nodes are not recorded by the NRG layer so we can rename.
-			if rBefore == 1 {
+			if len(ca.Group.Peers) == 1 && ca.Group.Desired == nil {
 				nca.Group.Name = groupNameForConsumer(newPeerSet, nca.Group.Storage)
 			}
 			nca.Group.Peers = newPeerSet
-			nca.Group.Preferred = curLeader
-			nca.Group.ScaleUp = true
+			nca.Group = ca.Group.withDesired(nca.Group)
+			nca.Group.Desired.ScaleUp = true
 		} else if rBefore > rAfter {
-			// Mark the current leader as preferred, it will be kept in the new peer set.
-			nca.Group.Preferred = curLeader
-			nca.Group.Peers = s.selectScaleDownPeers(nca.Group.Peers, curLeader, rAfter)
-			// Single nodes are not recorded by the NRG layer so we can rename.
-			// MUST do this, otherwise a scaleup afterward could potentially lead to inconsistencies.
-			if len(nca.Group.Peers) == 1 {
-				nca.Group.Name = groupNameForConsumer(nca.Group.Peers, nca.Group.Storage)
-			}
+			// Mark the group as scaling down, the current leader will be preserved.
+			nca.Group = ca.Group.withDesired(nca.Group)
+			nca.Group.Desired.ScaleDown = true
 		}
 
 		// Update config and client info on copy of existing.

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -4176,7 +4176,8 @@ func TestJetStreamClusterScaleConsumer(t *testing.T) {
 		if r == 0 {
 			r = si.Config.Replicas
 		}
-		js.UpdateConsumer("TEST", durCfg)
+		_, err = js.UpdateConsumer("TEST", durCfg)
+		require_NoError(t, err)
 
 		checkFor(t, time.Second*30, time.Millisecond*250, func() error {
 			if ci, err = js.ConsumerInfo("TEST", "DUR"); err != nil {
@@ -4196,6 +4197,7 @@ func TestJetStreamClusterScaleConsumer(t *testing.T) {
 			}
 			return nil
 		})
+		c.waitOnConsumerLeader(globalAccountName, "TEST", "DUR")
 
 		require_NoError(t, consumeOne(uint64(i+1)))
 	}
@@ -7756,6 +7758,10 @@ func TestJetStreamClusterConsumerInfoAfterCreate(t *testing.T) {
 	si, err = js.UpdateStream(cfg)
 	require_NoError(t, err)
 	require_NotEqual(t, si.Cluster.Leader, nl.Name())
+
+	// Wait for the scale down to be reconciled, otherwise the consumer could
+	// be placed on a peer that's still being removed from the stream.
+	c.waitOnStreamLeader(globalAccountName, "TEST")
 
 	// We pause applies for the server we're connected to.
 	// This is fine for the RAFT log and allowing the consumer to be created,
@@ -13575,6 +13581,169 @@ func TestJetStreamClusterConsumerScaleOnRetentionChange(t *testing.T) {
 	// switching back to interest retention must restore peer parity with the stream.
 	updateRetentionAndCheck(nats.LimitsPolicy, 1)
 	updateRetentionAndCheck(nats.InterestPolicy, 3)
+}
+
+func TestJetStreamClusterRetentionChangeWaitsForConsumerParity(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	// Limits retention at R3, so the legacy ephemeral starts out at R1.
+	cfg := &nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Retention: nats.LimitsPolicy,
+		Replicas:  3,
+	}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	ci, err := js.AddConsumer("TEST", &nats.ConsumerConfig{
+		AckPolicy:         nats.AckExplicitPolicy,
+		InactiveThreshold: time.Minute,
+	})
+	require_NoError(t, err)
+	cname := ci.Name
+	require_NotEqual(t, cname, _EMPTY_)
+
+	// How many peers the consumer is assigned to, according to the meta leader.
+	consumerPeers := func() int {
+		ml := c.leader()
+		if ml == nil {
+			return 0
+		}
+		mjs := ml.getJetStream()
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		ca := mjs.consumerAssignment(globalAccountName, "TEST", cname)
+		if ca == nil || ca.Group == nil {
+			return 0
+		}
+		return len(ca.Group.Peers)
+	}
+	require_Equal(t, consumerPeers(), 1)
+
+	cfg.Retention = nats.InterestPolicy
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+
+	// The consumer must reach peer parity with the stream BEFORE any server starts applying interest
+	// retention. A stream peer that runs interest retention without hosting a consumer replica would
+	// compute interest over an incomplete consumer set and remove messages that are still of interest.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		interest := 0
+		for _, s := range c.servers {
+			mset, err := s.globalAccount().lookupStream("TEST")
+			if err != nil || mset == nil || !mset.isInterestRetention() {
+				continue
+			}
+			interest++
+			// Re-read here, the consumer could have converged in the meantime.
+			if peers := consumerPeers(); peers < 3 {
+				t.Fatalf("Server %q applied interest retention while consumer was only on %d peer(s)", s.Name(), peers)
+			}
+		}
+		if interest == len(c.servers) && consumerPeers() == 3 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Timed out with %d/%d servers on interest retention and consumer on %d peer(s)",
+				interest, len(c.servers), consumerPeers())
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+func TestJetStreamClusterRetentionChangeOriginSurvivesScale(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R5S", 5)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Retention: nats.LimitsPolicy,
+		Replicas:  3,
+	}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	// Legacy ephemeral, presents as R=0 and sits at R1 under limits retention.
+	ci, err := js.AddConsumer("TEST", &nats.ConsumerConfig{
+		AckPolicy:         nats.AckExplicitPolicy,
+		InactiveThreshold: time.Minute,
+	})
+	require_NoError(t, err)
+	cname := ci.Name
+	require_NotEqual(t, cname, _EMPTY_)
+
+	// The peers assigned to the stream and to the consumer, according to the meta leader.
+	assignedPeers := func() (speers, cpeers []string) {
+		ml := c.leader()
+		if ml == nil {
+			return nil, nil
+		}
+		mjs := ml.getJetStream()
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		if sa := mjs.streamAssignment(globalAccountName, "TEST"); sa != nil && sa.Group != nil {
+			speers = sa.Group.Peers
+		}
+		if ca := mjs.consumerAssignment(globalAccountName, "TEST", cname); ca != nil && ca.Group != nil {
+			cpeers = ca.Group.Peers
+		}
+		return speers, cpeers
+	}
+	speers, cpeers := assignedPeers()
+	require_Equal(t, len(speers), 3)
+	require_Equal(t, len(cpeers), 1)
+
+	// Switch to interest retention. The consumer needs to reach peer parity before it can apply,
+	// so the old retention is held in the desired state's origin while the consumer scales up.
+	cfg.Retention = nats.InterestPolicy
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+
+	// While that is still converging, scale the stream. This re-registers the desired state and
+	// MUST NOT drop the pending retention origin, otherwise interest retention applies right away.
+	cfg.Replicas = 5
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		interest := 0
+		for _, s := range c.servers {
+			mset, err := s.GlobalAccount().lookupStream("TEST")
+			if err != nil || mset == nil || !mset.isInterestRetention() {
+				continue
+			}
+			interest++
+			// Every stream peer must host a consumer replica before interest retention applies.
+			// Re-read here, the consumer could have converged in the meantime.
+			speers, cpeers := assignedPeers()
+			for _, p := range speers {
+				if !slices.Contains(cpeers, p) {
+					t.Fatalf("Server %q applied interest retention, but stream peer %q hosts no consumer replica (stream peers %v, consumer peers %v)",
+						s.Name(), p, speers, cpeers)
+				}
+			}
+		}
+		speers, cpeers = assignedPeers()
+		if interest == len(c.servers) && len(speers) == 5 && len(cpeers) == 5 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Timed out with %d/%d servers on interest retention, stream peers %v, consumer peers %v",
+				interest, len(c.servers), speers, cpeers)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
 }
 
 func TestJetStreamClusterStreamPeerRemoveConsumerRemap(t *testing.T) {

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -7391,7 +7391,9 @@ func TestJetStreamClusterStreamResetWithLargeFirstSeq(t *testing.T) {
 	cfg.Replicas = 3
 	_, err = js.UpdateStream(cfg)
 	require_NoError(t, err)
+	c.waitOnStreamLeader("$G", "TEST")
 	nl := c.randomNonStreamLeader("$G", "TEST")
+	require_NotNil(t, nl)
 	c.waitOnStreamCurrent(nl, "$G", "TEST")
 
 	// Make sure we only sent the number of catchup msgs we expected.
@@ -7440,6 +7442,7 @@ func TestJetStreamClusterStreamCatchupInteriorNilMsgs(t *testing.T) {
 	cfg.Replicas = 3
 	_, err = js.UpdateStream(cfg)
 	require_NoError(t, err)
+	c.waitOnStreamLeader("$G", "TEST")
 	nl := c.randomNonStreamLeader("$G", "TEST")
 	c.waitOnStreamCurrent(nl, "$G", "TEST")
 

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -7492,6 +7492,9 @@ func TestJetStreamClusterStreamScaleDownChangesRaftGroup(t *testing.T) {
 	cfg.Replicas = 1
 	_, err = js.UpdateStream(cfg)
 	require_NoError(t, err)
+	// Wait for scale down to finish, since the group is NOT changed if scaling
+	// too fast since it would remain replicated throughout.
+	c.waitOnStreamLeader(globalAccountName, "TEST")
 	// Publish a couple more messages while it's R1.
 	for range 2 {
 		_, err = js.Publish("foo", []byte("B"))
@@ -7600,6 +7603,9 @@ func TestJetStreamClusterStreamRescaleCatchup(t *testing.T) {
 		cfg.Replicas = 1
 		_, err = js.UpdateStream(cfg)
 		require_NoError(t, err)
+		// Wait for scale down to finish, since the group is NOT changed if scaling
+		// too fast since it would remain replicated throughout.
+		c.waitOnStreamLeader(globalAccountName, "TEST")
 		cfg.Replicas = 3
 		_, err = js.UpdateStream(cfg)
 		require_NoError(t, err)
@@ -7745,10 +7751,13 @@ func TestJetStreamClusterConsumerScaleDownChangesRaftGroup(t *testing.T) {
 	n := mset.lookupConsumer("CONSUMER").raftNode()
 	old := n.Group()
 
-	// Scale stream down and back up.
+	// Scale consumer down and back up.
 	cfg.Replicas = 1
 	_, err = js.UpdateConsumer("TEST", cfg)
 	require_NoError(t, err)
+	// Wait for scale down to finish, since the group is NOT changed if scaling
+	// too fast since it would remain replicated throughout.
+	c.waitOnConsumerLeader(globalAccountName, "TEST", "CONSUMER")
 	cfg.Replicas = 3
 	_, err = js.UpdateConsumer("TEST", cfg)
 	require_NoError(t, err)
@@ -7830,10 +7839,13 @@ func TestJetStreamClusterConsumerRescaleCatchup(t *testing.T) {
 		rs.Shutdown()
 		rs.WaitForShutdown()
 
-		// Scale stream down and back up.
+		// Scale consumer down and back up.
 		cfg.Replicas = 1
 		_, err = js.UpdateConsumer("TEST", cfg)
 		require_NoError(t, err)
+		// Wait for scale down to finish, since the group is NOT changed if scaling
+		// too fast since it would remain replicated throughout.
+		c.waitOnConsumerLeader(globalAccountName, "TEST", "CONSUMER")
 		cfg.Replicas = 3
 		_, err = js.UpdateConsumer("TEST", cfg)
 		require_NoError(t, err)
@@ -11024,18 +11036,20 @@ func TestJetStreamClusterStreamScaleDownOfflinePeersHonorsReplicaCount(t *testin
 	mjs.mu.RUnlock()
 	require_Len(t, len(streamPeers), 5)
 
-	// Shut down three of the stream's peers. Only two of the five stream peers remain online.
+	// Shut down three of the stream's peers. Only two of the five stream peers
+	// remain online, so the stream's group has lost quorum.
 	sl := c.streamLeader(globalAccountName, "TEST")
 	var offline []*Server
+	var online []string
 	for _, p := range streamPeers {
-		if len(offline) == 3 {
-			break
-		}
-		if s := peerSrv[p]; s != sl && s != ml {
+		if s := peerSrv[p]; s != sl && s != ml && len(offline) < 3 {
 			offline = append(offline, s)
+		} else {
+			online = append(online, p)
 		}
 	}
 	require_Len(t, len(offline), 3)
+	require_Len(t, len(online), 2)
 	for _, s := range offline {
 		s.Shutdown()
 	}
@@ -11050,8 +11064,11 @@ func TestJetStreamClusterStreamScaleDownOfflinePeersHonorsReplicaCount(t *testin
 		return nil
 	})
 
-	// Scale the stream down to R3. Only two of the five peers are online, but
-	// the stream must still end up with the requested number of replicas.
+	// Scale the stream down to R3. The update is accepted and recorded as
+	// desired state, but with a majority of the peers offline the group can
+	// not commit membership changes. The scale down must stay pending rather
+	// than override quorum, which could select peers that miss acknowledged
+	// writes or split the group.
 	_, err = js.UpdateStream(&nats.StreamConfig{
 		Name:     "TEST",
 		Subjects: []string{"foo"},
@@ -11059,8 +11076,7 @@ func TestJetStreamClusterStreamScaleDownOfflinePeersHonorsReplicaCount(t *testin
 	})
 	require_NoError(t, err)
 
-	// Wait for the scale down to be applied in the meta layer.
-	var newPeers []string
+	// Wait for the desired scale down to be registered in the meta layer.
 	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
 		mjs.mu.RLock()
 		defer mjs.mu.RUnlock()
@@ -11068,24 +11084,65 @@ func TestJetStreamClusterStreamScaleDownOfflinePeersHonorsReplicaCount(t *testin
 		if sa == nil {
 			return fmt.Errorf("stream assignment not found")
 		}
-		if len(sa.Group.Peers) == len(streamPeers) {
-			return fmt.Errorf("scale down not applied yet, still %d peers", len(sa.Group.Peers))
+		if sa.Group.Desired == nil {
+			return fmt.Errorf("desired state not registered yet")
+		}
+		return nil
+	})
+
+	// While the group has no quorum the scale down must remain pending and
+	// the assigned peer set must remain unchanged.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mjs.mu.RLock()
+		sa := mjs.streamAssignment(globalAccountName, "TEST")
+		var peers int
+		var pending bool
+		if sa != nil {
+			peers = len(sa.Group.Peers)
+			pending = sa.Group.Desired != nil
+		}
+		mjs.mu.RUnlock()
+		require_True(t, sa != nil)
+		require_Len(t, peers, 5)
+		require_True(t, pending)
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Restart one of the offline peers. Three of the five peers are online
+	// again, restoring quorum, so the scale down can now proceed safely by
+	// committing membership changes through the group.
+	c.restartServer(offline[0])
+
+	// Wait for the scale down to complete in the meta layer.
+	var newPeers []string
+	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		sa := mjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil {
+			return fmt.Errorf("stream assignment not found")
+		}
+		if sa.Group.Desired != nil {
+			return fmt.Errorf("scale down still pending")
+		}
+		if len(sa.Group.Peers) != 3 {
+			return fmt.Errorf("expected 3 peers, got %d", len(sa.Group.Peers))
 		}
 		newPeers = copyStrings(sa.Group.Peers)
 		return nil
 	})
 
-	// The stream peer set must reflect the requested replica count.
-	require_Len(t, len(newPeers), 3)
-
-	// The online peers must be preferred and part of the new peer set.
-	for _, p := range streamPeers {
-		if slices.Contains(offline, peerSrv[p]) {
-			continue
-		}
+	// The peers that stayed online must be preferred and part of the new peer set.
+	for _, p := range online {
 		if !slices.Contains(newPeers, p) {
 			t.Fatalf("Online peer %q not selected by the scale down", peerSrv[p].Name())
 		}
+	}
+
+	// The new peer set must be a subset of the original peer set.
+	for _, p := range newPeers {
+		require_True(t, slices.Contains(streamPeers, p))
 	}
 }
 

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -102,10 +102,23 @@ func (sc *supercluster) waitOnStreamLeader(account, stream string) {
 	expires := time.Now().Add(30 * time.Second)
 	for time.Now().Before(expires) {
 		for _, c := range sc.clusters {
-			if leader := c.streamLeader(account, stream); leader != nil {
-				time.Sleep(200 * time.Millisecond)
-				return
+			leader := c.streamLeader(account, stream)
+			if leader == nil {
+				time.Sleep(100 * time.Millisecond)
+				continue
 			}
+			// Also wait for the stream leader to finish any scales/moves.
+			js := leader.getJetStream()
+			js.mu.RLock()
+			sa := js.streamAssignment(account, stream)
+			wait := sa == nil || (sa.Group != nil && sa.Group.Desired != nil)
+			js.mu.RUnlock()
+			if wait {
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			time.Sleep(200 * time.Millisecond)
+			return
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
@@ -1439,11 +1452,23 @@ func (c *cluster) waitOnConsumerLeader(account, stream, consumer string) {
 	c.t.Helper()
 	expires := time.Now().Add(30 * time.Second)
 	for time.Now().Before(expires) {
-		if leader := c.consumerLeader(account, stream, consumer); leader != nil {
-			time.Sleep(200 * time.Millisecond)
-			return
+		leader := c.consumerLeader(account, stream, consumer)
+		if leader == nil {
+			time.Sleep(100 * time.Millisecond)
+			continue
 		}
-		time.Sleep(100 * time.Millisecond)
+		// Also wait for the consumer leader to finish any scales/moves.
+		js := leader.getJetStream()
+		js.mu.RLock()
+		ca := js.consumerAssignment(account, stream, consumer)
+		wait := ca == nil || (ca.Group != nil && ca.Group.Desired != nil)
+		js.mu.RUnlock()
+		if wait {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		time.Sleep(200 * time.Millisecond)
+		return
 	}
 	antithesis.AssertUnreachable(c.t, "Timeout in cluster.waitOnConsumerLeader", map[string]any{
 		"cluster":  c.name,
@@ -1478,11 +1503,23 @@ func (c *cluster) waitOnStreamLeader(account, stream string) {
 	c.t.Helper()
 	expires := time.Now().Add(30 * time.Second)
 	for time.Now().Before(expires) {
-		if leader := c.streamLeader(account, stream); leader != nil {
-			time.Sleep(200 * time.Millisecond)
-			return
+		leader := c.streamLeader(account, stream)
+		if leader == nil {
+			time.Sleep(100 * time.Millisecond)
+			continue
 		}
-		time.Sleep(100 * time.Millisecond)
+		// Also wait for the stream leader to finish any scales/moves.
+		js := leader.getJetStream()
+		js.mu.RLock()
+		sa := js.streamAssignment(account, stream)
+		wait := sa == nil || (sa.Group != nil && sa.Group.Desired != nil)
+		js.mu.RUnlock()
+		if wait {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		time.Sleep(200 * time.Millisecond)
+		return
 	}
 	antithesis.AssertUnreachable(c.t, "Timeout in cluster.waitOnStreamLeader", map[string]any{
 		"cluster": c.name,

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -2430,14 +2430,6 @@ func TestJetStreamSuperClusterMovingStreamsAndConsumers(t *testing.T) {
 				m.AckSync()
 			}
 
-			// First make sure we disallow move and replica changes in same update.
-			_, err = js.UpdateStream(&nats.StreamConfig{
-				Name:      "MOVE",
-				Placement: &nats.Placement{Tags: []string{"cloud:gcp"}},
-				Replicas:  replicas + 1,
-			})
-			require_Error(t, err, NewJSStreamMoveAndScaleError())
-
 			// Now move to new cluster.
 			si, err = js.UpdateStream(&nats.StreamConfig{
 				Name:      "MOVE",
@@ -2445,21 +2437,7 @@ func TestJetStreamSuperClusterMovingStreamsAndConsumers(t *testing.T) {
 				Placement: &nats.Placement{Tags: []string{"cloud:gcp"}},
 			})
 			require_NoError(t, err)
-
-			checkFor(t, 10*time.Second, 500*time.Millisecond, func() error {
-				if si.Cluster.Name != "C1" {
-					return fmt.Errorf("Expected cluster of %q but got %q", "C1", si.Cluster.Name)
-				}
-				return nil
-			})
-
-			// Make sure we can not move an inflight stream and consumers, should error.
-			_, err = js.UpdateStream(&nats.StreamConfig{
-				Name:      "MOVE",
-				Replicas:  replicas,
-				Placement: &nats.Placement{Tags: []string{"cloud:aws"}},
-			})
-			require_Contains(t, err.Error(), "stream move already in progress")
+			require_Equal(t, si.Cluster.Name, "C1")
 
 			checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
 				si, err := js.StreamInfo("MOVE", nats.MaxWait(500*time.Millisecond))
@@ -3382,17 +3360,13 @@ func TestJetStreamSuperClusterTagInducedMoveCancel(t *testing.T) {
 		require_NoError(t, json.Unmarshal(rmsg.Data, &cancelResp))
 		return nil
 	})
-	if cancelResp.Error != nil && ErrorIdentifier(cancelResp.Error.ErrCode) == JSStreamMoveNotInProgress {
-		t.Skip("This can happen with delays, when Move completed before Cancel", cancelResp.Error)
-		return
-	}
 	require_True(t, cancelResp.Error == nil)
 
 	checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
 		si, err := js.StreamInfo("TEST")
 		require_NoError(t, err)
-		if si.Config.Placement != nil {
-			return fmt.Errorf("expected placement to be cleared got: %+v", si.Config.Placement)
+		if !reflect.DeepEqual(si.Config.Placement, &nats.Placement{Tags: []string{"C1"}}) {
+			return fmt.Errorf("expected placement to be back to initial state got: %+v", si.Config.Placement)
 		}
 		return nil
 	})
@@ -3530,10 +3504,6 @@ func TestJetStreamSuperClusterMoveCancel(t *testing.T) {
 		require_NoError(t, err)
 		var cancelResp JSApiStreamUpdateResponse
 		require_NoError(t, json.Unmarshal(rmsg.Data, &cancelResp))
-		if cancelResp.Error != nil && ErrorIdentifier(cancelResp.Error.ErrCode) == JSStreamMoveNotInProgress {
-			t.Skip("This can happen with delays, when Move completed before Cancel", cancelResp.Error)
-			return
-		}
 		require_True(t, cancelResp.Error == nil)
 
 		for _, sExpected := range streamPeerSrv {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -16475,6 +16475,7 @@ func TestJetStreamLimitsToInterestPolicy(t *testing.T) {
 	require_NoError(t, err)
 
 	// We need to wait for all nodes to have applied the new configs.
+	c.waitOnStreamLeader(globalAccountName, "TEST")
 	c.waitOnAllCurrent()
 
 	// The previously R1 consumer should now be R3, matching the stream.
@@ -16566,6 +16567,7 @@ func TestJetStreamLimitsToInterestPolicyWhileAcking(t *testing.T) {
 
 			// We need to wait for all nodes to have applied the new stream
 			// configuration.
+			c.waitOnStreamLeader(globalAccountName, "TEST")
 			c.waitOnAllCurrent()
 
 			var retention nats.RetentionPolicy

--- a/server/raft.go
+++ b/server/raft.go
@@ -66,8 +66,7 @@ type RaftNode interface {
 	ID() string
 	Group() string
 	Peers() []*Peer
-	ProposeKnownPeers(knownPeers []string)
-	UpdateKnownPeers(knownPeers []string)
+	PeerNames() []string
 	ProposeAddPeer(peer string) error
 	ProposeRemovePeer(peer string) error
 	MembershipChangeInProgress() bool
@@ -213,8 +212,9 @@ type raft struct {
 
 	extSt extensionState // Extension state
 
-	track bool // Whether out of resources checking is enabled.
-	dflag bool // Debug flag
+	track   bool // Whether out of resources checking is enabled.
+	dflag   bool // Debug flag
+	managed bool // Peers managed by reconciliation loop, not automatic peer addition.
 
 	psubj  string // Proposals subject
 	rpsubj string // Remove peers subject
@@ -317,6 +317,7 @@ type RaftConfig struct {
 	Store    string
 	Log      WAL
 	Track    bool
+	Managed  bool
 	Observer bool
 
 	// Recovering must be set for a Raft group that's recovering after a restart, or if it's
@@ -463,6 +464,7 @@ func (s *Server) initRaftNode(accName string, cfg *RaftConfig, labels pprofLabel
 		wtype:    cfg.Log.Type(),
 		dios:     s.diskIOSemaphore(),
 		track:    cfg.Track,
+		managed:  cfg.Managed,
 		peers:    make(map[string]*lps),
 		acks:     make(map[uint64]map[string]struct{}),
 		pae:      make(map[uint64]*appendEntry),
@@ -2276,31 +2278,6 @@ func (n *raft) Peers() []*Peer {
 	return peers
 }
 
-// Update and propose our known set of peers.
-func (n *raft) ProposeKnownPeers(knownPeers []string) {
-	n.Lock()
-	defer n.Unlock()
-	// If we are the leader update and send this update out.
-	if n.State() != Leader {
-		return
-	}
-	n.updateKnownPeersLocked(knownPeers)
-	n.sendPeerState()
-}
-
-// Update our known set of peers.
-func (n *raft) UpdateKnownPeers(knownPeers []string) {
-	n.Lock()
-	n.updateKnownPeersLocked(knownPeers)
-	n.Unlock()
-}
-
-func (n *raft) updateKnownPeersLocked(knownPeers []string) {
-	// Process like peer state update.
-	ps := &peerState{knownPeers, len(knownPeers), n.extSt}
-	n.processPeerState(ps)
-}
-
 // ApplyQ returns the apply queue that new commits will be sent to for the
 // upper layer to apply.
 func (n *raft) ApplyQ() *ipQueue[*CommittedEntry] { return n.apply }
@@ -3887,7 +3864,7 @@ func (n *raft) trackPeer(peer string) error {
 			isRemoved = false
 		}
 	}
-	if n.State() == Leader {
+	if !n.managed && n.State() == Leader {
 		if _, ok := n.peers[peer]; !ok {
 			// Check if this peer had been removed previously.
 			needPeerAdd = !isRemoved
@@ -3896,6 +3873,9 @@ func (n *raft) trackPeer(peer string) error {
 	if ps := n.peers[peer]; ps != nil {
 		ps.ts = time.Now()
 	}
+	// FIXME(mvv): if managed, could track meta assigned but not tracked peers here
+	//  that could help in preserving quorum if the meta assignment was updated but
+	//  it's not coming up on the new peer
 	n.Unlock()
 
 	if needPeerAdd {
@@ -4959,6 +4939,12 @@ func decodePeerState(buf []byte) (*peerState, error) {
 		ps.domainExt = extensionState(le.Uint16(buf[ri:]))
 	}
 	return ps, nil
+}
+
+func (n *raft) PeerNames() []string {
+	n.RLock()
+	defer n.RUnlock()
+	return n.peerNames()
 }
 
 // Lock should be held.

--- a/server/stream.go
+++ b/server/stream.go
@@ -369,13 +369,31 @@ type StreamAlternate struct {
 // ClusterInfo shows information about the underlying set of servers
 // that make up the stream or consumer.
 type ClusterInfo struct {
-	Name        string      `json:"name,omitempty"`
-	RaftGroup   string      `json:"raft_group,omitempty"`
-	Leader      string      `json:"leader,omitempty"`
-	LeaderSince *time.Time  `json:"leader_since,omitempty"`
-	SystemAcc   bool        `json:"system_account,omitempty"`
-	TrafficAcc  string      `json:"traffic_account,omitempty"`
-	Replicas    []*PeerInfo `json:"replicas,omitempty"`
+	Name        string              `json:"name,omitempty"`
+	RaftGroup   string              `json:"raft_group,omitempty"`
+	Leader      string              `json:"leader,omitempty"`
+	LeaderSince *time.Time          `json:"leader_since,omitempty"`
+	SystemAcc   bool                `json:"system_account,omitempty"`
+	TrafficAcc  string              `json:"traffic_account,omitempty"`
+	Replicas    []*PeerInfo         `json:"replicas,omitempty"`
+	Desired     *DesiredClusterInfo `json:"desired,omitempty"`
+}
+
+// DesiredClusterInfo shows information of the desired set of servers
+// that should make up the stream or consumer.
+type DesiredClusterInfo struct {
+	Name     string                    `json:"name,omitempty"`
+	Replicas []*PeerInfo               `json:"replicas,omitempty"`
+	Origin   *DesiredClusterInfoOrigin `json:"origin,omitempty"`
+}
+
+type DesiredClusterInfoOrigin struct {
+	// Original replicas before it was updated.
+	Replicas int `json:"replicas"`
+	// Original placement before it was updated.
+	Placement *Placement `json:"placement,omitempty"`
+	// When changing between retention policies, this retention remains active until unset.
+	Retention *RetentionPolicy `json:"retention,omitempty"`
 }
 
 // PeerInfo shows information about all the peers in the cluster that

--- a/server/stream.go
+++ b/server/stream.go
@@ -1170,7 +1170,6 @@ func (mset *stream) streamAssignment() *streamAssignment {
 
 func (mset *stream) setStreamAssignment(sa *streamAssignment) {
 	var node RaftNode
-	var peers []string
 
 	mset.mu.RLock()
 	js := mset.js
@@ -1180,7 +1179,6 @@ func (mset *stream) setStreamAssignment(sa *streamAssignment) {
 		js.mu.RLock()
 		if sa.Group != nil {
 			node = sa.Group.node
-			peers = sa.Group.Peers
 		}
 		js.mu.RUnlock()
 	}
@@ -1195,9 +1193,6 @@ func (mset *stream) setStreamAssignment(sa *streamAssignment) {
 
 	// Set our node.
 	mset.node = node
-	if mset.node != nil {
-		mset.node.UpdateKnownPeers(peers)
-	}
 
 	// Setup our info sub here as well for all stream members. This is now by design.
 	if mset.infoSub == nil {


### PR DESCRIPTION
This PR adds initial support for desired state reconciliation of stream and consumer updates that change the peer set. These, and follow-up, changes intend to fix loads of related issues surrounding peer set management of assets. For example, including but not limited to: a scale down not being guaranteed to select the right leader or servers with all data to prevent data loss, peers re-appearing in the stream/consumer Raft group after peer-removing a node, moving and scaling a stream concurrently may brick it such that it's stuck halfway into a move or is reverted back to the previous cluster with the stream config still referencing where it was meant to move to, and a consumer reverting to stale state after a consumer move.

This initial PR tries to do the minimal amount of work to have passing CI, while transitioning to a desired state design that allows for guaranteed and safe scaling and moving of assets. Importantly:
- The meta leader MUST never overwrite a stream/consumer peer set in-place as it does today. The meta leader may dictate where a stream/consumer needs to move, but the stream/consumer is responsible for making those changes be guaranteed safe.
- The meta leader always dictates the peer set, unless the stream/consumer is scaled down, since only the group itself knows which servers would be best to be preserved (i.e. the leader and most up-to-date servers), to guarantee no data loss. Previously the meta leader did a `sysRequest` stream/consumer info to figure out the leader (and for consumer moves the consumer state). Both could result in a stale leader/state being picked. And worse, if the leader doesn't respond in time (or at all), the meta leader would randomly pick a leader (or lose consumer state). This PR allows the removal of `sysRequest` entirely.
- Peer additions and removals are managed by the group's leader, no automatic additions of peers are allowed (like for the meta group). Before the group's leader is allowed to make any change, it first needs to communicate with the meta leader to assert that it's up-to-date with the meta state (linearizable and no stale local assignment), and the leader's Raft `term` is also wired through, so the meta leader also knows to ignore requests from stale leaders. This PR allows removing `ProposeKnownPeers` and `UpdateKnownPeers` from `raft.go`, as well as the calls to them in `js.createRaftGroup`, since those were unsafe and could result in removed peers re-appearing, desyncing the peer set in the meta assignment with that of the group.
- The stream/consumer `ClusterInfo` now returns the desired state information. Allowing tooling (like the CLI) to inspect the state as it changes.

This PR is split in 3 commits, to ease reviewing but also ease backporting to 2.14. Put simply: the first commit adds the models, the second commit adds meta layer reconciliation awareness, and the last commit actually starts populating the desired state and triggering the stream/consumer migration paths.

Likely 2.14 will require a compatibility commit to ease downgrading, and upgrading/downgrading as a whole should be tackled in a follow-up PR. However, the design of the desired state always guarantees: the stream/consumer config is always what the user asked it to be, the group's peer set is always the one that equals the underlying Raft group (or if the Raft group contains less peers, they get automatically added under the old behavior). So, worst-case given a downgrade to an incompatible version, the desired state configuration in the JSON will "fall off" and the assignment will remain "stuck" on which peers it was at that time. That does not violate correctness or safety when it comes to preserving data, it does however prevent the stream/consumer from moving to the desired config.

Having passing CI and the mentioned upgrade/downgrade focus isn't enough, and at least these follow-ups will be required in separate PRs:
- The system "move" and "move cancel" APIs should be made more reliable. A "move" can simply trigger a peer set change through desired state, and a "move cancel" can look at the desired state's origin to see where the stream needs to be moved back to. Both just need time to be wired appropriately.
- Server and asset-level peer-remove should be made desired state aware. Additionally, an "evacuate" endpoint should be added to enable the user to more easily move streams and consumers off a server while it's still online. Not only easing the decommissioning of a node, but also enabling to move data of R1 assets without losing data when a peer-remove of the node would've been used instead and without requiring to move all R1 assets in all accounts manually.
- Add stream move/scale guards. This PR removes the (admittedly brittle) guards to prevent concurrent move and scale of a stream, which allows to scale and move an R1 stream from cluster A to a R3 stream in cluster B in one go and safely. However, this technically opens up being able to constantly cycle moves between clusters until the stream/consumer peer set contain the total number of peers. This should likely get an upper bound, for example 10 peers maximum (since replication is capped at 5), to ensure such moves are still allowed from the API, but the system prevents the peers from growing semi-unbounded.
- Optimizations in how and when peers are added, ensuring a group doesn't go out of quorum when nodes are offline.
- An additional optimization can be made when moving a stream between clusters, to first scale up one stream replica in the new cluster, making it the leader and then doing local catchup for the other replicas in that cluster. This would allow both faster and less expensive (bandwidth-wise) moves of assets. But, although this is enabled by the desired state approach as well, it might need to be done after 2.15.0 lands considering timing and the other required follow-ups (this isn't a required optimization).

These follow-ups are also roughly marked with `FIXME` comments that need to be addressed prior to releasing 2.15.