### PR TITLE
[FIXED] Data race reading consumer config in stream consumer getters

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -476,6 +476,8 @@ type consumer struct {
 	maxdc             uint64
 	waiting           *waitQueue
 	cfg               ConsumerConfig
+	direct            bool // Immutable, enforced by checkNewConsumerConfig. Read without o.mu.
+	sourcing          bool // Immutable, enforced by checkNewConsumerConfig. Read without o.mu.
 	ici               *ConsumerInfo
 	store             ConsumerStore
 	active            bool
@@ -1185,6 +1187,8 @@ func (mset *stream) addConsumerWithAssignment(config *ConsumerConfig, oname stri
 		client:    s.createInternalJetStreamClient(),
 		sysc:      s.createInternalJetStreamClient(),
 		cfg:       *config,
+		direct:    config.Direct,
+		sourcing:  config.Sourcing,
 		dsubj:     config.DeliverSubject,
 		outq:      mset.outq,
 		active:    true,
@@ -2236,7 +2240,7 @@ func (o *consumer) deleteNotActive() {
 	}
 
 	s, js := o.mset.srv, o.srv.js.Load()
-	acc, stream, name, isDirect := o.acc.Name, o.stream, o.name, o.cfg.Direct
+	acc, stream, name, isDirect := o.acc.Name, o.stream, o.name, o.direct
 	// Capture our own view of the assignment while we still hold the lock.
 	ca := o.ca
 	var qch, cqch chan struct{}
@@ -2474,6 +2478,14 @@ func (acc *Account) checkNewConsumerConfig(cfg, ncfg *ConsumerConfig) error {
 	}
 	if cfg.MemoryStorage != ncfg.MemoryStorage {
 		return errors.New("storage type can not be updated")
+	}
+	// Direct and Sourcing classify the consumer for its whole lifetime, which the
+	// stream relies on when walking its consumer list, so they can not change.
+	if cfg.Direct != ncfg.Direct {
+		return errors.New("direct can not be updated")
+	}
+	if cfg.Sourcing != ncfg.Sourcing {
+		return errors.New("sourcing can not be updated")
 	}
 	if cfg.OptStartSeq != ncfg.OptStartSeq {
 		return errors.New("start sequence can not be updated")
@@ -5719,7 +5731,7 @@ func (o *consumer) deliverMsg(dsubj, ackReply string, pmsg *jsPubMsg, dc uint64,
 
 	// If we are ack none and mset is interest only we should make sure stream removes interest.
 	if ap == AckNone && rp != LimitsPolicy {
-		if mset != nil && mset.ackq != nil && (o.node == nil || o.cfg.Direct) {
+		if mset != nil && mset.ackq != nil && (o.node == nil || o.direct) {
 			mset.ackq.push(seq)
 		} else {
 			o.updateAcks(dseq, seq, _EMPTY_)

--- a/server/jetstream.go
+++ b/server/jetstream.go
@@ -1349,6 +1349,8 @@ func (a *Account) EnableJetStream(limits map[string]JetStreamAccountLimits, tq c
 						acc:           a,
 						srv:           s,
 						cfg:           cfg.ConsumerConfig,
+						direct:        cfg.Direct,
+						sourcing:      cfg.Sourcing,
 						active:        false,
 						stream:        mset.name(),
 						name:          cfg.Name,

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -12845,6 +12845,103 @@ func TestJetStreamConsumerUpdateConfigStopRace(t *testing.T) {
 }
 
 // Must be run with -race.
+// updateConfig assigns the whole ConsumerConfig under o.mu, while
+// getPublicConsumers/getDirectConsumers used to read o.cfg.Direct holding only
+// mset.clsMu. They read the immutable o.direct now. Real world pairing is
+// jsConsumerCreateRequest (update path) against jsConsumerListRequest.
+func TestJetStreamConsumerConfigDirectRace(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	mset, err := s.globalAccount().addStream(&StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Storage:  MemoryStorage,
+	})
+	require_NoError(t, err)
+
+	o, err := mset.addConsumer(&ConsumerConfig{
+		Durable:   "C",
+		AckPolicy: AckExplicit,
+	})
+	require_NoError(t, err)
+
+	const iters = 500
+	var wg sync.WaitGroup
+	wg.Add(2)
+	start := make(chan struct{})
+
+	// Writer: Description is updatable, and varying it defeats the
+	// DeepEqual early return in checkNewConsumerConfig.
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := range iters {
+			cfg := o.config()
+			cfg.Description = fmt.Sprintf("update-%d", i)
+			_ = o.updateConfig(&cfg)
+		}
+	}()
+
+	// Reader: walks cList without taking the consumer lock.
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iters {
+			if n := len(mset.getPublicConsumers()); n != 1 {
+				t.Errorf("Expected 1 public consumer, got %d", n)
+				return
+			}
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+}
+
+// Direct and Sourcing classify a consumer for its whole lifetime. The stream
+// reads them off the consumer without taking the consumer lock, so an update
+// must not be able to change them.
+func TestJetStreamConsumerUpdateRejectsDirectAndSourcingChange(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	mset, err := s.globalAccount().addStream(&StreamConfig{
+		Name:     "TEST",
+		Subjects: []string{"foo"},
+		Storage:  MemoryStorage,
+	})
+	require_NoError(t, err)
+
+	// Direct consumers need to be push based ephemerals.
+	od, err := mset.addConsumer(&ConsumerConfig{
+		DeliverSubject: "d",
+		AckPolicy:      AckNone,
+		Direct:         true,
+	})
+	require_NoError(t, err)
+
+	cfg := od.config()
+	cfg.Direct = false
+	require_Error(t, od.updateConfig(&cfg), errors.New("direct can not be updated"))
+	require_True(t, od.direct)
+	require_True(t, od.config().Direct)
+
+	os, err := mset.addConsumer(&ConsumerConfig{
+		Durable:   "S",
+		AckPolicy: AckExplicit,
+		Sourcing:  true,
+	})
+	require_NoError(t, err)
+
+	cfg = os.config()
+	cfg.Sourcing = false
+	require_Error(t, os.updateConfig(&cfg), errors.New("sourcing can not be updated"))
+	require_True(t, os.sourcing)
+	require_True(t, os.config().Sourcing)
+}
+
+// Must be run with -race.
 func TestJetStreamConsumerSetRateLimitAccountMpayRace(t *testing.T) {
 	acc := &Account{Name: "A"}
 	acc.mpay = 1024

--- a/server/stream.go
+++ b/server/stream.go
@@ -8648,7 +8648,7 @@ func (mset *stream) getPublicConsumers() []*consumer {
 
 	var obs []*consumer
 	for _, o := range mset.cList {
-		if !o.cfg.Direct {
+		if !o.direct {
 			obs = append(obs, o)
 		}
 	}
@@ -8662,7 +8662,7 @@ func (mset *stream) getDirectConsumers() []*consumer {
 
 	var obs []*consumer
 	for _, o := range mset.cList {
-		if o.cfg.Direct {
+		if o.direct {
 			obs = append(obs, o)
 		}
 	}
@@ -8735,7 +8735,7 @@ func (mset *stream) setConsumer(o *consumer) {
 	if len(o.subjf) > 0 {
 		mset.numFilter++
 	}
-	if o.cfg.Direct || o.cfg.Sourcing {
+	if o.direct || o.sourcing {
 		mset.sourcingConsumers++
 	}
 	// Now update consumers list as well
@@ -8758,7 +8758,7 @@ func (mset *stream) removeConsumer(o *consumer) {
 		if o.cfg.FilterSubject != _EMPTY_ && mset.numFilter > 0 {
 			mset.numFilter--
 		}
-		if (o.cfg.Direct || o.cfg.Sourcing) && mset.sourcingConsumers > 0 {
+		if (o.direct || o.sourcing) && mset.sourcingConsumers > 0 {
 			mset.sourcingConsumers--
 		}
 
@@ -8842,11 +8842,9 @@ func (mset *stream) numDirectConsumers() (num int) {
 
 	// Consumers that are direct are not recorded at the store level.
 	for _, o := range mset.cList {
-		o.mu.RLock()
-		if o.cfg.Direct {
+		if o.direct {
 			num++
 		}
-		o.mu.RUnlock()
 	}
 	return num
 }
@@ -8889,12 +8887,11 @@ func (mset *stream) partitionUnique(name string, partitions []string) bool {
 			if n == name {
 				continue
 			}
-			o.mu.RLock()
 			// Ignore direct/sourcing consumers.
-			if o.cfg.Direct || o.cfg.Sourcing {
-				o.mu.RUnlock()
+			if o.direct || o.sourcing {
 				continue
 			}
+			o.mu.RLock()
 			if o.subjf == nil {
 				o.mu.RUnlock()
 				return false


### PR DESCRIPTION
`getPublicConsumers` and `getDirectConsumers` walk `mset.cList` and read `o.cfg.Direct` while holding only `mset.clsMu`, never the consumer's own lock.
`updateConfig` assigns the whole `ConsumerConfig` struct under `o.mu`, so a consumer update concurrent with a consumer list is an unsynchronized read/write on the same field.

This is reachable from the JetStream API on a single server, no cluster required: `jsConsumerCreateRequest`'s update path against `jsConsumerListRequest`.
It shows up in downstream test suites that run `-race` while creating and listing consumers, where a single race poisons every test in the package run.

```
WARNING: DATA RACE
Write at 0x00c0006003e0 by goroutine 108:
  server.(*consumer).updateConfig()      consumer.go:2657   // o.cfg = *cfg
Previous read at 0x00c0006003e1 by goroutine 109:
  server.(*stream).getPublicConsumers()  stream.go:8633     // o.cfg.Direct
```

The two addresses are one byte apart: `MemoryStorage` and `Direct` are adjacent `bool`s in `ConsumerConfig`, so the struct assignment and the field read overlap in the same word.

## Changes

Following review, this takes `Direct` and `Sourcing` out of the racing set entirely rather than guarding each reader with a lock.

- `consumer` gains `direct` and `sourcing`, copied from the config at creation. Both production constructors set them, `addConsumerWithAssignment` and the offline placeholder in `EnableJetStream`.
- `checkNewConsumerConfig` rejects updates to either field. The check alone would not have fixed the race, since the wholesale `o.cfg` swap trips the detector even when the value never changes, which is why both halves are needed.
- No lock or atomics required to read them: they are written in the construction literal before `setConsumer` publishes the consumer into `cList` under `clsMu`, and every reader synchronizes through `clsMu`, the stream lock, or `o.mu`.
- The list-walking getters now take no consumer lock at all. `numDirectConsumers` drops the `o.mu.RLock` it was already taking for this field, and `partitionUnique` classifies before locking, so it only takes the consumer lock when it needs `o.subjf`.
- `setConsumer` and `removeConsumer` read the same pair unlocked too. Not demonstrably a race, since `stopWithFlags` clears `o.mset` under `o.mu` first and later updates reject a nil `mset`, but it can observe an updated value and mismatch `mset.sourcingConsumers`. Reading the creation value on both the increment and the decrement makes that accounting symmetric by construction.
- `locksordering.txt` is unchanged from base, since nothing nests locks anymore.

## On preventing updates

Both fields are prevented rather than just `Direct`, otherwise the cached value and `o.cfg` can disagree: `partitionUnique` and the `sourcingConsumers` count would answer from the creation value while `updateConfig`, `ca.Config.Sourcing` and `config()` follow the updated one.

Changing `Sourcing` on a non-direct consumer already misbehaves today, because `setConsumer` counts from the creation config and `removeConsumer` from the updated one, so a flip either leaks the count or steals another consumer's decrement, and that counter feeds MaxConsumers and work queue decisions. That argument does not hold when `Direct=true`, where both sides test `Direct || Sourcing`.

Worth a maintainer opinion: both fields are JSON exposed, and the metadata leader validates a config before proposing while peers revalidate on apply, so an older leader can commit an assignment a newer peer rejects. The same asymmetry already applies to the eight fields `checkNewConsumerConfig` rejects today, but these two predicates are new. No in-tree mirror, source, recovery or clustered path changes either field on an existing consumer, and the `Sourcing` downgrade retries always pick a fresh consumer name so they create rather than update. Happy to reduce this to `Direct` only if preferred.

## Testing

- `TestJetStreamConsumerConfigDirectRace` pairs an `updateConfig` loop with a `getPublicConsumers` loop, following the existing `TestJetStreamConsumerUpdateConfigStopRace` idiom. Reported the race on 8 of 8 runs before the change.
- `TestJetStreamConsumerUpdateRejectsDirectAndSourcingChange` covers the new checks, alongside the existing `TestJetStreamConsumerUpdateRejectsStorageChange`.
- Full CI matrix run locally, all 16 test groups green, plus the consumer suite under `-race`.