### PR TITLE
[FIXED] Filestore uncompressed block misread as compressed when first record length collides with 'cmp' magic

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -123,6 +123,18 @@ func (alg StoreCompression) String() string {
 	}
 }
 
+// compresses returns true for algorithms that actually compress the block
+// contents. We only ever write a compression metadata header for these, so this
+// also tells us whether a header we just read is one that we could have written.
+func (alg StoreCompression) compresses() bool {
+	switch alg {
+	case S2Compression:
+		return true
+	default:
+		return false
+	}
+}
+
 func (alg StoreCompression) MarshalJSON() ([]byte, error) {
 	var str string
 	switch alg {
@@ -7794,10 +7806,9 @@ func (mb *msgBlock) decompressIfNeeded(buf []byte) ([]byte, error) {
 		// compressed and return it as-is.
 		return buf, nil
 	} else {
-		// Metadata was present so it's quite likely the block contents
-		// are compressed. If by any chance the metadata claims that the
-		// block is uncompressed, then the input slice is just returned
-		// unmodified.
+		// Metadata was present, so the block contents are compressed. Note that
+		// UnmarshalMetadata never reports a header for NoCompression, so we can
+		// not strip metadata bytes off a block that was never compressed.
 		return meta.Algorithm.Decompress(buf[n:])
 	}
 }
@@ -13865,8 +13876,22 @@ func (c *CompressionInfo) UnmarshalMetadata(b []byte) (int, error) {
 	if b[0] != 'c' || b[1] != 'm' || b[2] != 'p' {
 		return 0, nil
 	}
+	// The magic is only three bytes long, so it can collide with the start of an
+	// uncompressed block. An uncompressed block starts with a message record and
+	// the first four bytes of that record hold the record length as a
+	// little-endian uint32, with hbit set when the message carries headers. A
+	// record length of 7368035 (0x706D63) therefore writes 'c', 'm' and 'p' into
+	// the first three bytes and leaves byte three holding 0 or hbit>>24 (0x80).
+	// Byte three has to name an algorithm that we could have written a header
+	// for, which means an algorithm that actually compresses. We never write a
+	// header for NoCompression, so anything else is a block that just happens to
+	// begin with the same three bytes and must be read as uncompressed.
+	alg := StoreCompression(b[3])
+	if !alg.compresses() {
+		return 0, nil
+	}
 	var n int
-	c.Algorithm = StoreCompression(b[3])
+	c.Algorithm = alg
 	c.OriginalSize, n = binary.Uvarint(b[4:])
 	if n <= 0 {
 		return 0, fmt.Errorf("metadata incomplete")

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -10799,6 +10799,117 @@ func TestFileStoreCompressionAfterTruncate(t *testing.T) {
 	}
 }
 
+func TestFileStoreUncompressedBlockLengthCollision(t *testing.T) {
+	// The first four bytes of a message record hold the record length as a
+	// little-endian uint32, with the high bit set when the message carries
+	// headers. A record length of 7368035 is 0x706D63, which little-endian puts
+	// 'c', 'm', 'p' into the first three bytes of the block. That is the same
+	// magic the compression metadata header uses, so an uncompressed block whose
+	// first record is exactly this long must still be read back as uncompressed.
+	const collidingRecordLen = 7368035
+
+	for _, test := range []struct {
+		title string
+		hdr   []byte
+	}{
+		// Byte three of the record length is 0x00, which reads as NoCompression.
+		{"NoHeaders", nil},
+		// Byte three of the record length is 0x80 (hbit), which reads as an
+		// unknown compression algorithm.
+		{"WithHeaders", []byte("NATS/1.0\r\nHdr: value\r\n\r\n")},
+	} {
+		t.Run(test.title, func(t *testing.T) {
+			testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
+				fcfg.BlockSize = 8 * 1024 * 1024 // Large enough to hold the record.
+				cfg := StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage}
+				fs, err := newFileStoreWithCreated(fcfg, cfg, time.Now(), prf(&fcfg), nil)
+				require_NoError(t, err)
+				defer fs.Stop()
+
+				subj, hdr := "foo", test.hdr
+				msg := bytes.Repeat([]byte("A"), collidingRecordLen-int(fileStoreMsgSize(subj, hdr, nil)))
+				require_Equal(t, fileStoreMsgSize(subj, hdr, msg), collidingRecordLen)
+
+				seq, _, err := fs.StoreMsg(subj, hdr, msg, 0)
+				require_NoError(t, err)
+				require_Equal(t, seq, 1)
+
+				var smv StoreMsg
+				sm, err := fs.LoadMsg(seq, &smv)
+				require_NoError(t, err)
+				require_True(t, bytes.Equal(sm.msg, msg))
+				require_True(t, bytes.Equal(sm.hdr, hdr))
+
+				require_NoError(t, fs.Stop())
+
+				// Confirm the block really does start with the colliding magic,
+				// otherwise this test proves nothing. Only the plaintext and
+				// uncompressed permutation stores the record verbatim at offset 0.
+				if fcfg.Cipher == NoCipher && fcfg.Compression == NoCompression {
+					blk, err := os.ReadFile(filepath.Join(fcfg.StoreDir, msgDir, fmt.Sprintf(blkScan, 1)))
+					require_NoError(t, err)
+					require_True(t, bytes.HasPrefix(blk, []byte("cmp")))
+				}
+
+				fs, err = newFileStoreWithCreated(fcfg, cfg, time.Now(), prf(&fcfg), nil)
+				require_NoError(t, err)
+				defer fs.Stop()
+
+				state := fs.State()
+				require_Equal(t, state.Msgs, 1)
+				require_Equal(t, state.FirstSeq, 1)
+				require_Equal(t, state.LastSeq, 1)
+
+				sm, err = fs.LoadMsg(seq, &smv)
+				require_NoError(t, err)
+				require_Equal(t, sm.subj, subj)
+				require_True(t, bytes.Equal(sm.hdr, hdr))
+				require_True(t, bytes.Equal(sm.msg, msg))
+
+				// The message must also stay removable after the restart.
+				removed, err := fs.RemoveMsg(seq)
+				require_NoError(t, err)
+				require_True(t, removed)
+			})
+		})
+	}
+}
+
+func TestCompressionInfoUnmarshalMetadataRecordLengthCollision(t *testing.T) {
+	// Build the start of an uncompressed block whose first record is exactly
+	// 7368035 bytes long, which is the length that collides with the 'cmp' magic.
+	recordStart := func(rl uint32) []byte {
+		b := make([]byte, 22)
+		binary.LittleEndian.PutUint32(b[0:], rl)
+		binary.LittleEndian.PutUint64(b[4:], 1)                          // Sequence.
+		binary.LittleEndian.PutUint64(b[12:], uint64(time.Now().Unix())) // Timestamp.
+		binary.LittleEndian.PutUint16(b[20:], 3)                         // Subject length.
+		return b
+	}
+
+	for _, test := range []struct {
+		title string
+		buf   []byte
+		n     int
+		alg   StoreCompression
+	}{
+		{"S2Header", (&CompressionInfo{Algorithm: S2Compression, OriginalSize: 12345}).MarshalMetadata(), 6, S2Compression},
+		{"NoMagic", recordStart(1024), 0, NoCompression},
+		{"CollidingLength", recordStart(7368035), 0, NoCompression},
+		{"CollidingLengthWithHeaders", recordStart(7368035 | hbit), 0, NoCompression},
+		{"UnknownAlgorithm", []byte{'c', 'm', 'p', 9, 1}, 0, NoCompression},
+		{"TooShort", []byte("cmp"), 0, NoCompression},
+	} {
+		t.Run(test.title, func(t *testing.T) {
+			var meta CompressionInfo
+			n, err := meta.UnmarshalMetadata(test.buf)
+			require_NoError(t, err)
+			require_Equal(t, n, test.n)
+			require_Equal(t, meta.Algorithm, test.alg)
+		})
+	}
+}
+
 func TestFileStoreTruncateRemovedBlock(t *testing.T) {
 	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
 		cfg := StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage}


