### PR TITLE
[FIXED] Prevent duplicate JetStream ingestion subscriptions during concurrent stream updates

### DIFF
--- a/server/jetstream_issue_7801_test.go
+++ b/server/jetstream_issue_7801_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+type issue7801TraceLogger struct {
+	DummyLogger
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *issue7801TraceLogger) Tracef(format string, args ...any) {
+	if len(args) == 1 {
+		if nested, ok := args[0].([]any); ok {
+			args = nested
+		}
+	}
+	l.mu.Lock()
+	l.lines = append(l.lines, fmt.Sprintf(format, args...))
+	l.mu.Unlock()
+}
+
+func (l *issue7801TraceLogger) countIngress(subject string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	count := 0
+	for _, line := range l.lines {
+		if strings.Contains(line, "<<-") && strings.Contains(line, "PUB") && strings.Contains(line, subject) {
+			count++
+		}
+	}
+	return count
+}
+
+// Regression test for issue #7801. The externally observable contract is one
+// publish request, one PubAck, and one stored stream message after concurrent,
+// equivalent stream updates.
+func TestJetStreamIssue7801ConcurrentStreamUpdatesDoNotMultiplyPublish(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	mset, err := s.GlobalAccount().addStream(&StreamConfig{
+		Name:     "ISSUE_7801",
+		Subjects: []string{"issue.7801.seed"},
+		Storage:  FileStorage,
+	})
+	if err != nil {
+		t.Fatalf("error adding stream: %v", err)
+	}
+
+	// The report used a large subject set and several clients updated the same
+	// stream concurrently. A larger set makes the stale-snapshot race reliable
+	// without inserting timing hooks into the production path.
+	subjects := make([]string, 2048)
+	for i := range subjects {
+		subjects[i] = fmt.Sprintf("issue.7801.subject.%d", i)
+	}
+	publishSubject := subjects[len(subjects)/2]
+
+	const updaters = 8
+	updateClients := make([]*nats.Conn, updaters)
+	for i := range updateClients {
+		updateClients[i] = clientConnectToServer(t, s)
+		defer updateClients[i].Close()
+	}
+	cfg := mset.config()
+	cfg.Subjects = append([]string(nil), subjects...)
+	updateRequest, err := json.Marshal(&cfg)
+	if err != nil {
+		t.Fatalf("error marshaling stream update: %v", err)
+	}
+	start := make(chan struct{})
+	errs := make(chan error, updaters)
+	var wg sync.WaitGroup
+	for _, nc := range updateClients {
+		wg.Add(1)
+		go func(nc *nats.Conn) {
+			defer wg.Done()
+			<-start
+			msg, err := nc.Request(fmt.Sprintf(JSApiStreamUpdateT, cfg.Name), updateRequest, 30*time.Second)
+			if err == nil {
+				var response JSApiStreamUpdateResponse
+				if err = json.Unmarshal(msg.Data, &response); err == nil && response.Error != nil {
+					err = response.Error
+				}
+			}
+			errs <- err
+		}(nc)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent stream update failed: %v", err)
+		}
+	}
+
+	observer := clientConnectToServer(t, s)
+	defer observer.Close()
+	js, err := observer.JetStream()
+	if err != nil {
+		t.Fatalf("error creating JetStream context: %v", err)
+	}
+	consumer, err := js.PullSubscribe(publishSubject, "ISSUE_7801_CONSUMER",
+		nats.BindStream(cfg.Name), nats.ManualAck())
+	if err != nil {
+		t.Fatalf("error creating observation consumer: %v", err)
+	}
+
+	trace := &issue7801TraceLogger{}
+	s.SetLogger(trace, false, true)
+	nc := clientConnectToServer(t, s)
+	defer nc.Close()
+	reply := nats.NewInbox()
+	acks, err := nc.SubscribeSync(reply)
+	if err != nil {
+		t.Fatalf("error subscribing for publish acknowledgements: %v", err)
+	}
+	if err := nc.PublishRequest(publishSubject, reply, []byte("one logical publish")); err != nil {
+		t.Fatalf("publish failed: %v", err)
+	}
+	if err := nc.Flush(); err != nil {
+		t.Fatalf("flush failed: %v", err)
+	}
+
+	ackCount := 0
+	for {
+		if _, err := acks.NextMsg(100 * time.Millisecond); err == nats.ErrTimeout {
+			break
+		} else if err != nil {
+			t.Fatalf("error receiving publish acknowledgement: %v", err)
+		}
+		ackCount++
+	}
+	state := mset.state()
+	deliveries, err := consumer.Fetch(int(state.Msgs), nats.MaxWait(5*time.Second))
+	if err != nil {
+		t.Fatalf("error fetching stored messages: %v", err)
+	}
+	sequences := make([]uint64, 0, len(deliveries))
+	redeliveryCount := 0
+	for _, msg := range deliveries {
+		metadata, err := msg.Metadata()
+		if err != nil {
+			t.Fatalf("error reading delivery metadata: %v", err)
+		}
+		sequences = append(sequences, metadata.Sequence.Stream)
+		if metadata.NumDelivered > 1 {
+			redeliveryCount++
+		}
+		if err := msg.Ack(); err != nil {
+			t.Fatalf("error acknowledging delivery: %v", err)
+		}
+	}
+	ingressCount := trace.countIngress(publishSubject)
+	if ingressCount != 1 || ackCount != 1 || state.Msgs != 1 || state.LastSeq != 1 || len(deliveries) != 1 || redeliveryCount != 0 {
+		t.Fatalf("one publish multiplied: ingresses=%d acks=%d messages=%d last_seq=%d deliveries=%d redeliveries=%d sequences=%v",
+			ingressCount, ackCount, state.Msgs, state.LastSeq, len(deliveries), redeliveryCount, sequences)
+	}
+}

