### PR TITLE
(2.15) [FIXED] Evict peer-removed peers for group below quorum

### DIFF
--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -2005,7 +2005,7 @@ func (s *Server) jsStreamInfoRequest(sub *subscription, c *client, a *Account, s
 				// We know we are a member here, if this group is new and we are preferred allow us to answer.
 				// Also, we have seen cases where rg.node is nil at this point,
 				// so check explicitly and bail if that is the case.
-				bail = rg.Preferred != ourID || (rg.node != nil && time.Since(rg.node.Created()) > lostQuorumIntervalDefault)
+				bail = rg.Preferred != ourID || (rg.node != nil && time.Since(rg.node.Created()) > lostQuorumInterval)
 			}
 			js.mu.RUnlock()
 			if bail {
@@ -5183,7 +5183,7 @@ func (s *Server) jsConsumerInfoRequest(sub *subscription, c *client, _ *Account,
 		// Also capture if we think there is no meta leader.
 		var isLeaderLess bool
 		if !isLeader {
-			isLeaderLess = groupLeaderless && time.Since(groupCreated) > lostQuorumIntervalDefault
+			isLeaderLess = groupLeaderless && time.Since(groupCreated) > lostQuorumInterval
 		}
 		js.mu.RUnlock()
 
@@ -5273,7 +5273,7 @@ func (s *Server) jsConsumerInfoRequest(sub *subscription, c *client, _ *Account,
 			bail := !node.Leaderless() || node.HadPreviousLeader() || rg == nil
 			if !bail {
 				js.mu.RLock()
-				bail = rg.Preferred != ourID || (rg.node != nil && time.Since(rg.node.Created()) > lostQuorumIntervalDefault)
+				bail = rg.Preferred != ourID || (rg.node != nil && time.Since(rg.node.Created()) > lostQuorumInterval)
 				js.mu.RUnlock()
 			}
 			if bail {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -207,6 +207,10 @@ type desiredRaftGroup struct {
 	ScaleUp   bool `json:"scale_up,omitempty"`
 	ScaleDown bool `json:"scale_down,omitempty"`
 
+	// Removed are peers an operator peer-removed from this group. A group that
+	// can't reach quorum may only evict what's recorded here.
+	Removed []string `json:"removed,omitempty"`
+
 	Origin *desiredRaftGroupOrigin `json:"origin,omitempty"`
 }
 
@@ -269,10 +273,18 @@ func (rg *raftGroup) withDesired(target *raftGroup) *raftGroup {
 		Cluster:   target.Cluster,
 		Preferred: target.Preferred,
 	}
-	// Must preserve the prior origin (if any).
-	if rg.Desired != nil && rg.Desired.Origin != nil {
-		origin := *rg.Desired.Origin
-		ng.Desired.Origin = &origin
+	if rg.Desired != nil {
+		// Must preserve the prior origin (if any).
+		if rg.Desired.Origin != nil {
+			origin := *rg.Desired.Origin
+			ng.Desired.Origin = &origin
+		}
+		// Must also preserve which peers were peer-removed.
+		for _, peer := range rg.Desired.Removed {
+			if !slices.Contains(ng.Desired.Peers, peer) {
+				ng.Desired.Removed = append(ng.Desired.Removed, peer)
+			}
+		}
 	}
 	return ng
 }
@@ -1377,7 +1389,7 @@ func (js *jetStream) isLeaderless() bool {
 
 	// If we don't have a leader.
 	// Make sure we have been running for enough time.
-	if meta.Leaderless() && time.Since(meta.Created()) > lostQuorumIntervalDefault {
+	if meta.Leaderless() && time.Since(meta.Created()) > lostQuorumInterval {
 		return true
 	}
 	return false
@@ -1420,7 +1432,7 @@ func (js *jetStream) isGroupLeaderless(rg *raftGroup) bool {
 			}
 		}
 		// Make sure we have been running for enough time.
-		if time.Since(node.Created()) > lostQuorumIntervalDefault {
+		if time.Since(node.Created()) > lostQuorumInterval {
 			return true
 		}
 	}
@@ -2739,6 +2751,21 @@ func (ca *consumerAssignment) copyGroup() *consumerAssignment {
 	return cca
 }
 
+// addRemoved records peers that were peer-removed from this group, so a group
+// that can't reach quorum knows which of its peers an operator took out.
+// Lock should be held.
+func (d *desiredRaftGroup) addRemoved(peers []string) {
+	if d == nil {
+		return
+	}
+	for _, peer := range peers {
+		if slices.Contains(d.Peers, peer) || slices.Contains(d.Removed, peer) {
+			continue
+		}
+		d.Removed = append(d.Removed, peer)
+	}
+}
+
 // copyGroup returns a copy of rg whose Peers slice and nested Desired placement
 // are independent of the original, so it can be mutated and encoded.
 // Lock should be held.
@@ -2752,6 +2779,7 @@ func (rg *raftGroup) copyGroup() *raftGroup {
 	if rg.Desired != nil {
 		cd := *rg.Desired
 		cd.Peers = copyStrings(rg.Desired.Peers)
+		cd.Removed = copyStrings(rg.Desired.Removed)
 		if rg.Desired.Origin != nil {
 			cr := *rg.Desired.Origin
 			cr.Placement = rg.Desired.Origin.Placement.clone()
@@ -2993,6 +3021,67 @@ func (js *jetStream) processRemovePeer(peer string) {
 	}
 }
 
+// checkEvictedPeers drops the peers an operator peer-removed from a group that
+// can't reach quorum without them. Removing them through the log would require
+// quorum, so a stuck group never recovers on its own. Once they're gone it can
+// elect a leader again and reconciliation takes over.
+// Returns whether the caller should check back.
+func (js *jetStream) checkEvictedPeers(n RaftNode, rg *raftGroup, desc string) bool {
+	js.mu.RLock()
+	cc := js.cluster
+	if n == nil || cc == nil || cc.meta == nil || js.metaRecovering || len(rg.Peers) == 0 {
+		js.mu.RUnlock()
+		return true
+	}
+	// Can only evict safely if the assignment recorded removed peers.
+	if rg.Desired == nil || len(rg.Desired.Removed) == 0 {
+		js.mu.RUnlock()
+		return false
+	}
+	// Wait until we're leaderless, but we're in contact with a meta leader.
+	if !n.Leaderless() || cc.meta.Leaderless() {
+		js.mu.RUnlock()
+		return true
+	}
+
+	groupPeers, removedPeers := copyStrings(rg.Peers), copyStrings(rg.Desired.Removed)
+	js.mu.RUnlock()
+
+	// Use voting membership, so a peer we speculatively dropped for an uncommitted
+	// removal is still accounted for. That also covers a scale-down or move that
+	// appended a removal of ourselves but never got to commit it: the assignment
+	// can still list us, and EvictPeers reverts the pending removal.
+	current, ourPeerId := n.VotingPeerNames(), n.ID()
+
+	// Skip if we're not member anymore, we're not allowed to make changes to this group.
+	if !slices.Contains(current, ourPeerId) || !slices.Contains(groupPeers, ourPeerId) {
+		return false
+	}
+
+	// Only drop peers an operator removed, and that the assignment hasn't taken
+	// back on since. Everyone else could still be taking part.
+	var evict []string
+	for _, peer := range current {
+		// Skip ourselves.
+		if peer == ourPeerId {
+			continue
+		}
+		if slices.Contains(removedPeers, peer) && !slices.Contains(groupPeers, peer) {
+			evict = append(evict, peer)
+		}
+	}
+	if len(evict) == 0 {
+		return false
+	}
+	evicted, err := n.EvictPeers(evict)
+	if err == errQuorumPossible {
+		js.srv.Debugf("JetStream cluster can not evict peers for %s, the peers left could still reach quorum without us", desc)
+	} else if err == nil && len(evicted) > 0 {
+		js.srv.Noticef("JetStream cluster evicted peers %+v for %s", evicted, desc)
+	}
+	return true
+}
+
 // peerRemoval controls how a peer is taken out of a stream's group.
 type peerRemoval struct {
 	// remove drops the peer right away, otherwise the group migrates off of it first.
@@ -3042,6 +3131,7 @@ func (js *jetStream) removePeerFromStreamLocked(sa *streamAssignment, peer strin
 
 	// Send our proposal for this csa. Also use same group definition for all the consumers as well.
 	consumers, deleted, _ := js.remapConsumerAssignments(accName, csa)
+
 	if err := cc.meta.Propose(cc.term, encodeAddStreamAssignment(csa)); err != nil {
 		return false
 	}
@@ -3739,6 +3829,12 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 	}
 	defer stopMigrationMonitoring()
 
+	// Start monitoring if we're already meant to be migrating. If we're out of quorum
+	// with peer-removed peers, it will trigger a shrink of the group.
+	if mset.isMigrating() {
+		startMigrationMonitoring()
+	}
+
 	// This is to optionally track when we are ready as a non-leader for direct access participation.
 	// Either direct or if we are a direct mirror, or both.
 	var dat *time.Ticker
@@ -3954,7 +4050,7 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 			migrating := mset.isMigrating()
 
 			// Check for migrations here. We set the state on the stream assignment update below.
-			if isLeader && migrating {
+			if migrating {
 				startMigrationMonitoring()
 			} else {
 				stopMigrationMonitoring()
@@ -4030,15 +4126,20 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 			// We get this when we have a new stream assignment caused by an update.
 			// We want to know if we are migrating.
 			migrating := mset.isMigrating()
-			if isLeader && migrating {
+			if migrating {
 				startMigrationMonitoring()
 			} else {
 				stopMigrationMonitoring()
 			}
 		case <-mmtc:
 			if !isLeader {
-				// We are no longer leader, so not our job.
-				stopMigrationMonitoring()
+				// We're not the leader, but check if we're out of quorum and
+				// need to shrink based on peer-removes.
+				if !js.checkEvictedPeers(n, sa.Group, fmt.Sprintf("stream '%s > %s'", accName, sa.Config.Name)) {
+					stopMigrationMonitoring()
+					continue
+				}
+				resetMigrationMonitoring(migrateFallbackCheckInterval)
 				continue
 			}
 			// Reset to the slower fallback speed.
@@ -7250,6 +7351,12 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 	}
 	defer stopMigrationMonitoring()
 
+	// Start monitoring if we're already meant to be migrating. If we're out of quorum
+	// with peer-removed peers, it will trigger a shrink of the group.
+	if o.isMigrating() {
+		startMigrationMonitoring()
+	}
+
 	// Track if we are leader.
 	var isLeader bool
 	var leaderTerm uint64
@@ -7337,7 +7444,7 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 			// Or the old leader is no longer part of the set and transferred leadership
 			// for this leader to resume with removal
 			migrating := o.isMigrating()
-			if isLeader && migrating {
+			if migrating {
 				startMigrationMonitoring()
 			} else {
 				stopMigrationMonitoring()
@@ -7345,18 +7452,24 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 		case <-uch:
 			// keep consumer assignment current
 			ca = o.consumerAssignment()
+
 			// We get this when we have a new consumer assignment caused by an update.
 			// We want to know if we are migrating.
 			migrating := o.isMigrating()
-			if isLeader && migrating {
+			if migrating {
 				startMigrationMonitoring()
 			} else {
 				stopMigrationMonitoring()
 			}
 		case <-mmtc:
 			if !isLeader {
-				// We are no longer leader, so not our job.
-				stopMigrationMonitoring()
+				// We're not the leader, but check if we're out of quorum and
+				// need to shrink based on peer-removes.
+				if !js.checkEvictedPeers(n, ca.Group, fmt.Sprintf("consumer '%s > %s > %s'", o.acc.Name, ca.Stream, ca.Name)) {
+					stopMigrationMonitoring()
+					continue
+				}
+				resetMigrationMonitoring(migrateFallbackCheckInterval)
 				continue
 			}
 			// Reset to the slower fallback speed.
@@ -8846,12 +8959,13 @@ func (cc *jetStreamCluster) reassignStreamPeers(sa *streamAssignment, peers []st
 		csa.Group.Desired.ScaleDown = d.ScaleDown
 		csa.Group.Desired.ScaleUp = d.ScaleUp
 	}
-	removeFrom := func(from []string) []string {
-		return slices.DeleteFunc(from, func(p string) bool { return slices.Contains(peers, p) })
-	}
 	if remove {
+		removeFrom := func(from []string) []string {
+			return slices.DeleteFunc(from, func(p string) bool { return slices.Contains(peers, p) })
+		}
 		csa.Group.Peers = removeFrom(csa.Group.Peers)
 		csa.Group.Desired.Peers = removeFrom(csa.Group.Desired.Peers)
+		csa.Group.Desired.addRemoved(peers)
 	}
 	// Don't carry a stale preferred into the remaining group.
 	isMember := func(peer string) bool {
@@ -8923,7 +9037,17 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 		}
 		// Leave the consumer alone if its peer set is unaffected.
 		if kept == len(consumerPeers) && kept == size {
-			continue
+			// If the consumer has any peers that need to be peer-removed, we can't skip.
+			var removals bool
+			if sa.Group.Desired != nil && len(sa.Group.Desired.Removed) > 0 {
+				removals = slices.ContainsFunc(ca.Group.Peers, func(p string) bool {
+					return slices.Contains(sa.Group.Desired.Removed, p) &&
+						(ca.Group.Desired == nil || !slices.Contains(ca.Group.Desired.Removed, p))
+				})
+			}
+			if !removals {
+				continue
+			}
 		}
 
 		// Drop peers that are no longer part of the stream. If moving, the tail MUST be the new peer set.
@@ -8974,11 +9098,18 @@ func (js *jetStream) remapConsumerAssignments(accName string, sa *streamAssignme
 			cca.Group = ca.Group.withDesired(cca.Group)
 			// Scaled down if we kept at least one peer, but removed others.
 			cca.Group.Desired.ScaleDown = kept > 0 && kept != len(consumerPeers)
+
+			// Drop any peers that are no longer part of the stream's peer set.
+			var dropped []string
+			cca.Group.Peers = slices.DeleteFunc(cca.Group.Peers, func(peer string) bool {
+				if slices.Contains(sa.Group.Peers, peer) {
+					return false
+				}
+				dropped = append(dropped, peer)
+				return true
+			})
+			cca.Group.Desired.addRemoved(dropped)
 		}
-		// Drop any peers that are no longer part of the stream's peer set.
-		cca.Group.Peers = slices.DeleteFunc(cca.Group.Peers, func(peer string) bool {
-			return !slices.Contains(sa.Group.Peers, peer)
-		})
 		// If a consumer lost all of its peers to removal.
 		if len(cca.Group.Peers) == 0 {
 			// Delete it if ephemeral.

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -3723,33 +3723,6 @@ func TestJetStreamClusterPeerRemovalAndStreamReassignmentWithoutSpace(t *testing
 	streamCurrent(2)
 }
 
-// Helpers for the meta leader peer reconciliation tests below.
-func metaStreamPeers(s *Server, account, stream string) []string {
-	js := s.getJetStream()
-	js.mu.RLock()
-	defer js.mu.RUnlock()
-	sa := js.streamAssignmentOrInflight(account, stream)
-	if sa == nil {
-		return nil
-	}
-	peers := copyStrings(sa.Group.Peers)
-	slices.Sort(peers)
-	return peers
-}
-
-func metaConsumerPeers(s *Server, account, stream, consumer string) []string {
-	js := s.getJetStream()
-	js.mu.RLock()
-	defer js.mu.RUnlock()
-	ca := js.consumerAssignmentOrInflight(account, stream, consumer)
-	if ca == nil {
-		return nil
-	}
-	peers := copyStrings(ca.Group.Peers)
-	slices.Sort(peers)
-	return peers
-}
-
 // Evacuating a server out of an R3 stream can leave it with two peers, needing a new one
 // admitted. That's only done by whoever is meta leader at the time, so if there's none then
 // (or it can't see the peer yet) the stream stays under-replicated. Becoming meta leader

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -12517,6 +12517,789 @@ func TestJetStreamClusterDesiredOriginReportsTarget(t *testing.T) {
 	}
 }
 
+// peerRemove takes the given servers out as an operator would, either out of the
+// cluster entirely or just out of the stream.
+func peerRemove(t *testing.T, c *cluster, nc *nats.Conn, stream string, serverScope bool, peers []string) {
+	t.Helper()
+	if !serverScope {
+		for _, name := range peers {
+			req, err := json.Marshal(&JSApiStreamRemovePeerRequest{Peer: name})
+			require_NoError(t, err)
+			rmsg, err := nc.Request(fmt.Sprintf(JSApiStreamRemovePeerT, stream), req, time.Second)
+			require_NoError(t, err)
+			var resp JSApiStreamRemovePeerResponse
+			require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
+			require_True(t, resp.Error == nil)
+		}
+		return
+	}
+
+	// The server scoped endpoint is system account only.
+	ml := c.leader()
+	require_NotNil(t, ml)
+	snc, err := nats.Connect(ml.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer snc.Close()
+
+	for _, name := range peers {
+		req, err := json.Marshal(&JSApiMetaServerRemoveRequest{Server: name})
+		require_NoError(t, err)
+		rmsg, err := snc.Request(JSApiRemoveServer, req, time.Second)
+		require_NoError(t, err)
+		var resp JSApiMetaServerRemoveResponse
+		require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
+		require_True(t, resp.Error == nil)
+	}
+}
+
+// proposeSelectedScaleDown rewrites a consumer assignment as if a scale-down had
+// already selected its final peer set before the group lost quorum: the desired
+// peers hold only the kept peer, while the actual peers still hold the downed
+// ones. A subsequent peer-remove of the downed servers is a no-op for the desired
+// peers, so recovering from this shape requires recording the removals against
+// the actual peers.
+func proposeSelectedScaleDown(t *testing.T, c *cluster, stream, consumer string, replicas int, keep *Server) {
+	t.Helper()
+	const desiredID = "selected-scale-down"
+
+	ml := c.leader()
+	require_NotNil(t, ml)
+	mjs := ml.getJetStream()
+	mjs.mu.Lock()
+	cc := mjs.cluster
+	ca := mjs.consumerAssignment(globalAccountName, stream, consumer)
+	if ca == nil || cc == nil || cc.meta == nil {
+		mjs.mu.Unlock()
+		t.Fatalf("no consumer assignment for %q", consumer)
+	}
+	nca := ca.copyGroup()
+	if replicas > 0 {
+		cfg := *nca.Config
+		cfg.Replicas = replicas
+		nca.Config = &cfg
+	}
+	nca.Group.Desired = &desiredRaftGroup{ID: desiredID, Peers: []string{keep.Node()}}
+	err := cc.meta.Propose(cc.term, encodeAddConsumerAssignment(nca))
+	mjs.mu.Unlock()
+	require_NoError(t, err)
+
+	// Wait for the assignment to be applied before returning.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		if ca := mjs.consumerAssignment(globalAccountName, stream, consumer); ca == nil ||
+			ca.Group.Desired == nil || ca.Group.Desired.ID != desiredID {
+			return fmt.Errorf("consumer %q assignment not applied yet", consumer)
+		}
+		return nil
+	})
+}
+
+// A stream and consumer that lost quorum, because their peers were shut down,
+// must recover once those peers are removed. They can't commit the peer removal
+// through their own log, since that needs the quorum they lost. Removing the
+// servers from the cluster takes them out of every group, removing them from the
+// stream only takes them out of this one and leaves them cluster members.
+func TestJetStreamClusterPeerRemoveRestoresQuorum(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		serverScope bool
+	}{
+		{"Server", true},
+		{"Stream", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c := createJetStreamClusterExplicit(t, "R5S", 5)
+			defer c.shutdown()
+
+			nc, js := jsClientConnect(t, c.randomServer())
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     "TEST",
+				Subjects: []string{"foo"},
+				Replicas: 3,
+			})
+			require_NoError(t, err)
+
+			_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+				Durable:   "dur",
+				AckPolicy: nats.AckExplicitPolicy,
+			})
+			require_NoError(t, err)
+
+			// A second consumer that will be rewritten below as a stuck scale-down.
+			_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+				Durable:   "scaled",
+				AckPolicy: nats.AckExplicitPolicy,
+			})
+			require_NoError(t, err)
+
+			_, err = js.Publish("foo", nil)
+			require_NoError(t, err)
+
+			// Shut down both stream followers, taking the stream and its consumer
+			// below quorum. The meta group has 3 of 5 servers left, so it stays
+			// available.
+			si, err := js.StreamInfo("TEST")
+			require_NoError(t, err)
+			require_Equal(t, len(si.Cluster.Replicas), 2)
+
+			var downed []string
+			for _, r := range si.Cluster.Replicas {
+				downed = append(downed, r.Name)
+			}
+			sl := c.serverByName(si.Cluster.Leader)
+			for _, name := range downed {
+				c.serverByName(name).Shutdown()
+			}
+			c.waitOnLeader()
+
+			// Reconnect to a server that's still up.
+			nc.Close()
+			nc, js = jsClientConnect(t, sl)
+			defer nc.Close()
+
+			// Both groups must be stuck at this point. The old leaders step down
+			// once they notice they've lost quorum, and no new leader can be
+			// elected. Can take up to lostQuorumInterval plus lostQuorumCheck for
+			// them to notice.
+			checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+				if l := c.streamLeader(globalAccountName, "TEST"); l != nil {
+					return fmt.Errorf("stream still has leader %q", l.Name())
+				}
+				for _, consumer := range []string{"dur", "scaled"} {
+					if l := c.consumerLeader(globalAccountName, "TEST", consumer); l != nil {
+						return fmt.Errorf("consumer %q still has leader %q", consumer, l.Name())
+					}
+				}
+				return nil
+			})
+			_, err = js.Publish("foo", nil)
+			require_Error(t, err, nats.ErrNoStreamResponse)
+
+			// The second consumer already selected its scale-down peer set, so the
+			// peer-remove below can't touch its desired peers, only its actual ones.
+			proposeSelectedScaleDown(t, c, "TEST", "scaled", 1, sl)
+
+			// Now remove both downed servers. Only a server peer-remove changes
+			// cluster membership, so that's the only one there is something to
+			// wait for. A stream peer-remove leaves it alone, which the check at
+			// the end of the test confirms.
+			peerRemove(t, c, nc, "TEST", test.serverScope, downed)
+			if test.serverScope {
+				checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+					ml := c.leader()
+					if ml == nil {
+						return errors.New("no meta leader")
+					}
+					if n := len(ml.getJetStream().getMetaGroup().Peers()); n != 3 {
+						return fmt.Errorf("expected 3 meta members, got %d", n)
+					}
+					return nil
+				})
+			}
+
+			// Both the stream and the consumers must now be able to elect a leader
+			// again, having evicted the removed peers, and become fully available.
+			c.waitOnStreamLeader(globalAccountName, "TEST")
+			c.waitOnConsumerLeader(globalAccountName, "TEST", "dur")
+			c.waitOnConsumerLeader(globalAccountName, "TEST", "scaled")
+
+			_, err = js.Publish("foo", nil)
+			require_NoError(t, err)
+
+			// And no group should reference the removed servers anymore.
+			// Waiting on the leaders above also waits for the groups to have
+			// converged, so this must hold right away.
+			si, err = js.StreamInfo("TEST")
+			require_NoError(t, err)
+			require_NotNil(t, si.Cluster)
+			require_Equal(t, len(si.Cluster.Replicas), 2)
+
+			ci, err := js.ConsumerInfo("TEST", "dur")
+			require_NoError(t, err)
+			require_NotNil(t, ci.Cluster)
+			require_Equal(t, len(ci.Cluster.Replicas), 2)
+
+			// The stuck scale-down settles on its selected peer.
+			sci, err := js.ConsumerInfo("TEST", "scaled")
+			require_NoError(t, err)
+			require_NotNil(t, sci.Cluster)
+			require_Equal(t, sci.Cluster.Leader, sl.Name())
+			require_Equal(t, len(sci.Cluster.Replicas), 0)
+
+			for _, name := range downed {
+				require_NotEqual(t, si.Cluster.Leader, name)
+				require_NotEqual(t, ci.Cluster.Leader, name)
+				for _, r := range si.Cluster.Replicas {
+					require_NotEqual(t, r.Name, name)
+				}
+				for _, r := range ci.Cluster.Replicas {
+					require_NotEqual(t, r.Name, name)
+				}
+			}
+
+			// Only a server peer-remove takes them out of the cluster as well.
+			expectedMetaPeers := 5
+			if test.serverScope {
+				expectedMetaPeers = 3
+			}
+			ml := c.leader()
+			require_NotNil(t, ml)
+			require_Equal(t, len(ml.getJetStream().getMetaGroup().Peers()), expectedMetaPeers)
+		})
+	}
+}
+
+// A stream peer remove that would leave the group below its replica count is rejected, even
+// when the peers are offline and the group is below quorum. Scaling the stream down is the
+// way out, after which the same removes are accepted and evict the peers, restoring the
+// stream without needing a server peer remove.
+func TestJetStreamClusterStreamPeerRemoveAfterScaleDownRestoresQuorum(t *testing.T) {
+	// Tag placement so the stream can only ever live on S-1, S-2 and S-3. That leaves no
+	// eligible replacement once peers go down, while the meta group keeps quorum on five.
+	c := createJetStreamClusterWithTemplateAndModHook(t, jsClusterTempl, "C", 5,
+		func(serverName, clusterName, storeDir, conf string) string {
+			switch serverName {
+			case "S-1", "S-2", "S-3":
+				return fmt.Sprintf("%s\nserver_tags: [server:%s, grp:a]", conf, serverName)
+			default:
+				return fmt.Sprintf("%s\nserver_tags: [server:%s, grp:b]", conf, serverName)
+			}
+		})
+	defer c.shutdown()
+
+	// The meta leader must be outside the stream's peer set so it stays able to propose.
+	for c.leader().Name() != "S-4" && c.leader().Name() != "S-5" {
+		require_NoError(t, c.leader().getJetStream().getMetaGroup().StepDown())
+		c.waitOnLeader()
+	}
+	ml := c.leader()
+
+	nc, js := jsClientConnect(t, ml)
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Replicas:  3,
+		Placement: &nats.Placement{Tags: []string{"grp:a"}},
+	}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	toSend := 5
+	for range toSend {
+		_, err = js.Publish("foo", nil)
+		require_NoError(t, err)
+	}
+
+	// Take two of the three stream peers down for good, putting the stream below quorum.
+	var offline []string
+	for _, name := range []string{"S-2", "S-3"} {
+		s := c.serverByName(name)
+		offline = append(offline, s.Node())
+		s.Shutdown()
+	}
+	checkFor(t, 15*time.Second, 250*time.Millisecond, func() error {
+		for _, p := range offline {
+			si, ok := ml.nodeToInfo.Load(p)
+			if !ok || si == nil || !si.(nodeInfo).offline {
+				return fmt.Errorf("peer %q not offline yet", p)
+			}
+		}
+		return nil
+	})
+
+	// The stream must actually be stuck before we exercise the recovery. The old leader
+	// steps down once it notices it has lost quorum, which can take up to
+	// lostQuorumInterval plus lostQuorumCheck.
+	checkFor(t, 30*time.Second, 250*time.Millisecond, func() error {
+		if l := c.streamLeader(globalAccountName, "TEST"); l != nil {
+			return fmt.Errorf("stream still has leader %q", l.Name())
+		}
+		return nil
+	})
+
+	removePeer := func(peer string) *JSApiStreamRemovePeerResponse {
+		t.Helper()
+		b, err := json.Marshal(JSApiStreamRemovePeerRequest{Peer: peer})
+		require_NoError(t, err)
+		msg, err := nc.Request(fmt.Sprintf(JSApiStreamRemovePeerT, "TEST"), b, 10*time.Second)
+		require_NoError(t, err)
+		var resp JSApiStreamRemovePeerResponse
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		return &resp
+	}
+
+	// At R3 there is nowhere to hand the peer to, so this must be rejected and the group
+	// left exactly as it was.
+	resp := removePeer(offline[0])
+	require_False(t, resp.Success)
+	require_Error(t, resp.Error, NewJSPeerRemapError())
+	require_Len(t, len(metaStreamPeers(ml, globalAccountName, "TEST")), 3)
+
+	// Scale the stream down. The request can time out waiting on a stream that has no
+	// leader to respond, what matters is that the meta layer records it.
+	cfg.Replicas = 1
+	_, _ = js.UpdateStream(cfg, nats.MaxWait(time.Second))
+	checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+		sjs := ml.getJetStream()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		sa := sjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil {
+			return errors.New("stream not found")
+		}
+		if sa.Config.Replicas != 1 {
+			return fmt.Errorf("expected R1, got R%d", sa.Config.Replicas)
+		}
+		return nil
+	})
+
+	// Now the same removes are accepted, the group is no longer short of its replica count.
+	for _, peer := range offline {
+		require_True(t, removePeer(peer).Success)
+	}
+
+	// Both offline peers are evicted, leaving the stream on its one surviving peer.
+	checkFor(t, 30*time.Second, 250*time.Millisecond, func() error {
+		sjs := ml.getJetStream()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		sa := sjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group == nil {
+			return errors.New("stream not found")
+		}
+		if sa.Group.Desired != nil {
+			return fmt.Errorf("stream still converging: peers=%v desired=%v scaleDown=%v scaleUp=%v",
+				sa.Group.Peers, sa.Group.Desired.Peers, sa.Group.Desired.ScaleDown, sa.Group.Desired.ScaleUp)
+		}
+		if len(sa.Group.Peers) != 1 {
+			return fmt.Errorf("expected 1 peer, got %v", sa.Group.Peers)
+		}
+		for _, p := range offline {
+			if slices.Contains(sa.Group.Peers, p) {
+				return fmt.Errorf("offline peer %q still in peer set %v", p, sa.Group.Peers)
+			}
+		}
+		return nil
+	})
+
+	// And the stream is usable again, with its data, without a server peer remove.
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+	_, err = js.Publish("foo", nil)
+	require_NoError(t, err)
+	si, err := js.StreamInfo("TEST")
+	require_NoError(t, err)
+	require_Equal(t, si.State.Msgs, uint64(toSend+1))
+	require_Len(t, len(si.Cluster.Replicas), 0)
+}
+
+// A scale-down or move that appended a removal of the surviving peer, but lost
+// quorum before committing it, leaves that peer speculatively dropped from its
+// own peer set while the assignment still lists it. Peer-removing the downed
+// servers must still evict them, reverting the stuck self-removal, or the
+// survivor could never campaign again.
+func TestJetStreamClusterStreamPeerRemoveWithUncommittedSelfRemoval(t *testing.T) {
+	// Tag placement so the stream can only ever live on S-1, S-2 and S-3, same as
+	// TestJetStreamClusterStreamPeerRemoveAfterScaleDownRestoresQuorum.
+	c := createJetStreamClusterWithTemplateAndModHook(t, jsClusterTempl, "C", 5,
+		func(serverName, clusterName, storeDir, conf string) string {
+			switch serverName {
+			case "S-1", "S-2", "S-3":
+				return fmt.Sprintf("%s\nserver_tags: [server:%s, grp:a]", conf, serverName)
+			default:
+				return fmt.Sprintf("%s\nserver_tags: [server:%s, grp:b]", conf, serverName)
+			}
+		})
+	defer c.shutdown()
+
+	// The meta leader must be outside the stream's peer set so it stays able to propose.
+	for c.leader().Name() != "S-4" && c.leader().Name() != "S-5" {
+		require_NoError(t, c.leader().getJetStream().getMetaGroup().StepDown())
+		c.waitOnLeader()
+	}
+	ml := c.leader()
+
+	nc, js := jsClientConnect(t, ml)
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Replicas:  3,
+		Placement: &nats.Placement{Tags: []string{"grp:a"}},
+	}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	_, err = js.Publish("foo", nil)
+	require_NoError(t, err)
+
+	// Take the other two stream peers down for good, leaving S-1 as the survivor.
+	survivor := c.serverByName("S-1")
+	var offline []string
+	for _, name := range []string{"S-2", "S-3"} {
+		s := c.serverByName(name)
+		offline = append(offline, s.Node())
+		s.Shutdown()
+	}
+
+	// The stream must be stuck before we exercise the recovery.
+	checkFor(t, 30*time.Second, 250*time.Millisecond, func() error {
+		if l := c.streamLeader(globalAccountName, "TEST"); l != nil {
+			return fmt.Errorf("stream still has leader %q", l.Name())
+		}
+		return nil
+	})
+
+	// Put the survivor in the state a scale-down or move would leave behind if it
+	// appended a removal of this peer and lost quorum before committing it. This
+	// is the same speculative apply processAppendEntry does for the entry.
+	mset, err := survivor.GlobalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	node := mset.raftNode().(*raft)
+	node.Lock()
+	node.membChange = &membChange{index: node.pindex + 1, peer: node.id, prev: node.peers[node.id]}
+	delete(node.peers, node.id)
+	node.adjustClusterSizeAndQuorum()
+	pendingSelfRemoval := node.pendingSelfRemoval()
+	node.Unlock()
+	require_True(t, pendingSelfRemoval)
+
+	// Scale the stream down, so the peer removes below aren't rejected for leaving
+	// the group short of its replica count. No leader can respond to the request.
+	cfg.Replicas = 1
+	_, _ = js.UpdateStream(cfg, nats.MaxWait(time.Second))
+	checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+		sjs := ml.getJetStream()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		sa := sjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil {
+			return errors.New("stream not found")
+		}
+		if sa.Config.Replicas != 1 {
+			return fmt.Errorf("expected R1, got R%d", sa.Config.Replicas)
+		}
+		return nil
+	})
+
+	// Remove both downed peers.
+	for _, peer := range offline {
+		b, err := json.Marshal(JSApiStreamRemovePeerRequest{Peer: peer})
+		require_NoError(t, err)
+		msg, err := nc.Request(fmt.Sprintf(JSApiStreamRemovePeerT, "TEST"), b, 10*time.Second)
+		require_NoError(t, err)
+		var resp JSApiStreamRemovePeerResponse
+		require_NoError(t, json.Unmarshal(msg.Data, &resp))
+		require_True(t, resp.Success)
+	}
+
+	// The survivor must evict the removed peers, revert its own stuck removal and
+	// be able to elect a leader again, settling the group at R1.
+	checkFor(t, 30*time.Second, 250*time.Millisecond, func() error {
+		node.RLock()
+		pendingSelfRemoval := node.pendingSelfRemoval()
+		node.RUnlock()
+		if pendingSelfRemoval {
+			return errors.New("self removal still pending")
+		}
+		if !slices.Contains(node.PeerNames(), node.ID()) {
+			return fmt.Errorf("not a member of our own group: %v", node.PeerNames())
+		}
+		sjs := ml.getJetStream()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		sa := sjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group == nil {
+			return errors.New("stream not found")
+		}
+		if len(sa.Group.Peers) != 1 || sa.Group.Peers[0] != survivor.Node() {
+			return fmt.Errorf("expected the survivor as only peer, got %v", sa.Group.Peers)
+		}
+		return nil
+	})
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+
+	_, err = js.Publish("foo", nil)
+	require_NoError(t, err)
+	si, err := js.StreamInfo("TEST")
+	require_NoError(t, err)
+	require_Equal(t, si.State.Msgs, uint64(2))
+	require_Equal(t, si.Cluster.Leader, survivor.Name())
+	require_Len(t, len(si.Cluster.Replicas), 0)
+}
+
+// A stream that lost quorum can't scale down either, removing peers needs the
+// quorum it just lost. Removing the downed servers must let it shrink around
+// them and settle at its new replica count.
+func TestJetStreamClusterPeerRemoveRestoresQuorumWhileScalingDown(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		serverScope bool
+	}{
+		{"Server", true},
+		{"Stream", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c := createJetStreamClusterExplicit(t, "R5S", 5)
+			defer c.shutdown()
+
+			nc, js := jsClientConnect(t, c.randomServer())
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:     "TEST",
+				Subjects: []string{"foo"},
+				Replicas: 3,
+			})
+			require_NoError(t, err)
+
+			// A consumer that will be rewritten below as a stuck scale-down.
+			_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+				Durable:   "scaled",
+				AckPolicy: nats.AckExplicitPolicy,
+			})
+			require_NoError(t, err)
+
+			_, err = js.Publish("foo", nil)
+			require_NoError(t, err)
+
+			// Shut down both stream followers, taking the stream below quorum. The
+			// meta group has 3 of 5 servers left, so it stays available.
+			si, err := js.StreamInfo("TEST")
+			require_NoError(t, err)
+			require_Equal(t, len(si.Cluster.Replicas), 2)
+
+			var downed []string
+			for _, r := range si.Cluster.Replicas {
+				downed = append(downed, r.Name)
+			}
+			sl := c.serverByName(si.Cluster.Leader)
+			for _, name := range downed {
+				c.serverByName(name).Shutdown()
+			}
+			c.waitOnLeader()
+
+			// Reconnect to a server that's still up.
+			nc.Close()
+			nc, js = jsClientConnect(t, sl)
+			defer nc.Close()
+
+			// Scale the stream down to R1. The meta layer takes the new replica
+			// count, but the group can't shrink to it while it has no quorum. The
+			// request races the old leader stepping down, so it may not get a
+			// response at all. What matters is that the new config took.
+			_, _ = js.UpdateStream(&nats.StreamConfig{
+				Name:     "TEST",
+				Subjects: []string{"foo"},
+				Replicas: 1,
+			})
+			checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+				ml := c.leader()
+				if ml == nil {
+					return errors.New("no meta leader")
+				}
+				mjs := ml.getJetStream()
+				mjs.mu.RLock()
+				sa := mjs.streamAssignment(globalAccountName, "TEST")
+				var replicas int
+				if sa != nil && sa.Config != nil {
+					replicas = sa.Config.Replicas
+				}
+				mjs.mu.RUnlock()
+				if replicas != 1 {
+					return fmt.Errorf("expected 1 replica in the assignment, got %d", replicas)
+				}
+				return nil
+			})
+
+			// It must be stuck, no leader can be elected.
+			checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+				if l := c.streamLeader(globalAccountName, "TEST"); l != nil {
+					return fmt.Errorf("stream still has leader %q", l.Name())
+				}
+				if l := c.consumerLeader(globalAccountName, "TEST", "scaled"); l != nil {
+					return fmt.Errorf("consumer still has leader %q", l.Name())
+				}
+				return nil
+			})
+			_, err = js.Publish("foo", nil)
+			require_Error(t, err, nats.ErrNoStreamResponse)
+
+			// The consumer already selected its scale-down peer set, so the
+			// peer-remove below can't touch its desired peers, only its actual ones.
+			proposeSelectedScaleDown(t, c, "TEST", "scaled", 0, sl)
+
+			// Now remove both downed servers. Only a server peer-remove changes
+			// cluster membership, so that's the only one there is something to
+			// wait for. A stream peer-remove leaves it alone, which the check at
+			// the end of the test confirms.
+			peerRemove(t, c, nc, "TEST", test.serverScope, downed)
+			if test.serverScope {
+				checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+					ml := c.leader()
+					if ml == nil {
+						return errors.New("no meta leader")
+					}
+					if n := len(ml.getJetStream().getMetaGroup().Peers()); n != 3 {
+						return fmt.Errorf("expected 3 meta members, got %d", n)
+					}
+					return nil
+				})
+			}
+
+			// The stream and consumer must be able to elect a leader again, having
+			// evicted the removed peers, and settle at R1.
+			c.waitOnStreamLeader(globalAccountName, "TEST")
+			c.waitOnConsumerLeader(globalAccountName, "TEST", "scaled")
+
+			_, err = js.Publish("foo", nil)
+			require_NoError(t, err)
+
+			si, err = js.StreamInfo("TEST")
+			require_NoError(t, err)
+			require_NotNil(t, si.Cluster)
+			require_Equal(t, si.Config.Replicas, 1)
+			require_Equal(t, len(si.Cluster.Replicas), 0)
+			for _, name := range downed {
+				require_NotEqual(t, si.Cluster.Leader, name)
+			}
+
+			// The stuck scale-down settles on its selected peer.
+			ci, err := js.ConsumerInfo("TEST", "scaled")
+			require_NoError(t, err)
+			require_NotNil(t, ci.Cluster)
+			require_Equal(t, ci.Cluster.Leader, sl.Name())
+			require_Equal(t, len(ci.Cluster.Replicas), 0)
+
+			// Only a server peer-remove takes them out of the cluster as well.
+			expectedMetaPeers := 5
+			if test.serverScope {
+				expectedMetaPeers = 3
+			}
+			ml := c.leader()
+			require_NotNil(t, ml)
+			require_Equal(t, len(ml.getJetStream().getMetaGroup().Peers()), expectedMetaPeers)
+		})
+	}
+}
+
+// A new desired state must not lose which peers were peer-removed, the group can
+// still be carrying them and need to shrink around them. Peers the new desired
+// set takes back on are no longer removed.
+func TestJetStreamClusterDesiredStateCarriesRemoved(t *testing.T) {
+	const a, b, c, d, e = "A", "B", "C", "D", "E"
+
+	newGroup := func() *raftGroup {
+		return &raftGroup{
+			Name:  "G",
+			Peers: []string{a, b, c},
+			Desired: &desiredRaftGroup{
+				Peers:   []string{a, c, d},
+				Removed: []string{b},
+			},
+		}
+	}
+
+	// A further removal must keep the earlier one on record.
+	rg := newGroup()
+	ng := rg.withDesired(&raftGroup{Name: "G", Peers: []string{a, d}})
+	require_True(t, slices.Contains(ng.Desired.Removed, b))
+	// And must not have mutated the original.
+	require_True(t, slices.Contains(rg.Desired.Removed, b))
+
+	// A peer the new desired set takes back on is no longer removed.
+	rg = newGroup()
+	ng = rg.withDesired(&raftGroup{Name: "G", Peers: []string{a, b, d}})
+	require_False(t, slices.Contains(ng.Desired.Removed, b))
+
+	// Recording is idempotent, and never records a peer that's still desired.
+	// In the real flow the peers are stripped from the desired set first, so that
+	// guard only catches a caller that hasn't.
+	rg = newGroup()
+	rg.Desired.addRemoved([]string{b, c, e})
+	require_Equal(t, len(rg.Desired.Removed), 2)
+	require_True(t, slices.Contains(rg.Desired.Removed, b))
+	require_True(t, slices.Contains(rg.Desired.Removed, e))
+	require_False(t, slices.Contains(rg.Desired.Removed, c))
+}
+
+// A consumer already scaling down can hold a peer-removed peer only in its actual
+// peer set, with its desired peers untouched by the removal. Remapping must still
+// record that removal, or the group could never evict the peer and stay leaderless
+// below quorum.
+func TestJetStreamClusterRemapConsumerRecordsRemovedActualPeer(t *testing.T) {
+	const a, b, c = "A", "B", "C"
+
+	js := &jetStream{cluster: &jetStreamCluster{}}
+	newAssignments := func(consumerPeers []string) (*streamAssignment, *consumerAssignment) {
+		// Stream already had peer C removed by the operator.
+		sa := &streamAssignment{
+			Config: &StreamConfig{Name: "TEST", Replicas: 2, Retention: LimitsPolicy},
+			Group: &raftGroup{
+				Name:  "S",
+				Peers: []string{a, b},
+				Desired: &desiredRaftGroup{
+					Peers:   []string{a, b},
+					Removed: []string{c},
+				},
+			},
+		}
+		// Consumer is mid-scale-down with its final peers already selected, C is
+		// gone from its desired peers but still in its actual peers, so the
+		// peer-remove itself is a desired no-op.
+		ca := &consumerAssignment{
+			Name:   "CONSUMER",
+			Stream: "TEST",
+			Config: &ConsumerConfig{Durable: "CONSUMER", Replicas: 2},
+			Group: &raftGroup{
+				Name:  "C",
+				Peers: consumerPeers,
+				Desired: &desiredRaftGroup{
+					Peers: []string{a, b},
+				},
+			},
+		}
+		sa.consumers = map[string]*consumerAssignment{ca.Name: ca}
+		return sa, ca
+	}
+
+	// The removed peer must be dropped from the actual peers and recorded as removed.
+	sa, _ := newAssignments([]string{a, b, c})
+	consumers, deleted, done := js.remapConsumerAssignments(globalAccountName, sa)
+	require_Len(t, len(deleted), 0)
+	require_False(t, done)
+	require_Len(t, len(consumers), 1)
+	cca := consumers[0]
+	require_False(t, slices.Contains(cca.Group.Peers, c))
+	require_True(t, slices.Contains(cca.Group.Desired.Removed, c))
+	require_True(t, slices.Contains(cca.Group.Peers, a))
+	require_True(t, slices.Contains(cca.Group.Peers, b))
+	require_True(t, slices.Equal(cca.Group.Desired.Peers, []string{a, b}))
+	require_False(t, cca.Group.Desired.ScaleDown)
+
+	// Recording is idempotent, once recorded there's nothing left to propose.
+	sa.consumers[cca.Name] = cca
+	consumers, deleted, _ = js.remapConsumerAssignments(globalAccountName, sa)
+	require_Len(t, len(consumers), 0)
+	require_Len(t, len(deleted), 0)
+
+	// If all actual peers were removed, the consumer jumps to its desired set.
+	sa, _ = newAssignments([]string{c})
+	consumers, deleted, _ = js.remapConsumerAssignments(globalAccountName, sa)
+	require_Len(t, len(deleted), 0)
+	require_Len(t, len(consumers), 1)
+	cca = consumers[0]
+	require_False(t, slices.Contains(cca.Group.Peers, c))
+	require_True(t, slices.Contains(cca.Group.Desired.Removed, c))
+	require_True(t, slices.Contains(cca.Group.Peers, a))
+	require_True(t, slices.Contains(cca.Group.Peers, b))
+}
+
 func TestJetStreamClusterStreamCreateRetryPreservesAssignmentCreated(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -30,6 +30,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -2293,4 +2294,31 @@ func checkStateAndErr(t *testing.T, c *cluster, accountName, streamName string) 
 		return StreamState{}, errors.Join(errs...)
 	}
 	return streamLeader.State, nil
