### PR TITLE
(2.15) NRG: Relax SyncAlways for replicated streams

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -69,6 +69,8 @@ type FileStoreConfig struct {
 	SyncInterval time.Duration
 	// SyncAlways is when the stream should sync all data writes.
 	SyncAlways bool
+	// SyncOnFlush relaxes SyncAlways to flush writes on FlushAllPending.
+	SyncOnFlush bool
 	// AsyncFlush allows async flush to batch write operations.
 	AsyncFlush bool
 	// Cipher is the cipher to use when encrypting.
@@ -187,9 +189,11 @@ type fileStore struct {
 	ageChkTime  int64       // When the message expiration is scheduled to run.
 	recovering  bool        // Timers, schedules, TTLs etc won't fire while set.
 	syncTmr     *time.Timer
+	syncMu      sync.Mutex // Serializes background and explicit block syncs.
 	cfg         FileStreamInfo
 	fcfg        FileStoreConfig
-	syncAlways  atomic.Bool // Mirrors FileStoreConfig.SyncAlways for lock-free reads from writeFileWithOptionalSync.
+	syncAlways  atomic.Bool // Effective SyncAlways behavior for lock-free reads.
+	syncOnFlush atomic.Bool // Effective sync on flush behavior. True only if SyncAlways and replicas > 1.
 	prf         keyGen
 	oldprf      keyGen
 	aek         cipher.AEAD
@@ -266,7 +270,6 @@ type msgBlock struct {
 	noTrack     bool
 	needSync    bool
 	needKeySync bool // Key file is written once and immutable, cleared after its one sync.
-	syncAlways  bool
 	noCompact   bool
 	closed      bool
 	ttls        uint64 // How many msgs have TTLs?
@@ -462,7 +465,8 @@ func newFileStoreWithCreatedAndMode(fcfg FileStoreConfig, cfg StreamConfig, crea
 		srv:        fcfg.srv,
 		recovering: recovering,
 	}
-	fs.syncAlways.Store(fcfg.SyncAlways)
+	fs.syncAlways.Store(fcfg.SyncAlways && !fcfg.SyncOnFlush)
+	fs.syncOnFlush.Store(fcfg.SyncOnFlush)
 
 	// Register with access time service.
 	ats.Register()
@@ -679,6 +683,45 @@ func (fs *fileStore) setCreatedTime(created time.Time) {
 	fs.mu.Unlock()
 }
 
+func (fs *fileStore) updateDurabilitySettingsLocked(replicas int) {
+	if !fs.fcfg.SyncAlways {
+		return
+	}
+	// If the stream is backed by a Raft WAL we relax the SyncAlways
+	// setting in favor of SyncOnFlush. Enable the new sync mode
+	// before disabling the old one so writes are never processed
+	// with both modes disabled.
+	if replicas > 1 {
+		fs.syncOnFlush.Store(true)
+		fs.syncAlways.Store(false)
+	} else {
+		fs.syncAlways.Store(true)
+		fs.syncOnFlush.Store(false)
+	}
+}
+
+// flushForScaleDown transitions a SyncOnFlush store back to SyncAlways.
+func (fs *fileStore) flushForScaleDown() error {
+	fs.mu.Lock()
+	if !fs.fcfg.SyncAlways {
+		fs.mu.Unlock()
+		return fs.FlushAllPending()
+	}
+	// Turn off syncOnFlush, and enable sync after every write.
+	// First enable sync after every write, so that any inflight
+	// or subsequent write gets synced
+	fs.updateDurabilitySettingsLocked(1)
+	fs.mu.Unlock()
+
+	// Sync all dirty blocks, so that we no longer have to rely
+	// on the backing Raft WAL.
+	fs.syncBlocks()
+
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	return fs.werr
+}
+
 func (fs *fileStore) UpdateConfig(cfg *StreamConfig) error {
 	start := time.Now()
 	defer func() {
@@ -748,6 +791,8 @@ func (fs *fileStore) UpdateConfig(cfg *StreamConfig) error {
 		}
 	}
 
+	fs.updateDurabilitySettingsLocked(cfg.Replicas)
+
 	if lmb := fs.lmb; lmb != nil {
 		// Enable/disable async flush depending on if it's supported and already initialized.
 		supportsAsyncFlush := !fs.fcfg.SyncAlways && cfg.Replicas > 1
@@ -758,9 +803,6 @@ func (fs *fileStore) UpdateConfig(cfg *StreamConfig) error {
 			supportsAsyncFlush = true
 			fs.fcfg.SyncAlways = false
 			fs.syncAlways.Store(false)
-			lmb.mu.Lock()
-			lmb.syncAlways = false
-			lmb.mu.Unlock()
 		}
 
 		if supportsAsyncFlush && !fs.fcfg.AsyncFlush {
@@ -1111,12 +1153,11 @@ func (fs *fileStore) noTrackSubjects() bool {
 // Will init the basics for a message block.
 func (fs *fileStore) initMsgBlock(index uint32) *msgBlock {
 	mb := &msgBlock{
-		fs:         fs,
-		index:      index,
-		cexp:       fs.fcfg.CacheExpire,
-		fexp:       fs.fcfg.SubjectStateExpire,
-		noTrack:    fs.noTrackSubjects(),
-		syncAlways: fs.fcfg.SyncAlways,
+		fs:      fs,
+		index:   index,
+		cexp:    fs.fcfg.CacheExpire,
+		fexp:    fs.fcfg.SubjectStateExpire,
+		noTrack: fs.noTrackSubjects(),
 	}
 
 	mdir := filepath.Join(fs.fcfg.StoreDir, msgDir)
@@ -5163,7 +5204,7 @@ func (fs *fileStore) genEncryptionKeysForBlock(mb *msgBlock) error {
 	if _, err := os.Stat(keyFile); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	sync := fs.syncAlways.Load()
+	sync := fs.syncAlways.Load() || fs.syncOnFlush.Load()
 	err = writeAtomically(fs.dios, keyFile, encrypted, defaultFilePerms, sync)
 	if err != nil {
 		return err
@@ -5676,6 +5717,12 @@ func (fs *fileStore) FlushAllPending() error {
 	defer fs.mu.Unlock()
 	// Return previous write errors immediately.
 	if fs.werr != nil {
+		return fs.werr
+	}
+	if fs.syncOnFlush.Load() {
+		fs.mu.Unlock()
+		fs.syncBlocks()
+		fs.mu.Lock()
 		return fs.werr
 	}
 	return fs.checkAndFlushLastBlock()
@@ -6504,7 +6551,7 @@ func (mb *msgBlock) compactWithFloor(floor uint64, fsDmap *interiorDeletes) erro
 
 	// We will write to a new file and mv/rename it in case of failure.
 	mfn := filepath.Join(mb.fs.fcfg.StoreDir, msgDir, fmt.Sprintf(newScan, mb.index))
-	sync := mb.syncAlways
+	sync := mb.fs.syncAlways.Load() || mb.fs.syncOnFlush.Load()
 	if err := writeAtomicallyWithTemp(mb.fs.dios, mfn, mb.mfn, nbuf, defaultFilePerms, sync); err != nil {
 		return err
 	}
@@ -8114,6 +8161,9 @@ func (mb *msgBlock) syncFile() error {
 
 // Sync msg and index files as needed. This is called from a timer.
 func (fs *fileStore) syncBlocks() {
+	fs.syncMu.Lock()
+	defer fs.syncMu.Unlock()
+
 	if fs.isClosed() {
 		return
 	}
@@ -8275,7 +8325,7 @@ func (fs *fileStore) syncBlocks() {
 	}
 
 	// Sync state file if we are not running with sync always.
-	if !fs.fcfg.SyncAlways {
+	if !fs.syncAlways.Load() {
 		fn := filepath.Join(fs.fcfg.StoreDir, msgDir, streamStreamStateFile)
 		var fd *os.File
 		var err error
@@ -8676,7 +8726,7 @@ func (mb *msgBlock) flushPendingMsgsLocked() (*LostStreamData, error) {
 	mb.cache.wp = int(wp)
 
 	// Check if we are in sync always mode.
-	if mb.syncAlways {
+	if mb.fs.syncAlways.Load() {
 		if err = mb.mfd.Sync(); err != nil {
 			mb.werr = err
 			assert.Unreachable("Filestore msg block encountered sync error", map[string]any{
@@ -14499,7 +14549,8 @@ func (alg StoreCompression) Decompress(buf []byte) ([]byte, error) {
 // sets O_SYNC on the open file if SyncAlways is set. The dios semaphore is
 // handled automatically by this function, so don't wrap calls to it in dios.
 func (fs *fileStore) writeFileWithOptionalSync(name string, data []byte, perm fs.FileMode) error {
-	return writeAtomically(fs.dios, name, data, perm, fs.syncAlways.Load())
+	sync := fs.syncAlways.Load() || fs.syncOnFlush.Load()
+	return writeAtomically(fs.dios, name, data, perm, sync)
 }
 
 func writeFileWithSync(dios *diskIOSemaphore, name string, data []byte, perm fs.FileMode) error {

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -8051,14 +8051,24 @@ func TestFileStoreMsgBlockShouldCompact(t *testing.T) {
 }
 
 func TestFileStoreInlineCompactionSync(t *testing.T) {
-	for _, syncAlways := range []bool{false, true} {
-		t.Run(fmt.Sprintf("sync_always_%v", syncAlways), func(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		syncAlways  bool
+		syncOnFlush bool
+		needSync    bool
+	}{
+		{"no_sync", false, false, true},
+		{"sync_always", true, false, false},
+		{"sync_on_flush", true, true, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
 			fs, err := newFileStore(
 				FileStoreConfig{
 					StoreDir:     t.TempDir(),
 					BlockSize:    3 * 1024 * 1024,
 					SyncInterval: time.Hour,
-					SyncAlways:   syncAlways,
+					SyncAlways:   test.syncAlways,
+					SyncOnFlush:  test.syncOnFlush,
 				},
 				StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage},
 			)
@@ -8100,8 +8110,8 @@ func TestFileStoreInlineCompactionSync(t *testing.T) {
 			fmb.mu.RUnlock()
 			// Compaction happened
 			require_LessThan(t, newRawbytes, oldRawbytes)
-			// SyncAlways store should sync inline compaction
-			require_Equal(t, needSync, !syncAlways)
+			// Durability modes should sync inline compaction.
+			require_Equal(t, needSync, test.needSync)
 		})
 	}
 }
@@ -15465,6 +15475,24 @@ func TestFileStoreEncryptionKeyFileSyncedBySyncBlocks(t *testing.T) {
 	fs2.mu.RLock()
 	lmb = fs2.lmb
 	fs2.mu.RUnlock()
+	require_NotNil(t, lmb)
+	lmb.mu.RLock()
+	needKeySync = lmb.needKeySync
+	lmb.mu.RUnlock()
+	require_False(t, needKeySync)
+
+	// With SyncOnFlush the key file write is also already synced, so the flag should not be set.
+	fcfg = FileStoreConfig{StoreDir: t.TempDir(), Cipher: AES, SyncAlways: true, SyncOnFlush: true}
+	fs3, err := newFileStoreWithCreated(fcfg, StreamConfig{Name: "S3", Storage: FileStorage}, time.Now(), prf(&fcfg), nil)
+	require_NoError(t, err)
+	defer fs3.Stop()
+
+	_, _, err = fs3.StoreMsg("foo", nil, []byte("Hello World"), 0)
+	require_NoError(t, err)
+
+	fs3.mu.RLock()
+	lmb = fs3.lmb
+	fs3.mu.RUnlock()
 	require_NotNil(t, lmb)
 	lmb.mu.RLock()
 	needKeySync = lmb.needKeySync

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -271,6 +271,17 @@ func (sa *streamAssignment) desiredOrigin() *desiredRaftGroupOrigin {
 	return sa.legacyMoveOrigin()
 }
 
+// isR1ScaleUpSource reports whether the given peer is the source for an
+// in-progress R1 scale-up.
+func (sa *streamAssignment) isR1ScaleUpSource(peer string) bool {
+	if sa == nil || sa.Group == nil || sa.Group.Desired == nil {
+		return false
+	}
+	d := sa.Group.Desired
+	return d.Origin != nil && d.Origin.Replicas == 1 && len(d.Peers) > 1 &&
+		len(d.Origin.Peers) == 1 && d.Origin.Peers[0] == peer
+}
+
 // moveInFlight returns whether a move is still converging, including one that was
 // started before the upgrade to desired state.
 func (sa *streamAssignment) moveInFlight() bool {
@@ -891,14 +902,14 @@ func (s *Server) JetStreamSnapshotStream(account, stream string) error {
 
 	// Hold lock when installing snapshot.
 	mset.mu.Lock()
+	defer mset.mu.Unlock()
 	if mset.node == nil {
-		mset.mu.Unlock()
 		return nil
 	}
-	err = mset.node.InstallSnapshot(mset.stateSnapshotLocked(), false)
-	mset.mu.Unlock()
-
-	return err
+	if err := mset.flushAllPending(); err != nil {
+		return err
+	}
+	return mset.node.InstallSnapshot(mset.stateSnapshotLocked(), false)
 }
 
 func (s *Server) JetStreamClusterPeers() []string {
@@ -3648,6 +3659,49 @@ func (mset *stream) waitOnConsumerAssignments() {
 	}
 }
 
+func prepareStreamRecovery(mset *stream, n RaftNode) error {
+	if n == nil || mset == nil || !mset.shouldReplayFromWAL() {
+		return nil
+	}
+
+	index, _, _ := n.Progress()
+	if index == 0 {
+		return nil
+	}
+
+	snapIndex, snapData, err := n.LoadLastSnapshot()
+	if err != nil {
+		if err != errNoSnapAvailable {
+			return err
+		}
+		// A newly created R3 stream can legitimately have no
+		// snapshot before its first periodic snapshot.
+		// In that case the WAL contains a complete history
+		// we can replay from.
+		// During an R1 scaleup, the new WAL does not contain
+		// the existing R1 history. Preserve the store if
+		// the source has restarted before the initial snapshot
+		// was installed
+		if mset.streamAssignment().isR1ScaleUpSource(n.ID()) {
+			return nil
+		}
+	}
+
+	// In case of clean shutdown, no need to replay from WAL
+	if snapIndex == index {
+		return nil
+	}
+
+	var snap *StreamReplicatedState
+	if err == nil {
+		snap, err = decodeStreamSnapshot(snapData)
+		if err != nil {
+			return err
+		}
+	}
+	return mset.prepareForWALReplay(snap)
+}
+
 // Monitor our stream node for this stream.
 func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnapshot bool) {
 	s, cc := js.server(), js.cluster
@@ -3726,6 +3780,16 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 	// Don't allow the upper layer to install snapshots until we have
 	// fully recovered from disk.
 	isRecovering := true
+
+	// Prepare the store for recovery. A newly created Raft node for
+	// an existing stream will skip this step, and instead bootstrap
+	// the WAL with a snapshot.
+	if !sendSnapshot {
+		if err := prepareStreamRecovery(mset, n); err != nil {
+			s.Warnf("Error preparing WAL replay recovery for stream '%s > %s': %v", accName, sa.Config.Name, err)
+			return
+		}
+	}
 
 	var (
 		snapMu           sync.Mutex
@@ -4613,6 +4677,17 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 		return mstat(MigrationStatusMembership, "stepping down before removing ourselves").withErr(err)
 	}
 
+	// Before publishing a stable R1 assignment, make the store independently durable
+	// because applying the assignment will remove the Raft node and its WAL.
+	if exactMatch && replicas == 1 {
+		if err := mset.flushForScaleDown(); err != nil {
+			if errors.Is(err, ErrStoreClosed) {
+				return mstat(MigrationStatusUnavailable, "shutting down")
+			}
+			return mstat(MigrationStatusSnapshot, "waiting to flush stream before finalizing R1 assignment").withErr(err)
+		}
+	}
+
 	// We're done.
 	update.MetaPeers = actualPeers
 	update.PeersMatch = exactMatch
@@ -5116,9 +5191,6 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				return 0, fmt.Errorf("unknown stream entry op type: %v", op)
 			}
 		} else if e.Type == EntrySnapshot {
-			// Everything operates on new replicated state. Will convert legacy snapshots to this for processing.
-			var ss *StreamReplicatedState
-
 			onBadState := func(err error) {
 				// If we are the leader or recovering, meaning we own the snapshot,
 				// we should stepdown and clear our raft state since our snapshot is bad.
@@ -5131,31 +5203,10 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				}
 			}
 
-			// Check if we are the new binary encoding.
-			if IsEncodedStreamState(e.Data) {
-				var err error
-				ss, err = DecodeStreamState(e.Data)
-				if err != nil {
-					onBadState(err)
-					return 0, err
-				}
-			} else {
-				var snap streamSnapshot
-				if err := json.Unmarshal(e.Data, &snap); err != nil {
-					onBadState(err)
-					return 0, err
-				}
-				// Convert over to StreamReplicatedState
-				ss = &StreamReplicatedState{
-					Msgs:     snap.Msgs,
-					Bytes:    snap.Bytes,
-					FirstSeq: snap.FirstSeq,
-					LastSeq:  snap.LastSeq,
-					Failed:   snap.Failed,
-				}
-				if len(snap.Deleted) > 0 {
-					ss.Deleted = append(ss.Deleted, DeleteSlice(snap.Deleted))
-				}
+			ss, err := decodeStreamSnapshot(e.Data)
+			if err != nil {
+				onBadState(err)
+				return 0, err
 			}
 
 			if err := mset.processSnapshot(ss, ce.Index); err != nil {
@@ -11752,6 +11803,28 @@ type streamSnapshot struct {
 	Deleted  []uint64 `json:"deleted,omitempty"`
 }
 
+func decodeStreamSnapshot(data []byte) (*StreamReplicatedState, error) {
+	if IsEncodedStreamState(data) {
+		return DecodeStreamState(data)
+	}
+
+	var snap streamSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return nil, err
+	}
+	state := &StreamReplicatedState{
+		Msgs:     snap.Msgs,
+		Bytes:    snap.Bytes,
+		FirstSeq: snap.FirstSeq,
+		LastSeq:  snap.LastSeq,
+		Failed:   snap.Failed,
+	}
+	if len(snap.Deleted) > 0 {
+		state.Deleted = append(state.Deleted, DeleteSlice(snap.Deleted))
+	}
+	return state, nil
+}
+
 // Grab a snapshot of a stream for clustered mode.
 func (mset *stream) stateSnapshot() []byte {
 	mset.mu.RLock()
@@ -12169,9 +12242,9 @@ func (mset *stream) processSnapshot(snap *StreamReplicatedState, index uint64) (
 		return errCatchupCorruptSnapshot
 	}
 
-	// Just return if up to date.
+	// No catchup is needed, flush any snapshot deletes before returning.
 	if sreq == nil {
-		return nil
+		return mset.flushAllPending()
 	}
 
 	// We need to catch up, but are already exceeding limits.
@@ -12302,7 +12375,7 @@ RETRY:
 		sreq = mset.calculateSyncRequest(&state, snap, index)
 		mset.mu.RUnlock()
 		if sreq == nil {
-			return nil
+			return mset.flushAllPending()
 		}
 	}
 
@@ -12548,6 +12621,13 @@ func (mset *stream) processCatchupMsg(msg []byte) (uint64, error) {
 // flushAllPending will flush any pending writes as a result of installing a snapshot or performing catchup.
 func (mset *stream) flushAllPending() error {
 	return mset.store.FlushAllPending()
+}
+
+func (mset *stream) flushForScaleDown() error {
+	if fs, ok := mset.store.(*fileStore); ok {
+		return fs.flushForScaleDown()
+	}
+	return nil
 }
 
 func (mset *stream) handleClusterSyncRequest(sub *subscription, c *client, _ *Account, subject, reply string, msg []byte) {
@@ -13113,11 +13193,13 @@ func (mset *stream) runCatchup(sendSubject string, sreq *streamSyncRequest) {
 						s.Warnf("Catchup for stream '%s > %s' completed (took %v), but requested sequence %d was larger than current state: %+v",
 							mset.account(), mset.name(), time.Since(start).Round(time.Millisecond), seq, state)
 						// Try our best to redo our invalidated snapshot as well.
-						if n := mset.raftNode(); n != nil {
-							if snap := mset.stateSnapshot(); snap != nil {
-								n.InstallSnapshot(snap, true)
+						mset.mu.Lock()
+						if n := mset.node; n != nil {
+							if err := mset.flushAllPending(); err == nil {
+								n.InstallSnapshot(mset.stateSnapshotLocked(), true)
 							}
 						}
+						mset.mu.Unlock()
 						// If we allow gap markers check if we have one pending.
 						if drOk && dr.First > 0 {
 							sendDR()

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -11811,6 +11811,182 @@ func TestJetStreamClusterAsyncFlushBasics(t *testing.T) {
 	t.Run("SyncAlways", func(t *testing.T) { test(t, true) })
 }
 
+func TestJetStreamClusterFileStoreSyncOnFlushReplicaTransitions(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	for _, s := range c.servers {
+		s.optsMu.Lock()
+		s.opts.SyncAlways = true
+		s.optsMu.Unlock()
+	}
+
+	nc, _ := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	cfg := &StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Storage:  FileStorage,
+		Replicas: 3,
+	}
+	_, err := jsStreamCreate(t, nc, cfg)
+	require_NoError(t, err)
+
+	checkMode := func(expectSyncAlways, expectSyncOnFlush bool) {
+		t.Helper()
+		s := c.streamLeader(globalAccountName, cfg.Name)
+		mset, err := s.globalAccount().lookupStream(cfg.Name)
+		require_NoError(t, err)
+		fs := mset.Store().(*fileStore)
+		fs.mu.RLock()
+		configuredSyncAlways := fs.fcfg.SyncAlways
+		configuredSyncOnFlush := fs.fcfg.SyncOnFlush
+		fs.mu.RUnlock()
+		require_True(t, configuredSyncAlways)
+		require_True(t, configuredSyncOnFlush)
+		require_Equal(t, fs.syncAlways.Load(), expectSyncAlways)
+		require_Equal(t, fs.syncOnFlush.Load(), expectSyncOnFlush)
+	}
+
+	checkMode(false, true)
+
+	cfg.Replicas = 1
+	_, err = jsStreamUpdate(t, nc, cfg)
+	require_NoError(t, err)
+	c.waitOnStreamLeader(globalAccountName, cfg.Name)
+	checkMode(true, false)
+	const numMsgs = 10
+	for range numMsgs {
+		sendStreamMsg(t, nc, "foo", "msg")
+	}
+
+	cfg.Replicas = 3
+	_, err = jsStreamUpdate(t, nc, cfg)
+	require_NoError(t, err)
+	c.waitOnStreamLeader(globalAccountName, cfg.Name)
+	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		return checkState(t, c, globalAccountName, cfg.Name)
+	})
+	checkMode(false, true)
+
+	s := c.streamLeader(globalAccountName, cfg.Name)
+	mset, err := s.globalAccount().lookupStream(cfg.Name)
+	require_NoError(t, err)
+	state := mset.state()
+	require_Equal(t, state.Msgs, numMsgs)
+	require_Equal(t, state.LastSeq, numMsgs)
+}
+
+func TestJetStreamClusterPrepareForWALReplayDoesNotAdvanceStore(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Storage: nats.FileStorage})
+	require_NoError(t, err)
+	_, err = js.Publish("foo", []byte("one"))
+	require_NoError(t, err)
+
+	mset, err := s.GlobalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	require_NoError(t, mset.prepareForWALReplay(&StreamReplicatedState{LastSeq: 2}))
+
+	state := mset.state()
+	require_Equal(t, state.Msgs, 1)
+	require_Equal(t, state.LastSeq, 1)
+	require_Equal(t, mset.lastSeq(), 1)
+}
+
+type snapshotlessRaftNode struct {
+	RaftNode
+	id string
+}
+
+func (n *snapshotlessRaftNode) ID() string                         { return n.id }
+func (n *snapshotlessRaftNode) Progress() (uint64, uint64, uint64) { return 1, 1, 0 }
+func (n *snapshotlessRaftNode) LoadLastSnapshot() (uint64, []byte, error) {
+	return 0, nil, errNoSnapAvailable
+}
+
+func TestJetStreamClusterPrepareForWALReplayPreservesR1ScaleUpSource(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Storage: nats.FileStorage})
+	require_NoError(t, err)
+	for range 3 {
+		_, err = js.Publish("foo", []byte("msg"))
+		require_NoError(t, err)
+	}
+
+	mset, err := s.GlobalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	fs := mset.store.(*fileStore)
+	fs.syncOnFlush.Store(true)
+
+	// Simulate the original R1 peer restarting before bootstrap completed.
+	const source = "source"
+	n := &snapshotlessRaftNode{id: source}
+	mset.mu.Lock()
+	mset.node = n
+	mset.sa = &streamAssignment{Group: &raftGroup{Desired: &desiredRaftGroup{
+		Peers: []string{source, "peer-2", "peer-3"},
+		Origin: &desiredRaftGroupOrigin{
+			Peers:    []string{source},
+			Replicas: 1,
+		},
+	}}}
+	mset.mu.Unlock()
+	defer func() {
+		mset.mu.Lock()
+		mset.node, mset.sa = nil, nil
+		mset.mu.Unlock()
+	}()
+
+	// Its new WAL cannot reconstruct the existing R1 stream state,
+	// prepareStreamRecovery must preserve the stream store
+	require_NoError(t, prepareStreamRecovery(mset, n))
+	state := mset.state()
+	require_Equal(t, state.Msgs, 3)
+	require_Equal(t, state.LastSeq, 3)
+}
+
+func TestJetStreamClusterPrepareForWALReplayTruncatesStore(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Storage: nats.FileStorage})
+	require_NoError(t, err)
+	for range 3 {
+		_, err = js.Publish("foo", []byte("msg"))
+		require_NoError(t, err)
+	}
+
+	mset, err := s.GlobalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+
+	state := mset.state()
+	require_Equal(t, state.Msgs, 3)
+	require_Equal(t, state.LastSeq, 3)
+	require_Equal(t, mset.lastSeq(), 3)
+
+	require_NoError(t, mset.prepareForWALReplay(&StreamReplicatedState{LastSeq: 2}))
+
+	state = mset.state()
+	require_Equal(t, state.Msgs, 2)
+	require_Equal(t, state.LastSeq, 2)
+	require_Equal(t, mset.lastSeq(), 2)
+}
+
 func TestJetStreamClusterAsyncFlushFileStoreFlushOnSnapshot(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/raft.go
+++ b/server/raft.go
@@ -41,6 +41,7 @@ type RaftNode interface {
 	Propose(term uint64, entry []byte) error
 	ProposeMulti(term uint64, entries []*Entry) error
 	ForwardProposal(entry []byte) error
+	LoadLastSnapshot() (uint64, []byte, error)
 	InstallSnapshot(snap []byte, force bool) error
 	CreateSnapshotCheckpoint(force bool) (RaftNodeCheckpoint, error)
 	SendSnapshot(snap []byte) error
@@ -1977,6 +1978,19 @@ func (n *raft) setupLastSnapshot() error {
 	}
 
 	return nil
+}
+
+func (n *raft) LoadLastSnapshot() (uint64, []byte, error) {
+	n.Lock()
+	defer n.Unlock()
+	snap, err := n.loadLastSnapshot()
+	if err != nil {
+		return 0, nil, err
+	}
+	if snap.lastIndex != n.papplied {
+		return 0, nil, errors.New("snapshot index mismatch")
+	}
+	return snap.lastIndex, snap.data, nil
 }
 
 // loadLastSnapshot will load and return our last snapshot.

--- a/server/stream.go
+++ b/server/stream.go
@@ -1096,6 +1096,15 @@ func (a *Account) addStreamWithAssignmentAndMode(config *StreamConfig, fsConfig 
 		fsCfg.SyncAlways = false
 		fsCfg.AsyncFlush = true
 	}
+
+	// If the stream is backed by a Raft log, we can relax
+	// SyncAlways so that we flush and sync whenever a
+	// stream snapshot is created. We can safely recover
+	// from the snapshot and the tail of the log.
+	if fsCfg.SyncAlways && config.Replicas > 1 {
+		fsCfg.SyncOnFlush = true
+	}
+
 	if err := mset.setupStore(fsCfg, recovering || restoring); err != nil {
 		mset.stop(true, false)
 		return nil, NewJSStreamStoreFailedError(err)
@@ -1606,6 +1615,63 @@ func (mset *stream) rebuildDedupe() {
 			mset.lmsgId = msgId
 		}
 	}
+}
+
+// Returns true if the underlying store should use the
+// Raft log for replaying the tail of stream during
+// recovery.
+func (mset *stream) shouldReplayFromWAL() bool {
+	if mset == nil || mset.node == nil || mset.store == nil || mset.store.Type() != FileStorage {
+		return false
+	}
+	fs, ok := mset.store.(*fileStore)
+	if !ok {
+		return false
+	}
+	return fs.syncOnFlush.Load()
+}
+
+// prepareForWALReplay truncates any stream filestore tail past the last
+// sequence of the given snapshot, in preparation of replaying the Raft log.
+func (mset *stream) prepareForWALReplay(snap *StreamReplicatedState) error {
+	if mset == nil || mset.store == nil {
+		return nil
+	}
+
+	mset.mu.Lock()
+	defer mset.mu.Unlock()
+
+	var snapSeq, clfs uint64
+	if snap != nil {
+		snapSeq = snap.LastSeq
+		clfs = snap.Failed
+	}
+
+	var state StreamState
+	mset.store.FastState(&state)
+	if state.LastSeq > snapSeq {
+		mset.srv.Debugf("Truncate to snapshot sequence %d", snapSeq)
+		if err := mset.store.Truncate(snapSeq); err != nil {
+			return err
+		}
+		mset.store.FastState(&state)
+	}
+
+	mset.lseq = state.LastSeq
+	mset.setCLFS(clfs)
+
+	mset.ddMu.Lock()
+	if mset.ddtmr != nil {
+		mset.ddtmr.Stop()
+		mset.ddtmr = nil
+	}
+	mset.ddmap = nil
+	mset.ddarr = nil
+	mset.ddindex = 0
+	mset.lmsgId = _EMPTY_
+	mset.rebuildDedupe()
+	mset.ddMu.Unlock()
+	return nil
 }
 
 // Lock should be held.


### PR DESCRIPTION
This patch reduces the number of calls fd.Sync() for replicated streams on servers configured with `sync_interval: always`. Before this patch, the server called `fd.Sync()` for each Raft `appendEntry`, plus one `fd.Sync` on the stream's filestore for each message batched in the same `appendEntry`. This commit introduces a new internal flush policy, which syncs the stream filestore only  only before creating a new snapshot. snapshot. This results in one `fd.Sync` call per raft appendEntry, plus one call for each dirty block in stream's filestore, before creating a snapshot.
This leaves streams fully recoverable, while getting rid of unnecessary `fd.Sync` calls.
