### PR TITLE
(2.15) [FIXED] Migration added offline peers & removed peers before catchup

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"maps"
 	"math"
 	"math/rand"
 	"os"
@@ -4285,14 +4286,9 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 	}
 	ourPeerId, cc, s := n.ID(), js.cluster, js.srv
 
-	// FIXME(mvv): a move should make sure that peers are also upper-layer current
-	//  should peers where we're moving to, become required for quorum before we move?
-	//// Check to see where we are..
-	//rg := mset.raftGroup()
-	//
-	//// Make sure we have correct cluster information on the other peers.
-	//ci := js.clusterInfo(rg)
-	//mset.checkClusterInfo(ci)
+	// Store whether any peers are currently being caught up, in which case they're
+	// not current yet and we need to wait before removing peers.
+	catchups := mset.catchupPeers()
 
 	js.mu.RLock()
 	// We are shutting down.
@@ -4453,16 +4449,51 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 				}
 			}
 		}
+
+		// Remove old peers one at a time, the leader selected last.
+		remove := s.selectPeerToRemove(ourPeerId, actual, remaining)
+
+		// Only remove a peer if the group left after the removal retains a
+		// store-current majority; otherwise wait for catchups to complete.
+		var currentCount int
+		var currentDesired []string
+		for _, p := range actual {
+			if p.Current && p.Lag == 0 && !slices.Contains(catchups, p.ID) {
+				if p.ID != remove {
+					currentCount++
+				}
+				if slices.Contains(desiredPeers, p.ID) {
+					currentDesired = append(currentDesired, p.ID)
+				}
+			}
+		}
+		if quorum := (len(actual)-1)/2 + 1; currentCount < quorum {
+			js.mu.RUnlock()
+			return
+		}
+		// If we have current desired peers, and we're not a desired peer ourselves, step down.
+		if len(currentDesired) > 0 && !slices.Contains(desiredPeers, ourPeerId) {
+			// If desired peers are still catching up, we wait for a quorum of them to complete for now.
+			if quorum := len(desiredPeers)/2 + 1; len(currentDesired) < quorum {
+				js.mu.RUnlock()
+				return
+			}
+			preferred := s.selectStepDownPreferred(ourPeerId, actual, currentDesired)
+			js.mu.RUnlock()
+			if preferred != _EMPTY_ {
+				n.StepDown(preferred)
+			}
+			return
+		}
+
+		js.mu.RUnlock()
 		// Step down and perform a leader transfer if we'd remove ourselves. We are
 		// selected last, so leadership changes at most once, and every remaining
 		// member is already in the desired peer set so any successor works.
-		remove := s.selectPeerToRemove(ourPeerId, actual, remaining)
-		if remove == ourPeerId {
-			js.mu.RUnlock()
-			n.StepDown()
-		} else {
-			js.mu.RUnlock()
+		if remove != ourPeerId {
 			n.ProposeRemovePeer(remove)
+		} else {
+			n.StepDown()
 		}
 		return
 	}
@@ -11766,6 +11797,12 @@ func (mset *stream) hasCatchupPeers() bool {
 	mset.mu.RLock()
 	defer mset.mu.RUnlock()
 	return len(mset.catchups) > 0
+}
+
+func (mset *stream) catchupPeers() []string {
+	mset.mu.RLock()
+	defer mset.mu.RUnlock()
+	return slices.Collect(maps.Keys(mset.catchups))
 }
 
 func (mset *stream) setCatchingUp() {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -204,7 +204,6 @@ type desiredRaftGroup struct {
 	Cluster   string   `json:"cluster,omitempty"`
 	Preferred string   `json:"preferred,omitempty"`
 
-	ScaleUp   bool `json:"scale_up,omitempty"`
 	ScaleDown bool `json:"scale_down,omitempty"`
 
 	// Removed are peers an operator peer-removed from this group. A group that
@@ -2719,7 +2718,11 @@ func (js *jetStream) setStreamAssignmentRecovering(sa *streamAssignment) {
 	sa.Restore = nil
 	if sa.Group != nil {
 		sa.Group.Preferred = _EMPTY_
-		sa.Group.ScaleUp = false
+		// Must be preserved while a migration is inflight, so peers that create
+		// their raft node late keep the empty-log protection.
+		if sa.Group.Desired == nil {
+			sa.Group.ScaleUp = false
+		}
 	}
 }
 
@@ -2731,7 +2734,11 @@ func (js *jetStream) setConsumerAssignmentRecovering(ca *consumerAssignment) {
 	ca.recovering = true
 	if ca.Group != nil {
 		ca.Group.Preferred = _EMPTY_
-		ca.Group.ScaleUp = false
+		// Must be preserved while a migration is inflight, so peers that create
+		// their raft node late keep the empty-log protection.
+		if ca.Group.Desired == nil {
+			ca.Group.ScaleUp = false
+		}
 	}
 }
 
@@ -4372,12 +4379,19 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 	}
 
 	// Extend the actual peer set through the log, but only if it's part of the desired set.
+	var candidates []string
 	for _, peer := range current {
 		if !slices.Contains(actualPeers, peer) && slices.Contains(desiredPeers, peer) {
-			js.mu.RUnlock()
-			n.ProposeAddPeer(peer)
-			return
+			candidates = append(candidates, peer)
 		}
+	}
+	if len(candidates) > 0 {
+		add := s.selectPeerToAdd(n, ourPeerId, actual, candidates)
+		js.mu.RUnlock()
+		if add != _EMPTY_ {
+			n.ProposeAddPeer(add)
+		}
+		return
 	}
 
 	// If scaling down, we need to select where to.
@@ -4401,8 +4415,6 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 		for _, peer := range desiredPeers {
 			if !slices.Contains(current, peer) {
 				combined = append(combined, peer)
-				// FIXME(mvv): for testing only add one replica per cycle.
-				break
 			}
 		}
 		update.MetaPeers = combined
@@ -7584,12 +7596,19 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 	}
 
 	// Extend the actual peer set through the log, but only if it's part of the desired set.
