### PR TITLE
[IMPROVED] Direct get performance and stream lock decoupling

### DIFF
--- a/locksordering.txt
+++ b/locksordering.txt
@@ -52,3 +52,10 @@ The "mset.batches.mu" lock protects the batching state without needing to hold t
 If "clMu" is used to commit a batch, it should only be acquired while already holding the batch lock.
 
     stream -> mset.batches.mu -> clMu
+
+The "isolateMu" lock isolates direct get and msg get reads from writes, so those reads do not
+observe partially applied rollups or atomic batches. Other read paths (consumer delivery,
+mirrors/sources, info requests, etc.) are sequentially consistent and may observe a prefix of
+an inflight batch. It must be acquired before the stream lock, never while holding it.
+
+    isolateMu -> stream

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -16,6 +16,7 @@ package server
 import (
 	"archive/tar"
 	"bytes"
+	"cmp"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -3868,6 +3869,9 @@ func (fs *fileStore) allLastSeqsLocked() ([]uint64, error) {
 // Most clients send in subjects even if they match the stream's ingest subjects.
 // Lock should be held.
 func (fs *fileStore) filterIsAll(filters []string) bool {
+	if len(filters) == 1 && filters[0] == fwcs {
+		return true
+	}
 	if len(filters) != len(fs.cfg.Subjects) {
 		return false
 	}
@@ -3945,6 +3949,17 @@ func (fs *fileStore) multiLastSeqsLocked(filters []string, maxSeq uint64, maxAll
 
 	// Collect all sequences needed.
 	seqs := make([]uint64, 0, len(subs))
+
+	// If covering the whole stream, check fast path of visiting only last blocks.
+	if maxSeq >= fs.state.LastSeq {
+		if maxAllowed > 0 && len(subs) > maxAllowed {
+			return nil, ErrTooManyResults
+		}
+		if err := fs.multiLastSeqsByLastBlockLocked(subs, &seqs); err != nil {
+			return nil, err
+		}
+	}
+
 	for i, lnf := lastBlkIndex, false; i >= 0; i-- {
 		if len(subs) == 0 {
 			break
@@ -4060,6 +4075,74 @@ func (fs *fileStore) MultiLastMsgs(filters []string, minSeq, maxSeq uint64, maxA
 		}
 	}
 	return total, np, nil
+}
+
+// multiLastSeqsByLastBlockLocked resolves last sequences via each subject's
+// last block (psi.lblk), moving resolved subjects from subs into seqs and
+// leaving unresolved ones (e.g. stale lblk) in subs for the caller.
+// Lock should be held.
+func (fs *fileStore) multiLastSeqsByLastBlockLocked(subs map[string]*psi, seqs *[]uint64) error {
+	// Sort requested subjects by their last block so each block is visited
+	// once and in order, one flat slice instead of per-block map bookkeeping.
+	type lblkSubj struct {
+		lblk uint32
+		subj string
+		info *psi
+	}
+	pairs := make([]lblkSubj, 0, len(subs))
+	for subj, info := range subs {
+		pairs = append(pairs, lblkSubj{info.lblk, subj, info})
+	}
+	slices.SortFunc(pairs, func(a, b lblkSubj) int {
+		return cmp.Compare(a.lblk, b.lblk)
+	})
+
+	var unresolved []lblkSubj
+	for i := 0; i < len(pairs); {
+		blkIdx := pairs[i].lblk
+		j := i + 1
+		for j < len(pairs) && pairs[j].lblk == blkIdx {
+			j++
+		}
+		mb := fs.bim[blkIdx]
+		if mb == nil {
+			unresolved = append(unresolved, pairs[i:j]...)
+			i = j
+			continue
+		}
+		mb.mu.Lock()
+		if err := mb.ensurePerSubjectInfoLoaded(); err != nil {
+			mb.mu.Unlock()
+			return err
+		}
+		for ; i < j; i++ {
+			subj := pairs[i].subj
+			ss, ok := mb.fss.Find(stringToBytes(subj))
+			if !ok || ss == nil {
+				unresolved = append(unresolved, pairs[i])
+				continue
+			}
+			// Check if we need to recalculate. We only care about the last sequence.
+			if ss.lastNeedsUpdate {
+				if err := mb.recalculateForSubj(subj, ss); err != nil {
+					mb.mu.Unlock()
+					return err
+				}
+			}
+			*seqs = append(*seqs, ss.Last)
+		}
+		mb.mu.Unlock()
+	}
+
+	// Shrink subs down to only the unresolved subjects, clearing wholesale
+	// rather than deleting per resolved subject.
+	if len(unresolved) < len(subs) {
+		clear(subs)
+		for _, p := range unresolved {
+			subs[p.subj] = p.info
+		}
+	}
+	return nil
 }
 
 // NumPending will return the number of pending messages matching the filter subject starting at sequence.

--- a/server/filestore.go
+++ b/server/filestore.go
@@ -3888,7 +3888,11 @@ func (fs *fileStore) filterIsAll(filters []string) bool {
 func (fs *fileStore) MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed int) ([]uint64, error) {
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()
+	return fs.multiLastSeqsLocked(filters, maxSeq, maxAllowed)
+}
 
+// Lock should be held.
+func (fs *fileStore) multiLastSeqsLocked(filters []string, maxSeq uint64, maxAllowed int) ([]uint64, error) {
 	if fs.state.Msgs == 0 || fs.noTrackSubjects() {
 		return nil, nil
 	}
@@ -4023,6 +4027,39 @@ func (fs *fileStore) MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed i
 	}
 	slices.Sort(seqs)
 	return seqs, nil
+}
+
+// MultiLastMsgs delivers the last message per subject matching the filters,
+// up to maxSeq and skipping sequences below minSeq, in ascending sequence
+// order through cb, all within a single read section so the batch is a
+// point-in-time snapshot of the store.
+func (fs *fileStore) MultiLastMsgs(filters []string, minSeq, maxSeq uint64, maxAllowed int, cb func(sm *StoreMsg, np uint64) bool) (uint64, uint64, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	seqs, err := fs.multiLastSeqsLocked(filters, maxSeq, maxAllowed)
+	if err != nil || len(seqs) == 0 {
+		return 0, 0, err
+	}
+	total := uint64(len(seqs))
+	np := total
+	for _, seq := range seqs {
+		if np > 0 {
+			np--
+		}
+		if seq < minSeq {
+			continue
+		}
+		var svp StoreMsg
+		sm, err := fs.msgForSeqLocked(seq, &svp, false)
+		if err != nil {
+			return total, np, err
+		}
+		if !cb(sm, np) {
+			break
+		}
+	}
+	return total, np, nil
 }
 
 // NumPending will return the number of pending messages matching the filter subject starting at sequence.

--- a/server/jetstream_api.go
+++ b/server/jetstream_api.go
@@ -3742,8 +3742,8 @@ func (s *Server) jsMsgGetRequest(sub *subscription, c *client, _ *Account, subje
 	var sm *StoreMsg
 
 	// Ensure this read request is isolated and doesn't interleave with writes.
-	mset.mu.RLock()
-	defer mset.mu.RUnlock()
+	mset.isolateMu.RLock()
+	defer mset.isolateMu.RUnlock()
 
 	// If AsOfTime is set, perform this first to get the sequence.
 	var seq uint64

--- a/server/jetstream_benchmark_test.go
+++ b/server/jetstream_benchmark_test.go
@@ -2344,3 +2344,146 @@ func startJSClusterAndConnect(b *testing.B, clusterSize int) (c *cluster, s *Ser
 
 	return c, s, shutdown, nc, js
 }
+
+// BenchmarkJetStreamDirectGet measures direct get latency, single and multi,
+// idle and while a concurrent writer floods the stream, plus the publish path
+// on its own to spot read-isolation cost on writes.
+func BenchmarkJetStreamDirectGet(b *testing.B) {
+	const numSubjects = 256
+
+	setup := func(b *testing.B) (*Server, *nats.Conn) {
+		b.Helper()
+		s := RunBasicJetStreamServer(b)
+		nc, js := jsClientConnect(b, s)
+		_, err := js.AddStream(&nats.StreamConfig{
+			Name:              "TEST",
+			Subjects:          []string{"foo.*"},
+			Storage:           nats.FileStorage,
+			MaxMsgsPerSubject: 1,
+			AllowDirect:       true,
+		})
+		if err != nil {
+			b.Fatalf("add stream: %v", err)
+		}
+		payload := make([]byte, 64)
+		for i := 0; i < numSubjects; i++ {
+			if _, err := js.PublishAsync(fmt.Sprintf("foo.%d", i), payload); err != nil {
+				b.Fatalf("preload: %v", err)
+			}
+		}
+		select {
+		case <-js.PublishAsyncComplete():
+		case <-time.After(10 * time.Second):
+			b.Fatalf("preload did not complete")
+		}
+		return s, nc
+	}
+
+	// Hammer the stream with async publishes over the same subject space for
+	// the duration of the benchmark. The stop func reports publishes acked.
+	startWriter := func(b *testing.B, s *Server) (stop func() uint64) {
+		b.Helper()
+		nc, js := jsClientConnect(b, s, nats.NoEcho())
+		done := make(chan struct{})
+		finished := make(chan struct{})
+		var acked atomic.Uint64
+		go func() {
+			defer close(finished)
+			payload := make([]byte, 64)
+			for i := 0; ; i++ {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				pa, err := js.PublishAsync(fmt.Sprintf("foo.%d", i%numSubjects), payload)
+				if err != nil {
+					// Pending limit reached, wait for completions.
+					select {
+					case <-js.PublishAsyncComplete():
+					case <-time.After(time.Second):
+					}
+					continue
+				}
+				go func() {
+					select {
+					case <-pa.Ok():
+						acked.Add(1)
+					case <-pa.Err():
+					case <-done:
+					}
+				}()
+			}
+		}()
+		return func() uint64 {
+			close(done)
+			<-finished
+			nc.Close()
+			return acked.Load()
+		}
+	}
+
+	single := `{"last_by_subj":"foo.7"}`
+	multi := `{"multi_last":["foo.7","foo.11","foo.13","foo.17","foo.19","foo.23","foo.29","foo.31"]}`
+	for _, bc := range []struct {
+		name       string
+		req        string
+		withWrites bool
+	}{
+		{"Single/Idle", single, false},
+		{"Single/UnderWrites", single, true},
+		{"Multi/Idle", multi, false},
+		{"Multi/UnderWrites", multi, true},
+	} {
+		b.Run(bc.name, func(b *testing.B) {
+			s, nc := setup(b)
+			defer s.Shutdown()
+			defer nc.Close()
+
+			var stop func() uint64
+			if bc.withWrites {
+				stop = startWriter(b, s)
+				// Let the writer get going.
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			getSubj := fmt.Sprintf(JSDirectMsgGetT, "TEST")
+			req := []byte(bc.req)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := nc.Request(getSubj, req, 5*time.Second); err != nil {
+					b.Fatalf("direct get: %v", err)
+				}
+			}
+			b.StopTimer()
+			if stop != nil {
+				writes := stop()
+				b.ReportMetric(float64(writes)/b.Elapsed().Seconds(), "writes/s")
+			}
+		})
+	}
+
+	b.Run("PublishOnly", func(b *testing.B) {
+		s, nc := setup(b)
+		defer s.Shutdown()
+		defer nc.Close()
+
+		_, js := jsClientConnect(b, s)
+		payload := make([]byte, 64)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := js.PublishAsync(fmt.Sprintf("foo.%d", i%numSubjects), payload); err != nil {
+				i--
+				select {
+				case <-js.PublishAsyncComplete():
+				case <-time.After(time.Second):
+				}
+			}
+		}
+		select {
+		case <-js.PublishAsyncComplete():
+		case <-time.After(30 * time.Second):
+			b.Fatalf("publishes did not complete")
+		}
+	})
+}

--- a/server/jetstream_cluster.go
+++ b/server/jetstream_cluster.go
@@ -4856,11 +4856,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				if err != nil {
 					return 0, err
 				}
-
-				// Ensure the whole batch is fully isolated, and reads
-				// can only happen after the full batch is committed.
 				mset.mu.Lock()
-
 				// Previous batch (if any) was abandoned.
 				if batch.id != _EMPTY_ && batchId != batch.id {
 					batch.rejectBatchState(mset)
@@ -4896,6 +4892,11 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 					continue
 				}
 
+				// Ensure the whole batch is fully isolated, and reads
+				// can only happen after the full batch is committed.
+				mset.mu.Unlock()
+				mset.isolateMu.Lock()
+
 				// Process any entries that are part of this batch but prior to the current one.
 				var entries []*Entry
 				for j, bce := range batch.entries {
@@ -4913,7 +4914,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 						}
 						// Important to clear, otherwise we could return the entries to the pool multiple times.
 						batch.clearBatchState()
-						mset.mu.Unlock()
+						mset.isolateMu.Unlock()
 					}
 					for _, entry := range entries {
 						// Non-normal entries (e.g. EntryCatchup) can be buffered but must be ignored.
@@ -4943,7 +4944,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				clearAndUnlock := func() {
 					// Important to clear, otherwise we could return the entries to the pool multiple times.
 					batch.clearBatchState()
-					mset.mu.Unlock()
+					mset.isolateMu.Unlock()
 				}
 				// Process remaining entries in the current entry.
 				for _, entry := range entries {
@@ -4963,7 +4964,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				}
 				// Clear state, batch was successful.
 				batch.clearBatchState()
-				mset.mu.Unlock()
+				mset.isolateMu.Unlock()
 				continue
 			} else if batch != nil && batch.id != _EMPTY_ {
 				// If a batch is abandoned without a commit, reject it.
@@ -4990,11 +4991,14 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				if dr.Num == 0 {
 					continue
 				}
+				// Delete ranges mutate message state, so hold the isolation lock like any other write.
+				mset.isolateMu.Lock()
 				mset.mu.Lock()
 				first, num := dr.First, dr.Num
 				lseq := first + num - 1
 				if mset.lseq >= lseq {
 					mset.mu.Unlock()
+					mset.isolateMu.Unlock()
 					continue
 				}
 				// Trim any prefix already applied so we only skip the uncovered tail.
@@ -5004,6 +5008,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				}
 				if err = mset.store.SkipMsgs(first, num); err != nil {
 					mset.mu.Unlock()
+					mset.isolateMu.Unlock()
 					js.srv.RateLimitWarnf("JetStream cluster failed to apply delete range [%d..%d] for '%s > %s': %v",
 						first, lseq, mset.account().Name, mset.cfg.Name, err)
 					return 0, err
@@ -5011,6 +5016,7 @@ func (js *jetStream) applyStreamEntries(mset *stream, ce *CommittedEntry, isReco
 				mset.clearAllPreAcksInRange(first, lseq)
 				mset.lseq = lseq
 				mset.mu.Unlock()
+				mset.isolateMu.Unlock()
 
 			case deleteMsgOp:
 				md, err := decodeMsgDelete(buf[1:])
@@ -5226,7 +5232,9 @@ func (mset *stream) skipBatchIfRecovering(batch *batchApply, buf []byte) (bool, 
 	return false, nil
 }
 
-func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isRecovering bool, needLock bool) error {
+// needIsolation should be false only if the caller already holds isolateMu
+// across a whole atomic batch; mset.mu must NOT be held by the caller.
+func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isRecovering bool, needIsolation bool) error {
 	s := js.srv
 
 	if op == compressedStreamMsgOp {
@@ -5239,13 +5247,9 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 
 	subject, reply, hdr, msg, lseq, ts, sourced, err := decodeStreamMsg(mbuf)
 	if err != nil {
-		if needLock {
-			mset.mu.RLock()
-		}
+		mset.mu.RLock()
 		acc, name, node := mset.accountLocked(false), mset.nameLocked(false), mset.node
-		if needLock {
-			mset.mu.RUnlock()
-		}
+		mset.mu.RUnlock()
 		if node != nil {
 			s.Errorf("JetStream cluster could not decode stream msg for '%s > %s' [%s]",
 				acc, name, node.Group())
@@ -5256,38 +5260,26 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 	// Check for flowcontrol here.
 	if len(msg) == 0 && len(hdr) > 0 && reply != _EMPTY_ && isControlHdr(hdr) {
 		if !isRecovering {
-			if needLock {
-				mset.mu.RLock()
-			}
+			mset.mu.RLock()
 			mset.sendFlowControlReply(reply, hdr)
-			if needLock {
-				mset.mu.RUnlock()
-			}
+			mset.mu.RUnlock()
 		}
 		return nil
 	}
 
-	if needLock {
-		mset.mu.RLock()
-	}
+	mset.mu.RLock()
 	// Grab last sequence and CLFS.
 	last, clfs := mset.lastSeqAndCLFS()
-	if needLock {
-		mset.mu.RUnlock()
-	}
+	mset.mu.RUnlock()
 
 	// We can skip if we know this is less than what we already have.
 	if lseq-clfs < last {
+		mset.mu.Lock()
 		s.Debugf("Apply stream entries for '%s > %s' skipping message with sequence %d with last of %d",
-			mset.accountLocked(needLock), mset.nameLocked(needLock), lseq+1-clfs, last)
-		if needLock {
-			mset.mu.Lock()
-		}
+			mset.accountLocked(false), mset.nameLocked(false), lseq+1-clfs, last)
 		// Check for any preAcks in case we are interest based.
 		mset.clearAllPreAcks(lseq + 1 - clfs)
-		if needLock {
-			mset.mu.Unlock()
-		}
+		mset.mu.Unlock()
 		return nil
 	}
 
@@ -5305,14 +5297,10 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 		if err != nil {
 			return err
 		}
-		if needLock {
-			mset.mu.Lock()
-		}
+		mset.mu.Lock()
 		mset.lseq = last
 		mset.clearAllPreAcks(last)
-		if needLock {
-			mset.mu.Unlock()
-		}
+		mset.mu.Unlock()
 		return nil
 	}
 
@@ -5324,7 +5312,7 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 		mt = mset.getAndDeleteMsgTrace(lseq)
 	}
 	// Process the actual message here.
-	err = mset.processJetStreamMsg(subject, reply, hdr, msg, lseq, ts, mt, sourced, needLock)
+	err = mset.processJetStreamMsg(subject, reply, hdr, msg, lseq, ts, mt, sourced, needIsolation)
 
 	// Take into account subject transforms, if any.
 	// The untransformed subject is replicated, but the transformed subject is used for consistency checks below.
@@ -5404,7 +5392,7 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 				_, err = mset.store.Compact(lseq + 1)
 				if err == nil {
 					// Retry
-					err = mset.processJetStreamMsg(subject, reply, hdr, msg, lseq, ts, mt, sourced, needLock)
+					err = mset.processJetStreamMsg(subject, reply, hdr, msg, lseq, ts, mt, sourced, needIsolation)
 				}
 			}
 			// FIXME(dlc) - We could just run a catchup with a request defining the span between what we expected
@@ -5416,7 +5404,7 @@ func (js *jetStream) applyStreamMsgOp(mset *stream, op entryOp, mbuf []byte, isR
 			return err
 		}
 		s.Debugf("Apply stream entries for '%s > %s' got error processing message: %v",
-			mset.accountLocked(needLock), mset.nameLocked(needLock), err)
+			mset.accountLocked(true), mset.nameLocked(true), err)
 
 		// There are some errors that we can't recover from.
 		if err != ErrMaxMsgs && err != ErrMaxBytes && err != ErrMaxMsgsPerSubject && err != ErrMsgTooLarge && err != ErrStoreClosed {

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -854,7 +854,11 @@ func (ms *memStore) filterIsAll(filters []string) bool {
 func (ms *memStore) MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed int) ([]uint64, error) {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
+	return ms.multiLastSeqsLocked(filters, maxSeq, maxAllowed)
+}
 
+// Write lock should be held, for recalculateForSubj.
+func (ms *memStore) multiLastSeqsLocked(filters []string, maxSeq uint64, maxAllowed int) ([]uint64, error) {
 	if len(ms.msgs) == 0 {
 		return nil, nil
 	}
@@ -904,6 +908,39 @@ func (ms *memStore) MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed in
 	}
 	slices.Sort(seqs)
 	return seqs, nil
+}
+
+// MultiLastMsgs delivers the last message per subject matching the filters,
+// up to maxSeq and skipping sequences below minSeq, in ascending sequence
+// order through cb, all within a single read section so the batch is a
+// point-in-time snapshot of the store.
+func (ms *memStore) MultiLastMsgs(filters []string, minSeq, maxSeq uint64, maxAllowed int, cb func(sm *StoreMsg, np uint64) bool) (uint64, uint64, error) {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	seqs, err := ms.multiLastSeqsLocked(filters, maxSeq, maxAllowed)
+	if err != nil || len(seqs) == 0 {
+		return 0, 0, err
+	}
+	total := uint64(len(seqs))
+	np := total
+	for _, seq := range seqs {
+		if np > 0 {
+			np--
+		}
+		if seq < minSeq {
+			continue
+		}
+		var svp StoreMsg
+		sm, err := ms.loadMsgLocked(seq, &svp, false)
+		if err != nil {
+			return total, np, err
+		}
+		if !cb(sm, np) {
+			break
+		}
+	}
+	return total, np, nil
 }
 
 // SubjectsTotals return message totals per subject.

--- a/server/memstore.go
+++ b/server/memstore.go
@@ -834,6 +834,9 @@ func (ms *memStore) allLastSeqsLocked() ([]uint64, error) {
 // Most clients send in subjects even if they match the stream's ingest subjects.
 // Lock should be held.
 func (ms *memStore) filterIsAll(filters []string) bool {
+	if len(filters) == 1 && filters[0] == fwcs {
+		return true
+	}
 	if len(filters) != len(ms.cfg.Subjects) {
 		return false
 	}

--- a/server/store.go
+++ b/server/store.go
@@ -117,6 +117,7 @@ type StreamStore interface {
 	SubjectsTotals(filterSubject string) map[string]uint64
 	AllLastSeqs() ([]uint64, error)
 	MultiLastSeqs(filters []string, maxSeq uint64, maxAllowed int) ([]uint64, error)
+	MultiLastMsgs(filters []string, minSeq, maxSeq uint64, maxAllowed int, cb func(sm *StoreMsg, np uint64) bool) (uint64, uint64, error)
 	SubjectForSeq(seq uint64) (string, error)
 	NumPending(sseq uint64, filter string, lastPerSubject bool) (total, validThrough uint64, err error)
 	NumPendingMulti(sseq uint64, sl *gsl.SimpleSublist, lastPerSubject bool) (total, validThrough uint64, err error)

--- a/server/store_test.go
+++ b/server/store_test.go
@@ -1476,3 +1476,75 @@ func TestStoreNumPendingLastPerSubjectExcludeOvercount(t *testing.T) {
 		},
 	)
 }
+
+// Resolving last sequences for many subjects whose last messages are spread
+// over the whole stream. For the filestore a small block size spreads them
+// across many blocks: WholeStream can resolve via each subject's last block,
+// Bounded must walk the blocks backwards from maxSeq.
+func Benchmark_StoreMultiLastSeqsManyBlocks(b *testing.B) {
+	const (
+		numSubjects = 1_000
+		msgsPerSubj = 100
+	)
+
+	run := func(b *testing.B, fs StreamStore) {
+		// Store each subject's messages contiguously so the per-subject last
+		// messages land spread out over the whole stream.
+		msg := []byte("ok")
+		for i := range numSubjects {
+			subj := fmt.Sprintf("foo.%d", i)
+			for range msgsPerSubj {
+				_, _, err := fs.StoreMsg(subj, nil, msg, 0)
+				require_NoError(b, err)
+			}
+		}
+
+		// A sparse subset of subjects spread over the whole stream. Resolving
+		// via each subject's last block only visits these few blocks, while
+		// the backwards walk must scan nearly every block to find them all.
+		var sparse []string
+		for i := 0; i < numSubjects; i += numSubjects / 10 {
+			sparse = append(sparse, fmt.Sprintf("foo.%d", i))
+		}
+
+		for _, bc := range []struct {
+			name    string
+			filters []string
+			matches int
+			maxSeq  uint64
+		}{
+			{"AllSubjects/WholeStream", []string{">"}, numSubjects, 0},
+			{"AllSubjects/Bounded", []string{">"}, numSubjects, numSubjects*msgsPerSubj - 1},
+			{"SparseSubjects/WholeStream", sparse, len(sparse), 0},
+			{"SparseSubjects/Bounded", sparse, len(sparse), numSubjects*msgsPerSubj - 1},
+		} {
+			b.Run(bc.name, func(b *testing.B) {
+				for range b.N {
+					seqs, err := fs.MultiLastSeqs(bc.filters, bc.maxSeq, -1)
+					require_NoError(b, err)
+					require_Len(b, len(seqs), bc.matches)
+				}
+			})
+		}
+	}
+
+	cfg := StreamConfig{Name: "zzz", Subjects: []string{"foo.*", "bar.*"}}
+
+	b.Run("Memory", func(b *testing.B) {
+		cfg := cfg
+		cfg.Storage = MemoryStorage
+		ms, err := newMemStore(&cfg)
+		require_NoError(b, err)
+		defer ms.Stop()
+		run(b, ms)
+	})
+	b.Run("File", func(b *testing.B) {
+		cfg := cfg
+		cfg.Storage = FileStorage
+		fs, err := newFileStore(
+			FileStoreConfig{StoreDir: b.TempDir(), BlockSize: 8192}, cfg)
+		require_NoError(b, err)
+		defer fs.Stop()
+		run(b, fs)
+	})
+}

--- a/server/store_test.go
+++ b/server/store_test.go
@@ -1359,6 +1359,89 @@ func TestFileStoreMultiLastSeqsAndLoadLastMsgWithLazySubjectState(t *testing.T) 
 	)
 }
 
+func TestStoreMultiLastMsgs(t *testing.T) {
+	testAllStoreAllPermutations(
+		t, false,
+		StreamConfig{Name: "zzz", Subjects: []string{"foo.*"}},
+		func(t *testing.T, fs StreamStore) {
+			// Three rounds over ten subjects, so every subject has multiple
+			// revisions and the last per subject sits in the final round.
+			// Seqs 1-30, last for foo.<i> is 21+i.
+			for range 3 {
+				for i := range 10 {
+					_, _, err := fs.StoreMsg(fmt.Sprintf("foo.%d", i), nil, nil, 0)
+					require_NoError(t, err)
+				}
+			}
+
+			type delivery struct {
+				seq uint64
+				np  uint64
+			}
+			load := func(filters []string, minSeq, maxSeq uint64, maxAllowed, stopAfter int) ([]delivery, uint64, uint64, error) {
+				var msgs []delivery
+				total, np, err := fs.MultiLastMsgs(filters, minSeq, maxSeq, maxAllowed, func(sm *StoreMsg, np uint64) bool {
+					msgs = append(msgs, delivery{sm.seq, np})
+					return stopAfter == 0 || len(msgs) < stopAfter
+				})
+				return msgs, total, np, err
+			}
+
+			// Whole stream delivers the last message per subject in ascending
+			// sequence order, with np counting down the remaining messages.
+			msgs, total, np, err := load([]string{"foo.*"}, 0, 0, -1, 0)
+			require_NoError(t, err)
+			require_Equal(t, total, 10)
+			require_Equal(t, np, 0)
+			require_Len(t, len(msgs), 10)
+			for i, d := range msgs {
+				require_Equal(t, d.seq, uint64(21+i))
+				require_Equal(t, d.np, uint64(9-i))
+			}
+
+			// minSeq skips lower sequences but still accounts for them in np.
+			msgs, total, np, err = load([]string{"foo.*"}, 26, 0, -1, 0)
+			require_NoError(t, err)
+			require_Equal(t, total, 10)
+			require_Equal(t, np, 0)
+			require_Len(t, len(msgs), 5)
+			for i, d := range msgs {
+				require_Equal(t, d.seq, uint64(26+i))
+				require_Equal(t, d.np, uint64(4-i))
+			}
+
+			// maxSeq resolves the last message per subject at or below it,
+			// stepping back to an earlier round where needed.
+			msgs, total, np, err = load([]string{"foo.*"}, 0, 25, -1, 0)
+			require_NoError(t, err)
+			require_Equal(t, total, 10)
+			require_Equal(t, np, 0)
+			require_Len(t, len(msgs), 10)
+			for i, d := range msgs {
+				require_Equal(t, d.seq, uint64(16+i))
+			}
+
+			// Stopping the callback early keeps np at the remaining count.
+			msgs, total, np, err = load([]string{"foo.*"}, 0, 0, -1, 3)
+			require_NoError(t, err)
+			require_Equal(t, total, 10)
+			require_Equal(t, np, 7)
+			require_Len(t, len(msgs), 3)
+
+			// Exceeding maxAllowed errors without delivering anything.
+			msgs, _, _, err = load([]string{"foo.*"}, 0, 0, 5, 0)
+			require_Error(t, err, ErrTooManyResults)
+			require_Len(t, len(msgs), 0)
+
+			// No matches.
+			msgs, total, _, err = load([]string{"bar.>"}, 0, 0, -1, 0)
+			require_NoError(t, err)
+			require_Equal(t, total, 0)
+			require_Len(t, len(msgs), 0)
+		},
+	)
+}
+
 func TestStoreNumPendingLastPerSubjectExcludeOvercount(t *testing.T) {
 	testAllStoreAllPermutations(
 		t, false,

--- a/server/stream.go
+++ b/server/stream.go
@@ -545,6 +545,13 @@ type stream struct {
 	client *client      // The internal JetStream client.
 	sysc   *client      // The internal JetStream system client.
 
+	// Isolates direct get and msg get reads from writes (ingest, atomic batch
+	// commits, purges and deletes), so those reads never observe a partially
+	// applied atomic batch or rollup. Other read paths (consumer delivery,
+	// mirrors/sources, mset.mu-based info) are sequentially consistent and may
+	// observe a prefix of an inflight batch.
+	isolateMu sync.RWMutex
+
 	// The current last subscription ID for the subscriptions through `client`.
 	// Those subscriptions are for the subjects filters being listened to and captured by the stream.
 	sid atomic.Uint64
@@ -2976,6 +2983,10 @@ func (mset *stream) getCfgName() string {
 
 // Purge will remove all messages from the stream and underlying store based on the request.
 func (mset *stream) purge(preq *JSApiStreamPurgeRequest) (purged uint64, err error) {
+	// Purges mutate message state, so hold the isolation lock like any other
+	// write so direct get requests don't observe a partially applied purge.
+	mset.isolateMu.Lock()
+	defer mset.isolateMu.Unlock()
 	return mset.purgeLocked(preq, true)
 }
 
@@ -3066,6 +3077,9 @@ func (mset *stream) deleteMsg(seq uint64) (bool, error) {
 	if mset.closed.Load() {
 		return false, errStreamClosed
 	}
+	// Deletes mutate message state, so hold the isolation lock like any other write.
+	mset.isolateMu.Lock()
+	defer mset.isolateMu.Unlock()
 	removed, err := mset.store.RemoveMsg(seq)
 	if err != nil {
 		return removed, err
@@ -3081,6 +3095,9 @@ func (mset *stream) eraseMsg(seq uint64) (bool, error) {
 	if mset.closed.Load() {
 		return false, errStreamClosed
 	}
+	// Deletes mutate message state, so hold the isolation lock like any other write.
+	mset.isolateMu.Lock()
+	defer mset.isolateMu.Unlock()
 	removed, err := mset.store.EraseMsg(seq)
 	if err != nil {
 		return removed, err
@@ -5928,7 +5945,7 @@ func (mset *stream) queueInbound(ib *ipQueue[*inMsg], subj, rply string, hdr, ms
 	im.subj, im.rply, im.hdr, im.msg, im.si, im.mt = subj, rply, hdr, msg, si, mt
 	if _, err := ib.push(im); err != nil {
 		im.returnToPool()
-		streamName := mset.cfg.Name
+		streamName := mset.getCfgName()
 		mset.srv.RateLimitWarnf("Dropping messages due to excessive stream ingest rate on '%s' > '%s': %s", mset.acc.Name, streamName, err)
 		if rply != _EMPTY_ {
 			hdr := []byte("NATS/1.0 429 Too Many Requests\r\n\r\n")
@@ -6081,12 +6098,12 @@ func (mset *stream) getDirectMulti(req *JSApiMsgGetRequest, reply string) {
 	// TODO(dlc) - Make configurable?
 	const maxAllowedResponses = 1024
 
-	// Ensure this read request is isolated and doesn't interleave with writes.
-	mset.mu.RLock()
-	defer mset.mu.RUnlock()
+	store, s := mset.store, mset.srv
+	name := mset.getCfgName()
 
-	// Grab store and name.
-	store, name, s := mset.store, mset.cfg.Name, mset.srv
+	// Ensure this read request is isolated and doesn't interleave with writes.
+	mset.isolateMu.RLock()
+	defer mset.isolateMu.RUnlock()
 
 	// Grab MaxBytes
 	mb := req.MaxBytes
@@ -6099,9 +6116,11 @@ func (mset *stream) getDirectMulti(req *JSApiMsgGetRequest, reply string) {
 	// If we have UpToTime set get the proper sequence.
 	if req.UpToTime != nil {
 		upToSeq = store.GetSeqFromTime((*req.UpToTime).UTC())
+		var state StreamState
+		store.FastState(&state)
 		// Avoid selecting a first sequence that will take us to before the stream first
 		// sequence, otherwise we can return messages after the supplied UpToTime.
-		if upToSeq <= mset.state().FirstSeq {
+		if upToSeq <= state.FirstSeq {
 			hdr := []byte("NATS/1.0 404 No Results\r\n\r\n")
 			mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
 			return
@@ -6113,7 +6132,7 @@ func (mset *stream) getDirectMulti(req *JSApiMsgGetRequest, reply string) {
 	// If not set, set to the last sequence and remember that for EOB.
 	if upToSeq == 0 {
 		var state StreamState
-		mset.store.FastState(&state)
+		store.FastState(&state)
 		upToSeq = state.LastSeq
 	}
 
@@ -6197,11 +6216,12 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 		return
 	}
 
-	// Ensure this read request is isolated and doesn't interleave with writes.
-	mset.mu.RLock()
-	defer mset.mu.RUnlock()
+	store, s := mset.store, mset.srv
+	name := mset.getCfgName()
 
-	store, name, s := mset.store, mset.cfg.Name, mset.srv
+	// Ensure this read request is isolated and doesn't interleave with writes.
+	mset.isolateMu.RLock()
+	defer mset.isolateMu.RUnlock()
 
 	var seq uint64
 	// Lookup start seq if AsOfTime is set.
@@ -6316,7 +6336,9 @@ func (mset *stream) getDirectRequest(req *JSApiMsgGetRequest, reply string) {
 	// If batch was requested send EOB.
 	if isBatchRequest {
 		// Update if the stream's last sequence has moved past our validThrough.
-		if mset.lseq > validThrough {
+		var state StreamState
+		store.FastState(&state)
+		if state.LastSeq > validThrough {
 			var err error
 			if np, _, err = store.NumPending(seq, req.NextFor, false); err != nil {
 				return
@@ -6357,11 +6379,13 @@ var (
 )
 
 // processJetStreamMsg is where we try to actually process the stream msg.
-func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, lseq uint64, ts int64, mt *msgTrace, sourced bool, needLock bool) error {
-	return mset.processJetStreamMsgWithBatch(subject, reply, hdr, msg, lseq, ts, mt, sourced, needLock, nil)
+// needIsolation should be false only if the caller already holds isolateMu
+// across a whole atomic batch; mset.mu must NOT be held by the caller.
+func (mset *stream) processJetStreamMsg(subject, reply string, hdr, msg []byte, lseq uint64, ts int64, mt *msgTrace, sourced bool, needIsolation bool) error {
+	return mset.processJetStreamMsgWithBatch(subject, reply, hdr, msg, lseq, ts, mt, sourced, needIsolation, nil)
 }
 
-func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg []byte, lseq uint64, ts int64, mt *msgTrace, sourced bool, needLock bool, fastBatch *FastBatch) (retErr error) {
+func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg []byte, lseq uint64, ts int64, mt *msgTrace, sourced bool, needIsolation bool, fastBatch *FastBatch) (retErr error) {
 	if mt != nil {
 		// Only the leader/standalone will have mt!=nil. On exit, send the
 		// message trace event.
@@ -6376,10 +6400,13 @@ func (mset *stream) processJetStreamMsgWithBatch(subject, reply string, hdr, msg
 
 	// Hold lock while storing the message, and potentially purging as part of a rollup.
 	// If we're writing an atomic batch of multiple messages, the lock is already held.
-	if needLock {
-		mset.mu.Lock()
-		defer mset.mu.Unlock()
+	if needIsolation {
+		mset.isolateMu.Lock()
+		defer mset.isolateMu.Unlock()
 	}
+	// Hold the stream lock for the lifetime of processing a single message.
+	mset.mu.Lock()
+	defer mset.mu.Unlock()
 
 	s, store := mset.srv, mset.store
 
@@ -7466,6 +7493,21 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 	storeDir := jsa.storeDir
 	jsa.mu.RUnlock()
 
+	// Parse the batch commit header.
+	var commit, commitEob, commitInvalid bool
+	if c := sliceHeader(JSBatchCommit, hdr); c != nil {
+		commitEob = bytes.Equal(c, []byte("eob"))
+		commitInvalid = !commitEob && !bytes.Equal(c, []byte("1"))
+		commit = true
+	}
+
+	// If not clustered, the commit message runs the consistency checks and
+	// commits straight to the store below, so hold the isolation lock across
+	// that whole section.
+	if !isClustered && commit {
+		mset.isolateMu.Lock()
+		defer mset.isolateMu.Unlock()
+	}
 	mset.mu.Lock()
 	if mset.batches == nil {
 		mset.batches = &batching{}
@@ -7493,7 +7535,7 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 			}
 			size := batchSeq
 			// Don't count the "End Of Batch" marker toward the batch size.
-			if bytes.Equal(sliceHeader(JSBatchCommit, hdr), []byte("eob")) {
+			if commitEob {
 				size--
 			}
 			if size > uint64(maxBatchSize) {
@@ -7543,18 +7585,13 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		batches.atomic[batchId] = b
 	}
 
-	var commit, commitEob bool
-	if c := sliceHeader(JSBatchCommit, hdr); c != nil {
-		commitEob = bytes.Equal(c, []byte("eob"))
-		// Reject the batch if the commit is not recognized.
-		if !commitEob && !bytes.Equal(c, []byte("1")) {
-			b.cleanupLocked(batchId, batches)
-			batches.mu.Unlock()
-			mset.mu.Unlock()
-			err := NewJSAtomicPublishInvalidBatchCommitError()
-			return respondError(err)
-		}
-		commit = true
+	// Reject the batch if the commit is not recognized.
+	if commitInvalid {
+		b.cleanupLocked(batchId, batches)
+		batches.mu.Unlock()
+		mset.mu.Unlock()
+		err := NewJSAtomicPublishInvalidBatchCommitError()
+		return respondError(err)
 	}
 
 	// The required API level can have the batch be rejected. But the header is always removed.
@@ -7760,9 +7797,11 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 		mset.clseq, mset.clfs = 0, 0
 		mset.clMu.Unlock()
 
-		// Ensure the whole batch is fully isolated, and reads
-		// can only happen after the full batch is committed.
-		// We keep holding the stream lock.
+		// Ensure the whole batch is fully isolated, and reads can only happen
+		// after the full batch is committed. isolateMu stays held until return
+		// via the defer above, but release mset.mu and batches.mu.
+		mset.mu.Unlock()
+		batches.mu.Unlock()
 		for seq := uint64(1); seq <= batchSeq; seq++ {
 			// Use the checked (and possibly rewritten) message from above, not the raw staged
 			// message, so transformations like counter increments and scheduled message
@@ -7777,9 +7816,15 @@ func (mset *stream) processJetStreamAtomicBatchMsg(batchId, subject, reply strin
 					bhdr = genHeader(bhdr, JSBatchCommit, "1")
 				}
 			}
-			_ = mset.processJetStreamMsg(bsubj, _reply, bhdr, bmsg, 0, 0, mt, false, false)
+			// If errored, assume all subsequent calls will fail too (for example, store is closed).
+			// Don't clean up the batch so that a restart can try to recover it.
+			if err = mset.processJetStreamMsg(bsubj, _reply, bhdr, bmsg, 0, 0, mt, false, false); err != nil {
+				return err
+			}
 		}
-		mset.mu.Unlock()
+		// Re-acquire for the cleanup below. If a concurrent staging error
+		// already cleaned the batch up, cleanupLocked is a no-op.
+		batches.mu.Lock()
 	} else {
 		term := mset.term
 		mset.mu.Unlock()

--- a/server/stream.go
+++ b/server/stream.go
@@ -6136,46 +6136,12 @@ func (mset *stream) getDirectMulti(req *JSApiMsgGetRequest, reply string) {
 		upToSeq = state.LastSeq
 	}
 
-	seqs, err := store.MultiLastSeqs(req.MultiLastFor, upToSeq, maxAllowedResponses)
-	if err != nil {
-		var hdr []byte
-		if err == ErrTooManyResults {
-			hdr = []byte("NATS/1.0 413 Too Many Results\r\n\r\n")
-		} else {
-			hdr = []byte(fmt.Sprintf("NATS/1.0 500 %v\r\n\r\n", err))
-		}
-		mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
-		return
-	}
-	if len(seqs) == 0 {
-		hdr := []byte("NATS/1.0 404 No Results\r\n\r\n")
-		mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
-		return
-	}
-
-	np, lseq, sentBytes, sent := uint64(len(seqs)), uint64(0), 0, 0
-	for _, seq := range seqs {
-		if seq < req.Seq {
-			if np > 0 {
-				np--
-			}
-			continue
-		}
-		var svp StoreMsg
-		sm, err := store.LoadMsg(seq, &svp)
-		if err != nil {
-			hdr := []byte("NATS/1.0 404 Message Not Found\r\n\r\n")
-			mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
-			return
-		}
-
+	var lseq uint64
+	var sentBytes, sent int
+	total, np, err := store.MultiLastMsgs(req.MultiLastFor, req.Seq, upToSeq, maxAllowedResponses, func(sm *StoreMsg, np uint64) bool {
 		hdr := sm.hdr
 		ts := time.Unix(0, sm.ts).UTC()
 
-		// Decrement num pending. This is an optimization, and we do not continue to look it up for these operations.
-		if np > 0 {
-			np--
-		}
 		if len(hdr) == 0 {
 			hdr = fmt.Appendf(nil, dgb, name, sm.subj, sm.seq, ts.Format(time.RFC3339Nano), np, lseq)
 		} else {
@@ -6194,12 +6160,33 @@ func (mset *stream) getDirectMulti(req *JSApiMsgGetRequest, reply string) {
 		// Check if we have exceeded max bytes.
 		sentBytes += len(sm.subj) + len(sm.hdr) + len(sm.msg)
 		if sentBytes >= mb {
-			break
+			return false
 		}
 		sent++
 		if req.Batch > 0 && sent >= req.Batch {
-			break
+			return false
 		}
+		return true
+	})
+	if err != nil {
+		var hdr []byte
+		switch {
+		case err == ErrTooManyResults:
+			hdr = []byte("NATS/1.0 413 Too Many Results\r\n\r\n")
+		case total > 0:
+			// A resolved message failed to load. Errors are folded into a 404
+			// regardless of cause, so internal errors don't leak to clients.
+			hdr = []byte("NATS/1.0 404 Message Not Found\r\n\r\n")
+		default:
+			hdr = []byte(fmt.Sprintf("NATS/1.0 500 %v\r\n\r\n", err))
+		}
+		mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
+		return
+	}
+	if total == 0 {
+		hdr := []byte("NATS/1.0 404 No Results\r\n\r\n")
+		mset.outq.send(newJSPubMsg(reply, _EMPTY_, _EMPTY_, hdr, nil, nil, 0))
+		return
 	}
 
 	// Send out EOB


### PR DESCRIPTION
This PR combines three improvements to speed up direct get reads when combined with stream writes and other operations that require the stream lock (like consumer deletes):

- Use a separate `mset.isolateMu` to isolate reads without needing to hold the stream lock. This ensures that such reads don't block operations like removing consumers. However, stream writes still need to wait for the read to complete before they're allowed to apply, in order to provide isolated reads. Otherwise you could get a partial read before a rollup applies or within an atomic batch.
- Direct multi requests are meant to be a point-in-time capture of messages. However, `MultiLastSeqs` returned sequences first, and then individual message lookups were performed which could fail to find a message given a TTL or MaxAge expiry happened between. `MultiLastMsgs` is added to load the messages while the store lock is still held, using a callback to receive the messages.
- `MultiLastSeqs` was also very expensive given filters that target a large range of blocks. This would result in doing a backward scan for the full range. However, given the search is for the full stream, the stream has up-to-date `psi.lblk` for a given subject, and up-to-date per-subject state, we could retrieve `ss.Last` directly without wasting time on walking non-matching blocks.