### PR TITLE
Make reverse response map removal constant time

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -196,6 +196,75 @@ type serviceRespEntry struct {
 	msub string
 }
 
+// rrIndexThreshold is the number of outstanding responses sharing a single
+// reply subject above which we build an index for constant time removal.
+// Reply subjects are normally unique per request, so the overwhelming majority
+// of entries stay a one element list and never allocate the index.
+const rrIndexThreshold = 16
+
+// respEntries holds the outstanding response entries for one reply subject.
+// The list is authoritative and unordered; idx, when present, maps a response
+// subject to its position in the list. Once allocated the index is kept for as
+// long as the reply subject has any entry left, since a subject that has been
+// shared once tends to be shared again.
+//
+// This is held by value in importMap.rrMap, so mutating it means writing it
+// back under its key. Add and remove entries through importMap.addRespEntry
+// and importMap.removeRespEntry, which keep that write back in one place,
+// rather than calling the methods below directly.
+type respEntries struct {
+	list []*serviceRespEntry
+	idx  map[string]int
+}
+
+// add appends an entry, building or maintaining the index as needed.
+func (re *respEntries) add(sre *serviceRespEntry) {
+	re.list = append(re.list, sre)
+	if re.idx != nil {
+		re.idx[sre.msub] = len(re.list) - 1
+		return
+	}
+	if len(re.list) > rrIndexThreshold {
+		re.idx = make(map[string]int, len(re.list))
+		for i, e := range re.list {
+			re.idx[e.msub] = i
+		}
+	}
+}
+
+// remove drops the entry for msub, in constant time once indexed.
+func (re *respEntries) remove(msub string) {
+	i := -1
+	if re.idx != nil {
+		var ok bool
+		if i, ok = re.idx[msub]; !ok {
+			return
+		}
+		delete(re.idx, msub)
+	} else {
+		for j, e := range re.list {
+			if e.msub == msub {
+				i = j
+				break
+			}
+		}
+		if i < 0 {
+			return
+		}
+	}
+	// Swap with the last entry so removal does not shift the whole list.
+	last := len(re.list) - 1
+	if i != last {
+		moved := re.list[last]
+		re.list[i] = moved
+		if re.idx != nil {
+			re.idx[moved.msub] = i
+		}
+	}
+	re.list[last] = nil
+	re.list = re.list[:last]
+}
+
 // ServiceRespType represents the types of service request response types.
 type ServiceRespType uint8
 
