### PR TITLE
[FIXED] Route TLS: preserve saved hostname on HostnameError when URL is an IP

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -6679,16 +6679,9 @@ func (c *client) doTLSHandshake(typ string, solicit bool, url *url.URL, tlsConfi
 			// See: https://github.com/nats-io/nats-server/issues/1256
 			// NOTE: As of Go 1.20, the HostnameError is wrapped so cannot
 			// type assert to check directly.
-			//
-			// Only clear the saved tlsName when the URL itself carries a
-			// hostname (not an IP). If the URL has an IP, the tlsName was
-			// used as a fallback for ServerName verification; clearing it
-			// would cause subsequent reconnection attempts to use the IP as
-			// ServerName, which fails against certificates that only have DNS
-			// SANs. See: https://github.com/nats-io/nats-server/issues/8309
 			var hostnameErr x509.HostnameError
 			if errors.As(err, &hostnameErr) {
-				if host == tlsName && net.ParseIP(url.Hostname()) == nil {
+				if host == tlsName {
 					resetTLSName = true
 				}
 			}

--- a/server/client.go
+++ b/server/client.go
@@ -6679,9 +6679,16 @@ func (c *client) doTLSHandshake(typ string, solicit bool, url *url.URL, tlsConfi
 			// See: https://github.com/nats-io/nats-server/issues/1256
 			// NOTE: As of Go 1.20, the HostnameError is wrapped so cannot
 			// type assert to check directly.
+			//
+			// Only clear the saved tlsName when the URL itself carries a
+			// hostname (not an IP). If the URL has an IP, the tlsName was
+			// used as a fallback for ServerName verification; clearing it
+			// would cause subsequent reconnection attempts to use the IP as
+			// ServerName, which fails against certificates that only have DNS
+			// SANs. See: https://github.com/nats-io/nats-server/issues/8309
 			var hostnameErr x509.HostnameError
 			if errors.As(err, &hostnameErr) {
-				if host == tlsName {
+				if host == tlsName && net.ParseIP(url.Hostname()) == nil {
 					resetTLSName = true
 				}
 			}

--- a/server/route.go
+++ b/server/route.go
@@ -1986,7 +1986,23 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL, rtype RouteType, goss
 			c.mu.Unlock()
 			if resetTLSName {
 				s.mu.Lock()
-				s.routeTLSName = _EMPTY_
+				if net.ParseIP(rURL.Hostname()) != nil && s.routeTLSLastName != _EMPTY_ {
+					// The URL hostname is an IP, meaning the saved tlsName was used
+					// as a fallback for ServerName. Instead of clearing tlsName
+					// outright, restore it from the backup so that the next
+					// reconnection attempt can try the hostname again. This
+					// handles the case where a transient error causes a
+					// HostnameError for a correctly configured hostname (DNS-only
+					// SANs). The backup is consumed so that on a subsequent
+					// failure, tlsName will be cleared and the IP will be tried
+					// instead, handling mixed DNS/IP SAN environments.
+					// See: https://github.com/nats-io/nats-server/issues/8309
+					// See: https://github.com/nats-io/nats-server/issues/1256
+					s.routeTLSName = s.routeTLSLastName
+					s.routeTLSLastName = _EMPTY_
+				} else {
+					s.routeTLSName = _EMPTY_
+				}
 				s.mu.Unlock()
 			}
 			return nil
@@ -2984,8 +3000,14 @@ func (c *client) isSolicitedRoute() bool {
 // Lock is held on entry
 func (s *Server) saveRouteTLSName(routes []*url.URL) {
 	for _, u := range routes {
-		if s.routeTLSName == _EMPTY_ && net.ParseIP(u.Hostname()) == nil {
-			s.routeTLSName = u.Hostname()
+		host := u.Hostname()
+		if net.ParseIP(host) == nil {
+			if s.routeTLSName == _EMPTY_ {
+				s.routeTLSName = host
+			}
+			if s.routeTLSLastName == _EMPTY_ {
+				s.routeTLSLastName = host
+			}
 		}
 	}
 }

--- a/server/route.go
+++ b/server/route.go
@@ -1987,21 +1987,21 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL, rtype RouteType, goss
 			if resetTLSName {
 				s.mu.Lock()
 				if net.ParseIP(rURL.Hostname()) != nil && s.routeTLSLastName != _EMPTY_ {
-					// The URL hostname is an IP, meaning the saved tlsName was used
-					// as a fallback for ServerName. Instead of clearing tlsName
-					// outright, restore it from the backup so that the next
-					// reconnection attempt can try the hostname again. This
-					// handles the case where a transient error causes a
-					// HostnameError for a correctly configured hostname (DNS-only
-					// SANs). The backup is consumed so that on a subsequent
-					// failure, tlsName will be cleared and the IP will be tried
-					// instead, handling mixed DNS/IP SAN environments.
-					// See: https://github.com/nats-io/nats-server/issues/8309
-					// See: https://github.com/nats-io/nats-server/issues/1256
+					// Restore from backup for DNS-only SAN certs (#8309);
+					// backup is consumed so IP fallback still works (#1256).
 					s.routeTLSName = s.routeTLSLastName
 					s.routeTLSLastName = _EMPTY_
 				} else {
 					s.routeTLSName = _EMPTY_
+				}
+				s.mu.Unlock()
+			} else if didSolicit && net.ParseIP(rURL.Hostname()) != nil && s.routeTLSLastName != _EMPTY_ {
+				// Handshake failed without resetTLSName, but the URL is an IP
+				// and we have a backup hostname. Restore it for the next attempt.
+				s.mu.Lock()
+				if s.routeTLSName == _EMPTY_ {
+					s.routeTLSName = s.routeTLSLastName
+					s.routeTLSLastName = _EMPTY_
 				}
 				s.mu.Unlock()
 			}

--- a/server/route.go
+++ b/server/route.go
@@ -1987,21 +1987,18 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL, rtype RouteType, goss
 			if resetTLSName {
 				s.mu.Lock()
 				if net.ParseIP(rURL.Hostname()) != nil && s.routeTLSLastName != _EMPTY_ {
-					// Restore from backup for DNS-only SAN certs (#8309);
-					// backup is consumed so IP fallback still works (#1256).
+					// Restore from backup for DNS-only SAN certs (#8309).
+					// The backup is not consumed so it remains available for
+					// future restores after IP-SAN fallback (#1256).
 					s.routeTLSName = s.routeTLSLastName
-					s.routeTLSLastName = _EMPTY_
 				} else {
 					s.routeTLSName = _EMPTY_
 				}
 				s.mu.Unlock()
-			} else if didSolicit && net.ParseIP(rURL.Hostname()) != nil && s.routeTLSLastName != _EMPTY_ {
-				// Handshake failed without resetTLSName, but the URL is an IP
-				// and we have a backup hostname. Restore it for the next attempt.
+			} else if didSolicit && net.ParseIP(rURL.Hostname()) != nil {
 				s.mu.Lock()
-				if s.routeTLSName == _EMPTY_ {
+				if s.routeTLSName == _EMPTY_ && s.routeTLSLastName != _EMPTY_ {
 					s.routeTLSName = s.routeTLSLastName
-					s.routeTLSLastName = _EMPTY_
 				}
 				s.mu.Unlock()
 			}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1951,38 +1951,91 @@ func TestRouteTLSNameBackupRestoreOnHostnameError(t *testing.T) {
 		t.Fatalf("routeTLSLastName should be 'localhost', got %q", savedTLSLastName)
 	}
 
-	// Verify that routeTLSName is preserved across implicit route reconnections.
-	for i := 0; i < 3; i++ {
-		s2.mu.RLock()
-		s2.forEachRoute(func(r *client) {
-			r.mu.Lock()
-			if r.route.routeType == Implicit {
-				r.nc.Close()
-			}
-			r.mu.Unlock()
-		})
-		s2.mu.RUnlock()
+	// Reload config to use IP-based route URLs. The explicit route is now an
+	// IP, so saveRouteTLSName won't update routeTLSName or routeTLSLastName.
+	// The saved "localhost" from the initial config is still in both fields.
+	reloadUpdateConfig(t, s2, c2Conf, fmt.Sprintf(tmpl, "127.0.0.1", o1.Cluster.Port))
 
-		checkClusterFormed(t, s1, s2)
-
-		s2.mu.RLock()
-		savedTLSName = s2.routeTLSName
-		s2.mu.RUnlock()
-		if savedTLSName != "localhost" {
-			t.Fatalf("routeTLSName should still be 'localhost' after implicit route reconnect, got %q", savedTLSName)
+	// Close implicit routes to trigger reconnection via gossip.
+	// The gossip URL uses an IP, so routeTLSName ("localhost") is used as
+	// the TLS ServerName. The certificate has "localhost" as a DNS SAN,
+	// so the handshake succeeds and the cluster reforms.
+	s2.mu.RLock()
+	s2.forEachRoute(func(r *client) {
+		r.mu.Lock()
+		if r.route.routeType == Implicit {
+			r.nc.Close()
 		}
+		r.mu.Unlock()
+	})
+	s2.mu.RUnlock()
+
+	checkClusterFormed(t, s1, s2)
+
+	// After successful reconnect, routeTLSName should still be "localhost".
+	s2.mu.RLock()
+	savedTLSName = s2.routeTLSName
+	savedTLSLastName = s2.routeTLSLastName
+	s2.mu.RUnlock()
+	if savedTLSName != "localhost" {
+		t.Fatalf("routeTLSName should still be 'localhost', got %q", savedTLSName)
+	}
+	if savedTLSLastName != "localhost" {
+		t.Fatalf("routeTLSLastName should still be 'localhost', got %q", savedTLSLastName)
 	}
 
-	// Simulate the HostnameError recovery path: when routeTLSName is cleared
-	// (e.g., by a HostnameError), routeTLSLastName should allow it to be
-	// restored for IP-based route URLs, giving the hostname one more chance
-	// before falling back to the IP.
+	// Now clear routeTLSName to simulate a HostnameError having cleared it.
+	// On the next reconnect attempt via gossip (IP URL), the server should
+	// restore routeTLSName from routeTLSLastName, giving the hostname one
+	// more chance before falling back to the IP.
 	s2.mu.Lock()
 	s2.routeTLSName = _EMPTY_
-	restoredName := s2.routeTLSLastName
 	s2.mu.Unlock()
-	if restoredName != "localhost" {
-		t.Fatalf("routeTLSLastName should be 'localhost', got %q", restoredName)
+
+	// Set a logger to capture the TLS handshake error.
+	l := &captureErrorLogger{errCh: make(chan string, 10)}
+	s2.SetLogger(l, false, false)
+
+	// Close all routes on s2 to trigger reconnection attempts.
+	s2.mu.RLock()
+	s2.forEachRoute(func(r *client) {
+		r.mu.Lock()
+		r.nc.Close()
+		r.mu.Unlock()
+	})
+	s2.mu.RUnlock()
+
+	// Wait for a TLS handshake error. Since routeTLSName is empty, the IP
+	// will be used as ServerName, which fails against the DNS-only certificate.
+	// The backup restore should then set routeTLSName = "localhost" for the
+	// next attempt, allowing the cluster to reform.
+	select {
+	case <-l.errCh:
+		// Got the expected TLS error.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Did not get the expected TLS handshake error")
+	}
+
+	// After the error, routeTLSName should be restored from the backup.
+	checkFor(t, 5*time.Second, 50*time.Millisecond, func() error {
+		s2.mu.RLock()
+		name := s2.routeTLSName
+		s2.mu.RUnlock()
+		if name != "localhost" {
+			return fmt.Errorf("routeTLSName should be 'localhost' (restored from backup), got %q", name)
+		}
+		return nil
+	})
+
+	// The cluster should now be able to reform using the restored hostname.
+	checkClusterFormed(t, s1, s2)
+
+	// The backup should be consumed after the restore.
+	s2.mu.RLock()
+	savedTLSLastName = s2.routeTLSLastName
+	s2.mu.RUnlock()
+	if savedTLSLastName != _EMPTY_ {
+		t.Fatalf("routeTLSLastName should be consumed (empty), got %q", savedTLSLastName)
 	}
 }
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1903,7 +1903,7 @@ func TestRouteSaveTLSName(t *testing.T) {
 	checkClusterFormed(t, s1, s2, s3)
 }
 
-func TestRouteTLSNamePreservedOnGossipReconnect(t *testing.T) {
+func TestRouteTLSNameBackupRestoreOnHostnameError(t *testing.T) {
 	c1Conf := createConfFile(t, []byte(`
 		port: -1
 		cluster {
@@ -1942,11 +1942,16 @@ func TestRouteTLSNamePreservedOnGossipReconnect(t *testing.T) {
 
 	s2.mu.RLock()
 	savedTLSName := s2.routeTLSName
+	savedTLSLastName := s2.routeTLSLastName
 	s2.mu.RUnlock()
 	if savedTLSName != "localhost" {
 		t.Fatalf("routeTLSName should be 'localhost', got %q", savedTLSName)
 	}
+	if savedTLSLastName != "localhost" {
+		t.Fatalf("routeTLSLastName should be 'localhost', got %q", savedTLSLastName)
+	}
 
+	// Verify that routeTLSName is preserved across implicit route reconnections.
 	for i := 0; i < 3; i++ {
 		s2.mu.RLock()
 		s2.forEachRoute(func(r *client) {
@@ -1966,6 +1971,18 @@ func TestRouteTLSNamePreservedOnGossipReconnect(t *testing.T) {
 		if savedTLSName != "localhost" {
 			t.Fatalf("routeTLSName should still be 'localhost' after implicit route reconnect, got %q", savedTLSName)
 		}
+	}
+
+	// Simulate the HostnameError recovery path: when routeTLSName is cleared
+	// (e.g., by a HostnameError), routeTLSLastName should allow it to be
+	// restored for IP-based route URLs, giving the hostname one more chance
+	// before falling back to the IP.
+	s2.mu.Lock()
+	s2.routeTLSName = _EMPTY_
+	restoredName := s2.routeTLSLastName
+	s2.mu.Unlock()
+	if restoredName != "localhost" {
+		t.Fatalf("routeTLSLastName should be 'localhost', got %q", restoredName)
 	}
 }
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1903,6 +1903,72 @@ func TestRouteSaveTLSName(t *testing.T) {
 	checkClusterFormed(t, s1, s2, s3)
 }
 
+func TestRouteTLSNamePreservedOnGossipReconnect(t *testing.T) {
+	c1Conf := createConfFile(t, []byte(`
+		port: -1
+		cluster {
+			name: "abc"
+			port: -1
+			pool_size: -1
+			tls {
+				cert_file: '../test/configs/certs/server-noip.pem'
+				key_file: '../test/configs/certs/server-key-noip.pem'
+				ca_file: '../test/configs/certs/ca.pem'
+			}
+		}
+	`))
+	s1, o1 := RunServerWithConfig(c1Conf)
+	defer s1.Shutdown()
+
+	tmpl := `
+	port: -1
+	cluster {
+		name: "abc"
+		port: -1
+		pool_size: -1
+		routes: ["nats://%s:%d"]
+		tls {
+			cert_file: '../test/configs/certs/server-noip.pem'
+			key_file: '../test/configs/certs/server-key-noip.pem'
+			ca_file: '../test/configs/certs/ca.pem'
+		}
+	}
+	`
+	c2Conf := createConfFile(t, []byte(fmt.Sprintf(tmpl, "localhost", o1.Cluster.Port)))
+	s2, _ := RunServerWithConfig(c2Conf)
+	defer s2.Shutdown()
+
+	checkClusterFormed(t, s1, s2)
+
+	s2.mu.RLock()
+	savedTLSName := s2.routeTLSName
+	s2.mu.RUnlock()
+	if savedTLSName != "localhost" {
+		t.Fatalf("routeTLSName should be 'localhost', got %q", savedTLSName)
+	}
+
+	for i := 0; i < 3; i++ {
+		s2.mu.RLock()
+		s2.forEachRoute(func(r *client) {
+			r.mu.Lock()
+			if r.route.routeType == Implicit {
+				r.nc.Close()
+			}
+			r.mu.Unlock()
+		})
+		s2.mu.RUnlock()
+
+		checkClusterFormed(t, s1, s2)
+
+		s2.mu.RLock()
+		savedTLSName = s2.routeTLSName
+		s2.mu.RUnlock()
+		if savedTLSName != "localhost" {
+			t.Fatalf("routeTLSName should still be 'localhost' after implicit route reconnect, got %q", savedTLSName)
+		}
+	}
+}
+
 func TestRoutePoolAndPerAccountErrors(t *testing.T) {
 	conf := createConfFile(t, []byte(`
 		port: -1

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -2030,12 +2030,14 @@ func TestRouteTLSNameBackupRestoreOnHostnameError(t *testing.T) {
 	// The cluster should now be able to reform using the restored hostname.
 	checkClusterFormed(t, s1, s2)
 
-	// The backup should be consumed after the restore.
+	// The backup is not consumed on restore, so it remains available for
+	// future HostnameError recovery (e.g., after IP-SAN fallback clears
+	// routeTLSName, the backup can still restore it for DNS-only peers).
 	s2.mu.RLock()
 	savedTLSLastName = s2.routeTLSLastName
 	s2.mu.RUnlock()
-	if savedTLSLastName != _EMPTY_ {
-		t.Fatalf("routeTLSLastName should be consumed (empty), got %q", savedTLSLastName)
+	if savedTLSLastName != "localhost" {
+		t.Fatalf("routeTLSLastName should still be 'localhost' (not consumed), got %q", savedTLSLastName)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -225,6 +225,7 @@ type Server struct {
 	routeResolver       netResolver
 	routesToSelf        map[string]struct{}
 	routeTLSName        string
+	routeTLSLastName    string
 	leafNodeListener    net.Listener
 	leafNodeListenerErr error
 	leafNodeInfo        Info


### PR DESCRIPTION
Resolves #8309.

### Problem
When a route TLS connection uses a saved `tlsName` (e.g. `routeTLSName`) as the ServerName fallback — because the URL hostname is an IP (typical for gossip-discovered routes) — and the handshake fails with `x509.HostnameError`, the saved `tlsName` was cleared. This caused all subsequent reconnection attempts via gossip to use the IP as `ServerName`, which permanently fails against certificates that only have DNS SANs (no IP SANs).

### Change
Add a persistent backup field `routeTLSLastName` that stores the hostname from configured route URLs alongside `routeTLSName`. When `routeTLSName` is cleared on `HostnameError` for an IP-based route URL, restore it from the backup. The backup is **not** consumed so it remains available for future recovery:

- **DNS-only SAN certificates** (#8309): `routeTLSName` is restored from the backup after a `HostnameError`, allowing the hostname to be retried on the next reconnection
- **Mixed DNS/IP SAN environments** (#1256): After restore, if the hostname fails again, `routeTLSName` is cleared and the IP is tried. The backup persists, so after the IP-SAN peer succeeds, a later DNS-only peer connection can still restore `routeTLSName` from the backup

Additionally, when a handshake fails with an IP URL and `routeTLSName` is already empty but the backup is available, restore `routeTLSName` from the backup for the next attempt.

### Review feedback addressed
- **P1 (persistent backup)**: `routeTLSLastName` is no longer consumed on restore, so it remains available for future DNS-only peer connections even after IP-SAN fallback clears `routeTLSName`
- **P2 (data race)**: All reads/writes of `routeTLSLastName` and `routeTLSName` are protected by `s.mu`
- **Test coverage**: `TestRouteTLSNameBackupRestoreOnHostnameError` now exercises the backup restore path end-to-end: clears `routeTLSName`, triggers reconnection, verifies TLS error occurs, verifies backup restore, and verifies cluster reformation

### Files changed
- `server/server.go`: Add `routeTLSLastName` field
- `server/route.go`: Save backup in `saveRouteTLSName`; restore from backup on `HostnameError` for IP URLs; also restore when handshake fails with empty `routeTLSName`
- `server/routes_test.go`: `TestRouteTLSNameBackupRestoreOnHostnameError` exercises backup restore end-to-end

Signed-off-by: Manideep Rayala <manideep3969@gmail.com>