### PR TITLE
fix: check AddWeightedMappings error in updateAccountClaimsWithRefresh

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -3498,7 +3498,9 @@ func (s *Server) updateAccountClaimsWithRefresh(a *Account, ac *jwt.AccountClaim
 			}
 		}
 		// This will overwrite existing entries
-		a.AddWeightedMappings(string(sub), mappings...)
+		if err := a.AddWeightedMappings(string(sub), mappings...); err != nil {
+			s.Warnf("Error updating mappings for account %s: %v", a.Name, err)
+		}
 	}
 	// remove mappings
 	for _, rmMapping := range removeList {


### PR DESCRIPTION
### Description

When an account JWT is pushed via `$SYS.REQ.CLAIMS.UPDATE`, `updateAccountClaimsWithRefresh` calls `Account.AddWeightedMappings` but discards the returned error. This means:

1. **Duplicate destination subject**: `jwt.Mapping.Validate` has no duplicate check, but `AddWeightedMappings` returns `duplicate entry for %q`. The pusher gets `200 "jwt updated"` while the mapping stays unchanged.
2. **Invalid transform token**: `NewSubjectTransform` returns an error for invalid transform tokens, which is also silently ignored.

### Fix

Capture the error from `AddWeightedMappings` and log a warning, so the operator is notified when mapping updates fail silently.

### References

- Closes #8468