### PR TITLE
(2.15) [ADDED] Drive stream move and cancel move via desired state

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -1230,10 +1230,10 @@
     "deprecates": ""
   },
   {
-    "constant": "JSStreamMoveInProgressF",
+    "constant": "JSStreamMoveInProgressErr",
     "code": 400,
     "error_code": 10124,
-    "description": "stream move already in progress: {msg}",
+    "description": "stream move already in progress",
     "comment": "",
     "help": "",
     "url": "",

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -1589,7 +1589,7 @@ func (s *Server) jsStreamUpdateRequest(sub *subscription, c *client, _ *Account,
 
 	// Handle clustered version here.
 	if s.JetStreamIsClustered() {
-		s.jsClusteredStreamUpdateRequest(ci, acc, subject, reply, copyBytes(rmsg), &cfg, nil, ncfg.Pedantic)
+		s.jsClusteredStreamUpdateRequest(ci, acc, subject, reply, copyBytes(rmsg), &cfg, ncfg.Pedantic)
 		return
 	}
 
@@ -2736,28 +2736,20 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 		return
 	}
 
-	var streamFound bool
-	cfg := StreamConfig{}
-	currPeers := []string{}
-	currCluster := _EMPTY_
-	js.mu.RLock()
-	sa := js.streamAssignmentOrInflight(accName, streamName)
-	if sa != nil {
-		cfg = *sa.Config.clone()
-		streamFound = true
-		if sa.Group.Desired != nil {
-			currPeers = copyStrings(sa.Group.Desired.Peers)
-		} else {
-			currPeers = copyStrings(sa.Group.Peers)
-		}
-		currCluster = sa.Group.Cluster
-	}
-	js.mu.RUnlock()
+	js.mu.Lock()
+	defer js.mu.Unlock()
 
-	if !streamFound {
+	osa := js.streamAssignmentOrInflight(accName, streamName)
+	if osa == nil {
 		resp.Error = NewJSStreamNotFoundError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
+	}
+
+	cfg := *osa.Config.clone()
+	currPeers, currCluster := copyStrings(osa.Group.Peers), osa.Group.Cluster
+	if d := osa.Group.Desired; d != nil {
+		currPeers, currCluster = copyStrings(d.Peers), d.Cluster
 	}
 
 	// if server was picked, make sure src peer exists and move it to first position.
@@ -2802,7 +2794,10 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 		cfg.Placement.Tags = append(cfg.Placement.Tags, req.Tags...)
 	}
 
-	// FIXME(mvv): scaffolded desired state into the move API for now, this endpoint needs to be refactored
+	// The cluster the new peer set is placed in, we stay in the current cluster unless
+	// we need to expand into another one below.
+	newCluster := currCluster
+
 	peers, e := cc.selectPeerGroup(cfg.Replicas+1, currCluster, &cfg, currPeers, 1, nil)
 	if len(peers) <= cfg.Replicas {
 		// since expanding in the same cluster did not yield a result, try in different cluster
@@ -2824,6 +2819,7 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 				peers = append(peers, newPeers[:cfg.Replicas]...)
 				// Keep only the new peers.
 				peers = peers[len(peers)-cfg.Replicas:]
+				newCluster = cluster
 				break
 			}
 			errs.accumulate(e)
@@ -2843,9 +2839,7 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 	s.Noticef("Requested move for stream '%s > %s' R=%d from %+v to %+v",
 		accName, streamName, cfg.Replicas, s.peerSetToNames(currPeers), s.peerSetToNames(peers))
 
-	// We will always have peers and therefore never do a callout, therefore it is safe to call inline
-	// We should be fine ignoring pedantic mode here. as we do not touch configuration.
-	s.jsClusteredStreamUpdateRequest(&ciNew, targetAcc.(*Account), subject, reply, rmsg, &cfg, peers, false)
+	s.jsClusteredStreamUpdateRequestLocked(&ciNew, targetAcc.(*Account), subject, reply, rmsg, &cfg, peers, newCluster, false)
 }
 
 // Request to have the metaleader move a stream on a peer to another
@@ -2888,112 +2882,64 @@ func (s *Server) jsLeaderServerStreamCancelMoveRequest(sub *subscription, c *cli
 		return
 	}
 
