### PR TITLE
(2.15) Raft proposal fast path

### DIFF
--- a/server/ipqueue.go
+++ b/server/ipqueue.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"errors"
+	"iter"
 	"sync"
 	"sync/atomic"
 )
@@ -140,16 +141,20 @@ func (q *ipQueue[T]) push(e T) (int, error) {
 	return l + 1, nil
 }
 
-// Add all elements pushed by generate to the queue while holding the queue
+// Add all elements yielded by seq to the queue while holding the queue
 // lock, preventing other producers from pushing interleaving elements.
-// On success, it returns the queue length after adding all pushed elements.
-// If a queue limit is reached, no pushed elements are retained, and it
+// On success, it returns the queue length after adding all yielded elements.
+// If a queue limit is reached, no yielded elements are retained, and it
 // returns the unchanged queue length and the first limit error.
-func (q *ipQueue[T]) pushMany(generate func(push func(T))) (int, error) {
+func (q *ipQueue[T]) pushMany(seq iter.Seq[T]) (int, error) {
 	q.Lock()
 	l, added, start := len(q.elts)-q.pos, 0, len(q.elts)
 	initialSize := q.sz
-	var err error
+	revert := func() {
+		clear(q.elts[start:])
+		q.elts = q.elts[:start]
+		q.sz, added = initialSize, 0
+	}
 	defer func() {
 		q.Unlock()
 		if l == 0 && added > 0 {
@@ -160,19 +165,16 @@ func (q *ipQueue[T]) pushMany(generate func(push func(T))) (int, error) {
 		}
 	}()
 
-	generate(func(e T) {
-		if err != nil {
-			return
-		}
+	for e := range seq {
 		if q.mlen > 0 && l+added == q.mlen {
-			err = errIPQLenLimitReached
-			return
+			revert()
+			return l, errIPQLenLimitReached
 		}
 		if q.calc != nil {
 			sz := q.calc(e)
 			if q.msz > 0 && q.sz+sz > q.msz {
-				err = errIPQSizeLimitReached
-				return
+				revert()
+				return l, errIPQSizeLimitReached
 			}
 			q.sz += sz
 		}
@@ -182,13 +184,8 @@ func (q *ipQueue[T]) pushMany(generate func(push func(T))) (int, error) {
 		}
 		q.elts = append(q.elts, e)
 		added++
-	})
-	if err != nil {
-		clear(q.elts[start:])
-		q.elts = q.elts[:start]
-		q.sz, added = initialSize, 0
 	}
-	return l + added, err
+	return l + added, nil
 }
 
 // Returns the whole list of elements currently present in the queue,

--- a/server/ipqueue.go
+++ b/server/ipqueue.go
@@ -140,6 +140,57 @@ func (q *ipQueue[T]) push(e T) (int, error) {
 	return l + 1, nil
 }
 
+// Add all elements pushed by generate to the queue while holding the queue
+// lock, preventing other producers from pushing interleaving elements.
+// On success, it returns the queue length after adding all pushed elements.
+// If a queue limit is reached, no pushed elements are retained, and it
+// returns the unchanged queue length and the first limit error.
+func (q *ipQueue[T]) pushMany(generate func(push func(T))) (int, error) {
+	q.Lock()
+	l, added, start := len(q.elts)-q.pos, 0, len(q.elts)
+	initialSize := q.sz
+	var err error
+	defer func() {
+		q.Unlock()
+		if l == 0 && added > 0 {
+			select {
+			case q.ch <- struct{}{}:
+			default:
+			}
+		}
+	}()
+
+	generate(func(e T) {
+		if err != nil {
+			return
+		}
+		if q.mlen > 0 && l+added == q.mlen {
+			err = errIPQLenLimitReached
+			return
+		}
+		if q.calc != nil {
+			sz := q.calc(e)
+			if q.msz > 0 && q.sz+sz > q.msz {
+				err = errIPQSizeLimitReached
+				return
+			}
+			q.sz += sz
+		}
+		if q.elts == nil {
+			// What comes out of the pool is already of size 0, so no need for [:0].
+			q.elts = *(q.pool.Get().(*[]T))
+		}
+		q.elts = append(q.elts, e)
+		added++
+	})
+	if err != nil {
+		clear(q.elts[start:])
+		q.elts = q.elts[:start]
+		q.sz, added = initialSize, 0
+	}
+	return l + added, err
+}
+
 // Returns the whole list of elements currently present in the queue,
 // emptying the queue. This should be called after receiving a notification
 // from the queue's `ch` notification channel that indicates that there

--- a/server/ipqueue_test.go
+++ b/server/ipqueue_test.go
@@ -114,6 +114,54 @@ func TestIPQueuePush(t *testing.T) {
 	}
 }
 
+func TestIPQueuePushMany(t *testing.T) {
+	s := &Server{}
+	q := newIPQueue[int](s, "test")
+
+	l, err := q.pushMany(func(push func(int)) {
+		for i := 1; i <= 3; i++ {
+			push(i)
+		}
+	})
+	require_NoError(t, err)
+	require_Equal(t, l, 3)
+	select {
+	case <-q.ch:
+	default:
+		t.Fatal("Should have been notified of additions")
+	}
+	values := q.pop()
+	require_Len(t, len(values), 3)
+	for i, value := range values {
+		require_Equal(t, value, i+1)
+	}
+	q.recycle(&values)
+
+	l, err = q.pushMany(func(func(int)) {})
+	require_NoError(t, err)
+	require_Equal(t, l, 0)
+	select {
+	case <-q.ch:
+		t.Fatal("Should not have been notified of additions")
+	default:
+	}
+
+	limited := newIPQueue[int](s, "limited", ipqLimitByLen[int](2))
+	l, err = limited.pushMany(func(push func(int)) {
+		for i := 1; i <= 3; i++ {
+			push(i)
+		}
+	})
+	require_Error(t, err, errIPQLenLimitReached)
+	require_Equal(t, l, 0)
+	require_Equal(t, limited.len(), 0)
+	select {
+	case <-limited.ch:
+		t.Fatal("Should not have been notified of rejected additions")
+	default:
+	}
+}
+
 func TestIPQueuePop(t *testing.T) {
 	s := &Server{}
 	q := newIPQueue[int](s, "test")

--- a/server/ipqueue_test.go
+++ b/server/ipqueue_test.go
@@ -118,9 +118,11 @@ func TestIPQueuePushMany(t *testing.T) {
 	s := &Server{}
 	q := newIPQueue[int](s, "test")
 
-	l, err := q.pushMany(func(push func(int)) {
+	l, err := q.pushMany(func(yield func(int) bool) {
 		for i := 1; i <= 3; i++ {
-			push(i)
+			if !yield(i) {
+				return
+			}
 		}
 	})
 	require_NoError(t, err)
@@ -137,7 +139,7 @@ func TestIPQueuePushMany(t *testing.T) {
 	}
 	q.recycle(&values)
 
-	l, err = q.pushMany(func(func(int)) {})
+	l, err = q.pushMany(func(func(int) bool) {})
 	require_NoError(t, err)
 	require_Equal(t, l, 0)
 	select {
@@ -147,9 +149,11 @@ func TestIPQueuePushMany(t *testing.T) {
 	}
 
 	limited := newIPQueue[int](s, "limited", ipqLimitByLen[int](2))
-	l, err = limited.pushMany(func(push func(int)) {
+	l, err = limited.pushMany(func(yield func(int) bool) {
 		for i := 1; i <= 3; i++ {
-			push(i)
+			if !yield(i) {
+				return
+			}
 		}
 	})
 	require_Error(t, err, errIPQLenLimitReached)

--- a/server/raft.go
+++ b/server/raft.go
@@ -3409,7 +3409,7 @@ func (n *raft) runAsLeader() {
 			n.resp.recycle(&ars)
 		case <-n.prop.ch:
 			const maxBatch = 256 * 1024
-			const maxEntries = 512
+			const maxEntries = 4096 // larger batches showed no benefit
 			var entries []*Entry
 
 			es, sz := n.prop.pop(), 0

--- a/server/raft.go
+++ b/server/raft.go
@@ -263,11 +263,14 @@ type raft struct {
 	quorumPaused bool // Pause replication and quorum participation to prevent log growth during slow applies.
 
 	overrunCount uint64 // Counter of how many times we were overrun, either as follower or as leader.
+
+	fastPathTerm atomic.Uint64 // Term accepting fast path proposals, zero when closed.
 }
 
 type proposedEntry struct {
 	*Entry
 	reply string // Optional, to respond once proposal handled
+	term  uint64 // Raft term in which it was accepted.
 }
 
 // catchupState structure that holds our subscription, and catchup term and index
@@ -926,11 +929,44 @@ func (s *Server) transferRaftLeaders() bool {
 	return didTransfer
 }
 
+// tryFastPathPropose enqueues the given data buffer to the
+// proposal queue, provided that the fast path is open, and that
+// the given term matches the current raft term.
+// Returns true if it was successfully enqueued. False if the
+// caller should fall back to the locking proposal path.
+func (n *raft) tryFastPathPropose(term uint64, data []byte) bool {
+	if term == 0 || term != n.fastPathTerm.Load() || n.State() != Leader {
+		return false
+	}
+	n.prop.push(newProposedEntry(newEntry(EntryNormal, data), _EMPTY_, term))
+	return true
+}
+
+// tryFastPathProposeMulti enqueues the given entries to the
+// proposal queue, provided that the fast path is open, and that
+// the given term matches the current raft term.
+// Returns true if the entries were successfully enqueued. False if the
+// caller should fall back to the locking proposal path.
+func (n *raft) tryFastPathProposeMulti(term uint64, entries []*Entry) bool {
+	if term == 0 || term != n.fastPathTerm.Load() || n.State() != Leader {
+		return false
+	}
+	_, err := n.prop.pushMany(func(push func(*proposedEntry)) {
+		for _, e := range entries {
+			push(newProposedEntry(e, _EMPTY_, term))
+		}
+	})
+	return err == nil
+}
+
 // Formal API
 
 // Propose will propose a new entry to the group.
 // This should only be called on the leader.
 func (n *raft) Propose(term uint64, data []byte) error {
+	if n.tryFastPathPropose(term, data) {
+		return nil
+	}
 	n.Lock()
 	defer n.Unlock()
 	return n.proposeLocked(term, data)
@@ -957,13 +993,16 @@ func (n *raft) proposeLocked(term uint64, data []byte) error {
 		n.overrunCount++
 		return errNotLeader
 	}
-	n.prop.push(newProposedEntry(newEntry(EntryNormal, data), _EMPTY_))
+	n.prop.push(newProposedEntry(newEntry(EntryNormal, data), _EMPTY_, n.term))
 	return nil
 }
 
 // ProposeMulti will propose multiple entries at once.
 // This should only be called on the leader.
 func (n *raft) ProposeMulti(term uint64, entries []*Entry) error {
+	if n.tryFastPathProposeMulti(term, entries) {
+		return nil
+	}
 	n.Lock()
 	defer n.Unlock()
 	// Check state under lock, we might not be leader anymore.
@@ -986,10 +1025,12 @@ func (n *raft) ProposeMulti(term uint64, entries []*Entry) error {
 		n.overrunCount++
 		return errNotLeader
 	}
-	for _, e := range entries {
-		n.prop.push(newProposedEntry(e, _EMPTY_))
-	}
-	return nil
+	_, err := n.prop.pushMany(func(push func(*proposedEntry)) {
+		for _, e := range entries {
+			push(newProposedEntry(e, _EMPTY_, n.term))
+		}
+	})
+	return err
 }
 
 // isLeaderOverrun returns whether we are overrun and should step down due to continuously increasing
@@ -1045,10 +1086,10 @@ func (n *raft) ProposeAddPeer(peer string) error {
 		n.RUnlock()
 		return errMembershipChange
 	}
-	prop := n.prop
+	prop, term := n.prop, n.term
 	n.RUnlock()
 
-	prop.push(newProposedEntry(newEntry(EntryAddPeer, []byte(peer)), _EMPTY_))
+	prop.push(newProposedEntry(newEntry(EntryAddPeer, []byte(peer)), _EMPTY_, term))
 	return nil
 }
 
@@ -1084,10 +1125,10 @@ func (n *raft) ProposeRemovePeer(peer string) error {
 		return errRemoveLastNode
 	}
 
-	prop := n.prop
+	prop, term := n.prop, n.term
 	n.RUnlock()
 
-	prop.push(newProposedEntry(newEntry(EntryRemovePeer, []byte(peer)), _EMPTY_))
+	prop.push(newProposedEntry(newEntry(EntryRemovePeer, []byte(peer)), _EMPTY_, term))
 	return nil
 }
 
@@ -2905,16 +2946,16 @@ var pePool = sync.Pool{
 	},
 }
 
-// Create a new proposedEntry.
-func newProposedEntry(entry *Entry, reply string) *proposedEntry {
+// Create a new single proposedEntry tagged with the term in which it was accepted.
+func newProposedEntry(entry *Entry, reply string, term uint64) *proposedEntry {
 	pe := pePool.Get().(*proposedEntry)
-	pe.Entry, pe.reply = entry, reply
+	pe.Entry, pe.reply, pe.term = entry, reply, term
 	return pe
 }
 
 // Will return this proosed entry.
 func (pe *proposedEntry) returnToPool() {
-	pe.Entry, pe.reply = nil, _EMPTY_
+	pe.Entry, pe.reply, pe.term = nil, _EMPTY_, 0
 	pePool.Put(pe)
 }
 
@@ -3168,12 +3209,12 @@ func (n *raft) handleForwardedRemovePeerProposal(sub *subscription, c *client, _
 		n.RUnlock()
 		return
 	}
-	prop := n.prop
+	prop, term := n.prop, n.term
 	n.RUnlock()
 
 	// Need to copy since this is underlying client/route buffer.
 	peer := copyBytes(msg)
-	prop.push(newProposedEntry(newEntry(EntryRemovePeer, peer), reply))
+	prop.push(newProposedEntry(newEntry(EntryRemovePeer, peer), reply, term))
 }
 
 // Called when a peer has forwarded a proposal.
@@ -3195,7 +3236,7 @@ func (n *raft) handleForwardedProposal(sub *subscription, c *client, _ *Account,
 		n.RUnlock()
 		return
 	}
-
+	term := n.term
 	if n.isLeaderOverrun() {
 		n.RUnlock()
 		n.Lock()
@@ -3206,7 +3247,7 @@ func (n *raft) handleForwardedProposal(sub *subscription, c *client, _ *Account,
 		if n.State() != Leader || !n.leaderState.Load() {
 			return
 		} else if !n.isLeaderOverrun() {
-			prop.push(newProposedEntry(newEntry(EntryNormal, msg), reply))
+			prop.push(newProposedEntry(newEntry(EntryNormal, msg), reply, n.term))
 			return
 		}
 		var state StreamState
@@ -3220,7 +3261,7 @@ func (n *raft) handleForwardedProposal(sub *subscription, c *client, _ *Account,
 	// Possible that we could fall through to here from multiple connections but if
 	// one does end up stepping down then the proposal queue gets drained anyway.
 	n.RUnlock()
-	prop.push(newProposedEntry(newEntry(EntryNormal, msg), reply))
+	prop.push(newProposedEntry(newEntry(EntryNormal, msg), reply, term))
 }
 
 // Adds peer with the given id to our membership,
@@ -3320,7 +3361,7 @@ func (n *raft) runAsLeader() {
 	}
 
 	n.Lock()
-	psubj, rpsubj := n.psubj, n.rpsubj
+	psubj, rpsubj, term := n.psubj, n.rpsubj, n.term
 
 	// For forwarded proposals, both normal and remove peer proposals.
 	fsub, err := n.subscribe(psubj, n.handleForwardedProposal)
@@ -3373,6 +3414,9 @@ func (n *raft) runAsLeader() {
 
 			es, sz := n.prop.pop(), 0
 			for _, b := range es {
+				if b.term != term {
+					continue
+				}
 				if b.ChangesMembership() {
 					n.sendMembershipChange(b.Entry)
 					continue
@@ -3395,7 +3439,7 @@ func (n *raft) runAsLeader() {
 			}
 			// Respond to any proposals waiting for a confirmation.
 			for _, pe := range es {
-				if pe.reply != _EMPTY_ {
+				if pe.term == term && pe.reply != _EMPTY_ {
 					n.sendReply(pe.reply, nil)
 				}
 				pe.returnToPool()
@@ -4984,6 +5028,17 @@ func (n *raft) sendAppendEntryLocked(entries []*Entry, checkLeader bool) error {
 		n.debug("Not sending append entry, not leader")
 		return errNotLeader
 	}
+
+	// The raft mutex remains held while entries are stored
+	// and sent to followers. If the leader is ready to take
+	// more proposals (no errors, not overrun), allow Propose
+	// and ProposeMulti to enqueue proposals for the current
+	// term without acquiring the raft mutex.
+	if checkLeader && n.werr == nil && !n.isLeaderOverrun() {
+		n.fastPathTerm.Store(n.term)
+		defer n.fastPathTerm.Store(0)
+	}
+
 	ae := n.buildAppendEntry(entries)
 
 	var err error
@@ -5611,6 +5666,8 @@ retry:
 	if pstate == Leader && state != Leader {
 		leadChanged = true
 		n.updateLeadChange(false)
+		// Disable fast path proposals before draining the proposal queue below.
+		n.fastPathTerm.Store(0)
 		// Drain the append entry response and proposal queues.
 		n.resp.drain()
 		n.prop.drain()

--- a/server/raft.go
+++ b/server/raft.go
@@ -951,9 +951,11 @@ func (n *raft) tryFastPathProposeMulti(term uint64, entries []*Entry) bool {
 	if term == 0 || term != n.fastPathTerm.Load() || n.State() != Leader {
 		return false
 	}
-	_, err := n.prop.pushMany(func(push func(*proposedEntry)) {
+	_, err := n.prop.pushMany(func(yield func(*proposedEntry) bool) {
 		for _, e := range entries {
-			push(newProposedEntry(e, _EMPTY_, term))
+			if !yield(newProposedEntry(e, _EMPTY_, term)) {
+				return
+			}
 		}
 	})
 	return err == nil
@@ -1025,9 +1027,11 @@ func (n *raft) ProposeMulti(term uint64, entries []*Entry) error {
 		n.overrunCount++
 		return errNotLeader
 	}
-	_, err := n.prop.pushMany(func(push func(*proposedEntry)) {
+	_, err := n.prop.pushMany(func(yield func(*proposedEntry) bool) {
 		for _, e := range entries {
-			push(newProposedEntry(e, _EMPTY_, n.term))
+			if !yield(newProposedEntry(e, _EMPTY_, n.term)) {
+				return
+			}
 		}
 	})
 	return err

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -490,7 +490,7 @@ func TestNRGSwitchStateClearsQueues(t *testing.T) {
 	require_Equal(t, n.prop.len(), 0)
 	require_Equal(t, n.resp.len(), 0)
 
-	n.prop.push(&proposedEntry{&Entry{}, _EMPTY_})
+	n.prop.push(&proposedEntry{Entry: &Entry{}, reply: _EMPTY_})
 	n.resp.push(&appendEntryResponse{})
 	require_Equal(t, n.prop.len(), 1)
 	require_Equal(t, n.resp.len(), 1)
@@ -498,6 +498,57 @@ func TestNRGSwitchStateClearsQueues(t *testing.T) {
 	n.switchState(Follower)
 	require_Equal(t, n.prop.len(), 0)
 	require_Equal(t, n.resp.len(), 0)
+}
+
+func TestNRGProposalFastPath(t *testing.T) {
+	s := &Server{}
+
+	n := &raft{
+		prop: newIPQueue[*proposedEntry](s, "prop"),
+		term: 1,
+	}
+
+	// Closed fast path
+	n.state.Store(int32(Leader))
+	require_False(t, n.tryFastPathPropose(0, []byte("closed zero term")))
+	require_False(t, n.tryFastPathPropose(1, []byte("closed")))
+
+	// Simulate the leader opening the fast path for the current term.
+	n.fastPathTerm.Store(n.term)
+	require_Equal(t, n.fastPathTerm.Load(), uint64(1))
+	require_False(t, n.tryFastPathPropose(2, []byte("wrong term")))
+
+	// The term may still match after stepping down, so the state check must
+	// prevent fast-path proposals too.
+	n.state.Store(int32(Follower))
+	require_False(t, n.tryFastPathPropose(1, []byte("not leader")))
+
+	// Single and multi-entry proposals are queued in proposal order, with the
+	// leader term attached to every entry.
+	n.state.Store(int32(Leader))
+	require_True(t, n.tryFastPathPropose(1, []byte("single")))
+	multi := []*Entry{
+		newEntry(EntryNormal, []byte("multi 1")),
+		newEntry(EntryNormal, []byte("multi 2")),
+	}
+	require_True(t, n.tryFastPathProposeMulti(1, multi))
+	multi[0] = nil // The queued proposals do not retain the caller's slice.
+
+	proposals := n.prop.pop()
+	require_Len(t, len(proposals), 3)
+	require_Equal(t, string(proposals[0].Data), "single")
+	require_Equal(t, string(proposals[1].Data), "multi 1")
+	require_Equal(t, string(proposals[2].Data), "multi 2")
+	for _, pe := range proposals {
+		require_Equal(t, pe.term, uint64(1))
+		pe.returnToPool()
+	}
+	n.prop.recycle(&proposals)
+
+	// Closing the fast path clears its term and prevents further proposals.
+	n.fastPathTerm.Store(0)
+	require_Equal(t, n.fastPathTerm.Load(), uint64(0))
+	require_False(t, n.tryFastPathPropose(1, []byte("closed again")))
 }
 
 func TestNRGStepDownOnSameTermDoesntClearVote(t *testing.T) {
@@ -7337,7 +7388,7 @@ func TestNRGReset(t *testing.T) {
 	n.snapfile = sfile
 
 	// Push something onto each queue so we can verify they are drained.
-	_, err := n.prop.push(&proposedEntry{&Entry{}, _EMPTY_})
+	_, err := n.prop.push(&proposedEntry{Entry: &Entry{}, reply: _EMPTY_})
 	require_NoError(t, err)
 	_, err = n.entry.push(&appendEntry{})
 	require_NoError(t, err)


### PR DESCRIPTION
Reduce contention by adding a proposal fast path that allows Propose and ProposeMulti to enqueue proposals in the hot path, without the need to acquire the raft mutex.