### PR TITLE
(2.15) [IMPROVED] Replace meta ForwardProposal with consumer assignment APIs

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -2325,27 +2325,21 @@ func (o *consumer) deleteNotActive() {
 	})
 
 	// If we are clustered, check if we still have this consumer assigned.
-	// If we do forward a proposal to delete ourselves to the metacontroller leader.
+	// If we do, ask the meta leader to delete us.
 	if !isDirect && s.JetStreamIsClustered() {
 		js.mu.RLock()
-		var (
-			meta        RaftNode
-			removeEntry []byte
-		)
 		nca := js.consumerAssignment(acc, stream, name)
-		// Only propose the delete if the meta-layer assignment still refers to
+		// Only request the delete if the meta-layer assignment still refers to
 		// the consumer we captured, otherwise we'd be racing a recreated
 		// consumer with the same name.
-		if cc := js.cluster; cc != nil && ca != nil && ca.sameIdentity(nca) {
-			meta = cc.meta
-			cca := ca.clone()
-			cca.Reply = _EMPTY_
-			removeEntry = encodeDeleteConsumerAssignment(cca)
-			meta.ForwardProposal(removeEntry)
-		}
+		requested := js.cluster != nil && ca != nil && ca.sameIdentity(nca)
 		js.mu.RUnlock()
 
-		if ca != nil && meta != nil {
+		if requested {
+			// The creation time is part of the consumer's identity, so the meta leader
+			// can equally reject the request if the consumer got recreated meanwhile.
+			s.sendConsumerAssignmentDelete(acc, stream, name, ca.Created)
+
 			// Check to make sure we went away.
 			// Don't think this needs to be a monitored go routine.
 			jitter := time.Duration(rand.Int63n(int64(cnaStart)))
@@ -2374,7 +2368,7 @@ func (o *consumer) deleteNotActive() {
 				js.mu.RUnlock()
 				if match {
 					s.Warnf("Consumer assignment for '%s > %s > %s' not cleaned up, retrying", acc, stream, name)
-					meta.ForwardProposal(removeEntry)
+					s.sendConsumerAssignmentDelete(acc, stream, name, ca.Created)
 					if interval < cnaMax {
 						interval *= 2
 						ticker.Reset(interval)

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -75,6 +75,10 @@ type jetStreamCluster struct {
 	// Processing desired assignment reconciliation.
 	streamReconcile   *subscription
 	consumerReconcile *subscription
+	// Internal requests to create or delete a consumer assignment, used by servers
+	// that have a local consumer the meta layer doesn't know about (yet).
+	consumerCreate *subscription
+	consumerDelete *subscription
 	// System level request to have the leader stepdown.
 	stepdown *subscription
 	// System level requests to remove a peer.
@@ -602,8 +606,8 @@ func (ca *consumerAssignment) clearResponded() {
 }
 
 // sameIdentity reports whether nca refers to the same logical consumer as ca.
-// Only stable identity fields (Name, Stream, Group name, Created time) are
-// compared; request-routing fields like Client/Reply and transient flags are
+// Only stable identity fields (Name, Stream, Created time) are compared;
+// request-routing fields like Client/Reply and transient flags are
 // intentionally excluded since processClusterCreateConsumer may set the
 // per-object o.ca to a clone with the original requester's Client/Reply
 // preserved while the meta-layer holds the newer values.
@@ -611,9 +615,7 @@ func (ca *consumerAssignment) sameIdentity(nca *consumerAssignment) bool {
 	return ca != nil && nca != nil &&
 		nca.Name == ca.Name &&
 		nca.Stream == ca.Stream &&
-		nca.Created.Equal(ca.Created) &&
-		nca.Group != nil && ca.Group != nil &&
-		nca.Group.Name == ca.Group.Name
+		nca.Created.Equal(ca.Created)
 }
 
 // clone returns a copy of ca. Field-explicit (rather than `*ca`) and
@@ -4344,63 +4346,10 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 
 			// Check to see if we have restored consumers here.
 			// These are not currently assigned so we will need to do so here.
-			if consumers := mset.getPublicConsumers(); len(consumers) > 0 {
-				// Need to read meta under the js lock, it's set to nil on shutdown.
-				js.mu.RLock()
-				meta := cc.meta
-				js.mu.RUnlock()
-				if meta == nil {
-					// We are shutting down.
-					continue
-				}
-				for _, o := range consumers {
-					name, cfg := o.String(), o.config()
-					rg, err := cc.createGroupForConsumer(&cfg, sa)
-					if err != nil {
-						s.Warnf("Could not create group for consumer '%s > %s > %s': %v",
-							sa.Client.serviceAccount(), sa.Config.Name, name, err)
-						continue
-					}
-					// Pick a preferred leader.
-					rg.setPreferred(s)
-
-					// Place our initial state here as well for assignment distribution.
-					state, _ := o.store.State()
-					ca := &consumerAssignment{
-						Group:   rg,
-						Stream:  sa.Config.Name,
-						Name:    name,
-						Config:  &cfg,
-						Client:  sa.Client,
-						Created: o.createdTime(),
-						State:   state,
-					}
-
-					// We make these compressed in case state is complex.
-					addEntry := encodeAddConsumerAssignmentCompressed(ca)
-					meta.ForwardProposal(addEntry)
-
-					// Check to make sure we see the assignment.
-					go func() {
-						ticker := time.NewTicker(time.Second)
-						defer ticker.Stop()
-						for range ticker.C {
-							js.mu.RLock()
-							ca, meta := js.consumerAssignment(ca.Client.serviceAccount(), sa.Config.Name, name), cc.meta
-							js.mu.RUnlock()
-							if ca == nil {
-								s.Warnf("Consumer assignment has not been assigned, retrying")
-								if meta != nil {
-									meta.ForwardProposal(addEntry)
-								} else {
-									return
-								}
-							} else {
-								return
-							}
-						}
-					}()
-				}
+			for _, o := range mset.getPublicConsumers() {
+				// Place our initial state along with the assignment, so it gets
+				// distributed to the other members of the consumer's group.
+				js.requestConsumerAssignment(sa, o, true)
 			}
 		}
 	}
@@ -6454,60 +6403,10 @@ func (js *jetStream) processClusterCreateStream(acc *Account, sa *streamAssignme
 
 					// Check to see if we have restored consumers here.
 					// These are not currently assigned so we will need to do so here.
-					if consumers := mset.getPublicConsumers(); len(consumers) > 0 {
-						// Need to read meta under the js lock, it's set to nil on shutdown.
-						js.mu.RLock()
-						cc := js.cluster
-						meta := cc.meta
-						js.mu.RUnlock()
-						if meta == nil {
-							// We are shutting down.
-							return
-						}
-
-						for _, o := range consumers {
-							name, cfg := o.String(), o.config()
-							rg, err := cc.createGroupForConsumer(&cfg, sa)
-							if err != nil {
-								s.Warnf("Could not create group for consumer '%s > %s > %s': %v",
-									sa.Client.serviceAccount(), sa.Config.Name, name, err)
-								continue
-							}
-
-							// Place our initial state here as well for assignment distribution.
-							ca := &consumerAssignment{
-								Group:   rg,
-								Stream:  sa.Config.Name,
-								Name:    name,
-								Config:  &cfg,
-								Client:  sa.Client,
-								Created: o.createdTime(),
-							}
-
-							addEntry := encodeAddConsumerAssignment(ca)
-							meta.ForwardProposal(addEntry)
-
-							// Check to make sure we see the assignment.
-							go func() {
-								ticker := time.NewTicker(time.Second)
-								defer ticker.Stop()
-								for range ticker.C {
-									js.mu.RLock()
-									ca, meta := js.consumerAssignment(ca.Client.serviceAccount(), sa.Config.Name, name), cc.meta
-									js.mu.RUnlock()
-									if ca == nil {
-										s.Warnf("Consumer assignment has not been assigned, retrying")
-										if meta != nil {
-											meta.ForwardProposal(addEntry)
-										} else {
-											return
-										}
-									} else {
-										return
-									}
-								}
-							}()
-						}
+					// The stream is R1, so the consumers can only be assigned to us
+					// and don't need their state distributed with the assignment.
+					for _, o := range mset.getPublicConsumers() {
+						js.requestConsumerAssignment(sa, o, false)
 					}
 				case <-s.quitCh:
 					return
@@ -8872,11 +8771,240 @@ func (rg *raftGroup) reconcileDesiredState(reconcile desiredAssignmentUpdate, re
 	return ng
 }
 
+// consumerAssignmentCreate is a request for the meta leader to create a consumer
+// assignment for a consumer that already exists on the requesting server, but that
+// the meta layer doesn't know about yet. For example a consumer that came back as
+// part of a stream restore.
+type consumerAssignmentCreate struct {
+	Account  string          `json:"account"`         // Account of the consumer.
+	Stream   string          `json:"stream"`          // Stream of the consumer.
+	Consumer string          `json:"consumer"`        // The consumer name itself.
+	Created  time.Time       `json:"created"`         // Creation time of the local consumer.
+	Config   json.RawMessage `json:"config"`          // Consumer config, kept raw so unknown fields can be rejected.
+	State    *ConsumerState  `json:"state,omitempty"` // Initial state to distribute with the assignment, if any.
+}
+
+// consumerAssignmentDelete is a request for the meta leader to delete a consumer
+// assignment. The account, stream, consumer name and creation time together identify
+// the consumer, so a consumer that was recreated under the same name isn't deleted.
+type consumerAssignmentDelete struct {
+	Account  string    `json:"account"`  // Account of the consumer.
+	Stream   string    `json:"stream"`   // Stream of the consumer.
+	Consumer string    `json:"consumer"` // The consumer name itself.
+	Created  time.Time `json:"created"`  // Creation time, part of the consumer's identity.
+}
+
+// consumerAssignmentCompressedMsg marks a consumer assignment request as being
+// s2-compressed, the request is plain JSON otherwise. Deliberately not '{' or any
+// leading JSON whitespace, so the first byte is an unambiguous discriminator.
+const consumerAssignmentCompressedMsg byte = 1
+
+// sendConsumerAssignmentCreate asks the meta leader to create a consumer assignment.
+func (s *Server) sendConsumerAssignmentCreate(create *consumerAssignmentCreate) {
+	// Only state can be complex, so only compress when we're distributing it.
+	// Keeps the common request plain JSON, and readable when observing the subject.
+	if create.State == nil {
+		s.sendInternalMsgLocked(consumerAssignmentCreateSubj, _EMPTY_, nil, create)
+		return
+	}
+	var bb bytes.Buffer
+	bb.WriteByte(consumerAssignmentCompressedMsg)
+	s2e := s2.NewWriter(&bb)
+	if err := json.NewEncoder(s2e).Encode(create); err != nil {
+		s2e.Close()
+		return
+	}
+	if err := s2e.Close(); err != nil {
+		return
+	}
+	// Pass the bytes along, so they're sent as-is instead of being marshaled again.
+	s.sendInternalMsgLocked(consumerAssignmentCreateSubj, _EMPTY_, nil, bb.Bytes())
+}
+
+// requestConsumerAssignment asks the meta leader to assign a consumer that exists locally,
+// but that the meta layer doesn't know about yet, i.e. one that came back with a stream
+// restore. Retries until we observe the assignment, since the request is best-effort.
+// If withState is set the consumer's current state is distributed with the assignment, which
+// is needed if the consumer's group spans more peers than just us.
+func (js *jetStream) requestConsumerAssignment(sa *streamAssignment, o *consumer, withState bool) {
+	s := js.srv
+	accName, streamName, name := sa.Client.serviceAccount(), sa.Config.Name, o.String()
+	cfg := o.config()
+	cfgJSON, err := json.Marshal(&cfg)
+	if err != nil {
+		s.Warnf("Could not encode config for consumer '%s > %s > %s': %v", accName, streamName, name, err)
+		return
+	}
+	create := &consumerAssignmentCreate{
+		Account:  accName,
+		Stream:   streamName,
+		Consumer: name,
+		Created:  o.createdTime(),
+		Config:   cfgJSON,
+	}
+	if withState {
+		create.State, _ = o.store.State()
+	}
+	s.sendConsumerAssignmentCreate(create)
+
+	// Check to make sure we see the assignment.
+	s.startGoRoutine(func() {
+		defer s.grWG.Done()
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+			case <-s.quitCh:
+				return
+			}
+			js.mu.RLock()
+			// Give up if we're shutting down, if the stream is gone, or once we
+			// observe the consumer assignment we asked for.
+			done := js.shuttingDown || js.cluster == nil ||
+				js.streamAssignment(accName, streamName) == nil ||
+				js.consumerAssignment(accName, streamName, name) != nil
+			js.mu.RUnlock()
+			if done {
+				return
+			}
+			s.Warnf("Consumer assignment for '%s > %s > %s' has not been assigned, retrying", accName, streamName, name)
+			s.sendConsumerAssignmentCreate(create)
+		}
+	})
+}
+
+// sendConsumerAssignmentDelete asks the meta leader to delete a consumer assignment.
+func (s *Server) sendConsumerAssignmentDelete(account, stream, consumer string, created time.Time) {
+	s.sendInternalMsgLocked(consumerAssignmentDeleteSubj, _EMPTY_, nil, &consumerAssignmentDelete{
+		Account:  account,
+		Stream:   stream,
+		Consumer: consumer,
+		Created:  created,
+	})
+}
+
+// processConsumerAssignmentCreate runs on the meta leader and creates an assignment for
+// a consumer that already exists on the requesting server. The request is idempotent, if
+// the consumer is already assigned (or a proposal is inflight) it is a no-op, so the
+// requester can simply retry until it observes the assignment.
+func (js *jetStream) processConsumerAssignmentCreate(_ *subscription, _ *client, _ *Account, _, _ string, msg []byte) {
+	if len(msg) == 0 {
+		return
+	}
+	var create consumerAssignmentCreate
+	var decoder *json.Decoder
+	if msg[0] == consumerAssignmentCompressedMsg {
+		decoder = json.NewDecoder(s2.NewReader(bytes.NewReader(msg[1:])))
+	} else {
+		decoder = json.NewDecoder(bytes.NewReader(msg))
+	}
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&create); err != nil {
+		return
+	}
+	if create.Consumer == _EMPTY_ || len(create.Config) == 0 {
+		return
+	}
+
+	js.mu.Lock()
+	defer js.mu.Unlock()
+
+	s, cc := js.srv, js.cluster
+	if cc == nil || cc.meta == nil {
+		return
+	}
+	sa := js.streamAssignmentOrInflight(create.Account, create.Stream)
+	if sa == nil || sa.Group == nil || sa.Config == nil {
+		return
+	}
+	// Nothing to do if we know about this consumer already.
+	if js.consumerAssignmentOrInflight(create.Account, create.Stream, create.Consumer) != nil {
+		return
+	}
+
+	ca := &consumerAssignment{
+		Stream:     create.Stream,
+		Name:       create.Consumer,
+		ConfigJSON: create.Config,
+		Client:     sa.Client,
+		Created:    create.Created,
+		State:      create.State,
+	}
+	// Populate ca.Config, we only got the raw config from the requester.
+	if err := decodeConsumerAssignmentConfig(ca); err != nil || ca.Config == nil || ca.unsupported != nil {
+		return
+	}
+
+	rg, err := cc.createGroupForConsumer(ca.Config, sa)
+	if err != nil {
+		s.Warnf("Could not create group for consumer '%s > %s > %s': %v",
+			create.Account, create.Stream, create.Consumer, err)
+		return
+	}
+	// Pick a preferred leader.
+	rg.setPreferred(s)
+	// Inherit cluster from stream.
+	rg.Cluster = sa.Group.Cluster
+	ca.Group = rg
+
+	// State can be complex, so make those compressed.
+	var entry []byte
+	if ca.State == nil {
+		entry = encodeAddConsumerAssignment(ca)
+	} else {
+		entry = encodeAddConsumerAssignmentCompressed(ca)
+	}
+	if err := cc.meta.Propose(cc.term, entry); err != nil {
+		return
+	}
+	cc.trackInflightConsumerProposal(create.Account, create.Stream, ca, false)
+}
+
+// processConsumerAssignmentDelete runs on the meta leader and deletes a consumer's
+// assignment. The request is idempotent, if the consumer is not assigned anymore (or a
+// delete proposal is inflight) it is a no-op, so the requester can simply retry until it
+// observes the assignment being gone.
+func (js *jetStream) processConsumerAssignmentDelete(_ *subscription, _ *client, _ *Account, _, _ string, msg []byte) {
+	var del consumerAssignmentDelete
+	decoder := json.NewDecoder(bytes.NewReader(msg))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&del); err != nil {
+		return
+	}
+	if del.Consumer == _EMPTY_ {
+		return
+	}
+
+	js.mu.Lock()
+	defer js.mu.Unlock()
+
+	cc := js.cluster
+	if cc == nil || cc.meta == nil {
+		return
+	}
+	ca := js.consumerAssignmentOrInflight(del.Account, del.Stream, del.Consumer)
+	// The creation time is part of the consumer's identity, only delete if the
+	// assignment still refers to the consumer the requester asked about. Otherwise
+	// we'd be deleting a new consumer that reused the name.
+	if ca == nil || !ca.Created.Equal(del.Created) {
+		return
+	}
+	cca := ca.clone()
+	cca.Reply = _EMPTY_
+	if err := cc.meta.Propose(cc.term, encodeDeleteConsumerAssignment(cca)); err != nil {
+		return
+	}
+	cc.trackInflightConsumerProposal(del.Account, del.Stream, cca, true)
+}
+
 const (
 	streamAssignmentSubj            = "$SYS.JSC.STREAM.ASSIGNMENT.RESULT"
 	streamAssignmentReconcileSubj   = "$SYS.JSC.STREAM.ASSIGNMENT.RECONCILE"
 	consumerAssignmentSubj          = "$SYS.JSC.CONSUMER.ASSIGNMENT.RESULT"
 	consumerAssignmentReconcileSubj = "$SYS.JSC.CONSUMER.ASSIGNMENT.RECONCILE"
+	consumerAssignmentCreateSubj    = "$SYS.JSC.CONSUMER.ASSIGNMENT.CREATE"
+	consumerAssignmentDeleteSubj    = "$SYS.JSC.CONSUMER.ASSIGNMENT.DELETE"
 )
 
 // Lock should be held.
@@ -8893,6 +9021,12 @@ func (js *jetStream) startUpdatesSub() {
 	}
 	if cc.consumerReconcile == nil {
 		cc.consumerReconcile, _ = s.systemSubscribe(consumerAssignmentReconcileSubj, _EMPTY_, false, c, js.reconcileDesiredConsumerAssignment)
+	}
+	if cc.consumerCreate == nil {
+		cc.consumerCreate, _ = s.systemSubscribe(consumerAssignmentCreateSubj, _EMPTY_, false, c, js.processConsumerAssignmentCreate)
+	}
+	if cc.consumerDelete == nil {
+		cc.consumerDelete, _ = s.systemSubscribe(consumerAssignmentDeleteSubj, _EMPTY_, false, c, js.processConsumerAssignmentDelete)
 	}
 	if cc.stepdown == nil {
 		cc.stepdown, _ = s.systemSubscribe(JSApiLeaderStepDown, _EMPTY_, false, c, s.jsLeaderStepDownRequest)
@@ -8932,6 +9066,14 @@ func (js *jetStream) stopUpdatesSub() {
 	if cc.consumerReconcile != nil {
 		cc.s.sysUnsubscribe(cc.consumerReconcile)
 		cc.consumerReconcile = nil
+	}
+	if cc.consumerCreate != nil {
+		cc.s.sysUnsubscribe(cc.consumerCreate)
+		cc.consumerCreate = nil
+	}
+	if cc.consumerDelete != nil {
+		cc.s.sysUnsubscribe(cc.consumerDelete)
+		cc.consumerDelete = nil
 	}
 	if cc.stepdown != nil {
 		cc.s.sysUnsubscribe(cc.stepdown)

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -4324,15 +4324,16 @@ func TestJetStreamClusterStreamScaleUpNoGroupCluster(t *testing.T) {
 	// Remove cluster and preferred.
 	sa.Group.Cluster = _EMPTY_
 	sa.Group.Preferred = _EMPTY_
-	// Insert into meta layer.
-	if sjs := s.getJetStream(); sjs != nil {
-		sjs.mu.RLock()
-		meta := sjs.cluster.meta
-		sjs.mu.RUnlock()
-		if meta != nil {
-			meta.ForwardProposal(encodeUpdateStreamAssignment(sa))
-		}
-	}
+	// Insert into meta layer, proposed by the meta leader itself.
+	ml := c.leader()
+	require_NotNil(t, ml)
+	mjs := ml.getJetStream()
+	require_NotNil(t, mjs)
+	mjs.mu.RLock()
+	meta, term := mjs.cluster.meta, mjs.cluster.term
+	mjs.mu.RUnlock()
+	require_NotNil(t, meta)
+	require_NoError(t, meta.Propose(term, encodeUpdateStreamAssignment(sa)))
 	// Make sure it got propagated..
 	checkFor(t, 10*time.Second, 200*time.Millisecond, func() error {
 		sa := mset.streamAssignment().copyGroup()

--- a/server/jetstream_cluster_4_test.go
+++ b/server/jetstream_cluster_4_test.go
@@ -9034,3 +9034,203 @@ func TestJetStreamClusterStreamSnapshots(t *testing.T) {
 		})
 	}
 }
+
+func TestJetStreamClusterConsumerAssignmentCreateAPI(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	ncsys, err := nats.Connect(c.randomServer().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer ncsys.Close()
+
+	cfg, err := json.Marshal(&ConsumerConfig{
+		Durable:   "CONSUMER",
+		Name:      "CONSUMER",
+		AckPolicy: AckExplicit,
+		Replicas:  3,
+	})
+	require_NoError(t, err)
+
+	created := time.Now().UTC()
+	req, err := json.Marshal(&consumerAssignmentCreate{
+		Account:  globalAccountName,
+		Stream:   "TEST",
+		Consumer: "CONSUMER",
+		Created:  created,
+		Config:   cfg,
+	})
+	require_NoError(t, err)
+	require_NoError(t, ncsys.Publish(consumerAssignmentCreateSubj, req))
+
+	// The meta leader creates the group for us and assigns the consumer.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		ci, err := js.ConsumerInfo("TEST", "CONSUMER")
+		if err != nil {
+			return err
+		}
+		if ci.Cluster == nil || len(ci.Cluster.Replicas) != 2 {
+			return fmt.Errorf("expected an R3 consumer, got %+v", ci.Cluster)
+		}
+		return nil
+	})
+
+	ml := c.leader()
+	mjs := ml.getJetStream()
+	require_NotNil(t, mjs)
+	getCa := func() *consumerAssignment {
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		return mjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+	}
+
+	ca := getCa()
+	require_NotNil(t, ca)
+	require_True(t, ca.Created.Equal(created))
+	require_NotNil(t, ca.Group)
+	require_Len(t, len(ca.Group.Peers), 3)
+
+	// Requests are idempotent, so the requester can simply retry until it observes the
+	// assignment. A repeat must not create a new group or reset the assignment.
+	require_NoError(t, ncsys.Publish(consumerAssignmentCreateSubj, req))
+	require_NoError(t, ncsys.Flush())
+	time.Sleep(500 * time.Millisecond)
+
+	nca := getCa()
+	require_NotNil(t, nca)
+	require_NotNil(t, nca.Group)
+	require_Equal(t, nca.Group.Name, ca.Group.Name)
+	require_True(t, nca.Created.Equal(created))
+}
+
+func TestJetStreamClusterConsumerAssignmentCreateCompressedAPI(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	cfgJSON, err := json.Marshal(&ConsumerConfig{
+		Durable:   "C",
+		AckPolicy: AckExplicit,
+		Replicas:  3,
+	})
+	require_NoError(t, err)
+
+	// State is only distributed when restoring, and is the one field that can grow
+	// large, so make sure a request carrying it survives being compressed and framed.
+	state := &ConsumerState{
+		Delivered: SequencePair{Consumer: 1000, Stream: 1000},
+		AckFloor:  SequencePair{Consumer: 1, Stream: 1},
+		Pending:   make(map[uint64]*Pending, 1000),
+	}
+	for i := uint64(2); i <= 1000; i++ {
+		state.Pending[i] = &Pending{Sequence: i, Timestamp: int64(i)}
+	}
+
+	s := c.randomServer()
+	s.sendConsumerAssignmentCreate(&consumerAssignmentCreate{
+		Account:  globalAccountName,
+		Stream:   "TEST",
+		Consumer: "C",
+		Created:  time.Now().UTC(),
+		Config:   cfgJSON,
+		State:    state,
+	})
+
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		sjs := s.getJetStream()
+		sjs.mu.RLock()
+		defer sjs.mu.RUnlock()
+		if ca := sjs.consumerAssignment(globalAccountName, "TEST", "C"); ca == nil {
+			return errors.New("consumer assignment not seen yet")
+		}
+		return nil
+	})
+}
+
+func TestJetStreamClusterConsumerAssignmentDeleteAPI(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	})
+	require_NoError(t, err)
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{
+		Durable:   "CONSUMER",
+		Replicas:  3,
+		AckPolicy: nats.AckExplicitPolicy,
+	})
+	require_NoError(t, err)
+
+	ml := c.leader()
+	mjs := ml.getJetStream()
+	require_NotNil(t, mjs)
+	getCa := func() *consumerAssignment {
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		return mjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
+	}
+
+	ca := getCa()
+	require_NotNil(t, ca)
+	created := ca.Created
+
+	ncsys, err := nats.Connect(c.randomServer().ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer ncsys.Close()
+
+	sendDelete := func(created time.Time) {
+		req, err := json.Marshal(&consumerAssignmentDelete{
+			Account:  globalAccountName,
+			Stream:   "TEST",
+			Consumer: "CONSUMER",
+			Created:  created,
+		})
+		require_NoError(t, err)
+		require_NoError(t, ncsys.Publish(consumerAssignmentDeleteSubj, req))
+		require_NoError(t, ncsys.Flush())
+	}
+
+	// The creation time is part of the consumer's identity, so a request that doesn't
+	// match must be ignored. Otherwise we'd delete a consumer that got recreated.
+	sendDelete(created.Add(-time.Second))
+	time.Sleep(500 * time.Millisecond)
+	nca := getCa()
+	require_NotNil(t, nca)
+	require_True(t, nca.Created.Equal(created))
+
+	// A matching request deletes the consumer.
+	sendDelete(created)
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		if getCa() != nil {
+			return errors.New("consumer assignment still present")
+		}
+		return nil
+	})
+	_, err = js.ConsumerInfo("TEST", "CONSUMER")
+	require_Error(t, err, nats.ErrConsumerNotFound)
+}


### PR DESCRIPTION
Replace the `meta.ForwardProposal` calls that add or remove consumers with meta leader APIs. A forwarded proposal is appended verbatim without the meta leader's upper layer ever seeing it, so it skips validation and inflight tracking.