@@ -266,7 +335,34 @@ type exportMap struct {
 type importMap struct {
 	streams  []*streamImport
 	services map[string][]*serviceImport
-	rrMap    map[string][]*serviceRespEntry
+	rrMap    map[string]respEntries
+}
+
+// addRespEntry records an outstanding response entry under reply.
+// Lock should be held on the owning account.
+func (im *importMap) addRespEntry(reply string, sre *serviceRespEntry) {
+	if im.rrMap == nil {
+		im.rrMap = make(map[string]respEntries)
+	}
+	re := im.rrMap[reply]
+	re.add(sre)
+	im.rrMap[reply] = re
+}
+
+// removeRespEntry drops the outstanding response entry for msub under reply,
+// dropping the reply subject itself once its last entry goes.
+// Lock should be held on the owning account.
+func (im *importMap) removeRespEntry(reply, msub string) {
+	re, ok := im.rrMap[reply]
+	if !ok {
+		return
+	}
+	re.remove(msub)
+	if len(re.list) == 0 {
+		delete(im.rrMap, reply)
+	} else {
+		im.rrMap[reply] = re
+	}
 }
 
 // NewAccount creates a new unlimited account with the given name.
@@ -1872,12 +1968,7 @@ func (a *Account) removeServiceImport(dstAccName, subject string) {
 // This tracks responses to service requests mappings. This is used for cleanup.
 func (a *Account) addReverseRespMapEntry(acc *Account, reply, from string) {
 	a.mu.Lock()
-	if a.imports.rrMap == nil {
-		a.imports.rrMap = make(map[string][]*serviceRespEntry)
-	}
-	sre := &serviceRespEntry{acc, from}
-	sra := a.imports.rrMap[reply]
-	a.imports.rrMap[reply] = append(sra, sre)
+	a.imports.addRespEntry(reply, &serviceRespEntry{acc, from})
 	a.mu.Unlock()
 }
 
@@ -1957,7 +2048,7 @@ func (a *Account) _checkForReverseEntry(reply string, si *serviceImport, checkIn
 		return
 	}
 
-	if sres := a.imports.rrMap[reply]; sres == nil {
+	if _, ok := a.imports.rrMap[reply]; !ok {
 		a.mu.RUnlock()
 		return
 	}
@@ -1979,22 +2070,18 @@ func (a *Account) _checkForReverseEntry(reply string, si *serviceImport, checkIn
 	// Delete the appropriate entries here based on optional si.
 	a.mu.Lock()
 	// We need a new lookup here because we have released the lock.
-	sres := a.imports.rrMap[reply]
+	var sres []*serviceRespEntry
 	if si == nil {
+		sres = a.imports.rrMap[reply].list
 		delete(a.imports.rrMap, reply)
-	} else if sres != nil {
-		// Find the one we are looking for..
-		for i, sre := range sres {
-			if sre.msub == si.from {
-				sres = append(sres[:i], sres[i+1:]...)
-				break
-			}
-		}
-		if len(sres) > 0 {
-			a.imports.rrMap[si.to] = sres
-		} else {
-			delete(a.imports.rrMap, si.to)
-		}
+	} else {
+		// Constant time once indexed, instead of a linear scan across every
+		// outstanding response that happens to share this reply subject.
+		// This also keys the write back off reply rather than si.to. Every
+		// caller reaches here with si.to equal to reply, so behavior is
+		// unchanged, but the lookup and the write back can no longer drift
+		// apart if that ever stops holding.
+		a.imports.removeRespEntry(reply, si.from)
 	}
 	a.mu.Unlock()
 

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -17,6 +17,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"slices"
 	"strconv"
@@ -4368,4 +4369,214 @@ func TestAccountSendTrackingLatencyRcRace(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+// sharedInboxRequests stands up a foo/bar service export/import pair and has
+// bar send numReqs requests that all share one reply subject. The responder
+// never answers, so every response is left outstanding under that single rrMap
+// key. Returns both accounts and the shared reply subject.
+func sharedInboxRequests(t *testing.T, numReqs int) (*Account, *Account, string) {
+	t.Helper()
+
+	s, fooAcc, barAcc := simpleAccountServer(t)
+	t.Cleanup(s.Shutdown)
+
+	if err := fooAcc.AddServiceExport("test", nil); err != nil {
+		t.Fatalf("Error adding service export: %v", err)
+	}
+	if err := barAcc.AddServiceImport(fooAcc, "test", _EMPTY_); err != nil {
+		t.Fatalf("Error adding service import: %v", err)
+	}
+
+	// Both connections are net.Pipe, so anything the server writes blocks until
+	// it is read. Drain them, otherwise the write loops sit on the flush
+	// deadline and shutdown takes ten seconds.
+	cfoo, rfoo, _ := newClientForServer(s)
+	t.Cleanup(cfoo.close)
+	go io.Copy(io.Discard, rfoo)
+	if err := cfoo.registerWithAccount(fooAcc); err != nil {
+		t.Fatalf("Error registering client with 'foo' account: %v", err)
+	}
+	// Responder never answers, so the entries stay outstanding.
+	cfoo.parse([]byte("SUB test 1\r\n"))
+
+	cbar, rbar, _ := newClientForServer(s)
+	t.Cleanup(cbar.close)
+	go io.Copy(io.Discard, rbar)
+	if err := cbar.registerWithAccount(barAcc); err != nil {
+		t.Fatalf("Error registering client with 'bar' account: %v", err)
+	}
+
+	const inbox = "my.inbox"
+	cbar.parse([]byte("SUB my.inbox 11\r\n"))
+	for i := 0; i < numReqs; i++ {
+		cbar.parse([]byte("PUB test my.inbox 4\r\nhelp\r\n"))
+	}
+
+	return fooAcc, barAcc, inbox
+}
+
+// A client is allowed to reuse a single reply subject across many concurrent
+// service import requests, which piles every outstanding response entry under
+// one rrMap key. Make sure those entries are tracked and removed correctly in
+// both the small (unindexed) and large (indexed) cases.
+func TestServiceImportReverseEntriesSharedReplySubject(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		numReqs int
+		indexed bool
+	}{
+		{"below index threshold", rrIndexThreshold - 1, false},
+		{"above index threshold", rrIndexThreshold * 100, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fooAcc, barAcc, inbox := sharedInboxRequests(t, test.numReqs)
+
+			barAcc.mu.RLock()
+			re, ok := barAcc.imports.rrMap[inbox]
+			numEntries, indexed := len(re.list), re.idx != nil
+			barAcc.mu.RUnlock()
+
+			if !ok {
+				t.Fatalf("Expected a reverse entry for %q", inbox)
+			}
+			if numEntries != test.numReqs {
+				t.Fatalf("Expected %d reverse entries, got %d", test.numReqs, numEntries)
+			}
+			if indexed != test.indexed {
+				t.Fatalf("Expected indexed to be %v, got %v", test.indexed, indexed)
+			}
+
+			// Now expire them the way the response threshold timer does, and make
+			// sure every entry is accounted for as we go.
+			fooAcc.mu.RLock()
+			var expired []*serviceImport
+			for _, si := range fooAcc.exports.responses {
+				expired = append(expired, si)
+			}
+			fooAcc.mu.RUnlock()
+
+			if len(expired) != test.numReqs {
+				t.Fatalf("Expected %d outstanding responses, got %d", test.numReqs, len(expired))
+			}
+
+			for i, si := range expired {
+				fooAcc.removeRespServiceImport(si, rsiTimeout)
+				barAcc.mu.RLock()
+				re, ok := barAcc.imports.rrMap[inbox]
+				remaining := len(re.list)
+				idxLen := len(re.idx)
+				barAcc.mu.RUnlock()
+
+				if expect := test.numReqs - i - 1; remaining != expect {
+					t.Fatalf("After %d removals expected %d entries, got %d", i+1, expect, remaining)
+				} else if expect == 0 {
+					if ok {
+						t.Fatalf("Expected the reverse entry for %q to be removed once empty", inbox)
+					}
+				} else if re.idx != nil && idxLen != remaining {
+					t.Fatalf("Index out of sync with list: %d vs %d", idxLen, remaining)
+				}
+			}
+
+			fooAcc.mu.RLock()
+			left := len(fooAcc.exports.responses)
+			fooAcc.mu.RUnlock()
+			if left != 0 {
+				t.Fatalf("Expected no outstanding responses left, got %d", left)
+			}
+		})
+	}
+}
+
+// The other removal path drops a whole reply subject at once instead of one
+// entry at a time. That is what runs when interest in the reply subject goes
+// away, so it is the path a disconnecting requestor takes.
+func TestServiceImportReverseEntriesBulkRemoval(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		numReqs int
+	}{
+		{"below index threshold", rrIndexThreshold - 1},
+		{"above index threshold", rrIndexThreshold * 100},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fooAcc, barAcc, inbox := sharedInboxRequests(t, test.numReqs)
+
+			fooAcc.mu.RLock()
+			outstanding := len(fooAcc.exports.responses)
+			fooAcc.mu.RUnlock()
+			if outstanding != test.numReqs {
+				t.Fatalf("Expected %d outstanding responses, got %d", test.numReqs, outstanding)
+			}
+
+			// A nil si means drop every entry under this reply subject and clean
+			// up the responses they point at on the exporting account.
+			barAcc.checkForReverseEntry(inbox, nil, false)
+
+			barAcc.mu.RLock()
+			_, ok := barAcc.imports.rrMap[inbox]
+			remaining := len(barAcc.imports.rrMap)
+			barAcc.mu.RUnlock()
+			if ok {
+				t.Fatalf("Expected the reverse entry for %q to be gone", inbox)
+			}
+			if remaining != 0 {
+				t.Fatalf("Expected no reverse entries left, got %d", remaining)
+			}
+
+			fooAcc.mu.RLock()
+			outstanding = len(fooAcc.exports.responses)
+			fooAcc.mu.RUnlock()
+			if outstanding != 0 {
+				t.Fatalf("Expected every outstanding response to be cleaned up, got %d", outstanding)
+			}
+		})
+	}
+}
+
+// Guards the cost of clearing outstanding responses. Each iteration clears the
+// whole set, so ns/op is the cost of draining n entries, not of one removal.
+// The shared case is the one that used to go quadratic; the unique case is the
+// common one and should stay where it is.
+func BenchmarkReverseRespMapRemoval(b *testing.B) {
+	for _, bench := range []struct {
+		name   string
+		shared bool
+	}{
+		{"SharedReplySubject", true},
+		{"UniqueReplySubjects", false},
+	} {
+		for _, n := range []int{1000, 10000, 40000} {
+			b.Run(fmt.Sprintf("%s/%d", bench.name, n), func(b *testing.B) {
+				replies, sis := make([]string, n), make([]*serviceImport, n)
+				for i := 0; i < n; i++ {
+					if bench.shared {
+						replies[i] = "my.inbox"
+					} else {
+						replies[i] = fmt.Sprintf("my.inbox.%d", i)
+					}
+					sis[i] = &serviceImport{from: fmt.Sprintf("_R_.%d", i), to: replies[i]}
+				}
+
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+					acc := NewAccount("bar")
+					for j := 0; j < n; j++ {
+						acc.addReverseRespMapEntry(acc, replies[j], sis[j].from)
+					}
+					b.StartTimer()
+
+					for j := 0; j < n; j++ {
+						acc.checkForReverseEntry(replies[j], sis[j], false)
+					}
+
+					if left := len(acc.imports.rrMap); left != 0 {
+						b.Fatalf("Expected no reverse entries left, got %d", left)
+					}
+				}
+			})
+		}
+	}
 }


