### PR TITLE
(2.15) [FIXED] Remove leftover atomic-batch staging dirs after cleanup

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -11732,7 +11732,16 @@ func (fs *fileStore) Delete(inline bool) error {
 	// Now move into different directory with "." prefix.
 	ndir := filepath.Join(filepath.Dir(fs.fcfg.StoreDir), tsep+filepath.Base(fs.fcfg.StoreDir))
 	if err := os.Rename(fs.fcfg.StoreDir, ndir); err != nil {
-		return err
+		// meta.inf is already gone, so StoreDir is unrecoverable. Rename fails when
+		// a leftover "." tomb exists (Linux ENOTEMPTY; Windows dest-exists). Remove
+		// both paths inline so callers that ignore the error do not leak the original dir.
+		if rerr := removeAllWithRetry(fs.dios, fs.fcfg.StoreDir); rerr != nil {
+			return rerr
+		}
+		if rerr := removeAllWithRetry(fs.dios, ndir); rerr != nil {
+			return rerr
+		}
+		return nil
 	}
 	// Do this in separate Go routine in case lots of blocks.
 	// Purge above protects us as does the removal of meta artifacts above.

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -3140,6 +3140,33 @@ func TestFileStoreStreamDeleteDirNotEmpty(t *testing.T) {
 	})
 }
 
