### PR TITLE
[FIXED] Missing stream snapshot on shutdown, plus test de-flakes

### DIFF
--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -3698,6 +3698,25 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 		failedSnapshots  int
 	)
 
+	// Make sure all pending data is flushed before allowing snapshots. Returns false if
+	// it couldn't be flushed, in which case we have no safe way to continue.
+	flushPending := func() bool {
+		err := mset.flushAllPending()
+		if err == nil {
+			return true
+		}
+		s.Errorf("Failed to flush pending data for '%s > %s' [%s]: %v", accName, mset.name(), n.Group(), err)
+		assert.Unreachable("Stream snapshot flush failed", map[string]any{
+			"account": accName,
+			"stream":  mset.name(),
+			"group":   n.Group(),
+			"err":     err,
+		})
+		mset.setWriteErr(err)
+		n.Stop()
+		return false
+	}
+
 	doSnapshot := func(force bool) {
 		// Suppress during recovery.
 		if mset == nil || isRecovering || isRestore {
@@ -3705,6 +3724,20 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 		}
 		snapMu.Lock()
 		defer snapMu.Unlock()
+
+		// Don't suppress a snapshot during shutdown.
+		if js.isShuttingDown() {
+			if !flushPending() {
+				return
+			}
+			if err := n.InstallSnapshot(mset.stateSnapshot(), true); err != nil &&
+				err != errNoSnapAvailable && err != errNodeClosed {
+				s.RateLimitWarnf("Failed to install snapshot for '%s > %s' [%s]: %v",
+					mset.acc.Name, mset.name(), n.Group(), err)
+			}
+			return
+		}
+
 		// If snapshots have failed, and we're not forced to, we'll wait for the timer since it'll now be forced.
 		if !force && failedSnapshots > 0 {
 			return
@@ -3732,20 +3765,8 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 			}
 			return
 		}
