### PR TITLE
[FIXED] Stale flow control stalls consumer after leader change

### DIFF
--- a/server/consumer.go
+++ b/server/consumer.go
@@ -1712,6 +1712,8 @@ func (o *consumer) setLeader(isLeader bool, term uint64) error {
 	o.resetPendingDeliveries()
 	// Reset num pending, these are only authoritative on the leader.
 	o.npc, o.npf = 0, 0
+	// Reset flow control accounting.
+	o.pbytes, o.fcsz, o.fcid = 0, 0, _EMPTY_
 	// ok if they are nil, we protect inside unsubscribe()
 	o.unsubscribe(o.ackSubOld)
 	o.unsubscribe(o.ackSub)

--- a/server/jetstream_consumer_test.go
+++ b/server/jetstream_consumer_test.go
@@ -13157,3 +13157,85 @@ func TestJetStreamConsumerResetResponseAcrossServiceImport(t *testing.T) {
 		})
 	})
 }
+
+func TestJetStreamConsumerFlowControlResetOnLeaderChange(t *testing.T) {
+	s := RunBasicJetStreamServer(t)
+	defer s.Shutdown()
+
+	nc, js := jsClientConnect(t, s)
+	defer nc.Close()
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name: "TEST", Subjects: []string{"foo"}, Storage: nats.MemoryStorage,
+	})
+	require_NoError(t, err)
+
+	mset, err := s.globalAccount().lookupStream("TEST")
+	require_NoError(t, err)
+
+	// A push consumer only delivers while there is interest on the deliver
+	// subject. We never read these, the subscription just keeps it active.
+	dsubj := "d.flowcontrol"
+	_, err = nc.Subscribe(dsubj, func(*nats.Msg) {})
+	require_NoError(t, err)
+	require_NoError(t, nc.Flush())
+
+	o, err := mset.addConsumer(&ConsumerConfig{
+		Durable:        "FC",
+		DeliverSubject: dsubj,
+		AckPolicy:      AckNone,
+		FlowControl:    true,
+		Heartbeat:      100 * time.Millisecond,
+	})
+	require_NoError(t, err)
+
+	state := func() (pbytes, maxpb int, fcid string, dseq uint64) {
+		o.mu.RLock()
+		defer o.mu.RUnlock()
+		return o.pbytes, o.maxpb, o.fcid, o.dseq
+	}
+
+	// Open the window up to the ceiling a long lived consumer reaches on its own,
+	// by doubling in processFlowControl.
+	o.mu.Lock()
+	o.pblimit, o.maxpb = JsFlowControlMaxPending, JsFlowControlMaxPending
+	o.mu.Unlock()
+
+	// Above the post-reset window (limit/16) so delivery gates later, below the
+	// arming threshold (limit/2) so no flow control request goes out.
+	const target = JsFlowControlMaxPending / 8
+	payload := make([]byte, 256*1024)
+	for sent := 0; sent < target; sent += len(payload) {
+		_, err = js.Publish("foo", payload)
+		require_NoError(t, err)
+	}
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		if pbytes, _, _, _ := state(); pbytes < target {
+			return fmt.Errorf("pbytes %d has not reached %d yet", pbytes, target)
+		}
+		return nil
+	})
+
+	// The state we expect to carry into the transition.
+	pbytes, maxpb, fcid, _ := state()
+	require_Equal(t, fcid, _EMPTY_)
+	require_Equal(t, maxpb, JsFlowControlMaxPending)
+	require_True(t, pbytes > JsFlowControlMaxPending/16)
+
+	// This is the sequence processConsumerLeaderChange runs.
+	require_NoError(t, o.setLeader(false, 0))
+	require_NoError(t, o.setLeader(true, 0))
+
+	pbytes, _, _, dseq := state()
+	require_Equal(t, pbytes, 0)
+
+	// And it must still deliver.
+	_, err = js.Publish("foo", []byte("hello"))
+	require_NoError(t, err)
+	checkFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		if _, _, _, cur := state(); cur <= dseq {
+			return fmt.Errorf("consumer is not delivering, dseq stuck at %d", cur)
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
A replicated consumer using flow control could get stuck after a leader change. `setLeader` did not reset the flow control accounting (`pbytes`, `fcsz`, `fcid`), so a consumer that stepped down while awaiting a flow control response, or with stale `pbytes` above the shrunk `maxpb` window, would stay stuck after becoming leader again. This PR fixes that by resetting these fields upon leader change.