### PR TITLE
[FIXED] Auth callout rejection reported as account connection limit

### DIFF
--- a/server/auth_callout_test.go
+++ b/server/auth_callout_test.go
@@ -3256,3 +3256,89 @@ func TestAuthCalloutOperatorModeMQTTOpaquePasswordUsesDefaultSentinel(t *testing
 	require_Equal(t, got.password, opaquePassword)
 	require_Equal(t, rc, mqttConnAckRCConnectionAccepted)
 }
+
+func TestAuthCalloutOperatorModeRejectionNotReportedAsAccountConnLimit(t *testing.T) {
+	_, spub := createKey(t)
+	sysClaim := jwt.NewAccountClaims(spub)
+	sysClaim.Name = "$SYS"
+	sysJwt, err := sysClaim.Encode(oKp)
+	require_NoError(t, err)
+
+	// TEST account, the account the callout would bind users to.
+	_, tpub := createKey(t)
+	accClaim := jwt.NewAccountClaims(tpub)
+	accClaim.Name = "TEST"
+	accJwt, err := accClaim.Encode(oKp)
+	require_NoError(t, err)
+
+	// AUTH service account.
+	akp, err := nkeys.FromSeed([]byte(authCalloutIssuerSeed))
+	require_NoError(t, err)
+	apub, err := akp.PublicKey()
+	require_NoError(t, err)
+
+	upub, svcCreds := createAuthServiceUser(t, akp)
+	defer removeFile(t, svcCreds)
+
+	authClaim := jwt.NewAccountClaims(apub)
+	authClaim.Name = "AUTH"
+	authClaim.EnableExternalAuthorization(upub)
+	authClaim.Authorization.AllowedAccounts.Add(tpub)
+	authJwt, err := authClaim.Encode(oKp)
+	require_NoError(t, err)
+
+	conf := fmt.Sprintf(`
+		listen: 127.0.0.1:-1
+		operator: %s
+		system_account: %s
+		resolver: MEM
+		resolver_preload: {
+			%s: %s
+			%s: %s
+			%s: %s
+		}
+    `, ojwt, spub, apub, authJwt, tpub, accJwt, spub, sysJwt)
+
+	// The callout service rejects every connection.
+	handler := func(m *nats.Msg) {
+		m.Respond(nil)
+	}
+
+	ac := NewAuthTest(t, conf, handler, nats.UserCredentials(svcCreds))
+	defer ac.Cleanup()
+
+	l := &captureErrorLogger{errCh: make(chan string, 10)}
+	ac.srv.SetLogger(l, false, false)
+
+	creds := createBasicAccountUser(t, akp)
+	defer removeFile(t, creds)
+
+	ac.RequireConnectError(nats.UserCredentials(creds))
+
+	// The callout rejected the user, so the server must report an
+	// authentication error and not the account connection limit.
+	var errs []string
+	for done := false; !done; {
+		select {
+		case e := <-l.errCh:
+			errs = append(errs, e)
+		case <-time.After(500 * time.Millisecond):
+			done = true
+		}
+	}
+	require_True(t, len(errs) > 0)
+	for _, e := range errs {
+		if strings.Contains(e, ErrTooManyAccountConnections.Error()) {
+			t.Fatalf("Auth callout rejection was reported as an account connection limit: %q", e)
+		}
+	}
+	var sawAuthErr bool
+	for _, e := range errs {
+		if strings.Contains(e, ErrAuthentication.Error()) {
+			sawAuthErr = true
+		}
+	}
+	if !sawAuthErr {
+		t.Fatalf("Expected an authentication error to be logged, got %q", errs)
+	}
+}

