### PR TITLE
[FIXED] Idempotent stream create uses same created timestamp

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -2109,7 +2109,7 @@ func (js *jetStream) applyMetaSnapshot(buf []byte, ru *recoveryUpdates, isRecove
 			if nsa := nasa[sn]; nsa == nil {
 				// Stream was removed.
 				saDel = append(saDel, sa)
-			} else if !nsa.Created.Equal(sa.Created) {
+			} else if !nsa.Created.Equal(sa.Created) && (nsa.Group == nil || sa.Group == nil || nsa.Group.Name != sa.Group.Name) {
 				// Stream was recreated.
 				saDel = append(saDel, sa)
 				saAdd = append(saAdd, nsa)
@@ -2140,7 +2140,7 @@ func (js *jetStream) applyMetaSnapshot(buf []byte, ru *recoveryUpdates, isRecove
 				// Consumer was either removed or recreated.
 				if nca := sa.consumers[ca.Name]; nca == nil {
 					caDel = append(caDel, ca)
-				} else if !nca.Created.Equal(ca.Created) {
+				} else if !nca.Created.Equal(ca.Created) && (nca.Group == nil || ca.Group == nil || nca.Group.Name != ca.Group.Name) {
 					caDel = append(caDel, ca)
 				}
 			}
@@ -8478,8 +8478,13 @@ func (s *Server) jsClusteredStreamRequest(ci *ClientInfo, acc *Account, subject,
 	if syncSubject == _EMPTY_ {
 		syncSubject = syncSubjForStream()
 	}
+	// Preserve the original creation time on an idempotent create retry.
+	created := time.Now().UTC()
+	if self != nil {
+		created = self.Created
+	}
 	// Sync subject for post snapshot sync.
-	sa := &streamAssignment{Group: rg, Sync: syncSubject, Config: cfg, Subject: subject, Reply: reply, Client: ci, Created: time.Now().UTC()}
+	sa := &streamAssignment{Group: rg, Sync: syncSubject, Config: cfg, Subject: subject, Reply: reply, Client: ci, Created: created}
 	if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(sa)); err != nil {
 		return
 	}

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -11523,6 +11523,243 @@ func TestJetStreamClusterMetaSnapshotRecoveryScaleConsumer(t *testing.T) {
 	})
 }
 