-
-		// Make sure all pending data is flushed before allowing snapshots.
-		if err := mset.flushAllPending(); err != nil {
-			// If the pending data couldn't be flushed, we have no safe way to continue.
-			s.Errorf("Failed to flush pending data for '%s > %s' [%s]: %v", accName, mset.name(), n.Group(), err)
-			assert.Unreachable("Stream snapshot flush failed", map[string]any{
-				"account": accName,
-				"stream":  mset.name(),
-				"group":   n.Group(),
-				"err":     err,
-			})
+		if !flushPending() {
 			c.Abort()
-			mset.setWriteErr(err)
-			n.Stop()
 			return
 		}
 
@@ -3902,19 +3923,13 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 		select {
 		case <-s.quitCh:
 			// Server shutting down, but we might receive this before qch, so try to snapshot.
-			snapMu.Lock()
-			fallbackSnapshot = true
-			snapMu.Unlock()
 			doSnapshot(false)
 			return
 		case <-mqch:
 			// Clean signal from shutdown routine so do best effort attempt to snapshot.
 			// Don't snapshot if not shutting down, monitor goroutine could be going away
 			// on a scale down or a remove for example.
-			if s.isShuttingDown() {
-				snapMu.Lock()
-				fallbackSnapshot = true
-				snapMu.Unlock()
+			if js.isShuttingDown() {
 				doSnapshot(false)
 			}
 			return

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -9239,13 +9239,13 @@ func TestJetStreamClusterStreamHealthCheckMustNotRecreate(t *testing.T) {
 		sa.Created = time.Time{}
 		return sjs, acc, sa, mset
 	}
-	checkNodeIsClosed := func(sa *streamAssignment) {
+	checkNodeIsClosed := func(sjs *jetStream, sa *streamAssignment) {
 		t.Helper()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
 		require_True(t, sa.Group != nil)
-		rg := sa.Group
-		require_True(t, rg.node != nil)
-		n := rg.node
-		require_Equal(t, n.State(), Closed)
+		require_True(t, sa.Group.node != nil)
+		require_Equal(t, sa.Group.node.State(), Closed)
 	}
 
 	_, err := js.AddStream(&nats.StreamConfig{
@@ -9259,10 +9259,15 @@ func TestJetStreamClusterStreamHealthCheckMustNotRecreate(t *testing.T) {
 	// We manually stop the RAFT node and ensure it doesn't get restarted.
 	rs := c.randomNonStreamLeader(globalAccountName, "TEST")
 	sjs, acc, sa, mset := getStreamAssignment(rs)
-	require_True(t, sa.Group != nil)
+	sjs.mu.RLock()
 	rg := sa.Group
-	require_True(t, rg.node != nil)
-	n := rg.node
+	var n RaftNode
+	if rg != nil {
+		n = rg.node
+	}
+	sjs.mu.RUnlock()
+	require_True(t, rg != nil)
+	require_True(t, n != nil)
 	n.Stop()
 	n.WaitForStop()
 
@@ -9281,9 +9286,9 @@ func TestJetStreamClusterStreamHealthCheckMustNotRecreate(t *testing.T) {
 
 	// The RAFT node should be closed. Checking health must not change that.
 	// Simulates a race condition where we're shutting down, but we're still in the stream monitor.
-	checkNodeIsClosed(sa)
+	checkNodeIsClosed(sjs, sa)
 	sjs.isStreamHealthy(acc, sa)
-	checkNodeIsClosed(sa)
+	checkNodeIsClosed(sjs, sa)
 
 	err = js.DeleteStream("TEST")
 	require_NoError(t, err)
@@ -9301,9 +9306,9 @@ func TestJetStreamClusterStreamHealthCheckMustNotRecreate(t *testing.T) {
 	sjs.mu.Unlock()
 
 	// The underlying stream has been deleted. Checking health must not recreate the stream.
-	checkNodeIsClosed(sa)
+	checkNodeIsClosed(sjs, sa)
 	sjs.isStreamHealthy(acc, sa)
-	checkNodeIsClosed(sa)
+	checkNodeIsClosed(sjs, sa)
 }
 
 func TestJetStreamClusterStreamHealthCheckMustNotDeleteEarly(t *testing.T) {
@@ -9557,13 +9562,13 @@ func TestJetStreamClusterConsumerHealthCheckMustNotRecreate(t *testing.T) {
 		ca.Created = time.Time{}
 		return sjs, sa, ca, mset
 	}
-	checkNodeIsClosed := func(ca *consumerAssignment) {
+	checkNodeIsClosed := func(sjs *jetStream, ca *consumerAssignment) {
 		t.Helper()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
 		require_True(t, ca.Group != nil)
-		rg := ca.Group
-		require_True(t, rg.node != nil)
-		n := rg.node
-		require_Equal(t, n.State(), Closed)
+		require_True(t, ca.Group.node != nil)
+		require_Equal(t, ca.Group.node.State(), Closed)
 	}
 
 	_, err := js.AddStream(&nats.StreamConfig{
@@ -9580,10 +9585,15 @@ func TestJetStreamClusterConsumerHealthCheckMustNotRecreate(t *testing.T) {
 	// We manually stop the RAFT node and ensure it doesn't get restarted.
 	rs := c.randomNonConsumerLeader(globalAccountName, "TEST", "CONSUMER")
 	sjs, sa, ca, mset := getConsumerAssignment(rs)
-	require_True(t, ca.Group != nil)
+	sjs.mu.RLock()
 	rg := ca.Group
-	require_True(t, rg.node != nil)
-	n := rg.node
+	var n RaftNode
+	if rg != nil {
+		n = rg.node
+	}
+	sjs.mu.RUnlock()
+	require_True(t, rg != nil)
+	require_True(t, n != nil)
 	n.Stop()
 	n.WaitForStop()
 
@@ -9598,9 +9608,9 @@ func TestJetStreamClusterConsumerHealthCheckMustNotRecreate(t *testing.T) {
 
 	// The RAFT node should be closed. Checking health must not change that.
 	// Simulates a race condition where we're shutting down.
-	checkNodeIsClosed(ca)
+	checkNodeIsClosed(sjs, ca)
 	require_Error(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca), errors.New("monitor goroutine not running"))
-	checkNodeIsClosed(ca)
+	checkNodeIsClosed(sjs, ca)
 
 	// We create a new RAFT group, the health check should detect this skew.
 	_, err = sjs.createRaftGroup(globalAccountName, ca.Group, false, MemoryStorage, pprofLabels{})
@@ -9628,9 +9638,9 @@ func TestJetStreamClusterConsumerHealthCheckMustNotRecreate(t *testing.T) {
 	sjs.mu.Unlock()
 
 	// The underlying consumer has been deleted. Checking health must not recreate the consumer.
-	checkNodeIsClosed(ca)
+	checkNodeIsClosed(sjs, ca)
 	require_Error(t, sjs.isConsumerHealthy(mset, "CONSUMER", ca), errors.New("consumer not found"))
-	checkNodeIsClosed(ca)
+	checkNodeIsClosed(sjs, ca)
 }
 
 func TestJetStreamClusterConsumerHealthCheckMustNotDeleteEarly(t *testing.T) {

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -5885,6 +5885,10 @@ func TestJetStreamClusterPeerOffline(t *testing.T) {
 }
 
 func TestJetStreamClusterNoQuorumStepdown(t *testing.T) {
+	lqi := lostQuorumInterval
+	lostQuorumInterval = 2 * time.Second
+	defer func() { lostQuorumInterval = lqi }()
+
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -11525,7 +11525,7 @@ func TestJetStreamClusterCreateR3StreamWithOfflineNodes(t *testing.T) {
 	c.waitOnLeader()
 	c.waitOnStreamLeader(globalAccountName, "FOO")
 	c.waitOnStreamLeader(globalAccountName, "BAR")
-	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
+	checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
 		if err := checkState(t, c, globalAccountName, "FOO"); err != nil {
 			return err
 		}

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -11354,13 +11354,34 @@ func TestJetStreamClusterSnapshotStreamAssetOnShutdown(t *testing.T) {
 		sds = append(sds, s.StoreDir())
 	}
 
-	for _, sd := range sds {
-		matches, err := filepath.Glob(filepath.Join(sd, "$SYS", "_js_", "*", snapshotsDir, "*"))
-		require_NoError(t, err)
-		require_True(t, len(matches) > 0)
-		for _, match := range matches {
-			require_NoError(t, os.RemoveAll(match))
+	// Snapshots installed for the stream's Raft group. Skips temporary files, an
+	// install writes into one before renaming it into place.
+	streamSnapshots := func(sd string) ([]string, error) {
+		matches, err := filepath.Glob(filepath.Join(sd, "$SYS", "_js_", "*", snapshotsDir))
+		if err != nil {
+			return nil, err
 		}
+		// Matches _meta_ and stream raft groups.
+		if len(matches) != 2 {
+			return nil, fmt.Errorf("expected 2 snapshot dirs for %s, got %d", sd, len(matches))
+		}
+		for _, match := range matches {
+			if !strings.Contains(match, "S-R3F") {
+				continue
+			}
+			entries, err := os.ReadDir(match)
+			if err != nil {
+				return nil, err
+			}
+			var snaps []string
+			for _, entry := range entries {
+				if name := entry.Name(); !strings.HasSuffix(name, ".tmp") {
+					snaps = append(snaps, name)
+				}
+			}
+			return snaps, nil
+		}
+		return nil, fmt.Errorf("no stream raft group for %s", sd)
 	}
 
 	// Publish, so we have something new to snapshot.
@@ -11370,28 +11391,29 @@ func TestJetStreamClusterSnapshotStreamAssetOnShutdown(t *testing.T) {
 		return checkState(t, c, globalAccountName, "TEST")
 	})
 
+	applied := make(map[string]uint64, len(sds))
+	for i, s := range c.servers {
+		mset, err := s.globalAccount().lookupStream("TEST")
+		require_NoError(t, err)
+		_, _, a := mset.raftNode().Progress()
+		applied[sds[i]] = a
+	}
+
 	// Shutdown servers, and check if all made stream snapshots.
 	for _, s := range c.servers {
 		s.Shutdown()
 	}
 	for _, sd := range sds {
-		matches, err := filepath.Glob(filepath.Join(sd, "$SYS", "_js_", "*", snapshotsDir))
+		snaps, err := streamSnapshots(sd)
 		require_NoError(t, err)
-		// Matches _meta_ and stream raft groups.
-		require_Len(t, len(matches), 2)
-		var foundStream bool
-		for _, match := range matches {
-			if !strings.Contains(match, "S-R3F") {
-				continue
-			}
-			foundStream = true
-			dirs, err := os.ReadDir(match)
-			require_NoError(t, err)
-			if len(dirs) != 1 {
-				t.Errorf("Missing snapshot for %s", match)
-			}
+		if len(snaps) != 1 {
+			t.Fatalf("Expected 1 snapshot for %s, got %d: %v", sd, len(snaps), snaps)
 		}
-		require_True(t, foundStream)
+		_, index, err := termAndIndexFromSnapFile(snaps[0])
+		require_NoError(t, err)
+		if index < applied[sd] {
+			t.Fatalf("Snapshot %s for %s doesn't cover applied index %d", snaps[0], sd, applied[sd])
+		}
 	}
 }
 

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -11606,33 +11606,34 @@ func TestJetStreamClusterAsyncFlushBasics(t *testing.T) {
 		var s *Server
 		checkStoreIsAsync := func(expectAsync bool) {
 			t.Helper()
-			mset, err := s.globalAccount().lookupStream("TEST")
-			require_NoError(t, err)
-			fs := mset.Store().(*fileStore)
-			fs.mu.RLock()
-			lmb := fs.lmb
-			asyncFlush := fs.fcfg.AsyncFlush
-			fip := fs.fip
-			fs.mu.RUnlock()
-			require_Equal(t, asyncFlush, expectAsync)
-			require_Equal(t, fip, !expectAsync)
-			require_NotNil(t, lmb)
-			lmb.mu.RLock()
-			flusher := lmb.flusher
-			lmb.mu.RUnlock()
-			if expectAsync {
-				if !flusher {
-					t.Fatal("flusher not initialized")
-				} else if !asyncFlush {
-					t.Fatal("async flush config not set")
+			checkFor(t, 2*time.Second, 50*time.Millisecond, func() error {
+				mset, err := s.globalAccount().lookupStream("TEST")
+				if err != nil {
+					return err
 				}
-			} else {
-				if flusher {
-					t.Fatal("flusher still initialized")
-				} else if asyncFlush {
-					t.Fatal("async flush config not reset")
+				fs := mset.Store().(*fileStore)
+				fs.mu.RLock()
+				lmb := fs.lmb
+				asyncFlush := fs.fcfg.AsyncFlush
+				fip := fs.fip
+				fs.mu.RUnlock()
+				if asyncFlush != expectAsync {
+					return fmt.Errorf("expected async flush config %v, got %v", expectAsync, asyncFlush)
 				}
-			}
+				if fip != !expectAsync {
+					return fmt.Errorf("expected flush in place %v, got %v", !expectAsync, fip)
+				}
+				if lmb == nil {
+					return errors.New("expected last message block to be set")
+				}
+				lmb.mu.RLock()
+				flusher := lmb.flusher
+				lmb.mu.RUnlock()
+				if flusher != expectAsync {
+					return fmt.Errorf("expected flusher initialized %v, got %v", expectAsync, flusher)
+				}
+				return nil
+			})
 		}
 
 		cfg := &StreamConfig{
@@ -11653,6 +11654,7 @@ func TestJetStreamClusterAsyncFlushBasics(t *testing.T) {
 		cfg.Replicas = 3
 		_, err = jsStreamUpdate(t, nc, cfg)
 		require_NoError(t, err)
+		c.waitOnStreamLeader(globalAccountName, "TEST")
 		checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
 			return checkState(t, c, globalAccountName, "TEST")
 		})
@@ -11664,6 +11666,7 @@ func TestJetStreamClusterAsyncFlushBasics(t *testing.T) {
 		cfg.Replicas = 1
 		_, err = jsStreamUpdate(t, nc, cfg)
 		require_NoError(t, err)
+		c.waitOnStreamLeader(globalAccountName, "TEST")
 		_, err = js.Publish("foo", nil)
 		require_NoError(t, err)
 		checkStoreIsAsync(false)

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -14002,6 +14002,10 @@ func TestJetStreamClusterMetaRescueBadRequest(t *testing.T) {
 }
 
 func TestJetStreamClusterMetaRescueSingleSurvivor(t *testing.T) {
+	lqi := lostQuorumInterval
+	lostQuorumInterval = 2 * time.Second
+	defer func() { lostQuorumInterval = lqi }()
+
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()
 

--- a/server/jetstream_helpers_test.go
+++ b/server/jetstream_helpers_test.go
@@ -50,7 +50,7 @@ func init() {
 	hbInterval = 50 * time.Millisecond
 	minElectionTimeout = 1500 * time.Millisecond
 	maxElectionTimeout = 3500 * time.Millisecond
-	lostQuorumInterval = 2 * time.Second
+	lostQuorumInterval = 5 * time.Second
 	lostQuorumCheck = 4 * hbInterval
 
 	// For statz and jetstream placement speedups as well.

--- a/server/raft.go
+++ b/server/raft.go
@@ -157,6 +157,9 @@ func (state RaftState) String() string {
 
 type raft struct {
 	sync.RWMutex
+	// Serializes writing snapshot files, since async snapshots are written with the Raft lock released.
+	// MUST be acquired while already holding the Raft lock. But the Raft lock may then be released.
+	snapLock sync.Mutex
 
 	created time.Time      // Time that the group was created
 	accName string         // Account name of the asset this raft group is for
@@ -1557,7 +1560,10 @@ func (n *raft) installSnapshot(snap *snapshot) error {
 	sn := fmt.Sprintf(snapFileT, snap.lastTerm, snap.lastIndex)
 	sfile := filepath.Join(snapDir, sn)
 
-	if err := writeFileWithSync(n.dios, sfile, n.encodeSnapshot(snap), defaultFilePerms); err != nil {
+	n.snapLock.Lock()
+	err := writeFileWithSync(n.dios, sfile, n.encodeSnapshot(snap), defaultFilePerms)
+	n.snapLock.Unlock()
+	if err != nil {
 		// We could set write err here, but if this is a temporary situation, too many open files etc.
 		// we want to retry and snapshots are not fatal.
 		return err
@@ -1750,13 +1756,18 @@ func (c *checkpoint) InstallSnapshot(data []byte) (uint64, error) {
 	}
 	encoded := n.encodeSnapshot(snap)
 
+	// Before releasing the Raft lock, we acquire the snapshot lock to make
+	// sure snapshot writes remain serial.
+	n.snapLock.Lock()
 	// Unlock while writing.
 	n.Unlock()
 	err := writeFileWithSync(n.dios, c.snapFile, encoded, defaultFilePerms)
+	n.snapLock.Unlock()
 	n.Lock()
 	// On any failure path, drop the file we just wrote so it doesn't get
 	// picked up by setupLastSnapshot on restart. Skip the remove if it's the
-	// snapshot already adopted into n.snapfile for this term/applied.
+	// snapshot already adopted into n.snapfile for this term/applied, a direct
+	// install that was serialized after our write will have overwritten it.
 	if closed := n.State() == Closed; closed || !n.snapshotting || err != nil {
 		if c.snapFile != n.snapfile {
 			os.Remove(c.snapFile)

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -6056,6 +6056,52 @@ func TestNRGInstallSnapshotFromCheckpoint(t *testing.T) {
 	require_Error(t, err, errors.New("snapshot index mismatch"))
 }
 
+// A forced install must be able to take over from an async snapshot that's still in
+// progress, otherwise a shutdown snapshot gets suppressed.
+func TestNRGForcedInstallSnapshotAbortsInProgressCheckpoint(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// Create a sample entry, the content doesn't matter, just that it's stored.
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	aeMsg1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+	aeMsg2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 1, entries: entries})
+	aeHeartbeat := encode(t, &appendEntry{leader: nats0, term: 1, commit: 2, pterm: 1, pindex: 2})
+
+	n.processAppendEntry(aeMsg1, n.aesub)
+	n.processAppendEntry(aeMsg2, n.aesub)
+	n.processAppendEntry(aeHeartbeat, n.aesub)
+	n.Applied(2)
+
+	// An async snapshot is in progress.
+	c, err := n.CreateSnapshotCheckpoint(false)
+	require_NoError(t, err)
+
+	// Without forcing we can't snapshot, this is what would suppress a shutdown snapshot.
+	require_Error(t, n.InstallSnapshot([]byte("blocked"), false), errSnapInProgress)
+
+	// Forcing installs directly, which aborts the checkpoint that was in progress. The
+	// install holds the Raft lock throughout, so the two can't interleave.
+	require_NoError(t, n.InstallSnapshot([]byte("fresh"), true))
+
+	// The aborted checkpoint must not be able to install or read anything anymore.
+	_, err = c.LoadLastSnapshot()
+	require_Error(t, err, errSnapAborted)
+	_, err = c.InstallSnapshot([]byte("stale"))
+	require_Error(t, err, errSnapAborted)
+
+	// And its late abort must not cancel anything installed after it.
+	c.Abort()
+
+	snap, err := n.loadLastSnapshot()
+	require_NoError(t, err)
+	require_True(t, bytes.Equal(snap.data, []byte("fresh")))
+}
+
 func TestNRGSnapshotCheckpointNodeClosed(t *testing.T) {
 	for _, test := range []struct {
 		title string

--- a/server/raft_test.go
+++ b/server/raft_test.go
@@ -6084,8 +6084,7 @@ func TestNRGForcedInstallSnapshotAbortsInProgressCheckpoint(t *testing.T) {
 	// Without forcing we can't snapshot, this is what would suppress a shutdown snapshot.
 	require_Error(t, n.InstallSnapshot([]byte("blocked"), false), errSnapInProgress)
 
-	// Forcing installs directly, which aborts the checkpoint that was in progress. The
-	// install holds the Raft lock throughout, so the two can't interleave.
+	// Forcing installs directly, which aborts the checkpoint that was in progress.
 	require_NoError(t, n.InstallSnapshot([]byte("fresh"), true))
 
 	// The aborted checkpoint must not be able to install or read anything anymore.
@@ -6100,6 +6099,106 @@ func TestNRGForcedInstallSnapshotAbortsInProgressCheckpoint(t *testing.T) {
 	snap, err := n.loadLastSnapshot()
 	require_NoError(t, err)
 	require_True(t, bytes.Equal(snap.data, []byte("fresh")))
+
+	// The aborted checkpoint targets the same file for the same term/applied index, so
+	// it must not have written anything, not even a temporary file it never renamed.
+	files, err := os.ReadDir(filepath.Join(n.sd, snapshotsDir))
+	require_NoError(t, err)
+	require_Len(t, len(files), 1)
+	require_Equal(t, files[0].Name(), fmt.Sprintf(snapFileT, 1, 2))
+}
+
+// A direct install must wait for a snapshot write that's already in flight. The async
+// install path releases the Raft lock while writing, and both would target the same
+// file, and the same temporary file it's renamed from.
+func TestNRGDirectInstallSnapshotWaitsForInFlightWrite(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// Create a sample entry, the content doesn't matter, just that it's stored.
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	aeMsg1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+	aeMsg2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 1, entries: entries})
+	aeHeartbeat := encode(t, &appendEntry{leader: nats0, term: 1, commit: 2, pterm: 1, pindex: 2})
+
+	n.processAppendEntry(aeMsg1, n.aesub)
+	n.processAppendEntry(aeMsg2, n.aesub)
+	n.processAppendEntry(aeHeartbeat, n.aesub)
+	n.Applied(2)
+
+	// Stand in for a checkpoint that's in the middle of writing its snapshot file.
+	n.snapLock.Lock()
+
+	installed := make(chan error, 1)
+	go func() {
+		installed <- n.InstallSnapshot([]byte("fresh"), true)
+	}()
+
+	select {
+	case err := <-installed:
+		t.Fatalf("Expected install to wait for the in-flight snapshot write, got %v", err)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	n.snapLock.Unlock()
+	require_NoError(t, <-installed)
+
+	snap, err := n.loadLastSnapshot()
+	require_NoError(t, err)
+	require_True(t, bytes.Equal(snap.data, []byte("fresh")))
+}
+
+// An async install must claim the snapshot write lock before it gives up the Raft lock,
+// otherwise a direct install could slip in between its checks and its write.
+func TestNRGCheckpointInstallSnapshotWaitsForInFlightWrite(t *testing.T) {
+	n, cleanup := initSingleMemRaftNode(t)
+	defer cleanup()
+
+	// Create a sample entry, the content doesn't matter, just that it's stored.
+	esm := encodeStreamMsgAllowCompress("foo", "_INBOX.foo", nil, nil, 0, 0, true)
+	entries := []*Entry{newEntry(EntryNormal, esm)}
+
+	nats0 := "S1Nunr6R" // "nats-0"
+
+	aeMsg1 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 0, pterm: 0, pindex: 0, entries: entries})
+	aeMsg2 := encode(t, &appendEntry{leader: nats0, term: 1, commit: 1, pterm: 1, pindex: 1, entries: entries})
+	aeHeartbeat := encode(t, &appendEntry{leader: nats0, term: 1, commit: 2, pterm: 1, pindex: 2})
+
+	n.processAppendEntry(aeMsg1, n.aesub)
+	n.processAppendEntry(aeMsg2, n.aesub)
+	n.processAppendEntry(aeHeartbeat, n.aesub)
+	n.Applied(2)
+
+	c, err := n.CreateSnapshotCheckpoint(false)
+	require_NoError(t, err)
+
+	snapDir := filepath.Join(n.sd, snapshotsDir)
+
+	// Stand in for another snapshot write that's already in flight.
+	n.snapLock.Lock()
+
+	installed := make(chan error, 1)
+	go func() {
+		_, err := c.InstallSnapshot([]byte("async"))
+		installed <- err
+	}()
+
+	// Must not have written anything yet, not even a temporary file.
+	time.Sleep(250 * time.Millisecond)
+	files, err := os.ReadDir(snapDir)
+	require_NoError(t, err)
+	require_Len(t, len(files), 0)
+
+	n.snapLock.Unlock()
+	require_NoError(t, <-installed)
+
+	snap, err := n.loadLastSnapshot()
+	require_NoError(t, err)
+	require_True(t, bytes.Equal(snap.data, []byte("async")))
 }
 
 func TestNRGSnapshotCheckpointNodeClosed(t *testing.T) {

--- a/server/stream.go
+++ b/server/stream.go
@@ -1221,15 +1221,24 @@ func (sa *streamAssignment) identity() string {
 	return getHash(sa.Created.UTC().Format(time.RFC3339Nano))
 }
 
+// Returned by monitorQuitC once the monitor was signaled to quit, so a monitor
+// that only gets there afterwards still exits immediately.
+var closedMonitorQuitC = func() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}()
+
 func (mset *stream) monitorQuitC() <-chan struct{} {
 	if mset == nil {
 		return nil
 	}
 	mset.mu.Lock()
 	defer mset.mu.Unlock()
-	// Recreate if a prior monitor routine was stopped.
+	// Don't recreate, a concurrent stopMonitoring would wait forever for a monitor
+	// that can't be signaled anymore. startMonitorWg creates it per generation.
 	if mset.mqch == nil {
-		mset.mqch = make(chan struct{})
+		return closedMonitorQuitC
 	}
 	return mset.mqch
 }
@@ -8486,6 +8495,11 @@ func (mset *stream) stop(deleteFlag, advisory bool) error {
 	}
 	mset.mu.Unlock()
 
+	// If we're shutting down, wait for the monitor routine, which attempts to snapshot.
+	if isShuttingDown && !deleteFlag {
+		mset.stopMonitoring()
+	}
+
 	for _, o := range obs {
 		if !o.isClosed() {
 			// Third flag says do not broadcast a signal.
@@ -9407,6 +9421,13 @@ func (mset *stream) checkConsumerReplication() {
 // the monitor goroutine directly and must not be wrapped with monitorMu.
 func (mset *stream) startMonitorWg() {
 	mset.monitorMu.Lock()
+	// Quit channel for this new monitor generation. Not if the stream is (being)
+	// stopped, stop won't signal again so the monitor must exit right away instead.
+	mset.mu.Lock()
+	if mset.mqch == nil && !mset.closed.Load() {
+		mset.mqch = make(chan struct{})
+	}
+	mset.mu.Unlock()
 	mset.monitorWg.Add(1)
 	mset.monitorMu.Unlock()
 }


### PR DESCRIPTION
Two problems prevented a stream from snapshotting on shutdown:

- `doSnapshot` suppressed the snapshot when an async checkpoint was still in progress (`errSnapInProgress`) or when `failedSnapshots > 0`. On shutdown we now bypass both and force-install directly, which aborts any in-flight checkpoint. `TestNRGForcedInstallSnapshotAbortsInProgressCheckpoint` covers that the aborted checkpoint can no longer load or install, and that its late `Abort()` doesn't cancel the freshly installed snapshot. (This was already the case before this PR, but now has test coverage)
- `monitorQuitC` recreated `mset.mqch` when it was nil, so a monitor goroutine starting after `stopMonitoring` had already signaled would wait on a channel that would never close, and `stopMonitoring` would block on `monitorWg` forever. It now returns a pre-closed channel instead; `startMonitorWg` creates the quit channel and skips it when the stream is closed or closing.

`stream.stop` now waits for the monitor routine when shutting down (and not deleting), so the shutdown snapshot actually completes before teardown continues.

Also de-flakes `TestJetStreamClusterAsyncFlushBasics` and `TestJetStreamClusterCreateR3StreamWithOfflineNodes`, and fixes a data race on `Group.node` in the health check test helpers.

Various tests also started flaking with `JetStream system temporarily unavailable` due to consistently changing to `lostQuorumInterval` in https://github.com/nats-io/nats-server/pull/8452, the test-only 2s is bumped to 5s.