### PR TITLE
[FIXED] Preserve stream created time after recovery

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -676,6 +676,12 @@ func (fs *fileStore) unlockAllMsgBlocks() {
 	}
 }
 
+func (fs *fileStore) setCreatedTime(created time.Time) {
+	fs.mu.Lock()
+	fs.cfg.Created = created
+	fs.mu.Unlock()
+}
+
 func (fs *fileStore) UpdateConfig(cfg *StreamConfig) error {
 	start := time.Now()
 	defer func() {

--- a/server/jetstream_test.go
+++ b/server/jetstream_test.go
@@ -6780,6 +6780,45 @@ func TestJetStreamUpdateStream(t *testing.T) {
 	}
 }
 
+func TestJetStreamFileStreamCreatedTimePreservedAfterRestartAndUpdate(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer func() { s.Shutdown() }()
+
+	nc, js := jsClientConnect(t, s)
+	defer func() { nc.Close() }()
+	si, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Storage: nats.FileStorage})
+	require_NoError(t, err)
+	created := si.Created
+
+	sd := s.JetStreamConfig().StoreDir
+	nc.Close()
+	s.Shutdown()
+	time.Sleep(10 * time.Millisecond)
+
+	s = RunJetStreamServerOnPort(-1, sd)
+	nc, js = jsClientConnect(t, s)
+	si, err = js.StreamInfo("TEST")
+	require_NoError(t, err)
+	if !si.Created.Equal(created) {
+		t.Fatalf("Expected created time %v after restart, got %v", created, si.Created)
+	}
+
+	cfg := si.Config
+	cfg.MaxMsgs = 1
+	_, err = js.UpdateStream(&cfg)
+	require_NoError(t, err)
+	nc.Close()
+	s.Shutdown()
+
+	s = RunJetStreamServerOnPort(-1, sd)
+	nc, js = jsClientConnect(t, s)
+	si, err = js.StreamInfo("TEST")
+	require_NoError(t, err)
+	if !si.Created.Equal(created) {
+		t.Fatalf("Expected created time %v after restart and update, got %v", created, si.Created)
+	}
+}
+
 func TestJetStreamDeleteMsg(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/server/stream.go
+++ b/server/stream.go
@@ -1636,10 +1636,10 @@ func (mset *stream) setCreatedTime(created time.Time) {
 	mset.mu.Lock()
 	mset.created = created
 	store := mset.store
-	mset.mu.Unlock()
 	if fs, ok := store.(*fileStore); ok {
 		fs.setCreatedTime(created)
 	}
+	mset.mu.Unlock()
 }
 
 // subjectsOverlap to see if these subjects overlap with existing subjects.

--- a/server/stream.go
+++ b/server/stream.go
@@ -1635,7 +1635,11 @@ func (mset *stream) createdTime() time.Time {
 func (mset *stream) setCreatedTime(created time.Time) {
 	mset.mu.Lock()
 	mset.created = created
+	store := mset.store
 	mset.mu.Unlock()
+	if fs, ok := store.(*fileStore); ok {
+		fs.setCreatedTime(created)
+	}
 }
 
 // subjectsOverlap to see if these subjects overlap with existing subjects.


### PR DESCRIPTION
During standalone file stream recovery, the persisted creation time was restored on the stream object, but the internal file store configuration retained the server startup time.

A subsequent stream configuration update persisted that stale value to `meta.inf`. After another restart, the changed creation time was exposed through the JetStream API.

This change keeps the stream and file store creation timestamps synchronized when restoring the persisted creation time.

A regression test covers:

1. Creating a file-backed stream.
2. Restarting the server.
3. Updating the stream configuration.
4. Restarting the server again.
5. Verifying that `StreamInfo.Created` remains unchanged.

Resolves #8470
