### PR TITLE
(2.15) [IMPROVED] Finalize desired meta reconciliation

### DIFF
--- a/server/errors.json
+++ b/server/errors.json
@@ -1280,10 +1280,10 @@
     "deprecates": ""
   },
   {
-    "constant": "JSStreamMoveNotInProgress",
+    "constant": "JSStreamReconfigureNotInProgressErr",
     "code": 400,
     "error_code": 10129,
-    "description": "stream move not in progress",
+    "description": "stream reconfiguration not in progress",
     "comment": "",
     "help": "",
     "url": "",
@@ -2234,6 +2234,16 @@
     "code": 400,
     "error_code": 10225,
     "description": "consumer's stream identity does not match: {msg}",
+    "comment": "",
+    "help": "",
+    "url": "",
+    "deprecates": ""
+  },
+  {
+    "constant": "JSStreamReconfigureInProgressErr",
+    "code": 400,
+    "error_code": 10226,
+    "description": "stream reconfiguration already in progress",
     "comment": "",
     "help": "",
     "url": "",

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -181,6 +181,14 @@ const (
 	JSApiStreamEvacuatePeer  = "$JS.API.STREAM.PEER.EVACUATE.*"
 	JSApiStreamEvacuatePeerT = "$JS.API.STREAM.PEER.EVACUATE.%s"
 
+	// JSApiStreamCancelMove is the endpoint to cancel an in-progress stream reconfiguration,
+	// rolling the stream back to the config and peers it had before the reconfiguration
+	// started. This is not limited to moves, any in-flight desired state is rolled back,
+	// which includes a scale up/down or a retention change.
+	// Will return JSON response.
+	JSApiStreamCancelMove  = "$JS.API.STREAM.CANCEL_MOVE.*"
+	JSApiStreamCancelMoveT = "$JS.API.STREAM.CANCEL_MOVE.%s"
+
 	// JSApiStreamLeaderStepDown is the endpoint to have stream leader stepdown.
 	// Will return JSON response.
 	JSApiStreamLeaderStepDown  = "$JS.API.STREAM.LEADER.STEPDOWN.*"
@@ -226,7 +234,9 @@ const (
 	JSApiServerStreamMove  = "$JS.API.ACCOUNT.STREAM.MOVE.*.*"
 	JSApiServerStreamMoveT = "$JS.API.ACCOUNT.STREAM.MOVE.%s.%s"
 
-	// JSApiServerStreamCancelMove is the endpoint to cancel a stream move
+	// JSApiServerStreamCancelMove is the endpoint to cancel an in-progress stream
+	// reconfiguration. Like JSApiStreamCancelMove this is not limited to moves, any
+	// in-flight desired state is rolled back to its origin.
 	// Only works from system account.
 	// Will return JSON response.
 	JSApiServerStreamCancelMove  = "$JS.API.ACCOUNT.STREAM.CANCEL_MOVE.*.*"
@@ -1037,6 +1047,7 @@ func (s *Server) setJetStreamExportSubs() error {
 		{JSApiStreamRestore, s.jsStreamRestoreRequest},
 		{JSApiStreamRemovePeer, s.jsStreamRemovePeerRequest},
 		{JSApiStreamEvacuatePeer, s.jsStreamEvacuatePeerRequest},
+		{JSApiStreamCancelMove, s.jsStreamCancelMoveRequest},
 		{JSApiStreamLeaderStepDown, s.jsStreamLeaderStepDownRequest},
 		{JSApiConsumerLeaderStepDown, s.jsConsumerLeaderStepDownRequest},
 		{JSApiMsgDelete, s.jsMsgDeleteRequest},
@@ -2386,6 +2397,81 @@ func (s *Server) jsConsumerLeaderStepDownRequest(sub *subscription, c *client, _
 	s.sendAPIResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(resp))
 }
 
+// Request to cancel an in-progress reconfiguration of a clustered stream, rolling the
+// desired state back to its origin. Not limited to moves, a scale or retention change
+// in flight is rolled back just the same.
+func (s *Server) jsStreamCancelMoveRequest(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
+	if c == nil || !s.JetStreamEnabled() {
+		return
+	}
+	ci, acc, hdr, msg, err := s.getRequestInfo(c, rmsg)
+	if err != nil {
+		s.Warnf(badAPIRequestT, msg)
+		return
+	}
+
+	name := tokenAt(subject, 5)
+
+	var resp = JSApiStreamUpdateResponse{ApiResponse: ApiResponse{Type: JSApiStreamUpdateResponseType}}
+
+	// A move only exists in clustered mode.
+	if !s.JetStreamIsClustered() {
+		resp.Error = NewJSClusterRequiredError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+
+	js, cc := s.getJetStreamCluster()
+	if js == nil || cc == nil {
+		return
+	}
+	if js.isLeaderless() {
+		resp.Error = NewJSClusterNotAvailError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+
+	js.mu.RLock()
+	isLeader := cc.isLeader()
+	js.mu.RUnlock()
+
+	// The rollback is proposed to the meta layer, only the meta leader can do that.
+	if !isLeader {
+		return
+	}
+
+	if errorOnRequiredApiLevel(hdr) {
+		resp.Error = NewJSRequiredApiLevelError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+
+	if hasJS, doErr := acc.checkJetStream(); !hasJS {
+		if doErr {
+			resp.Error = NewJSNotEnabledForAccountError()
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		}
+		return
+	}
+
+	js.mu.Lock()
+	defer js.mu.Unlock()
+
+	osa := js.streamAssignmentOrInflight(acc.Name, name)
+	if osa == nil {
+		resp.Error = NewJSStreamNotFoundError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+	// A group that has no desired state or origin has no reconfigure in progress.
+	if osa.desiredOrigin() == nil {
+		resp.Error = NewJSStreamReconfigureNotInProgressError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
+		return
+	}
+	s.jsClusteredStreamCancelMoveLocked(osa, acc.Name, reply)
+}
+
 // Request to remove a peer from a clustered stream.
 func (s *Server) jsStreamRemovePeerRequest(_ *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
 	s.jsStreamRemapPeerRequest(nil, c, nil, subject, reply, rmsg, true)
@@ -2969,7 +3055,9 @@ func (s *Server) jsLeaderServerStreamMoveRequest(sub *subscription, c *client, _
 	s.jsClusteredStreamUpdateRequestLocked(&ciNew, targetAcc.(*Account), subject, reply, rmsg, &cfg, peers, newCluster, false)
 }
 
-// Request to have the metaleader move a stream on a peer to another
+// Request to have the metaleader cancel an in-progress reconfiguration of a stream,
+// rolling the desired state back to its origin. Not limited to moves, a scale or
+// retention change in flight is rolled back just the same.
 func (s *Server) jsLeaderServerStreamCancelMoveRequest(sub *subscription, c *client, _ *Account, subject, reply string, rmsg []byte) {
 	if c == nil || !s.JetStreamEnabled() {
 		return
@@ -3025,48 +3113,13 @@ func (s *Server) jsLeaderServerStreamCancelMoveRequest(sub *subscription, c *cli
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
-	var origin *desiredRaftGroupOrigin
-	if osa.Group.Desired != nil {
-		origin = osa.Group.Desired.Origin
-	} else {
-		// A move started before the upgrade to desired state must stay cancellable,
-		// reconstruct the origin if it's a legacy move.
-		origin = osa.legacyMoveOrigin()
-	}
-	// A group that has no desired state or origin, so no move in progress.
-	if origin == nil {
-		resp.Error = NewJSStreamMoveNotInProgressError()
+	// A group that has no desired state or origin has no reconfigure in progress.
+	if osa.desiredOrigin() == nil {
+		resp.Error = NewJSStreamReconfigureNotInProgressError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(msg), s.jsonResponse(&resp))
 		return
 	}
-
-	csa := osa.copyGroup()
-	// Need to respond to the client that cancels.
-	csa.Reply = reply
-	// Revert replicas and placement in the config immediately.
-	csa.Config = osa.Config.clone()
-	csa.Config.Replicas = origin.Replicas
-	csa.Config.Placement = origin.Placement.clone()
-	if origin.Retention != nil {
-		csa.Config.Retention = *origin.Retention
-	}
-	// Move back to the initial peer set via desired state.
-	csa.Group.Peers = copyStrings(origin.Peers)
-	csa.Group.Cluster = origin.Cluster
-	csa.Group = osa.Group.withDesired(csa.Group)
-	// withDesired only carries over a prior origin, a legacy move has none yet.
-	// Record it, so the rollback reports the same target while it converges.
-	if csa.Group.Desired.Origin == nil {
-		csa.Group.Desired.Origin = origin
-	}
-
-	s.Noticef("Requested cancel of move: R=%d '%s > %s' and restore previous peer set %+v",
-		origin.Replicas, accName, streamName, s.peerSetToNames(origin.Peers))
-
-	if err = cc.meta.Propose(cc.term, encodeUpdateStreamAssignment(csa)); err != nil {
-		return
-	}
-	cc.trackInflightStreamProposal(accName, csa, false)
+	s.jsClusteredStreamCancelMoveLocked(osa, accName, reply)
 }
 
 // Request to have an account purged

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -205,7 +205,12 @@ type desiredRaftGroup struct {
 	Cluster   string   `json:"cluster,omitempty"`
 	Preferred string   `json:"preferred,omitempty"`
 
+	// ScaleDown marks this desired state as a scale down. The Peers field is the
+	// total set that can be scaled down from.
 	ScaleDown bool `json:"scale_down,omitempty"`
+
+	// Move marks this desired state as retargeting placement.
+	Move bool `json:"move,omitempty"`
 
 	// Removed are peers an operator peer-removed from this group. A group that
 	// can't reach quorum may only evict what's recorded here.
@@ -250,6 +255,27 @@ func (sa *streamAssignment) legacyMoveOrigin() *desiredRaftGroupOrigin {
 	}
 }
 
+// desiredOrigin returns the origin to roll back to, either recorded on the desired
+// state or reconstructed from a legacy move. Nil if there's nothing to roll back to.
+func (sa *streamAssignment) desiredOrigin() *desiredRaftGroupOrigin {
+	if sa == nil || sa.Group == nil {
+		return nil
+	}
+	if sa.Group.Desired != nil {
+		return sa.Group.Desired.Origin
+	}
+	return sa.legacyMoveOrigin()
+}
+
+// moveInFlight returns whether a move is still converging, including one that was
+// started before the upgrade to desired state.
+func (sa *streamAssignment) moveInFlight() bool {
+	if sa == nil || sa.Group == nil {
+		return false
+	}
+	return (sa.Group.Desired != nil && sa.Group.Desired.Move) || sa.legacyMoveOrigin() != nil
+}
+
 // withDesired returns a copy of rg with target expressed as the desired state.
 // target MUST already be a copy or fresh group, as it's directly referenced.
 func (rg *raftGroup) withDesired(target *raftGroup) *raftGroup {
@@ -274,6 +300,8 @@ func (rg *raftGroup) withDesired(target *raftGroup) *raftGroup {
 		Preferred: target.Preferred,
 	}
 	if rg.Desired != nil {
+		// Must preserve whether an in-flight move is being retargeted.
+		ng.Desired.Move = rg.Desired.Move
 		// Must preserve the prior origin (if any).
 		if rg.Desired.Origin != nil {
 			origin := *rg.Desired.Origin
@@ -381,6 +409,10 @@ func (rg *raftGroup) withRetentionChange(osa *streamAssignment, newRetention Ret
 		}
 		// Must always register desired state.
 		rg = osa.Group.withDesired(rg)
+		// A legacy move absorbed into desired state must keep counting as a move in flight.
+		if osa.legacyMoveOrigin() != nil {
+			rg.Desired.Move = true
+		}
 	}
 	// Desired state MUST always have an origin recorded, or it can't be rolled back or canceled.
 	rg.populateOrigin(osa)
@@ -8619,12 +8651,16 @@ func (rg *raftGroup) reconcileDesiredState(reconcile desiredAssignmentUpdate, re
 		}
 		ng := rg.copyGroup()
 		newPeers := rg.Peers
-		if len(newPeers) > replicas {
+		// An over-replicated peer set is a legacy move being converted into
+		// desired state, it must keep counting as a move in flight.
+		legacyMove := len(newPeers) > replicas
+		if legacyMove {
 			newPeers = newPeers[len(newPeers)-replicas:]
 		}
 		ng.Peers = newPeers
 		ng = rg.withDesired(ng)
 		ng.Desired.Term = reconcile.Term
+		ng.Desired.Move = legacyMove
 		return ng
 	}
 
@@ -9061,6 +9097,9 @@ func (cc *jetStreamCluster) reassignStreamPeers(sa *streamAssignment, peers []st
 	// Preserve how the group is meant to converge.
 	if d := sa.Group.Desired; d != nil {
 		csa.Group.Desired.ScaleDown = d.ScaleDown
+	} else if sa.legacyMoveOrigin() != nil {
+		// A legacy move absorbed into desired state must keep counting as a move in flight.
+		csa.Group.Desired.Move = true
 	}
 	if remove {
 		removeFrom := func(from []string) []string {
@@ -9889,6 +9928,49 @@ func sysRequest[T any](s *Server, subjFormat string, args ...any) (*T, error) {
 	}
 }
 
+// jsClusteredStreamCancelMoveLocked proposes a rollback of the stream's in-flight desired
+// state to its recorded origin. The caller MUST have verified an origin exists, via
+// desiredOrigin. The client is responded to once the rollback proposal applies.
+// Lock should be held.
+func (s *Server) jsClusteredStreamCancelMoveLocked(osa *streamAssignment, accName, reply string) {
+	js, cc := s.getJetStreamCluster()
+	if js == nil || cc == nil || cc.meta == nil {
+		return
+	}
+	origin := osa.desiredOrigin()
+	if origin == nil {
+		return
+	}
+	// A rollback of a move still counts as a move in flight, it must keep blocking other
+	// moves and scales until it completes. Must capture before the group is retargeted.
+	moveInFlight := osa.moveInFlight()
+
+	csa := osa.copyGroup()
+	// Need to respond to the client that cancels.
+	csa.Reply = reply
+	// Revert replicas, placement and retention in the config immediately.
+	csa.Config = osa.Config.clone()
+	csa.Config.Replicas = origin.Replicas
+	csa.Config.Placement = origin.Placement.clone()
+	if origin.Retention != nil {
+		csa.Config.Retention = *origin.Retention
+	}
+	// Move back to the initial peer set via desired state.
+	csa.Group.Peers = copyStrings(origin.Peers)
+	csa.Group.Cluster = origin.Cluster
+	csa.Group = osa.Group.withDesired(csa.Group)
+	csa.Group.Desired.Move = moveInFlight
+	// withDesired only carries over a prior origin, a legacy move has none yet.
+	// Record it, so the rollback reports the same target while it converges.
+	if csa.Group.Desired.Origin == nil {
+		csa.Group.Desired.Origin = origin
+	}
+	if err := cc.meta.Propose(cc.term, encodeUpdateStreamAssignment(csa)); err != nil {
+		return
+	}
+	cc.trackInflightStreamProposal(accName, csa, false)
+}
+
 func (s *Server) jsClusteredStreamUpdateRequest(ci *ClientInfo, acc *Account, subject, reply string, rmsg []byte, cfg *StreamConfig, pedantic bool) {
 	js := s.getJetStream()
 	if js == nil {
@@ -9996,11 +10078,34 @@ func (s *Server) jsClusteredStreamUpdateRequestLocked(ci *ClientInfo, acc *Accou
 	// Check for replica changes.
 	isReplicaChange := newCfg.Replicas != osa.Config.Replicas
 
-	// A move or scale retargets the desired peer set, so only one can be inflight at a time.
-	// Otherwise, peers of the abandoned target could accumulate in the assignment unbounded.
-	// A legacy move counts as well, it is inflight but not expressed as desired state yet.
-	// A retention change is allowed, it does not adjust the peer set.
-	if (isMoveRequest || isReplicaChange) && (osa.Group.Desired != nil || osa.legacyMoveOrigin() != nil) {
+	// Combining a move and a scale in a single update is not allowed.
+	if isMoveRequest && isReplicaChange {
+		resp.Error = NewJSStreamMoveAndScaleError()
+		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+		return
+	}
+
+	// A move retargets the desired peer set, so only one can be inflight at a time.
+	// Otherwise, peers of the abandoned target could accumulate in the assignment
+	// unbounded. A move can't combine with any other inflight reconfiguration across
+	// requests either, a scale and a retention change both converge through desired
+	// state. A legacy move counts as well, it is inflight but not expressed as desired
+	// state yet.
+	moveInFlight := osa.moveInFlight()
+	if isMoveRequest {
+		if moveInFlight {
+			resp.Error = NewJSStreamMoveInProgressError()
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+			return
+		}
+		if osa.Group.Desired != nil {
+			resp.Error = NewJSStreamReconfigureInProgressError()
+			s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
+			return
+		}
+	} else if isReplicaChange && moveInFlight {
+		// A scale can't combine with an inflight move either. Scales may freely stack
+		// onto an inflight scale or retention change, but not with a move.
 		resp.Error = NewJSStreamMoveInProgressError()
 		s.sendAPIErrResponse(ci, acc, subject, reply, string(rmsg), s.jsonResponse(&resp))
 		return
@@ -10035,6 +10140,7 @@ func (s *Server) jsClusteredStreamUpdateRequestLocked(ci *ClientInfo, acc *Accou
 			rg.Cluster = peerSetCluster
 		}
 		rg = osa.Group.withDesired(rg)
+		rg.Desired.Move = true
 	} else if isReplicaChange {
 		currentPeers := rg.Peers
 		if osa.Group.Desired != nil {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4299,13 +4299,21 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 	if leaderTerm == 0 {
 		return
 	}
-	ourPeerId, cc, s := n.ID(), js.cluster, js.srv
+	ourPeerId, s := n.ID(), js.srv
+
+	// Sanity-check: we're still the leader.
+	if !n.Leader() {
+		return
+	}
 
 	// Store whether any peers are currently being caught up, in which case they're
 	// not current yet and we need to wait before removing peers.
 	catchups := mset.catchupPeers()
 
+	// Snapshot the assignment state we need up front, so the Raft reads below don't
+	// contend for Raft locks while holding the JetStream lock.
 	js.mu.RLock()
+	cc := js.cluster
 	// We are shutting down.
 	if cc == nil || cc.meta == nil {
 		js.mu.RUnlock()
@@ -4315,35 +4323,35 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 		js.mu.RUnlock()
 		return
 	}
-	// Sanity-check: we're still the leader.
-	if !n.Leader() {
-		js.mu.RUnlock()
-		return
-	}
 	meta := cc.meta
 	accName, streamName, replicas := sa.Client.serviceAccount(), sa.Config.Name, sa.Config.Replicas
+	current := copyStrings(sa.Group.Peers)
+	// If desired state is missing, inform the meta leader to create desired state.
+	// Or, if the recorded leader term isn't ours, then get that updated first.
+	desired := sa.Group.Desired
+	var desiredID string
+	var desiredScaleDown bool
+	var desiredPeers []string
+	if desired != nil {
+		// MUST copy the peers, the assignment can be updated once we release below.
+		desiredID, desiredScaleDown, desiredPeers = desired.ID, desired.ScaleDown, copyStrings(desired.Peers)
+	}
+	needDesired := desired == nil || desired.ID == _EMPTY_ || desired.Term != leaderTerm
+	js.mu.RUnlock()
 
-	update := desiredAssignmentUpdate{Term: leaderTerm}
+	update := desiredAssignmentUpdate{Term: leaderTerm, ID: desiredID}
 	sendMetaUpdate := func() {
 		reconcile := &streamAssignmentReconcile{Account: accName, Stream: streamName, desiredAssignmentUpdate: update}
 		s.sendInternalMsgLocked(streamAssignmentReconcileSubj, _EMPTY_, nil, reconcile)
 	}
 
-	// If desired state is missing, inform the meta leader to create desired state.
-	// Or, if the recorded leader term isn't ours, then get that updated first.
-	desired := sa.Group.Desired
-	if desired != nil {
-		update.ID = desired.ID
-	}
-	if desired == nil || desired.ID == _EMPTY_ || desired.Term != leaderTerm {
-		js.mu.RUnlock()
+	if needDesired {
 		sendMetaUpdate()
 		return
 	}
 
 	// A snapshot is required. Automatically installs a snapshot for a R1 scaleup.
 	if n.NeedSnapshot() {
-		js.mu.RUnlock()
 		if err := mset.flushAllPending(); err == nil {
 			n.InstallSnapshot(mset.stateSnapshot(), true)
 		}
@@ -4351,7 +4359,6 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 	}
 	// If a membership change is in progress, we just wait for it to clear.
 	if n.MembershipChangeInProgress() {
-		js.mu.RUnlock()
 		return
 	}
 
@@ -4360,13 +4367,12 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 	for _, p := range actual {
 		actualPeers = append(actualPeers, p.ID)
 	}
-	desiredPeers := desired.Peers
 
 	// A raft member that is not current member or no longer part of the meta group,
 	// has been evicted from the cluster, e.g. by a server peer-remove. It can't take
 	// part in this migration, so remove it from the group right away rather than
 	// waiting for the rest of the migration to complete.
-	current, metaPeers := copyStrings(sa.Group.Peers), meta.PeerNames()
+	metaPeers := meta.PeerNames()
 	var evicted []string
 	for _, peer := range actualPeers {
 		if !slices.Contains(current, peer) || !slices.Contains(metaPeers, peer) {
@@ -4379,11 +4385,8 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 		// ourselves, preferring a successor that is already in the desired peer set.
 		remove := s.selectPeerToRemove(ourPeerId, actual, evicted)
 		if remove == ourPeerId {
-			preferred := s.selectStepDownPreferred(ourPeerId, actual, desiredPeers)
-			js.mu.RUnlock()
-			n.StepDown(preferred)
+			n.StepDown(s.selectStepDownPreferred(ourPeerId, actual, desiredPeers))
 		} else {
-			js.mu.RUnlock()
 			n.ProposeRemovePeer(remove)
 		}
 		return
@@ -4397,18 +4400,15 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 		}
 	}
 	if len(candidates) > 0 {
-		add := s.selectPeerToAdd(n, ourPeerId, actual, candidates)
-		js.mu.RUnlock()
-		if add != _EMPTY_ {
+		if add := s.selectPeerToAdd(n, ourPeerId, actual, candidates); add != _EMPTY_ {
 			n.ProposeAddPeer(add)
 		}
 		return
 	}
 
 	// If scaling down, we need to select where to.
-	if desired.ScaleDown {
-		update.ScaleDownPeers = s.selectScaleDownPeers(ourPeerId, actual, desired.Peers, replicas)
-		js.mu.RUnlock()
+	if desiredScaleDown {
+		update.ScaleDownPeers = s.selectScaleDownPeers(ourPeerId, actual, desiredPeers, replicas)
 		sendMetaUpdate()
 		return
 	}
@@ -4429,7 +4429,6 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 			}
 		}
 		update.MetaPeers = combined
-		js.mu.RUnlock()
 		sendMetaUpdate()
 		return
 	}
@@ -4448,7 +4447,18 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 
 	// If the peer sets are an exact match, we can remove a peer.
 	if len(remaining) > 0 && exactMatch {
-		// First need to check on any consumers and make sure they have moved properly before scaling down ourselves.
+		// Removing a peer is destructive, so re-validate our snapshot against the
+		// assignment before acting on it. While we hold the lock, look up the live
+		// assignment and also check on any consumers and make sure they have moved
+		// properly before scaling down ourselves.
+		js.mu.RLock()
+		sa = js.streamAssignment(accName, streamName)
+		if sa == nil || sa.Group == nil || sa.Group.Desired == nil || sa.Group.Desired.ID != desiredID {
+			// The desired state moved on under us, reassess on the next cycle.
+			js.mu.RUnlock()
+			return
+		}
+		var blockedBy string
 		for name, c := range sa.consumers {
 			if c.unsupported != nil {
 				continue
@@ -4456,13 +4466,20 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 			for _, peer := range c.Group.Peers {
 				// If we have peers still in the old set block.
 				if !slices.Contains(desiredPeers, peer) {
-					s.Debugf("Scale down of '%s > %s' blocked by consumer '%s'", sa.Client.serviceAccount(), sa.Config.Name, name)
-					js.mu.RUnlock()
-					// We need to wait but still nudge the meta leader since it might need to remap consumers.
-					sendMetaUpdate()
-					return
+					blockedBy = name
+					break
 				}
 			}
+			if blockedBy != _EMPTY_ {
+				break
+			}
+		}
+		js.mu.RUnlock()
+		if blockedBy != _EMPTY_ {
+			s.Debugf("Scale down of '%s > %s' blocked by consumer '%s'", accName, streamName, blockedBy)
+			// We need to wait but still nudge the meta leader since it might need to remap consumers.
+			sendMetaUpdate()
+			return
 		}
 
 		// Remove old peers one at a time, the leader selected last.
@@ -4483,25 +4500,20 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 			}
 		}
 		if quorum := (len(actual)-1)/2 + 1; currentCount < quorum {
-			js.mu.RUnlock()
 			return
 		}
 		// If we have current desired peers, and we're not a desired peer ourselves, step down.
 		if len(currentDesired) > 0 && !slices.Contains(desiredPeers, ourPeerId) {
 			// If desired peers are still catching up, we wait for a quorum of them to complete for now.
 			if quorum := len(desiredPeers)/2 + 1; len(currentDesired) < quorum {
-				js.mu.RUnlock()
 				return
 			}
-			preferred := s.selectStepDownPreferred(ourPeerId, actual, currentDesired)
-			js.mu.RUnlock()
-			if preferred != _EMPTY_ {
+			if preferred := s.selectStepDownPreferred(ourPeerId, actual, currentDesired); preferred != _EMPTY_ {
 				n.StepDown(preferred)
 			}
 			return
 		}
 
-		js.mu.RUnlock()
 		// Step down and perform a leader transfer if we'd remove ourselves. We are
 		// selected last, so leadership changes at most once, and every remaining
 		// member is already in the desired peer set so any successor works.
@@ -4516,7 +4528,6 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 	// We're done.
 	update.MetaPeers = actualPeers
 	update.PeersMatch = exactMatch
-	js.mu.RUnlock()
 	sendMetaUpdate()
 }
 
@@ -7558,20 +7569,23 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 	if leaderTerm == 0 {
 		return
 	}
-	ourPeerId, cc, s := n.ID(), js.cluster, js.srv
+	ourPeerId, s := n.ID(), js.srv
 
+	// Sanity-check: we're still the leader.
+	if !n.Leader() {
+		return
+	}
+
+	// Snapshot the assignment state we need up front, so the Raft reads below don't
+	// contend for Raft locks while holding the JetStream lock.
 	js.mu.RLock()
+	cc := js.cluster
 	// We are shutting down.
 	if cc == nil || cc.meta == nil {
 		js.mu.RUnlock()
 		return
 	}
 	if ca == nil || ca.Group == nil {
-		js.mu.RUnlock()
-		return
-	}
-	// Sanity-check: we're still the leader.
-	if !n.Leader() {
 		js.mu.RUnlock()
 		return
 	}
@@ -7585,28 +7599,35 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 	}
 
 	replicas := ca.Config.replicas(osa.Config)
+	// MUST copy, the stream assignment can be updated once we release below.
+	streamPeers := copyStrings(osa.Group.Peers)
+	current := copyStrings(ca.Group.Peers)
+	// If desired state is missing, inform the meta leader to create desired state.
+	// Or, if the recorded leader term isn't ours, then get that updated first.
+	desired := ca.Group.Desired
+	var desiredID string
+	var desiredScaleDown bool
+	var desiredPeers []string
+	if desired != nil {
+		// MUST copy the peers, the assignment can be updated once we release below.
+		desiredID, desiredScaleDown, desiredPeers = desired.ID, desired.ScaleDown, copyStrings(desired.Peers)
+	}
+	needDesired := desired == nil || desired.ID == _EMPTY_ || desired.Term != leaderTerm
+	js.mu.RUnlock()
 
-	update := desiredAssignmentUpdate{Term: leaderTerm}
+	update := desiredAssignmentUpdate{Term: leaderTerm, ID: desiredID}
 	sendMetaUpdate := func() {
 		reconcile := &consumerAssignmentReconcile{Account: accName, Stream: streamName, Consumer: consumerName, desiredAssignmentUpdate: update}
 		s.sendInternalMsgLocked(consumerAssignmentReconcileSubj, _EMPTY_, nil, reconcile)
 	}
 
-	// If desired state is missing, inform the meta leader to create desired state.
-	// Or, if the recorded leader term isn't ours, then get that updated first.
-	desired := ca.Group.Desired
-	if desired != nil {
-		update.ID = desired.ID
-	}
-	if desired == nil || desired.ID == _EMPTY_ || desired.Term != leaderTerm {
-		js.mu.RUnlock()
+	if needDesired {
 		sendMetaUpdate()
 		return
 	}
 
 	// A snapshot is required. Automatically installs a snapshot for a R1 scaleup.
 	if n.NeedSnapshot() {
-		js.mu.RUnlock()
 		if snap, err := o.store.EncodedState(); err == nil {
 			n.InstallSnapshot(snap, true)
 		}
@@ -7614,7 +7635,6 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 	}
 	// If a membership change is in progress, we just wait for it to clear.
 	if n.MembershipChangeInProgress() {
-		js.mu.RUnlock()
 		return
 	}
 
@@ -7623,13 +7643,12 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 	for _, p := range actual {
 		actualPeers = append(actualPeers, p.ID)
 	}
-	desiredPeers := desired.Peers
 
 	// A raft member that is not current member or no longer part of the meta group,
 	// has been evicted from the cluster, e.g. by a server peer-remove. It can't take
 	// part in this migration, so remove it from the group right away rather than
 	// waiting for the rest of the migration to complete.
-	current, metaPeers := copyStrings(ca.Group.Peers), meta.PeerNames()
+	metaPeers := meta.PeerNames()
 	var evicted []string
 	for _, peer := range actualPeers {
 		if !slices.Contains(current, peer) || !slices.Contains(metaPeers, peer) {
@@ -7642,11 +7661,8 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 		// ourselves, preferring a successor that is already in the desired peer set.
 		remove := s.selectPeerToRemove(ourPeerId, actual, evicted)
 		if remove == ourPeerId {
-			preferred := s.selectStepDownPreferred(ourPeerId, actual, desiredPeers)
-			js.mu.RUnlock()
-			n.StepDown(preferred)
+			n.StepDown(s.selectStepDownPreferred(ourPeerId, actual, desiredPeers))
 		} else {
-			js.mu.RUnlock()
 			n.ProposeRemovePeer(remove)
 		}
 		return
@@ -7660,18 +7676,15 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 		}
 	}
 	if len(candidates) > 0 {
-		add := s.selectPeerToAdd(n, ourPeerId, actual, candidates)
-		js.mu.RUnlock()
-		if add != _EMPTY_ {
+		if add := s.selectPeerToAdd(n, ourPeerId, actual, candidates); add != _EMPTY_ {
 			n.ProposeAddPeer(add)
 		}
 		return
 	}
 
 	// If scaling down, we need to select where to.
-	if desired.ScaleDown {
-		update.ScaleDownPeers = s.selectScaleDownPeers(ourPeerId, actual, desired.Peers, replicas)
-		js.mu.RUnlock()
+	if desiredScaleDown {
+		update.ScaleDownPeers = s.selectScaleDownPeers(ourPeerId, actual, desiredPeers, replicas)
 		sendMetaUpdate()
 		return
 	}
@@ -7692,17 +7705,15 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 			if slices.Contains(current, peer) {
 				continue
 			}
-			if !slices.Contains(osa.Group.Peers, peer) {
+			if !slices.Contains(streamPeers, peer) {
 				continue
 			}
 			combined = append(combined, peer)
 		}
 		if len(combined) == len(current) {
-			js.mu.RUnlock()
 			return
 		}
 		update.MetaPeers = combined
-		js.mu.RUnlock()
 		sendMetaUpdate()
 		return
 	}
@@ -7726,10 +7737,8 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 		// member is already in the desired peer set so any successor works.
 		remove := s.selectPeerToRemove(ourPeerId, actual, remaining)
 		if remove == ourPeerId {
-			js.mu.RUnlock()
 			n.StepDown()
 		} else {
-			js.mu.RUnlock()
 			n.ProposeRemovePeer(remove)
 		}
 		return
@@ -7738,7 +7747,6 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 	// We're done.
 	update.MetaPeers = actualPeers
 	update.PeersMatch = exactMatch
-	js.mu.RUnlock()
 	sendMetaUpdate()
 }
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4552,13 +4552,14 @@ func (mset *stream) isMigrating() bool {
 	if sa.Group.Desired != nil {
 		return true
 	}
-	// The sign of migration is if our group peer count != configured replica count.
-	if sa.Config.Replicas != len(sa.Group.Peers) {
+	// Without desired state, more peers than replicas is a legacy move left to finish.
+	// Fewer is under-replicated, healed by the meta leader; migrating would never converge.
+	if len(sa.Group.Peers) > sa.Config.Replicas {
 		return true
 	}
 	// Final sanity check is that the actual peer set equals the one in the assignment.
 	peers := sa.Group.node.PeerNames()
-	if sa.Config.Replicas != len(peers) {
+	if len(peers) > sa.Config.Replicas {
 		return true
 	}
 	for _, peer := range sa.Group.Peers {
@@ -7775,13 +7776,14 @@ func (o *consumer) isMigrating() bool {
 	if ca.Group.Desired != nil {
 		return true
 	}
-	// The sign of migration is if our group peer count != configured replica count.
-	if replicas != len(ca.Group.Peers) {
+	// Without desired state, more peers than replicas is a legacy move left to finish.
+	// Fewer is under-replicated, healed by the meta leader; migrating would never converge.
+	if len(ca.Group.Peers) > replicas {
 		return true
 	}
 	// Final sanity check is that the actual peer set equals the one in the assignment.
 	peers := ca.Group.node.PeerNames()
-	if replicas != len(peers) {
+	if len(peers) > replicas {
 		return true
 	}
 	for _, peer := range ca.Group.Peers {

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -192,6 +192,10 @@ type raftGroup struct {
 	Desired *desiredRaftGroup `json:"desired,omitempty"`
 	// Internal
 	node RaftNode
+	// migration reports what the group leader is currently doing to move this group
+	// toward its desired state. Local to the group leader and not replicated: only
+	// the leader drives the migration, and only the leader answers INFO requests.
+	migration *DesiredClusterInfoStatus
 }
 
 // desiredGroupPlacement specifies the desired peer set.
@@ -3887,6 +3891,8 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 			mmt.Stop()
 			mmt, mmtc = nil, nil
 		}
+		// Don't leave a stale status behind for a migration that's done or abandoned.
+		js.setMigrationStatus(mset.raftGroup(), nil)
 	}
 	defer stopMigrationMonitoring()
 
@@ -4199,7 +4205,9 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 			}
 			// Reset to the slower fallback speed.
 			resetMigrationMonitoring(migrateFallbackCheckInterval)
-			js.runStreamMigration(mset, sa, n, leaderTerm)
+			status := js.runStreamMigration(mset, sa, n, leaderTerm)
+			// Resolve after determining the status, so that we don't set it on a stale group.
+			js.setMigrationStatus(mset.raftGroup(), status)
 
 		case err := <-restoreDoneCh:
 			// We have completed a restore from snapshot on this server. The stream assignment has
@@ -4353,8 +4361,8 @@ func peerIDs(peers []*Peer) []string {
 // longer part of the meta group, it has been evicted from the cluster, e.g. by a
 // server peer-remove. It can't take part in a migration, so remove it from the
 // group right away rather than waiting for the rest of the migration to complete.
-// Returns true if we've acted, and the migration must wait for the next cycle.
-func (s *Server) removeEvictedPeers(n, meta RaftNode, actual []*Peer, actualPeers, current, desiredPeers []string) bool {
+// Returns a status if we've acted, and the migration must wait for the next cycle.
+func (s *Server) removeEvictedPeers(n, meta RaftNode, actual []*Peer, actualPeers, current, desiredPeers []string) *DesiredClusterInfoStatus {
 	metaPeers := meta.PeerNames()
 	var evicted []string
 	for _, peer := range actualPeers {
@@ -4363,24 +4371,29 @@ func (s *Server) removeEvictedPeers(n, meta RaftNode, actual []*Peer, actualPeer
 		}
 	}
 	if len(evicted) == 0 {
-		return false
+		return nil
 	}
 	// Remove evicted peers one at a time, the leader last so leadership stays
 	// stable throughout. Step down and perform a leader transfer if we'd remove
 	// ourselves, preferring a successor that is already in the desired peer set.
 	ourPeerId := n.ID()
-	if remove := s.selectPeerToRemove(ourPeerId, actual, evicted); remove == ourPeerId {
-		n.StepDown(s.selectStepDownPreferred(ourPeerId, actual, desiredPeers))
-	} else {
-		n.ProposeRemovePeer(remove)
+	remove := s.selectPeerToRemove(ourPeerId, actual, evicted)
+	if remove == ourPeerId {
+		err := n.StepDown(s.selectStepDownPreferred(ourPeerId, actual, desiredPeers))
+		return mstat(MigrationStatusMembership, "stepping down, evicted from group").withErr(err)
 	}
-	return true
+	err := n.ProposeRemovePeer(remove)
+	name := s.serverNameForNode(remove)
+	if name == _EMPTY_ {
+		name = fmt.Sprintf("with id %s", remove)
+	}
+	return mstat(MigrationStatusMembership, "removing evicted peer %s", name).withErr(err)
 }
 
 // extendPeerSet extends the actual peer set through the log, but only with peers
 // that are part of the desired set.
-// Returns true if we've acted, and the migration must wait for the next cycle.
-func (s *Server) extendPeerSet(n RaftNode, actual []*Peer, actualPeers, current, desiredPeers []string) bool {
+// Returns a status if we've acted, and the migration must wait for the next cycle.
+func (s *Server) extendPeerSet(n RaftNode, actual []*Peer, actualPeers, current, desiredPeers []string) *DesiredClusterInfoStatus {
 	var candidates []string
 	for _, peer := range current {
 		if !slices.Contains(actualPeers, peer) && slices.Contains(desiredPeers, peer) {
@@ -4388,25 +4401,27 @@ func (s *Server) extendPeerSet(n RaftNode, actual []*Peer, actualPeers, current,
 		}
 	}
 	if len(candidates) == 0 {
-		return false
+		return nil
 	}
-	if add := s.selectPeerToAdd(n, n.ID(), actual, candidates); add != _EMPTY_ {
-		n.ProposeAddPeer(add)
+	add := s.selectPeerToAdd(n, n.ID(), actual, candidates)
+	if add == _EMPTY_ {
+		return mstat(MigrationStatusQuorum, "waiting for quorum to add peer")
 	}
-	return true
+	err := n.ProposeAddPeer(add)
+	name := s.serverNameForNode(add)
+	if name == _EMPTY_ {
+		name = fmt.Sprintf("with id %s", add)
+	}
+	return mstat(MigrationStatusMembership, "adding peer %s", name).withErr(err)
 }
 
 // Migrate a stream from peer set A to peer set B.
-func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n RaftNode, leaderTerm uint64) {
-	if leaderTerm == 0 {
-		return
+func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n RaftNode, leaderTerm uint64) *DesiredClusterInfoStatus {
+	// Sanity-check: we're still the leader.
+	if leaderTerm == 0 || !n.Leader() {
+		return nil
 	}
 	ourPeerId, s := n.ID(), js.srv
-
-	// Sanity-check: we're still the leader.
-	if !n.Leader() {
-		return
-	}
 
 	// Store whether any peers are currently being caught up, in which case they're
 	// not current yet and we need to wait before removing peers.
@@ -4419,11 +4434,11 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 	// We are shutting down.
 	if cc == nil || cc.meta == nil {
 		js.mu.RUnlock()
-		return
+		return mstat(MigrationStatusUnavailable, "shutting down")
 	}
 	if sa == nil || sa.Group == nil {
 		js.mu.RUnlock()
-		return
+		return mstat(MigrationStatusUnavailable, "no stream assignment")
 	}
 	meta := cc.meta
 	accName, streamName, replicas := sa.Client.serviceAccount(), sa.Config.Name, sa.Config.Replicas
@@ -4438,36 +4453,42 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 	}
 	if needDesired {
 		sendMetaUpdate()
-		return
+		return mstat(MigrationStatusMeta, "requesting desired state from meta leader")
 	}
 	// A snapshot is required. Automatically installs a snapshot for a R1 scaleup.
 	if n.NeedSnapshot() {
-		if err := mset.flushAllPending(); err == nil {
-			n.InstallSnapshot(mset.stateSnapshot(), true)
+		if err := mset.flushAllPending(); err != nil {
+			if errors.Is(err, ErrStoreClosed) {
+				return mstat(MigrationStatusUnavailable, "shutting down")
+			}
+			return mstat(MigrationStatusSnapshot, "waiting to flush pending state for snapshot").withErr(err)
 		}
-		return
+		if err := n.InstallSnapshot(mset.stateSnapshot(), true); err != nil {
+			return mstat(MigrationStatusSnapshot, "waiting to install snapshot").withErr(err)
+		}
+		return mstat(MigrationStatusSnapshot, "installing snapshot")
 	}
 	// If a membership change is in progress, we just wait for it to clear.
 	if n.MembershipChangeInProgress() {
-		return
+		return mstat(MigrationStatusMembership, "waiting for membership change to commit")
 	}
 
 	actual := n.Peers()
 	actualPeers := peerIDs(actual)
 
 	// Remove any peers that have been evicted from the cluster.
-	if s.removeEvictedPeers(n, meta, actual, actualPeers, current, desiredPeers) {
-		return
+	if status := s.removeEvictedPeers(n, meta, actual, actualPeers, current, desiredPeers); status != nil {
+		return status
 	}
 	// Extend the actual peer set through the log.
-	if s.extendPeerSet(n, actual, actualPeers, current, desiredPeers) {
-		return
+	if status := s.extendPeerSet(n, actual, actualPeers, current, desiredPeers); status != nil {
+		return status
 	}
 	// If scaling down, we need to select where to.
 	if desiredScaleDown {
 		update.ScaleDownPeers = s.selectScaleDownPeers(ourPeerId, actual, desiredPeers, replicas)
 		sendMetaUpdate()
-		return
+		return mstat(MigrationStatusMeta, "selecting peers to scale down to")
 	}
 
 	// Add peers in our desired peer set.
@@ -4487,7 +4508,7 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 		}
 		update.MetaPeers = combined
 		sendMetaUpdate()
-		return
+		return mstat(MigrationStatusMeta, "expanding assignment with desired peers")
 	}
 
 	slices.Sort(current)
@@ -4513,7 +4534,7 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 		if sa == nil || sa.Group == nil || sa.Group.Desired == nil || sa.Group.Desired.ID != desiredID {
 			// The desired state moved on under us, reassess on the next cycle.
 			js.mu.RUnlock()
-			return
+			return mstat(MigrationStatusMeta, "desired state changed, reassessing")
 		}
 		var blockedBy string
 		for name, c := range sa.consumers {
@@ -4536,7 +4557,7 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 			s.Debugf("Scale down of '%s > %s' blocked by consumer '%s'", accName, streamName, blockedBy)
 			// We need to wait but still nudge the meta leader since it might need to remap consumers.
 			sendMetaUpdate()
-			return
+			return mstat(MigrationStatusBlocked, "waiting for consumer '%s' to migrate", blockedBy)
 		}
 
 		// Remove old peers one at a time, the leader selected last.
@@ -4557,35 +4578,60 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 			}
 		}
 		if quorum := (len(actual)-1)/2 + 1; currentCount < quorum {
-			return
+			return mstat(MigrationStatusCatchup, "waiting for peers to catch up")
 		}
 		// If we have current desired peers, and we're not a desired peer ourselves, step down.
 		if len(currentDesired) > 0 && !slices.Contains(desiredPeers, ourPeerId) {
 			// If desired peers are still catching up, we wait for a quorum of them to complete for now.
 			if quorum := len(desiredPeers)/2 + 1; len(currentDesired) < quorum {
-				return
+				return mstat(MigrationStatusCatchup, "waiting for desired peers to catch up")
 			}
-			if preferred := s.selectStepDownPreferred(ourPeerId, actual, currentDesired); preferred != _EMPTY_ {
-				n.StepDown(preferred)
+			preferred := s.selectStepDownPreferred(ourPeerId, actual, currentDesired)
+			if preferred == _EMPTY_ {
+				return mstat(MigrationStatusMembership, "waiting for a desired peer to step down to")
 			}
-			return
+			err := n.StepDown(preferred)
+			name := s.serverNameForNode(preferred)
+			if name == _EMPTY_ {
+				name = fmt.Sprintf("peer with id %s", preferred)
+			}
+			return mstat(MigrationStatusMembership, "stepping down to %s", name).withErr(err)
 		}
 
 		// Step down and perform a leader transfer if we'd remove ourselves. We are
 		// selected last, so leadership changes at most once, and every remaining
 		// member is already in the desired peer set so any successor works.
 		if remove != ourPeerId {
-			n.ProposeRemovePeer(remove)
-		} else {
-			n.StepDown()
+			err := n.ProposeRemovePeer(remove)
+			name := s.serverNameForNode(remove)
+			if name == _EMPTY_ {
+				name = fmt.Sprintf("with id %s", remove)
+			}
+			return mstat(MigrationStatusMembership, "removing peer %s", name).withErr(err)
 		}
-		return
+		err := n.StepDown()
+		return mstat(MigrationStatusMembership, "stepping down before removing ourselves").withErr(err)
 	}
 
 	// We're done.
 	update.MetaPeers = actualPeers
 	update.PeersMatch = exactMatch
 	sendMetaUpdate()
+	if !exactMatch {
+		return mstat(MigrationStatusMeta, "waiting for peer set to settle")
+	}
+	return nil
+}
+
+// setMigrationStatus records what the group leader is currently doing to converge
+// this group toward its desired state, so it can be reported through clusterInfo.
+func (js *jetStream) setMigrationStatus(rg *raftGroup, status *DesiredClusterInfoStatus) {
+	if js == nil || rg == nil {
+		return
+	}
+	js.mu.Lock()
+	defer js.mu.Unlock()
+	rg.migration = status
 }
 
 // Determine if we are migrating
@@ -5453,7 +5499,15 @@ func (js *jetStream) processStreamLeaderChange(mset *stream, isLeader bool, term
 	s, account, err := js.srv, sa.Client.serviceAccount(), sa.err
 	client, subject, reply := sa.Client, sa.Subject, sa.Reply
 	hasResponded := sa.markResponded()
+	// A migration status is only valid for the leader and term that wrote it.
+	clearMigration := sa.Group.migration != nil
 	js.mu.RUnlock()
+
+	if clearMigration {
+		js.mu.Lock()
+		sa.Group.migration = nil
+		js.mu.Unlock()
+	}
 
 	streamName := mset.name()
 
@@ -5718,6 +5772,7 @@ func (js *jetStream) processStreamAssignment(sa *streamAssignment) {
 			// Copy over private existing state from former SA.
 			if sa.Group != nil {
 				sa.Group.node = osa.Group.node
+				sa.Group.migration = osa.Group.migration
 			}
 			sa.consumers = osa.consumers
 			if osa.hasResponded() {
@@ -5841,6 +5896,7 @@ func (js *jetStream) processUpdateStreamAssignment(sa *streamAssignment) {
 	// Copy over private existing state from former SA.
 	if sa.Group != nil {
 		sa.Group.node = osa.Group.node
+		sa.Group.migration = osa.Group.migration
 	}
 	sa.consumers = osa.consumers
 	sa.err = osa.err
@@ -6594,6 +6650,7 @@ func (js *jetStream) processConsumerAssignment(ca *consumerAssignment) {
 		// Copy over private existing state from former CA.
 		if ca.Group != nil {
 			ca.Group.node = oca.Group.node
+			ca.Group.migration = oca.Group.migration
 		}
 		if oca.hasResponded() {
 			ca.markResponded()
@@ -7486,6 +7543,8 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 			mmt.Stop()
 			mmt, mmtc = nil, nil
 		}
+		// Don't leave a stale status behind for a migration that's done or abandoned.
+		js.setMigrationStatus(o.raftGroup(), nil)
 	}
 	defer stopMigrationMonitoring()
 
@@ -7612,7 +7671,9 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 			}
 			// Reset to the slower fallback speed.
 			resetMigrationMonitoring(migrateFallbackCheckInterval)
-			js.runConsumerMigration(o, ca, n, leaderTerm)
+			status := js.runConsumerMigration(o, ca, n, leaderTerm)
+			// Resolve after determining the status, so that we don't set it on a stale group.
+			js.setMigrationStatus(o.raftGroup(), status)
 
 		case <-t.C:
 			// Start forcing snapshots if they failed previously.
@@ -7622,17 +7683,13 @@ func (js *jetStream) monitorConsumer(o *consumer, ca *consumerAssignment) {
 	}
 }
 
-// Migrate a consumer from peer set A to peer set B. Returns true when migration is done.
-func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n RaftNode, leaderTerm uint64) {
-	if leaderTerm == 0 {
-		return
+// Migrate a consumer from peer set A to peer set B.
+func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n RaftNode, leaderTerm uint64) *DesiredClusterInfoStatus {
+	// Sanity-check: we're still the leader.
+	if leaderTerm == 0 || !n.Leader() {
+		return nil
 	}
 	ourPeerId, s := n.ID(), js.srv
-
-	// Sanity-check: we're still the leader.
-	if !n.Leader() {
-		return
-	}
 
 	// Snapshot the assignment state we need up front, so the Raft reads below don't
 	// contend for Raft locks while holding the JetStream lock.
@@ -7641,11 +7698,11 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 	// We are shutting down.
 	if cc == nil || cc.meta == nil {
 		js.mu.RUnlock()
-		return
+		return mstat(MigrationStatusUnavailable, "shutting down")
 	}
 	if ca == nil || ca.Group == nil {
 		js.mu.RUnlock()
-		return
+		return mstat(MigrationStatusUnavailable, "no consumer assignment")
 	}
 	meta := cc.meta
 	accName, streamName, consumerName := ca.Client.serviceAccount(), ca.Stream, ca.Name
@@ -7653,7 +7710,7 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 	osa := js.streamAssignment(accName, streamName)
 	if osa == nil {
 		js.mu.RUnlock()
-		return
+		return mstat(MigrationStatusUnavailable, "no stream assignment")
 	}
 
 	replicas := ca.Config.replicas(osa.Config)
@@ -7670,36 +7727,43 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 	}
 	if needDesired {
 		sendMetaUpdate()
-		return
+		return mstat(MigrationStatusMeta, "requesting desired state from meta leader")
 	}
 	// A snapshot is required. Automatically installs a snapshot for a R1 scaleup.
 	if n.NeedSnapshot() {
-		if snap, err := o.store.EncodedState(); err == nil {
-			n.InstallSnapshot(snap, true)
+		snap, err := o.store.EncodedState()
+		if err != nil {
+			if errors.Is(err, ErrStoreClosed) {
+				return mstat(MigrationStatusUnavailable, "shutting down")
+			}
+			return mstat(MigrationStatusSnapshot, "waiting to encode state for snapshot").withErr(err)
 		}
-		return
+		if err := n.InstallSnapshot(snap, true); err != nil {
+			return mstat(MigrationStatusSnapshot, "waiting to install snapshot").withErr(err)
+		}
+		return mstat(MigrationStatusSnapshot, "installing snapshot")
 	}
 	// If a membership change is in progress, we just wait for it to clear.
 	if n.MembershipChangeInProgress() {
-		return
+		return mstat(MigrationStatusMembership, "waiting for membership change to commit")
 	}
 
 	actual := n.Peers()
 	actualPeers := peerIDs(actual)
 
 	// Remove any peers that have been evicted from the cluster.
-	if s.removeEvictedPeers(n, meta, actual, actualPeers, current, desiredPeers) {
-		return
+	if status := s.removeEvictedPeers(n, meta, actual, actualPeers, current, desiredPeers); status != nil {
+		return status
 	}
 	// Extend the actual peer set through the log.
-	if s.extendPeerSet(n, actual, actualPeers, current, desiredPeers) {
-		return
+	if status := s.extendPeerSet(n, actual, actualPeers, current, desiredPeers); status != nil {
+		return status
 	}
 	// If scaling down, we need to select where to.
 	if desiredScaleDown {
 		update.ScaleDownPeers = s.selectScaleDownPeers(ourPeerId, actual, desiredPeers, replicas)
 		sendMetaUpdate()
-		return
+		return mstat(MigrationStatusMeta, "selecting peers to scale down to")
 	}
 
 	// Add peers in our desired peer set.
@@ -7724,11 +7788,11 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 			combined = append(combined, peer)
 		}
 		if len(combined) == len(current) {
-			return
+			return mstat(MigrationStatusBlocked, "waiting for stream to migrate first")
 		}
 		update.MetaPeers = combined
 		sendMetaUpdate()
-		return
+		return mstat(MigrationStatusMeta, "expanding assignment with desired peers")
 	}
 
 	slices.Sort(current)
@@ -7750,17 +7814,25 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 		// member is already in the desired peer set so any successor works.
 		remove := s.selectPeerToRemove(ourPeerId, actual, remaining)
 		if remove == ourPeerId {
-			n.StepDown()
-		} else {
-			n.ProposeRemovePeer(remove)
+			err := n.StepDown()
+			return mstat(MigrationStatusMembership, "stepping down before removing ourselves").withErr(err)
 		}
-		return
+		err := n.ProposeRemovePeer(remove)
+		name := s.serverNameForNode(remove)
+		if name == _EMPTY_ {
+			name = fmt.Sprintf("with id %s", remove)
+		}
+		return mstat(MigrationStatusMembership, "removing peer %s", name).withErr(err)
 	}
 
 	// We're done.
 	update.MetaPeers = actualPeers
 	update.PeersMatch = exactMatch
 	sendMetaUpdate()
+	if !exactMatch {
+		return mstat(MigrationStatusMeta, "waiting for peer set to settle")
+	}
+	return nil
 }
 
 // Determine if we are migrating
@@ -8150,7 +8222,15 @@ func (js *jetStream) processConsumerLeaderChangeWithAssignment(o *consumer, ca *
 	s, account, err := js.srv, ca.Client.serviceAccount(), ca.err
 	client, subject, reply, streamName, consumerName, sourcing := ca.Client, ca.Subject, ca.Reply, ca.Stream, ca.Name, ca.Config.Sourcing
 	hasResponded := ca.markResponded()
+	// A migration status is only valid for the leader and term that wrote it.
+	clearMigration := ca.Group.migration != nil
 	js.mu.RUnlock()
+
+	if clearMigration {
+		js.mu.Lock()
+		ca.Group.migration = nil
+		js.mu.Unlock()
+	}
 
 	acc, _ := s.LookupAccount(account)
 	if acc == nil {
@@ -12533,6 +12613,15 @@ func (js *jetStream) clusterInfo(rg *raftGroup) *ClusterInfo {
 		if !d.ScaleDown {
 			desiredPeers = copyStrings(d.Peers)
 		}
+	}
+	// The group leader can have a status before desired state exists, most importantly
+	// when it's still requesting it from the meta leader. Report that on its own.
+	if status := rg.migration; status != nil {
+		if desired == nil {
+			desired = &DesiredClusterInfo{}
+		}
+		cp := *status
+		desired.Status = &cp
 	}
 	js.mu.RUnlock()
 

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4326,7 +4326,77 @@ func (js *jetStream) monitorStream(mset *stream, sa *streamAssignment, sendSnaps
 	}
 }
 
-// Migrate a stream from peer set A to peer set B. Returns true when migration is done.
+// desiredSnapshot copies the group's desired state, so it stays usable after the
+// JetStream lock is released. needDesired is true if desired state is missing or was
+// recorded under another leader term, and the meta leader must record it first.
+// Lock should be held.
+func (rg *raftGroup) desiredSnapshot(leaderTerm uint64) (id string, scaleDown bool, peers []string, needDesired bool) {
+	desired := rg.Desired
+	if desired != nil {
+		// MUST copy the peers, the assignment can be updated once we release.
+		id, scaleDown, peers = desired.ID, desired.ScaleDown, copyStrings(desired.Peers)
+	}
+	needDesired = desired == nil || desired.ID == _EMPTY_ || desired.Term != leaderTerm
+	return id, scaleDown, peers, needDesired
+}
+
+// peerIDs returns the IDs of the given peers.
+func peerIDs(peers []*Peer) []string {
+	ids := make([]string, 0, len(peers))
+	for _, p := range peers {
+		ids = append(ids, p.ID)
+	}
+	return ids
+}
+
+// removeEvictedPeers removes a raft member that is not a current member or no
+// longer part of the meta group, it has been evicted from the cluster, e.g. by a
+// server peer-remove. It can't take part in a migration, so remove it from the
+// group right away rather than waiting for the rest of the migration to complete.
+// Returns true if we've acted, and the migration must wait for the next cycle.
+func (s *Server) removeEvictedPeers(n, meta RaftNode, actual []*Peer, actualPeers, current, desiredPeers []string) bool {
+	metaPeers := meta.PeerNames()
+	var evicted []string
+	for _, peer := range actualPeers {
+		if !slices.Contains(current, peer) || !slices.Contains(metaPeers, peer) {
+			evicted = append(evicted, peer)
+		}
+	}
+	if len(evicted) == 0 {
+		return false
+	}
+	// Remove evicted peers one at a time, the leader last so leadership stays
+	// stable throughout. Step down and perform a leader transfer if we'd remove
+	// ourselves, preferring a successor that is already in the desired peer set.
+	ourPeerId := n.ID()
+	if remove := s.selectPeerToRemove(ourPeerId, actual, evicted); remove == ourPeerId {
+		n.StepDown(s.selectStepDownPreferred(ourPeerId, actual, desiredPeers))
+	} else {
+		n.ProposeRemovePeer(remove)
+	}
+	return true
+}
+
+// extendPeerSet extends the actual peer set through the log, but only with peers
+// that are part of the desired set.
+// Returns true if we've acted, and the migration must wait for the next cycle.
+func (s *Server) extendPeerSet(n RaftNode, actual []*Peer, actualPeers, current, desiredPeers []string) bool {
+	var candidates []string
+	for _, peer := range current {
+		if !slices.Contains(actualPeers, peer) && slices.Contains(desiredPeers, peer) {
+			candidates = append(candidates, peer)
+		}
+	}
+	if len(candidates) == 0 {
+		return false
+	}
+	if add := s.selectPeerToAdd(n, n.ID(), actual, candidates); add != _EMPTY_ {
+		n.ProposeAddPeer(add)
+	}
+	return true
+}
+
+// Migrate a stream from peer set A to peer set B.
 func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n RaftNode, leaderTerm uint64) {
 	if leaderTerm == 0 {
 		return
@@ -4358,17 +4428,7 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 	meta := cc.meta
 	accName, streamName, replicas := sa.Client.serviceAccount(), sa.Config.Name, sa.Config.Replicas
 	current := copyStrings(sa.Group.Peers)
-	// If desired state is missing, inform the meta leader to create desired state.
-	// Or, if the recorded leader term isn't ours, then get that updated first.
-	desired := sa.Group.Desired
-	var desiredID string
-	var desiredScaleDown bool
-	var desiredPeers []string
-	if desired != nil {
-		// MUST copy the peers, the assignment can be updated once we release below.
-		desiredID, desiredScaleDown, desiredPeers = desired.ID, desired.ScaleDown, copyStrings(desired.Peers)
-	}
-	needDesired := desired == nil || desired.ID == _EMPTY_ || desired.Term != leaderTerm
+	desiredID, desiredScaleDown, desiredPeers, needDesired := sa.Group.desiredSnapshot(leaderTerm)
 	js.mu.RUnlock()
 
 	update := desiredAssignmentUpdate{Term: leaderTerm, ID: desiredID}
@@ -4376,12 +4436,10 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 		reconcile := &streamAssignmentReconcile{Account: accName, Stream: streamName, desiredAssignmentUpdate: update}
 		s.sendInternalMsgLocked(streamAssignmentReconcileSubj, _EMPTY_, nil, reconcile)
 	}
-
 	if needDesired {
 		sendMetaUpdate()
 		return
 	}
-
 	// A snapshot is required. Automatically installs a snapshot for a R1 scaleup.
 	if n.NeedSnapshot() {
 		if err := mset.flushAllPending(); err == nil {
@@ -4395,49 +4453,16 @@ func (js *jetStream) runStreamMigration(mset *stream, sa *streamAssignment, n Ra
 	}
 
 	actual := n.Peers()
-	actualPeers := make([]string, 0, len(actual))
-	for _, p := range actual {
-		actualPeers = append(actualPeers, p.ID)
-	}
+	actualPeers := peerIDs(actual)
 
-	// A raft member that is not current member or no longer part of the meta group,
-	// has been evicted from the cluster, e.g. by a server peer-remove. It can't take
-	// part in this migration, so remove it from the group right away rather than
-	// waiting for the rest of the migration to complete.
-	metaPeers := meta.PeerNames()
-	var evicted []string
-	for _, peer := range actualPeers {
-		if !slices.Contains(current, peer) || !slices.Contains(metaPeers, peer) {
-			evicted = append(evicted, peer)
-		}
-	}
-	if len(evicted) > 0 {
-		// Remove evicted peers one at a time, the leader last so leadership stays
-		// stable throughout. Step down and perform a leader transfer if we'd remove
-		// ourselves, preferring a successor that is already in the desired peer set.
-		remove := s.selectPeerToRemove(ourPeerId, actual, evicted)
-		if remove == ourPeerId {
-			n.StepDown(s.selectStepDownPreferred(ourPeerId, actual, desiredPeers))
-		} else {
-			n.ProposeRemovePeer(remove)
-		}
+	// Remove any peers that have been evicted from the cluster.
+	if s.removeEvictedPeers(n, meta, actual, actualPeers, current, desiredPeers) {
 		return
 	}
-
-	// Extend the actual peer set through the log, but only if it's part of the desired set.
-	var candidates []string
-	for _, peer := range current {
-		if !slices.Contains(actualPeers, peer) && slices.Contains(desiredPeers, peer) {
-			candidates = append(candidates, peer)
-		}
-	}
-	if len(candidates) > 0 {
-		if add := s.selectPeerToAdd(n, ourPeerId, actual, candidates); add != _EMPTY_ {
-			n.ProposeAddPeer(add)
-		}
+	// Extend the actual peer set through the log.
+	if s.extendPeerSet(n, actual, actualPeers, current, desiredPeers) {
 		return
 	}
-
 	// If scaling down, we need to select where to.
 	if desiredScaleDown {
 		update.ScaleDownPeers = s.selectScaleDownPeers(ourPeerId, actual, desiredPeers, replicas)
@@ -7635,17 +7660,7 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 	// MUST copy, the stream assignment can be updated once we release below.
 	streamPeers := copyStrings(osa.Group.Peers)
 	current := copyStrings(ca.Group.Peers)
-	// If desired state is missing, inform the meta leader to create desired state.
-	// Or, if the recorded leader term isn't ours, then get that updated first.
-	desired := ca.Group.Desired
-	var desiredID string
-	var desiredScaleDown bool
-	var desiredPeers []string
-	if desired != nil {
-		// MUST copy the peers, the assignment can be updated once we release below.
-		desiredID, desiredScaleDown, desiredPeers = desired.ID, desired.ScaleDown, copyStrings(desired.Peers)
-	}
-	needDesired := desired == nil || desired.ID == _EMPTY_ || desired.Term != leaderTerm
+	desiredID, desiredScaleDown, desiredPeers, needDesired := ca.Group.desiredSnapshot(leaderTerm)
 	js.mu.RUnlock()
 
 	update := desiredAssignmentUpdate{Term: leaderTerm, ID: desiredID}
@@ -7653,12 +7668,10 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 		reconcile := &consumerAssignmentReconcile{Account: accName, Stream: streamName, Consumer: consumerName, desiredAssignmentUpdate: update}
 		s.sendInternalMsgLocked(consumerAssignmentReconcileSubj, _EMPTY_, nil, reconcile)
 	}
-
 	if needDesired {
 		sendMetaUpdate()
 		return
 	}
-
 	// A snapshot is required. Automatically installs a snapshot for a R1 scaleup.
 	if n.NeedSnapshot() {
 		if snap, err := o.store.EncodedState(); err == nil {
@@ -7672,49 +7685,16 @@ func (js *jetStream) runConsumerMigration(o *consumer, ca *consumerAssignment, n
 	}
 
 	actual := n.Peers()
-	actualPeers := make([]string, 0, len(actual))
-	for _, p := range actual {
-		actualPeers = append(actualPeers, p.ID)
-	}
+	actualPeers := peerIDs(actual)
 
-	// A raft member that is not current member or no longer part of the meta group,
-	// has been evicted from the cluster, e.g. by a server peer-remove. It can't take
-	// part in this migration, so remove it from the group right away rather than
-	// waiting for the rest of the migration to complete.
-	metaPeers := meta.PeerNames()
-	var evicted []string
-	for _, peer := range actualPeers {
-		if !slices.Contains(current, peer) || !slices.Contains(metaPeers, peer) {
-			evicted = append(evicted, peer)
-		}
-	}
-	if len(evicted) > 0 {
-		// Remove evicted peers one at a time, the leader last so leadership stays
-		// stable throughout. Step down and perform a leader transfer if we'd remove
-		// ourselves, preferring a successor that is already in the desired peer set.
-		remove := s.selectPeerToRemove(ourPeerId, actual, evicted)
-		if remove == ourPeerId {
-			n.StepDown(s.selectStepDownPreferred(ourPeerId, actual, desiredPeers))
-		} else {
-			n.ProposeRemovePeer(remove)
-		}
+	// Remove any peers that have been evicted from the cluster.
+	if s.removeEvictedPeers(n, meta, actual, actualPeers, current, desiredPeers) {
 		return
 	}
-
-	// Extend the actual peer set through the log, but only if it's part of the desired set.
-	var candidates []string
-	for _, peer := range current {
-		if !slices.Contains(actualPeers, peer) && slices.Contains(desiredPeers, peer) {
-			candidates = append(candidates, peer)
-		}
-	}
-	if len(candidates) > 0 {
-		if add := s.selectPeerToAdd(n, ourPeerId, actual, candidates); add != _EMPTY_ {
-			n.ProposeAddPeer(add)
-		}
+	// Extend the actual peer set through the log.
+	if s.extendPeerSet(n, actual, actualPeers, current, desiredPeers) {
 		return
 	}
-
 	// If scaling down, we need to select where to.
 	if desiredScaleDown {
 		update.ScaleDownPeers = s.selectScaleDownPeers(ourPeerId, actual, desiredPeers, replicas)

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -15141,21 +15141,19 @@ func TestJetStreamClusterRetentionChangeOriginSurvivesScale(t *testing.T) {
 	_, err = js.UpdateStream(cfg)
 	require_NoError(t, err)
 
-	// While that is still converging the stream has desired state, so a scale must be rejected
-	// instead of retargeting the peer set and dropping the pending retention origin.
+	// While that is still converging the stream has desired state. A scale stacks on top,
+	// retargeting the peer set while the pending retention origin must be preserved.
 	cfg.Replicas = 5
 	_, err = js.UpdateStream(cfg)
-	require_Error(t, err, NewJSStreamMoveInProgressError())
+	require_NoError(t, err)
 
-	// Unblock the consumer scale-up so the stream can converge and the scale is accepted.
+	// Unblock the consumer scale-up so the stream can converge.
 	require_True(t, ml == c.leader())
 	mjs.mu.Lock()
 	mjs.startUpdatesSub()
 	mjs.mu.Unlock()
 
 	c.waitOnStreamLeader("$G", "TEST")
-	_, err = js.UpdateStream(cfg)
-	require_NoError(t, err)
 
 	// The scale must land on top of the applied retention change, not roll it back to the
 	// origin's limits retention, and the consumer must follow the stream to the new peer set.
@@ -15172,6 +15170,179 @@ func TestJetStreamClusterRetentionChangeOriginSurvivesScale(t *testing.T) {
 		if interest != len(c.servers) || len(speers) != 5 || len(cpeers) != 5 {
 			return fmt.Errorf("have %d/%d servers on interest retention, stream peers %v, consumer peers %v",
 				interest, len(c.servers), speers, cpeers)
+		}
+		return nil
+	})
+}
+
+func TestJetStreamClusterScaleStackingMoveExclusion(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R5S", 5)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Replicas: 3,
+	}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	// A move and a scale can't combine in a single update, even with nothing in flight.
+	// The guard fires before peer selection, so the placement doesn't need to resolve.
+	comboCfg := *cfg
+	comboCfg.Replicas = 5
+	comboCfg.Placement = &nats.Placement{Tags: []string{"na"}}
+	_, err = js.UpdateStream(&comboCfg)
+	require_Error(t, err, NewJSStreamMoveAndScaleError())
+
+	// Block the meta leader from reconciling desired stream assignments, so the
+	// desired state below stays in flight deterministically.
+	ml := c.leader()
+	mjs := ml.getJetStream()
+	mjs.mu.Lock()
+	streamReconcile := mjs.cluster.streamReconcile
+	mjs.cluster.streamReconcile = nil
+	mjs.mu.Unlock()
+	require_NotNil(t, streamReconcile)
+	ml.sysUnsubscribe(streamReconcile)
+
+	// Scale up, it stays converging while reconciliation is blocked.
+	cfg.Replicas = 5
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+
+	// A move can't combine with the in-flight scale.
+	moveCfg := *cfg
+	moveCfg.Placement = &nats.Placement{Tags: []string{"na"}}
+	_, err = js.UpdateStream(&moveCfg)
+	require_Error(t, err, NewJSStreamReconfigureInProgressError())
+
+	// Another scale stacks onto the in-flight one, retargeting the desired state while
+	// the origin from before the first scale is preserved.
+	cfg.Replicas = 4
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+
+	mjs.mu.RLock()
+	var replicas, originReplicas int
+	var hasDesired bool
+	if sa := mjs.streamAssignment(globalAccountName, "TEST"); sa != nil && sa.Config != nil && sa.Group != nil {
+		replicas = sa.Config.Replicas
+		if sa.Group.Desired != nil {
+			hasDesired = true
+			if sa.Group.Desired.Origin != nil {
+				originReplicas = sa.Group.Desired.Origin.Replicas
+			}
+		}
+	}
+	mjs.mu.RUnlock()
+	require_Equal(t, replicas, 4)
+	require_True(t, hasDesired)
+	require_Equal(t, originReplicas, 3)
+
+	// Unblock reconciliation, the stacked scale must converge.
+	require_True(t, ml == c.leader())
+	mjs.mu.Lock()
+	mjs.startUpdatesSub()
+	mjs.mu.Unlock()
+
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		sa := mjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group == nil {
+			return fmt.Errorf("no stream assignment")
+		}
+		if sa.Group.Desired != nil {
+			return fmt.Errorf("desired state still in flight")
+		}
+		if len(sa.Group.Peers) != 4 {
+			return fmt.Errorf("expected 4 peers, got %d", len(sa.Group.Peers))
+		}
+		return nil
+	})
+}
+
+func TestJetStreamClusterRetentionChangeMoveExclusion(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	cfg := &nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Retention: nats.LimitsPolicy,
+		Replicas:  3,
+	}
+	_, err := js.AddStream(cfg)
+	require_NoError(t, err)
+
+	// Block the meta leader from reconciling desired stream assignments, so the
+	// desired state below stays in flight deterministically.
+	ml := c.leader()
+	mjs := ml.getJetStream()
+	mjs.mu.Lock()
+	streamReconcile := mjs.cluster.streamReconcile
+	mjs.cluster.streamReconcile = nil
+	mjs.mu.Unlock()
+	require_NotNil(t, streamReconcile)
+	ml.sysUnsubscribe(streamReconcile)
+
+	// A retention change goes through desired state, it stays converging while
+	// reconciliation is blocked. No scale is involved.
+	cfg.Retention = nats.InterestPolicy
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+
+	mjs.mu.RLock()
+	sa := mjs.streamAssignment(globalAccountName, "TEST")
+	var hasDesired, isMove bool
+	var originReplicas int
+	if sa != nil && sa.Group != nil && sa.Group.Desired != nil {
+		hasDesired = true
+		isMove = sa.Group.Desired.Move
+		if sa.Group.Desired.Origin != nil {
+			originReplicas = sa.Group.Desired.Origin.Replicas
+		}
+	}
+	mjs.mu.RUnlock()
+	require_True(t, hasDesired)
+	// Confirm it is not a move, and the replicas are untouched so it is not a scale either.
+	require_False(t, isMove)
+	require_Equal(t, originReplicas, 3)
+
+	// A move can't combine with the in-flight retention change. The error must reflect
+	// that a reconfiguration is in flight, reporting a scale here would be wrong.
+	moveCfg := *cfg
+	moveCfg.Placement = &nats.Placement{Tags: []string{"na"}}
+	_, err = js.UpdateStream(&moveCfg)
+	require_Error(t, err, NewJSStreamReconfigureInProgressError())
+
+	// Unblock reconciliation, the retention change must converge.
+	require_True(t, ml == c.leader())
+	mjs.mu.Lock()
+	mjs.startUpdatesSub()
+	mjs.mu.Unlock()
+
+	c.waitOnStreamLeader(globalAccountName, "TEST")
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		mjs.mu.RLock()
+		defer mjs.mu.RUnlock()
+		sa := mjs.streamAssignment(globalAccountName, "TEST")
+		if sa == nil || sa.Group == nil || sa.Config == nil {
+			return fmt.Errorf("no stream assignment")
+		}
+		if sa.Group.Desired != nil {
+			return fmt.Errorf("desired state still in flight")
+		}
+		if sa.Config.Retention != InterestPolicy {
+			return fmt.Errorf("expected interest retention, got %v", sa.Config.Retention)
 		}
 		return nil
 	})

--- a/server/jetstream_cluster_1_test.go
+++ b/server/jetstream_cluster_1_test.go
@@ -4050,6 +4050,119 @@ func TestJetStreamClusterPeerRemovalAndConsumerReassignmentOnMetaLeaderChange(t 
 	})
 }
 
+// An under-replicated stream or consumer, one holding fewer peers than its configured
+// replica count, is not migrating. There are no peers to move off of, and the meta leader
+// heals it by adding peers back rather than through migration. Reporting it as migrating
+// leaves the migration monitor running against a group that cannot converge, which registers
+// desired state and clears it again every cycle, churning assignment proposals through the
+// meta log forever.
+func TestJetStreamClusterUnderReplicatedNotMigrating(t *testing.T) {
+	c := createJetStreamClusterExplicit(t, "R3S", 3)
+	defer c.shutdown()
+
+	nc, js := jsClientConnect(t, c.randomServer())
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{Name: "TEST", Subjects: []string{"foo"}, Replicas: 3})
+	require_NoError(t, err)
+
+	_, err = js.AddConsumer("TEST", &nats.ConsumerConfig{Durable: "dur", AckPolicy: nats.AckExplicitPolicy})
+	require_NoError(t, err)
+
+	// Strip a stream member out of the meta group, on a cluster with no spare to replace it.
+	ml := c.leader()
+	require_NotNil(t, ml)
+	peers := metaStreamPeers(ml, globalAccountName, "TEST")
+	require_Len(t, len(peers), 3)
+
+	// The member to remove must not be the meta leader, so the leader stays able to propose.
+	var gone, kept *Server
+	for _, s := range c.servers {
+		if s == ml || !slices.Contains(peers, s.Node()) {
+			continue
+		}
+		if gone == nil {
+			gone = s
+		} else {
+			kept = s
+		}
+	}
+	if kept == nil {
+		kept = ml
+	}
+	require_NotNil(t, gone)
+
+	snc, err := nats.Connect(ml.ClientURL(), nats.UserInfo("admin", "s3cr3t!"))
+	require_NoError(t, err)
+	defer snc.Close()
+
+	jsreq, err := json.Marshal(&JSApiMetaServerRemoveRequest{Server: gone.Name()})
+	require_NoError(t, err)
+	rmsg, err := snc.Request(JSApiRemoveServer, jsreq, 5*time.Second)
+	require_NoError(t, err)
+	var resp JSApiMetaServerRemoveResponse
+	require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
+	require_True(t, resp.Error == nil)
+	c.waitOnPeerCount(2)
+
+	// There is no spare left to take the removed peer's place, so the stream settles below its
+	// replica count and stays there. The consumer follows it down to 2 peers, while both still
+	// resolve to 3 replicas.
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		l := c.leader()
+		if l == nil {
+			return errors.New("no meta leader")
+		}
+		if p := metaStreamPeers(l, globalAccountName, "TEST"); len(p) != 2 {
+			return fmt.Errorf("expected stream on 2 peers, got %d", len(p))
+		}
+		if p := metaConsumerPeers(l, globalAccountName, "TEST", "dur"); len(p) != 2 {
+			return fmt.Errorf("expected consumer on 2 peers, got %d", len(p))
+		}
+		return nil
+	})
+
+	mset, err := kept.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+
+	// Both must settle out of migrating, rather than staying there because they're short a peer.
+	var o *consumer
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
+		if mset.isMigrating() {
+			return errors.New("stream still reports migrating while under-replicated")
+		}
+		if o = mset.lookupConsumer("dur"); o == nil {
+			return errors.New("consumer not found")
+		}
+		if o.isMigrating() {
+			return errors.New("consumer still reports migrating while under-replicated")
+		}
+		return nil
+	})
+
+	// And must stay settled, no desired state churn on either assignment.
+	for range 200 {
+		require_False(t, mset.isMigrating())
+		require_False(t, o.isMigrating())
+		l := c.leader()
+		require_NotNil(t, l)
+		ljs := l.getJetStream()
+		ljs.mu.RLock()
+		sa := ljs.streamAssignment(globalAccountName, "TEST")
+		ca := ljs.consumerAssignment(globalAccountName, "TEST", "dur")
+		streamChurning := sa != nil && sa.Group != nil && sa.Group.Desired != nil
+		consumerChurning := ca != nil && ca.Group != nil && ca.Group.Desired != nil
+		ljs.mu.RUnlock()
+		if streamChurning {
+			t.Fatalf("Desired state re-registered for an under-replicated stream, migration monitor is churning")
+		}
+		if consumerChurning {
+			t.Fatalf("Desired state re-registered for an under-replicated consumer, migration monitor is churning")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 func TestJetStreamClusterReconcileOnlyForNewMetaPeers(t *testing.T) {
 	c := createJetStreamClusterExplicit(t, "R3S", 3)
 	defer c.shutdown()

--- a/server/jetstream_cluster_3_test.go
+++ b/server/jetstream_cluster_3_test.go
@@ -8509,11 +8509,17 @@ func TestJetStreamClusterConsumerRemapWaitsForMonitorRoutineQuit(t *testing.T) {
 
 	// Simulate a consumer Raft group remapping that has been collapsed down into just a single update.
 	// Instead of one update to R1 and then to R3, it's just one update straight to the new R3 group.
+	sjs.mu.Lock()
 	ca := sjs.consumerAssignment(globalAccountName, "TEST", "CONSUMER")
-	require_NotNil(t, ca)
+	if ca == nil {
+		sjs.mu.Unlock()
+		t.Fatal("consumer assignment not found")
+	}
 	cca := ca.copyGroup()
 	cca.Group.Name = groupNameForConsumer(cca.Group.Peers, cca.Group.Storage)
-	require_NoError(t, cc.meta.Propose(cc.meta.Term(), encodeAddConsumerAssignment(cca)))
+	err = cc.meta.Propose(cc.meta.Term(), encodeAddConsumerAssignment(cca))
+	sjs.mu.Unlock()
+	require_NoError(t, err)
 
 	// The monitor routine should stop.
 	checkFor(t, 2*time.Second, 200*time.Millisecond, func() error {
@@ -14057,4 +14063,77 @@ func TestJetStreamClusterMetaReplicasInJsz(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+func TestJetStreamClusterMigrationStatusReportedInClusterInfo(t *testing.T) {
+	js := &jetStream{srv: &Server{}}
+
+	newGroup := func(desired *desiredRaftGroup) *raftGroup {
+		return &raftGroup{
+			Name:    "test",
+			Peers:   []string{"a"},
+			node:    &raft{},
+			Desired: desired,
+		}
+	}
+
+	// A status without any desired state must still be reported, on an otherwise
+	// empty desired block. This is what a group requesting desired state looks like.
+	rg := newGroup(nil)
+	js.setMigrationStatus(rg, mstat(MigrationStatusMeta, "requesting desired state from meta leader"))
+	ci := js.clusterInfo(rg)
+	require_NotNil(t, ci.Desired)
+	require_NotNil(t, ci.Desired.Status)
+	require_Equal(t, ci.Desired.Status.Description, "requesting desired state from meta leader")
+	require_Equal(t, ci.Desired.Status.Type, "meta")
+	require_Equal(t, ci.Desired.Status.Err, _EMPTY_)
+	require_Equal(t, ci.Desired.Name, _EMPTY_)
+	require_Len(t, len(ci.Desired.Replicas), 0)
+
+	// With desired state the status sits alongside it, and doesn't disturb it.
+	rg = newGroup(&desiredRaftGroup{ID: "id", Cluster: "C1", Peers: []string{"a", "b"}})
+	js.setMigrationStatus(rg, mstat(MigrationStatusMembership, "adding peer %s", "s2"))
+	ci = js.clusterInfo(rg)
+	require_NotNil(t, ci.Desired)
+	require_NotNil(t, ci.Desired.Status)
+	require_Equal(t, ci.Desired.Status.Description, "adding peer s2")
+	require_Equal(t, ci.Desired.Status.Type, "membership")
+	require_Equal(t, ci.Desired.Name, "C1")
+	require_Len(t, len(ci.Desired.Replicas), 2)
+
+	// A persistent fault is reported beside the line, leaving the line itself stable.
+	rg = newGroup(nil)
+	diskErr := errors.New("no space left on device")
+	js.setMigrationStatus(rg, mstat(MigrationStatusSnapshot, "waiting to encode state for snapshot").withErr(diskErr))
+	ci = js.clusterInfo(rg)
+	require_NotNil(t, ci.Desired)
+	require_NotNil(t, ci.Desired.Status)
+	require_Equal(t, ci.Desired.Status.Description, "waiting to encode state for snapshot")
+	require_Equal(t, ci.Desired.Status.Type, "snapshot")
+	require_Equal(t, ci.Desired.Status.Err, "no space left on device")
+
+	// Errors that resolve themselves on the next cycle must not be reported, they'd
+	// only flap in and out of stream info while the migration is healthy.
+	for _, benign := range []error{ErrStoreClosed, errNotLeader, errNodeClosed, errMembershipChange, errNoSnapAvailable} {
+		rg = newGroup(nil)
+		js.setMigrationStatus(rg, mstat(MigrationStatusMembership, "adding peer s2").withErr(benign))
+		ci = js.clusterInfo(rg)
+		require_NotNil(t, ci.Desired)
+		require_NotNil(t, ci.Desired.Status)
+		require_Equal(t, ci.Desired.Status.Description, "adding peer s2")
+		require_Equal(t, ci.Desired.Status.Err, _EMPTY_)
+	}
+
+	// A converged group reports desired state without a status.
+	rg = newGroup(&desiredRaftGroup{ID: "id", Cluster: "C1", Peers: []string{"a", "b"}})
+	ci = js.clusterInfo(rg)
+	require_NotNil(t, ci.Desired)
+	require_True(t, ci.Desired.Status == nil)
+
+	// Clearing the status must not leave an empty desired block behind.
+	rg = newGroup(nil)
+	js.setMigrationStatus(rg, mstat(MigrationStatusSnapshot, "installing snapshot"))
+	js.setMigrationStatus(rg, nil)
+	ci = js.clusterInfo(rg)
+	require_True(t, ci.Desired == nil)
 }

--- a/server/jetstream_errors_generated.go
+++ b/server/jetstream_errors_generated.go
@@ -584,9 +584,6 @@ const (
 	// JSStreamMoveInProgressErr stream move already in progress
 	JSStreamMoveInProgressErr ErrorIdentifier = 10124
 
-	// JSStreamMoveNotInProgress stream move not in progress
-	JSStreamMoveNotInProgress ErrorIdentifier = 10129
-
 	// JSStreamMsgDeleteFailedF Generic message deletion failure error string ({err})
 	JSStreamMsgDeleteFailedF ErrorIdentifier = 10057
 
@@ -613,6 +610,12 @@ const (
 
 	// JSStreamPurgeFailedF Generic stream purge failure error string ({err})
 	JSStreamPurgeFailedF ErrorIdentifier = 10110
+
+	// JSStreamReconfigureInProgressErr stream reconfiguration already in progress
+	JSStreamReconfigureInProgressErr ErrorIdentifier = 10226
+
+	// JSStreamReconfigureNotInProgressErr stream reconfiguration not in progress
+	JSStreamReconfigureNotInProgressErr ErrorIdentifier = 10129
 
 	// JSStreamReplicasNotSupportedErr replicas > 1 not supported in non-clustered mode
 	JSStreamReplicasNotSupportedErr ErrorIdentifier = 10074
@@ -873,7 +876,6 @@ var (
 		JSStreamMismatchErr:                          {Code: 400, ErrCode: 10056, Description: "stream name in subject does not match request"},
 		JSStreamMoveAndScaleErr:                      {Code: 400, ErrCode: 10123, Description: "can not move and scale a stream in a single update"},
 		JSStreamMoveInProgressErr:                    {Code: 400, ErrCode: 10124, Description: "stream move already in progress"},
-		JSStreamMoveNotInProgress:                    {Code: 400, ErrCode: 10129, Description: "stream move not in progress"},
 		JSStreamMsgDeleteFailedF:                     {Code: 500, ErrCode: 10057, Description: "{err}"},
 		JSStreamNameContainsPathSeparatorsErr:        {Code: 400, ErrCode: 10128, Description: "Stream name can not contain path separators"},
 		JSStreamNameExistErr:                         {Code: 400, ErrCode: 10058, Description: "stream name already in use with a different configuration"},
@@ -883,6 +885,8 @@ var (
 		JSStreamOfflineErr:                           {Code: 500, ErrCode: 10118, Description: "stream is offline"},
 		JSStreamOfflineReasonErrF:                    {Code: 500, ErrCode: 10194, Description: "stream is offline: {err}"},
 		JSStreamPurgeFailedF:                         {Code: 500, ErrCode: 10110, Description: "{err}"},
+		JSStreamReconfigureInProgressErr:             {Code: 400, ErrCode: 10226, Description: "stream reconfiguration already in progress"},
+		JSStreamReconfigureNotInProgressErr:          {Code: 400, ErrCode: 10129, Description: "stream reconfiguration not in progress"},
 		JSStreamReplicasNotSupportedErr:              {Code: 500, ErrCode: 10074, Description: "replicas > 1 not supported in non-clustered mode"},
 		JSStreamReplicasNotUpdatableErr:              {Code: 400, ErrCode: 10061, Description: "Replicas configuration can not be updated"},
 		JSStreamRestoreErrF:                          {Code: 500, ErrCode: 10062, Description: "restore failed: {err}"},
@@ -3081,16 +3085,6 @@ func NewJSStreamMoveInProgressError(opts ...ErrorOption) *ApiError {
 	return ApiErrors[JSStreamMoveInProgressErr]
 }
 
-// NewJSStreamMoveNotInProgressError creates a new JSStreamMoveNotInProgress error: "stream move not in progress"
-func NewJSStreamMoveNotInProgressError(opts ...ErrorOption) *ApiError {
-	eopts := parseOpts(opts)
-	if ae, ok := eopts.err.(*ApiError); ok {
-		return ae
-	}
-
-	return ApiErrors[JSStreamMoveNotInProgress]
-}
-
 // NewJSStreamMsgDeleteFailedError creates a new JSStreamMsgDeleteFailedF error: "{err}"
 func NewJSStreamMsgDeleteFailedError(err error, opts ...ErrorOption) *ApiError {
 	eopts := parseOpts(opts)
@@ -3197,6 +3191,26 @@ func NewJSStreamPurgeFailedError(err error, opts ...ErrorOption) *ApiError {
 		ErrCode:     e.ErrCode,
 		Description: strings.NewReplacer(args...).Replace(e.Description),
 	}
+}
+
+// NewJSStreamReconfigureInProgressError creates a new JSStreamReconfigureInProgressErr error: "stream reconfiguration already in progress"
+func NewJSStreamReconfigureInProgressError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSStreamReconfigureInProgressErr]
+}
+
+// NewJSStreamReconfigureNotInProgressError creates a new JSStreamReconfigureNotInProgressErr error: "stream reconfiguration not in progress"
+func NewJSStreamReconfigureNotInProgressError(opts ...ErrorOption) *ApiError {
+	eopts := parseOpts(opts)
+	if ae, ok := eopts.err.(*ApiError); ok {
+		return ae
+	}
+
+	return ApiErrors[JSStreamReconfigureNotInProgressErr]
 }
 
 // NewJSStreamReplicasNotSupportedError creates a new JSStreamReplicasNotSupportedErr error: "replicas > 1 not supported in non-clustered mode"

--- a/server/jetstream_super_cluster_test.go
+++ b/server/jetstream_super_cluster_test.go
@@ -2797,118 +2797,104 @@ func TestJetStreamSuperClusterMovingStreamWaitsForStoreCatchup(t *testing.T) {
 		streamCatchupActivityInterval = defaultStreamCatchupActivityInterval
 	})
 
-	for _, test := range []struct {
-		name     string
-		replicas int
-		// Group size expected to hold steady while the destination peers'
-		// store catchups are stalled.
-		holdPeers     int
-		finalReplicas int
-	}{
-		// Moving R3: the gate must hold the full old+new group, no old peer
-		// may be removed while no destination peer is store-current.
-		{name: "move", replicas: 3, holdPeers: 6, finalReplicas: 2},
-		// Moving to R1: old peers can be removed while the group left after
-		// each removal retains a store-current majority, so the group must
-		// shrink from 4 to 3 peers (us, one old peer, and the destination)
-		// and then hold.
-		{name: "move-scale-down", replicas: 1, holdPeers: 3, finalReplicas: 0},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			sc := createJetStreamTaggedSuperCluster(t)
-			defer sc.shutdown()
+	// Moving R3: the gate must hold the full old+new group of 6 peers, no old peer
+	// may be removed while no destination peer is store-current. A move can't be
+	// combined with a scale, in a single update or otherwise, so a move always
+	// holds the full old+new group here.
+	const holdPeers = 6
 
-			nc, js := jsClientConnect(t, sc.randomServer())
-			defer nc.Close()
+	sc := createJetStreamTaggedSuperCluster(t)
+	defer sc.shutdown()
 
-			_, err := js.AddStream(&nats.StreamConfig{
-				Name:      "TEST",
-				Replicas:  3,
-				Placement: &nats.Placement{Tags: []string{"cloud:aws"}},
-			})
-			require_NoError(t, err)
+	nc, js := jsClientConnect(t, sc.randomServer())
+	defer nc.Close()
 
-			toSend := 1_000
-			for range toSend {
-				_, err = js.Publish("TEST", []byte("HELLO WORLD"))
-				require_NoError(t, err)
-			}
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Replicas:  3,
+		Placement: &nats.Placement{Tags: []string{"cloud:aws"}},
+	})
+	require_NoError(t, err)
 
-			// Exhaust the source leader's outbound catchup budget, as if
-			// another large catchup holds all of it, so the destination peers
-			// can't complete their store catchup until it's released.
-			sl := sc.clusterForName("C1").streamLeader(globalAccountName, "TEST")
-			require_NotNil(t, sl)
-			hold := new(int64)
-			sl.gcbAdd(hold, int64(1)<<30)
-
-			mset, err := sl.globalAccount().lookupStream("TEST")
-			require_NoError(t, err)
-			node := mset.raftNode()
-			require_NotNil(t, node)
-			require_Len(t, len(node.PeerNames()), 3)
-
-			// Compact the leader's raft log so the destination peers can't be
-			// caught up through raft-log replay alone. They'll receive a raft
-			// snapshot and must pull the stream data through the (stalled)
-			// out-of-band catchup.
-			require_NoError(t, node.InstallSnapshot(mset.stateSnapshot(), true))
-
-			// Move the stream to the other cluster.
-			_, err = js.UpdateStream(&nats.StreamConfig{
-				Name:      "TEST",
-				Replicas:  test.replicas,
-				Placement: &nats.Placement{Tags: []string{"cloud:gcp"}},
-			})
-			require_NoError(t, err)
-
-			// Wait for the migration to reach its hold point, with store
-			// catchups in flight.
-			checkFor(t, 20*time.Second, 100*time.Millisecond, func() error {
-				if peers := node.PeerNames(); len(peers) != test.holdPeers {
-					return fmt.Errorf("expected %d peers, got %d", test.holdPeers, len(peers))
-				}
-				if !mset.hasCatchupPeers() {
-					return fmt.Errorf("no store catchups in flight yet")
-				}
-				return nil
-			})
-
-			// While the destination peers can't complete their store catchup,
-			// the gate must hold: leadership stays on the source leader and
-			// the group must not shrink further.
-			for done := time.Now().Add(2 * time.Second); time.Now().Before(done); time.Sleep(250 * time.Millisecond) {
-				require_True(t, node.Leader())
-				require_Len(t, len(node.PeerNames()), test.holdPeers)
-			}
-
-			// Release the budget, catchups can now complete and the move finish.
-			sl.gcbSubLast(hold)
-
-			sc.waitOnStreamLeader(globalAccountName, "TEST")
-			checkFor(t, 30*time.Second, 100*time.Millisecond, func() error {
-				si, err := js.StreamInfo("TEST")
-				if err != nil {
-					return err
-				}
-				if si.Cluster.Name != "C2" {
-					return fmt.Errorf("wrong cluster: %q", si.Cluster.Name)
-				}
-				if si.Cluster.Leader == _EMPTY_ {
-					return fmt.Errorf("no leader yet")
-				} else if !strings.HasPrefix(si.Cluster.Leader, "C2") {
-					return fmt.Errorf("wrong leader: %q", si.Cluster.Leader)
-				}
-				if len(si.Cluster.Replicas) != test.finalReplicas {
-					return fmt.Errorf("expected %d replicas, got %d", test.finalReplicas, len(si.Cluster.Replicas))
-				}
-				if si.State.Msgs != uint64(toSend) {
-					return fmt.Errorf("only see %d msgs", si.State.Msgs)
-				}
-				return nil
-			})
-		})
+	toSend := 1_000
+	for range toSend {
+		_, err = js.Publish("TEST", []byte("HELLO WORLD"))
+		require_NoError(t, err)
 	}
+
+	// Exhaust the source leader's outbound catchup budget, as if
+	// another large catchup holds all of it, so the destination peers
+	// can't complete their store catchup until it's released.
+	sl := sc.clusterForName("C1").streamLeader(globalAccountName, "TEST")
+	require_NotNil(t, sl)
+	hold := new(int64)
+	sl.gcbAdd(hold, int64(1)<<30)
+
+	mset, err := sl.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+	node := mset.raftNode()
+	require_NotNil(t, node)
+	require_Len(t, len(node.PeerNames()), 3)
+
+	// Compact the leader's raft log so the destination peers can't be
+	// caught up through raft-log replay alone. They'll receive a raft
+	// snapshot and must pull the stream data through the (stalled)
+	// out-of-band catchup.
+	require_NoError(t, node.InstallSnapshot(mset.stateSnapshot(), true))
+
+	// Move the stream to the other cluster.
+	_, err = js.UpdateStream(&nats.StreamConfig{
+		Name:      "TEST",
+		Replicas:  3,
+		Placement: &nats.Placement{Tags: []string{"cloud:gcp"}},
+	})
+	require_NoError(t, err)
+
+	// Wait for the migration to reach its hold point, with store
+	// catchups in flight.
+	checkFor(t, 20*time.Second, 100*time.Millisecond, func() error {
+		if peers := node.PeerNames(); len(peers) != holdPeers {
+			return fmt.Errorf("expected %d peers, got %d", holdPeers, len(peers))
+		}
+		if !mset.hasCatchupPeers() {
+			return fmt.Errorf("no store catchups in flight yet")
+		}
+		return nil
+	})
+
+	// While the destination peers can't complete their store catchup,
+	// the gate must hold: leadership stays on the source leader and
+	// the group must not shrink further.
+	for done := time.Now().Add(2 * time.Second); time.Now().Before(done); time.Sleep(250 * time.Millisecond) {
+		require_True(t, node.Leader())
+		require_Len(t, len(node.PeerNames()), holdPeers)
+	}
+
+	// Release the budget, catchups can now complete and the move finish.
+	sl.gcbSubLast(hold)
+
+	sc.waitOnStreamLeader(globalAccountName, "TEST")
+	checkFor(t, 30*time.Second, 100*time.Millisecond, func() error {
+		si, err := js.StreamInfo("TEST")
+		if err != nil {
+			return err
+		}
+		if si.Cluster.Name != "C2" {
+			return fmt.Errorf("wrong cluster: %q", si.Cluster.Name)
+		}
+		if si.Cluster.Leader == _EMPTY_ {
+			return fmt.Errorf("no leader yet")
+		} else if !strings.HasPrefix(si.Cluster.Leader, "C2") {
+			return fmt.Errorf("wrong leader: %q", si.Cluster.Leader)
+		}
+		if len(si.Cluster.Replicas) != 2 {
+			return fmt.Errorf("expected 2 replicas, got %d", len(si.Cluster.Replicas))
+		}
+		if si.State.Msgs != uint64(toSend) {
+			return fmt.Errorf("only see %d msgs", si.State.Msgs)
+		}
+		return nil
+	})
 }
 
 func TestJetStreamSuperClusterMovingStreamStaleCatchupPeerDoesNotBlock(t *testing.T) {
@@ -4122,8 +4108,11 @@ func TestJetStreamSuperClusterMoveThenScaleThenCancel(t *testing.T) {
 	require_Error(t, err)
 	require_Contains(t, err.Error(), "stream move already in progress")
 
+	// Any placement would do here, going back to the origin's is rejected just the
+	// same, canceling is only possible through the endpoint. The guard fires before
+	// peer selection, so the placement doesn't need to resolve to servers.
 	moveCfg := *cfg
-	moveCfg.Placement = &nats.Placement{Tags: []string{"C1"}}
+	moveCfg.Placement = &nats.Placement{Tags: []string{"C1", "C2"}}
 	_, err = js.UpdateStream(&moveCfg)
 	require_Error(t, err)
 	require_Contains(t, err.Error(), "stream move already in progress")
@@ -4156,6 +4145,109 @@ func TestJetStreamSuperClusterMoveThenScaleThenCancel(t *testing.T) {
 		}
 		if si.Config.Replicas != originReplicas {
 			return fmt.Errorf("expected R%d, got R%d", originReplicas, si.Config.Replicas)
+		}
+		if !reflect.DeepEqual(si.Config.Placement, &nats.Placement{Tags: []string{"C1"}}) {
+			return fmt.Errorf("expected placement to be restored, got %+v", si.Config.Placement)
+		}
+		if si.Cluster == nil || si.Cluster.Name != originCluster {
+			return fmt.Errorf("expected cluster %q, got %+v", originCluster, si.Cluster)
+		}
+		if si.State.Msgs != uint64(toSend) {
+			return fmt.Errorf("expected %d msgs, got %d", toSend, si.State.Msgs)
+		}
+		return nil
+	})
+}
+
+func TestJetStreamSuperClusterStreamCancelMoveAPI(t *testing.T) {
+	sc := moveTestSuperCluster(t)
+	defer sc.shutdown()
+
+	c1 := sc.clusterForName("C1")
+	nc, js := jsClientConnect(t, c1.randomNonLeader())
+	defer nc.Close()
+
+	cancelMove := func(stream string) *ApiError {
+		t.Helper()
+		rmsg, err := nc.Request(fmt.Sprintf(JSApiStreamCancelMoveT, stream), nil, 5*time.Second)
+		require_NoError(t, err)
+		var resp JSApiStreamUpdateResponse
+		require_NoError(t, json.Unmarshal(rmsg.Data, &resp))
+		return resp.Error
+	}
+
+	// An unknown stream has nothing to cancel.
+	apiErr := cancelMove("NOPE")
+	require_NotNil(t, apiErr)
+	require_Error(t, apiErr, NewJSStreamNotFoundError())
+
+	cfg := &nats.StreamConfig{
+		Name:      "TEST",
+		Subjects:  []string{"foo"},
+		Placement: &nats.Placement{Tags: []string{"C1"}},
+		Replicas:  3,
+	}
+	si, err := js.AddStream(cfg)
+	require_NoError(t, err)
+	require_Equal(t, si.Cluster.Name, "C1")
+
+	toSend := 100
+	for range toSend {
+		_, err = js.Publish("foo", []byte("hello"))
+		require_NoError(t, err)
+	}
+
+	// A stream that isn't moving has nothing to cancel either.
+	apiErr = cancelMove("TEST")
+	require_NotNil(t, apiErr)
+	require_Error(t, apiErr, NewJSStreamReconfigureNotInProgressError())
+
+	ml := sc.leader()
+	originPeers, originCluster, originReplicas := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+	require_Equal(t, len(originPeers), 3)
+	require_Equal(t, originCluster, "C1")
+
+	// Start a move to C2 by changing the placement tags.
+	cfg.Placement = &nats.Placement{Tags: []string{"C2"}}
+	_, err = js.UpdateStream(cfg)
+	require_NoError(t, err)
+
+	// Wait for the move to be in progress, i.e. the destination peers were added.
+	checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
+		peers, _, _ := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+		if len(peers) <= originReplicas {
+			return fmt.Errorf("move not in progress yet, %d peers", len(peers))
+		}
+		return nil
+	})
+
+	require_True(t, cancelMove("TEST") == nil)
+
+	// If the move converged before the cancel landed, it started a fresh move back rather
+	// than canceling. The assertions below can't tell those apart, so catch it here.
+	peers, _, _ := moveTestStreamGroup(t, ml, globalAccountName, "TEST")
+	for _, peer := range originPeers {
+		if !slices.Contains(peers, peer) {
+			t.Fatalf("Move converged before the cancel landed, cancel path not exercised: "+
+				"expected origin peer %q in %+v", peer, peers)
+		}
+	}
+
+	// The cancel must restore the origin recorded before the move.
+	checkFor(t, 10*time.Second, 250*time.Millisecond, func() error {
+		peers, cluster, replicas := moveTestStreamGroup(t, sc.leader(), globalAccountName, "TEST")
+		if replicas != originReplicas {
+			return fmt.Errorf("expected R%d, got R%d", originReplicas, replicas)
+		}
+		if cluster != originCluster {
+			return fmt.Errorf("expected cluster %q, got %q", originCluster, cluster)
+		}
+		if !moveTestSamePeers(peers, originPeers) {
+			return fmt.Errorf("expected peers %+v, got %+v", originPeers, peers)
+		}
+		si, err := js.StreamInfo("TEST")
+		if err != nil {
+			return err
 		}
 		if !reflect.DeepEqual(si.Config.Placement, &nats.Placement{Tags: []string{"C1"}}) {
 			return fmt.Errorf("expected placement to be restored, got %+v", si.Config.Placement)
@@ -4821,7 +4913,7 @@ func TestJetStreamSuperClusterReconcileWithoutMoveRecordsNoOrigin(t *testing.T) 
 	var cancelResp JSApiStreamUpdateResponse
 	require_NoError(t, json.Unmarshal(rmsg.Data, &cancelResp))
 	require_NotNil(t, cancelResp.Error)
-	require_Equal(t, cancelResp.Error.ErrCode, uint16(JSStreamMoveNotInProgress))
+	require_Error(t, cancelResp.Error, NewJSStreamReconfigureNotInProgressError())
 }
 
 // Move requests that keep cycling between clusters must not be able to grow the stream
@@ -4868,7 +4960,9 @@ func TestJetStreamSuperClusterCyclingMovesBoundGroupSize(t *testing.T) {
 
 	// Cycle the move target between the clusters. A retarget while a move is still in
 	// flight is rejected, so the peer sets can never accumulate peers of an abandoned
-	// target, and stay bounded well below the migration cap.
+	// target, and stay bounded well below the migration cap. The one exception is a
+	// retarget back to the origin's placement, which cancels the in-flight move and
+	// rolls back to the origin peers, keeping the set bounded just the same.
 	last := "C1"
 	var accepted, rejected int
 	for i := range 6 {

--- a/server/jetstream_versioning_test.go
+++ b/server/jetstream_versioning_test.go
@@ -669,8 +669,10 @@ func TestJetStreamApiErrorOnRequiredApiLevel(t *testing.T) {
 			var resp ApiResponse
 			require_NoError(t, json.Unmarshal(msg.Data, &resp))
 			require_True(t, resp.Error != nil)
-			// Peer remove or stepdown is not supported if not clustered.
-			if strings.Contains(apiSubject, ".STEPDOWN.") || strings.Contains(apiSubject, ".PEER.") {
+			// Peer remove, stepdown or cancel move is not supported if not clustered.
+			if strings.Contains(apiSubject, ".STEPDOWN.") ||
+				strings.Contains(apiSubject, ".PEER.") ||
+				strings.Contains(apiSubject, ".CANCEL_MOVE.") {
 				require_Error(t, resp.Error, NewJSClusterRequiredError())
 			} else {
 				require_Error(t, resp.Error, NewJSRequiredApiLevelError())

--- a/server/stream.go
+++ b/server/stream.go
@@ -385,6 +385,7 @@ type DesiredClusterInfo struct {
 	Name     string                    `json:"name,omitempty"`
 	Replicas []*PeerInfo               `json:"replicas,omitempty"`
 	Origin   *DesiredClusterInfoOrigin `json:"origin,omitempty"`
+	Status   *DesiredClusterInfoStatus `json:"status,omitempty"`
 }
 
 type DesiredClusterInfoOrigin struct {
@@ -394,6 +395,56 @@ type DesiredClusterInfoOrigin struct {
 	Placement *Placement `json:"placement,omitempty"`
 	// When changing between retention policies, this retention remains active until unset.
 	Retention *RetentionPolicy `json:"retention,omitempty"`
+}
+
+// MigrationStatusType classifies a migration status by what has to change for the
+// migration to advance, so it can be matched on without parsing the status line.
+type MigrationStatusType string
+
+const (
+	MigrationStatusMeta        MigrationStatusType = "meta"        // The meta leader must record or advance desired state.
+	MigrationStatusMembership  MigrationStatusType = "membership"  // A proposed membership change must commit.
+	MigrationStatusSnapshot    MigrationStatusType = "snapshot"    // A snapshot must be installed.
+	MigrationStatusCatchup     MigrationStatusType = "catchup"     // Peers must become store-current.
+	MigrationStatusQuorum      MigrationStatusType = "quorum"      // More peers must come online before we can act without losing quorum.
+	MigrationStatusBlocked     MigrationStatusType = "blocked"     // Another asset must move first, i.e. the stream/consumer ordering constraint.
+	MigrationStatusUnavailable MigrationStatusType = "unavailable" // Nothing to do here, we're shutting down, or the assignment is gone.
+)
+
+type DesiredClusterInfoStatus struct {
+	// Description is a short status line describing what the group leader is currently
+	// doing to move this group toward its desired state, or what it's waiting on.
+	Description string `json:"description"`
+	// Type classifies Description by what has to change for the migration to
+	// advance, so it can be matched on without parsing the status line.
+	Type MigrationStatusType `json:"type"`
+	// Err is the underlying failure behind this status, if it had one. Only set
+	// for faults that persist across cycles, never for races that resolve themselves.
+	Err string `json:"err,omitempty"`
+}
+
+// mstat builds a migration status of the given type. The line is a short, stable
+// phrase; keep it matchable by leaving anything unbounded to Err.
+func mstat(t MigrationStatusType, format string, args ...any) *DesiredClusterInfoStatus {
+	if len(args) == 0 {
+		return &DesiredClusterInfoStatus{Type: t, Description: format}
+	}
+	return &DesiredClusterInfoStatus{Type: t, Description: fmt.Sprintf(format, args...)}
+}
+
+// withErr attaches the underlying failure, unless it's one that resolves itself on
+// the next cycle. Those would flap in and out of the status for no good reason.
+func (status *DesiredClusterInfoStatus) withErr(err error) *DesiredClusterInfoStatus {
+	if err == nil ||
+		errors.Is(err, ErrStoreClosed) ||
+		errors.Is(err, errNotLeader) ||
+		errors.Is(err, errNodeClosed) ||
+		errors.Is(err, errMembershipChange) ||
+		errors.Is(err, errNoSnapAvailable) {
+		return status
+	}
+	status.Err = err.Error()
+	return status
 }
 
 // PeerInfo shows information about all the peers in the cluster that


### PR DESCRIPTION
This PR finalizes desired meta reconciliation with some tweaks:
- The JS lock was held throughout both `runStreamMigration` and `runConsumerMigration`. Now we snapshot the fields we need and then release the JS lock so we're not holding JS lock when accessing stream, consumer or Raft data/locks.
- When peer-removing a stream peer can't replace the peer, it leaves an empty spot that can be later added when a new peer joins the cluster. However, while in this "under-replicated" state it marked it as migrating, which resulted in constant meta layer churn since it initialized and finalized desired state in a loop while in this state. This PR fixes that by only running desired state reconciliation if there is desired state, if the assignment's peer set is different from the Raft group, or the group is part of a legacy move where the assignment's peer set is larger than the intended replica count.
- A stream cancel move endpoint was added, which has similar behavior to the system-level cancel move, but is scoped purely to the account the user is in and allows the user to cancel a move which wasn't possible before. The `"stream move not in progress"` error was renamed to `"stream reconfiguration not in progress"` and a `"stream reconfiguration already in progress"` error was added since desired state is not limited to moves, it also includes scaling and retention changes.
- Scale and retention changes can now be stacked again, and the meta layer and stream/consumer layer together ensure data is kept safe throughout. But, errors are kept to deny: concurrent scale and move, move while one is already in progress, move while a scale is already in progress, etc.
- A little bit of code deduplication between `runStreamMigration` and `runConsumerMigration` by extracting: `desiredSnapshot` which snapshots all desired-related data under the JS lock, `removeEvictedPeers` which removes peers that are still part of the Raft group, but are no longer in the assignment (usually as a result of peer-remove, but could fix lingering peer set desync prior to upgrade too), and `extendPeerSet` which gradually adds peers to the Raft group.
- Reporting migration status in stream/consumer info: `Cluster.Desired.Status: { Description: string, Type: string, Err: string? }`. The description contains a simple human-readable description of what status the migration is in, and the type contains an enum that can be used for identifying what the migration is waiting on, like a membership change, quorum, blocked on a consumer moving, etc.

Follow-up of https://github.com/nats-io/nats-server/pull/8432