+	var candidates []string
 	for _, peer := range current {
 		if !slices.Contains(actualPeers, peer) && slices.Contains(desiredPeers, peer) {
-			js.mu.RUnlock()
-			n.ProposeAddPeer(peer)
-			return
+			candidates = append(candidates, peer)
 		}
+	}
+	if len(candidates) > 0 {
+		add := s.selectPeerToAdd(n, ourPeerId, actual, candidates)
+		js.mu.RUnlock()
+		if add != _EMPTY_ {
+			n.ProposeAddPeer(add)
+		}
+		return
 	}
 
 	// If scaling down, we need to select where to.
@@ -7611,7 +7630,7 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 	if !foundAll {
 		// Only add a peer once the stream is actually hosted on it. A consumer can't
 		// move to a peer earlier until the stream is hosted there.
-		var nextPeer string
+		combined := current
 		for _, peer := range desiredPeers {
 			if slices.Contains(current, peer) {
 				continue
@@ -7619,15 +7638,13 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 			if !slices.Contains(osa.Group.Peers, peer) {
 				continue
 			}
-			nextPeer = peer
-			break
+			combined = append(combined, peer)
 		}
-		if nextPeer == _EMPTY_ {
+		if len(combined) == len(current) {
 			js.mu.RUnlock()
 			return
 		}
-		// FIXME(mvv): for testing only add one replica per cycle.
-		update.MetaPeers = append(current, nextPeer)
+		update.MetaPeers = combined
 		js.mu.RUnlock()
 		sendMetaUpdate()
 		return
@@ -8601,11 +8618,20 @@ func (rg *raftGroup) reconcileDesiredState(reconcile desiredAssignmentUpdate, re
 		if len(ng.Peers) >= replicas {
 			ng.Excluded = nil
 		}
+		// Don't reset ScaleUp here. If it was set, we'll want each replica to know
+		// about it until it unsets it as part of recovery.
 	} else {
 		// Skip if the peer set is unchanged.
 		slices.Sort(prevPeers)
 		if slices.Equal(metaPeers, prevPeers) {
 			return nil
+		}
+		// If new peers are added, mark this assignment for scale up.
+		for _, peer := range metaPeers {
+			if !slices.Contains(prevPeers, peer) {
+				ng.ScaleUp = true
+				break
+			}
 		}
 		// Still converging toward the desired peer set.
 		ng.Desired.ID = nuid.Next()
@@ -8957,7 +8983,6 @@ func (cc *jetStreamCluster) reassignStreamPeers(sa *streamAssignment, peers []st
 	// Preserve how the group is meant to converge.
 	if d := sa.Group.Desired; d != nil {
 		csa.Group.Desired.ScaleDown = d.ScaleDown
-		csa.Group.Desired.ScaleUp = d.ScaleUp
 	}
 	if remove {
 		removeFrom := func(from []string) []string {
@@ -9852,8 +9877,12 @@ func (s *Server) jsClusteredStreamUpdateRequestLocked(ci *ClientInfo, acc *Accou
 	// Make copy so to not change original.
 	rg := osa.copyGroup().Group
 
-	// Reset notion of scaling up, if this was done in a previous update.
-	rg.ScaleUp = false
+	// Reset notion of scaling up, if this was done in a previous update. Must be
+	// preserved while a migration is inflight, so peers that create their raft
+	// node late keep the empty-log protection.
+	if rg.Desired == nil {
+		rg.ScaleUp = false
+	}
 	if isMoveRequest {
 		if len(peerSet) == 0 {
 			nrg, err := js.createGroupForStream(ci, newCfg)
@@ -9916,7 +9945,6 @@ func (s *Server) jsClusteredStreamUpdateRequestLocked(ci *ClientInfo, acc *Accou
 			}
 			rg.Peers = peers
 			rg = osa.Group.withDesired(rg)
-			rg.Desired.ScaleUp = true
 		} else {
 			// Mark the group as scaling down, the current leader will be preserved.
 			rg.Peers = currentPeers
@@ -10170,6 +10198,45 @@ func (s *Server) selectPeerToRemove(curLeader string, current []*Peer, remaining
 		return _EMPTY_
 	}
 	return sorted[len(sorted)-1]
+}
+
+// selectPeerToAdd picks the peer from candidates that is most preferable to
+// add during a migration: the one we heard from most recently. An unheard
+// candidate is only picked if the live members still form a quorum in the
+// grown group, so adding an offline peer can't stall it. Empty if no peer
+// can be added safely right now.
+func (s *Server) selectPeerToAdd(n RaftNode, ourPeerId string, current []*Peer, candidates []string) string {
+	if len(candidates) == 0 {
+		return _EMPTY_
+	}
+	cutoff := time.Now().Add(-hbInterval * 3)
+	heard := func(ts time.Time) bool { return !ts.IsZero() && ts.After(cutoff) }
+	online := func(peer string) bool {
+		si, ok := s.nodeToInfo.Load(peer)
+		return ok && si != nil && !si.(nodeInfo).offline
+	}
+	// Prefer the candidate we've heard from most recently.
+	add, last := _EMPTY_, time.Time{}
+	for _, peer := range candidates {
+		if ts := n.LastHeardFromPeer(peer); online(peer) && heard(ts) && ts.After(last) {
+			add, last = peer, ts
+		}
+	}
+	if add != _EMPTY_ {
+		return add
+	}
+	// Otherwise, only add a peer if the members we've recently heard from can
+	// still reach quorum after the group has grown.
+	live := 0
+	for _, p := range current {
+		if p.ID == ourPeerId || (online(p.ID) && heard(p.Last)) {
+			live++
+		}
+	}
+	if quorum := (len(current)+1)/2 + 1; live >= quorum {
+		return candidates[0]
+	}
+	return _EMPTY_
 }
 
 // selectStepDownPreferred picks the peer to transfer leadership to before the
@@ -11021,8 +11088,12 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 
 		nca := ca.copyGroup()
 
-		// Reset notion of scaling up, if this was done in a previous update.
-		nca.Group.ScaleUp = false
+		// Reset notion of scaling up, if this was done in a previous update. Must be
+		// preserved while a migration is inflight, so peers that create their raft
+		// node late keep the empty-log protection.
+		if nca.Group.Desired == nil {
+			nca.Group.ScaleUp = false
+		}
 
 		rBefore := nca.Config.replicas(sa.Config)
 		rAfter := cfg.replicas(sa.Config)
@@ -11060,7 +11131,6 @@ func (s *Server) jsClusteredConsumerRequest(ci *ClientInfo, acc *Account, subjec
 			}
 			nca.Group.Peers = newPeerSet
 			nca.Group = ca.Group.withDesired(nca.Group)
-			nca.Group.Desired.ScaleUp = true
 		} else if rBefore > rAfter {
 			// Mark the group as scaling down, the current leader will be preserved.
 			nca.Group = ca.Group.withDesired(nca.Group)

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -8818,6 +8819,8 @@ func TestJetStreamClusterDesyncAfterFailedScaleUp(t *testing.T) {
 		cfg.Replicas = 3
 		_, err = js.UpdateStream(cfg)
 		require_NoError(t, err)
+		c.waitOnStreamLeader(globalAccountName, "TEST")
+		c.waitOnConsumerLeader(globalAccountName, "TEST", "CONSUMER")
 
 		checkStreamAndConsumerState := func() error {
 			t.Helper()
@@ -9002,6 +9005,217 @@ func TestJetStreamClusterScaleUpWithQuorum(t *testing.T) {
 		n.ResumeApply()
 	}
 	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+		return checkState(t, c, globalAccountName, "TEST")
+	})
+}
+
+func TestJetStreamClusterSelectPeerToAdd(t *testing.T) {
+	s := &Server{}
+	now := time.Now()
+	newNode := func(members map[string]time.Time, observed map[string]time.Time) *raft {
+		peers := make(map[string]*lps, len(members))
+		for id, ts := range members {
+			peers[id] = &lps{ts: ts}
+			s.nodeToInfo.Store(id, nodeInfo{})
+		}
+		for id := range observed {
+			s.nodeToInfo.Store(id, nodeInfo{})
+		}
+		return &raft{peers: peers, observed: observed}
+	}
+	selectFor := func(n *raft, candidates []string) string {
+		var current []*Peer
+		for id, ps := range n.peers {
+			current = append(current, &Peer{ID: id, Last: ps.ts})
+		}
+		return s.selectPeerToAdd(n, "A", current, candidates)
+	}
+
+	// No candidates to add.
+	n := newNode(map[string]time.Time{"A": {}}, nil)
+	require_Equal(t, selectFor(n, nil), _EMPTY_)
+
+	// A candidate we've recently heard from is preferred, even if an unheard
+	// candidate comes first.
+	n = newNode(map[string]time.Time{"A": {}}, map[string]time.Time{"C": now})
+	require_Equal(t, selectFor(n, []string{"B", "C"}), "C")
+
+	// The most recently heard candidate is preferred.
+	n = newNode(map[string]time.Time{"A": {}}, map[string]time.Time{"B": now.Add(-time.Second), "C": now})
+	require_Equal(t, selectFor(n, []string{"B", "C"}), "C")
+
+	// A candidate heard too long ago doesn't count as heard.
+	n = newNode(map[string]time.Time{"A": {}}, map[string]time.Time{"B": now.Add(-4 * hbInterval)})
+	require_Equal(t, selectFor(n, []string{"B"}), _EMPTY_)
+
+	// An unheard candidate can't be added to a group that would then require
+	// a quorum larger than its live members, e.g. growing R1 with an offline
+	// peer would require a quorum of two with only one live member.
+	n = newNode(map[string]time.Time{"A": {}}, nil)
+	require_Equal(t, selectFor(n, []string{"B"}), _EMPTY_)
+
+	// Same for a larger group: two live members of three can't grow to four,
+	// which would require a quorum of three.
+	n = newNode(map[string]time.Time{"A": {}, "B": now, "C": now.Add(-time.Minute)}, nil)
+	require_Equal(t, selectFor(n, []string{"D"}), _EMPTY_)
+
+	// An unheard candidate can be added if the live members still form a
+	// quorum in the grown group.
+	n = newNode(map[string]time.Time{"A": {}, "B": now, "C": now}, nil)
+	require_Equal(t, selectFor(n, []string{"D"}), "D")
+
+	// A candidate marked offline doesn't count as heard, even with a recent
+	// timestamp.
+	n = newNode(map[string]time.Time{"A": {}}, map[string]time.Time{"B": now})
+	s.nodeToInfo.Store("B", nodeInfo{offline: true})
+	require_Equal(t, selectFor(n, []string{"B"}), _EMPTY_)
+
+	// A member marked offline doesn't count toward the live quorum.
+	n = newNode(map[string]time.Time{"A": {}, "B": now, "C": now}, nil)
+	s.nodeToInfo.Store("C", nodeInfo{offline: true})
+	require_Equal(t, selectFor(n, []string{"D"}), _EMPTY_)
+}
+
+func TestJetStreamClusterScaleUpOfflinePeerPreservesQuorum(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R5S", 5)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	}
+	si, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	pubAck, err := js.Publish("foo", nil)
+	require_NoError(t, err)
+	require_Equal(t, pubAck.Sequence, 1)
+
+	// Identify the stream members: the leader, one member that stays up, and
+	// one member that we'll take down.
+	sl := c.streamLeader(globalAccountName, "TEST")
+	var otherUp, downMember *Server
+	for _, r := range si.Cluster.Replicas {
+		s := c.serverByName(r.Name)
+		require_NotNil(t, s)
+		if otherUp == nil {
+			otherUp = s
+		} else {
+			downMember = s
+		}
+	}
+	require_NotNil(t, otherUp)
+	require_NotNil(t, downMember)
+
+	// Move the meta leader to the stream member that stays up. We can't pause
+	// applies on the meta leader itself, and it must survive the shutdowns.
+	ml := otherUp
+	if c.leader() != ml {
+		ncSys, err := nats.Connect(c.leader().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+		require_NoError(t, err)
+		defer ncSys.Close()
+		jreq, err := json.Marshal(&JSApiLeaderStepdownRequest{Placement: &Placement{Preferred: ml.Name()}})
+		require_NoError(t, err)
+		_, err = ncSys.Request(JSApiLeaderStepDown, jreq, time.Second)
+		require_NoError(t, err)
+		c.waitOnLeader()
+		require_Equal(t, c.leader(), ml)
+	}
+
+	// Pause meta applies on the stream leader, so it doesn't see the scale up
+	// yet and the migration can't start.
+	smeta := sl.getJetStream().getMetaGroup()
+	require_NotNil(t, smeta)
+	require_NoError(t, smeta.PauseApply())
+
+	// Scale up the stream. The response times out since the stream leader can't
+	// respond while its applies are paused, so don't wait for it.
+	cfg.Replicas = 5
+	_, err = js.UpdateStream(cfg, nats.MaxWait(time.Second))
+	require_Error(t, err, context.DeadlineExceeded)
+
+	// Wait for the meta leader to register the desired scale up.
+	mjs := ml.getJetStream()
+	currentPeers := []string{sl.NodeName(), otherUp.NodeName(), downMember.NodeName()}
+	var desiredPeers []string
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		sa := mjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group.Desired == nil {
+			return fmt.Errorf("desired state not registered yet")
+		}
+		desiredPeers = copyStrings(sa.Group.Desired.Peers)
+		return nil
+	})
+	require_Len(t, len(desiredPeers), 5)
+
+	// The stream leader extends its raft group with the new desired peers in
+	// order, take down the server hosting the first one, as well as one of the
+	// existing members. The group then has two of three members online, and
+	// adding the offline peer to the raft group first would grow quorum to
+	// three and lose it. The online new peer must be added first.
+	var newPeer string
+	for _, p := range desiredPeers {
+		if !slices.Contains(currentPeers, p) {
+			newPeer = p
+			break
+		}
+	}
+	require_NotEqual(t, newPeer, _EMPTY_)
+	var downNew *Server
+	for _, s := range c.servers {
+		if s.NodeName() == newPeer {
+			downNew = s
+			break
+		}
+	}
+	require_NotNil(t, downNew)
+
+	downMember.Shutdown()
+	downMember.WaitForShutdown()
+	downNew.Shutdown()
+	downNew.WaitForShutdown()
+
+	// Reconnect in case we were connected to a downed server.
+	nc.Close()
+	nc, js = jsClientConnect(t, sl)
+	defer nc.Close()
+
+	// Resume applies on the stream leader, starting the migration.
+	smeta.ResumeApply()
+
+	// The stream must keep quorum: the migration must complete and publishes
+	// must work, even with the offline peers staying down.
+	checkFor(t, 20*time.Second, 200*time.Millisecond, func() error {
+		if _, err = js.Publish("foo", nil, nats.AckWait(time.Second)); err != nil {
+			return fmt.Errorf("publish failed: %v", err)
+		}
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		sa := mjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil {
+			return fmt.Errorf("stream assignment not found")
+		}
+		if sa.Group.Desired != nil {
+			return fmt.Errorf("scale up still pending")
+		}
+		if len(sa.Group.Peers) != 5 {
+			return fmt.Errorf("expected 5 peers, got %d", len(sa.Group.Peers))
+		}
+		return nil
+	})
+
+	// Restart the offline servers, they should catch up and the stream should heal.
+	for _, down := range []*Server{downMember, downNew} {
+		rs := c.restartServer(down)
+		c.waitOnStreamCurrent(rs, globalAccountName, "TEST")
+	}
+	checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
 		return checkState(t, c, globalAccountName, "TEST")
 	})
 }

--- a/server/jetstream_cluster_2_test.go
+++ b/server/jetstream_cluster_2_test.go
@@ -9076,6 +9076,18 @@ func TestJetStreamClusterSelectPeerToAdd(t *testing.T) {
 	require_Equal(t, selectFor(n, []string{"D"}), _EMPTY_)
 }
 
+func TestJetStreamClusterStreamCatchupPeers(t *testing.T) {
+	// Presence of an entry, not its lag, signals a peer requiring catchup.
+	// A zero-lag entry is included: it can mean a catchup stalled on its
+	// final message, kept so we don't lose track of the peer.
+	mset := &stream{catchups: map[string]uint64{"A": 0, "B": 100}}
+	peers := mset.catchupPeers()
+	slices.Sort(peers)
+	require_True(t, slices.Equal(peers, []string{"A", "B"}))
+	mset.catchups = nil
+	require_True(t, mset.catchupPeers() == nil)
+}
+
 func TestJetStreamClusterScaleUpOfflinePeerPreservesQuorum(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R5S", 5)
 	defer c.shutdown()

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -12873,8 +12873,8 @@ func TestJetStreamClusterStreamPeerRemoveAfterScaleDownRestoresQuorum(t *testing
 			return errors.New("stream not found")
 		}
 		if sa.Group.Desired != nil {
-			return fmt.Errorf("stream still converging: peers=%v desired=%v scaleDown=%v scaleUp=%v",
-				sa.Group.Peers, sa.Group.Desired.Peers, sa.Group.Desired.ScaleDown, sa.Group.Desired.ScaleUp)
+			return fmt.Errorf("stream still converging: peers=%v desired=%v scaleDown=%v",
+				sa.Group.Peers, sa.Group.Desired.Peers, sa.Group.Desired.ScaleDown)
 		}
 		if len(sa.Group.Peers) != 1 {
 			return fmt.Errorf("expected 1 peer, got %v", sa.Group.Peers)

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -2790,6 +2790,213 @@ func TestJetStreamSuperClusterMovingStreamAndMoveBack(t *testing.T) {
 	}
 }
 
+func TestJetStreamSuperClusterMovingStreamWaitsForStoreCatchup(t *testing.T) {
+	// Speed up catchup stall/retry cycles.
+	streamCatchupActivityInterval = 2 * time.Second
+	t.Cleanup(func() {
+		streamCatchupActivityInterval = defaultStreamCatchupActivityInterval
+	})
+
+	for _, test := range []struct {
+		name     string
+		replicas int
+		// Group size expected to hold steady while the destination peers'
+		// store catchups are stalled.
+		holdPeers     int
+		finalReplicas int
+	}{
+		// Moving R3: the gate must hold the full old+new group, no old peer
+		// may be removed while no destination peer is store-current.
+		{name: "move", replicas: 3, holdPeers: 6, finalReplicas: 2},
+		// Moving to R1: old peers can be removed while the group left after
+		// each removal retains a store-current majority, so the group must
+		// shrink from 4 to 3 peers (us, one old peer, and the destination)
+		// and then hold.
+		{name: "move-scale-down", replicas: 1, holdPeers: 3, finalReplicas: 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			sc := createJetStreamTaggedSuperCluster(t)
+			defer sc.shutdown()
+
+			nc, js := jsClientConnect(t, sc.randomServer())
+			defer nc.Close()
+
+			_, err := js.AddStream(&nats.StreamConfig{
+				Name:      "TEST",
+				Replicas:  3,
+				Placement: &nats.Placement{Tags: []string{"cloud:aws"}},
+			})
+			require_NoError(t, err)
+
+			toSend := 1_000
+			for range toSend {
+				_, err = js.Publish("TEST", []byte("HELLO WORLD"))
+				require_NoError(t, err)
+			}
+
+			// Exhaust the source leader's outbound catchup budget, as if
+			// another large catchup holds all of it, so the destination peers
+			// can't complete their store catchup until it's released.
+			sl := sc.clusterForName("C1").streamLeader(globalAccountName, "TEST")
+			require_NotNil(t, sl)
+			hold := new(int64)
+			sl.gcbAdd(hold, int64(1)<<30)
+
+			mset, err := sl.globalAccount().lookupStream("TEST")
+			require_NoError(t, err)
+			node := mset.raftNode()
+			require_NotNil(t, node)
+			require_Len(t, len(node.PeerNames()), 3)
+
+			// Compact the leader's raft log so the destination peers can't be
+			// caught up through raft-log replay alone. They'll receive a raft
+			// snapshot and must pull the stream data through the (stalled)
+			// out-of-band catchup.
+			require_NoError(t, node.InstallSnapshot(mset.stateSnapshot(), true))
+
+			// Move the stream to the other cluster.
+			_, err = js.UpdateStream(&nats.StreamConfig{
+				Name:      "TEST",
+				Replicas:  test.replicas,
+				Placement: &nats.Placement{Tags: []string{"cloud:gcp"}},
+			})
+			require_NoError(t, err)
+
+			// Wait for the migration to reach its hold point, with store
+			// catchups in flight.
+			checkFor(t, 20*time.Second, 100*time.Millisecond, func() error {
+				if peers := node.PeerNames(); len(peers) != test.holdPeers {
+					return fmt.Errorf("expected %d peers, got %d", test.holdPeers, len(peers))
+				}
+				if !mset.hasCatchupPeers() {
+					return fmt.Errorf("no store catchups in flight yet")
+				}
+				return nil
+			})
+
+			// While the destination peers can't complete their store catchup,
+			// the gate must hold: leadership stays on the source leader and
+			// the group must not shrink further.
+			for done := time.Now().Add(2 * time.Second); time.Now().Before(done); time.Sleep(250 * time.Millisecond) {
+				require_True(t, node.Leader())
+				require_Len(t, len(node.PeerNames()), test.holdPeers)
+			}
+
+			// Release the budget, catchups can now complete and the move finish.
+			sl.gcbSubLast(hold)
+
+			sc.waitOnStreamLeader(globalAccountName, "TEST")
+			checkFor(t, 30*time.Second, 100*time.Millisecond, func() error {
+				si, err := js.StreamInfo("TEST")
+				if err != nil {
+					return err
+				}
+				if si.Cluster.Name != "C2" {
+					return fmt.Errorf("wrong cluster: %q", si.Cluster.Name)
+				}
+				if si.Cluster.Leader == _EMPTY_ {
+					return fmt.Errorf("no leader yet")
+				} else if !strings.HasPrefix(si.Cluster.Leader, "C2") {
+					return fmt.Errorf("wrong leader: %q", si.Cluster.Leader)
+				}
+				if len(si.Cluster.Replicas) != test.finalReplicas {
+					return fmt.Errorf("expected %d replicas, got %d", test.finalReplicas, len(si.Cluster.Replicas))
+				}
+				if si.State.Msgs != uint64(toSend) {
+					return fmt.Errorf("only see %d msgs", si.State.Msgs)
+				}
+				return nil
+			})
+		})
+	}
+}
+
+func TestJetStreamSuperClusterMovingStreamStaleCatchupPeerDoesNotBlock(t *testing.T) {
+	sc := createJetStreamTaggedSuperCluster(t)
+	defer sc.shutdown()
+
+	nc, js := jsClientConnect(t, sc.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Replicas:  3,
+		Placement: &nats.Placement{Tags: []string{"cloud:aws"}},
+	})
+	require_NoError(t, err)
+
+	toSend := 100
+	for range toSend {
+		_, err = js.Publish("TEST", []byte("HELLO WORLD"))
+		require_NoError(t, err)
+	}
+
+	sl := sc.clusterForName("C1").streamLeader(globalAccountName, "TEST")
+	require_NotNil(t, sl)
+	mset, err := sl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	node := mset.raftNode()
+	require_NotNil(t, node)
+	require_Len(t, len(node.PeerNames()), 3)
+
+	// Pick an old peer that isn't us, it must be removed by the migration.
+	var stale string
+	for _, peer := range node.PeerNames() {
+		if peer != node.ID() {
+			stale = peer
+			break
+		}
+	}
+	require_NotEqual(t, stale, _EMPTY_)
+
+	// Move the stream to the other cluster.
+	_, err = js.UpdateStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Replicas:  3,
+		Placement: &nats.Placement{Tags: []string{"cloud:gcp"}},
+	})
+	require_NoError(t, err)
+
+	// Simulate an old peer whose catchup stalled and left its entry behind.
+	// runCatchup intentionally keeps the entry on a transient inactivity stall,
+	// and nothing clears it while we remain leader. Keep it set until both peer
+	// sets are in the group, so it's certain to be there once we start removing
+	// old peers. That peer is on its way out and doesn't need to become
+	// store-current, so it must not hold up the handover to the desired peers.
+	checkFor(t, 20*time.Second, 100*time.Millisecond, func() error {
+		mset.setCatchupPeer(stale, uint64(toSend))
+		if peers := node.PeerNames(); len(peers) != 6 {
+			return fmt.Errorf("expected 6 peers, got %d", len(peers))
+		}
+		return nil
+	})
+	require_True(t, mset.hasCatchupPeers())
+
+	// The migration must still complete, the stale entry must not wedge it.
+	sc.waitOnStreamLeader(globalAccountName, "TEST")
+	checkFor(t, 30*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("TEST")
+		if err != nil {
+			return err
+		}
+		if si.Cluster.Name != "C2" {
+			return fmt.Errorf("wrong cluster: %q", si.Cluster.Name)
+		}
+		if si.Cluster.Leader == _EMPTY_ {
+			return fmt.Errorf("no leader yet")
+		} else if !strings.HasPrefix(si.Cluster.Leader, "C2") {
+			return fmt.Errorf("wrong leader: %q", si.Cluster.Leader)
+		}
+		if len(si.Cluster.Replicas) != 2 {
+			return fmt.Errorf("expected 2 replicas, got %d", len(si.Cluster.Replicas))
+		}
+		if si.State.Msgs != uint64(toSend) {
+			return fmt.Errorf("only see %d msgs", si.State.Msgs)
+		}
+		return nil
+	})
+}
+
 func TestJetStreamSuperClusterImportConsumerStreamSubjectRemap(t *testing.T) {
 	template := `
 	listen: 127.0.0.1:-1

--- a/server/raft.go
+++ b/server/raft.go
@@ -69,6 +69,7 @@ type RaftNode interface {
 	Peers() []*Peer
 	PeerNames() []string
 	VotingPeerNames() []string
+	LastHeardFromPeer(peer string) time.Time
 	ProposeAddPeer(peer string) error
 	ProposeRemovePeer(peer string) error
 	EvictPeers(peers []string) ([]string, error)
@@ -180,9 +181,10 @@ type raft struct {
 	qn    int             // Number of nodes needed to establish quorum
 	peers map[string]*lps // Other peers in the Raft group
 
-	removed map[string]time.Time           // Peers that were removed from the group
-	acks    map[uint64]map[string]struct{} // Append entry responses/acks, map of entry index -> peer ID
-	pae     map[uint64]*appendEntry        // Pending append entries
+	removed  map[string]time.Time           // Peers that were removed from the group
+	observed map[string]time.Time           // Peers not in our peer set that we've heard from, only for managed groups
+	acks     map[uint64]map[string]struct{} // Append entry responses/acks, map of entry index -> peer ID
+	pae      map[uint64]*appendEntry        // Pending append entries
 
 	rescue *time.Timer // Non-nil while an unsafe quorum rescue is active (see RescueQuorum)
 	elect  *time.Timer // Election timer, normally accessed via electTimer
@@ -3969,16 +3971,39 @@ func (n *raft) trackPeer(peer string) error {
 	}
 	if ps := n.peers[peer]; ps != nil {
 		ps.ts = time.Now()
+		if n.observed != nil {
+			delete(n.observed, peer)
+			if len(n.observed) == 0 {
+				n.observed = nil
+			}
+		}
+	} else if n.managed && !isRemoved {
+		// For managed groups the meta layer can assign peers before they've been
+		// added to our peer set. Track when we hear from them, so the upper layer
+		// can prefer adding peers that are demonstrably up.
+		if n.observed == nil {
+			n.observed = make(map[string]time.Time, 1)
+		}
+		n.observed[peer] = time.Now()
 	}
-	// FIXME(mvv): if managed, could track meta assigned but not tracked peers here
-	//  that could help in preserving quorum if the meta assignment was updated but
-	//  it's not coming up on the new peer
 	n.Unlock()
 
 	if needPeerAdd {
 		n.ProposeAddPeer(peer)
 	}
 	return nil
+}
+
+// LastHeardFromPeer returns when we last heard from the given peer, even if
+// it's not in our peer set yet. Zero if we never heard from it. The upper
+// layer uses this to judge if a meta-assigned peer is up before adding it.
+func (n *raft) LastHeardFromPeer(peer string) time.Time {
+	n.RLock()
+	defer n.RUnlock()
+	if ps := n.peers[peer]; ps != nil {
+		return ps.ts
+	}
+	return n.observed[peer]
 }
 
 func (n *raft) runAsCandidate() {

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -3682,6 +3682,32 @@ func TestNRGDoesntRequestVoteOnWriteError(t *testing.T) {
 	require_Error(t, err, nats.ErrTimeout)
 }
 
+func TestNRGTrackPeerObserved(t *testing.T) {
+	n := &raft{managed: true, id: "A", peers: map[string]*lps{"A": {}}}
+
+	// Untracked peers of managed groups are observed when we hear from them.
+	require_True(t, n.LastHeardFromPeer("B").IsZero())
+	require_NoError(t, n.trackPeer("B"))
+	require_False(t, n.LastHeardFromPeer("B").IsZero())
+
+	// Members are tracked through their own peer state.
+	require_True(t, n.LastHeardFromPeer("A").IsZero())
+	require_NoError(t, n.trackPeer("A"))
+	require_False(t, n.LastHeardFromPeer("A").IsZero())
+
+	// Once the peer becomes a member, the observed entry is cleaned up.
+	require_Len(t, len(n.observed), 1)
+	n.peers["B"] = &lps{}
+	require_NoError(t, n.trackPeer("B"))
+	require_Len(t, len(n.observed), 0)
+	require_False(t, n.LastHeardFromPeer("B").IsZero())
+
+	// Removed peers are not observed.
+	n.removed = map[string]time.Time{"C": time.Now()}
+	require_NoError(t, n.trackPeer("C"))
+	require_True(t, n.LastHeardFromPeer("C").IsZero())
+}
+
 func TestNRGInitializeAndScaleUp(t *testing.T) {
 	n, cleanup := initSingleMemRaftNode(t)
 	defer cleanup()


### PR DESCRIPTION
This PR fixes two remaining issues, and removes the final two FIXMEs:
  
- Migrations would add peers as fast as possible, without checking whether the peer being added was even online. Adding an offline peer grows the quorum size, which could drop the group out of quorum until enough nodes came online. `selectPeerToAdd` now prefers the candidate we've heard from most recently, and only adds an unheard peer if the live members still reach quorum in the grown group.
- Migrations also didn't wait for upper-layer stream catchup to complete before removing old peers. An old peer is now only removed if the group left after the removal retains a store-current majority, based on `Current`/`Lag` and the stream's active `catchupPeers`.

Follow-up of https://github.com/nats-io/nats-server/pull/8432