### PR DESCRIPTION
Relates to #6307.

## Problem

A client may reuse a single reply subject across many concurrent service import requests. Nothing forbids this, and `nats.go`'s legacy pull subscription `Fetch` does exactly that — `newFetchInbox` returns the subscription's inbox unchanged for a non-wildcard subject, so every pull request on that subscription shares one reply subject.

Every outstanding response for a reply subject is appended to one slice in `Account.imports.rrMap`, and `_checkForReverseEntry` removes an entry by scanning that slice for a matching response subject:

```go
for i, sre := range sres {
    if sre.msub == si.from {
        sres = append(sres[:i], sres[i+1:]...)
        break
    }
}
```

When entries share a reply subject the slice length tracks the number of outstanding responses, so each removal is O(n) and clearing them all is O(n²).

That matters because `checkExpiredResponses` walks every outstanding response on each pass and re-arms its timer only once the pass has finished. Past a certain backlog a pass no longer completes within the response threshold, so the reaper falls permanently behind: the backlog grows, the next pass gets slower, and the account's memory grows without bound. We hit this on a production cluster where one `$SYS` response map reached ~1.5M entries with ~1.18M of them under a single reply subject, on a server pinned at ~1100–1400% CPU. Restarting the server is currently the only way out.

This is, I believe, the mechanism behind #6307, which we opened in Dec 2024 and where we posted heap profiles and `accountz` captures in May: the in-use heap on the affected pods is dominated by `addRespServiceImport` / `addReverseRespMapEntry` / `setupResponseServiceImport`, the entries sit on the system account's `exports.responses`, and the source is the auto-injected `$JS.API.>` import that `enableAllJetStreamServiceImportsAndMappings` creates for every JetStream-enabled account. What we could not explain at the time was why the entries were not simply expiring at the 2 minute response threshold. The answer is that they are, but the reaper cannot keep up once removal has gone quadratic, so it falls behind and never catches back up. That also explains an observation from that thread which puzzled us: the bloated pod was sometimes an API hot-spot and sometimes held zero stream leaders, because what matters is not how much JetStream work the node does, but whether a client on that node reuses one reply subject.