--- a/server/stream.go
+++ b/server/stream.go
@@ -515,6 +515,7 @@ type stream struct {
 	numFilter int                     // The number of filtered consumers.
 	cfg       StreamConfig            // The stream's config.
 	cfgMu     sync.RWMutex            // Config mutex used to solve some races with consumer code
+	updateMu  sync.Mutex              // Serializes configuration updates that depend on the current config.
 	created   time.Time               // Time the stream was created.
 	stype     StorageType             // The storage type.
 	tier      string                  // The tier is the number of replicas for the stream (e.g. "R1" or "R3").
@@ -2473,6 +2474,14 @@ func (mset *stream) updateWithAdvisory(config *StreamConfig, sendAdvisory bool, 
 	if err != nil {
 		return err
 	}
+
+	// The update is calculated from the current configuration before the stream
+	// lock is acquired below. Serialize updates for this stream so a concurrent
+	// caller cannot calculate and apply a second delta from the same stale
+	// configuration (for example, installing the same subject subscriptions
+	// more than once).
+	mset.updateMu.Lock()
+	defer mset.updateMu.Unlock()
 
 	mset.mu.RLock()
 	ocfg := mset.cfg


### PR DESCRIPTION
Resolves #7801.

The complete issue trace shows sequences 100-104 spanning two wire-level publishes, with each ingress multiplied independently. A controlled reproduction makes the boundary deterministic: one traced ingress produces eight PubAcks and eight durable stream records.

Concurrent equivalent stream updates could each calculate their subscription delta from the same stale stream configuration. Each update then installed the same internal ingestion subscription. A later protocol publish matched every duplicate subscription, so one ingress was independently accepted multiple times and produced multiple durable records, stream sequences, and PubAcks.

This change serializes `updateWithAdvisory` per stream, covering the configuration snapshot, delta calculation, and application. It does not add message deduplication or change publish retry, consumer acknowledgement, or redelivery semantics.

The regression test performs eight concurrent equivalent public stream updates, then verifies that one traced ingress produces exactly one PubAck, one durable record/stream sequence, one first delivery, and zero redeliveries.

Validation:

- Fresh `main` control (`8e54a59546b11dc62bf894b2360c12a01f465cf6`): 1 ingress -> 8 PubAcks, 8 records/sequences, 8 first deliveries.
- Candidate: 1 ingress -> 1 PubAck, 1 record/sequence, 1 first delivery, 0 redeliveries; 20/20 repeated witness runs passed.
- Targeted PubAck, explicit-ack, retry, deduplication, and redelivery tests passed.
- Strengthened race run covering the witness and `TestJetStreamUpdateStream` passed.
- `golangci-lint` and Linux amd64/386 builds passed.
- The full native run recorded two unrelated failures: the known `TestLeafNodeSlowConsumer` timing flake, and `TestOCSPPeerMonitor` failing to restart its fixed `8222` monitoring port between subtests. The OCSP failure reproduces identically on the unmodified base; the remainder of the `test` package passes with that baseline-broken case excluded.

I certify that this contribution is my original work and that I license it to the project under the Apache License 2.0.