+func TestJetStreamClusterStreamCreateRetryPreservesAssignmentCreated(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Replicas: 3}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	getCreated := func(s *Server) (time.Time, error) {
+		sjs := s.getJetStream()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		sa := sjs.streamAssignmentOrInflight(globalAccountName, "TEST")
+		if sa == nil {
+			return time.Time{}, fmt.Errorf("server %q has no stream assignment", s)
+		}
+		return sa.Created, nil
+	}
+	c.waitOnLeader()
+	created, err := getCreated(c.leader())
+	require_NoError(t, err)
+
+	// An idempotent create retry re-proposes the stream assignment.
+	_, err = js.AddStream(cfg)
+	require_NoError(t, err)
+
+	// The retry responds after its proposal applied, but replicas might lag.
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		for _, s := range c.servers {
+			sc, err := getCreated(s)
+			if err != nil {
+				return err
+			}
+			if !sc.Equal(created) {
+				return fmt.Errorf("server %q changed Created from %v to %v", s, created, sc)
+			}
+		}
+		return nil
+	})
+}
+
+func TestJetStreamClusterMetaSnapshotIdempotentCreatePreservesStream(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Replicas: 1}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	// Make sure the R1 stream is not hosted on the meta leader, so we can shut
+	// down its host while keeping the meta leader around.
+	sl := c.streamLeader(globalAccountName, "TEST")
+	require_NotNil(t, sl)
+	ml := c.leader()
+	require_NotNil(t, ml)
+	if sl == ml {
+		meta := ml.getJetStream().getMetaGroup()
+		require_NoError(t, meta.StepDown())
+		c.waitOnLeader()
+	}
+	ml = c.leader()
+	require_NotNil(t, ml)
+	require_NotEqual(t, sl, ml)
+
+	for range 10 {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+
+	// Capture the assignment's created time before the host goes down.
+	mljs := ml.getJetStream()
+	mljs.mu.RLock()
+	sa := mljs.streamAssignmentOrInflight(globalAccountName, "TEST")
+	if sa == nil {
+		mljs.mu.RUnlock()
+		t.Fatal("stream assignment not found")
+	}
+	created := sa.Created
+	mljs.mu.RUnlock()
+
+	sl.Shutdown()
+	sl.WaitForShutdown()
+
+	// Reconnect in case our client was on the downed server.
+	nc.Close()
+	nc, js = jsClientConnect(t, ml)
+	defer nc.Close()
+
+	// Perform an idempotent create while the host is down. The duplicate
+	// assignment is proposed, but the only member is down and can't respond.
+	_, err = js.AddStream(cfg, nats.MaxWait(time.Second))
+	require_Error(t, err, nats.ErrTimeout, context.DeadlineExceeded)
+
+	// Wait for the duplicate assignment to be applied, it must preserve the
+	// original created time.
+	var created2 time.Time
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		mljs.mu.RLock()
+		defer mljs.mu.RUnlock()
+		if len(mljs.cluster.inflightStreams[globalAccountName]) > 0 {
+			return fmt.Errorf("create proposal not applied yet")
+		}
+		nsa := mljs.streamAssignment(globalAccountName, "TEST")
+		if nsa == nil {
+			return fmt.Errorf("stream assignment not found")
+		}
+		if nsa == sa {
+			return fmt.Errorf("duplicate create proposal not applied yet")
+		}
+		created2 = nsa.Created
+		return nil
+	})
+	require_True(t, created2.Equal(created))
+
+	// Compact the meta log so the downed server recovers via snapshot and
+	// never replays the duplicate create entry.
+	require_NoError(t, ml.JetStreamSnapshotMeta())
+
+	// Restart. The server must not treat the idempotent create as a recreate,
+	// it holds the only copy of the data.
+	sl = c.restartServer(sl)
+	c.checkClusterFormed()
+	c.waitOnServerCurrent(sl)
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		state, err := checkStateAndErr(t, c, globalAccountName, "TEST")
+		if err != nil {
+			return err
+		}
+		if state.Msgs != 10 {
+			return fmt.Errorf("stream data lost on idempotent create: %+v", state)
+		}
+		return nil
+	})
+}
+
+func TestJetStreamClusterApplyMetaSnapshotRecreateDetection(t *testing.T) {
+	const acc, stream, consumer = "A", "TEST", "C"
+	created := time.Now().UTC()
+	recreatedTS := created.Add(time.Second)
+
+	group := func(name string) *raftGroup {
+		if name == _EMPTY_ {
+			return nil
+		}
+		return &raftGroup{Name: name, Storage: FileStorage}
+	}
+	scfg := &StreamConfig{Name: stream, Subjects: []string{"foo"}, Storage: FileStorage, Replicas: 3}
+	scfgJSON, err := json.Marshal(scfg)
+	require_NoError(t, err)
+	ccfg := &ConsumerConfig{Durable: consumer}
+	ccfgJSON, err := json.Marshal(ccfg)
+	require_NoError(t, err)
+
+	mkStream := func(created time.Time, groupName string) *streamAssignment {
+		return &streamAssignment{Client: &ClientInfo{Account: acc}, Created: created, Group: group(groupName), Config: scfg, ConfigJSON: scfgJSON}
+	}
+	mkConsumer := func(created time.Time, groupName string) *consumerAssignment {
+		return &consumerAssignment{Client: &ClientInfo{Account: acc}, Created: created, Group: group(groupName), Name: consumer, Stream: stream, Config: ccfg, ConfigJSON: ccfgJSON}
+	}
+
+	skey := mkStream(created, _EMPTY_).recoveryKey()
+	ckey := mkConsumer(created, _EMPTY_).recoveryKey()
+
+	applySnapshot := func(t *testing.T, osa, nsa *streamAssignment) *recoveryUpdates {
+		t.Helper()
+		js := &jetStream{srv: &Server{}, cluster: &jetStreamCluster{
+			streams: map[string]map[string]*streamAssignment{acc: {stream: osa}},
+		}}
+		buf, _, _, err := js.encodeMetaSnapshot(map[string]map[string]*streamAssignment{acc: {stream: nsa}})
+		require_NoError(t, err)
+		ru := &recoveryUpdates{
+			removeStreams:   make(map[string]*streamAssignment),
+			removeConsumers: make(map[string]map[string]*consumerAssignment),
+			addStreams:      make(map[string]*streamAssignment),
+			updateStreams:   make(map[string]*streamAssignment),
+			updateConsumers: make(map[string]map[string]*consumerAssignment),
+		}
+		require_NoError(t, js.applyMetaSnapshot(buf, ru, true))
+		return ru
+	}
+
+	for _, test := range []struct {
+		name      string
+		nCreated  time.Time
+		group     string
+		nGroup    string
+		recreated bool
+	}{
+		{"same created same group", created, "G-A", "G-A", false},
+		{"same created different group", created, "G-A", "G-B", false},
+		{"same created nil groups", created, _EMPTY_, _EMPTY_, false},
+		{"different created same group", recreatedTS, "G-A", "G-A", false},
+		{"different created different group", recreatedTS, "G-A", "G-B", true},
+		{"different created nil old group", recreatedTS, _EMPTY_, "G-A", true},
+		{"different created nil new group", recreatedTS, "G-A", _EMPTY_, true},
+		{"different created nil groups", recreatedTS, _EMPTY_, _EMPTY_, true},
+	} {
+		t.Run("stream/"+test.name, func(t *testing.T) {
+			osa := mkStream(created, test.group)
+			nsa := mkStream(test.nCreated, test.nGroup)
+			ru := applySnapshot(t, osa, nsa)
+
+			_, removed := ru.removeStreams[skey]
+			_, added := ru.addStreams[skey]
+			_, updated := ru.updateStreams[skey]
+			require_Equal(t, removed, test.recreated)
+			require_Equal(t, added, test.recreated)
+			require_Equal(t, updated, !test.recreated)
+		})
+
+		t.Run("consumer/"+test.name, func(t *testing.T) {
+			// Keep the stream itself unchanged so only the consumer varies.
+			osa := mkStream(created, "G-S")
+			osa.consumers = map[string]*consumerAssignment{consumer: mkConsumer(created, test.group)}
+			nsa := mkStream(created, "G-S")
+			nsa.consumers = map[string]*consumerAssignment{consumer: mkConsumer(test.nCreated, test.nGroup)}
+			ru := applySnapshot(t, osa, nsa)
+
+			_, updated := ru.updateStreams[skey]
+			require_True(t, updated)
+			_, removed := ru.removeConsumers[skey][ckey]
+			require_Equal(t, removed, test.recreated)
+			// The consumer from the snapshot is always (re)applied.
+			_, added := ru.updateConsumers[skey][ckey]
+			require_True(t, added)
+		})
+	}
+}
+
 // https://github.com/nats-io/nats-server/issues/8423
 func TestJetStreamClusterWorkQueueSourceMustNotAckOtherSubjects(t *testing.T) {
 	for _, replicas := range []int{1, 3} {


### PR DESCRIPTION
Follow-up of https://github.com/nats-io/nats-server/pull/8413

An idempotent stream create was not actually idempotent. The `Created` timestamp in the assignment would be updated to the current time, instead of preserving what was in the assignment already. This could result in recreating the stream and losing its data if such an "idempotent" stream create was performed while a node that hosts it was down and it then came back up and caught up from a meta snapshot containing the updated `Created` timestamp.

Only the `Created` timestamp is meant to be used for detecting a recreated stream/consumer. However, since the result of this bug may exist in meta logs for versions 2.14.4 and 2.12.14, this additional handling ensures the stream is only deleted when both the group name and the created time are different.