### PR TITLE
[FIXED] Inline block compaction ignores SyncAlways

### DIFF
--- a/server/filestore.go
+++ b/server/filestore.go
@@ -6255,20 +6255,13 @@ func (mb *msgBlock) compactWithFloor(floor uint64, fsDmap *interiorDeletes) erro
 
 	// We will write to a new file and mv/rename it in case of failure.
 	mfn := filepath.Join(mb.fs.fcfg.StoreDir, msgDir, fmt.Sprintf(newScan, mb.index))
-	mb.fs.dios.acquire()
-	err := os.WriteFile(mfn, nbuf, defaultFilePerms)
-	mb.fs.dios.release()
-	if err != nil {
-		_ = os.Remove(mfn)
-		return err
-	}
-	if err := os.Rename(mfn, mb.mfn); err != nil {
-		_ = os.Remove(mfn)
+	sync := mb.syncAlways
+	if err := writeAtomicallyWithTemp(mb.fs.dios, mfn, mb.mfn, nbuf, defaultFilePerms, sync); err != nil {
 		return err
 	}
 
-	// Make sure to sync
-	mb.needSync = true
+	// Make sure to sync if we have not done so yet
+	mb.needSync = !sync
 
 	// Capture the updated rbytes.
 	if rbytes := uint64(len(nbuf)); rbytes == mb.rbytes {
@@ -7940,7 +7933,6 @@ func (fs *fileStore) syncBlocks() {
 
 		// Check if we should compact here.
 		// Need to hold fs lock in case we reference psim when loading in the mb and we may remove this block if truly empty.
-		var compacted bool
 		if needsCompact {
 			// Load a delete map containing only interior deletes.
 			// This is used when compacting to know if tombstones are still relevant,
@@ -7959,14 +7951,14 @@ func (fs *fileStore) syncBlocks() {
 			err := mb.compactWithFloor(firstSeq, fsDmap)
 			// If this compact removed all raw bytes due to tombstone cleanup, schedule to remove.
 			shouldRemove := mb.rbytes == 0
+			needSync = mb.needSync
 			mb.mu.Unlock()
 			fs.mu.RUnlock()
 			if err != nil {
 				storeFsWerr(err)
 				continue
 			}
-			needDirSync = true
-			compacted = !shouldRemove
+			needDirSync = needDirSync || needSync || shouldRemove
 
 			// Check if we should remove. This will not be common, so we will re-take fs write lock here vs changing
 			//  it above which we would prefer to be a readlock such that other lookups can occur while compacting this block.
@@ -7993,7 +7985,7 @@ func (fs *fileStore) syncBlocks() {
 		}
 
 		// Check if we need to sync this block.
-		if needSync || compacted {
+		if needSync {
 			mb.mu.Lock()
 			err := mb.syncFile()
 			if err == nil {
@@ -13972,7 +13964,10 @@ func writeFileWithSync(dios *diskIOSemaphore, name string, data []byte, perm fs.
 const canFsyncDirectories = runtime.GOOS != "windows"
 
 func writeAtomically(dios *diskIOSemaphore, name string, data []byte, perm fs.FileMode, sync bool) error {
-	tmp := name + ".tmp"
+	return writeAtomicallyWithTemp(dios, name+".tmp", name, data, perm, sync)
+}
+
+func writeAtomicallyWithTemp(dios *diskIOSemaphore, tmp, name string, data []byte, perm fs.FileMode, sync bool) error {
 	flags := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
 	if sync {
 		flags = flags | os.O_SYNC

--- a/server/filestore_test.go
+++ b/server/filestore_test.go
@@ -8050,6 +8050,62 @@ func TestFileStoreMsgBlockShouldCompact(t *testing.T) {
 	require_False(t, shouldCompact)
 }
 
+func TestFileStoreInlineCompactionSync(t *testing.T) {
+	for _, syncAlways := range []bool{false, true} {
+		t.Run(fmt.Sprintf("sync_always_%v", syncAlways), func(t *testing.T) {
+			fs, err := newFileStore(
+				FileStoreConfig{
+					StoreDir:     t.TempDir(),
+					BlockSize:    3 * 1024 * 1024,
+					SyncInterval: time.Hour,
+					SyncAlways:   syncAlways,
+				},
+				StreamConfig{Name: "zzz", Subjects: []string{"foo"}, Storage: FileStorage},
+			)
+			require_NoError(t, err)
+			defer fs.Stop()
+
+			// Eleven records fit in the first block and put it over the inline
+			// compaction minimum. The twelfth record creates an active block.
+			msg := bytes.Repeat([]byte("Z"), 256*1024)
+			for range 12 {
+				_, _, err = fs.StoreMsg("foo", nil, msg, 0)
+				require_NoError(t, err)
+			}
+			require_Equal(t, fs.numMsgBlocks(), 2)
+
+			// Use syncBlocks to make sure mb.needSync
+			// is cleared on all blocks
+			fs.syncBlocks()
+			fs.mu.RLock()
+			fmb := fs.blks[0]
+			fmb.mu.RLock()
+			oldRawbytes, needSync := fmb.rbytes, fmb.needSync
+			fmb.mu.RUnlock()
+			fs.mu.RUnlock()
+
+			require_True(t, oldRawbytes > compactMinimum)
+			require_False(t, needSync)
+
+			// The final removal makes the first block less than half full and
+			// compacts it inline before RemoveMsg returns.
+			for seq := uint64(2); seq <= 7; seq++ {
+				removed, err := fs.RemoveMsg(seq)
+				require_True(t, removed)
+				require_NoError(t, err)
+			}
+
+			fmb.mu.RLock()
+			newRawbytes, needSync := fmb.rbytes, fmb.needSync
+			fmb.mu.RUnlock()
+			// Compaction happened
+			require_LessThan(t, newRawbytes, oldRawbytes)
+			// SyncAlways store should sync inline compaction
+			require_Equal(t, needSync, !syncAlways)
+		})
+	}
+}
+
 func TestFileStoreCheckSkipFirstBlockNotLoadOldBlocks(t *testing.T) {
 	sd := t.TempDir()
 	fs, err := newFileStore(


### PR DESCRIPTION
Inline compaction works by rewriting an entire block file and replacing the old file with the new compacted file. However, inline compaction ignored the SyncAlways setting. Meaning that a power loss could result in the loss of acknowledged messages.