+}
+
+// Helpers for the meta leader peer reconciliation tests.
+func metaStreamPeers(s *Server, account, stream string) []string {
+	js := s.getJetStream()
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+	sa := js.streamAssignmentOrInflight(account, stream)
+	if sa == nil {
+		return nil
+	}
+	peers := copyStrings(sa.Group.Peers)
+	slices.Sort(peers)
+	return peers
+}
+
+func metaConsumerPeers(s *Server, account, stream, consumer string) []string {
+	js := s.getJetStream()
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+	ca := js.consumerAssignmentOrInflight(account, stream, consumer)
+	if ca == nil {
+		return nil
+	}
+	peers := copyStrings(ca.Group.Peers)
+	slices.Sort(peers)
+	return peers
 }

--- a/server/raft.go
+++ b/server/raft.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -67,8 +68,10 @@ type RaftNode interface {
 	Group() string
 	Peers() []*Peer
 	PeerNames() []string
+	VotingPeerNames() []string
 	ProposeAddPeer(peer string) error
 	ProposeRemovePeer(peer string) error
+	EvictPeers(peers []string) ([]string, error)
 	MembershipChangeInProgress() bool
 	AdjustClusterSize(csz int) error
 	AdjustBootClusterSize(csz int) error
@@ -287,16 +290,17 @@ type membChange struct {
 }
 
 const (
-	minElectionTimeoutDefault      = 4 * time.Second
-	maxElectionTimeoutDefault      = 9 * time.Second
-	minCampaignTimeoutDefault      = 100 * time.Millisecond
-	maxCampaignTimeoutDefault      = 8 * minCampaignTimeoutDefault
-	hbIntervalDefault              = 1 * time.Second
-	lostQuorumIntervalDefault      = hbIntervalDefault * 10 // 10 seconds
-	lostQuorumCheckIntervalDefault = hbIntervalDefault * 10 // 10 seconds
-	observerModeIntervalDefault    = 48 * time.Hour
-	peerRemoveTimeoutDefault       = 5 * time.Minute
-	rescueQuorumTimeoutDefault     = 5 * time.Minute
+	minElectionTimeoutDefault       = 4 * time.Second
+	maxElectionTimeoutDefault       = 9 * time.Second
+	minCampaignTimeoutDefault       = 100 * time.Millisecond
+	maxCampaignTimeoutDefault       = 8 * minCampaignTimeoutDefault
+	hbIntervalDefault               = 1 * time.Second
+	lostQuorumIntervalDefault       = hbIntervalDefault * 10 // 10 seconds
+	lostQuorumCheckIntervalDefault  = hbIntervalDefault * 10 // 10 seconds
+	lostQuorumSignalIntervalDefault = 20 * time.Second
+	observerModeIntervalDefault     = 48 * time.Hour
+	peerRemoveTimeoutDefault        = 5 * time.Minute
+	rescueQuorumTimeoutDefault      = 5 * time.Minute
 )
 
 var (
@@ -307,6 +311,7 @@ var (
 	hbInterval           = hbIntervalDefault
 	lostQuorumInterval   = lostQuorumIntervalDefault
 	lostQuorumCheck      = lostQuorumCheckIntervalDefault
+	lostQuorumSignal     = lostQuorumSignalIntervalDefault
 	observerModeInterval = observerModeIntervalDefault
 	peerRemoveTimeout    = peerRemoveTimeoutDefault
 	rescueQuorumTimeout  = rescueQuorumTimeoutDefault
@@ -365,6 +370,9 @@ var (
 	errMembershipChange  = errors.New("raft: membership change in progress")
 	errRemoveLastNode    = errors.New("raft: cannot remove the last peer")
 	errPeerNotFound      = errors.New("raft: peer not found")
+	errNotManaged        = errors.New("raft: group membership is not managed")
+	errNotLeaderless     = errors.New("raft: group is not leaderless")
+	errQuorumPossible    = errors.New("raft: remaining peers could still reach quorum")
 )
 
 // This will bootstrap a raftNode by writing its config into the store directory.
@@ -1078,10 +1086,87 @@ func (n *raft) ProposeRemovePeer(peer string) error {
 	return nil
 }
 
+// EvictPeers forcibly drops the given peers from our membership, without going
+// through the log. Returns the peers that were evicted.
+//
+// This is only valid for managed groups, where the meta layer owns membership.
+// A group that has lost quorum can not commit an EntryRemovePeer of its own, so
+// it would stay stuck for as long as the downed peers are part of it. The meta
+// layer has already committed their removal by quorum, so we can apply that
+// decision directly and recover the ability to elect a leader.
+//
+// Errors for an unmanaged group, one that still has a leader and can shrink
+// through its own log instead, or one where the peers left behind could still
+// reach quorum without us.
+func (n *raft) EvictPeers(peers []string) ([]string, error) {
+	n.Lock()
+	defer n.Unlock()
+
+	// Only the meta layer can authorize this, so refuse for unmanaged groups.
+	if !n.managed {
+		return nil, errNotManaged
+	}
+	// If we have a leader we can remove peers through the log, which is ordered
+	// and therefore always preferred over deciding membership unilaterally.
+	if !n.Leaderless() {
+		return nil, errNotLeaderless
+	}
+	// Only safe to evict if the peers we leave behind can not reach quorum without
+	// us, otherwise they could commit entries we'd never see and we would diverge.
+	// Must be judged on voting membership, since a peer whose removal we appended
+	// but never committed can still be a voter for everyone else.
+	voting := n.votingPeerNames()
+	var remaining int
+	for _, peer := range voting {
+		if peer != n.id && !slices.Contains(peers, peer) {
+			remaining++
+		}
+	}
+	if remaining >= len(voting)/2+1 {
+		return nil, errQuorumPossible
+	}
+	// Revert an uncommitted membership change if it's about a peer we're evicting,
+	// or about ourselves. The leader that appended our removal is gone, and the
+	// peers that could still commit it are the ones the meta layer peer-removed,
+	// so it can never become official. Reverting restores us as a member, without
+	// which we would stay unable to campaign even after evicting the others.
+	if n.membChange != nil &&
+		(slices.Contains(peers, n.membChange.peer) || n.pendingSelfRemoval()) {
+		n.revertMembershipChange()
+	}
+	var evicted []string
+	for _, peer := range peers {
+		// Never evict ourselves, and never empty out the group.
+		if peer == n.id || len(n.peers) <= 1 {
+			continue
+		}
+		if _, ok := n.peers[peer]; !ok {
+			continue
+		}
+		// Marks the peer as removed so it can not rejoin or be re-added
+		// automatically, adjusts cluster size and quorum, and persists.
+		n.removePeer(peer)
+		evicted = append(evicted, peer)
+	}
+	if len(evicted) > 0 {
+		n.warn("Evicted peers %+v, cluster size is now %d", evicted, n.csz)
+	}
+	return evicted, nil
+}
+
 func (n *raft) MembershipChangeInProgress() bool {
 	n.RLock()
 	defer n.RUnlock()
 	return n.membChange != nil
+}
+
+// pendingSelfRemoval reports whether we have an uncommitted removal of ourselves.
+// We're speculatively dropped from our own peer set at append time, but the meta
+// layer can still consider us a member until the removal commits.
+// Lock should be held.
+func (n *raft) pendingSelfRemoval() bool {
+	// A removal tracks the previous membership state, an addition does not.
+	return n.membChange != nil && n.membChange.peer == n.id && n.membChange.prev != nil
 }
 
 // ClusterSize reports back the total cluster size.
@@ -3705,6 +3790,12 @@ func (n *raft) applyCommit(index uint64) error {
 			}
 		case EntryAddPeer:
 			newPeer := string(e.Data)
+			// Skip applying a membership change that was reverted by peer eviction, only valid
+			// if we won the election; a follower must always apply what the leader committed.
+			if n.membChange == nil && n.State() == Leader {
+				n.debug("Skipping reverted membership change adding peer %q", newPeer)
+				continue
+			}
 			n.debug("Added peer %q", newPeer)
 
 			// Store our peer in our global peer map for all peers.
@@ -3720,6 +3811,12 @@ func (n *raft) applyCommit(index uint64) error {
 
 		case EntryRemovePeer:
 			peer := string(e.Data)
+			// Skip applying a membership change that was reverted by peer eviction, only valid
+			// if we won the election; a follower must always apply what the leader committed.
+			if n.membChange == nil && n.State() == Leader {
+				n.debug("Skipping reverted membership change removing peer %q", peer)
+				continue
+			}
 			n.debug("Removing peer %q", peer)
 
 			n.removePeer(peer)
@@ -4130,25 +4227,32 @@ func (n *raft) truncateWAL(term, index uint64) {
 
 	// Check if we're truncating an uncommitted membership change.
 	if n.membChange != nil && n.membChange.index > index {
-		peer := n.membChange.peer
-		if ps := n.membChange.prev; ps != nil {
-			// This was a removal, add it back.
-			n.peers[peer] = ps
-			// If we were on the removed list, reverse that here.
-			if n.removed != nil {
-				delete(n.removed, peer)
-				if len(n.removed) == 0 {
-					n.removed = nil
-				}
-			}
-		} else {
-			// This was an addition, remove it.
-			delete(n.peers, peer)
-		}
-		n.adjustClusterSizeAndQuorum()
-		n.writePeerState(&peerState{n.peerNames(), n.csz, n.extSt})
-		n.membChange = nil
+		n.revertMembershipChange()
 	}
+}
+
+// Revert an uncommitted membership change that was speculatively applied to
+// our peer map at append time, restoring the committed membership.
+// Lock should be held.
+func (n *raft) revertMembershipChange() {
+	peer := n.membChange.peer
+	if ps := n.membChange.prev; ps != nil {
+		// This was a removal, add it back.
+		n.peers[peer] = ps
+		// If we were on the removed list, reverse that here.
+		if n.removed != nil {
+			delete(n.removed, peer)
+			if len(n.removed) == 0 {
+				n.removed = nil
+			}
+		}
+	} else {
+		// This was an addition, remove it.
+		delete(n.peers, peer)
+	}
+	n.adjustClusterSizeAndQuorum()
+	n.writePeerState(&peerState{n.peerNames(), n.csz, n.extSt})
+	n.membChange = nil
 }
 
 // Reset our WAL. This is equivalent to truncating all data from the log.
@@ -4947,6 +5051,25 @@ func (n *raft) PeerNames() []string {
 	return n.peerNames()
 }
 
+// VotingPeerNames returns every peer that could still be voting on entries,
+// which is our peer set plus a peer we speculatively dropped for a removal
+// that has not committed yet. See votingPeerNames.
+func (n *raft) VotingPeerNames() []string {
+	n.RLock()
+	defer n.RUnlock()
+	return n.votingPeerNames()
+}
+
+func (n *raft) votingPeerNames() []string {
+	peers := n.peerNames()
+	// Only a removal tracks the previous membership state, an addition does not,
+	// and there can only ever be one membership change inflight.
+	if n.membChange != nil && n.membChange.prev != nil && !slices.Contains(peers, n.membChange.peer) {
+		peers = append(peers, n.membChange.peer)
+	}
+	return peers
+}
+
 // Lock should be held.
 func (n *raft) peerNames() []string {
 	peers := make([]string, 0, len(n.peers))
@@ -5517,6 +5640,10 @@ func (n *raft) switchToCandidate() {
 	// Do not campaign with an uncommitted membership change about us,
 	// otherwise we would try to become leader outside our peer set.
 	if n.membChange != nil && n.membChange.peer == n.id {
+		// The election timer fired, so we've not heard from a leader. Clear it
+		// like campaigning would, or we'd keep reporting we have one and the
+		// upper layer could never recognize the group as stuck.
+		n.updateLeader(noLeader)
 		n.resetElect(minElectionTimeout)
 		return
 	}
@@ -5524,7 +5651,7 @@ func (n *raft) switchToCandidate() {
 	if n.State() != Candidate {
 		n.debug("Switching to candidate")
 	} else {
-		if n.lostQuorumLocked() && time.Since(n.llqrt) > 20*time.Second {
+		if n.lostQuorumLocked() && time.Since(n.llqrt) > lostQuorumSignal {
 			// We signal to the upper layers such that can alert on quorum lost.
 			n.updateLeadChange(false)
 			n.llqrt = time.Now()

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -1491,6 +1491,350 @@ func TestNRGTruncateWALRevertsUncommittedRemovePeer(t *testing.T) {
 	t.Run("Restart", func(t *testing.T) { test(KindRestart) })
 }
 
+func TestNRGEvictPeers(t *testing.T) {
+	nats0 := "S1Nunr6R" // "nats-0"
+	nats1 := "yrzKKRBu" // "nats-1"
+	nats2 := "cnrtt3eg" // "nats-2"
+	nats3 := "bkCGheKT" // "nats-3"
+
+	t.Run("Guards", func(t *testing.T) {
+		n, cleanup := initSingleMemRaftNode(t)
+		defer cleanup()
+
+		n.addPeer(nats0)
+
+		// Refuse for unmanaged groups.
+		_, err := n.EvictPeers([]string{nats0})
+		require_Error(t, err, errNotManaged)
+		n.Lock()
+		n.managed = true
+		n.Unlock()
+
+		// Refuse if we still have a leader.
+		n.Lock()
+		n.updateLeader(nats0)
+		n.Unlock()
+		_, err = n.EvictPeers([]string{nats0})
+		require_Error(t, err, errNotLeaderless)
+
+		n.Lock()
+		n.updateLeader(noLeader)
+		n.Unlock()
+
+		// Never evict ourselves.
+		evicted, err := n.EvictPeers([]string{n.id})
+		require_NoError(t, err)
+		require_Len(t, len(evicted), 0)
+
+		// Unknown peers are ignored.
+		evicted, err = n.EvictPeers([]string{nats1})
+		require_NoError(t, err)
+		require_Len(t, len(evicted), 0)
+
+		// The peer is evicted and marked removed, size and quorum shrink.
+		evicted, err = n.EvictPeers([]string{nats0})
+		require_NoError(t, err)
+		require_True(t, slices.Equal(evicted, []string{nats0}))
+		_, ok := n.peers[nats0]
+		require_False(t, ok)
+		_, ok = n.removed[nats0]
+		require_True(t, ok)
+		require_Equal(t, n.csz, 1)
+		require_Equal(t, n.qn, 1)
+
+		// Never empty out the group.
+		evicted, err = n.EvictPeers([]string{n.id})
+		require_NoError(t, err)
+		require_Len(t, len(evicted), 0)
+	})
+
+	// Evicting is only allowed if the peers left behind can't reach quorum
+	// without us, or they could commit entries we'd never see.
+	t.Run("RefusesWhenQuorumPossible", func(t *testing.T) {
+		n, cleanup := initSingleMemRaftNode(t)
+		defer cleanup()
+
+		n.addPeer(nats0)
+		n.addPeer(nats1)
+		n.addPeer(nats2)
+		n.addPeer(nats3)
+		require_Len(t, len(n.peers), 5)
+
+		n.Lock()
+		n.managed = true
+		n.updateLeader(noLeader)
+		n.Unlock()
+
+		// Three peers left is exactly quorum for the group of five, refuse.
+		_, err := n.EvictPeers([]string{nats0})
+		require_Error(t, err, errQuorumPossible)
+
+		// Two peers left can't commit without us, so we're good to go.
+		evicted, err := n.EvictPeers([]string{nats0, nats1})
+		require_NoError(t, err)
+		require_True(t, slices.Equal(evicted, []string{nats0, nats1}))
+		require_Equal(t, n.csz, 3)
+	})
+
+	// A stuck uncommitted RemovePeer of a peer we're not evicting speculatively
+	// dropped it from our peer map, but it can still be voting for everyone
+	// else. It must be counted when deciding if eviction is safe.
+	t.Run("RefusesForUncommittedRemovePeer", func(t *testing.T) {
+		n, cleanup := initSingleMemRaftNode(t)
+		defer cleanup()
+
+		n.addPeer(nats0)
+		n.addPeer(nats1)
+		n.addPeer(nats2)
+		n.addPeer(nats3)
+		require_Len(t, len(n.peers), 5)
+
+		esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+		normal := []*Entry{newEntry(EntryNormal, esm)}
+		removePeer := newEntry(EntryRemovePeer, []byte(nats3))
+		ae1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: normal})
+		ae2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 1, entries: []*Entry{removePeer}})
+		n.processAppendEntry(ae1, n.aesub)
+		n.processAppendEntry(ae2, n.aesub)
+
+		// The peer is gone speculatively, but it's still a voting member.
+		_, ok := n.peers[nats3]
+		require_False(t, ok)
+		require_Len(t, len(n.peers), 4)
+		require_Len(t, len(n.votingPeerNames()), 5)
+
+		n.Lock()
+		n.managed = true
+		n.updateLeader(noLeader)
+		n.Unlock()
+
+		// Only counting our peer map would leave two of four and evict, but the
+		// committed group is five and the three left could commit without us.
+		_, err := n.EvictPeers([]string{nats0})
+		require_Error(t, err, errQuorumPossible)
+
+		// Evicting the pending removal as well leaves too few behind, so allowed.
+		evicted, err := n.EvictPeers([]string{nats0, nats1, nats3})
+		require_NoError(t, err)
+		require_True(t, slices.Equal(evicted, []string{nats0, nats1, nats3}))
+		require_True(t, n.membChange == nil)
+		require_Equal(t, n.csz, 2)
+	})
+
+	// A stuck uncommitted RemovePeer of the peer we're evicting was already
+	// speculatively applied to the peer map. It must be reverted first so
+	// eviction properly marks the peer as removed.
+	t.Run("RevertsUncommittedRemovePeer", func(t *testing.T) {
+		n, cleanup := initSingleMemRaftNode(t)
+		defer cleanup()
+
+		n.addPeer(nats0)
+		n.addPeer(nats1)
+		require_Len(t, len(n.peers), 3)
+
+		esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+		normal := []*Entry{newEntry(EntryNormal, esm)}
+		removePeer := newEntry(EntryRemovePeer, []byte(nats1))
+		ae1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: normal})
+		ae2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 1, entries: []*Entry{removePeer}})
+		n.processAppendEntry(ae1, n.aesub)
+		n.processAppendEntry(ae2, n.aesub)
+
+		// The peer is gone speculatively, and a membership change is inflight.
+		_, ok := n.peers[nats1]
+		require_False(t, ok)
+		require_NotNil(t, n.membChange)
+
+		n.Lock()
+		n.managed = true
+		n.updateLeader(noLeader)
+		n.Unlock()
+
+		// Evicting the peer must first revert the speculative removal, then
+		// evict it for real: marked removed, size and quorum adjusted.
+		evicted, err := n.EvictPeers([]string{nats1})
+		require_NoError(t, err)
+		require_True(t, slices.Equal(evicted, []string{nats1}))
+		_, ok = n.peers[nats1]
+		require_False(t, ok)
+		_, ok = n.removed[nats1]
+		require_True(t, ok)
+		require_Equal(t, n.csz, 2)
+		require_Equal(t, n.qn, 2)
+		require_True(t, n.membChange == nil)
+	})
+
+	// A scale-down or move that appended a RemovePeer of ourselves, but never
+	// committed it, already dropped us from our own peer map. Evicting the
+	// peers the meta layer removed must revert it as well, or we'd evict the
+	// others and still not be a member that can campaign.
+	t.Run("RevertsUncommittedSelfRemoval", func(t *testing.T) {
+		n, cleanup := initSingleMemRaftNode(t)
+		defer cleanup()
+
+		n.addPeer(nats0)
+		n.addPeer(nats1)
+		require_Len(t, len(n.peers), 3)
+
+		esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+		normal := []*Entry{newEntry(EntryNormal, esm)}
+		removePeer := newEntry(EntryRemovePeer, []byte(n.id))
+		ae1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: normal})
+		ae2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 1, entries: []*Entry{removePeer}})
+		n.processAppendEntry(ae1, n.aesub)
+		n.processAppendEntry(ae2, n.aesub)
+
+		// We're gone from our own peer map speculatively.
+		_, ok := n.peers[n.id]
+		require_False(t, ok)
+		require_True(t, n.pendingSelfRemoval())
+
+		n.Lock()
+		n.managed = true
+		n.updateLeader(noLeader)
+		n.Unlock()
+
+		// Evicting the other peers must revert our own pending removal first,
+		// leaving us as the sole member with quorum of one.
+		evicted, err := n.EvictPeers([]string{nats0, nats1})
+		require_NoError(t, err)
+		require_True(t, slices.Equal(evicted, []string{nats0, nats1}))
+		_, ok = n.peers[n.id]
+		require_True(t, ok)
+		require_Len(t, len(n.peers), 1)
+		require_Equal(t, n.csz, 1)
+		require_Equal(t, n.qn, 1)
+		require_False(t, n.pendingSelfRemoval())
+		require_True(t, n.membChange == nil)
+
+		// We must be able to become leader again, and commit at quorum one.
+		n.Lock()
+		n.term++
+		n.Unlock()
+		n.switchToLeader()
+		n.sendAppendEntry(normal)
+		require_Equal(t, n.commit, n.pindex)
+	})
+
+	// A stuck uncommitted AddPeer speculatively added the peer to the peer
+	// map. While the peer is part of the assignment the change must be left
+	// alone, but once the assignment doesn't know it anymore it must be
+	// reverted, or the phantom peer would keep inflating size and quorum.
+	t.Run("RevertsUncommittedAddPeer", func(t *testing.T) {
+		n, cleanup := initSingleMemRaftNode(t)
+		defer cleanup()
+
+		n.addPeer(nats0)
+		require_Len(t, len(n.peers), 2)
+
+		esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+		normal := []*Entry{newEntry(EntryNormal, esm)}
+		addPeer := newEntry(EntryAddPeer, []byte(nats1))
+		ae1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: normal})
+		ae2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 1, entries: []*Entry{addPeer}})
+		n.processAppendEntry(ae1, n.aesub)
+		n.processAppendEntry(ae2, n.aesub)
+
+		// The peer is tracked speculatively, and a membership change is inflight.
+		_, ok := n.peers[nats1]
+		require_True(t, ok)
+		require_Equal(t, n.csz, 3)
+		require_NotNil(t, n.membChange)
+
+		n.Lock()
+		n.managed = true
+		n.updateLeader(noLeader)
+		n.Unlock()
+
+		// Evicting another peer must leave the membership change and its
+		// speculatively added peer alone; the assignment still contains it.
+		evicted, err := n.EvictPeers([]string{nats0})
+		require_NoError(t, err)
+		require_True(t, slices.Equal(evicted, []string{nats0}))
+		_, ok = n.peers[nats1]
+		require_True(t, ok)
+		_, ok = n.peers[nats0]
+		require_False(t, ok)
+		_, ok = n.removed[nats0]
+		require_True(t, ok)
+		require_Equal(t, n.csz, 2)
+		require_Equal(t, n.qn, 2)
+		require_NotNil(t, n.membChange)
+
+		// Once the added peer is peer-removed or reconciled away, it shows
+		// up in the evict list itself and the change is reverted. There's
+		// nothing to remove from the peer map, so it's not marked removed;
+		// the entry may still commit under another leader.
+		evicted, err = n.EvictPeers([]string{nats1})
+		require_NoError(t, err)
+		require_Len(t, len(evicted), 0)
+		_, ok = n.peers[nats1]
+		require_False(t, ok)
+		_, ok = n.removed[nats1]
+		require_False(t, ok)
+		require_Equal(t, n.csz, 1)
+		require_Equal(t, n.qn, 1)
+		require_True(t, n.membChange == nil)
+	})
+
+	// Sole survivor: eviction reverts an uncommitted AddPeer for a peer
+	// that was peer-removed, then we win the election. The entry stays in
+	// the WAL but commits as a no-op, so the phantom peer can't inflate
+	// quorum again.
+	t.Run("RevertedAddPeerCommitsAsNoopWhenLeader", func(t *testing.T) {
+		n, cleanup := initSingleMemRaftNode(t)
+		defer cleanup()
+
+		n.addPeer(nats0)
+		require_Len(t, len(n.peers), 2)
+
+		esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+		normal := []*Entry{newEntry(EntryNormal, esm)}
+		addPeer := newEntry(EntryAddPeer, []byte(nats1))
+		ae1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: normal})
+		ae2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 1, pindex: 1, entries: []*Entry{addPeer}})
+		n.processAppendEntry(ae1, n.aesub)
+		n.processAppendEntry(ae2, n.aesub)
+		require_NotNil(t, n.membChange)
+		require_Equal(t, n.csz, 3)
+
+		n.Lock()
+		n.managed = true
+		n.updateLeader(noLeader)
+		n.Unlock()
+
+		// Evict the other real peer and the peer-removed phantom, leaving us
+		// as the sole survivor. The uncommitted AddPeer is reverted, but
+		// stays in the WAL.
+		evicted, err := n.EvictPeers([]string{nats0, nats1})
+		require_NoError(t, err)
+		require_True(t, slices.Equal(evicted, []string{nats0}))
+		require_Equal(t, n.csz, 1)
+		require_Equal(t, n.qn, 1)
+		require_True(t, n.membChange == nil)
+
+		// Become leader. This appends our peer state above the reverted
+		// entry and self-commits everything at quorum 1. The AddPeer must
+		// commit as a no-op: no phantom peer, size and quorum stay 1.
+		n.Lock()
+		n.term++
+		n.Unlock()
+		n.switchToLeader()
+
+		require_Equal(t, n.commit, 3)
+		_, ok := n.peers[nats1]
+		require_False(t, ok)
+		require_Equal(t, n.csz, 1)
+		require_Equal(t, n.qn, 1)
+
+		// The group must remain functional, new proposals commit at quorum 1.
+		n.sendAppendEntry(normal)
+		require_Equal(t, n.commit, 4)
+		_, ok = n.peers[nats1]
+		require_False(t, ok)
+	})
+}
+
 func TestNRGResetWALClearsPendingAppendEntryCache(t *testing.T) {
 	n, cleanup := initSingleMemRaftNode(t)
 	defer cleanup()
@@ -6188,9 +6532,18 @@ func TestNRGDontSwitchToCandidateWithInflightSelfMembershipChange(t *testing.T) 
 	require_Equal(t, n.membChange.index, 2)
 
 	// We must not become a candidate while our own removal is uncommitted.
+	// The election timer firing does mean we've not heard from the leader, so
+	// we must still report as leaderless. Otherwise the upper layer would never
+	// see the group as stuck and could not recover it.
+	n.Lock()
+	n.updateLeader(nats0)
+	n.Unlock()
+	require_False(t, n.Leaderless())
+
 	n.Applied(1)
 	n.switchToCandidate()
 	require_Equal(t, n.State(), Follower)
+	require_True(t, n.Leaderless())
 
 	// Truncate the uncommitted removal back to the committed index. This
 	// restores us to our own peer set and clears the inflight change.


### PR DESCRIPTION
If a stream/consumer Raft group was below quorum, it wasn't possible to safely peer-remove nodes to get into quorum again. This PR fixes that by allowing nodes to be evicted when below quorum, but only those nodes that were explicitly peer-removed. Given a R3 stream without quorum due to 2 nodes being offline, it's now possible to peer-remove those two offline nodes and the stream will become operational again, albeit it at R1. If new peers were assigned to the stream, the stream would automatically scale up to R3, but on the new peers.

The desired state gets a new `rg.Desired.Removed` field that contains the set of explicitly peer-removed nodes, which are eligible for eviction if below quorum. Eviction is only allowed if this node thinks the stream/consumer Raft group is leaderless, it is not leaderless on the meta layer, it has desired state that specifies removed peers, and the node itself is still part of the group's peer set. A safety check also prevents eviction if the remaining peers could form a disjoint majority.

Follow-up of https://github.com/nats-io/nats-server/pull/8432