### PR DESCRIPTION
# What breaks

A message whose file store record is exactly 7368035 bytes long becomes unreadable after a restart.

Store one message on subject `foo`, no headers, 7368002 byte payload. That is a record length of exactly 7368035. Stop the store. Open it again. The first `LoadMsg` returns `no message found`, `RemoveMsg` then returns `stream store EOF`, and the block file on disk drops from 7368035 bytes to 0 bytes. Stream state still reports 1 message and 7368035 bytes.

Same record length, but this time with headers so the header bit is set on the length. Every read fails with `compression algorithm not known`. The message can not be loaded and can not be removed. The block file stays intact in that case.

Both variants reproduce with compression off and with compression on, under every cipher.

# Root cause

`CompressionInfo.MarshalMetadata` writes a 3 byte magic `cmp` and puts the algorithm in byte 3. `UnmarshalMetadata` treats any buffer starting with those 3 bytes as a compressed block.

An uncompressed block starts with a message record. The first 4 bytes of that record are the record length, little endian uint32, with `hbit` set when the message carries headers. 7368035 is 0x706D63. Little endian that lays down 0x63 0x6D 0x70, which is `c`, `m`, `p`. Byte 3 is then the top byte of the record length, so 0x00 without headers and 0x80 with headers.

The magic guard passes on an uncompressed block, and byte 3 gets read as the algorithm:

