### PR TITLE
[FIXED] `syncBlocks` may skip sync on compacted blocks

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -7833,6 +7833,48 @@ func (mb *msgBlock) ensureRawBytesLoaded() error {
 	return nil
 }
 
+// Lock should be held.
+func (mb *msgBlock) syncFile() error {
+	fd, didOpen := mb.mfd, false
+	if fd == nil {
+		mb.fs.dios.acquire()
+		var err error
+		fd, err = os.OpenFile(mb.mfn, os.O_RDWR, defaultFilePerms)
+		mb.fs.dios.release()
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		didOpen = true
+	}
+	if err := fd.Sync(); err != nil {
+		// Close fd if we opened it, but ignore its error since sync takes precedence.
+		if didOpen {
+			_ = fd.Close()
+		}
+		return err
+	}
+	if didOpen {
+		return fd.Close()
+	}
+	return nil
+}
+
+// Lock should be held.
+func (mb *msgBlock) syncFileAndDir() error {
+	if err := mb.syncFile(); err != nil {
+		return err
+	}
+	if canFsyncDirectories {
+		mb.fs.dios.acquire()
+		defer mb.fs.dios.release()
+		return syncDir(mb.mfn)
+	}
+	return nil
+}
+
 // Sync msg and index files as needed. This is called from a timer.
 func (fs *fileStore) syncBlocks() {
 	if fs.isClosed() {
@@ -7910,6 +7952,7 @@ func (fs *fileStore) syncBlocks() {
 
 		// Check if we should compact here.
 		// Need to hold fs lock in case we reference psim when loading in the mb and we may remove this block if truly empty.
+		var compacted bool
 		if needsCompact {
 			// Load a delete map containing only interior deletes.
 			// This is used when compacting to know if tombstones are still relevant,
@@ -7934,6 +7977,7 @@ func (fs *fileStore) syncBlocks() {
 				storeFsWerr(err)
 				continue
 			}
+			compacted = !shouldRemove
 
 			// Check if we should remove. This will not be common, so we will re-take fs write lock here vs changing
 			//  it above which we would prefer to be a readlock such that other lookups can occur while compacting this block.
@@ -7960,45 +8004,22 @@ func (fs *fileStore) syncBlocks() {
 		}
 
 		// Check if we need to sync this block.
-		if needSync {
-			mb.mu.Lock()
-			var fd *os.File
+		if needSync || compacted {
 			var err error
-			var didOpen bool
-			if mb.mfd != nil {
-				fd = mb.mfd
+			mb.mu.Lock()
+			if compacted {
+				err = mb.syncFileAndDir()
 			} else {
-				fs.dios.acquire()
-				fd, err = os.OpenFile(mb.mfn, os.O_RDWR, defaultFilePerms)
-				fs.dios.release()
-				didOpen = true
-				if err != nil && !os.IsNotExist(err) {
-					mb.mu.Unlock()
-					storeFsWerr(err)
-					continue
-				}
+				err = mb.syncFile()
 			}
-			// If we have an fd.
-			if fd != nil {
-				if err = fd.Sync(); err != nil {
-					// Close fd if we opened it, but ignore its error since sync takes precedence.
-					if didOpen {
-						_ = fd.Close()
-					}
-					mb.mu.Unlock()
-					storeFsWerr(err)
-					continue
-				}
-				// If we opened the file close the fd.
-				if didOpen {
-					if err = fd.Close(); err != nil {
-						mb.mu.Unlock()
-						storeFsWerr(err)
-						continue
-					}
-				}
+			if err == nil {
+				mb.needSync = false
 			}
 			mb.mu.Unlock()
+			if err != nil {
+				storeFsWerr(err)
+				continue
+			}
 		}
 	}
 

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -8191,6 +8191,63 @@ func TestFileStoreSyncCompressOnlyIfDirty(t *testing.T) {
 	require_False(t, noCompact)
 }
 
+func TestFileStoreSyncBlocksSyncsCompaction(t *testing.T) {
+	fs, err := newFileStore(
+		FileStoreConfig{StoreDir: t.TempDir(), BlockSize: 256, SyncInterval: time.Hour},
+		StreamConfig{Name: "zzz", Subjects: []string{"foo.*"}, Storage: FileStorage},
+	)
+	require_NoError(t, err)
+	defer fs.Stop()
+
+	// Create two full blocks and one active block.
+	for range 13 {
+		_, _, err = fs.StoreMsg("foo.BB", nil, []byte("hello"), 0)
+		require_NoError(t, err)
+	}
+	require_Equal(t, fs.numMsgBlocks(), 3)
+
+	checkAllNeedSync := func(expected bool) {
+		t.Helper()
+		fs.mu.RLock()
+		blks := append([]*msgBlock(nil), fs.blks...)
+		fs.mu.RUnlock()
+		for _, mb := range blks {
+			mb.mu.RLock()
+			needSync := mb.needSync
+			mb.mu.RUnlock()
+			require_Equal(t, needSync, expected)
+		}
+	}
+
+	// Start with all blocks synced.
+	checkAllNeedSync(true)
+	fs.syncBlocks()
+	checkAllNeedSync(false)
+
+	fs.mu.RLock()
+	mb := fs.blks[0]
+	fs.mu.RUnlock()
+
+	// Logical deletes make the synced block compactable without dirtying its file.
+	for _, seq := range []uint64{2, 3, 4, 5} {
+		_, err = fs.RemoveMsg(seq)
+		require_NoError(t, err)
+	}
+	mb.mu.RLock()
+	shouldCompact, needSync, rbytes := mb.shouldCompactSync(), mb.needSync, mb.rbytes
+	mb.mu.RUnlock()
+	require_True(t, shouldCompact)
+	require_False(t, needSync)
+
+	// The pass that compacts the block must also sync the replacement.
+	fs.syncBlocks()
+	mb.mu.RLock()
+	newRbytes := mb.rbytes
+	mb.mu.RUnlock()
+	require_LessThan(t, newRbytes, rbytes)
+	checkAllNeedSync(false)
+}
+
 // This test is for deleted interior message tracking after compaction from limits based deletes, meaning no tombstones.
 // Bug was that dmap would not be properly be hydrated after the compact from rebuild. But we did so in populateGlobalInfo.
 // So this is just to fix a bug in rebuildState tracking gaps after a compact.


### PR DESCRIPTION
`syncBlocks` should leave all message blocks synced after it returns. This was not always the case when a block needed compaction during the same pass. Specifically, if the block was initially marked as not needing sync, i.e. `mb.needSync = false`, then `syncBlocks` would miss the fact that `compactWithFloor` could later set
`mb.needSync = true` on that same block.
Keep track of blocks compacted and sync both the new compacted file and its directory before returning.