-	targetAcc, ok := s.accounts.Load(accName)
+	_, ok := s.accounts.Load(accName)
 	if !ok {
 		resp.Error = NewJSNoAccountError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
 
-	streamFound := false
-	cfg := StreamConfig{}
-	currPeers := []string{}
 	js.mu.Lock()
-	sa := js.streamAssignmentOrInflight(accName, streamName)
-	if sa != nil {
-		cfg = *sa.Config.clone()
-		streamFound = true
-		currPeers = copyStrings(sa.Group.Peers)
-	}
+	defer js.mu.Unlock()
 
-	if !streamFound {
-		js.mu.Unlock()
+	osa := js.streamAssignmentOrInflight(accName, streamName)
+	if osa == nil {
 		resp.Error = NewJSStreamNotFoundError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
-
-	// FIXME(mvv): scaffolded desired state into the cancel move API for now, this endpoint needs to be refactored
-	if sa.Group.Desired != nil {
-		origin := sa.Group.Desired.Origin
-		if origin == nil {
-			js.mu.Unlock()
-			resp.Error = NewJSStreamMoveNotInProgressError()
-			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
-			return
-		}
-
-		csa := sa.copyGroup()
-		// Need to respond to the client that cancels.
-		csa.Reply = reply
-		// Revert replicas and placement in the config immediately.
-		cfg.Replicas = origin.Replicas
-		cfg.Placement = origin.Placement
-		csa.Config = &cfg
-		// Move back to the initial peer set via desired state.
-		csa.Group.Peers = copyStrings(origin.Peers)
-		csa.Group.Cluster = origin.Cluster
-		csa.Group = sa.Group.withDesired(csa.Group)
-		// FIXME(mvv): does origin need to be cleared now?
-
-		s.Noticef("Requested cancel of move: R=%d '%s > %s' to peer set %+v and restore previous peer set %+v",
-			origin.Replicas, accName, streamName, s.peerSetToNames(currPeers), s.peerSetToNames(origin.Peers))
-
-		if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(csa)); err != nil {
-			js.mu.Unlock()
-			return
-		}
-		cc.trackInflightStreamProposal(accName, csa, false)
-		js.mu.Unlock()
-		return
+	var origin *desiredRaftGroupOrigin
+	if osa.Group.Desired != nil {
+		origin = osa.Group.Desired.Origin
+	} else {
+		// A move started before the upgrade to desired state must stay cancellable,
+		// reconstruct the origin if it's a legacy move.
+		origin = osa.legacyMoveOrigin()
 	}
-	js.mu.Unlock()
-
-	if len(currPeers) <= cfg.Replicas {
+	// A group that has no desired state or origin, so no move in progress.
+	if origin == nil {
 		resp.Error = NewJSStreamMoveNotInProgressError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
 
-	// make sure client is scoped to requested account
-	ciNew := *(ci)
-	ciNew.Account = accName
-
-	peers := currPeers[:cfg.Replicas]
-
-	// Remove placement in case tags don't match
-	// This can happen if the move was initiated by modifying the tags.
-	// This is an account operation.
-	// This can NOT happen when the move was initiated by the system account.
-	// There move honors the original tag list.
-	if cfg.Placement != nil && len(cfg.Placement.Tags) != 0 {
-	FOR_TAGCHECK:
-		for _, peer := range peers {
-			si, ok := s.nodeToInfo.Load(peer)
-			if !ok {
-				// can't verify tags, do the safe thing and error
-				resp.Error = NewJSStreamGeneralError(
-					fmt.Errorf("peer %s not present for tag validation", peer))
-				s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
-				return
-			}
-			nodeTags := si.(nodeInfo).tags
-			for _, tag := range cfg.Placement.Tags {
-				if !nodeTags.Contains(tag) {
-					// clear placement as tags don't match
-					cfg.Placement = nil
-					break FOR_TAGCHECK
-				}
-			}
-
-		}
+	csa := osa.copyGroup()
+	// Need to respond to the client that cancels.
+	csa.Reply = reply
+	// Revert replicas and placement in the config immediately.
+	csa.Config = osa.Config.clone()
+	csa.Config.Replicas = origin.Replicas
+	csa.Config.Placement = origin.Placement
+	if origin.Retention != nil {
+		csa.Config.Retention = *origin.Retention
+	}
+	// Move back to the initial peer set via desired state.
+	csa.Group.Peers = copyStrings(origin.Peers)
+	csa.Group.Cluster = origin.Cluster
+	csa.Group = osa.Group.withDesired(csa.Group)
+	// withDesired only carries over a prior origin, a legacy move has none yet.
+	// Record it, so the rollback reports the same target while it converges.
+	if csa.Group.Desired.Origin == nil {
+		csa.Group.Desired.Origin = origin
 	}
 
-	s.Noticef("Requested cancel of move: R=%d '%s > %s' to peer set %+v and restore previous peer set %+v",
-		cfg.Replicas, accName, streamName, s.peerSetToNames(currPeers), s.peerSetToNames(peers))
+	s.Noticef("Requested cancel of move: R=%d '%s > %s' and restore previous peer set %+v",
+		origin.Replicas, accName, streamName, s.peerSetToNames(origin.Peers))
 
-	// We will always have peers and therefore never do a callout, therefore it is safe to call inline
-	s.jsClusteredStreamUpdateRequest(&ciNew, targetAcc.(*Account), subject, reply, rmsg, &cfg, peers, false)
+	if err = cc.meta.Propose(cc.term, encodeUpdateStreamAssignment(csa)); err != nil {
+		return
+	}
+	cc.trackInflightStreamProposal(accName, csa, false)
 }
 
 // Request to have an account purged

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -208,6 +208,30 @@ type desiredRaftGroupOrigin struct {
 	Retention *RetentionPolicy `json:"retention,omitempty"`
 }
 
+// legacyMoveOrigin returns the origin of a move that was started before the upgrade to
+// desired state, or nil if there is no such move. Recognized by the group having more
+// peers than configured replicas.
+func (sa *streamAssignment) legacyMoveOrigin() *desiredRaftGroupOrigin {
+	// Only a group that has not been reconciled into desired state yet can hold a legacy move.
+	if sa == nil || sa.Config == nil || sa.Group == nil || sa.Group.Desired != nil {
+		return nil
+	}
+	replicas := sa.Config.Replicas
+	if replicas < 1 || len(sa.Group.Peers) <= replicas {
+		return nil
+	}
+	return &desiredRaftGroupOrigin{
+		Peers: copyStrings(sa.Group.Peers[:replicas]),
+		// Group.Cluster was only updated once a legacy move completed, so it still
+		// holds the origin cluster.
+		Cluster:  sa.Group.Cluster,
+		Replicas: replicas,
+		// NOTE: a legacy move did not record the placement it started with. We can't
+		// restore what's already lost, so we just preserve the final placement as before.
+		Placement: sa.Config.Placement,
+	}
+}
+
 // withDesired returns a copy of rg with target expressed as the desired state.
 // target MUST already be a copy or fresh group, as it's directly referenced.
 func (rg *raftGroup) withDesired(target *raftGroup) *raftGroup {
@@ -5635,7 +5659,8 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 			// If we already have a stream assignment and they are the same exact config, short circuit here.
 			if osa != nil {
 				if reflect.DeepEqual(osa.Config, sa.Config) {
-					if sa.Group.Name == osa.Group.Name && reflect.DeepEqual(sa.Group.Peers, osa.Group.Peers) {
+					if sa.Group.Name == osa.Group.Name && reflect.DeepEqual(sa.Group.Peers, osa.Group.Peers) &&
+						reflect.DeepEqual(sa.Group.Desired, osa.Group.Desired) {
 						// Since this already exists we know it succeeded, just respond to this caller.
 						js.mu.RLock()
 						client, subject, reply, recovering := sa.Client, sa.Subject, sa.Reply, sa.recovering
@@ -5656,11 +5681,13 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 							s.sendAPIResponse(client, acc, subject, reply, _EMPTY_, s.jsonResponse(&resp))
 						}
 						return
-					} else {
+					} else if sa.Group.Name != osa.Group.Name {
 						// We had a bug where we could have multiple assignments for the same
 						// stream but with different group assignments, including multiple raft
 						// groups. So check for that here. We can only bet on the last one being
 						// consistent in the long run, so let it continue if we see this condition.
+						// Only a differing group name means a duplicate group; a differing peer
+						// set or desired state is a normal peer change and must fall through.
 						s.Warnf("JetStream cluster detected duplicate assignment for stream %q for account %q", sa.Config.Name, acc.Name)
 						if osa.Group.node != nil && osa.Group.node != sa.Group.node {
 							osa.Group.node.Delete()
@@ -7959,15 +7986,18 @@ func (js *jetStream) reconcileDesiredStreamAssignment(_ *subscription, _ *client
 	// If any consumers need to be remapped, we can't mark the stream's desired state done yet.
 	var done bool
 
-	// A legacy in-progress move/scale (no desired state, more peers than replicas)
-	// first needs desired state initialized below. Remapping consumers now would
-	// propose direct peer swaps without migrating them, so postpone until the next
-	// cycle when they can move through desired state.
-	legacyMove := osa.Group.Desired == nil && len(osa.Group.Peers) > osa.Config.Replicas
+	// Without desired state there's nothing to remap consumers onto yet. Remapping now
+	// would propose direct peer swaps without migrating them, so postpone until the next
+	// cycle, once desired state is initialized below and they can move through it.
+	noDesired := osa.Group.Desired == nil
+
+	// A legacy in-progress move, started before the upgrade to desired state, needs
+	// its origin synthesized below to stay cancellable.
+	legacyOrigin := osa.legacyMoveOrigin()
 
 	// If the stream is scaling down and hasn't selected its final peer set yet,
 	// we need to wait before we remap.
-	if !legacyMove && (osa.Group.Desired == nil || !osa.Group.Desired.ScaleDown) {
+	if !noDesired && !osa.Group.Desired.ScaleDown {
 		// Need to remap any consumers.
 		consumers, _, done = js.remapConsumerAssignments(reconcile.Account, osa, false)
 	}
@@ -7976,6 +8006,17 @@ func (js *jetStream) reconcileDesiredStreamAssignment(_ *subscription, _ *client
 	if ng != nil {
 		sa := osa.copyGroup()
 		sa.Group = ng
+		// If it was a legacy move, we need to initialize the desired state origin.
+		if legacyOrigin != nil && sa.Group.Desired != nil {
+			// Must derive the desired cluster from the destination peers, or the origin
+			// cluster (still held by Group.Cluster) would be committed on convergence.
+			if dp := sa.Group.Desired.Peers; len(dp) > 0 {
+				if cluster := js.srv.clusterNameForNode(dp[0]); cluster != _EMPTY_ {
+					sa.Group.Desired.Cluster = cluster
+				}
+			}
+			sa.Group.Desired.Origin = legacyOrigin
+		}
 		// Single nodes are not recorded by the NRG layer so we can rename.
 		// MUST do this, otherwise a scaleup afterward could potentially lead to inconsistencies.
 		if sa.Group.Desired == nil && len(sa.Group.Peers) == 1 {
@@ -8059,7 +8100,6 @@ func (rg *raftGroup) reconcileDesiredState(reconcile desiredAssignmentUpdate, re
 	}
 
 	// Initialize desired state if not set.
-	// FIXME(mvv): test with pre-existing move state without desired.
 	if rg.Desired == nil {
 		// Request is about state that we don't have.
 		if reconcile.ID != _EMPTY_ {
@@ -9098,15 +9138,23 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 	cc.trackInflightStreamProposal(acc.Name, sa, false)
 }
 
-func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, subject, reply string, rmsg []byte, cfg *StreamConfig, peerSet []string, pedantic bool) {
+func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, subject, reply string, rmsg []byte, cfg *StreamConfig, pedantic bool) {
+	js := s.getJetStream()
+	if js == nil {
+		return
+	}
+	js.mu.Lock()
+	defer js.mu.Unlock()
+	s.jsClusteredStreamUpdateRequestLocked(ci, acc, subject, reply, rmsg, cfg, nil, _EMPTY_, pedantic)
+}
+
+// peerSetCluster is the cluster peerSet is placed in, it MUST be provided if peerSet is.
+// Lock should be held.
+func (s *Server) jsClusteredStreamUpdateRequestLocked(ci *ClientInfo, acc *Account, subject, reply string, rmsg []byte, cfg *StreamConfig, peerSet []string, peerSetCluster string, pedantic bool) {
 	js, cc := s.getJetStreamCluster()
 	if js == nil || cc == nil {
 		return
 	}
-
-	// Now process the request and proposal.
-	js.mu.Lock()
-	defer js.mu.Unlock()
 	meta := cc.meta
 	if meta == nil {
 		return
@@ -9133,9 +9181,7 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 
 	var newCfg *StreamConfig
 	if jsa := js.accounts[acc.Name]; jsa != nil {
-		js.mu.Unlock()
-		ncfg, err := jsa.configUpdateCheck(osa.Config, cfg, s, pedantic)
-		js.mu.Lock()
+		ncfg, err := jsa.configUpdateCheckLocked(osa.Config, cfg, s, pedantic)
 		if err != nil {
 			resp.Error = NewJSStreamUpdateError(err, Unless(err))
 			s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
@@ -9192,20 +9238,9 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 	rg := osa.copyGroup().Group
 
 	// Check for a move request.
-	var isMoveRequest, isMoveCancel bool
+	var isMoveRequest bool
 	if lPeerSet := len(peerSet); lPeerSet > 0 {
 		isMoveRequest = true
-		// check if this is a cancellation
-		if lPeerSet == osa.Config.Replicas && lPeerSet <= len(rg.Peers) {
-			isMoveCancel = true
-			// can only be a cancellation if the peer sets overlap as expected
-			for i := 0; i < lPeerSet; i++ {
-				if peerSet[i] != rg.Peers[i] {
-					isMoveCancel = false
-					break
-				}
-			}
-		}
 	} else {
 		isMoveRequest = newCfg.Placement != nil && !reflect.DeepEqual(osa.Config.Placement, newCfg.Placement)
 	}
@@ -9216,7 +9251,6 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 	isRetentionChange := newCfg.Retention != osa.Config.Retention
 
 	// FIXME(mvv): should move be prevented if already ongoing? maybe accept but with group size limits?
-	_ = isMoveCancel
 	//// Check if this is a move request, but no cancellation, and we are already moving this stream.
 	//if isMoveRequest && !isMoveCancel && osa.Config.Replicas != len(rg.Peers) {
 	//	resp.Error = NewJSStreamMoveInProgressError()
@@ -9250,6 +9284,7 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 				rg.Preferred = peerSet[0]
 			}
 			rg.Peers = peerSet
+			rg.Cluster = peerSetCluster
 		}
 		rg = osa.Group.withDesired(rg)
 	} else if isReplicaChange {
@@ -9306,14 +9341,23 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 		rg.Preferred = _EMPTY_
 	}
 
-	// If we're the first to specify an origin, capture it.
-	if rg.Desired != nil && rg.Desired.Origin == nil {
+	populateOrigin := func() {
+		currPeers, currCluster := copyStrings(osa.Group.Peers), osa.Group.Cluster
+		// If we had desired state without origin, need to capture what was
+		// rolled back to as the new origin.
+		if d := osa.Group.Desired; d != nil {
+			currPeers, currCluster = copyStrings(d.Peers), d.Cluster
+		}
 		rg.Desired.Origin = &desiredRaftGroupOrigin{
-			Peers:     osa.Group.Peers,
-			Cluster:   osa.Group.Cluster,
+			Peers:     currPeers,
+			Cluster:   currCluster,
 			Replicas:  osa.Config.Replicas,
 			Placement: osa.Config.Placement,
 		}
+	}
+	// If we're the first to specify an origin, capture it.
+	if rg.Desired != nil && rg.Desired.Origin == nil {
+		populateOrigin()
 	}
 
 	// A retention change should go through desired state, unless it is a singleton without desired state.
@@ -9328,12 +9372,7 @@ func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, su
 			// Only record the retention if we hadn't already recorded it.
 			if d := osa.Group.Desired; d == nil || d.Origin == nil || d.Origin.Retention == nil {
 				if rg.Desired.Origin == nil {
-					rg.Desired.Origin = &desiredRaftGroupOrigin{
-						Peers:     osa.Group.Peers,
-						Cluster:   osa.Group.Cluster,
-						Replicas:  osa.Config.Replicas,
-						Placement: osa.Config.Placement,
-					}
+					populateOrigin()
 				}
 				rg.Desired.Origin.Retention = &osa.Config.Retention
 			}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -9234,9 +9234,6 @@ func (s *Server) jsClusteredStreamUpdateRequestLocked(ci *ClientInfo, acc *Accou
 		}
 	}
 
-	// Make copy so to not change original.
-	rg := osa.copyGroup().Group
-
 	// Check for a move request.
 	var isMoveRequest bool
 	if lPeerSet := len(peerSet); lPeerSet > 0 {
@@ -9250,20 +9247,18 @@ func (s *Server) jsClusteredStreamUpdateRequestLocked(ci *ClientInfo, acc *Accou
 	// A retention change might result in consumer replica changes.
 	isRetentionChange := newCfg.Retention != osa.Config.Retention
 
-	// FIXME(mvv): should move be prevented if already ongoing? maybe accept but with group size limits?
-	//// Check if this is a move request, but no cancellation, and we are already moving this stream.
-	//if isMoveRequest && !isMoveCancel && osa.Config.Replicas != len(rg.Peers) {
-	//	resp.Error = NewJSStreamMoveInProgressError()
-	//	s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
-	//	return
-	//}
-	//
-	//// Can not move and scale at same time.
-	//if isMoveRequest && isReplicaChange {
-	//	resp.Error = NewJSStreamMoveAndScaleError()
-	//	s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
-	//	return
-	//}
+	// A move or scale retargets the desired peer set, so only one can be inflight at a time.
+	// Otherwise, peers of the abandoned target could accumulate in the assignment unbounded.
+	// A legacy move counts as well, it is inflight but not expressed as desired state yet.
+	// A retention change is allowed, it does not adjust the peer set.
+	if (isMoveRequest || isReplicaChange) && (osa.Group.Desired != nil || osa.legacyMoveOrigin() != nil) {
+		resp.Error = NewJSStreamMoveInProgressError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+		return
+	}
+
+	// Make copy so to not change original.
+	rg := osa.copyGroup().Group
 
 	// Reset notion of scaling up, if this was done in a previous update.
 	rg.ScaleUp = false
@@ -9347,6 +9342,10 @@ func (s *Server) jsClusteredStreamUpdateRequestLocked(ci *ClientInfo, acc *Accou
 		// rolled back to as the new origin.
 		if d := osa.Group.Desired; d != nil {
 			currPeers, currCluster = copyStrings(d.Peers), d.Cluster
+		} else if legacy := osa.legacyMoveOrigin(); legacy != nil {
+			// A legacy move is only encoded as an over-replicated peer set. Capture the peer
+			// set it started from, or a rollback would restore the enlarged set instead.
+			currPeers, currCluster = legacy.Peers, legacy.Cluster
 		}
 		rg.Desired.Origin = &desiredRaftGroupOrigin{
 			Peers:     currPeers,

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -7818,27 +7818,28 @@ func TestJetStreamClusterStreamUpscalePeersAfterDownscale(t *testing.T) {
 		})
 	}
 
-	_, err := js.AddStream(&nats.StreamConfig{
+	cfg := &nats.StreamConfig{
 		Name:     "TEST",
 		Subjects: []string{"foo"},
 		Replicas: 5,
-	})
+	}
+	_, err := js.AddStream(cfg)
 	require_NoError(t, err)
 
 	checkPeerSet()
 
-	_, err = js.UpdateStream(&nats.StreamConfig{
-		Name:     "TEST",
-		Subjects: []string{"foo"},
-		Replicas: 3,
-	})
+	cfg.Replicas = 3
+	_, err = js.UpdateStream(cfg)
 	require_NoError(t, err)
 
-	_, err = js.UpdateStream(&nats.StreamConfig{
-		Name:     "TEST",
-		Subjects: []string{"foo"},
-		Replicas: 5,
-	})
+	cfg.Replicas = 5
+	_, err = js.UpdateStream(cfg)
+	if err != nil {
+		// If still in progress, wait for it to complete before retrying.
+		require_Error(t, err, NewJSStreamMoveInProgressError())
+		c.waitOnStreamLeader(globalAccountName, "TEST")
+		_, err = js.UpdateStream(cfg)
+	}
 	require_NoError(t, err)
 
 	checkPeerSet()
@@ -13709,14 +13710,18 @@ func TestJetStreamClusterRetentionChangeOriginSurvivesScale(t *testing.T) {
 	_, err = js.UpdateStream(cfg)
 	require_NoError(t, err)
 
-	// While that is still converging, scale the stream. This re-registers the desired state and
-	// MUST NOT drop the pending retention origin, otherwise interest retention applies right away.
+	// While that is still converging the stream has desired state, so a scale must be rejected
+	// instead of retargeting the peer set and dropping the pending retention origin.
 	cfg.Replicas = 5
+	_, err = js.UpdateStream(cfg)
+	require_Error(t, err, NewJSStreamMoveInProgressError())
+	c.waitOnStreamLeader("$G", "TEST")
 	_, err = js.UpdateStream(cfg)
 	require_NoError(t, err)
 
-	deadline := time.Now().Add(5 * time.Second)
-	for {
+	// The scale must land on top of the applied retention change, not roll it back to the
+	// origin's limits retention, and the consumer must follow the stream to the new peer set.
+	checkFor(t, 5*time.Second, 10*time.Millisecond, func() error {
 		interest := 0
 		for _, s := range c.servers {
 			mset, err := s.GlobalAccount().lookupStream("TEST")
@@ -13724,26 +13729,14 @@ func TestJetStreamClusterRetentionChangeOriginSurvivesScale(t *testing.T) {
 				continue
 			}
 			interest++
-			// Every stream peer must host a consumer replica before interest retention applies.
-			// Re-read here, the consumer could have converged in the meantime.
-			speers, cpeers := assignedPeers()
-			for _, p := range speers {
-				if !slices.Contains(cpeers, p) {
-					t.Fatalf("Server %q applied interest retention, but stream peer %q hosts no consumer replica (stream peers %v, consumer peers %v)",
-						s.Name(), p, speers, cpeers)
-				}
-			}
 		}
-		speers, cpeers = assignedPeers()
-		if interest == len(c.servers) && len(speers) == 5 && len(cpeers) == 5 {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("Timed out with %d/%d servers on interest retention, stream peers %v, consumer peers %v",
+		speers, cpeers := assignedPeers()
+		if interest != len(c.servers) || len(speers) != 5 || len(cpeers) != 5 {
+			return fmt.Errorf("have %d/%d servers on interest retention, stream peers %v, consumer peers %v",
 				interest, len(c.servers), speers, cpeers)
 		}
-		time.Sleep(2 * time.Millisecond)
-	}
+		return nil
+	})
 }
 
 func TestJetStreamClusterStreamPeerRemoveConsumerRemap(t *testing.T) {

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -7878,10 +7878,17 @@ func TestJetStreamClusterReplicasChangeStreamInfo(t *testing.T) {
 	// Back up to 3
 	for i := 0; i < numStreams; i++ {
 		sname := fmt.Sprintf("TEST_%v", i)
-		_, err := js.UpdateStream(&nats.StreamConfig{
+		cfg := &nats.StreamConfig{
 			Name:     sname,
 			Replicas: 3,
-		})
+		}
+		_, err := js.UpdateStream(cfg)
+		if err != nil {
+			// If still in progress, wait for it to complete before retrying.
+			require_Error(t, err, NewJSStreamMoveInProgressError())
+			c.waitOnStreamLeader(globalAccountName, sname)
+			_, err = js.UpdateStream(cfg)
+		}
 		require_NoError(t, err)
 		c.waitOnStreamLeader(globalAccountName, sname)
 		for _, s := range c.servers {

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -5291,13 +5291,20 @@ func TestJetStreamClusterAccountUsageDrifts(t *testing.T) {
 	require_NoError(t, err)
 
 	// Now scale back up.
-	_, err = js.UpdateStream(&nats.StreamConfig{
+	cfg := &nats.StreamConfig{
 		Name:     "TEST1",
 		Subjects: []string{"foo"},
 		MaxBytes: 1 * 1024 * 1024 * 1024,
 		MaxMsgs:  1000,
 		Replicas: 3,
-	})
+	}
+	_, err = js.UpdateStream(cfg)
+	if err != nil {
+		// If still in progress, wait for it to complete before retrying.
+		require_Error(t, err, NewJSStreamMoveInProgressError())
+		c.waitOnStreamLeader(aExpPub, "TEST1")
+		_, err = js.UpdateStream(cfg)
+	}
 	require_NoError(t, err)
 	c.waitOnStreamLeader(aExpPub, "TEST1")
 
@@ -5601,11 +5608,18 @@ func TestJetStreamClusterOrphanConsumerSubjects(t *testing.T) {
 	require_NoError(t, err)
 
 	for _, replicas := range []int{3, 1, 3} {
-		_, err = js.UpdateStream(&nats.StreamConfig{
+		cfg := &nats.StreamConfig{
 			Name:     "TEST",
 			Subjects: []string{"bar.>"},
 			Replicas: replicas,
-		})
+		}
+		_, err = js.UpdateStream(cfg)
+		if err != nil {
+			// If still in progress, wait for it to complete before retrying.
+			require_Error(t, err, NewJSStreamMoveInProgressError())
+			c.waitOnStreamLeader("$G", "TEST")
+			_, err = js.UpdateStream(cfg)
+		}
 		require_NoError(t, err)
 		c.waitOnAllCurrent()
 	}

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -578,8 +578,8 @@ const (
 	// JSStreamMoveAndScaleErr can not move and scale a stream in a single update
 	JSStreamMoveAndScaleErr ErrorIdentifier = 10123
 
-	// JSStreamMoveInProgressF stream move already in progress: {msg}
-	JSStreamMoveInProgressF ErrorIdentifier = 10124
+	// JSStreamMoveInProgressErr stream move already in progress
+	JSStreamMoveInProgressErr ErrorIdentifier = 10124
 
 	// JSStreamMoveNotInProgress stream move not in progress
 	JSStreamMoveNotInProgress ErrorIdentifier = 10129
@@ -868,7 +868,7 @@ var (
 		JSStreamMirrorNotUpdatableErr:                {Code: 400, ErrCode: 10055, Description: "stream mirror configuration can not be updated"},
 		JSStreamMismatchErr:                          {Code: 400, ErrCode: 10056, Description: "stream name in subject does not match request"},
 		JSStreamMoveAndScaleErr:                      {Code: 400, ErrCode: 10123, Description: "can not move and scale a stream in a single update"},
-		JSStreamMoveInProgressF:                      {Code: 400, ErrCode: 10124, Description: "stream move already in progress: {msg}"},
+		JSStreamMoveInProgressErr:                    {Code: 400, ErrCode: 10124, Description: "stream move already in progress"},
 		JSStreamMoveNotInProgress:                    {Code: 400, ErrCode: 10129, Description: "stream move not in progress"},
 		JSStreamMsgDeleteFailedF:                     {Code: 500, ErrCode: 10057, Description: "{err}"},
 		JSStreamNameContainsPathSeparatorsErr:        {Code: 400, ErrCode: 10128, Description: "Stream name can not contain path separators"},
@@ -3051,20 +3051,14 @@ func NewJSStreamMoveAndScaleError(opts ...ErrorOption) *ApiError {
 	return ApiErrors[JSStreamMoveAndScaleErr]
 }
 
-// NewJSStreamMoveInProgressError creates a new JSStreamMoveInProgressF error: "stream move already in progress: {msg}"
-func NewJSStreamMoveInProgressError(msg interface{}, opts ...ErrorOption) *ApiError {
+// NewJSStreamMoveInProgressError creates a new JSStreamMoveInProgressErr error: "stream move already in progress"
+func NewJSStreamMoveInProgressError(opts ...ErrorOption) *ApiError {
 	eopts := parseOpts(opts)
 	if ae, ok := eopts.err.(*ApiError); ok {
 		return ae
 	}
 
-	e := ApiErrors[JSStreamMoveInProgressF]
-	args := e.toReplacerArgs([]interface{}{"{msg}", msg})
-	return &ApiError{
-		Code:        e.Code,
-		ErrCode:     e.ErrCode,
-		Description: strings.NewReplacer(args...).Replace(e.Description),
-	}
+	return ApiErrors[JSStreamMoveInProgressErr]
 }
 
 // NewJSStreamMoveNotInProgressError creates a new JSStreamMoveNotInProgress error: "stream move not in progress"

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -3454,14 +3454,20 @@ func TestJetStreamSuperClusterMoveCancel(t *testing.T) {
 			return fmt.Errorf("stream not found")
 		} else if len(sa.Group.Peers) != len(expectedPeers) {
 			return fmt.Errorf("stream peer group size not %d, but %d", len(expectedPeers), len(sa.Group.Peers))
+		} else if sa.Group.Desired != nil {
+			return fmt.Errorf("stream desired state set")
 		} else if da, ok := sa.consumers["DUR"]; !ok {
 			return fmt.Errorf("durable not found")
 		} else if len(da.Group.Peers) != len(expectedPeers) {
 			return fmt.Errorf("durable peer group size not %d, but %d", len(expectedPeers), len(da.Group.Peers))
+		} else if da.Group.Desired != nil {
+			return fmt.Errorf("durable consumer desired state set")
 		} else if ea, ok := sa.consumers[ephName]; !ok {
 			return fmt.Errorf("ephemeral not found")
 		} else if len(ea.Group.Peers) != 1 {
 			return fmt.Errorf("ephemeral peer group size not 1, but %d", len(ea.Group.Peers))
+		} else if ea.Group.Desired != nil {
+			return fmt.Errorf("ephemeral consumer desired state set")
 		} else if _, ok := expectedPeers[ea.Group.Peers[0]]; !ok {
 			return fmt.Errorf("ephemeral peer not an expected peer")
 		} else {
@@ -3628,6 +3634,9 @@ func TestJetStreamSuperClusterDoubleStreamMove(t *testing.T) {
 			if sa, ok := cc.streams["$G"]["TEST"]; !ok {
 				js.mu.Unlock()
 				return fmt.Errorf("stream not found in cluster")
+			} else if sa.Group.Desired != nil {
+				js.mu.Unlock()
+				return fmt.Errorf("move still in progress, desired state set")
 			} else if len(sa.Group.Peers) != 3 {
 				js.mu.Unlock()
 				return fmt.Errorf("peers not reset")
@@ -3756,6 +3765,26 @@ func moveTestStreamGroup(t *testing.T, s *Server, account, stream string) (peers
 	return copyStrings(sa.Group.Peers), sa.Group.Cluster, sa.Config.Replicas
 }
 
+// Returns the peer set as recorded in the meta layer's consumer assignment.
+func moveTestConsumerGroup(t *testing.T, s *Server, account, stream, consumer string) []string {
+	t.Helper()
+	js := s.getJetStream()
+	if js == nil {
+		return nil
+	}
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+	sa := js.streamAssignment(account, stream)
+	if sa == nil {
+		return nil
+	}
+	ca := sa.consumers[consumer]
+	if ca == nil || ca.Group == nil {
+		return nil
+	}
+	return copyStrings(ca.Group.Peers)
+}
+
 // Returns the peer ids of all servers in the cluster.
 func moveTestClusterPeers(c *cluster) []string {
 	peers := make([]string, 0, len(c.servers))
@@ -3832,9 +3861,8 @@ func moveTestCancelMove(t *testing.T, ncsys *nats.Conn, account, stream string) 
 	})
 }
 
-// A move followed by a scale must both be undone by a single cancel, since the desired
-// origin records the state from before the first change and must not be overwritten by
-// any subsequent change.
+// While a move is in progress, any further change that would retarget the desired peer
+// set must be rejected, and a cancel must restore the origin recorded before the move.
 func TestJetStreamSuperClusterMoveThenScaleThenCancel(t *testing.T) {
 	sc := moveTestSuperCluster(t)
 	defer sc.shutdown()
@@ -3879,22 +3907,29 @@ func TestJetStreamSuperClusterMoveThenScaleThenCancel(t *testing.T) {
 		return nil
 	})
 
-	// While the move is in progress, scale the stream down as well.
-	cfg.Replicas = 1
-	_, err = js.UpdateStream(cfg)
-	require_NoError(t, err)
-	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
-		if _, _, replicas := moveTestStreamGroup(t, ml, globalAccountName, "TEST"); replicas != 1 {
-			return fmt.Errorf("scale not applied yet, R%d", replicas)
-		}
-		return nil
-	})
+	// While the move is in progress, both a scale and another move must be rejected.
+	// Either would retarget the desired peer set the group is still converging on.
+	scaleCfg := *cfg
+	scaleCfg.Replicas = 1
+	_, err = js.UpdateStream(&scaleCfg)
+	require_Error(t, err)
+	require_Contains(t, err.Error(), "stream move already in progress")
+
+	moveCfg := *cfg
+	moveCfg.Placement = &nats.Placement{Tags: []string{"C1"}}
+	_, err = js.UpdateStream(&moveCfg)
+	require_Error(t, err)
+	require_Contains(t, err.Error(), "stream move already in progress")
+
+	// The rejected requests must not have altered anything.
+	_, _, replicas := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+	require_Equal(t, replicas, originReplicas)
 
 	ncsys, err := nats.Connect(c1.randomServer().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
 	require_NoError(t, err)
 	defer ncsys.Close()
 
-	// A single cancel must undo the scale as well as the move.
+	// A cancel must undo the move, restoring the origin recorded before it started.
 	moveTestCancelMove(t, ncsys, globalAccountName, "TEST")
 
 	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
@@ -4056,6 +4091,109 @@ func TestJetStreamSuperClusterLegacyMoveCancel(t *testing.T) {
 		}
 		if si.Cluster == nil || si.Cluster.Name != "C1" {
 			return fmt.Errorf("expected stream in C1, got %+v", si.Cluster)
+		}
+		return nil
+	})
+}
+
+// A legacy move is inflight just like one expressed as desired state, so a move or scale
+// on top of it must be rejected. Retargeting instead would record the over-replicated peer
+// set as the origin to roll back to, growing the assignment the guard is meant to bound.
+func TestJetStreamSuperClusterLegacyMoveRejectsMoveAndScale(t *testing.T) {
+	sc := moveTestSuperCluster(t)
+	defer sc.shutdown()
+
+	c1, c2 := sc.clusterForName("C1"), sc.clusterForName("C2")
+	nc, js := jsClientConnect(t, c1.randomNonLeader())
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Placement: &nats.Placement{Tags: []string{"C1"}},
+		Replicas:  1,
+	}
+	si, err := js.AddStream(cfg)
+	require_NoError(t, err)
+	require_Equal(t, si.Cluster.Name, "C1")
+
+	// Stall the move before injecting it, so it stays a legacy move without desired state.
+	ml := sc.leader()
+	originPeers, _, _ := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+	require_Equal(t, len(originPeers), 1)
+	var host *Server
+	for _, s := range c1.servers {
+		if getHash(s.Name()) == originPeers[0] {
+			host = s
+		}
+	}
+	require_NotNil(t, host)
+	host.Shutdown()
+	host.WaitForShutdown()
+	sc.waitOnLeader()
+	ml = sc.leader()
+	require_NotNil(t, ml)
+
+	destPeers := moveTestClusterPeers(c2)
+	require_True(t, moveTestSamePeers(moveTestInjectLegacyMove(t, ml, globalAccountName, "TEST", destPeers), originPeers))
+
+	// Nothing can reconcile this move, it is only expressed as an over-replicated peer set.
+	mjs := ml.getJetStream()
+	mjs.mu.RLock()
+	sa := mjs.streamAssignment(globalAccountName, "TEST")
+	hasDesired := sa != nil && sa.Group != nil && sa.Group.Desired != nil
+	mjs.mu.RUnlock()
+	require_False(t, hasDesired)
+
+	// Both a scale and a placement induced move must be rejected while it is in progress.
+	scaled := *cfg
+	scaled.Replicas = 3
+	_, err = js.UpdateStream(&scaled)
+	require_Error(t, err, NewJSStreamMoveInProgressError())
+
+	moved := *cfg
+	moved.Placement = &nats.Placement{Tags: []string{"C2"}}
+	_, err = js.UpdateStream(&moved)
+	require_Error(t, err, NewJSStreamMoveInProgressError())
+
+	// The peer set must be untouched by the rejected requests.
+	legacyPeers := append(copyStrings(originPeers), destPeers...)
+	peers, _, replicas := moveTestStreamGroup(t, sc.leader(), globalAccountName, "TEST")
+	require_Equal(t, replicas, 1)
+	require_True(t, moveTestSamePeers(peers, legacyPeers))
+
+	// A retention change does not retarget the peer set, so it is allowed and registers desired
+	// state. The origin it captures must be the peer set the legacy move started from, not the
+	// over-replicated set it is moving through, or a rollback would restore the enlarged set.
+	// The stream can't respond while its only peer is down, only the assignment matters here.
+	retention := *cfg
+	retention.Retention = nats.InterestPolicy
+	_, _ = js.UpdateStream(&retention, nats.MaxWait(time.Second))
+
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		mjs := sc.leader().getJetStream()
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		sa := mjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group == nil {
+			return errors.New("no stream assignment")
+		}
+		if sa.Config == nil || sa.Config.Retention != InterestPolicy {
+			return fmt.Errorf("retention change not applied yet: %+v", sa.Config)
+		}
+		d := sa.Group.Desired
+		if d == nil || d.Origin == nil {
+			return fmt.Errorf("no desired origin yet: %+v", d)
+		}
+		if !moveTestSamePeers(d.Origin.Peers, originPeers) {
+			return fmt.Errorf("expected origin peers %+v, got %+v", originPeers, d.Origin.Peers)
+		}
+		if d.Origin.Cluster != "C1" {
+			return fmt.Errorf("expected origin cluster %q, got %q", "C1", d.Origin.Cluster)
+		}
+		// The move itself is still in progress, so the assignment keeps both peer sets.
+		if !moveTestSamePeers(sa.Group.Peers, legacyPeers) {
+			return fmt.Errorf("expected peers %+v, got %+v", legacyPeers, sa.Group.Peers)
 		}
 		return nil
 	})
@@ -4477,6 +4615,98 @@ func TestJetStreamSuperClusterReconcileWithoutMoveRecordsNoOrigin(t *testing.T) 
 	require_NoError(t, json.Unmarshal(rmsg.Data, &cancelResp))
 	require_NotNil(t, cancelResp.Error)
 	require_Equal(t, cancelResp.Error.ErrCode, uint16(JSStreamMoveNotInProgress))
+}
+
+// Move requests that keep cycling between clusters must not be able to grow the stream
+// and consumer peer sets unbounded. A move is rejected while another is still in flight,
+// so the peer sets never accumulate peers of an abandoned target and can hold no more
+// than the origin plus the destination peers.
+func TestJetStreamSuperClusterCyclingMovesBoundGroupSize(t *testing.T) {
+	// Three clusters of five, so an unbounded peer set could grow to all 15 peers.
+	sc := createJetStreamSuperClusterWithTemplateAndModHook(t, jsClusterTempl, 5, 3,
+		func(serverName, clusterName, storeDir, conf string) string {
+			return fmt.Sprintf("%s\nserver_tags: [%s]", conf, clusterName)
+		}, nil)
+	defer sc.shutdown()
+
+	nc, js := jsClientConnect(t, sc.clusterForName("C1").randomNonLeader())
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Placement: &nats.Placement{Tags: []string{"C1"}},
+		Replicas:  5,
+	}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Durable: "DUR", AckPolicy: nats.AckExplicitPolicy})
+	require_NoError(t, err)
+
+	var maxStreamPeers, maxConsumerPeers int
+	check := func() {
+		t.Helper()
+		ml := sc.leader()
+		if ml == nil {
+			return
+		}
+		speers, _, _ := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+		cpeers := moveTestConsumerGroup(t, ml, globalAccountName, "TEST", "DUR")
+		maxStreamPeers, maxConsumerPeers = max(maxStreamPeers, len(speers)), max(maxConsumerPeers, len(cpeers))
+		// Only one move can be in flight, so the peer set holds at most the origin peers
+		// plus the destination peers.
+		require_LessThan(t, len(speers), 2*cfg.Replicas+1)
+		require_LessThan(t, len(cpeers), 2*cfg.Replicas+1)
+	}
+
+	// Cycle the move target between the clusters. A retarget while a move is still in
+	// flight is rejected, so the peer sets can never accumulate peers of an abandoned
+	// target, and stay bounded well below the migration cap.
+	last := "C1"
+	var accepted, rejected int
+	for i := range 6 {
+		tag := fmt.Sprintf("C%d", i%3+1)
+		cfg.Placement = &nats.Placement{Tags: []string{tag}}
+		if _, err = js.UpdateStream(cfg); err != nil {
+			require_Contains(t, err.Error(), "stream move already in progress")
+			rejected++
+		} else {
+			accepted++
+			last = tag
+		}
+		for range 8 {
+			check()
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	// The rejections are what keeps the peer sets bounded, so make sure we saw both a
+	// move that was let through and one that was turned away.
+	require_True(t, accepted > 0)
+	require_True(t, rejected > 0)
+
+	// Once the cycling stops, the last accepted move must still converge.
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		peers, cluster, replicas := moveTestStreamGroup(t, sc.leader(), globalAccountName, "TEST")
+		if len(peers) != replicas || cluster != last {
+			return fmt.Errorf("stream not settled: %d peers, R%d, cluster %q", len(peers), replicas, cluster)
+		}
+		cpeers := moveTestConsumerGroup(t, sc.leader(), globalAccountName, "TEST", "DUR")
+		if len(cpeers) != replicas {
+			return fmt.Errorf("consumer not settled: %d peers", len(cpeers))
+		}
+		si, err := js.StreamInfo("TEST")
+		if err != nil {
+			return err
+		}
+		if si.Cluster == nil || si.Cluster.Name != last {
+			return fmt.Errorf("stream not in %q: %+v", last, si.Cluster)
+		}
+		return nil
+	})
+
+	// Confirm the moves actually grew the peer sets, otherwise we'd not be testing much.
+	require_True(t, maxStreamPeers > cfg.Replicas)
+	require_True(t, maxConsumerPeers > cfg.Replicas)
 }
 
 func TestJetStreamSuperClusterPeerEvacuationAndStreamReassignment(t *testing.T) {

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -3681,6 +3682,17 @@ func TestJetStreamSuperClusterDoubleStreamMove(t *testing.T) {
 			}
 			nc.Close()
 		}
+		// The desired state must be cleared on every server before the move is complete.
+		for _, s := range c.servers {
+			js, cc := s.getJetStreamCluster()
+			js.mu.Lock()
+			sa, ok := cc.streams["$G"]["TEST"]
+			desired := ok && sa.Group.Desired != nil
+			js.mu.Unlock()
+			if desired {
+				return fmt.Errorf("move still in progress, desired state set on %s", s.Name())
+			}
+		}
 		return nil
 	}
 
@@ -3716,6 +3728,755 @@ func TestJetStreamSuperClusterDoubleStreamMove(t *testing.T) {
 	moveAndCheck(srvMoveList[3], srvMoveList[0], srvMoveList[2], srvMoveList[1], srvMoveList[0])
 	moveAndCheck(srvMoveList[0], srvMoveList[3], srvMoveList[2], srvMoveList[1], srvMoveList[3])
 	moveAndCheck(srvMoveList[3], srvMoveList[0], srvMoveList[2], srvMoveList[1], srvMoveList[0])
+}
+
+func moveTestSuperCluster(t *testing.T) *supercluster {
+	t.Helper()
+	// Tag every server with its cluster name, so a move can be targeted at a cluster.
+	return createJetStreamSuperClusterWithTemplateAndModHook(t, jsClusterTempl, 3, 2,
+		func(serverName, clusterName, storeDir, conf string) string {
+			return fmt.Sprintf("%s\nserver_tags: [%s]", conf, clusterName)
+		}, nil)
+}
+
+// Returns the peer set, cluster and configured replica count as recorded in the
+// meta layer's stream assignment.
+func moveTestStreamGroup(t *testing.T, s *Server, account, stream string) (peers []string, cluster string, replicas int) {
+	t.Helper()
+	js := s.getJetStream()
+	if js == nil {
+		return nil, _EMPTY_, 0
+	}
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+	sa := js.streamAssignment(account, stream)
+	if sa == nil || sa.Group == nil || sa.Config == nil {
+		return nil, _EMPTY_, 0
+	}
+	return copyStrings(sa.Group.Peers), sa.Group.Cluster, sa.Config.Replicas
+}
+
+// Returns the peer ids of all servers in the cluster.
+func moveTestClusterPeers(c *cluster) []string {
+	peers := make([]string, 0, len(c.servers))
+	for _, s := range c.servers {
+		peers = append(peers, getHash(s.Name()))
+	}
+	return peers
+}
+
+// Compares two peer sets, ignoring order.
+func moveTestSamePeers(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	as, bs := copyStrings(a), copyStrings(b)
+	slices.Sort(as)
+	slices.Sort(bs)
+	return slices.Equal(as, bs)
+}
+
+// Simulates a move that was started before the upgrade to desired state, by proposing
+// an assignment the way the legacy move did: the destination peers are appended to the
+// current peer set, Config.Replicas is left alone, and no desired state is recorded.
+// Returns the peer set the stream was on before the move was started.
+func moveTestInjectLegacyMove(t *testing.T, ml *Server, account, stream string, destPeers []string) []string {
+	t.Helper()
+	mjs := ml.getJetStream()
+	require_NotNil(t, mjs)
+
+	mjs.mu.Lock()
+	osa := mjs.streamAssignment(account, stream)
+	if osa == nil {
+		mjs.mu.Unlock()
+		t.Fatalf("no stream assignment for %q", stream)
+	}
+	nsa := osa.copyGroup()
+	cc := mjs.cluster
+	meta, term := cc.meta, cc.term
+	mjs.mu.Unlock()
+
+	originPeers := copyStrings(nsa.Group.Peers)
+	nsa.Group.Peers = append(copyStrings(originPeers), destPeers...)
+	require_NoError(t, meta.Propose(term, encodeUpdateStreamAssignment(nsa)))
+
+	// Wait for the legacy assignment to be applied on the meta leader.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		peers, _, replicas := moveTestStreamGroup(t, ml, account, stream)
+		if len(peers) <= replicas {
+			return fmt.Errorf("legacy move assignment not applied yet, %d peers for R%d", len(peers), replicas)
+		}
+		return nil
+	})
+	return originPeers
+}
+
+// Requests a cancel of an in-progress move. The request is retried, as the meta leader
+// can legitimately not be ready to serve it yet, e.g. while a stream is still being
+// created or before an in-progress move has been picked up.
+func moveTestCancelMove(t *testing.T, ncsys *nats.Conn, account, stream string) {
+	t.Helper()
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		rmsg, err := ncsys.Request(fmt.Sprintf(JSApiServerStreamCancelMoveT, account, stream), nil, 2*time.Second)
+		if err != nil {
+			return err
+		}
+		var resp JSApiStreamUpdateResponse
+		if err := json.Unmarshal(rmsg.Data, &resp); err != nil {
+			return err
+		}
+		if resp.Error != nil {
+			return fmt.Errorf("cancel move: %v", resp.Error)
+		}
+		return nil
+	})
+}
+
+// A move followed by a scale must both be undone by a single cancel, since the desired
+// origin records the state from before the first change and must not be overwritten by
+// any subsequent change.
+func TestJetStreamSuperClusterMoveThenScaleThenCancel(t *testing.T) {
+	sc := moveTestSuperCluster(t)
+	defer sc.shutdown()
+
+	c1 := sc.clusterForName("C1")
+	nc, js := jsClientConnect(t, c1.randomNonLeader())
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Placement: &nats.Placement{Tags: []string{"C1"}},
+		Replicas:  3,
+	}
+	si, err := js.AddStream(cfg)
+	require_NoError(t, err)
+	require_Equal(t, si.Cluster.Name, "C1")
+
+	toSend := 100
+	for range toSend {
+		_, err = js.Publish("foo", []byte("hello"))
+		require_NoError(t, err)
+	}
+
+	ml := sc.leader()
+	originPeers, originCluster, originReplicas := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+	require_Equal(t, len(originPeers), 3)
+	require_Equal(t, originCluster, "C1")
+	require_Equal(t, originReplicas, 3)
+
+	// Start a move to C2 by changing the placement tags.
+	cfg.Placement = &nats.Placement{Tags: []string{"C2"}}
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+
+	// Wait for the move to be in progress, i.e. the destination peers were added.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		peers, _, _ := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+		if len(peers) <= originReplicas {
+			return fmt.Errorf("move not in progress yet, %d peers", len(peers))
+		}
+		return nil
+	})
+
+	// While the move is in progress, scale the stream down as well.
+	cfg.Replicas = 1
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		if _, _, replicas := moveTestStreamGroup(t, ml, globalAccountName, "TEST"); replicas != 1 {
+			return fmt.Errorf("scale not applied yet, R%d", replicas)
+		}
+		return nil
+	})
+
+	ncsys, err := nats.Connect(c1.randomServer().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer ncsys.Close()
+
+	// A single cancel must undo the scale as well as the move.
+	moveTestCancelMove(t, ncsys, globalAccountName, "TEST")
+
+	checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+		peers, cluster, replicas := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+		if replicas != originReplicas {
+			return fmt.Errorf("expected R%d, got R%d", originReplicas, replicas)
+		}
+		if cluster != originCluster {
+			return fmt.Errorf("expected cluster %q, got %q", originCluster, cluster)
+		}
+		if !moveTestSamePeers(peers, originPeers) {
+			return fmt.Errorf("expected peers %+v, got %+v", originPeers, peers)
+		}
+		si, err := js.StreamInfo("TEST")
+		if err != nil {
+			return err
+		}
+		if si.Config.Replicas != originReplicas {
+			return fmt.Errorf("expected R%d, got R%d", originReplicas, si.Config.Replicas)
+		}
+		if !reflect.DeepEqual(si.Config.Placement, &nats.Placement{Tags: []string{"C1"}}) {
+			return fmt.Errorf("expected placement to be restored, got %+v", si.Config.Placement)
+		}
+		if si.Cluster == nil || si.Cluster.Name != originCluster {
+			return fmt.Errorf("expected cluster %q, got %+v", originCluster, si.Cluster)
+		}
+		if si.State.Msgs != uint64(toSend) {
+			return fmt.Errorf("expected %d msgs, got %d", toSend, si.State.Msgs)
+		}
+		return nil
+	})
+}
+
+// A move that was still in progress when the servers were upgraded to desired state must
+// be picked up and driven to completion, ending up on the destination peers only.
+func TestJetStreamSuperClusterLegacyMoveCompletes(t *testing.T) {
+	sc := moveTestSuperCluster(t)
+	defer sc.shutdown()
+
+	c1, c2 := sc.clusterForName("C1"), sc.clusterForName("C2")
+	nc, js := jsClientConnect(t, c1.randomNonLeader())
+	defer nc.Close()
+
+	si, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Placement: &nats.Placement{Tags: []string{"C1"}},
+		Replicas:  3,
+	})
+	require_NoError(t, err)
+	require_Equal(t, si.Cluster.Name, "C1")
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Durable: "DUR", AckPolicy: nats.AckExplicitPolicy})
+	require_NoError(t, err)
+
+	toSend := 100
+	for range toSend {
+		_, err = js.Publish("foo", []byte("hello"))
+		require_NoError(t, err)
+	}
+
+	ml := sc.leader()
+	destPeers := moveTestClusterPeers(c2)
+	originPeers := moveTestInjectLegacyMove(t, ml, globalAccountName, "TEST", destPeers)
+	require_Equal(t, len(originPeers), 3)
+
+	// The move must complete, ending up on the destination peers in the destination
+	// cluster. Group.Cluster is only updated when the move completes, so it must name
+	// the destination cluster once done.
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		peers, cluster, replicas := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+		if replicas != 3 {
+			return fmt.Errorf("expected R3, got R%d", replicas)
+		}
+		if !moveTestSamePeers(peers, destPeers) {
+			return fmt.Errorf("expected peers %+v, got %+v", destPeers, peers)
+		}
+		if cluster != "C2" {
+			return fmt.Errorf("expected cluster %q, got %q", "C2", cluster)
+		}
+
+		// No data lost, and the consumer moved along with the stream.
+		si, err := js.StreamInfo("TEST")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != uint64(toSend) {
+			return fmt.Errorf("expected %d msgs, got %d", toSend, si.State.Msgs)
+		}
+		if si.Cluster == nil || si.Cluster.Name != "C2" {
+			return fmt.Errorf("expected stream in C2, got %+v", si.Cluster)
+		}
+		ci, err := js.ConsumerInfo("TEST", "DUR")
+		if err != nil {
+			return err
+		}
+		if ci.Cluster == nil || ci.Cluster.Name != "C2" {
+			return fmt.Errorf("expected consumer in C2, got %+v", ci.Cluster)
+		}
+		return nil
+	})
+}
+
+// A move that was still in progress when the servers were upgraded to desired state must
+// remain cancellable, moving the stream back onto the peer set it started from.
+func TestJetStreamSuperClusterLegacyMoveCancel(t *testing.T) {
+	sc := moveTestSuperCluster(t)
+	defer sc.shutdown()
+
+	c1, c2 := sc.clusterForName("C1"), sc.clusterForName("C2")
+	nc, js := jsClientConnect(t, c1.randomNonLeader())
+	defer nc.Close()
+
+	si, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Placement: &nats.Placement{Tags: []string{"C1"}},
+		Replicas:  3,
+	})
+	require_NoError(t, err)
+	require_Equal(t, si.Cluster.Name, "C1")
+
+	toSend := 100
+	for range toSend {
+		_, err = js.Publish("foo", []byte("hello"))
+		require_NoError(t, err)
+	}
+
+	ml := sc.leader()
+	destPeers := moveTestClusterPeers(c2)
+	originPeers := moveTestInjectLegacyMove(t, ml, globalAccountName, "TEST", destPeers)
+	require_Equal(t, len(originPeers), 3)
+
+	ncsys, err := nats.Connect(c1.randomServer().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer ncsys.Close()
+
+	moveTestCancelMove(t, ncsys, globalAccountName, "TEST")
+
+	// Must move back onto the peer set the stream was on before the legacy move, and
+	// not forward onto the destination peers.
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		peers, cluster, replicas := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+		if replicas != 3 {
+			return fmt.Errorf("expected R3, got R%d", replicas)
+		}
+		if !moveTestSamePeers(peers, originPeers) {
+			return fmt.Errorf("expected peers %+v, got %+v", originPeers, peers)
+		}
+		if cluster != "C1" {
+			return fmt.Errorf("expected cluster %q, got %q", "C1", cluster)
+		}
+		si, err := js.StreamInfo("TEST")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != uint64(toSend) {
+			return fmt.Errorf("expected %d msgs, got %d", toSend, si.State.Msgs)
+		}
+		if si.Cluster == nil || si.Cluster.Name != "C1" {
+			return fmt.Errorf("expected stream in C1, got %+v", si.Cluster)
+		}
+		return nil
+	})
+}
+
+// A legacy move that is stalled must remain cancellable. Only the stream's group leader
+// publishes a reconcile, so while the stream has no leader the meta leader never gets to
+// synthesize desired state, and the cancel must recognize the over-replicated peer set as
+// a move in progress instead of rejecting it.
+func TestJetStreamSuperClusterLegacyMoveCancelWithoutReconcile(t *testing.T) {
+	sc := moveTestSuperCluster(t)
+	defer sc.shutdown()
+
+	c1, c2 := sc.clusterForName("C1"), sc.clusterForName("C2")
+	nc, js := jsClientConnect(t, c1.randomNonLeader())
+	defer nc.Close()
+
+	// R1, so stopping a single server is enough to leave the move without a stream leader.
+	si, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Placement: &nats.Placement{Tags: []string{"C1"}},
+		Replicas:  1,
+	})
+	require_NoError(t, err)
+	require_Equal(t, si.Cluster.Name, "C1")
+
+	toSend := 100
+	for range toSend {
+		_, err = js.Publish("foo", []byte("hello"))
+		require_NoError(t, err)
+	}
+
+	// Stall the move before injecting it, by stopping the only server hosting the stream.
+	// Otherwise, it would immediately reconcile itself into desired state.
+	ml := sc.leader()
+	originPeers, _, _ := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+	require_Equal(t, len(originPeers), 1)
+	var host *Server
+	for _, s := range c1.servers {
+		if getHash(s.Name()) == originPeers[0] {
+			host = s
+		}
+	}
+	require_NotNil(t, host)
+	host.Shutdown()
+	host.WaitForShutdown()
+	sc.waitOnLeader()
+	ml = sc.leader()
+	require_NotNil(t, ml)
+
+	destPeers := moveTestClusterPeers(c2)
+	require_True(t, moveTestSamePeers(moveTestInjectLegacyMove(t, ml, globalAccountName, "TEST", destPeers), originPeers))
+
+	desiredState := func() *desiredRaftGroup {
+		ml := sc.leader()
+		require_NotNil(t, ml)
+		mjs := ml.getJetStream()
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		sa := mjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group == nil {
+			return nil
+		}
+		return sa.Group.Desired
+	}
+	// Nothing can reconcile this move, so it is still only expressed as an over-replicated peer set.
+	require_True(t, desiredState() == nil)
+
+	ncsys, err := nats.Connect(c2.randomServer().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer ncsys.Close()
+
+	// Single-shot, the cancel must be accepted based on the legacy peer set alone.
+	rmsg, err := ncsys.Request(fmt.Sprintf(JSApiServerStreamCancelMoveT, globalAccountName, "TEST"), nil, 5*time.Second)
+	require_NoError(t, err)
+	var cancelResp JSApiStreamUpdateResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &cancelResp))
+	require_True(t, cancelResp.Error == nil)
+
+	// The cancel must target the peer set the legacy move started from, both as the desired
+	// peer set to migrate back onto and as the origin to roll back to.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		d := desiredState()
+		if d == nil {
+			return errors.New("desired state not initialized yet")
+		}
+		if !moveTestSamePeers(d.Peers, originPeers) {
+			return fmt.Errorf("expected desired peers %+v, got %+v", originPeers, d.Peers)
+		}
+		if d.Origin == nil {
+			return errors.New("expected a desired origin")
+		}
+		if !moveTestSamePeers(d.Origin.Peers, originPeers) {
+			return fmt.Errorf("expected origin peers %+v, got %+v", originPeers, d.Origin.Peers)
+		}
+		if d.Origin.Replicas != 1 {
+			return fmt.Errorf("expected origin R1, got R%d", d.Origin.Replicas)
+		}
+		if d.Origin.Cluster != "C1" {
+			return fmt.Errorf("expected origin cluster %q, got %q", "C1", d.Origin.Cluster)
+		}
+		return nil
+	})
+
+	// And once the stream can make progress again the cancel must actually complete, leaving
+	// the stream on the peer set it started from, with the desired state cleared.
+	c1.restartServer(host)
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		peers, cluster, replicas := moveTestStreamGroup(t, sc.leader(), globalAccountName, "TEST")
+		if replicas != 1 {
+			return fmt.Errorf("expected R1, got R%d", replicas)
+		}
+		if !moveTestSamePeers(peers, originPeers) {
+			return fmt.Errorf("expected peers %+v, got %+v", originPeers, peers)
+		}
+		if cluster != "C1" {
+			return fmt.Errorf("expected cluster %q, got %q", "C1", cluster)
+		}
+		if d := desiredState(); d != nil {
+			return fmt.Errorf("desired state not cleared: %+v", d)
+		}
+		si, err := js.StreamInfo("TEST")
+		if err != nil {
+			return err
+		}
+		if si.State.Msgs != uint64(toSend) {
+			return fmt.Errorf("expected %d msgs, got %d", toSend, si.State.Msgs)
+		}
+		if si.Cluster == nil || si.Cluster.Name != "C1" {
+			return fmt.Errorf("expected stream in C1, got %+v", si.Cluster)
+		}
+		return nil
+	})
+}
+
+// A legacy move must be reconciled through desired state: the meta leader initializes the
+// desired state from the in-progress move, recording the peer set the move started from as
+// the origin, and the destination as the desired peer set and cluster.
+func TestJetStreamSuperClusterLegacyMoveInitializesDesiredState(t *testing.T) {
+	sc := moveTestSuperCluster(t)
+	defer sc.shutdown()
+
+	c1, c2 := sc.clusterForName("C1"), sc.clusterForName("C2")
+	nc, js := jsClientConnect(t, c1.randomNonLeader())
+	defer nc.Close()
+
+	si, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Placement: &nats.Placement{Tags: []string{"C1"}},
+		Replicas:  3,
+	})
+	require_NoError(t, err)
+	require_Equal(t, si.Cluster.Name, "C1")
+
+	toSend := 100
+	for range toSend {
+		_, err = js.Publish("foo", []byte("hello"))
+		require_NoError(t, err)
+	}
+
+	ml := sc.leader()
+	destPeers := moveTestClusterPeers(c2)
+	originPeers := moveTestInjectLegacyMove(t, ml, globalAccountName, "TEST", destPeers)
+	require_Equal(t, len(originPeers), 3)
+
+	// The meta leader must initialize desired state for the legacy move, recording an
+	// origin that allows rolling back to where the stream was before the move started.
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		mjs := ml.getJetStream()
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		sa := mjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group == nil {
+			return fmt.Errorf("no stream assignment")
+		}
+		desired := sa.Group.Desired
+		if desired == nil {
+			return fmt.Errorf("desired state not initialized yet")
+		}
+		// The desired peer set and cluster must be the destination of the move, or the
+		// move would not complete, and the origin cluster would be committed on the
+		// assignment once it does.
+		if !moveTestSamePeers(desired.Peers, destPeers) {
+			return fmt.Errorf("expected desired peers %+v, got %+v", destPeers, desired.Peers)
+		}
+		if desired.Cluster != "C2" {
+			return fmt.Errorf("expected desired cluster %q, got %q", "C2", desired.Cluster)
+		}
+		// The origin must be where the move started from, not where it is heading.
+		origin := desired.Origin
+		if origin == nil {
+			return fmt.Errorf("desired origin not recorded")
+		}
+		if !moveTestSamePeers(origin.Peers, originPeers) {
+			return fmt.Errorf("expected origin peers %+v, got %+v", originPeers, origin.Peers)
+		}
+		if origin.Cluster != "C1" {
+			return fmt.Errorf("expected origin cluster %q, got %q", "C1", origin.Cluster)
+		}
+		if origin.Replicas != 3 {
+			return fmt.Errorf("expected origin R3, got R%d", origin.Replicas)
+		}
+		return nil
+	})
+
+	// Once the move completes the desired state must be cleared again.
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		mjs := ml.getJetStream()
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		sa := mjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group == nil {
+			return fmt.Errorf("no stream assignment")
+		}
+		if sa.Group.Desired != nil {
+			return fmt.Errorf("desired state not cleared yet: %+v", sa.Group.Desired)
+		}
+		if !moveTestSamePeers(sa.Group.Peers, destPeers) {
+			return fmt.Errorf("expected peers %+v, got %+v", destPeers, sa.Group.Peers)
+		}
+		if sa.Group.Cluster != "C2" {
+			return fmt.Errorf("expected cluster %q, got %q", "C2", sa.Group.Cluster)
+		}
+		return nil
+	})
+}
+
+// A move requested through $JS.API.SERVER.STREAM.MOVE passes an explicit peer set, rather
+// than deriving one from placement. The assignment must still end up naming the cluster the
+// new peer set is in, or any later placement decision is made against the origin cluster and
+// pulls the stream back out of the cluster it was moved to.
+func TestJetStreamSuperClusterServerMoveRequestUpdatesGroupCluster(t *testing.T) {
+	sc := moveTestSuperCluster(t)
+	defer sc.shutdown()
+
+	c1, c2 := sc.clusterForName("C1"), sc.clusterForName("C2")
+	nc, js := jsClientConnect(t, c1.randomNonLeader())
+	defer nc.Close()
+
+	// Deliberately no placement, so the only thing steering a later scale back
+	// toward C1 would be a stale Group.Cluster.
+	si, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+	require_Equal(t, si.Cluster.Name, "C1")
+
+	toSend := 100
+	for range toSend {
+		_, err = js.Publish("foo", []byte("hello"))
+		require_NoError(t, err)
+	}
+
+	ml := sc.leader()
+	originPeers, originCluster, _ := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+	require_Equal(t, len(originPeers), 3)
+	require_Equal(t, originCluster, "C1")
+
+	c1Peers, c2Peers := moveTestClusterPeers(c1), moveTestClusterPeers(c2)
+	require_True(t, moveTestSamePeers(originPeers, c1Peers))
+
+	ncsys, err := nats.Connect(c1.randomServer().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer ncsys.Close()
+
+	// Move to C2 by targeting the tag every C2 server carries.
+	moveReq, err := json.Marshal(&JSApiMetaServerStreamMoveRequest{Tags: []string{"C2"}})
+	require_NoError(t, err)
+	rmsg, err := ncsys.Request(fmt.Sprintf(JSApiServerStreamMoveT, globalAccountName, "TEST"), moveReq, 5*time.Second)
+	require_NoError(t, err)
+	var moveResp JSApiStreamUpdateResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &moveResp))
+	require_True(t, moveResp.Error == nil)
+
+	// While the move is in progress the desired state must name the destination cluster,
+	// and once it completes that cluster must be committed onto the assignment.
+	var sawDesired bool
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		mjs := ml.getJetStream()
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		sa := mjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group == nil {
+			return fmt.Errorf("no stream assignment")
+		}
+		if d := sa.Group.Desired; d != nil {
+			sawDesired = true
+			if d.Cluster != "C2" {
+				return fmt.Errorf("expected desired cluster %q, got %q", "C2", d.Cluster)
+			}
+			return fmt.Errorf("move still in progress")
+		}
+		if !moveTestSamePeers(sa.Group.Peers, c2Peers) {
+			return fmt.Errorf("expected peers %+v, got %+v", c2Peers, sa.Group.Peers)
+		}
+		if sa.Group.Cluster != "C2" {
+			return fmt.Errorf("expected cluster %q, got %q", "C2", sa.Group.Cluster)
+		}
+		return nil
+	})
+	require_True(t, sawDesired)
+
+	// Scaling after the move must be placed against the cluster the stream now lives in.
+	// With a stale Group.Cluster the scale up below selects peers back in C1.
+	for _, replicas := range []int{1, 3} {
+		_, err = js.UpdateStream(&nats.StreamConfig{
+			Name:     "TEST",
+			Subjects: []string{"foo"},
+			Replicas: replicas,
+		})
+		require_NoError(t, err)
+
+		checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+			peers, cluster, cfgReplicas := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+			if cfgReplicas != replicas {
+				return fmt.Errorf("expected R%d, got R%d", replicas, cfgReplicas)
+			}
+			if len(peers) != replicas {
+				return fmt.Errorf("expected %d peers, got %+v", replicas, peers)
+			}
+			if cluster != "C2" {
+				return fmt.Errorf("expected cluster %q, got %q", "C2", cluster)
+			}
+			for _, peer := range peers {
+				if !slices.Contains(c2Peers, peer) {
+					return fmt.Errorf("peer %q is not in C2, peers %+v", peer, peers)
+				}
+			}
+			si, err := js.StreamInfo("TEST")
+			if err != nil {
+				return err
+			}
+			if si.State.Msgs != uint64(toSend) {
+				return fmt.Errorf("expected %d msgs, got %d", toSend, si.State.Msgs)
+			}
+			return nil
+		})
+	}
+}
+
+// Desired state is also initialized for a group that is merely converging on its
+// assignment, without any move or scale having been requested. That must not record a
+// desired origin, or the stream would report a rollback target and answer a cancel move
+// with success while no move is in progress.
+func TestJetStreamSuperClusterReconcileWithoutMoveRecordsNoOrigin(t *testing.T) {
+	sc := moveTestSuperCluster(t)
+	defer sc.shutdown()
+
+	c1 := sc.clusterForName("C1")
+	nc, js := jsClientConnect(t, c1.randomNonLeader())
+	defer nc.Close()
+
+	si, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+	require_Equal(t, si.Cluster.Name, "C1")
+
+	ml := sc.leader()
+	originPeers, originCluster, _ := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+	require_Equal(t, len(originPeers), 3)
+	require_Equal(t, originCluster, "C1")
+
+	ncsys, err := nats.Connect(c1.randomServer().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer ncsys.Close()
+
+	// Ask the meta leader to initialize desired state, the way a group leader does when it
+	// finds itself migrating. No move or scale was requested, so there is no origin.
+	// The term is deliberately far ahead of any real group term, so the group leader's own
+	// updates are fenced off and the desired state stays pinned for the assertions below.
+	reconcile, err := json.Marshal(&streamAssignmentReconcile{
+		Account:                 globalAccountName,
+		Stream:                  "TEST",
+		desiredAssignmentUpdate: desiredAssignmentUpdate{Term: math.MaxUint64},
+	})
+	require_NoError(t, err)
+	require_NoError(t, ncsys.Publish(streamAssignmentReconcileSubj, reconcile))
+
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		mjs := ml.getJetStream()
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		sa := mjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group == nil {
+			return fmt.Errorf("no stream assignment")
+		}
+		if sa.Group.Desired == nil {
+			return fmt.Errorf("desired state not initialized yet")
+		}
+		// Desired state is only about converging on the assignment we already have.
+		if !moveTestSamePeers(sa.Group.Desired.Peers, originPeers) {
+			return fmt.Errorf("expected desired peers %+v, got %+v", originPeers, sa.Group.Desired.Peers)
+		}
+		if sa.Group.Desired.Origin != nil {
+			return fmt.Errorf("expected no desired origin, got %+v", sa.Group.Desired.Origin)
+		}
+		// The assignment itself must be untouched.
+		if !moveTestSamePeers(sa.Group.Peers, originPeers) {
+			return fmt.Errorf("expected peers %+v, got %+v", originPeers, sa.Group.Peers)
+		}
+		if sa.Group.Cluster != originCluster {
+			return fmt.Errorf("expected cluster %q, got %q", originCluster, sa.Group.Cluster)
+		}
+		return nil
+	})
+
+	// And with no move in progress, a cancel must be rejected rather than reporting success
+	// and proposing a spurious assignment update.
+	rmsg, err := ncsys.Request(fmt.Sprintf(JSApiServerStreamCancelMoveT, globalAccountName, "TEST"), nil, 5*time.Second)
+	require_NoError(t, err)
+	var cancelResp JSApiStreamUpdateResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &cancelResp))
+	require_NotNil(t, cancelResp.Error)
+	require_Equal(t, cancelResp.Error.ErrCode, uint16(JSStreamMoveNotInProgress))
 }
 
 func TestJetStreamSuperClusterPeerEvacuationAndStreamReassignment(t *testing.T) {

--- a/server/stream.go
+++ b/server/stream.go
@@ -1651,7 +1651,17 @@ func (jsa *jsAccount) subjectsOverlap(subjects []string, self *stream) bool {
 // StreamDefaultDuplicatesWindow default duplicates window.
 const StreamDefaultDuplicatesWindow = 2 * time.Minute
 
+// Do not hold the jetStream lock, it will be read-locked internally.
 func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic bool) (StreamConfig, *ApiError) {
+	if js := s.getJetStream(); js != nil {
+		js.mu.RLock()
+		defer js.mu.RUnlock()
+	}
+	return s.checkStreamCfgLocked(config, acc, pedantic)
+}
+
+// jetStream lock (read or write) should be held, if JetStream is enabled.
+func (s *Server) checkStreamCfgLocked(config *StreamConfig, acc *Account, pedantic bool) (StreamConfig, *ApiError) {
 	lim := &s.getOpts().JetStreamLimits
 
 	if config == nil {
@@ -1852,12 +1862,10 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 		var cfg StreamConfig
 		if s.JetStreamIsClustered() {
 			if js, _ := s.getJetStreamCluster(); js != nil {
-				js.mu.RLock()
-				if sa := js.streamAssignment(acc.Name, streamName); sa != nil {
+				if sa := js.streamAssignmentOrInflight(acc.Name, streamName); sa != nil {
 					cfg = *sa.Config.clone()
 					exists = true
 				}
-				js.mu.RUnlock()
 			}
 		} else if mset, err := acc.lookupStream(streamName); err == nil {
 			cfg = mset.cfg
@@ -1962,19 +1970,12 @@ func (s *Server) checkStreamCfg(config *StreamConfig, acc *Account, pedantic boo
 				cfg.MirrorDirect = ocfg.AllowDirect
 			} else if js := s.getJetStream(); js != nil && js.isClustered() {
 				// Could not find it here. If we are clustered we can look it up.
-				js.mu.RLock()
-				if cc := js.cluster; cc != nil {
-					if as := cc.streams[acc.Name]; as != nil {
-						if sa := as[cfg.Mirror.Name]; sa != nil {
-							if pedantic && cfg.MirrorDirect != sa.Config.AllowDirect {
-								js.mu.RUnlock()
-								return StreamConfig{}, NewJSPedanticError(fmt.Errorf("origin stream has direct get set, mirror has it disabled"))
-							}
-							cfg.MirrorDirect = sa.Config.AllowDirect
-						}
+				if sa := js.streamAssignmentOrInflight(acc.Name, cfg.Mirror.Name); sa != nil {
+					if pedantic && cfg.MirrorDirect != sa.Config.AllowDirect {
+						return StreamConfig{}, NewJSPedanticError(fmt.Errorf("origin stream has direct get set, mirror has it disabled"))
 					}
+					cfg.MirrorDirect = sa.Config.AllowDirect
 				}
-				js.mu.RUnlock()
 			}
 		} else {
 			if cfg.Mirror.External.DeliverPrefix != _EMPTY_ {
@@ -2290,9 +2291,17 @@ func (mset *stream) fileStoreConfig() (FileStoreConfig, error) {
 	return fs.fileStoreConfig(), nil
 }
 
-// Do not hold jsAccount or jetStream lock
+// Do not hold jsAccount or jetStream lock, the latter will be read-locked internally.
 func (jsa *jsAccount) configUpdateCheck(old, new *StreamConfig, s *Server, pedantic bool) (*StreamConfig, error) {
-	cfg, apiErr := s.checkStreamCfg(new, jsa.acc(), pedantic)
+	js, _ := jsa.jetStreamAndClustered()
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+	return jsa.configUpdateCheckLocked(old, new, s, pedantic)
+}
+
+// Do not hold jsAccount lock. The jetStream lock (read or write) should be held.
+func (jsa *jsAccount) configUpdateCheckLocked(old, new *StreamConfig, s *Server, pedantic bool) (*StreamConfig, error) {
+	cfg, apiErr := s.checkStreamCfgLocked(new, jsa.acc(), pedantic)
 	if apiErr != nil {
 		return nil, apiErr
 	}
@@ -2406,8 +2415,6 @@ func (jsa *jsAccount) configUpdateCheck(old, new *StreamConfig, s *Server, pedan
 	if !hasTier {
 		return nil, NewJSNoLimitsError()
 	}
-	js.mu.RLock()
-	defer js.mu.RUnlock()
 	if isClustered {
 		_, reserved = js.tieredStreamAndReservationCount(acc.Name, tier, &cfg)
 	}


### PR DESCRIPTION
The move and cancel move endpoints are now wired fully through desired state. The cancel move endpoint can now be reliably used; the first move (either through stream updates or the move endpoint) initialize the "origin" which is the peer set and config (replicas, placement and retention) at that time, multiple moves or scales could technically be run even before the full desired state change completes, a cancel will then always roll back to the origin. However, concurrent stream move or scale requests are rejected to keep the peer set bounded, as otherwise cycling moves between clusters or cycling between replication counts could result in all peers being admitted larger than `2*replicas`. This restriction does not apply to consumers, they can be freely scaled within the stream's peer set.

This PR additionally fixes the JS lock being released and re-acquired before calling `jsa.configUpdateCheck`, and ensures legacy moves are translated to desired state properly and can be rolled back through the improved cancel move endpoint as well.

Follow-up of https://github.com/nats-io/nats-server/pull/8432