### PR TITLE
[FIXED] Route missing after reconnect due to gossip URL mismatch

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -2457,10 +2457,13 @@ func upgradeRouteToSolicited(r *client, url *url.URL, rtype RouteType) {
 		return
 	}
 	r.mu.Lock()
-	if !r.route.didSolicit {
-		r.route.didSolicit = true
+	// On disconnect, an explicit route only reconnects if the connection's
+	// URL matches a configured route. So adopt the given URL rather than
+	// keeping a gossiped one, which may not match any configured route.
+	if !r.route.didSolicit || (rtype == Explicit && r.route.routeType != Explicit) {
 		r.route.url = url
 	}
+	r.route.didSolicit = true
 	if rtype == Explicit {
 		r.route.routeType = Explicit
 	}
@@ -2909,6 +2912,7 @@ func (s *Server) connectToRoute(rURL *url.URL, rtype RouteType, firstConnect boo
 	for attempts := 0; s.isRunning(); {
 		if tryForEver {
 			if !s.routeStillValid(rURL) {
+				s.Debugf("Not attempting to connect to explicit route %q, no longer part of configured routes", rURL.Redacted())
 				return
 			}
 			if accName != _EMPTY_ {
@@ -2916,6 +2920,7 @@ func (s *Server) connectToRoute(rURL *url.URL, rtype RouteType, firstConnect boo
 				_, valid := s.accRoutes[accName]
 				s.mu.RUnlock()
 				if !valid {
+					s.Debugf("Not attempting to connect to route %q for account %q, no longer a per-account route", rURL.Redacted(), accName)
 					return
 				}
 			}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -5663,3 +5663,66 @@ func BenchmarkProcessLeafMsgArgs_Queues(b *testing.B) {
 		}
 	}
 }
+
+func TestRouteReconnectAfterDuplicateRouteUpgrade(t *testing.T) {
+	// Default pool size + pinned $SYS route, like a production setup, with a
+	// hostname-based route URL like production configs use.
+	ob := DefaultOptions()
+	sb := RunServer(ob)
+	defer sb.Shutdown()
+
+	oa := DefaultOptions()
+	oa.Routes = RoutesFromStr(fmt.Sprintf("nats://localhost:%d", sb.ClusterAddr().Port))
+	sa := RunServer(oa)
+	defer sa.Shutdown()
+	checkClusterFormed(t, sa, sb)
+
+	// Find A's pooled route connection for the slot that carries the global
+	// account's interest.
+	gSlot := computeRoutePoolIdx(sa.getOpts().Cluster.PoolSize, globalAccountName)
+	var route *client
+	sa.mu.RLock()
+	sa.forEachRouteIdx(gSlot, func(r *client) bool {
+		route = r
+		return false
+	})
+	sa.mu.RUnlock()
+	require_NotNil(t, route)
+
+	// Put the connection in the pre-upgrade gossip-dial state, then run the
+	// actual upgrade with the configured URL, as duplicate-route resolution
+	// does. The upgrade must adopt the configured URL so the later reconnect
+	// passes routeStillValid.
+	gossipURL, err := url.Parse(fmt.Sprintf("nats-route://127.0.0.1:%d/", sb.ClusterAddr().Port))
+	require_NoError(t, err)
+	route.mu.Lock()
+	route.route.didSolicit = true
+	route.route.routeType = Implicit
+	route.route.url = gossipURL
+	route.mu.Unlock()
+
+	configured := oa.Routes[0]
+	upgradeRouteToSolicited(route, configured, Explicit)
+
+	route.mu.Lock()
+	upURL := route.route.url
+	route.mu.Unlock()
+	require_Equal(t, upURL, configured)
+
+	// Drop the connection the way a fault would (slow consumer). The sibling
+	// pool slots and the pinned $SYS route stay up, so the remote is never
+	// treated as new and only this reconnect can re-establish the slot.
+	route.closeConnection(SlowConsumerWriteDeadline)
+	checkClusterFormed(t, sa, sb)
+
+	// Interest must flow across the re-established slot again.
+	nca := natsConnect(t, sa.ClientURL())
+	defer nca.Close()
+	ncb := natsConnect(t, sb.ClientURL())
+	defer ncb.Close()
+	natsSub(t, ncb, "reconnect.echo", func(m *nats.Msg) { m.Respond(m.Data) })
+	natsFlush(t, ncb)
+	checkSubInterest(t, sa, globalAccountName, "reconnect.echo", 2*time.Second)
+	_, err = nca.Request("reconnect.echo", []byte("ping"), time.Second)
+	require_NoError(t, err)
+}


### PR DESCRIPTION
Found via Antithesis testing: `upgradeRouteToSolicited` could upgrade a gossip-dialed connection to `Explicit` while keeping its gossip URL, so after a disconnect `routeStillValid` rejected that URL and the reconnect was silently abandoned, leaving a route pool slot unfilled between two live servers. This PR adopts the configured URL during the upgrade, so reconnects always pass `routeStillValid`.