### PR TITLE
[IMPROVED] Expire MaxAge block prefixes after v4 recovery

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -6876,6 +6876,41 @@ func (o *consumer) decStreamPending(sseq uint64, subj string) {
 	}
 }
 
+func (o *consumer) expireStreamPendingPrefix(first uint64) {
+	if first == 0 {
+		return
+	}
+	type pendingTerm struct {
+		sseq, dseq, dc uint64
+	}
+	var terms []pendingTerm
+	o.mu.Lock()
+	for sseq, p := range o.pending {
+		if sseq >= first {
+			continue
+		}
+		terms = append(terms, pendingTerm{sseq, p.Sequence, o.deliveryCount(sseq)})
+	}
+	for sseq := range o.rdc {
+		if sseq >= first {
+			continue
+		}
+		if _, ok := o.pending[sseq]; ok || !o.isLeader() {
+			continue
+		}
+		delete(o.rdc, sseq)
+		o.removeFromRedeliverQueue(sseq)
+		// Pass 0 as the delivered sequence to only remove the redelivered state.
+		o.updateAcks(0, sseq, _EMPTY_)
+	}
+	o.streamNumPending()
+	o.mu.Unlock()
+
+	for _, pt := range terms {
+		go o.processTerm(pt.sseq, pt.dseq, pt.dc, ackTermUnackedLimitsReason, _EMPTY_)
+	}
+}
+
 func (o *consumer) account() *Account {
 	o.mu.RLock()
 	a := o.acc

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -171,6 +171,10 @@ type psi struct {
 	lblk  uint32
 }
 
+// storageExpirePrefixHandler receives one completed local MaxAge prefix expiry.
+// first is the new stream floor; msgs and bytes are the removed totals.
+type storageExpirePrefixHandler func(first, msgs, bytes uint64)
+
 type fileStore struct {
 	srv         *Server
 	mu          sync.RWMutex
@@ -179,6 +183,7 @@ type fileStore struct {
 	ld          *LostStreamData
 	scb         StorageUpdateHandler
 	rmcb        StorageRemoveMsgHandler
+	epcb        storageExpirePrefixHandler
 	pmsgcb      ProcessJetStreamMsgHandler
 	ageChk      *time.Timer // Timer to expire messages.
 	ageChkRun   bool        // Whether message expiration is currently running.
@@ -267,6 +272,8 @@ type msgBlock struct {
 	closed      bool
 	ttls        uint64 // How many msgs have TTLs?
 	schedules   uint64 // How many msgs have schedules?
+	tsKnown     bool   // Whether timestamp, TTL, and schedule metadata is known.
+	tsOrdered   bool   // Whether message record timestamps are in sequence order.
 
 	// Used to mock write failures.
 	mockWriteErr bool
@@ -2071,6 +2078,10 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 			if version >= 3 {
 				schedules = readU64()
 			}
+			var tsOrdered bool
+			if version >= 5 {
+				tsOrdered = readU64() != 0
+			}
 			if bi < 0 {
 				_ = os.Remove(fn)
 				return errCorruptState
@@ -2082,6 +2093,8 @@ func (fs *fileStore) recoverFullState() (rerr error) {
 			mb.first.ts, mb.last.ts = fts+baseTime, lts+baseTime
 			mb.ttls = ttls
 			mb.schedules = schedules
+			mb.tsKnown = version >= 3
+			mb.tsOrdered = tsOrdered
 			if numDeleted > 0 {
 				dmap, n, err := avl.Decode(buf[bi:])
 				if err != nil {
@@ -2627,16 +2640,18 @@ func (fs *fileStore) expireMsgsOnRecover() error {
 			last.ts = mb.last.ts
 		}
 		// Make sure we do subject cleanup as well.
-		if err := mb.ensurePerSubjectInfoLoaded(); err != nil {
-			return err
-		}
-		mb.fss.IterOrdered(func(bsubj []byte, ss *SimpleState) bool {
-			subj := bytesToString(bsubj)
-			for i := uint64(0); i < ss.Msgs; i++ {
-				fs.removePerSubject(subj)
+		if !mb.noTrack {
+			if err := mb.ensurePerSubjectInfoLoaded(); err != nil {
+				return err
 			}
-			return true
-		})
+			mb.fss.IterOrdered(func(bsubj []byte, ss *SimpleState) bool {
+				subj := bytesToString(bsubj)
+				for i := uint64(0); i < ss.Msgs; i++ {
+					fs.removePerSubject(subj)
+				}
+				return true
+			})
+		}
 		if err := mb.dirtyCloseWithRemove(true); err != nil {
 			return err
 		}
@@ -2652,7 +2667,33 @@ func (fs *fileStore) expireMsgsOnRecover() error {
 			break
 		}
 		// Can we remove whole block here?
-		if mb.last.ts <= minAge {
+		if mb.expirePrefixEligibleLocked(minAge) {
+			if err := mb.ensurePerSubjectInfoLoaded(); err != nil {
+				mb.mu.Unlock()
+				return err
+			}
+			if mb.expirePrefixEligibleLocked(minAge) {
+				purged += mb.msgs
+				bytes += mb.bytes
+				err := deleteEmptyBlock(mb)
+				mb.mu.Unlock()
+				if err != nil {
+					return err
+				}
+				continue
+			}
+		}
+
+		// If we are here we have to process the interior messages of this blk.
+		// This will load fss as well.
+		if err := mb.loadMsgsWithLock(); err != nil {
+			mb.mu.Unlock()
+			return err
+		}
+		// Pre-v5 full states do not record timestamp ordering. Once loading
+		// proves this block is an ordered, expired prefix, remove it and keep
+		// recovering later blocks instead of treating it as a boundary block.
+		if mb.expirePrefixEligibleLocked(minAge) {
 			purged += mb.msgs
 			bytes += mb.bytes
 			err := deleteEmptyBlock(mb)
@@ -2661,13 +2702,6 @@ func (fs *fileStore) expireMsgsOnRecover() error {
 				return err
 			}
 			continue
-		}
-
-		// If we are here we have to process the interior messages of this blk.
-		// This will load fss as well.
-		if err := mb.loadMsgsWithLock(); err != nil {
-			mb.mu.Unlock()
-			return err
 		}
 
 		var smv StoreMsg
@@ -2696,6 +2730,14 @@ func (fs *fileStore) expireMsgsOnRecover() error {
 			}
 
 			// No error and sm != nil from here onward.
+
+			if ttl, err := getMessageTTL(sm.hdr); err == nil && ttl < 0 {
+				atomic.StoreUint64(&mb.first.seq, sm.seq)
+				mb.first.ts = sm.ts
+				needNextFirst = false
+				nts = sm.ts
+				break
+			}
 
 			// Check for done.
 			if minAge < sm.ts {
@@ -2733,14 +2775,19 @@ func (fs *fileStore) expireMsgsOnRecover() error {
 			mb.selectNextFirst()
 		}
 		// Check if empty after processing, could happen if tail of messages are all deleted.
+		empty := mb.msgs == 0
 		var err error
-		if mb.msgs == 0 {
+		if empty {
 			err = deleteEmptyBlock(mb)
 		}
 		mb.finishedWithCache()
 		mb.mu.Unlock()
 		if err != nil {
 			return err
+		}
+		if empty {
+			// The whole block was scanned, so no surviving boundary remains.
+			continue
 		}
 		break
 	}
@@ -4755,6 +4802,14 @@ func (fs *fileStore) RegisterStorageRemoveMsg(cb StorageRemoveMsgHandler) {
 	fs.mu.Unlock()
 }
 
+// registerStorageExpirePrefix installs the stream owner for completed local
+// prefix expiry. Unlike StorageUpdateHandler, this has an explicit range floor.
+func (fs *fileStore) registerStorageExpirePrefix(cb storageExpirePrefixHandler) {
+	fs.mu.Lock()
+	fs.epcb = cb
+	fs.mu.Unlock()
+}
+
 // RegisterProcessJetStreamMsg registers a callback to process new JetStream messages.
 func (fs *fileStore) RegisterProcessJetStreamMsg(cb ProcessJetStreamMsgHandler) {
 	fs.mu.Lock()
@@ -4855,6 +4910,7 @@ func (fs *fileStore) newMsgBlockForWrite() (*msgBlock, error) {
 	}
 
 	mb := fs.initMsgBlock(index)
+	mb.tsKnown, mb.tsOrdered = true, true
 	// Lock should be held to quiet race detector.
 	mb.mu.Lock()
 	if err := mb.setupWriteCache(rbuf); err != nil {
@@ -5088,17 +5144,27 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 		return err
 	}
 
+	// Track header metadata even when no expiration wheel or scheduler is active.
+	// Whole-block MaxAge expiry relies on these counts to avoid bypassing per-message semantics.
+	hasTTL := ttl != 0 || len(sliceHeader(JSMessageTTL, hdr)) > 0
+	hasSchedule := len(sliceHeader(JSSchedulePattern, hdr)) > 0
+	if hasTTL || hasSchedule {
+		fs.lmb.mu.Lock()
+		if hasTTL {
+			fs.lmb.ttls++
+		}
+		if hasSchedule {
+			fs.lmb.schedules++
+		}
+		fs.lmb.mu.Unlock()
+	}
+
 	// Per-message TTL.
 	if ttl > 0 {
 		if fs.ttls != nil {
 			expires := time.Duration(ts) + (time.Second * time.Duration(ttl))
 			fs.ttls.Add(seq, int64(expires))
 		}
-		// Need to count these regardless as we might want to enable TTLs
-		// later via UpdateConfig.
-		fs.lmb.mu.Lock()
-		fs.lmb.ttls++
-		fs.lmb.mu.Unlock()
 	}
 
 	// Check if we have and need the age expiration timer running.
@@ -5113,9 +5179,6 @@ func (fs *fileStore) storeRawMsg(subj string, hdr, msg []byte, seq uint64, ts, t
 	if fs.scheduling != nil {
 		if schedule, apiErr := nextMessageSchedule(hdr, ts); apiErr == nil && !schedule.IsZero() {
 			fs.scheduling.add(seq, subj, schedule.UnixNano())
-			fs.lmb.mu.Lock()
-			fs.lmb.schedules++
-			fs.lmb.mu.Unlock()
 		} else if getMessageScheduler(hdr) == _EMPTY_ {
 			fs.scheduling.removeSubject(subj)
 		}
@@ -5770,6 +5833,271 @@ func (fs *fileStore) deleteFirstMsg() (bool, error) {
 // Lock should be held.
 func (fs *fileStore) removeMsgViaLimits(seq uint64) (bool, error) {
 	return fs.removeMsg(seq, false, true, false)
+}
+
+// Lock should be held.
+func (mb *msgBlock) expirePrefixEligibleLocked(cutoff int64) bool {
+	return mb.msgs > 0 && mb.tsKnown && mb.tsOrdered && mb.ttls == 0 && mb.schedules == 0 &&
+		mb.first.ts > 0 && mb.last.ts >= mb.first.ts && mb.last.ts <= cutoff
+}
+
+type expirePrefixSubject struct {
+	subj string
+	msgs uint64
+}
+
+type expirePrefixBlock struct {
+	mb       *msgBlock
+	msgs     uint64
+	bytes    uint64
+	subjects []expirePrefixSubject
+}
+
+// Lock should be held.
+func (mb *msgBlock) collectExpirePrefixSubjectsLocked(totals map[string]uint64) ([]expirePrefixSubject, error) {
+	if mb.noTrack {
+		return nil, nil
+	}
+	if mb.fss == nil {
+		return nil, errors.New("missing message block subject state")
+	}
+
+	subjects := make([]expirePrefixSubject, 0, mb.fss.Size())
+	var count uint64
+	var rerr error
+	mb.fss.IterFast(func(subj []byte, ss *SimpleState) bool {
+		if ss == nil || ss.Msgs == 0 {
+			rerr = fmt.Errorf("invalid message block subject state for %q", subj)
+			return false
+		}
+		if ss.Msgs > math.MaxUint64-count {
+			rerr = errors.New("message block subject accounting overflow")
+			return false
+		}
+		count += ss.Msgs
+
+		name := string(subj)
+		if ss.Msgs > math.MaxUint64-totals[name] {
+			rerr = fmt.Errorf("message block subject accounting overflow for %q", name)
+			return false
+		}
+		totals[name] += ss.Msgs
+		subjects = append(subjects, expirePrefixSubject{subj: name, msgs: ss.Msgs})
+		return true
+	})
+	if rerr != nil {
+		return nil, rerr
+	}
+	if count != mb.msgs {
+		return nil, fmt.Errorf("message block accounting mismatch: %d messages, %d subject entries", mb.msgs, count)
+	}
+	return subjects, nil
+}
+
+// Lock should be held.
+func (fs *fileStore) validateExpirePrefixSubjectsLocked(totals map[string]uint64) error {
+	for subj, msgs := range totals {
+		info, ok := fs.psim.Find(stringToBytes(subj))
+		if !ok || info == nil || info.total < msgs {
+			return fmt.Errorf("message block subject accounting mismatch for %q", subj)
+		}
+	}
+	return nil
+}
+
+// Lock should be held.
+func (fs *fileStore) removeExpirePrefixSubjectsLocked(blocks []expirePrefixBlock) {
+	for _, block := range blocks {
+		for _, subj := range block.subjects {
+			info, _ := fs.psim.Find(stringToBytes(subj.subj))
+			info.total -= subj.msgs
+			if info.total == 0 {
+				fs.psim.Delete(stringToBytes(subj.subj))
+				fs.tsl -= len(subj.subj)
+			}
+		}
+	}
+}
+
+// Lock should be held.
+func (mb *msgBlock) removeForExpirePrefixLocked() error {
+	if fd := mb.mfd; fd != nil {
+		mb.mfd = nil
+		if err := fd.Close(); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	if mb.mfn != _EMPTY_ {
+		if err := os.Remove(mb.mfn); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		mb.mfn = _EMPTY_
+	}
+
+	if mb.ctmr != nil {
+		mb.ctmr.Stop()
+		mb.ctmr = nil
+	}
+	mb.clearCacheAndOffset()
+	if mb.qch != nil {
+		close(mb.qch)
+		mb.qch = nil
+	}
+	mb.fss = nil
+	mb.closed = true
+
+	// The key file is now an orphan and recovery removes it. Do not turn a
+	// successful block removal into a partial prefix failure if that cleanup
+	// happens to fail.
+	if mb.kfn != _EMPTY_ {
+		_ = os.Remove(mb.kfn)
+		mb.kfn = _EMPTY_
+	}
+	return nil
+}
+
+// expirePrefixViaLimits removes locally verified complete blocks without
+// forcing a full state write. It validates every candidate block and all
+// shared accounting before unlinking the first block. If an unlink fails after
+// earlier blocks were removed, it returns the committed prefix so its callback
+// and the next timer run can account for exactly that work.
+func (fs *fileStore) expirePrefixViaLimits(first uint64, cutoff int64) (uint64, error) {
+	fs.mu.Lock()
+	if fs.isClosed() {
+		fs.mu.Unlock()
+		return 0, ErrStoreClosed
+	}
+	if err := fs.werr; err != nil {
+		fs.mu.Unlock()
+		return 0, err
+	}
+
+	purged, bytes, newFirst, err := fs.expirePrefixViaLimitsLocked(first, cutoff)
+	scb, epcb := fs.scb, fs.epcb
+	fs.mu.Unlock()
+
+	if purged > 0 {
+		if epcb != nil {
+			epcb(newFirst, purged, bytes)
+		} else if scb != nil {
+			// A range has no single-message sequence or subject.
+			scb(-int64(purged), -int64(bytes), 0, _EMPTY_)
+		}
+	}
+	return purged, err
+}
+
+// Lock should be held.
+func (fs *fileStore) expirePrefixViaLimitsLocked(first uint64, cutoff int64) (purged, bytes, newFirst uint64, rerr error) {
+	if first == 0 || first != fs.state.FirstSeq || fs.state.Msgs == 0 {
+		return 0, 0, 0, nil
+	}
+
+	var blocks []expirePrefixBlock
+	totals := make(map[string]uint64)
+	next := first
+	for _, mb := range fs.blks {
+		if mb == fs.lmb {
+			break
+		}
+
+		mb.mu.Lock()
+		needsCleanup := mb.cache == nil
+		finish := func() {
+			if needsCleanup {
+				mb.finishedWithCache()
+			}
+		}
+		if atomic.LoadUint64(&mb.first.seq) < next {
+			finish()
+			mb.mu.Unlock()
+			break
+		}
+		if !mb.tsKnown || !mb.tsOrdered {
+			if err := mb.loadMsgsWithLock(); err != nil {
+				finish()
+				mb.mu.Unlock()
+				return 0, 0, 0, err
+			}
+		}
+		if !mb.expirePrefixEligibleLocked(cutoff) {
+			finish()
+			mb.mu.Unlock()
+			break
+		}
+		if err := mb.ensurePerSubjectInfoLoaded(); err != nil {
+			finish()
+			mb.mu.Unlock()
+			return 0, 0, 0, err
+		}
+		subjects, err := mb.collectExpirePrefixSubjectsLocked(totals)
+		if err != nil {
+			finish()
+			mb.mu.Unlock()
+			return 0, 0, 0, err
+		}
+		if purged > fs.state.Msgs || bytes > fs.state.Bytes ||
+			mb.msgs > fs.state.Msgs-purged || mb.bytes > fs.state.Bytes-bytes {
+			finish()
+			mb.mu.Unlock()
+			return 0, 0, 0, errors.New("message block accounting exceeds stream state")
+		}
+
+		blocks = append(blocks, expirePrefixBlock{mb: mb, msgs: mb.msgs, bytes: mb.bytes, subjects: subjects})
+		purged += mb.msgs
+		bytes += mb.bytes
+		next = atomic.LoadUint64(&mb.last.seq) + 1
+		finish()
+		mb.mu.Unlock()
+	}
+	if len(blocks) == 0 {
+		return 0, 0, 0, nil
+	}
+	if err := fs.validateExpirePrefixSubjectsLocked(totals); err != nil {
+		return 0, 0, 0, err
+	}
+
+	committed := 0
+	for ; committed < len(blocks); committed++ {
+		mb := blocks[committed].mb
+		mb.mu.Lock()
+		err := mb.removeForExpirePrefixLocked()
+		mb.mu.Unlock()
+		if err != nil {
+			rerr = err
+			break
+		}
+	}
+	if committed == 0 {
+		return 0, 0, 0, rerr
+	}
+	blocks = blocks[:committed]
+
+	purged, bytes = 0, 0
+	for _, block := range blocks {
+		purged += block.msgs
+		bytes += block.bytes
+	}
+	fs.removeExpirePrefixSubjectsLocked(blocks)
+	for _, block := range blocks {
+		delete(fs.bim, block.mb.index)
+	}
+	fs.blks = copyMsgBlocks(fs.blks[committed:])
+	fs.state.Msgs -= purged
+	fs.state.Bytes -= bytes
+	// Keep a safe floor if leading empty-block cleanup fails. Successful cleanup
+	// below replaces it with the first live sequence and timestamp.
+	lastRemoved := blocks[len(blocks)-1].mb
+	fs.state.FirstSeq = atomic.LoadUint64(&lastRemoved.last.seq) + 1
+	fs.state.FirstTime = time.Time{}
+	fs.firstMoved = true
+	if err := fs.selectNextFirst(); err != nil {
+		rerr = errors.Join(rerr, err)
+	}
+	newFirst = fs.state.FirstSeq
+	fs.dirty++
+
+	return purged, bytes, newFirst, rerr
 }
 
 // RemoveMsg will remove the message from this store.
@@ -6961,8 +7289,6 @@ func (fs *fileStore) cancelAgeChk() {
 
 // Will expire msgs that are too old.
 func (fs *fileStore) expireMsgs() {
-	// We need to delete one by one here and can not optimize for the time being.
-	// Reason is that we need more information to adjust ack pending in consumers.
 	var smv StoreMsg
 	var sm *StoreMsg
 
@@ -6981,11 +7307,31 @@ func (fs *fileStore) expireMsgs() {
 		return
 	}
 	fs.ageChkRun = true
+
+	var first uint64
+	if maxAge > 0 && !sdmEnabled {
+		first = fs.state.FirstSeq
+	}
 	fs.mu.Unlock()
 
-	if maxAge > 0 {
-		var seq uint64
-		for sm, seq, _ = fs.LoadNextMsg(fwcs, true, 0, &smv); sm != nil && sm.ts <= minAge; sm, seq, _ = fs.LoadNextMsg(fwcs, true, seq+1, &smv) {
+	var seq uint64
+	var prefixErr error
+	if first > 0 {
+		// expirePrefixViaLimits validates each block itself. Calling it directly
+		// also lets recovered pre-v5 blocks load and learn timestamp ordering.
+		_, prefixErr = fs.expirePrefixViaLimits(first, minAge)
+		if prefixErr == nil {
+			fs.mu.RLock()
+			seq = fs.state.FirstSeq
+			fs.mu.RUnlock()
+		}
+	}
+
+	// A failed range validation has not removed anything. Leave its prefix for a
+	// bounded retry instead of turning the same timer run into partial
+	// per-message work.
+	if maxAge > 0 && prefixErr == nil {
+		for sm, seq, _ = fs.LoadNextMsg(fwcs, true, seq, &smv); sm != nil && sm.ts <= minAge; sm, seq, _ = fs.LoadNextMsg(fwcs, true, seq+1, &smv) {
 			if len(sm.hdr) > 0 {
 				if ttl, err := getMessageTTL(sm.hdr); err == nil && ttl < 0 {
 					// The message has a negative TTL, therefore it must "never expire".
@@ -7564,6 +7910,9 @@ func (mb *msgBlock) updateAccounting(seq uint64, ts int64, rl uint64) {
 	isDeleted := seq&ebit != 0
 	if isDeleted {
 		seq = seq &^ ebit
+	}
+	if mb.msgs > 0 && ts < mb.last.ts {
+		mb.tsOrdered = false
 	}
 
 	fseq := atomic.LoadUint64(&mb.first.seq)
@@ -8178,6 +8527,9 @@ func (mb *msgBlock) indexCacheBuf(buf []byte) error {
 
 	lbuf := uint32(len(buf))
 	var seq, ttls, schedules uint64
+	var lastTs int64
+	var haveTs bool
+	tsOrdered := true
 	var sm StoreMsg // Used for finding headers
 
 	// To ensure the sequence keeps moving up. As well as confirming our index
@@ -8218,6 +8570,7 @@ func (mb *msgBlock) indexCacheBuf(buf []byte) error {
 		// Clear any erase bits.
 		erased := seq&ebit != 0
 		seq = seq &^ ebit
+		ts := int64(le.Uint64(hdr[12:]))
 
 		// The sequence needs to only ever move up.
 		if seq <= last {
@@ -8229,6 +8582,10 @@ func (mb *msgBlock) indexCacheBuf(buf []byte) error {
 		// We defer checksum checks to individual msg cache lookups to amortorize costs and
 		// not introduce latency for first message from a newly loaded block.
 		if seq >= mbFirstSeq {
+			if haveTs && ts < lastTs {
+				tsOrdered = false
+			}
+			lastTs, haveTs = ts, true
 			last = seq
 
 			// If the first sequence doesn't align with what we had in-memory, we need to rebuild.
@@ -8302,6 +8659,8 @@ func (mb *msgBlock) indexCacheBuf(buf []byte) error {
 	mb.cache.wp = int(lbuf)
 	mb.ttls = ttls
 	mb.schedules = schedules
+	mb.tsKnown = true
+	mb.tsOrdered = tsOrdered
 	mb.cache.registerRecycle()
 
 	return nil
@@ -11757,10 +12116,13 @@ func (fs *fileStore) cancelSyncTimer() {
 // The full state file is versioned.
 // - 0x1: original binary index.db format
 // - 0x2: adds support for TTL count field after num deleted
+// - 0x3: adds support for schedule count field after TTL count
+// - 0x4: adds last block to per-subject state
+// - 0x5: adds per-block timestamp ordering metadata
 const (
 	fullStateMagic      = uint8(11)
 	fullStateMinVersion = uint8(1) // What is the minimum version we know how to parse?
-	fullStateVersion    = uint8(4) // What is the current version written out to index.db?
+	fullStateVersion    = uint8(5) // What is the current version written out to index.db?
 )
 
 // This go routine periodically writes out our full stream state index.
@@ -11891,7 +12253,7 @@ func (fs *fileStore) _writeFullState(force bool) error {
 		binary.MaxVarintLen64 + fs.tsl + // NumSubjects + total subject length
 		numSubjects*(binary.MaxVarintLen64*4) + // psi record
 		binary.MaxVarintLen64 + // Num blocks.
-		len(fs.blks)*((binary.MaxVarintLen64*8)+avgDmapLen) + // msg blocks, avgDmapLen is est for dmaps
+		len(fs.blks)*((binary.MaxVarintLen64*10)+avgDmapLen) + // msg blocks, avgDmapLen is est for dmaps
 		binary.MaxVarintLen64 + 8 + 8 // last index + record checksum + full state checksum
 
 	// Do 4k on stack if possible.
@@ -11953,6 +12315,11 @@ func (fs *fileStore) _writeFullState(force bool) error {
 		buf = binary.AppendUvarint(buf, uint64(numDeleted))
 		buf = binary.AppendUvarint(buf, mb.ttls)      // Field is new in version 2
 		buf = binary.AppendUvarint(buf, mb.schedules) // Field is new in version 3
+		if mb.tsOrdered {
+			buf = binary.AppendUvarint(buf, 1) // Field is new in version 5
+		} else {
+			buf = binary.AppendUvarint(buf, 0)
+		}
 		if numDeleted > 0 {
 			dmap := mb.dmap.Encode(scratch[:0])
 			dmapTotalLen += len(dmap)

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -36,6 +36,7 @@ import (
 	"reflect"
 	"runtime"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -46,6 +47,7 @@ import (
 	"unsafe"
 
 	"github.com/klauspost/compress/s2"
+	"github.com/minio/highwayhash"
 	"github.com/nats-io/nats-server/v2/server/ats"
 	"github.com/nats-io/nats-server/v2/server/avl"
 	"github.com/nats-io/nats-server/v2/server/gsl"
@@ -15383,4 +15385,350 @@ func Benchmark_FileStoreDeleteMapExists(b *testing.B) {
 		v.Exists(uint64(i%numMsgs) + 1)
 	}
 	b.StopTimer()
+}
+
+const (
+	expiryPrefixFullStateV4 = uint8(4)
+	expiryPrefixFullStateV5 = uint8(5)
+)
+
+// rewriteExpiryPrefixFullStateV4 converts an immediately written v5 state into
+// the exact v4 payload written by the predecessor. Version 5 only added a
+// canonical tsOrdered uvarint after each block's schedules field.
+func rewriteExpiryPrefixFullStateV4(tb testing.TB, storeDir, stream string) {
+	tb.Helper()
+	fn := filepath.Join(storeDir, msgDir, streamStreamStateFile)
+	state, err := os.ReadFile(fn)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if len(state) < hdrLen+highwayhash.Size64 {
+		tb.Fatalf("stream state is too short: %d", len(state))
+	}
+
+	payload, checksum := state[:len(state)-highwayhash.Size64], state[len(state)-highwayhash.Size64:]
+	if payload[0] != fullStateMagic {
+		tb.Fatalf("unexpected stream state magic: %d", payload[0])
+	}
+	if payload[1] == expiryPrefixFullStateV4 {
+		return
+	}
+	if payload[1] != expiryPrefixFullStateV5 {
+		tb.Fatalf("unexpected stream state version: %d", payload[1])
+	}
+
+	key := sha256.Sum256([]byte(stream))
+	hh, err := highwayhash.NewDigest64(key[:])
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if _, err := hh.Write(payload); err != nil {
+		tb.Fatal(err)
+	}
+	if expected := hh.Sum(nil); !bytes.Equal(checksum, expected) {
+		tb.Fatal("stream state checksum does not match")
+	}
+
+	v4, err := expiryPrefixFullStateV5AsV4(payload)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	hh.Reset()
+	if _, err := hh.Write(v4); err != nil {
+		tb.Fatal(err)
+	}
+	v4 = append(v4, hh.Sum(nil)...)
+	if err := os.WriteFile(fn, v4, defaultFilePerms); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+func expiryPrefixFullStateV5AsV4(v5 []byte) ([]byte, error) {
+	if len(v5) < hdrLen || v5[0] != fullStateMagic || v5[1] != expiryPrefixFullStateV5 {
+		return nil, fmt.Errorf("unexpected v5 stream state")
+	}
+
+	v4 := append([]byte(nil), v5[:hdrLen]...)
+	v4[1] = expiryPrefixFullStateV4
+	off := hdrLen
+	copyUvarint := func() (uint64, error) {
+		value, n := binary.Uvarint(v5[off:])
+		if n <= 0 {
+			return 0, fmt.Errorf("invalid stream state uvarint at %d", off)
+		}
+		v4 = append(v4, v5[off:off+n]...)
+		off += n
+		return value, nil
+	}
+	copyVarint := func() error {
+		_, n := binary.Varint(v5[off:])
+		if n <= 0 {
+			return fmt.Errorf("invalid stream state varint at %d", off)
+		}
+		v4 = append(v4, v5[off:off+n]...)
+		off += n
+		return nil
+	}
+
+	for range 3 {
+		if _, err := copyUvarint(); err != nil {
+			return nil, err
+		}
+	}
+	if err := copyVarint(); err != nil {
+		return nil, err
+	}
+	if _, err := copyUvarint(); err != nil {
+		return nil, err
+	}
+	if err := copyVarint(); err != nil {
+		return nil, err
+	}
+
+	nsubjects, err := copyUvarint()
+	if err != nil {
+		return nil, err
+	}
+	for range nsubjects {
+		length, err := copyUvarint()
+		if err != nil {
+			return nil, err
+		}
+		if length > uint64(len(v5)-off) {
+			return nil, fmt.Errorf("invalid stream state subject length at %d", off)
+		}
+		v4 = append(v4, v5[off:off+int(length)]...)
+		off += int(length)
+		for range 3 {
+			if _, err := copyUvarint(); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	nblocks, err := copyUvarint()
+	if err != nil {
+		return nil, err
+	}
+	for range nblocks {
+		for range 3 {
+			if _, err := copyUvarint(); err != nil {
+				return nil, err
+			}
+		}
+		if err := copyVarint(); err != nil {
+			return nil, err
+		}
+		if _, err := copyUvarint(); err != nil {
+			return nil, err
+		}
+		if err := copyVarint(); err != nil {
+			return nil, err
+		}
+		numDeleted, err := copyUvarint()
+		if err != nil {
+			return nil, err
+		}
+		for range 2 {
+			if _, err := copyUvarint(); err != nil {
+				return nil, err
+			}
+		}
+
+		// Drop tsOrdered, which is the only field added in version 5.
+		if _, n := binary.Uvarint(v5[off:]); n <= 0 {
+			return nil, fmt.Errorf("invalid stream state tsOrdered at %d", off)
+		} else {
+			off += n
+		}
+		if numDeleted > 0 {
+			_, n, err := avl.Decode(v5[off:])
+			if err != nil {
+				return nil, err
+			}
+			v4 = append(v4, v5[off:off+n]...)
+			off += n
+		}
+	}
+	if _, err := copyUvarint(); err != nil {
+		return nil, err
+	}
+	if len(v5)-off != 8 {
+		return nil, fmt.Errorf("invalid stream state checksum length: %d", len(v5)-off)
+	}
+	return append(v4, v5[off:]...), nil
+}
+
+const expireMsgsBenchMessages = 16_384
+
+func storeExpireMsgsBenchFixture(tb testing.TB, fs *fileStore) {
+	tb.Helper()
+	expired := time.Now().Add(-time.Hour).UnixNano()
+	msg := bytes.Repeat([]byte("x"), 128)
+	for seq := uint64(1); seq <= expireMsgsBenchMessages; seq++ {
+		if err := fs.StoreRawMsg("foo", nil, msg, seq, expired, 0, false); err != nil {
+			tb.Fatalf("error storing message %d: %v", seq, err)
+		}
+	}
+	if err := fs.StoreRawMsg("foo", nil, msg, expireMsgsBenchMessages+1, time.Now().UnixNano(), 0, false); err != nil {
+		tb.Fatalf("error storing surviving message: %v", err)
+	}
+}
+
+func setExpireMsgsBenchMaxAge(fs *fileStore) {
+	setExpireMsgsBenchMaxAgeFor(fs, time.Second)
+}
+
+func setExpireMsgsBenchMaxAgeFor(fs *fileStore, maxAge time.Duration) {
+	fs.mu.Lock()
+	fs.cfg.MaxAge = maxAge
+	fs.mu.Unlock()
+}
+
+func BenchmarkFileStoreExpireMsgsColdBlocks(b *testing.B) {
+	dir := b.TempDir()
+	i := 0
+	for b.Loop() {
+		b.StopTimer()
+		fcfg := FileStoreConfig{StoreDir: filepath.Join(dir, fmt.Sprintf("%d", i)), BlockSize: 64 * 1024}
+		cfg := StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Storage: FileStorage}
+		fs, err := newFileStore(fcfg, cfg)
+		if err != nil {
+			b.Fatal(err)
+		}
+		storeExpireMsgsBenchFixture(b, fs)
+		if err := fs.stop(false, true); err != nil {
+			b.Fatal(err)
+		}
+		rewriteExpiryPrefixFullStateV4(b, fcfg.StoreDir, cfg.Name)
+
+		fs, err = newFileStore(fcfg, cfg)
+		if err != nil {
+			b.Fatal(err)
+		}
+		setExpireMsgsBenchMaxAge(fs)
+
+		b.StartTimer()
+		fs.expireMsgs()
+		b.StopTimer()
+		if state := fs.State(); state.Msgs != 1 || state.FirstSeq != expireMsgsBenchMessages+1 {
+			b.Fatalf("unexpected state after expiry: %+v", state)
+		}
+		if err := fs.stop(false, true); err != nil {
+			b.Fatal(err)
+		}
+		i++
+		b.StartTimer()
+	}
+}
+
+func newExpireMsgsEndToEndFixture(tb testing.TB, pending int) (*Server, *stream, *fileStore, *consumer) {
+	tb.Helper()
+	s := RunBasicJetStreamServer(tb)
+	mset, err := s.GlobalAccount().addStreamWithStore(&StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Storage:  FileStorage,
+	}, &FileStoreConfig{BlockSize: 64 * 1024})
+	if err != nil {
+		s.Shutdown()
+		tb.Fatal(err)
+	}
+	fs, ok := mset.store.(*fileStore)
+	if !ok {
+		mset.stop(true, true)
+		s.Shutdown()
+		tb.Fatal("expected a file store")
+	}
+	storeExpireMsgsBenchFixture(tb, fs)
+	o, err := mset.addConsumer(&ConsumerConfig{
+		Durable:       "C",
+		DeliverPolicy: DeliverNew,
+		AckPolicy:     AckExplicit,
+	})
+	if err != nil {
+		mset.stop(true, true)
+		s.Shutdown()
+		tb.Fatal(err)
+	}
+
+	o.mu.Lock()
+	o.pending = make(map[uint64]*Pending)
+	o.rdc = make(map[uint64]uint64)
+	for i := 1; i <= pending; i++ {
+		seq := uint64(i * expireMsgsBenchMessages / pending)
+		o.pending[seq] = &Pending{Sequence: seq, Timestamp: time.Now().UnixNano()}
+		o.rdc[seq] = 1
+	}
+	o.dseq = expireMsgsBenchMessages + 2
+	o.sseq = expireMsgsBenchMessages + 2
+	state := ConsumerState{
+		Delivered:   SequencePair{Consumer: o.dseq - 1, Stream: o.sseq - 1},
+		Pending:     o.pending,
+		Redelivered: o.rdc,
+	}
+	o.mu.Unlock()
+	cfs, ok := o.store.(*consumerFileStore)
+	if !ok {
+		mset.stop(true, true)
+		s.Shutdown()
+		tb.Fatal("expected a file consumer store")
+	}
+	if err := cfs.ForceUpdate(&state); err != nil {
+		mset.stop(true, true)
+		s.Shutdown()
+		tb.Fatal(err)
+	}
+	setExpireMsgsBenchMaxAge(fs)
+	return s, mset, fs, o
+}
+
+func waitForExpireMsgsBenchConsumer(tb testing.TB, fs *fileStore, o *consumer) {
+	tb.Helper()
+	expires := time.Now().Add(10 * time.Second)
+	for time.Now().Before(expires) {
+		o.mu.RLock()
+		np := len(o.pending)
+		o.mu.RUnlock()
+		state := fs.State()
+		if np == 0 && state.Msgs == 1 && state.FirstSeq == expireMsgsBenchMessages+1 {
+			cs, err := o.store.BorrowState()
+			if err == nil && (cs == nil || len(cs.Pending) == 0) {
+				return
+			}
+		}
+		time.Sleep(time.Millisecond)
+	}
+	tb.Fatal("timed out waiting for MaxAge expiry")
+}
+
+func benchmarkFileStoreExpireMsgsEndToEnd(b *testing.B, pending int) {
+	var results []time.Duration
+	for b.Loop() {
+		b.StopTimer()
+		s, mset, fs, o := newExpireMsgsEndToEndFixture(b, pending)
+		b.StartTimer()
+		start := time.Now()
+		fs.expireMsgs()
+		waitForExpireMsgsBenchConsumer(b, fs, o)
+		results = append(results, time.Since(start))
+		b.StopTimer()
+		mset.stop(true, true)
+		s.Shutdown()
+		b.StartTimer()
+	}
+	sort.Slice(results, func(i, j int) bool { return results[i] < results[j] })
+	if len(results) > 0 {
+		p95 := results[(len(results)*95+99)/100-1]
+		b.ReportMetric(float64(p95), "p95-ns/op")
+	}
+}
+
+func BenchmarkFileStoreExpireMsgsEndToEnd(b *testing.B) {
+	b.Run("sparse-pending", func(b *testing.B) {
+		benchmarkFileStoreExpireMsgsEndToEnd(b, 128)
+	})
+	b.Run("dense-pending", func(b *testing.B) {
+		benchmarkFileStoreExpireMsgsEndToEnd(b, 4096)
+	})
 }

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -15559,6 +15559,775 @@ func expiryPrefixFullStateV5AsV4(v5 []byte) ([]byte, error) {
 	return append(v4, v5[off:]...), nil
 }
 
+const expiryPrefixTestMsgs = 12
+
+type expiryPrefixUpdate struct {
+	msgs, bytes int64
+	seq         uint64
+	subj        string
+}
+
+func newExpiryPrefixTestStore(t *testing.T, dir string, maxAge time.Duration) *fileStore {
+	return newExpiryPrefixTestStoreWithBlockSize(t, dir, maxAge, 256)
+}
+
+func newExpiryPrefixTestStoreWithBlockSize(t *testing.T, dir string, maxAge time.Duration, blockSize uint64) *fileStore {
+	t.Helper()
+	fs, err := newFileStore(FileStoreConfig{StoreDir: dir, BlockSize: blockSize}, StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo.*"},
+		MaxAge:   maxAge,
+		Storage:  FileStorage,
+	})
+	if err != nil {
+		t.Fatalf("error creating file store: %v", err)
+	}
+	return fs
+}
+
+func storeExpiryPrefixMsgs(t *testing.T, fs *fileStore, n uint64, timestamp func(uint64) int64, header func(uint64) []byte) {
+	t.Helper()
+	msg := bytes.Repeat([]byte("x"), 160)
+	for seq := uint64(1); seq <= n; seq++ {
+		var hdr []byte
+		if header != nil {
+			hdr = header(seq)
+		}
+		if err := fs.StoreRawMsg(fmt.Sprintf("foo.%d", seq&1), hdr, msg, seq, timestamp(seq), 0, false); err != nil {
+			t.Fatalf("error storing message %d: %v", seq, err)
+		}
+	}
+}
+
+func testExpiryPrefixBlockCount(t *testing.T, fs *fileStore, min int) {
+	t.Helper()
+	fs.mu.RLock()
+	nblks := len(fs.blks)
+	fs.mu.RUnlock()
+	if nblks < min {
+		t.Fatalf("expected at least %d message blocks, got %d", min, nblks)
+	}
+}
+
+func expiryPrefixTestStore(t *testing.T) (*fileStore, int64, uint64) {
+	t.Helper()
+	fs := newExpiryPrefixTestStore(t, t.TempDir(), 0)
+	now := time.Now().UnixNano()
+	expired := now - int64(time.Hour)
+	storeExpiryPrefixMsgs(t, fs, expiryPrefixTestMsgs, func(uint64) int64 { return expired }, nil)
+	if err := fs.StoreRawMsg("foo.0", nil, bytes.Repeat([]byte("s"), 160), expiryPrefixTestMsgs+1, now, 0, false); err != nil {
+		t.Fatalf("error storing surviving message: %v", err)
+	}
+	testExpiryPrefixBlockCount(t, fs, 3)
+	return fs, now, expiryPrefixTestMsgs + 1
+}
+
+func TestFileStoreExpirePrefixUpdatesResidentStateAndHandler(t *testing.T) {
+	fs, cutoff, survivor := expiryPrefixTestStore(t)
+	defer fs.Stop()
+
+	var updates []expiryPrefixUpdate
+	fs.RegisterStorageUpdates(func(msgs, bytes int64, seq uint64, subj string) {
+		updates = append(updates, expiryPrefixUpdate{msgs, bytes, seq, subj})
+	})
+	updates = nil
+
+	var first, msgs, bytes uint64
+	fs.registerStorageExpirePrefix(func(floor, removed, removedBytes uint64) {
+		first, msgs, bytes = floor, removed, removedBytes
+	})
+
+	state := fs.State()
+	purged, err := fs.expirePrefixViaLimits(state.FirstSeq, cutoff-time.Minute.Nanoseconds())
+	require_NoError(t, err)
+	require_Equal(t, purged, uint64(expiryPrefixTestMsgs))
+	require_Equal(t, first, survivor)
+	require_Equal(t, msgs, uint64(expiryPrefixTestMsgs))
+	require_True(t, bytes > 0)
+	require_Equal(t, len(updates), 0)
+
+	state = fs.State()
+	if state.Msgs != 1 || state.FirstSeq != survivor || state.LastSeq != survivor {
+		t.Fatalf("unexpected state after prefix expiry: %+v", state)
+	}
+	if _, err := fs.LoadMsg(survivor, nil); err != nil {
+		t.Fatalf("could not load surviving message: %v", err)
+	}
+	ss, err := fs.FilteredState(0, "foo.0")
+	if err != nil {
+		t.Fatalf("error loading subject state: %v", err)
+	}
+	if ss.Msgs != 1 || ss.First != survivor || ss.Last != survivor {
+		t.Fatalf("unexpected surviving subject state: %+v", ss)
+	}
+	ss, err = fs.FilteredState(0, "foo.1")
+	if err != nil {
+		t.Fatalf("error loading removed subject state: %v", err)
+	}
+	if ss.Msgs != 0 {
+		t.Fatalf("expected removed subject state to be empty, got %+v", ss)
+	}
+}
+
+func TestFileStoreExpirePrefixRemovesDeletedRecords(t *testing.T) {
+	fs, _, survivor := expiryPrefixTestStore(t)
+	defer fs.Stop()
+
+	removed, err := fs.EraseMsg(2)
+	require_NoError(t, err)
+	require_True(t, removed)
+	var updates []expiryPrefixUpdate
+	fs.RegisterStorageUpdates(func(msgs, bytes int64, seq uint64, subj string) {
+		updates = append(updates, expiryPrefixUpdate{msgs, bytes, seq, subj})
+	})
+	updates = nil
+	fs.mu.Lock()
+	fs.cfg.MaxAge = time.Second
+	fs.mu.Unlock()
+	fs.expireMsgs()
+
+	state := fs.State()
+	require_Equal(t, state.Msgs, uint64(1))
+	require_Equal(t, state.FirstSeq, survivor)
+	require_Equal(t, state.LastSeq, survivor)
+	require_Equal(t, state.NumDeleted, 0)
+	require_Equal(t, len(updates), 1)
+	require_Equal(t, updates[0].msgs, int64(1-expiryPrefixTestMsgs))
+	require_Equal(t, updates[0].seq, uint64(0))
+	totals := fs.SubjectsTotals(fwcs)
+	require_Equal(t, totals["foo.0"], uint64(1))
+	require_Equal(t, totals["foo.1"], uint64(0))
+}
+
+func TestFileStoreExpirePrefixSkipsLeadingEmptyBlocks(t *testing.T) {
+	fs := newExpiryPrefixTestStore(t, t.TempDir(), 0)
+	defer fs.Stop()
+
+	now := time.Now().UnixNano()
+	expired := now - int64(time.Hour)
+	require_NoError(t, fs.StoreRawMsg("foo.0", nil, nil, 1, expired, 0, false))
+	require_NoError(t, fs.StoreRawMsg("foo.0", nil, nil, 2, expired, 0, false))
+	fs.mu.Lock()
+	_, err := fs.newMsgBlockForWrite()
+	fs.mu.Unlock()
+	require_NoError(t, err)
+	removed, err := fs.RemoveMsg(2)
+	require_NoError(t, err)
+	require_True(t, removed)
+	fs.mu.Lock()
+	_, err = fs.newMsgBlockForWrite()
+	fs.mu.Unlock()
+	require_NoError(t, err)
+	require_NoError(t, fs.SkipMsgs(3, 7))
+	fs.mu.Lock()
+	_, err = fs.newMsgBlockForWrite()
+	fs.mu.Unlock()
+	require_NoError(t, err)
+	require_NoError(t, fs.StoreRawMsg("foo.0", nil, nil, 10, now, 0, false))
+
+	fs.mu.RLock()
+	require_Len(t, len(fs.blks), 4)
+	for _, empty := range fs.blks[1:3] {
+		empty.mu.RLock()
+		require_Equal(t, empty.msgs, uint64(0))
+		empty.mu.RUnlock()
+	}
+	first := fs.state.FirstSeq
+	fs.mu.RUnlock()
+
+	var floor uint64
+	fs.registerStorageExpirePrefix(func(first, _, _ uint64) {
+		floor = first
+	})
+	purged, err := fs.expirePrefixViaLimits(first, now-time.Minute.Nanoseconds())
+	require_NoError(t, err)
+	require_Equal(t, purged, uint64(1))
+	require_Equal(t, floor, uint64(10))
+	require_Equal(t, fs.State().FirstSeq, uint64(10))
+	fs.mu.RLock()
+	require_Len(t, len(fs.blks), 1)
+	fs.mu.RUnlock()
+}
+
+func expiryPrefixDiskContents(t *testing.T, fs *fileStore) map[string][]byte {
+	t.Helper()
+	contents := make(map[string][]byte)
+	root := fs.fcfg.StoreDir
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		contents[rel] = data
+		return nil
+	})
+	require_NoError(t, err)
+	return contents
+}
+
+func TestFileStoreExpirePrefixRetriesAfterLaterBlockReadFailure(t *testing.T) {
+	fs, _, survivor := expiryPrefixTestStore(t)
+	defer fs.Stop()
+
+	var updates []expiryPrefixUpdate
+	fs.RegisterStorageUpdates(func(msgs, bytes int64, seq uint64, subj string) {
+		updates = append(updates, expiryPrefixUpdate{msgs, bytes, seq, subj})
+	})
+	updates = nil
+	require_NoError(t, fs.FlushAllPending())
+	before := fs.State()
+	beforeSubjects := fs.SubjectsTotals(fwcs)
+	fs.mu.RLock()
+	beforeBlocks, beforeBlockIndex := len(fs.blks), len(fs.bim)
+	fs.mu.RUnlock()
+	beforeFiles := expiryPrefixDiskContents(t, fs)
+
+	// Force generation of the second eligible block's subject state to read from
+	// a write-only descriptor. The first block has already passed preflight when
+	// this fails, so the test catches any mutation before all inputs validate.
+	var setupErr error
+	fs.mu.Lock()
+	fs.cfg.MaxAge = 30 * time.Minute
+	later := fs.blks[1]
+	later.mu.Lock()
+	if later.mfd != nil {
+		setupErr = later.mfd.Close()
+		later.mfd = nil
+	}
+	if setupErr == nil {
+		later.clearCacheAndOffset()
+		later.fss = nil
+		later.mfd, setupErr = os.OpenFile(later.mfn, os.O_WRONLY, defaultFilePerms)
+	}
+	later.mu.Unlock()
+	fs.mu.Unlock()
+	require_NoError(t, setupErr)
+
+	fs.expireMsgs()
+
+	after := fs.State()
+	require_Equal(t, after.Msgs, before.Msgs)
+	require_Equal(t, after.Bytes, before.Bytes)
+	require_Equal(t, after.FirstSeq, before.FirstSeq)
+	require_Equal(t, after.LastSeq, before.LastSeq)
+	fs.mu.RLock()
+	afterBlocks, afterBlockIndex := len(fs.blks), len(fs.bim)
+	fs.mu.RUnlock()
+	require_Equal(t, afterBlocks, beforeBlocks)
+	require_Equal(t, afterBlockIndex, beforeBlockIndex)
+	afterSubjects := fs.SubjectsTotals(fwcs)
+	require_Equal(t, len(afterSubjects), len(beforeSubjects))
+	for subject, total := range beforeSubjects {
+		require_Equal(t, afterSubjects[subject], total)
+	}
+	require_Equal(t, len(updates), 0)
+	require_True(t, fs.werr == nil)
+	afterFiles := expiryPrefixDiskContents(t, fs)
+	require_Equal(t, len(afterFiles), len(beforeFiles))
+	for file, contents := range beforeFiles {
+		if !bytes.Equal(afterFiles[file], contents) {
+			t.Fatalf("message block %q changed after failed prefix preflight", file)
+		}
+	}
+
+	fs.mu.Lock()
+	retryScheduled := fs.ageChk != nil && fs.ageChkTime > 0 && fs.ageChkTime <= time.Now().Add(3*time.Second).UnixNano()
+	running := fs.ageChkRun
+	fs.cancelAgeChk()
+	fs.mu.Unlock()
+	require_False(t, running)
+	require_True(t, retryScheduled)
+
+	fs.mu.Lock()
+	later.mu.Lock()
+	var restoreErr error
+	if later.mfd != nil {
+		restoreErr = later.mfd.Close()
+		later.mfd = nil
+	}
+	later.mu.Unlock()
+	fs.mu.Unlock()
+	require_NoError(t, restoreErr)
+
+	fs.expireMsgs()
+	state := fs.State()
+	require_Equal(t, state.Msgs, uint64(1))
+	require_Equal(t, state.FirstSeq, survivor)
+	require_Equal(t, len(updates), 1)
+	require_Equal(t, updates[0].msgs, int64(-expiryPrefixTestMsgs))
+	require_Equal(t, updates[0].seq, uint64(0))
+	require_Equal(t, updates[0].subj, _EMPTY_)
+	require_True(t, fs.werr == nil)
+
+	// A rejected preflight must not leave the store unable to accept normal
+	// writes after the retry succeeds.
+	require_NoError(t, fs.StoreRawMsg("foo.1", nil, []byte("normal"), survivor+1, time.Now().UnixNano(), 0, false))
+	state = fs.State()
+	require_Equal(t, state.Msgs, uint64(2))
+	require_Equal(t, state.FirstSeq, survivor)
+	require_Equal(t, state.LastSeq, survivor+1)
+}
+
+func TestFileStoreExpirePrefixRecoversWithPriorFullState(t *testing.T) {
+	fs, cutoff, survivor := expiryPrefixTestStore(t)
+	require_NoError(t, fs.forceWriteFullState())
+	stateFile := filepath.Join(fs.fcfg.StoreDir, msgDir, streamStreamStateFile)
+	prior, err := os.ReadFile(stateFile)
+	require_NoError(t, err)
+
+	state := fs.State()
+	purged, err := fs.expirePrefixViaLimits(state.FirstSeq, cutoff-time.Minute.Nanoseconds())
+	require_NoError(t, err)
+	require_Equal(t, purged, uint64(expiryPrefixTestMsgs))
+	require_NoError(t, fs.Stop())
+	// Restore the state file from before the via-limits block removals to model
+	// a crash before the normal asynchronous full-state write.
+	require_NoError(t, os.WriteFile(stateFile, prior, defaultFilePerms))
+
+	fs = newExpiryPrefixTestStore(t, filepath.Dir(filepath.Dir(stateFile)), 0)
+	defer fs.Stop()
+	state = fs.State()
+	require_Equal(t, state.Msgs, uint64(1))
+	require_Equal(t, state.FirstSeq, survivor)
+	require_Equal(t, state.LastSeq, survivor)
+	_, err = fs.LoadMsg(survivor, nil)
+	require_NoError(t, err)
+}
+
+func TestFileStoreExpireMsgsUsesPrefixAfterV4Recovery(t *testing.T) {
+	dir := t.TempDir()
+	fs := newExpiryPrefixTestStore(t, dir, 0)
+	now := time.Now().UnixNano()
+	storeExpiryPrefixMsgs(t, fs, expiryPrefixTestMsgs, func(uint64) int64 {
+		return now - int64(time.Hour)
+	}, nil)
+	survivor := uint64(expiryPrefixTestMsgs + 1)
+	require_NoError(t, fs.StoreRawMsg("foo.0", nil, bytes.Repeat([]byte("s"), 160), survivor, now+int64(time.Hour), 0, false))
+	testExpiryPrefixBlockCount(t, fs, 3)
+	require_NoError(t, fs.forceWriteFullState())
+	require_NoError(t, fs.Stop())
+
+	rewriteExpiryPrefixFullStateV4(t, dir, "TEST")
+	stateFile := filepath.Join(dir, msgDir, streamStreamStateFile)
+	state, err := os.ReadFile(stateFile)
+	require_NoError(t, err)
+	if len(state) < hdrLen+8 || state[0] != fullStateMagic || state[1] != expiryPrefixFullStateV4 {
+		t.Fatalf("expected predecessor-format v4 state, got %v", state[:min(len(state), hdrLen)])
+	}
+
+	fs = newExpiryPrefixTestStore(t, dir, 0)
+	defer fs.Stop()
+	fs.mu.RLock()
+	mb := fs.blks[0]
+	mb.mu.RLock()
+	known, ordered := mb.tsKnown, mb.tsOrdered
+	mb.mu.RUnlock()
+	fs.mu.RUnlock()
+	require_True(t, known)
+	require_False(t, ordered)
+
+	var updates int
+	fs.RegisterStorageUpdates(func(msgs, bytes int64, seq uint64, subj string) {
+		if msgs < 0 {
+			updates++
+		}
+	})
+	var first, msgs, bytes uint64
+	var ranges int
+	fs.registerStorageExpirePrefix(func(floor, removed, removedBytes uint64) {
+		first, msgs, bytes = floor, removed, removedBytes
+		ranges++
+	})
+	fs.mu.Lock()
+	fs.cfg.MaxAge = time.Second
+	fs.mu.Unlock()
+	fs.expireMsgs()
+
+	require_Equal(t, ranges, 1)
+	require_Equal(t, first, survivor)
+	require_Equal(t, msgs, uint64(expiryPrefixTestMsgs))
+	require_True(t, bytes > 0)
+	require_Equal(t, updates, 0)
+	streamState := fs.State()
+	require_Equal(t, streamState.Msgs, uint64(1))
+	require_Equal(t, streamState.FirstSeq, survivor)
+	require_Equal(t, streamState.LastSeq, survivor)
+	_, err = fs.LoadMsg(survivor, nil)
+	require_NoError(t, err)
+	foo0, err := fs.FilteredState(0, "foo.0")
+	require_NoError(t, err)
+	require_Equal(t, foo0.Msgs, uint64(1))
+	foo1, err := fs.FilteredState(0, "foo.1")
+	require_NoError(t, err)
+	require_Equal(t, foo1.Msgs, uint64(0))
+}
+
+func TestFileStoreRecoverMaxAgeExpiresAllV4Blocks(t *testing.T) {
+	dir := t.TempDir()
+	fcfg := FileStoreConfig{StoreDir: dir, BlockSize: 64 * 1024}
+	cfg := StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Storage: FileStorage}
+	fs, err := newFileStore(fcfg, cfg)
+	require_NoError(t, err)
+	storeExpireMsgsBenchFixture(t, fs)
+	require_NoError(t, fs.forceWriteFullState())
+	require_NoError(t, fs.Stop())
+	rewriteExpiryPrefixFullStateV4(t, dir, cfg.Name)
+
+	cfg.MaxAge = time.Minute
+	fs, err = newFileStore(fcfg, cfg)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	state := fs.State()
+	require_Equal(t, state.Msgs, uint64(1))
+	require_Equal(t, state.FirstSeq, uint64(expireMsgsBenchMessages+1))
+	require_Equal(t, state.LastSeq, uint64(expireMsgsBenchMessages+1))
+	_, err = fs.LoadMsg(expireMsgsBenchMessages+1, nil)
+	require_NoError(t, err)
+}
+
+func TestFileStoreExpirePrefixKeepsFutureTimestamp(t *testing.T) {
+	fs := newExpiryPrefixTestStoreWithBlockSize(t, t.TempDir(), 0, 1024)
+	defer fs.Stop()
+
+	now := time.Now().UnixNano()
+	expired, future := now-int64(time.Hour), now+int64(time.Hour)
+	msg := bytes.Repeat([]byte("x"), 100)
+	for seq := uint64(1); seq <= 16; seq++ {
+		ts := expired
+		if seq == 2 {
+			ts = future
+		}
+		if err := fs.StoreRawMsg("foo.0", nil, msg, seq, ts, 0, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := fs.StoreRawMsg("foo.0", nil, msg, 17, now, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	testExpiryPrefixBlockCount(t, fs, 3)
+
+	var ranges int
+	fs.registerStorageExpirePrefix(func(uint64, uint64, uint64) {
+		ranges++
+	})
+	fs.mu.Lock()
+	fs.cfg.MaxAge = time.Second
+	fs.mu.Unlock()
+	fs.expireMsgs()
+	require_Equal(t, ranges, 0)
+	if _, err := fs.LoadMsg(2, nil); err != nil {
+		t.Fatalf("future-dated message was removed: %v", err)
+	}
+	if state := fs.State(); state.FirstSeq != 2 {
+		t.Fatalf("unexpected state after out-of-order expiry: %+v", state)
+	}
+}
+
+func TestFileStoreExpirePrefixKeepsNegativeTTL(t *testing.T) {
+	fs := newExpiryPrefixTestStoreWithBlockSize(t, t.TempDir(), 0, 1024)
+	defer fs.Stop()
+
+	now := time.Now().UnixNano()
+	expired := now - int64(time.Hour)
+	hdr := []byte("NATS/1.0\r\n" + JSMessageTTL + ": never\r\n\r\n")
+	msg := bytes.Repeat([]byte("x"), 100)
+	if err := fs.StoreRawMsg("foo.0", hdr, msg, 1, expired, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	for seq := uint64(2); seq <= 16; seq++ {
+		if err := fs.StoreRawMsg("foo.1", nil, msg, seq, expired, 0, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := fs.StoreRawMsg("foo.0", nil, msg, 17, now, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	testExpiryPrefixBlockCount(t, fs, 3)
+
+	var ranges int
+	fs.registerStorageExpirePrefix(func(uint64, uint64, uint64) {
+		ranges++
+	})
+	fs.mu.Lock()
+	fs.cfg.MaxAge = time.Second
+	fs.mu.Unlock()
+	fs.expireMsgs()
+	require_Equal(t, ranges, 0)
+
+	if _, err := fs.LoadMsg(1, nil); err != nil {
+		t.Fatalf("negative-TTL message was removed: %v", err)
+	}
+	if _, err := fs.LoadMsg(17, nil); err != nil {
+		t.Fatalf("surviving message was removed: %v", err)
+	}
+	if state := fs.State(); state.FirstSeq != 1 {
+		t.Fatalf("unexpected state after negative-TTL expiry: %+v", state)
+	}
+}
+
+func TestFileStoreExpirePrefixFallsBackForScheduledMessages(t *testing.T) {
+	fs := newExpiryPrefixTestStore(t, t.TempDir(), 0)
+	defer fs.Stop()
+
+	now := time.Now().UnixNano()
+	header := []byte("NATS/1.0\r\n" + JSSchedulePattern + ": @at 2099-01-01T00:00:00Z\r\n\r\n")
+	storeExpiryPrefixMsgs(t, fs, expiryPrefixTestMsgs, func(uint64) int64 { return now - int64(time.Hour) }, func(uint64) []byte {
+		return header
+	})
+	require_NoError(t, fs.StoreRawMsg("foo.0", nil, []byte("survivor"), expiryPrefixTestMsgs+1, now, 0, false))
+	testExpiryPrefixBlockCount(t, fs, 3)
+
+	var ranges int
+	fs.registerStorageExpirePrefix(func(uint64, uint64, uint64) {
+		ranges++
+	})
+	fs.mu.Lock()
+	fs.cfg.MaxAge = time.Second
+	fs.mu.Unlock()
+
+	fs.expireMsgs()
+	state := fs.State()
+	require_Equal(t, ranges, 0)
+	require_Equal(t, state.Msgs, uint64(1))
+	require_Equal(t, state.FirstSeq, uint64(expiryPrefixTestMsgs+1))
+}
+
+func TestFileStoreExpirePrefixDoesNotLoadSurvivingBlocks(t *testing.T) {
+	dir := t.TempDir()
+	fs, cutoff, survivor := expiryPrefixTestStore(t)
+	if err := fs.Stop(); err != nil {
+		t.Fatal(err)
+	}
+
+	fs = newExpiryPrefixTestStore(t, dir, 0)
+	expired := cutoff - int64(time.Hour)
+	storeExpiryPrefixMsgs(t, fs, expiryPrefixTestMsgs, func(uint64) int64 { return expired }, nil)
+	if err := fs.StoreRawMsg("foo.0", nil, bytes.Repeat([]byte("s"), 160), survivor, cutoff, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	fs = newExpiryPrefixTestStore(t, dir, 0)
+	defer fs.Stop()
+
+	fs.mu.RLock()
+	mb := fs.lmb
+	mb.mu.RLock()
+	cached := mb.cache
+	mb.mu.RUnlock()
+	first := fs.state.FirstSeq
+	fs.mu.RUnlock()
+	if cached != nil {
+		t.Fatal("expected surviving block cache to be cold")
+	}
+	purged, err := fs.expirePrefixViaLimits(first, cutoff-time.Minute.Nanoseconds())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if purged != expiryPrefixTestMsgs {
+		t.Fatalf("expected 12 messages to be purged, got %d", purged)
+	}
+
+	mb.mu.RLock()
+	cached = mb.cache
+	mb.mu.RUnlock()
+	if cached != nil {
+		t.Fatal("prefix expiry loaded the surviving block")
+	}
+}
+
+func TestFileStoreExpirePrefixRejectsInconsistentAccounting(t *testing.T) {
+	fs, cutoff, _ := expiryPrefixTestStore(t)
+	defer fs.Stop()
+
+	fs.mu.Lock()
+	first := fs.state.FirstSeq
+	fs.state.Bytes = 0
+	fs.mu.Unlock()
+	purged, err := fs.expirePrefixViaLimits(first, cutoff-time.Minute.Nanoseconds())
+	if err == nil {
+		t.Fatal("expected inconsistent accounting to reject prefix expiry")
+	}
+	if purged != 0 {
+		t.Fatalf("expected no messages to be reported as purged, got %d", purged)
+	}
+	state := fs.State()
+	if state.FirstSeq != first {
+		t.Fatalf("unexpected state after rejected prefix expiry: %+v", state)
+	}
+}
+
+func TestFileStoreRecoverMaxAgePreservesFutureTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	fs := newExpiryPrefixTestStoreWithBlockSize(t, dir, 0, 1024)
+	now := time.Now().UnixNano()
+	expired, future := now-int64(time.Hour), now+int64(time.Hour)
+	msg := bytes.Repeat([]byte("x"), 100)
+	for seq := uint64(1); seq <= 16; seq++ {
+		ts := expired
+		if seq == 2 {
+			ts = future
+		}
+		if err := fs.StoreRawMsg("foo.0", nil, msg, seq, ts, 0, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := fs.StoreRawMsg("foo.0", nil, msg, 17, now, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	fs = newExpiryPrefixTestStoreWithBlockSize(t, dir, time.Second, 1024)
+	defer fs.Stop()
+	if _, err := fs.LoadMsg(2, nil); err != nil {
+		t.Fatalf("future-dated message disappeared during recovery: %v", err)
+	}
+	if state := fs.State(); state.FirstSeq != 2 {
+		t.Fatalf("unexpected state after out-of-order recovery: %+v", state)
+	}
+}
+
+func TestFileStoreRecoverMaxAgeHonorsNeverTTL(t *testing.T) {
+	dir := t.TempDir()
+	fs := newExpiryPrefixTestStore(t, dir, 0)
+	hdr := []byte("NATS/1.0\r\n" + JSMessageTTL + ": never\r\n\r\n")
+	if err := fs.StoreRawMsg("foo.0", hdr, []byte("never"), 1, time.Now().Add(-time.Hour).UnixNano(), -1, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	fs = newExpiryPrefixTestStore(t, dir, time.Second)
+	defer fs.Stop()
+	state := fs.State()
+	if state.Msgs != 1 || state.FirstSeq != 1 {
+		t.Fatalf("never-TTL message disappeared during recovery: %+v", state)
+	}
+}
+
+func TestFileStoreRecoverMaxAgeNoTrackHonorsNeverTTL(t *testing.T) {
+	dir := t.TempDir()
+	newStore := func(maxAge time.Duration) *fileStore {
+		t.Helper()
+		fs, err := newFileStore(FileStoreConfig{StoreDir: dir, BlockSize: 1024}, StreamConfig{
+			Name:    "TEST",
+			MaxAge:  maxAge,
+			Storage: FileStorage,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return fs
+	}
+
+	fs := newStore(0)
+	hdr := []byte("NATS/1.0\r\n" + JSMessageTTL + ": never\r\n\r\n")
+	if err := fs.StoreRawMsg("foo", hdr, []byte("never"), 1, time.Now().Add(-time.Hour).UnixNano(), 0, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.Stop(); err != nil {
+		t.Fatal(err)
+	}
+
+	fs = newStore(time.Second)
+	defer fs.Stop()
+	if _, err := fs.LoadMsg(1, nil); err != nil {
+		t.Fatalf("never-TTL message disappeared from an untracked store: %v", err)
+	}
+	if state := fs.State(); state.Msgs != 1 || state.FirstSeq != 1 {
+		t.Fatalf("unexpected state after untracked recovery: %+v", state)
+	}
+}
+
+func TestFileStoreRecoverMaxAgeNoTrackExpires(t *testing.T) {
+	dir := t.TempDir()
+	newStore := func(maxAge time.Duration) *fileStore {
+		t.Helper()
+		fs, err := newFileStore(FileStoreConfig{StoreDir: dir, BlockSize: 1024}, StreamConfig{
+			Name:    "TEST",
+			MaxAge:  maxAge,
+			Storage: FileStorage,
+		})
+		require_NoError(t, err)
+		return fs
+	}
+
+	fs := newStore(0)
+	require_NoError(t, fs.StoreRawMsg("foo", nil, []byte("expired"), 1, time.Now().Add(-time.Hour).UnixNano(), 0, false))
+	require_NoError(t, fs.Stop())
+
+	fs = newStore(time.Second)
+	defer fs.Stop()
+	state := fs.State()
+	require_Equal(t, state.Msgs, uint64(0))
+	require_Equal(t, state.FirstSeq, uint64(2))
+	require_Equal(t, state.LastSeq, uint64(1))
+}
+
+func TestFileStoreExpirePrefixKeepsFutureTimestampAfterDeletedTail(t *testing.T) {
+	dir := t.TempDir()
+	fs := newExpiryPrefixTestStoreWithBlockSize(t, dir, 0, 1024)
+	now := time.Now().UnixNano()
+	expired := now - 2*int64(time.Hour)
+	future := now + int64(time.Hour)
+	msg := bytes.Repeat([]byte("x"), 100)
+
+	require_NoError(t, fs.StoreRawMsg("foo.0", nil, msg, 1, expired, 0, false))
+	require_NoError(t, fs.StoreRawMsg("foo.0", nil, msg, 2, future, 0, false))
+	require_NoError(t, fs.StoreRawMsg("foo.0", nil, msg, 3, now-int64(time.Hour), 0, false))
+	_, err := fs.EraseMsg(3)
+	require_NoError(t, err)
+	fs.mu.RLock()
+	mb := fs.lmb
+	mb.mu.RLock()
+	ordered := mb.tsOrdered
+	mb.mu.RUnlock()
+	fs.mu.RUnlock()
+	require_False(t, ordered)
+
+	fs.mu.Lock()
+	_, err = fs.newMsgBlockForWrite()
+	fs.mu.Unlock()
+	require_NoError(t, err)
+	require_NoError(t, fs.StoreRawMsg("foo.0", nil, msg, 4, now, 0, false))
+	require_NoError(t, fs.Stop())
+
+	fs = newExpiryPrefixTestStoreWithBlockSize(t, dir, 0, 1024)
+	defer fs.Stop()
+	_, err = fs.LoadMsg(1, nil)
+	require_NoError(t, err)
+
+	var ranges int
+	fs.registerStorageExpirePrefix(func(uint64, uint64, uint64) {
+		ranges++
+	})
+	fs.mu.Lock()
+	fs.cfg.MaxAge = time.Second
+	fs.mu.Unlock()
+	fs.expireMsgs()
+	require_Equal(t, ranges, 0)
+
+	if _, err := fs.LoadMsg(2, nil); err != nil {
+		t.Fatalf("future-dated message was removed after loading a deleted tail: %v", err)
+	}
+	if state := fs.State(); state.FirstSeq != 2 {
+		t.Fatalf("unexpected state after expiry: %+v", state)
+	}
+}
+
 const expireMsgsBenchMessages = 16_384
 
 func storeExpireMsgsBenchFixture(tb testing.TB, fs *fileStore) {

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -16,6 +16,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"encoding/json"
@@ -8781,4 +8782,110 @@ func TestJetStreamClusterCreateGroupForConsumerNoPeers(t *testing.T) {
 	require_True(t, cerr == nil)
 	require_True(t, rg != nil)
 	require_Len(t, len(rg.Peers), 3)
+}
+
+func TestJetStreamClusterMaxAgeR3ConcurrentTimers(t *testing.T) {
+	c := createJetStreamClusterWithTemplate(t, jsClusterTempl, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	cfg := &StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		MaxBytes: 100 * 1024,
+		Storage:  FileStorage,
+		Replicas: 3,
+	}
+	_, err := jsStreamCreate(t, nc, cfg)
+	require_NoError(t, err)
+
+	stores := make([]*fileStore, 0, len(c.servers))
+	for i, s := range c.servers {
+		mset, err := s.globalAccount().lookupStream("TEST")
+		require_NoError(t, err)
+		fs, ok := mset.store.(*fileStore)
+		require_True(t, ok)
+		fs.mu.Lock()
+		if i == 0 {
+			fs.fcfg.BlockSize = 4 * 1024
+		} else {
+			fs.fcfg.BlockSize = 8 * 1024
+		}
+		fs.mu.Unlock()
+		stores = append(stores, fs)
+	}
+
+	const expired = 48
+	msg := bytes.Repeat([]byte("x"), 1024)
+	for range expired {
+		_, err := js.Publish("foo", msg)
+		require_NoError(t, err)
+	}
+	checkFor(t, 5*time.Second, 25*time.Millisecond, func() error {
+		return checkState(t, c, "$G", "TEST")
+	})
+	for _, fs := range stores {
+		require_True(t, fs.numMsgBlocks() > 1)
+	}
+
+	// Keep MaxAge disabled until the prefix and boundary message are present on
+	// every replica, then drive the three local timers at the same time.
+	time.Sleep(2200 * time.Millisecond)
+	_, err = js.Publish("foo", msg)
+	require_NoError(t, err)
+	checkFor(t, 5*time.Second, 25*time.Millisecond, func() error {
+		return checkState(t, c, "$G", "TEST")
+	})
+
+	for _, fs := range stores {
+		fs.mu.Lock()
+		fs.cfg.MaxAge = 2 * time.Second
+		fs.mu.Unlock()
+	}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for _, fs := range stores {
+		wg.Go(func() {
+			<-start
+			fs.expireMsgs()
+		})
+	}
+	close(start)
+	wg.Wait()
+	for _, fs := range stores {
+		fs.mu.Lock()
+		fs.cancelAgeChk()
+		fs.mu.Unlock()
+	}
+
+	checkFor(t, 5*time.Second, 25*time.Millisecond, func() error {
+		for _, fs := range stores {
+			state := fs.State()
+			if state.Msgs != 1 || state.FirstSeq != expired+1 || state.LastSeq != expired+1 {
+				return fmt.Errorf("unexpected local state after concurrent expiry: %+v", state)
+			}
+		}
+		return checkState(t, c, "$G", "TEST")
+	})
+
+	// A normal replicated write after the independent local timers confirms that
+	// no expiry path left the stream or its store unable to accept new data.
+	for _, fs := range stores {
+		fs.mu.Lock()
+		fs.cfg.MaxAge = 0
+		fs.mu.Unlock()
+	}
+	_, err = js.Publish("foo", []byte("after expiry"))
+	require_NoError(t, err)
+	checkFor(t, 5*time.Second, 25*time.Millisecond, func() error {
+		for _, fs := range stores {
+			state := fs.State()
+			if state.Msgs != 2 || state.FirstSeq != expired+1 || state.LastSeq != expired+2 {
+				return fmt.Errorf("unexpected local state after normal write: %+v", state)
+			}
+		}
+		return checkState(t, c, "$G", "TEST")
+	})
 }

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math/rand"
 	"net/url"
 	os "os"
@@ -13013,5 +13014,113 @@ func TestJetStreamConsumerResetResponseAcrossServiceImport(t *testing.T) {
 			c.waitOnConsumerLeader("A", "TEST", "CONSUMER")
 			return c.consumerLeader("A", "TEST", "CONSUMER")
 		})
+	})
+}
+
+func TestJetStreamConsumerExpireStreamPendingPrefix(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	mset, err := s.GlobalAccount().addStream(&StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Storage:  FileStorage,
+	})
+	require_NoError(t, err)
+
+	nc := clientConnectToServer(t, s)
+	defer nc.Close()
+	sub, err := nc.SubscribeSync("deliver")
+	require_NoError(t, err)
+	asub, err := nc.SubscribeSync("$JS.EVENT.ADVISORY.CONSUMER.MSG_TERMINATED.TEST.C")
+	require_NoError(t, err)
+	require_NoError(t, nc.FlushTimeout(10*time.Second))
+
+	o, err := mset.addConsumer(&ConsumerConfig{
+		Durable:        "C",
+		DeliverSubject: "deliver",
+		AckPolicy:      AckExplicit,
+	})
+	require_NoError(t, err)
+
+	for i := 1; i <= 6; i++ {
+		sendStreamMsg(t, nc, "foo", fmt.Sprintf("message %d", i))
+	}
+	for i := 0; i < 6; i++ {
+		_, err := sub.NextMsg(2 * time.Second)
+		require_NoError(t, err)
+	}
+
+	o.mu.RLock()
+	require_Equal(t, 6, len(o.pending))
+	o.mu.RUnlock()
+
+	mset.expirePrefixUpdates(5, 4, 0)
+	checkFor(t, 2*time.Second, 10*time.Millisecond, func() error {
+		o.mu.RLock()
+		np := len(o.pending)
+		o.mu.RUnlock()
+		if np != 2 {
+			return fmt.Errorf("expected 2 pending messages above floor, got %d", np)
+		}
+		state, err := o.store.BorrowState()
+		if err != nil {
+			return err
+		}
+		if state == nil || len(state.Pending) != 2 {
+			return fmt.Errorf("expected 2 persisted pending messages, got %+v", state)
+		}
+		return nil
+	})
+
+	for i := 0; i < 4; i++ {
+		_, err := asub.NextMsg(time.Second)
+		require_NoError(t, err)
+	}
+}
+
+func TestJetStreamConsumerExpireStreamPendingPrefixCleansRedelivery(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	mset, err := s.GlobalAccount().addStream(&StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Storage:  FileStorage,
+	})
+	require_NoError(t, err)
+	o, err := mset.addConsumer(&ConsumerConfig{Durable: "C", AckPolicy: AckExplicit})
+	require_NoError(t, err)
+
+	o.mu.Lock()
+	o.rdc = map[uint64]uint64{1: 2, 2: 2, 5: 2}
+	o.addToRedeliverQueue(1, 2, 5)
+	o.dseq, o.sseq = 5, 6
+	state := ConsumerState{
+		Delivered:   SequencePair{Consumer: 5, Stream: 5},
+		Redelivered: map[uint64]uint64{1: 2, 2: 2, 5: 2},
+	}
+	o.mu.Unlock()
+	cfs, ok := o.store.(*consumerFileStore)
+	require_True(t, ok)
+	require_NoError(t, cfs.ForceUpdate(&state))
+
+	mset.expirePrefixUpdates(5, 4, 0)
+	checkFor(t, 2*time.Second, 10*time.Millisecond, func() error {
+		o.mu.RLock()
+		inMemory := maps.Clone(o.rdc)
+		queued := append([]uint64(nil), o.rdq...)
+		o.mu.RUnlock()
+		if len(inMemory) != 1 || inMemory[5] != 2 || len(queued) != 1 || queued[0] != 5 {
+			return fmt.Errorf("unexpected redelivery state after prefix expiry: rdc=%v rdq=%v", inMemory, queued)
+		}
+		state, err := o.store.BorrowState()
+		if err != nil {
+			return err
+		}
+		if state == nil || len(state.Redelivered) != 1 || state.Redelivered[5] != 2 {
+			return fmt.Errorf("unexpected persisted redelivery state after prefix expiry: %+v", state)
+		}
+		return nil
 	})
 }

--- a/server/store.go
+++ b/server/store.go
@@ -81,7 +81,8 @@ type StoreMsg struct {
 }
 
 // Used to call back into the upper layers to report on changes in storage resources.
-// For the cases where its a single message we will also supply sequence number and subject.
+// A single-message change supplies its sequence number and subject; batch and range
+// changes use a zero sequence and empty subject.
 type StorageUpdateHandler func(msgs, bytes int64, seq uint64, subj string)
 
 // Used to call back into the upper layers to remove a message.

--- a/server/stream.go
+++ b/server/stream.go
@@ -5208,6 +5208,9 @@ func (mset *stream) setupStore(fsCfg *FileStoreConfig) error {
 			mset.removeMsg(seq)
 		}
 	})
+	if fs, ok := mset.store.(*fileStore); ok {
+		fs.registerStorageExpirePrefix(mset.expirePrefixUpdates)
+	}
 	mset.store.RegisterProcessJetStreamMsg(func(im *inMsg) {
 		if mset.IsClustered() {
 			if mset.IsLeader() {
@@ -5222,13 +5225,33 @@ func (mset *stream) setupStore(fsCfg *FileStoreConfig) error {
 	return nil
 }
 
+// expirePrefixUpdates handles the local file-store range after it has
+// committed the removal. This is deliberately separate from StorageUpdateHandler:
+// a range has a stream floor, not a synthetic single-message sequence.
+func (mset *stream) expirePrefixUpdates(first, msgs, bytes uint64) {
+	if first == 0 || msgs == 0 {
+		return
+	}
+	mset.mu.Lock()
+	mset.clearAllPreAcksBelowFloor(first)
+	mset.mu.Unlock()
+
+	mset.clsMu.RLock()
+	for _, o := range mset.cList {
+		o.expireStreamPendingPrefix(first)
+	}
+	mset.clsMu.RUnlock()
+
+	if mset.jsa != nil {
+		mset.jsa.updateUsage(mset.tier, mset.stype, -int64(bytes))
+	}
+}
+
 // Called for any updates to the underlying stream. We pass through the bytes to the
 // jetstream account. We do local processing for stream pending for consumers, but only
 // for removals.
 // Lock should not be held.
 func (mset *stream) storeUpdates(md, bd int64, seq uint64, subj string) {
-	// If we have a single negative update then we will process our consumers for stream pending.
-	// Purge and Store handled separately inside individual calls.
 	if md == -1 && seq > 0 && subj != _EMPTY_ {
 		// We use our consumer list mutex here instead of the main stream lock since it may be held already.
 		mset.clsMu.RLock()


### PR DESCRIPTION
Recovered v4 file-store blocks now reach the range validator. It learns timestamp order before it selects an eligible MaxAge prefix. Cold upgraded stores can remove complete expired blocks with one range update instead of one removal per message.

The repair also reuses the existing `selectNextFirst` owner after prefix removal. This removes leading empty blocks and makes the stream `FirstSeq` and removal callback use the first live sequence.

Tests and benchmarks remain in `server/filestore_test.go`. No new proof file or second cleanup path is added.

**Workload:** `cold restarted v4-index file-store MaxAge expiry of 16,384 timestamp-ordered messages across complete blocks`

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| `ns/op` | 11582922 | 3967472 | 65.7% lower |

**Workload:** `end-to-end file-store MaxAge expiry of 16,384 messages with 128 pending and redelivered consumer records`

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| `ns/op` | 15349524 | 3909440 | 74.5% lower |
| `p95-ns/op` | 16824277 | 4498940 | 73.3% lower |

**Workload:** `end-to-end file-store MaxAge expiry of 16,384 messages with 4,096 pending and redelivered consumer records`

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| `ns/op` | 28702905 | 16201338 | 43.6% lower |
| `p95-ns/op` | 30625625 | 17492837 | 42.9% lower |

The cleanup repair showed no material change in five sequential 100-iteration benchmark samples against the exact measured Candidate.

Proof includes the focused file-store, consumer, and cluster tests; the regression repeated 10 times; its race run; `go vet ./server`; and Linux, Linux/386, and Windows builds. The full native store suite had one existing timing flake. It also reproduces on the Candidate and the untouched upstream base.

---

Generated by [Perfloop](https://app.perfloop.ai). Human sponsor: [Tomas Senart](https://github.com/tsenart). [Measurements and checks](https://app.perfloop.ai/t/oss/case_yng2yjnryc).