+func TestFileStoreDeleteRemovesStoreDirWhenRenameDestExists(t *testing.T) {
+	testFileStoreAllPermutations(t, func(t *testing.T, fcfg FileStoreConfig) {
+		// Keep the tomb inside the test temp root so it is cleaned up.
+		root := fcfg.StoreDir
+		fcfg.StoreDir = filepath.Join(root, "store")
+
+		fs, err := newFileStoreWithCreated(fcfg, StreamConfig{Name: "zzz", Storage: FileStorage}, time.Now(), prf(&fcfg), nil)
+		require_NoError(t, err)
+		defer fs.Stop()
+
+		_, _, err = fs.StoreMsg("foo", nil, []byte("Hello World"), 0)
+		require_NoError(t, err)
+
+		// Non-empty dest so Linux rename fails with ENOTEMPTY, not only Windows dest-exists.
+		tomb := filepath.Join(filepath.Dir(fcfg.StoreDir), tsep+filepath.Base(fcfg.StoreDir))
+		require_NoError(t, os.MkdirAll(tomb, defaultDirPerms))
+		require_NoError(t, os.WriteFile(filepath.Join(tomb, "leftover"), []byte("x"), defaultFilePerms))
+
+		require_NoError(t, fs.Delete(true))
+
+		_, err = os.Stat(fcfg.StoreDir)
+		require_True(t, os.IsNotExist(err))
+		_, err = os.Stat(tomb)
+		require_True(t, os.IsNotExist(err))
+	})
+}
+
 func TestFileStoreConsumerPerf(t *testing.T) {
 	// Comment out to run, holding place for now.
 	t.SkipNow()

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -20,7 +20,6 @@ import (
 	"maps"
 	"math"
 	"math/big"
-	"os"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -105,20 +104,7 @@ func (b *atomicBatch) cleanupLocked(batchId string, batches *batching) {
 	}
 	globalInflightAtomicBatches.Add(-1)
 	b.timer.Stop()
-	err := b.store.Delete(true)
-	if fs, ok := b.store.(*fileStore); ok {
-		dir := fs.fcfg.StoreDir
-		tomb := filepath.Join(filepath.Dir(dir), tsep+filepath.Base(dir))
-		if err != nil {
-			fs.warn("atomic batch staging Delete failed for %q: %v", dir, err)
-		}
-		if rerr := os.RemoveAll(dir); rerr != nil {
-			fs.warn("atomic batch staging dir remove failed for %q: %v", dir, rerr)
-		}
-		if rerr := os.RemoveAll(tomb); rerr != nil {
-			fs.warn("atomic batch staging tombstone remove failed for %q: %v", tomb, rerr)
-		}
-	}
+	b.store.Delete(true)
 	delete(batches.atomic, batchId)
 	// Reset so that another invocation doesn't double-account.
 	b.timer = nil

--- a/server/jetstream_batching.go
+++ b/server/jetstream_batching.go
@@ -20,6 +20,7 @@ import (
 	"maps"
 	"math"
 	"math/big"
+	"os"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -104,7 +105,20 @@ func (b *atomicBatch) cleanupLocked(batchId string, batches *batching) {
 	}
 	globalInflightAtomicBatches.Add(-1)
 	b.timer.Stop()
-	b.store.Delete(true)
+	err := b.store.Delete(true)
+	if fs, ok := b.store.(*fileStore); ok {
+		dir := fs.fcfg.StoreDir
+		tomb := filepath.Join(filepath.Dir(dir), tsep+filepath.Base(dir))
+		if err != nil {
+			fs.warn("atomic batch staging Delete failed for %q: %v", dir, err)
+		}
+		if rerr := os.RemoveAll(dir); rerr != nil {
+			fs.warn("atomic batch staging dir remove failed for %q: %v", dir, rerr)
+		}
+		if rerr := os.RemoveAll(tomb); rerr != nil {
+			fs.warn("atomic batch staging tombstone remove failed for %q: %v", tomb, rerr)
+		}
+	}
 	delete(batches.atomic, batchId)
 	// Reset so that another invocation doesn't double-account.
 	b.timer = nil

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -2106,6 +2108,70 @@ func TestJetStreamAtomicBatchPublishSingleServerRecovery(t *testing.T) {
 			require_Equal(t, string(getHeader("Nats-Batch-Commit", sm.Header)), "1")
 		}
 	}
+}
+
+func TestJetStreamAtomicBatchCleanupRemovesStagingWhenRenameFails(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc := clientConnectToServer(t, s)
+	defer nc.Close()
+
+	cfg := &StreamConfig{
+		Name:               "TEST",
+		Subjects:           []string{"foo"},
+		Storage:            FileStorage,
+		Retention:          LimitsPolicy,
+		Replicas:           1,
+		AllowAtomicPublish: true,
+	}
+	_, err := jsStreamCreate(t, nc, cfg)
+	require_NoError(t, err)
+
+	mset, err := s.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	jsa := mset.jsa
+	jsa.mu.RLock()
+	storeDir := jsa.storeDir
+	jsa.mu.RUnlock()
+
+	const batchId = "uuid"
+	hash, dir := getBatchStoreDir(storeDir, "TEST", batchId)
+	tomb := filepath.Join(filepath.Dir(dir), tsep+hash)
+	require_NoError(t, os.MkdirAll(tomb, defaultDirPerms))
+
+	mset.mu.Lock()
+	if mset.batches == nil {
+		mset.batches = &batching{}
+	}
+	batches := mset.batches
+	mset.mu.Unlock()
+
+	batches.mu.Lock()
+	globalInflightAtomicBatches.Add(1)
+	b, err := batches.newAtomicBatch(mset, batchId, 1, FileStorage, storeDir, "TEST")
+	if err != nil {
+		globalInflightAtomicBatches.Add(-1)
+		batches.mu.Unlock()
+		require_NoError(t, err)
+	}
+	if batches.atomic == nil {
+		batches.atomic = make(map[string]*atomicBatch, 1)
+	}
+	batches.atomic[batchId] = b
+	_, _, err = b.store.StoreMsg("foo", nil, []byte("x"), 0)
+	if err != nil {
+		batches.mu.Unlock()
+		require_NoError(t, err)
+	}
+
+	b.cleanupLocked(batchId, batches)
+	batches.mu.Unlock()
+
+	_, err = os.Stat(dir)
+	require_True(t, os.IsNotExist(err))
+	_, err = os.Stat(tomb)
+	require_True(t, os.IsNotExist(err))
 }
 
 func TestJetStreamAtomicBatchPublishSingleServerRecoveryCommitEob(t *testing.T) {

--- a/server/jetstream_batching_test.go
+++ b/server/jetstream_batching_test.go
@@ -2139,6 +2139,7 @@ func TestJetStreamAtomicBatchCleanupRemovesStagingWhenRenameFails(t *testing.T) 
 	hash, dir := getBatchStoreDir(storeDir, "TEST", batchId)
 	tomb := filepath.Join(filepath.Dir(dir), tsep+hash)
 	require_NoError(t, os.MkdirAll(tomb, defaultDirPerms))
+	require_NoError(t, os.WriteFile(filepath.Join(tomb, "leftover"), []byte("x"), defaultFilePerms))
 
 	mset.mu.Lock()
 	if mset.batches == nil {


### PR DESCRIPTION
## Summary
- JetStream R=1 file-backed atomic batches stage under `streams/<name>/batches/<hash>/`.
- `FileStore.Delete` unlinks `meta.inf` then `Rename`s `StoreDir` to `.<name>`. If that rename fails (leftover non-empty tomb / Windows dest-exists), it used to return immediately and leak the original directory. Callers ignore the error, and there is no runtime sweeper (startup `RemoveAll` of `batches/` is recovery-only).
- On rename failure, `Delete` now `removeAllWithRetry`s both the original `StoreDir` and the sibling tomb **inline**, then returns nil if that cleanup succeeds. The success-path rename + async tomb purge is unchanged.
- `cleanupLocked` just calls `store.Delete(true)` again. Memory stores are unchanged. `AsyncFlush`, `stopLocked()`, and startup recovery are not modified.

Fixes #8472

## Test plan
- [x] `go test ./server -count=1 -timeout 180s -run TestFileStoreDeleteRemovesStoreDirWhenRenameDestExists`
- [x] `go test ./server -count=1 -timeout 120s -run TestJetStreamAtomicBatchCleanupRemovesStagingWhenRenameFails`
- [x] `go test ./server -count=1 -timeout 180s -run ^TestJetStreamAtomicBatchPublishCleanup$`
- [ ] Linux CI (canonical)

The FileStore test forces `os.Rename` to fail by pre-creating a **non-empty** destination tomb (Linux `ENOTEMPTY`, not only Windows dest-exists), then asserts both the original store dir and `.<name>` are gone.

## Note on Windows
`TestJetStreamAtomicBatchPublishSingleServerRecovery` failed locally on Windows during `testing.T` TempDir cleanup:

`unlinkat .../batches/<hash>/msgs/1.blk: The process cannot access the file because it is being used by another process`

That test hard-kills and recovers a partial batch. It does **not** call `cleanupLocked`. The open `.blk` is leftover FileStore handle lifetime after `Stop()` / restart recovery, which this PR does not change. The new FileStore dest-exists test and the atomic-batch cleanup test passed on the same Windows machine.