`$JS.API.CONSUMER.MSG.NEXT` is already special-cased in `processServiceImport` for what looks like this reason, but every other JS API call and every user-defined service export still take this path.

## Change

Keep the slice — that is what the common case wants, since reply subjects are normally unique per request and the list holds a single entry — but build an index once a reply subject accumulates more than `rrIndexThreshold` (16) outstanding responses. Removal then swaps with the last entry instead of shifting, and finds its target through the index.

`respEntries` is held by value in `rrMap`, so a mutation has to be written back under its key. Rather than leave that to each caller, `importMap` owns `addRespEntry` and `removeRespEntry` and the write back lives in one place.

The removal path also keys off `reply` throughout. It previously looked the entry up under `reply` but wrote the remainder back under `si.to`. **Every caller reaches that code with the two equal**, so this is not a behaviour change — entries are only ever added under `to`, and the sole `si != nil` removal path is `removeRespServiceImport` → `checkForReverseEntry(to, si, false)`. It removes a mismatch between the key read and the key written, nothing more. An earlier revision of this description claimed it fixed a reachable bug; it does not.

## Numbers

`BenchmarkReverseRespMapRemoval` clears n outstanding responses, so ns/op is the cost of draining the whole set. Apple M3, `-benchtime 5x`:

| shared reply subject | before | after |
|---|---|---|
| 1000 | 102.6µs | 85.0µs |
| 10000 | 5.148ms | 0.795ms |
| 40000 | 103.197ms | 3.349ms |