--- a/server/client.go
+++ b/server/client.go
@@ -847,6 +847,9 @@ func (c *client) RemoteAddress() net.Addr {
 // Helper function to report errors.
 func (c *client) reportErrRegisterAccount(acc *Account, err error) {
 	if err == ErrTooManyAccountConnections {
+		// Record the reason so that processConnect() can tell this apart from an
+		// authentication rejection, which has to be reported differently.
+		c.setAuthError(err)
 		c.maxAccountConnExceeded()
 		return
 	}
@@ -2337,7 +2340,6 @@ func (c *client) processConnect(arg []byte) error {
 	if srv != nil && srv.trustedKeys == nil {
 		c.opts.JWT = _EMPTY_
 	}
-	ujwt := c.opts.JWT
 
 	// For headers both client and server need to support.
 	c.headers = supportsHeaders && c.opts.Headers
@@ -2365,17 +2367,11 @@ func (c *client) processConnect(arg []byte) error {
 
 		// Check for Auth
 		if ok := srv.checkAuthentication(c); !ok {
-			// We may fail here because we reached max limits on an account.
-			if ujwt != _EMPTY_ {
-				c.mu.Lock()
-				acc := c.acc
-				c.mu.Unlock()
-				srv.mu.Lock()
-				tooManyAccCons := acc != nil && acc != srv.gacc
-				srv.mu.Unlock()
-				if tooManyAccCons {
-					return ErrTooManyAccountConnections
-				}
+			// We may fail here because we reached max limits on an account, in
+			// which case registerWithAccount() has already notified the client
+			// and closed the connection, so don't report an auth violation.
+			if c.getAuthError() == ErrTooManyAccountConnections {
+				return ErrTooManyAccountConnections
 			}
 			c.authViolation()
 			return ErrAuthentication

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -7913,3 +7913,62 @@ func TestJWTSystemAccountJetStreamDomainMapping(t *testing.T) {
 	_, err := nc.Request(domainAPI[:len(domainAPI)-1]+"INFO", nil, 2*time.Second)
 	require_NoError(t, err)
 }
+
+func TestJWTAccountMaxConnsStillReportedAsAccountLimit(t *testing.T) {
+	s := opTrustBasicSetup()
+	defer s.Shutdown()
+	buildMemAccResolver(s)
+
+	okp, _ := nkeys.FromSeed(oSeed)
+
+	fooKP, _ := nkeys.CreateAccount()
+	fooPub, _ := fooKP.PublicKey()
+	fooAC := jwt.NewAccountClaims(fooPub)
+	fooAC.Limits.Conn = 1
+	fooJWT, err := fooAC.Encode(okp)
+	require_NoError(t, err)
+	addAccountToMemResolver(s, fooPub, fooJWT)
+
+	c1, cr1, cs1 := createClient(t, s, fooKP)
+	defer c1.close()
+	c1.parseAsync(cs1)
+	l, _ := cr1.ReadString('\n')
+	if !strings.HasPrefix(l, "PONG") {
+		t.Fatalf("Expected PONG, got %q", l)
+	}
+
+	el := &captureErrorLogger{errCh: make(chan string, 10)}
+	s.SetLogger(el, false, false)
+
+	// This one exceeds the account connection limit.
+	c2, cr2, cs2 := createClient(t, s, fooKP)
+	defer c2.close()
+	c2.parseAsync(cs2)
+	l, _ = cr2.ReadString('\n')
+	if !strings.Contains(l, ErrTooManyAccountConnections.Error()) {
+		t.Fatalf("Expected the account connection limit error, got %q", l)
+	}
+
+	// The server must report the limit, not an authentication violation.
+	var errs []string
+	for done := false; !done; {
+		select {
+		case e := <-el.errCh:
+			errs = append(errs, e)
+		case <-time.After(500 * time.Millisecond):
+			done = true
+		}
+	}
+	var sawLimit bool
+	for _, e := range errs {
+		if strings.Contains(e, ErrAuthentication.Error()) {
+			t.Fatalf("Account connection limit was reported as an authentication error: %q", e)
+		}
+		if strings.Contains(e, ErrTooManyAccountConnections.Error()) {
+			sawLimit = true
+		}
+	}
+	if !sawLimit {
+		t.Fatalf("Expected the account connection limit to be logged, got %q", errs)
+	}
+}


### PR DESCRIPTION
Resolves #8441

## Problem

`processConnect()` guessed at *why* `checkAuthentication()` returned false: if the client presented a JWT and was already bound to a non-global account, it assumed the only possible cause was the account connection limit.

```go
if ujwt != _EMPTY_ {
    ...
    tooManyAccCons := acc != nil && acc != srv.gacc
    if tooManyAccCons {
        return ErrTooManyAccountConnections
    }
}
```

That heuristic predates auth callout. In operator mode it is wrong, because `processClientOrLeafAuthentication()` calls `RegisterNkeyUser()` — which binds the client to the callout account — *before* the callout service is ever invoked. By the time a callout rejects the token, `c.acc` is already the callout account, so the heuristic fires.

Two consequences, not just a bad log line:

1. Every auth callout rejection is logged as `maximum account active connections exceeded`, which sends operators looking at a connection limit that was never involved.
2. Because `processConnect()` returns early, the rejection never reaches `authViolation()`. So no auth error event is published, the client is never sent `-ERR 'Authorization Violation'`, and `readLoop` closes the connection as a `ProtocolViolation` instead of an `AuthenticationViolation`.

## Fix

The server already has the mechanism for this. `c.authErr` exists precisely because "the authentication stack is simply returning a boolean, and the only authentication error reported is the generic `ErrAuthentication`" — so instead of guessing, record the real reason where it is actually known.

`reportErrRegisterAccount()` is the single place that observes `ErrTooManyAccountConnections`, so it now calls `setAuthError()`, and `processConnect()` checks that instead of inferring from the account binding. This deletes the heuristic rather than special-casing around it.

The genuine limit case is unchanged. Every other authentication failure — auth callout rejection included — now correctly falls through to `authViolation()`.

Note one intentional behaviour change beyond callout: an nkey user in config mode that trips the account limit previously did not match the `ujwt != ""` guard and so was reported as an authorization violation. It is now reported as the connection limit, consistent with operator mode.

## Testing

Two regression tests, both verified to fail without the corresponding half of the fix:

- `TestAuthCalloutOperatorModeRejectionNotReportedAsAccountConnLimit` — operator mode with a callout service that rejects. Fails on `main` with:
  ```
  Auth callout rejection was reported as an account connection limit:
  "127.0.0.1:52337 - cid:7 - maximum account active connections exceeded"
  ```
- `TestJWTAccountMaxConnsStillReportedAsAccountLimit` — guards the other direction, that a real `Limits.Conn` breach is still reported as the account limit and not as an authentication error. Fails if `setAuthError()` is omitted.

Suites run locally on `main` + this change: `TestAuthCallout*`, `TestJWT*`, `TestAuth*`, `TestClient*`, `TestAccount*`, `TestOperatorMode*`, `TestLeafNode*`, `TestMQTT*`, `TestWS*` — all pass. (`TestLeafNodeSecondInfoBeforeConnectDoesNotPanic` flaked once with an i/o timeout under a large parallel run and passes consistently in isolation; it does not touch this code path.)
