### PR TITLE
(2.15) [ADDED] Peer evacuation and reconciliation of assignments

### DIFF
--- a/locksordering.txt
+++ b/locksordering.txt
@@ -6,6 +6,12 @@ jetStream -> jsAccount -> Server -> client -> Account
 
 jetStream -> jsAccount -> stream -> consumer
 
+The "prMu" lock protects the peer reconcile signaling state on jetStream, so
+signaling is cheap and never contends on the JS lock. It must not be held while
+acquiring the JetStream lock.
+
+  jetStream -> prMu
+
 A lock to protect jetstream account's usage has been introduced: jsAccount.usageMu.
 This lock is independent and can be invoked under any other lock: jsAccount -> jsa.usageMu, stream -> jsa.usageMu, etc...
 

--- a/server/consumer.go
+++ b/server/consumer.go
@@ -399,9 +399,9 @@ const (
 )
 
 // Calculate accurate replicas for the consumer config with the parent stream config.
-func (consCfg ConsumerConfig) replicas(strCfg *StreamConfig) int {
+func (consCfg *ConsumerConfig) replicas(strCfg *StreamConfig) int {
 	if consCfg.Replicas == 0 || consCfg.Replicas > strCfg.Replicas {
-		if !isDurableConsumer(&consCfg) && strCfg.Retention == LimitsPolicy && consCfg.Replicas == 0 {
+		if !isDurableConsumer(consCfg) && strCfg.Retention == LimitsPolicy && consCfg.Replicas == 0 {
 			// Matches old-school ephemerals only, where the replica count is 0.
 			return 1
 		}

--- a/server/events.go
+++ b/server/events.go
@@ -1773,7 +1773,7 @@ func (s *Server) remoteServerUpdate(sub *subscription, c *client, _ *Account, su
 
 	node := getHash(si.Name)
 	accountNRG := si.AccountNRG()
-	oldInfo, _ := s.nodeToInfo.Swap(node, nodeInfo{
+	newInfo := nodeInfo{
 		name:            si.Name,
 		version:         si.Version,
 		cluster:         si.Cluster,
@@ -1786,12 +1786,20 @@ func (s *Server) remoteServerUpdate(sub *subscription, c *client, _ *Account, su
 		js:              si.JetStreamEnabled(),
 		binarySnapshots: si.BinaryStreamSnapshot(),
 		accountNRG:      accountNRG,
-	})
+	}
+	oldInfo, _ := s.nodeToInfo.Swap(node, newInfo)
 	if oldInfo == nil || accountNRG != oldInfo.(nodeInfo).accountNRG {
 		// One of the servers we received statsz from changed its mind about
 		// whether or not it supports in-account NRG, so update the groups
 		// with this information.
 		s.updateNRGAccountStatus()
+	}
+
+	// Process a peer's statsz when it has sufficient information.
+	if newInfo.selectable() {
+		if js := s.getJetStream(); js != nil {
+			js.processPeerStatsz(node)
+		}
 	}
 }
 

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -127,6 +127,15 @@ type jetStream struct {
 	// System level request to purge a stream move
 	accountPurge *subscription
 
+	// Debounced reconcile of assignments for peers that became selectable.
+	// Has its own lock so signaling is cheap and never contends on the JS lock.
+	prMu    sync.Mutex
+	prPeers map[string]struct{}
+	// Meta peers that were just added but that we can't place on yet, because
+	// we have no STATSZ for them. Their first STATSZ moves them into prPeers.
+	prNewPeers map[string]struct{}
+	prRunning  bool
+
 	// Some bools regarding general state.
 	metaRecovering bool
 	standAlone     bool

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -174,6 +174,11 @@ const (
 	JSApiStreamRemovePeer  = "$JS.API.STREAM.PEER.REMOVE.*"
 	JSApiStreamRemovePeerT = "$JS.API.STREAM.PEER.REMOVE.%s"
 
+	// JSApiStreamEvacuatePeer is the endpoint to evacuate a peer from a clustered stream and its consumers.
+	// Will return JSON response.
+	JSApiStreamEvacuatePeer  = "$JS.API.STREAM.PEER.EVACUATE.*"
+	JSApiStreamEvacuatePeerT = "$JS.API.STREAM.PEER.EVACUATE.%s"
+
 	// JSApiStreamLeaderStepDown is the endpoint to have stream leader stepdown.
 	// Will return JSON response.
 	JSApiStreamLeaderStepDown  = "$JS.API.STREAM.LEADER.STEPDOWN.*"
@@ -193,6 +198,11 @@ const (
 	// Only works from system account.
 	// Will return JSON response.
 	JSApiRemoveServer = "$JS.API.SERVER.REMOVE"
+
+	// JSApiEvacuateServer is the endpoint to evacuate a peer server from the cluster.
+	// Only works from system account.
+	// Will return JSON response.
+	JSApiEvacuateServer = "$JS.API.SERVER.EVACUATE"
 
 	// JSApiMetaRescue is the endpoint to unsafely lower the meta group's quorum
 	// requirement on the surviving servers for disaster recovery.
@@ -837,6 +847,7 @@ func (js *jetStream) apiDispatch(sub *subscription, c *client, acc *Account, sub
 	// Ignore system level directives meta stepdown, peer remove and meta rescue requests here.
 	if subject == JSApiLeaderStepDown ||
 		subject == JSApiRemoveServer ||
+		subject == JSApiEvacuateServer ||
 		subject == JSApiMetaRescue ||
 		strings.HasPrefix(subject, jsAPIAccountPre) {
 		return
@@ -1019,6 +1030,7 @@ func (s *Server) setJetStreamExportSubs() error {
 		{JSApiStreamSnapshot, s.jsStreamSnapshotRequest},
 		{JSApiStreamRestore, s.jsStreamRestoreRequest},
 		{JSApiStreamRemovePeer, s.jsStreamRemovePeerRequest},
+		{JSApiStreamEvacuatePeer, s.jsStreamEvacuatePeerRequest},
 		{JSApiStreamLeaderStepDown, s.jsStreamLeaderStepDownRequest},
 		{JSApiConsumerLeaderStepDown, s.jsConsumerLeaderStepDownRequest},
 		{JSApiMsgDelete, s.jsMsgDeleteRequest},
@@ -2361,7 +2373,16 @@ func (s *Server) jsConsumerLeaderStepDownRequest(sub *subscription, c *client, _
 }
 
 // Request to remove a peer from a clustered stream.
-func (s *Server) jsStreamRemovePeerRequest(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+func (s *Server) jsStreamRemovePeerRequest(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+	s.jsStreamRemapPeerRequest(nil, c, nil, subject, reply, rmsg, true)
+}
+
+// Request to evacuate a peer from a clustered stream.
+func (s *Server) jsStreamEvacuatePeerRequest(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+	s.jsStreamRemapPeerRequest(nil, c, nil, subject, reply, rmsg, false)
+}
+
+func (s *Server) jsStreamRemapPeerRequest(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte, remove bool) {
 	if c == nil || !s.JetStreamEnabled() {
 		return
 	}
@@ -2441,18 +2462,20 @@ func (s *Server) jsStreamRemovePeerRequest(sub *subscription, c *client, _ *Acco
 		return
 	}
 
-	js.mu.RLock()
-	rg := sa.Group
+	js.mu.Lock()
+	defer js.mu.Unlock()
+	isGroupMember := func(peer string) bool {
+		return sa.Group.isMember(peer) || (sa.Group.Desired != nil && slices.Contains(sa.Group.Desired.Peers, peer))
+	}
 
 	// Check to see if we are a member of the group.
 	// Peer here is either a peer ID or a server name, convert to node name.
 	nodeName := getHash(req.Peer)
-	isMember := rg.isMember(nodeName)
+	isMember := isGroupMember(nodeName)
 	if !isMember {
 		nodeName = req.Peer
-		isMember = rg.isMember(nodeName)
+		isMember = isGroupMember(nodeName)
 	}
-	js.mu.RUnlock()
 
 	// Make sure we are a member.
 	if !isMember {
@@ -2462,7 +2485,7 @@ func (s *Server) jsStreamRemovePeerRequest(sub *subscription, c *client, _ *Acco
 	}
 
 	// If we are here we have a valid peer member set for removal.
-	if !js.removePeerFromStream(sa, nodeName) {
+	if !js.removePeerFromStreamLocked(sa, nodeName, remove) {
 		resp.Error = NewJSPeerRemapError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
@@ -2570,6 +2593,95 @@ func (s *Server) jsLeaderServerRemoveRequest(sub *subscription, c *client, _ *Ac
 	}
 	// Only copy the request, the subject and reply are already copied.
 	cc.peerRemoveReply[found] = peerRemoveInfo{ci: ci, subject: subject, reply: reply, request: string(msg)}
+}
+
+// Request to have the metaleader evacuate a peer from the system.
+func (s *Server) jsLeaderServerEvacuateRequest(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+	if c == nil || !s.JetStreamEnabled() {
+		return
+	}
+
+	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
+	if err != nil {
+		s.Warnf(badAPIRequestT, msg)
+		return
+	}
+	if acc != s.SystemAccount() {
+		return
+	}
+
+	js, cc := s.getJetStreamCluster()
+	if js == nil || cc == nil {
+		return
+	}
+
+	js.mu.RLock()
+	isLeader := cc.isLeader()
+	meta := cc.meta
+	js.mu.RUnlock()
+
+	// Extra checks here but only leader is listening.
+	if !isLeader {
+		return
+	}
+
+	var resp = JSApiMetaServerRemoveResponse{ApiResponse: ApiResponse{Type: JSApiMetaServerRemoveResponseType}}
+	if errorOnRequiredApiLevel(hdr) {
+		resp.Error = NewJSRequiredApiLevelError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+
+	if isEmptyRequest(msg) {
+		resp.Error = NewJSBadRequestError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+
+	var req JSApiMetaServerRemoveRequest
+	if err := s.unmarshalRequest(c, acc, subject, msg, &req); err != nil {
+		resp.Error = NewJSInvalidJSONError(err)
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+
+	js.mu.Lock()
+	defer js.mu.Unlock()
+
+	var found string
+	for _, p := range meta.Peers() {
+		// If Peer is specified, it takes precedence
+		if req.Peer != _EMPTY_ {
+			if p.ID == req.Peer {
+				found = req.Peer
+				break
+			}
+			continue
+		}
+		si, ok := s.nodeToInfo.Load(p.ID)
+		if ok && si.(nodeInfo).name == req.Server {
+			found = p.ID
+			break
+		}
+	}
+
+	if found == _EMPTY_ {
+		resp.Error = NewJSClusterServerNotMemberError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+
+	for _, sa := range js.streamAssignmentsOrInflightSeqAllAccounts() {
+		if sa.unsupported != nil {
+			continue
+		}
+		if sa.Group.isMember(found) || (sa.Group.Desired != nil && slices.Contains(sa.Group.Desired.Peers, found)) {
+			js.removePeerFromStreamLocked(sa, found, false)
+		}
+	}
+
+	resp.Success = true
+	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 }
 
 // jsMetaRescueRequest handles $JS.API.META.RESCUE requests. This is a broadcast

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2485,7 +2485,7 @@ func (s *Server) jsStreamRemapPeerRequest(_ *subscription, c *client, _ *Account
 	}
 
 	// If we are here we have a valid peer member set for removal.
-	if !js.removePeerFromStreamLocked(sa, nodeName, remove) {
+	if !js.removePeerFromStreamLocked(sa, nodeName, peerRemoval{remove: remove, requireReplicas: true}) {
 		resp.Error = NewJSPeerRemapError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
@@ -2676,7 +2676,7 @@ func (s *Server) jsLeaderServerEvacuateRequest(sub *subscription, c *client, _ *
 			continue
 		}
 		if sa.Group.isMember(found) || (sa.Group.Desired != nil && slices.Contains(sa.Group.Desired.Peers, found)) {
-			js.removePeerFromStreamLocked(sa, found, false)
+			js.removePeerFromStreamLocked(sa, found, peerRemoval{exclude: true})
 		}
 	}
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -183,6 +183,9 @@ type raftGroup struct {
 	Cluster   string      `json:"cluster,omitempty"`
 	Preferred string      `json:"preferred,omitempty"`
 	ScaleUp   bool        `json:"scale_up,omitempty"`
+	// Excluded peers are evacuated and can't be added to this group as part of the meta
+	// leader's reconciliation. Cleared when this group is at the configured replicas.
+	Excluded []string `json:"excluded,omitempty"`
 	// Desired holds the target placement while this group is being moved or
 	// scaled; it is nil when the group is stable.
 	Desired *desiredRaftGroup `json:"desired,omitempty"`
@@ -2745,6 +2748,7 @@ func (rg *raftGroup) copyGroup() *raftGroup {
 	}
 	cg := *rg
 	cg.Peers = copyStrings(rg.Peers)
+	cg.Excluded = copyStrings(rg.Excluded)
 	if rg.Desired != nil {
 		cd := *rg.Desired
 		cd.Peers = copyStrings(rg.Desired.Peers)
@@ -2760,69 +2764,174 @@ func (rg *raftGroup) copyGroup() *raftGroup {
 
 // Lock should be held.
 func (sa *streamAssignment) missingPeers() bool {
-	return len(sa.Group.Peers) < sa.Config.Replicas
+	targetPeers := sa.targetPeers()
+	return len(targetPeers) < sa.Config.Replicas
 }
 
-// Called when we detect a new peer. Only the leader will process checking
-// for any streams, and consequently any consumers.
-func (js *jetStream) processAddPeer(peer string) {
-	js.mu.Lock()
-	defer js.mu.Unlock()
+// The peer set this stream, and its consumers, must end up on.
+// Lock should be held.
+func (sa *streamAssignment) targetPeers() []string {
+	targetPeers := sa.Group.Peers
+	if sa.Group.Desired != nil {
+		// Peers are only known if not scaling down.
+		if !sa.Group.Desired.ScaleDown {
+			targetPeers = sa.Group.Desired.Peers
+		}
+	} else if len(targetPeers) > sa.Config.Replicas {
+		// If the stream is already moving, without desired state, the last N peers are the target.
+		targetPeers = targetPeers[len(targetPeers)-sa.Config.Replicas:]
+	}
+	return targetPeers
+}
 
-	s, cc := js.srv, js.cluster
-	if cc == nil || cc.meta == nil {
+// Returns the group's peers that are no longer part of the meta peer set.
+// Lock should be held.
+func (rg *raftGroup) stalePeers(metaPeers map[string]struct{}) []string {
+	var stale []string
+	for _, p := range rg.Peers {
+		if _, ok := metaPeers[p]; !ok {
+			stale = append(stale, p)
+		}
+	}
+	if rg.Desired != nil {
+		for _, p := range rg.Desired.Peers {
+			if _, ok := metaPeers[p]; !ok && !slices.Contains(stale, p) {
+				stale = append(stale, p)
+			}
+		}
+	}
+	return stale
+}
+
+// peerSelectable reports whether we've received STATSZ for this node.
+func (s *Server) peerSelectable(peer string) bool {
+	si, ok := s.nodeToInfo.Load(peer)
+	if !ok || si == nil {
+		return false
+	}
+	return si.(nodeInfo).selectable()
+}
+
+// Called when a peer is added to the meta group. Reconciling only makes sense
+// once we can actually place on it, so hold it until its first STATSZ arrives.
+func (js *jetStream) processAddPeer(peer string) {
+	// Only the meta leader reconciles, check the atomic so we don't need the JS lock.
+	if !js.srv.isMetaLeader.Load() {
 		return
 	}
-	isLeader := cc.isLeader()
+	js.prMu.Lock()
+	if js.prNewPeers == nil {
+		js.prNewPeers = make(map[string]struct{})
+	}
+	js.prNewPeers[peer] = struct{}{}
+	js.prMu.Unlock()
 
-	// Now check if we are meta-leader. We will check for any re-assignments.
+	// Must track before checking, or STATSZ landing in between would find nothing
+	// tracked while we'd go on waiting for a transition that already happened.
+	if js.srv.peerSelectable(peer) {
+		js.processPeerStatsz(peer)
+	}
+}
+
+// Called when we gain or lose meta leadership, to reset which peers we're still
+// waiting on.
+// Lock should be held.
+func (js *jetStream) seedNewPeers(isLeader bool) {
+	js.prMu.Lock()
+	defer js.prMu.Unlock()
+
+	// Anything we were waiting on is from a term we no longer own.
+	js.prNewPeers = nil
 	if !isLeader {
 		return
 	}
 
-	sir, ok := s.nodeToInfo.Load(peer)
-	if !ok || sir == nil {
+	cc := js.cluster
+	if cc == nil || cc.meta == nil {
 		return
 	}
-	si := sir.(nodeInfo)
-
-	for accName, sa := range js.streamAssignmentsOrInflightSeqAllAccounts() {
-		if sa.unsupported != nil {
+	s := js.srv
+	for _, p := range cc.meta.Peers() {
+		if s.peerSelectable(p.ID) {
 			continue
 		}
-		if sa.missingPeers() {
-			// Make sure the right cluster etc.
-			if si.cluster != sa.Client.Cluster {
-				continue
-			}
-			// If we are here we can add in this peer.
-			csa := sa.copyGroup()
-			csa.Group.Peers = append(csa.Group.Peers, peer)
-			// Keep the desired peer set in sync.
-			if d := csa.Group.Desired; d != nil {
-				d.ID = nuid.Next()
-				d.Peers = csa.Group.Peers
-				d.Preferred = _EMPTY_
-			}
-			// Send our proposal for this csa. Also use same group definition for all the consumers as well.
-			consumers, deleted, _ := js.remapConsumerAssignments(accName, csa)
-			if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(csa)); err != nil {
-				return
-			}
-			cc.trackInflightStreamProposal(accName, csa, false)
-			for _, cca := range consumers {
-				if err := cc.meta.Propose(cc.term, encodeAddConsumerAssignment(cca)); err != nil {
-					return
-				}
-				cc.trackInflightConsumerProposal(accName, csa.Config.Name, cca, false)
-			}
-			for _, ca := range deleted {
-				if err := cc.meta.Propose(cc.term, encodeDeleteConsumerAssignment(ca)); err != nil {
-					return
-				}
-				cc.trackInflightConsumerProposal(accName, csa.Config.Name, ca, true)
-			}
+		if js.prNewPeers == nil {
+			js.prNewPeers = make(map[string]struct{})
 		}
+		js.prNewPeers[p.ID] = struct{}{}
+	}
+}
+
+// Called on a STATSZ that makes a node selectable for placement. Only meta peers
+// that were just added are of interest, everything else either can't be placed
+// on or was already reconciled when it joined.
+func (js *jetStream) processPeerStatsz(peer string) {
+	// Only the meta leader reconciles, check the atomic so we don't need the JS lock.
+	if !js.srv.isMetaLeader.Load() {
+		return
+	}
+	js.prMu.Lock()
+	_, isNew := js.prNewPeers[peer]
+	delete(js.prNewPeers, peer)
+	js.prMu.Unlock()
+
+	if isNew {
+		js.signalPeerReconcile(peer)
+	}
+}
+
+// Signals that assignments should be reconciled for this peer.
+// Only the leader will process checking.
+func (js *jetStream) signalPeerReconcile(peer string) {
+	// Only the meta leader reconciles, check the atomic so we don't need the JS lock.
+	if !js.srv.isMetaLeader.Load() {
+		return
+	}
+	js.prMu.Lock()
+	defer js.prMu.Unlock()
+
+	if js.prPeers == nil {
+		js.prPeers = make(map[string]struct{})
+	}
+	js.prPeers[peer] = struct{}{}
+
+	// A sweep is already in flight, it will pick this peer up.
+	if js.prRunning {
+		return
+	}
+	// Don't hold up the caller, and don't propose under its locks.
+	js.prRunning = true
+	if !js.srv.startGoRoutine(js.runPeerReconcile) {
+		js.prRunning, js.prPeers = false, nil
+	}
+}
+
+// Reconciles assignments for all peers signaled through signalPeerReconcile,
+// until none are left pending. Runs on its own goroutine, one at a time.
+func (js *jetStream) runPeerReconcile() {
+	defer js.srv.grWG.Done()
+
+	for {
+		js.prMu.Lock()
+		peers := js.prPeers
+		js.prPeers = nil
+		// Stop once nothing is left pending. Clearing must happen under the same
+		// lock as the check, or a peer signaled right now would be dropped.
+		if len(peers) == 0 {
+			js.prRunning = false
+			js.prMu.Unlock()
+			return
+		}
+		js.prMu.Unlock()
+
+		js.mu.Lock()
+		cc := js.cluster
+		// Only reconcile if we're in a position to, drop these peers otherwise. We
+		// loop back around either way, so we always stop through the check above.
+		if cc != nil && cc.meta != nil && !js.metaRecovering && cc.isLeader() {
+			js.reconcilePeerAssignments(peers)
+		}
+		js.mu.Unlock()
 	}
 }
 
@@ -2831,6 +2940,11 @@ func (js *jetStream) processRemovePeer(peer string) {
 	if js == nil || js.disabled.Load() {
 		return
 	}
+
+	// It's leaving the meta group, so stop waiting for its first STATSZ.
+	js.prMu.Lock()
+	delete(js.prNewPeers, peer)
+	js.prMu.Unlock()
 
 	js.mu.Lock()
 	s, cc := js.srv, js.cluster
@@ -2874,33 +2988,56 @@ func (js *jetStream) processRemovePeer(peer string) {
 			continue
 		}
 		if sa.Group.isMember(peer) || (sa.Group.Desired != nil && slices.Contains(sa.Group.Desired.Peers, peer)) {
-			js.removePeerFromStreamLocked(sa, peer, true)
+			js.removePeerFromStreamLocked(sa, peer, peerRemoval{remove: true})
 		}
 	}
 }
 
+// peerRemoval controls how a peer is taken out of a stream's group.
+type peerRemoval struct {
+	// remove drops the peer right away, otherwise the group migrates off of it first.
+	remove bool
+	// requireReplicas rejects the removal when it would leave the group below its replica count.
+	requireReplicas bool
+	// exclude keeps the peer out of this group's placement until the group is healed.
+	// Set when evacuating a server, which stays in the meta peer set and would
+	// otherwise be a candidate to hand the stream straight back to.
+	exclude bool
+}
+
+// Removes or evacuates the given peer from the stream's group, and its consumers.
+// Reports whether the removal was applied.
 // Lock should be held.
-func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer string, remove bool) bool {
+func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer string, opts peerRemoval) bool {
 	cc := js.cluster
 	if cc == nil || cc.meta == nil {
 		return false
 	}
-	csa, replaced := cc.remapStreamAssignment(sa, peer, remove)
+	csa, replaced := cc.remapStreamAssignment(sa, peer, opts.remove)
 	if csa == nil {
 		return false
 	}
 	accName := sa.Client.serviceAccount()
+	// Reject if the group would miss replicas and all are required.
+	if opts.requireReplicas && csa.missingPeers() {
+		cc.s.Warnf("JetStream cluster rejected peer removal, no replacement available for stream '%s > %s'", accName, sa.Config.Name)
+		return false
+	}
 	if !replaced {
 		cc.s.Warnf("JetStream cluster could not replace peer for stream '%s > %s'", accName, sa.Config.Name)
 	}
+	// If the peer couldn't be replaced but we need to exclude, track it so it doesn't get readded.
+	if opts.exclude && csa.missingPeers() && !slices.Contains(csa.Group.Excluded, peer) {
+		csa.Group.Excluded = append(csa.Group.Excluded, peer)
+	}
 
 	// If we're evacuating a peer, consumer remapping can happen lazily.
-	if !remove {
+	if !opts.remove {
 		if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(csa)); err != nil {
 			return false
 		}
 		cc.trackInflightStreamProposal(accName, csa, false)
-		return replaced
+		return true
 	}
 
 	// Send our proposal for this csa. Also use same group definition for all the consumers as well.
@@ -2922,7 +3059,7 @@ func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer strin
 		}
 		cc.trackInflightConsumerProposal(accName, csa.Config.Name, ca, true)
 	}
-	return replaced
+	return true
 }
 
 // Check if we have peer related entries.
@@ -6843,6 +6980,11 @@ func (js *jetStream) consumerAssignmentOrInflight(account, stream, consumer stri
 // Will gather all consumer assignments for the specified account and stream, both applied and inflight assignments.
 // Lock should be held.
 func (js *jetStream) consumerAssignmentsOrInflightSeq(account, stream string) iter.Seq[*consumerAssignment] {
+	return js.consumerAssignmentsOrInflightSeqFor(account, stream, nil)
+}
+
+// Lock should be held.
+func (js *jetStream) consumerAssignmentsOrInflightSeqFor(account string, stream string, sa *streamAssignment) iter.Seq[*consumerAssignment] {
 	return func(yield func(*consumerAssignment) bool) {
 		cc := js.cluster
 		if cc == nil {
@@ -6858,9 +7000,10 @@ func (js *jetStream) consumerAssignmentsOrInflightSeq(account, stream string) it
 				return
 			}
 		}
-		sa := js.streamAssignment(account, stream)
 		if sa == nil {
-			return
+			if sa = js.streamAssignment(account, stream); sa == nil {
+				return
+			}
 		}
 		for _, ca := range sa.consumers {
 			// Skip if we already iterated over it as inflight.
@@ -8341,6 +8484,10 @@ func (rg *raftGroup) reconcileDesiredState(reconcile desiredAssignmentUpdate, re
 		ng.Cluster = ng.Desired.Cluster
 		ng.Preferred = _EMPTY_
 		ng.Desired = nil
+		// Clear exclusions if converged at the configured replica count.
+		if len(ng.Peers) >= replicas {
+			ng.Excluded = nil
+		}
 	} else {
 		// Skip if the peer set is unchanged.
 		slices.Sort(prevPeers)
@@ -8546,6 +8693,80 @@ func (js *jetStream) processLeaderChange(isLeader bool, term uint64) {
 		// Clear check.
 		cc.streamsCheck = false
 	}
+
+	// Reconcile assignments for missing or stale peers, for all peers.
+	js.seedNewPeers(isLeader)
+	if isLeader {
+		js.reconcilePeerAssignments(nil)
+	}
+}
+
+// Reconciles stream and consumer assignments with missing peers, or peers that have since
+// been removed from the meta peer set.
+// Lock should be held.
+func (js *jetStream) reconcilePeerAssignments(peers map[string]struct{}) {
+	cc := js.cluster
+	if cc == nil || cc.meta == nil {
+		return
+	}
+
+	// The meta peer set as we know it right now.
+	mp := cc.meta.Peers()
+	metaPeers := make(map[string]struct{}, len(mp))
+	for _, p := range mp {
+		metaPeers[p.ID] = struct{}{}
+	}
+
+	// If peers are specified, they're the only ones eligible for addition.
+	var ignore []string
+	if len(peers) > 0 {
+		var eligible bool
+		ignore = make([]string, 0, len(mp))
+		for _, p := range mp {
+			if _, ok := peers[p.ID]; ok {
+				eligible = true
+			} else {
+				ignore = append(ignore, p.ID)
+			}
+		}
+		// None of them have joined the meta group yet, for example when a statsz
+		// fires before the peer joins. Nothing to do.
+		if !eligible {
+			return
+		}
+	}
+
+	for accName, sa := range js.streamAssignmentsOrInflightSeqAllAccounts() {
+		if sa.unsupported != nil {
+			continue
+		}
+
+		// Remove any stale meta peers, and add missing.
+		if stale := sa.Group.stalePeers(metaPeers); len(stale) > 0 || sa.missingPeers() {
+			if nsa, _ := cc.reassignStreamPeers(sa, stale, true, sa.Config.Replicas, ignore...); nsa != nil {
+				sa = nsa
+				if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(sa)); err != nil {
+					return
+				}
+				cc.trackInflightStreamProposal(accName, nsa, false)
+			}
+		}
+
+		// Now do the same for consumers.
+		consumers, deleted, _ := js.remapConsumerAssignments(accName, sa)
+		for _, ca := range consumers {
+			if err := cc.meta.Propose(cc.term, encodeAddConsumerAssignment(ca)); err != nil {
+				return
+			}
+			cc.trackInflightConsumerProposal(accName, sa.Config.Name, ca, false)
+		}
+		for _, ca := range deleted {
+			if err := cc.meta.Propose(cc.term, encodeDeleteConsumerAssignment(ca)); err != nil {
+				return
+			}
+			cc.trackInflightConsumerProposal(accName, sa.Config.Name, ca, true)
+		}
+	}
 }
 
 // Lock should be held.
@@ -8553,7 +8774,15 @@ func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, peer str
 	if !sa.Group.isMember(peer) && (sa.Group.Desired == nil || !slices.Contains(sa.Group.Desired.Peers, peer)) {
 		return nil, false
 	}
+	return cc.reassignStreamPeers(sa, []string{peer}, remove, 0)
+}
 
+// Replaces the given peers in the group, growing it toward minReplicas if it's smaller.
+// If remove is set they're dropped right away, otherwise the group migrates off them.
+// Ignored peers are kept out of placement, but stay if already in the group.
+// Returns nil if the peer set is unchanged or empty, replaced if all peers got a replacement.
+// Lock should be held.
+func (cc *jetStreamCluster) reassignStreamPeers(sa *streamAssignment, peers []string, remove bool, minReplicas int, ignore ...string) (csa *streamAssignment, replaced bool) {
 	// If the group is already converging toward a desired peer set, that set is what
 	// actually drives membership, so base the replacement on it. Otherwise we'd hand back
 	// a peer set that the in-flight migration reconciles right back over.
@@ -8562,25 +8791,46 @@ func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, peer str
 		basePeers, baseCluster = d.Peers, d.Cluster
 	}
 
-	// Invoke placement algo passing RG peers that stay (existing) and the peer that is being removed (ignore)
-	retain, ignore := make([]string, 0, len(basePeers)), []string{peer}
+	// Invoke placement algo passing RG peers that stay (existing) and those being removed (ignore).
+	retain := make([]string, 0, len(basePeers))
 	for _, v := range basePeers {
-		if v != peer {
+		if !slices.Contains(peers, v) {
 			retain = append(retain, v)
 		}
 	}
-
-	removeFrom := func(peers []string) []string {
-		for i, p := range peers {
-			if p == peer {
-				peers[i] = peers[len(peers)-1]
-				return peers[:len(peers)-1]
+	// Peers taken away by an operator stay out of placement until the group is healed.
+	// Ones that have since left the meta peer set are dropped, placement only draws from
+	// that set, so they can't be selected anyway and there's no point preserving them.
+	var excluded []string
+	if len(sa.Group.Excluded) > 0 && cc.meta != nil {
+		mp := cc.meta.Peers()
+		metaPeers := make(map[string]struct{}, len(mp))
+		for _, p := range mp {
+			metaPeers[p.ID] = struct{}{}
+		}
+		for _, p := range sa.Group.Excluded {
+			if _, ok := metaPeers[p]; ok {
+				excluded = append(excluded, p)
 			}
 		}
-		return peers
 	}
-
-	newPeers, placementError := cc.selectPeerGroup(len(basePeers), baseCluster, sa.Config, retain, 0, ignore)
+	// selectPeerGroup folds skip into a set, so any overlap between these is harmless.
+	skip := peers
+	if len(ignore) > 0 || len(excluded) > 0 {
+		skip = slices.Concat(peers, ignore, excluded)
+	}
+	// Placement is all-or-nothing, so if we can't add every peer we're missing in one
+	// go, add as many as we can and heal the remainder on a later pass. Walking down
+	// from the target means the first success is the largest group we can form.
+	target := max(len(basePeers), minReplicas)
+	var newPeers []string
+	var placementError *selectPeerError
+	for r := target; ; r-- {
+		newPeers, placementError = cc.selectPeerGroup(r, baseCluster, sa.Config, retain, 0, skip)
+		if placementError == nil || r <= len(retain)+1 {
+			break
+		}
+	}
 
 	csa = sa.copyGroup()
 	csa.Group.Cluster = baseCluster
@@ -8588,13 +8838,16 @@ func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, peer str
 		csa.Group.Peers = newPeers
 		replaced = true
 	} else {
-		csa.Group.Peers = removeFrom(copyStrings(basePeers))
+		csa.Group.Peers = retain
 	}
 	csa.Group = sa.Group.withDesired(csa.Group)
 	// Preserve how the group is meant to converge.
 	if d := sa.Group.Desired; d != nil {
 		csa.Group.Desired.ScaleDown = d.ScaleDown
 		csa.Group.Desired.ScaleUp = d.ScaleUp
+	}
+	removeFrom := func(from []string) []string {
+		return slices.DeleteFunc(from, func(p string) bool { return slices.Contains(peers, p) })
 	}
 	if remove {
 		csa.Group.Peers = removeFrom(csa.Group.Peers)
@@ -8614,6 +8867,15 @@ func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, peer str
 	if len(csa.Group.Desired.Peers) == 0 {
 		return nil, false
 	}
+	// Preserve excluded peer set only if the group is still missing peers.
+	csa.Group.Excluded = excluded
+	if !csa.missingPeers() {
+		csa.Group.Excluded = nil
+	}
+	// Nothing actually changes, don't propose a no-op migration.
+	if slices.Equal(csa.Group.Peers, sa.Group.Peers) && slices.Equal(csa.Group.Desired.Peers, basePeers) {
+		return nil, false
+	}
 	// If no peers remain, immediately jump to desired set.
 	if len(csa.Group.Peers) == 0 {
 		csa.Group.Peers = csa.Group.Desired.Peers
@@ -8627,15 +8889,9 @@ func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, peer str
 // peer set.
 // Lock should be held.
 func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignment) (consumers, deleted []*consumerAssignment, done bool) {
-	targetPeers := sa.Group.Peers
-	if sa.Group.Desired != nil {
-		targetPeers = sa.Group.Desired.Peers
-	} else if len(targetPeers) > sa.Config.Replicas {
-		// If the stream is already moving, without desired state, the last N peers are the target.
-		targetPeers = targetPeers[len(targetPeers)-sa.Config.Replicas:]
-	}
+	targetPeers := sa.targetPeers()
 	done = true
-	for ca := range js.consumerAssignmentsOrInflightSeq(accName, sa.Config.Name) {
+	for ca := range js.consumerAssignmentsOrInflightSeqFor(accName, sa.Config.Name, sa) {
 		if ca.Config == nil || ca.unsupported != nil {
 			continue
 		}
@@ -8651,12 +8907,29 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 		if sa.Config.Retention != LimitsPolicy {
 			r = sa.Config.Replicas
 		}
-		// Drop peers that are no longer part of the stream. If moving, the tail MUST be the new peer set.
-		var newPeers []string
+		// Perform a quick check, without allocating, whether this consumer needs to be remapped.
 		kept := 0
 		for _, p := range consumerPeers {
 			if slices.Contains(targetPeers, p) {
 				kept++
+			}
+		}
+		// Backfill can only draw from the target peer set, so that bounds how far we can grow.
+		size := kept
+		if size < r {
+			size = min(r, max(kept, len(targetPeers)))
+		} else if size > r {
+			size = r
+		}
+		// Leave the consumer alone if its peer set is unaffected.
+		if kept == len(consumerPeers) && kept == size {
+			continue
+		}
+
+		// Drop peers that are no longer part of the stream. If moving, the tail MUST be the new peer set.
+		newPeers := make([]string, 0, max(kept, size))
+		for _, p := range consumerPeers {
+			if slices.Contains(targetPeers, p) {
 				newPeers = append(newPeers, p)
 			}
 		}
@@ -8674,10 +8947,6 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 			}
 		} else if len(newPeers) > r {
 			newPeers = newPeers[:r]
-		}
-		// Leave the consumer alone if its peer set is unaffected.
-		if kept == len(consumerPeers) && len(newPeers) == len(consumerPeers) {
-			continue
 		}
 		cca := ca.copyGroup()
 		// Adjust preferred as needed.
@@ -8967,7 +9236,7 @@ func (cc *jetStreamCluster) selectPeerGroup(r int, cluster string, cfg *StreamCo
 		}
 
 		// If we've never heard from a server, don't consider.
-		if ni.cfg == nil || ni.stats == nil {
+		if !ni.selectable() {
 			s.Debugf("Peer selection: discard %s@%s reason: offline", ni.name, ni.cluster)
 			err.offline = true
 			continue

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -78,6 +78,8 @@ type jetStreamCluster struct {
 	stepdown *subscription
 	// System level requests to remove a peer.
 	peerRemove *subscription
+	// System level requests to evacuate a peer.
+	peerEvacuate *subscription
 	// System level request to move a stream
 	peerStreamMove *subscription
 	// System level request to cancel a stream move
@@ -2803,7 +2805,7 @@ func (js *jetStream) processAddPeer(peer string) {
 				d.Preferred = _EMPTY_
 			}
 			// Send our proposal for this csa. Also use same group definition for all the consumers as well.
-			consumers, _, _ := js.remapConsumerAssignments(accName, csa, false)
+			consumers, deleted, _ := js.remapConsumerAssignments(accName, csa)
 			if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(csa)); err != nil {
 				return
 			}
@@ -2813,6 +2815,12 @@ func (js *jetStream) processAddPeer(peer string) {
 					return
 				}
 				cc.trackInflightConsumerProposal(accName, csa.Config.Name, cca, false)
+			}
+			for _, ca := range deleted {
+				if err := cc.meta.Propose(cc.term, encodeDeleteConsumerAssignment(ca)); err != nil {
+					return
+				}
+				cc.trackInflightConsumerProposal(accName, csa.Config.Name, ca, true)
 			}
 		}
 	}
@@ -2865,37 +2873,38 @@ func (js *jetStream) processRemovePeer(peer string) {
 		if sa.unsupported != nil {
 			continue
 		}
-		if rg := sa.Group; rg.isMember(peer) {
-			js.removePeerFromStreamLocked(sa, peer)
+		if sa.Group.isMember(peer) || (sa.Group.Desired != nil && slices.Contains(sa.Group.Desired.Peers, peer)) {
+			js.removePeerFromStreamLocked(sa, peer, true)
 		}
 	}
 }
 
-// Assumes all checks have already been done.
-func (js *jetStream) removePeerFromStream(sa *streamAssignment, peer string) bool {
-	js.mu.Lock()
-	defer js.mu.Unlock()
-	return js.removePeerFromStreamLocked(sa, peer)
-}
-
 // Lock should be held.
-func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer string) bool {
-	if rg := sa.Group; !rg.isMember(peer) {
-		return false
-	}
-
-	s, cc, csa := js.srv, js.cluster, sa.copyGroup()
+func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer string, remove bool) bool {
+	cc := js.cluster
 	if cc == nil || cc.meta == nil {
 		return false
 	}
-	replaced := cc.remapStreamAssignment(csa, peer)
+	csa, replaced := cc.remapStreamAssignment(sa, peer, remove)
+	if csa == nil {
+		return false
+	}
 	accName := sa.Client.serviceAccount()
 	if !replaced {
-		s.Warnf("JetStream cluster could not replace peer for stream '%s > %s'", accName, sa.Config.Name)
+		cc.s.Warnf("JetStream cluster could not replace peer for stream '%s > %s'", accName, sa.Config.Name)
+	}
+
+	// If we're evacuating a peer, consumer remapping can happen lazily.
+	if !remove {
+		if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(csa)); err != nil {
+			return false
+		}
+		cc.trackInflightStreamProposal(accName, csa, false)
+		return replaced
 	}
 
 	// Send our proposal for this csa. Also use same group definition for all the consumers as well.
-	consumers, deleted, _ := js.remapConsumerAssignments(accName, csa, true)
+	consumers, deleted, _ := js.remapConsumerAssignments(accName, csa)
 	if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(csa)); err != nil {
 		return false
 	}
@@ -4026,6 +4035,9 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 
 // Migrate a stream from peer set A to peer set B. Returns true when migration is done.
 func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n RaftNode, leaderTerm uint64) {
+	if leaderTerm == 0 {
+		return
+	}
 	ourPeerId, cc, s := n.ID(), js.cluster, js.srv
 
 	// FIXME(mvv): a move should make sure that peers are also upper-layer current
@@ -4044,6 +4056,11 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 		return
 	}
 	if sa == nil || sa.Group == nil {
+		js.mu.RUnlock()
+		return
+	}
+	// Sanity-check: we're still the leader.
+	if !n.Leader() {
 		js.mu.RUnlock()
 		return
 	}
@@ -4068,6 +4085,14 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 		return
 	}
 
+	// A snapshot is required. Automatically installs a snapshot for a R1 scaleup.
+	if n.NeedSnapshot() {
+		js.mu.RUnlock()
+		if err := mset.flushAllPending(); err == nil {
+			n.InstallSnapshot(mset.stateSnapshot(), true)
+		}
+		return
+	}
 	// If a membership change is in progress, we just wait for it to clear.
 	if n.MembershipChangeInProgress() {
 		js.mu.RUnlock()
@@ -7193,7 +7218,7 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 			}
 			// Reset to the slower fallback speed.
 			resetMigrationMonitoring(migrateFallbackCheckInterval)
-			js.runConsumerMigration(ca, n, leaderTerm)
+			js.runConsumerMigration(o, ca, n, leaderTerm)
 
 		case <-t.C:
 			// Start forcing snapshots if they failed previously.
@@ -7204,12 +7229,24 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 }
 
 // Migrate a consumer from peer set A to peer set B. Returns true when migration is done.
-func (js *jetStream) runConsumerMigration(ca *consumerAssignment, n RaftNode, leaderTerm uint64) {
+func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n RaftNode, leaderTerm uint64) {
+	if leaderTerm == 0 {
+		return
+	}
 	ourPeerId, cc, s := n.ID(), js.cluster, js.srv
 
 	js.mu.RLock()
 	// We are shutting down.
 	if cc == nil || cc.meta == nil {
+		js.mu.RUnlock()
+		return
+	}
+	if ca == nil || ca.Group == nil {
+		js.mu.RUnlock()
+		return
+	}
+	// Sanity-check: we're still the leader.
+	if !n.Leader() {
 		js.mu.RUnlock()
 		return
 	}
@@ -7242,6 +7279,14 @@ func (js *jetStream) runConsumerMigration(ca *consumerAssignment, n RaftNode, le
 		return
 	}
 
+	// A snapshot is required. Automatically installs a snapshot for a R1 scaleup.
+	if n.NeedSnapshot() {
+		js.mu.RUnlock()
+		if snap, err := o.store.EncodedState(); err == nil {
+			n.InstallSnapshot(snap, true)
+		}
+		return
+	}
 	// If a membership change is in progress, we just wait for it to clear.
 	if n.MembershipChangeInProgress() {
 		js.mu.RUnlock()
@@ -8091,6 +8136,7 @@ func (js *jetStream) reconcileDesiredStreamAssignment(_ *subscription, _ *client
 
 	// We stage consumer updates and do them after the stream update.
 	var consumers []*consumerAssignment
+	var deleted []*consumerAssignment
 
 	// If any consumers need to be remapped, we can't mark the stream's desired state done yet.
 	var done bool
@@ -8108,7 +8154,7 @@ func (js *jetStream) reconcileDesiredStreamAssignment(_ *subscription, _ *client
 	// we need to wait before we remap.
 	if !noDesired && !osa.Group.Desired.ScaleDown {
 		// Need to remap any consumers.
-		consumers, _, done = js.remapConsumerAssignments(reconcile.Account, osa, false)
+		consumers, deleted, done = js.remapConsumerAssignments(reconcile.Account, osa)
 	}
 
 	ng := osa.Group.reconcileDesiredState(reconcile.desiredAssignmentUpdate, osa.Config.Replicas, done)
@@ -8143,6 +8189,12 @@ func (js *jetStream) reconcileDesiredStreamAssignment(_ *subscription, _ *client
 			return
 		}
 		cc.trackInflightConsumerProposal(reconcile.Account, reconcile.Stream, ca, false)
+	}
+	for _, ca := range deleted {
+		if err := cc.meta.Propose(cc.term, encodeDeleteConsumerAssignment(ca)); err != nil {
+			return
+		}
+		cc.trackInflightConsumerProposal(reconcile.Account, reconcile.Stream, ca, true)
 	}
 }
 
@@ -8329,6 +8381,9 @@ func (js *jetStream) startUpdatesSub() {
 	if cc.peerRemove == nil {
 		cc.peerRemove, _ = s.systemSubscribe(JSApiRemoveServer, _EMPTY_, false, c, s.jsLeaderServerRemoveRequest)
 	}
+	if cc.peerEvacuate == nil {
+		cc.peerEvacuate, _ = s.systemSubscribe(JSApiEvacuateServer, _EMPTY_, false, c, s.jsLeaderServerEvacuateRequest)
+	}
 	if cc.peerStreamMove == nil {
 		cc.peerStreamMove, _ = s.systemSubscribe(JSApiServerStreamMove, _EMPTY_, false, c, s.jsLeaderServerStreamMoveRequest)
 	}
@@ -8366,6 +8421,10 @@ func (js *jetStream) stopUpdatesSub() {
 	if cc.peerRemove != nil {
 		cc.s.sysUnsubscribe(cc.peerRemove)
 		cc.peerRemove = nil
+	}
+	if cc.peerEvacuate != nil {
+		cc.s.sysUnsubscribe(cc.peerEvacuate)
+		cc.peerEvacuate = nil
 	}
 	if cc.peerStreamMove != nil {
 		cc.s.sysUnsubscribe(cc.peerStreamMove)
@@ -8490,7 +8549,11 @@ func (js *jetStream) processLeaderChange(isLeader bool, term uint64) {
 }
 
 // Lock should be held.
-func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, removePeer string) bool {
+func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, peer string, remove bool) (csa *streamAssignment, replaced bool) {
+	if !sa.Group.isMember(peer) && (sa.Group.Desired == nil || !slices.Contains(sa.Group.Desired.Peers, peer)) {
+		return nil, false
+	}
+
 	// If the group is already converging toward a desired peer set, that set is what
 	// actually drives membership, so base the replacement on it. Otherwise we'd hand back
 	// a peer set that the in-flight migration reconciles right back over.
@@ -8500,56 +8563,70 @@ func (cc *jetStreamCluster) remapStreamAssignment(sa *streamAssignment, removePe
 	}
 
 	// Invoke placement algo passing RG peers that stay (existing) and the peer that is being removed (ignore)
-	retain, ignore := make([]string, 0, len(basePeers)), []string{removePeer}
+	retain, ignore := make([]string, 0, len(basePeers)), []string{peer}
 	for _, v := range basePeers {
-		if v != removePeer {
+		if v != peer {
 			retain = append(retain, v)
 		}
 	}
 
-	newPeers, placementError := cc.selectPeerGroup(len(basePeers), baseCluster, sa.Config, retain, 0, ignore)
-
-	if placementError == nil {
-		sa.Group.Peers = newPeers
-		// Don't influence preferred leader.
-		sa.Group.Preferred = _EMPTY_
-		// Keep the desired peer set in sync, it must not retain the removed peer.
-		if d := sa.Group.Desired; d != nil {
-			d.ID = nuid.Next()
-			d.Peers = newPeers
-			d.Preferred = _EMPTY_
-		}
-		return true
-	}
-
-	// If R1 just return to avoid bricking the stream.
-	if sa.Group.node == nil || len(sa.Group.Peers) == 1 {
-		return false
-	}
-
-	// If we are here let's remove the peer at least, as long as we are R>1
 	removeFrom := func(peers []string) []string {
-		for i, peer := range peers {
-			if peer == removePeer {
+		for i, p := range peers {
+			if p == peer {
 				peers[i] = peers[len(peers)-1]
 				return peers[:len(peers)-1]
 			}
 		}
 		return peers
 	}
-	sa.Group.Peers = removeFrom(sa.Group.Peers)
-	if d := sa.Group.Desired; d != nil {
-		d.ID = nuid.Next()
-		d.Peers = removeFrom(d.Peers)
+
+	newPeers, placementError := cc.selectPeerGroup(len(basePeers), baseCluster, sa.Config, retain, 0, ignore)
+
+	csa = sa.copyGroup()
+	csa.Group.Cluster = baseCluster
+	if placementError == nil {
+		csa.Group.Peers = newPeers
+		replaced = true
+	} else {
+		csa.Group.Peers = removeFrom(copyStrings(basePeers))
 	}
-	return false
+	csa.Group = sa.Group.withDesired(csa.Group)
+	// Preserve how the group is meant to converge.
+	if d := sa.Group.Desired; d != nil {
+		csa.Group.Desired.ScaleDown = d.ScaleDown
+		csa.Group.Desired.ScaleUp = d.ScaleUp
+	}
+	if remove {
+		csa.Group.Peers = removeFrom(csa.Group.Peers)
+		csa.Group.Desired.Peers = removeFrom(csa.Group.Desired.Peers)
+	}
+	// Don't carry a stale preferred into the remaining group.
+	isMember := func(peer string) bool {
+		return slices.Contains(csa.Group.Peers, peer) || slices.Contains(csa.Group.Desired.Peers, peer)
+	}
+	if csa.Group.Preferred != _EMPTY_ && !isMember(csa.Group.Preferred) {
+		csa.Group.Preferred = _EMPTY_
+	}
+	if csa.Group.Desired.Preferred != _EMPTY_ && !isMember(csa.Group.Desired.Preferred) {
+		csa.Group.Desired.Preferred = _EMPTY_
+	}
+	// Don't allow moving to an empty set.
+	if len(csa.Group.Desired.Peers) == 0 {
+		return nil, false
+	}
+	// If no peers remain, immediately jump to desired set.
+	if len(csa.Group.Peers) == 0 {
+		csa.Group.Peers = csa.Group.Desired.Peers
+		csa.Group.Cluster = csa.Group.Desired.Cluster
+	}
+	return csa, replaced
 }
 
 // Remaps the stream's consumers onto its target peer set. Also reports if all consumers have
 // converged, meaning none need to be remapped and none are still moving toward their desired
 // peer set.
 // Lock should be held.
-func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignment, remove bool) (consumers, deleted []*consumerAssignment, done bool) {
+func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignment) (consumers, deleted []*consumerAssignment, done bool) {
 	targetPeers := sa.Group.Peers
 	if sa.Group.Desired != nil {
 		targetPeers = sa.Group.Desired.Peers
@@ -8582,11 +8659,6 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 				kept++
 				newPeers = append(newPeers, p)
 			}
-		}
-		// If an ephemeral lost all of its peers to removal, we delete it rather than move it.
-		if kept == 0 && remove && !isDurableConsumer(ca.Config) {
-			deleted = append(deleted, ca)
-			continue
 		}
 		// Backfill from the shuffled target set until the consumer has its desired number of target peers.
 		if len(newPeers) < r {
@@ -8629,17 +8701,30 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 			cca.Config = &cfg
 		}
 		// Only use desired state if the stream did as well.
-		// FIXME(mvv): improve peer-remove
 		if sa.Group.Desired != nil {
 			cca.Group = ca.Group.withDesired(cca.Group)
 			// Scaled down if we kept at least one peer, but removed others.
 			cca.Group.Desired.ScaleDown = kept > 0 && kept != len(consumerPeers)
 		}
+		// Drop any peers that are no longer part of the stream's peer set.
+		cca.Group.Peers = slices.DeleteFunc(cca.Group.Peers, func(peer string) bool {
+			return !slices.Contains(sa.Group.Peers, peer)
+		})
+		// If a consumer lost all of its peers to removal.
+		if len(cca.Group.Peers) == 0 {
+			// Delete it if ephemeral.
+			if !isDurableConsumer(ca.Config) {
+				deleted = append(deleted, ca)
+				continue
+			}
+			// Durable immediately jumps to the desired peers.
+			cca.Group.Peers = newPeers
+		}
 		// We can not propose here before the stream itself so we collect them.
 		consumers = append(consumers, cca)
 	}
 	// Any consumer we remap here still needs to move onto its new peer set.
-	done = done && len(consumers) == 0
+	done = done && len(consumers) == 0 && len(deleted) == 0
 	return consumers, deleted, done
 }
 

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -3723,6 +3723,492 @@ func TestJetStreamClusterPeerRemovalAndStreamReassignmentWithoutSpace(t *testing
 	streamCurrent(2)
 }
 
+// Helpers for the meta leader peer reconciliation tests below.
+func metaStreamPeers(s *Server, account, stream string) []string {
+	js := s.getJetStream()
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+	sa := js.streamAssignmentOrInflight(account, stream)
+	if sa == nil {
+		return nil
+	}
+	peers := copyStrings(sa.Group.Peers)
+	slices.Sort(peers)
+	return peers
+}
+
+func metaConsumerPeers(s *Server, account, stream, consumer string) []string {
+	js := s.getJetStream()
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+	ca := js.consumerAssignmentOrInflight(account, stream, consumer)
+	if ca == nil {
+		return nil
+	}
+	peers := copyStrings(ca.Group.Peers)
+	slices.Sort(peers)
+	return peers
+}
+
+// Evacuating a server out of an R3 stream can leave it with two peers, needing a new one
+// admitted. That's only done by whoever is meta leader at the time, so if there's none then
+// (or it can't see the peer yet) the stream stays under-replicated. Becoming meta leader
+// must reconcile it, without handing the stream back to the evacuated server.
+func TestJetStreamClusterPeerRemovalAndStreamReassignmentOnMetaLeaderChange(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R4S", 4)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomNonLeader())
+	defer nc.Close()
+
+	// The server scoped endpoint is system account only.
+	snc, _ := jsClientConnect(t, c.randomServer(), nats.UserInfo("admin", "s3cr3t!"))
+	defer snc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "dur",
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	ml := c.leader()
+	peers := metaStreamPeers(ml, globalAccountName, "TEST")
+	require_Len(t, len(peers), 3)
+
+	// The one server not hosting the stream, the only peer that can be admitted once the
+	// stream is left with missing peers. And a stream member we can peer-remove, must not
+	// be the meta leader so it stays able to propose.
+	var spare, member *Server
+	for _, s := range c.servers {
+		if !slices.Contains(peers, s.Node()) {
+			spare = s
+		} else if s != ml {
+			member = s
+		}
+	}
+	require_NotNil(t, spare)
+	require_NotNil(t, member)
+
+	// The spare must stay invisible to the meta leader until we say otherwise, so stop its
+	// statsz. Receiving one would both make it visible again and reconcile.
+	spare.mu.Lock()
+	if spare.sys != nil {
+		clearTimer(&spare.sys.stmr)
+	}
+	spare.mu.Unlock()
+
+	// Make the meta leader unaware of the spare server, as happens for real when a server
+	// just joined the meta group but its statsz hasn't arrived yet. Peer selection can't
+	// pick it then, and nothing retries.
+	sir, ok := ml.nodeToInfo.Load(spare.Node())
+	require_True(t, ok)
+	si := sir.(nodeInfo)
+	ml.nodeToInfo.Delete(spare.Node())
+
+	// Evacuate one of the stream's peers, no replacement can be selected for it. The
+	// server is going away, so this is applied even though the stream is left short.
+	jsreq, err := json.Marshal(&JSApiMetaServerRemoveRequest{Peer: member.Node()})
+	require_NoError(t, err)
+	rmsg, err := snc.Request(JSApiEvacuateServer, jsreq, 5*time.Second)
+	require_NoError(t, err)
+	var resp JSApiMetaServerRemoveResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
+	require_True(t, resp.Success)
+
+	// The stream, and its consumer, are now left with just two peers.
+	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+		if sp := metaStreamPeers(ml, globalAccountName, "TEST"); len(sp) != 2 {
+			return fmt.Errorf("expected 2 stream peers, got: %v", sp)
+		}
+		if cp := metaConsumerPeers(ml, globalAccountName, "TEST", "dur"); len(cp) != 2 {
+			return fmt.Errorf("expected 2 consumer peers, got: %v", cp)
+		}
+		return nil
+	})
+
+	// The spare server becomes visible to the meta leader again.
+	ml.nodeToInfo.Store(spare.Node(), si)
+
+	// Becoming meta leader must reconcile the assignments and admit a new peer.
+	require_NoError(t, ml.getJetStream().getMetaGroup().StepDown())
+
+	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+		nml := c.leader()
+		if nml == nil {
+			return errors.New("no meta leader")
+		}
+		sp := metaStreamPeers(nml, globalAccountName, "TEST")
+		if len(sp) != 3 {
+			return fmt.Errorf("expected 3 stream peers, got: %v", sp)
+		}
+		// The spare must have been admitted, not the peer we just evacuated.
+		if slices.Contains(sp, member.Node()) {
+			return fmt.Errorf("evacuated peer %q back in stream peers: %v", member.Node(), sp)
+		}
+		if !slices.Contains(sp, spare.Node()) {
+			return fmt.Errorf("spare peer %q not in stream peers: %v", spare.Node(), sp)
+		}
+		cp := metaConsumerPeers(nml, globalAccountName, "TEST", "dur")
+		if len(cp) != 3 {
+			return fmt.Errorf("expected 3 consumer peers, got: %v", cp)
+		}
+		if slices.Contains(cp, member.Node()) {
+			return fmt.Errorf("evacuated peer %q back in consumer peers: %v", member.Node(), cp)
+		}
+		for _, p := range cp {
+			if !slices.Contains(sp, p) {
+				return fmt.Errorf("consumer peers %v not hosted by stream peers %v", cp, sp)
+			}
+		}
+		return nil
+	})
+}
+
+// A stream left with missing peers, because there was nowhere to place a replacement, must
+// be reconciled once a server that can host one joins, without needing a meta leader change.
+// The peer that was deliberately evacuated must stay out of it.
+func TestJetStreamClusterPeerRemovalAndStreamReassignmentOnNewServer(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomNonLeader())
+	defer nc.Close()
+
+	// The server scoped endpoint is system account only.
+	snc, _ := jsClientConnect(t, c.randomServer(), nats.UserInfo("admin", "s3cr3t!"))
+	defer snc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "dur",
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	// Evacuate one of the stream's peers, must not be the meta leader so it stays able to
+	// propose. Every server hosts the stream, so no replacement can be selected. The server
+	// is going away, so this is applied even though the stream is left short.
+	ml := c.leader()
+	var member *Server
+	for _, s := range c.servers {
+		if s != ml {
+			member = s
+			break
+		}
+	}
+	require_NotNil(t, member)
+
+	jsreq, err := json.Marshal(&JSApiMetaServerRemoveRequest{Peer: member.Node()})
+	require_NoError(t, err)
+	rmsg, err := snc.Request(JSApiEvacuateServer, jsreq, 5*time.Second)
+	require_NoError(t, err)
+	var resp JSApiMetaServerRemoveResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
+	require_True(t, resp.Success)
+
+	// The stream, and its consumer, are now left with just two peers.
+	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+		if sp := metaStreamPeers(ml, globalAccountName, "TEST"); len(sp) != 2 {
+			return fmt.Errorf("expected 2 stream peers, got: %v", sp)
+		}
+		if cp := metaConsumerPeers(ml, globalAccountName, "TEST", "dur"); len(cp) != 2 {
+			return fmt.Errorf("expected 2 consumer peers, got: %v", cp)
+		}
+		return nil
+	})
+
+	// Adding a server must reconcile the assignments and admit it as the new peer. The peer
+	// we removed is eligible again for placement, but was taken out deliberately so it must
+	// not be handed the stream back.
+	ns := c.addInNewServer()
+	c.waitOnPeerCount(4)
+
+	checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
+		sp := metaStreamPeers(ml, globalAccountName, "TEST")
+		if len(sp) != 3 {
+			return fmt.Errorf("expected 3 stream peers, got: %v", sp)
+		}
+		if !slices.Contains(sp, ns.Node()) {
+			return fmt.Errorf("expected new server in stream peers, got: %v", sp)
+		}
+		if slices.Contains(sp, member.Node()) {
+			return fmt.Errorf("removed peer back in stream peers: %v", sp)
+		}
+		cp := metaConsumerPeers(ml, globalAccountName, "TEST", "dur")
+		if len(cp) != 3 {
+			return fmt.Errorf("expected 3 consumer peers, got: %v", cp)
+		}
+		for _, p := range cp {
+			if !slices.Contains(sp, p) {
+				return fmt.Errorf("consumer peers %v not hosted by stream peers %v", cp, sp)
+			}
+		}
+		return nil
+	})
+
+	// All without the meta leader having changed.
+	require_True(t, c.leader() == ml)
+
+	// The exclusion only exists to keep placement off the evacuated peer while the group
+	// is short. Now that it's healed it must be gone, the peer is not fenced off forever.
+	sjs := ml.getJetStream()
+	sjs.mu.RLock()
+	defer sjs.mu.RUnlock()
+	sa := sjs.streamAssignment(globalAccountName, "TEST")
+	require_NotNil(t, sa)
+	require_Len(t, len(sa.Group.Excluded), 0)
+}
+
+// The meta leader can change halfway through proposing the stream and consumer updates that
+// follow a peer removal. The stream update lands, the consumer updates don't, leaving the
+// consumer pointing at a peer that's gone. Becoming meta leader must reconcile it.
+func TestJetStreamClusterPeerRemovalAndConsumerReassignmentOnMetaLeaderChange(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R5S", 5)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomNonLeader())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "dur",
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	ml := c.leader()
+	peers := metaStreamPeers(ml, globalAccountName, "TEST")
+	require_Len(t, len(peers), 3)
+
+	// Pick a server that neither hosts the stream nor is the meta leader, and remove it from
+	// the meta group. The stream and its consumer are unaffected by that removal.
+	var gone *Server
+	for _, s := range c.servers {
+		if s != ml && !slices.Contains(peers, s.Node()) {
+			gone = s
+			break
+		}
+	}
+	require_NotNil(t, gone)
+	goneID := gone.Node()
+
+	snc, err := nats.Connect(ml.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer snc.Close()
+
+	jsreq, err := json.Marshal(&JSApiMetaServerRemoveRequest{Server: gone.Name()})
+	require_NoError(t, err)
+	rmsg, err := snc.Request(JSApiRemoveServer, jsreq, 5*time.Second)
+	require_NoError(t, err)
+	var resp JSApiMetaServerRemoveResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
+	require_True(t, resp.Error == nil)
+	c.waitOnPeerCount(4)
+
+	// Simulate the meta leader having proposed the stream update but losing leadership before
+	// the consumer updates: the consumer is left referencing the removed peer.
+	mjs := ml.getJetStream()
+	mjs.mu.Lock()
+	cc := mjs.cluster
+	oca := mjs.consumerAssignmentOrInflight(globalAccountName, "TEST", "dur")
+	cca := oca.copyGroup()
+	cca.Group.Peers = append(copyStrings(peers[:2]), goneID)
+	err = cc.meta.Propose(cc.term, encodeAddConsumerAssignment(cca))
+	mjs.mu.Unlock()
+	require_NoError(t, err)
+
+	// Nothing re-triggers reconciling the consumer, it stays pointing at the removed peer.
+	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+		if cp := metaConsumerPeers(ml, globalAccountName, "TEST", "dur"); !slices.Contains(cp, goneID) {
+			return fmt.Errorf("consumer peers %v no longer contain %q", cp, goneID)
+		}
+		return nil
+	})
+
+	// Becoming meta leader must reconcile the consumer back onto the stream's peer set.
+	require_NoError(t, mjs.getMetaGroup().StepDown())
+
+	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+		nml := c.leader()
+		if nml == nil {
+			return errors.New("no meta leader")
+		}
+		sp := metaStreamPeers(nml, globalAccountName, "TEST")
+		if len(sp) != 3 {
+			return fmt.Errorf("expected 3 stream peers, got: %v", sp)
+		}
+		cp := metaConsumerPeers(nml, globalAccountName, "TEST", "dur")
+		if len(cp) != 3 {
+			return fmt.Errorf("expected 3 consumer peers, got: %v", cp)
+		}
+		if slices.Contains(cp, goneID) {
+			return fmt.Errorf("consumer peers %v still contain removed peer %q", cp, goneID)
+		}
+		for _, p := range cp {
+			if !slices.Contains(sp, p) {
+				return fmt.Errorf("consumer peers %v not hosted by stream peers %v", cp, sp)
+			}
+		}
+		return nil
+	})
+}
+
+func TestJetStreamClusterReconcileOnlyForNewMetaPeers(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	ml := c.leader()
+	js := ml.getJetStream()
+	require_NotNil(t, js)
+
+	// Grab a peer we've already got STATSZ for, so it's selectable for placement.
+	var selectable string
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		js.mu.RLock()
+		cc := js.cluster
+		js.mu.RUnlock()
+		if cc == nil || cc.meta == nil {
+			return errors.New("no meta group yet")
+		}
+		for _, p := range cc.meta.Peers() {
+			if ml.peerSelectable(p.ID) {
+				selectable = p.ID
+				return nil
+			}
+		}
+		return errors.New("no selectable peer yet")
+	})
+
+	reset := func() {
+		t.Helper()
+		checkFor(t, 2*time.Second, 10*time.Millisecond, func() error {
+			js.prMu.Lock()
+			defer js.prMu.Unlock()
+			if js.prRunning {
+				return errors.New("peer reconcile still in flight")
+			}
+			js.prPeers, js.prNewPeers = nil, nil
+			return nil
+		})
+	}
+	signaled := func() bool {
+		js.prMu.Lock()
+		defer js.prMu.Unlock()
+		return js.prRunning || len(js.prPeers) > 0
+	}
+	tracked := func(peer string) bool {
+		js.prMu.Lock()
+		defer js.prMu.Unlock()
+		_, ok := js.prNewPeers[peer]
+		return ok
+	}
+	// Holds the JS lock, so a signaled sweep parks before doing any work, which keeps
+	// the signal itself observable.
+	locked := func(f func()) {
+		js.mu.Lock()
+		defer js.mu.Unlock()
+		f()
+	}
+
+	// Leaving the meta group before ever reporting in drops the tracking.
+	reset()
+	js.processAddPeer("PEER-GONE")
+	require_True(t, tracked("PEER-GONE"))
+	js.processRemovePeer("PEER-GONE")
+	require_False(t, tracked("PEER-GONE"))
+
+	// STATSZ for a node that was not just added to the meta group must not reconcile.
+	reset()
+	locked(func() {
+		js.processPeerStatsz("PEER-NOT-ADDED")
+		require_False(t, signaled())
+		// Not even for one we already know all about.
+		js.processPeerStatsz(selectable)
+		require_False(t, signaled())
+	})
+
+	// A new peer we can't place on yet is held until its first STATSZ.
+	reset()
+	locked(func() {
+		js.processAddPeer("PEER-NEW")
+		require_True(t, tracked("PEER-NEW"))
+		require_False(t, signaled())
+
+		// Which is what reconciles it.
+		js.processPeerStatsz("PEER-NEW")
+		require_False(t, tracked("PEER-NEW"))
+		require_True(t, signaled())
+	})
+
+	// Only that first one, it's not a newly added peer anymore.
+	reset()
+	locked(func() {
+		js.processPeerStatsz("PEER-NEW")
+		require_False(t, signaled())
+	})
+
+	// A peer we already have STATSZ for reconciles as soon as it joins, there is no
+	// transition to selectable left to wait for. Also covers STATSZ racing ahead of
+	// the peer being added to the meta group.
+	reset()
+	locked(func() {
+		js.processAddPeer(selectable)
+		require_False(t, tracked(selectable))
+		require_True(t, signaled())
+	})
+
+	// Every peer has reported in, so becoming leader leaves nothing to wait on.
+	reset()
+	locked(func() { js.seedNewPeers(true) })
+	require_False(t, tracked(selectable))
+
+	// A peer we have no STATSZ for, as if it had joined the meta group while we were
+	// still a follower and never got tracked. Seeding on leader change is what lets
+	// its first STATSZ reconcile the assignments the sweep could not place on it. A
+	// live peer keeps reporting in, so retry until we seed while it's unselectable.
+	si, ok := ml.nodeToInfo.Load(selectable)
+	require_True(t, ok)
+	defer ml.nodeToInfo.Store(selectable, si)
+	checkFor(t, 5*time.Second, 50*time.Millisecond, func() error {
+		ml.nodeToInfo.Store(selectable, nodeInfo{})
+		locked(func() { js.seedNewPeers(true) })
+		if !tracked(selectable) {
+			return fmt.Errorf("unselectable peer %q not tracked", selectable)
+		}
+		return nil
+	})
+	locked(func() {
+		js.processPeerStatsz(selectable)
+		require_False(t, tracked(selectable))
+		require_True(t, signaled())
+	})
+
+	// Losing leadership drops what we were waiting on, it's not ours to reconcile.
+	reset()
+	locked(func() {
+		js.processAddPeer("PEER-NEW")
+		require_True(t, tracked("PEER-NEW"))
+		js.seedNewPeers(false)
+		require_False(t, tracked("PEER-NEW"))
+	})
+}
+
 func TestJetStreamClusterPeerRemovalAndServerBroughtBack(t *testing.T) {
 	// Speed up for this test
 	peerRemoveTimeout = 2 * time.Second
@@ -3828,9 +4314,10 @@ func TestJetStreamClusterPeerRemoveAndEvacuateMatrix(t *testing.T) {
 			// stream's peer set to hand it to.
 			replaceable := test.replicas < clusterSize
 
-			// The stream scoped endpoint reports that it could not remap the peer
-			// when there is nowhere to move the stream to. The server scoped
-			// endpoint only reports on the peer itself, so it always succeeds.
+			// The stream scoped endpoint rejects the request when there is nowhere to
+			// move the stream to, leaving the peer set untouched. The server scoped
+			// endpoint is best effort and only reports on the peer itself, so it
+			// always succeeds.
 			opSuccess := test.serverScope || replaceable
 
 			// Removing the only peer of an R1 stream hands it to an empty
@@ -3845,11 +4332,12 @@ func TestJetStreamClusterPeerRemoveAndEvacuateMatrix(t *testing.T) {
 				metaPeersAfterOp--
 			}
 
-			// Without a replacement the stream is left one peer short until a new
-			// server shows up to backfill it. Either way it ends back on its
+			// A server scoped op without a replacement leaves the stream one peer short
+			// until a new server shows up to backfill it. A rejected stream scoped op
+			// leaves the peer set exactly as it was. Either way the stream ends on its
 			// configured replica count once a new server is added.
 			peersAfterOp := test.replicas
-			if !replaceable {
+			if opSuccess && !replaceable {
 				peersAfterOp--
 			}
 
@@ -3894,9 +4382,9 @@ func TestJetStreamClusterPeerRemoveAndEvacuateMatrix(t *testing.T) {
 			require_NotNil(t, ml)
 			require_NotEqual(t, ml, rs)
 
-			// Wait for the stream to settle on the expected number of peers, with the
-			// targeted peer no longer among them.
-			checkPeers := func(expected int) {
+			// Wait for the stream to settle on the expected number of peers. The targeted
+			// peer must be gone if the op was applied, and still there if it was rejected.
+			checkPeers := func(expected int, containsTarget bool) {
 				t.Helper()
 				checkFor(t, 30*time.Second, 250*time.Millisecond, func() error {
 					sjs := ml.getJetStream()
@@ -3912,8 +4400,8 @@ func TestJetStreamClusterPeerRemoveAndEvacuateMatrix(t *testing.T) {
 					if len(sa.Group.Peers) != expected {
 						return fmt.Errorf("expected %d peers, got %d", expected, len(sa.Group.Peers))
 					}
-					if slices.Contains(sa.Group.Peers, target) {
-						return fmt.Errorf("peer %q still in peer set %v", target, sa.Group.Peers)
+					if got := slices.Contains(sa.Group.Peers, target); got != containsTarget {
+						return fmt.Errorf("peer %q in peer set = %v, want %v (peers %v)", target, got, containsTarget, sa.Group.Peers)
 					}
 					return nil
 				})
@@ -3944,15 +4432,15 @@ func TestJetStreamClusterPeerRemoveAndEvacuateMatrix(t *testing.T) {
 				require_NoError(t, json.Unmarshal(msg.Data, &resp))
 				require_Equal(t, resp.Success, opSuccess)
 				if !opSuccess {
-					// There was nowhere to move the peer to, but it is still taken
-					// out of the stream.
+					// There was nowhere to move the peer to, so the request is rejected
+					// and the stream is left alone.
 					require_Error(t, resp.Error, NewJSPeerRemapError())
 				}
 			}
 
 			// A server remove also takes the peer out of the meta group.
 			c.waitOnPeerCount(metaPeersAfterOp)
-			checkPeers(peersAfterOp)
+			checkPeers(peersAfterOp, !opSuccess)
 
 			// A peer remove hands an R1 stream to an empty replacement, an evacuation
 			// migrates its data across first.
@@ -3976,7 +4464,7 @@ func TestJetStreamClusterPeerRemoveAndEvacuateMatrix(t *testing.T) {
 			// left alone.
 			ns := c.addInNewServer()
 			c.waitOnPeerCount(metaPeersAfterOp + 1)
-			checkPeers(test.replicas)
+			checkPeers(test.replicas, !opSuccess)
 
 			// The new server must have been taken on by a stream that was short of its
 			// replica count, and must have been left alone by one that was not.
@@ -3988,7 +4476,7 @@ func TestJetStreamClusterPeerRemoveAndEvacuateMatrix(t *testing.T) {
 				if sa == nil || sa.Group == nil {
 					return fmt.Errorf("stream not found")
 				}
-				got, want := slices.Contains(sa.Group.Peers, ns.Node()), test.replicas > 1
+				got, want := slices.Contains(sa.Group.Peers, ns.Node()), peersAfterOp < test.replicas
 				if got != want {
 					return fmt.Errorf("new server in peer set = %v, want %v (peers %v)", got, want, sa.Group.Peers)
 				}
@@ -4000,6 +4488,429 @@ func TestJetStreamClusterPeerRemoveAndEvacuateMatrix(t *testing.T) {
 			require_Equal(t, si.State.Msgs, expectedMsgs+1)
 		})
 	}
+}
+
+func TestJetStreamClusterStreamPeerRemoveNoReplacementIsRejected(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		evacuate bool
+	}{
+		{"Remove", false},
+		{"Evacuate", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// An R3 stream on a 3 node cluster has nowhere to hand a peer to.
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+
+			nc, js := jsClientConnect(t, c.randomServer())
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     "TEST",
+				Subjects: []string{"foo"},
+				Replicas: 3,
+			})
+			require_NoError(t, err)
+
+			ml := c.leader()
+			require_NotNil(t, ml)
+
+			sjs := ml.getJetStream()
+			sjs.mu.RLock()
+			sa := sjs.streamAssignment(globalAccountName, "TEST")
+			peers := append([]string(nil), sa.Group.Peers...)
+			sjs.mu.RUnlock()
+			require_Len(t, len(peers), 3)
+
+			rs := c.randomNonStreamLeader(globalAccountName, "TEST")
+			require_NotNil(t, rs)
+			target := rs.Node()
+
+			subjT := JSApiStreamRemovePeerT
+			if test.evacuate {
+				subjT = JSApiStreamEvacuatePeerT
+			}
+			b, err := json.Marshal(JSApiStreamRemovePeerRequest{Peer: target})
+			require_NoError(t, err)
+			msg, err := nc.Request(fmt.Sprintf(subjT, "TEST"), b, 10*time.Second)
+			require_NoError(t, err)
+			var resp JSApiStreamRemovePeerResponse
+			require_NoError(t, json.Unmarshal(msg.Data, &resp))
+
+			// The request must be rejected up front, rather than shortening the group
+			// and having a later reconcile add the peer straight back.
+			require_False(t, resp.Success)
+			require_Error(t, resp.Error, NewJSPeerRemapError())
+
+			checkPeers := func() {
+				t.Helper()
+				sjs := ml.getJetStream()
+				sjs.mu.RLock()
+				defer sjs.mu.RUnlock()
+				sa := sjs.streamAssignment(globalAccountName, "TEST")
+				require_NotNil(t, sa)
+				require_True(t, sa.Group.Desired == nil)
+				require_True(t, slices.Equal(sa.Group.Peers, peers))
+			}
+			checkPeers()
+
+			// A meta leader change runs reconcilePeerAssignments, which must find
+			// nothing to heal.
+			require_NoError(t, ml.getJetStream().getMetaGroup().StepDown())
+			c.waitOnLeader()
+			ml = c.leader()
+			require_NotNil(t, ml)
+
+			time.Sleep(500 * time.Millisecond)
+			checkPeers()
+
+			// The stream is untouched and still fully usable.
+			_, err = js.Publish("foo", []byte("HELLO"))
+			require_NoError(t, err)
+			si, err := js.StreamInfo("TEST")
+			require_NoError(t, err)
+			require_Equal(t, si.State.Msgs, 1)
+			require_Len(t, len(si.Cluster.Replicas), 2)
+		})
+	}
+}
+
+// A stream peer remove that would leave the group short is rejected even when the peer is
+// offline. Scaling the stream down is the way out, that drops offline peers first.
+func TestJetStreamClusterStreamPeerRemoveOfflinePeerIsRejected(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		evacuate bool
+	}{
+		{"Remove", false},
+		{"Evacuate", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// An R3 stream on a 3 node cluster has nowhere to hand a peer to.
+			c := createJetStreamClusterExplicit(t, "R3S", 3)
+			defer c.shutdown()
+
+			// Connect to the meta leader, it is the one server we know stays up below.
+			ml := c.leader()
+			require_NotNil(t, ml)
+			nc, js := jsClientConnect(t, ml)
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     "TEST",
+				Subjects: []string{"foo"},
+				Replicas: 3,
+			})
+			require_NoError(t, err)
+
+			// Take down a stream peer that is neither the meta nor the stream leader, so
+			// both layers stay able to make progress.
+			sl := c.streamLeader(globalAccountName, "TEST")
+			var member *Server
+			for _, s := range c.servers {
+				if s != ml && s != sl {
+					member = s
+					break
+				}
+			}
+			require_NotNil(t, member)
+			target := member.Node()
+			member.Shutdown()
+
+			// Wait for the meta leader to consider it offline, that's the state under test.
+			checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+				si, ok := ml.nodeToInfo.Load(target)
+				if !ok || si == nil || !si.(nodeInfo).offline {
+					return fmt.Errorf("peer %q not offline yet", target)
+				}
+				return nil
+			})
+
+			subjT := JSApiStreamRemovePeerT
+			if test.evacuate {
+				subjT = JSApiStreamEvacuatePeerT
+			}
+			b, err := json.Marshal(JSApiStreamRemovePeerRequest{Peer: target})
+			require_NoError(t, err)
+			msg, err := nc.Request(fmt.Sprintf(subjT, "TEST"), b, 10*time.Second)
+			require_NoError(t, err)
+			var resp JSApiStreamRemovePeerResponse
+			require_NoError(t, json.Unmarshal(msg.Data, &resp))
+			require_False(t, resp.Success)
+			require_Error(t, resp.Error, NewJSPeerRemapError())
+
+			// The peer set is untouched, offline peer and all.
+			sjs := ml.getJetStream()
+			sjs.mu.RLock()
+			sa := sjs.streamAssignmentOrInflight(globalAccountName, "TEST")
+			require_NotNil(t, sa)
+			require_Len(t, len(sa.Group.Peers), 3)
+			require_True(t, slices.Contains(sa.Group.Peers, target))
+			require_Len(t, len(sa.Group.Excluded), 0)
+			sjs.mu.RUnlock()
+
+			// Scaling down is the documented way out, and it takes the offline peer.
+			_, err = js.UpdateStream(&nats.StreamConfig{
+				Name:     "TEST",
+				Subjects: []string{"foo"},
+				Replicas: 2,
+			})
+			require_NoError(t, err)
+
+			checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+				sjs := ml.getJetStream()
+				sjs.mu.RLock()
+				defer sjs.mu.RUnlock()
+				sa := sjs.streamAssignment(globalAccountName, "TEST")
+				if sa == nil || sa.Group == nil {
+					return fmt.Errorf("stream not found")
+				}
+				if sa.Group.Desired != nil {
+					return fmt.Errorf("stream still converging")
+				}
+				if len(sa.Group.Peers) != 2 {
+					return fmt.Errorf("expected 2 peers, got %v", sa.Group.Peers)
+				}
+				if slices.Contains(sa.Group.Peers, target) {
+					return fmt.Errorf("offline peer %q still in peer set %v", target, sa.Group.Peers)
+				}
+				return nil
+			})
+		})
+	}
+}
+
+// An exclusion is not a reason to migrate on its own, so a stale one is left alone until
+// the group has some other reason to move, and is gone once the group is healed.
+func TestJetStreamClusterEvacuateExclusionNotClearedByNoOpMigration(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	// Connect to the meta leader, it is the one server we know stays put below.
+	ml := c.leader()
+	require_NotNil(t, ml)
+	nc, js := jsClientConnect(t, ml)
+	defer nc.Close()
+
+	// The server scoped endpoints are system account only.
+	snc, _ := jsClientConnect(t, ml, nats.UserInfo("admin", "s3cr3t!"))
+	defer snc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	// Evacuate a server other than the meta leader. With only three servers there is no
+	// replacement, so the stream is left short and the peer is excluded.
+	var member *Server
+	for _, s := range c.servers {
+		if s != ml {
+			member = s
+			break
+		}
+	}
+	require_NotNil(t, member)
+	target := member.Node()
+
+	b, err := json.Marshal(JSApiMetaServerRemoveRequest{Peer: target})
+	require_NoError(t, err)
+	msg, err := snc.Request(JSApiEvacuateServer, b, 10*time.Second)
+	require_NoError(t, err)
+	var resp JSApiMetaServerRemoveResponse
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_True(t, resp.Success)
+
+	excluded := func() []string {
+		t.Helper()
+		l := c.leader()
+		require_NotNil(t, l)
+		sjs := l.getJetStream()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		sa := sjs.streamAssignment(globalAccountName, "TEST")
+		require_NotNil(t, sa)
+		return copyStrings(sa.Group.Excluded)
+	}
+
+	// Wait for the evacuation to settle, so what follows can't race its migration.
+	checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+		l := c.leader()
+		if l == nil {
+			return errors.New("no meta leader")
+		}
+		sjs := l.getJetStream()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		sa := sjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group == nil {
+			return fmt.Errorf("stream not found")
+		}
+		if sa.Group.Desired != nil {
+			return fmt.Errorf("stream still converging")
+		}
+		if len(sa.Group.Peers) != 2 || slices.Contains(sa.Group.Peers, target) {
+			return fmt.Errorf("expected 2 peers without %q, got %v", target, sa.Group.Peers)
+		}
+		if !slices.Contains(sa.Group.Excluded, target) {
+			return fmt.Errorf("expected %q to be excluded, got %v", target, sa.Group.Excluded)
+		}
+		return nil
+	})
+
+	// Now take the same server out of the meta group, so the exclusion is dead weight,
+	// placement only ever draws from the meta peer set.
+	msg, err = snc.Request(JSApiRemoveServer, b, 10*time.Second)
+	require_NoError(t, err)
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_True(t, resp.Success)
+	c.waitOnPeerCount(2)
+
+	// Reconcile every assignment. Dropping the stale exclusion is not worth a migration
+	// of its own, so the group must be left exactly as it is.
+	require_NoError(t, c.leader().getJetStream().getMetaGroup().StepDown())
+	c.waitOnLeader()
+	time.Sleep(500 * time.Millisecond)
+	require_True(t, slices.Contains(excluded(), target))
+
+	// Adding a server gives the group a real reason to move. Now it heals to its replica
+	// count, and the exclusions go with it.
+	ns := c.addInNewServer()
+	c.waitOnPeerCount(3)
+
+	checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+		l := c.leader()
+		if l == nil {
+			return errors.New("no meta leader")
+		}
+		sjs := l.getJetStream()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		sa := sjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group == nil {
+			return fmt.Errorf("stream not found")
+		}
+		if len(sa.Group.Peers) != 3 {
+			return fmt.Errorf("expected 3 peers, got %v", sa.Group.Peers)
+		}
+		if !slices.Contains(sa.Group.Peers, ns.Node()) {
+			return fmt.Errorf("expected new server in peers, got %v", sa.Group.Peers)
+		}
+		if len(sa.Group.Excluded) != 0 {
+			return fmt.Errorf("expected exclusions cleared, got %v", sa.Group.Excluded)
+		}
+		return nil
+	})
+}
+
+// Lowering the replica count to match a short group heals it just as well as adding a peer
+// back, so the exclusions must not survive that convergence either. Otherwise the evacuated
+// peer stays ineligible and a later loss can fail to heal against available capacity.
+func TestJetStreamClusterEvacuateExclusionClearedByReplicaDecrease(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	// Connect to the meta leader, it is the one server we know stays put below.
+	ml := c.leader()
+	require_NotNil(t, ml)
+	nc, js := jsClientConnect(t, ml)
+	defer nc.Close()
+
+	// The server scoped endpoints are system account only.
+	snc, _ := jsClientConnect(t, ml, nats.UserInfo("admin", "s3cr3t!"))
+	defer snc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	// Evacuate a server other than the meta leader. With only three servers there is no
+	// replacement, so the stream is left short and the peer is excluded.
+	var member *Server
+	for _, s := range c.servers {
+		if s != ml {
+			member = s
+			break
+		}
+	}
+	require_NotNil(t, member)
+	target := member.Node()
+
+	b, err := json.Marshal(JSApiMetaServerRemoveRequest{Peer: target})
+	require_NoError(t, err)
+	msg, err := snc.Request(JSApiEvacuateServer, b, 10*time.Second)
+	require_NoError(t, err)
+	var resp JSApiMetaServerRemoveResponse
+	require_NoError(t, json.Unmarshal(msg.Data, &resp))
+	require_True(t, resp.Success)
+
+	// Wait for the evacuation to settle, so the update below can't race its migration.
+	checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+		l := c.leader()
+		if l == nil {
+			return errors.New("no meta leader")
+		}
+		sjs := l.getJetStream()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		sa := sjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group == nil {
+			return fmt.Errorf("stream not found")
+		}
+		if sa.Group.Desired != nil {
+			return fmt.Errorf("stream still converging")
+		}
+		if len(sa.Group.Peers) != 2 || slices.Contains(sa.Group.Peers, target) {
+			return fmt.Errorf("expected 2 peers without %q, got %v", target, sa.Group.Peers)
+		}
+		if !slices.Contains(sa.Group.Excluded, target) {
+			return fmt.Errorf("expected %q to be excluded, got %v", target, sa.Group.Excluded)
+		}
+		return nil
+	})
+
+	// The evacuated peer is still in the meta group, so it remains a placement candidate
+	// for as long as the exclusion is kept around.
+	c.waitOnPeerCount(3)
+
+	// Accept the group as it stands by lowering the replica count to the surviving peers.
+	// The group is no longer short, so the evacuation is fully accounted for.
+	_, err = js.UpdateStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 2,
+	})
+	require_NoError(t, err)
+
+	checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+		l := c.leader()
+		if l == nil {
+			return errors.New("no meta leader")
+		}
+		sjs := l.getJetStream()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		sa := sjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group == nil {
+			return fmt.Errorf("stream not found")
+		}
+		if sa.Group.Desired != nil {
+			return fmt.Errorf("stream still converging")
+		}
+		if len(sa.Group.Peers) != 2 || slices.Contains(sa.Group.Peers, target) {
+			return fmt.Errorf("expected 2 peers without %q, got %v", target, sa.Group.Peers)
+		}
+		if len(sa.Group.Excluded) != 0 {
+			return fmt.Errorf("expected exclusions cleared, got %v", sa.Group.Excluded)
+		}
+		return nil
+	})
 }
 
 func TestJetStreamClusterPeerRemoveAndEvacuateConsumersMatrix(t *testing.T) {
@@ -4035,15 +4946,14 @@ func TestJetStreamClusterPeerRemoveAndEvacuateConsumersMatrix(t *testing.T) {
 			// stream's peer set to hand it to.
 			replaceable := test.streamReplicas < clusterSize
 
-			// Without a replacement the stream is left one peer short.
+			// Without a replacement the request is rejected and nothing moves, so
+			// either way the stream keeps its replica count.
 			peersAfterOp := test.streamReplicas
-			if !replaceable {
-				peersAfterOp--
-			}
 
 			// A peer remove drops an ephemeral that loses its only peer, an
 			// evacuation migrates it across instead. Durables are always remapped.
-			consumerDeleted := !test.evacuate && test.ephemeral && test.consumerReplicas == 1
+			// A rejected request leaves the consumer alone.
+			consumerDeleted := replaceable && !test.evacuate && test.ephemeral && test.consumerReplicas == 1
 
 			// Each case gets its own stream so that the cases stay independent.
 			stream := fmt.Sprintf("TEST_%d", i)
@@ -4094,15 +5004,16 @@ func TestJetStreamClusterPeerRemoveAndEvacuateConsumersMatrix(t *testing.T) {
 			require_NoError(t, json.Unmarshal(msg.Data, &resp))
 			require_Equal(t, resp.Success, replaceable)
 			if !replaceable {
-				// There was nowhere to move the peer to, but it is still taken out
-				// of the stream.
+				// There was nowhere to move the peer to, so the request is rejected
+				// and the stream is left alone.
 				require_Error(t, resp.Error, NewJSPeerRemapError())
 			}
 
 			ml := c.leader()
 			require_NotNil(t, ml)
 
-			// The stream must settle without the targeted peer.
+			// The stream must settle without the targeted peer, unless the request
+			// was rejected, in which case the peer set must be untouched.
 			checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
 				sjs := ml.getJetStream()
 				sjs.mu.RLock()
@@ -4117,14 +5028,15 @@ func TestJetStreamClusterPeerRemoveAndEvacuateConsumersMatrix(t *testing.T) {
 				if len(sa.Group.Peers) != peersAfterOp {
 					return fmt.Errorf("expected %d peers, got %d", peersAfterOp, len(sa.Group.Peers))
 				}
-				if slices.Contains(sa.Group.Peers, target) {
-					return fmt.Errorf("peer %q still in peer set %v", target, sa.Group.Peers)
+				if got := slices.Contains(sa.Group.Peers, target); got != !replaceable {
+					return fmt.Errorf("peer %q in peer set = %v, want %v (peers %v)", target, got, !replaceable, sa.Group.Peers)
 				}
 				return nil
 			})
 
 			// The consumer either got dropped, or it moved off of the targeted peer
 			// onto as much of the stream's peer set as its own replica count asks for.
+			// A rejected request leaves it where it was.
 			expectedConsumerPeers := min(test.consumerReplicas, peersAfterOp)
 			checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
 				sjs := ml.getJetStream()
@@ -4146,8 +5058,8 @@ func TestJetStreamClusterPeerRemoveAndEvacuateConsumersMatrix(t *testing.T) {
 				if len(ca.Group.Peers) != expectedConsumerPeers {
 					return fmt.Errorf("expected %d consumer peers, got %v", expectedConsumerPeers, ca.Group.Peers)
 				}
-				if slices.Contains(ca.Group.Peers, target) {
-					return fmt.Errorf("peer %q still in consumer peer set %v", target, ca.Group.Peers)
+				if got := slices.Contains(ca.Group.Peers, target); got != !replaceable {
+					return fmt.Errorf("peer %q in consumer peer set = %v, want %v (peers %v)", target, got, !replaceable, ca.Group.Peers)
 				}
 				return nil
 			})
@@ -14339,8 +15251,8 @@ func TestJetStreamClusterStreamAddPeerConsumerRemap(t *testing.T) {
 	require_Len(t, len(ci.Cluster.Replicas), 0)
 	r1Peer := ci.Cluster.Leader
 
-	// Remove a stream peer that hosts neither the R1 durable nor the ephemeral. With only
-	// three servers there is no replacement, which leaves the stream with a missing peer.
+	// Evacuate a server hosting neither the R1 durable nor the ephemeral. With only three
+	// servers there is no replacement, which leaves the stream with a missing peer.
 	si, err := js.StreamInfo("TEST")
 	require_NoError(t, err)
 	peers := []string{si.Cluster.Leader}
@@ -14356,15 +15268,19 @@ func TestJetStreamClusterStreamAddPeerConsumerRemap(t *testing.T) {
 	}
 	require_NotEqual(t, toRemove, _EMPTY_)
 
-	b, err := json.Marshal(JSApiStreamRemovePeerRequest{Peer: toRemove})
+	// The server scoped endpoint is system account only.
+	snc, _ := jsClientConnect(t, c.randomServer(), nats.UserInfo("admin", "s3cr3t!"))
+	defer snc.Close()
+
+	b, err := json.Marshal(JSApiMetaServerRemoveRequest{Server: toRemove})
 	require_NoError(t, err)
-	msg, err := nc.Request(fmt.Sprintf(JSApiStreamRemovePeerT, "TEST"), b, time.Second)
+	msg, err := snc.Request(JSApiEvacuateServer, b, 5*time.Second)
 	require_NoError(t, err)
-	var resp JSApiStreamRemovePeerResponse
+	var resp JSApiMetaServerRemoveResponse
 	require_NoError(t, json.Unmarshal(msg.Data, &resp))
-	// The peer could not be replaced, but it is still removed from the stream.
-	require_False(t, resp.Success)
-	require_Error(t, resp.Error, NewJSPeerRemapError())
+	// The peer could not be replaced, but the server is going away so it is still
+	// taken out of the stream.
+	require_True(t, resp.Success)
 
 	checkStreamPeers := func(replicas int) {
 		t.Helper()

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -3806,6 +3806,368 @@ func TestJetStreamClusterPeerRemovalAndServerBroughtBack(t *testing.T) {
 	})
 }
 
+func TestJetStreamClusterPeerRemoveAndEvacuateMatrix(t *testing.T) {
+	const clusterSize = 3
+	for _, test := range []struct {
+		name        string
+		evacuate    bool
+		serverScope bool
+		replicas    int
+	}{
+		{"Remove/Stream/R1", false, false, 1},
+		{"Remove/Stream/R3", false, false, 3},
+		{"Remove/Server/R1", false, true, 1},
+		{"Remove/Server/R3", false, true, 3},
+		{"Evacuate/Stream/R1", true, false, 1},
+		{"Evacuate/Stream/R3", true, false, 3},
+		{"Evacuate/Server/R1", true, true, 1},
+		{"Evacuate/Server/R3", true, true, 3},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// A peer can only be replaced if there is a server outside of the
+			// stream's peer set to hand it to.
+			replaceable := test.replicas < clusterSize
+
+			// The stream scoped endpoint reports that it could not remap the peer
+			// when there is nowhere to move the stream to. The server scoped
+			// endpoint only reports on the peer itself, so it always succeeds.
+			opSuccess := test.serverScope || replaceable
+
+			// Removing the only peer of an R1 stream hands it to an empty
+			// replacement, discarding the data. An evacuation migrates the data
+			// across first.
+			retainsData := test.evacuate || test.replicas > 1
+
+			// A server remove takes the peer out of the meta group as well, an
+			// evacuation leaves it in.
+			metaPeersAfterOp := clusterSize
+			if test.serverScope && !test.evacuate {
+				metaPeersAfterOp--
+			}
+
+			// Without a replacement the stream is left one peer short until a new
+			// server shows up to backfill it. Either way it ends back on its
+			// configured replica count once a new server is added.
+			peersAfterOp := test.replicas
+			if !replaceable {
+				peersAfterOp--
+			}
+
+			c := createJetStreamClusterExplicit(t, "R3S", clusterSize)
+			defer c.shutdown()
+
+			nc, js := jsClientConnect(t, c.randomServer())
+			defer nc.Close()
+
+			// The meta stepdown and server scoped endpoints are system account only.
+			snc, _ := jsClientConnect(t, c.randomServer(), nats.UserInfo("admin", "s3cr3t!"))
+			defer snc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     "TEST",
+				Subjects: []string{"foo"},
+				Replicas: test.replicas,
+			})
+			require_NoError(t, err)
+
+			toSend := 10
+			for range toSend {
+				_, err = js.Publish("foo", nil)
+				require_NoError(t, err)
+			}
+
+			// Target a stream peer that is not the meta leader, so the meta layer
+			// stays put for the duration of the operation.
+			rs := c.randomNonStreamLeader(globalAccountName, "TEST")
+			if rs == nil {
+				rs = c.streamLeader(globalAccountName, "TEST")
+			}
+			require_NotNil(t, rs)
+			target := rs.Node()
+
+			ml := c.leader()
+			if ml == rs {
+				require_NoError(t, ml.getJetStream().getMetaGroup().StepDown())
+				c.waitOnLeader()
+				ml = c.leader()
+			}
+			require_NotNil(t, ml)
+			require_NotEqual(t, ml, rs)
+
+			// Wait for the stream to settle on the expected number of peers, with the
+			// targeted peer no longer among them.
+			checkPeers := func(expected int) {
+				t.Helper()
+				checkFor(t, 30*time.Second, 250*time.Millisecond, func() error {
+					sjs := ml.getJetStream()
+					sjs.mu.RLock()
+					defer sjs.mu.RUnlock()
+					sa := sjs.streamAssignment(globalAccountName, "TEST")
+					if sa == nil || sa.Group == nil {
+						return fmt.Errorf("stream not found")
+					}
+					if sa.Group.Desired != nil {
+						return fmt.Errorf("stream still converging")
+					}
+					if len(sa.Group.Peers) != expected {
+						return fmt.Errorf("expected %d peers, got %d", expected, len(sa.Group.Peers))
+					}
+					if slices.Contains(sa.Group.Peers, target) {
+						return fmt.Errorf("peer %q still in peer set %v", target, sa.Group.Peers)
+					}
+					return nil
+				})
+			}
+
+			if test.serverScope {
+				subj := JSApiRemoveServer
+				if test.evacuate {
+					subj = JSApiEvacuateServer
+				}
+				b, err := json.Marshal(JSApiMetaServerRemoveRequest{Peer: target})
+				require_NoError(t, err)
+				msg, err := snc.Request(subj, b, 10*time.Second)
+				require_NoError(t, err)
+				var resp JSApiMetaServerRemoveResponse
+				require_NoError(t, json.Unmarshal(msg.Data, &resp))
+				require_Equal(t, resp.Success, opSuccess)
+			} else {
+				subjT := JSApiStreamRemovePeerT
+				if test.evacuate {
+					subjT = JSApiStreamEvacuatePeerT
+				}
+				b, err := json.Marshal(JSApiStreamRemovePeerRequest{Peer: target})
+				require_NoError(t, err)
+				msg, err := nc.Request(fmt.Sprintf(subjT, "TEST"), b, 10*time.Second)
+				require_NoError(t, err)
+				var resp JSApiStreamRemovePeerResponse
+				require_NoError(t, json.Unmarshal(msg.Data, &resp))
+				require_Equal(t, resp.Success, opSuccess)
+				if !opSuccess {
+					// There was nowhere to move the peer to, but it is still taken
+					// out of the stream.
+					require_Error(t, resp.Error, NewJSPeerRemapError())
+				}
+			}
+
+			// A server remove also takes the peer out of the meta group.
+			c.waitOnPeerCount(metaPeersAfterOp)
+			checkPeers(peersAfterOp)
+
+			// A peer remove hands an R1 stream to an empty replacement, an evacuation
+			// migrates its data across first.
+			expectedMsgs := uint64(toSend)
+			if !retainsData {
+				expectedMsgs = 0
+			}
+			si, err := js.StreamInfo("TEST")
+			require_NoError(t, err)
+			require_Equal(t, si.State.Msgs, expectedMsgs)
+
+			// Whatever happened, the stream must still be writable.
+			_, err = js.Publish("foo", []byte("HELLO"))
+			require_NoError(t, err)
+			si, err = js.StreamInfo("TEST")
+			require_NoError(t, err)
+			require_Equal(t, si.State.Msgs, expectedMsgs+1)
+
+			// Now add capacity back. A stream that is short of its replica count must
+			// take the new server on, one that is already at its replica count must be
+			// left alone.
+			ns := c.addInNewServer()
+			c.waitOnPeerCount(metaPeersAfterOp + 1)
+			checkPeers(test.replicas)
+
+			// The new server must have been taken on by a stream that was short of its
+			// replica count, and must have been left alone by one that was not.
+			checkFor(t, 2*time.Second, 250*time.Millisecond, func() error {
+				sjs := ml.getJetStream()
+				sjs.mu.RLock()
+				defer sjs.mu.RUnlock()
+				sa := sjs.streamAssignment(globalAccountName, "TEST")
+				if sa == nil || sa.Group == nil {
+					return fmt.Errorf("stream not found")
+				}
+				got, want := slices.Contains(sa.Group.Peers, ns.Node()), test.replicas > 1
+				if got != want {
+					return fmt.Errorf("new server in peer set = %v, want %v (peers %v)", got, want, sa.Group.Peers)
+				}
+				return nil
+			})
+
+			si, err = js.StreamInfo("TEST")
+			require_NoError(t, err)
+			require_Equal(t, si.State.Msgs, expectedMsgs+1)
+		})
+	}
+}
+
+func TestJetStreamClusterPeerRemoveAndEvacuateConsumersMatrix(t *testing.T) {
+	const clusterSize = 3
+	c := createJetStreamClusterExplicit(t, "R3S", clusterSize)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	for i, test := range []struct {
+		name             string
+		evacuate         bool
+		streamReplicas   int
+		consumerReplicas int
+		ephemeral        bool
+	}{
+		{"Remove/StreamR1/DurableR1", false, 1, 1, false},
+		{"Remove/StreamR1/EphemeralR1", false, 1, 1, true},
+		{"Remove/StreamR3/DurableR1", false, 3, 1, false},
+		{"Remove/StreamR3/EphemeralR1", false, 3, 1, true},
+		{"Remove/StreamR3/DurableR3", false, 3, 3, false},
+		{"Remove/StreamR3/EphemeralR3", false, 3, 3, true},
+		{"Evacuate/StreamR1/DurableR1", true, 1, 1, false},
+		{"Evacuate/StreamR1/EphemeralR1", true, 1, 1, true},
+		{"Evacuate/StreamR3/DurableR1", true, 3, 1, false},
+		{"Evacuate/StreamR3/EphemeralR1", true, 3, 1, true},
+		{"Evacuate/StreamR3/DurableR3", true, 3, 3, false},
+		{"Evacuate/StreamR3/EphemeralR3", true, 3, 3, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// A peer can only be replaced if there is a server outside of the
+			// stream's peer set to hand it to.
+			replaceable := test.streamReplicas < clusterSize
+
+			// Without a replacement the stream is left one peer short.
+			peersAfterOp := test.streamReplicas
+			if !replaceable {
+				peersAfterOp--
+			}
+
+			// A peer remove drops an ephemeral that loses its only peer, an
+			// evacuation migrates it across instead. Durables are always remapped.
+			consumerDeleted := !test.evacuate && test.ephemeral && test.consumerReplicas == 1
+
+			// Each case gets its own stream so that the cases stay independent.
+			stream := fmt.Sprintf("TEST_%d", i)
+			subject := fmt.Sprintf("foo.%d", i)
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     stream,
+				Subjects: []string{subject},
+				Replicas: test.streamReplicas,
+			})
+			require_NoError(t, err)
+
+			ccfg := &nats.ConsumerConfig{
+				AckPolicy:         nats.AckExplicitPolicy,
+				Replicas:          test.consumerReplicas,
+				InactiveThreshold: time.Hour,
+			}
+			if !test.ephemeral {
+				ccfg.Durable = "CONSUMER"
+			}
+			cinfo, err := js.AddConsumer(stream, ccfg)
+			require_NoError(t, err)
+			consumer := cinfo.Name
+
+			// Target a peer that hosts the consumer, so that every case actually
+			// exercises the consumer being taken off of the targeted peer. A
+			// replicated consumer sits on every stream peer, so any of them will do.
+			var rs *Server
+			if test.consumerReplicas == 1 {
+				rs = c.consumerLeader(globalAccountName, stream, consumer)
+			} else {
+				rs = c.randomNonStreamLeader(globalAccountName, stream)
+				if rs == nil {
+					rs = c.streamLeader(globalAccountName, stream)
+				}
+			}
+			require_NotNil(t, rs)
+			target := rs.Node()
+
+			subjT := JSApiStreamRemovePeerT
+			if test.evacuate {
+				subjT = JSApiStreamEvacuatePeerT
+			}
+			b, err := json.Marshal(JSApiStreamRemovePeerRequest{Peer: target})
+			require_NoError(t, err)
+			msg, err := nc.Request(fmt.Sprintf(subjT, stream), b, 10*time.Second)
+			require_NoError(t, err)
+			var resp JSApiStreamRemovePeerResponse
+			require_NoError(t, json.Unmarshal(msg.Data, &resp))
+			require_Equal(t, resp.Success, replaceable)
+			if !replaceable {
+				// There was nowhere to move the peer to, but it is still taken out
+				// of the stream.
+				require_Error(t, resp.Error, NewJSPeerRemapError())
+			}
+
+			ml := c.leader()
+			require_NotNil(t, ml)
+
+			// The stream must settle without the targeted peer.
+			checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+				sjs := ml.getJetStream()
+				sjs.mu.RLock()
+				defer sjs.mu.RUnlock()
+				sa := sjs.streamAssignment(globalAccountName, stream)
+				if sa == nil || sa.Group == nil {
+					return fmt.Errorf("stream not found")
+				}
+				if sa.Group.Desired != nil {
+					return fmt.Errorf("stream still converging")
+				}
+				if len(sa.Group.Peers) != peersAfterOp {
+					return fmt.Errorf("expected %d peers, got %d", peersAfterOp, len(sa.Group.Peers))
+				}
+				if slices.Contains(sa.Group.Peers, target) {
+					return fmt.Errorf("peer %q still in peer set %v", target, sa.Group.Peers)
+				}
+				return nil
+			})
+
+			// The consumer either got dropped, or it moved off of the targeted peer
+			// onto as much of the stream's peer set as its own replica count asks for.
+			expectedConsumerPeers := min(test.consumerReplicas, peersAfterOp)
+			checkFor(t, 5*time.Second, 250*time.Millisecond, func() error {
+				sjs := ml.getJetStream()
+				sjs.mu.RLock()
+				defer sjs.mu.RUnlock()
+				ca := sjs.consumerAssignment(globalAccountName, stream, consumer)
+				if consumerDeleted {
+					if ca != nil {
+						return fmt.Errorf("consumer still assigned to %v", ca.Group.Peers)
+					}
+					return nil
+				}
+				if ca == nil || ca.Group == nil {
+					return fmt.Errorf("consumer not found")
+				}
+				if ca.Group.Desired != nil {
+					return fmt.Errorf("consumer still converging")
+				}
+				if len(ca.Group.Peers) != expectedConsumerPeers {
+					return fmt.Errorf("expected %d consumer peers, got %v", expectedConsumerPeers, ca.Group.Peers)
+				}
+				if slices.Contains(ca.Group.Peers, target) {
+					return fmt.Errorf("peer %q still in consumer peer set %v", target, ca.Group.Peers)
+				}
+				return nil
+			})
+
+			// A surviving consumer must still be usable.
+			if !consumerDeleted {
+				_, err = js.Publish(subject, []byte("HELLO"))
+				require_NoError(t, err)
+				// Bind by name, an ephemeral has no durable name to pass here.
+				sub, err := js.PullSubscribe(subject, _EMPTY_, nats.Bind(stream, consumer))
+				require_NoError(t, err)
+				defer sub.Unsubscribe()
+				msgs, err := sub.Fetch(1, nats.MaxWait(10*time.Second))
+				require_NoError(t, err)
+				require_Len(t, len(msgs), 1)
+			}
+		})
+	}
+}
+
 func TestJetStreamClusterPeerExclusionTag(t *testing.T) {
 	c := createJetStreamClusterWithTemplateAndModHook(t, jsClusterTempl, "C", 3,
 		func(serverName, clusterName, storeDir, conf string) string {
@@ -10449,6 +10811,19 @@ func TestJetStreamClusterAsyncFlushFileStoreFlushOnSnapshot(t *testing.T) {
 	n := mset.raftNode().(*raft)
 	_, _, previousApplied := n.Progress()
 
+	// An initial snapshot is installed shortly after the stream is created. Wait for it
+	// and remove it again, since the leader change below only snapshots if one is needed.
+	checkFor(t, 5*time.Second, 200*time.Millisecond, func() error {
+		n.Lock()
+		defer n.Unlock()
+		if n.snapfile == _EMPTY_ {
+			return errors.New("no initial snapshot yet")
+		}
+		os.Remove(n.snapfile)
+		n.snapfile = _EMPTY_
+		return nil
+	})
+
 	// Confirm no pending writes.
 	require_Equal(t, lmb.pendingWriteSize(), 0)
 
@@ -12693,7 +13068,7 @@ func TestJetStreamClusterMetaRecoveryRecreateStream(t *testing.T) {
 			mset, err := rs.globalAccount().lookupStream("TEST")
 			require_NoError(t, err)
 			streamNode := mset.raftNode()
-			require_NoError(t, streamNode.InstallSnapshot(mset.stateSnapshot(), false))
+			require_NoError(t, streamNode.InstallSnapshot(mset.stateSnapshot(), true))
 		}
 
 		// Although the meta node is paused, we add one more meta entry to move the commit up one more.

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -2114,14 +2114,23 @@ func TestJetStreamClusterReplacementPolicyAfterPeerRemoveNoPlace(t *testing.T) {
 		}
 	}
 
-	// Remove 1 peer replica (this will be random cloud region as initial placement was randomized ordering)
-	_, err = nc.Request("$JS.API.STREAM.PEER.REMOVE.TEST", []byte(`{"peer":"`+osi.Cluster.Replicas[0].Name+`"}`), time.Second*10)
+	// Evacuate 1 peer replica (this will be random cloud region as initial placement was
+	// randomized ordering). A stream scoped peer remove would be rejected here, there is no
+	// eligible replacement, so go through the server scoped endpoint which is best effort.
+	snc, _ := jsClientConnect(t, s, nats.UserInfo("admin", "s3cr3t!"))
+	defer snc.Close()
+	ereq, err := json.Marshal(JSApiMetaServerRemoveRequest{Server: osi.Cluster.Replicas[0].Name})
 	require_NoError(t, err)
+	emsg, err := snc.Request(JSApiEvacuateServer, ereq, time.Second*10)
+	require_NoError(t, err)
+	var eresp JSApiMetaServerRemoveResponse
+	require_NoError(t, json.Unmarshal(emsg.Data, &eresp))
+	require_True(t, eresp.Success)
 
 	sc.waitOnStreamLeader(globalAccountName, "TEST")
 
 	// Verify R2 since no eligible peer can replace the removed peer without braking unique constraint
-	checkFor(t, time.Second, 200*time.Millisecond, func() error {
+	checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
 		osi, err = jsc.StreamInfo("TEST")
 		require_NoError(t, err)
 		if len(osi.Cluster.Replicas) != 1 {

--- a/server/norace_1_test.go
+++ b/server/norace_1_test.go
@@ -6237,6 +6237,8 @@ func TestNoRaceJetStreamClusterEnsureWALCompact(t *testing.T) {
 	node := mset.raftNode()
 	require_True(t, node != nil)
 
+	_, err = js.Publish("foo", []byte("bar"))
+	require_NoError(t, err)
 	err = node.InstallSnapshot(mset.stateSnapshot(), false)
 	require_NoError(t, err)
 

--- a/server/raft.go
+++ b/server/raft.go
@@ -1513,7 +1513,7 @@ func (n *raft) createSnapshotCheckpointLocked(force bool) (*checkpoint, error) {
 	if n.State() == Closed {
 		return nil, errNodeClosed
 	}
-	if n.snapshotting {
+	if !force && n.snapshotting {
 		return nil, errSnapInProgress
 	}
 
@@ -1729,7 +1729,7 @@ func (c *checkpoint) InstallSnapshot(data []byte) (uint64, error) {
 func (n *raft) NeedSnapshot() bool {
 	n.RLock()
 	defer n.RUnlock()
-	return n.snapfile == _EMPTY_ && n.applied > 1
+	return n.snapfile == _EMPTY_ && n.applied > 0
 }
 
 const (

--- a/server/server.go
+++ b/server/server.go
@@ -402,6 +402,13 @@ type nodeInfo struct {
 	accountNRG      bool
 }
 
+// selectable reports whether we've had STATSZ from this node. Peer selection
+// skips nodes without config or stats, so until then there's nothing we could
+// place on it.
+func (ni nodeInfo) selectable() bool {
+	return ni.cfg != nil && ni.stats != nil
+}
+
 type stats struct {
 	inMsgs           int64
 	inBytes          int64


### PR DESCRIPTION
This PR wires peer removals and additions into desired state.
- `reconcilePeerAssignments` runs on a meta leader change, so proposals that were missed or only partially applied can be retried by the next leader.
- Peer additions through `processAddPeer` now also obey the rules of `cc.selectPeerGroup`, which requires waiting for STATSZ info if it isn't yet available for the newly added node.
- A new set of "peer evacuate" endpoints (`$JS.API.STREAM.PEER.EVACUATE.<stream>` and, for the system account, `$JS.API.SERVER.EVACUATE`) offers the same semantics as peer-remove while not immediately removing the peer, so it can cooperate in catching up the new peer. This also allows evacuating all R1 streams of a server that is to be decommissioned ahead of time, whereas a peer-remove of a server hosting an R1 stream does get a new server assigned but would otherwise lose all data.

`reconcilePeerAssignments` scans every stream and consumer assignment on each meta leader change and peer add, benchmarked locally at ~100-290 ms for 100k streams/500k consumers, under `js.mu`. That is purely a no-op scan; actually reconciling is significantly more expensive, since each affected assignment's proposal needs to be retried. A large contributor is `selectPeerGroup`, which loops over all stream assignments per call to determine HA asset counts. This is not addressed in this PR, but noted for clarity, and `selectPeerGroup` can only be made faster once all `meta.ForwardProposal` calls are gone since we can then purely rely on atomics.

Follow-up of https://github.com/nats-io/nats-server/pull/8432