- 0x00 reads as `NoCompression`. `UnmarshalMetadata` reports a header of n bytes, `decompressIfNeeded` calls `NoCompression.Decompress(buf[n:])`, and that returns the slice unchanged. The block silently loses its first 5 bytes. Every record after that is misaligned, and the block gets truncated to 0 bytes on the first read.
- 0x80 reads as an algorithm nobody knows, so `Decompress` fails outright.

Both call sites hit this, `recompressOnDiskIfNeeded` and `decompressIfNeeded`.

# The fix

Byte 3 has to name an algorithm that actually compresses. A metadata header is only ever written when the configured algorithm is not `NoCompression`, so `NoCompression` in byte 3 can not be a header this server wrote. Neither can 0x80, nor any other value we can not decompress.

`UnmarshalMetadata` now reports no header for those, and the block is read as uncompressed. I added `StoreCompression.compresses` for that check so a new algorithm only has to be added in one place.

I also corrected the comment on `decompressIfNeeded`. It claimed the input slice comes back unmodified when the metadata says the block is uncompressed. It did not. It stripped the metadata bytes. That is now impossible, since `UnmarshalMetadata` never reports a header for `NoCompression`.

No on-disk format change. Nothing new gets written.

# Known limitation

This closes every collision a default configuration can hit, but not every collision the format allows. A headerless record of exactly 24145763 bytes lays down `c`, `m`, `p`, 0x01, and 0x01 is `S2Compression`, which does compress. Hitting it needs `max_payload` raised above 23MB, far past the 1MB default. I looked at closing it by sniffing the S2 framing and decided against it: a zero length S2 body emits no magic at all, so the sniff can misjudge a genuinely compressed block and lose data, which is worse than the case it would fix. If you want that case handled too I would rather do it in a follow up with a plausibility check on the record length.

# Already written blocks

Compressed blocks: byte 3 is always `S2Compression`, the only algorithm that compresses. Parsing is unchanged, and the existing compression tests still pass.

Colliding blocks with headers: the server refused to read them and never rewrote them, so they are still intact on disk. This patch reads them back correctly.

Colliding blocks without headers: the block file was already truncated to 0 bytes by the first read after the restart. That data is gone, and no read side change brings it back. Stream state still counts the message. What this patch does is stop the truncation from happening at all.

An older server still reads anything written after this patch, since the bytes on disk do not change.

# Tests

`TestFileStoreUncompressedBlockLengthCollision` covers both variants across all 6 cipher and compression permutations, so 12 subtests. Each one stores the colliding record, checks the raw block really does start with `cmp`, stops the store, reopens it from disk, asserts `LoadMsg` returns the exact subject, headers and payload, and then removes the message.

On main all 12 fail. 6 with `no message found`, 6 with `compression algorithm not known`. With the fix all 12 pass.

`TestCompressionInfoUnmarshalMetadataRecordLengthCollision` pins the parser directly. A real S2 header still parses. Both colliding record lengths and an unknown algorithm byte report no header.

```
go test ./server -run 'TestFileStore.*Compress|TestFileStoreUncompressedBlockLengthCollision|TestCompressionInfo' -count=1
ok  	github.com/nats-io/nats-server/v2/server	7.860s
```

The 263 file store tests in the package are green too:

```
go test ./server -run 'TestFileStore|TestCompression|TestMsgBlock' -count=1
ok  	github.com/nats-io/nats-server/v2/server	758.372s
```

Resolves #8433
