### PR TITLE
(2.15) Fix leaf node advertisement with no_advertise

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1030,7 +1030,9 @@ func (s *Server) startLeafNodeAcceptLoop() {
 		s.mu.Unlock()
 		return
 	}
-	s.leafURLsMap[s.leafNodeInfo.IP]++
+	if !opts.LeafNode.NoAdvertise {
+		s.leafURLsMap[s.leafNodeInfo.IP]++
+	}
 	s.generateLeafNodeInfoJSON()
 
 	// Setup state that can enable shutdown
@@ -1562,7 +1564,7 @@ func (c *client) processLeafnodeInfo(info *Info) {
 	if firstINFO && !c.flags.isSet(compressionNegotiated) {
 		// A solicited leafnode connection must first receive a leafnode INFO.
 		// Classify wrong-port connections before any leaf-specific negotiation.
-		if didSolicit && (info.CID == 0 || info.LeafNodeURLs == nil) {
+		if didSolicit && (info.CID == 0 || (info.LeafNodeURLs == nil && !info.InfoOnConnect)) {
 			c.mu.Unlock()
 			c.Errorf(ErrConnectedToWrongPort.Error())
 			c.closeConnection(WrongPort)

--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1187,6 +1187,59 @@ func TestLeafNodeRemoteWrongPort(t *testing.T) {
 	}
 }
 
+func TestLeafNodeNoAdvertiseDoesNotAdvertiseListener(t *testing.T) {
+	hubConf := createConfFile(t, []byte(`
+		listen: "127.0.0.1:-1"
+		leafnodes {
+			listen: "127.0.0.1:-1"
+			no_advertise: true
+		}
+	`))
+	hub, hubOpts := RunServerWithConfig(hubConf)
+	defer hub.Shutdown()
+
+	leafConf := createConfFile(t, []byte(fmt.Sprintf(`
+		listen: "127.0.0.1:-1"
+		leafnodes {
+			reconnect: "50ms"
+			remotes: [
+				{
+					url: "nats://localhost:%d"
+				}
+			]
+		}
+	`, hubOpts.LeafNode.Port)))
+	leaf, _ := RunServerWithConfig(leafConf)
+	defer leaf.Shutdown()
+
+	checkLeafNodeConnected(t, hub)
+	checkLeafNodeConnected(t, leaf)
+
+	configURL := fmt.Sprintf("nats://localhost:%d", hubOpts.LeafNode.Port)
+
+	checkFor(t, time.Second, 10*time.Millisecond, func() error {
+		leaf.mu.RLock()
+		defer leaf.mu.RUnlock()
+		var remote *leafNodeCfg
+		for cfg := range leaf.leafRemoteCfgs {
+			remote = cfg
+			break
+		}
+		if remote == nil {
+			return fmt.Errorf("expected a leaf remote config")
+		}
+		remote.RLock()
+		defer remote.RUnlock()
+		if got, want := len(remote.urls), 1; got != want {
+			return fmt.Errorf("expected %d reconnect URL, got %d: %v", want, got, remote.urls)
+		}
+		if got := remote.urls[0].String(); got != configURL {
+			return fmt.Errorf("expected reconnect URL %q, got %q", configURL, got)
+		}
+		return nil
+	})
+}
+
 func TestLeafNodeRemoteIsHub(t *testing.T) {
 	oa := testDefaultOptionsForGateway("A")
 	oa.Accounts = []*Account{NewAccount("sys")}
@@ -1516,6 +1569,42 @@ func TestLeafNodeInfoPermissionUpdatesAllowedForSolicitedLeaf(t *testing.T) {
 	require_True(t, c.canSubscribe("import.foo"))
 	require_False(t, c.pubAllowed("other.foo"))
 	require_False(t, c.canSubscribe("other.foo"))
+}
+
+func TestLeafNodeInfoOnConnectWithoutLeafNodeURLsAccepted(t *testing.T) {
+	s := &Server{}
+	s.setOpts(DefaultOptions())
+	cli, srv := net.Pipe()
+	defer cli.Close()
+	defer srv.Close()
+
+	c := &client{
+		kind: LEAF,
+		srv:  s,
+		nc:   cli,
+		acc:  NewAccount("TEST"),
+		leaf: &leaf{
+			remote: func() *leafNodeCfg {
+				cfg := newLeafNodeCfg(&RemoteLeafOpts{})
+				cfg.curURL = &url.URL{}
+				return cfg
+			}(),
+		},
+	}
+	c.initClient()
+	c.flags.set(handshakeComplete)
+
+	c.processLeafnodeInfo(&Info{
+		ID:            "hub",
+		Name:          "hub",
+		CID:           1,
+		InfoOnConnect: true,
+		Nonce:         "nonce",
+	})
+
+	require_False(t, c.isClosed())
+	require_True(t, c.flags.isSet(infoReceived))
+	require_Equal(t, "hub", c.leaf.remoteServer)
 }
 
 func TestLeafNodePubAllowedPruning(t *testing.T) {


### PR DESCRIPTION
## Summary

Respect `leafnodes.no_advertise` when advertising leaf-node listener URLs.

Previously, the server always added its own leaf listener address to the
advertised leaf-node URL set. As a result, connected leaf nodes could learn
the hub address and later try to reconnect to it even when `no_advertise`
was enabled.

Avoid adding the local leaf listener URL when `no_advertise` is set.

This also means a legitimate initial leaf INFO may contain no
`LeafNodeURLs`. Update the solicited leaf handshake validation so an
`InfoOnConnect` INFO without advertised leaf URLs is not incorrectly
classified as a wrong-port connection.

## Tests

Added regression coverage for:

- a hub configured with `leafnodes.no_advertise=true` not leaking its leaf
  listener into the leaf's reconnect URL set
- accepting a legitimate `InfoOnConnect` leaf INFO without `LeafNodeURLs`
- preserving existing wrong-port detection behavior

Verified with:

```text
go test ./server -run '^TestLeafNodeNoAdvertiseDoesNotAdvertiseListener$' -count=20
go test ./server -run '^TestLeafNodeInfoOnConnectWithoutLeafNodeURLsAccepted$' -count=20
go test ./server -run '^TestLeafNodeRemoteWrongPort$' -count=20
go test ./server -run 'LeafNode.*WrongPort|LeafNodeNoAdvertise' -count=10
```
Resolves #8367