| unique reply subjects | before | after |
|---|---|---|
| 1000 | 98.3µs | 86.6µs |
| 10000 | 0.856ms | 0.851ms |
| 40000 | 3.611ms | 3.349ms |

The quadratic growth is visible in the shared column before the change: four times the entries costs twenty times the work. After it, and in the unique case throughout, cost is linear in the number of entries. Allocations are identical in both columns of the unique case (39898 allocs/op, 1842411 B/op at n=40000), since the index is never allocated for a reply subject holding a single entry.

Separately, measured over 50k requests each with its own reply subject, steady-state cost is **380.6 vs 370.2 bytes** per outstanding request. An earlier version of this patch replaced the slice with a plain `map[string]*serviceRespEntry` and cost 590.1 bytes per request, which is why the threshold exists.

## Testing

- `TestServiceImportReverseEntriesSharedReplySubject` covers both the unindexed and indexed paths, removing entries one at a time and asserting the index stays in sync with the list.
- `TestServiceImportReverseEntriesBulkRemoval` covers the other removal path, where `si == nil` drops a whole reply subject at once and cleans up the matching responses on the exporting account. That is what runs when interest in the reply subject goes away.
- `BenchmarkReverseRespMapRemoval` guards the complexity in-tree rather than only in this description.

Note the previous behaviour was correct, only slow, so these tests guard the invariant this change introduces rather than reproducing a wrong result.

Both tests share a `sharedInboxRequests` helper which drains the `net.Pipe` connections it creates. Without that drain the server's write loops sit on the flush deadline and each subtest spends 10 seconds in `Shutdown`; with it the two tests together run in under two seconds.

I ran `go test ./server -run 'Service|Import|Export|Response|Account|Latency'` on this branch and on `main` for comparison, and both passed. On one earlier run this branch hit `TestLeafNodeWithWeightedDQRequestsToSuperClusterWithSeparateAccounts` failing its final `require_True(t, r2.Load() > r1.Load())`. That test drains subscribers based on `rand.Intn(6) > 4` and then asserts a distribution, and it passes in isolation on both this branch and `main`, so I believe it is unrelated flakiness — but I am flagging it rather than hiding it, in case you read it differently.

I have not run the full suite, only that subset plus the JetStream tests touching accounts. Happy to run more, or to rework the approach if you would rather solve this a different way — for instance by bounding the reaper's work per pass instead, which the `TODO(dlc)` in `processServiceImport` hints at.
